### PR TITLE
feat(web): dashboard UI for per-user signing secrets

### DIFF
--- a/web/src/app/(app)/settings/page.test.tsx
+++ b/web/src/app/(app)/settings/page.test.tsx
@@ -57,6 +57,171 @@ describe("Settings — Export section", () => {
   });
 });
 
+// --- Signing secrets ---
+
+type FetchInit = { method?: string; body?: BodyInit };
+type MockResponse = { ok: boolean; status: number; text: () => Promise<string>; json: () => Promise<unknown> };
+
+function makeFetchMock(
+  routes: Record<string, (init?: FetchInit) => MockResponse | Promise<MockResponse>>,
+) {
+  return jest.fn(async (url: string, init?: FetchInit) => {
+    const method = init?.method ?? "GET";
+    const key = `${method} ${url}`;
+    const handler = routes[key] ?? routes[url];
+    if (!handler) {
+      throw new Error(`unmocked ${key}`);
+    }
+    return handler(init);
+  });
+}
+
+function jsonResp(body: unknown, status = 200): MockResponse {
+  const text = JSON.stringify(body);
+  return { ok: status >= 200 && status < 300, status, text: async () => text, json: async () => body };
+}
+
+function errResp(text: string, status: number): MockResponse {
+  return { ok: false, status, text: async () => text, json: async () => ({}) };
+}
+
+describe("Settings — Signing secrets section", () => {
+  const defaultSecret = {
+    id: "wsec_default0001",
+    name: "default",
+    secret_prefix: "abcd1234efgh",
+    created_at: "2026-04-15T10:00:00Z",
+  };
+
+  it("lists existing secrets without exposing plaintext", async () => {
+    global.fetch = makeFetchMock({
+      "/api/v1/users/me/signing-secrets": () => jsonResp({ secrets: [defaultSecret] }),
+    }) as unknown as typeof fetch;
+
+    render(<SettingsPage />);
+    await waitFor(() => {
+      expect(screen.getByText("default")).toBeInTheDocument();
+    });
+    // Prefix is shown with a trailing ellipsis.
+    expect(screen.getByText("abcd1234efgh…")).toBeInTheDocument();
+    // Critical: nothing in the rendered DOM should contain a 32+ char
+    // hex blob (the full plaintext form). The mock never returns one.
+    expect(document.body.innerHTML).not.toMatch(/[a-f0-9]{32,}/i);
+  });
+
+  it("disables Delete when only one secret exists", async () => {
+    global.fetch = makeFetchMock({
+      "/api/v1/users/me/signing-secrets": () => jsonResp({ secrets: [defaultSecret] }),
+    }) as unknown as typeof fetch;
+
+    render(<SettingsPage />);
+    await waitFor(() => expect(screen.getByText("default")).toBeInTheDocument());
+    const delBtn = screen.getByRole("button", { name: /^delete$/i });
+    expect(delBtn).toBeDisabled();
+  });
+
+  it("creates a new secret and shows the plaintext exactly once, then hides it on dismiss", async () => {
+    const created = {
+      id: "wsec_new0002",
+      name: "rolling",
+      secret: "deadbeef".repeat(8), // 64-char "plaintext"
+      secret_prefix: "deadbeefdead",
+      created_at: "2026-04-27T16:10:00Z",
+    };
+    let listCallCount = 0;
+    global.fetch = makeFetchMock({
+      "GET /api/v1/users/me/signing-secrets": () => {
+        listCallCount++;
+        if (listCallCount === 1) return jsonResp({ secrets: [defaultSecret] });
+        return jsonResp({ secrets: [defaultSecret, { ...created, secret: undefined }] });
+      },
+      "POST /api/v1/users/me/signing-secrets": () => jsonResp(created, 201),
+    }) as unknown as typeof fetch;
+
+    render(<SettingsPage />);
+    await waitFor(() => expect(screen.getByText("default")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: /create new secret/i }));
+    fireEvent.change(screen.getByPlaceholderText(/rolling-2026/i), { target: { value: "rolling" } });
+    fireEvent.click(screen.getByRole("button", { name: /^create$/i }));
+
+    // The plaintext is now in a readonly input with the warning banner.
+    await waitFor(() => {
+      expect(screen.getByText(/Save this secret now/i)).toBeInTheDocument();
+    });
+    const plaintextInput = screen.getByLabelText(/plaintext signing secret/i) as HTMLInputElement;
+    expect(plaintextInput.value).toBe(created.secret);
+
+    // After dismiss, the plaintext disappears from the rendered DOM.
+    fireEvent.click(screen.getByRole("button", { name: /^dismiss$/i }));
+    expect(screen.queryByText(/save this secret now/i)).not.toBeInTheDocument();
+    expect(document.body.innerHTML).not.toContain(created.secret);
+  });
+
+  it("shows an inline error when the cap is reached on create", async () => {
+    global.fetch = makeFetchMock({
+      "GET /api/v1/users/me/signing-secrets": () => jsonResp({ secrets: [defaultSecret] }),
+      "POST /api/v1/users/me/signing-secrets": () =>
+        errResp("at most 5 signing secrets per user; delete one before creating another", 400),
+    }) as unknown as typeof fetch;
+
+    render(<SettingsPage />);
+    await waitFor(() => expect(screen.getByText("default")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: /create new secret/i }));
+    fireEvent.click(screen.getByRole("button", { name: /^create$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/at most 5 signing secrets/i)).toBeInTheDocument();
+    });
+  });
+
+  it("DELETEs the right id when confirming a row delete", async () => {
+    const second = { ...defaultSecret, id: "wsec_other", name: "other", secret_prefix: "1111" };
+    const deletedIDs: string[] = [];
+    global.fetch = makeFetchMock({
+      "GET /api/v1/users/me/signing-secrets": () => jsonResp({ secrets: [defaultSecret, second] }),
+      [`DELETE /api/v1/users/me/signing-secrets/${encodeURIComponent("wsec_other")}`]: () => {
+        deletedIDs.push("wsec_other");
+        return { ok: true, status: 204, text: async () => "", json: async () => ({}) };
+      },
+    }) as unknown as typeof fetch;
+
+    render(<SettingsPage />);
+    await waitFor(() => expect(screen.getByText("other")).toBeInTheDocument());
+
+    // Two rows now → both Delete buttons should be enabled.
+    const delButtons = screen.getAllByRole("button", { name: /^delete$/i });
+    expect(delButtons).toHaveLength(2);
+    fireEvent.click(delButtons[1]);
+    fireEvent.click(screen.getByRole("button", { name: /^confirm$/i }));
+
+    await waitFor(() => {
+      expect(deletedIDs).toEqual(["wsec_other"]);
+    });
+  });
+
+  it("surfaces a 'cannot delete the last' error inline", async () => {
+    const second = { ...defaultSecret, id: "wsec_other", name: "other", secret_prefix: "1111" };
+    global.fetch = makeFetchMock({
+      "GET /api/v1/users/me/signing-secrets": () => jsonResp({ secrets: [defaultSecret, second] }),
+      [`DELETE /api/v1/users/me/signing-secrets/${encodeURIComponent("wsec_other")}`]: () =>
+        errResp("cannot delete the last signing secret; create a new one first", 400),
+    }) as unknown as typeof fetch;
+
+    render(<SettingsPage />);
+    await waitFor(() => expect(screen.getByText("other")).toBeInTheDocument());
+
+    const delButtons = screen.getAllByRole("button", { name: /^delete$/i });
+    fireEvent.click(delButtons[1]);
+    fireEvent.click(screen.getByRole("button", { name: /^confirm$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/cannot delete the last/i)).toBeInTheDocument();
+    });
+  });
+});
+
 describe("Settings — Danger zone (delete account)", () => {
   it("hides the confirm input until the user opens the flow", () => {
     render(<SettingsPage />);

--- a/web/src/app/(app)/settings/page.tsx
+++ b/web/src/app/(app)/settings/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useAuth } from "../../components/AuthProvider";
 
 export default function SettingsPage() {
@@ -16,11 +16,12 @@ export default function SettingsPage() {
       <header>
         <h1 className="text-2xl font-bold tracking-tight mb-1">Settings</h1>
         <p className="text-sm text-muted">
-          Account profile, data export, and account deletion.
+          Account profile, webhook signing secrets, data export, and account deletion.
         </p>
       </header>
 
       <ProfileSection user={user} />
+      <SigningSecretsSection />
       <ExportSection />
       <DangerZone />
     </div>
@@ -76,6 +77,327 @@ function ExportSection() {
       </a>
     </section>
   );
+}
+
+// --- Signing secrets ---
+
+type SigningSecretSummary = {
+  id: string;
+  name: string;
+  secret_prefix: string;
+  created_at: string;
+  last_signed_at?: string;
+};
+
+type CreatedSecret = {
+  id: string;
+  name: string;
+  secret: string;        // plaintext, only shown once
+  secret_prefix: string;
+  created_at: string;
+};
+
+function SigningSecretsSection() {
+  const [secrets, setSecrets] = useState<SigningSecretSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState("");
+  // The freshly-created secret stays in component state (not refetched)
+  // so the plaintext can be displayed exactly once. After dismissal it
+  // is gone — the API will never return it again.
+  const [created, setCreated] = useState<CreatedSecret | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState("");
+  const [newName, setNewName] = useState("");
+  const [showCreateForm, setShowCreateForm] = useState(false);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setLoadError("");
+    try {
+      const res = await fetch("/api/v1/users/me/signing-secrets", { credentials: "include" });
+      if (!res.ok) {
+        setLoadError(`Failed to load (HTTP ${res.status})`);
+        setLoading(false);
+        return;
+      }
+      const body = await res.json();
+      setSecrets(body.secrets ?? []);
+    } catch (err) {
+      setLoadError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void refresh(); }, [refresh]);
+
+  const handleCreate = async () => {
+    setCreating(true);
+    setCreateError("");
+    try {
+      const res = await fetch("/api/v1/users/me/signing-secrets", {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name: newName.trim() }),
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => `HTTP ${res.status}`);
+        setCreateError(text.trim() || `HTTP ${res.status}`);
+        return;
+      }
+      const body: CreatedSecret = await res.json();
+      setCreated(body);
+      setShowCreateForm(false);
+      setNewName("");
+      await refresh();
+    } catch (err) {
+      setCreateError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  return (
+    <section>
+      <h2 className="text-lg font-semibold mb-2">Webhook signing secrets</h2>
+      <p className="text-sm text-muted mb-4 max-w-2xl">
+        HMAC secrets used to sign your agents&apos; inbound webhook payloads.
+        Pass any of these to <code className="font-mono text-xs bg-surface px-1.5 py-0.5 rounded border border-border">verify_signature()</code>{" "}
+        in the SDK to confirm a payload came from e2a. The relay always signs
+        with your most recently created secret; older ones stay valid for
+        verification until you delete them, so rotation is: create new → swap
+        in your code → delete old. Up to 5 active secrets at a time.
+      </p>
+
+      {created && <CreatedSecretBanner secret={created} onDismiss={() => setCreated(null)} />}
+
+      {loading ? (
+        <p className="text-sm text-muted">Loading…</p>
+      ) : loadError ? (
+        <p className="text-sm text-red-700 dark:text-red-400">{loadError}</p>
+      ) : (
+        <SigningSecretsTable secrets={secrets} onChange={refresh} />
+      )}
+
+      <div className="mt-4">
+        {!showCreateForm ? (
+          <button
+            onClick={() => { setShowCreateForm(true); setCreateError(""); }}
+            className="px-4 py-2 bg-foreground text-background rounded-lg text-sm font-medium hover:opacity-90 transition disabled:opacity-50"
+            disabled={!loadError && secrets.length >= 5}
+            title={!loadError && secrets.length >= 5 ? "Cap reached — delete one first" : undefined}
+          >
+            Create new secret
+          </button>
+        ) : (
+          <div className="space-y-2 max-w-md">
+            <label className="block">
+              <span className="text-sm">Name (optional, e.g. <code className="font-mono text-xs">prod</code>)</span>
+              <input
+                autoFocus
+                type="text"
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                placeholder="rolling-2026-04"
+                className="mt-1 w-full border border-border rounded-lg px-3 py-2 text-sm bg-surface focus:outline-none focus:ring-2 focus:ring-foreground/20 focus:border-foreground/50 transition"
+              />
+            </label>
+            {createError && (
+              <p className="text-sm text-red-700 dark:text-red-400">{createError}</p>
+            )}
+            <div className="flex gap-2">
+              <button
+                onClick={handleCreate}
+                disabled={creating}
+                className="px-4 py-2 bg-foreground text-background rounded-lg text-sm font-medium hover:opacity-90 transition disabled:opacity-50"
+              >
+                {creating ? "Creating…" : "Create"}
+              </button>
+              <button
+                onClick={() => { setShowCreateForm(false); setNewName(""); setCreateError(""); }}
+                disabled={creating}
+                className="px-4 py-2 border border-border rounded-lg text-sm hover:bg-background transition"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function CreatedSecretBanner({ secret, onDismiss }: { secret: CreatedSecret; onDismiss: () => void }) {
+  const [copied, setCopied] = useState(false);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(secret.secret);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Older browsers / test envs without clipboard support — silently
+      // do nothing; the value is still visible in the textarea.
+    }
+  };
+
+  return (
+    <div className="mb-4 border border-amber-300 dark:border-amber-800/40 bg-amber-50 dark:bg-amber-950/20 rounded-lg p-4">
+      <h3 className="text-sm font-semibold mb-1">Save this secret now — you can&apos;t see it again</h3>
+      <p className="text-sm text-muted mb-3">
+        This is the only time the full plaintext value will be shown. Copy it
+        into your environment variable (commonly <code className="font-mono text-xs">E2A_HMAC_SECRET</code>) before dismissing.
+      </p>
+      <div className="flex gap-2 items-start">
+        <input
+          readOnly
+          value={secret.secret}
+          aria-label="Plaintext signing secret"
+          onFocus={(e) => e.currentTarget.select()}
+          className="flex-1 font-mono text-xs bg-surface border border-border rounded-lg px-3 py-2"
+        />
+        <button
+          onClick={copy}
+          className="px-3 py-2 border border-border rounded-lg text-sm hover:bg-background transition whitespace-nowrap"
+        >
+          {copied ? "Copied" : "Copy"}
+        </button>
+        <button
+          onClick={onDismiss}
+          className="px-3 py-2 border border-border rounded-lg text-sm hover:bg-background transition"
+        >
+          Dismiss
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function SigningSecretsTable({ secrets, onChange }: { secrets: SigningSecretSummary[]; onChange: () => Promise<void> | void }) {
+  if (secrets.length === 0) {
+    return (
+      <p className="text-sm text-muted">
+        No secrets yet. New accounts always get a default one — if you&apos;re seeing this, something is wrong.
+      </p>
+    );
+  }
+  return (
+    <div className="border border-border rounded-lg overflow-hidden">
+      <table className="w-full text-sm">
+        <thead className="bg-surface text-muted">
+          <tr>
+            <th className="text-left px-4 py-2 font-medium">Name</th>
+            <th className="text-left px-4 py-2 font-medium">Prefix</th>
+            <th className="text-left px-4 py-2 font-medium">Created</th>
+            <th className="text-left px-4 py-2 font-medium">Last used</th>
+            <th className="px-4 py-2"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {secrets.map((s) => (
+            <SigningSecretRow
+              key={s.id}
+              secret={s}
+              isLast={secrets.length === 1}
+              onChange={onChange}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function SigningSecretRow({
+  secret,
+  isLast,
+  onChange,
+}: {
+  secret: SigningSecretSummary;
+  isLast: boolean;
+  onChange: () => Promise<void> | void;
+}) {
+  const [confirming, setConfirming] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    setError("");
+    try {
+      const res = await fetch(`/api/v1/users/me/signing-secrets/${encodeURIComponent(secret.id)}`, {
+        method: "DELETE",
+        credentials: "include",
+      });
+      if (!res.ok) {
+        const text = await res.text().catch(() => `HTTP ${res.status}`);
+        setError(text.trim() || `HTTP ${res.status}`);
+        return;
+      }
+      await onChange();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setDeleting(false);
+      setConfirming(false);
+    }
+  };
+
+  return (
+    <tr className="border-t border-border">
+      <td className="px-4 py-3">{secret.name || "—"}</td>
+      <td className="px-4 py-3 font-mono text-xs">{secret.secret_prefix}…</td>
+      <td className="px-4 py-3 text-muted">{formatDate(secret.created_at)}</td>
+      <td className="px-4 py-3 text-muted">
+        {secret.last_signed_at ? formatRelative(secret.last_signed_at) : "Never"}
+      </td>
+      <td className="px-4 py-3 text-right">
+        {error && <span className="text-xs text-red-700 dark:text-red-400 mr-2">{error}</span>}
+        {confirming ? (
+          <span className="inline-flex gap-1">
+            <button
+              onClick={handleDelete}
+              disabled={deleting}
+              className="px-2 py-1 bg-red-600 text-white rounded text-xs hover:bg-red-700 transition disabled:opacity-50"
+            >
+              {deleting ? "Deleting…" : "Confirm"}
+            </button>
+            <button
+              onClick={() => { setConfirming(false); setError(""); }}
+              disabled={deleting}
+              className="px-2 py-1 border border-border rounded text-xs hover:bg-background transition"
+            >
+              Cancel
+            </button>
+          </span>
+        ) : (
+          <button
+            onClick={() => setConfirming(true)}
+            disabled={isLast}
+            title={isLast ? "Cannot delete your only signing secret — create a new one first" : undefined}
+            className="px-2 py-1 border border-border rounded text-xs hover:bg-background transition disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Delete
+          </button>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+function formatRelative(iso: string): string {
+  try {
+    const ts = new Date(iso).getTime();
+    const ageSec = (Date.now() - ts) / 1000;
+    if (ageSec < 60) return "just now";
+    if (ageSec < 3600) return `${Math.floor(ageSec / 60)}m ago`;
+    if (ageSec < 86400) return `${Math.floor(ageSec / 3600)}h ago`;
+    return `${Math.floor(ageSec / 86400)}d ago`;
+  } catch {
+    return iso;
+  }
 }
 
 type DeleteState = "idle" | "deleting" | "error";


### PR DESCRIPTION
## Summary

Wraps the CRUD endpoints shipped in #55 with a UI in /settings so hosted users can actually see, create, and rotate the HMAC secret they need to call \`verify_signature()\`.

| Action | UX |
|---|---|
| **List** | Table: name, 12-char prefix, created date, "last used" relative time. Plaintext never round-trips through the page. |
| **Create** | Modal with optional name input. On success, plaintext shown **exactly once** in a prominent yellow banner with copy-to-clipboard + dismiss. After dismiss, plaintext is gone from the DOM. |
| **Delete (per row)** | Two-click confirm. Disabled in UI when the user has only one secret (tooltip explains). Server-side "cannot delete last" / "not found" errors surface inline next to the row. |
| **Cap protection** | Create button disabled when user is at 5 secrets. If a race slips through, server's 400 surfaces inline. |

## Tests (6 new)

- list omits plaintext (asserts no 32+ char hex string in DOM)
- single-secret disables Delete button
- create round-trip: plaintext shown → dismiss removes it from DOM
- cap-reached error surfaces inline
- delete sends DELETE to the right id
- "cannot delete last" server error surfaces inline

## Test plan

- [x] \`npm run build\` (web) clean — settings route prerenders fine
- [x] \`npm test --testPathPatterns=settings\` — 13/13 pass (was 7; +6 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)