### PR TITLE
feat(python,cli): labels parity — Python SDK + CLI inbox filter

### DIFF
--- a/cli/src/__tests__/args.test.ts
+++ b/cli/src/__tests__/args.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getFlag, hasFlag, parseArgs } from "../bin/e2a.js";
+import { getFlag, getFlags, hasFlag, parseArgs } from "../bin/e2a.js";
 
 describe("parseArgs", () => {
   it("extracts command and remaining args", () => {
@@ -46,6 +46,22 @@ describe("getFlag", () => {
     expect(getFlag(args, "--body")).toBe("hello");
     // --to should still work
     expect(getFlag(args, "--to")).toBe("a@b.com");
+  });
+});
+
+describe("getFlags", () => {
+  it("collects repeated flag values (used by --label, --to, --cc, etc.)", () => {
+    expect(
+      getFlags(["--label", "urgent", "--label", "follow-up"], "--label"),
+    ).toEqual(["urgent", "follow-up"]);
+  });
+
+  it("returns an empty array when the flag is absent", () => {
+    expect(getFlags(["--unread"], "--label")).toEqual([]);
+  });
+
+  it("returns a single-entry array for a single occurrence", () => {
+    expect(getFlags(["--label", "urgent"], "--label")).toEqual(["urgent"]);
   });
 });
 

--- a/cli/src/bin/e2a.ts
+++ b/cli/src/bin/e2a.ts
@@ -39,7 +39,7 @@ Usage:
   e2a pending show <id>             Show a held message's full detail
   e2a pending approve <id> [--edit] Approve (and optionally edit) a held message
   e2a pending reject <id> [--reason …]  Reject a held message
-  e2a inbox [--unread|--read] [--limit N] [--oldest] [--from substr] [--subject substr] [--conversation id] [--since ts] [--until ts] [--token …]   List messages (newest first; --oldest for FIFO)
+  e2a inbox [--unread|--read] [--limit N] [--oldest] [--from substr] [--subject substr] [--conversation id] [--since ts] [--until ts] [--label …] [--token …]   List messages (newest first; --oldest for FIFO; --label repeats to AND-match)
   e2a read <message-id>             Read a message
   e2a reply <msg-id> --body … [--reply-all] [--cc …] [--bcc …]
   e2a forward <msg-id> --to … [--cc …] [--bcc …] [--body …]
@@ -214,6 +214,7 @@ async function main() {
         conversationId: getFlag(args, "--conversation"),
         since: getFlag(args, "--since"),
         until: getFlag(args, "--until"),
+        labels: getFlags(args, "--label"),
       });
       break;
     }
@@ -306,4 +307,4 @@ if (!isTestImport) {
   });
 }
 
-export { getFlag, hasFlag, parseArgs };
+export { getFlag, getFlags, hasFlag, parseArgs };

--- a/cli/src/commands/inbox.ts
+++ b/cli/src/commands/inbox.ts
@@ -12,6 +12,7 @@ export async function inbox(
     conversationId?: string;
     since?: string;
     until?: string;
+    labels?: string[];
   },
 ): Promise<void> {
   const client = createClient({ from: agentFrom });
@@ -31,6 +32,7 @@ export async function inbox(
     conversationId: filters?.conversationId,
     since: filters?.since,
     until: filters?.until,
+    labels: filters?.labels && filters.labels.length ? filters.labels : undefined,
   });
 
   if (!res.messages || res.messages.length === 0) {

--- a/sdks/python/src/e2a/v1/api.py
+++ b/sdks/python/src/e2a/v1/api.py
@@ -38,6 +38,8 @@ from e2a.v1.generated import (
     SendEmailRequest,
     SendEmailResponse,
     UpdateAgentRequest,
+    UpdateMessageRequest,
+    UpdateMessageResponse,
     VerifyDomainResponse,
 )
 
@@ -197,6 +199,7 @@ class E2AApi:
         conversation_id: Optional[str] = None,
         since: Optional[str] = None,
         until: Optional[str] = None,
+        labels: Optional[list[str]] = None,
     ) -> ListMessagesResponse:
         """List messages for an agent.
 
@@ -215,22 +218,40 @@ class E2AApi:
         produces a valid value as long as it ends in ``Z`` or has a
         timezone offset). Bracket on ``created_at`` (``>= since`` and
         ``< until``).
+
+        ``labels``: AND-match. A row is returned only if EVERY label
+        in the list is present on the row. Each entry must match the
+        same charset as a writable label (``[a-z0-9:_-]+``, ≤64 chars).
+        Reading by ``e2a:*`` system labels is allowed even though
+        setting them is server-only. Encoded as repeated
+        ``?labels=`` query params; the filter is part of the cursor
+        identity so continuation pages must reuse the same labels.
         """
