### PR TITLE
docs: pre-launch polish — SECURITY.md, badges, fixups

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # e2a — Email for AI agents
 
+[![Tests](https://github.com/Mnexa-AI/e2a/actions/workflows/test.yml/badge.svg?branch=main)](https://github.com/Mnexa-AI/e2a/actions/workflows/test.yml)
+[![Build image](https://github.com/Mnexa-AI/e2a/actions/workflows/build-image.yml/badge.svg?branch=main)](https://github.com/Mnexa-AI/e2a/actions/workflows/build-image.yml)
+[![License](https://img.shields.io/github/license/Mnexa-AI/e2a)](LICENSE)
+[![npm @e2a/sdk](https://img.shields.io/npm/v/%40e2a%2Fsdk?label=%40e2a%2Fsdk)](https://www.npmjs.com/package/@e2a/sdk)
+[![PyPI e2a](https://img.shields.io/pypi/v/e2a)](https://pypi.org/project/e2a/)
+
 Authenticated email gateway for AI agents. Receive emails as webhooks or via WebSocket, send emails through an HTTP API, and verify the identity of every sender — humans and other agents alike.
 
 - **Authenticated transport** — SPF/DKIM verified on inbound; HMAC-signed `X-E2A-Auth-*` headers on every delivery
@@ -406,7 +412,7 @@ The Next.js dashboard ships as a static export, so its config is inlined at buil
 - **OAuth CSRF** — single-use, time-limited nonce in the `state` parameter
 - **Production mode** (`E2A_ENV=production`) enforces the above where development mode is more permissive
 
-Report security issues privately to **security@mnexa.ai** — do not file public GitHub issues for vulnerabilities.
+Report security issues privately — see [SECURITY.md](SECURITY.md) for the disclosure process and what's in scope. **Do not file public GitHub issues for vulnerabilities.**
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -57,10 +57,11 @@ cd e2a
 docker compose up -d
 ```
 
-Postgres comes up first (migrations run automatically), then e2a. The server listens on:
+Postgres comes up first (migrations run automatically), then the API server, then the dashboard. Three host ports:
 
 - `:8080` — HTTP API
 - `:2525` — SMTP relay
+- `:3000` — Dashboard (Caddy + Next.js, proxies `/api/*` to the API server)
 
 Health check:
 
@@ -68,6 +69,8 @@ Health check:
 curl http://localhost:8080/api/health
 # {"status":"ok"}
 ```
+
+Open `http://localhost:3000` in a browser to view the dashboard. Sign-in requires Google OAuth credentials configured in `config.yaml`; for an API-only smoke test you can skip the dashboard and use the bootstrap flow below.
 
 Create your first user and API key (no OAuth required):
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,88 @@
+# Security Policy
+
+e2a is an authenticated email gateway. A vulnerability in this codebase
+can affect every deployment that uses it — including the ability to
+forge signed `X-E2A-Auth-*` headers, bypass HITL approval gates, exfil
+inbound mail, or spoof agent identity. We take that responsibility
+seriously and ask that you report issues privately rather than in
+public GitHub issues.
+
+## Reporting a vulnerability
+
+Email **security@mnexa.ai** with:
+
+- A description of the issue
+- Steps to reproduce (or a proof-of-concept)
+- The version / commit you observed it on (run `e2a -version` or check
+  `VERSION` in the repo)
+- Any mitigations you suggest
+
+You can also use GitHub's [private vulnerability reporting](https://github.com/Mnexa-AI/e2a/security/advisories/new)
+to file a draft advisory directly against this repo.
+
+We aim to:
+
+- **Acknowledge receipt** within 3 business days
+- **Provide a substantive response** (preliminary assessment + next steps)
+  within 7 business days
+- **Ship a fix** for confirmed high-severity issues within 30 days,
+  faster when active exploitation is plausible
+
+We will credit reporters in the release notes unless you ask to remain
+anonymous. We don't currently run a paid bounty program.
+
+## Supported versions
+
+| Version | Status |
+|---------|--------|
+| Latest tagged release on `main` | ✅ Receives security fixes |
+| Older minor versions | ❌ Please upgrade to the latest |
+
+The project is pre-1.0; we maintain only the most recent release line.
+Self-hosters running pinned versions should plan to upgrade promptly
+when an advisory is published.
+
+## Scope
+
+In scope (please report):
+
+- Authentication bypass — anything that lets an unauthenticated caller
+  reach an authenticated endpoint, or that lets one user act as another
+- Forging or replaying `X-E2A-Auth-*` headers (HMAC, timestamp, body
+  hash) without knowing the signing secret
+- Bypassing HITL approval (sending an outbound message that should
+  have been held for review)
+- SPF/DKIM verification flaws (causing inbound mail to be marked
+  verified when it shouldn't, or vice versa)
+- SSRF in webhook delivery, OAuth callback handling, or any other
+  outbound HTTP path
+- Privilege escalation across users, agents, or domains
+- SQL injection, command injection, path traversal
+- Memory-safety issues in the Go server (e.g. in the SMTP parser)
+- Cryptographic flaws (HMAC misuse, weak random, predictable IDs)
+
+Out of scope:
+
+- Deployments running with the example `change-me-in-production` HMAC
+  secret (the server refuses to start with it; reaching this state
+  requires deliberate misconfiguration)
+- Lack of features (e.g. "no rate limit on X" — open an issue or PR)
+- Vulnerabilities in dependencies that don't have a reachable code
+  path through e2a (please file with the upstream project)
+- Issues only reproducible against `agents.e2a.dev` infrastructure
+  rather than the OSS code (those go to the hosted-product security
+  team via the same email)
+- Email deliverability complaints, spam filter behavior
+
+## Disclosure timeline
+
+Once a fix is merged and released, we will publish a GitHub Security
+Advisory describing the issue, affected versions, and remediation. We
+ask that reporters hold public disclosure until the advisory is
+published or 90 days after first contact, whichever is sooner.
+
+## Bug-bounty alternatives
+
+We don't pay bounties yet. If you'd like recognition beyond credit in
+the advisory — a public thanks on the website, a swag pack — say so in
+your initial report and we'll do our best.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,6 +32,12 @@ services:
     environment:
       E2A_DATABASE_URL: "postgres://e2a:e2a@postgres:5432/e2a?sslmode=disable"
       E2A_HMAC_SECRET: "change-me-in-production"
+      # Demo shared domain so the README's slug-based `agents register`
+      # example works without DNS setup. agents.localhost never resolves
+      # externally, so no real mail will arrive — fine for an API smoke
+      # test. Production deployments override this to a real mail
+      # domain (or unset it to disable slug registration entirely).
+      E2A_SHARED_DOMAIN: "agents.localhost"
     # Healthcheck is defined in the Dockerfile (HEALTHCHECK instruction)
     # so it travels with the image. Anyone using the image — including
     # this compose file — gets it for free.

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -5,7 +5,7 @@ TypeScript/Node.js SDK for [e2a](https://e2a.dev) — email for AI agents.
 ## Install
 
 ```bash
-npm install e2a
+npm install @e2a/sdk
 ```
 
 ## Quick Start

--- a/web/package.json
+++ b/web/package.json
@@ -2,6 +2,7 @@
   "name": "web",
   "version": "0.1.0",
   "private": true,
+  "license": "Apache-2.0",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## Summary

A small batch of pre-announcement housekeeping. No code changes.

| Change | Why |
|---|---|
| New `SECURITY.md` | An OSS project that handles email auth, HMAC signing, and OAuth needs a documented private-disclosure path. Routes reports to `security@mnexa.ai` and GitHub's private advisory form, sets response/triage targets, defines scope. README's Security section now points at it. |
| `sdks/typescript/README.md` install fix | Said `npm install e2a`; actual package is `@e2a/sdk`. First copy-paste any user did would 404. Caught in the original readiness audit and never fixed. |
| `web/package.json` license field | Other workspaces declare `"license": "Apache-2.0"`; web was the lone outlier. |
| README badges | Tests, image build, license, npm, and PyPI. Standard signal that the project is alive and what its release surface is. |

## Deferred / not in this PR

- **`CONTRIBUTING.md`** — defer until external contributors actually start showing up. The README already states the DCO requirement and points at the dev tooling.
- **`CODE_OF_CONDUCT.md`** — same reasoning.
- **npm/PyPI author email** (`josh@mnexa.ai`) — already permanently indexed on prior published versions; no point churning it now.
- **GitHub repo description / topics / homepage** — those are repo-settings changes, not code, and I'll set them via `gh repo edit` after this merges.

## Test plan

- [ ] CI green (no behavioral changes; should be a fast pass)
- [ ] Badges in the rendered README on GitHub all resolve to a non-broken page
- [ ] `npm install @e2a/sdk` matches the actual published package name
- [ ] `SECURITY.md` shows up in the GitHub repo's "Security" tab as the policy

🤖 Generated with [Claude Code](https://claude.com/claude-code)