### PR TITLE
fix(cli): use semver range for @e2a/sdk so workspace links during build

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -19,7 +19,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@e2a/sdk": "1.3.0"
+    "@e2a/sdk": "^1.3.1"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",


### PR DESCRIPTION
## Summary

PR #31 bumped both `@e2a/sdk` and `@e2a/cli` to `1.3.1`, but didn't update the CLI's dependency on the SDK — `cli/package.json` still pinned `@e2a/sdk` to **exactly** `1.3.0`. After the bump, npm's exact-match resolution refused to use the local workspace symlink (workspace was at 1.3.1) and silently fetched `@e2a/sdk@1.3.0` from the registry instead.

The published 1.3.0 doesn't have the `fetchInfo` static method that [cli/src/commands/agents.ts:22](cli/src/commands/agents.ts#L22) and [cli/src/commands/login.ts:251](cli/src/commands/login.ts#L251) call (added during the user-data-rights work). So the CLI build broke with `Property 'fetchInfo' does not exist on type 'typeof E2AApi'`.

The publish-cli.yml workflow's `test` job hit this error, the `publish` job was skipped, and **`@e2a/cli@1.3.1` never made it to npm** while `@e2a/sdk@1.3.1` and `e2a@1.3.1` (Python) did.

## Fix

```diff
-    "@e2a/sdk": "1.3.0"
+    "@e2a/sdk": "^1.3.1"
```

Switching to a caret range satisfies the local 1.3.1 workspace (so the symlink takes precedence during build) and any published 1.3.x, so downstream npm users still resolve correctly. The range moves with each version bump going forward.

## Verified locally

```
$ rm -rf node_modules cli/node_modules sdks/typescript/node_modules
$ npm install --package-lock=false   # clean state
$ npm run build --workspace @e2a/sdk
$ npm run build --workspace @e2a/cli
$ npm test --workspace @e2a/cli      # 97 passing
```

## After merge

Re-trigger the CLI publish via `workflow_dispatch`:

```
gh workflow run "Publish CLI" --ref main
```

The previously-claimed `1.3.1` slot on npm is still empty (404), so we don't need to bump again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)