### PR TITLE
cli: migrate from WSListener to client.listen() (1.3.4)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/cli",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "CLI for e2a — email for AI agents",
   "bin": {
     "e2a": "./dist/bin/e2a.js"
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/Mnexa-AI/e2a/tree/main/cli",
   "bugs": "https://github.com/Mnexa-AI/e2a/issues",
   "dependencies": {
-    "@e2a/sdk": "^1.4.0"
+    "@e2a/sdk": "^1.7.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/cli/src/commands/listen.ts
+++ b/cli/src/commands/listen.ts
@@ -1,4 +1,3 @@
-import { WSListener } from "@e2a/sdk/v1";
 import type { E2AClient, WSNotification } from "@e2a/sdk/v1";
 import { createClient } from "../sdk.js";
 
@@ -23,44 +22,39 @@ export async function listen(opts: ListenOptions): Promise<void> {
 
   process.stderr.write(`Listening for emails to ${agentEmail}...\n`);
 
-  const listener = new WSListener({
-    apiKey: client.api.apiKey,
-    agentEmail,
-    baseUrl: client.api.baseUrl,
-    reconnect: true,
-  });
+  // client.listen() returns a WSStream — both AsyncIterable<WSNotification>
+  // and EventEmitter. We use both: events for connection lifecycle, the
+  // for-await loop for the happy path.
+  const stream = client.listen({ agentEmail });
 
-  listener.on("open", () => {
+  stream.on("open", () => {
     process.stderr.write("Connected.\n");
   });
 
-  listener.on("close", (code: number, reason: string) => {
+  stream.on("close", (code: number, reason: string) => {
     process.stderr.write(`WS closed: code=${code} reason="${reason}"\n`);
   });
 
-  listener.on("error", (err: Error) => {
+  stream.on("error", (err: Error) => {
     process.stderr.write(`Connection error: ${err.message}\n`);
   });
 
-  listener.on("notification", async (notification: WSNotification) => {
+  process.on("SIGINT", () => {
+    stream.close();
+    process.stderr.write("\nDisconnecting...\n");
+    process.exit(0);
+  });
+
+  // Iterate notifications. handleNotification swallows its own errors so
+  // a single bad message doesn't tear down the loop.
+  for await (const notification of stream) {
     try {
       await handleNotification(client, agentEmail, notification, opts);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       process.stderr.write(`Error handling message: ${message}\n`);
     }
-  });
-
-  process.on("SIGINT", () => {
-    listener.close();
-    process.stderr.write("\nDisconnecting...\n");
-    process.exit(0);
-  });
-
-  listener.connect();
-
-  // Keep process alive; exits via SIGINT
-  await new Promise(() => {});
+  }
 }
 
 export async function handleNotification(


### PR DESCRIPTION
## Summary

Switches \`e2a listen\` from the older callback-based \`WSListener\` pattern to the new \`client.listen()\` async iteration shipped in [@e2a/sdk@1.7.0](https://github.com/Mnexa-AI/e2a/pull/53).

\`\`\`diff
- const listener = new WSListener({ apiKey: client.api.apiKey, agentEmail, baseUrl: client.api.baseUrl });
- listener.on(\"notification\", async (notification) => { ... });
- listener.connect();
- await new Promise(() => {});
+ const stream = client.listen({ agentEmail });
+ for await (const notification of stream) { ... }
\`\`\`

Connection-lifecycle events (\`open\` / \`close\` / \`error\`) still go through the EventEmitter side of the \`WSStream\` returned by \`client.listen()\` — same behavior, picked up via the hybrid AsyncIterable+EventEmitter type. SIGINT handler still calls \`stream.close()\` to terminate cleanly.

## Versioning

- **\`@e2a/cli\` 1.3.3 → 1.3.4** (patch — internal refactor; CLI surface unchanged)
- **\`@e2a/sdk\` dep \`^1.4.0\` → \`^1.7.0\`** — \`client.listen()\` only landed in 1.7.0; the previous floor was technically broad enough to resolve to anything in 1.x and would crash at runtime if someone pinned an older version explicitly.

## Test plan

- [x] \`npm run build --workspace @e2a/cli\` clean
- [x] \`npm test --workspace @e2a/cli\` — 99/99 (no test changes needed; the public seams \`handleNotification\` / \`forwardMessage\` / \`extractResponseText\` kept the same signatures)
- [ ] After merge: \`gh workflow run \"Publish CLI\" --ref main\` and verify \`@e2a/cli@1.3.4\` lands on npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)