### PR TITLE
fix(hitl): preserve References chain on HITL-approved replies

### DIFF
--- a/internal/agent/attach_references_test.go
+++ b/internal/agent/attach_references_test.go
@@ -1,0 +1,112 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/outbound"
+)
+
+// fakeInboundLookup is a stub that satisfies hitlInboundLookup so we can
+// drive attachReferencesChain without a live Postgres. Each test sets up
+// the fields it cares about; everything else is zero-valued.
+type fakeInboundLookup struct {
+	calledWith struct {
+		agentID        string
+		emailMessageID string
+	}
+	wantAgentID        string // when non-empty, t.Errorf if a different agent is queried
+	returnInbound      *identity.Message
+	returnErr          error
+}
+
+func (f *fakeInboundLookup) GetInboundByEmailMessageID(_ context.Context, agentID, emailMessageID string) (*identity.Message, error) {
+	f.calledWith.agentID = agentID
+	f.calledWith.emailMessageID = emailMessageID
+	return f.returnInbound, f.returnErr
+}
+
+func TestAttachReferencesChain_NoReplyToMessageID(t *testing.T) {
+	// /send (not a reply): nothing to do, lookup must not happen.
+	lookup := &fakeInboundLookup{}
+	req := outbound.SendRequest{To: []string{"a@host"}}
+
+	attachReferencesChain(context.Background(), lookup, "agent-1", &req)
+
+	if lookup.calledWith.agentID != "" {
+		t.Errorf("lookup invoked unexpectedly: agentID=%q", lookup.calledWith.agentID)
+	}
+	if req.References != nil {
+		t.Errorf("References = %v, want nil for non-reply", req.References)
+	}
+}
+
+func TestAttachReferencesChain_HappyPath_BuildsChain(t *testing.T) {
+	// HITL approval: parent inbound has a prior References chain, the
+	// rebuilt chain must include both prior IDs and the parent's own ID.
+	parentRaw := []byte("References: <u1@gmail> <a1@e2a>\r\nFrom: u@x\r\n\r\nbody")
+	lookup := &fakeInboundLookup{
+		returnInbound: &identity.Message{RawMessage: parentRaw},
+	}
+	req := outbound.SendRequest{ReplyToMessageID: "<parent@e2a>"}
+
+	attachReferencesChain(context.Background(), lookup, "agent-1", &req)
+
+	if lookup.calledWith.agentID != "agent-1" {
+		t.Errorf("agentID = %q, want agent-1", lookup.calledWith.agentID)
+	}
+	if lookup.calledWith.emailMessageID != "<parent@e2a>" {
+		t.Errorf("emailMessageID = %q, want <parent@e2a>", lookup.calledWith.emailMessageID)
+	}
+	want := []string{"<u1@gmail>", "<a1@e2a>", "<parent@e2a>"}
+	if !reflect.DeepEqual(req.References, want) {
+		t.Errorf("References = %v, want %v", req.References, want)
+	}
+}
+
+func TestAttachReferencesChain_InboundExpired_FallsBack(t *testing.T) {
+	// Parent inbound row has expired (TTL elapsed) — lookup returns
+	// ErrNoRows. We must NOT fail the send: References stays nil and
+	// the compose layer falls back to single-id legacy behavior.
+	lookup := &fakeInboundLookup{returnErr: errors.New("sql: no rows in result set")}
+	req := outbound.SendRequest{ReplyToMessageID: "<parent@e2a>"}
+
+	attachReferencesChain(context.Background(), lookup, "agent-1", &req)
+
+	if req.References != nil {
+		t.Errorf("References = %v, want nil (fall back to single-id on lookup failure)", req.References)
+	}
+}
+
+func TestAttachReferencesChain_InboundMissingNoErr(t *testing.T) {
+	// Defensive: lookup returns (nil, nil). Treat the same as expired —
+	// don't crash, fall back to legacy.
+	lookup := &fakeInboundLookup{}
+	req := outbound.SendRequest{ReplyToMessageID: "<parent@e2a>"}
+
+	attachReferencesChain(context.Background(), lookup, "agent-1", &req)
+
+	if req.References != nil {
+		t.Errorf("References = %v, want nil", req.References)
+	}
+}
+
+func TestAttachReferencesChain_TopOfThread(t *testing.T) {
+	// Parent inbound has no prior References / In-Reply-To (top of
+	// thread). Rebuilt chain is just the parent's own Message-ID.
+	parentRaw := []byte("From: u@x\r\nSubject: Hi\r\n\r\nbody")
+	lookup := &fakeInboundLookup{
+		returnInbound: &identity.Message{RawMessage: parentRaw},
+	}
+	req := outbound.SendRequest{ReplyToMessageID: "<u1@gmail>"}
+
+	attachReferencesChain(context.Background(), lookup, "agent-1", &req)
+
+	want := []string{"<u1@gmail>"}
+	if !reflect.DeepEqual(req.References, want) {
+		t.Errorf("References = %v, want %v", req.References, want)
+	}
+}

