### PR TITLE
chore: add Product Hunt launch badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![npm @e2a/sdk](https://img.shields.io/npm/v/%40e2a%2Fsdk?label=%40e2a%2Fsdk)](https://www.npmjs.com/package/@e2a/sdk)
 [![PyPI e2a](https://img.shields.io/pypi/v/e2a)](https://pypi.org/project/e2a/)
 
+<a href="https://www.producthunt.com/products/e2a-open-source-email-api-for-agents?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-e2a-open-source-email-api-for-agents" target="_blank" rel="noopener noreferrer"><img alt="e2a – open-source email API for agents - Give your AI agents a real, authenticated email address. | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1145559&theme=light&t=1778615217650"></a>
+
 Authenticated email gateway for AI agents. Receive emails as webhooks or via WebSocket, send emails through an HTTP API, and verify the identity of every sender — humans and other agents alike.
 
 - **Authenticated transport** — SPF/DKIM verified on inbound; HMAC-signed `X-E2A-Auth-*` headers on every delivery

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -98,6 +98,22 @@ export default function Home() {
             Read the docs
           </Link>
         </div>
+        <div style={{ marginTop: 28, display: "flex", justifyContent: "center" }}>
+          <a
+            href="https://www.producthunt.com/products/e2a-open-source-email-api-for-agents?embed=true&utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-e2a-open-source-email-api-for-agents"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1145559&theme=light&t=1778615217650"
+              alt="e2a – open-source email API for agents - Give your AI agents a real, authenticated email address. | Product Hunt"
+              width={250}
+              height={54}
+              style={{ display: "block" }}
+            />
+          </a>
+        </div>
       </section>
 
       <div style={{ height: "0.5px", background: "#E8E0D4" }} />


### PR DESCRIPTION
## Summary
- Adds the Product Hunt "Featured" badge to `README.md` (under the existing shields row).
- Adds the same badge to the landing page hero in `web/src/app/page.tsx`, centered below the "Get started free / Read the docs" buttons.

Both link to the e2a Product Hunt listing for the launch.

## Test plan
- [ ] `cd web && npm run dev` → open `http://localhost:3000`, confirm badge renders under the hero CTAs and clicks through to PH in a new tab
- [ ] View `README.md` on GitHub (preview in PR) → confirm badge renders and links to PH

🤖 Generated with [Claude Code](https://claude.com/claude-code)