### PR TITLE
fix(cli): add repository metadata for npm provenance verification

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -18,6 +18,13 @@
     "node": ">=18"
   },
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Mnexa-AI/e2a",
+    "directory": "cli"
+  },
+  "homepage": "https://github.com/Mnexa-AI/e2a/tree/main/cli",
+  "bugs": "https://github.com/Mnexa-AI/e2a/issues",
   "dependencies": {
     "@e2a/sdk": "^1.3.1"
   },


### PR DESCRIPTION
## Summary

The `@e2a/cli@1.3.1` publish was rejected by npm with:

```
422 Unprocessable Entity - PUT https://registry.npmjs.org/@e2a%2fcli
Error verifying sigstore provenance bundle: Failed to validate
repository information: package.json: "repository.url" is "",
expected to match "https://github.com/Mnexa-AI/e2a" from provenance
```

npm's provenance verification cross-checks the OIDC-attested repo URL from GitHub Actions against the package.json. **`cli/package.json` had no `repository`, `homepage`, or `bugs` fields.** The SDK at `sdks/typescript/package.json` has all three — that's why `@e2a/sdk@1.3.1` published cleanly while `@e2a/cli@1.3.1` stalled.

## Fix

Mirror the SDK's metadata block:

```diff
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Mnexa-AI/e2a",
+    "directory": "cli"
+  },
+  "homepage": "https://github.com/Mnexa-AI/e2a/tree/main/cli",
+  "bugs": "https://github.com/Mnexa-AI/e2a/issues",
```

## After merge

Re-trigger:

```
gh workflow run "Publish CLI" --ref main
```

The 1.3.1 slot on npm is still empty (the prior failed attempts didn't claim it), so we don't need to bump again. Verifying with `npm view @e2a/cli@1.3.1 license` should report `Apache-2.0` after the publish lands.