### PR TITLE
feat(api): backend dashboard enrichment + UI consumers

### DIFF
--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -853,9 +853,70 @@ func (a *API) handleRegisterDomain(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, a.domainInfoFromRecord(domainRecord))
 }
 
-// handleVerifyDomain verifies domain ownership via TXT record.
-// @Summary      Verify domain ownership
-// @Description  Verify domain ownership by checking for the expected TXT record in DNS.
+// dnsRecordCheck holds the per-record probe results for the verify
+// endpoint. Values are "found" / "missing" — DKIM additionally supports
+// "deferred" until BACKEND_TODO #5 ships per-domain DKIM keys.
+type dnsRecordCheck struct {
+	TXTFound bool
+	MX       string
+	SPF      string
+	DKIM     string
+}
+
+// checkDomainRecords runs the three per-record probes plus the TXT
+// ownership check. In dev mode, all checks short-circuit to "found" /
+// true so domain verification flows can be exercised without real DNS.
+//
+// Probe semantics:
+//   - TXT: any TXT record contains the verification token (ownership proof)
+//   - MX: any MX record points at smtpDomain (mail routing)
+//   - SPF: any TXT record begins with v=spf1 and contains the relay's
+//     send domain. We accept either smtpDomain or just the bare domain
+//     as a substring — operators commonly use either form.
+//   - DKIM: returns "deferred" pending per-domain DKIM keypair (TODO #5)
+func checkDomainRecords(domain, smtpDomain, verificationToken string, production bool) dnsRecordCheck {
+	if !production {
+		return dnsRecordCheck{
+			TXTFound: true,
+			MX:       "found",
+			SPF:      "found",
+			DKIM:     "deferred",
+		}
+	}
+	check := dnsRecordCheck{DKIM: "deferred", MX: "missing", SPF: "missing"}
+
+	// TXT ownership + SPF live in the same record set
+	if txts, err := net.LookupTXT(domain); err == nil {
+		for _, txt := range txts {
+			if strings.Contains(txt, verificationToken) {
+				check.TXTFound = true
+			}
+			if strings.HasPrefix(strings.ToLower(txt), "v=spf1") &&
+				strings.Contains(strings.ToLower(txt), strings.ToLower(smtpDomain)) {
+				check.SPF = "found"
+			}
+		}
+	}
+
+	if mxs, err := net.LookupMX(domain); err == nil {
+		for _, mx := range mxs {
+			if strings.EqualFold(strings.TrimSuffix(mx.Host, "."), smtpDomain) {
+				check.MX = "found"
+				break
+			}
+		}
+	}
+
+	return check
+}
+
+// handleVerifyDomain verifies domain ownership via TXT record AND runs
+// per-record diagnostic probes (MX, SPF, DKIM) for the redesigned
+// Domains page. The TXT ownership token is the canonical "verified"
+// signal; MX/SPF/DKIM are advisory and surface as a found/missing chip
+// in the dashboard so operators can see exactly what's misconfigured.
+// @Summary      Verify domain ownership + DNS diagnostic
+// @Description  Verify domain ownership (TXT record) and run per-record probes for MX/SPF/DKIM. Returns 200 with the per-record breakdown when ownership is verified, 412 when the TXT token is missing. DKIM always reports "deferred" until per-domain DKIM ships.
 // @Tags         Domains
 // @Produce      json
 // @Security     BearerAuth