--- a/internal/agent/hitl_api.go
+++ b/internal/agent/hitl_api.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"log"
@@ -275,6 +276,7 @@ func (a *API) handleApprovePendingMessage(w http.ResponseWriter, r *http.Request
 			if err != nil {
 				return identity.SendResult{}, err
 			}
+			attachReferencesChain(r.Context(), a.store, agent.ID, &sendReq)
 			result, err := a.sender.Send(agent, sendReq)
 			if err != nil {
 				return identity.SendResult{}, err
@@ -322,6 +324,36 @@ func (a *API) handleApprovePendingMessage(w http.ResponseWriter, r *http.Request
 		"method":     sent.Method,
 		"edited":     sent.Edited,
 	})
+}
+
+// attachReferencesChain rebuilds the References chain on a HITL-approved
+// SendRequest by looking up the parent inbound's raw message via
+// email_message_id. Required because the pending-outbound row only
+// persists the parent's Message-ID, not its raw message — without
+// re-deriving here, HITL-protected replies fall back to single-id
+// References and fork Gmail threads in multi-party conversations.
+//
+// No-op when ReplyToMessageID is empty (a fresh /send, not a reply) or
+// when the parent inbound has expired / been deleted. In the expiry
+// case we silently fall back to legacy single-id behavior — better
+// than refusing the send. Callers must keep ReplyToMessageID populated
+// regardless; only References is filled in here.
+func attachReferencesChain(ctx context.Context, store hitlInboundLookup, agentID string, req *outbound.SendRequest) {
+	if req.ReplyToMessageID == "" {
+		return
+	}
+	inbound, err := store.GetInboundByEmailMessageID(ctx, agentID, req.ReplyToMessageID)
+	if err != nil || inbound == nil {
+		return
+	}
+	req.References = outbound.BuildReferencesChain(inbound.RawMessage, req.ReplyToMessageID)
+}
+
+// hitlInboundLookup is the narrow store contract attachReferencesChain
+// needs. Defined as an interface so tests can stub it without spinning
+// up the full identity store.
+type hitlInboundLookup interface {
+	GetInboundByEmailMessageID(ctx context.Context, agentID, emailMessageID string) (*identity.Message, error)
 }
 
 // buildSendRequestFromMessage reconstructs a SendRequest from a stored

