### PR TITLE
fix(mcp): preserve GitHub org case in mcpName (Mnexa-AI not mnexa-ai)

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@e2a/mcp-server",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "MCP server for e2a — email for AI agents",
-  "mcpName": "io.github.mnexa-ai/mcp-server",
+  "mcpName": "io.github.Mnexa-AI/mcp-server",
   "bin": {
     "e2a-mcp": "dist/index.js"
   },

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.mnexa-ai/mcp-server",
+  "name": "io.github.Mnexa-AI/mcp-server",
   "title": "e2a — email for AI agents",
   "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verified.",
   "websiteUrl": "https://e2a.dev",
@@ -9,13 +9,13 @@
     "source": "github",
     "subfolder": "mcp"
   },
-  "version": "0.3.1",
+  "version": "0.3.2",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@e2a/mcp-server",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Why

MCP Registry rejected the 0.3.1 publish:

> status 403: You have permission to publish: \`io.github.jiashuoz/*\`, \`io.github.Mnexa-AI/*\`. Attempting to publish: \`io.github.mnexa-ai/mcp-server\`.

The Registry's [publishing guide](https://github.com/modelcontextprotocol/registry/blob/main/docs/modelcontextprotocol-io/quickstart.mdx) lowercases the org name in its example (\`io.github.my-username/...\`), but the actual permission engine is case-sensitive and preserves the canonical GitHub org slug. Our org is \`Mnexa-AI\` (mixed case), so the published name must be \`io.github.Mnexa-AI/mcp-server\`, not what #101 landed.

## What

Two-file diff in both `mcp/package.json` and `mcp/server.json`:
- `mcpName` / `name`: `io.github.mnexa-ai/mcp-server` → `io.github.Mnexa-AI/mcp-server`
- `version` (and `packages[0].version`): `0.3.1` → `0.3.2`

The version bump is necessary because 0.3.1 is already locked on npm with the wrong `mcpName`. Registry verification reads the live npm manifest and would still reject at 0.3.1 even after the typo fix.

## Verification

- ✅ `mcp/server.json` re-validates against schema 2025-12-11 with the new name
- ✅ Three version locations consistent: `package.json`, `server.json:version`, `server.json:packages[0].version`
- ⏳ Registry publish — gated on this PR merging + tag `mcp-v0.3.2` firing publish-mcp.yml

## Post-merge ceremony

```bash
git tag mcp-v0.3.2 && git push origin mcp-v0.3.2
# wait for publish-mcp.yml (~60s)
cd mcp && mcp-publisher publish
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)