-        params: dict[str, str] = {"status": status, "page_size": str(page_size)}
+        # Build query string by hand so repeated `labels=` params
+        # work — httpx accepts a list value for a key and emits each
+        # element as its own occurrence, which is the shape the
+        # server-side parser expects (`r.URL.Query()["labels"]`).
+        params: list[tuple[str, str]] = [
+            ("status", status),
+            ("page_size", str(page_size)),
+        ]
         if sort:
-            params["sort"] = sort
+            params.append(("sort", sort))
         if from_:
-            params["from"] = from_
+            params.append(("from", from_))
         if subject_contains:
-            params["subject_contains"] = subject_contains
+            params.append(("subject_contains", subject_contains))
         if conversation_id:
-            params["conversation_id"] = conversation_id
+            params.append(("conversation_id", conversation_id))
         if since:
-            params["since"] = since
+            params.append(("since", since))
         if until:
-            params["until"] = until
+            params.append(("until", until))
+        if labels:
+            for label in labels:
+                params.append(("labels", label))
         if token:
-            params["token"] = token
+            params.append(("token", token))
         resp = self._client.get(
             f"/api/v1/agents/{_encode_email(agent_email)}/messages",
             params=params,
@@ -259,6 +280,30 @@ class E2AApi:
         )
         _check_response(resp)
         return SendEmailResponse.model_validate(resp.json())
+
+    def update_message_labels(
+        self,
+        agent_email: str,
+        message_id: str,
+        body: UpdateMessageRequest,
+    ) -> UpdateMessageResponse:
+        """Apply a labels delta to a message.
+
+        ``body`` carries ``add_labels`` and/or ``remove_labels``. Labels
+        are lowercase strings drawn from ``[a-z0-9:_-]+``, capped at 64
+        chars each and 50 per request; the post-update label set is
+        capped at 100 per message. The ``e2a:`` prefix is reserved for
+        server-applied system labels and rejected on user writes. A
+        label appearing in both lists is removed (remove wins).
+        Returns the post-update label set so callers can echo state
+        without a follow-up fetch.
+        """
+        resp = self._client.patch(
+            f"/api/v1/agents/{_encode_email(agent_email)}/messages/{message_id}",
+            json=body.model_dump(by_alias=True, exclude_none=True),
+        )
+        _check_response(resp)
+        return UpdateMessageResponse.model_validate(resp.json())
 
     def send_email(
         self,

--- a/sdks/python/src/e2a/v1/async_client.py
+++ b/sdks/python/src/e2a/v1/async_client.py
@@ -41,6 +41,8 @@ from e2a.v1.generated import (
     SendEmailRequest,
     SendEmailResponse,
     UpdateAgentRequest,
+    UpdateMessageRequest,
+    UpdateMessageResponse,
     VerifyDomainResponse,
 )
 from e2a.v1.generated import internal_agent
@@ -170,24 +172,33 @@ class AsyncE2AApi:
         conversation_id: Optional[str] = None,
         since: Optional[str] = None,
         until: Optional[str] = None,
+        labels: Optional[list[str]] = None,
     ) -> ListMessagesResponse:
         """Async variant of :meth:`E2AApi.list_messages`. See that
         method for the full filter / sort docs."""
-        params: dict[str, str] = {"status": status, "page_size": str(page_size)}
+        # Build query string by hand so repeated `labels=` params work
+        # — see the sync sibling for the rationale.
+        params: list[tuple[str, str]] = [
+            ("status", status),
+            ("page_size", str(page_size)),
+        ]
         if sort:
-            params["sort"] = sort
+            params.append(("sort", sort))
         if from_:
