### PR TITLE
feat(api): add Idempotency-Key + close SES double-send window

### DIFF
--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/headers"
 	"github.com/Mnexa-AI/e2a/internal/hitlnotify"
 	"github.com/Mnexa-AI/e2a/internal/hitlworker"
+	"github.com/Mnexa-AI/e2a/internal/idempotency"
 	"github.com/Mnexa-AI/e2a/internal/identity"
 	"github.com/Mnexa-AI/e2a/internal/oauth"
 	"github.com/Mnexa-AI/e2a/internal/outbound"
@@ -190,6 +191,15 @@ func main() {
 		log.Printf("[oauth] provider enabled: issuer=%s", cfg.HTTP.PublicURL)
 	}
 
+	// Idempotency-Key support on /api/v1/send and /api/v1/agents/{email}/messages/{id}/reply.
+	// Replays the cached response on retry; closes the double-send window for callers
+	// behind at-least-once delivery (job queues, agent frameworks that retry tool calls,
+	// model-driven re-invocations). Always wired in production — keeping it optional in
+	// the agent package surfaces a clearer 5xx path for environments that don't run
+	// against this codebase's postgres.
+	idempotencyStore := idempotency.NewStore(pool)
+	api.SetIdempotencyStore(idempotencyStore)
+
 	api.RegisterRoutes(router)
 
 	// WebSocket route for local-mode agents
@@ -271,6 +281,12 @@ func main() {
 						res.AccessTokensDeleted, res.RefreshTokensDeleted,
 						res.ClientsDeleted)
 				}
+			}
+
+			if deleted, err := idempotencyStore.Sweep(context.Background()); err != nil {
+				log.Printf("Failed to sweep idempotency keys: %v", err)
+			} else if deleted > 0 {
+				log.Printf("Swept %d idempotency key(s) past TTL", deleted)
 			}
 		}
 	}()

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -19,6 +20,7 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/auth"
 	"github.com/Mnexa-AI/e2a/internal/dkim"
 	"github.com/Mnexa-AI/e2a/internal/hitlnotify"
+	"github.com/Mnexa-AI/e2a/internal/idempotency"
 	"github.com/Mnexa-AI/e2a/internal/identity"
 	"github.com/Mnexa-AI/e2a/internal/oauth"
 	"github.com/Mnexa-AI/e2a/internal/outbound"
@@ -146,6 +148,7 @@ type API struct {
 	notifier       *hitlnotify.Notifier   // optional; if nil, holdForApproval doesn't send notification email
 	oauthProvider  fosite.OAuth2Provider  // optional; if nil, /api/oauth/* endpoints return 404
 	oauthStorage   *oauth.Storage         // optional; consent handler needs Pool() for cross-package tx
+	idempotency    *idempotency.Store     // optional; when nil, Idempotency-Key header is ignored
 }
 
 // SetApprovalSigner wires in the magic-link signer after construction so
@@ -173,6 +176,13 @@ func (a *API) SetOAuthProvider(p fosite.OAuth2Provider) { a.oauthProvider = p }
 // it, but it's required for /consent to work; setting one without the
 // other is a misconfiguration the consent handler surfaces as a 503.
 func (a *API) SetOAuthStorage(s *oauth.Storage) { a.oauthStorage = s }
+
+// SetIdempotencyStore enables Idempotency-Key processing on the
+// outbound /send and /reply endpoints. When nil (the default) the
+// header is silently ignored — keeps the agent package usable in
+// environments that don't have postgres wired or want to disable
+// the feature. The cmd/e2a runtime always sets it.
+func (a *API) SetIdempotencyStore(s *idempotency.Store) { a.idempotency = s }
 
 func NewAPI(store *identity.Store, sender *outbound.Sender, smtpRelay *outbound.SMTPRelay, userAuth *auth.UserAuth, usage usage.UsageTracker, smtpDomain, fromDomain, sharedDomain, publicURL string, production bool) *API {
 	return &API{
@@ -1295,7 +1305,10 @@ func (a *API) holdForApproval(w http.ResponseWriter, r *http.Request, agent *ide
 // @Failure      400 {string} string "Missing required fields"
 // @Failure      401 {string} string "Missing or invalid API key"
 // @Failure      403 {string} string "Agent domain not verified"
+// @Failure      409 {string} string "Another request with this Idempotency-Key is in progress"
+// @Failure      422 {string} string "Idempotency-Key reused with a different request body"
 // @Failure      429 {string} string "Rate limit exceeded"
+// @Param        Idempotency-Key header string false "Caller-generated unique key (recommend UUIDv4). Retries with the same key + same body replay the original response; with a different body return 422."
 // @Router       /api/v1/send [post]
 func (a *API) handleSendEmail(w http.ResponseWriter, r *http.Request) {
 	user, err := a.authenticateUser(r)
@@ -1304,8 +1317,21 @@ func (a *API) handleSendEmail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	bodyBytes, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxRequestBytesSend))
+	if err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	replayed, captureW, finalize := a.idempotencyGuard(w, r, user.ID, bodyBytes)
+	if replayed {
+		return
+	}
+	defer finalize()
+	w = captureW
+
 	var req outbound.SendRequest
-	if err := readJSON(w, r, &req, maxRequestBytesSend); err != nil {
+	if err := json.Unmarshal(bodyBytes, &req); err != nil {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return
 	}
@@ -1519,7 +1545,10 @@ type ReplyRequest struct {
 // @Failure      401 {string} string "Missing or invalid API key"
 // @Failure      403 {string} string "Agent domain not verified"
 // @Failure      404 {string} string "Message not found or does not belong to this agent"
+// @Failure      409 {string} string "Another request with this Idempotency-Key is in progress"
+// @Failure      422 {string} string "Idempotency-Key reused with a different request body"
 // @Failure      429 {string} string "Rate limit exceeded"
+// @Param        Idempotency-Key header string false "Caller-generated unique key (recommend UUIDv4). Retries with the same key + same body replay the original response; with a different body return 422."
 // @Router       /api/v1/agents/{email}/messages/{id}/reply [post]
 func (a *API) handleReplyToMessage(w http.ResponseWriter, r *http.Request) {
 	user, err := a.authenticateUser(r)
@@ -1527,6 +1556,19 @@ func (a *API) handleReplyToMessage(w http.ResponseWriter, r *http.Request) {
 		a.writeAuthError(w, r, err)
 		return
 	}
+
+	bodyBytes, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxRequestBytesSend))
+	if err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	replayed, captureW, finalize := a.idempotencyGuard(w, r, user.ID, bodyBytes)
+	if replayed {
+		return
+	}
+	defer finalize()
+	w = captureW
 
 	vars := mux.Vars(r)
 	email := vars["email"]
@@ -1562,7 +1604,7 @@ func (a *API) handleReplyToMessage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var req ReplyRequest
-	if err := readJSON(w, r, &req, maxRequestBytesSend); err != nil {
+	if err := json.Unmarshal(bodyBytes, &req); err != nil {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return
 	}

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -1406,6 +1406,11 @@ func (a *API) handleSendEmail(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "self-send failed", http.StatusInternalServerError)
 			return
 		}
+		// Loopback row writes are irreversible from the caller's
+		// perspective (the inbox row is now visible). Lock the
+		// idempotency key in so a late 5xx from logging / response
+		// flushing doesn't release it and let a retry double-write.
+		markSideEffectCommitted(w)
 		slug, _, _ := strings.Cut(agent.EmailAddress(), "@")
 		log.Printf("[mail] dir=outbound type=send method=loopback from=%s to=%s slug=%s conv_id=%s subject=%q provider_id=%s", agent.EmailAddress(), agent.EmailAddress(), slug, req.ConversationID, req.Subject, providerID)
 		w.Header().Set("Content-Type", "application/json")
@@ -1427,6 +1432,12 @@ func (a *API) handleSendEmail(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("send failed: %v", err), http.StatusInternalServerError)
 		return
 	}
+	// Upstream send accepted — past this point, any handler-side
+	// failure must NOT release the idempotency key (retrying would
+	// double-send to SES). markSideEffectCommitted flips finalize's
+	// policy to "cache the response no matter what status code we
+	// end up writing".
+	markSideEffectCommitted(w)
 
 	// Record outbound message with canonicalized recipients from result
 	outMsg, err := a.store.CreateOutboundMessage(r.Context(), agent.ID, result.To, result.CC, result.BCC, req.Subject, "send", result.Method, result.MessageID, req.ConversationID)
@@ -1698,6 +1709,8 @@ func (a *API) handleReplyToMessage(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "self-reply failed", http.StatusInternalServerError)
 			return
 		}
+		// See handleSendEmail's self-send branch for rationale.
+		markSideEffectCommitted(w)
 		slug, _, _ := strings.Cut(agent.EmailAddress(), "@")
 		log.Printf("[mail] dir=outbound type=reply method=loopback from=%s to=%s slug=%s conv_id=%s subject=%q provider_id=%s in_reply_to=%s",
 			agent.EmailAddress(), agent.EmailAddress(), slug, req.ConversationID, subject, providerID, inbound.EmailMessageID)
@@ -1720,6 +1733,8 @@ func (a *API) handleReplyToMessage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, fmt.Sprintf("delivery failed: %v", err), http.StatusInternalServerError)
 		return
 	}
+	// Upstream send accepted — see handleSendEmail for the rationale.
+	markSideEffectCommitted(w)
 
 	// Record outbound message with canonicalized recipients from result
 	outMsg, err := a.store.CreateOutboundMessage(r.Context(), agent.ID, result.To, result.CC, result.BCC, subject, "reply", result.Method, result.MessageID, req.ConversationID)

--- a/internal/agent/api_test.go
+++ b/internal/agent/api_test.go
@@ -18,11 +18,12 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/Mnexa-AI/e2a/internal/agent"
 	"github.com/Mnexa-AI/e2a/internal/auth"
-	"github.com/Mnexa-AI/e2a/internal/usage"
 	"github.com/Mnexa-AI/e2a/internal/config"
+	"github.com/Mnexa-AI/e2a/internal/idempotency"
 	"github.com/Mnexa-AI/e2a/internal/identity"
 	"github.com/Mnexa-AI/e2a/internal/outbound"
 	"github.com/Mnexa-AI/e2a/internal/testutil"
+	"github.com/Mnexa-AI/e2a/internal/usage"
 )
 
 func setupAPI(t *testing.T) (*httptest.Server, *identity.Store, *pgxpool.Pool) {
@@ -33,6 +34,7 @@ func setupAPI(t *testing.T) (*httptest.Server, *identity.Store, *pgxpool.Pool) {
 	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
 	noopUsage := usage.NewNoopUsageTracker()
 	api := agent.NewAPI(store, sender, smtpRelay, nil, noopUsage, "e2a.dev", "test.e2a.dev", "agents.e2a.dev", "", false)
+	api.SetIdempotencyStore(idempotency.NewStore(pool))
 	router := mux.NewRouter()
 	api.RegisterRoutes(router)
 	server := httptest.NewServer(router)
@@ -279,6 +281,7 @@ func setupAPIWithSMTP(t *testing.T) (*httptest.Server, *identity.Store, *pgxpool
 	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
 	noopUsage := usage.NewNoopUsageTracker()
 	api := agent.NewAPI(store, sender, smtpRelay, nil, noopUsage, "e2a.dev", "test.e2a.dev", "agents.e2a.dev", "", false)
+	api.SetIdempotencyStore(idempotency.NewStore(pool))
 	router := mux.NewRouter()
 	api.RegisterRoutes(router)
 	server := httptest.NewServer(router)

--- a/internal/agent/export_test.go
+++ b/internal/agent/export_test.go
@@ -3,7 +3,11 @@ package agent
 // Test seams: re-export unexported helpers we want to unit-test from
 // the external `agent_test` package without widening the public API.
 
-import "github.com/Mnexa-AI/e2a/internal/outbound"
+import (
+	"net/http"
+
+	"github.com/Mnexa-AI/e2a/internal/outbound"
+)
 
 // IsSelfSendForTest is the agent_test-package handle for isSelfSend.
 // Pure function over (request, agent email); see selfsend.go for the
@@ -12,4 +16,31 @@ import "github.com/Mnexa-AI/e2a/internal/outbound"
 // reader doesn't reach for it from production code.
 func IsSelfSendForTest(req outbound.SendRequest, agentEmail string) bool {
 	return isSelfSend(req, agentEmail)
+}
+
+// AuthenticateUserForTest exposes API.authenticateUser so external
+// test helpers can construct synthetic guard-protected handlers
+// without re-implementing the bearer-token plumbing.
+func (a *API) AuthenticateUserForTest(r *http.Request) (userID string, err error) {
+	u, err := a.authenticateUser(r)
+	if err != nil {
+		return "", err
+	}
+	return u.ID, nil
+}
+
+// IdempotencyGuardForTest exposes API.idempotencyGuard so tests in the
+// external agent_test package can verify the side-effect-committed
+// caching policy end-to-end (the standard handlers don't have a
+// natural way to reach the "5xx after side effect" branch in a unit
+// test).
+func (a *API) IdempotencyGuardForTest(w http.ResponseWriter, r *http.Request, userID string, bodyBytes []byte) (replayed bool, out http.ResponseWriter, finalize func()) {
+	return a.idempotencyGuard(w, r, userID, bodyBytes)
+}
+
+// MarkSideEffectCommittedForTest exposes markSideEffectCommitted so
+// the external test harness can flip the cache-on-error flag from
+// inside a synthetic handler.
+func MarkSideEffectCommittedForTest(w http.ResponseWriter) {
+	markSideEffectCommitted(w)
 }

--- a/internal/agent/idempotency_api_test.go
+++ b/internal/agent/idempotency_api_test.go
@@ -1,0 +1,309 @@
+package agent_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+)
+
+// idempotencyHeaders builds the Authorization + Idempotency-Key header
+// set used across these tests. Returns a request ready for http.Do.
+func idempotencyRequest(t *testing.T, method, url, body, apiKey, idemKey string) *http.Request {
+	t.Helper()
+	var rdr io.Reader
+	if body != "" {
+		rdr = strings.NewReader(body)
+	}
+	req, err := http.NewRequest(method, url, rdr)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	if idemKey != "" {
+		req.Header.Set("Idempotency-Key", idemKey)
+	}
+	return req
+}
+
+// setupVerifiedSendingAgent provisions a fully-onboarded sending agent
+// keyed off the test name. Returns the server URL, the SMTP capture
+// closure, and the bearer API key.
+func setupVerifiedSendingAgent(t *testing.T, namePrefix string) (serverURL string, smtpDone func() []testutil.SMTPMessage, apiKey string) {
+	t.Helper()
+	srv, store, _, done := setupAPIWithSMTP(t)
+	ctx := context.Background()
+	user, err := store.CreateOrGetUser(ctx, namePrefix+"-owner@example.com", "Owner", "google-"+namePrefix)
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	keyObj, err := store.CreateAPIKey(ctx, user.ID, namePrefix+"-key", nil)
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+	domain := namePrefix + ".example.com"
+	if _, err := store.ClaimOrCreateDomain(ctx, domain, user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+	if err := store.VerifyDomain(ctx, domain, user.ID); err != nil {
+		t.Fatalf("VerifyDomain: %v", err)
+	}
+	if _, err := store.CreateAgent(ctx, "agent@"+domain, domain, "", "https://example.com/webhook", "", user.ID); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	return srv.URL, done, keyObj.PlaintextKey
+}
+
+func TestSendEmail_IdempotencyKey_DuplicateReplaysAndSkipsResend(t *testing.T) {
+	serverURL, smtpDone, apiKey := setupVerifiedSendingAgent(t, "idem-replay")
+
+	payload := `{"to":["alice@example.com"],"subject":"Hi","body":"first body"}`
+	idemKey := "key-replay-001"
+
+	// First call: should send once and return 200.
+	resp1, err := http.DefaultClient.Do(idempotencyRequest(t, "POST", serverURL+"/api/v1/send", payload, apiKey, idemKey))
+	if err != nil {
+		t.Fatalf("first send: %v", err)
+	}
+	body1, _ := io.ReadAll(resp1.Body)
+	resp1.Body.Close()
+	if resp1.StatusCode != 200 {
+		t.Fatalf("first status = %d, body = %s", resp1.StatusCode, body1)
+	}
+	if resp1.Header.Get("Idempotent-Replayed") != "" {
+		t.Errorf("first call should not be marked replayed, got %q", resp1.Header.Get("Idempotent-Replayed"))
+	}
+
+	// Second call: same key + same body must NOT re-send; response must be byte-identical.
+	resp2, err := http.DefaultClient.Do(idempotencyRequest(t, "POST", serverURL+"/api/v1/send", payload, apiKey, idemKey))
+	if err != nil {
+		t.Fatalf("second send: %v", err)
+	}
+	body2, _ := io.ReadAll(resp2.Body)
+	resp2.Body.Close()
+	if resp2.StatusCode != 200 {
+		t.Fatalf("second status = %d, body = %s", resp2.StatusCode, body2)
+	}
+	if resp2.Header.Get("Idempotent-Replayed") != "true" {
+		t.Errorf("Idempotent-Replayed = %q, want \"true\"", resp2.Header.Get("Idempotent-Replayed"))
+	}
+	if !bytes.Equal(body1, body2) {
+		t.Errorf("replay body diverged:\nfirst:  %s\nsecond: %s", body1, body2)
+	}
+
+	msgs := smtpDone()
+	if len(msgs) != 1 {
+		t.Errorf("SMTP messages sent = %d, want exactly 1 (replay must not re-hit SMTP)", len(msgs))
+	}
+}
+
+func TestSendEmail_IdempotencyKey_DifferentBodyReturns422(t *testing.T) {
+	serverURL, smtpDone, apiKey := setupVerifiedSendingAgent(t, "idem-mismatch")
+
+	idemKey := "key-mismatch-001"
+	payloadA := `{"to":["alice@example.com"],"subject":"A","body":"first"}`
+	payloadB := `{"to":["alice@example.com"],"subject":"B","body":"different"}`
+
+	resp1, _ := http.DefaultClient.Do(idempotencyRequest(t, "POST", serverURL+"/api/v1/send", payloadA, apiKey, idemKey))
+	if resp1.StatusCode != 200 {
+		t.Fatalf("first status = %d", resp1.StatusCode)
+	}
+	resp1.Body.Close()
+
+	resp2, _ := http.DefaultClient.Do(idempotencyRequest(t, "POST", serverURL+"/api/v1/send", payloadB, apiKey, idemKey))
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusUnprocessableEntity {
+		body, _ := io.ReadAll(resp2.Body)
+		t.Errorf("second status = %d, want 422; body=%s", resp2.StatusCode, body)
+	}
+
+	msgs := smtpDone()
+	if len(msgs) != 1 {
+		t.Errorf("SMTP messages sent = %d, want 1 (mismatch must not trigger second send)", len(msgs))
+	}
+}
+
+func TestSendEmail_IdempotencyKey_TooLongReturns400(t *testing.T) {
+	serverURL, _, apiKey := setupVerifiedSendingAgent(t, "idem-long")
+
+	tooLong := strings.Repeat("x", 300)
+	payload := `{"to":["alice@example.com"],"subject":"x","body":"y"}`
+
+	resp, err := http.DefaultClient.Do(idempotencyRequest(t, "POST", serverURL+"/api/v1/send", payload, apiKey, tooLong))
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, want 400; body=%s", resp.StatusCode, body)
+	}
+}
+
+func TestSendEmail_NoIdempotencyKey_BehavesAsBefore(t *testing.T) {
+	// Existing /send tests cover the no-header path implicitly; this
+	// pins down that wiring the idempotency store has not introduced
+	// a regression for plain POSTs that omit the header.
+	serverURL, smtpDone, apiKey := setupVerifiedSendingAgent(t, "idem-none")
+
+	payload := `{"to":["alice@example.com"],"subject":"x","body":"y"}`
+
+	for i := 0; i < 2; i++ {
+		resp, err := http.DefaultClient.Do(idempotencyRequest(t, "POST", serverURL+"/api/v1/send", payload, apiKey, ""))
+		if err != nil {
+			t.Fatalf("send %d: %v", i, err)
+		}
+		if resp.StatusCode != 200 {
+			t.Fatalf("send %d status = %d", i, resp.StatusCode)
+		}
+		var sendResp map[string]string
+		_ = json.NewDecoder(resp.Body).Decode(&sendResp)
+		resp.Body.Close()
+		if sendResp["message_id"] == "" {
+			t.Errorf("send %d: missing message_id", i)
+		}
+	}
+
+	msgs := smtpDone()
+	if len(msgs) != 2 {
+		t.Errorf("SMTP messages sent = %d, want 2 (no header => no dedup)", len(msgs))
+	}
+}
+
+func TestSendEmail_IdempotencyKey_ConcurrentSameKey_OnlyOneSends(t *testing.T) {
+	serverURL, smtpDone, apiKey := setupVerifiedSendingAgent(t, "idem-conc")
+
+	payload := `{"to":["alice@example.com"],"subject":"x","body":"y"}`
+	const idemKey = "key-conc-001"
+	const N = 6
+
+	var (
+		wg          sync.WaitGroup
+		mu          sync.Mutex
+		twoXX       int
+		conflicts   int
+		others      int
+	)
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			resp, err := http.DefaultClient.Do(idempotencyRequest(t, "POST", serverURL+"/api/v1/send", payload, apiKey, idemKey))
+			if err != nil {
+				t.Errorf("request error: %v", err)
+				return
+			}
+			defer resp.Body.Close()
+			mu.Lock()
+			defer mu.Unlock()
+			switch {
+			case resp.StatusCode >= 200 && resp.StatusCode < 300:
+				twoXX++
+			case resp.StatusCode == http.StatusConflict:
+				conflicts++
+			default:
+				others++
+			}
+		}()
+	}
+	wg.Wait()
+
+	// All N callers should either succeed (the original + any replays
+	// after Complete) or get 409 while the original is in-flight; no
+	// 5xx, no 422.
+	if others != 0 {
+		t.Errorf("unexpected non-2xx/non-409 responses = %d", others)
+	}
+	if twoXX+conflicts != N {
+		t.Errorf("twoXX(%d) + conflicts(%d) != N(%d)", twoXX, conflicts, N)
+	}
+
+	msgs := smtpDone()
+	if len(msgs) != 1 {
+		t.Errorf("SMTP messages sent = %d, want exactly 1 across %d concurrent same-key requests", len(msgs), N)
+	}
+}
+
+func TestReplyToMessage_IdempotencyKey_DuplicateReplays(t *testing.T) {
+	srv, store, _, smtpDone := setupAPIWithSMTP(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "idem-reply-owner@example.com", "Owner", "google-idem-reply")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "idem-reply-key", nil)
+	_, _ = store.ClaimOrCreateDomain(ctx, "idem-reply.example.com", user.ID)
+	_ = store.VerifyDomain(ctx, "idem-reply.example.com", user.ID)
+	a, _ := store.CreateAgent(ctx, "agent@idem-reply.example.com", "idem-reply.example.com", "", "https://example.com/webhook", "", user.ID)
+
+	// Synthesize an inbound to reply to.
+	inboundRaw := []byte("From: sender@example.com\r\nTo: agent@idem-reply.example.com\r\nMessage-ID: <m1@example.com>\r\nSubject: Hello\r\n\r\nHello body\r\n")
+	inMsg, err := store.CreateInboundMessage(ctx, "", a.ID, "sender@example.com", "agent@idem-reply.example.com", "<m1@example.com>", "Hello", "", "", inboundRaw, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateInboundMessage: %v", err)
+	}
+
+	url := srv.URL + "/api/v1/agents/agent@idem-reply.example.com/messages/" + inMsg.ID + "/reply"
+	payload := `{"body":"my reply"}`
+	idemKey := "key-reply-001"
+
+	resp1, _ := http.DefaultClient.Do(idempotencyRequest(t, "POST", url, payload, apiKeyObj.PlaintextKey, idemKey))
+	body1, _ := io.ReadAll(resp1.Body)
+	resp1.Body.Close()
+	if resp1.StatusCode != 200 {
+		t.Fatalf("first status = %d, body=%s", resp1.StatusCode, body1)
+	}
+
+	resp2, _ := http.DefaultClient.Do(idempotencyRequest(t, "POST", url, payload, apiKeyObj.PlaintextKey, idemKey))
+	body2, _ := io.ReadAll(resp2.Body)
+	resp2.Body.Close()
+	if resp2.StatusCode != 200 {
+		t.Fatalf("second status = %d, body=%s", resp2.StatusCode, body2)
+	}
+	if resp2.Header.Get("Idempotent-Replayed") != "true" {
+		t.Errorf("Idempotent-Replayed = %q, want \"true\"", resp2.Header.Get("Idempotent-Replayed"))
+	}
+	if !bytes.Equal(body1, body2) {
+		t.Errorf("replay body diverged")
+	}
+
+	msgs := smtpDone()
+	if len(msgs) != 1 {
+		t.Errorf("SMTP messages sent = %d, want 1 (reply replay must not re-send)", len(msgs))
+	}
+}
+
+func TestSendEmail_IdempotencyKey_ClientErrorReleasesKey(t *testing.T) {
+	// 4xx response must release the key so the caller can retry with a
+	// corrected payload using the SAME key (rather than being locked
+	// into the bad-response cache for 24h).
+	serverURL, smtpDone, apiKey := setupVerifiedSendingAgent(t, "idem-4xx")
+
+	idemKey := "key-4xx-001"
+	// Missing subject + body — handler returns 400.
+	bad := `{"to":["alice@example.com"]}`
+	good := `{"to":["alice@example.com"],"subject":"hi","body":"ok"}`
+
+	resp1, _ := http.DefaultClient.Do(idempotencyRequest(t, "POST", serverURL+"/api/v1/send", bad, apiKey, idemKey))
+	resp1.Body.Close()
+	if resp1.StatusCode != http.StatusBadRequest {
+		t.Fatalf("first status = %d, want 400", resp1.StatusCode)
+	}
+
+	// Same key, valid payload now — should succeed (key was Released).
+	resp2, _ := http.DefaultClient.Do(idempotencyRequest(t, "POST", serverURL+"/api/v1/send", good, apiKey, idemKey))
+	resp2.Body.Close()
+	if resp2.StatusCode != 200 {
+		t.Errorf("second status = %d, want 200 (key should have been released after 400)", resp2.StatusCode)
+	}
+
+	msgs := smtpDone()
+	if len(msgs) != 1 {
+		t.Errorf("SMTP messages sent = %d, want 1 (only the second call should send)", len(msgs))
+	}
+}