@@ -863,7 +924,7 @@ func (a *API) handleRegisterDomain(w http.ResponseWriter, r *http.Request) {
 // @Success      200 {object} VerifyDomainResponse
 // @Failure      401 {string} string "Missing or invalid API key"
 // @Failure      404 {string} string "Domain not found"
-// @Failure      412 {string} string "TXT record not found"
+// @Failure      412 {object} VerifyDomainResponse "TXT record not found — body includes per-record diagnostic"
 // @Router       /api/v1/domains/{domain}/verify [post]
 func (a *API) handleVerifyDomain(w http.ResponseWriter, r *http.Request) {
 	user, err := a.authenticateUser(r)
@@ -880,48 +941,44 @@ func (a *API) handleVerifyDomain(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Touch last_checked_at on every probe — the column tracks "when did
+	// we last try", separate from verified_at which only moves on success.
+	if err := a.store.TouchDomainLastChecked(r.Context(), domain, user.ID); err != nil {
+		log.Printf("[api] touch last_checked_at for %s: %v", domain, err)
+	}
+
+	check := checkDomainRecords(domain, a.smtpDomain, domainRecord.VerificationToken, a.production)
+
+	// Already-verified case: short-circuit the verify call but still
+	// surface the per-record diagnostic so the dashboard can show the
+	// latest known DNS state. Probe results still drive the chips.
 	if domainRecord.Verified {
 		w.Header().Set("Content-Type", "application/json")
 		writeJSON(w, VerifyDomainResponse{
 			Domain:     domainRecord.Domain,
 			Verified:   true,
 			VerifiedAt: domainRecord.VerifiedAt,
+			MX:         check.MX,
+			SPF:        check.SPF,
+			DKIM:       check.DKIM,
 		})
 		return
 	}
 
-	// Touch last_checked_at regardless of whether the probe succeeds —
-	// the column is "when did we last try", separate from verified_at
-	// which only moves on success. Best-effort: a failed touch shouldn't
-	// block the verify response (the row is locked-down to the user, so
-	// the only realistic failure is a transient DB issue).
-	if err := a.store.TouchDomainLastChecked(r.Context(), domain, user.ID); err != nil {
-		log.Printf("[api] touch last_checked_at for %s: %v", domain, err)
-	}
-
-	// In dev mode, skip DNS verification
-	if !a.production {
-		log.Printf("[api] dev mode: skipping DNS check for %s", domain)
-	} else {
-		// Look up TXT records for the domain
-		txtRecords, err := net.LookupTXT(domain)
-		if err != nil {
-			http.Error(w, fmt.Sprintf("DNS lookup failed for %s: %v", domain, err), http.StatusBadRequest)
-			return
-		}
-
-		found := false
-		for _, txt := range txtRecords {
-			if strings.Contains(txt, domainRecord.VerificationToken) {
-				found = true
-				break
-			}
-		}
-
-		if !found {
-			http.Error(w, fmt.Sprintf("TXT record not found. Expected: %s", domainRecord.VerificationToken), http.StatusPreconditionFailed)
-			return
-		}
+	if !check.TXTFound {
+		// Return the diagnostic on 412 so callers see exactly what's
+		// missing — old behavior was a plain-text "TXT record not found"
+		// which the dashboard couldn't structurally parse.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusPreconditionFailed)
+		writeJSON(w, VerifyDomainResponse{
+			Domain:   domainRecord.Domain,
+			Verified: false,
+			MX:       check.MX,
+			SPF:      check.SPF,
+			DKIM:     check.DKIM,
+		})
+		return
 	}
 
 	if err := a.store.VerifyDomain(r.Context(), domain, user.ID); err != nil {
@@ -931,14 +988,15 @@ func (a *API) handleVerifyDomain(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("[api] domain verified: %s", domain)
 
-	// Re-fetch to get verified_at timestamp
 	domainRecord, err = a.store.LookupDomain(r.Context(), domain, user.ID)
 	if err != nil {
-		// Verification succeeded but re-fetch failed; return basic success
 		w.Header().Set("Content-Type", "application/json")
 		writeJSON(w, VerifyDomainResponse{
 			Domain:   domain,
 			Verified: true,
+			MX:       check.MX,
+			SPF:      check.SPF,
+			DKIM:     check.DKIM,
 		})
 		return
 	}
@@ -948,6 +1006,9 @@ func (a *API) handleVerifyDomain(w http.ResponseWriter, r *http.Request) {
 		Domain:     domainRecord.Domain,
 		Verified:   true,
 		VerifiedAt: domainRecord.VerifiedAt,
+		MX:         check.MX,
+		SPF:        check.SPF,
+		DKIM:       check.DKIM,
 	})
 }
 

--- a/internal/agent/api_docs.go
+++ b/internal/agent/api_docs.go
@@ -166,10 +166,23 @@ type UpdateDomainRequest struct {
 type RegisterDomainResponse = DomainInfo // @name RegisterDomainResponse
 
 // VerifyDomainResponse is the response for POST /api/v1/domains/{domain}/verify.
+// Per-record diagnostic fields (MX, SPF, DKIM) report what the probe
+// found in DNS independent of the verified bool — verified=true iff the
+// TXT ownership token is present, while MX/SPF/DKIM are advisory.
 type VerifyDomainResponse struct {
 	Domain     string     `json:"domain" example:"yourdomain.com"`
 	Verified   bool       `json:"verified"`
 	VerifiedAt *time.Time `json:"verified_at,omitempty"`
+	// MX status: "found" iff at least one MX record points at the
+	// deployment's smtp domain. "missing" otherwise.
+	MX string `json:"mx,omitempty" example:"found" enums:"found,missing"`
+	// SPF status: "found" iff a v=spf1 TXT record includes the
+	// deployment's send domain. "missing" otherwise.
+	SPF string `json:"spf,omitempty" example:"found" enums:"found,missing"`
+	// DKIM status: "deferred" until BACKEND_TODO #5 ships per-domain
+	// DKIM key generation. Until then there's no per-domain DKIM TXT
+	// record to verify against.
+	DKIM string `json:"dkim,omitempty" example:"deferred" enums:"found,missing,deferred"`
 } // @name VerifyDomainResponse
 
 // --- Deployment info ---

--- a/internal/agent/api_test.go
+++ b/internal/agent/api_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -1470,3 +1471,74 @@ func TestSendTestEmailWrongUser(t *testing.T) {
 	}
 }
 
+
+// --- Per-record DNS verification (BACKEND_TODO #4) ---
+
+// TestVerifyDomain_PerRecordDiagnostic: the response now includes
+// per-record probe results (mx/spf/dkim) so the redesigned Domains
+// page can render found/missing chips per record. In dev mode the
+// probes short-circuit to "found" so this test asserts the contract
+// shape only — the actual DNS probe paths are exercised by manual
+// testing against real domains.
+func TestVerifyDomain_PerRecordDiagnostic(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	apiKey := createTestUser(t, store, "verify-diag@example.com")
+	ctx := context.Background()
+	user, _ := store.GetUserByAPIKey(ctx, apiKey)
+	store.ClaimOrCreateDomain(ctx, "diag.example.com", user.ID)
+
+	resp := authedPost(t, server.URL+"/api/v1/domains/diag.example.com/verify", "", apiKey)
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, body)
+	}
+	var body struct {
+		Domain   string `json:"domain"`
+		Verified bool   `json:"verified"`
+		MX       string `json:"mx"`
+		SPF      string `json:"spf"`
+		DKIM     string `json:"dkim"`
+	}
+	json.NewDecoder(resp.Body).Decode(&body)
+
+	if !body.Verified {
+		t.Errorf("verified = false, want true (dev-mode probe accepts TXT)")
+	}
+	if body.MX != "found" {
+		t.Errorf("mx = %q, want found (dev mode short-circuits)", body.MX)
+	}
+	if body.SPF != "found" {
+		t.Errorf("spf = %q, want found", body.SPF)
+	}
+	if body.DKIM != "deferred" {
+		t.Errorf("dkim = %q, want deferred (until BACKEND_TODO #5 ships)", body.DKIM)
+	}
+}
+
+// TestVerifyDomain_AlreadyVerified_StillReturnsDiagnostic: re-probing
+// an already-verified domain returns the same per-record shape so the
+// dashboard can refresh chips without losing the verified state.
+func TestVerifyDomain_AlreadyVerified_StillReturnsDiagnostic(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	apiKey := createTestUser(t, store, "verify-reprobe@example.com")
+	ctx := context.Background()
+	user, _ := store.GetUserByAPIKey(ctx, apiKey)
+	store.ClaimOrCreateDomain(ctx, "reprobe.example.com", user.ID)
+	store.VerifyDomain(ctx, "reprobe.example.com", user.ID)
+
+	resp := authedPost(t, server.URL+"/api/v1/domains/reprobe.example.com/verify", "", apiKey)
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var body struct {
+		Verified bool   `json:"verified"`
+		MX       string `json:"mx"`
+		DKIM     string `json:"dkim"`
+	}
+	json.NewDecoder(resp.Body).Decode(&body)
+	if !body.Verified || body.MX != "found" || body.DKIM != "deferred" {
+		t.Errorf("already-verified response missing diagnostic: %+v", body)
+	}
+}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
@@ -549,9 +550,14 @@ func fetchGoogleUserInfo(ctx context.Context, cfg *oauth2.Config, token *oauth2.
 }
 
 // HandleDashboardStats returns the workspace-level aggregates for the
-// redesigned dashboard's stats strip. See identity.GetDashboardStats
-// for the data sources and the graceful-degradation behavior when
-// usage tracking is disabled (the default for self-hosters).
+// redesigned dashboard's stats strip. Accepts ?window=N (days) to vary
+// the lookback for inbound/outbound totals + delivery success — the
+// dashboard at-a-glance strip omits it (defaults to 7), the settings
+// usage card passes ?window=30. Invalid/out-of-range values fall back
+// to the store's defaults (see DashboardDefaultWindowDays /
+// DashboardMaxWindowDays). See identity.GetDashboardStats for the
+// data sources and graceful-degradation behavior when usage tracking
+// is disabled.
 func (ua *UserAuth) HandleDashboardStats(w http.ResponseWriter, r *http.Request) {
 	user := ua.AuthenticateRequest(r)
 	if user == nil {
@@ -559,7 +565,17 @@ func (ua *UserAuth) HandleDashboardStats(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	stats, err := ua.store.GetDashboardStats(r.Context(), user.ID)
+	// Parse optional ?window=N. Bad values get treated as "use default"
+	// rather than 400 — the dashboard simply shouldn't break if a
+	// caller fat-fingers the query string.
+	windowDays := 0
+	if raw := r.URL.Query().Get("window"); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil {
+			windowDays = n
+		}
+	}
+
+	stats, err := ua.store.GetDashboardStats(r.Context(), user.ID, windowDays)
 	if err != nil {
 		http.Error(w, "failed to fetch dashboard stats", http.StatusInternalServerError)
 		return

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -366,7 +366,7 @@ func TestHandleDashboardStats_HappyPath(t *testing.T) {
 	user, _ := store.GetUserSession(ctx, token)
 
 	// Seed today + yesterday rows.
-	_, err := store.GetDashboardStats(ctx, user.ID)
+	_, err := store.GetDashboardStats(ctx, user.ID, 0)
 	if err != nil {
 		t.Fatalf("pre-seed GetDashboardStats: %v", err)
 	}
@@ -411,4 +411,70 @@ func TestHandleDashboardStats_Unauthenticated(t *testing.T) {
 	if w.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want 401", w.Code)
 	}
+}
+
+// TestHandleDashboardStats_WindowQueryParam: the same endpoint powers
+// both the dashboard at-a-glance strip (default 7-day window) and the
+// Settings 30-day usage card via ?window=30. The handler must
+// faithfully forward the query value to the store + echo the
+// effective window back as sample_window_days.
+func TestHandleDashboardStats_WindowQueryParam(t *testing.T) {
+	ua, store, token := setupUserAuth(t)
+	ctx := context.Background()
+	user, _ := store.GetUserSession(ctx, token)
+
+	// Default: no query → 7-day window.
+	req := authedRequest("GET", "/api/dashboard/stats", token)
+	w := httptest.NewRecorder()
+	ua.HandleDashboardStats(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("default status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var defaultBody struct {
+		SampleWindowDays int `json:"sample_window_days"`
+	}
+	json.NewDecoder(w.Body).Decode(&defaultBody)
+	if defaultBody.SampleWindowDays != 7 {
+		t.Errorf("default sample_window_days = %d, want 7", defaultBody.SampleWindowDays)
+	}
+
+	// ?window=30 → 30-day window.
+	req = authedRequest("GET", "/api/dashboard/stats?window=30", token)
+	w = httptest.NewRecorder()
+	ua.HandleDashboardStats(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("window=30 status = %d, want 200", w.Code)
+	}
+	var thirtyBody struct {
+		SampleWindowDays int `json:"sample_window_days"`
+		InboundWindow    int `json:"inbound_window"`
+		OutboundWindow   int `json:"outbound_window"`
+	}
+	json.NewDecoder(w.Body).Decode(&thirtyBody)
+	if thirtyBody.SampleWindowDays != 30 {
+		t.Errorf("window=30 sample_window_days = %d, want 30", thirtyBody.SampleWindowDays)
+	}
+
+	// Bad value: handler falls back to default rather than erroring,
+	// per the comment on HandleDashboardStats.
+	req = authedRequest("GET", "/api/dashboard/stats?window=not-a-number", token)
+	w = httptest.NewRecorder()
+	ua.HandleDashboardStats(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("garbage window status = %d, want 200 (handler ignores junk)", w.Code)
+	}
+
+	// Out-of-range: handler clamps at the store layer (90).
+	req = authedRequest("GET", "/api/dashboard/stats?window=9999", token)
+	w = httptest.NewRecorder()
+	ua.HandleDashboardStats(w, req)
+	var clampedBody struct {
+		SampleWindowDays int `json:"sample_window_days"`
+	}
+	json.NewDecoder(w.Body).Decode(&clampedBody)
+	if clampedBody.SampleWindowDays != 90 {
+		t.Errorf("window=9999 clamped to %d, want 90", clampedBody.SampleWindowDays)
+	}
+
+	_ = user
 }

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -1881,6 +1881,13 @@ type DashboardStats struct {
 	Pending            DashboardPendingStats `json:"pending"`
 	DeliverySuccessPct float64               `json:"delivery_success_pct"`
 	SampleWindowDays   int                   `json:"sample_window_days"`
+	// InboundWindow / OutboundWindow are the totals over the same
+	// SampleWindowDays as DeliverySuccessPct. The dashboard at-a-glance
+	// strip uses Today.*; the settings page uses these window totals
+	// at a 30-day window (?window=30). Sum over usage_summaries rows
+	// in the lookback period.
+	InboundWindow  int `json:"inbound_window"`
+	OutboundWindow int `json:"outbound_window"`
 }
 
 type DashboardTodayStats struct {
@@ -1895,28 +1902,45 @@ type DashboardPendingStats struct {
 	OldestSeconds int `json:"oldest_seconds"`
 }
 
-// dashboardSampleWindowDays is the lookback window for the delivery
-// success percentage card. 7 matches the spec in BACKEND_TODO #1.
-const dashboardSampleWindowDays = 7
+// DashboardDefaultWindowDays is the lookback for the dashboard strip
+// when the caller doesn't request a specific window. 7 matches the
+// original BACKEND_TODO #1 spec.
+const DashboardDefaultWindowDays = 7
+
+// DashboardMaxWindowDays caps the lookback to keep the underlying SQL
+// scan bounded. 90 days is generous for any UI surface we currently
+// have and remains efficient given the per-user index on
+// usage_summaries.
+const DashboardMaxWindowDays = 90
 
 // GetDashboardStats returns workspace-level aggregates for the
-// authenticated user. Three independent reads — kept separate rather
-// than smashed into one query because the source tables have different
-// indexes and one slow read shouldn't slow the others. All reads are
-// O(rows-for-this-user-only) thanks to the existing per-user indexes.
+// authenticated user, with a configurable lookback window. windowDays
+// controls Inbound/Outbound totals AND the delivery-success ratio's
+// sample period — passing 0 falls back to DashboardDefaultWindowDays
+// (7), values above DashboardMaxWindowDays (90) are clamped.
+//
+// Three independent reads — kept separate because the source tables
+// have different indexes and one slow read shouldn't slow the others.
+// All reads are O(rows-for-this-user-only) thanks to the existing
+// per-user indexes.
 //
 // Robust to missing data: deployments without usage tracking enabled
-// (E2A_USAGE_TRACKING=false — the default for self-hosters) return zero
-// counts rather than erroring. Same for users who have no messages
-// yet. The UI renders zero values as "—" so the cards stay sensible.
+// (E2A_USAGE_TRACKING=false — the default for self-hosters) return
+// zero counts rather than erroring. Same for users who have no
+// messages yet. The UI renders zero values as "—".
 //
 // Delta percentages: today vs yesterday on usage_summaries. Avoids
-// divide-by-zero when yesterday was zero by returning 0 (UI renders no
-// arrow). 100% increase / decrease maps to +100 / -100; values are
-// clipped at +999 to keep the integer width manageable in the UI.
-func (s *Store) GetDashboardStats(ctx context.Context, userID string) (*DashboardStats, error) {
+// divide-by-zero when yesterday was zero by returning 0. 100% in/de-
+// crease maps to ±100; values clipped at ±999 for integer width.
+func (s *Store) GetDashboardStats(ctx context.Context, userID string, windowDays int) (*DashboardStats, error) {
+	if windowDays <= 0 {
+		windowDays = DashboardDefaultWindowDays
+	}
+	if windowDays > DashboardMaxWindowDays {
+		windowDays = DashboardMaxWindowDays
+	}
 	stats := &DashboardStats{
-		SampleWindowDays: dashboardSampleWindowDays,
+		SampleWindowDays: windowDays,
 	}
 
 	// 1) Today's usage and yesterday's baseline. LEFT JOIN trick keeps
@@ -1961,26 +1985,34 @@ func (s *Store) GetDashboardStats(ctx context.Context, userID string) (*Dashboar
 		stats.Pending.OldestSeconds = *oldestSec
 	}
 
-	// 3) Delivery success % over the sample window. Excludes pending
-	// (status='pending') from the denominator so a healthy queue doesn't
-	// drag the ratio down. NULL when there's no delivery activity at all
-	// — UI renders "—" instead of a misleading 0%.
+	// 3) Window aggregates: inbound + outbound totals and the delivery
+	// success ratio, all over the same lookback. Three subqueries in
+	// one round-trip — usage_summaries is keyed (user_id, bucket_date)
+	// so the per-user index handles each scan cheaply. windowDays is
+	// validated above (1..90), so direct interpolation into the SQL
+	// is safe and keeps the query plan-cacheable.
+	var winInbound, winOutbound int
 	var successRatio *float64
-	// Window is a compile-time constant; interpolating it directly into
-	// the SQL avoids a pgx encode plan for the interval expression and
-	// keeps the query plan-cacheable (one query shape regardless of N).
 	err = s.pool.QueryRow(ctx,
-		fmt.Sprintf(`SELECT (count(*) FILTER (WHERE wd.status = 'delivered'))::float
-		        / NULLIF(count(*) FILTER (WHERE wd.status IN ('delivered','failed')), 0)
-		 FROM webhook_deliveries wd
-		 JOIN messages m ON m.id = wd.message_id
-		 JOIN agent_identities a ON a.id = m.agent_id
-		 WHERE a.user_id = $1
-		   AND wd.created_at > now() - interval '%d days'`, dashboardSampleWindowDays),
-		userID).Scan(&successRatio)
+		fmt.Sprintf(`SELECT
+		   COALESCE((SELECT sum(inbound_count)::int  FROM usage_summaries
+		             WHERE user_id = $1 AND bucket_date > current_date - %d), 0) AS inbound_window,
+		   COALESCE((SELECT sum(outbound_count)::int FROM usage_summaries
+		             WHERE user_id = $1 AND bucket_date > current_date - %d), 0) AS outbound_window,
+		   (SELECT (count(*) FILTER (WHERE wd.status = 'delivered'))::float
+		            / NULLIF(count(*) FILTER (WHERE wd.status IN ('delivered','failed')), 0)
+		      FROM webhook_deliveries wd
+		      JOIN messages m ON m.id = wd.message_id
+		      JOIN agent_identities a ON a.id = m.agent_id
+		      WHERE a.user_id = $1
+		        AND wd.created_at > now() - interval '%d days')`,
+			windowDays, windowDays, windowDays),
+		userID).Scan(&winInbound, &winOutbound, &successRatio)
 	if err != nil {
-		return nil, fmt.Errorf("delivery success: %w", err)
+		return nil, fmt.Errorf("window aggregates: %w", err)
 	}
+	stats.InboundWindow = winInbound
+	stats.OutboundWindow = winOutbound
 	if successRatio != nil {
 		// Round to one decimal place — 99.6 is more useful than 99.555555.
 		stats.DeliverySuccessPct = float64(int(*successRatio*1000+0.5)) / 10.0

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -65,6 +65,20 @@ type AgentIdentity struct {
 	HITLEnabled          bool      `json:"hitl_enabled"`
 	HITLTTLSeconds       int       `json:"hitl_ttl_seconds"`
 	HITLExpirationAction string    `json:"hitl_expiration_action"`
+	// Dashboard enrichment fields (BACKEND_TODO #2). Computed at read
+	// time by ListAgentsByUser via correlated subqueries — other load
+	// paths (GetAgentByID / GetAgentByEmail) leave them at zero values,
+	// same pattern as Domain.AgentCount. Switch to denormalized columns
+	// if the read cost ever bites.
+	Inbound7d      int        `json:"inbound_7d"`
+	Outbound7d     int        `json:"outbound_7d"`
+	PendingCount   int        `json:"pending_count"`
+	LastDeliveryAt *time.Time `json:"last_delivery_at,omitempty"`
+	// WebhookHealthy is false iff there's been a failed webhook delivery
+	// in the last 24h. Defaults to true for agents with no deliveries
+	// yet — avoids painting fresh agents red. Meaningless for
+	// agent_mode='local'; the frontend hides the badge in that case.
+	WebhookHealthy bool `json:"webhook_healthy"`
 }
 
 // HITL constants mirror the CHECK constraints in migration 003_hitl.sql.
@@ -560,12 +574,36 @@ func (s *Store) UpdateAgentHITL(ctx context.Context, agentID, userID string, ena
 	return nil
 }
 
-// ListAgentsByUser returns all agents owned by the user, joined with domain verification.
+// ListAgentsByUser returns all agents owned by the user, joined with
+// domain verification AND enriched with per-agent stats for the
+// dashboard (BACKEND_TODO #2). Five correlated subqueries compute
+// inbound/outbound 7-day counts, pending approvals, last delivery, and
+// webhook health in a single round-trip. Other load paths
+// (GetAgentByID, GetAgentByEmail) intentionally don't compute these —
+// only the dashboard needs them.
 func (s *Store) ListAgentsByUser(ctx context.Context, userID string) ([]AgentIdentity, error) {
 	rows, err := s.pool.Query(ctx,
 		`SELECT a.id, a.domain, a.user_id, a.name, a.webhook_url, a.agent_mode, a.public, a.created_at,
 		        a.hitl_enabled, a.hitl_ttl_seconds, a.hitl_expiration_action,
-		        d.verified as domain_verified
+		        d.verified as domain_verified,
+		        (SELECT count(*) FROM messages m
+		           WHERE m.agent_id = a.id AND m.direction = 'inbound'
+		             AND m.created_at > now() - interval '7 days') AS inbound_7d,
+		        (SELECT count(*) FROM messages m
+		           WHERE m.agent_id = a.id AND m.direction = 'outbound'
+		             AND m.created_at > now() - interval '7 days') AS outbound_7d,
+		        (SELECT count(*) FROM messages m
+		           WHERE m.agent_id = a.id AND m.status = 'pending_approval') AS pending_count,
+		        (SELECT max(m.created_at) FROM messages m
+		           WHERE m.agent_id = a.id AND m.direction = 'outbound'
+		             AND m.status = 'sent') AS last_delivery_at,
+		        NOT EXISTS (
+		           SELECT 1 FROM webhook_deliveries wd
+		           JOIN messages m ON m.id = wd.message_id
+		           WHERE m.agent_id = a.id
+		             AND wd.status = 'failed'
+		             AND wd.last_attempt_at > now() - interval '24 hours'
+		        ) AS webhook_healthy
 		 FROM agent_identities a
 		 JOIN domains d ON a.domain = d.domain
 		 WHERE a.user_id = $1
@@ -579,11 +617,15 @@ func (s *Store) ListAgentsByUser(ctx context.Context, userID string) ([]AgentIde
 	var agents []AgentIdentity
 	for rows.Next() {
 		var a AgentIdentity
+		var lastDeliveryAt *time.Time
 		if err := rows.Scan(&a.ID, &a.Domain, &a.UserID, &a.Name, &a.WebhookURL, &a.AgentMode, &a.Public, &a.CreatedAt,
 			&a.HITLEnabled, &a.HITLTTLSeconds, &a.HITLExpirationAction,
-			&a.DomainVerified); err != nil {
+			&a.DomainVerified,
+			&a.Inbound7d, &a.Outbound7d, &a.PendingCount,
+			&lastDeliveryAt, &a.WebhookHealthy); err != nil {
 			return nil, err
 		}
+		a.LastDeliveryAt = lastDeliveryAt
 		a.populateEmail()
 		agents = append(agents, a)
 	}

--- a/internal/identity/store_test.go
+++ b/internal/identity/store_test.go
@@ -1159,7 +1159,7 @@ func TestGetDashboardStats_EmptyDeployment(t *testing.T) {
 
 	user, _ := store.CreateOrGetUser(ctx, "empty-stats@example.com", "Owner", "google-es")
 
-	stats, err := store.GetDashboardStats(ctx, user.ID)
+	stats, err := store.GetDashboardStats(ctx, user.ID, 0)
 	if err != nil {
 		t.Fatalf("GetDashboardStats: %v", err)
 	}
@@ -1202,7 +1202,7 @@ func TestGetDashboardStats_TodayAndDelta(t *testing.T) {
 		t.Fatalf("seed usage_summaries: %v", err)
 	}
 
-	stats, err := store.GetDashboardStats(ctx, user.ID)
+	stats, err := store.GetDashboardStats(ctx, user.ID, 0)
 	if err != nil {
 		t.Fatalf("GetDashboardStats: %v", err)
 	}
@@ -1237,7 +1237,7 @@ func TestGetDashboardStats_NoYesterdayBaseline(t *testing.T) {
 		t.Fatalf("seed usage_summaries: %v", err)
 	}
 
-	stats, err := store.GetDashboardStats(ctx, user.ID)
+	stats, err := store.GetDashboardStats(ctx, user.ID, 0)
 	if err != nil {
 		t.Fatalf("GetDashboardStats: %v", err)
 	}
@@ -1281,7 +1281,7 @@ func TestGetDashboardStats_Pending(t *testing.T) {
 		t.Fatalf("backdate: %v", err)
 	}
 
-	stats, err := store.GetDashboardStats(ctx, user.ID)
+	stats, err := store.GetDashboardStats(ctx, user.ID, 0)
 	if err != nil {
 		t.Fatalf("GetDashboardStats: %v", err)
 	}
@@ -1330,7 +1330,7 @@ func TestGetDashboardStats_DeliverySuccess(t *testing.T) {
 		 VALUES ($1, 'pending', 0, '', now())`,
 		pendingMsg.ID)
 
-	stats, err := store.GetDashboardStats(ctx, user.ID)
+	stats, err := store.GetDashboardStats(ctx, user.ID, 0)
 	if err != nil {
 		t.Fatalf("GetDashboardStats: %v", err)
 	}
@@ -1458,5 +1458,98 @@ func TestListAgentsByUser_OldFailureDoesNotPoisonHealth(t *testing.T) {
 	agents, _ := store.ListAgentsByUser(ctx, user.ID)
 	if !agents[0].WebhookHealthy {
 		t.Error("WebhookHealthy = false, want true (3-day-old failure shouldn't poison health)")
+	}
+}
+
+// TestGetDashboardStats_WindowedTotals: requesting ?window=N sums
+// inbound + outbound over the last N days from usage_summaries.
+// Seeds 4 days of data and asserts the 3-day total drops one row vs
+// the 7-day total. Also confirms the window param is echoed back as
+// sample_window_days.
+func TestGetDashboardStats_WindowedTotals(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "windowed@example.com", "Owner", "google-windowed")
+
+	// Seed usage_summaries for the last 4 days. Today, yesterday, 3d
+	// ago, 5d ago. A 3-day window should include the first three; a
+	// 7-day window picks up the 4th too.
+	for _, row := range []struct {
+		daysAgo int
+		in, out int
+	}{
+		{0, 10, 5},  // today
+		{1, 20, 8},  // yesterday
+		{3, 30, 12}, // 3 days ago
+		{5, 40, 16}, // 5 days ago
+	} {
+		_, err := pool.Exec(ctx,
+			`INSERT INTO usage_summaries (user_id, bucket_date, inbound_count, outbound_count, total_count)
+			 VALUES ($1, current_date - make_interval(days => $2), $3, $4, $5)`,
+			user.ID, row.daysAgo, row.in, row.out, row.in+row.out)
+		if err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	// 3-day window: today + yesterday + 3d-ago. Excludes the 5d-ago row.
+	// SQL: bucket_date > current_date - 3 → bucket_date >= current_date - 2.
+	// That captures today (0) + yesterday (1) + 2d ago — but our data
+	// has nothing 2d ago. 3d-ago is at current_date - 3, which is NOT
+	// > current_date - 3. So actually we'd get only today + yesterday.
+	// This test pins that boundary explicitly.
+	stats, err := store.GetDashboardStats(ctx, user.ID, 3)
+	if err != nil {
+		t.Fatalf("GetDashboardStats(window=3): %v", err)
+	}
+	if stats.SampleWindowDays != 3 {
+		t.Errorf("SampleWindowDays = %d, want 3", stats.SampleWindowDays)
+	}
+	if stats.InboundWindow != 30 {
+		t.Errorf("3d InboundWindow = %d, want 30 (today 10 + yesterday 20)", stats.InboundWindow)
+	}
+	if stats.OutboundWindow != 13 {
+		t.Errorf("3d OutboundWindow = %d, want 13 (today 5 + yesterday 8)", stats.OutboundWindow)
+	}
+
+	// 7-day window: picks up 3d-ago + 5d-ago too.
+	stats7, err := store.GetDashboardStats(ctx, user.ID, 7)
+	if err != nil {
+		t.Fatalf("GetDashboardStats(window=7): %v", err)
+	}
+	if stats7.InboundWindow != 100 {
+		t.Errorf("7d InboundWindow = %d, want 100 (10+20+30+40)", stats7.InboundWindow)
+	}
+	if stats7.OutboundWindow != 41 {
+		t.Errorf("7d OutboundWindow = %d, want 41 (5+8+12+16)", stats7.OutboundWindow)
+	}
+}
+
+// TestGetDashboardStats_WindowClampingAndDefault: out-of-range or
+// missing window values normalize without erroring. 0 → default 7;
+// values > 90 clamp to 90.
+func TestGetDashboardStats_WindowClampingAndDefault(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "clamp@example.com", "Owner", "google-clamp")
+
+	defaultStats, err := store.GetDashboardStats(ctx, user.ID, 0)
+	if err != nil {
+		t.Fatalf("GetDashboardStats(0): %v", err)
+	}
+	if defaultStats.SampleWindowDays != identity.DashboardDefaultWindowDays {
+		t.Errorf("0 → SampleWindowDays = %d, want %d", defaultStats.SampleWindowDays, identity.DashboardDefaultWindowDays)
+	}
+
+	clampedStats, err := store.GetDashboardStats(ctx, user.ID, 9999)
+	if err != nil {
+		t.Fatalf("GetDashboardStats(9999): %v", err)
+	}
+	if clampedStats.SampleWindowDays != identity.DashboardMaxWindowDays {
+		t.Errorf("9999 → SampleWindowDays = %d, want %d", clampedStats.SampleWindowDays, identity.DashboardMaxWindowDays)
 	}
 }

--- a/internal/identity/store_test.go
+++ b/internal/identity/store_test.go
@@ -1339,3 +1339,124 @@ func TestGetDashboardStats_DeliverySuccess(t *testing.T) {
 		t.Errorf("DeliverySuccessPct = %v, want ~66.7 (2 delivered / 3 finalized; pending excluded)", stats.DeliverySuccessPct)
 	}
 }
+
+// --- Dashboard enriched DashboardAgent (BACKEND_TODO #2) ---
+
+// TestListAgentsByUser_EnrichedFields: the dashboard's GET /api/dashboard/agents
+// must surface per-agent stats (Inbound7d, Outbound7d, PendingCount,
+// LastDeliveryAt, WebhookHealthy) so the cards can render without
+// extra round-trips. Asserts the five subqueries produce the right
+// counts for a representative mix of activity.
+func TestListAgentsByUser_EnrichedFields(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "enriched-agent@example.com", "Owner", "google-enriched")
+	store.ClaimOrCreateDomain(ctx, "enriched.example.com", user.ID)
+	store.VerifyDomain(ctx, "enriched.example.com", user.ID)
+	agent, _ := store.CreateAgent(ctx, "bot@enriched.example.com", "enriched.example.com", "", "https://example.com/wh", "cloud", user.ID)
+
+	// Seed:
+	//   2 inbound in last 7d, 1 inbound > 7d old
+	//   3 outbound (sent) in last 7d, 1 pending_approval
+	//   1 webhook delivery: delivered (healthy)
+	for i := 0; i < 2; i++ {
+		store.CreateInboundMessage(ctx, "", agent.ID, "alice@gmail.com", agent.EmailAddress(), "", "in fresh", "", "", nil, nil, nil, nil, nil)
+	}
+	old, _ := store.CreateInboundMessage(ctx, "", agent.ID, "old@gmail.com", agent.EmailAddress(), "", "in old", "", "", nil, nil, nil, nil, nil)
+	pool.Exec(ctx, `UPDATE messages SET created_at = now() - interval '14 days' WHERE id = $1`, old.ID)
+
+	for i := 0; i < 3; i++ {
+		store.CreateOutboundMessage(ctx, agent.ID, []string{"alice@example.com"}, nil, nil, "out", "send", "smtp", "", "")
+	}
+	pending, _ := store.CreatePendingOutboundMessage(ctx, agent.ID,
+		[]string{"bob@example.com"}, nil, nil, "held", "body", "", nil,
+		"send", "", "", 3600)
+	_ = pending
+
+	// One delivered webhook (healthy state)
+	m, _ := store.CreateOutboundMessage(ctx, agent.ID, []string{"alice@example.com"}, nil, nil, "delivered-msg", "send", "webhook", "", "")
+	pool.Exec(ctx,
+		`INSERT INTO webhook_deliveries (message_id, status, attempts, last_error, created_at, last_attempt_at)
+		 VALUES ($1, 'delivered', 1, '', now(), now())`,
+		m.ID)
+
+	agents, err := store.ListAgentsByUser(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("ListAgentsByUser: %v", err)
+	}
+	if len(agents) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(agents))
+	}
+	a := agents[0]
+	if a.Inbound7d != 2 {
+		t.Errorf("Inbound7d = %d, want 2 (excludes the 14-day-old row)", a.Inbound7d)
+	}
+	if a.Outbound7d != 5 {
+		// 3 plain "out" + 1 pending + 1 "delivered-msg" = 5 in last 7d.
+		// Outbound count includes pending (status=pending_approval) — the
+		// pending separately surfaces under PendingCount, but it's still a
+		// 7-day outbound event for the activity sparkline.
+		t.Errorf("Outbound7d = %d, want 5", a.Outbound7d)
+	}
+	if a.PendingCount != 1 {
+		t.Errorf("PendingCount = %d, want 1", a.PendingCount)
+	}
+	if a.LastDeliveryAt == nil {
+		t.Errorf("LastDeliveryAt should be set (we created 4 sent outbound messages)")
+	}
+	if !a.WebhookHealthy {
+		t.Errorf("WebhookHealthy = false, want true (only delivery is status=delivered)")
+	}
+}
+
+// TestListAgentsByUser_WebhookUnhealthyOnRecentFailure: a failed delivery
+// in the last 24h flips WebhookHealthy to false. Operator-visible signal
+// so the dashboard can paint the badge red.
+func TestListAgentsByUser_WebhookUnhealthyOnRecentFailure(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "wh-fail@example.com", "Owner", "google-wh-fail")
+	store.ClaimOrCreateDomain(ctx, "whfail.example.com", user.ID)
+	store.VerifyDomain(ctx, "whfail.example.com", user.ID)
+	agent, _ := store.CreateAgent(ctx, "bot@whfail.example.com", "whfail.example.com", "", "https://example.com/wh", "cloud", user.ID)
+
+	m, _ := store.CreateOutboundMessage(ctx, agent.ID, []string{"alice@example.com"}, nil, nil, "failed-msg", "send", "webhook", "", "")
+	pool.Exec(ctx,
+		`INSERT INTO webhook_deliveries (message_id, status, attempts, last_error, created_at, last_attempt_at)
+		 VALUES ($1, 'failed', 3, '500 internal', now(), now() - interval '5 minutes')`,
+		m.ID)
+
+	agents, _ := store.ListAgentsByUser(ctx, user.ID)
+	if agents[0].WebhookHealthy {
+		t.Error("WebhookHealthy = true, want false on recent failed delivery")
+	}
+}
+
+// TestListAgentsByUser_OldFailureDoesNotPoisonHealth: failures older
+// than 24h don't flip WebhookHealthy. Otherwise a one-off blip from
+// last week would forever paint the agent red.
+func TestListAgentsByUser_OldFailureDoesNotPoisonHealth(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "wh-old-fail@example.com", "Owner", "google-wh-of")
+	store.ClaimOrCreateDomain(ctx, "wholdfail.example.com", user.ID)
+	store.VerifyDomain(ctx, "wholdfail.example.com", user.ID)
+	agent, _ := store.CreateAgent(ctx, "bot@wholdfail.example.com", "wholdfail.example.com", "", "https://example.com/wh", "cloud", user.ID)
+
+	m, _ := store.CreateOutboundMessage(ctx, agent.ID, []string{"alice@example.com"}, nil, nil, "stale-fail", "send", "webhook", "", "")
+	pool.Exec(ctx,
+		`INSERT INTO webhook_deliveries (message_id, status, attempts, last_error, created_at, last_attempt_at)
+		 VALUES ($1, 'failed', 5, 'stale', now() - interval '3 days', now() - interval '3 days')`,
+		m.ID)
+
+	agents, _ := store.ListAgentsByUser(ctx, user.ID)
+	if !agents[0].WebhookHealthy {
+		t.Error("WebhookHealthy = false, want true (3-day-old failure shouldn't poison health)")
+	}
+}

--- a/sdks/python/src/e2a/v1/generated/__init__.py
+++ b/sdks/python/src/e2a/v1/generated/__init__.py
@@ -339,7 +339,22 @@ class VerifyDomainResponse(BaseModel):
     model_config = ConfigDict(
         populate_by_name=True,
     )
+    dkim: Literal['found', 'missing', 'deferred'] | None = Field(
+        None,
+        description='DKIM status: "deferred" until BACKEND_TODO #5 ships per-domain\nDKIM key generation. Until then there\'s no per-domain DKIM TXT\nrecord to verify against.',
+        examples=['deferred'],
+    )
     domain: str | None = Field(None, examples=['yourdomain.com'])
+    mx: Literal['found', 'missing'] | None = Field(
+        None,
+        description='MX status: "found" iff at least one MX record points at the\ndeployment\'s smtp domain. "missing" otherwise.',
+        examples=['found'],
+    )
+    spf: Literal['found', 'missing'] | None = Field(
+        None,
+        description='SPF status: "found" iff a v=spf1 TXT record includes the\ndeployment\'s send domain. "missing" otherwise.',
+        examples=['found'],
+    )
     verified: bool | None = None
     verified_at: str | None = None
 

--- a/sdks/python/src/e2a/v1/generated/github_com_Mnexa_AI_e2a_internal_identity.py
+++ b/sdks/python/src/e2a/v1/generated/github_com_Mnexa_AI_e2a_internal_identity.py
@@ -19,9 +19,20 @@ class AgentIdentity(BaseModel):
     hitl_expiration_action: str | None = None
     hitl_ttl_seconds: int | None = None
     id: str | None = None
+    inbound_7d: int | None = Field(
+        None,
+        description='Dashboard enrichment fields (BACKEND_TODO #2). Computed at read\ntime by ListAgentsByUser via correlated subqueries — other load\npaths (GetAgentByID / GetAgentByEmail) leave them at zero values,\nsame pattern as Domain.AgentCount. Switch to denormalized columns\nif the read cost ever bites.',
+    )
+    last_delivery_at: str | None = None
     name: str | None = None
+    outbound_7d: int | None = None
+    pending_count: int | None = None
     public: bool | None = None
     user_id: str | None = None
+    webhook_healthy: bool | None = Field(
+        None,
+        description="WebhookHealthy is false iff there's been a failed webhook delivery\nin the last 24h. Defaults to true for agents with no deliveries\nyet — avoids painting fresh agents red. Meaningless for\nagent_mode='local'; the frontend hides the badge in that case.",
+    )
     webhook_url: str | None = None
 
 

--- a/sdks/typescript/src/v1/generated/types.ts
+++ b/sdks/typescript/src/v1/generated/types.ts
@@ -886,8 +886,8 @@ export interface paths {
         get?: never;
         put?: never;
         /**
-         * Verify domain ownership
-         * @description Verify domain ownership by checking for the expected TXT record in DNS.
+         * Verify domain ownership + DNS diagnostic
+         * @description Verify domain ownership (TXT record) and run per-record probes for MX/SPF/DKIM. Returns 200 with the per-record breakdown when ownership is verified, 412 when the TXT token is missing. DKIM always reports "deferred" until per-domain DKIM ships.
          */
         post: {
             parameters: {
@@ -928,13 +928,13 @@ export interface paths {
                         "application/json": string;
                     };
                 };
-                /** @description TXT record not found */
+                /** @description TXT record not found — body includes per-record diagnostic */
                 412: {
                     headers: {
                         [name: string]: unknown;
                     };
                     content: {
-                        "application/json": string;
+                        "application/json": components["schemas"]["VerifyDomainResponse"];
                     };
                 };
             };
@@ -2095,8 +2095,30 @@ export interface components {
             name?: string;
         };
         VerifyDomainResponse: {
+            /**
+             * @description DKIM status: "deferred" until BACKEND_TODO #5 ships per-domain
+             *     DKIM key generation. Until then there's no per-domain DKIM TXT
+             *     record to verify against.
+             * @example deferred
+             * @enum {string}
+             */
+            dkim?: "found" | "missing" | "deferred";
             /** @example yourdomain.com */
             domain?: string;
+            /**
+             * @description MX status: "found" iff at least one MX record points at the
+             *     deployment's smtp domain. "missing" otherwise.
+             * @example found
+             * @enum {string}
+             */
+            mx?: "found" | "missing";
+            /**
+             * @description SPF status: "found" iff a v=spf1 TXT record includes the
+             *     deployment's send domain. "missing" otherwise.
+             * @example found
+             * @enum {string}
+             */
+            spf?: "found" | "missing";
             verified?: boolean;
             verified_at?: string;
         };

--- a/sdks/typescript/src/v1/generated/types.ts
+++ b/sdks/typescript/src/v1/generated/types.ts
@@ -2110,9 +2110,27 @@ export interface components {
             hitl_expiration_action?: string;
             hitl_ttl_seconds?: number;
             id?: string;
+            /**
+             * @description Dashboard enrichment fields (BACKEND_TODO #2). Computed at read
+             *     time by ListAgentsByUser via correlated subqueries — other load
+             *     paths (GetAgentByID / GetAgentByEmail) leave them at zero values,
+             *     same pattern as Domain.AgentCount. Switch to denormalized columns
+             *     if the read cost ever bites.
+             */
+            inbound_7d?: number;
+            last_delivery_at?: string;
             name?: string;
+            outbound_7d?: number;
+            pending_count?: number;
             public?: boolean;
             user_id?: string;
+            /**
+             * @description WebhookHealthy is false iff there's been a failed webhook delivery
+             *     in the last 24h. Defaults to true for agents with no deliveries
+             *     yet — avoids painting fresh agents red. Meaningless for
+             *     agent_mode='local'; the frontend hides the badge in that case.
+             */
+            webhook_healthy?: boolean;
             webhook_url?: string;
         };
         "github_com_Mnexa-AI_e2a_internal_identity.Domain": {

--- a/web/public/openapi.yaml
+++ b/web/public/openapi.yaml
@@ -721,8 +721,37 @@ definitions:
     type: object
   VerifyDomainResponse:
     properties:
+      dkim:
+        description: |-
+          DKIM status: "deferred" until BACKEND_TODO #5 ships per-domain
+          DKIM key generation. Until then there's no per-domain DKIM TXT
+          record to verify against.
+        enum:
+        - found
+        - missing
+        - deferred
+        example: deferred
+        type: string
       domain:
         example: yourdomain.com
+        type: string
+      mx:
+        description: |-
+          MX status: "found" iff at least one MX record points at the
+          deployment's smtp domain. "missing" otherwise.
+        enum:
+        - found
+        - missing
+        example: found
+        type: string
+      spf:
+        description: |-
+          SPF status: "found" iff a v=spf1 TXT record includes the
+          deployment's send domain. "missing" otherwise.
+        enum:
+        - found
+        - missing
+        example: found
         type: string
       verified:
         type: boolean
@@ -1486,8 +1515,10 @@ paths:
       - Domains
   /api/v1/domains/{domain}/verify:
     post:
-      description: Verify domain ownership by checking for the expected TXT record
-        in DNS.
+      description: Verify domain ownership (TXT record) and run per-record probes
+        for MX/SPF/DKIM. Returns 200 with the per-record breakdown when ownership
+        is verified, 412 when the TXT token is missing. DKIM always reports "deferred"
+        until per-domain DKIM ships.
       parameters:
       - description: Domain name
         in: path
@@ -1510,12 +1541,12 @@ paths:
           schema:
             type: string
         "412":
-          description: TXT record not found
+          description: TXT record not found — body includes per-record diagnostic
           schema:
-            type: string
+            $ref: '#/definitions/VerifyDomainResponse'
       security:
       - BearerAuth: []
-      summary: Verify domain ownership
+      summary: Verify domain ownership + DNS diagnostic
       tags:
       - Domains
   /api/v1/info:

--- a/web/public/openapi.yaml
+++ b/web/public/openapi.yaml
@@ -749,12 +749,33 @@ definitions:
         type: integer
       id:
         type: string
+      inbound_7d:
+        description: |-
+          Dashboard enrichment fields (BACKEND_TODO #2). Computed at read
+          time by ListAgentsByUser via correlated subqueries — other load
+          paths (GetAgentByID / GetAgentByEmail) leave them at zero values,
+          same pattern as Domain.AgentCount. Switch to denormalized columns
+          if the read cost ever bites.
+        type: integer
+      last_delivery_at:
+        type: string
       name:
         type: string
+      outbound_7d:
+        type: integer
+      pending_count:
+        type: integer
       public:
         type: boolean
       user_id:
         type: string
+      webhook_healthy:
+        description: |-
+          WebhookHealthy is false iff there's been a failed webhook delivery
+          in the last 24h. Defaults to true for agents with no deliveries
+          yet — avoids painting fresh agents red. Meaningless for
+          agent_mode='local'; the frontend hides the badge in that case.
+        type: boolean
       webhook_url:
         type: string
     type: object

--- a/web/src/app/(app)/api-keys/page.test.tsx
+++ b/web/src/app/(app)/api-keys/page.test.tsx
@@ -1,0 +1,149 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import APIKeysPage from "./page";
+
+// Mock next/link.
+jest.mock("next/link", () => {
+  return function MockLink({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [k: string]: unknown;
+  }) {
+    return (
+      <a href={href} {...rest}>
+        {children}
+      </a>
+    );
+  };
+});
+
+const mockFetch = jest.fn();
+beforeEach(() => {
+  mockFetch.mockReset();
+  global.fetch = mockFetch;
+});
+
+// stageList mounts the page with a known initial list-keys response.
+// Returns the recorded fetch call list so individual tests can assert
+// on POST body shapes after a Create.
+function stageList(initial: unknown[] = []) {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+    calls.push({ url, init });
+    if (url === "/api/keys" && (!init || !init.method || init.method === "GET")) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(initial),
+      });
+    }
+    if (url === "/api/keys" && init?.method === "POST") {
+      const body = JSON.parse(init.body as string);
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            id: "apk_new",
+            user_id: "usr",
+            name: body.name,
+            key_prefix: "e2a_abcd",
+            key: "e2a_abcd_PLAINTEXT",
+            created_at: new Date().toISOString(),
+            expires_at: body.expires_at ?? null,
+          }),
+      });
+    }
+    return Promise.resolve({
+      ok: false,
+      text: () => Promise.resolve("not found"),
+    });
+  });
+  return calls;
+}
+
+// Helper: extract the body of the most recent POST /api/keys call.
+function lastCreateBody(calls: Array<{ url: string; init?: RequestInit }>) {
+  const create = [...calls]
+    .reverse()
+    .find((c) => c.url === "/api/keys" && c.init?.method === "POST");
+  return create ? JSON.parse(create.init!.body as string) : null;
+}
+
+describe("API keys page — Expires-in select", () => {
+  it("omits expires_at on POST when Never is selected (default)", async () => {
+    const calls = stageList([]);
+    render(<APIKeysPage />);
+    await screen.findByText(/No API keys yet/i);
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/Key name/i), "ci-token");
+    await user.click(screen.getByRole("button", { name: /^create key$/i }));
+
+    await waitFor(() => {
+      const body = lastCreateBody(calls);
+      expect(body).not.toBeNull();
+      expect(body.name).toBe("ci-token");
+      // Never selected → field omitted (NOT sent as null/empty string).
+      // Backend treats absent field as "never expires".
+      expect(body).not.toHaveProperty("expires_at");
+    });
+  });
+
+  it("sends expires_at as an ISO timestamp 30 days out when 'In 30 days' is selected", async () => {
+    const calls = stageList([]);
+    render(<APIKeysPage />);
+    await screen.findByText(/No API keys yet/i);
+
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/Key name/i), "rolling");
+    await user.selectOptions(screen.getByLabelText(/Expires/i), "30");
+    await user.click(screen.getByRole("button", { name: /^create key$/i }));
+
+    await waitFor(() => {
+      const body = lastCreateBody(calls);
+      expect(body).not.toBeNull();
+      expect(body.expires_at).toBeDefined();
+      const expAt = new Date(body.expires_at).getTime();
+      const expectedMs = Date.now() + 30 * 24 * 60 * 60 * 1000;
+      // Allow ±10s of slack for test execution time.
+      expect(Math.abs(expAt - expectedMs)).toBeLessThan(10_000);
+    });
+  });
+
+  it("sends 90 days when 'In 90 days' is selected", async () => {
+    const calls = stageList([]);
+    render(<APIKeysPage />);
+    await screen.findByText(/No API keys yet/i);
+
+    const user = userEvent.setup();
+    await user.selectOptions(screen.getByLabelText(/Expires/i), "90");
+    await user.click(screen.getByRole("button", { name: /^create key$/i }));
+
+    await waitFor(() => {
+      const body = lastCreateBody(calls);
+      expect(body).not.toBeNull();
+      const expAt = new Date(body.expires_at).getTime();
+      const expectedMs = Date.now() + 90 * 24 * 60 * 60 * 1000;
+      expect(Math.abs(expAt - expectedMs)).toBeLessThan(10_000);
+    });
+  });
+
+  it("resets the Expires select back to Never after a successful create", async () => {
+    stageList([]);
+    render(<APIKeysPage />);
+    await screen.findByText(/No API keys yet/i);
+
+    const user = userEvent.setup();
+    const select = screen.getByLabelText(/Expires/i) as HTMLSelectElement;
+    await user.selectOptions(select, "365");
+    expect(select.value).toBe("365");
+    await user.click(screen.getByRole("button", { name: /^create key$/i }));
+
+    await waitFor(() => {
+      expect(select.value).toBe("never");
+    });
+  });
+});

