### PR TITLE
fix(webhook): make GetPendingDeliveries actually atomic across workers

### DIFF
--- a/internal/webhook/store.go
+++ b/internal/webhook/store.go
@@ -55,30 +55,77 @@ func (s *DeliveryStore) CreateDelivery(ctx context.Context, messageID string, la
 	return d, nil
 }
 
+// LeaseDuration is how long a leased delivery is hidden from other workers.
+// On a clean delivery the row's next_retry_at is overwritten by the success
+// path (MarkDelivered) or a real backoff (RecordFailure). The lease only
+// matters as a recovery mechanism when a worker dies mid-delivery — after
+// LeaseDuration the row becomes eligible again and another worker picks it
+// up. Long enough that a legitimate slow webhook won't be double-fired,
+// short enough that a crashed worker doesn't strand its rows for hours.
+const LeaseDuration = 5 * time.Minute
+
+// GetPendingDeliveries atomically claims up to `limit` due deliveries.
+// Each returned row's next_retry_at is pushed by LeaseDuration so other
+// workers (in this process or a different replica) won't grab the same
+// row. The standard `WHERE status='pending' AND next_retry_at <= now()`
+// filter then naturally excludes leased rows.
+//
+// This must run inside a transaction: `FOR UPDATE SKIP LOCKED` only
+// holds the row lock for the lifetime of the surrounding transaction.
+// pool.Query (autocommit) would release the lock as soon as the SELECT
+// completed, leaving a window where two callers could each return the
+// same row.
 func (s *DeliveryStore) GetPendingDeliveries(ctx context.Context, limit int) ([]Delivery, error) {
-	rows, err := s.pool.Query(ctx,
-		`SELECT m.agent_id, wd.message_id, wd.status, wd.attempts, wd.max_attempts, wd.last_error, wd.last_attempt_at, wd.next_retry_at, wd.created_at, wd.expires_at
-		 FROM webhook_deliveries wd
-		 JOIN messages m ON m.id = wd.message_id
-		 WHERE wd.status = 'pending' AND wd.next_retry_at <= now() AND wd.expires_at > now()
-		 ORDER BY wd.next_retry_at
-		 LIMIT $1
-		 FOR UPDATE SKIP LOCKED`, limit,
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx)
+
+	// Single CTE: select+lock the candidate rows, then update their
+	// next_retry_at in the same statement so the lease is committed
+	// atomically with the read. RETURNING gives us the same shape the
+	// caller previously got from the plain SELECT.
+	rows, err := tx.Query(ctx,
+		`WITH candidates AS (
+		    SELECT wd.message_id
+		    FROM webhook_deliveries wd
+		    WHERE wd.status = 'pending' AND wd.next_retry_at <= now() AND wd.expires_at > now()
+		    ORDER BY wd.next_retry_at
+		    LIMIT $1
+		    FOR UPDATE SKIP LOCKED
+		 )
+		 UPDATE webhook_deliveries wd
+		 SET next_retry_at = now() + ($2 * interval '1 second')
+		 FROM candidates c
+		 JOIN messages m ON m.id = c.message_id
+		 WHERE wd.message_id = c.message_id
+		 RETURNING m.agent_id, wd.message_id, wd.status, wd.attempts, wd.max_attempts,
+		           wd.last_error, wd.last_attempt_at, wd.next_retry_at, wd.created_at, wd.expires_at`,
+		limit, int(LeaseDuration.Seconds()),
 	)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
 
 	var deliveries []Delivery
 	for rows.Next() {
 		var d Delivery
 		if err := rows.Scan(&d.AgentID, &d.MessageID, &d.Status, &d.Attempts, &d.MaxAttempts, &d.LastError, &d.LastAttemptAt, &d.NextRetryAt, &d.CreatedAt, &d.ExpiresAt); err != nil {
+			rows.Close()
 			return nil, err
 		}
 		deliveries = append(deliveries, d)
 	}
-	return deliveries, rows.Err()
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return deliveries, nil
 }
 
 func (s *DeliveryStore) MarkDelivered(ctx context.Context, messageID string) error {

--- a/internal/webhook/store_test.go
+++ b/internal/webhook/store_test.go
@@ -71,6 +71,111 @@ func TestCreateDeliveryAndGetPendingDeliveriesUsesMessageKeyedSchema(t *testing.
 	}
 }
 
