### PR TITLE
feat(mcp): add @e2a/mcp-server for ADK and other MCP clients

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -1,0 +1,54 @@
+name: Publish MCP server
+
+on:
+  push:
+    tags:
+      - "mcp-v*"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false # never cancel a running publish
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+      - run: npm install --package-lock=false
+      - run: npm run build --workspace @e2a/sdk
+      - run: npm test --workspace @e2a/mcp-server
+      - run: npm run build --workspace @e2a/mcp-server
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      # Node 24 ships with npm >= 11, which is the floor npm's trusted-publisher
+      # OIDC flow requires (docs.npmjs.com/trusted-publishers: "npm CLI 11.5.1
+      # or later and Node 22.14.0 or higher"). Node 20 + npm 10.x silently
+      # skips the OIDC handshake and surfaces a misleading 404 PUT error
+      # (npm/cli#9088, #8730).
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+          registry-url: "https://registry.npmjs.org"
+
+      - run: npm install --package-lock=false
+      - run: npm run build --workspace @e2a/sdk
+      - run: npm run build --workspace @e2a/mcp-server
+
+      - name: Publish to npm
+        run: npm publish --workspace @e2a/mcp-server --access public --provenance

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -166,6 +166,21 @@ jobs:
       - run: npm test --workspace @e2a/cli
       - run: npm run build --workspace @e2a/cli
 
+  mcp:
+    name: MCP server tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+      - run: npm install --package-lock=false
+      - run: npm run build --workspace @e2a/sdk
+      - run: npm test --workspace @e2a/mcp-server
+      - run: npm run build --workspace @e2a/mcp-server
+
   swagger:
     name: Swagger spec freshness
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,15 @@ Triggered by GitHub release publish or `workflow_dispatch`.
 3. Commit and push to main
 4. `gh workflow run "Publish CLI" --ref main`
 
+### MCP server
+Triggered by tag push (`mcp-v*`) or `workflow_dispatch`. Publishes `@e2a/mcp-server` to npm with provenance.
+1. Bump `version` in `mcp/package.json`
+2. `npm run build --workspace @e2a/mcp-server`
+3. Commit and push to main
+4. `git tag mcp-v<VERSION> && git push origin mcp-v<VERSION>`
+
+The first publish requires `@e2a/mcp-server` to be configured as a trusted publisher on npmjs.com against `Mnexa-AI/e2a` + `publish-mcp.yml` (one-time, done in the npm web UI).
+
 ## Key Conventions
 
 - **npm workspaces**: root `package.json` declares `cli` and `sdks/typescript` as workspaces. Always use `--workspace` flag for workspace commands. Use `--package-lock=false` for install.

