### PR TITLE
ci: build and publish e2a-web image alongside the server

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -5,14 +5,16 @@ on:
     branches: [main]
     tags: ["v*"]
   pull_request:
-    # Only re-run on PRs that could plausibly change the image; doc-only
-    # PRs don't need to wait on a multi-arch build.
+    # Re-run on PRs that could plausibly change either image. Two image
+    # variants (server + web) build in parallel via the matrix below;
+    # doc-only PRs are still skipped.
     paths:
       - "Dockerfile"
       - "go.mod"
       - "go.sum"
       - "cmd/**"
       - "internal/**"
+      - "web/**"
       - ".github/workflows/build-image.yml"
   workflow_dispatch:
 
@@ -22,6 +24,8 @@ permissions:
   id-token: write  # for keyless cosign signing via Sigstore OIDC
 
 concurrency:
+  # One concurrency group per ref+image so a queued web build can't
+  # cancel an in-flight server publish (or vice versa).
   group: ${{ github.workflow }}-${{ github.ref }}
   # Image builds shouldn't be canceled mid-flight: a half-pushed
   # multi-arch manifest is recoverable but better avoided. Tests can be
@@ -30,9 +34,23 @@ concurrency:
 
 jobs:
   build:
-    name: Build and push image
+    name: Build ${{ matrix.display_name }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      # Don't cancel the server build if the web build fails (or vice
+      # versa) — they're independent images.
+      fail-fast: false
+      matrix:
+        include:
+          - image: e2a
+            display_name: server image
+            context: .
+            dockerfile: Dockerfile
+          - image: e2a-web
+            display_name: web image
+            context: web
+            dockerfile: web/Dockerfile
     steps:
       - uses: actions/checkout@v4
 
@@ -56,7 +74,7 @@ jobs:
       - uses: docker/metadata-action@v5
         id: meta
         with:
-          images: ghcr.io/mnexa-ai/e2a
+          images: ghcr.io/mnexa-ai/${{ matrix.image }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -69,17 +87,19 @@ jobs:
       - uses: docker/build-push-action@v5
         id: build
         with:
-          context: .
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
           # Build on PRs to verify the Dockerfile still works, but only
           # push on real branch/tag/manual events.
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
-          # GHA cache cuts subsequent multi-arch rebuilds from ~10 min to
-          # ~1-2 min when only Go source changes.
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Per-image cache scopes — without scoping, the two matrix
+          # entries would clobber each other's cache and rebuild from
+          # scratch every time.
+          cache-from: type=gha,scope=${{ matrix.image }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.image }}
           # Supply-chain transparency for OSS images: provenance records
           # how the image was built; SBOM enumerates installed packages.
           # Both are attached as in-toto attestations on the registry.
@@ -93,7 +113,7 @@ jobs:
       # Keyless signing: the workflow's OIDC token gets exchanged for a
       # short-lived cert from Sigstore's Fulcio CA. No long-lived keys
       # to manage or rotate. Verify with:
-      #   cosign verify ghcr.io/mnexa-ai/e2a:<tag> \
+      #   cosign verify ghcr.io/mnexa-ai/<image>:<tag> \
       #     --certificate-identity-regexp '^https://github\.com/Mnexa-AI/e2a/' \
       #     --certificate-oidc-issuer https://token.actions.githubusercontent.com
       - name: Sign image with cosign

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -24,8 +24,11 @@ permissions:
   id-token: write  # for keyless cosign signing via Sigstore OIDC
 
 concurrency:
-  # One concurrency group per ref+image so a queued web build can't
-  # cancel an in-flight server publish (or vice versa).
+  # One concurrency group per ref. The matrix below already parallelizes
+  # the two images within a single run; the group then queues *across*
+  # runs so back-to-back pushes to the same ref don't race to publish
+  # the same tag (workflow-level concurrency can't reference matrix
+  # variables, so per-image scoping isn't possible without restructuring).
   group: ${{ github.workflow }}-${{ github.ref }}
   # Image builds shouldn't be canceled mid-flight: a half-pushed
   # multi-arch manifest is recoverable but better avoided. Tests can be

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,5 +36,20 @@ services:
     # so it travels with the image. Anyone using the image — including
     # this compose file — gets it for free.
 
+  web:
+    build:
+      context: web
+      dockerfile: Dockerfile
+    depends_on:
+      e2a:
+        condition: service_started
+    restart: unless-stopped
+    ports:
+      - "3000:80"
+    environment:
+      # Caddy proxies /api/* to this URL. The default service name "e2a"
+      # resolves on the compose network — no extra config needed.
+      E2A_BACKEND: "http://e2a:8080"
+
 volumes:
   pgdata:

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,7 @@
+# Keep `docker build -f web/Dockerfile web` snappy when the build
+# context is the web/ directory. The repo-root .dockerignore excludes
+# web/ entirely (correct for the Go image) but doesn't apply here.
+node_modules
+.next
+out
+.env*

--- a/web/Caddyfile
+++ b/web/Caddyfile
@@ -1,0 +1,48 @@
+# Caddy config for the e2a static dashboard. Designed to run behind a
+# TLS-terminating reverse proxy (Caddy itself, nginx, Traefik, an
+# ingress controller, …) so we listen plain HTTP.
+#
+# Operators tune behavior via environment variables — the {$VAR:default}
+# syntax lets each one stay optional. See web/Dockerfile for the
+# corresponding ARG/ENV plumbing.
+
+{
+    # We assume the deployment terminates TLS upstream. Disabling
+    # auto-HTTPS keeps Caddy from trying to provision certs for a
+    # non-routable internal hostname.
+    auto_https off
+    # Quiet the admin endpoint — not useful inside a container.
+    admin off
+}
+
+:{$WEB_PORT:80} {
+    root * /srv
+    encode gzip zstd
+
+    # API + auth + WebSocket all live under /api/*. The default target
+    # is the docker-compose service name "e2a"; override via E2A_BACKEND
+    # for any other topology (k8s service DNS, external LB, etc.).
+    handle /api/* {
+        reverse_proxy {$E2A_BACKEND:http://e2a:8080}
+    }
+
+    # Next.js static export emits routes as foo.html or foo/index.html.
+    # try_files probes both before falling through to the literal path,
+    # which makes /dashboard, /dashboard/, and direct file requests all
+    # resolve correctly. No SPA fallback to /index.html — every route
+    # is pre-rendered, so a 404 is a real 404.
+    handle {
+        try_files {path}.html {path}/index.html {path}
+        file_server
+    }
+
+    # Long-cache hashed Next.js bundles; everything else stays
+    # short-cached so a redeploy is reflected quickly.
+    @hashed path /_next/static/*
+    header @hashed Cache-Control "public, max-age=31536000, immutable"
+
+    log {
+        output stdout
+        format console
+    }
+}

--- a/web/Caddyfile
+++ b/web/Caddyfile
@@ -36,10 +36,15 @@
         file_server
     }
 
-    # Long-cache hashed Next.js bundles; everything else stays
-    # short-cached so a redeploy is reflected quickly.
+    # Long-cache hashed Next.js bundles; everything else (HTML, root /)
+    # gets explicit no-cache so a redeploy is reflected on the next page
+    # load. Without the explicit header, browsers fall back to heuristic
+    # freshness, which is short-lived but inconsistent across vendors.
     @hashed path /_next/static/*
     header @hashed Cache-Control "public, max-age=31536000, immutable"
+
+    @notHashed not path /_next/static/*
+    header @notHashed Cache-Control "no-cache"
 
     log {
         output stdout

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,9 +1,63 @@
+# syntax=docker/dockerfile:1.6
+#
+# Two-stage build: Next.js produces a static export, Caddy serves it
+# with a parameterizable reverse-proxy to the e2a API backend.
+#
+# Build context is the `web/` directory:
+#   docker build -t e2a-web -f web/Dockerfile web
+#
+# Customizing branding/SEO for a non-default deployment:
+#   docker build \
+#     --build-arg NEXT_PUBLIC_SITE_URL=https://e2a.example.com \
+#     --build-arg NEXT_PUBLIC_AGENTS_DOMAIN=agents.example.com \
+#     -t e2a-web -f web/Dockerfile web
+#
+# Next.js inlines NEXT_PUBLIC_* values at build time (a static-export
+# constraint), so these cannot be overridden at container start. To
+# rebrand a published image, rebuild from source with --build-arg.
+
+# ── Builder ─────────────────────────────────────────────────────────
 FROM node:22-alpine AS builder
 WORKDIR /app
+
+# Install deps first so the layer caches when only source changes.
 COPY package.json package-lock.json ./
-RUN npm ci
-COPY . .
+RUN npm ci --no-audit --prefer-offline
+
+# Empty defaults make the published OSS image generic. The hosted
+# deployment overrides these at build time. See web/.env.example for
+# the full list and what each one controls.
+ARG NEXT_PUBLIC_SITE_URL=
+ARG NEXT_PUBLIC_SITE_NAME=
+ARG NEXT_PUBLIC_AGENTS_DOMAIN=
+ARG NEXT_PUBLIC_FEEDBACK_EMAIL=
+ARG NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=
+
+ENV NEXT_PUBLIC_SITE_URL=$NEXT_PUBLIC_SITE_URL \
+    NEXT_PUBLIC_SITE_NAME=$NEXT_PUBLIC_SITE_NAME \
+    NEXT_PUBLIC_AGENTS_DOMAIN=$NEXT_PUBLIC_AGENTS_DOMAIN \
+    NEXT_PUBLIC_FEEDBACK_EMAIL=$NEXT_PUBLIC_FEEDBACK_EMAIL \
+    NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=$NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION
+
+COPY . ./
 RUN npm run build
 
+# ── Runtime ─────────────────────────────────────────────────────────
+# Caddy 2 serves the static export and reverse-proxies /api/* to the
+# e2a Go backend. The Caddyfile uses {$VAR:default} substitution so
+# operators can rewire the proxy target without editing the file:
+#
+#   docker run \
+#     -e E2A_BACKEND=http://e2a-server:8080 \
+#     -e WEB_PORT=8081 \
+#     -p 8081:8081 ghcr.io/mnexa-ai/e2a-web
 FROM caddy:2-alpine
 COPY --from=builder /app/out /srv
+COPY Caddyfile /etc/caddy/Caddyfile
+
+# Default port; override with WEB_PORT env. Healthcheck reads the same
+# var so it works regardless of the chosen port.
+ENV WEB_PORT=80
+EXPOSE 80
+HEALTHCHECK --interval=10s --timeout=3s --start-period=5s --retries=3 \
+    CMD wget -q -O - "http://127.0.0.1:${WEB_PORT}/" >/dev/null || exit 1

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -52,6 +52,11 @@ RUN npm run build
 #     -e WEB_PORT=8081 \
 #     -p 8081:8081 ghcr.io/mnexa-ai/e2a-web
 FROM caddy:2-alpine
+# wget is provided by alpine's busybox applet, but caddy:2-alpine doesn't
+# guarantee it stays — Caddy's official Dockerfile doesn't `apk add` it.
+# Install explicitly so the HEALTHCHECK below can't silently break if a
+# future base image trims busybox.
+RUN apk add --no-cache wget
 COPY --from=builder /app/out /srv
 COPY Caddyfile /etc/caddy/Caddyfile
 


### PR DESCRIPTION
## Summary

Adds a second image — `ghcr.io/mnexa-ai/e2a-web` — that's Caddy 2 serving the Next.js static export with a parameterizable reverse-proxy to the e2a backend. Same publish triggers as the server image: every push to `main`, every `v*` tag, manual via `workflow_dispatch`.

## What's in the PR

### `web/Dockerfile` — multi-stage build

- **Builder**: `node:22-alpine` runs `npm ci && npm run build` to produce the static export at `out/`. All five `NEXT_PUBLIC_*` knobs ([web/.env.example](web/.env.example)) are wired as `ARG` + `ENV` with **empty defaults** so the OSS image renders as a neutral deployment — landing page samples read `my-agent@your-domain.com` instead of any branded domain, the feedback-email link is hidden, no Google Search Console verification leaks. Hosted deployment overrides via `--build-arg` at build time. Runtime override isn't possible because Next.js inlines these values during the static export — that's a Next.js constraint, not something we can change.
- **Runtime**: `caddy:2-alpine` copies `out/` to `/srv` and the parameterizable Caddyfile to `/etc/caddy/Caddyfile`. `EXPOSE 80`, `HEALTHCHECK` reads `$WEB_PORT` so it works regardless of the chosen port.

### `web/Caddyfile` — env-driven reverse proxy

- Listens on `:{$WEB_PORT:80}`.
- Routes `/api/*` to `{$E2A_BACKEND:http://e2a:8080}` — default points at the `docker-compose` service name, override for k8s/external LB/any other topology.
- `try_files {path}.html {path}/index.html {path}` for Next.js static-export route resolution. **No SPA fallback to `/index.html`** — every route is pre-rendered by Next.js, so a 404 is a real 404 (catches typos in operator config rather than masking them).
- Hashed `_next/static/*` bundles get `Cache-Control: public, max-age=31536000, immutable`; everything else stays short-cached.
- `auto_https off` because we assume the deployment terminates TLS upstream (Caddy itself, nginx, Traefik, k8s ingress).

### `.github/workflows/build-image.yml` — matrix build

- Single job converted to a matrix over `[e2a, e2a-web]`. Both build in parallel; `fail-fast: false` so a failure in one doesn't kill the other's publish.
- **Per-image GHA cache scopes** (`scope=${{ matrix.image }}`) — without scoping, the two matrix entries clobber each other's cache and rebuild from cold every time.
- Same supply-chain story as the server image: provenance + SBOM attestations, keyless cosign signing via Sigstore OIDC.
- PR `paths:` broadened to include `web/**` so a UI-only change still triggers the image build (catches a broken Dockerfile in PR CI rather than after merge).

### `docker-compose.yaml` — dashboard out of the box

Self-hosters running `docker compose up` now get a working dashboard at `http://localhost:3000`. Web service `depends_on: e2a` and proxies `/api/*` to it via the compose-network DNS name.

## Verified locally

```
$ docker build -t e2a-web:local -f web/Dockerfile web
… clean build, ~6.6s on a warm cache …

$ docker run -d --rm -p 18765:80 -e E2A_BACKEND=http://does-not-resolve:8080 e2a-web:local
$ curl -sI http://127.0.0.1:18765/                  # → 200 (landing page, 34646 bytes)
$ curl -sI http://127.0.0.1:18765/dashboard         # → 200 (Next.js route via try_files)
$ curl -sI http://127.0.0.1:18765/api/health        # → 502 (proxied to unresolvable backend, as expected)
```

The rendered HTML confirms the empty-default behavior: `og:url=http://localhost:3000`, `og:site_name=e2a`, landing-page step 1 reads "Sign in and bring your own domain — register it once and verify the DNS records" (the `AGENTS_DOMAIN`-empty fallback), and code samples interpolate `your-domain.com`.

## Known limitations

- **Branding requires a rebuild.** Next.js inlines `NEXT_PUBLIC_*` at build time. Operators who want their own site URL/feedback email/agents domain need to rebuild the image with `--build-arg` overrides; the published image's values can't be swapped at container start. If we ever want runtime config without rebuild, we'd switch to a server-rendered Next.js (drop `output: "export"`) or add a startup script that does string replacement on the static files. Both are bigger changes — happy to consider in a follow-up if the rebuild requirement bites.
- **No internal TLS.** Image listens HTTP only; expects upstream termination. Adding self-signed TLS is one Caddyfile block away if we want it bundled, but most deployments terminate at an ingress.

## Test plan

- [ ] Workflow YAML parses (GitHub will surface a syntax error on push)
- [ ] Both matrix jobs (server + web) appear in PR Checks and run in parallel
- [ ] Each builds without push (`push: false` on PR)
- [ ] After merge, **two** images visible at https://github.com/orgs/Mnexa-AI/packages — `e2a` and `e2a-web` — both with `main` and `sha-<long sha>` tags
- [ ] Both signatures verify with cosign
- [ ] `docker compose up` from a fresh clone serves the dashboard at http://localhost:3000 with API calls reaching the backend on :8080
- [ ] Cache scopes don't collide (subsequent runs show "CACHED" for the unchanged image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)