### PR TITLE
docs: sweep for SDK 2.0 — show parse_webhook everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,26 +146,25 @@ The MAC binds to **both** `message_id` and a SHA-256 of the raw message body. Su
 
 #### Verifying the signature
 
-The `X-E2A-Auth-Verified` field is the *server's claim* — anyone who can reach your webhook URL can set it. To make a security decision, **verify the signature** with the shared HMAC secret:
+The `X-E2A-Auth-Verified` field is the *server's claim* — anyone who can reach your webhook URL can set it. To make a security decision, **verify the signature** with one of your account's signing secrets (manage them in the dashboard's Settings → Webhook signing secrets, or via `/api/v1/users/me/signing-secrets`).
+
+The SDKs gate field access behind verification by default — accessing `email.sender`, `email.subject`, etc. on an unverified webhook payload raises `UnverifiedEmailError`, so you can't accidentally trust attacker-controllable fields. The one-call shortcut:
 
 ```python
 from e2a.v1 import E2AClient
 client = E2AClient()
-email = client.parse(request_body)
-if not email.verify_signature(my_hmac_secret):
-    return 401  # untrusted, reject
-# now safe to act on email.sender, email.is_verified, etc.
+email = client.parse_webhook(request_body)  # parse + verify, raises on bad signature
+# safe to use email.sender, email.subject, …
 ```
 
 ```typescript
 import { E2AClient } from "@e2a/sdk";
-const email = await client.parse(req.body);
-if (!email.verifySignature(myHmacSecret)) {
-  return res.status(401).end();
-}
+const email = await client.parseWebhook(req.body); // throws on bad signature
 ```
 
-Both SDKs check, in order: body_hash matches the raw message bytes, HMAC matches the canonical, and timestamp is within a 5-minute replay window. Returns `true` only if all three hold. Treat `false` as untrusted regardless of the `is_verified` claim.
+Both forms read the secret from `E2A_HMAC_SECRET` by default; pass it explicitly as a second argument if you keep it elsewhere. Under the hood the verify step checks, in order: body_hash matches the raw message bytes, HMAC matches the canonical auth string, and timestamp is within a 5-minute replay window.
+
+REST-fetched messages (`client.get_message(...)`, `client.list_messages(...)`) are pre-verified — the bearer token already authenticated the channel — so field access works directly without a verify step.
 
 ### Conversation threading
 
@@ -239,8 +238,8 @@ pip install 'e2a[ws]'      # adds WebSocket support
 ```python
 from e2a.v1 import E2AClient
 
-client = E2AClient()                # reads E2A_API_KEY
-email = client.parse(request_body)  # validate + decode webhook payload
+client = E2AClient()                          # reads E2A_API_KEY
+email = client.parse_webhook(request_body)    # parse + HMAC-verify (reads E2A_HMAC_SECRET)
 print(email.sender, email.subject)
 email.reply("Got it!", conversation_id="conv_123")
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -51,6 +51,18 @@ For the machine-readable spec, see [`web/public/openapi.yaml`](../web/public/ope
 
 Both endpoints require a valid API key or session. The export omits internal identifiers (Google subject, API key hashes, session tokens) — see [data-handling.md](data-handling.md) for the full data model.
 
+### Webhook signing secrets
+
+Per-user HMAC secrets used to sign inbound webhook payloads. Up to 5 active per user. Plaintext is returned **once** at creation; subsequent reads see only the 12-char prefix.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/users/me/signing-secrets` | List the user's signing secrets (id, name, prefix, created_at, last_signed_at). |
+| `POST` | `/users/me/signing-secrets` | Create a new signing secret. Returns the plaintext exactly once — store it immediately. Body: `{"name": "..."}`. |
+| `DELETE` | `/users/me/signing-secrets/{id}` | Delete a signing secret. Cannot delete the last one (returns 409); rotate by creating a new one first, switching consumers over, then deleting the old one. |
+
+The SDKs read the secret from `E2A_HMAC_SECRET` by default — `client.parse_webhook(body)` / `client.parseWebhook(body)` does parse + verify in one call. See [sdks/python/README.md](../sdks/python/README.md#quick-start) and [sdks/typescript/README.md](../sdks/typescript/README.md#webhook-cloud-agents).
+
 ## HITL magic links
 
 These endpoints accept a signed `token` query parameter (from notification emails) instead of an API key, so reviewers can approve from any mail client without auth.

--- a/examples/adk-cloud-webhook/.env.example
+++ b/examples/adk-cloud-webhook/.env.example
@@ -1,7 +1,9 @@
 # From e2a.dev — settings → API keys
 E2A_API_KEY=e2a_...
 
-# From e2a.dev — settings → HMAC secret. Used to verify inbound webhooks.
+# From e2a.dev — Settings → Webhook signing secrets → "Create".
+# Copy it the moment it's shown; it isn't retrievable later. Used by
+# client.parse_webhook() to verify inbound HMAC signatures.
 E2A_HMAC_SECRET=
 
 # From https://aistudio.google.com/apikey

--- a/examples/adk-cloud-webhook/README.md
+++ b/examples/adk-cloud-webhook/README.md
@@ -14,7 +14,7 @@ e2a relay
     v  HTTPS POST /webhook (signed)
 this app
     |
-    +-- verify HMAC
+    +-- parse_webhook (parse + verify HMAC)
     +-- look up / create ADK session keyed by conversation_id
     +-- runner.run_async(...)
     +-- email.reply(text, conversation_id=...)
@@ -28,9 +28,10 @@ e2a relay -> SMTP -> human
 - Python 3.10+
 - An e2a account with a registered **cloud-mode** agent. Sign up at
   [e2a.dev](https://e2a.dev), create an agent, set its mode to `cloud`.
-  You'll need its **API key**, the **HMAC secret** for the deployment
-  (settings page), and a public webhook URL (see "Exposing the webhook"
-  below).
+  You'll need its **API key**, an **HMAC signing secret** (create one in
+  Settings → Webhook signing secrets — copy it the moment it's shown,
+  it's not retrievable later), and a public webhook URL (see "Exposing
+  the webhook" below).
 - A Google AI Studio API key for Gemini —
   [aistudio.google.com/apikey](https://aistudio.google.com/apikey).
 

--- a/examples/adk-cloud-webhook/webhook.py
+++ b/examples/adk-cloud-webhook/webhook.py
@@ -5,7 +5,7 @@ Pipeline per request:
     POST /webhook (raw e2a payload)
         |
         v
-    parse + verify HMAC          <-- reject unsigned/replayed payloads
+    parse_webhook (parse + verify HMAC)  <-- rejects unsigned/replayed payloads
         |
         v
     map (sender, conversation_id) -> ADK (user_id, session_id)
@@ -55,9 +55,11 @@ def _require_env(name: str) -> str:
     return val
 
 
-HMAC_SECRET = _require_env("E2A_HMAC_SECRET")
-# E2A_API_KEY is consumed implicitly by E2AClient on construction.
+# Both E2A_API_KEY (for E2AClient) and E2A_HMAC_SECRET (for parse_webhook)
+# are consumed implicitly by the SDK. We just assert presence here so a
+# missing secret fails fast at startup rather than on the first request.
 _require_env("E2A_API_KEY")
+_require_env("E2A_HMAC_SECRET")
 _require_env("GOOGLE_API_KEY")
 
 
@@ -83,11 +85,13 @@ async def health() -> dict[str, str]:
 @app.post("/webhook")
 async def webhook(request: Request) -> dict[str, str]:
     body = await request.body()
-    email: InboundEmail = request.app.state.e2a.parse(body)
-
-    if not email.verify_signature(HMAC_SECRET):
-        # Reject unverified payloads. Anyone can reach a public webhook URL;
-        # the HMAC is what proves the payload came from your e2a relay.
+    # parse_webhook does parse + HMAC-verify in one call. Reads
+    # E2A_HMAC_SECRET from the env, raises PermissionError on bad signature.
+    # Anyone can reach a public webhook URL; this is what proves the payload
+    # came from your e2a relay.
+    try:
+        email: InboundEmail = request.app.state.e2a.parse_webhook(body)
+    except PermissionError:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="bad signature")
 
     # First contact has no conversation_id — mint one so this thread has an
@@ -98,11 +102,12 @@ async def webhook(request: Request) -> dict[str, str]:
     # user_id scopes a session to a particular human counterpart. Different
     # senders get isolated session histories even on the same agent.
     #
-    # Safety note: email.sender is only trustworthy *because* the HMAC check
-    # above passed — that signature binds to the sender claim e2a verified
-    # via SPF/DKIM. If you ever move this assignment above the verify call,
-    # you re-introduce a session-poisoning vector (any unauthenticated POST
-    # could claim to be any sender and read/write that user's session).
+    # Safety note: email.sender is only trustworthy *because* parse_webhook
+    # verified the HMAC — that signature binds to the sender claim e2a
+    # verified via SPF/DKIM. The SDK enforces this by raising
+    # UnverifiedEmailError on field access until verification succeeds, so
+    # accidentally swapping in client.parse(body) here would surface as a
+    # runtime error rather than a silent session-poisoning vector.
     user_id = email.sender
 
     sessions = request.app.state.sessions

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -38,15 +38,20 @@ client = E2AClient()
 
 Mount the webhook in your web framework:
 
+Webhook payloads are HMAC-signed. The SDK gates field access behind verification — accessing `email.sender`, `email.subject`, etc. on an unverified payload raises `UnverifiedEmailError`. Use `client.parse_webhook(...)` to parse + verify in one call:
+
 **FastAPI:**
 ```python
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, HTTPException
 
 app = FastAPI()
 
 @app.post("/webhook")
 async def webhook(request: Request):
-    email = client.parse(await request.body())
+    try:
+        email = client.parse_webhook(await request.body())  # reads E2A_HMAC_SECRET
+    except PermissionError:
+        raise HTTPException(401, "bad signature")
     print(f"From: {email.sender}, Subject: {email.subject}")
     email.reply("Thanks for reaching out!")
     return {"ok": True}
@@ -54,16 +59,21 @@ async def webhook(request: Request):
 
 **Flask:**
 ```python
-from flask import Flask, request
+from flask import Flask, request, abort
 
 app = Flask(__name__)
 
 @app.post("/webhook")
 def webhook():
-    email = client.parse(request.get_data())
+    try:
+        email = client.parse_webhook(request.get_data())
+    except PermissionError:
+        abort(401)
     email.reply("Thanks for reaching out!")
     return {"ok": True}
 ```
+
+Get a signing secret from the dashboard's Settings → Webhook signing secrets (or `POST /api/v1/users/me/signing-secrets`). Set it as `E2A_HMAC_SECRET` so `parse_webhook` picks it up automatically, or pass it explicitly: `client.parse_webhook(body, secret="whsec_...")`.
 
 ## Raw vs high-level API
 
@@ -98,7 +108,7 @@ whether the other side is a human replying from Gmail or another e2a agent.
 ```python
 @app.post("/webhook")
 async def webhook(request: Request):
-    email = client.parse(await request.body())
+    email = client.parse_webhook(await request.body())
 
     if email.conversation_id:
         # Follow-up — route to the existing conversation
@@ -186,7 +196,7 @@ Inbound email attachments are automatically parsed and available on
 `email.attachments`:
 
 ```python
-email = client.parse(body)
+email = client.parse_webhook(body)
 for att in email.attachments:
     print(f"{att.filename} ({att.content_type}, {att.size} bytes)")
     save_file(att.filename, att.data)
@@ -239,7 +249,7 @@ client = AsyncE2AClient()  # reads E2A_API_KEY from env
 
 @app.post("/webhook")
 async def webhook(request: Request):
-    email = client.parse(await request.body())
+    email = await client.parse_webhook(await request.body())
     await email.reply("Thanks!", conversation_id="conv_123")
     return {"ok": True}
 ```
@@ -359,9 +369,13 @@ print(result.status, result.message_id)
 | `auth` | `AuthHeaders` | Full authentication details |
 | `raw_message` | `bytes` | Raw RFC 2822 email bytes |
 
+All claim fields (`message_id`, `sender`, `recipient`, `to`, `cc`, `subject`, `text_body`, `html_body`, `attachments`, `conversation_id`, `received_at`) are gated — accessing them on an unverified webhook payload raises `UnverifiedEmailError`. Always-available regardless of verification: `auth`, `raw_message`, `is_verified`, `verified`, `unverified_payload`. Emails returned by `client.get_message(...)` and `client.list_messages(...)` are pre-verified (the bearer token already authenticated the channel).
+
 **Methods:**
 
+- `email.verify_signature(secret=None)` → `bool` — verifies the HMAC; falls back to `E2A_HMAC_SECRET`. Sets the verified flag on success so claim fields become accessible.
 - `email.reply(body, html_body=None, conversation_id=None, attachments=None)` → `SendResult`
+- `email.unverified_payload` — escape hatch for inspection (debugging, logging) without verifying. Treat as untrusted.
 
 ## API Reference
 
@@ -369,8 +383,9 @@ print(result.status, result.message_id)
 
 High-level sync client. `api_key` falls back to `E2A_API_KEY` env var.
 
-- `client.parse(body)` → `InboundEmail` — accepts bytes, str, dict, or `MessageDetail`
-- `client.get_message(message_id)` → `InboundEmail`
+- `client.parse_webhook(body, secret=None)` → `InboundEmail` — parse + HMAC-verify (recommended for webhook handlers). Reads `E2A_HMAC_SECRET` if no secret is passed; raises `PermissionError` on bad signature.
+- `client.parse(body)` → `InboundEmail` — accepts bytes, str, dict, or `MessageDetail`. Returns *unverified* — claim fields raise `UnverifiedEmailError` until `email.verify_signature()` succeeds.
+- `client.get_message(message_id)` → `InboundEmail` — pre-verified (REST channel auth)
 - `client.get_messages(status="unread", page_size=50)` → `MessageList`
 - `client.reply(message_id, body, ...)` → `SendResult`
 - `client.send(to, subject, body, ...)` → `SendResult`
@@ -393,6 +408,8 @@ Same as `E2AClient` — all I/O methods are `async`. `parse()` is sync (no I/O n
 ### Exceptions
 
 - `E2AApiError` — API error (has `status_code` and `message`)
+- `UnverifiedEmailError` — raised on `InboundEmail` claim-field access before `verify_signature()` has succeeded
+- `PermissionError` — raised by `parse_webhook` on bad signature
 
 ## License
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -12,18 +12,27 @@ npm install @e2a/sdk
 
 ### Webhook (cloud agents)
 
+Webhook payloads are HMAC-signed. The SDK gates field access behind verification — accessing `email.sender`, `email.subject`, etc. on an unverified payload throws `UnverifiedEmailError`. Use `client.parseWebhook(...)` to parse + verify in one call:
+
 ```typescript
 import { E2AClient } from "@e2a/sdk";
 
 const client = new E2AClient(); // uses E2A_API_KEY env var
 
 app.post("/webhook", async (req, res) => {
-  const email = await client.parse(req.body);
+  let email;
+  try {
+    email = await client.parseWebhook(req.body); // reads E2A_HMAC_SECRET
+  } catch {
+    return res.status(401).end();
+  }
   console.log(`From: ${email.sender}, Subject: ${email.subject}`);
   await email.reply("Got it!");
   res.json({ ok: true });
 });
 ```
+
+Get a signing secret from the dashboard's Settings → Webhook signing secrets (or `POST /api/v1/users/me/signing-secrets`). Set it as `E2A_HMAC_SECRET` so `parseWebhook` picks it up automatically, or pass it explicitly: `client.parseWebhook(body, "whsec_...")`.
 
 ### Polling
 
@@ -70,9 +79,13 @@ await client.send(["alice@example.com", "bob@example.com"], "Hello", "Hi!", {
 | `baseUrl`   | `string` | `https://e2a.dev`      | API base URL                   |
 | `timeout`   | `number` | `30000`                | Request timeout in ms          |
 
+### `client.parseWebhook(body, secret?)` → `Promise<InboundEmail>`
+
+Parse + HMAC-verify a webhook payload in one call. Reads `E2A_HMAC_SECRET` if `secret` is omitted; throws on bad signature. Recommended entry point for webhook handlers.
+
 ### `client.parse(body)` → `Promise<InboundEmail>`
 
-Parse a webhook payload (Buffer, string, or object) into an `InboundEmail`.
+Parse a webhook payload (Buffer, string, or object) into an `InboundEmail`. Returns *unverified* — accessing claim fields like `sender` or `subject` throws `UnverifiedEmailError` until `email.verifySignature()` succeeds. Prefer `parseWebhook` unless you need to inspect the payload before verifying.
 
 ### `client.getMessages(opts?)` → `Promise<MessageList>`
 
@@ -80,7 +93,7 @@ Fetch messages. Options: `status` ("unread", "read", "all"), `pageSize`, `token`
 
 ### `client.getMessage(messageId)` → `Promise<InboundEmail>`
 
-Fetch a single message with full content.
+Fetch a single message with full content. Returns a pre-verified email (the bearer token already authenticated the channel) — no `verifySignature` step needed.
 
 ### `client.reply(messageId, body, opts?)` → `Promise<SendResult>`
 
@@ -107,6 +120,10 @@ Send a new email. `to` is `string[]`. Options: `htmlBody`, `cc`, `bcc`, `convers
 | `auth`          | `AuthHeaders`     | Authentication headers             |
 | `isVerified`    | `boolean`         | Whether sender identity is verified|
 | `reply(body)`   | method            | Reply to this email                |
+
+All claim fields above (everything except `auth`, `rawMessage`, `verified`, `isVerified`, `unverifiedPayload`) are gated — accessing them on an unverified webhook payload throws `UnverifiedEmailError`. Call `email.verifySignature(secret?)` first (reads `E2A_HMAC_SECRET` by default), or use `client.parseWebhook(body)` which combines parse + verify. `email.unverifiedPayload` is an escape hatch for inspection before verifying — treat its contents as untrusted.
+
+Exported error class: `UnverifiedEmailError extends Error`.
 
 ## Conversation threading
 

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -1,6 +1,6 @@
 # Email Skill
 
-<!-- version: 5 -->
+<!-- version: 6 -->
 
 You can give yourself an email address and use it to check your inbox, read, reply to, and send emails.
 
@@ -11,7 +11,7 @@ Email is powered by [e2a](https://e2a.dev) — email for AI agents.
 ```bash
 _E2A_STATE="$HOME/.e2a/skill"
 _E2A_CHECK="$_E2A_STATE/last-check"
-_E2A_LOCAL=5
+_E2A_LOCAL=6
 _E2A_NOW=$(date +%s)
 _E2A_SKIP=0
 if [ -f "$_E2A_CHECK" ]; then
@@ -122,7 +122,11 @@ If the user wants to receive emails on a cloud-hosted agent via webhook:
 
 Go to https://e2a.dev and register a new agent in "Cloud" mode. Enter your webhook URL (must be HTTPS).
 
-### 2. Implement the webhook endpoint
+### 2. Create a signing secret
+
+In the dashboard's Settings → Webhook signing secrets, create one and copy it (shown once). Set it as `E2A_HMAC_SECRET` in your webhook environment so the SDK can verify inbound payloads automatically.
+
+### 3. Implement the webhook endpoint
 
 #### Python
 
@@ -136,7 +140,7 @@ Example webhook handler using FastAPI:
 
 ```python
 import e2a
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, HTTPException, Request
 
 app = FastAPI()
 
@@ -148,7 +152,13 @@ client = e2a.E2AClient(api_key="e2a_...")  # or set E2A_API_KEY env var
 
 @app.post("/webhook")
 async def webhook(request: Request):
-    email = client.parse(await request.body())
+    # parse_webhook does parse + HMAC-verify in one call.
+    # Reads E2A_HMAC_SECRET from the env automatically.
+    try:
+        email = client.parse_webhook(await request.body())
+    except PermissionError:
+        raise HTTPException(401, "bad signature")
+
     print(f"From: {email.sender}")
     print(f"Subject: {email.subject}")
     print(f"Body: {email.text_body}")
@@ -181,7 +191,15 @@ app.use(express.json());
 const client = new E2AClient({ apiKey: process.env.E2A_API_KEY! });
 
 app.post("/webhook", async (req, res) => {
-  const email = await client.parse(req.body);
+  // parseWebhook does parse + HMAC-verify in one call.
+  // Reads E2A_HMAC_SECRET from the env automatically.
+  let email;
+  try {
+    email = await client.parseWebhook(req.body);
+  } catch {
+    return res.status(401).end();
+  }
+
   console.log(`From: ${email.sender}`);
   console.log(`Subject: ${email.subject}`);
   console.log(`Body: ${email.textBody}`);
@@ -215,9 +233,9 @@ The webhook receives a JSON payload with these fields:
 }
 ```
 
-`to` and `cc` are the parsed `To:` / `Cc:` headers from the original message; `recipient` is this delivery's per-agent target. `client.parse()` handles decoding the raw message and gives you `email.subject`, `email.text_body`, `email.html_body`, `email.attachments`, `email.to`, `email.cc`, and `email.reply()`.
+`to` and `cc` are the parsed `To:` / `Cc:` headers from the original message; `recipient` is this delivery's per-agent target. `client.parse_webhook()` handles HMAC verification and decoding, and gives you `email.subject`, `email.text_body`, `email.html_body`, `email.attachments`, `email.to`, `email.cc`, and `email.reply()`.
 
-Check `email.is_verified` to confirm the sender's identity was verified by e2a.
+The SDK gates field access behind verification — accessing `email.sender` etc. on an unverified payload raises `UnverifiedEmailError`. `parse_webhook` handles the verify step for you; `client.parse(...)` returns an unverified email, and you must call `email.verify_signature()` before reading claim fields. Check `email.is_verified` if you want to confirm the sender's identity was verified by e2a.
 
 For full SDK documentation, see https://e2a.dev/python-sdk.
 
@@ -256,7 +274,7 @@ The `--agent` flag is optional if `agent_email` is set in your config.
 ## Reference
 
 - Config file: `~/.e2a/config.json` (JSON with `api_key`, `api_url`, `agent_email`, `shared_domain`)
-- Environment variables that override config: `E2A_API_KEY`, `E2A_URL`, `E2A_SHARED_DOMAIN` (CLI). `E2A_AGENT_EMAIL` is honored by the Python/TS SDK constructors when you don't pass `agent_email` explicitly.
+- Environment variables that override config: `E2A_API_KEY`, `E2A_URL`, `E2A_SHARED_DOMAIN` (CLI). `E2A_AGENT_EMAIL` is honored by the Python/TS SDK constructors when you don't pass `agent_email` explicitly. `E2A_HMAC_SECRET` is read by `client.parse_webhook` / `client.parseWebhook` and `email.verify_signature()` / `email.verifySignature()` to verify inbound webhook signatures.
 - CLI docs: https://www.npmjs.com/package/@e2a/cli
 - TypeScript SDK: https://www.npmjs.com/package/@e2a/sdk
 - Python SDK: https://e2a.dev/python-sdk


### PR DESCRIPTION
## Summary

Now that SDKs are at 2.0 with the strict-verify gate (#57), update every webhook example across the docs to use the new patterns:

- **README, both SDK READMEs, SKILL.md, ADK example** — all switched from `client.parse(body)` → `client.parse_webhook(body)` / `client.parseWebhook(body)`. The new shortcut handles parse + verify in one call and reads `E2A_HMAC_SECRET` from the env automatically.
- Documented the `UnverifiedEmailError` gate, the `unverified_payload` escape hatch, and that REST-fetched emails (`get_message`, `list_messages`) are pre-verified.
- Pointed users at the dashboard's Settings → Webhook signing secrets (the per-user CRUD shipped in #55/#56) for getting a secret.
- Bumped `skills/SKILL.md` to version 6 so installed copies auto-prompt to update.
- Added the `/api/v1/users/me/signing-secrets` endpoints to `docs/api.md`.

## Test plan

- [x] All examples still parse syntactically (Python webhook + Markdown rendering)
- [ ] Spot-check rendered READMEs on GitHub once merged
- [ ] After merge, anyone with the SKILL installed will see the v6 update prompt on next session

🤖 Generated with [Claude Code](https://claude.com/claude-code)