### PR TITLE
chore: add .env.example + env_file wiring for local dev OAuth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,60 @@
+# Backend (Go) env vars. Copy to .env and fill in values for local dev.
+#
+# docker-compose passes everything from .env to the e2a service via
+# env_file. cmd/e2a/main.go also calls godotenv.Load() so a binary run
+# directly from this directory will see the same vars.
+#
+# .env is gitignored — do not commit secrets.
+
+# ── Required ────────────────────────────────────────────────────────
+# Postgres connection. The default points at the docker-compose
+# postgres service, which is what `make docker-up` brings up.
+E2A_DATABASE_URL=postgres://e2a:e2a@localhost:5433/e2a?sslmode=disable
+
+# HMAC signing secret for X-E2A-Auth-* headers on every webhook
+# delivery. Production refuses to start with the placeholder below or
+# any value < 32 bytes. Generate with: openssl rand -hex 32
+E2A_HMAC_SECRET=change-me-in-production
+
+# ── Dashboard sign-in (Google OAuth) ────────────────────────────────
+# Required if you want the Next.js dashboard's "Sign in with Google"
+# button to work. The CLI/SDKs use API keys and don't need this.
+#
+# To set up:
+#   1. https://console.cloud.google.com/apis/credentials → Create
+#      OAuth client ID → Application type "Web application"
+#   2. Add authorized redirect URIs:
+#        http://localhost:3000/api/auth/callback   (Next dev / docker compose web)
+#        http://localhost:8080/api/auth/callback   (binary run directly)
+#        https://your-deployment.example.com/api/auth/callback  (prod)
+#   3. Copy the client ID and client secret below
+E2A_GOOGLE_CLIENT_ID=
+E2A_GOOGLE_CLIENT_SECRET=
+
+# OAuth callback URL the backend constructs for Google. Must match one
+# of the authorized redirect URIs in the Google client config above.
+# Defaults to http://localhost:3000/api/auth/callback if unset.
+E2A_OAUTH_REDIRECT_URL=http://localhost:3000/api/auth/callback
+
+# ── Optional ────────────────────────────────────────────────────────
+# Externally visible base URL of the API. Required for HITL magic-link
+# emails to render absolute URLs. Empty disables HITL email notifier.
+E2A_PUBLIC_URL=http://localhost:8080
+
+# Shared mail domain for slug-based agent registration. Empty disables
+# the slug shortcut. agents.localhost is a fine demo value: localhost
+# never resolves externally so no real mail will arrive, but the
+# `e2a agents register <slug>` flow still works against the API.
+E2A_SHARED_DOMAIN=agents.localhost
+
+# Outbound SMTP relay (only needed if you want agents to send mail).
+# Most operators point at SES, Postmark, Mailgun, etc.
+E2A_OUTBOUND_SMTP_HOST=
+E2A_OUTBOUND_SMTP_PORT=587
+E2A_OUTBOUND_SMTP_USERNAME=
+E2A_OUTBOUND_SMTP_PASSWORD=
+E2A_OUTBOUND_SMTP_FROM_DOMAIN=
+
+# Per-message usage tracking. Only useful for hosted deployments doing
+# billing reconciliation; leave false for self-host.
+E2A_USAGE_TRACKING=false

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,6 +29,14 @@ services:
     ports:
       - "2525:2525"
       - "8080:8080"
+    # Load secrets and OAuth credentials from .env if present.
+    # `.env` is gitignored; see .env.example for the full set of vars.
+    # Anything explicitly set under `environment:` below overrides the
+    # .env value, so the database/HMAC defaults stay deterministic for
+    # the demo even if the user edits .env.
+    env_file:
+      - path: .env
+        required: false
     environment:
       E2A_DATABASE_URL: "postgres://e2a:e2a@postgres:5432/e2a?sslmode=disable"
       E2A_HMAC_SECRET: "change-me-in-production"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -113,6 +113,9 @@ func Load(path string) (*Config, error) {
 	if v := os.Getenv("E2A_GOOGLE_CLIENT_SECRET"); v != "" {
 		cfg.OAuth.GoogleClientSecret = v
 	}
+	if v := os.Getenv("E2A_OAUTH_REDIRECT_URL"); v != "" {
+		cfg.OAuth.RedirectURL = v
+	}
 	if v := os.Getenv("E2A_OUTBOUND_SMTP_HOST"); v != "" {
 		cfg.OutboundSMTP.Host = v
 	}


### PR DESCRIPTION
## Summary
- Adds `.env.example` documenting every backend env var with Google OAuth setup steps
- Wires docker-compose to load `.env` via `env_file` (optional; explicit `environment:` block still wins for demo-critical defaults like DB URL, HMAC secret, and shared domain)
- Adds `E2A_OAUTH_REDIRECT_URL` env override in `internal/config/config.go` so the redirect URL can match the dev server's actual port without editing `config.yaml`

## Why
Self-hosters and contributors trying the dashboard's "Sign in with Google" locally currently have no clean place to drop OAuth client credentials — they'd have to edit a tracked file. This sets up the standard `.env` pattern, gitignored, so secrets stay out of the repo.

## Test plan
- [ ] `docker compose up` with no `.env` present — service still starts (env_file marked `required: false`)
- [ ] `docker compose up` with a `.env` containing OAuth creds — sign-in flow works end-to-end
- [ ] Setting `E2A_OAUTH_REDIRECT_URL` overrides the YAML value in `cfg.OAuth.RedirectURL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)