--- a/mcp/.gitignore
+++ b/mcp/.gitignore
@@ -1,0 +1,3 @@
+dist/
+node_modules/
+*.tgz

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,159 @@
+# @e2a/mcp-server
+
+[Model Context Protocol](https://modelcontextprotocol.io) server for [e2a](https://e2a.dev) — gives any MCP-aware AI agent its own email inbox to send, receive, reply, and (optionally) review held outbound mail before it ships.
+
+Works with Google ADK, LangChain, OpenAI Agents SDK, Claude Desktop, Cursor, Cline, and any other MCP host.
+
+## Install
+
+No install — invoke directly with `npx`:
+
+```bash
+npx -y @e2a/mcp-server
+```
+
+Requires Node 18+. The server speaks MCP over stdio.
+
+## Configuration
+
+Set these in the MCP host's environment block.
+
+| Variable | Required | Default | Description |
+| --- | --- | --- | --- |
+| `E2A_API_KEY` | yes | — | API key from the [e2a dashboard](https://e2a.dev) |
+| `E2A_AGENT_EMAIL` | no | — | Default agent inbox. Scopes the tools so the LLM doesn't have to repeat the address. |
+| `E2A_BASE_URL` | no | `https://e2a.dev` | Self-hosted deployment URL |
+
+## Quick start
+
+### Google ADK (Python)
+
+```python
+from google.adk.agents import Agent
+from google.adk.tools.mcp_tool import McpToolset
+from google.adk.tools.mcp_tool.mcp_session_manager import StdioConnectionParams
+from mcp import StdioServerParameters
+
+root_agent = Agent(
+    model="gemini-flash-latest",
+    name="e2a_agent",
+    instruction="Help the user manage their email. Reply to threads with `reply_to_message` to preserve threading headers.",
+    tools=[
+        McpToolset(
+            connection_params=StdioConnectionParams(
+                server_params=StdioServerParameters(
+                    command="npx",
+                    args=["-y", "@e2a/mcp-server"],
+                    env={
+                        "E2A_API_KEY": "YOUR_E2A_API_KEY",
+                        "E2A_AGENT_EMAIL": "your-bot@your-domain.com",
+                    },
+                ),
+                timeout=30,
+            ),
+        ),
+    ],
+)
+```
+
+### LangChain (Python)
+
+Using [`langchain-mcp-adapters`](https://github.com/langchain-ai/langchain-mcp-adapters):
+
+```python
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langgraph.prebuilt import create_react_agent
+
+client = MultiServerMCPClient({
+    "e2a": {
+        "command": "npx",
+        "args": ["-y", "@e2a/mcp-server"],
+        "transport": "stdio",
+        "env": {
+            "E2A_API_KEY": "YOUR_E2A_API_KEY",
+            "E2A_AGENT_EMAIL": "your-bot@your-domain.com",
+        },
+    },
+})
+
+tools = await client.get_tools()
+agent = create_react_agent("anthropic:claude-sonnet-4-6", tools)
+```
+
+### OpenAI Agents SDK (Python)
+
+```python
+from agents import Agent, Runner
+from agents.mcp import MCPServerStdio
+
+async with MCPServerStdio(
+    params={
+        "command": "npx",
+        "args": ["-y", "@e2a/mcp-server"],
+        "env": {
+            "E2A_API_KEY": "YOUR_E2A_API_KEY",
+            "E2A_AGENT_EMAIL": "your-bot@your-domain.com",
+        },
+    },
+) as e2a:
+    agent = Agent(name="e2a_agent", mcp_servers=[e2a])
+    result = await Runner.run(agent, "Reply to the latest unread email politely.")
+```
+
+### Claude Desktop / Cline / Cursor
+
+Add to the MCP config (`claude_desktop_config.json`, `cline_mcp_settings.json`, etc.):
+
+```json
+{
+  "mcpServers": {
+    "e2a": {
+      "command": "npx",
+      "args": ["-y", "@e2a/mcp-server"],
+      "env": {
+        "E2A_API_KEY": "YOUR_E2A_API_KEY",
+        "E2A_AGENT_EMAIL": "your-bot@your-domain.com"
+      }
+    }
+  }
+}
+```
+
+## Tools
+
+### Identity
+
+| Tool | Description |
+| --- | --- |
+| `whoami` | Get the default agent's full record (requires `E2A_AGENT_EMAIL`). |
+| `list_agents` | List every agent inbox owned by the authenticated user. |
+| `create_agent` | Register a new inbox using a slug on the shared domain. Defaults to `local` mode — no webhook required. |
+
+### Messages
+
+| Tool | Description |
+| --- | --- |
+| `send_email` | Send a new email. When the agent has HITL enabled, the message is held and returns `status: pending_approval` instead of `sent`. |
+| `reply_to_message` | Reply to an inbound message. Preserves In-Reply-To / References for thread continuity. |
+| `list_messages` | List inbound mail. Filter by `status` (unread / read / all), paginate with `page_size` + `token`. |
+| `get_message` | Fetch full body, headers, and attachment metadata for one message. |
+
+### Human-in-the-loop approval
+
+| Tool | Description |
+| --- | --- |
+| `list_pending_messages` | List outbound mail awaiting human approval, soonest-expiring first. |
+| `get_pending_message` | Get the full draft (subject, recipients, body) of a pending message. |
+| `approve_pending_message` | Send a held message, optionally with reviewer edits (subject / body / recipients). |
+| `reject_pending_message` | Discard a held message; the optional `reason` is stored for audit. |
+
+## Links
+
+- [e2a docs](https://e2a.dev)
+- [Source](https://github.com/Mnexa-AI/e2a/tree/main/mcp)
+- [Issues](https://github.com/Mnexa-AI/e2a/issues)
+- [Model Context Protocol](https://modelcontextprotocol.io)
+
+## License
+
+Apache-2.0

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "MCP server for e2a — email for AI agents",
   "bin": {
-    "e2a-mcp": "./dist/index.js"
+    "e2a-mcp": "dist/index.js"
   },
   "type": "module",
   "main": "./dist/index.js",
@@ -36,7 +36,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Mnexa-AI/e2a",
+    "url": "git+https://github.com/Mnexa-AI/e2a.git",
     "directory": "mcp"
   },
   "homepage": "https://github.com/Mnexa-AI/e2a/tree/main/mcp",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@e2a/mcp-server",
+  "version": "0.1.0",
+  "description": "MCP server for e2a — email for AI agents",
+  "bin": {
+    "e2a-mcp": "./dist/index.js"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "prepublishOnly": "npm run build"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Mnexa-AI/e2a",
+    "directory": "mcp"
+  },
+  "homepage": "https://github.com/Mnexa-AI/e2a/tree/main/mcp",
+  "bugs": "https://github.com/Mnexa-AI/e2a/issues",
+  "dependencies": {
+    "@e2a/sdk": "^2.2.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.4",
+    "vitest": "^4.1.5"
+  }
+}

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -18,6 +18,21 @@
   "engines": {
     "node": ">=18"
   },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "email",
+    "agent",
+    "ai",
+    "e2a",
+    "adk",
+    "google-adk",
+    "langchain",
+    "claude",
+    "anthropic",
+    "openai",
+    "agents"
+  ],
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/mcp/src/client.ts
+++ b/mcp/src/client.ts
@@ -1,0 +1,10 @@
+import { E2AClient } from "@e2a/sdk/v1";
+import type { McpConfig } from "./config.js";
+
+export function makeClient(cfg: McpConfig): E2AClient {
+  return new E2AClient({
+    apiKey: cfg.apiKey,
+    ...(cfg.baseUrl ? { baseUrl: cfg.baseUrl } : {}),
+    ...(cfg.agentEmail ? { agentEmail: cfg.agentEmail } : {}),
+  });
+}

--- a/mcp/src/config.ts
+++ b/mcp/src/config.ts
@@ -1,0 +1,21 @@
+export interface McpConfig {
+  apiKey: string;
+  baseUrl?: string;
+  agentEmail?: string;
+}
+
+export class ConfigError extends Error {}
+
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): McpConfig {
+  const apiKey = env.E2A_API_KEY;
+  if (!apiKey) {
+    throw new ConfigError(
+      "E2A_API_KEY is required. Set it in the MCP server's environment (typically via your ADK MCPToolset `env` config).",
+    );
+  }
+  return {
+    apiKey,
+    baseUrl: env.E2A_BASE_URL || undefined,
+    agentEmail: env.E2A_AGENT_EMAIL || undefined,
+  };
+}

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createRequire } from "node:module";
+import { ConfigError, loadConfig } from "./config.js";
+import { makeClient } from "./client.js";
+import { buildServer } from "./server.js";
+
+const require = createRequire(import.meta.url);
+const pkg = require("../package.json") as { version: string };
+
+async function main(): Promise<void> {
+  let cfg;
+  try {
+    cfg = loadConfig();
+  } catch (err) {
+    if (err instanceof ConfigError) {
+      process.stderr.write(`${err.message}\n`);
+      process.exit(1);
+    }
+    throw err;
+  }
+  const client = makeClient(cfg);
+  const server = buildServer({ client, version: pkg.version });
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+main().catch((err) => {
+  const message = err instanceof Error ? err.stack ?? err.message : String(err);
+  process.stderr.write(`e2a-mcp fatal: ${message}\n`);
+  process.exit(1);
+});

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -1,0 +1,21 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { E2AClient } from "@e2a/sdk/v1";
+import { registerMessageTools } from "./tools/messages.js";
+import { registerAgentTools } from "./tools/agents.js";
+import { registerHitlTools } from "./tools/hitl.js";
+
+export interface BuildServerOptions {
+  client: E2AClient;
+  version?: string;
+}
+
+export function buildServer({ client, version = "0.1.0" }: BuildServerOptions): McpServer {
+  const server = new McpServer({
+    name: "e2a",
+    version,
+  });
+  registerMessageTools(server, client);
+  registerAgentTools(server, client);
+  registerHitlTools(server, client);
+  return server;
+}

--- a/mcp/src/tools/agents.ts
+++ b/mcp/src/tools/agents.ts
@@ -1,0 +1,16 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { E2AClient } from "@e2a/sdk/v1";
+import { runTool } from "./util.js";
+
+export function registerAgentTools(server: McpServer, client: E2AClient): void {
+  server.registerTool(
+    "list_agents",
+    {
+      title: "List agents",
+      description:
+        "List every agent inbox owned by the authenticated user. Useful for orientation — which inbox to send `from` or query messages against. Read-only.",
+      inputSchema: {},
+    },
+    async () => runTool(() => client.listAgents()),
+  );
+}

--- a/mcp/src/tools/agents.ts
+++ b/mcp/src/tools/agents.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { E2AClient } from "@e2a/sdk/v1";
+import { z } from "zod";
 import { runTool } from "./util.js";
 
 export function registerAgentTools(server: McpServer, client: E2AClient): void {
@@ -12,5 +13,66 @@ export function registerAgentTools(server: McpServer, client: E2AClient): void {
       inputSchema: {},
     },
     async () => runTool(() => client.listAgents()),
+  );
+
+  server.registerTool(
+    "whoami",
+    {
+      title: "Get the default agent's identity",
+      description:
+        "Return the agent inbox this server is scoped to (the value of E2A_AGENT_EMAIL). Use this to discover your own address before sending. If no default agent is configured, errors — call `list_agents` and pass `agent_email` explicitly to other tools.",
+      inputSchema: {},
+    },
+    async () =>
+      runTool(() => {
+        const email = client.agentEmail;
+        if (!email) {
+          throw new Error(
+            "no default agent configured. Set E2A_AGENT_EMAIL in the server environment, or call list_agents.",
+          );
+        }
+        return client.api.getAgent(email);
+      }),
+  );
+
+  server.registerTool(
+    "create_agent",
+    {
+      title: "Create a new agent inbox on the shared domain",
+      description:
+        "Register a new agent using a slug on the deployment's shared domain (e.g. slug 'support-bot' → support-bot@<shared-domain>). Defaults to `local` mode so the agent receives mail via `list_messages` polling — no webhook server required. Pass `agent_mode: 'cloud'` and `webhook_url` for push delivery. For custom (non-shared) domains, use the e2a CLI or dashboard. Slug must be lowercase letters, numbers, and hyphens.",
+      inputSchema: {
+        slug: z
+          .string()
+          .regex(/^[a-z0-9][a-z0-9-]*$/)
+          .describe(
+            "Local part of the new email address. Lowercase letters, numbers, and hyphens; must start with a letter or number.",
+          ),
+        name: z
+          .string()
+          .optional()
+          .describe("Display name for the agent. Defaults to the slug."),
+        agent_mode: z
+          .enum(["local", "cloud"])
+          .optional()
+          .describe(
+            "`local` (default) for poll-based delivery via this MCP server. `cloud` requires `webhook_url` and pushes inbound mail to that URL.",
+          ),
+        webhook_url: z
+          .string()
+          .url()
+          .optional()
+          .describe("Required when `agent_mode` is `cloud`. Ignored in local mode."),
+      },
+    },
+    async (args) =>
+      runTool(() =>
+        client.registerAgent({
+          slug: args.slug,
+          agent_mode: args.agent_mode ?? "local",
+          ...(args.name !== undefined ? { name: args.name } : {}),
+          ...(args.webhook_url !== undefined ? { webhook_url: args.webhook_url } : {}),
+        }),
+      ),
   );
 }

--- a/mcp/src/tools/hitl.ts
+++ b/mcp/src/tools/hitl.ts
@@ -1,0 +1,66 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { E2AClient } from "@e2a/sdk/v1";
+import { z } from "zod";
+import { runTool } from "./util.js";
+
+export function registerHitlTools(server: McpServer, client: E2AClient): void {
+  server.registerTool(
+    "list_pending_approvals",
+    {
+      title: "List outbound messages awaiting approval",
+      description:
+        "List outbound emails composed by HITL-enabled agents that are held pending human review, sorted by soonest-expiring first. Use this when the user asks what's waiting for them to approve. Body content is not included in summaries — call `get_pending_approval` for the full draft.",
+      inputSchema: {},
+    },
+    async () => runTool(() => client.listPendingMessages()),
+  );
+
+  server.registerTool(
+    "get_pending_approval",
+    {
+      title: "Get a pending-approval message",
+      description:
+        "Fetch the full draft (subject, recipients, body, attachments) of one outbound message awaiting human approval. Body content is only present while the message is `pending_approval` — after a terminal transition the server scrubs it.",
+      inputSchema: {
+        message_id: z.string().describe("The pending message ID (msg_…)."),
+      },
+    },
+    async (args) => runTool(() => client.getPendingMessage(args.message_id)),
+  );
+
+  server.registerTool(
+    "approve_pending_message",
+    {
+      title: "Approve a pending outbound message",
+      description:
+        "Send a held outbound message via the upstream relay. Approve-as-is by passing only `message_id`, or apply reviewer edits by supplying any subset of subject / body_text / body_html / to / cc / bcc — those fields override the stored draft before send. Returns 409 if the message is no longer pending.",
+      inputSchema: {
+        message_id: z.string(),
+        subject: z.string().optional(),
+        body_text: z.string().optional(),
+        body_html: z.string().optional(),
+        to: z.array(z.string()).optional(),
+        cc: z.array(z.string()).optional(),
+        bcc: z.array(z.string()).optional(),
+      },
+    },
+    async (args) => {
+      const { message_id, ...overrides } = args;
+      return runTool(() => client.approveMessage(message_id, overrides));
+    },
+  );
+
+  server.registerTool(
+    "reject_pending_message",
+    {
+      title: "Reject a pending outbound message",
+      description:
+        "Discard a held outbound message. The message is never sent and body columns are scrubbed; the optional `reason` is stored for audit. Returns 409 if the message is no longer pending.",
+      inputSchema: {
+        message_id: z.string(),
+        reason: z.string().optional(),
+      },
+    },
+    async (args) => runTool(() => client.rejectMessage(args.message_id, args.reason)),
+  );
+}

--- a/mcp/src/tools/hitl.ts
+++ b/mcp/src/tools/hitl.ts
@@ -5,18 +5,18 @@ import { runTool } from "./util.js";
 
 export function registerHitlTools(server: McpServer, client: E2AClient): void {
   server.registerTool(
-    "list_pending_approvals",
+    "list_pending_messages",
     {
       title: "List outbound messages awaiting approval",
       description:
-        "List outbound emails composed by HITL-enabled agents that are held pending human review, sorted by soonest-expiring first. Use this when the user asks what's waiting for them to approve. Body content is not included in summaries — call `get_pending_approval` for the full draft.",
+        "List outbound emails composed by HITL-enabled agents that are held pending human review, sorted by soonest-expiring first. Use this when the user asks what's waiting for them to approve. Body content is not included in summaries — call `get_pending_message` for the full draft.",
       inputSchema: {},
     },
     async () => runTool(() => client.listPendingMessages()),
   );
 
   server.registerTool(
-    "get_pending_approval",
+    "get_pending_message",
     {
       title: "Get a pending-approval message",
       description:

--- a/mcp/src/tools/messages.ts
+++ b/mcp/src/tools/messages.ts
@@ -1,0 +1,127 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { E2AClient } from "@e2a/sdk/v1";
+import { z } from "zod";
+import { runTool } from "./util.js";
+
+export function registerMessageTools(server: McpServer, client: E2AClient): void {
+  server.registerTool(
+    "send_email",
+    {
+      title: "Send email",
+      description:
+        "Send a new email from the agent's inbox. Use this for outbound mail to a fresh recipient. To reply to a thread you received, use `reply_to_message` instead so threading headers (In-Reply-To, References) are preserved. If the agent has HITL approval enabled, the message is held for human review and the response indicates `status: pending_approval` rather than `sent`.",
+      inputSchema: {
+        to: z.array(z.string()).describe("Recipient email addresses (one or more)."),
+        subject: z.string(),
+        body: z.string().describe("Plain-text body. Use `html_body` for HTML."),
+        html_body: z.string().optional(),
+        cc: z.array(z.string()).optional(),
+        bcc: z.array(z.string()).optional(),
+        conversation_id: z
+          .string()
+          .optional()
+          .describe("Optional conversation grouping ID. Server generates one if omitted."),
+        agent_email: z
+          .string()
+          .optional()
+          .describe(
+            "Sending agent's inbox. Omit when E2A_AGENT_EMAIL is set in the server environment.",
+          ),
+      },
+    },
+    async (args) =>
+      runTool(() =>
+        client.send(args.to, args.subject, args.body, {
+          ...(args.html_body !== undefined ? { htmlBody: args.html_body } : {}),
+          ...(args.cc !== undefined ? { cc: args.cc } : {}),
+          ...(args.bcc !== undefined ? { bcc: args.bcc } : {}),
+          ...(args.conversation_id !== undefined
+            ? { conversationId: args.conversation_id }
+            : {}),
+          ...(args.agent_email !== undefined ? { agentEmail: args.agent_email } : {}),
+        }),
+      ),
+  );
+
+  server.registerTool(
+    "reply_to_message",
+    {
+      title: "Reply to a received message",
+      description:
+        "Reply to an inbound message identified by `message_id`. Preserves the References and In-Reply-To headers so the reply lands in the same email thread as the original. Pass `reply_all: true` to copy the original Cc list. Subject is auto-derived (Re: …) by the server.",
+      inputSchema: {
+        message_id: z.string().describe("ID of the inbound message to reply to (e.g. msg_…)."),
+        body: z.string().describe("Plain-text reply body."),
+        html_body: z.string().optional(),
+        reply_all: z
+          .boolean()
+          .optional()
+          .describe("If true, copy the original message's Cc list."),
+        cc: z.array(z.string()).optional(),
+        bcc: z.array(z.string()).optional(),
+        conversation_id: z.string().optional(),
+        agent_email: z.string().optional(),
+      },
+    },
+    async (args) =>
+      runTool(() =>
+        client.reply(args.message_id, args.body, {
+          ...(args.html_body !== undefined ? { htmlBody: args.html_body } : {}),
+          ...(args.reply_all !== undefined ? { replyAll: args.reply_all } : {}),
+          ...(args.cc !== undefined ? { cc: args.cc } : {}),
+          ...(args.bcc !== undefined ? { bcc: args.bcc } : {}),
+          ...(args.conversation_id !== undefined
+            ? { conversationId: args.conversation_id }
+            : {}),
+          ...(args.agent_email !== undefined ? { agentEmail: args.agent_email } : {}),
+        }),
+      ),
+  );
+
+  server.registerTool(
+    "list_messages",
+    {
+      title: "List inbound messages",
+      description:
+        "List messages the agent has received, newest first. Filter by `status` (unread/read/all; default unread) and paginate with `page_size` + `token`. Returns summaries only — use `get_message` for the full body.",
+      inputSchema: {
+        status: z.enum(["unread", "read", "all"]).optional(),
+        page_size: z.number().int().positive().max(100).optional(),
+        token: z.string().optional().describe("Pagination token from a previous response."),
+        agent_email: z.string().optional(),
+      },
+    },
+    async (args) =>
+      runTool(() =>
+        client.listMessages({
+          ...(args.status !== undefined ? { status: args.status } : {}),
+          ...(args.page_size !== undefined ? { pageSize: args.page_size } : {}),
+          ...(args.token !== undefined ? { token: args.token } : {}),
+          ...(args.agent_email !== undefined ? { agentEmail: args.agent_email } : {}),
+        }),
+      ),
+  );
+
+  server.registerTool(
+    "get_message",
+    {
+      title: "Get a message",
+      description:
+        "Fetch full detail for one inbound message — body, headers, auth results, and attachment metadata. Pass the `message_id` from `list_messages`.",
+      inputSchema: {
+        message_id: z.string(),
+        agent_email: z.string().optional(),
+      },
+    },
+    async (args) =>
+      runTool(() => {
+        const agentEmail = args.agent_email ?? client.agentEmail;
+        if (!agentEmail) {
+          throw new Error(
+            "agent_email is required (no E2A_AGENT_EMAIL in environment).",
+          );
+        }
+        return client.api.getMessage(agentEmail, args.message_id);
+      }),
+  );
+}

--- a/mcp/src/tools/util.ts
+++ b/mcp/src/tools/util.ts
@@ -1,0 +1,23 @@
+export type ToolResult = {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+};
+
+export async function runTool<T>(fn: () => Promise<T>): Promise<ToolResult> {
+  try {
+    const result = await fn();
+    const text =
+      result === undefined
+        ? "OK"
+        : typeof result === "string"
+          ? result
+          : JSON.stringify(result, null, 2);
+    return { content: [{ type: "text", text }] };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      content: [{ type: "text", text: `e2a error: ${message}` }],
+      isError: true,
+    };
+  }
+}

--- a/mcp/tests/config.test.ts
+++ b/mcp/tests/config.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { ConfigError, loadConfig } from "../src/config.js";
+
+describe("loadConfig", () => {
+  it("reads required and optional vars", () => {
+    const cfg = loadConfig({
+      E2A_API_KEY: "key_123",
+      E2A_BASE_URL: "https://api.example.com",
+      E2A_AGENT_EMAIL: "bot@example.com",
+    });
+    expect(cfg).toEqual({
+      apiKey: "key_123",
+      baseUrl: "https://api.example.com",
+      agentEmail: "bot@example.com",
+    });
+  });
+
+  it("treats empty optional vars as undefined", () => {
+    const cfg = loadConfig({
+      E2A_API_KEY: "key_123",
+      E2A_BASE_URL: "",
+      E2A_AGENT_EMAIL: "",
+    });
+    expect(cfg.baseUrl).toBeUndefined();
+    expect(cfg.agentEmail).toBeUndefined();
+  });
+
+  it("throws ConfigError when API key is missing", () => {
+    expect(() => loadConfig({})).toThrowError(ConfigError);
+    expect(() => loadConfig({})).toThrow(/E2A_API_KEY/);
+  });
+});

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -5,20 +5,30 @@ import type { E2AClient } from "@e2a/sdk/v1";
 import { buildServer } from "../src/server.js";
 
 // Minimal stub of E2AClient — only the methods our tools actually call.
-function makeStubClient(): E2AClient {
+function makeStubClient(overrides: Partial<{ agentEmail: string }> = {}): E2AClient {
   const stub = {
-    agentEmail: "bot@example.com",
+    agentEmail: overrides.agentEmail ?? "bot@example.com",
     api: {
       getMessage: vi.fn(async (_email: string, id: string) => ({
         message_id: id,
         from: "alice@example.com",
         subject: "hi",
       })),
+      getAgent: vi.fn(async (email: string) => ({
+        id: email,
+        email,
+        agent_mode: "local",
+      })),
     },
     send: vi.fn(async () => ({ message_id: "msg_sent", status: "sent" })),
     reply: vi.fn(async () => ({ message_id: "msg_reply", status: "sent" })),
     listMessages: vi.fn(async () => ({ messages: [], next_token: undefined })),
     listAgents: vi.fn(async () => ({ agents: [{ email: "bot@example.com" }] })),
+    registerAgent: vi.fn(async (body: Record<string, unknown>) => ({
+      email: `${body.slug}@agents.example.com`,
+      domain: "agents.example.com",
+      id: `${body.slug}@agents.example.com`,
+    })),
     listPendingMessages: vi.fn(async () => ({ messages: [] })),
     getPendingMessage: vi.fn(async (id: string) => ({ id, status: "pending_approval" })),
     approveMessage: vi.fn(async () => ({ message_id: "msg_x", status: "sent" })),
@@ -54,8 +64,10 @@ describe("e2a MCP server", () => {
         "list_messages",
         "get_message",
         "list_agents",
-        "list_pending_approvals",
-        "get_pending_approval",
+        "whoami",
+        "create_agent",
+        "list_pending_messages",
+        "get_pending_message",
         "approve_pending_message",
         "reject_pending_message",
       ].sort(),
@@ -111,6 +123,64 @@ describe("e2a MCP server", () => {
     expect(stub.api.getMessage).toHaveBeenCalledWith("bot@example.com", "msg_abc");
   });
 
+  it("whoami returns the env-scoped agent record", async () => {
+    const res = await client.callTool({ name: "whoami", arguments: {} });
+    expect(stub.api.getAgent).toHaveBeenCalledWith("bot@example.com");
+    const content = res.content as Array<{ type: string; text: string }>;
+    expect(content[0]?.text).toContain("bot@example.com");
+  });
+
+  it("whoami errors clearly when no default agent is configured", async () => {
+    const bareStub = makeStubClient({ agentEmail: "" });
+    const bareClient = await connect(bareStub);
+    const res = await bareClient.callTool({ name: "whoami", arguments: {} });
+    expect(res.isError).toBe(true);
+    const content = res.content as Array<{ type: string; text: string }>;
+    expect(content[0]?.text).toMatch(/E2A_AGENT_EMAIL/);
+  });
+
+  it("create_agent defaults agent_mode to local", async () => {
+    await client.callTool({
+      name: "create_agent",
+      arguments: { slug: "new-bot" },
+    });
+    expect(stub.registerAgent).toHaveBeenCalledWith({
+      slug: "new-bot",
+      agent_mode: "local",
+    });
+  });
+
+  it("create_agent forwards cloud-mode webhook", async () => {
+    await client.callTool({
+      name: "create_agent",
+      arguments: {
+        slug: "cloud-bot",
+        agent_mode: "cloud",
+        webhook_url: "https://example.com/hook",
+        name: "Cloud Bot",
+      },
+    });
+    expect(stub.registerAgent).toHaveBeenCalledWith({
+      slug: "cloud-bot",
+      agent_mode: "cloud",
+      name: "Cloud Bot",
+      webhook_url: "https://example.com/hook",
+    });
+  });
+
+  it("list_pending_messages calls the SDK", async () => {
+    await client.callTool({ name: "list_pending_messages", arguments: {} });
+    expect(stub.listPendingMessages).toHaveBeenCalledOnce();
+  });
+
+  it("get_pending_message forwards the id", async () => {
+    await client.callTool({
+      name: "get_pending_message",
+      arguments: { message_id: "msg_p" },
+    });
+    expect(stub.getPendingMessage).toHaveBeenCalledWith("msg_p");
+  });
+
   it("approve_pending_message strips message_id and forwards overrides", async () => {
     await client.callTool({
       name: "approve_pending_message",
@@ -124,6 +194,14 @@ describe("e2a MCP server", () => {
       subject: "edited subject",
       body_text: "edited body",
     });
+  });
+
+  it("approve_pending_message approve-as-is sends empty overrides", async () => {
+    await client.callTool({
+      name: "approve_pending_message",
+      arguments: { message_id: "msg_p" },
+    });
+    expect(stub.approveMessage).toHaveBeenCalledWith("msg_p", {});
   });
 
   it("reject_pending_message forwards the reason", async () => {

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { E2AClient } from "@e2a/sdk/v1";
+import { buildServer } from "../src/server.js";
+
+// Minimal stub of E2AClient — only the methods our tools actually call.
+function makeStubClient(): E2AClient {
+  const stub = {
+    agentEmail: "bot@example.com",
+    api: {
+      getMessage: vi.fn(async (_email: string, id: string) => ({
+        message_id: id,
+        from: "alice@example.com",
+        subject: "hi",
+      })),
+    },
+    send: vi.fn(async () => ({ message_id: "msg_sent", status: "sent" })),
+    reply: vi.fn(async () => ({ message_id: "msg_reply", status: "sent" })),
+    listMessages: vi.fn(async () => ({ messages: [], next_token: undefined })),
+    listAgents: vi.fn(async () => ({ agents: [{ email: "bot@example.com" }] })),
+    listPendingMessages: vi.fn(async () => ({ messages: [] })),
+    getPendingMessage: vi.fn(async (id: string) => ({ id, status: "pending_approval" })),
+    approveMessage: vi.fn(async () => ({ message_id: "msg_x", status: "sent" })),
+    rejectMessage: vi.fn(async () => ({ message_id: "msg_x", status: "rejected" })),
+  };
+  return stub as unknown as E2AClient;
+}
+
+async function connect(stub: E2AClient): Promise<Client> {
+  const server = buildServer({ client: stub, version: "0.0.0-test" });
+  const client = new Client({ name: "test-client", version: "0.0.0" });
+  const [clientT, serverT] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverT), client.connect(clientT)]);
+  return client;
+}
+
+describe("e2a MCP server", () => {
+  let stub: E2AClient;
+  let client: Client;
+
+  beforeEach(async () => {
+    stub = makeStubClient();
+    client = await connect(stub);
+  });
+
+  it("registers exactly the v1 tool set", async () => {
+    const { tools } = await client.listTools();
+    const names = tools.map((t) => t.name).sort();
+    expect(names).toEqual(
+      [
+        "send_email",
+        "reply_to_message",
+        "list_messages",
+        "get_message",
+        "list_agents",
+        "list_pending_approvals",
+        "get_pending_approval",
+        "approve_pending_message",
+        "reject_pending_message",
+      ].sort(),
+    );
+  });
+
+  it("send_email forwards args to client.send", async () => {
+    await client.callTool({
+      name: "send_email",
+      arguments: {
+        to: ["alice@example.com"],
+        subject: "hi",
+        body: "hello",
+        cc: ["bob@example.com"],
+      },
+    });
+    expect(stub.send).toHaveBeenCalledWith(
+      ["alice@example.com"],
+      "hi",
+      "hello",
+      { cc: ["bob@example.com"] },
+    );
+  });
+
+  it("reply_to_message forwards args to client.reply", async () => {
+    await client.callTool({
+      name: "reply_to_message",
+      arguments: {
+        message_id: "msg_in",
+        body: "thanks",
+        reply_all: true,
+      },
+    });
+    expect(stub.reply).toHaveBeenCalledWith("msg_in", "thanks", { replyAll: true });
+  });
+
+  it("list_messages forwards filters", async () => {
+    await client.callTool({
+      name: "list_messages",
+      arguments: { status: "unread", page_size: 10 },
+    });
+    expect(stub.listMessages).toHaveBeenCalledWith({
+      status: "unread",
+      pageSize: 10,
+    });
+  });
+
+  it("get_message uses the env agent email when omitted", async () => {
+    await client.callTool({
+      name: "get_message",
+      arguments: { message_id: "msg_abc" },
+    });
+    expect(stub.api.getMessage).toHaveBeenCalledWith("bot@example.com", "msg_abc");
+  });
+
+  it("approve_pending_message strips message_id and forwards overrides", async () => {
+    await client.callTool({
+      name: "approve_pending_message",
+      arguments: {
+        message_id: "msg_p",
+        subject: "edited subject",
+        body_text: "edited body",
+      },
+    });
+    expect(stub.approveMessage).toHaveBeenCalledWith("msg_p", {
+      subject: "edited subject",
+      body_text: "edited body",
+    });
+  });
+
+  it("reject_pending_message forwards the reason", async () => {
+    await client.callTool({
+      name: "reject_pending_message",
+      arguments: { message_id: "msg_p", reason: "wrong recipient" },
+    });
+    expect(stub.rejectMessage).toHaveBeenCalledWith("msg_p", "wrong recipient");
+  });
+
+  it("surfaces SDK errors as isError results", async () => {
+    (stub.send as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error("HTTP 403: domain not verified"),
+    );
+    const res = await client.callTool({
+      name: "send_email",
+      arguments: { to: ["x@example.com"], subject: "s", body: "b" },
+    });
+    expect(res.isError).toBe(true);
+    const content = res.content as Array<{ type: string; text: string }>;
+    expect(content[0]?.text).toMatch(/domain not verified/);
+  });
+});

--- a/mcp/tsconfig.json
+++ b/mcp/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": false
+  },
+  "include": ["src"],
+  "exclude": ["dist", "node_modules", "**/*.test.ts", "tests"]
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "workspaces": [
     "cli",
-    "sdks/typescript"
+    "sdks/typescript",
+    "mcp"
   ]
 }


### PR DESCRIPTION
## Summary
- New `mcp/` workspace (`@e2a/mcp-server`) that wraps the TypeScript SDK as an MCP stdio server, distributable via `npx -y @e2a/mcp-server`.
- Targets the [Google ADK integrations](https://github.com/google/adk-docs/blob/main/CONTRIBUTING.md#integrations) path and works with any MCP host — LangChain (via `langchain-mcp-adapters`), OpenAI Agents SDK (`MCPServerStdio`), Claude Desktop, Cursor, Cline.
- v1 ships **11 tools**, prioritized for the agent send/receive loop, identity discovery, and HITL approval:
  - **Identity**: `whoami`, `list_agents`, `create_agent` (slug-based, defaults to `local` agent_mode so MCP-only users don't need a webhook server)
  - **Messages**: `send_email`, `reply_to_message`, `list_messages`, `get_message`
  - **HITL**: `list_pending_messages`, `get_pending_message`, `approve_pending_message`, `reject_pending_message`
- Auth via `E2A_API_KEY`; optional `E2A_BASE_URL` (self-hosted) and `E2A_AGENT_EMAIL` (scopes tools to one inbox so the LLM doesn't pay tokens repeating it).
- New CI jobs in [test.yml](.github/workflows/test.yml) for unit tests, plus [publish-mcp.yml](.github/workflows/publish-mcp.yml) for tag-driven npm release with OIDC provenance.
- [mcp/README.md](mcp/README.md) with copy-pasteable quick-starts for ADK / LangChain / OpenAI Agents / Claude Desktop.

## Deliberately out of scope (v1.x)
- `update/delete_agent` and the domain tools — one-time setup, destructive surface to expose to an LLM. Stay in CLI/dashboard.
- `parse` / `parseWebhook` (webhook handler concern) and `listen` (WS streaming has no MCP-tool analog; use `list_messages?status=unread` polling).
- Attachments in tool schemas — schema is involved; punted to v0.2.
- Hosted remote MCP at `mcp.e2a.dev` — the real differentiator. Eliminates `npx` from every community guide and lights up browser-based MCP clients. v2.

## Test plan
- [x] `npm run build --workspace @e2a/mcp-server` — clean tsc
- [x] `npm test --workspace @e2a/mcp-server` — 18/18 vitest passing (in-memory MCP client → server round-trip covering tool registration, arg forwarding, env scoping, SDK-error → `isError` mapping, and the full `loadConfig` surface)
- [x] Stdio smoke: `E2A_API_KEY=test node mcp/dist/index.js` answers `tools/list` with all 11 tools; missing key exits 1 with a clear message
- [x] End-to-end against `cmd/e2a-contract-server` over real stdio: tool discovery, agent create + list, message list, full HITL approval loop (enable HITL → `send_email` → `list_pending_messages` → `get_pending_message` → `approve_pending_message` with edits)
- [x] `npm publish --dry-run` — clean tarball (10 files, 19.4 KB), README included, no warnings
- [ ] Configure `@e2a/mcp-server` as a trusted publisher on npmjs.com (one-time, manual)
- [ ] Tag `mcp-v0.1.0` → first npm publish (post-merge)
- [ ] adk-docs PR + logo asset (needs the npm publish first so `npx -y @e2a/mcp-server` resolves)

🤖 Generated with [Claude Code](https://claude.com/claude-code)