### PR TITLE
feat(api): list_messages search filters + propagate to SDKs/MCP/CLI

### DIFF
--- a/cli/src/bin/e2a.ts
+++ b/cli/src/bin/e2a.ts
@@ -37,7 +37,7 @@ Usage:
   e2a pending show <id>             Show a held message's full detail
   e2a pending approve <id> [--edit] Approve (and optionally edit) a held message
   e2a pending reject <id> [--reason …]  Reject a held message
-  e2a inbox [--unread|--read] [--limit N] [--oldest] [--token …]   List messages (newest first; --oldest for FIFO)
+  e2a inbox [--unread|--read] [--limit N] [--oldest] [--from substr] [--subject substr] [--conversation id] [--since ts] [--until ts] [--token …]   List messages (newest first; --oldest for FIFO)
   e2a read <message-id>             Read a message
   e2a reply <msg-id> --body … [--reply-all] [--cc …] [--bcc …]
   e2a send [--to …] [--cc …] [--bcc …] --subject … --body …
@@ -193,7 +193,13 @@ async function main() {
       // message at a time. Default is the new server-side default,
       // newest-first.
       const sort: "asc" | undefined = hasFlag(args, "--oldest") ? "asc" : undefined;
-      await inbox(status, limit, token, getFlag(args, "--agent"), sort);
+      await inbox(status, limit, token, getFlag(args, "--agent"), sort, {
+        from: getFlag(args, "--from"),
+        subjectContains: getFlag(args, "--subject"),
+        conversationId: getFlag(args, "--conversation"),
+        since: getFlag(args, "--since"),
+        until: getFlag(args, "--until"),
+      });
       break;
     }
     case "read":

