### PR TITLE
fix(audit): prod e2e findings — Retry-After, agent_mode required, error consistency, email normalization, CRLF reject, MCP strict schemas

### DIFF
--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -53,6 +53,28 @@ func readJSON(w http.ResponseWriter, r *http.Request, dst any, maxBytes int64) e
 	return json.NewDecoder(r.Body).Decode(dst)
 }
 
+// normalizeEmail is the agent-package-local alias for identity.NormalizeEmail.
+// Defined here as a one-line forwarder so the existing call sites in this
+// file stay readable; the canonical implementation lives in identity so
+// ws/, auth/, and oauth_handlers all reach the same canonicalization.
+func normalizeEmail(email string) string {
+	return identity.NormalizeEmail(email)
+}
+
+// writeTooManyRequests sends a 429 response with a Retry-After header
+// (delay-seconds form, RFC 7231 §7.1.3). Callers should pass the
+// duration returned from Limiter.AllowWithRetryAfter so the value
+// reflects when the next slot actually opens up. Callers must return
+// after invoking this — it writes the full response.
+func writeTooManyRequests(w http.ResponseWriter, retryAfter time.Duration, msg string) {
+	secs := int(retryAfter.Round(time.Second).Seconds())
+	if secs < 1 {
+		secs = 1
+	}
+	w.Header().Set("Retry-After", strconv.Itoa(secs))
+	http.Error(w, msg, http.StatusTooManyRequests)
+}
+
 // Standard request body limits. Most agent/domain payloads are tiny;
 // /send carries a full email body which can include large HTML +
 // attachments base64-inlined, so it gets the largest cap. Anything over
@@ -205,6 +227,18 @@ func NewAPI(store *identity.Store, sender *outbound.Sender, smtpRelay *outbound.
 }
 
 func (a *API) RegisterRoutes(r *mux.Router) {
+	// Catch-all 404/405 handlers so every error response leaves the
+	// server as `text/plain; charset=utf-8` with a single-line body.
+	// gorilla/mux's defaults are bare status codes with no body and no
+	// Content-Type, which breaks client error handling and surfaced
+	// during the e2e contract sweep — see tests/e2e-prod 07-error-contract.
+	r.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	})
+	r.MethodNotAllowedHandler = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	})
+
 	// --- Public SDK/CLI contract: /api/v1/... ---
 	r.HandleFunc("/api/v1/agents", a.handleListAgents).Methods("GET")
 	r.HandleFunc("/api/v1/agents", a.handleRegisterAgent).Methods("POST")
@@ -445,12 +479,27 @@ func (a *API) resolveAgentForUser(r *http.Request, email string, user *identity.
 	return agent, nil
 }
 
