### PR TITLE
docs: correct README scaling section — workers ARE coordinated

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,14 @@ The Next.js dashboard ships as a static export, so its config is inlined at buil
 
 ### Scaling and limitations
 
-**Single-instance for now.** The server keeps several pieces of state in-process: the WebSocket hub for local-mode agents, per-IP/per-agent rate limiters, and background workers for HITL expiration, webhook retry, and cleanup. Running two replicas behind a load balancer today would split WebSocket clients across pods and fire each background worker twice, leading to duplicated emails on HITL TTL expiry. **Vertical scaling is fine; horizontal scaling needs additional work** (advisory locks or leader election for the workers, sticky sessions or a shared pub/sub for the WebSocket hub).
+**Most state is already DB-coordinated.** The HITL expiration worker, the webhook retry worker, and the periodic cleanup worker all use Postgres `SELECT … FOR UPDATE SKIP LOCKED` (or rely on `DELETE` idempotency for cleanup), so running multiple replicas concurrently is safe — only one worker claims a given pending message at a time, no duplicate sends. User sessions live in Postgres and the OAuth nonce travels in a cookie + the OAuth state parameter, so dashboard sign-in survives load-balancer rebalancing.
+
+That leaves two real horizontal-scaling caveats:
+
+1. **WebSocket fan-out is per-replica.** The hub is an in-memory `map[agentID]*conn` ([internal/ws/hub.go](internal/ws/hub.go)). An agent connected to replica A won't receive real-time notifications for events that happen on replica B — an inbound mail arriving at B's SMTP relay, a HITL approval firing on B's API, etc. Messages aren't lost: they stay `unread` in Postgres and the agent drains them on the next reconnect or REST fetch. They're just not pushed in real-time. Fix: a shared pub/sub (Redis, NATS) for cross-replica notification fan-out, or sticky sessions plus a per-replica routing layer.
+2. **Rate limits multiply with replica count.** Limiters are in-process (per-IP, per-agent, per-user — see `ratelimit.New(...)` calls in [internal/agent/api.go](internal/agent/api.go)). With two replicas the effective caps are 2× looser, not stricter. Operators who need exact global limits would move the limiters to a shared store (Redis, or a Postgres-backed token bucket).
+
+**Vertical scaling is fine.** The API, the SMTP relay, and all three background workers run safely on multiple replicas today — the only paths that need attention before you do are the two above.
 
 **Dashboard auth is Google OAuth only.** [`internal/auth/auth.go`](internal/auth/auth.go) imports `golang.org/x/oauth2/google` directly and the config exposes `google_client_id` / `google_client_secret`. Teams running GitHub OAuth, Microsoft Entra, Okta, or generic OIDC need to add a provider in that package. The CLI and SDKs authenticate with API keys, which are provider-agnostic.
 


### PR DESCRIPTION
## Summary

Re-audit of the **Scaling and limitations** section against the actual code turned up one outright wrong claim plus two missing nuances. Rewriting the affected paragraph for accuracy.

## Audit findings

| Claim in README | Verdict |
|---|---|
| WebSocket hub is in-process | ✅ True ([internal/ws/hub.go:15](internal/ws/hub.go#L15)) |
| "per-IP/per-agent rate limiters" | ⚠️ Incomplete — there's also a per-user limiter (`pollLimit`, [api.go:170](internal/agent/api.go#L170)) |
| "background workers for HITL expiration, webhook retry, and cleanup" | ✅ True (all goroutines in `cmd/e2a/main.go`) |
| **"fire each background worker twice, leading to duplicated emails on HITL TTL expiry"** | ❌ **False.** The HITL worker ([identity/store.go:1167](internal/identity/store.go#L1167)) and webhook retry worker ([webhook/store.go:66](internal/webhook/store.go#L66)) explicitly use `SELECT … FOR UPDATE SKIP LOCKED`. The HITL site has a comment that literally says *"concurrent workers don't race for the same row."* The cleanup worker is `DELETE`-only and idempotent. Running multiple replicas concurrently is **already safe** for the workers. |
| **"horizontal scaling needs … advisory locks or leader election for the workers"** | ❌ **False.** Already coordinated via SKIP LOCKED. This advice is unnecessary and misleadingly suggests the workers are unsafe today. |
| "Otherwise infra-agnostic" claims | ✅ True (verified separately) |
| "Dashboard auth is Google OAuth only" | ✅ True |

Plus a missing real caveat: **rate limiters are in-process**, so `N` replicas means `N×` effective rate — limits get **looser**, not stricter, with horizontal scale. Operators expect the opposite, so worth calling out.

Also missing on the positive side: **sessions live in Postgres** and **OAuth state lives in cookies + the OAuth state parameter**, so dashboard sign-in already survives load-balancer rebalancing.

## What changes

Rewrites the lead paragraph to:

1. Lead with what already works (DB-coordinated workers via SKIP LOCKED, DB-backed sessions, stateless OAuth).
2. Name the two real horizontal-scaling caveats:
   - WebSocket fan-out is per-replica (with a clarification that messages aren't lost — they stay `unread` and drain on reconnect; they're just not pushed in real-time).
   - Rate limits multiply with replica count.
3. Close with "vertical scaling is fine; horizontal works for everything except those two paths."

The other two paragraphs in the section ("Dashboard auth is Google OAuth only" and "Otherwise infra-agnostic") audit clean and stay unchanged.

## Test plan

- [ ] Rendered README on the PR page reads cleanly
- [ ] Code links (`internal/ws/hub.go`, `internal/agent/api.go`) resolve to existing files
- [ ] Numbered list renders properly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)