### PR TITLE
fix(hitl): gate self-sends through HITL approval

### DIFF
--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -231,7 +231,7 @@ func main() {
 	// HITL expiration worker: transitions pending_approval messages that
 	// blew past their TTL into expired_approved (auto-send) or
 	// expired_rejected based on the owning agent's hitl_expiration_action.
-	hitlWorker := hitlworker.New(store, sender, usageTracker)
+	hitlWorker := hitlworker.New(store, sender, usageTracker, cfg.OutboundSMTP.FromDomain)
 	hitlCtx, hitlCancel := context.WithCancel(context.Background())
 	go func() {
 		if err := hitlWorker.Run(hitlCtx); err != nil && err != context.Canceled {

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -1169,12 +1169,14 @@ func (a *API) handleSendEmail(w http.ResponseWriter, r *http.Request) {
 
 	selfSend := isSelfSend(req, agent.EmailAddress())
 
-	// HITL is intentionally bypassed for self-sends. Holding a "note
-	// to self" for approval is degenerate UX — the reviewer and the
-	// author are the same identity, and the approval magic-link would
-	// be a no-op confirmation. External recipients still flow through
-	// HITL normally.
-	if agent.HITLEnabled && !selfSend {
+	// HITL applies to self-sends too — the gate is "did a human
+	// review this outbound message" regardless of recipient. The
+	// approval-finalize path (see hitl_api.go / hitl_magic_api.go)
+	// detects the self-send shape on the held message and routes
+	// the delivery through the loopback short-circuit instead of
+	// outbound.Sender, which would otherwise strip the agent's own
+	// address from the recipient list and error.
+	if agent.HITLEnabled {
 		a.holdForApproval(w, r, agent, req, "send", "")
 		return
 	}
@@ -1446,10 +1448,11 @@ func (a *API) handleReplyToMessage(w http.ResponseWriter, r *http.Request) {
 	sendReq.BCC = stripAgentSelfAliases(sendReq.BCC, agent.EmailAddress())
 	selfReply := isSelfSend(sendReq, agent.EmailAddress())
 
-	// HITL on a self-reply is bypassed for the same reason it's
-	// bypassed on a self-send (see selfsend.go docstring): holding
-	// a self-note for the agent to approve to itself is degenerate.
-	if agent.HITLEnabled && !selfReply {
+	// HITL applies to self-replies for the same reason as self-sends:
+	// a reviewer-in-the-loop gate doesn't care whether the recipient
+	// is external or the agent itself. The approval finalizer routes
+	// the held reply through loopback when it's a self-reply.
+	if agent.HITLEnabled {
 		a.holdForApproval(w, r, agent, sendReq, "reply", inbound.EmailMessageID)
 		return
 	}

--- a/internal/agent/hitl_api.go
+++ b/internal/agent/hitl_api.go
@@ -277,6 +277,14 @@ func (a *API) handleApprovePendingMessage(w http.ResponseWriter, r *http.Request
 				return identity.SendResult{}, err
 			}
 			attachReferencesChain(r.Context(), a.store, agent.ID, &sendReq)
+			// Self-sends bypass the SMTP relay — outbound.Sender would
+			// strip the agent's own address from the recipient list and
+			// error "no valid recipients". Loopback writes the inbound
+			// row directly and reports method=loopback on the now-sent
+			// outbound row, matching the non-HITL self-send shape.
+			if isSelfSend(sendReq, agent.EmailAddress()) {
+				return a.selfSendApprovalDelivery(r.Context(), agent, sendReq)
+			}
 			result, err := a.sender.Send(agent, sendReq)
 			if err != nil {
 				return identity.SendResult{}, err

--- a/internal/agent/hitl_api_test.go
+++ b/internal/agent/hitl_api_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -343,5 +344,89 @@ func TestSendTestEmailHITLGate(t *testing.T) {
 	}
 	if len(toR) != 1 || toR[0] != agent.EmailAddress() {
 		t.Errorf("to_recipients = %v, want [%s]", toR, agent.EmailAddress())
+	}
+}
+
+// TestSendTestEmailHITLApproveDeliversViaLoopback: the original
+// production repro for PR #109. With HITL on, the Test email button
+// holds a self-send; clicking approve via the dashboard endpoint must
+// finalize via loopback. Before the fix this errored with
+// "no valid recipients" because the approval finalizer routed through
+// outbound.Sender.Send, which strips the agent's own address.
+func TestSendTestEmailHITLApproveDeliversViaLoopback(t *testing.T) {
+	server, store, pool, smtpDone := setupAPIWithSMTP(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "owner-hitl-test-approve@example.com", "Owner", "google-hitl-test-approve")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "hitl-test-approve-key")
+	store.ClaimOrCreateDomain(ctx, "hitl-test-approve.example.com", user.ID)
+	store.VerifyDomain(ctx, "hitl-test-approve.example.com", user.ID)
+	agent, _ := store.CreateAgent(ctx, "bot@hitl-test-approve.example.com", "hitl-test-approve.example.com", "", "https://example.com/webhook", "", user.ID)
+	enableHITL(t, store, agent.ID, user.ID)
+
+	// Step 1: click Test → held for approval.
+	testReq, _ := http.NewRequest("POST", server.URL+"/api/v1/agents/bot@hitl-test-approve.example.com/test", nil)
+	testReq.Header.Set("Authorization", "Bearer "+apiKey.PlaintextKey)
+	testResp, err := http.DefaultClient.Do(testReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer testResp.Body.Close()
+	if testResp.StatusCode != http.StatusAccepted {
+		t.Fatalf("test hold status = %d, want 202", testResp.StatusCode)
+	}
+	var holdBody struct {
+		Status    string `json:"status"`
+		MessageID string `json:"message_id"`
+	}
+	if err := json.NewDecoder(testResp.Body).Decode(&holdBody); err != nil {
+		t.Fatal(err)
+	}
+	if holdBody.MessageID == "" {
+		t.Fatal("hold response missing message_id")
+	}
+
+	// Step 2: approve via the dashboard endpoint.
+	approveReq, _ := http.NewRequest("POST", server.URL+"/api/v1/messages/"+holdBody.MessageID+"/approve", bytes.NewBufferString(`{}`))
+	approveReq.Header.Set("Authorization", "Bearer "+apiKey.PlaintextKey)
+	approveReq.Header.Set("Content-Type", "application/json")
+	approveResp, err := http.DefaultClient.Do(approveReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer approveResp.Body.Close()
+	if approveResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(approveResp.Body)
+		t.Fatalf("approve status = %d, want 200; body=%s", approveResp.StatusCode, body)
+	}
+	var approveBody map[string]interface{}
+	json.NewDecoder(approveResp.Body).Decode(&approveBody)
+	if approveBody["method"] != "loopback" {
+		t.Errorf("approve method = %v, want loopback", approveBody["method"])
+	}
+
+	// Loopback path → no SMTP traffic at all.
+	if msgs := smtpDone(); len(msgs) != 0 {
+		t.Fatalf("self-send test-email approve must not hit SMTP, got %d messages", len(msgs))
+	}
+
+	// Outbound row → sent + loopback; inbound row landed in the agent's mailbox.
+	var status, method string
+	pool.QueryRow(ctx,
+		`SELECT status, method FROM messages WHERE id=$1`, holdBody.MessageID,
+	).Scan(&status, &method)
+	if status != identity.MessageStatusSent {
+		t.Errorf("outbound status = %q, want sent", status)
+	}
+	if method != "loopback" {
+		t.Errorf("outbound method = %q, want loopback", method)
+	}
+
+	var inboundCount int
+	pool.QueryRow(ctx,
+		`SELECT count(*) FROM messages WHERE agent_id=$1 AND direction='inbound' AND subject='Test email from e2a'`,
+		agent.ID).Scan(&inboundCount)
+	if inboundCount != 1 {
+		t.Errorf("inbound rows = %d, want 1", inboundCount)
 	}
 }

--- a/internal/agent/hitl_magic_api.go
+++ b/internal/agent/hitl_magic_api.go
@@ -222,6 +222,12 @@ func (a *API) magicApprove(w http.ResponseWriter, r *http.Request, messageID, us
 				return identity.SendResult{}, err
 			}
 			attachReferencesChain(r.Context(), a.store, agent.ID, &sendReq)
+			// Self-sends (including the Test email button) deliver via
+			// loopback — see the dashboard-approve branch in hitl_api.go
+			// for the rationale; both paths must stay symmetric.
+			if isSelfSend(sendReq, agent.EmailAddress()) {
+				return a.selfSendApprovalDelivery(r.Context(), agent, sendReq)
+			}
 			result, err := a.sender.Send(agent, sendReq)
 			if err != nil {
 				return identity.SendResult{}, err

--- a/internal/agent/hitl_magic_api_test.go
+++ b/internal/agent/hitl_magic_api_test.go
@@ -235,6 +235,68 @@ func TestMagicApprovePOSTSends(t *testing.T) {
 	}
 }
 
+// TestMagicApprovePOSTSelfSendDeliversViaLoopback: approving a held
+// self-send via the magic-link path must route through loopback —
+// outbound.Sender.Send would strip the agent's own address (self-spam
+// guard) and fail with "no valid recipients". Asserts no SMTP traffic,
+// outbound row → sent+loopback, inbound row landed.
+func TestMagicApprovePOSTSelfSendDeliversViaLoopback(t *testing.T) {
+	server, store, signer, smtpDone := setupMagicLinkAPI(t)
+	a, userID := prepareHITLAgent(t, store, "post-approve-self")
+
+	// Hold a self-send (To = agent's own address).
+	ctx := context.Background()
+	held, err := store.CreatePendingOutboundMessage(ctx, a.ID,
+		[]string{a.EmailAddress()}, nil, nil,
+		"self-magic", "note to self via magic link", "", nil,
+		"send", "", "", 3600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tok, _ := signer.Sign(held.ID, approvaltoken.ActionApprove, time.Now().Add(1*time.Hour))
+	resp := postForm(t, server.URL+"/api/v1/approve", map[string]string{"t": tok})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("POST approve (self-send): status = %d, body: %s", resp.StatusCode, readBody(t, resp))
+	}
+	if body := readBody(t, resp); !strings.Contains(body, "Approved") {
+		t.Errorf("expected 'Approved' on the result page, got: %s", body)
+	}
+
+	if msgs := smtpDone(); len(msgs) != 0 {
+		t.Fatalf("self-send approve must not hit SMTP, got %d messages", len(msgs))
+	}
+
+	got, _ := store.GetOutboundMessageForUser(ctx, held.ID, userID)
+	if got.Status != identity.MessageStatusSent {
+		t.Errorf("outbound status = %q, want sent", got.Status)
+	}
+	if got.Method != "loopback" {
+		t.Errorf("method = %q, want loopback", got.Method)
+	}
+
+	// Inbound row reaches the agent's mailbox. GetMessagesByAgent's
+	// "all" status returns inbound rows regardless of read state.
+	inboxes, err := store.GetMessagesByAgent(ctx, a.ID, "all", 10, time.Time{}, "")
+	if err != nil {
+		t.Fatalf("GetMessagesByAgent: %v", err)
+	}
+	if len(inboxes) != 1 || inboxes[0].Subject != "self-magic" {
+		t.Errorf("inbound rows = %d, subjects = %v; want one row 'self-magic'", len(inboxes), subjectsOf(inboxes))
+	}
+}
+
+// subjectsOf is a small helper to keep error messages readable when an
+// inbox-shape assertion fails.
+func subjectsOf(msgs []identity.Message) []string {
+	out := make([]string, len(msgs))
+	for i, m := range msgs {
+		out[i] = m.Subject
+	}
+	return out
+}
+
 func TestMagicRejectPOSTWithReason(t *testing.T) {
 	server, store, signer, smtpDone := setupMagicLinkAPI(t)
 	a, userID := prepareHITLAgent(t, store, "post-reject")

--- a/internal/agent/selfsend.go
+++ b/internal/agent/selfsend.go
@@ -73,8 +73,10 @@ func stripAgentSelfAliases(addrs []string, agentEmail string) []string {
 //
 // Notable behavior choices (documented because they diverge from a
 // pure-SMTP send):
-//   - HITL is bypassed before this function is called. Holding a
-//     self-note for approval is degenerate UX.
+//   - This is the non-HITL fast path. The HITL-gated counterpart
+//     (selfSendApprovalDelivery) writes ONLY the inbound row; the
+//     outbound row already exists from holdForApproval and gets
+//     updated to status=sent by ApproveAndSend.
 //   - Webhook + WebSocket delivery are intentionally NOT fired on the
 //     inbound row. Cloud-mode agents whose webhook handler is what
 //     triggered the self-send would otherwise re-enter their own code
@@ -231,6 +233,56 @@ func composeLoopbackMIME(
 		time.Now().UTC().Format(time.RFC1123Z),
 	)
 	return append([]byte(received), msg...), nil
+}
+
+// selfSendApprovalDelivery is the HITL-gated counterpart of performSelfSend:
+// it writes ONLY the inbound row and returns an identity.SendResult shaped
+// for ApproveAndSend's send callback. The pre-existing held outbound row is
+// finalized to status=sent by ApproveAndSend itself using the result's
+// provider_message_id + method columns — calling CreateOutboundMessage here
+// would create a duplicate row and unanchor the operator-visible audit
+// trail (held → sent for a specific row id).
+//
+// Same delivery semantics as performSelfSend: loopback method, synthetic
+// Received: line, no webhook/WS replay. Domain verification is checked
+// upstream at handleSendEmail; the approval finalize trusts the gate it
+// already passed at hold time.
+func (a *API) selfSendApprovalDelivery(
+	ctx context.Context,
+	agent *identity.AgentIdentity,
+	req outbound.SendRequest,
+) (identity.SendResult, error) {
+	providerID := loopbackProviderID(a.fromDomain)
+	email := agent.EmailAddress()
+
+	rawMessage, err := composeLoopbackMIME(agent, req, providerID, a.fromDomain)
+	if err != nil {
+		return identity.SendResult{}, fmt.Errorf("self-send approval compose: %w", err)
+	}
+	if _, err := a.store.CreateInboundMessage(
+		ctx,
+		"",
+		agent.ID,
+		email, // sender
+		email, // recipient (per-delivery target)
+		providerID,
+		req.Subject,
+		req.ConversationID,
+		"unread",
+		rawMessage,
+		nil, // no DKIM/SPF auth headers on a synthetic loopback
+		[]string{email},
+		nil, // cc
+		nil, // reply_to
+	); err != nil {
+		return identity.SendResult{}, fmt.Errorf("self-send approval inbound row: %w", err)
+	}
+
+	return identity.SendResult{
+		ProviderMessageID: providerID,
+		Method:            "loopback",
+		To:                []string{email},
+	}, nil
 }
 
 // loopbackProviderID synthesizes an RFC 5322-shaped Message-ID for the

--- a/internal/agent/selfsend.go
+++ b/internal/agent/selfsend.go
@@ -2,57 +2,23 @@ package agent
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"fmt"
-	"strings"
-	"time"
 
 	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/loopback"
 	"github.com/Mnexa-AI/e2a/internal/outbound"
 )
 
-// isSelfSend reports whether req targets only the sender's own
-// inbox — i.e., the agent is writing a note to itself. Used by
-// handleSendEmail to short-circuit the SMTP path: a round-trip
-// through SES + MX + the local SMTP receiver is wasted work when
-// the destination is local. Returns true only when there's a
-// single To recipient that matches the agent's own address (case-
-// insensitive, trimmed) AND no Cc/Bcc — any mixed/external
-// recipient routes through normal SMTP unchanged.
-//
-// Callers that have CC/BCC carrying agent aliases (e.g. the reply
-// path with replyAll=true on a self-thread, where the original
-// message's CC list already includes the agent) should strip them
-// via stripAgentSelfAliases before checking — outbound.Sender does
-// the same alias-strip downstream as a self-spam guard, so doing
-// it here is purely "see through" the aliases earlier.
+// isSelfSend / stripAgentSelfAliases delegate to internal/loopback so the
+// hitlworker package can share the same predicate logic without an upward
+// import. Kept as unexported aliases here to minimize the diff at every
+// call site and to preserve the existing test export below.
 func isSelfSend(req outbound.SendRequest, agentEmail string) bool {
-	if len(req.CC) != 0 || len(req.BCC) != 0 {
-		return false
-	}
-	if len(req.To) != 1 {
-		return false
-	}
-	return strings.EqualFold(strings.TrimSpace(req.To[0]), agentEmail)
+	return loopback.IsSelfSend(req, agentEmail)
 }
 
-// stripAgentSelfAliases removes case-insensitive, whitespace-trimmed
-// matches of agentEmail from addrs. Used to pre-clean reply
-// recipients so isSelfSend can recognize replyAll-on-a-self-thread
-// as still a self-send. Returns a fresh slice; the input is not
-// mutated.
 func stripAgentSelfAliases(addrs []string, agentEmail string) []string {
-	if len(addrs) == 0 {
-		return addrs
-	}
-	out := make([]string, 0, len(addrs))
-	for _, a := range addrs {
-		if !strings.EqualFold(strings.TrimSpace(a), agentEmail) {
-			out = append(out, a)
-		}
-	}
-	return out
+	return loopback.StripAgentSelfAliases(addrs, agentEmail)
 }
 
 // performSelfSend writes the message as BOTH an outbound row (sender's
@@ -61,33 +27,10 @@ func stripAgentSelfAliases(addrs []string, agentEmail string) []string {
 // list_messages, threading, and downstream tooling don't need any
 // special-casing.
 //
-// The inbound row's raw_message is a full, RFC 5322-conformant MIME
-// message — composed via outbound.ComposeMessageWithAttachments, the
-// same function the real SMTP path uses — and prefixed with one
-// synthetic `Received:` line per RFC 5321 §4.4 documenting that
-// delivery happened via the local loopback rather than over SMTP.
-// Doing the composition here (instead of stashing just the body text)
-// means the SDK's InboundEmail.fromPayload parser finds attachments
-// + body parts naturally; without it, self-sends with attachments
-// would silently drop the attachments on read.
-//
-// Notable behavior choices (documented because they diverge from a
-// pure-SMTP send):
-//   - This is the non-HITL fast path. The HITL-gated counterpart
-//     (selfSendApprovalDelivery) writes ONLY the inbound row; the
-//     outbound row already exists from holdForApproval and gets
-//     updated to status=sent by ApproveAndSend.
-//   - Webhook + WebSocket delivery are intentionally NOT fired on the
-//     inbound row. Cloud-mode agents whose webhook handler is what
-//     triggered the self-send would otherwise re-enter their own code
-//     and loop. Local-mode agents (the common case) pick up the row
-//     via the next list_messages poll, which IS the intended UX.
-//   - Domain verification + rate limit are still enforced upstream;
-//     loopback isn't a backdoor to bypass those gates.
-//   - auth_headers stays NULL on the inbound row: no DKIM/SPF was
-//     actually evaluated because nothing arrived over the wire. The
-//     operator-facing signal "this row didn't come from external mail"
-//     is preserved by that null column.
+// This is the non-HITL fast path. The HITL-gated counterpart
+// (selfSendApprovalDelivery) writes ONLY the inbound row; the outbound
+// row already exists from holdForApproval and gets updated to
+// status=sent by ApproveAndSend.
 //
 // Returns the provider-style message id used for the outbound row.
 // Method on the outbound row is "loopback" so operators can tell the
@@ -97,8 +40,12 @@ func (a *API) performSelfSend(
 	agent *identity.AgentIdentity,
 	req outbound.SendRequest,
 ) (string, error) {
-	providerID := loopbackProviderID(a.fromDomain)
 	email := agent.EmailAddress()
+
+	// Allocate providerID up front so the outbound row and inbound row
+	// reference the same Message-ID — matching the two-row shape an
+	// SMTP roundtrip produces.
+	providerID := loopback.ProviderID(a.fromDomain)
 
 	if _, err := a.store.CreateOutboundMessage(
 		ctx,
@@ -115,26 +62,25 @@ func (a *API) performSelfSend(
 		return "", fmt.Errorf("self-send outbound row: %w", err)
 	}
 
-	rawMessage, err := composeLoopbackMIME(agent, req, providerID, a.fromDomain)
+	rawMessage, err := loopback.ComposeMIME(agent, req, providerID, a.fromDomain)
 	if err != nil {
 		return "", fmt.Errorf("self-send compose: %w", err)
 	}
-
 	if _, err := a.store.CreateInboundMessage(
 		ctx,
-		"", // generate fresh id; mirrors the SMTP path which never reuses outbound ids
+		"",
 		agent.ID,
-		email, // sender
-		email, // recipient (per-delivery target)
+		email,
+		email,
 		providerID,
 		req.Subject,
 		req.ConversationID,
 		"unread",
 		rawMessage,
-		nil, // no DKIM/SPF auth headers on a synthetic loopback
+		nil,
 		[]string{email},
-		nil, // cc
-		nil, // reply_to — empty per CreateInboundMessage docstring ("never silently falls back to sender")
+		nil,
+		nil,
 	); err != nil {
 		return "", fmt.Errorf("self-send inbound row: %w", err)
 	}
@@ -142,160 +88,26 @@ func (a *API) performSelfSend(
 	return providerID, nil
 }
 
-// composeLoopbackMIME builds the RFC 5322 / 2046 message bytes the
-// inbound row will store as raw_message.
-//
-// We delegate to the same composer the real SMTP path uses
-// (outbound.ComposeMessageWithAttachments) so the produced message is
-// byte-equivalent to what an external roundtrip would have generated
-// — same headers, same multipart structure, same attachment encoding.
-// The SDK's InboundEmail.fromPayload → parseRawEmail pipeline then
-// finds body text/html AND attachments without any loopback-specific
-// branch.
-//
-// We prepend ONE synthetic Received: line per RFC 5321 §4.4 ("each
-// time a message is relayed... the receiving SMTP server MUST insert
-// a 'Received:' line"). Mature local-delivery MTAs (sendmail's local
-// mailer, Postfix's local daemon, Exim's local_smtp transport) all
-// add such a line even for same-host delivery; doing the same here
-// keeps stored messages forensically self-documenting. The "loopback"
-// keyword is the searchable signal — `grep "with loopback"` over raw
-// messages finds every self-send.
-func composeLoopbackMIME(
-	agent *identity.AgentIdentity,
-	req outbound.SendRequest,
-	providerID, fromDomain string,
-) ([]byte, error) {
-	email := agent.EmailAddress()
-	headerFrom := fmt.Sprintf("%q <%s>", agent.Name, email)
-	if agent.Name == "" {
-		headerFrom = email
-	}
-
-	var msg []byte
-	var err error
-	if len(req.Attachments) > 0 {
-		msg, err = outbound.ComposeMessageWithAttachments(
-			headerFrom,
-			[]string{email},
-			nil, // cc
-			req.Subject,
-			req.Body,
-			req.HTMLBody,
-			"",  // reply_to_message_id — self-send is never a reply
-			nil, // references
-			fromDomain,
-			"", // reply_to header
-			req.ConversationID,
-			req.Attachments,
-		)
-	} else {
-		// No attachments → simpler single-part path. Lets us keep the
-		// stored MIME small for the common "note to self" case rather
-		// than always emitting a multipart envelope.
-		contentType := "text/plain"
-		body := req.Body
-		if req.HTMLBody != "" {
-			contentType = "text/html"
-			body = req.HTMLBody
-		}
-		msg, err = outbound.ComposeMessage(
-			headerFrom,
-			[]string{email},
-			nil, // cc
-			req.Subject,
-			body,
-			contentType,
-			"",  // reply_to_message_id
-			nil, // references
-			fromDomain,
-			"", // reply_to header
-			req.ConversationID,
-		)
-	}
-	if err != nil {
-		return nil, err
-	}
-
-	// Prepend the synthetic Received: line. CRLF line endings to match
-	// the rest of the MIME message ComposeMessage produces. The "with
-	// loopback" keyword is the canonical local-delivery indicator,
-	// mirroring sendmail's "with local" and Postfix's "with LMTP".
-	host := fromDomain
-	if host == "" {
-		host = "e2a.local"
-	}
-	received := fmt.Sprintf(
-		"Received: by %s (e2a) with loopback id %s for <%s>;\r\n\t%s\r\n",
-		host,
-		providerID,
-		email,
-		time.Now().UTC().Format(time.RFC1123Z),
-	)
-	return append([]byte(received), msg...), nil
-}
-
 // selfSendApprovalDelivery is the HITL-gated counterpart of performSelfSend:
-// it writes ONLY the inbound row and returns an identity.SendResult shaped
-// for ApproveAndSend's send callback. The pre-existing held outbound row is
-// finalized to status=sent by ApproveAndSend itself using the result's
-// provider_message_id + method columns — calling CreateOutboundMessage here
-// would create a duplicate row and unanchor the operator-visible audit
-// trail (held → sent for a specific row id).
+// it writes ONLY the inbound row (via loopback.DeliverInbound) and returns
+// an identity.SendResult shaped for ApproveAndSend's send callback. The
+// pre-existing held outbound row is finalized to status=sent by
+// ApproveAndSend itself using the result's provider_message_id + method
+// columns — calling CreateOutboundMessage here would create a duplicate
+// row and unanchor the operator-visible audit trail (held → sent for a
+// specific row id).
 //
-// Same delivery semantics as performSelfSend: loopback method, synthetic
-// Received: line, no webhook/WS replay. Domain verification is checked
-// upstream at handleSendEmail; the approval finalize trusts the gate it
-// already passed at hold time.
+// Failure-mode note: the inbound row write happens INSIDE ApproveAndSend's
+// send callback but uses a non-tx connection. If the callback succeeds but
+// the subsequent tx UPDATE / Commit fails, the inbound row will exist
+// while the outbound row stays pending_approval. Same crash-window class
+// as the existing SES-side issue documented on ApproveAndSend's docstring.
+// Operator-visible symptom: a "self-message" inbox row with no matching
+// status=sent outbound row.
 func (a *API) selfSendApprovalDelivery(
 	ctx context.Context,
 	agent *identity.AgentIdentity,
 	req outbound.SendRequest,
 ) (identity.SendResult, error) {
-	providerID := loopbackProviderID(a.fromDomain)
-	email := agent.EmailAddress()
-
-	rawMessage, err := composeLoopbackMIME(agent, req, providerID, a.fromDomain)
-	if err != nil {
-		return identity.SendResult{}, fmt.Errorf("self-send approval compose: %w", err)
-	}
-	if _, err := a.store.CreateInboundMessage(
-		ctx,
-		"",
-		agent.ID,
-		email, // sender
-		email, // recipient (per-delivery target)
-		providerID,
-		req.Subject,
-		req.ConversationID,
-		"unread",
-		rawMessage,
-		nil, // no DKIM/SPF auth headers on a synthetic loopback
-		[]string{email},
-		nil, // cc
-		nil, // reply_to
-	); err != nil {
-		return identity.SendResult{}, fmt.Errorf("self-send approval inbound row: %w", err)
-	}
-
-	return identity.SendResult{
-		ProviderMessageID: providerID,
-		Method:            "loopback",
-		To:                []string{email},
-	}, nil
-}
-
-// loopbackProviderID synthesizes an RFC 5322-shaped Message-ID for the
-// outbound row's provider_message_id column. Mirrors what an external
-// MTA would have stamped on the message — keeps the column non-empty
-// and recognizable in operator queries (the "@loopback.<domain>" host
-// portion makes self-sends greppable across the dataset).
-func loopbackProviderID(fromDomain string) string {
-	var b [16]byte
-	_, _ = rand.Read(b[:])
-	host := fromDomain
-	if host == "" {
-		host = "e2a.local"
-	}
-	return fmt.Sprintf("<%s@loopback.%s>", hex.EncodeToString(b[:]), host)
+	return loopback.DeliverInbound(ctx, a.store, agent, req, a.fromDomain)
 }

--- a/internal/agent/selfsend_test.go
+++ b/internal/agent/selfsend_test.go
@@ -3,6 +3,7 @@ package agent_test
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"strings"
 	"testing"
 
@@ -418,11 +419,12 @@ func TestSelfReply_ReplyAllOnSelfThread_LoopbackShortCircuit(t *testing.T) {
 	}
 }
 
-// TestSelfSend_BypassesHITL: an agent with HITL enabled still self-
-// sends immediately. Holding a note-to-self for the agent to approve
-// to itself is degenerate UX; the loopback path explicitly skips the
-// approval queue.
-func TestSelfSend_BypassesHITL(t *testing.T) {
+// TestSelfSend_HoldsForHITL: an agent with HITL enabled holds a
+// self-send for approval just like any other send. The "is the
+// recipient external" question is independent of "did a human
+// review this outbound message". The approval-finalize path then
+// delivers via loopback (see TestSelfSend_HITLApprovalDeliversViaLoopback).
+func TestSelfSend_HoldsForHITL(t *testing.T) {
 	server, store, pool := setupAPI(t)
 	ctx := context.Background()
 
@@ -453,25 +455,117 @@ func TestSelfSend_BypassesHITL(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	payload := `{"to":["bot@hitlself.example.com"],"subject":"hitl self","body":"this should still ship immediately"}`
+	payload := `{"to":["bot@hitlself.example.com"],"subject":"hitl self","body":"this should be held for approval"}`
 	resp := authedPost(t, server.URL+"/api/v1/send", payload, apiKeyObj.PlaintextKey)
 	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
-		t.Fatalf("status=%d want 200 (HITL must be bypassed for self-send); body=%s", resp.StatusCode, readBody(t, resp))
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("status=%d want 202 (HITL must hold the self-send); body=%s", resp.StatusCode, readBody(t, resp))
 	}
 	var body map[string]string
 	json.NewDecoder(resp.Body).Decode(&body)
-	if body["status"] != "sent" {
-		t.Errorf("status=%q want sent (not pending_approval)", body["status"])
+	if body["status"] != "pending_approval" {
+		t.Errorf("status=%q want pending_approval", body["status"])
 	}
 
-	// And no pending-approval row should exist.
+	// And the held row should exist as pending_approval (no inbound
+	// row yet — that's written by the approval finalize step).
 	var pending int
 	pool.QueryRow(ctx,
 		`SELECT count(*) FROM messages WHERE agent_id=$1 AND status='pending_approval'`,
 		agentRow.ID).Scan(&pending)
-	if pending != 0 {
-		t.Errorf("pending rows=%d want 0 — HITL was supposed to be bypassed", pending)
+	if pending != 1 {
+		t.Errorf("pending rows=%d want 1", pending)
+	}
+	var inbound int
+	pool.QueryRow(ctx,
+		`SELECT count(*) FROM messages WHERE agent_id=$1 AND direction='inbound'`,
+		agentRow.ID).Scan(&inbound)
+	if inbound != 0 {
+		t.Errorf("inbound rows=%d want 0 (loopback delivery should wait for approval)", inbound)
+	}
+}
+
+// TestSelfSend_HITLApprovalDeliversViaLoopback: when a self-send is
+// held for HITL approval and then approved, the finalize step delivers
+// via the loopback path — outbound row flips to status=sent with
+// method=loopback, and an inbound row is created in the agent's inbox.
+// Before this fix the finalize path called outbound.Sender.Send, which
+// strips the agent's own address from the recipient list and errors
+// with "no valid recipients".
+func TestSelfSend_HITLApprovalDeliversViaLoopback(t *testing.T) {
+	server, store, pool := setupAPI(t)
+	ctx := context.Background()
+
+	user, err := store.CreateOrGetUser(ctx, "hitl-self-approve@example.com", "Owner", "google-hitl-self-approve")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	apiKeyObj, err := store.CreateAPIKey(ctx, user.ID, "hitl-self-approve-key")
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+	if _, err := store.ClaimOrCreateDomain(ctx, "hitlselfapprove.example.com", user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+	if err := store.VerifyDomain(ctx, "hitlselfapprove.example.com", user.ID); err != nil {
+		t.Fatalf("VerifyDomain: %v", err)
+	}
+	agentRow, err := store.CreateAgent(ctx, "bot@hitlselfapprove.example.com", "hitlselfapprove.example.com", "", "", "local", user.ID)
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`UPDATE agent_identities SET hitl_enabled=true WHERE id=$1`,
+		agentRow.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	// Step 1: send → held for approval
+	payload := `{"to":["bot@hitlselfapprove.example.com"],"subject":"awaiting review","body":"please approve me"}`
+	resp := authedPost(t, server.URL+"/api/v1/send", payload, apiKeyObj.PlaintextKey)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("hold status=%d want 202; body=%s", resp.StatusCode, readBody(t, resp))
+	}
+	var holdBody map[string]string
+	json.NewDecoder(resp.Body).Decode(&holdBody)
+	heldMessageID := holdBody["message_id"]
+	if heldMessageID == "" {
+		t.Fatal("hold response missing message_id")
+	}
+
+	// Step 2: approve via the dashboard endpoint (empty body = approve as-is)
+	approveURL := server.URL + "/api/v1/messages/" + heldMessageID + "/approve"
+	approveResp := authedPost(t, approveURL, `{}`, apiKeyObj.PlaintextKey)
+	defer approveResp.Body.Close()
+	if approveResp.StatusCode != 200 {
+		t.Fatalf("approve status=%d want 200; body=%s", approveResp.StatusCode, readBody(t, approveResp))
+	}
+	var approveBody map[string]interface{}
+	json.NewDecoder(approveResp.Body).Decode(&approveBody)
+	if approveBody["method"] != "loopback" {
+		t.Errorf("approve method=%v want loopback", approveBody["method"])
+	}
+
+	// Step 3: outbound row is now sent + loopback, and the inbound
+	// row exists with the same subject.
+	var sentStatus, sentMethod string
+	pool.QueryRow(ctx,
+		`SELECT status, method FROM messages WHERE id=$1`,
+		heldMessageID).Scan(&sentStatus, &sentMethod)
+	if sentStatus != "sent" {
+		t.Errorf("outbound status=%q want sent", sentStatus)
+	}
+	if sentMethod != "loopback" {
+		t.Errorf("outbound method=%q want loopback", sentMethod)
+	}
+
+	var inboundCount int
+	pool.QueryRow(ctx,
+		`SELECT count(*) FROM messages WHERE agent_id=$1 AND direction='inbound' AND subject='awaiting review'`,
+		agentRow.ID).Scan(&inboundCount)
+	if inboundCount != 1 {
+		t.Errorf("inbound rows=%d want 1 (loopback delivery should write the recipient-side row)", inboundCount)
 	}
 }
 

--- a/internal/hitlworker/worker.go
+++ b/internal/hitlworker/worker.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/loopback"
 	"github.com/Mnexa-AI/e2a/internal/outbound"
 	"github.com/Mnexa-AI/e2a/internal/usage"
 )
@@ -28,20 +29,28 @@ const DefaultBatchSize = 100
 
 // Worker runs the TTL sweep. Construct with New, start with Run.
 type Worker struct {
-	store     *identity.Store
-	sender    *outbound.Sender
-	usage     usage.UsageTracker
-	interval  time.Duration
-	batchSize int
+	store      *identity.Store
+	sender     *outbound.Sender
+	usage      usage.UsageTracker
+	fromDomain string
+	interval   time.Duration
+	batchSize  int
 }
 
-func New(store *identity.Store, sender *outbound.Sender, usage usage.UsageTracker) *Worker {
+// New constructs a Worker. fromDomain is the deployment's outbound
+// from-domain (cfg.OutboundSMTP.FromDomain) — used by the self-send
+// loopback branch to stamp the synthetic Message-ID / Received headers
+// the same way internal/agent does on the user-driven approve path.
+// Pass "" if the deployment has no outbound relay configured; the
+// loopback path falls back to "e2a.local" for the host portion.
+func New(store *identity.Store, sender *outbound.Sender, usage usage.UsageTracker, fromDomain string) *Worker {
 	return &Worker{
-		store:     store,
-		sender:    sender,
-		usage:     usage,
-		interval:  DefaultInterval,
-		batchSize: DefaultBatchSize,
+		store:      store,
+		sender:     sender,
+		usage:      usage,
+		fromDomain: fromDomain,
+		interval:   DefaultInterval,
+		batchSize:  DefaultBatchSize,
 	}
 }
 
@@ -111,6 +120,19 @@ func (w *Worker) autoApprove(ctx context.Context, c identity.ExpirationCandidate
 				return identity.SendResult{}, err
 			}
 			w.attachReferencesChain(ctx, agent.ID, &req)
+			// Self-sends bypass the SMTP relay — outbound.Sender would
+			// strip the agent's own address from the recipient list and
+			// error "no valid recipients", which the worker would then
+			// interpret as a send failure and auto-REJECT the row,
+			// silently inverting the operator-configured
+			// hitl_expiration_action="approve" policy. Loopback writes
+			// the inbound row directly and reports method=loopback on
+			// the now-sent outbound row, matching the user-driven
+			// approve paths in internal/agent/hitl_api.go and
+			// internal/agent/hitl_magic_api.go.
+			if loopback.IsSelfSend(req, agent.EmailAddress()) {
+				return loopback.DeliverInbound(ctx, w.store, agent, req, w.fromDomain)
+			}
 			result, err := w.sender.Send(agent, req)
 			if err != nil {
 				return identity.SendResult{}, err

--- a/internal/hitlworker/worker_test.go
+++ b/internal/hitlworker/worker_test.go
@@ -31,7 +31,7 @@ func setupWorker(t *testing.T) (
 	store := identity.NewStore(pool)
 	smtpRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{Host: smtpAddr.Host, Port: smtpAddr.Port})
 	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
-	w := hitlworker.New(store, sender, usage.NewNoopUsageTracker())
+	w := hitlworker.New(store, sender, usage.NewNoopUsageTracker(), "test.e2a.dev")
 	return w, store, pool, smtpDone
 }
 
@@ -161,6 +161,71 @@ func TestWorkerAutoApprovesExpiredPending(t *testing.T) {
 	}
 }
 
+// TestWorkerAutoApproveSelfSendDeliversViaLoopback: a held self-send
+// whose TTL expires with the agent's hitl_expiration_action="approve"
+// must be auto-approved via the loopback path — outbound.Sender.Send
+// would strip the agent's own address (self-spam guard) and error
+// "no valid recipients", which the worker would then translate into
+// auto-REJECT, silently inverting the operator-configured policy.
+//
+// Asserts: outbound row → expired_approved + method=loopback, inbound
+// row appears in the agent's mailbox, no SMTP traffic.
+func TestWorkerAutoApproveSelfSendDeliversViaLoopback(t *testing.T) {
+	w, store, pool, smtpDone := setupWorker(t)
+	ctx := context.Background()
+
+	agent := prepareAgent(t, store, "auto-approve-self", identity.HITLExpirationApprove)
+	msg, err := store.CreatePendingOutboundMessage(ctx, agent.ID,
+		[]string{agent.EmailAddress()}, nil, nil,
+		"self auto-approve", "note to self body", "", nil,
+		"send", "", "", 60)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backdateExpiry(t, pool, msg.ID)
+
+	w.RunOnce(ctx)
+
+	// SMTP must NOT be hit — loopback is the whole point.
+	if msgs := smtpDone(); len(msgs) != 0 {
+		t.Fatalf("SMTP should not be hit on self-send auto-approve, got %d messages: %+v", len(msgs), msgs)
+	}
+
+	// Outbound row → expired_approved, method=loopback, body scrubbed.
+	var status, method string
+	var providerID *string
+	var bodyText *string
+	err = pool.QueryRow(ctx,
+		`SELECT status, method, provider_message_id, body_text FROM messages WHERE id = $1`,
+		msg.ID,
+	).Scan(&status, &method, &providerID, &bodyText)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status != identity.MessageStatusExpiredApproved {
+		t.Errorf("status = %q, want %q (worker should NOT have fallen back to expired_rejected)", status, identity.MessageStatusExpiredApproved)
+	}
+	if method != "loopback" {
+		t.Errorf("method = %q, want loopback", method)
+	}
+	if providerID == nil || *providerID == "" {
+		t.Error("provider_message_id should be populated after loopback delivery")
+	}
+	if bodyText != nil {
+		t.Errorf("body_text not scrubbed: %v", bodyText)
+	}
+
+	// Inbound row landed in the agent's mailbox.
+	var inboundCount int
+	pool.QueryRow(ctx,
+		`SELECT count(*) FROM messages
+		   WHERE agent_id=$1 AND direction='inbound' AND subject='self auto-approve'`,
+		agent.ID).Scan(&inboundCount)
+	if inboundCount != 1 {
+		t.Errorf("inbound rows after self-send auto-approve = %d, want 1", inboundCount)
+	}
+}
+
 func TestWorkerAutoApproveSendFailureFallsBackToRejected(t *testing.T) {
 	// Sender pointed at a bogus port so SMTP dial fails; still share the DB
 	// and store with the fake SMTP from setupWorker to keep setup terse.
@@ -169,7 +234,7 @@ func TestWorkerAutoApproveSendFailureFallsBackToRejected(t *testing.T) {
 
 	badRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{Host: "127.0.0.1", Port: 1})
 	badSender := outbound.NewSender(badRelay, "test.e2a.dev")
-	w := hitlworker.New(store, badSender, usage.NewNoopUsageTracker())
+	w := hitlworker.New(store, badSender, usage.NewNoopUsageTracker(), "test.e2a.dev")
 
 	agent := prepareAgent(t, store, "auto-approve-fail", identity.HITLExpirationApprove)
 	msg, _ := store.CreatePendingOutboundMessage(ctx, agent.ID,

--- a/internal/loopback/loopback.go
+++ b/internal/loopback/loopback.go
@@ -1,0 +1,247 @@
+// Package loopback delivers agent-to-self messages without touching the
+// upstream SMTP relay. A self-send (agent emails itself) is a degenerate
+// case for SMTP: the relay would refuse it as a self-spam guard, and the
+// roundtrip through SES + MX + the local SMTP receiver is wasted work
+// when the destination is local anyway.
+//
+// Two callers, two entry points:
+//
+//   - internal/agent reaches us via DeliverInbound from the HITL
+//     approval finalizer (selfSendApprovalDelivery) and from its own
+//     fast path (performSelfSend). The fast path writes the outbound
+//     row itself; the approval path lets ApproveAndSend update the
+//     pre-existing held outbound row.
+//   - internal/hitlworker reaches us via DeliverInbound from the TTL
+//     auto-approve callback. Same shape as the user-driven approval
+//     path — the held outbound row already exists; we only write the
+//     inbound counterpart.
+//
+// Living here (rather than in internal/agent) lets the worker import us
+// without dragging the entire agent package's surface in. Mirrors the
+// existing duplication strategy for sendRequestFromStoredMessage but
+// avoids it for the larger MIME-composition body.
+package loopback
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"strings"
+	"time"
+
+	"context"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/outbound"
+)
+
+// IsSelfSend reports whether req targets only the sender's own inbox —
+// i.e., the agent is writing a note to itself. Returns true only when
+// there's a single To recipient that matches the agent's own address
+// (case-insensitive, trimmed) AND no Cc/Bcc — any mixed/external
+// recipient routes through normal SMTP unchanged.
+//
+// Callers that have CC/BCC carrying agent aliases (e.g. the reply path
+// with replyAll=true on a self-thread, where the original message's CC
+// list already includes the agent) should strip them via
+// StripAgentSelfAliases before checking — outbound.Sender does the same
+// alias-strip downstream as a self-spam guard, so doing it here is
+// purely "see through" the aliases earlier.
+func IsSelfSend(req outbound.SendRequest, agentEmail string) bool {
+	if len(req.CC) != 0 || len(req.BCC) != 0 {
+		return false
+	}
+	if len(req.To) != 1 {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(req.To[0]), agentEmail)
+}
+
+// StripAgentSelfAliases removes case-insensitive, whitespace-trimmed
+// matches of agentEmail from addrs. Used to pre-clean reply recipients
+// so IsSelfSend can recognize replyAll-on-a-self-thread as still a
+// self-send. Returns a fresh slice; the input is not mutated.
+func StripAgentSelfAliases(addrs []string, agentEmail string) []string {
+	if len(addrs) == 0 {
+		return addrs
+	}
+	out := make([]string, 0, len(addrs))
+	for _, a := range addrs {
+		if !strings.EqualFold(strings.TrimSpace(a), agentEmail) {
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+// ProviderID synthesizes an RFC 5322-shaped Message-ID for the outbound
+// row's provider_message_id column. Mirrors what an external MTA would
+// have stamped — keeps the column non-empty and recognizable in
+// operator queries (the "@loopback.<domain>" host portion makes
+// self-sends greppable across the dataset).
+func ProviderID(fromDomain string) string {
+	var b [16]byte
+	_, _ = rand.Read(b[:])
+	host := fromDomain
+	if host == "" {
+		host = "e2a.local"
+	}
+	return fmt.Sprintf("<%s@loopback.%s>", hex.EncodeToString(b[:]), host)
+}
+
+// ComposeMIME builds the RFC 5322 / 2046 message bytes the inbound row
+// will store as raw_message.
+//
+// Delegates to the same composer the real SMTP path uses
+// (outbound.ComposeMessageWithAttachments) so the produced message is
+// byte-equivalent to what an external roundtrip would have generated —
+// same headers, same multipart structure, same attachment encoding.
+// The SDK's InboundEmail.fromPayload → parseRawEmail pipeline then
+// finds body text/html AND attachments without any loopback-specific
+// branch.
+//
+// Prepends ONE synthetic Received: line per RFC 5321 §4.4 ("each time a
+// message is relayed... the receiving SMTP server MUST insert a
+// 'Received:' line"). Mature local-delivery MTAs (sendmail's local
+// mailer, Postfix's local daemon, Exim's local_smtp transport) all add
+// such a line even for same-host delivery; doing the same here keeps
+// stored messages forensically self-documenting. The "loopback" keyword
+// is the searchable signal — `grep "with loopback"` over raw messages
+// finds every self-send.
+//
+// Threading: req.ReplyToMessageID and req.References are passed through
+// to the composer, so self-replies that reach this path via the HITL
+// approval finalizer preserve In-Reply-To / References headers — same
+// shape an SMTP-routed reply would carry.
+func ComposeMIME(agent *identity.AgentIdentity, req outbound.SendRequest, providerID, fromDomain string) ([]byte, error) {
+	email := agent.EmailAddress()
+	headerFrom := fmt.Sprintf("%q <%s>", agent.Name, email)
+	if agent.Name == "" {
+		headerFrom = email
+	}
+
+	var msg []byte
+	var err error
+	if len(req.Attachments) > 0 {
+		msg, err = outbound.ComposeMessageWithAttachments(
+			headerFrom,
+			[]string{email},
+			nil, // cc
+			req.Subject,
+			req.Body,
+			req.HTMLBody,
+			req.ReplyToMessageID,
+			req.References,
+			fromDomain,
+			"", // reply_to header
+			req.ConversationID,
+			req.Attachments,
+		)
+	} else {
+		// No attachments → simpler single-part path. Lets us keep the
+		// stored MIME small for the common "note to self" case rather
+		// than always emitting a multipart envelope.
+		contentType := "text/plain"
+		body := req.Body
+		if req.HTMLBody != "" {
+			contentType = "text/html"
+			body = req.HTMLBody
+		}
+		msg, err = outbound.ComposeMessage(
+			headerFrom,
+			[]string{email},
+			nil, // cc
+			req.Subject,
+			body,
+			contentType,
+			req.ReplyToMessageID,
+			req.References,
+			fromDomain,
+			"", // reply_to header
+			req.ConversationID,
+		)
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	host := fromDomain
+	if host == "" {
+		host = "e2a.local"
+	}
+	received := fmt.Sprintf(
+		"Received: by %s (e2a) with loopback id %s for <%s>;\r\n\t%s\r\n",
+		host,
+		providerID,
+		email,
+		time.Now().UTC().Format(time.RFC1123Z),
+	)
+	return append([]byte(received), msg...), nil
+}
+
+// InboundWriter is the subset of *identity.Store DeliverInbound uses.
+// Lets tests swap in fakes; production code passes the real store.
+type InboundWriter interface {
+	CreateInboundMessage(ctx context.Context, id, agentID, senderEmail, recipient, emailMessageID, subject, conversationID, deliveryStatus string, rawMessage []byte, authHeaders map[string]string, toRecipients, cc, replyTo []string) (*identity.Message, error)
+}
+
+// DeliverInbound writes the recipient-side row for a loopback self-send
+// and returns an identity.SendResult shaped for the ApproveAndSend send
+// callback (or the worker's ExpireApproveAndSend send callback).
+//
+// Does NOT write the outbound row — the caller is one of:
+//   - HITL approval: the held outbound row already exists;
+//     ApproveAndSend's UPDATE flips it to status=sent + method=loopback
+//     using the result's columns.
+//   - hitlworker TTL auto-approve: same shape via ExpireApproveAndSend.
+//
+// The non-HITL fast path in internal/agent (performSelfSend) calls
+// CreateOutboundMessage itself before calling DeliverInbound; that
+// path has no held row to update.
+//
+// Notable choices documented because they diverge from a pure-SMTP
+// send:
+//   - Webhook + WebSocket delivery are intentionally NOT fired on the
+//     inbound row. Cloud-mode agents whose webhook handler triggered
+//     the send would otherwise re-enter their own code and loop.
+//     Local-mode agents pick up the row via the next list_messages
+//     poll, which IS the intended UX.
+//   - auth_headers stays NULL: no DKIM/SPF was actually evaluated
+//     because nothing arrived over the wire. The operator-facing signal
+//     "this row didn't come from external mail" is preserved by that
+//     null column.
+//   - Domain verification + rate limit are enforced upstream by the
+//     caller. Loopback isn't a backdoor for those gates.
+func DeliverInbound(ctx context.Context, store InboundWriter, agent *identity.AgentIdentity, req outbound.SendRequest, fromDomain string) (identity.SendResult, error) {
+	providerID := ProviderID(fromDomain)
+	email := agent.EmailAddress()
+
+	rawMessage, err := ComposeMIME(agent, req, providerID, fromDomain)
+	if err != nil {
+		return identity.SendResult{}, fmt.Errorf("loopback compose: %w", err)
+	}
+	if _, err := store.CreateInboundMessage(
+		ctx,
+		"", // generate fresh id; mirrors the SMTP path which never reuses outbound ids
+		agent.ID,
+		email, // sender
+		email, // recipient (per-delivery target)
+		providerID,
+		req.Subject,
+		req.ConversationID,
+		"unread",
+		rawMessage,
+		nil, // no DKIM/SPF auth headers on a synthetic loopback
+		[]string{email},
+		nil, // cc
+		nil, // reply_to
+	); err != nil {
+		return identity.SendResult{}, fmt.Errorf("loopback inbound row: %w", err)
+	}
+
+	return identity.SendResult{
+		ProviderMessageID: providerID,
+		Method:            "loopback",
+		To:                []string{email},
+	}, nil
+}


### PR DESCRIPTION
## Summary
- Remove the `!selfSend` short-circuit in `handleSendEmail` + `handleReplyToMessage` so self-sends are held for HITL approval like any other outbound message.
- Route the approval finalizer (dashboard + magic-link) through a new `selfSendApprovalDelivery` helper that writes only the inbound counterpart row; `ApproveAndSend` updates the held outbound row to `status=sent` + `method=loopback`, matching the non-HITL self-send shape.
- Update `selfsend_test.go`: rename the bypass test to `TestSelfSend_HoldsForHITL` and add `TestSelfSend_HITLApprovalDeliversViaLoopback` covering the end-to-end held → approved → inbound-row-written path.

## Why
Approving a held self-send went through `outbound.Sender.Send`, whose self-spam guard strips the agent's own address from the recipient list — leaving "no valid recipients" and a 400 on the magic-link approve page. The simplest repro: dashboard "Test email" button on an agent with HITL enabled.

The previous design's claim ("reviewer == author is degenerate UX, so skip HITL") doesn't survive the Test-button flow or any agent-to-self automation. HITL is a "did a human review this" gate; that question is independent of where the recipient lives.

## Test plan
- [x] `go test ./internal/agent/ ./internal/identity/ -count=1 -p 1` — green
- [x] `TestSelfSend_HoldsForHITL` — HITL-enabled self-send returns 202 + `pending_approval`, no inbound row written
- [x] `TestSelfSend_HITLApprovalDeliversViaLoopback` — held self-send approved via `/api/v1/messages/{id}/approve`, outbound row flips to `sent` + `method=loopback`, inbound row appears in agent inbox
- [x] Existing `TestSendTestEmailHITLGate`, `TestSelfSend_HappyPath`, `TestSelfReply_LoopbackShortCircuit` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)