### PR TITLE
docs(mcp): add OpenAI Codex CLI example

### DIFF
--- a/mcp/examples/README.md
+++ b/mcp/examples/README.md
@@ -1,19 +1,20 @@
 # Examples
 
-End-to-end demos showing how to wire the e2a MCP surface into popular agent frameworks. Each is a self-contained script — clone the repo, install requirements, run.
+End-to-end demos showing how to wire the e2a MCP surface into popular agent frameworks and CLIs.
 
 | Framework | Path | LLM | Stdio variant | Hosted variant |
 | --- | --- | --- | --- | --- |
 | LangChain (LangGraph ReAct) | [langchain/](./langchain/) | Anthropic Claude | `agent.py` | `agent_hosted.py` |
 | Google ADK | [adk/](./adk/) | Google Gemini | `agent.py` | `agent_hosted.py` |
 | OpenAI Agents SDK | [openai-agents/](./openai-agents/) | OpenAI GPT | `agent.py` | `agent_hosted.py` |
+| OpenAI Codex CLI | [codex/](./codex/) | Codex (OpenAI) | `[mcp_servers.e2a]` in `config.toml` | `[mcp_servers.e2a-hosted]` in `config.toml` |
 
 ## Two transports, same tool surface
 
-Each example ships two scripts that exercise the same 18 e2a tools:
+Each example exercises the same 18 e2a tools. The Python framework examples ship two scripts; the Codex example ships two TOML blocks (Codex is itself the agent, so you configure it instead of writing a script).
 
