### PR TITLE
release: SDKs 2.3.0, CLI 1.4.0, MCP 0.3.4

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/cli",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "description": "CLI for e2a — email for AI agents",
   "bin": {
     "e2a": "./dist/bin/e2a.js"
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/Mnexa-AI/e2a/tree/main/cli",
   "bugs": "https://github.com/Mnexa-AI/e2a/issues",
   "dependencies": {
-    "@e2a/sdk": "^2.2.0"
+    "@e2a/sdk": "^2.3.0"
   },
   "devDependencies": {
     "@types/node": "^25.9.1",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/mcp-server",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "MCP server for e2a — email for AI agents",
   "mcpName": "io.github.Mnexa-AI/mcp-server",
   "bin": {
@@ -43,7 +43,7 @@
   "homepage": "https://github.com/Mnexa-AI/e2a/tree/main/mcp",
   "bugs": "https://github.com/Mnexa-AI/e2a/issues",
   "dependencies": {
-    "@e2a/sdk": "^2.2.0",
+    "@e2a/sdk": "^2.3.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.5",
     "express": "^5.0.0",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -9,13 +9,13 @@
     "source": "github",
     "subfolder": "mcp"
   },
-  "version": "0.3.3",
+  "version": "0.3.4",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@e2a/mcp-server",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "transport": {
         "type": "stdio"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,10 @@
     },
     "cli": {
       "name": "@e2a/cli",
-      "version": "1.3.4",
+      "version": "1.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@e2a/sdk": "^2.2.0"
+        "@e2a/sdk": "^2.3.0"
       },
       "bin": {
         "e2a": "dist/bin/e2a.js"
@@ -32,10 +32,10 @@
     },
     "mcp": {
       "name": "@e2a/mcp-server",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "Apache-2.0",
       "dependencies": {
-        "@e2a/sdk": "^2.2.0",
+        "@e2a/sdk": "^2.3.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.0.0",
@@ -3209,7 +3209,7 @@
     },
     "sdks/typescript": {
       "name": "@e2a/sdk",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "Apache-2.0",
       "dependencies": {
         "mailparser": "^3.9.8",

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -65,3 +65,22 @@ The webhook payload schema now includes an optional `reply_to: string[]`
 field. Existing consumers that ignore unknown fields are unaffected; older
 SDK versions parsing the same payload continue to work and simply do not
 see the new key.
+
+### Other generated-type additions
+The high-level surface above is what most consumers will touch. For users
+of `client.api.*` or `e2a.v1.generated.*` directly, the following backend
+endpoints / fields also landed since 2.2.0 and are reflected in the
+regenerated types:
+
+- Per-record DNS verification — separate MX / SPF / DKIM diagnostic
+  responses on the domain-verification endpoints.
+- Enriched `DashboardAgent` — `Inbound7d`, `Outbound7d`, `Pending`,
+  `LastDelivery`, `WebhookHealthy` fields on the dashboard list.
+- OAuth 2.1 authorization-server endpoints (fosite-backed) used by the
+  MCP server flow.
+- Per-domain DKIM key generation endpoint.
+- One-time signing-secret reveal on creation.
+- Pending-review polish — provenance, quoted-inbound, headers-preview,
+  draft-footer fields on the review payload.
+
+These are additive and don't break existing 2.2.0 callers.

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Changelog
 
-## Unreleased
+## 2.3.0
 
 ### Added
+- `idempotency_key` parameter on `E2AClient.send()` / `.reply()` and their async
+  counterparts (and on the lower-level `E2AApi.send_email()` /
+  `reply_to_message()`). When supplied, it is sent as the `Idempotency-Key`
+  header so the server can deduplicate retries of the same send/reply. When
+  omitted, the SDK generates a fresh UUIDv4 per call — that gives
+  network-layer retry safety only; supply a stable key derived from the
+  triggering event (e.g. the inbound message id or a job id) to deduplicate
+  across an explicit retry loop.
 - `InboundEmail.reply_to` and `AsyncInboundEmail.reply_to` (`list[str]`) — the
   parsed `Reply-To:` header from the inbound message, surfaced as a first-class
   field so consumers no longer need to re-parse `raw_message` with stdlib

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "e2a"
-version = "2.2.0"
+version = "2.3.0"
 description = "Python SDK for the e2a protocol — email-to-agent authentication"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/sdk",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "TypeScript SDK for e2a — email for AI agents",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

Bundled release commit covering the four publishable packages, all driven by features that already landed on `main` (Idempotency-Key #143, reply_to / dashboard / DKIM-diag / per-record DNS / OAuth 2.1 / SES double-send fix).

- **Python SDK** 2.2.0 → 2.3.0 — `idempotency_key` on `send()` / `reply()` (+ async + low-level), `reply_to` on inbound + REST list, CHANGELOG entry.
- **TypeScript SDK** 2.2.0 → 2.3.0 — matching idempotency-key + reply_to surface.
- **CLI** 1.3.4 → 1.4.0 — picks up `@e2a/sdk ^2.3.0`.
- **MCP server** 0.3.3 → 0.3.4 — deps refresh (zod 3→4, @types/node 25.9) and `@e2a/sdk ^2.3.0`.

Each publish is gated on its own tag/workflow after merge:
- `python-v2.3.0` → triggers `publish-sdk.yml`
- `ts-sdk-v2.3.0` → triggers `publish-ts-sdk.yml`
- `mcp-v0.3.4` → triggers `publish-mcp.yml`
- CLI 1.4.0 → `gh workflow run "Publish CLI" --ref main`

### Publish order (important)
`cli@1.4.0` and `mcp@0.3.4` both pin `@e2a/sdk ^2.3.0`. The CLI / MCP publish workflows do a fresh `npm install` from the registry, so they will fail to resolve `@e2a/sdk@^2.3.0` until `ts-sdk-v2.3.0` finishes publishing. Sequence after merge:

1. Push `python-v2.3.0` and `ts-sdk-v2.3.0` (these are independent).
2. **Wait for `publish-ts-sdk.yml` to finish and `@e2a/sdk@2.3.0` to appear on npm.**
3. Push `mcp-v0.3.4` and run `gh workflow run "Publish CLI" --ref main`.

## Test plan
- [x] `npm run build` for `@e2a/sdk`, `@e2a/cli`, `@e2a/mcp-server` — all green locally.
- [x] `npm test` for all three workspaces — SDK 82, CLI 100, MCP 84 tests pass.
- [ ] CI on this PR (`Python SDK tests`, `Python SDK contract tests`, etc.).
- [ ] Tags pushed after merge (in the order above) → each `publish-*.yml` validates and publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)