### PR TITLE
feat(api): backend support for the Loft dashboard refresh

### DIFF
--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -109,7 +109,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("Failed to bootstrap user: %v", err)
 		}
-		key, err := store.CreateAPIKey(ctx, user.ID, "bootstrap")
+		key, err := store.CreateAPIKey(ctx, user.ID, "bootstrap", nil)
 		if err != nil {
 			log.Fatalf("Failed to create API key: %v", err)
 		}

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -207,6 +207,7 @@ func (a *API) RegisterRoutes(r *mux.Router) {
 	r.HandleFunc("/api/v1/domains", a.handleListDomains).Methods("GET")
 	r.HandleFunc("/api/v1/domains", a.handleRegisterDomain).Methods("POST")
 	r.HandleFunc("/api/v1/domains/{domain}/verify", a.handleVerifyDomain).Methods("POST")
+	r.HandleFunc("/api/v1/domains/{domain}", a.handleUpdateDomain).Methods("PATCH")
 	r.HandleFunc("/api/v1/domains/{domain}", a.handleDeleteDomain).Methods("DELETE")
 
 	r.HandleFunc("/api/v1/agents/{email}/test", a.handleSendTestEmail).Methods("POST")
@@ -266,8 +267,10 @@ func (a *API) RegisterRoutes(r *mux.Router) {
 		r.HandleFunc("/api/auth/callback", a.userAuth.HandleCallback).Methods("GET")
 		r.HandleFunc("/api/auth/logout", a.userAuth.HandleLogout).Methods("POST")
 		r.HandleFunc("/api/auth/me", a.userAuth.HandleMe).Methods("GET")
+		r.HandleFunc("/api/auth/me", a.userAuth.HandleUpdateMe).Methods("PATCH")
 
 		// Dashboard
+		r.HandleFunc("/api/dashboard/stats", a.userAuth.HandleDashboardStats).Methods("GET")
 		r.HandleFunc("/api/dashboard/agents", a.userAuth.HandleDashboardAgents).Methods("GET")
 		r.HandleFunc("/api/dashboard/agents/{email}", a.userAuth.HandleUpdateAgent).Methods("PUT")
 		r.HandleFunc("/api/dashboard/agents/{email}", a.userAuth.HandleDeleteAgent).Methods("DELETE")
@@ -887,6 +890,15 @@ func (a *API) handleVerifyDomain(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Touch last_checked_at regardless of whether the probe succeeds —
+	// the column is "when did we last try", separate from verified_at
+	// which only moves on success. Best-effort: a failed touch shouldn't
+	// block the verify response (the row is locked-down to the user, so
+	// the only realistic failure is a transient DB issue).
+	if err := a.store.TouchDomainLastChecked(r.Context(), domain, user.ID); err != nil {
+		log.Printf("[api] touch last_checked_at for %s: %v", domain, err)
+	}
+
 	// In dev mode, skip DNS verification
 	if !a.production {
 		log.Printf("[api] dev mode: skipping DNS check for %s", domain)
@@ -937,6 +949,78 @@ func (a *API) handleVerifyDomain(w http.ResponseWriter, r *http.Request) {
 		Verified:   true,
 		VerifiedAt: domainRecord.VerifiedAt,
 	})
+}
+
+// handleUpdateDomain serves PATCH /api/v1/domains/{domain}. Currently
+// supports a single mutable field — is_primary — surfaced for the
+// dashboard's "Set as primary" button. The partial unique index on
+// (user_id) WHERE is_primary=true makes the multi-statement swap-
+// then-set transaction necessary; SetDomainPrimary handles that
+// atomically. Other domain fields (verification token, verified
+// timestamp) are managed by the dedicated verify path and aren't
+// settable here.
+// @Summary      Update a domain
+// @Description  Update mutable fields on a domain. The only supported field today is `is_primary` — passing `true` promotes this domain and clears the flag from any previously-primary domain in a single transaction. Passing `false` is a no-op (use SetDomainPrimary on a different domain to demote this one).
+// @Tags         Domains
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        domain path string true "Domain name"
+// @Param        request body UpdateDomainRequest true "Fields to update"
+// @Success      200 {object} DomainInfo
+// @Failure      400 {string} string "Invalid request"
+// @Failure      401 {string} string "Missing or invalid API key"
+// @Failure      404 {string} string "Domain not found"
+// @Router       /api/v1/domains/{domain} [patch]
+func (a *API) handleUpdateDomain(w http.ResponseWriter, r *http.Request) {
+	user, err := a.authenticateUser(r)
+	if err != nil {
+		a.writeAuthError(w, r, err)
+		return
+	}
+
+	domain := mux.Vars(r)["domain"]
+
+	var req struct {
+		IsPrimary *bool `json:"is_primary,omitempty"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+	if req.IsPrimary == nil {
+		http.Error(w, "no updatable fields provided", http.StatusBadRequest)
+		return
+	}
+	if !*req.IsPrimary {
+		// Demote is a no-op — to switch primary, promote a different
+		// domain. This keeps the partial unique index meaningful:
+		// exactly one primary or zero, never a "no domain is primary
+		// because I demoted the only one" footgun.
+		http.Error(w, "to switch primary, PATCH the new primary domain instead", http.StatusBadRequest)
+		return
+	}
+
+	if err := a.store.SetDomainPrimary(r.Context(), domain, user.ID); err != nil {
+		if errors.Is(err, identity.ErrDomainNotFound) {
+			http.Error(w, "domain not found", http.StatusNotFound)
+			return
+		}
+		log.Printf("[api] SetDomainPrimary %s: %v", domain, err)
+		http.Error(w, "failed to update domain", http.StatusInternalServerError)
+		return
+	}
+
+	d, err := a.store.LookupDomain(r.Context(), domain, user.ID)
+	if err != nil {
+		// Should be unreachable — SetDomainPrimary just succeeded against
+		// this row. Still, return a useful error rather than nil-dereffing
+		// in domainInfoFromRecord.
+		http.Error(w, "failed to read back domain", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	writeJSON(w, a.domainInfoFromRecord(d))
 }
 
 // handleListDomains lists all domains owned by the authenticated user.
@@ -1036,8 +1120,11 @@ func (a *API) domainInfoFromRecord(d *identity.Domain) DomainInfo {
 			MX:  DNSRecord{Host: "@", Value: a.smtpDomain, Priority: &mxPriority},
 			TXT: DNSRecord{Host: "@", Value: d.VerificationToken},
 		},
-		CreatedAt:  d.CreatedAt,
-		VerifiedAt: d.VerifiedAt,
+		CreatedAt:     d.CreatedAt,
+		VerifiedAt:    d.VerifiedAt,
+		IsPrimary:     d.IsPrimary,
+		LastCheckedAt: d.LastCheckedAt,
+		AgentCount:    d.AgentCount,
 	}
 }
 

--- a/internal/agent/api_docs.go
+++ b/internal/agent/api_docs.go
@@ -124,6 +124,18 @@ type DomainInfo struct {
 	DNSRecords        DNSRecords `json:"dns_records"`
 	CreatedAt         time.Time  `json:"created_at"`
 	VerifiedAt        *time.Time `json:"verified_at,omitempty"`
+	// IsPrimary marks the user's default domain — at most one per
+	// user, enforced server-side via SetDomainPrimary. The redesign's
+	// Domains list renders this as a "Primary" chip.
+	IsPrimary bool `json:"is_primary"`
+	// LastCheckedAt is the timestamp of the most recent
+	// /api/v1/domains/{domain}/verify probe (success or failure).
+	// Distinct from VerifiedAt, which only updates on success.
+	LastCheckedAt *time.Time `json:"last_checked_at,omitempty"`
+	// AgentCount is populated by list endpoints. Single-domain endpoints
+	// (register, verify) leave it zero — the count would require an
+	// extra query that callers can derive from the agents list anyway.
+	AgentCount int `json:"agent_count"`
 } // @name Domain
 
 // DNSRecords contains the DNS records needed for domain verification.
@@ -143,6 +155,12 @@ type DNSRecord struct {
 type ListDomainsResponse struct {
 	Domains []DomainInfo `json:"domains"`
 } // @name ListDomainsResponse
+
+// UpdateDomainRequest is the body for PATCH /api/v1/domains/{domain}.
+// Only `is_primary=true` is meaningful — see handleUpdateDomain.
+type UpdateDomainRequest struct {
+	IsPrimary *bool `json:"is_primary,omitempty"`
+} // @name UpdateDomainRequest
 
 // RegisterDomainResponse is the response for POST /api/v1/domains.
 type RegisterDomainResponse = DomainInfo // @name RegisterDomainResponse
@@ -274,12 +292,22 @@ type PendingMessageSummary struct {
 // bodies since the server scrubs them on transition.
 type PendingMessageDetail struct {
 	PendingMessageSummary
-	EmailMessageID    string       `json:"email_message_id,omitempty" example:"<orig@gmail.com>"`
-	BodyText          string       `json:"body_text,omitempty"`
-	BodyHTML          string       `json:"body_html,omitempty"`
-	Attachments       []Attachment `json:"attachments,omitempty"`
-	Edited            bool         `json:"edited,omitempty"`
-	ReviewedAt        string       `json:"reviewed_at,omitempty" example:"2025-01-15T10:35:00Z"`
+	EmailMessageID string       `json:"email_message_id,omitempty" example:"<orig@gmail.com>"`
+	BodyText       string       `json:"body_text,omitempty"`
+	BodyHTML       string       `json:"body_html,omitempty"`
+	Attachments    []Attachment `json:"attachments,omitempty"`
+	Edited         bool         `json:"edited,omitempty"`
+	ReviewedAt     string       `json:"reviewed_at,omitempty" example:"2025-01-15T10:35:00Z"`
+	// ReviewedByUserID identifies the human reviewer for approved or
+	// rejected messages. NULL on TTL-expired transitions (worker
+	// auto-approve / auto-reject) where no human reviewed the message.
+	ReviewedByUserID  *string      `json:"reviewed_by_user_id,omitempty" example:"usr_abc123"`
+	// ReviewedByName is the JOIN'd display name from the reviewer's
+	// users row. NULL when reviewed_by_user_id is null (worker) or when
+	// the reviewer's user account has since been deleted (the FK has
+	// ON DELETE SET NULL specifically so this doesn't poison the audit
+	// trail).
+	ReviewedByName    *string      `json:"reviewed_by_name,omitempty" example:"Jamie"`
 	RejectionReason   string       `json:"rejection_reason,omitempty"`
 	ProviderMessageID string       `json:"provider_message_id,omitempty"`
 	Method            string       `json:"method,omitempty" example:"smtp"`

--- a/internal/agent/api_test.go
+++ b/internal/agent/api_test.go
@@ -45,7 +45,7 @@ func createTestUser(t *testing.T, store *identity.Store, email string) string {
 	if err != nil {
 		t.Fatalf("CreateOrGetUser: %v", err)
 	}
-	key, err := store.CreateAPIKey(ctx, user.ID, "test-key-"+email)
+	key, err := store.CreateAPIKey(ctx, user.ID, "test-key-"+email, nil)
 	if err != nil {
 		t.Fatalf("CreateAPIKey: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestGetAgentAuth(t *testing.T) {
 
 	// Create user and API key
 	user, _ := store.CreateOrGetUser(ctx, "owner-auth@example.com", "Owner", "google-auth")
-	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "auth-key")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "auth-key", nil)
 
 	// Register agent owned by this user
 	store.ClaimOrCreateDomain(ctx, "auth.example.com", user.ID)
@@ -230,7 +230,7 @@ func TestSendEmailUnverified(t *testing.T) {
 
 	// Create user and API key, register agent (not domain-verified)
 	user, _ := store.CreateOrGetUser(ctx, "owner-unverified@example.com", "Owner", "google-unverified-send")
-	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "unverified-key")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "unverified-key", nil)
 	store.ClaimOrCreateDomain(ctx, "unverified-send.example.com", user.ID)
 	store.CreateAgent(ctx, "agent@unverified-send.example.com", "unverified-send.example.com", "", "https://example.com/webhook", "", user.ID)
 
@@ -251,7 +251,7 @@ func TestSendEmailMissingFields(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-send-missing@example.com", "Owner", "google-send-missing")
-	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "send-missing-key")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "send-missing-key", nil)
 	store.ClaimOrCreateDomain(ctx, "send-missing.example.com", user.ID)
 	store.VerifyDomain(ctx, "send-missing.example.com", user.ID)
 	store.CreateAgent(ctx, "agent@send-missing.example.com", "send-missing.example.com", "", "https://example.com/webhook", "", user.ID)
@@ -289,7 +289,7 @@ func TestSendEmailViaSMTP(t *testing.T) {
 
 	// Create user and API key
 	user, _ := store.CreateOrGetUser(ctx, "owner-send@example.com", "Owner", "google-send")
-	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "send-key")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "send-key", nil)
 
 	// Agent (sender)
 	store.ClaimOrCreateDomain(ctx, "sender.example.com", user.ID)
@@ -344,7 +344,7 @@ func TestReplyToMessageUnverifiedDomain(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-unverified-reply@example.com", "Owner", "google-unverified-reply")
-	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "unverified-reply-key")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "unverified-reply-key", nil)
 	store.ClaimOrCreateDomain(ctx, "unverified-reply.example.com", user.ID)
 	agent, _ := store.CreateAgent(ctx, "agent@unverified-reply.example.com", "unverified-reply.example.com", "", "https://example.com/webhook", "", user.ID)
 
@@ -367,7 +367,7 @@ func TestReplyToMessageNotFound(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-reply-notfound@example.com", "Owner", "google-reply-notfound")
-	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "reply-notfound-key")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "reply-notfound-key", nil)
 	store.ClaimOrCreateDomain(ctx, "reply-notfound.example.com", user.ID)
 	store.VerifyDomain(ctx, "reply-notfound.example.com", user.ID)
 	store.CreateAgent(ctx, "agent@reply-notfound.example.com", "reply-notfound.example.com", "", "https://example.com/webhook", "", user.ID)
@@ -393,7 +393,7 @@ func TestReplyToMessageWrongAgent(t *testing.T) {
 	agentA, _ := store.CreateAgent(ctx, "agent@reply-a.example.com", "reply-a.example.com", "", "https://example.com/webhook", "", userA.ID)
 
 	userB, _ := store.CreateOrGetUser(ctx, "owner-reply-b@example.com", "OwnerB", "google-reply-b")
-	apiKeyB, _ := store.CreateAPIKey(ctx, userB.ID, "reply-b-key")
+	apiKeyB, _ := store.CreateAPIKey(ctx, userB.ID, "reply-b-key", nil)
 	store.ClaimOrCreateDomain(ctx, "reply-b.example.com", userB.ID)
 	store.VerifyDomain(ctx, "reply-b.example.com", userB.ID)
 	store.CreateAgent(ctx, "agent@reply-b.example.com", "reply-b.example.com", "", "https://example.com/webhook", "", userB.ID)
@@ -418,7 +418,7 @@ func TestReplyToMessageMissingBody(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-reply-nobody@example.com", "Owner", "google-reply-nobody")
-	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "reply-nobody-key")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "reply-nobody-key", nil)
 	store.ClaimOrCreateDomain(ctx, "reply-nobody.example.com", user.ID)
 	store.VerifyDomain(ctx, "reply-nobody.example.com", user.ID)
 	a, _ := store.CreateAgent(ctx, "agent@reply-nobody.example.com", "reply-nobody.example.com", "", "https://example.com/webhook", "", user.ID)
@@ -442,7 +442,7 @@ func TestReplyToMessageViaSMTP(t *testing.T) {
 
 	// Create user and API key for the replying agent
 	user, _ := store.CreateOrGetUser(ctx, "owner-replier@example.com", "Owner", "google-replier")
-	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "replier-key")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "replier-key", nil)
 
 	// Sender agent (the one replying)
 	store.ClaimOrCreateDomain(ctx, "replier.example.com", user.ID)
@@ -491,7 +491,7 @@ func TestReplyToMessageSharedDomainDisplayName(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-shared-reply@example.com", "Owner", "google-shared-reply")
-	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "shared-reply-key")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "shared-reply-key", nil)
 
 	// Create a shared-domain agent directly (domain contains "@" → IsSharedDomain() = true)
 	agentEmail := "reply-bot@agents.e2a.dev"
@@ -726,7 +726,7 @@ func TestListAgents_Success(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-list@example.com", "Owner", "google-list")
-	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "list-key")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "list-key", nil)
 	store.ClaimOrCreateDomain(ctx, "list.example.com", user.ID)
 	store.CreateAgent(ctx, "agent1@list.example.com", "list.example.com", "", "https://example.com/webhook", "", user.ID)
 	store.ClaimOrCreateDomain(ctx, "list2.example.com", user.ID)
@@ -776,7 +776,7 @@ func TestListAgents_Empty(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-empty-list@example.com", "Owner", "google-empty-list")
-	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "empty-list-key")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "empty-list-key", nil)
 
 	req, _ := http.NewRequest("GET", server.URL+"/api/v1/agents", nil)
 	req.Header.Set("Authorization", "Bearer "+apiKeyObj.PlaintextKey)
@@ -813,7 +813,7 @@ func TestGetMessages_CloudModeAllowed(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-cloud-poll@example.com", "Owner", "google-cloud-poll")
-	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "cloud-poll-key")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "cloud-poll-key", nil)
 	store.ClaimOrCreateDomain(ctx, "cloud-poll.example.com", user.ID)
 	store.VerifyDomain(ctx, "cloud-poll.example.com", user.ID)
 	store.CreateAgent(ctx, "agent@cloud-poll.example.com", "cloud-poll.example.com", "", "https://example.com/webhook", "", user.ID)
@@ -833,7 +833,7 @@ func TestGetMessage_CloudModeAllowed(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-cloud-msg@example.com", "Owner", "google-cloud-msg")
-	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "cloud-msg-key")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "cloud-msg-key", nil)
 	store.ClaimOrCreateDomain(ctx, "cloud-msg.example.com", user.ID)
 	store.VerifyDomain(ctx, "cloud-msg.example.com", user.ID)
 	ag, _ := store.CreateAgent(ctx, "agent@cloud-msg.example.com", "cloud-msg.example.com", "", "https://example.com/webhook", "", user.ID)
@@ -857,7 +857,7 @@ func TestGetMessages_InvalidStatus(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-inv-status@example.com", "Owner", "google-inv-status")
-	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "inv-status-key")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "inv-status-key", nil)
 	store.ClaimOrCreateDomain(ctx, "inv-status.example.com", user.ID)
 	store.CreateAgent(ctx, "agent@inv-status.example.com", "inv-status.example.com", "", "", "local", user.ID)
 
@@ -876,7 +876,7 @@ func TestGetMessages_EmptyList(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-empty-poll@example.com", "Owner", "google-empty-poll")
-	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "empty-poll-key")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "empty-poll-key", nil)
 	store.ClaimOrCreateDomain(ctx, "empty-poll.example.com", user.ID)
 	store.CreateAgent(ctx, "agent@empty-poll.example.com", "empty-poll.example.com", "", "", "local", user.ID)
 
@@ -919,7 +919,7 @@ func TestGetMessage_NotFound(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-msg-nf@example.com", "Owner", "google-msg-nf")
-	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "msg-nf-key")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "msg-nf-key", nil)
 	store.ClaimOrCreateDomain(ctx, "msg-nf.example.com", user.ID)
 	store.CreateAgent(ctx, "agent@msg-nf.example.com", "msg-nf.example.com", "", "", "local", user.ID)
 
@@ -938,7 +938,7 @@ func TestGetMessages_Pagination(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-pagination@example.com", "Owner", "google-pagination")
-	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "pagination-key")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "pagination-key", nil)
 	store.ClaimOrCreateDomain(ctx, "pagination.example.com", user.ID)
 	a, _ := store.CreateAgent(ctx, "agent@pagination.example.com", "pagination.example.com", "", "", "local", user.ID)
 
@@ -999,7 +999,7 @@ func TestGetMessages_PaginationFilterMismatch(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-filtermm@example.com", "Owner", "google-filtermm")
-	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "filtermm-key")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "filtermm-key", nil)
 	store.ClaimOrCreateDomain(ctx, "filtermm.example.com", user.ID)
 	a, _ := store.CreateAgent(ctx, "agent@filtermm.example.com", "filtermm.example.com", "", "", "local", user.ID)
 
@@ -1038,7 +1038,7 @@ func TestGetMessages_InvalidToken(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-badtoken@example.com", "Owner", "google-badtoken")
-	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "badtoken-key")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "badtoken-key", nil)
 	store.ClaimOrCreateDomain(ctx, "badtoken.example.com", user.ID)
 	store.CreateAgent(ctx, "agent@badtoken.example.com", "badtoken.example.com", "", "", "local", user.ID)
 
@@ -1057,7 +1057,7 @@ func TestGetMessages_PageSizeDefault(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-pagedefault@example.com", "Owner", "google-pagedefault")
-	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "pagedefault-key")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "pagedefault-key", nil)
 	store.ClaimOrCreateDomain(ctx, "pagedefault.example.com", user.ID)
 	a, _ := store.CreateAgent(ctx, "agent@pagedefault.example.com", "pagedefault.example.com", "", "", "local", user.ID)
 
@@ -1271,7 +1271,7 @@ func TestVerifyDomainDevModeSkipsDNS(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-devdns@example.com", "Owner", "google-devdns")
-	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "devdns-key")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "devdns-key", nil)
 	// Create agent with a domain that has no real DNS TXT records
 	store.ClaimOrCreateDomain(ctx, "fake.norealdns.local", user.ID)
 	store.CreateAgent(ctx, "agent@fake.norealdns.local", "fake.norealdns.local", "", "https://example.com/webhook", "", user.ID)
@@ -1319,7 +1319,7 @@ func TestMailLog_SendEmail(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-log-send@example.com", "Owner", "google-log-send")
-	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "log-send-key")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "log-send-key", nil)
 	store.ClaimOrCreateDomain(ctx, "log-send.example.com", user.ID)
 	store.VerifyDomain(ctx, "log-send.example.com", user.ID)
 	store.CreateAgent(ctx, "bot@log-send.example.com", "log-send.example.com", "", "https://example.com/webhook", "", user.ID)
@@ -1350,7 +1350,7 @@ func TestMailLog_ReplyEmail(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-log-reply@example.com", "Owner", "google-log-reply")
-	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "log-reply-key")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "log-reply-key", nil)
 	store.ClaimOrCreateDomain(ctx, "log-reply.example.com", user.ID)
 	store.VerifyDomain(ctx, "log-reply.example.com", user.ID)
 	ag, _ := store.CreateAgent(ctx, "bot@log-reply.example.com", "log-reply.example.com", "", "https://example.com/webhook", "", user.ID)
@@ -1384,7 +1384,7 @@ func TestSendTestEmailSuccess(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-test@example.com", "Owner", "google-test-email")
-	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "test-email-key")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "test-email-key", nil)
 	store.ClaimOrCreateDomain(ctx, "test-email.example.com", user.ID)
 	store.VerifyDomain(ctx, "test-email.example.com", user.ID)
 	store.CreateAgent(ctx, "bot@test-email.example.com", "test-email.example.com", "", "https://example.com/webhook", "", user.ID)
@@ -1433,7 +1433,7 @@ func TestSendTestEmailUnverifiedDomain(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-unverified-test@example.com", "Owner", "google-unverified-test")
-	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "unverified-test-key")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "unverified-test-key", nil)
 	store.ClaimOrCreateDomain(ctx, "unverified-test.example.com", user.ID)
 	store.CreateAgent(ctx, "bot@unverified-test.example.com", "unverified-test.example.com", "", "https://example.com/webhook", "", user.ID)
 

--- a/internal/agent/hitl_agent_update_test.go
+++ b/internal/agent/hitl_agent_update_test.go
@@ -31,7 +31,7 @@ func TestUpdateAgentHITLViaV1Endpoint(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-v1-up@example.com", "Owner", "google-v1-up")
-	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "v1-up-key")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "v1-up-key", nil)
 	store.ClaimOrCreateDomain(ctx, "v1up.example.com", user.ID)
 	store.VerifyDomain(ctx, "v1up.example.com", user.ID)
 	agent, _ := store.CreateAgent(ctx, "bot@v1up.example.com", "v1up.example.com", "", "https://example.com/webhook", "", user.ID)
@@ -67,7 +67,7 @@ func TestUpdateAgentPartialHITLPreservesOthers(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-v1-part@example.com", "Owner", "google-v1-part")
-	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "v1-part-key")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "v1-part-key", nil)
 	store.ClaimOrCreateDomain(ctx, "v1part.example.com", user.ID)
 	store.VerifyDomain(ctx, "v1part.example.com", user.ID)
 	agent, _ := store.CreateAgent(ctx, "bot@v1part.example.com", "v1part.example.com", "", "https://example.com/webhook", "", user.ID)
@@ -100,7 +100,7 @@ func TestUpdateAgentRejectsEmptyBody(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-v1-empty@example.com", "Owner", "google-v1-empty")
-	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "v1-empty-key")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "v1-empty-key", nil)
 	store.ClaimOrCreateDomain(ctx, "v1empty.example.com", user.ID)
 	store.VerifyDomain(ctx, "v1empty.example.com", user.ID)
 	agent, _ := store.CreateAgent(ctx, "bot@v1empty.example.com", "v1empty.example.com", "", "https://example.com/webhook", "", user.ID)
@@ -117,7 +117,7 @@ func TestUpdateAgentRejectsInvalidExpirationAction(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-v1-bad@example.com", "Owner", "google-v1-bad")
-	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "v1-bad-key")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "v1-bad-key", nil)
 	store.ClaimOrCreateDomain(ctx, "v1bad.example.com", user.ID)
 	store.VerifyDomain(ctx, "v1bad.example.com", user.ID)
 	agent, _ := store.CreateAgent(ctx, "bot@v1bad.example.com", "v1bad.example.com", "", "https://example.com/webhook", "", user.ID)
@@ -140,7 +140,7 @@ func TestUpdateAgentCrossUserForbidden(t *testing.T) {
 	agentA, _ := store.CreateAgent(ctx, "bot@acrossup.example.com", "acrossup.example.com", "", "https://example.com/webhook", "", userA.ID)
 
 	userB, _ := store.CreateOrGetUser(ctx, "b-cross-up@example.com", "B", "google-b-cross-up")
-	keyB, _ := store.CreateAPIKey(ctx, userB.ID, "b-cross-up-key")
+	keyB, _ := store.CreateAPIKey(ctx, userB.ID, "b-cross-up-key", nil)
 
 	resp := authedPut(t, server.URL+"/api/v1/agents/"+agentA.ID,
 		`{"hitl_enabled":true}`, keyB.PlaintextKey)

--- a/internal/agent/hitl_api.go
+++ b/internal/agent/hitl_api.go
@@ -42,6 +42,8 @@ type pendingMessageDetail struct {
 	Attachments       []outbound.Attachment `json:"attachments,omitempty"`
 	Edited            bool                  `json:"edited,omitempty"`
 	ReviewedAt        string                `json:"reviewed_at,omitempty"`
+	ReviewedByUserID  *string               `json:"reviewed_by_user_id,omitempty"`
+	ReviewedByName    *string               `json:"reviewed_by_name,omitempty"`
 	RejectionReason   string                `json:"rejection_reason,omitempty"`
 	ProviderMessageID string                `json:"provider_message_id,omitempty"`
 	Method            string                `json:"method,omitempty"`
@@ -74,6 +76,8 @@ func messageToDetail(m identity.Message) pendingMessageDetail {
 		BodyText:              m.BodyText,
 		BodyHTML:              m.BodyHTML,
 		Edited:                m.Edited,
+		ReviewedByUserID:      m.ReviewedByUserID,
+		ReviewedByName:        m.ReviewedByName,
 		RejectionReason:       m.RejectionReason,
 		ProviderMessageID:     m.ProviderMessageID,
 		Method:                m.Method,

--- a/internal/agent/hitl_api_test.go
+++ b/internal/agent/hitl_api_test.go
@@ -29,7 +29,7 @@ func TestSendEmailHITLGateHolds(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-hitl-send@example.com", "Owner", "google-hitl-send")
-	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "hitl-send-key")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "hitl-send-key", nil)
 	store.ClaimOrCreateDomain(ctx, "hitl-send.example.com", user.ID)
 	store.VerifyDomain(ctx, "hitl-send.example.com", user.ID)
 	agent, _ := store.CreateAgent(ctx, "bot@hitl-send.example.com", "hitl-send.example.com", "", "https://example.com/webhook", "", user.ID)
@@ -124,7 +124,7 @@ func TestSendEmailHITLGatePersistsAttachments(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-hitl-att@example.com", "Owner", "google-hitl-att")
-	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "hitl-att-key")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "hitl-att-key", nil)
 	store.ClaimOrCreateDomain(ctx, "hitl-att.example.com", user.ID)
 	store.VerifyDomain(ctx, "hitl-att.example.com", user.ID)
 	agent, _ := store.CreateAgent(ctx, "bot@hitl-att.example.com", "hitl-att.example.com", "", "https://example.com/webhook", "", user.ID)
@@ -176,7 +176,7 @@ func TestSendEmailHITLOffStillSends(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-hitl-off@example.com", "Owner", "google-hitl-off")
-	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "hitl-off-key")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "hitl-off-key", nil)
 	store.ClaimOrCreateDomain(ctx, "hitl-off.example.com", user.ID)
 	store.VerifyDomain(ctx, "hitl-off.example.com", user.ID)
 	store.CreateAgent(ctx, "bot@hitl-off.example.com", "hitl-off.example.com", "", "https://example.com/webhook", "", user.ID)
@@ -215,7 +215,7 @@ func TestReplyHITLGateHoldsWithReplyTo(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-hitl-reply@example.com", "Owner", "google-hitl-reply")
-	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "hitl-reply-key")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "hitl-reply-key", nil)
 	store.ClaimOrCreateDomain(ctx, "hitl-reply.example.com", user.ID)
 	store.VerifyDomain(ctx, "hitl-reply.example.com", user.ID)
 	agent, _ := store.CreateAgent(ctx, "bot@hitl-reply.example.com", "hitl-reply.example.com", "", "https://example.com/webhook", "", user.ID)
@@ -290,7 +290,7 @@ func TestSendTestEmailHITLGate(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-hitl-test@example.com", "Owner", "google-hitl-test")
-	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "hitl-test-key")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "hitl-test-key", nil)
 	store.ClaimOrCreateDomain(ctx, "hitl-test.example.com", user.ID)
 	store.VerifyDomain(ctx, "hitl-test.example.com", user.ID)
 	agent, _ := store.CreateAgent(ctx, "bot@hitl-test.example.com", "hitl-test.example.com", "", "https://example.com/webhook", "", user.ID)
@@ -358,7 +358,7 @@ func TestSendTestEmailHITLApproveDeliversViaLoopback(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-hitl-test-approve@example.com", "Owner", "google-hitl-test-approve")
-	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "hitl-test-approve-key")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "hitl-test-approve-key", nil)
 	store.ClaimOrCreateDomain(ctx, "hitl-test-approve.example.com", user.ID)
 	store.VerifyDomain(ctx, "hitl-test-approve.example.com", user.ID)
 	agent, _ := store.CreateAgent(ctx, "bot@hitl-test-approve.example.com", "hitl-test-approve.example.com", "", "https://example.com/webhook", "", user.ID)

--- a/internal/agent/hitl_approval_api_test.go
+++ b/internal/agent/hitl_approval_api_test.go
@@ -39,7 +39,7 @@ func TestListPendingMessagesHandler(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-list@example.com", "Owner", "google-list-handler")
-	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "list-key")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "list-key", nil)
 	store.ClaimOrCreateDomain(ctx, "list-h.example.com", user.ID)
 	store.VerifyDomain(ctx, "list-h.example.com", user.ID)
 	agent, _ := store.CreateAgent(ctx, "bot@list-h.example.com", "list-h.example.com", "", "https://example.com/webhook", "", user.ID)
@@ -97,7 +97,7 @@ func TestListPendingMessagesRejectsOtherStatus(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-listreject@example.com", "Owner", "google-list-reject")
-	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "list-reject-key")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "list-reject-key", nil)
 
 	resp := authed(t, "GET", server.URL+"/api/v1/messages?status=sent", "", apiKey.PlaintextKey)
 	defer resp.Body.Close()
@@ -112,7 +112,7 @@ func TestGetOutboundMessageHandler(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-getdetail@example.com", "Owner", "google-get-detail")
-	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "get-detail-key")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "get-detail-key", nil)
 	store.ClaimOrCreateDomain(ctx, "get-detail.example.com", user.ID)
 	store.VerifyDomain(ctx, "get-detail.example.com", user.ID)
 	agent, _ := store.CreateAgent(ctx, "bot@get-detail.example.com", "get-detail.example.com", "", "https://example.com/webhook", "", user.ID)
@@ -158,7 +158,7 @@ func TestGetOutboundMessageCrossUserReturns404(t *testing.T) {
 
 	// User A creates pending
 	userA, _ := store.CreateOrGetUser(ctx, "owner-cross-a@example.com", "A", "google-cross-a")
-	keyA, _ := store.CreateAPIKey(ctx, userA.ID, "a-key")
+	keyA, _ := store.CreateAPIKey(ctx, userA.ID, "a-key", nil)
 	store.ClaimOrCreateDomain(ctx, "cross-a.example.com", userA.ID)
 	store.VerifyDomain(ctx, "cross-a.example.com", userA.ID)
 	agentA, _ := store.CreateAgent(ctx, "bot@cross-a.example.com", "cross-a.example.com", "", "https://example.com/webhook", "", userA.ID)
@@ -166,7 +166,7 @@ func TestGetOutboundMessageCrossUserReturns404(t *testing.T) {
 
 	// User B (no access to A's messages)
 	userB, _ := store.CreateOrGetUser(ctx, "owner-cross-b@example.com", "B", "google-cross-b")
-	keyB, _ := store.CreateAPIKey(ctx, userB.ID, "b-key")
+	keyB, _ := store.CreateAPIKey(ctx, userB.ID, "b-key", nil)
 
 	resp := authed(t, "POST", server.URL+"/api/v1/send",
 		`{"to":["x@example.com"],"subject":"h","body":"b"}`, keyA.PlaintextKey)
@@ -189,7 +189,7 @@ func TestApprovePendingMessageSendsViaSMTP(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-approve@example.com", "Owner", "google-approve-handler")
-	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "approve-key")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "approve-key", nil)
 	store.ClaimOrCreateDomain(ctx, "approve-h.example.com", user.ID)
 	store.VerifyDomain(ctx, "approve-h.example.com", user.ID)
 	agent, _ := store.CreateAgent(ctx, "bot@approve-h.example.com", "approve-h.example.com", "", "https://example.com/webhook", "", user.ID)
@@ -256,7 +256,7 @@ func TestApprovePendingMessageWithEditsSendsEditedContent(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-apprv-edit@example.com", "Owner", "google-apprv-edit")
-	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "apprv-edit-key")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "apprv-edit-key", nil)
 	store.ClaimOrCreateDomain(ctx, "apprv-edit.example.com", user.ID)
 	store.VerifyDomain(ctx, "apprv-edit.example.com", user.ID)
 	agent, _ := store.CreateAgent(ctx, "bot@apprv-edit.example.com", "apprv-edit.example.com", "", "https://example.com/webhook", "", user.ID)
@@ -309,7 +309,7 @@ func TestApproveAlreadySentReturns409(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-apprv-409@example.com", "Owner", "google-apprv-409")
-	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "apprv-409-key")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "apprv-409-key", nil)
 	store.ClaimOrCreateDomain(ctx, "apprv-409.example.com", user.ID)
 	store.VerifyDomain(ctx, "apprv-409.example.com", user.ID)
 	agent, _ := store.CreateAgent(ctx, "bot@apprv-409.example.com", "apprv-409.example.com", "", "https://example.com/webhook", "", user.ID)
@@ -332,7 +332,7 @@ func TestApproveReplyFromHITLUsesStoredReplyTo(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-apprv-reply@example.com", "Owner", "google-apprv-reply")
-	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "apprv-reply-key")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "apprv-reply-key", nil)
 	store.ClaimOrCreateDomain(ctx, "apprv-reply.example.com", user.ID)
 	store.VerifyDomain(ctx, "apprv-reply.example.com", user.ID)
 	agent, _ := store.CreateAgent(ctx, "bot@apprv-reply.example.com", "apprv-reply.example.com", "", "https://example.com/webhook", "", user.ID)
@@ -373,7 +373,7 @@ func TestRejectPendingMessageHandler(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-reject-h@example.com", "Owner", "google-reject-h")
-	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "reject-h-key")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "reject-h-key", nil)
 	store.ClaimOrCreateDomain(ctx, "reject-h.example.com", user.ID)
 	store.VerifyDomain(ctx, "reject-h.example.com", user.ID)
 	agent, _ := store.CreateAgent(ctx, "bot@reject-h.example.com", "reject-h.example.com", "", "https://example.com/webhook", "", user.ID)
@@ -424,7 +424,7 @@ func TestRejectAlreadyRejectedReturns409(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "owner-reject-twice@example.com", "Owner", "google-reject-twice-h")
-	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "reject-twice-key")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "reject-twice-key", nil)
 	store.ClaimOrCreateDomain(ctx, "reject-twice.example.com", user.ID)
 	store.VerifyDomain(ctx, "reject-twice.example.com", user.ID)
 	agent, _ := store.CreateAgent(ctx, "bot@reject-twice.example.com", "reject-twice.example.com", "", "https://example.com/webhook", "", user.ID)
@@ -459,14 +459,14 @@ func TestApproveCrossUserReturns404(t *testing.T) {
 	ctx := context.Background()
 
 	userA, _ := store.CreateOrGetUser(ctx, "a-apprv-cross@example.com", "A", "google-a-cross")
-	keyA, _ := store.CreateAPIKey(ctx, userA.ID, "a-cross-key")
+	keyA, _ := store.CreateAPIKey(ctx, userA.ID, "a-cross-key", nil)
 	store.ClaimOrCreateDomain(ctx, "a-cross.example.com", userA.ID)
 	store.VerifyDomain(ctx, "a-cross.example.com", userA.ID)
 	agentA, _ := store.CreateAgent(ctx, "bot@a-cross.example.com", "a-cross.example.com", "", "https://example.com/webhook", "", userA.ID)
 	enableHITL(t, store, agentA.ID, userA.ID)
 
 	userB, _ := store.CreateOrGetUser(ctx, "b-apprv-cross@example.com", "B", "google-b-cross")
-	keyB, _ := store.CreateAPIKey(ctx, userB.ID, "b-cross-key")
+	keyB, _ := store.CreateAPIKey(ctx, userB.ID, "b-cross-key", nil)
 
 	sendResp := authed(t, "POST", server.URL+"/api/v1/send",
 		`{"to":["x@example.com"],"subject":"h","body":"b"}`, keyA.PlaintextKey)

--- a/internal/agent/oauth_bearer_test.go
+++ b/internal/agent/oauth_bearer_test.go
@@ -228,7 +228,7 @@ func TestBearer_APIKey_StillWorks(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	key, err := store.CreateAPIKey(ctx, user.ID, "test-key")
+	key, err := store.CreateAPIKey(ctx, user.ID, "test-key", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/agent/selfsend_test.go
+++ b/internal/agent/selfsend_test.go
@@ -22,7 +22,7 @@ func TestSelfSend_HappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateOrGetUser: %v", err)
 	}
-	apiKeyObj, err := store.CreateAPIKey(ctx, user.ID, "self-send-key")
+	apiKeyObj, err := store.CreateAPIKey(ctx, user.ID, "self-send-key", nil)
 	if err != nil {
 		t.Fatalf("CreateAPIKey: %v", err)
 	}
@@ -111,7 +111,7 @@ func TestSelfSend_PreservesAttachmentsInMIME(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateOrGetUser: %v", err)
 	}
-	apiKeyObj, err := store.CreateAPIKey(ctx, user.ID, "self-attach-key")
+	apiKeyObj, err := store.CreateAPIKey(ctx, user.ID, "self-attach-key", nil)
 	if err != nil {
 		t.Fatalf("CreateAPIKey: %v", err)
 	}
@@ -202,7 +202,7 @@ func TestSelfSend_NoAttachmentsUsesSinglePart(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "self-plain@example.com", "Owner", "google-self-plain")
-	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "self-plain-key")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "self-plain-key", nil)
 	store.ClaimOrCreateDomain(ctx, "selfplain.example.com", user.ID)
 	store.VerifyDomain(ctx, "selfplain.example.com", user.ID)
 	store.CreateAgent(ctx, "bot@selfplain.example.com", "selfplain.example.com", "", "", "local", user.ID)
@@ -252,7 +252,7 @@ func TestSelfReply_LoopbackShortCircuit(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "self-reply@example.com", "Owner", "google-self-reply")
-	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "self-reply-key")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "self-reply-key", nil)
 	store.ClaimOrCreateDomain(ctx, "selfreply.example.com", user.ID)
 	store.VerifyDomain(ctx, "selfreply.example.com", user.ID)
 	store.CreateAgent(ctx, "bot@selfreply.example.com", "selfreply.example.com", "", "", "local", user.ID)
@@ -350,7 +350,7 @@ func TestSelfReply_ReplyAllOnSelfThread_LoopbackShortCircuit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateOrGetUser: %v", err)
 	}
-	apiKeyObj, err := store.CreateAPIKey(ctx, user.ID, "self-replyall-key")
+	apiKeyObj, err := store.CreateAPIKey(ctx, user.ID, "self-replyall-key", nil)
 	if err != nil {
 		t.Fatalf("CreateAPIKey: %v", err)
 	}
@@ -432,7 +432,7 @@ func TestSelfSend_HoldsForHITL(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateOrGetUser: %v", err)
 	}
-	apiKeyObj, err := store.CreateAPIKey(ctx, user.ID, "hitl-self-key")
+	apiKeyObj, err := store.CreateAPIKey(ctx, user.ID, "hitl-self-key", nil)
 	if err != nil {
 		t.Fatalf("CreateAPIKey: %v", err)
 	}
@@ -500,7 +500,7 @@ func TestSelfSend_HITLApprovalDeliversViaLoopback(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateOrGetUser: %v", err)
 	}
-	apiKeyObj, err := store.CreateAPIKey(ctx, user.ID, "hitl-self-approve-key")
+	apiKeyObj, err := store.CreateAPIKey(ctx, user.ID, "hitl-self-approve-key", nil)
 	if err != nil {
 		t.Fatalf("CreateAPIKey: %v", err)
 	}
@@ -577,7 +577,7 @@ func TestSelfSend_RequiresVerifiedDomain(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "self-unverified@example.com", "Owner", "google-self-unv")
-	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "self-unv-key")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "self-unv-key", nil)
 	store.ClaimOrCreateDomain(ctx, "selfunv.example.com", user.ID)
 	// no VerifyDomain
 	store.CreateAgent(ctx, "bot@selfunv.example.com", "selfunv.example.com", "", "", "local", user.ID)

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -243,7 +243,7 @@ func (ua *UserAuth) defaultAgentEmail(ctx context.Context, userID string) string
 }
 
 func (ua *UserAuth) writeCLIHandoffPage(w http.ResponseWriter, r *http.Request, user *identity.User, handoff *cliLoginHandoff) error {
-	key, err := ua.store.CreateAPIKey(r.Context(), user.ID, "CLI login")
+	key, err := ua.store.CreateAPIKey(r.Context(), user.ID, "CLI login", nil)
 	if err != nil {
 		return fmt.Errorf("failed to create api key: %w", err)
 	}
@@ -459,6 +459,60 @@ func (ua *UserAuth) HandleMe(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, user)
 }
 
+// HandleUpdateMe accepts a PATCH that updates the authenticated user's
+// display name. Other identity fields (email, google_subject) come from
+// the OAuth provider and are not user-editable.
+//
+// Validation:
+//   - name: required, 1–80 chars after TrimSpace
+//   - rejects leading/trailing whitespace by comparing to TrimSpace
+//     (we don't silently normalize — that would surprise a caller who
+//     expected their exact bytes back from /me)
+const (
+	minDisplayNameLen = 1
+	maxDisplayNameLen = 80
+)
+
+func (ua *UserAuth) HandleUpdateMe(w http.ResponseWriter, r *http.Request) {
+	user := ua.AuthenticateRequest(r)
+	if user == nil {
+		http.Error(w, "not authenticated", http.StatusUnauthorized)
+		return
+	}
+
+	var req struct {
+		Name *string `json:"name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+
+	if req.Name == nil {
+		http.Error(w, "no fields to update", http.StatusBadRequest)
+		return
+	}
+
+	name := *req.Name
+	if name != strings.TrimSpace(name) {
+		http.Error(w, "name must not have leading or trailing whitespace", http.StatusBadRequest)
+		return
+	}
+	if len(name) < minDisplayNameLen || len(name) > maxDisplayNameLen {
+		http.Error(w, "name must be 1–80 characters", http.StatusBadRequest)
+		return
+	}
+
+	updated, err := ua.store.UpdateUserName(r.Context(), user.ID, name)
+	if err != nil {
+		http.Error(w, "failed to update profile", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	writeJSON(w, updated)
+}
+
 // AuthenticateRequest extracts the user from the session cookie. Returns nil if not authenticated.
 func (ua *UserAuth) AuthenticateRequest(r *http.Request) *identity.User {
 	cookie, err := r.Cookie(SessionCookieName)
@@ -492,6 +546,27 @@ func fetchGoogleUserInfo(ctx context.Context, cfg *oauth2.Config, token *oauth2.
 		return nil, err
 	}
 	return &info, nil
+}
+
+// HandleDashboardStats returns the workspace-level aggregates for the
+// redesigned dashboard's stats strip. See identity.GetDashboardStats
+// for the data sources and the graceful-degradation behavior when
+// usage tracking is disabled (the default for self-hosters).
+func (ua *UserAuth) HandleDashboardStats(w http.ResponseWriter, r *http.Request) {
+	user := ua.AuthenticateRequest(r)
+	if user == nil {
+		http.Error(w, "not authenticated", http.StatusUnauthorized)
+		return
+	}
+
+	stats, err := ua.store.GetDashboardStats(r.Context(), user.ID)
+	if err != nil {
+		http.Error(w, "failed to fetch dashboard stats", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	writeJSON(w, stats)
 }
 
 // HandleDashboardAgents lists agents owned by the authenticated user.
@@ -695,11 +770,29 @@ func (ua *UserAuth) HandleCreateAPIKey(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req struct {
-		Name string `json:"name"`
+		Name      string  `json:"name"`
+		ExpiresAt *string `json:"expires_at,omitempty"` // optional ISO 8601 timestamp
 	}
 	json.NewDecoder(r.Body).Decode(&req)
 
-	key, err := ua.store.CreateAPIKey(r.Context(), user.ID, req.Name)
+	// Parse optional expires_at. Empty string and missing field both mean
+	// "never expires" — symmetric with the NULL column default. Malformed
+	// or already-past timestamps are client errors, not "use NULL silently."
+	var expiresAt *time.Time
+	if req.ExpiresAt != nil && *req.ExpiresAt != "" {
+		t, err := time.Parse(time.RFC3339, *req.ExpiresAt)
+		if err != nil {
+			http.Error(w, "expires_at must be an RFC 3339 timestamp", http.StatusBadRequest)
+			return
+		}
+		if !t.After(time.Now()) {
+			http.Error(w, "expires_at must be in the future", http.StatusBadRequest)
+			return
+		}
+		expiresAt = &t
+	}
+
+	key, err := ua.store.CreateAPIKey(r.Context(), user.ID, req.Name, expiresAt)
 	if err != nil {
 		http.Error(w, "failed to create API key", http.StatusInternalServerError)
 		return

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/Mnexa-AI/e2a/internal/auth"
 	"github.com/Mnexa-AI/e2a/internal/config"
@@ -145,5 +147,268 @@ func TestHandleAgentActivity_WithMessages(t *testing.T) {
 	}
 	if activity[2].Direction != "inbound" || activity[2].Subject != "Hello" {
 		t.Errorf("third entry: direction=%q subject=%q", activity[2].Direction, activity[2].Subject)
+	}
+}
+
+
+// --- API key endpoints (Item #3) ---
+
+// authedJSON constructs a POST/PATCH with a JSON body and session cookie.
+// Local to auth_test so the existing authedRequest stays body-less.
+func authedJSON(method, url, sessionToken, body string) *http.Request {
+	req := httptest.NewRequest(method, url, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.AddCookie(&http.Cookie{Name: auth.SessionCookieName, Value: sessionToken})
+	return req
+}
+
+// TestHandleListAPIKeys_ReturnsLastUsedAtAndExpiresAt: the dashboard
+// API keys table needs both columns to render. Asserts the JSON
+// response actually carries them (previously dropped from the SELECT).
+func TestHandleListAPIKeys_ReturnsLastUsedAtAndExpiresAt(t *testing.T) {
+	ua, store, token := setupUserAuth(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "josh@test.com", "Josh", "google-sub-123")
+	expiresAt := time.Now().Add(7 * 24 * time.Hour).UTC().Truncate(time.Second)
+	store.CreateAPIKey(ctx, user.ID, "with-exp", &expiresAt)
+	store.CreateAPIKey(ctx, user.ID, "no-exp", nil)
+
+	req := authedRequest("GET", "/api/keys", token)
+	w := httptest.NewRecorder()
+	ua.HandleListAPIKeys(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var keys []identity.APIKey
+	if err := json.NewDecoder(w.Body).Decode(&keys); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(keys) != 2 {
+		t.Fatalf("expected 2 keys, got %d", len(keys))
+	}
+	// One key must carry ExpiresAt; the other must have it nil.
+	var sawExpiry, sawNoExpiry bool
+	for _, k := range keys {
+		if k.Name == "with-exp" {
+			if k.ExpiresAt == nil || !k.ExpiresAt.Equal(expiresAt) {
+				t.Errorf("with-exp ExpiresAt = %v, want %v", k.ExpiresAt, expiresAt)
+			}
+			sawExpiry = true
+		}
+		if k.Name == "no-exp" {
+			if k.ExpiresAt != nil {
+				t.Errorf("no-exp ExpiresAt = %v, want nil", k.ExpiresAt)
+			}
+			sawNoExpiry = true
+		}
+	}
+	if !sawExpiry || !sawNoExpiry {
+		t.Errorf("expected both with-exp and no-exp in response; sawExpiry=%v sawNoExpiry=%v", sawExpiry, sawNoExpiry)
+	}
+}
+
+// TestHandleCreateAPIKey_AcceptsExpiresAt: POST /api/keys with a
+// future RFC 3339 timestamp persists it on the row.
+func TestHandleCreateAPIKey_AcceptsExpiresAt(t *testing.T) {
+	ua, store, token := setupUserAuth(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "josh@test.com", "Josh", "google-sub-123")
+
+	expiresAt := time.Now().Add(48 * time.Hour).UTC().Truncate(time.Second)
+	body := `{"name":"ci","expires_at":"` + expiresAt.Format(time.RFC3339) + `"}`
+	req := authedJSON("POST", "/api/keys", token, body)
+	w := httptest.NewRecorder()
+	ua.HandleCreateAPIKey(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body=%s", w.Code, w.Body.String())
+	}
+	var created identity.APIKey
+	json.NewDecoder(w.Body).Decode(&created)
+	if created.ExpiresAt == nil || !created.ExpiresAt.Equal(expiresAt) {
+		t.Errorf("created.ExpiresAt = %v, want %v", created.ExpiresAt, expiresAt)
+	}
+
+	// Round-trip through the DB to confirm it was actually persisted.
+	keys, _ := store.ListAPIKeys(ctx, user.ID)
+	if len(keys) != 1 || keys[0].ExpiresAt == nil || !keys[0].ExpiresAt.Equal(expiresAt) {
+		t.Errorf("persisted ExpiresAt mismatch: %+v", keys)
+	}
+}
+
+// TestHandleCreateAPIKey_RejectsPastExpiresAt: a past timestamp must
+// be a 400 — silently swallowing it would issue a key that's already
+// expired, which is worse UX than rejecting at create time.
+func TestHandleCreateAPIKey_RejectsPastExpiresAt(t *testing.T) {
+	ua, _, token := setupUserAuth(t)
+
+	past := time.Now().Add(-1 * time.Hour).UTC().Format(time.RFC3339)
+	req := authedJSON("POST", "/api/keys", token, `{"name":"backdated","expires_at":"`+past+`"}`)
+	w := httptest.NewRecorder()
+	ua.HandleCreateAPIKey(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleCreateAPIKey_RejectsMalformedExpiresAt: not-RFC-3339 →
+// 400, not "silently fall back to NULL." The handler chooses to fail
+// loudly because misformed input is a real client bug worth surfacing.
+func TestHandleCreateAPIKey_RejectsMalformedExpiresAt(t *testing.T) {
+	ua, _, token := setupUserAuth(t)
+
+	req := authedJSON("POST", "/api/keys", token, `{"name":"bad","expires_at":"next-tuesday"}`)
+	w := httptest.NewRecorder()
+	ua.HandleCreateAPIKey(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+}
+
+// --- PATCH /api/auth/me (Item #8) ---
+
+func TestHandleUpdateMe_HappyPath(t *testing.T) {
+	ua, store, token := setupUserAuth(t)
+	ctx := context.Background()
+
+	req := authedJSON("PATCH", "/api/auth/me", token, `{"name":"Jamie"}`)
+	w := httptest.NewRecorder()
+	ua.HandleUpdateMe(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var got identity.User
+	json.NewDecoder(w.Body).Decode(&got)
+	if got.Name != "Jamie" {
+		t.Errorf("returned Name = %q, want Jamie", got.Name)
+	}
+
+	// Round-trip: a follow-up GetUserByID sees the persisted name.
+	persisted, _ := store.GetUserByID(ctx, got.ID)
+	if persisted.Name != "Jamie" {
+		t.Errorf("persisted Name = %q, want Jamie", persisted.Name)
+	}
+}
+
+func TestHandleUpdateMe_Unauthenticated(t *testing.T) {
+	ua, _, _ := setupUserAuth(t)
+
+	req := httptest.NewRequest("PATCH", "/api/auth/me", strings.NewReader(`{"name":"Jamie"}`))
+	w := httptest.NewRecorder()
+	ua.HandleUpdateMe(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestHandleUpdateMe_ValidationErrors(t *testing.T) {
+	ua, _, token := setupUserAuth(t)
+
+	// Each case asserts that the validation gate fires and a 400 is
+	// returned BEFORE any DB write. The handler chooses to reject rather
+	// than normalize so a caller's exact bytes round-trip cleanly through
+	// /me on the next GET.
+	cases := []struct {
+		name string
+		body string
+	}{
+		{"empty string", `{"name":""}`},
+		{"leading whitespace", `{"name":" Jamie"}`},
+		{"trailing whitespace", `{"name":"Jamie "}`},
+		{"too long", `{"name":"` + strings.Repeat("a", 81) + `"}`},
+		{"missing name field", `{}`},
+		{"malformed JSON", `{not-json}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := authedJSON("PATCH", "/api/auth/me", token, tc.body)
+			w := httptest.NewRecorder()
+			ua.HandleUpdateMe(w, req)
+			if w.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestHandleUpdateMe_MaxBoundary(t *testing.T) {
+	// 80 chars must succeed; 81 already covered by ValidationErrors.
+	ua, _, token := setupUserAuth(t)
+
+	body := `{"name":"` + strings.Repeat("a", 80) + `"}`
+	req := authedJSON("PATCH", "/api/auth/me", token, body)
+	w := httptest.NewRecorder()
+	ua.HandleUpdateMe(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("80-char name should succeed; got status=%d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// --- Dashboard stats endpoint (Item #1) ---
+
+// TestHandleDashboardStats_HappyPath: GET /api/dashboard/stats wraps
+// store.GetDashboardStats. Asserts the JSON shape matches the spec
+// in BACKEND_TODO #1 (sections for today / pending / delivery /
+// window).
+func TestHandleDashboardStats_HappyPath(t *testing.T) {
+	ua, store, token := setupUserAuth(t)
+	ctx := context.Background()
+
+	// Need to look up the user that setupUserAuth created so we can
+	// seed usage rows against the right user_id.
+	user, _ := store.GetUserSession(ctx, token)
+
+	// Seed today + yesterday rows.
+	_, err := store.GetDashboardStats(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("pre-seed GetDashboardStats: %v", err)
+	}
+
+	req := authedRequest("GET", "/api/dashboard/stats", token)
+	w := httptest.NewRecorder()
+	ua.HandleDashboardStats(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	var got struct {
+		Today struct {
+			Inbound          int `json:"inbound"`
+			Outbound         int `json:"outbound"`
+			InboundDeltaPct  int `json:"inbound_delta_pct"`
+			OutboundDeltaPct int `json:"outbound_delta_pct"`
+		} `json:"today"`
+		Pending struct {
+			Count         int `json:"count"`
+			OldestSeconds int `json:"oldest_seconds"`
+		} `json:"pending"`
+		DeliverySuccessPct float64 `json:"delivery_success_pct"`
+		SampleWindowDays   int     `json:"sample_window_days"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.SampleWindowDays != 7 {
+		t.Errorf("sample_window_days = %d, want 7", got.SampleWindowDays)
+	}
+}
+
+func TestHandleDashboardStats_Unauthenticated(t *testing.T) {
+	ua, _, _ := setupUserAuth(t)
+
+	req := httptest.NewRequest("GET", "/api/dashboard/stats", nil)
+	w := httptest.NewRecorder()
+	ua.HandleDashboardStats(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
 	}
 }

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -29,7 +29,7 @@ func setupDomainAndAgent(t *testing.T, ts *testutil.E2ATestServer, email, domain
 	if err != nil {
 		t.Fatalf("CreateOrGetUser: %v", err)
 	}
-	apiKey, err := ts.Store.CreateAPIKey(ctx, user.ID, domain+"-key")
+	apiKey, err := ts.Store.CreateAPIKey(ctx, user.ID, domain+"-key", nil)
 	if err != nil {
 		t.Fatalf("CreateAPIKey: %v", err)
 	}

--- a/internal/identity/hitl_approve_test.go
+++ b/internal/identity/hitl_approve_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/Mnexa-AI/e2a/internal/identity"
 	"github.com/Mnexa-AI/e2a/internal/testutil"
@@ -256,6 +257,109 @@ func TestApproveAndSendHappyPath(t *testing.T) {
 	}
 	if dbEdited {
 		t.Error("db edited should be false")
+	}
+}
+
+// TestApproveAndSend_RecordsReviewedBy: migration 012 attributes the
+// approval to the human reviewer. ApproveAndSend passes its userID
+// argument straight into reviewed_by_user_id; GetOutboundMessageForUser's
+// JOIN with users surfaces the reviewer's display name as
+// ReviewedByName.
+func TestApproveAndSend_RecordsReviewedBy(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, a := setupPendingAgent(t, store, "approve-reviewer")
+	// setupPendingAgent's user has Name="Owner"; the dashboard pulls
+	// reviewed_by_name from the JOIN'd users.name column, so the test
+	// asserts whatever that helper set.
+
+	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
+		[]string{"alice@example.com"}, nil, nil,
+		"With reviewer", "body", "", nil, "send", "", "", 3600)
+
+	sent, err := store.ApproveAndSend(ctx, msg.ID, user.ID, identity.PendingApprovalEdit{},
+		func(m *identity.Message) (identity.SendResult, error) {
+			return identity.SendResult{ProviderMessageID: "<x@y>", Method: "smtp", To: m.ToRecipients}, nil
+		})
+	if err != nil {
+		t.Fatalf("ApproveAndSend: %v", err)
+	}
+	if sent.ReviewedByUserID == nil || *sent.ReviewedByUserID != user.ID {
+		t.Errorf("returned ReviewedByUserID = %v, want %q", sent.ReviewedByUserID, user.ID)
+	}
+
+	// Round-trip via GetOutboundMessageForUser — the JOIN with users
+	// must populate ReviewedByName for the detail panel.
+	got, err := store.GetOutboundMessageForUser(ctx, msg.ID, user.ID)
+	if err != nil {
+		t.Fatalf("GetOutboundMessageForUser: %v", err)
+	}
+	if got.ReviewedByUserID == nil || *got.ReviewedByUserID != user.ID {
+		t.Errorf("ReviewedByUserID via Get = %v, want %q", got.ReviewedByUserID, user.ID)
+	}
+	if got.ReviewedByName == nil || *got.ReviewedByName == "" {
+		t.Errorf("ReviewedByName via Get should be populated; got %v", got.ReviewedByName)
+	}
+}
+
+// TestRejectPending_RecordsReviewedBy: same shape for the reject side.
+func TestRejectPending_RecordsReviewedBy(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, a := setupPendingAgent(t, store, "reject-reviewer")
+	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
+		[]string{"alice@example.com"}, nil, nil,
+		"to-reject", "body", "", nil, "send", "", "", 3600)
+
+	rejected, err := store.RejectPending(ctx, msg.ID, user.ID, "wrong tone")
+	if err != nil {
+		t.Fatalf("RejectPending: %v", err)
+	}
+	if rejected.ReviewedByUserID == nil || *rejected.ReviewedByUserID != user.ID {
+		t.Errorf("rejected ReviewedByUserID = %v, want %q", rejected.ReviewedByUserID, user.ID)
+	}
+	if rejected.ReviewedByName == nil || *rejected.ReviewedByName == "" {
+		t.Errorf("rejected ReviewedByName should be populated; got %v", rejected.ReviewedByName)
+	}
+}
+
+// TestExpireApprove_ReviewedByNil: TTL auto-approve has no human
+// reviewer, so reviewed_by_user_id stays NULL. The redesign's
+// pending detail panel uses this signal to render "expired"
+// instead of "approved by X".
+func TestExpireApprove_ReviewedByNil(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, a := setupPendingAgent(t, store, "expire-no-reviewer")
+	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
+		[]string{"alice@example.com"}, nil, nil,
+		"to-expire", "body", "", nil, "send", "", "", 3600)
+	// Backdate so ExpireApproveAndSend's pending+expired predicate fires.
+	pool.Exec(ctx, `UPDATE messages SET approval_expires_at = $1 WHERE id = $2`,
+		time.Now().Add(-5*time.Minute), msg.ID)
+
+	sent, err := store.ExpireApproveAndSend(ctx, msg.ID,
+		func(m *identity.Message) (identity.SendResult, error) {
+			return identity.SendResult{ProviderMessageID: "<x@y>", Method: "smtp", To: m.ToRecipients}, nil
+		})
+	if err != nil {
+		t.Fatalf("ExpireApproveAndSend: %v", err)
+	}
+	if sent.ReviewedByUserID != nil {
+		t.Errorf("ReviewedByUserID = %v, want nil on worker-triggered approve", sent.ReviewedByUserID)
+	}
+
+	// Detail endpoint also leaves both fields nil.
+	got, _ := store.GetOutboundMessageForUser(ctx, msg.ID, user.ID)
+	if got.ReviewedByUserID != nil || got.ReviewedByName != nil {
+		t.Errorf("detail row should have null reviewer (worker action); got userID=%v name=%v",
+			got.ReviewedByUserID, got.ReviewedByName)
 	}
 }
 

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -35,6 +35,20 @@ type Domain struct {
 	VerificationToken string     `json:"verification_token"`
 	CreatedAt         time.Time  `json:"created_at"`
 	VerifiedAt        *time.Time `json:"verified_at,omitempty"`
+	// IsPrimary marks the user's default domain. At most one TRUE per
+	// user (enforced by a partial unique index in migration 013).
+	IsPrimary bool `json:"is_primary"`
+	// LastCheckedAt is updated whenever the verification probe runs,
+	// successful or not. NULL until the first probe — distinct from
+	// "probed and failed" which is captured by `verified=false` + a
+	// non-null LastCheckedAt.
+	LastCheckedAt *time.Time `json:"last_checked_at,omitempty"`
+	// AgentCount is computed at read time by ListDomainsByUser and is
+	// not a persisted column. Single-domain LookupDomain leaves it at
+	// the zero value — callers that need the count call the list path
+	// (this column-versus-aggregate split avoids changing every store
+	// signature to thread an agent-counter through).
+	AgentCount int `json:"agent_count"`
 }
 
 type AgentIdentity struct {
@@ -148,7 +162,18 @@ type Message struct {
 	Status             string          `json:"status,omitempty"`
 	ApprovalExpiresAt  *time.Time      `json:"approval_expires_at,omitempty"`
 	ReviewedAt         *time.Time      `json:"reviewed_at,omitempty"`
-	RejectionReason    string          `json:"rejection_reason,omitempty"`
+	// ReviewedByUserID identifies the human reviewer who approved or
+	// rejected this message. NULL on worker-triggered transitions
+	// (TTL auto-approve / auto-reject) — operator-visible signal "no
+	// human looked at this." Set by ApproveAndSend and RejectPending,
+	// left null by ExpireApproveAndSend / ExpireReject.
+	ReviewedByUserID *string `json:"reviewed_by_user_id,omitempty"`
+	// ReviewedByName is the JOIN'd display name from the reviewer's
+	// users row, populated only by GetOutboundMessageForUser. List
+	// endpoints leave this empty to avoid a join-per-row cost — the
+	// pending-detail page is where reviewer attribution matters.
+	ReviewedByName  *string `json:"reviewed_by_name,omitempty"`
+	RejectionReason string          `json:"rejection_reason,omitempty"`
 	Edited             bool            `json:"edited,omitempty"`
 	BodyText           string          `json:"body_text,omitempty"`
 	BodyHTML           string          `json:"body_html,omitempty"`
@@ -221,9 +246,9 @@ func (s *Store) ClaimOrCreateDomain(ctx context.Context, domain, userID string) 
 		 SET user_id = EXCLUDED.user_id,
 		     verification_token = EXCLUDED.verification_token
 		 WHERE domains.verified = false
-		 RETURNING domain, user_id, verified, verification_token, created_at, verified_at`,
+		 RETURNING domain, user_id, verified, verification_token, created_at, verified_at, is_primary, last_checked_at`,
 		domain, userID, verificationToken,
-	).Scan(&d.Domain, &d.UserID, &d.Verified, &d.VerificationToken, &d.CreatedAt, &d.VerifiedAt)
+	).Scan(&d.Domain, &d.UserID, &d.Verified, &d.VerificationToken, &d.CreatedAt, &d.VerifiedAt, &d.IsPrimary, &d.LastCheckedAt)
 
 	if err == nil {
 		return d, nil
@@ -232,9 +257,9 @@ func (s *Store) ClaimOrCreateDomain(ctx context.Context, domain, userID string) 
 	// No row returned — domain exists and is verified. Check ownership.
 	existing := &Domain{}
 	err = s.pool.QueryRow(ctx,
-		`SELECT domain, user_id, verified, verification_token, created_at, verified_at
+		`SELECT domain, user_id, verified, verification_token, created_at, verified_at, is_primary, last_checked_at
 		 FROM domains WHERE domain = $1`, domain,
-	).Scan(&existing.Domain, &existing.UserID, &existing.Verified, &existing.VerificationToken, &existing.CreatedAt, &existing.VerifiedAt)
+	).Scan(&existing.Domain, &existing.UserID, &existing.Verified, &existing.VerificationToken, &existing.CreatedAt, &existing.VerifiedAt, &existing.IsPrimary, &existing.LastCheckedAt)
 	if err != nil {
 		return nil, fmt.Errorf("domain lookup failed: %w", err)
 	}
@@ -250,10 +275,10 @@ func (s *Store) ClaimOrCreateDomain(ctx context.Context, domain, userID string) 
 func (s *Store) LookupDomain(ctx context.Context, domain, userID string) (*Domain, error) {
 	d := &Domain{}
 	err := s.pool.QueryRow(ctx,
-		`SELECT domain, user_id, verified, verification_token, created_at, verified_at
+		`SELECT domain, user_id, verified, verification_token, created_at, verified_at, is_primary, last_checked_at
 		 FROM domains WHERE domain = $1 AND user_id = $2`,
 		normalizeDomain(domain), userID,
-	).Scan(&d.Domain, &d.UserID, &d.Verified, &d.VerificationToken, &d.CreatedAt, &d.VerifiedAt)
+	).Scan(&d.Domain, &d.UserID, &d.Verified, &d.VerificationToken, &d.CreatedAt, &d.VerifiedAt, &d.IsPrimary, &d.LastCheckedAt)
 	if err != nil {
 		return nil, fmt.Errorf("domain not found")
 	}
@@ -277,11 +302,18 @@ func (s *Store) VerifyDomain(ctx context.Context, domain, userID string) error {
 }
 
 // ListDomainsByUser returns all domains owned by the user (excludes system rows).
+// AgentCount is computed inline via a correlated subquery — one round-trip
+// regardless of how many domains the user has, and the per-row count is
+// cheap because (agent_identities.user_id, agent_identities.domain) is
+// indexed via the existing idx_agent_identities_user.
 func (s *Store) ListDomainsByUser(ctx context.Context, userID string) ([]Domain, error) {
 	rows, err := s.pool.Query(ctx,
-		`SELECT domain, user_id, verified, verification_token, created_at, verified_at
-		 FROM domains WHERE user_id = $1
-		 ORDER BY created_at DESC`, userID,
+		`SELECT d.domain, d.user_id, d.verified, d.verification_token, d.created_at, d.verified_at,
+		        d.is_primary, d.last_checked_at,
+		        (SELECT count(*) FROM agent_identities a WHERE a.domain = d.domain AND a.user_id = d.user_id) AS agent_count
+		 FROM domains d
+		 WHERE d.user_id = $1
+		 ORDER BY d.created_at DESC`, userID,
 	)
 	if err != nil {
 		return nil, err
@@ -291,12 +323,72 @@ func (s *Store) ListDomainsByUser(ctx context.Context, userID string) ([]Domain,
 	var domains []Domain
 	for rows.Next() {
 		var d Domain
-		if err := rows.Scan(&d.Domain, &d.UserID, &d.Verified, &d.VerificationToken, &d.CreatedAt, &d.VerifiedAt); err != nil {
+		if err := rows.Scan(&d.Domain, &d.UserID, &d.Verified, &d.VerificationToken, &d.CreatedAt, &d.VerifiedAt, &d.IsPrimary, &d.LastCheckedAt, &d.AgentCount); err != nil {
 			return nil, err
 		}
 		domains = append(domains, d)
 	}
 	return domains, rows.Err()
+}
+
+// SetDomainPrimary marks a domain as the user's primary in a single
+// transaction: first clear any other primary belonging to the user, then
+// set the requested domain. The partial unique index in migration 013
+// makes the clear-first step necessary — otherwise the two writes would
+// race and one would fail with a unique violation.
+//
+// Returns ErrDomainNotFound when the domain doesn't exist or isn't owned
+// by the user.
+func (s *Store) SetDomainPrimary(ctx context.Context, domain, userID string) error {
+	domain = normalizeDomain(domain)
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback(ctx)
+		}
+	}()
+
+	if _, err := tx.Exec(ctx,
+		`UPDATE domains SET is_primary = false WHERE user_id = $1 AND is_primary = true`,
+		userID); err != nil {
+		return err
+	}
+	tag, err := tx.Exec(ctx,
+		`UPDATE domains SET is_primary = true WHERE domain = $1 AND user_id = $2`,
+		domain, userID)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrDomainNotFound
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return err
+	}
+	committed = true
+	return nil
+}
+
+// TouchDomainLastChecked records that the verification probe ran. Call
+// this from POST /api/v1/domains/{domain}/verify whether the probe
+// succeeded or not — the LastCheckedAt column is "when did we last try",
+// not "when did we last succeed" (the latter is verified_at).
+func (s *Store) TouchDomainLastChecked(ctx context.Context, domain, userID string) error {
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE domains SET last_checked_at = now() WHERE domain = $1 AND user_id = $2`,
+		normalizeDomain(domain), userID)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrDomainNotFound
+	}
+	return nil
 }
 
 // HasAgentsOnDomain checks whether the owned domain still has agents.
@@ -849,6 +941,8 @@ func (s *Store) GetOutboundMessageForUser(ctx context.Context, messageID, userID
 		approvalExpires    *time.Time
 		reviewedAt         *time.Time
 		rejectionReason    *string
+		reviewedByID       *string
+		reviewedByName     *string
 	)
 	err := s.pool.QueryRow(ctx,
 		`SELECT m.id, m.agent_id, m.direction, m.sender, m.recipient, m.subject,
@@ -858,9 +952,11 @@ func (s *Store) GetOutboundMessageForUser(ctx context.Context, messageID, userID
 		        m.to_recipients, m.cc, m.bcc,
 		        m.status, m.approval_expires_at, m.reviewed_at,
 		        m.rejection_reason, m.edited,
-		        m.body_text, m.body_html, m.attachments_json
+		        m.body_text, m.body_html, m.attachments_json,
+		        m.reviewed_by_user_id, r.name
 		 FROM messages m
 		 JOIN agent_identities a ON a.id = m.agent_id
+		 LEFT JOIN users r ON r.id = m.reviewed_by_user_id
 		 WHERE m.id = $1 AND a.user_id = $2 AND m.direction = 'outbound'`,
 		messageID, userID,
 	).Scan(
@@ -872,6 +968,7 @@ func (s *Store) GetOutboundMessageForUser(ctx context.Context, messageID, userID
 		&m.Status, &approvalExpires, &reviewedAt,
 		&rejectionReason, &m.Edited,
 		&bodyText, &bodyHTML, &attachments,
+		&reviewedByID, &reviewedByName,
 	)
 	if err != nil {
 		return nil, ErrMessageNotFound
@@ -900,6 +997,8 @@ func (s *Store) GetOutboundMessageForUser(ctx context.Context, messageID, userID
 	if len(attachments) > 0 {
 		m.AttachmentsJSON = json.RawMessage(attachments)
 	}
+	m.ReviewedByUserID = reviewedByID
+	m.ReviewedByName = reviewedByName
 	return m, nil
 }
 
@@ -1096,6 +1195,7 @@ func (s *Store) ApproveAndSend(
 		        subject           = $9,
 		        edited            = $10,
 		        reviewed_at       = now(),
+		        reviewed_by_user_id = $11,
 		        body_text         = NULL,
 		        body_html         = NULL,
 		        attachments_json  = NULL
@@ -1110,6 +1210,7 @@ func (s *Store) ApproveAndSend(
 		firstOr(result.To, ""),
 		m.Subject,
 		editedByReviewer || m.Edited,
+		userID,
 	)
 	if err != nil {
 		return nil, err
@@ -1132,6 +1233,8 @@ func (s *Store) ApproveAndSend(
 	m.Edited = editedByReviewer || m.Edited
 	now := time.Now()
 	m.ReviewedAt = &now
+	reviewerID := userID
+	m.ReviewedByUserID = &reviewerID
 	m.BodyText = ""
 	m.BodyHTML = ""
 	m.AttachmentsJSON = nil
@@ -1426,6 +1529,7 @@ func (s *Store) RejectPending(ctx context.Context, messageID, userID, reason str
 		    SET status = $3,
 		        rejection_reason = $4,
 		        reviewed_at = now(),
+		        reviewed_by_user_id = $2,
 		        body_text = NULL,
 		        body_html = NULL,
 		        attachments_json = NULL
@@ -1663,6 +1767,23 @@ func (s *Store) GetUserByID(ctx context.Context, id string) (*User, error) {
 	return u, nil
 }
 
+// UpdateUserName persists a new display name on the user row and
+// returns the updated User. Input validation (length, whitespace) is
+// the caller's responsibility — this layer only enforces that the row
+// exists.
+func (s *Store) UpdateUserName(ctx context.Context, userID, name string) (*User, error) {
+	u := &User{}
+	err := s.pool.QueryRow(ctx,
+		`UPDATE users SET name = $1 WHERE id = $2
+		 RETURNING id, email, name, google_subject, created_at`,
+		name, userID,
+	).Scan(&u.ID, &u.Email, &u.Name, &u.GoogleSubject, &u.CreatedAt)
+	if err != nil {
+		return nil, err
+	}
+	return u, nil
+}
+
 // --- Session management ---
 
 const SessionTTL = 7 * 24 * time.Hour
@@ -1706,15 +1827,159 @@ func (s *Store) DeleteExpiredUserSessions(ctx context.Context) (int64, error) {
 	return tag.RowsAffected(), nil
 }
 
+// --- Dashboard aggregates ---
+
+// DashboardStats is the workspace-level summary returned by
+// GetDashboardStats. Each section corresponds to one of the cards on the
+// redesigned dashboard's stats strip; null/zero values render as "—"
+// in the UI, so deployments without E2A_USAGE_TRACKING enabled
+// degrade gracefully.
+type DashboardStats struct {
+	Today              DashboardTodayStats   `json:"today"`
+	Pending            DashboardPendingStats `json:"pending"`
+	DeliverySuccessPct float64               `json:"delivery_success_pct"`
+	SampleWindowDays   int                   `json:"sample_window_days"`
+}
+
+type DashboardTodayStats struct {
+	Inbound          int `json:"inbound"`
+	Outbound         int `json:"outbound"`
+	InboundDeltaPct  int `json:"inbound_delta_pct"`
+	OutboundDeltaPct int `json:"outbound_delta_pct"`
+}
+
+type DashboardPendingStats struct {
+	Count         int `json:"count"`
+	OldestSeconds int `json:"oldest_seconds"`
+}
+
+// dashboardSampleWindowDays is the lookback window for the delivery
+// success percentage card. 7 matches the spec in BACKEND_TODO #1.
+const dashboardSampleWindowDays = 7
+
+// GetDashboardStats returns workspace-level aggregates for the
+// authenticated user. Three independent reads — kept separate rather
+// than smashed into one query because the source tables have different
+// indexes and one slow read shouldn't slow the others. All reads are
+// O(rows-for-this-user-only) thanks to the existing per-user indexes.
+//
+// Robust to missing data: deployments without usage tracking enabled
+// (E2A_USAGE_TRACKING=false — the default for self-hosters) return zero
+// counts rather than erroring. Same for users who have no messages
+// yet. The UI renders zero values as "—" so the cards stay sensible.
+//
+// Delta percentages: today vs yesterday on usage_summaries. Avoids
+// divide-by-zero when yesterday was zero by returning 0 (UI renders no
+// arrow). 100% increase / decrease maps to +100 / -100; values are
+// clipped at +999 to keep the integer width manageable in the UI.
+func (s *Store) GetDashboardStats(ctx context.Context, userID string) (*DashboardStats, error) {
+	stats := &DashboardStats{
+		SampleWindowDays: dashboardSampleWindowDays,
+	}
+
+	// 1) Today's usage and yesterday's baseline. LEFT JOIN trick keeps
+	// the query a single row even when one or both buckets are absent.
+	var todayInbound, todayOutbound, yesterdayInbound, yesterdayOutbound int
+	err := s.pool.QueryRow(ctx,
+		`SELECT
+		   COALESCE((SELECT inbound_count  FROM usage_summaries WHERE user_id = $1 AND bucket_date = current_date), 0),
+		   COALESCE((SELECT outbound_count FROM usage_summaries WHERE user_id = $1 AND bucket_date = current_date), 0),
+		   COALESCE((SELECT inbound_count  FROM usage_summaries WHERE user_id = $1 AND bucket_date = current_date - 1), 0),
+		   COALESCE((SELECT outbound_count FROM usage_summaries WHERE user_id = $1 AND bucket_date = current_date - 1), 0)`,
+		userID).Scan(&todayInbound, &todayOutbound, &yesterdayInbound, &yesterdayOutbound)
+	if err != nil {
+		return nil, fmt.Errorf("today/yesterday usage: %w", err)
+	}
+	stats.Today = DashboardTodayStats{
+		Inbound:          todayInbound,
+		Outbound:         todayOutbound,
+		InboundDeltaPct:  deltaPct(todayInbound, yesterdayInbound),
+		OutboundDeltaPct: deltaPct(todayOutbound, yesterdayOutbound),
+	}
+
+	// 2) Pending HITL approvals across the user's agents. Joining via
+	// the agent_id keeps the per-user partial index on messages
+	// (idx_messages_pending_approval) usable.
+	var pendingCount int
+	var oldestSec *int
+	err = s.pool.QueryRow(ctx,
+		`SELECT count(*),
+		        CASE WHEN count(*) = 0 THEN NULL
+		             ELSE EXTRACT(EPOCH FROM (now() - MIN(m.created_at)))::int
+		        END
+		 FROM messages m
+		 JOIN agent_identities a ON a.id = m.agent_id
+		 WHERE a.user_id = $1 AND m.status = 'pending_approval'`,
+		userID).Scan(&pendingCount, &oldestSec)
+	if err != nil {
+		return nil, fmt.Errorf("pending count: %w", err)
+	}
+	stats.Pending.Count = pendingCount
+	if oldestSec != nil {
+		stats.Pending.OldestSeconds = *oldestSec
+	}
+
+	// 3) Delivery success % over the sample window. Excludes pending
+	// (status='pending') from the denominator so a healthy queue doesn't
+	// drag the ratio down. NULL when there's no delivery activity at all
+	// — UI renders "—" instead of a misleading 0%.
+	var successRatio *float64
+	// Window is a compile-time constant; interpolating it directly into
+	// the SQL avoids a pgx encode plan for the interval expression and
+	// keeps the query plan-cacheable (one query shape regardless of N).
+	err = s.pool.QueryRow(ctx,
+		fmt.Sprintf(`SELECT (count(*) FILTER (WHERE wd.status = 'delivered'))::float
+		        / NULLIF(count(*) FILTER (WHERE wd.status IN ('delivered','failed')), 0)
+		 FROM webhook_deliveries wd
+		 JOIN messages m ON m.id = wd.message_id
+		 JOIN agent_identities a ON a.id = m.agent_id
+		 WHERE a.user_id = $1
+		   AND wd.created_at > now() - interval '%d days'`, dashboardSampleWindowDays),
+		userID).Scan(&successRatio)
+	if err != nil {
+		return nil, fmt.Errorf("delivery success: %w", err)
+	}
+	if successRatio != nil {
+		// Round to one decimal place — 99.6 is more useful than 99.555555.
+		stats.DeliverySuccessPct = float64(int(*successRatio*1000+0.5)) / 10.0
+	}
+
+	return stats, nil
+}
+
+// deltaPct computes the integer percentage change of current vs
+// previous. Zero previous → 0 (no arrow in UI). Clipped to ±999 to
+// keep the value width manageable.
+func deltaPct(current, previous int) int {
+	if previous == 0 {
+		return 0
+	}
+	delta := float64(current-previous) / float64(previous) * 100
+	if delta > 999 {
+		return 999
+	}
+	if delta < -999 {
+		return -999
+	}
+	return int(delta)
+}
+
 // --- Per-user API keys ---
 
 type APIKey struct {
-	ID           string    `json:"id"`
-	UserID       string    `json:"user_id"`
-	Name         string    `json:"name"`
-	KeyPrefix    string    `json:"key_prefix"`
-	PlaintextKey string    `json:"key,omitempty"` // only set once at creation, never stored
-	CreatedAt    time.Time `json:"created_at"`
+	ID           string     `json:"id"`
+	UserID       string     `json:"user_id"`
+	Name         string     `json:"name"`
+	KeyPrefix    string     `json:"key_prefix"`
+	PlaintextKey string     `json:"key,omitempty"` // only set once at creation, never stored
+	CreatedAt    time.Time  `json:"created_at"`
+	// LastUsedAt is updated by GetUserByAPIKey on every successful
+	// AuthenticateRequest. NULL on keys that have never been used.
+	LastUsedAt *time.Time `json:"last_used_at,omitempty"`
+	// ExpiresAt is the optional hard expiry. AuthenticateRequest rejects
+	// keys whose expires_at has passed. NULL means "never expires"
+	// (the backward-compatible default).
+	ExpiresAt *time.Time `json:"expires_at,omitempty"`
 }
 
 func hashAPIKey(plaintext string) string {
@@ -1722,7 +1987,10 @@ func hashAPIKey(plaintext string) string {
 	return hex.EncodeToString(h[:])
 }
 
-func (s *Store) CreateAPIKey(ctx context.Context, userID, name string) (*APIKey, error) {
+// CreateAPIKey issues a fresh API key for the user. expiresAt is the
+// optional hard expiration; pass nil to issue a never-expiring key (the
+// backward-compatible default).
+func (s *Store) CreateAPIKey(ctx context.Context, userID, name string, expiresAt *time.Time) (*APIKey, error) {
 	id := "apk_" + generateID()
 	plaintext := generateAPIKey()
 	keyHash := hashAPIKey(plaintext)
@@ -1736,10 +2004,11 @@ func (s *Store) CreateAPIKey(ctx context.Context, userID, name string) (*APIKey,
 		KeyPrefix:    prefix,
 		PlaintextKey: plaintext,
 		CreatedAt:    now,
+		ExpiresAt:    expiresAt,
 	}
 	_, err := s.pool.Exec(ctx,
-		`INSERT INTO api_keys (id, user_id, name, key_prefix, key_hash, created_at) VALUES ($1, $2, $3, $4, $5, $6)`,
-		ak.ID, ak.UserID, ak.Name, ak.KeyPrefix, keyHash, ak.CreatedAt,
+		`INSERT INTO api_keys (id, user_id, name, key_prefix, key_hash, created_at, expires_at) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+		ak.ID, ak.UserID, ak.Name, ak.KeyPrefix, keyHash, ak.CreatedAt, ak.ExpiresAt,
 	)
 	if err != nil {
 		return nil, err
@@ -1749,7 +2018,7 @@ func (s *Store) CreateAPIKey(ctx context.Context, userID, name string) (*APIKey,
 
 func (s *Store) ListAPIKeys(ctx context.Context, userID string) ([]APIKey, error) {
 	rows, err := s.pool.Query(ctx,
-		`SELECT id, user_id, name, key_prefix, created_at FROM api_keys WHERE user_id = $1 AND revoked_at IS NULL ORDER BY created_at DESC`,
+		`SELECT id, user_id, name, key_prefix, created_at, last_used_at, expires_at FROM api_keys WHERE user_id = $1 AND revoked_at IS NULL ORDER BY created_at DESC`,
 		userID,
 	)
 	if err != nil {
@@ -1759,7 +2028,7 @@ func (s *Store) ListAPIKeys(ctx context.Context, userID string) ([]APIKey, error
 	var keys []APIKey
 	for rows.Next() {
 		var k APIKey
-		if err := rows.Scan(&k.ID, &k.UserID, &k.Name, &k.KeyPrefix, &k.CreatedAt); err != nil {
+		if err := rows.Scan(&k.ID, &k.UserID, &k.Name, &k.KeyPrefix, &k.CreatedAt, &k.LastUsedAt, &k.ExpiresAt); err != nil {
 			return nil, err
 		}
 		keys = append(keys, k)
@@ -1780,13 +2049,24 @@ func (s *Store) DeleteAPIKey(ctx context.Context, keyID, userID string) error {
 	return nil
 }
 
+// GetUserByAPIKey authenticates a bearer token and returns the owning
+// user. Rejects revoked keys and time-expired keys; touches last_used_at
+// only on the success path so the column stays a real "last successful
+// authentication" signal (rather than "last attempt").
+//
+// Expiration semantics: expires_at IS NULL means the key never expires
+// (preserves the pre-migration default). A non-null expires_at must be in
+// the future, evaluated against now() in the same query so there's no
+// clock skew between row read and check.
 func (s *Store) GetUserByAPIKey(ctx context.Context, apiKey string) (*User, error) {
 	keyHash := hashAPIKey(apiKey)
 	u := &User{}
 	err := s.pool.QueryRow(ctx,
 		`WITH touched AS (
 		   UPDATE api_keys SET last_used_at = now()
-		   WHERE key_hash = $1 AND revoked_at IS NULL
+		   WHERE key_hash = $1
+		     AND revoked_at IS NULL
+		     AND (expires_at IS NULL OR expires_at > now())
 		   RETURNING user_id
 		 )
 		 SELECT u.id, u.email, u.name, u.google_subject, u.created_at

--- a/internal/identity/store_test.go
+++ b/internal/identity/store_test.go
@@ -105,7 +105,7 @@ func TestCreateAPIKey(t *testing.T) {
 		t.Fatalf("CreateOrGetUser: %v", err)
 	}
 
-	key, err := store.CreateAPIKey(ctx, user.ID, "test key")
+	key, err := store.CreateAPIKey(ctx, user.ID, "test key", nil)
 	if err != nil {
 		t.Fatalf("CreateAPIKey: %v", err)
 	}
@@ -129,8 +129,8 @@ func TestListAPIKeys(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "apikey-list@example.com", "Owner", "google-apikey-list")
-	store.CreateAPIKey(ctx, user.ID, "key-1")
-	store.CreateAPIKey(ctx, user.ID, "key-2")
+	store.CreateAPIKey(ctx, user.ID, "key-1", nil)
+	store.CreateAPIKey(ctx, user.ID, "key-2", nil)
 
 	keys, err := store.ListAPIKeys(ctx, user.ID)
 	if err != nil {
@@ -147,7 +147,7 @@ func TestDeleteAPIKey(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "apikey-del@example.com", "Owner", "google-apikey-del")
-	key, _ := store.CreateAPIKey(ctx, user.ID, "to-delete")
+	key, _ := store.CreateAPIKey(ctx, user.ID, "to-delete", nil)
 
 	err := store.DeleteAPIKey(ctx, key.ID, user.ID)
 	if err != nil {
@@ -166,7 +166,7 @@ func TestGetUserByAPIKey(t *testing.T) {
 	ctx := context.Background()
 
 	user, _ := store.CreateOrGetUser(ctx, "apikey-lookup@example.com", "Owner", "google-apikey-lookup")
-	key, _ := store.CreateAPIKey(ctx, user.ID, "lookup-key")
+	key, _ := store.CreateAPIKey(ctx, user.ID, "lookup-key", nil)
 
 	got, err := store.GetUserByAPIKey(ctx, key.PlaintextKey)
 	if err != nil {
@@ -177,6 +177,91 @@ func TestGetUserByAPIKey(t *testing.T) {
 	}
 	if got.Email != "apikey-lookup@example.com" {
 		t.Errorf("Email = %q", got.Email)
+	}
+}
+
+// TestAPIKey_ListReturnsLastUsedAtAndExpiresAt asserts the columns
+// added/exposed by migration 011: last_used_at is populated by
+// GetUserByAPIKey and surfaced by ListAPIKeys; expires_at is round-
+// tripped from CreateAPIKey through the list endpoint.
+func TestAPIKey_ListReturnsLastUsedAtAndExpiresAt(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "apikey-lastused@example.com", "Owner", "google-apikey-lastused")
+
+	// One key with expiry, one without — covers both column states.
+	expiresAt := time.Now().Add(7 * 24 * time.Hour).UTC().Round(time.Microsecond)
+	withExpiry, _ := store.CreateAPIKey(ctx, user.ID, "with-expiry", &expiresAt)
+	neverExpires, _ := store.CreateAPIKey(ctx, user.ID, "never-expires", nil)
+
+	// Before any use, last_used_at is NULL on both rows.
+	keys, err := store.ListAPIKeys(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("ListAPIKeys: %v", err)
+	}
+	byID := map[string]identity.APIKey{}
+	for _, k := range keys {
+		byID[k.ID] = k
+	}
+	if k := byID[withExpiry.ID]; k.LastUsedAt != nil {
+		t.Errorf("with-expiry LastUsedAt = %v, want nil before first use", k.LastUsedAt)
+	}
+	if k := byID[withExpiry.ID]; k.ExpiresAt == nil || !k.ExpiresAt.Equal(expiresAt) {
+		t.Errorf("with-expiry ExpiresAt = %v, want %v", k.ExpiresAt, expiresAt)
+	}
+	if k := byID[neverExpires.ID]; k.ExpiresAt != nil {
+		t.Errorf("never-expires ExpiresAt = %v, want nil", k.ExpiresAt)
+	}
+
+	// Authenticate once → last_used_at should populate on that row only.
+	if _, err := store.GetUserByAPIKey(ctx, withExpiry.PlaintextKey); err != nil {
+		t.Fatalf("GetUserByAPIKey: %v", err)
+	}
+	keys, _ = store.ListAPIKeys(ctx, user.ID)
+	for _, k := range keys {
+		if k.ID == withExpiry.ID {
+			if k.LastUsedAt == nil {
+				t.Errorf("with-expiry LastUsedAt should be set after auth")
+			}
+		} else if k.ID == neverExpires.ID {
+			if k.LastUsedAt != nil {
+				t.Errorf("never-expires LastUsedAt = %v, want nil (untouched key)", k.LastUsedAt)
+			}
+		}
+	}
+}
+
+// TestAPIKey_ExpiredKeyRejectedAtAuth: a key whose expires_at has
+// passed must fail GetUserByAPIKey. This is the auth-side gate that
+// makes the expires_at column actually enforce anything.
+func TestAPIKey_ExpiredKeyRejectedAtAuth(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "apikey-expired@example.com", "Owner", "google-apikey-expired")
+
+	// Issue with a future expiry, then backdate via direct SQL — Create
+	// rejects past timestamps at the handler layer, but the store itself
+	// doesn't validate (it's the auth gate that does the enforcement).
+	future := time.Now().Add(1 * time.Hour)
+	key, _ := store.CreateAPIKey(ctx, user.ID, "soon-to-expire", &future)
+	if _, err := pool.Exec(ctx, `UPDATE api_keys SET expires_at = $1 WHERE id = $2`,
+		time.Now().Add(-1*time.Minute), key.ID); err != nil {
+		t.Fatalf("backdate: %v", err)
+	}
+
+	if _, err := store.GetUserByAPIKey(ctx, key.PlaintextKey); err == nil {
+		t.Error("GetUserByAPIKey should reject expired keys; got success")
+	}
+
+	// Sanity: a key with NULL expires_at issued by the same user still
+	// authenticates fine (i.e. the gate is per-row, not per-user).
+	stillValid, _ := store.CreateAPIKey(ctx, user.ID, "still-valid", nil)
+	if _, err := store.GetUserByAPIKey(ctx, stillValid.PlaintextKey); err != nil {
+		t.Errorf("never-expiring key should still authenticate: %v", err)
 	}
 }
 
@@ -919,5 +1004,338 @@ func TestGetUserSigningSecrets_MostRecentFirst(t *testing.T) {
 	}
 	if got[1].ID != rolling.ID {
 		t.Errorf("[1] should be the middle one (%q), got %q", rolling.ID, got[1].ID)
+	}
+}
+
+// --- Domain enrichment (Item #7) ---
+
+// TestListDomainsByUser_ReturnsEnrichmentColumns: migration 013 adds
+// is_primary and last_checked_at; ListDomainsByUser also computes
+// agent_count via a correlated subquery. All three must round-trip
+// through the JSON response for the dashboard to render the chips.
+func TestListDomainsByUser_ReturnsEnrichmentColumns(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "domains-enrichment@example.com", "Owner", "google-de")
+
+	// Two domains: one verified with an agent, one bare.
+	store.ClaimOrCreateDomain(ctx, "with-agent.example.com", user.ID)
+	store.VerifyDomain(ctx, "with-agent.example.com", user.ID)
+	store.CreateAgent(ctx, "bot@with-agent.example.com", "with-agent.example.com", "", "https://example.com/wh", "", user.ID)
+
+	store.ClaimOrCreateDomain(ctx, "no-agent.example.com", user.ID)
+
+	domains, err := store.ListDomainsByUser(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("ListDomainsByUser: %v", err)
+	}
+	if len(domains) != 2 {
+		t.Fatalf("expected 2 domains, got %d", len(domains))
+	}
+	byName := map[string]identity.Domain{}
+	for _, d := range domains {
+		byName[d.Domain] = d
+	}
+	if got := byName["with-agent.example.com"].AgentCount; got != 1 {
+		t.Errorf("with-agent.example.com AgentCount = %d, want 1", got)
+	}
+	if got := byName["no-agent.example.com"].AgentCount; got != 0 {
+		t.Errorf("no-agent.example.com AgentCount = %d, want 0", got)
+	}
+	// Defaults: is_primary=false, last_checked_at=nil — until something
+	// actually promotes / probes them.
+	for _, d := range domains {
+		if d.IsPrimary {
+			t.Errorf("%s IsPrimary = true, want default false", d.Domain)
+		}
+		if d.LastCheckedAt != nil {
+			t.Errorf("%s LastCheckedAt = %v, want nil before any probe", d.Domain, d.LastCheckedAt)
+		}
+	}
+}
+
+// TestSetDomainPrimary_EnforcesAtMostOnePerUser: promoting a second
+// domain must demote the first in the same transaction. The partial
+// unique index in migration 013 enforces the invariant at the DB
+// level; SetDomainPrimary handles the sequencing.
+func TestSetDomainPrimary_EnforcesAtMostOnePerUser(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "primary-swap@example.com", "Owner", "google-ps")
+	store.ClaimOrCreateDomain(ctx, "first.example.com", user.ID)
+	store.VerifyDomain(ctx, "first.example.com", user.ID)
+	store.ClaimOrCreateDomain(ctx, "second.example.com", user.ID)
+	store.VerifyDomain(ctx, "second.example.com", user.ID)
+
+	if err := store.SetDomainPrimary(ctx, "first.example.com", user.ID); err != nil {
+		t.Fatalf("promote first: %v", err)
+	}
+	// Now promote the second — first should auto-demote.
+	if err := store.SetDomainPrimary(ctx, "second.example.com", user.ID); err != nil {
+		t.Fatalf("promote second: %v", err)
+	}
+
+	domains, _ := store.ListDomainsByUser(ctx, user.ID)
+	var primaryCount int
+	for _, d := range domains {
+		if d.IsPrimary {
+			primaryCount++
+			if d.Domain != "second.example.com" {
+				t.Errorf("primary = %q, want second.example.com", d.Domain)
+			}
+		}
+	}
+	if primaryCount != 1 {
+		t.Errorf("primary count = %d, want exactly 1", primaryCount)
+	}
+}
+
+// TestSetDomainPrimary_NotOwned: a user can't promote a domain that
+// belongs to someone else — return ErrDomainNotFound (NOT a permissions
+// error, so we don't leak existence of cross-user rows).
+func TestSetDomainPrimary_NotOwned(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	owner, _ := store.CreateOrGetUser(ctx, "owner-pri@example.com", "Owner", "google-op")
+	store.ClaimOrCreateDomain(ctx, "owned.example.com", owner.ID)
+	store.VerifyDomain(ctx, "owned.example.com", owner.ID)
+
+	intruder, _ := store.CreateOrGetUser(ctx, "intruder-pri@example.com", "Intruder", "google-ip")
+
+	if err := store.SetDomainPrimary(ctx, "owned.example.com", intruder.ID); err == nil {
+		t.Error("expected error promoting non-owned domain; got nil")
+	}
+	// Owner's row stayed put.
+	domains, _ := store.ListDomainsByUser(ctx, owner.ID)
+	for _, d := range domains {
+		if d.IsPrimary {
+			t.Errorf("intruder's call promoted %s; want no promotion", d.Domain)
+		}
+	}
+}
+
+// TestTouchDomainLastChecked_PersistsTimestamp: ensures the column
+// actually moves when called. This is the only path that writes
+// last_checked_at; without the touch, the column stays NULL even after
+// many verification probes.
+func TestTouchDomainLastChecked_PersistsTimestamp(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "touched@example.com", "Owner", "google-touched")
+	store.ClaimOrCreateDomain(ctx, "touched.example.com", user.ID)
+
+	before := time.Now()
+	if err := store.TouchDomainLastChecked(ctx, "touched.example.com", user.ID); err != nil {
+		t.Fatalf("TouchDomainLastChecked: %v", err)
+	}
+
+	d, _ := store.LookupDomain(ctx, "touched.example.com", user.ID)
+	if d.LastCheckedAt == nil {
+		t.Fatal("LastCheckedAt should be populated after touch")
+	}
+	if d.LastCheckedAt.Before(before.Add(-1 * time.Second)) {
+		t.Errorf("LastCheckedAt = %v, expected to be at or after %v", d.LastCheckedAt, before)
+	}
+}
+
+// --- Dashboard stats (Item #1) ---
+
+// TestGetDashboardStats_EmptyDeployment: a brand-new user with no
+// activity returns zeros everywhere, no errors. The redesign uses
+// these zeros to render "—" in the cards rather than crashing the
+// dashboard.
+func TestGetDashboardStats_EmptyDeployment(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "empty-stats@example.com", "Owner", "google-es")
+
+	stats, err := store.GetDashboardStats(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("GetDashboardStats: %v", err)
+	}
+	if stats.Today.Inbound != 0 || stats.Today.Outbound != 0 {
+		t.Errorf("today counts = %+v, want zero", stats.Today)
+	}
+	if stats.Today.InboundDeltaPct != 0 || stats.Today.OutboundDeltaPct != 0 {
+		t.Errorf("delta counts = %+v, want zero (no baseline)", stats.Today)
+	}
+	if stats.Pending.Count != 0 || stats.Pending.OldestSeconds != 0 {
+		t.Errorf("pending = %+v, want zero", stats.Pending)
+	}
+	if stats.DeliverySuccessPct != 0 {
+		t.Errorf("delivery success = %v, want 0 (no deliveries → no ratio)", stats.DeliverySuccessPct)
+	}
+	if stats.SampleWindowDays != 7 {
+		t.Errorf("sample_window_days = %d, want 7", stats.SampleWindowDays)
+	}
+}
+
+// TestGetDashboardStats_TodayAndDelta: today's counts come from
+// usage_summaries; deltas come from today-vs-yesterday. Seeds both
+// rows directly to keep the test focused on the read path.
+func TestGetDashboardStats_TodayAndDelta(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "today-stats@example.com", "Owner", "google-ts")
+
+	// Today: 100 in / 50 out. Yesterday: 80 in / 50 out.
+	// Expected deltas: inbound +25% (100→80 is actually +25% reverse — let
+	// me re-check: (100-80)/80 = +25 ✓), outbound 0% (50/50 unchanged).
+	_, err := pool.Exec(ctx,
+		`INSERT INTO usage_summaries (user_id, bucket_date, inbound_count, outbound_count, total_count)
+		 VALUES ($1, current_date, 100, 50, 150),
+		        ($1, current_date - 1, 80, 50, 130)`,
+		user.ID)
+	if err != nil {
+		t.Fatalf("seed usage_summaries: %v", err)
+	}
+
+	stats, err := store.GetDashboardStats(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("GetDashboardStats: %v", err)
+	}
+	if stats.Today.Inbound != 100 {
+		t.Errorf("Inbound = %d, want 100", stats.Today.Inbound)
+	}
+	if stats.Today.Outbound != 50 {
+		t.Errorf("Outbound = %d, want 50", stats.Today.Outbound)
+	}
+	if stats.Today.InboundDeltaPct != 25 {
+		t.Errorf("InboundDeltaPct = %d, want 25 (100 vs 80)", stats.Today.InboundDeltaPct)
+	}
+	if stats.Today.OutboundDeltaPct != 0 {
+		t.Errorf("OutboundDeltaPct = %d, want 0 (50 vs 50)", stats.Today.OutboundDeltaPct)
+	}
+}
+
+// TestGetDashboardStats_NoYesterdayBaseline: delta_pct is 0 when there's
+// no yesterday data (avoids divide-by-zero, lets UI hide the arrow).
+func TestGetDashboardStats_NoYesterdayBaseline(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "no-base@example.com", "Owner", "google-nb")
+
+	_, err := pool.Exec(ctx,
+		`INSERT INTO usage_summaries (user_id, bucket_date, inbound_count, outbound_count, total_count)
+		 VALUES ($1, current_date, 42, 7, 49)`,
+		user.ID)
+	if err != nil {
+		t.Fatalf("seed usage_summaries: %v", err)
+	}
+
+	stats, err := store.GetDashboardStats(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("GetDashboardStats: %v", err)
+	}
+	if stats.Today.Inbound != 42 || stats.Today.Outbound != 7 {
+		t.Errorf("today counts: %+v", stats.Today)
+	}
+	if stats.Today.InboundDeltaPct != 0 || stats.Today.OutboundDeltaPct != 0 {
+		t.Errorf("deltas with no baseline = %+v, want 0 to avoid divide-by-zero", stats.Today)
+	}
+}
+
+// TestGetDashboardStats_Pending: pending count + oldest_seconds come
+// from the messages table joined to agent_identities. Asserts both
+// the count and that oldest_seconds reflects the *oldest* row (not
+// the most recent).
+func TestGetDashboardStats_Pending(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "pending-stats@example.com", "Owner", "google-ps2")
+	store.ClaimOrCreateDomain(ctx, "ps.example.com", user.ID)
+	store.VerifyDomain(ctx, "ps.example.com", user.ID)
+	agent, _ := store.CreateAgent(ctx, "bot@ps.example.com", "ps.example.com", "", "https://example.com/wh", "", user.ID)
+
+	// Two pending — one fresh, one ~2h old.
+	for i := 0; i < 2; i++ {
+		store.CreatePendingOutboundMessage(ctx, agent.ID,
+			[]string{"alice@example.com"}, nil, nil,
+			fmt.Sprintf("subject-%d", i), "body", "", nil,
+			"send", "", "", 3600)
+	}
+	// Backdate the second one to ~2 hours old. created_at and
+	// approval_expires_at are both moved so the partial index still
+	// considers it pending.
+	if _, err := pool.Exec(ctx,
+		`UPDATE messages SET created_at = now() - interval '2 hours'
+		 WHERE agent_id = $1
+		   AND id = (SELECT id FROM messages WHERE agent_id = $1 ORDER BY created_at DESC LIMIT 1)`,
+		agent.ID); err != nil {
+		t.Fatalf("backdate: %v", err)
+	}
+
+	stats, err := store.GetDashboardStats(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("GetDashboardStats: %v", err)
+	}
+	if stats.Pending.Count != 2 {
+		t.Errorf("Pending.Count = %d, want 2", stats.Pending.Count)
+	}
+	// Allow some slack for query latency — oldest should be ≥ ~2h.
+	if stats.Pending.OldestSeconds < 7000 {
+		t.Errorf("Pending.OldestSeconds = %d, want >= 7000 (~2h)", stats.Pending.OldestSeconds)
+	}
+}
+
+// TestGetDashboardStats_DeliverySuccess: webhook_deliveries success
+// ratio over the 7-day window. Pending rows are excluded so a healthy
+// queue doesn't pull the percentage down.
+func TestGetDashboardStats_DeliverySuccess(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "delivery-stats@example.com", "Owner", "google-ds")
+	store.ClaimOrCreateDomain(ctx, "ds.example.com", user.ID)
+	store.VerifyDomain(ctx, "ds.example.com", user.ID)
+	agent, _ := store.CreateAgent(ctx, "bot@ds.example.com", "ds.example.com", "", "https://example.com/wh", "", user.ID)
+
+	// Seed three outbound messages with three different delivery states.
+	// CreateOutboundMessage doesn't auto-create webhook_deliveries; we
+	// insert those rows directly to exercise the GetDashboardStats query.
+	for i, status := range []string{"delivered", "delivered", "failed"} {
+		m, _ := store.CreateOutboundMessage(ctx, agent.ID,
+			[]string{"alice@example.com"}, nil, nil,
+			fmt.Sprintf("subj-%d", i), "send", "smtp", "", "")
+		_, err := pool.Exec(ctx,
+			`INSERT INTO webhook_deliveries (message_id, status, attempts, last_error, created_at)
+			 VALUES ($1, $2, 1, '', now())`,
+			m.ID, status)
+		if err != nil {
+			t.Fatalf("seed webhook_deliveries: %v", err)
+		}
+	}
+	// One pending — must NOT affect the ratio.
+	pendingMsg, _ := store.CreateOutboundMessage(ctx, agent.ID,
+		[]string{"alice@example.com"}, nil, nil, "pending", "send", "smtp", "", "")
+	pool.Exec(ctx,
+		`INSERT INTO webhook_deliveries (message_id, status, attempts, last_error, created_at)
+		 VALUES ($1, 'pending', 0, '', now())`,
+		pendingMsg.ID)
+
+	stats, err := store.GetDashboardStats(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("GetDashboardStats: %v", err)
+	}
+	// 2 delivered / 3 finalized = 66.7%
+	if stats.DeliverySuccessPct < 66 || stats.DeliverySuccessPct > 67 {
+		t.Errorf("DeliverySuccessPct = %v, want ~66.7 (2 delivered / 3 finalized; pending excluded)", stats.DeliverySuccessPct)
 	}
 }

--- a/internal/identity/user_data_rights_test.go
+++ b/internal/identity/user_data_rights_test.go
@@ -58,10 +58,10 @@ func seedUserData(t *testing.T, store *identity.Store, ctx context.Context, labe
 		t.Fatalf("seed: CreateOutboundMessage: %v", err)
 	}
 
-	if _, err := store.CreateAPIKey(ctx, user.ID, "primary"); err != nil {
+	if _, err := store.CreateAPIKey(ctx, user.ID, "primary", nil); err != nil {
 		t.Fatalf("seed: CreateAPIKey 1: %v", err)
 	}
-	if _, err := store.CreateAPIKey(ctx, user.ID, "ci"); err != nil {
+	if _, err := store.CreateAPIKey(ctx, user.ID, "ci", nil); err != nil {
 		t.Fatalf("seed: CreateAPIKey 2: %v", err)
 	}
 

--- a/internal/testutil/contract_server.go
+++ b/internal/testutil/contract_server.go
@@ -113,7 +113,7 @@ func StartContractServer(ctx context.Context, dbURL string) (*ContractServer, er
 		pool.Close()
 		return nil, err
 	}
-	key, err := store.CreateAPIKey(ctx, user.ID, "contract-key")
+	key, err := store.CreateAPIKey(ctx, user.ID, "contract-key", nil)
 	if err != nil {
 		_ = smtpServer.Close()
 		_ = httpServer.Shutdown(context.Background())

--- a/migrations/011_api_keys_expires_at.sql
+++ b/migrations/011_api_keys_expires_at.sql
@@ -1,0 +1,21 @@
+-- 011_api_keys_expires_at.sql
+--
+-- Add an optional expiration timestamp to api_keys so users can issue
+-- time-limited credentials. Authentication rejects rows where expires_at
+-- has passed; keys with NULL expires_at never expire (backward-compatible
+-- default for the keys that exist today).
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS leaves existing schemas untouched.
+-- Non-destructive on prod-sized tables: ALTER TABLE ... ADD COLUMN with a
+-- NULL default is a metadata-only operation in Postgres.
+
+ALTER TABLE api_keys
+    ADD COLUMN IF NOT EXISTS expires_at TIMESTAMPTZ NULL;
+
+-- Partial index supports the AuthenticateRequest path's `expires_at > now()
+-- OR expires_at IS NULL` predicate without scanning never-expiring rows.
+-- For self-hosters with thousands of legacy keys (all expires_at NULL),
+-- this keeps the auth lookup fast as time-limited keys gradually appear.
+CREATE INDEX IF NOT EXISTS idx_api_keys_expires
+    ON api_keys (expires_at)
+    WHERE expires_at IS NOT NULL;

--- a/migrations/012_hitl_reviewer.sql
+++ b/migrations/012_hitl_reviewer.sql
@@ -1,0 +1,18 @@
+-- 012_hitl_reviewer.sql
+--
+-- Attribute HITL approval / rejection actions to the human reviewer.
+-- The redesigned pending detail panel surfaces "approved by Jamie 14m ago";
+-- without this column, only the timestamp survives review.
+--
+-- ON DELETE SET NULL preserves the message audit trail even if the
+-- reviewer's user row is later deleted (right-of-deletion request) —
+-- losing the message provenance because a user wound down their account
+-- would be the wrong tradeoff for a security-adjacent feature.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS leaves existing schemas
+-- untouched. Non-destructive on prod-sized tables — adding a nullable
+-- column is a metadata-only operation in Postgres.
+
+ALTER TABLE messages
+    ADD COLUMN IF NOT EXISTS reviewed_by_user_id TEXT
+        REFERENCES users(id) ON DELETE SET NULL;

--- a/migrations/013_domain_enrichment.sql
+++ b/migrations/013_domain_enrichment.sql
@@ -1,0 +1,37 @@
+-- 013_domain_enrichment.sql
+--
+-- Surface "is this the user's default domain?" and "when did we last
+-- check DNS?" on the domains list. The redesign's Domains page renders
+-- both as chips/timestamps; without them the UI shows static
+-- "verified/pending" only.
+--
+-- - is_primary: at most one TRUE per user, enforced by a partial unique
+--   index. Read paths don't change for non-primary callers — the column
+--   is purely metadata until callers opt in.
+-- - last_checked_at: updated whenever the verification probe runs (whether
+--   it succeeded or not). NULL means "never probed since the column was
+--   added" — distinct from "probed and failed", which is a separate state
+--   captured by `verified=false` + a non-null `last_checked_at`.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS leaves existing schemas
+-- untouched. Non-destructive on prod-sized tables — both columns are
+-- nullable with default-NULL behavior, so the add is metadata-only.
+--
+-- The partial unique index has UNIQUE in its name to match the existing
+-- naming convention for partial uniques in this schema. Created without
+-- CONCURRENTLY because the domains table is small — a one-pass scan
+-- under an exclusive lock is faster than the concurrent-index machinery
+-- when row counts are in the hundreds.
+
+ALTER TABLE domains
+    ADD COLUMN IF NOT EXISTS is_primary BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE domains
+    ADD COLUMN IF NOT EXISTS last_checked_at TIMESTAMPTZ;
+
+-- Enforce one primary per user. NULL user_ids (the seeded shared
+-- domain) are excluded — they're not "owned" so the per-user
+-- uniqueness invariant doesn't apply.
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_domains_primary_per_user
+    ON domains (user_id)
+    WHERE is_primary = true AND user_id IS NOT NULL;

--- a/sdks/python/src/e2a/v1/generated/__init__.py
+++ b/sdks/python/src/e2a/v1/generated/__init__.py
@@ -122,9 +122,21 @@ class Domain(BaseModel):
     model_config = ConfigDict(
         populate_by_name=True,
     )
+    agent_count: int | None = Field(
+        None,
+        description='AgentCount is populated by list endpoints. Single-domain endpoints\n(register, verify) leave it zero — the count would require an\nextra query that callers can derive from the agents list anyway.',
+    )
     created_at: str | None = None
     dns_records: DNSRecords | None = None
     domain: str | None = Field(None, examples=['yourdomain.com'])
+    is_primary: bool | None = Field(
+        None,
+        description='IsPrimary marks the user\'s default domain — at most one per\nuser, enforced server-side via SetDomainPrimary. The redesign\'s\nDomains list renders this as a "Primary" chip.',
+    )
+    last_checked_at: str | None = Field(
+        None,
+        description='LastCheckedAt is the timestamp of the most recent\n/api/v1/domains/{domain}/verify probe (success or failure).\nDistinct from VerifiedAt, which only updates on success.',
+    )
     verification_token: str | None = Field(None, examples=['e2a-verify=abc123'])
     verified: bool | None = None
     verified_at: str | None = None
@@ -294,6 +306,13 @@ class UpdateAgentRequest(BaseModel):
     webhook_url: str | None = None
 
 
+class UpdateDomainRequest(BaseModel):
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
+    is_primary: bool | None = None
+
+
 class UsageEventEntry(BaseModel):
     model_config = ConfigDict(
         populate_by_name=True,
@@ -381,6 +400,16 @@ class PendingMessageDetail(BaseModel):
     provider_message_id: str | None = None
     rejection_reason: str | None = None
     reviewed_at: str | None = Field(None, examples=['2025-01-15T10:35:00Z'])
+    reviewed_by_name: str | None = Field(
+        None,
+        description="ReviewedByName is the JOIN'd display name from the reviewer's\nusers row. NULL when reviewed_by_user_id is null (worker) or when\nthe reviewer's user account has since been deleted (the FK has\nON DELETE SET NULL specifically so this doesn't poison the audit\ntrail).",
+        examples=['Jamie'],
+    )
+    reviewed_by_user_id: str | None = Field(
+        None,
+        description='ReviewedByUserID identifies the human reviewer for approved or\nrejected messages. NULL on TTL-expired transitions (worker\nauto-approve / auto-reject) where no human reviewed the message.',
+        examples=['usr_abc123'],
+    )
     status: (
         Literal[
             'sent',

--- a/sdks/python/src/e2a/v1/generated/github_com_Mnexa_AI_e2a_internal_identity.py
+++ b/sdks/python/src/e2a/v1/generated/github_com_Mnexa_AI_e2a_internal_identity.py
@@ -29,8 +29,20 @@ class Domain(BaseModel):
     model_config = ConfigDict(
         populate_by_name=True,
     )
+    agent_count: int | None = Field(
+        None,
+        description='AgentCount is computed at read time by ListDomainsByUser and is\nnot a persisted column. Single-domain LookupDomain leaves it at\nthe zero value — callers that need the count call the list path\n(this column-versus-aggregate split avoids changing every store\nsignature to thread an agent-counter through).',
+    )
     created_at: str | None = None
     domain: str | None = None
+    is_primary: bool | None = Field(
+        None,
+        description="IsPrimary marks the user's default domain. At most one TRUE per\nuser (enforced by a partial unique index in migration 013).",
+    )
+    last_checked_at: str | None = Field(
+        None,
+        description='LastCheckedAt is updated whenever the verification probe runs,\nsuccessful or not. NULL until the first probe — distinct from\n"probed and failed" which is captured by `verified=false` + a\nnon-null LastCheckedAt.',
+    )
     user_id: str | None = None
     verification_token: str | None = None
     verified: bool | None = None
@@ -67,6 +79,14 @@ class Message(BaseModel):
         description='ReplyTo is the parsed Reply-To: header on inbound messages — empty\nwhen the header was absent. Distinct from Sender so consumers can\nrecover the original From: of forwarded / notification mail whose\nReply-To points at a different mailbox. Outbound-irrelevant.',
     )
     reviewed_at: str | None = None
+    reviewed_by_name: str | None = Field(
+        None,
+        description="ReviewedByName is the JOIN'd display name from the reviewer's\nusers row, populated only by GetOutboundMessageForUser. List\nendpoints leave this empty to avoid a join-per-row cost — the\npending-detail page is where reviewer attribution matters.",
+    )
+    reviewed_by_user_id: str | None = Field(
+        None,
+        description='ReviewedByUserID identifies the human reviewer who approved or\nrejected this message. NULL on worker-triggered transitions\n(TTL auto-approve / auto-reject) — operator-visible signal "no\nhuman looked at this." Set by ApproveAndSend and RejectPending,\nleft null by ExpireApproveAndSend / ExpireReject.',
+    )
     sender: str | None = None
     status: str | None = Field(
         None,

--- a/sdks/typescript/src/v1/generated/types.ts
+++ b/sdks/typescript/src/v1/generated/types.ts
@@ -815,7 +815,65 @@ export interface paths {
         };
         options?: never;
         head?: never;
-        patch?: never;
+        /**
+         * Update a domain
+         * @description Update mutable fields on a domain. The only supported field today is `is_primary` — passing `true` promotes this domain and clears the flag from any previously-primary domain in a single transaction. Passing `false` is a no-op (use SetDomainPrimary on a different domain to demote this one).
+         */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Domain name */
+                    domain: string;
+                };
+                cookie?: never;
+            };
+            /** @description Fields to update */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["UpdateDomainRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Domain"];
+                    };
+                };
+                /** @description Invalid request */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Missing or invalid API key */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Domain not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+            };
+        };
         trace?: never;
     };
     "/api/v1/domains/{domain}/verify": {
@@ -1702,10 +1760,28 @@ export interface components {
             slug_registration_enabled?: boolean;
         };
         Domain: {
+            /**
+             * @description AgentCount is populated by list endpoints. Single-domain endpoints
+             *     (register, verify) leave it zero — the count would require an
+             *     extra query that callers can derive from the agents list anyway.
+             */
+            agent_count?: number;
             created_at?: string;
             dns_records?: components["schemas"]["DNSRecords"];
             /** @example yourdomain.com */
             domain?: string;
+            /**
+             * @description IsPrimary marks the user's default domain — at most one per
+             *     user, enforced server-side via SetDomainPrimary. The redesign's
+             *     Domains list renders this as a "Primary" chip.
+             */
+            is_primary?: boolean;
+            /**
+             * @description LastCheckedAt is the timestamp of the most recent
+             *     /api/v1/domains/{domain}/verify probe (success or failure).
+             *     Distinct from VerifiedAt, which only updates on success.
+             */
+            last_checked_at?: string;
             /** @example e2a-verify=abc123 */
             verification_token?: string;
             verified?: boolean;
@@ -1813,6 +1889,22 @@ export interface components {
             rejection_reason?: string;
             /** @example 2025-01-15T10:35:00Z */
             reviewed_at?: string;
+            /**
+             * @description ReviewedByName is the JOIN'd display name from the reviewer's
+             *     users row. NULL when reviewed_by_user_id is null (worker) or when
+             *     the reviewer's user account has since been deleted (the FK has
+             *     ON DELETE SET NULL specifically so this doesn't poison the audit
+             *     trail).
+             * @example Jamie
+             */
+            reviewed_by_name?: string;
+            /**
+             * @description ReviewedByUserID identifies the human reviewer for approved or
+             *     rejected messages. NULL on TTL-expired transitions (worker
+             *     auto-approve / auto-reject) where no human reviewed the message.
+             * @example usr_abc123
+             */
+            reviewed_by_user_id?: string;
             /**
              * @example pending_approval
              * @enum {string}
@@ -1974,6 +2066,9 @@ export interface components {
             hitl_ttl_seconds?: number;
             webhook_url?: string;
         };
+        UpdateDomainRequest: {
+            is_primary?: boolean;
+        };
         UsageEventEntry: {
             agent_id?: string;
             created_at?: string;
@@ -2021,8 +2116,28 @@ export interface components {
             webhook_url?: string;
         };
         "github_com_Mnexa-AI_e2a_internal_identity.Domain": {
+            /**
+             * @description AgentCount is computed at read time by ListDomainsByUser and is
+             *     not a persisted column. Single-domain LookupDomain leaves it at
+             *     the zero value — callers that need the count call the list path
+             *     (this column-versus-aggregate split avoids changing every store
+             *     signature to thread an agent-counter through).
+             */
+            agent_count?: number;
             created_at?: string;
             domain?: string;
+            /**
+             * @description IsPrimary marks the user's default domain. At most one TRUE per
+             *     user (enforced by a partial unique index in migration 013).
+             */
+            is_primary?: boolean;
+            /**
+             * @description LastCheckedAt is updated whenever the verification probe runs,
+             *     successful or not. NULL until the first probe — distinct from
+             *     "probed and failed" which is captured by `verified=false` + a
+             *     non-null LastCheckedAt.
+             */
+            last_checked_at?: string;
             user_id?: string;
             verification_token?: string;
             verified?: boolean;
@@ -2060,6 +2175,21 @@ export interface components {
              */
             reply_to?: string[];
             reviewed_at?: string;
+            /**
+             * @description ReviewedByName is the JOIN'd display name from the reviewer's
+             *     users row, populated only by GetOutboundMessageForUser. List
+             *     endpoints leave this empty to avoid a join-per-row cost — the
+             *     pending-detail page is where reviewer attribution matters.
+             */
+            reviewed_by_name?: string;
+            /**
+             * @description ReviewedByUserID identifies the human reviewer who approved or
+             *     rejected this message. NULL on worker-triggered transitions
+             *     (TTL auto-approve / auto-reject) — operator-visible signal "no
+             *     human looked at this." Set by ApproveAndSend and RejectPending,
+             *     left null by ExpireApproveAndSend / ExpireReject.
+             */
+            reviewed_by_user_id?: string;
             sender?: string;
             /**
              * @description HITL approval fields. Status defaults to 'sent'; body and attachments

--- a/tests/contract/contract_test.go
+++ b/tests/contract/contract_test.go
@@ -108,7 +108,7 @@ func setupEnv(t *testing.T) *testEnv {
 	if err != nil {
 		t.Fatalf("create user: %v", err)
 	}
-	key, err := ts.Store.CreateAPIKey(ctx, user.ID, "contract-key")
+	key, err := ts.Store.CreateAPIKey(ctx, user.ID, "contract-key", nil)
 	if err != nil {
 		t.Fatalf("create api key: %v", err)
 	}

--- a/web/public/openapi.yaml
+++ b/web/public/openapi.yaml
@@ -176,12 +176,30 @@ definitions:
     type: object
   Domain:
     properties:
+      agent_count:
+        description: |-
+          AgentCount is populated by list endpoints. Single-domain endpoints
+          (register, verify) leave it zero — the count would require an
+          extra query that callers can derive from the agents list anyway.
+        type: integer
       created_at:
         type: string
       dns_records:
         $ref: '#/definitions/DNSRecords'
       domain:
         example: yourdomain.com
+        type: string
+      is_primary:
+        description: |-
+          IsPrimary marks the user's default domain — at most one per
+          user, enforced server-side via SetDomainPrimary. The redesign's
+          Domains list renders this as a "Primary" chip.
+        type: boolean
+      last_checked_at:
+        description: |-
+          LastCheckedAt is the timestamp of the most recent
+          /api/v1/domains/{domain}/verify probe (success or failure).
+          Distinct from VerifiedAt, which only updates on success.
         type: string
       verification_token:
         example: e2a-verify=abc123
@@ -375,6 +393,22 @@ definitions:
         type: string
       reviewed_at:
         example: "2025-01-15T10:35:00Z"
+        type: string
+      reviewed_by_name:
+        description: |-
+          ReviewedByName is the JOIN'd display name from the reviewer's
+          users row. NULL when reviewed_by_user_id is null (worker) or when
+          the reviewer's user account has since been deleted (the FK has
+          ON DELETE SET NULL specifically so this doesn't poison the audit
+          trail).
+        example: Jamie
+        type: string
+      reviewed_by_user_id:
+        description: |-
+          ReviewedByUserID identifies the human reviewer for approved or
+          rejected messages. NULL on TTL-expired transitions (worker
+          auto-approve / auto-reject) where no human reviewed the message.
+        example: usr_abc123
         type: string
       status:
         enum:
@@ -621,6 +655,11 @@ definitions:
       webhook_url:
         type: string
     type: object
+  UpdateDomainRequest:
+    properties:
+      is_primary:
+        type: boolean
+    type: object
   UsageEventEntry:
     properties:
       agent_id:
@@ -721,9 +760,29 @@ definitions:
     type: object
   github_com_Mnexa-AI_e2a_internal_identity.Domain:
     properties:
+      agent_count:
+        description: |-
+          AgentCount is computed at read time by ListDomainsByUser and is
+          not a persisted column. Single-domain LookupDomain leaves it at
+          the zero value — callers that need the count call the list path
+          (this column-versus-aggregate split avoids changing every store
+          signature to thread an agent-counter through).
+        type: integer
       created_at:
         type: string
       domain:
+        type: string
+      is_primary:
+        description: |-
+          IsPrimary marks the user's default domain. At most one TRUE per
+          user (enforced by a partial unique index in migration 013).
+        type: boolean
+      last_checked_at:
+        description: |-
+          LastCheckedAt is updated whenever the verification probe runs,
+          successful or not. NULL until the first probe — distinct from
+          "probed and failed" which is captured by `verified=false` + a
+          non-null LastCheckedAt.
         type: string
       user_id:
         type: string
@@ -798,6 +857,21 @@ definitions:
           type: string
         type: array
       reviewed_at:
+        type: string
+      reviewed_by_name:
+        description: |-
+          ReviewedByName is the JOIN'd display name from the reviewer's
+          users row, populated only by GetOutboundMessageForUser. List
+          endpoints leave this empty to avoid a join-per-row cost — the
+          pending-detail page is where reviewer attribution matters.
+        type: string
+      reviewed_by_user_id:
+        description: |-
+          ReviewedByUserID identifies the human reviewer who approved or
+          rejected this message. NULL on worker-triggered transitions
+          (TTL auto-approve / auto-reject) — operator-visible signal "no
+          human looked at this." Set by ApproveAndSend and RejectPending,
+          left null by ExpireApproveAndSend / ExpireReject.
         type: string
       sender:
         type: string
@@ -1344,6 +1418,49 @@ paths:
       security:
       - BearerAuth: []
       summary: Delete a domain
+      tags:
+      - Domains
+    patch:
+      consumes:
+      - application/json
+      description: Update mutable fields on a domain. The only supported field today
+        is `is_primary` — passing `true` promotes this domain and clears the flag
+        from any previously-primary domain in a single transaction. Passing `false`
+        is a no-op (use SetDomainPrimary on a different domain to demote this one).
+      parameters:
+      - description: Domain name
+        in: path
+        name: domain
+        required: true
+        type: string
+      - description: Fields to update
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/UpdateDomainRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/Domain'
+        "400":
+          description: Invalid request
+          schema:
+            type: string
+        "401":
+          description: Missing or invalid API key
+          schema:
+            type: string
+        "404":
+          description: Domain not found
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Update a domain
       tags:
       - Domains
   /api/v1/domains/{domain}/verify:

--- a/web/src/app/components/types.ts
+++ b/web/src/app/components/types.ts
@@ -54,6 +54,11 @@ export type PendingMessageDetail = PendingMessageSummary & {
   attachments?: PendingAttachment[];
   edited?: boolean;
   reviewed_at?: string;
+  // Set on approved/rejected rows. Null on worker-triggered transitions
+  // (TTL auto-approve / auto-reject) — UI renders "expired" instead of
+  // a reviewer name in that case. The two fields move together.
+  reviewed_by_user_id?: string | null;
+  reviewed_by_name?: string | null;
   rejection_reason?: string;
   provider_message_id?: string;
   method?: string;
@@ -83,4 +88,67 @@ export type APIKeyData = {
   key_prefix?: string; // non-secret prefix, shown in list view
   name: string;
   created_at: string;
+  // Updated on every successful authenticated request. Null until the
+  // key is first used. Surfaces in the "Last used" column.
+  last_used_at?: string | null;
+  // Optional hard expiry — keys with null expires_at never expire.
+  // AuthenticateRequest rejects expired keys at the auth gate.
+  expires_at?: string | null;
+};
+
+// GET /api/dashboard/stats — workspace-level aggregates for the
+// dashboard stats strip. Null/zero values are rendered as "—" by the
+// stat card components.
+export type DashboardStats = {
+  today: {
+    inbound: number;
+    outbound: number;
+    inbound_delta_pct: number;
+    outbound_delta_pct: number;
+  };
+  pending: {
+    count: number;
+    oldest_seconds: number;
+  };
+  delivery_success_pct: number;
+  sample_window_days: number;
+};
+
+// Domain enrichment fields — chips on the Domains page. is_primary is
+// at most true on one row per user; last_checked_at moves on every
+// verification probe (success or failure).
+export type DomainInfo = {
+  domain: string;
+  verified: boolean;
+  verification_token: string;
+  dns_records: {
+    mx: { host: string; value: string; priority?: number };
+    txt: { host: string; value: string };
+  };
+  created_at: string;
+  verified_at?: string | null;
+  is_primary: boolean;
+  last_checked_at?: string | null;
+  agent_count: number;
+};
+
+// Request body for PATCH /api/v1/domains/{domain}. is_primary=true
+// promotes the domain (atomically demoting any prior primary).
+// is_primary=false is rejected — switch primary by promoting a
+// different domain.
+export type UpdateDomainRequest = {
+  is_primary?: boolean;
+};
+
+// Request body for POST /api/keys. expires_at is an RFC 3339
+// timestamp; omit or null to issue a never-expiring key.
+export type CreateAPIKeyRequest = {
+  name: string;
+  expires_at?: string;
+};
+
+// Request body for PATCH /api/auth/me. Only `name` is updatable today;
+// other identity fields come from the OAuth provider.
+export type UpdateMeRequest = {
+  name: string;
 };


### PR DESCRIPTION
## Summary

Implements **BACKEND_TODO items 1, 3, 6, 7, 8** — the smallest set of backend additions that lets the redesigned dashboard render real data where the UI currently shows "—" placeholders. Web PR #3 will pick up the rendering; this PR delivers the data + endpoints + tests.

Stacked on top of **#109** (fix/hitl-self-send). Review that first.

| # | What | Why |
|---|---|---|
| 1 | `GET /api/dashboard/stats` — workspace aggregates | Dashboard stats strip (Inbound today / Outbound today / Pending / Delivery success %) |
| 3 | `api_keys.expires_at` + return `last_used_at` | API keys table's Last used + Expires columns; expired keys 401 at auth |
| 6 | `messages.reviewed_by_user_id` + JOIN'd reviewed_by_name | Pending detail: "approved by Jamie 14m ago" |
| 7 | `domains.is_primary` + `last_checked_at` + computed `agent_count` + `PATCH /api/v1/domains/{domain}` | Domains list chips + promote-to-primary |
| 8 | `PATCH /api/auth/me` | Settings → Profile → Edit name |

## Migrations

Three idempotent migrations, all metadata-only on prod-sized tables:
- `011_api_keys_expires_at.sql` — adds `expires_at TIMESTAMPTZ` + partial index
- `012_hitl_reviewer.sql` — adds `reviewed_by_user_id TEXT REFERENCES users ON DELETE SET NULL`
- `013_domain_enrichment.sql` — adds `is_primary BOOLEAN`, `last_checked_at TIMESTAMPTZ`, partial unique index for one-primary-per-user

## Design notes worth flagging at review

- **Auth gate atomicity (#3)**: `GetUserByAPIKey` now rejects expired keys in the same atomic CTE that touches `last_used_at` — no race window where a stale-but-expired key still registers a "last used" timestamp.
- **Reviewer attribution NULL semantics (#6)**: TTL-expired worker transitions (auto-approve / auto-reject) leave `reviewed_by_user_id` NULL by design — the UI uses this to distinguish "human reviewed" from "system auto-resolved". `ON DELETE SET NULL` preserves audit trail when reviewers wind down their accounts.
- **`is_primary` demote UX (#7)**: `PATCH ... {is_primary: false}` is rejected. To switch primary, promote a different domain — that's atomic via `SetDomainPrimary` and keeps the invariant "exactly one primary or zero, never accidentally none." The dashboard never has a "demote" button.
- **`/me` name validation (#8)**: Leading/trailing whitespace is rejected (400), not silently trimmed. Keeps bytes round-tripping cleanly through subsequent GETs.
- **Graceful degradation (#1)**: Dashboard stats returns zeros (no errors) when `E2A_USAGE_TRACKING` is disabled (the default for self-hosters) or the user has no activity. UI renders zero values as "—".

## SDK + types

- `web/src/app/components/types.ts` updated with `DashboardStats`, `DomainInfo`, `CreateAPIKeyRequest`, `UpdateDomainRequest`, `UpdateMeRequest`; existing `PendingMessageDetail` and `APIKeyData` extended with the new fields.
- TS + Python SDK types regenerated via `make generate`.
- OpenAPI spec at `web/public/openapi.yaml` regenerated.

## Test plan

- [x] `make test` — all packages green except the pre-existing webhook-tests flake (also fails on `fix/hitl-self-send` parent; not a regression — tracked separately)
- [x] New tests:
  - `TestAPIKey_ListReturnsLastUsedAtAndExpiresAt`, `TestAPIKey_ExpiredKeyRejectedAtAuth`
  - `TestHandleListAPIKeys_ReturnsLastUsedAtAndExpiresAt`, `TestHandleCreateAPIKey_AcceptsExpiresAt`, `TestHandleCreateAPIKey_RejectsPastExpiresAt`, `TestHandleCreateAPIKey_RejectsMalformedExpiresAt`
  - `TestHandleUpdateMe_HappyPath` + Unauthenticated, ValidationErrors, MaxBoundary
  - `TestApproveAndSend_RecordsReviewedBy`, `TestRejectPending_RecordsReviewedBy`, `TestExpireApprove_ReviewedByNil`
  - `TestListDomainsByUser_ReturnsEnrichmentColumns`, `TestSetDomainPrimary_EnforcesAtMostOnePerUser`, `TestSetDomainPrimary_NotOwned`, `TestTouchDomainLastChecked_PersistsTimestamp`
  - `TestGetDashboardStats_EmptyDeployment`, `TestGetDashboardStats_TodayAndDelta`, `TestGetDashboardStats_NoYesterdayBaseline`, `TestGetDashboardStats_Pending`, `TestGetDashboardStats_DeliverySuccess`
  - `TestHandleDashboardStats_HappyPath`, `TestHandleDashboardStats_Unauthenticated`

🤖 Generated with [Claude Code](https://claude.com/claude-code)