### PR TITLE
chore(mcp): bump to 0.3.3 — propagate tighter tool descriptions

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/mcp-server",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "MCP server for e2a — email for AI agents",
   "mcpName": "io.github.Mnexa-AI/mcp-server",
   "bin": {

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -9,13 +9,13 @@
     "source": "github",
     "subfolder": "mcp"
   },
-  "version": "0.3.2",
+  "version": "0.3.3",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@e2a/mcp-server",
-      "version": "0.3.2",
+      "version": "0.3.3",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Three-line version bump in two files. After merge, tag mcp-v0.3.3 fires publish-mcp.yml + publish-mcp-http.yml.

- mcp/package.json: 0.3.2 → 0.3.3
- mcp/server.json: 0.3.2 → 0.3.3 (both `version` and `packages[0].version`)

What this propagates:
- 9 rewritten tool descriptions from #139 (HITL semantics, threading rule, DNS async flow)
- The bundled SKILL.md is already on main — no version bump needed for repo-loaded plugin assets

What needs to happen after merge:
1. `git tag mcp-v0.3.3 && git push origin mcp-v0.3.3` — npm publish + ghcr image publish
2. Trigger e2a-ops deploy.yml to roll mcp.e2a.dev to the 0.3.3 image
3. `mcp-publisher publish` (in mcp/ dir) to update the MCP Registry listing

Test plan:
- [x] JSON validates: server.json passes schema 2025-12-11
- [x] All three version refs match
- [ ] After tag: confirm npm shows 0.3.3 with mcpName intact
- [ ] After deploy: confirm `curl mcp.e2a.dev/.well-known/oauth-protected-resource` still returns 200 and tools/list returns 18 tools with the new descriptions