### PR TITLE
feat(mcp): MCP Registry metadata — mcpName + server.json

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@e2a/mcp-server",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "MCP server for e2a — email for AI agents",
+  "mcpName": "io.github.mnexa-ai/mcp-server",
   "bin": {
     "e2a-mcp": "dist/index.js"
   },

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.mnexa-ai/mcp-server",
+  "title": "e2a — email for AI agents",
+  "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verified.",
+  "websiteUrl": "https://e2a.dev",
+  "repository": {
+    "url": "https://github.com/Mnexa-AI/e2a",
+    "source": "github",
+    "subfolder": "mcp"
+  },
+  "version": "0.3.1",
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "@e2a/mcp-server",
+      "version": "0.3.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "environmentVariables": [
+        {
+          "name": "E2A_API_KEY",
+          "description": "e2a API key from https://e2a.dev",
+          "isRequired": true,
+          "isSecret": true
+        },
+        {
+          "name": "E2A_AGENT_EMAIL",
+          "description": "Default agent inbox (e.g. bot@your-domain.com). Optional — single-agent accounts auto-resolve."
+        },
+        {
+          "name": "E2A_BASE_URL",
+          "description": "Self-hosted e2a backend URL. Defaults to https://e2a.dev.",
+          "default": "https://e2a.dev"
+        }
+      ]
+    }
+  ],
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.e2a.dev/mcp",
+      "headers": [
+        {
+          "name": "Authorization",
+          "description": "Bearer token: accepts an e2a API key (e2a_…) or OAuth 2.1 access token (ate2a_…)",
+          "value": "Bearer {e2a_api_key}",
+          "isRequired": true,
+          "variables": {
+            "e2a_api_key": {
+              "description": "Your e2a API key from https://e2a.dev",
+              "isRequired": true,
+              "isSecret": true
+            }
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Prep for publishing `@e2a/mcp-server` to [the official MCP Registry](https://registry.modelcontextprotocol.io). Two artifacts:

1. **`mcp/package.json`** — adds `mcpName: "io.github.mnexa-ai/mcp-server"`. This is the verification handshake the Registry uses at publish time: it confirms the npm package belongs to the publisher claiming the registry name. The convention `io.github.OWNER/NAME` is required for GitHub-based auth (lowercased per the Registry's namespacing rules). Also bumps version `0.3.0 → 0.3.1` — two fixes merged since the `0.3.0` tag warrant a publish (single-agent prefetch #98 + hosted-MCP example variants #99).

2. **`mcp/server.json`** — the Registry's canonical server descriptor. Lists **both transports in one entry**:
   - `packages[]` → stdio via `@e2a/mcp-server@0.3.1` with three env vars (`E2A_API_KEY` required+secret, optional `E2A_AGENT_EMAIL`, optional `E2A_BASE_URL`)
   - `remotes[]` → `streamable-http` at `https://mcp.e2a.dev/mcp` with `Authorization: Bearer {e2a_api_key}` header (the registry exposes `e2a_api_key` as a user-configurable variable)

Validated against schema [`2025-12-11`](https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json) — passes structural checks, description fits the 100-char limit.

## Publish flow (post-merge, manual step required)

This PR doesn't publish — it lands the metadata. To actually push to the Registry:

```bash
# 1. After merge, tag the release. publish-mcp.yml fires and ships
#    @e2a/mcp-server@0.3.1 to npm with the mcpName field baked in.
git tag mcp-v0.3.1 && git push origin mcp-v0.3.1

# 2. Install the Registry's publisher CLI.
brew install mcp-publisher

# 3. Auth interactively with GitHub OAuth.
mcp-publisher login github

# 4. Publish. Reads ./server.json, verifies that
#    @e2a/mcp-server@0.3.1 on npm has the matching mcpName field,
#    then writes the listing.
cd mcp && mcp-publisher publish
```

## Why this matters

The Registry is the upstream that several downstream catalogs (mcp.directory, Glama, Smithery, mcpmarket) cross-reference. Listing here propagates the npm + hosted info to those catalogs on their next sync, often without separate submissions.

## Test plan

- [x] `mcp/server.json` validates against schema 2025-12-11 (manual jsonschema check)
- [x] `mcp/package.json` still parses; version bump consistent with the npm pipeline
- [ ] After merge + tag + publish: confirm Registry shows e2a at `https://registry.modelcontextprotocol.io/v0/servers/io.github.mnexa-ai/mcp-server`

🤖 Generated with [Claude Code](https://claude.com/claude-code)