### PR TITLE
release: SDKs 2.4.0, CLI 1.5.0, MCP 0.4.0

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/cli",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "CLI for e2a — email for AI agents",
   "bin": {
     "e2a": "./dist/bin/e2a.js"
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/Mnexa-AI/e2a/tree/main/cli",
   "bugs": "https://github.com/Mnexa-AI/e2a/issues",
   "dependencies": {
-    "@e2a/sdk": "^2.3.0"
+    "@e2a/sdk": "^2.4.0"
   },
   "devDependencies": {
     "@types/node": "^25.9.1",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/mcp-server",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "description": "MCP server for e2a — email for AI agents",
   "mcpName": "io.github.Mnexa-AI/mcp-server",
   "bin": {
@@ -43,7 +43,7 @@
   "homepage": "https://github.com/Mnexa-AI/e2a/tree/main/mcp",
   "bugs": "https://github.com/Mnexa-AI/e2a/issues",
   "dependencies": {
-    "@e2a/sdk": "^2.3.0",
+    "@e2a/sdk": "^2.4.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.5",
     "express": "^5.0.0",

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -9,13 +9,13 @@
     "source": "github",
     "subfolder": "mcp"
   },
-  "version": "0.3.4",
+  "version": "0.4.0",
   "packages": [
     {
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@e2a/mcp-server",
-      "version": "0.3.4",
+      "version": "0.4.0",
       "transport": {
         "type": "stdio"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,10 @@
     },
     "cli": {
       "name": "@e2a/cli",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@e2a/sdk": "^2.3.0"
+        "@e2a/sdk": "^2.4.0"
       },
       "bin": {
         "e2a": "dist/bin/e2a.js"
@@ -32,10 +32,10 @@
     },
     "mcp": {
       "name": "@e2a/mcp-server",
-      "version": "0.3.4",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@e2a/sdk": "^2.3.0",
+        "@e2a/sdk": "^2.4.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "cors": "^2.8.5",
         "express": "^5.0.0",
@@ -3209,7 +3209,7 @@
     },
     "sdks/typescript": {
       "name": "@e2a/sdk",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "mailparser": "^3.9.8",

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+## 2.4.0
+
+### Added
+- `idempotency_key` parameter on `E2AClient.approve_message()` and its
+  async counterpart (and on the lower-level `E2AApi.approve_message()`).
+  Approve fires a real SES send, so without a stable key a retry after
+  a transient failure could double-send. When supplied it's threaded
+  through as the `Idempotency-Key` header; when omitted the SDK mints
+  a fresh UUIDv4 per call — that gives network-layer retry safety only.
+  Supply a stable key derived from the review event (typically the
+  pending `message_id`) to dedupe across an explicit retry loop.
+- `sort`, `from_`, `subject_contains`, `conversation_id`, `since`,
+  `until` kwargs on `E2AApi.list_messages()` and the high-level
+  `E2AClient.get_messages()` (sync + async). `sort` defaults
+  server-side to newest-first; pass `"asc"` for FIFO polling. The
+  substring filters are case-insensitive and capped at 200 chars
+  server-side. `since` / `until` accept RFC3339 timestamps and
+  bracket `created_at`. Filter values are encoded into `next_token`,
+  so continuation requests must keep the same filter values.
+
+### Changed
+- **Default sort flipped to newest-first** on `GET /messages`. Prior
+  releases silently returned oldest-first for `direction=inbound` (the
+  SDK default) and newest-first for `direction=all`. A polling agent
+  that relied on FIFO drain order should now pass `sort="asc"` to
+  preserve the old behavior.
+- `agent_mode` is now a required field on `RegisterAgentRequest`. The
+  server previously silently defaulted to `"cloud"` and then 400'd
+  with a cryptic "webhook_url is required" message; it now explicitly
+  rejects requests missing `agent_mode` with a clear error. Pydantic
+  v2 will raise a validation error if you instantiate the request
+  without it. Set `agent_mode="local"` or `"cloud"` explicitly.
+
 ## 2.3.0
 
 ### Added

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "e2a"
-version = "2.3.0"
+version = "2.4.0"
 description = "Python SDK for the e2a protocol — email-to-agent authentication"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/sdk",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "TypeScript SDK for e2a — email for AI agents",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

Bundle release picking up everything since the 2.3.0 cut on 2026-05-25:

- **#147** RFC 2047 subject decode at relay parse
- **#148** `idempotencyGuard` on approve endpoint
- **#149** newest-first default sort + `?sort=asc|desc` (default flip)
- **#152** prod e2e audit findings (Retry-After headers, `agent_mode` required, error-shape consistency, case-insensitive email lookup, …)
- **#153** `idempotency_key` exposed on approve across SDKs/MCP/CLI
- **#154** `list_messages` search filters (`from` / `subject_contains` / `conversation_id` / `since` / `until`)
- **#155** Python SDK test fixup for required `agent_mode`
- **#156** registration rate limit bumped 20 → 200/hr per IP

## Versions

| Package | From | To | Headline change |
|---|---|---|---|
| Python SDK | 2.3.0 | 2.4.0 | filters + sort + idempotency-on-approve; required `agent_mode` |
| TypeScript SDK | 2.3.0 | 2.4.0 | same surface; required `agent_mode` is TS-compile breaking for callers omitting it |
| MCP server | 0.3.4 | 0.4.0 | same surface via tool args; required `agent_mode` on `create_agent` |
| CLI | 1.4.0 | 1.5.0 | new flags on `inbox` / `send` / `reply` / `pending approve` |

## Breaking-change notes (filed in CHANGELOG)
- **Default sort flipped to newest-first** on `GET /messages`. Polling agents that drained the inbox FIFO must pass `sort="asc"` after upgrading. Server-side, pre-upgrade pagination tokens are honored under their original sort to avoid mid-pagination breakage across deploys.
- **`agent_mode` is now required** on agent registration. Old code that omitted it relied on the (broken) server default to "cloud"; new server returns 400 with a clear error. TS SDK types it as required.

## Test plan
- [x] `npm run build` for `@e2a/sdk`, `@e2a/cli`, `@e2a/mcp-server` — green.
- [x] `npm test` — SDK 85 / CLI 100 / MCP 88 tests pass.
- [ ] CI on this PR (Python SDK tests, contract tests, Go tests, generated-code freshness).
- [ ] Tags pushed after merge → each `publish-*.yml` validates and publishes; CLI via workflow_dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)