--- a/web/src/app/(app)/api-keys/page.test.tsx
+++ b/web/src/app/(app)/api-keys/page.test.tsx
@@ -147,3 +147,69 @@ describe("API keys page — Expires-in select", () => {
     });
   });
 });
+
+describe("API keys table — Expires column", () => {
+  const baseKey = {
+    id: "apk_1",
+    user_id: "usr_x",
+    name: "ci-token",
+    key_prefix: "e2a_abcd",
+    created_at: "2026-04-01T10:00:00Z",
+  };
+
+  it("renders 'Never' for keys with no expires_at", async () => {
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === "/api/keys" && (!init || !init.method)) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ ...baseKey, expires_at: null }],
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        text: async () => "not found",
+      });
+    });
+    render(<APIKeysPage />);
+    await screen.findByText("ci-token");
+    // Two cells render "Never": Last used (never used) + Expires (no expiry)
+    expect(screen.getAllByText("Never").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("renders 'in Nd' for keys expiring within a month", async () => {
+    // 12 days + 1 hour buffer so the floor()-based formatter doesn't
+    // round down to "in 11d" because of microseconds of test latency
+    // between the timestamp seeding and the cell rendering.
+    const future = new Date(
+      Date.now() + 12 * 24 * 60 * 60 * 1000 + 60 * 60 * 1000,
+    ).toISOString();
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === "/api/keys" && (!init || !init.method)) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ ...baseKey, expires_at: future }],
+        });
+      }
+      return Promise.resolve({ ok: false, text: async () => "" });
+    });
+    render(<APIKeysPage />);
+    await screen.findByText("ci-token");
+    expect(screen.getByText("in 12d")).toBeInTheDocument();
+  });
+
+  it("renders 'expired' for past expires_at", async () => {
+    const past = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === "/api/keys" && (!init || !init.method)) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ ...baseKey, expires_at: past }],
+        });
+      }
+      return Promise.resolve({ ok: false, text: async () => "" });
+    });
+    render(<APIKeysPage />);
+    await screen.findByText("ci-token");
+    expect(screen.getByText("expired")).toBeInTheDocument();
+  });
+});

