### PR TITLE
python-sdk: listen() yields lightweight WSNotifications (1.6.0)

### DIFF
--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -259,22 +259,40 @@ from e2a.v1 import AsyncE2AClient
 
 async def main():
     async with AsyncE2AClient(api_key="e2a_...") as client:
-        async for email in client.listen("my-bot@agents.e2a.dev"):
-            print(f"From: {email.sender}, Subject: {email.subject}")
+        async for notif in client.listen("my-bot@agents.e2a.dev"):
+            # The notification is lightweight metadata only — no body, no REST call.
+            print(f"From: {notif.from_}, Subject: {notif.subject}")
+
+            # Fetch the full email when you actually want it.
+            email = await client.get_message(notif.message_id)
             await email.reply("Got it!")
 
 asyncio.run(main())
 ```
 
-`listen()` connects to e2a's WebSocket endpoint, receives lightweight
-notifications, fetches the full message via REST, and yields
-`AsyncInboundEmail` objects. It reconnects automatically with exponential
-backoff (1s, 2s, 4s, ... up to 30s).
+`listen()` yields `WSNotification` objects — the lightweight metadata
+the server pushes (`message_id`, `from_`, `recipient`, `subject`,
+`received_at`, `conversation_id`). It does **not** auto-fetch the body:
+that's the caller's call. This matches the server design (small WS
+frames, explicit REST fetch) and lets callers skip messages without a
+network round-trip.
 
-The WebSocket protocol is notification-only (server-to-client). The client
+Reconnects automatically with exponential backoff (1s, 2s, 4s, ... up
+to 30s by default). Protocol is server-to-client only — the client
 never sends application frames.
 
-**Parameters:**
+**`WSNotification` fields:**
+
+| Field | Type | Notes |
+|---|---|---|
+| `message_id` | `str` | Pass to `client.get_message(...)` to fetch the body |
+| `from_` | `str` | Sender. Trailing underscore: `from` is a Python keyword |
+| `recipient` | `str` | Per-delivery target (your agent's address) |
+| `subject` | `str` |  |
+| `received_at` | `str` | RFC 3339 timestamp |
+| `conversation_id` | `str \| None` | Threading; `None` for first contact |
+
+**`listen()` parameters:**
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
@@ -362,7 +380,7 @@ High-level sync client. `api_key` falls back to `E2A_API_KEY` env var.
 
 Same as `E2AClient` — all I/O methods are `async`. `parse()` is sync (no I/O needed).
 
-- `client.listen(agent_email=None, reconnect=True, max_backoff=30.0)` → `AsyncIterator[AsyncInboundEmail]` (requires `e2a[ws]`)
+- `client.listen(agent_email=None, reconnect=True, max_backoff=30.0)` → `AsyncIterator[WSNotification]` (requires `e2a[ws]`). Yields lightweight notifications; call `await client.get_message(notif.message_id)` to fetch the body.
 - `client.api` → `AsyncE2AApi` (raw typed async access)
 
 ### Models

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "e2a"
-version = "1.5.0"
+version = "1.6.0"
 description = "Python SDK for the e2a protocol — email-to-agent authentication"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdks/python/src/e2a/__init__.py
+++ b/sdks/python/src/e2a/__init__.py
@@ -18,6 +18,7 @@ from e2a.v1 import (
     MessageList,
     MessageSummary,
     SendResult,
+    WSNotification,
     fetch_info,
     fetch_info_async,
 )
@@ -35,6 +36,7 @@ __all__ = [
     "MessageList",
     "MessageSummary",
     "SendResult",
+    "WSNotification",
     "fetch_info",
     "fetch_info_async",
 ]

--- a/sdks/python/src/e2a/v1/__init__.py
+++ b/sdks/python/src/e2a/v1/__init__.py
@@ -5,6 +5,7 @@ from e2a.v1.generated import *  # noqa: F401,F403
 from e2a.v1.api import E2AApi, E2AApiError, fetch_info  # noqa: F401
 from e2a.v1.async_client import AsyncE2AApi, AsyncE2AClient  # noqa: F401
 from e2a.v1.async_client import fetch_info as fetch_info_async  # noqa: F401
+from e2a.v1.websocket import WSNotification  # noqa: F401
 from e2a.v1.client import E2AClient  # noqa: F401
 from e2a.v1.handler import (  # noqa: F401
     AsyncInboundEmail,
@@ -36,4 +37,6 @@ __all__ = [
     # Discovery (mirror of TS E2AApi.fetchInfo)
     "fetch_info",
     "fetch_info_async",
+    # WebSocket
+    "WSNotification",
 ]

--- a/sdks/python/src/e2a/v1/async_client.py
+++ b/sdks/python/src/e2a/v1/async_client.py
@@ -15,6 +15,9 @@ from urllib.parse import quote
 
 import httpx
 
+if TYPE_CHECKING:
+    from e2a.v1.websocket import WSNotification
+
 from e2a.v1.api import E2AApiError, _check_response
 from e2a.v1.generated import (
     Agent,
@@ -537,11 +540,17 @@ class AsyncE2AClient:
         agent_email: Optional[str] = None,
         reconnect: bool = True,
         max_backoff: float = 30.0,
-    ) -> AsyncIterator[AsyncInboundEmail]:
-        """Listen for emails via WebSocket.
+    ) -> "AsyncIterator[WSNotification]":
+        """Listen for inbound mail via WebSocket. Yields lightweight notifications.
 
-        Connects to e2a's WS endpoint and yields ``AsyncInboundEmail``
-        objects. Requires ``pip install e2a[ws]``.
+        Each yielded :class:`WSNotification` carries metadata (message_id,
+        sender, subject, etc.) — no body. Call ``await self.get_message(
+        notif.message_id)`` to fetch the full email when you actually need
+        it. This matches the server's design (small WS frames, explicit REST
+        fetch) and lets callers skip messages without a network round-trip.
+
+        Reconnects with exponential backoff (1s → ``max_backoff``) by default.
+        Requires ``pip install e2a[ws]``.
         """
         from e2a.v1.websocket import listen as _ws_listen
 

--- a/sdks/python/src/e2a/v1/websocket.py
+++ b/sdks/python/src/e2a/v1/websocket.py
@@ -1,8 +1,20 @@
 """Notification-only WebSocket listener for e2a v1.
 
-Connects to ``/api/v1/agents/{email}/ws`` and yields full
-``AsyncInboundEmail`` objects. The protocol is server-to-client only —
-the client never sends application frames.
+Connects to ``/api/v1/agents/{email}/ws`` and yields lightweight
+:class:`WSNotification` objects — one per inbound message. The protocol
+is server-to-client only; the client never sends application frames.
+
+The notification carries metadata (message_id, sender, subject, etc.).
+Callers fetch the full body via REST when they want it::
+
+    async for notif in client.listen():
+        if notif.subject.startswith("URGENT"):
+            email = await client.get_message(notif.message_id)
+            # ... act on the full email
+        # else: drop the notification, no REST round-trip happened
+
+This matches the server's design — the WS frame is intentionally small,
+and the REST fetch (which marks the message read) stays explicit.
 
 Requires ``websockets``::
 
@@ -14,14 +26,46 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, AsyncIterator, Optional
 from urllib.parse import quote, urlencode, urlparse, urlunparse
 
 if TYPE_CHECKING:
     from e2a.v1.async_client import AsyncE2AClient
-    from e2a.v1.handler import AsyncInboundEmail
 
 logger = logging.getLogger("e2a.v1.websocket")
+
+
+@dataclass
+class WSNotification:
+    """Lightweight notification pushed over the WebSocket on new inbound mail.
+
+    Mirrors the wire shape sent by the server. ``from_`` is spelled with a
+    trailing underscore to avoid Python's reserved word, matching the
+    convention used elsewhere in the SDK (e.g. :attr:`MessageDetail.from_`).
+    """
+
+    message_id: str
+    from_: str
+    recipient: str
+    subject: str
+    received_at: str
+    conversation_id: Optional[str] = None
+
+    @classmethod
+    def from_payload(cls, payload: dict) -> "WSNotification":
+        """Build a notification from the raw dict pushed by the server.
+
+        Tolerates older payload shapes that used ``to`` instead of ``recipient``.
+        """
+        return cls(
+            message_id=payload.get("message_id", ""),
+            from_=payload.get("from", ""),
+            recipient=payload.get("recipient") or payload.get("to") or "",
+            subject=payload.get("subject", ""),
+            received_at=payload.get("received_at", ""),
+            conversation_id=payload.get("conversation_id"),
+        )
 
 
 def _build_ws_url(base_url: str, agent_email: str, api_key: str) -> str:
@@ -38,13 +82,15 @@ async def listen(
     agent_email: Optional[str] = None,
     reconnect: bool = True,
     max_backoff: float = 30.0,
-) -> AsyncIterator[AsyncInboundEmail]:
-    """Connect to e2a's v1 WebSocket and yield AsyncInboundEmail objects.
+) -> AsyncIterator[WSNotification]:
+    """Connect to e2a's v1 WebSocket and yield :class:`WSNotification` objects.
 
-    On each notification (lightweight metadata), fetches the full message
-    via REST (which marks it as read) and yields it.
+    Each notification is the lightweight metadata frame the server pushes —
+    no body, no REST round-trip. Call ``await client.get_message(notif.message_id)``
+    when you actually want the full email.
 
-    No ACK frames are sent — the protocol is server-to-client only.
+    Reconnects with exponential backoff (1s → ``max_backoff``) by default.
+    The protocol is server-to-client only; no ACK frames are sent.
     """
     email = agent_email or client.agent_email
     if not email:
@@ -65,8 +111,8 @@ async def listen(
 
     while True:
         try:
-            async for msg in _connect_and_stream(client, ws_url, email):
-                yield msg
+            async for notif in _connect_and_stream(ws_url, email):
+                yield notif
                 backoff = 1.0  # Reset on successful message
         except Exception as exc:
             logger.warning("WebSocket disconnected: %s", exc)
@@ -80,13 +126,13 @@ async def listen(
 
 
 async def _connect_and_stream(
-    client: AsyncE2AClient,
     ws_url: str,
     agent_email: str,
-) -> AsyncIterator[AsyncInboundEmail]:
-    """Connect once and yield messages until disconnect.
+) -> AsyncIterator[WSNotification]:
+    """Connect once and yield notifications until disconnect.
 
-    Does NOT send any frames (no ACK). The REST fetch marks messages read.
+    Does NOT send any frames (no ACK). Does NOT fetch the full message —
+    that's the caller's call.
     """
     import websockets
 
@@ -95,16 +141,11 @@ async def _connect_and_stream(
 
         async for raw in ws:
             try:
-                notification = json.loads(raw)
-                message_id = notification.get("message_id")
-                if not message_id:
+                payload = json.loads(raw)
+                if not payload.get("message_id"):
                     logger.warning("WS notification missing message_id: %s", raw)
                     continue
-
-                # Fetch full message via REST (marks it as read)
-                email = await client.get_message(message_id, agent_email=agent_email)
-                yield email
-
+                yield WSNotification.from_payload(payload)
             except Exception:
                 logger.exception("Error processing WS notification")
                 continue

--- a/sdks/python/tests/test_v1_websocket.py
+++ b/sdks/python/tests/test_v1_websocket.py
@@ -1,4 +1,9 @@
-"""Tests for e2a.v1.websocket — WS URL building, notification streaming, no ACKs."""
+"""Tests for e2a.v1.websocket — WS URL building, notification streaming, no ACKs.
+
+The listener is intentionally lightweight: it yields :class:`WSNotification`
+metadata only, never fetches the full message via REST. Callers do that
+explicitly when they want the body.
+"""
 
 import json
 import sys
@@ -6,7 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from e2a.v1.websocket import _build_ws_url
+from e2a.v1.websocket import WSNotification, _build_ws_url
 
 
 # ── _build_ws_url ────────────────────────────────────────────────
@@ -32,6 +37,39 @@ def test_build_ws_url_uses_v1_path():
     assert "/api/v1/agents/" in url
     # Must NOT use legacy /api/agents/ path
     assert "/api/agents/" not in url.replace("/api/v1/agents/", "")
+
+
+# ── WSNotification.from_payload ──────────────────────────────────
+
+
+def test_ws_notification_from_payload():
+    n = WSNotification.from_payload({
+        "message_id": "msg_1",
+        "from": "alice@example.com",
+        "recipient": "bot@agents.e2a.dev",
+        "subject": "Hi",
+        "received_at": "2026-04-27T10:00:00Z",
+        "conversation_id": "conv_xyz",
+    })
+    assert n.message_id == "msg_1"
+    assert n.from_ == "alice@example.com"
+    assert n.recipient == "bot@agents.e2a.dev"
+    assert n.subject == "Hi"
+    assert n.received_at == "2026-04-27T10:00:00Z"
+    assert n.conversation_id == "conv_xyz"
+
+
+def test_ws_notification_from_payload_legacy_to_field():
+    """Older payloads used `to` instead of `recipient` — tolerate it."""
+    n = WSNotification.from_payload({
+        "message_id": "msg_legacy",
+        "from": "alice@example.com",
+        "to": "bot@agents.e2a.dev",
+        "subject": "",
+        "received_at": "",
+    })
+    assert n.recipient == "bot@agents.e2a.dev"
+    assert n.conversation_id is None
 
 
 # ── _connect_and_stream ──────────────────────────────────────────
@@ -67,26 +105,52 @@ def _patch_websockets_connect(fake_ws):
 
 
 @pytest.mark.anyio
-async def test_connect_and_stream_fetches_message():
-    """On WS notification, should fetch full message via client.get_message()."""
+async def test_connect_and_stream_yields_notifications_no_fetch():
+    """Lightweight by design: yield WSNotification, never call get_message()."""
     from e2a.v1.websocket import _connect_and_stream
 
-    fake_email = MagicMock()
-    fake_email.message_id = "msg_123"
-
-    mock_client = AsyncMock()
-    mock_client.get_message = AsyncMock(return_value=fake_email)
-
-    notification = json.dumps({"message_id": "msg_123", "from": "alice@example.com"})
-    fake_ws = FakeWebSocket([notification])
+    payload = json.dumps({
+        "message_id": "msg_123",
+        "from": "alice@example.com",
+        "recipient": "bot@agents.e2a.dev",
+        "subject": "Hi",
+        "received_at": "2026-04-27T10:00:00Z",
+        "conversation_id": "conv_xyz",
+    })
+    fake_ws = FakeWebSocket([payload])
 
     with _patch_websockets_connect(fake_ws):
-        messages = []
-        async for msg in _connect_and_stream(mock_client, "wss://e2a.dev/ws", "bot@agents.e2a.dev"):
-            messages.append(msg)
+        results = []
+        async for notif in _connect_and_stream("wss://e2a.dev/ws", "bot@agents.e2a.dev"):
+            results.append(notif)
 
-    assert len(messages) == 1
-    mock_client.get_message.assert_called_once_with("msg_123", agent_email="bot@agents.e2a.dev")
+    assert len(results) == 1
+    n = results[0]
+    assert isinstance(n, WSNotification)
+    assert n.message_id == "msg_123"
+    assert n.from_ == "alice@example.com"
+    assert n.recipient == "bot@agents.e2a.dev"
+    assert n.subject == "Hi"
+    assert n.conversation_id == "conv_xyz"
+
+
+@pytest.mark.anyio
+async def test_connect_and_stream_tolerates_legacy_to_field():
+    """Older payloads used `to: string` instead of `recipient`."""
+    from e2a.v1.websocket import _connect_and_stream
+
+    payload = json.dumps({
+        "message_id": "msg_legacy",
+        "from": "alice@example.com",
+        "to": "bot@agents.e2a.dev",
+        "subject": "Hi",
+        "received_at": "2026-04-27T10:00:00Z",
+    })
+    fake_ws = FakeWebSocket([payload])
+
+    with _patch_websockets_connect(fake_ws):
+        async for notif in _connect_and_stream("wss://e2a.dev/ws", "bot@agents.e2a.dev"):
+            assert notif.recipient == "bot@agents.e2a.dev"
 
 
 @pytest.mark.anyio
@@ -94,18 +158,13 @@ async def test_connect_and_stream_no_ack_sent():
     """The WS client must NEVER send any frames (no ACK)."""
     from e2a.v1.websocket import _connect_and_stream
 
-    fake_email = MagicMock()
-    mock_client = AsyncMock()
-    mock_client.get_message = AsyncMock(return_value=fake_email)
-
-    notification = json.dumps({"message_id": "msg_123"})
-    fake_ws = FakeWebSocket([notification])
+    payload = json.dumps({"message_id": "msg_123", "from": "a@b.c", "recipient": "bot@agents.e2a.dev", "subject": "", "received_at": ""})
+    fake_ws = FakeWebSocket([payload])
 
     with _patch_websockets_connect(fake_ws):
-        async for _ in _connect_and_stream(mock_client, "wss://e2a.dev/ws", "bot@agents.e2a.dev"):
+        async for _ in _connect_and_stream("wss://e2a.dev/ws", "bot@agents.e2a.dev"):
             pass
 
-    # Assert send was never called — no ACK frames
     fake_ws.send.assert_not_called()
 
 
@@ -114,23 +173,19 @@ async def test_connect_and_stream_skips_malformed():
     """Notifications without message_id should be skipped, not crash."""
     from e2a.v1.websocket import _connect_and_stream
 
-    fake_email = MagicMock()
-    mock_client = AsyncMock()
-    mock_client.get_message = AsyncMock(return_value=fake_email)
-
     messages_in = [
-        json.dumps({"from": "alice@example.com"}),  # no message_id
-        json.dumps({"message_id": "msg_456", "from": "bob@example.com"}),
+        json.dumps({"from": "alice@example.com"}),  # no message_id — drop
+        json.dumps({"message_id": "msg_456", "from": "bob@example.com", "recipient": "bot@agents.e2a.dev", "subject": "", "received_at": ""}),
     ]
     fake_ws = FakeWebSocket(messages_in)
 
     with _patch_websockets_connect(fake_ws):
         results = []
-        async for msg in _connect_and_stream(mock_client, "wss://e2a.dev/ws", "bot@agents.e2a.dev"):
-            results.append(msg)
+        async for notif in _connect_and_stream("wss://e2a.dev/ws", "bot@agents.e2a.dev"):
+            results.append(notif)
 
     assert len(results) == 1
-    mock_client.get_message.assert_called_once_with("msg_456", agent_email="bot@agents.e2a.dev")
+    assert results[0].message_id == "msg_456"
 
 
 # ── listen() ─────────────────────────────────────────────────────
@@ -168,13 +223,18 @@ async def test_listen_no_reconnect_exits():
     """With reconnect=False, listen() should exit after first disconnect."""
     from e2a.v1.websocket import listen
 
-    fake_email = MagicMock()
+    fake_notif = WSNotification(
+        message_id="msg_1",
+        from_="alice@example.com",
+        recipient="bot@agents.e2a.dev",
+        subject="Hi",
+        received_at="2026-04-27T10:00:00Z",
+    )
     mock_client = MagicMock()
     mock_client.agent_email = "bot@agents.e2a.dev"
     mock_client.api = MagicMock()
     mock_client.api.base_url = "https://e2a.dev"
     mock_client.api.api_key = "k"
-    mock_client.get_message = AsyncMock(return_value=fake_email)
 
     call_count = 0
 
@@ -182,16 +242,18 @@ async def test_listen_no_reconnect_exits():
         nonlocal call_count
         call_count += 1
         if call_count == 1:
-            yield fake_email
+            yield fake_notif
             return
-        yield fake_email  # should never reach here
+        yield fake_notif  # should never reach here
 
     mock_ws = MagicMock()
     with patch("e2a.v1.websocket._connect_and_stream", side_effect=fake_connect_and_stream), \
          patch.dict(sys.modules, {"websockets": mock_ws}):
         results = []
-        async for msg in listen(mock_client, reconnect=False):
-            results.append(msg)
+        async for notif in listen(mock_client, reconnect=False):
+            results.append(notif)
 
     assert len(results) == 1
     assert call_count == 1
+    # The lightweight contract: client.get_message was never called by listen().
+    assert not hasattr(mock_client.get_message, "called") or not mock_client.get_message.called


### PR DESCRIPTION
## Summary

Aligns Python's WebSocket listener with the server's lightweight-by-design intent — and with TS's existing model. \`listen()\` now yields the new \`WSNotification\` dataclass (metadata only), instead of auto-fetching the full message via REST on every push.

## Why

The server's WS frame is intentionally small: \`message_id\`, \`from\`, \`recipient\`, \`subject\`, \`received_at\`, \`conversation_id\`. Python's prior behavior — silently calling \`get_message()\` on every notification — defeated that:

- Forced a REST round-trip + \"mark as read\" side-effect on every notification, even when the caller wanted to skip the message.
- Couldn't filter by metadata (subject, sender) without paying for the body fetch.
- Hid the protocol from anyone debugging connection issues.

## API

```python
async for notif in client.listen():
    if notif.subject.startswith(\"URGENT\"):
        email = await client.get_message(notif.message_id)
        await email.reply(\"...\")
```

\`WSNotification\` mirrors the wire shape:

| Field | Notes |
|---|---|
| \`message_id\` | Pass to \`get_message(...)\` for the body |
| \`from_\` | Trailing underscore (Python keyword) |
| \`recipient\` | Per-delivery target |
| \`subject\` | |
| \`received_at\` | RFC 3339 |
| \`conversation_id\` | \`None\` for first contact |

\`WSNotification.from_payload(...)\` tolerates legacy \`to: string\` payloads (pre-PR #48), so any cached payloads still parse.

## Breaking

This changes the yielded type from \`AsyncInboundEmail\` to \`WSNotification\`. Per audit discussion with @jiashuoz, no known active consumers (WS extra is opt-in, no support reports). Minor bump (1.5 → 1.6) since pre-2.0 and the surface is small.

## Test plan

- [x] 154/154 pass (was 150; +4 for dataclass + legacy-tolerance + no-REST-fetch contract)
- [x] Old auto-fetch test deleted; new test asserts \`client.get_message\` is **never** called by \`listen()\`
- [ ] After merge: tag \`python-v1.6.0\`, verify \`e2a==1.6.0\` lands on PyPI

Sequel PRs (out of scope here):
- **PR 2 (TS 1.7):** Add \`client.listen()\` AsyncIterable+EventEmitter, fix stale \`WSNotification\` type (\`to: string\` → \`recipient: string\`), exponential backoff in \`WSListener\`.
- **PR 3 (CLI 1.3.4):** Migrate \`cli/src/commands/listen.ts\` to the new \`client.listen()\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)