-            params["from"] = from_
+            params.append(("from", from_))
         if subject_contains:
-            params["subject_contains"] = subject_contains
+            params.append(("subject_contains", subject_contains))
         if conversation_id:
-            params["conversation_id"] = conversation_id
+            params.append(("conversation_id", conversation_id))
         if since:
-            params["since"] = since
+            params.append(("since", since))
         if until:
-            params["until"] = until
+            params.append(("until", until))
+        if labels:
+            for label in labels:
+                params.append(("labels", label))
         if token:
-            params["token"] = token
+            params.append(("token", token))
         resp = await self._client.get(
             f"/api/v1/agents/{_encode_email(agent_email)}/messages",
             params=params,
@@ -216,6 +227,20 @@ class AsyncE2AApi:
         )
         _check_response(resp)
         return SendEmailResponse.model_validate(resp.json())
+
+    async def update_message_labels(
+        self,
+        agent_email: str,
+        message_id: str,
+        body: UpdateMessageRequest,
+    ) -> UpdateMessageResponse:
+        """Async variant of :meth:`E2AApi.update_message_labels`."""
+        resp = await self._client.patch(
+            f"/api/v1/agents/{_encode_email(agent_email)}/messages/{message_id}",
+            json=body.model_dump(by_alias=True, exclude_none=True),
+        )
+        _check_response(resp)
+        return UpdateMessageResponse.model_validate(resp.json())
 
     async def send_email(
         self,
@@ -419,6 +444,7 @@ class AsyncE2AClient:
         conversation_id: Optional[str] = None,
         since: Optional[str] = None,
         until: Optional[str] = None,
+        labels: Optional[list[str]] = None,
     ) -> MessageList:
         """Fetch message summaries with ergonomic field names.
 
@@ -426,7 +452,7 @@ class AsyncE2AClient:
         ``"asc"`` to drain the inbox in arrival order — FIFO polling.
 
         Search filters (``from_``, ``subject_contains``, ``conversation_id``,
-        ``since``, ``until``) match the sync client — see
+        ``since``, ``until``, ``labels``) match the sync client — see
         :meth:`E2AApi.list_messages` for the full reference.
         """
         email = self._require_agent_email(agent_email)
@@ -441,6 +467,7 @@ class AsyncE2AClient:
             conversation_id=conversation_id,
             since=since,
             until=until,
+            labels=labels,
         )
         messages = [
             MessageSummary(
@@ -454,6 +481,7 @@ class AsyncE2AClient:
                 subject=m.subject or "",
                 status=m.status or "",
                 created_at=m.created_at or "",
+                labels=list(m.labels or []),
             )
             for m in (resp.messages or [])
         ]
@@ -497,6 +525,27 @@ class AsyncE2AClient:
             message_id=resp.message_id or "",
             method=resp.method or "",
         )
+
+    async def update_message_labels(
+        self,
+        message_id: str,
+        add_labels: Optional[list[str]] = None,
+        remove_labels: Optional[list[str]] = None,
+        agent_email: Optional[str] = None,
+    ) -> list[str]:
+        """Async variant of :meth:`E2AClient.update_message_labels`.
+
+        Returns the post-update label set so the caller can echo state
+        without a separate fetch. ``add_labels`` / ``remove_labels`` are
+        each capped at 50 entries per call; the per-message cap is 100.
+        Labels matching ``e2a:*`` are server-applied only and rejected
+        on user writes. Empty / None for both arguments is a no-op
+        that returns the current labels.
+        """
+        email = self._require_agent_email(agent_email)
+        req = UpdateMessageRequest(add_labels=add_labels, remove_labels=remove_labels)
+        resp = await self.api.update_message_labels(email, message_id, req)
+        return list(resp.labels or [])
 
     async def send(
         self,

--- a/sdks/python/src/e2a/v1/client.py
+++ b/sdks/python/src/e2a/v1/client.py
@@ -21,6 +21,8 @@ from e2a.v1.generated import (
     ReplyToMessageRequest,
     SendEmailRequest,
     UpdateAgentRequest,
+    UpdateMessageRequest,
+    UpdateMessageResponse,
 )
 from e2a.v1.generated import internal_agent
 from e2a.v1.handler import (
@@ -191,6 +193,7 @@ class E2AClient:
         conversation_id: Optional[str] = None,
         since: Optional[str] = None,
         until: Optional[str] = None,
+        labels: Optional[list[str]] = None,
     ) -> MessageList:
         """Fetch message summaries with ergonomic field names.
 
@@ -201,6 +204,11 @@ class E2AClient:
         filters (capped at 200 chars server-side). ``conversation_id``
         exact-matches a thread. ``since`` / ``until`` are RFC3339
         timestamps bounding ``created_at``.
+
+        ``labels``: AND-match filter. A row is returned only if EVERY
+        label in the list is present. Each entry must match
+        ``[a-z0-9:_-]+`` (≤64 chars). Reading by ``e2a:*`` system
+        labels is allowed; setting them is server-only.
         """
         email = self._require_agent_email(agent_email)
         resp = self.api.list_messages(
@@ -214,6 +222,7 @@ class E2AClient:
             conversation_id=conversation_id,
             since=since,
             until=until,
+            labels=labels,
         )
         messages = [
             MessageSummary(
@@ -227,6 +236,7 @@ class E2AClient:
                 subject=m.subject or "",
                 status=m.status or "",
                 created_at=m.created_at or "",
+                labels=list(m.labels or []),
             )
             for m in (resp.messages or [])
         ]
@@ -271,6 +281,31 @@ class E2AClient:
             message_id=resp.message_id or "",
             method=resp.method or "",
         )
