### PR TITLE
fix: auto-seed configured shared_domain row at server startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,25 @@ Copy `config.example.yaml` to `config.yaml` and fill in values, or set the envir
 
 `env: production` in [config.example.yaml](config.example.yaml) enforces TLS for SMTP and HTTPS for webhook URLs. Leave it as `development` for local work.
 
+#### Shared-domain setup
+
+If you set `E2A_SHARED_DOMAIN` (or `shared_domain` in `config.yaml`) so users can register agents with just a slug — `alice@agents.yourcompany.com` — there are two parts to it: DNS you set up once, and a database row the server takes care of for you.
+
+**You do (once, externally):**
+
+1. Pick the subdomain (e.g. `agents.yourcompany.com`).
+2. Add an `MX` record pointing it at the host running the e2a SMTP relay.
+3. Add `A`/`AAAA` records for that host.
+4. Open inbound port 25 (the SMTP listener defaults to `:2525` — either change `smtp.listen_addr` to `:25` or NAT 25→2525).
+5. Provision a TLS cert for the SMTP domain and set `smtp.tls_cert` / `smtp.tls_key`.
+6. Add SPF/DKIM TXT records on the subdomain so outbound mail from your relay isn't rejected by recipient mail servers.
+
+**The server does (automatically, at startup):**
+
+The shared domain needs a row in the `domains` table — it's the FK target for every agent registered against it. The server seeds this row idempotently every time it boots: `INSERT … ON CONFLICT DO NOTHING` against the configured `shared_domain`, with `user_id = NULL` and `verified = true` (system-owned, pre-verified). You don't run a migration, you don't `psql` anything by hand. Change the configured domain later? Restart and the new row appears; the old one stays as a harmless orphan because the API layer reads `cfg.SharedDomain` to decide what's reserved, not the table.
+
+If you leave `shared_domain` empty, slug registration is disabled and every agent must use a custom domain the user verifies — no DNS setup required from you.
+
 ### CLI / SDK user
 
 End-users only need to know the deployment URL — the rest is auto-discovered.