+// Regression (deterministic): a second call to GetPendingDeliveries
+// immediately after the first must not re-claim the same rows. Pre-fix,
+// the autocommit query had no lease — both calls returned the identical
+// N rows. Post-fix, the first call bumps next_retry_at by LeaseDuration,
+// so the second call sees nothing eligible.
+func TestGetPendingDeliveriesLeasesClaimedRows(t *testing.T) {
+	_, identityStore, deliveryStore, agent, _ := setupDeliveryFixture(t)
+	ctx := context.Background()
+
+	for i := 0; i < 3; i++ {
+		m, err := identityStore.CreateOutboundMessage(ctx, agent.ID,
+			[]string{"alice@example.com"}, nil, nil,
+			"hi", "send", "webhook", "", "")
+		if err != nil {
+			t.Fatalf("CreateOutboundMessage: %v", err)
+		}
+		if _, err := deliveryStore.CreateDelivery(ctx, m.ID, ""); err != nil {
+			t.Fatalf("CreateDelivery: %v", err)
+		}
+	}
+
+	first, err := deliveryStore.GetPendingDeliveries(ctx, 10)
+	if err != nil {
+		t.Fatalf("first GetPendingDeliveries: %v", err)
+	}
+	if len(first) != 3 {
+		t.Fatalf("first call returned %d, want 3", len(first))
+	}
+
+	second, err := deliveryStore.GetPendingDeliveries(ctx, 10)
+	if err != nil {
+		t.Fatalf("second GetPendingDeliveries: %v", err)
+	}
+	if len(second) != 0 {
+		t.Errorf("second call returned %d rows, want 0 — lease did not hide claimed rows", len(second))
+	}
+}
+
+// Regression (probabilistic): two workers (or two replicas) calling
+// GetPendingDeliveries in parallel must not both receive the same row.
+// Pre-fix the FOR UPDATE SKIP LOCKED was a no-op because the SELECT ran
+// in autocommit mode, so the lock was released the moment the rows were
+// returned to the caller — both workers would then deliver the same
+// webhook. The fix wraps the lookup in a transaction and bumps
+// next_retry_at as a lease so the second caller sees an empty result.
+func TestGetPendingDeliveriesIsSafeForConcurrentCallers(t *testing.T) {
+	pool, identityStore, deliveryStore, agent, _ := setupDeliveryFixture(t)
+	_ = pool
+	_ = agent
+	ctx := context.Background()
+
+	// Create N pending deliveries so the test is meaningful.
+	const n = 4
+	for i := 0; i < n; i++ {
+		m, err := identityStore.CreateOutboundMessage(ctx, agent.ID,
+			[]string{"alice@example.com"}, nil, nil,
+			"hi", "send", "webhook", "", "")
+		if err != nil {
+			t.Fatalf("CreateOutboundMessage: %v", err)
+		}
+		if _, err := deliveryStore.CreateDelivery(ctx, m.ID, ""); err != nil {
+			t.Fatalf("CreateDelivery: %v", err)
+		}
+	}
+
+	// Two workers race to claim the batch.
+	type result struct {
+		ds  []webhook.Delivery
+		err error
+	}
+	out := make(chan result, 2)
+	start := make(chan struct{})
+	for i := 0; i < 2; i++ {
+		go func() {
+			<-start
+			ds, err := deliveryStore.GetPendingDeliveries(ctx, n)
+			out <- result{ds, err}
+		}()
+	}
+	close(start)
+	a := <-out
+	b := <-out
+	if a.err != nil || b.err != nil {
+		t.Fatalf("GetPendingDeliveries errors: %v / %v", a.err, b.err)
+	}
+
+	// Every message_id should appear at most once across the two batches.
+	seen := make(map[string]int)
+	for _, d := range a.ds {
+		seen[d.MessageID]++
+	}
+	for _, d := range b.ds {
+		seen[d.MessageID]++
+	}
+	for id, count := range seen {
+		if count > 1 {
+			t.Errorf("delivery %s claimed %d times — same row leased to two workers", id, count)
+		}
+	}
+	total := len(a.ds) + len(b.ds)
+	if total < 1 || total > n {
+		t.Errorf("total deliveries claimed = %d, want in [1, %d]", total, n)
+	}
+}
+
 func TestDeliveryStatusUpdatesByMessageID(t *testing.T) {
 	_, identityStore, deliveryStore, _, msg := setupDeliveryFixture(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

The retry worker's `SELECT … FOR UPDATE SKIP LOCKED` was running through `pool.Query` (autocommit), which **releases the row lock the moment the SELECT completes**. Two retry workers — in this process or across two replicas — calling `GetPendingDeliveries` in close succession would each receive the same rows and both fire the webhook. Real double-delivery hazard for any multi-replica deployment; single-replica was safe by accident.

## Fix

Wraps the lookup in an explicit transaction and uses a single CTE to atomically:

1. SELECT … FOR UPDATE SKIP LOCKED LIMIT N
2. UPDATE webhook_deliveries SET next_retry_at = now() + 5 min
3. RETURNING the same shape callers got before

The standard `status='pending' AND next_retry_at <= now()` filter then naturally hides leased rows from other workers. If a worker dies mid-delivery the row becomes eligible again after the lease expires — automatic recovery, no new schema column or status value needed.

## Regression tests

- **Deterministic** (`TestGetPendingDeliveriesLeasesClaimedRows`): two serial calls — second returns 0 rows. Would fail against pre-fix autocommit code.
- **Probabilistic** (`TestGetPendingDeliveriesIsSafeForConcurrentCallers`): two parallel calls — no `message_id` appears twice across the two batches.

Both pass against Postgres locally + full integration suite green.

## Test plan
- [x] `make test-unit` green
- [x] `make test-integration` green (identity, agent, hitlworker, hitlnotify all pass)
- [x] New webhook regression tests pass
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)