--- a/internal/agent/idempotency_guard.go
+++ b/internal/agent/idempotency_guard.go
@@ -24,7 +24,8 @@ import (
 //     capturing wrapper around w that records the response so the
 //     deferred `finalize()` can persist it. `finalize` MUST be deferred
 //     by the caller — it decides between Complete and Release based on
-//     the observed status code.
+//     the observed status code AND whether the handler signalled that
+//     a non-recoverable side effect committed (see markSideEffectCommitted).
 //
 // On any internal error from the store (e.g. a transient DB blip),
 // the guard fails open: the request proceeds without idempotency,
@@ -36,12 +37,20 @@ import (
 // Status-code policy for finalize:
 //   - 2xx → Complete (cache for TTL). 202 (HITL held) included; a
 //     retry must not create a second pending_approval row.
-//   - 4xx or 5xx → Release. Client errors mean the caller can fix
-//     and retry; 5xx is treated as "side effect uncertain" — better
-//     to risk a double-send than lock the caller out of recovery
-//     for the next TTL window. The HITL-approval path (slice 2,
-//     send_attempts) layers a separate exactly-once gate for that
-//     code path.
+//   - 4xx or 5xx, side effect NOT committed → Release. Client errors
+//     mean the caller can fix and retry; an early server error before
+//     the side effect happened means the caller can safely retry too.
+//   - 4xx or 5xx, side effect committed → Complete (cache the error
+//     response). Once the upstream send (or the loopback row writes)
+//     accepted, we're locked in; a late server error must not free
+//     the key for a retry that would double-send. Handlers signal
+//     this via markSideEffectCommitted(w) after the irreversible
+//     step succeeded.
+//
+// The signal is in-band on the capturingWriter (rather than a return
+// from idempotencyGuard) so that no-header handlers and replay paths
+// can ignore it entirely — the helper is a no-op when the writer
+// isn't a capturing wrapper.
 func (a *API) idempotencyGuard(w http.ResponseWriter, r *http.Request, userID string, bodyBytes []byte) (replayed bool, out http.ResponseWriter, finalize func()) {
 	noop := func() {}
 
@@ -90,24 +99,57 @@ func (a *API) idempotencyGuard(w http.ResponseWriter, r *http.Request, userID st
 			if code == 0 {
 				code = http.StatusOK
 			}
-			if code >= 400 {
-				if err := a.idempotency.Release(r.Context(), userID, key); err != nil {
-					log.Printf("[idempotency] release error: %v", err)
+			if shouldCacheResponse(code, cap.sideEffectCommitted) {
+				if err := a.idempotency.Complete(r.Context(), userID, key, idempotency.CachedResponse{
+					StatusCode:  code,
+					ContentType: cap.Header().Get("Content-Type"),
+					Body:        cap.body.Bytes(),
+				}); err != nil {
+					log.Printf("[idempotency] complete error: %v", err)
 				}
 				return
 			}
-			if err := a.idempotency.Complete(r.Context(), userID, key, idempotency.CachedResponse{
-				StatusCode:  code,
-				ContentType: cap.Header().Get("Content-Type"),
-				Body:        cap.body.Bytes(),
-			}); err != nil {
-				log.Printf("[idempotency] complete error: %v", err)
+			if err := a.idempotency.Release(r.Context(), userID, key); err != nil {
+				log.Printf("[idempotency] release error: %v", err)
 			}
 		}
 	}
 
 	// Unreachable in practice; satisfy the compiler with a no-op pass-through.
 	return false, w, noop
+}
+
+// shouldCacheResponse decides whether finalize should Complete (cache
+// the response) or Release the claim. Pulled out as a pure function
+// so the policy can be unit-tested without standing up the full
+// HTTP + DB stack.
+//
+// Rule: cache on 2xx/3xx always; cache on 4xx/5xx ONLY if the handler
+// signalled that an irreversible side effect committed (i.e. the
+// upstream send accepted, or the loopback DB rows landed). Otherwise
+// Release so the caller can retry with the same key.
+func shouldCacheResponse(statusCode int, sideEffectCommitted bool) bool {
+	if statusCode < 400 {
+		return true
+	}
+	return sideEffectCommitted
+}
+
+// markSideEffectCommitted is called by handlers immediately after an
+// irreversible action succeeds (an upstream SMTP/SES accept, a
+// loopback row write) and BEFORE the response is written. It tells
+// finalize to cache the eventual response no matter what status
+// code the handler ends up writing — late panics, write errors, or
+// follow-up DB writes that fail post-send must NOT release the
+// key, because doing so would let a retry double-send.
+//
+// No-op when w isn't a capturingWriter (no-header path / replay
+// path), so handlers can call it unconditionally without branching
+// on whether idempotency is active for this request.
+func markSideEffectCommitted(w http.ResponseWriter) {
+	if cw, ok := w.(*capturingWriter); ok {
+		cw.sideEffectCommitted = true
+	}
 }
 
 // capturingWriter is a minimal http.ResponseWriter wrapper that
@@ -120,8 +162,9 @@ func (a *API) idempotencyGuard(w http.ResponseWriter, r *http.Request, userID st
 // single goroutine, matching the http server contract.
 type capturingWriter struct {
 	http.ResponseWriter
-	statusCode int
-	body       bytes.Buffer
+	statusCode          int
+	body                bytes.Buffer
+	sideEffectCommitted bool
 }
 
 func (c *capturingWriter) WriteHeader(code int) {

--- a/internal/agent/idempotency_guard.go
+++ b/internal/agent/idempotency_guard.go
@@ -1,0 +1,140 @@
+package agent
+
+import (
+	"bytes"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/Mnexa-AI/e2a/internal/idempotency"
+)
+
+// idempotencyGuard runs the Idempotency-Key handshake at the start of a
+// side-effectful POST handler. The transport contract is Stripe-style:
+//
+//   - No header → transparent no-op. The handler runs unchanged.
+//   - Header set + cached completed response (same body) → server writes
+//     the cached response verbatim and the caller MUST return from the
+//     handler. Detected via the returned `replayed=true`.
+//   - Header set + cached completed response (different body) → 422.
+//     replayed=true; caller returns.
+//   - Header set + another request currently in-flight → 409.
+//     replayed=true; caller returns.
+//   - Header set + claim acquired → handler proceeds. `out` is a
+//     capturing wrapper around w that records the response so the
+//     deferred `finalize()` can persist it. `finalize` MUST be deferred
+//     by the caller — it decides between Complete and Release based on
+//     the observed status code.
+//
+// On any internal error from the store (e.g. a transient DB blip),
+// the guard fails open: the request proceeds without idempotency,
+// the operator gets a log line, and no claim is recorded. The
+// alternative — failing the request closed — would conflate
+// idempotency-store outages with /send outages and make the system
+// more brittle than the no-header baseline.
+//
+// Status-code policy for finalize:
+//   - 2xx → Complete (cache for TTL). 202 (HITL held) included; a
+//     retry must not create a second pending_approval row.
+//   - 4xx or 5xx → Release. Client errors mean the caller can fix
+//     and retry; 5xx is treated as "side effect uncertain" — better
+//     to risk a double-send than lock the caller out of recovery
+//     for the next TTL window. The HITL-approval path (slice 2,
+//     send_attempts) layers a separate exactly-once gate for that
+//     code path.
+func (a *API) idempotencyGuard(w http.ResponseWriter, r *http.Request, userID string, bodyBytes []byte) (replayed bool, out http.ResponseWriter, finalize func()) {
+	noop := func() {}
+
+	if a.idempotency == nil {
+		return false, w, noop
+	}
+	key := strings.TrimSpace(r.Header.Get("Idempotency-Key"))
+	if key == "" {
+		return false, w, noop
+	}
+	if len(key) > idempotency.MaxKeyLength {
+		http.Error(w, "Idempotency-Key exceeds max length", http.StatusBadRequest)
+		return true, nil, nil
+	}
+
+	res, err := a.idempotency.Claim(r.Context(), userID, key, r.URL.Path, idempotency.HashRequest(r.URL.Path, bodyBytes))
+	if err != nil {
+		log.Printf("[idempotency] claim error: %v (failing open)", err)
+		return false, w, noop
+	}
+
+	switch res.Outcome {
+	case idempotency.OutcomeReplay:
+		if res.Cached.ContentType != "" {
+			w.Header().Set("Content-Type", res.Cached.ContentType)
+		}
+		w.Header().Set("Idempotent-Replayed", "true")
+		w.WriteHeader(res.Cached.StatusCode)
+		_, _ = w.Write(res.Cached.Body)
+		return true, nil, nil
+
+	case idempotency.OutcomeMismatch:
+		http.Error(w, "Idempotency-Key reused with a different request body", http.StatusUnprocessableEntity)
+		return true, nil, nil
+
+	case idempotency.OutcomeInFlight:
+		http.Error(w, "another request with this Idempotency-Key is in progress", http.StatusConflict)
+		return true, nil, nil
+
+	case idempotency.OutcomeAcquired:
+		cap := &capturingWriter{ResponseWriter: w}
+		return false, cap, func() {
+			// WriteHeader may not have been called explicitly (Go's
+			// http package implicitly writes 200 on first Write).
+			code := cap.statusCode
+			if code == 0 {
+				code = http.StatusOK
+			}
+			if code >= 400 {
+				if err := a.idempotency.Release(r.Context(), userID, key); err != nil {
+					log.Printf("[idempotency] release error: %v", err)
+				}
+				return
+			}
+			if err := a.idempotency.Complete(r.Context(), userID, key, idempotency.CachedResponse{
+				StatusCode:  code,
+				ContentType: cap.Header().Get("Content-Type"),
+				Body:        cap.body.Bytes(),
+			}); err != nil {
+				log.Printf("[idempotency] complete error: %v", err)
+			}
+		}
+	}
+
+	// Unreachable in practice; satisfy the compiler with a no-op pass-through.
+	return false, w, noop
+}
+
+// capturingWriter is a minimal http.ResponseWriter wrapper that
+// records the outgoing status code and body so the idempotency layer
+// can cache the response for replay. It still forwards everything to
+// the underlying writer, so the live client receives the response
+// unchanged.
+//
+// Not safe for concurrent use; handlers write their response from a
+// single goroutine, matching the http server contract.
+type capturingWriter struct {
+	http.ResponseWriter
+	statusCode int
+	body       bytes.Buffer
+}
+
+func (c *capturingWriter) WriteHeader(code int) {
+	if c.statusCode == 0 {
+		c.statusCode = code
+	}
+	c.ResponseWriter.WriteHeader(code)
+}
+
+func (c *capturingWriter) Write(b []byte) (int, error) {
+	if c.statusCode == 0 {
+		c.statusCode = http.StatusOK
+	}
+	c.body.Write(b)
+	return c.ResponseWriter.Write(b)
+}

--- a/internal/agent/idempotency_guard_internal_test.go
+++ b/internal/agent/idempotency_guard_internal_test.go
@@ -1,0 +1,69 @@
+package agent
+
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+// shouldCacheResponse is the pure policy function the guard uses to
+// decide between Complete (cache) and Release (free for retry).
+// Exhaustive matrix.
+func TestShouldCacheResponse(t *testing.T) {
+	cases := []struct {
+		name      string
+		status    int
+		sideEff   bool
+		wantCache bool
+	}{
+		{"200 + no side effect → cache", 200, false, true},
+		{"202 (HITL held) + no side effect → cache", 202, false, true},
+		{"302 redirect + no side effect → cache", 302, false, true},
+		{"400 + no side effect → release", 400, false, false},
+		{"422 + no side effect → release", 422, false, false},
+		{"500 + no side effect → release", 500, false, false},
+		{"503 + no side effect → release", 503, false, false},
+
+		// The new behavior: once the side effect committed, even error
+		// responses must be cached so a retry can't re-trigger the
+		// side effect. The 500 here is from a panic recovery /
+		// post-send failure; we MUST NOT release.
+		{"200 + side effect committed → cache", 200, true, true},
+		{"400 + side effect committed → cache (defensive)", 400, true, true},
+		{"500 + side effect committed → cache (no double-send)", 500, true, true},
+		{"503 + side effect committed → cache (no double-send)", 503, true, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := shouldCacheResponse(c.status, c.sideEff); got != c.wantCache {
+				t.Errorf("shouldCacheResponse(%d, %v) = %v, want %v", c.status, c.sideEff, got, c.wantCache)
+			}
+		})
+	}
+}
+
+// markSideEffectCommitted is a no-op when the writer isn't a
+// capturingWriter (no-header path or replay path). Verify it doesn't
+// panic against a bare http.ResponseWriter and doesn't somehow leave
+// state behind.
+func TestMarkSideEffectCommitted_NoopOnBareWriter(t *testing.T) {
+	rec := httptest.NewRecorder()
+	markSideEffectCommitted(rec)
+	if rec.Code != 200 {
+		t.Errorf("recorder Code = %d, want 200", rec.Code)
+	}
+	if rec.Body.Len() != 0 {
+		t.Errorf("recorder Body changed: %q", rec.Body.String())
+	}
+}
+
+// markSideEffectCommitted DOES flip the flag on the capturing wrapper.
+func TestMarkSideEffectCommitted_FlipsFlagOnCapturingWriter(t *testing.T) {
+	cw := &capturingWriter{ResponseWriter: httptest.NewRecorder()}
+	if cw.sideEffectCommitted {
+		t.Fatal("freshly-constructed capturingWriter should have sideEffectCommitted=false")
+	}
+	markSideEffectCommitted(cw)
+	if !cw.sideEffectCommitted {
+		t.Error("sideEffectCommitted not set by markSideEffectCommitted")
+	}
+}

--- a/internal/agent/idempotency_sideeffect_test.go
+++ b/internal/agent/idempotency_sideeffect_test.go
@@ -1,0 +1,283 @@
+package agent_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/mux"
+
+	"github.com/Mnexa-AI/e2a/internal/agent"
+	"github.com/Mnexa-AI/e2a/internal/config"
+	"github.com/Mnexa-AI/e2a/internal/idempotency"
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/outbound"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+	"github.com/Mnexa-AI/e2a/internal/usage"
+)
+
+// Integration tests for the side-effect-committed caching policy on
+// /api/v1/send and /api/v1/agents/{email}/messages/{id}/reply.
+//
+// The standard handlers don't have a natural code path to "5xx after
+// SES already accepted" — that scenario is a panic recovery, late
+// context cancel, or a follow-up DB write that returned 5xx. To
+// exercise the guard's caching decision in this branch without
+// fragile timing tricks, these tests register their own synthetic
+// handlers using the test-only shims in export_test.go.
+
+// newAPIWithIdempotency mirrors setupAPI from api_test.go but returns
+// the API value directly (rather than the bound httptest.Server) so a
+// test can register its own routes against the same store + guard.
+func newAPIWithIdempotency(t *testing.T) (*agent.API, *identity.Store, string) {
+	t.Helper()
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	smtpRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{})
+	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
+	noopUsage := usage.NewNoopUsageTracker()
+	api := agent.NewAPI(store, sender, smtpRelay, nil, noopUsage, "e2a.dev", "test.e2a.dev", "agents.e2a.dev", "", false)
+	api.SetIdempotencyStore(idempotency.NewStore(pool))
+
+	ctx := context.Background()
+	user, err := store.CreateOrGetUser(ctx, "guard-sideeffect-owner@example.com", "Owner", "google-guard-sideeffect-"+t.Name())
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	key, err := store.CreateAPIKey(ctx, user.ID, "guard-sideeffect-key", nil)
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+	return api, store, key.PlaintextKey
+}
+
+func TestIdempotencyGuard_5xxAfterSideEffect_CachesResponse(t *testing.T) {
+	api, _, apiKey := newAPIWithIdempotency(t)
+
+	var handlerCalls int
+	mux := http.NewServeMux()
+	mux.HandleFunc("/test/late-5xx", func(w http.ResponseWriter, r *http.Request) {
+		uid, err := api.AuthenticateUserForTest(r)
+		if err != nil {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		bodyBytes, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 1<<20))
+		if err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		replayed, captureW, finalize := api.IdempotencyGuardForTest(w, r, uid, bodyBytes)
+		if replayed {
+			return
+		}
+		defer finalize()
+		w = captureW
+
+		// Simulate "SES accepted the message" / "loopback rows
+		// written" — the irreversible step.
+		handlerCalls++
+		agent.MarkSideEffectCommittedForTest(w)
+
+		// Simulate a late failure post-side-effect.
+		http.Error(w, "simulated late failure", http.StatusInternalServerError)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	payload := `{"hello":"world"}`
+	idemKey := "key-5xx-cache-001"
+
+	send := func(label string) (status int, body []byte, replayedHdr string) {
+		t.Helper()
+		req, _ := http.NewRequest("POST", server.URL+"/test/late-5xx", strings.NewReader(payload))
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+		req.Header.Set("Idempotency-Key", idemKey)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s: %v", label, err)
+		}
+		defer resp.Body.Close()
+		b, _ := io.ReadAll(resp.Body)
+		return resp.StatusCode, b, resp.Header.Get("Idempotent-Replayed")
+	}
+
+	status1, body1, replayed1 := send("first")
+	if status1 != http.StatusInternalServerError {
+		t.Fatalf("first status = %d, want 500", status1)
+	}
+	if replayed1 != "" {
+		t.Errorf("first response unexpectedly marked replayed: %q", replayed1)
+	}
+
+	// Second call with same key + same body MUST replay the cached
+	// 500 — the handler body MUST NOT run again. This is the
+	// double-send protection for the immediate /send and /reply
+	// paths: a 5xx coming from anywhere AFTER the upstream send
+	// accepted must lock the caller into the cached error rather
+	// than letting them retry blindly.
+	status2, body2, replayed2 := send("second")
+	if status2 != http.StatusInternalServerError {
+		t.Fatalf("second status = %d, want 500 (cached)", status2)
+	}
+	if replayed2 != "true" {
+		t.Errorf("second response Idempotent-Replayed = %q, want \"true\"", replayed2)
+	}
+	if !bytes.Equal(body1, body2) {
+		t.Errorf("cached response diverged:\nfirst:  %q\nsecond: %q", body1, body2)
+	}
+	if handlerCalls != 1 {
+		t.Errorf("handler ran %d time(s), want exactly 1 (replay must not re-invoke)", handlerCalls)
+	}
+}
+
+// Negative case: when the handler hits a 5xx BEFORE the side effect
+// committed (e.g. upstream send error, early validation), the key
+// must be Released so a retry with the same key can succeed.
+// This is the existing Release-on-error behavior — verifying it
+// still holds when the side-effect flag is NOT flipped.
+func TestIdempotencyGuard_5xxWithoutSideEffect_ReleasesKey(t *testing.T) {
+	api, _, apiKey := newAPIWithIdempotency(t)
+
+	var handlerCalls int
+	failFirstCall := true
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/test/early-5xx", func(w http.ResponseWriter, r *http.Request) {
+		uid, err := api.AuthenticateUserForTest(r)
+		if err != nil {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		bodyBytes, _ := io.ReadAll(http.MaxBytesReader(w, r.Body, 1<<20))
+		replayed, captureW, finalize := api.IdempotencyGuardForTest(w, r, uid, bodyBytes)
+		if replayed {
+			return
+		}
+		defer finalize()
+		w = captureW
+
+		handlerCalls++
+		if failFirstCall {
+			// Simulate an EARLY failure — upstream send rejected, or
+			// a validation error after the body decode. NO side
+			// effect committed yet.
+			http.Error(w, "simulated upstream failure", http.StatusInternalServerError)
+			return
+		}
+		agent.MarkSideEffectCommittedForTest(w)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	send := func(label string) int {
+		t.Helper()
+		req, _ := http.NewRequest("POST", server.URL+"/test/early-5xx", strings.NewReader(`{"hello":"world"}`))
+		req.Header.Set("Authorization", "Bearer "+apiKey)
+		req.Header.Set("Idempotency-Key", "key-5xx-release-001")
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s: %v", label, err)
+		}
+		resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	if got := send("first"); got != http.StatusInternalServerError {
+		t.Fatalf("first status = %d, want 500", got)
+	}
+
+	// Now allow the handler to succeed. Retry with the SAME key —
+	// must be accepted because the first 5xx released the slot.
+	failFirstCall = false
+	if got := send("second"); got != http.StatusOK {
+		t.Fatalf("second status = %d, want 200 (key should have been released after first 5xx)", got)
+	}
+	if handlerCalls != 2 {
+		t.Errorf("handler ran %d time(s), want exactly 2 (retry must be allowed)", handlerCalls)
+	}
+}
+
+// End-to-end on the real /api/v1/send path: SES error → handler
+// returns 5xx → key released → retry allowed. Exercises the real
+// handleSendEmail wiring rather than a synthetic harness, to verify
+// markSideEffectCommitted is positioned correctly (it must NOT
+// already have fired by the time sender.Send errors).
+func TestSendEmail_IdempotencyKey_SenderErrorReleasesKey(t *testing.T) {
+	// Point the outbound relay at an unreachable address so
+	// sender.Send returns an error without ever accepting the
+	// message at the SMTP layer.
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	smtpRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{
+		Host: "127.0.0.1",
+		Port: 1, // reserved; will fail to connect
+	})
+	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
+	noopUsage := usage.NewNoopUsageTracker()
+	api := agent.NewAPI(store, sender, smtpRelay, nil, noopUsage, "e2a.dev", "test.e2a.dev", "agents.e2a.dev", "", false)
+	api.SetIdempotencyStore(idempotency.NewStore(pool))
+
+	ctx := context.Background()
+	user, _ := store.CreateOrGetUser(ctx, "send-err-owner@example.com", "Owner", "google-send-err")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "send-err-key", nil)
+	_, _ = store.ClaimOrCreateDomain(ctx, "send-err.example.com", user.ID)
+	_ = store.VerifyDomain(ctx, "send-err.example.com", user.ID)
+	_, _ = store.CreateAgent(ctx, "agent@send-err.example.com", "send-err.example.com", "", "https://example.com/webhook", "", user.ID)
+
+	router := mux.NewRouter()
+	api.RegisterRoutes(router)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	payload := `{"to":["alice@example.com"],"subject":"x","body":"y"}`
+	idemKey := "key-sender-err-001"
+
+	post := func(label string) int {
+		t.Helper()
+		req, _ := http.NewRequest("POST", srv.URL+"/api/v1/send", strings.NewReader(payload))
+		req.Header.Set("Authorization", "Bearer "+apiKeyObj.PlaintextKey)
+		req.Header.Set("Idempotency-Key", idemKey)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s: %v", label, err)
+		}
+		resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	// First call: SMTP relay unreachable → handleSendEmail returns 500.
+	if got := post("first"); got != http.StatusInternalServerError {
+		t.Fatalf("first status = %d, want 500", got)
+	}
+
+	// Second call with same key — must be allowed (released, not
+	// cached) because no SES side effect committed. Will also return
+	// 500 because the relay is still unreachable, but the handler
+	// MUST be invoked rather than serving a cached 500.
+	if got := post("second"); got != http.StatusInternalServerError {
+		t.Fatalf("second status = %d, want 500 (relay still unreachable)", got)
+	}
+	// The Idempotent-Replayed header should NOT be set on the
+	// second call — that would indicate cache rather than re-run.
+	req3, _ := http.NewRequest("POST", srv.URL+"/api/v1/send", strings.NewReader(payload))
+	req3.Header.Set("Authorization", "Bearer "+apiKeyObj.PlaintextKey)
+	req3.Header.Set("Idempotency-Key", idemKey)
+	req3.Header.Set("Content-Type", "application/json")
+	resp3, _ := http.DefaultClient.Do(req3)
+	defer resp3.Body.Close()
+	if resp3.Header.Get("Idempotent-Replayed") == "true" {
+		t.Error("Idempotent-Replayed=true on 5xx retry — key should have been released, not cached")
+	}
+}

--- a/internal/hitlworker/worker.go
+++ b/internal/hitlworker/worker.go
@@ -151,6 +151,17 @@ func (w *Worker) autoApprove(ctx context.Context, c identity.ExpirationCandidate
 		if err == identity.ErrNotPendingApproval {
 			return
 		}
+		// ErrSendInProgress means another worker is mid-send for this
+		// row (send_attempts is 'attempting' and not yet stale). Don't
+		// auto-reject — that would invert the operator-configured
+		// expiration_action="approve" policy by terminally rejecting a
+		// message that may have actually been sent. Skip silently; the
+		// next poll either sees status='sent' (the in-flight worker
+		// committed) or the row goes stale (10min window) and another
+		// worker takes over.
+		if err == identity.ErrSendInProgress {
+			return
+		}
 		log.Printf("[hitl-worker] auto-approve %s: send failed: %v", c.MessageID, err)
 		w.autoReject(ctx, c.MessageID, fmt.Sprintf("auto-approve send failed: %v", err))
 		return

--- a/internal/idempotency/store.go
+++ b/internal/idempotency/store.go
@@ -1,0 +1,293 @@
+// Package idempotency implements the storage backing the
+// Idempotency-Key header on the outbound send endpoints.
+//
+// Stripe-style semantics:
+//
+//   - Caller sends `Idempotency-Key: <string>` on a POST that has a
+//     side-effect (creating an outbound email).
+//   - Server scopes the key by (user_id, key) and remembers it for
+//     [TTL].
+//   - Same key + same request body hash → replay the cached response;
+//     do NOT redo the side effect.
+//   - Same key + different request body hash → 422 (mismatch).
+//   - Same key, prior request still in-flight → 409.
+//
+// Why (user_id, key) and not (api_key_id, key): the request path's
+// authenticator (internal/agent.API.authenticateUser) returns only the
+// owning user, and threading the credential id through every handler
+// is invasive. UUIDv4 collisions across one user's keys are
+// mathematically negligible, and the body-hash check catches the
+// pathological collision case explicitly with a 422. Stripe scopes
+// at the account level for the same reason.
+package idempotency
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// MaxKeyLength caps Idempotency-Key header values. Past this the
+// header is rejected at the request boundary (400). Matches the
+// upper-bound Stripe documents.
+const MaxKeyLength = 255
+
+// TTL is how long a completed row stays cached (and continues
+// rejecting body-mismatched replays) before the sweep removes it.
+const TTL = 24 * time.Hour
+
+// StaleClaimWindow is the age past which an in_progress row is
+// treated as the leftover of a crashed handler and may be taken over
+// by the next caller. Bounded above by SMTPRelay's worst-case retry
+// envelope (~6.5min) but kept tighter so legitimate stalls produce a
+// loud 409 to the second caller rather than silently double-sending.
+const StaleClaimWindow = 5 * time.Minute
+
+// SweepInterval is the cadence the cmd/e2a hourly cleanup loop uses
+// when invoking Sweep. Exposed as a constant so the loop and the
+// docstring stay consistent.
+const SweepInterval = 1 * time.Hour
+
+// ClaimOutcome describes what happened when a caller tried to claim
+// (user_id, key) for a fresh request.
+type ClaimOutcome int
+
+const (
+	// OutcomeAcquired — caller owns the row and MUST follow up with
+	// Complete (success path) or Release (caller-side abort that
+	// did not produce a side-effect, e.g. early validation failure).
+	OutcomeAcquired ClaimOutcome = iota
+	// OutcomeReplay — a previous request with this key completed
+	// successfully and the body hash matches. Serve the cached
+	// response verbatim.
+	OutcomeReplay
+	// OutcomeMismatch — a previous completed request used this key
+	// with a different body. Refuse with 422.
+	OutcomeMismatch
+	// OutcomeInFlight — a concurrent request with this key is still
+	// being processed (and the row is not stale). Refuse with 409.
+	OutcomeInFlight
+)
+
+// CachedResponse is what the server replays for an OutcomeReplay.
+// Content-Type is captured separately so the replay is wire-faithful.
+type CachedResponse struct {
+	StatusCode  int
+	ContentType string
+	Body        []byte
+}
+
+// ClaimResult bundles the outcome with the cached response when the
+// outcome is OutcomeReplay. Other outcomes leave Cached zero-valued.
+type ClaimResult struct {
+	Outcome ClaimOutcome
+	Cached  CachedResponse
+}
+
+// Store is the postgres-backed idempotency store.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+// NewStore wraps a pgx pool. The pool must already have the schema
+// from migrations/015_idempotency_and_send_attempts.sql applied.
+func NewStore(pool *pgxpool.Pool) *Store {
+	return &Store{pool: pool}
+}
+
+// HashBody returns the sha256 hex of the raw request body. Exposed so
+// callers (the HTTP layer) can compute it once from the bytes they
+// already read, rather than re-reading or re-encoding.
+func HashBody(body []byte) string {
+	sum := sha256.Sum256(body)
+	return hex.EncodeToString(sum[:])
+}
+
+// HashRequest mixes the request path into the body hash so the same
+// Idempotency-Key cannot accidentally replay a cached response across
+// different routes (e.g. reusing a key set on a reply to message A
+// while replying to message B). The path is included on its own line
+// before the body so the hash is unambiguous about where path ends
+// and body begins.
+//
+// Callers compute this once with the raw body bytes they already
+// have and pass the result to Store.Claim.
+func HashRequest(path string, body []byte) string {
+	h := sha256.New()
+	h.Write([]byte(path))
+	h.Write([]byte{'\n'})
+	h.Write(body)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// Claim atomically reserves (userID, key) for the caller. The outcome
+// determines what the HTTP layer should do next:
+//
+//   - OutcomeAcquired → run the side effect, then Complete on success
+//     or Release on caller-side abort.
+//   - OutcomeReplay   → write Cached to the response, do NOT re-run
+//     the side effect.
+//   - OutcomeMismatch → respond 422.
+//   - OutcomeInFlight → respond 409.
+//
+// path is the request route (e.g. "/api/v1/send") and is stored only
+// for diagnostics; it is NOT part of the dedup key, so the same
+// idempotency key cannot be reused across different routes (Stripe
+// documents the same behavior — surfaces caller bugs faster than a
+// silent allow).
+//
+// Concurrency: the claim is decided in a single UPSERT with
+// RETURNING. Two concurrent callers can never both observe
+// OutcomeAcquired because only one of the racing statements has its
+// row materialized in RETURNING — the other either hits the conflict
+// path (DO UPDATE WHERE not stale → row skipped in RETURNING) or, if
+// the row was stale, the takeover serializes on the unique-index
+// lock and the loser sees a non-stale in_progress on its follow-up
+// read.
+func (s *Store) Claim(ctx context.Context, userID, key, path, bodyHash string) (ClaimResult, error) {
+	if userID == "" {
+		return ClaimResult{}, errors.New("idempotency: userID required")
+	}
+	if key == "" {
+		return ClaimResult{}, errors.New("idempotency: key required")
+	}
+
+	staleSecs := int(StaleClaimWindow.Seconds())
+
+	// Atomic claim path. Returns a row iff we own the slot — either as
+	// a fresh INSERT, or as a stale-takeover where the DO UPDATE's
+	// WHERE clause is true. Returns no rows when an existing row
+	// blocks us (completed, or in_progress but not yet stale), in
+	// which case we read the existing row to classify the outcome.
+	var owned int
+	err := s.pool.QueryRow(ctx,
+		`INSERT INTO idempotency_keys (
+		     user_id, key, request_path, request_body_hash,
+		     response_status, response_content_type, response_body,
+		     status, created_at, completed_at
+		 )
+		 VALUES ($1, $2, $3, $4, 0, '', ''::bytea, 'in_progress', now(), NULL)
+		 ON CONFLICT (user_id, key) DO UPDATE
+		    SET request_path          = EXCLUDED.request_path,
+		        request_body_hash     = EXCLUDED.request_body_hash,
+		        response_status       = 0,
+		        response_content_type = '',
+		        response_body         = ''::bytea,
+		        status                = 'in_progress',
+		        created_at            = now(),
+		        completed_at          = NULL
+		  WHERE idempotency_keys.status = 'in_progress'
+		    AND idempotency_keys.created_at < now() - make_interval(secs => $5)
+		 RETURNING 1`,
+		userID, key, path, bodyHash, staleSecs,
+	).Scan(&owned)
+	if err == nil {
+		return ClaimResult{Outcome: OutcomeAcquired}, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return ClaimResult{}, err
+	}
+
+	// Lost the race. Read the existing row to classify.
+	var (
+		gotStatus string
+		gotHash   string
+		gotCode   int
+		gotCT     string
+		gotBody   []byte
+	)
+	err = s.pool.QueryRow(ctx,
+		`SELECT status, request_body_hash, response_status,
+		        response_content_type, response_body
+		   FROM idempotency_keys
+		  WHERE user_id = $1 AND key = $2`,
+		userID, key,
+	).Scan(&gotStatus, &gotHash, &gotCode, &gotCT, &gotBody)
+	if err != nil {
+		// The row has to exist — we just lost a conflict against it.
+		// If pgx.ErrNoRows fires here it means the row was swept
+		// between the UPSERT and this SELECT (a 24-hour-old row
+		// becoming sweep-eligible mid-call, vanishingly unlikely);
+		// treat that as transient and let the caller retry.
+		return ClaimResult{}, err
+	}
+
+	if gotStatus == "in_progress" {
+		return ClaimResult{Outcome: OutcomeInFlight}, nil
+	}
+	// gotStatus == "completed"
+	if gotHash != bodyHash {
+		return ClaimResult{Outcome: OutcomeMismatch}, nil
+	}
+	return ClaimResult{
+		Outcome: OutcomeReplay,
+		Cached: CachedResponse{
+			StatusCode:  gotCode,
+			ContentType: gotCT,
+			Body:        gotBody,
+		},
+	}, nil
+}
+
+// Complete records the response for an OutcomeAcquired claim. After
+// this point any subsequent Claim with the same key either replays
+// (body matches) or 422s (body differs), until the row is swept.
+//
+// Idempotent against double-call: only updates rows still marked
+// in_progress, so a stray re-Complete from a buggy caller cannot
+// overwrite an already-cached response.
+func (s *Store) Complete(ctx context.Context, userID, key string, resp CachedResponse) error {
+	_, err := s.pool.Exec(ctx,
+		`UPDATE idempotency_keys
+		    SET status                = 'completed',
+		        response_status       = $3,
+		        response_content_type = $4,
+		        response_body         = $5,
+		        completed_at          = now()
+		  WHERE user_id = $1 AND key = $2 AND status = 'in_progress'`,
+		userID, key, resp.StatusCode, resp.ContentType, resp.Body,
+	)
+	return err
+}
+
+// Release drops an OutcomeAcquired claim without recording a response.
+// Use when the caller decided not to perform the side effect (e.g.
+// the request failed validation before any external work happened),
+// so the next caller with the same key can try again with a fresh
+// payload rather than getting OutcomeMismatch on the second attempt.
+//
+// Only deletes in_progress rows so it cannot accidentally wipe a
+// completed cache entry.
+func (s *Store) Release(ctx context.Context, userID, key string) error {
+	_, err := s.pool.Exec(ctx,
+		`DELETE FROM idempotency_keys
+		  WHERE user_id = $1 AND key = $2 AND status = 'in_progress'`,
+		userID, key,
+	)
+	return err
+}
+
+// Sweep removes completed rows older than TTL. Returns the count
+// deleted. Wire this into the cmd/e2a hourly cleanup loop.
+//
+// Does NOT delete in_progress rows past StaleClaimWindow on its own —
+// those are taken over by the next Claim via the UPSERT WHERE clause,
+// which keeps the takeover path concentrated in one place (the
+// concurrency model lives in Claim, not split across two functions).
+func (s *Store) Sweep(ctx context.Context) (int64, error) {
+	ttlSecs := int(TTL.Seconds())
+	tag, err := s.pool.Exec(ctx,
+		`DELETE FROM idempotency_keys
+		  WHERE status = 'completed' AND created_at < now() - make_interval(secs => $1)`,
+		ttlSecs,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return tag.RowsAffected(), nil
+}

--- a/internal/idempotency/store_test.go
+++ b/internal/idempotency/store_test.go
@@ -1,0 +1,352 @@
+package idempotency_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Mnexa-AI/e2a/internal/idempotency"
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+)
+
+func newStoreAndUser(t *testing.T) (*idempotency.Store, string, *pgxpool.Pool) {
+	t.Helper()
+	pool := testutil.TestDB(t)
+	identStore := identity.NewStore(pool)
+	u, err := identStore.CreateOrGetUser(context.Background(), "idem-"+t.Name()+"@example.com", "Idem", "google-idem-"+t.Name())
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	return idempotency.NewStore(pool), u.ID, pool
+}
+
+func TestClaim_FreshAcquires(t *testing.T) {
+	store, userID, _ := newStoreAndUser(t)
+	ctx := context.Background()
+
+	res, err := store.Claim(ctx, userID, "key-fresh", "/api/v1/send", idempotency.HashBody([]byte(`{"a":1}`)))
+	if err != nil {
+		t.Fatalf("Claim: %v", err)
+	}
+	if res.Outcome != idempotency.OutcomeAcquired {
+		t.Errorf("Outcome = %d, want OutcomeAcquired", res.Outcome)
+	}
+}
+
+func TestClaim_SameKeySameBodyAfterComplete_Replays(t *testing.T) {
+	store, userID, _ := newStoreAndUser(t)
+	ctx := context.Background()
+
+	body := []byte(`{"to":["a@b.com"],"subject":"x","body":"y"}`)
+	hash := idempotency.HashBody(body)
+
+	first, err := store.Claim(ctx, userID, "key-replay", "/api/v1/send", hash)
+	if err != nil || first.Outcome != idempotency.OutcomeAcquired {
+		t.Fatalf("first claim: outcome=%d err=%v", first.Outcome, err)
+	}
+
+	cached := idempotency.CachedResponse{
+		StatusCode:  200,
+		ContentType: "application/json",
+		Body:        []byte(`{"status":"sent","message_id":"msg_abc"}`),
+	}
+	if err := store.Complete(ctx, userID, "key-replay", cached); err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+
+	second, err := store.Claim(ctx, userID, "key-replay", "/api/v1/send", hash)
+	if err != nil {
+		t.Fatalf("second Claim: %v", err)
+	}
+	if second.Outcome != idempotency.OutcomeReplay {
+		t.Fatalf("Outcome = %d, want OutcomeReplay", second.Outcome)
+	}
+	if second.Cached.StatusCode != cached.StatusCode {
+		t.Errorf("StatusCode = %d, want %d", second.Cached.StatusCode, cached.StatusCode)
+	}
+	if second.Cached.ContentType != cached.ContentType {
+		t.Errorf("ContentType = %q, want %q", second.Cached.ContentType, cached.ContentType)
+	}
+	if string(second.Cached.Body) != string(cached.Body) {
+		t.Errorf("Body = %q, want %q", second.Cached.Body, cached.Body)
+	}
+}
+
+func TestClaim_SameKeyDifferentBody_Mismatches(t *testing.T) {
+	store, userID, _ := newStoreAndUser(t)
+	ctx := context.Background()
+
+	hash1 := idempotency.HashBody([]byte(`{"a":1}`))
+	hash2 := idempotency.HashBody([]byte(`{"a":2}`))
+
+	first, _ := store.Claim(ctx, userID, "key-mismatch", "/api/v1/send", hash1)
+	if first.Outcome != idempotency.OutcomeAcquired {
+		t.Fatalf("first Outcome = %d", first.Outcome)
+	}
+	_ = store.Complete(ctx, userID, "key-mismatch", idempotency.CachedResponse{StatusCode: 200, Body: []byte("ok")})
+
+	second, err := store.Claim(ctx, userID, "key-mismatch", "/api/v1/send", hash2)
+	if err != nil {
+		t.Fatalf("second Claim: %v", err)
+	}
+	if second.Outcome != idempotency.OutcomeMismatch {
+		t.Errorf("Outcome = %d, want OutcomeMismatch", second.Outcome)
+	}
+}
+
+func TestClaim_InFlightDuringActiveClaim(t *testing.T) {
+	store, userID, _ := newStoreAndUser(t)
+	ctx := context.Background()
+
+	hash := idempotency.HashBody([]byte(`{"a":1}`))
+
+	first, _ := store.Claim(ctx, userID, "key-inflight", "/api/v1/send", hash)
+	if first.Outcome != idempotency.OutcomeAcquired {
+		t.Fatalf("first Outcome = %d", first.Outcome)
+	}
+
+	// Same body, but first hasn't completed — second must 409.
+	second, err := store.Claim(ctx, userID, "key-inflight", "/api/v1/send", hash)
+	if err != nil {
+		t.Fatalf("second Claim: %v", err)
+	}
+	if second.Outcome != idempotency.OutcomeInFlight {
+		t.Errorf("Outcome = %d, want OutcomeInFlight", second.Outcome)
+	}
+}
+
+func TestClaim_StaleInProgressIsTakenOver(t *testing.T) {
+	store, userID, pool := newStoreAndUser(t)
+	ctx := context.Background()
+
+	// Acquire a claim, then age it past the stale window by direct UPDATE.
+	first, _ := store.Claim(ctx, userID, "key-stale", "/api/v1/send", idempotency.HashBody([]byte(`{"original":1}`)))
+	if first.Outcome != idempotency.OutcomeAcquired {
+		t.Fatalf("first Outcome = %d", first.Outcome)
+	}
+
+	// Age the in_progress row past StaleClaimWindow.
+	if _, err := pool.Exec(ctx, `UPDATE idempotency_keys SET created_at = now() - $2::interval WHERE user_id = $1 AND key = 'key-stale'`,
+		userID, (idempotency.StaleClaimWindow + time.Minute).String()); err != nil {
+		t.Fatalf("age row: %v", err)
+	}
+
+	// Second caller, possibly with a different body, takes over.
+	second, err := store.Claim(ctx, userID, "key-stale", "/api/v1/send", idempotency.HashBody([]byte(`{"replacement":1}`)))
+	if err != nil {
+		t.Fatalf("second Claim: %v", err)
+	}
+	if second.Outcome != idempotency.OutcomeAcquired {
+		t.Errorf("Outcome = %d, want OutcomeAcquired (stale takeover)", second.Outcome)
+	}
+}
+
+func TestClaim_DifferentUsersIsolated(t *testing.T) {
+	pool := testutil.TestDB(t)
+	identStore := identity.NewStore(pool)
+	idemStore := idempotency.NewStore(pool)
+	ctx := context.Background()
+
+	uA, _ := identStore.CreateOrGetUser(ctx, "user-a@example.com", "A", "google-a")
+	uB, _ := identStore.CreateOrGetUser(ctx, "user-b@example.com", "B", "google-b")
+
+	hash := idempotency.HashBody([]byte(`{"x":1}`))
+
+	a, _ := idemStore.Claim(ctx, uA.ID, "shared", "/api/v1/send", hash)
+	if a.Outcome != idempotency.OutcomeAcquired {
+		t.Fatalf("A Outcome = %d", a.Outcome)
+	}
+	// Same key, different user — must not collide.
+	b, _ := idemStore.Claim(ctx, uB.ID, "shared", "/api/v1/send", hash)
+	if b.Outcome != idempotency.OutcomeAcquired {
+		t.Errorf("B Outcome = %d, want OutcomeAcquired (different user)", b.Outcome)
+	}
+}
+
+func TestRelease_AllowsFreshClaim(t *testing.T) {
+	store, userID, _ := newStoreAndUser(t)
+	ctx := context.Background()
+
+	first, _ := store.Claim(ctx, userID, "key-release", "/api/v1/send", idempotency.HashBody([]byte(`{"a":1}`)))
+	if first.Outcome != idempotency.OutcomeAcquired {
+		t.Fatalf("first Outcome = %d", first.Outcome)
+	}
+
+	if err := store.Release(ctx, userID, "key-release"); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+
+	// After release, a fresh claim with any body should re-acquire.
+	second, err := store.Claim(ctx, userID, "key-release", "/api/v1/send", idempotency.HashBody([]byte(`{"a":99}`)))
+	if err != nil {
+		t.Fatalf("second Claim: %v", err)
+	}
+	if second.Outcome != idempotency.OutcomeAcquired {
+		t.Errorf("Outcome = %d, want OutcomeAcquired after Release", second.Outcome)
+	}
+}
+
+func TestRelease_DoesNotDeleteCompletedRow(t *testing.T) {
+	store, userID, _ := newStoreAndUser(t)
+	ctx := context.Background()
+
+	hash := idempotency.HashBody([]byte(`{"a":1}`))
+	first, _ := store.Claim(ctx, userID, "key-rel-completed", "/api/v1/send", hash)
+	if first.Outcome != idempotency.OutcomeAcquired {
+		t.Fatalf("first Outcome = %d", first.Outcome)
+	}
+	_ = store.Complete(ctx, userID, "key-rel-completed", idempotency.CachedResponse{StatusCode: 200, Body: []byte("ok")})
+
+	// A buggy caller invokes Release post-Complete; must be a no-op.
+	if err := store.Release(ctx, userID, "key-rel-completed"); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+
+	// Replay must still work.
+	second, _ := store.Claim(ctx, userID, "key-rel-completed", "/api/v1/send", hash)
+	if second.Outcome != idempotency.OutcomeReplay {
+		t.Errorf("Outcome = %d, want OutcomeReplay (Release should not have wiped completed row)", second.Outcome)
+	}
+}
+
+func TestComplete_DoubleCallIsNoop(t *testing.T) {
+	store, userID, _ := newStoreAndUser(t)
+	ctx := context.Background()
+
+	hash := idempotency.HashBody([]byte(`{"a":1}`))
+	first, _ := store.Claim(ctx, userID, "key-dbl", "/api/v1/send", hash)
+	if first.Outcome != idempotency.OutcomeAcquired {
+		t.Fatalf("first Outcome = %d", first.Outcome)
+	}
+	originalCached := idempotency.CachedResponse{StatusCode: 200, ContentType: "application/json", Body: []byte(`{"status":"sent"}`)}
+	_ = store.Complete(ctx, userID, "key-dbl", originalCached)
+
+	// A buggy caller re-Completes with a different body. Must not
+	// overwrite the cached response.
+	_ = store.Complete(ctx, userID, "key-dbl", idempotency.CachedResponse{StatusCode: 500, Body: []byte("oops")})
+
+	replay, _ := store.Claim(ctx, userID, "key-dbl", "/api/v1/send", hash)
+	if replay.Outcome != idempotency.OutcomeReplay {
+		t.Fatalf("Outcome = %d", replay.Outcome)
+	}
+	if string(replay.Cached.Body) != string(originalCached.Body) {
+		t.Errorf("cached body = %q, want %q (Complete should be no-op after first call)", replay.Cached.Body, originalCached.Body)
+	}
+}
+
+func TestSweep_DeletesCompletedRowsPastTTL(t *testing.T) {
+	store, userID, pool := newStoreAndUser(t)
+	ctx := context.Background()
+
+	hash := idempotency.HashBody([]byte(`{"a":1}`))
+	first, _ := store.Claim(ctx, userID, "key-sweep", "/api/v1/send", hash)
+	if first.Outcome != idempotency.OutcomeAcquired {
+		t.Fatalf("first Outcome = %d", first.Outcome)
+	}
+	_ = store.Complete(ctx, userID, "key-sweep", idempotency.CachedResponse{StatusCode: 200, Body: []byte("ok")})
+
+	// Age the row past TTL.
+	if _, err := pool.Exec(ctx, `UPDATE idempotency_keys SET created_at = now() - $2::interval WHERE user_id = $1 AND key = 'key-sweep'`,
+		userID, (idempotency.TTL + time.Hour).String()); err != nil {
+		t.Fatalf("age row: %v", err)
+	}
+
+	deleted, err := store.Sweep(ctx)
+	if err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if deleted < 1 {
+		t.Errorf("deleted = %d, want >= 1", deleted)
+	}
+
+	// After sweep, the key is reusable.
+	third, _ := store.Claim(ctx, userID, "key-sweep", "/api/v1/send", hash)
+	if third.Outcome != idempotency.OutcomeAcquired {
+		t.Errorf("Outcome = %d, want OutcomeAcquired (sweep should have removed completed row)", third.Outcome)
+	}
+}
+
+func TestSweep_DoesNotDeleteRecentInProgress(t *testing.T) {
+	store, userID, _ := newStoreAndUser(t)
+	ctx := context.Background()
+
+	hash := idempotency.HashBody([]byte(`{"a":1}`))
+	first, _ := store.Claim(ctx, userID, "key-sweep-active", "/api/v1/send", hash)
+	if first.Outcome != idempotency.OutcomeAcquired {
+		t.Fatalf("first Outcome = %d", first.Outcome)
+	}
+
+	if _, err := store.Sweep(ctx); err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+
+	// Active in_progress claim must survive sweep.
+	second, _ := store.Claim(ctx, userID, "key-sweep-active", "/api/v1/send", hash)
+	if second.Outcome != idempotency.OutcomeInFlight {
+		t.Errorf("Outcome = %d, want OutcomeInFlight (sweep should have kept active claim)", second.Outcome)
+	}
+}
+
+func TestClaim_ConcurrentSameKeyOnlyOneAcquires(t *testing.T) {
+	store, userID, _ := newStoreAndUser(t)
+	ctx := context.Background()
+
+	hash := idempotency.HashBody([]byte(`{"a":1}`))
+	const N = 25
+
+	var (
+		wg          sync.WaitGroup
+		mu          sync.Mutex
+		acquired    int
+		inflight    int
+		other       int
+	)
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			res, err := store.Claim(ctx, userID, "key-concurrent", "/api/v1/send", hash)
+			if err != nil {
+				t.Errorf("Claim: %v", err)
+				return
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			switch res.Outcome {
+			case idempotency.OutcomeAcquired:
+				acquired++
+			case idempotency.OutcomeInFlight:
+				inflight++
+			default:
+				other++
+			}
+		}()
+	}
+	wg.Wait()
+
+	if acquired != 1 {
+		t.Errorf("acquired = %d, want exactly 1 across %d concurrent Claims", acquired, N)
+	}
+	if other != 0 {
+		t.Errorf("unexpected outcomes = %d (expected only Acquired+InFlight)", other)
+	}
+	if acquired+inflight != N {
+		t.Errorf("acquired(%d) + inflight(%d) != N(%d)", acquired, inflight, N)
+	}
+}
+
+func TestClaim_EmptyArgsRejected(t *testing.T) {
+	store, userID, _ := newStoreAndUser(t)
+	ctx := context.Background()
+
+	if _, err := store.Claim(ctx, "", "key", "/path", "hash"); err == nil {
+		t.Error("Claim with empty userID returned nil error")
+	}
+	if _, err := store.Claim(ctx, userID, "", "/path", "hash"); err == nil {
+		t.Error("Claim with empty key returned nil error")
+	}
+}

--- a/internal/identity/send_attempts.go
+++ b/internal/identity/send_attempts.go
@@ -1,0 +1,205 @@
+package identity
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// SendAttemptStaleWindow is how long an 'attempting' send_attempts row
+// stays "owned" by the original worker before the next caller is
+// allowed to take it over. Bounded above by outbound.SMTPRelay's
+// worst-case retry envelope (~6.5min) plus headroom — kept tighter
+// would risk concurrent SES sends if a real upstream stall happened.
+const SendAttemptStaleWindow = 10 * time.Minute
+
+// ErrSendInProgress is returned by ApproveAndSend (and the underlying
+// ClaimSendAttempt) when a concurrent attempt for the same message
+// is still in-flight at the SES layer. Callers should treat this as
+// transient — the in-flight caller will either commit (the next
+// retry sees status='sent' and replays) or time out (the row goes
+// stale and the next retry takes over).
+var ErrSendInProgress = errors.New("send already in progress for this message")
+
+// SendAttemptOutcome describes the result of trying to reserve a
+// (message_id) slot for an upstream SES send.
+type SendAttemptOutcome int
+
+const (
+	// SendAttemptAcquired — caller now owns the slot and must follow
+	// up with MarkSendSucceeded or MarkSendFailed.
+	SendAttemptAcquired SendAttemptOutcome = iota
+	// SendAttemptAlreadySent — a prior attempt for this message
+	// already succeeded at SES; SendResult is populated with the
+	// recorded provider id and recipient lists. Callers must NOT
+	// re-invoke the upstream send.
+	SendAttemptAlreadySent
+	// SendAttemptInFlight — a concurrent caller holds the slot and
+	// the row is not stale. Callers should surface ErrSendInProgress.
+	SendAttemptInFlight
+)
+
+// SendAttemptResult bundles the outcome with the cached SendResult
+// when the outcome is SendAttemptAlreadySent.
+type SendAttemptResult struct {
+	Outcome SendAttemptOutcome
+	Sent    SendResult
+}
+
+// ClaimSendAttempt atomically reserves the send_attempts row for
+// messageID. Concurrency model mirrors internal/idempotency.Claim:
+// one UPSERT with a stale-takeover WHERE clause; the loser does a
+// follow-up SELECT to classify the existing row.
+//
+// Allowed transitions:
+//
+//	(no row)                              → acquired (fresh INSERT)
+//	status='failed'                       → acquired (UPSERT path takes over)
+//	status='attempting' AND stale         → acquired (UPSERT path takes over)
+//	status='attempting' AND NOT stale     → InFlight (refuse)
+//	status='sent'                         → AlreadySent (reuse recorded result)
+//
+// Called from ApproveAndSend in a SEPARATE small transaction so the
+// claim row outlives any rollback of the surrounding approval
+// transaction. That's what closes the documented double-send window:
+// once status='sent' is committed here, a retry sees AlreadySent and
+// skips the upstream send even if the messages-row UPDATE inside
+// the approval tx never committed.
+func (s *Store) ClaimSendAttempt(ctx context.Context, messageID string) (SendAttemptResult, error) {
+	if messageID == "" {
+		return SendAttemptResult{}, errors.New("identity: messageID required")
+	}
+
+	staleSecs := int(SendAttemptStaleWindow.Seconds())
+
+	var owned int
+	err := s.pool.QueryRow(ctx,
+		`INSERT INTO send_attempts (
+		     message_id, status, attempted_at, completed_at,
+		     provider_message_id, method,
+		     to_recipients, cc_recipients, bcc_recipients,
+		     error
+		 )
+		 VALUES ($1, 'attempting', now(), NULL, '', '', '{}', '{}', '{}', '')
+		 ON CONFLICT (message_id) DO UPDATE
+		    SET status              = 'attempting',
+		        attempted_at        = now(),
+		        completed_at        = NULL,
+		        provider_message_id = '',
+		        method              = '',
+		        to_recipients       = '{}',
+		        cc_recipients       = '{}',
+		        bcc_recipients      = '{}',
+		        error               = ''
+		  WHERE send_attempts.status = 'failed'
+		     OR (send_attempts.status = 'attempting'
+		         AND send_attempts.attempted_at < now() - make_interval(secs => $2))
+		 RETURNING 1`,
+		messageID, staleSecs,
+	).Scan(&owned)
+	if err == nil {
+		return SendAttemptResult{Outcome: SendAttemptAcquired}, nil
+	}
+	if !errors.Is(err, pgx.ErrNoRows) {
+		return SendAttemptResult{}, err
+	}
+
+	// Lost the race — classify the existing row.
+	var (
+		status   string
+		provider string
+		method   string
+		to       []string
+		cc       []string
+		bcc      []string
+	)
+	err = s.pool.QueryRow(ctx,
+		`SELECT status, provider_message_id, method,
+		        to_recipients, cc_recipients, bcc_recipients
+		   FROM send_attempts
+		  WHERE message_id = $1`,
+		messageID,
+	).Scan(&status, &provider, &method, &to, &cc, &bcc)
+	if err != nil {
+		return SendAttemptResult{}, err
+	}
+
+	switch status {
+	case "sent":
+		return SendAttemptResult{
+			Outcome: SendAttemptAlreadySent,
+			Sent: SendResult{
+				ProviderMessageID: provider,
+				Method:            method,
+				To:                to,
+				CC:                cc,
+				BCC:               bcc,
+			},
+		}, nil
+	case "attempting":
+		// Not stale (the UPSERT WHERE refused to take over) — another
+		// worker holds the slot.
+		return SendAttemptResult{Outcome: SendAttemptInFlight}, nil
+	default:
+		// 'failed' should have been taken over by the UPSERT; if we
+		// see it here treat as InFlight defensively rather than
+		// silently re-sending.
+		return SendAttemptResult{Outcome: SendAttemptInFlight}, nil
+	}
+}
+
+// MarkSendSucceeded records the result of a successful upstream send.
+// Idempotent against double-call: only updates rows still 'attempting'
+// so a stray re-Mark from a buggy caller cannot overwrite a previous
+// success or revive a failed row.
+func (s *Store) MarkSendSucceeded(ctx context.Context, messageID string, r SendResult) error {
+	// pgx serializes a nil []string as SQL NULL, which would violate
+	// the NOT NULL constraint on cc_recipients / bcc_recipients (the
+	// DEFAULT '{}' only fires when the column is omitted from
+	// INSERT/UPDATE, not when an explicit NULL is supplied). Coerce
+	// here so callers can pass partial SendResults without thinking
+	// about it.
+	to := r.To
+	if to == nil {
+		to = []string{}
+	}
+	cc := r.CC
+	if cc == nil {
+		cc = []string{}
+	}
+	bcc := r.BCC
+	if bcc == nil {
+		bcc = []string{}
+	}
+	_, err := s.pool.Exec(ctx,
+		`UPDATE send_attempts
+		    SET status              = 'sent',
+		        completed_at        = now(),
+		        provider_message_id = $2,
+		        method              = $3,
+		        to_recipients       = $4,
+		        cc_recipients       = $5,
+		        bcc_recipients      = $6,
+		        error               = ''
+		  WHERE message_id = $1 AND status = 'attempting'`,
+		messageID, r.ProviderMessageID, r.Method, to, cc, bcc,
+	)
+	return err
+}
+
+// MarkSendFailed records that the upstream send failed for messageID,
+// so the next ClaimSendAttempt is allowed to take over and retry.
+// Idempotent against double-call: only updates rows still 'attempting'.
+func (s *Store) MarkSendFailed(ctx context.Context, messageID, errMsg string) error {
+	_, err := s.pool.Exec(ctx,
+		`UPDATE send_attempts
+		    SET status       = 'failed',
+		        completed_at = now(),
+		        error        = $2
+		  WHERE message_id = $1 AND status = 'attempting'`,
+		messageID, errMsg,
+	)
+	return err
+}

--- a/internal/identity/send_attempts_test.go
+++ b/internal/identity/send_attempts_test.go
@@ -1,0 +1,326 @@
+package identity_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+)
+
+// ClaimSendAttempt low-level: covers the four state transitions
+// (fresh, in-flight, already-sent, failed-takeover) without going
+// through the full ApproveAndSend wrapper.
+
+func TestClaimSendAttempt_FreshAcquires(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	_, a := setupPendingAgent(t, store, "claim-fresh")
+	msg, _ := store.CreatePendingOutboundMessage(context.Background(), a.ID,
+		[]string{"x@example.com"}, nil, nil, "x", "b", "", nil, "send", "", "", 3600)
+
+	res, err := store.ClaimSendAttempt(context.Background(), msg.ID)
+	if err != nil {
+		t.Fatalf("ClaimSendAttempt: %v", err)
+	}
+	if res.Outcome != identity.SendAttemptAcquired {
+		t.Errorf("Outcome = %d, want SendAttemptAcquired", res.Outcome)
+	}
+}
+
+func TestClaimSendAttempt_InFlightOnSecondCall(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	_, a := setupPendingAgent(t, store, "claim-inflight")
+	msg, _ := store.CreatePendingOutboundMessage(context.Background(), a.ID,
+		[]string{"x@example.com"}, nil, nil, "x", "b", "", nil, "send", "", "", 3600)
+
+	first, _ := store.ClaimSendAttempt(context.Background(), msg.ID)
+	if first.Outcome != identity.SendAttemptAcquired {
+		t.Fatalf("first Outcome = %d", first.Outcome)
+	}
+
+	second, err := store.ClaimSendAttempt(context.Background(), msg.ID)
+	if err != nil {
+		t.Fatalf("second Claim: %v", err)
+	}
+	if second.Outcome != identity.SendAttemptInFlight {
+		t.Errorf("Outcome = %d, want SendAttemptInFlight", second.Outcome)
+	}
+}
+
+func TestClaimSendAttempt_AlreadySentReplaysCachedResult(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	_, a := setupPendingAgent(t, store, "claim-sent")
+	msg, _ := store.CreatePendingOutboundMessage(context.Background(), a.ID,
+		[]string{"alice@example.com"}, []string{"bob@example.com"}, nil,
+		"x", "b", "", nil, "send", "", "", 3600)
+
+	first, _ := store.ClaimSendAttempt(context.Background(), msg.ID)
+	if first.Outcome != identity.SendAttemptAcquired {
+		t.Fatalf("first Outcome = %d", first.Outcome)
+	}
+	want := identity.SendResult{
+		ProviderMessageID: "<ses-xyz@amazonses.com>",
+		Method:            "smtp",
+		To:                []string{"alice@example.com"},
+		CC:                []string{"bob@example.com"},
+		BCC:               []string{},
+	}
+	if err := store.MarkSendSucceeded(context.Background(), msg.ID, want); err != nil {
+		t.Fatalf("MarkSendSucceeded: %v", err)
+	}
+
+	second, err := store.ClaimSendAttempt(context.Background(), msg.ID)
+	if err != nil {
+		t.Fatalf("second Claim: %v", err)
+	}
+	if second.Outcome != identity.SendAttemptAlreadySent {
+		t.Fatalf("Outcome = %d, want SendAttemptAlreadySent", second.Outcome)
+	}
+	if second.Sent.ProviderMessageID != want.ProviderMessageID {
+		t.Errorf("provider id = %q, want %q", second.Sent.ProviderMessageID, want.ProviderMessageID)
+	}
+	if second.Sent.Method != want.Method {
+		t.Errorf("method = %q, want %q", second.Sent.Method, want.Method)
+	}
+	if len(second.Sent.To) != 1 || second.Sent.To[0] != "alice@example.com" {
+		t.Errorf("To = %v, want [alice@example.com]", second.Sent.To)
+	}
+}
+
+func TestClaimSendAttempt_FailedAllowsRetry(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	_, a := setupPendingAgent(t, store, "claim-failed")
+	msg, _ := store.CreatePendingOutboundMessage(context.Background(), a.ID,
+		[]string{"x@example.com"}, nil, nil, "x", "b", "", nil, "send", "", "", 3600)
+
+	first, _ := store.ClaimSendAttempt(context.Background(), msg.ID)
+	if first.Outcome != identity.SendAttemptAcquired {
+		t.Fatalf("first Outcome = %d", first.Outcome)
+	}
+	if err := store.MarkSendFailed(context.Background(), msg.ID, "ses timeout"); err != nil {
+		t.Fatalf("MarkSendFailed: %v", err)
+	}
+
+	// After failure, the next call may take over.
+	second, err := store.ClaimSendAttempt(context.Background(), msg.ID)
+	if err != nil {
+		t.Fatalf("second Claim: %v", err)
+	}
+	if second.Outcome != identity.SendAttemptAcquired {
+		t.Errorf("Outcome = %d, want SendAttemptAcquired (failed should be reclaimable)", second.Outcome)
+	}
+}
+
+func TestClaimSendAttempt_ConcurrentOnlyOneAcquires(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	_, a := setupPendingAgent(t, store, "claim-conc")
+	msg, _ := store.CreatePendingOutboundMessage(context.Background(), a.ID,
+		[]string{"x@example.com"}, nil, nil, "x", "b", "", nil, "send", "", "", 3600)
+
+	const N = 20
+	var (
+		wg        sync.WaitGroup
+		mu        sync.Mutex
+		acquired  int
+		inflight  int
+		otherCnt  int
+	)
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			res, err := store.ClaimSendAttempt(context.Background(), msg.ID)
+			if err != nil {
+				t.Errorf("Claim: %v", err)
+				return
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			switch res.Outcome {
+			case identity.SendAttemptAcquired:
+				acquired++
+			case identity.SendAttemptInFlight:
+				inflight++
+			default:
+				otherCnt++
+			}
+		}()
+	}
+	wg.Wait()
+
+	if acquired != 1 {
+		t.Errorf("acquired = %d, want exactly 1 of %d concurrent ClaimSendAttempt calls", acquired, N)
+	}
+	if otherCnt != 0 {
+		t.Errorf("unexpected outcomes = %d", otherCnt)
+	}
+	if acquired+inflight != N {
+		t.Errorf("acquired(%d)+inflight(%d) != N(%d)", acquired, inflight, N)
+	}
+}
+
+// ApproveAndSend-level: the integration scenarios that motivated
+// send_attempts.
+
+// Simulates the documented crash window: send() succeeded at SES,
+// the approval-tx UPDATE/COMMIT then "rolled back" (we mimic this by
+// directly resetting messages.status back to pending_approval and
+// clearing the provider_message_id). The next ApproveAndSend call
+// must NOT re-invoke send() and must finalize the message row with
+// the originally-recorded SendResult.
+func TestApproveAndSend_TxRollbackRetry_DoesNotCallSendTwice(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	user, a := setupPendingAgent(t, store, "approve-rollback")
+	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
+		[]string{"alice@example.com"}, nil, nil, "x", "body", "", nil, "send", "", "", 3600)
+
+	var sendCalls int32
+
+	// First call — succeeds end-to-end.
+	_, err := store.ApproveAndSend(ctx, msg.ID, user.ID, identity.PendingApprovalEdit{},
+		func(m *identity.Message) (identity.SendResult, error) {
+			atomic.AddInt32(&sendCalls, 1)
+			return identity.SendResult{
+				ProviderMessageID: "<ses-orig@amazonses.com>",
+				Method:            "smtp",
+				To:                m.ToRecipients,
+			}, nil
+		})
+	if err != nil {
+		t.Fatalf("first ApproveAndSend: %v", err)
+	}
+
+	// Simulate the surrounding approval-tx having rolled back AFTER
+	// SES accepted the send. The send_attempts row stays
+	// status='sent' (this is what the new exactly-once gate
+	// preserves); the messages row goes back to pending_approval
+	// with the provider id cleared.
+	if _, err := pool.Exec(ctx,
+		`UPDATE messages
+		    SET status = 'pending_approval',
+		        provider_message_id = '',
+		        reviewed_at = NULL,
+		        reviewed_by_user_id = NULL,
+		        body_text = 'body',
+		        body_html = ''
+		  WHERE id = $1`, msg.ID); err != nil {
+		t.Fatalf("simulate rollback: %v", err)
+	}
+
+	// Second call — must reuse the cached result, not re-invoke send().
+	second, err := store.ApproveAndSend(ctx, msg.ID, user.ID, identity.PendingApprovalEdit{},
+		func(m *identity.Message) (identity.SendResult, error) {
+			atomic.AddInt32(&sendCalls, 1)
+			return identity.SendResult{}, errors.New("send should not have been called on retry")
+		})
+	if err != nil {
+		t.Fatalf("retry ApproveAndSend: %v", err)
+	}
+	if got := atomic.LoadInt32(&sendCalls); got != 1 {
+		t.Errorf("send() invoked %d time(s), want exactly 1 across the rollback + retry", got)
+	}
+	if second.ProviderMessageID != "<ses-orig@amazonses.com>" {
+		t.Errorf("retry returned ProviderMessageID = %q, want the cached <ses-orig@amazonses.com>", second.ProviderMessageID)
+	}
+	if second.Status != identity.MessageStatusSent {
+		t.Errorf("retry returned status = %q, want sent", second.Status)
+	}
+}
+
+func TestApproveAndSend_SendErrorMarksFailedAndAllowsRetry(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	user, a := setupPendingAgent(t, store, "approve-failed")
+	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
+		[]string{"alice@example.com"}, nil, nil, "x", "body", "", nil, "send", "", "", 3600)
+
+	var sendCalls int32
+
+	// First call — send() returns error. ApproveAndSend should bubble
+	// the error and mark send_attempts.status='failed'.
+	_, err := store.ApproveAndSend(ctx, msg.ID, user.ID, identity.PendingApprovalEdit{},
+		func(m *identity.Message) (identity.SendResult, error) {
+			atomic.AddInt32(&sendCalls, 1)
+			return identity.SendResult{}, errors.New("ses temporarily unavailable")
+		})
+	if err == nil {
+		t.Fatalf("first ApproveAndSend: nil error, want send failure")
+	}
+
+	// Status row must NOT have transitioned to sent (the approval tx
+	// rolled back).
+	var status string
+	if err := pool.QueryRow(ctx, `SELECT status FROM messages WHERE id = $1`, msg.ID).Scan(&status); err != nil {
+		t.Fatalf("read status: %v", err)
+	}
+	if status != identity.MessageStatusPendingApproval {
+		t.Errorf("messages.status = %q, want pending_approval", status)
+	}
+
+	// Second call — send() must be re-invoked (failed attempts allow retry).
+	second, err := store.ApproveAndSend(ctx, msg.ID, user.ID, identity.PendingApprovalEdit{},
+		func(m *identity.Message) (identity.SendResult, error) {
+			atomic.AddInt32(&sendCalls, 1)
+			return identity.SendResult{
+				ProviderMessageID: "<ses-retry@amazonses.com>",
+				Method:            "smtp",
+				To:                m.ToRecipients,
+			}, nil
+		})
+	if err != nil {
+		t.Fatalf("retry ApproveAndSend: %v", err)
+	}
+	if got := atomic.LoadInt32(&sendCalls); got != 2 {
+		t.Errorf("send() invoked %d time(s), want exactly 2 (one failure + one retry)", got)
+	}
+	if second.Status != identity.MessageStatusSent {
+		t.Errorf("retry status = %q, want sent", second.Status)
+	}
+	if second.ProviderMessageID != "<ses-retry@amazonses.com>" {
+		t.Errorf("retry ProviderMessageID = %q", second.ProviderMessageID)
+	}
+}
+
+// Direct InFlight: force a stale in_progress claim into the table
+// (without going through ApproveAndSend) and verify the next call
+// surfaces ErrSendInProgress via the wrapper.
+func TestApproveAndSend_InFlightReturnsErrSendInProgress(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	user, a := setupPendingAgent(t, store, "approve-inflight")
+	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
+		[]string{"alice@example.com"}, nil, nil, "x", "body", "", nil, "send", "", "", 3600)
+
+	// Plant a recent 'attempting' row directly so the next
+	// ClaimSendAttempt observes InFlight.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO send_attempts (message_id, status, attempted_at)
+		 VALUES ($1, 'attempting', now())`, msg.ID); err != nil {
+		t.Fatalf("seed inflight row: %v", err)
+	}
+
+	var sendCalls int32
+	_, err := store.ApproveAndSend(ctx, msg.ID, user.ID, identity.PendingApprovalEdit{},
+		func(m *identity.Message) (identity.SendResult, error) {
+			atomic.AddInt32(&sendCalls, 1)
+			return identity.SendResult{}, nil
+		})
+	if !errors.Is(err, identity.ErrSendInProgress) {
+		t.Errorf("err = %v, want ErrSendInProgress", err)
+	}
+	if got := atomic.LoadInt32(&sendCalls); got != 0 {
+		t.Errorf("send() invoked %d time(s), want 0 when InFlight", got)
+	}
+}

--- a/internal/identity/send_attempts_test.go
+++ b/internal/identity/send_attempts_test.go
@@ -292,6 +292,116 @@ func TestApproveAndSend_SendErrorMarksFailedAndAllowsRetry(t *testing.T) {
 	}
 }
 
+// ExpireApproveAndSend (worker path) — same exactly-once guarantee
+// as ApproveAndSend. The polling-loop nature of the auto-expire
+// worker makes a missing gate strictly worse than the human-approval
+// path: any commit failure after SES success guarantees a re-send on
+// the next poll. These tests verify the gate behaves identically on
+// the worker side.
+
+// Mirrors TestApproveAndSend_TxRollbackRetry_DoesNotCallSendTwice
+// but for the worker-side expiration path.
+func TestExpireApproveAndSend_TxRollbackRetry_DoesNotCallSendTwice(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	_, a := setupPendingAgent(t, store, "expire-rollback")
+	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
+		[]string{"alice@example.com"}, nil, nil, "x", "body", "", nil, "send", "", "", 60)
+	// ExpireApproveAndSend only picks up rows whose approval_expires_at
+	// is in the past — push the expiry back so the WHERE matches.
+	if _, err := pool.Exec(ctx, `UPDATE messages SET approval_expires_at = now() - interval '1 minute' WHERE id = $1`, msg.ID); err != nil {
+		t.Fatalf("age approval_expires_at: %v", err)
+	}
+
+	var sendCalls int32
+
+	// First poll — succeeds end-to-end.
+	_, err := store.ExpireApproveAndSend(ctx, msg.ID,
+		func(m *identity.Message) (identity.SendResult, error) {
+			atomic.AddInt32(&sendCalls, 1)
+			return identity.SendResult{
+				ProviderMessageID: "<ses-exp-orig@amazonses.com>",
+				Method:            "smtp",
+				To:                m.ToRecipients,
+			}, nil
+		})
+	if err != nil {
+		t.Fatalf("first ExpireApproveAndSend: %v", err)
+	}
+
+	// Simulate the surrounding approval-tx having rolled back AFTER
+	// SES accepted the send: status goes back to pending_approval,
+	// reviewed_at + provider_message_id cleared, approval_expires_at
+	// re-aged so the next poll still matches.
+	if _, err := pool.Exec(ctx,
+		`UPDATE messages
+		    SET status              = 'pending_approval',
+		        provider_message_id = '',
+		        reviewed_at         = NULL,
+		        body_text           = 'body',
+		        body_html           = '',
+		        approval_expires_at = now() - interval '1 minute'
+		  WHERE id = $1`, msg.ID); err != nil {
+		t.Fatalf("simulate rollback: %v", err)
+	}
+
+	// Second poll — must reuse the cached SendResult, NOT re-invoke send().
+	second, err := store.ExpireApproveAndSend(ctx, msg.ID,
+		func(m *identity.Message) (identity.SendResult, error) {
+			atomic.AddInt32(&sendCalls, 1)
+			return identity.SendResult{}, errors.New("send should not have been called on retry")
+		})
+	if err != nil {
+		t.Fatalf("retry ExpireApproveAndSend: %v", err)
+	}
+	if got := atomic.LoadInt32(&sendCalls); got != 1 {
+		t.Errorf("send() invoked %d time(s), want exactly 1 across the rollback + retry", got)
+	}
+	if second.ProviderMessageID != "<ses-exp-orig@amazonses.com>" {
+		t.Errorf("retry returned ProviderMessageID = %q, want the cached <ses-exp-orig@amazonses.com>", second.ProviderMessageID)
+	}
+	if second.Status != identity.MessageStatusExpiredApproved {
+		t.Errorf("retry returned status = %q, want expired_approved", second.Status)
+	}
+}
+
+// ExpireApproveAndSend in the face of a peer-worker mid-send: the
+// claim sees status='attempting' and returns ErrSendInProgress. The
+// hitlworker loop treats this as "skip silently" so it does NOT
+// auto-reject a row that may have actually been sent.
+func TestExpireApproveAndSend_InFlightReturnsErrSendInProgress(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	_, a := setupPendingAgent(t, store, "expire-inflight")
+	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
+		[]string{"alice@example.com"}, nil, nil, "x", "body", "", nil, "send", "", "", 60)
+	if _, err := pool.Exec(ctx, `UPDATE messages SET approval_expires_at = now() - interval '1 minute' WHERE id = $1`, msg.ID); err != nil {
+		t.Fatalf("age approval_expires_at: %v", err)
+	}
+
+	// Plant a recent 'attempting' row as if a peer worker had claimed it.
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO send_attempts (message_id, status, attempted_at)
+		 VALUES ($1, 'attempting', now())`, msg.ID); err != nil {
+		t.Fatalf("seed inflight row: %v", err)
+	}
+
+	var sendCalls int32
+	_, err := store.ExpireApproveAndSend(ctx, msg.ID,
+		func(m *identity.Message) (identity.SendResult, error) {
+			atomic.AddInt32(&sendCalls, 1)
+			return identity.SendResult{}, nil
+		})
+	if !errors.Is(err, identity.ErrSendInProgress) {
+		t.Errorf("err = %v, want ErrSendInProgress", err)
+	}
+	if got := atomic.LoadInt32(&sendCalls); got != 0 {
+		t.Errorf("send() invoked %d time(s), want 0 when InFlight", got)
+	}
+}
+
 // Direct InFlight: force a stale in_progress claim into the table
 // (without going through ApproveAndSend) and verify the next call
 // surfaces ErrSendInProgress via the wrapper.

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -1198,7 +1198,10 @@ type SendResult struct {
 //
 // Ownership is enforced by the agent -> user join. Messages owned by
 // another user return ErrMessageNotFound. Messages whose status is not
-// 'pending_approval' return ErrNotPendingApproval.
+// 'pending_approval' return ErrNotPendingApproval. If another worker is
+// already mid-send for this message (rare; only possible after the
+// approval row lock was released without status changing — e.g. a
+// pool drop mid-send), this returns ErrSendInProgress.
 //
 // Concurrency / failure mode notes:
 //
@@ -1209,14 +1212,15 @@ type SendResult struct {
 //     unaffected; deadlock is not possible because only one row is ever
 //     locked per call.
 //
-//   - There is a narrow crash window where send() may succeed at SES but
-//     the subsequent UPDATE or Commit fails (DB connection drop, pool
-//     exhaustion). The transaction rolls back, the row stays pending, and
-//     a retry — by the same reviewer or the expiration worker — would
-//     re-send to SES. Eliminating this requires SES-side idempotency keys
-//     or a separate "send attempts" table; deferred for v1. Callers that
-//     see both a successful send callback and a subsequent error from
-//     this function should log both rather than silently retry.
+//   - The old crash window where send() succeeded at SES but the
+//     subsequent UPDATE/Commit failed (DB blip, pool exhaustion) is now
+//     closed by the send_attempts table. Around send() we run two small
+//     auxiliary transactions that outlive the surrounding approval
+//     transaction: ClaimSendAttempt before send(), MarkSendSucceeded
+//     (or MarkSendFailed) after. If the approval tx rolls back AFTER
+//     send() succeeded, the next retry of ApproveAndSend reads
+//     send_attempts.status='sent', reuses the recorded SendResult, and
+//     skips the upstream send entirely.
 func (s *Store) ApproveAndSend(
 	ctx context.Context,
 	messageID, userID string,
@@ -1262,7 +1266,7 @@ func (s *Store) ApproveAndSend(
 		 FROM messages m
 		 JOIN agent_identities a ON a.id = m.agent_id
 		 WHERE m.id = $1 AND m.direction = 'outbound'
-		 FOR UPDATE OF m`,
+		 FOR NO KEY UPDATE OF m`,
 		messageID,
 	).Scan(
 		&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.Subject,
@@ -1304,9 +1308,42 @@ func (s *Store) ApproveAndSend(
 
 	editedByReviewer := edits.Apply(&m)
 
-	result, err := send(&m)
+	// Exactly-once gate around the upstream send. Runs OUTSIDE the
+	// approval transaction so its outcome survives an approval-tx
+	// rollback — that's the whole point of send_attempts.
+	claim, err := s.ClaimSendAttempt(ctx, messageID)
 	if err != nil {
 		return nil, err
+	}
+
+	var result SendResult
+	switch claim.Outcome {
+	case SendAttemptAcquired:
+		result, err = send(&m)
+		if err != nil {
+			// Mark failed in a separate tx so the next retry can
+			// take over. Best-effort: log if the mark itself fails,
+			// don't shadow the original send error.
+			if markErr := s.MarkSendFailed(ctx, messageID, err.Error()); markErr != nil {
+				log.Printf("[approve] MarkSendFailed for %s: %v", messageID, markErr)
+			}
+			return nil, err
+		}
+		if markErr := s.MarkSendSucceeded(ctx, messageID, result); markErr != nil {
+			// The upstream send DID succeed; failing to record it
+			// only weakens the exactly-once guarantee for the next
+			// retry (it would re-send). Log loudly and proceed —
+			// the approval tx below still finalizes the message
+			// row from this attempt.
+			log.Printf("[approve] MarkSendSucceeded for %s: %v (next retry may re-send)", messageID, markErr)
+		}
+	case SendAttemptAlreadySent:
+		// A prior approval-tx attempt succeeded at SES but its
+		// surrounding tx rolled back. Reuse the recorded result and
+		// skip the upstream send.
+		result = claim.Sent
+	case SendAttemptInFlight:
+		return nil, ErrSendInProgress
 	}
 
 	_, err = tx.Exec(txCtx,

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -1485,18 +1485,36 @@ func (s *Store) ListExpiredPending(ctx context.Context, limit int) ([]Expiration
 
 // ExpireApproveAndSend is the worker-side counterpart to ApproveAndSend:
 // no user ownership check (the caller is the expiration worker, which is
-// system-scoped), SELECT ... FOR UPDATE SKIP LOCKED so concurrent workers
-// don't race for the same row, and the terminal status is
+// system-scoped), SELECT ... FOR NO KEY UPDATE SKIP LOCKED so concurrent
+// workers don't race for the same row, and the terminal status is
 // 'expired_approved' instead of 'sent'. On send failure the transaction
 // rolls back; the worker should then call ExpireReject to move the row
 // to a final state so the row doesn't get picked up on every sweep.
 //
-// Same concurrency / crash-window notes as ApproveAndSend apply: the
-// row-level lock is held for the duration of the send callback (bounded
-// by SMTPRelay timeouts), and a crash between SES acceptance and
-// commit can leave a pending row that would re-send on the next sweep.
+// Exactly-once guarantee: like ApproveAndSend, this method runs the
+// send() callback under a send_attempts gate so a crash between SES
+// acceptance and the surrounding tx commit does NOT cause the next
+// worker poll to re-send. ClaimSendAttempt / MarkSendSucceeded /
+// MarkSendFailed run in separate small transactions that outlive the
+// approval tx; on retry, an AlreadySent verdict reuses the cached
+// SendResult and skips the upstream send entirely. Without this, the
+// polling-loop nature of the worker would guarantee a re-send on any
+// commit failure — strictly worse than the human-approval path,
+// where a re-send needs an explicit click.
+//
 // SKIP LOCKED means multiple app instances can run the worker without
-// contending on the same row.
+// contending on the same row. The row-level FOR NO KEY UPDATE lock on
+// messages is held for the duration of the send callback (bounded by
+// SMTPRelay timeouts); FOR NO KEY UPDATE rather than FOR UPDATE so
+// the send_attempts INSERT in a separate connection can acquire its
+// KEY SHARE lock for FK enforcement — see ApproveAndSend's docstring
+// for the full rationale.
+//
+// If a concurrent worker is mid-send for the same row (the
+// send_attempts row is 'attempting' and not yet stale), returns
+// ErrSendInProgress. The worker loop should treat this like
+// ErrNotPendingApproval — skip silently and let the next poll handle
+// it.
 func (s *Store) ExpireApproveAndSend(
 	ctx context.Context,
 	messageID string,
@@ -1536,7 +1554,7 @@ func (s *Store) ExpireApproveAndSend(
 		   AND direction = 'outbound'
 		   AND status = 'pending_approval'
 		   AND approval_expires_at < now()
-		 FOR UPDATE SKIP LOCKED`,
+		 FOR NO KEY UPDATE SKIP LOCKED`,
 		messageID,
 	).Scan(
 		&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.Subject,
@@ -1572,9 +1590,35 @@ func (s *Store) ExpireApproveAndSend(
 		m.AttachmentsJSON = json.RawMessage(attachments)
 	}
 
-	result, err := send(&m)
+	// Exactly-once gate, identical to ApproveAndSend's bracket. Runs
+	// OUTSIDE this approval tx so the SES outcome survives an approval
+	// tx rollback. See ApproveAndSend's docstring for the full
+	// rationale.
+	claim, err := s.ClaimSendAttempt(ctx, messageID)
 	if err != nil {
 		return nil, err
+	}
+
+	var result SendResult
+	switch claim.Outcome {
+	case SendAttemptAcquired:
+		result, err = send(&m)
+		if err != nil {
+			if markErr := s.MarkSendFailed(ctx, messageID, err.Error()); markErr != nil {
+				log.Printf("[expire] MarkSendFailed for %s: %v", messageID, markErr)
+			}
+			return nil, err
+		}
+		if markErr := s.MarkSendSucceeded(ctx, messageID, result); markErr != nil {
+			log.Printf("[expire] MarkSendSucceeded for %s: %v (next worker poll may re-send)", messageID, markErr)
+		}
+	case SendAttemptAlreadySent:
+		// A prior auto-approve attempt succeeded at SES but its
+		// approval tx rolled back. Reuse the recorded result and
+		// skip the upstream send.
+		result = claim.Sent
+	case SendAttemptInFlight:
+		return nil, ErrSendInProgress
 	}
 
 	_, err = tx.Exec(txCtx,

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -1205,12 +1205,21 @@ type SendResult struct {
 //
 // Concurrency / failure mode notes:
 //
-//   - The row-level FOR UPDATE lock is held for the duration of the send
-//     callback. In practice that is bounded by outbound.SMTPRelay's per-
-//     attempt deadline (2min) plus its internal retry backoff (1s/5s/15s)
-//     — worst case ~6.5min of lock on this single row. Other rows are
-//     unaffected; deadlock is not possible because only one row is ever
-//     locked per call.
+//   - The row-level FOR NO KEY UPDATE lock is held on the messages row
+//     for the duration of the send callback. In practice that is
+//     bounded by outbound.SMTPRelay's per-attempt deadline (2min) plus
+//     its internal retry backoff (1s/5s/15s) — worst case ~6.5min of
+//     lock on this single row. Other rows are unaffected; deadlock is
+//     not possible because only one row is ever locked per call.
+//
+//     Why NO KEY UPDATE rather than the stricter FOR UPDATE: the
+//     send_attempts INSERT below runs on a SEPARATE pool connection
+//     and needs a KEY SHARE lock on this messages row for FK
+//     enforcement. FOR UPDATE blocks KEY SHARE; FOR NO KEY UPDATE
+//     allows it. The downgrade is safe because nothing in this
+//     codebase mutates messages.id (the only key column) after
+//     creation — all UPDATEs touch non-key columns, which NO KEY
+//     UPDATE serializes against itself exactly like FOR UPDATE.
 //
 //   - The old crash window where send() succeeded at SES but the
 //     subsequent UPDATE/Commit failed (DB blip, pool exhaustion) is now

--- a/internal/testutil/contract_server.go
+++ b/internal/testutil/contract_server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/agent"
 	"github.com/Mnexa-AI/e2a/internal/config"
 	"github.com/Mnexa-AI/e2a/internal/headers"
+	"github.com/Mnexa-AI/e2a/internal/idempotency"
 	"github.com/Mnexa-AI/e2a/internal/identity"
 	"github.com/Mnexa-AI/e2a/internal/outbound"
 	"github.com/Mnexa-AI/e2a/internal/relay"
@@ -50,6 +51,7 @@ func StartContractServer(ctx context.Context, dbURL string) (*ContractServer, er
 
 	router := mux.NewRouter()
 	api := agent.NewAPI(store, sender, smtpRelay, nil, noopUsage, "e2a.dev", "test.e2a.dev", "agents.e2a.dev", "", false)
+	api.SetIdempotencyStore(idempotency.NewStore(pool))
 	api.RegisterRoutes(router)
 
 	wsHub := ws.NewHub()

--- a/internal/testutil/db.go
+++ b/internal/testutil/db.go
@@ -106,8 +106,10 @@ func truncateAll(ctx context.Context, pool *pgxpool.Pool) error {
 	_, err := pool.Exec(ctx, `
 		TRUNCATE oauth_pkce_requests, oauth_refresh_tokens, oauth_access_tokens,
 		         oauth_auth_codes, oauth_clients,
-		         usage_summaries, usage_events, webhook_deliveries, messages,
-		         api_keys, webhook_signing_secrets, agent_identities, domains,
+		         usage_summaries, usage_events, webhook_deliveries,
+		         send_attempts, messages,
+		         idempotency_keys, api_keys, webhook_signing_secrets,
+		         agent_identities, domains,
 		         user_sessions, users CASCADE
 	`)
 	if err != nil {

--- a/internal/testutil/server.go
+++ b/internal/testutil/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/agent"
 	"github.com/Mnexa-AI/e2a/internal/config"
 	"github.com/Mnexa-AI/e2a/internal/headers"
+	"github.com/Mnexa-AI/e2a/internal/idempotency"
 	"github.com/Mnexa-AI/e2a/internal/identity"
 	"github.com/Mnexa-AI/e2a/internal/outbound"
 	"github.com/Mnexa-AI/e2a/internal/relay"
@@ -49,6 +50,7 @@ func TestServer(t *testing.T, pool *pgxpool.Pool) *E2ATestServer {
 	router := mux.NewRouter()
 	noopUsage := usage.NewNoopUsageTracker()
 	api := agent.NewAPI(store, sender, smtpRelay, nil, noopUsage, "e2a.dev", "test.e2a.dev", "agents.e2a.dev", "", false)
+	api.SetIdempotencyStore(idempotency.NewStore(pool))
 	api.RegisterRoutes(router)
 
 	// WebSocket route for local-mode agents

--- a/migrations/015_idempotency_and_send_attempts.sql
+++ b/migrations/015_idempotency_and_send_attempts.sql
@@ -1,0 +1,86 @@
+-- 015_idempotency_and_send_attempts.sql
+--
+-- Two related tables that together give the outbound send path
+-- exactly-once semantics under retry:
+--
+--   1) idempotency_keys (slice 1) — caller-facing dedup. When a request
+--      sets `Idempotency-Key: <string>` on POST /api/v1/send or POST
+--      /api/v1/agents/{email}/messages/{id}/reply, the server claims a
+--      row here, does the work once, and replays the cached response
+--      verbatim on any subsequent request with the same key.
+--
+--      Scope is (user_id, key) rather than (api_key_id, key). Stripe
+--      uses account-level scoping for the same reason: API keys are
+--      credentials, not identities, and a user rotating their key
+--      should not silently reset their idempotency window. UUIDv4
+--      collisions across a single user's keys are mathematically
+--      negligible, and the body-hash check below catches the
+--      pathological-collision case explicitly with a 422.
+--
+--      response_body holds the exact bytes the server returned on the
+--      first call (Content-Type included separately so the replay
+--      reproduces the original response wire-faithfully). status_code
+--      is the HTTP status to replay (typically 200 for immediate send
+--      or 202 for HITL-held).
+--
+--      status='in_progress' is the claim marker between INSERT and the
+--      UPDATE that records the response. A row that sits in_progress
+--      longer than the in-code stale window (5min) is treated as the
+--      remnant of a crashed handler and re-claimable by the next
+--      caller; see internal/idempotency for the takeover rule.
+--
+--   2) send_attempts (slice 2) — internal exactly-once gate for the
+--      HITL approval path. Closes the documented crash window in
+--      internal/identity/store.go: ApproveAndSend used to call the
+--      SES-bound send() callback inside its approval transaction, so
+--      a successful SES handoff followed by a DB commit failure would
+--      leave the message row pending — and a retry would re-send to
+--      SES.
+--
+--      The fix: ApproveAndSend now writes send_attempts rows in two
+--      small autonomous transactions that bracket the SES call, so
+--      the outcome of the upstream send survives any failure of the
+--      surrounding approval transaction. On retry, ApproveAndSend
+--      consults send_attempts FIRST: status='sent' means the previous
+--      attempt succeeded at SES — reuse the recorded provider id,
+--      skip the SES call. status='attempting' that is recent (<10min)
+--      means another worker is mid-send — return 409 and let the
+--      caller retry. status='failed' or no row means proceed.
+--
+-- Both tables are referenced in code under their bare names; see
+-- internal/idempotency/ (slice 1) and internal/identity/store.go's
+-- ApproveAndSend (slice 2).
+--
+-- Idempotent: CREATE TABLE IF NOT EXISTS, CREATE INDEX IF NOT EXISTS,
+-- no DROP, no rewrites. Safe to rerun on prod-sized data.
+
+CREATE TABLE IF NOT EXISTS idempotency_keys (
+    user_id               TEXT        NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    key                   TEXT        NOT NULL,
+    request_path          TEXT        NOT NULL,
+    request_body_hash     TEXT        NOT NULL,
+    response_status       INTEGER     NOT NULL DEFAULT 0,
+    response_content_type TEXT        NOT NULL DEFAULT '',
+    response_body         BYTEA       NOT NULL DEFAULT ''::bytea,
+    status                TEXT        NOT NULL CHECK (status IN ('in_progress', 'completed')),
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    completed_at          TIMESTAMPTZ,
+    PRIMARY KEY (user_id, key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_idempotency_keys_created_at ON idempotency_keys(created_at);
+
+CREATE TABLE IF NOT EXISTS send_attempts (
+    message_id         TEXT        PRIMARY KEY REFERENCES messages(id) ON DELETE CASCADE,
+    attempted_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    completed_at       TIMESTAMPTZ,
+    status             TEXT        NOT NULL CHECK (status IN ('attempting', 'sent', 'failed')),
+    provider_message_id TEXT       NOT NULL DEFAULT '',
+    method             TEXT        NOT NULL DEFAULT '',
+    to_recipients      TEXT[]      NOT NULL DEFAULT '{}',
+    cc_recipients      TEXT[]      NOT NULL DEFAULT '{}',
+    bcc_recipients     TEXT[]      NOT NULL DEFAULT '{}',
+    error              TEXT        NOT NULL DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS idx_send_attempts_attempted_at ON send_attempts(attempted_at);

--- a/sdks/python/src/e2a/v1/api.py
+++ b/sdks/python/src/e2a/v1/api.py
@@ -11,6 +11,7 @@ see :class:`e2a.v1.client.E2AClient`.
 from __future__ import annotations
 
 import os
+import uuid
 from typing import Optional
 from urllib.parse import quote
 
@@ -57,6 +58,19 @@ def _check_response(resp: httpx.Response) -> None:
         except Exception:
             message = f"HTTP {resp.status_code}"
         raise E2AApiError(resp.status_code, message)
+
+
+def _idempotency_header(idempotency_key: Optional[str]) -> dict:
+    """Build the ``Idempotency-Key`` header for a side-effectful send.
+
+    A caller-supplied key is passed through verbatim. When ``None``, a
+    fresh UUIDv4 is generated so callers get retry-safe transport
+    behavior by default. To benefit across an explicit retry loop the
+    caller must supply a stable key (the per-call default does not
+    survive retries — each call would mint a new UUID).
+    """
+    key = idempotency_key if idempotency_key is not None else uuid.uuid4().hex
+    return {"Idempotency-Key": key}
 
 
 def _encode_email(email: str) -> str:
@@ -200,18 +214,25 @@ class E2AApi:
         agent_email: str,
         message_id: str,
         body: ReplyToMessageRequest,
+        idempotency_key: Optional[str] = None,
     ) -> SendEmailResponse:
         resp = self._client.post(
             f"/api/v1/agents/{_encode_email(agent_email)}/messages/{message_id}/reply",
             json=body.model_dump(by_alias=True, exclude_none=True),
+            headers=_idempotency_header(idempotency_key),
         )
         _check_response(resp)
         return SendEmailResponse.model_validate(resp.json())
 
-    def send_email(self, body: SendEmailRequest) -> SendEmailResponse:
+    def send_email(
+        self,
+        body: SendEmailRequest,
+        idempotency_key: Optional[str] = None,
+    ) -> SendEmailResponse:
         resp = self._client.post(
             "/api/v1/send",
             json=body.model_dump(by_alias=True, exclude_none=True),
+            headers=_idempotency_header(idempotency_key),
         )
         _check_response(resp)
         return SendEmailResponse.model_validate(resp.json())

--- a/sdks/python/src/e2a/v1/async_client.py
+++ b/sdks/python/src/e2a/v1/async_client.py
@@ -19,7 +19,7 @@ import httpx
 if TYPE_CHECKING:
     from e2a.v1.websocket import WSNotification
 
-from e2a.v1.api import E2AApiError, _check_response
+from e2a.v1.api import E2AApiError, _check_response, _idempotency_header
 from e2a.v1.generated import (
     Agent,
     ApprovePendingMessageRequest,
@@ -187,18 +187,25 @@ class AsyncE2AApi:
         agent_email: str,
         message_id: str,
         body: ReplyToMessageRequest,
+        idempotency_key: Optional[str] = None,
     ) -> SendEmailResponse:
         resp = await self._client.post(
             f"/api/v1/agents/{_encode_email(agent_email)}/messages/{message_id}/reply",
             json=body.model_dump(by_alias=True, exclude_none=True),
+            headers=_idempotency_header(idempotency_key),
         )
         _check_response(resp)
         return SendEmailResponse.model_validate(resp.json())
 
-    async def send_email(self, body: SendEmailRequest) -> SendEmailResponse:
+    async def send_email(
+        self,
+        body: SendEmailRequest,
+        idempotency_key: Optional[str] = None,
+    ) -> SendEmailResponse:
         resp = await self._client.post(
             "/api/v1/send",
             json=body.model_dump(by_alias=True, exclude_none=True),
+            headers=_idempotency_header(idempotency_key),
         )
         _check_response(resp)
         return SendEmailResponse.model_validate(resp.json())
@@ -416,8 +423,15 @@ class AsyncE2AClient:
         conversation_id: Optional[str] = None,
         attachments: Optional[list[Attachment]] = None,
         agent_email: Optional[str] = None,
+        idempotency_key: Optional[str] = None,
     ) -> SendResult:
-        """Reply to an inbound email."""
+        """Reply to an inbound email.
+
+        ``idempotency_key`` is sent as the ``Idempotency-Key`` header.
+        Supply a stable key derived from the triggering event (e.g. the
+        inbound message id) to make this reply safe to retry; omit to
+        let the SDK generate a fresh UUIDv4 per call.
+        """
         email = self._require_agent_email(agent_email)
         req = ReplyToMessageRequest(
             body=body,
@@ -428,7 +442,7 @@ class AsyncE2AClient:
             conversation_id=conversation_id,
             attachments=_serialize_attachments(attachments),
         )
-        resp = await self.api.reply_to_message(email, message_id, req)
+        resp = await self.api.reply_to_message(email, message_id, req, idempotency_key=idempotency_key)
         return SendResult(
             status=resp.status or "",
             message_id=resp.message_id or "",
@@ -446,8 +460,15 @@ class AsyncE2AClient:
         conversation_id: Optional[str] = None,
         attachments: Optional[list[Attachment]] = None,
         agent_email: Optional[str] = None,
+        idempotency_key: Optional[str] = None,
     ) -> SendResult:
-        """Send a new email."""
+        """Send a new email.
+
+        ``idempotency_key`` is sent as the ``Idempotency-Key`` header.
+        Supply a stable key derived from the triggering event (e.g. a
+        job id) to make this send safe to retry; omit to let the SDK
+        generate a fresh UUIDv4 per call.
+        """
         email = self._require_agent_email(agent_email)
         req = SendEmailRequest(
             to=to,
@@ -460,7 +481,7 @@ class AsyncE2AClient:
             conversation_id=conversation_id,
             attachments=_serialize_attachments(attachments),
         )
-        resp = await self.api.send_email(req)
+        resp = await self.api.send_email(req, idempotency_key=idempotency_key)
         return SendResult(
             status=resp.status or "",
             message_id=resp.message_id or "",

--- a/sdks/python/src/e2a/v1/client.py
+++ b/sdks/python/src/e2a/v1/client.py
@@ -219,8 +219,16 @@ class E2AClient:
         conversation_id: Optional[str] = None,
         attachments: Optional[list[Attachment]] = None,
         agent_email: Optional[str] = None,
+        idempotency_key: Optional[str] = None,
     ) -> SendResult:
-        """Reply to an inbound email."""
+        """Reply to an inbound email.
+
+        ``idempotency_key`` is sent as the ``Idempotency-Key`` header.
+        Supply a stable key derived from the triggering event (e.g. the
+        inbound message id) to make this reply safe to retry; omit to
+        let the SDK generate a fresh UUIDv4 per call (network-layer
+        retry safety only).
+        """
         email = self._require_agent_email(agent_email)
         req = ReplyToMessageRequest(
             body=body,
@@ -231,7 +239,7 @@ class E2AClient:
             conversation_id=conversation_id,
             attachments=_serialize_attachments(attachments),
         )
-        resp = self.api.reply_to_message(email, message_id, req)
+        resp = self.api.reply_to_message(email, message_id, req, idempotency_key=idempotency_key)
         return SendResult(
             status=resp.status or "",
             message_id=resp.message_id or "",
@@ -249,8 +257,16 @@ class E2AClient:
         conversation_id: Optional[str] = None,
         attachments: Optional[list[Attachment]] = None,
         agent_email: Optional[str] = None,
+        idempotency_key: Optional[str] = None,
     ) -> SendResult:
-        """Send a new email."""
+        """Send a new email.
+
+        ``idempotency_key`` is sent as the ``Idempotency-Key`` header.
+        Supply a stable key derived from the triggering event (e.g. a
+        job id) to make this send safe to retry; omit to let the SDK
+        generate a fresh UUIDv4 per call (network-layer retry safety
+        only — does not help across an explicit retry loop).
+        """
         email = self._require_agent_email(agent_email)
         req = SendEmailRequest(
             to=to,
@@ -263,7 +279,7 @@ class E2AClient:
             conversation_id=conversation_id,
             attachments=_serialize_attachments(attachments),
         )
-        resp = self.api.send_email(req)
+        resp = self.api.send_email(req, idempotency_key=idempotency_key)
         return SendResult(
             status=resp.status or "",
             message_id=resp.message_id or "",

--- a/sdks/python/tests/test_idempotency.py
+++ b/sdks/python/tests/test_idempotency.py
@@ -1,0 +1,130 @@
+"""Tests for the Idempotency-Key transport behavior in the Python SDK."""
+
+import re
+
+import pytest
+
+from e2a.v1.api import E2AApi
+from e2a.v1.client import E2AClient
+from e2a.v1.generated import ReplyToMessageRequest, SendEmailRequest
+
+
+BASE = "https://e2a.dev"
+
+UUIDV4_RE = re.compile(
+    r"^[0-9a-f]{32}$|^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+
+def test_send_email_auto_generates_idempotency_key(httpx_mock):
+    httpx_mock.add_response(
+        url=f"{BASE}/api/v1/send",
+        method="POST",
+        json={"status": "sent", "message_id": "msg_abc", "method": "smtp"},
+    )
+
+    with E2AApi(api_key="e2a_test") as api:
+        api.send_email(
+            SendEmailRequest(to=["alice@example.com"], subject="x", body="y")
+        )
+
+    req = httpx_mock.get_request()
+    key = req.headers["Idempotency-Key"]
+    assert key, "Idempotency-Key header not set"
+    assert UUIDV4_RE.match(key), f"key {key!r} is not a UUIDv4 hex/canonical shape"
+
+
+def test_send_email_honors_caller_supplied_key(httpx_mock):
+    httpx_mock.add_response(
+        url=f"{BASE}/api/v1/send",
+        method="POST",
+        json={"status": "sent", "message_id": "msg_abc", "method": "smtp"},
+    )
+
+    with E2AApi(api_key="e2a_test") as api:
+        api.send_email(
+            SendEmailRequest(to=["alice@example.com"], subject="x", body="y"),
+            idempotency_key="user-supplied-key-42",
+        )
+
+    req = httpx_mock.get_request()
+    assert req.headers["Idempotency-Key"] == "user-supplied-key-42"
+
+
+def test_reply_to_message_carries_idempotency_key(httpx_mock):
+    httpx_mock.add_response(
+        url=f"{BASE}/api/v1/agents/bot%40test.dev/messages/msg_in_xyz/reply",
+        method="POST",
+        json={"status": "sent", "message_id": "msg_out_xyz", "method": "smtp"},
+    )
+
+    with E2AApi(api_key="e2a_test") as api:
+        api.reply_to_message(
+            "bot@test.dev",
+            "msg_in_xyz",
+            ReplyToMessageRequest(body="hi"),
+            idempotency_key="reply-key-1",
+        )
+
+    req = httpx_mock.get_request()
+    assert req.headers["Idempotency-Key"] == "reply-key-1"
+
+
+def test_send_email_generates_different_key_each_call(httpx_mock):
+    httpx_mock.add_response(
+        url=f"{BASE}/api/v1/send",
+        method="POST",
+        json={"status": "sent", "message_id": "msg_a", "method": "smtp"},
+    )
+    httpx_mock.add_response(
+        url=f"{BASE}/api/v1/send",
+        method="POST",
+        json={"status": "sent", "message_id": "msg_b", "method": "smtp"},
+    )
+
+    with E2AApi(api_key="e2a_test") as api:
+        api.send_email(SendEmailRequest(to=["a@b.com"], subject="x", body="y"))
+        api.send_email(SendEmailRequest(to=["a@b.com"], subject="x", body="y"))
+
+    reqs = httpx_mock.get_requests()
+    keys = [r.headers["Idempotency-Key"] for r in reqs]
+    assert len(keys) == 2
+    assert keys[0] != keys[1], "auto-generated keys should differ per call"
+
+
+def test_high_level_client_send_threads_idempotency_key(httpx_mock):
+    httpx_mock.add_response(
+        url=f"{BASE}/api/v1/send",
+        method="POST",
+        json={"status": "sent", "message_id": "msg_xyz", "method": "smtp"},
+    )
+
+    with E2AClient(
+        api_key="e2a_test", agent_email="bot@test.dev"
+    ) as client:
+        client.send(
+            ["alice@example.com"],
+            "x",
+            "y",
+            idempotency_key="client-key-99",
+        )
+
+    req = httpx_mock.get_request()
+    assert req.headers["Idempotency-Key"] == "client-key-99"
+
+
+def test_high_level_client_reply_threads_idempotency_key(httpx_mock):
+    httpx_mock.add_response(
+        url=f"{BASE}/api/v1/agents/bot%40test.dev/messages/msg_in_abc/reply",
+        method="POST",
+        json={"status": "sent", "message_id": "msg_out_abc", "method": "smtp"},
+    )
+
+    with E2AClient(
+        api_key="e2a_test", agent_email="bot@test.dev"
+    ) as client:
+        client.reply("msg_in_abc", "hi", idempotency_key="client-reply-key")
+
+    req = httpx_mock.get_request()
+    assert req.headers["Idempotency-Key"] == "client-reply-key"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -24,7 +24,7 @@
     "generate:types": "openapi-typescript /tmp/e2a-openapi3.yaml -o src/v1/generated/types.ts",
     "generate": "npm run generate:openapi3 && npm run generate:types",
     "test": "npm run test:unit",
-    "test:unit": "vitest run test/v1/api.test.ts test/v1/client.test.ts test/v1/verify.test.ts test/v1/ws.test.ts",
+    "test:unit": "vitest run test/v1/api.test.ts test/v1/client.test.ts test/v1/verify.test.ts test/v1/ws.test.ts test/v1/idempotency.test.ts",
     "test:contract": "vitest run test/v1/contract.test.ts",
     "test:live": "vitest run test/e2e.test.ts",
     "prepublishOnly": "npm run build"

--- a/sdks/typescript/src/v1/api.ts
+++ b/sdks/typescript/src/v1/api.ts
@@ -15,6 +15,40 @@ export interface E2AApiOptions {
 }
 
 /**
+ * Per-call options for side-effectful sends (sendEmail, replyToMessage).
+ *
+ * `idempotencyKey` is sent on the `Idempotency-Key` header. The server
+ * caches the response keyed by (user, key) and replays it on retry,
+ * preventing double-sends when the caller (or its retry layer, or the
+ * network) repeats the request. When omitted the SDK generates a
+ * fresh UUIDv4 per call — devs get the protection by default. To get
+ * real benefit across retries, the *caller* must supply a stable key
+ * that survives their retry loop (the per-call default does not).
+ */
+export interface SendOptions {
+  idempotencyKey?: string;
+}
+
+function newIdempotencyKey(): string {
+  // crypto.randomUUID() is available in Node 19+ and all modern
+  // browsers. Falls back to a Math.random hex if absent (deprecated
+  // runtimes only) — better than throwing at request time.
+  const c: { randomUUID?: () => string } | undefined =
+    typeof globalThis !== "undefined" ? (globalThis as { crypto?: { randomUUID?: () => string } }).crypto : undefined;
+  if (c?.randomUUID) return c.randomUUID();
+  return (
+    Date.now().toString(16) +
+    "-" +
+    Math.random().toString(16).slice(2) +
+    Math.random().toString(16).slice(2)
+  );
+}
+
+function idempotencyHeaders(opts: SendOptions): Record<string, string> {
+  return { "Idempotency-Key": opts.idempotencyKey ?? newIdempotencyKey() };
+}
+
+/**
  * Read an env var if `process.env` is reachable (Node), else "".
  * Exported so the high-level client can share the same browser-safe
  * lookup for `E2A_AGENT_EMAIL`.
@@ -129,11 +163,13 @@ export class E2AApi {
     email: string,
     messageId: string,
     body: Schemas["ReplyToMessageRequest"],
+    opts: SendOptions = {},
   ): Promise<Schemas["SendEmailResponse"]> {
     return this.request(
       "POST",
       `/api/v1/agents/${encodeURIComponent(email)}/messages/${encodeURIComponent(messageId)}/reply`,
       body,
+      { extraHeaders: idempotencyHeaders(opts) },
     );
   }
 
@@ -166,8 +202,11 @@ export class E2AApi {
 
   async sendEmail(
     body: Schemas["SendEmailRequest"],
+    opts: SendOptions = {},
   ): Promise<Schemas["SendEmailResponse"]> {
-    return this.request("POST", "/api/v1/send", body);
+    return this.request("POST", "/api/v1/send", body, {
+      extraHeaders: idempotencyHeaders(opts),
+    });
   }
 
   // ── HITL (human-in-the-loop approval) ───────────────────────────
@@ -268,8 +307,9 @@ export class E2AApi {
     method: string,
     path: string,
     body?: unknown,
+    opts: { extraHeaders?: Record<string, string> } = {},
   ): Promise<T> {
-    const resp = await this.raw(method, path, body);
+    const resp = await this.raw(method, path, body, opts);
     return resp.json() as Promise<T>;
   }
 
@@ -278,9 +318,11 @@ export class E2AApi {
     method: string,
     path: string,
     body?: unknown,
+    opts: { extraHeaders?: Record<string, string> } = {},
   ): Promise<Response> {
     const headers: Record<string, string> = {
       Authorization: `Bearer ${this.apiKey}`,
+      ...(opts.extraHeaders ?? {}),
     };
     if (body !== undefined) {
       headers["Content-Type"] = "application/json";

--- a/sdks/typescript/src/v1/client.ts
+++ b/sdks/typescript/src/v1/client.ts
@@ -212,6 +212,15 @@ export class E2AClient {
       conversationId?: string;
       attachments?: Schemas["internal_agent.Attachment"][];
       agentEmail?: string;
+      /**
+       * Stable key for retry-safe replies. When set, the server caches
+       * the response and replays it on retry with the same key + body.
+       * Omit to let the SDK generate a fresh per-call key (gives you
+       * network-layer retry safety but no benefit across explicit retry
+       * loops — for that, supply your own key derived from the
+       * triggering event).
+       */
+      idempotencyKey?: string;
     },
   ) {
     const req: Schemas["ReplyToMessageRequest"] = { body };
@@ -225,6 +234,7 @@ export class E2AClient {
       this.requireEmail(opts?.agentEmail),
       messageId,
       req,
+      { idempotencyKey: opts?.idempotencyKey },
     );
   }
 
@@ -259,6 +269,15 @@ export class E2AClient {
       conversationId?: string;
       attachments?: Schemas["internal_agent.Attachment"][];
       agentEmail?: string;
+      /**
+       * Stable key for retry-safe sends. When set, the server caches
+       * the response and replays it on retry with the same key + body.
+       * Omit to let the SDK generate a fresh per-call key (gives you
+       * network-layer retry safety but no benefit across explicit retry
+       * loops — for that, supply your own key derived from the
+       * triggering event).
+       */
+      idempotencyKey?: string;
     },
   ) {
     const req: Schemas["SendEmailRequest"] = {
@@ -272,7 +291,7 @@ export class E2AClient {
     if (opts?.bcc) req.bcc = opts.bcc;
     if (opts?.conversationId) req.conversation_id = opts.conversationId;
     if (opts?.attachments) req.attachments = opts.attachments;
-    return this.api.sendEmail(req);
+    return this.api.sendEmail(req, { idempotencyKey: opts?.idempotencyKey });
   }
 
   // ── HITL (human-in-the-loop approval) ───────────────────────────

--- a/sdks/typescript/src/v1/generated/types.ts
+++ b/sdks/typescript/src/v1/generated/types.ts
@@ -472,7 +472,10 @@ export interface paths {
         post: {
             parameters: {
                 query?: never;
-                header?: never;
+                header?: {
+                    /** @description Caller-generated unique key (recommend UUIDv4). Retries with the same key + same body replay the original response; with a different body return 422. */
+                    "Idempotency-Key"?: string;
+                };
                 path: {
                     /**
                      * @description Agent email address
@@ -541,6 +544,24 @@ export interface paths {
                 };
                 /** @description Message not found or does not belong to this agent */
                 404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Another request with this Idempotency-Key is in progress */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Idempotency-Key reused with a different request body */
+                422: {
                     headers: {
                         [name: string]: unknown;
                     };
@@ -1306,7 +1327,10 @@ export interface paths {
         post: {
             parameters: {
                 query?: never;
-                header?: never;
+                header?: {
+                    /** @description Caller-generated unique key (recommend UUIDv4). Retries with the same key + same body replay the original response; with a different body return 422. */
+                    "Idempotency-Key"?: string;
+                };
                 path?: never;
                 cookie?: never;
             };
@@ -1355,6 +1379,24 @@ export interface paths {
                 };
                 /** @description Agent domain not verified */
                 403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Another request with this Idempotency-Key is in progress */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Idempotency-Key reused with a different request body */
+                422: {
                     headers: {
                         [name: string]: unknown;
                     };

--- a/sdks/typescript/src/v1/index.ts
+++ b/sdks/typescript/src/v1/index.ts
@@ -4,7 +4,7 @@ export type * from "./generated/types.js";
 
 // Hand-written v1 SDK surface
 export { E2AApi, E2AApiError } from "./api.js";
-export type { E2AApiOptions } from "./api.js";
+export type { E2AApiOptions, SendOptions } from "./api.js";
 export { E2AClient } from "./client.js";
 export type { E2AClientOptions } from "./client.js";
 export { InboundEmail, UnverifiedEmailError } from "./inbound-email.js";

--- a/sdks/typescript/test/v1/idempotency.test.ts
+++ b/sdks/typescript/test/v1/idempotency.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { E2AApi, E2AClient } from "../../src/v1/index.js";
+
+const BASE = "http://localhost:9998";
+
+/**
+ * Capture the headers passed to fetch() on the most recent call.
+ * Returns a mock + a getter for the last set of headers seen.
+ */
+function spyFetch(status = 200, body: unknown = { status: "sent", message_id: "msg_xyz" }) {
+  let lastHeaders: Record<string, string> = {};
+  const mock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+    lastHeaders = (init?.headers as Record<string, string>) ?? {};
+    return {
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve(body),
+      text: () => Promise.resolve(JSON.stringify(body ?? "")),
+    } as Partial<Response> as Response;
+  });
+  return { mock, lastHeaders: () => lastHeaders };
+}
+
+describe("Idempotency-Key transport behavior", () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("sendEmail auto-generates a UUIDv4 Idempotency-Key when none supplied", async () => {
+    const spy = spyFetch();
+    globalThis.fetch = spy.mock;
+
+    const api = new E2AApi({ apiKey: "e2a_test", baseUrl: BASE });
+    await api.sendEmail({
+      to: ["alice@example.com"],
+      subject: "x",
+      body: "y",
+    });
+
+    const headers = spy.lastHeaders();
+    expect(headers["Idempotency-Key"]).toBeDefined();
+    // UUIDv4 has the canonical 8-4-4-4-12 hex shape.
+    expect(headers["Idempotency-Key"]).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+    );
+  });
+
+  it("sendEmail honors a caller-supplied Idempotency-Key verbatim", async () => {
+    const spy = spyFetch();
+    globalThis.fetch = spy.mock;
+
+    const api = new E2AApi({ apiKey: "e2a_test", baseUrl: BASE });
+    await api.sendEmail(
+      { to: ["alice@example.com"], subject: "x", body: "y" },
+      { idempotencyKey: "user-supplied-key-42" },
+    );
+
+    expect(spy.lastHeaders()["Idempotency-Key"]).toBe("user-supplied-key-42");
+  });
+
+  it("replyToMessage carries the Idempotency-Key header", async () => {
+    const spy = spyFetch();
+    globalThis.fetch = spy.mock;
+
+    const api = new E2AApi({ apiKey: "e2a_test", baseUrl: BASE });
+    await api.replyToMessage(
+      "bot@test.dev",
+      "msg_in_abc",
+      { body: "hi" },
+      { idempotencyKey: "reply-key-1" },
+    );
+
+    expect(spy.lastHeaders()["Idempotency-Key"]).toBe("reply-key-1");
+  });
+
+  it("sendEmail generates a different key on each call by default", async () => {
+    const spy = spyFetch();
+    globalThis.fetch = spy.mock;
+
+    const api = new E2AApi({ apiKey: "e2a_test", baseUrl: BASE });
+    await api.sendEmail({ to: ["a@b.com"], subject: "x", body: "y" });
+    const k1 = spy.lastHeaders()["Idempotency-Key"];
+    await api.sendEmail({ to: ["a@b.com"], subject: "x", body: "y" });
+    const k2 = spy.lastHeaders()["Idempotency-Key"];
+
+    expect(k1).toBeDefined();
+    expect(k2).toBeDefined();
+    expect(k1).not.toBe(k2);
+  });
+
+  it("high-level E2AClient.send threads idempotencyKey through", async () => {
+    const spy = spyFetch();
+    globalThis.fetch = spy.mock;
+
+    const client = new E2AClient({
+      apiKey: "e2a_test",
+      baseUrl: BASE,
+      agentEmail: "bot@test.dev",
+    });
+    await client.send(["alice@example.com"], "x", "y", {
+      idempotencyKey: "client-key-99",
+    });
+    expect(spy.lastHeaders()["Idempotency-Key"]).toBe("client-key-99");
+  });
+
+  it("high-level E2AClient.reply threads idempotencyKey through", async () => {
+    const spy = spyFetch();
+    globalThis.fetch = spy.mock;
+
+    const client = new E2AClient({
+      apiKey: "e2a_test",
+      baseUrl: BASE,
+      agentEmail: "bot@test.dev",
+    });
+    await client.reply("msg_in_abc", "hi", { idempotencyKey: "client-reply-key" });
+    expect(spy.lastHeaders()["Idempotency-Key"]).toBe("client-reply-key");
+  });
+});

--- a/web/public/openapi.yaml
+++ b/web/public/openapi.yaml
@@ -1373,6 +1373,12 @@ paths:
         required: true
         schema:
           $ref: '#/definitions/ReplyToMessageRequest'
+      - description: Caller-generated unique key (recommend UUIDv4). Retries with
+          the same key + same body replay the original response; with a different
+          body return 422.
+        in: header
+        name: Idempotency-Key
+        type: string
       produces:
       - application/json
       responses:
@@ -1398,6 +1404,14 @@ paths:
             type: string
         "404":
           description: Message not found or does not belong to this agent
+          schema:
+            type: string
+        "409":
+          description: Another request with this Idempotency-Key is in progress
+          schema:
+            type: string
+        "422":
+          description: Idempotency-Key reused with a different request body
           schema:
             type: string
         "429":
@@ -1821,6 +1835,12 @@ paths:
         required: true
         schema:
           $ref: '#/definitions/SendEmailRequest'
+      - description: Caller-generated unique key (recommend UUIDv4). Retries with
+          the same key + same body replay the original response; with a different
+          body return 422.
+        in: header
+        name: Idempotency-Key
+        type: string
       produces:
       - application/json
       responses:
@@ -1842,6 +1862,14 @@ paths:
             type: string
         "403":
           description: Agent domain not verified
+          schema:
+            type: string
+        "409":
+          description: Another request with this Idempotency-Key is in progress
+          schema:
+            type: string
+        "422":
+          description: Idempotency-Key reused with a different request body
           schema:
             type: string
         "429":


### PR DESCRIPTION
## Summary

Two related slices on one PR. Together they give the outbound send path
end-to-end exactly-once semantics under retry — for both the caller
(via the new `Idempotency-Key` header) and the internal HITL approval
flow (via the new `send_attempts` table).

### Slice 1 — Caller-facing `Idempotency-Key`

Stripe-style header on `POST /api/v1/send` and `POST /api/v1/agents/{email}/messages/{id}/reply`:

- Same key + same body → cached response replayed verbatim (`Idempotent-Replayed: true`).
- Same key + different body → 422.
- In-flight duplicate → 409.
- No header → existing behavior, unchanged.
- 24h TTL, scoped per user, swept by the existing hourly cleanup loop.

Why now: LLM agents have more sources of duplicate sends than typical
backends (framework-level tool retries, model-driven re-invocations,
orchestrator at-least-once semantics). Header is optional; no
existing caller is affected.

Scope choice: keyed by `(user_id, key)` rather than `(api_key_id, key)`.
API keys are credentials, not identities; threading the credential id
through `authenticateUser` is invasive. UUIDv4 collision risk across a
single user's keys is negligible, and the body-hash check catches
pathological collisions explicitly with 422. Matches Stripe's
account-level model. Rationale captured in the migration comment.

### Slice 2 — Internal exactly-once: `send_attempts`

Closes the documented crash window at `internal/identity/store.go`
where `send()` could succeed at SES but the approval transaction
then failed to commit — causing a retry to re-send. The new
`send_attempts` table records SES outcomes in two small auxiliary
transactions that bracket the upstream call and outlive any
rollback of the surrounding approval tx. On retry, `ClaimSendAttempt`
returns `AlreadySent` with the recorded `SendResult` and the
upstream send is skipped.

Side-fix: downgraded the messages-row lock from `FOR UPDATE` to
`FOR NO KEY UPDATE`. The original lock blocked the FK-enforcement
(`KEY SHARE`) lock needed by the separate-connection
`send_attempts` INSERT — would deadlock without this change.
`FOR NO KEY UPDATE` preserves all approval-side serialization
semantics (only allows concurrent FK insertions, which is exactly
what we need).

### SDKs

- TS + Python: optional `idempotencyKey` on `sendEmail` / `replyToMessage`
  and the high-level `client.send` / `client.reply`. Defaults to a
  fresh UUIDv4 per call so callers get transport-layer safety by
  default. To get cross-retry-loop safety, callers supply a stable
  key derived from their triggering event (job id, inbound message id, etc.).
- Swagger annotations + regenerated `openapi.yaml` and TS types.

## Tests

- **Idempotency store** (DB-backed, 11 cases): fresh acquire, replay,
  body-mismatch, in-flight, stale takeover, cross-user isolation,
  release semantics, double-Complete is no-op, TTL sweep, sweep
  preserves active claims, 25-goroutine concurrent same-key race
  (exactly one acquires).
- **API integration** (HTTP-level, 6 cases): replay returns identical
  body + `Idempotent-Replayed: true`, no second SMTP send;
  body-mismatch returns 422; key >255 chars returns 400; no-key
  path unchanged with two SMTP sends; 6-goroutine concurrent same-key
  request produces exactly one SMTP send; reply endpoint replays.
- **send_attempts store** (DB-backed, 5 cases): state-machine matrix
  + 20-goroutine concurrent race.
- **ApproveAndSend exactly-once** (DB-backed, 3 cases): simulated
  tx-rollback retry calls `send()` exactly once and finalizes the
  message row with the cached `SendResult`; `send()` failure goes to
  `failed` and allows retry; planted stale `attempting` row produces
  `ErrSendInProgress` without invoking `send()`.
- **TS SDK** (6 cases): header auto-generation matches UUIDv4 shape,
  caller key wins, each call gets a different default key, threads
  through `E2AClient.send` / `.reply`.
- **Python SDK** (6 cases): same coverage, sync client.

## Verification

```
make test          # full Go suite (-tags integration -p 1)
npm test --workspace @e2a/sdk   # 82 tests pass
pytest sdks/python/tests        # 190 tests pass
```

The pre-existing `internal/e2e` build error (`p.Body.To != "string"` —
`Body.To` is `[]string`) on `main` is unrelated to this PR and was
not introduced by it.

## Test plan

- [ ] CI passes (Go + TS + Python suites, contract tests)
- [ ] Manual: against a dev instance, `curl -H 'Idempotency-Key: foo' POST /api/v1/send` twice with the same payload — second response is byte-identical, only one mail in Mailpit
- [ ] Manual: same key with a different body — second response is 422
- [ ] Manual: simulate HITL approve where SES succeeds but the approval tx is force-rolled-back; reapprove → no double-send in Mailpit

🤖 Generated with [Claude Code](https://claude.com/claude-code)