### PR TITLE
feat(api): forward inbound messages — /messages/{id}/forward across SDKs, CLI, MCP

### DIFF
--- a/cli/src/bin/e2a.ts
+++ b/cli/src/bin/e2a.ts
@@ -9,6 +9,7 @@ import {
 } from "../commands/agents.js";
 import { inbox } from "../commands/inbox.js";
 import { read } from "../commands/read.js";
+import { forward } from "../commands/forward.js";
 import { reply } from "../commands/reply.js";
 import { send } from "../commands/send.js";
 import { config } from "../commands/config.js";
@@ -40,6 +41,7 @@ Usage:
   e2a inbox [--unread|--read] [--limit N] [--oldest] [--from substr] [--subject substr] [--conversation id] [--since ts] [--until ts] [--token …]   List messages (newest first; --oldest for FIFO)
   e2a read <message-id>             Read a message
   e2a reply <msg-id> --body … [--reply-all] [--cc …] [--bcc …]
+  e2a forward <msg-id> --to … [--cc …] [--bcc …] [--body …]
   e2a send [--to …] [--cc …] [--bcc …] --subject … --body …
   e2a listen [options]              Listen for emails via WebSocket
   e2a domains list                  List your domains
@@ -222,6 +224,17 @@ async function main() {
         replyAll: hasFlag(args, "--reply-all"),
         cc: getFlags(args, "--cc"),
         bcc: getFlags(args, "--bcc"),
+        from: getFlag(args, "--agent"),
+        idempotencyKey: getFlag(args, "--idempotency-key"),
+      });
+      break;
+    case "forward":
+      await forward(args[0], {
+        to: getFlags(args, "--to"),
+        cc: getFlags(args, "--cc"),
+        bcc: getFlags(args, "--bcc"),
+        body: getFlag(args, "--body"),
+        htmlBody: getFlag(args, "--html-body"),
         from: getFlag(args, "--agent"),
         idempotencyKey: getFlag(args, "--idempotency-key"),
       });

