### PR TITLE
docs(mcp): runnable e2e examples for ADK, LangChain, OpenAI Agents

### DIFF
--- a/mcp/examples/README.md
+++ b/mcp/examples/README.md
@@ -1,0 +1,22 @@
+# Examples
+
+End-to-end demos showing how to wire `@e2a/mcp-server` into popular agent frameworks. Each is a self-contained script — clone the repo, install requirements, run.
+
+| Framework | Path | LLM |
+| --- | --- | --- |
+| LangChain (LangGraph ReAct) | [langchain/](./langchain/) | Anthropic Claude |
+| Google ADK | [adk/](./adk/) | Google Gemini |
+| OpenAI Agents SDK | [openai-agents/](./openai-agents/) | OpenAI GPT |
+
+All examples consume the published [@e2a/mcp-server](https://www.npmjs.com/package/@e2a/mcp-server) from npm via `npx -y` — no local build needed. Bring your own [e2a API key](https://e2a.dev) and an LLM key for whichever framework you're trying.
+
+## Things to try once a demo is running
+
+- `what's in my inbox?` — exercises `list_messages` + `get_message`
+- `reply to the most recent message politely` — exercises `reply_to_message` (preserves threading headers)
+- `who am I?` — exercises `whoami`
+- `what's waiting for my approval?` — exercises `list_pending_messages` (works once you've enabled HITL on your agent)
+
+## Pointing at a self-hosted e2a
+
+Set `E2A_BASE_URL=https://your-deployment.example.com` in the environment and the examples forward it to the MCP server automatically.

--- a/mcp/examples/adk/README.md
+++ b/mcp/examples/adk/README.md
@@ -1,0 +1,33 @@
+# Google ADK × e2a
+
+Google ADK [`Agent`](https://google.github.io/adk-docs/) powered by Gemini that uses [@e2a/mcp-server](https://www.npmjs.com/package/@e2a/mcp-server) for all 11 e2a tools over stdio.
+
+## Prerequisites
+
+- Node 18+ (`npx -y @e2a/mcp-server`)
+- Python 3.10+
+- An [e2a API key](https://e2a.dev)
+- A [Google AI Studio key](https://aistudio.google.com/apikey) for Gemini
+
+## Run
+
+```bash
+pip install -r requirements.txt
+export E2A_API_KEY=e2a_…
+export E2A_AGENT_EMAIL=your-bot@your-domain.com   # optional default inbox
+export GOOGLE_API_KEY=…
+
+adk web              # opens the ADK Web UI on http://localhost:8000
+# or:
+adk run agent.py     # interactive CLI
+```
+
+Then in the chat:
+
+> What's in my inbox?
+> Reply to the latest message politely.
+> Send an email to alice@example.com — subject "test", body "hello from ADK".
+
+## How it works
+
+`McpToolset` spawns the e2a MCP server with `StdioConnectionParams`. ADK auto-discovers the tools and surfaces them to Gemini. Module-scope `root_agent` is the convention ADK's `run` / `web` look for.

--- a/mcp/examples/adk/agent.py
+++ b/mcp/examples/adk/agent.py
@@ -1,0 +1,58 @@
+"""End-to-end demo: Google ADK agent driving @e2a/mcp-server over stdio.
+
+Wires the e2a MCP server into an ADK `Agent` so the LLM can send,
+read, and reply to email through natural-language prompts.
+
+Requires:
+  E2A_API_KEY      e2a API key (https://e2a.dev)
+  E2A_AGENT_EMAIL  (optional) default agent inbox
+  E2A_BASE_URL     (optional) self-hosted e2a base URL
+  GOOGLE_API_KEY   Google AI Studio key
+
+Run interactively (recommended — opens ADK Web UI):
+  pip install -r requirements.txt
+  adk web
+
+Or CLI:
+  adk run agent.py
+"""
+
+import os
+
+from google.adk.agents import Agent
+from google.adk.tools.mcp_tool import McpToolset
+from google.adk.tools.mcp_tool.mcp_session_manager import StdioConnectionParams
+from mcp import StdioServerParameters
+
+
+def _e2a_env() -> dict[str, str]:
+    env = {"E2A_API_KEY": os.environ["E2A_API_KEY"]}
+    for k in ("E2A_AGENT_EMAIL", "E2A_BASE_URL"):
+        if k in os.environ:
+            env[k] = os.environ[k]
+    return env
+
+
+root_agent = Agent(
+    model="gemini-flash-latest",
+    name="e2a_agent",
+    instruction=(
+        "You manage email through the e2a tools. Call whoami once to "
+        "find your inbox address. Use list_messages and get_message to "
+        "read; use reply_to_message (not send_email) when replying to "
+        "an existing thread so In-Reply-To and References headers are "
+        "preserved."
+    ),
+    tools=[
+        McpToolset(
+            connection_params=StdioConnectionParams(
+                server_params=StdioServerParameters(
+                    command="npx",
+                    args=["-y", "@e2a/mcp-server"],
+                    env=_e2a_env(),
+                ),
+                timeout=30,
+            ),
+        ),
+    ],
+)

--- a/mcp/examples/adk/requirements.txt
+++ b/mcp/examples/adk/requirements.txt
@@ -1,0 +1,1 @@
+google-adk>=1.0

--- a/mcp/examples/langchain/README.md
+++ b/mcp/examples/langchain/README.md
@@ -1,0 +1,28 @@
+# LangChain × e2a
+
+LangGraph ReAct agent that drives [@e2a/mcp-server](https://www.npmjs.com/package/@e2a/mcp-server) over stdio via [`langchain-mcp-adapters`](https://github.com/langchain-ai/langchain-mcp-adapters). The agent picks up all 11 e2a tools and uses them to answer natural-language email tasks.
+
+## Prerequisites
+
+- Node 18+ (the agent shells out to `npx -y @e2a/mcp-server`)
+- Python 3.10+
+- An [e2a API key](https://e2a.dev)
+- An [Anthropic API key](https://console.anthropic.com/)
+
+## Run
+
+```bash
+pip install -r requirements.txt
+export E2A_API_KEY=e2a_…
+export E2A_AGENT_EMAIL=your-bot@your-domain.com   # optional default inbox
+export ANTHROPIC_API_KEY=sk-ant-…
+
+python agent.py "what's in my inbox?"
+python agent.py "reply to the most recent message politely"
+```
+
+## How it works
+
+`MultiServerMCPClient` spawns the e2a MCP server with the right env. `client.get_tools()` returns LangChain `BaseTool` objects, one per MCP tool. The ReAct agent treats them like any other LangChain tool.
+
+To swap models, change `"anthropic:claude-sonnet-4-6"` to any provider:model string [`init_chat_model`](https://python.langchain.com/docs/how_to/chat_models_universal_init/) accepts.

--- a/mcp/examples/langchain/agent.py
+++ b/mcp/examples/langchain/agent.py
@@ -21,6 +21,13 @@ import sys
 from langchain_mcp_adapters.client import MultiServerMCPClient
 from langgraph.prebuilt import create_react_agent
 
+SYSTEM_PROMPT = (
+    "You manage email through the e2a tools. Call whoami once to find "
+    "your inbox address. Use list_messages and get_message to read; "
+    "use reply_to_message (not send_email) when replying to an existing "
+    "thread so In-Reply-To and References headers are preserved."
+)
+
 
 def _e2a_env() -> dict[str, str]:
     env = {"E2A_API_KEY": os.environ["E2A_API_KEY"]}
@@ -44,7 +51,7 @@ async def main(prompt: str) -> None:
     tools = await client.get_tools()
     print(f"Loaded {len(tools)} e2a tools: {', '.join(t.name for t in tools)}\n")
 
-    agent = create_react_agent("anthropic:claude-sonnet-4-6", tools)
+    agent = create_react_agent("anthropic:claude-sonnet-4-6", tools, prompt=SYSTEM_PROMPT)
     result = await agent.ainvoke({"messages": [{"role": "user", "content": prompt}]})
 
     final = result["messages"][-1]

--- a/mcp/examples/langchain/agent.py
+++ b/mcp/examples/langchain/agent.py
@@ -1,0 +1,56 @@
+"""End-to-end demo: LangChain agent driving @e2a/mcp-server over stdio.
+
+Wires the e2a MCP server into a LangGraph ReAct agent so the LLM can
+send, read, and reply to email through natural-language prompts.
+
+Requires:
+  E2A_API_KEY        e2a API key (https://e2a.dev)
+  E2A_AGENT_EMAIL    (optional) default agent inbox
+  E2A_BASE_URL       (optional) self-hosted e2a base URL
+  ANTHROPIC_API_KEY  Anthropic API key
+
+Run:
+  pip install -r requirements.txt
+  python agent.py "what's in my inbox?"
+"""
+
+import asyncio
+import os
+import sys
+
+from langchain_mcp_adapters.client import MultiServerMCPClient
+from langgraph.prebuilt import create_react_agent
+
+
+def _e2a_env() -> dict[str, str]:
+    env = {"E2A_API_KEY": os.environ["E2A_API_KEY"]}
+    for k in ("E2A_AGENT_EMAIL", "E2A_BASE_URL"):
+        if k in os.environ:
+            env[k] = os.environ[k]
+    return env
+
+
+async def main(prompt: str) -> None:
+    client = MultiServerMCPClient(
+        {
+            "e2a": {
+                "command": "npx",
+                "args": ["-y", "@e2a/mcp-server"],
+                "transport": "stdio",
+                "env": _e2a_env(),
+            },
+        }
+    )
+    tools = await client.get_tools()
+    print(f"Loaded {len(tools)} e2a tools: {', '.join(t.name for t in tools)}\n")
+
+    agent = create_react_agent("anthropic:claude-sonnet-4-6", tools)
+    result = await agent.ainvoke({"messages": [{"role": "user", "content": prompt}]})
+
+    final = result["messages"][-1]
+    print(getattr(final, "content", final))
+
+
+if __name__ == "__main__":
+    prompt = " ".join(sys.argv[1:]) or "what's in my inbox?"
+    asyncio.run(main(prompt))

--- a/mcp/examples/langchain/requirements.txt
+++ b/mcp/examples/langchain/requirements.txt
@@ -1,0 +1,3 @@
+langchain-mcp-adapters>=0.1.0
+langgraph>=0.2.0
+langchain-anthropic>=0.3.0

--- a/mcp/examples/openai-agents/README.md
+++ b/mcp/examples/openai-agents/README.md
@@ -1,0 +1,26 @@
+# OpenAI Agents SDK × e2a
+
+[OpenAI Agents SDK](https://openai.github.io/openai-agents-python/) `Agent` driving [@e2a/mcp-server](https://www.npmjs.com/package/@e2a/mcp-server) over stdio.
+
+## Prerequisites
+
+- Node 18+ (`npx -y @e2a/mcp-server`)
+- Python 3.10+
+- An [e2a API key](https://e2a.dev)
+- An [OpenAI API key](https://platform.openai.com/api-keys)
+
+## Run
+
+```bash
+pip install -r requirements.txt
+export E2A_API_KEY=e2a_…
+export E2A_AGENT_EMAIL=your-bot@your-domain.com   # optional default inbox
+export OPENAI_API_KEY=sk-…
+
+python agent.py "what's in my inbox?"
+python agent.py "reply to the most recent message politely"
+```
+
+## How it works
+
+`MCPServerStdio` spawns the e2a MCP server, the `Agent` lists all 11 tools as its toolset, and `Runner.run` drives the loop. The async-context-manager wrapper ensures the subprocess is cleaned up when the run finishes.

--- a/mcp/examples/openai-agents/agent.py
+++ b/mcp/examples/openai-agents/agent.py
@@ -1,0 +1,57 @@
+"""End-to-end demo: OpenAI Agents SDK using @e2a/mcp-server over stdio.
+
+Wires the e2a MCP server into an `Agent` so the LLM can send, read,
+and reply to email through natural-language prompts.
+
+Requires:
+  E2A_API_KEY      e2a API key (https://e2a.dev)
+  E2A_AGENT_EMAIL  (optional) default agent inbox
+  E2A_BASE_URL     (optional) self-hosted e2a base URL
+  OPENAI_API_KEY   OpenAI API key
+
+Run:
+  pip install -r requirements.txt
+  python agent.py "what's in my inbox?"
+"""
+
+import asyncio
+import os
+import sys
+
+from agents import Agent, Runner
+from agents.mcp import MCPServerStdio
+
+
+def _e2a_env() -> dict[str, str]:
+    env = {"E2A_API_KEY": os.environ["E2A_API_KEY"]}
+    for k in ("E2A_AGENT_EMAIL", "E2A_BASE_URL"):
+        if k in os.environ:
+            env[k] = os.environ[k]
+    return env
+
+
+async def main(prompt: str) -> None:
+    async with MCPServerStdio(
+        name="e2a",
+        params={
+            "command": "npx",
+            "args": ["-y", "@e2a/mcp-server"],
+            "env": _e2a_env(),
+        },
+    ) as e2a:
+        agent = Agent(
+            name="e2a_agent",
+            instructions=(
+                "Manage email through the e2a tools. Use whoami once to "
+                "find the inbox; list_messages + get_message to read; "
+                "reply_to_message (not send_email) to reply in-thread."
+            ),
+            mcp_servers=[e2a],
+        )
+        result = await Runner.run(agent, prompt)
+        print(result.final_output)
+
+
+if __name__ == "__main__":
+    prompt = " ".join(sys.argv[1:]) or "what's in my inbox?"
+    asyncio.run(main(prompt))

--- a/mcp/examples/openai-agents/requirements.txt
+++ b/mcp/examples/openai-agents/requirements.txt
@@ -1,0 +1,1 @@
+openai-agents>=0.0.13


### PR DESCRIPTION
## Summary

Three self-contained agent demos under [mcp/examples/](mcp/examples/) that drive the published [@e2a/mcp-server](https://www.npmjs.com/package/@e2a/mcp-server) over stdio:

| Framework | Path | LLM |
| --- | --- | --- |
| LangChain (LangGraph ReAct) | [mcp/examples/langchain/](mcp/examples/langchain/) | Anthropic Claude |
| Google ADK | [mcp/examples/adk/](mcp/examples/adk/) | Google Gemini |
| OpenAI Agents SDK | [mcp/examples/openai-agents/](mcp/examples/openai-agents/) | OpenAI GPT |

Each example: one README + requirements.txt + an `agent.py` you can run with `pip install -r requirements.txt && python agent.py "..."` (or `adk web` / `adk run` for ADK). All point at the npm-published package — no local build needed.

Doubles as living docs and as the canonical "does the published package work in real frameworks?" verification harness.

## Verified end-to-end

- **LangChain**: spawned `npx -y @e2a/mcp-server@0.1.1` from a clean venv via `MultiServerMCPClient.get_tools()` — all **11 tools loaded** with parseable schemas.
- **Google ADK + Gemini**: imported `root_agent` from [mcp/examples/adk/agent.py](mcp/examples/adk/agent.py) into an `InMemoryRunner`, drove `gemini-flash-latest` against real `api.e2a.dev`. The model **chained two tool calls** (`whoami` → `list_agents`) and synthesized a correct natural-language answer. End-to-end including the LLM loop and multi-turn tool calling.
- Python syntax check on all three `agent.py` files.

The OpenAI Agents example uses the same stdio wire-up as the other two and shares the verified protocol path — shipping as-is without a direct LLM-in-the-loop run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)