### PR TITLE
feat(limits): generic per-user resource limits + dashboard surface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test:
 	E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable" go test -tags integration -p 1 ./...
 
 test-unit:
-	go test ./internal/headers/ ./internal/outbound/ ./internal/relay/ ./internal/config/ ./internal/webhook/ ./internal/approvaltoken/
+	go test ./internal/headers/ ./internal/outbound/ ./internal/relay/ ./internal/config/ ./internal/webhook/ ./internal/approvaltoken/ ./internal/limits/
 
 test-integration:
 	E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable" go test -p 1 ./internal/identity/ ./internal/agent/ ./internal/hitlworker/ ./internal/hitlnotify/

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ test:
 	E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable" go test -tags integration -p 1 ./...
 
 test-unit:
-	go test ./internal/headers/ ./internal/outbound/ ./internal/relay/ ./internal/config/ ./internal/webhook/ ./internal/approvaltoken/ ./internal/limits/
+	go test -short ./internal/headers/ ./internal/outbound/ ./internal/relay/ ./internal/config/ ./internal/webhook/ ./internal/approvaltoken/ ./internal/limits/
 
 test-integration:
 	E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable" go test -p 1 ./internal/identity/ ./internal/agent/ ./internal/hitlworker/ ./internal/hitlnotify/ ./internal/limits/

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test-unit:
 	go test ./internal/headers/ ./internal/outbound/ ./internal/relay/ ./internal/config/ ./internal/webhook/ ./internal/approvaltoken/ ./internal/limits/
 
 test-integration:
-	E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable" go test -p 1 ./internal/identity/ ./internal/agent/ ./internal/hitlworker/ ./internal/hitlnotify/
+	E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable" go test -p 1 ./internal/identity/ ./internal/agent/ ./internal/hitlworker/ ./internal/hitlnotify/ ./internal/limits/
 
 test-e2e:
 	E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable" go test -tags integration -p 1 ./internal/e2e/

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test-unit:
 	go test -short ./internal/headers/ ./internal/outbound/ ./internal/relay/ ./internal/config/ ./internal/webhook/ ./internal/approvaltoken/ ./internal/limits/
 
 test-integration:
-	E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable" go test -p 1 ./internal/identity/ ./internal/agent/ ./internal/hitlworker/ ./internal/hitlnotify/ ./internal/limits/
+	E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable" go test -p 1 ./internal/identity/ ./internal/agent/ ./internal/hitlworker/ ./internal/hitlnotify/ ./internal/limits/ ./internal/relay/
 
 test-e2e:
 	E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable" go test -tags integration -p 1 ./internal/e2e/

--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -225,6 +225,8 @@ func main() {
 		time.Duration(cfg.Limits.CacheTTLSeconds)*time.Second,
 	)
 	api.SetEnforcer(enforcer)
+	api.SetUsageStore(usageStore)
+	api.SetInternalAPISecret(cfg.Limits.InternalAPISecret)
 
 	api.RegisterRoutes(router)
 

--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/hitlworker"
 	"github.com/Mnexa-AI/e2a/internal/idempotency"
 	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/limits"
 	"github.com/Mnexa-AI/e2a/internal/oauth"
 	"github.com/Mnexa-AI/e2a/internal/outbound"
 	"github.com/Mnexa-AI/e2a/internal/relay"
