### PR TITLE
fix(api): tighten send/domain validation, complete domains CRUD

### DIFF
--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"net/mail"
 	"net/url"
 	"os"
 	"regexp"
@@ -30,6 +31,7 @@ import (
 	"github.com/google/go-github/v72/github"
 	"github.com/gorilla/mux"
 	"github.com/ory/fosite"
+	"golang.org/x/net/idna"
 )
 
 // writeJSON encodes payload as the response body. Logs encoding errors
@@ -285,6 +287,7 @@ func (a *API) RegisterRoutes(r *mux.Router) {
 	r.HandleFunc("/api/v1/domains", a.handleListDomains).Methods("GET")
 	r.HandleFunc("/api/v1/domains", a.handleRegisterDomain).Methods("POST")
 	r.HandleFunc("/api/v1/domains/{domain}/verify", a.handleVerifyDomain).Methods("POST")
+	r.HandleFunc("/api/v1/domains/{domain}", a.handleGetDomain).Methods("GET")
 	r.HandleFunc("/api/v1/domains/{domain}", a.handleUpdateDomain).Methods("PATCH")
 	r.HandleFunc("/api/v1/domains/{domain}", a.handleDeleteDomain).Methods("DELETE")
 
@@ -961,13 +964,21 @@ func (a *API) handleRegisterDomain(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return
 	}
-	if req.Domain == "" {
-		http.Error(w, "domain is required", http.StatusBadRequest)
+	// Syntactic validation before any DB work — rejects whitespace,
+	// control chars, missing TLD, over-length names, etc., and
+	// normalizes IDN to Punycode. Without this the previous handler
+	// accepted strings like "not a domain, just garbage" and wrote
+	// them straight to billing_customers + DNS records.
+	normalized, err := validateDomain(req.Domain)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+	req.Domain = normalized
 	// The configured shared domain is reserved — users cannot claim it
 	// as a custom domain, since it backs slug-based agent registration
-	// for everyone.
+	// for everyone. Compare against the normalized form so an attacker
+	// can't sneak in a homoglyph or trailing whitespace variant.
 	if a.sharedDomain != "" && strings.EqualFold(req.Domain, a.sharedDomain) {
 		http.Error(w, "reserved domain", http.StatusBadRequest)
 		return
@@ -996,6 +1007,58 @@ func (a *API) handleRegisterDomain(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
 	writeJSON(w, a.domainInfoFromRecord(domainRecord))
+}
+
+// handleGetDomain serves GET /api/v1/domains/{domain}. Returns the
+// caller's view of a single domain they own, including the DNS-record
+// instructions and the current verification + agent-count state. The
+// OpenAPI spec has documented this endpoint since the domains CRUD
+// surface landed, but the route was never registered — clients hitting
+// it got 405 (other methods are wired at the same path) and had to fall
+// back to listing all domains and filtering client-side.
+//
+// Anti-enumeration: an unowned domain returns the same 404 as a
+// nonexistent domain. We never confirm existence to a non-owner.
+//
+// @Summary      Get a domain
+// @Description  Returns the authenticated user's view of a single domain
+//
+//	they own, including DNS records and verification state.
+//	Returns 404 for both nonexistent and unowned domains
+//	(anti-enumeration — we never confirm existence to a
+//	non-owner).
+//
+// @Tags         Domains
+// @Produce      json
+// @Security     BearerAuth
+// @Param        domain path string true "Domain name"
+// @Success      200 {object} Domain "OK"
+// @Failure      401 {string} string "Missing or invalid API key"
+// @Failure      404 {string} string "Domain not found"
+// @Router       /api/v1/domains/{domain} [get]
+func (a *API) handleGetDomain(w http.ResponseWriter, r *http.Request) {
+	user, err := a.authenticateUser(r)
+	if err != nil {
+		a.writeAuthError(w, r, err)
+		return
+	}
+
+	domain := mux.Vars(r)["domain"]
+	if domain == "" {
+		http.Error(w, "domain is required", http.StatusBadRequest)
+		return
+	}
+
+	d, err := a.store.LookupDomain(r.Context(), domain, user.ID)
+	if err != nil {
+		// LookupDomain is ownership-scoped — same 404 for nonexistent
+		// and unowned. Don't surface the underlying error string.
+		http.Error(w, "domain not found", http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	writeJSON(w, a.domainInfoFromRecord(d))
 }
 
 // dnsRecordCheck holds the per-record probe results for the verify
@@ -1487,6 +1550,15 @@ func (a *API) handleSendEmail(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "at least one recipient in to or cc is required", http.StatusBadRequest)
 		return
 	}
+	// Reject syntactically-invalid recipients before queueing. Without
+	// this the message would HITL-queue, consume a slot of the user's
+	// messages_month quota, and only fail downstream at SMTP-time as
+	// an unactionable bounce. Per-recipient delivery success/bounce
+	// for *syntactically-valid* addresses is handled at the SMTP layer.
+	if err := validateRecipients(req.To, req.CC, req.BCC); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 	if err := validateConversationID(req.ConversationID); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -1810,6 +1882,14 @@ func (a *API) handleReplyToMessage(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Body == "" {
 		http.Error(w, "body is required", http.StatusBadRequest)
+		return
+	}
+	// User-supplied CC/BCC on the reply must still pass syntactic
+	// validation; the implicit "To" comes from the inbound message
+	// and is trusted to already be valid (SES would have rejected the
+	// inbound otherwise).
+	if err := validateRecipients(req.CC, req.BCC); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	if err := validateConversationID(req.ConversationID); err != nil {
@@ -2549,6 +2629,72 @@ func validateConversationID(id string) error {
 		return errors.New("conversation_id must not contain CR or LF")
 	}
 	return nil
+}
+
+// validateRecipients ensures every entry in the joined To/CC/BCC slices
+// is a syntactically valid RFC 5322 address. We use net/mail.ParseAddress
+// rather than a custom regex because it handles bare local@domain,
+// display-name forms ("Bob Smith <bob@x.com>"), quoted local parts, and
+// IDN domains uniformly. Semantic validity (the mailbox actually exists,
+// the user can receive) is checked downstream by the SMTP relay on a
+// per-recipient basis — that's the right layer for best-effort delivery.
+// The API layer's job is only to reject syntactic garbage that could
+// never route through SMTP at all (no @, whitespace, etc.).
+//
+// Returns the first invalid address found, with a wrapped parser error
+// suitable for surfacing to the caller. Empty slices are not an error
+// here — handlers already enforce "at least one recipient" separately
+// with a more specific message.
+func validateRecipients(groups ...[]string) error {
+	for _, group := range groups {
+		for _, addr := range group {
+			if addr == "" {
+				return errors.New("recipient address must not be empty")
+			}
+			if _, err := mail.ParseAddress(addr); err != nil {
+				return fmt.Errorf("invalid recipient %q: %w", addr, err)
+			}
+		}
+	}
+	return nil
+}
+
+// validateDomain runs the IDNA "Lookup" profile against a user-supplied
+// domain string. Lookup is the strictest of the four IDNA profiles and
+// is what DNS resolvers themselves apply when converting a name into
+// a wire-format query — it rejects whitespace, control characters,
+// invalid label combinations, and over-length names; converts Unicode
+// IDN to Punycode along the way. We additionally require at least one
+// period because IDNA accepts bare labels like "localhost" which
+// aren't legal as a user-claimable domain.
+//
+// Returns the ASCII-normalized form on success so callers can persist
+// the canonical wire-format (e.g. "xn--e1afmkfd.xn--p1ai" for
+// "пример.рф") instead of the raw input.
+func validateDomain(domain string) (string, error) {
+	if domain == "" {
+		return "", errors.New("domain is required")
+	}
+	if !strings.Contains(domain, ".") {
+		return "", errors.New("domain must contain at least one period")
+	}
+	ascii, err := idna.Lookup.ToASCII(domain)
+	if err != nil {
+		return "", fmt.Errorf("invalid domain: %w", err)
+	}
+	// IDNA's VerifyDNSLength option only enforces the 253-char total
+	// length; the 63-char per-label DNS limit (RFC 1035) is not
+	// checked. Walk labels explicitly so we don't accept domains that
+	// would fail downstream at the resolver.
+	for _, label := range strings.Split(ascii, ".") {
+		if label == "" {
+			return "", errors.New("invalid domain: empty label")
+		}
+		if len(label) > 63 {
+			return "", errors.New("invalid domain: label exceeds 63 characters")
+		}
+	}
+	return ascii, nil
 }
 
 func clientIP(r *http.Request) string {

--- a/internal/agent/validate_test.go
+++ b/internal/agent/validate_test.go
@@ -1,6 +1,9 @@
 package agent
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestValidateConversationID(t *testing.T) {
 	cases := []struct {
@@ -20,6 +23,74 @@ func TestValidateConversationID(t *testing.T) {
 			err := validateConversationID(tc.id)
 			if (err != nil) != tc.wantErr {
 				t.Errorf("validateConversationID(%q) err=%v, wantErr=%v", tc.id, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateRecipients(t *testing.T) {
+	cases := []struct {
+		name    string
+		groups  [][]string
+		wantErr bool
+	}{
+		{"empty groups", [][]string{}, false},
+		{"empty slice", [][]string{{}}, false},
+		{"single valid", [][]string{{"alice@example.com"}}, false},
+		{"multiple groups, all valid", [][]string{{"a@x.com", "b@x.com"}, {"c@x.com"}, {"d@x.com"}}, false},
+		{"display-name form", [][]string{{"Alice Smith <alice@example.com>"}}, false},
+		{"IDN domain (Unicode)", [][]string{{"alice@пример.рф"}}, false},
+		{"single invalid — no @", [][]string{{"not an email"}}, true},
+		{"valid then invalid", [][]string{{"alice@x.com", "garbage"}}, true},
+		{"invalid in CC group", [][]string{{"alice@x.com"}, {"oops"}, {"bob@x.com"}}, true},
+		{"empty string in slice", [][]string{{"alice@x.com", ""}}, true},
+		{"whitespace garbage", [][]string{{"   "}}, true},
+		// Typos that LOOK valid pass — SMTP layer handles those (this
+		// is the layering we explicitly want; see validateRecipients
+		// comment in api.go).
+		{"typo but syntactically valid", [][]string{{"bob@gmial.com"}}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateRecipients(tc.groups...)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validateRecipients(%v) err=%v, wantErr=%v", tc.groups, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateDomain(t *testing.T) {
+	cases := []struct {
+		name      string
+		input     string
+		wantErr   bool
+		wantASCII string // expected normalized output on success; "" means don't check
+	}{
+		// Valid
+		{"plain ASCII", "example.com", false, "example.com"},
+		{"subdomain", "agents.example.com", false, "agents.example.com"},
+		{"with hyphen", "my-domain.example.com", false, "my-domain.example.com"},
+		{"IDN normalizes to Punycode", "пример.рф", false, "xn--e1afmkfd.xn--p1ai"},
+		// Invalid — what today's prod was accepting before the fix
+		{"empty", "", true, ""},
+		{"whitespace + comma — the bug repro", "not a domain, just garbage", true, ""},
+		{"single space", "exam ple.com", true, ""},
+		{"no period — bare label", "localhost", true, ""},
+		{"trailing newline", "example.com\n", true, ""},
+		{"control char", "exa\x00mple.com", true, ""},
+		// Length bounds — IDNA enforces 63-char label and 253-char total
+		{"label exceeds 63 chars", strings.Repeat("a", 64) + ".com", true, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := validateDomain(tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Errorf("validateDomain(%q) err=%v, wantErr=%v", tc.input, err, tc.wantErr)
+				return
+			}
+			if !tc.wantErr && tc.wantASCII != "" && got != tc.wantASCII {
+				t.Errorf("validateDomain(%q) got=%q, want=%q (Punycode normalization)", tc.input, got, tc.wantASCII)
 			}
 		})
 	}

--- a/sdks/typescript/src/v1/generated/types.ts
+++ b/sdks/typescript/src/v1/generated/types.ts
@@ -793,7 +793,51 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /**
+         * Get a domain
+         * @description Returns the authenticated user's view of a single domain
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Domain name */
+                    domain: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["Domain"];
+                    };
+                };
+                /** @description Missing or invalid API key */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Domain not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+            };
+        };
         put?: never;
         post?: never;
         /**

--- a/web/public/openapi.yaml
+++ b/web/public/openapi.yaml
@@ -1670,6 +1670,34 @@ paths:
       summary: Delete a domain
       tags:
       - Domains
+    get:
+      description: Returns the authenticated user's view of a single domain
+      parameters:
+      - description: Domain name
+        in: path
+        name: domain
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/Domain'
+        "401":
+          description: Missing or invalid API key
+          schema:
+            type: string
+        "404":
+          description: Domain not found
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Get a domain
+      tags:
+      - Domains
     patch:
       consumes:
       - application/json


### PR DESCRIPTION
## Summary
Three real bugs surfaced by yesterday's e2e-prod run:

### 1. \`/api/v1/send\` accepted syntactically-invalid recipients
\`POST /send {to: ["not an email"]}\` returned **202 with a message_id**. Message got HITL-held, consumed \`messages_month\` quota, would only ever fail at SMTP-time as an unactionable bounce. Same gap in \`/messages/{id}/reply\` for user-supplied CC/BCC.

**Fix:** \`validateRecipients()\` runs \`net/mail.ParseAddress\` on each entry; first failure → 400. SMTP layer continues handling per-recipient success/bounce for *syntactically-valid* addresses (typos like \`bob@gmial.com\` still pass — same layering as Resend, SendGrid, Postmark, Mailgun, and SES).

### 2. \`POST /api/v1/domains\` accepted garbage
\`{domain: "not a domain, just garbage"}\` returned **201** with verification token and DNS records. Pollutes the user's domain list with un-verifiable entries.

**Fix:** \`validateDomain()\` runs \`golang.org/x/net/idna\`'s Lookup profile (strictest, what DNS resolvers themselves apply). Rejects whitespace, control chars, invalid labels, over-length names. Returns ASCII-normalized form — IDN like \`пример.рф\` is persisted as \`xn--e1afmkfd.xn--p1ai\`. Adds explicit per-label 63-char check because IDNA's \`VerifyDNSLength\` only enforces the 253-char *total*.

### 3. \`GET /api/v1/domains/{domain}\` returned 405
The OpenAPI spec has documented this endpoint forever, but the route was never registered. Other methods (PATCH/DELETE/verify) are at the same path so gorilla/mux 405'd on GET. Clients had to LIST and filter.

**Fix:** \`handleGetDomain\` mirrors \`handleGetAgent\` — auth, ownership-scoped lookup, 404 for nonexistent *and* unowned (anti-enumeration), return the \`Domain\` schema on hit.

## Tests
\`internal/agent/validate_test.go\` extended with 23 new cases:

- \`validateRecipients\` — empty groups, display-name form, IDN domains, garbage strings, whitespace-only, the exact \`"not an email"\` repro from the e2e-prod failure, and the "typo that's valid syntax" case (\`bob@gmial.com\`) to lock in the API/SMTP layering.
- \`validateDomain\` — plain ASCII, IDN normalization to Punycode, the \`"not a domain, just garbage"\` repro, length bounds (label > 63 chars), empty labels, control chars.

All pass. Full \`make test-unit\` clean. Full \`go test ./internal/agent/\` clean (49s, DB-backed).

## Regenerated artifacts
- \`web/public/openapi.yaml\` — adds the GET endpoint (+28 lines)
- \`sdks/typescript/src/v1/generated/types.ts\` — adds the operation (+45 lines)
- Python SDK regen had no diff (\`Domain\` shape already present from 2.5.0 release)

## Test plan
- [x] \`make test-unit\` clean
- [x] \`go test ./internal/agent/ -short\` clean (49s)
- [x] All 23 new test cases pass
- [x] \`make swagger && make generate-sdk\` regenerated cleanly
- [ ] After deploy: re-run e2e-prod suites — \`07-error-contract / send-bad-recipient\`, \`08-mcp / send-bad-recipient-accepted\`, \`10-domains / register-malformed\`, \`10-domains / GET roundtrip\` should now all pass

## Follow-up not in scope
Bigger picture: codebase has been disciplined about business-logic validation but lax about syntactic input validation at the API boundary. Worth a small follow-up sweep across other handlers. Not in scope here.