### PR TITLE
fix(python-sdk): pass required agent_mode in slug-registration tests

### DIFF
--- a/sdks/python/tests/test_v1_api.py
+++ b/sdks/python/tests/test_v1_api.py
@@ -158,13 +158,13 @@ def test_register_agent(httpx_mock):
     )
 
     with E2AApi(api_key="k") as api:
-        result = api.register_agent(RegisterAgentRequest(slug="new"))
+        result = api.register_agent(RegisterAgentRequest(slug="new", agent_mode="local"))
 
     assert isinstance(result, RegisterAgentResponse)
     assert result.email == "new@agents.e2a.dev"
 
     body = json.loads(httpx_mock.get_request().content)
-    assert body == {"slug": "new"}
+    assert body == {"slug": "new", "agent_mode": "local"}
 
 
 def test_get_agent(httpx_mock):

--- a/sdks/python/tests/test_v1_async_client.py
+++ b/sdks/python/tests/test_v1_async_client.py
@@ -294,10 +294,10 @@ async def test_register_agent_slug(httpx_mock):
     )
 
     async with AsyncE2AClient(api_key="k") as client:
-        await client.register_agent("new")
+        await client.register_agent("new", agent_mode="local")
 
     body = json.loads(httpx_mock.get_request().content)
-    assert body == {"slug": "new"}
+    assert body == {"slug": "new", "agent_mode": "local"}
 
 
 @pytest.mark.anyio

--- a/sdks/python/tests/test_v1_client.py
+++ b/sdks/python/tests/test_v1_client.py
@@ -442,10 +442,10 @@ def test_register_agent_slug_only(httpx_mock):
     )
 
     with E2AClient(api_key="k") as client:
-        result = client.register_agent("new")
+        result = client.register_agent("new", agent_mode="local")
 
     body = json.loads(httpx_mock.get_request().content)
-    assert body == {"slug": "new"}
+    assert body == {"slug": "new", "agent_mode": "local"}
 
 
 def test_register_agent_custom_domain(httpx_mock):


### PR DESCRIPTION
## Summary

PR #152 made `agent_mode` a required field on `RegisterAgentRequest`, but four slug-only registration tests in the Python SDK still relied on the old implicit default. Those tests have been failing on `main` since #152 merged — see [the failing job](https://github.com/Mnexa-AI/e2a/actions/runs/26424739609/job/77786000877).

Fixed by passing `agent_mode="local"` in the four affected tests (the analogous TS SDK tests in `client.test.ts` / `api.test.ts` already do this).

Tests updated:
- `tests/test_v1_api.py::test_register_agent`
- `tests/test_v1_async_client.py::test_register_agent_slug` (asyncio + trio)
- `tests/test_v1_client.py::test_register_agent_slug_only`

## Test plan

- [x] `pytest tests/test_v1_api.py::test_register_agent tests/test_v1_async_client.py::test_register_agent_slug tests/test_v1_client.py::test_register_agent_slug_only -v` → 4 passed
- [ ] CI: Python SDK tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)