### PR TITLE
chore(sdk,cli): bump to 1.3.1 to publish corrected Apache-2.0 license

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -217,3 +217,7 @@ wss://e2a.dev/api/v1/agents/{email}/ws?token={api_key}
 The server sends lightweight JSON notifications (message_id, from, subject, received_at) when emails arrive. The CLI fetches full message content via the REST API as needed (`--json` and `--forward` modes). This keeps the WebSocket connection fast and avoids large attachments blocking notifications.
 
 When the CLI disconnects and reconnects, all messages that arrived while offline are drained immediately as notifications.
+
+## License
+
+Apache-2.0 — see [LICENSE](https://github.com/Mnexa-AI/e2a/blob/main/LICENSE) and [NOTICE](https://github.com/Mnexa-AI/e2a/blob/main/NOTICE) in the upstream repo.

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/cli",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "CLI for e2a — email for AI agents",
   "bin": {
     "e2a": "./dist/bin/e2a.js"

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -373,3 +373,7 @@ Same as `E2AClient` — all I/O methods are `async`. `parse()` is sync (no I/O n
 ### Exceptions
 
 - `E2AApiError` — API error (has `status_code` and `message`)
+
+## License
+
+Apache-2.0 — see [LICENSE](https://github.com/Mnexa-AI/e2a/blob/main/LICENSE) and [NOTICE](https://github.com/Mnexa-AI/e2a/blob/main/NOTICE) in the upstream repo.

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "e2a"
-version = "1.3.0"
+version = "1.3.1"
 description = "Python SDK for the e2a protocol — email-to-agent authentication"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -161,4 +161,4 @@ await agentA.send(["bob@agent.acme.com"], "Can you handle this?", bodyText, {
 
 ## License
 
-MIT
+Apache-2.0 — see [LICENSE](https://github.com/Mnexa-AI/e2a/blob/main/LICENSE) and [NOTICE](https://github.com/Mnexa-AI/e2a/blob/main/NOTICE) in the upstream repo.

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/sdk",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "TypeScript SDK for e2a — email for AI agents",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

The `1.3.0` published versions of `@e2a/sdk`, `@e2a/cli`, and the Python `e2a` package all show **MIT** as the license on npm and PyPI:

```
$ npm view @e2a/sdk license
MIT
$ npm view @e2a/cli license
MIT
$ curl -s https://pypi.org/pypi/e2a/json | jq '.info.classifiers'
[..., "License :: OSI Approved :: MIT License", ...]
```

The repo source has been **Apache-2.0** across all three for a while:

```
sdks/typescript/package.json:  "license": "Apache-2.0"
sdks/python/pyproject.toml:    license = "Apache-2.0"
cli/package.json:              "license": "Apache-2.0"
```

But registry metadata is frozen per-version — fixing the published license requires a new release. Hence the bump.

## Changes

- **Bump `@e2a/sdk`, `@e2a/cli`, and Python `e2a` from `1.3.0` → `1.3.1`.** Patch bump because there's no behavior change.
- **Fix `sdks/typescript/README.md`** — line 164 literally said "MIT". This README ships inside the npm tarball, so the published landing page on npmjs.com was stamped MIT regardless of `package.json`. Replaced with the proper Apache-2.0 + LICENSE/NOTICE pointer.
- **Add License sections to Python SDK + CLI READMEs** for consistency (they previously had no license section at all).

## After merge

Publish workflows are tag-triggered (per CLAUDE.md → "Publishing"):

```
git tag ts-sdk-v1.3.1 && git push origin ts-sdk-v1.3.1
git tag python-v1.3.1 && git push origin python-v1.3.1
gh workflow run "Publish CLI" --ref main
```

I'll run those once the PR is merged.

## Test plan

- [ ] CI green (no behavior change; should be a fast pass)
- [ ] After publish, `npm view @e2a/sdk@1.3.1 license` reports `Apache-2.0`
- [ ] After publish, `npm view @e2a/cli@1.3.1 license` reports `Apache-2.0`
- [ ] After publish, `pip show e2a` (post-install) reports Apache-2.0 metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)