### PR TITLE
docs: fix SDK 2.0 sweep regressions caught in post-merge review

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,8 +152,8 @@ The SDKs gate field access behind verification by default — accessing `email.s
 
 ```python
 from e2a.v1 import E2AClient
-client = E2AClient()
-email = client.parse_webhook(request_body)  # parse + verify, raises on bad signature
+client = E2AClient()  # reads E2A_API_KEY
+email = client.parse_webhook(request_body)  # reads E2A_HMAC_SECRET; raises on bad signature
 # safe to use email.sender, email.subject, …
 ```
 
@@ -164,7 +164,7 @@ const email = await client.parseWebhook(req.body); // throws on bad signature
 
 Both forms read the secret from `E2A_HMAC_SECRET` by default; pass it explicitly as a second argument if you keep it elsewhere. Under the hood the verify step checks, in order: body_hash matches the raw message bytes, HMAC matches the canonical auth string, and timestamp is within a 5-minute replay window.
 
-REST-fetched messages (`client.get_message(...)`, `client.list_messages(...)`) are pre-verified — the bearer token already authenticated the channel — so field access works directly without a verify step.
+Emails returned by `client.get_message(...)` are pre-verified — the bearer token already authenticated the channel — so field access works directly without a verify step. (Listing endpoints like `get_messages` / `listMessages` return lightweight summaries, not `InboundEmail`, so the gate doesn't apply.)
 
 ### Conversation threading
 
@@ -250,8 +250,9 @@ WebSocket (local agents):
 from e2a.v1 import AsyncE2AClient
 
 async with AsyncE2AClient(api_key="e2a_…") as client:
-    async for email in client.listen("bot@your-domain.com"):
-        print(email.sender, email.subject)
+    async for notif in client.listen("bot@your-domain.com"):
+        # notif is lightweight metadata — fetch the body when you want it
+        email = await client.get_message(notif.message_id)
         await email.reply("Got it!")
 ```
 
@@ -322,7 +323,7 @@ e2a doesn't replace webhooks — agents *receive* email via webhooks. It bridges
 
 The relay strips any incoming `X-E2A-Auth-*` from inbound messages and re-signs with HMAC-SHA256 against `signing.hmac_secret`. The signed canonical binds `Sender + Verified + Body-Hash + Message-Id` together — replay attempts, body swaps, and sender-only forgery all fail validation. Each delivery is bound to *that specific message body*, not just the sender claim, so a captured `(headers, signature)` tuple can't be lifted onto a different message.
 
-Receivers verify with the SDK's `verify(headers, secret)` helper (TS and Python both ship one) — no API call back to e2a needed. If the HMAC secret leaks, rotate it and old signatures stop verifying. If it's *stolen from the relay*, the attacker has bigger access than headers anyway.
+Receivers verify with the SDK — `client.parse_webhook(body)` / `client.parseWebhook(body)` does parse + HMAC verify in one call (or `email.verify_signature(secret)` if you parsed first). No API call back to e2a needed. If a signing secret leaks, rotate it via the dashboard and old signatures stop verifying. If it's *stolen from the relay*, the attacker has bigger access than headers anyway.
 
 ### Isn't this just SMTP with extra steps?
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -57,9 +57,9 @@ Per-user HMAC secrets used to sign inbound webhook payloads. Up to 5 active per 
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET` | `/users/me/signing-secrets` | List the user's signing secrets (id, name, prefix, created_at, last_signed_at). |
-| `POST` | `/users/me/signing-secrets` | Create a new signing secret. Returns the plaintext exactly once — store it immediately. Body: `{"name": "..."}`. |
-| `DELETE` | `/users/me/signing-secrets/{id}` | Delete a signing secret. Cannot delete the last one (returns 409); rotate by creating a new one first, switching consumers over, then deleting the old one. |
+| `GET` | `/users/me/signing-secrets` | List the user's signing secrets (`id`, `name`, `secret_prefix`, `created_at`, `last_signed_at`). |
+| `POST` | `/users/me/signing-secrets` | Create a new signing secret. Returns the plaintext exactly once (in the `secret` field) — store it immediately. Body: `{"name": "..."}`. Returns `400` if the user already has 5 secrets. |
+| `DELETE` | `/users/me/signing-secrets/{id}` | Delete a signing secret. Returns `400` if it's the user's last remaining secret; rotate by creating a new one first, switching consumers over, then deleting the old one. |
 
 The SDKs read the secret from `E2A_HMAC_SECRET` by default — `client.parse_webhook(body)` / `client.parseWebhook(body)` does parse + verify in one call. See [sdks/python/README.md](../sdks/python/README.md#quick-start) and [sdks/typescript/README.md](../sdks/typescript/README.md#webhook-cloud-agents).
 

--- a/examples/adk-cloud-webhook/README.md
+++ b/examples/adk-cloud-webhook/README.md
@@ -108,7 +108,7 @@ This is the entire trick. The webhook is ~30 lines of business logic;
 ADK does the actual memory work, e2a does the actual email work.
 
 See [webhook.py](webhook.py) for the implementation, including
-[HMAC signature verification](https://github.com/Mnexa-AI/e2a/blob/main/sdks/python/README.md)
+[HMAC signature verification](https://github.com/Mnexa-AI/e2a/blob/main/sdks/python/README.md#quick-start)
 which you should *always* do on a public webhook before trusting any
 field on the parsed payload.
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -14,6 +14,17 @@ For WebSocket real-time delivery:
 pip install e2a[ws]
 ```
 
