### PR TITLE
feat(sdks): 2.1 — rename E2A_HMAC_SECRET to E2A_WEBHOOK_SECRET

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The SDKs gate field access behind verification by default — accessing `email.s
 ```python
 from e2a.v1 import E2AClient
 client = E2AClient()  # reads E2A_API_KEY
-email = client.parse_webhook(request_body)  # reads E2A_HMAC_SECRET; raises on bad signature
+email = client.parse_webhook(request_body)  # reads E2A_WEBHOOK_SECRET; raises on bad signature
 # safe to use email.sender, email.subject, …
 ```
 
@@ -162,7 +162,7 @@ import { E2AClient } from "@e2a/sdk";
 const email = await client.parseWebhook(req.body); // throws on bad signature
 ```
 
-Both forms read the secret from `E2A_HMAC_SECRET` by default; pass it explicitly as a second argument if you keep it elsewhere. Under the hood the verify step checks, in order: body_hash matches the raw message bytes, HMAC matches the canonical auth string, and timestamp is within a 5-minute replay window.
+Both forms read the secret from `E2A_WEBHOOK_SECRET` by default; pass it explicitly as a second argument if you keep it elsewhere. Under the hood the verify step checks, in order: body_hash matches the raw message bytes, HMAC matches the canonical auth string, and timestamp is within a 5-minute replay window.
 
 Emails returned by `client.get_message(...)` are pre-verified — the bearer token already authenticated the channel — so field access works directly without a verify step. (Listing endpoints like `get_messages` / `listMessages` return lightweight summaries, not `InboundEmail`, so the gate doesn't apply.)
 
@@ -239,7 +239,7 @@ pip install 'e2a[ws]'      # adds WebSocket support
 from e2a.v1 import E2AClient
 
 client = E2AClient()                          # reads E2A_API_KEY
-email = client.parse_webhook(request_body)    # parse + HMAC-verify (reads E2A_HMAC_SECRET)
+email = client.parse_webhook(request_body)    # parse + HMAC-verify (reads E2A_WEBHOOK_SECRET)
 print(email.sender, email.subject)
 email.reply("Got it!", conversation_id="conv_123")
 ```

--- a/docs/api.md
+++ b/docs/api.md
@@ -61,7 +61,7 @@ Per-user HMAC secrets used to sign inbound webhook payloads. Up to 5 active per 
 | `POST` | `/users/me/signing-secrets` | Create a new signing secret. Returns the plaintext exactly once (in the `secret` field) — store it immediately. Body: `{"name": "..."}`. Returns `400` if the user already has 5 secrets. |
 | `DELETE` | `/users/me/signing-secrets/{id}` | Delete a signing secret. Returns `400` if it's the user's last remaining secret; rotate by creating a new one first, switching consumers over, then deleting the old one. |
 
-The SDKs read the secret from `E2A_HMAC_SECRET` by default — `client.parse_webhook(body)` / `client.parseWebhook(body)` does parse + verify in one call. See [sdks/python/README.md](../sdks/python/README.md#quick-start) and [sdks/typescript/README.md](../sdks/typescript/README.md#webhook-cloud-agents).
+The SDKs read the secret from `E2A_WEBHOOK_SECRET` by default (with `E2A_HMAC_SECRET` accepted as a deprecated alias for SDK 2.0 users) — `client.parse_webhook(body)` / `client.parseWebhook(body)` does parse + verify in one call. See [sdks/python/README.md](../sdks/python/README.md#quick-start) and [sdks/typescript/README.md](../sdks/typescript/README.md#webhook-cloud-agents).
 
 ## HITL magic links
 

--- a/examples/adk-cloud-webhook/.env.example
+++ b/examples/adk-cloud-webhook/.env.example
@@ -4,7 +4,7 @@ E2A_API_KEY=e2a_...
 # From e2a.dev — Settings → Webhook signing secrets → "Create".
 # Copy it the moment it's shown; it isn't retrievable later. Used by
 # client.parse_webhook() to verify inbound HMAC signatures.
-E2A_HMAC_SECRET=
+E2A_WEBHOOK_SECRET=
 
 # From https://aistudio.google.com/apikey
 GOOGLE_API_KEY=

--- a/examples/adk-cloud-webhook/webhook.py
+++ b/examples/adk-cloud-webhook/webhook.py
@@ -55,11 +55,11 @@ def _require_env(name: str) -> str:
     return val
 
 
-# Both E2A_API_KEY (for E2AClient) and E2A_HMAC_SECRET (for parse_webhook)
+# Both E2A_API_KEY (for E2AClient) and E2A_WEBHOOK_SECRET (for parse_webhook)
 # are consumed implicitly by the SDK. We just assert presence here so a
 # missing secret fails fast at startup rather than on the first request.
 _require_env("E2A_API_KEY")
-_require_env("E2A_HMAC_SECRET")
+_require_env("E2A_WEBHOOK_SECRET")
 _require_env("GOOGLE_API_KEY")
 
 
@@ -86,7 +86,7 @@ async def health() -> dict[str, str]:
 async def webhook(request: Request) -> dict[str, str]:
     body = await request.body()
     # parse_webhook does parse + HMAC-verify in one call. Reads
-    # E2A_HMAC_SECRET from the env, raises PermissionError on bad signature.
+    # E2A_WEBHOOK_SECRET from the env, raises PermissionError on bad signature.
     # Anyone can reach a public webhook URL; this is what proves the payload
     # came from your e2a relay.
     try:

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -23,7 +23,7 @@ Webhook-parsed emails now refuse to expose claim fields (`sender`, `subject`, `t
 + email = client.parse_webhook(await request.body())
 ```
 
-`parse_webhook` reads the secret from `E2A_HMAC_SECRET`; set it before upgrading. If you must inspect the payload before verifying, use `email.unverified_payload`. REST-fetched emails (`client.get_message`) are unaffected — they're pre-verified via the bearer token. Full background in the [PR](https://github.com/Mnexa-AI/e2a/pull/57).
+`parse_webhook` reads the secret from `E2A_WEBHOOK_SECRET`; set it before upgrading. If you must inspect the payload before verifying, use `email.unverified_payload`. REST-fetched emails (`client.get_message`) are unaffected — they're pre-verified via the bearer token. Full background in the [PR](https://github.com/Mnexa-AI/e2a/pull/57).
 
 ## Import paths
 
@@ -60,7 +60,7 @@ app = FastAPI()
 @app.post("/webhook")
 async def webhook(request: Request):
     try:
-        email = client.parse_webhook(await request.body())  # reads E2A_HMAC_SECRET
+        email = client.parse_webhook(await request.body())  # reads E2A_WEBHOOK_SECRET
     except PermissionError:
         raise HTTPException(401, "bad signature")
     # ValueError is raised if no secret is configured — let it 500 so a misconfig
@@ -86,7 +86,7 @@ def webhook():
     return {"ok": True}
 ```
 
-Get a signing secret from the dashboard's Settings → Webhook signing secrets (or `POST /api/v1/users/me/signing-secrets`). Set it as `E2A_HMAC_SECRET` so `parse_webhook` picks it up automatically, or pass it explicitly: `client.parse_webhook(body, secret="whsec_...")`.
+Get a signing secret from the dashboard's Settings → Webhook signing secrets (or `POST /api/v1/users/me/signing-secrets`). Set it as `E2A_WEBHOOK_SECRET` so `parse_webhook` picks it up automatically, or pass it explicitly: `client.parse_webhook(body, secret="whsec_...")`.
 
 ## Raw vs high-level API
 
@@ -386,7 +386,7 @@ All claim fields (`message_id`, `sender`, `recipient`, `to`, `cc`, `subject`, `t
 
 **Methods:**
 
-- `email.verify_signature(secret=None)` → `bool` — verifies the HMAC; falls back to `E2A_HMAC_SECRET`. Sets the verified flag on success so claim fields become accessible.
+- `email.verify_signature(secret=None)` → `bool` — verifies the HMAC; falls back to `E2A_WEBHOOK_SECRET`. Sets the verified flag on success so claim fields become accessible.
 - `email.reply(body, html_body=None, conversation_id=None, attachments=None)` → `SendResult`
 - `email.unverified_payload` — escape hatch for inspection (debugging, logging) without verifying. Treat as untrusted.
 
@@ -396,7 +396,7 @@ All claim fields (`message_id`, `sender`, `recipient`, `to`, `cc`, `subject`, `t
 
 High-level sync client. `api_key` falls back to `E2A_API_KEY` env var.
 
-- `client.parse_webhook(body, secret=None)` → `InboundEmail` — parse + HMAC-verify (recommended for webhook handlers). Reads `E2A_HMAC_SECRET` if no secret is passed; raises `PermissionError` on bad signature.
+- `client.parse_webhook(body, secret=None)` → `InboundEmail` — parse + HMAC-verify (recommended for webhook handlers). Reads `E2A_WEBHOOK_SECRET` if no secret is passed; raises `PermissionError` on bad signature.
 - `client.parse(body)` → `InboundEmail` — accepts bytes, str, dict, or `MessageDetail`. Returns *unverified* — claim fields raise `UnverifiedEmailError` until `email.verify_signature()` succeeds.
 - `client.get_message(message_id)` → `InboundEmail` — pre-verified (REST channel auth)
 - `client.get_messages(status="unread", page_size=50)` → `MessageList`

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "e2a"
-version = "2.0.0"
+version = "2.1.0"
 description = "Python SDK for the e2a protocol — email-to-agent authentication"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdks/python/src/e2a/v1/client.py
+++ b/sdks/python/src/e2a/v1/client.py
@@ -123,8 +123,8 @@ class E2AClient:
         works. Raises :class:`PermissionError` on signature failure
         (so a webhook handler can let the exception bubble to a 401).
 
-        ``secret`` defaults to the ``E2A_HMAC_SECRET`` environment
-        variable.
+        ``secret`` defaults to the ``E2A_WEBHOOK_SECRET`` environment
+        variable (with ``E2A_HMAC_SECRET`` accepted as a deprecated alias).
         """
         email = self.parse(body)
         if not email.verify_signature(secret):

--- a/sdks/python/src/e2a/v1/handler.py
+++ b/sdks/python/src/e2a/v1/handler.py
@@ -131,6 +131,36 @@ def _verify_auth_headers(
     return hmac.compare_digest(h.signature, expected)
 
 
+_warned_legacy_env = False
+
+
+def _resolve_webhook_secret() -> str:
+    """Read the webhook signing secret from env, preferring the new name.
+
+    Order: ``E2A_WEBHOOK_SECRET`` (canonical) → ``E2A_HMAC_SECRET`` (legacy
+    alias, kept for backward compatibility with SDK 2.0). Emits a one-time
+    DeprecationWarning when only the legacy name is set so users notice
+    before the alias is removed in a future major release.
+    """
+    val = os.environ.get("E2A_WEBHOOK_SECRET", "")
+    if val:
+        return val
+    legacy = os.environ.get("E2A_HMAC_SECRET", "")
+    if legacy:
+        global _warned_legacy_env
+        if not _warned_legacy_env:
+            import warnings
+            warnings.warn(
+                "E2A_HMAC_SECRET is deprecated; rename it to E2A_WEBHOOK_SECRET. "
+                "The legacy name will be removed in a future major release.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            _warned_legacy_env = True
+        return legacy
+    return ""
+
+
 @dataclass
 class Attachment:
     """An email attachment."""
@@ -312,9 +342,9 @@ class InboundEmail:
         On success, transitions this instance to the "verified" state
         so subsequent property reads (sender, subject, body, …) work.
 
-        ``secret`` defaults to the ``E2A_HMAC_SECRET`` environment
-        variable when omitted, so the standard webhook-handler pattern
-        is just::
+        ``secret`` defaults to the ``E2A_WEBHOOK_SECRET`` environment
+        variable when omitted (with ``E2A_HMAC_SECRET`` accepted as a
+        deprecated alias), so the standard webhook-handler pattern is::
 
             email = client.parse(body)
             if not email.verify_signature():
@@ -336,11 +366,11 @@ class InboundEmail:
         a verify attempt that always fails.
         """
         if secret is None:
-            secret = os.environ.get("E2A_HMAC_SECRET", "")
+            secret = _resolve_webhook_secret()
         if not secret:
             raise ValueError(
                 "verify_signature requires a secret. Pass it explicitly "
-                "or set E2A_HMAC_SECRET in the environment."
+                "or set E2A_WEBHOOK_SECRET in the environment."
             )
         ok = _verify_auth_headers(self._auth, self._raw_message, secret)
         if ok:
@@ -672,11 +702,11 @@ class AsyncInboundEmail:
     def verify_signature(self, secret: Optional[str] = None) -> bool:
         """See :meth:`InboundEmail.verify_signature` — identical contract."""
         if secret is None:
-            secret = os.environ.get("E2A_HMAC_SECRET", "")
+            secret = _resolve_webhook_secret()
         if not secret:
             raise ValueError(
                 "verify_signature requires a secret. Pass it explicitly "
-                "or set E2A_HMAC_SECRET in the environment."
+                "or set E2A_WEBHOOK_SECRET in the environment."
             )
         ok = _verify_auth_headers(self._auth, self._raw_message, secret)
         if ok:

--- a/sdks/python/tests/test_v1_handler.py
+++ b/sdks/python/tests/test_v1_handler.py
@@ -452,18 +452,20 @@ def test_unverified_email_allows_verify_inputs():
 
 def test_verify_signature_with_no_secret_and_no_env_raises(monkeypatch):
     """No secret + no env → ValueError (better than silent False)."""
+    monkeypatch.delenv("E2A_WEBHOOK_SECRET", raising=False)
     monkeypatch.delenv("E2A_HMAC_SECRET", raising=False)
     raw = _make_raw_email()
     data = _make_webhook_data(raw)
     email = build_inbound_email(data, _mock_client())
 
-    with pytest.raises(ValueError, match="E2A_HMAC_SECRET"):
+    with pytest.raises(ValueError, match="E2A_WEBHOOK_SECRET"):
         email.verify_signature()
 
 
 def test_verify_signature_reads_env_when_no_arg(monkeypatch):
-    """Default secret comes from E2A_HMAC_SECRET when not passed."""
-    monkeypatch.setenv("E2A_HMAC_SECRET", "wrong-secret-but-not-empty")
+    """Default secret comes from E2A_WEBHOOK_SECRET when not passed."""
+    monkeypatch.delenv("E2A_HMAC_SECRET", raising=False)
+    monkeypatch.setenv("E2A_WEBHOOK_SECRET", "wrong-secret-but-not-empty")
     raw = _make_raw_email()
     data = _make_webhook_data(raw)
     email = build_inbound_email(data, _mock_client())
@@ -472,6 +474,46 @@ def test_verify_signature_reads_env_when_no_arg(monkeypatch):
     # False (not raises) — the assertion here is that it CALLED verify
     # (didn't raise the no-secret ValueError).
     assert email.verify_signature() is False
+
+
+def test_verify_signature_falls_back_to_legacy_env(monkeypatch, recwarn):
+    """E2A_HMAC_SECRET still works for SDK 2.0 users, with a deprecation warning."""
+    # Reset the module-level "warned once" flag so this test sees the warning
+    # regardless of test ordering.
+    from e2a.v1 import handler as _handler
+    _handler._warned_legacy_env = False
+
+    monkeypatch.delenv("E2A_WEBHOOK_SECRET", raising=False)
+    monkeypatch.setenv("E2A_HMAC_SECRET", "wrong-secret-but-not-empty")
+    raw = _make_raw_email()
+    data = _make_webhook_data(raw)
+    email = build_inbound_email(data, _mock_client())
+
+    assert email.verify_signature() is False  # called the verify path
+    deprecations = [w for w in recwarn.list if issubclass(w.category, DeprecationWarning)]
+    assert any("E2A_HMAC_SECRET" in str(w.message) for w in deprecations), (
+        "expected DeprecationWarning mentioning E2A_HMAC_SECRET"
+    )
+
+
+def test_verify_signature_prefers_canonical_env_over_legacy(monkeypatch):
+    """When both names are set, E2A_WEBHOOK_SECRET wins (no warning)."""
+    from e2a.v1 import handler as _handler
+    _handler._warned_legacy_env = False
+
+    monkeypatch.setenv("E2A_WEBHOOK_SECRET", "canonical-wrong")
+    monkeypatch.setenv("E2A_HMAC_SECRET", "legacy-wrong")
+    raw = _make_raw_email()
+    data = _make_webhook_data(raw)
+    email = build_inbound_email(data, _mock_client())
+
+    import warnings
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        assert email.verify_signature() is False
+        assert not any(issubclass(w.category, DeprecationWarning) for w in caught), (
+            "should not warn when canonical env var is set"
+        )
 
 
 def test_verify_signature_unlocks_field_access_on_success():

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -17,7 +17,7 @@ Webhook-parsed emails now refuse to expose claim fields (`sender`, `subject`, `t
 + const email = await client.parseWebhook(req.body);
 ```
 
-`parseWebhook` reads the secret from `E2A_HMAC_SECRET`; set it before upgrading. If you must inspect the payload before verifying, use `email.unverifiedPayload`. REST-fetched emails (`client.getMessage`) are unaffected — they're pre-verified via the bearer token. Full background in the [PR](https://github.com/Mnexa-AI/e2a/pull/57).
+`parseWebhook` reads the secret from `E2A_WEBHOOK_SECRET`; set it before upgrading. If you must inspect the payload before verifying, use `email.unverifiedPayload`. REST-fetched emails (`client.getMessage`) are unaffected — they're pre-verified via the bearer token. Full background in the [PR](https://github.com/Mnexa-AI/e2a/pull/57).
 
 ## Quick Start
 
@@ -33,7 +33,7 @@ const client = new E2AClient(); // uses E2A_API_KEY env var
 app.post("/webhook", async (req, res) => {
   let email;
   try {
-    email = await client.parseWebhook(req.body); // reads E2A_HMAC_SECRET
+    email = await client.parseWebhook(req.body); // reads E2A_WEBHOOK_SECRET
   } catch {
     return res.status(401).end();
   }
@@ -43,7 +43,7 @@ app.post("/webhook", async (req, res) => {
 });
 ```
 
-Get a signing secret from the dashboard's Settings → Webhook signing secrets (or `POST /api/v1/users/me/signing-secrets`). Set it as `E2A_HMAC_SECRET` so `parseWebhook` picks it up automatically, or pass it explicitly: `client.parseWebhook(body, "whsec_...")`.
+Get a signing secret from the dashboard's Settings → Webhook signing secrets (or `POST /api/v1/users/me/signing-secrets`). Set it as `E2A_WEBHOOK_SECRET` so `parseWebhook` picks it up automatically, or pass it explicitly: `client.parseWebhook(body, "whsec_...")`.
 
 ### Polling
 
@@ -92,7 +92,7 @@ await client.send(["alice@example.com", "bob@example.com"], "Hello", "Hi!", {
 
 ### `client.parseWebhook(body, secret?)` → `Promise<InboundEmail>`
 
-Parse + HMAC-verify a webhook payload in one call. Reads `E2A_HMAC_SECRET` if `secret` is omitted; throws on bad signature. Recommended entry point for webhook handlers.
+Parse + HMAC-verify a webhook payload in one call. Reads `E2A_WEBHOOK_SECRET` if `secret` is omitted; throws on bad signature. Recommended entry point for webhook handlers.
 
 ### `client.parse(body)` → `Promise<InboundEmail>`
 
@@ -133,7 +133,7 @@ Send a new email. `to` is `string[]`. Options: `htmlBody`, `cc`, `bcc`, `convers
 | `unverifiedPayload` | `WebhookPayload` | Raw payload pre-verification — escape hatch for inspection; treat as untrusted |
 | `reply(body)`   | method            | Reply to this email                |
 
-All claim fields above (everything except `auth`, `rawMessage`, `verified`, `isVerified`, `unverifiedPayload`) are gated — accessing them on an unverified webhook payload throws `UnverifiedEmailError`. Call `email.verifySignature(secret?)` first (reads `E2A_HMAC_SECRET` by default), or use `client.parseWebhook(body)` which combines parse + verify. `email.unverifiedPayload` is an escape hatch for inspection before verifying — treat its contents as untrusted.
+All claim fields above (everything except `auth`, `rawMessage`, `verified`, `isVerified`, `unverifiedPayload`) are gated — accessing them on an unverified webhook payload throws `UnverifiedEmailError`. Call `email.verifySignature(secret?)` first (reads `E2A_WEBHOOK_SECRET` by default), or use `client.parseWebhook(body)` which combines parse + verify. `email.unverifiedPayload` is an escape hatch for inspection before verifying — treat its contents as untrusted.
 
 Exported error class: `UnverifiedEmailError extends Error`.
 

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/sdk",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "TypeScript SDK for e2a — email for AI agents",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/sdks/typescript/src/v1/client.ts
+++ b/sdks/typescript/src/v1/client.ts
@@ -67,7 +67,8 @@ export class E2AClient {
    * already-verified {@link InboundEmail} so getters work directly.
    * Throws on signature failure — let it bubble to a 401 response.
    *
-   * `secret` defaults to the `E2A_HMAC_SECRET` environment variable.
+   * `secret` defaults to the `E2A_WEBHOOK_SECRET` environment variable
+   * (with `E2A_HMAC_SECRET` accepted as a deprecated alias).
    */
   async parseWebhook(
     body: Buffer | string | MessagePayload,

--- a/sdks/typescript/src/v1/inbound-email.ts
+++ b/sdks/typescript/src/v1/inbound-email.ts
@@ -148,9 +148,25 @@ export class UnverifiedEmailError extends Error {
   }
 }
 
-/** Read an env var if `process.env` is reachable (Node), else "". */
-function envHmacSecret(): string {
-  if (typeof process !== "undefined" && process.env && process.env.E2A_HMAC_SECRET) {
+let warnedLegacyEnv = false;
+
+/**
+ * Resolve the webhook signing secret from env. Prefers `E2A_WEBHOOK_SECRET`
+ * (canonical); falls back to `E2A_HMAC_SECRET` (deprecated alias kept for
+ * backward compat with SDK 2.0). Warns once when only the legacy name is set.
+ */
+function envWebhookSecret(): string {
+  if (typeof process === "undefined" || !process.env) return "";
+  if (process.env.E2A_WEBHOOK_SECRET) return process.env.E2A_WEBHOOK_SECRET;
+  if (process.env.E2A_HMAC_SECRET) {
+    if (!warnedLegacyEnv) {
+      warnedLegacyEnv = true;
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[e2a] E2A_HMAC_SECRET is deprecated; rename it to E2A_WEBHOOK_SECRET. " +
+          "The legacy name will be removed in a future major release.",
+      );
+    }
     return process.env.E2A_HMAC_SECRET;
   }
   return "";
@@ -281,8 +297,9 @@ export class InboundEmail {
    * Cryptographically verify the auth headers and unlock field access.
    *
    * On success, transitions this instance to "verified" so subsequent
-   * getters work. `secret` defaults to the `E2A_HMAC_SECRET`
-   * environment variable when omitted.
+   * getters work. `secret` defaults to the `E2A_WEBHOOK_SECRET`
+   * environment variable when omitted (with `E2A_HMAC_SECRET` accepted
+   * as a deprecated alias — set the new name to silence the warning).
    *
    * Returns `true` if HMAC + body-hash + timestamp checks all pass.
    * Returns `false` for any tampering / expired / wrong-secret —
@@ -291,10 +308,10 @@ export class InboundEmail {
    * Throws if no secret is available (neither passed nor in env).
    */
   verifySignature(secret?: string): boolean {
-    const resolved = secret ?? envHmacSecret();
+    const resolved = secret ?? envWebhookSecret();
     if (!resolved) {
       throw new Error(
-        "verifySignature requires a secret. Pass it explicitly or set E2A_HMAC_SECRET in the environment.",
+        "verifySignature requires a secret. Pass it explicitly or set E2A_WEBHOOK_SECRET in the environment.",
       );
     }
     const ok = verifyAuthHeaders(this.auth, this.rawMessage, resolved);

--- a/sdks/typescript/test/v1/verify.test.ts
+++ b/sdks/typescript/test/v1/verify.test.ts
@@ -156,26 +156,54 @@ describe("InboundEmail field-access gate", () => {
   });
 
   it("verifySignature with no secret + no env throws", async () => {
-    const prev = process.env.E2A_HMAC_SECRET;
+    const prevWebhook = process.env.E2A_WEBHOOK_SECRET;
+    const prevHmac = process.env.E2A_HMAC_SECRET;
+    delete process.env.E2A_WEBHOOK_SECRET;
     delete process.env.E2A_HMAC_SECRET;
     try {
       const { email } = await signedEmail({ secret: SECRET });
-      expect(() => email.verifySignature()).toThrow(/E2A_HMAC_SECRET/);
+      expect(() => email.verifySignature()).toThrow(/E2A_WEBHOOK_SECRET/);
     } finally {
-      if (prev !== undefined) process.env.E2A_HMAC_SECRET = prev;
+      if (prevWebhook !== undefined) process.env.E2A_WEBHOOK_SECRET = prevWebhook;
+      if (prevHmac !== undefined) process.env.E2A_HMAC_SECRET = prevHmac;
     }
   });
 
-  it("verifySignature falls back to E2A_HMAC_SECRET env var", async () => {
-    const prev = process.env.E2A_HMAC_SECRET;
-    process.env.E2A_HMAC_SECRET = SECRET;
+  it("verifySignature reads E2A_WEBHOOK_SECRET env var", async () => {
+    const prevWebhook = process.env.E2A_WEBHOOK_SECRET;
+    const prevHmac = process.env.E2A_HMAC_SECRET;
+    process.env.E2A_WEBHOOK_SECRET = SECRET;
+    delete process.env.E2A_HMAC_SECRET;
     try {
       const { email } = await signedEmail({ secret: SECRET });
       expect(email.verifySignature()).toBe(true);
       expect(email.sender).toBe("alice@example.com");
     } finally {
-      if (prev === undefined) delete process.env.E2A_HMAC_SECRET;
-      else process.env.E2A_HMAC_SECRET = prev;
+      if (prevWebhook === undefined) delete process.env.E2A_WEBHOOK_SECRET;
+      else process.env.E2A_WEBHOOK_SECRET = prevWebhook;
+      if (prevHmac !== undefined) process.env.E2A_HMAC_SECRET = prevHmac;
+    }
+  });
+
+  it("verifySignature falls back to legacy E2A_HMAC_SECRET with a deprecation warning", async () => {
+    const prevWebhook = process.env.E2A_WEBHOOK_SECRET;
+    const prevHmac = process.env.E2A_HMAC_SECRET;
+    delete process.env.E2A_WEBHOOK_SECRET;
+    process.env.E2A_HMAC_SECRET = SECRET;
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    };
+    try {
+      const { email } = await signedEmail({ secret: SECRET });
+      expect(email.verifySignature()).toBe(true);
+      expect(warnings.some((w) => /E2A_HMAC_SECRET/.test(w) && /deprecated/i.test(w))).toBe(true);
+    } finally {
+      console.warn = origWarn;
+      if (prevWebhook !== undefined) process.env.E2A_WEBHOOK_SECRET = prevWebhook;
+      if (prevHmac === undefined) delete process.env.E2A_HMAC_SECRET;
+      else process.env.E2A_HMAC_SECRET = prevHmac;
     }
   });
 

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -1,6 +1,6 @@
 # Email Skill
 
-<!-- version: 7 -->
+<!-- version: 8 -->
 
 You can give yourself an email address and use it to check your inbox, read, reply to, and send emails.
 
@@ -11,7 +11,7 @@ Email is powered by [e2a](https://e2a.dev) — email for AI agents.
 ```bash
 _E2A_STATE="$HOME/.e2a/skill"
 _E2A_CHECK="$_E2A_STATE/last-check"
-_E2A_LOCAL=7
+_E2A_LOCAL=8
 _E2A_NOW=$(date +%s)
 _E2A_SKIP=0
 if [ -f "$_E2A_CHECK" ]; then
@@ -124,7 +124,7 @@ Go to https://e2a.dev and register a new agent in "Cloud" mode. Enter your webho
 
 ### 2. Create a signing secret
 
-In the dashboard's Settings → Webhook signing secrets, create one and copy it (shown once). Set it as `E2A_HMAC_SECRET` in your webhook environment so the SDK can verify inbound payloads automatically.
+In the dashboard's Settings → Webhook signing secrets, create one and copy it (shown once). Set it as `E2A_WEBHOOK_SECRET` in your webhook environment so the SDK can verify inbound payloads automatically.
 
 ### 3. Implement the webhook endpoint
 
@@ -153,7 +153,7 @@ client = e2a.E2AClient(api_key="e2a_...")  # or set E2A_API_KEY env var
 @app.post("/webhook")
 async def webhook(request: Request):
     # parse_webhook does parse + HMAC-verify in one call.
-    # Reads E2A_HMAC_SECRET from the env automatically — make sure that's
+    # Reads E2A_WEBHOOK_SECRET from the env automatically — make sure that's
     # set or you'll get a ValueError on the first request.
     try:
         email = client.parse_webhook(await request.body())
@@ -195,7 +195,7 @@ const client = new E2AClient({ apiKey: process.env.E2A_API_KEY! });
 
 app.post("/webhook", async (req, res) => {
   // parseWebhook does parse + HMAC-verify in one call.
-  // Reads E2A_HMAC_SECRET from the env automatically.
+  // Reads E2A_WEBHOOK_SECRET from the env automatically.
   let email;
   try {
     email = await client.parseWebhook(req.body);
@@ -277,7 +277,7 @@ The `--agent` flag is optional if `agent_email` is set in your config.
 ## Reference
 
 - Config file: `~/.e2a/config.json` (JSON with `api_key`, `api_url`, `agent_email`, `shared_domain`)
-- Environment variables that override config: `E2A_API_KEY`, `E2A_URL`, `E2A_SHARED_DOMAIN` (CLI). `E2A_AGENT_EMAIL` is honored by the Python/TS SDK constructors when you don't pass `agent_email` explicitly. `E2A_HMAC_SECRET` is read by `client.parse_webhook` / `client.parseWebhook` and `email.verify_signature()` / `email.verifySignature()` to verify inbound webhook signatures.
+- Environment variables that override config: `E2A_API_KEY`, `E2A_URL`, `E2A_SHARED_DOMAIN` (CLI). `E2A_AGENT_EMAIL` is honored by the Python/TS SDK constructors when you don't pass `agent_email` explicitly. `E2A_WEBHOOK_SECRET` is read by `client.parse_webhook` / `client.parseWebhook` and `email.verify_signature()` / `email.verifySignature()` to verify inbound webhook signatures.
 - CLI docs: https://www.npmjs.com/package/@e2a/cli
 - TypeScript SDK: https://www.npmjs.com/package/@e2a/sdk
 - Python SDK: https://e2a.dev/python-sdk


### PR DESCRIPTION
## Summary

Rename the SDK-side webhook signing secret env var to follow industry convention. Stripe / GitHub / Slack / Resend / Svix / Shopify all name the env var after what it's *for* (webhook / signing) rather than the underlying primitive (HMAC). `E2A_HMAC_SECRET` was opaque and confusingly shared a name with the operator's server-side HITL signing key.

**Non-breaking** (Path B): both SDKs read `E2A_WEBHOOK_SECRET` as canonical and accept `E2A_HMAC_SECRET` as a deprecated alias. SDK 2.0 users keep working; first call emits a one-time `DeprecationWarning` (Python) / `console.warn` (TS) telling them to rename.

## Scope of changes

- `sdks/python/src/e2a/v1/handler.py`: new `_resolve_webhook_secret()` helper (canonical → legacy → empty), wired into both sync + async `verify_signature` impls. Error message references the new name.
- `sdks/typescript/src/v1/inbound-email.ts`: parallel `envWebhookSecret()` helper. `verifySignature()` reads the new name with the legacy fallback.
- Both SDKs bumped to **2.1.0**.
- Tests updated: existing tests re-pointed at `E2A_WEBHOOK_SECRET`. New tests cover (1) canonical-only path, (2) legacy fallback raises a `DeprecationWarning`, (3) canonical-set-with-legacy doesn't warn.
- Docs swept: top-level README, both SDK READMEs, `docs/api.md`, `skills/SKILL.md` (v7 → v8), the ADK example's `.env.example` + `webhook.py`. Each README/note still mentions the legacy alias so 2.0 users searching for `E2A_HMAC_SECRET` find the migration path.
- Server-side files (`docker-compose.yaml`, root `.env.example`, `docs/deployment.md`, `docs/data-handling.md`) deliberately left alone — the operator's `E2A_HMAC_SECRET` is a separate concept (HITL token signing, not webhook verification).

## Test plan

- [x] Python: 32 handler tests + 163 unit tests pass (e2e failures pre-existing, need live server)
- [x] TS: 68/68 unit tests pass (was 67, +1 for the legacy deprecation test)
- [ ] CI green
- [ ] Tag + publish `python-v2.1.0` and `ts-sdk-v2.1.0` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)