--- a/internal/agent/hitl_magic_api.go
+++ b/internal/agent/hitl_magic_api.go
@@ -221,6 +221,7 @@ func (a *API) magicApprove(w http.ResponseWriter, r *http.Request, messageID, us
 			if err != nil {
 				return identity.SendResult{}, err
 			}
+			attachReferencesChain(r.Context(), a.store, agent.ID, &sendReq)
 			result, err := a.sender.Send(agent, sendReq)
 			if err != nil {
 				return identity.SendResult{}, err

--- a/internal/hitlworker/worker.go
+++ b/internal/hitlworker/worker.go
@@ -110,6 +110,7 @@ func (w *Worker) autoApprove(ctx context.Context, c identity.ExpirationCandidate
 			if err != nil {
 				return identity.SendResult{}, err
 			}
+			w.attachReferencesChain(ctx, agent.ID, &req)
 			result, err := w.sender.Send(agent, req)
 			if err != nil {
 				return identity.SendResult{}, err
@@ -159,6 +160,23 @@ func (w *Worker) autoReject(ctx context.Context, messageID, reason string) {
 	}
 	log.Printf("[mail:%s] dir=outbound type=%s status=expired_rejected agent=%s reason=%q auto_rejected=true",
 		rejected.ID, rejected.Type, rejected.AgentID, reason)
+}
+
+// attachReferencesChain rebuilds the References chain on a HITL-approved
+// SendRequest by looking up the parent inbound's raw message via
+// email_message_id. Duplicates the equivalent helper in internal/agent
+// for the same reason sendRequestFromStoredMessage does — keep this
+// low-level package free of upward imports. See that helper's docstring
+// for the full rationale.
+func (w *Worker) attachReferencesChain(ctx context.Context, agentID string, req *outbound.SendRequest) {
+	if req.ReplyToMessageID == "" {
+		return
+	}
+	inbound, err := w.store.GetInboundByEmailMessageID(ctx, agentID, req.ReplyToMessageID)
+	if err != nil || inbound == nil {
+		return
+	}
+	req.References = outbound.BuildReferencesChain(inbound.RawMessage, req.ReplyToMessageID)
 }
 
 // sendRequestFromStoredMessage reconstructs a SendRequest from a locked

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -563,6 +563,35 @@ func (s *Store) GetInboundMessage(ctx context.Context, id string) (*Message, err
 	return m, nil
 }
 
+// GetInboundByEmailMessageID looks up an inbound message by its RFC 5322
+// Message-ID for the given agent. Used by HITL flows to reach the parent
+// inbound at approval time so the References chain can be rebuilt — the
+// pending-outbound row only stores the parent's Message-ID, not its raw
+// message. Scoped to agent_id to prevent any cross-agent reach across
+// shared infra. Returns sql.ErrNoRows when the inbound has expired or
+// was never persisted; callers must tolerate that and fall back to
+// legacy single-id threading.
+func (s *Store) GetInboundByEmailMessageID(ctx context.Context, agentID, emailMessageID string) (*Message, error) {
+	if emailMessageID == "" {
+		return nil, fmt.Errorf("empty email_message_id")
+	}
+	m := &Message{}
+	err := s.pool.QueryRow(ctx,
+		`SELECT id, agent_id, direction, sender, recipient, to_recipients, cc, subject, email_message_id, raw_message, created_at, expires_at
+		 FROM messages
+		 WHERE agent_id = $1
+		   AND direction = 'inbound'
+		   AND email_message_id = $2
+		   AND expires_at > now()
+		 ORDER BY created_at DESC LIMIT 1`,
+		agentID, emailMessageID,
+	).Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.ToRecipients, &m.CC, &m.Subject, &m.EmailMessageID, &m.RawMessage, &m.CreatedAt, &m.ExpiresAt)
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
 // CreateOutboundMessage stores an outbound message with multi-recipient support.
 // The recipient param is kept for backward compat with the singular recipient column;
 // toRecipients, cc, and bcc are the canonical outbound-only multi-recipient fields.


### PR DESCRIPTION
## Summary

Follow-up to #72. The non-HITL `/reply` path now writes the full `References` chain so multi-party Gmail threads anchor correctly. **HITL-protected replies took a different path**: they stored the `SendRequest` fields to the `messages` table, then rebuilt and sent at approval time via `buildSendRequestFromMessage` / `sendRequestFromStoredMessage`. Neither helper persisted or restored `References`, so HITL-approved replies fell back to single-id `References` and continued to fork Gmail threads in the same multi-party scenarios that #72 set out to fix.

## Approach

Two designs were considered:

- **(A)** Add a `references_chain` column to `messages` and persist it at hold-for-approval time. Schema change.
- **(B)** Re-derive at approval time by looking up the parent inbound's `raw_message` via the `email_message_id` that's already on the pending row. No schema change.

This PR takes **option B**. The parent inbound's raw message is retained for the same TTL window, so re-derivation always succeeds in the common case. When it doesn't (e.g. inbound GC'd before approval — possible if TTLs are configured asymmetrically), the lookup returns `ErrNoRows`, the fallback kicks in, and we send with single-id References. Worse than the new fixed behavior, but identical to today's behavior — never a regression.

## Changes

- **`identity.Store.GetInboundByEmailMessageID`**: new query, scoped to `agent_id` to keep look-ups within ownership boundaries. Honors `expires_at`.
- **`agent.attachReferencesChain`**: helper that runs the lookup and sets `References` on the `SendRequest`. No-op when `ReplyToMessageID` is empty (fresh `/send`) or when the lookup fails. Takes a narrow `hitlInboundLookup` interface so unit tests can stub without a DB.
- **Wired into all 3 HITL-approval call sites**:
  - Human-approval API (`hitl_api.go`)
  - Magic-link approval API (`hitl_magic_api.go`)
  - TTL auto-approve worker (`hitlworker/worker.go`) — keeps its own copy of the helper as a `Worker` method to avoid an upward import, mirroring the existing pattern for `sendRequestFromStoredMessage`.

## Test plan

- [x] **5 unit tests** covering `attachReferencesChain`:
  - happy path (parent inbound has prior chain)
  - non-reply no-op (fresh `/send`)
  - expired-inbound fallback (lookup returns `ErrNoRows`)
  - missing-inbound fallback (defensive: lookup returns `(nil, nil)`)
  - top-of-thread (parent has no prior `References`/`In-Reply-To`)
- [x] `go build ./...` clean.
- [x] `go vet ./...` clean.
- [x] `make test-unit` passes (all packages).
- [x] `go test ./internal/agent/ -run AttachReferences` passes.
- [ ] Integration test for `GetInboundByEmailMessageID` runs against the live Postgres in CI (same shape as existing `GetInboundMessage`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)