### PR TITLE
feat(web): reveal signing secrets after creation

### DIFF
--- a/internal/agent/signing_secrets_api.go
+++ b/internal/agent/signing_secrets_api.go
@@ -19,12 +19,16 @@ type CreateSigningSecretRequest struct {
 	Name string `json:"name"`
 }
 
-// SigningSecretSummary is the safe-to-list shape: prefix only, no
-// plaintext. Returned by GET (list) and as a field of the create
-// response so callers can confirm what they just made.
+// SigningSecretSummary is the list shape. Includes the full plaintext
+// `secret` so the dashboard can show it on demand — this is a known
+// relaxation of the previous "show once at creation" posture; the
+// hashes-only flow for API keys is the longer-term direction. The
+// `secret_prefix` field is still populated for backwards-compatible
+// list views that only want the preview.
 type SigningSecretSummary struct {
 	ID           string  `json:"id"`
 	Name         string  `json:"name"`
+	Secret       string  `json:"secret"`
 	SecretPrefix string  `json:"secret_prefix"`
 	CreatedAt    string  `json:"created_at"`
 	LastSignedAt *string `json:"last_signed_at,omitempty"`
@@ -52,7 +56,7 @@ type ListSigningSecretsResponse struct {
 // this response; they're only shown at creation.
 //
 // @Summary      List your webhook signing secrets
-// @Description  Returns the authenticated user's webhook signing secrets (metadata + 12-char prefix preview only — full secrets are only shown once at creation). Sorted most-recent-first; the most-recent secret is what the e2a relay uses for new signatures.
+// @Description  Returns the authenticated user's webhook signing secrets (metadata, 12-char prefix, and full plaintext secret). Sorted most-recent-first; the most-recent secret is what the e2a relay uses for new signatures.
 // @Tags         User
 // @Produce      json
 // @Security     BearerAuth
@@ -171,6 +175,7 @@ func toSummary(s identity.SigningSecret) SigningSecretSummary {
 	out := SigningSecretSummary{
 		ID:           s.ID,
 		Name:         s.Name,
+		Secret:       s.Secret,
 		SecretPrefix: s.SecretPrefix,
 		CreatedAt:    s.CreatedAt.UTC().Format("2006-01-02T15:04:05Z"),
 	}

--- a/internal/agent/signing_secrets_api.go
+++ b/internal/agent/signing_secrets_api.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"encoding/json"
 	"errors"
+	"log"
 	"net/http"
 	"strings"
 
@@ -20,11 +21,12 @@ type CreateSigningSecretRequest struct {
 }
 
 // SigningSecretSummary is the list shape. Includes the full plaintext
-// `secret` so the dashboard can show it on demand — this is a known
-// relaxation of the previous "show once at creation" posture; the
-// hashes-only flow for API keys is the longer-term direction. The
-// `secret_prefix` field is still populated for backwards-compatible
-// list views that only want the preview.
+// `secret` because the relay already stores it that way (it has to —
+// it signs with it on every inbound). Surfacing it on list lets the
+// dashboard show the value on demand without storing yet another copy.
+// API keys are deliberately not handled the same way: their
+// hashes-only posture is intentional and we keep it.
+// The `secret_prefix` field stays populated for compact list views.
 type SigningSecretSummary struct {
 	ID           string  `json:"id"`
 	Name         string  `json:"name"`
@@ -78,6 +80,14 @@ func (a *API) handleListSigningSecrets(w http.ResponseWriter, r *http.Request) {
 	for _, s := range secrets {
 		out.Secrets = append(out.Secrets, toSummary(s))
 	}
+	// Audit trail: this endpoint hands out live HMAC credentials, so we
+	// record every call. No secret values in the log, just count and
+	// user — enough for "who pulled their secrets and when" forensics
+	// without making the log itself a leak vector.
+	log.Printf("[api] signing-secrets list: user=%s count=%d", user.ID, len(out.Secrets))
+	// Defense-in-depth against intermediary caches: the response body
+	// contains credentials, so it must never sit in a shared cache.
+	w.Header().Set("Cache-Control", "no-store")
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(out)
 }

--- a/internal/agent/signing_secrets_api.go
+++ b/internal/agent/signing_secrets_api.go
@@ -51,9 +51,9 @@ type ListSigningSecretsResponse struct {
 } // @name ListSigningSecretsResponse
 
 // handleListSigningSecrets returns the authenticated user's webhook
-// signing secrets — id, name, prefix, created_at, last_signed_at —
-// sorted most-recent-first. The plaintext secret values are NOT in
-// this response; they're only shown at creation.
+// signing secrets — id, name, prefix, plaintext secret, created_at,
+// last_signed_at — sorted most-recent-first. See SigningSecretSummary
+// for the rationale on exposing the plaintext on list.
 //
 // @Summary      List your webhook signing secrets
 // @Description  Returns the authenticated user's webhook signing secrets (metadata, 12-char prefix, and full plaintext secret). Sorted most-recent-first; the most-recent secret is what the e2a relay uses for new signatures.

--- a/internal/agent/signing_secrets_api_test.go
+++ b/internal/agent/signing_secrets_api_test.go
@@ -120,9 +120,9 @@ func TestSigningSecrets_List_IncludesPlaintext(t *testing.T) {
 
 // --- Create ---
 
-func TestSigningSecrets_Create_ReturnsPlaintextOnce(t *testing.T) {
+func TestSigningSecrets_Create_ReturnsPlaintext(t *testing.T) {
 	server, store, _ := setupAPI(t)
-	apiKey := createTestUser(t, store, "create-once@example.com")
+	apiKey := createTestUser(t, store, "create-plaintext@example.com")
 
 	resp := authedReq(t, "POST", server.URL+"/api/v1/users/me/signing-secrets",
 		`{"name":"prod"}`, apiKey)

--- a/internal/agent/signing_secrets_api_test.go
+++ b/internal/agent/signing_secrets_api_test.go
@@ -298,3 +298,47 @@ func TestSigningSecrets_Delete_OtherUsersSecret_Returns404(t *testing.T) {
 		t.Error("A's secret was somehow deleted by B")
 	}
 }
+
+// Regression test for the most-load-bearing property of this
+// endpoint: now that List returns plaintext, a cross-user query must
+// never see another user's secret. The scoping is implicit in the SQL
+// `WHERE user_id = $1`, and this test exists to catch a future
+// refactor that loosens it.
+func TestSigningSecrets_List_DoesNotLeakOtherUsers(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	keyA := createTestUser(t, store, "leak-a@example.com")
+	keyB := createTestUser(t, store, "leak-b@example.com")
+
+	// A creates a named secret so we have a specific plaintext to look for.
+	r := authedReq(t, "POST", server.URL+"/api/v1/users/me/signing-secrets",
+		`{"name":"a-only"}`, keyA)
+	var aCreated createResp
+	json.NewDecoder(r.Body).Decode(&aCreated)
+	r.Body.Close()
+
+	// B lists. The response body must not contain A's plaintext or ID.
+	listR := authedReq(t, "GET", server.URL+"/api/v1/users/me/signing-secrets", "", keyB)
+	defer listR.Body.Close()
+	body, _ := io.ReadAll(listR.Body)
+	if strings.Contains(string(body), aCreated.Secret) {
+		t.Errorf("B's list leaked A's plaintext secret:\n%s", body)
+	}
+	if strings.Contains(string(body), aCreated.ID) {
+		t.Errorf("B's list leaked A's secret ID:\n%s", body)
+	}
+}
+
+// The list response carries live credentials, so it must instruct
+// intermediaries not to cache it. Defense-in-depth — the
+// Authorization header should already prevent shared caches from
+// storing it, but we set Cache-Control: no-store explicitly.
+func TestSigningSecrets_List_SetsNoStore(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	apiKey := createTestUser(t, store, "no-store@example.com")
+
+	resp := authedReq(t, "GET", server.URL+"/api/v1/users/me/signing-secrets", "", apiKey)
+	defer resp.Body.Close()
+	if got := resp.Header.Get("Cache-Control"); got != "no-store" {
+		t.Errorf("Cache-Control = %q, want no-store", got)
+	}
+}

--- a/internal/agent/signing_secrets_api_test.go
+++ b/internal/agent/signing_secrets_api_test.go
@@ -18,6 +18,7 @@ import (
 type signingSecretSummary struct {
 	ID           string  `json:"id"`
 	Name         string  `json:"name"`
+	Secret       string  `json:"secret"`
 	SecretPrefix string  `json:"secret_prefix"`
 	CreatedAt    string  `json:"created_at"`
 	LastSignedAt *string `json:"last_signed_at,omitempty"`
@@ -81,9 +82,13 @@ func TestSigningSecrets_Unauthenticated(t *testing.T) {
 
 // --- List ---
 
-func TestSigningSecrets_List_OmitsPlaintext(t *testing.T) {
+// The list endpoint now exposes the plaintext `secret` so the
+// dashboard can display the full value on demand. The 12-char
+// `secret_prefix` is kept for clients that only want the preview and
+// must equal the first 12 chars of the secret.
+func TestSigningSecrets_List_IncludesPlaintext(t *testing.T) {
 	server, store, _ := setupAPI(t)
-	apiKey := createTestUser(t, store, "list-omits@example.com")
+	apiKey := createTestUser(t, store, "list-includes@example.com")
 
 	resp := authedReq(t, "GET", server.URL+"/api/v1/users/me/signing-secrets", "", apiKey)
 	defer resp.Body.Close()
@@ -105,11 +110,11 @@ func TestSigningSecrets_List_OmitsPlaintext(t *testing.T) {
 	if got.Secrets[0].SecretPrefix == "" {
 		t.Error("SecretPrefix should be populated")
 	}
-
-	// CRITICAL: the raw response must not contain the field "secret"
-	// or any 64-char-hex-looking thing (the prefix is only 12 chars).
-	if strings.Contains(string(body), `"secret":`) {
-		t.Errorf("list response leaks plaintext secret field:\n%s", body)
+	if len(got.Secrets[0].Secret) != 64 {
+		t.Errorf("Secret length = %d, want 64 hex chars on list", len(got.Secrets[0].Secret))
+	}
+	if got.Secrets[0].Secret[:12] != got.Secrets[0].SecretPrefix {
+		t.Errorf("Secret[:12] = %q, SecretPrefix = %q", got.Secrets[0].Secret[:12], got.Secrets[0].SecretPrefix)
 	}
 }
 
@@ -157,12 +162,13 @@ func TestSigningSecrets_Create_ReturnsPlaintextOnce(t *testing.T) {
 		t.Error("created secret not found in store")
 	}
 
-	// Subsequent list MUST NOT include the plaintext.
+	// Subsequent list must include the same plaintext (this is the
+	// "view secret again" behavior the dashboard needs).
 	listR := authedReq(t, "GET", server.URL+"/api/v1/users/me/signing-secrets", "", apiKey)
 	defer listR.Body.Close()
 	listBody, _ := io.ReadAll(listR.Body)
-	if strings.Contains(string(listBody), got.Secret) {
-		t.Errorf("list leaks plaintext after create:\n%s", listBody)
+	if !strings.Contains(string(listBody), got.Secret) {
+		t.Errorf("list missing plaintext after create:\n%s", listBody)
 	}
 }
 

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -1941,11 +1941,12 @@ func (s *Store) CreateSigningSecret(ctx context.Context, userID, name string) (*
 }
 
 // ListSigningSecrets returns the user's secrets in most-recent-first
-// order. The plaintext Secret is intentionally omitted; only the
-// SecretPrefix preview is exposed.
+// order. Populates both Secret (plaintext) and SecretPrefix; callers
+// that build a list shape for the dashboard get to choose which to
+// surface.
 func (s *Store) ListSigningSecrets(ctx context.Context, userID string) ([]SigningSecret, error) {
 	rows, err := s.pool.Query(ctx,
-		`SELECT id, user_id, name, substring(secret, 1, 12), created_at, last_signed_at
+		`SELECT id, user_id, name, secret, substring(secret, 1, 12), created_at, last_signed_at
 		 FROM webhook_signing_secrets WHERE user_id = $1
 		 ORDER BY created_at DESC`,
 		userID,
@@ -1957,7 +1958,7 @@ func (s *Store) ListSigningSecrets(ctx context.Context, userID string) ([]Signin
 	var out []SigningSecret
 	for rows.Next() {
 		var s SigningSecret
-		if err := rows.Scan(&s.ID, &s.UserID, &s.Name, &s.SecretPrefix, &s.CreatedAt, &s.LastSignedAt); err != nil {
+		if err := rows.Scan(&s.ID, &s.UserID, &s.Name, &s.Secret, &s.SecretPrefix, &s.CreatedAt, &s.LastSignedAt); err != nil {
 			return nil, err
 		}
 		out = append(out, s)

--- a/internal/identity/store_test.go
+++ b/internal/identity/store_test.go
@@ -608,8 +608,13 @@ func TestCreateOrGetUser_AutoCreatesSigningSecret(t *testing.T) {
 	if secrets[0].SecretPrefix == "" {
 		t.Error("SecretPrefix should be set on list")
 	}
-	if secrets[0].Secret != "" {
-		t.Error("plaintext Secret must NOT be returned by List")
+	// Plaintext is exposed on List so the dashboard can render the full
+	// value on demand. The first 12 chars must equal the prefix.
+	if len(secrets[0].Secret) != 64 {
+		t.Errorf("plaintext Secret should be 64 hex chars on list, got len=%d", len(secrets[0].Secret))
+	}
+	if secrets[0].Secret[:12] != secrets[0].SecretPrefix {
+		t.Errorf("Secret prefix mismatch: Secret[:12]=%q, SecretPrefix=%q", secrets[0].Secret[:12], secrets[0].SecretPrefix)
 	}
 }
 

--- a/sdks/python/src/e2a/v1/generated/__init__.py
+++ b/sdks/python/src/e2a/v1/generated/__init__.py
@@ -261,6 +261,7 @@ class SigningSecretSummary(BaseModel):
     id: str | None = None
     last_signed_at: str | None = None
     name: str | None = None
+    secret: str | None = None
     secret_prefix: str | None = None
 
 

--- a/sdks/typescript/src/v1/generated/types.ts
+++ b/sdks/typescript/src/v1/generated/types.ts
@@ -1436,7 +1436,7 @@ export interface paths {
         };
         /**
          * List your webhook signing secrets
-         * @description Returns the authenticated user's webhook signing secrets (metadata + 12-char prefix preview only — full secrets are only shown once at creation). Sorted most-recent-first; the most-recent secret is what the e2a relay uses for new signatures.
+         * @description Returns the authenticated user's webhook signing secrets (metadata, 12-char prefix, and full plaintext secret). Sorted most-recent-first; the most-recent secret is what the e2a relay uses for new signatures.
          */
         get: {
             parameters: {
@@ -1947,6 +1947,7 @@ export interface components {
             id?: string;
             last_signed_at?: string;
             name?: string;
+            secret?: string;
             secret_prefix?: string;
         };
         UpdateAgentRequest: {

--- a/web/public/openapi.yaml
+++ b/web/public/openapi.yaml
@@ -565,6 +565,8 @@ definitions:
         type: string
       name:
         type: string
+      secret:
+        type: string
       secret_prefix:
         type: string
     type: object
@@ -1623,10 +1625,9 @@ paths:
       - User
   /api/v1/users/me/signing-secrets:
     get:
-      description: Returns the authenticated user's webhook signing secrets (metadata
-        + 12-char prefix preview only — full secrets are only shown once at creation).
-        Sorted most-recent-first; the most-recent secret is what the e2a relay uses
-        for new signatures.
+      description: Returns the authenticated user's webhook signing secrets (metadata,
+        12-char prefix, and full plaintext secret). Sorted most-recent-first; the
+        most-recent secret is what the e2a relay uses for new signatures.
       produces:
       - application/json
       responses:

--- a/web/src/app/(app)/settings/page.test.tsx
+++ b/web/src/app/(app)/settings/page.test.tsx
@@ -92,7 +92,7 @@ describe("Settings — Signing secrets section", () => {
   const defaultSecret = {
     id: "wsec_default0001",
     name: "default",
-    secret: "abcd1234efgh".repeat(5).slice(0, 64),
+    secret: "abcd1234efgh".repeat(6).slice(0, 64),
     secret_prefix: "abcd1234efgh",
     created_at: "2026-04-15T10:00:00Z",
   };
@@ -139,7 +139,7 @@ describe("Settings — Signing secrets section", () => {
     expect(delBtn).toBeDisabled();
   });
 
-  it("creates a new secret and shows the plaintext exactly once, then hides it on dismiss", async () => {
+  it("creates a new secret, shows the plaintext in the banner, and hides the banner on dismiss", async () => {
     const created = {
       id: "wsec_new0002",
       name: "rolling",
@@ -152,7 +152,10 @@ describe("Settings — Signing secrets section", () => {
       "GET /api/v1/users/me/signing-secrets": () => {
         listCallCount++;
         if (listCallCount === 1) return jsonResp({ secrets: [defaultSecret] });
-        return jsonResp({ secrets: [defaultSecret, { ...created, secret: undefined }] });
+        // Second list reflects the row added by POST. The row carries
+        // `secret` because it's the reveal source for Show — we just
+        // start collapsed so the plaintext isn't in the rendered DOM.
+        return jsonResp({ secrets: [defaultSecret, created] });
       },
       "POST /api/v1/users/me/signing-secrets": () => jsonResp(created, 201),
     }) as unknown as typeof fetch;
@@ -164,16 +167,18 @@ describe("Settings — Signing secrets section", () => {
     fireEvent.change(screen.getByPlaceholderText(/rolling-2026/i), { target: { value: "rolling" } });
     fireEvent.click(screen.getByRole("button", { name: /^create$/i }));
 
-    // The plaintext is now in a readonly input with the warning banner.
+    // The plaintext appears in a readonly input inside the new-secret banner.
     await waitFor(() => {
-      expect(screen.getByText(/Save this secret now/i)).toBeInTheDocument();
+      expect(screen.getByText(/new signing secret created/i)).toBeInTheDocument();
     });
     const plaintextInput = screen.getByLabelText(/plaintext signing secret/i) as HTMLInputElement;
     expect(plaintextInput.value).toBe(created.secret);
 
-    // After dismiss, the plaintext disappears from the rendered DOM.
+    // After dismiss the banner is gone. The plaintext still lives in
+    // the table row state (so Show works) but is not in the rendered
+    // DOM because the row starts collapsed.
     fireEvent.click(screen.getByRole("button", { name: /^dismiss$/i }));
-    expect(screen.queryByText(/save this secret now/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/new signing secret created/i)).not.toBeInTheDocument();
     expect(document.body.innerHTML).not.toContain(created.secret);
   });
 

--- a/web/src/app/(app)/settings/page.test.tsx
+++ b/web/src/app/(app)/settings/page.test.tsx
@@ -86,14 +86,18 @@ function errResp(text: string, status: number): MockResponse {
 }
 
 describe("Settings — Signing secrets section", () => {
+  // The list endpoint now returns the full plaintext `secret` so the
+  // dashboard can offer a Show/Hide toggle. Fixtures include both
+  // prefix and full secret for that reason.
   const defaultSecret = {
     id: "wsec_default0001",
     name: "default",
+    secret: "abcd1234efgh".repeat(5).slice(0, 64),
     secret_prefix: "abcd1234efgh",
     created_at: "2026-04-15T10:00:00Z",
   };
 
-  it("lists existing secrets without exposing plaintext", async () => {
+  it("lists existing secrets with the prefix hidden by default", async () => {
     global.fetch = makeFetchMock({
       "/api/v1/users/me/signing-secrets": () => jsonResp({ secrets: [defaultSecret] }),
     }) as unknown as typeof fetch;
@@ -102,11 +106,26 @@ describe("Settings — Signing secrets section", () => {
     await waitFor(() => {
       expect(screen.getByText("default")).toBeInTheDocument();
     });
-    // Prefix is shown with a trailing ellipsis.
+    // Prefix is shown with a trailing ellipsis until the user clicks Show.
     expect(screen.getByText("abcd1234efgh…")).toBeInTheDocument();
-    // Critical: nothing in the rendered DOM should contain a 32+ char
-    // hex blob (the full plaintext form). The mock never returns one.
-    expect(document.body.innerHTML).not.toMatch(/[a-f0-9]{32,}/i);
+    expect(screen.queryByText(defaultSecret.secret)).not.toBeInTheDocument();
+  });
+
+  it("toggles the full secret on Show / Hide", async () => {
+    global.fetch = makeFetchMock({
+      "/api/v1/users/me/signing-secrets": () => jsonResp({ secrets: [defaultSecret] }),
+    }) as unknown as typeof fetch;
+
+    render(<SettingsPage />);
+    await waitFor(() => expect(screen.getByText("default")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: /^show$/i }));
+    expect(screen.getByText(defaultSecret.secret)).toBeInTheDocument();
+    expect(screen.queryByText("abcd1234efgh…")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /^hide$/i }));
+    expect(screen.queryByText(defaultSecret.secret)).not.toBeInTheDocument();
+    expect(screen.getByText("abcd1234efgh…")).toBeInTheDocument();
   });
 
   it("disables Delete when only one secret exists", async () => {
@@ -177,7 +196,7 @@ describe("Settings — Signing secrets section", () => {
   });
 
   it("DELETEs the right id when confirming a row delete", async () => {
-    const second = { ...defaultSecret, id: "wsec_other", name: "other", secret_prefix: "1111" };
+    const second = { ...defaultSecret, id: "wsec_other", name: "other", secret: "1111".repeat(16), secret_prefix: "1111" };
     const deletedIDs: string[] = [];
     global.fetch = makeFetchMock({
       "GET /api/v1/users/me/signing-secrets": () => jsonResp({ secrets: [defaultSecret, second] }),
@@ -202,7 +221,7 @@ describe("Settings — Signing secrets section", () => {
   });
 
   it("surfaces a 'cannot delete the last' error inline", async () => {
-    const second = { ...defaultSecret, id: "wsec_other", name: "other", secret_prefix: "1111" };
+    const second = { ...defaultSecret, id: "wsec_other", name: "other", secret: "1111".repeat(16), secret_prefix: "1111" };
     global.fetch = makeFetchMock({
       "GET /api/v1/users/me/signing-secrets": () => jsonResp({ secrets: [defaultSecret, second] }),
       [`DELETE /api/v1/users/me/signing-secrets/${encodeURIComponent("wsec_other")}`]: () =>

--- a/web/src/app/(app)/settings/page.test.tsx
+++ b/web/src/app/(app)/settings/page.test.tsx
@@ -1,6 +1,13 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import SettingsPage from "./page";
 
+// jsdom doesn't provide navigator.clipboard. The signing-secret Copy
+// button calls writeText, so we install a jest mock once at module
+// level so individual tests can assert on it.
+const writeText = jest.fn(async () => {});
+Object.assign(navigator, { clipboard: { writeText } });
+beforeEach(() => writeText.mockClear());
+
 // Mock next/link to plain anchors so we don't need a router in jsdom.
 jest.mock("next/link", () => {
   return function MockLink({ href, children, ...rest }: { href: string; children: React.ReactNode; [k: string]: unknown }) {
@@ -126,6 +133,28 @@ describe("Settings — Signing secrets section", () => {
     fireEvent.click(screen.getByRole("button", { name: /^hide$/i }));
     expect(screen.queryByText(defaultSecret.secret)).not.toBeInTheDocument();
     expect(screen.getByText("abcd1234efgh…")).toBeInTheDocument();
+  });
+
+  it("copies the full plaintext to the clipboard and flips the Copy label", async () => {
+    global.fetch = makeFetchMock({
+      "/api/v1/users/me/signing-secrets": () => jsonResp({ secrets: [defaultSecret] }),
+    }) as unknown as typeof fetch;
+
+    render(<SettingsPage />);
+    await waitFor(() => expect(screen.getByText("default")).toBeInTheDocument());
+
+    // Copy is only rendered once the row is revealed — that's the
+    // point of the feature, you can't copy what you haven't disclosed.
+    expect(screen.queryByRole("button", { name: /^copy$/i })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /^show$/i }));
+
+    fireEvent.click(screen.getByRole("button", { name: /^copy$/i }));
+    expect(writeText).toHaveBeenCalledWith(defaultSecret.secret);
+    // The handler is async (await writeText) so the "Copied" flip is
+    // applied on the next microtask — waitFor lets jsdom flush it.
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /^copied$/i })).toBeInTheDocument();
+    });
   });
 
   it("disables Delete when only one secret exists", async () => {

--- a/web/src/app/(app)/settings/page.tsx
+++ b/web/src/app/(app)/settings/page.tsx
@@ -250,10 +250,10 @@ function CreatedSecretBanner({ secret, onDismiss }: { secret: CreatedSecret; onD
 
   return (
     <div className="mb-4 border border-amber-300 dark:border-amber-800/40 bg-amber-50 dark:bg-amber-950/20 rounded-lg p-4">
-      <h3 className="text-sm font-semibold mb-1">Save this secret now — you can&apos;t see it again</h3>
+      <h3 className="text-sm font-semibold mb-1">New signing secret created</h3>
       <p className="text-sm text-muted mb-3">
-        This is the only time the full plaintext value will be shown. Copy it
-        into your environment variable (commonly <code className="font-mono text-xs">E2A_HMAC_SECRET</code>) before dismissing.
+        Copy it into your environment variable (commonly <code className="font-mono text-xs">E2A_HMAC_SECRET</code>).
+        You can also reveal it later from the table below.
       </p>
       <div className="flex gap-2 items-start">
         <input

--- a/web/src/app/(app)/settings/page.tsx
+++ b/web/src/app/(app)/settings/page.tsx
@@ -84,6 +84,10 @@ function ExportSection() {
 type SigningSecretSummary = {
   id: string;
   name: string;
+  // The server returns the full plaintext on every list response, so
+  // the dashboard can offer a "show secret" reveal after creation.
+  // `secret_prefix` is kept for compact list views.
+  secret: string;
   secret_prefix: string;
   created_at: string;
   last_signed_at?: string;
@@ -168,6 +172,7 @@ function SigningSecretsSection() {
         with your most recently created secret; older ones stay valid for
         verification until you delete them, so rotation is: create new → swap
         in your code → delete old. Up to 5 active secrets at a time.
+        Click <strong>Show</strong> below to reveal the full secret at any time.
       </p>
 
       {created && <CreatedSecretBanner secret={created} onDismiss={() => setCreated(null)} />}
@@ -289,7 +294,7 @@ function SigningSecretsTable({ secrets, onChange }: { secrets: SigningSecretSumm
         <thead className="bg-surface text-muted">
           <tr>
             <th className="text-left px-4 py-2 font-medium">Name</th>
-            <th className="text-left px-4 py-2 font-medium">Prefix</th>
+            <th className="text-left px-4 py-2 font-medium">Secret</th>
             <th className="text-left px-4 py-2 font-medium">Created</th>
             <th className="text-left px-4 py-2 font-medium">Last used</th>
             <th className="px-4 py-2"></th>
@@ -322,6 +327,8 @@ function SigningSecretRow({
   const [confirming, setConfirming] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [error, setError] = useState("");
+  const [revealed, setRevealed] = useState(false);
+  const [copied, setCopied] = useState(false);
 
   const handleDelete = async () => {
     setDeleting(true);
@@ -345,10 +352,43 @@ function SigningSecretRow({
     }
   };
 
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(secret.secret);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Older browsers / test envs without clipboard support — silently
+      // do nothing; the value is visible once revealed.
+    }
+  };
+
   return (
     <tr className="border-t border-border">
       <td className="px-4 py-3">{secret.name || "—"}</td>
-      <td className="px-4 py-3 font-mono text-xs">{secret.secret_prefix}…</td>
+      <td className="px-4 py-3 font-mono text-xs">
+        <div className="flex items-center gap-2">
+          <span className="break-all">
+            {revealed ? secret.secret : `${secret.secret_prefix}…`}
+          </span>
+          <button
+            type="button"
+            onClick={() => setRevealed((v) => !v)}
+            className="px-2 py-1 border border-border rounded text-xs hover:bg-background transition shrink-0"
+          >
+            {revealed ? "Hide" : "Show"}
+          </button>
+          {revealed && (
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="px-2 py-1 border border-border rounded text-xs hover:bg-background transition shrink-0"
+            >
+              {copied ? "Copied" : "Copy"}
+            </button>
+          )}
+        </div>
+      </td>
       <td className="px-4 py-3 text-muted">{formatDate(secret.created_at)}</td>
       <td className="px-4 py-3 text-muted">
         {secret.last_signed_at ? formatRelative(secret.last_signed_at) : "Never"}


### PR DESCRIPTION
## Summary

- `GET /api/v1/users/me/signing-secrets` now returns the full plaintext `secret` field alongside the existing `secret_prefix`. Plaintext was already stored in `webhook_signing_secrets.secret` (the relay needs it to sign HMACs), so this is a behavioral relaxation only — no new attack surface vs. DB-level access.
- Settings → Webhook signing secrets table gains a per-row Show / Hide toggle and a Copy button. Default display is still the 12-char prefix.
- API keys are intentionally **not** changed. They're stored as SHA-256 hashes; adding a plaintext column would be a real security regression. Users who lose an API key should delete + recreate.

## Test plan

- [x] `go test ./internal/identity/... ./internal/agent/...` (serial; project requires `-p 1`)
- [x] `cd web && npm test` — 136/136 passing, including new Show/Hide test
- [x] `cd web && npm run lint`
- [ ] Manual: open Settings, expand a secret with Show, hit Copy