### PR TITLE
feat(web): link GitHub repo from landing header and footer

### DIFF
--- a/web/src/app/page.test.tsx
+++ b/web/src/app/page.test.tsx
@@ -102,6 +102,12 @@ describe("Navigation auth state", () => {
     expect(screen.queryByText("API Keys")).not.toBeInTheDocument();
     expect(screen.queryByText("Sign out")).not.toBeInTheDocument();
   });
+
+  it("links the GitHub repo from the header", () => {
+    render(<Home />);
+    const githubLink = screen.getByRole("link", { name: /view source on github/i });
+    expect(githubLink).toHaveAttribute("href", "https://github.com/Mnexa-AI/e2a");
+  });
 });
 
 describe("Footer", () => {
@@ -110,7 +116,15 @@ describe("Footer", () => {
     expect(screen.getByText("API Docs")).toBeInTheDocument();
     expect(screen.getByText("Claude Skill")).toBeInTheDocument();
     expect(screen.getByText("Feedback")).toBeInTheDocument();
-    expect(screen.getByText("MIT License")).toBeInTheDocument();
+    expect(screen.getByText("Apache 2.0")).toBeInTheDocument();
+  });
+
+  it("links the GitHub repo from the footer", () => {
+    render(<Home />);
+    const githubLink = screen
+      .getAllByRole("link")
+      .find((l) => l.textContent === "GitHub" && l.getAttribute("href") === "https://github.com/Mnexa-AI/e2a");
+    expect(githubLink).toBeInTheDocument();
   });
 
   it("renders SDK and CLI footer links", () => {

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -46,6 +46,18 @@ export default function Home() {
                 </div>
               )}
             </div>
+            <a
+              href="https://github.com/Mnexa-AI/e2a"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="View source on GitHub"
+              className="nav-secondary-link"
+              style={{ display: "inline-flex", alignItems: "center", color: "#7A6F63", padding: "6px 10px", borderRadius: 6, textDecoration: "none" }}
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M12 .5C5.65.5.5 5.65.5 12c0 5.08 3.29 9.39 7.86 10.91.58.1.79-.25.79-.56 0-.27-.01-1.16-.02-2.1-3.2.7-3.87-1.36-3.87-1.36-.52-1.32-1.27-1.67-1.27-1.67-1.04-.71.08-.7.08-.7 1.15.08 1.76 1.18 1.76 1.18 1.02 1.76 2.69 1.25 3.34.96.1-.74.4-1.25.72-1.54-2.55-.29-5.24-1.28-5.24-5.69 0-1.26.45-2.29 1.18-3.1-.12-.29-.51-1.46.11-3.04 0 0 .96-.31 3.15 1.18a10.95 10.95 0 0 1 5.74 0c2.19-1.49 3.15-1.18 3.15-1.18.62 1.58.23 2.75.11 3.04.74.81 1.18 1.84 1.18 3.1 0 4.42-2.69 5.4-5.25 5.68.41.36.78 1.06.78 2.13 0 1.54-.01 2.78-.01 3.16 0 .31.21.67.8.56C20.21 21.39 23.5 17.08 23.5 12 23.5 5.65 18.35.5 12 .5z"/>
+              </svg>
+            </a>
             <div style={{ marginLeft: 8, paddingLeft: 18, borderLeft: "0.5px solid #E8E0D4" }}>
               {checkingAuth ? (
                 <span style={{ fontSize: 12, color: "#A89A8A" }}>...</span>
@@ -310,6 +322,7 @@ export default function Home() {
       <footer className="site-footer" style={{ padding: "20px 32px", borderTop: "0.5px solid #E8E0D4", display: "flex", alignItems: "center", justifyContent: "space-between" }}>
         <span style={{ fontFamily: "'IBM Plex Mono', monospace", fontWeight: 600, fontSize: 13, color: "#1C1A17" }}>e2a</span>
         <div className="footer-links" style={{ display: "flex", gap: 20 }}>
+          <a href="https://github.com/Mnexa-AI/e2a" target="_blank" rel="noopener noreferrer" style={{ fontSize: 12, color: "#A89A8A", textDecoration: "none" }}>GitHub</a>
           <Link href="/api-docs" style={{ fontSize: 12, color: "#A89A8A", textDecoration: "none" }}>API Docs</Link>
           <Link href="/blog" style={{ fontSize: 12, color: "#A89A8A", textDecoration: "none" }}>Blog</Link>
           <a href="https://pypi.org/project/e2a/" target="_blank" rel="noopener noreferrer" style={{ fontSize: 12, color: "#A89A8A", textDecoration: "none" }}>Python SDK</a>
@@ -318,7 +331,7 @@ export default function Home() {
           <a href="https://github.com/Mnexa-AI/e2a-claude-code-skill" target="_blank" rel="noopener noreferrer" style={{ fontSize: 12, color: "#A89A8A", textDecoration: "none" }}>Claude Skill</a>
           <Link href="/feedback" style={{ fontSize: 12, color: "#A89A8A", textDecoration: "none" }}>Feedback</Link>
         </div>
-        <span style={{ fontSize: 12, color: "#A89A8A" }}>MIT License</span>
+        <span style={{ fontSize: 12, color: "#A89A8A" }}>Apache 2.0</span>
       </footer>
 
       <style>{`


### PR DESCRIPTION
## Summary

The marketing page didn't link to the OSS source — only to the peripheral Claude Code skill repo. With the launch coming, that's the most-clicked link people want when they land. Adds two pointers:

- **Header**: GitHub icon (Octocat SVG, `aria-label="View source on GitHub"`) in the secondary nav, sitting between the Docs dropdown and the sign-in divider.
- **Footer**: "GitHub" text link as the first entry of the footer-links group.

Both go to https://github.com/Mnexa-AI/e2a.

## Drive-by

The footer license blurb said **"MIT License"** but the project is Apache 2.0. Fixed.

## Tests

- Updated the existing footer test that asserted `MIT License` → `Apache 2.0`
- Added a header test (queries via `getByRole("link", { name: /view source on github/i })` so we don't need to inspect SVG markup)
- Added a footer test that the GitHub entry resolves to the right URL

All 122 web tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)