### PR TITLE
examples: add Google ADK cloud-webhook tutorial

### DIFF
--- a/examples/adk-cloud-webhook/.env.example
+++ b/examples/adk-cloud-webhook/.env.example
@@ -1,0 +1,11 @@
+# From e2a.dev — settings → API keys
+E2A_API_KEY=e2a_...
+
+# From e2a.dev — settings → HMAC secret. Used to verify inbound webhooks.
+E2A_HMAC_SECRET=
+
+# From https://aistudio.google.com/apikey
+GOOGLE_API_KEY=
+
+# Use Gemini API (not Vertex AI) for the demo.
+GOOGLE_GENAI_USE_VERTEXAI=FALSE

--- a/examples/adk-cloud-webhook/.gitignore
+++ b/examples/adk-cloud-webhook/.gitignore
@@ -1,0 +1,5 @@
+.env
+.venv/
+__pycache__/
+*.egg-info/
+*.pyc

--- a/examples/adk-cloud-webhook/README.md
+++ b/examples/adk-cloud-webhook/README.md
@@ -1,0 +1,127 @@
+# ADK + e2a: an email inbox for a Google ADK agent
+
+A minimal end-to-end example: a Google [Agent Development Kit](https://adk.dev/)
+agent receives email through an [e2a](https://e2a.dev) cloud-mode webhook,
+runs a turn, and replies — keeping a per-thread conversation memory by
+mapping e2a's `conversation_id` to ADK's `session_id`.
+
+```
+human (Gmail)
+    |
+    v  SMTP
+e2a relay
+    |
+    v  HTTPS POST /webhook (signed)
+this app
+    |
+    +-- verify HMAC
+    +-- look up / create ADK session keyed by conversation_id
+    +-- runner.run_async(...)
+    +-- email.reply(text, conversation_id=...)
+    |
+    v
+e2a relay -> SMTP -> human
+```
+
+## Prerequisites
+
+- Python 3.10+
+- An e2a account with a registered **cloud-mode** agent. Sign up at
+  [e2a.dev](https://e2a.dev), create an agent, set its mode to `cloud`.
+  You'll need its **API key**, the **HMAC secret** for the deployment
+  (settings page), and a public webhook URL (see "Exposing the webhook"
+  below).
+- A Google AI Studio API key for Gemini —
+  [aistudio.google.com/apikey](https://aistudio.google.com/apikey).
+
+## Setup
+
+```bash
+cd examples/adk-cloud-webhook
+python -m venv .venv && source .venv/bin/activate
+pip install -e .
+cp .env.example .env
+# edit .env with your three secrets
+```
+
+## Run the webhook
+
+```bash
+uvicorn webhook:app --host 0.0.0.0 --port 18080 --reload
+```
+
+Health check:
+
+```bash
+curl http://localhost:18080/health
+# {"status":"ok"}
+```
+
+## Exposing the webhook
+
+The webhook needs a public HTTPS URL e2a can POST to. For local
+development, [ngrok](https://ngrok.com/) or
+[cloudflared](https://github.com/cloudflare/cloudflared) work well:
+
+```bash
+ngrok http 18080
+# Forwarding  https://abc123.ngrok.io -> http://localhost:18080
+```
+
+Set that public URL on your agent (replace `<YOUR_AGENT_EMAIL>` and
+`<YOUR_API_KEY>`):
+
+```bash
+curl -X PUT https://e2a.dev/api/v1/agents/<YOUR_AGENT_EMAIL> \
+  -H "Authorization: Bearer <YOUR_API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{"webhook_url":"https://abc123.ngrok.io/webhook"}'
+```
+
+## Try it
+
+Send a plain email from any address to your agent's e2a email. Watch the
+uvicorn logs — you'll see the inbound POST, ADK pick a session, the agent
+generate a reply, and the reply post back to e2a. Reply to the agent's
+message from your inbox and you'll see ADK reuse the same session — the
+agent remembers the prior turn.
+
+## How `conversation_id` keeps memory across turns
+
+Email is stateless at the SMTP layer. e2a re-creates threading by
+propagating an opaque `conversation_id` through each round-trip:
+
+1. **First inbound** has `conversation_id = None` (the human just
+   started a thread). The webhook mints `conv_<random>` and uses it as
+   the ADK `session_id` when creating the session.
+2. The webhook calls `email.reply(text, conversation_id=conv_<random>)`.
+   e2a stamps `X-E2A-Conversation-Id: conv_<random>` on the outbound
+   message and remembers the binding to the message ID.
+3. **Subsequent inbound** (the human replies in their mail client) lands
+   with the same `conversation_id` set — recovered from `In-Reply-To` /
+   `References` lookup. The webhook calls `get_session` with that ID and
+   gets back the existing ADK session, so the agent sees full prior
+   context on the next `runner.run_async` call.
+
+This is the entire trick. The webhook is ~30 lines of business logic;
+ADK does the actual memory work, e2a does the actual email work.
+
+See [webhook.py](webhook.py) for the implementation, including
+[HMAC signature verification](https://github.com/Mnexa-AI/e2a/blob/main/sdks/python/README.md)
+which you should *always* do on a public webhook before trusting any
+field on the parsed payload.
+
+## What this example deliberately doesn't show
+
+- **Persistence.** `InMemorySessionService` loses everything on restart.
+  Production deployments should use `DatabaseSessionService` (Postgres /
+  SQLite) — see [ADK sessions docs](https://adk.dev/sessions/session/).
+- **Tools.** The agent has no tools beyond text generation. Add them to
+  `agent.py` once the email loop works end-to-end.
+- **Attachments.** `email.attachments` is exposed by the SDK but ignored
+  here. ADK's `Content` supports inline data parts if you want to feed
+  attachments to a vision model.
+- **HITL.** The agent replies immediately. If you want human approval
+  before the reply goes out, enable HITL on the agent
+  ([docs](https://github.com/Mnexa-AI/e2a/blob/main/README.md)) and the
+  `email.reply()` call returns 202 with the reply held for review.

--- a/examples/adk-cloud-webhook/README.md
+++ b/examples/adk-cloud-webhook/README.md
@@ -113,8 +113,11 @@ field on the parsed payload.
 
 ## What this example deliberately doesn't show
 
-- **Persistence.** `InMemorySessionService` loses everything on restart.
-  Production deployments should use `DatabaseSessionService` (Postgres /
+- **Persistence + multi-worker safety.** `InMemorySessionService` loses
+  everything on restart. It also lives in *one* Python process — running
+  `uvicorn ... --workers 4` shards sessions per-worker, so the same
+  conversation can land on different workers and lose memory at random.
+  For anything beyond the demo, use `DatabaseSessionService` (Postgres /
   SQLite) — see [ADK sessions docs](https://adk.dev/sessions/session/).
 - **Tools.** The agent has no tools beyond text generation. Add them to
   `agent.py` once the email loop works end-to-end.

--- a/examples/adk-cloud-webhook/agent.py
+++ b/examples/adk-cloud-webhook/agent.py
@@ -1,0 +1,20 @@
+"""ADK agent definition.
+
+Kept deliberately minimal so the focus stays on the e2a integration in
+webhook.py. Swap in your own instruction, tools, or sub-agents as needed.
+"""
+
+from google.adk.agents import LlmAgent
+
+APP_NAME = "e2a-adk-demo"
+
+agent = LlmAgent(
+    name="email_assistant",
+    model="gemini-flash-latest",
+    instruction=(
+        "You are a friendly assistant who replies to emails. "
+        "Be concise — 1-3 short paragraphs. "
+        "Don't include 'Subject:' or quoted-reply blocks; the email "
+        "wrapper handles that. Just write the body."
+    ),
+)

--- a/examples/adk-cloud-webhook/pyproject.toml
+++ b/examples/adk-cloud-webhook/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "adk-cloud-webhook"
+version = "0.1.0"
+description = "Example: a Google ADK agent with an e2a email inbox, delivered via webhook."
+readme = "README.md"
+requires-python = ">=3.10"
+
+dependencies = [
+  # google-adk 2.0 is in pre-release as of writing and may reorganize imports.
+  # Pin to the 1.x line until 2.0 ships and the code is verified against it.
+  "google-adk>=1.31,<2",
+  "e2a>=1.4,<2",
+  "fastapi>=0.115",
+  "uvicorn[standard]>=0.30",
+  "python-dotenv>=1.0",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["agent", "webhook"]
+only-include = ["agent.py", "webhook.py"]

--- a/examples/adk-cloud-webhook/webhook.py
+++ b/examples/adk-cloud-webhook/webhook.py
@@ -1,0 +1,141 @@
+"""FastAPI webhook that turns e2a inbound emails into ADK agent turns.
+
+Pipeline per request:
+
+    POST /webhook (raw e2a payload)
+        |
+        v
+    parse + verify HMAC          <-- reject unsigned/replayed payloads
+        |
+        v
+    map (sender, conversation_id) -> ADK (user_id, session_id)
+        |                               first contact: conv_id is None;
+        |                               we mint one and use it as session_id
+        v
+    Runner.run_async(...)        <-- multi-turn memory via ADK sessions
+        |
+        v
+    email.reply(text, conversation_id=...)  <-- echoes our id back so the
+                                                next inbound matches
+
+The conversation_id <-> session_id binding is what lets ADK accumulate
+context across email turns even though SMTP itself is stateless.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+from dotenv import load_dotenv
+from fastapi import FastAPI, HTTPException, Request, status
+from google.adk.runners import Runner
+from google.adk.sessions import InMemorySessionService
+from google.genai import types
+
+from e2a.v1 import E2AClient
+
+from agent import APP_NAME, agent
+
+load_dotenv()
+
+
+def _require_env(name: str) -> str:
+    val = os.environ.get(name)
+    if not val:
+        raise RuntimeError(
+            f"Missing required env var {name}. "
+            f"Copy .env.example to .env and fill it in."
+        )
+    return val
+
+
+HMAC_SECRET = _require_env("E2A_HMAC_SECRET")
+# E2A_API_KEY is consumed implicitly by E2AClient on construction.
+_require_env("E2A_API_KEY")
+_require_env("GOOGLE_API_KEY")
+
+
+@asynccontextmanager
+async def lifespan(_: FastAPI) -> AsyncIterator[None]:
+    # Lazy-init shared resources once per process.
+    app.state.e2a = E2AClient()
+    app.state.sessions = InMemorySessionService()
+    app.state.runner = Runner(
+        agent=agent, app_name=APP_NAME, session_service=app.state.sessions
+    )
+    yield
+
+
+app = FastAPI(title="ADK + e2a webhook", lifespan=lifespan)
+
+
+@app.get("/health")
+async def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/webhook")
+async def webhook(request: Request) -> dict[str, str]:
+    body = await request.body()
+    email = request.app.state.e2a.parse(body)
+
+    if not email.verify_signature(HMAC_SECRET):
+        # Reject unverified payloads. Anyone can reach a public webhook URL;
+        # the HMAC is what proves the payload came from your e2a relay.
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="bad signature")
+
+    # First contact has no conversation_id — mint one so this thread has an
+    # ID we can echo back on every reply. The same id becomes the ADK
+    # session_id, keying multi-turn memory.
+    conversation_id = email.conversation_id or f"conv_{uuid.uuid4().hex[:12]}"
+
+    # user_id scopes a session to a particular human counterpart. Different
+    # senders get isolated session histories even on the same agent.
+    user_id = email.sender
+
+    sessions = request.app.state.sessions
+    session = await sessions.get_session(
+        app_name=APP_NAME, user_id=user_id, session_id=conversation_id
+    )
+    if session is None:
+        session = await sessions.create_session(
+            app_name=APP_NAME, user_id=user_id, session_id=conversation_id
+        )
+
+    msg = types.Content(
+        role="user",
+        parts=[types.Part(text=_format_email_for_agent(email))],
+    )
+
+    runner: Runner = request.app.state.runner
+    reply_text = ""
+    async for event in runner.run_async(
+        user_id=user_id, session_id=conversation_id, new_message=msg
+    ):
+        if event.is_final_response() and event.content and event.content.parts:
+            reply_text = event.content.parts[0].text or ""
+
+    if not reply_text:
+        # Agent produced no response (rare — usually means a tool call without
+        # a final text turn). Don't reply with an empty email.
+        return {"status": "no_reply", "conversation_id": conversation_id}
+
+    email.reply(reply_text, conversation_id=conversation_id)
+    return {"status": "replied", "conversation_id": conversation_id}
+
+
+def _format_email_for_agent(email) -> str:
+    """Flatten the email into a single text block for the agent.
+
+    A more sophisticated agent could be given the headers as a separate
+    structured tool call. For a tutorial, plain prose is enough.
+    """
+    return (
+        f"From: {email.sender}\n"
+        f"Subject: {email.subject}\n"
+        f"\n"
+        f"{email.text_body}"
+    )

--- a/examples/adk-cloud-webhook/webhook.py
+++ b/examples/adk-cloud-webhook/webhook.py
@@ -24,6 +24,7 @@ context across email turns even though SMTP itself is stateless.
 
 from __future__ import annotations
 
+import logging
 import os
 import uuid
 from contextlib import asynccontextmanager
@@ -35,11 +36,13 @@ from google.adk.runners import Runner
 from google.adk.sessions import InMemorySessionService
 from google.genai import types
 
-from e2a.v1 import E2AClient
+from e2a.v1 import E2AClient, InboundEmail
 
 from agent import APP_NAME, agent
 
 load_dotenv()
+log = logging.getLogger("adk-webhook")
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
 
 
 def _require_env(name: str) -> str:
@@ -80,7 +83,7 @@ async def health() -> dict[str, str]:
 @app.post("/webhook")
 async def webhook(request: Request) -> dict[str, str]:
     body = await request.body()
-    email = request.app.state.e2a.parse(body)
+    email: InboundEmail = request.app.state.e2a.parse(body)
 
     if not email.verify_signature(HMAC_SECRET):
         # Reject unverified payloads. Anyone can reach a public webhook URL;
@@ -94,6 +97,12 @@ async def webhook(request: Request) -> dict[str, str]:
 
     # user_id scopes a session to a particular human counterpart. Different
     # senders get isolated session histories even on the same agent.
+    #
+    # Safety note: email.sender is only trustworthy *because* the HMAC check
+    # above passed — that signature binds to the sender claim e2a verified
+    # via SPF/DKIM. If you ever move this assignment above the verify call,
+    # you re-introduce a session-poisoning vector (any unauthenticated POST
+    # could claim to be any sender and read/write that user's session).
     user_id = email.sender
 
     sessions = request.app.state.sessions
@@ -120,14 +129,23 @@ async def webhook(request: Request) -> dict[str, str]:
 
     if not reply_text:
         # Agent produced no response (rare — usually means a tool call without
-        # a final text turn). Don't reply with an empty email.
+        # a final text turn). Don't reply with an empty email; log so the
+        # operator can investigate why the run finished without text.
+        log.warning(
+            "agent produced no reply text user=%s conv=%s msg=%s",
+            user_id, conversation_id, email.message_id,
+        )
         return {"status": "no_reply", "conversation_id": conversation_id}
 
+    log.info(
+        "replying user=%s conv=%s msg=%s reply_chars=%d",
+        user_id, conversation_id, email.message_id, len(reply_text),
+    )
     email.reply(reply_text, conversation_id=conversation_id)
     return {"status": "replied", "conversation_id": conversation_id}
 
 
-def _format_email_for_agent(email) -> str:
+def _format_email_for_agent(email: InboundEmail) -> str:
     """Flatten the email into a single text block for the agent.
 
     A more sophisticated agent could be given the headers as a separate

--- a/web/src/app/blog/email-agent-with-google-adk/page.mdx
+++ b/web/src/app/blog/email-agent-with-google-adk/page.mdx
@@ -1,0 +1,192 @@
+import { getPost } from "../posts";
+
+export const post = getPost("email-agent-with-google-adk");
+
+export const metadata = {
+  title: { absolute: `${post.title} — e2a` },
+  description: post.description,
+  alternates: { canonical: `/blog/${post.slug}` },
+  openGraph: {
+    title: post.title,
+    description: post.description,
+    url: `https://e2a.dev/blog/${post.slug}`,
+    type: "article",
+    publishedTime: new Date(post.date + "T00:00:00Z").toISOString(),
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: post.title,
+    description: post.description,
+  },
+};
+
+<div style={{ fontSize: 11, color: "#A89A8A", fontFamily: "'IBM Plex Mono', monospace", marginBottom: 6 }}>
+  {new Date(post.date + "T00:00:00Z").toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric", timeZone: "UTC" })} · {post.readingMinutes} min read
+</div>
+
+# Give your Google ADK agent an email inbox (with conversation memory)
+
+Google's [Agent Development Kit](https://adk.dev/) gives you a clean abstraction for multi-turn agents: define an `LlmAgent`, wire up a `Runner`, hand the runner a `session_id`, and ADK keeps the conversation history straight across turns. Sessions are exactly the right primitive for stateful chat.
+
+The problem is that "stateful chat" usually means a UI you built, a WebSocket you maintain, or a Slack bot whose installation is its own project. None of that reaches the people who actually want to talk to your agent — customers replying from Gmail, vendors using Outlook, anyone who already has an inbox.
+
+This post walks through giving an ADK agent a real email address, with HMAC-verified inbound delivery and multi-turn memory that survives across email replies. The full runnable example lives at [examples/adk-cloud-webhook](https://github.com/Mnexa-AI/e2a/tree/main/examples/adk-cloud-webhook) in the e2a repo; this post is the narrated tour.
+
+## What you'll have when you're done
+
+1. A real email address like `assistant@agents.e2a.dev` that anyone can write to.
+2. An ADK agent (Gemini Flash by default — swap in any model) that receives each email as an agent turn.
+3. **Multi-turn memory across email replies.** When a human replies to your agent's reply, ADK loads the same session — the agent remembers the prior turns without you doing any thread-tracking yourself.
+
+The whole webhook is ~30 lines of business logic. ADK does the memory work; e2a does the email work.
+
+## Prerequisites
+
+- Python 3.10+
+- A free e2a account at [e2a.dev](https://e2a.dev) — you'll register a **cloud-mode** agent (one that receives mail via HTTPS webhook, not WebSocket).
+- A Google AI Studio API key — [aistudio.google.com/apikey](https://aistudio.google.com/apikey).
+- [ngrok](https://ngrok.com/) or [cloudflared](https://github.com/cloudflare/cloudflared) for exposing the local webhook during development.
+
+## Step 1: Clone the example and install
+
+```bash
+git clone https://github.com/Mnexa-AI/e2a.git
+cd e2a/examples/adk-cloud-webhook
+python -m venv .venv && source .venv/bin/activate
+pip install -e .
+cp .env.example .env
+```
+
+The `pyproject.toml` pulls in `google-adk>=1.31`, `e2a>=1.4`, and FastAPI. Edit `.env` with your three secrets when prompted.
+
+## Step 2: Register a cloud-mode agent
+
+In the e2a dashboard, register an agent with `agent_mode: cloud`. You'll get an email address (e.g. `assistant@agents.e2a.dev`) and an API key. The webhook URL field can stay empty for now — we'll fill it in once we have a public URL.
+
+## Step 3: Run the webhook locally
+
+```bash
+uvicorn webhook:app --host 0.0.0.0 --port 18080 --reload
+```
+
+Health check:
+
+```bash
+curl http://localhost:18080/health
+# {"status":"ok"}
+```
+
+## Step 4: Expose it with ngrok
+
+```bash
+ngrok http 18080
+# Forwarding  https://abc123.ngrok.io -> http://localhost:18080
+```
+
+Set that public URL on your agent (replace `<EMAIL>` and `<API_KEY>`; the `@` in `EMAIL` must be URL-encoded as `%40`):
+
+```bash
+curl -X PUT "https://e2a.dev/api/v1/agents/assistant%40agents.e2a.dev" \
+  -H "Authorization: Bearer <API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{"webhook_url":"https://abc123.ngrok.io/webhook"}'
+```
+
+## Step 5: Send the first email
+
+From any inbox, send a plain message to your agent's address:
+
+```
+Subject: Quick question about ADK
+Body:    What's the difference between InMemorySessionService and DatabaseSessionService?
+```
+
+In the uvicorn logs you'll see something like:
+
+```
+INFO replying user=you@gmail.com conv=conv_a1b2c3d4e5f6 msg=msg_xyz reply_chars=412
+```
+
+A few seconds later, the agent's reply lands in your inbox — verified sender, threaded properly.
+
+## Step 6: Reply, and watch ADK remember
+
+Hit reply in your mail client and ask a follow-up that depends on the prior turn — *"what about persistence guarantees?"*, without restating the context. The webhook receives the inbound:
+
+```
+INFO replying user=you@gmail.com conv=conv_a1b2c3d4e5f6 msg=msg_followup reply_chars=389
+```
+
+Note the `conv=` value — **same as the first turn**. ADK loaded the existing session and the agent has full memory of what was just discussed. No thread parsing on your part, no `In-Reply-To` lookup, no hand-rolled state.
+
+## How `conversation_id` keeps memory across turns
+
+This is the only non-obvious part of the whole setup. Email is stateless at the SMTP layer — every message is independent. e2a re-creates threading by carrying an opaque `conversation_id` through each round-trip:
+
+```
+First inbound (conversation_id = None — human just started a thread)
+        │
+        v
+Webhook mints conv_<random>, uses it as ADK session_id
+        │
+        v
+session = sessions.get_session(...)        # returns None
+session = sessions.create_session(..., session_id=conv_<random>)
+        │
+        v
+runner.run_async(...)                       # ADK records turn 1
+        │
+        v
+email.reply(text, conversation_id=conv_<random>)
+        │       e2a stamps X-E2A-Conversation-Id on the outbound
+        v
+... human replies in their mail client ...
+        │
+        v
+Inbound has conversation_id = conv_<random>      ← recovered from
+        │                                          In-Reply-To / References
+        v
+session = sessions.get_session(...)        # returns the existing session
+        │
+        v
+runner.run_async(...)                       # ADK has full prior context
+```
+
+The webhook does the binding in two lines:
+
+```python
+conversation_id = email.conversation_id or f"conv_{uuid.uuid4().hex[:12]}"
+
+session = await sessions.get_session(app_name=APP_NAME, user_id=user_id, session_id=conversation_id)
+if session is None:
+    session = await sessions.create_session(app_name=APP_NAME, user_id=user_id, session_id=conversation_id)
+```
+
+That's it. Any agent framework that lets you supply your own session ID can be wired the same way; ADK's `(app_name, user_id, session_id)` tuple is the easiest case because the IDs are opaque strings and the `get_session` / `create_session` APIs are straightforward.
+
+## Always verify the HMAC
+
+The first thing the webhook does after parsing the payload is:
+
+```python
+if not email.verify_signature(HMAC_SECRET):
+    raise HTTPException(status_code=401, detail="bad signature")
+```
+
+This isn't optional. Anyone on the internet can POST to your public webhook URL — the HMAC signature is what proves the payload came from your e2a relay and not from someone trying to inject a fake email into your agent's session. If you skip the verify, every claim on the payload (sender, recipient, message id, body) becomes attacker-controlled. The SDK's `verify_signature` checks the HMAC against the body hash and rejects replays older than 5 minutes, all in one call.
+
+## What this example deliberately doesn't show
+
+- **Persistence + multi-worker safety.** `InMemorySessionService` loses everything on restart. It also lives in *one* Python process — running `uvicorn ... --workers 4` shards sessions per-worker. For anything beyond the demo, use `DatabaseSessionService` (Postgres / SQLite) — see [ADK sessions docs](https://adk.dev/sessions/session/).
+- **Tools.** The agent has no tools — just text generation. Add them in `agent.py` once the email loop works.
+- **Attachments.** `email.attachments` is exposed by the SDK but ignored here. ADK's `Content` supports inline data parts if you want to feed PDFs or images to a vision model.
+- **Human-in-the-loop.** The agent replies immediately. If you want approval before each outbound, [enable HITL on the agent](/blog/human-in-the-loop-for-agent-email) and the `email.reply()` call returns 202 with the message held for review.
+
+## What to build next
+
+- **Swap to your own domain.** [Register a custom domain](/docs) so mail arrives at `assistant@yourcompany.com` instead of the shared `agents.e2a.dev`.
+- **Add tools to the ADK agent.** Calendar lookup, CRM queries, document retrieval — anything the agent should be able to do mid-thread. ADK's tool calling will weave them into the same session memory.
+- **Move sessions to Postgres.** ADK's `DatabaseSessionService` is a one-line swap and survives restarts + multi-worker deployments.
+- **Run the whole thing in production.** The webhook is a regular FastAPI app; deploy to Cloud Run, Fly, Railway, or anywhere else that runs HTTP. Use a secrets manager for the three env vars and you're done.
+
+The full runnable example, with smoke-testable signature verification and the type hints to make it easy to swap in your own agent, is at [examples/adk-cloud-webhook](https://github.com/Mnexa-AI/e2a/tree/main/examples/adk-cloud-webhook). PRs welcome — particularly for `DatabaseSessionService` recipes, attachment handling, and other framework integrations.

--- a/web/src/app/blog/posts.ts
+++ b/web/src/app/blog/posts.ts
@@ -41,6 +41,15 @@ export const posts: Post[] = [
     author: "e2a",
     readingMinutes: 6,
   },
+  {
+    slug: "email-agent-with-google-adk",
+    title: "Give your Google ADK agent an email inbox (with conversation memory)",
+    description:
+      "Wire a Google Agent Development Kit agent to a real email address. HMAC-verified webhooks, multi-turn memory across email replies via the conversation_id ↔ ADK session_id binding, ~30 lines of business logic. Full runnable example included.",
+    date: "2026-04-27",
+    author: "e2a",
+    readingMinutes: 7,
+  },
 ];
 
 export function getPost(slug: string): Post | undefined {


### PR DESCRIPTION
## Summary

First entry under a new top-level [examples/](examples/) directory: a runnable, end-to-end demo that gives a Google [Agent Development Kit](https://adk.dev/) agent an email inbox via an e2a cloud-mode webhook, with multi-turn memory via the `conversation_id` ↔ ADK `session_id` mapping.

## What it shows

- **HMAC signature verification** — the webhook rejects any payload that doesn't verify against the configured \`E2A_HMAC_SECRET\` (always do this on a public endpoint).
- **First-contact conversation minting** — when an inbound has no \`conversation_id\` (the human just started the thread), the webhook mints \`conv_<random>\` and uses it as ADK's \`session_id\`.
- **Multi-turn memory** — when the human replies, the same \`conversation_id\` arrives, the same ADK session is resumed via \`get_session(...)\`, and the agent sees full prior context.
- **The whole webhook is ~30 lines of business logic** — ADK does the actual memory work, e2a does the actual email work.

## Files

- [pyproject.toml](examples/adk-cloud-webhook/pyproject.toml) — pins \`google-adk>=1.31,<2\`, \`e2a>=1.4,<2\`, FastAPI, uvicorn
- [agent.py](examples/adk-cloud-webhook/agent.py) — minimal ADK \`LlmAgent\` (Gemini Flash + 4-line instruction)
- [webhook.py](examples/adk-cloud-webhook/webhook.py) — FastAPI app with \`/health\` and \`/webhook\`
- [README.md](examples/adk-cloud-webhook/README.md) — setup, run, ngrok, "what this deliberately doesn't show"
- [.env.example](examples/adk-cloud-webhook/.env.example) — three env vars

## What's verified

- \`pip install -e .\` resolves against \`google-adk 1.31.1\` and \`e2a 1.4.0\`.
- Imports clean; FastAPI registers \`/health\` and \`/webhook\`.
- Smoke test with a mocked ADK runner confirmed: unsigned → 401, wrong-secret → 401, signed first-contact → 200 mints a fresh \`conv_*\`, signed follow-up reuses the same id (i.e. session resumption is wired correctly). Smoke test was not committed — it's a one-shot verification artifact.

## What's not verified

- Real Gemini call. The smoke test stubs the runner. The first user to clone this with a real \`GOOGLE_API_KEY\` will exercise the agent loop end-to-end.

Follow-up: a blog post at \`/blog/email-agent-with-google-adk\` will narrate the same code and link back to this example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)