### PR TITLE
fix(mcp): validate bearer during initialize

### DIFF
--- a/mcp/src/http-server.ts
+++ b/mcp/src/http-server.ts
@@ -163,6 +163,17 @@ function resourceMetadataURL(req: Request, opts: HttpServerOptions): string {
   return `${base}/.well-known/oauth-protected-resource`;
 }
 
+function bearerChallenge(req: Request, opts: HttpServerOptions): string {
+  return `Bearer realm="e2a", resource_metadata="${resourceMetadataURL(req, opts)}"`;
+}
+
+class InvalidBearerError extends Error {
+  constructor() {
+    super("invalid bearer token");
+    this.name = "InvalidBearerError";
+  }
+}
+
 async function handleClientRequest(
   req: Request,
   res: Response,
@@ -171,10 +182,7 @@ async function handleClientRequest(
 ): Promise<void> {
   const bearer = extractBearer(req);
   if (!bearer) {
-    res.setHeader(
-      "WWW-Authenticate",
-      `Bearer realm="e2a", resource_metadata="${resourceMetadataURL(req, opts)}"`,
-    );
+    res.setHeader("WWW-Authenticate", bearerChallenge(req, opts));
     res.status(401).json(jsonRpcError(req.body, -32001, "missing bearer token"));
     return;
   }
@@ -200,7 +208,20 @@ async function handleClientRequest(
   }
 
   if (!entry && isInitializeRequest(req.body)) {
-    const client = await buildSessionClient(opts, bearer);
+    let client: E2AClient;
+    try {
+      client = await buildSessionClient(opts, bearer);
+    } catch (err) {
+      if (err instanceof InvalidBearerError) {
+        res.setHeader(
+          "WWW-Authenticate",
+          `${bearerChallenge(req, opts)}, error="invalid_token"`,
+        );
+        res.status(401).json(jsonRpcError(req.body, -32001, "invalid bearer token"));
+        return;
+      }
+      throw err;
+    }
     const server = buildServer({ client });
     const bearerFp = fingerprintBearer(bearer);
     const transport = new StreamableHTTPServerTransport({
@@ -259,10 +280,7 @@ async function handleStreamingOrDelete(
   // notification stream or terminate it.
   const bearer = extractBearer(req);
   if (!bearer) {
-    res.setHeader(
-      "WWW-Authenticate",
-      `Bearer realm="e2a", resource_metadata="${resourceMetadataURL(req, opts)}"`,
-    );
+    res.setHeader("WWW-Authenticate", bearerChallenge(req, opts));
     res.status(401).end();
     return;
   }
@@ -337,21 +355,37 @@ export async function buildSessionClient(
   };
 
   const client = make();
-  // Env-var path already populated agentEmail — operator opted in
-  // explicitly, don't second-guess them with an API call.
-  if (client.agentEmail) return client;
-
   let resolved: string | undefined;
   try {
     const { agents } = await client.listAgents();
-    if (Array.isArray(agents) && agents.length === 1) {
+    // Env-var path already populated agentEmail — operator opted in
+    // explicitly, don't second-guess it with auto-resolution.
+    if (!client.agentEmail && Array.isArray(agents) && agents.length === 1) {
       resolved = agents[0]?.email;
     }
-  } catch {
-    // Best-effort. Multi-agent / zero-agent / network-failed all land
-    // here and leave agentEmail empty.
+  } catch (err) {
+    if (isUnauthorizedError(err)) {
+      throw new InvalidBearerError();
+    }
+    // Non-auth failures remain best-effort. A transient backend hiccup
+    // shouldn't break MCP initialize; worst case, the user sees the
+    // same "agentEmail is required" error they'd see today.
   }
   return resolved ? make(resolved) : client;
+}
+
+function isUnauthorizedError(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  const maybe = err as {
+    status?: unknown;
+    statusCode?: unknown;
+    response?: { status?: unknown };
+  };
+  return (
+    maybe.status === 401
+    || maybe.statusCode === 401
+    || maybe.response?.status === 401
+  );
 }
 
 function extractBearer(req: Request): string | null {

--- a/mcp/tests/http.test.ts
+++ b/mcp/tests/http.test.ts
@@ -3,6 +3,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { E2AClient } from "@e2a/sdk/v1";
 import { startHttpServer } from "../src/http-server.js";
+import { Sessions } from "../src/session.js";
 
 // Reuse the same stub shape from tools.test.ts. Only the methods the
 // tools actually call need to be present.
@@ -24,6 +25,12 @@ function makeStubClient(): E2AClient {
     rejectMessage: vi.fn(async () => ({ message_id: "x", status: "rejected" })),
   };
   return stub as unknown as E2AClient;
+}
+
+function makeHttpError(statusCode: number): Error & { statusCode: number } {
+  const err = new Error(`HTTP ${statusCode}`) as Error & { statusCode: number };
+  err.statusCode = statusCode;
+  return err;
 }
 
 describe("HTTP MCP server", () => {
@@ -80,6 +87,50 @@ describe("HTTP MCP server", () => {
     expect(res.headers.get("www-authenticate")).toMatch(/Bearer realm="e2a"/);
     const body = await res.json();
     expect(body.error.message).toMatch(/missing bearer/);
+  });
+
+  it("invalid bearer returns 401 during initialize before session allocation", async () => {
+    await close();
+    const sessions = new Sessions({ idleTimeoutMs: 60_000, maxSessions: 10 });
+    const invalidStub = makeStubClient();
+    invalidStub.listAgents = vi.fn(async () => {
+      throw makeHttpError(401);
+    }) as E2AClient["listAgents"];
+    const { close: c, port } = await startHttpServer(0, {
+      baseUrl: "http://e2a.local",
+      allowedHosts: ["127.0.0.1", "localhost"],
+      clientFactory: () => invalidStub,
+      sessions,
+    });
+    close = c;
+    url = `http://127.0.0.1:${port}/mcp`;
+
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        Authorization: "Bearer bogus_token",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "x", version: "0" },
+        },
+      }),
+    });
+
+    expect(res.status).toBe(401);
+    expect(res.headers.get("www-authenticate")).toMatch(/Bearer realm="e2a"/);
+    expect(res.headers.get("mcp-session-id")).toBeNull();
+    expect(sessions.size()).toBe(0);
+    expect(invalidStub.listAgents).toHaveBeenCalledOnce();
+    const body = await res.json();
+    expect(body.error.message).toMatch(/invalid bearer/);
   });
 
   it("rejects requests that present a known session-id with a different bearer", async () => {
@@ -280,7 +331,7 @@ describe("HTTP MCP server", () => {
       await transport.close();
     });
 
-    it("skips the listAgents probe when agentEmail is already set", async () => {
+    it("validates the bearer but skips reconstruction when agentEmail is already set", async () => {
       // Stub from beforeEach already has agentEmail "bot@example.com".
       const factory = vi.fn(() => stub);
       await close();
@@ -297,8 +348,9 @@ describe("HTTP MCP server", () => {
       // since the env-var path (constructor) already populated it.
       expect(factory).toHaveBeenCalledTimes(1);
       expect(factory.mock.calls[0]).toEqual(["e2a_test"]);
-      // And listAgents was NOT invoked as a probe at session init.
-      expect(stub.listAgents).not.toHaveBeenCalled();
+      // listAgents still validates the bearer once at session init,
+      // but does not trigger a second construction for auto-resolution.
+      expect(stub.listAgents).toHaveBeenCalledOnce();
       await transport.close();
     });
 
@@ -370,6 +422,7 @@ describe("HTTP MCP server", () => {
 
   it("tool call dispatches to the per-session client", async () => {
     const { client, transport } = await connect();
+    vi.mocked(stub.listAgents).mockClear();
     await client.callTool({ name: "list_agents", arguments: {} });
     expect(stub.listAgents).toHaveBeenCalledOnce();
     await transport.close();

--- a/mcp/tests/http.test.ts
+++ b/mcp/tests/http.test.ts
@@ -125,7 +125,9 @@ describe("HTTP MCP server", () => {
     });
 
     expect(res.status).toBe(401);
-    expect(res.headers.get("www-authenticate")).toMatch(/Bearer realm="e2a"/);
+    expect(res.headers.get("www-authenticate")).toMatch(
+      /Bearer realm="e2a", .*error="invalid_token"/,
+    );
     expect(res.headers.get("mcp-session-id")).toBeNull();
     expect(sessions.size()).toBe(0);
     expect(invalidStub.listAgents).toHaveBeenCalledOnce();


### PR DESCRIPTION
## Summary

Hi, I am an AI agent helping with the MCP auth/session issue described in #102.

This PR validates the bearer during MCP `initialize` before session allocation, so a bogus non-empty bearer no longer receives a successful initialize response or an `Mcp-Session-Id`.

Changes:
- reuse a `WWW-Authenticate` bearer challenge helper across MCP auth failures
- detect 401-style SDK/backend errors during session client construction
- return `401` + `WWW-Authenticate` for invalid bearers during `initialize`
- keep non-auth `listAgents()` failures best-effort so transient backend hiccups do not block initialize
- add a regression proving invalid bearer initialize does not allocate a session or issue `Mcp-Session-Id`
- update the existing agent-email test to reflect that `listAgents()` now validates the bearer while still avoiding client reconstruction when `agentEmail` is already set

Addresses #102.

## Verification

The local environment routes HTTP through a proxy by default, so MCP loopback tests need `NO_PROXY=127.0.0.1,localhost`.

- `npm_config_cache=/tmp/npm-cache-e2a-102 npm --workspace sdks/typescript run build`
- `NO_PROXY=127.0.0.1,localhost npm_config_cache=/tmp/npm-cache-e2a-102 npm --workspace mcp test -- tests/http.test.ts`
- `NO_PROXY=127.0.0.1,localhost npm_config_cache=/tmp/npm-cache-e2a-102 npm --workspace mcp test`
- `npm_config_cache=/tmp/npm-cache-e2a-102 npm --workspace mcp run build`
- `git diff --check`

Note: the first plain `npm install` attempt failed because the local user npm cache had root-owned files. I reran with `npm_config_cache=/tmp/npm-cache-e2a-102`; no lockfile changes are included.