+
+    def update_message_labels(
+        self,
+        message_id: str,
+        add_labels: Optional[list[str]] = None,
+        remove_labels: Optional[list[str]] = None,
+        agent_email: Optional[str] = None,
+    ) -> list[str]:
+        """Apply a labels delta to a message; return the post-update set.
+
+        ``add_labels`` / ``remove_labels`` are each capped at 50 entries
+        per call. Labels are lowercased server-side and must match
+        ``[a-z0-9:_-]+`` up to 64 chars. The ``e2a:`` prefix is
+        reserved for server-applied system labels — caller writes that
+        try to set them return 400. A label that appears in both
+        lists is removed (remove wins).
+
+        Empty / None for both arguments is a no-op that simply echoes
+        the current label set — useful as a cheap "fetch labels only"
+        call without pulling the full message body.
+        """
+        email = self._require_agent_email(agent_email)
+        req = UpdateMessageRequest(add_labels=add_labels, remove_labels=remove_labels)
+        resp = self.api.update_message_labels(email, message_id, req)
+        return list(resp.labels or [])
 
     def send(
         self,

--- a/sdks/python/src/e2a/v1/handler.py
+++ b/sdks/python/src/e2a/v1/handler.py
@@ -197,6 +197,10 @@ class MessageSummary:
     # positional constructors (test fixtures, custom adapters) keep
     # working without shifting the trailing args.
     reply_to: list[str] = field(default_factory=list)
+    # Per-message string labels (`urgent`, `follow-up`, …). Always a
+    # list — empty for unlabelled rows, never None. Defaulted so
+    # existing positional constructors keep working.
+    labels: list[str] = field(default_factory=list)
 
 
 @dataclass

--- a/sdks/python/tests/test_v1_api.py
+++ b/sdks/python/tests/test_v1_api.py
@@ -24,6 +24,8 @@ from e2a.v1.generated import (
     SendEmailRequest,
     SendEmailResponse,
     UpdateAgentRequest,
+    UpdateMessageRequest,
+    UpdateMessageResponse,
     VerifyDomainResponse,
 )
 
@@ -396,6 +398,41 @@ def test_reply_with_html_and_conversation(httpx_mock):
         "html_body": "<p>Thanks!</p>",
         "conversation_id": "conv_abc",
     }
