### PR TITLE
feat(oauth): v0.3 PR A — OAuth 2.1 backend (full endpoint surface)

### DIFF
--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -154,7 +154,8 @@ func main() {
 	// in v0.3 PR B; this enables the *validation* path so OAuth tokens
 	// inserted directly into the DB (or via future endpoints) can
 	// authenticate against /api/v1/*.
-	api.SetOAuthStore(oauth.NewStore(pool))
+	oauthStore := oauth.NewStore(pool)
+	api.SetOAuthStore(oauthStore)
 	// HITL magic-link token signer reuses the shared HMAC secret so operators
 	// don't have to configure a second key.
 	approvalSigner := approvaltoken.NewSigner(cfg.Signing.HMACSecret)
@@ -242,6 +243,17 @@ func main() {
 				log.Printf("Failed to clean up expired webhook deliveries: %v", err)
 			} else if deleted > 0 {
 				log.Printf("Cleaned up %d expired webhook delivery record(s)", deleted)
+			}
+
+			// OAuth retention: drop auth codes older than 7d (60s
+			// useful life, kept briefly for replay-detection logs)
+			// and revoked/rotated tokens older than 30d. Rows still
+			// carry user_id + agent_email (PII) — minimizing past
+			// usefulness.
+			if res, err := oauthStore.DeleteExpired(context.Background()); err != nil {
+				log.Printf("Failed to clean up expired oauth rows: %v", err)
+			} else if res.Codes > 0 || res.Tokens > 0 {
+				log.Printf("Cleaned up %d expired oauth code(s), %d token(s)", res.Codes, res.Tokens)
 			}
 		}
 	}()

--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/hitlnotify"
 	"github.com/Mnexa-AI/e2a/internal/hitlworker"
 	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/oauth"
 	"github.com/Mnexa-AI/e2a/internal/outbound"
 	"github.com/Mnexa-AI/e2a/internal/relay"
 	"github.com/Mnexa-AI/e2a/internal/usage"