+## Upgrading from 1.x to 2.0
+
+Webhook-parsed emails now refuse to expose claim fields (`sender`, `subject`, `text_body`, …) until the HMAC signature is verified — `email.sender` raises `UnverifiedEmailError` instead of silently returning attacker-controllable data. The one-line fix is to switch `client.parse(body)` → `client.parse_webhook(body)`:
+
+```diff
+- email = client.parse(await request.body())
++ email = client.parse_webhook(await request.body())
+```
+
+`parse_webhook` reads the secret from `E2A_HMAC_SECRET`; set it before upgrading. If you must inspect the payload before verifying, use `email.unverified_payload`. REST-fetched emails (`client.get_message`) are unaffected — they're pre-verified via the bearer token. Full background in the [PR](https://github.com/Mnexa-AI/e2a/pull/57).
+
 ## Import paths
 
 The stable, pinned API surface lives under `e2a.v1`:
@@ -52,6 +63,8 @@ async def webhook(request: Request):
         email = client.parse_webhook(await request.body())  # reads E2A_HMAC_SECRET
     except PermissionError:
         raise HTTPException(401, "bad signature")
+    # ValueError is raised if no secret is configured — let it 500 so a misconfig
+    # surfaces loudly, or catch it here to return a clearer message.
     print(f"From: {email.sender}, Subject: {email.subject}")
     email.reply("Thanks for reaching out!")
     return {"ok": True}
@@ -369,7 +382,7 @@ print(result.status, result.message_id)
 | `auth` | `AuthHeaders` | Full authentication details |
 | `raw_message` | `bytes` | Raw RFC 2822 email bytes |
 
-All claim fields (`message_id`, `sender`, `recipient`, `to`, `cc`, `subject`, `text_body`, `html_body`, `attachments`, `conversation_id`, `received_at`) are gated — accessing them on an unverified webhook payload raises `UnverifiedEmailError`. Always-available regardless of verification: `auth`, `raw_message`, `is_verified`, `verified`, `unverified_payload`. Emails returned by `client.get_message(...)` and `client.list_messages(...)` are pre-verified (the bearer token already authenticated the channel).
+All claim fields (`message_id`, `sender`, `recipient`, `to`, `cc`, `subject`, `text_body`, `html_body`, `attachments`, `conversation_id`, `received_at`) are gated — accessing them on an unverified webhook payload raises `UnverifiedEmailError`. Always-available regardless of verification: `auth`, `raw_message`, `is_verified`, `verified`, `unverified_payload`. Emails returned by `client.get_message(...)` are pre-verified (the bearer token already authenticated the channel). `client.get_messages(...)` returns lightweight `MessageSummary` items, not `InboundEmail`, so the gate doesn't apply.
 
 **Methods:**
 