+
+
+def test_update_message_labels(httpx_mock):
+    httpx_mock.add_response(
+        url=f"{BASE}/api/v1/agents/bot%40agents.e2a.dev/messages/msg_123",
+        method="PATCH",
+        json={"message_id": "msg_123", "labels": ["follow-up", "urgent"]},
+    )
+
+    with E2AApi(api_key="k") as api:
+        result = api.update_message_labels(
+            "bot@agents.e2a.dev",
+            "msg_123",
+            UpdateMessageRequest(add_labels=["urgent", "follow-up"], remove_labels=["unread"]),
+        )
+
+    assert isinstance(result, UpdateMessageResponse)
+    assert result.message_id == "msg_123"
+    assert result.labels == ["follow-up", "urgent"]
+    body = json.loads(httpx_mock.get_request().content)
+    assert body == {"add_labels": ["urgent", "follow-up"], "remove_labels": ["unread"]}
+
+
+def test_list_messages_emits_repeated_labels_query(httpx_mock):
+    # Multiple ?labels= params must be sent as repeated occurrences so
+    # the server-side parser (r.URL.Query()["labels"]) sees a slice.
+    # Encoded as `labels=urgent&labels=follow-up`, not a CSV.
+    httpx_mock.add_response(
+        url=f"{BASE}/api/v1/agents/bot%40agents.e2a.dev/messages?status=unread&page_size=50&labels=urgent&labels=follow-up",
+        method="GET",
+        json={"messages": []},
+    )
+
+    with E2AApi(api_key="k") as api:
+        api.list_messages("bot@agents.e2a.dev", labels=["urgent", "follow-up"])
 
 
 def test_send_email(httpx_mock):

--- a/sdks/python/tests/test_v1_async_client.py
+++ b/sdks/python/tests/test_v1_async_client.py
@@ -208,6 +208,35 @@ async def test_get_messages(httpx_mock):
     assert result.next_token == "tok_abc"
 
 
+@pytest.mark.anyio
+async def test_update_message_labels(httpx_mock):
+    httpx_mock.add_response(
+        url=f"{BASE}/api/v1/agents/bot%40agents.e2a.dev/messages/msg_123",
+        method="PATCH",
+        json={"message_id": "msg_123", "labels": ["follow-up", "urgent"]},
+    )
+
+    async with AsyncE2AClient(api_key="k", agent_email="bot@agents.e2a.dev") as client:
+        result = await client.update_message_labels(
+            "msg_123", add_labels=["urgent", "follow-up"], remove_labels=["unread"],
+        )
+
+    assert result == ["follow-up", "urgent"]
+
+
+@pytest.mark.anyio
+async def test_get_messages_with_labels_filter(httpx_mock):
+    # Repeated ?labels= params, same shape as the sync client.
+    httpx_mock.add_response(
+        url=f"{BASE}/api/v1/agents/bot%40agents.e2a.dev/messages?status=all&page_size=50&labels=urgent&labels=follow-up",
+        method="GET",
+        json={"messages": []},
+    )
+
+    async with AsyncE2AClient(api_key="k", agent_email="bot@agents.e2a.dev") as client:
+        await client.get_messages(status="all", labels=["urgent", "follow-up"])
+
+
 # ── reply() ──────────────────────────────────────────────────────
 
 

--- a/sdks/python/tests/test_v1_client.py
+++ b/sdks/python/tests/test_v1_client.py
@@ -223,6 +223,94 @@ def test_get_messages_empty(httpx_mock):
     assert result.next_token is None
 
 