--- a/cli/src/commands/inbox.ts
+++ b/cli/src/commands/inbox.ts
@@ -4,10 +4,17 @@ export async function inbox(
   status: string,
   limit: number,
   token: string | undefined,
-  from: string | undefined,
+  agentFrom: string | undefined,
   sort?: "asc" | "desc",
+  filters?: {
+    from?: string;
+    subjectContains?: string;
+    conversationId?: string;
+    since?: string;
+    until?: string;
+  },
 ): Promise<void> {
-  const client = createClient({ from });
+  const client = createClient({ from: agentFrom });
 
   if (!client.agentEmail) {
     process.stderr.write("No agent email. Set one with: e2a config set agent_email <email>\n");
@@ -19,6 +26,11 @@ export async function inbox(
     pageSize: limit,
     token,
     sort,
+    from: filters?.from,
+    subjectContains: filters?.subjectContains,
+    conversationId: filters?.conversationId,
+    since: filters?.since,
+    until: filters?.until,
   });
 
   if (!res.messages || res.messages.length === 0) {

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -1759,16 +1759,21 @@ func (a *API) handleReplyToMessage(w http.ResponseWriter, r *http.Request) {
 
 // handleGetMessages lists messages for an agent.
 // @Summary      List messages for an agent
-// @Description  Fetch messages for an agent. Returns lightweight summaries (no raw message content). Supports opaque token-based pagination via `page_size` and `token`. **Default sort is newest-first** across all directions — pass `?sort=asc` to flip to oldest-first when you need FIFO polling semantics (drain the inbox in arrival order). `direction` defaults to `inbound` for SDK back-compat.
+// @Description  Fetch messages for an agent. Returns lightweight summaries (no raw message content). Supports opaque token-based pagination via `page_size` and `token`. **Default sort is newest-first** across all directions — pass `?sort=asc` to flip to oldest-first when you need FIFO polling semantics (drain the inbox in arrival order). `direction` defaults to `inbound` for SDK back-compat. **Search filters** (`from`, `subject_contains`, `conversation_id`, `since`, `until`) narrow the result set server-side; substring filters are case-insensitive (Postgres ILIKE). Filter values are encoded into `next_token`, so continuation requests must keep the same filters or restart the query.
 // @Tags         Email
 // @Produce      json
 // @Security     BearerAuth
-// @Param        email     path  string true  "Agent email address" example(my-bot@example.com)
-// @Param        direction query string false "Filter by message direction" Enums(inbound, outbound, all) default(inbound)
-// @Param        status    query string false "Filter by inbox status (only meaningful when direction includes inbound)" Enums(unread, read, all) default(unread)
-// @Param        page_size query int    false "Number of messages per page (1-100)" minimum(1) maximum(100) default(50)
-// @Param        sort      query string false "Sort order by created_at. Default `desc` (newest first); pass `asc` for FIFO polling." Enums(asc, desc) default(desc)
-// @Param        token     query string false "Opaque pagination token from a previous response's next_token"
+// @Param        email            path  string true  "Agent email address" example(my-bot@example.com)
+// @Param        direction        query string false "Filter by message direction" Enums(inbound, outbound, all) default(inbound)
+// @Param        status           query string false "Filter by inbox status (only meaningful when direction includes inbound)" Enums(unread, read, all) default(unread)
+// @Param        page_size        query int    false "Number of messages per page (1-100)" minimum(1) maximum(100) default(50)
+// @Param        sort             query string false "Sort order by created_at. Default `desc` (newest first); pass `asc` for FIFO polling." Enums(asc, desc) default(desc)
+// @Param        from             query string false "Case-insensitive substring match on the sender column. Max 200 chars."
+// @Param        subject_contains query string false "Case-insensitive substring match on the subject column. Max 200 chars."
+// @Param        conversation_id  query string false "Exact match on conversation_id — narrow to a single thread."
+// @Param        since            query string false "RFC3339 timestamp; only messages with created_at >= since are returned."
+// @Param        until            query string false "RFC3339 timestamp; only messages with created_at < until are returned."
+// @Param        token            query string false "Opaque pagination token from a previous response's next_token"
 // @Success      200 {object} ListMessagesResponse
 // @Failure      400 {string} string "Invalid status, pagination token, or filter mismatch"
 // @Failure      401 {string} string "Missing or invalid API key"
@@ -1850,6 +1855,48 @@ func (a *API) handleGetMessages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Search filters. Each is optional; empty / zero means no constraint.
+	// Substring filters are bound to 200 chars to keep ILIKE patterns
+	// from running away on a hot path. Time-range filters take RFC3339
+	// timestamps and reject anything else with 400.
+	const maxFilterStr = 200
+	fromFilter := strings.TrimSpace(r.URL.Query().Get("from"))
+	if len(fromFilter) > maxFilterStr {
+		http.Error(w, "from filter too long (max 200 chars)", http.StatusBadRequest)
+		return
+	}
+	subjectContains := strings.TrimSpace(r.URL.Query().Get("subject_contains"))
+	if len(subjectContains) > maxFilterStr {
+		http.Error(w, "subject_contains filter too long (max 200 chars)", http.StatusBadRequest)
+		return
+	}
+	conversationIDFilter := strings.TrimSpace(r.URL.Query().Get("conversation_id"))
+	if len(conversationIDFilter) > maxFilterStr {
+		http.Error(w, "conversation_id too long", http.StatusBadRequest)
+		return
+	}
+	var since, until time.Time
+	if s := strings.TrimSpace(r.URL.Query().Get("since")); s != "" {
+		t, err := time.Parse(time.RFC3339, s)
+		if err != nil {
+			http.Error(w, "since must be RFC3339 (e.g. 2026-05-25T00:00:00Z)", http.StatusBadRequest)
+			return
+		}
+		since = t
+	}
+	if u := strings.TrimSpace(r.URL.Query().Get("until")); u != "" {
+		t, err := time.Parse(time.RFC3339, u)
+		if err != nil {
+			http.Error(w, "until must be RFC3339 (e.g. 2026-05-25T00:00:00Z)", http.StatusBadRequest)
+			return
+		}
+		until = t
+	}
+	if !since.IsZero() && !until.IsZero() && !since.Before(until) {
+		http.Error(w, "since must be earlier than until", http.StatusBadRequest)
+		return
+	}
+
 	// Decode opaque pagination token (encodes cursor position + filters)
 	var afterTime time.Time
 	var afterID string
@@ -1861,12 +1908,17 @@ func (a *API) handleGetMessages(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		var cursor struct {
-			CreatedAt time.Time `json:"c"`
-			ID        string    `json:"i"`
-			Status    string    `json:"s"`
-			Direction string    `json:"d"`
-			AgentID   string    `json:"a"`
-			Sort      string    `json:"so,omitempty"`
+			CreatedAt       time.Time `json:"c"`
+			ID              string    `json:"i"`
+			Status          string    `json:"s"`
+			Direction       string    `json:"d"`
+			AgentID         string    `json:"a"`
+			Sort            string    `json:"so,omitempty"`
+			From            string    `json:"f,omitempty"`
+			SubjectContains string    `json:"sc,omitempty"`
+			ConversationID  string    `json:"cv,omitempty"`
+			Since           string    `json:"sn,omitempty"`
+			Until           string    `json:"un,omitempty"`
 		}
 		if err := json.Unmarshal(decoded, &cursor); err != nil {
 			http.Error(w, "invalid pagination token", http.StatusBadRequest)
@@ -1907,6 +1959,25 @@ func (a *API) handleGetMessages(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "token was created for a different agent — start a new query without a token", http.StatusBadRequest)
 			return
 		}
+		// Search filters are part of the cursor identity: the result
+		// set isn't stable across them. Continuation must use the
+		// same filter values that produced the cursor.
+		sinceStr := ""
+		if !since.IsZero() {
+			sinceStr = since.UTC().Format(time.RFC3339Nano)
+		}
+		untilStr := ""
+		if !until.IsZero() {
+			untilStr = until.UTC().Format(time.RFC3339Nano)
+		}
+		if cursor.From != fromFilter ||
+			cursor.SubjectContains != subjectContains ||
+			cursor.ConversationID != conversationIDFilter ||
+			cursor.Since != sinceStr ||
+			cursor.Until != untilStr {
+			http.Error(w, "token was created with different search filters — start a new query without a token", http.StatusBadRequest)
+			return
+		}
 		afterTime = cursor.CreatedAt
 		afterID = cursor.ID
 	}
@@ -1926,7 +1997,20 @@ func (a *API) handleGetMessages(w http.ResponseWriter, r *http.Request) {
 	descending := sort == "desc"
 
 	// Fetch pageSize+1 to determine if there are more pages
-	messages, err := a.store.GetMessagesByAgent(r.Context(), agent.ID, status, direction, descending, pageSize+1, afterTime, afterID)
+	messages, err := a.store.GetMessagesByAgent(r.Context(), identity.MessageListFilter{
+		AgentID:         agent.ID,
+		Status:          status,
+		Direction:       direction,
+		Descending:      descending,
+		Limit:           pageSize + 1,
+		AfterTime:       afterTime,
+		AfterID:         afterID,
+		From:            fromFilter,
+		SubjectContains: subjectContains,
+		ConversationID:  conversationIDFilter,
+		Since:           since,
+		Until:           until,
+	})
 	if err != nil {
 		http.Error(w, "failed to fetch messages", http.StatusInternalServerError)
 		return
@@ -1997,14 +2081,39 @@ func (a *API) handleGetMessages(w http.ResponseWriter, r *http.Request) {
 	var nextToken *string
 	if hasMore {
 		last := messages[len(messages)-1]
+		sinceStr := ""
+		if !since.IsZero() {
+			sinceStr = since.UTC().Format(time.RFC3339Nano)
+		}
+		untilStr := ""
+		if !until.IsZero() {
+			untilStr = until.UTC().Format(time.RFC3339Nano)
+		}
 		cursorJSON, err := json.Marshal(struct {
-			CreatedAt time.Time `json:"c"`
-			ID        string    `json:"i"`
-			Status    string    `json:"s"`
-			Direction string    `json:"d"`
-			AgentID   string    `json:"a"`
-			Sort      string    `json:"so,omitempty"`
-		}{CreatedAt: last.CreatedAt, ID: last.ID, Status: status, Direction: direction, AgentID: agent.ID, Sort: sort})
+			CreatedAt       time.Time `json:"c"`
+			ID              string    `json:"i"`
+			Status          string    `json:"s"`
+			Direction       string    `json:"d"`
+			AgentID         string    `json:"a"`
+			Sort            string    `json:"so,omitempty"`
+			From            string    `json:"f,omitempty"`
+			SubjectContains string    `json:"sc,omitempty"`
+			ConversationID  string    `json:"cv,omitempty"`
+			Since           string    `json:"sn,omitempty"`
+			Until           string    `json:"un,omitempty"`
+		}{
+			CreatedAt:       last.CreatedAt,
+			ID:              last.ID,
+			Status:          status,
+			Direction:       direction,
+			AgentID:         agent.ID,
+			Sort:            sort,
+			From:            fromFilter,
+			SubjectContains: subjectContains,
+			ConversationID:  conversationIDFilter,
+			Since:           sinceStr,
+			Until:           untilStr,
+		})
 		if err != nil {
 			http.Error(w, "failed to build pagination token", http.StatusInternalServerError)
 			return

--- a/internal/agent/api_test.go
+++ b/internal/agent/api_test.go
@@ -1381,6 +1381,237 @@ func TestGetMessages_SortMismatchOnTokenReplay(t *testing.T) {
 	}
 }
 
+// ── Search filters (from / subject_contains / conversation_id / since / until) ─
+
+// TestGetMessages_FromFilter narrows by sender via case-insensitive
+// substring. The dashboard/MCP/CLI all need to support "show me mail
+// from this sender" without paginating the whole inbox.
+func TestGetMessages_FromFilter(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "owner-from@example.com", "Owner", "google-from")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "from-key", nil)
+	store.ClaimOrCreateDomain(ctx, "from.example.com", user.ID)
+	a, _ := store.CreateAgent(ctx, "agent@from.example.com", "from.example.com", "", "", "local", user.ID)
+
+	store.CreateInboundMessage(ctx, "", a.ID, "alice@acme.com", "agent@from.example.com", "", "from alice 1", "", "unread", nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", a.ID, "bob@other.com", "agent@from.example.com", "", "from bob", "", "unread", nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", a.ID, "alice@acme.com", "agent@from.example.com", "", "from alice 2", "", "unread", nil, nil, nil, nil, nil)
+
+	// ILIKE substring — `acme.com` matches both alice rows but not bob.
+	req, _ := http.NewRequest("GET", server.URL+"/api/v1/agents/agent@from.example.com/messages?status=all&from=acme.com", nil)
+	req.Header.Set("Authorization", "Bearer "+apiKeyObj.PlaintextKey)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+
+	var body struct {
+		Messages []struct {
+			From    string `json:"from"`
+			Subject string `json:"subject"`
+		} `json:"messages"`
+	}
+	json.NewDecoder(resp.Body).Decode(&body)
+	if len(body.Messages) != 2 {
+		t.Fatalf("got %d messages, want 2 (only the alice rows)", len(body.Messages))
+	}
+	for _, m := range body.Messages {
+		if !strings.Contains(strings.ToLower(m.From), "acme.com") {
+			t.Errorf("non-matching row leaked: from=%q subject=%q", m.From, m.Subject)
+		}
+	}
+}
+
+// TestGetMessages_SubjectContains uses ILIKE so callers can search
+// "invoice" and match both "Invoice #123" and "Your invoice".
+func TestGetMessages_SubjectContains(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "owner-subj@example.com", "Owner", "google-subj")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "subj-key", nil)
+	store.ClaimOrCreateDomain(ctx, "subj.example.com", user.ID)
+	a, _ := store.CreateAgent(ctx, "agent@subj.example.com", "subj.example.com", "", "", "local", user.ID)
+
+	store.CreateInboundMessage(ctx, "", a.ID, "s@example.com", "agent@subj.example.com", "", "Invoice #123", "", "unread", nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", a.ID, "s@example.com", "agent@subj.example.com", "", "Your invoice for May", "", "unread", nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", a.ID, "s@example.com", "agent@subj.example.com", "", "Unrelated", "", "unread", nil, nil, nil, nil, nil)
+
+	req, _ := http.NewRequest("GET", server.URL+"/api/v1/agents/agent@subj.example.com/messages?status=all&subject_contains=invoice", nil)
+	req.Header.Set("Authorization", "Bearer "+apiKeyObj.PlaintextKey)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+
+	var body struct {
+		Messages []struct {
+			Subject string `json:"subject"`
+		} `json:"messages"`
+	}
+	json.NewDecoder(resp.Body).Decode(&body)
+	if len(body.Messages) != 2 {
+		t.Fatalf("got %d messages, want 2 (both invoice variants)", len(body.Messages))
+	}
+}
+
+// TestGetMessages_SinceUntil bounds the result set by created_at.
+func TestGetMessages_SinceUntil(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "owner-time@example.com", "Owner", "google-time")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "time-key", nil)
+	store.ClaimOrCreateDomain(ctx, "time.example.com", user.ID)
+	a, _ := store.CreateAgent(ctx, "agent@time.example.com", "time.example.com", "", "", "local", user.ID)
+
+	// Two messages with a known gap. Capture the boundary timestamp so
+	// the assertion doesn't depend on wall-clock precision.
+	store.CreateInboundMessage(ctx, "", a.ID, "s@example.com", "agent@time.example.com", "", "early", "", "unread", nil, nil, nil, nil, nil)
+	time.Sleep(20 * time.Millisecond)
+	boundary := time.Now()
+	time.Sleep(20 * time.Millisecond)
+	store.CreateInboundMessage(ctx, "", a.ID, "s@example.com", "agent@time.example.com", "", "late", "", "unread", nil, nil, nil, nil, nil)
+
+	url := server.URL + "/api/v1/agents/agent@time.example.com/messages?status=all&since=" + boundary.UTC().Format(time.RFC3339Nano)
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Set("Authorization", "Bearer "+apiKeyObj.PlaintextKey)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+	var body struct {
+		Messages []struct {
+			Subject string `json:"subject"`
+		} `json:"messages"`
+	}
+	json.NewDecoder(resp.Body).Decode(&body)
+	if len(body.Messages) != 1 || body.Messages[0].Subject != "late" {
+		got := make([]string, 0, len(body.Messages))
+		for _, m := range body.Messages {
+			got = append(got, m.Subject)
+		}
+		t.Errorf("since filter: subjects = %v, want [late]", got)
+	}
+}
+
+// TestGetMessages_ConversationIDFilter exact-matches a thread id.
+func TestGetMessages_ConversationIDFilter(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "owner-conv@example.com", "Owner", "google-conv")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "conv-key", nil)
+	store.ClaimOrCreateDomain(ctx, "conv.example.com", user.ID)
+	a, _ := store.CreateAgent(ctx, "agent@conv.example.com", "conv.example.com", "", "", "local", user.ID)
+
+	store.CreateInboundMessage(ctx, "", a.ID, "s@example.com", "agent@conv.example.com", "", "in conv A", "conv_a_xxxx", "unread", nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", a.ID, "s@example.com", "agent@conv.example.com", "", "in conv B", "conv_b_yyyy", "unread", nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", a.ID, "s@example.com", "agent@conv.example.com", "", "also conv A", "conv_a_xxxx", "unread", nil, nil, nil, nil, nil)
+
+	req, _ := http.NewRequest("GET", server.URL+"/api/v1/agents/agent@conv.example.com/messages?status=all&conversation_id=conv_a_xxxx", nil)
+	req.Header.Set("Authorization", "Bearer "+apiKeyObj.PlaintextKey)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d", resp.StatusCode)
+	}
+
+	var body struct {
+		Messages []struct {
+			ConversationID string `json:"conversation_id"`
+		} `json:"messages"`
+	}
+	json.NewDecoder(resp.Body).Decode(&body)
+	if len(body.Messages) != 2 {
+		t.Fatalf("got %d messages, want 2 (conv_a only)", len(body.Messages))
+	}
+	for _, m := range body.Messages {
+		if m.ConversationID != "conv_a_xxxx" {
+			t.Errorf("leaked non-matching conversation: %q", m.ConversationID)
+		}
+	}
+}
+
+// TestGetMessages_InvalidFiltersRejected covers the validation paths.
+func TestGetMessages_InvalidFiltersRejected(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "owner-bad-filt@example.com", "Owner", "google-bad-filt")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "bad-filt-key", nil)
+	store.ClaimOrCreateDomain(ctx, "bad-filt.example.com", user.ID)
+	store.CreateAgent(ctx, "agent@bad-filt.example.com", "bad-filt.example.com", "", "", "local", user.ID)
+
+	cases := []struct {
+		name string
+		q    string
+	}{
+		{"bad since", "since=not-a-date"},
+		{"bad until", "until=20260525"},
+		{"inverted range", "since=2026-06-01T00:00:00Z&until=2026-05-01T00:00:00Z"},
+		{"from too long", "from=" + strings.Repeat("x", 201)},
+		{"subject too long", "subject_contains=" + strings.Repeat("y", 201)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := http.NewRequest("GET", server.URL+"/api/v1/agents/agent@bad-filt.example.com/messages?"+tc.q, nil)
+			req.Header.Set("Authorization", "Bearer "+apiKeyObj.PlaintextKey)
+			resp, _ := http.DefaultClient.Do(req)
+			defer resp.Body.Close()
+			if resp.StatusCode != 400 {
+				body, _ := io.ReadAll(resp.Body)
+				t.Errorf("status = %d, want 400; body = %s", resp.StatusCode, body)
+			}
+		})
+	}
+}
+
+// TestGetMessages_FilterMismatchOnTokenReplay rejects continuation
+// with different filters, same way sort + status do — otherwise the
+// cursor anchors against a different result set and rows would drop.
+func TestGetMessages_FilterMismatchOnTokenReplay(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "owner-filt-mm@example.com", "Owner", "google-filt-mm")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "filt-mm-key", nil)
+	store.ClaimOrCreateDomain(ctx, "filt-mm.example.com", user.ID)
+	a, _ := store.CreateAgent(ctx, "agent@filt-mm.example.com", "filt-mm.example.com", "", "", "local", user.ID)
+
+	for i := 0; i < 4; i++ {
+		store.CreateInboundMessage(ctx, "", a.ID, "alice@acme.com", "agent@filt-mm.example.com", "", fmt.Sprintf("msg-%d", i), "", "unread", nil, nil, nil, nil, nil)
+	}
+
+	req, _ := http.NewRequest("GET", server.URL+"/api/v1/agents/agent@filt-mm.example.com/messages?status=all&from=acme.com&page_size=2", nil)
+	req.Header.Set("Authorization", "Bearer "+apiKeyObj.PlaintextKey)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	var page1 struct {
+		NextToken *string `json:"next_token"`
+	}
+	json.NewDecoder(resp.Body).Decode(&page1)
+	if page1.NextToken == nil {
+		t.Fatal("expected next_token")
+	}
+
+	// Continuation with a different `from` filter — handler must reject.
+	req2, _ := http.NewRequest("GET", server.URL+"/api/v1/agents/agent@filt-mm.example.com/messages?status=all&from=other.com&token="+*page1.NextToken, nil)
+	req2.Header.Set("Authorization", "Bearer "+apiKeyObj.PlaintextKey)
+	resp2, _ := http.DefaultClient.Do(req2)
+	defer resp2.Body.Close()
+	if resp2.StatusCode != 400 {
+		t.Errorf("filter mismatch: status = %d, want 400", resp2.StatusCode)
+	}
+}
+
 func TestGetMessages_InvalidToken(t *testing.T) {
 	server, store, _ := setupAPI(t)
 	ctx := context.Background()

--- a/internal/agent/api_test.go
+++ b/internal/agent/api_test.go
@@ -1540,6 +1540,87 @@ func TestGetMessages_ConversationIDFilter(t *testing.T) {
 	}
 }
 
