### PR TITLE
docs(readme): add product demo video above the fold

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Authenticated email gateway for AI agents. Receive emails as webhooks or via Web
 - **Human in the loop** — opt-in approval gate that holds outbound mail until a reviewer approves via dashboard, magic-link email, or CLI
 - **CLI + SDKs** — TypeScript and Python SDKs, plus a `e2a` CLI for everyday agent ops
 
+<video src="docs/demo.mp4" controls autoplay muted loop width="800"></video>
+
 ## Use it
 
 You can either use the hosted instance or self-host.


### PR DESCRIPTION
Adds a 80-second silent demo above-the-fold in the README:
- Human emails `support-bot@agents.e2a.dev` from Gmail
- Agent receives the JSON event in real time via WebSocket with SPF/DKIM verdict + HMAC-signed headers
- Agent replies via the API
- Reply lands threaded in the original Gmail conversation

Source recorded with Screen Studio at 4K, transcoded to 1080p H.264 (audio stripped, since it's a silent text-overlay demo): **39MB → 4.6MB** with `+faststart` so it streams progressively. `<video controls autoplay muted loop>` so it plays inline on github.com without a click.

Placed right after the feature bullets and before `## Use it` — the first concrete artifact a skimmer sees, but doesn't push the Quickstart materially down for users who're already sold.

For HN visitors who skim the bullets, this is the magic-moment beat in <60s.