### PR TITLE
feat(api): newest-first default sort on list_messages + opt-in ?sort=asc

### DIFF
--- a/cli/src/bin/e2a.ts
+++ b/cli/src/bin/e2a.ts
@@ -37,7 +37,7 @@ Usage:
   e2a pending show <id>             Show a held message's full detail
   e2a pending approve <id> [--edit] Approve (and optionally edit) a held message
   e2a pending reject <id> [--reason …]  Reject a held message
-  e2a inbox [options]               List messages
+  e2a inbox [--unread|--read] [--limit N] [--oldest] [--token …]   List messages (newest first; --oldest for FIFO)
   e2a read <message-id>             Read a message
   e2a reply <msg-id> --body … [--reply-all] [--cc …] [--bcc …]
   e2a send [--to …] [--cc …] [--bcc …] --subject … --body …
@@ -188,7 +188,12 @@ async function main() {
         }
       }
       const token = getFlag(args, "--token");
-      await inbox(status, limit, token, getFlag(args, "--agent"));
+      // --oldest flips the inbox to FIFO order (oldest first). Useful
+      // when draining a backlog with a poller that processes one
+      // message at a time. Default is the new server-side default,
+      // newest-first.
+      const sort: "asc" | undefined = hasFlag(args, "--oldest") ? "asc" : undefined;
+      await inbox(status, limit, token, getFlag(args, "--agent"), sort);
       break;
     }
     case "read":