@@ -201,6 +202,30 @@ func main() {
 	idempotencyStore := idempotency.NewStore(pool)
 	api.SetIdempotencyStore(idempotencyStore)
 
+	// Resource-limits enforcer. The OSS server is plan-agnostic: it
+	// reads the per-user caps from account_limits and enforces them at
+	// agent-create / domain-register / message-send / inbound RCPT TO.
+	// What "Free" or "Pro" mean (and how Stripe plumbs those into
+	// account_limits) is the responsibility of an external provisioner
+	// (hosted billing sidecar, admin tooling). Self-hosters who don't
+	// run a provisioner get the generous config defaults applied to
+	// every user — effectively unlimited unless they tighten the
+	// `limits:` config block.
+	usageStore := usage.NewStore(pool)
+	enforcer := limits.NewEnforcer(
+		limits.NewStore(pool),
+		usageStore,
+		limits.Defaults{
+			PlanCode:         cfg.Limits.PlanCode,
+			MaxAgents:        cfg.Limits.MaxAgents,
+			MaxDomains:       cfg.Limits.MaxDomains,
+			MaxMessagesMonth: cfg.Limits.MaxMessagesMonth,
+			MaxStorageBytes:  cfg.Limits.MaxStorageBytes,
+		},
+		time.Duration(cfg.Limits.CacheTTLSeconds)*time.Second,
+	)
+	api.SetEnforcer(enforcer)
+
 	api.RegisterRoutes(router)
 
 	// WebSocket route for local-mode agents
@@ -216,6 +241,7 @@ func main() {
 
 	// SMTP Relay
 	smtpServer := relay.NewServer(cfg, store, signer, persistentDeliverer, usageTracker, wsHub)
+	smtpServer.SetEnforcer(enforcer)
 
 	// Graceful shutdown
 	sigCh := make(chan os.Signal, 1)

--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -227,6 +227,7 @@ func main() {
 	api.SetEnforcer(enforcer)
 	api.SetUsageStore(usageStore)
 	api.SetInternalAPISecret(cfg.Limits.InternalAPISecret)
+	api.SetBillingHookURL(cfg.Limits.BillingHookURL)
 
 	api.RegisterRoutes(router)
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -69,4 +69,10 @@ limits:
   max_messages_month: 1000000000
   max_storage_bytes: 1125899906842624  # 1 PiB — effectively unbounded
   cache_ttl_seconds: 60
+  # Shared HMAC secret used to authenticate /api/internal/limits/invalidate.
+  # Set this on both the e2a server and the external limits provisioner
+  # (e.g. a hosted-service billing sidecar). Leave empty for self-host
+  # without a provisioner — the endpoint will 503. Generate with:
+  # openssl rand -hex 32. Override with E2A_INTERNAL_API_SECRET.
+  internal_api_secret: ""
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -75,4 +75,11 @@ limits:
   # without a provisioner — the endpoint will 503. Generate with:
   # openssl rand -hex 32. Override with E2A_INTERNAL_API_SECRET.
   internal_api_secret: ""
+  # URL the OSS server POSTs (HMAC-signed) when a user deletes their
+  # account, so an external billing service can cancel their
+  # subscription before the cascade drops the user row. Empty
+  # disables the call (self-host without billing). Example for a
+  # docker compose deployment alongside the hosted billing sidecar:
+  # billing_hook_url: "http://billing:9000/api/internal/billing/cancel"
+  billing_hook_url: ""
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -52,3 +52,21 @@ outbound_smtp:
   password: ""
   from_domain: "relay.example.com"
 
+# Per-user resource caps applied when a user has no row in the
+# account_limits table. Hosted-service deployments overwrite these per
+# user via an external provisioner (the e2a-billing sidecar, an admin
+# tool, manual SQL). Self-host operators who do not run any provisioner
+# rely solely on these defaults — values below are intentionally high so
+# the limits subsystem is effectively off until you opt in.
+#
+# To convert a self-host into a paywall-aware install, set these to your
+# "free" shape and write the upgraded caps into account_limits from
+# whatever billing system you run.
+limits:
+  plan_code: "default"
+  max_agents: 1000000
+  max_domains: 1000000
+  max_messages_month: 1000000000
+  max_storage_bytes: 1125899906842624  # 1 PiB — effectively unbounded
+  cache_ttl_seconds: 60
+

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -173,6 +173,8 @@ type API struct {
 	oauthStorage   *oauth.Storage         // optional; consent handler needs Pool() for cross-package tx
 	idempotency    *idempotency.Store     // optional; when nil, Idempotency-Key header is ignored
 	enforcer       limits.Enforcer        // optional; when nil, all limit checks are skipped (effectively unlimited)
+	usageStore     *usage.Store           // optional; needed by handleGetMyLimits to surface current counts
+	internalAPISecret string              // optional; when empty, /api/internal/* endpoints return 503
 }
 
 // SetApprovalSigner wires in the magic-link signer after construction so
@@ -213,6 +215,19 @@ func (a *API) SetIdempotencyStore(s *idempotency.Store) { a.idempotency = s }
 // unlimited capacity. The cmd/e2a runtime always sets it; tests that
 // don't care about limits omit it and continue to work as before.
 func (a *API) SetEnforcer(e limits.Enforcer) { a.enforcer = e }
+
+// SetUsageStore wires in the usage store used by handleGetMyLimits to
+// surface the user's current counts (agents, domains, messages this
+// month, storage bytes) alongside the resolved caps. Separate from the
+// usage.UsageTracker (which is for recording events) so the dashboard
+// read path can stay alive even when usage-tracking is otherwise off.
+func (a *API) SetUsageStore(s *usage.Store) { a.usageStore = s }
+
+// SetInternalAPISecret wires in the shared HMAC secret used to
+// authenticate the /api/internal/limits/invalidate endpoint. When
+// empty (default), that endpoint returns 503 — self-host operators
+// who don't run a billing provisioner never need to configure it.
+func (a *API) SetInternalAPISecret(s string) { a.internalAPISecret = s }
 
 func NewAPI(store *identity.Store, sender *outbound.Sender, smtpRelay *outbound.SMTPRelay, userAuth *auth.UserAuth, usage usage.UsageTracker, smtpDomain, fromDomain, sharedDomain, publicURL string, production bool) *API {
 	return &API{
@@ -270,6 +285,19 @@ func (a *API) RegisterRoutes(r *mux.Router) {
 	// no way to target someone else's data.
 	r.HandleFunc("/api/v1/users/me/export", a.handleExportUserData).Methods("GET")
 	r.HandleFunc("/api/v1/users/me", a.handleDeleteUserData).Methods("DELETE")
+
+	// Internal machine-to-machine endpoint: the external limits
+	// provisioner (hosted billing sidecar) calls this to bust the
+	// in-process limits cache for a given user immediately after it
+	// writes account_limits. Authenticated by shared HMAC over the
+	// request body; deliberately not advertised in OpenAPI.
+	r.HandleFunc("/api/internal/limits/invalidate", a.handleInvalidateLimits).Methods("POST")
+
+	// Current user's resource limits + month-to-date usage. Dashboard
+	// reads this on every page load to render the "you've used X of Y"
+	// surface and an upgrade affordance when an external provisioner
+	// has populated an upgrade_url.
+	r.HandleFunc("/api/v1/users/me/limits", a.handleGetMyLimits).Methods("GET")
 
 	// Per-user webhook signing secrets — multi-secret rotation, fully
 	// user-managed (create + delete; no auto-rotation, no TTL).

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -175,6 +175,7 @@ type API struct {
 	enforcer       limits.Enforcer        // optional; when nil, all limit checks are skipped (effectively unlimited)
 	usageStore     *usage.Store           // optional; needed by handleGetMyLimits to surface current counts
 	internalAPISecret string              // optional; when empty, /api/internal/* endpoints return 503
+	billingHookURL string                 // optional; when set, handleDeleteUserData POSTs an HMAC-signed user-deleted notice here (sidecar's /api/internal/billing/cancel)
 }
 
 // SetApprovalSigner wires in the magic-link signer after construction so
@@ -228,6 +229,15 @@ func (a *API) SetUsageStore(s *usage.Store) { a.usageStore = s }
 // empty (default), that endpoint returns 503 — self-host operators
 // who don't run a billing provisioner never need to configure it.
 func (a *API) SetInternalAPISecret(s string) { a.internalAPISecret = s }
+
+// SetBillingHookURL wires in the URL of an external billing service's
+// user-event endpoint. When the user deletes their account, the API
+// HMAC-signs a JSON payload and POSTs it there so the billing service
+// can cancel the corresponding Stripe subscription. When empty (the
+// self-host default), no hook fires — appropriate for deployments
+// without a billing service. The same internal_api_secret is reused
+// for the signature.
+func (a *API) SetBillingHookURL(s string) { a.billingHookURL = s }
 
 func NewAPI(store *identity.Store, sender *outbound.Sender, smtpRelay *outbound.SMTPRelay, userAuth *auth.UserAuth, usage usage.UsageTracker, smtpDomain, fromDomain, sharedDomain, publicURL string, production bool) *API {
 	return &API{

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/hitlnotify"
 	"github.com/Mnexa-AI/e2a/internal/idempotency"
 	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/limits"
 	"github.com/Mnexa-AI/e2a/internal/oauth"
 	"github.com/Mnexa-AI/e2a/internal/outbound"
 	"github.com/Mnexa-AI/e2a/internal/ratelimit"
@@ -171,6 +172,7 @@ type API struct {
 	oauthProvider  fosite.OAuth2Provider  // optional; if nil, /api/oauth/* endpoints return 404
 	oauthStorage   *oauth.Storage         // optional; consent handler needs Pool() for cross-package tx
 	idempotency    *idempotency.Store     // optional; when nil, Idempotency-Key header is ignored
+	enforcer       limits.Enforcer        // optional; when nil, all limit checks are skipped (effectively unlimited)
 }
 
 // SetApprovalSigner wires in the magic-link signer after construction so
@@ -205,6 +207,12 @@ func (a *API) SetOAuthStorage(s *oauth.Storage) { a.oauthStorage = s }
 // environments that don't have postgres wired or want to disable
 // the feature. The cmd/e2a runtime always sets it.
 func (a *API) SetIdempotencyStore(s *idempotency.Store) { a.idempotency = s }
+
+// SetEnforcer wires in the resource-limits enforcer. When nil (the
+// default) every check passes — handlers behave as if every user has
+// unlimited capacity. The cmd/e2a runtime always sets it; tests that
+// don't care about limits omit it and continue to work as before.
+func (a *API) SetEnforcer(e limits.Enforcer) { a.enforcer = e }
 
 func NewAPI(store *identity.Store, sender *outbound.Sender, smtpRelay *outbound.SMTPRelay, userAuth *auth.UserAuth, usage usage.UsageTracker, smtpDomain, fromDomain, sharedDomain, publicURL string, production bool) *API {
 	return &API{
@@ -602,6 +610,21 @@ func (a *API) handleRegisterAgent(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Enforce the per-user agent cap. Done after auth + domain checks so
+	// unauthenticated / invalid-domain callers see the same 401/400 they
+	// would without limits enabled — the 402 is reserved for "valid
+	// request, but you're out of capacity."
+	if a.enforcer != nil {
+		if err := a.enforcer.CheckAgentCreate(r.Context(), user.ID); err != nil {
+			if limits.WriteLimitError(w, err) {
+				return
+			}
+			log.Printf("[api] limits.CheckAgentCreate error: %v", err)
+			http.Error(w, "limits check failed", http.StatusInternalServerError)
+			return
+		}
+	}
+
 	// agent_mode is required (no implicit default — see RegisterAgentRequest
 	// docs). The old behavior defaulted to "cloud" and then 400'd with
 	// "webhook_url is required for cloud agent mode" on innocuous slug-only
@@ -910,6 +933,20 @@ func (a *API) handleRegisterDomain(w http.ResponseWriter, r *http.Request) {
 	if a.sharedDomain != "" && strings.EqualFold(req.Domain, a.sharedDomain) {
 		http.Error(w, "reserved domain", http.StatusBadRequest)
 		return
+	}
+
+	// Enforce the per-user domain cap. Reserved-domain rejection above
+	// runs first because a reserved attempt is invalid regardless of
+	// capacity — surface the more specific error.
+	if a.enforcer != nil {
+		if err := a.enforcer.CheckDomainCreate(r.Context(), user.ID); err != nil {
+			if limits.WriteLimitError(w, err) {
+				return
+			}
+			log.Printf("[api] limits.CheckDomainCreate error: %v", err)
+			http.Error(w, "limits check failed", http.StatusInternalServerError)
+			return
+		}
 	}
 
 	domainRecord, err := a.store.ClaimOrCreateDomain(r.Context(), req.Domain, user.ID)
@@ -1449,6 +1486,22 @@ func (a *API) handleSendEmail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Enforce the per-user message-flow + storage caps before any
+	// expensive work (HITL hold, MIME compose, SES handoff). HITL holds
+	// count: a held message will eventually be sent, so admitting it
+	// past the cap would let users bank thousands of holds against a
+	// future downgrade.
+	if a.enforcer != nil {
+		if err := a.enforcer.CheckMessageSend(r.Context(), user.ID); err != nil {
+			if limits.WriteLimitError(w, err) {
+				return
+			}
+			log.Printf("[api] limits.CheckMessageSend error: %v", err)
+			http.Error(w, "limits check failed", http.StatusInternalServerError)
+			return
+		}
+	}
+
 	selfSend := isSelfSend(req, agent.EmailAddress())
 
 	// HITL applies to self-sends too — the gate is "did a human
@@ -1463,7 +1516,10 @@ func (a *API) handleSendEmail(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Record usage (side-effect only — never block on quota)
+	// Record usage (side-effect only — never block on quota; the
+	// pre-check above is the gate. RecordAndCheck stays "record" because
+	// it also fires from background workers (hitlworker, magic-link
+	// approval) where a pre-check has already happened upstream.)
 	if _, err := a.usage.RecordAndCheck(r.Context(), user.ID, agent.ID, agent.Domain, "outbound"); err != nil {
 		log.Printf("[api] usage recording error: %v", err)
 	}
@@ -1559,6 +1615,19 @@ func (a *API) handleSendTestEmail(w http.ResponseWriter, r *http.Request) {
 	if !agent.DomainVerified {
 		http.Error(w, "agent domain must be verified before sending test email", http.StatusForbidden)
 		return
+	}
+
+	// Test sends count against the cap — they're a real outbound
+	// message that flows through SES (or loopback under HITL). No carve-out.
+	if a.enforcer != nil {
+		if err := a.enforcer.CheckMessageSend(r.Context(), user.ID); err != nil {
+			if limits.WriteLimitError(w, err) {
+				return
+			}
+			log.Printf("[api] limits.CheckMessageSend error: %v", err)
+			http.Error(w, "limits check failed", http.StatusInternalServerError)
+			return
+		}
 	}
 
 	envelopeFrom := fmt.Sprintf("noreply@%s", a.fromDomain)
@@ -1681,6 +1750,19 @@ func (a *API) handleReplyToMessage(w http.ResponseWriter, r *http.Request) {
 	if !agent.DomainVerified {
 		http.Error(w, "agent domain must be verified before sending", http.StatusForbidden)
 		return
+	}
+
+	// Enforce message-flow + storage caps before composing the reply.
+	// See handleSendEmail for the rationale on HITL accounting.
+	if a.enforcer != nil {
+		if err := a.enforcer.CheckMessageSend(r.Context(), user.ID); err != nil {
+			if limits.WriteLimitError(w, err) {
+				return
+			}
+			log.Printf("[api] limits.CheckMessageSend error: %v", err)
+			http.Error(w, "limits check failed", http.StatusInternalServerError)
+			return
+		}
 	}
 
 	var req ReplyRequest

--- a/internal/agent/billing_hook_test.go
+++ b/internal/agent/billing_hook_test.go
@@ -1,0 +1,200 @@
+package agent_test
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/gorilla/mux"
+
+	"github.com/Mnexa-AI/e2a/internal/agent"
+	"github.com/Mnexa-AI/e2a/internal/auth"
+	"github.com/Mnexa-AI/e2a/internal/config"
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/outbound"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+	"github.com/Mnexa-AI/e2a/internal/usage"
+)
+
+// These tests cover the user-delete → billing-hook escape valve.
+// The hook is best-effort: a failure must NOT block account deletion
+// (otherwise a billing-service outage holds users hostage to a
+// subscription they can't cancel by deleting their account).
+
+// recordedHookCall captures what the OSS server sent the hook.
+type recordedHookCall struct {
+	mu        sync.Mutex
+	body      []byte
+	signature string
+	called    bool
+}
+
+// setupAPIWithBillingHook wires an API with a configured billing-hook
+// URL pointing at the returned httptest server. The returned hookSrv
+// behaves per `hookStatus` so individual tests can simulate success
+// (204), transient outage (500), unreachable (close the server), etc.
+func setupAPIWithBillingHook(t *testing.T, internalSecret string, hookStatus int) (*httptest.Server, *identity.Store, *recordedHookCall, *httptest.Server) {
+	t.Helper()
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	smtpRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{})
+	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
+	userAuth := auth.NewUserAuth(&config.OAuthConfig{}, store, false)
+
+	rec := &recordedHookCall{}
+	hookSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		rec.mu.Lock()
+		rec.body = body
+		rec.signature = r.Header.Get("X-E2A-Internal-Signature")
+		rec.called = true
+		rec.mu.Unlock()
+		w.WriteHeader(hookStatus)
+	}))
+	t.Cleanup(hookSrv.Close)
+
+	api := agent.NewAPI(store, sender, smtpRelay, userAuth, usage.NewNoopUsageTracker(),
+		"e2a.dev", "test.e2a.dev", "agents.e2a.dev", "", false)
+	api.SetInternalAPISecret(internalSecret)
+	api.SetBillingHookURL(hookSrv.URL)
+
+	router := mux.NewRouter()
+	api.RegisterRoutes(router)
+	apiSrv := httptest.NewServer(router)
+	t.Cleanup(apiSrv.Close)
+	return apiSrv, store, rec, hookSrv
+}
+
+// expectedHMAC re-derives what the X-E2A-Internal-Signature header
+// SHOULD be for the recorded body. Independent computation, so a bug
+// in either side (sign or verify) shows up.
+func expectedHMAC(secret string, body []byte) string {
+	h := hmac.New(sha256.New, []byte(secret))
+	h.Write(body)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// --- Happy path: hook fires with right user_id + signature ---
+
+func TestDeleteUser_FiresBillingHook(t *testing.T) {
+	secret := "test-internal-secret"
+	apiSrv, store, rec, _ := setupAPIWithBillingHook(t, secret, http.StatusNoContent)
+	token := createTestUser(t, store, "hook-fires@test.com")
+	ctx := context.Background()
+	user, err := store.CreateOrGetUser(ctx, "hook-fires@test.com", "Test", "google-hook-fires@test.com")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+
+	req, _ := http.NewRequest("DELETE", apiSrv.URL+"/api/v1/users/me?confirm=DELETE", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		buf, _ := io.ReadAll(resp.Body)
+		t.Fatalf("delete status = %d body = %s", resp.StatusCode, string(buf))
+	}
+
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if !rec.called {
+		t.Fatalf("billing hook was not called")
+	}
+
+	// Body shape: {"user_id":"<id>"}.
+	var hookBody struct {
+		UserID string `json:"user_id"`
+	}
+	if err := json.Unmarshal(rec.body, &hookBody); err != nil {
+		t.Fatalf("hook body not JSON: %v (body=%q)", err, string(rec.body))
+	}
+	if hookBody.UserID != user.ID {
+		t.Errorf("hook user_id = %q, want %q", hookBody.UserID, user.ID)
+	}
+
+	// Signature matches an independent HMAC over the exact body the
+	// hook received. Catches both signing-side bugs (wrong key, wrong
+	// algorithm) and body-bytes drift (whitespace, key order).
+	if got, want := rec.signature, expectedHMAC(secret, rec.body); got != want {
+		t.Errorf("signature mismatch:\n  got      %s\n  expected %s", got, want)
+	}
+
+	// User actually deleted (the cascade ran after the hook).
+	if _, err := store.GetUserByID(ctx, user.ID); err == nil {
+		t.Errorf("user still exists after delete; cascade should have removed them")
+	}
+}
+
+// --- Best-effort: hook failures do NOT block deletion ---
+
+func TestDeleteUser_HookFailureDoesNotBlockDeletion(t *testing.T) {
+	// Hook returns 500 on every call — simulates billing-service outage.
+	apiSrv, store, rec, _ := setupAPIWithBillingHook(t, "secret", http.StatusInternalServerError)
+	token := createTestUser(t, store, "hook-fails@test.com")
+	ctx := context.Background()
+	user, err := store.CreateOrGetUser(ctx, "hook-fails@test.com", "Test", "google-hook-fails@test.com")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+
+	req, _ := http.NewRequest("DELETE", apiSrv.URL+"/api/v1/users/me?confirm=DELETE", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("delete status = %d, want 200 despite hook failure", resp.StatusCode)
+	}
+
+	rec.mu.Lock()
+	called := rec.called
+	rec.mu.Unlock()
+	if !called {
+		t.Errorf("hook should have been attempted before deletion")
+	}
+	// User STILL deleted despite hook failure. This is the
+	// load-bearing assertion: deletion is the user's right and a
+	// billing-side outage must not hold their right hostage.
+	if _, err := store.GetUserByID(ctx, user.ID); err == nil {
+		t.Errorf("hook failed but user was not deleted; cascade must proceed regardless")
+	}
+}
+
+// --- No hook configured: deletion still proceeds, no HTTP call ---
+
+func TestDeleteUser_NoHookConfigured(t *testing.T) {
+	// Standard setup without SetBillingHookURL — self-host pattern.
+	server, store, _ := setupAPI(t)
+	token := createTestUser(t, store, "no-hook@test.com")
+	ctx := context.Background()
+	user, err := store.CreateOrGetUser(ctx, "no-hook@test.com", "Test", "google-no-hook@test.com")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+
+	req, _ := http.NewRequest("DELETE", server.URL+"/api/v1/users/me?confirm=DELETE", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("delete status = %d, want 200", resp.StatusCode)
+	}
+	if _, err := store.GetUserByID(ctx, user.ID); err == nil {
+		t.Errorf("user still exists after delete")
+	}
+}

--- a/internal/agent/enforcer_wiring_test.go
+++ b/internal/agent/enforcer_wiring_test.go
@@ -1,0 +1,184 @@
+package agent_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/limits"
+)
+
+// These tests verify the END-TO-END wiring between the enforcer and
+// the HTTP handlers: that a user over cap actually receives HTTP 402
+// from POST /api/v1/agents and POST /api/v1/domains, with the
+// LimitErrorBody shape callers can read. The enforcer's Check methods
+// have unit tests via fakes; this layer proves the handler chain
+// (auth → check → 402) is wired correctly so a regression in a
+// SetEnforcer caller or a re-ordering of guards in the handler is
+// caught.
+//
+// They live in package agent_test (external) because they exercise
+// the real HTTP surface.
+
+// limitsForBlock returns a Limits where max_agents = 0 — blocks all
+// agent creates regardless of the user's current count. Everything
+// else is permissive so the only thing that can fire is the agent cap.
+func limitsForBlock(planCode, upgradeURL string) limits.Limits {
+	return limits.Limits{
+		PlanCode:         planCode,
+		MaxAgents:        0,
+		MaxDomains:       1000,
+		MaxMessagesMonth: 1_000_000,
+		MaxStorageBytes:  1 << 40,
+		UpgradeURL:       upgradeURL,
+	}
+}
+
+func TestRegisterAgent_Returns402WhenAgentCapHit(t *testing.T) {
+	server, store, pool, enf := setupAPIWithLimits(t, "")
+	token := createTestUser(t, store, "enf-agent-blocked@test.com")
+
+	ctx := context.Background()
+	user, err := store.CreateOrGetUser(ctx, "enf-agent-blocked@test.com", "Test User", "google-enf-agent-blocked@test.com")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+
+	// Block: max_agents=0 means EVERY create attempt is over cap.
+	lstore := limits.NewStore(pool)
+	if err := lstore.Upsert(ctx, user.ID, limitsForBlock("free_test", "https://billing.example/upgrade")); err != nil {
+		t.Fatalf("Upsert limits: %v", err)
+	}
+	enf.Invalidate(user.ID)
+
+	// Slug-based registration so we don't need to set up a custom
+	// domain. agents.e2a.dev is the shared domain seeded by testutil.
+	body := `{"slug":"capblock","agent_mode":"local"}`
+	req, _ := http.NewRequest("POST", server.URL+"/api/v1/agents", bytes.NewReader([]byte(body)))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusPaymentRequired {
+		buf, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 402; body = %s", resp.StatusCode, string(buf))
+	}
+
+	// LimitErrorBody shape — dashboards + SDK clients depend on this
+	// being stable. Tightening this assertion catches accidental field
+	// renames.
+	var lerr limits.LimitErrorBody
+	if err := json.NewDecoder(resp.Body).Decode(&lerr); err != nil {
+		t.Fatalf("body not JSON: %v", err)
+	}
+	if lerr.Resource != "agents" {
+		t.Errorf("Resource = %q, want agents", lerr.Resource)
+	}
+	if lerr.Limit != 0 {
+		t.Errorf("Limit = %d, want 0", lerr.Limit)
+	}
+	if lerr.PlanCode != "free_test" {
+		t.Errorf("PlanCode = %q, want free_test", lerr.PlanCode)
+	}
+	if lerr.UpgradeURL != "https://billing.example/upgrade" {
+		t.Errorf("UpgradeURL = %q, want https://billing.example/upgrade", lerr.UpgradeURL)
+	}
+	if lerr.Error == "" {
+		t.Errorf("Error message empty; want human-readable string for logs")
+	}
+}
+
+func TestRegisterAgent_201WhenUnderCap(t *testing.T) {
+	server, store, pool, enf := setupAPIWithLimits(t, "")
+	token := createTestUser(t, store, "enf-agent-ok@test.com")
+
+	ctx := context.Background()
+	user, err := store.CreateOrGetUser(ctx, "enf-agent-ok@test.com", "Test User", "google-enf-agent-ok@test.com")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+
+	// Generous caps — happy path baseline. Confirms the enforcer
+	// wiring doesn't accidentally block when it shouldn't.
+	lstore := limits.NewStore(pool)
+	if err := lstore.Upsert(ctx, user.ID, limits.Limits{
+		PlanCode:         "pro_test",
+		MaxAgents:        25,
+		MaxDomains:       10,
+		MaxMessagesMonth: 50_000,
+		MaxStorageBytes:  10 << 30,
+	}); err != nil {
+		t.Fatalf("Upsert limits: %v", err)
+	}
+	enf.Invalidate(user.ID)
+
+	body := `{"slug":"undercap","agent_mode":"local"}`
+	req, _ := http.NewRequest("POST", server.URL+"/api/v1/agents", bytes.NewReader([]byte(body)))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		buf, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 201; body = %s", resp.StatusCode, string(buf))
+	}
+}
+
+func TestRegisterDomain_Returns402WhenDomainCapHit(t *testing.T) {
+	server, store, pool, enf := setupAPIWithLimits(t, "")
+	token := createTestUser(t, store, "enf-domain-blocked@test.com")
+
+	ctx := context.Background()
+	user, err := store.CreateOrGetUser(ctx, "enf-domain-blocked@test.com", "Test User", "google-enf-domain-blocked@test.com")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+
+	// max_domains=0 — every register attempt over cap.
+	lstore := limits.NewStore(pool)
+	if err := lstore.Upsert(ctx, user.ID, limits.Limits{
+		PlanCode:         "free_test",
+		MaxAgents:        1000,
+		MaxDomains:       0,
+		MaxMessagesMonth: 1_000_000,
+		MaxStorageBytes:  1 << 40,
+		UpgradeURL:       "https://billing.example/upgrade",
+	}); err != nil {
+		t.Fatalf("Upsert limits: %v", err)
+	}
+	enf.Invalidate(user.ID)
+
+	body := `{"domain":"capblock.example.com"}`
+	req, _ := http.NewRequest("POST", server.URL+"/api/v1/domains", bytes.NewReader([]byte(body)))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusPaymentRequired {
+		buf, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 402; body = %s", resp.StatusCode, string(buf))
+	}
+
+	var lerr limits.LimitErrorBody
+	if err := json.NewDecoder(resp.Body).Decode(&lerr); err != nil {
+		t.Fatalf("body not JSON: %v", err)
+	}
+	if lerr.Resource != "domains" {
+		t.Errorf("Resource = %q, want domains", lerr.Resource)
+	}
+}

--- a/internal/agent/lifecycle_test.go
+++ b/internal/agent/lifecycle_test.go
@@ -1,0 +1,145 @@
+package agent_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/agent"
+	"github.com/Mnexa-AI/e2a/internal/limits"
+)
+
+// TestUserLifecycle_DefaultThenProThenFree walks a single user through
+// the three states a paid-SaaS user can be in:
+//
+//  1. Brand new — no row in account_limits → falls through to the
+//     operator default (configured in config.yaml's `limits:` block).
+//  2. Upgraded — sidecar wrote a Pro row → dashboard shows Pro caps.
+//  3. Downgraded — sidecar wrote a Free row after Stripe cancellation
+//     → dashboard shows Free caps with no upgrade_url (so it renders
+//     "Upgrade" instead of "Manage billing").
+//
+// This is the test that proves the three slices (enforcer fallback,
+// account_limits upsert, GET /me/limits read + cache invalidation)
+// compose correctly. Failing here means at least one seam drifted.
+func TestUserLifecycle_DefaultThenProThenFree(t *testing.T) {
+	server, store, pool, enf := setupAPIWithLimits(t, "")
+	token := createTestUser(t, store, "lifecycle@test.com")
+	ctx := context.Background()
+	user, err := store.CreateOrGetUser(ctx, "lifecycle@test.com", "Test User", "google-lifecycle@test.com")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+
+	// --- State 1: brand new user, no account_limits row ---
+	//
+	// setupAPIWithLimits configured operator defaults of
+	// 100/10/1_000_000/1<<40. That's what the dashboard should see.
+	info := fetchLimits(t, server.URL, token)
+	if info.PlanCode != "default" {
+		t.Errorf("state=new: PlanCode = %q, want 'default'", info.PlanCode)
+	}
+	if info.Limits.MaxAgents != 100 {
+		t.Errorf("state=new: MaxAgents = %d, want 100 (operator default)", info.Limits.MaxAgents)
+	}
+	if info.UpgradeURL != "" {
+		t.Errorf("state=new: UpgradeURL = %q, want empty (no sub yet)", info.UpgradeURL)
+	}
+
+	// --- State 2: upgrade — sidecar wrote a Pro row ---
+	//
+	// We're simulating what the sidecar's accountlimits.Writer does
+	// after Stripe's customer.subscription.created event lands. From
+	// the OSS server's perspective the only thing that matters is
+	// the row in account_limits + the cache invalidate; bypassing
+	// the HTTP call between sidecar and OSS is fine because the
+	// invalidate endpoint is unit-tested separately.
+	lstore := limits.NewStore(pool)
+	proRow := limits.Limits{
+		PlanCode:         "pro",
+		MaxAgents:        25,
+		MaxDomains:       10,
+		MaxMessagesMonth: 50_000,
+		MaxStorageBytes:  10 << 30,
+		UpgradeURL:       "https://billing.example/portal",
+	}
+	if err := lstore.Upsert(ctx, user.ID, proRow); err != nil {
+		t.Fatalf("Upsert pro: %v", err)
+	}
+	enf.Invalidate(user.ID) // mimic the sidecar's invalidate ping
+
+	info = fetchLimits(t, server.URL, token)
+	if info.PlanCode != "pro" {
+		t.Errorf("state=pro: PlanCode = %q, want 'pro'", info.PlanCode)
+	}
+	if info.Limits != (agent.LimitsCaps{MaxAgents: 25, MaxDomains: 10, MaxMessagesMonth: 50_000, MaxStorageBytes: 10 << 30}) {
+		t.Errorf("state=pro: caps = %+v, want Pro shape", info.Limits)
+	}
+	if info.UpgradeURL != "https://billing.example/portal" {
+		t.Errorf("state=pro: UpgradeURL = %q, want billing portal URL (Manage Billing button renders)", info.UpgradeURL)
+	}
+
+	// --- State 3: downgrade — sidecar wrote a Free row after cancel ---
+	//
+	// Stripe's customer.subscription.deleted event landed; the
+	// sidecar wrote Free caps + cleared upgrade_url so the dashboard
+	// renders the "Upgrade" CTA again (not "Manage Billing", which
+	// would be confusing on a free account).
+	freeRow := limits.Limits{
+		PlanCode:         "free",
+		MaxAgents:        3,
+		MaxDomains:       1,
+		MaxMessagesMonth: 3_000,
+		MaxStorageBytes:  1 << 30,
+		UpgradeURL:       "",
+	}
+	if err := lstore.Upsert(ctx, user.ID, freeRow); err != nil {
+		t.Fatalf("Upsert free: %v", err)
+	}
+	enf.Invalidate(user.ID)
+
+	info = fetchLimits(t, server.URL, token)
+	if info.PlanCode != "free" {
+		t.Errorf("state=free: PlanCode = %q, want 'free'", info.PlanCode)
+	}
+	if info.Limits != (agent.LimitsCaps{MaxAgents: 3, MaxDomains: 1, MaxMessagesMonth: 3_000, MaxStorageBytes: 1 << 30}) {
+		t.Errorf("state=free: caps = %+v, want Free shape", info.Limits)
+	}
+	if info.UpgradeURL != "" {
+		t.Errorf("state=free: UpgradeURL = %q, want empty (Upgrade button renders)", info.UpgradeURL)
+	}
+
+	// Sanity: re-fetch after a no-op invalidate should still show
+	// Free. Catches a cache-coherence bug where a stale Pro entry
+	// could survive into post-downgrade reads.
+	enf.Invalidate(user.ID)
+	info = fetchLimits(t, server.URL, token)
+	if info.PlanCode != "free" {
+		t.Errorf("state=free (re-read): PlanCode = %q, want 'free'", info.PlanCode)
+	}
+}
+
+// fetchLimits hits GET /api/v1/users/me/limits with the given token and
+// returns the parsed LimitsInfo. Centralized helper so the lifecycle
+// test reads as a sequence of state transitions rather than HTTP boilerplate.
+func fetchLimits(t *testing.T, baseURL, token string) agent.LimitsInfo {
+	t.Helper()
+	req, _ := http.NewRequest("GET", baseURL+"/api/v1/users/me/limits", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("GET /me/limits status=%d body=%s", resp.StatusCode, string(body))
+	}
+	var info agent.LimitsInfo
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return info
+}

--- a/internal/agent/limits_api.go
+++ b/internal/agent/limits_api.go
@@ -1,0 +1,189 @@
+package agent
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+)
+
+// LimitsInfo is the response body for GET /api/v1/users/me/limits. It
+// bundles the user's resolved caps with their current usage so the
+// dashboard renders the "you're using X of Y" surface in one round
+// trip. plan_code and upgrade_url come straight from the limits row
+// (opaque to OSS — written by whatever provisions the row); when no
+// row exists, plan_code is the operator default and upgrade_url is
+// empty.
+type LimitsInfo struct {
+	PlanCode   string      `json:"plan_code"`
+	Limits     LimitsCaps  `json:"limits"`
+	Usage      LimitsUsage `json:"usage"`
+	UpgradeURL string      `json:"upgrade_url"`
+} // @name LimitsInfo
+
+type LimitsCaps struct {
+	MaxAgents        int   `json:"max_agents"`
+	MaxDomains       int   `json:"max_domains"`
+	MaxMessagesMonth int   `json:"max_messages_month"`
+	MaxStorageBytes  int64 `json:"max_storage_bytes"`
+} // @name LimitsCaps
+
+type LimitsUsage struct {
+	Agents        int   `json:"agents"`
+	Domains       int   `json:"domains"`
+	MessagesMonth int   `json:"messages_month"`
+	StorageBytes  int64 `json:"storage_bytes"`
+} // @name LimitsUsage
+
+// handleGetMyLimits returns the authenticated user's caps + current
+// usage. Read-only; safe to call from the dashboard on every page load.
+//
+// @Summary      Get the current user's limits and usage
+// @Description  Returns the resolved per-user caps (from account_limits or operator defaults) plus the user's current usage. Dashboard uses this to render the upgrade affordance and the "you've used X of Y" surface.
+// @Tags         Users
+// @Produce      json
+// @Security     BearerAuth
+// @Success      200 {object} LimitsInfo
+// @Failure      401 {string} string "Missing or invalid API key"
+// @Failure      503 {string} string "Limits subsystem not configured"
+// @Router       /api/v1/users/me/limits [get]
+func (a *API) handleGetMyLimits(w http.ResponseWriter, r *http.Request) {
+	user, err := a.authenticateUser(r)
+	if err != nil {
+		a.writeAuthError(w, r, err)
+		return
+	}
+	if a.enforcer == nil {
+		// Self-host without limits wired. The dashboard should never
+		// show its limits surface in this case (NEXT_PUBLIC_BILLING_API
+		// is empty), so this is an "operator misconfig" path rather
+		// than a normal one. 503 makes it loud.
+		http.Error(w, "limits subsystem not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	caps, err := a.enforcer.Get(r.Context(), user.ID)
+	if err != nil {
+		log.Printf("[api] limits.Get error: %v", err)
+		http.Error(w, "limits lookup failed", http.StatusInternalServerError)
+		return
+	}
+
+	// Read usage directly from the usage store. Done outside the
+	// enforcer because the enforcer never caches counts (would lie
+	// after a just-created agent or just-sent message). Errors here
+	// are non-fatal — surface 0 with a log so the dashboard still
+	// renders something instead of erroring the whole panel.
+	ctx := r.Context()
+	usageReport := LimitsUsage{}
+	if a.usageStore != nil {
+		if n, err := a.usageStore.CountAgentsByUser(ctx, user.ID); err == nil {
+			usageReport.Agents = n
+		} else {
+			log.Printf("[api] CountAgentsByUser: %v", err)
+		}
+		if n, err := a.usageStore.CountDomainsByUser(ctx, user.ID); err == nil {
+			usageReport.Domains = n
+		} else {
+			log.Printf("[api] CountDomainsByUser: %v", err)
+		}
+		if n, err := a.usageStore.MessagesThisMonth(ctx, user.ID); err == nil {
+			usageReport.MessagesMonth = n
+		} else {
+			log.Printf("[api] MessagesThisMonth: %v", err)
+		}
+		if n, err := a.usageStore.GetStorageBytes(ctx, user.ID); err == nil {
+			usageReport.StorageBytes = n
+		} else {
+			log.Printf("[api] GetStorageBytes: %v", err)
+		}
+	}
+
+	resp := LimitsInfo{
+		PlanCode: caps.PlanCode,
+		Limits: LimitsCaps{
+			MaxAgents:        caps.MaxAgents,
+			MaxDomains:       caps.MaxDomains,
+			MaxMessagesMonth: caps.MaxMessagesMonth,
+			MaxStorageBytes:  caps.MaxStorageBytes,
+		},
+		Usage:      usageReport,
+		UpgradeURL: caps.UpgradeURL,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	writeJSON(w, resp)
+}
+
+// invalidateLimitsRequest is the body of POST /api/internal/limits/invalidate.
+type invalidateLimitsRequest struct {
+	UserID string `json:"user_id"`
+}
+
+// handleInvalidateLimits busts the in-process limits cache for the
+// given user. Called by the external provisioner (billing sidecar)
+// immediately after it writes account_limits, so the next request from
+// that user sees the new caps without waiting ~60s for natural TTL
+// expiry.
+//
+// Authentication is a shared HMAC over the request body. The sidecar
+// signs with the same secret the OSS server is configured with, sends
+// the hex digest in X-E2A-Internal-Signature, and the OSS server
+// verifies with a constant-time compare. Anything else (bearer tokens,
+// API keys) would either tangle this machine-to-machine endpoint with
+// user-scoped auth or require a separate credential store.
+//
+// The endpoint is intentionally not advertised in the OpenAPI spec —
+// it's an internal seam between the OSS server and its operator's
+// provisioner. Self-hosters who don't run a provisioner simply leave
+// InternalAPISecret empty and the endpoint 503s.
+func (a *API) handleInvalidateLimits(w http.ResponseWriter, r *http.Request) {
+	if a.internalAPISecret == "" {
+		http.Error(w, "internal api not configured", http.StatusServiceUnavailable)
+		return
+	}
+	if a.enforcer == nil {
+		http.Error(w, "limits subsystem not configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, 1024))
+	if err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	sig := r.Header.Get("X-E2A-Internal-Signature")
+	if sig == "" {
+		http.Error(w, "missing signature", http.StatusUnauthorized)
+		return
+	}
+	expected := hmacHexSHA256([]byte(a.internalAPISecret), body)
+	if subtle.ConstantTimeCompare([]byte(sig), []byte(expected)) != 1 {
+		http.Error(w, "invalid signature", http.StatusUnauthorized)
+		return
+	}
+
+	var req invalidateLimitsRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.UserID == "" {
+		http.Error(w, "user_id is required", http.StatusBadRequest)
+		return
+	}
+
+	a.enforcer.Invalidate(req.UserID)
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func hmacHexSHA256(key, body []byte) string {
+	h := hmac.New(sha256.New, key)
+	h.Write(body)
+	return hex.EncodeToString(h.Sum(nil))
+}
+

--- a/internal/agent/limits_api_test.go
+++ b/internal/agent/limits_api_test.go
@@ -1,0 +1,201 @@
+package agent_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Mnexa-AI/e2a/internal/agent"
+	"github.com/Mnexa-AI/e2a/internal/auth"
+	"github.com/Mnexa-AI/e2a/internal/config"
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/limits"
+	"github.com/Mnexa-AI/e2a/internal/outbound"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+	"github.com/Mnexa-AI/e2a/internal/usage"
+)
+
+// setupAPIWithLimits returns a live test server plus the underlying
+// pool/store/enforcer so callers can write directly to the DB the API
+// is reading from. testutil.TestDB(t) creates a fresh pool AND
+// truncates the schema on every call — so callers must NOT call it
+// again from inside the test or they'll wipe their own setup.
+func setupAPIWithLimits(t *testing.T, internalSecret string) (*httptest.Server, *identity.Store, *pgxpool.Pool, limits.Enforcer) {
+	t.Helper()
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	smtpRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{})
+	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
+	userAuth := auth.NewUserAuth(&config.OAuthConfig{}, store, false)
+	usageStore := usage.NewStore(pool)
+
+	defaults := limits.Defaults{
+		PlanCode: "default", MaxAgents: 100, MaxDomains: 10,
+		MaxMessagesMonth: 1_000_000, MaxStorageBytes: 1 << 40,
+	}
+	enf := limits.NewEnforcer(limits.NewStore(pool), usageStore, defaults, 0)
+
+	api := agent.NewAPI(store, sender, smtpRelay, userAuth, usage.NewNoopUsageTracker(), "e2a.dev", "test.e2a.dev", "agents.e2a.dev", "", false)
+	api.SetEnforcer(enf)
+	api.SetUsageStore(usageStore)
+	api.SetInternalAPISecret(internalSecret)
+
+	router := mux.NewRouter()
+	api.RegisterRoutes(router)
+	server := httptest.NewServer(router)
+	t.Cleanup(server.Close)
+	return server, store, pool, enf
+}
+
+func TestGetMyLimits_ReturnsDefaultsForNewUser(t *testing.T) {
+	server, store, _, _ := setupAPIWithLimits(t, "")
+	token := createTestUser(t, store, "limitsread@test.com")
+
+	req, _ := http.NewRequest("GET", server.URL+"/api/v1/users/me/limits", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, string(body))
+	}
+	var info agent.LimitsInfo
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if info.PlanCode != "default" {
+		t.Errorf("PlanCode = %q, want default", info.PlanCode)
+	}
+	if info.Limits.MaxAgents != 100 {
+		t.Errorf("MaxAgents = %d, want 100", info.Limits.MaxAgents)
+	}
+	if info.Usage.Agents != 0 || info.Usage.Domains != 0 || info.Usage.MessagesMonth != 0 || info.Usage.StorageBytes != 0 {
+		t.Errorf("Usage on brand-new user = %+v, want all zeros", info.Usage)
+	}
+	if info.UpgradeURL != "" {
+		t.Errorf("UpgradeURL on default = %q, want empty", info.UpgradeURL)
+	}
+}
+
+func TestGetMyLimits_ReflectsAccountLimitsRow(t *testing.T) {
+	server, store, pool, enf := setupAPIWithLimits(t, "")
+	token := createTestUser(t, store, "rowuser@test.com")
+
+	// CreateOrGetUser with the same email returns the existing user
+	// row (idempotent), which gives us the user_id we need to write
+	// the account_limits FK target.
+	ctx := context.Background()
+	user, err := store.CreateOrGetUser(ctx, "rowuser@test.com", "Test User", "google-rowuser@test.com")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+
+	// Write the row through the same pool the API reads from.
+	ls := limits.NewStore(pool)
+	if err := ls.Upsert(ctx, user.ID, limits.Limits{
+		PlanCode:         "test_pro",
+		MaxAgents:        50,
+		MaxDomains:       10,
+		MaxMessagesMonth: 50_000,
+		MaxStorageBytes:  10 << 30,
+		UpgradeURL:       "https://billing.example/portal",
+	}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	// Bust the cache so the API picks up the new row immediately.
+	enf.Invalidate(user.ID)
+
+	req, _ := http.NewRequest("GET", server.URL+"/api/v1/users/me/limits", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, body = %s", resp.StatusCode, string(body))
+	}
+	var info agent.LimitsInfo
+	if err := json.NewDecoder(resp.Body).Decode(&info); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if info.PlanCode != "test_pro" {
+		t.Errorf("PlanCode = %q, want test_pro", info.PlanCode)
+	}
+	if info.UpgradeURL != "https://billing.example/portal" {
+		t.Errorf("UpgradeURL = %q, want billing.example/portal", info.UpgradeURL)
+	}
+	if info.Limits.MaxAgents != 50 {
+		t.Errorf("MaxAgents = %d, want 50", info.Limits.MaxAgents)
+	}
+}
+
+func TestInvalidateLimits_RejectsMissingSignature(t *testing.T) {
+	server, _, _, _ := setupAPIWithLimits(t, "test-secret-1")
+
+	body := []byte(`{"user_id":"u_x"}`)
+	req, _ := http.NewRequest("POST", server.URL+"/api/internal/limits/invalidate", bytes.NewReader(body))
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("missing sig: status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestInvalidateLimits_RejectsWrongSignature(t *testing.T) {
+	server, _, _, _ := setupAPIWithLimits(t, "test-secret-2")
+
+	body := []byte(`{"user_id":"u_x"}`)
+	req, _ := http.NewRequest("POST", server.URL+"/api/internal/limits/invalidate", bytes.NewReader(body))
+	req.Header.Set("X-E2A-Internal-Signature", "deadbeef")
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("wrong sig: status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestInvalidateLimits_AcceptsCorrectSignature(t *testing.T) {
+	secret := "test-secret-3"
+	server, _, _, _ := setupAPIWithLimits(t, secret)
+
+	body := []byte(`{"user_id":"u_xyz"}`)
+	h := hmac.New(sha256.New, []byte(secret))
+	h.Write(body)
+	sig := hex.EncodeToString(h.Sum(nil))
+
+	req, _ := http.NewRequest("POST", server.URL+"/api/internal/limits/invalidate", bytes.NewReader(body))
+	req.Header.Set("X-E2A-Internal-Signature", sig)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		buf, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d body=%s, want 204", resp.StatusCode, string(buf))
+	}
+}
+
+func TestInvalidateLimits_503WhenSecretUnset(t *testing.T) {
+	server, _, _, _ := setupAPIWithLimits(t, "")
+
+	body := []byte(`{"user_id":"u_x"}`)
+	req, _ := http.NewRequest("POST", server.URL+"/api/internal/limits/invalidate", bytes.NewReader(body))
+	req.Header.Set("X-E2A-Internal-Signature", "anything")
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("no-secret config: status = %d, want 503", resp.StatusCode)
+	}
+}

--- a/internal/agent/user_data_rights_api.go
+++ b/internal/agent/user_data_rights_api.go
@@ -1,9 +1,17 @@
 package agent
 
 import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"io"
 	"log"
 	"net/http"
+	"time"
 
 	"github.com/Mnexa-AI/e2a/internal/identity"
 )
@@ -122,6 +130,21 @@ func (a *API) handleDeleteUserData(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Best-effort notify of the external billing hook (sidecar) BEFORE
+	// the cascade. The hook is responsible for canceling the user's
+	// Stripe subscription so they stop being billed. We do NOT block
+	// account deletion on this — if the hook is unreachable or the
+	// underlying Stripe call fails, log loud and proceed. A reconciler
+	// (post-launch follow-up) catches the orphan.
+	//
+	// Self-host operators who don't run a billing service leave
+	// billingHookURL empty; the call is then a no-op.
+	if a.billingHookURL != "" {
+		if err := a.notifyBillingUserDeleted(r.Context(), user.ID); err != nil {
+			log.Printf("[api] billing-hook user-delete failed (continuing): user=%s err=%v", user.ID, err)
+		}
+	}
+
 	res, err := a.store.DeleteUserData(r.Context(), user.ID)
 	if err != nil {
 		log.Printf("[api] delete user data failed: user=%s err=%v", user.ID, err)
@@ -136,4 +159,42 @@ func (a *API) handleDeleteUserData(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	writeJSON(w, res)
+}
+
+// notifyBillingUserDeleted HMAC-POSTs to the external billing hook so
+// the user's Stripe subscription gets canceled before the OSS cascade
+// removes the rest of their data. Caller already checked
+// a.billingHookURL is non-empty.
+//
+// Returns an error on transport / non-204 status, but the caller logs
+// + continues — we never block a user's account deletion on a
+// billing-side outage. A reconciler picks up any orphaned customer
+// records later.
+func (a *API) notifyBillingUserDeleted(ctx context.Context, userID string) error {
+	body, err := json.Marshal(map[string]string{"user_id": userID})
+	if err != nil {
+		return err
+	}
+	h := hmac.New(sha256.New, []byte(a.internalAPISecret))
+	h.Write(body)
+	sig := hex.EncodeToString(h.Sum(nil))
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.billingHookURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-E2A-Internal-Signature", sig)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("billing hook returned %d: %s", resp.StatusCode, string(b))
+	}
+	return nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -108,6 +108,13 @@ type LimitsConfig struct {
 	// default), that endpoint returns 503 — no provisioner, no
 	// invalidation. Must be set to the same value on both ends.
 	InternalAPISecret string `yaml:"internal_api_secret"`
+	// BillingHookURL is the URL the OSS server POSTs to when a user
+	// deletes their account, so the external billing service (e.g.
+	// the hosted billing sidecar's /api/internal/billing/cancel) can
+	// cancel the user's Stripe subscription. Empty disables the call
+	// — appropriate for self-host without billing. The same
+	// InternalAPISecret signs the POST body.
+	BillingHookURL string `yaml:"billing_hook_url"`
 }
 
 func Load(path string) (*Config, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -102,6 +102,12 @@ type LimitsConfig struct {
 	// (recommended for tests that mutate account_limits and want
 	// immediate visibility).
 	CacheTTLSeconds int `yaml:"cache_ttl_seconds"`
+	// InternalAPISecret is the shared HMAC secret the external limits
+	// provisioner (e.g. the hosted billing sidecar) uses to authenticate
+	// to /api/internal/limits/invalidate. When empty (the self-host
+	// default), that endpoint returns 503 — no provisioner, no
+	// invalidation. Must be set to the same value on both ends.
+	InternalAPISecret string `yaml:"internal_api_secret"`
 }
 
 func Load(path string) (*Config, error) {
@@ -139,6 +145,9 @@ func Load(path string) (*Config, error) {
 	// Env overrides — secrets only (never duplicated in yaml)
 	if v := os.Getenv("E2A_DATABASE_URL"); v != "" {
 		cfg.Database.URL = v
+	}
+	if v := os.Getenv("E2A_INTERNAL_API_SECRET"); v != "" {
+		cfg.Limits.InternalAPISecret = v
 	}
 	if v := os.Getenv("E2A_HMAC_SECRET"); v != "" {
 		cfg.Signing.HMACSecret = v

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	OAuth        OAuthConfig        `yaml:"oauth"`
 	Signing      SigningConfig      `yaml:"signing"`
 	OutboundSMTP OutboundSMTPConfig `yaml:"outbound_smtp"`
+	Limits       LimitsConfig       `yaml:"limits"`
 	Env          string             `yaml:"env"` // "development" or "production"
 	// SharedDomain enables slug-based agent registration. When set
 	// (e.g. "agents.example.com"), users can register agents with just a
@@ -79,6 +80,30 @@ type OutboundSMTPConfig struct {
 	FromDomain string `yaml:"from_domain"`
 }
 
+// LimitsConfig is the operator-configured fallback applied to any user
+// who does not yet have a row in account_limits. The hosted billing
+// sidecar populates rows for paying customers; self-hosted operators
+// who do not run a billing service rely on these defaults for every
+// user. Defaults below intentionally lean generous so a self-host that
+// never touches the limits subsystem is not accidentally throttled.
+//
+// Hosted-service operators who want every brand-new signup capped to a
+// "free" shape should set these to the Free-tier numbers — the sidecar
+// will then overwrite them on upgrade.
+type LimitsConfig struct {
+	PlanCode         string `yaml:"plan_code"`
+	MaxAgents        int    `yaml:"max_agents"`
+	MaxDomains       int    `yaml:"max_domains"`
+	MaxMessagesMonth int    `yaml:"max_messages_month"`
+	MaxStorageBytes  int64  `yaml:"max_storage_bytes"`
+	// CacheTTLSeconds controls how long resolved Limits are cached
+	// in-process. The cache covers the account_limits read only; current
+	// usage counts are always live. Set to 0 to disable caching
+	// (recommended for tests that mutate account_limits and want
+	// immediate visibility).
+	CacheTTLSeconds int `yaml:"cache_ttl_seconds"`
+}
+
 func Load(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -92,6 +117,17 @@ func Load(path string) (*Config, error) {
 		},
 		HTTP: HTTPConfig{
 			ListenAddr: ":8080",
+		},
+		// Generous defaults so self-host operators who do not configure
+		// `limits:` are not accidentally throttled. Hosted operators
+		// override these in config.prod.yaml.
+		Limits: LimitsConfig{
+			PlanCode:         "default",
+			MaxAgents:        1_000_000,
+			MaxDomains:       1_000_000,
+			MaxMessagesMonth: 1_000_000_000,
+			MaxStorageBytes:  1 << 50, // 1 PiB
+			CacheTTLSeconds:  60,
 		},
 		Env: "development",
 	}

--- a/internal/limits/enforcer.go
+++ b/internal/limits/enforcer.go
@@ -173,14 +173,32 @@ func (e *DBEnforcer) CheckMessageSend(ctx context.Context, userID string) error 
 		return err
 	}
 	if storage >= lim.MaxStorageBytes {
+		// Storage values can exceed int32 (MaxStorageBytes is BIGINT in
+		// the DB and may be 100 GiB+ on Scale). The LimitExceededError
+		// fields are int — that's 32-bit on 32-bit platforms. Clamp via
+		// safeInt64ToInt so we don't roll over on unusual targets; the
+		// real value is also surfaced verbatim in the Limits field for
+		// callers that need bytes-accurate access.
 		return &LimitExceededError{
 			Resource: "storage",
-			Limit:    int(lim.MaxStorageBytes / 1024), // expose in KB for log/UI legibility
-			Current:  int(storage / 1024),
+			Limit:    safeInt64ToInt(lim.MaxStorageBytes),
+			Current:  safeInt64ToInt(storage),
 			Limits:   lim,
 		}
 	}
 	return nil
+}
+
+// safeInt64ToInt clamps an int64 to int.Max{,Min} so a downstream JSON
+// encode never silently produces a negative number from int overflow
+// on 32-bit Go targets. Production runs 64-bit; this is purely
+// defensive against a future 32-bit build (or an ARM32 host).
+func safeInt64ToInt(v int64) int {
+	const maxInt = int64(^uint(0) >> 1)
+	if v > maxInt {
+		return int(maxInt)
+	}
+	return int(v)
 }
 
 func (e *DBEnforcer) cacheGet(userID string) (Limits, bool) {

--- a/internal/limits/enforcer.go
+++ b/internal/limits/enforcer.go
@@ -1,0 +1,213 @@
+package limits
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/Mnexa-AI/e2a/internal/usage"
+)
+
+// Counter is the subset of *usage.Store the enforcer needs. Declared
+// here as an interface so tests can supply a fake without standing up
+// the full usage store.
+type Counter interface {
+	CountAgentsByUser(ctx context.Context, userID string) (int, error)
+	CountDomainsByUser(ctx context.Context, userID string) (int, error)
+	MessagesThisMonth(ctx context.Context, userID string) (int, error)
+	GetStorageBytes(ctx context.Context, userID string) (int64, error)
+}
+
+// limitsReader is the subset of *Store the enforcer needs. Declared as
+// an interface so tests can supply a fake without a real Postgres pool.
+type limitsReader interface {
+	Get(ctx context.Context, userID string) (Limits, bool, error)
+}
+
+// DBEnforcer is the production Enforcer: reads account_limits + falls
+// back to operator Defaults, counts current resources via the usage
+// store, and caches the resolved Limits in-process for cacheTTL to keep
+// hot paths off the DB on every send.
+//
+// The cache only stores the *Limits* (caps), not the *counts*. Counts
+// must always reflect the live database — caching them would mean a
+// just-created agent or just-sent message wouldn't show up until TTL
+// expiry, which would either let users exceed caps or let the dashboard
+// lie about current usage. Reading the count is one bounded query per
+// check; the win from caching limits is avoiding the join into
+// account_limits, which is the costlier read.
+type DBEnforcer struct {
+	store    limitsReader
+	counter  Counter
+	defaults Defaults
+	cacheTTL time.Duration
+
+	mu    sync.Mutex
+	cache map[string]cachedLimits
+}
+
+type cachedLimits struct {
+	limits  Limits
+	expires time.Time
+}
+
+// NewEnforcer constructs the production enforcer. cacheTTL of 0 disables
+// the cache (every Get hits the DB) — useful for tests that mutate
+// account_limits and want immediate visibility.
+func NewEnforcer(store *Store, counter Counter, defaults Defaults, cacheTTL time.Duration) *DBEnforcer {
+	return &DBEnforcer{
+		store:    store,
+		counter:  counter,
+		defaults: defaults,
+		cacheTTL: cacheTTL,
+		cache:    make(map[string]cachedLimits),
+	}
+}
+
+// newEnforcerWithReader is the test seam: lets unit tests inject a fake
+// limitsReader so they don't need a Postgres pool.
+func newEnforcerWithReader(reader limitsReader, counter Counter, defaults Defaults, cacheTTL time.Duration) *DBEnforcer {
+	return &DBEnforcer{
+		store:    reader,
+		counter:  counter,
+		defaults: defaults,
+		cacheTTL: cacheTTL,
+		cache:    make(map[string]cachedLimits),
+	}
+}
+
+func (e *DBEnforcer) Get(ctx context.Context, userID string) (Limits, error) {
+	if cached, ok := e.cacheGet(userID); ok {
+		return cached, nil
+	}
+	row, found, err := e.store.Get(ctx, userID)
+	if err != nil {
+		return Limits{}, err
+	}
+	var resolved Limits
+	if found {
+		resolved = row
+	} else {
+		resolved = Limits{
+			PlanCode:         e.defaults.PlanCode,
+			MaxAgents:        e.defaults.MaxAgents,
+			MaxDomains:       e.defaults.MaxDomains,
+			MaxMessagesMonth: e.defaults.MaxMessagesMonth,
+			MaxStorageBytes:  e.defaults.MaxStorageBytes,
+		}
+	}
+	e.cachePut(userID, resolved)
+	return resolved, nil
+}
+
+func (e *DBEnforcer) Invalidate(userID string) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	delete(e.cache, userID)
+}
+
+func (e *DBEnforcer) CheckAgentCreate(ctx context.Context, userID string) error {
+	lim, err := e.Get(ctx, userID)
+	if err != nil {
+		return err
+	}
+	count, err := e.counter.CountAgentsByUser(ctx, userID)
+	if err != nil {
+		return err
+	}
+	if count >= lim.MaxAgents {
+		return &LimitExceededError{
+			Resource: "agents",
+			Limit:    lim.MaxAgents,
+			Current:  count,
+			Limits:   lim,
+		}
+	}
+	return nil
+}
+
+func (e *DBEnforcer) CheckDomainCreate(ctx context.Context, userID string) error {
+	lim, err := e.Get(ctx, userID)
+	if err != nil {
+		return err
+	}
+	count, err := e.counter.CountDomainsByUser(ctx, userID)
+	if err != nil {
+		return err
+	}
+	if count >= lim.MaxDomains {
+		return &LimitExceededError{
+			Resource: "domains",
+			Limit:    lim.MaxDomains,
+			Current:  count,
+			Limits:   lim,
+		}
+	}
+	return nil
+}
+
+// CheckMessageSend enforces both the month-flow cap and the storage
+// stock cap. Either being exceeded blocks the operation. The flow cap
+// is checked first because it's the cheaper read; if both would fail,
+// the user sees "messages" as the reason, which is the easier one to
+// explain ("you sent N this month").
+func (e *DBEnforcer) CheckMessageSend(ctx context.Context, userID string) error {
+	lim, err := e.Get(ctx, userID)
+	if err != nil {
+		return err
+	}
+	msgCount, err := e.counter.MessagesThisMonth(ctx, userID)
+	if err != nil {
+		return err
+	}
+	if msgCount >= lim.MaxMessagesMonth {
+		return &LimitExceededError{
+			Resource: "messages",
+			Limit:    lim.MaxMessagesMonth,
+			Current:  msgCount,
+			Limits:   lim,
+		}
+	}
+	storage, err := e.counter.GetStorageBytes(ctx, userID)
+	if err != nil {
+		return err
+	}
+	if storage >= lim.MaxStorageBytes {
+		return &LimitExceededError{
+			Resource: "storage",
+			Limit:    int(lim.MaxStorageBytes / 1024), // expose in KB for log/UI legibility
+			Current:  int(storage / 1024),
+			Limits:   lim,
+		}
+	}
+	return nil
+}
+
+func (e *DBEnforcer) cacheGet(userID string) (Limits, bool) {
+	if e.cacheTTL <= 0 {
+		return Limits{}, false
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	c, ok := e.cache[userID]
+	if !ok || time.Now().After(c.expires) {
+		return Limits{}, false
+	}
+	return c.limits, true
+}
+
+func (e *DBEnforcer) cachePut(userID string, l Limits) {
+	if e.cacheTTL <= 0 {
+		return
+	}
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.cache[userID] = cachedLimits{limits: l, expires: time.Now().Add(e.cacheTTL)}
+}
+
+// Compile-time check: DBEnforcer satisfies the Enforcer interface and
+// the Counter dependency is satisfied by *usage.Store.
+var (
+	_ Enforcer = (*DBEnforcer)(nil)
+	_ Counter  = (*usage.Store)(nil)
+)

--- a/internal/limits/http.go
+++ b/internal/limits/http.go
@@ -1,0 +1,53 @@
+package limits
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// LimitErrorBody is the JSON payload returned with HTTP 402 when a
+// Check* call surfaces a *LimitExceededError. Handlers MUST use this
+// shape so the dashboard and SDK clients can render a uniform "you hit
+// a cap, here's how to upgrade" affordance regardless of which limit
+// fired. plan_code is the opaque label written by the external limits
+// provisioner; upgrade_url is empty when no provisioner has supplied
+// one.
+type LimitErrorBody struct {
+	Error      string `json:"error"`      // human-readable message
+	Resource   string `json:"resource"`   // "agents" | "domains" | "messages" | "storage"
+	Limit      int    `json:"limit"`      // cap that was hit
+	Current    int    `json:"current"`    // the user's current count for that resource
+	PlanCode   string `json:"plan_code"`  // opaque label from account_limits
+	UpgradeURL string `json:"upgrade_url"`// optional URL to surface in the dashboard
+}
+
+// WriteLimitError writes a 402 Payment Required response with the
+// LimitErrorBody payload. Centralized here so every Check* call site in
+// HTTP handlers can convert the typed error uniformly:
+//
+//	if err := enforcer.CheckAgentCreate(ctx, userID); err != nil {
+//	    if limits.WriteLimitError(w, err) { return }
+//	    // some other DB error — propagate as 5xx
+//	}
+//
+// Returns true when err was a *LimitExceededError and a 402 was
+// written; false when the error was something else (caller must handle
+// it themselves, typically as 5xx).
+func WriteLimitError(w http.ResponseWriter, err error) bool {
+	le, ok := IsLimitExceeded(err)
+	if !ok {
+		return false
+	}
+	body := LimitErrorBody{
+		Error:      le.Error(),
+		Resource:   le.Resource,
+		Limit:      le.Limit,
+		Current:    le.Current,
+		PlanCode:   le.Limits.PlanCode,
+		UpgradeURL: le.Limits.UpgradeURL,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusPaymentRequired)
+	_ = json.NewEncoder(w).Encode(body)
+	return true
+}

--- a/internal/limits/http.go
+++ b/internal/limits/http.go
@@ -13,10 +13,16 @@ import (
 // provisioner; upgrade_url is empty when no provisioner has supplied
 // one.
 type LimitErrorBody struct {
-	Error      string `json:"error"`      // human-readable message
-	Resource   string `json:"resource"`   // "agents" | "domains" | "messages" | "storage"
-	Limit      int    `json:"limit"`      // cap that was hit
-	Current    int    `json:"current"`    // the user's current count for that resource
+	Error    string `json:"error"`    // human-readable message
+	Resource string `json:"resource"` // "agents" | "domains" | "messages" | "storage"
+	// Limit + Current are RAW counts in the resource's natural unit:
+	// integer count for agents/domains/messages, **bytes** for storage.
+	// SDK consumers should treat them as opaque and format per
+	// resource. An earlier revision returned storage values in KB,
+	// which is inconsistent with every other resource — fixed in
+	// favor of bytes-everywhere.
+	Limit      int    `json:"limit"`
+	Current    int    `json:"current"`
 	PlanCode   string `json:"plan_code"`  // opaque label from account_limits
 	UpgradeURL string `json:"upgrade_url"`// optional URL to surface in the dashboard
 }

--- a/internal/limits/integration_test.go
+++ b/internal/limits/integration_test.go
@@ -1,0 +1,152 @@
+package limits_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/limits"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+	"github.com/Mnexa-AI/e2a/internal/usage"
+)
+
+// These tests exercise the real Postgres trigger + account_limits + the
+// enforcer end to end. They live behind testutil.TestDB so they're part
+// of the integration tier (skipped when no DB is reachable).
+
+func setupLimitsUser(t *testing.T, name string) (*pgxpool.Pool, *identity.Store, *usage.Store, *identity.AgentIdentity, string) {
+	t.Helper()
+	pool := testutil.TestDB(t)
+	idStore := identity.NewStore(pool)
+	usageStore := usage.NewStore(pool)
+	ctx := context.Background()
+
+	user, err := idStore.CreateOrGetUser(ctx, name+"@limits.test", name, "google-sub-"+name)
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	if _, err := idStore.ClaimOrCreateDomain(ctx, name+".example.com", user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+	agent, err := idStore.CreateAgent(ctx, "bot@"+name+".example.com", name+".example.com", "", "https://example.com/w", "cloud", user.ID)
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	return pool, idStore, usageStore, agent, user.ID
+}
+
+func TestStorageTrigger_IncrementsOnInsert(t *testing.T) {
+	_, idStore, usageStore, agent, userID := setupLimitsUser(t, "stg1")
+	ctx := context.Background()
+
+	// Outbound row has no raw_message / body_*, so storage delta is 0
+	// for the subject column (subject isn't in the trigger's size sum).
+	// Use the HITL pending-outbound path to exercise body_text/body_html.
+	attachJSON := []byte(`[{"filename":"a.txt","content_type":"text/plain","data":"aGVsbG8="}]`)
+	_, err := idStore.CreatePendingOutboundMessage(ctx, agent.ID,
+		[]string{"alice@example.com"}, nil, nil,
+		"hi", "body text here", "<p>body html here</p>", attachJSON,
+		"send", "", "", 60,
+	)
+	if err != nil {
+		t.Fatalf("CreatePendingOutboundMessage: %v", err)
+	}
+
+	got, err := usageStore.GetStorageBytes(ctx, userID)
+	if err != nil {
+		t.Fatalf("GetStorageBytes: %v", err)
+	}
+	wantAtLeast := int64(len("body text here") + len("<p>body html here</p>") + len(attachJSON))
+	if got < wantAtLeast {
+		t.Errorf("storage_bytes = %d, want >= %d", got, wantAtLeast)
+	}
+}
+
+func TestStorageTrigger_DecrementsOnDelete(t *testing.T) {
+	pool, idStore, usageStore, agent, userID := setupLimitsUser(t, "stg2")
+	ctx := context.Background()
+
+	msg, err := idStore.CreatePendingOutboundMessage(ctx, agent.ID,
+		[]string{"alice@example.com"}, nil, nil,
+		"hi", "some body text", "", nil,
+		"send", "", "", 60,
+	)
+	if err != nil {
+		t.Fatalf("CreatePendingOutboundMessage: %v", err)
+	}
+
+	before, _ := usageStore.GetStorageBytes(ctx, userID)
+	if before == 0 {
+		t.Fatalf("storage_bytes did not increment on insert (got 0)")
+	}
+
+	// Hard-delete the message to fire the AFTER DELETE trigger. We use
+	// raw SQL because the public store API only soft-expires; the
+	// trigger correctness for hard deletes (retention sweep, cascade)
+	// is what we want to verify.
+	if _, err := pool.Exec(ctx, `DELETE FROM messages WHERE id = $1`, msg.ID); err != nil {
+		t.Fatalf("DELETE: %v", err)
+	}
+
+	after, _ := usageStore.GetStorageBytes(ctx, userID)
+	if after >= before {
+		t.Errorf("storage_bytes = %d after delete, want < %d", after, before)
+	}
+}
+
+func TestEnforcer_BlocksAtAgentCap_RealDB(t *testing.T) {
+	pool, idStore, usageStore, _, userID := setupLimitsUser(t, "agentcap")
+	ctx := context.Background()
+
+	limitsStore := limits.NewStore(pool)
+	// Write a tight cap directly: the user already has 1 agent (from
+	// fixture). max_agents=1 means the next create should be blocked.
+	if err := limitsStore.Upsert(ctx, userID, limits.Limits{
+		PlanCode: "test", MaxAgents: 1, MaxDomains: 100,
+		MaxMessagesMonth: 1_000_000, MaxStorageBytes: 1 << 40,
+	}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	enf := limits.NewEnforcer(limitsStore, usageStore, limits.Defaults{
+		PlanCode: "default", MaxAgents: 1_000_000, MaxDomains: 1_000_000,
+		MaxMessagesMonth: 1_000_000_000, MaxStorageBytes: 1 << 50,
+	}, 0)
+
+	err := enf.CheckAgentCreate(ctx, userID)
+	le, ok := limits.IsLimitExceeded(err)
+	if !ok {
+		t.Fatalf("CheckAgentCreate at 1/1 cap: got %v, want LimitExceededError", err)
+	}
+	if le.Resource != "agents" || le.Limit != 1 || le.Current != 1 {
+		t.Errorf("LimitExceeded = %+v, want agents 1/1", le)
+	}
+	if le.Limits.PlanCode != "test" {
+		t.Errorf("PlanCode = %q, want test", le.Limits.PlanCode)
+	}
+
+	// Sanity: a fresh agent insert via the real store should succeed
+	// when limits are loosened.
+	if err := limitsStore.Upsert(ctx, userID, limits.Limits{
+		PlanCode: "test", MaxAgents: 5, MaxDomains: 100,
+		MaxMessagesMonth: 1_000_000, MaxStorageBytes: 1 << 40,
+	}); err != nil {
+		t.Fatalf("Upsert (loosen): %v", err)
+	}
+	enf.Invalidate(userID)
+	if err := enf.CheckAgentCreate(ctx, userID); err != nil {
+		t.Errorf("CheckAgentCreate after loosen: %v, want nil", err)
+	}
+
+	// Side check: limits row is visible via Get.
+	got, found, err := limitsStore.Get(ctx, userID)
+	if err != nil || !found {
+		t.Fatalf("Get: err=%v found=%v", err, found)
+	}
+	if got.MaxAgents != 5 {
+		t.Errorf("Get MaxAgents = %d, want 5", got.MaxAgents)
+	}
+	_ = idStore // keeps the fixture-imported store referenced
+}

--- a/internal/limits/integration_test.go
+++ b/internal/limits/integration_test.go
@@ -13,11 +13,16 @@ import (
 )
 
 // These tests exercise the real Postgres trigger + account_limits + the
-// enforcer end to end. They live behind testutil.TestDB so they're part
-// of the integration tier (skipped when no DB is reachable).
+// enforcer end to end. They share the test database with other DB-using
+// packages, so we skip under `go test -short` (used by `make test-unit`)
+// to avoid trampling concurrent-package state. `make test-integration`
+// runs without -short and serializes packages with -p 1.
 
 func setupLimitsUser(t *testing.T, name string) (*pgxpool.Pool, *identity.Store, *usage.Store, *identity.AgentIdentity, string) {
 	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping DB-backed limits test under -short")
+	}
 	pool := testutil.TestDB(t)
 	idStore := identity.NewStore(pool)
 	usageStore := usage.NewStore(pool)

--- a/internal/limits/limits.go
+++ b/internal/limits/limits.go
@@ -1,0 +1,93 @@
+// Package limits enforces per-user resource caps at the agent-create,
+// domain-register, and message-send paths.
+//
+// The OSS server is intentionally agnostic about what those caps mean.
+// A row in account_limits is the contract; whatever populates it (the
+// hosted-service sidecar, an admin tool, a self-host operator with SQL
+// access) owns the semantics of plan_code and upgrade_url. The OSS
+// server only enforces the integer caps and echoes the opaque label.
+//
+// When no row exists for a user, the enforcer falls back to the
+// operator-configured Defaults (config.yaml `limits:` block). Self-host
+// operators who do not want any cap can leave Defaults at MaxInt32.
+package limits
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// Limits is the resolved per-user cap set: either read from
+// account_limits or filled from operator Defaults when no row exists.
+type Limits struct {
+	PlanCode         string `json:"plan_code"`
+	MaxAgents        int    `json:"max_agents"`
+	MaxDomains       int    `json:"max_domains"`
+	MaxMessagesMonth int    `json:"max_messages_month"`
+	MaxStorageBytes  int64  `json:"max_storage_bytes"`
+	UpgradeURL       string `json:"upgrade_url"`
+}
+
+// Defaults is the operator-configured fallback applied when a user has
+// no account_limits row. It is also returned verbatim from Get for
+// brand-new users so the dashboard has something to render.
+type Defaults struct {
+	PlanCode         string
+	MaxAgents        int
+	MaxDomains       int
+	MaxMessagesMonth int
+	MaxStorageBytes  int64
+}
+
+// Enforcer is the interface that handlers call. Implementations must be
+// safe for concurrent use.
+type Enforcer interface {
+	// Get returns the resolved Limits for the user. Never returns
+	// ErrLimitExceeded; that error is reserved for the Check methods.
+	Get(ctx context.Context, userID string) (Limits, error)
+
+	// CheckAgentCreate returns nil if the user may create another agent,
+	// or *LimitExceededError if they have already hit the cap.
+	CheckAgentCreate(ctx context.Context, userID string) error
+
+	// CheckDomainCreate returns nil if the user may register another
+	// domain, or *LimitExceededError if they have already hit the cap.
+	CheckDomainCreate(ctx context.Context, userID string) error
+
+	// CheckMessageSend returns nil if the user may send/receive another
+	// message this calendar month, or *LimitExceededError if they have
+	// already hit the cap. Counts inbound+outbound in the current UTC
+	// month against MaxMessagesMonth.
+	CheckMessageSend(ctx context.Context, userID string) error
+
+	// Invalidate evicts the user's cached Limits so the next Get/Check
+	// re-reads from the database. Called by the limits-invalidate HTTP
+	// endpoint when an external writer (e.g. billing sidecar) has just
+	// updated account_limits.
+	Invalidate(userID string)
+}
+
+// LimitExceededError is returned by Check* methods when the user has
+// reached a cap. Handlers convert it to HTTP 402 with the Limits payload
+// so the dashboard can show the current cap and any upgrade affordance.
+type LimitExceededError struct {
+	Resource string // "agents" | "domains" | "messages"
+	Limit    int    // the cap that was hit
+	Current  int    // the user's current count (counts vary by resource)
+	Limits   Limits // full resolved limits for upgrade-URL rendering
+}
+
+func (e *LimitExceededError) Error() string {
+	return fmt.Sprintf("limits: %s cap reached (%d/%d)", e.Resource, e.Current, e.Limit)
+}
+
+// IsLimitExceeded reports whether err is a *LimitExceededError, and
+// returns it if so. Callers convert the typed error to HTTP 402.
+func IsLimitExceeded(err error) (*LimitExceededError, bool) {
+	var le *LimitExceededError
+	if errors.As(err, &le) {
+		return le, true
+	}
+	return nil, false
+}

--- a/internal/limits/limits_test.go
+++ b/internal/limits/limits_test.go
@@ -221,6 +221,14 @@ func TestCheckMessageSend_BlocksOnStorage(t *testing.T) {
 	if le.Resource != "storage" {
 		t.Errorf("Resource = %q, want storage", le.Resource)
 	}
+	// Storage values come through as RAW BYTES (not KB) per the
+	// resource-natural-unit contract documented on LimitErrorBody.
+	if le.Limit != 1024*1024 {
+		t.Errorf("Limit = %d, want %d (bytes)", le.Limit, 1024*1024)
+	}
+	if le.Current != 1024*1024 {
+		t.Errorf("Current = %d, want %d (bytes)", le.Current, 1024*1024)
+	}
 }
 
 func TestCheckMessageSend_MonthCapTakesPrecedenceOverStorage(t *testing.T) {

--- a/internal/limits/limits_test.go
+++ b/internal/limits/limits_test.go
@@ -1,0 +1,268 @@
+package limits
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeStore implements limitsReader. Test stubs use this to control
+// what Get returns without standing up Postgres.
+type fakeStore struct {
+	mu    sync.Mutex
+	row   Limits
+	found bool
+	err   error
+	calls int
+}
+
+func (f *fakeStore) Get(ctx context.Context, userID string) (Limits, bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	return f.row, f.found, f.err
+}
+
+// fakeCounter implements Counter. Counts and storage are set directly
+// by the test; calls increment so tests can assert no-cache behaviour
+// on the count side.
+type fakeCounter struct {
+	mu              sync.Mutex
+	agents          int
+	domains         int
+	messagesMonth   int
+	storageBytes    int64
+	countAgentsErr  error
+	countDomainsErr error
+	messagesErr     error
+	storageErr      error
+}
+
+func (f *fakeCounter) CountAgentsByUser(ctx context.Context, userID string) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.agents, f.countAgentsErr
+}
+func (f *fakeCounter) CountDomainsByUser(ctx context.Context, userID string) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.domains, f.countDomainsErr
+}
+func (f *fakeCounter) MessagesThisMonth(ctx context.Context, userID string) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.messagesMonth, f.messagesErr
+}
+func (f *fakeCounter) GetStorageBytes(ctx context.Context, userID string) (int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.storageBytes, f.storageErr
+}
+
+func defaultsForTest() Defaults {
+	return Defaults{
+		PlanCode:         "default",
+		MaxAgents:        5,
+		MaxDomains:       2,
+		MaxMessagesMonth: 100,
+		MaxStorageBytes:  10_000,
+	}
+}
+
+func TestEnforcer_GetFallsBackToDefaultsWhenNoRow(t *testing.T) {
+	store := &fakeStore{found: false}
+	counter := &fakeCounter{}
+	e := newEnforcerWithReader(store, counter, defaultsForTest(), 0)
+
+	got, err := e.Get(context.Background(), "user1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.MaxAgents != 5 || got.MaxDomains != 2 || got.MaxMessagesMonth != 100 || got.MaxStorageBytes != 10_000 {
+		t.Errorf("Get fallback = %+v, want defaults", got)
+	}
+	if got.PlanCode != "default" {
+		t.Errorf("PlanCode = %q, want default", got.PlanCode)
+	}
+	if got.UpgradeURL != "" {
+		t.Errorf("UpgradeURL = %q on fallback, want empty", got.UpgradeURL)
+	}
+}
+
+func TestEnforcer_GetReturnsRowWhenPresent(t *testing.T) {
+	row := Limits{
+		PlanCode: "pro", MaxAgents: 50, MaxDomains: 10,
+		MaxMessagesMonth: 50_000, MaxStorageBytes: 10 << 30,
+		UpgradeURL: "https://billing.example/portal",
+	}
+	store := &fakeStore{row: row, found: true}
+	counter := &fakeCounter{}
+	e := newEnforcerWithReader(store, counter, defaultsForTest(), 0)
+
+	got, err := e.Get(context.Background(), "user1")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != row {
+		t.Errorf("Get = %+v, want %+v", got, row)
+	}
+}
+
+func TestEnforcer_GetPropagatesStoreError(t *testing.T) {
+	sentinel := errors.New("db down")
+	store := &fakeStore{err: sentinel}
+	e := newEnforcerWithReader(store, &fakeCounter{}, defaultsForTest(), 0)
+
+	_, err := e.Get(context.Background(), "user1")
+	if !errors.Is(err, sentinel) {
+		t.Errorf("Get error = %v, want %v", err, sentinel)
+	}
+}
+
+func TestEnforcer_CacheServesFromMemoryWithinTTL(t *testing.T) {
+	store := &fakeStore{found: true, row: Limits{PlanCode: "p", MaxAgents: 1, MaxDomains: 1, MaxMessagesMonth: 1, MaxStorageBytes: 1}}
+	e := newEnforcerWithReader(store, &fakeCounter{}, defaultsForTest(), time.Minute)
+
+	for i := 0; i < 5; i++ {
+		if _, err := e.Get(context.Background(), "user1"); err != nil {
+			t.Fatalf("Get: %v", err)
+		}
+	}
+	if store.calls != 1 {
+		t.Errorf("store hit %d times, want 1 (cache should serve subsequent)", store.calls)
+	}
+}
+
+func TestEnforcer_InvalidateClearsCachedRow(t *testing.T) {
+	store := &fakeStore{found: true, row: Limits{MaxAgents: 1, MaxDomains: 1, MaxMessagesMonth: 1, MaxStorageBytes: 1}}
+	e := newEnforcerWithReader(store, &fakeCounter{}, defaultsForTest(), time.Minute)
+
+	_, _ = e.Get(context.Background(), "user1")
+	e.Invalidate("user1")
+	_, _ = e.Get(context.Background(), "user1")
+	if store.calls != 2 {
+		t.Errorf("store hit %d times after invalidate, want 2", store.calls)
+	}
+}
+
+func TestCheckAgentCreate_AllowsBelowCap(t *testing.T) {
+	store := &fakeStore{found: true, row: Limits{MaxAgents: 3, MaxDomains: 1, MaxMessagesMonth: 1, MaxStorageBytes: 1}}
+	counter := &fakeCounter{agents: 2}
+	e := newEnforcerWithReader(store, counter, defaultsForTest(), 0)
+
+	if err := e.CheckAgentCreate(context.Background(), "user1"); err != nil {
+		t.Errorf("CheckAgentCreate at 2/3: %v, want nil", err)
+	}
+}
+
+func TestCheckAgentCreate_BlocksAtCap(t *testing.T) {
+	store := &fakeStore{found: true, row: Limits{PlanCode: "free", MaxAgents: 3, MaxDomains: 1, MaxMessagesMonth: 1, MaxStorageBytes: 1, UpgradeURL: "https://up"}}
+	counter := &fakeCounter{agents: 3}
+	e := newEnforcerWithReader(store, counter, defaultsForTest(), 0)
+
+	err := e.CheckAgentCreate(context.Background(), "user1")
+	le, ok := IsLimitExceeded(err)
+	if !ok {
+		t.Fatalf("CheckAgentCreate at cap = %v, want LimitExceededError", err)
+	}
+	if le.Resource != "agents" {
+		t.Errorf("Resource = %q, want agents", le.Resource)
+	}
+	if le.Limit != 3 || le.Current != 3 {
+		t.Errorf("Limit/Current = %d/%d, want 3/3", le.Limit, le.Current)
+	}
+	if le.Limits.UpgradeURL != "https://up" {
+		t.Errorf("UpgradeURL not propagated to error: %q", le.Limits.UpgradeURL)
+	}
+}
+
+func TestCheckDomainCreate_BlocksAtCap(t *testing.T) {
+	store := &fakeStore{found: true, row: Limits{MaxAgents: 100, MaxDomains: 1, MaxMessagesMonth: 1, MaxStorageBytes: 1}}
+	counter := &fakeCounter{domains: 1}
+	e := newEnforcerWithReader(store, counter, defaultsForTest(), 0)
+
+	err := e.CheckDomainCreate(context.Background(), "user1")
+	le, ok := IsLimitExceeded(err)
+	if !ok {
+		t.Fatalf("CheckDomainCreate at cap = %v, want LimitExceededError", err)
+	}
+	if le.Resource != "domains" {
+		t.Errorf("Resource = %q, want domains", le.Resource)
+	}
+}
+
+func TestCheckMessageSend_BlocksOnMonthFlow(t *testing.T) {
+	store := &fakeStore{found: true, row: Limits{MaxAgents: 100, MaxDomains: 100, MaxMessagesMonth: 1000, MaxStorageBytes: 1 << 40}}
+	counter := &fakeCounter{messagesMonth: 1000, storageBytes: 0}
+	e := newEnforcerWithReader(store, counter, defaultsForTest(), 0)
+
+	err := e.CheckMessageSend(context.Background(), "user1")
+	le, ok := IsLimitExceeded(err)
+	if !ok {
+		t.Fatalf("CheckMessageSend at month cap = %v, want LimitExceededError", err)
+	}
+	if le.Resource != "messages" {
+		t.Errorf("Resource = %q, want messages", le.Resource)
+	}
+}
+
+func TestCheckMessageSend_BlocksOnStorage(t *testing.T) {
+	store := &fakeStore{found: true, row: Limits{MaxAgents: 100, MaxDomains: 100, MaxMessagesMonth: 1_000_000, MaxStorageBytes: 1024 * 1024}}
+	counter := &fakeCounter{messagesMonth: 10, storageBytes: 1024 * 1024}
+	e := newEnforcerWithReader(store, counter, defaultsForTest(), 0)
+
+	err := e.CheckMessageSend(context.Background(), "user1")
+	le, ok := IsLimitExceeded(err)
+	if !ok {
+		t.Fatalf("CheckMessageSend at storage cap = %v, want LimitExceededError", err)
+	}
+	if le.Resource != "storage" {
+		t.Errorf("Resource = %q, want storage", le.Resource)
+	}
+}
+
+func TestCheckMessageSend_MonthCapTakesPrecedenceOverStorage(t *testing.T) {
+	// Both caps hit; the enforcer reports the cheaper-to-explain one.
+	store := &fakeStore{found: true, row: Limits{MaxAgents: 100, MaxDomains: 100, MaxMessagesMonth: 1000, MaxStorageBytes: 1024}}
+	counter := &fakeCounter{messagesMonth: 1000, storageBytes: 1024}
+	e := newEnforcerWithReader(store, counter, defaultsForTest(), 0)
+
+	err := e.CheckMessageSend(context.Background(), "user1")
+	le, ok := IsLimitExceeded(err)
+	if !ok {
+		t.Fatalf("want LimitExceededError")
+	}
+	if le.Resource != "messages" {
+		t.Errorf("Resource = %q, want messages", le.Resource)
+	}
+}
+
+func TestLimitExceededError_FormatsResourceAndCounts(t *testing.T) {
+	e := &LimitExceededError{Resource: "agents", Limit: 3, Current: 3}
+	if got := e.Error(); got != "limits: agents cap reached (3/3)" {
+		t.Errorf("Error() = %q", got)
+	}
+}
+
+func TestIsLimitExceeded_WrappedError(t *testing.T) {
+	base := &LimitExceededError{Resource: "agents", Limit: 1, Current: 1}
+	wrapped := wrap(base)
+	got, ok := IsLimitExceeded(wrapped)
+	if !ok || got != base {
+		t.Errorf("IsLimitExceeded did not unwrap: ok=%v got=%v", ok, got)
+	}
+}
+
+// wrap exists to test errors.As traversal through fmt.Errorf chains —
+// real callers will commonly wrap with context.
+func wrap(err error) error {
+	type wrapper struct{ inner error }
+	return &wrappedErr{inner: err}
+}
+
+type wrappedErr struct{ inner error }
+
+func (w *wrappedErr) Error() string { return "wrapped: " + w.inner.Error() }
+func (w *wrappedErr) Unwrap() error { return w.inner }

--- a/internal/limits/store.go
+++ b/internal/limits/store.go
@@ -1,0 +1,63 @@
+package limits
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Store wraps account_limits row access. Writes are intended for
+// external provisioners (the hosted billing sidecar, admin tooling);
+// the OSS server itself only reads.
+type Store struct {
+	pool *pgxpool.Pool
+}
+
+func NewStore(pool *pgxpool.Pool) *Store {
+	return &Store{pool: pool}
+}
+
+// Get returns the user's row from account_limits. Returns (Limits{},
+// pgx.ErrNoRows, false) when no row exists so callers can apply
+// operator-configured defaults — distinguishing "no row" from "real DB
+// error" is important: a transient DB hiccup must fail closed, while a
+// genuinely-missing row is the normal case for a fresh user.
+func (s *Store) Get(ctx context.Context, userID string) (Limits, bool, error) {
+	l := Limits{}
+	err := s.pool.QueryRow(ctx,
+		`SELECT plan_code, max_agents, max_domains, max_messages_month, max_storage_bytes, upgrade_url
+		   FROM account_limits WHERE user_id = $1`, userID,
+	).Scan(&l.PlanCode, &l.MaxAgents, &l.MaxDomains, &l.MaxMessagesMonth, &l.MaxStorageBytes, &l.UpgradeURL)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Limits{}, false, nil
+		}
+		return Limits{}, false, err
+	}
+	return l, true, nil
+}
+
+// Upsert writes/overwrites the user's row. Only used by external
+// provisioners; not invoked from any OSS request path. Exposed here so
+// the future internal-limits-invalidate endpoint can also serve as a
+// minimal "set limits" API for the sidecar without that code reaching
+// into the table directly.
+func (s *Store) Upsert(ctx context.Context, userID string, l Limits) error {
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO account_limits
+		    (user_id, plan_code, max_agents, max_domains, max_messages_month, max_storage_bytes, upgrade_url, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, now())
+		 ON CONFLICT (user_id) DO UPDATE SET
+		    plan_code          = EXCLUDED.plan_code,
+		    max_agents         = EXCLUDED.max_agents,
+		    max_domains        = EXCLUDED.max_domains,
+		    max_messages_month = EXCLUDED.max_messages_month,
+		    max_storage_bytes  = EXCLUDED.max_storage_bytes,
+		    upgrade_url        = EXCLUDED.upgrade_url,
+		    updated_at         = now()`,
+		userID, l.PlanCode, l.MaxAgents, l.MaxDomains, l.MaxMessagesMonth, l.MaxStorageBytes, l.UpgradeURL,
+	)
+	return err
+}

--- a/internal/relay/inbound_limit_test.go
+++ b/internal/relay/inbound_limit_test.go
@@ -1,0 +1,228 @@
+package relay_test
+
+import (
+	"context"
+	"net"
+	"net/smtp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mnexa-AI/e2a/internal/config"
+	"github.com/Mnexa-AI/e2a/internal/headers"
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/limits"
+	"github.com/Mnexa-AI/e2a/internal/relay"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+	"github.com/Mnexa-AI/e2a/internal/usage"
+	"github.com/Mnexa-AI/e2a/internal/webhook"
+	"github.com/Mnexa-AI/e2a/internal/ws"
+)
+
+// Integration test for the SMTP-level enforcement path: when the
+// recipient's owner has hit a message-flow or storage cap, RCPT TO
+// must be rejected with SMTP 552 ("mailbox quota exceeded") so the
+// upstream MTA bounces the message back to the original sender.
+//
+// This is the inbound counterpart to the HTTP 402 wiring tests in
+// internal/agent/. Skipped under -short because it needs a real DB
+// and an actual SMTP socket bind.
+
+func TestRelay_RcptTo_Rejects552WhenOverCap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SMTP integration test under -short")
+	}
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	store := identity.NewStore(pool)
+
+	// Seed a user + verified domain + agent. The agent's owner is the
+	// user_id the enforcer will look up.
+	user, err := store.CreateOrGetUser(ctx, "relay-cap@test.com", "Test", "google-relay-cap@test.com")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	if _, err := store.ClaimOrCreateDomain(ctx, "relay-cap.example.com", user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+	// Flip verified so the domain-not-verified guard doesn't fire
+	// first (Rcpt() checks DomainVerified before the limits check).
+	if _, err := pool.Exec(ctx, `UPDATE domains SET verified = true WHERE domain = $1`, "relay-cap.example.com"); err != nil {
+		t.Fatalf("verify domain: %v", err)
+	}
+	agentEmail := "bot@relay-cap.example.com"
+	if _, err := store.CreateAgent(ctx, agentEmail, "relay-cap.example.com", "", "https://example.com/w", "cloud", user.ID); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	// Block the user via account_limits — max_messages_month=0 makes
+	// the next CheckMessageSend trip immediately.
+	lstore := limits.NewStore(pool)
+	if err := lstore.Upsert(ctx, user.ID, limits.Limits{
+		PlanCode:         "free_test",
+		MaxAgents:        100,
+		MaxDomains:       100,
+		MaxMessagesMonth: 0,
+		MaxStorageBytes:  1 << 40,
+	}); err != nil {
+		t.Fatalf("Upsert limits: %v", err)
+	}
+
+	// Stand up a real relay.Server on an ephemeral port. Need an HMAC
+	// signing secret long enough for non-production wiring (32+ bytes).
+	signer := headers.NewSigner("test-relay-hmac-key-32-bytes-long!")
+	cfg := &config.Config{
+		SMTP: config.SMTPConfig{
+			ListenAddr: "127.0.0.1:0", // ephemeral
+			Domain:     "test.relay",
+		},
+		Env: "development",
+	}
+	// usage tracker + webhook deliverer + ws hub aren't relevant for
+	// the RCPT path under test; pass benign defaults.
+	deliverer := webhook.NewPersistentDeliverer(webhook.NewDeliverer(false), webhook.NewDeliveryStore(pool))
+	server := relay.NewServer(cfg, store, signer, deliverer, usage.NewNoopUsageTracker(), ws.NewHub())
+	enf := limits.NewEnforcer(lstore, usage.NewStore(pool), limits.Defaults{
+		PlanCode: "default", MaxAgents: 1, MaxDomains: 1, MaxMessagesMonth: 1, MaxStorageBytes: 1,
+	}, 0)
+	server.SetEnforcer(enf)
+
+	// ListenAndServe blocks; run it in a goroutine. We don't have a
+	// public accessor for the port the OS picked, so we open the
+	// listener ourselves, hand it to the server, and read the addr.
+	// Simpler: bind a free port up front and pass via config.
+	port, err := freePort()
+	if err != nil {
+		t.Fatalf("freePort: %v", err)
+	}
+	cfg.SMTP.ListenAddr = "127.0.0.1:" + port
+	// Rebuild server with the resolved port (NewServer copies ListenAddr).
+	server = relay.NewServer(cfg, store, signer, deliverer, usage.NewNoopUsageTracker(), ws.NewHub())
+	server.SetEnforcer(enf)
+
+	listenErrCh := make(chan error, 1)
+	go func() { listenErrCh <- server.ListenAndServe() }()
+	t.Cleanup(func() { _ = server.Close() })
+
+	// Wait for the server to be ready to accept. Poll the port up to
+	// 2s — the SMTP banner write is fast once the listener is bound.
+	deadline := time.Now().Add(2 * time.Second)
+	var conn net.Conn
+	for time.Now().Before(deadline) {
+		conn, err = net.Dial("tcp", cfg.SMTP.ListenAddr)
+		if err == nil {
+			conn.Close()
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("server never accepted on %s: %v", cfg.SMTP.ListenAddr, err)
+	}
+
+	// Open an SMTP client and run the handshake. Rcpt() should reject
+	// with 552 because the user is at message cap.
+	c, err := smtp.Dial(cfg.SMTP.ListenAddr)
+	if err != nil {
+		t.Fatalf("smtp.Dial: %v", err)
+	}
+	defer c.Close()
+
+	if err := c.Mail("sender@elsewhere.test"); err != nil {
+		t.Fatalf("MAIL FROM: %v", err)
+	}
+	err = c.Rcpt(agentEmail)
+	if err == nil {
+		t.Fatal("RCPT TO succeeded; expected 552 cap rejection")
+	}
+	// net/smtp error message looks like "552 5.2.2 mailbox quota exceeded".
+	msg := err.Error()
+	if !strings.Contains(msg, "552") {
+		t.Errorf("RCPT TO error = %q, want it to contain '552'", msg)
+	}
+	if !strings.Contains(strings.ToLower(msg), "quota") {
+		t.Errorf("RCPT TO error = %q, want it to mention 'quota'", msg)
+	}
+}
+
+// freePort asks the OS for a port, closes the listener so the relay
+// can bind to it. Race-prone in theory (another process could grab
+// it between us closing and the relay binding) but fine for tests.
+func freePort() (string, error) {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", err
+	}
+	defer l.Close()
+	_, p, err := net.SplitHostPort(l.Addr().String())
+	return p, err
+}
+
+// TestRelay_RcptTo_AcceptsWhenUnderCap is the happy-path baseline —
+// proves the test setup doesn't falsely accept everything.
+func TestRelay_RcptTo_AcceptsWhenUnderCap(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SMTP integration test under -short")
+	}
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	store := identity.NewStore(pool)
+	user, _ := store.CreateOrGetUser(ctx, "relay-ok@test.com", "Test", "google-relay-ok@test.com")
+	if _, err := store.ClaimOrCreateDomain(ctx, "relay-ok.example.com", user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE domains SET verified = true WHERE domain = $1`, "relay-ok.example.com"); err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	agentEmail := "bot@relay-ok.example.com"
+	if _, err := store.CreateAgent(ctx, agentEmail, "relay-ok.example.com", "", "https://example.com/w", "cloud", user.ID); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	// Generous caps — RCPT should succeed.
+	lstore := limits.NewStore(pool)
+	if err := lstore.Upsert(ctx, user.ID, limits.Limits{
+		PlanCode:         "pro_test",
+		MaxAgents:        100, MaxDomains: 100, MaxMessagesMonth: 100_000, MaxStorageBytes: 1 << 40,
+	}); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	signer := headers.NewSigner("test-relay-hmac-key-32-bytes-long!")
+	port, _ := freePort()
+	cfg := &config.Config{SMTP: config.SMTPConfig{ListenAddr: "127.0.0.1:" + port, Domain: "test.relay"}, Env: "development"}
+	deliverer := webhook.NewPersistentDeliverer(webhook.NewDeliverer(false), webhook.NewDeliveryStore(pool))
+	server := relay.NewServer(cfg, store, signer, deliverer, usage.NewNoopUsageTracker(), ws.NewHub())
+	enf := limits.NewEnforcer(lstore, usage.NewStore(pool),
+		limits.Defaults{PlanCode: "default", MaxAgents: 1, MaxDomains: 1, MaxMessagesMonth: 1, MaxStorageBytes: 1}, 0)
+	server.SetEnforcer(enf)
+	go func() { _ = server.ListenAndServe() }()
+	t.Cleanup(func() { _ = server.Close() })
+
+	// Wait-for-ready
+	deadline := time.Now().Add(2 * time.Second)
+	var err error
+	for time.Now().Before(deadline) {
+		var conn net.Conn
+		conn, err = net.Dial("tcp", cfg.SMTP.ListenAddr)
+		if err == nil {
+			conn.Close()
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("server not ready: %v", err)
+	}
+
+	c, err := smtp.Dial(cfg.SMTP.ListenAddr)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer c.Close()
+	if err := c.Mail("sender@elsewhere.test"); err != nil {
+		t.Fatalf("MAIL FROM: %v", err)
+	}
+	if err := c.Rcpt(agentEmail); err != nil {
+		t.Errorf("RCPT TO under-cap returned %v; want nil (accepted)", err)
+	}
+}

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/emailauth"
 	"github.com/Mnexa-AI/e2a/internal/headers"
 	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/limits"
 	"github.com/Mnexa-AI/e2a/internal/usage"
 	"github.com/Mnexa-AI/e2a/internal/webhook"
 	"github.com/Mnexa-AI/e2a/internal/ws"
@@ -31,6 +32,7 @@ type Server struct {
 	deliverer  *webhook.PersistentDeliverer
 	hub        *ws.Hub
 	usage      usage.UsageTracker
+	enforcer   limits.Enforcer // optional; when nil, inbound caps are not enforced
 	smtpDomain string
 	// outboundFromDomain is the domain used in envelope MAIL FROM for mail we
 	// originate (e.g. "send.e2a.dev"). Inbound messages whose envelope MAIL FROM
@@ -39,6 +41,14 @@ type Server struct {
 	// In-Reply-To lookup so they cannot forge conversation IDs.
 	outboundFromDomain string
 }
+
+// SetEnforcer wires in the resource-limits enforcer used to reject
+// inbound recipients whose owner has hit the message-flow or storage
+// cap. When nil (the default) every RCPT TO is accepted as far as the
+// limits subsystem is concerned — handy for tests and for self-host
+// operators who run without limits enabled. The cmd/e2a runtime always
+// sets it.
+func (s *Server) SetEnforcer(e limits.Enforcer) { s.enforcer = e }
 
 func NewServer(cfg *config.Config, store *identity.Store, signer *headers.Signer, deliverer *webhook.PersistentDeliverer, usage usage.UsageTracker, hub *ws.Hub) *Server {
 	s := &Server{
@@ -140,6 +150,22 @@ func (s *session) Rcpt(to string, opts *smtp.RcptOptions) error {
 	if !agent.DomainVerified {
 		log.Printf("[%s] [%s] rejecting %s: domain not verified", s.id, s.from, to)
 		return &smtp.SMTPError{Code: 550, EnhancedCode: smtp.EnhancedCode{5, 1, 1}, Message: "recipient not found"}
+	}
+
+	// Reject at SMTP envelope time if the recipient's owner has hit the
+	// message-flow or storage cap. 552 (mailbox quota exceeded, RFC 5321
+	// §4.2.2) tells the upstream MTA to bounce the message back to the
+	// original sender with a deliverable error rather than retry. We
+	// fail open on enforcer errors (DB hiccup) so a transient outage
+	// doesn't lose mail — the storage trigger is the safety net.
+	if s.relay.enforcer != nil && agent.UserID != "" {
+		if err := s.relay.enforcer.CheckMessageSend(ctx, agent.UserID); err != nil {
+			if le, ok := limits.IsLimitExceeded(err); ok {
+				log.Printf("[%s] [%s] rejecting %s: limit exceeded (%s)", s.id, s.from, to, le.Resource)
+				return &smtp.SMTPError{Code: 552, EnhancedCode: smtp.EnhancedCode{5, 2, 2}, Message: "mailbox quota exceeded"}
+			}
+			log.Printf("[%s] [%s] limits check error (failing open): %v", s.id, s.from, err)
+		}
 	}
 
 	s.recipients = append(s.recipients, to)

--- a/internal/usage/store.go
+++ b/internal/usage/store.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -93,6 +95,59 @@ func (s *Store) CountAgentsByUser(ctx context.Context, userID string) (int, erro
 		`SELECT COUNT(*) FROM agent_identities WHERE user_id = $1`, userID,
 	).Scan(&count)
 	return count, err
+}
+
+// CountDomainsByUser returns the number of domains owned by the user.
+// Used by the limits enforcer to check max_domains caps. Counts every
+// row in domains regardless of verification status; an unverified
+// domain still consumes a slot until the user deletes it.
+func (s *Store) CountDomainsByUser(ctx context.Context, userID string) (int, error) {
+	var count int
+	err := s.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM domains WHERE user_id = $1`, userID,
+	).Scan(&count)
+	return count, err
+}
+
+// MessagesThisMonth returns the user's inbound+outbound message count
+// for the current UTC calendar month, summed from usage_summaries.
+// Returns 0 with no error if the user has no rows yet. The reference is
+// time.Now().UTC() so server clocks crossing midnight UTC roll the
+// counter consistently with the daily bucket_date written by
+// IncrementUsageSummary.
+func (s *Store) MessagesThisMonth(ctx context.Context, userID string) (int, error) {
+	now := time.Now().UTC()
+	monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC).Format("2006-01-02")
+	var count int
+	err := s.pool.QueryRow(ctx,
+		`SELECT COALESCE(SUM(total_count), 0)
+		   FROM usage_summaries
+		  WHERE user_id = $1 AND bucket_date >= $2`,
+		userID, monthStart,
+	).Scan(&count)
+	return count, err
+}
+
+// GetStorageBytes returns the user's current materialized storage bytes
+// from account_usage. Returns 0 with no error if the user has no row
+// yet — the trigger in migration 016 lazily creates the row on first
+// message insert, so a pre-message user legitimately has 0 storage.
+func (s *Store) GetStorageBytes(ctx context.Context, userID string) (int64, error) {
+	var bytes int64
+	err := s.pool.QueryRow(ctx,
+		`SELECT storage_bytes FROM account_usage WHERE user_id = $1`, userID,
+	).Scan(&bytes)
+	if err != nil {
+		// No row yet → 0 bytes. The trigger creates rows lazily on
+		// first message insert, so a pre-message user legitimately has
+		// 0 storage and should not see a synthetic error on first
+		// dashboard load.
+		if errors.Is(err, pgx.ErrNoRows) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	return bytes, nil
 }
 
 func generateBillingID() string {

--- a/internal/webhook/store.go
+++ b/internal/webhook/store.go
@@ -31,24 +31,29 @@ func NewDeliveryStore(pool *pgxpool.Pool) *DeliveryStore {
 }
 
 func (s *DeliveryStore) CreateDelivery(ctx context.Context, messageID string, lastError string) (*Delivery, error) {
-	now := time.Now()
-
 	d := &Delivery{
 		MessageID:   messageID,
 		Status:      "pending",
 		Attempts:    0,
 		MaxAttempts: 2,
 		LastError:   lastError,
-		NextRetryAt: now,
-		CreatedAt:   now,
-		ExpiresAt:   now.Add(DeliveryTTL),
 	}
 
-	_, err := s.pool.Exec(ctx,
+	// next_retry_at MUST be set in the Postgres clock domain — the
+	// GetPendingDeliveries SELECT compares against Postgres now(), and a
+	// Go-side time.Now() rounded into Postgres's microsecond TIMESTAMPTZ
+	// can land fractionally in the future relative to a now() captured
+	// microseconds later, causing the just-inserted row to be excluded
+	// from the next claim cycle. created_at and expires_at use the same
+	// Postgres now() for internal consistency. RETURNING populates the
+	// struct so callers see the actual stored values.
+	ttlSeconds := int(DeliveryTTL.Seconds())
+	err := s.pool.QueryRow(ctx,
 		`INSERT INTO webhook_deliveries (message_id, status, attempts, max_attempts, last_error, next_retry_at, created_at, expires_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
-		d.MessageID, d.Status, d.Attempts, d.MaxAttempts, d.LastError, d.NextRetryAt, d.CreatedAt, d.ExpiresAt,
-	)
+		 VALUES ($1, $2, $3, $4, $5, now(), now(), now() + ($6 * interval '1 second'))
+		 RETURNING next_retry_at, created_at, expires_at`,
+		d.MessageID, d.Status, d.Attempts, d.MaxAttempts, d.LastError, ttlSeconds,
+	).Scan(&d.NextRetryAt, &d.CreatedAt, &d.ExpiresAt)
 	if err != nil {
 		return nil, err
 	}

--- a/migrations/016_account_limits.sql
+++ b/migrations/016_account_limits.sql
@@ -1,0 +1,127 @@
+-- 016_account_limits.sql
+--
+-- Per-user resource caps + matching usage rollup. Two tables, one purpose:
+-- the OSS server gains a generic limits primitive (no Stripe, no plan
+-- names, no $) that any operator can drive however they like.
+--
+-- account_limits — the caps. One row per user; missing row falls back to
+-- operator-configured defaults (config.yaml `limits:` block). `plan_code`
+-- and `upgrade_url` are opaque to the OSS server: they are written by
+-- whatever provisions the row (hosted-service sidecar, admin tool, manual
+-- SQL) and echoed back to the dashboard verbatim. The OSS server only
+-- enforces the integer caps.
+--
+-- account_usage — current stock counters that pair with the stock caps
+-- (storage today; future stock metrics fit here). Flow caps like
+-- max_messages_month are tracked in usage_summaries instead, since that
+-- table already aggregates per-day per-user message counts.
+--
+-- Storage is maintained by a trigger on the messages table: every INSERT
+-- adds the sum of the size-bearing columns (raw_message, body_text,
+-- body_html, attachments_json) to the user's storage_bytes; every DELETE
+-- subtracts. The trigger guarantees consistency across all delete paths
+-- (the retention sweep, ON DELETE CASCADE from agent_identities deletion,
+-- user-initiated message delete) without requiring every call site to
+-- remember to update the counter.
+--
+-- The trigger does NOT handle UPDATE. The only known column-update path
+-- today is HITL approve-with-edits replacing body_text/body_html; the
+-- resulting drift is bounded (a few KB per edited approval) and the
+-- counter self-corrects on the retention sweep when the message expires.
+-- Add UPDATE handling here if a larger update path emerges.
+--
+-- One-time backfill seeds account_usage from existing messages so the
+-- counter is accurate the first time the trigger fires. ON CONFLICT DO
+-- NOTHING makes the backfill idempotent — re-running the migration is a
+-- no-op once rows exist.
+--
+-- Idempotent: CREATE TABLE/TRIGGER/FUNCTION use IF NOT EXISTS or
+-- OR REPLACE. Additive only — no destructive ALTERs. Safe to rerun on
+-- prod-sized data; the backfill INSERT scales linearly with messages but
+-- runs once.
+
+CREATE TABLE IF NOT EXISTS account_limits (
+    user_id            TEXT        PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    plan_code          TEXT        NOT NULL DEFAULT 'default',
+    max_agents         INTEGER     NOT NULL,
+    max_domains        INTEGER     NOT NULL,
+    max_messages_month INTEGER     NOT NULL,
+    max_storage_bytes  BIGINT      NOT NULL,
+    upgrade_url        TEXT        NOT NULL DEFAULT '',
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_account_limits_updated_at ON account_limits(updated_at);
+
+CREATE TABLE IF NOT EXISTS account_usage (
+    user_id       TEXT        PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    storage_bytes BIGINT      NOT NULL DEFAULT 0,
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Storage delta trigger. The size of a message is the sum of its
+-- size-bearing columns; nullable columns are coerced to 0 so the math
+-- works on rows that only populate a subset (e.g. inbound rows have
+-- raw_message but no body_*; HITL pending outbound rows have body_*
+-- but no raw_message).
+CREATE OR REPLACE FUNCTION e2a_messages_storage_delta() RETURNS TRIGGER AS $$
+DECLARE
+    uid   TEXT;
+    delta BIGINT;
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        SELECT user_id INTO uid FROM agent_identities WHERE id = NEW.agent_id;
+        IF uid IS NULL THEN
+            RETURN NEW;
+        END IF;
+        delta := COALESCE(octet_length(NEW.raw_message), 0)
+               + COALESCE(octet_length(NEW.body_text), 0)
+               + COALESCE(octet_length(NEW.body_html), 0)
+               + COALESCE(octet_length(NEW.attachments_json::text), 0);
+        INSERT INTO account_usage (user_id, storage_bytes)
+        VALUES (uid, delta)
+        ON CONFLICT (user_id) DO UPDATE
+            SET storage_bytes = account_usage.storage_bytes + EXCLUDED.storage_bytes,
+                updated_at    = now();
+        RETURN NEW;
+    ELSIF TG_OP = 'DELETE' THEN
+        SELECT user_id INTO uid FROM agent_identities WHERE id = OLD.agent_id;
+        IF uid IS NULL THEN
+            RETURN OLD;
+        END IF;
+        delta := COALESCE(octet_length(OLD.raw_message), 0)
+               + COALESCE(octet_length(OLD.body_text), 0)
+               + COALESCE(octet_length(OLD.body_html), 0)
+               + COALESCE(octet_length(OLD.attachments_json::text), 0);
+        UPDATE account_usage
+           SET storage_bytes = GREATEST(storage_bytes - delta, 0),
+               updated_at    = now()
+         WHERE user_id = uid;
+        RETURN OLD;
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS e2a_messages_storage_delta_trg ON messages;
+CREATE TRIGGER e2a_messages_storage_delta_trg
+AFTER INSERT OR DELETE ON messages
+FOR EACH ROW EXECUTE FUNCTION e2a_messages_storage_delta();
+
+-- One-time backfill of storage from existing messages. Idempotent via
+-- ON CONFLICT DO NOTHING: the second time the migration runs, every user
+-- with messages already has a row, so the INSERT is a no-op. Users with
+-- zero messages get no row; the limits enforcer treats a missing row as
+-- storage_bytes=0, which is correct.
+INSERT INTO account_usage (user_id, storage_bytes)
+SELECT a.user_id,
+       COALESCE(SUM(
+           COALESCE(octet_length(m.raw_message), 0)
+         + COALESCE(octet_length(m.body_text), 0)
+         + COALESCE(octet_length(m.body_html), 0)
+         + COALESCE(octet_length(m.attachments_json::text), 0)
+       ), 0)
+  FROM messages m
+  JOIN agent_identities a ON a.id = m.agent_id
+ GROUP BY a.user_id
+ON CONFLICT (user_id) DO NOTHING;

--- a/migrations/017_account_limits_last_event_at.sql
+++ b/migrations/017_account_limits_last_event_at.sql
@@ -1,0 +1,23 @@
+-- 017_account_limits_last_event_at.sql
+--
+-- Adds a monotonic version field to account_limits so the external
+-- provisioner (hosted billing sidecar) can safely apply caps in the
+-- presence of out-of-order delivery from its own event source.
+--
+-- The OSS server treats last_event_at as opaque — same property as
+-- plan_code / upgrade_url. Whatever external system writes the row
+-- supplies a timestamp; the UPSERT in the writer compares incoming
+-- vs current and only applies the update when the incoming value is
+-- strictly newer. Self-host operators who write account_limits via
+-- SQL or a custom admin tool can set last_event_at = now() and the
+-- predicate is a no-op for them.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS, backfill from updated_at as
+-- a safe floor.
+
+ALTER TABLE account_limits
+    ADD COLUMN IF NOT EXISTS last_event_at TIMESTAMPTZ;
+
+UPDATE account_limits
+   SET last_event_at = updated_at
+ WHERE last_event_at IS NULL;

--- a/migrations/018_account_limits_last_event_id.sql
+++ b/migrations/018_account_limits_last_event_id.sql
@@ -1,0 +1,15 @@
+-- 018_account_limits_last_event_id.sql
+--
+-- Companion to migration 017's last_event_at. Adds an event-id
+-- tiebreaker column so the external provisioner can resolve
+-- same-second ordering deterministically. OSS treats the value as
+-- opaque, same property as plan_code / upgrade_url / last_event_at.
+--
+-- See e2a-ops migration 003 for the rationale and the predicate
+-- shape — they mirror.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS. No backfill needed; the
+-- writer's predicate handles NULL last_event_id correctly.
+
+ALTER TABLE account_limits
+    ADD COLUMN IF NOT EXISTS last_event_id TEXT;

--- a/sdks/python/src/e2a/v1/generated/__init__.py
+++ b/sdks/python/src/e2a/v1/generated/__init__.py
@@ -143,6 +143,26 @@ class Domain(BaseModel):
     verified_at: str | None = None
 
 
+class LimitsCaps(BaseModel):
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
+    max_agents: int | None = None
+    max_domains: int | None = None
+    max_messages_month: int | None = None
+    max_storage_bytes: int | None = None
+
+
+class LimitsUsage(BaseModel):
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
+    agents: int | None = None
+    domains: int | None = None
+    messages_month: int | None = None
+    storage_bytes: int | None = None
+
+
 class ListAgentsResponse(BaseModel):
     model_config = ConfigDict(
         populate_by_name=True,
@@ -407,6 +427,16 @@ class ApprovePendingMessageRequest(BaseModel):
     cc: list[str] | None = None
     subject: str | None = None
     to: list[str] | None = None
+
+
+class LimitsInfo(BaseModel):
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
+    limits: LimitsCaps | None = None
+    plan_code: str | None = None
+    upgrade_url: str | None = None
+    usage: LimitsUsage | None = None
 
 
 class ListMessagesResponse(BaseModel):

--- a/sdks/typescript/src/v1/generated/types.ts
+++ b/sdks/typescript/src/v1/generated/types.ts
@@ -1553,6 +1553,63 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/users/me/limits": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get the current user's limits and usage
+         * @description Returns the resolved per-user caps (from account_limits or operator defaults) plus the user's current usage. Dashboard uses this to render the upgrade affordance and the "you've used X of Y" surface.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["LimitsInfo"];
+                    };
+                };
+                /** @description Missing or invalid API key */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Limits subsystem not configured */
+                503: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/users/me/signing-secrets": {
         parameters: {
             query?: never;
@@ -1855,6 +1912,24 @@ export interface components {
             verification_token?: string;
             verified?: boolean;
             verified_at?: string;
+        };
+        LimitsCaps: {
+            max_agents?: number;
+            max_domains?: number;
+            max_messages_month?: number;
+            max_storage_bytes?: number;
+        };
+        LimitsInfo: {
+            limits?: components["schemas"]["LimitsCaps"];
+            plan_code?: string;
+            upgrade_url?: string;
+            usage?: components["schemas"]["LimitsUsage"];
+        };
+        LimitsUsage: {
+            agents?: number;
+            domains?: number;
+            messages_month?: number;
+            storage_bytes?: number;
         };
         ListAgentsResponse: {
             agents?: components["schemas"]["Agent"][];

--- a/web/public/openapi.yaml
+++ b/web/public/openapi.yaml
@@ -211,6 +211,39 @@ definitions:
       verified_at:
         type: string
     type: object
+  LimitsCaps:
+    properties:
+      max_agents:
+        type: integer
+      max_domains:
+        type: integer
+      max_messages_month:
+        type: integer
+      max_storage_bytes:
+        type: integer
+    type: object
+  LimitsInfo:
+    properties:
+      limits:
+        $ref: '#/definitions/LimitsCaps'
+      plan_code:
+        type: string
+      upgrade_url:
+        type: string
+      usage:
+        $ref: '#/definitions/LimitsUsage'
+    type: object
+  LimitsUsage:
+    properties:
+      agents:
+        type: integer
+      domains:
+        type: integer
+      messages_month:
+        type: integer
+      storage_bytes:
+        type: integer
+    type: object
   ListAgentsResponse:
     properties:
       agents:
@@ -2031,6 +2064,31 @@ paths:
       summary: Export your data
       tags:
       - User
+  /api/v1/users/me/limits:
+    get:
+      description: Returns the resolved per-user caps (from account_limits or operator
+        defaults) plus the user's current usage. Dashboard uses this to render the
+        upgrade affordance and the "you've used X of Y" surface.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/LimitsInfo'
+        "401":
+          description: Missing or invalid API key
+          schema:
+            type: string
+        "503":
+          description: Limits subsystem not configured
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Get the current user's limits and usage
+      tags:
+      - Users
   /api/v1/users/me/signing-secrets:
     get:
       description: Returns the authenticated user's webhook signing secrets (metadata,

--- a/web/src/app/(app)/billing/page.test.tsx
+++ b/web/src/app/(app)/billing/page.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { SWRConfig } from "swr";
+import BillingPage from "./page";
+
+// Mock next/link so the PageShell / Topbar links don't try to resolve
+// router state.
+jest.mock("next/link", () => {
+  return function MockLink({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [k: string]: unknown;
+  }) {
+    return (
+      <a href={href} {...rest}>
+        {children}
+      </a>
+    );
+  };
+});
+
+const mockFetch = jest.fn();
+beforeEach(() => {
+  mockFetch.mockReset();
+  global.fetch = mockFetch;
+});
+
+// Wraps the page in a fresh SWR provider per test so cached responses
+// from a previous test don't leak into this one and silently mask a
+// missing mock.
+function renderPage() {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      <BillingPage />
+    </SWRConfig>,
+  );
+}
+
+function stageLimits(payload: unknown) {
+  mockFetch.mockImplementation((url: string) => {
+    if (url === "/api/v1/users/me/limits") {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(payload),
+      });
+    }
+    return Promise.resolve({ ok: false, text: () => Promise.resolve("404") });
+  });
+}
+
+describe("BillingPage", () => {
+  it("renders plan name and all four usage rows", async () => {
+    stageLimits({
+      plan_code: "default",
+      limits: {
+        max_agents: 100,
+        max_domains: 10,
+        max_messages_month: 50000,
+        max_storage_bytes: 10737418240,
+      },
+      usage: {
+        agents: 3,
+        domains: 1,
+        messages_month: 1247,
+        storage_bytes: 425600,
+      },
+      upgrade_url: "",
+    });
+    renderPage();
+
+    await waitFor(() =>
+      expect(screen.getByText(/Default \(operator-configured\)/i)).toBeInTheDocument(),
+    );
+    expect(screen.getByText("Agents")).toBeInTheDocument();
+    expect(screen.getByText("Domains")).toBeInTheDocument();
+    expect(screen.getByText("Messages this month")).toBeInTheDocument();
+    expect(screen.getByText("Storage")).toBeInTheDocument();
+
+    // Spot-check formatted numbers — message count uses thousands
+    // separator, storage uses unit suffix.
+    expect(screen.getByText(/1,247/)).toBeInTheDocument();
+    expect(screen.getByText(/415\.6 KB|425600/)).toBeInTheDocument();
+  });
+
+  it("hides Upgrade and Manage Billing buttons when NEXT_PUBLIC_BILLING_API is unset", async () => {
+    // Default Jest env has no NEXT_PUBLIC_BILLING_API set — the module
+    // already captured an empty string at import time, so neither
+    // button should render.
+    stageLimits({
+      plan_code: "default",
+      limits: { max_agents: 1, max_domains: 1, max_messages_month: 1, max_storage_bytes: 1 },
+      usage: { agents: 0, domains: 0, messages_month: 0, storage_bytes: 0 },
+      upgrade_url: "",
+    });
+    renderPage();
+
+    await waitFor(() => screen.getByText(/Default/i));
+    expect(screen.queryByText(/Upgrade/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Manage billing/i)).not.toBeInTheDocument();
+  });
+
+  it("renders error state when the API returns non-2xx", async () => {
+    mockFetch.mockImplementation(() =>
+      Promise.resolve({
+        ok: false,
+        status: 503,
+        text: () => Promise.resolve("limits subsystem not configured"),
+      }),
+    );
+    renderPage();
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Couldn't load your limits/i),
+      ).toBeInTheDocument(),
+    );
+  });
+});

--- a/web/src/app/(app)/billing/page.tsx
+++ b/web/src/app/(app)/billing/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import useSWR from "swr";
 import { PageShell } from "../../components/loft/PageShell";
 
@@ -108,6 +108,43 @@ export default function BillingPage() {
     fetchLimits,
   );
 
+  // Disable the action buttons while a POST is in flight so a
+  // double-click doesn't create two Stripe sessions.
+  const [actionPending, setActionPending] = useState<"upgrade" | "portal" | null>(null);
+
+  // Both Upgrade and Manage Billing POST to the sidecar and follow the
+  // returned `url`. POST (not GET) because the OSS session cookie is
+  // SameSite=Lax — Lax permits top-level GET navigations from third
+  // parties, which would make GET endpoints CSRF-able (a malicious
+  // page could create real Stripe Checkout sessions for the victim).
+  // POSTs from a third-party origin are blocked by Lax, so the dashboard
+  // owns the call and the cross-origin attack surface is gone.
+  async function postBilling(endpoint: string, kind: "upgrade" | "portal") {
+    setActionPending(kind);
+    try {
+      const res = await fetch(endpoint, {
+        method: "POST",
+        credentials: "include",
+      });
+      if (!res.ok) {
+        const body = await res.text().catch(() => "");
+        throw new Error(`HTTP ${res.status}${body ? `: ${body}` : ""}`);
+      }
+      const json = (await res.json()) as { url?: string };
+      if (!json.url) {
+        throw new Error("billing endpoint returned no url");
+      }
+      window.location.href = json.url;
+    } catch (err) {
+      // Best-effort recovery: surface the error to the user, clear
+      // the pending state, and let them retry. We don't reset SWR
+      // because the underlying limits data is unaffected by a
+      // failed checkout/portal session.
+      setActionPending(null);
+      alert(`Could not open billing: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
   // When the user navigates away (e.g. to Stripe Checkout) and hits
   // Back, the browser may restore the page from bfcache with any
   // in-flight fetch abandoned. SWR's isLoading state then sticks at
@@ -175,33 +212,31 @@ export default function BillingPage() {
               {BILLING_API && (
                 <div className="flex items-center gap-2">
                   {data.upgrade_url ? (
-                    // upgrade_url is set by the external provisioner on
-                    // active subscriptions to point at the Stripe-hosted
-                    // billing portal (via a GET on the sidecar's
-                    // /api/billing/portal which 302s to a fresh portal
-                    // session). Same-tab navigation: Stripe's portal
-                    // already has a "Return to merchant" link that
-                    // redirects back to PORTAL_RETURN_URL, so the user
-                    // never gets stranded.
-                    <a
-                      href={data.upgrade_url}
-                      className="px-3 py-1.5 rounded-md text-sm border hover:bg-background transition"
+                    // upgrade_url present → user has an active Stripe
+                    // subscription. Clicking POSTs to the sidecar,
+                    // which returns a fresh Stripe Billing Portal URL.
+                    <button
+                      type="button"
+                      disabled={actionPending !== null}
+                      onClick={() => postBilling(data.upgrade_url, "portal")}
+                      className="px-3 py-1.5 rounded-md text-sm border hover:bg-background transition disabled:opacity-50 disabled:cursor-not-allowed"
                       style={{ borderColor: "var(--border)", color: "var(--fg)" }}
                     >
-                      Manage billing
-                    </a>
+                      {actionPending === "portal" ? "Opening…" : "Manage billing"}
+                    </button>
                   ) : (
-                    // No upgrade_url → user is on the free/default plan.
-                    // Send them to the sidecar's checkout endpoint. The
-                    // sidecar's GET /api/billing/checkout 302-redirects
-                    // to Stripe-hosted Checkout for the Pro plan (the
-                    // default when ?plan= is omitted).
-                    <a
-                      href={`${BILLING_API}/api/billing/checkout`}
-                      className="px-3 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent/90 transition"
+                    // No upgrade_url → free/default plan. POST to the
+                    // sidecar's checkout endpoint to create a Stripe
+                    // Checkout session for the Pro plan (default when
+                    // no plan is specified in the body).
+                    <button
+                      type="button"
+                      disabled={actionPending !== null}
+                      onClick={() => postBilling(`${BILLING_API}/api/billing/checkout`, "upgrade")}
+                      className="px-3 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent/90 transition disabled:opacity-50 disabled:cursor-not-allowed"
                     >
-                      Upgrade
-                    </a>
+                      {actionPending === "upgrade" ? "Opening…" : "Upgrade"}
+                    </button>
                   )}
                 </div>
               )}

--- a/web/src/app/(app)/billing/page.tsx
+++ b/web/src/app/(app)/billing/page.tsx
@@ -176,12 +176,15 @@ export default function BillingPage() {
                 <div className="flex items-center gap-2">
                   {data.upgrade_url ? (
                     // upgrade_url is set by the external provisioner on
-                    // active subscriptions to point at the Stripe-managed
-                    // portal. Render as "Manage billing".
+                    // active subscriptions to point at the Stripe-hosted
+                    // billing portal (via a GET on the sidecar's
+                    // /api/billing/portal which 302s to a fresh portal
+                    // session). Same-tab navigation: Stripe's portal
+                    // already has a "Return to merchant" link that
+                    // redirects back to PORTAL_RETURN_URL, so the user
+                    // never gets stranded.
                     <a
                       href={data.upgrade_url}
-                      target="_blank"
-                      rel="noopener noreferrer"
                       className="px-3 py-1.5 rounded-md text-sm border hover:bg-background transition"
                       style={{ borderColor: "var(--border)", color: "var(--fg)" }}
                     >

--- a/web/src/app/(app)/billing/page.tsx
+++ b/web/src/app/(app)/billing/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import useSWR from "swr";
 import { PageShell } from "../../components/loft/PageShell";
 
@@ -107,6 +108,20 @@ export default function BillingPage() {
     fetchLimits,
   );
 
+  // When the user navigates away (e.g. to Stripe Checkout) and hits
+  // Back, the browser may restore the page from bfcache with any
+  // in-flight fetch abandoned. SWR's isLoading state then sticks at
+  // true and the user sees a permanent "Loading…". Force a revalidate
+  // on every pageshow with persisted=true so the page never gets
+  // stuck after a Back navigation.
+  useEffect(() => {
+    const onShow = (e: PageTransitionEvent) => {
+      if (e.persisted) void mutate();
+    };
+    window.addEventListener("pageshow", onShow);
+    return () => window.removeEventListener("pageshow", onShow);
+  }, [mutate]);
+
   // Compute usage percentages once data is loaded. Guard zero limits
   // (treat as 0% rather than NaN/Infinity) so a misconfigured row with
   // max_*=0 doesn't paint a full red bar.
@@ -174,9 +189,12 @@ export default function BillingPage() {
                     </a>
                   ) : (
                     // No upgrade_url → user is on the free/default plan.
-                    // Send them to the sidecar's checkout endpoint.
+                    // Send them to the sidecar's checkout endpoint. The
+                    // sidecar's GET /api/billing/checkout 302-redirects
+                    // to Stripe-hosted Checkout for the Pro plan (the
+                    // default when ?plan= is omitted).
                     <a
-                      href={`${BILLING_API}/checkout`}
+                      href={`${BILLING_API}/api/billing/checkout`}
                       className="px-3 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent/90 transition"
                     >
                       Upgrade

--- a/web/src/app/(app)/billing/page.tsx
+++ b/web/src/app/(app)/billing/page.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import useSWR from "swr";
+import { PageShell } from "../../components/loft/PageShell";
+
+// LimitsInfo matches the shape returned by GET /api/v1/users/me/limits.
+// Kept inline rather than imported from a generated client because the
+// OSS SDK doesn't expose this endpoint yet (it's a dashboard-only
+// surface — SDK consumers would call /agents and /messages directly).
+type LimitsInfo = {
+  plan_code: string;
+  limits: {
+    max_agents: number;
+    max_domains: number;
+    max_messages_month: number;
+    max_storage_bytes: number;
+  };
+  usage: {
+    agents: number;
+    domains: number;
+    messages_month: number;
+    storage_bytes: number;
+  };
+  upgrade_url: string;
+};
+
+// BILLING_API is the base URL of the external limits provisioner (the
+// hosted billing sidecar). When empty the dashboard renders the usage
+// surface without Upgrade / Manage Billing affordances — appropriate
+// for self-host deployments that don't run a paid tier. Set at build
+// time via NEXT_PUBLIC_BILLING_API; populated in the prod web image.
+const BILLING_API = (process.env.NEXT_PUBLIC_BILLING_API ?? "").replace(/\/$/, "");
+
+async function fetchLimits(): Promise<LimitsInfo> {
+  const res = await fetch("/api/v1/users/me/limits", { credentials: "include" });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`limits: HTTP ${res.status}${body ? ` — ${body}` : ""}`);
+  }
+  return res.json();
+}
+
+// formatBytes renders storage in the unit that makes the number
+// human-legible — KB / MB / GB. Matches the formatting Resend and
+// AgentMail use in their dashboards so users carrying mental models
+// from those tools aren't surprised.
+function formatBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+  if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(n / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+function formatNumber(n: number): string {
+  return n.toLocaleString();
+}
+
+// pctTone picks the bar color based on how close to the cap the user
+// is. <70% neutral, 70-90% warning, >=90% danger. Tones reuse existing
+// CSS vars so the dashboard's theme tokens own the actual colors.
+function pctTone(pct: number): "neutral" | "warn" | "danger" {
+  if (pct >= 90) return "danger";
+  if (pct >= 70) return "warn";
+  return "neutral";
+}
+
+type UsageRowProps = {
+  label: string;
+  current: string;
+  limit: string;
+  pct: number;
+};
+
+function UsageRow({ label, current, limit, pct }: UsageRowProps) {
+  const tone = pctTone(pct);
+  const barColor =
+    tone === "danger"
+      ? "var(--accent-danger, #ef4444)"
+      : tone === "warn"
+      ? "var(--accent-warn, #f59e0b)"
+      : "var(--accent)";
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-baseline justify-between text-sm">
+        <span className="text-foreground font-medium">{label}</span>
+        <span className="text-muted">
+          {current} <span className="text-muted/70">/ {limit}</span>
+        </span>
+      </div>
+      <div className="h-1.5 rounded-full bg-background overflow-hidden">
+        <div
+          className="h-full rounded-full transition-[width] duration-300"
+          style={{
+            width: `${Math.min(100, Math.max(0, pct))}%`,
+            background: barColor,
+          }}
+          aria-hidden
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function BillingPage() {
+  const { data, error, isLoading, mutate } = useSWR<LimitsInfo>(
+    "limits",
+    fetchLimits,
+  );
+
+  // Compute usage percentages once data is loaded. Guard zero limits
+  // (treat as 0% rather than NaN/Infinity) so a misconfigured row with
+  // max_*=0 doesn't paint a full red bar.
+  const pct = (used: number, cap: number) => (cap > 0 ? (used / cap) * 100 : 0);
+
+  return (
+    <PageShell
+      crumbs={["Billing"]}
+      eyebrow="Plan & usage"
+      title="Billing"
+      subtitle="Your current resource caps and month-to-date usage."
+    >
+      {error && (
+        <div
+          className="rounded-lg border px-4 py-3 text-sm mb-6"
+          style={{
+            borderColor: "var(--border)",
+            background: "var(--bg-elev)",
+            color: "var(--fg-muted)",
+          }}
+        >
+          Couldn&apos;t load your limits. {String(error.message ?? error)}
+        </div>
+      )}
+
+      {isLoading && !data && (
+        <div className="text-sm text-muted">Loading…</div>
+      )}
+
+      {data && (
+        <div className="space-y-6">
+          {/* Plan summary card */}
+          <section
+            className="rounded-xl border p-5"
+            style={{
+              borderColor: "var(--border)",
+              background: "var(--surface)",
+            }}
+          >
+            <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+              <div>
+                <div className="text-xs uppercase tracking-wide text-muted">
+                  Current plan
+                </div>
+                <div className="text-lg font-semibold text-foreground mt-1">
+                  {data.plan_code === "default"
+                    ? "Default (operator-configured)"
+                    : data.plan_code}
+                </div>
+              </div>
+              {BILLING_API && (
+                <div className="flex items-center gap-2">
+                  {data.upgrade_url ? (
+                    // upgrade_url is set by the external provisioner on
+                    // active subscriptions to point at the Stripe-managed
+                    // portal. Render as "Manage billing".
+                    <a
+                      href={data.upgrade_url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="px-3 py-1.5 rounded-md text-sm border hover:bg-background transition"
+                      style={{ borderColor: "var(--border)", color: "var(--fg)" }}
+                    >
+                      Manage billing
+                    </a>
+                  ) : (
+                    // No upgrade_url → user is on the free/default plan.
+                    // Send them to the sidecar's checkout endpoint.
+                    <a
+                      href={`${BILLING_API}/checkout`}
+                      className="px-3 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent/90 transition"
+                    >
+                      Upgrade
+                    </a>
+                  )}
+                </div>
+              )}
+            </div>
+          </section>
+
+          {/* Usage card */}
+          <section
+            className="rounded-xl border p-5 space-y-5"
+            style={{
+              borderColor: "var(--border)",
+              background: "var(--surface)",
+            }}
+          >
+            <div>
+              <div className="text-xs uppercase tracking-wide text-muted">
+                This billing period
+              </div>
+              <div className="text-sm text-muted mt-1">
+                Counters reset at the start of each calendar month (UTC).
+              </div>
+            </div>
+
+            <UsageRow
+              label="Agents"
+              current={formatNumber(data.usage.agents)}
+              limit={formatNumber(data.limits.max_agents)}
+              pct={pct(data.usage.agents, data.limits.max_agents)}
+            />
+            <UsageRow
+              label="Domains"
+              current={formatNumber(data.usage.domains)}
+              limit={formatNumber(data.limits.max_domains)}
+              pct={pct(data.usage.domains, data.limits.max_domains)}
+            />
+            <UsageRow
+              label="Messages this month"
+              current={formatNumber(data.usage.messages_month)}
+              limit={formatNumber(data.limits.max_messages_month)}
+              pct={pct(data.usage.messages_month, data.limits.max_messages_month)}
+            />
+            <UsageRow
+              label="Storage"
+              current={formatBytes(data.usage.storage_bytes)}
+              limit={formatBytes(data.limits.max_storage_bytes)}
+              pct={pct(data.usage.storage_bytes, data.limits.max_storage_bytes)}
+            />
+
+            <div className="pt-2">
+              <button
+                onClick={() => mutate()}
+                className="text-xs text-muted hover:text-foreground transition"
+              >
+                Refresh
+              </button>
+            </div>
+          </section>
+        </div>
+      )}
+    </PageShell>
+  );
+}

--- a/web/src/app/components/loft/Sidebar.tsx
+++ b/web/src/app/components/loft/Sidebar.tsx
@@ -6,7 +6,7 @@ import type { ReactNode } from "react";
 import { useAuth } from "../AuthProvider";
 import { usePendingCount } from "../hooks/usePendingCount";
 
-type IconKey = "plus" | "grid" | "clock" | "globe" | "key" | "settings" | "msg" | "shield";
+type IconKey = "plus" | "grid" | "clock" | "globe" | "key" | "settings" | "msg" | "shield" | "card";
 
 const ICONS: Record<IconKey, ReactNode> = {
   plus: (
@@ -49,6 +49,13 @@ const ICONS: Record<IconKey, ReactNode> = {
     </>
   ),
   msg: <path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z" />,
+  card: (
+    <>
+      <rect x="3" y="5" width="18" height="14" rx="2" />
+      <path d="M3 10h18" />
+      <path d="M7 15h3" />
+    </>
+  ),
   // Shield-with-checkmark — denotes the signing-secret integrity guard.
   // Matches the "API keys" icon's silhouette weight so the credential
   // pair reads as visually related in the sidebar.
@@ -93,6 +100,7 @@ const NAV_ITEMS: NavItem[] = [
   { href: "/domains", label: "Domains", icon: "globe" },
   { href: "/api-keys", label: "API keys", icon: "key" },
   { href: "/webhook-secrets", label: "Webhook secrets", icon: "shield" },
+  { href: "/billing", label: "Billing", icon: "card" },
 ];
 
 function NavIcon({ kind }: { kind: IconKey }) {


### PR DESCRIPTION
## Summary

Adds a generic, billing-agnostic resource-limits primitive to OSS so an external provisioner (the private `e2a-ops/billing` sidecar in our case, but anything that can write the `account_limits` table works) can drive per-user caps. The OSS server itself stays free of Stripe / plan-name / dollar-amount references — `plan_code` and `upgrade_url` are opaque strings written by whoever provisions the row.

The OSS half of a two-repo change. The hosted-service Stripe sidecar that drives this primitive lives in [Mnexa-AI/e2a-ops](https://github.com/Mnexa-AI/e2a-ops) on branch `feat/billing-sidecar` (companion PR).

## What's in here

- **Schema (migrations 016-018):** `account_limits` (caps) + `account_usage` (storage rollup) + INSERT/DELETE trigger on `messages` that maintains `storage_bytes`; idempotent backfill from existing rows. Migration 017 adds `last_event_at` and 018 adds `last_event_id` as a composite ordering field the external provisioner uses to guard against out-of-order delivery.
- **`internal/limits` package:** `Enforcer` interface, `DBEnforcer` with a 60s cache (limits only; counts always live), `LimitExceededError` carrying `upgrade_url` for 402 responses. Operator-configured defaults in `config.yaml` for self-host.
- **Wiring:** enforcer checks at `POST /api/v1/agents`, `POST /api/v1/domains`, `POST /api/v1/send`, `POST /api/v1/agents/{email}/messages/{id}/reply`, `POST /api/v1/agents/{email}/test`, and SMTP RCPT TO. Cap-exceeded responses are HTTP 402 with a `LimitErrorBody` payload, or SMTP 552 for inbound.
- **HTTP endpoints:**
  - `GET /api/v1/users/me/limits` (session-authed) — returns caps + current usage for the dashboard.
  - `POST /api/internal/limits/invalidate` (HMAC-signed) — busts the in-process cache after a provisioner write.
- **Dashboard:** `/billing` page with usage bars, Upgrade/Manage Billing buttons gated by `NEXT_PUBLIC_BILLING_API`. Buttons POST via fetch (SameSite=Lax-safe; not CSRF-able).
- **User-deletion hook:** new `BillingHookURL` config; on `DELETE /api/v1/users/me`, OSS POSTs an HMAC-signed `{user_id}` to the external billing service so it can cancel the user's subscription before the cascade.
- **Pre-existing webhook race fix:** unrelated to billing but exposed by the new trigger — `CreateDelivery` now uses Postgres `now()` for `next_retry_at` instead of binding Go's `time.Now()`, fixing a clock-domain mismatch with `GetPendingDeliveries`.

## OSS hygiene check

Confirmed via grep: no Stripe SDK import, no dollar amounts, no plan names in production code. Only mentions are doc comments that compare patterns ("Stripe-style idempotency") or explicitly state the separation ("no Stripe in OSS").

## Test plan

- [x] `make test-unit` passes (7 packages: headers, outbound, relay, config, webhook, approvaltoken, limits)
- [x] `make test-integration` passes (6 packages, runs with -p 1: identity, agent, hitlworker, hitlnotify, limits, relay)
- [x] Web `npx jest` passes (25 suites / 259 tests including new `/billing` page tests)
- [x] End-to-end manual walkthrough: sign in → /billing shows Free defaults → click Upgrade → Stripe Checkout → pay with 4242 4242 4242 4242 → redirected back → caps flipped to Pro → click Manage Billing → portal → cancel immediately → caps back to Free
- [x] DB-backed integration tests cover: storage trigger increments/decrements correctly; enforcer blocks at agent/domain/message caps; full user lifecycle (default → Pro → Free); ordering predicate rejects out-of-order events; same-second event_id tiebreaker resolves correctly

## Pre-deploy checklist (operators only)

The `config.example.yaml` `limits:` block ships with intentionally generous defaults (1 million / 1 billion) so self-host isn't accidentally throttled. Hosted operators override these in their own config. Set `internal_api_secret` and `billing_hook_url` if running with a billing provisioner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)