### PR TITLE
fix: audit findings (C2/C3 + 7 H + 5 M)

### DIFF
--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -223,53 +224,85 @@ func main() {
 		}
 	}()
 
+	// workerWG tracks every background goroutine that needs to drain
+	// before the process exits on SIGTERM. Without it the main
+	// goroutine would return as soon as httpServer.Shutdown returns,
+	// dropping in-flight webhook deliveries and HITL TTL transitions
+	// mid-iteration. retryCancel/hitlCancel signal the workers to
+	// stop; wg.Wait() at the end of shutdown blocks for the current
+	// iteration to settle.
+	//
+	// Known gap: NotifyPendingApprovalAsync goroutines are detached
+	// (context.Background, no handle) and remain at risk. Operators
+	// running rolling deploys should ensure SMTP is reachable from
+	// the new replica before reaping the old one so notifications
+	// have somewhere to land. Threading the wg through the notifier
+	// is a follow-up.
+	var workerWG sync.WaitGroup
+
 	// Webhook delivery retry worker
 	retryWorker := webhook.NewRetryWorker(deliveryStore, deliverer, store)
 	retryCtx, retryCancel := context.WithCancel(context.Background())
-	go retryWorker.Start(retryCtx)
+	workerWG.Add(1)
+	go func() {
+		defer workerWG.Done()
+		retryWorker.Start(retryCtx)
+	}()
 
 	// HITL expiration worker: transitions pending_approval messages that
 	// blew past their TTL into expired_approved (auto-send) or
 	// expired_rejected based on the owning agent's hitl_expiration_action.
 	hitlWorker := hitlworker.New(store, sender, usageTracker, cfg.OutboundSMTP.FromDomain)
 	hitlCtx, hitlCancel := context.WithCancel(context.Background())
+	workerWG.Add(1)
 	go func() {
+		defer workerWG.Done()
 		if err := hitlWorker.Run(hitlCtx); err != nil && err != context.Canceled {
 			log.Printf("[hitl-worker] stopped: %v", err)
 		}
 	}()
 
