### PR TITLE
chore(github): PR template with multi-surface checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,54 @@
+<!--
+Thanks for the PR! Keep the description tight — explain *why*, link the
+context, and use the checklist below to surface anything that's still
+open.
+
+If this PR doesn't touch the API or any client surface (e.g. docs-only,
+infra, refactor), feel free to delete the "Client surface checklist"
+section entirely.
+-->
+
+## Summary
+
+<!-- 1–3 sentences: what changes, why. Link the issue / RFC / Slack thread if any. -->
+
+## Client surface checklist
+
+<!--
+Every API change must land in every client at the same time. Skipping a
+client should be an explicit decision noted below, not an oversight.
+Delete rows that genuinely don't apply (e.g. `e2a config` doesn't need
+to be in the Python SDK).
+-->
+
+- [ ] Go handler + integration tests
+- [ ] Migration written + idempotent + safe on prod-sized tables (see [CLAUDE.md](../CLAUDE.md))
+- [ ] OpenAPI spec + generated types refreshed (`make generate` is clean)
+- [ ] TypeScript SDK — `api.ts` (raw) **and** `client.ts` (high-level)
+- [ ] Python SDK sync — `api.py` (raw) **and** `client.py` (high-level)
+- [ ] Python SDK async — `async_client.py` (both raw and high-level methods)
+- [ ] CLI command or flag in `cli/src/commands/` + wired into `cli/src/bin/e2a.ts`
+- [ ] MCP tool in `mcp/src/tools/` + registry assertion in `mcp/tests/{tools,http}.test.ts`
+- [ ] Tests at each surface above (positive + at least one negative-path / regression case)
+
+**If a row is intentionally skipped**, state why here so the reviewer doesn't have to guess:
+
+> _e.g. "MCP tool deferred — endpoint is admin-only and not useful to an LLM"_
+
+## Operational risk
+
+<!--
+Touched user data, side effects, auth, billing, notifications, or
+external integrations? Note rollback behavior, feature flags, anything
+worth flagging to oncall.
+-->
+
+## Test plan
+
+<!--
+What you ran locally, what should be tried after merge. Tick items as
+they're verified.
+-->
+
+- [ ]
+- [ ]


### PR DESCRIPTION
## Summary

Adds \`.github/pull_request_template.md\` as a forcing function against the parity gap we hit on PR #171 — Forward shipped to Go/TS/CLI/MCP but missed the Python SDK, requiring PR #175 to close two PRs later. The template surfaces the full client matrix at PR-author time so the gap is visible at review.

## What it does

When someone opens a PR via \`gh pr create\` or the web "New PR" form, GitHub auto-fills the body with the template. It includes:

- **Client surface checklist** — explicit rows for Go, TS SDK, Python SDK (sync + async), CLI, MCP, plus migration safety, regenerated types, and tests per surface.
- **A note that rows can be deleted** if the PR genuinely doesn't touch that surface.
- **A "why skipped" field** so reviewers can see intentional omissions instead of guessing.
- Standard sections for summary, operational risk, and test plan.

## What it doesn't do

This is a forcing function for authors and reviewers — it doesn't fail CI. The next step (deferred) is the automated surface-coverage check that parses \`openapi.yaml\` and the SDK source to assert every endpoint has a method in every SDK. That's a one-PR-sized chunk on its own.

## Test plan

- [x] \`gh pr create\` against this branch picks up the template body (this PR's body should reflect the template's structure)
- [ ] After merge, open a sample PR and confirm the GitHub web UI auto-fills it