### PR TITLE
feat: migrate Claude Code skill into the public repo

### DIFF
--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -1,0 +1,261 @@
+# Email Skill
+
+<!-- version: 5 -->
+
+You can give yourself an email address and use it to check your inbox, read, reply to, and send emails.
+
+Email is powered by [e2a](https://e2a.dev) — email for AI agents.
+
+## Preamble (run first)
+
+```bash
+_E2A_STATE="$HOME/.e2a/skill"
+_E2A_CHECK="$_E2A_STATE/last-check"
+_E2A_LOCAL=5
+_E2A_NOW=$(date +%s)
+_E2A_SKIP=0
+if [ -f "$_E2A_CHECK" ]; then
+  _E2A_LAST=$(cat "$_E2A_CHECK")
+  [ $((_E2A_NOW - _E2A_LAST)) -lt 86400 ] && _E2A_SKIP=1
+fi
+if [ "$_E2A_SKIP" -eq 0 ]; then
+  mkdir -p "$_E2A_STATE"
+  echo "$_E2A_NOW" > "$_E2A_CHECK"
+  _E2A_REMOTE=$(curl -sf https://raw.githubusercontent.com/Mnexa-AI/e2a/main/skills/SKILL.md | sed -n 's/.*version: \([0-9]*\).*/\1/p' | head -1)
+  if [ -n "$_E2A_REMOTE" ] && [ "$_E2A_REMOTE" -gt "$_E2A_LOCAL" ] 2>/dev/null; then
+    echo "E2A_SKILL_UPDATE_AVAILABLE $_E2A_LOCAL $_E2A_REMOTE"
+  fi
+fi
+```
+
+If output contains `E2A_SKILL_UPDATE_AVAILABLE`: tell the user a new version of the e2a skill is available and ask if they'd like to update. If yes, run:
+
+```bash
+curl -sf -o .claude/skills/e2a/SKILL.md https://raw.githubusercontent.com/Mnexa-AI/e2a/main/skills/SKILL.md
+```
+
+Then re-read the updated file and follow its instructions instead.
+
+If there is no output, continue silently.
+
+## Setup
+
+Run through these steps in order. Skip any step that's already done.
+
+### 1. Install the CLI
+
+```bash
+which e2a || npm install -g @e2a/cli
+```
+
+### 2. Log in and register an agent
+
+Read `~/.e2a/config.json`. If the file exists and has both `api_key` and `agent_email`, you're already set up — skip this step.
+
+If the file is missing or incomplete, the user needs to log in:
+
+```bash
+e2a login
+```
+
+This opens a browser where the user authenticates and creates an agent. Both `api_key` and `agent_email` are automatically saved to `~/.e2a/config.json`.
+
+If the user is logged in but has no agent yet, they can register one:
+
+```bash
+e2a agents register <slug>
+```
+
+This creates `<slug>@agents.e2a.dev` as your email address and saves it to config.
+
+## OpenClaw Integration
+
+If the user wants to connect email to an OpenClaw agent running locally:
+
+`e2a listen` connects to e2a over WebSocket to receive emails in real time, then forwards each email as an HTTP POST to the local OpenClaw gateway. The user does not need to configure WebSocket directly — `e2a listen --forward` handles the full pipeline.
+
+### 1. Enable the responses endpoint
+
+Read `~/.openclaw/openclaw.json`. Check if `gateway.http.endpoints.responses.enabled` is `true`. If the key is missing or set to `false`, update the config to enable it:
+
+```json
+{
+  "gateway": {
+    "http": {
+      "endpoints": {
+        "responses": {
+          "enabled": true
+        }
+      }
+    }
+  }
+}
+```
+
+After editing the config, restart the gateway:
+
+```bash
+openclaw gateway restart
+```
+
+### 2. Find the gateway token
+
+Read `~/.openclaw/openclaw.json` and extract the `gateway.auth.token` value. If the file doesn't exist, OpenClaw isn't installed yet — tell the user to install and start OpenClaw first.
+
+### 3. Start the email listener
+
+```bash
+e2a listen --forward http://localhost:18789/v1/responses --forward-token <gateway-token>
+```
+
+Replace `<gateway-token>` with the token from the previous step. The default OpenClaw gateway port is `18789`.
+
+This runs in the foreground and forwards every incoming email to the local OpenClaw agent as an API request. The agent's response is automatically sent back as an email reply.
+
+To run it in the background, the user can use `nohup`, `tmux`, or a process manager.
+
+## Cloud Webhook Integration
+
+If the user wants to receive emails on a cloud-hosted agent via webhook:
+
+### 1. Register a cloud agent
+
+Go to https://e2a.dev and register a new agent in "Cloud" mode. Enter your webhook URL (must be HTTPS).
+
+### 2. Implement the webhook endpoint
+
+#### Python
+
+Install the Python SDK:
+
+```bash
+pip install e2a
+```
+
+Example webhook handler using FastAPI:
+
+```python
+import e2a
+from fastapi import FastAPI, Request
+
+app = FastAPI()
+
+# Webhook mode: agent_email is optional — it auto-resolves from the payload
+client = e2a.E2AClient(api_key="e2a_...")  # or set E2A_API_KEY env var
+
+# For single-agent setups, you can also set it explicitly:
+# client = e2a.E2AClient(api_key="e2a_...", agent_email="bot@agents.e2a.dev")
+
+@app.post("/webhook")
+async def webhook(request: Request):
+    email = client.parse(await request.body())
+    print(f"From: {email.sender}")
+    print(f"Subject: {email.subject}")
+    print(f"Body: {email.text_body}")
+
+    # Reply — agent_email auto-resolves from email.recipient
+    email.reply("Thanks for your email!")
+
+    return {"ok": True}
+```
+
+#### TypeScript
+
+Install the TypeScript SDK:
+
+```bash
+npm install @e2a/sdk
+```
+
+Example webhook handler using Express:
+
+```typescript
+import { E2AClient } from "@e2a/sdk";
+import express from "express";
+
+const app = express();
+app.use(express.json());
+
+// Webhook mode: agent_email is optional — it auto-resolves from the payload.
+// E2AClient requires apiKey explicitly; pass it from env or config.
+const client = new E2AClient({ apiKey: process.env.E2A_API_KEY! });
+
+app.post("/webhook", async (req, res) => {
+  const email = await client.parse(req.body);
+  console.log(`From: ${email.sender}`);
+  console.log(`Subject: ${email.subject}`);
+  console.log(`Body: ${email.textBody}`);
+
+  // Reply — agent_email auto-resolves from email.recipient
+  await email.reply("Thanks for your email!");
+
+  res.json({ ok: true });
+});
+
+app.listen(3000);
+```
+
+The webhook receives a JSON payload with these fields:
+
+```json
+{
+  "message_id": "msg_abc123",
+  "conversation_id": "conv_xyz",
+  "from": "alice@example.com",
+  "to": "agent@agents.e2a.dev",
+  "raw_message": "<base64-encoded RFC 2822 email>",
+  "auth_headers": {
+    "X-E2A-Auth-Verified": "true",
+    "X-E2A-Auth-Sender": "alice@example.com",
+    "X-E2A-Auth-Domain-Check": "spf=pass; dkim=pass"
+  },
+  "received_at": "2026-03-28T10:00:00Z"
+}
+```
+
+`client.parse()` handles decoding the raw message and gives you `email.subject`, `email.text_body`, `email.html_body`, `email.attachments`, and `email.reply()`.
+
+Check `email.is_verified` to confirm the sender's identity was verified by e2a.
+
+For full SDK documentation, see https://e2a.dev/python-sdk.
+
+## Commands
+
+```bash
+# Log in — opens browser to authenticate, saves api_key and agent_email to ~/.e2a/config.json
+# SDKs automatically read E2A_API_KEY from the environment, or you can pass the key from config directly
+e2a login
+
+# Check inbox
+e2a inbox
+
+# Check inbox for a specific agent (if you have multiple)
+e2a inbox --agent <agent-email>
+
+# Read a specific message
+e2a read <message-id>
+
+# Reply to a message
+e2a reply <message-id> --body "your reply"
+
+# Send a new email
+e2a send --to <recipient> --subject "subject" --body "body"
+
+# List custom domains
+e2a domains list
+
+# Register and verify a custom domain
+e2a domains register <domain>
+e2a domains verify <domain>
+```
+
+The `--agent` flag is optional if `agent_email` is set in your config.
+
+## Reference
+
+- Config file: `~/.e2a/config.json` (JSON with `api_key`, `api_url`, `agent_email`, `shared_domain`)
+- Environment variables that override config: `E2A_API_KEY`, `E2A_URL`, `E2A_SHARED_DOMAIN` (CLI). `E2A_AGENT_EMAIL` is honored by the Python/TS SDK constructors when you don't pass `agent_email` explicitly.
+- CLI docs: https://www.npmjs.com/package/@e2a/cli
+- TypeScript SDK: https://www.npmjs.com/package/@e2a/sdk
+- Python SDK: https://e2a.dev/python-sdk
+- e2a docs: https://e2a.dev/docs

--- a/web/src/app/(app)/dashboard/_components/ConnectInstructions.tsx
+++ b/web/src/app/(app)/dashboard/_components/ConnectInstructions.tsx
@@ -13,7 +13,7 @@ export function ConnectInstructions({ mode }: { mode?: string }) {
           : "Install the e2a skill to set up your webhook endpoint."}
       </p>
       <p className="text-xs font-medium text-foreground">Install the e2a skill</p>
-      <CodeBlock code={`mkdir -p .claude/skills/e2a\ncurl -o .claude/skills/e2a/SKILL.md \\\n  https://raw.githubusercontent.com/Mnexa-AI/e2a-claude-code-skill/main/SKILL.md`} />
+      <CodeBlock code={`mkdir -p .claude/skills/e2a\ncurl -o .claude/skills/e2a/SKILL.md \\\n  https://raw.githubusercontent.com/Mnexa-AI/e2a/main/skills/SKILL.md`} />
       <p className="text-xs text-muted">
         Then use <code className="text-[11px] bg-surface px-1 py-0.5 rounded border border-border">/e2a</code> in your agent to get started.
         {isLocal

--- a/web/src/app/(app)/get-started/_components/SuccessPanel.tsx
+++ b/web/src/app/(app)/get-started/_components/SuccessPanel.tsx
@@ -116,7 +116,7 @@ export function SuccessPanel({
       <div className="space-y-4">
         <CodeBlock
           title="Install the e2a skill"
-          code={`mkdir -p .claude/skills/e2a\ncurl -o .claude/skills/e2a/SKILL.md \\\n  https://raw.githubusercontent.com/Mnexa-AI/e2a-claude-code-skill/main/SKILL.md`}
+          code={`mkdir -p .claude/skills/e2a\ncurl -o .claude/skills/e2a/SKILL.md \\\n  https://raw.githubusercontent.com/Mnexa-AI/e2a/main/skills/SKILL.md`}
         />
         <p className="text-sm text-muted">
           Then use{" "}

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -39,7 +39,7 @@ export default function Home() {
               {docsOpen && (
                 <div style={{ position: "absolute", top: "100%", left: 0, background: "#FDFAF6", border: "0.5px solid #E8E0D4", borderRadius: 8, padding: "6px 0", minWidth: 160, boxShadow: "0 4px 12px rgba(0,0,0,0.08)", zIndex: 100 }}>
                   <Link href="/api-docs" style={{ display: "block", fontSize: 13, color: "#7A6F63", padding: "7px 16px", textDecoration: "none" }} onMouseEnter={e => (e.currentTarget.style.background = "#F5EDE3")} onMouseLeave={e => (e.currentTarget.style.background = "transparent")}>API Reference</Link>
-                  <a href="https://github.com/Mnexa-AI/e2a-claude-code-skill" target="_blank" rel="noopener noreferrer" style={{ display: "block", fontSize: 13, color: "#7A6F63", padding: "7px 16px", textDecoration: "none" }} onMouseEnter={e => (e.currentTarget.style.background = "#F5EDE3")} onMouseLeave={e => (e.currentTarget.style.background = "transparent")}>Claude Code skill</a>
+                  <a href="https://github.com/Mnexa-AI/e2a/blob/main/skills/SKILL.md" target="_blank" rel="noopener noreferrer" style={{ display: "block", fontSize: 13, color: "#7A6F63", padding: "7px 16px", textDecoration: "none" }} onMouseEnter={e => (e.currentTarget.style.background = "#F5EDE3")} onMouseLeave={e => (e.currentTarget.style.background = "transparent")}>Claude Code skill</a>
                   <a href="https://pypi.org/project/e2a/" target="_blank" rel="noopener noreferrer" style={{ display: "block", fontSize: 13, color: "#7A6F63", padding: "7px 16px", textDecoration: "none" }} onMouseEnter={e => (e.currentTarget.style.background = "#F5EDE3")} onMouseLeave={e => (e.currentTarget.style.background = "transparent")}>Python SDK</a>
                   <a href="https://www.npmjs.com/package/@e2a/sdk" target="_blank" rel="noopener noreferrer" style={{ display: "block", fontSize: 13, color: "#7A6F63", padding: "7px 16px", textDecoration: "none" }} onMouseEnter={e => (e.currentTarget.style.background = "#F5EDE3")} onMouseLeave={e => (e.currentTarget.style.background = "transparent")}>TypeScript SDK</a>
                   <a href="https://www.npmjs.com/package/@e2a/cli" target="_blank" rel="noopener noreferrer" style={{ display: "block", fontSize: 13, color: "#7A6F63", padding: "7px 16px", textDecoration: "none" }} onMouseEnter={e => (e.currentTarget.style.background = "#F5EDE3")} onMouseLeave={e => (e.currentTarget.style.background = "transparent")}>CLI</a>
@@ -158,7 +158,7 @@ export default function Home() {
                 <div style={{ color: "#5A5248" }}># drop the e2a skill into your Claude Code project</div>
                 <div style={{ color: "#E8E0D4" }}>mkdir -p .claude/skills/e2a</div>
                 <div style={{ color: "#E8E0D4" }}>curl -o .claude/skills/e2a/SKILL.md \</div>
-                <div style={{ color: "#E8E0D4" }}>&nbsp;&nbsp;https://raw.githubusercontent.com/Mnexa-AI/e2a-claude-code-skill/main/SKILL.md</div>
+                <div style={{ color: "#E8E0D4" }}>&nbsp;&nbsp;https://raw.githubusercontent.com/Mnexa-AI/e2a/main/skills/SKILL.md</div>
                 <div style={{ color: "#2A2620" }}>&nbsp;</div>
                 <div style={{ color: "#5A5248" }}># then tell Claude Code:</div>
                 <div style={{ color: "#E8E0D4" }}>/e2a register my-agent</div>
@@ -328,7 +328,7 @@ export default function Home() {
           <a href="https://pypi.org/project/e2a/" target="_blank" rel="noopener noreferrer" style={{ fontSize: 12, color: "#A89A8A", textDecoration: "none" }}>Python SDK</a>
           <a href="https://www.npmjs.com/package/@e2a/sdk" target="_blank" rel="noopener noreferrer" style={{ fontSize: 12, color: "#A89A8A", textDecoration: "none" }}>TypeScript SDK</a>
           <a href="https://www.npmjs.com/package/@e2a/cli" target="_blank" rel="noopener noreferrer" style={{ fontSize: 12, color: "#A89A8A", textDecoration: "none" }}>CLI</a>
-          <a href="https://github.com/Mnexa-AI/e2a-claude-code-skill" target="_blank" rel="noopener noreferrer" style={{ fontSize: 12, color: "#A89A8A", textDecoration: "none" }}>Claude Skill</a>
+          <a href="https://github.com/Mnexa-AI/e2a/blob/main/skills/SKILL.md" target="_blank" rel="noopener noreferrer" style={{ fontSize: 12, color: "#A89A8A", textDecoration: "none" }}>Claude Skill</a>
           <Link href="/feedback" style={{ fontSize: 12, color: "#A89A8A", textDecoration: "none" }}>Feedback</Link>
         </div>
         <span style={{ fontSize: 12, color: "#A89A8A" }}>Apache 2.0</span>


### PR DESCRIPTION
## Summary

Migrates the e2a Claude Code skill from the standalone `Mnexa-AI/e2a-claude-code-skill` repo into this repo at [`skills/SKILL.md`](skills/SKILL.md). The standalone repo will be **deleted** after this PR merges, so every reference (inside SKILL.md and across the web UI) gets repointed at the new canonical URL in the same commit. No mirror to keep in sync.

## Reference repointing

7 places needed updating to keep working after the standalone repo is deleted:

| File | What changed |
|---|---|
| [`skills/SKILL.md:24`](skills/SKILL.md#L24) | Self-update version-check curl |
| [`skills/SKILL.md:34`](skills/SKILL.md#L34) | Self-update install curl |
| [`web/src/app/page.tsx:42`](web/src/app/page.tsx#L42) | Docs dropdown "Claude Code skill" link |
| [`web/src/app/page.tsx:161`](web/src/app/page.tsx#L161) | Landing-page hero code sample (curl URL) |
| [`web/src/app/page.tsx:331`](web/src/app/page.tsx#L331) | Footer "Claude Skill" link |
| [`web/src/app/(app)/get-started/_components/SuccessPanel.tsx:119`](web/src/app/(app)/get-started/_components/SuccessPanel.tsx#L119) | Get-started install snippet |
| [`web/src/app/(app)/dashboard/_components/ConnectInstructions.tsx:16`](web/src/app/(app)/dashboard/_components/ConnectInstructions.tsx#L16) | Dashboard "Connect" install snippet |

New canonical URLs:
- Raw: `https://raw.githubusercontent.com/Mnexa-AI/e2a/main/skills/SKILL.md`
- Browse: `https://github.com/Mnexa-AI/e2a/blob/main/skills/SKILL.md`

## Drive-by correctness fixes in SKILL.md

While auditing the file against the current code, four real issues turned up:

1. **Setup step numbering** jumped from `### 1. Install the CLI` straight to `### 3. Log in and register an agent` — no `### 2`. Renumbered to 2.

2. **TypeScript webhook example** wrote `const client = new E2AClient();` with a comment claiming env-var fallback. Wrong on both counts: `E2AClient`'s constructor takes a required `E2AClientOptions` arg, and there's no env reading. Pasting the example would fail to typecheck. Fixed to `new E2AClient({ apiKey: process.env.E2A_API_KEY! })`.

3. **Reference → config keys** listed `api_key, api_url, agent_email` — missing `shared_domain` (added to the CLI config recently so self-hosters can override the auto-discovered shared mail domain). Added.

4. **Reference → env vars** was missing `E2A_SHARED_DOMAIN` and conflated CLI-honored vars with SDK-honored ones. Split: `E2A_API_KEY` / `E2A_URL` / `E2A_SHARED_DOMAIN` are CLI vars; `E2A_AGENT_EMAIL` is honored by the Python/TS SDK constructors when `agent_email` isn't passed explicitly.

Bumped `<!-- version: 4 -->` → 5 (and the matching `_E2A_LOCAL=4` → 5 constant inside the self-update preamble) so existing installs get prompted to update next time the preamble runs.

## After merge — manual step

Delete `github.com/Mnexa-AI/e2a-claude-code-skill`. Every install URL in this repo and the Claude Code skill content itself has been repointed at the new canonical location, so deletion won't break anything inside e2a's own surface. **Old curl URLs that third parties have copied into their own docs/tutorials will start 404'ing** — that's the cost of consolidating, and there's no clean way to redirect a deleted GitHub repo. The skill's self-update preamble running in the wild will start fetching from the new URL on its next 24-hour check, so end-user installs will eventually heal themselves; ones that haven't run the preamble in 24h+ will need a manual `curl` from the new URL.

## Test plan

- [ ] CI green (`web/` rebuild + tests pass — verified locally, 122 web tests still pass after the URL changes)
- [ ] After merge, `https://raw.githubusercontent.com/Mnexa-AI/e2a/main/skills/SKILL.md` resolves
- [ ] Standalone repo deleted

🤖 Generated with [Claude Code](https://claude.com/claude-code)