--- a/cli/src/commands/inbox.ts
+++ b/cli/src/commands/inbox.ts
@@ -5,6 +5,7 @@ export async function inbox(
   limit: number,
   token: string | undefined,
   from: string | undefined,
+  sort?: "asc" | "desc",
 ): Promise<void> {
   const client = createClient({ from });
 
@@ -17,6 +18,7 @@ export async function inbox(
     status,
     pageSize: limit,
     token,
+    sort,
   });
 
   if (!res.messages || res.messages.length === 0) {

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -1759,7 +1759,7 @@ func (a *API) handleReplyToMessage(w http.ResponseWriter, r *http.Request) {
 
 // handleGetMessages lists messages for an agent.
 // @Summary      List messages for an agent
-// @Description  Fetch messages for an agent. Returns lightweight summaries (no raw message content). Supports opaque token-based pagination via `page_size` and `token`. `direction` defaults to `inbound` for SDK back-compat; the dashboard inbox passes `direction=all` to fetch mixed inbound+outbound rows newest-first.
+// @Description  Fetch messages for an agent. Returns lightweight summaries (no raw message content). Supports opaque token-based pagination via `page_size` and `token`. **Default sort is newest-first** across all directions — pass `?sort=asc` to flip to oldest-first when you need FIFO polling semantics (drain the inbox in arrival order). `direction` defaults to `inbound` for SDK back-compat.
 // @Tags         Email
 // @Produce      json
 // @Security     BearerAuth
@@ -1767,6 +1767,7 @@ func (a *API) handleReplyToMessage(w http.ResponseWriter, r *http.Request) {
 // @Param        direction query string false "Filter by message direction" Enums(inbound, outbound, all) default(inbound)
 // @Param        status    query string false "Filter by inbox status (only meaningful when direction includes inbound)" Enums(unread, read, all) default(unread)
 // @Param        page_size query int    false "Number of messages per page (1-100)" minimum(1) maximum(100) default(50)
+// @Param        sort      query string false "Sort order by created_at. Default `desc` (newest first); pass `asc` for FIFO polling." Enums(asc, desc) default(desc)
 // @Param        token     query string false "Opaque pagination token from a previous response's next_token"
 // @Success      200 {object} ListMessagesResponse
 // @Failure      400 {string} string "Invalid status, pagination token, or filter mismatch"
@@ -1834,15 +1835,25 @@ func (a *API) handleGetMessages(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Sort order: SDK polling reads oldest-first (so agents process the
-	// oldest unread message first). Dashboard inbox reads newest-first.
-	// Tied to direction for now — if a consumer needs the other axis
-	// later, add a ?sort=asc|desc param.
-	descending := direction != "inbound"
+	// Sort order: defaults to newest-first across all directions. Pass
+	// ?sort=asc to flip to oldest-first — useful for FIFO polling
+	// agents that want to drain the inbox in arrival order.
+	//
+	// History: prior to this change, inbound silently defaulted to
+	// oldest-first while direction=all defaulted to newest-first, with
+	// no way to override either. That mismatch leaked to consumers
+	// (notably MCP `list_messages` which claimed newest-first while
+	// the call returned oldest-first). Now the surface is uniform.
+	reqSort := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("sort")))
+	if reqSort != "" && reqSort != "asc" && reqSort != "desc" {
+		http.Error(w, "sort must be 'asc' or 'desc'", http.StatusBadRequest)
+		return
+	}
 
 	// Decode opaque pagination token (encodes cursor position + filters)
 	var afterTime time.Time
 	var afterID string
+	var cursorSort string
 	if tok := r.URL.Query().Get("token"); tok != "" {
 		decoded, err := base64.RawURLEncoding.DecodeString(tok)
 		if err != nil {
@@ -1855,6 +1866,7 @@ func (a *API) handleGetMessages(w http.ResponseWriter, r *http.Request) {
 			Status    string    `json:"s"`
 			Direction string    `json:"d"`
 			AgentID   string    `json:"a"`
+			Sort      string    `json:"so,omitempty"`
 		}
 		if err := json.Unmarshal(decoded, &cursor); err != nil {
 			http.Error(w, "invalid pagination token", http.StatusBadRequest)
@@ -1869,8 +1881,26 @@ func (a *API) handleGetMessages(w http.ResponseWriter, r *http.Request) {
 		if cursorDirection == "" {
 			cursorDirection = "inbound"
 		}
+		// Tokens issued before the default-sort flip encode `Sort: ""`.
+		// Map empty to the legacy sort that was in effect at the time
+		// of issue (inbound=asc, anything else=desc); used both to
+		// detect explicit-sort mismatches and to honor the cursor's
+		// implied sort when the continuation request supplies no
+		// explicit ?sort= param.
+		cursorSort = cursor.Sort
+		if cursorSort == "" {
+			if cursorDirection == "inbound" {
+				cursorSort = "asc"
+			} else {
+				cursorSort = "desc"
+			}
+		}
 		if cursor.Status != status || cursorDirection != direction {
 			http.Error(w, "token was created with different filters — start a new query without a token", http.StatusBadRequest)
+			return
+		}
+		if reqSort != "" && cursorSort != reqSort {
+			http.Error(w, "token was created with a different sort order — start a new query without a token", http.StatusBadRequest)
 			return
 		}
 		if cursor.AgentID != agent.ID {
@@ -1880,6 +1910,20 @@ func (a *API) handleGetMessages(w http.ResponseWriter, r *http.Request) {
 		afterTime = cursor.CreatedAt
 		afterID = cursor.ID
 	}
+
+	// Resolve effective sort. If the request supplied an explicit value
+	// use it. Otherwise honor the cursor's implied sort (preserves
+	// in-flight pagination across a deploy that flipped the default);
+	// for a fresh query without a token, fall through to newest-first.
+	sort := reqSort
+	if sort == "" {
+		if cursorSort != "" {
+			sort = cursorSort
+		} else {
+			sort = "desc"
+		}
+	}
+	descending := sort == "desc"
 
 	// Fetch pageSize+1 to determine if there are more pages
 	messages, err := a.store.GetMessagesByAgent(r.Context(), agent.ID, status, direction, descending, pageSize+1, afterTime, afterID)
@@ -1959,7 +2003,8 @@ func (a *API) handleGetMessages(w http.ResponseWriter, r *http.Request) {
 			Status    string    `json:"s"`
 			Direction string    `json:"d"`
 			AgentID   string    `json:"a"`
-		}{CreatedAt: last.CreatedAt, ID: last.ID, Status: status, Direction: direction, AgentID: agent.ID})
+			Sort      string    `json:"so,omitempty"`
+		}{CreatedAt: last.CreatedAt, ID: last.ID, Status: status, Direction: direction, AgentID: agent.ID, Sort: sort})
 		if err != nil {
 			http.Error(w, "failed to build pagination token", http.StatusInternalServerError)
 			return

--- a/internal/agent/api_test.go
+++ b/internal/agent/api_test.go
@@ -1216,6 +1216,171 @@ func TestGetMessages_DirectionTokenReplayRejected(t *testing.T) {
 	}
 }
 
+// TestGetMessages_DefaultSortIsNewestFirst pins down the post-change
+// default: a bare `GET /messages` (no `direction`, no `sort`) must
+// return rows in newest-first order. Prior to this PR the inbound
+// default was oldest-first, which leaked through MCP `list_messages`
+// where the tool description claimed "newest first".
+func TestGetMessages_DefaultSortIsNewestFirst(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "owner-sort-default@example.com", "Owner", "google-sort-default")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "sort-default-key", nil)
+	store.ClaimOrCreateDomain(ctx, "sort-default.example.com", user.ID)
+	a, _ := store.CreateAgent(ctx, "agent@sort-default.example.com", "sort-default.example.com", "", "", "local", user.ID)
+
+	// Distinct created_at per message — without the sleep, time.Now()
+	// can tie within a single millisecond and tiebreaks by random ID,
+	// which makes the order assertion flaky.
+	subjects := []string{"first", "second", "third"}
+	for _, s := range subjects {
+		store.CreateInboundMessage(ctx, "", a.ID, "sender@example.com", "agent@sort-default.example.com", "", s, "", "unread", nil, nil, nil, nil, nil)
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	req, _ := http.NewRequest("GET", server.URL+"/api/v1/agents/agent@sort-default.example.com/messages?status=all", nil)
+	req.Header.Set("Authorization", "Bearer "+apiKeyObj.PlaintextKey)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+
+	var body struct {
+		Messages []struct {
+			Subject string `json:"subject"`
+		} `json:"messages"`
+	}
+	json.NewDecoder(resp.Body).Decode(&body)
+	if len(body.Messages) != 3 {
+		t.Fatalf("got %d messages, want 3", len(body.Messages))
+	}
+	wantOrder := []string{"third", "second", "first"}
+	for i, got := range body.Messages {
+		if got.Subject != wantOrder[i] {
+			t.Errorf("position %d: subject = %q, want %q (newest-first order)", i, got.Subject, wantOrder[i])
+		}
+	}
+}
+
+// TestGetMessages_SortAsc_OldestFirst confirms that ?sort=asc returns
+// the FIFO order — the explicit opt-in for SDK polling agents that
+// process the inbox in arrival order.
+func TestGetMessages_SortAsc_OldestFirst(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "owner-sort-asc@example.com", "Owner", "google-sort-asc")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "sort-asc-key", nil)
+	store.ClaimOrCreateDomain(ctx, "sort-asc.example.com", user.ID)
+	a, _ := store.CreateAgent(ctx, "agent@sort-asc.example.com", "sort-asc.example.com", "", "", "local", user.ID)
+
+	subjects := []string{"first", "second", "third"}
+	for _, s := range subjects {
+		store.CreateInboundMessage(ctx, "", a.ID, "sender@example.com", "agent@sort-asc.example.com", "", s, "", "unread", nil, nil, nil, nil, nil)
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	req, _ := http.NewRequest("GET", server.URL+"/api/v1/agents/agent@sort-asc.example.com/messages?status=all&sort=asc", nil)
+	req.Header.Set("Authorization", "Bearer "+apiKeyObj.PlaintextKey)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+
+	var body struct {
+		Messages []struct {
+			Subject string `json:"subject"`
+		} `json:"messages"`
+	}
+	json.NewDecoder(resp.Body).Decode(&body)
+	if len(body.Messages) != 3 {
+		t.Fatalf("got %d messages, want 3", len(body.Messages))
+	}
+	for i, got := range body.Messages {
+		if got.Subject != subjects[i] {
+			t.Errorf("position %d: subject = %q, want %q (oldest-first order under sort=asc)", i, got.Subject, subjects[i])
+		}
+	}
+}
+
+// TestGetMessages_InvalidSortRejected rejects gibberish sort values
+// rather than silently defaulting — matches how invalid direction /
+// status / page_size are handled.
+func TestGetMessages_InvalidSortRejected(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "owner-sort-bad@example.com", "Owner", "google-sort-bad")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "sort-bad-key", nil)
+	store.ClaimOrCreateDomain(ctx, "sort-bad.example.com", user.ID)
+	store.CreateAgent(ctx, "agent@sort-bad.example.com", "sort-bad.example.com", "", "", "local", user.ID)
+
+	req, _ := http.NewRequest("GET", server.URL+"/api/v1/agents/agent@sort-bad.example.com/messages?sort=sideways", nil)
+	req.Header.Set("Authorization", "Bearer "+apiKeyObj.PlaintextKey)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	if resp.StatusCode != 400 {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+// TestGetMessages_SortMismatchOnTokenReplay covers the safety property:
+// once a query has a pagination token (encoding the chosen sort), the
+// next request can't silently flip the sort and walk a corrupt result
+// set. Either supply the same explicit sort or restart the query.
+func TestGetMessages_SortMismatchOnTokenReplay(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "owner-sort-mm@example.com", "Owner", "google-sort-mm")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "sort-mm-key", nil)
+	store.ClaimOrCreateDomain(ctx, "sort-mm.example.com", user.ID)
+	a, _ := store.CreateAgent(ctx, "agent@sort-mm.example.com", "sort-mm.example.com", "", "", "local", user.ID)
+
+	for i := 0; i < 3; i++ {
+		store.CreateInboundMessage(ctx, "", a.ID, "sender@example.com", "agent@sort-mm.example.com", "", fmt.Sprintf("subj-%d", i), "", "unread", nil, nil, nil, nil, nil)
+	}
+
+	// First page with explicit sort=asc.
+	req, _ := http.NewRequest("GET", server.URL+"/api/v1/agents/agent@sort-mm.example.com/messages?status=all&sort=asc&page_size=2", nil)
+	req.Header.Set("Authorization", "Bearer "+apiKeyObj.PlaintextKey)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	var page1 struct {
+		NextToken *string `json:"next_token"`
+	}
+	json.NewDecoder(resp.Body).Decode(&page1)
+	if page1.NextToken == nil {
+		t.Fatal("expected next_token for paginated asc query")
+	}
+
+	// Continuation with explicit sort=desc — handler must reject.
+	req2, _ := http.NewRequest("GET", server.URL+"/api/v1/agents/agent@sort-mm.example.com/messages?status=all&sort=desc&token="+*page1.NextToken, nil)
+	req2.Header.Set("Authorization", "Bearer "+apiKeyObj.PlaintextKey)
+	resp2, _ := http.DefaultClient.Do(req2)
+	defer resp2.Body.Close()
+	if resp2.StatusCode != 400 {
+		t.Errorf("sort mismatch: status = %d, want 400", resp2.StatusCode)
+	}
+
+	// Continuation without explicit sort — handler must honor the
+	// cursor's sort and succeed. This is what makes the migration
+	// across the default flip painless.
+	req3, _ := http.NewRequest("GET", server.URL+"/api/v1/agents/agent@sort-mm.example.com/messages?status=all&token="+*page1.NextToken, nil)
+	req3.Header.Set("Authorization", "Bearer "+apiKeyObj.PlaintextKey)
+	resp3, _ := http.DefaultClient.Do(req3)
+	defer resp3.Body.Close()
+	if resp3.StatusCode != 200 {
+		body, _ := io.ReadAll(resp3.Body)
+		t.Errorf("implicit-sort continuation: status = %d, want 200; body = %s", resp3.StatusCode, body)
+	}
+}
+
 func TestGetMessages_InvalidToken(t *testing.T) {
 	server, store, _ := setupAPI(t)
 	ctx := context.Background()

--- a/mcp/src/tools/messages.ts
+++ b/mcp/src/tools/messages.ts
@@ -88,10 +88,16 @@ export function registerMessageTools(server: McpServer, client: E2AClient): void
     {
       title: "List inbound messages",
       description:
-        "List messages the agent has received, newest first. Filter by `status` (unread/read/all; default unread) and paginate with `page_size` + `token`. Returns summaries only — use `get_message` for the full body.",
+        "List messages the agent has received, newest first by default. Filter by `status` (unread/read/all; default unread) and paginate with `page_size` + `token`. Pass `sort: \"asc\"` for FIFO order (oldest unread first) when the caller wants to drain the inbox in arrival order. Returns summaries only — use `get_message` for the full body.",
       inputSchema: {
         status: z.enum(["unread", "read", "all"]).optional(),
         page_size: z.number().int().positive().max(100).optional(),
+        sort: z
+          .enum(["asc", "desc"])
+          .optional()
+          .describe(
+            "Sort order by created_at. Defaults to `desc` (newest first). Pass `asc` for FIFO polling — drain the inbox in arrival order. Switching sort mid-pagination rejects the existing token.",
+          ),
         token: z.string().optional().describe("Pagination token from a previous response."),
         agent_email: z.string().optional(),
       },
@@ -101,6 +107,7 @@ export function registerMessageTools(server: McpServer, client: E2AClient): void
         client.listMessages({
           ...(args.status !== undefined ? { status: args.status } : {}),
           ...(args.page_size !== undefined ? { pageSize: args.page_size } : {}),
+          ...(args.sort !== undefined ? { sort: args.sort } : {}),
           ...(args.token !== undefined ? { token: args.token } : {}),
           ...(args.agent_email !== undefined ? { agentEmail: args.agent_email } : {}),
         }),

--- a/sdks/python/src/e2a/v1/api.py
+++ b/sdks/python/src/e2a/v1/api.py
@@ -191,8 +191,19 @@ class E2AApi:
         status: str = "unread",
         page_size: int = 50,
         token: Optional[str] = None,
+        sort: Optional[str] = None,
     ) -> ListMessagesResponse:
+        """List messages for an agent.
+
+        ``sort`` defaults server-side to ``"desc"`` (newest first).
+        Pass ``"asc"`` for FIFO polling — drain the inbox in arrival
+        order. The choice is encoded in ``next_token`` so subsequent
+        pages keep the same order; switching mid-pagination returns
+        400.
+        """
         params: dict[str, str] = {"status": status, "page_size": str(page_size)}
+        if sort:
+            params["sort"] = sort
         if token:
             params["token"] = token
         resp = self._client.get(

--- a/sdks/python/src/e2a/v1/async_client.py
+++ b/sdks/python/src/e2a/v1/async_client.py
@@ -164,8 +164,14 @@ class AsyncE2AApi:
         status: str = "unread",
         page_size: int = 50,
         token: Optional[str] = None,
+        sort: Optional[str] = None,
     ) -> ListMessagesResponse:
+        """Async variant of :meth:`E2AApi.list_messages`. See that
+        method for the ``sort`` semantics (defaults newest-first;
+        pass ``"asc"`` for FIFO polling)."""
         params: dict[str, str] = {"status": status, "page_size": str(page_size)}
+        if sort:
+            params["sort"] = sort
         if token:
             params["token"] = token
         resp = await self._client.get(
@@ -389,10 +395,15 @@ class AsyncE2AClient:
         page_size: int = 50,
         token: Optional[str] = None,
         agent_email: Optional[str] = None,
+        sort: Optional[str] = None,
     ) -> MessageList:
-        """Fetch message summaries with ergonomic field names."""
+        """Fetch message summaries with ergonomic field names.
+
+        ``sort`` defaults server-side to ``"desc"`` (newest first). Pass
+        ``"asc"`` to drain the inbox in arrival order — FIFO polling.
+        """
         email = self._require_agent_email(agent_email)
-        resp = await self.api.list_messages(email, status=status, page_size=page_size, token=token)
+        resp = await self.api.list_messages(email, status=status, page_size=page_size, token=token, sort=sort)
         messages = [
             MessageSummary(
                 message_id=m.message_id or "",

--- a/sdks/python/src/e2a/v1/client.py
+++ b/sdks/python/src/e2a/v1/client.py
@@ -185,10 +185,15 @@ class E2AClient:
         page_size: int = 50,
         token: Optional[str] = None,
         agent_email: Optional[str] = None,
+        sort: Optional[str] = None,
     ) -> MessageList:
-        """Fetch message summaries with ergonomic field names."""
+        """Fetch message summaries with ergonomic field names.
+
+        ``sort`` defaults server-side to ``"desc"`` (newest first). Pass
+        ``"asc"`` to drain the inbox in arrival order — FIFO polling.
+        """
         email = self._require_agent_email(agent_email)
-        resp = self.api.list_messages(email, status=status, page_size=page_size, token=token)
+        resp = self.api.list_messages(email, status=status, page_size=page_size, token=token, sort=sort)
         messages = [
             MessageSummary(
                 message_id=m.message_id or "",

--- a/sdks/typescript/src/v1/api.ts
+++ b/sdks/typescript/src/v1/api.ts
@@ -138,11 +138,22 @@ export class E2AApi {
 
   async listMessages(
     email: string,
-    opts?: { status?: string; pageSize?: number; token?: string },
+    opts?: {
+      status?: string;
+      pageSize?: number;
+      token?: string;
+      /**
+       * Sort by created_at. Defaults server-side to `"desc"` (newest
+       * first). Pass `"asc"` for FIFO polling semantics — process the
+       * oldest unread message first, drain in arrival order.
+       */
+      sort?: "asc" | "desc";
+    },
   ): Promise<Schemas["ListMessagesResponse"]> {
     const params = new URLSearchParams();
     if (opts?.status) params.set("status", opts.status);
     if (opts?.pageSize) params.set("page_size", String(opts.pageSize));
+    if (opts?.sort) params.set("sort", opts.sort);
     if (opts?.token) params.set("token", opts.token);
     const qs = params.toString();
     const path = `/api/v1/agents/${encodeURIComponent(email)}/messages${qs ? `?${qs}` : ""}`;

--- a/sdks/typescript/src/v1/client.ts
+++ b/sdks/typescript/src/v1/client.ts
@@ -171,11 +171,19 @@ export class E2AClient {
     pageSize?: number;
     token?: string;
     agentEmail?: string;
+    /**
+     * Sort by created_at. Defaults server-side to `"desc"` (newest
+     * first). Pass `"asc"` to drain the inbox in arrival order — FIFO
+     * polling. The choice is encoded in `next_token` so subsequent
+     * pages keep the same order; switching mid-pagination returns 400.
+     */
+    sort?: "asc" | "desc";
   }) {
     return this.api.listMessages(this.requireEmail(opts?.agentEmail), {
       status: opts?.status,
       pageSize: opts?.pageSize,
       token: opts?.token,
+      sort: opts?.sort,
     });
   }
 

--- a/sdks/typescript/src/v1/generated/types.ts
+++ b/sdks/typescript/src/v1/generated/types.ts
@@ -316,7 +316,7 @@ export interface paths {
         };
         /**
          * List messages for an agent
-         * @description Fetch messages for an agent. Returns lightweight summaries (no raw message content). Supports opaque token-based pagination via `page_size` and `token`. `direction` defaults to `inbound` for SDK back-compat; the dashboard inbox passes `direction=all` to fetch mixed inbound+outbound rows newest-first.
+         * @description Fetch messages for an agent. Returns lightweight summaries (no raw message content). Supports opaque token-based pagination via `page_size` and `token`. **Default sort is newest-first** across all directions — pass `?sort=asc` to flip to oldest-first when you need FIFO polling semantics (drain the inbox in arrival order). `direction` defaults to `inbound` for SDK back-compat.
          */
         get: {
             parameters: {
@@ -327,6 +327,8 @@ export interface paths {
                     status?: "unread" | "read" | "all";
                     /** @description Number of messages per page (1-100) */
                     page_size?: number;
+                    /** @description Sort order by created_at. Default `desc` (newest first); pass `asc` for FIFO polling. */
+                    sort?: "asc" | "desc";
                     /** @description Opaque pagination token from a previous response's next_token */
                     token?: string;
                 };

--- a/web/public/openapi.yaml
+++ b/web/public/openapi.yaml
@@ -1272,8 +1272,9 @@ paths:
     get:
       description: Fetch messages for an agent. Returns lightweight summaries (no
         raw message content). Supports opaque token-based pagination via `page_size`
-        and `token`. `direction` defaults to `inbound` for SDK back-compat; the dashboard
-        inbox passes `direction=all` to fetch mixed inbound+outbound rows newest-first.
+        and `token`. **Default sort is newest-first** across all directions — pass
+        `?sort=asc` to flip to oldest-first when you need FIFO polling semantics (drain
+        the inbox in arrival order). `direction` defaults to `inbound` for SDK back-compat.
       parameters:
       - description: Agent email address
         example: my-bot@example.com
@@ -1307,6 +1308,15 @@ paths:
         minimum: 1
         name: page_size
         type: integer
+      - default: desc
+        description: Sort order by created_at. Default `desc` (newest first); pass
+          `asc` for FIFO polling.
+        enum:
+        - asc
+        - desc
+        in: query
+        name: sort
+        type: string
       - description: Opaque pagination token from a previous response's next_token
         in: query
         name: token


### PR DESCRIPTION
## Summary
The list_messages endpoint had a baked-in sort policy: `direction=inbound` returned oldest-first (FIFO polling), `direction=all` returned newest-first (dashboard inbox). The two disagreed with every downstream doc — most visibly with MCP `list_messages` whose tool description claimed "newest first" while implicitly using `direction=inbound` and returning oldest-first.

Make the surface uniform across all directions and consumers: **default sort is `desc` (newest first); opt into FIFO with `?sort=asc`.**

## Migration
- **Fresh queries**: new default applies — newest-first.
- **Pre-upgrade pagination tokens**: contain no `Sort` field. Handler maps empty → legacy sort (inbound=asc, all=desc) and honors it when the continuation request has no explicit `?sort`. Pagination across the deploy completes consistently.
- **Mid-pagination sort switch**: rejected with 400 + a clear restart-the-query message. Pagination tokens encode the chosen sort.
- **SDK polling agents** that depended on the old default need to either pass `?sort=asc` explicitly or accept newest-first ordering.

## Propagation across surfaces
- **API** ([internal/agent/api.go](internal/agent/api.go)): `?sort=asc\|desc` param, validated, encoded into cursor JSON as `so`. Swagger annotation updated.
- **TS SDK** ([sdks/typescript/src/v1/api.ts](sdks/typescript/src/v1/api.ts), [client.ts](sdks/typescript/src/v1/client.ts)): `sort?: "asc" \| "desc"` option on `listMessages`.
- **Python SDK** ([sdks/python/src/e2a/v1/api.py](sdks/python/src/e2a/v1/api.py) + sync/async client): `sort` kwarg, optional.
- **MCP** ([mcp/src/tools/messages.ts](mcp/src/tools/messages.ts)): `sort` zod enum on the `list_messages` tool, description updated to match.
- **CLI** ([cli/src/bin/e2a.ts](cli/src/bin/e2a.ts) + [inbox.ts](cli/src/commands/inbox.ts)): `e2a inbox --oldest` for FIFO; default flips to newest-first.
- **OpenAPI** ([web/public/openapi.yaml](web/public/openapi.yaml)) + generated TS types regenerated via `make generate`.

## Test plan
- [x] `TestGetMessages_DefaultSortIsNewestFirst` — bare query returns `["third", "second", "first"]`.
- [x] `TestGetMessages_SortAsc_OldestFirst` — `?sort=asc` returns `["first", "second", "third"]`.
- [x] `TestGetMessages_InvalidSortRejected` — `?sort=sideways` → 400.
- [x] `TestGetMessages_SortMismatchOnTokenReplay` — token sort=asc + request sort=desc → 400; token sort=asc + no request sort → 200 (legacy/cursor continuation path).
- [x] All existing `TestGetMessages_*` tests still green (pagination, legacy-token-without-direction, direction-token-replay).
- [x] TS SDK / CLI / MCP unit suites: 82 + 100 + 84 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)