### PR TITLE
ci: cross-compile builder stages to skip QEMU emulation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,17 @@
-FROM golang:1.26-alpine AS builder
+# Pin the builder to the host's native arch (BUILDPLATFORM) so multi-arch
+# `docker buildx build` doesn't re-run the Go compile under QEMU for each
+# target. With CGO_ENABLED=0, Go cross-compiles cleanly to any platform
+# from any host — TARGETOS/TARGETARCH pick the output's arch. The runtime
+# stage below uses the default platform (set per-target by buildx) so the
+# alpine layer matches the binary.
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
+ARG TARGETOS TARGETARCH
 
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -o /e2a ./cmd/e2a
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /e2a ./cmd/e2a
 
 FROM alpine:3.22
 RUN apk add --no-cache ca-certificates wget \

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -17,7 +17,12 @@
 # rebrand a published image, rebuild from source with --build-arg.
 
 # ── Builder ─────────────────────────────────────────────────────────
-FROM node:22-alpine AS builder
+# Pin to the host's native arch — Next.js' static export is HTML/CSS/JS,
+# so the build itself is arch-neutral. Native npm deps that the builder
+# pulls (@next/swc-*, esbuild) match the host platform automatically,
+# which is what we want. The runtime stage stays per-target so each arch
+# gets its own caddy binary.
+FROM --platform=$BUILDPLATFORM node:22-alpine AS builder
 WORKDIR /app
 
 # Install deps first so the layer caches when only source changes.


### PR DESCRIPTION
## Summary

Pin both Dockerfile builder stages to `BUILDPLATFORM` so the heavy compute runs **natively** on the amd64 GitHub runner instead of inside QEMU emulation for the arm64 half of the matrix. Runtime stages stay per-target so each architecture still gets the right alpine/caddy layer.

The change is 15 lines across two Dockerfiles. Workflow YAML is unchanged.

## How it works

**Server (`Dockerfile`)** — Go cross-compiles cleanly with `CGO_ENABLED=0` (which we already set), so this is a one-shot env-var switch:

```dockerfile
FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
ARG TARGETOS TARGETARCH
…
RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /e2a ./cmd/e2a
```

The arm64 build no longer pays the QEMU cost for the entire Go toolchain — `go build` runs at native amd64 speed and just emits an arm64 binary.

**Web (`web/Dockerfile`)** — Next.js' static export is HTML/CSS/JS, which is arch-neutral. Native npm deps the builder pulls (`@next/swc-*`, `esbuild`) match the build host automatically (which is what we want — they need to run on the build host). So no `TARGETOS/TARGETARCH` plumbing is needed; just pinning to `BUILDPLATFORM` is enough:

```dockerfile
FROM --platform=$BUILDPLATFORM node:22-alpine AS builder
```

## Expected impact

Cold multi-arch builds should drop from ~6–8 min to ~2–3 min on amd64 GitHub runners. The remaining QEMU-emulated work is only the final runtime layers (`apk add wget` on alpine, copying static files into caddy:2-alpine) — totaling ~50 MB, near-instant under emulation.

## Verified locally

```
$ docker buildx build --platform linux/amd64,linux/arm64 -t e2a:multi -f Dockerfile .
… succeeds, manifest list produced …

$ docker buildx build --platform linux/amd64,linux/arm64 -t e2a-web:multi -f web/Dockerfile web
… succeeds …

$ docker run --rm --platform linux/arm64 e2a-web:multi sh -c 'uname -m && wget --version | head -1'
aarch64
GNU Wget 1.25.0 built on linux-musl.

$ docker run --rm --platform linux/amd64 e2a-web:multi sh -c 'uname -m'
x86_64
```

Per-arch containers report the right `uname -m`, the explicit `wget` from PR #17 is present (GNU 1.25.0, not busybox), and the Caddyfile + static export are byte-identical between arches.

## Risk surface

- **Go cross-compile** is the canonical pattern for `CGO_ENABLED=0` projects. No surprises expected.
- **Native npm deps for Next** — `@next/swc-*` and `esbuild` get prebuilt binaries for the platform they execute on. With the builder pinned to `BUILDPLATFORM`, that's the runner's native arch (amd64 in CI). Same as how the previous setup ran them on the emulated arm64 — except now they run native. Output (the `out/` directory) is HTML/CSS/JS and identical regardless of build host.
- **Image content** — runtime layers (`alpine:3.22`, `caddy:2-alpine`) are still pulled per-target, so the actual binaries that ship in each arch's image are arch-correct.

## Test plan

- [ ] Both matrix jobs (server + web) appear in PR Checks and run in parallel
- [ ] Each builds without push (PR trigger has `push: false`)
- [ ] Build time on this PR is **noticeably shorter** than the ~6–8 min baseline from PR #16/#17
- [ ] After merge, both images publish to GHCR and are signed with cosign
- [ ] `docker pull --platform linux/arm64 ghcr.io/mnexa-ai/e2a` and `…/e2a-web` work; `uname -m` inside reports `aarch64`
- [ ] `docker pull --platform linux/amd64 …` works; `uname -m` reports `x86_64`
- [ ] If build time is still painful, the next escalation is native arm64 runners (`ubuntu-24.04-arm`) — bigger restructuring, separate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)