### PR TITLE
test(e2e-prod): fix 3 MCP test bugs in 12-mcp-extended

### DIFF
--- a/tests/e2e-prod/suites/12-mcp-extended.test.ts
+++ b/tests/e2e-prod/suites/12-mcp-extended.test.ts
@@ -70,8 +70,15 @@ test("mcp-ext: send_email tool happy path with HITL agent queues message", async
     return;
   }
   const email = await ensureHitlAgent();
+  // The MCP send_email tool's schema uses `agent_email` (matching the
+  // E2A_AGENT_EMAIL env var name), NOT `from` (which is the raw HTTP
+  // API name). Passing `from` triggers Zod's strict-schema rejection
+  // before the tool body ever runs. The corresponding param is also
+  // optional when E2A_AGENT_EMAIL is set in the server env, but we
+  // pass it explicitly here because this test creates a fresh agent
+  // per run and we want to send from THAT agent, not the env default.
   const r = await callTool(mcp, "send_email", {
-    from: email,
+    agent_email: email,
     to: [SINK_EMAIL],
     subject: uniqueSubject("mcp send"),
     body: "from MCP",
@@ -108,8 +115,11 @@ test("mcp-ext: list_pending_messages and get_pending_message round-trip", async 
   }
   const id = s.body.message_id;
 
-  // list_pending_messages — should include our queued msg.
-  const lp = await callTool(mcp, "list_pending_messages", { page_size: 20 });
+  // list_pending_messages — should include our queued msg. The MCP
+  // tool's schema is strictInputSchema({}) — it takes ZERO arguments
+  // (no page_size, no token). The HTTP API does paginate; the MCP
+  // wrapper deliberately doesn't expose that surface. Pass nothing.
+  const lp = await callTool(mcp, "list_pending_messages");
   if (lp.isError) {
     fail(SUITE, "list-pending-error", `list_pending_messages isError: ${extractText(lp).slice(0, 200)}`);
   } else {
@@ -195,11 +205,19 @@ test("mcp-ext: get_message returns shape and only own messages", async () => {
     info(SUITE, "get-msg-absent", "no get_message tool — skipping");
     return;
   }
-  // First find a message id from the inbox.
-  const listMsgs = await apiClient.get<{ messages: Array<{ id: string }> }>("/api/v1/messages", { query: { limit: 1 } });
+  // The MCP get_message tool fetches via the AGENT-scoped endpoint
+  // GET /api/v1/agents/{agent_email}/messages/{id} — anti-enumeration
+  // 404s on any message that doesn't belong to the pinned agent. We
+  // pull candidate IDs from the same scope so the test exercises the
+  // happy path instead of accidentally tripping the cross-agent guard.
+  const pinnedAgent = apiClient.env.primaryAgentEmail;
+  const listMsgs = await apiClient.get<{ messages: Array<{ id: string }> }>(
+    `/api/v1/agents/${encodeURIComponent(pinnedAgent)}/messages`,
+    { query: { limit: 1 } },
+  );
   const id = listMsgs.body?.messages?.[0]?.id;
   if (!id) {
-    info(SUITE, "get-msg-no-fixture", "no messages in inbox — cannot probe get_message happy path");
+    info(SUITE, "get-msg-no-fixture", `no messages in agent ${pinnedAgent}'s inbox — cannot probe get_message happy path`);
     return;
   }
   const r = await callTool(mcp, "get_message", { message_id: id });


### PR DESCRIPTION
## Summary
Six findings from yesterday's full e2e-prod run categorized as "smaller issues / test-fixable / test-environment" — turned out to be **3 test bugs** (fixed here) and **3 non-bugs** (notes only).

## Investigation results

| # | Finding | Verdict | Evidence | Action |
|---|---|---|---|---|
| 4 | \`agents: update hitl_enabled via PUT persists\` failed | **Not a real bug** — same root cause as #8 | Log shows \`AssertionError: 402 !== 201\` at the test's **setup** (\`POST /agents\`); never reached PUT readback | None until #8 resolved |
| 5 | MCP \`send_email\` rejects \`from\` | **Test bug** | [\`mcp/src/tools/messages.ts:32-37\`](mcp/src/tools/messages.ts#L32-L37) declares \`agent_email\` (optional), not \`from\` | **Fixed** |
| 6 | MCP \`list_pending_messages\` rejects \`page_size\` | **Test bug** | [\`mcp/src/tools/hitl.ts:14\`](mcp/src/tools/hitl.ts#L14) is \`strictInputSchema({})\` — zero args | **Fixed** |
| 7 | MCP \`get_message\` returns 404 for visible message | **Test bug** | MCP routes through agent-scoped \`/api/v1/agents/{email}/messages/{id}\`; test pulled IDs from user-scoped \`/api/v1/messages\`, picking messages from a different agent than MCP was pinned to | **Fixed** |
| 8 | Cascade-fail at \`agents cap (25/25)\` | **Operational, not code** | Test account accumulated leftover resources across runs | Separate ops task (not in PR) |
| 9 | \`usage.agents=17\` vs \`/agents list=18\` | **Expected timing race** | Two sequential HTTP calls at 1 RPS during multi-minute concurrent-create run; test already tolerates ±1 and reported as INFO | None |

## Code changes
All three test bugs live in [\`tests/e2e-prod/suites/12-mcp-extended.test.ts\`](tests/e2e-prod/suites/12-mcp-extended.test.ts):

- \`send_email\`: \`from\` → \`agent_email\`
- \`list_pending_messages\`: drop the args object entirely (passes the tool's strict {})
- \`get_message\`: pull candidate IDs from the agent-scoped endpoint so the test exercises the happy path

Inline comments on each fix explain *why* (and reference the source-of-truth schema line) so the next person editing the test can't make the same mistake.

## Test plan
- [x] Investigation confirmed for each finding (file + line citations in commit message)
- [ ] After merge + next e2e-prod run, all three previously-failed tests should pass against prod, leaving only **#8 (operational)** as the remaining suite-runtime failure mode

## What's NOT in this PR
- **#8 (cap exhaustion)** — needs a one-time cleanup pass on prod (delete leftover \`e2etest-*\` agents and \`*.example.com\` domains). Operational task, will run via psql/API after PR lands.
- **Pre-run cleanup hardening in the harness** — could prevent #8 from re-occurring; out of scope here, file as follow-up if you want it.