### PR TITLE
chore(ratelimit): bump agent-registration cap from 20 to 200/hr per IP

### DIFF
--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -219,7 +219,7 @@ func NewAPI(store *identity.Store, sender *outbound.Sender, smtpRelay *outbound.
 		publicURL:     publicURL,
 		production:    production,
 		sendLimit:     ratelimit.New(1*time.Minute, 60), // 60 sends per agent per minute
-		regLimit:      ratelimit.New(1*time.Hour, 20),   // 20 registrations per IP per hour
+		regLimit:      ratelimit.New(1*time.Hour, 200),  // 200 registrations per IP per hour
 		pollLimit:     ratelimit.New(1*time.Minute, 60), // 60 poll requests per user per minute
 		feedbackLimit: ratelimit.New(1*time.Hour, 10),   // 10 feedback submissions per IP per hour
 		dcrLimit:      ratelimit.New(1*time.Hour, 10),   // 10 OAuth client registrations per IP per hour
@@ -510,7 +510,7 @@ type RegisterAgentResponse struct {
 
 // handleRegisterAgent creates a new agent.
 // @Summary      Register a new agent
-// @Description  Register a new agent with a custom domain or, on deployments where slug registration is enabled, a slug on the shared domain. Use `slug` for instant onboarding (no DNS needed), or `email` for a custom domain (requires domain to be registered and verified first). `agent_mode` is required and must be "local" (inbound delivered via WebSocket / pollable REST) or "cloud" (inbound POSTed to `webhook_url`). Rate limited to 20 registrations per source IP per hour; 429 responses carry a `Retry-After` header in delay-seconds form.
+// @Description  Register a new agent with a custom domain or, on deployments where slug registration is enabled, a slug on the shared domain. Use `slug` for instant onboarding (no DNS needed), or `email` for a custom domain (requires domain to be registered and verified first). `agent_mode` is required and must be "local" (inbound delivered via WebSocket / pollable REST) or "cloud" (inbound POSTed to `webhook_url`). Rate limited to 200 registrations per source IP per hour; 429 responses carry a `Retry-After` header in delay-seconds form.
 // @Tags         Agents
 // @Accept       json
 // @Produce      json
@@ -524,7 +524,7 @@ type RegisterAgentResponse struct {
 // @Router       /api/v1/agents [post]
 func (a *API) handleRegisterAgent(w http.ResponseWriter, r *http.Request) {
 	if ok, retryAfter := a.regLimit.AllowWithRetryAfter(clientIP(r)); !ok {
-		writeTooManyRequests(w, retryAfter, "rate limit exceeded — max 20 agent registrations per hour per IP")
+		writeTooManyRequests(w, retryAfter, "rate limit exceeded — max 200 agent registrations per hour per IP")
 		return
 	}
 

--- a/sdks/typescript/src/v1/generated/types.ts
+++ b/sdks/typescript/src/v1/generated/types.ts
@@ -47,7 +47,7 @@ export interface paths {
         put?: never;
         /**
          * Register a new agent
-         * @description Register a new agent with a custom domain or, on deployments where slug registration is enabled, a slug on the shared domain. Use `slug` for instant onboarding (no DNS needed), or `email` for a custom domain (requires domain to be registered and verified first). `agent_mode` is required and must be "local" (inbound delivered via WebSocket / pollable REST) or "cloud" (inbound POSTed to `webhook_url`). Rate limited to 20 registrations per source IP per hour; 429 responses carry a `Retry-After` header in delay-seconds form.
+         * @description Register a new agent with a custom domain or, on deployments where slug registration is enabled, a slug on the shared domain. Use `slug` for instant onboarding (no DNS needed), or `email` for a custom domain (requires domain to be registered and verified first). `agent_mode` is required and must be "local" (inbound delivered via WebSocket / pollable REST) or "cloud" (inbound POSTed to `webhook_url`). Rate limited to 200 registrations per source IP per hour; 429 responses carry a `Retry-After` header in delay-seconds form.
          */
         post: {
             parameters: {

--- a/web/public/openapi.yaml
+++ b/web/public/openapi.yaml
@@ -1131,7 +1131,7 @@ paths:
         instant onboarding (no DNS needed), or `email` for a custom domain (requires
         domain to be registered and verified first). `agent_mode` is required and
         must be "local" (inbound delivered via WebSocket / pollable REST) or "cloud"
-        (inbound POSTed to `webhook_url`). Rate limited to 20 registrations per source
+        (inbound POSTed to `webhook_url`). Rate limited to 200 registrations per source
         IP per hour; 429 responses carry a `Retry-After` header in delay-seconds form.
       parameters:
       - description: Agent registration details


### PR DESCRIPTION
## Summary

- Bumps the per-IP `POST /api/v1/agents` rate-limit cap from 20/hr to 200/hr.
- The 20/hr default was too tight for development environments where multiple test harnesses or CI runners share an egress IP — the Loft e2e harness mints 3 agents per run, which capped a single egress IP at ~6 runs/hr.
- 200/hr leaves headroom for ~60 e2e runs/hour and remains abuse-protective: a real attacker would saturate any per-IP cap in seconds anyway, so the actual abuse defense is identity-based throttling (already in place via the user-scoped limits).

## Touch list

- [internal/agent/api.go:222](https://github.com/Mnexa-AI/e2a/blob/chore/bump-reg-rate-limit/internal/agent/api.go#L222) — `regLimit` cap `20 → 200`
- [internal/agent/api.go:527](https://github.com/Mnexa-AI/e2a/blob/chore/bump-reg-rate-limit/internal/agent/api.go#L527) — 429 error string `20 → 200`
- [internal/agent/api.go:513](https://github.com/Mnexa-AI/e2a/blob/chore/bump-reg-rate-limit/internal/agent/api.go#L513) — swag `@Description` updated, which regenerated through:
  - `web/public/openapi.yaml` — single-line description change
  - `sdks/typescript/src/v1/generated/types.ts` — single-line description change

3 files, +5/-5. No tests pinned the 20 value, so none needed updating.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/agent/...` — full suite including DB-backed integration, all PASS
- [x] `make swagger-check` — spec regen is stable
- [ ] After deploy: `curl https://e2a.dev/api/v1/info` returns 200
- [ ] After deploy (optional): fire 25 `POST /api/v1/agents` from one IP within an hour, expect no 429s
- [ ] After deploy: a Loft e2e run from a single egress IP completes without hitting the cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)