### PR TITLE
feat(web): wire live values into the four Loft placeholders

### DIFF
--- a/web/src/app/(app)/api-keys/page.tsx
+++ b/web/src/app/(app)/api-keys/page.tsx
@@ -6,8 +6,26 @@ import { PageShell } from "../../components/loft/PageShell";
 import { Chip } from "../../components/loft/Chip";
 
 // Graceful degradation per REDESIGN.md §5:
-// - "Last used" column hidden until BACKEND_TODO #3 ships api_keys.last_used_at
+// - "Last used" surfaced now that BACKEND_TODO #3 shipped api_keys.last_used_at
 // - "Scopes" column intentionally omitted (BACKEND_TODO #11 — deferred indefinitely)
+
+// formatRelative renders a "X ago" string for the Last used cell. Tight
+// here because the column needs to read at-a-glance on a wide table —
+// full timestamps eat horizontal space. Falls back to a date for old
+// usage.
+function formatRelative(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  if (diff < 0 || isNaN(diff)) return "—";
+  const sec = Math.floor(diff / 1000);
+  if (sec < 60) return "just now";
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  if (day < 30) return `${day}d ago`;
+  return new Date(iso).toLocaleDateString();
+}
 
 export default function APIKeysPage() {
   const [keys, setKeys] = useState<APIKeyData[]>([]);
@@ -177,6 +195,7 @@ export default function APIKeysPage() {
                 <th className="px-4 py-2.5 font-semibold">Name</th>
                 <th className="px-4 py-2.5 font-semibold">Prefix</th>
                 <th className="px-4 py-2.5 font-semibold">Created</th>
+                <th className="px-4 py-2.5 font-semibold">Last used</th>
                 <th className="px-4 py-2.5 font-semibold"></th>
               </tr>
             </thead>
@@ -202,6 +221,16 @@ export default function APIKeysPage() {
                     style={{ color: "var(--fg-muted)" }}
                   >
                     {new Date(k.created_at).toLocaleDateString()}
+                  </td>
+                  <td
+                    className="px-4 py-3 font-mono text-[12px]"
+                    style={{ color: "var(--fg-muted)" }}
+                  >
+                    {k.last_used_at ? (
+                      formatRelative(k.last_used_at)
+                    ) : (
+                      <span style={{ color: "var(--fg-subtle)" }}>Never</span>
+                    )}
                   </td>
                   <td className="px-4 py-3 text-right">
                     <button

--- a/web/src/app/(app)/dashboard/page.tsx
+++ b/web/src/app/(app)/dashboard/page.tsx
@@ -4,24 +4,72 @@ import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { useAuth } from "../../components/AuthProvider";
 import { listAgents, deleteAgent } from "../../components/onboarding/api";
-import type { DashboardAgent } from "../../components/types";
+import type { DashboardAgent, DashboardStats } from "../../components/types";
 import { PageShell } from "../../components/loft/PageShell";
 import { AgentsEmptyState } from "./_components/AgentsEmptyState";
 import { AgentCard } from "./_components/AgentCard";
 
-// Stats strip — all four cards render `—` until GET /api/dashboard/stats ships
-// (see BACKEND_TODO #1). Don't fabricate values.
+// Formats a percent-change number as a short delta string. 0 → null so
+// the caller can hide the row entirely (no baseline → no arrow).
+function formatDelta(pct: number): string | null {
+  if (pct === 0) return null;
+  const sign = pct > 0 ? "+" : "";
+  return `${sign}${pct}% vs yesterday`;
+}
+
+// Stats strip — populated from GET /api/dashboard/stats. Zero counts and
+// missing baselines are rendered as bare numbers (no delta arrow) so the
+// cards stay sensible on deployments without usage tracking enabled.
 function StatsStrip() {
-  const stats = [
-    { label: "Inbound today", value: "—", delta: null as string | null },
-    { label: "Outbound today", value: "—", delta: null as string | null },
-    { label: "Pending review", value: "—", delta: null as string | null },
-    { label: "Delivery success", value: "—", delta: null as string | null },
+  const [stats, setStats] = useState<DashboardStats | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/dashboard/stats")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (!cancelled) setStats(data);
+      })
+      .catch(() => {
+        // Swallow — leaves stats=null, which renders "—" below. The
+        // dashboard load shouldn't fail because the stats endpoint is
+        // down or the user has tracking disabled.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const cards = [
+    {
+      label: "Inbound today",
+      value: stats ? String(stats.today.inbound) : "—",
+      delta: stats ? formatDelta(stats.today.inbound_delta_pct) : null,
+    },
+    {
+      label: "Outbound today",
+      value: stats ? String(stats.today.outbound) : "—",
+      delta: stats ? formatDelta(stats.today.outbound_delta_pct) : null,
+    },
+    {
+      label: "Pending review",
+      value: stats ? String(stats.pending.count) : "—",
+      delta: null as string | null,
+    },
+    {
+      label: "Delivery success",
+      value: stats
+        ? stats.delivery_success_pct > 0
+          ? `${stats.delivery_success_pct}%`
+          : "—"
+        : "—",
+      delta: stats ? `last ${stats.sample_window_days}d` : null,
+    },
   ];
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-3 mb-6">
-      {stats.map((s) => (
+      {cards.map((s) => (
         <div
           key={s.label}
           className="px-4 py-3.5"

--- a/web/src/app/(app)/dashboard/pending/review/page.tsx
+++ b/web/src/app/(app)/dashboard/pending/review/page.tsx
@@ -363,13 +363,28 @@ function ReviewContent() {
           </Field>
         )}
 
-        {/* Reviewed-by data omitted until BACKEND_TODO #6 ships — only reviewed_at is shown. */}
+        {/* Reviewer attribution from BACKEND_TODO #6. reviewed_by_name is
+            null on worker-triggered transitions (TTL auto-approve / auto-
+            reject) — surface that as "auto-resolved" so reviewers know no
+            human looked at the message. */}
         {msg.reviewed_at && notPending && (
           <p
             className="text-[12px] mt-2"
             style={{ color: "var(--fg-muted)" }}
           >
-            Reviewed at {new Date(msg.reviewed_at).toLocaleString()}
+            {msg.reviewed_by_name ? (
+              <>
+                Reviewed by{" "}
+                <span style={{ color: "var(--fg)", fontWeight: 500 }}>
+                  {msg.reviewed_by_name}
+                </span>{" "}
+                at {new Date(msg.reviewed_at).toLocaleString()}
+              </>
+            ) : (
+              <>
+                Auto-resolved at {new Date(msg.reviewed_at).toLocaleString()}
+              </>
+            )}
           </p>
         )}
       </div>

--- a/web/src/app/(app)/domains/_components/DomainCard.tsx
+++ b/web/src/app/(app)/domains/_components/DomainCard.tsx
@@ -84,6 +84,9 @@ export function DomainCard({
               <Dot tone={domain.verified ? "success" : "warn"} />
               {domain.verified ? "Verified" : "Unverified"}
             </Chip>
+            {domain.is_primary && (
+              <Chip tone="neutral">Primary</Chip>
+            )}
           </div>
           <p
             className="text-[12px]"
@@ -107,6 +110,12 @@ export function DomainCard({
               <>
                 {" · verified "}
                 {new Date(domain.verified_at).toLocaleDateString()}
+              </>
+            )}
+            {domain.last_checked_at && (
+              <>
+                {" · last checked "}
+                {new Date(domain.last_checked_at).toLocaleDateString()}
               </>
             )}
           </p>

--- a/web/src/app/(app)/domains/_components/DomainList.tsx
+++ b/web/src/app/(app)/domains/_components/DomainList.tsx
@@ -19,7 +19,13 @@ export function DomainList({
         <DomainCard
           key={d.domain}
           domain={d}
-          agentCount={agents.filter((a) => a.domain === d.domain).length}
+          // Prefer the server-computed count; fall back to the
+          // client-side filter for deployments still on a backend
+          // without BACKEND_TODO #7 (defensive, not strictly needed
+          // post-rebase).
+          agentCount={
+            d.agent_count ?? agents.filter((a) => a.domain === d.domain).length
+          }
           onVerified={onRefresh}
           onDeleted={onRefresh}
         />

--- a/web/src/app/components/onboarding/types.ts
+++ b/web/src/app/components/onboarding/types.ts
@@ -31,6 +31,12 @@ export type DomainInfo = {
   };
   created_at: string;
   verified_at: string | null;
+  // Backend PR A enrichment. is_primary is true on at most one domain
+  // per user; last_checked_at moves on every verification probe
+  // (success or failure); agent_count is computed at read time.
+  is_primary?: boolean;
+  last_checked_at?: string | null;
+  agent_count?: number;
 };
 
 /** The progress state for a domain through onboarding. */


### PR DESCRIPTION
## Summary

Backend PR A (#110) populated the fields the Loft redesign had been rendering "—" against. This PR replaces the placeholders in the four affected components only — **no layout changes, just data wiring**.

Stacked on **#110** (backend/pr-a) which is stacked on **#109** which is stacked on **#108** which is stacked on **#107** which is stacked on **#106**. The chain is now physically linear (rebased earlier). Review **#110** first.

## Changes

| Target | File | What changed |
|---|---|---|
| Dashboard stats strip | `dashboard/page.tsx` | Replaces the four hard-coded `value: "—"` cards with a `useEffect` that fetches `GET /api/dashboard/stats` and renders `today.inbound`, `today.outbound`, `pending.count`, `delivery_success_pct`. Delta percentages render as a "+12% vs yesterday" subtext. |
| API keys "Last used" column | `api-keys/page.tsx` | Adds the column the table was already designed for. Renders relative time ("just now" / "12m ago" / "3h ago" / "5d ago", date fallback). NULL renders as muted "Never". |
| Pending review "reviewed by" line | `dashboard/pending/review/page.tsx` | When `reviewed_by_name` is set, renders "Reviewed by Jamie at …". On TTL-expired worker transitions where `reviewed_by_user_id` is NULL, renders "Auto-resolved at …" — operators see the message wasn't human-approved. |
| Domains card | `domains/_components/DomainCard.tsx` + `DomainList.tsx` | Adds a "Primary" chip when `is_primary=true`. Uses server-computed `agent_count` (falls back to client filter for defensive compatibility). Adds "last checked {date}" to the date row when `last_checked_at` is set. |

`onboarding/types.ts`'s `DomainInfo` gains the three new optional fields (`is_primary`, `last_checked_at`, `agent_count`) so `DomainCard`'s prop type matches what `GET /api/v1/domains` now returns. The other types come from `components/types.ts` (already updated in #110).

## Graceful degradation preserved

- Stats endpoint failure → `stats=null` → cards keep showing "—" instead of erroring the dashboard load.
- `delivery_success_pct === 0` (no deliveries yet) → "—" instead of "0%" (misleading).
- Worker auto-resolved messages get "Auto-resolved at …" instead of a missing reviewer name.
- Domains without a `last_checked_at` (never probed) just omit the trailing "· last checked …" — no empty fragment.

## Test plan

- [x] `npm run lint` — 0 errors (1 pre-existing warning in unrelated `ResumePanel.tsx`)
- [x] `npm test` — 146/146 pass
- [x] `npm run build` — all 19 routes prerender cleanly
- [ ] Manual: `docker compose up` and visit /dashboard, /api-keys, /domains, /dashboard/pending/review with a real session

🤖 Generated with [Claude Code](https://claude.com/claude-code)