--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -108,6 +108,9 @@ func main() {
 
 	// Services
 	store := identity.NewStore(pool)
+	if err := store.EnsureSharedDomain(ctx, cfg.SharedDomain); err != nil {
+		log.Fatalf("Failed to seed shared domain row: %v", err)
+	}
 	signer := headers.NewSigner(cfg.Signing.HMACSecret)
 	deliverer := webhook.NewDeliverer(cfg.IsProduction())
 	deliveryStore := webhook.NewDeliveryStore(pool)

--- a/internal/identity/shared_domain_test.go
+++ b/internal/identity/shared_domain_test.go
@@ -1,0 +1,95 @@
+package identity_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+)
+
+func TestEnsureSharedDomain_EmptyIsNoop(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	if err := store.EnsureSharedDomain(ctx, ""); err != nil {
+		t.Fatalf("EnsureSharedDomain(\"\"): %v", err)
+	}
+}
+
+func TestEnsureSharedDomain_InsertsSystemRow(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	const dom = "agents.test.example.com"
+	if err := store.EnsureSharedDomain(ctx, dom); err != nil {
+		t.Fatalf("EnsureSharedDomain: %v", err)
+	}
+
+	var userID *string
+	var verified bool
+	err := pool.QueryRow(ctx,
+		`SELECT user_id, verified FROM domains WHERE domain = $1`, dom,
+	).Scan(&userID, &verified)
+	if err != nil {
+		t.Fatalf("query seeded row: %v", err)
+	}
+	if userID != nil {
+		t.Errorf("user_id = %v, want NULL (system-owned)", *userID)
+	}
+	if !verified {
+		t.Error("verified = false, want true")
+	}
+
+	user, err := store.CreateOrGetUser(ctx, "alice@elsewhere.com", "Alice", "google-shared-domain-agent")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	if _, err := store.CreateAgent(ctx, "alice@"+dom, dom, "", "https://example.com/wh", "", user.ID); err != nil {
+		t.Fatalf("CreateAgent on shared domain: %v (FK to domains row should resolve)", err)
+	}
+}
+
+func TestEnsureSharedDomain_Idempotent(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	const dom = "agents.idem.example.com"
+	for i := 0; i < 3; i++ {
+		if err := store.EnsureSharedDomain(ctx, dom); err != nil {
+			t.Fatalf("EnsureSharedDomain attempt %d: %v", i, err)
+		}
+	}
+
+	var n int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM domains WHERE domain = $1`, dom,
+	).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("row count after 3 calls = %d, want 1", n)
+	}
+}
+
+func TestEnsureSharedDomain_NormalizesCase(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	if err := store.EnsureSharedDomain(ctx, "Agents.Mixed.Example.COM"); err != nil {
+		t.Fatalf("EnsureSharedDomain: %v", err)
+	}
+	var n int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM domains WHERE domain = $1`, "agents.mixed.example.com",
+	).Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("expected 1 row at lowercased domain, got %d", n)
+	}
+}

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -161,6 +161,34 @@ func NewStore(pool *pgxpool.Pool) *Store {
 
 // --- Domain CRUD ---
 
+// EnsureSharedDomain inserts a system row for the configured shared
+// mail domain so slug-based agent registration can satisfy the
+// agent_identities.domain → domains.domain foreign key. The row is
+// owned by no user (user_id = NULL) and pre-verified — it represents
+// infrastructure the operator runs, not user-claimed identity.
+//
+// Called once at server startup. Idempotent via ON CONFLICT DO NOTHING,
+// and a no-op when the operator has not configured a shared domain.
+// Without this, any deployment whose shared_domain differs from the
+// hardcoded migration seed (`agents.e2a.dev`) gets an FK violation the
+// first time a user tries to register a slug-based agent.
+func (s *Store) EnsureSharedDomain(ctx context.Context, domain string) error {
+	if domain == "" {
+		return nil
+	}
+	domain = normalizeDomain(domain)
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO domains (domain, user_id, verified, verified_at)
+		 VALUES ($1, NULL, true, now())
+		 ON CONFLICT (domain) DO NOTHING`,
+		domain,
+	)
+	if err != nil {
+		return fmt.Errorf("ensure shared domain %q: %w", domain, err)
+	}
+	return nil
+}
+
 // ClaimOrCreateDomain implements the atomic create/claim logic from the design doc.
 // Creates if new, overwrites user_id if unverified, returns if verified+same
 // user, errors if verified+different user. Callers are responsible for


### PR DESCRIPTION
## Summary
The migration hardcodes a single seed row for \`agents.e2a.dev\` (the hosted deployment's shared domain). Any self-hoster who configures a different \`shared_domain\` hits an FK violation on \`agent_identities.domain → domains.domain\` the first time a user tries to register a slug-based agent — registration fails with an opaque foreign-key error and the operator has no documented fix short of inserting the row manually via psql.

This adds \`Store.EnsureSharedDomain\` and calls it once from \`cmd/e2a/main.go\` after the store is constructed.

- Idempotent \`INSERT … ON CONFLICT DO NOTHING\` with \`user_id=NULL, verified=true\` — system-owned, pre-verified row representing infrastructure the operator runs
- No-op when no shared domain is configured
- Domain string is IDNA-normalized (matches every other domain write) so operator config case doesn't break later lookups

## Why this matters for the OSS launch
Without it, "self-hostable" is technically true but practically false: the very first action a new user takes after standing up the server (registering an agent against the operator's shared mail domain) fails. Production operators are most exposed because they've already done the DNS/MX/SPF setup and expect the registration call to "just work."

## Test plan
- [x] \`TestEnsureSharedDomain_EmptyIsNoop\` — empty config → no row, no error
- [x] \`TestEnsureSharedDomain_InsertsSystemRow\` — fresh insert, then \`CreateAgent\` against the seeded shared domain succeeds (FK resolves)
- [x] \`TestEnsureSharedDomain_Idempotent\` — three calls, exactly one row
- [x] \`TestEnsureSharedDomain_NormalizesCase\` — \`Agents.Mixed.Example.COM\` → row stored as lowercase

🤖 Generated with [Claude Code](https://claude.com/claude-code)