### PR TITLE
feat(web): settings page with data export and account deletion

### DIFF
--- a/web/src/app/(app)/settings/page.test.tsx
+++ b/web/src/app/(app)/settings/page.test.tsx
@@ -1,0 +1,123 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import SettingsPage from "./page";
+
+// Mock next/link to plain anchors so we don't need a router in jsdom.
+jest.mock("next/link", () => {
+  return function MockLink({ href, children, ...rest }: { href: string; children: React.ReactNode; [k: string]: unknown }) {
+    return <a href={href} {...rest}>{children}</a>;
+  };
+});
+
+const signOut = jest.fn();
+let mockAuth: {
+  user: { id: string; email: string; name: string; created_at: string } | null;
+  loading: boolean;
+  signOut: jest.Mock;
+};
+
+jest.mock("../../components/AuthProvider", () => ({
+  useAuth: () => mockAuth,
+}));
+
+beforeEach(() => {
+  mockAuth = {
+    user: {
+      id: "usr_abc123",
+      email: "alice@example.com",
+      name: "Alice",
+      created_at: "2026-04-01T10:00:00Z",
+    },
+    loading: false,
+    signOut,
+  };
+});
+
+describe("Settings — Profile section", () => {
+  it("shows the user's name, email, ID, and member-since date", () => {
+    render(<SettingsPage />);
+    expect(screen.getByText("Alice")).toBeInTheDocument();
+    expect(screen.getByText("alice@example.com")).toBeInTheDocument();
+    expect(screen.getByText("usr_abc123")).toBeInTheDocument();
+    // The exact format depends on locale but the year should always render.
+    expect(screen.getByText(/2026/)).toBeInTheDocument();
+  });
+
+  it("renders nothing when user is null (defensive)", () => {
+    mockAuth.user = null;
+    const { container } = render(<SettingsPage />);
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("Settings — Export section", () => {
+  it("links the Download export button at the API endpoint", () => {
+    render(<SettingsPage />);
+    const link = screen.getByRole("link", { name: /download export/i });
+    expect(link).toHaveAttribute("href", "/api/v1/users/me/export");
+  });
+});
+
+describe("Settings — Danger zone (delete account)", () => {
+  it("hides the confirm input until the user opens the flow", () => {
+    render(<SettingsPage />);
+    expect(screen.queryByPlaceholderText("DELETE")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /delete account/i }));
+    expect(screen.getByPlaceholderText("DELETE")).toBeInTheDocument();
+  });
+
+  it("disables the final delete button until confirmation matches", () => {
+    render(<SettingsPage />);
+    fireEvent.click(screen.getByRole("button", { name: /delete account/i }));
+    const finalBtn = screen.getByRole("button", { name: /delete my account/i });
+    expect(finalBtn).toBeDisabled();
+
+    const input = screen.getByPlaceholderText("DELETE") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "delete" } }); // wrong case
+    expect(finalBtn).toBeDisabled();
+
+    fireEvent.change(input, { target: { value: "DELETE" } });
+    expect(finalBtn).toBeEnabled();
+  });
+
+  it("issues DELETE /api/v1/users/me?confirm=DELETE with cookie credentials on confirmation", async () => {
+    // Hold the response in a deferred Promise so the assertion runs
+    // before the success handler tries to redirect (which would mutate
+    // window.location and is hard to mock cleanly in jsdom).
+    type FetchLike = { ok: boolean; status: number; text: () => Promise<string>; json: () => Promise<unknown> };
+    let resolveFetch: (resp: FetchLike) => void = () => {};
+    const fetchPromise = new Promise<FetchLike>((r) => { resolveFetch = r; });
+    const fetchMock = jest.fn(() => fetchPromise);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<SettingsPage />);
+    fireEvent.click(screen.getByRole("button", { name: /delete account/i }));
+    fireEvent.change(screen.getByPlaceholderText("DELETE"), { target: { value: "DELETE" } });
+    fireEvent.click(screen.getByRole("button", { name: /delete my account/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/v1/users/me?confirm=DELETE",
+        expect.objectContaining({ method: "DELETE", credentials: "include" }),
+      );
+    });
+    // Resolve so the test doesn't leak a pending promise — but don't
+    // await the redirect, since that path mutates window.location.
+    resolveFetch({ ok: true, status: 200, text: async () => "{}", json: async () => ({ user_deleted: true }) });
+  });
+
+  it("shows an error message when the server rejects the delete", async () => {
+    global.fetch = jest.fn(async () => ({ ok: false, status: 400, text: async () => "nope" })) as unknown as typeof fetch;
+    render(<SettingsPage />);
+    fireEvent.click(screen.getByRole("button", { name: /delete account/i }));
+    fireEvent.change(screen.getByPlaceholderText("DELETE"), { target: { value: "DELETE" } });
+    fireEvent.click(screen.getByRole("button", { name: /delete my account/i }));
+
+    // The error paragraph renders as "Failed: nope" in a single <p>.
+    // Match by the full string rather than splitting between Failed/nope
+    // since text-matching by sub-substring of a single text node only
+    // matches once.
+    await waitFor(() => {
+      expect(screen.getByText(/Failed:\s*nope/)).toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/app/(app)/settings/page.tsx
+++ b/web/src/app/(app)/settings/page.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useState } from "react";
+import { useAuth } from "../../components/AuthProvider";
+
+export default function SettingsPage() {
+  const { user } = useAuth();
+
+  // Auth provider gates the (app) layout above us — by the time this
+  // renders we always have a user. The narrow check just keeps the
+  // type system happy.
+  if (!user) return null;
+
+  return (
+    <div className="space-y-12">
+      <header>
+        <h1 className="text-2xl font-bold tracking-tight mb-1">Settings</h1>
+        <p className="text-sm text-muted">
+          Account profile, data export, and account deletion.
+        </p>
+      </header>
+
+      <ProfileSection user={user} />
+      <ExportSection />
+      <DangerZone />
+    </div>
+  );
+}
+
+function ProfileSection({
+  user,
+}: {
+  user: { id: string; email: string; name: string; created_at: string };
+}) {
+  return (
+    <section>
+      <h2 className="text-lg font-semibold mb-4">Profile</h2>
+      <dl className="grid grid-cols-[140px_1fr] gap-y-3 gap-x-6 text-sm">
+        <dt className="text-muted">Name</dt>
+        <dd>{user.name || "—"}</dd>
+        <dt className="text-muted">Email</dt>
+        <dd>{user.email}</dd>
+        <dt className="text-muted">User ID</dt>
+        <dd className="font-mono text-xs">{user.id}</dd>
+        <dt className="text-muted">Member since</dt>
+        <dd>{formatDate(user.created_at)}</dd>
+      </dl>
+    </section>
+  );
+}
+
+function ExportSection() {
+  // Browser does the heavy lifting: the API sets Content-Disposition:
+  // attachment, so a same-origin GET (cookie auth flows automatically)
+  // triggers a download with the right filename. No client-side blob
+  // juggling needed for large mailboxes.
+  return (
+    <section>
+      <h2 className="text-lg font-semibold mb-2">Your data</h2>
+      <p className="text-sm text-muted mb-4 max-w-2xl">
+        Download a JSON dump of everything we store about you: profile, agents,
+        domains, API key metadata, all messages with bodies, and usage events.
+        Internal identifiers (Google subject, key hashes, session tokens) are
+        excluded. Right of access — GDPR Article 15 / CCPA equivalent.
+      </p>
+      <a
+        href="/api/v1/users/me/export"
+        className="inline-flex items-center gap-2 px-4 py-2 bg-foreground text-background rounded-lg text-sm font-medium hover:opacity-90 transition"
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+          <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+          <polyline points="7 10 12 15 17 10" />
+          <line x1="12" y1="15" x2="12" y2="3" />
+        </svg>
+        Download export
+      </a>
+    </section>
+  );
+}
+
+type DeleteState = "idle" | "deleting" | "error";
+
+function DangerZone() {
+  const [open, setOpen] = useState(false);
+  const [confirmText, setConfirmText] = useState("");
+  const [state, setState] = useState<DeleteState>("idle");
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const ready = confirmText === "DELETE";
+
+  const handleDelete = async () => {
+    if (!ready) return;
+    setState("deleting");
+    setErrorMessage("");
+    try {
+      const res = await fetch("/api/v1/users/me?confirm=DELETE", {
+        method: "DELETE",
+        credentials: "include",
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => `HTTP ${res.status}`);
+        setState("error");
+        setErrorMessage(text.trim());
+        return;
+      }
+      // Session is gone server-side along with the user; bouncing back
+      // to the marketing landing page is the cleanest exit.
+      window.location.href = "/?account_deleted=1";
+    } catch (err) {
+      setState("error");
+      setErrorMessage(err instanceof Error ? err.message : String(err));
+    }
+  };
+
+  return (
+    <section>
+      <h2 className="text-lg font-semibold mb-2 text-red-700 dark:text-red-400">
+        Danger zone
+      </h2>
+      <div className="border border-red-200 dark:border-red-800/40 rounded-lg p-5">
+        <h3 className="text-sm font-medium mb-1">Delete account</h3>
+        <p className="text-sm text-muted mb-4 max-w-2xl">
+          Permanently delete your account along with all your agents, domains,
+          messages, API keys, and sessions, in a single Postgres transaction.
+          <strong className="text-foreground"> This is irreversible.</strong>{" "}
+          Right of deletion — GDPR Article 17 / CCPA &quot;Do Not Sell or Share&quot;.
+        </p>
+        {!open ? (
+          <button
+            onClick={() => setOpen(true)}
+            className="px-4 py-2 border border-red-300 dark:border-red-800 text-red-700 dark:text-red-400 rounded-lg text-sm font-medium hover:bg-red-50 dark:hover:bg-red-950/30 transition"
+          >
+            Delete account…
+          </button>
+        ) : (
+          <div className="space-y-3">
+            <label className="block">
+              <span className="text-sm">
+                Type <code className="font-mono text-xs bg-surface px-1.5 py-0.5 rounded border border-border">DELETE</code> to confirm:
+              </span>
+              <input
+                autoFocus
+                type="text"
+                value={confirmText}
+                onChange={(e) => setConfirmText(e.target.value)}
+                placeholder="DELETE"
+                className="mt-1 w-full max-w-xs border border-border rounded-lg px-3 py-2 text-sm font-mono bg-surface focus:outline-none focus:ring-2 focus:ring-red-500/30 focus:border-red-500 transition"
+              />
+            </label>
+            {state === "error" && (
+              <p className="text-sm text-red-700 dark:text-red-400">
+                Failed: {errorMessage || "unknown error"}
+              </p>
+            )}
+            <div className="flex gap-2">
+              <button
+                onClick={handleDelete}
+                disabled={!ready || state === "deleting"}
+                className="px-4 py-2 bg-red-600 text-white rounded-lg text-sm font-medium hover:bg-red-700 transition disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {state === "deleting" ? "Deleting…" : "Delete my account"}
+              </button>
+              <button
+                onClick={() => {
+                  setOpen(false);
+                  setConfirmText("");
+                  setState("idle");
+                  setErrorMessage("");
+                }}
+                disabled={state === "deleting"}
+                className="px-4 py-2 border border-border rounded-lg text-sm hover:bg-background transition"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function formatDate(iso: string): string {
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    }).format(new Date(iso));
+  } catch {
+    return iso;
+  }
+}

--- a/web/src/app/components/Sidebar.tsx
+++ b/web/src/app/components/Sidebar.tsx
@@ -156,6 +156,22 @@ export function Sidebar() {
 
       {/* Bottom section */}
       <div className="border-t border-border px-3 py-3 space-y-2">
+        {/* Settings link */}
+        <Link
+          href="/settings"
+          className={`flex items-center gap-3 px-3 py-2 rounded-lg text-sm transition ${
+            pathname === "/settings"
+              ? "bg-accent/10 text-accent font-medium"
+              : "text-muted hover:text-foreground hover:bg-background"
+          }`}
+        >
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <circle cx="12" cy="12" r="3" />
+            <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
+          </svg>
+          Settings
+        </Link>
+
         {/* Feedback link */}
         <Link
           href="/feedback"


### PR DESCRIPTION
## Summary

The user-data-rights endpoints we shipped in v0.2.0 (`GET /api/v1/users/me/export`, `DELETE /api/v1/users/me`) were API-only with no dashboard surface — a half-shipped feature. This adds **`/settings`** with three sections:

### Profile
Read-only: name, email, user ID (mono-spaced), member-since date. Sourced from the existing `AuthProvider`, no extra fetch.

### Your data
"Download export" anchor pointing at `/api/v1/users/me/export`. The browser does all the work — the API already sets `Content-Disposition: attachment` with the user's id in the filename, the dashboard's session cookie auths the request, the download streams cleanly without any client-side blob juggling.

### Danger zone
Typed-confirmation flow before the destructive call. User clicks **"Delete account…"** → a confirm input appears → the final delete button stays disabled until they type **`DELETE`** exactly (matches the server's `confirm=DELETE` guardrail). On 200, the page redirects to `/?account_deleted=1` — session is gone server-side along with the user, so dashboard routes will 401 anyway.

### Sidebar
New "Settings" link in the bottom section just above "Send Feedback", gear icon, same styling as the other secondary nav items.

## Tests

7 new tests, all passing locally (129 web tests total):

- Profile renders the right user fields
- Renders nothing if `AuthProvider` hasn't loaded a user yet (defensive)
- Export anchor points at the right URL
- Confirm input is hidden until the user opens the flow
- Final-delete button stays disabled until `DELETE` matches exactly (rejects lowercase, partial, etc.)
- Submitting issues `DELETE /api/v1/users/me?confirm=DELETE` with `credentials: "include"`
- Server-side error message surfaces in the danger-zone box

The redirect path on success is intentionally not asserted — jsdom blocks clean reassignment of `window.location` and the behavior is trivial enough that mocking it cleanly costs more than the assertion is worth.

## Why now

The v0.2.0 tag is already pushed, but the GitHub Release isn't published yet. Landing this before announcing means the release notes can honestly say "delete and export your data right from the dashboard" instead of "delete and export your data via curl." After this merges I'll either:

- Re-cut the v0.2.0 tag onto the new commit (clean, since `:0.2.0` images haven't been pulled by anyone yet), or
- Cut a v0.2.1 immediately after.

Will pick whichever you prefer once the PR is green.

## Test plan

- [ ] CI green
- [ ] After merge: visit `/settings` in the dashboard, see profile + the two action sections
- [ ] Click "Download export" → JSON file downloads, named `e2a-export-<user_id>.json`
- [ ] Open the danger zone, type "DELETE", final button enables
- [ ] Click final button → user is wiped, redirected to landing with `account_deleted=1` query param