### PR TITLE
fix(api): idempotencyGuard on approve endpoint

### DIFF
--- a/internal/agent/hitl_api.go
+++ b/internal/agent/hitl_api.go
@@ -389,6 +389,15 @@ func (a *API) handleApprovePendingMessage(w http.ResponseWriter, r *http.Request
 		}
 		return
 	}
+	// SES has accepted the send and the outbound row has transitioned
+	// to 'sent' with body scrubbed. Past this point any handler-side
+	// failure (usage recording, log write, response flush) must NOT
+	// release the idempotency key — a retry would either re-fire SES
+	// or short-circuit via send_attempts and return a 200 with a
+	// different body than the first call's 5xx. Mirrors the
+	// markSideEffectCommitted call at internal/agent/api.go:1413,1440
+	// for send and 1713,1737 for reply.
+	markSideEffectCommitted(w)
 
 	// Record usage only after the message actually leaves the gateway.
 	if _, err := a.usage.RecordAndCheck(r.Context(), user.ID, agent.ID, agent.Domain, "outbound"); err != nil {

--- a/internal/agent/hitl_api.go
+++ b/internal/agent/hitl_api.go
@@ -274,8 +274,7 @@ func (req approveRequest) toEdit() (identity.PendingApprovalEdit, error) {
 // @Failure      401 {string} string "Missing or invalid API key"
 // @Failure      403 {string} string "Agent domain not verified"
 // @Failure      404 {string} string "Message not found or not owned by this user"
-// @Failure      409 {string} string "Message is no longer pending approval"
-// @Failure      409 {string} string "Another request with this Idempotency-Key is in progress"
+// @Failure      409 {string} string "Message is no longer pending approval, or another request with this Idempotency-Key is in progress"
 // @Failure      422 {string} string "Idempotency-Key reused with a different request body"
 // @Param        Idempotency-Key header string false "Caller-generated unique key (recommend UUIDv4). Approve fires a real outbound send (SES); on retry with the same key + same body the server replays the original response instead of double-sending. A different body returns 422."
 // @Router       /api/v1/messages/{id}/approve [post]

--- a/internal/agent/hitl_api.go
+++ b/internal/agent/hitl_api.go
@@ -275,6 +275,9 @@ func (req approveRequest) toEdit() (identity.PendingApprovalEdit, error) {
 // @Failure      403 {string} string "Agent domain not verified"
 // @Failure      404 {string} string "Message not found or not owned by this user"
 // @Failure      409 {string} string "Message is no longer pending approval"
+// @Failure      409 {string} string "Another request with this Idempotency-Key is in progress"
+// @Failure      422 {string} string "Idempotency-Key reused with a different request body"
+// @Param        Idempotency-Key header string false "Caller-generated unique key (recommend UUIDv4). Approve fires a real outbound send (SES); on retry with the same key + same body the server replays the original response instead of double-sending. A different body returns 422."
 // @Router       /api/v1/messages/{id}/approve [post]
 func (a *API) handleApprovePendingMessage(w http.ResponseWriter, r *http.Request) {
 	user, err := a.authenticateUser(r)
@@ -285,16 +288,34 @@ func (a *API) handleApprovePendingMessage(w http.ResponseWriter, r *http.Request
 
 	messageID := mux.Vars(r)["id"]
 
+	// Read the body up front so the idempotency guard can hash it. Approve
+	// is side-effectful (it triggers an SES send) so a retry without the
+	// guard would double-send; symmetric with handleSendEmail /
+	// handleReplyToMessage.
+	bodyBytes, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxRequestBytesSmall))
+	if err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	replayed, captureW, finalize := a.idempotencyGuard(w, r, user.ID, bodyBytes)
+	if replayed {
+		return
+	}
+	defer finalize()
+	w = captureW
+
 	var req approveRequest
 	// Empty body is allowed (approve-as-is). Only error if body is present
 	// but malformed. We deliberately do NOT gate on r.ContentLength > 0
 	// because Transfer-Encoding: chunked yields ContentLength == -1; that
 	// would silently drop the reviewer's overrides (subject/body/to/cc/bcc/
-	// attachment edits) and send the stored draft as-is. readJSON returns
-	// io.EOF on a truly-empty body, which we treat as "approve-as-is".
-	if err := readJSON(w, r, &req, maxRequestBytesSmall); err != nil && !errors.Is(err, io.EOF) {
-		http.Error(w, "invalid request body", http.StatusBadRequest)
-		return
+	// attachment edits) and send the stored draft as-is.
+	if len(bodyBytes) > 0 {
+		if err := json.Unmarshal(bodyBytes, &req); err != nil {
+			http.Error(w, "invalid request body", http.StatusBadRequest)
+			return
+		}
 	}
 	edits, err := req.toEdit()
 	if err != nil {

--- a/internal/agent/idempotency_api_test.go
+++ b/internal/agent/idempotency_api_test.go
@@ -307,3 +307,176 @@ func TestSendEmail_IdempotencyKey_ClientErrorReleasesKey(t *testing.T) {
 		t.Errorf("SMTP messages sent = %d, want 1 (only the second call should send)", len(msgs))
 	}
 }
+
+// setupHITLSendingAgent provisions a fully-onboarded HITL-enabled sending
+// agent for the approve-idempotency tests. Mirrors setupVerifiedSendingAgent
+// but also flips hitl_enabled so that POST /api/v1/send produces a pending
+// row instead of sending immediately.
+func setupHITLSendingAgent(t *testing.T, namePrefix string) (serverURL string, smtpDone func() []testutil.SMTPMessage, apiKey string) {
+	t.Helper()
+	srv, store, _, done := setupAPIWithSMTP(t)
+	ctx := context.Background()
+	user, err := store.CreateOrGetUser(ctx, namePrefix+"-owner@example.com", "Owner", "google-"+namePrefix)
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	keyObj, err := store.CreateAPIKey(ctx, user.ID, namePrefix+"-key", nil)
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+	domain := namePrefix + ".example.com"
+	if _, err := store.ClaimOrCreateDomain(ctx, domain, user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+	if err := store.VerifyDomain(ctx, domain, user.ID); err != nil {
+		t.Fatalf("VerifyDomain: %v", err)
+	}
+	agent, err := store.CreateAgent(ctx, "agent@"+domain, domain, "", "https://example.com/webhook", "", user.ID)
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	enableHITL(t, store, agent.ID, user.ID)
+	return srv.URL, done, keyObj.PlaintextKey
+}
+
+// createPendingMessage runs POST /api/v1/send against an HITL-enabled agent
+// and returns the resulting pending message_id. The send response is 202
+// pending_approval; no SMTP traffic at this point.
+func createPendingMessage(t *testing.T, serverURL, apiKey string) string {
+	t.Helper()
+	resp, err := http.DefaultClient.Do(idempotencyRequest(t, "POST", serverURL+"/api/v1/send",
+		`{"to":["alice@example.com"],"subject":"Hi","body":"draft body"}`,
+		apiKey, ""))
+	if err != nil {
+		t.Fatalf("send: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("send setup: status=%d body=%s", resp.StatusCode, body)
+	}
+	var sb struct{ MessageID string `json:"message_id"` }
+	if err := json.NewDecoder(resp.Body).Decode(&sb); err != nil {
+		t.Fatalf("decode send response: %v", err)
+	}
+	if sb.MessageID == "" {
+		t.Fatal("send returned no message_id")
+	}
+	return sb.MessageID
+}
+
+// TestApprovePending_IdempotencyKey_DuplicateReplaysAndSkipsResend covers
+// the SES double-fire window: a retried approve with the same key must
+// replay the original response byte-for-byte and must NOT re-hit SMTP.
+// Without the guard, a transient client retry after a successful approve
+// would double-send the same email.
+func TestApprovePending_IdempotencyKey_DuplicateReplaysAndSkipsResend(t *testing.T) {
+	serverURL, smtpDone, apiKey := setupHITLSendingAgent(t, "approve-idem-replay")
+	msgID := createPendingMessage(t, serverURL, apiKey)
+
+	idemKey := "approve-replay-001"
+	url := serverURL + "/api/v1/messages/" + msgID + "/approve"
+
+	// First approve: empty body (approve-as-is). One SMTP message expected.
+	resp1, err := http.DefaultClient.Do(idempotencyRequest(t, "POST", url, "", apiKey, idemKey))
+	if err != nil {
+		t.Fatalf("first approve: %v", err)
+	}
+	body1, _ := io.ReadAll(resp1.Body)
+	resp1.Body.Close()
+	if resp1.StatusCode != 200 {
+		t.Fatalf("first status = %d, body = %s", resp1.StatusCode, body1)
+	}
+	if resp1.Header.Get("Idempotent-Replayed") != "" {
+		t.Errorf("first call should not be marked replayed, got %q", resp1.Header.Get("Idempotent-Replayed"))
+	}
+
+	// Second approve: same key + same (empty) body must replay, NOT re-send.
+	resp2, err := http.DefaultClient.Do(idempotencyRequest(t, "POST", url, "", apiKey, idemKey))
+	if err != nil {
+		t.Fatalf("second approve: %v", err)
+	}
+	body2, _ := io.ReadAll(resp2.Body)
+	resp2.Body.Close()
+	if resp2.StatusCode != 200 {
+		t.Fatalf("second status = %d, body = %s", resp2.StatusCode, body2)
+	}
+	if resp2.Header.Get("Idempotent-Replayed") != "true" {
+		t.Errorf("Idempotent-Replayed = %q, want \"true\"", resp2.Header.Get("Idempotent-Replayed"))
+	}
+	if !bytes.Equal(body1, body2) {
+		t.Errorf("replay body diverged:\nfirst:  %s\nsecond: %s", body1, body2)
+	}
+
+	msgs := smtpDone()
+	if len(msgs) != 1 {
+		t.Errorf("SMTP messages sent = %d, want exactly 1 (replay must not re-fire SES)", len(msgs))
+	}
+}
+
+// TestApprovePending_IdempotencyKey_DifferentBodyReturns422 covers the
+// safety property of the guard: a retry with the same key but different
+// override body is treated as a different request and rejected, not
+// silently replayed. Without this, a reviewer who fat-fingers an edit
+// and retries could end up with the wrong content sent.
+func TestApprovePending_IdempotencyKey_DifferentBodyReturns422(t *testing.T) {
+	serverURL, smtpDone, apiKey := setupHITLSendingAgent(t, "approve-idem-mismatch")
+	msgID := createPendingMessage(t, serverURL, apiKey)
+
+	idemKey := "approve-mismatch-001"
+	url := serverURL + "/api/v1/messages/" + msgID + "/approve"
+
+	// First approve with override A.
+	resp1, err := http.DefaultClient.Do(idempotencyRequest(t, "POST", url,
+		`{"subject":"Edited A"}`, apiKey, idemKey))
+	if err != nil {
+		t.Fatalf("first approve: %v", err)
+	}
+	resp1.Body.Close()
+	if resp1.StatusCode != 200 {
+		t.Fatalf("first status = %d", resp1.StatusCode)
+	}
+
+	// Second approve, same key, different override body. Must 422.
+	resp2, err := http.DefaultClient.Do(idempotencyRequest(t, "POST", url,
+		`{"subject":"Edited B"}`, apiKey, idemKey))
+	if err != nil {
+		t.Fatalf("second approve: %v", err)
+	}
+	resp2.Body.Close()
+	if resp2.StatusCode != http.StatusUnprocessableEntity {
+		t.Errorf("second status = %d, want 422", resp2.StatusCode)
+	}
+
+	msgs := smtpDone()
+	if len(msgs) != 1 {
+		t.Errorf("SMTP messages sent = %d, want 1 (the 422 must not re-fire)", len(msgs))
+	}
+}
+
+// TestApprovePending_NoIdempotencyKey_BehavesAsBefore guarantees the
+// guard is opt-in: legacy clients that don't set the header still get
+// the pre-2.4 approve behavior (single send, no replay header).
+func TestApprovePending_NoIdempotencyKey_BehavesAsBefore(t *testing.T) {
+	serverURL, smtpDone, apiKey := setupHITLSendingAgent(t, "approve-no-idem")
+	msgID := createPendingMessage(t, serverURL, apiKey)
+
+	resp, err := http.DefaultClient.Do(idempotencyRequest(t, "POST",
+		serverURL+"/api/v1/messages/"+msgID+"/approve", "", apiKey, ""))
+	if err != nil {
+		t.Fatalf("approve: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d", resp.StatusCode)
+	}
+	if resp.Header.Get("Idempotent-Replayed") != "" {
+		t.Errorf("Idempotent-Replayed should be absent for unkeyed calls, got %q",
+			resp.Header.Get("Idempotent-Replayed"))
+	}
+
+	msgs := smtpDone()
+	if len(msgs) != 1 {
+		t.Errorf("SMTP messages sent = %d, want 1", len(msgs))
+	}
+}

--- a/internal/agent/idempotency_sideeffect_test.go
+++ b/internal/agent/idempotency_sideeffect_test.go
@@ -3,6 +3,7 @@ package agent_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -281,3 +282,111 @@ func TestSendEmail_IdempotencyKey_SenderErrorReleasesKey(t *testing.T) {
 		t.Error("Idempotent-Replayed=true on 5xx retry — key should have been released, not cached")
 	}
 }
+
+// TestApprovePending_IdempotencyKey_SenderErrorReleasesKey mirrors the
+// /send sender-error test for the approve path: when the upstream
+// SMTP relay is unreachable, ApproveAndSend's send callback returns
+// an error BEFORE the row transitions to 'sent', so the side-effect
+// flag is never set on the response writer. The guard must release
+// the key — otherwise a retry would replay a stale 500 instead of
+// actually getting the message out once the relay comes back.
+//
+// Pair this with TestApprovePending_IdempotencyKey_DuplicateReplaysAndSkipsResend
+// (in idempotency_api_test.go, happy-path side) — together they
+// pin both branches of the side-effect-committed decision for the
+// approve handler.
+func TestApprovePending_IdempotencyKey_SenderErrorReleasesKey(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	// Unreachable relay → sender.Send returns an error inside
+	// ApproveAndSend's callback, so ApproveAndSend returns non-nil
+	// err and the approve handler 500s BEFORE reaching the
+	// markSideEffectCommitted call.
+	smtpRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{
+		Host: "127.0.0.1",
+		Port: 1, // reserved; will fail to connect
+	})
+	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
+	noopUsage := usage.NewNoopUsageTracker()
+	api := agent.NewAPI(store, sender, smtpRelay, nil, noopUsage, "e2a.dev", "test.e2a.dev", "agents.e2a.dev", "", false)
+	api.SetIdempotencyStore(idempotency.NewStore(pool))
+
+	ctx := context.Background()
+	user, _ := store.CreateOrGetUser(ctx, "approve-relay-err@example.com", "Owner", "google-approve-relay-err")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "approve-relay-err-key", nil)
+	_, _ = store.ClaimOrCreateDomain(ctx, "approve-relay-err.example.com", user.ID)
+	_ = store.VerifyDomain(ctx, "approve-relay-err.example.com", user.ID)
+	a, _ := store.CreateAgent(ctx, "agent@approve-relay-err.example.com", "approve-relay-err.example.com", "", "https://example.com/webhook", "", user.ID)
+	// Flip HITL on so /send produces a pending row instead of sending.
+	enableHITL(t, store, a.ID, user.ID)
+
+	router := mux.NewRouter()
+	api.RegisterRoutes(router)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	// Create a pending message — the relay isn't hit here (status 202
+	// pending_approval), so this succeeds even though the relay is
+	// unreachable.
+	sendReq, _ := http.NewRequest("POST", srv.URL+"/api/v1/send",
+		strings.NewReader(`{"to":["alice@example.com"],"subject":"draft","body":"draft body"}`))
+	sendReq.Header.Set("Authorization", "Bearer "+apiKeyObj.PlaintextKey)
+	sendReq.Header.Set("Content-Type", "application/json")
+	sendResp, err := http.DefaultClient.Do(sendReq)
+	if err != nil {
+		t.Fatalf("setup send: %v", err)
+	}
+	defer sendResp.Body.Close()
+	if sendResp.StatusCode != http.StatusAccepted && sendResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(sendResp.Body)
+		t.Fatalf("setup send: status=%d body=%s", sendResp.StatusCode, body)
+	}
+	var sb struct{ MessageID string `json:"message_id"` }
+	if err := json.NewDecoder(sendResp.Body).Decode(&sb); err != nil {
+		t.Fatalf("setup send: decode body: %v", err)
+	}
+	if sb.MessageID == "" {
+		t.Fatal("setup send: no message_id")
+	}
+
+	idemKey := "approve-relay-err-key-001"
+	approveURL := srv.URL + "/api/v1/messages/" + sb.MessageID + "/approve"
+
+	approve := func(label string) (status int, replayed string) {
+		t.Helper()
+		req, _ := http.NewRequest("POST", approveURL, strings.NewReader(""))
+		req.Header.Set("Authorization", "Bearer "+apiKeyObj.PlaintextKey)
+		req.Header.Set("Idempotency-Key", idemKey)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("%s: %v", label, err)
+		}
+		resp.Body.Close()
+		return resp.StatusCode, resp.Header.Get("Idempotent-Replayed")
+	}
+
+	// First approve: the relay is unreachable, sender.Send errors,
+	// ApproveAndSend returns an error path that yields 500 from the
+	// handler. Critically, markSideEffectCommitted is NOT reached.
+	status1, replayed1 := approve("first")
+	if status1 != http.StatusInternalServerError {
+		t.Fatalf("first approve status = %d, want 500 (relay unreachable)", status1)
+	}
+	if replayed1 != "" {
+		t.Errorf("first call unexpectedly marked replayed: %q", replayed1)
+	}
+
+	// Second approve with the same key: handler MUST run again
+	// (the guard released the key on the 500) — otherwise a
+	// transient relay outage would lock the reviewer out of ever
+	// retrying. Status is still 500 because the relay is still
+	// down, but Idempotent-Replayed MUST NOT be "true".
+	status2, replayed2 := approve("second")
+	if status2 != http.StatusInternalServerError {
+		t.Fatalf("second approve status = %d, want 500 (relay still down)", status2)
+	}
+	if replayed2 == "true" {
+		t.Error("Idempotent-Replayed=true on retry after pre-side-effect 5xx — key must release, not cache")
+	}
+}
+

--- a/sdks/typescript/src/v1/generated/types.ts
+++ b/sdks/typescript/src/v1/generated/types.ts
@@ -1146,7 +1146,10 @@ export interface paths {
         post: {
             parameters: {
                 query?: never;
-                header?: never;
+                header?: {
+                    /** @description Caller-generated unique key (recommend UUIDv4). Approve fires a real outbound send (SES); on retry with the same key + same body the server replays the original response instead of double-sending. A different body returns 422. */
+                    "Idempotency-Key"?: string;
+                };
                 path: {
                     /**
                      * @description Message ID
@@ -1208,8 +1211,17 @@ export interface paths {
                         "application/json": string;
                     };
                 };
-                /** @description Message is no longer pending approval */
+                /** @description Message is no longer pending approval, or another request with this Idempotency-Key is in progress */
                 409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Idempotency-Key reused with a different request body */
+                422: {
                     headers: {
                         [name: string]: unknown;
                     };

--- a/web/public/openapi.yaml
+++ b/web/public/openapi.yaml
@@ -1766,6 +1766,13 @@ paths:
         name: request
         schema:
           $ref: '#/definitions/ApprovePendingMessageRequest'
+      - description: Caller-generated unique key (recommend UUIDv4). Approve fires
+          a real outbound send (SES); on retry with the same key + same body the server
+          replays the original response instead of double-sending. A different body
+          returns 422.
+        in: header
+        name: Idempotency-Key
+        type: string
       produces:
       - application/json
       responses:
@@ -1790,7 +1797,12 @@ paths:
           schema:
             type: string
         "409":
-          description: Message is no longer pending approval
+          description: Message is no longer pending approval, or another request with
+            this Idempotency-Key is in progress
+          schema:
+            type: string
+        "422":
+          description: Idempotency-Key reused with a different request body
           schema:
             type: string
       security:


### PR DESCRIPTION
## Summary
`POST /api/v1/messages/{id}/approve` fires an upstream SES send but was never wrapped in `idempotencyGuard`. A client retry after a successful approve (timeout / dropped connection / browser refresh) could double-send the same email — the row transitions to `sent` so the second call doesn't see `pending_approval`, but on chunked / partial reads the path through `ApproveAndSend` could re-trigger the send callback.

Same fix pattern as #143 used for `send_email` and `reply_to_message`: read body up front, hash via guard, replay on duplicate key + same body, 422 on key + different body.

## Behavior
- **No header** (legacy clients): unchanged — single send, no replay header.
- **Same key + same body**: 200 with `Idempotent-Replayed: true`, response bytes identical, no SES send.
- **Same key + different body**: 422, no SES send.
- **Empty body "approve-as-is"** still works (`len(bodyBytes) > 0` guard around the unmarshal).

## Test plan
- [x] `TestApprovePending_IdempotencyKey_DuplicateReplaysAndSkipsResend` — exactly 1 SMTP message after two same-key approves.
- [x] `TestApprovePending_IdempotencyKey_DifferentBodyReturns422` — 422 + 1 SMTP message.
- [x] `TestApprovePending_NoIdempotencyKey_BehavesAsBefore` — opt-in regression guard.
- [x] Existing approve + send/reply idempotency suites still green (`TestApprove*`, `TestSendEmail_Idempotency*`, `TestReplyToMessage_Idempotency*`).

## Followup
PR 3 (separate) will plumb `idempotency_key` through the SDKs / MCP / CLI for the approve path, matching how 2.3.0 already exposes it for send/reply. Until then, the guard is reachable via raw `Idempotency-Key` HTTP header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)