+def test_get_messages_surfaces_labels(httpx_mock):
+    # Regression: every row must expose `labels` as a list (never
+    # None). The wire field is a JSON array; the dataclass mirror
+    # must populate it.
+    httpx_mock.add_response(
+        url=f"{BASE}/api/v1/agents/bot%40agents.e2a.dev/messages?status=unread&page_size=50",
+        method="GET",
+        json={
+            "messages": [
+                {
+                    "message_id": "m1",
+                    "from": "alice@example.com",
+                    "to": ["bot@agents.e2a.dev"], "recipient": "bot@agents.e2a.dev",
+                    "subject": "Hi",
+                    "status": "unread",
+                    "created_at": "2026-03-30T10:00:00Z",
+                    "labels": ["urgent", "follow-up"],
+                },
+                {
+                    "message_id": "m2",
+                    "from": "bob@example.com",
+                    "to": ["bot@agents.e2a.dev"], "recipient": "bot@agents.e2a.dev",
+                    "subject": "Hi",
+                    "status": "unread",
+                    "created_at": "2026-03-30T10:00:00Z",
+                    "labels": [],
+                },
+            ]
+        },
+    )
+
+    with E2AClient(api_key="k", agent_email="bot@agents.e2a.dev") as client:
+        result = client.get_messages()
+
+    assert result.messages[0].labels == ["urgent", "follow-up"]
+    assert result.messages[1].labels == []
+
+
+def test_get_messages_with_labels_filter(httpx_mock):
+    # Filter must be emitted as repeated ?labels=foo&labels=bar.
+    httpx_mock.add_response(
+        url=f"{BASE}/api/v1/agents/bot%40agents.e2a.dev/messages?status=all&page_size=50&labels=urgent&labels=follow-up",
+        method="GET",
+        json={"messages": []},
+    )
+
+    with E2AClient(api_key="k", agent_email="bot@agents.e2a.dev") as client:
+        client.get_messages(status="all", labels=["urgent", "follow-up"])
+
+
+def test_update_message_labels(httpx_mock):
+    httpx_mock.add_response(
+        url=f"{BASE}/api/v1/agents/bot%40agents.e2a.dev/messages/msg_123",
+        method="PATCH",
+        json={"message_id": "msg_123", "labels": ["follow-up", "urgent"]},
+    )
+
+    with E2AClient(api_key="k", agent_email="bot@agents.e2a.dev") as client:
+        result = client.update_message_labels(
+            "msg_123", add_labels=["urgent", "follow-up"], remove_labels=["unread"],
+        )
+
+    # High-level returns just the labels list (most callers want the
+    # post-update state, not the wrapping response object).
+    assert result == ["follow-up", "urgent"]
+    body = json.loads(httpx_mock.get_request().content)
+    assert body == {"add_labels": ["urgent", "follow-up"], "remove_labels": ["unread"]}
+
+
+def test_update_message_labels_empty_delta_echoes_current(httpx_mock):
+    # PATCH with both lists None is a no-op that returns current
+    # labels — useful as a cheap "fetch labels only" call. The
+    # request body has no add_labels/remove_labels (model_dump
+    # exclude_none=True drops them).
+    httpx_mock.add_response(
+        url=f"{BASE}/api/v1/agents/bot%40agents.e2a.dev/messages/msg_123",
+        method="PATCH",
+        json={"message_id": "msg_123", "labels": ["urgent"]},
+    )
+
+    with E2AClient(api_key="k", agent_email="bot@agents.e2a.dev") as client:
+        result = client.update_message_labels("msg_123")
+
+    assert result == ["urgent"]
+    body = json.loads(httpx_mock.get_request().content)
+    assert body == {}
+
+
 # ── reply() ──────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Brings the labels feature to the Python SDK (sync + async) and the CLI inbox command. The TS SDK + CLI labels command already shipped in #173; this closes the remaining surface gaps so all clients are at parity.

## What's added

**Python SDK — `api.py` and `async_client.py` (raw HTTP)**
- `list_messages(..., labels: list[str] | None = None)` — emitted as repeated `?labels=` query params
- `update_message_labels(agent_email, message_id, body)` → `UpdateMessageResponse` (PATCH)

**Python SDK — `client.py` and `async_client.py` (high-level)**
- `get_messages(..., labels=...)` plumbs the filter through
- `MessageSummary.labels: list[str]` (always present, defaults to `[]`)
- `update_message_labels(message_id, add_labels=..., remove_labels=..., agent_email=...)` — returns the post-update label list directly

**CLI**
- `e2a inbox --label <l> [--label <l> ...]` — flag repeats to AND-match
- `getFlags` exported so the args test can cover repeated-flag parsing

## Verification

- Python: 197 tests pass (+6 new — PATCH on raw + high-level sync + async, labels surfaced on MessageSummary, filter emission, empty-delta echo)
- CLI: 103 tests pass (+3 new getFlags coverage)

## Backwards compatibility

- `MessageSummary.labels` is defaulted (`field(default_factory=list)`) so any existing positional constructors keep working.
- `list_messages` / `get_messages` keep all existing keyword-only params; `labels` is appended at the end and optional.

## Test plan

- [x] `pytest sdks/python/tests/` — 197 pass
- [x] `npm test --workspace @e2a/cli` — 103 pass
- [ ] Manual: `e2a inbox --label urgent --label follow-up` against a live deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)