+// RegisterAgentRequest is the request body for POST /api/v1/agents.
+//
+// `agent_mode` is required and must be either "local" or "cloud":
+//
+//   - "local"  — the e2a server queues inbound mail in its own store and
+//     pushes notifications over a WebSocket (`/api/v1/agents/{email}/ws`)
+//     or makes it pollable via the REST API. Use this when the agent
+//     runs on a laptop, edge device, or behind NAT without a public URL.
+//     `webhook_url` is not required.
+//
+//   - "cloud" — the e2a server delivers inbound mail to the agent over
+//     HTTPS POST to `webhook_url`. Use this when the agent is deployed
+//     somewhere publicly reachable. `webhook_url` MUST be set and must
+//     point to an HTTPS endpoint that resolves to a non-private IP.
 type RegisterAgentRequest struct {
-	Email      string `json:"email"`
-	Slug       string `json:"slug"`
-	Name       string `json:"name"`
-	WebhookURL string `json:"webhook_url"`
-	AgentMode  string `json:"agent_mode"`
+	Email      string `json:"email" example:"my-bot@yourdomain.com"`
+	Slug       string `json:"slug" example:"my-bot"`
+	Name       string `json:"name" example:"My Bot"`
+	WebhookURL string `json:"webhook_url,omitempty" example:"https://example.com/e2a/webhook"`
+	// AgentMode selects how inbound mail is delivered. Required; must be "local" or "cloud". See the type-level docs for the difference.
+	AgentMode string `json:"agent_mode" example:"local" enums:"local,cloud" binding:"required"`
 } // @name RegisterAgentRequest
 
 type RegisterAgentResponse struct {
@@ -461,7 +510,7 @@ type RegisterAgentResponse struct {
 
 // handleRegisterAgent creates a new agent.
 // @Summary      Register a new agent
-// @Description  Register a new agent with a custom domain or, on deployments where slug registration is enabled, a slug on the shared domain. Use `slug` for instant onboarding (no DNS needed), or `email` for a custom domain (requires domain to be registered and verified first).
+// @Description  Register a new agent with a custom domain or, on deployments where slug registration is enabled, a slug on the shared domain. Use `slug` for instant onboarding (no DNS needed), or `email` for a custom domain (requires domain to be registered and verified first). `agent_mode` is required and must be "local" (inbound delivered via WebSocket / pollable REST) or "cloud" (inbound POSTed to `webhook_url`). Rate limited to 20 registrations per source IP per hour; 429 responses carry a `Retry-After` header in delay-seconds form.
 // @Tags         Agents
 // @Accept       json
 // @Produce      json
@@ -471,11 +520,11 @@ type RegisterAgentResponse struct {
 // @Failure      400 {string} string "Invalid request"
 // @Failure      401 {string} string "Missing or invalid API key"
 // @Failure      409 {string} string "Agent already exists"
-// @Failure      429 {string} string "Rate limit exceeded"
+// @Failure      429 {string} string "Rate limit exceeded — see Retry-After header"
 // @Router       /api/v1/agents [post]
 func (a *API) handleRegisterAgent(w http.ResponseWriter, r *http.Request) {
-	if !a.regLimit.Allow(clientIP(r)) {
-		http.Error(w, "rate limit exceeded — try again later", http.StatusTooManyRequests)
+	if ok, retryAfter := a.regLimit.AllowWithRetryAfter(clientIP(r)); !ok {
+		writeTooManyRequests(w, retryAfter, "rate limit exceeded — max 20 agent registrations per hour per IP")
 		return
 	}
 
@@ -484,6 +533,12 @@ func (a *API) handleRegisterAgent(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return
 	}
+	// Canonicalize the address so subsequent lookups match regardless
+	// of the case the caller used. See normalizeEmail's doc comment.
+	// `slug` is deliberately NOT normalized — its validator (validateSlug)
+	// is strict-lowercase by design, so "MyBot" must 400 rather than
+	// silently becoming "mybot".
+	req.Email = normalizeEmail(req.Email)
 
 	// Shared-domain registration via slug
 	isSharedDomain := false
@@ -547,10 +602,14 @@ func (a *API) handleRegisterAgent(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// Validate agent mode
+	// agent_mode is required (no implicit default — see RegisterAgentRequest
+	// docs). The old behavior defaulted to "cloud" and then 400'd with
+	// "webhook_url is required for cloud agent mode" on innocuous slug-only
+	// payloads, which was a surprising DX foot-gun.
 	agentMode := req.AgentMode
 	if agentMode == "" {
-		agentMode = "cloud"
+		http.Error(w, "agent_mode is required (must be 'local' or 'cloud')", http.StatusBadRequest)
+		return
 	}
 	if agentMode != "cloud" && agentMode != "local" {
 		http.Error(w, "agent_mode must be 'cloud' or 'local'", http.StatusBadRequest)
@@ -629,7 +688,7 @@ func (a *API) handleListAgents(w http.ResponseWriter, r *http.Request) {
 // @Failure      403 {string} string "Agent not owned by this user"
 // @Router       /api/v1/agents/{email} [get]
 func (a *API) handleGetAgent(w http.ResponseWriter, r *http.Request) {
-	email := mux.Vars(r)["email"]
+	email := normalizeEmail(mux.Vars(r)["email"])
 
 	user, err := a.authenticateUser(r)
 	if err != nil {
@@ -688,7 +747,7 @@ func agentInfoFromIdentity(ag *identity.AgentIdentity) AgentInfo {
 // @Failure      404 {string} string "Agent not found"
 // @Router       /api/v1/agents/{email} [put]
 func (a *API) handleUpdateAgent(w http.ResponseWriter, r *http.Request) {
-	email := mux.Vars(r)["email"]
+	email := normalizeEmail(mux.Vars(r)["email"])
 
 	user, err := a.authenticateUser(r)
 	if err != nil {
@@ -791,7 +850,7 @@ func (a *API) handleUpdateAgent(w http.ResponseWriter, r *http.Request) {
 // @Failure      500 {string} string "Internal server error"
 // @Router       /api/v1/agents/{email} [delete]
 func (a *API) handleDeleteAgent(w http.ResponseWriter, r *http.Request) {
-	email := mux.Vars(r)["email"]
+	email := normalizeEmail(mux.Vars(r)["email"])
 
 	user, err := a.authenticateUser(r)
 	if err != nil {
@@ -1294,7 +1353,7 @@ func (a *API) holdForApproval(w http.ResponseWriter, r *http.Request, agent *ide
 
 // handleSendEmail sends a new email from the authenticated user's agent.
 // @Summary      Send a new email
-// @Description  Send an email from your agent to any recipient. Your agent must be domain-verified. Messages are delivered via SMTP. Rate limited to 60 sends per agent per minute. Pass conversation_id to tag the message as part of a thread. When the owning agent has HITL (human-in-the-loop) enabled, the server responds with 202 Accepted and status="pending_approval" instead — the message is held until a reviewer approves it via the dashboard, CLI, or magic link, or until the approval TTL expires and the configured expiration action fires.
+// @Description  Send an email from your agent to any recipient. Your agent must be domain-verified. Messages are delivered via SMTP. Rate limited to 60 sends per agent per minute; 429 responses carry a `Retry-After` header in delay-seconds form. Pass conversation_id to tag the message as part of a thread. When the owning agent has HITL (human-in-the-loop) enabled, the server responds with 202 Accepted and status="pending_approval" instead — the message is held until a reviewer approves it via the dashboard, CLI, or magic link, or until the approval TTL expires and the configured expiration action fires.
 // @Tags         Email
 // @Accept       json
 // @Produce      json
@@ -1340,6 +1399,15 @@ func (a *API) handleSendEmail(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "subject and body are required", http.StatusBadRequest)
 		return
 	}
+	// Reject CRLF in subject at the API boundary. Downstream the subject
+	// is Q-encoded by outbound/compose, so unencoded CRLF can't actually
+	// reach the SMTP envelope and smuggle headers — but allowing it
+	// through the API means malformed bytes propagate into stored rows,
+	// notification emails, dashboards, and audit logs. Reject early.
+	if strings.ContainsAny(req.Subject, "\r\n") {
+		http.Error(w, "subject must not contain CR or LF characters", http.StatusBadRequest)
+		return
+	}
 	if len(req.To) == 0 && len(req.CC) == 0 {
 		http.Error(w, "at least one recipient in to or cc is required", http.StatusBadRequest)
 		return
@@ -1352,6 +1420,7 @@ func (a *API) handleSendEmail(w http.ResponseWriter, r *http.Request) {
 	// Resolve agent from "from" field, or auto-select if user has exactly one agent
 	var agent *identity.AgentIdentity
 	if req.From != "" {
+		req.From = normalizeEmail(req.From)
 		agent, err = a.resolveAgentForUser(r, req.From, user)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("invalid from: %v", err), http.StatusBadRequest)
@@ -1370,8 +1439,8 @@ func (a *API) handleSendEmail(w http.ResponseWriter, r *http.Request) {
 		agent = &agents[0]
 	}
 
-	if !a.sendLimit.Allow(agent.ID) {
-		http.Error(w, "rate limit exceeded — max 60 sends per minute", http.StatusTooManyRequests)
+	if ok, retryAfter := a.sendLimit.AllowWithRetryAfter(agent.ID); !ok {
+		writeTooManyRequests(w, retryAfter, "rate limit exceeded — max 60 sends per minute per agent")
 		return
 	}
 
@@ -1473,7 +1542,7 @@ func (a *API) handleSendEmail(w http.ResponseWriter, r *http.Request) {
 // @Failure      500 {string} string "Failed to send test email"
 // @Router       /api/v1/agents/{email}/test [post]
 func (a *API) handleSendTestEmail(w http.ResponseWriter, r *http.Request) {
-	agentEmail := mux.Vars(r)["email"]
+	agentEmail := normalizeEmail(mux.Vars(r)["email"])
 
 	user, err := a.authenticateUser(r)
 	if err != nil {
@@ -1542,7 +1611,7 @@ type ReplyRequest struct {
 
 // handleReplyToMessage replies to a previously received email.
 // @Summary      Reply to an inbound email
-// @Description  Reply to a previously received email using its message ID. The reply is sent as a real email back to the original sender, with proper threading headers (In-Reply-To, References). Pass conversation_id to tag the reply with your thread ID — the recipient will see it on their inbound payload. Rate limited to 60 sends per agent per minute. When the owning agent has HITL enabled, the server returns 202 Accepted and status="pending_approval" instead of sending immediately.
+// @Description  Reply to a previously received email using its message ID. The reply is sent as a real email back to the original sender, with proper threading headers (In-Reply-To, References). Pass conversation_id to tag the reply with your thread ID — the recipient will see it on their inbound payload. Rate limited to 60 sends per agent per minute; 429 responses carry a `Retry-After` header in delay-seconds form. When the owning agent has HITL enabled, the server returns 202 Accepted and status="pending_approval" instead of sending immediately.
 // @Tags         Email
 // @Accept       json
 // @Produce      json
@@ -1582,7 +1651,7 @@ func (a *API) handleReplyToMessage(w http.ResponseWriter, r *http.Request) {
 	w = captureW
 
 	vars := mux.Vars(r)
-	email := vars["email"]
+	email := normalizeEmail(vars["email"])
 	msgID := vars["id"]
 
 	// Resolve agent from URL path and verify user owns it
@@ -1604,8 +1673,8 @@ func (a *API) handleReplyToMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !a.sendLimit.Allow(agent.ID) {
-		http.Error(w, "rate limit exceeded — max 60 sends per minute", http.StatusTooManyRequests)
+	if ok, retryAfter := a.sendLimit.AllowWithRetryAfter(agent.ID); !ok {
+		writeTooManyRequests(w, retryAfter, "rate limit exceeded — max 60 sends per minute per agent")
 		return
 	}
 
@@ -1786,14 +1855,13 @@ func (a *API) handleGetMessages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !a.pollLimit.Allow(user.ID) {
-		w.Header().Set("Retry-After", "60")
-		http.Error(w, "rate limit exceeded — max 60 requests per minute", http.StatusTooManyRequests)
+	if ok, retryAfter := a.pollLimit.AllowWithRetryAfter(user.ID); !ok {
+		writeTooManyRequests(w, retryAfter, "rate limit exceeded — max 60 requests per minute per user")
 		return
 	}
 
 	// Resolve agent from URL path
-	email := mux.Vars(r)["email"]
+	email := normalizeEmail(mux.Vars(r)["email"])
 	agent, err := a.resolveAgentForUser(r, email, user)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("agent not found: %v", err), http.StatusNotFound)
@@ -2152,14 +2220,13 @@ func (a *API) handleGetMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !a.pollLimit.Allow(user.ID) {
-		w.Header().Set("Retry-After", "60")
-		http.Error(w, "rate limit exceeded — max 60 requests per minute", http.StatusTooManyRequests)
+	if ok, retryAfter := a.pollLimit.AllowWithRetryAfter(user.ID); !ok {
+		writeTooManyRequests(w, retryAfter, "rate limit exceeded — max 60 requests per minute per user")
 		return
 	}
 
 	vars := mux.Vars(r)
-	email := vars["email"]
+	email := normalizeEmail(vars["email"])
 	msgID := vars["id"]
 
 	// Resolve agent from URL path and verify user owns it
@@ -2232,8 +2299,8 @@ func (a *API) handleInfo(w http.ResponseWriter, r *http.Request) {
 
 func (a *API) handleFeedback(w http.ResponseWriter, r *http.Request) {
 	ip := clientIP(r)
-	if !a.feedbackLimit.Allow(ip) {
-		http.Error(w, "rate limit exceeded — max 10 feedback submissions per hour", http.StatusTooManyRequests)
+	if ok, retryAfter := a.feedbackLimit.AllowWithRetryAfter(ip); !ok {
+		writeTooManyRequests(w, retryAfter, "rate limit exceeded — max 10 feedback submissions per hour per IP")
 		return
 	}
 

--- a/internal/agent/api_test.go
+++ b/internal/agent/api_test.go
@@ -101,7 +101,7 @@ func TestRegisterAgent(t *testing.T) {
 	store.ClaimOrCreateDomain(ctx, "reg.example.com", user.ID)
 	store.VerifyDomain(ctx, "reg.example.com", user.ID)
 
-	payload := `{"email":"agent@reg.example.com","webhook_url":"https://example.com/webhook"}`
+	payload := `{"email":"agent@reg.example.com","webhook_url":"https://example.com/webhook","agent_mode":"cloud"}`
 	resp := authedPost(t, server.URL+"/api/v1/agents", payload, apiKey)
 	defer resp.Body.Close()
 
@@ -134,10 +134,30 @@ func TestRegisterAgentMissingFields(t *testing.T) {
 	}
 }
 
+// TestRegisterAgentMissingAgentMode pins the breaking-change behavior: an
+// otherwise-valid slug payload that omits `agent_mode` now 400s with an
+// explicit message rather than silently defaulting to `cloud` and then
+// 400'ing on the missing `webhook_url`.
+func TestRegisterAgentMissingAgentMode(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	apiKey := createTestUser(t, store, "nomode@example.com")
+
+	payload := `{"slug":"nomode-bot","name":"Bot"}`
+	resp := authedPost(t, server.URL+"/api/v1/agents", payload, apiKey)
+	defer resp.Body.Close()
+	if resp.StatusCode != 400 {
+		t.Fatalf("status = %d, want 400", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "agent_mode") {
+		t.Errorf("body should explain the missing field, got %q", string(body))
+	}
+}
+
 func TestRegisterAgentUnauthenticated(t *testing.T) {
 	server, _, _ := setupAPI(t)
 
-	payload := `{"email":"agent@unauth.example.com","webhook_url":"https://example.com/webhook"}`
+	payload := `{"email":"agent@unauth.example.com","webhook_url":"https://example.com/webhook","agent_mode":"cloud"}`
 	resp, _ := http.Post(server.URL+"/api/v1/agents", "application/json", bytes.NewBufferString(payload))
 	defer resp.Body.Close()
 	if resp.StatusCode != 401 {
@@ -159,7 +179,7 @@ func TestRegisterAgentSSRF(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			payload := `{"email":"agent@ssrf-` + tt.name + `.example.com","webhook_url":"` + tt.webhookURL + `"}`
+			payload := `{"email":"agent@ssrf-` + tt.name + `.example.com","webhook_url":"` + tt.webhookURL + `","agent_mode":"cloud"}`
 			resp := authedPost(t, server.URL+"/api/v1/agents", payload, apiKey)
 			defer resp.Body.Close()
 			if resp.StatusCode != 400 {
@@ -178,7 +198,7 @@ func TestRegisterAgentDuplicate(t *testing.T) {
 	store.ClaimOrCreateDomain(ctx, "dup-api.example.com", user.ID)
 	store.VerifyDomain(ctx, "dup-api.example.com", user.ID)
 
-	payload := `{"email":"agent@dup-api.example.com","webhook_url":"https://example.com/webhook"}`
+	payload := `{"email":"agent@dup-api.example.com","webhook_url":"https://example.com/webhook","agent_mode":"cloud"}`
 	resp1 := authedPost(t, server.URL+"/api/v1/agents", payload, apiKey)
 	resp1.Body.Close()
 
@@ -537,7 +557,7 @@ func TestRegisterAgentWithSlug(t *testing.T) {
 	server, store, _ := setupAPI(t)
 	apiKey := createTestUser(t, store, "owner@example.com")
 
-	payload := `{"slug":"my-cool-bot","name":"Cool Bot","webhook_url":"https://example.com/webhook"}`
+	payload := `{"slug":"my-cool-bot","name":"Cool Bot","webhook_url":"https://example.com/webhook","agent_mode":"cloud"}`
 	resp := authedPost(t, server.URL+"/api/v1/agents", payload, apiKey)
 	defer resp.Body.Close()
 
@@ -589,7 +609,7 @@ func TestRegisterAgentSlugValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			payload := fmt.Sprintf(`{"slug":%q,"name":"Bot","webhook_url":"https://example.com/webhook"}`, tt.slug)
+			payload := fmt.Sprintf(`{"slug":%q,"name":"Bot","webhook_url":"https://example.com/webhook","agent_mode":"cloud"}`, tt.slug)
 			resp := authedPost(t, server.URL+"/api/v1/agents", payload, apiKey)
 			defer resp.Body.Close()
 			if resp.StatusCode != 400 {
@@ -606,7 +626,7 @@ func TestRegisterAgentSlugValidAccepted(t *testing.T) {
 	slugs := []string{"ab", "my-bot", "support-agent-1", "a1"}
 	for _, slug := range slugs {
 		t.Run(slug, func(t *testing.T) {
-			payload := fmt.Sprintf(`{"slug":%q,"name":"Bot","webhook_url":"https://example.com/webhook"}`, slug)
+			payload := fmt.Sprintf(`{"slug":%q,"name":"Bot","webhook_url":"https://example.com/webhook","agent_mode":"cloud"}`, slug)
 			resp := authedPost(t, server.URL+"/api/v1/agents", payload, apiKey)
 			defer resp.Body.Close()
 			if resp.StatusCode != 201 {
@@ -620,7 +640,7 @@ func TestRegisterAgentDuplicateSlug(t *testing.T) {
 	server, store, _ := setupAPI(t)
 	apiKey := createTestUser(t, store, "dupslug@example.com")
 
-	payload := `{"slug":"dup-slug","name":"Bot","webhook_url":"https://example.com/webhook"}`
+	payload := `{"slug":"dup-slug","name":"Bot","webhook_url":"https://example.com/webhook","agent_mode":"cloud"}`
 	resp1 := authedPost(t, server.URL+"/api/v1/agents", payload, apiKey)
 	resp1.Body.Close()
 

--- a/internal/agent/oauth_handlers.go
+++ b/internal/agent/oauth_handlers.go
@@ -11,9 +11,11 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/Mnexa-AI/e2a/internal/identity"
 	"github.com/Mnexa-AI/e2a/internal/oauth"
 	"github.com/gorilla/mux"
 	"github.com/jackc/pgx/v5"
@@ -243,7 +245,12 @@ func (a *API) handleOAuthRegister(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	if !a.dcrLimit.Allow(dcrSourceIP(r)) {
+	if ok, retryAfter := a.dcrLimit.AllowWithRetryAfter(dcrSourceIP(r)); !ok {
+		secs := int(retryAfter.Round(time.Second).Seconds())
+		if secs < 1 {
+			secs = 1
+		}
+		w.Header().Set("Retry-After", strconv.Itoa(secs))
 		writeOAuthError(w, http.StatusTooManyRequests, "rate_limited",
 			"too many registrations from this IP; try again later")
 		return
@@ -401,7 +408,12 @@ func (a *API) handleOAuthGetClient(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	if !a.dcrLimit.Allow(dcrSourceIP(r)) {
+	if ok, retryAfter := a.dcrLimit.AllowWithRetryAfter(dcrSourceIP(r)); !ok {
+		secs := int(retryAfter.Round(time.Second).Seconds())
+		if secs < 1 {
+			secs = 1
+		}
+		w.Header().Set("Retry-After", strconv.Itoa(secs))
 		writeOAuthError(w, http.StatusTooManyRequests, "rate_limited",
 			"too many client-metadata requests from this IP; try again later")
 		return
@@ -713,7 +725,7 @@ func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
 	agentChoice := r.PostFormValue("agent_choice")
 	switch {
 	case strings.HasPrefix(agentChoice, "existing:"):
-		email := strings.TrimPrefix(agentChoice, "existing:")
+		email := identity.NormalizeEmail(strings.TrimPrefix(agentChoice, "existing:"))
 		agent, err := a.store.GetAgentByEmail(ctx, email)
 		if err != nil {
 			http.Error(w, "chosen agent does not exist", http.StatusBadRequest)

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -618,6 +618,7 @@ func (ua *UserAuth) HandleDeleteAgent(w http.ResponseWriter, r *http.Request) {
 	// Extract agent email from URL path
 	path := strings.TrimPrefix(r.URL.Path, "/api/dashboard/agents/")
 	email, _ := url.PathUnescape(path)
+	email = identity.NormalizeEmail(email)
 	if email == "" {
 		http.Error(w, "agent email required", http.StatusBadRequest)
 		return
@@ -647,6 +648,7 @@ func (ua *UserAuth) HandleUpdateAgent(w http.ResponseWriter, r *http.Request) {
 
 	path := strings.TrimPrefix(r.URL.Path, "/api/dashboard/agents/")
 	email, _ := url.PathUnescape(path)
+	email = identity.NormalizeEmail(email)
 	if email == "" {
 		http.Error(w, "agent email required", http.StatusBadRequest)
 		return
@@ -747,6 +749,7 @@ func (ua *UserAuth) HandleAgentActivity(w http.ResponseWriter, r *http.Request) 
 	// Extract agent email from URL path: /api/dashboard/agents/{email}/activity
 	path := strings.TrimPrefix(r.URL.Path, "/api/dashboard/agents/")
 	email, _ := url.PathUnescape(strings.TrimSuffix(path, "/activity"))
+	email = identity.NormalizeEmail(email)
 	if email == "" {
 		http.Error(w, "agent email required", http.StatusBadRequest)
 		return

--- a/internal/identity/email.go
+++ b/internal/identity/email.go
@@ -1,0 +1,18 @@
+package identity
+
+import "strings"
+
+// NormalizeEmail returns the canonical lookup form of an email address:
+// lower-cased, with surrounding whitespace stripped. Every external-input
+// email used as a lookup key (path vars, form fields, OAuth consent
+// choices, WebSocket subscriptions) must funnel through this so case
+// variants ("Alice@x.com" vs "alice@x.com") resolve to the same row.
+//
+// Per RFC 5321 §2.4 the local-part is technically case-sensitive — a
+// small number of providers (most famously ProtonMail) preserve case.
+// We collapse it anyway because consistency across HTTP path, JSON body,
+// SMTP envelope, and dashboard URL is more important than spec purity
+// for the agent-inbox use case. Document this if a user complains.
+func NormalizeEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}

--- a/internal/identity/email_test.go
+++ b/internal/identity/email_test.go
@@ -1,0 +1,50 @@
+package identity
+
+import "testing"
+
+func TestNormalizeEmail(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"already lowercase", "alice@example.com", "alice@example.com"},
+		{"mixed case", "Alice@Example.COM", "alice@example.com"},
+		{"all uppercase", "ALICE@EXAMPLE.COM", "alice@example.com"},
+		{"leading whitespace", "  alice@example.com", "alice@example.com"},
+		{"trailing whitespace", "alice@example.com  ", "alice@example.com"},
+		{"surrounding whitespace + case", "  Alice@Example.COM  ", "alice@example.com"},
+		{"tab whitespace", "\talice@example.com\t", "alice@example.com"},
+		{"local-part with plus", "Alice+Filter@Example.com", "alice+filter@example.com"},
+		// Inner whitespace is NOT a valid email anyway; we just confirm we
+		// don't strip inside the address — the validator catches it later.
+		{"inner space preserved", "alice @example.com", "alice @example.com"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NormalizeEmail(tt.in); got != tt.want {
+				t.Errorf("NormalizeEmail(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNormalizeEmailIdempotent guards against silent regressions where a
+// future change adds non-idempotent behavior (e.g. URL-decoding, IDN
+// punycode conversion) without updating the contract: calling
+// NormalizeEmail on its own output must return the same string.
+func TestNormalizeEmailIdempotent(t *testing.T) {
+	for _, in := range []string{
+		"alice@example.com",
+		"Alice@Example.COM",
+		"  Alice@Example.COM  ",
+		"",
+	} {
+		once := NormalizeEmail(in)
+		twice := NormalizeEmail(once)
+		if once != twice {
+			t.Errorf("not idempotent for %q: once=%q twice=%q", in, once, twice)
+		}
+	}
+}

--- a/internal/outbound/compose_test.go
+++ b/internal/outbound/compose_test.go
@@ -82,6 +82,47 @@ func TestComposeMessageSubjectRFC2047Encoding(t *testing.T) {
 	}
 }
 
+// TestComposeMessageSubjectCRLFNeutralized confirms that even if a CRLF
+// reaches ComposeMessage (e.g. some future caller skips the API-layer
+// validation in handleSendEmail), the Q-encoding step neutralizes it so
+// no header smuggling can occur on the SMTP envelope. Belt + suspenders
+// with the API-layer reject in handleSendEmail.
+func TestComposeMessageSubjectCRLFNeutralized(t *testing.T) {
+	smuggled := "Hello\r\nBcc: attacker@evil.com\r\nX-Smuggled: yes"
+	raw, err := ComposeMessage(
+		"from@test.com", []string{"to@test.com"}, nil,
+		smuggled, "Body", "text/plain", "", nil, "test.dev", "", "",
+	)
+	if err != nil {
+		t.Fatalf("ComposeMessage failed: %v", err)
+	}
+	headerEnd := strings.Index(string(raw), "\r\n\r\n")
+	if headerEnd < 0 {
+		t.Fatal("no header/body separator")
+	}
+	headers := string(raw)[:headerEnd]
+	// No smuggled headers should appear on their own line.
+	for _, smuggled := range []string{"\r\nBcc: attacker@evil.com", "\r\nX-Smuggled:"} {
+		if strings.Contains(headers, smuggled) {
+			t.Errorf("composed headers contain smuggled line: %q\nfull headers:\n%s", smuggled, headers)
+		}
+	}
+	// The Subject header should round-trip back to the original literal
+	// via Go's WordDecoder, confirming the bytes survived encode/decode.
+	msg, err := mail.ReadMessage(strings.NewReader(string(raw)))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	dec := new(mime.WordDecoder)
+	got, err := dec.DecodeHeader(msg.Header.Get("Subject"))
+	if err != nil {
+		t.Fatalf("decode subject: %v", err)
+	}
+	if got != smuggled {
+		t.Errorf("decoded subject = %q, want %q", got, smuggled)
+	}
+}
+
 func TestComposeMessageASCIISubjectUnchanged(t *testing.T) {
 	// Pure-ASCII subjects should pass through without encoded-word wrapping.
 	raw, err := ComposeMessage(

--- a/internal/ratelimit/ratelimit.go
+++ b/internal/ratelimit/ratelimit.go
@@ -26,13 +26,25 @@ func New(window time.Duration, max int) *Limiter {
 // Allow returns true if the key has not exceeded the rate limit.
 // If allowed, the attempt is recorded.
 func (l *Limiter) Allow(key string) bool {
+	ok, _ := l.AllowWithRetryAfter(key)
+	return ok
+}
+
+// AllowWithRetryAfter behaves like Allow but additionally returns the
+// duration the caller must wait before the next attempt could succeed
+// (rounded up to the next whole second so callers can use it for the
+// Retry-After response header). When the request is allowed, the
+// returned duration is zero. The returned duration is conservative
+// (>= one second when blocked) so that a Retry-After header always
+// communicates a meaningful, RFC 7231 §7.1.3-compatible delay.
+func (l *Limiter) AllowWithRetryAfter(key string) (bool, time.Duration) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
 	now := time.Now()
 	cutoff := now.Add(-l.window)
 
-	// Prune expired entries
+	// Prune expired entries in place.
 	valid := l.buckets[key][:0]
 	for _, t := range l.buckets[key] {
 		if t.After(cutoff) {
@@ -42,11 +54,21 @@ func (l *Limiter) Allow(key string) bool {
 
 	if len(valid) >= l.max {
 		l.buckets[key] = valid
-		return false
+		// The oldest in-window hit drops off the window at oldest+window,
+		// so that's when one more slot opens up.
+		retryAfter := valid[0].Add(l.window).Sub(now)
+		if retryAfter < time.Second {
+			retryAfter = time.Second
+		}
+		// Round up to the next whole second for header use.
+		if retryAfter%time.Second != 0 {
+			retryAfter = retryAfter.Truncate(time.Second) + time.Second
+		}
+		return false, retryAfter
 	}
 
 	l.buckets[key] = append(valid, now)
-	return true
+	return true, 0
 }
 
 func (l *Limiter) cleanupLoop() {

--- a/internal/ratelimit/ratelimit_test.go
+++ b/internal/ratelimit/ratelimit_test.go
@@ -84,6 +84,56 @@ func TestCleanupLoopRunsAutomatically(t *testing.T) {
 	}
 }
 
+func TestAllowWithRetryAfter_AllowedReturnsZero(t *testing.T) {
+	l := New(1*time.Second, 3)
+	ok, retry := l.AllowWithRetryAfter("k")
+	if !ok {
+		t.Fatal("expected allow on first attempt")
+	}
+	if retry != 0 {
+		t.Errorf("expected retryAfter=0 when allowed, got %v", retry)
+	}
+}
+
+func TestAllowWithRetryAfter_BlockedReturnsPositiveDuration(t *testing.T) {
+	l := New(60*time.Second, 2)
+	for i := 0; i < 2; i++ {
+		if ok, _ := l.AllowWithRetryAfter("k"); !ok {
+			t.Fatalf("attempt %d should have been allowed", i+1)
+		}
+	}
+	ok, retry := l.AllowWithRetryAfter("k")
+	if ok {
+		t.Fatal("3rd attempt over limit must be denied")
+	}
+	// Should be roughly the window (60s) minus elapsed test time;
+	// the helper rounds up to whole seconds.
+	if retry < time.Second {
+		t.Errorf("retryAfter must be at least 1s, got %v", retry)
+	}
+	if retry > 60*time.Second {
+		t.Errorf("retryAfter must not exceed the window (%v), got %v", 60*time.Second, retry)
+	}
+	if retry%time.Second != 0 {
+		t.Errorf("retryAfter should be a whole number of seconds (for HTTP Retry-After), got %v", retry)
+	}
+}
+
+func TestAllowWithRetryAfter_RetryAfterShrinksAsWindowAdvances(t *testing.T) {
+	// Use a multi-second window so the ceiling-to-whole-second rounding
+	// (required for HTTP Retry-After) doesn't mask sub-second shrinkage.
+	l := New(10*time.Second, 1)
+	if ok, _ := l.AllowWithRetryAfter("k"); !ok {
+		t.Fatal("first attempt should be allowed")
+	}
+	_, retry1 := l.AllowWithRetryAfter("k")
+	time.Sleep(2 * time.Second)
+	_, retry2 := l.AllowWithRetryAfter("k")
+	if retry2 >= retry1 {
+		t.Errorf("retryAfter should shrink as the window advances: first=%v second=%v", retry1, retry2)
+	}
+}
+
 func TestCleanupLoopKeepsActiveEntries(t *testing.T) {
 	l := New(100*time.Millisecond, 10)
 

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -45,8 +45,10 @@ func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Resolve agent and verify ownership
-	email := mux.Vars(r)["email"]
+	// Resolve agent and verify ownership. Canonicalize the email so that
+	// `ws://.../UPPER@x.dev/ws?token=…` resolves identically to the
+	// lower-case form — matches the REST API's `normalizeEmail` policy.
+	email := identity.NormalizeEmail(mux.Vars(r)["email"])
 	agent, err := h.store.GetAgentByEmail(r.Context(), email)
 	if err != nil {
 		http.Error(w, "agent not found", http.StatusNotFound)

--- a/mcp/src/tools/agents.ts
+++ b/mcp/src/tools/agents.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { E2AClient } from "@e2a/sdk/v1";
 import { z } from "zod";
-import { runTool } from "./util.js";
+import { runTool, strictInputSchema } from "./util.js";
 
 export function registerAgentTools(server: McpServer, client: E2AClient): void {
   server.registerTool(
@@ -10,7 +10,7 @@ export function registerAgentTools(server: McpServer, client: E2AClient): void {
       title: "List agents",
       description:
         "List every agent inbox owned by the authenticated user. Useful for orientation — which inbox to send `from` or query messages against. Read-only.",
-      inputSchema: {},
+      inputSchema: strictInputSchema({}),
     },
     async () => runTool(() => client.listAgents()),
   );
@@ -21,7 +21,7 @@ export function registerAgentTools(server: McpServer, client: E2AClient): void {
       title: "Get the default agent's identity",
       description:
         "Use first when starting work on e2a to learn which agent you're acting AS — remember an agent IS an email address, and other tools default to this one. Resolution order: (1) `E2A_AGENT_EMAIL` from the server env when set, (2) the sole agent on the account when there's exactly one. Errors only when neither path resolves — typically because the account owns multiple agents. In that case the error inlines the available emails so you can pass one as `agent_email` to other tools (or have the user pin a default via `E2A_AGENT_EMAIL`); no follow-up `list_agents` call needed. If the error says zero agents, run `create_agent` first.",
-      inputSchema: {},
+      inputSchema: strictInputSchema({}),
     },
     async () =>
       runTool(async () => {
@@ -60,7 +60,7 @@ export function registerAgentTools(server: McpServer, client: E2AClient): void {
       title: "Create a new agent inbox on the shared domain",
       description:
         "Register a new agent using a slug on the deployment's shared domain (e.g. slug 'support-bot' → support-bot@<shared-domain>). Defaults to `local` mode so the agent receives mail via `list_messages` polling — no webhook server required. Pass `agent_mode: 'cloud'` and `webhook_url` for push delivery; in that case the webhook handler MUST HMAC-verify every delivery against the account's webhook signing secret (`E2A_WEBHOOK_SECRET`, shown in the dashboard) — the e2a SDK exposes `parseWebhook(body, secret)` for this. For a custom (non-shared) domain, use `register_domain` to start the verification flow. Slug must be lowercase letters, numbers, and hyphens.",
-      inputSchema: {
+      inputSchema: strictInputSchema({
         slug: z
           .string()
           .regex(/^[a-z0-9][a-z0-9-]*$/)
@@ -82,7 +82,7 @@ export function registerAgentTools(server: McpServer, client: E2AClient): void {
           .url()
           .optional()
           .describe("Required when `agent_mode` is `cloud`. Ignored in local mode."),
-      },
+      }),
     },
     async (args) =>
       runTool(() =>
@@ -101,7 +101,7 @@ export function registerAgentTools(server: McpServer, client: E2AClient): void {
       title: "Update an agent's configuration",
       description:
         "Mutate a subset of an agent's settings. **This is the path to enable HITL approval gates** on an existing agent (HITL is NOT in the create_agent flow): set `hitl_enabled: true`, optionally with `hitl_ttl_seconds` and `hitl_expiration_action`. Same path to disable HITL, change the approval window, switch between local and cloud delivery, or rebind the webhook URL when an agent's downstream service moves. Omitted fields keep their current value server-side; an explicitly-passed zero is honored (e.g. `hitl_ttl_seconds: 0` sets the window to immediate, not a no-op).",
-      inputSchema: {
+      inputSchema: strictInputSchema({
         agent_email: z
           .string()
           .email()
@@ -142,7 +142,7 @@ export function registerAgentTools(server: McpServer, client: E2AClient): void {
           .describe(
             "What happens to a pending message at TTL expiry: `approve` ships it; `reject` drops it.",
           ),
-      },
+      }),
     },
     async (args) =>
       runTool(() => {
@@ -159,7 +159,7 @@ export function registerAgentTools(server: McpServer, client: E2AClient): void {
       title: "Delete an agent inbox (DESTRUCTIVE)",
       description:
         "Permanently delete the agent identity and CASCADE-remove every message, pending outbound, and webhook-delivery record bound to it. Irreversible. Existing OAuth tokens bound to this agent are revoked automatically. Requires `confirm: true` — set it explicitly to acknowledge the destructive action.",
-      inputSchema: {
+      inputSchema: strictInputSchema({
         agent_email: z
           .string()
           .email()
@@ -172,7 +172,7 @@ export function registerAgentTools(server: McpServer, client: E2AClient): void {
           .describe(
             "Must be set to true to proceed. Guard against an LLM hallucinating a delete from ambiguous context.",
           ),
-      },
+      }),
     },
     async (args) =>
       runTool(async () => {

--- a/mcp/src/tools/domains.ts
+++ b/mcp/src/tools/domains.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { E2AClient } from "@e2a/sdk/v1";
 import { z } from "zod";
-import { runTool } from "./util.js";
+import { runTool, strictInputSchema } from "./util.js";
 
 /**
  * Domain-management tools. Mirrors the four domain endpoints the
@@ -22,7 +22,7 @@ export function registerDomainTools(server: McpServer, client: E2AClient): void 
       title: "List domains",
       description:
         "List every custom mail domain registered under the authenticated user, with verification status (verified / pending DNS / failed) and the verification token for each. Useful to discover which domains can already send/receive mail and which still need DNS records to be added. Read-only; cheap to call.",
-      inputSchema: {},
+      inputSchema: strictInputSchema({}),
     },
     async () => runTool(() => client.listDomains()),
   );
@@ -33,14 +33,14 @@ export function registerDomainTools(server: McpServer, client: E2AClient): void 
       title: "Register a custom mail domain (returns DNS records to publish)",
       description:
         "Use to start the custom-domain flow. **This is step 1 of an asynchronous two-step process**: this tool returns the MX + TXT records the user must publish on their DNS provider; it does NOT make the domain live. Step 2 is `verify_domain` — but only AFTER the records are published AND DNS propagation has completed (typically minutes, occasionally hours). Do not call `verify_domain` immediately, and do not promise the user the domain works yet. **Composition tip**: if a DNS-provider MCP (Cloudflare, Route 53, NS1, …) is loaded in the same host, hand the returned records to its `create_dns_record`-style tool, then surface the wait expectation to the user. If no DNS MCP is available, show the records verbatim and ask the user to add them manually. The domain is created in an unverified state — `delete_domain` is the reverse op. Idempotent against an existing-but-unverified row.",
-      inputSchema: {
+      inputSchema: strictInputSchema({
         domain: z
           .string()
           .min(1)
           .describe(
             "Fully-qualified domain name to register. e.g. 'mail.acme.com'. Subdomains are recommended (so the apex remains free for marketing mail).",
           ),
-      },
+      }),
     },
     async (args) => runTool(() => client.registerDomain(args.domain)),
   );
@@ -51,12 +51,12 @@ export function registerDomainTools(server: McpServer, client: E2AClient): void 
       title: "Verify a custom mail domain's DNS records",
       description:
         "Use as step 2 of the custom-domain flow, AFTER `register_domain` returned records AND the user (or a DNS MCP) published them AND DNS has had time to propagate (minutes to hours). Probes DNS for the issued MX + TXT records and flips the domain's `verified` bit on success. Idempotent — safe to retry as propagation completes. If `verified: false` comes back, the response includes the resolved-record state for diagnostics; surface that to the user rather than retrying in a tight loop. Don't poll; let the user drive the recheck.",
-      inputSchema: {
+      inputSchema: strictInputSchema({
         domain: z
           .string()
           .min(1)
           .describe("Domain to verify. Must have been registered already via `register_domain`."),
-      },
+      }),
     },
     async (args) => runTool(() => client.verifyDomain(args.domain)),
   );
@@ -67,14 +67,14 @@ export function registerDomainTools(server: McpServer, client: E2AClient): void 
       title: "Delete a custom mail domain (DESTRUCTIVE)",
       description:
         "Permanently remove a domain registration. CASCADES to every agent on that domain and every message/pending-outbound/webhook-delivery bound to those agents. Irreversible. Existing OAuth tokens bound to those agents are revoked. Requires `confirm: true` — set it explicitly to acknowledge the destructive scope.",
-      inputSchema: {
+      inputSchema: strictInputSchema({
         domain: z.string().min(1).describe("Domain to delete."),
         confirm: z
           .literal(true)
           .describe(
             "Must be set to true to proceed. Guard against an LLM hallucinating a delete from ambiguous context.",
           ),
-      },
+      }),
     },
     async (args) =>
       runTool(async () => {

--- a/mcp/src/tools/hitl.ts
+++ b/mcp/src/tools/hitl.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { E2AClient } from "@e2a/sdk/v1";
 import { z } from "zod";
-import { runTool } from "./util.js";
+import { runTool, strictInputSchema } from "./util.js";
 import { attachmentsArraySchema } from "./attachments.js";
 
 export function registerHitlTools(server: McpServer, client: E2AClient): void {
@@ -11,7 +11,7 @@ export function registerHitlTools(server: McpServer, client: E2AClient): void {
       title: "List outbound messages awaiting approval",
       description:
         "Use when the user asks what's awaiting approval, or after a `send_email`/`reply_to_message` returned `pending_approval` and they want to see the queue. Lists held outbound messages from HITL-enabled agents sorted by soonest-expiring first. Body content is summary-only — call `get_pending_message` for the full draft of one. Read-only; cheap, but don't poll it on a loop.",
-      inputSchema: {},
+      inputSchema: strictInputSchema({}),
     },
     async () => runTool(() => client.listPendingMessages()),
   );
@@ -22,9 +22,9 @@ export function registerHitlTools(server: McpServer, client: E2AClient): void {
       title: "Get a pending-approval message",
       description:
         "Fetch the full draft (subject, recipients, body, attachments) of one outbound message awaiting human approval. Body content is only present while the message is `pending_approval` — after a terminal transition the server scrubs it.",
-      inputSchema: {
+      inputSchema: strictInputSchema({
         message_id: z.string().describe("The pending message ID (msg_…)."),
-      },
+      }),
     },
     async (args) => runTool(() => client.getPendingMessage(args.message_id)),
   );
@@ -35,7 +35,7 @@ export function registerHitlTools(server: McpServer, client: E2AClient): void {
       title: "Approve a pending outbound message",
       description:
         "Use to release a held outbound message — typically after the user reviewed it via `get_pending_message`. Approve-as-is by passing only `message_id`; apply reviewer edits by supplying any subset of subject / body_text / body_html / to / cc / bcc / attachments (those override the stored draft before send). Field semantics: omit a field to keep the draft's value; pass it (including empty `attachments: []` to strip all attachments) to override. Returns 409 if the message is no longer pending.",
-      inputSchema: {
+      inputSchema: strictInputSchema({
         message_id: z.string(),
         subject: z.string().optional(),
         body_text: z.string().optional(),
@@ -50,7 +50,7 @@ export function registerHitlTools(server: McpServer, client: E2AClient): void {
           .describe(
             "Stable key for retry-safe approves. Approve fires a real SES send, so a retried call without this header could double-send. For approve-as-is, the pending `message_id` is a natural stable key — same review event, same key, retry replays. **If you change overrides between attempts** (e.g. tweak the subject after a 5xx and retry), pick a fresh key per attempt: same key + different body returns 422.",
           ),
-      },
+      }),
     },
     async (args) => {
       const { message_id, idempotency_key, ...overrides } = args;
@@ -68,10 +68,10 @@ export function registerHitlTools(server: McpServer, client: E2AClient): void {
       title: "Reject a pending outbound message",
       description:
         "Discard a held outbound message. The message is never sent and body columns are scrubbed; the optional `reason` is stored for audit. Returns 409 if the message is no longer pending.",
-      inputSchema: {
+      inputSchema: strictInputSchema({
         message_id: z.string(),
         reason: z.string().optional(),
-      },
+      }),
     },
     async (args) => runTool(() => client.rejectMessage(args.message_id, args.reason)),
   );

--- a/mcp/src/tools/messages.ts
+++ b/mcp/src/tools/messages.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { E2AClient } from "@e2a/sdk/v1";
 import { z } from "zod";
-import { runTool } from "./util.js";
+import { runTool, strictInputSchema } from "./util.js";
 import { attachmentsArraySchema } from "./attachments.js";
 
 export function registerMessageTools(server: McpServer, client: E2AClient): void {
@@ -11,7 +11,7 @@ export function registerMessageTools(server: McpServer, client: E2AClient): void
       title: "Send email",
       description:
         "Use when starting a NEW email thread to a fresh recipient. To respond to a message you can see in `list_messages`, use `reply_to_message` instead — it preserves the In-Reply-To / References headers so the reply lands in the same thread, which this tool deliberately does not do. Attach files via `attachments`; pass base64 strings produced by other tools (e.g. `get_attachment_data`) verbatim — don't hand-encode raw text. **`pending_approval` is not failure.** If the agent has HITL enabled, the response is `{ status: \"pending_approval\", message_id: ... }`; the message is held for human review — do not retry. Check on it with `list_pending_messages` / `get_pending_message`.",
-      inputSchema: {
+      inputSchema: strictInputSchema({
         to: z.array(z.string()).describe("Recipient email addresses (one or more)."),
         subject: z.string(),
         body: z.string().describe("Plain-text body. Use `html_body` for HTML."),
@@ -35,7 +35,7 @@ export function registerMessageTools(server: McpServer, client: E2AClient): void
           .describe(
             "Sending agent's inbox. Omit when E2A_AGENT_EMAIL is set in the server environment.",
           ),
-      },
+      }),
     },
     async (args) =>
       runTool(() =>
@@ -61,7 +61,7 @@ export function registerMessageTools(server: McpServer, client: E2AClient): void
       title: "Reply to a received message",
       description:
         "Use whenever you're responding to a message you can see in the inbox — preserves the In-Reply-To and References headers so the reply joins the original email thread instead of starting a new one. Prefer this over `send_email` for any response to an inbound; thread fragmentation (broken conversation view in the recipient's mail client) is the most visible symptom of using `send_email` by mistake. Pass `reply_all: true` to copy the original Cc list; subject is auto-derived as `Re: …` by the server. Same HITL caveat as `send_email`: a `pending_approval` status is success, not failure.",
-      inputSchema: {
+      inputSchema: strictInputSchema({
         message_id: z.string().describe("ID of the inbound message to reply to (e.g. msg_…)."),
         body: z.string().describe("Plain-text reply body."),
         html_body: z.string().optional(),
@@ -80,7 +80,7 @@ export function registerMessageTools(server: McpServer, client: E2AClient): void
             "Stable key for retry-safe replies. A natural choice is the inbound `message_id` you're replying to — the same triggering event yields the same key, so a retry replays the original response instead of double-sending. Omit to let the SDK mint a fresh UUIDv4 per call.",
           ),
         agent_email: z.string().optional(),
-      },
+      }),
     },
     async (args) =>
       runTool(() =>
@@ -107,7 +107,7 @@ export function registerMessageTools(server: McpServer, client: E2AClient): void
       title: "List inbound messages",
       description:
         "List messages the agent has received, newest first by default. Filter by `status` (unread/read/all; default unread) and paginate with `page_size` + `token`. Pass `sort: \"asc\"` for FIFO order (oldest unread first) when the caller wants to drain the inbox in arrival order. **Search filters** (`from`, `subject_contains`, `conversation_id`, `since`, `until`) narrow the result set server-side — use them instead of paginating the full inbox client-side. Returns summaries only — use `get_message` for the full body.",
-      inputSchema: {
+      inputSchema: strictInputSchema({
         status: z.enum(["unread", "read", "all"]).optional(),
         page_size: z.number().int().positive().max(100).optional(),
         sort: z
@@ -149,7 +149,7 @@ export function registerMessageTools(server: McpServer, client: E2AClient): void
           ),
         token: z.string().optional().describe("Pagination token from a previous response."),
         agent_email: z.string().optional(),
-      },
+      }),
     },
     async (args) =>
       runTool(() =>
@@ -178,10 +178,10 @@ export function registerMessageTools(server: McpServer, client: E2AClient): void
       title: "Get a message",
       description:
         "Use after `list_messages` to read one inbound message in full — body (text + html), headers, conversation id, and attachment metadata. Pass the `message_id` from the list response. Attachment bytes are NOT included (would blow context for any non-trivial PDF); the response lists each attachment's filename, content_type, and 0-based `index` plus size_bytes. To get the actual bytes of one attachment (inspect, forward, hand off), call `get_attachment_data` with that index. The raw MIME blob is also omitted for the same reason.",
-      inputSchema: {
+      inputSchema: strictInputSchema({
         message_id: z.string(),
         agent_email: z.string().optional(),
-      },
+      }),
     },
     async (args) =>
       runTool(async () => {
@@ -236,7 +236,7 @@ export function registerMessageTools(server: McpServer, client: E2AClient): void
       title: "Fetch one attachment's bytes from an inbound message",
       description:
         "Returns the base64-encoded content of one attachment from an inbound message. Use this when you want to inspect, forward, or hand off an attachment surfaced by `get_message`. Indexes are 0-based and stable within a message (see `attachments[].index` from get_message). To forward to another recipient, pass the returned `{filename, content_type, data}` verbatim as an entry in `send_email`'s or `reply_to_message`'s `attachments[]` array. Refuses attachments larger than 2 MB after decoding — these are too big for inline retrieval and the LLM context cost would be prohibitive.",
-      inputSchema: {
+      inputSchema: strictInputSchema({
         message_id: z.string(),
         attachment_index: z
           .number()
@@ -251,7 +251,7 @@ export function registerMessageTools(server: McpServer, client: E2AClient): void
           .describe(
             "Agent inbox holding the message. Omit when E2A_AGENT_EMAIL is set in the server environment.",
           ),
-      },
+      }),
     },
     async (args) =>
       runTool(async () => {

--- a/mcp/src/tools/util.ts
+++ b/mcp/src/tools/util.ts
@@ -1,7 +1,18 @@
+import { z, type ZodRawShape } from "zod";
+
 export type ToolResult = {
   content: Array<{ type: "text"; text: string }>;
   isError?: boolean;
 };
+
+// strictInputSchema wraps a zod raw shape in a strict ZodObject so the
+// MCP SDK rejects unknown argument keys instead of silently stripping
+// them. Without this, a typo like `limit` against a tool that takes
+// `page_size` succeeds with the bogus arg ignored — which the e2e
+// contract sweep caught as a foot-gun. Apply to every registerTool call.
+export function strictInputSchema<S extends ZodRawShape>(shape: S) {
+  return z.object(shape).strict();
+}
 
 export async function runTool<T>(fn: () => Promise<T>): Promise<ToolResult> {
   try {

--- a/sdks/python/src/e2a/v1/generated/__init__.py
+++ b/sdks/python/src/e2a/v1/generated/__init__.py
@@ -267,11 +267,15 @@ class RegisterAgentRequest(BaseModel):
     model_config = ConfigDict(
         populate_by_name=True,
     )
-    agent_mode: str | None = None
-    email: str | None = None
-    name: str | None = None
-    slug: str | None = None
-    webhook_url: str | None = None
+    agent_mode: Literal['local', 'cloud'] = Field(
+        ...,
+        description='AgentMode selects how inbound mail is delivered. Required; must be "local" or "cloud". See the type-level docs for the difference.',
+        examples=['local'],
+    )
+    email: str | None = Field(None, examples=['my-bot@yourdomain.com'])
+    name: str | None = Field(None, examples=['My Bot'])
+    slug: str | None = Field(None, examples=['my-bot'])
+    webhook_url: str | None = Field(None, examples=['https://example.com/e2a/webhook'])
 
 
 class RegisterAgentResponse(BaseModel):

--- a/sdks/typescript/src/v1/generated/types.ts
+++ b/sdks/typescript/src/v1/generated/types.ts
@@ -47,7 +47,7 @@ export interface paths {
         put?: never;
         /**
          * Register a new agent
-         * @description Register a new agent with a custom domain or, on deployments where slug registration is enabled, a slug on the shared domain. Use `slug` for instant onboarding (no DNS needed), or `email` for a custom domain (requires domain to be registered and verified first).
+         * @description Register a new agent with a custom domain or, on deployments where slug registration is enabled, a slug on the shared domain. Use `slug` for instant onboarding (no DNS needed), or `email` for a custom domain (requires domain to be registered and verified first). `agent_mode` is required and must be "local" (inbound delivered via WebSocket / pollable REST) or "cloud" (inbound POSTed to `webhook_url`). Rate limited to 20 registrations per source IP per hour; 429 responses carry a `Retry-After` header in delay-seconds form.
          */
         post: {
             parameters: {
@@ -99,7 +99,7 @@ export interface paths {
                         "application/json": string;
                     };
                 };
-                /** @description Rate limit exceeded */
+                /** @description Rate limit exceeded — see Retry-After header */
                 429: {
                     headers: {
                         [name: string]: unknown;
@@ -479,7 +479,7 @@ export interface paths {
         put?: never;
         /**
          * Reply to an inbound email
-         * @description Reply to a previously received email using its message ID. The reply is sent as a real email back to the original sender, with proper threading headers (In-Reply-To, References). Pass conversation_id to tag the reply with your thread ID — the recipient will see it on their inbound payload. Rate limited to 60 sends per agent per minute. When the owning agent has HITL enabled, the server returns 202 Accepted and status="pending_approval" instead of sending immediately.
+         * @description Reply to a previously received email using its message ID. The reply is sent as a real email back to the original sender, with proper threading headers (In-Reply-To, References). Pass conversation_id to tag the reply with your thread ID — the recipient will see it on their inbound payload. Rate limited to 60 sends per agent per minute; 429 responses carry a `Retry-After` header in delay-seconds form. When the owning agent has HITL enabled, the server returns 202 Accepted and status="pending_approval" instead of sending immediately.
          */
         post: {
             parameters: {
@@ -1346,7 +1346,7 @@ export interface paths {
         put?: never;
         /**
          * Send a new email
-         * @description Send an email from your agent to any recipient. Your agent must be domain-verified. Messages are delivered via SMTP. Rate limited to 60 sends per agent per minute. Pass conversation_id to tag the message as part of a thread. When the owning agent has HITL (human-in-the-loop) enabled, the server responds with 202 Accepted and status="pending_approval" instead — the message is held until a reviewer approves it via the dashboard, CLI, or magic link, or until the approval TTL expires and the configured expiration action fires.
+         * @description Send an email from your agent to any recipient. Your agent must be domain-verified. Messages are delivered via SMTP. Rate limited to 60 sends per agent per minute; 429 responses carry a `Retry-After` header in delay-seconds form. Pass conversation_id to tag the message as part of a thread. When the owning agent has HITL (human-in-the-loop) enabled, the server responds with 202 Accepted and status="pending_approval" instead — the message is held until a reviewer approves it via the dashboard, CLI, or magic link, or until the approval TTL expires and the configured expiration action fires.
          */
         post: {
             parameters: {
@@ -2070,10 +2070,19 @@ export interface components {
             type?: "send" | "reply" | "test";
         };
         RegisterAgentRequest: {
-            agent_mode?: string;
+            /**
+             * @description AgentMode selects how inbound mail is delivered. Required; must be "local" or "cloud". See the type-level docs for the difference.
+             * @example local
+             * @enum {string}
+             */
+            agent_mode: "local" | "cloud";
+            /** @example my-bot@yourdomain.com */
             email?: string;
+            /** @example My Bot */
             name?: string;
+            /** @example my-bot */
             slug?: string;
+            /** @example https://example.com/e2a/webhook */
             webhook_url?: string;
         };
         RegisterAgentResponse: {

--- a/tests/e2e-prod/.gitignore
+++ b/tests/e2e-prod/.gitignore
@@ -1,0 +1,1 @@
+reports/

--- a/tests/e2e-prod/consolidate.ts
+++ b/tests/e2e-prod/consolidate.ts
@@ -1,0 +1,56 @@
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+interface Finding {
+  severity: "info" | "warn" | "fail";
+  suite: string;
+  test: string;
+  message: string;
+}
+interface Report {
+  timestamp: string;
+  counts: { info: number; warn: number; fail: number };
+  findings: Finding[];
+}
+
+const dir = "./reports";
+const files = readdirSync(dir).filter((f) => f.endsWith(".json") && f !== "consolidated.json");
+const all: Finding[] = [];
+for (const f of files) {
+  const r = JSON.parse(readFileSync(join(dir, f), "utf-8")) as Report;
+  all.push(...r.findings);
+}
+
+const bySeverity = {
+  fail: all.filter((f) => f.severity === "fail"),
+  warn: all.filter((f) => f.severity === "warn"),
+  info: all.filter((f) => f.severity === "info"),
+};
+
+const out = {
+  timestamp: new Date().toISOString(),
+  total_findings: all.length,
+  counts: { fail: bySeverity.fail.length, warn: bySeverity.warn.length, info: bySeverity.info.length },
+  fail: bySeverity.fail,
+  warn: bySeverity.warn,
+  info: bySeverity.info,
+};
+writeFileSync(join(dir, "consolidated.json"), JSON.stringify(out, null, 2));
+
+console.log(`Consolidated ${all.length} findings from ${files.length} suite reports:`);
+console.log(`  FAIL: ${bySeverity.fail.length}`);
+console.log(`  WARN: ${bySeverity.warn.length}`);
+console.log(`  INFO: ${bySeverity.info.length}`);
+console.log("");
+if (bySeverity.fail.length > 0) {
+  console.log("=== FAIL ===");
+  for (const f of bySeverity.fail) console.log(`  [${f.suite}] ${f.test}: ${f.message}`);
+  console.log("");
+}
+if (bySeverity.warn.length > 0) {
+  console.log("=== WARN ===");
+  for (const f of bySeverity.warn) console.log(`  [${f.suite}] ${f.test}: ${f.message}`);
+  console.log("");
+}
+console.log("=== INFO (highlights) ===");
+for (const f of bySeverity.info) console.log(`  [${f.suite}] ${f.test}: ${f.message}`);

--- a/tests/e2e-prod/harness/cleanup.ts
+++ b/tests/e2e-prod/harness/cleanup.ts
@@ -1,0 +1,59 @@
+import type { ApiClient } from "./client.ts";
+
+type Kind = "agent" | "domain" | "signing_secret";
+
+interface Tracked {
+  kind: Kind;
+  id: string;
+}
+
+const tracked: Tracked[] = [];
+
+export function track(kind: Kind, id: string): void {
+  tracked.push({ kind, id });
+}
+
+export function untrack(kind: Kind, id: string): void {
+  const i = tracked.findIndex((t) => t.kind === kind && t.id === id);
+  if (i >= 0) tracked.splice(i, 1);
+}
+
+export async function cleanup(client: ApiClient, opts: { force?: boolean } = {}): Promise<{
+  attempted: number;
+  succeeded: number;
+  failed: Array<{ kind: Kind; id: string; reason: string }>;
+}> {
+  const failed: Array<{ kind: Kind; id: string; reason: string }> = [];
+  let succeeded = 0;
+  for (const t of [...tracked].reverse()) {
+    try {
+      const path = pathFor(t);
+      const res = await client.delete(path);
+      if (res.status === 204 || res.status === 200 || res.status === 404 || res.status === 403) {
+        // 403 == "not owned"/already deleted under anti-enumeration semantics
+        succeeded++;
+        untrack(t.kind, t.id);
+      } else {
+        failed.push({ ...t, reason: `HTTP ${res.status}: ${res.raw.slice(0, 200)}` });
+      }
+    } catch (e) {
+      failed.push({ ...t, reason: (e as Error).message });
+    }
+  }
+  return { attempted: tracked.length + succeeded, succeeded, failed };
+}
+
+function pathFor(t: Tracked): string {
+  switch (t.kind) {
+    case "agent":
+      return `/api/v1/agents/${encodeURIComponent(t.id)}`;
+    case "domain":
+      return `/api/v1/domains/${encodeURIComponent(t.id)}`;
+    case "signing_secret":
+      return `/api/v1/users/me/signing-secrets/${encodeURIComponent(t.id)}`;
+  }
+}
+
+export function getTracked(): readonly Tracked[] {
+  return tracked;
+}

--- a/tests/e2e-prod/harness/client.ts
+++ b/tests/e2e-prod/harness/client.ts
@@ -1,0 +1,111 @@
+import { loadEnv, type ProdEnv } from "./env.ts";
+
+export interface RawResponse<T = unknown> {
+  status: number;
+  ok: boolean;
+  headers: Record<string, string>;
+  body: T | null;
+  raw: string;
+  latencyMs: number;
+}
+
+export interface RequestOpts {
+  apiKey?: string | null;
+  headers?: Record<string, string>;
+  body?: unknown;
+  query?: Record<string, string | number | undefined>;
+  expect?: number | number[];
+}
+
+export class RateLimiter {
+  private lastTickMs = 0;
+  private readonly rps: number;
+  constructor(rps: number) {
+    this.rps = rps;
+  }
+  async tick(): Promise<void> {
+    const interval = 1000 / this.rps;
+    const now = Date.now();
+    const wait = Math.max(0, this.lastTickMs + interval - now);
+    if (wait > 0) await new Promise((r) => setTimeout(r, wait));
+    this.lastTickMs = Date.now();
+  }
+}
+
+export class ApiClient {
+  readonly env: ProdEnv;
+  readonly limiter: RateLimiter;
+
+  constructor(env?: ProdEnv, rpsOverride?: number) {
+    this.env = env ?? loadEnv();
+    this.limiter = new RateLimiter(rpsOverride ?? this.env.rateLimitRps);
+  }
+
+  async request<T = unknown>(method: string, path: string, opts: RequestOpts = {}): Promise<RawResponse<T>> {
+    await this.limiter.tick();
+    const url = new URL(path, this.env.apiUrl);
+    if (opts.query) {
+      for (const [k, v] of Object.entries(opts.query)) {
+        if (v !== undefined) url.searchParams.set(k, String(v));
+      }
+    }
+    const headers: Record<string, string> = {
+      Accept: "application/json",
+      ...(opts.headers ?? {}),
+    };
+    const key = opts.apiKey === null ? null : opts.apiKey ?? this.env.apiKey;
+    if (key) headers.Authorization = `Bearer ${key}`;
+    let body: string | undefined;
+    if (opts.body !== undefined) {
+      body = typeof opts.body === "string" ? opts.body : JSON.stringify(opts.body);
+      headers["Content-Type"] = headers["Content-Type"] ?? "application/json";
+    }
+    const t0 = performance.now();
+    const res = await fetch(url, { method, headers, body });
+    const raw = await res.text();
+    const latencyMs = performance.now() - t0;
+    let parsed: T | null = null;
+    if (raw.length > 0) {
+      try {
+        parsed = JSON.parse(raw) as T;
+      } catch {
+        parsed = null;
+      }
+    }
+    const out: RawResponse<T> = {
+      status: res.status,
+      ok: res.ok,
+      headers: Object.fromEntries(res.headers.entries()),
+      body: parsed,
+      raw,
+      latencyMs,
+    };
+    if (opts.expect !== undefined) {
+      const expected = Array.isArray(opts.expect) ? opts.expect : [opts.expect];
+      if (!expected.includes(res.status)) {
+        throw new Error(
+          `${method} ${url.pathname}: expected ${expected.join("|")}, got ${res.status}. Body: ${raw.slice(0, 400)}`,
+        );
+      }
+    }
+    return out;
+  }
+
+  get<T = unknown>(path: string, opts: RequestOpts = {}) {
+    return this.request<T>("GET", path, opts);
+  }
+  post<T = unknown>(path: string, opts: RequestOpts = {}) {
+    return this.request<T>("POST", path, opts);
+  }
+  patch<T = unknown>(path: string, opts: RequestOpts = {}) {
+    return this.request<T>("PATCH", path, opts);
+  }
+  put<T = unknown>(path: string, opts: RequestOpts = {}) {
+    return this.request<T>("PUT", path, opts);
+  }
+  delete<T = unknown>(path: string, opts: RequestOpts = {}) {
+    return this.request<T>("DELETE", path, opts);
+  }
+}
+
+export const defaultClient = new ApiClient();

--- a/tests/e2e-prod/harness/env.ts
+++ b/tests/e2e-prod/harness/env.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export interface ProdEnv {
+  apiUrl: string;
+  apiKey: string;
+  primaryAgentEmail: string;
+  sharedDomain: string;
+  allowStress: boolean;
+  cleanupMode: "always" | "on_success" | "never";
+  rateLimitRps: number;
+}
+
+function readLocalConfig(): { api_key?: string; api_url?: string; agent_email?: string; shared_domain?: string } {
+  try {
+    const raw = readFileSync(join(homedir(), ".e2a", "config.json"), "utf-8");
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+
+export function loadEnv(): ProdEnv {
+  const local = readLocalConfig();
+  const env: ProdEnv = {
+    apiUrl: process.env.E2A_API_URL ?? local.api_url ?? "https://e2a.dev",
+    apiKey: process.env.E2A_API_KEY ?? local.api_key ?? "",
+    primaryAgentEmail: process.env.E2A_PRIMARY_AGENT ?? local.agent_email ?? "",
+    sharedDomain: process.env.E2A_SHARED_DOMAIN ?? local.shared_domain ?? "agents.e2a.dev",
+    allowStress: process.env.E2E_PROD_STRESS === "1",
+    cleanupMode: (process.env.E2E_CLEANUP as ProdEnv["cleanupMode"]) ?? "always",
+    rateLimitRps: Number(process.env.E2E_RPS ?? "1"),
+  };
+  if (!env.apiKey) {
+    throw new Error("No API key found. Set E2A_API_KEY or run `e2a login` first.");
+  }
+  if (!env.primaryAgentEmail) {
+    throw new Error("No primary agent email. Set E2A_PRIMARY_AGENT.");
+  }
+  return env;
+}

--- a/tests/e2e-prod/harness/fixtures.ts
+++ b/tests/e2e-prod/harness/fixtures.ts
@@ -1,0 +1,21 @@
+import { randomBytes } from "node:crypto";
+
+const RUN_ID = randomBytes(3).toString("hex");
+
+export function runId(): string {
+  return RUN_ID;
+}
+
+export function uniqueSlug(prefix = "e2etest"): string {
+  return `${prefix}-${RUN_ID}-${randomBytes(3).toString("hex")}`;
+}
+
+export function uniqueSubject(label: string): string {
+  return `[e2e-${RUN_ID}] ${label} ${Date.now()}`;
+}
+
+export function uniqueIdempotencyKey(): string {
+  return `idem-${RUN_ID}-${randomBytes(6).toString("hex")}`;
+}
+
+export const SINK_EMAIL = process.env.E2E_SINK_EMAIL ?? "blackhole+e2e@e2a.dev";

--- a/tests/e2e-prod/harness/mcp.ts
+++ b/tests/e2e-prod/harness/mcp.ts
@@ -1,0 +1,123 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id: number;
+  method: string;
+  params?: unknown;
+}
+
+interface JsonRpcResponse<T = unknown> {
+  jsonrpc: "2.0";
+  id: number;
+  result?: T;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+export class StdioMcpClient {
+  private proc!: ChildProcessWithoutNullStreams;
+  private buf = "";
+  private pending = new Map<number, (resp: JsonRpcResponse) => void>();
+  private nextId = 1;
+  private stderr = "";
+
+  async start(command: string, args: string[], env: Record<string, string>): Promise<void> {
+    this.proc = spawn(command, args, { env: { ...process.env, ...env }, stdio: ["pipe", "pipe", "pipe"] });
+    this.proc.stdout.setEncoding("utf-8");
+    this.proc.stderr.setEncoding("utf-8");
+    this.proc.stdout.on("data", (chunk: string) => this.onStdout(chunk));
+    this.proc.stderr.on("data", (chunk: string) => {
+      this.stderr += chunk;
+    });
+    await this.call("initialize", {
+      protocolVersion: "2024-11-05",
+      capabilities: {},
+      clientInfo: { name: "e2e-prod", version: "0.0.1" },
+    });
+    // MCP requires an initialized notification — fire-and-forget.
+    this.notify("notifications/initialized", {});
+  }
+
+  private onStdout(chunk: string): void {
+    this.buf += chunk;
+    while (true) {
+      const nl = this.buf.indexOf("\n");
+      if (nl < 0) break;
+      const line = this.buf.slice(0, nl).trim();
+      this.buf = this.buf.slice(nl + 1);
+      if (line.length === 0) continue;
+      let msg: JsonRpcResponse;
+      try {
+        msg = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      const cb = this.pending.get(msg.id);
+      if (cb) {
+        this.pending.delete(msg.id);
+        cb(msg);
+      }
+    }
+  }
+
+  call<T = unknown>(method: string, params?: unknown, timeoutMs = 15_000): Promise<T> {
+    const id = this.nextId++;
+    const req: JsonRpcRequest = { jsonrpc: "2.0", id, method, params };
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`MCP call ${method} timed out after ${timeoutMs}ms. stderr: ${this.stderr.slice(0, 500)}`));
+      }, timeoutMs);
+      this.pending.set(id, (resp) => {
+        clearTimeout(timer);
+        if (resp.error) {
+          reject(new Error(`MCP ${method} error ${resp.error.code}: ${resp.error.message}`));
+        } else {
+          resolve(resp.result as T);
+        }
+      });
+      this.proc.stdin.write(JSON.stringify(req) + "\n");
+    });
+  }
+
+  notify(method: string, params: unknown): void {
+    const msg = { jsonrpc: "2.0", method, params };
+    this.proc.stdin.write(JSON.stringify(msg) + "\n");
+  }
+
+  async stop(): Promise<void> {
+    try {
+      this.proc.stdin.end();
+    } catch {}
+    return new Promise((resolve) => {
+      const t = setTimeout(() => {
+        try {
+          this.proc.kill("SIGKILL");
+        } catch {}
+        resolve();
+      }, 2_000);
+      this.proc.once("exit", () => {
+        clearTimeout(t);
+        resolve();
+      });
+    });
+  }
+
+  getStderr(): string {
+    return this.stderr;
+  }
+}
+
+export interface McpToolCall {
+  name: string;
+  arguments?: Record<string, unknown>;
+}
+
+export interface McpToolResult {
+  content?: Array<{ type: string; text?: string }>;
+  isError?: boolean;
+}
+
+export async function callTool(c: StdioMcpClient, name: string, args?: Record<string, unknown>): Promise<McpToolResult> {
+  return c.call<McpToolResult>("tools/call", { name, arguments: args ?? {} });
+}

--- a/tests/e2e-prod/harness/report.ts
+++ b/tests/e2e-prod/harness/report.ts
@@ -1,0 +1,46 @@
+import { writeFileSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+
+export interface Finding {
+  severity: "info" | "warn" | "fail";
+  suite: string;
+  test: string;
+  message: string;
+  detail?: unknown;
+}
+
+const findings: Finding[] = [];
+
+export function record(f: Finding): void {
+  findings.push(f);
+  const tag = f.severity === "fail" ? "FAIL" : f.severity === "warn" ? "WARN" : "INFO";
+  console.log(`[${tag}] ${f.suite} / ${f.test}: ${f.message}`);
+}
+
+export function info(suite: string, test: string, message: string, detail?: unknown) {
+  record({ severity: "info", suite, test, message, detail });
+}
+export function warn(suite: string, test: string, message: string, detail?: unknown) {
+  record({ severity: "warn", suite, test, message, detail });
+}
+export function fail(suite: string, test: string, message: string, detail?: unknown) {
+  record({ severity: "fail", suite, test, message, detail });
+}
+
+export function writeReport(path: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const summary = {
+    timestamp: new Date().toISOString(),
+    counts: {
+      info: findings.filter((f) => f.severity === "info").length,
+      warn: findings.filter((f) => f.severity === "warn").length,
+      fail: findings.filter((f) => f.severity === "fail").length,
+    },
+    findings,
+  };
+  writeFileSync(path, JSON.stringify(summary, null, 2));
+}
+
+export function getFindings(): readonly Finding[] {
+  return findings;
+}

--- a/tests/e2e-prod/package.json
+++ b/tests/e2e-prod/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "e2a-e2e-prod",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "smoke": "node smoke.ts",
+    "test": "node --test --test-reporter=spec suites/*.test.ts"
+  }
+}

--- a/tests/e2e-prod/smoke.ts
+++ b/tests/e2e-prod/smoke.ts
@@ -1,0 +1,31 @@
+import { ApiClient } from "./harness/client.ts";
+
+const client = new ApiClient();
+console.log(`API:  ${client.env.apiUrl}`);
+console.log(`Key:  ${client.env.apiKey.slice(0, 12)}…`);
+console.log(`Agent: ${client.env.primaryAgentEmail}`);
+console.log(`Shared domain: ${client.env.sharedDomain}`);
+console.log(`Rate limit: ${client.env.rateLimitRps} RPS`);
+console.log("");
+
+const info = await client.get("/api/v1/info", { expect: 200 });
+console.log(`GET /api/v1/info  ${info.status}  ${info.latencyMs.toFixed(0)}ms`);
+console.log(`  ${JSON.stringify(info.body)}`);
+
+const agent = await client.get(`/api/v1/agents/${encodeURIComponent(client.env.primaryAgentEmail)}`, { expect: 200 });
+console.log(`GET /agents/${client.env.primaryAgentEmail}  ${agent.status}  ${agent.latencyMs.toFixed(0)}ms`);
+console.log(`  ${JSON.stringify(agent.body)}`);
+
+const agents = await client.get<{ agents?: unknown[] }>("/api/v1/agents", { expect: 200 });
+console.log(`GET /agents  ${agents.status}  ${agents.latencyMs.toFixed(0)}ms  count=${agents.body?.agents?.length ?? "?"}`);
+
+const domains = await client.get<{ domains?: unknown[] }>("/api/v1/domains", { expect: 200 });
+console.log(`GET /domains  ${domains.status}  ${domains.latencyMs.toFixed(0)}ms  count=${domains.body?.domains?.length ?? "?"}`);
+
+const secrets = await client.get<{ secrets?: unknown[] }>("/api/v1/users/me/signing-secrets", { expect: 200 });
+console.log(`GET /users/me/signing-secrets  ${secrets.status}  ${secrets.latencyMs.toFixed(0)}ms  count=${secrets.body?.secrets?.length ?? "?"}`);
+
+const msgs = await client.get<{ messages?: unknown[] }>("/api/v1/messages", { query: { limit: 5 }, expect: 200 });
+console.log(`GET /messages?limit=5  ${msgs.status}  ${msgs.latencyMs.toFixed(0)}ms  count=${msgs.body?.messages?.length ?? "?"}`);
+
+console.log("\nSmoke OK");

--- a/tests/e2e-prod/suites/01-basic.test.ts
+++ b/tests/e2e-prod/suites/01-basic.test.ts
@@ -1,0 +1,230 @@
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { cleanup, track } from "../harness/cleanup.ts";
+import { uniqueSlug, uniqueSubject, SINK_EMAIL } from "../harness/fixtures.ts";
+import { fail, info, warn, writeReport } from "../harness/report.ts";
+
+const client = new ApiClient();
+const SUITE = "01-basic";
+
+after(async () => {
+  const result = await cleanup(client);
+  if (result.failed.length > 0) {
+    warn(SUITE, "cleanup", `failed to delete ${result.failed.length} resources`, result.failed);
+  } else {
+    info(SUITE, "cleanup", `cleaned up ${result.succeeded} resources`);
+  }
+  writeReport(`./reports/01-basic.json`);
+});
+
+test("info: public deployment metadata is returned", async () => {
+  const r = await client.get<{ shared_domain: string; slug_registration_enabled: boolean; public_url: string }>(
+    "/api/v1/info",
+  );
+  assert.equal(r.status, 200);
+  assert.ok(r.body?.shared_domain, "shared_domain present");
+  assert.ok(r.body?.public_url?.startsWith("http"), "public_url is a URL");
+  assert.equal(typeof r.body?.slug_registration_enabled, "boolean");
+});
+
+test("agents: list returns user's agents with required fields", async () => {
+  const r = await client.get<{ agents: Array<{ email: string; domain: string; agent_mode: string }> }>(
+    "/api/v1/agents",
+  );
+  assert.equal(r.status, 200);
+  assert.ok(Array.isArray(r.body?.agents));
+  for (const a of r.body!.agents) {
+    assert.ok(a.email && a.email.includes("@"), `agent.email valid: ${a.email}`);
+    assert.ok(a.domain, `agent.domain set: ${a.email}`);
+    assert.ok(["local", "cloud"].includes(a.agent_mode), `agent_mode in enum: ${a.agent_mode}`);
+  }
+});
+
+test("agents: get primary agent by email", async () => {
+  const email = client.env.primaryAgentEmail;
+  const r = await client.get<{ email: string; domain: string; domain_verified: boolean }>(
+    `/api/v1/agents/${encodeURIComponent(email)}`,
+  );
+  assert.equal(r.status, 200);
+  assert.equal(r.body?.email, email);
+  assert.equal(typeof r.body?.domain_verified, "boolean");
+});
+
+test("agents: get nonexistent agent returns 403 (anti-enumeration; matches spec)", async () => {
+  const r = await client.get(`/api/v1/agents/nonexistent-${Date.now()}@agents.e2a.dev`);
+  assert.equal(r.status, 403, `spec only documents 200/401/403 — expected 403 for unknown, got ${r.status}`);
+});
+
+test("agents: get malformed email returns 4xx", async () => {
+  const r = await client.get(`/api/v1/agents/not-an-email`);
+  assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}`);
+});
+
+test("agents: POST without agent_mode defaults to cloud and 400s (DX finding)", async () => {
+  const r = await client.post("/api/v1/agents", { body: { slug: uniqueSlug("nomode"), name: "no mode" } });
+  if (r.status === 201) {
+    info(SUITE, "no-mode-default", "POST /agents without agent_mode succeeded — default behavior should be documented");
+  } else {
+    info(
+      SUITE,
+      "no-mode-default",
+      `POST /agents without agent_mode → ${r.status} "${r.raw.slice(0, 120)}". RegisterAgentRequest schema does not declare a default or required mode. Recommend either documenting agent_mode as required, or defaulting to "local" for slug onboarding.`,
+    );
+  }
+  // No assertion — informational only.
+});
+
+test("agents: create + read + delete (slug on shared domain)", async () => {
+  const slug = uniqueSlug();
+  const create = await client.post<{ email: string; id: string; domain: string }>("/api/v1/agents", {
+    body: { slug, name: `e2e ${slug}`, agent_mode: "local" },
+  });
+  assert.equal(create.status, 201, `create slug-agent expected 201, got ${create.status}: ${create.raw.slice(0, 200)}`);
+  assert.ok(create.body?.email, "create returns email");
+  assert.equal(create.body?.domain, client.env.sharedDomain);
+  const email = create.body!.email;
+  track("agent", email);
+
+  const got = await client.get<{ email: string; domain_verified: boolean }>(
+    `/api/v1/agents/${encodeURIComponent(email)}`,
+  );
+  assert.equal(got.status, 200);
+  assert.equal(got.body?.email, email);
+  assert.equal(got.body?.domain_verified, true, "slug-domain agent should be auto-verified");
+
+  const del = await client.delete(`/api/v1/agents/${encodeURIComponent(email)}`);
+  assert.ok(del.status === 204 || del.status === 200, `delete expected 200/204, got ${del.status}`);
+
+  const after = await client.get(`/api/v1/agents/${encodeURIComponent(email)}`);
+  assert.equal(after.status, 403, `deleted agent should 403 (anti-enumeration), got ${after.status}`);
+});
+
+test("agents: create with missing slug AND email returns 4xx", async () => {
+  const r = await client.post("/api/v1/agents", { body: { name: "no identifier" } });
+  assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
+});
+
+test("agents: create with duplicate slug returns 409 (or 4xx)", async () => {
+  const slug = uniqueSlug();
+  const first = await client.post<{ email: string }>("/api/v1/agents", {
+    body: { slug, name: "first", agent_mode: "local" },
+  });
+  assert.equal(first.status, 201);
+  track("agent", first.body!.email);
+  const second = await client.post("/api/v1/agents", { body: { slug, name: "second", agent_mode: "local" } });
+  assert.ok(second.status >= 400 && second.status < 500, `dup slug expected 4xx, got ${second.status}`);
+  if (second.status !== 409) {
+    info(SUITE, "dup-slug-code", `spec documents 409 for "Agent already exists" but got ${second.status}: ${second.raw.slice(0, 120)}`);
+  }
+});
+
+test("agents: update hitl_enabled via PUT persists", async () => {
+  const slug = uniqueSlug();
+  const c = await client.post<{ email: string }>("/api/v1/agents", {
+    body: { slug, name: "update target", agent_mode: "local" },
+  });
+  assert.equal(c.status, 201);
+  const email = c.body!.email;
+  track("agent", email);
+
+  const upd = await client.put(`/api/v1/agents/${encodeURIComponent(email)}`, { body: { hitl_enabled: true } });
+  assert.equal(upd.status, 200, `update expected 200, got ${upd.status}: ${upd.raw.slice(0, 200)}`);
+
+  const g = await client.get<{ hitl_enabled: boolean }>(`/api/v1/agents/${encodeURIComponent(email)}`);
+  assert.equal(g.body?.hitl_enabled, true, "hitl_enabled update persisted");
+});
+
+test("agents: update with invalid agent_mode enum returns 4xx", async () => {
+  const slug = uniqueSlug();
+  const c = await client.post<{ email: string }>("/api/v1/agents", {
+    body: { slug, name: "invalid mode", agent_mode: "local" },
+  });
+  assert.equal(c.status, 201);
+  track("agent", c.body!.email);
+  const r = await client.put(`/api/v1/agents/${encodeURIComponent(c.body!.email)}`, {
+    body: { agent_mode: "not-a-real-mode" },
+  });
+  assert.ok(r.status >= 400 && r.status < 500, `expected 4xx for bad enum, got ${r.status}: ${r.raw.slice(0, 200)}`);
+});
+
+test("send: HITL-enabled agent returns 202 pending_approval", async () => {
+  const slug = uniqueSlug("hitl");
+  const c = await client.post<{ email: string }>("/api/v1/agents", {
+    body: { slug, name: "hitl", agent_mode: "local" },
+  });
+  assert.equal(c.status, 201);
+  const email = c.body!.email;
+  track("agent", email);
+  const u = await client.put(`/api/v1/agents/${encodeURIComponent(email)}`, {
+    body: { hitl_enabled: true, hitl_expiration_action: "reject", hitl_ttl_seconds: 60 },
+  });
+  assert.equal(u.status, 200);
+
+  const send = await client.post<{ message_id: string; status: string }>("/api/v1/send", {
+    body: {
+      from: email,
+      to: [SINK_EMAIL],
+      subject: uniqueSubject("hitl pending"),
+      body: "test body — should never go out, immediately rejected",
+    },
+  });
+  assert.ok(
+    send.status === 202 || send.status === 200,
+    `expected 202/200, got ${send.status}: ${send.raw.slice(0, 200)}`,
+  );
+  if (send.status !== 202) {
+    fail(SUITE, "send-hitl-pending", `HITL agent should yield 202 pending_approval, got ${send.status}`, send.body);
+    return;
+  }
+  assert.equal(send.body?.status, "pending_approval", "status field should be pending_approval");
+  assert.ok(send.body?.message_id?.startsWith("msg_"), "message_id has msg_ prefix");
+
+  const reject = await client.post(`/api/v1/messages/${send.body!.message_id}/reject`, {
+    body: { reason: "e2e test rejection" },
+  });
+  assert.ok(reject.status === 200, `reject expected 200, got ${reject.status}: ${reject.raw.slice(0, 200)}`);
+});
+
+test("send: missing 'to' returns 4xx", async () => {
+  const r = await client.post("/api/v1/send", {
+    body: { from: client.env.primaryAgentEmail, subject: "no to", body: "hi" },
+  });
+  assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
+});
+
+test("send: unowned 'from' returns 4xx (auth/scope guard)", async () => {
+  const r = await client.post("/api/v1/send", {
+    body: { from: "someone-else@example.com", to: [SINK_EMAIL], subject: "spoof", body: "hi" },
+  });
+  assert.ok(r.status >= 400 && r.status < 500, `expected 4xx (cannot send as non-owned), got ${r.status}`);
+});
+
+test("messages: list with limit + pagination tokens", async () => {
+  const r = await client.get<{ messages: unknown[]; next_token?: string }>("/api/v1/messages", {
+    query: { limit: 5 },
+  });
+  assert.equal(r.status, 200);
+  assert.ok(Array.isArray(r.body?.messages));
+  if (r.body!.messages.length >= 5) {
+    assert.ok(r.body!.next_token === undefined || typeof r.body!.next_token === "string", "next_token is string|absent");
+  }
+});
+
+test("signing-secrets: list returns documented shape", async () => {
+  const r = await client.get<{ secrets: Array<{ id: string; created_at: string }> }>(
+    "/api/v1/users/me/signing-secrets",
+  );
+  assert.equal(r.status, 200);
+  assert.ok(Array.isArray(r.body?.secrets));
+  for (const s of r.body!.secrets) {
+    assert.ok(s.id, "secret has id");
+    assert.ok(s.created_at, "secret has created_at");
+  }
+});
+
+test("domains: list returns documented shape", async () => {
+  const r = await client.get<{ domains: Array<{ domain: string }> }>("/api/v1/domains");
+  assert.equal(r.status, 200);
+  assert.ok(Array.isArray(r.body?.domains));
+});

--- a/tests/e2e-prod/suites/02-authz.test.ts
+++ b/tests/e2e-prod/suites/02-authz.test.ts
@@ -1,0 +1,119 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { cleanup, track } from "../harness/cleanup.ts";
+import { uniqueSlug } from "../harness/fixtures.ts";
+import { info, warn, writeReport, fail } from "../harness/report.ts";
+
+const client = new ApiClient();
+const SUITE = "02-authz";
+
+after(async () => {
+  const r = await cleanup(client);
+  if (r.failed.length) warn(SUITE, "cleanup", `failed ${r.failed.length}`, r.failed);
+  writeReport(`./reports/02-authz.json`);
+});
+
+test("authz: no Authorization header returns 401 on list agents", async () => {
+  const r = await client.get("/api/v1/agents", { apiKey: null });
+  assert.equal(r.status, 401, `no key expected 401, got ${r.status}: ${r.raw.slice(0, 200)}`);
+});
+
+test("authz: malformed Authorization header returns 401", async () => {
+  const r = await client.get("/api/v1/agents", { apiKey: null, headers: { Authorization: "NotBearer foo" } });
+  assert.equal(r.status, 401, `bad scheme expected 401, got ${r.status}: ${r.raw.slice(0, 200)}`);
+});
+
+test("authz: random API key with valid prefix returns 401", async () => {
+  const r = await client.get("/api/v1/agents", {
+    apiKey: "e2a_0000000000000000000000000000000000000000000000000000000000000000",
+  });
+  assert.equal(r.status, 401, `bogus key expected 401, got ${r.status}`);
+});
+
+test("authz: random API key without 'e2a_' prefix returns 401", async () => {
+  const r = await client.get("/api/v1/agents", { apiKey: "not-an-e2a-key" });
+  assert.equal(r.status, 401, `bad prefix expected 401, got ${r.status}`);
+});
+
+test("authz: 401 body does NOT leak hint about key validity", async () => {
+  const r1 = await client.get("/api/v1/agents", { apiKey: "e2a_00000000000000000000000000000000" });
+  const r2 = await client.get("/api/v1/agents", { apiKey: "garbage" });
+  if (r1.raw === r2.raw) {
+    info(SUITE, "401-uniform", "401 bodies are identical for malformed vs bogus-but-shaped — good (no oracle)");
+  } else {
+    info(
+      SUITE,
+      "401-uniform",
+      `401 bodies differ between malformed and well-shaped bogus keys. Could be a weak side-channel oracle. Bodies: "${r1.raw.slice(0, 80)}" vs "${r2.raw.slice(0, 80)}"`,
+    );
+  }
+});
+
+test("authz: bogus 'from' on /send returns 4xx (cannot impersonate)", async () => {
+  const r = await client.post("/api/v1/send", {
+    body: {
+      from: "not-mine@some-random-domain-i-dont-own-987654.com",
+      to: ["blackhole@e2a.dev"],
+      subject: "spoof attempt",
+      body: "this should be rejected",
+    },
+  });
+  assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
+});
+
+test("authz: GET /agents/<email-i-dont-own> returns 403 (no info leak)", async () => {
+  const r = await client.get(`/api/v1/agents/${encodeURIComponent("nobody@example.com")}`);
+  assert.equal(r.status, 403, `expected 403, got ${r.status}: ${r.raw.slice(0, 200)}`);
+});
+
+test("authz: PUT /agents/<email-i-dont-own> returns 403 or 4xx", async () => {
+  const r = await client.put(`/api/v1/agents/${encodeURIComponent("nobody@example.com")}`, {
+    body: { hitl_enabled: true },
+  });
+  assert.ok(r.status === 403 || (r.status >= 400 && r.status < 500), `expected 4xx, got ${r.status}`);
+});
+
+test("authz: DELETE /agents/<email-i-dont-own> returns 403 or 4xx (no cross-tenant delete)", async () => {
+  const r = await client.delete(`/api/v1/agents/${encodeURIComponent("nobody@example.com")}`);
+  assert.ok(r.status === 403 || (r.status >= 400 && r.status < 500), `expected 4xx, got ${r.status}`);
+  if (r.status === 200 || r.status === 204) {
+    fail(SUITE, "cross-tenant-delete", "CRITICAL: deleted an agent we don't own");
+  }
+});
+
+test("authz: GET /agents/<email>/messages of unowned agent returns 4xx", async () => {
+  const r = await client.get(`/api/v1/agents/${encodeURIComponent("nobody@example.com")}/messages`);
+  assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
+});
+
+test("authz: GET /messages/<bogus-id> returns 4xx, not 200", async () => {
+  const r = await client.get(`/api/v1/messages/msg_does_not_exist_${Date.now()}`);
+  assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
+});
+
+test("authz: POST /messages/<bogus>/approve returns 4xx", async () => {
+  const r = await client.post(`/api/v1/messages/msg_bogus_${Date.now()}/approve`, { body: {} });
+  assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}`);
+});
+
+test("authz: POST /messages/<bogus>/reject returns 4xx", async () => {
+  const r = await client.post(`/api/v1/messages/msg_bogus_${Date.now()}/reject`, { body: { reason: "n/a" } });
+  assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}`);
+});
+
+test("authz: signing-secret DELETE of bogus id returns 4xx (no cross-tenant leak)", async () => {
+  const r = await client.delete(`/api/v1/users/me/signing-secrets/sec_bogus_${Date.now()}`);
+  assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}`);
+});
+
+test("authz: can act on own agent (positive control)", async () => {
+  const slug = uniqueSlug("authz");
+  const c = await client.post<{ email: string }>("/api/v1/agents", {
+    body: { slug, name: "authz pos", agent_mode: "local" },
+  });
+  assert.equal(c.status, 201);
+  track("agent", c.body!.email);
+  const g = await client.get(`/api/v1/agents/${encodeURIComponent(c.body!.email)}`);
+  assert.equal(g.status, 200);
+});

--- a/tests/e2e-prod/suites/03-concurrency.test.ts
+++ b/tests/e2e-prod/suites/03-concurrency.test.ts
@@ -1,0 +1,164 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { cleanup, track } from "../harness/cleanup.ts";
+import { uniqueSlug } from "../harness/fixtures.ts";
+import { info, warn, writeReport, fail } from "../harness/report.ts";
+
+const client = new ApiClient();
+// Burst client for fan-out tests; capped at 5 RPS so we stay polite on prod.
+const burst = new ApiClient(client.env, 5);
+const SUITE = "03-concurrency";
+
+after(async () => {
+  const r = await cleanup(client);
+  if (r.failed.length) warn(SUITE, "cleanup", `failed ${r.failed.length}`, r.failed);
+  writeReport(`./reports/03-concurrency.json`);
+});
+
+test("concurrency: 5 parallel creates with distinct slugs all succeed", async () => {
+  const slugs = Array.from({ length: 5 }, () => uniqueSlug("par"));
+  const results = await Promise.all(
+    slugs.map((slug) =>
+      burst.post<{ email: string }>("/api/v1/agents", { body: { slug, name: "par", agent_mode: "local" } }),
+    ),
+  );
+  for (const r of results) {
+    assert.equal(r.status, 201, `parallel create failed: ${r.status} ${r.raw.slice(0, 200)}`);
+    if (r.body?.email) track("agent", r.body.email);
+  }
+});
+
+test("concurrency: 5 parallel creates with the SAME slug — exactly one wins, rest 409/4xx", async () => {
+  const slug = uniqueSlug("race");
+  const results = await Promise.all(
+    Array.from({ length: 5 }, () =>
+      burst.post<{ email: string }>("/api/v1/agents", { body: { slug, name: "race", agent_mode: "local" } }),
+    ),
+  );
+  const successes = results.filter((r) => r.status === 201);
+  const conflicts = results.filter((r) => r.status === 409);
+  const otherFails = results.filter((r) => r.status !== 201 && r.status !== 409);
+
+  assert.equal(successes.length, 1, `expected exactly 1 success, got ${successes.length}: ${results.map((r) => r.status).join(",")}`);
+  for (const w of successes) if (w.body?.email) track("agent", w.body.email);
+
+  if (otherFails.length > 0) {
+    info(
+      SUITE,
+      "race-non-409",
+      `${otherFails.length} losing creates returned ${otherFails.map((r) => r.status).join(",")} instead of 409 (spec). Body samples: ${otherFails.map((r) => r.raw.slice(0, 80)).join(" | ")}`,
+    );
+  } else {
+    info(SUITE, "race-clean", `all ${conflicts.length} losers returned 409 cleanly`);
+  }
+});
+
+test("concurrency: parallel reads of same agent return consistent body", async () => {
+  const slug = uniqueSlug("cr");
+  const c = await client.post<{ email: string }>("/api/v1/agents", {
+    body: { slug, name: "consistency", agent_mode: "local" },
+  });
+  assert.equal(c.status, 201);
+  const email = c.body!.email;
+  track("agent", email);
+
+  const reads = await Promise.all(
+    Array.from({ length: 8 }, () => burst.get<{ email: string; hitl_enabled: boolean }>(`/api/v1/agents/${encodeURIComponent(email)}`)),
+  );
+  for (const r of reads) {
+    assert.equal(r.status, 200);
+    assert.equal(r.body?.email, email);
+  }
+  const bodies = new Set(reads.map((r) => JSON.stringify(r.body)));
+  assert.equal(bodies.size, 1, `expected identical bodies under parallel read, got ${bodies.size} distinct`);
+});
+
+test("concurrency: parallel PUT toggles converge to a final state (no 500)", async () => {
+  const slug = uniqueSlug("toggle");
+  const c = await client.post<{ email: string }>("/api/v1/agents", {
+    body: { slug, name: "toggle", agent_mode: "local" },
+  });
+  assert.equal(c.status, 201);
+  const email = c.body!.email;
+  track("agent", email);
+
+  const ops = await Promise.all([
+    burst.put(`/api/v1/agents/${encodeURIComponent(email)}`, { body: { hitl_enabled: true } }),
+    burst.put(`/api/v1/agents/${encodeURIComponent(email)}`, { body: { hitl_enabled: false } }),
+    burst.put(`/api/v1/agents/${encodeURIComponent(email)}`, { body: { hitl_enabled: true } }),
+    burst.put(`/api/v1/agents/${encodeURIComponent(email)}`, { body: { hitl_enabled: false } }),
+  ]);
+  for (const r of ops) {
+    if (r.status >= 500) {
+      fail(SUITE, "parallel-put-500", `PUT returned ${r.status} under concurrent updates: ${r.raw.slice(0, 200)}`);
+    }
+    assert.ok(r.status < 500, `no 5xx under contention, got ${r.status}`);
+  }
+  // Final state should be one of the toggled values, not corrupted.
+  const final = await client.get<{ hitl_enabled: boolean }>(`/api/v1/agents/${encodeURIComponent(email)}`);
+  assert.equal(final.status, 200);
+  assert.equal(typeof final.body?.hitl_enabled, "boolean");
+});
+
+test("concurrency: parallel DELETE of the same agent — one succeeds, rest 403/4xx, never 500", async () => {
+  const slug = uniqueSlug("del");
+  const c = await client.post<{ email: string }>("/api/v1/agents", {
+    body: { slug, name: "del", agent_mode: "local" },
+  });
+  assert.equal(c.status, 201);
+  const email = c.body!.email;
+  // Don't track — this test consumes it.
+
+  const results = await Promise.all(
+    Array.from({ length: 4 }, () => burst.delete(`/api/v1/agents/${encodeURIComponent(email)}`)),
+  );
+  const ok = results.filter((r) => r.status === 200 || r.status === 204);
+  const fivexx = results.filter((r) => r.status >= 500);
+  assert.equal(fivexx.length, 0, `no 5xx under parallel delete, got: ${results.map((r) => r.status).join(",")}`);
+  assert.ok(ok.length >= 1, `at least one delete should succeed, got ${ok.length}: ${results.map((r) => r.status).join(",")}`);
+  if (ok.length > 1) {
+    info(SUITE, "delete-idempotent", `${ok.length} parallel deletes all returned 2xx — endpoint is idempotent (fine, but worth noting)`);
+  }
+});
+
+test("concurrency: 8 parallel sends from HITL agent — all queue (no dropped/duplicated)", async () => {
+  const slug = uniqueSlug("hitlconc");
+  const c = await client.post<{ email: string }>("/api/v1/agents", {
+    body: { slug, name: "hitl-conc", agent_mode: "local" },
+  });
+  assert.equal(c.status, 201);
+  const email = c.body!.email;
+  track("agent", email);
+  const u = await client.put(`/api/v1/agents/${encodeURIComponent(email)}`, {
+    body: { hitl_enabled: true, hitl_expiration_action: "reject", hitl_ttl_seconds: 60 },
+  });
+  assert.equal(u.status, 200);
+
+  const N = 8;
+  const sends = await Promise.all(
+    Array.from({ length: N }, (_, i) =>
+      burst.post<{ message_id: string; status: string }>("/api/v1/send", {
+        body: {
+          from: email,
+          to: ["blackhole@e2a.dev"],
+          subject: `parallel ${i}`,
+          body: `parallel send #${i}`,
+        },
+      }),
+    ),
+  );
+
+  const ids = new Set<string>();
+  for (const r of sends) {
+    assert.ok(r.status === 202 || r.status === 200, `parallel send: status ${r.status}, body: ${r.raw.slice(0, 200)}`);
+    assert.ok(r.body?.message_id?.startsWith("msg_"), `message_id present and prefixed`);
+    ids.add(r.body!.message_id);
+  }
+  assert.equal(ids.size, N, `expected ${N} distinct message_ids, got ${ids.size}`);
+
+  // Best-effort reject all so no actual mail leaves the system.
+  for (const id of ids) {
+    await client.post(`/api/v1/messages/${id}/reject`, { body: { reason: "e2e cleanup" } });
+  }
+});

--- a/tests/e2e-prod/suites/04-quota.test.ts
+++ b/tests/e2e-prod/suites/04-quota.test.ts
@@ -1,0 +1,107 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { cleanup, track } from "../harness/cleanup.ts";
+import { uniqueSlug } from "../harness/fixtures.ts";
+import { fail, info, warn, writeReport } from "../harness/report.ts";
+
+const client = new ApiClient();
+// Burst client for probing the limit. Capped at 10 RPS.
+const burst = new ApiClient(client.env, 10);
+const SUITE = "04-quota";
+
+after(async () => {
+  const r = await cleanup(client);
+  if (r.failed.length) warn(SUITE, "cleanup", `failed ${r.failed.length}`, r.failed);
+  writeReport(`./reports/04-quota.json`);
+});
+
+test("quota: send /api/v1/send rapidly until first 429 (spec says 60/min/agent)", async () => {
+  const slug = uniqueSlug("quota");
+  const c = await client.post<{ email: string }>("/api/v1/agents", {
+    body: { slug, name: "quota", agent_mode: "local" },
+  });
+  assert.equal(c.status, 201);
+  const email = c.body!.email;
+  track("agent", email);
+  await client.put(`/api/v1/agents/${encodeURIComponent(email)}`, {
+    body: { hitl_enabled: true, hitl_expiration_action: "reject", hitl_ttl_seconds: 60 },
+  });
+
+  const ids: string[] = [];
+  let limited: { status: number; retryAfter: string | undefined; index: number } | null = null;
+
+  const MAX_PROBE = 70;
+  for (let i = 0; i < MAX_PROBE; i++) {
+    const r = await burst.post<{ message_id: string; status: string }>("/api/v1/send", {
+      body: { from: email, to: ["blackhole@e2a.dev"], subject: `probe ${i}`, body: "x" },
+    });
+    if (r.status === 429) {
+      limited = { status: r.status, retryAfter: r.headers["retry-after"], index: i };
+      break;
+    }
+    if (r.status >= 400) {
+      info(SUITE, "send-probe-non-429-error", `unexpected ${r.status} at i=${i}: ${r.raw.slice(0, 200)}`);
+      break;
+    }
+    if (r.body?.message_id) ids.push(r.body.message_id);
+  }
+
+  if (limited === null) {
+    info(SUITE, "send-rate-limit", `no 429 hit after ${MAX_PROBE} sends — limit higher than spec's 60/min OR not enforced per-agent on this codepath`);
+  } else {
+    info(SUITE, "send-rate-limit-hit", `429 at request #${limited.index + 1}. Retry-After: ${limited.retryAfter ?? "(missing)"}`);
+    if (!limited.retryAfter) {
+      fail(SUITE, "missing-retry-after", "429 returned without Retry-After header (clients can't back off intelligently)");
+    } else {
+      const v = Number(limited.retryAfter);
+      assert.ok(!Number.isNaN(v) || /^[A-Z][a-z]{2},/.test(limited.retryAfter), `Retry-After should be seconds or HTTP-date, got "${limited.retryAfter}"`);
+    }
+  }
+
+  // Reject everything we queued so no actual mail leaves the system.
+  for (const id of ids) {
+    await burst.post(`/api/v1/messages/${id}/reject`, { body: { reason: "e2e cleanup" } });
+  }
+});
+
+test("quota: 429 on /agents create is documented and observable under repeated creates", async () => {
+  // Spec lists 429 for POST /agents. Probe by creating in a tight loop.
+  let createdLimit: number | null = null;
+  let lastCreatedEmail: string | null = null;
+  for (let i = 0; i < 15; i++) {
+    const r = await burst.post<{ email: string }>("/api/v1/agents", {
+      body: { slug: uniqueSlug(`q${i}`), name: "q", agent_mode: "local" },
+    });
+    if (r.body?.email) {
+      track("agent", r.body.email);
+      lastCreatedEmail = r.body.email;
+    }
+    if (r.status === 429) {
+      createdLimit = i;
+      const retryAfter = r.headers["retry-after"];
+      info(SUITE, "create-rate-limit-hit", `429 on /agents create at i=${i}. Retry-After: ${retryAfter ?? "(missing)"}`);
+      if (!retryAfter) {
+        fail(SUITE, "missing-retry-after-create", "429 on /agents create without Retry-After header");
+      }
+      break;
+    }
+    if (r.status !== 201) {
+      info(SUITE, "create-non-201", `unexpected ${r.status} at i=${i}: ${r.raw.slice(0, 200)}`);
+      break;
+    }
+  }
+  if (createdLimit === null) {
+    info(SUITE, "create-rate-limit", `no 429 on /agents create after 15 sequential creates — limit higher than 15/min`);
+  }
+  // We already track created agents; cleanup will delete them.
+  assert.ok(true);
+});
+
+test("quota: rate-limited send still allows reads from same key (non-blocking)", async () => {
+  // Even when a send-quota is exhausted, GETs on the same key should keep working.
+  const r = await burst.get("/api/v1/info");
+  assert.equal(r.status, 200, "info endpoint should remain accessible regardless of send quota");
+  const a = await burst.get("/api/v1/agents");
+  assert.equal(a.status, 200, "list agents should remain accessible");
+});

--- a/tests/e2e-prod/suites/05-security.test.ts
+++ b/tests/e2e-prod/suites/05-security.test.ts
@@ -1,0 +1,188 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { cleanup, track } from "../harness/cleanup.ts";
+import { uniqueSlug } from "../harness/fixtures.ts";
+import { fail, info, warn, writeReport } from "../harness/report.ts";
+
+const client = new ApiClient();
+const SUITE = "05-security";
+
+after(async () => {
+  const r = await cleanup(client);
+  if (r.failed.length) warn(SUITE, "cleanup", `failed ${r.failed.length}`, r.failed);
+  writeReport(`./reports/05-security.json`);
+});
+
+test("security: signing-secrets list exposes plaintext secret (documented; verify scoping)", async () => {
+  const r = await client.get<{ secrets: Array<{ id: string; secret?: string; prefix?: string }> }>(
+    "/api/v1/users/me/signing-secrets",
+  );
+  assert.equal(r.status, 200);
+  for (const s of r.body!.secrets) {
+    if (s.secret) {
+      assert.ok(s.secret.length > 16, "plaintext secret should be substantial entropy");
+    } else {
+      info(SUITE, "secret-not-in-list", `secret ${s.id} listed without plaintext field — endpoint may only return prefix`);
+    }
+  }
+});
+
+test("security: signing-secret create + delete (cleanup roundtrip)", async () => {
+  const c = await client.post<{ id: string; secret?: string }>("/api/v1/users/me/signing-secrets", {
+    body: { name: "e2e test" },
+  });
+  assert.ok(c.status === 200 || c.status === 201, `expected 2xx, got ${c.status}: ${c.raw.slice(0, 200)}`);
+  if (c.body?.id) track("signing_secret", c.body.id);
+  if (c.body?.secret) {
+    assert.ok(c.body.secret.length > 16, "freshly-created secret has substantial entropy");
+  } else {
+    info(SUITE, "create-secret-no-plaintext", "POST /signing-secrets did not return plaintext — verify users can retrieve later");
+  }
+});
+
+test("security: signing-secret DELETE with bogus id returns 4xx (no cross-tenant lookup)", async () => {
+  const r = await client.delete(`/api/v1/users/me/signing-secrets/sec_definitely_not_real_${Date.now()}`);
+  assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
+});
+
+test("security: agent name field doesn't leak HTML/script into stored body", async () => {
+  const slug = uniqueSlug("xss");
+  const payload = `<script>alert("xss")</script>&"<><`;
+  const c = await client.post<{ email: string }>("/api/v1/agents", {
+    body: { slug, name: payload, agent_mode: "local" },
+  });
+  assert.equal(c.status, 201, c.raw.slice(0, 200));
+  track("agent", c.body!.email);
+  const g = await client.get<{ name: string }>(`/api/v1/agents/${encodeURIComponent(c.body!.email)}`);
+  assert.equal(g.status, 200);
+  // Response is JSON — characters should be present literally, NOT HTML-escaped (JSON handles escaping).
+  // The risk is if the server were silently HTML-encoding into storage; that would harm clients.
+  if (g.body?.name !== payload) {
+    info(
+      SUITE,
+      "name-mutated",
+      `agent name was mutated: stored "${g.body?.name}" vs sent "${payload}". Server may be sanitizing — verify intent.`,
+    );
+  } else {
+    info(SUITE, "name-roundtrip", "agent name round-trips byte-for-byte through JSON");
+  }
+});
+
+test("security: slug accepts only safe characters (no spaces/slashes injected)", async () => {
+  const r = await client.post("/api/v1/agents", {
+    body: { slug: "evil slug with spaces /and/slashes", name: "x", agent_mode: "local" },
+  });
+  if (r.status === 201) {
+    fail(SUITE, "unsafe-slug-accepted", `server accepted slug with spaces and slashes: ${r.raw.slice(0, 200)}`);
+  } else {
+    assert.ok(r.status >= 400 && r.status < 500, `expected 4xx for unsafe slug, got ${r.status}`);
+  }
+});
+
+test("security: extremely long subject is bounded (no 500)", async () => {
+  const slug = uniqueSlug("longsubj");
+  const c = await client.post<{ email: string }>("/api/v1/agents", {
+    body: { slug, name: "long", agent_mode: "local" },
+  });
+  assert.equal(c.status, 201);
+  track("agent", c.body!.email);
+  await client.put(`/api/v1/agents/${encodeURIComponent(c.body!.email)}`, {
+    body: { hitl_enabled: true, hitl_expiration_action: "reject" },
+  });
+
+  const subject = "A".repeat(10_000);
+  const r = await client.post<{ message_id: string }>("/api/v1/send", {
+    body: { from: c.body!.email, to: ["blackhole@e2a.dev"], subject, body: "x" },
+  });
+  if (r.status >= 500) {
+    fail(SUITE, "long-subject-500", `10k-char subject caused ${r.status}: ${r.raw.slice(0, 200)}`);
+  }
+  assert.ok(r.status < 500, `expected 4xx or 2xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  if ((r.status === 200 || r.status === 202) && r.body?.message_id) {
+    // Clean up any queued mail.
+    await client.post(`/api/v1/messages/${r.body.message_id}/reject`, { body: { reason: "e2e long-subject cleanup" } });
+  }
+});
+
+test("security: CRLF injection in subject rejected or sanitized (no header smuggling)", async () => {
+  const slug = uniqueSlug("crlf");
+  const c = await client.post<{ email: string }>("/api/v1/agents", {
+    body: { slug, name: "crlf", agent_mode: "local" },
+  });
+  assert.equal(c.status, 201);
+  track("agent", c.body!.email);
+  await client.put(`/api/v1/agents/${encodeURIComponent(c.body!.email)}`, {
+    body: { hitl_enabled: true, hitl_expiration_action: "reject" },
+  });
+
+  const r = await client.post<{ message_id: string }>("/api/v1/send", {
+    body: {
+      from: c.body!.email,
+      to: ["blackhole@e2a.dev"],
+      subject: "Hello\r\nBcc: attacker@evil.com\r\nX-Smuggled: yes",
+      body: "x",
+    },
+  });
+  if (r.status >= 500) {
+    fail(SUITE, "crlf-500", `CRLF in subject caused ${r.status}: ${r.raw.slice(0, 200)}`);
+  }
+  if (r.status === 200 || r.status === 202) {
+    info(SUITE, "crlf-accepted", `CRLF in subject accepted (${r.status}). Server should sanitize before SMTP — verify in outbound path.`);
+    if (r.body?.message_id) {
+      await client.post(`/api/v1/messages/${r.body.message_id}/reject`, { body: { reason: "e2e crlf cleanup" } });
+    }
+  } else {
+    info(SUITE, "crlf-rejected", `CRLF in subject rejected with ${r.status} — good`);
+  }
+});
+
+test("security: export endpoint returns user's data only", async () => {
+  const r = await client.get<{ user?: { email?: string }; agents?: unknown[]; messages?: unknown[] }>(
+    "/api/v1/users/me/export",
+  );
+  assert.equal(r.status, 200, `export expected 200, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  assert.ok(r.body, "export returns body");
+  // Lightly assert shape — we don't know other tenants' emails to confirm absence, but we can confirm presence of own.
+  info(SUITE, "export-size", `export body length: ${r.raw.length} bytes`);
+});
+
+test("security: case-insensitive email path doesn't bypass ownership", async () => {
+  const email = client.env.primaryAgentEmail;
+  const upper = email.toUpperCase();
+  const lower = email.toLowerCase();
+  const a = await client.get(`/api/v1/agents/${encodeURIComponent(lower)}`);
+  const b = await client.get(`/api/v1/agents/${encodeURIComponent(upper)}`);
+  // Both should return same outcome (consistent normalization), neither should be 5xx.
+  assert.ok(a.status < 500, `lowercase: ${a.status}`);
+  assert.ok(b.status < 500, `uppercase: ${b.status}`);
+  if (a.status !== b.status) {
+    info(SUITE, "case-asymmetry", `case sensitivity differs: lower→${a.status} vs upper→${b.status}. May or may not be an issue depending on RFC compliance preference.`);
+  }
+});
+
+test("security: send body with HTML — html_body distinct from body", async () => {
+  const slug = uniqueSlug("html");
+  const c = await client.post<{ email: string }>("/api/v1/agents", {
+    body: { slug, name: "html", agent_mode: "local" },
+  });
+  assert.equal(c.status, 201);
+  track("agent", c.body!.email);
+  await client.put(`/api/v1/agents/${encodeURIComponent(c.body!.email)}`, {
+    body: { hitl_enabled: true, hitl_expiration_action: "reject" },
+  });
+
+  const r = await client.post<{ message_id: string; status: string }>("/api/v1/send", {
+    body: {
+      from: c.body!.email,
+      to: ["blackhole@e2a.dev"],
+      subject: "html test",
+      body: "plain text alt",
+      html_body: "<p>HTML content with <a href='https://evil.example.com'>link</a></p>",
+    },
+  });
+  assert.ok(r.status === 200 || r.status === 202, `expected 200/202, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  if (r.body?.message_id) {
+    await client.post(`/api/v1/messages/${r.body.message_id}/reject`, { body: { reason: "e2e html cleanup" } });
+  }
+});

--- a/tests/e2e-prod/suites/06-reliability.test.ts
+++ b/tests/e2e-prod/suites/06-reliability.test.ts
@@ -1,0 +1,180 @@
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { cleanup, track } from "../harness/cleanup.ts";
+import { uniqueSlug } from "../harness/fixtures.ts";
+import { fail, info, warn, writeReport } from "../harness/report.ts";
+
+const client = new ApiClient();
+const SUITE = "06-reliability";
+
+let sharedAgentEmail = "";
+
+before(async () => {
+  // Single agent shared across reliability tests to avoid hitting the agent-creation rate limit.
+  const slug = uniqueSlug("rel");
+  const c = await client.post<{ email: string }>("/api/v1/agents", {
+    body: { slug, name: "rel-shared", agent_mode: "local" },
+  });
+  if (c.status !== 201) {
+    throw new Error(`shared-agent setup failed: ${c.status} ${c.raw.slice(0, 200)}`);
+  }
+  sharedAgentEmail = c.body!.email;
+  track("agent", sharedAgentEmail);
+});
+
+after(async () => {
+  const r = await cleanup(client);
+  if (r.failed.length) warn(SUITE, "cleanup", `failed ${r.failed.length}`, r.failed);
+  writeReport(`./reports/06-reliability.json`);
+});
+
+function wsUrl(email: string): string {
+  const base = client.env.apiUrl.replace(/^http/, "ws");
+  return `${base}/api/v1/agents/${encodeURIComponent(email)}/ws`;
+}
+
+function openWS(url: string, key?: string | null, timeoutMs = 5_000): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const u = new URL(url);
+    if (key) u.searchParams.set("token", key);
+    const ws = new WebSocket(u.toString());
+    const t = setTimeout(() => {
+      try {
+        ws.close();
+      } catch {}
+      reject(new Error(`WS open timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    ws.addEventListener("open", () => {
+      clearTimeout(t);
+      resolve(ws);
+    });
+    ws.addEventListener("error", (e: Event) => {
+      clearTimeout(t);
+      reject(new Error(`WS error: ${(e as ErrorEvent).message ?? "unknown"}`));
+    });
+  });
+}
+
+function waitClose(ws: WebSocket, timeoutMs = 3_000): Promise<{ code: number; reason: string }> {
+  return new Promise((resolve) => {
+    const t = setTimeout(() => resolve({ code: -1, reason: "timeout" }), timeoutMs);
+    ws.addEventListener("close", (e: CloseEvent) => {
+      clearTimeout(t);
+      resolve({ code: e.code, reason: e.reason });
+    });
+  });
+}
+
+test("reliability: WS to own agent opens", async () => {
+  const ws = await openWS(wsUrl(sharedAgentEmail), client.env.apiKey, 5_000);
+  assert.equal(ws.readyState, 1, "WS readyState should be OPEN");
+  ws.close();
+  await waitClose(ws);
+});
+
+test("reliability: WS without api_key fails to open", async () => {
+  try {
+    await openWS(wsUrl(sharedAgentEmail), null, 3_000);
+    fail(SUITE, "ws-unauth-open", "WS opened without auth — should have rejected");
+  } catch {
+    info(SUITE, "ws-unauth-rejected", "WS without api_key correctly rejected");
+  }
+});
+
+test("reliability: WS with wrong api_key fails to open", async () => {
+  try {
+    await openWS(wsUrl(sharedAgentEmail), "e2a_00000000000000000000000000000000", 3_000);
+    fail(SUITE, "ws-badkey-open", "WS opened with bogus key — should have rejected");
+  } catch {
+    info(SUITE, "ws-badkey-rejected", "WS with bogus api_key correctly rejected");
+  }
+});
+
+test("reliability: WS to non-owned agent fails to open", async () => {
+  try {
+    await openWS(wsUrl("nobody@example.com"), client.env.apiKey, 3_000);
+    fail(SUITE, "ws-cross-tenant", "WS opened against non-owned agent — cross-tenant break");
+  } catch {
+    info(SUITE, "ws-cross-tenant-rejected", "WS to non-owned agent correctly rejected");
+  }
+});
+
+test("reliability: WS reconnect cycle (open → close → open) works", async () => {
+  const first = await openWS(wsUrl(sharedAgentEmail), client.env.apiKey, 5_000);
+  first.close();
+  await waitClose(first);
+  await new Promise((r) => setTimeout(r, 250));
+  const second = await openWS(wsUrl(sharedAgentEmail), client.env.apiKey, 5_000);
+  assert.equal(second.readyState, 1, "reconnect should succeed");
+  second.close();
+  await waitClose(second);
+});
+
+test("reliability: two concurrent WS sessions to same agent", async () => {
+  const [a, b] = await Promise.all([
+    openWS(wsUrl(sharedAgentEmail), client.env.apiKey, 5_000),
+    openWS(wsUrl(sharedAgentEmail), client.env.apiKey, 5_000),
+  ]);
+  // Either both open (server allows fan-out) or one is rejected — both are valid designs.
+  if (a.readyState === 1 && b.readyState === 1) {
+    info(SUITE, "ws-multi-session", "server allows multiple concurrent WS sessions to same agent (fan-out)");
+  } else {
+    info(SUITE, "ws-single-session", `only one WS held — states a=${a.readyState} b=${b.readyState}`);
+  }
+  try { a.close(); } catch {}
+  try { b.close(); } catch {}
+});
+
+test("reliability: idempotent PUT — applying same payload twice yields same state", async () => {
+  const payload = { hitl_enabled: true, hitl_expiration_action: "reject", hitl_ttl_seconds: 120 };
+  const first = await client.put(`/api/v1/agents/${encodeURIComponent(sharedAgentEmail)}`, { body: payload });
+  const second = await client.put(`/api/v1/agents/${encodeURIComponent(sharedAgentEmail)}`, { body: payload });
+  assert.equal(first.status, 200);
+  assert.equal(second.status, 200);
+  const g = await client.get<{ hitl_enabled: boolean; hitl_ttl_seconds: number; hitl_expiration_action: string }>(
+    `/api/v1/agents/${encodeURIComponent(sharedAgentEmail)}`,
+  );
+  assert.equal(g.body?.hitl_enabled, true);
+  assert.equal(g.body?.hitl_ttl_seconds, 120);
+  assert.equal(g.body?.hitl_expiration_action, "reject");
+});
+
+test("reliability: server timestamps are RFC3339-parseable", async () => {
+  const r = await client.get<{ created_at: string }>(`/api/v1/agents/${encodeURIComponent(sharedAgentEmail)}`);
+  assert.ok(r.body?.created_at);
+  const t = new Date(r.body!.created_at).valueOf();
+  assert.ok(!Number.isNaN(t), `created_at should parse as date: ${r.body?.created_at}`);
+  assert.ok(t > 0 && t < Date.now() + 60_000, "created_at is plausibly recent");
+});
+
+test("reliability: GET /messages with bogus next_token returns 4xx, not 500", async () => {
+  const r = await client.get("/api/v1/messages", {
+    query: { limit: 5, next_token: "completely-invalid-token-xx" },
+  });
+  if (r.status >= 500) {
+    fail(SUITE, "pagination-500", `bogus next_token caused ${r.status}: ${r.raw.slice(0, 200)}`);
+  }
+  assert.ok(r.status < 500, `expected <500, got ${r.status}: ${r.raw.slice(0, 200)}`);
+});
+
+test("reliability: GET /messages with negative limit returns 4xx, not 500", async () => {
+  const r = await client.get("/api/v1/messages", { query: { limit: -5 } });
+  if (r.status >= 500) {
+    fail(SUITE, "negative-limit-500", `negative limit caused ${r.status}: ${r.raw.slice(0, 200)}`);
+  }
+  assert.ok(r.status < 500, `expected <500, got ${r.status}`);
+});
+
+test("reliability: GET /messages with absurdly large limit returns 4xx or capped result, not 500", async () => {
+  const r = await client.get<{ messages: unknown[] }>("/api/v1/messages", { query: { limit: 1_000_000 } });
+  if (r.status >= 500) {
+    fail(SUITE, "huge-limit-500", `huge limit caused ${r.status}: ${r.raw.slice(0, 200)}`);
+  }
+  assert.ok(r.status < 500, `expected <500, got ${r.status}`);
+  if (r.status === 200 && Array.isArray(r.body?.messages) && r.body!.messages.length > 1000) {
+    info(SUITE, "limit-uncapped", `server returned ${r.body!.messages.length} items for limit=1M — no server-side cap`);
+  } else if (r.status === 200) {
+    info(SUITE, "limit-capped", `server capped result to ${r.body?.messages.length ?? "?"} items for limit=1M`);
+  }
+});

--- a/tests/e2e-prod/suites/07-error-contract.test.ts
+++ b/tests/e2e-prod/suites/07-error-contract.test.ts
@@ -1,0 +1,149 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient, type RawResponse } from "../harness/client.ts";
+import { cleanup } from "../harness/cleanup.ts";
+import { fail, info, warn, writeReport } from "../harness/report.ts";
+
+const client = new ApiClient();
+const SUITE = "07-error-contract";
+
+after(async () => {
+  const r = await cleanup(client);
+  if (r.failed.length) warn(SUITE, "cleanup", `failed ${r.failed.length}`, r.failed);
+  writeReport(`./reports/07-error-contract.json`);
+});
+
+// Track which endpoints return JSON error bodies vs text. Spec varies per endpoint —
+// the doc has many `schema: type: string` 4xx responses, suggesting bare-text errors
+// are intentional. We surface the actual shape so the SDK team can normalize.
+const shapeMap = new Map<string, { contentType: string; sample: string; status: number }>();
+
+function noteShape(label: string, r: RawResponse) {
+  shapeMap.set(label, {
+    contentType: r.headers["content-type"] ?? "",
+    sample: r.raw.slice(0, 120),
+    status: r.status,
+  });
+}
+
+test("error-contract: malformed JSON body returns 4xx, not 5xx", async () => {
+  const r = await client.post("/api/v1/agents", { body: "{not json", headers: { "Content-Type": "application/json" } });
+  noteShape("post-agents-bad-json", r);
+  if (r.status >= 500) fail(SUITE, "bad-json-500", `malformed JSON caused ${r.status}: ${r.raw.slice(0, 200)}`);
+  assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}`);
+});
+
+test("error-contract: empty body on POST /agents returns 4xx", async () => {
+  const r = await client.post("/api/v1/agents", { body: "", headers: { "Content-Type": "application/json" } });
+  noteShape("post-agents-empty", r);
+  assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
+});
+
+test("error-contract: wrong content-type on POST /agents returns 4xx", async () => {
+  const r = await client.post("/api/v1/agents", {
+    body: "slug=foo&name=bar",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+  });
+  noteShape("post-agents-wrong-ct", r);
+  assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
+});
+
+test("error-contract: GET /info ignores body+method shenanigans", async () => {
+  const r = await client.get("/api/v1/info");
+  assert.equal(r.status, 200);
+});
+
+test("error-contract: POST /info returns 4xx or 405 (read-only endpoint)", async () => {
+  const r = await client.post("/api/v1/info", { body: {} });
+  noteShape("post-info", r);
+  assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
+});
+
+test("error-contract: PUT /api/v1/messages (no such method) returns 405 or 4xx", async () => {
+  const r = await client.put("/api/v1/messages", { body: {} });
+  noteShape("put-messages", r);
+  assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}`);
+});
+
+test("error-contract: DELETE /api/v1/messages (no such method) returns 4xx", async () => {
+  const r = await client.delete("/api/v1/messages");
+  noteShape("delete-messages", r);
+  assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}`);
+});
+
+test("error-contract: GET nonexistent path returns 404", async () => {
+  const r = await client.get("/api/v1/this/does/not/exist");
+  noteShape("nonexistent-path", r);
+  assert.equal(r.status, 404, `expected 404, got ${r.status}`);
+});
+
+test("error-contract: traversal attempt returns 4xx, not file leak", async () => {
+  const r = await client.get("/api/v1/agents/..%2F..%2Fetc%2Fpasswd");
+  if (r.status === 200) {
+    fail(SUITE, "traversal-200", "path traversal returned 200 — possible bug");
+  }
+  assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}`);
+});
+
+test("error-contract: very long email path is bounded (no 500)", async () => {
+  const long = "a".repeat(2000) + "@example.com";
+  const r = await client.get(`/api/v1/agents/${encodeURIComponent(long)}`);
+  if (r.status >= 500) fail(SUITE, "long-email-500", `${r.status}: ${r.raw.slice(0, 200)}`);
+  assert.ok(r.status < 500, `expected <500, got ${r.status}`);
+});
+
+test("error-contract: invalid query types on /messages?limit=abc handled gracefully", async () => {
+  const r = await client.get("/api/v1/messages?limit=abc");
+  if (r.status >= 500) fail(SUITE, "bad-limit-500", `${r.status}: ${r.raw.slice(0, 200)}`);
+  assert.ok(r.status < 500, `expected <500, got ${r.status}`);
+});
+
+test("error-contract: PATCH on /domains/<bogus> returns 4xx", async () => {
+  const r = await client.patch(`/api/v1/domains/bogus-${Date.now()}.example.com`, { body: {} });
+  noteShape("patch-bogus-domain", r);
+  assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
+});
+
+test("error-contract: POST /domains/<bogus>/verify returns 4xx", async () => {
+  const r = await client.post(`/api/v1/domains/bogus-${Date.now()}.example.com/verify`, { body: {} });
+  noteShape("verify-bogus-domain", r);
+  assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
+});
+
+test("error-contract: invalid email path in /send.from", async () => {
+  const r = await client.post("/api/v1/send", {
+    body: { from: "not-an-email", to: ["someone@example.com"], subject: "x", body: "x" },
+  });
+  noteShape("send-bad-from", r);
+  assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
+});
+
+test("error-contract: send with empty 'to' array returns 4xx", async () => {
+  const r = await client.post("/api/v1/send", {
+    body: { from: client.env.primaryAgentEmail, to: [], subject: "x", body: "x" },
+  });
+  noteShape("send-empty-to", r);
+  assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
+});
+
+test("error-contract: send with invalid recipient address returns 4xx (no smtp call)", async () => {
+  const r = await client.post("/api/v1/send", {
+    body: { from: client.env.primaryAgentEmail, to: ["definitely not an email"], subject: "x", body: "x" },
+  });
+  noteShape("send-bad-recipient", r);
+  assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
+});
+
+test("error-contract: summary of error response shapes (informational)", async () => {
+  const byContentType = new Map<string, string[]>();
+  for (const [label, info] of shapeMap.entries()) {
+    const ct = info.contentType.split(";")[0].trim();
+    const arr = byContentType.get(ct) ?? [];
+    arr.push(`${label}=${info.status}`);
+    byContentType.set(ct, arr);
+  }
+  for (const [ct, labels] of byContentType.entries()) {
+    info(SUITE, "shape-by-ct", `Content-Type "${ct}": ${labels.join(", ")}`);
+  }
+  // No assertion — surface info only.
+});

--- a/tests/e2e-prod/suites/08-mcp.test.ts
+++ b/tests/e2e-prod/suites/08-mcp.test.ts
@@ -1,0 +1,170 @@
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { cleanup } from "../harness/cleanup.ts";
+import { StdioMcpClient, callTool } from "../harness/mcp.ts";
+import { fail, info, warn, writeReport } from "../harness/report.ts";
+
+const apiClient = new ApiClient();
+const SUITE = "08-mcp";
+
+const mcp = new StdioMcpClient();
+
+before(async () => {
+  await mcp.start("node", ["/Users/joshzhang/Desktop/e2a/mcp/dist/index.js"], {
+    E2A_API_KEY: apiClient.env.apiKey,
+    E2A_BASE_URL: apiClient.env.apiUrl,
+    E2A_AGENT_EMAIL: apiClient.env.primaryAgentEmail,
+  });
+});
+
+after(async () => {
+  await mcp.stop();
+  const r = await cleanup(apiClient);
+  if (r.failed.length) warn(SUITE, "cleanup", `failed ${r.failed.length}`, r.failed);
+  writeReport(`./reports/08-mcp.json`);
+});
+
+test("mcp: tools/list returns the expected tool surface", async () => {
+  const r = await mcp.call<{ tools: Array<{ name: string; description?: string }> }>("tools/list");
+  assert.ok(Array.isArray(r.tools), "tools is array");
+  const names = r.tools.map((t) => t.name).sort();
+  info(SUITE, "tool-surface", `MCP exposes ${names.length} tools: ${names.join(", ")}`);
+  // Should at least have these — adjust if the server changes.
+  const required = ["list_agents", "whoami"];
+  for (const req of required) {
+    assert.ok(names.includes(req), `expected tool "${req}" in surface, got ${names.join(",")}`);
+  }
+});
+
+test("mcp: list_agents returns user's agents", async () => {
+  const r = await callTool(mcp, "list_agents");
+  assert.equal(r.isError, undefined, `list_agents reported isError: ${JSON.stringify(r)}`);
+  assert.ok(r.content && r.content.length > 0, "tool returned content");
+  // Tool wraps JSON-as-text per the MCP SDK convention.
+  const text = r.content!.find((c) => c.type === "text")?.text;
+  assert.ok(text, "text content present");
+  const parsed = JSON.parse(text!) as { agents?: Array<{ email: string }> };
+  assert.ok(Array.isArray(parsed.agents), "agents array present");
+  assert.ok(parsed.agents!.some((a) => a.email === apiClient.env.primaryAgentEmail), "primary agent listed");
+});
+
+test("mcp: whoami returns the env-pinned default agent", async () => {
+  const r = await callTool(mcp, "whoami");
+  assert.equal(r.isError, undefined, `whoami isError: ${JSON.stringify(r)}`);
+  const text = r.content?.find((c) => c.type === "text")?.text;
+  assert.ok(text, "text content present");
+  const parsed = JSON.parse(text!) as { email?: string };
+  assert.equal(parsed.email, apiClient.env.primaryAgentEmail, "whoami returns the pinned agent");
+});
+
+test("mcp: unknown tool name produces an error result (isError or JSON-RPC error)", async () => {
+  // Per the MCP spec, tool-level errors use `isError: true` in the result;
+  // JSON-RPC errors are reserved for protocol-level failures. The @mcp/sdk
+  // implements this by catching tool-not-found and wrapping it as isError,
+  // so a well-behaved client must check both layers.
+  let errored = false;
+  let detail = "";
+  try {
+    const r = await callTool(mcp, "this_tool_definitely_does_not_exist");
+    if (r.isError) {
+      errored = true;
+      detail = `isError result: ${r.content?.find((c) => c.type === "text")?.text?.slice(0, 200)}`;
+    }
+  } catch (e) {
+    errored = true;
+    detail = `JSON-RPC error: ${(e as Error).message}`;
+  }
+  assert.ok(errored, "unknown tool must produce an error at one of the two layers");
+  info(SUITE, "unknown-tool-err", detail);
+});
+
+test("mcp: send_email with invalid recipient returns isError, never sends mail", async () => {
+  // Check if send_email is exposed first.
+  const list = await mcp.call<{ tools: Array<{ name: string }> }>("tools/list");
+  const sendTool = list.tools.find((t) => t.name === "send_email" || t.name === "send");
+  if (!sendTool) {
+    info(SUITE, "send-tool-absent", "no send_email tool in MCP surface — skipping invalid-recipient test");
+    return;
+  }
+  const r = await callTool(mcp, sendTool.name, {
+    to: ["definitely not a valid email"],
+    subject: "should fail validation",
+    body: "should never reach SMTP",
+  });
+  if (r.isError) {
+    info(SUITE, "send-bad-recipient-error", "MCP send tool reported isError on invalid recipient — good");
+  } else {
+    const text = r.content?.find((c) => c.type === "text")?.text;
+    fail(SUITE, "send-bad-recipient-accepted", `MCP send accepted invalid recipient: ${text?.slice(0, 200)}`);
+  }
+});
+
+test("mcp: list_messages tool works against the inbox", async () => {
+  const list = await mcp.call<{ tools: Array<{ name: string }> }>("tools/list");
+  const t = list.tools.find((x) => x.name === "list_messages");
+  if (!t) {
+    info(SUITE, "list-messages-absent", "no list_messages tool — skipping");
+    return;
+  }
+  // page_size is the actual MCP tool param (not `limit`, which is the
+  // raw HTTP API name). Use page_size here; the strict-schema test
+  // below specifically verifies unknown keys like `limit` are rejected.
+  const r = await callTool(mcp, "list_messages", { page_size: 5 });
+  assert.equal(r.isError, undefined, `list_messages isError: ${JSON.stringify(r)}`);
+  const text = r.content?.find((c) => c.type === "text")?.text;
+  assert.ok(text, "text content present");
+  const parsed = JSON.parse(text!) as { messages?: unknown[] };
+  assert.ok(Array.isArray(parsed.messages), `messages array present`);
+});
+
+test("mcp: tool arg validation — unknown keys are rejected (strict schemas)", async () => {
+  const list = await mcp.call<{ tools: Array<{ name: string }> }>("tools/list");
+  const t = list.tools.find((x) => x.name === "list_messages");
+  if (!t) {
+    info(SUITE, "list-messages-absent", "skipping arg-type test");
+    return;
+  }
+  // `limit` is not a valid arg for list_messages (the MCP tool uses `page_size`).
+  // With strict schemas, the unknown key should be rejected at the MCP layer.
+  let errored = false;
+  let detail = "";
+  try {
+    const r = await callTool(mcp, "list_messages", { limit: "not-a-number" });
+    if (r.isError) {
+      errored = true;
+      detail = `isError: ${r.content?.find((c) => c.type === "text")?.text?.slice(0, 200)}`;
+    }
+  } catch (e) {
+    errored = true;
+    detail = `JSON-RPC error: ${(e as Error).message}`;
+  }
+  assert.ok(errored, "unknown arg `limit` should be rejected by strict schema");
+  info(SUITE, "unknown-arg-rejected", detail);
+});
+
+test("mcp: tool arg validation — wrong type for declared param is rejected", async () => {
+  // page_size is declared as z.number().int().positive(); a string must be rejected.
+  let errored = false;
+  let detail = "";
+  try {
+    const r = await callTool(mcp, "list_messages", { page_size: "not-a-number" });
+    if (r.isError) {
+      errored = true;
+      detail = `isError: ${r.content?.find((c) => c.type === "text")?.text?.slice(0, 200)}`;
+    }
+  } catch (e) {
+    errored = true;
+    detail = `JSON-RPC error: ${(e as Error).message}`;
+  }
+  assert.ok(errored, "string page_size should be rejected by zod number validator");
+  info(SUITE, "bad-type-rejected", detail);
+});
+
+test("mcp: server stays alive across multiple tool calls", async () => {
+  // Quick health-check: run a few list_agents in sequence to confirm process stability.
+  for (let i = 0; i < 3; i++) {
+    const r = await callTool(mcp, "list_agents");
+    assert.equal(r.isError, undefined, `iteration ${i} failed: ${JSON.stringify(r)}`);
+  }
+});

--- a/tests/e2e-prod/suites/09-postfix.test.ts
+++ b/tests/e2e-prod/suites/09-postfix.test.ts
@@ -1,0 +1,159 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { cleanup, track } from "../harness/cleanup.ts";
+import { info, warn, writeReport } from "../harness/report.ts";
+import { uniqueSlug } from "../harness/fixtures.ts";
+
+const client = new ApiClient();
+const SUITE = "09-postfix";
+
+after(async () => {
+  const r = await cleanup(client);
+  if (r.failed.length) warn(SUITE, "cleanup", `failed ${r.failed.length}`, r.failed);
+  writeReport(`./reports/09-postfix.json`);
+});
+
+test("postfix #3: POST /agents without agent_mode returns 400 (was implicit default to cloud)", async () => {
+  const slug = uniqueSlug("nomode");
+  const r = await client.post("/api/v1/agents", { body: { slug, name: "no mode" } });
+  assert.equal(r.status, 400, `expected 400, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  // Body should mention agent_mode explicitly.
+  assert.ok(/agent_mode/i.test(r.raw), `expected error mentioning agent_mode, got: ${r.raw.slice(0, 200)}`);
+  info(SUITE, "agent-mode-required", `body: "${r.raw.trim()}"`);
+});
+
+test("postfix #3: invalid agent_mode value returns 400", async () => {
+  const slug = uniqueSlug("badmode");
+  const r = await client.post("/api/v1/agents", {
+    body: { slug, name: "bad mode", agent_mode: "neither-local-nor-cloud" },
+  });
+  assert.equal(r.status, 400, `expected 400, got ${r.status}`);
+});
+
+test("postfix #4: GET nonexistent path returns 404 with text/plain body", async () => {
+  const r = await client.get("/api/v1/this/does/not/exist");
+  assert.equal(r.status, 404, `expected 404, got ${r.status}`);
+  const ct = r.headers["content-type"] ?? "";
+  assert.ok(ct.startsWith("text/plain"), `expected text/plain, got "${ct}"`);
+  assert.ok(r.raw.trim().length > 0, "body should be non-empty");
+  info(SUITE, "404-shape", `Content-Type: "${ct}", body: "${r.raw.trim()}"`);
+});
+
+test("postfix #4: wrong-method on /info returns 405 with text/plain body (was empty)", async () => {
+  const r = await client.post("/api/v1/info", { body: {} });
+  assert.equal(r.status, 405, `expected 405, got ${r.status}`);
+  const ct = r.headers["content-type"] ?? "";
+  assert.ok(ct.startsWith("text/plain"), `expected text/plain, got "${ct}"`);
+  assert.ok(r.raw.trim().length > 0, "body should be non-empty");
+  info(SUITE, "405-shape", `Content-Type: "${ct}", body: "${r.raw.trim()}"`);
+});
+
+test("postfix #4: wrong-method on /messages returns 405 with body", async () => {
+  const r = await client.put("/api/v1/messages", { body: {} });
+  assert.equal(r.status, 405, `expected 405, got ${r.status}`);
+  const ct = r.headers["content-type"] ?? "";
+  assert.ok(ct.startsWith("text/plain"), `expected text/plain, got "${ct}"`);
+});
+
+test("postfix #6: GET /agents/{email} is case-insensitive (lowercase + uppercase match)", async () => {
+  const email = client.env.primaryAgentEmail;
+  const lower = await client.get(`/api/v1/agents/${encodeURIComponent(email.toLowerCase())}`);
+  const upper = await client.get(`/api/v1/agents/${encodeURIComponent(email.toUpperCase())}`);
+  assert.equal(lower.status, 200, "lowercase form should resolve");
+  assert.equal(upper.status, 200, `uppercase form should also resolve, got ${upper.status}: ${upper.raw.slice(0, 200)}`);
+  if (lower.body && upper.body) {
+    // Both should resolve to the same canonical agent.
+    const lEmail = (lower.body as { email?: string }).email;
+    const uEmail = (upper.body as { email?: string }).email;
+    assert.equal(lEmail, uEmail, "both case forms should resolve to the same canonical email");
+  }
+});
+
+test("postfix #6: GET /agents/{email} with mixed-case still matches", async () => {
+  const email = client.env.primaryAgentEmail;
+  const local = email.split("@")[0];
+  const domain = email.split("@")[1];
+  const mixed = local.toUpperCase() + "@" + domain.toLowerCase();
+  const r = await client.get(`/api/v1/agents/${encodeURIComponent(mixed)}`);
+  assert.equal(r.status, 200, `mixed-case email should match, got ${r.status}: ${r.raw.slice(0, 200)}`);
+});
+
+test("postfix #7: /send with CRLF in subject is rejected at the API (400)", async () => {
+  const r = await client.post("/api/v1/send", {
+    body: {
+      from: client.env.primaryAgentEmail,
+      to: ["blackhole@e2a.dev"],
+      subject: "Hello\r\nBcc: attacker@evil.com",
+      body: "x",
+    },
+  });
+  assert.equal(r.status, 400, `expected 400 (CRLF rejected), got ${r.status}: ${r.raw.slice(0, 200)}`);
+  assert.ok(/CR|LF|\\r|\\n|newline|line/i.test(r.raw), `expected error mentioning CR/LF, got: ${r.raw.slice(0, 200)}`);
+  info(SUITE, "crlf-rejected", `body: "${r.raw.trim()}"`);
+});
+
+test("postfix #7: bare LF in subject is also rejected (no carriage return)", async () => {
+  const r = await client.post("/api/v1/send", {
+    body: {
+      from: client.env.primaryAgentEmail,
+      to: ["blackhole@e2a.dev"],
+      subject: "Hello\nX-Smuggled: yes",
+      body: "x",
+    },
+  });
+  assert.equal(r.status, 400, `expected 400 for bare LF, got ${r.status}: ${r.raw.slice(0, 200)}`);
+});
+
+test("postfix #1 #2: /send 429 includes Retry-After header (probed via invalid payloads + 1 quota-hit guard)", async () => {
+  // We can't probe the send rate limit on prod without queueing real HITL
+  // notifications. Instead we verify the header CONTRACT: the docs (and
+  // OpenAPI) now say 429 carries Retry-After. We'll skip the active probe.
+  info(
+    SUITE,
+    "retry-after-probe-skipped",
+    "skipping active 60-send rate-limit probe to avoid triggering HITL notification emails — see issue #146",
+  );
+});
+
+test("postfix #1 #2: /agents 429 includes Retry-After header (active probe — does NOT send mail)", async () => {
+  // Agent creation is a pure CRUD op; failing creates don't fan out to SMTP.
+  // Probe until we see a 429 OR exhaust 25 attempts.
+  let saw429 = false;
+  let retryAfter: string | undefined;
+  for (let i = 0; i < 25; i++) {
+    const r = await client.post<{ email?: string }>("/api/v1/agents", {
+      body: { slug: uniqueSlug(`pf${i}`), name: "pf", agent_mode: "local" },
+    });
+    if (r.status === 429) {
+      saw429 = true;
+      retryAfter = r.headers["retry-after"];
+      break;
+    }
+    if (r.status === 201 && r.body?.email) {
+      // Track in the cleanup registry so the after() hook removes it,
+      // even if the loop exits early or a later attempt fails — leaving
+      // 10+ probe agents around per run pollutes the account.
+      track("agent", r.body.email);
+    }
+  }
+  if (!saw429) {
+    info(SUITE, "no-429-hit", "did not hit /agents rate limit in 25 attempts — limit higher than expected");
+    return;
+  }
+  assert.ok(retryAfter, "429 must carry Retry-After header");
+  const secs = Number(retryAfter);
+  assert.ok(!Number.isNaN(secs) && secs > 0, `Retry-After should be positive seconds, got "${retryAfter}"`);
+  info(SUITE, "retry-after-ok", `429 carries Retry-After: ${retryAfter}s — fix landed`);
+});
+
+test("postfix #8: MCP strict-schema fix is in the prod MCP server (informational)", async () => {
+  // Prod MCP server is a separate deployment; the fix needs to be re-deployed.
+  // This test just notes the assertion. The actual schema-strict assertions
+  // ran in suite 08-mcp against the LOCAL MCP server dist.
+  info(
+    SUITE,
+    "mcp-fix-deploy-note",
+    "MCP strict schemas verified against local dist (08-mcp). Prod MCP deployment carries the previous version until re-deployed.",
+  );
+});

--- a/web/public/openapi.yaml
+++ b/web/public/openapi.yaml
@@ -550,15 +550,27 @@ definitions:
   RegisterAgentRequest:
     properties:
       agent_mode:
+        description: AgentMode selects how inbound mail is delivered. Required; must
+          be "local" or "cloud". See the type-level docs for the difference.
+        enum:
+        - local
+        - cloud
+        example: local
         type: string
       email:
+        example: my-bot@yourdomain.com
         type: string
       name:
+        example: My Bot
         type: string
       slug:
+        example: my-bot
         type: string
       webhook_url:
+        example: https://example.com/e2a/webhook
         type: string
+    required:
+    - agent_mode
     type: object
   RegisterAgentResponse:
     properties:
@@ -1117,7 +1129,10 @@ paths:
       description: Register a new agent with a custom domain or, on deployments where
         slug registration is enabled, a slug on the shared domain. Use `slug` for
         instant onboarding (no DNS needed), or `email` for a custom domain (requires
-        domain to be registered and verified first).
+        domain to be registered and verified first). `agent_mode` is required and
+        must be "local" (inbound delivered via WebSocket / pollable REST) or "cloud"
+        (inbound POSTed to `webhook_url`). Rate limited to 20 registrations per source
+        IP per hour; 429 responses carry a `Retry-After` header in delay-seconds form.
       parameters:
       - description: Agent registration details
         in: body
@@ -1145,7 +1160,7 @@ paths:
           schema:
             type: string
         "429":
-          description: Rate limit exceeded
+          description: Rate limit exceeded — see Retry-After header
           schema:
             type: string
       security:
@@ -1418,8 +1433,9 @@ paths:
         reply is sent as a real email back to the original sender, with proper threading
         headers (In-Reply-To, References). Pass conversation_id to tag the reply with
         your thread ID — the recipient will see it on their inbound payload. Rate
-        limited to 60 sends per agent per minute. When the owning agent has HITL enabled,
-        the server returns 202 Accepted and status="pending_approval" instead of sending
+        limited to 60 sends per agent per minute; 429 responses carry a `Retry-After`
+        header in delay-seconds form. When the owning agent has HITL enabled, the
+        server returns 202 Accepted and status="pending_approval" instead of sending
         immediately.
       parameters:
       - description: Agent email address
@@ -1902,11 +1918,12 @@ paths:
       - application/json
       description: Send an email from your agent to any recipient. Your agent must
         be domain-verified. Messages are delivered via SMTP. Rate limited to 60 sends
-        per agent per minute. Pass conversation_id to tag the message as part of a
-        thread. When the owning agent has HITL (human-in-the-loop) enabled, the server
-        responds with 202 Accepted and status="pending_approval" instead — the message
-        is held until a reviewer approves it via the dashboard, CLI, or magic link,
-        or until the approval TTL expires and the configured expiration action fires.
+        per agent per minute; 429 responses carry a `Retry-After` header in delay-seconds
+        form. Pass conversation_id to tag the message as part of a thread. When the
+        owning agent has HITL (human-in-the-loop) enabled, the server responds with
+        202 Accepted and status="pending_approval" instead — the message is held until
+        a reviewer approves it via the dashboard, CLI, or magic link, or until the
+        approval TTL expires and the configured expiration action fires.
       parameters:
       - description: Email to send
         in: body


### PR DESCRIPTION
## Summary

Ran a comprehensive e2e audit against the prod service (e2a.dev) across basic functionality, authz, concurrency, quota, data security, reliability, error contract, and MCP tools. This PR fixes the 8 findings, hardens the tests around them, and adds the audit harness so future runs are repeatable.

Two independent code reviews on the patch (one initial, one focused on the fix deltas) — both pass with only style nits remaining.

**Behavioral fixes**

- **`Retry-After` on every 429.** `ratelimit.AllowWithRetryAfter()` returns the duration until the next slot opens (whole seconds, RFC 7231 §7.1.3). Applied to `POST /api/v1/agents`, `/send`, message polling, `/feedback`, and OAuth DCR. Spec descriptions now state the quota and reference the header.
- **`agent_mode` is required on `POST /api/v1/agents`** (breaking — previously defaulted to `cloud` then 400'd with "webhook_url required" on `{slug, name}` payloads). `binding:"required"` drives swag to emit it in OpenAPI's `required` array; the TS SDK now types it as non-optional.
- **404/405 are consistent `text/plain` with single-line bodies** — `gorilla/mux`'s default 405 had empty body and no Content-Type, which broke SDK error parsing.
- **Email path lookup is case-insensitive.** New `identity.NormalizeEmail()` applied at every external email input: REST handlers (`/agents/{email}`, `/messages/{id}`, reply path), WS upgrade (`/agents/{email}/ws`), three dashboard handlers in `internal/auth`, and OAuth consent's `agent_choice`. Slugs are intentionally NOT normalized — `validateSlug`'s regex is strict-lowercase by design.
- **CRLF in `/send` subject is rejected at the API.** Defense in depth on top of `outbound/compose`'s Q-encoding.
- **MCP tool schemas are strict** — `strictInputSchema()` wraps every `registerTool` shape in `z.object(shape).strict()`. Catches typo'd params like `limit` against `list_messages` (where the param is `page_size`).

**Tests added**

- `internal/identity/email_test.go` — `NormalizeEmail` table-driven + idempotence
- `internal/ratelimit/ratelimit_test.go` — `AllowWithRetryAfter` (allowed=0, blocked≥1s+whole-seconds, shrinks-as-window-advances)
- `internal/outbound/compose_test.go` — Q-encoding neutralizes CRLF subject smuggling
- `internal/agent/api_test.go` — `TestRegisterAgentMissingAgentMode` pins the new 400 behavior; existing `TestRegister*` fixtures now pass `agent_mode:"cloud"` explicitly (were relying on the implicit default)
- `tests/e2e-prod/` — full audit harness + 9 suites (basic, authz, concurrency, quota, security, reliability, error-contract, MCP, post-deploy verification). Reports gitignored.

**Side effects**

- Generated TS SDK `types.ts` reflects `agent_mode: "local" | "cloud"` non-optional.
- Generated Python `__init__.py` uses `Field(...)` for the required marker on `agent_mode`.
- OpenAPI spec carries the new `required: [agent_mode]` and updated rate-limit descriptions.

**Related**

- Issue #146 — HITL approval notification opt-out (filed separately, awaits implementation).
- Pre-existing flake on `TestGetPendingDeliveriesLeasesClaimedRows` in `internal/webhook` — fails on `main` HEAD too, not caused by this PR.

## Test plan

- [ ] CI: `make test-unit` passes (no DB needed)
- [ ] CI: `make test-integration` passes against the staging Postgres
- [ ] CI: `cd mcp && npm test` — 84/84 vitest tests pass
- [ ] CI: `make swagger-check` — no diff (regen stable)
- [ ] Manual: after deploy, run `cd tests/e2e-prod && node --test --test-reporter=spec suites/09-postfix.test.ts` against prod to confirm:
  - `POST /agents` without `agent_mode` → 400 with message mentioning `agent_mode`
  - `/agents` 429 carries `Retry-After` header (probe loop)
  - `GET /agents/UPPER@...` resolves the same as lowercase
  - `POST /send` with CRLF subject → 400
  - 404/405 carry `text/plain` body
- [ ] Manual: re-run the full audit suite (`tests/e2e-prod/suites/*.test.ts`) after deploy to confirm no new findings — note that suites touching happy-path `/send` will queue HITL notifications to the account owner, see #146 for the opt-out work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)