### PR TITLE
release(cli): 1.3.1 → 1.3.2 — ship login hang fix

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/cli",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "CLI for e2a — email for AI agents",
   "bin": {
     "e2a": "./dist/bin/e2a.js"


### PR DESCRIPTION
Single-line version bump in `cli/package.json` so the orphan-timer fix from #45 reaches users via npm.

## What's in 1.3.2 vs 1.3.1

- [#45](https://github.com/Mnexa-AI/e2a/pull/45) — `fix(cli): clear orphan timeout that hung the terminal after `e2a login`` (the only delta)

## Publishing

After merge, the `Publish CLI` workflow needs to be triggered manually per the project's release process:

```
gh workflow run "Publish CLI" --ref main
```

`@e2a/sdk` dependency is already at `^1.3.1` — caret range, no SDK release coupling.

## Sanity checks

- [x] `npm run build --workspace @e2a/cli` clean
- [x] `npm test --workspace @e2a/cli` — 97/97 tests pass
- [x] login hang manually verified fixed locally