### PR TITLE
feat(sdks): 2.2 — deprecate parse(), prefer parse_webhook

### DIFF
--- a/cli/src/__tests__/read.test.ts
+++ b/cli/src/__tests__/read.test.ts
@@ -1,15 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const mockGetMessage = vi.fn();
-const mockParse = vi.fn();
 
 vi.mock("../sdk.js", () => ({
   createClient: vi.fn(() => ({
     agentEmail: "bot@agents.e2a.dev",
-    api: {
-      getMessage: mockGetMessage,
-    },
-    parse: mockParse,
+    getMessage: mockGetMessage,
   })),
 }));
 
@@ -36,7 +32,6 @@ describe("read", () => {
       throw new Error("process.exit");
     });
     mockGetMessage.mockReset();
-    mockParse.mockReset();
   });
 
   afterEach(() => {
@@ -52,16 +47,7 @@ describe("read", () => {
   });
 
   it("displays parsed InboundEmail fields including date", async () => {
-    const detail = {
-      message_id: "msg_123",
-      from: "alice@example.com",
-      to: "bot@agents.e2a.dev",
-      subject: "Hello",
-      created_at: "2025-01-15T10:30:00Z",
-      raw_message: "U3ViamVjdDogSGVsbG8NCg0KSGkgdGhlcmUh",
-    };
-    mockGetMessage.mockResolvedValue(detail);
-    mockParse.mockResolvedValue({
+    mockGetMessage.mockResolvedValue({
       messageId: "msg_123",
       sender: "alice@example.com",
       recipient: "bot@agents.e2a.dev",
@@ -69,12 +55,12 @@ describe("read", () => {
       cc: [],
       subject: "Hello",
       textBody: "Hi there!",
+      receivedAt: "2025-01-15T10:30:00Z",
     });
 
     await read("msg_123", undefined);
 
-    expect(mockGetMessage).toHaveBeenCalledWith("bot@agents.e2a.dev", "msg_123");
-    expect(mockParse).toHaveBeenCalledWith(detail);
+    expect(mockGetMessage).toHaveBeenCalledWith("msg_123");
     expect(mockStdout).toHaveBeenCalledWith("Message ID: msg_123\n");
     expect(mockStdout).toHaveBeenCalledWith("From: alice@example.com\n");
     expect(mockStdout).toHaveBeenCalledWith("Date: 2025-01-15T10:30:00Z\n");
@@ -87,8 +73,7 @@ describe("read", () => {
   });
 
   it("prints Also-To and Cc when the message had other recipients", async () => {
-    mockGetMessage.mockResolvedValue({});
-    mockParse.mockResolvedValue({
+    mockGetMessage.mockResolvedValue({
       messageId: "msg_group",
       sender: "alice@example.com",
       recipient: "bot-a@agents.e2a.dev",
@@ -97,6 +82,7 @@ describe("read", () => {
       cc: ["watcher@example.com"],
       subject: "Group",
       textBody: "",
+      receivedAt: null,
     });
 
     await read("msg_group", undefined);
@@ -106,8 +92,7 @@ describe("read", () => {
   });
 
   it("prints Also-To when the agent was Bcc'd (not in the To: header)", async () => {
-    mockGetMessage.mockResolvedValue({});
-    mockParse.mockResolvedValue({
+    mockGetMessage.mockResolvedValue({
       messageId: "msg_bcc",
       sender: "alice@example.com",
       recipient: "bot-bcc@agents.e2a.dev",
@@ -115,6 +100,7 @@ describe("read", () => {
       cc: [],
       subject: "BCC",
       textBody: "",
+      receivedAt: null,
     });
 
     await read("msg_bcc", undefined);
@@ -125,16 +111,7 @@ describe("read", () => {
   });
 
   it("shows 'unknown' when receivedAt is null", async () => {
-    const detail = {
-      message_id: "msg_456",
-      from: "bob@example.com",
-      to: "bot@agents.e2a.dev",
-      subject: "Test",
-      created_at: undefined,
-      raw_message: "",
-    };
-    mockGetMessage.mockResolvedValue(detail);
-    mockParse.mockResolvedValue({
+    mockGetMessage.mockResolvedValue({
       messageId: "msg_456",
       sender: "bob@example.com",
       recipient: "bot@agents.e2a.dev",
@@ -142,6 +119,7 @@ describe("read", () => {
       cc: [],
       subject: "Test",
       textBody: "",
+      receivedAt: null,
     });
 
     await read("msg_456", undefined);

--- a/cli/src/commands/read.ts
+++ b/cli/src/commands/read.ts
@@ -13,8 +13,10 @@ export async function read(messageId: string | undefined, from: string | undefin
     process.exit(1);
   }
 
-  const detail = await client.api.getMessage(client.agentEmail, messageId);
-  const email = await client.parse(detail);
+  // getMessage returns a pre-verified InboundEmail (the bearer token
+  // already authenticated the channel) — no `verifySignature` step
+  // needed, no second roundtrip for the raw detail.
+  const email = await client.getMessage(messageId);
 
   process.stdout.write(`Message ID: ${email.messageId}\n`);
   process.stdout.write(`From: ${email.sender}\n`);
@@ -29,7 +31,7 @@ export async function read(messageId: string | undefined, from: string | undefin
   if (email.cc.length > 0) {
     process.stdout.write(`Cc: ${email.cc.join(", ")}\n`);
   }
-  process.stdout.write(`Date: ${detail.created_at ?? "unknown"}\n`);
+  process.stdout.write(`Date: ${email.receivedAt ?? "unknown"}\n`);
   process.stdout.write(`Subject: ${email.subject}\n`);
   process.stdout.write("\n");
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -397,7 +397,7 @@ All claim fields (`message_id`, `sender`, `recipient`, `to`, `cc`, `subject`, `t
 High-level sync client. `api_key` falls back to `E2A_API_KEY` env var.
 
 - `client.parse_webhook(body, secret=None)` → `InboundEmail` — parse + HMAC-verify (recommended for webhook handlers). Reads `E2A_WEBHOOK_SECRET` if no secret is passed; raises `PermissionError` on bad signature.
-- `client.parse(body)` → `InboundEmail` — accepts bytes, str, dict, or `MessageDetail`. Returns *unverified* — claim fields raise `UnverifiedEmailError` until `email.verify_signature()` succeeds.
+- `client.parse(body)` → `InboundEmail` — *deprecated since 2.2, removed in 3.0.* Accepts bytes, str, dict, or `MessageDetail` and returns an unverified email. Use `parse_webhook` for webhook handlers, or `email.unverified_payload` for inspection without verification. Calling `parse` emits a `DeprecationWarning`.
 - `client.get_message(message_id)` → `InboundEmail` — pre-verified (REST channel auth)
 - `client.get_messages(status="unread", page_size=50)` → `MessageList`
 - `client.reply(message_id, body, ...)` → `SendResult`

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "e2a"
-version = "2.1.0"
+version = "2.2.0"
 description = "Python SDK for the e2a protocol — email-to-agent authentication"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdks/python/src/e2a/v1/async_client.py
+++ b/sdks/python/src/e2a/v1/async_client.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import base64
 import json
 import os
+import warnings
 from typing import TYPE_CHECKING, Any, AsyncIterator, Optional
 from urllib.parse import quote
 
@@ -306,13 +307,33 @@ class AsyncE2AClient:
     ) -> AsyncInboundEmail:
         """Parse a webhook payload into an AsyncInboundEmail.
 
+        .. deprecated:: 2.2
+           Use :meth:`parse_webhook` for webhook handlers (parse + verify
+           in one call) or :attr:`AsyncInboundEmail.unverified_payload`
+           for inspection without verification. ``parse`` will be removed
+           in 3.0.
+
         Synchronous (no I/O). The returned email's ``.reply()`` is async.
 
         Returns an *unverified* AsyncInboundEmail — claim fields raise
         :class:`UnverifiedEmailError` until you call
-        :meth:`AsyncInboundEmail.verify_signature`. For webhook handlers,
-        prefer :meth:`parse_webhook` which combines parse + verify.
+        :meth:`AsyncInboundEmail.verify_signature`.
         """
+        warnings.warn(
+            "AsyncE2AClient.parse() is deprecated and will be removed in 3.0. "
+            "For webhook handlers, use client.parse_webhook(body) — it "
+            "parses and HMAC-verifies in one call. For inspection without "
+            "verification, use email.unverified_payload after parse_webhook.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._parse_unverified(body)
+
+    def _parse_unverified(
+        self,
+        body: bytes | str | dict[str, Any] | MessageDetail,
+    ) -> AsyncInboundEmail:
+        """Internal parse without the deprecation warning."""
         if isinstance(body, MessageDetail):
             data = body.model_dump(by_alias=True)
         elif isinstance(body, dict):
@@ -334,7 +355,7 @@ class AsyncE2AClient:
         See :meth:`E2AClient.parse_webhook` — identical contract.
         Synchronous despite living on the async client (no I/O).
         """
-        email = self.parse(body)
+        email = self._parse_unverified(body)
         if not email.verify_signature(secret):
             raise PermissionError("HMAC signature verification failed")
         return email

--- a/sdks/python/src/e2a/v1/client.py
+++ b/sdks/python/src/e2a/v1/client.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import base64
 import json
 import os
+import warnings
 from typing import Any, Optional
 
 from e2a.v1.api import E2AApi
@@ -92,14 +93,39 @@ class E2AClient:
     ) -> InboundEmail:
         """Parse a webhook payload or MessageDetail into an InboundEmail.
 
+        .. deprecated:: 2.2
+           Use :meth:`parse_webhook` for webhook handlers (parse + verify
+           in one call) or :attr:`InboundEmail.unverified_payload` for
+           inspection without verification. ``parse`` will be removed in
+           3.0.
+
         Accepts bytes, JSON string, dict, or a generated MessageDetail.
 
         The returned InboundEmail starts in the *unverified* state —
-        property accesses (sender, subject, body, …) will raise
-        :class:`UnverifiedEmailError` until you call
-        :meth:`InboundEmail.verify_signature`. For webhook handlers,
-        prefer :meth:`parse_webhook` which combines parse + verify.
+        property accesses (sender, subject, body, …) raise
+        :class:`UnverifiedEmailError` until :meth:`InboundEmail.verify_signature`
+        succeeds. The combination of "looks usable" + "blows up on first
+        field access" is precisely the trap that motivated the deprecation;
+        ``parse_webhook`` raises immediately on bad signatures and returns
+        a ready-to-use object on success.
         """
+        warnings.warn(
+            "E2AClient.parse() is deprecated and will be removed in 3.0. "
+            "For webhook handlers, use client.parse_webhook(body) — it "
+            "parses and HMAC-verifies in one call. For inspection without "
+            "verification, use email.unverified_payload after parse_webhook.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self._parse_unverified(body)
+
+    def _parse_unverified(
+        self,
+        body: bytes | str | dict[str, Any] | MessageDetail,
+    ) -> InboundEmail:
+        """Internal parse without the deprecation warning. ``parse_webhook``
+        delegates here so the recommended path doesn't emit the warning
+        meant for direct ``parse`` callers."""
         if isinstance(body, MessageDetail):
             data = body.model_dump(by_alias=True)
         elif isinstance(body, dict):
@@ -126,7 +152,7 @@ class E2AClient:
         ``secret`` defaults to the ``E2A_WEBHOOK_SECRET`` environment
         variable (with ``E2A_HMAC_SECRET`` accepted as a deprecated alias).
         """
-        email = self.parse(body)
+        email = self._parse_unverified(body)
         if not email.verify_signature(secret):
             raise PermissionError("HMAC signature verification failed")
         return email

--- a/sdks/python/src/e2a/v1/handler.py
+++ b/sdks/python/src/e2a/v1/handler.py
@@ -344,11 +344,14 @@ class InboundEmail:
 
         ``secret`` defaults to the ``E2A_WEBHOOK_SECRET`` environment
         variable when omitted (with ``E2A_HMAC_SECRET`` accepted as a
-        deprecated alias), so the standard webhook-handler pattern is::
+        deprecated alias).
 
-            email = client.parse(body)
-            if not email.verify_signature():
-                return 401
+        Most webhook handlers should use :meth:`E2AClient.parse_webhook`
+        instead — it calls ``verify_signature`` internally and raises
+        ``PermissionError`` on failure, so the handler reads as one
+        concise call. Use ``verify_signature`` directly only when you
+        need to inspect ``unverified_payload`` first or have some other
+        reason to keep the unverified object around.
 
         Checks (in order):
 

--- a/sdks/python/tests/test_v1_async_client.py
+++ b/sdks/python/tests/test_v1_async_client.py
@@ -121,6 +121,36 @@ async def test_parse_unsupported_type():
             client.parse(12345)
 
 
+@pytest.mark.anyio
+async def test_parse_emits_deprecation_warning():
+    """Mirror of the sync test — async client's `parse` must also emit
+    the deprecation warning so async webhook handlers see the same
+    migration signal."""
+    webhook = _make_message_detail_json()
+    async with AsyncE2AClient(api_key="k", agent_email="bot@agents.e2a.dev") as client:
+        with pytest.warns(DeprecationWarning, match="parse_webhook"):
+            client.parse(webhook)
+
+
+@pytest.mark.anyio
+async def test_parse_webhook_does_not_emit_deprecation_warning(monkeypatch):
+    """Same regression guard as the sync test — `parse_webhook` must not
+    surface the deprecation warning meant for direct `parse` callers."""
+    import warnings
+
+    monkeypatch.setenv("E2A_WEBHOOK_SECRET", "secret-xyz")
+    webhook = _make_message_detail_json()
+    async with AsyncE2AClient(api_key="k", agent_email="bot@agents.e2a.dev") as client:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            try:
+                client.parse_webhook(webhook)
+            except DeprecationWarning:
+                pytest.fail("parse_webhook should not emit DeprecationWarning")
+            except PermissionError:
+                pass
+
+
 # ── get_message() ────────────────────────────────────────────────
 
 

--- a/sdks/python/tests/test_v1_client.py
+++ b/sdks/python/tests/test_v1_client.py
@@ -116,6 +116,40 @@ def test_parse_unsupported_type():
             client.parse(12345)
 
 
+def test_parse_emits_deprecation_warning():
+    """Calling the legacy `parse` method on the sync client emits a
+    DeprecationWarning that points users at parse_webhook. Pin the
+    deprecation contract so it isn't silently dropped before 3.0."""
+    webhook = _make_message_detail_json()
+    with E2AClient(api_key="k", agent_email="bot@agents.e2a.dev") as client:
+        with pytest.warns(DeprecationWarning, match="parse_webhook"):
+            client.parse(webhook)
+
+
+def test_parse_webhook_does_not_emit_deprecation_warning(monkeypatch):
+    """The recommended path must not emit the deprecation warning even
+    though it shares the underlying parse logic. Regression: an early
+    refactor had parse_webhook delegate to parse(), which made every
+    correct caller see the deprecation message."""
+    import warnings
+
+    monkeypatch.setenv("E2A_WEBHOOK_SECRET", "secret-xyz")
+    webhook = _make_message_detail_json()
+    with E2AClient(api_key="k", agent_email="bot@agents.e2a.dev") as client:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            try:
+                client.parse_webhook(webhook)
+            except DeprecationWarning:
+                pytest.fail("parse_webhook should not emit DeprecationWarning")
+            except PermissionError:
+                # Expected — fixture body has no real signature, so
+                # verify_signature returns False and parse_webhook raises.
+                # The point of this test is the absence of DeprecationWarning,
+                # which we'd have hit before the PermissionError if present.
+                pass
+
+
 # ── get_message() ────────────────────────────────────────────────
 
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -96,7 +96,9 @@ Parse + HMAC-verify a webhook payload in one call. Reads `E2A_WEBHOOK_SECRET` if
 
 ### `client.parse(body)` → `Promise<InboundEmail>`
 
-Parse a webhook payload (Buffer, string, or object) into an `InboundEmail`. Returns *unverified* — accessing claim fields like `sender` or `subject` throws `UnverifiedEmailError` until `email.verifySignature()` succeeds. Prefer `parseWebhook` unless you need to inspect the payload before verifying.
+**Deprecated since 2.2 — will be removed in 3.0.** Use `parseWebhook` for webhook handlers, or call `parseWebhook` and read `email.unverifiedPayload` after the verification failure for inspection without verification. Calling `parse` logs a one-time deprecation warning to `console.warn`.
+
+Parses a webhook payload (Buffer, string, or object) into an `InboundEmail` and returns it in the unverified state — accessing claim fields like `sender` or `subject` throws `UnverifiedEmailError` until `email.verifySignature()` succeeds.
 
 ### `client.getMessages(opts?)` → `Promise<MessageList>`
 

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/sdk",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "TypeScript SDK for e2a — email for AI agents",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/sdks/typescript/src/v1/client.ts
+++ b/sdks/typescript/src/v1/client.ts
@@ -8,6 +8,27 @@ import { WSStream } from "./ws.js";
 type Schemas = components["schemas"];
 type MessagePayload = Schemas["MessageDetail"] | WebhookPayload;
 
+// Module-scoped flag so the deprecation message appears once per
+// process, not once per call. Mirrors the standard Node deprecation
+// pattern (cf. util.deprecate). Tests that need to assert the warning
+// fires can reset this via the exported test helper below.
+let _parseWarnedOnce = false;
+function warnParseDeprecated(): void {
+  if (_parseWarnedOnce) return;
+  _parseWarnedOnce = true;
+  console.warn(
+    "[e2a] E2AClient.parse() is deprecated and will be removed in 3.0. " +
+      "For webhook handlers, use client.parseWebhook(body) — it parses " +
+      "and HMAC-verifies in one call. For inspection without " +
+      "verification, use email.unverifiedPayload after parseWebhook.",
+  );
+}
+
+/** Test-only: reset the once-per-process deprecation flag. */
+export function _resetParseDeprecationWarningForTests(): void {
+  _parseWarnedOnce = false;
+}
+
 export interface E2AClientOptions extends E2AApiOptions {
   /**
    * Default agent email for message/WS operations. Falls back to the
@@ -45,12 +66,32 @@ export class E2AClient {
   /**
    * Parse a webhook payload (or raw `MessageDetail`) into an {@link InboundEmail}.
    *
+   * @deprecated since 2.2 — will be removed in 3.0. For webhook
+   * handlers, use {@link parseWebhook} (parse + HMAC-verify in one
+   * call). For inspection without verification, call `parseWebhook`
+   * and then read `email.unverifiedPayload` after catching the
+   * verification failure. Calling `parse` logs a one-time deprecation
+   * warning to `console.warn`.
+   *
    * Returns an *unverified* InboundEmail — claim getters (sender,
    * subject, body, …) throw `UnverifiedEmailError` until you call
-   * {@link InboundEmail.verifySignature}. For webhook handlers,
-   * prefer {@link parseWebhook} which combines parse + verify.
+   * {@link InboundEmail.verifySignature}. The "looks usable until you
+   * touch a field" shape is precisely the trap that motivated the
+   * deprecation.
    */
   async parse(body: Buffer | string | MessagePayload): Promise<InboundEmail> {
+    warnParseDeprecated();
+    return this._parseUnverified(body);
+  }
+
+  /**
+   * Internal parse without the deprecation warning. `parseWebhook`
+   * delegates here so the recommended path doesn't emit the warning
+   * meant for direct `parse` callers.
+   */
+  private async _parseUnverified(
+    body: Buffer | string | MessagePayload,
+  ): Promise<InboundEmail> {
     const detail: MessagePayload =
       typeof body === "string"
         ? (JSON.parse(body) as MessagePayload)
@@ -74,7 +115,7 @@ export class E2AClient {
     body: Buffer | string | MessagePayload,
     secret?: string,
   ): Promise<InboundEmail> {
-    const email = await this.parse(body);
+    const email = await this._parseUnverified(body);
     if (!email.verifySignature(secret)) {
       throw new Error("HMAC signature verification failed");
     }

--- a/sdks/typescript/test/v1/client.test.ts
+++ b/sdks/typescript/test/v1/client.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { E2AClient } from "../../src/v1/client.js";
+import {
+  E2AClient,
+  _resetParseDeprecationWarningForTests,
+} from "../../src/v1/client.js";
 import { InboundEmail } from "../../src/v1/inbound-email.js";
 import type { WebhookPayload } from "../../src/v1/inbound-email.js";
 
@@ -222,6 +225,82 @@ describe("E2AClient", () => {
     );
     expect(fromBuffer.unverifiedPayload.messageId).toBe("msg_buffer");
     expect(fromBuffer.unverifiedPayload.sender).toBe("dana@example.com");
+  });
+
+  // ── Deprecation contract for parse() ─────────────────────────────
+
+  it("parse() logs a deprecation warning pointing at parseWebhook", async () => {
+    // Mirrors the Python SDK contract — pin so the warning isn't silently
+    // dropped before the 3.0 removal.
+    _resetParseDeprecationWarningForTests();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const payload: WebhookPayload = {
+        message_id: "msg_dep_1",
+        from: "x@example.com",
+        to: ["bot@test.dev"],
+        recipient: "bot@test.dev",
+        raw_message: Buffer.from(
+          "From: x@example.com\r\nTo: bot@test.dev\r\nSubject: D\r\n\r\nbody",
+        ).toString("base64"),
+      };
+      await client.parse(payload);
+      expect(warn).toHaveBeenCalledOnce();
+      expect(warn.mock.calls[0][0]).toContain("parseWebhook");
+      expect(warn.mock.calls[0][0]).toContain("deprecated");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("parse() warning is once-per-process, not once-per-call", async () => {
+    // The warning would be obnoxious if it fired on every call in a hot
+    // webhook handler. Pin the once-per-process behaviour so future
+    // refactors don't regress it.
+    _resetParseDeprecationWarningForTests();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const payload: WebhookPayload = {
+        message_id: "msg_dep_2",
+        from: "x@example.com",
+        to: ["bot@test.dev"],
+        recipient: "bot@test.dev",
+        raw_message: Buffer.from(
+          "From: x@example.com\r\nTo: bot@test.dev\r\nSubject: D\r\n\r\nbody",
+        ).toString("base64"),
+      };
+      await client.parse(payload);
+      await client.parse(payload);
+      await client.parse(payload);
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it("parseWebhook() does not emit the parse() deprecation warning", async () => {
+    // Regression: an early refactor had parseWebhook delegate to parse(),
+    // which made every correct caller see the deprecation message.
+    _resetParseDeprecationWarningForTests();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const payload: WebhookPayload = {
+        message_id: "msg_dep_3",
+        from: "x@example.com",
+        to: ["bot@test.dev"],
+        recipient: "bot@test.dev",
+        raw_message: Buffer.from(
+          "From: x@example.com\r\nTo: bot@test.dev\r\nSubject: D\r\n\r\nbody",
+        ).toString("base64"),
+        auth_headers: {},
+      };
+      await expect(
+        client.parseWebhook(payload, "any-secret"),
+      ).rejects.toThrow();
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("reply", async () => {


### PR DESCRIPTION
## Summary

`client.parse(body)` returns an `InboundEmail` in the unverified state — looks usable, but every claim getter (`sender`, `subject`, `text_body`, `.reply()`, …) trips `UnverifiedEmailError` on first access. The shape is what bit us in [mnexa-ai's ntds inbox worker](https://github.com/Mnexa-AI/mnexa-ai/commit/136e2423): intake verified, the worker re-parsed the persisted body without re-verifying, every dispatch raised, the row retried 5x and gave up.

`client.parse_webhook(body, secret)` already exists and combines parse + HMAC-verify in one call. This PR deprecates the lower-level `parse()` so callers see a clear migration signal in IDEs and at runtime, then schedules removal in 3.0.

## Changes (Python + TypeScript, kept consistent)

- **`parse()` is deprecated.** Python emits `DeprecationWarning`; TS logs once-per-process to `console.warn`. Both messages point at `parse_webhook` and explain the migration. Behavior is unchanged — existing code keeps working with a noisy log line.
- **`parse_webhook` no longer routes through `parse()` internally.** Both SDKs now have a private `_parse_unverified` / `_parseUnverified` that the recommended path delegates to, so it stays warning-free.
- **Deprecation contract tests** in both SDKs pin: warning fires on `parse()`, never fires on `parse_webhook()`, and on TS the warning is once-per-process (a hot webhook handler shouldn't log on every call).
- **Docstrings + READMEs** mark `parse` as deprecated with the migration recipe.
- **Drive-by:** the CLI's `e2a read` command was calling `client.parse(detail)` and then accessing claim getters — pre-existing 2.0 gate bug that would have already been broken at runtime. Switched to `client.getMessage()` (returns pre-verified, also drops a redundant roundtrip).
- **Version bump:** Python 2.1.0 → 2.2.0, TS 2.1.0 → 2.2.0.

## Why deprecate instead of remove

Soft-deprecate gives existing consumers (mnexa-ai's `mnexa-api` + `mnexa-ntds` services, plus any external `pip install e2a` / `npm install @e2a/sdk` users on 2.x) one minor cycle to migrate before 3.0 removes the method. No breaking change today; the warning surfaces the trap.

## Test plan

- [x] `pytest tests/` (Python SDK) — 174 passed, e2e suite skips without server creds (pre-existing)
- [x] `npm test --workspace @e2a/sdk` — 71 passed including 3 new deprecation tests
- [x] `npm test --workspace @e2a/cli` — 99 passed (read.test.ts updated for the CLI refactor)
- [ ] After merge: tag `python-v2.2.0` and `ts-sdk-v2.2.0` to trigger the publish workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)