### PR TITLE
ci: add Docker image build and push workflow

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,109 @@
+name: Build and push Docker image
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+    # Only re-run on PRs that could plausibly change the image; doc-only
+    # PRs don't need to wait on a multi-arch build.
+    paths:
+      - "Dockerfile"
+      - "go.mod"
+      - "go.sum"
+      - "cmd/**"
+      - "internal/**"
+      - ".github/workflows/build-image.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write  # for keyless cosign signing via Sigstore OIDC
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  # Image builds shouldn't be canceled mid-flight: a half-pushed
+  # multi-arch manifest is recoverable but better avoided. Tests can be
+  # canceled (test.yml does), publishes shouldn't.
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build and push image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      # QEMU registers binfmt_misc handlers so this amd64 runner can
+      # cross-build arm64 layers under emulation. Without this step the
+      # arm64 build fails with "exec format error" — buildx alone does
+      # not install the emulators.
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      # Skip login on PR builds: we don't push from a PR, and PRs from
+      # forks only get a read-only GITHUB_TOKEN anyway.
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/mnexa-ai/e2a
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=sha,prefix=sha-,format=long
+            # "latest" tracks the newest stable release, not the tip of
+            # main, so `docker pull …:latest` is never an untested build.
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - uses: docker/build-push-action@v5
+        id: build
+        with:
+          context: .
+          # Build on PRs to verify the Dockerfile still works, but only
+          # push on real branch/tag/manual events.
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          # GHA cache cuts subsequent multi-arch rebuilds from ~10 min to
+          # ~1-2 min when only Go source changes.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          # Supply-chain transparency for OSS images: provenance records
+          # how the image was built; SBOM enumerates installed packages.
+          # Both are attached as in-toto attestations on the registry.
+          provenance: mode=max
+          sbom: true
+
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@v3
+
+      # Keyless signing: the workflow's OIDC token gets exchanged for a
+      # short-lived cert from Sigstore's Fulcio CA. No long-lived keys
+      # to manage or rotate. Verify with:
+      #   cosign verify ghcr.io/mnexa-ai/e2a:<tag> \
+      #     --certificate-identity-regexp '^https://github\.com/Mnexa-AI/e2a/' \
+      #     --certificate-oidc-issuer https://token.actions.githubusercontent.com
+      - name: Sign image with cosign
+        if: github.event_name != 'pull_request'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          images=""
+          for tag in ${TAGS}; do
+            images+="${tag}@${DIGEST} "
+          done
+          cosign sign --yes ${images}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -171,6 +171,12 @@ jobs:
         with:
           go-version: "1.26"
           cache: true
+      # swag invokes `go list` internally to walk the dependency tree;
+      # without modules pre-fetched it errors with "cannot find all
+      # dependencies" on a cold cache. Locally the cache is warm, so this
+      # only ever bites in CI.
+      - name: Pre-fetch Go modules for swag
+        run: go mod download
       - name: Install swag
         run: go install github.com/swaggo/swag/cmd/swag@v1.16.4
       - name: Check spec is up to date

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,11 @@ name: Tests
 
 on:
   push:
+    # Restrict push trigger to main: feature-branch pushes only fire the
+    # pull_request event (via synchronize) once a PR is open, avoiding
+    # duplicate runs that GitHub Actions otherwise produces when both
+    # events fire on the same SHA.
+    branches: [main]
     paths-ignore:
       # Top-level docs only — keep CI running for SDK/CLI READMEs
       # since those ship to npm/PyPI as part of the package.