+// TestGetMessages_FilterEscapesLikeWildcards covers the "users expect
+// substring search, not glob" property. Postgres ILIKE treats `%` and
+// `_` as wildcards; without escaping, `?from=foo_bar` would also match
+// `fooXbar` and `?subject_contains=10%discount` would match
+// "10[anything]discount". Verify the escape: a row that contains the
+// literal `_` matches; a row with a different char in the same
+// position does NOT.
+func TestGetMessages_FilterEscapesLikeWildcards(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "owner-like-esc@example.com", "Owner", "google-like-esc")
+	apiKeyObj, _ := store.CreateAPIKey(ctx, user.ID, "like-esc-key", nil)
+	store.ClaimOrCreateDomain(ctx, "like-esc.example.com", user.ID)
+	a, _ := store.CreateAgent(ctx, "agent@like-esc.example.com", "like-esc.example.com", "", "", "local", user.ID)
+
+	// Two rows that would collide under unescaped ILIKE %foo_bar%:
+	// the literal-underscore one we want to match, and the wildcard
+	// would-also-match one we don't.
+	store.CreateInboundMessage(ctx, "", a.ID, "foo_bar@acme.com", "agent@like-esc.example.com", "", "literal underscore", "", "unread", nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", a.ID, "fooXbar@acme.com", "agent@like-esc.example.com", "", "wildcard collision", "", "unread", nil, nil, nil, nil, nil)
+	// Subject column: `%discount` would match every subject under
+	// unescaped ILIKE; the escape keeps it literal.
+	store.CreateInboundMessage(ctx, "", a.ID, "s@acme.com", "agent@like-esc.example.com", "", "10%discount today", "", "unread", nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", a.ID, "s@acme.com", "agent@like-esc.example.com", "", "Unrelated subject", "", "unread", nil, nil, nil, nil, nil)
+
+	// from=foo_bar should match only the literal-underscore row.
+	req, _ := http.NewRequest("GET", server.URL+"/api/v1/agents/agent@like-esc.example.com/messages?status=all&from=foo_bar", nil)
+	req.Header.Set("Authorization", "Bearer "+apiKeyObj.PlaintextKey)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, body)
+	}
+	var body struct {
+		Messages []struct {
+			From string `json:"from"`
+		} `json:"messages"`
+	}
+	json.NewDecoder(resp.Body).Decode(&body)
+	if len(body.Messages) != 1 {
+		got := make([]string, 0, len(body.Messages))
+		for _, m := range body.Messages {
+			got = append(got, m.From)
+		}
+		t.Fatalf("from=foo_bar matched %d rows: %v — wildcard `_` should be escaped", len(body.Messages), got)
+	}
+	if body.Messages[0].From != "foo_bar@acme.com" {
+		t.Errorf("from=foo_bar matched %q, want foo_bar@acme.com", body.Messages[0].From)
+	}
+
+	// subject_contains=10%discount should match only the literal-%
+	// row. Without ESCAPE '\', `%` collapses the pattern to match
+	// every subject in the inbox.
+	req2, _ := http.NewRequest("GET", server.URL+"/api/v1/agents/agent@like-esc.example.com/messages?status=all&subject_contains=10%25discount", nil)
+	req2.Header.Set("Authorization", "Bearer "+apiKeyObj.PlaintextKey)
+	resp2, _ := http.DefaultClient.Do(req2)
+	defer resp2.Body.Close()
+	if resp2.StatusCode != 200 {
+		body, _ := io.ReadAll(resp2.Body)
+		t.Fatalf("status = %d, body = %s", resp2.StatusCode, body)
+	}
+	var body2 struct {
+		Messages []struct {
+			Subject string `json:"subject"`
+		} `json:"messages"`
+	}
+	json.NewDecoder(resp2.Body).Decode(&body2)
+	if len(body2.Messages) != 1 {
+		got := make([]string, 0, len(body2.Messages))
+		for _, m := range body2.Messages {
+			got = append(got, m.Subject)
+		}
+		t.Fatalf("subject_contains=10%%%%discount matched %d rows: %v — `%%` should be escaped", len(body2.Messages), got)
+	}
+	if body2.Messages[0].Subject != "10%discount today" {
+		t.Errorf("unexpected subject match: %q", body2.Messages[0].Subject)
+	}
+}
+
 // TestGetMessages_InvalidFiltersRejected covers the validation paths.
 func TestGetMessages_InvalidFiltersRejected(t *testing.T) {
 	server, store, _ := setupAPI(t)

--- a/internal/agent/hitl_magic_api_test.go
+++ b/internal/agent/hitl_magic_api_test.go
@@ -278,7 +278,12 @@ func TestMagicApprovePOSTSelfSendDeliversViaLoopback(t *testing.T) {
 
 	// Inbound row reaches the agent's mailbox. GetMessagesByAgent's
 	// "all" status returns inbound rows regardless of read state.
-	inboxes, err := store.GetMessagesByAgent(ctx, a.ID, "all", "inbound", false, 10, time.Time{}, "")
+	inboxes, err := store.GetMessagesByAgent(ctx, identity.MessageListFilter{
+		AgentID:   a.ID,
+		Status:    "all",
+		Direction: "inbound",
+		Limit:     10,
+	})
 	if err != nil {
 		t.Fatalf("GetMessagesByAgent: %v", err)
 	}

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -1812,30 +1812,47 @@ func (s *Store) ListActivityByAgent(ctx context.Context, agentID string, limit i
 	return messages, rows.Err()
 }
 
-// GetMessagesByAgent returns messages for an agent, filtered by status and
-// direction.
+// MessageListFilter bundles the params for GetMessagesByAgent. Zero
+// values on the optional substring / time / ID filters mean "no
+// constraint" — callers omit what they don't want to filter on.
+type MessageListFilter struct {
+	AgentID    string
+	Status     string // "unread" | "read" | "all"
+	Direction  string // "inbound" | "outbound" | "all"
+	Descending bool
+	Limit      int
+	AfterTime  time.Time
+	AfterID    string
+	// Optional search filters. Empty / zero means "no constraint".
+	// From / SubjectContains are case-insensitive substring matches
+	// (Postgres ILIKE) and bound to 200 chars at the handler layer.
+	From            string
+	SubjectContains string
+	ConversationID  string // exact match
+	Since           time.Time // created_at >= Since
+	Until           time.Time // created_at <  Until
+}
+
+// GetMessagesByAgent returns messages for an agent, filtered by status,
+// direction, and the optional search filters on the MessageListFilter
+// struct.
 //
 //   - direction: "inbound" (default for SDK polling), "outbound", or "all"
 //     (used by the dashboard inbox).
 //   - status: "unread" | "read" | "all" — only applies when direction
 //     selects inbound rows; ignored on pure outbound queries.
-//   - descending: cursor walks newest→oldest when true (dashboard inbox);
-//     oldest→newest when false (SDK polling — agents process the oldest
-//     unread message first).
+//   - descending: cursor walks newest→oldest when true; oldest→newest
+//     when false (FIFO polling).
+//   - From / SubjectContains: case-insensitive substring (ILIKE).
+//   - ConversationID: exact match.
+//   - Since / Until: time-range bracket on created_at.
 //
 // The SELECT includes columns both consumers need: the inbox needs
 // `status` (outbound HITL lifecycle), `webhook_status`/`last_error`
 // (outbound delivery), and `octet_length(raw_message)` (size column);
 // the polling SDK ignores these fields and reads only the existing
 // inbound-relevant ones from the Message struct.
-func (s *Store) GetMessagesByAgent(
-	ctx context.Context,
-	agentID, status, direction string,
-	descending bool,
-	limit int,
-	afterTime time.Time,
-	afterID string,
-) ([]Message, error) {
+func (s *Store) GetMessagesByAgent(ctx context.Context, f MessageListFilter) ([]Message, error) {
 	var query string
 	var args []interface{}
 
@@ -1844,7 +1861,7 @@ func (s *Store) GetMessagesByAgent(
 		 LEFT JOIN webhook_deliveries wd ON wd.message_id = m.id
 		 WHERE m.agent_id = $1 AND m.expires_at > now()`
 
-	switch direction {
+	switch f.Direction {
 	case "outbound":
 		query = baseSelect + ` AND m.direction = 'outbound'`
 	case "all":
@@ -1856,14 +1873,14 @@ func (s *Store) GetMessagesByAgent(
 	// Inbox status filter only applies when inbound rows are in the
 	// result set. Silently ignored for pure outbound queries — the
 	// handler validates 400 on bad combinations before reaching here.
-	if direction != "outbound" {
-		switch status {
+	if f.Direction != "outbound" {
+		switch f.Status {
 		case "all":
 			// no extra clause
 		case "read":
 			query += ` AND m.inbox_status = 'read'`
 		default: // "unread"
-			if direction == "inbound" {
+			if f.Direction == "inbound" {
 				query += ` AND m.inbox_status = 'unread'`
 			}
 			// For direction='all', "unread" would silently drop every
@@ -1873,22 +1890,46 @@ func (s *Store) GetMessagesByAgent(
 		}
 	}
 
-	args = append(args, agentID)
+	args = append(args, f.AgentID)
+
+	// Optional search filters — each appends one arg and one WHERE
+	// clause. Ordering matches the docstring so a code reader can
+	// see at a glance which knobs map to which SQL fragment.
+	if f.From != "" {
+		query += fmt.Sprintf(` AND m.sender ILIKE $%d`, len(args)+1)
+		args = append(args, "%"+f.From+"%")
+	}
+	if f.SubjectContains != "" {
+		query += fmt.Sprintf(` AND m.subject ILIKE $%d`, len(args)+1)
+		args = append(args, "%"+f.SubjectContains+"%")
+	}
+	if f.ConversationID != "" {
+		query += fmt.Sprintf(` AND m.conversation_id = $%d`, len(args)+1)
+		args = append(args, f.ConversationID)
+	}
+	if !f.Since.IsZero() {
+		query += fmt.Sprintf(` AND m.created_at >= $%d`, len(args)+1)
+		args = append(args, f.Since)
+	}
+	if !f.Until.IsZero() {
+		query += fmt.Sprintf(` AND m.created_at < $%d`, len(args)+1)
+		args = append(args, f.Until)
+	}
 
 	cursorCmp := ">"
 	sortDir := "ASC"
-	if descending {
+	if f.Descending {
 		cursorCmp = "<"
 		sortDir = "DESC"
 	}
 
-	if afterID != "" {
+	if f.AfterID != "" {
 		query += fmt.Sprintf(` AND (m.created_at, m.id) %s ($%d, $%d)`, cursorCmp, len(args)+1, len(args)+2)
-		args = append(args, afterTime, afterID)
+		args = append(args, f.AfterTime, f.AfterID)
 	}
 
 	query += fmt.Sprintf(` ORDER BY m.created_at %s, m.id %s LIMIT $%d`, sortDir, sortDir, len(args)+1)
-	args = append(args, limit)
+	args = append(args, f.Limit)
 
 	rows, err := s.pool.Query(ctx, query, args...)
 	if err != nil {

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -1812,6 +1812,21 @@ func (s *Store) ListActivityByAgent(ctx context.Context, agentID string, limit i
 	return messages, rows.Err()
 }
 
+// escapeLikePattern escapes the three SQL LIKE/ILIKE metacharacters
+// (%, _, \) by prefixing them with backslash. Callers pair the
+// returned pattern with `ESCAPE '\'` in the SQL fragment so the
+// driver treats backslash as the escape char.
+//
+// This is NOT for SQL injection protection — pgx parameter binding
+// already handles that — it's for "user-typed substring search,
+// not glob". Without this, `?from=foo_bar` would match `fooXbar`,
+// and `?from=%@acme.com` would match every row in the table.
+var likeEscaper = strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
+
+func escapeLikePattern(s string) string {
+	return likeEscaper.Replace(s)
+}
+
 // MessageListFilter bundles the params for GetMessagesByAgent. Zero
 // values on the optional substring / time / ID filters mean "no
 // constraint" — callers omit what they don't want to filter on.
@@ -1895,13 +1910,20 @@ func (s *Store) GetMessagesByAgent(ctx context.Context, f MessageListFilter) ([]
 	// Optional search filters — each appends one arg and one WHERE
 	// clause. Ordering matches the docstring so a code reader can
 	// see at a glance which knobs map to which SQL fragment.
+	//
+	// ILIKE filters use ESCAPE '\' so the caller's literal `%`, `_`,
+	// and `\` characters match themselves instead of acting as SQL
+	// pattern wildcards. Without this, `?from=foo_bar` would also
+	// match `fooXbar`, and `?from=%@acme.com` would match every row.
+	// pgx parameter binding still protects against injection — this
+	// is purely a "users expect substring search, not glob" fix.
 	if f.From != "" {
-		query += fmt.Sprintf(` AND m.sender ILIKE $%d`, len(args)+1)
-		args = append(args, "%"+f.From+"%")
+		query += fmt.Sprintf(` AND m.sender ILIKE $%d ESCAPE '\'`, len(args)+1)
+		args = append(args, "%"+escapeLikePattern(f.From)+"%")
 	}
 	if f.SubjectContains != "" {
-		query += fmt.Sprintf(` AND m.subject ILIKE $%d`, len(args)+1)
-		args = append(args, "%"+f.SubjectContains+"%")
+		query += fmt.Sprintf(` AND m.subject ILIKE $%d ESCAPE '\'`, len(args)+1)
+		args = append(args, "%"+escapeLikePattern(f.SubjectContains)+"%")
 	}
 	if f.ConversationID != "" {
 		query += fmt.Sprintf(` AND m.conversation_id = $%d`, len(args)+1)

--- a/internal/identity/store_test.go
+++ b/internal/identity/store_test.go
@@ -393,7 +393,12 @@ func TestInboundMessageRoundTripsToCcLists(t *testing.T) {
 	}
 
 	// And the list path (GET /messages) — yet another SELECT.
-	msgs, err := store.GetMessagesByAgent(ctx, a.ID, "all", "inbound", false, 10, time.Time{}, "")
+	msgs, err := store.GetMessagesByAgent(ctx, identity.MessageListFilter{
+		AgentID:   a.ID,
+		Status:    "all",
+		Direction: "inbound",
+		Limit:     10,
+	})
 	if err != nil {
 		t.Fatalf("GetMessagesByAgent: %v", err)
 	}

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -16,7 +16,7 @@ import (
 type HandlerStore interface {
 	GetUserByAPIKey(ctx context.Context, apiKey string) (*identity.User, error)
 	GetAgentByEmail(ctx context.Context, email string) (*identity.AgentIdentity, error)
-	GetMessagesByAgent(ctx context.Context, agentID, status, direction string, descending bool, limit int, afterTime time.Time, afterID string) ([]identity.Message, error)
+	GetMessagesByAgent(ctx context.Context, f identity.MessageListFilter) ([]identity.Message, error)
 }
 
 // Handler upgrades HTTP connections to WebSocket for local-mode agents.
@@ -105,7 +105,12 @@ func (h *Handler) drainUnread(agent *identity.AgentIdentity) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	messages, err := h.store.GetMessagesByAgent(ctx, agent.ID, "unread", "inbound", false, 100, time.Time{}, "")
+	messages, err := h.store.GetMessagesByAgent(ctx, identity.MessageListFilter{
+		AgentID:   agent.ID,
+		Status:    "unread",
+		Direction: "inbound",
+		Limit:     100,
+	})
 	if err != nil {
 		log.Printf("[ws] drain error for %s: %v", agent.ID, err)
 		return

--- a/internal/ws/handler_test.go
+++ b/internal/ws/handler_test.go
@@ -35,7 +35,7 @@ func (m *mockStore) GetAgentByEmail(_ context.Context, email string) (*identity.
 	return m.agent, m.agentErr
 }
 
-func (m *mockStore) GetMessagesByAgent(_ context.Context, agentID, status, direction string, descending bool, limit int, afterTime time.Time, afterID string) ([]identity.Message, error) {
+func (m *mockStore) GetMessagesByAgent(_ context.Context, _ identity.MessageListFilter) ([]identity.Message, error) {
 	return m.messages, m.msgErr
 }
 

--- a/mcp/src/tools/messages.ts
+++ b/mcp/src/tools/messages.ts
@@ -88,7 +88,7 @@ export function registerMessageTools(server: McpServer, client: E2AClient): void
     {
       title: "List inbound messages",
       description:
-        "List messages the agent has received, newest first by default. Filter by `status` (unread/read/all; default unread) and paginate with `page_size` + `token`. Pass `sort: \"asc\"` for FIFO order (oldest unread first) when the caller wants to drain the inbox in arrival order. Returns summaries only — use `get_message` for the full body.",
+        "List messages the agent has received, newest first by default. Filter by `status` (unread/read/all; default unread) and paginate with `page_size` + `token`. Pass `sort: \"asc\"` for FIFO order (oldest unread first) when the caller wants to drain the inbox in arrival order. **Search filters** (`from`, `subject_contains`, `conversation_id`, `since`, `until`) narrow the result set server-side — use them instead of paginating the full inbox client-side. Returns summaries only — use `get_message` for the full body.",
       inputSchema: {
         status: z.enum(["unread", "read", "all"]).optional(),
         page_size: z.number().int().positive().max(100).optional(),
@@ -97,6 +97,37 @@ export function registerMessageTools(server: McpServer, client: E2AClient): void
           .optional()
           .describe(
             "Sort order by created_at. Defaults to `desc` (newest first). Pass `asc` for FIFO polling — drain the inbox in arrival order. Switching sort mid-pagination rejects the existing token.",
+          ),
+        from: z
+          .string()
+          .max(200)
+          .optional()
+          .describe(
+            "Case-insensitive substring on the sender address. Example: `acme.com` matches every message from any `*@acme.com` sender.",
+          ),
+        subject_contains: z
+          .string()
+          .max(200)
+          .optional()
+          .describe(
+            "Case-insensitive substring on the subject line. Example: `invoice` matches `Invoice #123` and `Your invoice`.",
+          ),
+        conversation_id: z
+          .string()
+          .max(200)
+          .optional()
+          .describe("Exact match on the thread/conversation id."),
+        since: z
+          .string()
+          .optional()
+          .describe(
+            "RFC3339 timestamp. Only messages with `created_at >= since` are returned. Example: `2026-05-25T00:00:00Z`.",
+          ),
+        until: z
+          .string()
+          .optional()
+          .describe(
+            "RFC3339 timestamp. Only messages with `created_at < until` are returned. Combine with `since` to bracket a date range.",
           ),
         token: z.string().optional().describe("Pagination token from a previous response."),
         agent_email: z.string().optional(),
@@ -108,6 +139,15 @@ export function registerMessageTools(server: McpServer, client: E2AClient): void
           ...(args.status !== undefined ? { status: args.status } : {}),
           ...(args.page_size !== undefined ? { pageSize: args.page_size } : {}),
           ...(args.sort !== undefined ? { sort: args.sort } : {}),
+          ...(args.from !== undefined ? { from: args.from } : {}),
+          ...(args.subject_contains !== undefined
+            ? { subjectContains: args.subject_contains }
+            : {}),
+          ...(args.conversation_id !== undefined
+            ? { conversationId: args.conversation_id }
+            : {}),
+          ...(args.since !== undefined ? { since: args.since } : {}),
+          ...(args.until !== undefined ? { until: args.until } : {}),
           ...(args.token !== undefined ? { token: args.token } : {}),
           ...(args.agent_email !== undefined ? { agentEmail: args.agent_email } : {}),
         }),

--- a/sdks/python/src/e2a/v1/api.py
+++ b/sdks/python/src/e2a/v1/api.py
@@ -192,6 +192,11 @@ class E2AApi:
         page_size: int = 50,
         token: Optional[str] = None,
         sort: Optional[str] = None,
+        from_: Optional[str] = None,
+        subject_contains: Optional[str] = None,
+        conversation_id: Optional[str] = None,
+        since: Optional[str] = None,
+        until: Optional[str] = None,
     ) -> ListMessagesResponse:
         """List messages for an agent.
 
@@ -200,10 +205,30 @@ class E2AApi:
         order. The choice is encoded in ``next_token`` so subsequent
         pages keep the same order; switching mid-pagination returns
         400.
+
+        ``from_``, ``subject_contains``: case-insensitive substring
+        match (Postgres ILIKE). Capped server-side at 200 chars.
+
+        ``conversation_id``: exact match — narrow to one thread.
+
+        ``since`` / ``until``: RFC3339 timestamps (``datetime.isoformat()``
+        produces a valid value as long as it ends in ``Z`` or has a
+        timezone offset). Bracket on ``created_at`` (``>= since`` and
+        ``< until``).
         """
         params: dict[str, str] = {"status": status, "page_size": str(page_size)}
         if sort:
             params["sort"] = sort
+        if from_:
+            params["from"] = from_
+        if subject_contains:
+            params["subject_contains"] = subject_contains
+        if conversation_id:
+            params["conversation_id"] = conversation_id
+        if since:
+            params["since"] = since
+        if until:
+            params["until"] = until
         if token:
             params["token"] = token
         resp = self._client.get(

--- a/sdks/python/src/e2a/v1/async_client.py
+++ b/sdks/python/src/e2a/v1/async_client.py
@@ -165,13 +165,27 @@ class AsyncE2AApi:
         page_size: int = 50,
         token: Optional[str] = None,
         sort: Optional[str] = None,
+        from_: Optional[str] = None,
+        subject_contains: Optional[str] = None,
+        conversation_id: Optional[str] = None,
+        since: Optional[str] = None,
+        until: Optional[str] = None,
     ) -> ListMessagesResponse:
         """Async variant of :meth:`E2AApi.list_messages`. See that
-        method for the ``sort`` semantics (defaults newest-first;
-        pass ``"asc"`` for FIFO polling)."""
+        method for the full filter / sort docs."""
         params: dict[str, str] = {"status": status, "page_size": str(page_size)}
         if sort:
             params["sort"] = sort
+        if from_:
+            params["from"] = from_
+        if subject_contains:
+            params["subject_contains"] = subject_contains
+        if conversation_id:
+            params["conversation_id"] = conversation_id
+        if since:
+            params["since"] = since
+        if until:
+            params["until"] = until
         if token:
             params["token"] = token
         resp = await self._client.get(
@@ -396,14 +410,34 @@ class AsyncE2AClient:
         token: Optional[str] = None,
         agent_email: Optional[str] = None,
         sort: Optional[str] = None,
+        from_: Optional[str] = None,
+        subject_contains: Optional[str] = None,
+        conversation_id: Optional[str] = None,
+        since: Optional[str] = None,
+        until: Optional[str] = None,
     ) -> MessageList:
         """Fetch message summaries with ergonomic field names.
 
         ``sort`` defaults server-side to ``"desc"`` (newest first). Pass
         ``"asc"`` to drain the inbox in arrival order — FIFO polling.
+
+        Search filters (``from_``, ``subject_contains``, ``conversation_id``,
+        ``since``, ``until``) match the sync client — see
+        :meth:`E2AApi.list_messages` for the full reference.
         """
         email = self._require_agent_email(agent_email)
-        resp = await self.api.list_messages(email, status=status, page_size=page_size, token=token, sort=sort)
+        resp = await self.api.list_messages(
+            email,
+            status=status,
+            page_size=page_size,
+            token=token,
+            sort=sort,
+            from_=from_,
+            subject_contains=subject_contains,
+            conversation_id=conversation_id,
+            since=since,
+            until=until,
+        )
         messages = [
             MessageSummary(
                 message_id=m.message_id or "",

--- a/sdks/python/src/e2a/v1/client.py
+++ b/sdks/python/src/e2a/v1/client.py
@@ -186,14 +186,35 @@ class E2AClient:
         token: Optional[str] = None,
         agent_email: Optional[str] = None,
         sort: Optional[str] = None,
+        from_: Optional[str] = None,
+        subject_contains: Optional[str] = None,
+        conversation_id: Optional[str] = None,
+        since: Optional[str] = None,
+        until: Optional[str] = None,
     ) -> MessageList:
         """Fetch message summaries with ergonomic field names.
 
         ``sort`` defaults server-side to ``"desc"`` (newest first). Pass
         ``"asc"`` to drain the inbox in arrival order — FIFO polling.
+
+        ``from_`` / ``subject_contains`` are case-insensitive substring
+        filters (capped at 200 chars server-side). ``conversation_id``
+        exact-matches a thread. ``since`` / ``until`` are RFC3339
+        timestamps bounding ``created_at``.
         """
         email = self._require_agent_email(agent_email)
-        resp = self.api.list_messages(email, status=status, page_size=page_size, token=token, sort=sort)
+        resp = self.api.list_messages(
+            email,
+            status=status,
+            page_size=page_size,
+            token=token,
+            sort=sort,
+            from_=from_,
+            subject_contains=subject_contains,
+            conversation_id=conversation_id,
+            since=since,
+            until=until,
+        )
         messages = [
             MessageSummary(
                 message_id=m.message_id or "",

--- a/sdks/typescript/src/v1/api.ts
+++ b/sdks/typescript/src/v1/api.ts
@@ -148,12 +148,30 @@ export class E2AApi {
        * oldest unread message first, drain in arrival order.
        */
       sort?: "asc" | "desc";
+      /**
+       * Server-side search filters. All optional; substring filters
+       * are case-insensitive (Postgres ILIKE) and capped at 200 chars
+       * by the server. `since` / `until` accept RFC3339 timestamps
+       * (`new Date().toISOString()` works). Filters are encoded into
+       * `next_token`, so continuation requests must reuse the same
+       * filter values or restart the query.
+       */
+      from?: string;
+      subjectContains?: string;
+      conversationId?: string;
+      since?: string;
+      until?: string;
     },
   ): Promise<Schemas["ListMessagesResponse"]> {
     const params = new URLSearchParams();
     if (opts?.status) params.set("status", opts.status);
     if (opts?.pageSize) params.set("page_size", String(opts.pageSize));
     if (opts?.sort) params.set("sort", opts.sort);
+    if (opts?.from) params.set("from", opts.from);
+    if (opts?.subjectContains) params.set("subject_contains", opts.subjectContains);
+    if (opts?.conversationId) params.set("conversation_id", opts.conversationId);
+    if (opts?.since) params.set("since", opts.since);
+    if (opts?.until) params.set("until", opts.until);
     if (opts?.token) params.set("token", opts.token);
     const qs = params.toString();
     const path = `/api/v1/agents/${encodeURIComponent(email)}/messages${qs ? `?${qs}` : ""}`;

--- a/sdks/typescript/src/v1/client.ts
+++ b/sdks/typescript/src/v1/client.ts
@@ -178,12 +178,27 @@ export class E2AClient {
      * pages keep the same order; switching mid-pagination returns 400.
      */
     sort?: "asc" | "desc";
+    /** Case-insensitive substring on sender. Capped at 200 chars. */
+    from?: string;
+    /** Case-insensitive substring on subject. Capped at 200 chars. */
+    subjectContains?: string;
+    /** Exact-match thread id. */
+    conversationId?: string;
+    /** RFC3339 timestamp; messages with created_at >= since. */
+    since?: string;
+    /** RFC3339 timestamp; messages with created_at < until. */
+    until?: string;
   }) {
     return this.api.listMessages(this.requireEmail(opts?.agentEmail), {
       status: opts?.status,
       pageSize: opts?.pageSize,
       token: opts?.token,
       sort: opts?.sort,
+      from: opts?.from,
+      subjectContains: opts?.subjectContains,
+      conversationId: opts?.conversationId,
+      since: opts?.since,
+      until: opts?.until,
     });
   }
 

--- a/sdks/typescript/src/v1/generated/types.ts
+++ b/sdks/typescript/src/v1/generated/types.ts
@@ -316,7 +316,7 @@ export interface paths {
         };
         /**
          * List messages for an agent
-         * @description Fetch messages for an agent. Returns lightweight summaries (no raw message content). Supports opaque token-based pagination via `page_size` and `token`. **Default sort is newest-first** across all directions — pass `?sort=asc` to flip to oldest-first when you need FIFO polling semantics (drain the inbox in arrival order). `direction` defaults to `inbound` for SDK back-compat.
+         * @description Fetch messages for an agent. Returns lightweight summaries (no raw message content). Supports opaque token-based pagination via `page_size` and `token`. **Default sort is newest-first** across all directions — pass `?sort=asc` to flip to oldest-first when you need FIFO polling semantics (drain the inbox in arrival order). `direction` defaults to `inbound` for SDK back-compat. **Search filters** (`from`, `subject_contains`, `conversation_id`, `since`, `until`) narrow the result set server-side; substring filters are case-insensitive (Postgres ILIKE). Filter values are encoded into `next_token`, so continuation requests must keep the same filters or restart the query.
          */
         get: {
             parameters: {
@@ -329,6 +329,16 @@ export interface paths {
                     page_size?: number;
                     /** @description Sort order by created_at. Default `desc` (newest first); pass `asc` for FIFO polling. */
                     sort?: "asc" | "desc";
+                    /** @description Case-insensitive substring match on the sender column. Max 200 chars. */
+                    from?: string;
+                    /** @description Case-insensitive substring match on the subject column. Max 200 chars. */
+                    subject_contains?: string;
+                    /** @description Exact match on conversation_id — narrow to a single thread. */
+                    conversation_id?: string;
+                    /** @description RFC3339 timestamp; only messages with created_at >= since are returned. */
+                    since?: string;
+                    /** @description RFC3339 timestamp; only messages with created_at < until are returned. */
+                    until?: string;
                     /** @description Opaque pagination token from a previous response's next_token */
                     token?: string;
                 };

--- a/web/public/openapi.yaml
+++ b/web/public/openapi.yaml
@@ -1275,6 +1275,10 @@ paths:
         and `token`. **Default sort is newest-first** across all directions — pass
         `?sort=asc` to flip to oldest-first when you need FIFO polling semantics (drain
         the inbox in arrival order). `direction` defaults to `inbound` for SDK back-compat.
+        **Search filters** (`from`, `subject_contains`, `conversation_id`, `since`,
+        `until`) narrow the result set server-side; substring filters are case-insensitive
+        (Postgres ILIKE). Filter values are encoded into `next_token`, so continuation
+        requests must keep the same filters or restart the query.
       parameters:
       - description: Agent email address
         example: my-bot@example.com
@@ -1316,6 +1320,30 @@ paths:
         - desc
         in: query
         name: sort
+        type: string
+      - description: Case-insensitive substring match on the sender column. Max 200
+          chars.
+        in: query
+        name: from
+        type: string
+      - description: Case-insensitive substring match on the subject column. Max 200
+          chars.
+        in: query
+        name: subject_contains
+        type: string
+      - description: Exact match on conversation_id — narrow to a single thread.
+        in: query
+        name: conversation_id
+        type: string
+      - description: RFC3339 timestamp; only messages with created_at >= since are
+          returned.
+        in: query
+        name: since
+        type: string
+      - description: RFC3339 timestamp; only messages with created_at < until are
+          returned.
+        in: query
+        name: until
         type: string
       - description: Opaque pagination token from a previous response's next_token
         in: query


### PR DESCRIPTION
> Replaces #151, which auto-closed when its base branch (#149) was deleted on merge. Rebased onto current `main` (which now includes #149's `?sort=asc|desc` param).

## Summary
Server-side search filters on `GET /messages` so callers can find "mail from Alice this week" without paginating the full inbox client-side.

## New query params
| Param | Match | Notes |
|---|---|---|
| `from` | ILIKE substring on `sender` | case-insensitive, cap 200 chars, **`%` and `_` escaped** |
| `subject_contains` | ILIKE substring on `subject` | cap 200 chars, **`%` and `_` escaped** |
| `conversation_id` | exact match on thread id | — |
| `since` | `created_at >= since` | RFC3339, inclusive |
| `until` | `created_at <  until` | RFC3339, exclusive |

Filter values are encoded into `next_token` so continuation requests walk the same result set the cursor anchors against. Switching any filter mid-pagination 400s.

## Code shape
`GetMessagesByAgent` swapped from 7 positional args to a `MessageListFilter` struct.

## Client propagation
| Surface | Shape |
|---|---|
| TS SDK | `from`, `subjectContains`, `conversationId`, `since`, `until` opts on `listMessages` |
| Python SDK | same; `from_` to dodge the Python keyword |
| MCP | five zod fields + per-field describe() prose |
| CLI | `--from`, `--subject`, `--conversation`, `--since`, `--until` |
| OpenAPI | regenerated; TS types follow |

## Test plan
- [x] `TestGetMessages_FromFilter`, `TestGetMessages_SubjectContains`, `TestGetMessages_SinceUntil`, `TestGetMessages_ConversationIDFilter`, `TestGetMessages_InvalidFiltersRejected`, `TestGetMessages_FilterMismatchOnTokenReplay` — full filter coverage.
- [x] `TestGetMessages_FilterEscapesLikeWildcards` — proves `?from=foo_bar` doesn't also match `fooXbar`, and `?subject_contains=10%discount` doesn't collapse to a wildcard match.
- [x] All existing `TestGetMessages_*` still green.
- [x] TS / CLI / MCP unit suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)