-	// Periodic cleanup of expired messages and sessions
+	// Periodic cleanup of expired messages and sessions. Bound to its
+	// own cancel-context so shutdown stops the loop instead of
+	// orphaning the goroutine.
+	cleanupCtx, cleanupCancel := context.WithCancel(context.Background())
+	workerWG.Add(1)
 	go func() {
+		defer workerWG.Done()
 		ticker := time.NewTicker(1 * time.Hour)
 		defer ticker.Stop()
-		for range ticker.C {
-			if deleted, err := store.DeleteExpiredMessages(context.Background()); err != nil {
-				log.Printf("Failed to clean up expired messages: %v", err)
-			} else if deleted > 0 {
-				log.Printf("Cleaned up %d expired message(s)", deleted)
-			}
+		for {
+			select {
+			case <-cleanupCtx.Done():
+				return
+			case <-ticker.C:
+				if deleted, err := store.DeleteExpiredMessages(cleanupCtx); err != nil {
+					log.Printf("Failed to clean up expired messages: %v", err)
+				} else if deleted > 0 {
+					log.Printf("Cleaned up %d expired message(s)", deleted)
+				}
 
-			if deleted, err := store.DeleteExpiredUserSessions(context.Background()); err != nil {
-				log.Printf("Failed to clean up expired user sessions: %v", err)
-			} else if deleted > 0 {
-				log.Printf("Cleaned up %d expired user session(s)", deleted)
-			}
+				if deleted, err := store.DeleteExpiredUserSessions(cleanupCtx); err != nil {
+					log.Printf("Failed to clean up expired user sessions: %v", err)
+				} else if deleted > 0 {
+					log.Printf("Cleaned up %d expired user session(s)", deleted)
+				}
 
-			if deleted, err := deliveryStore.DeleteExpiredDeliveries(context.Background()); err != nil {
-				log.Printf("Failed to clean up expired webhook deliveries: %v", err)
-			} else if deleted > 0 {
-				log.Printf("Cleaned up %d expired webhook delivery record(s)", deleted)
-			}
+				if deleted, err := deliveryStore.DeleteExpiredDeliveries(cleanupCtx); err != nil {
+					log.Printf("Failed to clean up expired webhook deliveries: %v", err)
+				} else if deleted > 0 {
+					log.Printf("Cleaned up %d expired webhook delivery record(s)", deleted)
+				}
 
-			if oauthStorage != nil {
-				if res, err := oauthStorage.CleanupExpired(context.Background(), time.Now()); err != nil {
-					log.Printf("Failed to clean up expired OAuth rows: %v", err)
-				} else if res.Total() > 0 {
-					log.Printf("Cleaned up OAuth rows: codes=%d pkce=%d access=%d refresh=%d clients=%d",
-						res.AuthCodesDeleted, res.PKCERequestsDeleted,
-						res.AccessTokensDeleted, res.RefreshTokensDeleted,
-						res.ClientsDeleted)
+				if oauthStorage != nil {
+					if res, err := oauthStorage.CleanupExpired(cleanupCtx, time.Now()); err != nil {
+						log.Printf("Failed to clean up expired OAuth rows: %v", err)
+					} else if res.Total() > 0 {
+						log.Printf("Cleaned up OAuth rows: codes=%d pkce=%d access=%d refresh=%d clients=%d",
+							res.AuthCodesDeleted, res.PKCERequestsDeleted,
+							res.AccessTokensDeleted, res.RefreshTokensDeleted,
+							res.ClientsDeleted)
+					}
 				}
 			}
 		}
@@ -278,8 +311,41 @@ func main() {
 	<-sigCh
 	log.Println("Shutting down...")
 
+	// Signal every background worker to stop. Their inner ctx-select
+	// branches return on the next iteration; processBatch / RunOnce
+	// calls already in flight finish their current row before the
+	// goroutine exits.
 	retryCancel()
 	hitlCancel()
+	cleanupCancel()
+
+	// SMTP server: close the listener so no new connections, but
+	// existing connections finish their DATA per the relay's own
+	// connection lifecycle.
 	smtpServer.Close()
-	httpServer.Shutdown(ctx)
+
+	// Bound httpServer.Shutdown so a misbehaving request can't block
+	// shutdown forever. 30s matches typical platform SIGKILL windows
+	// (Kubernetes terminationGracePeriodSeconds defaults to 30).
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer shutdownCancel()
+	if err := httpServer.Shutdown(shutdownCtx); err != nil {
+		log.Printf("HTTP server shutdown error: %v", err)
+	}
+
+	// Wait for the workers' current iteration to settle. Bound the
+	// wait so a stuck worker (e.g. SMTP send to a hanging recipient)
+	// can't block process exit indefinitely — past the deadline we
+	// fall through and let the goroutines die with the process.
+	drainDone := make(chan struct{})
+	go func() {
+		workerWG.Wait()
+		close(drainDone)
+	}()
+	select {
+	case <-drainDone:
+		log.Println("Background workers drained cleanly.")
+	case <-time.After(30 * time.Second):
+		log.Println("Background workers did not drain within 30s; exiting anyway.")
+	}
 }

--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -324,19 +324,30 @@ func main() {
 	// connection lifecycle.
 	smtpServer.Close()
 
-	// Bound httpServer.Shutdown so a misbehaving request can't block
-	// shutdown forever. 30s matches typical platform SIGKILL windows
-	// (Kubernetes terminationGracePeriodSeconds defaults to 30).
-	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	// Single shared deadline for both HTTP shutdown and worker drain.
+	// 30s matches Kubernetes' default terminationGracePeriodSeconds.
+	// A naive `httpServer.Shutdown(30s)` followed by a second 30s
+	// `workerWG.Wait()` would budget 60s total — past the platform's
+	// SIGKILL window, the kernel reaps us before the drain phase even
+	// runs. Sharing one deadline guarantees we don't outlast the
+	// platform grace period, with whichever phase finishes first
+	// donating the remainder to the other.
+	//
+	// Operators wanting longer drain (e.g. SMTP send to slow recipient
+	// mid-flight) should bump terminationGracePeriodSeconds AND the
+	// constant below in lockstep.
+	const shutdownBudget = 30 * time.Second
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), shutdownBudget)
 	defer shutdownCancel()
+
 	if err := httpServer.Shutdown(shutdownCtx); err != nil {
 		log.Printf("HTTP server shutdown error: %v", err)
 	}
 
-	// Wait for the workers' current iteration to settle. Bound the
-	// wait so a stuck worker (e.g. SMTP send to a hanging recipient)
-	// can't block process exit indefinitely — past the deadline we
-	// fall through and let the goroutines die with the process.
+	// Wait for workers' current iteration to settle, bounded by the
+	// REMAINING share of the same deadline (whatever Shutdown didn't
+	// consume). Past it, fall through and let the goroutines die
+	// with the process.
 	drainDone := make(chan struct{})
 	go func() {
 		workerWG.Wait()
@@ -345,7 +356,7 @@ func main() {
 	select {
 	case <-drainDone:
 		log.Println("Background workers drained cleanly.")
-	case <-time.After(30 * time.Second):
-		log.Println("Background workers did not drain within 30s; exiting anyway.")
+	case <-shutdownCtx.Done():
+		log.Println("Background workers did not drain within shutdown budget; exiting anyway.")
 	}
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -29,7 +29,7 @@ For the machine-readable spec, see [`web/public/openapi.yaml`](../web/public/ope
 | Method | Path | Description |
 |--------|------|-------------|
 | `GET` | `/agents/{email}/messages` | List inbound messages for the agent |
-| `GET` | `/agents/{email}/messages/{id}` | Fetch a single inbound message (transitions `unread` → `read` for local-mode agents) |
+| `GET` | `/agents/{email}/messages/{id}` | Fetch a single inbound message. Side effect: any `unread` row flips to `read` on read, regardless of agent mode. |
 | `POST` | `/agents/{email}/messages/{id}/reply` | Reply to an inbound message |
 
 ## Messages — outbound / HITL
@@ -37,7 +37,7 @@ For the machine-readable spec, see [`web/public/openapi.yaml`](../web/public/ope
 | Method | Path | Description |
 |--------|------|-------------|
 | `POST` | `/send` | Send an email (held with `202 Accepted` if HITL enabled on the agent) |
-| `GET` | `/messages` | List outbound messages owned by the user (filterable by status) |
+| `GET` | `/messages` | List outbound messages owned by the user. Only `status=pending_approval` is accepted (the default); any other value returns `400`. |
 | `GET` | `/messages/{id}` | Get a single outbound message |
 | `POST` | `/messages/{id}/approve` | Approve a `pending_approval` message |
 | `POST` | `/messages/{id}/reject` | Reject a `pending_approval` message |
@@ -53,11 +53,11 @@ Both endpoints require a valid API key or session. The export omits internal ide
 
 ### Webhook signing secrets
 
-Per-user HMAC secrets used to sign inbound webhook payloads. Up to 5 active per user. Plaintext is returned **once** at creation; subsequent reads see only the 12-char prefix.
+Per-user HMAC secrets used to sign inbound webhook payloads. Up to 5 active per user (including the `default` row auto-created at user signup). The list endpoint returns the full plaintext `secret` on every read — this is intentional, see the `SigningSecretSummary` Go doc; SDKs depend on it.
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET` | `/users/me/signing-secrets` | List the user's signing secrets (`id`, `name`, `secret_prefix`, `created_at`, `last_signed_at`). |
+| `GET` | `/users/me/signing-secrets` | List the user's signing secrets. Returns `id`, `name`, **`secret`** (full plaintext), `secret_prefix`, `created_at`, `last_signed_at`. |
 | `POST` | `/users/me/signing-secrets` | Create a new signing secret. Returns the plaintext exactly once (in the `secret` field) — store it immediately. Body: `{"name": "..."}`. Returns `400` if the user already has 5 secrets. |
 | `DELETE` | `/users/me/signing-secrets/{id}` | Delete a signing secret. Returns `400` if it's the user's last remaining secret; rotate by creating a new one first, switching consumers over, then deleting the old one. |
 

--- a/internal/agent/api_docs.go
+++ b/internal/agent/api_docs.go
@@ -75,8 +75,25 @@ type ListMessagesResponse struct {
 // Recipient is this delivery's per-agent target. ReplyTo is the parsed
 // Reply-To: header — empty when the sender did not request a different
 // reply mailbox (the server never falls back to From: silently).
+//
+// This shape covers both inbound and outbound rows since the dashboard
+// inbox queries `?direction=all`. The non-`omitempty` fields are
+// present on every row; the others are direction-specific:
+//
+//   - Status (inbound):       "unread" | "read"; empty string for outbound rows.
+//   - HITLStatus (outbound):  the outbound delivery state ("pending_approval",
+//                              "sent", "rejected", "expired_*"); empty for inbound.
+//   - WebhookStatus (outbound): delivery state of the most recent webhook
+//                              attempt ("delivered", "pending", "failed");
+//                              empty for inbound.
+//   - WebhookError (outbound): last webhook delivery error text when
+//                              WebhookStatus is "failed"; empty otherwise.
+//   - SizeBytes:               raw message length in bytes (best-effort,
+//                              0 when the row was migrated from a pre-sizing
+//                              build).
 type MessageSummary struct {
 	MessageID      string   `json:"message_id" example:"msg_abc123"`
+	Direction      string   `json:"direction" example:"inbound" enums:"inbound,outbound"`
 	From           string   `json:"from" example:"alice@example.com"`
 	To             []string `json:"to" example:"my-bot@example.com"`
 	CC             []string `json:"cc,omitempty"`
@@ -84,7 +101,16 @@ type MessageSummary struct {
 	Recipient      string   `json:"recipient" example:"my-bot@example.com"`
 	Subject        string   `json:"subject" example:"Hello"`
 	ConversationID string   `json:"conversation_id,omitempty"`
-	Status         string   `json:"status" example:"unread" enums:"unread,read"`
+	// Status carries the inbound inbox_status value (`unread` | `read`).
+	// Empty string for outbound rows — clients filtering on Status must
+	// gate on `Direction == "inbound"` first. The enum was removed from
+	// the swag annotation deliberately so SDK generators don't emit a
+	// `Literal["unread", "read"]` that breaks at runtime.
+	Status         string   `json:"status"`
+	HITLStatus     string   `json:"hitl_status,omitempty" example:"sent" enums:"pending_approval,sent,rejected,expired_approved,expired_rejected"`
+	WebhookStatus  string   `json:"webhook_status,omitempty" example:"delivered" enums:"pending,delivered,failed"`
+	WebhookError   string   `json:"webhook_error,omitempty"`
+	SizeBytes      int      `json:"size_bytes,omitempty" example:"4231"`
 	CreatedAt      string   `json:"created_at" example:"2025-01-15T10:30:00Z"`
 } // @name MessageSummary
 

--- a/internal/agent/hitl_api.go
+++ b/internal/agent/hitl_api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -285,12 +286,15 @@ func (a *API) handleApprovePendingMessage(w http.ResponseWriter, r *http.Request
 	messageID := mux.Vars(r)["id"]
 
 	var req approveRequest
-	// Empty body is allowed (approve-as-is). Only error if body is present but malformed.
-	if r.ContentLength > 0 {
-		if err := readJSON(w, r, &req, maxRequestBytesSmall); err != nil {
-			http.Error(w, "invalid request body", http.StatusBadRequest)
-			return
-		}
+	// Empty body is allowed (approve-as-is). Only error if body is present
+	// but malformed. We deliberately do NOT gate on r.ContentLength > 0
+	// because Transfer-Encoding: chunked yields ContentLength == -1; that
+	// would silently drop the reviewer's overrides (subject/body/to/cc/bcc/
+	// attachment edits) and send the stored draft as-is. readJSON returns
+	// io.EOF on a truly-empty body, which we treat as "approve-as-is".
+	if err := readJSON(w, r, &req, maxRequestBytesSmall); err != nil && !errors.Is(err, io.EOF) {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
 	}
 	edits, err := req.toEdit()
 	if err != nil {
@@ -467,11 +471,13 @@ func (a *API) handleRejectPendingMessage(w http.ResponseWriter, r *http.Request)
 	messageID := mux.Vars(r)["id"]
 
 	var req rejectRequest
-	if r.ContentLength > 0 {
-		if err := readJSON(w, r, &req, maxRequestBytesSmall); err != nil {
-			http.Error(w, "invalid request body", http.StatusBadRequest)
-			return
-		}
+	// Empty body is allowed (reject with no reason). Same chunked-encoding
+	// caveat as handleApprovePendingMessage above — gating on
+	// ContentLength > 0 silently drops the rejection reason on chunked
+	// requests.
+	if err := readJSON(w, r, &req, maxRequestBytesSmall); err != nil && !errors.Is(err, io.EOF) {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
 	}
 
 	rejected, err := a.store.RejectPending(r.Context(), messageID, user.ID, req.Reason)

--- a/internal/agent/hitl_approval_api_test.go
+++ b/internal/agent/hitl_approval_api_test.go
@@ -4,10 +4,35 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
 )
+
+// authedChunked posts a body with Transfer-Encoding: chunked so the
+// server sees ContentLength == -1. Used to regression-test handlers
+// that previously gated body decode on ContentLength > 0 (which
+// silently swallowed bodies on chunked requests).
+func authedChunked(t *testing.T, method, url, body, apiKey string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(method, url, io.NopCloser(strings.NewReader(body)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	// Force chunked: Body is an io.Reader of unknown length; clear
+	// ContentLength so net/http's transport doesn't infer a length and
+	// adds Transfer-Encoding: chunked instead.
+	req.ContentLength = -1
+	req.TransferEncoding = []string{"chunked"}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
 
 // authed does an authenticated request of arbitrary method.
 func authed(t *testing.T, method, url, body, apiKey string) *http.Response {
@@ -579,6 +604,110 @@ func TestApproveAlreadySentReturns409(t *testing.T) {
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusConflict {
 		t.Errorf("status = %d, want 409", resp.StatusCode)
+	}
+}
+
+// Regression: Transfer-Encoding: chunked yields ContentLength == -1 on
+// the server, and the approve handler used to skip body decode for
+// non-positive ContentLength. That silently dropped the reviewer's
+// overrides (subject/body/to/cc/bcc) and sent the stored draft as-is —
+// a HITL invariant breach. This test posts edits via chunked encoding
+// and asserts the SMTP send reflects them.
+func TestApprovePendingMessageWithChunkedEditsHonorsOverrides(t *testing.T) {
+	server, store, _, smtpDone := setupAPIWithSMTP(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "owner-apprv-chunk@example.com", "Owner", "google-apprv-chunk")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "apprv-chunk-key", nil)
+	store.ClaimOrCreateDomain(ctx, "apprv-chunk.example.com", user.ID)
+	store.VerifyDomain(ctx, "apprv-chunk.example.com", user.ID)
+	agent, _ := store.CreateAgent(ctx, "bot@apprv-chunk.example.com", "apprv-chunk.example.com", "", "https://example.com/webhook", "", user.ID)
+	enableHITL(t, store, agent.ID, user.ID)
+
+	sendResp := authed(t, "POST", server.URL+"/api/v1/send",
+		`{"to":["alice@example.com"],"subject":"Original subject","body":"original body"}`,
+		apiKey.PlaintextKey)
+	defer sendResp.Body.Close()
+	var sendBody struct{ MessageID string `json:"message_id"` }
+	json.NewDecoder(sendResp.Body).Decode(&sendBody)
+
+	editPayload := `{"subject":"Edited via chunked","body_text":"chunked body","to":["bob@example.com"]}`
+	appResp := authedChunked(t, "POST",
+		server.URL+"/api/v1/messages/"+sendBody.MessageID+"/approve",
+		editPayload, apiKey.PlaintextKey)
+	defer appResp.Body.Close()
+	if appResp.StatusCode != http.StatusOK {
+		t.Fatalf("approve via chunked: status = %d", appResp.StatusCode)
+	}
+	var appBody struct {
+		Edited bool `json:"edited"`
+	}
+	json.NewDecoder(appResp.Body).Decode(&appBody)
+	if !appBody.Edited {
+		t.Error("response.edited should be true — chunked body was decoded")
+	}
+
+	msgs := smtpDone()
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 SMTP message, got %d", len(msgs))
+	}
+	if msgs[0].To != "bob@example.com" {
+		t.Errorf("SMTP To = %q, want bob@example.com (edited)", msgs[0].To)
+	}
+	if !strings.Contains(msgs[0].Data, "Edited via chunked") {
+		t.Errorf("SMTP missing edited subject (chunked body was swallowed):\n%s", msgs[0].Data)
+	}
+	if !strings.Contains(msgs[0].Data, "chunked body") {
+		t.Errorf("SMTP missing edited body:\n%s", msgs[0].Data)
+	}
+	if strings.Contains(msgs[0].Data, "Original subject") {
+		t.Errorf("SMTP contains original subject — overrides were dropped:\n%s", msgs[0].Data)
+	}
+}
+
+// Regression: same chunked-encoding bug on the reject path silently
+// dropped the rejection reason. Assert the reason round-trips through
+// a chunked POST.
+func TestRejectPendingMessageWithChunkedReasonRecordsReason(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "owner-rej-chunk@example.com", "Owner", "google-rej-chunk")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "rej-chunk-key", nil)
+	store.ClaimOrCreateDomain(ctx, "rej-chunk.example.com", user.ID)
+	store.VerifyDomain(ctx, "rej-chunk.example.com", user.ID)
+	agent, _ := store.CreateAgent(ctx, "bot@rej-chunk.example.com", "rej-chunk.example.com", "", "https://example.com/webhook", "", user.ID)
+	enableHITL(t, store, agent.ID, user.ID)
+
+	sendResp := authed(t, "POST", server.URL+"/api/v1/send",
+		`{"to":["alice@example.com"],"subject":"Bad draft","body":"…"}`,
+		apiKey.PlaintextKey)
+	defer sendResp.Body.Close()
+	var sendBody struct{ MessageID string `json:"message_id"` }
+	json.NewDecoder(sendResp.Body).Decode(&sendBody)
+
+	rejResp := authedChunked(t, "POST",
+		server.URL+"/api/v1/messages/"+sendBody.MessageID+"/reject",
+		`{"reason":"off-topic for this audience"}`, apiKey.PlaintextKey)
+	defer rejResp.Body.Close()
+	if rejResp.StatusCode != http.StatusOK {
+		t.Fatalf("reject via chunked: status = %d", rejResp.StatusCode)
+	}
+
+	// Verify the reason landed via the detail endpoint.
+	detailResp := authed(t, "GET",
+		server.URL+"/api/v1/messages/"+sendBody.MessageID, "", apiKey.PlaintextKey)
+	defer detailResp.Body.Close()
+	var detail struct {
+		Status          string `json:"status"`
+		RejectionReason string `json:"rejection_reason"`
+	}
+	json.NewDecoder(detailResp.Body).Decode(&detail)
+	if detail.Status != "rejected" {
+		t.Errorf("detail.status = %q, want rejected", detail.Status)
+	}
+	if detail.RejectionReason != "off-topic for this audience" {
+		t.Errorf("rejection_reason = %q — chunked body was swallowed", detail.RejectionReason)
 	}
 }
 

--- a/internal/emailauth/checker.go
+++ b/internal/emailauth/checker.go
@@ -1,6 +1,7 @@
 package emailauth
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"log"
@@ -97,6 +98,20 @@ func checkSPF(remoteIP net.IP, senderEmail string) CheckResult {
 }
 
 func checkDKIM(rawMessage []byte) CheckResult {
+	// RFC 6376 §3.5 defines the `l=` tag (body length limit). Honoring
+	// it lets an attacker append arbitrary unsigned content (HTML,
+	// prompt-injection payloads) to a legitimately-signed message, and
+	// the receiver still sees dkim=pass. Agents that act on
+	// `verified=true` headers may then execute the attacker-tacked-on
+	// instructions. We refuse any signature carrying `l=` outright.
+	// Conservative trade-off: a sender that uses `l=` and a sender
+	// that doesn't both fail if their messages reach us — but `l=` is
+	// rare in modern signing configs (Gmail, M365, SES all omit it by
+	// default).
+	if dkimSignatureHasBodyLengthTag(rawMessage) {
+		return CheckResult{Status: StatusFail, Detail: "DKIM-Signature includes l= body-length tag (refused: would allow tail-content injection)"}
+	}
+
 	verifications, err := dkim.Verify(bytes.NewReader(rawMessage))
 	if err != nil {
 		return CheckResult{Status: StatusTempError, Detail: err.Error()}
@@ -116,6 +131,92 @@ func checkDKIM(rawMessage []byte) CheckResult {
 	// All signatures failed
 	firstErr := verifications[0].Err
 	return CheckResult{Status: StatusFail, Detail: firstErr.Error()}
+}
+
+// dkimSignatureHasBodyLengthTag reports whether any DKIM-Signature
+// header in rawMessage carries an `l=` tag. The tag is a semicolon-
+// separated tag-value entry per RFC 6376 §3.5; whitespace and folding
+// can occur freely, so we reassemble each multi-line header before
+// parsing.
+//
+// We err on the side of refusal: any `l=` (whether the value matches
+// the actual body length or not) is treated as suspicious because the
+// attacker model is "extend the body past the signed length" — even
+// `l=<actual_length>` becomes exploitable the moment a downstream
+// MTA or replay re-frames the message.
+func dkimSignatureHasBodyLengthTag(rawMessage []byte) bool {
+	// Read the header block: lines up to (but not including) the first
+	// empty line. RFC 5322 line ending is CRLF but we tolerate LF.
+	scanner := bufio.NewScanner(bytes.NewReader(rawMessage))
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var currentHeader strings.Builder
+	inDKIM := false
+
+	flushAndCheck := func() bool {
+		if !inDKIM {
+			return false
+		}
+		hit := tagValueContainsKey(currentHeader.String(), "l")
+		currentHeader.Reset()
+		inDKIM = false
+		return hit
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			// End of header block.
+			if flushAndCheck() {
+				return true
+			}
+			return false
+		}
+		// Folded continuation: starts with SP or HTAB.
+		if len(line) > 0 && (line[0] == ' ' || line[0] == '\t') {
+			if inDKIM {
+				currentHeader.WriteByte(' ')
+				currentHeader.WriteString(strings.TrimLeft(line, " \t"))
+			}
+			continue
+		}
+		// New header line — finalize the previous one first.
+		if flushAndCheck() {
+			return true
+		}
+		// Case-insensitive prefix match per RFC 5322.
+		if colon := strings.IndexByte(line, ':'); colon > 0 {
+			name := strings.TrimSpace(line[:colon])
+			if strings.EqualFold(name, "DKIM-Signature") {
+				inDKIM = true
+				currentHeader.WriteString(strings.TrimLeft(line[colon+1:], " \t"))
+			}
+		}
+	}
+	// EOF without a blank line — flush whatever's pending.
+	if flushAndCheck() {
+		return true
+	}
+	return false
+}
+
+// tagValueContainsKey reports whether a DKIM tag-value string (the
+// part after `DKIM-Signature:`) carries the given key. RFC 6376 §3.2
+// format: tag = name "=" value, entries separated by `;`, with
+// optional FWS around the `=` and trimming on both sides. We don't
+// care about the value here, only the presence of the key.
+func tagValueContainsKey(s, key string) bool {
+	for _, entry := range strings.Split(s, ";") {
+		eq := strings.IndexByte(entry, '=')
+		if eq < 0 {
+			continue
+		}
+		name := strings.TrimSpace(entry[:eq])
+		if name == key {
+			return true
+		}
+	}
+	return false
 }
 
 func extractDomain(email string) string {

--- a/internal/emailauth/checker_test.go
+++ b/internal/emailauth/checker_test.go
@@ -2,6 +2,7 @@ package emailauth
 
 import (
 	"net"
+	"strings"
 	"testing"
 )
 
@@ -73,6 +74,120 @@ func TestSummaryFormat(t *testing.T) {
 	summary := r.Summary()
 	if summary != "spf=pass; dkim=none" {
 		t.Errorf("summary = %q, want %q", summary, "spf=pass; dkim=none")
+	}
+}
+
+// Regression for the DKIM `l=` tail-content injection vector. Honoring
+// the length tag lets an attacker append arbitrary unsigned bytes
+// after the signed portion of a legitimate signature; receivers that
+// trust `dkim=pass` then process attacker-controlled content as if it
+// were authenticated. checkDKIM must refuse the signature outright.
+func TestCheckDKIMLengthTagRefused(t *testing.T) {
+	// Minimal but realistic DKIM-Signature header carrying `l=`. The
+	// signature value is junk — we never reach signature verification
+	// because the l= refusal short-circuits earlier.
+	msg := []byte("DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=example.com;\r\n" +
+		" s=selector1; t=1700000000; l=10;\r\n" +
+		" h=From:To:Subject;\r\n" +
+		" bh=base64bodyhash==;\r\n" +
+		" b=base64signature==\r\n" +
+		"From: alice@example.com\r\n" +
+		"To: bot@e2a.dev\r\n" +
+		"Subject: Hi\r\n" +
+		"\r\n" +
+		"AAAAAAAAAA[attacker-appended-content-past-signed-length]")
+
+	result := checkDKIM(msg)
+	if result.Status != StatusFail {
+		t.Errorf("DKIM status = %q, want %q (l= must trigger refusal)", result.Status, StatusFail)
+	}
+	if result.Detail == "" {
+		t.Error("expected non-empty Detail explaining the l= refusal")
+	}
+}
+
+func TestCheckDKIMNoLengthTagFallsThroughToVerify(t *testing.T) {
+	// Same shape but without l=. We don't have a real signing key here,
+	// so the underlying Verify will fail with a verification error
+	// rather than the l= refusal. Asserting we move past the l= gate
+	// (status != fail-with-l=-detail) — the actual verify result is a
+	// fail or temperror, not the l= sentinel.
+	msg := []byte("DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed; d=example.com;\r\n" +
+		" s=selector1; t=1700000000;\r\n" +
+		" h=From:To:Subject;\r\n" +
+		" bh=base64bodyhash==;\r\n" +
+		" b=base64signature==\r\n" +
+		"From: alice@example.com\r\n" +
+		"To: bot@e2a.dev\r\n" +
+		"Subject: Hi\r\n" +
+		"\r\n" +
+		"body")
+
+	result := checkDKIM(msg)
+	if result.Status == StatusFail && strings.Contains(result.Detail, "l= body-length tag") {
+		t.Errorf("DKIM refused with l= detail despite no l= tag in header: %q", result.Detail)
+	}
+}
+
+func TestDKIMSignatureHasBodyLengthTag(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		want bool
+	}{
+		{
+			name: "no DKIM header",
+			msg:  "From: a@x\r\n\r\nbody",
+			want: false,
+		},
+		{
+			name: "DKIM without l=",
+			msg:  "DKIM-Signature: v=1; a=rsa-sha256; d=example.com; s=s1; h=From; bh=x; b=y\r\nFrom: a@x\r\n\r\nbody",
+			want: false,
+		},
+		{
+			name: "DKIM with l= inline",
+			msg:  "DKIM-Signature: v=1; l=42; d=example.com; s=s1; h=From; bh=x; b=y\r\nFrom: a@x\r\n\r\nbody",
+			want: true,
+		},
+		{
+			name: "DKIM with l= on folded continuation",
+			msg:  "DKIM-Signature: v=1; a=rsa-sha256;\r\n l=200;\r\n d=example.com\r\nFrom: a@x\r\n\r\nbody",
+			want: true,
+		},
+		{
+			name: "DKIM with l= and surrounding whitespace",
+			msg:  "DKIM-Signature: v=1; a=rsa-sha256;  l =  10 ; d=example.com\r\nFrom: a@x\r\n\r\nbody",
+			want: true,
+		},
+		{
+			name: "l appears as substring of another tag (lang, length-not-l)",
+			msg:  "DKIM-Signature: v=1; lang=en; d=example.com; s=s1\r\nFrom: a@x\r\n\r\nbody",
+			want: false,
+		},
+		{
+			name: "two DKIM headers, second has l=",
+			msg:  "DKIM-Signature: v=1; d=safe.com\r\nDKIM-Signature: v=1; l=5; d=bad.com\r\nFrom: a@x\r\n\r\nbody",
+			want: true,
+		},
+		{
+			name: "case-insensitive header name",
+			msg:  "dkim-signature: v=1; l=10\r\nFrom: a@x\r\n\r\nbody",
+			want: true,
+		},
+		{
+			name: "LF-only line endings tolerated",
+			msg:  "DKIM-Signature: v=1; l=10\nFrom: a@x\n\nbody",
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := dkimSignatureHasBodyLengthTag([]byte(tt.msg))
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/hitlnotify/notifier.go
+++ b/internal/hitlnotify/notifier.go
@@ -150,6 +150,17 @@ func (n *Notifier) NotifyPendingApproval(ctx context.Context, msg *identity.Mess
 // after logging so callers don't need to.
 func (n *Notifier) NotifyPendingApprovalAsync(msg *identity.Message, agent *identity.AgentIdentity) {
 	if n == nil {
+		// Operator-side misconfiguration: notifier wasn't wired (most
+		// likely because OutboundSMTP.FromDomain or HTTP.PublicURL is
+		// unset; the wiring in cmd/e2a/main.go gates on both). The API
+		// still returns 202 pending_approval to the caller, but the
+		// reviewer never gets an email — silent and confusing without
+		// a log line.
+		msgID := ""
+		if msg != nil {
+			msgID = msg.ID
+		}
+		log.Printf("[hitl-notify] suppressed (notifier not configured): msg=%s", msgID)
 		return
 	}
 	go func() {

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -343,11 +343,20 @@ func nullIfEmptyBytes(b []byte) interface{} {
 	return b
 }
 
-// GetDKIMKey returns the stored selector + private key bytes for a
-// domain, used by the outbound signer. Returns ("", nil, nil) when the
-// domain has no key — callers MUST treat this as "skip signing" and
-// fall back to whatever the relay-level fallback does.
-func (s *Store) GetDKIMKey(ctx context.Context, domain string) (string, []byte, error) {
+// GetDKIMKeyInternal returns the stored selector + private key bytes
+// for a domain. The "Internal" suffix is load-bearing: this function
+// does NOT scope by user — it takes a domain name and returns whoever
+// owns that domain's signing key. ONLY call from server-internal
+// codepaths where the domain has already been resolved from a
+// trusted source (e.g. an outbound message's sender field, after the
+// agent layer has authenticated the owner). A handler that ever
+// takes a user-supplied domain string and feeds it to this function
+// becomes a "sign as anyone" primitive: don't.
+//
+// Returns ("", nil, nil) when the domain has no key — callers MUST
+// treat this as "skip signing" and fall back to whatever the
+// relay-level fallback does.
+func (s *Store) GetDKIMKeyInternal(ctx context.Context, domain string) (string, []byte, error) {
 	var selector string
 	var privKey []byte
 	err := s.pool.QueryRow(ctx,

--- a/internal/oauth/retention.go
+++ b/internal/oauth/retention.go
@@ -157,13 +157,18 @@ type ConnectionEntry struct {
 //
 // The session JSONB carries the agent_email we pinned at consent
 // time, so we extract it via a JSONB path expression rather than
-// rejoining the agent table.
+// rejoining the agent table. The JSON key is the lowercase struct
+// tag (`agent_email`) — Session is encoded via json.Marshal at
+// storage.go::marshalRequest, so the field name on disk follows the
+// `json:"agent_email"` tag, not the Go field name. Reading the
+// uppercase form (the original mistake) returned an empty string for
+// every real row.
 func (s *Storage) ExportConnectionsForUser(ctx context.Context, userID string) ([]ConnectionEntry, error) {
 	rows, err := s.pool.Query(ctx, `
 		SELECT
 		    rt.client_id,
 		    c.client_name,
-		    COALESCE(rt.request->'session'->>'AgentEmail', '')              AS agent_email,
+		    COALESCE(rt.request->'session'->>'agent_email', '')             AS agent_email,
 		    array_to_string(c.scopes, ' ')                                  AS scope,
 		    MIN(rt.created_at)                                              AS issued_at,
 		    MAX(rt.expires_at)                                              AS expires_at,

--- a/internal/oauth/retention_test.go
+++ b/internal/oauth/retention_test.go
@@ -2,10 +2,13 @@ package oauth_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Mnexa-AI/e2a/internal/oauth"
 )
 
 // mustExec wraps a pool.Exec call and fails the test on error. Used
@@ -219,24 +222,24 @@ func TestExportConnectionsForUser(t *testing.T) {
 		    user_id, request, requested_at, expires_at, active, revoked_at, created_at)
 		VALUES
 		    ('rt-A1', 'r1', $1, $2,
-		     jsonb_build_object('session', jsonb_build_object('AgentEmail','a@e.dev')),
+		     jsonb_build_object('session', jsonb_build_object('agent_email','a@e.dev')),
 		     $3, $4, true, NULL, $3),
 		    ('rt-A2', 'r2', $1, $2,
-		     jsonb_build_object('session', jsonb_build_object('AgentEmail','a@e.dev')),
+		     jsonb_build_object('session', jsonb_build_object('agent_email','a@e.dev')),
 		     $5, $6, true, NULL, $5),
 
 		    ('rt-A3', 'r3', $1, $2,
-		     jsonb_build_object('session', jsonb_build_object('AgentEmail','b@e.dev')),
+		     jsonb_build_object('session', jsonb_build_object('agent_email','b@e.dev')),
 		     $3, $4, false, $5, $3),
 		    ('rt-A4', 'r4', $1, $2,
-		     jsonb_build_object('session', jsonb_build_object('AgentEmail','b@e.dev')),
+		     jsonb_build_object('session', jsonb_build_object('agent_email','b@e.dev')),
 		     $5, $6, false, $5, $5),
 
 		    ('rt-A5', 'r5', $1, $2,
-		     jsonb_build_object('session', jsonb_build_object('AgentEmail','c@e.dev')),
+		     jsonb_build_object('session', jsonb_build_object('agent_email','c@e.dev')),
 		     $3, $4, false, $5, $3),
 		    ('rt-A6', 'r6', $1, $2,
-		     jsonb_build_object('session', jsonb_build_object('AgentEmail','c@e.dev')),
+		     jsonb_build_object('session', jsonb_build_object('agent_email','c@e.dev')),
 		     $5, $6, true, NULL, $5),
 
 		    ('rt-B1', 'r7', $1, $7, '{}'::jsonb, $3, $4, true, NULL, $3)
@@ -294,6 +297,59 @@ func TestExportConnectionsForUser(t *testing.T) {
 	}
 	if len(gotB) != 1 {
 		t.Errorf("userB connections = %d, want 1", len(gotB))
+	}
+}
+
+// Regression: prior versions of the test seeded the session JSONB
+// directly via `jsonb_build_object('agent_email', ...)`. The query
+// at the time read `request->'session'->>'AgentEmail'` (Go field
+// name). The test passed against the hand-built JSONB but production
+// rows — written by fosite via `json.Marshal(*Session)` — landed
+// with the lowercase `agent_email` json-tag, so every real
+// connection exported `agent_email: ""`. This test serializes a real
+// Session via the production marshal path and asserts the export
+// round-trips, locking the contract against future drift.
+func TestExportConnectionsForUser_UsesProductionSessionShape(t *testing.T) {
+	st, _, pool, userID, clientID := setup(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	exp := now.Add(time.Hour)
+
+	sess := &oauth.Session{
+		UserID:     userID,
+		AgentEmail: "round-trip@e.dev",
+		Subject:    userID,
+	}
+	sessJSON, err := json.Marshal(sess)
+	if err != nil {
+		t.Fatalf("marshal session: %v", err)
+	}
+	// Build the `request` JSONB the same way fosite would: an
+	// envelope with a `session` field that holds the marshaled
+	// Session. Anything else (form, scopes, …) is irrelevant to
+	// this query.
+	envelope := map[string]any{"session": json.RawMessage(sessJSON)}
+	envelopeJSON, err := json.Marshal(envelope)
+	if err != nil {
+		t.Fatalf("marshal envelope: %v", err)
+	}
+
+	mustExec(t, pool, `
+		INSERT INTO oauth_refresh_tokens (signature, request_id, client_id,
+		    user_id, request, requested_at, expires_at, active, created_at)
+		VALUES ('rt-prod', 'r-prod', $1, $2, $3::jsonb, $4, $5, true, $4)
+	`, clientID, userID, envelopeJSON, now, exp)
+
+	got, err := st.ExportConnectionsForUser(ctx, userID)
+	if err != nil {
+		t.Fatalf("ExportConnectionsForUser: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 connection, got %d", len(got))
+	}
+	if got[0].AgentEmail != "round-trip@e.dev" {
+		t.Errorf("AgentEmail = %q, want %q — the JSONB key the query reads must match the json tag fosite writes",
+			got[0].AgentEmail, "round-trip@e.dev")
 	}
 }
 

--- a/internal/outbound/sender.go
+++ b/internal/outbound/sender.go
@@ -17,8 +17,15 @@ import (
 // available — skip signing". Implementations should NOT return an
 // error for the not-found case; that's a normal flow during the
 // migration window when older domains haven't been keyed yet.
+//
+// Method name carries the "Internal" suffix to flag the boundary:
+// this is NOT user-input-safe. The caller must have already
+// authenticated and authorized the from-domain (e.g. via the agent
+// layer's ownership check on the sender). A handler that ever calls
+// this with a user-supplied domain string becomes a "sign as
+// anyone" primitive.
 type DKIMKeyLookup interface {
-	GetDKIMKey(ctx context.Context, domain string) (selector string, privateKey []byte, err error)
+	GetDKIMKeyInternal(ctx context.Context, domain string) (selector string, privateKey []byte, err error)
 }
 
 // Attachment is a base64-encoded file attachment.
@@ -214,7 +221,7 @@ func (s *Sender) signMessage(message []byte, domain string) ([]byte, bool) {
 	if s.dkimLookup == nil || domain == "" {
 		return nil, false
 	}
-	selector, privKey, err := s.dkimLookup.GetDKIMKey(context.Background(), domain)
+	selector, privKey, err := s.dkimLookup.GetDKIMKeyInternal(context.Background(), domain)
 	if err != nil {
 		log.Printf("[sender] dkim key lookup for %s: %v", domain, err)
 		return nil, false

--- a/internal/outbound/sender_test.go
+++ b/internal/outbound/sender_test.go
@@ -95,7 +95,7 @@ type fakeDKIMLookup struct {
 	get func(ctx context.Context, domain string) (string, []byte, error)
 }
 
-func (f *fakeDKIMLookup) GetDKIMKey(ctx context.Context, domain string) (string, []byte, error) {
+func (f *fakeDKIMLookup) GetDKIMKeyInternal(ctx context.Context, domain string) (string, []byte, error) {
 	return f.get(ctx, domain)
 }
 

--- a/sdks/python/src/e2a/v1/generated/__init__.py
+++ b/sdks/python/src/e2a/v1/generated/__init__.py
@@ -182,13 +182,32 @@ class MessageSummary(BaseModel):
     cc: list[str] | None = None
     conversation_id: str | None = None
     created_at: str | None = Field(None, examples=['2025-01-15T10:30:00Z'])
+    direction: Literal['inbound', 'outbound'] | None = Field(None, examples=['inbound'])
     from_: str | None = Field(None, alias='from', examples=['alice@example.com'])
+    hitl_status: (
+        Literal[
+            'pending_approval',
+            'sent',
+            'rejected',
+            'expired_approved',
+            'expired_rejected',
+        ]
+        | None
+    ) = Field(None, examples=['sent'])
     message_id: str | None = Field(None, examples=['msg_abc123'])
     recipient: str | None = Field(None, examples=['my-bot@example.com'])
     reply_to: list[str] | None = None
-    status: Literal['unread', 'read'] | None = Field(None, examples=['unread'])
+    size_bytes: int | None = Field(None, examples=[4231])
+    status: str | None = Field(
+        None,
+        description='Status carries the inbound inbox_status value (`unread` | `read`).\nEmpty string for outbound rows — clients filtering on Status must\ngate on `Direction == "inbound"` first. The enum was removed from\nthe swag annotation deliberately so SDK generators don\'t emit a\n`Literal["unread", "read"]` that breaks at runtime.',
+    )
     subject: str | None = Field(None, examples=['Hello'])
     to: list[str] | None = Field(None, examples=[['my-bot@example.com']])
+    webhook_error: str | None = None
+    webhook_status: Literal['pending', 'delivered', 'failed'] | None = Field(
+        None, examples=['delivered']
+    )
 
 
 class OAuthConnectionEntry(BaseModel):

--- a/sdks/typescript/src/v1/generated/types.ts
+++ b/sdks/typescript/src/v1/generated/types.ts
@@ -1837,18 +1837,33 @@ export interface components {
             conversation_id?: string;
             /** @example 2025-01-15T10:30:00Z */
             created_at?: string;
+            /**
+             * @example inbound
+             * @enum {string}
+             */
+            direction?: "inbound" | "outbound";
             /** @example alice@example.com */
             from?: string;
+            /**
+             * @example sent
+             * @enum {string}
+             */
+            hitl_status?: "pending_approval" | "sent" | "rejected" | "expired_approved" | "expired_rejected";
             /** @example msg_abc123 */
             message_id?: string;
             /** @example my-bot@example.com */
             recipient?: string;
             reply_to?: string[];
+            /** @example 4231 */
+            size_bytes?: number;
             /**
-             * @example unread
-             * @enum {string}
+             * @description Status carries the inbound inbox_status value (`unread` | `read`).
+             *     Empty string for outbound rows — clients filtering on Status must
+             *     gate on `Direction == "inbound"` first. The enum was removed from
+             *     the swag annotation deliberately so SDK generators don't emit a
+             *     `Literal["unread", "read"]` that breaks at runtime.
              */
-            status?: "unread" | "read";
+            status?: string;
             /** @example Hello */
             subject?: string;
             /**
@@ -1857,6 +1872,12 @@ export interface components {
              *     ]
              */
             to?: string[];
+            webhook_error?: string;
+            /**
+             * @example delivered
+             * @enum {string}
+             */
+            webhook_status?: "pending" | "delivered" | "failed";
         };
         OAuthConnectionEntry: {
             agent_email?: string;

--- a/tests/contract/contract_test.go
+++ b/tests/contract/contract_test.go
@@ -75,6 +75,12 @@ type step struct {
 	Subject      string                 `yaml:"subject,omitempty"`
 	VerifyDomain string                 `yaml:"verify_domain,omitempty"`
 	Expect       *expectation           `yaml:"expect,omitempty"`
+	// Capture extracts values from the response and stores them as
+	// placeholders for later steps. Keys are the placeholder names
+	// (without curly braces); values are dotted JSON paths into the
+	// response body. After this step runs, later steps can reference
+	// the captured value as `{name}` in `path` / `body` / `expect`.
+	Capture map[string]string `yaml:"capture,omitempty"`
 }
 
 type expectation struct {
@@ -384,6 +390,20 @@ func (r *runner) execRequest(t *testing.T, s *step) {
 		if !valuesEqual(actual, resolvedExpected) {
 			t.Fatalf("step %s: path %q = %v (%T), want %v (%T)", s.ID, resolvedPath, actual, actual, resolvedExpected, resolvedExpected)
 		}
+	}
+
+	// Capture phase — done after assertions so a captured value is
+	// only stored when the step's contract held. Values are stringified
+	// because that's the form the placeholder resolver works with;
+	// downstream `body_match` comparisons coerce via valuesEqual so
+	// types still round-trip correctly when needed.
+	for name, srcPath := range s.Capture {
+		resolvedSrc := r.resolve(srcPath)
+		raw, found := jsonPathGet(jsonBody, resolvedSrc)
+		if !found {
+			t.Fatalf("step %s: capture path %q not found in response: %s", s.ID, resolvedSrc, rawBody)
+		}
+		r.vars[name] = fmt.Sprint(raw)
 	}
 }
 

--- a/tests/contract/scenarios.yaml
+++ b/tests/contract/scenarios.yaml
@@ -369,6 +369,311 @@ scenarios:
         expect:
           status: 200
 
+  - name: hitl_send_holds_202
+    description: >
+      With HITL enabled on the agent, POST /send returns 202 +
+      status=pending_approval + approval_expires_at, and the message
+      surfaces on GET /messages?status=pending_approval.
+    setup:
+      - register_domain: hitl-hold.test.dev
+      - verify_domain: hitl-hold.test.dev
+      - register_agent:
+          email: bot@hitl-hold.test.dev
+          agent_mode: local
+    steps:
+      - id: enable_hitl
+        action: request
+        method: PUT
+        path: /api/v1/agents/{agent_email}
+        body:
+          hitl_enabled: true
+        expect:
+          status: 200
+          body_match:
+            hitl_enabled: true
+
+      - id: send_held
+        action: request
+        method: POST
+        path: /api/v1/send
+        body:
+          from: "{agent_email}"
+          to:
+            - alice@example.com
+          subject: Hold me
+          body: please review before sending
+        expect:
+          status: 202
+          body_contains:
+            - status
+            - message_id
+            - approval_expires_at
+          body_match:
+            status: pending_approval
+
+      - id: list_pending
+        action: request
+        method: GET
+        path: /api/v1/messages?status=pending_approval
+        expect:
+          status: 200
+          body_match:
+            "messages.length": 1
+            "messages[0].status": pending_approval
+            "messages[0].direction": outbound
+            "messages[0].subject": Hold me
+
+  - name: hitl_reject_records_reason
+    description: >
+      Reject endpoint accepts a reason in the body and the detail GET
+      surfaces it. Catches the chunked-body regression (rejection
+      reason was silently dropped when ContentLength was unknown).
+    setup:
+      - register_domain: hitl-reject.test.dev
+      - verify_domain: hitl-reject.test.dev
+      - register_agent:
+          email: bot@hitl-reject.test.dev
+          agent_mode: local
+    steps:
+      - id: enable_hitl
+        action: request
+        method: PUT
+        path: /api/v1/agents/{agent_email}
+        body:
+          hitl_enabled: true
+        expect:
+          status: 200
+
+      - id: send_held
+        action: request
+        method: POST
+        path: /api/v1/send
+        body:
+          from: "{agent_email}"
+          to:
+            - alice@example.com
+          subject: To be rejected
+          body: this should never go out
+        expect:
+          status: 202
+          body_contains:
+            - message_id
+        capture:
+          held_id: message_id
+
+      - id: reject
+        action: request
+        method: POST
+        path: /api/v1/messages/{held_id}/reject
+        body:
+          reason: off-topic for this audience
+        expect:
+          status: 200
+          body_match:
+            status: rejected
+            rejection_reason: off-topic for this audience
+
+      - id: detail_round_trip
+        action: request
+        method: GET
+        path: /api/v1/messages/{held_id}
+        expect:
+          status: 200
+          body_match:
+            status: rejected
+            rejection_reason: off-topic for this audience
+
+  - name: messages_direction_all_shape
+    description: >
+      GET /agents/{email}/messages?direction=all returns the dashboard-
+      inbox shape: every row carries `direction`, outbound rows carry
+      `hitl_status` and `webhook_status`. Catches the H1 SDK contract
+      drift if api_docs.MessageSummary falls out of sync with the
+      handler again.
+    setup:
+      - register_domain: mixed.test.dev
+      - verify_domain: mixed.test.dev
+      - register_agent:
+          email: bot@mixed.test.dev
+          agent_mode: local
+      - inject_message:
+          agent_email: "{agent_email}"
+          from: external@example.com
+          subject: an inbound row
+    steps:
+      - id: enable_hitl
+        action: request
+        method: PUT
+        path: /api/v1/agents/{agent_email}
+        body:
+          hitl_enabled: true
+        expect:
+          status: 200
+
+      - id: outbound_held
+        action: request
+        method: POST
+        path: /api/v1/send
+        body:
+          from: "{agent_email}"
+          to:
+            - someone@example.com
+          subject: an outbound row
+          body: pending
+        expect:
+          status: 202
+
+      - id: list_mixed
+        action: request
+        method: GET
+        path: /api/v1/agents/{agent_email}/messages?direction=all&page_size=10
+        expect:
+          status: 200
+          body_contains:
+            - messages
+          # Two rows — the order is most-recent-first so the outbound
+          # held row lands at index 0.
+          body_match:
+            "messages.length": 2
+            "messages[0].direction": outbound
+            "messages[0].hitl_status": pending_approval
+            "messages[1].direction": inbound
+
+  - name: signing_secrets_crud_cap
+    description: >
+      Per-user webhook signing secrets cap at 5 (including the
+      "default" one auto-created at user signup; see
+      EnsureUserHasSigningSecret). Creating beyond cap 400s. List
+      returns the full plaintext for every row — deliberate posture,
+      see SigningSecretSummary docstring.
+    setup:
+      - register_domain: signing.test.dev
+      - verify_domain: signing.test.dev
+    steps:
+      - id: create_1
+        action: request
+        method: POST
+        path: /api/v1/users/me/signing-secrets
+        body:
+          name: first
+        expect:
+          status: 201
+          body_contains:
+            - id
+            - name
+            - secret
+            - secret_prefix
+
+      - id: create_2
+        action: request
+        method: POST
+        path: /api/v1/users/me/signing-secrets
+        body:
+          name: second
+        expect:
+          status: 201
+
+      - id: create_3
+        action: request
+        method: POST
+        path: /api/v1/users/me/signing-secrets
+        body:
+          name: third
+        expect:
+          status: 201
+
+      - id: create_4_reaches_cap
+        action: request
+        method: POST
+        path: /api/v1/users/me/signing-secrets
+        body:
+          name: fourth
+        expect:
+          status: 201
+
+      - id: create_5_fails_cap
+        # User already has 1 default + 4 created = 5 (cap). 6th creation
+        # must 400 with the documented cap error.
+        action: request
+        method: POST
+        path: /api/v1/users/me/signing-secrets
+        body:
+          name: would-be-fifth
+        expect:
+          status: 400
+
+      - id: list_returns_plaintext
+        action: request
+        method: GET
+        path: /api/v1/users/me/signing-secrets
+        expect:
+          status: 200
+          body_contains:
+            - secrets
+          # The plaintext `secret` field IS in the list response by
+          # design (different posture from API keys). The `create_1`
+          # step above already validates that the create call returns
+          # `secret` + `secret_prefix`; this assertion locks down the
+          # count so a future "redact on list" change would have to
+          # break the contract test.
+          body_match:
+            "secrets.length": 5
+
+  - name: info_unauthenticated_shape
+    description: >
+      GET /api/v1/info is the deployment-discovery endpoint — works
+      without auth and surfaces shared_domain / slug_registration_enabled
+      / public_url. Catches drift in the DeploymentInfo struct.
+    auth_override: none
+    steps:
+      - id: info
+        action: request
+        method: GET
+        path: /api/v1/info
+        expect:
+          status: 200
+          body_contains:
+            - shared_domain
+            - slug_registration_enabled
+
+  - name: pending_messages_status_filter_strict
+    description: >
+      /api/v1/messages only accepts status=pending_approval. Any other
+      status value (or "all") returns 400. Pins the documented
+      behavior so the docs/api.md "filterable by status" claim is
+      either fixed or the handler is broadened.
+    setup:
+      - register_domain: pstatus.test.dev
+      - verify_domain: pstatus.test.dev
+    steps:
+      - id: default_is_pending
+        action: request
+        method: GET
+        path: /api/v1/messages
+        expect:
+          status: 200
+
+      - id: explicit_pending_ok
+        action: request
+        method: GET
+        path: /api/v1/messages?status=pending_approval
+        expect:
+          status: 200
+
+      - id: sent_filter_rejected
+        action: request
+        method: GET
+        path: /api/v1/messages?status=sent
+        expect:
+          status: 400
+
+      - id: all_filter_rejected
+        action: request
+        method: GET
+        path: /api/v1/messages?status=all
+        expect:
+          status: 400
+
   - name: ws_auth_rejection
     description: WebSocket endpoint rejects missing or invalid query-param tokens
     setup:

--- a/web/public/openapi.yaml
+++ b/web/public/openapi.yaml
@@ -301,8 +301,23 @@ definitions:
       created_at:
         example: "2025-01-15T10:30:00Z"
         type: string
+      direction:
+        enum:
+        - inbound
+        - outbound
+        example: inbound
+        type: string
       from:
         example: alice@example.com
+        type: string
+      hitl_status:
+        enum:
+        - pending_approval
+        - sent
+        - rejected
+        - expired_approved
+        - expired_rejected
+        example: sent
         type: string
       message_id:
         example: msg_abc123
@@ -314,11 +329,16 @@ definitions:
         items:
           type: string
         type: array
+      size_bytes:
+        example: 4231
+        type: integer
       status:
-        enum:
-        - unread
-        - read
-        example: unread
+        description: |-
+          Status carries the inbound inbox_status value (`unread` | `read`).
+          Empty string for outbound rows — clients filtering on Status must
+          gate on `Direction == "inbound"` first. The enum was removed from
+          the swag annotation deliberately so SDK generators don't emit a
+          `Literal["unread", "read"]` that breaks at runtime.
         type: string
       subject:
         example: Hello
@@ -329,6 +349,15 @@ definitions:
         items:
           type: string
         type: array
+      webhook_error:
+        type: string
+      webhook_status:
+        enum:
+        - pending
+        - delivered
+        - failed
+        example: delivered
+        type: string
     type: object
   OAuthConnectionEntry:
     properties:

--- a/web/src/app/(app)/dashboard/agents/messages/page.tsx
+++ b/web/src/app/(app)/dashboard/agents/messages/page.tsx
@@ -11,7 +11,7 @@
 // Selection state lives in `window.location.hash` (#conv:X or #orphan:X)
 // so deep-links work and the back button moves between threads.
 
-import { useMemo, useState, useSyncExternalStore } from "react";
+import { Suspense, useMemo, useState, useSyncExternalStore } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import useSWR from "swr";
 import { listAgentMessages } from "../../../../components/onboarding/api";
@@ -35,7 +35,19 @@ function useUrlHash(): string {
   return useSyncExternalStore(subscribeHash, getHash, () => "");
 }
 
+// AgentInboxPage wraps the content in <Suspense>. Next.js 16+ requires
+// useSearchParams() to live inside a Suspense boundary; otherwise the
+// whole route opts into client-only rendering and any future server
+// component above this page silently bails the static export.
 export default function AgentInboxPage() {
+  return (
+    <Suspense fallback={null}>
+      <AgentInboxContent />
+    </Suspense>
+  );
+}
+
+function AgentInboxContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const email = searchParams.get("email") ?? "";
@@ -47,7 +59,7 @@ export default function AgentInboxPage() {
     data: initialPage,
     error: fetchError,
   } = useSWR(
-    email ? agentMessagesKey(email, "all") : null,
+    email ? agentMessagesKey(email, "all", "all") : null,
     () => listAgentMessages(email, { direction: "all", status: "all", pageSize: 100 }),
     // `keepPreviousData` is on globally for the smooth-revalidation
     // UX, but for per-agent keys it shows the WRONG agent's data

--- a/web/src/app/(app)/dashboard/agents/messages/view/page.test.tsx
+++ b/web/src/app/(app)/dashboard/agents/messages/view/page.test.tsx
@@ -3,8 +3,11 @@
 // redirects, ⌘↵ triggers Approve, missing params surface an error.
 
 import { render, screen, waitFor } from "../../../../../../test-utils/swr";
+import { render as rawRender } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import { mutate } from "swr";
 import AgentMessageFocusPage from "./page";
+import { pendingMessageKey } from "../../../../../../lib/swrKeys";
 
 const mockUseSearchParams = jest.fn();
 const mockRouterPush = jest.fn();
@@ -358,18 +361,51 @@ describe("AgentMessageFocusPage", () => {
   // focus page would render data from cache, skip the fetcher, never
   // call onSuccess, and leave draftBody as "" — the reviewer would
   // click Edit and see a blank textarea instead of the agent's body.
-  // The effect-based seed runs on every data change, so cache hits
-  // also seed correctly.
-  it("seeds the draft-body textarea from outboundSWR.data so cache hits populate the editor", async () => {
+  // The effect-based seed runs on every data change (including the
+  // synchronous cache-hit case), so warm-cache navigation seeds too.
+  //
+  // To genuinely reproduce the bug condition (vs asserting the
+  // post-fix shape on a fetch path that pre-fix code would also have
+  // passed), we render WITHOUT the test-utils/swr fresh-Map wrapper,
+  // use the module-level SWR cache, pre-seed pendingMessageKey(id)
+  // before mounting, and assert mockFetch was never called for the
+  // outbound endpoint. A pre-fix implementation (onSuccess-only seed)
+  // would observe data via the cache but never fire onSuccess, so
+  // the textarea would be empty and the assertion would fail.
+  it("seeds the textarea from pre-populated SWR cache without firing a fetch (true cache-hit regression)", async () => {
     setSearchParams({ email: "support@acme.io", id: "msg_pending" });
-    mockOutboundOnly(OUTBOUND_PENDING);
+    // Pre-seed the cache the page is about to subscribe to. The
+    // jest.setup.ts afterEach nukes the module-level cache between
+    // tests, so this seed is isolated to this test.
+    await mutate(
+      pendingMessageKey("msg_pending"),
+      OUTBOUND_PENDING,
+      { revalidate: false },
+    );
+    // Fetch must NOT be called: any call indicates the page hit the
+    // network rather than the cache, defeating the bug reproduction.
+    mockFetch.mockImplementation(() => {
+      throw new Error(
+        "fetch was called — cache hit did not happen, test reproduces nothing",
+      );
+    });
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
 
-    render(<AgentMessageFocusPage />);
+    // Bypass test-utils/swr — it provides a fresh-Map SWRConfig
+    // per render, which would isolate this test's mounted hooks
+    // from the seed we just placed on the module-level cache.
+    rawRender(<AgentMessageFocusPage />);
+
+    // Page renders against the seeded cache synchronously; action
+    // card appears without a fetch.
     await waitFor(() => {
       expect(screen.getByTestId("action-card")).toBeInTheDocument();
     });
+    // Assert no outbound fetch happened.
+    expect(mockFetch).not.toHaveBeenCalled();
 
+    // The H3 fix's invariant: textarea is seeded from cache-resolved
+    // data, even though onSuccess never fired.
     await user.click(screen.getByText(/^edit draft$/i));
     const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
     expect(textarea.value).toContain("Thanks for sending over the renewal draft");

--- a/web/src/app/(app)/dashboard/agents/messages/view/page.test.tsx
+++ b/web/src/app/(app)/dashboard/agents/messages/view/page.test.tsx
@@ -350,6 +350,31 @@ describe("AgentMessageFocusPage", () => {
     expect(approveBody).toContain('"body_text":"Edited body"');
   });
 
+  // Regression for H3: previously the draft-body textarea was seeded
+  // only from SWR's onSuccess callback. onSuccess fires after a real
+  // fetch — not on a cache hit served within dedupingInterval. If
+  // another surface (e.g. PendingDetailPanel) populated
+  // pendingMessageKey(id) just before the user navigated here, the
+  // focus page would render data from cache, skip the fetcher, never
+  // call onSuccess, and leave draftBody as "" — the reviewer would
+  // click Edit and see a blank textarea instead of the agent's body.
+  // The effect-based seed runs on every data change, so cache hits
+  // also seed correctly.
+  it("seeds the draft-body textarea from outboundSWR.data so cache hits populate the editor", async () => {
+    setSearchParams({ email: "support@acme.io", id: "msg_pending" });
+    mockOutboundOnly(OUTBOUND_PENDING);
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    render(<AgentMessageFocusPage />);
+    await waitFor(() => {
+      expect(screen.getByTestId("action-card")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText(/^edit draft$/i));
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    expect(textarea.value).toContain("Thanks for sending over the renewal draft");
+  });
+
   // Regression: navigating from message A to message B via ?id= must
   // reset the inner per-message state (draftBody, editingDraft,
   // hasUserEditedRef, rejectReason). Before keying FocusContent by

--- a/web/src/app/(app)/dashboard/agents/messages/view/page.tsx
+++ b/web/src/app/(app)/dashboard/agents/messages/view/page.tsx
@@ -11,7 +11,7 @@
 // union is a tracked follow-up; until then we do two requests in the
 // worst case.
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import useSWR from "swr";
@@ -108,7 +108,20 @@ function decodeInboundBody(rawBase64: string | undefined): string {
 // per-message state (draftBody, editingDraft, hasUserEditedRef,
 // rejectReason, showRejectPrompt, submitError) would persist across
 // the navigation and corrupt B with A's UI state.
+// Next.js 16+ requires useSearchParams to live inside a Suspense
+// boundary. The current "use client" declaration at the top of the
+// file currently keeps this working, but adding any server component
+// above the route would silently bail the static export. Wrap
+// pre-emptively so the routing tree stays static-export-safe.
 export default function AgentMessageFocusPage() {
+  return (
+    <Suspense fallback={null}>
+      <FocusPageRouter />
+    </Suspense>
+  );
+}
+
+function FocusPageRouter() {
   const searchParams = useSearchParams();
   const email = searchParams.get("email") ?? "";
   const id = searchParams.get("id") ?? "";

--- a/web/src/app/(app)/dashboard/agents/messages/view/page.tsx
+++ b/web/src/app/(app)/dashboard/agents/messages/view/page.tsx
@@ -155,18 +155,7 @@ function FocusContent({
   const outboundSWR = useSWR(
     id ? pendingMessageKey(id) : null,
     () => getPendingMessage(id),
-    {
-      shouldRetryOnError: false,
-      keepPreviousData: false,
-      // Seed the draft-body textarea the first time data arrives.
-      // Doing this in SWR's onSuccess callback (which fires from
-      // SWR's internal fetch effect, not our render) keeps the
-      // setState off the render path that React 19's lint guards.
-      onSuccess: (data) => {
-        if (hasUserEditedRef.current) return;
-        setDraftBody(data.body_text ?? "");
-      },
-    },
+    { shouldRetryOnError: false, keepPreviousData: false },
   );
   const outboundIs404 =
     outboundSWR.error instanceof ApiError && outboundSWR.error.status === 404;
@@ -214,6 +203,24 @@ function FocusContent({
   const [showRejectPrompt, setShowRejectPrompt] = useState(false);
   const [rejectReason, setRejectReason] = useState("");
 
+  // Seed the draft-body textarea from the loaded outbound message.
+  // Previously this lived in SWR's onSuccess callback, but onSuccess
+  // only fires on a real fetch — not on a cache-hit served within
+  // SWR's dedupingInterval. If the pending panel populated
+  // pendingMessageKey(id) shortly before the user landed on this
+  // page (e.g. via a future "Open in focus" link), the focus page
+  // would hit cache, skip the fetcher, never call onSuccess, and
+  // the reviewer would see an empty textarea.
+  //
+  // Effect-based seeding fires on every render where outboundSWR.data
+  // changes — including the cache-hit case where data resolves
+  // synchronously on mount. The hasUserEditedRef guard prevents
+  // window-focus revalidation from stomping in-progress edits.
+  useEffect(() => {
+    if (hasUserEditedRef.current) return;
+    if (!outboundSWR.data) return;
+    setDraftBody(outboundSWR.data.body_text ?? "");
+  }, [outboundSWR.data]);
 
   const isPending = msg?.direction === "outbound" && msg.data.status === "pending_approval";
 

--- a/web/src/app/(app)/dashboard/agents/settings/page.tsx
+++ b/web/src/app/(app)/dashboard/agents/settings/page.tsx
@@ -5,7 +5,7 @@
 // zone for deletion. The dashboard card is now lean: identity +
 // stats + Open-inbox / Settings CTAs only; the editors live here.
 
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Eyebrow } from "../../../../components/loft/Eyebrow";
 import { deleteAgent } from "../../../../components/onboarding/api";
@@ -15,17 +15,23 @@ import { AgentModeSwitcher } from "../../_components/AgentModeSwitcher";
 import { WebhookEditor } from "../../_components/WebhookEditor";
 import { HITLEditor } from "../../_components/HITLEditor";
 
+// Suspense-wrap so useSearchParams stays inside a Suspense boundary
+// per Next.js 16+ requirements. Inner content is keyed by email so
+// navigating between agents (?email=A → ?email=B) re-mounts the
+// editors with fresh state — without the key, useState would persist
+// the previous agent's settings while a new fetch was in flight.
 export default function AgentSettingsPage() {
+  return (
+    <Suspense fallback={null}>
+      <AgentSettingsRouter />
+    </Suspense>
+  );
+}
+
+function AgentSettingsRouter() {
   const searchParams = useSearchParams();
   const email = searchParams.get("email") ?? "";
-
-  // Inner content is keyed by email so navigating between agents
-  // (?email=A → ?email=B) re-mounts the editors with fresh state.
-  // Without the key, useState would persist the previous agent's
-  // settings while a new fetch was in flight.
-  return (
-    <AgentSettingsContent key={email} email={email} />
-  );
+  return <AgentSettingsContent key={email} email={email} />;
 }
 
 function AgentSettingsContent({ email }: { email: string }) {

--- a/web/src/app/(app)/domains/page.test.tsx
+++ b/web/src/app/(app)/domains/page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "../../../test-utils/swr";
 import userEvent from "@testing-library/user-event";
 import DomainsPage from "./page";
 

--- a/web/src/app/(app)/domains/page.tsx
+++ b/web/src/app/(app)/domains/page.tsx
@@ -1,12 +1,19 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState } from "react";
+import useSWR from "swr";
 import { DomainList } from "./_components/DomainList";
 import { AddDomainForm } from "./_components/AddDomainForm";
 import { listDomains, listAgents } from "../../components/onboarding/api";
 import type { DomainInfo } from "../../components/onboarding/types";
 import type { DashboardAgent } from "../../components/types";
 import { PageShell } from "../../components/loft/PageShell";
+import {
+  agentsKey,
+  domainsKey,
+  invalidateAgents,
+  invalidateDomains,
+} from "../../../lib/swrKeys";
 
 // Domains stats strip — Total / Verified / Pending are computed
 // client-side from the domain list; Agents · 7d renders `—` until a
@@ -59,34 +66,54 @@ function DomainsStatsStrip({ domains }: { domains: DomainInfo[] }) {
 }
 
 export default function DomainsPage() {
-  const [domains, setDomains] = useState<DomainInfo[]>([]);
-  const [agents, setAgents] = useState<DashboardAgent[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState("");
   const [showAddForm, setShowAddForm] = useState(false);
+  // Share the cache with the dashboard's verified-domains stat
+  // (useSWR(domainsKey) on /dashboard) so any mutation here flows
+  // through to that surface in the same tick. Before this migration
+  // the page kept its own useState copy and the dashboard's count
+  // stayed stale until tab-focus revalidation eventually caught up.
+  const {
+    data: domains = [],
+    error: domainsError,
+    isLoading: domainsLoading,
+    mutate: refetchDomains,
+  } = useSWR<DomainInfo[]>(domainsKey, () => listDomains());
+  const {
+    data: agents = [],
+    isLoading: agentsLoading,
+    mutate: refetchAgents,
+  } = useSWR<DashboardAgent[]>(agentsKey, () => listAgents());
 
-  const fetchData = useCallback(async () => {
-    try {
-      const [domainsData, agentsData] = await Promise.all([
-        listDomains(),
-        listAgents(),
-      ]);
-      setDomains(domainsData);
-      setAgents(agentsData);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to load data");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  const loading = (domainsLoading || agentsLoading) && domains.length === 0;
+  const error = domainsError
+    ? domainsError instanceof Error
+      ? domainsError.message
+      : "Failed to load data"
+    : "";
 
-  useEffect(() => {
-    fetchData();
-  }, [fetchData]);
-
+  // After a child component finishes a domain mutation (register /
+  // verify / delete / set-primary) it calls onRefresh; we trigger
+  // SWR revalidation via the hook-supplied mutate function so this
+  // component re-renders against fresh data immediately. We also
+  // fire the global invalidateDomains/invalidateAgents helpers so
+  // OTHER surfaces subscribed to the same keys (dashboard's
+  // verified-domains stat, agent cards) refresh in the same tick.
+  // The hook-scoped mutate is what guarantees the local re-render —
+  // global mutate alone wouldn't update an SWRConfig-scoped cache
+  // (e.g. in tests with a fresh-Map provider).
   const handleDomainRegistered = () => {
     setShowAddForm(false);
-    fetchData();
+    void refetchDomains();
+    void refetchAgents();
+    void invalidateDomains();
+    void invalidateAgents();
+  };
+
+  const handleListChanged = () => {
+    void refetchDomains();
+    void refetchAgents();
+    void invalidateDomains();
+    void invalidateAgents();
   };
 
   // Empty state
@@ -191,7 +218,7 @@ export default function DomainsPage() {
           Loading...
         </div>
       ) : (
-        <DomainList domains={domains} agents={agents} onRefresh={fetchData} />
+        <DomainList domains={domains} agents={agents} onRefresh={handleListChanged} />
       )}
     </PageShell>
   );

--- a/web/src/app/oauth/consent/page.tsx
+++ b/web/src/app/oauth/consent/page.tsx
@@ -253,7 +253,19 @@ function ConsentForm({
 
   const creating = agentChoice === "create_new";
   const slugValid = !creating || SLUG_PATTERN.test(slug);
-  const submitDisabled = !slugValid;
+  // Verify the inbound redirect_uri matches one of the values the
+  // client registered. fosite re-validates this server-side so a
+  // mismatch isn't an exploit, but the UI was happy to render
+  // "Redirect: https://attacker.example" with no warning and let
+  // the user click Authorize. The backend would then 400 with a
+  // generic OAuth error, leaving the user confused. Bail loudly
+  // upfront instead.
+  const inboundRedirect = params["redirect_uri"] ?? "";
+  const redirectMismatch =
+    inboundRedirect !== "" &&
+    client.redirect_uris.length > 0 &&
+    !client.redirect_uris.includes(inboundRedirect);
+  const submitDisabled = !slugValid || redirectMismatch;
 
   // The hidden inputs re-emit every OAuth param we received. We use
   // params (the readback of useSearchParams) rather than re-deriving
@@ -270,6 +282,24 @@ function ConsentForm({
         <strong>{client.client_name}</strong> is asking to send and receive
         email on your behalf via e2a.
       </p>
+
+      {redirectMismatch && (
+        <div
+          role="alert"
+          className="mb-4 p-3 text-sm border rounded"
+          style={{
+            background: "var(--danger-bg)",
+            color: "var(--danger-strong)",
+            borderColor: "var(--danger-bg)",
+          }}
+        >
+          <strong>Redirect URI mismatch.</strong> The redirect URL this
+          request is using (<span className="font-mono">{inboundRedirect}</span>)
+          is not on the client&apos;s registered list. The server would
+          reject the authorization anyway — refusing in the UI to avoid
+          phishing-by-confused-redirect.
+        </div>
+      )}
 
       <form method="POST" action="/api/oauth/consent" className="space-y-4">
         {Object.entries(params).map(([k, v]) => (

--- a/web/src/lib/swrKeys.ts
+++ b/web/src/lib/swrKeys.ts
@@ -18,8 +18,18 @@ export const agentsKey = "agents";
 export const domainsKey = "domains";
 export const pendingMessagesKey = "pending-messages";
 
-export const agentMessagesKey = (email: string, direction: string = "all", token?: string) =>
-  ["agent-messages", email, direction, token ?? null] as const;
+// Key tuple includes every filter that affects the response so two
+// surfaces fetching the same email under different filters don't
+// poison each other's cache. Pre-fix the key omitted `status`, so a
+// future surface filtering by status would collide with the existing
+// all-status inbox view.
+export const agentMessagesKey = (
+  email: string,
+  direction: string = "all",
+  status: string = "all",
+  token?: string,
+) =>
+  ["agent-messages", email, direction, status, token ?? null] as const;
 
 export const pendingMessageKey = (id: string) => ["pending-message", id] as const;
 export const inboundMessageKey = (email: string, id: string) => ["inbound-message", email, id] as const;


### PR DESCRIPTION
## Summary

Applies the critical + high + small-medium findings from the comprehensive audit (PRs #140 follow-up). Independent reviewers ran against post-merge `main`; this branch lands the verified ones in the recommended fix order. Larger mediums (M2/M3/M4/M5/M8/M11) deferred to a follow-up.

## Findings landed

**Critical (silent correctness / security bugs):**
- **C2** — HITL approve/reject decode body even when `Transfer-Encoding: chunked` (`ContentLength == -1`). Previously the reviewer's edits / rejection reason were silently dropped on chunked requests. Regression tests via `Transfer-Encoding: chunked` HTTP requests.
- **C3** — DKIM verifier refuses any signature carrying `l=` body-length tag. Honoring `l=` lets an attacker append unsigned tail content to a legitimately-signed message and still get `dkim=pass`.

**High:**
- **H1** — `MessageSummary` doc shim updated to mirror the runtime handler (added `direction`, `hitl_status`, `webhook_status`, `webhook_error`, `size_bytes`; dropped the inaccurate `enums:"unread,read"`). `make generate` re-ran; TS + Python SDKs updated.
- **H2** — Six new contract scenarios in `tests/contract/scenarios.yaml` covering HITL hold/reject, mixed-direction listing, signing-secrets cap, deployment info, status filter strictness. Runner extended with `capture:` so multi-step flows can reference IDs from prior steps.
- **H3** — Focus-page draft seeded via `useEffect(outboundSWR.data)` so SWR cache hits (where `onSuccess` doesn't fire) still populate the textarea.
- **H4** — Background workers tracked in `sync.WaitGroup`; SIGTERM signals cancel, waits up to 30s for drain. `httpServer.Shutdown` now bounded to 30s. Hourly cleanup goroutine reads `ctx.Done()` instead of running on `Background`.
- **H5** — `/domains/page.tsx` migrated to `useSWR(domainsKey)`. `DomainCard` verify/setPrimary/delete + `AddDomainForm` now call hook-scoped mutate **and** the global `invalidateDomains` / `invalidateAgents`, so the dashboard's verified-domains stat updates immediately.
- **H6** — `GetDKIMKey` renamed to `GetDKIMKeyInternal` + load-bearing comment flagging the unscoped boundary so a future caller can't accidentally feed user input into it.
- **H7** — GDPR connections export query now reads `'agent_email'` (the JSON tag) instead of `'AgentEmail'` (the Go field name). The retention test was masking this by seeding the wrong key on both sides; new test marshals via `json.Marshal(*Session)` so any future field-rename drift is caught.

**Mediums (small):**
- **M1** — `agentMessagesKey` tuple includes `status` so future filtered surfaces can't collide on the same SWR cache key.
- **M6** — OAuth consent UI compares inbound `redirect_uri` against `client.redirect_uris` and refuses early with an inline error banner on mismatch (backend still re-validates; this prevents phishing-by-confused-redirect at the UI layer).
- **M7** — `NotifyPendingApprovalAsync`'s nil-receiver no-op now logs a single line per request so silent suppression is visible to operators.
- **M9** — `useSearchParams` callers in `messages/page.tsx`, `view/page.tsx`, `settings/page.tsx` wrapped in `<Suspense fallback={null}>` for Next.js 16+ static-export safety.
- **M10** — `docs/api.md` fixed: single-msg GET flips read regardless of agent mode; `/messages` only accepts `status=pending_approval`; signing-secrets list returns full plaintext secret.

## Findings deferred (follow-up PR)

- **M2** — pagination cursors unsigned (need HMAC binding to the deployment signing secret)
- **M3** — magic-link approval tokens replay-able within TTL (needs `consumed_at` column + index)
- **M4** — DKIM private keys unencrypted at rest (needs KEK + envelope encryption)
- **M5** — webhook delivery DNS rebinding (needs `http.Transport.DialContext` + Control callback)
- **M8** — OAuth consent CSRF token (relies on SameSite=Lax alone today)
- **M11** — `formatExpiresIn` duplicated across 4 surfaces, none tick (touches multiple files + tests)

Plus the audit-deferred Lows. None of the deferred items are silently active bugs (M2-M5/M8 are defense-in-depth; M11 is UX freshness).

## Test plan

- [x] `npm test` (web) — 256/256 passing
- [x] `go build ./...` — clean
- [x] `go test ./internal/oauth/...` — H7 regression locked in
- [x] `go test ./internal/agent/...` — C2 chunked-body regressions + existing suite
- [x] `go test ./internal/emailauth/...` — C3 `l=` refusal + 9 sub-tests
- [x] `go test ./tests/contract/...` — 6 new scenarios + all existing pass
- [ ] CI green on all jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)