--- a/cli/src/__tests__/login.test.ts
+++ b/cli/src/__tests__/login.test.ts
@@ -262,7 +262,9 @@ describe("login", () => {
 
     // Confirm the manual-fallback hint is always printed, not just when
     // openBrowser errors. Headless boxes/SSH/containers depend on this.
-    const stderrCalls = mockStderr.mock.calls.map((c) => c[0]).join("");
+    const stderrCalls = mockStderr.mock.calls
+      .map((c: unknown[]) => String(c[0]))
+      .join("");
     expect(stderrCalls).toMatch(/If it doesn't open, visit:/);
     expect(stderrCalls).toMatch(/\/api\/auth\/login/);
   });


### PR DESCRIPTION
## Summary

Publishes multi-arch (amd64 + arm64) images of the Go server to `ghcr.io/mnexa-ai/e2a` on every push to `main`, on `v*` tags, and via `workflow_dispatch`. PRs that touch the Dockerfile, Go source, or this workflow itself trigger a build-only run (no push) so a broken image surfaces in PR CI rather than after merge.

## What's in the workflow beyond the original spec

The first draft was the minimum viable version. This expanded one folds in everything we discussed before opening the PR:

**Correctness fixes**
- `docker/setup-qemu-action@v3` — without this the arm64 build fails on the amd64 GitHub runner. `setup-buildx` doesn't install binfmt handlers.
- `pull_request:` trigger with `push: ${{ github.event_name != 'pull_request' }}` so PR CI catches a broken Dockerfile before merge.

**Conventions matching the rest of `.github/workflows/`**
- `timeout-minutes: 30` (test.yml uses 10; image builds need more, especially on cold cache).
- `concurrency:` group with `cancel-in-progress: false` — image publish is one of the few things you don't want canceled mid-flight.
- `paths:` filter on PR trigger so doc-only PRs don't sit waiting on a multi-arch build.

**Design choices we discussed**
- `latest` tag only fires on semver tag pushes, not on main. `docker pull …:latest` returns a tested release, never untested tip-of-main code.
- `type=sha,prefix=sha-` (instead of empty prefix) so SHA-tagged images are unambiguous from any future branch named after a hex string.

**Supply-chain hygiene**
- GHA build cache (`cache-from: type=gha`, `cache-to: type=gha,mode=max`).
- Build provenance (`provenance: mode=max`) and SPDX SBOM (`sbom: true`) attached as in-toto attestations on the registry.
- Keyless image signing with cosign via Sigstore OIDC. No long-lived keys; the workflow's GitHub OIDC token gets exchanged for a short-lived Fulcio cert. Required permission: `id-token: write`.

## Drive-by CI fixes folded in

Surfaced when this PR's first run lit up red:

1. **CLI typecheck regression** ([95f7165](https://github.com/Mnexa-AI/e2a/commit/95f7165)) — `cli/src/__tests__/login.test.ts:265` used `mockStderr.mock.calls.map((c) => c[0])` where `c` had no inferred type because `mockStderr` was typed as bare `ReturnType<typeof vi.spyOn>` (gives `MockInstance<unknown[], unknown>`). `tsc --noImplicitAny` rejected it; vitest's runtime check is more lenient, which is why `npm test` passed locally. Fixed with explicit `(c: unknown[])` annotation.

2. **Swagger freshness on cold module cache** ([95f7165](https://github.com/Mnexa-AI/e2a/commit/95f7165)) — latent CI bug, not new. `swag init` invokes `go list` internally to walk the dep tree, but `swagger:` job had no `go mod download` step before it. Locally the GOPATH cache is warm so it works; in CI on first run with no cache hit, swag errored with "cannot find all dependencies." Added a `go mod download` step before swag.

3. **Duplicate CI runs on every PR push** ([02d2657](https://github.com/Mnexa-AI/e2a/commit/02d2657)) — `test.yml` triggered on both `push` and `pull_request`, so a feature-branch push with an open PR fired *both* events on the same SHA, running 9 jobs twice (keyed on different refs, so the concurrency group didn't dedup). Restricted `push:` to `main` only — `pull_request.synchronize` already covers feature-branch updates. Halves CI minutes per PR.

## Verifying signatures

After merge, anyone can verify a published image with:

```
cosign verify ghcr.io/mnexa-ai/e2a:<tag> \
  --certificate-identity-regexp '^https://github\.com/Mnexa-AI/e2a/' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com
```

The verification check is also documented in a comment next to the signing step.

## Test plan

- [ ] Workflow YAML parses (GitHub will surface a syntax error on push)
- [ ] PR trigger runs the build job (this very PR — should appear in Checks)
- [ ] PR build does **not** push to GHCR (verify in the build-push step's logs: `push: false`)
- [ ] Each test.yml job runs **once** per PR push, not twice (after [02d2657](https://github.com/Mnexa-AI/e2a/commit/02d2657))
- [ ] On merge, image appears at https://github.com/Mnexa-AI/e2a/pkgs/container/e2a with `main` and `sha-<long sha>` tags
- [ ] No `latest` tag is updated on the merge (only on `v*` tags)
- [ ] Image runs locally: `docker run --rm ghcr.io/mnexa-ai/e2a:main e2a -h` boots the binary
- [ ] Cosign verification passes against the published image
- [ ] Subsequent runs hit the GHA cache (look for "CACHED" markers in build-push step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)