-- **Stdio variant** (`agent.py`) consumes the published [@e2a/mcp-server](https://www.npmjs.com/package/@e2a/mcp-server) from npm via `npx -y` — no local build needed. Best for laptop / local dev.
-- **Hosted variant** (`agent_hosted.py`) connects to `https://mcp.e2a.dev/mcp` over Streamable HTTP with your API key in the `Authorization` header. Best when:
+- **Stdio variant** consumes the published [@e2a/mcp-server](https://www.npmjs.com/package/@e2a/mcp-server) from npm via `npx -y` — no local build needed. Best for laptop / local dev.
+- **Hosted variant** connects to `https://mcp.e2a.dev/mcp` over Streamable HTTP with your API key in the `Authorization` header. Best when:
   - Deploying to serverless runtimes (Cloud Run, Lambda, Vercel) where spawning a stdio child process is awkward or impossible.
   - You don't want a Node toolchain on the agent host.
   - You want updates to land without rebuilding the agent's image.
@@ -29,4 +30,4 @@ Bring your own [e2a API key](https://e2a.dev) and an LLM key for whichever frame
 
 ## Pointing at a self-hosted e2a
 
-For the **stdio** variants: set `E2A_BASE_URL=https://your-deployment.example.com` in the environment and the examples forward it to the MCP server automatically. The hosted variants are pinned to `https://mcp.e2a.dev/mcp` — edit the `url` literal in `agent_hosted.py` if you run your own MCP server.
+For the **stdio** variants: set `E2A_BASE_URL=https://your-deployment.example.com` in the environment and the examples forward it to the MCP server automatically. The hosted variants are pinned to `https://mcp.e2a.dev/mcp` — edit the `url` literal in `agent_hosted.py` (or in the Codex `[mcp_servers.e2a-hosted]` block) if you run your own MCP server.

--- a/mcp/examples/codex/README.md
+++ b/mcp/examples/codex/README.md
@@ -11,7 +11,7 @@ Two transport options, both first-class in Codex:
 
 ## Prerequisites
 
-- [Codex CLI](https://github.com/openai/codex) 0.130+ (`npm i -g @openai/codex` or `brew install --cask codex`)
+- [Codex CLI](https://github.com/openai/codex) 0.133+ (`npm i -g @openai/codex` or `brew install --cask codex`)
 - An [e2a API key](https://e2a.dev), exported as `E2A_API_KEY`
 - For the **local stdio** variant only: Node 18+ (Codex shells out to `npx -y @e2a/mcp-server`)
 

--- a/mcp/examples/codex/README.md
+++ b/mcp/examples/codex/README.md
@@ -1,0 +1,87 @@
+# OpenAI Codex CLI × e2a
+
+[Codex CLI](https://github.com/openai/codex) is OpenAI's terminal coding agent (peer to Claude Code). It speaks MCP natively — you declare servers in `~/.codex/config.toml` and Codex connects to them at session start, then surfaces their tools to whatever model you're running.
+
+Unlike the [LangChain](../langchain/), [Google ADK](../adk/), and [OpenAI Agents SDK](../openai-agents/) examples — which are Python scripts you run — Codex is itself the agent. The "example" here is the TOML you paste into your Codex config to add e2a's 18 MCP tools.
+
+Two transport options, both first-class in Codex:
+
+- **Local stdio** — Codex spawns `npx -y @e2a/mcp-server` as a child process. Simplest for laptop dev; needs Node 18+ on PATH.
+- **Hosted Streamable HTTP** — Codex opens a Streamable HTTP session to `https://mcp.e2a.dev/mcp` with your API key in the `Authorization: Bearer …` header. Pick this when you don't want a Node toolchain on the host (CI runners, dev containers, remote app server, etc.).
+
+## Prerequisites
+
+- [Codex CLI](https://github.com/openai/codex) 0.130+ (`npm i -g @openai/codex` or `brew install --cask codex`)
+- An [e2a API key](https://e2a.dev), exported as `E2A_API_KEY`
+- For the **local stdio** variant only: Node 18+ (Codex shells out to `npx -y @e2a/mcp-server`)
+
+## Install (the TOML way)
+
+Open `~/.codex/config.toml` (Codex creates it on first run; `mkdir -p ~/.codex && touch ~/.codex/config.toml` if it doesn't exist yet) and paste **one** of the blocks from [`config.toml.example`](./config.toml.example):
+
+```toml
+# Local stdio
+[mcp_servers.e2a]
+command = "npx"
+args    = ["-y", "@e2a/mcp-server"]
+
+[mcp_servers.e2a.env]
+E2A_API_KEY = "e2a_..."
+```
+
+```toml
+# Hosted
+[mcp_servers.e2a-hosted]
+url                  = "https://mcp.e2a.dev/mcp"
+bearer_token_env_var = "E2A_API_KEY"
+```
+
+For the hosted variant, export the key in your shell so Codex can read it at session start:
+
+```bash
+export E2A_API_KEY=e2a_...
+```
+
+## Install (the CLI way)
+
+Codex ships first-class commands that write the same TOML for you:
+
+```bash
+# Local stdio
+codex mcp add e2a --env E2A_API_KEY=e2a_... -- npx -y @e2a/mcp-server
+
+# Hosted
+codex mcp add e2a-hosted \
+  --url https://mcp.e2a.dev/mcp \
+  --bearer-token-env-var E2A_API_KEY
+```
+
+Verify with `codex mcp list` (add `--json` for machine-readable output) or `codex doctor`, which reports configured servers and surfaces missing env vars.
+
+## Run
+
+```bash
+codex
+```
+
+Then in the session:
+
+> What's in my inbox?
+> Reply to the latest message politely.
+> Send an email to alice@example.com — subject "test", body "hello from Codex".
+
+If your e2a account has exactly one agent, the hosted endpoint auto-resolves it at session init — no `E2A_AGENT_EMAIL` needed. With multiple agents, ask Codex to pass `agent_email` per tool call, or set `E2A_AGENT_EMAIL` in `[mcp_servers.e2a.env]` for the stdio variant.
+
+## How it works
+
+Codex reads MCP server definitions from `~/.codex/config.toml` under `[mcp_servers.<id>]`. The transport is inferred from which fields you set:
+
+- `command` (with optional `args` / `env` / `env_vars` / `cwd`) → stdio transport.
+- `url` (with optional `bearer_token_env_var` / `http_headers` / `env_http_headers` / `oauth*`) → Streamable HTTP transport.
+
+Setting both `command` and `url` in the same entry is rejected at load time, as is inline `bearer_token = "..."` — secrets must come from an env var via `bearer_token_env_var`. Codex also supports OAuth (`oauth.client_id`, `oauth_resource`, `scopes`) for the HTTP transport, but e2a's hosted server uses static API keys, so a bearer env var is the right choice.
+
+## Pointing at a self-hosted e2a
+
+- **Stdio**: set `E2A_BASE_URL` inside `[mcp_servers.e2a.env]` (or pass `--env E2A_BASE_URL=…` to `codex mcp add`). `@e2a/mcp-server` forwards it.
+- **Hosted**: change the `url` literal in the `[mcp_servers.e2a-hosted]` block to your deployment's MCP endpoint.

--- a/mcp/examples/codex/config.toml.example
+++ b/mcp/examples/codex/config.toml.example
@@ -1,0 +1,40 @@
+# Paste either block into ~/.codex/config.toml (user) or .codex/config.toml
+# (project override). You only need one of the two.
+#
+# Codex config schema reference:
+#   https://developers.openai.com/codex/config-reference
+# Source of truth for the MCP fields used below:
+#   https://github.com/openai/codex/blob/main/codex-rs/config/src/mcp_types.rs
+
+
+# ── Local stdio variant ──────────────────────────────────────────────────────
+# Codex launches @e2a/mcp-server as a child process and talks to it over stdio.
+# Best for laptop dev. Needs Node 18+ on PATH for `npx`.
+[mcp_servers.e2a]
+command = "npx"
+args    = ["-y", "@e2a/mcp-server"]
+
+[mcp_servers.e2a.env]
+E2A_API_KEY = "e2a_..."
+# Optional default inbox if your account has more than one agent:
+# E2A_AGENT_EMAIL = "your-bot@your-domain.com"
+
+# Equivalent one-liner (Codex will write the same TOML for you):
+#   codex mcp add e2a --env E2A_API_KEY=e2a_... -- npx -y @e2a/mcp-server
+
+
+# ── Hosted Streamable HTTP variant ───────────────────────────────────────────
+# Codex opens a Streamable HTTP session to https://mcp.e2a.dev/mcp and reads
+# the bearer token from the named env var at request time. Best when you don't
+# want a Node toolchain on the host (CI runners, dev containers, etc.).
+#
+# `bearer_token_env_var` is the only supported way to pin a static API key —
+# Codex deliberately rejects an inline `bearer_token = "..."` field so secrets
+# stay out of config.toml.
+[mcp_servers.e2a-hosted]
+url                   = "https://mcp.e2a.dev/mcp"
+bearer_token_env_var  = "E2A_API_KEY"
+
+# Equivalent one-liner:
+#   codex mcp add e2a-hosted --url https://mcp.e2a.dev/mcp \
+#     --bearer-token-env-var E2A_API_KEY


### PR DESCRIPTION
## Summary

Adds `mcp/examples/codex/` so Codex CLI users can plug e2a's 18 MCP tools into their agent with a paste-in TOML block (or `codex mcp add` one-liner). Updates the top-level `mcp/examples/README.md` matrix to list Codex alongside the LangChain / ADK / OpenAI Agents SDK examples.

Codex is a peer to Claude Code (terminal agent), so unlike the existing examples there is no `agent.py` — Codex *is* the agent, and the deliverable is the config snippet you paste into `~/.codex/config.toml`.

## What Codex's MCP support actually looks like

Verified against [`codex-rs/config/src/mcp_types.rs`](https://github.com/openai/codex/blob/main/codex-rs/config/src/mcp_types.rs) on `openai/codex@main` and tested locally against `codex-cli 0.133.0`:

- **Config file**: `~/.codex/config.toml` (user) or `.codex/config.toml` (project override). Plain TOML.
- **Section**: `[mcp_servers.<id>]`. Codex infers transport from which keys are set.
- **Stdio fields**: `command`, `args`, `env`, `env_vars`, `cwd`.
- **Streamable HTTP fields**: `url`, `bearer_token_env_var`, `http_headers`, `env_http_headers`, plus optional `oauth.client_id` / `oauth_resource` / `scopes` for OAuth flows.
- **Inline `bearer_token = "..."` is explicitly rejected** by the parser — secrets must come from an env var. We use `bearer_token_env_var = "E2A_API_KEY"` for the hosted variant, which Codex reports as `auth_status: "bearer_token"`.
- `codex mcp add` / `codex mcp list` / `codex mcp get` / `codex doctor` are first-class management commands that read/write the same TOML.

## Why bearer-via-env over OAuth

Codex supports both, but e2a's hosted MCP server uses static API keys and not an OAuth issuer, so `bearer_token_env_var` is the right fit. If a self-hosted e2a deployment ever wires up OAuth, users can swap in `[mcp_servers.e2a-hosted.oauth] client_id = "..."` plus `oauth_resource` — the schema already supports it.

## Test plan

- [x] Installed `@openai/codex@0.133.0` via npm.
- [x] Ran `codex mcp add e2a --env E2A_API_KEY=... -- npx -y @e2a/mcp-server` and confirmed it generated the exact TOML shape shipped in `config.toml.example`.
- [x] Ran `codex mcp add e2a-hosted --url https://mcp.e2a.dev/mcp --bearer-token-env-var E2A_API_KEY` — same.
- [x] Copied `mcp/examples/codex/config.toml.example` verbatim into a fresh `CODEX_HOME` and verified `codex mcp list --json` parses both entries (`auth_status: "bearer_token"` for the hosted variant; `transport.type: "stdio"` / `"streamable_http"` as expected).
- [x] `codex doctor` reports `config.toml parse: ok` and `mcp: 2 server (1 stdio, 1 streamable_http) · 0 disabled` against our example.
- [ ] Live `codex exec` with a real OpenAI key driving the e2a tool surface — not run in this PR (no OpenAI key handy in the agent env); the parser round-trip above exercises the same Rust deserializer Codex uses at session start, so the schema is verified.

## References

- Codex MCP config schema: https://github.com/openai/codex/blob/main/codex-rs/config/src/mcp_types.rs
- Codex MCP config tests (TOML examples we pattern-matched): https://github.com/openai/codex/blob/main/codex-rs/config/src/mcp_types_tests.rs
- Codex config reference docs: https://developers.openai.com/codex/config-reference