--- a/cli/src/commands/forward.ts
+++ b/cli/src/commands/forward.ts
@@ -1,0 +1,44 @@
+import { createClient } from "../sdk.js";
+
+export async function forward(
+  messageId: string | undefined,
+  opts: {
+    to: string[];
+    cc?: string[];
+    bcc?: string[];
+    body?: string;
+    htmlBody?: string;
+    from?: string;
+    idempotencyKey?: string;
+  },
+): Promise<void> {
+  if (!messageId) {
+    process.stderr.write(
+      "Usage: e2a forward <message-id> --to <addr> [--cc <addr>] [--bcc <addr>] [--body \"...\"] [--html-body \"...\"]\n",
+    );
+    process.exit(1);
+  }
+  if (!opts.to.length) {
+    process.stderr.write("--to is required (at least one recipient)\n");
+    process.exit(1);
+  }
+
+  const client = createClient({ from: opts.from });
+
+  if (!client.agentEmail) {
+    process.stderr.write(
+      "No agent email configured. Run 'e2a register' first or use --agent.\n",
+    );
+    process.exit(1);
+  }
+
+  const res = await client.forward(messageId, opts.to, {
+    cc: opts.cc?.length ? opts.cc : undefined,
+    bcc: opts.bcc?.length ? opts.bcc : undefined,
+    body: opts.body,
+    htmlBody: opts.htmlBody,
+    idempotencyKey: opts.idempotencyKey,
+  });
+
+  process.stdout.write(`Sent: ${res.message_id}\n`);
+}

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -1636,7 +1636,7 @@ func (a *API) handleSendEmail(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if selfSend {
-		providerID, err := a.performSelfSend(r.Context(), agent, req)
+		providerID, err := a.performSelfSend(r.Context(), agent, req, "send")
 		if err != nil {
 			log.Printf("[api] self-send failed: agent=%s error=%v", agent.EmailAddress(), err)
 			http.Error(w, "self-send failed", http.StatusInternalServerError)
@@ -1973,7 +1973,7 @@ func (a *API) handleReplyToMessage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if selfReply {
-		providerID, err := a.performSelfSend(r.Context(), agent, sendReq)
+		providerID, err := a.performSelfSend(r.Context(), agent, sendReq, "reply")
 		if err != nil {
 			log.Printf("[api] self-reply failed: agent=%s error=%v", agent.EmailAddress(), err)
 			http.Error(w, "self-reply failed", http.StatusInternalServerError)
@@ -2175,7 +2175,7 @@ func (a *API) handleForwardMessage(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if selfForward {
-		providerID, err := a.performSelfSend(r.Context(), agent, sendReq)
+		providerID, err := a.performSelfSend(r.Context(), agent, sendReq, "forward")
 		if err != nil {
 			log.Printf("[api] self-forward failed: agent=%s error=%v", agent.EmailAddress(), err)
 			http.Error(w, "self-forward failed", http.StatusInternalServerError)

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -284,6 +284,7 @@ func (a *API) RegisterRoutes(r *mux.Router) {
 	r.HandleFunc("/api/v1/agents/{email}/messages", a.handleGetMessages).Methods("GET")
 	r.HandleFunc("/api/v1/agents/{email}/messages/{id}", a.handleGetMessage).Methods("GET")
 	r.HandleFunc("/api/v1/agents/{email}/messages/{id}/reply", a.handleReplyToMessage).Methods("POST")
+	r.HandleFunc("/api/v1/agents/{email}/messages/{id}/forward", a.handleForwardMessage).Methods("POST")
 	r.HandleFunc("/api/v1/domains", a.handleListDomains).Methods("GET")
 	r.HandleFunc("/api/v1/domains", a.handleRegisterDomain).Methods("POST")
 	r.HandleFunc("/api/v1/domains/{domain}/verify", a.handleVerifyDomain).Methods("POST")
@@ -1441,7 +1442,7 @@ func (a *API) domainInfoFromRecord(d *identity.Domain) DomainInfo {
 // handleSendTestEmail when agent.HITLEnabled is true.
 //
 // replyToEmailMessageID is the inbound Message-ID being replied to, or "".
-// msgType is one of "send", "reply", or "test".
+// msgType is one of "send", "reply", "test", or "forward".
 func (a *API) holdForApproval(w http.ResponseWriter, r *http.Request, agent *identity.AgentIdentity, req outbound.SendRequest, msgType, replyToEmailMessageID string) {
 	var attachmentsJSON []byte
 	if len(req.Attachments) > 0 {
@@ -2014,6 +2015,205 @@ func (a *API) handleReplyToMessage(w http.ResponseWriter, r *http.Request) {
 	slug, _, _ := strings.Cut(agent.EmailAddress(), "@")
 	if outMsg != nil {
 		log.Printf("[mail:%s] dir=outbound type=reply from=%s to=%v slug=%s conv_id=%s subject=%q in_reply_to=%s", outMsg.ID, agent.EmailAddress(), result.To, slug, req.ConversationID, subject, msgID)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	writeJSON(w, map[string]string{
+		"status":     "sent",
+		"message_id": result.MessageID,
+		"method":     result.Method,
+	})
+}
+
+// ForwardRequest is the JSON body for /api/v1/agents/{email}/messages/{id}/forward.
+type ForwardRequest struct {
+	To             []string              `json:"to"`
+	CC             []string              `json:"cc,omitempty"`
+	BCC            []string              `json:"bcc,omitempty"`
+	Body           string                `json:"body,omitempty"`
+	HTMLBody       string                `json:"html_body,omitempty"`
+	ConversationID string                `json:"conversation_id,omitempty"`
+	Attachments    []outbound.Attachment `json:"attachments,omitempty"`
+}
+
+// handleForwardMessage forwards a previously received email to new recipients.
+// @Summary      Forward an inbound email
+// @Description  Forward a previously received email to one or more new recipients. The server prepends the caller's optional comment, then a Gmail-style "Forwarded message" block with the original headers and best-effort extracted body. A forward is treated as a NEW thread — no In-Reply-To/References headers are emitted; pass conversation_id to bind it to an existing thread explicitly. Rate limited to 60 sends per agent per minute; 429 responses carry a `Retry-After` header in delay-seconds form. When the owning agent has HITL enabled, the server returns 202 Accepted with status="pending_approval".
+// @Tags         Email
+// @Accept       json
+// @Produce      json
+// @Security     BearerAuth
+// @Param        email path string true "Agent email address" example(my-bot@example.com)
+// @Param        id    path string true "Message ID from the inbound payload" example(msg_abc123)
+// @Param        request body ForwardMessageRequest true "Forward content"
+// @Success      200 {object} SendEmailResponse "Forward sent immediately"
+// @Success      202 {object} SendEmailResponse "Forward held for human approval"
+// @Failure      400 {string} string "Missing or invalid fields"
+// @Failure      401 {string} string "Missing or invalid API key"
+// @Failure      403 {string} string "Agent domain not verified"
+// @Failure      404 {string} string "Message not found or does not belong to this agent"
+// @Failure      409 {string} string "Another request with this Idempotency-Key is in progress"
+// @Failure      422 {string} string "Idempotency-Key reused with a different request body"
+// @Failure      429 {string} string "Rate limit exceeded"
+// @Param        Idempotency-Key header string false "Caller-generated unique key (recommend UUIDv4). Retries with the same key + same body replay the original response; with a different body return 422."
+// @Router       /api/v1/agents/{email}/messages/{id}/forward [post]
+func (a *API) handleForwardMessage(w http.ResponseWriter, r *http.Request) {
+	user, err := a.authenticateUser(r)
+	if err != nil {
+		a.writeAuthError(w, r, err)
+		return
+	}
+
+	bodyBytes, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxRequestBytesSend))
+	if err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	replayed, captureW, finalize := a.idempotencyGuard(w, r, user.ID, bodyBytes)
+	if replayed {
+		return
+	}
+	defer finalize()
+	w = captureW
+
+	vars := mux.Vars(r)
+	email := normalizeEmail(vars["email"])
+	msgID := vars["id"]
+
+	agent, err := a.resolveAgentForUser(r, email, user)
+	if err != nil {
+		http.Error(w, "agent not found", http.StatusNotFound)
+		return
+	}
+
+	inbound, err := a.store.GetInboundMessage(r.Context(), msgID)
+	if err != nil {
+		http.Error(w, "message not found", http.StatusNotFound)
+		return
+	}
+	if inbound.AgentID != agent.ID {
+		http.Error(w, "message not found", http.StatusNotFound)
+		return
+	}
+
+	if ok, retryAfter := a.sendLimit.AllowWithRetryAfter(agent.ID); !ok {
+		writeTooManyRequests(w, retryAfter, "rate limit exceeded — max 60 sends per minute per agent")
+		return
+	}
+
+	if !agent.DomainVerified {
+		http.Error(w, "agent domain must be verified before sending", http.StatusForbidden)
+		return
+	}
+
+	if a.enforcer != nil {
+		if err := a.enforcer.CheckMessageSend(r.Context(), user.ID); err != nil {
+			if limits.WriteLimitError(w, err) {
+				return
+			}
+			log.Printf("[api] limits.CheckMessageSend error: %v", err)
+			http.Error(w, "limits check failed", http.StatusInternalServerError)
+			return
+		}
+	}
+
+	var req ForwardRequest
+	if err := json.Unmarshal(bodyBytes, &req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if len(req.To) == 0 && len(req.CC) == 0 {
+		http.Error(w, "at least one recipient in to or cc is required", http.StatusBadRequest)
+		return
+	}
+	if err := validateRecipients(req.To, req.CC, req.BCC); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	if err := validateConversationID(req.ConversationID); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	subject := outbound.BuildForwardSubject(inbound.Subject)
+	fwdCtx := outbound.ExtractForwardContext(inbound.RawMessage)
+	composedBody := outbound.BuildForwardBody(req.Body, fwdCtx)
+	var composedHTML string
+	if req.HTMLBody != "" || fwdCtx.HTML != "" || fwdCtx.Text != "" {
+		composedHTML = outbound.BuildForwardHTMLBody(req.HTMLBody, fwdCtx)
+	}
+
+	sendReq := outbound.SendRequest{
+		To:             req.To,
+		CC:             req.CC,
+		BCC:            req.BCC,
+		Subject:        subject,
+		Body:           composedBody,
+		HTMLBody:       composedHTML,
+		ConversationID: req.ConversationID,
+		Attachments:    req.Attachments,
+	}
+
+	// Pre-clean self-aliases so isSelfSend sees a true self-loop when
+	// the caller forwarded a message to the agent's own address.
+	sendReq.CC = stripAgentSelfAliases(sendReq.CC, agent.EmailAddress())
+	sendReq.BCC = stripAgentSelfAliases(sendReq.BCC, agent.EmailAddress())
+	selfForward := isSelfSend(sendReq, agent.EmailAddress())
+
+	if agent.HITLEnabled {
+		// inbound.EmailMessageID is persisted so the review panel can
+		// attach the InboundContext pane. buildSendRequestFromMessage
+		// gates ReplyToMessageID on type="reply", so this won't be
+		// promoted to a threading header on approval.
+		a.holdForApproval(w, r, agent, sendReq, "forward", inbound.EmailMessageID)
+		return
+	}
+
+	if _, err := a.usage.RecordAndCheck(r.Context(), user.ID, agent.ID, agent.Domain, "outbound"); err != nil {
+		log.Printf("[api] usage recording error: %v", err)
+	}
+
+	if selfForward {
+		providerID, err := a.performSelfSend(r.Context(), agent, sendReq)
+		if err != nil {
+			log.Printf("[api] self-forward failed: agent=%s error=%v", agent.EmailAddress(), err)
+			http.Error(w, "self-forward failed", http.StatusInternalServerError)
+			return
+		}
+		markSideEffectCommitted(w)
+		slug, _, _ := strings.Cut(agent.EmailAddress(), "@")
+		log.Printf("[mail] dir=outbound type=forward method=loopback from=%s to=%s slug=%s conv_id=%s subject=%q provider_id=%s orig=%s",
+			agent.EmailAddress(), agent.EmailAddress(), slug, req.ConversationID, subject, providerID, msgID)
+		w.Header().Set("Content-Type", "application/json")
+		writeJSON(w, map[string]string{
+			"status":     "sent",
+			"message_id": providerID,
+			"method":     "loopback",
+		})
+		return
+	}
+
+	result, err := a.sender.Send(agent, sendReq)
+	if err != nil {
+		if outbound.IsValidationError(err) {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		log.Printf("[api] forward failed: agent=%s to=%v error=%v", agent.Domain, req.To, err)
+		http.Error(w, fmt.Sprintf("delivery failed: %v", err), http.StatusInternalServerError)
+		return
+	}
+	markSideEffectCommitted(w)
+
+	outMsg, err := a.store.CreateOutboundMessage(r.Context(), agent.ID, result.To, result.CC, result.BCC, subject, "forward", result.Method, result.MessageID, req.ConversationID)
+	if err != nil {
+		log.Printf("[api] failed to record outbound message: %v", err)
+	}
+
+	slug, _, _ := strings.Cut(agent.EmailAddress(), "@")
+	if outMsg != nil {
+		log.Printf("[mail:%s] dir=outbound type=forward from=%s to=%v slug=%s conv_id=%s subject=%q orig=%s", outMsg.ID, agent.EmailAddress(), result.To, slug, req.ConversationID, subject, msgID)
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/agent/api_docs.go
+++ b/internal/agent/api_docs.go
@@ -64,6 +64,21 @@ type ReplyToMessageRequest struct {
 	Attachments    []Attachment `json:"attachments,omitempty"`
 } // @name ReplyToMessageRequest
 
+// ForwardMessageRequest is the request body for forwarding a message.
+// Body and html_body are the caller's optional comment to prepend; the
+// server appends a quoted block with the original headers and body. A
+// forward is treated as a new thread (no In-Reply-To/References) — pass
+// conversation_id to bind it to an existing thread explicitly.
+type ForwardMessageRequest struct {
+	To             []string     `json:"to" example:"alice@example.com"`
+	CC             []string     `json:"cc,omitempty" example:"bob@example.com"`
+	BCC            []string     `json:"bcc,omitempty" example:"carol@example.com"`
+	Body           string       `json:"body,omitempty" example:"FYI — see below"`
+	HTMLBody       string       `json:"html_body,omitempty" example:"<p>FYI — see below</p>"`
+	ConversationID string       `json:"conversation_id,omitempty"`
+	Attachments    []Attachment `json:"attachments,omitempty"`
+} // @name ForwardMessageRequest
+
 // ListMessagesResponse wraps the message list with pagination.
 type ListMessagesResponse struct {
 	Messages  []MessageSummary `json:"messages"`
@@ -323,7 +338,7 @@ type PendingMessageSummary struct {
 	AgentID           string    `json:"agent_id" example:"my-bot@example.com"`
 	Direction         string    `json:"direction" example:"outbound"`
 	Subject           string    `json:"subject" example:"Re: contract details"`
-	Type              string    `json:"type,omitempty" example:"send" enums:"send,reply,test"`
+	Type              string    `json:"type,omitempty" example:"send" enums:"send,reply,test,forward"`
 	ConversationID    string    `json:"conversation_id,omitempty"`
 	To                []string  `json:"to" example:"alice@example.com"`
 	CC                []string  `json:"cc,omitempty"`

--- a/internal/agent/forward_api_test.go
+++ b/internal/agent/forward_api_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -277,4 +278,239 @@ func firstNLines(s string, n int) string {
 		lines = lines[:n]
 	}
 	return strings.Join(lines, "\n")
+}
+
+func TestForwardMessageSelfForwardUsesLoopback(t *testing.T) {
+	server, store, pool, smtpDone := setupAPIWithSMTP(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "owner-fwd-self@example.com", "Owner", "google-fwd-self")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "fwd-self-key", nil)
+	store.ClaimOrCreateDomain(ctx, "fwd-self.example.com", user.ID)
+	store.VerifyDomain(ctx, "fwd-self.example.com", user.ID)
+	// agent_mode=local so we don't need a webhook URL — the loopback
+	// delivery writes the inbound row directly.
+	agent, _ := store.CreateAgent(ctx, "bot@fwd-self.example.com", "fwd-self.example.com", "", "", "local", user.ID)
+
+	raw := rawInboundForForwardTest("alice@gmail.com", "bot@fwd-self.example.com", "Original", "body line")
+	msg, _ := store.CreateInboundMessage(ctx, "", agent.ID, "alice@gmail.com", "bot@fwd-self.example.com", "<orig@gmail.com>", "Original", "", "", raw, nil, nil, nil, nil)
+
+	// Forward to the agent's OWN address — should short-circuit SMTP.
+	payload := `{"to":["bot@fwd-self.example.com"],"body":"loopback me"}`
+	req, _ := http.NewRequest("POST",
+		server.URL+"/api/v1/agents/bot@fwd-self.example.com/messages/"+msg.ID+"/forward",
+		bytes.NewBufferString(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey.PlaintextKey)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var result map[string]string
+	json.NewDecoder(resp.Body).Decode(&result)
+	if result["method"] != "loopback" {
+		t.Errorf("method = %q, want loopback (SMTP must not be involved on self-forward)", result["method"])
+	}
+	if result["status"] != "sent" {
+		t.Errorf("status = %q, want sent", result["status"])
+	}
+
+	// SMTP must NOT have been touched.
+	if msgs := smtpDone(); len(msgs) != 0 {
+		t.Fatalf("expected 0 SMTP messages on self-forward, got %d", len(msgs))
+	}
+
+	// Two outbound rows now exist for the agent: the original inbound
+	// (direction=inbound) created by setup, plus a new outbound
+	// (type=forward) AND a new inbound for the loopback delivery.
+	var outboundForwards, inboundLoopback int
+	pool.QueryRow(ctx,
+		`SELECT count(*) FROM messages WHERE agent_id=$1 AND direction='outbound' AND message_type='forward'`,
+		agent.ID).Scan(&outboundForwards)
+	pool.QueryRow(ctx,
+		`SELECT count(*) FROM messages WHERE agent_id=$1 AND direction='inbound' AND sender='bot@fwd-self.example.com'`,
+		agent.ID).Scan(&inboundLoopback)
+	if outboundForwards != 1 {
+		t.Errorf("outbound forward rows = %d, want 1", outboundForwards)
+	}
+	if inboundLoopback != 1 {
+		t.Errorf("inbound loopback rows = %d, want 1", inboundLoopback)
+	}
+}
+
+func TestForwardMessageHTMLAtSMTP(t *testing.T) {
+	server, store, _, smtpDone := setupAPIWithSMTP(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "owner-fwd-html@example.com", "Owner", "google-fwd-html")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "fwd-html-key", nil)
+	store.ClaimOrCreateDomain(ctx, "fwd-html.example.com", user.ID)
+	store.VerifyDomain(ctx, "fwd-html.example.com", user.ID)
+	agent, _ := store.CreateAgent(ctx, "bot@fwd-html.example.com", "fwd-html.example.com", "", "https://example.com/webhook", "", user.ID)
+
+	// Multipart inbound with both text and HTML parts — the forward
+	// should preserve both at the SMTP wire.
+	boundary := "INBOUNDBOUND"
+	raw := []byte("From: alice@gmail.com\r\n" +
+		"To: bot@fwd-html.example.com\r\n" +
+		"Subject: Multi-part\r\n" +
+		"Message-ID: <orig-html@gmail.com>\r\n" +
+		"Content-Type: multipart/alternative; boundary=\"" + boundary + "\"\r\n" +
+		"\r\n" +
+		"--" + boundary + "\r\n" +
+		"Content-Type: text/plain; charset=utf-8\r\n" +
+		"\r\n" +
+		"text part body\r\n" +
+		"--" + boundary + "\r\n" +
+		"Content-Type: text/html; charset=utf-8\r\n" +
+		"\r\n" +
+		"<p>html part body</p>\r\n" +
+		"--" + boundary + "--\r\n")
+	msg, _ := store.CreateInboundMessage(ctx, "", agent.ID, "alice@gmail.com", "bot@fwd-html.example.com", "<orig-html@gmail.com>", "Multi-part", "", "", raw, nil, nil, nil, nil)
+
+	payload := `{"to":["dest@example.com"],"body":"plain comment","html_body":"<p>html comment</p>"}`
+	req, _ := http.NewRequest("POST",
+		server.URL+"/api/v1/agents/bot@fwd-html.example.com/messages/"+msg.ID+"/forward",
+		bytes.NewBufferString(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey.PlaintextKey)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	msgs := smtpDone()
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 SMTP message, got %d", len(msgs))
+	}
+	body := msgs[0].Data
+
+	if !strings.Contains(body, "multipart/alternative") {
+		t.Errorf("SMTP body missing multipart/alternative Content-Type")
+	}
+	if !strings.Contains(body, "Content-Type: text/plain") {
+		t.Errorf("SMTP body missing text/plain part")
+	}
+	if !strings.Contains(body, "Content-Type: text/html") {
+		t.Errorf("SMTP body missing text/html part")
+	}
+	if !strings.Contains(body, "plain comment") {
+		t.Errorf("SMTP body missing plain-text caller comment")
+	}
+	// HTML can be QP-encoded over the wire, so check the HTML
+	// comment substring; the forwarded original HTML follows.
+	if !strings.Contains(body, "html comment") {
+		t.Errorf("SMTP body missing html caller comment")
+	}
+	if !strings.Contains(body, "html part body") {
+		t.Errorf("SMTP body missing original HTML content quoted from forwarded message")
+	}
+}
+
+func TestForwardMessageWithAttachments(t *testing.T) {
+	server, store, _, smtpDone := setupAPIWithSMTP(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "owner-fwd-att@example.com", "Owner", "google-fwd-att")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "fwd-att-key", nil)
+	store.ClaimOrCreateDomain(ctx, "fwd-att.example.com", user.ID)
+	store.VerifyDomain(ctx, "fwd-att.example.com", user.ID)
+	agent, _ := store.CreateAgent(ctx, "bot@fwd-att.example.com", "fwd-att.example.com", "", "https://example.com/webhook", "", user.ID)
+
+	raw := rawInboundForForwardTest("alice@gmail.com", "bot@fwd-att.example.com", "Original", "body")
+	msg, _ := store.CreateInboundMessage(ctx, "", agent.ID, "alice@gmail.com", "bot@fwd-att.example.com", "<orig-att@gmail.com>", "Original", "", "", raw, nil, nil, nil, nil)
+
+	// "hello" → "aGVsbG8=" base64
+	payload := `{
+	  "to":["dest@example.com"],
+	  "body":"see attached",
+	  "attachments":[
+	    {"filename":"note.txt","content_type":"text/plain","data":"aGVsbG8="}
+	  ]
+	}`
+	req, _ := http.NewRequest("POST",
+		server.URL+"/api/v1/agents/bot@fwd-att.example.com/messages/"+msg.ID+"/forward",
+		bytes.NewBufferString(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey.PlaintextKey)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	msgs := smtpDone()
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 SMTP message, got %d", len(msgs))
+	}
+	body := msgs[0].Data
+
+	if !strings.Contains(body, `filename="note.txt"`) {
+		t.Errorf("SMTP body missing attachment filename")
+	}
+	if !strings.Contains(body, "Content-Disposition: attachment") {
+		t.Errorf("SMTP body missing attachment Content-Disposition")
+	}
+	if !strings.Contains(body, "aGVsbG8=") {
+		t.Errorf("SMTP body missing attachment data (base64 of 'hello')")
+	}
+}
+
+func TestForwardMessageIdempotentReplay(t *testing.T) {
+	server, store, _, smtpDone := setupAPIWithSMTP(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "owner-fwd-idem@example.com", "Owner", "google-fwd-idem")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "fwd-idem-key", nil)
+	store.ClaimOrCreateDomain(ctx, "fwd-idem.example.com", user.ID)
+	store.VerifyDomain(ctx, "fwd-idem.example.com", user.ID)
+	agent, _ := store.CreateAgent(ctx, "bot@fwd-idem.example.com", "fwd-idem.example.com", "", "https://example.com/webhook", "", user.ID)
+
+	raw := rawInboundForForwardTest("alice@gmail.com", "bot@fwd-idem.example.com", "Original", "body")
+	msg, _ := store.CreateInboundMessage(ctx, "", agent.ID, "alice@gmail.com", "bot@fwd-idem.example.com", "<orig-idem@gmail.com>", "Original", "", "", raw, nil, nil, nil, nil)
+
+	url := server.URL + "/api/v1/agents/bot@fwd-idem.example.com/messages/" + msg.ID + "/forward"
+	payload := `{"to":["dest@example.com"],"body":"once"}`
+	idemKey := "fwd-idem-key-001"
+
+	doForward := func() (*http.Response, []byte) {
+		req, _ := http.NewRequest("POST", url, bytes.NewBufferString(payload))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+apiKey.PlaintextKey)
+		req.Header.Set("Idempotency-Key", idemKey)
+		r, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("forward: %v", err)
+		}
+		b, _ := io.ReadAll(r.Body)
+		r.Body.Close()
+		return r, b
+	}
+
+	r1, b1 := doForward()
+	if r1.StatusCode != 200 {
+		t.Fatalf("first status = %d, body=%s", r1.StatusCode, b1)
+	}
+	if r1.Header.Get("Idempotent-Replayed") != "" {
+		t.Errorf("first call should not be marked replayed")
+	}
+
+	r2, b2 := doForward()
+	if r2.StatusCode != 200 {
+		t.Fatalf("second status = %d, body=%s", r2.StatusCode, b2)
+	}
+	if r2.Header.Get("Idempotent-Replayed") != "true" {
+		t.Errorf("second call must be marked Idempotent-Replayed=true, got %q", r2.Header.Get("Idempotent-Replayed"))
+	}
+	if !bytes.Equal(b1, b2) {
+		t.Errorf("replay body diverged:\nfirst:  %s\nsecond: %s", b1, b2)
+	}
+
+	if msgs := smtpDone(); len(msgs) != 1 {
+		t.Errorf("SMTP messages = %d, want exactly 1 (replay must not re-send)", len(msgs))
+	}
 }

--- a/internal/agent/forward_api_test.go
+++ b/internal/agent/forward_api_test.go
@@ -1,0 +1,280 @@
+package agent_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+)
+
+// rawInboundForForwardTest builds a minimal RFC 5322 message that the
+// forward handler's MIME extractor can parse. Includes a Subject so the
+// composed forward subject can be asserted.
+func rawInboundForForwardTest(from, to, subject, body string) []byte {
+	return []byte("From: " + from + "\r\n" +
+		"To: " + to + "\r\n" +
+		"Subject: " + subject + "\r\n" +
+		"Content-Type: text/plain; charset=utf-8\r\n" +
+		"\r\n" +
+		body)
+}
+
+func TestForwardMessageUnauthorized(t *testing.T) {
+	server, _, _ := setupAPI(t)
+
+	req, _ := http.NewRequest("POST", server.URL+"/api/v1/agents/any@example.com/messages/msg_123/forward",
+		bytes.NewBufferString(`{"to":["alice@example.com"]}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 401 {
+		t.Errorf("status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestForwardMessageNotFound(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "owner-fwd-notfound@example.com", "Owner", "google-fwd-notfound")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "fwd-notfound-key", nil)
+	store.ClaimOrCreateDomain(ctx, "fwd-notfound.example.com", user.ID)
+	store.VerifyDomain(ctx, "fwd-notfound.example.com", user.ID)
+	store.CreateAgent(ctx, "agent@fwd-notfound.example.com", "fwd-notfound.example.com", "", "https://example.com/webhook", "", user.ID)
+
+	req, _ := http.NewRequest("POST",
+		server.URL+"/api/v1/agents/agent@fwd-notfound.example.com/messages/msg_nonexistent/forward",
+		bytes.NewBufferString(`{"to":["alice@example.com"]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey.PlaintextKey)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 404 {
+		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestForwardMessageWrongAgent(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	ctx := context.Background()
+
+	userA, _ := store.CreateOrGetUser(ctx, "owner-fwd-a@example.com", "OwnerA", "google-fwd-a")
+	store.ClaimOrCreateDomain(ctx, "fwd-a.example.com", userA.ID)
+	store.VerifyDomain(ctx, "fwd-a.example.com", userA.ID)
+	agentA, _ := store.CreateAgent(ctx, "agent@fwd-a.example.com", "fwd-a.example.com", "", "https://example.com/webhook", "", userA.ID)
+
+	userB, _ := store.CreateOrGetUser(ctx, "owner-fwd-b@example.com", "OwnerB", "google-fwd-b")
+	apiKeyB, _ := store.CreateAPIKey(ctx, userB.ID, "fwd-b-key", nil)
+	store.ClaimOrCreateDomain(ctx, "fwd-b.example.com", userB.ID)
+	store.VerifyDomain(ctx, "fwd-b.example.com", userB.ID)
+	store.CreateAgent(ctx, "agent@fwd-b.example.com", "fwd-b.example.com", "", "https://example.com/webhook", "", userB.ID)
+
+	msg, _ := store.CreateInboundMessage(ctx, "", agentA.ID, "alice@gmail.com", "bot@fwd-a.example.com", "<orig@gmail.com>", "Hello", "", "", nil, nil, nil, nil, nil)
+
+	req, _ := http.NewRequest("POST",
+		server.URL+"/api/v1/agents/agent@fwd-b.example.com/messages/"+msg.ID+"/forward",
+		bytes.NewBufferString(`{"to":["alice@example.com"]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKeyB.PlaintextKey)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 404 {
+		t.Errorf("status = %d, want 404 (wrong agent)", resp.StatusCode)
+	}
+}
+
+func TestForwardMessageUnverifiedDomain(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "owner-fwd-unverified@example.com", "Owner", "google-fwd-unverified")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "fwd-unverified-key", nil)
+	store.ClaimOrCreateDomain(ctx, "fwd-unverified.example.com", user.ID)
+	agent, _ := store.CreateAgent(ctx, "agent@fwd-unverified.example.com", "fwd-unverified.example.com", "", "https://example.com/webhook", "", user.ID)
+
+	msg, _ := store.CreateInboundMessage(ctx, "", agent.ID, "alice@gmail.com", "agent@fwd-unverified.example.com", "<orig@gmail.com>", "Hello", "", "", nil, nil, nil, nil, nil)
+
+	req, _ := http.NewRequest("POST",
+		server.URL+"/api/v1/agents/agent@fwd-unverified.example.com/messages/"+msg.ID+"/forward",
+		bytes.NewBufferString(`{"to":["alice@example.com"]}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey.PlaintextKey)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 403 {
+		t.Errorf("status = %d, want 403", resp.StatusCode)
+	}
+}
+
+func TestForwardMessageMissingRecipients(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "owner-fwd-norecip@example.com", "Owner", "google-fwd-norecip")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "fwd-norecip-key", nil)
+	store.ClaimOrCreateDomain(ctx, "fwd-norecip.example.com", user.ID)
+	store.VerifyDomain(ctx, "fwd-norecip.example.com", user.ID)
+	agent, _ := store.CreateAgent(ctx, "agent@fwd-norecip.example.com", "fwd-norecip.example.com", "", "https://example.com/webhook", "", user.ID)
+
+	msg, _ := store.CreateInboundMessage(ctx, "", agent.ID, "alice@gmail.com", "agent@fwd-norecip.example.com", "<orig@gmail.com>", "Hello", "", "", nil, nil, nil, nil, nil)
+
+	req, _ := http.NewRequest("POST",
+		server.URL+"/api/v1/agents/agent@fwd-norecip.example.com/messages/"+msg.ID+"/forward",
+		bytes.NewBufferString(`{"body":"fyi"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey.PlaintextKey)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 400 {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestForwardMessageViaSMTP(t *testing.T) {
+	server, store, _, smtpDone := setupAPIWithSMTP(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "owner-fwd-smtp@example.com", "Owner", "google-fwd-smtp")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "fwd-smtp-key", nil)
+	store.ClaimOrCreateDomain(ctx, "fwd-smtp.example.com", user.ID)
+	store.VerifyDomain(ctx, "fwd-smtp.example.com", user.ID)
+	agent, _ := store.CreateAgent(ctx, "bot@fwd-smtp.example.com", "fwd-smtp.example.com", "", "https://example.com/webhook", "", user.ID)
+
+	raw := rawInboundForForwardTest("alice@gmail.com", "bot@fwd-smtp.example.com", "Original Subject", "original body content")
+	msg, _ := store.CreateInboundMessage(ctx, "", agent.ID, "alice@gmail.com", "bot@fwd-smtp.example.com", "<orig@gmail.com>", "Original Subject", "", "", raw, nil, nil, nil, nil)
+
+	payload := `{"to":["destination@example.com"],"body":"FYI — see below"}`
+	req, _ := http.NewRequest("POST",
+		server.URL+"/api/v1/agents/bot@fwd-smtp.example.com/messages/"+msg.ID+"/forward",
+		bytes.NewBufferString(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey.PlaintextKey)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var result map[string]string
+	json.NewDecoder(resp.Body).Decode(&result)
+	if result["status"] != "sent" {
+		t.Errorf("status = %q, want sent", result["status"])
+	}
+	if result["method"] != "smtp" {
+		t.Errorf("method = %q, want smtp", result["method"])
+	}
+
+	msgs := smtpDone()
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 SMTP message, got %d", len(msgs))
+	}
+	if msgs[0].To != "destination@example.com" {
+		t.Errorf("SMTP To = %q, want destination@example.com (the forward target, NOT the original sender)", msgs[0].To)
+	}
+	if !strings.Contains(msgs[0].Data, "Subject: Fwd: Original Subject") {
+		t.Errorf("SMTP body missing Subject prefix Fwd:\nbody snippet: %s", firstNLines(msgs[0].Data, 20))
+	}
+	if !strings.Contains(msgs[0].Data, "FYI — see below") {
+		t.Errorf("SMTP body missing caller comment")
+	}
+	if !strings.Contains(msgs[0].Data, "---------- Forwarded message ---------") {
+		t.Errorf("SMTP body missing forwarded divider")
+	}
+	if !strings.Contains(msgs[0].Data, "From: alice@gmail.com") {
+		t.Errorf("SMTP body missing original From in quoted block")
+	}
+	if !strings.Contains(msgs[0].Data, "original body content") {
+		t.Errorf("SMTP body missing original body content")
+	}
+	// Forward must NOT inherit reply threading headers
+	if strings.Contains(msgs[0].Data, "In-Reply-To:") {
+		t.Errorf("SMTP body unexpectedly contains In-Reply-To header — forward should be a new thread")
+	}
+}
+
+func TestForwardMessageHITLHolds(t *testing.T) {
+	server, store, pool, smtpDone := setupAPIWithSMTP(t)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "owner-fwd-hitl@example.com", "Owner", "google-fwd-hitl")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "fwd-hitl-key", nil)
+	store.ClaimOrCreateDomain(ctx, "fwd-hitl.example.com", user.ID)
+	store.VerifyDomain(ctx, "fwd-hitl.example.com", user.ID)
+	agent, _ := store.CreateAgent(ctx, "bot@fwd-hitl.example.com", "fwd-hitl.example.com", "", "https://example.com/webhook", "", user.ID)
+	enableHITL(t, store, agent.ID, user.ID)
+
+	raw := rawInboundForForwardTest("alice@gmail.com", "bot@fwd-hitl.example.com", "Original", "body")
+	msg, _ := store.CreateInboundMessage(ctx, "", agent.ID, "alice@gmail.com", "bot@fwd-hitl.example.com", "<orig@gmail.com>", "Original", "", "", raw, nil, nil, nil, nil)
+
+	payload := `{"to":["dest@example.com"],"body":"please review"}`
+	req, _ := http.NewRequest("POST",
+		server.URL+"/api/v1/agents/bot@fwd-hitl.example.com/messages/"+msg.ID+"/forward",
+		bytes.NewBufferString(payload))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+apiKey.PlaintextKey)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202", resp.StatusCode)
+	}
+
+	var body struct {
+		Status    string `json:"status"`
+		MessageID string `json:"message_id"`
+	}
+	json.NewDecoder(resp.Body).Decode(&body)
+	if body.Status != "pending_approval" {
+		t.Errorf("status = %q, want pending_approval", body.Status)
+	}
+
+	// SMTP must not have been touched.
+	if msgs := smtpDone(); len(msgs) != 0 {
+		t.Fatalf("expected 0 SMTP messages, got %d", len(msgs))
+	}
+
+	// DB row must have type="forward" and persist the original
+	// email_message_id (so the reviewer can see what's being forwarded
+	// via InboundContext).
+	var (
+		status, subject string
+		msgType, emid   *string
+	)
+	err := pool.QueryRow(ctx,
+		`SELECT status, subject, message_type, email_message_id
+		 FROM messages WHERE id = $1`, body.MessageID,
+	).Scan(&status, &subject, &msgType, &emid)
+	if err != nil {
+		t.Fatalf("read pending row: %v", err)
+	}
+	if status != identity.MessageStatusPendingApproval {
+		t.Errorf("status = %q, want pending_approval", status)
+	}
+	if subject != "Fwd: Original" {
+		t.Errorf("subject = %q, want %q", subject, "Fwd: Original")
+	}
+	if msgType == nil || *msgType != "forward" {
+		t.Errorf("message_type = %v, want forward", msgType)
+	}
+	if emid == nil || *emid != "<orig@gmail.com>" {
+		t.Errorf("email_message_id = %v, want <orig@gmail.com>", emid)
+	}
+}
+
+func firstNLines(s string, n int) string {
+	lines := strings.SplitN(s, "\n", n+1)
+	if len(lines) > n {
+		lines = lines[:n]
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/agent/hitl_api.go
+++ b/internal/agent/hitl_api.go
@@ -48,12 +48,12 @@ type pendingMessageDetail struct {
 	RejectionReason   string                `json:"rejection_reason,omitempty"`
 	ProviderMessageID string                `json:"provider_message_id,omitempty"`
 	Method            string                `json:"method,omitempty"`
-	// InboundContext is attached only when this is a reply (i.e. when
-	// email_message_id is non-empty and the inbound row is still in
-	// retention). Used by the review panel to render the "In reply to"
-	// pane with SPF/DKIM/DMARC provenance — without it, reviewers can't
-	// see what the original message looked like or whether it was
-	// auth-validated.
+	// InboundContext is attached when this is a reply or a forward
+	// (i.e. when email_message_id is non-empty and the parent inbound
+	// row is still in retention). Used by the review panel to render
+	// the "In reply to" / "Forwarding" pane with SPF/DKIM/DMARC
+	// provenance — without it, reviewers can't see what the original
+	// message looked like or whether it was auth-validated.
 	InboundContext *pendingMessageInboundContext `json:"inbound,omitempty"`
 }
 
@@ -449,12 +449,23 @@ type hitlInboundLookup interface {
 
 // buildSendRequestFromMessage reconstructs a SendRequest from a stored
 // pending-approval message (with any reviewer edits already applied).
+//
+// ReplyToMessageID is only copied through for type="reply". Forwards
+// also persist email_message_id (so the review panel can render the
+// "what's being forwarded" pane via InboundContext), but a forward must
+// ship as a new thread — copying email_message_id into ReplyToMessageID
+// would emit In-Reply-To/References on the outbound and stitch the
+// forward into the original thread.
 func buildSendRequestFromMessage(m *identity.Message) (outbound.SendRequest, error) {
 	var attachments []outbound.Attachment
 	if len(m.AttachmentsJSON) > 0 {
 		if err := json.Unmarshal(m.AttachmentsJSON, &attachments); err != nil {
 			return outbound.SendRequest{}, err
 		}
+	}
+	replyToMessageID := ""
+	if m.Type == "reply" {
+		replyToMessageID = m.EmailMessageID
 	}
 	return outbound.SendRequest{
 		To:               m.ToRecipients,
@@ -463,7 +474,7 @@ func buildSendRequestFromMessage(m *identity.Message) (outbound.SendRequest, err
 		Subject:          m.Subject,
 		Body:             m.BodyText,
 		HTMLBody:         m.BodyHTML,
-		ReplyToMessageID: m.EmailMessageID,
+		ReplyToMessageID: replyToMessageID,
 		ConversationID:   m.ConversationID,
 		Attachments:      attachments,
 	}, nil

--- a/internal/agent/selfsend.go
+++ b/internal/agent/selfsend.go
@@ -35,10 +35,17 @@ func stripAgentSelfAliases(addrs []string, agentEmail string) []string {
 // Returns the provider-style message id used for the outbound row.
 // Method on the outbound row is "loopback" so operators can tell the
 // difference from "smtp" in logs and audits.
+// msgType is one of "send", "reply", or "forward" — recorded on the
+// outbound row so audit queries can distinguish a self-note from a
+// self-reply or self-forward. Without it, the loopback branch of
+// handleReplyToMessage / handleForwardMessage would store "send" and
+// fork the audit shape from the SMTP branch (which records the
+// caller's actual intent).
 func (a *API) performSelfSend(
 	ctx context.Context,
 	agent *identity.AgentIdentity,
 	req outbound.SendRequest,
+	msgType string,
 ) (string, error) {
 	email := agent.EmailAddress()
 
@@ -54,7 +61,7 @@ func (a *API) performSelfSend(
 		nil,
 		nil,
 		req.Subject,
-		"send",
+		msgType,
 		"loopback",
 		providerID,
 		req.ConversationID,

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -68,8 +68,8 @@ func TestInboundDelivered(t *testing.T) {
 	if p.Body.From != "alice@gmail.com" {
 		t.Errorf("From = %q", p.Body.From)
 	}
-	if p.Body.To != "agent@inbound.example.com" {
-		t.Errorf("To = %q", p.Body.To)
+	if len(p.Body.To) != 1 || p.Body.To[0] != "agent@inbound.example.com" {
+		t.Errorf("To = %v, want [agent@inbound.example.com]", p.Body.To)
 	}
 
 	// Domain-Check header should be present
@@ -242,12 +242,12 @@ func TestPollMode_E2E(t *testing.T) {
 
 	var listResp struct {
 		Messages []struct {
-			MessageID      string `json:"message_id"`
-			From           string `json:"from"`
-			To             string `json:"to"`
-			Subject        string `json:"subject"`
-			Status         string `json:"status"`
-			ConversationID string `json:"conversation_id"`
+			MessageID      string   `json:"message_id"`
+			From           string   `json:"from"`
+			To             []string `json:"to"`
+			Subject        string   `json:"subject"`
+			Status         string   `json:"status"`
+			ConversationID string   `json:"conversation_id"`
 		} `json:"messages"`
 		HasMore bool `json:"has_more"`
 	}
@@ -278,7 +278,7 @@ func TestPollMode_E2E(t *testing.T) {
 	var msgResp struct {
 		MessageID      string            `json:"message_id"`
 		From           string            `json:"from"`
-		To             string            `json:"to"`
+		To             []string          `json:"to"`
 		AuthHeaders    map[string]string `json:"auth_headers"`
 		RawMessage     string            `json:"raw_message"`
 		ConversationID string            `json:"conversation_id"`

--- a/internal/outbound/forward.go
+++ b/internal/outbound/forward.go
@@ -187,8 +187,15 @@ func BuildForwardBody(comment string, ctx ForwardContext) string {
 	writeHeaderLine(&buf, "Cc", ctx.Cc)
 	buf.WriteString("\r\n")
 	if ctx.Text != "" {
-		buf.WriteString(strings.ReplaceAll(ctx.Text, "\n", "\r\n"))
-		if !strings.HasSuffix(ctx.Text, "\n") {
+		// Normalize line endings before re-emitting: a naive
+		// ReplaceAll("\n","\r\n") turns existing "\r\n" into "\r\r\n",
+		// which mail clients render as a literal CR. Real-world bodies
+		// almost always arrive CRLF-terminated, so the lazy form would
+		// fire on virtually every multi-line forward.
+		text := strings.ReplaceAll(ctx.Text, "\r\n", "\n")
+		text = strings.ReplaceAll(text, "\n", "\r\n")
+		buf.WriteString(text)
+		if !strings.HasSuffix(text, "\r\n") {
 			buf.WriteString("\r\n")
 		}
 	}

--- a/internal/outbound/forward.go
+++ b/internal/outbound/forward.go
@@ -1,0 +1,260 @@
+package outbound
+
+import (
+	"bytes"
+	"encoding/base64"
+	"io"
+	"mime"
+	"mime/multipart"
+	"mime/quotedprintable"
+	"net/mail"
+	"strings"
+)
+
+// ForwardContext captures the header + body fields from an inbound message
+// that a forward should quote. Headers are kept as raw strings (no
+// re-parsing) so the quoted block renders the same lexical text the
+// original sender chose, including display names. Text/HTML are
+// best-effort decoded from the raw MIME — empty strings on parse
+// failure so the forward still ships with the header block.
+type ForwardContext struct {
+	From    string
+	Date    string
+	Subject string
+	To      string
+	Cc      string
+	Text    string
+	HTML    string
+}
+
+// ExtractForwardContext parses an RFC 5322 raw message and pulls out the
+// fields needed to compose a forward quote. Parse failures degrade
+// gracefully — the returned context's body fields stay empty so the
+// caller still gets a usable header block to prepend.
+func ExtractForwardContext(rawMessage []byte) ForwardContext {
+	ctx := ForwardContext{}
+	if len(rawMessage) == 0 {
+		return ctx
+	}
+
+	msg, err := mail.ReadMessage(bytes.NewReader(rawMessage))
+	if err != nil {
+		return ctx
+	}
+
+	ctx.From = strings.TrimSpace(msg.Header.Get("From"))
+	ctx.Date = strings.TrimSpace(msg.Header.Get("Date"))
+	ctx.Subject = strings.TrimSpace(msg.Header.Get("Subject"))
+	ctx.To = strings.TrimSpace(msg.Header.Get("To"))
+	ctx.Cc = strings.TrimSpace(msg.Header.Get("Cc"))
+
+	contentType := msg.Header.Get("Content-Type")
+	encoding := msg.Header.Get("Content-Transfer-Encoding")
+	ctx.Text, ctx.HTML = extractBodyParts(msg.Body, contentType, encoding)
+	return ctx
+}
+
+// extractBodyParts walks a message body looking for the text/plain and
+// text/html parts. Recurses into multipart/alternative and
+// multipart/mixed. The body io.Reader is consumed in a single pass — for
+// non-multipart bodies the entire reader is treated as a single part.
+func extractBodyParts(body io.Reader, contentType, encoding string) (textOut, htmlOut string) {
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		// No Content-Type or malformed — fall through and treat as
+		// text/plain. Cheaper than refusing the forward.
+		mediaType = "text/plain"
+		params = nil
+	}
+
+	if !strings.HasPrefix(mediaType, "multipart/") {
+		raw, err := io.ReadAll(body)
+		if err != nil {
+			return "", ""
+		}
+		decoded := decodeTransferEncoding(raw, encoding)
+		switch mediaType {
+		case "text/html":
+			return "", string(decoded)
+		default:
+			return string(decoded), ""
+		}
+	}
+
+	boundary := params["boundary"]
+	if boundary == "" {
+		return "", ""
+	}
+
+	mr := multipart.NewReader(body, boundary)
+	for {
+		part, err := mr.NextPart()
+		if err != nil {
+			break
+		}
+		partCT := part.Header.Get("Content-Type")
+		partEnc := part.Header.Get("Content-Transfer-Encoding")
+		partType, _, _ := mime.ParseMediaType(partCT)
+
+		if strings.HasPrefix(partType, "multipart/") {
+			nestedText, nestedHTML := extractBodyParts(part, partCT, partEnc)
+			if textOut == "" {
+				textOut = nestedText
+			}
+			if htmlOut == "" {
+				htmlOut = nestedHTML
+			}
+			_ = part.Close()
+			continue
+		}
+
+		raw, err := io.ReadAll(part)
+		_ = part.Close()
+		if err != nil {
+			continue
+		}
+		decoded := decodeTransferEncoding(raw, partEnc)
+		switch partType {
+		case "text/plain":
+			if textOut == "" {
+				textOut = string(decoded)
+			}
+		case "text/html":
+			if htmlOut == "" {
+				htmlOut = string(decoded)
+			}
+		}
+		if textOut != "" && htmlOut != "" {
+			break
+		}
+	}
+	return textOut, htmlOut
+}
+
+// decodeTransferEncoding decodes the Content-Transfer-Encoding wrapping
+// of a body part. Unknown encodings pass through unchanged — better to
+// surface raw bytes than drop the part entirely.
+func decodeTransferEncoding(data []byte, encoding string) []byte {
+	switch strings.ToLower(strings.TrimSpace(encoding)) {
+	case "quoted-printable":
+		decoded, err := io.ReadAll(quotedprintable.NewReader(bytes.NewReader(data)))
+		if err != nil {
+			return data
+		}
+		return decoded
+	case "base64":
+		decoded, err := base64.StdEncoding.DecodeString(string(bytes.TrimSpace(data)))
+		if err != nil {
+			return data
+		}
+		return decoded
+	default:
+		return data
+	}
+}
+
+// BuildForwardSubject prefixes "Fwd: " unless the subject already starts
+// with Fwd:, Fw:, or Re:. The dedup avoids stacking on chains. Empty
+// inputs produce "Fwd: (no subject)" so the recipient still sees the
+// message is a forward.
+func BuildForwardSubject(orig string) string {
+	trimmed := strings.TrimSpace(orig)
+	if trimmed == "" {
+		return "Fwd: (no subject)"
+	}
+	lower := strings.ToLower(trimmed)
+	if strings.HasPrefix(lower, "fwd:") || strings.HasPrefix(lower, "fw:") {
+		return trimmed
+	}
+	return "Fwd: " + trimmed
+}
+
+// BuildForwardBody composes the text/plain body of a forward: the
+// caller's optional comment, a Gmail-style divider, the original headers
+// as a quote block, then the original text body if extraction
+// succeeded.
+func BuildForwardBody(comment string, ctx ForwardContext) string {
+	var buf strings.Builder
+	if c := strings.TrimRight(comment, "\r\n"); c != "" {
+		buf.WriteString(c)
+		buf.WriteString("\r\n\r\n")
+	}
+	buf.WriteString("---------- Forwarded message ---------\r\n")
+	writeHeaderLine(&buf, "From", ctx.From)
+	writeHeaderLine(&buf, "Date", ctx.Date)
+	writeHeaderLine(&buf, "Subject", ctx.Subject)
+	writeHeaderLine(&buf, "To", ctx.To)
+	writeHeaderLine(&buf, "Cc", ctx.Cc)
+	buf.WriteString("\r\n")
+	if ctx.Text != "" {
+		buf.WriteString(strings.ReplaceAll(ctx.Text, "\n", "\r\n"))
+		if !strings.HasSuffix(ctx.Text, "\n") {
+			buf.WriteString("\r\n")
+		}
+	}
+	return buf.String()
+}
+
+// BuildForwardHTMLBody composes the text/html body of a forward. The
+// caller's HTML comment is emitted as-is (the API contract treats
+// html_body as caller-controlled markup); the forwarded block is wrapped
+// in a blockquote so mail clients render it visually as a quote.
+func BuildForwardHTMLBody(commentHTML string, ctx ForwardContext) string {
+	var buf strings.Builder
+	if c := strings.TrimSpace(commentHTML); c != "" {
+		buf.WriteString(c)
+		buf.WriteString("\r\n<br><br>\r\n")
+	}
+	buf.WriteString(`<div class="forwarded">`)
+	buf.WriteString("\r\n")
+	buf.WriteString("---------- Forwarded message ---------<br>\r\n")
+	writeHTMLHeaderLine(&buf, "From", ctx.From)
+	writeHTMLHeaderLine(&buf, "Date", ctx.Date)
+	writeHTMLHeaderLine(&buf, "Subject", ctx.Subject)
+	writeHTMLHeaderLine(&buf, "To", ctx.To)
+	writeHTMLHeaderLine(&buf, "Cc", ctx.Cc)
+	buf.WriteString("<br>\r\n")
+	if ctx.HTML != "" {
+		buf.WriteString(`<blockquote style="margin:0 0 0 0.8ex;border-left:1px solid #ccc;padding-left:1ex">`)
+		buf.WriteString("\r\n")
+		buf.WriteString(ctx.HTML)
+		buf.WriteString("\r\n</blockquote>")
+	} else if ctx.Text != "" {
+		buf.WriteString(`<blockquote style="margin:0 0 0 0.8ex;border-left:1px solid #ccc;padding-left:1ex"><pre>`)
+		buf.WriteString(htmlEscape(ctx.Text))
+		buf.WriteString("</pre></blockquote>")
+	}
+	buf.WriteString("\r\n</div>")
+	return buf.String()
+}
+
+func writeHeaderLine(buf *strings.Builder, name, value string) {
+	if value == "" {
+		return
+	}
+	buf.WriteString(name)
+	buf.WriteString(": ")
+	buf.WriteString(value)
+	buf.WriteString("\r\n")
+}
+
+func writeHTMLHeaderLine(buf *strings.Builder, name, value string) {
+	if value == "" {
+		return
+	}
+	buf.WriteString("<b>")
+	buf.WriteString(name)
+	buf.WriteString(":</b> ")
+	buf.WriteString(htmlEscape(value))
+	buf.WriteString("<br>\r\n")
+}
+
+// htmlEscape is a tiny subset of html.EscapeString — sufficient for
+// the four characters that can break a blockquote. Avoids pulling in
+// html/template for one function.
+func htmlEscape(s string) string {
+	if !strings.ContainsAny(s, "&<>\"") {
+		return s
+	}
+	return strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", "\"", "&quot;").Replace(s)
+}

--- a/internal/outbound/forward_test.go
+++ b/internal/outbound/forward_test.go
@@ -165,6 +165,33 @@ func TestBuildForwardBody_WithCommentAndContext(t *testing.T) {
 	}
 }
 
+func TestBuildForwardBody_PreservesCRLFLineEndings(t *testing.T) {
+	// Regression: a naive strings.ReplaceAll("\n","\r\n") turns
+	// already-CRLF input into "\r\r\n", which renders as a literal
+	// CR character in some mail clients. Real inbound bodies are
+	// CRLF-terminated, so this would fire on most forwards.
+	ctx := ForwardContext{From: "alice@example.com", Text: "line1\r\nline2\r\nline3\r\n"}
+	body := BuildForwardBody("", ctx)
+	if strings.Contains(body, "\r\r\n") {
+		t.Errorf("body contains malformed \\r\\r\\n sequence:\n%q", body)
+	}
+	if !strings.Contains(body, "line1\r\nline2\r\nline3\r\n") {
+		t.Errorf("body lost CRLF line endings:\n%q", body)
+	}
+}
+
+func TestBuildForwardBody_NormalizesLFOnlyInput(t *testing.T) {
+	// LF-only input must still be re-emitted as CRLF (SMTP requirement).
+	ctx := ForwardContext{From: "alice@example.com", Text: "line1\nline2\nline3"}
+	body := BuildForwardBody("", ctx)
+	if strings.Contains(body, "\r\r\n") {
+		t.Errorf("body contains malformed \\r\\r\\n sequence:\n%q", body)
+	}
+	if !strings.Contains(body, "line1\r\nline2\r\nline3\r\n") {
+		t.Errorf("body did not convert LF to CRLF or add trailing CRLF:\n%q", body)
+	}
+}
+
 func TestBuildForwardBody_NoCommentNoOriginalBody(t *testing.T) {
 	ctx := ForwardContext{From: "alice@example.com", Subject: "Hi"}
 	body := BuildForwardBody("", ctx)

--- a/internal/outbound/forward_test.go
+++ b/internal/outbound/forward_test.go
@@ -1,0 +1,211 @@
+package outbound
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildForwardSubject(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"Hello", "Fwd: Hello"},
+		{"  Hello  ", "Fwd: Hello"},
+		{"", "Fwd: (no subject)"},
+		{"Fwd: Hello", "Fwd: Hello"},
+		{"fwd: lower", "fwd: lower"},
+		{"Fw: short form", "Fw: short form"},
+		{"FW: caps", "FW: caps"},
+	}
+	for _, c := range cases {
+		got := BuildForwardSubject(c.in)
+		if got != c.want {
+			t.Errorf("BuildForwardSubject(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestExtractForwardContext_TextPlain(t *testing.T) {
+	raw := []byte("From: alice@example.com\r\n" +
+		"To: agent@e2a.dev\r\n" +
+		"Subject: Hi\r\n" +
+		"Date: Mon, 1 Jan 2026 10:00:00 +0000\r\n" +
+		"Content-Type: text/plain; charset=utf-8\r\n" +
+		"\r\n" +
+		"hello world")
+
+	ctx := ExtractForwardContext(raw)
+	if ctx.From != "alice@example.com" {
+		t.Errorf("From = %q", ctx.From)
+	}
+	if ctx.Subject != "Hi" {
+		t.Errorf("Subject = %q", ctx.Subject)
+	}
+	if ctx.To != "agent@e2a.dev" {
+		t.Errorf("To = %q", ctx.To)
+	}
+	if ctx.Text != "hello world" {
+		t.Errorf("Text = %q", ctx.Text)
+	}
+	if ctx.HTML != "" {
+		t.Errorf("HTML = %q, want empty", ctx.HTML)
+	}
+}
+
+func TestExtractForwardContext_MultipartAlternative(t *testing.T) {
+	raw := []byte("From: alice@example.com\r\n" +
+		"Subject: Hi\r\n" +
+		"Content-Type: multipart/alternative; boundary=\"BOUND\"\r\n" +
+		"\r\n" +
+		"--BOUND\r\n" +
+		"Content-Type: text/plain; charset=utf-8\r\n" +
+		"\r\n" +
+		"plain body\r\n" +
+		"--BOUND\r\n" +
+		"Content-Type: text/html; charset=utf-8\r\n" +
+		"\r\n" +
+		"<p>html body</p>\r\n" +
+		"--BOUND--\r\n")
+
+	ctx := ExtractForwardContext(raw)
+	if !strings.Contains(ctx.Text, "plain body") {
+		t.Errorf("Text = %q, want contains 'plain body'", ctx.Text)
+	}
+	if !strings.Contains(ctx.HTML, "<p>html body</p>") {
+		t.Errorf("HTML = %q, want contains '<p>html body</p>'", ctx.HTML)
+	}
+}
+
+func TestExtractForwardContext_QuotedPrintable(t *testing.T) {
+	raw := []byte("From: alice@example.com\r\n" +
+		"Subject: Hi\r\n" +
+		"Content-Type: text/plain; charset=utf-8\r\n" +
+		"Content-Transfer-Encoding: quoted-printable\r\n" +
+		"\r\n" +
+		"caf=C3=A9")
+
+	ctx := ExtractForwardContext(raw)
+	if ctx.Text != "café" {
+		t.Errorf("Text = %q, want 'café'", ctx.Text)
+	}
+}
+
+func TestExtractForwardContext_MultipartMixedWrappingAlternative(t *testing.T) {
+	raw := []byte("From: alice@example.com\r\n" +
+		"Subject: Hi\r\n" +
+		"Content-Type: multipart/mixed; boundary=\"OUTER\"\r\n" +
+		"\r\n" +
+		"--OUTER\r\n" +
+		"Content-Type: multipart/alternative; boundary=\"INNER\"\r\n" +
+		"\r\n" +
+		"--INNER\r\n" +
+		"Content-Type: text/plain; charset=utf-8\r\n" +
+		"\r\n" +
+		"inner text\r\n" +
+		"--INNER\r\n" +
+		"Content-Type: text/html; charset=utf-8\r\n" +
+		"\r\n" +
+		"<p>inner html</p>\r\n" +
+		"--INNER--\r\n" +
+		"--OUTER\r\n" +
+		"Content-Type: application/pdf\r\n" +
+		"Content-Disposition: attachment; filename=\"a.pdf\"\r\n" +
+		"\r\n" +
+		"PDFBINARY\r\n" +
+		"--OUTER--\r\n")
+
+	ctx := ExtractForwardContext(raw)
+	if !strings.Contains(ctx.Text, "inner text") {
+		t.Errorf("Text = %q, want contains 'inner text'", ctx.Text)
+	}
+	if !strings.Contains(ctx.HTML, "inner html") {
+		t.Errorf("HTML = %q, want contains 'inner html'", ctx.HTML)
+	}
+}
+
+func TestExtractForwardContext_MalformedReturnsEmpty(t *testing.T) {
+	ctx := ExtractForwardContext([]byte("not an email"))
+	if ctx.From != "" || ctx.Text != "" || ctx.HTML != "" {
+		t.Errorf("malformed input produced non-empty fields: %+v", ctx)
+	}
+}
+
+func TestExtractForwardContext_EmptyInput(t *testing.T) {
+	ctx := ExtractForwardContext(nil)
+	if ctx != (ForwardContext{}) {
+		t.Errorf("empty input produced non-zero context: %+v", ctx)
+	}
+}
+
+func TestBuildForwardBody_WithCommentAndContext(t *testing.T) {
+	ctx := ForwardContext{
+		From:    "alice@example.com",
+		Date:    "Mon, 1 Jan 2026 10:00:00 +0000",
+		Subject: "Hi",
+		To:      "agent@e2a.dev",
+		Text:    "hello world",
+	}
+	body := BuildForwardBody("FYI", ctx)
+	wantSubstrings := []string{
+		"FYI",
+		"---------- Forwarded message ---------",
+		"From: alice@example.com",
+		"Date: Mon, 1 Jan 2026 10:00:00 +0000",
+		"Subject: Hi",
+		"To: agent@e2a.dev",
+		"hello world",
+	}
+	for _, s := range wantSubstrings {
+		if !strings.Contains(body, s) {
+			t.Errorf("body missing %q\nfull body:\n%s", s, body)
+		}
+	}
+	if strings.Contains(body, "Cc:") {
+		t.Errorf("body has Cc line when ctx.Cc is empty")
+	}
+}
+
+func TestBuildForwardBody_NoCommentNoOriginalBody(t *testing.T) {
+	ctx := ForwardContext{From: "alice@example.com", Subject: "Hi"}
+	body := BuildForwardBody("", ctx)
+	if !strings.HasPrefix(body, "---------- Forwarded message ---------") {
+		t.Errorf("body should start with divider when no comment, got: %q", body)
+	}
+}
+
+func TestBuildForwardHTMLBody_PrefersHTMLOverText(t *testing.T) {
+	ctx := ForwardContext{
+		From: "alice@example.com",
+		HTML: "<p>original html</p>",
+		Text: "plain fallback",
+	}
+	html := BuildForwardHTMLBody("<p>FYI</p>", ctx)
+	if !strings.Contains(html, "<p>original html</p>") {
+		t.Errorf("html body missing original HTML: %s", html)
+	}
+	if strings.Contains(html, "plain fallback") {
+		t.Errorf("html body shouldn't fall back to text when HTML present")
+	}
+	if !strings.Contains(html, "<p>FYI</p>") {
+		t.Errorf("html body missing caller comment")
+	}
+}
+
+func TestBuildForwardHTMLBody_FallsBackToTextInPre(t *testing.T) {
+	ctx := ForwardContext{From: "alice@example.com", Text: "plain only"}
+	html := BuildForwardHTMLBody("", ctx)
+	if !strings.Contains(html, "<pre>plain only</pre>") {
+		t.Errorf("html body should wrap text fallback in <pre>: %s", html)
+	}
+}
+
+func TestBuildForwardHTMLBody_EscapesHTMLSpecialsInHeaders(t *testing.T) {
+	ctx := ForwardContext{From: `"Eve <evil@x>" <alice@example.com>`, Subject: "<script>alert(1)</script>"}
+	html := BuildForwardHTMLBody("", ctx)
+	if strings.Contains(html, "<script>alert(1)</script>") {
+		t.Errorf("html body must escape <script> in subject: %s", html)
+	}
+	if !strings.Contains(html, "&lt;script&gt;") {
+		t.Errorf("html body should contain escaped &lt;script&gt;: %s", html)
+	}
+}

--- a/mcp/src/tools/messages.ts
+++ b/mcp/src/tools/messages.ts
@@ -102,6 +102,59 @@ export function registerMessageTools(server: McpServer, client: E2AClient): void
   );
 
   server.registerTool(
+    "forward_message",
+    {
+      title: "Forward an inbound message",
+      description:
+        "Forward a message the agent has received to one or more new recipients. The server auto-prepends a Gmail-style header block (From/Date/Subject/To/Cc) and the original body to whatever optional comment you pass in `body`/`html_body`. **Unlike `reply_to_message`, a forward is a NEW thread** — no In-Reply-To / References headers are emitted, so the recipient sees a fresh conversation. Use this when the user asks to share a received email with someone else; use `reply_to_message` when continuing the existing conversation. Same HITL behavior as send/reply: `pending_approval` is success, not failure.",
+      inputSchema: strictInputSchema({
+        message_id: z.string().describe("ID of the inbound message to forward (e.g. msg_…)."),
+        to: z.array(z.string()).describe("Forward target addresses (one or more)."),
+        cc: z.array(z.string()).optional(),
+        bcc: z.array(z.string()).optional(),
+        body: z
+          .string()
+          .optional()
+          .describe(
+            "Optional plain-text comment to prepend above the forwarded content. The original body is appended automatically.",
+          ),
+        html_body: z.string().optional(),
+        attachments: attachmentsArraySchema,
+        conversation_id: z
+          .string()
+          .optional()
+          .describe(
+            "Optional conversation grouping ID. A forward is a new thread by default — set this only to bind it to an existing thread explicitly.",
+          ),
+        idempotency_key: z
+          .string()
+          .optional()
+          .describe(
+            "Stable key for retry-safe forwards. The inbound `message_id` plus target list is a natural choice.",
+          ),
+        agent_email: z.string().optional(),
+      }),
+    },
+    async (args) =>
+      runTool(() =>
+        client.forward(args.message_id, args.to, {
+          ...(args.body !== undefined ? { body: args.body } : {}),
+          ...(args.html_body !== undefined ? { htmlBody: args.html_body } : {}),
+          ...(args.cc !== undefined ? { cc: args.cc } : {}),
+          ...(args.bcc !== undefined ? { bcc: args.bcc } : {}),
+          ...(args.attachments !== undefined ? { attachments: args.attachments } : {}),
+          ...(args.conversation_id !== undefined
+            ? { conversationId: args.conversation_id }
+            : {}),
+          ...(args.idempotency_key !== undefined
+            ? { idempotencyKey: args.idempotency_key }
+            : {}),
+          ...(args.agent_email !== undefined ? { agentEmail: args.agent_email } : {}),
+        }),
+      ),
+  );
+
+  server.registerTool(
     "list_messages",
     {
       title: "List inbound messages",

--- a/mcp/tests/http.test.ts
+++ b/mcp/tests/http.test.ts
@@ -197,6 +197,7 @@ describe("HTTP MCP server", () => {
       [
         "send_email",
         "reply_to_message",
+        "forward_message",
         "list_messages",
         "get_message",
         "get_attachment_data",

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -22,6 +22,7 @@ function makeStubClient(overrides: Partial<{ agentEmail: string }> = {}): E2ACli
     },
     send: vi.fn(async () => ({ message_id: "msg_sent", status: "sent" })),
     reply: vi.fn(async () => ({ message_id: "msg_reply", status: "sent" })),
+    forward: vi.fn(async () => ({ message_id: "msg_fwd", status: "sent" })),
     listMessages: vi.fn(async () => ({ messages: [], next_token: undefined })),
     listAgents: vi.fn(async () => ({ agents: [{ email: "bot@example.com" }] })),
     registerAgent: vi.fn(async (body: Record<string, unknown>) => ({
@@ -122,6 +123,7 @@ describe("e2a MCP server", () => {
       [
         "send_email",
         "reply_to_message",
+        "forward_message",
         "list_messages",
         "get_message",
         "get_attachment_data",
@@ -170,6 +172,22 @@ describe("e2a MCP server", () => {
       },
     });
     expect(stub.reply).toHaveBeenCalledWith("msg_in", "thanks", { replyAll: true });
+  });
+
+  it("forward_message forwards args to client.forward", async () => {
+    await client.callTool({
+      name: "forward_message",
+      arguments: {
+        message_id: "msg_in",
+        to: ["destination@example.com"],
+        body: "FYI",
+      },
+    });
+    expect(stub.forward).toHaveBeenCalledWith(
+      "msg_in",
+      ["destination@example.com"],
+      { body: "FYI" },
+    );
   });
 
   it("list_messages forwards filters", async () => {

--- a/migrations/019_message_type_forward.sql
+++ b/migrations/019_message_type_forward.sql
@@ -1,0 +1,17 @@
+-- 019_message_type_forward.sql
+--
+-- Allow the value 'forward' in messages.message_type.
+--
+-- The /api/v1/agents/{email}/messages/{id}/forward endpoint records its
+-- outbound row with message_type='forward' so audit queries can
+-- distinguish a forward (new thread, no In-Reply-To) from a reply
+-- (same thread). Mirrors the pattern used by 008_loopback_method.sql
+-- to expand the messages.method CHECK constraint.
+--
+-- Idempotent: drops the prior check by canonical name and re-adds it
+-- with the expanded value set. The CHECK is reasserted by name so a
+-- replay against an already-migrated DB is a no-op.
+
+ALTER TABLE messages DROP CONSTRAINT IF EXISTS messages_message_type_check;
+ALTER TABLE messages ADD CONSTRAINT messages_message_type_check
+    CHECK (message_type IN ('send', 'reply', 'test', 'forward'));

--- a/sdks/python/src/e2a/v1/generated/__init__.py
+++ b/sdks/python/src/e2a/v1/generated/__init__.py
@@ -280,7 +280,9 @@ class PendingMessageSummary(BaseModel):
     ) = Field(None, examples=['pending_approval'])
     subject: str | None = Field(None, examples=['Re: contract details'])
     to: list[str] | None = Field(None, examples=[['alice@example.com']])
-    type: Literal['send', 'reply', 'test'] | None = Field(None, examples=['send'])
+    type: Literal['send', 'reply', 'test', 'forward'] | None = Field(
+        None, examples=['send']
+    )
 
 
 class RegisterAgentRequest(BaseModel):
@@ -429,6 +431,19 @@ class ApprovePendingMessageRequest(BaseModel):
     to: list[str] | None = None
 
 
+class ForwardMessageRequest(BaseModel):
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
+    attachments: list[internal_agent.Attachment] | None = None
+    bcc: list[str] | None = Field(None, examples=[['carol@example.com']])
+    body: str | None = Field(None, examples=['FYI — see below'])
+    cc: list[str] | None = Field(None, examples=[['bob@example.com']])
+    conversation_id: str | None = None
+    html_body: str | None = Field(None, examples=['<p>FYI — see below</p>'])
+    to: list[str] | None = Field(None, examples=[['alice@example.com']])
+
+
 class LimitsInfo(BaseModel):
     model_config = ConfigDict(
         populate_by_name=True,
@@ -508,7 +523,9 @@ class PendingMessageDetail(BaseModel):
     ) = Field(None, examples=['pending_approval'])
     subject: str | None = Field(None, examples=['Re: contract details'])
     to: list[str] | None = Field(None, examples=[['alice@example.com']])
-    type: Literal['send', 'reply', 'test'] | None = Field(None, examples=['send'])
+    type: Literal['send', 'reply', 'test', 'forward'] | None = Field(
+        None, examples=['send']
+    )
 
 
 class ReplyToMessageRequest(BaseModel):

--- a/sdks/typescript/src/v1/api.ts
+++ b/sdks/typescript/src/v1/api.ts
@@ -202,6 +202,20 @@ export class E2AApi {
     );
   }
 
+  async forwardMessage(
+    email: string,
+    messageId: string,
+    body: Schemas["ForwardMessageRequest"],
+    opts: SendOptions = {},
+  ): Promise<Schemas["SendEmailResponse"]> {
+    return this.request(
+      "POST",
+      `/api/v1/agents/${encodeURIComponent(email)}/messages/${encodeURIComponent(messageId)}/forward`,
+      body,
+      { extraHeaders: idempotencyHeaders(opts) },
+    );
+  }
+
   // ── Domains ─────────────────────────────────────────────────────
 
   async listDomains(): Promise<Schemas["ListDomainsResponse"]> {

--- a/sdks/typescript/src/v1/client.ts
+++ b/sdks/typescript/src/v1/client.ts
@@ -261,6 +261,47 @@ export class E2AClient {
     );
   }
 
+  /**
+   * Forward an inbound message to one or more new recipients. The
+   * server prepends the optional comment, then a Gmail-style header
+   * block with the original From/Date/Subject/To/Cc and the original
+   * body. A forward is treated as a new thread — no In-Reply-To /
+   * References headers are emitted. Pass conversationId to bind the
+   * forward to an existing thread explicitly.
+   */
+  async forward(
+    messageId: string,
+    to: string[],
+    opts?: {
+      body?: string;
+      htmlBody?: string;
+      cc?: string[];
+      bcc?: string[];
+      conversationId?: string;
+      attachments?: Schemas["internal_agent.Attachment"][];
+      agentEmail?: string;
+      /**
+       * Stable key for retry-safe forwards. When set, the server caches
+       * the response and replays it on retry with the same key + body.
+       */
+      idempotencyKey?: string;
+    },
+  ) {
+    const req: Schemas["ForwardMessageRequest"] = { to };
+    if (opts?.body) req.body = opts.body;
+    if (opts?.htmlBody) req.html_body = opts.htmlBody;
+    if (opts?.cc) req.cc = opts.cc;
+    if (opts?.bcc) req.bcc = opts.bcc;
+    if (opts?.conversationId) req.conversation_id = opts.conversationId;
+    if (opts?.attachments) req.attachments = opts.attachments;
+    return this.api.forwardMessage(
+      this.requireEmail(opts?.agentEmail),
+      messageId,
+      req,
+      { idempotencyKey: opts?.idempotencyKey },
+    );
+  }
+
   // ── Domains ─────────────────────────────────────────────────────
 
   async listDomains() {

--- a/sdks/typescript/src/v1/generated/types.ts
+++ b/sdks/typescript/src/v1/generated/types.ts
@@ -468,6 +468,136 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/agents/{email}/messages/{id}/forward": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Forward an inbound email
+         * @description Forward a previously received email to one or more new recipients. The server prepends the caller's optional comment, then a Gmail-style "Forwarded message" block with the original headers and best-effort extracted body. A forward is treated as a NEW thread — no In-Reply-To/References headers are emitted; pass conversation_id to bind it to an existing thread explicitly. Rate limited to 60 sends per agent per minute; 429 responses carry a `Retry-After` header in delay-seconds form. When the owning agent has HITL enabled, the server returns 202 Accepted with status="pending_approval".
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: {
+                    /** @description Caller-generated unique key (recommend UUIDv4). Retries with the same key + same body replay the original response; with a different body return 422. */
+                    "Idempotency-Key"?: string;
+                };
+                path: {
+                    /**
+                     * @description Agent email address
+                     * @example my-bot@example.com
+                     */
+                    email: string;
+                    /**
+                     * @description Message ID from the inbound payload
+                     * @example msg_abc123
+                     */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            /** @description Forward content */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["ForwardMessageRequest"];
+                };
+            };
+            responses: {
+                /** @description Forward sent immediately */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SendEmailResponse"];
+                    };
+                };
+                /** @description Forward held for human approval */
+                202: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["SendEmailResponse"];
+                    };
+                };
+                /** @description Missing or invalid fields */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Missing or invalid API key */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Agent domain not verified */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Message not found or does not belong to this agent */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Another request with this Idempotency-Key is in progress */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Idempotency-Key reused with a different request body */
+                422: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Rate limit exceeded */
+                429: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/agents/{email}/messages/{id}/reply": {
         parameters: {
             query?: never;
@@ -1957,6 +2087,32 @@ export interface components {
             verified?: boolean;
             verified_at?: string;
         };
+        ForwardMessageRequest: {
+            attachments?: components["schemas"]["internal_agent.Attachment"][];
+            /**
+             * @example [
+             *       "carol@example.com"
+             *     ]
+             */
+            bcc?: string[];
+            /** @example FYI — see below */
+            body?: string;
+            /**
+             * @example [
+             *       "bob@example.com"
+             *     ]
+             */
+            cc?: string[];
+            conversation_id?: string;
+            /** @example <p>FYI — see below</p> */
+            html_body?: string;
+            /**
+             * @example [
+             *       "alice@example.com"
+             *     ]
+             */
+            to?: string[];
+        };
         LimitsCaps: {
             max_agents?: number;
             max_domains?: number;
@@ -2137,7 +2293,7 @@ export interface components {
              * @example send
              * @enum {string}
              */
-            type?: "send" | "reply" | "test";
+            type?: "send" | "reply" | "test" | "forward";
         };
         PendingMessageInboundContext: {
             /**
@@ -2186,7 +2342,7 @@ export interface components {
              * @example send
              * @enum {string}
              */
-            type?: "send" | "reply" | "test";
+            type?: "send" | "reply" | "test" | "forward";
         };
         RegisterAgentRequest: {
             /**

--- a/sdks/typescript/src/v1/inbound-email.ts
+++ b/sdks/typescript/src/v1/inbound-email.ts
@@ -402,6 +402,31 @@ export class InboundEmail {
   }
 
   /**
+   * Forward this email to new recipients. Requires the email to be
+   * verified first. The server prepends the optional comment, then a
+   * Gmail-style header block with the original From/Date/Subject/To/Cc
+   * and the original body. Forwards ship as a new thread (no
+   * In-Reply-To); pass conversationId to bind to an existing thread.
+   */
+  async forward(
+    to: string[],
+    opts?: {
+      body?: string;
+      htmlBody?: string;
+      cc?: string[];
+      bcc?: string[];
+      conversationId?: string;
+      attachments?: Schemas["internal_agent.Attachment"][];
+    },
+  ) {
+    this.requireVerified();
+    return this._client.forward(this._messageId, to, {
+      ...opts,
+      agentEmail: this._recipient,
+    });
+  }
+
+  /**
    * Build an InboundEmail from a raw `MessageDetail` response.
    *
    * Decodes the base64 `raw_message`, parses MIME headers/body/attachments.

--- a/web/public/openapi.yaml
+++ b/web/public/openapi.yaml
@@ -211,6 +211,39 @@ definitions:
       verified_at:
         type: string
     type: object
+  ForwardMessageRequest:
+    properties:
+      attachments:
+        items:
+          $ref: '#/definitions/internal_agent.Attachment'
+        type: array
+      bcc:
+        example:
+        - carol@example.com
+        items:
+          type: string
+        type: array
+      body:
+        example: FYI — see below
+        type: string
+      cc:
+        example:
+        - bob@example.com
+        items:
+          type: string
+        type: array
+      conversation_id:
+        type: string
+      html_body:
+        example: <p>FYI — see below</p>
+        type: string
+      to:
+        example:
+        - alice@example.com
+        items:
+          type: string
+        type: array
+    type: object
   LimitsCaps:
     properties:
       max_agents:
@@ -504,6 +537,7 @@ definitions:
         - send
         - reply
         - test
+        - forward
         example: send
         type: string
     type: object
@@ -577,6 +611,7 @@ definitions:
         - send
         - reply
         - test
+        - forward
         example: send
         type: string
     type: object
@@ -1456,6 +1491,87 @@ paths:
       security:
       - BearerAuth: []
       summary: Get a single message
+      tags:
+      - Email
+  /api/v1/agents/{email}/messages/{id}/forward:
+    post:
+      consumes:
+      - application/json
+      description: Forward a previously received email to one or more new recipients.
+        The server prepends the caller's optional comment, then a Gmail-style "Forwarded
+        message" block with the original headers and best-effort extracted body. A
+        forward is treated as a NEW thread — no In-Reply-To/References headers are
+        emitted; pass conversation_id to bind it to an existing thread explicitly.
+        Rate limited to 60 sends per agent per minute; 429 responses carry a `Retry-After`
+        header in delay-seconds form. When the owning agent has HITL enabled, the
+        server returns 202 Accepted with status="pending_approval".
+      parameters:
+      - description: Agent email address
+        example: my-bot@example.com
+        in: path
+        name: email
+        required: true
+        type: string
+      - description: Message ID from the inbound payload
+        example: msg_abc123
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Forward content
+        in: body
+        name: request
+        required: true
+        schema:
+          $ref: '#/definitions/ForwardMessageRequest'
+      - description: Caller-generated unique key (recommend UUIDv4). Retries with
+          the same key + same body replay the original response; with a different
+          body return 422.
+        in: header
+        name: Idempotency-Key
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Forward sent immediately
+          schema:
+            $ref: '#/definitions/SendEmailResponse'
+        "202":
+          description: Forward held for human approval
+          schema:
+            $ref: '#/definitions/SendEmailResponse'
+        "400":
+          description: Missing or invalid fields
+          schema:
+            type: string
+        "401":
+          description: Missing or invalid API key
+          schema:
+            type: string
+        "403":
+          description: Agent domain not verified
+          schema:
+            type: string
+        "404":
+          description: Message not found or does not belong to this agent
+          schema:
+            type: string
+        "409":
+          description: Another request with this Idempotency-Key is in progress
+          schema:
+            type: string
+        "422":
+          description: Idempotency-Key reused with a different request body
+          schema:
+            type: string
+        "429":
+          description: Rate limit exceeded
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Forward an inbound email
       tags:
       - Email
   /api/v1/agents/{email}/messages/{id}/reply:


### PR DESCRIPTION
## Summary

Adds a Forward endpoint mirroring the existing Reply path: `POST /api/v1/agents/{email}/messages/{id}/forward`.

- **Server compose**: caller's optional comment, then a Gmail-style \`---------- Forwarded message ---------\` header block (From / Date / Subject / To / Cc), then the original body best-effort extracted from the inbound's stored MIME (text/plain, text/html, multipart/alternative, multipart/mixed, quoted-printable, base64).
- **Threading**: forwards ship as a **new thread** — no \`In-Reply-To\` / \`References\` headers. Callers can pass \`conversation_id\` to bind explicitly.
- **HITL fix**: \`buildSendRequestFromMessage\` now only copies \`email_message_id\` → \`ReplyToMessageID\` when \`type=\"reply\"\`, so HITL-approved forwards don't accidentally inherit threading headers and stitch into the original conversation.
- **\`InboundContext\` review pane**: forwards still persist \`email_message_id\` on the pending row, so reviewers see what's being forwarded.
- **Migration 019** extends the \`messages.message_type\` CHECK constraint to allow \`'forward'\` (mirrors the pattern from 008_loopback_method.sql).
- **Compile fix**: \`internal/e2e/e2e_test.go\` had three local-struct declarations of \`To\` as \`string\` that should have been \`[]string\` — pre-existing, unrelated to this change but blocking build. Fixed in this PR.

## Surfaces shipped

- Go handler + 7 integration tests (auth, not-found, wrong-agent, unverified-domain, missing-recipients, SMTP happy-path, HITL hold)
- Compose helpers + 12 unit tests
- TypeScript SDK: \`api.forwardMessage\`, \`client.forward()\`, \`InboundEmail.forward()\`
- Python SDK: regenerated types
- CLI: \`e2a forward <msg-id> --to … [--body …]\`
- MCP: \`forward_message\` tool + tests

## What's NOT in scope (deferred)

- Auto-forwarding the original's attachments (caller can attach manually; future \`include_original_attachments\` flag)
- Conversations / Threads API
- Labels
- Drafts

## Test plan

- [x] Go: \`make test-unit && make test-integration\` for \`internal/agent\` + \`internal/outbound\` — all green
- [x] TS SDK: 85 tests pass
- [x] CLI: 100 tests pass
- [x] MCP: 89 tests pass (1 new forward test added)
- [ ] Live e2e against running service: in progress on this branch — register agent, inject inbound via SMTP, call \`POST /forward\`, verify SMTP receives forwarded message with \`Subject: Fwd: …\`, divider, original body, no \`In-Reply-To\`.

Pre-existing failures NOT caused by this PR:
- \`TestInboundDelivered\` / \`TestReplayProtection\` in \`internal/e2e\` (signature verification failures, reproducible on main with my e2e compile fix applied but backend changes stashed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)