@@ -403,7 +416,7 @@ Same as `E2AClient` — all I/O methods are `async`. `parse()` is sync (no I/O n
 - `InboundEmail` / `AsyncInboundEmail` — parsed email with `.reply()`
 - `Attachment` — `filename`, `content_type`, `data` (bytes), `size`
 - `SendResult` — `status`, `message_id`, `method`
-- `AuthHeaders` — `verified`, `sender`, `entity_type`, `domain_check`, `delegation`, `signature`, `timestamp`
+- `AuthHeaders` — `verified`, `sender`, `entity_type`, `domain_check`, `delegation`, `signature`, `timestamp`, `message_id`, `body_hash`
 
 ### Exceptions
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -8,6 +8,17 @@ TypeScript/Node.js SDK for [e2a](https://e2a.dev) — email for AI agents.
 npm install @e2a/sdk
 ```
 
+## Upgrading from 1.x to 2.0
+
+Webhook-parsed emails now refuse to expose claim fields (`sender`, `subject`, `textBody`, …) until the HMAC signature is verified — `email.sender` throws `UnverifiedEmailError` instead of silently returning attacker-controllable data. The one-line fix is to switch `client.parse(body)` → `client.parseWebhook(body)`:
+
+```diff
+- const email = await client.parse(req.body);
++ const email = await client.parseWebhook(req.body);
+```
+
+`parseWebhook` reads the secret from `E2A_HMAC_SECRET`; set it before upgrading. If you must inspect the payload before verifying, use `email.unverifiedPayload`. REST-fetched emails (`client.getMessage`) are unaffected — they're pre-verified via the bearer token. Full background in the [PR](https://github.com/Mnexa-AI/e2a/pull/57).
+
 ## Quick Start
 
 ### Webhook (cloud agents)
@@ -119,6 +130,7 @@ Send a new email. `to` is `string[]`. Options: `htmlBody`, `cc`, `bcc`, `convers
 | `attachments`   | `Attachment[]`    | File attachments                   |
 | `auth`          | `AuthHeaders`     | Authentication headers             |
 | `isVerified`    | `boolean`         | Whether sender identity is verified|
+| `unverifiedPayload` | `WebhookPayload` | Raw payload pre-verification — escape hatch for inspection; treat as untrusted |
 | `reply(body)`   | method            | Reply to this email                |
 
 All claim fields above (everything except `auth`, `rawMessage`, `verified`, `isVerified`, `unverifiedPayload`) are gated — accessing them on an unverified webhook payload throws `UnverifiedEmailError`. Call `email.verifySignature(secret?)` first (reads `E2A_HMAC_SECRET` by default), or use `client.parseWebhook(body)` which combines parse + verify. `email.unverifiedPayload` is an escape hatch for inspection before verifying — treat its contents as untrusted.

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -1,6 +1,6 @@
 # Email Skill
 
-<!-- version: 6 -->
+<!-- version: 7 -->
 
 You can give yourself an email address and use it to check your inbox, read, reply to, and send emails.
 
@@ -11,7 +11,7 @@ Email is powered by [e2a](https://e2a.dev) — email for AI agents.
 ```bash
 _E2A_STATE="$HOME/.e2a/skill"
 _E2A_CHECK="$_E2A_STATE/last-check"
-_E2A_LOCAL=6
+_E2A_LOCAL=7
 _E2A_NOW=$(date +%s)
 _E2A_SKIP=0
 if [ -f "$_E2A_CHECK" ]; then
@@ -153,7 +153,8 @@ client = e2a.E2AClient(api_key="e2a_...")  # or set E2A_API_KEY env var
 @app.post("/webhook")
 async def webhook(request: Request):
     # parse_webhook does parse + HMAC-verify in one call.
-    # Reads E2A_HMAC_SECRET from the env automatically.
+    # Reads E2A_HMAC_SECRET from the env automatically — make sure that's
+    # set or you'll get a ValueError on the first request.
     try:
         email = client.parse_webhook(await request.body())
     except PermissionError:
@@ -186,9 +187,11 @@ import express from "express";
 const app = express();
 app.use(express.json());
 
-// Webhook mode: agent_email is optional — it auto-resolves from the payload.
-// E2AClient requires apiKey explicitly; pass it from env or config.
+// Webhook mode: agentEmail is optional — it auto-resolves from email.recipient.
 const client = new E2AClient({ apiKey: process.env.E2A_API_KEY! });
+
+// For single-agent setups, you can also set it explicitly:
+// const client = new E2AClient({ apiKey: process.env.E2A_API_KEY!, agentEmail: "bot@agents.e2a.dev" });
 
 app.post("/webhook", async (req, res) => {
   // parseWebhook does parse + HMAC-verify in one call.


### PR DESCRIPTION
## Summary

Post-merge review of #57 and #58 surfaced several doc/code drift issues. Fixes for all of them in one batch.

**Critical (wrong/broken information that would mislead users):**
- `README.md` WebSocket Python example was still iterating `email` directly — broken since #52 made `listen()` yield `WSNotification` metadata. Switched to the documented `notif → client.get_message(...)` pattern.
- `README.md` FAQ referenced a non-existent SDK helper `verify(headers, secret)`. Pointed at `parse_webhook` / `verify_signature` instead.
- `README.md` and `sdks/python/README.md` claimed `list_messages` returned pre-verified `InboundEmail` objects — wrong on both counts (the method is `get_messages` and it returns lightweight `MessageSummary`, not `InboundEmail`).
- `docs/api.md` signing-secrets table had two factual errors: status code (`409` → `400`) and JSON field name (`prefix` → `secret_prefix`).

**Should-fix:**
- Added a "Upgrading from 1.x to 2.0" section to both SDK READMEs with the one-line `parse` → `parse_webhook` migration. A breaking-major bump deserves at least a paragraph of upgrade guidance.
- Noted `ValueError` (raised when no HMAC secret is set) in the FastAPI example so misconfig fails loudly.
- `sdks/python/README.md` `AuthHeaders` was missing two real fields (`message_id`, `body_hash`).

**Nice-to-have:**
- `unverifiedPayload` row added to the TS `InboundEmail` property table (was described in prose but missing from the table).
- Anchored the ADK README's verify link to `#quick-start` so it lands on the section, not the README root.
- Noted `E2A_API_KEY` env auto-read in the README's verify snippet.

## Test plan
- [x] All affected files render in the IDE preview
- [x] Spot-checked claims against actual SDK code and the Go signing-secrets handler
- [ ] Confirm rendered links resolve on GitHub after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)