### PR TITLE
feat: Claude Code plugin manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,12 +5,15 @@
     "email": "support@e2a.dev",
     "url": "https://e2a.dev"
   },
+  "metadata": {
+    "description": "e2a plugins for Claude Code — authenticated email for AI agents"
+  },
   "plugins": [
     {
       "name": "e2a",
       "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and audit-grade send/receive. 18 MCP tools over hosted streamable HTTP with OAuth.",
       "category": "productivity",
-      "source": ".",
+      "source": "./",
       "homepage": "https://e2a.dev"
     }
   ]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "e2a",
+  "owner": {
+    "name": "Mnexa AI",
+    "email": "support@e2a.dev",
+    "url": "https://e2a.dev"
+  },
+  "plugins": [
+    {
+      "name": "e2a",
+      "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and audit-grade send/receive. 18 MCP tools over hosted streamable HTTP with OAuth.",
+      "category": "productivity",
+      "source": ".",
+      "homepage": "https://e2a.dev"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,29 @@
+{
+  "name": "e2a",
+  "version": "0.3.2",
+  "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and audit-grade send/receive. 18 MCP tools over hosted streamable HTTP with OAuth.",
+  "author": {
+    "name": "Mnexa AI",
+    "url": "https://e2a.dev"
+  },
+  "homepage": "https://e2a.dev",
+  "repository": "https://github.com/Mnexa-AI/e2a",
+  "license": "Apache-2.0",
+  "keywords": [
+    "email",
+    "smtp",
+    "agents",
+    "hitl",
+    "spf",
+    "dkim",
+    "inbox",
+    "mcp",
+    "oauth"
+  ],
+  "mcpServers": {
+    "e2a": {
+      "type": "http",
+      "url": "https://mcp.e2a.dev/mcp"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a Claude Code plugin manifest so users can install e2a from a fresh Claude Code session and complete OAuth against `https://mcp.e2a.dev/mcp`.

- `.claude-plugin/marketplace.json` — single-plugin marketplace pointing at this repo
- `.claude-plugin/plugin.json` — plugin definition with a hosted streamable-HTTP MCP server (no `headers` field, so Claude Code's OAuth discovery fires on 401 instead of silently using a token)
- Version pinned to `0.3.2` to match `@e2a/mcp-server`

### Install (for testing)

```bash
claude plugin marketplace add Mnexa-AI/e2a
claude plugin install e2a@e2a
```

On first tool call, Claude Code POSTs `https://mcp.e2a.dev/mcp`, our server returns `401` with `WWW-Authenticate`, and Claude Code opens the browser for the OAuth dance. After approval, all 18 tools (`messages.*`, `hitl.*`, `domains.*`, `agents.*`) become available.

## Test plan

- [ ] Clone repo fresh, run `claude plugin marketplace add Mnexa-AI/e2a` in Claude Code, confirm `e2a` appears
- [ ] `claude plugin install e2a@e2a` succeeds, plugin shows enabled
- [ ] First tool invocation triggers OAuth browser flow (not a 401 error to the user)
- [ ] After auth, `e2a.list_messages`, `e2a.send_message`, `e2a.list_agents`, `e2a.list_domains`, HITL tools all show up — 18 total
- [ ] Confirm `.claude-plugin/` and existing `.claude/` directory coexist without conflict (Claude Code reads them as separate concerns)

## How this compares to other plugins we examined

We patterned off five real community plugins. `chrome-devtools-mcp` inlines `mcpServers` in `plugin.json` (vs. a separate `.mcp.json` like `cap-js/mcp-server` or `aria`) — we followed the inline shape since we only ship one server. The closest functional twin is `datarails-financeos`, the only OAuth-style hosted-MCP plugin we found in the official marketplace: identical `{type: "http", url: "..."}` block with no `headers` field, which is what triggers Claude Code's OAuth discovery rather than presenting a pre-baked token. Top-level fields (`author{name,url}`, `homepage`, `repository`, `license`, `keywords`) match `cashflow`, `aria`, and `anson` exactly; marketplace shape (`name`, `owner{name,email,url}`, `plugins[].source`) matches `anthropics/knowledge-work-plugins`.

## Sources patterned from

- https://github.com/anthropics/claude-plugins-community/blob/main/.claude-plugin/marketplace.json
- https://github.com/anthropics/claude-plugins-official/blob/main/.claude-plugin/marketplace.json
- https://github.com/anthropics/knowledge-work-plugins/blob/main/.claude-plugin/marketplace.json
- https://github.com/Datarails/dr-claude-code-plugins-re/blob/main/.claude-plugin/plugin.json (closest hosted-MCP twin)
- https://github.com/ChromeDevTools/chrome-devtools-mcp/blob/main/.claude-plugin/plugin.json (inline `mcpServers`)
- https://github.com/cashflow-tech/plugin/blob/main/.claude-plugin/plugin.json (OAuth-flavored plugin shape)

Note: the marketplace `$schema` URL referenced by `anthropics/claude-plugins-official` (`https://anthropic.com/claude-code/marketplace.schema.json`) currently 404s, so we validated by mimicking 4+ accepted plugins rather than against a published schema.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>