### PR TITLE
release: SDKs 2.4.0 → 2.5.0 (limits primitive types)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3209,7 +3209,7 @@
     },
     "sdks/typescript": {
       "name": "@e2a/sdk",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "mailparser": "^3.9.8",

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 2.5.0
+
+### Added
+- Generated types for the per-user resource-limits primitive that
+  shipped with #158: `LimitsInfo`, `LimitsCaps`, `LimitsUsage`. These
+  describe the response shape of `GET /api/v1/users/me/limits`, which
+  the hosted dashboard uses to render the upgrade affordance and the
+  "you've used X of Y" surface. The high-level `E2AClient` doesn't
+  yet expose a typed helper for this endpoint — it's surfaced as a
+  dashboard-only concern today, and SDK consumers querying their own
+  usage should call `/agents` / `/messages` directly. The types are
+  emitted so anyone consuming the raw OpenAPI generation has the
+  shapes available.
+
+### Notes
+- No runtime client behavior changed in this release. If you're not
+  using the limits primitive (self-host deployments without a paid
+  tier), 2.5.0 is functionally identical to 2.4.0.
+
 ## 2.4.0
 
 ### Added

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "e2a"
-version = "2.4.0"
+version = "2.5.0"
 description = "Python SDK for the e2a protocol — email-to-agent authentication"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/sdk",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "TypeScript SDK for e2a — email for AI agents",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary
Narrow release covering only PR #158 (limits primitive). New generated types: \`LimitsInfo\`, \`LimitsCaps\`, \`LimitsUsage\` — the response shape of \`GET /api/v1/users/me/limits\`.

The high-level clients don't expose a typed helper for this endpoint yet — it's surfaced as a dashboard-only concern today, and SDK consumers querying their own usage should call \`/agents\` / \`/messages\` directly. The types are emitted so anyone consuming the raw OpenAPI generation has the shapes available.

## Versions
| Package | Old | New | Reason |
|---|---|---|---|
| \`@e2a/sdk\` (TS) | 2.4.0 | 2.5.0 | New generated types |
| \`e2a\` (Python) | 2.4.0 | 2.5.0 | New generated types |
| \`@e2a/cli\` | 1.5.0 | — | Unchanged (no commits since 1.5.0) |
| \`@e2a/mcp-server\` | 0.4.0 | — | Unchanged (no commits since 0.4.0) |

CLI and MCP are deliberately not version-bumped — patch bumps for unchanged code add noise to the npm release feed.

## Behavior
No runtime client changes. Self-host deployments without a paid tier are functionally identical to 2.4.0.

## After merge

\`\`\`bash
git tag python-v2.5.0 && git push origin python-v2.5.0
git tag ts-sdk-v2.5.0 && git push origin ts-sdk-v2.5.0
\`\`\`

…fires the \`Publish Python SDK\` and \`Publish TypeScript SDK\` workflows.

## Test plan
- [x] \`npm run build --workspace @e2a/sdk\` clean
- [x] \`npm test --workspace @e2a/sdk\` — 85 tests passing
- [x] \`package-lock.json\` regenerated against the bumped \`@e2a/sdk\`
- [ ] After tag push: confirm both publish workflows succeed and the new versions appear on npm + PyPI