### PR TITLE
ts-sdk: env-var fallbacks (1.5.0) — make E2A_API_KEY + E2A_AGENT_EMAIL actually work

### DIFF
--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -13,7 +13,7 @@ npm install @e2a/sdk
 ### Webhook (cloud agents)
 
 ```typescript
-import { E2AClient } from "e2a";
+import { E2AClient } from "@e2a/sdk";
 
 const client = new E2AClient(); // uses E2A_API_KEY env var
 
@@ -28,7 +28,7 @@ app.post("/webhook", async (req, res) => {
 ### Polling
 
 ```typescript
-import { E2AClient } from "e2a";
+import { E2AClient } from "@e2a/sdk";
 
 const client = new E2AClient({
   apiKey: "e2a_...",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/sdk",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "TypeScript SDK for e2a — email for AI agents",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/sdks/typescript/src/v1/api.ts
+++ b/sdks/typescript/src/v1/api.ts
@@ -3,12 +3,27 @@ import type { components } from "./generated/types.js";
 type Schemas = components["schemas"];
 
 export interface E2AApiOptions {
-  /** API key (required). */
-  apiKey: string;
+  /**
+   * API key. Falls back to the `E2A_API_KEY` environment variable when
+   * omitted. Throws at construction if neither is set.
+   */
+  apiKey?: string;
   /** Base URL. Defaults to "https://e2a.dev". */
   baseUrl?: string;
   /** Request timeout in ms. Defaults to 30 000. */
   timeout?: number;
+}
+
+/**
+ * Read an env var if `process.env` is reachable (Node), else "".
+ * Exported so the high-level client can share the same browser-safe
+ * lookup for `E2A_AGENT_EMAIL`.
+ */
+export function envVar(name: string): string {
+  if (typeof process !== "undefined" && process.env && process.env[name]) {
+    return process.env[name] as string;
+  }
+  return "";
 }
 
 /**
@@ -22,9 +37,14 @@ export class E2AApi {
   readonly apiKey: string;
   private readonly timeout: number;
 
-  constructor(opts: E2AApiOptions) {
-    if (!opts.apiKey) throw new Error("apiKey is required");
-    this.apiKey = opts.apiKey;
+  constructor(opts: E2AApiOptions = {}) {
+    const apiKey = opts.apiKey || envVar("E2A_API_KEY");
+    if (!apiKey) {
+      throw new Error(
+        "apiKey is required. Pass it to E2AApi() or set E2A_API_KEY in the environment.",
+      );
+    }
+    this.apiKey = apiKey;
     this.baseUrl = (opts.baseUrl ?? "https://e2a.dev").replace(/\/+$/, "");
     this.timeout = opts.timeout ?? 30_000;
   }

--- a/sdks/typescript/src/v1/client.ts
+++ b/sdks/typescript/src/v1/client.ts
@@ -1,5 +1,5 @@
 import type { components } from "./generated/types.js";
-import { E2AApi, E2AApiError } from "./api.js";
+import { E2AApi, E2AApiError, envVar } from "./api.js";
 import type { E2AApiOptions } from "./api.js";
 import { InboundEmail } from "./inbound-email.js";
 import type { WebhookPayload } from "./inbound-email.js";
@@ -8,7 +8,10 @@ type Schemas = components["schemas"];
 type MessagePayload = Schemas["MessageDetail"] | WebhookPayload;
 
 export interface E2AClientOptions extends E2AApiOptions {
-  /** Default agent email for message/WS operations. */
+  /**
+   * Default agent email for message/WS operations. Falls back to the
+   * `E2A_AGENT_EMAIL` environment variable when omitted.
+   */
   agentEmail?: string;
 }
 
@@ -21,9 +24,9 @@ export class E2AClient {
   readonly api: E2AApi;
   readonly agentEmail: string;
 
-  constructor(opts: E2AClientOptions) {
+  constructor(opts: E2AClientOptions = {}) {
     this.api = new E2AApi(opts);
-    this.agentEmail = opts.agentEmail ?? "";
+    this.agentEmail = opts.agentEmail || envVar("E2A_AGENT_EMAIL");
   }
 
   private requireEmail(override?: string): string {

--- a/sdks/typescript/test/v1/api.test.ts
+++ b/sdks/typescript/test/v1/api.test.ts
@@ -24,8 +24,30 @@ describe("E2AApi", () => {
     globalThis.fetch = originalFetch;
   });
 
-  it("requires apiKey", () => {
-    expect(() => new E2AApi({ apiKey: "" })).toThrow("apiKey is required");
+  it("requires apiKey via arg or env", () => {
+    const prev = process.env.E2A_API_KEY;
+    delete process.env.E2A_API_KEY;
+    try {
+      expect(() => new E2AApi({ apiKey: "" })).toThrow(/apiKey is required/);
+      expect(() => new E2AApi({})).toThrow(/E2A_API_KEY/);
+    } finally {
+      if (prev !== undefined) process.env.E2A_API_KEY = prev;
+    }
+  });
+
+  it("falls back to E2A_API_KEY env var when apiKey not passed", () => {
+    const prev = process.env.E2A_API_KEY;
+    process.env.E2A_API_KEY = "e2a_from_env";
+    try {
+      const a = new E2AApi({});
+      expect(a.apiKey).toBe("e2a_from_env");
+      // Explicit arg still wins.
+      const b = new E2AApi({ apiKey: "e2a_explicit" });
+      expect(b.apiKey).toBe("e2a_explicit");
+    } finally {
+      if (prev === undefined) delete process.env.E2A_API_KEY;
+      else process.env.E2A_API_KEY = prev;
+    }
   });
 
   it("strips trailing slash from baseUrl", () => {

--- a/sdks/typescript/test/v1/client.test.ts
+++ b/sdks/typescript/test/v1/client.test.ts
@@ -31,9 +31,34 @@ describe("E2AClient", () => {
   });
 
   it("requires agentEmail at point of use", async () => {
-    const c = new E2AClient({ apiKey: "e2a_test", baseUrl: BASE });
-    globalThis.fetch = mockFetch(200, { messages: [] });
-    await expect(c.listMessages()).rejects.toThrow("agentEmail is required");
+    const prev = process.env.E2A_AGENT_EMAIL;
+    delete process.env.E2A_AGENT_EMAIL;
+    try {
+      const c = new E2AClient({ apiKey: "e2a_test", baseUrl: BASE });
+      globalThis.fetch = mockFetch(200, { messages: [] });
+      await expect(c.listMessages()).rejects.toThrow("agentEmail is required");
+    } finally {
+      if (prev !== undefined) process.env.E2A_AGENT_EMAIL = prev;
+    }
+  });
+
+  it("falls back to E2A_AGENT_EMAIL env var when agentEmail not passed", () => {
+    const prev = process.env.E2A_AGENT_EMAIL;
+    process.env.E2A_AGENT_EMAIL = "env-default@test.dev";
+    try {
+      const c = new E2AClient({ apiKey: "e2a_test", baseUrl: BASE });
+      expect(c.agentEmail).toBe("env-default@test.dev");
+      // Explicit arg still wins.
+      const c2 = new E2AClient({
+        apiKey: "e2a_test",
+        baseUrl: BASE,
+        agentEmail: "explicit@test.dev",
+      });
+      expect(c2.agentEmail).toBe("explicit@test.dev");
+    } finally {
+      if (prev === undefined) delete process.env.E2A_AGENT_EMAIL;
+      else process.env.E2A_AGENT_EMAIL = prev;
+    }
   });
 
   it("exposes the raw api", () => {


### PR DESCRIPTION
## Summary

The TS SDK's README has promised since v1 that \`E2AApi\` falls back to \`E2A_API_KEY\` and \`E2AClient\` falls back to \`E2A_AGENT_EMAIL\`. Neither was actually implemented — the code required explicit args and the README was aspirational. This PR makes the behavior match the docs (and matches what the Python SDK has done all along).

| Class | Before | After |
|---|---|---|
| \`E2AApi\` | Threw \`apiKey is required\` if not passed | Falls back to \`E2A_API_KEY\` env, throws clearer error if neither set |
| \`E2AClient\` | \`agentEmail = opts.agentEmail ?? \"\"\` | Falls back to \`E2A_AGENT_EMAIL\` env when not passed |

Pure addition. Passing args explicitly still wins. Browser-safe (\`typeof process\` guard).

## Bonus README fix

The README's import statements said \`from \"e2a\"\` — published package is \`@e2a/sdk\`. Fixed both occurrences.

## Why minor (1.5.0)

Additive new feature; semver minor. No existing call site breaks — the only behavioral change is that previously-throwing constructors now succeed when env vars are present.

## Test plan

- [x] \`npm run build --workspace @e2a/sdk\` clean
- [x] \`npm test --workspace @e2a/sdk\` — 55/55 pass (added 2 new env-fallback cases that save/restore \`process.env\` to avoid cross-test leakage)
- [ ] After merge: tag \`ts-sdk-v1.5.0\` and verify \`@e2a/sdk@1.5.0\` lands on npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)