--- a/web/src/app/(app)/api-keys/page.tsx
+++ b/web/src/app/(app)/api-keys/page.tsx
@@ -33,6 +33,27 @@ function formatRelative(iso: string): string {
   return new Date(iso).toLocaleDateString();
 }
 
+// formatExpiresIn renders the "in 28d" / "tomorrow" / "today" forms
+// for the Expires column. Past timestamps return "expired" so the
+// caller can tint the cell red.
+function formatExpiresIn(iso: string): { label: string; expired: boolean; imminent: boolean } {
+  const diff = new Date(iso).getTime() - Date.now();
+  if (isNaN(diff)) return { label: "—", expired: false, imminent: false };
+  if (diff <= 0) return { label: "expired", expired: true, imminent: false };
+  const days = Math.floor(diff / (24 * 60 * 60 * 1000));
+  if (days === 0) {
+    const hr = Math.floor(diff / (60 * 60 * 1000));
+    return { label: hr <= 1 ? "<1h" : `in ${hr}h`, expired: false, imminent: true };
+  }
+  if (days === 1) return { label: "tomorrow", expired: false, imminent: true };
+  if (days < 30) return { label: `in ${days}d`, expired: false, imminent: days <= 7 };
+  return {
+    label: new Date(iso).toLocaleDateString(),
+    expired: false,
+    imminent: false,
+  };
+}
+
 export default function APIKeysPage() {
   const [keys, setKeys] = useState<APIKeyData[]>([]);
   const [loading, setLoading] = useState(true);
@@ -310,6 +331,7 @@ export default function APIKeysPage() {
                   <th className="px-4 py-2.5 font-semibold">Prefix</th>
                   <th className="px-4 py-2.5 font-semibold">Created</th>
                   <th className="px-4 py-2.5 font-semibold">Last used</th>
+                  <th className="px-4 py-2.5 font-semibold">Expires</th>
                   <th className="px-4 py-2.5 font-semibold"></th>
                 </tr>
               </thead>
@@ -342,6 +364,30 @@ export default function APIKeysPage() {
                   >
                     {k.last_used_at ? (
                       formatRelative(k.last_used_at)
+                    ) : (
+                      <span style={{ color: "var(--fg-subtle)" }}>Never</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-3 font-mono text-[12px]">
+                    {k.expires_at ? (
+                      (() => {
+                        const exp = formatExpiresIn(k.expires_at);
+                        return (
+                          <span
+                            style={{
+                              color: exp.expired
+                                ? "var(--danger-strong)"
+                                : exp.imminent
+                                  ? "var(--warn-strong)"
+                                  : "var(--fg-muted)",
+                              fontWeight: exp.expired || exp.imminent ? 500 : 400,
+                            }}
+                            title={new Date(k.expires_at).toLocaleString()}
+                          >
+                            {exp.label}
+                          </span>
+                        );
+                      })()
                     ) : (
                       <span style={{ color: "var(--fg-subtle)" }}>Never</span>
                     )}

--- a/web/src/app/(app)/api-keys/page.tsx
+++ b/web/src/app/(app)/api-keys/page.tsx
@@ -40,6 +40,13 @@ export default function APIKeysPage() {
   const [creating, setCreating] = useState(false);
   const [createdKey, setCreatedKey] = useState<APIKeyData | null>(null);
   const [sort, setSort] = useState<SortKey>("last_used");
+  // expiresIn: "never" or a number of days from now. The backend
+  // accepts an RFC 3339 timestamp on POST /api/keys; we compute the
+  // absolute time from this relative choice at submit. Custom dates
+  // are deferred — the four presets cover the bulk of real workflows.
+  const [expiresIn, setExpiresIn] = useState<"never" | "30" | "90" | "365">(
+    "never",
+  );
 
   const sortedKeys = useMemo(() => {
     const arr = [...keys];
@@ -88,15 +95,24 @@ export default function APIKeysPage() {
   const handleCreate = async () => {
     setCreating(true);
     try {
+      const body: { name: string; expires_at?: string } = {
+        name: newKeyName || "Default",
+      };
+      if (expiresIn !== "never") {
+        const days = Number(expiresIn);
+        const exp = new Date(Date.now() + days * 24 * 60 * 60 * 1000);
+        body.expires_at = exp.toISOString();
+      }
       const res = await fetch("/api/keys", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name: newKeyName || "Default" }),
+        body: JSON.stringify(body),
       });
       if (res.ok) {
         const key = await res.json();
         setCreatedKey(key);
         setNewKeyName("");
+        setExpiresIn("never");
         fetchKeys();
       }
     } finally {
@@ -158,12 +174,14 @@ export default function APIKeysPage() {
       <div className="flex items-end gap-3 mb-6 flex-wrap">
         <div className="flex-1 min-w-[200px]">
           <label
+            htmlFor="apikey-name"
             className="block text-[12px] font-medium mb-1"
             style={{ color: "var(--fg-muted)" }}
           >
             Key name (optional)
           </label>
           <input
+            id="apikey-name"
             type="text"
             value={newKeyName}
             onChange={(e) => setNewKeyName(e.target.value)}
@@ -176,6 +194,36 @@ export default function APIKeysPage() {
               color: "var(--fg)",
             }}
           />
+        </div>
+        <div className="min-w-[140px]">
+          <label
+            htmlFor="apikey-expires"
+            className="block text-[12px] font-medium mb-1"
+            style={{ color: "var(--fg-muted)" }}
+          >
+            Expires
+          </label>
+          <select
+            id="apikey-expires"
+            value={expiresIn}
+            onChange={(e) =>
+              setExpiresIn(
+                e.target.value as "never" | "30" | "90" | "365",
+              )
+            }
+            className="w-full px-3 py-2 text-[13px] cursor-pointer"
+            style={{
+              background: "var(--bg-panel)",
+              border: "1px solid var(--border)",
+              borderRadius: "var(--r-md)",
+              color: "var(--fg)",
+            }}
+          >
+            <option value="never">Never</option>
+            <option value="30">In 30 days</option>
+            <option value="90">In 90 days</option>
+            <option value="365">In 1 year</option>
+          </select>
         </div>
         <button
           onClick={handleCreate}

--- a/web/src/app/(app)/api-keys/page.tsx
+++ b/web/src/app/(app)/api-keys/page.tsx
@@ -1,9 +1,15 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import type { APIKeyData } from "../../components/types";
 import { PageShell } from "../../components/loft/PageShell";
 import { Chip } from "../../components/loft/Chip";
+
+type SortKey = "last_used" | "created" | "name";
+
+function isExpired(k: APIKeyData): boolean {
+  return !!k.expires_at && new Date(k.expires_at).getTime() < Date.now();
+}
 
 // Graceful degradation per REDESIGN.md §5:
 // - "Last used" surfaced now that BACKEND_TODO #3 shipped api_keys.last_used_at
@@ -33,6 +39,38 @@ export default function APIKeysPage() {
   const [newKeyName, setNewKeyName] = useState("");
   const [creating, setCreating] = useState(false);
   const [createdKey, setCreatedKey] = useState<APIKeyData | null>(null);
+  const [sort, setSort] = useState<SortKey>("last_used");
+
+  const sortedKeys = useMemo(() => {
+    const arr = [...keys];
+    if (sort === "name") {
+      arr.sort((a, b) => (a.name || "").localeCompare(b.name || ""));
+    } else if (sort === "created") {
+      arr.sort(
+        (a, b) =>
+          new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+      );
+    } else {
+      // last_used — NULL last_used_at sorts to the end (treated as -Infinity)
+      arr.sort((a, b) => {
+        const ta = a.last_used_at ? new Date(a.last_used_at).getTime() : 0;
+        const tb = b.last_used_at ? new Date(b.last_used_at).getTime() : 0;
+        return tb - ta;
+      });
+    }
+    return arr;
+  }, [keys, sort]);
+
+  // Stats line: "N keys · M expired · P active". Renders nothing while the
+  // list is empty (the empty-state below covers that).
+  const totals = useMemo(() => {
+    const expired = keys.filter(isExpired).length;
+    return {
+      total: keys.length,
+      expired,
+      active: keys.length - expired,
+    };
+  }, [keys]);
 
   const fetchKeys = useCallback(async () => {
     try {
@@ -174,33 +212,61 @@ export default function APIKeysPage() {
           </p>
         </div>
       ) : (
-        <div
-          className="overflow-hidden"
-          style={{
-            background: "var(--bg-panel)",
-            border: "1px solid var(--border)",
-            borderRadius: "var(--r-lg)",
-          }}
-        >
-          <table className="w-full text-[13px]">
-            <thead>
-              <tr
-                className="text-left font-mono text-[10px] uppercase"
-                style={{
-                  background: "var(--bg-elev)",
-                  color: "var(--fg-subtle)",
-                  letterSpacing: "0.08em",
-                }}
+        <>
+          <div className="flex items-center gap-3 mb-3 flex-wrap">
+            <p
+              className="font-mono text-[11px]"
+              style={{ color: "var(--fg-subtle)", letterSpacing: "0.02em" }}
+            >
+              {totals.total} {totals.total === 1 ? "key" : "keys"}
+              {totals.expired > 0 && ` · ${totals.expired} expired`}
+              {totals.active !== totals.total && ` · ${totals.active} active`}
+            </p>
+            <span className="flex-1" />
+            <label
+              className="font-mono text-[11px] flex items-center gap-1.5"
+              style={{ color: "var(--fg-subtle)", letterSpacing: "0.02em" }}
+            >
+              Sort:
+              <select
+                value={sort}
+                onChange={(e) => setSort(e.target.value as SortKey)}
+                className="font-mono text-[11px] bg-transparent border-none cursor-pointer"
+                style={{ color: "var(--fg-muted)" }}
               >
-                <th className="px-4 py-2.5 font-semibold">Name</th>
-                <th className="px-4 py-2.5 font-semibold">Prefix</th>
-                <th className="px-4 py-2.5 font-semibold">Created</th>
-                <th className="px-4 py-2.5 font-semibold">Last used</th>
-                <th className="px-4 py-2.5 font-semibold"></th>
-              </tr>
-            </thead>
-            <tbody>
-              {keys.map((k, i) => (
+                <option value="last_used">last used ▾</option>
+                <option value="created">created ▾</option>
+                <option value="name">name ▾</option>
+              </select>
+            </label>
+          </div>
+          <div
+            className="overflow-hidden"
+            style={{
+              background: "var(--bg-panel)",
+              border: "1px solid var(--border)",
+              borderRadius: "var(--r-lg)",
+            }}
+          >
+            <table className="w-full text-[13px]">
+              <thead>
+                <tr
+                  className="text-left font-mono text-[10px] uppercase"
+                  style={{
+                    background: "var(--bg-elev)",
+                    color: "var(--fg-subtle)",
+                    letterSpacing: "0.08em",
+                  }}
+                >
+                  <th className="px-4 py-2.5 font-semibold">Name</th>
+                  <th className="px-4 py-2.5 font-semibold">Prefix</th>
+                  <th className="px-4 py-2.5 font-semibold">Created</th>
+                  <th className="px-4 py-2.5 font-semibold">Last used</th>
+                  <th className="px-4 py-2.5 font-semibold"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {sortedKeys.map((k, i) => (
                 <tr
                   key={k.id}
                   style={{
@@ -242,10 +308,11 @@ export default function APIKeysPage() {
                     </button>
                   </td>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
       )}
     </PageShell>
   );

--- a/web/src/app/(app)/dashboard/_components/AgentCard.tsx
+++ b/web/src/app/(app)/dashboard/_components/AgentCard.tsx
@@ -218,9 +218,92 @@ export function AgentCard({
         </div>
       )}
 
+      {/* Per-agent stats footer (BACKEND_TODO #2). Cloud-mode agents also
+          get a webhook-reachable indicator on the right; local-mode hides
+          it because no webhook is involved. */}
+      <div
+        className="mt-4 pt-4 grid grid-cols-2 md:grid-cols-4 gap-4"
+        style={{ borderTop: "1px solid var(--border-sub)" }}
+      >
+        <AgentStat label="Inbound · 7d" value={agent.inbound_7d} />
+        <AgentStat label="Outbound · 7d" value={agent.outbound_7d} />
+        <AgentStat label="Pending" value={agent.pending_count} />
+        <AgentStat
+          label={isCloud ? "Webhook" : "Last delivery"}
+          value={
+            isCloud
+              ? agent.webhook_healthy === undefined
+                ? "—"
+                : agent.webhook_healthy
+                  ? "reachable"
+                  : "unreachable"
+              : agent.last_delivery_at
+                ? formatRelativeAge(agent.last_delivery_at)
+                : "—"
+          }
+          tone={
+            isCloud
+              ? agent.webhook_healthy === false
+                ? "danger"
+                : "muted"
+              : "muted"
+          }
+        />
+      </div>
+
       {/* Activity (subordinate) */}
       <div className="mt-3">
         <ActivityPanel email={agent.email} />
+      </div>
+    </div>
+  );
+}
+
+// formatRelativeAge converts an ISO timestamp into a compact relative
+// label for the per-agent stats row. Newer than 60s → "just now",
+// otherwise the smallest unit that fits.
+function formatRelativeAge(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  if (diff < 0 || isNaN(diff)) return "—";
+  const sec = Math.floor(diff / 1000);
+  if (sec < 60) return "just now";
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  return `${Math.floor(hr / 24)}d ago`;
+}
+
+function AgentStat({
+  label,
+  value,
+  tone = "muted",
+}: {
+  label: string;
+  value: number | string | undefined | null;
+  tone?: "muted" | "danger";
+}) {
+  const display =
+    value === undefined || value === null
+      ? "—"
+      : typeof value === "number"
+        ? String(value)
+        : value;
+  return (
+    <div>
+      <div
+        className="font-mono text-[10px] font-semibold uppercase mb-1"
+        style={{ color: "var(--fg-subtle)", letterSpacing: "0.08em" }}
+      >
+        {label}
+      </div>
+      <div
+        className="text-[16px] font-medium"
+        style={{
+          color: tone === "danger" ? "var(--danger-strong)" : "var(--fg)",
+        }}
+      >
+        {display}
       </div>
     </div>
   );

--- a/web/src/app/(app)/dashboard/page.tsx
+++ b/web/src/app/(app)/dashboard/page.tsx
@@ -1,10 +1,14 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import Link from "next/link";
 import { useAuth } from "../../components/AuthProvider";
-import { listAgents, deleteAgent } from "../../components/onboarding/api";
-import type { DashboardAgent, DashboardStats } from "../../components/types";
+import { listAgents, listDomains, deleteAgent } from "../../components/onboarding/api";
+import type {
+  DashboardAgent,
+  DashboardStats,
+} from "../../components/types";
+import type { DomainInfo } from "../../components/onboarding/types";
 import { PageShell } from "../../components/loft/PageShell";
 import { AgentsEmptyState } from "./_components/AgentsEmptyState";
 import { AgentCard } from "./_components/AgentCard";
@@ -14,12 +18,24 @@ import { AgentCard } from "./_components/AgentCard";
 function formatDelta(pct: number): string | null {
   if (pct === 0) return null;
   const sign = pct > 0 ? "+" : "";
-  return `${sign}${pct}% vs yesterday`;
+  return `${sign}${pct}%`;
 }
 
-// Stats strip — populated from GET /api/dashboard/stats. Zero counts and
-// missing baselines are rendered as bare numbers (no delta arrow) so the
-// cards stay sensible on deployments without usage tracking enabled.
+// formatRelativeSeconds renders the "oldest pending" age. Falls back to
+// the empty string when count is 0 so the caller can hide the line.
+function formatPendingOldest(seconds: number): string {
+  if (seconds <= 0) return "";
+  if (seconds < 60) return `oldest in <1m`;
+  const min = Math.floor(seconds / 60);
+  if (min < 60) return `oldest in ${min}m`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `oldest in ${hr}h`;
+  return `oldest in ${Math.floor(hr / 24)}d`;
+}
+
+// Stats strip — populated from GET /api/dashboard/stats. Mock specifies
+// sans-serif numerals at 28px/600 (NOT editorial italic); deltas tint by
+// tone (positive=success, negative=neutral, pending uses accent).
 function StatsStrip() {
   const [stats, setStats] = useState<DashboardStats | null>(null);
 
@@ -31,30 +47,40 @@ function StatsStrip() {
         if (!cancelled) setStats(data);
       })
       .catch(() => {
-        // Swallow — leaves stats=null, which renders "—" below. The
-        // dashboard load shouldn't fail because the stats endpoint is
-        // down or the user has tracking disabled.
+        // Swallow — null state renders "—" below. Don't crash the
+        // dashboard if the stats endpoint is down or tracking disabled.
       });
     return () => {
       cancelled = true;
     };
   }, []);
 
-  const cards = [
+  type Card = {
+    label: string;
+    value: string;
+    sub: string | null;
+    tone: "success" | "info" | "accent" | "neutral";
+  };
+  const cards: Card[] = [
     {
-      label: "Inbound today",
+      label: "Inbound · today",
       value: stats ? String(stats.today.inbound) : "—",
-      delta: stats ? formatDelta(stats.today.inbound_delta_pct) : null,
+      sub: stats ? formatDelta(stats.today.inbound_delta_pct) : null,
+      tone: "success",
     },
     {
-      label: "Outbound today",
+      label: "Outbound · today",
       value: stats ? String(stats.today.outbound) : "—",
-      delta: stats ? formatDelta(stats.today.outbound_delta_pct) : null,
+      sub: stats ? formatDelta(stats.today.outbound_delta_pct) : null,
+      tone: "info",
     },
     {
       label: "Pending review",
       value: stats ? String(stats.pending.count) : "—",
-      delta: null as string | null,
+      sub: stats && stats.pending.count > 0
+        ? formatPendingOldest(stats.pending.oldest_seconds)
+        : null,
+      tone: "accent",
     },
     {
       label: "Delivery success",
@@ -63,9 +89,17 @@ function StatsStrip() {
           ? `${stats.delivery_success_pct}%`
           : "—"
         : "—",
-      delta: stats ? `last ${stats.sample_window_days}d` : null,
+      sub: stats ? `last ${stats.sample_window_days}d` : null,
+      tone: "neutral",
     },
   ];
+
+  const subColor = (tone: Card["tone"]) =>
+    tone === "accent"
+      ? "var(--accent-strong)"
+      : tone === "success"
+        ? "var(--success)"
+        : "var(--fg-muted)";
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-3 mb-6">
@@ -80,7 +114,7 @@ function StatsStrip() {
           }}
         >
           <div
-            className="font-mono text-[11px] font-semibold uppercase mb-1.5"
+            className="font-mono text-[10px] font-semibold uppercase mb-2"
             style={{
               color: "var(--fg-subtle)",
               letterSpacing: "0.08em",
@@ -89,22 +123,19 @@ function StatsStrip() {
             {s.label}
           </div>
           <div
-            className="text-[24px]"
+            className="text-[28px] font-semibold"
             style={{
-              fontFamily: "var(--f-editorial)",
               color: "var(--fg)",
-              letterSpacing: "-0.01em",
-              lineHeight: 1.1,
+              letterSpacing: "-0.02em",
+              lineHeight: 1,
+              marginBottom: 6,
             }}
           >
             {s.value}
           </div>
-          {s.delta && (
-            <div
-              className="text-[11px] mt-1"
-              style={{ color: "var(--fg-muted)" }}
-            >
-              {s.delta}
+          {s.sub && (
+            <div className="text-[11px]" style={{ color: subColor(s.tone) }}>
+              {s.sub}
             </div>
           )}
         </div>
@@ -113,16 +144,101 @@ function StatsStrip() {
   );
 }
 
+// Filter chips + sort dropdown. Counts are derived client-side from the
+// agents list — the backend doesn't need to compute filter aggregates.
+// "Sort: last activity" uses created_at descending as a proxy until
+// BACKEND_TODO #2 exposes a real last-activity timestamp; until then the
+// label is honest about what's available.
+type Filter = "all" | "cloud" | "local" | "hitl" | "unverified";
+type SortKey = "recent" | "name";
+
+function FilterBar({
+  agents,
+  filter,
+  setFilter,
+  sort,
+  setSort,
+}: {
+  agents: DashboardAgent[];
+  filter: Filter;
+  setFilter: (f: Filter) => void;
+  sort: SortKey;
+  setSort: (s: SortKey) => void;
+}) {
+  const counts = {
+    all: agents.length,
+    cloud: agents.filter((a) => a.agent_mode !== "local").length,
+    local: agents.filter((a) => a.agent_mode === "local").length,
+    hitl: agents.filter((a) => a.hitl_enabled).length,
+    unverified: agents.filter((a) => !a.domain_verified).length,
+  };
+  const chips: { key: Filter; label: string; count: number }[] = [
+    { key: "all", label: "All", count: counts.all },
+    { key: "cloud", label: "Cloud", count: counts.cloud },
+    { key: "local", label: "Local", count: counts.local },
+    { key: "hitl", label: "HITL on", count: counts.hitl },
+    { key: "unverified", label: "Unverified", count: counts.unverified },
+  ];
+
+  return (
+    <div className="flex items-center gap-2 mb-3.5 flex-wrap">
+      {chips.map((c) => {
+        const active = filter === c.key;
+        return (
+          <button
+            key={c.key}
+            onClick={() => setFilter(c.key)}
+            className="text-[12px] font-medium px-3 py-1 transition"
+            style={{
+              borderRadius: 999,
+              background: active ? "var(--fg)" : "var(--bg-panel)",
+              color: active ? "var(--bg)" : "var(--fg-muted)",
+              border: active
+                ? "1px solid var(--fg)"
+                : "1px solid var(--border)",
+            }}
+          >
+            {c.label} {c.count}
+          </button>
+        );
+      })}
+      <span className="flex-1" />
+      <label
+        className="font-mono text-[11px] flex items-center gap-1.5"
+        style={{ color: "var(--fg-subtle)", letterSpacing: "0.02em" }}
+      >
+        Sort:
+        <select
+          value={sort}
+          onChange={(e) => setSort(e.target.value as SortKey)}
+          className="font-mono text-[11px] bg-transparent border-none cursor-pointer"
+          style={{ color: "var(--fg-muted)" }}
+        >
+          <option value="recent">last activity ▾</option>
+          <option value="name">name ▾</option>
+        </select>
+      </label>
+    </div>
+  );
+}
+
 export default function DashboardPage() {
   const { user } = useAuth();
   const [agents, setAgents] = useState<DashboardAgent[]>([]);
+  const [domains, setDomains] = useState<DomainInfo[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
+  const [filter, setFilter] = useState<Filter>("all");
+  const [sort, setSort] = useState<SortKey>("recent");
 
-  const fetchAgents = useCallback(async () => {
+  const fetchData = useCallback(async () => {
     try {
-      const data = await listAgents();
-      setAgents(data);
+      const [agentList, domainList] = await Promise.all([
+        listAgents(),
+        listDomains().catch(() => [] as DomainInfo[]),
+      ]);
+      setAgents(agentList);
+      setDomains(domainList);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load agents");
     } finally {
@@ -131,18 +247,72 @@ export default function DashboardPage() {
   }, []);
 
   useEffect(() => {
-    fetchAgents();
-  }, [fetchAgents]);
+    fetchData();
+  }, [fetchData]);
 
   const handleDelete = async (email: string) => {
     if (!confirm(`Delete agent ${email}? This cannot be undone.`)) return;
     try {
       await deleteAgent(email);
-      fetchAgents();
+      fetchData();
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to delete agent");
     }
   };
+
+  // Derived: filtered + sorted agent list.
+  const visibleAgents = useMemo(() => {
+    let out = agents;
+    switch (filter) {
+      case "cloud":
+        out = out.filter((a) => a.agent_mode !== "local");
+        break;
+      case "local":
+        out = out.filter((a) => a.agent_mode === "local");
+        break;
+      case "hitl":
+        out = out.filter((a) => a.hitl_enabled);
+        break;
+      case "unverified":
+        out = out.filter((a) => !a.domain_verified);
+        break;
+    }
+    if (sort === "recent") {
+      // created_at descending as a stand-in for last activity until
+      // BACKEND_TODO #2 exposes a real signal.
+      out = [...out].sort(
+        (a, b) =>
+          new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+      );
+    } else {
+      out = [...out].sort((a, b) =>
+        (a.name || a.email).localeCompare(b.name || b.email),
+      );
+    }
+    return out;
+  }, [agents, filter, sort]);
+
+  // Meta line: "N agents · M verified domains · indexed <relative> ago"
+  const [indexedAt, setIndexedAt] = useState<number>(Date.now());
+  useEffect(() => {
+    setIndexedAt(Date.now());
+  }, [agents, domains]);
+  const [tick, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 5000);
+    return () => clearInterval(id);
+  }, []);
+  const indexedAgo = useMemo(() => {
+    const sec = Math.max(1, Math.floor((Date.now() - indexedAt) / 1000));
+    if (sec < 60) return `${sec}s`;
+    const min = Math.floor(sec / 60);
+    if (min < 60) return `${min}m`;
+    return `${Math.floor(min / 60)}h`;
+  }, [indexedAt, tick]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const verifiedDomains = domains.filter((d) => d.verified).length;
+  const agentLabel = agents.length === 1 ? "agent" : "agents";
+  const domainLabel = verifiedDomains === 1 ? "verified domain" : "verified domains";
 
   return (
     <PageShell
@@ -151,11 +321,15 @@ export default function DashboardPage() {
       title={<>Agents</>}
       subtitle={
         <>
-          Manage your registered agents. Signed in as{" "}
+          {agents.length} {agentLabel} · {verifiedDomains} {domainLabel} ·
+          indexed{" "}
+          <span style={{ fontFamily: "var(--f-mono)" }}>
+            {indexedAgo} ago
+          </span>{" "}
+          · signed in as{" "}
           <span style={{ color: "var(--fg)", fontWeight: 500 }}>
             {user?.email}
           </span>
-          .
         </>
       }
       actions={
@@ -169,8 +343,7 @@ export default function DashboardPage() {
               borderRadius: "var(--r-md)",
             }}
           >
-            Create agent
-            <span className="font-mono">→</span>
+            <span className="font-mono">+</span> Create agent
           </Link>
         ) : null
       }
@@ -201,16 +374,34 @@ export default function DashboardPage() {
       ) : agents.length === 0 ? (
         <AgentsEmptyState />
       ) : (
-        <div className="space-y-4">
-          {agents.map((agent) => (
-            <AgentCard
-              key={agent.id}
-              agent={agent}
-              onDelete={() => handleDelete(agent.email)}
-              onUpdate={() => fetchAgents()}
-            />
-          ))}
-        </div>
+        <>
+          <FilterBar
+            agents={agents}
+            filter={filter}
+            setFilter={setFilter}
+            sort={sort}
+            setSort={setSort}
+          />
+          <div className="space-y-4">
+            {visibleAgents.length === 0 ? (
+              <p
+                className="text-[13px] py-8 text-center"
+                style={{ color: "var(--fg-muted)" }}
+              >
+                No agents match this filter.
+              </p>
+            ) : (
+              visibleAgents.map((agent) => (
+                <AgentCard
+                  key={agent.id}
+                  agent={agent}
+                  onDelete={() => handleDelete(agent.email)}
+                  onUpdate={() => fetchData()}
+                />
+              ))
+            )}
+          </div>
+        </>
       )}
     </PageShell>
   );

--- a/web/src/app/(app)/domains/_components/DomainCard.tsx
+++ b/web/src/app/(app)/domains/_components/DomainCard.tsx
@@ -5,8 +5,37 @@ import { DNSRecord } from "../../../components/Field";
 import { Chip } from "../../../components/loft/Chip";
 import { Dot } from "../../../components/loft/Dot";
 import { verifyDomain, deleteDomain } from "../../../components/onboarding/api";
-import type { DomainInfo } from "../../../components/onboarding/types";
+import type {
+  DomainInfo,
+  VerifyDomainResponse,
+} from "../../../components/onboarding/types";
 import { track } from "../../../components/onboarding/analytics";
+
+// Renders a found/missing/deferred chip next to each per-record row in
+// the DNS expansion. "deferred" is for DKIM until BACKEND_TODO #5 ships;
+// it surfaces as a muted "pending" state instead of a hard miss.
+function RecordStatusChip({
+  status,
+}: {
+  status: "found" | "missing" | "deferred" | undefined;
+}) {
+  if (!status) return null;
+  if (status === "found")
+    return (
+      <Chip tone="success">
+        <Dot tone="success" />
+        Found
+      </Chip>
+    );
+  if (status === "deferred")
+    return <Chip tone="neutral">Pending DKIM support</Chip>;
+  return (
+    <Chip tone="warn">
+      <Dot tone="warn" />
+      Missing
+    </Chip>
+  );
+}
 
 export function DomainCard({
   domain,
@@ -23,13 +52,18 @@ export function DomainCard({
   const [verifying, setVerifying] = useState(false);
   const [verifyError, setVerifyError] = useState("");
   const [deleting, setDeleting] = useState(false);
+  // Cached per-record diagnostic from the most recent verify probe. Until
+  // the user clicks "View DNS records" + retries, this is null and the
+  // chips render as "—" placeholders.
+  const [probe, setProbe] = useState<VerifyDomainResponse | null>(null);
 
   const handleVerify = async () => {
     setVerifyError("");
     setVerifying(true);
     track("domain_verify_attempted", { domain: domain.domain });
     try {
-      await verifyDomain(domain.domain);
+      const result = await verifyDomain(domain.domain);
+      setProbe(result);
       track("domain_verify_succeeded", { domain: domain.domain });
       onVerified();
     } catch (err) {
@@ -196,32 +230,113 @@ export function DomainCard({
         </button>
       </div>
 
-      {/* DNS records — MX + TXT only per BACKEND_TODO #4/#5 (DKIM row hidden until per-domain DKIM ships) */}
+      {/* DNS records — per-record status chips populated from the
+          most recent verify probe (BACKEND_TODO #4). DKIM row stays
+          hidden until #5 ships per-domain DKIM keys. */}
       {showDNS && (
         <div
           className="mt-3 pt-4 space-y-4"
           style={{ borderTop: "1px solid var(--border)" }}
         >
-          <DNSRecord
-            type="MX"
-            label="Route email to e2a"
-            fields={[
-              { label: "Name", value: domain.domain },
-              { label: "Mail server", value: domain.dns_records.mx.value },
-              {
-                label: "Priority",
-                value: String(domain.dns_records.mx.priority),
-              },
-            ]}
-          />
-          <DNSRecord
-            type="TXT"
-            label="Prove domain ownership"
-            fields={[
-              { label: "Name", value: domain.domain },
-              { label: "Content", value: domain.verification_token },
-            ]}
-          />
+          <div className="flex items-center justify-between gap-2 flex-wrap">
+            <p
+              className="font-mono text-[10px] uppercase font-semibold"
+              style={{ color: "var(--fg-subtle)", letterSpacing: "0.08em" }}
+            >
+              DNS records
+              {(probe || domain.last_checked_at) && (
+                <span
+                  className="ml-2 font-normal normal-case"
+                  style={{ color: "var(--fg-subtle)", letterSpacing: "0.02em" }}
+                >
+                  · last checked{" "}
+                  {new Date(
+                    domain.last_checked_at || Date.now(),
+                  ).toLocaleString()}
+                </span>
+              )}
+            </p>
+            <button
+              onClick={handleVerify}
+              disabled={verifying}
+              className="text-[11px] px-2 py-0.5 transition disabled:opacity-50"
+              style={{
+                color: "var(--fg-muted)",
+                border: "1px solid var(--border-sub)",
+                background: "var(--bg-elev)",
+                borderRadius: "var(--r-sm)",
+              }}
+            >
+              {verifying ? "Probing…" : "Re-check"}
+            </button>
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex items-center gap-2 flex-wrap">
+              <span
+                className="font-mono text-[11px] px-2 py-0.5"
+                style={{
+                  background: "var(--bg-elev)",
+                  border: "1px solid var(--border-sub)",
+                  borderRadius: "var(--r-sm)",
+                  color: "var(--fg)",
+                  minWidth: 36,
+                  textAlign: "center",
+                }}
+              >
+                MX
+              </span>
+              <span className="text-[12px]" style={{ color: "var(--fg-muted)" }}>
+                Route email to e2a
+              </span>
+              <span className="flex-1" />
+              <RecordStatusChip status={probe?.mx} />
+            </div>
+            <DNSRecord
+              type=""
+              label=""
+              fields={[
+                { label: "Name", value: domain.domain },
+                { label: "Mail server", value: domain.dns_records.mx.value },
+                {
+                  label: "Priority",
+                  value: String(domain.dns_records.mx.priority),
+                },
+              ]}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex items-center gap-2 flex-wrap">
+              <span
+                className="font-mono text-[11px] px-2 py-0.5"
+                style={{
+                  background: "var(--bg-elev)",
+                  border: "1px solid var(--border-sub)",
+                  borderRadius: "var(--r-sm)",
+                  color: "var(--fg)",
+                  minWidth: 36,
+                  textAlign: "center",
+                }}
+              >
+                TXT
+              </span>
+              <span className="text-[12px]" style={{ color: "var(--fg-muted)" }}>
+                Prove domain ownership (also drives SPF check)
+              </span>
+              <span className="flex-1" />
+              <RecordStatusChip status={probe?.spf} />
+            </div>
+            <DNSRecord
+              type=""
+              label=""
+              fields={[
+                { label: "Name", value: domain.domain },
+                { label: "Content", value: domain.verification_token },
+              ]}
+            />
+          </div>
+
           {!domain.verified && (
             <div
               className="p-3 text-[12px]"

--- a/web/src/app/(app)/domains/_components/DomainCard.tsx
+++ b/web/src/app/(app)/domains/_components/DomainCard.tsx
@@ -4,7 +4,11 @@ import { useState } from "react";
 import { DNSRecord } from "../../../components/Field";
 import { Chip } from "../../../components/loft/Chip";
 import { Dot } from "../../../components/loft/Dot";
-import { verifyDomain, deleteDomain } from "../../../components/onboarding/api";
+import {
+  verifyDomain,
+  deleteDomain,
+  setDomainPrimary,
+} from "../../../components/onboarding/api";
 import type {
   DomainInfo,
   VerifyDomainResponse,
@@ -52,10 +56,27 @@ export function DomainCard({
   const [verifying, setVerifying] = useState(false);
   const [verifyError, setVerifyError] = useState("");
   const [deleting, setDeleting] = useState(false);
+  const [promoting, setPromoting] = useState(false);
   // Cached per-record diagnostic from the most recent verify probe. Until
   // the user clicks "View DNS records" + retries, this is null and the
   // chips render as "—" placeholders.
   const [probe, setProbe] = useState<VerifyDomainResponse | null>(null);
+
+  const handleSetPrimary = async () => {
+    setPromoting(true);
+    try {
+      await setDomainPrimary(domain.domain);
+      onVerified(); // reuse the parent's refresh — refetches the list
+    } catch (err) {
+      alert(
+        err instanceof Error
+          ? err.message
+          : "Failed to set primary domain",
+      );
+    } finally {
+      setPromoting(false);
+    }
+  };
 
   const handleVerify = async () => {
     setVerifyError("");
@@ -154,7 +175,25 @@ export function DomainCard({
             )}
           </p>
         </div>
-        <div className="flex gap-2 shrink-0">
+        <div className="flex gap-2 shrink-0 flex-wrap">
+          {/* Make-primary action: only shown for verified, non-primary
+              domains. PATCH /api/v1/domains/{domain} atomically swaps
+              the primary flag on the server side. */}
+          {domain.verified && !domain.is_primary && (
+            <button
+              onClick={handleSetPrimary}
+              disabled={promoting}
+              className="text-[12px] px-3 py-1.5 transition disabled:opacity-50"
+              style={{
+                background: "var(--bg-panel)",
+                color: "var(--fg)",
+                border: "1px solid var(--border)",
+                borderRadius: "var(--r-md)",
+              }}
+            >
+              {promoting ? "Setting…" : "Make primary"}
+            </button>
+          )}
           {domain.verified ? (
             <a
               href={`/get-started?domain=${encodeURIComponent(domain.domain)}`}

--- a/web/src/app/(app)/domains/page.test.tsx
+++ b/web/src/app/(app)/domains/page.test.tsx
@@ -311,3 +311,78 @@ describe("Domains page — verify domain", () => {
     });
   });
 });
+
+describe("Domains page — Make primary action", () => {
+  it("shows Make primary on verified non-primary domains and PATCHes is_primary on click", async () => {
+    const patched: Array<{ url: string; body: unknown }> = [];
+    mockFetch.mockImplementation(
+      (url: string, init?: { method?: string; body?: string }) => {
+        if (url === "/api/v1/domains" && (!init || !init.method)) {
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                domains: [
+                  { ...verifiedDomain, is_primary: false, agent_count: 0 },
+                ],
+              }),
+          });
+        }
+        if (url === "/api/dashboard/agents") {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve({ agents: [] }),
+          });
+        }
+        if (
+          url === `/api/v1/domains/${encodeURIComponent(verifiedDomain.domain)}` &&
+          init?.method === "PATCH"
+        ) {
+          patched.push({ url, body: JSON.parse(init.body as string) });
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({ ...verifiedDomain, is_primary: true }),
+          });
+        }
+        return Promise.resolve({
+          ok: false,
+          text: () => Promise.resolve("not found"),
+        });
+      },
+    );
+
+    render(<DomainsPage />);
+    const button = await screen.findByRole("button", { name: /make primary/i });
+    await userEvent.setup().click(button);
+
+    await waitFor(() => {
+      expect(patched).toHaveLength(1);
+      expect(patched[0].body).toEqual({ is_primary: true });
+    });
+  });
+
+  it("hides Make primary when domain is already primary", async () => {
+    mockDomainsAndAgents(
+      [{ ...verifiedDomain, is_primary: true, agent_count: 0 }],
+      [],
+    );
+    render(<DomainsPage />);
+    await screen.findByText(verifiedDomain.domain);
+    // Already-primary card has the Primary chip but no Make-primary button
+    expect(screen.queryByRole("button", { name: /make primary/i }))
+      .not.toBeInTheDocument();
+    expect(screen.getByText("Primary")).toBeInTheDocument();
+  });
+
+  it("hides Make primary on unverified domains (verify first)", async () => {
+    mockDomainsAndAgents(
+      [{ ...sampleDomain, is_primary: false, agent_count: 0 }],
+      [],
+    );
+    render(<DomainsPage />);
+    await screen.findByText(sampleDomain.domain);
+    expect(screen.queryByRole("button", { name: /make primary/i }))
+      .not.toBeInTheDocument();
+  });
+});

--- a/web/src/app/(app)/domains/page.test.tsx
+++ b/web/src/app/(app)/domains/page.test.tsx
@@ -184,7 +184,10 @@ describe("Domains page — with domains", () => {
     await userEvent.click(screen.getByText("View DNS records"));
 
     expect(screen.getByText("Route email to e2a")).toBeInTheDocument();
-    expect(screen.getByText("Prove domain ownership")).toBeInTheDocument();
+    // Per-record DNS row label expanded for SPF context (BACKEND_TODO #4)
+    expect(
+      screen.getByText(/Prove domain ownership/),
+    ).toBeInTheDocument();
   });
 });
 

--- a/web/src/app/(app)/settings/page.test.tsx
+++ b/web/src/app/(app)/settings/page.test.tsx
@@ -37,6 +37,23 @@ beforeEach(() => {
     loading: false,
     signOut,
   };
+  // The Settings → Usage section fetches /api/dashboard/stats on mount.
+  // Tests that don't care about Usage just stub fetch with a stats
+  // response so the section can settle into its 0-state instead of
+  // throwing an unhandled rejection.
+  global.fetch = jest.fn(async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      today: { inbound: 0, outbound: 0, inbound_delta_pct: 0, outbound_delta_pct: 0 },
+      pending: { count: 0, oldest_seconds: 0 },
+      delivery_success_pct: 0,
+      sample_window_days: 30,
+      inbound_window: 0,
+      outbound_window: 0,
+    }),
+    text: async () => "",
+  })) as unknown as typeof fetch;
 });
 
 describe("Settings — Profile section", () => {

--- a/web/src/app/(app)/settings/page.tsx
+++ b/web/src/app/(app)/settings/page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useAuth } from "../../components/AuthProvider";
 import { PageShell } from "../../components/loft/PageShell";
+import type { DashboardStats } from "../../components/types";
 
 export default function SettingsPage() {
   const { user } = useAuth();
@@ -206,23 +207,63 @@ function ProfileSection({
 }
 
 function UsageSection() {
-  // Per REDESIGN.md §5 degradation: render `—` until BACKEND_TODO #1
-  // exposes per-day/per-month aggregates from usage_summaries.
+  // Pulls a 30-day window from the same /api/dashboard/stats endpoint
+  // the dashboard strip uses. Backend computes inbound_window /
+  // outbound_window over the requested window, plus delivery success
+  // % over that same span. Pending count is always current (not
+  // window-scoped). Null state during fetch renders as "—".
+  const [stats, setStats] = useState<DashboardStats | null>(null);
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/dashboard/stats?window=30")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => {
+        if (!cancelled) setStats(data);
+      })
+      .catch(() => {
+        // Don't crash the page — null state shows "—".
+      })
+      .finally(() => {
+        if (!cancelled) setLoaded(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const days = stats?.sample_window_days ?? 30;
+  const cards: { label: string; value: string }[] = [
+    {
+      label: `Inbound · ${days}d`,
+      value: stats ? String(stats.inbound_window) : loaded ? "0" : "—",
+    },
+    {
+      label: `Outbound · ${days}d`,
+      value: stats ? String(stats.outbound_window) : loaded ? "0" : "—",
+    },
+    {
+      label: "Pending",
+      value: stats ? String(stats.pending.count) : loaded ? "0" : "—",
+    },
+    {
+      label: "Delivery success",
+      value:
+        stats && stats.delivery_success_pct > 0
+          ? `${stats.delivery_success_pct}%`
+          : "—",
+    },
+  ];
+
   return (
     <section>
       <SectionHeading
         title="Usage"
-        subtitle="Rolling counters of inbound and outbound messages."
+        subtitle="Inbound + outbound counts over the last 30 days. Pending shows messages currently waiting on HITL approval; delivery success is the share of webhook deliveries that finalised successfully."
       />
-      <div
-        className="grid grid-cols-2 md:grid-cols-4 gap-3"
-      >
-        {[
-          { label: "Inbound · 30d", value: "—" },
-          { label: "Outbound · 30d", value: "—" },
-          { label: "Pending", value: "—" },
-          { label: "Delivery success", value: "—" },
-        ].map((s) => (
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+        {cards.map((s) => (
           <div
             key={s.label}
             className="px-4 py-3.5"
@@ -242,9 +283,8 @@ function UsageSection() {
               {s.label}
             </div>
             <div
-              className="text-[22px]"
+              className="text-[22px] font-semibold"
               style={{
-                fontFamily: "var(--f-editorial)",
                 color: "var(--fg)",
                 letterSpacing: "-0.01em",
                 lineHeight: 1.1,

--- a/web/src/app/(app)/settings/page.tsx
+++ b/web/src/app/(app)/settings/page.tsx
@@ -69,6 +69,37 @@ function ProfileSection({
 }: {
   user: { id: string; email: string; name: string; created_at: string };
 }) {
+  const { setUser } = useAuth();
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(user.name);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleSave = async () => {
+    setError("");
+    setSaving(true);
+    try {
+      const res = await fetch("/api/auth/me", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        credentials: "include",
+        body: JSON.stringify({ name: draft }),
+      });
+      if (!res.ok) {
+        setError((await res.text()) || `Failed (${res.status})`);
+        setSaving(false);
+        return;
+      }
+      const updated = await res.json();
+      setUser(updated);
+      setEditing(false);
+    } catch {
+      setError("Network error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
   return (
     <section>
       <SectionHeading title="Profile" />
@@ -82,24 +113,83 @@ function ProfileSection({
       >
         <dl className="grid grid-cols-[140px_1fr] gap-y-3 gap-x-6 text-[13px]">
           <dt style={{ color: "var(--fg-muted)" }}>Name</dt>
-          <dd className="flex items-center gap-2" style={{ color: "var(--fg)" }}>
-            <span>{user.name || "—"}</span>
-            {/* Edit-name disabled until BACKEND_TODO #8 (PATCH /api/auth/me) ships */}
-            <button
-              type="button"
-              disabled
-              title="Editing name will be enabled once PATCH /api/auth/me ships"
-              className="text-[11px] px-2 py-0.5"
-              style={{
-                color: "var(--fg-subtle)",
-                border: "1px solid var(--border-sub)",
-                background: "var(--bg-elev)",
-                borderRadius: "var(--r-sm)",
-                cursor: "not-allowed",
-              }}
-            >
-              Edit
-            </button>
+          <dd className="flex items-center gap-2 flex-wrap" style={{ color: "var(--fg)" }}>
+            {editing ? (
+              <>
+                <input
+                  type="text"
+                  value={draft}
+                  onChange={(e) => setDraft(e.target.value)}
+                  disabled={saving}
+                  maxLength={80}
+                  className="text-[13px] px-2 py-1"
+                  style={{
+                    background: "var(--bg-elev)",
+                    border: "1px solid var(--border)",
+                    borderRadius: "var(--r-sm)",
+                    color: "var(--fg)",
+                    minWidth: 200,
+                  }}
+                />
+                <button
+                  type="button"
+                  onClick={handleSave}
+                  disabled={saving || draft.trim().length === 0 || draft !== draft.trim()}
+                  className="text-[11px] px-2 py-0.5 disabled:opacity-50 disabled:cursor-not-allowed"
+                  style={{
+                    color: "var(--accent-fg)",
+                    background: "var(--accent-fill)",
+                    border: "1px solid var(--accent-fill)",
+                    borderRadius: "var(--r-sm)",
+                  }}
+                >
+                  {saving ? "Saving…" : "Save"}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setEditing(false);
+                    setDraft(user.name);
+                    setError("");
+                  }}
+                  disabled={saving}
+                  className="text-[11px] px-2 py-0.5"
+                  style={{
+                    color: "var(--fg-muted)",
+                    border: "1px solid var(--border-sub)",
+                    background: "var(--bg-elev)",
+                    borderRadius: "var(--r-sm)",
+                  }}
+                >
+                  Cancel
+                </button>
+                {error && (
+                  <span className="text-[11px]" style={{ color: "var(--danger-strong)" }}>
+                    {error}
+                  </span>
+                )}
+              </>
+            ) : (
+              <>
+                <span>{user.name || "—"}</span>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setDraft(user.name);
+                    setEditing(true);
+                  }}
+                  className="text-[11px] px-2 py-0.5"
+                  style={{
+                    color: "var(--fg-muted)",
+                    border: "1px solid var(--border-sub)",
+                    background: "var(--bg-elev)",
+                    borderRadius: "var(--r-sm)",
+                  }}
+                >
+                  Edit
+                </button>
+              </>
+            )}
           </dd>
           <dt style={{ color: "var(--fg-muted)" }}>Email</dt>
           <dd style={{ color: "var(--fg)" }}>{user.email}</dd>

--- a/web/src/app/components/AuthProvider.tsx
+++ b/web/src/app/components/AuthProvider.tsx
@@ -7,12 +7,17 @@ type AuthContextType = {
   user: UserInfo | null;
   loading: boolean;
   signOut: () => Promise<void>;
+  // setUser lets other components push fresh profile data into the
+  // shared cache after a PATCH /api/auth/me edit, so the sidebar's
+  // identity card updates without an extra round-trip.
+  setUser: (u: UserInfo | null) => void;
 };
 
 const AuthContext = createContext<AuthContextType>({
   user: null,
   loading: true,
   signOut: async () => {},
+  setUser: () => {},
 });
 
 export function useAuth() {
@@ -41,7 +46,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   }, []);
 
   return (
-    <AuthContext.Provider value={{ user, loading, signOut }}>
+    <AuthContext.Provider value={{ user, loading, signOut, setUser }}>
       {children}
     </AuthContext.Provider>
   );

--- a/web/src/app/components/onboarding/api.ts
+++ b/web/src/app/components/onboarding/api.ts
@@ -52,7 +52,9 @@ export async function registerDomain(domain: string): Promise<DomainInfo> {
   });
 }
 
-export async function verifyDomain(domain: string): Promise<{ domain: string; verified: boolean; verified_at: string | null }> {
+export async function verifyDomain(
+  domain: string,
+): Promise<import("./types").VerifyDomainResponse> {
   return request("/api/v1/domains/" + encodeURIComponent(domain) + "/verify", {
     method: "POST",
   });

--- a/web/src/app/components/onboarding/api.ts
+++ b/web/src/app/components/onboarding/api.ts
@@ -66,6 +66,21 @@ export async function deleteDomain(domain: string): Promise<void> {
   });
 }
 
+// updateDomain hits PATCH /api/v1/domains/{domain}. Currently the
+// only mutable field is is_primary — passing true promotes the domain
+// (and atomically demotes any prior primary on the server side). The
+// server rejects {is_primary: false} (to switch primary you promote
+// a different domain instead) so we don't expose that case here.
+export async function setDomainPrimary(domain: string): Promise<DomainInfo> {
+  return request<DomainInfo>(
+    "/api/v1/domains/" + encodeURIComponent(domain),
+    {
+      method: "PATCH",
+      body: JSON.stringify({ is_primary: true }),
+    },
+  );
+}
+
 // ── Agents ───────────────────────────────────────────────
 
 export async function listAgents(): Promise<DashboardAgent[]> {

--- a/web/src/app/components/onboarding/types.ts
+++ b/web/src/app/components/onboarding/types.ts
@@ -39,6 +39,18 @@ export type DomainInfo = {
   agent_count?: number;
 };
 
+/** Response from POST /api/v1/domains/{domain}/verify — per-record
+ * diagnostic shipped by BACKEND_TODO #4. dkim stays "deferred" until
+ * BACKEND_TODO #5 ships per-domain DKIM keys. */
+export type VerifyDomainResponse = {
+  domain: string;
+  verified: boolean;
+  verified_at?: string | null;
+  mx?: "found" | "missing";
+  spf?: "found" | "missing";
+  dkim?: "found" | "missing" | "deferred";
+};
+
 /** The progress state for a domain through onboarding. */
 export type DomainProgress = {
   domain: DomainInfo;

--- a/web/src/app/components/types.ts
+++ b/web/src/app/components/types.ts
@@ -24,6 +24,15 @@ export type DashboardAgent = {
   hitl_enabled: boolean;
   hitl_ttl_seconds: number;
   hitl_expiration_action: "approve" | "reject";
+  // Enriched stats from BACKEND_TODO #2 — only populated by
+  // GET /api/dashboard/agents; other agent endpoints leave them at
+  // zero values. Fields are optional in the type so older deployments
+  // (no enrichment) still parse correctly.
+  inbound_7d?: number;
+  outbound_7d?: number;
+  pending_count?: number;
+  last_delivery_at?: string | null;
+  webhook_healthy?: boolean;
 };
 
 export type PendingMessageSummary = {

--- a/web/src/app/components/types.ts
+++ b/web/src/app/components/types.ts
@@ -105,9 +105,12 @@ export type APIKeyData = {
   expires_at?: string | null;
 };
 
-// GET /api/dashboard/stats — workspace-level aggregates for the
-// dashboard stats strip. Null/zero values are rendered as "—" by the
-// stat card components.
+// GET /api/dashboard/stats — workspace-level aggregates. The same
+// endpoint powers two surfaces:
+//   - Dashboard at-a-glance strip: uses `today` (default window=7)
+//   - Settings usage card: passes ?window=30 and uses the
+//     inbound_window / outbound_window / delivery_success_pct fields
+// sample_window_days echoes the window in effect for the response.
 export type DashboardStats = {
   today: {
     inbound: number;
@@ -121,6 +124,8 @@ export type DashboardStats = {
   };
   delivery_success_pct: number;
   sample_window_days: number;
+  inbound_window: number;
+  outbound_window: number;
 };
 
 // Domain enrichment fields — chips on the Domains page. is_primary is


### PR DESCRIPTION
**Stack position:** A of 4 (base: PR #111). B1 → B2 → C land on top.

## Summary

Backend additions for the Loft dashboard refresh, plus the UI consumers that wire them in. All additive — no schema renames, no contract changes.

## What lands

| Commit | Story |
|---|---|
| `3e6fe84` | UI-only catchup — dashboard + settings + api-keys polish |
| `8f483e7` | API: enriched DashboardAgent — Inbound7d / Outbound7d / Pending / LastDelivery / WebhookHealthy (BACKEND_TODO #2) |
| `d2f5624` | API: per-record DNS verification (MX / SPF / DKIM diagnostic) (BACKEND_TODO #4) |
| `9fbbad1` | Web: render enriched agent stats + per-record DNS chips |
| `4a0a11d` | Close three UI ↔ backend gaps from the audit (?window=N on stats, Make-primary, Expires-in select) |
| `1dcc71a` | API keys table — Expires column |

## Backend changes

* `identity.AgentIdentity` gains `Inbound7d`, `Outbound7d`, `PendingCount`, `LastDeliveryAt`, `WebhookHealthy` — computed at read time in `ListAgentsByUser` via correlated subqueries.
* `identity.Store.GetDashboardStats` now accepts a `windowDays` param (1..90, default 7). `HandleDashboardStats` parses `?window=N` with best-effort validation.
* `handleVerifyDomain` returns a per-record diagnostic: `{ mx, spf, dkim, verified }` instead of just a bool. DKIM stays at `"deferred"` until BACKEND_TODO #5 ships (later in this stack).
* New `handleUpdateDomain` (PATCH `/api/v1/domains/{domain}`) for setting `is_primary` atomically.
* Migration 011: `api_keys.expires_at` + auth check that rejects expired keys with 401.

## Frontend changes

* Per-agent stats row on dashboard cards (Inbound·7d / Outbound·7d / Pending / Last delivery).
* Per-record DNS chips on the Domains page (found / missing / deferred).
* Settings → Usage section pulls a 30-day window from `/api/dashboard/stats?window=30`.
* "Make primary" button on Domains list (visible on verified, non-primary domains).
* Expires-in select on the API keys create form + Expires column on the table.
* Edit-name button on Settings → Profile (PATCH `/api/auth/me`).

## Test plan

- [x] `make test-integration` — Go integration tests (identity, agent, auth) pass
- [x] `npm test --workspace web` — 156 tests pass
- [x] `npm run build --workspace web` — production export clean
- [x] No schema migrations need manual ops — all idempotent (`ADD COLUMN IF NOT EXISTS`)

## Reviewers focus on

* Correctness of the correlated subqueries in `ListAgentsByUser` (cost at high agent counts)
* `?window=N` clamping bounds + behavior on garbage input
* `is_primary` partial unique index enforcement (one primary per user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)