### PR TITLE
fix(relay): decode RFC 2047 encoded subjects at inbound parse

### DIFF
--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"io"
 	"log"
+	"mime"
 	"net"
 	"net/mail"
 	"strings"
@@ -433,7 +434,7 @@ func extractThreadInfo(body []byte) threadInfo {
 	}
 	return threadInfo{
 		MessageID:      msg.Header.Get("Message-Id"),
-		Subject:        msg.Header.Get("Subject"),
+		Subject:        decodeMIMEHeader(msg.Header.Get("Subject")),
 		InReplyTo:      msg.Header.Get("In-Reply-To"),
 		References:     refs,
 		From:           fromHeader,
@@ -445,6 +446,22 @@ func extractThreadInfo(body []byte) threadInfo {
 		CC:             extractAddressList(msg.Header.Get("Cc")),
 		ConversationID: msg.Header.Get("X-E2A-Conversation-Id"),
 	}
+}
+
+// decodeMIMEHeader decodes any RFC 2047 encoded-word runs in a header value
+// (e.g. `=?utf-8?Q?caf=C3=A9?=` → `café`). Used for display fields like
+// Subject so downstream consumers (DB, list summaries, dashboard) see the
+// UTF-8 form instead of the wire-encoded form. If decoding fails the original
+// value is returned — preserving the field is better than dropping it.
+func decodeMIMEHeader(v string) string {
+	if v == "" {
+		return v
+	}
+	decoded, err := (&mime.WordDecoder{}).DecodeHeader(v)
+	if err != nil {
+		return v
+	}
+	return decoded
 }
 
 // extractAddressList parses an RFC 5322 address-list header (To/Cc) into bare

--- a/internal/relay/server_test.go
+++ b/internal/relay/server_test.go
@@ -212,6 +212,47 @@ func TestExtractThreadInfoMalformed(t *testing.T) {
 	}
 }
 
+// TestExtractThreadInfoDecodesEncodedSubject covers RFC 2047 encoded-word
+// subjects like the ones SES emits for unicode characters. Storing the wire
+// form leaked `=?utf-8?q?...?=` into list summaries, dashboards, and the CLI
+// inbox — every consumer that didn't independently re-parse raw_message.
+func TestExtractThreadInfoDecodesEncodedSubject(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{
+			name: "Q-encoded em dash",
+			raw:  "Message-Id: <x@send.e2a.dev>\r\nSubject: =?utf-8?q?e2a_MCP_e2e_=E2=80=94_HITL_approve_path?=\r\nFrom: a@b.com\r\nTo: c@d.com\r\n\r\nHi\r\n",
+			want: "e2a MCP e2e — HITL approve path",
+		},
+		{
+			name: "B-encoded utf-8",
+			raw:  "Message-Id: <x@send.e2a.dev>\r\nSubject: =?utf-8?B?Y2Fmw6k=?=\r\nFrom: a@b.com\r\nTo: c@d.com\r\n\r\nHi\r\n",
+			want: "café",
+		},
+		{
+			name: "plain ASCII passes through untouched",
+			raw:  "Message-Id: <x@send.e2a.dev>\r\nSubject: Plain ASCII\r\nFrom: a@b.com\r\nTo: c@d.com\r\n\r\nHi\r\n",
+			want: "Plain ASCII",
+		},
+		{
+			name: "malformed encoded-word falls back to raw",
+			raw:  "Message-Id: <x@send.e2a.dev>\r\nSubject: =?utf-8?q?broken\r\nFrom: a@b.com\r\nTo: c@d.com\r\n\r\nHi\r\n",
+			want: "=?utf-8?q?broken",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractThreadInfo([]byte(tc.raw)).Subject
+			if got != tc.want {
+				t.Errorf("Subject = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestSessionResetClearsThreadInfo(t *testing.T) {
 	s := &session{
 		from:           "alice@example.com",


### PR DESCRIPTION
## Summary
Subjects like `=?utf-8?q?caf=C3=A9?=` were stored verbatim in `messages.subject`, leaking the wire form to every list-summary surface — REST `GET /messages`, web inbox ([ThreadRow.tsx:134](web/src/app/components/messages/ThreadRow.tsx#L134), [messages/view/page.tsx:357](web/src/app/\(app\)/dashboard/agents/messages/view/page.tsx#L357)), CLI `e2a inbox` ([cli/src/commands/inbox.ts:38](cli/src/commands/inbox.ts#L38)), MCP `list_messages`. The detail path only worked by accident because both SDKs re-parse `raw_message` to extract a clean subject ([TS inbound-email.ts:431-449](sdks/typescript/src/v1/inbound-email.ts#L431-L449), [Python handler.py:548-552](sdks/python/src/e2a/v1/handler.py#L548-L552)).

Discovered via MCP e2e — `list_messages` returned `=?utf-8?q?e2a_MCP_e2e_=E2=80=94_HITL_approve_path?=` while `get_message` returned the decoded form for the same row.

## Fix
One-line decode at the relay's `extractThreadInfo` ([internal/relay/server.go:436](internal/relay/server.go#L436)). New `decodeMIMEHeader` helper uses `mime.WordDecoder.DecodeHeader`; falls back to the raw value on decode error so a malformed encoded-word never drops the subject entirely.

## Header audit
Only Subject leaks today:
- `Message-Id`, `In-Reply-To`, `References` — opaque IDs, no display text.
- `From` / `Reply-To` / `To` / `Cc` — go through `mail.ParseAddress*`; we discard display names and keep only the bare address.
- Attachment filenames are decoded downstream by mailparser / `email.policy.default` when the body is parsed.

## Test plan
- [x] New `TestExtractThreadInfoDecodesEncodedSubject` — Q-encoded, B-encoded, plain ASCII passthrough, malformed fallback.
- [x] Full `internal/relay/...` suite green.
- [x] `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)