### PR TITLE
chore(mcp): bump to 0.1.1

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/mcp-server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "MCP server for e2a — email for AI agents",
   "bin": {
     "e2a-mcp": "dist/index.js"


### PR DESCRIPTION
## Summary
- One-line version bump in [mcp/package.json](mcp/package.json) so the publish workflow can land. The 0.1.0 slot is reserved on npm for 72 hours after an unpublish, blocking the original `mcp-v0.1.0` tag.
- No code changes.

## Test plan
- [x] CI already validated the underlying code in #82
- [ ] After merge: tag `mcp-v0.1.1` → publish workflow lands @e2a/mcp-server@0.1.1 on npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)