### PR TITLE
docs(readme): host demo video via GitHub user-attachments CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Authenticated email gateway for AI agents. Receive emails as webhooks or via Web
 - **Human in the loop** — opt-in approval gate that holds outbound mail until a reviewer approves via dashboard, magic-link email, or CLI
 - **CLI + SDKs** — TypeScript and Python SDKs, plus a `e2a` CLI for everyday agent ops
 
-<video src="https://github.com/user-attachments/assets/330e0031-999e-4758-b179-160b8af1ea69" controls autoplay muted loop width="800"></video>
+<video src="https://github.com/user-attachments/assets/b55a8f18-6470-44e3-a053-97dfb787228c" controls autoplay muted loop width="800"></video>
 
 ## Use it
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Authenticated email gateway for AI agents. Receive emails as webhooks or via Web
 - **Human in the loop** — opt-in approval gate that holds outbound mail until a reviewer approves via dashboard, magic-link email, or CLI
 - **CLI + SDKs** — TypeScript and Python SDKs, plus a `e2a` CLI for everyday agent ops
 
-<video src="docs/demo.mp4" controls autoplay muted loop width="800"></video>
+<video src="https://github.com/user-attachments/assets/330e0031-999e-4758-b179-160b8af1ea69" controls autoplay muted loop width="800"></video>
 
 ## Use it
 


### PR DESCRIPTION
Previous PR (#41) committed the MP4 to `docs/demo.mp4` and embedded it via a relative path. **The video didn't render** — GitHub's README HTML sanitizer strips `<video src="<relative-path>">` outright. Only `<video>` tags whose `src` resolves to `github.com/user-attachments/...` or a `githubusercontent.com` URL survive sanitization.

Fix:
- Drag-dropped the MP4 into a GitHub comment textbox (the standard way to upload to user-attachments CDN)
- Replaced the README's `src="docs/demo.mp4"` with the CDN URL
- Removed the committed `docs/demo.mp4` since the CDN is now the source of truth (saves 4.6MB in git history)
- Kept the `docs/originals/` gitignore entry — still useful for keeping local source files for future re-cuts

Net change: -4.6MB binary, +1 working video embed.