### PR TITLE
fix(outbound): preserve full References chain on replies for multi-party threads

### DIFF
--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -1107,7 +1107,7 @@ func (a *API) handleSendTestEmail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	message, err := outbound.ComposeMessage(headerFrom, to, nil, subject, body, "text/plain", "", a.fromDomain, "", "")
+	message, err := outbound.ComposeMessage(headerFrom, to, nil, subject, body, "text/plain", "", nil, a.fromDomain, "", "")
 	if err != nil {
 		log.Printf("[api] compose test email failed: %v", err)
 		http.Error(w, "failed to compose test email", http.StatusInternalServerError)
@@ -1233,6 +1233,11 @@ func (a *API) handleReplyToMessage(w http.ResponseWriter, r *http.Request) {
 		replyTo = []string{inbound.Sender}
 	}
 
+	// Build the full References chain from the inbound's prior chain plus
+	// the inbound itself. Required so multi-party replies thread correctly
+	// for participants who didn't see the immediate parent's Message-ID.
+	references := outbound.BuildReferencesChain(inbound.RawMessage, inbound.EmailMessageID)
+
 	// Build the SendRequest and route through Sender
 	sendReq := outbound.SendRequest{
 		To:               replyTo,
@@ -1242,6 +1247,7 @@ func (a *API) handleReplyToMessage(w http.ResponseWriter, r *http.Request) {
 		Body:             req.Body,
 		HTMLBody:         req.HTMLBody,
 		ReplyToMessageID: inbound.EmailMessageID,
+		References:       references,
 		ConversationID:   req.ConversationID,
 		Attachments:      req.Attachments,
 	}

--- a/internal/hitlnotify/notifier.go
+++ b/internal/hitlnotify/notifier.go
@@ -127,6 +127,7 @@ func (n *Notifier) NotifyPendingApproval(ctx context.Context, msg *identity.Mess
 		fromHeader, []string{owner.Email}, nil,
 		subject, text, htmlBody,
 		"",            // no reply-to-message-id (fresh notification)
+		nil,           // no references chain (fresh notification)
 		n.fromDomain,  // from_domain (Message-ID generation)
 		fromAddr,      // reply_to — point replies back at the platform, not the agent
 		"",            // no conversation_id

--- a/internal/outbound/compose.go
+++ b/internal/outbound/compose.go
@@ -22,7 +22,21 @@ import (
 // When conversationID is non-empty, an X-E2A-Conversation-ID header is written
 // so recipient agents on this platform can continue the same application thread
 // without depending on In-Reply-To chains.
-func ComposeMessage(from string, to []string, cc []string, subject, body, contentType, replyToMsgID, fromDomain, replyTo, conversationID string) ([]byte, error) {
+//
+// Threading headers (RFC 5322 § 3.6.4):
+//   - replyToMsgID is the immediate parent's Message-ID — written to In-Reply-To.
+//   - references is the FULL ancestor chain in conversation order (oldest →
+//     newest, including the immediate parent). When non-empty, written as the
+//     References header in space-separated form. When empty but replyToMsgID
+//     is set, References falls back to [replyToMsgID] for backwards compat.
+//
+// Why the full chain matters: in multi-party email threads, some participants
+// may not have seen every prior Message-ID (e.g. agent A replies only to
+// agent B; agent B then replies-all back to user — user has no record of
+// agent A's reply). Without the full References chain, the user's mail client
+// (Gmail) can't anchor the reply to the existing thread and forks a new one.
+// With the full chain, the client matches on ANY prior ID and threads correctly.
+func ComposeMessage(from string, to []string, cc []string, subject, body, contentType, replyToMsgID string, references []string, fromDomain, replyTo, conversationID string) ([]byte, error) {
 	if contentType == "" {
 		contentType = "text/plain"
 	}
@@ -45,10 +59,7 @@ func ComposeMessage(from string, to []string, cc []string, subject, body, conten
 	writeHeader("MIME-Version", "1.0")
 	writeHeader("Content-Type", contentType+"; charset=utf-8")
 
-	if replyToMsgID != "" {
-		writeHeader("In-Reply-To", replyToMsgID)
-		writeHeader("References", replyToMsgID)
-	}
+	writeThreadingHeaders(writeHeader, replyToMsgID, references)
 	if conversationID != "" {
 		writeHeader("X-E2A-Conversation-ID", conversationID)
 	}
@@ -61,9 +72,10 @@ func ComposeMessage(from string, to []string, cc []string, subject, body, conten
 
 // ComposeMultipartMessage builds an RFC 2822 multipart/alternative email with text and HTML parts.
 // If htmlBody is empty, falls back to a single text/plain message via ComposeMessage.
-func ComposeMultipartMessage(from string, to []string, cc []string, subject, textBody, htmlBody, replyToMsgID, fromDomain, replyTo, conversationID string) ([]byte, error) {
+// See ComposeMessage for replyToMsgID / references semantics.
+func ComposeMultipartMessage(from string, to []string, cc []string, subject, textBody, htmlBody, replyToMsgID string, references []string, fromDomain, replyTo, conversationID string) ([]byte, error) {
 	if htmlBody == "" {
-		return ComposeMessage(from, to, cc, subject, textBody, "text/plain", replyToMsgID, fromDomain, replyTo, conversationID)
+		return ComposeMessage(from, to, cc, subject, textBody, "text/plain", replyToMsgID, references, fromDomain, replyTo, conversationID)
 	}
 
 	boundary := generateBoundary()
@@ -86,10 +98,7 @@ func ComposeMultipartMessage(from string, to []string, cc []string, subject, tex
 	writeHeader("MIME-Version", "1.0")
 	writeHeader("Content-Type", fmt.Sprintf("multipart/alternative; boundary=%q", boundary))
 
-	if replyToMsgID != "" {
-		writeHeader("In-Reply-To", replyToMsgID)
-		writeHeader("References", replyToMsgID)
-	}
+	writeThreadingHeaders(writeHeader, replyToMsgID, references)
 	if conversationID != "" {
 		writeHeader("X-E2A-Conversation-ID", conversationID)
 	}
@@ -116,7 +125,8 @@ func ComposeMultipartMessage(from string, to []string, cc []string, subject, tex
 
 // ComposeMessageWithAttachments builds an RFC 2822 multipart/mixed email with attachments.
 // If no attachments are provided, falls back to ComposeMultipartMessage.
-func ComposeMessageWithAttachments(from string, to []string, cc []string, subject, textBody, htmlBody, replyToMsgID, fromDomain, replyTo, conversationID string, attachments []Attachment) ([]byte, error) {
+// See ComposeMessage for replyToMsgID / references semantics.
+func ComposeMessageWithAttachments(from string, to []string, cc []string, subject, textBody, htmlBody, replyToMsgID string, references []string, fromDomain, replyTo, conversationID string, attachments []Attachment) ([]byte, error) {
 	// Defense-in-depth header-injection guard: reject any attachment
 	// whose user-supplied Filename or ContentType contains CR or LF.
 	// fmt.Sprintf("%q", ...) escapes Filename safely, but ContentType
@@ -131,7 +141,7 @@ func ComposeMessageWithAttachments(from string, to []string, cc []string, subjec
 		}
 	}
 	if len(attachments) == 0 {
-		return ComposeMultipartMessage(from, to, cc, subject, textBody, htmlBody, replyToMsgID, fromDomain, replyTo, conversationID)
+		return ComposeMultipartMessage(from, to, cc, subject, textBody, htmlBody, replyToMsgID, references, fromDomain, replyTo, conversationID)
 	}
 
 	mixedBoundary := generateBoundary()
@@ -154,10 +164,7 @@ func ComposeMessageWithAttachments(from string, to []string, cc []string, subjec
 	writeHeader("MIME-Version", "1.0")
 	writeHeader("Content-Type", fmt.Sprintf("multipart/mixed; boundary=%q", mixedBoundary))
 
-	if replyToMsgID != "" {
-		writeHeader("In-Reply-To", replyToMsgID)
-		writeHeader("References", replyToMsgID)
-	}
+	writeThreadingHeaders(writeHeader, replyToMsgID, references)
 	if conversationID != "" {
 		writeHeader("X-E2A-Conversation-ID", conversationID)
 	}
@@ -217,6 +224,25 @@ func ComposeMessageWithAttachments(from string, to []string, cc []string, subjec
 // DecodeAttachmentData decodes a base64-encoded attachment data string.
 func DecodeAttachmentData(data string) ([]byte, error) {
 	return base64.StdEncoding.DecodeString(data)
+}
+
+// writeThreadingHeaders writes the In-Reply-To and References headers per
+// RFC 5322 § 3.6.4. References is the full ancestor chain in conversation
+// order (oldest → newest) and must be space-separated message-ids; mail
+// clients use it to anchor a reply to an existing thread by matching ANY
+// id in the chain. When references is empty but replyToMsgID is set, the
+// References header falls back to a single id (legacy behavior); use a
+// non-empty references slice for any reply that may reach a recipient who
+// did not see the immediate parent (multi-party / agent-mediated threads).
+func writeThreadingHeaders(writeHeader func(string, string), replyToMsgID string, references []string) {
+	if replyToMsgID != "" {
+		writeHeader("In-Reply-To", replyToMsgID)
+	}
+	if len(references) > 0 {
+		writeHeader("References", strings.Join(references, " "))
+	} else if replyToMsgID != "" {
+		writeHeader("References", replyToMsgID)
+	}
 }
 
 func headerWriter(buf *strings.Builder) func(string, string) {

--- a/internal/outbound/compose_test.go
+++ b/internal/outbound/compose_test.go
@@ -16,6 +16,7 @@ func TestComposeMessageBasic(t *testing.T) {
 		"This is a test message.",
 		"text/plain",
 		"",
+		nil,
 		"relay.e2a.dev",
 		"",
 		"",
@@ -49,7 +50,7 @@ func TestComposeMessageBasic(t *testing.T) {
 func TestComposeMessageSubjectRFC2047Encoding(t *testing.T) {
 	raw, err := ComposeMessage(
 		"from@test.com", []string{"to@test.com"}, nil,
-		"Résumé 📄 for アリス", "Body", "text/plain", "", "test.dev", "", "",
+		"Résumé 📄 for アリス", "Body", "text/plain", "", nil, "test.dev", "", "",
 	)
 	if err != nil {
 		t.Fatalf("ComposeMessage failed: %v", err)
@@ -85,7 +86,7 @@ func TestComposeMessageASCIISubjectUnchanged(t *testing.T) {
 	// Pure-ASCII subjects should pass through without encoded-word wrapping.
 	raw, err := ComposeMessage(
 		"from@test.com", []string{"to@test.com"}, nil,
-		"Hello Alice", "Body", "text/plain", "", "test.dev", "", "",
+		"Hello Alice", "Body", "text/plain", "", nil, "test.dev", "", "",
 	)
 	if err != nil {
 		t.Fatalf("ComposeMessage failed: %v", err)
@@ -105,6 +106,7 @@ func TestComposeMessageMultipleRecipients(t *testing.T) {
 		"Body",
 		"text/plain",
 		"",
+		nil,
 		"test.dev",
 		"",
 		"",
@@ -131,6 +133,7 @@ func TestComposeMessageCCOnlyOmitsToHeader(t *testing.T) {
 		"Body",
 		"text/plain",
 		"",
+		nil,
 		"test.dev",
 		"",
 		"",
@@ -158,6 +161,7 @@ func TestComposeMessageNoBccHeader(t *testing.T) {
 		"Body",
 		"text/plain",
 		"",
+		nil,
 		"test.dev",
 		"",
 		"",
@@ -172,7 +176,7 @@ func TestComposeMessageNoBccHeader(t *testing.T) {
 }
 
 func TestComposeMessageDefaultContentType(t *testing.T) {
-	raw, err := ComposeMessage("from@test.com", []string{"to@test.com"}, nil, "Sub", "Body", "", "", "test.dev", "", "")
+	raw, err := ComposeMessage("from@test.com", []string{"to@test.com"}, nil, "Sub", "Body", "", "", nil, "test.dev", "", "")
 	if err != nil {
 		t.Fatalf("ComposeMessage failed: %v", err)
 	}
@@ -187,7 +191,7 @@ func TestComposeMessageDefaultContentType(t *testing.T) {
 func TestComposeMessageReplyTo(t *testing.T) {
 	raw, err := ComposeMessage(
 		"from@test.com", []string{"to@test.com"}, nil, "Re: Hello", "Reply body",
-		"text/plain", "<original-msg-id@example.com>", "test.dev", "", "",
+		"text/plain", "<original-msg-id@example.com>", nil, "test.dev", "", "",
 	)
 	if err != nil {
 		t.Fatalf("ComposeMessage failed: %v", err)
@@ -203,7 +207,7 @@ func TestComposeMessageReplyTo(t *testing.T) {
 }
 
 func TestComposeMessageNoReplyTo(t *testing.T) {
-	raw, err := ComposeMessage("from@test.com", []string{"to@test.com"}, nil, "Sub", "Body", "", "", "test.dev", "", "")
+	raw, err := ComposeMessage("from@test.com", []string{"to@test.com"}, nil, "Sub", "Body", "", "", nil, "test.dev", "", "")
 	if err != nil {
 		t.Fatalf("ComposeMessage failed: %v", err)
 	}
@@ -220,7 +224,7 @@ func TestComposeMessageNoReplyTo(t *testing.T) {
 func TestComposeMessageConversationIDHeader(t *testing.T) {
 	raw, err := ComposeMessage(
 		"from@test.com", []string{"to@test.com"}, nil,
-		"Hello", "Body", "text/plain", "", "test.dev", "", "081158ac-bf25-4eb6-a6b0-02828ec670c3",
+		"Hello", "Body", "text/plain", "", nil, "test.dev", "", "081158ac-bf25-4eb6-a6b0-02828ec670c3",
 	)
 	if err != nil {
 		t.Fatalf("ComposeMessage failed: %v", err)
@@ -234,7 +238,7 @@ func TestComposeMessageConversationIDHeader(t *testing.T) {
 func TestComposeMessageNoConversationIDHeader(t *testing.T) {
 	raw, err := ComposeMessage(
 		"from@test.com", []string{"to@test.com"}, nil,
-		"Hello", "Body", "text/plain", "", "test.dev", "", "",
+		"Hello", "Body", "text/plain", "", nil, "test.dev", "", "",
 	)
 	if err != nil {
 		t.Fatalf("ComposeMessage failed: %v", err)
@@ -248,7 +252,7 @@ func TestComposeMultipartMessage(t *testing.T) {
 	raw, err := ComposeMultipartMessage(
 		"bot@agent.example.com", []string{"alice@gmail.com"}, nil,
 		"Re: Hello", "Plain text body", "<p>HTML body</p>",
-		"<orig@example.com>", "relay.e2a.dev", "", "",
+		"<orig@example.com>", nil, "relay.e2a.dev", "", "",
 	)
 	if err != nil {
 		t.Fatalf("ComposeMultipartMessage failed: %v", err)
@@ -280,7 +284,7 @@ func TestComposeMultipartMessageFallsBackToPlain(t *testing.T) {
 	raw, err := ComposeMultipartMessage(
 		"bot@agent.example.com", []string{"alice@gmail.com"}, nil,
 		"Hello", "Plain text only", "",
-		"", "relay.e2a.dev", "", "",
+		"", nil, "relay.e2a.dev", "", "",
 	)
 	if err != nil {
 		t.Fatalf("ComposeMultipartMessage failed: %v", err)
@@ -299,7 +303,7 @@ func TestComposeMultipartMessageWithCC(t *testing.T) {
 		[]string{"alice@gmail.com"},
 		[]string{"bob@gmail.com", "carol@gmail.com"},
 		"Hello", "Plain", "<p>HTML</p>",
-		"", "relay.e2a.dev", "", "",
+		"", nil, "relay.e2a.dev", "", "",
 	)
 	if err != nil {
 		t.Fatalf("ComposeMultipartMessage failed: %v", err)
@@ -315,7 +319,7 @@ func TestComposeMultipartMessageConversationIDHeader(t *testing.T) {
 	raw, err := ComposeMultipartMessage(
 		"bot@agent.example.com", []string{"alice@gmail.com"}, nil,
 		"Hi", "Plain", "<p>HTML</p>",
-		"", "relay.e2a.dev", "", "conv-xyz",
+		"", nil, "relay.e2a.dev", "", "conv-xyz",
 	)
 	if err != nil {
 		t.Fatalf("ComposeMultipartMessage failed: %v", err)
@@ -337,7 +341,7 @@ func TestComposeMessageStripsCRLFFromConversationID(t *testing.T) {
 		"sender@agents.e2a.dev",
 		[]string{"target@victim.com"}, nil,
 		"hi", "benign", "text/plain",
-		"", "agents.e2a.dev", "",
+		"", nil, "agents.e2a.dev", "",
 		malicious,
 	)
 	if err != nil {
@@ -360,5 +364,96 @@ func TestComposeMessageStripsCRLFFromConversationID(t *testing.T) {
 	}
 	if parsed.Header.Get("Bcc") != "" {
 		t.Errorf("Bcc header should be absent, got %q", parsed.Header.Get("Bcc"))
+	}
+}
+
+// References header behavior — multi-id chain (RFC 5322 § 3.6.4).
+//
+// In multi-party threads where the immediate-parent Message-ID is not in
+// every recipient's mailbox, References must include the full ancestor
+// chain so receiving clients can anchor on ANY known id. A single-id
+// References (legacy behavior) forks the thread for any participant that
+// missed the parent.
+
+func TestComposeMessageReferencesMultiIDChain(t *testing.T) {
+	chain := []string{"<u1@gmail>", "<a1@e2a>", "<b1@e2a>"}
+	raw, err := ComposeMessage(
+		"from@test.com", []string{"to@test.com"}, nil,
+		"Re: Hello", "Body", "text/plain",
+		"<b1@e2a>", chain, // immediate parent + full chain
+		"test.dev", "", "",
+	)
+	if err != nil {
+		t.Fatalf("ComposeMessage failed: %v", err)
+	}
+
+	msg, _ := mail.ReadMessage(strings.NewReader(string(raw)))
+	if got := msg.Header.Get("In-Reply-To"); got != "<b1@e2a>" {
+		t.Errorf("In-Reply-To = %q, want <b1@e2a>", got)
+	}
+	if got := msg.Header.Get("References"); got != "<u1@gmail> <a1@e2a> <b1@e2a>" {
+		t.Errorf("References = %q, want full space-separated chain", got)
+	}
+}
+
+func TestComposeMessageReferencesFallbackToSingleID(t *testing.T) {
+	// Legacy callers that pass replyToMsgID without a chain should still
+	// produce a valid (single-id) References header — backwards-compatible.
+	raw, err := ComposeMessage(
+		"from@test.com", []string{"to@test.com"}, nil,
+		"Re: Hello", "Body", "text/plain",
+		"<orig@example.com>", nil,
+		"test.dev", "", "",
+	)
+	if err != nil {
+		t.Fatalf("ComposeMessage failed: %v", err)
+	}
+
+	msg, _ := mail.ReadMessage(strings.NewReader(string(raw)))
+	if got := msg.Header.Get("References"); got != "<orig@example.com>" {
+		t.Errorf("References = %q, want single-id fallback", got)
+	}
+}
+
+func TestComposeMessageReferencesWithoutInReplyTo(t *testing.T) {
+	// Edge: a caller could pass references with no parent (shouldn't
+	// happen in practice). References should still be written; In-Reply-To
+	// is omitted. Belt-and-suspenders so the headers are at least
+	// internally consistent if a caller forgets to set replyToMsgID.
+	chain := []string{"<u1@host>"}
+	raw, err := ComposeMessage(
+		"from@test.com", []string{"to@test.com"}, nil,
+		"Sub", "Body", "text/plain",
+		"", chain,
+		"test.dev", "", "",
+	)
+	if err != nil {
+		t.Fatalf("ComposeMessage failed: %v", err)
+	}
+
+	msg, _ := mail.ReadMessage(strings.NewReader(string(raw)))
+	if got := msg.Header.Get("In-Reply-To"); got != "" {
+		t.Errorf("In-Reply-To = %q, want empty", got)
+	}
+	if got := msg.Header.Get("References"); got != "<u1@host>" {
+		t.Errorf("References = %q, want <u1@host>", got)
+	}
+}
+
+func TestComposeMultipartMessageReferencesMultiIDChain(t *testing.T) {
+	chain := []string{"<u1@gmail>", "<a1@e2a>"}
+	raw, err := ComposeMultipartMessage(
+		"bot@example.com", []string{"to@test.com"}, nil,
+		"Re: Hi", "Plain", "<p>HTML</p>",
+		"<a1@e2a>", chain,
+		"relay.e2a.dev", "", "",
+	)
+	if err != nil {
+		t.Fatalf("ComposeMultipartMessage failed: %v", err)
+	}
+
+	msg, _ := mail.ReadMessage(strings.NewReader(string(raw)))
+	if got := msg.Header.Get("References"); got != "<u1@gmail> <a1@e2a>" {
+		t.Errorf("References = %q, want full chain", got)
 	}
 }

--- a/internal/outbound/reply.go
+++ b/internal/outbound/reply.go
@@ -69,6 +69,77 @@ func ParseReplyRecipients(rawMessage []byte, replyAll bool, extraCC []string) (*
 	return result, nil
 }
 
+// BuildReferencesChain returns the References chain to write on a reply,
+// per RFC 5322 § 3.6.4:
+//
+//   - If the parent has a References header, return: parent.References ++ [parentMsgID]
+//   - Else if the parent has an In-Reply-To header, return: parent.InReplyTo ++ [parentMsgID]
+//   - Else return: [parentMsgID] (the reply still has at least the parent in its chain)
+//
+// parentMsgID must be the canonicalized RFC 5322 Message-ID of the inbound
+// being replied to (i.e. the same value the caller passes as
+// SendRequest.ReplyToMessageID for the In-Reply-To header). Empty input
+// yields an empty chain — callers fall back to legacy single-id behavior.
+//
+// This chain matters for multi-party threads where one participant's reply
+// is delivered only to a subset of the recipients (e.g. agent-mediated
+// scheduler scenarios). Without the full chain, a downstream reply-to-all
+// has In-Reply-To pointing at a Message-ID that recipients outside the
+// subset have never seen, and Gmail/other clients fork the thread.
+func BuildReferencesChain(rawMessage []byte, parentMsgID string) []string {
+	if parentMsgID == "" {
+		return nil
+	}
+
+	var prior []string
+	if len(rawMessage) > 0 {
+		if msg, err := mail.ReadMessage(bytes.NewReader(rawMessage)); err == nil {
+			if refs := strings.TrimSpace(msg.Header.Get("References")); refs != "" {
+				prior = parseMessageIDList(refs)
+			} else if irt := strings.TrimSpace(msg.Header.Get("In-Reply-To")); irt != "" {
+				// In-Reply-To SHOULD contain a single id, but some clients
+				// pack multiple. Treat it the same way as References as a
+				// pragmatic recovery — better than dropping prior context.
+				prior = parseMessageIDList(irt)
+			}
+		}
+		// Parse failures fall through silently — better to send a reply
+		// with a shorter chain than to fail the whole send. The reply
+		// will still thread for participants who saw the parent.
+	}
+
+	chain := make([]string, 0, len(prior)+1)
+	for _, id := range prior {
+		// Drop the parent if it was already in the prior chain — append it
+		// once at the end so the chain ends with the immediate parent
+		// (which mirrors what In-Reply-To points at).
+		if id != parentMsgID {
+			chain = append(chain, id)
+		}
+	}
+	chain = append(chain, parentMsgID)
+	return chain
+}
+
+// parseMessageIDList splits a References / In-Reply-To header value into
+// individual message-ids. The header format is one or more <local@domain>
+// tokens separated by whitespace (RFC 5322 § 3.6.4); the official grammar
+// is permissive enough that we tokenize on whitespace and then trim — any
+// fragment that isn't bracketed is dropped.
+func parseMessageIDList(header string) []string {
+	if header == "" {
+		return nil
+	}
+	fields := strings.Fields(header)
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		if strings.HasPrefix(f, "<") && strings.HasSuffix(f, ">") && len(f) > 2 {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
 // parseAddressList parses an RFC 5322 address list header and returns
 // lowercased bare email addresses. Invalid entries are silently skipped.
 func parseAddressList(header string) []string {

--- a/internal/outbound/reply_test.go
+++ b/internal/outbound/reply_test.go
@@ -125,3 +125,144 @@ func TestParseReplyRecipients_NotReplyAllIgnoresOriginalRecipients(t *testing.T)
 		t.Errorf("CC = %v, want empty (not reply-all)", r.CC)
 	}
 }
+
+// --- BuildReferencesChain ---
+//
+// Threading correctness is the load-bearing test: in a multi-party email
+// thread, a recipient that was not on every prior message must still be
+// able to anchor the reply via the References chain. These tests cover
+// the spec behavior in RFC 5322 § 3.6.4 and the specific multi-party
+// scheduler scenario that motivated the fix.
+
+func TestBuildReferencesChain_NoParent(t *testing.T) {
+	got := BuildReferencesChain([]byte{}, "")
+	if got != nil {
+		t.Errorf("got %v, want nil for empty parent", got)
+	}
+}
+
+func TestBuildReferencesChain_NoRawMessage(t *testing.T) {
+	// No raw message but we have the parent's Message-ID — chain is just [parent].
+	got := BuildReferencesChain(nil, "<parent@host>")
+	want := []string{"<parent@host>"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestBuildReferencesChain_ParentHasReferences(t *testing.T) {
+	// Spec case: parent has References → new chain = parent.References ++ [parent.MessageID].
+	raw := buildRawMessage(map[string]string{
+		"References": "<u1@host> <a1@host>",
+	}, "body")
+
+	got := BuildReferencesChain(raw, "<parent@host>")
+	want := []string{"<u1@host>", "<a1@host>", "<parent@host>"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestBuildReferencesChain_ParentHasInReplyToOnly(t *testing.T) {
+	// Spec case: parent has only In-Reply-To → use it as the prior chain.
+	raw := buildRawMessage(map[string]string{
+		"In-Reply-To": "<u1@host>",
+	}, "body")
+
+	got := BuildReferencesChain(raw, "<parent@host>")
+	want := []string{"<u1@host>", "<parent@host>"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestBuildReferencesChain_ParentHasNeither(t *testing.T) {
+	// Top of thread: no References, no In-Reply-To → chain = [parent].
+	raw := buildRawMessage(map[string]string{
+		"From":    "alice@gmail.com",
+		"Subject": "Hi",
+	}, "body")
+
+	got := BuildReferencesChain(raw, "<parent@host>")
+	want := []string{"<parent@host>"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestBuildReferencesChain_DropsDuplicateParent(t *testing.T) {
+	// If the parent's own Message-ID was already in its References (some
+	// clients write it that way), the resulting chain must not contain
+	// duplicates — the parent appears exactly once, at the end.
+	raw := buildRawMessage(map[string]string{
+		"References": "<u1@host> <parent@host> <a1@host>",
+	}, "body")
+
+	got := BuildReferencesChain(raw, "<parent@host>")
+	want := []string{"<u1@host>", "<a1@host>", "<parent@host>"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestBuildReferencesChain_MalformedRaw(t *testing.T) {
+	// Garbage raw message must not blow up the send. Fall back to [parent].
+	got := BuildReferencesChain([]byte("not an RFC 2822 message at all"), "<parent@host>")
+	want := []string{"<parent@host>"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestBuildReferencesChain_MultilineFolded(t *testing.T) {
+	// References headers commonly span multiple lines via RFC 5322 folding
+	// (CRLF + WSP). net/mail unfolds these; we just need the IDs back.
+	raw := []byte("References: <u1@host>\r\n <a1@host>\r\n <a2@host>\r\nSubject: Hi\r\n\r\nbody")
+
+	got := BuildReferencesChain(raw, "<parent@host>")
+	want := []string{"<u1@host>", "<a1@host>", "<a2@host>", "<parent@host>"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+// MultiPartyThreadFork is the regression case for the bug this PR fixes.
+//
+// Scenario: a Gmail user (U) emails an agent (A); A replies with cc=B
+// where B is another agent. B replies back to A (only) via e2a — that
+// reply's Message-ID never enters U's mailbox. Then A replies-all with
+// the booking confirmation. With the old behavior, In-Reply-To pointed
+// at B's Message-ID, which U has never seen, and Gmail forked the thread.
+// With the chain, References still contains <u1>, so Gmail can anchor.
+func TestBuildReferencesChain_MultiPartyThreadFork(t *testing.T) {
+	// B → A (the inbound A is now responding to). B's References chain
+	// already includes the original user message and A's first outbound.
+	bToA := buildRawMessage(map[string]string{
+		"From":       "b@e2a.dev",
+		"To":         "a@e2a.dev",
+		"Subject":    "Re: Hello",
+		"References": "<u1@gmail> <a1@e2a>",
+	}, "body")
+
+	// A is now sending a reply. Its parent Message-ID is B's reply.
+	got := BuildReferencesChain(bToA, "<b1@e2a>")
+
+	// The chain MUST contain <u1@gmail> — that is the only Message-ID
+	// the original user U has in their mailbox. Without it, U's Gmail
+	// can't thread A's reply against the existing conversation.
+	foundU := false
+	for _, id := range got {
+		if id == "<u1@gmail>" {
+			foundU = true
+			break
+		}
+	}
+	if !foundU {
+		t.Errorf("regression: References chain %v missing <u1@gmail> — Gmail will fork the thread for the original user", got)
+	}
+
+	want := []string{"<u1@gmail>", "<a1@e2a>", "<b1@e2a>"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}

--- a/internal/outbound/sender.go
+++ b/internal/outbound/sender.go
@@ -17,6 +17,14 @@ type Attachment struct {
 } // @name Attachment
 
 // SendRequest is the outbound email contract.
+//
+// References is the full ancestor Message-ID chain for a reply, oldest →
+// newest. When non-empty, it is written verbatim into the References:
+// header so receiving mail clients can anchor the reply to an existing
+// thread by matching ANY id in the chain — required for multi-party
+// threads where the immediate-parent Message-ID may not be in every
+// participant's mailbox. When empty but ReplyToMessageID is set, the
+// References header falls back to a single id (legacy behavior).
 type SendRequest struct {
 	From             string       `json:"from,omitempty"`
 	To               []string     `json:"to"`
@@ -26,6 +34,7 @@ type SendRequest struct {
 	Body             string       `json:"body"`
 	HTMLBody         string       `json:"html_body,omitempty"`
 	ReplyToMessageID string       `json:"reply_to_message_id"`
+	References       []string     `json:"references,omitempty"`
 	ConversationID   string       `json:"conversation_id,omitempty"`
 	Attachments      []Attachment `json:"attachments,omitempty"`
 }
@@ -127,11 +136,11 @@ func (s *Sender) Send(agent *identity.AgentIdentity, req SendRequest) (*SendResu
 
 	var message []byte
 	if len(req.Attachments) > 0 {
-		message, err = ComposeMessageWithAttachments(headerFrom, to, cc, req.Subject, req.Body, req.HTMLBody, req.ReplyToMessageID, s.fromDomain, replyTo, req.ConversationID, req.Attachments)
+		message, err = ComposeMessageWithAttachments(headerFrom, to, cc, req.Subject, req.Body, req.HTMLBody, req.ReplyToMessageID, req.References, s.fromDomain, replyTo, req.ConversationID, req.Attachments)
 	} else if req.HTMLBody != "" {
-		message, err = ComposeMultipartMessage(headerFrom, to, cc, req.Subject, req.Body, req.HTMLBody, req.ReplyToMessageID, s.fromDomain, replyTo, req.ConversationID)
+		message, err = ComposeMultipartMessage(headerFrom, to, cc, req.Subject, req.Body, req.HTMLBody, req.ReplyToMessageID, req.References, s.fromDomain, replyTo, req.ConversationID)
 	} else {
-		message, err = ComposeMessage(headerFrom, to, cc, req.Subject, req.Body, "text/plain", req.ReplyToMessageID, s.fromDomain, replyTo, req.ConversationID)
+		message, err = ComposeMessage(headerFrom, to, cc, req.Subject, req.Body, "text/plain", req.ReplyToMessageID, req.References, s.fromDomain, replyTo, req.ConversationID)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("compose message: %w", err)

--- a/internal/relay/flow_test.go
+++ b/internal/relay/flow_test.go
@@ -47,7 +47,7 @@ func simulateInbound(t *testing.T, raw []byte, envelopeFrom string, lookup func(
 func composeAgentOutbound(t *testing.T, agentAddr string, to []string, subject, body, replyToMsgID, conversationID string) []byte {
 	t.Helper()
 	headerFrom := fmt.Sprintf("%q <%s>", agentAddr+" via e2a", platformFrom)
-	raw, err := outbound.ComposeMessage(headerFrom, to, nil, subject, body, "text/plain", replyToMsgID, relayFromDomain, agentAddr, conversationID)
+	raw, err := outbound.ComposeMessage(headerFrom, to, nil, subject, body, "text/plain", replyToMsgID, nil, relayFromDomain, agentAddr, conversationID)
 	if err != nil {
 		t.Fatalf("compose: %v", err)
 	}


### PR DESCRIPTION
## Summary

When a reply is sent via `/api/v1/agents/.../messages/{id}/reply`, the outbound's `References` header is set to a single Message-ID — the immediate parent's. That works for two-party threads where every recipient has the parent in their mailbox, but **breaks multi-party threads where a participant's reply was delivered to only a subset of recipients**.

### Concrete scenario (multi-party scheduler)

1. User **U** emails agent **A** (Cc: agent **B**). Gmail thread anchor: `<u1>`.
2. Agent A replies-all → User receives, threading on `<u1>`. ✅
3. Agent B replies to A only via e2a → A sees `<b1>`, U does **not**.
4. Agent A replies-all (booking confirmation) → `In-Reply-To: <b1>`, `References: <b1>`. Gmail user U has never seen `<b1>`, so it can't anchor and **forks the thread**.

This was discovered while testing a scheduler agent built on e2a — the booking confirmation appeared as a brand-new thread to the original user.

### Fix

Per RFC 5322 § 3.6.4, build `References` from the parent's prior `References` (or `In-Reply-To` if no `References`) plus the parent's own `Message-ID`. Recipients can then thread on **any** id in the chain — so the original user's Gmail anchors on `<u1>` even when `<b1>` is unknown.

## Changes

- `outbound.SendRequest`: new optional `References []string` field. When empty, `References` header falls back to a single id (legacy behavior).
- `outbound.BuildReferencesChain`: helper that parses an inbound's raw RFC 2822 message and constructs the new chain. Robust to malformed raw messages (falls back to `[parentMsgID]`) and de-duplicates the parent if it already appears in the prior chain.
- `handleReplyToMessage`: builds the chain from `inbound.RawMessage` and passes it through to `SendRequest`.
- `ComposeMessage` / `ComposeMultipartMessage` / `ComposeMessageWithAttachments`: accept `references []string` and write a space-separated `References` header when non-empty.

## Test plan

- [x] 13 new unit tests covering all `BuildReferencesChain` branches: References / In-Reply-To-only / neither / parent-already-in-chain / malformed / multiline-folded / **multi-party-fork regression**.
- [x] Multi-id `References` header tests for `ComposeMessage` and `ComposeMultipartMessage`.
- [x] Single-id fallback test for backwards-compat with callers that don't pass the chain.
- [x] `make test-unit` passes (all packages).
- [x] `go vet ./...` and `go build ./...` clean.
- [ ] Manual Gmail verification post-deploy: re-run the scheduler scenario and confirm the booking confirmation lands in the same Gmail thread as the kickoff. RFC compliance is necessary but not sufficient — the receiving client decides which ids to match.

## Out of scope

- Gmail's actual threading behavior on a real conversation (validates separately, post-deploy).
- Other clients (Outlook, Apple Mail) — they all follow RFC 5322 References-based threading, so this should improve threading there too, but isn't separately verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)