### PR TITLE
feat(mcp): single-agent default at session init

### DIFF
--- a/mcp/src/http-server.ts
+++ b/mcp/src/http-server.ts
@@ -41,8 +41,13 @@ export interface HttpServerOptions {
   /**
    * Test seam: override how the per-session E2AClient is built. The
    * default constructs `new E2AClient({ apiKey: bearer, baseUrl })`.
+   *
+   * The optional second arg carries the agent_email resolved by the
+   * single-agent prefetch (see {@link buildSessionClient}). Tests that
+   * want to exercise the prefetch path can pass it through to their
+   * stub; tests that only care about the bearer can ignore it.
    */
-  clientFactory?: (bearer: string) => E2AClient;
+  clientFactory?: (bearer: string, opts?: { agentEmail?: string }) => E2AClient;
 }
 
 interface BuiltApp {
@@ -195,9 +200,7 @@ async function handleClientRequest(
   }
 
   if (!entry && isInitializeRequest(req.body)) {
-    const client = opts.clientFactory
-      ? opts.clientFactory(bearer)
-      : new E2AClient({ apiKey: bearer, baseUrl: opts.baseUrl });
+    const client = await buildSessionClient(opts, bearer);
     const server = buildServer({ client });
     const bearerFp = fingerprintBearer(bearer);
     const transport = new StreamableHTTPServerTransport({
@@ -289,6 +292,66 @@ async function handleStreamingOrDelete(
     return;
   }
   await entry.transport.handleRequest(req, res);
+}
+
+/**
+ * Construct the per-session E2AClient, opportunistically resolving a
+ * default agent_email when the user has exactly one agent.
+ *
+ * Why this lives here and not in the SDK: the SDK is a thin contract
+ * shared by CLI, browser, server, and Python users — auto-resolving an
+ * agent on construction would be too magical for those callers. The
+ * MCP transport, on the other hand, has a clear notion of "session
+ * init": one prefetch per session is cheap and lets every subsequent
+ * tool call dispatch without forcing the LLM (or the user) to pass
+ * agent_email explicitly. The OAuth grant already binds the user to
+ * one agent at consent, so for the dominant single-agent case the
+ * default is unambiguous.
+ *
+ * Resolution order (highest precedence first):
+ *   1. `E2A_AGENT_EMAIL` env var (constructor reads it into agentEmail).
+ *   2. listAgents() yields exactly one agent — use it.
+ *   3. Otherwise leave agentEmail empty. Tools that take an optional
+ *      agent_email arg keep their existing fall-back behavior
+ *      (whoami's manual single-agent resolution, error with hint
+ *      otherwise).
+ *
+ * listAgents failures are swallowed: a transient backend hiccup
+ * shouldn't break MCP initialize. Worst case, the user sees the same
+ * "agentEmail is required" error they'd see today.
+ */
+export async function buildSessionClient(
+  opts: HttpServerOptions,
+  bearer: string,
+): Promise<E2AClient> {
+  const make = (agentEmail?: string): E2AClient => {
+    if (opts.clientFactory) {
+      // Preserve the no-arg-factory shape for callers (and tests) that
+      // don't care about the resolved email. Pass the email through
+      // only when we actually have one.
+      return agentEmail
+        ? opts.clientFactory(bearer, { agentEmail })
+        : opts.clientFactory(bearer);
+    }
+    return new E2AClient({ apiKey: bearer, baseUrl: opts.baseUrl, agentEmail });
+  };
+
+  const client = make();
+  // Env-var path already populated agentEmail — operator opted in
+  // explicitly, don't second-guess them with an API call.
+  if (client.agentEmail) return client;
+
+  let resolved: string | undefined;
+  try {
+    const { agents } = await client.listAgents();
+    if (Array.isArray(agents) && agents.length === 1) {
+      resolved = agents[0]?.email;
+    }
+  } catch {
+    // Best-effort. Multi-agent / zero-agent / network-failed all land
+    // here and leave agentEmail empty.
+  }
+  return resolved ? make(resolved) : client;
 }
 
 function extractBearer(req: Request): string | null {

--- a/mcp/tests/http.test.ts
+++ b/mcp/tests/http.test.ts
@@ -218,6 +218,138 @@ describe("HTTP MCP server", () => {
     await transport.close();
   });
 
+  describe("session-init agent prefetch", () => {
+    // The prefetch resolves a default agent_email at session-init when
+    // (a) E2A_AGENT_EMAIL is unset on the constructed client, and
+    // (b) listAgents() yields exactly one agent.
+    // We drive it via clientFactory so we can stub listAgents and
+    // observe whether the resolved email gets passed back through.
+
+    function makeProbeClient(opts: {
+      initialEmail?: string;
+      agents: Array<{ email: string }>;
+      listAgentsThrows?: boolean;
+    }): E2AClient {
+      return {
+        agentEmail: opts.initialEmail ?? "",
+        api: {},
+        send: vi.fn(),
+        reply: vi.fn(),
+        listMessages: vi.fn(async () => ({ messages: [] })),
+        listAgents: vi.fn(async () => {
+          if (opts.listAgentsThrows) throw new Error("upstream 500");
+          return { agents: opts.agents };
+        }),
+        registerAgent: vi.fn(),
+        listPendingMessages: vi.fn(async () => ({ messages: [] })),
+        getPendingMessage: vi.fn(),
+        approveMessage: vi.fn(),
+        rejectMessage: vi.fn(),
+      } as unknown as E2AClient;
+    }
+
+    it("resolves agent_email when listAgents returns exactly one agent", async () => {
+      const probe = makeProbeClient({ agents: [{ email: "solo@bot.example.com" }] });
+      const final = makeProbeClient({
+        initialEmail: "solo@bot.example.com",
+        agents: [{ email: "solo@bot.example.com" }],
+      });
+      const factory = vi.fn((_bearer: string, factoryOpts?: { agentEmail?: string }) =>
+        factoryOpts?.agentEmail ? final : probe,
+      );
+
+      await close();
+      const { close: c, port } = await startHttpServer(0, {
+        baseUrl: "http://e2a.local",
+        allowedHosts: ["127.0.0.1", "localhost"],
+        clientFactory: factory,
+      });
+      close = c;
+      url = `http://127.0.0.1:${port}/mcp`;
+
+      const { transport } = await connect();
+      // Factory called twice: probe construction (no agentEmail), then
+      // final construction with the resolved email.
+      expect(factory).toHaveBeenCalledTimes(2);
+      expect(factory.mock.calls[0]).toEqual(["e2a_test"]);
+      expect(factory.mock.calls[1]).toEqual([
+        "e2a_test",
+        { agentEmail: "solo@bot.example.com" },
+      ]);
+      expect(probe.listAgents).toHaveBeenCalledOnce();
+      await transport.close();
+    });
+
+    it("skips the listAgents probe when agentEmail is already set", async () => {
+      // Stub from beforeEach already has agentEmail "bot@example.com".
+      const factory = vi.fn(() => stub);
+      await close();
+      const { close: c, port } = await startHttpServer(0, {
+        baseUrl: "http://e2a.local",
+        allowedHosts: ["127.0.0.1", "localhost"],
+        clientFactory: factory,
+      });
+      close = c;
+      url = `http://127.0.0.1:${port}/mcp`;
+
+      const { transport } = await connect();
+      // Factory called once with just the bearer — no resolved email
+      // since the env-var path (constructor) already populated it.
+      expect(factory).toHaveBeenCalledTimes(1);
+      expect(factory.mock.calls[0]).toEqual(["e2a_test"]);
+      // And listAgents was NOT invoked as a probe at session init.
+      expect(stub.listAgents).not.toHaveBeenCalled();
+      await transport.close();
+    });
+
+    it("leaves agentEmail empty when the account has multiple agents", async () => {
+      const probe = makeProbeClient({
+        agents: [
+          { email: "a@bot.example.com" },
+          { email: "b@bot.example.com" },
+        ],
+      });
+      const factory = vi.fn(() => probe);
+      await close();
+      const { close: c, port } = await startHttpServer(0, {
+        baseUrl: "http://e2a.local",
+        allowedHosts: ["127.0.0.1", "localhost"],
+        clientFactory: factory,
+      });
+      close = c;
+      url = `http://127.0.0.1:${port}/mcp`;
+
+      const { transport } = await connect();
+      // Factory called exactly once — probe ran, but no resolution
+      // (>1 agent), so the second construction was skipped.
+      expect(factory).toHaveBeenCalledTimes(1);
+      expect(probe.listAgents).toHaveBeenCalledOnce();
+      await transport.close();
+    });
+
+    it("does not block session init when listAgents throws", async () => {
+      const probe = makeProbeClient({ agents: [], listAgentsThrows: true });
+      const factory = vi.fn(() => probe);
+      await close();
+      const { close: c, port } = await startHttpServer(0, {
+        baseUrl: "http://e2a.local",
+        allowedHosts: ["127.0.0.1", "localhost"],
+        clientFactory: factory,
+      });
+      close = c;
+      url = `http://127.0.0.1:${port}/mcp`;
+
+      // Initialize should succeed even though the prefetch errored.
+      const { client, transport } = await connect();
+      const { tools } = await client.listTools();
+      expect(tools.length).toBeGreaterThan(0);
+      expect(probe.listAgents).toHaveBeenCalledOnce();
+      // No re-construction since resolution failed.
+      expect(factory).toHaveBeenCalledTimes(1);
+      await transport.close();
+    });
+  });
+
   it("forwards Bearer transparently to the per-session E2AClient", async () => {
     // The factory we passed receives the bearer string. We can assert it
     // gets exactly what the client sent without any rewriting.


### PR DESCRIPTION
## Summary

End-to-end test against the freshly-deployed hosted MCP surfaced friction: every message-scoped tool (`list_messages`, `get_message`, `send_email`, `reply_to_message`, …) errored `"agentEmail is required"` when called without an explicit `agent_email`, even though the user had exactly one agent and had just authorized that agent at OAuth consent. Only `whoami` worked, because it carries its own inline `listAgents()` resolution.

This hoists `whoami`'s resolution to **session-init time**. On `isInitializeRequest`, if the constructed `E2AClient` has no `agentEmail` (env var unset — the dominant hosted-OAuth case), the MCP server calls `listAgents()` once; if the user has exactly one agent, the client is rebuilt with that email pinned. Every subsequent tool call in the session sees a populated `client.agentEmail` and the SDK's per-call `requireEmail()` returns it instead of throwing.

## Resolution order (highest precedence first)

1. `E2A_AGENT_EMAIL` env var — constructor populates `agentEmail`; operator opted in, don't second-guess
2. `listAgents()` yields exactly one agent → use it
3. Otherwise leave empty — multi-agent users keep today's UX (pass explicitly or rely on `whoami`'s resolution)

## Scope of change

- **Zero backend change** — agent_email already lives in `oauth_access_tokens.request` JSONB via `oauth.Session`, but exposing it requires a new endpoint. Deferred.
- **Zero schema change**
- **Zero SDK change** — `E2AClient.agentEmail` stays `readonly`; we just rebuild the instance with the resolved email
- Pure MCP server change: 71 lines added in `http-server.ts`, 132 lines of tests in `http.test.ts`

## Why not the OAuth-grant binding approach?

It's the right shape for multi-agent users (read `session.AgentEmail` from the bound grant — already persisted, just no API to expose it). But we have zero multi-agent OAuth users today, and that path needs a backend endpoint, auth-middleware refactor to thread session-on-context, and an MCP-side preflight call. **YAGNI for the actual reported problem.** Filed as a follow-up if a multi-agent OAuth user ever surfaces friction.

## Failure handling

`listAgents()` errors are swallowed; session init proceeds with empty `agentEmail`. A transient backend hiccup shouldn't break MCP initialize — worst case the user sees the same `"agentEmail is required"` error they'd see today.

## Test plan

- [x] Unit: resolves agent_email when listAgents returns exactly one agent (factory called twice, second call carries the resolved email)
- [x] Unit: skips the listAgents probe when agentEmail is already set (env var path; factory called once)
- [x] Unit: leaves agentEmail empty when the account has multiple agents (factory called once, no rebuild)
- [x] Unit: does not block session init when listAgents throws (initialize still completes, tools listable)
- [x] All 84 existing MCP tests still pass
- [x] `npx tsc --noEmit` clean
- [ ] After merge + npm publish (`mcp-v0.3.1`) + prod deploy: end-to-end smoke against hosted `mcp.e2a.dev` — `list_messages` succeeds without explicit `agent_email`

🤖 Generated with [Claude Code](https://claude.com/claude-code)