### PR TITLE
feat(migrate): add usage_events indexes for hosted analytics views

### DIFF
--- a/migrations/009_usage_events_user_created_idx.sql
+++ b/migrations/009_usage_events_user_created_idx.sql
@@ -1,0 +1,22 @@
+-- 009_usage_events_user_created_idx.sql
+-- e2a:no-transaction
+--
+-- Index supporting per-user time-range scans of usage_events. Powers
+-- the EXISTS checks in the hosted v_signup_funnel view and any future
+-- per-user activity queries. Leading column is user_id so the index
+-- also serves queries that filter on user_id alone.
+--
+-- CREATE INDEX CONCURRENTLY so the index build does not block writes
+-- on self-hosters with sizeable usage_events tables. The runner's
+-- e2a:no-transaction directive (see internal/identity/migrate.go) skips
+-- the BeginTx wrapper for this file — required because Postgres
+-- rejects CONCURRENTLY inside a transaction. Single-statement only
+-- per the runner's contract.
+--
+-- Idempotent via IF NOT EXISTS. On a fresh DB the table will be small
+-- and the build is near-instant; on hosted prod (data since 2026-04-25
+-- when usage tracking was enabled) the table is still small as of
+-- this migration.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_usage_events_user_created
+    ON usage_events (user_id, created_at);

--- a/migrations/010_usage_events_created_idx.sql
+++ b/migrations/010_usage_events_created_idx.sql
@@ -1,0 +1,18 @@
+-- 010_usage_events_created_idx.sql
+-- e2a:no-transaction
+--
+-- Index supporting global time-range scans of usage_events. Powers
+-- the hosted v_top_agents_7d view (filters by created_at, then groups
+-- by agent_id) and any "events in the last N days" query that isn't
+-- already served by usage_summaries' (user_id, bucket_date) PK.
+--
+-- Why a separate index from 009: that one's leading column is user_id,
+-- so it can't serve a query that filters created_at alone — Postgres
+-- would full-scan. A dedicated (created_at) index closes that gap.
+--
+-- CREATE INDEX CONCURRENTLY per the same reasoning as 009. Split into
+-- its own file because the runner requires single-statement migrations
+-- under the e2a:no-transaction directive.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_usage_events_created
+    ON usage_events (created_at);


### PR DESCRIPTION
## Summary
- `009_usage_events_user_created_idx.sql` — `(user_id, created_at)` index for per-user EXISTS scans in the hosted `v_signup_funnel` view (also serves user_id-only filters).
- `010_usage_events_created_idx.sql` — `(created_at)` index for global time-range scans in the hosted `v_top_agents_7d` view. Separate from 009 because Postgres can't use a leading-column-mismatched index for created_at-only filters.

Both use `CREATE INDEX CONCURRENTLY IF NOT EXISTS` with the `e2a:no-transaction` directive so the build doesn't block writes and is safe to re-run. Auto-applies on next binary deploy via the embedded-migration runner.

## Test plan
- [ ] CI green
- [ ] On deploy, confirm both indexes exist in hosted DB: `\d usage_events`
- [ ] Verify `v_signup_funnel` and `v_top_agents_7d` queries use the new indexes (EXPLAIN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)