@@ -149,6 +150,11 @@ func main() {
 	// HTTP API
 	router := mux.NewRouter()
 	api := agent.NewAPI(store, sender, smtpRelay, userAuth, usageTracker, cfg.SMTP.Domain, cfg.OutboundSMTP.FromDomain, cfg.SharedDomain, cfg.HTTP.PublicURL, cfg.IsProduction())
+	// OAuth storage for ate2a_-prefixed bearer tokens. Endpoints land
+	// in v0.3 PR B; this enables the *validation* path so OAuth tokens
+	// inserted directly into the DB (or via future endpoints) can
+	// authenticate against /api/v1/*.
+	api.SetOAuthStore(oauth.NewStore(pool))
 	// HITL magic-link token signer reuses the shared HMAC secret so operators
 	// don't have to configure a second key.
 	approvalSigner := approvaltoken.NewSigner(cfg.Signing.HMACSecret)

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -237,6 +237,12 @@ func (a *API) RegisterRoutes(r *mux.Router) {
 	r.HandleFunc("/api/health", a.handleHealth).Methods("GET", "HEAD")
 	r.HandleFunc("/api/feedback", a.handleFeedback).Methods("POST")
 
+	// OAuth 2.1 authorization server discovery (RFC 8414). 404s when
+	// OAuth isn't configured on the deployment. Unauthenticated and
+	// cacheable; clients hit this once at startup to learn the
+	// authorize/token/register/revoke endpoints.
+	r.HandleFunc("/.well-known/oauth-authorization-server", a.handleOAuthDiscovery).Methods("GET")
+
 	// User auth (Google OAuth for agent developers)
 	if a.userAuth != nil {
 		r.HandleFunc("/api/auth/login", a.userAuth.HandleLogin).Methods("GET")

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -260,6 +260,10 @@ func (a *API) RegisterRoutes(r *mux.Router) {
 	// refresh_token grants. Public clients only; no client_secret.
 	r.HandleFunc("/api/oauth/token", a.handleOAuthToken).Methods("POST")
 
+	// RFC 7009 revoke endpoint. Refresh-token revocation cascades to
+	// the whole chain; access-token revocation is single-row.
+	r.HandleFunc("/api/oauth/revoke", a.handleOAuthRevoke).Methods("POST")
+
 	// User auth (Google OAuth for agent developers)
 	if a.userAuth != nil {
 		r.HandleFunc("/api/auth/login", a.userAuth.HandleLogin).Methods("GET")

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -250,6 +250,12 @@ func (a *API) RegisterRoutes(r *mux.Router) {
 	// Per-IP rate limited.
 	r.HandleFunc("/api/oauth/register", a.handleOAuthRegister).Methods("POST")
 
+	// OAuth 2.1 Authorization Code + PKCE flow.
+	// GET /api/oauth/authorize  — entry point; 302s to consent UI.
+	// POST /api/oauth/consent   — form processor; mints code + 302s back to client.
+	r.HandleFunc("/api/oauth/authorize", a.handleOAuthAuthorize).Methods("GET")
+	r.HandleFunc("/api/oauth/consent", a.handleOAuthConsent).Methods("POST")
+
 	// User auth (Google OAuth for agent developers)
 	if a.userAuth != nil {
 		r.HandleFunc("/api/auth/login", a.userAuth.HandleLogin).Methods("GET")

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -140,6 +140,7 @@ type API struct {
 	regLimit       *ratelimit.Limiter
 	pollLimit      *ratelimit.Limiter
 	feedbackLimit  *ratelimit.Limiter
+	dcrLimit       *ratelimit.Limiter // Dynamic Client Registration — anonymous endpoint, per-IP
 	approvalSigner *approvaltoken.Signer // optional; if nil, magic-link endpoints return 404
 	notifier       *hitlnotify.Notifier  // optional; if nil, holdForApproval doesn't send notification email
 }
@@ -178,6 +179,7 @@ func NewAPI(store *identity.Store, sender *outbound.Sender, smtpRelay *outbound.
 		regLimit:      ratelimit.New(1*time.Hour, 20),   // 20 registrations per IP per hour
 		pollLimit:     ratelimit.New(1*time.Minute, 60), // 60 poll requests per user per minute
 		feedbackLimit: ratelimit.New(1*time.Hour, 10),   // 10 feedback submissions per IP per hour
+		dcrLimit:      ratelimit.New(1*time.Hour, 10),   // 10 OAuth client registrations per IP per hour
 	}
 }
 
@@ -242,6 +244,11 @@ func (a *API) RegisterRoutes(r *mux.Router) {
 	// cacheable; clients hit this once at startup to learn the
 	// authorize/token/register/revoke endpoints.
 	r.HandleFunc("/.well-known/oauth-authorization-server", a.handleOAuthDiscovery).Methods("GET")
+
+	// OAuth 2.1 Dynamic Client Registration (RFC 7591). Public clients
+	// only (PKCE-based) — confidential clients aren't supported in v0.3.
+	// Per-IP rate limited.
+	r.HandleFunc("/api/oauth/register", a.handleOAuthRegister).Methods("POST")
 
 	// User auth (Google OAuth for agent developers)
 	if a.userAuth != nil {

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -319,6 +319,32 @@ func (a *API) authenticateUser(r *http.Request) (*identity.User, error) {
 	return nil, fmt.Errorf("authorization required")
 }
 
+// writeAuthError writes a 401 response, attaching an RFC 6750 §3
+// WWW-Authenticate challenge when the failed credential looked like
+// an OAuth access token. Without the header, MCP clients can't tell
+// "your access token is invalid, run OAuth again" from "your API key
+// is bad" — both surface as a generic 401, and the client can't
+// auto-trigger re-auth. The error_description is set per-variant so
+// SDKs can surface a useful message ("revoked" vs "expired").
+func (a *API) writeAuthError(w http.ResponseWriter, r *http.Request, err error) {
+	bearer := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+	if strings.HasPrefix(bearer, oauth.AccessTokenPrefix) {
+		desc := "the access token is invalid"
+		if err != nil {
+			msg := err.Error()
+			switch {
+			case strings.Contains(msg, "revoked"):
+				desc = "the access token has been revoked"
+			case strings.Contains(msg, "expired"):
+				desc = "the access token has expired"
+			}
+		}
+		w.Header().Set("WWW-Authenticate",
+			`Bearer realm="e2a", error="invalid_token", error_description="`+desc+`"`)
+	}
+	http.Error(w, "authentication required", http.StatusUnauthorized)
+}
+
 // lookupUserByOAuthToken resolves an ate2a_-prefixed bearer to the
 // owning user. Fails closed if OAuth isn't configured on this
 // deployment, if the token has been revoked, or if the access portion
@@ -414,7 +440,7 @@ func (a *API) handleRegisterAgent(w http.ResponseWriter, r *http.Request) {
 	// Require authentication (API key or session) for agent registration.
 	user, err := a.authenticateUser(r)
 	if err != nil {
-		http.Error(w, "authentication required", http.StatusUnauthorized)
+		a.writeAuthError(w, r, err)
 		return
 	}
 
@@ -507,7 +533,7 @@ func (a *API) handleRegisterAgent(w http.ResponseWriter, r *http.Request) {
 func (a *API) handleListAgents(w http.ResponseWriter, r *http.Request) {
 	user, err := a.authenticateUser(r)
 	if err != nil {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		a.writeAuthError(w, r, err)
 		return
 	}
 
@@ -544,7 +570,7 @@ func (a *API) handleGetAgent(w http.ResponseWriter, r *http.Request) {
 
 	user, err := a.authenticateUser(r)
 	if err != nil {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		a.writeAuthError(w, r, err)
 		return
 	}
 	ag, err := a.resolveAgentForUser(r, email, user)
@@ -603,7 +629,7 @@ func (a *API) handleUpdateAgent(w http.ResponseWriter, r *http.Request) {
 
 	user, err := a.authenticateUser(r)
 	if err != nil {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		a.writeAuthError(w, r, err)
 		return
 	}
 	ag, err := a.resolveAgentForUser(r, email, user)
@@ -706,7 +732,7 @@ func (a *API) handleDeleteAgent(w http.ResponseWriter, r *http.Request) {
 
 	user, err := a.authenticateUser(r)
 	if err != nil {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		a.writeAuthError(w, r, err)
 		return
 	}
 
@@ -743,7 +769,7 @@ func (a *API) handleDeleteAgent(w http.ResponseWriter, r *http.Request) {
 func (a *API) handleRegisterDomain(w http.ResponseWriter, r *http.Request) {
 	user, err := a.authenticateUser(r)
 	if err != nil {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		a.writeAuthError(w, r, err)
 		return
 	}
 
@@ -790,7 +816,7 @@ func (a *API) handleRegisterDomain(w http.ResponseWriter, r *http.Request) {
 func (a *API) handleVerifyDomain(w http.ResponseWriter, r *http.Request) {
 	user, err := a.authenticateUser(r)
 	if err != nil {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		a.writeAuthError(w, r, err)
 		return
 	}
 
@@ -876,7 +902,7 @@ func (a *API) handleVerifyDomain(w http.ResponseWriter, r *http.Request) {
 func (a *API) handleListDomains(w http.ResponseWriter, r *http.Request) {
 	user, err := a.authenticateUser(r)
 	if err != nil {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		a.writeAuthError(w, r, err)
 		return
 	}
 
@@ -910,7 +936,7 @@ func (a *API) handleListDomains(w http.ResponseWriter, r *http.Request) {
 func (a *API) handleDeleteDomain(w http.ResponseWriter, r *http.Request) {
 	user, err := a.authenticateUser(r)
 	if err != nil {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		a.writeAuthError(w, r, err)
 		return
 	}
 
@@ -1038,7 +1064,7 @@ func (a *API) holdForApproval(w http.ResponseWriter, r *http.Request, agent *ide
 func (a *API) handleSendEmail(w http.ResponseWriter, r *http.Request) {
 	user, err := a.authenticateUser(r)
 	if err != nil {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		a.writeAuthError(w, r, err)
 		return
 	}
 
@@ -1151,7 +1177,7 @@ func (a *API) handleSendTestEmail(w http.ResponseWriter, r *http.Request) {
 
 	user, err := a.authenticateUser(r)
 	if err != nil {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		a.writeAuthError(w, r, err)
 		return
 	}
 
@@ -1235,7 +1261,7 @@ type ReplyRequest struct {
 func (a *API) handleReplyToMessage(w http.ResponseWriter, r *http.Request) {
 	user, err := a.authenticateUser(r)
 	if err != nil {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		a.writeAuthError(w, r, err)
 		return
 	}
 
@@ -1386,7 +1412,7 @@ func (a *API) handleReplyToMessage(w http.ResponseWriter, r *http.Request) {
 func (a *API) handleGetMessages(w http.ResponseWriter, r *http.Request) {
 	user, err := a.authenticateUser(r)
 	if err != nil {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		a.writeAuthError(w, r, err)
 		return
 	}
 
@@ -1536,7 +1562,7 @@ func (a *API) handleGetMessages(w http.ResponseWriter, r *http.Request) {
 func (a *API) handleGetMessage(w http.ResponseWriter, r *http.Request) {
 	user, err := a.authenticateUser(r)
 	if err != nil {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		a.writeAuthError(w, r, err)
 		return
 	}
 

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/auth"
 	"github.com/Mnexa-AI/e2a/internal/hitlnotify"
 	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/oauth"
 	"github.com/Mnexa-AI/e2a/internal/outbound"
 	"github.com/Mnexa-AI/e2a/internal/ratelimit"
 	"github.com/Mnexa-AI/e2a/internal/usage"
@@ -119,6 +120,7 @@ func validateSlug(slug string) error {
 
 type API struct {
 	store          *identity.Store
+	oauthStore     *oauth.Store // nil when OAuth isn't enabled; dispatch falls back to API-key-only
 	sender         *outbound.Sender
 	smtpRelay      *outbound.SMTPRelay
 	userAuth       *auth.UserAuth
@@ -152,6 +154,13 @@ func (a *API) SetApprovalSigner(s *approvaltoken.Signer) { a.approvalSigner = s 
 // still persists the pending message but doesn't fire the email — useful
 // for tests that don't want the async SMTP traffic.
 func (a *API) SetNotifier(n *hitlnotify.Notifier) { a.notifier = n }
+
+// SetOAuthStore wires in the OAuth storage layer so authenticateUser
+// can resolve ate2a_-prefixed bearer tokens to a User. When nil, only
+// the legacy API-key path (e2a_ prefix or no prefix) authenticates;
+// OAuth tokens get rejected as "not configured". Matches the optional
+// dependency pattern of SetApprovalSigner / SetNotifier above.
+func (a *API) SetOAuthStore(s *oauth.Store) { a.oauthStore = s }
 
 func NewAPI(store *identity.Store, sender *outbound.Sender, smtpRelay *outbound.SMTPRelay, userAuth *auth.UserAuth, usage usage.UsageTracker, smtpDomain, fromDomain, sharedDomain, publicURL string, production bool) *API {
 	return &API{
@@ -253,13 +262,26 @@ func (a *API) RegisterWSRoute(r *mux.Router, handle http.HandlerFunc) {
 	r.HandleFunc("/api/v1/agents/{email}/ws", handle)
 }
 
-// authenticateUser extracts and validates the API key from the request, returning the owning user.
-// Falls back to session cookie auth if no Authorization header is present.
+// authenticateUser extracts and validates the bearer credential from
+// the request, returning the owning user.
+//
+// Dispatch is by token prefix:
+//   - ate2a_  → OAuth access token (oauth_tokens table). The MCP/web
+//     UX path: client got it from the /api/oauth/token endpoint.
+//     Rejected if missing, revoked, or past expires_at.
+//   - anything else (typically e2a_, but we accept legacy unprefixed
+//     keys too) → API key (api_keys table). The CLI/SDK path.
+//
+// If no Authorization header is present, falls back to the session
+// cookie used by the web dashboard.
 func (a *API) authenticateUser(r *http.Request) (*identity.User, error) {
-	apiKey := r.Header.Get("Authorization")
-	if apiKey != "" {
-		apiKey = strings.TrimPrefix(apiKey, "Bearer ")
-		return a.store.GetUserByAPIKey(r.Context(), apiKey)
+	authHeader := r.Header.Get("Authorization")
+	if authHeader != "" {
+		bearer := strings.TrimPrefix(authHeader, "Bearer ")
+		if strings.HasPrefix(bearer, oauth.AccessTokenPrefix) {
+			return a.lookupUserByOAuthToken(r, bearer)
+		}
+		return a.store.GetUserByAPIKey(r.Context(), bearer)
 	}
 	// Fall back to session cookie auth
 	if a.userAuth != nil {
@@ -268,6 +290,31 @@ func (a *API) authenticateUser(r *http.Request) (*identity.User, error) {
 		}
 	}
 	return nil, fmt.Errorf("authorization required")
+}
+
+// lookupUserByOAuthToken resolves an ate2a_-prefixed bearer to the
+// owning user. Fails closed if OAuth isn't configured on this
+// deployment, if the token has been revoked, or if the access portion
+// has expired (refresh expiry is irrelevant here — the client needs
+// to have already exchanged for a fresh access token).
+func (a *API) lookupUserByOAuthToken(r *http.Request, bearer string) (*identity.User, error) {
+	if a.oauthStore == nil {
+		return nil, fmt.Errorf("oauth tokens not enabled on this deployment")
+	}
+	tok, err := a.oauthStore.LookupTokenByAccess(r.Context(), bearer)
+	if err != nil {
+		// ErrTokenNotFound is the common case (bad/expired token);
+		// other errors are infrastructure failures. Both surface as
+		// 401 to the caller via the same path.
+		return nil, fmt.Errorf("oauth token invalid: %w", err)
+	}
+	if !tok.IsActive(time.Now()) {
+		if tok.RevokedAt != nil {
+			return nil, fmt.Errorf("oauth token revoked")
+		}
+		return nil, fmt.Errorf("oauth token expired")
+	}
+	return a.store.GetUserByID(r.Context(), tok.UserID)
 }
 
 // resolveAgentForUser loads an agent by email address and verifies the user owns it.

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -256,6 +256,10 @@ func (a *API) RegisterRoutes(r *mux.Router) {
 	r.HandleFunc("/api/oauth/authorize", a.handleOAuthAuthorize).Methods("GET")
 	r.HandleFunc("/api/oauth/consent", a.handleOAuthConsent).Methods("POST")
 
+	// OAuth 2.1 token endpoint — authorization_code (with PKCE) and
+	// refresh_token grants. Public clients only; no client_secret.
+	r.HandleFunc("/api/oauth/token", a.handleOAuthToken).Methods("POST")
+
 	// User auth (Google OAuth for agent developers)
 	if a.userAuth != nil {
 		r.HandleFunc("/api/auth/login", a.userAuth.HandleLogin).Methods("GET")

--- a/internal/agent/oauth_auth_test.go
+++ b/internal/agent/oauth_auth_test.go
@@ -1,0 +1,242 @@
+package agent_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Mnexa-AI/e2a/internal/agent"
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/oauth"
+	"github.com/Mnexa-AI/e2a/internal/outbound"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+	"github.com/Mnexa-AI/e2a/internal/usage"
+	"github.com/gorilla/mux"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Mnexa-AI/e2a/internal/config"
+)
+
+// setupAPIWithOAuth wires the API with OAuth enabled. Pairs with the
+// existing setupAPI helper but adds the oauth.Store so ate2a_-prefixed
+// bearer tokens are dispatched correctly.
+func setupAPIWithOAuth(t *testing.T) (*httptest.Server, *identity.Store, *oauth.Store, *pgxpool.Pool) {
+	t.Helper()
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	oauthStore := oauth.NewStore(pool)
+	smtpRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{})
+	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
+	noopUsage := usage.NewNoopUsageTracker()
+	api := agent.NewAPI(store, sender, smtpRelay, nil, noopUsage, "e2a.dev", "test.e2a.dev", "agents.e2a.dev", "", false)
+	api.SetOAuthStore(oauthStore)
+	router := mux.NewRouter()
+	api.RegisterRoutes(router)
+	server := httptest.NewServer(router)
+	t.Cleanup(server.Close)
+	return server, store, oauthStore, pool
+}
+
+// seedUserAndAPIKey creates a user and an API key, returns both.
+func seedUserAndAPIKey(t *testing.T, store *identity.Store, email string) (*identity.User, string) {
+	t.Helper()
+	ctx := context.Background()
+	user, err := store.CreateOrGetUser(ctx, email, "Test User", "google-"+email)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key, err := store.CreateAPIKey(ctx, user.ID, "test-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return user, key.PlaintextKey
+}
+
+// seedOAuthClient creates a public OAuth client and returns its id.
+func seedOAuthClient(t *testing.T, s *oauth.Store) string {
+	t.Helper()
+	c := &oauth.Client{
+		ClientID:     oauth.NewClientID(),
+		ClientName:   "test-client",
+		RedirectURIs: []string{"http://127.0.0.1:54321/callback"},
+		ClientType:   "public",
+		CreatedVia:   "dcr",
+	}
+	if err := s.RegisterClient(context.Background(), c); err != nil {
+		t.Fatal(err)
+	}
+	return c.ClientID
+}
+
+// issueOAuthToken inserts an oauth_tokens row directly — we don't
+// need the /api/oauth/token endpoint for these tests (that's a future
+// slice); we just need the store-level row so the dispatch path can
+// validate against it.
+func issueOAuthToken(t *testing.T, s *oauth.Store, clientID, userID string, opts ...func(*oauth.Token)) *oauth.Token {
+	t.Helper()
+	now := time.Now()
+	refreshExp := now.Add(oauth.RefreshTokenLifetime)
+	tok := &oauth.Token{
+		AccessToken:      oauth.NewAccessToken(),
+		RefreshToken:     oauth.NewRefreshToken(),
+		RefreshChainID:   oauth.NewChainID(),
+		ClientID:         clientID,
+		UserID:           userID,
+		Scope:            "e2a",
+		ExpiresAt:        now.Add(oauth.AccessTokenLifetime),
+		RefreshExpiresAt: &refreshExp,
+	}
+	for _, opt := range opts {
+		opt(tok)
+	}
+	if err := s.IssueToken(context.Background(), tok); err != nil {
+		t.Fatal(err)
+	}
+	return tok
+}
+
+// getWithBearer sends an authenticated GET to /api/v1/agents (the
+// simplest authenticated endpoint).
+func getWithBearer(t *testing.T, server *httptest.Server, bearer string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest("GET", server.URL+"/api/v1/agents", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bearer != "" {
+		req.Header.Set("Authorization", "Bearer "+bearer)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+// ──────────────────────── regression: API key still works ────────────────────────
+
+func TestAuth_APIKeyStillWorks_PostOAuth(t *testing.T) {
+	server, store, _, _ := setupAPIWithOAuth(t)
+	_, apiKey := seedUserAndAPIKey(t, store, "apikey-user@example.com")
+
+	resp := getWithBearer(t, server, apiKey)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("API key auth regressed: got %d, want 200", resp.StatusCode)
+	}
+}
+
+// ──────────────────────── OAuth happy path ────────────────────────
+
+func TestAuth_OAuthToken_Active(t *testing.T) {
+	server, store, oauthStore, _ := setupAPIWithOAuth(t)
+	user, _ := seedUserAndAPIKey(t, store, "oauth-user@example.com")
+	clientID := seedOAuthClient(t, oauthStore)
+	tok := issueOAuthToken(t, oauthStore, clientID, user.ID)
+
+	resp := getWithBearer(t, server, tok.AccessToken)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("active OAuth token should authenticate: got %d", resp.StatusCode)
+	}
+}
+
+// ──────────────────────── OAuth rejection paths ────────────────────────
+
+func TestAuth_OAuthToken_Revoked(t *testing.T) {
+	server, store, oauthStore, _ := setupAPIWithOAuth(t)
+	user, _ := seedUserAndAPIKey(t, store, "revoked-user@example.com")
+	clientID := seedOAuthClient(t, oauthStore)
+	tok := issueOAuthToken(t, oauthStore, clientID, user.ID)
+
+	// Revoke the token.
+	if err := oauthStore.RevokeToken(context.Background(), tok.AccessToken); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := getWithBearer(t, server, tok.AccessToken)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("revoked OAuth token should be rejected: got %d", resp.StatusCode)
+	}
+}
+
+func TestAuth_OAuthToken_Expired(t *testing.T) {
+	server, store, oauthStore, _ := setupAPIWithOAuth(t)
+	user, _ := seedUserAndAPIKey(t, store, "expired-user@example.com")
+	clientID := seedOAuthClient(t, oauthStore)
+	tok := issueOAuthToken(t, oauthStore, clientID, user.ID, func(t *oauth.Token) {
+		t.ExpiresAt = time.Now().Add(-1 * time.Minute) // already expired
+	})
+
+	resp := getWithBearer(t, server, tok.AccessToken)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expired OAuth token should be rejected: got %d", resp.StatusCode)
+	}
+}
+
+func TestAuth_OAuthToken_Unknown(t *testing.T) {
+	server, _, _, _ := setupAPIWithOAuth(t)
+
+	// Well-formed-looking but nonexistent token.
+	resp := getWithBearer(t, server, oauth.AccessTokenPrefix+"deadbeefdeadbeefdeadbeefdeadbeef")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("unknown OAuth token should be rejected: got %d", resp.StatusCode)
+	}
+}
+
+// TestAuth_OAuthPrefix_WithoutStore_FailsClosed ensures a deployment
+// that hasn't called SetOAuthStore rejects ate2a_ tokens cleanly
+// (rather than e.g. falling back to GetUserByAPIKey which would
+// return ErrAPIKeyNotFound and surface as 401 anyway — but with a
+// less informative error). Same 401, more debuggable.
+func TestAuth_OAuthPrefix_WithoutStore_FailsClosed(t *testing.T) {
+	// Manually set up an API *without* the OAuth store.
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	smtpRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{})
+	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
+	noopUsage := usage.NewNoopUsageTracker()
+	api := agent.NewAPI(store, sender, smtpRelay, nil, noopUsage, "e2a.dev", "test.e2a.dev", "agents.e2a.dev", "", false)
+	// Note: no SetOAuthStore call.
+	router := mux.NewRouter()
+	api.RegisterRoutes(router)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	resp := getWithBearer(t, server, oauth.AccessTokenPrefix+"00112233445566778899aabbccddeeff")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("OAuth bearer without configured store should 401: got %d", resp.StatusCode)
+	}
+}
+
+// TestAuth_MalformedBearer covers the gap between API-key prefix
+// (e2a_) and OAuth prefix (ate2a_): some arbitrary garbage bearer
+// must not authenticate. The current dispatch treats anything not
+// starting with ate2a_ as an API-key candidate, so this exercises
+// the GetUserByAPIKey not-found path.
+func TestAuth_MalformedBearer(t *testing.T) {
+	server, _, _, _ := setupAPIWithOAuth(t)
+	resp := getWithBearer(t, server, "garbage-not-an-api-key")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("garbage bearer should 401: got %d", resp.StatusCode)
+	}
+}
+
+// TestAuth_NoBearer ensures an unauthenticated request still 401s.
+// Regression guard for "did I accidentally let the OAuth path through
+// when no Authorization header is present."
+func TestAuth_NoBearer(t *testing.T) {
+	server, _, _, _ := setupAPIWithOAuth(t)
+	resp := getWithBearer(t, server, "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("no bearer should 401: got %d", resp.StatusCode)
+	}
+}

--- a/internal/agent/oauth_auth_test.go
+++ b/internal/agent/oauth_auth_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -160,6 +161,35 @@ func TestAuth_OAuthToken_Revoked(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Fatalf("revoked OAuth token should be rejected: got %d", resp.StatusCode)
+	}
+	// U11: revoked-token 401 must carry RFC 6750 §3 WWW-Authenticate
+	// challenge so MCP clients can distinguish "re-OAuth" from "API
+	// key bad" and trigger their re-auth flow.
+	wa := resp.Header.Get("WWW-Authenticate")
+	if wa == "" {
+		t.Fatal("revoked OAuth token 401 missing WWW-Authenticate header")
+	}
+	if !strings.Contains(wa, `error="invalid_token"`) {
+		t.Errorf(`WWW-Authenticate should contain error="invalid_token": got %q`, wa)
+	}
+	if !strings.Contains(wa, "revoked") {
+		t.Errorf("WWW-Authenticate error_description should mention 'revoked': got %q", wa)
+	}
+}
+
+// TestAuth_OAuthToken_Revoked_Challenge is covered above. This test
+// covers the parallel API-key path: a bad API key 401 must NOT carry
+// WWW-Authenticate (different auth scheme; clients shouldn't try to
+// re-OAuth a bad API key).
+func TestAuth_APIKey_No_OAuthChallenge(t *testing.T) {
+	server, _, _, _ := setupAPIWithOAuth(t)
+	resp := getWithBearer(t, server, "e2a_definitely_not_a_real_key_value_here")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("bad API key should 401: got %d", resp.StatusCode)
+	}
+	if wa := resp.Header.Get("WWW-Authenticate"); wa != "" {
+		t.Errorf("API-key path must not emit OAuth WWW-Authenticate: got %q", wa)
 	}
 }
 

--- a/internal/agent/oauth_authorize_test.go
+++ b/internal/agent/oauth_authorize_test.go
@@ -293,6 +293,28 @@ func TestAuthorize_NoSession_RedirectsToLogin(t *testing.T) {
 	if !strings.HasSuffix(loc.Path, "/api/auth/login") {
 		t.Errorf("expected redirect to /api/auth/login, got %q", loc.String())
 	}
+	// U2: the login redirect MUST carry return_to so Google-callback
+	// can resume the OAuth flow. Without it, the user lands on
+	// /dashboard with no way to restart consent except by re-invoking
+	// from their MCP client.
+	rt := loc.Query().Get("return_to")
+	if rt == "" {
+		t.Fatal("login redirect missing return_to — user can't resume OAuth after Google completes")
+	}
+	if !strings.HasPrefix(rt, "/api/oauth/authorize") {
+		t.Errorf("return_to should be /api/oauth/authorize…: got %q", rt)
+	}
+	// And the original authorize params must round-trip through it.
+	rtURL, err := url.Parse(rt)
+	if err != nil {
+		t.Fatalf("return_to should be parseable: %v", err)
+	}
+	if rtURL.Query().Get("client_id") != f.client.ClientID {
+		t.Errorf("return_to must carry client_id: got %q", rtURL.Query().Get("client_id"))
+	}
+	if rtURL.Query().Get("state") != "test-state" {
+		t.Errorf("return_to must carry state: got %q", rtURL.Query().Get("state"))
+	}
 }
 
 func TestAuthorize_WithSession_RedirectsToConsentUI(t *testing.T) {

--- a/internal/agent/oauth_authorize_test.go
+++ b/internal/agent/oauth_authorize_test.go
@@ -270,6 +270,93 @@ func TestAuthorize_UnsupportedResponseType_RedirectError(t *testing.T) {
 	}
 }
 
+// TestAuthorize_LoopbackPortAgnostic guards the RFC 8252 §7.3 fix:
+// when a client registers http://127.0.0.1:8765/cb (its development
+// port at registration time) but actually binds to a different
+// ephemeral port (say 8932) at runtime, the request's redirect_uri
+// must still match. Native MCP clients hit this routinely because
+// the OS assigns the port at socket-bind time.
+func TestAuthorize_LoopbackPortAgnostic(t *testing.T) {
+	pool := testutil.TestDB(t)
+	identStore := identity.NewStore(pool)
+	oauthStore := oauth.NewStore(pool)
+	smtpRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{})
+	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
+
+	ua := auth.NewUserAuth(&config.OAuthConfig{
+		GoogleClientID:     "test-id",
+		GoogleClientSecret: "test-secret",
+		RedirectURL:        "http://localhost/api/auth/callback",
+	}, identStore, false)
+
+	api := agent.NewAPI(identStore, sender, smtpRelay, ua, usage.NewNoopUsageTracker(), "e2a.dev", "test.e2a.dev", "agents.e2a.dev", "https://e2a.dev", false)
+	api.SetOAuthStore(oauthStore)
+	router := mux.NewRouter()
+	api.RegisterRoutes(router)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	user, err := identStore.CreateOrGetUser(context.Background(), "loopback@example.com", "U", "google-loopback")
+	if err != nil {
+		t.Fatal(err)
+	}
+	token, err := identStore.CreateUserSession(context.Background(), user.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Client registers with port 8765; later requests with port 8932.
+	client := &oauth.Client{
+		ClientID:     oauth.NewClientID(),
+		ClientName:   "loopback client",
+		RedirectURIs: []string{"http://127.0.0.1:8765/cb"},
+		ClientType:   "public",
+		CreatedVia:   "dcr",
+	}
+	if err := oauthStore.RegisterClient(context.Background(), client); err != nil {
+		t.Fatal(err)
+	}
+
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", client.ClientID)
+	q.Set("redirect_uri", "http://127.0.0.1:8932/cb") // different port
+	q.Set("code_challenge", testPKCEChallenge)
+	q.Set("code_challenge_method", "S256")
+	q.Set("scope", "e2a")
+	q.Set("state", "x")
+
+	resp := doGET(t, server.URL+"/api/oauth/authorize?"+q.Encode(), token)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("loopback port mismatch should be accepted per RFC 8252 §7.3, got %d", resp.StatusCode)
+	}
+
+	// Negative: non-loopback https mismatch is still rejected.
+	q.Set("redirect_uri", "https://attacker.example.com/cb")
+	resp2 := doGET(t, server.URL+"/api/oauth/authorize?"+q.Encode(), token)
+	defer resp2.Body.Close()
+	assertOAuthError(t, resp2, http.StatusBadRequest, "invalid_request")
+}
+
+// TestAuthorize_MissingPKCEMethod_RedirectError guards the spec fix:
+// per RFC 7636 §4.3 an absent code_challenge_method defaults to
+// "plain", which we don't support. OAuth 2.1 §4.1.1 promotes it to
+// REQUIRED. The authorize endpoint must reject (with the same
+// redirect-with-error path as other logical errors).
+func TestAuthorize_MissingPKCEMethod_RedirectError(t *testing.T) {
+	f := newAuthzFixture(t)
+	resp := doGET(t, f.authorizeURL(map[string]string{"code_challenge_method": ""}), f.sessionToken)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected 302 with error, got %d", resp.StatusCode)
+	}
+	loc := parseLocation(t, resp)
+	if loc.Query().Get("error") != "invalid_request" {
+		t.Errorf("expected error=invalid_request, got %q", loc.Query().Get("error"))
+	}
+}
+
 func TestAuthorize_MissingPKCE_RedirectError(t *testing.T) {
 	f := newAuthzFixture(t)
 	resp := doGET(t, f.authorizeURL(map[string]string{"code_challenge": ""}), f.sessionToken)
@@ -419,6 +506,12 @@ func TestConsent_Deny_RedirectsWithError(t *testing.T) {
 	if loc.Query().Get("state") != "test-state" {
 		t.Errorf("state must round-trip, got %q", loc.Query().Get("state"))
 	}
+	// RFC 9207 §2.4: the issuer identifier MUST appear on error
+	// authorization responses too, so a mix-up-aware client can
+	// distinguish errors from this AS vs an attacker's AS.
+	if got := loc.Query().Get("iss"); got != "https://e2a.dev" {
+		t.Errorf("iss param missing on error redirect: got %q", got)
+	}
 }
 
 func TestConsent_InvalidAction_400(t *testing.T) {
@@ -446,6 +539,12 @@ func TestConsent_Allow_CreateNew_DefaultSlug(t *testing.T) {
 	}
 	if loc.Query().Get("state") != "test-state" {
 		t.Errorf("state must round-trip, got %q", loc.Query().Get("state"))
+	}
+	// RFC 9207 §2: the authorization response must include the
+	// issuer identifier so a mix-up-aware client can verify which
+	// AS minted the code. Must match the discovery `issuer`.
+	if got := loc.Query().Get("iss"); got != "https://e2a.dev" {
+		t.Errorf("iss param mismatch: want %q, got %q", "https://e2a.dev", got)
 	}
 
 	// The auth code row should be present and bound to a new agent on

--- a/internal/agent/oauth_authorize_test.go
+++ b/internal/agent/oauth_authorize_test.go
@@ -1,0 +1,555 @@
+package agent_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/agent"
+	"github.com/Mnexa-AI/e2a/internal/auth"
+	"github.com/Mnexa-AI/e2a/internal/config"
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/oauth"
+	"github.com/Mnexa-AI/e2a/internal/outbound"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+	"github.com/Mnexa-AI/e2a/internal/usage"
+	"github.com/gorilla/mux"
+)
+
+// authzFixture bundles the state every authorize/consent test needs:
+// a running server, the OAuth store, the identity store, a session
+// token, a user, and a registered client whose redirect_uri the tests
+// can reuse without re-registering.
+type authzFixture struct {
+	server       *httptest.Server
+	identStore   *identity.Store
+	oauthStore   *oauth.Store
+	user         *identity.User
+	sessionToken string
+	client       *oauth.Client
+}
+
+const (
+	// Reusable PKCE code_challenge — 43-char base64url-encoded SHA-256
+	// digest of a deterministic verifier ("dummy-verifier"). The
+	// authorize endpoint only checks shape; PKCE verification happens
+	// at /token (slice 7). The string lengths match RFC 7636 §4.2.
+	testPKCEChallenge = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLM1234"
+	testRedirectURI   = "https://client.example.com/cb"
+)
+
+func newAuthzFixture(t *testing.T) *authzFixture {
+	t.Helper()
+	pool := testutil.TestDB(t)
+	identStore := identity.NewStore(pool)
+	oauthStore := oauth.NewStore(pool)
+	smtpRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{})
+	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
+	noopUsage := usage.NewNoopUsageTracker()
+
+	ua := auth.NewUserAuth(&config.OAuthConfig{
+		GoogleClientID:     "test-id",
+		GoogleClientSecret: "test-secret",
+		RedirectURL:        "http://localhost/api/auth/callback",
+	}, identStore, false)
+
+	// publicURL is critical — the authorize endpoint 503s without it.
+	api := agent.NewAPI(identStore, sender, smtpRelay, ua, noopUsage, "e2a.dev", "test.e2a.dev", "agents.e2a.dev", "https://e2a.dev", false)
+	api.SetOAuthStore(oauthStore)
+	router := mux.NewRouter()
+	api.RegisterRoutes(router)
+	server := httptest.NewServer(router)
+	t.Cleanup(server.Close)
+
+	// Need a shared-domain row for slug-based agent creation.
+	if err := identStore.EnsureSharedDomain(context.Background(), "agents.e2a.dev"); err != nil {
+		t.Fatalf("EnsureSharedDomain: %v", err)
+	}
+
+	// Seed user + session.
+	user, err := identStore.CreateOrGetUser(context.Background(), "authz-user@example.com", "User", "google-authz")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	token, err := identStore.CreateUserSession(context.Background(), user.ID)
+	if err != nil {
+		t.Fatalf("CreateUserSession: %v", err)
+	}
+
+	// Seed an OAuth client with the test redirect_uri pre-registered.
+	client := &oauth.Client{
+		ClientID:     oauth.NewClientID(),
+		ClientName:   "Test Client",
+		RedirectURIs: []string{testRedirectURI},
+		ClientType:   "public",
+		CreatedVia:   "dcr",
+	}
+	if err := oauthStore.RegisterClient(context.Background(), client); err != nil {
+		t.Fatalf("RegisterClient: %v", err)
+	}
+
+	return &authzFixture{
+		server:       server,
+		identStore:   identStore,
+		oauthStore:   oauthStore,
+		user:         user,
+		sessionToken: token,
+		client:       client,
+	}
+}
+
+// authorizeURL builds /api/oauth/authorize?<all params> with the
+// fixture's client_id pre-filled. Override individual fields via opts
+// — useful for "with malformed X" tests.
+func (f *authzFixture) authorizeURL(overrides map[string]string) string {
+	q := url.Values{}
+	q.Set("response_type", "code")
+	q.Set("client_id", f.client.ClientID)
+	q.Set("redirect_uri", testRedirectURI)
+	q.Set("code_challenge", testPKCEChallenge)
+	q.Set("code_challenge_method", "S256")
+	q.Set("scope", "e2a")
+	q.Set("state", "test-state")
+	for k, v := range overrides {
+		if v == "" {
+			q.Del(k)
+		} else {
+			q.Set(k, v)
+		}
+	}
+	return f.server.URL + "/api/oauth/authorize?" + q.Encode()
+}
+
+// doGET sends a GET that does NOT follow redirects. Tests usually want
+// to inspect the Location header rather than chase it.
+func doGET(t *testing.T, urlStr string, sessionToken string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest("GET", urlStr, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sessionToken != "" {
+		req.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: sessionToken})
+	}
+	resp, err := noRedirectClient().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+// doPOSTForm sends a POST with form body, no redirect following.
+func doPOSTForm(t *testing.T, urlStr, sessionToken string, form url.Values) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest("POST", urlStr, strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	if sessionToken != "" {
+		req.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: sessionToken})
+	}
+	resp, err := noRedirectClient().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+func noRedirectClient() *http.Client {
+	return &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
+}
+
+// parseLocation parses the Location header off a redirect response.
+// Fails the test if absent or unparseable.
+func parseLocation(t *testing.T, resp *http.Response) *url.URL {
+	t.Helper()
+	loc := resp.Header.Get("Location")
+	if loc == "" {
+		t.Fatalf("expected Location header on %d response", resp.StatusCode)
+	}
+	u, err := url.Parse(loc)
+	if err != nil {
+		t.Fatalf("Location header not parseable: %q", loc)
+	}
+	return u
+}
+
+// ──────────────────────── GET /api/oauth/authorize ────────────────────────
+
+func TestAuthorize_NoOAuthStore_404(t *testing.T) {
+	pool := testutil.TestDB(t)
+	identStore := identity.NewStore(pool)
+	smtpRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{})
+	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
+	api := agent.NewAPI(identStore, sender, smtpRelay, nil, usage.NewNoopUsageTracker(), "e2a.dev", "test.e2a.dev", "agents.e2a.dev", "https://e2a.dev", false)
+	router := mux.NewRouter()
+	api.RegisterRoutes(router)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	resp := doGET(t, server.URL+"/api/oauth/authorize?response_type=code&client_id=x&redirect_uri=https://example.com/cb&code_challenge="+testPKCEChallenge+"&code_challenge_method=S256&scope=e2a", "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("want 404 without oauth store, got %d", resp.StatusCode)
+	}
+}
+
+func TestAuthorize_NoPublicURL_503(t *testing.T) {
+	pool := testutil.TestDB(t)
+	identStore := identity.NewStore(pool)
+	oauthStore := oauth.NewStore(pool)
+	smtpRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{})
+	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
+	// empty publicURL
+	api := agent.NewAPI(identStore, sender, smtpRelay, nil, usage.NewNoopUsageTracker(), "e2a.dev", "test.e2a.dev", "agents.e2a.dev", "", false)
+	api.SetOAuthStore(oauthStore)
+	router := mux.NewRouter()
+	api.RegisterRoutes(router)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	resp := doGET(t, server.URL+"/api/oauth/authorize", "")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("want 503 without publicURL, got %d", resp.StatusCode)
+	}
+}
+
+func TestAuthorize_MissingClientID_400(t *testing.T) {
+	f := newAuthzFixture(t)
+	resp := doGET(t, f.authorizeURL(map[string]string{"client_id": ""}), f.sessionToken)
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_request")
+}
+
+func TestAuthorize_BadRedirectURI_400(t *testing.T) {
+	f := newAuthzFixture(t)
+	resp := doGET(t, f.authorizeURL(map[string]string{"redirect_uri": "https://example.com/cb#frag"}), f.sessionToken)
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_request")
+}
+
+func TestAuthorize_UnknownClient_400(t *testing.T) {
+	f := newAuthzFixture(t)
+	resp := doGET(t, f.authorizeURL(map[string]string{"client_id": "mcp_deadbeefcafe"}), f.sessionToken)
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_request")
+}
+
+func TestAuthorize_RedirectURI_NotRegistered_400(t *testing.T) {
+	f := newAuthzFixture(t)
+	resp := doGET(t, f.authorizeURL(map[string]string{"redirect_uri": "https://attacker.example.com/cb"}), f.sessionToken)
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_request")
+}
+
+// TestAuthorize_UnsupportedResponseType_RedirectError verifies that
+// once redirect_uri is verified, soft errors come back via redirect
+// per RFC 6749 §4.1.2.1 — not direct HTTP 400.
+func TestAuthorize_UnsupportedResponseType_RedirectError(t *testing.T) {
+	f := newAuthzFixture(t)
+	resp := doGET(t, f.authorizeURL(map[string]string{"response_type": "token"}), f.sessionToken)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected 302, got %d", resp.StatusCode)
+	}
+	loc := parseLocation(t, resp)
+	if loc.Query().Get("error") != "unsupported_response_type" {
+		t.Errorf("expected error=unsupported_response_type, got %q", loc.Query().Get("error"))
+	}
+	if loc.Query().Get("state") != "test-state" {
+		t.Errorf("state must round-trip: got %q", loc.Query().Get("state"))
+	}
+}
+
+func TestAuthorize_MissingPKCE_RedirectError(t *testing.T) {
+	f := newAuthzFixture(t)
+	resp := doGET(t, f.authorizeURL(map[string]string{"code_challenge": ""}), f.sessionToken)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected 302, got %d", resp.StatusCode)
+	}
+	if parseLocation(t, resp).Query().Get("error") != "invalid_request" {
+		t.Error("expected invalid_request error in redirect")
+	}
+}
+
+func TestAuthorize_NoSession_RedirectsToLogin(t *testing.T) {
+	f := newAuthzFixture(t)
+	resp := doGET(t, f.authorizeURL(nil), "") // no session cookie
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected 302 redirect to login, got %d", resp.StatusCode)
+	}
+	loc := parseLocation(t, resp)
+	if !strings.HasSuffix(loc.Path, "/api/auth/login") {
+		t.Errorf("expected redirect to /api/auth/login, got %q", loc.String())
+	}
+}
+
+func TestAuthorize_WithSession_RedirectsToConsentUI(t *testing.T) {
+	f := newAuthzFixture(t)
+	resp := doGET(t, f.authorizeURL(nil), f.sessionToken)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected 302 to consent UI, got %d", resp.StatusCode)
+	}
+	loc := parseLocation(t, resp)
+	if !strings.HasSuffix(loc.Path, "/oauth/consent") {
+		t.Errorf("expected /oauth/consent path, got %q", loc.Path)
+	}
+	q := loc.Query()
+	if q.Get("client_id") != f.client.ClientID {
+		t.Errorf("client_id must round-trip: got %q", q.Get("client_id"))
+	}
+	if q.Get("redirect_uri") != testRedirectURI {
+		t.Errorf("redirect_uri must round-trip: got %q", q.Get("redirect_uri"))
+	}
+	if q.Get("code_challenge") != testPKCEChallenge {
+		t.Errorf("code_challenge must round-trip: got %q", q.Get("code_challenge"))
+	}
+	if q.Get("state") != "test-state" {
+		t.Errorf("state must round-trip: got %q", q.Get("state"))
+	}
+}
+
+// ──────────────────────── POST /api/oauth/consent ────────────────────────
+
+// consentForm builds the standard "happy path" form for the fixture.
+// Tests override individual fields with the overrides map.
+func (f *authzFixture) consentForm(overrides map[string]string) url.Values {
+	form := url.Values{}
+	form.Set("action", "allow")
+	form.Set("agent_choice", "create_new")
+	form.Set("new_agent_slug", "") // default
+	form.Set("response_type", "code")
+	form.Set("client_id", f.client.ClientID)
+	form.Set("redirect_uri", testRedirectURI)
+	form.Set("code_challenge", testPKCEChallenge)
+	form.Set("code_challenge_method", "S256")
+	form.Set("scope", "e2a")
+	form.Set("state", "test-state")
+	for k, v := range overrides {
+		if v == "" && k != "new_agent_slug" {
+			form.Del(k)
+		} else {
+			form.Set(k, v)
+		}
+	}
+	return form
+}
+
+func TestConsent_NoSession_401(t *testing.T) {
+	f := newAuthzFixture(t)
+	resp := doPOSTForm(t, f.server.URL+"/api/oauth/consent", "", f.consentForm(nil))
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusUnauthorized, "access_denied")
+}
+
+func TestConsent_MissingClientID_400(t *testing.T) {
+	f := newAuthzFixture(t)
+	form := f.consentForm(map[string]string{"client_id": ""})
+	form.Del("client_id")
+	resp := doPOSTForm(t, f.server.URL+"/api/oauth/consent", f.sessionToken, form)
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_request")
+}
+
+func TestConsent_UnknownClient_400(t *testing.T) {
+	f := newAuthzFixture(t)
+	resp := doPOSTForm(t, f.server.URL+"/api/oauth/consent", f.sessionToken,
+		f.consentForm(map[string]string{"client_id": "mcp_unknownclientx"}))
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_request")
+}
+
+func TestConsent_TamperedRedirectURI_400(t *testing.T) {
+	f := newAuthzFixture(t)
+	resp := doPOSTForm(t, f.server.URL+"/api/oauth/consent", f.sessionToken,
+		f.consentForm(map[string]string{"redirect_uri": "https://attacker.example.com/cb"}))
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_request")
+}
+
+func TestConsent_Deny_RedirectsWithError(t *testing.T) {
+	f := newAuthzFixture(t)
+	resp := doPOSTForm(t, f.server.URL+"/api/oauth/consent", f.sessionToken,
+		f.consentForm(map[string]string{"action": "deny"}))
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected 302, got %d", resp.StatusCode)
+	}
+	loc := parseLocation(t, resp)
+	if !strings.HasPrefix(loc.String(), testRedirectURI) {
+		t.Errorf("must redirect back to client redirect_uri: got %q", loc.String())
+	}
+	if loc.Query().Get("error") != "access_denied" {
+		t.Errorf("expected error=access_denied, got %q", loc.Query().Get("error"))
+	}
+	if loc.Query().Get("state") != "test-state" {
+		t.Errorf("state must round-trip, got %q", loc.Query().Get("state"))
+	}
+}
+
+func TestConsent_InvalidAction_400(t *testing.T) {
+	f := newAuthzFixture(t)
+	resp := doPOSTForm(t, f.server.URL+"/api/oauth/consent", f.sessionToken,
+		f.consentForm(map[string]string{"action": "shenanigan"}))
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_request")
+}
+
+func TestConsent_Allow_CreateNew_DefaultSlug(t *testing.T) {
+	f := newAuthzFixture(t)
+	resp := doPOSTForm(t, f.server.URL+"/api/oauth/consent", f.sessionToken, f.consentForm(nil))
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected 302 with code, got %d", resp.StatusCode)
+	}
+	loc := parseLocation(t, resp)
+	if !strings.HasPrefix(loc.String(), testRedirectURI) {
+		t.Errorf("must redirect back to client: got %q", loc.String())
+	}
+	code := loc.Query().Get("code")
+	if !strings.HasPrefix(code, oauth.AuthCodePrefix) {
+		t.Errorf("returned code should have %q prefix: got %q", oauth.AuthCodePrefix, code)
+	}
+	if loc.Query().Get("state") != "test-state" {
+		t.Errorf("state must round-trip, got %q", loc.Query().Get("state"))
+	}
+
+	// The auth code row should be present and bound to a new agent on
+	// the shared domain — the default slug should start with the
+	// slugified client name ("test-client-…").
+	gotCode, state, err := f.oauthStore.AtomicConsumeCode(context.Background(), code)
+	if err != nil {
+		t.Fatalf("AtomicConsumeCode: %v", err)
+	}
+	if state != oauth.ConsumeFresh {
+		t.Errorf("expected ConsumeFresh, got state=%v", state)
+	}
+	if gotCode.UserID != f.user.ID {
+		t.Errorf("code.UserID = %q, want %q", gotCode.UserID, f.user.ID)
+	}
+	if !strings.HasSuffix(gotCode.AgentEmail, "@agents.e2a.dev") {
+		t.Errorf("agent should be on shared domain: got %q", gotCode.AgentEmail)
+	}
+	if !strings.HasPrefix(gotCode.AgentEmail, "test-client-") {
+		t.Errorf("default slug should start with slugified client name: got %q", gotCode.AgentEmail)
+	}
+	if gotCode.CodeChallenge != testPKCEChallenge {
+		t.Errorf("PKCE challenge must be preserved: got %q", gotCode.CodeChallenge)
+	}
+}
+
+func TestConsent_Allow_CreateNew_UserOverrideSlug(t *testing.T) {
+	f := newAuthzFixture(t)
+	form := f.consentForm(nil)
+	form.Set("new_agent_slug", "my-custom-bot")
+	resp := doPOSTForm(t, f.server.URL+"/api/oauth/consent", f.sessionToken, form)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected 302, got %d", resp.StatusCode)
+	}
+	loc := parseLocation(t, resp)
+	code := loc.Query().Get("code")
+	gotCode, state, err := f.oauthStore.AtomicConsumeCode(context.Background(), code)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state != oauth.ConsumeFresh {
+		t.Errorf("expected ConsumeFresh, got %v", state)
+	}
+	if gotCode.AgentEmail != "my-custom-bot@agents.e2a.dev" {
+		t.Errorf("user-overridden slug must be used verbatim: got %q", gotCode.AgentEmail)
+	}
+}
+
+func TestConsent_Allow_CreateNew_InvalidSlug_400(t *testing.T) {
+	f := newAuthzFixture(t)
+	form := f.consentForm(nil)
+	form.Set("new_agent_slug", "BAD SLUG WITH SPACES")
+	resp := doPOSTForm(t, f.server.URL+"/api/oauth/consent", f.sessionToken, form)
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_request")
+}
+
+func TestConsent_Allow_CreateNew_SlugCollision_409(t *testing.T) {
+	f := newAuthzFixture(t)
+	// Pre-create the agent so the consent attempt collides.
+	if _, err := f.identStore.CreateAgent(context.Background(), "taken-slug@agents.e2a.dev", "agents.e2a.dev", "", "", "local", f.user.ID); err != nil {
+		t.Fatal(err)
+	}
+	form := f.consentForm(nil)
+	form.Set("new_agent_slug", "taken-slug")
+	resp := doPOSTForm(t, f.server.URL+"/api/oauth/consent", f.sessionToken, form)
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusConflict, "invalid_request")
+}
+
+func TestConsent_Allow_ExistingAgent_OK(t *testing.T) {
+	f := newAuthzFixture(t)
+	// User must own an agent first.
+	agentEmail := "mine@agents.e2a.dev"
+	if _, err := f.identStore.CreateAgent(context.Background(), agentEmail, "agents.e2a.dev", "", "", "local", f.user.ID); err != nil {
+		t.Fatal(err)
+	}
+	form := f.consentForm(map[string]string{"agent_choice": "existing:" + agentEmail})
+	resp := doPOSTForm(t, f.server.URL+"/api/oauth/consent", f.sessionToken, form)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusFound {
+		t.Fatalf("expected 302 with code, got %d", resp.StatusCode)
+	}
+	loc := parseLocation(t, resp)
+	code := loc.Query().Get("code")
+	gotCode, state, err := f.oauthStore.AtomicConsumeCode(context.Background(), code)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state != oauth.ConsumeFresh {
+		t.Errorf("expected ConsumeFresh, got %v", state)
+	}
+	if gotCode.AgentEmail != agentEmail {
+		t.Errorf("agent_email on code should reflect choice: got %q", gotCode.AgentEmail)
+	}
+}
+
+func TestConsent_Allow_ExistingAgent_NotOwned_403(t *testing.T) {
+	f := newAuthzFixture(t)
+	// Another user owns "victim-agent".
+	other, err := f.identStore.CreateOrGetUser(context.Background(), "other@example.com", "Other", "google-other")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.identStore.CreateAgent(context.Background(), "victim-agent@agents.e2a.dev", "agents.e2a.dev", "", "", "local", other.ID); err != nil {
+		t.Fatal(err)
+	}
+	form := f.consentForm(map[string]string{"agent_choice": "existing:victim-agent@agents.e2a.dev"})
+	resp := doPOSTForm(t, f.server.URL+"/api/oauth/consent", f.sessionToken, form)
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusForbidden, "access_denied")
+}
+
+func TestConsent_Allow_ExistingAgent_NotFound_400(t *testing.T) {
+	f := newAuthzFixture(t)
+	form := f.consentForm(map[string]string{"agent_choice": "existing:does-not-exist@agents.e2a.dev"})
+	resp := doPOSTForm(t, f.server.URL+"/api/oauth/consent", f.sessionToken, form)
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_request")
+}
+
+func TestConsent_BadAgentChoice_400(t *testing.T) {
+	f := newAuthzFixture(t)
+	form := f.consentForm(map[string]string{"agent_choice": "weird-value"})
+	resp := doPOSTForm(t, f.server.URL+"/api/oauth/consent", f.sessionToken, form)
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_request")
+}

--- a/internal/agent/oauth_discovery_test.go
+++ b/internal/agent/oauth_discovery_test.go
@@ -98,6 +98,13 @@ func TestOAuthDiscovery_Enabled(t *testing.T) {
 	if !equalStringSlice(meta.ScopesSupported, wantScopes) {
 		t.Errorf("scopes_supported: want %v, got %v", wantScopes, meta.ScopesSupported)
 	}
+	// v0.3 supports public clients only (PKCE). Asserting "none" only
+	// keeps discovery and DCR consistent — if a future slice adds
+	// confidential support, both files must change together.
+	wantAuthMethods := []string{"none"}
+	if !equalStringSlice(meta.TokenEndpointAuthMethodsSupported, wantAuthMethods) {
+		t.Errorf("token_endpoint_auth_methods_supported: want %v, got %v", wantAuthMethods, meta.TokenEndpointAuthMethodsSupported)
+	}
 }
 
 // TestOAuthDiscovery_NoOAuthStore_404 covers a deployment that hasn't

--- a/internal/agent/oauth_discovery_test.go
+++ b/internal/agent/oauth_discovery_test.go
@@ -111,6 +111,13 @@ func TestOAuthDiscovery_Enabled(t *testing.T) {
 	if !equalStringSlice(meta.RevocationEndpointAuthMethodsSupported, wantAuthMethods) {
 		t.Errorf("revocation_endpoint_auth_methods_supported: want %v, got %v", wantAuthMethods, meta.RevocationEndpointAuthMethodsSupported)
 	}
+	// RFC 9207 §3: advertising support tells clients to expect an
+	// `iss` parameter on the authorization response. Mix-up-aware
+	// clients (incl. MCP clients) use this to decide whether to
+	// enforce the check.
+	if !meta.AuthorizationResponseIssParameterSupported {
+		t.Error("authorization_response_iss_parameter_supported should be advertised true (RFC 9207)")
+	}
 }
 
 // TestOAuthDiscovery_NoOAuthStore_404 covers a deployment that hasn't

--- a/internal/agent/oauth_discovery_test.go
+++ b/internal/agent/oauth_discovery_test.go
@@ -1,0 +1,171 @@
+package agent_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/agent"
+	"github.com/Mnexa-AI/e2a/internal/config"
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/oauth"
+	"github.com/Mnexa-AI/e2a/internal/outbound"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+	"github.com/Mnexa-AI/e2a/internal/usage"
+	"github.com/gorilla/mux"
+)
+
+// newDiscoveryServer builds a minimal API server for discovery tests.
+// Variants control whether OAuth is enabled and what publicURL is set
+// to — those are the two knobs that gate the endpoint's behavior.
+func newDiscoveryServer(t *testing.T, oauthEnabled bool, publicURL string) *httptest.Server {
+	t.Helper()
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	smtpRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{})
+	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
+	noopUsage := usage.NewNoopUsageTracker()
+	api := agent.NewAPI(store, sender, smtpRelay, nil, noopUsage, "e2a.dev", "test.e2a.dev", "agents.e2a.dev", publicURL, false)
+	if oauthEnabled {
+		api.SetOAuthStore(oauth.NewStore(pool))
+	}
+	router := mux.NewRouter()
+	api.RegisterRoutes(router)
+	server := httptest.NewServer(router)
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestOAuthDiscovery_Enabled(t *testing.T) {
+	server := newDiscoveryServer(t, true, "https://e2a.dev")
+
+	resp, err := http.Get(server.URL + "/.well-known/oauth-authorization-server")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Errorf("want application/json content-type, got %q", ct)
+	}
+	if cc := resp.Header.Get("Cache-Control"); cc == "" {
+		t.Error("expected Cache-Control header to be set (clients should cache discovery)")
+	}
+
+	var meta agent.OAuthAuthorizationServerMetadata
+	if err := json.NewDecoder(resp.Body).Decode(&meta); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// Issuer + endpoint URLs must be absolute and derived from publicURL.
+	cases := map[string]string{
+		"issuer":                 meta.Issuer,
+		"authorization_endpoint": meta.AuthorizationEndpoint,
+		"token_endpoint":         meta.TokenEndpoint,
+		"registration_endpoint":  meta.RegistrationEndpoint,
+		"revocation_endpoint":    meta.RevocationEndpoint,
+	}
+	for field, val := range cases {
+		if !strings.HasPrefix(val, "https://e2a.dev") {
+			t.Errorf("%s should be absolute under publicURL: got %q", field, val)
+		}
+	}
+	if meta.Issuer != "https://e2a.dev" {
+		t.Errorf("issuer must equal publicURL exactly (no trailing slash, no path): got %q", meta.Issuer)
+	}
+
+	// Capability lists must match what the server actually implements.
+	// Regression-grade: if someone adds plaintext PKCE without updating
+	// this list, clients will silently negotiate the weaker method.
+	wantResponseTypes := []string{"code"}
+	if !equalStringSlice(meta.ResponseTypesSupported, wantResponseTypes) {
+		t.Errorf("response_types_supported: want %v, got %v", wantResponseTypes, meta.ResponseTypesSupported)
+	}
+	wantGrants := []string{"authorization_code", "refresh_token"}
+	if !equalStringSlice(meta.GrantTypesSupported, wantGrants) {
+		t.Errorf("grant_types_supported: want %v, got %v", wantGrants, meta.GrantTypesSupported)
+	}
+	wantPKCE := []string{"S256"}
+	if !equalStringSlice(meta.CodeChallengeMethodsSupported, wantPKCE) {
+		t.Errorf("code_challenge_methods_supported: want %v (S256 only), got %v", wantPKCE, meta.CodeChallengeMethodsSupported)
+	}
+	wantScopes := []string{"e2a"}
+	if !equalStringSlice(meta.ScopesSupported, wantScopes) {
+		t.Errorf("scopes_supported: want %v, got %v", wantScopes, meta.ScopesSupported)
+	}
+}
+
+// TestOAuthDiscovery_NoOAuthStore_404 covers a deployment that hasn't
+// wired in oauth.Store. Hiding the document (rather than returning a
+// half-populated one) signals to clients that OAuth genuinely isn't
+// available — they'll fall back to API-key auth instead of looping on
+// a broken discovery doc.
+func TestOAuthDiscovery_NoOAuthStore_404(t *testing.T) {
+	server := newDiscoveryServer(t, false, "https://e2a.dev")
+	resp, err := http.Get(server.URL + "/.well-known/oauth-authorization-server")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("OAuth not configured should 404: got %d", resp.StatusCode)
+	}
+}
+
+// TestOAuthDiscovery_NoPublicURL_404 covers the misconfigured-operator
+// case: oauth.Store is wired but http.public_url is empty. Returning a
+// document with empty or request-derived URLs would let an attacker
+// behind a proxy spoof the issuer; better to fail loudly.
+func TestOAuthDiscovery_NoPublicURL_404(t *testing.T) {
+	server := newDiscoveryServer(t, true, "")
+	resp, err := http.Get(server.URL + "/.well-known/oauth-authorization-server")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("missing publicURL should 404: got %d", resp.StatusCode)
+	}
+}
+
+// TestOAuthDiscovery_TrailingSlashNormalized guards against the
+// publicURL having a trailing slash, which would otherwise produce
+// "https://e2a.dev//api/oauth/token" — most clients tolerate it, but
+// RFC 8414 says the issuer URL MUST NOT have a trailing slash for
+// issuer-identifier matching to work.
+func TestOAuthDiscovery_TrailingSlashNormalized(t *testing.T) {
+	server := newDiscoveryServer(t, true, "https://e2a.dev/")
+	resp, err := http.Get(server.URL + "/.well-known/oauth-authorization-server")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var meta agent.OAuthAuthorizationServerMetadata
+	if err := json.NewDecoder(resp.Body).Decode(&meta); err != nil {
+		t.Fatal(err)
+	}
+	if meta.Issuer != "https://e2a.dev" {
+		t.Errorf("issuer must not have trailing slash: got %q", meta.Issuer)
+	}
+	if strings.Contains(meta.TokenEndpoint, "//api") {
+		t.Errorf("endpoints should not have doubled slashes: %q", meta.TokenEndpoint)
+	}
+}
+
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/agent/oauth_discovery_test.go
+++ b/internal/agent/oauth_discovery_test.go
@@ -105,6 +105,12 @@ func TestOAuthDiscovery_Enabled(t *testing.T) {
 	if !equalStringSlice(meta.TokenEndpointAuthMethodsSupported, wantAuthMethods) {
 		t.Errorf("token_endpoint_auth_methods_supported: want %v, got %v", wantAuthMethods, meta.TokenEndpointAuthMethodsSupported)
 	}
+	// L7: revocation_endpoint_auth_methods_supported must also be
+	// advertised so RFC 8414 §2 strict clients don't warn on missing
+	// metadata for the revoke endpoint.
+	if !equalStringSlice(meta.RevocationEndpointAuthMethodsSupported, wantAuthMethods) {
+		t.Errorf("revocation_endpoint_auth_methods_supported: want %v, got %v", wantAuthMethods, meta.RevocationEndpointAuthMethodsSupported)
+	}
 }
 
 // TestOAuthDiscovery_NoOAuthStore_404 covers a deployment that hasn't

--- a/internal/agent/oauth_handlers.go
+++ b/internal/agent/oauth_handlers.go
@@ -519,9 +519,14 @@ func (a *API) handleOAuthAuthorize(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if user := a.userAuth.AuthenticateRequest(r); user == nil {
-		// PR B will add return_to here. For now: kick to login so the
-		// user at least lands on a working sign-in page.
-		http.Redirect(w, r, strings.TrimRight(a.publicURL, "/")+"/api/auth/login", http.StatusFound)
+		// Carry the full authorize request (path + query) through login
+		// so the user resumes consent after Google completes instead of
+		// dropping onto the dashboard. HandleLogin validates return_to
+		// against an /api/oauth/-only allow-list, so this is safe even
+		// with attacker-controlled query params.
+		returnTo := r.URL.RequestURI() // path + query, no host
+		loginURL := strings.TrimRight(a.publicURL, "/") + "/api/auth/login?return_to=" + url.QueryEscape(returnTo)
+		http.Redirect(w, r, loginURL, http.StatusFound)
 		return
 	}
 

--- a/internal/agent/oauth_handlers.go
+++ b/internal/agent/oauth_handlers.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -26,16 +27,17 @@ import (
 // — omitting an OPTIONAL field (e.g. introspection_endpoint, jwks_uri) is
 // itself a signal to clients that the feature isn't supported.
 type OAuthAuthorizationServerMetadata struct {
-	Issuer                            string   `json:"issuer"`
-	AuthorizationEndpoint             string   `json:"authorization_endpoint"`
-	TokenEndpoint                     string   `json:"token_endpoint"`
-	RegistrationEndpoint              string   `json:"registration_endpoint"`
-	RevocationEndpoint                string   `json:"revocation_endpoint"`
-	ResponseTypesSupported            []string `json:"response_types_supported"`
-	GrantTypesSupported               []string `json:"grant_types_supported"`
-	CodeChallengeMethodsSupported     []string `json:"code_challenge_methods_supported"`
-	TokenEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported"`
-	ScopesSupported                   []string `json:"scopes_supported"`
+	Issuer                                 string   `json:"issuer"`
+	AuthorizationEndpoint                  string   `json:"authorization_endpoint"`
+	TokenEndpoint                          string   `json:"token_endpoint"`
+	RegistrationEndpoint                   string   `json:"registration_endpoint"`
+	RevocationEndpoint                     string   `json:"revocation_endpoint"`
+	ResponseTypesSupported                 []string `json:"response_types_supported"`
+	GrantTypesSupported                    []string `json:"grant_types_supported"`
+	CodeChallengeMethodsSupported          []string `json:"code_challenge_methods_supported"`
+	TokenEndpointAuthMethodsSupported      []string `json:"token_endpoint_auth_methods_supported"`
+	RevocationEndpointAuthMethodsSupported []string `json:"revocation_endpoint_auth_methods_supported"`
+	ScopesSupported                        []string `json:"scopes_supported"`
 }
 
 // handleOAuthDiscovery serves the RFC 8414 authorization-server metadata
@@ -63,11 +65,12 @@ func (a *API) handleOAuthDiscovery(w http.ResponseWriter, r *http.Request) {
 		TokenEndpoint:                     base + "/api/oauth/token",
 		RegistrationEndpoint:              base + "/api/oauth/register",
 		RevocationEndpoint:                base + "/api/oauth/revoke",
-		ResponseTypesSupported:            []string{"code"},
-		GrantTypesSupported:               []string{"authorization_code", "refresh_token"},
-		CodeChallengeMethodsSupported:     []string{"S256"},
-		TokenEndpointAuthMethodsSupported: []string{"none"},
-		ScopesSupported:                   []string{"e2a"},
+		ResponseTypesSupported:                 []string{"code"},
+		GrantTypesSupported:                    []string{"authorization_code", "refresh_token"},
+		CodeChallengeMethodsSupported:          []string{"S256"},
+		TokenEndpointAuthMethodsSupported:      []string{"none"},
+		RevocationEndpointAuthMethodsSupported: []string{"none"},
+		ScopesSupported:                        []string{"e2a"},
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "public, max-age=3600")
@@ -144,6 +147,14 @@ func validateRedirectURI(raw string) error {
 	if u.Fragment != "" {
 		return errors.New("redirect_uri must not contain a fragment")
 	}
+	// Reject userinfo (e.g. "https://anything@evil.com/cb" parses as
+	// host=evil.com). The URI looks legitimate to a human reviewing
+	// client metadata but the authority is attacker-controlled. Exact-
+	// string match at consent saves us, but rejecting at registration
+	// keeps the stored set readable and the surface tight.
+	if u.User != nil {
+		return errors.New("redirect_uri must not contain userinfo")
+	}
 	switch u.Scheme {
 	case "":
 		return errors.New("redirect_uri must include a scheme")
@@ -166,6 +177,32 @@ func validateRedirectURI(raw string) error {
 	}
 }
 
+// dcrSourceIP returns the IP we'll bucket DCR rate-limits by. The
+// repo-wide clientIP() trusts X-Forwarded-For unconditionally, which is
+// safe enough for authed endpoints (the auth happens first) but is a
+// real bypass on the only unauthenticated persistent-write endpoint —
+// DCR. An attacker rotating XFF defeats the 10/IP/hr cap and fills
+// oauth_clients.
+//
+// Preference order:
+//  1. CF-Connecting-IP — set by Cloudflare at the edge and stripped
+//     from inbound requests, so it can't be spoofed by a client. Used
+//     in prod (orange-cloud is on).
+//  2. r.RemoteAddr — the direct peer. In prod this is Caddy's loopback
+//     address, so all real clients share one bucket; that's
+//     conservative-but-correct. In dev (direct connections) it's the
+//     real client IP.
+//
+// XFF is never consulted here. If we add other unauthenticated
+// persistent-write endpoints, they should use this helper too.
+func dcrSourceIP(r *http.Request) string {
+	if ip := strings.TrimSpace(r.Header.Get("CF-Connecting-IP")); ip != "" {
+		return ip
+	}
+	host, _, _ := net.SplitHostPort(r.RemoteAddr)
+	return host
+}
+
 // handleOAuthRegister implements RFC 7591 Dynamic Client Registration.
 // Anonymous endpoint (RFC 7591 §2 — "open registration"). Per-IP rate
 // limited because anyone on the internet can hit it.
@@ -179,7 +216,7 @@ func (a *API) handleOAuthRegister(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	if !a.dcrLimit.Allow(clientIP(r)) {
+	if !a.dcrLimit.Allow(dcrSourceIP(r)) {
 		writeOAuthError(w, http.StatusTooManyRequests, "rate_limited", "too many registrations from this IP; try again later")
 		return
 	}
@@ -208,12 +245,23 @@ func (a *API) handleOAuthRegister(w http.ResponseWriter, r *http.Request) {
 		writeOAuthError(w, http.StatusBadRequest, "invalid_redirect_uri", "too many redirect_uris (max 10)")
 		return
 	}
+	// Dedupe + validate. Duplicate URIs serve no functional purpose
+	// (exact-match lookup short-circuits on the first hit) and let a
+	// hostile DCR caller exhaust the soft cap with no real value.
+	seen := make(map[string]struct{}, len(req.RedirectURIs))
+	deduped := req.RedirectURIs[:0]
 	for _, raw := range req.RedirectURIs {
 		if err := validateRedirectURI(raw); err != nil {
 			writeOAuthError(w, http.StatusBadRequest, "invalid_redirect_uri", err.Error())
 			return
 		}
+		if _, ok := seen[raw]; ok {
+			continue
+		}
+		seen[raw] = struct{}{}
+		deduped = append(deduped, raw)
 	}
+	req.RedirectURIs = deduped
 
 	// Defaults. RFC 7591 §2 lets the server fill in unspecified
 	// metadata; we default to the only combination v0.3 supports.
@@ -878,9 +926,17 @@ func (a *API) handleTokenRefresh(w http.ResponseWriter, r *http.Request) {
 
 	oldTok, err := a.oauthStore.LookupTokenByRefresh(r.Context(), refreshToken)
 	if err != nil {
-		// Either never existed or already rotated. Both surface as
-		// invalid_grant; chain-level revocation on the rotated case
-		// requires schema support not yet present.
+		// Either never existed, already rotated, or a DB error.
+		// ErrTokenNotFound is by far the common case: a rotated-and-
+		// replayed refresh hits this path because the column gets
+		// NULLed on rotation. We can't distinguish "stolen and
+		// replayed" from "never existed" without a separate
+		// rotated-history index (tracked follow-up). Until that lands,
+		// log every miss as a SECURITY event so ops can spot a pattern.
+		if errors.Is(err, oauth.ErrTokenNotFound) {
+			log.Printf("[oauth][SECURITY] refresh-grant lookup miss for client=%s — token never existed OR was rotated (possible replay)",
+				clientID)
+		}
 		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "refresh token invalid")
 		return
 	}
@@ -921,6 +977,20 @@ func (a *API) handleTokenRefresh(w http.ResponseWriter, r *http.Request) {
 		RefreshExpiresAt: &refreshExp,
 	}
 	if err := a.oauthStore.RotateRefreshToken(r.Context(), refreshToken, newTok); err != nil {
+		// ErrTokenNotFound here is the rotation race: two refresh
+		// requests with the same token arrived simultaneously, both
+		// passed the earlier LookupTokenByRefresh, and now the loser
+		// finds the row already NULLed. That's an invalid_grant from
+		// the caller's POV — not a 500. Still log it: even legitimate
+		// races indicate buggy client code (clients should serialize
+		// their refresh attempts), and the same path catches actual
+		// replay attempts.
+		if errors.Is(err, oauth.ErrTokenNotFound) {
+			log.Printf("[oauth][SECURITY] refresh rotation race or replay for client=%s user=%s chain=%s",
+				oldTok.ClientID, oldTok.UserID, oldTok.RefreshChainID)
+			writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "refresh token was already consumed")
+			return
+		}
 		writeOAuthError(w, http.StatusInternalServerError, "server_error", "failed to rotate refresh token")
 		return
 	}

--- a/internal/agent/oauth_handlers.go
+++ b/internal/agent/oauth_handlers.go
@@ -37,11 +37,10 @@ type OAuthAuthorizationServerMetadata struct {
 	CodeChallengeMethodsSupported          []string `json:"code_challenge_methods_supported"`
 	TokenEndpointAuthMethodsSupported      []string `json:"token_endpoint_auth_methods_supported"`
 	RevocationEndpointAuthMethodsSupported []string `json:"revocation_endpoint_auth_methods_supported"`
-	ScopesSupported                        []string `json:"scopes_supported"`
-	// Per RFC 8414 §2 — pointer to human-readable docs for e2a's OAuth
-	// surface (scope semantics, agent-pinning, slug conventions, etc.).
-	// Optional in the RFC but useful for client devs probing discovery.
-	ServiceDocumentation string `json:"service_documentation,omitempty"`
+	ScopesSupported []string `json:"scopes_supported"`
+	// RFC 9207 §3 — clients use this to know they should expect an
+	// `iss` parameter on the authorization response (mix-up defense).
+	AuthorizationResponseIssParameterSupported bool `json:"authorization_response_iss_parameter_supported,omitempty"`
 }
 
 // handleOAuthDiscovery serves the RFC 8414 authorization-server metadata
@@ -69,13 +68,13 @@ func (a *API) handleOAuthDiscovery(w http.ResponseWriter, r *http.Request) {
 		TokenEndpoint:                     base + "/api/oauth/token",
 		RegistrationEndpoint:              base + "/api/oauth/register",
 		RevocationEndpoint:                base + "/api/oauth/revoke",
-		ResponseTypesSupported:                 []string{"code"},
-		GrantTypesSupported:                    []string{"authorization_code", "refresh_token"},
-		CodeChallengeMethodsSupported:          []string{"S256"},
-		TokenEndpointAuthMethodsSupported:      []string{"none"},
-		RevocationEndpointAuthMethodsSupported: []string{"none"},
-		ScopesSupported:                        []string{"e2a"},
-		ServiceDocumentation:                   "https://e2a.dev/docs/oauth",
+		ResponseTypesSupported:                     []string{"code"},
+		GrantTypesSupported:                        []string{"authorization_code", "refresh_token"},
+		CodeChallengeMethodsSupported:              []string{"S256"},
+		TokenEndpointAuthMethodsSupported:          []string{"none"},
+		RevocationEndpointAuthMethodsSupported:     []string{"none"},
+		ScopesSupported:                            []string{"e2a"},
+		AuthorizationResponseIssParameterSupported: true,
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "public, max-age=3600")
@@ -244,7 +243,7 @@ func (a *API) handleOAuthRegister(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if len(req.ClientName) > 200 {
-		writeOAuthError(w, http.StatusBadRequest, "invalid_client_metadata", "client_name must be ≤200 characters")
+		writeOAuthError(w, http.StatusBadRequest, "invalid_client_metadata", "client_name must be 200 characters or fewer")
 		return
 	}
 	if len(req.RedirectURIs) == 0 {
@@ -414,10 +413,14 @@ func validateAuthorizeParamsLogical(p *oauthAuthorizeParams) (errCode, errDesc s
 		return "invalid_request", "code_challenge is required (PKCE mandatory)"
 	}
 	if !pkceChallengePattern.MatchString(p.CodeChallenge) {
-		return "invalid_request", "code_challenge format invalid (must be unreserved-chars, 43–128)"
+		return "invalid_request", "code_challenge format invalid (must be unreserved-chars, length 43 to 128)"
 	}
-	if p.CodeChallengeMethod != "" && p.CodeChallengeMethod != "S256" {
-		return "invalid_request", "code_challenge_method must be 'S256'"
+	// RFC 7636 §4.3 says an absent code_challenge_method defaults to
+	// "plain", and OAuth 2.1 §4.1.1 makes it REQUIRED when
+	// code_challenge is present. Discovery advertises S256 only, so
+	// reject anything but explicit "S256" — including absence.
+	if p.CodeChallengeMethod != "S256" {
+		return "invalid_request", "code_challenge_method must be S256"
 	}
 	// Scope: only "e2a" supported. Empty defaults to "e2a".
 	if p.Scope != "" && p.Scope != "e2a" {
@@ -430,7 +433,10 @@ func validateAuthorizeParamsLogical(p *oauthAuthorizeParams) (errCode, errDesc s
 // an error code (and optional description) in the query, per RFC 6749
 // §4.1.2.1. Use this only when redirect_uri has been validated against
 // the registered client. errDesc is omitted from the URL when empty.
-func redirectWithOAuthError(w http.ResponseWriter, r *http.Request, redirectURI, errCode, errDesc, state string) {
+// issuer (RFC 9207) is included unconditionally so mix-up-aware clients
+// can verify which AS produced the response — including error
+// responses, which §2.4 of RFC 9207 explicitly covers.
+func redirectWithOAuthError(w http.ResponseWriter, r *http.Request, redirectURI, errCode, errDesc, state, issuer string) {
 	u, err := url.Parse(redirectURI)
 	if err != nil {
 		// Should be unreachable — caller has already validated.
@@ -445,18 +451,70 @@ func redirectWithOAuthError(w http.ResponseWriter, r *http.Request, redirectURI,
 	if state != "" {
 		q.Set("state", state)
 	}
+	if issuer != "" {
+		q.Set("iss", issuer)
+	}
 	u.RawQuery = q.Encode()
 	http.Redirect(w, r, u.String(), http.StatusFound)
 }
 
 // redirectMatchesRegistered does an exact-string match per OAuth 2.1
-// guidance. No prefix matching, no scheme-only matching — every
-// registered URI is enumerated explicitly.
+// guidance, with one carve-out: per RFC 8252 §7.3, loopback
+// redirect_uris (http on localhost / 127.0.0.1 / ::1) match
+// port-agnostically. Native MCP clients (Cursor, Cline, Claude Code's
+// local listener) get an OS-assigned ephemeral port at runtime, so
+// requiring the registered port to match exactly breaks them under
+// port contention.
+//
+// The carve-out is scoped: only http loopback URIs get the port-
+// ignored match. https and custom schemes still require byte-exact
+// match (they don't have the ephemeral-port problem and exact match
+// closes a class of attacks via attacker-controlled URI tails).
 func redirectMatchesRegistered(want string, registered []string) bool {
 	for _, r := range registered {
 		if r == want {
 			return true
 		}
+	}
+	wantU, err := url.Parse(want)
+	if err != nil || !isLoopbackHTTP(wantU) {
+		return false
+	}
+	for _, r := range registered {
+		regU, err := url.Parse(r)
+		if err != nil || !isLoopbackHTTP(regU) {
+			continue
+		}
+		// Hostname must match exactly — RFC 8252 §7.3 calls out
+		// "127.0.0.1" and "[::1]" specifically; "localhost" is
+		// SHOULD-NOT for the client per §8.3 but we accept all three
+		// and require them to round-trip. The match deliberately
+		// doesn't equate 127.0.0.1 with localhost.
+		if wantU.Scheme == regU.Scheme &&
+			wantU.Hostname() == regU.Hostname() &&
+			wantU.Path == regU.Path {
+			return true
+		}
+	}
+	return false
+}
+
+// issuer returns the canonical issuer URL for this deployment — the
+// same string the discovery doc advertises, the same value clients
+// should expect to see in the `iss` parameter of an authorization
+// response (RFC 9207) or a JWT `iss` claim if we ever add JWT access
+// tokens. Centralized so the TrimRight invariant is enforced once.
+func (a *API) issuer() string {
+	return strings.TrimRight(a.publicURL, "/")
+}
+
+func isLoopbackHTTP(u *url.URL) bool {
+	if u.Scheme != "http" {
+		return false
+	}
+	switch u.Hostname() {
+	case "localhost", "127.0.0.1", "::1":
+		return true
 	}
 	return false
 }
@@ -508,7 +566,7 @@ func (a *API) handleOAuthAuthorize(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if errCode, errDesc := validateAuthorizeParamsLogical(p); errCode != "" {
-		redirectWithOAuthError(w, r, p.RedirectURI, errCode, errDesc, p.State)
+		redirectWithOAuthError(w, r, p.RedirectURI, errCode, errDesc, p.State, a.issuer())
 		return
 	}
 
@@ -640,19 +698,19 @@ func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if errCode, errDesc := validateAuthorizeParamsLogical(p); errCode != "" {
-		redirectWithOAuthError(w, r, p.RedirectURI, errCode, errDesc, p.State)
+		redirectWithOAuthError(w, r, p.RedirectURI, errCode, errDesc, p.State, a.issuer())
 		return
 	}
 
 	user := a.userAuth.AuthenticateRequest(r)
 	if user == nil {
-		writeOAuthError(w, http.StatusUnauthorized, "access_denied", "session required — log in before consenting")
+		writeOAuthError(w, http.StatusUnauthorized, "access_denied", "session required: log in before consenting")
 		return
 	}
 
 	action := r.PostFormValue("action")
 	if action == "deny" {
-		redirectWithOAuthError(w, r, p.RedirectURI, "access_denied", "user denied consent", p.State)
+		redirectWithOAuthError(w, r, p.RedirectURI, "access_denied", "user denied consent", p.State, a.issuer())
 		return
 	}
 	if action != "allow" {
@@ -727,7 +785,7 @@ func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
 
 		if _, err := a.store.CreateAgentTx(r.Context(), tx, authCode.AgentEmail, a.sharedDomain, "", "", "local", user.ID); err != nil {
 			if strings.Contains(err.Error(), "duplicate") {
-				writeOAuthError(w, http.StatusConflict, "invalid_request", "that slug is already taken — pick another")
+				writeOAuthError(w, http.StatusConflict, "invalid_request", "that slug is already taken; pick another")
 				return
 			}
 			writeOAuthError(w, http.StatusInternalServerError, "server_error", "failed to create agent")
@@ -753,6 +811,9 @@ func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
 	if p.State != "" {
 		q.Set("state", p.State)
 	}
+	// RFC 9207 §2: include the issuer in the authorization response so
+	// mix-up-aware clients can verify which AS minted the code.
+	q.Set("iss", a.issuer())
 	redirectURL.RawQuery = q.Encode()
 	http.Redirect(w, r, redirectURL.String(), http.StatusFound)
 }

--- a/internal/agent/oauth_handlers.go
+++ b/internal/agent/oauth_handlers.go
@@ -2,6 +2,9 @@ package agent
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -671,4 +674,228 @@ func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
 	}
 	redirectURL.RawQuery = q.Encode()
 	http.Redirect(w, r, redirectURL.String(), http.StatusFound)
+}
+
+// ───────────────────────── Token endpoint (RFC 6749 §4.1.3, §6) ─────────────────────────
+
+// OAuthTokenResponse is the success body for /api/oauth/token. Field
+// names follow RFC 6749 §5.1 verbatim.
+type OAuthTokenResponse struct {
+	AccessToken  string `json:"access_token"`
+	TokenType    string `json:"token_type"` // always "Bearer"
+	ExpiresIn    int    `json:"expires_in"` // seconds; access-token lifetime
+	RefreshToken string `json:"refresh_token,omitempty"`
+	Scope        string `json:"scope,omitempty"`
+}
+
+// pkceVerifierPattern enforces RFC 7636 §4.1 — same unreserved char set
+// as the challenge, length 43–128.
+var pkceVerifierPattern = regexp.MustCompile(`^[A-Za-z0-9._~-]{43,128}$`)
+
+// verifyPKCE_S256 confirms BASE64URL-NO-PAD(SHA256(verifier)) ==
+// challenge using a constant-time comparison so timing channels can't
+// be used to brute-force the challenge.
+func verifyPKCE_S256(verifier, challenge string) bool {
+	if !pkceVerifierPattern.MatchString(verifier) {
+		return false
+	}
+	h := sha256.Sum256([]byte(verifier))
+	computed := base64.RawURLEncoding.EncodeToString(h[:])
+	return subtle.ConstantTimeCompare([]byte(computed), []byte(challenge)) == 1
+}
+
+// writeTokenResponse emits the RFC 6749 §5.1 success body, including
+// the no-store cache directive required by §5.1 (so caches and dev
+// tools don't accidentally persist the access token).
+func writeTokenResponse(w http.ResponseWriter, t *oauth.Token) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
+	writeJSON(w, OAuthTokenResponse{
+		AccessToken:  t.AccessToken,
+		TokenType:    "Bearer",
+		ExpiresIn:    int(oauth.AccessTokenLifetime / time.Second),
+		RefreshToken: t.RefreshToken,
+		Scope:        t.Scope,
+	})
+}
+
+// handleOAuthToken dispatches by grant_type. Both grant types are
+// public-client only (no client_secret); identity is bound via PKCE on
+// the auth_code grant and via possession of the refresh on the refresh
+// grant.
+//
+// Per RFC 6749 §3.2, the request MUST be application/x-www-form-urlencoded.
+func (a *API) handleOAuthToken(w http.ResponseWriter, r *http.Request) {
+	if a.oauthStore == nil {
+		http.NotFound(w, r)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_request", "could not parse form body")
+		return
+	}
+	switch r.PostFormValue("grant_type") {
+	case "authorization_code":
+		a.handleTokenAuthCode(w, r)
+	case "refresh_token":
+		a.handleTokenRefresh(w, r)
+	case "":
+		writeOAuthError(w, http.StatusBadRequest, "invalid_request", "grant_type is required")
+	default:
+		writeOAuthError(w, http.StatusBadRequest, "unsupported_grant_type",
+			"only authorization_code and refresh_token grants are supported")
+	}
+}
+
+// handleTokenAuthCode implements the authorization_code grant (RFC 6749 §4.1.3).
+// Order matters:
+//  1. Atomically consume the code. A replay (already-consumed) triggers
+//     RFC 6749 §10.5 defense — revoke all tokens for the same
+//     (client_id, user_id) pair and return invalid_grant.
+//  2. Bind: client_id and redirect_uri on the request must match the
+//     code's recorded values.
+//  3. PKCE: verify code_verifier ⇒ recomputed challenge matches.
+//  4. Issue tokens (access + refresh) with a fresh refresh_chain_id.
+func (a *API) handleTokenAuthCode(w http.ResponseWriter, r *http.Request) {
+	code := r.PostFormValue("code")
+	redirectURI := r.PostFormValue("redirect_uri")
+	clientID := r.PostFormValue("client_id")
+	codeVerifier := r.PostFormValue("code_verifier")
+
+	if code == "" || redirectURI == "" || clientID == "" || codeVerifier == "" {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_request",
+			"code, redirect_uri, client_id, and code_verifier are required")
+		return
+	}
+
+	authCode, state, err := a.oauthStore.AtomicConsumeCode(r.Context(), code)
+	if err != nil {
+		writeOAuthError(w, http.StatusInternalServerError, "server_error", "code consume failed")
+		return
+	}
+	switch state {
+	case oauth.ConsumeFresh:
+		// proceed
+	case oauth.ConsumeAlreadyConsumed:
+		// RFC 6749 §10.5 — revoke every token issued via this (client,
+		// user) pair. We have the row even though it was already
+		// consumed; use its client_id/user_id, not the request's, so a
+		// replayer can't redirect the revocation to a different account.
+		if authCode != nil {
+			_, _ = a.oauthStore.RevokeAllByClientUser(r.Context(), authCode.ClientID, authCode.UserID)
+		}
+		writeOAuthError(w, http.StatusBadRequest, "invalid_grant",
+			"authorization code already used; associated tokens revoked")
+		return
+	case oauth.ConsumeExpired:
+		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "authorization code expired")
+		return
+	case oauth.ConsumeNotFound:
+		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "unknown authorization code")
+		return
+	}
+
+	if authCode.ClientID != clientID {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "client_id does not match the code")
+		return
+	}
+	if authCode.RedirectURI != redirectURI {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "redirect_uri does not match the code")
+		return
+	}
+	if !verifyPKCE_S256(codeVerifier, authCode.CodeChallenge) {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "code_verifier does not match code_challenge")
+		return
+	}
+
+	now := time.Now()
+	refreshExp := now.Add(oauth.RefreshTokenLifetime)
+	tok := &oauth.Token{
+		AccessToken:      oauth.NewAccessToken(),
+		RefreshToken:     oauth.NewRefreshToken(),
+		RefreshChainID:   oauth.NewChainID(),
+		ClientID:         authCode.ClientID,
+		UserID:           authCode.UserID,
+		AgentEmail:       authCode.AgentEmail,
+		Scope:            authCode.Scope,
+		ExpiresAt:        now.Add(oauth.AccessTokenLifetime),
+		RefreshExpiresAt: &refreshExp,
+	}
+	if err := a.oauthStore.IssueToken(r.Context(), tok); err != nil {
+		writeOAuthError(w, http.StatusInternalServerError, "server_error", "failed to issue tokens")
+		return
+	}
+	writeTokenResponse(w, tok)
+}
+
+// handleTokenRefresh implements the refresh_token grant (RFC 6749 §6)
+// with rotation per OAuth 2.1 / §10.4 reuse defense.
+//
+// Behavior:
+//  1. Look up the refresh. If not found at all, return invalid_grant
+//     — we can't distinguish "never existed" from "already rotated";
+//     full chain-level reuse defense on rotated rows is tracked as a
+//     follow-up (would require schema work to keep rotated values
+//     indexed). Rotation still provides single-use defense.
+//  2. If found but revoked or refresh-expired: revoke the entire
+//     chain (§10.4) and return invalid_grant.
+//  3. If client_id mismatch: revoke chain and return invalid_grant
+//     — an unexpected client presenting this refresh is malicious.
+//  4. Atomically rotate: NULL the old refresh, INSERT the new row
+//     under the same chain_id.
+func (a *API) handleTokenRefresh(w http.ResponseWriter, r *http.Request) {
+	refreshToken := r.PostFormValue("refresh_token")
+	clientID := r.PostFormValue("client_id")
+	if refreshToken == "" || clientID == "" {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_request",
+			"refresh_token and client_id are required")
+		return
+	}
+
+	oldTok, err := a.oauthStore.LookupTokenByRefresh(r.Context(), refreshToken)
+	if err != nil {
+		// Either never existed or already rotated. Both surface as
+		// invalid_grant; chain-level revocation on the rotated case
+		// requires schema support not yet present.
+		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "refresh token invalid")
+		return
+	}
+
+	// client_id binding (§10.4). Treat mismatch as hostile and burn
+	// the chain — a different client presenting this refresh means
+	// either token confusion at the client or theft.
+	if oldTok.ClientID != clientID {
+		_, _ = a.oauthStore.RevokeChainByID(r.Context(), oldTok.RefreshChainID)
+		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "client_id does not match the refresh token")
+		return
+	}
+
+	now := time.Now()
+	expired := oldTok.RefreshExpiresAt != nil && now.After(*oldTok.RefreshExpiresAt)
+	if oldTok.RevokedAt != nil || expired {
+		// Presenting a refresh that's revoked or past TTL is suspect.
+		// Revoke the chain so any sibling tokens are torn down too.
+		_, _ = a.oauthStore.RevokeChainByID(r.Context(), oldTok.RefreshChainID)
+		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "refresh token revoked or expired")
+		return
+	}
+
+	refreshExp := now.Add(oauth.RefreshTokenLifetime)
+	newTok := &oauth.Token{
+		AccessToken:      oauth.NewAccessToken(),
+		RefreshToken:     oauth.NewRefreshToken(),
+		RefreshChainID:   oldTok.RefreshChainID, // inherit chain
+		ClientID:         oldTok.ClientID,
+		UserID:           oldTok.UserID,
+		AgentEmail:       oldTok.AgentEmail,
+		Scope:            oldTok.Scope,
+		ExpiresAt:        now.Add(oauth.AccessTokenLifetime),
+		RefreshExpiresAt: &refreshExp,
+	}
+	if err := a.oauthStore.RotateRefreshToken(r.Context(), refreshToken, newTok); err != nil {
+		writeOAuthError(w, http.StatusInternalServerError, "server_error", "failed to rotate refresh token")
+		return
+	}
+	writeTokenResponse(w, newTok)
 }

--- a/internal/agent/oauth_handlers.go
+++ b/internal/agent/oauth_handlers.go
@@ -899,3 +899,89 @@ func (a *API) handleTokenRefresh(w http.ResponseWriter, r *http.Request) {
 	}
 	writeTokenResponse(w, newTok)
 }
+
+// ───────────────────────── Revoke endpoint (RFC 7009) ─────────────────────────
+
+// handleOAuthRevoke implements RFC 7009 §2. Public clients revoke their
+// own tokens by presenting client_id (no client_secret since they're
+// public).
+//
+// Per §2.2:
+//   - Successful revocation responds with 200 and empty body.
+//   - An invalid token (already revoked, never existed, etc.) ALSO
+//     responds 200 — the server "MUST NOT" leak which tokens are valid.
+//   - Bad inputs (missing token, missing client_id, client_id mismatch)
+//     return 400.
+//
+// Refresh-token revocation cascades to the whole refresh chain because
+// §2 says "the authorization server SHOULD also invalidate all access
+// tokens based on the same authorization grant." Our chain_id groups
+// exactly that set.
+func (a *API) handleOAuthRevoke(w http.ResponseWriter, r *http.Request) {
+	if a.oauthStore == nil {
+		http.NotFound(w, r)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_request", "could not parse form body")
+		return
+	}
+	token := strings.TrimSpace(r.PostFormValue("token"))
+	clientID := strings.TrimSpace(r.PostFormValue("client_id"))
+	hint := r.PostFormValue("token_type_hint") // optional
+
+	if token == "" || clientID == "" {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_request", "token and client_id are required")
+		return
+	}
+
+	// Try the lookup order suggested by the hint; fall back to the
+	// other type if the first returns nothing. Hint is advisory per
+	// RFC 7009 §2.1 — we MUST handle the "wrong hint" case gracefully.
+	var (
+		found  *oauth.Token
+		isRefresh bool
+	)
+	if hint == "refresh_token" {
+		if t, err := a.oauthStore.LookupTokenByRefresh(r.Context(), token); err == nil {
+			found, isRefresh = t, true
+		} else if t, err := a.oauthStore.LookupTokenByAccess(r.Context(), token); err == nil {
+			found = t
+		}
+	} else {
+		if t, err := a.oauthStore.LookupTokenByAccess(r.Context(), token); err == nil {
+			found = t
+		} else if t, err := a.oauthStore.LookupTokenByRefresh(r.Context(), token); err == nil {
+			found, isRefresh = t, true
+		}
+	}
+
+	// Not found — silently 200 (don't leak token existence). Some
+	// clients call revoke on logout regardless of validity; making them
+	// branch on the response would be unfriendly.
+	if found == nil {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// Client binding. Mismatch is a real protocol error (the client
+	// shouldn't have this token), so 400 — but per §2.1 we use
+	// "invalid_client" since the client_id doesn't authenticate.
+	if found.ClientID != clientID {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_client", "client_id does not match the token")
+		return
+	}
+
+	if isRefresh {
+		if _, err := a.oauthStore.RevokeChainByID(r.Context(), found.RefreshChainID); err != nil {
+			writeOAuthError(w, http.StatusInternalServerError, "server_error", "revocation failed")
+			return
+		}
+	} else {
+		if err := a.oauthStore.RevokeToken(r.Context(), found.AccessToken); err != nil {
+			writeOAuthError(w, http.StatusInternalServerError, "server_error", "revocation failed")
+			return
+		}
+	}
+	w.WriteHeader(http.StatusOK)
+}

--- a/internal/agent/oauth_handlers.go
+++ b/internal/agent/oauth_handlers.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/subtle"
@@ -8,6 +9,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -15,6 +17,7 @@ import (
 	"time"
 
 	"github.com/Mnexa-AI/e2a/internal/oauth"
+	"github.com/jackc/pgx/v5"
 )
 
 // OAuthAuthorizationServerMetadata is the RFC 8414 response shape for
@@ -132,21 +135,21 @@ func writeOAuthError(w http.ResponseWriter, status int, code, desc string) {
 //   - URIs without scheme/authority for http(s)
 func validateRedirectURI(raw string) error {
 	if raw == "" {
-		return errOAuthInvalid("redirect_uri cannot be empty")
+		return errors.New("redirect_uri cannot be empty")
 	}
 	u, err := url.Parse(raw)
 	if err != nil {
-		return errOAuthInvalid("redirect_uri is not a valid URI")
+		return errors.New("redirect_uri is not a valid URI")
 	}
 	if u.Fragment != "" {
-		return errOAuthInvalid("redirect_uri must not contain a fragment")
+		return errors.New("redirect_uri must not contain a fragment")
 	}
 	switch u.Scheme {
 	case "":
-		return errOAuthInvalid("redirect_uri must include a scheme")
+		return errors.New("redirect_uri must include a scheme")
 	case "https":
 		if u.Host == "" {
-			return errOAuthInvalid("https redirect_uri must include a host")
+			return errors.New("https redirect_uri must include a host")
 		}
 		return nil
 	case "http":
@@ -155,21 +158,13 @@ func validateRedirectURI(raw string) error {
 		if host == "localhost" || host == "127.0.0.1" || host == "::1" {
 			return nil
 		}
-		return errOAuthInvalid("http redirect_uri must use a loopback host (localhost, 127.0.0.1, or ::1)")
+		return errors.New("http redirect_uri must use a loopback host (localhost, 127.0.0.1, or ::1)")
 	default:
 		// Custom scheme (e.g. "myapp://callback"). Must have a non-empty
 		// scheme; that's all RFC 8252 §7.1 requires.
 		return nil
 	}
 }
-
-// errOAuthInvalid is a sentinel-like helper to make validation read
-// linearly; the caller maps these to HTTP 400 invalid_client_metadata.
-type oauthValidationError struct{ msg string }
-
-func (e *oauthValidationError) Error() string { return e.msg }
-
-func errOAuthInvalid(msg string) error { return &oauthValidationError{msg: msg} }
 
 // handleOAuthRegister implements RFC 7591 Dynamic Client Registration.
 // Anonymous endpoint (RFC 7591 §2 — "open registration"). Per-IP rate
@@ -372,9 +367,10 @@ func validateAuthorizeParamsLogical(p *oauthAuthorizeParams) (errCode, errDesc s
 }
 
 // redirectWithOAuthError 302s the user-agent back to redirect_uri with
-// an error code in the query, per RFC 6749 §4.1.2.1. Use this only when
-// redirect_uri has been validated against the registered client.
-func redirectWithOAuthError(w http.ResponseWriter, r *http.Request, redirectURI, errCode, state string) {
+// an error code (and optional description) in the query, per RFC 6749
+// §4.1.2.1. Use this only when redirect_uri has been validated against
+// the registered client. errDesc is omitted from the URL when empty.
+func redirectWithOAuthError(w http.ResponseWriter, r *http.Request, redirectURI, errCode, errDesc, state string) {
 	u, err := url.Parse(redirectURI)
 	if err != nil {
 		// Should be unreachable — caller has already validated.
@@ -383,6 +379,9 @@ func redirectWithOAuthError(w http.ResponseWriter, r *http.Request, redirectURI,
 	}
 	q := u.Query()
 	q.Set("error", errCode)
+	if errDesc != "" {
+		q.Set("error_description", errDesc)
+	}
 	if state != "" {
 		q.Set("state", state)
 	}
@@ -449,8 +448,7 @@ func (a *API) handleOAuthAuthorize(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if errCode, errDesc := validateAuthorizeParamsLogical(p); errCode != "" {
-		_ = errDesc // logged via the OAuth error code; description is descriptive only
-		redirectWithOAuthError(w, r, p.RedirectURI, errCode, p.State)
+		redirectWithOAuthError(w, r, p.RedirectURI, errCode, errDesc, p.State)
 		return
 	}
 
@@ -577,8 +575,7 @@ func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if errCode, errDesc := validateAuthorizeParamsLogical(p); errCode != "" {
-		_ = errDesc
-		redirectWithOAuthError(w, r, p.RedirectURI, errCode, p.State)
+		redirectWithOAuthError(w, r, p.RedirectURI, errCode, errDesc, p.State)
 		return
 	}
 
@@ -590,7 +587,7 @@ func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
 
 	action := r.PostFormValue("action")
 	if action == "deny" {
-		redirectWithOAuthError(w, r, p.RedirectURI, "access_denied", p.State)
+		redirectWithOAuthError(w, r, p.RedirectURI, "access_denied", "user denied consent", p.State)
 		return
 	}
 	if action != "allow" {
@@ -599,7 +596,17 @@ func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	agentChoice := r.PostFormValue("agent_choice")
-	var agentEmail string
+	authCode := &oauth.AuthorizationCode{
+		Code:                oauth.NewAuthCode(),
+		ClientID:            p.ClientID,
+		UserID:              user.ID,
+		RedirectURI:         p.RedirectURI,
+		CodeChallenge:       p.CodeChallenge,
+		CodeChallengeMethod: "S256",
+		Scope:               "e2a",
+		ExpiresAt:           time.Now().Add(oauth.AuthCodeLifetime),
+	}
+
 	switch {
 	case strings.HasPrefix(agentChoice, "existing:"):
 		email := strings.TrimPrefix(agentChoice, "existing:")
@@ -612,7 +619,12 @@ func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
 			writeOAuthError(w, http.StatusForbidden, "access_denied", "you do not own that agent")
 			return
 		}
-		agentEmail = email
+		authCode.AgentEmail = email
+		// Single-statement path — IssueCode on its own pool conn is fine.
+		if err := a.oauthStore.IssueCode(r.Context(), authCode); err != nil {
+			writeOAuthError(w, http.StatusInternalServerError, "server_error", "failed to issue authorization code")
+			return
+		}
 
 	case agentChoice == "create_new":
 		if a.sharedDomain == "" {
@@ -631,10 +643,24 @@ func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
 			writeOAuthError(w, http.StatusBadRequest, "invalid_request", "invalid slug: "+err.Error())
 			return
 		}
-		agentEmail = slug + "@" + a.sharedDomain
-		// Local-mode agent (no webhook). PR B's UI will let the user
-		// switch this later.
-		if _, err := a.store.CreateAgent(r.Context(), agentEmail, a.sharedDomain, "", "", "local", user.ID); err != nil {
+		authCode.AgentEmail = slug + "@" + a.sharedDomain
+
+		// Multi-statement path: agent creation + code insertion must
+		// commit together so a partial failure (IssueCode dies after
+		// CreateAgent commits) doesn't leave a phantom agent the user
+		// never authorized. Both stores share the same pool — we begin
+		// the tx on the oauth pool, pass it to both Tx-accepting
+		// variants, and only commit at the end.
+		tx, err := a.oauthStore.Pool().BeginTx(r.Context(), pgx.TxOptions{})
+		if err != nil {
+			writeOAuthError(w, http.StatusInternalServerError, "server_error", "failed to begin transaction")
+			return
+		}
+		// Rollback is a no-op after a successful commit — safe to defer
+		// unconditionally.
+		defer func() { _ = tx.Rollback(r.Context()) }()
+
+		if _, err := a.store.CreateAgentTx(r.Context(), tx, authCode.AgentEmail, a.sharedDomain, "", "", "local", user.ID); err != nil {
 			if strings.Contains(err.Error(), "duplicate") {
 				writeOAuthError(w, http.StatusConflict, "invalid_request", "that slug is already taken — pick another")
 				return
@@ -642,27 +668,17 @@ func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
 			writeOAuthError(w, http.StatusInternalServerError, "server_error", "failed to create agent")
 			return
 		}
+		if err := a.oauthStore.IssueCodeTx(r.Context(), tx, authCode); err != nil {
+			writeOAuthError(w, http.StatusInternalServerError, "server_error", "failed to issue authorization code")
+			return
+		}
+		if err := tx.Commit(r.Context()); err != nil {
+			writeOAuthError(w, http.StatusInternalServerError, "server_error", "failed to commit consent")
+			return
+		}
 
 	default:
 		writeOAuthError(w, http.StatusBadRequest, "invalid_request", "agent_choice must be 'existing:<email>' or 'create_new'")
-		return
-	}
-
-	// Mint the authorization code. AuthCodeLifetime is 60s — the client
-	// must POST /api/oauth/token immediately.
-	authCode := &oauth.AuthorizationCode{
-		Code:                oauth.NewAuthCode(),
-		ClientID:            p.ClientID,
-		UserID:              user.ID,
-		AgentEmail:          agentEmail,
-		RedirectURI:         p.RedirectURI,
-		CodeChallenge:       p.CodeChallenge,
-		CodeChallengeMethod: "S256",
-		Scope:               "e2a",
-		ExpiresAt:           time.Now().Add(oauth.AuthCodeLifetime),
-	}
-	if err := a.oauthStore.IssueCode(r.Context(), authCode); err != nil {
-		writeOAuthError(w, http.StatusInternalServerError, "server_error", "failed to issue authorization code")
 		return
 	}
 
@@ -783,7 +799,14 @@ func (a *API) handleTokenAuthCode(w http.ResponseWriter, r *http.Request) {
 		// consumed; use its client_id/user_id, not the request's, so a
 		// replayer can't redirect the revocation to a different account.
 		if authCode != nil {
-			_, _ = a.oauthStore.RevokeAllByClientUser(r.Context(), authCode.ClientID, authCode.UserID)
+			n, revErr := a.oauthStore.RevokeAllByClientUser(r.Context(), authCode.ClientID, authCode.UserID)
+			if revErr != nil {
+				log.Printf("[oauth][SECURITY] auth-code reuse detected for client=%s user=%s — revocation FAILED: %v",
+					authCode.ClientID, authCode.UserID, revErr)
+			} else {
+				log.Printf("[oauth][SECURITY] auth-code reuse detected for client=%s user=%s — revoked %d token(s)",
+					authCode.ClientID, authCode.UserID, n)
+			}
 		}
 		writeOAuthError(w, http.StatusBadRequest, "invalid_grant",
 			"authorization code already used; associated tokens revoked")
@@ -866,7 +889,9 @@ func (a *API) handleTokenRefresh(w http.ResponseWriter, r *http.Request) {
 	// the chain — a different client presenting this refresh means
 	// either token confusion at the client or theft.
 	if oldTok.ClientID != clientID {
-		_, _ = a.oauthStore.RevokeChainByID(r.Context(), oldTok.RefreshChainID)
+		n, revErr := a.oauthStore.RevokeChainByID(r.Context(), oldTok.RefreshChainID)
+		log.Printf("[oauth][SECURITY] refresh client_id mismatch: token-owner=%s presenter=%s — chain=%s revoked %d row(s) err=%v",
+			oldTok.ClientID, clientID, oldTok.RefreshChainID, n, revErr)
 		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "client_id does not match the refresh token")
 		return
 	}
@@ -876,7 +901,9 @@ func (a *API) handleTokenRefresh(w http.ResponseWriter, r *http.Request) {
 	if oldTok.RevokedAt != nil || expired {
 		// Presenting a refresh that's revoked or past TTL is suspect.
 		// Revoke the chain so any sibling tokens are torn down too.
-		_, _ = a.oauthStore.RevokeChainByID(r.Context(), oldTok.RefreshChainID)
+		n, revErr := a.oauthStore.RevokeChainByID(r.Context(), oldTok.RefreshChainID)
+		log.Printf("[oauth][SECURITY] refresh on revoked/expired token: client=%s user=%s revoked=%v expired=%v — chain=%s revoked %d row(s) err=%v",
+			oldTok.ClientID, oldTok.UserID, oldTok.RevokedAt != nil, expired, oldTok.RefreshChainID, n, revErr)
 		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "refresh token revoked or expired")
 		return
 	}
@@ -901,6 +928,49 @@ func (a *API) handleTokenRefresh(w http.ResponseWriter, r *http.Request) {
 }
 
 // ───────────────────────── Revoke endpoint (RFC 7009) ─────────────────────────
+
+// lookupRevocableToken tries access-token then refresh-token lookups
+// (or refresh-first when the hint asks). Returns:
+//   - (token, isRefresh, nil) when found
+//   - (nil, false, nil)        when both lookups returned ErrTokenNotFound
+//   - (nil, false, err)        when a lookup returned anything else
+//     (e.g. DB connection error) — caller should 500 rather than silently
+//     pretending the token was unknown
+func (a *API) lookupRevocableToken(ctx context.Context, token, hint string) (*oauth.Token, bool, error) {
+	if hint == "refresh_token" {
+		t, err := a.oauthStore.LookupTokenByRefresh(ctx, token)
+		if err == nil {
+			return t, true, nil
+		}
+		if !errors.Is(err, oauth.ErrTokenNotFound) {
+			return nil, false, err
+		}
+		t, err = a.oauthStore.LookupTokenByAccess(ctx, token)
+		if err == nil {
+			return t, false, nil
+		}
+		if errors.Is(err, oauth.ErrTokenNotFound) {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+
+	t, err := a.oauthStore.LookupTokenByAccess(ctx, token)
+	if err == nil {
+		return t, false, nil
+	}
+	if !errors.Is(err, oauth.ErrTokenNotFound) {
+		return nil, false, err
+	}
+	t, err = a.oauthStore.LookupTokenByRefresh(ctx, token)
+	if err == nil {
+		return t, true, nil
+	}
+	if errors.Is(err, oauth.ErrTokenNotFound) {
+		return nil, false, nil
+	}
+	return nil, false, err
+}
 
 // handleOAuthRevoke implements RFC 7009 §2. Public clients revoke their
 // own tokens by presenting client_id (no client_secret since they're
@@ -936,24 +1006,14 @@ func (a *API) handleOAuthRevoke(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Try the lookup order suggested by the hint; fall back to the
-	// other type if the first returns nothing. Hint is advisory per
-	// RFC 7009 §2.1 — we MUST handle the "wrong hint" case gracefully.
-	var (
-		found  *oauth.Token
-		isRefresh bool
-	)
-	if hint == "refresh_token" {
-		if t, err := a.oauthStore.LookupTokenByRefresh(r.Context(), token); err == nil {
-			found, isRefresh = t, true
-		} else if t, err := a.oauthStore.LookupTokenByAccess(r.Context(), token); err == nil {
-			found = t
-		}
-	} else {
-		if t, err := a.oauthStore.LookupTokenByAccess(r.Context(), token); err == nil {
-			found = t
-		} else if t, err := a.oauthStore.LookupTokenByRefresh(r.Context(), token); err == nil {
-			found, isRefresh = t, true
-		}
+	// other type if the first returns ErrTokenNotFound. Hint is
+	// advisory per RFC 7009 §2.1 — we MUST handle the "wrong hint"
+	// case gracefully. Other errors (DB down, etc.) bubble up as 500
+	// so ops sees the real failure instead of a silent 200.
+	found, isRefresh, err := a.lookupRevocableToken(r.Context(), token, hint)
+	if err != nil {
+		writeOAuthError(w, http.StatusInternalServerError, "server_error", "token lookup failed")
+		return
 	}
 
 	// Not found — silently 200 (don't leak token existence). Some

--- a/internal/agent/oauth_handlers.go
+++ b/internal/agent/oauth_handlers.go
@@ -38,6 +38,10 @@ type OAuthAuthorizationServerMetadata struct {
 	TokenEndpointAuthMethodsSupported      []string `json:"token_endpoint_auth_methods_supported"`
 	RevocationEndpointAuthMethodsSupported []string `json:"revocation_endpoint_auth_methods_supported"`
 	ScopesSupported                        []string `json:"scopes_supported"`
+	// Per RFC 8414 §2 — pointer to human-readable docs for e2a's OAuth
+	// surface (scope semantics, agent-pinning, slug conventions, etc.).
+	// Optional in the RFC but useful for client devs probing discovery.
+	ServiceDocumentation string `json:"service_documentation,omitempty"`
 }
 
 // handleOAuthDiscovery serves the RFC 8414 authorization-server metadata
@@ -71,6 +75,7 @@ func (a *API) handleOAuthDiscovery(w http.ResponseWriter, r *http.Request) {
 		TokenEndpointAuthMethodsSupported:      []string{"none"},
 		RevocationEndpointAuthMethodsSupported: []string{"none"},
 		ScopesSupported:                        []string{"e2a"},
+		ServiceDocumentation:                   "https://e2a.dev/docs/oauth",
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "public, max-age=3600")
@@ -199,7 +204,14 @@ func dcrSourceIP(r *http.Request) string {
 	if ip := strings.TrimSpace(r.Header.Get("CF-Connecting-IP")); ip != "" {
 		return ip
 	}
-	host, _, _ := net.SplitHostPort(r.RemoteAddr)
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		// RemoteAddr lacks the expected "host:port" shape (unix socket,
+		// future transport, malformed test setup). Fall back to the raw
+		// value rather than bucket all such requests under "" — which
+		// would let any single weird peer DoS the limiter for everyone.
+		return r.RemoteAddr
+	}
 	return host
 }
 

--- a/internal/agent/oauth_handlers.go
+++ b/internal/agent/oauth_handlers.go
@@ -1,0 +1,60 @@
+package agent
+
+import (
+	"net/http"
+	"strings"
+)
+
+// OAuthAuthorizationServerMetadata is the RFC 8414 response shape for
+// GET /.well-known/oauth-authorization-server. Field names use snake_case
+// per the RFC. Only fields the e2a server actually advertises are listed
+// — omitting an OPTIONAL field (e.g. introspection_endpoint, jwks_uri) is
+// itself a signal to clients that the feature isn't supported.
+type OAuthAuthorizationServerMetadata struct {
+	Issuer                            string   `json:"issuer"`
+	AuthorizationEndpoint             string   `json:"authorization_endpoint"`
+	TokenEndpoint                     string   `json:"token_endpoint"`
+	RegistrationEndpoint              string   `json:"registration_endpoint"`
+	RevocationEndpoint                string   `json:"revocation_endpoint"`
+	ResponseTypesSupported            []string `json:"response_types_supported"`
+	GrantTypesSupported               []string `json:"grant_types_supported"`
+	CodeChallengeMethodsSupported     []string `json:"code_challenge_methods_supported"`
+	TokenEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported"`
+	ScopesSupported                   []string `json:"scopes_supported"`
+}
+
+// handleOAuthDiscovery serves the RFC 8414 authorization-server metadata
+// document so MCP clients (and any other OAuth 2.1 client) can locate the
+// authorize/token/register/revoke endpoints from a single well-known URL.
+//
+// Unauthenticated by design — RFC 8414 §3 requires the document be
+// publicly retrievable. Cache for 1h: values are stable for the lifetime
+// of a deployment.
+//
+// 404 when OAuth isn't configured on this deployment (no oauthStore wired
+// in via SetOAuthStore) or when http.public_url isn't set, since the
+// metadata MUST contain absolute URLs and we'd rather hide the endpoint
+// than emit values derived from request headers (X-Forwarded-Host
+// spoofing → issuer confusion).
+func (a *API) handleOAuthDiscovery(w http.ResponseWriter, r *http.Request) {
+	if a.oauthStore == nil || a.publicURL == "" {
+		http.NotFound(w, r)
+		return
+	}
+	base := strings.TrimRight(a.publicURL, "/")
+	meta := OAuthAuthorizationServerMetadata{
+		Issuer:                            base,
+		AuthorizationEndpoint:             base + "/api/oauth/authorize",
+		TokenEndpoint:                     base + "/api/oauth/token",
+		RegistrationEndpoint:              base + "/api/oauth/register",
+		RevocationEndpoint:                base + "/api/oauth/revoke",
+		ResponseTypesSupported:            []string{"code"},
+		GrantTypesSupported:               []string{"authorization_code", "refresh_token"},
+		CodeChallengeMethodsSupported:     []string{"S256"},
+		TokenEndpointAuthMethodsSupported: []string{"none", "client_secret_basic"},
+		ScopesSupported:                   []string{"e2a"},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	writeJSON(w, meta)
+}

--- a/internal/agent/oauth_handlers.go
+++ b/internal/agent/oauth_handlers.go
@@ -1,8 +1,13 @@
 package agent
 
 import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"time"
 
@@ -282,4 +287,388 @@ func (a *API) handleOAuthRegister(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(http.StatusCreated)
 	writeJSON(w, resp)
+}
+
+// ───────────────────────── Authorize + Consent (RFC 6749 §4.1) ─────────────────────────
+
+// oauthAuthorizeParams is the parsed + validated form of an
+// authorization request. The same struct is used for both GET /authorize
+// (params in query string) and the re-passed hidden form values in
+// POST /consent — re-parsing on POST defends against client_id / scope
+// tampering between the two requests.
+type oauthAuthorizeParams struct {
+	ResponseType        string
+	ClientID            string
+	RedirectURI         string
+	CodeChallenge       string
+	CodeChallengeMethod string
+	Scope               string
+	State               string
+}
+
+// pkceChallengePattern enforces the RFC 7636 §4.2 char set: unreserved
+// (ALPHA / DIGIT / "-" / "." / "_" / "~"). Length 43–128 since the
+// S256 method always produces a 43-char base64url-encoded SHA-256
+// digest, but RFC allows up to 128 to leave room for future methods.
+var pkceChallengePattern = regexp.MustCompile(`^[A-Za-z0-9._~-]{43,128}$`)
+
+// parseAuthorizeParams pulls the OAuth params from r.Form (which works
+// for both query strings on GET and form bodies on POST after
+// ParseForm). Returns *oauthAuthorizeParams + nil on success.
+func parseAuthorizeParams(values url.Values) *oauthAuthorizeParams {
+	return &oauthAuthorizeParams{
+		ResponseType:        strings.TrimSpace(values.Get("response_type")),
+		ClientID:            strings.TrimSpace(values.Get("client_id")),
+		RedirectURI:         strings.TrimSpace(values.Get("redirect_uri")),
+		CodeChallenge:       strings.TrimSpace(values.Get("code_challenge")),
+		CodeChallengeMethod: strings.TrimSpace(values.Get("code_challenge_method")),
+		Scope:               strings.TrimSpace(values.Get("scope")),
+		State:               values.Get("state"),
+	}
+}
+
+// validateAuthorizeParamsShape checks the params we can validate without
+// hitting the DB. Used before the redirect_uri is known to be safe.
+// Returns a descriptive error suitable for a 400 response — RFC 6749
+// §4.1.2.1 requires we *not* redirect to an unverified URI, so these
+// must surface as direct HTTP errors, not as redirect-with-error.
+func validateAuthorizeParamsShape(p *oauthAuthorizeParams) error {
+	if p.ClientID == "" {
+		return errors.New("client_id is required")
+	}
+	if p.RedirectURI == "" {
+		return errors.New("redirect_uri is required")
+	}
+	if err := validateRedirectURI(p.RedirectURI); err != nil {
+		return err
+	}
+	return nil
+}
+
+// validateAuthorizeParamsLogical checks params that, if invalid, are
+// safe to surface via redirect-with-error (because the redirect_uri
+// already verified-good). Per RFC 6749 §4.1.2.1.
+func validateAuthorizeParamsLogical(p *oauthAuthorizeParams) (errCode, errDesc string) {
+	if p.ResponseType != "code" {
+		return "unsupported_response_type", "response_type must be 'code'"
+	}
+	if p.CodeChallenge == "" {
+		return "invalid_request", "code_challenge is required (PKCE mandatory)"
+	}
+	if !pkceChallengePattern.MatchString(p.CodeChallenge) {
+		return "invalid_request", "code_challenge format invalid (must be unreserved-chars, 43–128)"
+	}
+	if p.CodeChallengeMethod != "" && p.CodeChallengeMethod != "S256" {
+		return "invalid_request", "code_challenge_method must be 'S256'"
+	}
+	// Scope: only "e2a" supported. Empty defaults to "e2a".
+	if p.Scope != "" && p.Scope != "e2a" {
+		return "invalid_scope", `only scope "e2a" is supported`
+	}
+	return "", ""
+}
+
+// redirectWithOAuthError 302s the user-agent back to redirect_uri with
+// an error code in the query, per RFC 6749 §4.1.2.1. Use this only when
+// redirect_uri has been validated against the registered client.
+func redirectWithOAuthError(w http.ResponseWriter, r *http.Request, redirectURI, errCode, state string) {
+	u, err := url.Parse(redirectURI)
+	if err != nil {
+		// Should be unreachable — caller has already validated.
+		http.Error(w, "invalid redirect_uri", http.StatusBadRequest)
+		return
+	}
+	q := u.Query()
+	q.Set("error", errCode)
+	if state != "" {
+		q.Set("state", state)
+	}
+	u.RawQuery = q.Encode()
+	http.Redirect(w, r, u.String(), http.StatusFound)
+}
+
+// redirectMatchesRegistered does an exact-string match per OAuth 2.1
+// guidance. No prefix matching, no scheme-only matching — every
+// registered URI is enumerated explicitly.
+func redirectMatchesRegistered(want string, registered []string) bool {
+	for _, r := range registered {
+		if r == want {
+			return true
+		}
+	}
+	return false
+}
+
+// handleOAuthAuthorize is the authorization endpoint (RFC 6749 §4.1.1).
+//
+// Flow:
+//  1. Parse + shape-validate query params. If client_id / redirect_uri
+//     are bad → direct 400 (cannot safely redirect).
+//  2. Load client and verify redirect_uri is in its registered set.
+//     If not → direct 400.
+//  3. Logically validate remaining params. If any fails → redirect to
+//     the now-known-safe redirect_uri with error=… &state=… (§4.1.2.1).
+//  4. Check session cookie. If absent → 302 to /api/auth/login so the
+//     user signs in with Google. (Return-to-authorize after login lands
+//     in v0.3 PR B; for now the user re-launches the MCP flow.)
+//  5. If session present → 302 to {publicURL}/oauth/consent with the
+//     authorize params encoded as query string. The web app renders
+//     the consent UI and POSTs back to /api/oauth/consent.
+func (a *API) handleOAuthAuthorize(w http.ResponseWriter, r *http.Request) {
+	if a.oauthStore == nil {
+		http.NotFound(w, r)
+		return
+	}
+	if a.publicURL == "" {
+		writeOAuthError(w, http.StatusServiceUnavailable, "server_error", "OAuth flow not configured: http.public_url is unset")
+		return
+	}
+
+	if err := r.ParseForm(); err != nil {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_request", "could not parse query string")
+		return
+	}
+	p := parseAuthorizeParams(r.Form)
+
+	if err := validateAuthorizeParamsShape(p); err != nil {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	client, err := a.oauthStore.GetClient(r.Context(), p.ClientID)
+	if err != nil {
+		// Per RFC: client_id mismatch is a direct error, not a redirect.
+		writeOAuthError(w, http.StatusBadRequest, "invalid_request", "unknown client_id")
+		return
+	}
+	if !redirectMatchesRegistered(p.RedirectURI, client.RedirectURIs) {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_request", "redirect_uri does not match any registered URI")
+		return
+	}
+
+	if errCode, errDesc := validateAuthorizeParamsLogical(p); errCode != "" {
+		_ = errDesc // logged via the OAuth error code; description is descriptive only
+		redirectWithOAuthError(w, r, p.RedirectURI, errCode, p.State)
+		return
+	}
+
+	// Session check. Without userAuth wired we can't authenticate the
+	// browser — fail closed.
+	if a.userAuth == nil {
+		writeOAuthError(w, http.StatusServiceUnavailable, "server_error", "user auth not configured on this deployment")
+		return
+	}
+	if user := a.userAuth.AuthenticateRequest(r); user == nil {
+		// PR B will add return_to here. For now: kick to login so the
+		// user at least lands on a working sign-in page.
+		http.Redirect(w, r, strings.TrimRight(a.publicURL, "/")+"/api/auth/login", http.StatusFound)
+		return
+	}
+
+	// 302 to consent UI (web/), passing all params through. The consent
+	// page itself reads /api/auth/me + /api/dashboard/agents to populate
+	// the agent dropdown and pre-fill the suggested slug.
+	consentURL, _ := url.Parse(strings.TrimRight(a.publicURL, "/") + "/oauth/consent")
+	q := consentURL.Query()
+	q.Set("response_type", p.ResponseType)
+	q.Set("client_id", p.ClientID)
+	q.Set("redirect_uri", p.RedirectURI)
+	q.Set("code_challenge", p.CodeChallenge)
+	q.Set("code_challenge_method", "S256")
+	q.Set("scope", "e2a")
+	if p.State != "" {
+		q.Set("state", p.State)
+	}
+	consentURL.RawQuery = q.Encode()
+	http.Redirect(w, r, consentURL.String(), http.StatusFound)
+}
+
+// generateSlugSuffix returns a 6-hex-char nanoid-style suffix used to
+// disambiguate auto-generated agent slugs (e.g. "claude-code-a1b2c3").
+// 24 bits is plenty given the slug uniqueness constraint is per shared
+// domain and collisions only need to be statistically negligible during
+// a single retry window.
+func generateSlugSuffix() string {
+	b := make([]byte, 3)
+	if _, err := rand.Read(b); err != nil {
+		panic(fmt.Sprintf("oauth: crypto/rand failed: %v", err))
+	}
+	return hex.EncodeToString(b)
+}
+
+// slugifyClientName lowercases and sanitizes a client name into a
+// slug-safe prefix. Falls back to "agent" when the name produces an
+// empty slug (all punctuation / non-ASCII).
+func slugifyClientName(name string) string {
+	var b strings.Builder
+	prevHyphen := false
+	for _, r := range strings.ToLower(name) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			prevHyphen = false
+		default:
+			// Collapse any non-alnum into single hyphen; skip leading hyphens
+			if b.Len() > 0 && !prevHyphen {
+				b.WriteRune('-')
+				prevHyphen = true
+			}
+		}
+	}
+	out := strings.TrimRight(b.String(), "-")
+	if out == "" {
+		out = "agent"
+	}
+	// Cap the prefix so the final "{prefix}-{6hex}" stays under the
+	// 40-char slug limit (slug rule: 2–40 chars). 30 + 1 + 6 = 37.
+	if len(out) > 30 {
+		out = strings.TrimRight(out[:30], "-")
+	}
+	return out
+}
+
+// generateDefaultAgentSlug returns "{slug(client_name)}-{6hex}" — the
+// pre-populated default we'd suggest if the user clicks "Create new
+// inbox" without typing anything. Users can override entirely.
+func generateDefaultAgentSlug(clientName string) string {
+	return slugifyClientName(clientName) + "-" + generateSlugSuffix()
+}
+
+// handleOAuthConsent processes the consent form (RFC 6749 §4.1.2). The
+// form is POSTed by the web consent UI; we re-validate the OAuth params
+// (anti-tamper), check the user's session, then either redirect with
+// an authorization code (action=allow) or with error=access_denied
+// (action=deny).
+//
+// On allow + agent_choice=create_new the agent is created in the same
+// request so the issued code can already carry a valid agent_email —
+// downstream tool calls don't need to handle "code valid but agent
+// missing" as a separate case.
+func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
+	if a.oauthStore == nil {
+		http.NotFound(w, r)
+		return
+	}
+	if a.userAuth == nil {
+		writeOAuthError(w, http.StatusServiceUnavailable, "server_error", "user auth not configured on this deployment")
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_request", "could not parse form body")
+		return
+	}
+	p := parseAuthorizeParams(r.Form)
+
+	// Shape + client_id + redirect_uri match. Same chain as /authorize
+	// — we don't trust the form was honestly re-passed.
+	if err := validateAuthorizeParamsShape(p); err != nil {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		return
+	}
+	client, err := a.oauthStore.GetClient(r.Context(), p.ClientID)
+	if err != nil {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_request", "unknown client_id")
+		return
+	}
+	if !redirectMatchesRegistered(p.RedirectURI, client.RedirectURIs) {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_request", "redirect_uri does not match any registered URI")
+		return
+	}
+	if errCode, errDesc := validateAuthorizeParamsLogical(p); errCode != "" {
+		_ = errDesc
+		redirectWithOAuthError(w, r, p.RedirectURI, errCode, p.State)
+		return
+	}
+
+	user := a.userAuth.AuthenticateRequest(r)
+	if user == nil {
+		writeOAuthError(w, http.StatusUnauthorized, "access_denied", "session required — log in before consenting")
+		return
+	}
+
+	action := r.PostFormValue("action")
+	if action == "deny" {
+		redirectWithOAuthError(w, r, p.RedirectURI, "access_denied", p.State)
+		return
+	}
+	if action != "allow" {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_request", "action must be 'allow' or 'deny'")
+		return
+	}
+
+	agentChoice := r.PostFormValue("agent_choice")
+	var agentEmail string
+	switch {
+	case strings.HasPrefix(agentChoice, "existing:"):
+		email := strings.TrimPrefix(agentChoice, "existing:")
+		agent, err := a.store.GetAgentByEmail(r.Context(), email)
+		if err != nil {
+			writeOAuthError(w, http.StatusBadRequest, "invalid_request", "chosen agent does not exist")
+			return
+		}
+		if agent.UserID != user.ID {
+			writeOAuthError(w, http.StatusForbidden, "access_denied", "you do not own that agent")
+			return
+		}
+		agentEmail = email
+
+	case agentChoice == "create_new":
+		if a.sharedDomain == "" {
+			writeOAuthError(w, http.StatusServiceUnavailable, "server_error", "shared-domain auto-create is not configured")
+			return
+		}
+		slug := strings.TrimSpace(r.PostFormValue("new_agent_slug"))
+		if slug == "" {
+			// Default — used when web/ submits with the placeholder
+			// unmodified. We re-resolve client.ClientName here (rather
+			// than trusting the form) so a tampered form can't poison
+			// the slug.
+			slug = generateDefaultAgentSlug(client.ClientName)
+		}
+		if err := validateSlug(slug); err != nil {
+			writeOAuthError(w, http.StatusBadRequest, "invalid_request", "invalid slug: "+err.Error())
+			return
+		}
+		agentEmail = slug + "@" + a.sharedDomain
+		// Local-mode agent (no webhook). PR B's UI will let the user
+		// switch this later.
+		if _, err := a.store.CreateAgent(r.Context(), agentEmail, a.sharedDomain, "", "", "local", user.ID); err != nil {
+			if strings.Contains(err.Error(), "duplicate") {
+				writeOAuthError(w, http.StatusConflict, "invalid_request", "that slug is already taken — pick another")
+				return
+			}
+			writeOAuthError(w, http.StatusInternalServerError, "server_error", "failed to create agent")
+			return
+		}
+
+	default:
+		writeOAuthError(w, http.StatusBadRequest, "invalid_request", "agent_choice must be 'existing:<email>' or 'create_new'")
+		return
+	}
+
+	// Mint the authorization code. AuthCodeLifetime is 60s — the client
+	// must POST /api/oauth/token immediately.
+	authCode := &oauth.AuthorizationCode{
+		Code:                oauth.NewAuthCode(),
+		ClientID:            p.ClientID,
+		UserID:              user.ID,
+		AgentEmail:          agentEmail,
+		RedirectURI:         p.RedirectURI,
+		CodeChallenge:       p.CodeChallenge,
+		CodeChallengeMethod: "S256",
+		Scope:               "e2a",
+		ExpiresAt:           time.Now().Add(oauth.AuthCodeLifetime),
+	}
+	if err := a.oauthStore.IssueCode(r.Context(), authCode); err != nil {
+		writeOAuthError(w, http.StatusInternalServerError, "server_error", "failed to issue authorization code")
+		return
+	}
+
+	redirectURL, _ := url.Parse(p.RedirectURI)
+	q := redirectURL.Query()
+	q.Set("code", authCode.Code)
+	if p.State != "" {
+		q.Set("state", p.State)
+	}
+	redirectURL.RawQuery = q.Encode()
+	http.Redirect(w, r, redirectURL.String(), http.StatusFound)
 }

--- a/internal/agent/oauth_handlers.go
+++ b/internal/agent/oauth_handlers.go
@@ -2,7 +2,11 @@ package agent
 
 import (
 	"net/http"
+	"net/url"
 	"strings"
+	"time"
+
+	"github.com/Mnexa-AI/e2a/internal/oauth"
 )
 
 // OAuthAuthorizationServerMetadata is the RFC 8414 response shape for
@@ -51,10 +55,231 @@ func (a *API) handleOAuthDiscovery(w http.ResponseWriter, r *http.Request) {
 		ResponseTypesSupported:            []string{"code"},
 		GrantTypesSupported:               []string{"authorization_code", "refresh_token"},
 		CodeChallengeMethodsSupported:     []string{"S256"},
-		TokenEndpointAuthMethodsSupported: []string{"none", "client_secret_basic"},
+		TokenEndpointAuthMethodsSupported: []string{"none"},
 		ScopesSupported:                   []string{"e2a"},
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "public, max-age=3600")
 	writeJSON(w, meta)
+}
+
+// ───────────────────────── Dynamic Client Registration (RFC 7591) ─────────────────────────
+
+// OAuthRegisterRequest is the RFC 7591 §2 client metadata POSTed to
+// /api/oauth/register. We only accept the fields v0.3 supports —
+// unknown fields are tolerated (forward-compat with RFC 7591 extensions)
+// but ignored. Public clients only: token_endpoint_auth_method must be
+// "none" or omitted.
+type OAuthRegisterRequest struct {
+	ClientName              string   `json:"client_name"`
+	RedirectURIs            []string `json:"redirect_uris"`
+	GrantTypes              []string `json:"grant_types,omitempty"`
+	ResponseTypes           []string `json:"response_types,omitempty"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method,omitempty"`
+	Scope                   string   `json:"scope,omitempty"`
+}
+
+// OAuthRegisterResponse is the RFC 7591 §3.2.1 success response. Echoes
+// back the metadata the server actually stored (after defaults applied)
+// plus the assigned client_id and issuance timestamp. No client_secret
+// is returned — v0.3 supports public clients only.
+type OAuthRegisterResponse struct {
+	ClientID                string   `json:"client_id"`
+	ClientIDIssuedAt        int64    `json:"client_id_issued_at"`
+	ClientName              string   `json:"client_name"`
+	RedirectURIs            []string `json:"redirect_uris"`
+	GrantTypes              []string `json:"grant_types"`
+	ResponseTypes           []string `json:"response_types"`
+	TokenEndpointAuthMethod string   `json:"token_endpoint_auth_method"`
+	Scope                   string   `json:"scope"`
+}
+
+// OAuthError is the RFC 7591 §3.2.2 / RFC 6749 §5.2 error response.
+// Always use this shape for OAuth-endpoint errors (rather than plain
+// http.Error) so RFC-compliant clients can parse machine-readable
+// error codes instead of free-form strings.
+type OAuthError struct {
+	Error            string `json:"error"`
+	ErrorDescription string `json:"error_description,omitempty"`
+}
+
+// writeOAuthError sends the RFC-shaped JSON error with the given status.
+func writeOAuthError(w http.ResponseWriter, status int, code, desc string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(status)
+	writeJSON(w, OAuthError{Error: code, ErrorDescription: desc})
+}
+
+// validateRedirectURI enforces our redirect_uri allow-list per RFC 8252
+// §7 (native apps) and the OAuth 2.1 draft (web). Allowed:
+//   - https://… (web apps, must have host)
+//   - http://localhost[:port]/… and http://127.0.0.1[:port]/… and
+//     http://[::1][:port]/… (loopback for desktop dev; OAuth 2.1 §10.3.3)
+//   - custom-scheme://… (native apps registering a private-use URI)
+//
+// Rejected:
+//   - http://anything-non-loopback (would expose codes in transit)
+//   - URIs with fragments (RFC 6749 §3.1.2)
+//   - URIs without scheme/authority for http(s)
+func validateRedirectURI(raw string) error {
+	if raw == "" {
+		return errOAuthInvalid("redirect_uri cannot be empty")
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return errOAuthInvalid("redirect_uri is not a valid URI")
+	}
+	if u.Fragment != "" {
+		return errOAuthInvalid("redirect_uri must not contain a fragment")
+	}
+	switch u.Scheme {
+	case "":
+		return errOAuthInvalid("redirect_uri must include a scheme")
+	case "https":
+		if u.Host == "" {
+			return errOAuthInvalid("https redirect_uri must include a host")
+		}
+		return nil
+	case "http":
+		// Only loopback is allowed for http://.
+		host := u.Hostname()
+		if host == "localhost" || host == "127.0.0.1" || host == "::1" {
+			return nil
+		}
+		return errOAuthInvalid("http redirect_uri must use a loopback host (localhost, 127.0.0.1, or ::1)")
+	default:
+		// Custom scheme (e.g. "myapp://callback"). Must have a non-empty
+		// scheme; that's all RFC 8252 §7.1 requires.
+		return nil
+	}
+}
+
+// errOAuthInvalid is a sentinel-like helper to make validation read
+// linearly; the caller maps these to HTTP 400 invalid_client_metadata.
+type oauthValidationError struct{ msg string }
+
+func (e *oauthValidationError) Error() string { return e.msg }
+
+func errOAuthInvalid(msg string) error { return &oauthValidationError{msg: msg} }
+
+// handleOAuthRegister implements RFC 7591 Dynamic Client Registration.
+// Anonymous endpoint (RFC 7591 §2 — "open registration"). Per-IP rate
+// limited because anyone on the internet can hit it.
+//
+// 404 when OAuth isn't configured (parity with discovery).
+// 429 when the per-IP limit is exceeded.
+// 400 invalid_client_metadata for bad input (RFC 7591 §3.2.2).
+// 201 on success with the full registered metadata (RFC 7591 §3.2.1).
+func (a *API) handleOAuthRegister(w http.ResponseWriter, r *http.Request) {
+	if a.oauthStore == nil {
+		http.NotFound(w, r)
+		return
+	}
+	if !a.dcrLimit.Allow(clientIP(r)) {
+		writeOAuthError(w, http.StatusTooManyRequests, "rate_limited", "too many registrations from this IP; try again later")
+		return
+	}
+
+	var req OAuthRegisterRequest
+	if err := readJSON(w, r, &req, maxRequestBytesSmall); err != nil {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_client_metadata", "request body must be JSON")
+		return
+	}
+
+	if strings.TrimSpace(req.ClientName) == "" {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_client_metadata", "client_name is required")
+		return
+	}
+	if len(req.ClientName) > 200 {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_client_metadata", "client_name must be ≤200 characters")
+		return
+	}
+	if len(req.RedirectURIs) == 0 {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_redirect_uri", "at least one redirect_uri is required")
+		return
+	}
+	if len(req.RedirectURIs) > 10 {
+		// Soft cap to keep one client from filling a row with hundreds
+		// of URIs. Real apps register 1-3.
+		writeOAuthError(w, http.StatusBadRequest, "invalid_redirect_uri", "too many redirect_uris (max 10)")
+		return
+	}
+	for _, raw := range req.RedirectURIs {
+		if err := validateRedirectURI(raw); err != nil {
+			writeOAuthError(w, http.StatusBadRequest, "invalid_redirect_uri", err.Error())
+			return
+		}
+	}
+
+	// Defaults. RFC 7591 §2 lets the server fill in unspecified
+	// metadata; we default to the only combination v0.3 supports.
+	if len(req.GrantTypes) == 0 {
+		req.GrantTypes = []string{"authorization_code", "refresh_token"}
+	}
+	if len(req.ResponseTypes) == 0 {
+		req.ResponseTypes = []string{"code"}
+	}
+	if req.TokenEndpointAuthMethod == "" {
+		req.TokenEndpointAuthMethod = "none"
+	}
+	if req.Scope == "" {
+		req.Scope = "e2a"
+	}
+
+	// Capability enforcement — reject anything outside what we actually
+	// implement, so a client gets a clear error at registration time
+	// rather than a confusing one at /token time.
+	for _, gt := range req.GrantTypes {
+		if gt != "authorization_code" && gt != "refresh_token" {
+			writeOAuthError(w, http.StatusBadRequest, "invalid_client_metadata", "unsupported grant_type: "+gt)
+			return
+		}
+	}
+	for _, rt := range req.ResponseTypes {
+		if rt != "code" {
+			writeOAuthError(w, http.StatusBadRequest, "invalid_client_metadata", "unsupported response_type: "+rt)
+			return
+		}
+	}
+	if req.TokenEndpointAuthMethod != "none" {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_client_metadata",
+			`only token_endpoint_auth_method="none" (public clients with PKCE) is supported in v0.3`)
+		return
+	}
+	if req.Scope != "e2a" {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_client_metadata", `only scope="e2a" is supported`)
+		return
+	}
+
+	client := &oauth.Client{
+		ClientID:     oauth.NewClientID(),
+		ClientName:   req.ClientName,
+		RedirectURIs: req.RedirectURIs,
+		ClientType:   "public",
+		CreatedVia:   "dcr",
+	}
+	if err := a.oauthStore.RegisterClient(r.Context(), client); err != nil {
+		writeOAuthError(w, http.StatusInternalServerError, "server_error", "failed to register client")
+		return
+	}
+	// Use the handler's wall clock for client_id_issued_at — RegisterClient
+	// doesn't read created_at back. The DB's DEFAULT now() will differ by
+	// at most milliseconds; this field is informational per RFC 7591 §3.2.1.
+	issuedAt := time.Now().Unix()
+
+	resp := OAuthRegisterResponse{
+		ClientID:                client.ClientID,
+		ClientIDIssuedAt:        issuedAt,
+		ClientName:              client.ClientName,
+		RedirectURIs:            client.RedirectURIs,
+		GrantTypes:              req.GrantTypes,
+		ResponseTypes:           req.ResponseTypes,
+		TokenEndpointAuthMethod: req.TokenEndpointAuthMethod,
+		Scope:                   req.Scope,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.WriteHeader(http.StatusCreated)
+	writeJSON(w, resp)
 }

--- a/internal/agent/oauth_integration_test.go
+++ b/internal/agent/oauth_integration_test.go
@@ -1,0 +1,180 @@
+package agent_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/agent"
+	"github.com/Mnexa-AI/e2a/internal/auth"
+	"github.com/Mnexa-AI/e2a/internal/oauth"
+)
+
+// TestOAuthFlow_FullRoundtrip chains every endpoint in this PR:
+// register → consent → token → authed call → refresh → revoke →
+// authed call fails. The point isn't to re-test what unit tests
+// already cover; it's to catch contract drift between stages — the
+// kind of regression where each endpoint passes its own tests but the
+// payload one stage produces no longer matches what the next stage
+// expects (agent_email plumbing, scope echoing, prefix changes, etc.).
+func TestOAuthFlow_FullRoundtrip(t *testing.T) {
+	f := newAuthzFixture(t)
+	ctx := context.Background()
+
+	const (
+		// Distinct from the fixture's preregistered redirect_uri so
+		// we know we're using the DCR-issued client, not the fixture's.
+		integRedirectURI = "https://client.example.com/integration-cb"
+	)
+
+	// ── stage 1: DCR ───────────────────────────────────────────────
+	dcrResp := postJSON(t, f.server, "/api/oauth/register", agent.OAuthRegisterRequest{
+		ClientName:   "Integration Test Client",
+		RedirectURIs: []string{integRedirectURI},
+	})
+	if dcrResp.StatusCode != http.StatusCreated {
+		t.Fatalf("DCR failed: %d", dcrResp.StatusCode)
+	}
+	var registered agent.OAuthRegisterResponse
+	if err := json.NewDecoder(dcrResp.Body).Decode(&registered); err != nil {
+		t.Fatal(err)
+	}
+	dcrResp.Body.Close()
+
+	// ── stage 2: consent (allow + create_new) ──────────────────────
+	pkceVerifier := pkceVerifierKnown
+	pkceChallenge := pkceChallengeFor(pkceVerifier)
+
+	consentForm := url.Values{}
+	consentForm.Set("action", "allow")
+	consentForm.Set("agent_choice", "create_new")
+	consentForm.Set("new_agent_slug", "integ-flow-bot")
+	consentForm.Set("response_type", "code")
+	consentForm.Set("client_id", registered.ClientID)
+	consentForm.Set("redirect_uri", integRedirectURI)
+	consentForm.Set("code_challenge", pkceChallenge)
+	consentForm.Set("code_challenge_method", "S256")
+	consentForm.Set("scope", "e2a")
+	consentForm.Set("state", "integ-state")
+
+	consentResp := doPOSTForm(t, f.server.URL+"/api/oauth/consent", f.sessionToken, consentForm)
+	if consentResp.StatusCode != http.StatusFound {
+		t.Fatalf("consent should redirect with code: got %d", consentResp.StatusCode)
+	}
+	consentLoc := parseLocation(t, consentResp)
+	consentResp.Body.Close()
+	if !strings.HasPrefix(consentLoc.String(), integRedirectURI) {
+		t.Fatalf("consent must redirect to client redirect_uri: got %q", consentLoc.String())
+	}
+	authCodeStr := consentLoc.Query().Get("code")
+	if !strings.HasPrefix(authCodeStr, oauth.AuthCodePrefix) {
+		t.Fatalf("expected oace_-prefixed code in redirect: got %q", authCodeStr)
+	}
+	if consentLoc.Query().Get("state") != "integ-state" {
+		t.Errorf("state should round-trip through consent: got %q", consentLoc.Query().Get("state"))
+	}
+
+	// Sanity: the agent was actually created on the shared domain
+	// (this confirms M1's tx commit, not just the code insert).
+	agentEmail := "integ-flow-bot@agents.e2a.dev"
+	gotAgent, err := f.identStore.GetAgentByEmail(ctx, agentEmail)
+	if err != nil {
+		t.Fatalf("consent should have created the agent atomically with the code: %v", err)
+	}
+	if gotAgent.UserID != f.user.ID {
+		t.Errorf("created agent owner: want %q, got %q", f.user.ID, gotAgent.UserID)
+	}
+
+	// ── stage 3: token exchange ────────────────────────────────────
+	tokForm := url.Values{}
+	tokForm.Set("grant_type", "authorization_code")
+	tokForm.Set("code", authCodeStr)
+	tokForm.Set("redirect_uri", integRedirectURI)
+	tokForm.Set("client_id", registered.ClientID)
+	tokForm.Set("code_verifier", pkceVerifier)
+
+	tokResp := postToken(t, f.server.URL, tokForm)
+	initial := decodeToken(t, tokResp)
+	tokResp.Body.Close()
+
+	// Token's agent_email should match what consent created — this is
+	// the contract drift M2 most cares about. We don't surface
+	// agent_email in the /token response (it's an internal field on
+	// oauth_tokens), so verify via store lookup.
+	storedTok, err := f.oauthStore.LookupTokenByAccess(ctx, initial.AccessToken)
+	if err != nil {
+		t.Fatalf("LookupTokenByAccess: %v", err)
+	}
+	if storedTok.AgentEmail != agentEmail {
+		t.Errorf("agent_email contract drift between code and token: code=%q token=%q", agentEmail, storedTok.AgentEmail)
+	}
+
+	// ── stage 4: authed call with bearer ───────────────────────────
+	if status := getAgentsWithBearer(t, f.server.URL, initial.AccessToken); status != http.StatusOK {
+		t.Fatalf("bearer call with fresh access_token should 200: got %d", status)
+	}
+
+	// ── stage 5: refresh rotation ──────────────────────────────────
+	refForm := url.Values{}
+	refForm.Set("grant_type", "refresh_token")
+	refForm.Set("refresh_token", initial.RefreshToken)
+	refForm.Set("client_id", registered.ClientID)
+	refResp := postToken(t, f.server.URL, refForm)
+	rotated := decodeToken(t, refResp)
+	refResp.Body.Close()
+	if rotated.AccessToken == initial.AccessToken {
+		t.Error("refresh must rotate the access token")
+	}
+	if rotated.RefreshToken == initial.RefreshToken {
+		t.Error("refresh must rotate the refresh token (single-use)")
+	}
+	// Rotated tokens still authenticate.
+	if status := getAgentsWithBearer(t, f.server.URL, rotated.AccessToken); status != http.StatusOK {
+		t.Fatalf("bearer call with rotated access_token should 200: got %d", status)
+	}
+
+	// ── stage 6: revoke (refresh — should burn the whole chain) ────
+	revForm := url.Values{}
+	revForm.Set("token", rotated.RefreshToken)
+	revForm.Set("client_id", registered.ClientID)
+	revForm.Set("token_type_hint", "refresh_token")
+	revResp := postRevoke(t, f.server.URL, revForm)
+	if revResp.StatusCode != http.StatusOK {
+		t.Fatalf("revoke should 200: got %d", revResp.StatusCode)
+	}
+	revResp.Body.Close()
+
+	// ── stage 7: authed call now 401 (both chain members revoked) ──
+	if status := getAgentsWithBearer(t, f.server.URL, initial.AccessToken); status != http.StatusUnauthorized {
+		t.Errorf("original access token must be 401 after chain revoke: got %d", status)
+	}
+	if status := getAgentsWithBearer(t, f.server.URL, rotated.AccessToken); status != http.StatusUnauthorized {
+		t.Errorf("rotated access token must be 401 after chain revoke: got %d", status)
+	}
+}
+
+// getAgentsWithBearer is a thin wrapper that hits /api/v1/agents with
+// a Bearer token (no body, simplest authed endpoint). Returns only the
+// status — callers don't care about the response shape, just the
+// auth outcome.
+func getAgentsWithBearer(t *testing.T, serverURL, bearer string) int {
+	t.Helper()
+	req, err := http.NewRequest("GET", serverURL+"/api/v1/agents", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode
+}
+
+// (auth import is used implicitly via session token cookie name in
+// helpers from other test files; keep it referenced.)
+var _ = auth.SessionCookieName

--- a/internal/agent/oauth_register_test.go
+++ b/internal/agent/oauth_register_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -297,3 +298,32 @@ func assertOAuthError(t *testing.T, resp *http.Response, wantStatus int, wantCod
 // the test file is otherwise context-free and we don't want to pull in
 // context.Background() at every callsite.
 func testCtx() context.Context { return context.Background() }
+
+// TestOAuthRegister_RateLimited asserts the per-IP cap kicks in. The
+// httptest server uses 127.0.0.1 for every request, so all calls share
+// the same rate-limit bucket — 10 succeed, the 11th 429s. Guard against
+// a regression that disables the limiter or silently drops the IP key.
+func TestOAuthRegister_RateLimited(t *testing.T) {
+	server, _ := newDCRServer(t)
+
+	good := func(i int) agent.OAuthRegisterRequest {
+		return agent.OAuthRegisterRequest{
+			ClientName:   fmt.Sprintf("ratelimit-client-%d", i),
+			RedirectURIs: []string{"https://example.com/callback"},
+		}
+	}
+
+	// First 10 should succeed (the configured cap).
+	for i := 0; i < 10; i++ {
+		resp := postJSON(t, server, "/api/oauth/register", good(i))
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("request %d should have succeeded under the cap: got %d: %s", i+1, resp.StatusCode, string(body))
+		}
+	}
+	// 11th must 429.
+	resp := postJSON(t, server, "/api/oauth/register", good(11))
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusTooManyRequests, "rate_limited")
+}

--- a/internal/agent/oauth_register_test.go
+++ b/internal/agent/oauth_register_test.go
@@ -299,6 +299,138 @@ func assertOAuthError(t *testing.T, resp *http.Response, wantStatus int, wantCod
 // context.Background() at every callsite.
 func testCtx() context.Context { return context.Background() }
 
+// TestOAuthRegister_RejectsUserinfoInRedirect guards L8: rejects URIs
+// with embedded userinfo (e.g. "https://anything@evil.com/cb"). The
+// authority section is attacker-controlled in those — the URI looks
+// legit to a human reviewer of client metadata.
+func TestOAuthRegister_RejectsUserinfoInRedirect(t *testing.T) {
+	server, _ := newDCRServer(t)
+	resp := postJSON(t, server, "/api/oauth/register", agent.OAuthRegisterRequest{
+		ClientName:   "userinfo-rejection",
+		RedirectURIs: []string{"https://anything@evil.com/cb"},
+	})
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_redirect_uri")
+}
+
+// TestOAuthRegister_DedupesRedirectURIs guards M5 — submitting the
+// same URI twice stores it once. Otherwise a hostile DCR caller can
+// fill the 10-URI cap with one effective URL.
+func TestOAuthRegister_DedupesRedirectURIs(t *testing.T) {
+	server, oauthStore := newDCRServer(t)
+	resp := postJSON(t, server, "/api/oauth/register", agent.OAuthRegisterRequest{
+		ClientName: "dup",
+		RedirectURIs: []string{
+			"https://example.com/cb",
+			"https://example.com/cb",
+			"https://example.com/cb",
+		},
+	})
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("dedup should not reject: got %d", resp.StatusCode)
+	}
+	var got agent.OAuthRegisterResponse
+	_ = json.NewDecoder(resp.Body).Decode(&got)
+	resp.Body.Close()
+	if len(got.RedirectURIs) != 1 {
+		t.Errorf("response should reflect deduped list: got %d entries", len(got.RedirectURIs))
+	}
+	row, err := oauthStore.GetClient(testCtx(), got.ClientID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(row.RedirectURIs) != 1 {
+		t.Errorf("stored row should have 1 URI, got %d", len(row.RedirectURIs))
+	}
+}
+
+// postJSONWithHeaders is postJSON + a header bag, so M4 tests can set
+// X-Forwarded-For or CF-Connecting-IP per request.
+func postJSONWithHeaders(t *testing.T, server *httptest.Server, path string, body any, headers map[string]string) *http.Response {
+	t.Helper()
+	buf, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest("POST", server.URL+path, bytes.NewReader(buf))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+// TestOAuthRegister_XFFCannotBypassRateLimit guards M4: an attacker
+// rotating X-Forwarded-For must NOT defeat dcrLimit. We send 11 DCR
+// requests, each with a different XFF value, all from the same
+// RemoteAddr (the httptest loopback). With the old clientIP() helper
+// the 11th would have succeeded (each XFF was a "different IP"); with
+// dcrSourceIP() the 11th must 429 because RemoteAddr is the shared
+// bucket key.
+func TestOAuthRegister_XFFCannotBypassRateLimit(t *testing.T) {
+	server, _ := newDCRServer(t)
+	good := func(i int) agent.OAuthRegisterRequest {
+		return agent.OAuthRegisterRequest{
+			ClientName:   fmt.Sprintf("xff-bypass-%d", i),
+			RedirectURIs: []string{"https://example.com/callback"},
+		}
+	}
+	for i := 0; i < 10; i++ {
+		resp := postJSONWithHeaders(t, server, "/api/oauth/register", good(i), map[string]string{
+			"X-Forwarded-For": fmt.Sprintf("198.51.100.%d", i+1),
+		})
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("burn-in request %d: want 201, got %d", i+1, resp.StatusCode)
+		}
+	}
+	resp := postJSONWithHeaders(t, server, "/api/oauth/register", good(11), map[string]string{
+		"X-Forwarded-For": "203.0.113.99",
+	})
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusTooManyRequests, "rate_limited")
+}
+
+// TestOAuthRegister_CFConnectingIPGivesSeparateBuckets confirms the
+// flipside: legit Cloudflare-fronted traffic with different real
+// client IPs DOES get separate buckets, so we don't accidentally
+// punish all users behind one upstream proxy.
+func TestOAuthRegister_CFConnectingIPGivesSeparateBuckets(t *testing.T) {
+	server, _ := newDCRServer(t)
+	good := func(i int) agent.OAuthRegisterRequest {
+		return agent.OAuthRegisterRequest{
+			ClientName:   fmt.Sprintf("cf-ip-%d", i),
+			RedirectURIs: []string{"https://example.com/callback"},
+		}
+	}
+	// 10 requests as IP A, then 10 requests as IP B — all should pass.
+	for i := 0; i < 10; i++ {
+		resp := postJSONWithHeaders(t, server, "/api/oauth/register", good(i), map[string]string{
+			"CF-Connecting-IP": "203.0.113.10",
+		})
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("ip-A request %d: want 201, got %d", i+1, resp.StatusCode)
+		}
+	}
+	for i := 10; i < 20; i++ {
+		resp := postJSONWithHeaders(t, server, "/api/oauth/register", good(i), map[string]string{
+			"CF-Connecting-IP": "203.0.113.20",
+		})
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("ip-B request %d (should be separate bucket): want 201, got %d", i+1, resp.StatusCode)
+		}
+	}
+}
+
 // TestOAuthRegister_RateLimited asserts the per-IP cap kicks in. The
 // httptest server uses 127.0.0.1 for every request, so all calls share
 // the same rate-limit bucket — 10 succeed, the 11th 429s. Guard against

--- a/internal/agent/oauth_register_test.go
+++ b/internal/agent/oauth_register_test.go
@@ -1,0 +1,299 @@
+package agent_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/agent"
+	"github.com/Mnexa-AI/e2a/internal/config"
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/oauth"
+	"github.com/Mnexa-AI/e2a/internal/outbound"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+	"github.com/Mnexa-AI/e2a/internal/usage"
+	"github.com/gorilla/mux"
+)
+
+// newDCRServer is a copy of newDiscoveryServer's setup tuned for DCR
+// tests — we return both the server and the oauth store so tests can
+// verify the row landed in the DB (not just the HTTP response shape).
+func newDCRServer(t *testing.T) (*httptest.Server, *oauth.Store) {
+	t.Helper()
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	smtpRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{})
+	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
+	oauthStore := oauth.NewStore(pool)
+	api := agent.NewAPI(store, sender, smtpRelay, nil, usage.NewNoopUsageTracker(), "e2a.dev", "test.e2a.dev", "agents.e2a.dev", "https://e2a.dev", false)
+	api.SetOAuthStore(oauthStore)
+	router := mux.NewRouter()
+	api.RegisterRoutes(router)
+	server := httptest.NewServer(router)
+	t.Cleanup(server.Close)
+	return server, oauthStore
+}
+
+// postJSON sends a JSON body to the given path. Returns the response so
+// the caller can assert on status + body shape.
+func postJSON(t *testing.T, server *httptest.Server, path string, body any) *http.Response {
+	t.Helper()
+	buf, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.Post(server.URL+path, "application/json", bytes.NewReader(buf))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+func TestOAuthRegister_Success_DefaultsApplied(t *testing.T) {
+	server, oauthStore := newDCRServer(t)
+
+	resp := postJSON(t, server, "/api/oauth/register", agent.OAuthRegisterRequest{
+		ClientName:   "Test Client",
+		RedirectURIs: []string{"https://example.com/callback"},
+		// grant_types / response_types / token_endpoint_auth_method /
+		// scope intentionally omitted — defaults should fill them in.
+	})
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("want 201, got %d", resp.StatusCode)
+	}
+	if cc := resp.Header.Get("Cache-Control"); !strings.Contains(cc, "no-store") {
+		t.Errorf("DCR responses should be no-store; got %q", cc)
+	}
+
+	var got agent.OAuthRegisterResponse
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.HasPrefix(got.ClientID, oauth.ClientIDPrefix) {
+		t.Errorf("client_id should have %q prefix: got %q", oauth.ClientIDPrefix, got.ClientID)
+	}
+	if got.ClientIDIssuedAt == 0 {
+		t.Error("client_id_issued_at must be a non-zero unix timestamp")
+	}
+	if got.ClientName != "Test Client" {
+		t.Errorf("client_name echo: want %q, got %q", "Test Client", got.ClientName)
+	}
+	if len(got.RedirectURIs) != 1 || got.RedirectURIs[0] != "https://example.com/callback" {
+		t.Errorf("redirect_uris echo wrong: got %v", got.RedirectURIs)
+	}
+
+	// Defaults applied:
+	wantGrants := []string{"authorization_code", "refresh_token"}
+	if !equalStringSlice(got.GrantTypes, wantGrants) {
+		t.Errorf("grant_types default: want %v, got %v", wantGrants, got.GrantTypes)
+	}
+	if !equalStringSlice(got.ResponseTypes, []string{"code"}) {
+		t.Errorf("response_types default: want [code], got %v", got.ResponseTypes)
+	}
+	if got.TokenEndpointAuthMethod != "none" {
+		t.Errorf("token_endpoint_auth_method default: want none, got %q", got.TokenEndpointAuthMethod)
+	}
+	if got.Scope != "e2a" {
+		t.Errorf("scope default: want e2a, got %q", got.Scope)
+	}
+
+	// Verify the row actually landed in the DB.
+	row, err := oauthStore.GetClient(testCtx(), got.ClientID)
+	if err != nil {
+		t.Fatalf("GetClient: %v", err)
+	}
+	if row.ClientType != "public" {
+		t.Errorf("DB row should be public client: got %q", row.ClientType)
+	}
+	if row.CreatedVia != "dcr" {
+		t.Errorf("DB row created_via: want dcr, got %q", row.CreatedVia)
+	}
+	if row.ClientSecretHash != "" {
+		t.Errorf("public client must not have a secret hash: got %q", row.ClientSecretHash)
+	}
+}
+
+// TestOAuthRegister_NoOAuthStore_404 — symmetric with discovery: an
+// operator who hasn't wired OAuth gets a clean 404, not a confusing
+// 500 from a nil store deref.
+func TestOAuthRegister_NoOAuthStore_404(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	smtpRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{})
+	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
+	api := agent.NewAPI(store, sender, smtpRelay, nil, usage.NewNoopUsageTracker(), "e2a.dev", "test.e2a.dev", "agents.e2a.dev", "https://e2a.dev", false)
+	// no SetOAuthStore
+	router := mux.NewRouter()
+	api.RegisterRoutes(router)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	resp := postJSON(t, server, "/api/oauth/register", agent.OAuthRegisterRequest{
+		ClientName:   "x",
+		RedirectURIs: []string{"https://example.com/callback"},
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("OAuth not configured should 404: got %d", resp.StatusCode)
+	}
+}
+
+func TestOAuthRegister_MissingClientName(t *testing.T) {
+	server, _ := newDCRServer(t)
+	resp := postJSON(t, server, "/api/oauth/register", agent.OAuthRegisterRequest{
+		RedirectURIs: []string{"https://example.com/callback"},
+	})
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_client_metadata")
+}
+
+func TestOAuthRegister_MissingRedirectURIs(t *testing.T) {
+	server, _ := newDCRServer(t)
+	resp := postJSON(t, server, "/api/oauth/register", agent.OAuthRegisterRequest{
+		ClientName: "x",
+	})
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_redirect_uri")
+}
+
+// TestOAuthRegister_RedirectURI_VariousShapes table-drives the URI
+// validator so a future change is visibly safe.
+func TestOAuthRegister_RedirectURI_VariousShapes(t *testing.T) {
+	server, _ := newDCRServer(t)
+	cases := []struct {
+		name        string
+		uri         string
+		wantStatus  int
+		wantErrCode string
+	}{
+		{"https web", "https://example.com/callback", http.StatusCreated, ""},
+		{"http loopback hostname", "http://localhost:8765/cb", http.StatusCreated, ""},
+		{"http loopback ipv4", "http://127.0.0.1:8765/cb", http.StatusCreated, ""},
+		{"http loopback ipv6", "http://[::1]:8765/cb", http.StatusCreated, ""},
+		{"custom scheme native app", "myapp://oauth-callback", http.StatusCreated, ""},
+
+		{"http non-loopback rejected", "http://example.com/cb", http.StatusBadRequest, "invalid_redirect_uri"},
+		{"fragment rejected", "https://example.com/cb#frag", http.StatusBadRequest, "invalid_redirect_uri"},
+		{"missing scheme rejected", "example.com/cb", http.StatusBadRequest, "invalid_redirect_uri"},
+		{"empty string rejected", "", http.StatusBadRequest, "invalid_redirect_uri"},
+		{"https without host rejected", "https:///cb", http.StatusBadRequest, "invalid_redirect_uri"},
+	}
+	for i, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			resp := postJSON(t, server, "/api/oauth/register", agent.OAuthRegisterRequest{
+				ClientName:   fmt.Sprintf("uri-test-%d", i),
+				RedirectURIs: []string{c.uri},
+			})
+			defer resp.Body.Close()
+			if resp.StatusCode != c.wantStatus {
+				t.Fatalf("uri=%q: want status %d, got %d", c.uri, c.wantStatus, resp.StatusCode)
+			}
+			if c.wantErrCode != "" {
+				assertOAuthError(t, resp, c.wantStatus, c.wantErrCode)
+			}
+		})
+	}
+}
+
+// TestOAuthRegister_RejectsConfidential — discovery advertises only
+// "none" in token_endpoint_auth_methods_supported; this confirms DCR
+// matches that contract. If a future slice adds confidential support,
+// this test should be replaced (not deleted).
+func TestOAuthRegister_RejectsConfidential(t *testing.T) {
+	server, _ := newDCRServer(t)
+	resp := postJSON(t, server, "/api/oauth/register", agent.OAuthRegisterRequest{
+		ClientName:              "confidential client",
+		RedirectURIs:            []string{"https://example.com/cb"},
+		TokenEndpointAuthMethod: "client_secret_basic",
+	})
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_client_metadata")
+}
+
+func TestOAuthRegister_RejectsUnsupportedGrant(t *testing.T) {
+	server, _ := newDCRServer(t)
+	resp := postJSON(t, server, "/api/oauth/register", agent.OAuthRegisterRequest{
+		ClientName:   "x",
+		RedirectURIs: []string{"https://example.com/cb"},
+		GrantTypes:   []string{"client_credentials"},
+	})
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_client_metadata")
+}
+
+func TestOAuthRegister_RejectsUnsupportedResponseType(t *testing.T) {
+	server, _ := newDCRServer(t)
+	resp := postJSON(t, server, "/api/oauth/register", agent.OAuthRegisterRequest{
+		ClientName:    "x",
+		RedirectURIs:  []string{"https://example.com/cb"},
+		ResponseTypes: []string{"token"}, // implicit flow — not supported
+	})
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_client_metadata")
+}
+
+func TestOAuthRegister_RejectsUnsupportedScope(t *testing.T) {
+	server, _ := newDCRServer(t)
+	resp := postJSON(t, server, "/api/oauth/register", agent.OAuthRegisterRequest{
+		ClientName:   "x",
+		RedirectURIs: []string{"https://example.com/cb"},
+		Scope:        "admin",
+	})
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_client_metadata")
+}
+
+func TestOAuthRegister_TooManyRedirectURIs(t *testing.T) {
+	server, _ := newDCRServer(t)
+	uris := make([]string, 11)
+	for i := range uris {
+		uris[i] = fmt.Sprintf("https://example.com/cb%d", i)
+	}
+	resp := postJSON(t, server, "/api/oauth/register", agent.OAuthRegisterRequest{
+		ClientName:   "x",
+		RedirectURIs: uris,
+	})
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_redirect_uri")
+}
+
+// TestOAuthRegister_InvalidJSON guards against panics on garbage input.
+// readJSON rejects it before validation runs.
+func TestOAuthRegister_InvalidJSON(t *testing.T) {
+	server, _ := newDCRServer(t)
+	resp, err := http.Post(server.URL+"/api/oauth/register", "application/json", strings.NewReader("not json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_client_metadata")
+}
+
+// assertOAuthError decodes the RFC 7591/6749 error body and asserts on
+// status + error code. Centralized so each test reads as a one-liner.
+func assertOAuthError(t *testing.T, resp *http.Response, wantStatus int, wantCode string) {
+	t.Helper()
+	if resp.StatusCode != wantStatus {
+		t.Errorf("status: want %d, got %d", wantStatus, resp.StatusCode)
+	}
+	var e agent.OAuthError
+	if err := json.NewDecoder(resp.Body).Decode(&e); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+	if e.Error != wantCode {
+		t.Errorf("error code: want %q, got %q (description: %q)", wantCode, e.Error, e.ErrorDescription)
+	}
+}
+
+// testCtx returns a background context — kept as a tiny helper because
+// the test file is otherwise context-free and we don't want to pull in
+// context.Background() at every callsite.
+func testCtx() context.Context { return context.Background() }

--- a/internal/agent/oauth_revoke_test.go
+++ b/internal/agent/oauth_revoke_test.go
@@ -1,0 +1,220 @@
+package agent_test
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/oauth"
+)
+
+// postRevoke is a tiny convenience for the standard application/x-www-form
+// shape RFC 7009 §2 requires.
+func postRevoke(t *testing.T, server string, form url.Values) *http.Response {
+	t.Helper()
+	resp, err := http.Post(server+"/api/oauth/revoke", "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+// TestRevoke_AccessToken_Happy mints a token via auth_code grant, then
+// revokes it, then verifies the access-token row is marked revoked.
+func TestRevoke_AccessToken_Happy(t *testing.T) {
+	f := newAuthzFixture(t)
+	tr := mintInitialTokens(t, f)
+
+	form := url.Values{}
+	form.Set("token", tr.AccessToken)
+	form.Set("client_id", f.client.ClientID)
+	form.Set("token_type_hint", "access_token")
+	resp := postRevoke(t, f.server.URL, form)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+
+	got, err := f.oauthStore.LookupTokenByAccess(context.Background(), tr.AccessToken)
+	if err != nil {
+		t.Fatalf("LookupTokenByAccess: %v", err)
+	}
+	if got.RevokedAt == nil {
+		t.Error("expected access token to be revoked, but RevokedAt is nil")
+	}
+}
+
+// TestRevoke_RefreshToken_RevokesChain — refresh-token revocation
+// must cascade to all access tokens in the chain (RFC 7009 §2 SHOULD).
+func TestRevoke_RefreshToken_RevokesChain(t *testing.T) {
+	f := newAuthzFixture(t)
+	tr := mintInitialTokens(t, f)
+
+	// Rotate once so the chain has two members.
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", tr.RefreshToken)
+	form.Set("client_id", f.client.ClientID)
+	resp := postToken(t, f.server.URL, form)
+	tr2 := decodeToken(t, resp)
+	resp.Body.Close()
+
+	// Revoke the newer refresh — both rows should die.
+	form = url.Values{}
+	form.Set("token", tr2.RefreshToken)
+	form.Set("client_id", f.client.ClientID)
+	form.Set("token_type_hint", "refresh_token")
+	rresp := postRevoke(t, f.server.URL, form)
+	defer rresp.Body.Close()
+	if rresp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", rresp.StatusCode)
+	}
+
+	// Original access token (older chain member) — revoked.
+	got, err := f.oauthStore.LookupTokenByAccess(context.Background(), tr.AccessToken)
+	if err != nil {
+		t.Fatalf("LookupTokenByAccess(old): %v", err)
+	}
+	if got.RevokedAt == nil {
+		t.Error("chain revoke should kill the older chain member; old access token still active")
+	}
+	// New access token also revoked.
+	got2, err := f.oauthStore.LookupTokenByAccess(context.Background(), tr2.AccessToken)
+	if err != nil {
+		t.Fatalf("LookupTokenByAccess(new): %v", err)
+	}
+	if got2.RevokedAt == nil {
+		t.Error("chain revoke should kill the newer chain member; new access token still active")
+	}
+}
+
+// TestRevoke_HintWrong_StillWorks — hint is advisory. Sending
+// hint=refresh_token but passing an access_token must still revoke.
+func TestRevoke_HintWrong_StillWorks(t *testing.T) {
+	f := newAuthzFixture(t)
+	tr := mintInitialTokens(t, f)
+
+	form := url.Values{}
+	form.Set("token", tr.AccessToken)
+	form.Set("client_id", f.client.ClientID)
+	form.Set("token_type_hint", "refresh_token") // wrong hint
+	resp := postRevoke(t, f.server.URL, form)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200 despite wrong hint, got %d", resp.StatusCode)
+	}
+}
+
+// TestRevoke_NoHint_StillWorks — many clients omit the hint entirely.
+func TestRevoke_NoHint_StillWorks(t *testing.T) {
+	f := newAuthzFixture(t)
+	tr := mintInitialTokens(t, f)
+
+	form := url.Values{}
+	form.Set("token", tr.AccessToken)
+	form.Set("client_id", f.client.ClientID)
+	resp := postRevoke(t, f.server.URL, form)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+}
+
+// TestRevoke_UnknownToken_200 — silently 200 on unknown token per
+// RFC 7009 §2.2 (no leaking which tokens exist).
+func TestRevoke_UnknownToken_200(t *testing.T) {
+	f := newAuthzFixture(t)
+	form := url.Values{}
+	form.Set("token", "ate2a_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	form.Set("client_id", f.client.ClientID)
+	resp := postRevoke(t, f.server.URL, form)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("unknown token must 200 (no existence leak), got %d", resp.StatusCode)
+	}
+}
+
+// TestRevoke_AlreadyRevoked_200 — idempotent. Some clients call
+// revoke unconditionally on logout.
+func TestRevoke_AlreadyRevoked_200(t *testing.T) {
+	f := newAuthzFixture(t)
+	tr := mintInitialTokens(t, f)
+
+	form := url.Values{}
+	form.Set("token", tr.AccessToken)
+	form.Set("client_id", f.client.ClientID)
+
+	resp1 := postRevoke(t, f.server.URL, form)
+	resp1.Body.Close()
+	resp2 := postRevoke(t, f.server.URL, form)
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("second revoke must also 200 (idempotent), got %d", resp2.StatusCode)
+	}
+}
+
+// TestRevoke_ClientIDMismatch_400 — a different client must not be
+// able to revoke this client's tokens. invalid_client per §2.1.
+func TestRevoke_ClientIDMismatch_400(t *testing.T) {
+	f := newAuthzFixture(t)
+	tr := mintInitialTokens(t, f)
+
+	other := &oauth.Client{
+		ClientID:     oauth.NewClientID(),
+		ClientName:   "Other",
+		RedirectURIs: []string{"https://other.example.com/cb"},
+		ClientType:   "public",
+		CreatedVia:   "dcr",
+	}
+	if err := f.oauthStore.RegisterClient(context.Background(), other); err != nil {
+		t.Fatal(err)
+	}
+
+	form := url.Values{}
+	form.Set("token", tr.AccessToken)
+	form.Set("client_id", other.ClientID)
+	resp := postRevoke(t, f.server.URL, form)
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_client")
+
+	// And the token must still be active.
+	got, err := f.oauthStore.LookupTokenByAccess(context.Background(), tr.AccessToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.RevokedAt != nil {
+		t.Error("foreign-client revoke attempt must NOT touch the token")
+	}
+}
+
+func TestRevoke_MissingToken_400(t *testing.T) {
+	f := newAuthzFixture(t)
+	form := url.Values{}
+	form.Set("client_id", f.client.ClientID)
+	resp := postRevoke(t, f.server.URL, form)
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_request")
+}
+
+func TestRevoke_MissingClientID_400(t *testing.T) {
+	f := newAuthzFixture(t)
+	form := url.Values{}
+	form.Set("token", "ate2a_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+	resp := postRevoke(t, f.server.URL, form)
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_request")
+}
+
+func TestRevoke_NoOAuthStore_404(t *testing.T) {
+	server := newDiscoveryServer(t, false, "https://e2a.dev")
+	form := url.Values{}
+	form.Set("token", "ate2a_xxx")
+	form.Set("client_id", "mcp_xxx")
+	resp := postRevoke(t, server.URL, form)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("want 404 without oauth store, got %d", resp.StatusCode)
+	}
+}

--- a/internal/agent/oauth_token_test.go
+++ b/internal/agent/oauth_token_test.go
@@ -389,6 +389,41 @@ func TestToken_Refresh_ClientIDMismatch_RevokesChain(t *testing.T) {
 	}
 }
 
+// TestToken_Refresh_RotationRace simulates a lost race: two refresh
+// requests with the same token both pass lookup, then one wins the
+// rotation. The loser hits RowsAffected==0 inside RotateRefreshToken,
+// which surfaces as ErrTokenNotFound. Per M3, the handler must turn
+// that into 400 invalid_grant, not 500.
+//
+// We can't realistically race against an in-flight handler, so we
+// stage the same end state directly: mint tokens, rotate via the API
+// to NULL the old refresh, then re-attempt the original refresh.
+// LookupTokenByRefresh on a NULLed row returns ErrTokenNotFound — same
+// path the actual race takes, so the assertion (400 + invalid_grant)
+// covers both.
+func TestToken_Refresh_RotationRace(t *testing.T) {
+	f := newAuthzFixture(t)
+	tr := mintInitialTokens(t, f)
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", tr.RefreshToken)
+	form.Set("client_id", f.client.ClientID)
+
+	// Win the race.
+	winner := postToken(t, f.server.URL, form)
+	_ = decodeToken(t, winner)
+	winner.Body.Close()
+
+	// Loser replays the same refresh.
+	loser := postToken(t, f.server.URL, form)
+	defer loser.Body.Close()
+	if loser.StatusCode != http.StatusBadRequest {
+		t.Fatalf("rotation race loser must 400 (not 500): got %d", loser.StatusCode)
+	}
+	assertOAuthError(t, loser, http.StatusBadRequest, "invalid_grant")
+}
+
 func TestToken_Refresh_UnknownToken(t *testing.T) {
 	f := newAuthzFixture(t)
 	form := url.Values{}

--- a/internal/agent/oauth_token_test.go
+++ b/internal/agent/oauth_token_test.go
@@ -1,0 +1,418 @@
+package agent_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mnexa-AI/e2a/internal/agent"
+	"github.com/Mnexa-AI/e2a/internal/oauth"
+)
+
+// pkceVerifierKnown / pkceChallengeKnown is a verifier/challenge pair
+// pre-computed at test-construction time so callers can mix them with
+// stored codes without recomputing. The math:
+//
+//	verifier  = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOP123" (43 chars)
+//	challenge = base64url-nopad(sha256(verifier))
+//
+// Helper below derives the challenge — tests don't need to recompute.
+const pkceVerifierKnown = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOP1"
+
+func pkceChallengeFor(verifier string) string {
+	h := sha256.Sum256([]byte(verifier))
+	return base64.RawURLEncoding.EncodeToString(h[:])
+}
+
+// issueCodeForTest manually inserts a fresh authorization code (the
+// same row /consent would create) so token-endpoint tests don't have
+// to run the consent flow first.
+func issueCodeForTest(t *testing.T, f *authzFixture, agentEmail, challenge string) string {
+	t.Helper()
+	code := oauth.NewAuthCode()
+	if err := f.oauthStore.IssueCode(context.Background(), &oauth.AuthorizationCode{
+		Code:                code,
+		ClientID:            f.client.ClientID,
+		UserID:              f.user.ID,
+		AgentEmail:          agentEmail,
+		RedirectURI:         testRedirectURI,
+		CodeChallenge:       challenge,
+		CodeChallengeMethod: "S256",
+		Scope:               "e2a",
+		ExpiresAt:           time.Now().Add(oauth.AuthCodeLifetime),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return code
+}
+
+// postToken posts a form to /api/oauth/token. Returns the response.
+func postToken(t *testing.T, server string, form url.Values) *http.Response {
+	t.Helper()
+	resp, err := http.Post(server+"/api/oauth/token", "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+// decodeToken decodes a /token success body and asserts the basic
+// invariants every successful response must satisfy.
+func decodeToken(t *testing.T, resp *http.Response) agent.OAuthTokenResponse {
+	t.Helper()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("want 200, got %d: %s", resp.StatusCode, string(body))
+	}
+	if cc := resp.Header.Get("Cache-Control"); !strings.Contains(cc, "no-store") {
+		t.Errorf("Cache-Control must contain no-store per RFC 6749 §5.1: got %q", cc)
+	}
+	var tr agent.OAuthTokenResponse
+	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !strings.HasPrefix(tr.AccessToken, oauth.AccessTokenPrefix) {
+		t.Errorf("access_token must have %q prefix: got %q", oauth.AccessTokenPrefix, tr.AccessToken)
+	}
+	if tr.TokenType != "Bearer" {
+		t.Errorf("token_type must be Bearer: got %q", tr.TokenType)
+	}
+	if tr.ExpiresIn <= 0 {
+		t.Errorf("expires_in must be > 0: got %d", tr.ExpiresIn)
+	}
+	return tr
+}
+
+// ──────────────────────── authorization_code grant ────────────────────────
+
+func TestToken_AuthCode_Happy(t *testing.T) {
+	f := newAuthzFixture(t)
+	challenge := pkceChallengeFor(pkceVerifierKnown)
+	code := issueCodeForTest(t, f, "ag1@agents.e2a.dev", challenge)
+
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", testRedirectURI)
+	form.Set("client_id", f.client.ClientID)
+	form.Set("code_verifier", pkceVerifierKnown)
+
+	resp := postToken(t, f.server.URL, form)
+	defer resp.Body.Close()
+	tr := decodeToken(t, resp)
+
+	if !strings.HasPrefix(tr.RefreshToken, oauth.RefreshTokenPrefix) {
+		t.Errorf("refresh_token must have %q prefix: got %q", oauth.RefreshTokenPrefix, tr.RefreshToken)
+	}
+	if tr.Scope != "e2a" {
+		t.Errorf("scope echo: got %q", tr.Scope)
+	}
+}
+
+// TestToken_AuthCode_NoOAuthStore_404 — symmetry with discovery / DCR.
+func TestToken_AuthCode_NoOAuthStore_404(t *testing.T) {
+	// Build a server without an oauth store.
+	server := newDiscoveryServer(t, false, "https://e2a.dev")
+	resp := postToken(t, server.URL, url.Values{"grant_type": {"authorization_code"}})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("want 404 without oauth store, got %d", resp.StatusCode)
+	}
+}
+
+func TestToken_NoGrantType_400(t *testing.T) {
+	f := newAuthzFixture(t)
+	resp := postToken(t, f.server.URL, url.Values{})
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_request")
+}
+
+func TestToken_UnsupportedGrantType_400(t *testing.T) {
+	f := newAuthzFixture(t)
+	resp := postToken(t, f.server.URL, url.Values{"grant_type": {"client_credentials"}})
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "unsupported_grant_type")
+}
+
+func TestToken_AuthCode_MissingFields_400(t *testing.T) {
+	f := newAuthzFixture(t)
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", "oace_doesntmatter")
+	// missing redirect_uri, client_id, code_verifier
+	resp := postToken(t, f.server.URL, form)
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_request")
+}
+
+func TestToken_AuthCode_UnknownCode(t *testing.T) {
+	f := newAuthzFixture(t)
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", "oace_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	form.Set("redirect_uri", testRedirectURI)
+	form.Set("client_id", f.client.ClientID)
+	form.Set("code_verifier", pkceVerifierKnown)
+	resp := postToken(t, f.server.URL, form)
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_grant")
+}
+
+// TestToken_AuthCode_Reuse_RevokesTokens — RFC 6749 §10.5: replaying a
+// consumed code must (a) be rejected and (b) burn all tokens the
+// original code minted, since we have to assume the attacker now holds
+// them.
+func TestToken_AuthCode_Reuse_RevokesTokens(t *testing.T) {
+	f := newAuthzFixture(t)
+	challenge := pkceChallengeFor(pkceVerifierKnown)
+	code := issueCodeForTest(t, f, "ag-reuse@agents.e2a.dev", challenge)
+
+	baseForm := func() url.Values {
+		form := url.Values{}
+		form.Set("grant_type", "authorization_code")
+		form.Set("code", code)
+		form.Set("redirect_uri", testRedirectURI)
+		form.Set("client_id", f.client.ClientID)
+		form.Set("code_verifier", pkceVerifierKnown)
+		return form
+	}
+
+	// First call: fresh.
+	resp1 := postToken(t, f.server.URL, baseForm())
+	tr1 := decodeToken(t, resp1)
+	resp1.Body.Close()
+
+	// Second call: must fail.
+	resp2 := postToken(t, f.server.URL, baseForm())
+	defer resp2.Body.Close()
+	assertOAuthError(t, resp2, http.StatusBadRequest, "invalid_grant")
+
+	// The originally-issued access token must be revoked.
+	got, err := f.oauthStore.LookupTokenByAccess(context.Background(), tr1.AccessToken)
+	if err != nil {
+		t.Fatalf("LookupTokenByAccess: %v", err)
+	}
+	if got.RevokedAt == nil {
+		t.Error("reuse defense: expected the first-issued token to be revoked, but it is not")
+	}
+}
+
+func TestToken_AuthCode_PKCEMismatch(t *testing.T) {
+	f := newAuthzFixture(t)
+	challenge := pkceChallengeFor(pkceVerifierKnown)
+	code := issueCodeForTest(t, f, "ag@agents.e2a.dev", challenge)
+
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", testRedirectURI)
+	form.Set("client_id", f.client.ClientID)
+	form.Set("code_verifier", "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX") // 43 chars, wrong
+	resp := postToken(t, f.server.URL, form)
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_grant")
+}
+
+func TestToken_AuthCode_ClientIDMismatch(t *testing.T) {
+	f := newAuthzFixture(t)
+	challenge := pkceChallengeFor(pkceVerifierKnown)
+	code := issueCodeForTest(t, f, "ag@agents.e2a.dev", challenge)
+
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", testRedirectURI)
+	form.Set("client_id", "mcp_anotherclientx") // not f.client.ClientID
+	form.Set("code_verifier", pkceVerifierKnown)
+	resp := postToken(t, f.server.URL, form)
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_grant")
+}
+
+func TestToken_AuthCode_RedirectURIMismatch(t *testing.T) {
+	f := newAuthzFixture(t)
+	challenge := pkceChallengeFor(pkceVerifierKnown)
+	code := issueCodeForTest(t, f, "ag@agents.e2a.dev", challenge)
+
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", "https://attacker.example.com/cb")
+	form.Set("client_id", f.client.ClientID)
+	form.Set("code_verifier", pkceVerifierKnown)
+	resp := postToken(t, f.server.URL, form)
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_grant")
+}
+
+// TestToken_AuthCode_ExpiredCode — IssueCode lets us set expires_at
+// directly; we age it 2 minutes (past the 60s lifetime).
+func TestToken_AuthCode_ExpiredCode(t *testing.T) {
+	f := newAuthzFixture(t)
+	challenge := pkceChallengeFor(pkceVerifierKnown)
+	code := oauth.NewAuthCode()
+	if err := f.oauthStore.IssueCode(context.Background(), &oauth.AuthorizationCode{
+		Code:                code,
+		ClientID:            f.client.ClientID,
+		UserID:              f.user.ID,
+		AgentEmail:          "ag@agents.e2a.dev",
+		RedirectURI:         testRedirectURI,
+		CodeChallenge:       challenge,
+		CodeChallengeMethod: "S256",
+		Scope:               "e2a",
+		ExpiresAt:           time.Now().Add(-2 * time.Minute), // already expired
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", testRedirectURI)
+	form.Set("client_id", f.client.ClientID)
+	form.Set("code_verifier", pkceVerifierKnown)
+	resp := postToken(t, f.server.URL, form)
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_grant")
+}
+
+// ──────────────────────── refresh_token grant ────────────────────────
+
+// mintInitialTokens runs through the auth_code path to get a fresh
+// (access, refresh) pair for refresh-grant tests.
+func mintInitialTokens(t *testing.T, f *authzFixture) agent.OAuthTokenResponse {
+	t.Helper()
+	challenge := pkceChallengeFor(pkceVerifierKnown)
+	code := issueCodeForTest(t, f, "ag-refresh@agents.e2a.dev", challenge)
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", testRedirectURI)
+	form.Set("client_id", f.client.ClientID)
+	form.Set("code_verifier", pkceVerifierKnown)
+	resp := postToken(t, f.server.URL, form)
+	defer resp.Body.Close()
+	return decodeToken(t, resp)
+}
+
+func TestToken_Refresh_Happy(t *testing.T) {
+	f := newAuthzFixture(t)
+	tr := mintInitialTokens(t, f)
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", tr.RefreshToken)
+	form.Set("client_id", f.client.ClientID)
+	resp := postToken(t, f.server.URL, form)
+	defer resp.Body.Close()
+	newTr := decodeToken(t, resp)
+
+	if newTr.AccessToken == tr.AccessToken {
+		t.Error("access token should rotate")
+	}
+	if newTr.RefreshToken == tr.RefreshToken {
+		t.Error("refresh token must rotate (single-use)")
+	}
+}
+
+// TestToken_Refresh_Reuse_RevokesChain — RFC 6749 §10.4 reuse defense.
+// After a successful rotation, the old refresh is gone (NULLed). A
+// second attempt to reuse it should be rejected.
+func TestToken_Refresh_Reuse_OldFails(t *testing.T) {
+	f := newAuthzFixture(t)
+	tr := mintInitialTokens(t, f)
+
+	// Rotate once.
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", tr.RefreshToken)
+	form.Set("client_id", f.client.ClientID)
+	resp := postToken(t, f.server.URL, form)
+	_ = decodeToken(t, resp)
+	resp.Body.Close()
+
+	// Try to reuse the original refresh.
+	resp2 := postToken(t, f.server.URL, form)
+	defer resp2.Body.Close()
+	assertOAuthError(t, resp2, http.StatusBadRequest, "invalid_grant")
+}
+
+func TestToken_Refresh_ClientIDMismatch_RevokesChain(t *testing.T) {
+	f := newAuthzFixture(t)
+	tr := mintInitialTokens(t, f)
+
+	// Register a SECOND client, then try to use refresh issued under
+	// the first one. That's the "credential confusion / theft" case;
+	// the original chain should be burned.
+	other := &oauth.Client{
+		ClientID:     oauth.NewClientID(),
+		ClientName:   "Other",
+		RedirectURIs: []string{"https://elsewhere.example.com/cb"},
+		ClientType:   "public",
+		CreatedVia:   "dcr",
+	}
+	if err := f.oauthStore.RegisterClient(context.Background(), other); err != nil {
+		t.Fatal(err)
+	}
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", tr.RefreshToken)
+	form.Set("client_id", other.ClientID)
+	resp := postToken(t, f.server.URL, form)
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_grant")
+
+	// The originally-issued access token must be revoked because chain
+	// got nuked.
+	got, err := f.oauthStore.LookupTokenByAccess(context.Background(), tr.AccessToken)
+	if err != nil {
+		t.Fatalf("LookupTokenByAccess: %v", err)
+	}
+	if got.RevokedAt == nil {
+		t.Error("client_id mismatch on refresh should revoke the chain — original access token still active")
+	}
+}
+
+func TestToken_Refresh_UnknownToken(t *testing.T) {
+	f := newAuthzFixture(t)
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", "rte2a_doesnotexistxxxxxxxxxxxxxxxxxxxxxx")
+	form.Set("client_id", f.client.ClientID)
+	resp := postToken(t, f.server.URL, form)
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_grant")
+}
+
+func TestToken_Refresh_MissingFields_400(t *testing.T) {
+	f := newAuthzFixture(t)
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	// missing refresh_token + client_id
+	resp := postToken(t, f.server.URL, form)
+	defer resp.Body.Close()
+	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_request")
+}
+
+// ──────────────────────── PKCE helper sanity ────────────────────────
+
+// Smoke test for the constant — verifier+challenge round-trip cleanly.
+// If this fails, every other auth_code test fails noisily, so isolate
+// the math here for fast diagnosis.
+func TestPKCE_ChallengeDerivation_Sanity(t *testing.T) {
+	chal := pkceChallengeFor(pkceVerifierKnown)
+	if len(chal) != 43 {
+		t.Errorf("S256 challenge must be 43 chars: got %d (%q)", len(chal), chal)
+	}
+	if strings.ContainsAny(chal, "=+/") {
+		t.Errorf("base64url-nopad must not produce =, +, or /: got %q", chal)
+	}
+}

--- a/internal/agent/oauth_token_test.go
+++ b/internal/agent/oauth_token_test.go
@@ -71,8 +71,13 @@ func decodeToken(t *testing.T, resp *http.Response) agent.OAuthTokenResponse {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("want 200, got %d: %s", resp.StatusCode, string(body))
 	}
+	// RFC 6749 §5.1 requires both Cache-Control: no-store AND
+	// Pragma: no-cache so old HTTP/1.0 caches don't persist tokens.
 	if cc := resp.Header.Get("Cache-Control"); !strings.Contains(cc, "no-store") {
 		t.Errorf("Cache-Control must contain no-store per RFC 6749 §5.1: got %q", cc)
+	}
+	if pr := resp.Header.Get("Pragma"); pr != "no-cache" {
+		t.Errorf("Pragma must be no-cache per RFC 6749 §5.1: got %q", pr)
 	}
 	var tr agent.OAuthTokenResponse
 	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
@@ -84,8 +89,11 @@ func decodeToken(t *testing.T, resp *http.Response) agent.OAuthTokenResponse {
 	if tr.TokenType != "Bearer" {
 		t.Errorf("token_type must be Bearer: got %q", tr.TokenType)
 	}
-	if tr.ExpiresIn <= 0 {
-		t.Errorf("expires_in must be > 0: got %d", tr.ExpiresIn)
+	// Exact match — a future regression that changed unit (ms vs s)
+	// or introduced rounding would pass a > 0 check.
+	wantExpiresIn := int(oauth.AccessTokenLifetime / time.Second)
+	if tr.ExpiresIn != wantExpiresIn {
+		t.Errorf("expires_in must equal AccessTokenLifetime in seconds: want %d, got %d", wantExpiresIn, tr.ExpiresIn)
 	}
 	return tr
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -193,10 +193,15 @@ func validateCLICallbackURL(raw string) (*url.URL, error) {
 
 // OAuthState is encoded into the OAuth state parameter. It carries the CSRF
 // nonce and, for CLI-initiated logins, the callback URL and CLI state token.
+// For browser-initiated logins triggered mid-flow (e.g. /api/oauth/authorize
+// 302-ing through /api/auth/login), ReturnTo carries the relative path the
+// user should land on after Google completes — letting them resume the OAuth
+// flow instead of dropping onto the dashboard.
 type OAuthState struct {
 	Nonce       string `json:"n"`
 	CLICallback string `json:"cb,omitempty"`
 	CLIState    string `json:"cs,omitempty"`
+	ReturnTo    string `json:"rt,omitempty"`
 }
 
 func EncodeOAuthState(s *OAuthState) string {
@@ -252,11 +257,19 @@ func (ua *UserAuth) writeCLIHandoffPage(w http.ResponseWriter, r *http.Request, 
 }
 
 // HandleLogin redirects the user to Google OAuth.
+//
 // CLI login params (cli_callback, cli_state) are encoded into the OAuth state
-// parameter so they survive the redirect through Google without relying on cookies.
+// so they survive the redirect through Google without cookies.
+//
+// Browser logins triggered mid-OAuth (the /api/oauth/authorize handler 302s
+// here when the user has no session) pass return_to so the post-login
+// redirect resumes the original flow instead of dropping the user on the
+// dashboard. The path is restricted to /api/oauth/… on our own origin so it
+// can't be repurposed as an open redirect.
 func (ua *UserAuth) HandleLogin(w http.ResponseWriter, r *http.Request) {
 	cliCallback := r.URL.Query().Get("cli_callback")
 	cliState := r.URL.Query().Get("cli_state")
+	returnTo := r.URL.Query().Get("return_to")
 	if (cliCallback == "") != (cliState == "") {
 		http.Error(w, "cli_callback and cli_state must be provided together", http.StatusBadRequest)
 		return
@@ -274,10 +287,37 @@ func (ua *UserAuth) HandleLogin(w http.ResponseWriter, r *http.Request) {
 		state.CLICallback = callbackURL.String()
 		state.CLIState = cliState
 	}
+	if returnTo != "" {
+		safe, err := validateReturnTo(returnTo)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		state.ReturnTo = safe
+	}
 
 	ua.setCookie(w, StateCookieName, nonce, 600)
 
 	http.Redirect(w, r, ua.oauthConfig.AuthCodeURL(EncodeOAuthState(state)), http.StatusFound)
+}
+
+// validateReturnTo restricts return_to to an /api/oauth/… path on our own
+// origin (a relative path with no scheme/host, or an absolute URL whose
+// path begins with /api/oauth/). This prevents the param from being used
+// as an open redirect to attacker-controlled hosts.
+func validateReturnTo(raw string) (string, error) {
+	u, err := url.Parse(raw)
+	if err != nil {
+		return "", fmt.Errorf("return_to is not a valid URL")
+	}
+	if u.Scheme != "" || u.Host != "" {
+		// Disallow absolute URLs entirely — keeps the surface tiny.
+		return "", fmt.Errorf("return_to must be a relative path on this origin")
+	}
+	if !strings.HasPrefix(u.Path, "/api/oauth/") {
+		return "", fmt.Errorf("return_to must be an /api/oauth/ path")
+	}
+	return u.RequestURI(), nil
 }
 
 // HandleCallback processes the Google OAuth callback and creates a session.
@@ -354,6 +394,17 @@ func (ua *UserAuth) HandleCallback(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
 		return
+	}
+
+	// Mid-flow login (e.g. /api/oauth/authorize 302-ed here) — return
+	// the user to where they came from. validateReturnTo at /login time
+	// guarantees this is an /api/oauth/ path on our origin; revalidate
+	// here defensively in case the encoded state was tampered.
+	if state.ReturnTo != "" {
+		if safe, err := validateReturnTo(state.ReturnTo); err == nil {
+			http.Redirect(w, r, ua.baseURL+safe, http.StatusFound)
+			return
+		}
 	}
 
 	http.Redirect(w, r, ua.baseURL+"/dashboard", http.StatusFound)

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"golang.org/x/net/idna"
 )
@@ -366,6 +367,24 @@ func (s *Store) GetAgentByEmail(ctx context.Context, email string) (*AgentIdenti
 // CreateAgent inserts an agent with a domain FK. Does NOT check domain ownership —
 // that's the API handler's responsibility (shared domain skips the check).
 func (s *Store) CreateAgent(ctx context.Context, agentEmail, domain, name, webhookURL, agentMode, userID string) (*AgentIdentity, error) {
+	return createAgent(ctx, s.pool, agentEmail, domain, name, webhookURL, agentMode, userID)
+}
+
+// CreateAgentTx inserts an agent inside a caller-owned transaction.
+// Used by OAuth consent so agent creation and authorization-code
+// issuance commit together (or both roll back on partial failure).
+func (s *Store) CreateAgentTx(ctx context.Context, tx pgx.Tx, agentEmail, domain, name, webhookURL, agentMode, userID string) (*AgentIdentity, error) {
+	return createAgent(ctx, tx, agentEmail, domain, name, webhookURL, agentMode, userID)
+}
+
+// agentExecutor is the subset of pgxpool.Pool + pgx.Tx that createAgent
+// needs. Lets the same body serve both stand-alone and in-transaction
+// callers without duplicating the SQL.
+type agentExecutor interface {
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
+}
+
+func createAgent(ctx context.Context, exec agentExecutor, agentEmail, domain, name, webhookURL, agentMode, userID string) (*AgentIdentity, error) {
 	if agentMode == "" {
 		agentMode = "cloud"
 	}
@@ -383,7 +402,7 @@ func (s *Store) CreateAgent(ctx context.Context, agentEmail, domain, name, webho
 		HITLTTLSeconds:       HITLDefaultTTLSeconds,
 		HITLExpirationAction: HITLDefaultExpirationAct,
 	}
-	_, err := s.pool.Exec(ctx,
+	_, err := exec.Exec(ctx,
 		`INSERT INTO agent_identities (id, domain, user_id, name, webhook_url, agent_mode, public, created_at)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
 		a.ID, a.Domain, a.UserID, a.Name, a.WebhookURL, a.AgentMode, a.Public, a.CreatedAt,

--- a/internal/identity/user_data_rights.go
+++ b/internal/identity/user_data_rights.go
@@ -20,15 +20,32 @@ import (
 //     the user and is omitted on purpose.
 //   - User session tokens are transient and excluded.
 type UserExport struct {
-	GeneratedAt    time.Time            `json:"generated_at"`
-	SchemaVersion  string               `json:"schema_version"`
-	User           UserExportUser       `json:"user"`
-	Domains        []Domain             `json:"domains"`
-	Agents         []AgentIdentity      `json:"agents"`
-	APIKeys        []APIKeyExportEntry  `json:"api_keys"`
-	Messages       []Message            `json:"messages"`
-	UsageEvents    []UsageEventEntry    `json:"usage_events,omitempty"`
+	GeneratedAt      time.Time                  `json:"generated_at"`
+	SchemaVersion    string                     `json:"schema_version"`
+	User             UserExportUser             `json:"user"`
+	Domains          []Domain                   `json:"domains"`
+	Agents           []AgentIdentity            `json:"agents"`
+	APIKeys          []APIKeyExportEntry        `json:"api_keys"`
+	Messages         []Message                  `json:"messages"`
+	UsageEvents      []UsageEventEntry          `json:"usage_events,omitempty"`
+	OAuthConnections []OAuthConnectionEntry     `json:"oauth_connections"`
 } // @name UserExport
+
+// OAuthConnectionEntry is one row of oauth_tokens for the user, joined
+// with the client metadata that authorized it. Token hashes are NOT
+// exported — they're credential equivalents and aren't recoverable
+// from the column anyway. The export reflects "which apps you've
+// connected and when," which is the user's own data.
+type OAuthConnectionEntry struct {
+	ClientID         string     `json:"client_id"`
+	ClientName       string     `json:"client_name"`
+	Scope            string     `json:"scope"`
+	AgentEmail       string     `json:"agent_email,omitempty"`
+	CreatedAt        time.Time  `json:"created_at"`
+	ExpiresAt        time.Time  `json:"expires_at"`
+	RefreshExpiresAt *time.Time `json:"refresh_expires_at,omitempty"`
+	RevokedAt        *time.Time `json:"revoked_at,omitempty"`
+} // @name OAuthConnectionEntry
 
 // UserExportUser mirrors User but omits the google_subject internal
 // identifier from the export payload.
@@ -113,20 +130,60 @@ func (s *Store) ExportUserData(ctx context.Context, userID string) (*UserExport,
 		return nil, fmt.Errorf("export: load usage events: %w", err)
 	}
 
+	// OAuth connections — the user's authorized MCP/web clients,
+	// joined with the client metadata. Token hashes are intentionally
+	// not included.
+	oauthConns, err := scanOAuthConnectionsForUser(ctx, tx, userID)
+	if err != nil {
+		return nil, fmt.Errorf("export: load oauth connections: %w", err)
+	}
+
 	if err := tx.Commit(ctx); err != nil {
 		return nil, fmt.Errorf("export: commit: %w", err)
 	}
 
 	return &UserExport{
-		GeneratedAt:   time.Now().UTC(),
-		SchemaVersion: "1",
-		User:          u,
-		Domains:       domains,
-		Agents:        agents,
-		APIKeys:       keys,
-		Messages:      messages,
-		UsageEvents:   events,
+		GeneratedAt:      time.Now().UTC(),
+		SchemaVersion:    "1",
+		User:             u,
+		Domains:          domains,
+		Agents:           agents,
+		APIKeys:          keys,
+		Messages:         messages,
+		UsageEvents:      events,
+		OAuthConnections: oauthConns,
 	}, nil
+}
+
+func scanOAuthConnectionsForUser(ctx context.Context, tx pgx.Tx, userID string) ([]OAuthConnectionEntry, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT t.client_id, COALESCE(c.client_name, ''), t.scope, t.agent_email,
+		       t.created_at, t.expires_at, t.refresh_expires_at, t.revoked_at
+		FROM oauth_tokens t
+		LEFT JOIN oauth_clients c ON c.client_id = t.client_id
+		WHERE t.user_id = $1
+		ORDER BY t.created_at
+	`, userID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []OAuthConnectionEntry{}
+	for rows.Next() {
+		var e OAuthConnectionEntry
+		var agentEmail *string
+		if err := rows.Scan(
+			&e.ClientID, &e.ClientName, &e.Scope, &agentEmail,
+			&e.CreatedAt, &e.ExpiresAt, &e.RefreshExpiresAt, &e.RevokedAt,
+		); err != nil {
+			return nil, err
+		}
+		if agentEmail != nil {
+			e.AgentEmail = *agentEmail
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
 }
 
 // DeleteUserDataResult breaks out per-table row counts for audit logs.

--- a/internal/identity/user_data_rights_test.go
+++ b/internal/identity/user_data_rights_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/oauth"
 	"github.com/Mnexa-AI/e2a/internal/testutil"
 )
 
@@ -144,6 +146,85 @@ func TestExportUserData(t *testing.T) {
 	}
 	if dump.GeneratedAt.IsZero() {
 		t.Error("export is missing generated_at")
+	}
+}
+
+// TestExportUserData_OAuthConnections covers the P1 finding: the user's
+// authorized MCP/web clients must appear in the right-of-access export.
+// Token hashes must NOT be exported (credential equivalents) — the
+// metadata-only payload is what GDPR Art. 15 covers.
+func TestExportUserData_OAuthConnections(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	oauthStore := oauth.NewStore(pool)
+	ctx := context.Background()
+
+	user := seedUserData(t, store, ctx, "oauth-exporter")
+
+	// Seed a registered client + an active token for the user.
+	client := &oauth.Client{
+		ClientID:     oauth.NewClientID(),
+		ClientName:   "Test MCP Client",
+		RedirectURIs: []string{"https://client.example.com/cb"},
+		ClientType:   "public",
+		CreatedVia:   "dcr",
+	}
+	if err := oauthStore.RegisterClient(ctx, client); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	refreshExp := now.Add(oauth.RefreshTokenLifetime)
+	tok := &oauth.Token{
+		AccessToken:      oauth.NewAccessToken(),
+		RefreshToken:     oauth.NewRefreshToken(),
+		RefreshChainID:   oauth.NewChainID(),
+		ClientID:         client.ClientID,
+		UserID:           user.ID,
+		AgentEmail:       "exporter-bot@agents.e2a.dev",
+		Scope:            "e2a",
+		ExpiresAt:        now.Add(oauth.AccessTokenLifetime),
+		RefreshExpiresAt: &refreshExp,
+	}
+	if err := oauthStore.IssueToken(ctx, tok); err != nil {
+		t.Fatal(err)
+	}
+
+	dump, err := store.ExportUserData(ctx, user.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dump.OAuthConnections) != 1 {
+		t.Fatalf("oauth_connections: want 1, got %d", len(dump.OAuthConnections))
+	}
+	got := dump.OAuthConnections[0]
+	if got.ClientID != client.ClientID {
+		t.Errorf("ClientID: want %q, got %q", client.ClientID, got.ClientID)
+	}
+	if got.ClientName != "Test MCP Client" {
+		t.Errorf("ClientName: want %q, got %q", "Test MCP Client", got.ClientName)
+	}
+	if got.AgentEmail != "exporter-bot@agents.e2a.dev" {
+		t.Errorf("AgentEmail: want %q, got %q", "exporter-bot@agents.e2a.dev", got.AgentEmail)
+	}
+	if got.Scope != "e2a" {
+		t.Errorf("Scope: want %q, got %q", "e2a", got.Scope)
+	}
+
+	// Token hashes are credential equivalents and MUST NOT appear in
+	// the export. The JSON shape doesn't have token fields, but a
+	// regression that exposed them would surface here.
+	raw, err := json.Marshal(dump)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(raw), tok.AccessToken) {
+		t.Error("export leaks access_token plaintext")
+	}
+	if strings.Contains(string(raw), tok.RefreshToken) {
+		t.Error("export leaks refresh_token plaintext")
+	}
+	if strings.Contains(string(raw), oauth.HashToken(tok.AccessToken)) {
+		t.Error("export leaks access_token_hash — credential-equivalent for offline preimage attacks against the table")
 	}
 }
 

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -1,0 +1,475 @@
+// Package oauth implements the storage layer + HTTP handlers for the
+// MCP OAuth 2.1 authorization server (.claude/design/mcp-system.md §4.3).
+//
+// This file holds the storage primitives. Higher-level flow logic
+// (auth code reuse triggers token revocation, refresh chain rotation,
+// etc.) is composed in the endpoint handlers from these primitives —
+// the store is pure CRUD + atomic mutations, no policy.
+package oauth
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Token / ID prefixes. Kept here as a single source of truth so the
+// dispatch in identity.GetUserByBearer can grep for them.
+const (
+	ClientIDPrefix     = "mcp_"
+	AuthCodePrefix     = "oace_"
+	AccessTokenPrefix  = "ate2a_"
+	RefreshTokenPrefix = "rte2a_"
+	ChainIDPrefix      = "rch_"
+)
+
+// Lifetimes are spec-aligned defaults; the design doc justifies each.
+const (
+	AuthCodeLifetime       = 60 * time.Second
+	AccessTokenLifetime    = 1 * time.Hour
+	RefreshTokenLifetime   = 30 * 24 * time.Hour
+)
+
+// Client is an OAuth 2.1 registered client (Claude Code, Cursor, etc.).
+// Public clients (PKCE-only) have empty ClientSecretHash; confidential
+// clients store a hash, never plaintext.
+type Client struct {
+	ClientID         string
+	ClientName       string
+	RedirectURIs     []string
+	ClientType       string // "public" | "confidential"
+	ClientSecretHash string
+	Metadata         json.RawMessage
+	CreatedAt        time.Time
+	CreatedVia       string // "dcr" | "admin"
+}
+
+// AuthorizationCode is a one-shot code issued at consent and exchanged
+// at /api/oauth/token for an access/refresh pair.
+type AuthorizationCode struct {
+	Code                string
+	ClientID            string
+	UserID              string
+	AgentEmail          string // empty if null in DB
+	RedirectURI         string
+	CodeChallenge       string
+	CodeChallengeMethod string // always "S256"
+	Scope               string
+	ExpiresAt           time.Time
+	ConsumedAt          *time.Time // nil = not yet consumed
+}
+
+// Token represents one row in oauth_tokens (one access token + the
+// refresh token it was paired with, if not yet rotated).
+type Token struct {
+	AccessToken      string
+	RefreshToken     string // empty if rotated
+	RefreshChainID   string
+	ClientID         string
+	UserID           string
+	AgentEmail       string // empty if null
+	Scope            string
+	ExpiresAt        time.Time
+	RefreshExpiresAt *time.Time
+	RevokedAt        *time.Time
+	CreatedAt        time.Time
+}
+
+// IsActive returns true if the token has not been revoked and the
+// access-token portion hasn't expired. Callers that care about refresh
+// lifetime should check RefreshExpiresAt separately.
+func (t *Token) IsActive(now time.Time) bool {
+	return t.RevokedAt == nil && now.Before(t.ExpiresAt)
+}
+
+// Store is the OAuth persistence layer. Wraps a pgxpool.Pool and
+// exposes only the primitives the OAuth handlers need.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+func NewStore(pool *pgxpool.Pool) *Store {
+	return &Store{pool: pool}
+}
+
+// ───────────────────────── token / ID generation ─────────────────────────
+
+// New64HexBytes returns the prefix + 32 hex chars (16 bytes of entropy
+// from crypto/rand). 128 bits is more than enough for an opaque token.
+func newPrefixed(prefix string, n int) string {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		// Same pattern as identity.generateID: panic on RNG failure.
+		// Returning a non-random token would poison the database; a
+		// 500 is the correct surface for a broken OS RNG.
+		panic(fmt.Sprintf("oauth: crypto/rand failed: %v", err))
+	}
+	return prefix + hex.EncodeToString(b)
+}
+
+// NewClientID returns 'mcp_' + 12 hex chars (6 bytes / 48 bits).
+// Client IDs are identifiers, not secrets — entropy just needs to be
+// enough to avoid accidental collision.
+func NewClientID() string { return newPrefixed(ClientIDPrefix, 6) }
+
+// NewAuthCode returns 'oace_' + 32 hex chars (128 bits). One-shot,
+// 60s lifetime — treated as a bearer credential per RFC 6749 §10.5.
+func NewAuthCode() string { return newPrefixed(AuthCodePrefix, 16) }
+
+// NewAccessToken returns 'ate2a_' + 32 hex chars (128 bits).
+func NewAccessToken() string { return newPrefixed(AccessTokenPrefix, 16) }
+
+// NewRefreshToken returns 'rte2a_' + 32 hex chars (128 bits).
+func NewRefreshToken() string { return newPrefixed(RefreshTokenPrefix, 16) }
+
+// NewChainID groups all access+refresh tokens that descend from the
+// same authorization-code exchange. Used to revoke entire chains when
+// a refresh token is reused (RFC 6749 §10.4 defense).
+func NewChainID() string { return newPrefixed(ChainIDPrefix, 12) }
+
+// ───────────────────────── clients ─────────────────────────
+
+// RegisterClient inserts a new oauth_clients row. Caller is responsible
+// for hashing client_secret beforehand if confidential.
+func (s *Store) RegisterClient(ctx context.Context, c *Client) error {
+	if c.Metadata == nil {
+		c.Metadata = json.RawMessage("{}")
+	}
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO oauth_clients
+		    (client_id, client_name, redirect_uris, client_type,
+		     client_secret_hash, metadata, created_via)
+		VALUES ($1, $2, $3, $4, NULLIF($5, ''), $6, $7)
+	`, c.ClientID, c.ClientName, c.RedirectURIs, c.ClientType,
+		c.ClientSecretHash, c.Metadata, c.CreatedVia)
+	return err
+}
+
+// ErrClientNotFound is returned by GetClient when the client_id does
+// not exist. Use errors.Is to detect.
+var ErrClientNotFound = errors.New("oauth: client not found")
+
+// GetClient looks up an OAuth client by its client_id.
+func (s *Store) GetClient(ctx context.Context, clientID string) (*Client, error) {
+	var c Client
+	var secretHash *string
+	err := s.pool.QueryRow(ctx, `
+		SELECT client_id, client_name, redirect_uris, client_type,
+		       client_secret_hash, metadata, created_at, created_via
+		FROM oauth_clients WHERE client_id = $1
+	`, clientID).Scan(
+		&c.ClientID, &c.ClientName, &c.RedirectURIs, &c.ClientType,
+		&secretHash, &c.Metadata, &c.CreatedAt, &c.CreatedVia,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrClientNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	if secretHash != nil {
+		c.ClientSecretHash = *secretHash
+	}
+	return &c, nil
+}
+
+// ───────────────────────── authorization codes ─────────────────────────
+
+// IssueCode inserts a fresh authorization code. expires_at must be set
+// by the caller (typically time.Now().Add(AuthCodeLifetime)).
+func (s *Store) IssueCode(ctx context.Context, c *AuthorizationCode) error {
+	var agentEmail *string
+	if c.AgentEmail != "" {
+		agentEmail = &c.AgentEmail
+	}
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO oauth_authorization_codes
+		    (code, client_id, user_id, agent_email, redirect_uri,
+		     code_challenge, code_challenge_method, scope, expires_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+	`, c.Code, c.ClientID, c.UserID, agentEmail, c.RedirectURI,
+		c.CodeChallenge, c.CodeChallengeMethod, c.Scope, c.ExpiresAt)
+	return err
+}
+
+// ConsumeResult disambiguates the outcome of AtomicConsumeCode.
+type ConsumeResult int
+
+const (
+	ConsumeFresh           ConsumeResult = iota // just consumed by this call
+	ConsumeAlreadyConsumed                      // a previous call already consumed — replay attempt
+	ConsumeExpired                              // exists but expires_at passed
+	ConsumeNotFound                             // no such code
+)
+
+// AtomicConsumeCode tries to mark a code consumed and return the row.
+// The UPDATE is conditional on (consumed_at IS NULL AND expires_at >
+// NOW()), so concurrent consume attempts can never both succeed.
+//
+// Returns ConsumeFresh + the code on success. On contention or replay,
+// returns ConsumeAlreadyConsumed and the code so the caller can revoke
+// downstream tokens per RFC 6749 §10.5. On expiry/missing, the code
+// pointer may be nil.
+func (s *Store) AtomicConsumeCode(ctx context.Context, code string) (*AuthorizationCode, ConsumeResult, error) {
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Conditional update: only this call wins.
+	var (
+		c               AuthorizationCode
+		agentEmail      *string
+		consumedAtRaw   *time.Time
+	)
+	err = tx.QueryRow(ctx, `
+		UPDATE oauth_authorization_codes
+		SET consumed_at = NOW()
+		WHERE code = $1 AND consumed_at IS NULL AND expires_at > NOW()
+		RETURNING code, client_id, user_id, agent_email, redirect_uri,
+		          code_challenge, code_challenge_method, scope,
+		          expires_at, consumed_at
+	`, code).Scan(
+		&c.Code, &c.ClientID, &c.UserID, &agentEmail, &c.RedirectURI,
+		&c.CodeChallenge, &c.CodeChallengeMethod, &c.Scope,
+		&c.ExpiresAt, &consumedAtRaw,
+	)
+	if err == nil {
+		if agentEmail != nil {
+			c.AgentEmail = *agentEmail
+		}
+		c.ConsumedAt = consumedAtRaw
+		if err := tx.Commit(ctx); err != nil {
+			return nil, 0, err
+		}
+		return &c, ConsumeFresh, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return nil, 0, err
+	}
+
+	// Update returned no rows. Disambiguate: was it not found, expired,
+	// or already consumed? Use the same tx for a read-after-failed-write.
+	now := time.Now()
+	err = tx.QueryRow(ctx, `
+		SELECT code, client_id, user_id, agent_email, redirect_uri,
+		       code_challenge, code_challenge_method, scope,
+		       expires_at, consumed_at
+		FROM oauth_authorization_codes WHERE code = $1
+	`, code).Scan(
+		&c.Code, &c.ClientID, &c.UserID, &agentEmail, &c.RedirectURI,
+		&c.CodeChallenge, &c.CodeChallengeMethod, &c.Scope,
+		&c.ExpiresAt, &consumedAtRaw,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		_ = tx.Commit(ctx)
+		return nil, ConsumeNotFound, nil
+	}
+	if err != nil {
+		return nil, 0, err
+	}
+	if agentEmail != nil {
+		c.AgentEmail = *agentEmail
+	}
+	c.ConsumedAt = consumedAtRaw
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, 0, err
+	}
+
+	if c.ConsumedAt != nil {
+		return &c, ConsumeAlreadyConsumed, nil
+	}
+	if !c.ExpiresAt.After(now) {
+		return &c, ConsumeExpired, nil
+	}
+	// Shouldn't happen — the UPDATE should have matched. Treat as
+	// already-consumed defensively.
+	return &c, ConsumeAlreadyConsumed, nil
+}
+
+// ───────────────────────── tokens ─────────────────────────
+
+// IssueToken inserts an oauth_tokens row. Used both at code-exchange
+// time (initial token issuance) and refresh time (a new row in the
+// same RefreshChainID — caller separately nulls the prior row's
+// refresh_token via RotateRefreshToken).
+func (s *Store) IssueToken(ctx context.Context, t *Token) error {
+	var agentEmail *string
+	if t.AgentEmail != "" {
+		agentEmail = &t.AgentEmail
+	}
+	var refreshToken *string
+	if t.RefreshToken != "" {
+		refreshToken = &t.RefreshToken
+	}
+	_, err := s.pool.Exec(ctx, `
+		INSERT INTO oauth_tokens
+		    (access_token, refresh_token, refresh_chain_id, client_id,
+		     user_id, agent_email, scope, expires_at, refresh_expires_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+	`, t.AccessToken, refreshToken, t.RefreshChainID, t.ClientID,
+		t.UserID, agentEmail, t.Scope, t.ExpiresAt, t.RefreshExpiresAt)
+	return err
+}
+
+// ErrTokenNotFound is returned by lookup methods when the token does
+// not exist. Use errors.Is to detect.
+var ErrTokenNotFound = errors.New("oauth: token not found")
+
+// LookupTokenByAccess fetches the row for an access token, regardless
+// of revoked/expired state. Callers must check IsActive() or the
+// individual fields. This shape lets the auth middleware emit clear
+// errors ("revoked" vs "expired") without re-querying.
+func (s *Store) LookupTokenByAccess(ctx context.Context, accessToken string) (*Token, error) {
+	return s.lookupToken(ctx, "access_token = $1", accessToken)
+}
+
+// LookupTokenByRefresh fetches the row by refresh_token. Returns
+// ErrTokenNotFound when the refresh_token doesn't exist OR has been
+// rotated (set NULL). Caller should not distinguish: both cases
+// indicate a replayed or stale refresh.
+func (s *Store) LookupTokenByRefresh(ctx context.Context, refreshToken string) (*Token, error) {
+	return s.lookupToken(ctx, "refresh_token = $1", refreshToken)
+}
+
+func (s *Store) lookupToken(ctx context.Context, whereClause, arg string) (*Token, error) {
+	var t Token
+	var (
+		refreshToken     *string
+		agentEmail       *string
+		refreshExpiresAt *time.Time
+		revokedAt        *time.Time
+	)
+	err := s.pool.QueryRow(ctx, `
+		SELECT access_token, refresh_token, refresh_chain_id, client_id,
+		       user_id, agent_email, scope, expires_at,
+		       refresh_expires_at, revoked_at, created_at
+		FROM oauth_tokens WHERE `+whereClause,
+		arg,
+	).Scan(
+		&t.AccessToken, &refreshToken, &t.RefreshChainID, &t.ClientID,
+		&t.UserID, &agentEmail, &t.Scope, &t.ExpiresAt,
+		&refreshExpiresAt, &revokedAt, &t.CreatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, ErrTokenNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	if refreshToken != nil {
+		t.RefreshToken = *refreshToken
+	}
+	if agentEmail != nil {
+		t.AgentEmail = *agentEmail
+	}
+	t.RefreshExpiresAt = refreshExpiresAt
+	t.RevokedAt = revokedAt
+	return &t, nil
+}
+
+// RotateRefreshToken issues a new token and atomically NULLs the prior
+// refresh_token. The new token inherits the same RefreshChainID so a
+// future reuse of any earlier refresh in this chain can revoke the
+// whole family. Returns the newly-issued token's data after insert.
+func (s *Store) RotateRefreshToken(ctx context.Context, oldRefresh string, newToken *Token) error {
+	if newToken.RefreshChainID == "" {
+		return errors.New("oauth: RotateRefreshToken requires RefreshChainID on new token")
+	}
+	tx, err := s.pool.BeginTx(ctx, pgx.TxOptions{})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	res, err := tx.Exec(ctx,
+		`UPDATE oauth_tokens SET refresh_token = NULL WHERE refresh_token = $1`,
+		oldRefresh,
+	)
+	if err != nil {
+		return fmt.Errorf("invalidate old refresh: %w", err)
+	}
+	if res.RowsAffected() == 0 {
+		// The refresh token didn't exist or was already rotated.
+		// Caller (the /token endpoint) must catch this and revoke the
+		// chain — that's the RFC 6749 §10.4 reuse defense. Returning
+		// an error here surfaces the contract.
+		return ErrTokenNotFound
+	}
+
+	var agentEmail *string
+	if newToken.AgentEmail != "" {
+		agentEmail = &newToken.AgentEmail
+	}
+	var refreshTokenArg *string
+	if newToken.RefreshToken != "" {
+		refreshTokenArg = &newToken.RefreshToken
+	}
+	if _, err := tx.Exec(ctx, `
+		INSERT INTO oauth_tokens
+		    (access_token, refresh_token, refresh_chain_id, client_id,
+		     user_id, agent_email, scope, expires_at, refresh_expires_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+	`, newToken.AccessToken, refreshTokenArg, newToken.RefreshChainID,
+		newToken.ClientID, newToken.UserID, agentEmail, newToken.Scope,
+		newToken.ExpiresAt, newToken.RefreshExpiresAt,
+	); err != nil {
+		return fmt.Errorf("insert new token: %w", err)
+	}
+
+	return tx.Commit(ctx)
+}
+
+// RevokeToken marks a single access token revoked (sets revoked_at).
+// Also NULLs the refresh_token so a refresh-grant attempt on this row
+// fails the lookup. Used by /api/oauth/revoke (RFC 7009).
+func (s *Store) RevokeToken(ctx context.Context, accessToken string) error {
+	_, err := s.pool.Exec(ctx, `
+		UPDATE oauth_tokens
+		SET revoked_at = NOW(), refresh_token = NULL
+		WHERE access_token = $1 AND revoked_at IS NULL
+	`, accessToken)
+	return err
+}
+
+// RevokeChainByID marks every row in a refresh_chain_id revoked.
+// Returns the number of rows updated. Caller of refresh-grant on a
+// reused refresh token must call this with the chain_id loaded from
+// the matching row to enforce RFC 6749 §10.4.
+func (s *Store) RevokeChainByID(ctx context.Context, chainID string) (int, error) {
+	res, err := s.pool.Exec(ctx, `
+		UPDATE oauth_tokens
+		SET revoked_at = NOW(), refresh_token = NULL
+		WHERE refresh_chain_id = $1 AND revoked_at IS NULL
+	`, chainID)
+	if err != nil {
+		return 0, err
+	}
+	return int(res.RowsAffected()), nil
+}
+
+// RevokeAllByClientUser marks every active token for a (client_id,
+// user_id) pair revoked. Used when an authorization code is replayed
+// (RFC 6749 §10.5) — we don't know exactly which tokens were issued
+// from the compromised code, so we revoke the broader pair as a safe
+// over-approximation. Returns the count.
+func (s *Store) RevokeAllByClientUser(ctx context.Context, clientID, userID string) (int, error) {
+	res, err := s.pool.Exec(ctx, `
+		UPDATE oauth_tokens
+		SET revoked_at = NOW(), refresh_token = NULL
+		WHERE client_id = $1 AND user_id = $2 AND revoked_at IS NULL
+	`, clientID, userID)
+	if err != nil {
+		return 0, err
+	}
+	return int(res.RowsAffected()), nil
+}

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -551,3 +551,47 @@ func (s *Store) RevokeAllByClientUser(ctx context.Context, clientID, userID stri
 	}
 	return int(res.RowsAffected()), nil
 }
+
+// DeleteExpiredResult breaks out per-table counts for the periodic
+// cleanup worker's log line. Both counts contribute to the same data-
+// minimization goal (stop retaining PII past usefulness) but it's
+// useful in operations to see which table is doing the work.
+type DeleteExpiredResult struct {
+	Codes  int
+	Tokens int
+}
+
+// DeleteExpired removes oauth_* rows that are no longer useful.
+//
+// Authorization codes: 60s live; we keep them around briefly past
+// expiry so replay attempts still hit ConsumeAlreadyConsumed (for the
+// SECURITY log), then delete after 7 days.
+//
+// Tokens: keep revoked rows for 30d (audit window) and let already-
+// rotated rows die at 30d past their access expiry. Active rows are
+// untouched.
+//
+// Called from the cmd/e2a periodic worker. Returns row counts and any
+// error from the first failing DELETE.
+func (s *Store) DeleteExpired(ctx context.Context) (DeleteExpiredResult, error) {
+	var res DeleteExpiredResult
+	tag, err := s.pool.Exec(ctx, `
+		DELETE FROM oauth_authorization_codes
+		WHERE expires_at < NOW() - INTERVAL '7 days'
+	`)
+	if err != nil {
+		return res, fmt.Errorf("delete expired codes: %w", err)
+	}
+	res.Codes = int(tag.RowsAffected())
+
+	tag, err = s.pool.Exec(ctx, `
+		DELETE FROM oauth_tokens
+		WHERE (revoked_at IS NOT NULL AND revoked_at < NOW() - INTERVAL '30 days')
+		   OR (expires_at < NOW() - INTERVAL '30 days' AND refresh_token_hash IS NULL)
+	`)
+	if err != nil {
+		return res, fmt.Errorf("delete expired tokens: %w", err)
+	}
+	res.Tokens = int(tag.RowsAffected())
+	return res, nil
+}

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -97,6 +98,21 @@ type Store struct {
 
 func NewStore(pool *pgxpool.Pool) *Store {
 	return &Store{pool: pool}
+}
+
+// Pool returns the underlying pgxpool. Exposed so callers that need
+// to span multiple stores in one transaction (e.g. consent's combined
+// agent-create + code-issue) can BeginTx themselves. Don't reach for
+// this from new code — prefer adding a method that runs the work
+// inside the store.
+func (s *Store) Pool() *pgxpool.Pool { return s.pool }
+
+// dbExecutor is the subset of pgx.Tx + pgxpool.Pool that issueCode/
+// related helpers need. Lets the same SQL body run against either a
+// pool (for stand-alone calls) or an externally-owned tx (for
+// multi-statement consent flow).
+type dbExecutor interface {
+	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }
 
 // ───────────────────────── token / ID generation ─────────────────────────
@@ -182,14 +198,25 @@ func (s *Store) GetClient(ctx context.Context, clientID string) (*Client, error)
 
 // ───────────────────────── authorization codes ─────────────────────────
 
-// IssueCode inserts a fresh authorization code. expires_at must be set
-// by the caller (typically time.Now().Add(AuthCodeLifetime)).
+// IssueCode inserts a fresh authorization code on the pool. expires_at
+// must be set by the caller (typically time.Now().Add(AuthCodeLifetime)).
 func (s *Store) IssueCode(ctx context.Context, c *AuthorizationCode) error {
+	return issueCode(ctx, s.pool, c)
+}
+
+// IssueCodeTx inserts a fresh authorization code inside a caller-owned
+// transaction. Used by consent when agent creation and code issuance
+// must commit together — see the create_new branch of handleOAuthConsent.
+func (s *Store) IssueCodeTx(ctx context.Context, tx pgx.Tx, c *AuthorizationCode) error {
+	return issueCode(ctx, tx, c)
+}
+
+func issueCode(ctx context.Context, exec dbExecutor, c *AuthorizationCode) error {
 	var agentEmail *string
 	if c.AgentEmail != "" {
 		agentEmail = &c.AgentEmail
 	}
-	_, err := s.pool.Exec(ctx, `
+	_, err := exec.Exec(ctx, `
 		INSERT INTO oauth_authorization_codes
 		    (code, client_id, user_id, agent_email, redirect_uri,
 		     code_challenge, code_challenge_method, scope, expires_at)

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -298,16 +298,28 @@ func (s *Store) AtomicConsumeCode(ctx context.Context, code string) (*Authorizat
 
 	// Update returned no rows. Disambiguate: was it not found, expired,
 	// or already consumed? Use the same tx for a read-after-failed-write.
-	now := time.Now()
+	//
+	// CRITICAL: the expiry check must use the DB clock, not Go's wall
+	// clock. The UPDATE above used Postgres NOW(); if Go's time.Now()
+	// disagrees by even a few ms (normal NTP skew between an app VM
+	// and a managed Postgres) we can land in a state where:
+	//   UPDATE fails:  DB sees NOW() > expires_at  → 0 rows
+	//   Go disagrees:  expires_at > go_now         → "not expired"
+	// and the code falls through to "shouldn't happen" → and we
+	// previously defaulted to ConsumeAlreadyConsumed, which triggers
+	// RevokeAllByClientUser at the caller — wiping the user's other
+	// live tokens for that client. Now we compute is_expired in SQL
+	// using the same clock the UPDATE used.
+	var isExpired bool
 	err = tx.QueryRow(ctx, `
 		SELECT code, client_id, user_id, agent_email, redirect_uri,
 		       code_challenge, code_challenge_method, scope,
-		       expires_at, consumed_at
+		       expires_at, consumed_at, (NOW() > expires_at) AS is_expired
 		FROM oauth_authorization_codes WHERE code = $1
 	`, code).Scan(
 		&c.Code, &c.ClientID, &c.UserID, &agentEmail, &c.RedirectURI,
 		&c.CodeChallenge, &c.CodeChallengeMethod, &c.Scope,
-		&c.ExpiresAt, &consumedAtRaw,
+		&c.ExpiresAt, &consumedAtRaw, &isExpired,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		_ = tx.Commit(ctx)
@@ -328,12 +340,16 @@ func (s *Store) AtomicConsumeCode(ctx context.Context, code string) (*Authorizat
 	if c.ConsumedAt != nil {
 		return &c, ConsumeAlreadyConsumed, nil
 	}
-	if !c.ExpiresAt.After(now) {
+	if isExpired {
 		return &c, ConsumeExpired, nil
 	}
-	// Shouldn't happen — the UPDATE should have matched. Treat as
-	// already-consumed defensively.
-	return &c, ConsumeAlreadyConsumed, nil
+	// Defensive fallthrough: row exists, isn't consumed, isn't expired,
+	// yet the UPDATE didn't take. Genuinely shouldn't happen with the
+	// same-tx read above. Treat as ConsumeExpired rather than
+	// ConsumeAlreadyConsumed — the latter is more destructive (triggers
+	// RevokeAllByClientUser at the caller), and we'd rather over-reject
+	// than over-revoke.
+	return &c, ConsumeExpired, nil
 }
 
 // ───────────────────────── tokens ─────────────────────────

--- a/internal/oauth/store.go
+++ b/internal/oauth/store.go
@@ -10,6 +10,7 @@ package oauth
 import (
 	"context"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -20,6 +21,18 @@ import (
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+// HashToken returns the SHA-256 hex of a plaintext token. We store
+// SHA-256 (not bcrypt/argon2) because tokens are 128-bit random — slow
+// hashes buy nothing against an input space that can't be brute-forced
+// in any realistic timeframe, and the hot bearer-validation path runs
+// on every authed request. SHA-256 also matches the existing
+// identity.hashAPIKey pattern in the same DB so a DB read is uniformly
+// non-credential-bearing.
+func HashToken(plaintext string) string {
+	h := sha256.Sum256([]byte(plaintext))
+	return hex.EncodeToString(h[:])
+}
 
 // Token / ID prefixes. Kept here as a single source of truth so the
 // dispatch in identity.GetUserByBearer can grep for them.
@@ -328,22 +341,27 @@ func (s *Store) AtomicConsumeCode(ctx context.Context, code string) (*Authorizat
 // IssueToken inserts an oauth_tokens row. Used both at code-exchange
 // time (initial token issuance) and refresh time (a new row in the
 // same RefreshChainID — caller separately nulls the prior row's
-// refresh_token via RotateRefreshToken).
+// refresh_token_hash via RotateRefreshToken).
+//
+// The plaintext t.AccessToken / t.RefreshToken are hashed before write;
+// only the hashes hit disk. The plaintext stays on the struct so the
+// caller can return it in the issuance HTTP response (one-time view).
 func (s *Store) IssueToken(ctx context.Context, t *Token) error {
 	var agentEmail *string
 	if t.AgentEmail != "" {
 		agentEmail = &t.AgentEmail
 	}
-	var refreshToken *string
+	var refreshHash *string
 	if t.RefreshToken != "" {
-		refreshToken = &t.RefreshToken
+		h := HashToken(t.RefreshToken)
+		refreshHash = &h
 	}
 	_, err := s.pool.Exec(ctx, `
 		INSERT INTO oauth_tokens
-		    (access_token, refresh_token, refresh_chain_id, client_id,
+		    (access_token_hash, refresh_token_hash, refresh_chain_id, client_id,
 		     user_id, agent_email, scope, expires_at, refresh_expires_at)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-	`, t.AccessToken, refreshToken, t.RefreshChainID, t.ClientID,
+	`, HashToken(t.AccessToken), refreshHash, t.RefreshChainID, t.ClientID,
 		t.UserID, agentEmail, t.Scope, t.ExpiresAt, t.RefreshExpiresAt)
 	return err
 }
@@ -354,36 +372,54 @@ var ErrTokenNotFound = errors.New("oauth: token not found")
 
 // LookupTokenByAccess fetches the row for an access token, regardless
 // of revoked/expired state. Callers must check IsActive() or the
-// individual fields. This shape lets the auth middleware emit clear
-// errors ("revoked" vs "expired") without re-querying.
+// individual fields. The returned Token.AccessToken is populated with
+// the caller's plaintext (we can't reconstruct it from the hash);
+// Token.RefreshToken is left empty because we no longer have the
+// plaintext for sibling refresh tokens.
 func (s *Store) LookupTokenByAccess(ctx context.Context, accessToken string) (*Token, error) {
-	return s.lookupToken(ctx, "access_token = $1", accessToken)
+	t, err := s.lookupToken(ctx, "access_token_hash = $1", HashToken(accessToken))
+	if err != nil {
+		return nil, err
+	}
+	t.AccessToken = accessToken
+	return t, nil
 }
 
 // LookupTokenByRefresh fetches the row by refresh_token. Returns
 // ErrTokenNotFound when the refresh_token doesn't exist OR has been
-// rotated (set NULL). Caller should not distinguish: both cases
-// indicate a replayed or stale refresh.
+// rotated (refresh_token_hash set NULL). Caller should not distinguish:
+// both cases indicate a replayed or stale refresh.
+//
+// Token.RefreshToken is populated with the caller's plaintext;
+// Token.AccessToken is left empty.
 func (s *Store) LookupTokenByRefresh(ctx context.Context, refreshToken string) (*Token, error) {
-	return s.lookupToken(ctx, "refresh_token = $1", refreshToken)
+	t, err := s.lookupToken(ctx, "refresh_token_hash = $1", HashToken(refreshToken))
+	if err != nil {
+		return nil, err
+	}
+	t.RefreshToken = refreshToken
+	return t, nil
 }
 
-func (s *Store) lookupToken(ctx context.Context, whereClause, arg string) (*Token, error) {
+// lookupToken returns the row fields that aren't the bearer plaintext.
+// AccessToken / RefreshToken on the returned struct are intentionally
+// blank — the caller knows which one they queried with and sets it.
+func (s *Store) lookupToken(ctx context.Context, whereClause, hashedArg string) (*Token, error) {
 	var t Token
 	var (
-		refreshToken     *string
+		hasRefresh       bool
 		agentEmail       *string
 		refreshExpiresAt *time.Time
 		revokedAt        *time.Time
 	)
 	err := s.pool.QueryRow(ctx, `
-		SELECT access_token, refresh_token, refresh_chain_id, client_id,
+		SELECT (refresh_token_hash IS NOT NULL), refresh_chain_id, client_id,
 		       user_id, agent_email, scope, expires_at,
 		       refresh_expires_at, revoked_at, created_at
 		FROM oauth_tokens WHERE `+whereClause,
-		arg,
+		hashedArg,
 	).Scan(
-		&t.AccessToken, &refreshToken, &t.RefreshChainID, &t.ClientID,
+		&hasRefresh, &t.RefreshChainID, &t.ClientID,
 		&t.UserID, &agentEmail, &t.Scope, &t.ExpiresAt,
 		&refreshExpiresAt, &revokedAt, &t.CreatedAt,
 	)
@@ -393,9 +429,7 @@ func (s *Store) lookupToken(ctx context.Context, whereClause, arg string) (*Toke
 	if err != nil {
 		return nil, err
 	}
-	if refreshToken != nil {
-		t.RefreshToken = *refreshToken
-	}
+	_ = hasRefresh // hash presence is implicit in revoked_at/rotation state; reserved for future "has live refresh" callers
 	if agentEmail != nil {
 		t.AgentEmail = *agentEmail
 	}
@@ -419,8 +453,8 @@ func (s *Store) RotateRefreshToken(ctx context.Context, oldRefresh string, newTo
 	defer func() { _ = tx.Rollback(ctx) }()
 
 	res, err := tx.Exec(ctx,
-		`UPDATE oauth_tokens SET refresh_token = NULL WHERE refresh_token = $1`,
-		oldRefresh,
+		`UPDATE oauth_tokens SET refresh_token_hash = NULL WHERE refresh_token_hash = $1`,
+		HashToken(oldRefresh),
 	)
 	if err != nil {
 		return fmt.Errorf("invalidate old refresh: %w", err)
@@ -437,16 +471,17 @@ func (s *Store) RotateRefreshToken(ctx context.Context, oldRefresh string, newTo
 	if newToken.AgentEmail != "" {
 		agentEmail = &newToken.AgentEmail
 	}
-	var refreshTokenArg *string
+	var refreshHash *string
 	if newToken.RefreshToken != "" {
-		refreshTokenArg = &newToken.RefreshToken
+		h := HashToken(newToken.RefreshToken)
+		refreshHash = &h
 	}
 	if _, err := tx.Exec(ctx, `
 		INSERT INTO oauth_tokens
-		    (access_token, refresh_token, refresh_chain_id, client_id,
+		    (access_token_hash, refresh_token_hash, refresh_chain_id, client_id,
 		     user_id, agent_email, scope, expires_at, refresh_expires_at)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-	`, newToken.AccessToken, refreshTokenArg, newToken.RefreshChainID,
+	`, HashToken(newToken.AccessToken), refreshHash, newToken.RefreshChainID,
 		newToken.ClientID, newToken.UserID, agentEmail, newToken.Scope,
 		newToken.ExpiresAt, newToken.RefreshExpiresAt,
 	); err != nil {
@@ -457,14 +492,14 @@ func (s *Store) RotateRefreshToken(ctx context.Context, oldRefresh string, newTo
 }
 
 // RevokeToken marks a single access token revoked (sets revoked_at).
-// Also NULLs the refresh_token so a refresh-grant attempt on this row
-// fails the lookup. Used by /api/oauth/revoke (RFC 7009).
+// Also NULLs the refresh_token_hash so a refresh-grant attempt on this
+// row fails the lookup. Used by /api/oauth/revoke (RFC 7009).
 func (s *Store) RevokeToken(ctx context.Context, accessToken string) error {
 	_, err := s.pool.Exec(ctx, `
 		UPDATE oauth_tokens
-		SET revoked_at = NOW(), refresh_token = NULL
-		WHERE access_token = $1 AND revoked_at IS NULL
-	`, accessToken)
+		SET revoked_at = NOW(), refresh_token_hash = NULL
+		WHERE access_token_hash = $1 AND revoked_at IS NULL
+	`, HashToken(accessToken))
 	return err
 }
 
@@ -475,7 +510,7 @@ func (s *Store) RevokeToken(ctx context.Context, accessToken string) error {
 func (s *Store) RevokeChainByID(ctx context.Context, chainID string) (int, error) {
 	res, err := s.pool.Exec(ctx, `
 		UPDATE oauth_tokens
-		SET revoked_at = NOW(), refresh_token = NULL
+		SET revoked_at = NOW(), refresh_token_hash = NULL
 		WHERE refresh_chain_id = $1 AND revoked_at IS NULL
 	`, chainID)
 	if err != nil {
@@ -492,7 +527,7 @@ func (s *Store) RevokeChainByID(ctx context.Context, chainID string) (int, error
 func (s *Store) RevokeAllByClientUser(ctx context.Context, clientID, userID string) (int, error) {
 	res, err := s.pool.Exec(ctx, `
 		UPDATE oauth_tokens
-		SET revoked_at = NOW(), refresh_token = NULL
+		SET revoked_at = NOW(), refresh_token_hash = NULL
 		WHERE client_id = $1 AND user_id = $2 AND revoked_at IS NULL
 	`, clientID, userID)
 	if err != nil {

--- a/internal/oauth/store_test.go
+++ b/internal/oauth/store_test.go
@@ -291,6 +291,76 @@ func newTestToken(clientID, userID string) *oauth.Token {
 	}
 }
 
+// TestDeleteExpired guards PM1: the periodic worker must reclaim
+// PII-bearing rows past usefulness. We seed four scenarios and verify
+// the GC deletes exactly the right ones, leaving active rows alone.
+func TestDeleteExpired(t *testing.T) {
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+	store := oauth.NewStore(pool)
+	idStore := identity.NewStore(pool)
+	clientID := seedClient(t, store)
+	userID := seedUser(t, idStore)
+
+	insertCode := func(label string, expiresAt time.Time) string {
+		t.Helper()
+		c := &oauth.AuthorizationCode{
+			Code:                oauth.NewAuthCode(),
+			ClientID:            clientID,
+			UserID:              userID,
+			RedirectURI:         "https://example.com/cb",
+			CodeChallenge:       "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLM1234",
+			CodeChallengeMethod: "S256",
+			Scope:               "e2a",
+			ExpiresAt:           expiresAt,
+		}
+		if err := store.IssueCode(ctx, c); err != nil {
+			t.Fatalf("seed %s: %v", label, err)
+		}
+		return c.Code
+	}
+
+	// Code well past the 7d cleanup horizon — should be deleted.
+	oldCode := insertCode("old", time.Now().Add(-8*24*time.Hour))
+	// Code recently expired (1h ago) — should be kept (within 7d).
+	recentCode := insertCode("recent", time.Now().Add(-time.Hour))
+	// Active code — should be kept.
+	activeCode := insertCode("active", time.Now().Add(time.Hour))
+
+	// An active token — should be kept.
+	active := newTestToken(clientID, userID)
+	if err := store.IssueToken(ctx, active); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := store.DeleteExpired(ctx)
+	if err != nil {
+		t.Fatalf("DeleteExpired: %v", err)
+	}
+
+	if res.Codes != 1 {
+		t.Errorf("expected 1 code deleted (the 8d-old one), got %d", res.Codes)
+	}
+
+	// Confirm what stayed vs went. We use AtomicConsumeCode as a
+	// presence-and-state probe: deleted codes return ConsumeNotFound;
+	// kept ones return their actual state.
+	if _, state, _ := store.AtomicConsumeCode(ctx, oldCode); state != oauth.ConsumeNotFound {
+		t.Errorf("old code should be gone, got state=%v", state)
+	}
+	if _, state, _ := store.AtomicConsumeCode(ctx, recentCode); state != oauth.ConsumeExpired {
+		t.Errorf("recent expired code should still exist (state=ConsumeExpired), got state=%v", state)
+	}
+	if _, state, _ := store.AtomicConsumeCode(ctx, activeCode); state != oauth.ConsumeFresh {
+		t.Errorf("active code should be consumable, got state=%v", state)
+	}
+
+	// Active token survives.
+	if _, err := store.LookupTokenByAccess(ctx, active.AccessToken); err != nil {
+		t.Errorf("active token should still exist: %v", err)
+	}
+}
+
 // TestIssueToken_StoresHashNotPlaintext is the regression guard for the
 // at-rest hashing fix. We issue a token, then query the raw column
 // directly and confirm:

--- a/internal/oauth/store_test.go
+++ b/internal/oauth/store_test.go
@@ -1,0 +1,640 @@
+package oauth_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/oauth"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+)
+
+// seedUser returns a freshly-inserted user ID. Needed because the
+// oauth_authorization_codes / oauth_tokens tables FK on users.id.
+func seedUser(t *testing.T, store *identity.Store) string {
+	t.Helper()
+	user, err := store.CreateOrGetUser(context.Background(),
+		"oauth-test-"+oauth.NewChainID()+"@example.com",
+		"OAuth Test", "google-test-"+oauth.NewChainID())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return user.ID
+}
+
+// seedClient registers a client and returns its ID. Most tests need
+// a client_id to satisfy the codes/tokens FK.
+func seedClient(t *testing.T, s *oauth.Store) string {
+	t.Helper()
+	c := &oauth.Client{
+		ClientID:     oauth.NewClientID(),
+		ClientName:   "test-client",
+		RedirectURIs: []string{"http://127.0.0.1:54321/callback"},
+		ClientType:   "public",
+		CreatedVia:   "dcr",
+	}
+	if err := s.RegisterClient(context.Background(), c); err != nil {
+		t.Fatal(err)
+	}
+	return c.ClientID
+}
+
+// ────────────────────────── token prefix shape ──────────────────────────
+
+func TestIDGenerators_HaveCorrectPrefixesAndLengths(t *testing.T) {
+	cases := []struct {
+		name    string
+		got     string
+		prefix  string
+		hexLen  int
+	}{
+		{"client_id", oauth.NewClientID(), "mcp_", 12},
+		{"auth_code", oauth.NewAuthCode(), "oace_", 32},
+		{"access_token", oauth.NewAccessToken(), "ate2a_", 32},
+		{"refresh_token", oauth.NewRefreshToken(), "rte2a_", 32},
+		{"chain_id", oauth.NewChainID(), "rch_", 24},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if !strings.HasPrefix(c.got, c.prefix) {
+				t.Fatalf("expected prefix %q, got %q", c.prefix, c.got)
+			}
+			rest := strings.TrimPrefix(c.got, c.prefix)
+			if len(rest) != c.hexLen {
+				t.Fatalf("expected %d hex chars after prefix, got %d (%q)", c.hexLen, len(rest), rest)
+			}
+		})
+	}
+}
+
+func TestIDGenerators_AreUnique(t *testing.T) {
+	// 1000 generations should never collide given 128-bit entropy.
+	seen := make(map[string]bool, 1000)
+	for i := 0; i < 1000; i++ {
+		id := oauth.NewAccessToken()
+		if seen[id] {
+			t.Fatalf("collision after %d iterations: %s", i, id)
+		}
+		seen[id] = true
+	}
+}
+
+// ────────────────────────── clients ──────────────────────────
+
+func TestRegisterClient_PublicAndRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+	store := oauth.NewStore(pool)
+
+	c := &oauth.Client{
+		ClientID:     oauth.NewClientID(),
+		ClientName:   "Claude Code",
+		RedirectURIs: []string{"http://127.0.0.1:54321/callback"},
+		ClientType:   "public",
+		Metadata:     json.RawMessage(`{"software_id":"claude-code"}`),
+		CreatedVia:   "dcr",
+	}
+	if err := store.RegisterClient(ctx, c); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.GetClient(ctx, c.ClientID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ClientName != "Claude Code" || got.ClientType != "public" {
+		t.Errorf("round-trip mismatch: %+v", got)
+	}
+	if len(got.RedirectURIs) != 1 || got.RedirectURIs[0] != "http://127.0.0.1:54321/callback" {
+		t.Errorf("redirect_uris: %v", got.RedirectURIs)
+	}
+	if got.ClientSecretHash != "" {
+		t.Errorf("public client should have empty secret hash, got %q", got.ClientSecretHash)
+	}
+}
+
+func TestRegisterClient_Confidential(t *testing.T) {
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+	store := oauth.NewStore(pool)
+
+	c := &oauth.Client{
+		ClientID:         oauth.NewClientID(),
+		ClientName:       "admin-tool",
+		RedirectURIs:     []string{"https://internal.example.com/cb"},
+		ClientType:       "confidential",
+		ClientSecretHash: "argon2id$v=19$m=65536$saltsalt$hash",
+		CreatedVia:       "admin",
+	}
+	if err := store.RegisterClient(ctx, c); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.GetClient(ctx, c.ClientID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ClientSecretHash != c.ClientSecretHash {
+		t.Errorf("secret hash round-trip mismatch")
+	}
+	if got.CreatedVia != "admin" {
+		t.Errorf("created_via: %q", got.CreatedVia)
+	}
+}
+
+func TestGetClient_NotFound(t *testing.T) {
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+	store := oauth.NewStore(pool)
+
+	_, err := store.GetClient(ctx, "mcp_nonexistent")
+	if !errors.Is(err, oauth.ErrClientNotFound) {
+		t.Fatalf("expected ErrClientNotFound, got %v", err)
+	}
+}
+
+// ────────────────────────── authorization codes ──────────────────────────
+
+func TestAtomicConsumeCode_FreshExchange(t *testing.T) {
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+	store := oauth.NewStore(pool)
+	idStore := identity.NewStore(pool)
+	clientID := seedClient(t, store)
+	userID := seedUser(t, idStore)
+
+	code := oauth.NewAuthCode()
+	if err := store.IssueCode(ctx, &oauth.AuthorizationCode{
+		Code:                code,
+		ClientID:            clientID,
+		UserID:              userID,
+		AgentEmail:          "bot@agents.e2a.dev",
+		RedirectURI:         "http://127.0.0.1:54321/callback",
+		CodeChallenge:       "challenge-value",
+		CodeChallengeMethod: "S256",
+		Scope:               "e2a",
+		ExpiresAt:           time.Now().Add(60 * time.Second),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, result, err := store.AtomicConsumeCode(ctx, code)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != oauth.ConsumeFresh {
+		t.Fatalf("expected ConsumeFresh, got %v", result)
+	}
+	if got.ClientID != clientID || got.UserID != userID {
+		t.Errorf("returned code has wrong owner")
+	}
+	if got.ConsumedAt == nil {
+		t.Errorf("ConsumedAt should be set on fresh consume")
+	}
+}
+
+func TestAtomicConsumeCode_AlreadyConsumed(t *testing.T) {
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+	store := oauth.NewStore(pool)
+	idStore := identity.NewStore(pool)
+	clientID := seedClient(t, store)
+	userID := seedUser(t, idStore)
+
+	code := oauth.NewAuthCode()
+	if err := store.IssueCode(ctx, &oauth.AuthorizationCode{
+		Code: code, ClientID: clientID, UserID: userID,
+		RedirectURI: "http://127.0.0.1:54321/callback",
+		CodeChallenge: "x", CodeChallengeMethod: "S256",
+		Scope: "e2a", ExpiresAt: time.Now().Add(60 * time.Second),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// First consume: fresh.
+	if _, r, err := store.AtomicConsumeCode(ctx, code); err != nil || r != oauth.ConsumeFresh {
+		t.Fatalf("first consume: r=%v err=%v", r, err)
+	}
+	// Replay: must report already-consumed and still return the row
+	// (caller needs UserID + ClientID to revoke downstream tokens).
+	got, r, err := store.AtomicConsumeCode(ctx, code)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r != oauth.ConsumeAlreadyConsumed {
+		t.Fatalf("replay: expected ConsumeAlreadyConsumed, got %v", r)
+	}
+	if got == nil || got.ClientID != clientID || got.UserID != userID {
+		t.Errorf("replay should return the row data for downstream revocation")
+	}
+}
+
+func TestAtomicConsumeCode_Expired(t *testing.T) {
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+	store := oauth.NewStore(pool)
+	idStore := identity.NewStore(pool)
+	clientID := seedClient(t, store)
+	userID := seedUser(t, idStore)
+
+	code := oauth.NewAuthCode()
+	if err := store.IssueCode(ctx, &oauth.AuthorizationCode{
+		Code: code, ClientID: clientID, UserID: userID,
+		RedirectURI: "http://127.0.0.1:54321/callback",
+		CodeChallenge: "x", CodeChallengeMethod: "S256",
+		Scope: "e2a", ExpiresAt: time.Now().Add(-1 * time.Second),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, r, err := store.AtomicConsumeCode(ctx, code)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r != oauth.ConsumeExpired {
+		t.Fatalf("expected ConsumeExpired, got %v", r)
+	}
+}
+
+func TestAtomicConsumeCode_NotFound(t *testing.T) {
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+	store := oauth.NewStore(pool)
+	_, r, err := store.AtomicConsumeCode(ctx, "oace_doesnotexist")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r != oauth.ConsumeNotFound {
+		t.Fatalf("expected ConsumeNotFound, got %v", r)
+	}
+}
+
+// ────────────────────────── tokens ──────────────────────────
+
+func newTestToken(clientID, userID string) *oauth.Token {
+	now := time.Now()
+	refreshExp := now.Add(oauth.RefreshTokenLifetime)
+	return &oauth.Token{
+		AccessToken:      oauth.NewAccessToken(),
+		RefreshToken:     oauth.NewRefreshToken(),
+		RefreshChainID:   oauth.NewChainID(),
+		ClientID:         clientID,
+		UserID:           userID,
+		AgentEmail:       "bot@agents.e2a.dev",
+		Scope:            "e2a",
+		ExpiresAt:        now.Add(oauth.AccessTokenLifetime),
+		RefreshExpiresAt: &refreshExp,
+	}
+}
+
+func TestIssueTokenAndLookupByAccess(t *testing.T) {
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+	store := oauth.NewStore(pool)
+	idStore := identity.NewStore(pool)
+	clientID := seedClient(t, store)
+	userID := seedUser(t, idStore)
+
+	tok := newTestToken(clientID, userID)
+	if err := store.IssueToken(ctx, tok); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.LookupTokenByAccess(ctx, tok.AccessToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AccessToken != tok.AccessToken || got.RefreshToken != tok.RefreshToken {
+		t.Errorf("round-trip mismatch")
+	}
+	if got.AgentEmail != "bot@agents.e2a.dev" {
+		t.Errorf("agent_email: %q", got.AgentEmail)
+	}
+	if !got.IsActive(time.Now()) {
+		t.Errorf("freshly-issued token should be active")
+	}
+}
+
+func TestLookupTokenByAccess_NotFound(t *testing.T) {
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+	store := oauth.NewStore(pool)
+	_, err := store.LookupTokenByAccess(ctx, "ate2a_doesnotexist")
+	if !errors.Is(err, oauth.ErrTokenNotFound) {
+		t.Fatalf("expected ErrTokenNotFound, got %v", err)
+	}
+}
+
+func TestLookupTokenByRefresh_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+	store := oauth.NewStore(pool)
+	idStore := identity.NewStore(pool)
+	clientID := seedClient(t, store)
+	userID := seedUser(t, idStore)
+
+	tok := newTestToken(clientID, userID)
+	if err := store.IssueToken(ctx, tok); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.LookupTokenByRefresh(ctx, tok.RefreshToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AccessToken != tok.AccessToken {
+		t.Errorf("refresh→access round-trip mismatch")
+	}
+}
+
+func TestRotateRefreshToken_HappyPath(t *testing.T) {
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+	store := oauth.NewStore(pool)
+	idStore := identity.NewStore(pool)
+	clientID := seedClient(t, store)
+	userID := seedUser(t, idStore)
+
+	old := newTestToken(clientID, userID)
+	if err := store.IssueToken(ctx, old); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	refreshExp := now.Add(oauth.RefreshTokenLifetime)
+	fresh := &oauth.Token{
+		AccessToken:      oauth.NewAccessToken(),
+		RefreshToken:     oauth.NewRefreshToken(),
+		RefreshChainID:   old.RefreshChainID, // same chain — that's the invariant
+		ClientID:         clientID,
+		UserID:           userID,
+		AgentEmail:       old.AgentEmail,
+		Scope:            old.Scope,
+		ExpiresAt:        now.Add(oauth.AccessTokenLifetime),
+		RefreshExpiresAt: &refreshExp,
+	}
+	if err := store.RotateRefreshToken(ctx, old.RefreshToken, fresh); err != nil {
+		t.Fatal(err)
+	}
+
+	// The old refresh_token should now be NULL — looking it up by
+	// refresh returns ErrTokenNotFound.
+	if _, err := store.LookupTokenByRefresh(ctx, old.RefreshToken); !errors.Is(err, oauth.ErrTokenNotFound) {
+		t.Errorf("old refresh should be invalidated, got %v", err)
+	}
+	// The new refresh works.
+	if _, err := store.LookupTokenByRefresh(ctx, fresh.RefreshToken); err != nil {
+		t.Errorf("new refresh should be live: %v", err)
+	}
+	// The OLD access token is still active (it's the old session
+	// still doing its work; rotation only affects refresh, not access).
+	old2, err := store.LookupTokenByAccess(ctx, old.AccessToken)
+	if err != nil || !old2.IsActive(now) {
+		t.Errorf("old access should remain active until its own expiry")
+	}
+}
+
+func TestRotateRefreshToken_ReusedRefreshReturnsErrTokenNotFound(t *testing.T) {
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+	store := oauth.NewStore(pool)
+	idStore := identity.NewStore(pool)
+	clientID := seedClient(t, store)
+	userID := seedUser(t, idStore)
+
+	old := newTestToken(clientID, userID)
+	if err := store.IssueToken(ctx, old); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+	refreshExp := now.Add(oauth.RefreshTokenLifetime)
+	// First rotation: success.
+	rot1 := &oauth.Token{
+		AccessToken: oauth.NewAccessToken(), RefreshToken: oauth.NewRefreshToken(),
+		RefreshChainID: old.RefreshChainID, ClientID: clientID, UserID: userID,
+		Scope: "e2a", ExpiresAt: now.Add(time.Hour), RefreshExpiresAt: &refreshExp,
+	}
+	if err := store.RotateRefreshToken(ctx, old.RefreshToken, rot1); err != nil {
+		t.Fatalf("first rotate: %v", err)
+	}
+
+	// Attacker (or buggy client) replays the OLD refresh token.
+	// Expected: rotation fails with ErrTokenNotFound. The /token
+	// endpoint then revokes the entire chain.
+	rot2 := &oauth.Token{
+		AccessToken: oauth.NewAccessToken(), RefreshToken: oauth.NewRefreshToken(),
+		RefreshChainID: old.RefreshChainID, ClientID: clientID, UserID: userID,
+		Scope: "e2a", ExpiresAt: now.Add(time.Hour), RefreshExpiresAt: &refreshExp,
+	}
+	err := store.RotateRefreshToken(ctx, old.RefreshToken, rot2)
+	if !errors.Is(err, oauth.ErrTokenNotFound) {
+		t.Fatalf("expected ErrTokenNotFound on reused refresh, got %v", err)
+	}
+}
+
+func TestRevokeToken(t *testing.T) {
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+	store := oauth.NewStore(pool)
+	idStore := identity.NewStore(pool)
+	clientID := seedClient(t, store)
+	userID := seedUser(t, idStore)
+
+	tok := newTestToken(clientID, userID)
+	if err := store.IssueToken(ctx, tok); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.RevokeToken(ctx, tok.AccessToken); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := store.LookupTokenByAccess(ctx, tok.AccessToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.RevokedAt == nil {
+		t.Errorf("revoked_at should be set")
+	}
+	if got.IsActive(time.Now()) {
+		t.Errorf("revoked token should not be active")
+	}
+	// Refresh is NULLed on revoke, so refresh-grant on it returns
+	// ErrTokenNotFound (the right surface for a revoked refresh).
+	if _, err := store.LookupTokenByRefresh(ctx, tok.RefreshToken); !errors.Is(err, oauth.ErrTokenNotFound) {
+		t.Errorf("refresh on revoked token: expected ErrTokenNotFound, got %v", err)
+	}
+}
+
+func TestRevokeChainByID(t *testing.T) {
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+	store := oauth.NewStore(pool)
+	idStore := identity.NewStore(pool)
+	clientID := seedClient(t, store)
+	userID := seedUser(t, idStore)
+
+	// Two rotations in the same chain → 3 tokens total.
+	t0 := newTestToken(clientID, userID)
+	if err := store.IssueToken(ctx, t0); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now()
+	refreshExp := now.Add(oauth.RefreshTokenLifetime)
+	t1 := &oauth.Token{
+		AccessToken: oauth.NewAccessToken(), RefreshToken: oauth.NewRefreshToken(),
+		RefreshChainID: t0.RefreshChainID, ClientID: clientID, UserID: userID,
+		Scope: "e2a", ExpiresAt: now.Add(time.Hour), RefreshExpiresAt: &refreshExp,
+	}
+	if err := store.RotateRefreshToken(ctx, t0.RefreshToken, t1); err != nil {
+		t.Fatal(err)
+	}
+	t2 := &oauth.Token{
+		AccessToken: oauth.NewAccessToken(), RefreshToken: oauth.NewRefreshToken(),
+		RefreshChainID: t0.RefreshChainID, ClientID: clientID, UserID: userID,
+		Scope: "e2a", ExpiresAt: now.Add(time.Hour), RefreshExpiresAt: &refreshExp,
+	}
+	if err := store.RotateRefreshToken(ctx, t1.RefreshToken, t2); err != nil {
+		t.Fatal(err)
+	}
+
+	// All three rows live in the same chain. RevokeChainByID hits them all.
+	n, err := store.RevokeChainByID(ctx, t0.RefreshChainID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 3 {
+		t.Fatalf("expected 3 rows revoked (the whole chain), got %d", n)
+	}
+
+	// Lookup any chain member: revoked_at set, IsActive false.
+	for _, ax := range []string{t0.AccessToken, t1.AccessToken, t2.AccessToken} {
+		got, err := store.LookupTokenByAccess(ctx, ax)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.RevokedAt == nil || got.IsActive(time.Now()) {
+			t.Errorf("chain member %s should be revoked", ax)
+		}
+	}
+}
+
+func TestRevokeAllByClientUser(t *testing.T) {
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+	store := oauth.NewStore(pool)
+	idStore := identity.NewStore(pool)
+	clientID := seedClient(t, store)
+	userID := seedUser(t, idStore)
+	// A SECOND client+user pair that should be unaffected.
+	otherClient := seedClient(t, store)
+	otherUser := seedUser(t, idStore)
+
+	// Two tokens in different chains for the target pair.
+	target1 := newTestToken(clientID, userID)
+	target2 := newTestToken(clientID, userID)
+	other := newTestToken(otherClient, otherUser)
+	for _, tt := range []*oauth.Token{target1, target2, other} {
+		if err := store.IssueToken(ctx, tt); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	n, err := store.RevokeAllByClientUser(ctx, clientID, userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 2 {
+		t.Fatalf("expected 2 rows revoked, got %d", n)
+	}
+
+	// The other pair's token is untouched.
+	got, err := store.LookupTokenByAccess(ctx, other.AccessToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.RevokedAt != nil {
+		t.Errorf("unrelated token should not be revoked")
+	}
+}
+
+// TestLookupToken_ExpiredButNotRevoked confirms a token past its
+// access expires_at returns the row (not ErrTokenNotFound). The
+// caller's IsActive() check is what decides serve-or-reject.
+func TestLookupToken_ExpiredButNotRevoked(t *testing.T) {
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+	store := oauth.NewStore(pool)
+	idStore := identity.NewStore(pool)
+	clientID := seedClient(t, store)
+	userID := seedUser(t, idStore)
+
+	now := time.Now()
+	refreshExp := now.Add(oauth.RefreshTokenLifetime)
+	tok := &oauth.Token{
+		AccessToken: oauth.NewAccessToken(), RefreshToken: oauth.NewRefreshToken(),
+		RefreshChainID: oauth.NewChainID(), ClientID: clientID, UserID: userID,
+		Scope: "e2a", ExpiresAt: now.Add(-1 * time.Minute), // expired
+		RefreshExpiresAt: &refreshExp,
+	}
+	if err := store.IssueToken(ctx, tok); err != nil {
+		t.Fatal(err)
+	}
+	got, err := store.LookupTokenByAccess(ctx, tok.AccessToken)
+	if err != nil {
+		t.Fatalf("expired token should still be looked up (caller decides): %v", err)
+	}
+	if got.IsActive(time.Now()) {
+		t.Errorf("expired token should report IsActive=false")
+	}
+	if got.RevokedAt != nil {
+		t.Errorf("expired (not revoked) should have RevokedAt nil")
+	}
+}
+
+// TestUserCascade ensures FK CASCADE on user deletion takes tokens
+// with it — defends against orphaned auth state after user deletion.
+func TestUserCascade_TokensAndCodesDeletedWithUser(t *testing.T) {
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+	store := oauth.NewStore(pool)
+	idStore := identity.NewStore(pool)
+	clientID := seedClient(t, store)
+	userID := seedUser(t, idStore)
+
+	tok := newTestToken(clientID, userID)
+	if err := store.IssueToken(ctx, tok); err != nil {
+		t.Fatal(err)
+	}
+	code := oauth.NewAuthCode()
+	if err := store.IssueCode(ctx, &oauth.AuthorizationCode{
+		Code: code, ClientID: clientID, UserID: userID,
+		RedirectURI: "http://127.0.0.1:54321/cb",
+		CodeChallenge: "x", CodeChallengeMethod: "S256",
+		Scope: "e2a", ExpiresAt: time.Now().Add(60 * time.Second),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Direct cascade-triggering DELETE on the users table. This is what
+	// identity.DeleteUser does internally; we test the FK shape here.
+	if _, err := pool.Exec(ctx, "DELETE FROM users WHERE id = $1", userID); err != nil {
+		t.Fatal(err)
+	}
+
+	// Both rows should be gone via ON DELETE CASCADE.
+	if _, err := store.LookupTokenByAccess(ctx, tok.AccessToken); !errors.Is(err, oauth.ErrTokenNotFound) {
+		t.Errorf("token should be cascade-deleted with user, got %v", err)
+	}
+	var n int
+	if err := pool.QueryRow(ctx, "SELECT COUNT(*) FROM oauth_authorization_codes WHERE code = $1", code).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Errorf("auth code should be cascade-deleted with user, got count=%d", n)
+	}
+}

--- a/internal/oauth/store_test.go
+++ b/internal/oauth/store_test.go
@@ -291,6 +291,74 @@ func newTestToken(clientID, userID string) *oauth.Token {
 	}
 }
 
+// TestIssueToken_StoresHashNotPlaintext is the regression guard for the
+// at-rest hashing fix. We issue a token, then query the raw column
+// directly and confirm:
+//   - the access_token_hash column equals SHA-256(plaintext)
+//   - the access_token_hash column does NOT equal the plaintext itself
+//   - same for refresh_token_hash
+//   - there is no column named "access_token" or "refresh_token" we can
+//     still query for the plaintext (defense against a partial schema
+//     migration)
+//
+// If anyone reverts the store to write plaintext, or adds a debug
+// column that does, this test fails loud.
+func TestIssueToken_StoresHashNotPlaintext(t *testing.T) {
+	ctx := context.Background()
+	pool := testutil.TestDB(t)
+	store := oauth.NewStore(pool)
+	idStore := identity.NewStore(pool)
+	clientID := seedClient(t, store)
+	userID := seedUser(t, idStore)
+
+	tok := newTestToken(clientID, userID)
+	if err := store.IssueToken(ctx, tok); err != nil {
+		t.Fatal(err)
+	}
+
+	var storedAccessHash, storedRefreshHash string
+	err := pool.QueryRow(ctx, `
+		SELECT access_token_hash, refresh_token_hash
+		FROM oauth_tokens
+		WHERE refresh_chain_id = $1
+	`, tok.RefreshChainID).Scan(&storedAccessHash, &storedRefreshHash)
+	if err != nil {
+		t.Fatalf("raw query: %v", err)
+	}
+
+	wantAccessHash := oauth.HashToken(tok.AccessToken)
+	if storedAccessHash != wantAccessHash {
+		t.Errorf("access_token_hash mismatch: want %q, got %q", wantAccessHash, storedAccessHash)
+	}
+	if storedAccessHash == tok.AccessToken {
+		t.Error("FAIL: access_token_hash column contains the plaintext token (should be SHA-256 hex)")
+	}
+	if strings.HasPrefix(storedAccessHash, oauth.AccessTokenPrefix) {
+		t.Errorf("access_token_hash should not have the bearer prefix: got %q", storedAccessHash)
+	}
+
+	wantRefreshHash := oauth.HashToken(tok.RefreshToken)
+	if storedRefreshHash != wantRefreshHash {
+		t.Errorf("refresh_token_hash mismatch: want %q, got %q", wantRefreshHash, storedRefreshHash)
+	}
+	if storedRefreshHash == tok.RefreshToken {
+		t.Error("FAIL: refresh_token_hash column contains the plaintext token (should be SHA-256 hex)")
+	}
+
+	// Defense against partial migration: the old plaintext columns must
+	// not exist. Querying them should fail with a "column does not
+	// exist" error from Postgres.
+	var dummy string
+	err = pool.QueryRow(ctx, `SELECT access_token FROM oauth_tokens LIMIT 1`).Scan(&dummy)
+	if err == nil {
+		t.Error("FAIL: access_token column still exists — plaintext fallback present")
+	}
+	err = pool.QueryRow(ctx, `SELECT refresh_token FROM oauth_tokens LIMIT 1`).Scan(&dummy)
+	if err == nil {
+		t.Error("FAIL: refresh_token column still exists — plaintext fallback present")
+	}
+}
+
 func TestIssueTokenAndLookupByAccess(t *testing.T) {
 	ctx := context.Background()
 	pool := testutil.TestDB(t)
@@ -308,8 +376,16 @@ func TestIssueTokenAndLookupByAccess(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.AccessToken != tok.AccessToken || got.RefreshToken != tok.RefreshToken {
-		t.Errorf("round-trip mismatch")
+	// Plaintext access token is reconstructed from the lookup input
+	// (we hash it for the WHERE; the column stores only the hash).
+	if got.AccessToken != tok.AccessToken {
+		t.Errorf("AccessToken should round-trip via input: want %q, got %q", tok.AccessToken, got.AccessToken)
+	}
+	// Refresh-token plaintext is NOT recoverable from a by-access
+	// lookup — we don't store it. Confirm it's empty so callers don't
+	// accidentally treat a stale field as a live credential.
+	if got.RefreshToken != "" {
+		t.Errorf("RefreshToken must NOT be populated on LookupTokenByAccess (cannot reconstruct from hash): got %q", got.RefreshToken)
 	}
 	if got.AgentEmail != "bot@agents.e2a.dev" {
 		t.Errorf("agent_email: %q", got.AgentEmail)
@@ -346,8 +422,20 @@ func TestLookupTokenByRefresh_RoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.AccessToken != tok.AccessToken {
-		t.Errorf("refresh→access round-trip mismatch")
+	// Refresh-token plaintext round-trips via input (we hashed it for
+	// the WHERE). Access-token plaintext is NOT recoverable from this
+	// lookup path; verify the field is empty so a future caller that
+	// reads got.AccessToken doesn't quietly authenticate as nothing.
+	if got.RefreshToken != tok.RefreshToken {
+		t.Errorf("RefreshToken should round-trip via input: want %q, got %q", tok.RefreshToken, got.RefreshToken)
+	}
+	if got.AccessToken != "" {
+		t.Errorf("AccessToken must NOT be populated on LookupTokenByRefresh: got %q", got.AccessToken)
+	}
+	// The non-credential fields (chain, client, user) MUST round-trip
+	// since handlers depend on them for the refresh-grant decision.
+	if got.RefreshChainID != tok.RefreshChainID {
+		t.Errorf("RefreshChainID round-trip: want %q, got %q", tok.RefreshChainID, got.RefreshChainID)
 	}
 }
 

--- a/migrations/006_oauth.sql
+++ b/migrations/006_oauth.sql
@@ -1,0 +1,94 @@
+-- OAuth 2.1 schema for the MCP authorization layer.
+--
+-- Per .claude/design/mcp-system.md §4.3. Three tables, all idempotent:
+--
+--   oauth_clients               — registered OAuth clients (Claude Code, Cursor,
+--                                  Cline, etc.). Public via Dynamic Client
+--                                  Registration (RFC 7591) or admin-curated.
+--   oauth_authorization_codes   — one-shot codes minted at consent and
+--                                  exchanged at /api/oauth/token. 60s lifetime.
+--   oauth_tokens                — access + refresh tokens. Access ~1h, refresh
+--                                  ~30d. refresh_chain_id groups rotations so
+--                                  refresh-token reuse triggers chain-wide
+--                                  revocation per RFC 6749 §10.4.
+--
+-- Token format conventions (enforced in application code, not DB):
+--   client_id      = 'mcp_'   + nanoid(12)
+--   code           = 'oace_'  + hex(32)
+--   access_token   = 'ate2a_' + hex(32)
+--   refresh_token  = 'rte2a_' + hex(32)
+--
+-- All FKs CASCADE on user_id / client_id deletion: tokens die with their owner.
+
+CREATE TABLE IF NOT EXISTS oauth_clients (
+    client_id            TEXT PRIMARY KEY,
+    client_name          TEXT NOT NULL,
+    redirect_uris        TEXT[] NOT NULL,
+    client_type          TEXT NOT NULL CHECK (client_type IN ('public', 'confidential')),
+    -- Null for public clients (PKCE-only authentication). Stored as a
+    -- hash, never plaintext, so a DB leak can't reveal client secrets
+    -- (which authenticate at /api/oauth/token).
+    client_secret_hash   TEXT,
+    metadata             JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_via          TEXT NOT NULL CHECK (created_via IN ('dcr', 'admin'))
+);
+
+CREATE TABLE IF NOT EXISTS oauth_authorization_codes (
+    code                    TEXT PRIMARY KEY,
+    client_id               TEXT NOT NULL REFERENCES oauth_clients(client_id) ON DELETE CASCADE,
+    user_id                 TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    -- Selected by the user on the consent screen; null when the
+    -- user has zero agents and declined auto-create.
+    agent_email             TEXT,
+    redirect_uri            TEXT NOT NULL,
+    code_challenge          TEXT NOT NULL,
+    code_challenge_method   TEXT NOT NULL CHECK (code_challenge_method = 'S256'),
+    scope                   TEXT NOT NULL,
+    expires_at              TIMESTAMPTZ NOT NULL,
+    -- Single-use: set to NOW() on first successful exchange at
+    -- /api/oauth/token. A second exchange attempt sees consumed_at
+    -- IS NOT NULL and triggers token-chain revocation (defense in
+    -- depth against replay attacks).
+    consumed_at             TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS oauth_codes_user ON oauth_authorization_codes(user_id);
+
+CREATE TABLE IF NOT EXISTS oauth_tokens (
+    access_token         TEXT PRIMARY KEY,
+    -- Unique when present; null after rotation (a refresh-grant
+    -- invalidates the previous refresh_token by NULLing it out).
+    refresh_token        TEXT UNIQUE,
+    -- Groups all access/refresh tokens in a rotation chain so reuse
+    -- of an old refresh_token can revoke every sibling at once.
+    refresh_chain_id     TEXT NOT NULL,
+    client_id            TEXT NOT NULL REFERENCES oauth_clients(client_id) ON DELETE CASCADE,
+    user_id              TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    -- Pinned default agent inbox for this connection. Tool calls
+    -- can override per-call; this is the fallback.
+    agent_email          TEXT,
+    scope                TEXT NOT NULL,
+    expires_at           TIMESTAMPTZ NOT NULL,
+    refresh_expires_at   TIMESTAMPTZ,
+    revoked_at           TIMESTAMPTZ,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Hot path: validate Bearer token for an API request.
+-- Partial index because revoked tokens are dead weight in the index.
+CREATE INDEX IF NOT EXISTS oauth_tokens_user_active
+    ON oauth_tokens(user_id) WHERE revoked_at IS NULL;
+
+-- Refresh-grant lookup: find by refresh_token.
+-- Partial because rotated rows have refresh_token = NULL.
+CREATE INDEX IF NOT EXISTS oauth_tokens_refresh
+    ON oauth_tokens(refresh_token) WHERE refresh_token IS NOT NULL;
+
+-- "List my OAuth connections" query — per (client, user) pair.
+CREATE INDEX IF NOT EXISTS oauth_tokens_client
+    ON oauth_tokens(client_id, user_id);
+
+-- Chain-wide revocation: find every sibling of a rotated token.
+CREATE INDEX IF NOT EXISTS oauth_tokens_chain
+    ON oauth_tokens(refresh_chain_id);

--- a/migrations/006_oauth.sql
+++ b/migrations/006_oauth.sql
@@ -42,7 +42,15 @@ CREATE TABLE IF NOT EXISTS oauth_clients (
     client_secret_hash   TEXT,
     metadata             JSONB NOT NULL DEFAULT '{}'::jsonb,
     created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    created_via          TEXT NOT NULL CHECK (created_via IN ('dcr', 'admin'))
+    created_via          TEXT NOT NULL CHECK (created_via IN ('dcr', 'admin')),
+    -- Optional attribution to a registering user. NULL for DCR
+    -- registrations (anonymous per RFC 7591 §2) and for admin-
+    -- curated rows where no user-of-record is meaningful. When a
+    -- referenced user is deleted, this clears to NULL — the client
+    -- row persists because client_ids are shared across users
+    -- (Claude Code's client_id is the same for every user who's
+    -- authorized it).
+    created_by_user_id   TEXT REFERENCES users(id) ON DELETE SET NULL
 );
 
 CREATE TABLE IF NOT EXISTS oauth_authorization_codes (

--- a/migrations/006_oauth.sql
+++ b/migrations/006_oauth.sql
@@ -15,8 +15,19 @@
 -- Token format conventions (enforced in application code, not DB):
 --   client_id      = 'mcp_'   + nanoid(12)
 --   code           = 'oace_'  + hex(32)
---   access_token   = 'ate2a_' + hex(32)
---   refresh_token  = 'rte2a_' + hex(32)
+--   access_token   = 'ate2a_' + hex(32)  — plaintext returned ONCE at issuance; DB stores SHA-256 hex.
+--   refresh_token  = 'rte2a_' + hex(32)  — same.
+--
+-- Tokens are STORED HASHED (SHA-256 hex of the plaintext). A DB read
+-- (replica leak, backup exfil, SQL injection in any other package
+-- against this DB) therefore yields no usable bearer credentials —
+-- the attacker would need to break SHA-256 preimage on a 128-bit
+-- input space. The plaintext is only ever in memory while the
+-- issuance response is being written; we never log it.
+--
+-- This matches the existing api_keys.key_hash pattern (see
+-- internal/identity/store.go:hashAPIKey). Lookups compute SHA-256
+-- of the candidate bearer in Go and query by the hash column.
 --
 -- All FKs CASCADE on user_id / client_id deletion: tokens die with their owner.
 
@@ -56,10 +67,13 @@ CREATE TABLE IF NOT EXISTS oauth_authorization_codes (
 CREATE INDEX IF NOT EXISTS oauth_codes_user ON oauth_authorization_codes(user_id);
 
 CREATE TABLE IF NOT EXISTS oauth_tokens (
-    access_token         TEXT PRIMARY KEY,
-    -- Unique when present; null after rotation (a refresh-grant
-    -- invalidates the previous refresh_token by NULLing it out).
-    refresh_token        TEXT UNIQUE,
+    -- SHA-256 hex of the plaintext access_token. Lookups compute the
+    -- hash in Go and query by it; the plaintext never lands on disk.
+    access_token_hash    TEXT PRIMARY KEY,
+    -- SHA-256 hex of the plaintext refresh_token. Unique when present;
+    -- null after rotation (a refresh-grant invalidates the previous
+    -- refresh_token by NULLing the hash column out).
+    refresh_token_hash   TEXT UNIQUE,
     -- Groups all access/refresh tokens in a rotation chain so reuse
     -- of an old refresh_token can revoke every sibling at once.
     refresh_chain_id     TEXT NOT NULL,
@@ -80,10 +94,10 @@ CREATE TABLE IF NOT EXISTS oauth_tokens (
 CREATE INDEX IF NOT EXISTS oauth_tokens_user_active
     ON oauth_tokens(user_id) WHERE revoked_at IS NULL;
 
--- Refresh-grant lookup: find by refresh_token.
--- Partial because rotated rows have refresh_token = NULL.
+-- Refresh-grant lookup: find by refresh_token_hash.
+-- Partial because rotated rows have refresh_token_hash = NULL.
 CREATE INDEX IF NOT EXISTS oauth_tokens_refresh
-    ON oauth_tokens(refresh_token) WHERE refresh_token IS NOT NULL;
+    ON oauth_tokens(refresh_token_hash) WHERE refresh_token_hash IS NOT NULL;
 
 -- "List my OAuth connections" query — per (client, user) pair.
 CREATE INDEX IF NOT EXISTS oauth_tokens_client


### PR DESCRIPTION
## Summary

Complete OAuth 2.1 authorization-server backend for e2a — the foundation for browser-flow auth on `mcp.e2a.dev` so users don't paste API keys.

All 6 RFC endpoints land here. Consent UI (web/) is PR B.

## Endpoints

| Method | Path | RFC |
| --- | --- | --- |
| GET | `/.well-known/oauth-authorization-server` | 8414 (discovery) |
| POST | `/api/oauth/register` | 7591 (DCR — public clients only) |
| GET | `/api/oauth/authorize` | 6749 §4.1.1 |
| POST | `/api/oauth/consent` | 6749 §4.1.2 (with slug override) |
| POST | `/api/oauth/token` | 6749 §4.1.3 + §6 (PKCE-S256) |
| POST | `/api/oauth/revoke` | 7009 |

Token prefixes: `mcp_` client_id · `oace_` auth_code (60s, one-shot) · `ate2a_` access token (1h) · `rte2a_` refresh token (30d, rotating) · `rch_` chain id.

## Security posture

- **PKCE mandatory** — discovery advertises S256 only; `/authorize` rejects missing `code_challenge`; `/token` constant-time-compares the recomputed challenge.
- **Auth-code reuse (§10.5)** — `AtomicConsumeCode` returns `ConsumeAlreadyConsumed` on replay; `/token` then revokes every token for the `(client_id, user_id)` pair.
- **Refresh rotation (§10.4)** — single-use refresh; client_id mismatch or revoked/expired row burns the entire `refresh_chain_id`.
- **redirect_uri** — exact-string match against the registered set; never inferred from request headers; fragments rejected.
- **Issuer URL** — derived only from `http.public_url`; discovery returns 404 when unset rather than emit proxy-spoofable URLs.
- **DCR rate limit** — 10/IP/hour for anonymous registrations.
- **CSRF on consent POST** — session cookie is `SameSite=Lax`, so cross-origin POSTs don't carry it.

## Bearer dispatch

`authenticateUser` already (since `cd676fb`) routes `ate2a_`-prefixed bearers to the OAuth store and falls back to API-key lookup for everything else. Existing API keys keep working unchanged.

## Slug override

Per the original design discussion: the consent form's `new_agent_slug` is free-text, validated server-side. No auto-merge with a default — when blank we apply `{slug(client_name)}-{6hex}`; otherwise we use the user's value verbatim. Collision → 409 invalid_request; UI will pre-check.

## Test plan

- [x] Discovery (4 tests) — happy + no-store/no-publicURL 404 + trailing-slash normalization
- [x] DCR (14 tests) — defaults, redirect_uri validator table, rejected schemes/grants/scopes/methods, IP limit shape
- [x] Authorize + Consent (24 tests) — param shape, redirect_uri binding, session redirect, slug override, slug collision 409, agent-ownership check, deny redirect, tamper resistance
- [x] Token (17 tests) — PKCE happy/mismatch, code reuse revokes downstream tokens, refresh rotation, refresh-reuse, client_id mismatch nukes chain
- [x] Revoke (10 tests) — access + refresh (chain cascade), wrong hint, no hint, unknown token 200, idempotent, client mismatch 400
- [x] Existing auth tests (8) — API-key path unaffected
- [x] Full `go test ./internal/agent/ ./internal/oauth/ -p 1` passes

## Deferred / follow-ups

- `return_to` after Google login (currently lands on `/dashboard`; PR B)
- Confidential clients (discovery advertises `none` only)
- Chain revocation on _rotated_ refresh replay (needs index on rotated values; current store NULLs the column so lookup misses)
- Audit columns: who issued, when, from which IP

🤖 Generated with [Claude Code](https://claude.com/claude-code)