### PR TITLE
feat(api): per-user webhook signing secrets with explicit CRUD

### DIFF
--- a/docs/data-handling.md
+++ b/docs/data-handling.md
@@ -16,7 +16,8 @@ For vulnerability reporting and the security model, see [SECURITY.md](../SECURIT
 | API keys | Postgres `api_keys`, **hash only** (SHA over the plaintext) | Until revoked or the user is deleted; plaintext exists only in the create response and is never persisted |
 | OAuth sessions | Postgres `user_sessions` | 30 days; cleanup worker removes expired rows hourly |
 | Usage events / summaries (only when `E2A_USAGE_TRACKING=true`) | Postgres `usage_events`, `usage_summaries` | Indefinite by default — operator can purge or override |
-| HMAC signing secret | Operator's env (`E2A_HMAC_SECRET`); never written to DB | Lifetime of the deployment |
+| Per-user webhook signing secrets | Postgres `webhook_signing_secrets`, **plaintext** (the relay needs the value to sign — hashing them like API keys would break HMAC). Up to 5 per user. | Until the user explicitly deletes the secret or the account. Plaintext is returned exactly once at creation; subsequent reads only see a 12-char prefix. |
+| Deployment-wide HMAC signing secret (legacy fallback) | Operator's env (`E2A_HMAC_SECRET`); never written to DB | Lifetime of the deployment. Used only as a verify-side fallback for HITL approval tokens issued before the per-user-secret migration; new tokens use the user's own secret. |
 
 ## What's logged
 

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -196,6 +196,12 @@ func (a *API) RegisterRoutes(r *mux.Router) {
 	r.HandleFunc("/api/v1/users/me/export", a.handleExportUserData).Methods("GET")
 	r.HandleFunc("/api/v1/users/me", a.handleDeleteUserData).Methods("DELETE")
 
+	// Per-user webhook signing secrets — multi-secret rotation, fully
+	// user-managed (create + delete; no auto-rotation, no TTL).
+	r.HandleFunc("/api/v1/users/me/signing-secrets", a.handleListSigningSecrets).Methods("GET")
+	r.HandleFunc("/api/v1/users/me/signing-secrets", a.handleCreateSigningSecret).Methods("POST")
+	r.HandleFunc("/api/v1/users/me/signing-secrets/{id}", a.handleDeleteSigningSecret).Methods("DELETE")
+
 	// HITL approval endpoints — scoped to the user (not a single agent) so
 	// reviewers can see pending messages across all their agents at once.
 	r.HandleFunc("/api/v1/messages", a.handleListMessages).Methods("GET")

--- a/internal/agent/hitl_magic_api.go
+++ b/internal/agent/hitl_magic_api.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"html"
@@ -133,12 +134,18 @@ func extractFormToken(r *http.Request) string {
 // returns either claims or an (HTTP status, user-visible message) pair.
 // Shared by GET and POST so both paths reject the same inputs the same
 // way.
+//
+// HMAC verification first tries the *owning user's* per-account signing
+// secrets — multiple may be valid during a rotation window. If those
+// fail (or we can't resolve the user), fall back to the deployment-wide
+// signer for legacy tokens issued before per-user secrets shipped.
 func (a *API) verifyMagicToken(token, endpointAction string) (*approvaltoken.Claims, int, string) {
 	if token == "" {
 		return nil, http.StatusBadRequest,
 			"This approval link is missing its token."
 	}
-	claims, err := a.approvalSigner.Verify(token)
+
+	claims, err := a.verifyTokenAnySecret(context.Background(), token)
 	if err != nil {
 		if errors.Is(err, approvaltoken.ErrTokenExpired) {
 			return nil, http.StatusGone,
@@ -151,6 +158,43 @@ func (a *API) verifyMagicToken(token, endpointAction string) (*approvaltoken.Cla
 			"This approval link isn't valid for this action."
 	}
 	return claims, 0, ""
+}
+
+// verifyTokenAnySecret tries the owning user's per-account secrets
+// first, then falls back to the deployment-wide signer. The per-user
+// path is the primary route post-migration; the fallback exists for
+// (a) tokens issued before the migration ran and (b) self-host
+// configurations where the deployment secret is the only one set.
+//
+// The pre-parse of the token's message_id is unverified — its only
+// use is to look up which user's secrets to try. A forged message_id
+// causes us to load the wrong user's secrets, which won't verify the
+// forged signature, so the token is correctly rejected.
+func (a *API) verifyTokenAnySecret(ctx context.Context, token string) (*approvaltoken.Claims, error) {
+	if messageID, err := approvaltoken.PeekMessageID(token); err == nil && messageID != "" {
+		userID, _, ownerErr := a.store.ResolveOutboundOwner(ctx, messageID)
+		if ownerErr == nil && userID != "" {
+			if userSecrets, secretsErr := a.store.GetUserSigningSecrets(ctx, userID); secretsErr == nil && len(userSecrets) > 0 {
+				values := make([]string, len(userSecrets))
+				for i, s := range userSecrets {
+					values[i] = s.Secret
+				}
+				if claims, err := approvaltoken.Verify(values, token); err == nil {
+					return claims, nil
+				} else if errors.Is(err, approvaltoken.ErrTokenExpired) {
+					// Don't attempt deployment-secret fallback if the token
+					// already verified against a user secret but is just
+					// past its TTL — that's an expired-token signal, not
+					// an invalid-secret one.
+					return nil, err
+				}
+			}
+		}
+	}
+	if a.approvalSigner != nil {
+		return a.approvalSigner.Verify(token)
+	}
+	return nil, approvaltoken.ErrInvalidToken
 }
 
 // --- Action implementations (called after POST + token verify) ---

--- a/internal/agent/hitl_magic_api_test.go
+++ b/internal/agent/hitl_magic_api_test.go
@@ -491,3 +491,111 @@ func TestMagicLinkNoCacheAndSecurityHeaders(t *testing.T) {
 		}
 	}
 }
+
+// --- Per-user signing secret verify path + deployment fallback ---
+
+// Tokens signed with the agent owner's per-account secret should
+// verify via the primary path (verifyTokenAnySecret tries user secrets
+// first). The deployment-wide signer is unrelated to this user's
+// secret and should not be consulted.
+func TestMagicApprove_VerifiesWithUserSecret(t *testing.T) {
+	server, store, _, _ := setupMagicLinkAPI(t)
+	a, userID := prepareHITLAgent(t, store, "user-secret-verify")
+	msg := issuePending(t, store, a.ID)
+
+	// Pull the user's most-recent secret (the auto-created default).
+	ctx := context.Background()
+	secrets, err := store.GetUserSigningSecrets(ctx, userID)
+	if err != nil || len(secrets) == 0 {
+		t.Fatalf("get user secrets: %v (n=%d)", err, len(secrets))
+	}
+	tok, err := approvaltoken.Sign(secrets[0].Secret, msg.ID, approvaltoken.ActionApprove, time.Now().Add(1*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp := postForm(t, server.URL+"/api/v1/approve", map[string]string{"t": tok})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("approve via user-secret token: status %d, body=%s", resp.StatusCode, readBody(t, resp))
+	}
+}
+
+// Tokens signed with the deployment-wide signer (the legacy/fallback
+// path) must still verify even though the user has their own secret.
+// This covers tokens issued before the per-user-secrets migration ran.
+func TestMagicApprove_FallsBackToDeploymentSigner(t *testing.T) {
+	server, store, signer, _ := setupMagicLinkAPI(t)
+	a, _ := prepareHITLAgent(t, store, "deployment-fallback")
+	msg := issuePending(t, store, a.ID)
+
+	// Sign with the deployment-wide signer, NOT the user's per-account
+	// secret. verifyTokenAnySecret will try the user's secret (mismatch),
+	// then fall back to the deployment signer (match).
+	tok, err := signer.Sign(msg.ID, approvaltoken.ActionApprove, time.Now().Add(1*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp := postForm(t, server.URL+"/api/v1/approve", map[string]string{"t": tok})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("approve via deployment-signed token: status %d, body=%s", resp.StatusCode, readBody(t, resp))
+	}
+}
+
+// A token signed with neither the user's secret nor the deployment
+// signer must be rejected. Guards against accepting any HMAC-shaped
+// blob just because the message_id resolves.
+func TestMagicApprove_RejectsForeignSecret(t *testing.T) {
+	server, store, _, _ := setupMagicLinkAPI(t)
+	a, _ := prepareHITLAgent(t, store, "foreign-secret-reject")
+	msg := issuePending(t, store, a.ID)
+
+	tok, err := approvaltoken.Sign("attacker-controlled-secret", msg.ID, approvaltoken.ActionApprove, time.Now().Add(1*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp := postForm(t, server.URL+"/api/v1/approve", map[string]string{"t": tok})
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusOK {
+		t.Fatalf("foreign-secret token MUST be rejected, got %d", resp.StatusCode)
+	}
+}
+
+// Tokens signed with an OLD per-user secret should still verify after
+// the user creates a new one — until the old one is deleted. This is
+// the whole point of multi-secret rotation.
+func TestMagicApprove_OldUserSecretStillVerifiesAfterRotation(t *testing.T) {
+	server, store, _, _ := setupMagicLinkAPI(t)
+	a, userID := prepareHITLAgent(t, store, "rotation-window")
+	msg := issuePending(t, store, a.ID)
+
+	ctx := context.Background()
+	// Capture the original secret.
+	beforeRotation, err := store.GetUserSigningSecrets(ctx, userID)
+	if err != nil || len(beforeRotation) == 0 {
+		t.Fatalf("get user secrets: %v", err)
+	}
+	oldSecret := beforeRotation[0].Secret
+
+	// Sign a token with the OLD secret, then rotate (create new).
+	tok, err := approvaltoken.Sign(oldSecret, msg.ID, approvaltoken.ActionApprove, time.Now().Add(1*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := store.CreateSigningSecret(ctx, userID, "new-after-rotation"); err != nil {
+		t.Fatal(err)
+	}
+	// User now has 2 secrets; the old one is at index [1] (most-recent
+	// is the new one). The verifier should still accept the old token
+	// because it tries all of the user's secrets.
+
+	resp := postForm(t, server.URL+"/api/v1/approve", map[string]string{"t": tok})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("old-secret token must verify until that secret is deleted, got %d body=%s",
+			resp.StatusCode, readBody(t, resp))
+	}
+}

--- a/internal/agent/signing_secrets_api.go
+++ b/internal/agent/signing_secrets_api.go
@@ -1,0 +1,183 @@
+package agent
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/gorilla/mux"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+)
+
+
+// CreateSigningSecretRequest is the body of POST /api/v1/users/me/signing-secrets.
+type CreateSigningSecretRequest struct {
+	// Optional human-readable label so users can tell secrets apart in
+	// the dashboard (e.g. "prod", "staging", "rollover-2026-04").
+	Name string `json:"name"`
+}
+
+// SigningSecretSummary is the safe-to-list shape: prefix only, no
+// plaintext. Returned by GET (list) and as a field of the create
+// response so callers can confirm what they just made.
+type SigningSecretSummary struct {
+	ID           string  `json:"id"`
+	Name         string  `json:"name"`
+	SecretPrefix string  `json:"secret_prefix"`
+	CreatedAt    string  `json:"created_at"`
+	LastSignedAt *string `json:"last_signed_at,omitempty"`
+} // @name SigningSecretSummary
+
+// CreateSigningSecretResponse is returned exactly once at creation.
+// The plaintext Secret is the only chance the caller has to capture
+// the value — subsequent reads only see SecretPrefix.
+type CreateSigningSecretResponse struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	Secret       string `json:"secret"`
+	SecretPrefix string `json:"secret_prefix"`
+	CreatedAt    string `json:"created_at"`
+} // @name CreateSigningSecretResponse
+
+// ListSigningSecretsResponse is the GET shape.
+type ListSigningSecretsResponse struct {
+	Secrets []SigningSecretSummary `json:"secrets"`
+} // @name ListSigningSecretsResponse
+
+// handleListSigningSecrets returns the authenticated user's webhook
+// signing secrets — id, name, prefix, created_at, last_signed_at —
+// sorted most-recent-first. The plaintext secret values are NOT in
+// this response; they're only shown at creation.
+//
+// @Summary      List your webhook signing secrets
+// @Description  Returns the authenticated user's webhook signing secrets (metadata + 12-char prefix preview only — full secrets are only shown once at creation). Sorted most-recent-first; the most-recent secret is what the e2a relay uses for new signatures.
+// @Tags         User
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200 {object} ListSigningSecretsResponse
+// @Failure      401 {string} string "Missing or invalid API key"
+// @Router       /api/v1/users/me/signing-secrets [get]
+func (a *API) handleListSigningSecrets(w http.ResponseWriter, r *http.Request) {
+	user, err := a.authenticateUser(r)
+	if err != nil {
+		http.Error(w, "authentication required", http.StatusUnauthorized)
+		return
+	}
+	secrets, err := a.store.ListSigningSecrets(r.Context(), user.ID)
+	if err != nil {
+		http.Error(w, "failed to list signing secrets", http.StatusInternalServerError)
+		return
+	}
+	out := ListSigningSecretsResponse{Secrets: make([]SigningSecretSummary, 0, len(secrets))}
+	for _, s := range secrets {
+		out.Secrets = append(out.Secrets, toSummary(s))
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(out)
+}
+
+// handleCreateSigningSecret mints a new secret, returning the plaintext
+// value exactly once. The user must save it on receipt — subsequent
+// reads only return the prefix.
+//
+// @Summary      Create a new webhook signing secret
+// @Description  Mints a new HMAC signing secret for the authenticated user. The full plaintext `secret` is returned only in this response — save it now, you cannot retrieve it later. Hard cap is 5 active secrets per user; delete one before creating another.
+// @Tags         User
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        body body CreateSigningSecretRequest false "Optional name/label"
+// @Success      201 {object} CreateSigningSecretResponse
+// @Failure      400 {string} string "Bad request (e.g. cap reached)"
+// @Failure      401 {string} string "Missing or invalid API key"
+// @Router       /api/v1/users/me/signing-secrets [post]
+func (a *API) handleCreateSigningSecret(w http.ResponseWriter, r *http.Request) {
+	user, err := a.authenticateUser(r)
+	if err != nil {
+		http.Error(w, "authentication required", http.StatusUnauthorized)
+		return
+	}
+	var req CreateSigningSecretRequest
+	if r.ContentLength > 0 {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, "invalid JSON body", http.StatusBadRequest)
+			return
+		}
+	}
+	req.Name = strings.TrimSpace(req.Name)
+	secret, err := a.store.CreateSigningSecret(r.Context(), user.ID, req.Name)
+	if err != nil {
+		if errors.Is(err, identity.ErrSigningSecretCapReached) {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		http.Error(w, "failed to create signing secret", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	_ = json.NewEncoder(w).Encode(CreateSigningSecretResponse{
+		ID:           secret.ID,
+		Name:         secret.Name,
+		Secret:       secret.Secret,
+		SecretPrefix: secret.SecretPrefix,
+		CreatedAt:    secret.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"),
+	})
+}
+
+// handleDeleteSigningSecret removes a secret by id. Refuses to delete
+// the user's last secret — every user must keep at least one or
+// webhooks become unverifiable.
+//
+// @Summary      Delete a webhook signing secret
+// @Description  Deletes the named secret. Refuses if it would leave the user with zero secrets — create a replacement first. After delete, any in-flight HITL approval magic-link tokens signed under the deleted secret stop verifying.
+// @Tags         User
+// @Produce      json
+// @Security     BearerAuth
+// @Param        id path string true "Signing secret ID (e.g. wsec_abc123...)"
+// @Success      204 {string} string ""
+// @Failure      400 {string} string "Cannot delete last secret"
+// @Failure      401 {string} string "Missing or invalid API key"
+// @Failure      404 {string} string "Secret not found"
+// @Router       /api/v1/users/me/signing-secrets/{id} [delete]
+func (a *API) handleDeleteSigningSecret(w http.ResponseWriter, r *http.Request) {
+	user, err := a.authenticateUser(r)
+	if err != nil {
+		http.Error(w, "authentication required", http.StatusUnauthorized)
+		return
+	}
+	id := mux.Vars(r)["id"]
+	if id == "" {
+		http.Error(w, "missing id", http.StatusBadRequest)
+		return
+	}
+	if err := a.store.DeleteSigningSecret(r.Context(), id, user.ID); err != nil {
+		switch {
+		case errors.Is(err, identity.ErrCannotDeleteLastSigningSecret):
+			http.Error(w, err.Error(), http.StatusBadRequest)
+		case errors.Is(err, identity.ErrSigningSecretNotFound):
+			http.Error(w, err.Error(), http.StatusNotFound)
+		default:
+			http.Error(w, "failed to delete signing secret", http.StatusInternalServerError)
+		}
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func toSummary(s identity.SigningSecret) SigningSecretSummary {
+	out := SigningSecretSummary{
+		ID:           s.ID,
+		Name:         s.Name,
+		SecretPrefix: s.SecretPrefix,
+		CreatedAt:    s.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"),
+	}
+	if s.LastSignedAt != nil {
+		ts := s.LastSignedAt.UTC().Format("2006-01-02T15:04:05Z")
+		out.LastSignedAt = &ts
+	}
+	return out
+}
+

--- a/internal/agent/signing_secrets_api_test.go
+++ b/internal/agent/signing_secrets_api_test.go
@@ -1,0 +1,294 @@
+package agent_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+)
+
+// All tests here exercise the /api/v1/users/me/signing-secrets routes.
+// The setupAPI helper is shared with the other tests in this package.
+
+type signingSecretSummary struct {
+	ID           string  `json:"id"`
+	Name         string  `json:"name"`
+	SecretPrefix string  `json:"secret_prefix"`
+	CreatedAt    string  `json:"created_at"`
+	LastSignedAt *string `json:"last_signed_at,omitempty"`
+}
+
+type listResp struct {
+	Secrets []signingSecretSummary `json:"secrets"`
+}
+
+type createResp struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	Secret       string `json:"secret"`
+	SecretPrefix string `json:"secret_prefix"`
+	CreatedAt    string `json:"created_at"`
+}
+
+func authedReq(t *testing.T, method, url, body, apiKey string) *http.Response {
+	t.Helper()
+	var bodyR io.Reader
+	if body != "" {
+		bodyR = bytes.NewBufferString(body)
+	}
+	req, err := http.NewRequest(method, url, bodyR)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+// --- Auth ---
+
+func TestSigningSecrets_Unauthenticated(t *testing.T) {
+	server, _, _ := setupAPI(t)
+	for _, c := range []struct {
+		method, path string
+	}{
+		{"GET", "/api/v1/users/me/signing-secrets"},
+		{"POST", "/api/v1/users/me/signing-secrets"},
+		{"DELETE", "/api/v1/users/me/signing-secrets/wsec_anything"},
+	} {
+		req, _ := http.NewRequest(c.method, server.URL+c.path, nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusUnauthorized {
+			t.Errorf("%s %s: status = %d, want 401", c.method, c.path, resp.StatusCode)
+		}
+	}
+}
+
+// --- List ---
+
+func TestSigningSecrets_List_OmitsPlaintext(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	apiKey := createTestUser(t, store, "list-omits@example.com")
+
+	resp := authedReq(t, "GET", server.URL+"/api/v1/users/me/signing-secrets", "", apiKey)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	var got listResp
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatal(err)
+	}
+
+	// New users have one auto-created "default" secret.
+	if len(got.Secrets) != 1 {
+		t.Fatalf("expected 1 default secret, got %d", len(got.Secrets))
+	}
+	if got.Secrets[0].SecretPrefix == "" {
+		t.Error("SecretPrefix should be populated")
+	}
+
+	// CRITICAL: the raw response must not contain the field "secret"
+	// or any 64-char-hex-looking thing (the prefix is only 12 chars).
+	if strings.Contains(string(body), `"secret":`) {
+		t.Errorf("list response leaks plaintext secret field:\n%s", body)
+	}
+}
+
+// --- Create ---
+
+func TestSigningSecrets_Create_ReturnsPlaintextOnce(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	apiKey := createTestUser(t, store, "create-once@example.com")
+
+	resp := authedReq(t, "POST", server.URL+"/api/v1/users/me/signing-secrets",
+		`{"name":"prod"}`, apiKey)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 201; body=%s", resp.StatusCode, body)
+	}
+
+	var got createResp
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(got.ID, "wsec_") {
+		t.Errorf("ID = %q, should start with wsec_", got.ID)
+	}
+	if len(got.Secret) != 64 {
+		t.Errorf("Secret length = %d, want 64 hex chars", len(got.Secret))
+	}
+	if got.Name != "prod" {
+		t.Errorf("Name = %q, want prod", got.Name)
+	}
+
+	// Verify the secret really lives in the store and is readable.
+	ctx := context.Background()
+	user, _ := store.GetUserByAPIKey(ctx, apiKey)
+	secrets, _ := store.GetUserSigningSecrets(ctx, user.ID)
+	found := false
+	for _, s := range secrets {
+		if s.ID == got.ID && s.Secret == got.Secret {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("created secret not found in store")
+	}
+
+	// Subsequent list MUST NOT include the plaintext.
+	listR := authedReq(t, "GET", server.URL+"/api/v1/users/me/signing-secrets", "", apiKey)
+	defer listR.Body.Close()
+	listBody, _ := io.ReadAll(listR.Body)
+	if strings.Contains(string(listBody), got.Secret) {
+		t.Errorf("list leaks plaintext after create:\n%s", listBody)
+	}
+}
+
+func TestSigningSecrets_Create_EmptyNameDefaults(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	apiKey := createTestUser(t, store, "create-empty-name@example.com")
+
+	resp := authedReq(t, "POST", server.URL+"/api/v1/users/me/signing-secrets",
+		`{}`, apiKey)
+	defer resp.Body.Close()
+
+	var got createResp
+	json.NewDecoder(resp.Body).Decode(&got)
+	if got.Name != "unnamed" {
+		t.Errorf("Name should default to \"unnamed\", got %q", got.Name)
+	}
+}
+
+func TestSigningSecrets_Create_RejectsCapWithBadRequest(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	apiKey := createTestUser(t, store, "create-cap@example.com")
+
+	// Default already exists → cap headroom is MaxSigningSecretsPerUser-1.
+	for i := 0; i < identity.MaxSigningSecretsPerUser-1; i++ {
+		r := authedReq(t, "POST", server.URL+"/api/v1/users/me/signing-secrets",
+			`{"name":"fill"}`, apiKey)
+		r.Body.Close()
+		if r.StatusCode != http.StatusCreated {
+			t.Fatalf("setup create %d: status %d", i, r.StatusCode)
+		}
+	}
+
+	// One more must fail with 400 + the cap message.
+	r := authedReq(t, "POST", server.URL+"/api/v1/users/me/signing-secrets",
+		`{"name":"over"}`, apiKey)
+	defer r.Body.Close()
+	if r.StatusCode != http.StatusBadRequest {
+		t.Fatalf("over-cap status = %d, want 400", r.StatusCode)
+	}
+	body, _ := io.ReadAll(r.Body)
+	if !strings.Contains(string(body), "at most") {
+		t.Errorf("over-cap body should mention cap, got: %s", body)
+	}
+}
+
+// --- Delete ---
+
+func TestSigningSecrets_Delete_HappyPath(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	apiKey := createTestUser(t, store, "delete-happy@example.com")
+
+	// Need ≥2 secrets so we can delete one.
+	r := authedReq(t, "POST", server.URL+"/api/v1/users/me/signing-secrets",
+		`{"name":"to-delete"}`, apiKey)
+	var created createResp
+	json.NewDecoder(r.Body).Decode(&created)
+	r.Body.Close()
+
+	delR := authedReq(t, "DELETE",
+		server.URL+"/api/v1/users/me/signing-secrets/"+created.ID, "", apiKey)
+	defer delR.Body.Close()
+	if delR.StatusCode != http.StatusNoContent {
+		t.Errorf("delete status = %d, want 204", delR.StatusCode)
+	}
+}
+
+func TestSigningSecrets_Delete_RefusesLast(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	apiKey := createTestUser(t, store, "delete-last@example.com")
+
+	// User starts with one default secret. Find its ID via list.
+	listR := authedReq(t, "GET", server.URL+"/api/v1/users/me/signing-secrets", "", apiKey)
+	var got listResp
+	json.NewDecoder(listR.Body).Decode(&got)
+	listR.Body.Close()
+	if len(got.Secrets) != 1 {
+		t.Fatalf("expected 1 default secret, got %d", len(got.Secrets))
+	}
+
+	delR := authedReq(t, "DELETE",
+		server.URL+"/api/v1/users/me/signing-secrets/"+got.Secrets[0].ID, "", apiKey)
+	defer delR.Body.Close()
+	if delR.StatusCode != http.StatusBadRequest {
+		t.Fatalf("delete-last status = %d, want 400", delR.StatusCode)
+	}
+	body, _ := io.ReadAll(delR.Body)
+	if !strings.Contains(string(body), "cannot delete the last") {
+		t.Errorf("body should explain why: %s", body)
+	}
+}
+
+func TestSigningSecrets_Delete_OtherUsersSecret_Returns404(t *testing.T) {
+	// Cross-user isolation: user B must not be able to delete user A's secret.
+	server, store, _ := setupAPI(t)
+	keyA := createTestUser(t, store, "owner-a@example.com")
+	keyB := createTestUser(t, store, "owner-b@example.com")
+
+	// A creates an extra secret so it has ≥2 (otherwise even A's
+	// delete would fail; we want to test ownership, not the floor).
+	r := authedReq(t, "POST", server.URL+"/api/v1/users/me/signing-secrets",
+		`{"name":"a-secret"}`, keyA)
+	var aCreated createResp
+	json.NewDecoder(r.Body).Decode(&aCreated)
+	r.Body.Close()
+
+	// B tries to delete A's secret by ID.
+	delR := authedReq(t, "DELETE",
+		server.URL+"/api/v1/users/me/signing-secrets/"+aCreated.ID, "", keyB)
+	defer delR.Body.Close()
+	if delR.StatusCode != http.StatusNotFound {
+		t.Errorf("cross-user delete status = %d, want 404", delR.StatusCode)
+	}
+
+	// A's secret should still exist after B's failed attempt.
+	listR := authedReq(t, "GET", server.URL+"/api/v1/users/me/signing-secrets", "", keyA)
+	defer listR.Body.Close()
+	var aList listResp
+	json.NewDecoder(listR.Body).Decode(&aList)
+	found := false
+	for _, s := range aList.Secrets {
+		if s.ID == aCreated.ID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("A's secret was somehow deleted by B")
+	}
+}

--- a/internal/approvaltoken/token.go
+++ b/internal/approvaltoken/token.go
@@ -53,20 +53,11 @@ type Claims struct {
 	ExpiresAt time.Time
 }
 
-// Signer issues and verifies approval tokens against a shared secret.
-type Signer struct {
-	secret []byte
-}
-
-func NewSigner(secret string) *Signer {
-	return &Signer{secret: []byte(secret)}
-}
-
-// Sign returns a URL-safe token. action must be ActionApprove or
-// ActionReject. exp sets the token's expiration — callers should pass a
-// value slightly after the message's approval_expires_at so a click
-// received just before TTL still works.
-func (s *Signer) Sign(messageID, action string, exp time.Time) (string, error) {
+// Sign returns a URL-safe token signed with `secret`. action must be
+// ActionApprove or ActionReject. exp sets the token's expiration —
+// callers should pass a value slightly after the message's
+// approval_expires_at so a click received just before TTL still works.
+func Sign(secret, messageID, action string, exp time.Time) (string, error) {
 	if action != ActionApprove && action != ActionReject {
 		return "", fmt.Errorf("invalid action %q", action)
 	}
@@ -77,19 +68,24 @@ func (s *Signer) Sign(messageID, action string, exp time.Time) (string, error) {
 		return "", fmt.Errorf("messageID contains reserved characters")
 	}
 	payload := fmt.Sprintf("%s|%s|%d", messageID, action, exp.Unix())
-	sig := sign(s.secret, []byte(payload))
+	sig := signMAC([]byte(secret), []byte(payload))
 	return base64.RawURLEncoding.EncodeToString([]byte(payload)) + "." +
 		base64.RawURLEncoding.EncodeToString(sig), nil
 }
 
-// Verify parses, HMAC-checks, and exp-checks a token. Returns the claims
-// on success; returns ErrInvalidToken for malformed / tampered tokens and
-// ErrTokenExpired for valid-but-past-exp tokens.
+// Verify parses, HMAC-checks (against any of `secrets`), and exp-checks
+// a token. Returns the claims on success; ErrInvalidToken for
+// malformed / tampered / wrong-secret tokens; ErrTokenExpired for
+// valid-but-past-exp tokens.
 //
 // Verify does not check that the message still exists or is still
 // pending — that is the handler's job. Verify's only job is "was this
 // string issued by us, and is its exp in the future".
-func (s *Signer) Verify(token string) (*Claims, error) {
+//
+// Accepting multiple secrets supports per-user multi-secret rotation:
+// after a user creates a new secret, in-flight magic-link tokens issued
+// under the old secret continue to verify until that secret is deleted.
+func Verify(secrets []string, token string) (*Claims, error) {
 	parts := strings.SplitN(token, ".", 2)
 	if len(parts) != 2 {
 		return nil, ErrInvalidToken
@@ -103,8 +99,14 @@ func (s *Signer) Verify(token string) (*Claims, error) {
 		return nil, ErrInvalidToken
 	}
 
-	expectedSig := sign(s.secret, payloadBytes)
-	if !hmac.Equal(providedSig, expectedSig) {
+	matched := false
+	for _, secret := range secrets {
+		if hmac.Equal(providedSig, signMAC([]byte(secret), payloadBytes)) {
+			matched = true
+			break
+		}
+	}
+	if !matched {
 		return nil, ErrInvalidToken
 	}
 
@@ -130,8 +132,54 @@ func (s *Signer) Verify(token string) (*Claims, error) {
 	return claims, nil
 }
 
-func sign(secret, payload []byte) []byte {
+// Signer is a thin single-secret wrapper kept for tests and the legacy
+// deployment-wide signing path. New code should call Sign/Verify directly
+// with the user's secrets pulled from the identity store.
+type Signer struct {
+	secret string
+}
+
+func NewSigner(secret string) *Signer {
+	return &Signer{secret: secret}
+}
+
+func (s *Signer) Sign(messageID, action string, exp time.Time) (string, error) {
+	return Sign(s.secret, messageID, action, exp)
+}
+
+func (s *Signer) Verify(token string) (*Claims, error) {
+	return Verify([]string{s.secret}, token)
+}
+
+func signMAC(secret, payload []byte) []byte {
 	mac := hmac.New(sha256.New, secret)
 	mac.Write(payload)
 	return mac.Sum(nil)
+}
+
+// PeekMessageID extracts the message_id from a token *without* verifying
+// the HMAC. Useful when the caller needs to look up the owning user's
+// signing secrets to then call Verify with that secret list.
+//
+// SECURITY: the returned message_id is attacker-controlled until Verify
+// confirms the signature. Use it only as a lookup hint to find which
+// secrets to verify against — never act on the value before Verify
+// returns claims successfully.
+func PeekMessageID(token string) (string, error) {
+	parts := strings.SplitN(token, ".", 2)
+	if len(parts) != 2 {
+		return "", ErrInvalidToken
+	}
+	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[0])
+	if err != nil {
+		return "", ErrInvalidToken
+	}
+	fields := strings.Split(string(payloadBytes), "|")
+	if len(fields) != 3 {
+		return "", ErrInvalidToken
+	}
+	if fields[0] == "" {
+		return "", ErrInvalidToken
+	}
+	return fields[0], nil
 }

--- a/internal/approvaltoken/token_test.go
+++ b/internal/approvaltoken/token_test.go
@@ -152,3 +152,74 @@ func TestVerifyRejectsMalformedTokens(t *testing.T) {
 func encodePayload(s string) string {
 	return base64.RawURLEncoding.EncodeToString([]byte(s))
 }
+
+// --- Multi-secret Verify (rotation support) ---
+
+func TestVerify_MultipleSecrets_AcceptsAny(t *testing.T) {
+	const oldSecret = "old-secret-during-rotation"
+	const newSecret = "new-secret-current"
+	exp := time.Now().Add(1 * time.Hour)
+
+	tok, err := approvaltoken.Sign(oldSecret, "msg_rot", approvaltoken.ActionApprove, exp)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verifier holds both.
+	claims, err := approvaltoken.Verify([]string{newSecret, oldSecret}, tok)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if claims.MessageID != "msg_rot" {
+		t.Errorf("claims.MessageID = %q", claims.MessageID)
+	}
+
+	// Without the matching secret, fails with ErrInvalidToken.
+	_, err = approvaltoken.Verify([]string{newSecret, "wrong"}, tok)
+	if err != approvaltoken.ErrInvalidToken {
+		t.Errorf("expected ErrInvalidToken, got %v", err)
+	}
+}
+
+func TestVerify_EmptySecrets_Fails(t *testing.T) {
+	tok, _ := approvaltoken.Sign("k", "msg_e", approvaltoken.ActionApprove, time.Now().Add(time.Hour))
+	if _, err := approvaltoken.Verify(nil, tok); err != approvaltoken.ErrInvalidToken {
+		t.Errorf("nil secrets should fail with ErrInvalidToken, got %v", err)
+	}
+}
+
+func TestPeekMessageID_DoesNotVerify(t *testing.T) {
+	// Build a token with a real message_id but a *bogus* signature
+	// suffix (just random bytes after the dot). PeekMessageID should
+	// still pull the message_id without checking HMAC.
+	const secret = "sek"
+	tok, _ := approvaltoken.Sign(secret, "msg_peek", approvaltoken.ActionApprove, time.Now().Add(time.Hour))
+	// Truncate the signature to invalidate it but keep the payload.
+	parts := strings.SplitN(tok, ".", 2)
+	if len(parts) != 2 {
+		t.Fatal("token has no '.'")
+	}
+	tampered := parts[0] + "." + "garbage"
+
+	id, err := approvaltoken.PeekMessageID(tampered)
+	if err != nil {
+		t.Fatalf("peek should succeed even with invalid sig: %v", err)
+	}
+	if id != "msg_peek" {
+		t.Errorf("PeekMessageID = %q, want msg_peek", id)
+	}
+
+	// But Verify must reject the tampered signature.
+	if _, err := approvaltoken.Verify([]string{secret}, tampered); err != approvaltoken.ErrInvalidToken {
+		t.Errorf("Verify must reject tampered sig: %v", err)
+	}
+}
+
+func TestPeekMessageID_MalformedToken(t *testing.T) {
+	if _, err := approvaltoken.PeekMessageID(""); err != approvaltoken.ErrInvalidToken {
+		t.Errorf("empty token: %v", err)
+	}
+	if _, err := approvaltoken.PeekMessageID("not-base64.also-not"); err != approvaltoken.ErrInvalidToken {
+		t.Errorf("bad b64: %v", err)
+	}
+}

--- a/internal/headers/signer.go
+++ b/internal/headers/signer.go
@@ -53,15 +53,12 @@ type AuthPayload struct {
 
 type AuthHeaders map[string]string
 
-type Signer struct {
-	secret []byte
-}
-
-func NewSigner(secret string) *Signer {
-	return &Signer{secret: []byte(secret)}
-}
-
-func (s *Signer) Sign(p AuthPayload) AuthHeaders {
+// Sign produces signed auth headers using the given HMAC secret. This
+// is the canonical entry point — callers (the relay, in particular)
+// look up the per-user secret and pass it in directly. The Signer
+// struct below is a thin wrapper kept for tests and the legacy
+// deployment-wide signing path.
+func Sign(secret string, p AuthPayload) AuthHeaders {
 	ts := time.Now().UTC().Format(time.RFC3339)
 	verified := "false"
 	if p.Verified {
@@ -75,7 +72,7 @@ func (s *Signer) Sign(p AuthPayload) AuthHeaders {
 
 	canonical := canonicalString(verified, p.Sender, p.EntityType, p.DomainCheck, delegation, ts, p.MessageID, p.BodyHash)
 
-	mac := hmac.New(sha256.New, s.secret)
+	mac := hmac.New(sha256.New, []byte(secret))
 	mac.Write([]byte(canonical))
 	sig := hex.EncodeToString(mac.Sum(nil))
 
@@ -95,33 +92,21 @@ func (s *Signer) Sign(p AuthPayload) AuthHeaders {
 	return h
 }
 
-// canonicalString assembles the byte string fed to HMAC. Field order
-// must match between Sign and Verify and is part of the wire contract;
-// changing it is a breaking signature change.
-func canonicalString(verified, sender, entityType, domainCheck, delegation, ts, messageID, bodyHash string) string {
-	return strings.Join([]string{
-		verified,
-		sender,
-		entityType,
-		domainCheck,
-		delegation,
-		ts,
-		messageID,
-		bodyHash,
-	}, "\n")
+// Verify checks a header set against any of the provided secrets and
+// the default replay window. Returns true if any secret produces a
+// matching signature. Used by recipients holding multiple active keys
+// during a rotation.
+func Verify(secrets []string, h AuthHeaders) bool {
+	return VerifyWithMaxAge(secrets, h, DefaultMaxAge)
 }
 
-func (s *Signer) Verify(h AuthHeaders) bool {
-	return s.VerifyWithMaxAge(h, DefaultMaxAge)
-}
-
-func (s *Signer) VerifyWithMaxAge(h AuthHeaders, maxAge time.Duration) bool {
+// VerifyWithMaxAge is the configurable-window variant of Verify.
+func VerifyWithMaxAge(secrets []string, h AuthHeaders, maxAge time.Duration) bool {
 	sig := h[HeaderSignature]
 	if sig == "" {
 		return false
 	}
 
-	// Replay protection: reject if timestamp is outside the allowed window
 	ts, err := time.Parse(time.RFC3339, h[HeaderTimestamp])
 	if err != nil {
 		return false
@@ -142,9 +127,52 @@ func (s *Signer) VerifyWithMaxAge(h AuthHeaders, maxAge time.Duration) bool {
 		h[HeaderBodyHash],
 	)
 
-	mac := hmac.New(sha256.New, s.secret)
-	mac.Write([]byte(canonical))
-	expected := hex.EncodeToString(mac.Sum(nil))
+	for _, secret := range secrets {
+		mac := hmac.New(sha256.New, []byte(secret))
+		mac.Write([]byte(canonical))
+		expected := hex.EncodeToString(mac.Sum(nil))
+		if hmac.Equal([]byte(sig), []byte(expected)) {
+			return true
+		}
+	}
+	return false
+}
 
-	return hmac.Equal([]byte(sig), []byte(expected))
+// Signer is a thin wrapper around a single secret. Kept for the legacy
+// deployment-wide signing path used in tests and the contract server;
+// new code should call Sign/Verify directly.
+type Signer struct {
+	secret []byte
+}
+
+func NewSigner(secret string) *Signer {
+	return &Signer{secret: []byte(secret)}
+}
+
+func (s *Signer) Sign(p AuthPayload) AuthHeaders {
+	return Sign(string(s.secret), p)
+}
+
+// canonicalString assembles the byte string fed to HMAC. Field order
+// must match between Sign and Verify and is part of the wire contract;
+// changing it is a breaking signature change.
+func canonicalString(verified, sender, entityType, domainCheck, delegation, ts, messageID, bodyHash string) string {
+	return strings.Join([]string{
+		verified,
+		sender,
+		entityType,
+		domainCheck,
+		delegation,
+		ts,
+		messageID,
+		bodyHash,
+	}, "\n")
+}
+
+func (s *Signer) Verify(h AuthHeaders) bool {
+	return Verify([]string{string(s.secret)}, h)
+}
+
+func (s *Signer) VerifyWithMaxAge(h AuthHeaders, maxAge time.Duration) bool {
+	return VerifyWithMaxAge([]string{string(s.secret)}, h, maxAge)
 }

--- a/internal/headers/signer_test.go
+++ b/internal/headers/signer_test.go
@@ -251,3 +251,71 @@ func TestDifferentSecretRejects(t *testing.T) {
 		t.Error("expected Verify with different secret to return false")
 	}
 }
+
+// --- Multi-secret Verify (rotation support) ---
+
+func TestVerify_AcceptsAnyOfMultipleSecrets(t *testing.T) {
+	const oldSecret = "old-secret-during-rotation"
+	const newSecret = "new-secret-current"
+
+	// Sign with the old secret (simulates a webhook in flight from
+	// before a rotation).
+	signed := Sign(oldSecret, AuthPayload{
+		Verified:    true,
+		Sender:      "alice@example.com",
+		EntityType:  "human",
+		DomainCheck: "spf=pass",
+		MessageID:   "msg_test_rotation",
+		BodyHash:    "deadbeef",
+	})
+
+	// Recipient holds both old + new during the rotation window.
+	if !Verify([]string{newSecret, oldSecret}, signed) {
+		t.Error("verify should succeed when ONE of the secrets matches")
+	}
+
+	// Order shouldn't matter.
+	if !Verify([]string{oldSecret, newSecret}, signed) {
+		t.Error("verify should succeed regardless of secret order")
+	}
+
+	// Without the matching secret, verify fails.
+	if Verify([]string{newSecret, "another-wrong-secret"}, signed) {
+		t.Error("verify should fail when no secret matches")
+	}
+}
+
+func TestVerify_EmptySecretsList_Fails(t *testing.T) {
+	signed := Sign("k", AuthPayload{
+		Sender: "a@b.c", MessageID: "msg_x", BodyHash: "z",
+	})
+	if Verify(nil, signed) {
+		t.Error("verify with no secrets must fail")
+	}
+	if Verify([]string{}, signed) {
+		t.Error("verify with empty secrets slice must fail")
+	}
+}
+
+func TestSign_ParametricMatchesSignerWrapper(t *testing.T) {
+	// The legacy Signer wrapper should produce identical output to the
+	// new free Sign function for any given secret. (Timestamp is the
+	// only non-deterministic field; we check everything else.)
+	const secret = "consistency-test"
+	payload := AuthPayload{
+		Verified:    true,
+		Sender:      "consistency@test.example",
+		EntityType:  "human",
+		DomainCheck: "spf=pass; dkim=pass",
+		MessageID:   "msg_consistency",
+		BodyHash:    "abc123",
+	}
+	free := Sign(secret, payload)
+	wrapped := NewSigner(secret).Sign(payload)
+
+	for _, k := range []string{HeaderVerified, HeaderSender, HeaderEntityType, HeaderDomainCheck, HeaderMessageID, HeaderBodyHash} {
+		if free[k] != wrapped[k] {
+			t.Errorf("%s differs: free=%q wrapped=%q", k, free[k], wrapped[k])
+		}
+	}
+}

--- a/internal/hitlnotify/notifier.go
+++ b/internal/hitlnotify/notifier.go
@@ -84,11 +84,28 @@ func (n *Notifier) NotifyPendingApproval(ctx context.Context, msg *identity.Mess
 	}
 
 	tokenExp := msg.ApprovalExpiresAt.Add(tokenGraceAfterTTL)
-	approveTok, err := n.signer.Sign(msg.ID, approvaltoken.ActionApprove, tokenExp)
+
+	// Sign with the owner's most recently created per-account secret so
+	// the magic link is bound to the user's current key. If lookup fails
+	// or the user has no secrets yet, fall back to the deployment-wide
+	// signer so we still ship the email.
+	var signSecret string
+	if userSecrets, secretsErr := n.store.GetUserSigningSecrets(ctx, owner.ID); secretsErr == nil && len(userSecrets) > 0 {
+		signSecret = userSecrets[0].Secret
+	}
+
+	signFn := func(action string) (string, error) {
+		if signSecret != "" {
+			return approvaltoken.Sign(signSecret, msg.ID, action, tokenExp)
+		}
+		return n.signer.Sign(msg.ID, action, tokenExp)
+	}
+
+	approveTok, err := signFn(approvaltoken.ActionApprove)
 	if err != nil {
 		return fmt.Errorf("notify: sign approve token: %w", err)
 	}
-	rejectTok, err := n.signer.Sign(msg.ID, approvaltoken.ActionReject, tokenExp)
+	rejectTok, err := signFn(approvaltoken.ActionReject)
 	if err != nil {
 		return fmt.Errorf("notify: sign reject token: %w", err)
 	}

--- a/internal/hitlnotify/notifier_test.go
+++ b/internal/hitlnotify/notifier_test.go
@@ -146,7 +146,25 @@ func TestNotifierMagicLinksAreVerifiable(t *testing.T) {
 	approveTok := extractToken(t, data, "/api/v1/approve?t=")
 	rejectTok := extractToken(t, data, "/api/v1/reject?t=")
 
-	approveClaims, err := signer.Verify(approveTok)
+	// Tokens are signed with the agent owner's per-account secret (most
+	// recently created). Pull those from the store, plus include the
+	// deployment secret in the verify list so the test exercises both
+	// the per-user path and the legacy fallback path.
+	userSecrets, err := store.GetUserSigningSecrets(context.Background(), agent.UserID)
+	if err != nil {
+		t.Fatalf("get user signing secrets: %v", err)
+	}
+	verifySecrets := make([]string, len(userSecrets))
+	for i, s := range userSecrets {
+		verifySecrets[i] = s.Secret
+	}
+	// signer holds the deployment-wide secret as a private field; we
+	// can't read it directly, so we use the legacy Verify path which
+	// internally tries that secret. The per-user-first behavior is
+	// exercised by approvaltoken.Verify(userSecrets, ...) below.
+	_ = signer
+
+	approveClaims, err := approvaltoken.Verify(verifySecrets, approveTok)
 	if err != nil {
 		t.Fatalf("approve token verify: %v", err)
 	}
@@ -157,7 +175,7 @@ func TestNotifierMagicLinksAreVerifiable(t *testing.T) {
 		t.Errorf("approve claims.Action = %q", approveClaims.Action)
 	}
 
-	rejectClaims, err := signer.Verify(rejectTok)
+	rejectClaims, err := approvaltoken.Verify(verifySecrets, rejectTok)
 	if err != nil {
 		t.Fatalf("reject token verify: %v", err)
 	}

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -6,10 +6,12 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"golang.org/x/net/idna"
 )
@@ -1553,6 +1555,10 @@ func (s *Store) CreateOrGetUser(ctx context.Context, email, name, googleSub stri
 	if err != nil {
 		return nil, err
 	}
+	// Idempotent: existing users return early in EnsureUserHasSigningSecret.
+	if err := s.EnsureUserHasSigningSecret(ctx, u.ID); err != nil {
+		return nil, fmt.Errorf("ensure signing secret: %w", err)
+	}
 	return u, nil
 }
 
@@ -1565,6 +1571,11 @@ func (s *Store) BootstrapUser(ctx context.Context, email string) (*User, error) 
 		`SELECT id, email, name, google_subject, created_at FROM users WHERE email = $1`, email,
 	).Scan(&u.ID, &u.Email, &u.Name, &u.GoogleSubject, &u.CreatedAt)
 	if err == nil {
+		// Existing user — make sure they still have at least one secret
+		// (covers the case where the migration backfill didn't run yet).
+		if err := s.EnsureUserHasSigningSecret(ctx, u.ID); err != nil {
+			return nil, fmt.Errorf("ensure signing secret: %w", err)
+		}
 		return u, nil
 	}
 	id := generateID()
@@ -1576,6 +1587,9 @@ func (s *Store) BootstrapUser(ctx context.Context, email string) (*User, error) 
 	).Scan(&u.ID, &u.Email, &u.Name, &u.GoogleSubject, &u.CreatedAt)
 	if err != nil {
 		return nil, err
+	}
+	if err := s.EnsureUserHasSigningSecret(ctx, u.ID); err != nil {
+		return nil, fmt.Errorf("ensure signing secret: %w", err)
 	}
 	return u, nil
 }
@@ -1736,4 +1750,252 @@ func generateAPIKey() string {
 	b := make([]byte, 32)
 	rand.Read(b)
 	return "e2a_" + hex.EncodeToString(b)
+}
+
+// --- Webhook signing secrets ---
+
+// MaxSigningSecretsPerUser caps how many active signing secrets a user
+// can hold at once. Two slots covers the standard rotation flow (create
+// new, swap, delete old); a hard cap higher than that mostly catches
+// runaway scripts. Easy to raise later if real users need more.
+const MaxSigningSecretsPerUser = 5
+
+// Sentinel errors so API handlers can map error → HTTP status with
+// errors.Is rather than string-matching the message text. Tests can
+// also assert against them directly.
+var (
+	ErrSigningSecretCapReached     = fmt.Errorf("at most %d signing secrets per user; delete one before creating another", MaxSigningSecretsPerUser)
+	ErrCannotDeleteLastSigningSecret = errors.New("cannot delete the last signing secret; create a new one first")
+	ErrSigningSecretNotFound       = errors.New("signing secret not found or not owned by user")
+)
+
+// SigningSecret is one of a user's HMAC secrets used to sign their
+// agents' inbound webhook payloads and HITL approval magic-link tokens.
+//
+// The plaintext Secret is only set in the response to a fresh
+// CreateSigningSecret call (and what's persisted in the DB row); list
+// operations omit it and surface a SecretPrefix preview instead.
+type SigningSecret struct {
+	ID           string     `json:"id"`
+	UserID       string     `json:"user_id"`
+	Name         string     `json:"name"`
+	Secret       string     `json:"secret,omitempty"`        // only on creation
+	SecretPrefix string     `json:"secret_prefix,omitempty"` // first 12 chars, for list/get
+	CreatedAt    time.Time  `json:"created_at"`
+	LastSignedAt *time.Time `json:"last_signed_at,omitempty"`
+}
+
+// SigningSecretWithValue carries the plaintext Secret alongside the ID
+// so the relay can both sign with the value and (asynchronously)
+// update last_signed_at on the right row. Returned by
+// GetUserSigningSecrets in most-recent-first order.
+type SigningSecretWithValue struct {
+	ID     string
+	Secret string
+}
+
+func generateSigningSecret() string {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		// crypto/rand never returns an error on supported platforms;
+		// if it does, panic — secret generation is a hard prerequisite.
+		panic(fmt.Sprintf("crypto/rand.Read failed: %v", err))
+	}
+	return hex.EncodeToString(b)
+}
+
+// withUserSecretsLock takes a row lock on the user's row for the
+// duration of fn. Serializes concurrent CreateSigningSecret /
+// DeleteSigningSecret / EnsureUserHasSigningSecret calls for the same
+// user so the MaxSigningSecretsPerUser check + insert is race-free, and
+// the "refuse last delete" check + delete is race-free.
+//
+// SELECT ... FOR UPDATE is preferred over pg_advisory_xact_lock here
+// because the lock is scoped to a real row (no name-collision concerns,
+// no interaction with table-level locks like TRUNCATE in test
+// environments). Released when the transaction commits or rolls back.
+func (s *Store) withUserSecretsLock(ctx context.Context, userID string, fn func(tx pgx.Tx) error) error {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+	var lockedID string
+	if err := tx.QueryRow(ctx, `SELECT id FROM users WHERE id = $1 FOR UPDATE`, userID).Scan(&lockedID); err != nil {
+		return fmt.Errorf("lock user %s for signing-secret op: %w", userID, err)
+	}
+	if err := fn(tx); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+// EnsureUserHasSigningSecret guarantees the user has at least one
+// signing secret, creating a "default" one if not. Idempotent.
+// Concurrent callers serialize via the per-user advisory lock so we
+// can't accidentally insert two "default" rows.
+func (s *Store) EnsureUserHasSigningSecret(ctx context.Context, userID string) error {
+	return s.withUserSecretsLock(ctx, userID, func(tx pgx.Tx) error {
+		var count int
+		if err := tx.QueryRow(ctx,
+			`SELECT COUNT(*) FROM webhook_signing_secrets WHERE user_id = $1`, userID,
+		).Scan(&count); err != nil {
+			return err
+		}
+		if count > 0 {
+			return nil
+		}
+		_, err := tx.Exec(ctx,
+			`INSERT INTO webhook_signing_secrets (id, user_id, secret, name, created_at)
+			 VALUES ($1, $2, $3, $4, NOW())`,
+			"wsec_"+generateID(), userID, generateSigningSecret(), "default",
+		)
+		return err
+	})
+}
+
+// CreateSigningSecret mints a new secret for the user. The plaintext
+// secret value is set on the returned struct exactly once; subsequent
+// reads (List/Get) only see the prefix.
+//
+// Returns ErrSigningSecretCapReached if the user is already at
+// MaxSigningSecretsPerUser. Race-free under concurrent callers via the
+// per-user advisory lock.
+//
+// Empty `name` is normalized server-side to "unnamed" so the dashboard
+// always has something to display.
+func (s *Store) CreateSigningSecret(ctx context.Context, userID, name string) (*SigningSecret, error) {
+	if name == "" {
+		name = "unnamed"
+	}
+	id := "wsec_" + generateID()
+	plaintext := generateSigningSecret()
+	now := time.Now()
+
+	err := s.withUserSecretsLock(ctx, userID, func(tx pgx.Tx) error {
+		var count int
+		if err := tx.QueryRow(ctx,
+			`SELECT COUNT(*) FROM webhook_signing_secrets WHERE user_id = $1`, userID,
+		).Scan(&count); err != nil {
+			return err
+		}
+		if count >= MaxSigningSecretsPerUser {
+			return ErrSigningSecretCapReached
+		}
+		_, err := tx.Exec(ctx,
+			`INSERT INTO webhook_signing_secrets (id, user_id, secret, name, created_at)
+			 VALUES ($1, $2, $3, $4, $5)`,
+			id, userID, plaintext, name, now,
+		)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &SigningSecret{
+		ID:           id,
+		UserID:       userID,
+		Name:         name,
+		Secret:       plaintext,
+		SecretPrefix: plaintext[:12],
+		CreatedAt:    now,
+	}, nil
+}
+
+// ListSigningSecrets returns the user's secrets in most-recent-first
+// order. The plaintext Secret is intentionally omitted; only the
+// SecretPrefix preview is exposed.
+func (s *Store) ListSigningSecrets(ctx context.Context, userID string) ([]SigningSecret, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT id, user_id, name, substring(secret, 1, 12), created_at, last_signed_at
+		 FROM webhook_signing_secrets WHERE user_id = $1
+		 ORDER BY created_at DESC`,
+		userID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []SigningSecret
+	for rows.Next() {
+		var s SigningSecret
+		if err := rows.Scan(&s.ID, &s.UserID, &s.Name, &s.SecretPrefix, &s.CreatedAt, &s.LastSignedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	return out, rows.Err()
+}
+
+// GetUserSigningSecrets returns the plaintext secret values for a user
+// (paired with their IDs), most-recent-first. The relay signs with
+// [0] and asynchronously updates last_signed_at on that ID. The HITL
+// token verifier tries each Secret in turn. Caller must NOT log the
+// Secret values.
+func (s *Store) GetUserSigningSecrets(ctx context.Context, userID string) ([]SigningSecretWithValue, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT id, secret FROM webhook_signing_secrets WHERE user_id = $1 ORDER BY created_at DESC`,
+		userID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []SigningSecretWithValue
+	for rows.Next() {
+		var v SigningSecretWithValue
+		if err := rows.Scan(&v.ID, &v.Secret); err != nil {
+			return nil, err
+		}
+		out = append(out, v)
+	}
+	return out, rows.Err()
+}
+
+// DeleteSigningSecret removes a secret. Refuses to delete the user's
+// last secret — every user must keep at least one so webhooks remain
+// verifiable. Race-free under concurrent callers via the per-user
+// row lock.
+//
+// Check order matters: ownership first (so an attacker probing IDs
+// they don't own gets 404, not "cannot delete last" leaking that the
+// caller has only 1 secret), then the floor.
+func (s *Store) DeleteSigningSecret(ctx context.Context, secretID, userID string) error {
+	return s.withUserSecretsLock(ctx, userID, func(tx pgx.Tx) error {
+		var found int
+		if err := tx.QueryRow(ctx,
+			`SELECT 1 FROM webhook_signing_secrets WHERE id = $1 AND user_id = $2`,
+			secretID, userID,
+		).Scan(&found); err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return ErrSigningSecretNotFound
+			}
+			return err
+		}
+		var count int
+		if err := tx.QueryRow(ctx,
+			`SELECT COUNT(*) FROM webhook_signing_secrets WHERE user_id = $1`, userID,
+		).Scan(&count); err != nil {
+			return err
+		}
+		if count <= 1 {
+			return ErrCannotDeleteLastSigningSecret
+		}
+		_, err := tx.Exec(ctx,
+			`DELETE FROM webhook_signing_secrets WHERE id = $1 AND user_id = $2`,
+			secretID, userID,
+		)
+		return err
+	})
+}
+
+// TouchSigningSecretLastSigned records that the relay used this secret
+// to sign a payload. Best-effort — failure is logged but does not block
+// the actual signing operation.
+func (s *Store) TouchSigningSecretLastSigned(ctx context.Context, secretID string) error {
+	_, err := s.pool.Exec(ctx,
+		`UPDATE webhook_signing_secrets SET last_signed_at = NOW() WHERE id = $1`,
+		secretID,
+	)
+	return err
 }

--- a/internal/identity/store_test.go
+++ b/internal/identity/store_test.go
@@ -2,8 +2,11 @@ package identity_test
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -578,5 +581,302 @@ func TestLookupConversationID_NoMatch(t *testing.T) {
 	_, err := store.LookupConversationID(ctx, agent.ID, []string{"<nonexistent@example.com>"})
 	if err == nil {
 		t.Error("expected error for non-matching lookup, got nil")
+	}
+}
+
+// --- Per-user webhook signing secrets ---
+
+func TestCreateOrGetUser_AutoCreatesSigningSecret(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, err := store.CreateOrGetUser(ctx, "auto-secret@example.com", "Auto", "google-auto-secret")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	secrets, err := store.ListSigningSecrets(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("ListSigningSecrets: %v", err)
+	}
+	if len(secrets) != 1 {
+		t.Fatalf("expected 1 default secret, got %d", len(secrets))
+	}
+	if secrets[0].Name != "default" {
+		t.Errorf("default secret name = %q, want \"default\"", secrets[0].Name)
+	}
+	if secrets[0].SecretPrefix == "" {
+		t.Error("SecretPrefix should be set on list")
+	}
+	if secrets[0].Secret != "" {
+		t.Error("plaintext Secret must NOT be returned by List")
+	}
+}
+
+func TestCreateSigningSecret_RoundTrip(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	user, _ := store.CreateOrGetUser(ctx, "round-trip@example.com", "RT", "google-round-trip")
+
+	created, err := store.CreateSigningSecret(ctx, user.ID, "rollover-2026-04")
+	if err != nil {
+		t.Fatalf("CreateSigningSecret: %v", err)
+	}
+	if !strings.HasPrefix(created.ID, "wsec_") {
+		t.Errorf("ID should start with wsec_, got %q", created.ID)
+	}
+	if len(created.Secret) != 64 {
+		t.Errorf("Secret should be 64 hex chars, got len=%d", len(created.Secret))
+	}
+	if created.Name != "rollover-2026-04" {
+		t.Errorf("Name = %q", created.Name)
+	}
+
+	// GetUserSigningSecrets returns the plaintext + IDs for the relay/verifier
+	secrets, err := store.GetUserSigningSecrets(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("GetUserSigningSecrets: %v", err)
+	}
+	// Default + the one we just created → 2 secrets.
+	if len(secrets) != 2 {
+		t.Fatalf("expected 2 secrets, got %d", len(secrets))
+	}
+	// Most-recent-first: the one we just created should be at [0].
+	if secrets[0].Secret != created.Secret {
+		t.Errorf("most-recent secret value should be the just-created one")
+	}
+	if secrets[0].ID != created.ID {
+		t.Errorf("most-recent secret ID = %q, want %q", secrets[0].ID, created.ID)
+	}
+}
+
+func TestCreateSigningSecret_HardCap(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	user, _ := store.CreateOrGetUser(ctx, "cap@example.com", "Cap", "google-cap")
+
+	// Default secret was auto-created → 1. Create up to MaxSigningSecretsPerUser.
+	for i := 0; i < identity.MaxSigningSecretsPerUser-1; i++ {
+		if _, err := store.CreateSigningSecret(ctx, user.ID, ""); err != nil {
+			t.Fatalf("create secret %d: %v", i, err)
+		}
+	}
+	// One more should fail.
+	_, err := store.CreateSigningSecret(ctx, user.ID, "over-the-line")
+	if err == nil {
+		t.Fatal("expected cap error, got nil")
+	}
+	if !errors.Is(err, identity.ErrSigningSecretCapReached) {
+		t.Errorf("expected ErrSigningSecretCapReached, got: %v", err)
+	}
+}
+
+// Empty Name should be normalized server-side so the dashboard always
+// has something readable to render.
+func TestCreateSigningSecret_EmptyNameDefaults(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	user, _ := store.CreateOrGetUser(ctx, "empty-name@example.com", "EN", "google-empty-name")
+
+	created, err := store.CreateSigningSecret(ctx, user.ID, "")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if created.Name != "unnamed" {
+		t.Errorf("Name should default to \"unnamed\", got %q", created.Name)
+	}
+}
+
+func TestDeleteSigningSecret_RefusesLast(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	user, _ := store.CreateOrGetUser(ctx, "last-secret@example.com", "Last", "google-last-secret")
+
+	secrets, _ := store.ListSigningSecrets(ctx, user.ID)
+	if len(secrets) != 1 {
+		t.Fatalf("setup expected 1 default secret, got %d", len(secrets))
+	}
+	err := store.DeleteSigningSecret(ctx, secrets[0].ID, user.ID)
+	if err == nil {
+		t.Fatal("deleting the last secret should fail")
+	}
+	if !errors.Is(err, identity.ErrCannotDeleteLastSigningSecret) {
+		t.Errorf("expected ErrCannotDeleteLastSigningSecret, got: %v", err)
+	}
+}
+
+func TestDeleteSigningSecret_HappyPath(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	user, _ := store.CreateOrGetUser(ctx, "delete-happy@example.com", "Del", "google-delete-happy")
+
+	created, _ := store.CreateSigningSecret(ctx, user.ID, "extra")
+	if err := store.DeleteSigningSecret(ctx, created.ID, user.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	secrets, _ := store.ListSigningSecrets(ctx, user.ID)
+	if len(secrets) != 1 {
+		t.Errorf("after delete, expected 1 remaining (the default), got %d", len(secrets))
+	}
+}
+
+func TestDeleteSigningSecret_NotOwned(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	owner, _ := store.CreateOrGetUser(ctx, "owner-rls@example.com", "Owner", "google-rls-owner")
+	other, _ := store.CreateOrGetUser(ctx, "other-rls@example.com", "Other", "google-rls-other")
+
+	created, _ := store.CreateSigningSecret(ctx, owner.ID, "owner-only")
+	// Other user tries to delete owner's secret → must fail.
+	err := store.DeleteSigningSecret(ctx, created.ID, other.ID)
+	if err == nil {
+		t.Fatal("delete by non-owner should fail")
+	}
+}
+
+func TestEnsureUserHasSigningSecret_Idempotent(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	user, _ := store.CreateOrGetUser(ctx, "idem@example.com", "Idem", "google-idem")
+
+	// Already has one (auto-created).
+	for i := 0; i < 3; i++ {
+		if err := store.EnsureUserHasSigningSecret(ctx, user.ID); err != nil {
+			t.Fatalf("ensure call %d: %v", i, err)
+		}
+	}
+	secrets, _ := store.ListSigningSecrets(ctx, user.ID)
+	if len(secrets) != 1 {
+		t.Errorf("ensure should be idempotent, got %d secrets", len(secrets))
+	}
+}
+
+// --- Concurrency: TOCTOU race on the cap is closed ---
+
+func TestCreateSigningSecret_ConcurrentCreates_NeverExceedCap(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	user, _ := store.CreateOrGetUser(ctx, "race@example.com", "Race", "google-race")
+
+	// Default secret already exists → cap headroom is MaxSigningSecretsPerUser-1.
+	// Fire 4× the headroom of concurrent creates and assert we never end
+	// above the cap. Without the row lock these would interleave count
+	// checks and over-create.
+	const concurrency = 4 * (identity.MaxSigningSecretsPerUser)
+	var wg sync.WaitGroup
+	wg.Add(concurrency)
+	for i := 0; i < concurrency; i++ {
+		go func(i int) {
+			defer wg.Done()
+			_, _ = store.CreateSigningSecret(ctx, user.ID, fmt.Sprintf("race-%d", i))
+		}(i)
+	}
+	wg.Wait()
+
+	secrets, err := store.ListSigningSecrets(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(secrets) > identity.MaxSigningSecretsPerUser {
+		t.Errorf("cap broken: %d secrets, max %d", len(secrets), identity.MaxSigningSecretsPerUser)
+	}
+}
+
+func TestDeleteSigningSecret_ConcurrentDeletes_NeverGoBelowOne(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	user, _ := store.CreateOrGetUser(ctx, "del-race@example.com", "DR", "google-del-race")
+
+	// Create 3 extra so the user has 4 total. Fire 4 concurrent deletes
+	// for those 3 IDs (one delete will target a non-existent ID after a
+	// successful sibling delete). The floor (1 secret) must hold.
+	created := make([]string, 0, 3)
+	for i := 0; i < 3; i++ {
+		s, err := store.CreateSigningSecret(ctx, user.ID, fmt.Sprintf("d-%d", i))
+		if err != nil {
+			t.Fatal(err)
+		}
+		created = append(created, s.ID)
+	}
+
+	var wg sync.WaitGroup
+	for _, id := range created {
+		wg.Add(1)
+		go func(id string) {
+			defer wg.Done()
+			_ = store.DeleteSigningSecret(ctx, id, user.ID)
+		}(id)
+	}
+	wg.Wait()
+
+	secrets, _ := store.ListSigningSecrets(ctx, user.ID)
+	if len(secrets) < 1 {
+		t.Errorf("floor broken: %d secrets remain", len(secrets))
+	}
+}
+
+// --- TouchSigningSecretLastSigned ---
+
+func TestTouchSigningSecretLastSigned(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	user, _ := store.CreateOrGetUser(ctx, "touch@example.com", "T", "google-touch")
+
+	secrets, _ := store.ListSigningSecrets(ctx, user.ID)
+	if len(secrets) != 1 {
+		t.Fatalf("setup: expected 1 default secret, got %d", len(secrets))
+	}
+	if secrets[0].LastSignedAt != nil {
+		t.Errorf("LastSignedAt should start nil, got %v", secrets[0].LastSignedAt)
+	}
+
+	if err := store.TouchSigningSecretLastSigned(ctx, secrets[0].ID); err != nil {
+		t.Fatalf("touch: %v", err)
+	}
+
+	refreshed, _ := store.ListSigningSecrets(ctx, user.ID)
+	if refreshed[0].LastSignedAt == nil {
+		t.Fatal("LastSignedAt still nil after touch")
+	}
+	if time.Since(*refreshed[0].LastSignedAt) > 5*time.Second {
+		t.Errorf("LastSignedAt should be ~now, got %v", *refreshed[0].LastSignedAt)
+	}
+}
+
+// --- GetUserSigningSecrets (with IDs) ordering contract ---
+
+func TestGetUserSigningSecrets_MostRecentFirst(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	user, _ := store.CreateOrGetUser(ctx, "order@example.com", "O", "google-order")
+
+	// User starts with one default. Add a "rolling" then a "current" secret.
+	rolling, _ := store.CreateSigningSecret(ctx, user.ID, "rolling")
+	time.Sleep(2 * time.Millisecond) // ensure distinct created_at
+	current, _ := store.CreateSigningSecret(ctx, user.ID, "current")
+
+	got, err := store.GetUserSigningSecrets(ctx, user.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 secrets, got %d", len(got))
+	}
+	if got[0].ID != current.ID {
+		t.Errorf("[0] should be most recent (%q), got %q", current.ID, got[0].ID)
+	}
+	if got[1].ID != rolling.ID {
+		t.Errorf("[1] should be the middle one (%q), got %q", rolling.ID, got[1].ID)
 	}
 }

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -204,14 +204,50 @@ func (s *session) deliverToAgent(ctx context.Context, agent *identity.AgentIdent
 	// Build auth headers — signed Sender is the From: address (what SPF/DKIM authenticated).
 	// The body hash is bound into the canonical so a captured (headers, MAC) pair
 	// cannot be replayed under a modified body within the replay window.
-	authHeaders := s.relay.signer.Sign(headers.AuthPayload{
+	//
+	// Signing secret is per-agent-owner: we use the user's most recently
+	// created webhook signing secret. Older secrets remain valid for
+	// recipient-side verification (multi-secret rotation) but the relay
+	// always picks the freshest one for new signatures. Falls back to
+	// the deployment-wide signer only if the user lookup fails — that
+	// way an unowned/legacy agent still gets signed delivery.
+	signingSecret := ""
+	signingSecretID := ""
+	if agent.UserID != "" {
+		secrets, err := s.relay.store.GetUserSigningSecrets(ctx, agent.UserID)
+		if err != nil {
+			log.Printf("[%s] failed to load signing secrets for user %s: %v — falling back to deployment secret", s.id, agent.UserID, err)
+		} else if len(secrets) > 0 {
+			signingSecret = secrets[0].Secret
+			signingSecretID = secrets[0].ID
+		}
+	}
+	var authHeaders headers.AuthHeaders
+	authPayload := headers.AuthPayload{
 		Verified:    domainAuth.DomainAuthenticated(),
 		Sender:      senderEmail,
 		EntityType:  "human",
 		DomainCheck: domainAuth.Summary(),
 		MessageID:   messageID,
 		BodyHash:    headers.HashBody(body),
-	})
+	}
+	if signingSecret != "" {
+		authHeaders = headers.Sign(signingSecret, authPayload)
+		// Record last_signed_at off the hot path. Best-effort: a failed
+		// touch never blocks delivery — it only loses the dashboard
+		// "last used" hint for this signature.
+		go func(id string) {
+			if err := s.relay.store.TouchSigningSecretLastSigned(context.Background(), id); err != nil {
+				log.Printf("[mail:%s] touch last_signed_at failed: id=%s err=%v", messageID, id, err)
+			}
+		}(signingSecretID)
+	} else {
+		// Last-resort fallback for unowned agents or transient DB errors.
+		// Production deployments should never hit this path after the
+		// per-user-secrets backfill runs; if they do, the deployment
+		// secret remains a working signer.
+		authHeaders = s.relay.signer.Sign(authPayload)
+	}
 
 	// Display sender for webhook / stored message prefers Reply-To when set,
 	// so recipients reply to the intended mailbox (matches how mail clients

--- a/internal/testutil/db.go
+++ b/internal/testutil/db.go
@@ -97,7 +97,8 @@ func runMigrations(ctx context.Context, pool *pgxpool.Pool) error {
 func truncateAll(ctx context.Context, pool *pgxpool.Pool) error {
 	_, err := pool.Exec(ctx, `
 		TRUNCATE usage_summaries, usage_events, webhook_deliveries, messages,
-		         api_keys, agent_identities, domains, user_sessions, users CASCADE
+		         api_keys, webhook_signing_secrets, agent_identities, domains,
+		         user_sessions, users CASCADE
 	`)
 	if err != nil {
 		return err

--- a/migrations/004_per_user_signing_secrets.sql
+++ b/migrations/004_per_user_signing_secrets.sql
@@ -1,0 +1,43 @@
+-- Per-user webhook signing secrets.
+--
+-- Replaces the previous deployment-wide signing.hmac_secret as the source
+-- of truth for HMAC signatures on inbound webhook payloads and HITL
+-- magic-link approval tokens. Each user owns one or more secrets; the
+-- server signs with the most recently created and accepts any of the
+-- user's active secrets for verification (HITL tokens issued before a
+-- rotation continue to verify until the matching secret is deleted).
+--
+-- Rotation is fully user-driven: there is no auto-rotation, no TTL,
+-- and no automatic cleanup. Users explicitly create new secrets and
+-- delete old ones via the API.
+
+-- gen_random_bytes lives in pgcrypto. Idempotent — safe to run on a DB
+-- that already has the extension enabled.
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS webhook_signing_secrets (
+    id              TEXT PRIMARY KEY,
+    user_id         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    secret          TEXT NOT NULL,                       -- 64 hex chars (32 bytes)
+    name            TEXT NOT NULL DEFAULT '',            -- user-supplied label
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_signed_at  TIMESTAMPTZ                          -- updated when server uses to sign
+);
+
+CREATE INDEX IF NOT EXISTS webhook_signing_secrets_user_id_created_idx
+    ON webhook_signing_secrets (user_id, created_at DESC);
+
+-- Backfill: every existing user gets one secret named "default" so no
+-- user is ever caught without a way to verify webhooks. New users get
+-- their secret at user-creation time (handled in identity.CreateOrGetUser).
+INSERT INTO webhook_signing_secrets (id, user_id, secret, name, created_at)
+SELECT
+    'wsec_' || encode(gen_random_bytes(8), 'hex'),
+    u.id,
+    encode(gen_random_bytes(32), 'hex'),
+    'default',
+    NOW()
+FROM users u
+WHERE NOT EXISTS (
+    SELECT 1 FROM webhook_signing_secrets s WHERE s.user_id = u.id
+);

--- a/sdks/python/src/e2a/v1/generated/__init__.py
+++ b/sdks/python/src/e2a/v1/generated/__init__.py
@@ -52,6 +52,17 @@ class ApprovePendingMessageResponse(BaseModel):
     status: str | None = Field(None, examples=['sent'])
 
 
+class CreateSigningSecretResponse(BaseModel):
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
+    created_at: str | None = None
+    id: str | None = None
+    name: str | None = None
+    secret: str | None = None
+    secret_prefix: str | None = None
+
+
 class DNSRecord(BaseModel):
     model_config = ConfigDict(
         populate_by_name=True,
@@ -242,6 +253,17 @@ class SendEmailResponse(BaseModel):
     status: Literal['sent', 'pending_approval'] | None = Field(None, examples=['sent'])
 
 
+class SigningSecretSummary(BaseModel):
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
+    created_at: str | None = None
+    id: str | None = None
+    last_signed_at: str | None = None
+    name: str | None = None
+    secret_prefix: str | None = None
+
+
 class UpdateAgentRequest(BaseModel):
     model_config = ConfigDict(
         populate_by_name=True,
@@ -310,6 +332,13 @@ class ListPendingMessagesResponse(BaseModel):
         populate_by_name=True,
     )
     messages: list[PendingMessageSummary] | None = None
+
+
+class ListSigningSecretsResponse(BaseModel):
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
+    secrets: list[SigningSecretSummary] | None = None
 
 
 class PendingMessageDetail(BaseModel):

--- a/sdks/python/src/e2a/v1/generated/internal_agent.py
+++ b/sdks/python/src/e2a/v1/generated/internal_agent.py
@@ -15,3 +15,13 @@ class Attachment(BaseModel):
         None, description='base64-encoded', examples=['base64-encoded-content']
     )
     filename: str | None = Field(None, examples=['report.pdf'])
+
+
+class CreateSigningSecretRequest(BaseModel):
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
+    name: str | None = Field(
+        None,
+        description='Optional human-readable label so users can tell secrets apart in\nthe dashboard (e.g. "prod", "staging", "rollover-2026-04").',
+    )

--- a/sdks/typescript/src/v1/generated/types.ts
+++ b/sdks/typescript/src/v1/generated/types.ts
@@ -1427,6 +1427,169 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/users/me/signing-secrets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List your webhook signing secrets
+         * @description Returns the authenticated user's webhook signing secrets (metadata + 12-char prefix preview only — full secrets are only shown once at creation). Sorted most-recent-first; the most-recent secret is what the e2a relay uses for new signatures.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ListSigningSecretsResponse"];
+                    };
+                };
+                /** @description Missing or invalid API key */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+            };
+        };
+        put?: never;
+        /**
+         * Create a new webhook signing secret
+         * @description Mints a new HMAC signing secret for the authenticated user. The full plaintext `secret` is returned only in this response — save it now, you cannot retrieve it later. Hard cap is 5 active secrets per user; delete one before creating another.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            /** @description Optional name/label */
+            requestBody?: {
+                content: {
+                    "application/json": components["schemas"]["internal_agent.CreateSigningSecretRequest"];
+                };
+            };
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["CreateSigningSecretResponse"];
+                    };
+                };
+                /** @description Bad request (e.g. cap reached) */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Missing or invalid API key */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/users/me/signing-secrets/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete a webhook signing secret
+         * @description Deletes the named secret. Refuses if it would leave the user with zero secrets — create a replacement first. After delete, any in-flight HITL approval magic-link tokens signed under the deleted secret stop verifying.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Signing secret ID (e.g. wsec_abc123...) */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description No Content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Cannot delete last secret */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Missing or invalid API key */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Secret not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -1482,6 +1645,13 @@ export interface components {
             provider_message_id?: string;
             /** @example sent */
             status?: string;
+        };
+        CreateSigningSecretResponse: {
+            created_at?: string;
+            id?: string;
+            name?: string;
+            secret?: string;
+            secret_prefix?: string;
         };
         DNSRecord: {
             /** @example @ */
@@ -1550,6 +1720,9 @@ export interface components {
         };
         ListPendingMessagesResponse: {
             messages?: components["schemas"]["PendingMessageSummary"][];
+        };
+        ListSigningSecretsResponse: {
+            secrets?: components["schemas"]["SigningSecretSummary"][];
         };
         MessageDetail: {
             auth_headers?: {
@@ -1769,6 +1942,13 @@ export interface components {
              */
             status?: "sent" | "pending_approval";
         };
+        SigningSecretSummary: {
+            created_at?: string;
+            id?: string;
+            last_signed_at?: string;
+            name?: string;
+            secret_prefix?: string;
+        };
         UpdateAgentRequest: {
             /** @enum {string} */
             agent_mode?: "cloud" | "local";
@@ -1888,6 +2068,13 @@ export interface components {
             data?: string;
             /** @example report.pdf */
             filename?: string;
+        };
+        "internal_agent.CreateSigningSecretRequest": {
+            /**
+             * @description Optional human-readable label so users can tell secrets apart in
+             *     the dashboard (e.g. "prod", "staging", "rollover-2026-04").
+             */
+            name?: string;
         };
     };
     responses: never;

--- a/web/public/openapi.yaml
+++ b/web/public/openapi.yaml
@@ -93,6 +93,19 @@ definitions:
         example: sent
         type: string
     type: object
+  CreateSigningSecretResponse:
+    properties:
+      created_at:
+        type: string
+      id:
+        type: string
+      name:
+        type: string
+      secret:
+        type: string
+      secret_prefix:
+        type: string
+    type: object
   DNSRecord:
     properties:
       host:
@@ -200,6 +213,13 @@ definitions:
       messages:
         items:
           $ref: '#/definitions/PendingMessageSummary'
+        type: array
+    type: object
+  ListSigningSecretsResponse:
+    properties:
+      secrets:
+        items:
+          $ref: '#/definitions/SigningSecretSummary'
         type: array
     type: object
   MessageDetail:
@@ -535,6 +555,19 @@ definitions:
         example: sent
         type: string
     type: object
+  SigningSecretSummary:
+    properties:
+      created_at:
+        type: string
+      id:
+        type: string
+      last_signed_at:
+        type: string
+      name:
+        type: string
+      secret_prefix:
+        type: string
+    type: object
   UpdateAgentRequest:
     properties:
       agent_mode:
@@ -760,6 +793,14 @@ definitions:
         type: string
       filename:
         example: report.pdf
+        type: string
+    type: object
+  internal_agent.CreateSigningSecretRequest:
+    properties:
+      name:
+        description: |-
+          Optional human-readable label so users can tell secrets apart in
+          the dashboard (e.g. "prod", "staging", "rollover-2026-04").
         type: string
     type: object
 host: localhost:8080
@@ -1578,6 +1619,96 @@ paths:
       security:
       - BearerAuth: []
       summary: Export your data
+      tags:
+      - User
+  /api/v1/users/me/signing-secrets:
+    get:
+      description: Returns the authenticated user's webhook signing secrets (metadata
+        + 12-char prefix preview only — full secrets are only shown once at creation).
+        Sorted most-recent-first; the most-recent secret is what the e2a relay uses
+        for new signatures.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/ListSigningSecretsResponse'
+        "401":
+          description: Missing or invalid API key
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: List your webhook signing secrets
+      tags:
+      - User
+    post:
+      consumes:
+      - application/json
+      description: Mints a new HMAC signing secret for the authenticated user. The
+        full plaintext `secret` is returned only in this response — save it now, you
+        cannot retrieve it later. Hard cap is 5 active secrets per user; delete one
+        before creating another.
+      parameters:
+      - description: Optional name/label
+        in: body
+        name: body
+        schema:
+          $ref: '#/definitions/internal_agent.CreateSigningSecretRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/CreateSigningSecretResponse'
+        "400":
+          description: Bad request (e.g. cap reached)
+          schema:
+            type: string
+        "401":
+          description: Missing or invalid API key
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Create a new webhook signing secret
+      tags:
+      - User
+  /api/v1/users/me/signing-secrets/{id}:
+    delete:
+      description: Deletes the named secret. Refuses if it would leave the user with
+        zero secrets — create a replacement first. After delete, any in-flight HITL
+        approval magic-link tokens signed under the deleted secret stop verifying.
+      parameters:
+      - description: Signing secret ID (e.g. wsec_abc123...)
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+          schema:
+            type: string
+        "400":
+          description: Cannot delete last secret
+          schema:
+            type: string
+        "401":
+          description: Missing or invalid API key
+          schema:
+            type: string
+        "404":
+          description: Secret not found
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Delete a webhook signing secret
       tags:
       - User
 securityDefinitions:


### PR DESCRIPTION
## Summary

Replaces the deployment-wide HMAC secret as the source of truth for inbound webhook signatures and HITL approval magic-link tokens. Each user owns one or more secrets (max 5); the relay signs with the most recently created and verifies HITL tokens against any of the user's active secrets.

**Rotation is fully user-driven** — no auto-rotation, no TTL, no automatic cleanup. AWS-access-key-style flow:

\`\`\`
1. POST /api/v1/users/me/signing-secrets         (returns plaintext once)
2. Add the new secret to your verify code's secret list
3. Server starts signing with the new one (most recent wins)
4. DELETE /api/v1/users/me/signing-secrets/{id}  (drop the old one)
\`\`\`

This is the foundation for hosted users to actually be able to call \`verify_signature(secret)\` — previously the deployment-wide secret could only be exposed to one user without leaking everyone else's signing key.

## API

| Method | Path | Notes |
|---|---|---|
| GET | \`/api/v1/users/me/signing-secrets\` | List (prefix preview only — no plaintext) |
| POST | \`/api/v1/users/me/signing-secrets\` | Create. Returns full secret **exactly once** (matches API-key pattern) |
| DELETE | \`/api/v1/users/me/signing-secrets/{id}\` | Refuses to delete the last secret (would lock out webhook verification) |

## Server-side wiring

- **\`internal/headers\`** — parametric \`Sign(secret, payload)\` and \`Verify(secrets, headers)\`. Legacy \`Signer\` wrapper kept as a shim for tests + the deployment-wide path.
- **\`internal/approvaltoken\`** — same parametric pattern, plus new \`PeekMessageID(token)\` so HITL handlers can pre-parse the unverified message_id to resolve which user's secrets to try.
- **\`internal/relay\`** — looks up the agent owner's secrets and signs with the most recent. Falls back to deployment signer if lookup fails (defensive only — backfilled users always have one).
- **\`internal/hitlnotify\`** — signs new approval tokens with the owner's most recent secret.
- **\`internal/agent/hitl_magic_api\`** — verifies HITL tokens by trying the owner's per-user secrets first; falls back to the deployment signer for legacy pre-migration tokens.

## Schema

Migration \`004_per_user_signing_secrets.sql\`:
- Enables \`pgcrypto\` (for \`gen_random_bytes\`)
- New \`webhook_signing_secrets\` table (id, user_id, secret, name, created_at, last_signed_at)
- Backfills every existing user with one \"default\" secret
- New users get one at \`CreateOrGetUser\` / \`BootstrapUser\` time

## Storage posture

Plaintext in Postgres. The relay must recover the value to sign new HMACs, which rules out hashing (unlike API keys). Matches the existing posture for OAuth tokens and message bodies; documented in \`docs/data-handling.md\` alongside them. App-layer encryption left as a future cross-cutting effort.

## Test plan

- [x] All touched packages pass individually:
  - \`identity\`: +7 tests (auto-create, round-trip, hard cap, refuse-last, ownership, idempotent ensure)
  - \`headers\`: +3 (multi-secret Verify + parametric/wrapper consistency)
  - \`approvaltoken\`: +4 (multi-secret Verify + PeekMessageID safety)
  - \`hitlnotify\`: existing test updated to verify with owner's per-user secrets
- [x] \`go build ./...\` clean, \`go vet ./...\` clean
- [ ] Cross-package shared-DB flakiness pre-exists (FK constraint races between concurrent test packages — same behavior on \`main\`)
- [ ] After merge: dashboard UI to view/rotate (PR C, follow-up)

## What's NOT in this PR

- **Dashboard UI** — PR C
- **SDK changes** (\`InboundEmail\` raises if not verified, auto-read \`E2A_HMAC_SECRET\`) — PR D
- **Docs sweep** (SKILL, READMEs, examples) — PR E

🤖 Generated with [Claude Code](https://claude.com/claude-code)