### PR TITLE
feat(api): conversations — thin read layer + SDKs/CLI/MCP

### DIFF
--- a/cli/src/bin/e2a.ts
+++ b/cli/src/bin/e2a.ts
@@ -9,6 +9,7 @@ import {
 } from "../commands/agents.js";
 import { inbox } from "../commands/inbox.js";
 import { read } from "../commands/read.js";
+import { conversationsList, conversationsShow } from "../commands/conversations.js";
 import { forward } from "../commands/forward.js";
 import { labels } from "../commands/labels.js";
 import { reply } from "../commands/reply.js";
@@ -44,6 +45,8 @@ Usage:
   e2a reply <msg-id> --body … [--reply-all] [--cc …] [--bcc …]
   e2a forward <msg-id> --to … [--cc …] [--bcc …] [--body …]
   e2a labels <msg-id> [--add <label> …] [--remove <label> …]
+  e2a conversations list [--limit N] [--since ts] [--until ts]   List conversations
+  e2a conversations show <conv-id>                               Show a conversation
   e2a send [--to …] [--cc …] [--bcc …] --subject … --body …
   e2a listen [options]              Listen for emails via WebSocket
   e2a domains list                  List your domains
@@ -271,6 +274,29 @@ async function main() {
         forwardToken: getFlag(args, "--forward-token"),
       });
       break;
+    case "conversations": {
+      const sub = args[0];
+      if (sub === "list") {
+        const pageSizeStr = getFlag(args, "--limit");
+        const pageSize = pageSizeStr ? parseInt(pageSizeStr, 10) : undefined;
+        if (pageSize !== undefined && (!Number.isFinite(pageSize) || pageSize < 1)) {
+          process.stderr.write("--limit must be a positive integer\n");
+          process.exit(1);
+        }
+        await conversationsList({
+          pageSize,
+          since: getFlag(args, "--since"),
+          until: getFlag(args, "--until"),
+          from: getFlag(args, "--agent"),
+        });
+      } else if (sub === "show") {
+        await conversationsShow(args[1], { from: getFlag(args, "--agent") });
+      } else {
+        process.stderr.write("Usage: e2a conversations [list|show]\n");
+        process.exit(1);
+      }
+      break;
+    }
     case "domains": {
       const sub = args[0];
       if (sub === "list") {

--- a/cli/src/commands/conversations.ts
+++ b/cli/src/commands/conversations.ts
@@ -1,0 +1,92 @@
+import { createClient } from "../sdk.js";
+
+export async function conversationsList(opts: {
+  pageSize?: number;
+  since?: string;
+  until?: string;
+  from?: string;
+}): Promise<void> {
+  const client = createClient({ from: opts.from });
+  if (!client.agentEmail) {
+    process.stderr.write("No agent email. Set one with: e2a config set agent_email <email>\n");
+    process.exit(1);
+  }
+
+  const res = await client.listConversations({
+    pageSize: opts.pageSize,
+    since: opts.since,
+    until: opts.until,
+  });
+  const convos = res.conversations ?? [];
+  if (convos.length === 0) {
+    process.stdout.write("No conversations.\n");
+    return;
+  }
+
+  // Compute ID column width from actual data (never truncate IDs).
+  const idW = Math.max(15, ...convos.map((c) => (c.conversation_id || "").length)) + 2;
+  const subjW = 40;
+  process.stdout.write(
+    `${"CONVERSATION ID".padEnd(idW)} ${"MSGS".padStart(5)}  ${"UNREAD".padEnd(7)} ${"SUBJECT".padEnd(subjW)} LAST ACTIVITY\n`,
+  );
+  for (const c of convos) {
+    const id = (c.conversation_id || "").padEnd(idW);
+    const msgs = String(c.message_count ?? 0).padStart(5);
+    const unread = (c.has_unread ? "yes" : "no").padEnd(7);
+    const subj = (c.latest_subject || "").padEnd(subjW).slice(0, subjW);
+    process.stdout.write(`${id} ${msgs}  ${unread} ${subj} ${c.last_message_at || ""}\n`);
+  }
+  process.stdout.write(`\n${convos.length} conversations\n`);
+}
+
+export async function conversationsShow(
+  conversationId: string | undefined,
+  opts: { from?: string },
+): Promise<void> {
+  if (!conversationId) {
+    process.stderr.write("Usage: e2a conversations show <conversation-id>\n");
+    process.exit(1);
+  }
+  const client = createClient({ from: opts.from });
+  if (!client.agentEmail) {
+    process.stderr.write("No agent email. Set one with: e2a config set agent_email <email>\n");
+    process.exit(1);
+  }
+
+  const detail = await client.getConversation(conversationId);
+  process.stdout.write(`Conversation:  ${detail.conversation_id}\n`);
+  process.stdout.write(`Messages:      ${detail.message_count ?? 0} `);
+  process.stdout.write(`(inbound: ${detail.inbound_count ?? 0}, outbound: ${detail.outbound_count ?? 0})\n`);
+  process.stdout.write(`Unread:        ${detail.has_unread ? "yes" : "no"}\n`);
+  if (detail.first_message_at) {
+    process.stdout.write(`First message: ${detail.first_message_at}\n`);
+  }
+  if (detail.last_message_at) {
+    process.stdout.write(`Last message:  ${detail.last_message_at}\n`);
+  }
+  if (detail.participants && detail.participants.length) {
+    process.stdout.write(`Participants:  ${detail.participants.join(", ")}\n`);
+  }
+  if (detail.labels && detail.labels.length) {
+    process.stdout.write(`Labels:        ${detail.labels.join(", ")}\n`);
+  }
+  process.stdout.write("\n");
+
+  const msgs = detail.messages ?? [];
+  if (msgs.length === 0) {
+    return;
+  }
+  const idW = Math.max(15, ...msgs.map((m) => (m.message_id || "").length)) + 2;
+  const fromW = 25;
+  const subjW = 35;
+  process.stdout.write(
+    `${"ID".padEnd(idW)} ${"DIR".padEnd(4)} ${"FROM".padEnd(fromW)} ${"SUBJECT".padEnd(subjW)} CREATED\n`,
+  );
+  for (const m of msgs) {
+    const id = (m.message_id || "").padEnd(idW);
+    const dir = (m.direction || "?").padEnd(4);
+    const from = (m.from || "").padEnd(fromW).slice(0, fromW);
+    const subj = (m.subject || "").padEnd(subjW).slice(0, subjW);
+    process.stdout.write(`${id} ${dir} ${from} ${subj} ${m.created_at || ""}\n`);
+  }
+}

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -286,6 +286,8 @@ func (a *API) RegisterRoutes(r *mux.Router) {
 	r.HandleFunc("/api/v1/agents/{email}/messages/{id}", a.handleUpdateMessage).Methods("PATCH")
 	r.HandleFunc("/api/v1/agents/{email}/messages/{id}/reply", a.handleReplyToMessage).Methods("POST")
 	r.HandleFunc("/api/v1/agents/{email}/messages/{id}/forward", a.handleForwardMessage).Methods("POST")
+	r.HandleFunc("/api/v1/agents/{email}/conversations", a.handleListConversations).Methods("GET")
+	r.HandleFunc("/api/v1/agents/{email}/conversations/{id}", a.handleGetConversation).Methods("GET")
 	r.HandleFunc("/api/v1/domains", a.handleListDomains).Methods("GET")
 	r.HandleFunc("/api/v1/domains", a.handleRegisterDomain).Methods("POST")
 	r.HandleFunc("/api/v1/domains/{domain}/verify", a.handleVerifyDomain).Methods("POST")
@@ -2700,6 +2702,194 @@ func (a *API) handleGetMessage(w http.ResponseWriter, r *http.Request) {
 		"auth_headers":    msg.AuthHeaders,
 		"raw_message":     msg.RawMessage,
 	})
+}
+
+// handleListConversations returns the agent's conversations sorted by
+// most-recent activity. Thin read layer over messages.conversation_id —
+// no separate storage, no pagination (server caps at 100 per response,
+// which covers the inbox-style use case). Filter on the window via
+// `since` / `until` (RFC3339, brackets last_message_at).
+// @Summary      List conversations for an agent
+// @Description  Returns conversation summaries for an agent — one row per non-empty conversation_id, with aggregated counts and the latest message's subject/sender. Sorted by `last_message_at` descending. The response is hard-capped at 100 conversations (pagination is intentionally deferred for slice 1). Use `since` / `until` to bracket the active window. Messages with empty `conversation_id` are NOT in any conversation — they remain individually visible via the messages list.
+// @Tags         Email
+// @Produce      json
+// @Security     BearerAuth
+// @Param        email path  string true  "Agent email address" example(my-bot@example.com)
+// @Param        since query string false "RFC3339 timestamp; only conversations whose latest message is >= since" example(2026-05-01T00:00:00Z)
+// @Param        until query string false "RFC3339 timestamp; only conversations whose latest message is < until"
+// @Param        page_size query int false "Max conversations to return (server clamps to 100)" minimum(1) maximum(100) default(100)
+// @Success      200 {object} ListConversationsResponse
+// @Failure      400 {string} string "Invalid since/until"
+// @Failure      401 {string} string "Missing or invalid API key"
+// @Failure      404 {string} string "Agent not found or not owned by this user"
+// @Router       /api/v1/agents/{email}/conversations [get]
+func (a *API) handleListConversations(w http.ResponseWriter, r *http.Request) {
+	user, err := a.authenticateUser(r)
+	if err != nil {
+		a.writeAuthError(w, r, err)
+		return
+	}
+
+	if ok, retryAfter := a.pollLimit.AllowWithRetryAfter(user.ID); !ok {
+		writeTooManyRequests(w, retryAfter, "rate limit exceeded — max 60 requests per minute per user")
+		return
+	}
+
+	email := normalizeEmail(mux.Vars(r)["email"])
+	agent, err := a.resolveAgentForUser(r, email, user)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("agent not found: %v", err), http.StatusNotFound)
+		return
+	}
+
+	var since, until time.Time
+	if s := strings.TrimSpace(r.URL.Query().Get("since")); s != "" {
+		t, err := time.Parse(time.RFC3339, s)
+		if err != nil {
+			http.Error(w, "since must be RFC3339 (e.g. 2026-05-25T00:00:00Z)", http.StatusBadRequest)
+			return
+		}
+		since = t
+	}
+	if u := strings.TrimSpace(r.URL.Query().Get("until")); u != "" {
+		t, err := time.Parse(time.RFC3339, u)
+		if err != nil {
+			http.Error(w, "until must be RFC3339", http.StatusBadRequest)
+			return
+		}
+		until = t
+	}
+	if !since.IsZero() && !until.IsZero() && !since.Before(until) {
+		http.Error(w, "since must be earlier than until", http.StatusBadRequest)
+		return
+	}
+
+	pageSize := 100
+	if ps := strings.TrimSpace(r.URL.Query().Get("page_size")); ps != "" {
+		n, err := strconv.Atoi(ps)
+		if err != nil || n < 1 {
+			http.Error(w, "page_size must be a positive integer", http.StatusBadRequest)
+			return
+		}
+		pageSize = n
+	}
+
+	convos, err := a.store.ListConversationsByAgent(r.Context(), identity.ConversationListFilter{
+		AgentID: agent.ID,
+		Limit:   pageSize,
+		Since:   since,
+		Until:   until,
+	})
+	if err != nil {
+		log.Printf("[api] ListConversationsByAgent: agent=%s err=%v", agent.ID, err)
+		http.Error(w, "failed to fetch conversations", http.StatusInternalServerError)
+		return
+	}
+
+	summaries := make([]map[string]interface{}, len(convos))
+	for i, c := range convos {
+		summaries[i] = conversationSummaryToWire(c)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	writeJSON(w, map[string]interface{}{
+		"conversations": summaries,
+	})
+}
+
+// handleGetConversation returns a single conversation's detail — the
+// aggregate summary fields plus all member messages chronologically.
+// @Summary      Get a conversation
+// @Description  Returns the full conversation — aggregate counts, participant union, label union, and every member message (oldest-first). Messages share the schema of `MessageSummary` from the list endpoint. Returns 404 when no non-expired messages exist for `(agent, conversation_id)`; cross-agent access is indistinguishable from not-found.
+// @Tags         Email
+// @Produce      json
+// @Security     BearerAuth
+// @Param        email path string true "Agent email address" example(my-bot@example.com)
+// @Param        id    path string true "Conversation ID" example(conv_abc123)
+// @Success      200 {object} ConversationDetail
+// @Failure      401 {string} string "Missing or invalid API key"
+// @Failure      404 {string} string "Conversation not found"
+// @Router       /api/v1/agents/{email}/conversations/{id} [get]
+func (a *API) handleGetConversation(w http.ResponseWriter, r *http.Request) {
+	user, err := a.authenticateUser(r)
+	if err != nil {
+		a.writeAuthError(w, r, err)
+		return
+	}
+
+	if ok, retryAfter := a.pollLimit.AllowWithRetryAfter(user.ID); !ok {
+		writeTooManyRequests(w, retryAfter, "rate limit exceeded — max 60 requests per minute per user")
+		return
+	}
+
+	vars := mux.Vars(r)
+	email := normalizeEmail(vars["email"])
+	convoID := vars["id"]
+
+	agent, err := a.resolveAgentForUser(r, email, user)
+	if err != nil {
+		http.Error(w, fmt.Sprintf("agent not found: %v", err), http.StatusNotFound)
+		return
+	}
+
+	detail, err := a.store.GetConversationByID(r.Context(), agent.ID, convoID)
+	if err != nil {
+		if errors.Is(err, identity.ErrMessageNotFound) {
+			http.Error(w, "conversation not found", http.StatusNotFound)
+			return
+		}
+		log.Printf("[api] GetConversationByID: agent=%s conv=%s err=%v", agent.ID, convoID, err)
+		http.Error(w, "failed to fetch conversation", http.StatusInternalServerError)
+		return
+	}
+
+	// Build the wire shape: embedded summary fields + member messages
+	// rendered the same way GetMessages does (reuses the contract for
+	// labels/cc/reply_to/status etc.).
+	resp := conversationSummaryToWire(detail.ConversationSummary)
+	resp["participants"] = orEmptySlice(detail.Participants)
+	resp["labels"] = orEmptySlice(detail.Labels)
+
+	msgs := make([]map[string]interface{}, len(detail.Messages))
+	for i, m := range detail.Messages {
+		msgs[i] = map[string]interface{}{
+			"message_id":      m.ID,
+			"direction":       m.Direction,
+			"from":            m.Sender,
+			"to":              orEmptySlice(m.ToRecipients),
+			"cc":              m.CC,
+			"reply_to":        m.ReplyTo,
+			"recipient":       m.Recipient,
+			"subject":         m.Subject,
+			"conversation_id": m.ConversationID,
+			"status":          m.InboxStatus,
+			"labels":          orEmptySlice(m.Labels),
+			"created_at":      m.CreatedAt.UTC().Format(time.RFC3339),
+		}
+	}
+	resp["messages"] = msgs
+
+	w.Header().Set("Content-Type", "application/json")
+	writeJSON(w, resp)
+}
+
+// conversationSummaryToWire is the shared serializer for
+// ConversationSummary — used both standalone (list) and as the
+// embedded shape inside ConversationDetail. Keeps the two endpoints'
+// summary fields byte-identical so a list row can be rendered with
+// the same client code as a detail row.
+func conversationSummaryToWire(c identity.ConversationSummary) map[string]interface{} {
+	return map[string]interface{}{
+		"conversation_id":  c.ID,
+		"last_message_at":  c.LastMessageAt.UTC().Format(time.RFC3339),
+		"first_message_at": c.FirstMessageAt.UTC().Format(time.RFC3339),
+		"message_count":    c.MessageCount,
+		"inbound_count":    c.InboundCount,
+		"outbound_count":   c.OutboundCount,
+		"has_unread":       c.HasUnread,
+		"latest_subject":   c.LatestSubject,
+		"latest_sender":    c.LatestSender,
+	}
 }
 
 // stringSlicesEqual reports whether two ordered string slices have

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -85,6 +85,13 @@ func writeTooManyRequests(w http.ResponseWriter, retryAfter time.Duration, msg s
 const (
 	maxRequestBytesSmall = 64 * 1024        // 64 KB — domain/agent CRUD, HITL approve
 	maxRequestBytesSend  = 25 * 1024 * 1024 // 25 MB — outbound /send + reply (matches typical SMTP attachment limits)
+
+	// maxFilterStr bounds free-form query-string filters (from /
+	// subject_contains / conversation_id) and any equivalent path
+	// param such as /conversations/{id}. 200 covers human-typed
+	// substrings and msg-style IDs without making slow-query logs
+	// noisy on bad input.
+	maxFilterStr = 200
 )
 
 // ValidateWebhookImageURL — see ValidateWebhookURL.
@@ -2330,7 +2337,6 @@ func (a *API) handleGetMessages(w http.ResponseWriter, r *http.Request) {
 	// Substring filters are bound to 200 chars to keep ILIKE patterns
 	// from running away on a hot path. Time-range filters take RFC3339
 	// timestamps and reject anything else with 400.
-	const maxFilterStr = 200
 	fromFilter := strings.TrimSpace(r.URL.Query().Get("from"))
 	if len(fromFilter) > maxFilterStr {
 		http.Error(w, "from filter too long (max 200 chars)", http.StatusBadRequest)
@@ -2526,65 +2532,13 @@ func (a *API) handleGetMessages(w http.ResponseWriter, r *http.Request) {
 		messages = messages[:pageSize]
 	}
 
-	// Response shape: existing SDK consumers see the same wire fields they
-	// always have (`status` continues to carry the inbox_status value for
-	// inbound rows). New consumers (dashboard inbox) read the additional
-	// fields: `direction`, `hitl_status` (outbound HITL lifecycle),
-	// `webhook_status`/`webhook_error` (outbound delivery), `size_bytes`.
-	type messageSummary struct {
-		ID             string   `json:"message_id"`
-		Direction      string   `json:"direction"`
-		From           string   `json:"from"`
-		To             []string `json:"to"`
-		CC             []string `json:"cc,omitempty"`
-		ReplyTo        []string `json:"reply_to,omitempty"`
-		Recipient      string   `json:"recipient"`
-		Subject        string   `json:"subject"`
-		ConversationID string   `json:"conversation_id,omitempty"`
-		Status         string   `json:"status"` // back-compat: inbox_status value (read/unread); empty for outbound
-		HITLStatus     string   `json:"hitl_status,omitempty"`
-		WebhookStatus  string   `json:"webhook_status,omitempty"`
-		WebhookError   string   `json:"webhook_error,omitempty"`
-		SizeBytes      int      `json:"size_bytes,omitempty"`
-		// Labels is always present (never nil) so clients can render
-		// it without a null-check. Empty slice for unlabelled rows —
-		// matches the DB DEFAULT '{}' invariant.
-		Labels         []string `json:"labels"`
-		CreatedAt      string   `json:"created_at"`
-	}
-
+	// Response shape: messageSummary (package-level type) — every
+	// message-list endpoint uses the same builder so adding a new
+	// field is a one-place edit. See messageSummaryFromIdentity for
+	// the inbound/outbound branching of HITL/webhook fields.
 	summaries := make([]messageSummary, len(messages))
 	for i, m := range messages {
-		// HITLStatus + WebhookStatus only make sense for outbound rows;
-		// leave them empty on inbound to keep the response compact.
-		var hitl, wh, whErr string
-		var size int
-		if m.Direction == "outbound" {
-			hitl = m.Status
-			wh = m.WebhookStatus
-			whErr = m.WebhookError
-			size = m.SizeBytes
-		} else {
-			size = m.SizeBytes
-		}
-		summaries[i] = messageSummary{
-			ID:             m.ID,
-			Direction:      m.Direction,
-			From:           m.Sender,
-			To:             orEmptySlice(m.ToRecipients),
-			CC:             m.CC,
-			ReplyTo:        m.ReplyTo,
-			Recipient:      m.Recipient,
-			Subject:        m.Subject,
-			ConversationID: m.ConversationID,
-			Status:         m.InboxStatus,
-			HITLStatus:     hitl,
-			WebhookStatus:  wh,
-			WebhookError:   whErr,
-			SizeBytes:      size,
-			Labels:         orEmptySlice(m.Labels),
-			CreatedAt:      m.CreatedAt.UTC().Format(time.RFC3339),
-		}
+		summaries[i] = messageSummaryFromIdentity(m)
 	}
 
 	// Build next_token from last message (includes filters for validation)
@@ -2826,6 +2780,21 @@ func (a *API) handleGetConversation(w http.ResponseWriter, r *http.Request) {
 	email := normalizeEmail(vars["email"])
 	convoID := vars["id"]
 
+	// Bound the path-param length and reject CRLF before it reaches
+	// the DB. pgx parameter binding prevents SQL injection, but an
+	// unbounded path param could still produce slow-query log noise
+	// and waste an index lookup on a giant comparison key. The same
+	// 200-char cap that the list endpoint's ?conversation_id= filter
+	// uses; matches validateConversationID's CR/LF check.
+	if len(convoID) > maxFilterStr {
+		http.Error(w, "conversation_id too long (max 200 chars)", http.StatusBadRequest)
+		return
+	}
+	if err := validateConversationID(convoID); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
 	agent, err := a.resolveAgentForUser(r, email, user)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("agent not found: %v", err), http.StatusNotFound)
@@ -2844,28 +2813,17 @@ func (a *API) handleGetConversation(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Build the wire shape: embedded summary fields + member messages
-	// rendered the same way GetMessages does (reuses the contract for
-	// labels/cc/reply_to/status etc.).
+	// rendered via the shared messageSummaryFromIdentity helper, so a
+	// conversation row and a list-messages row carry the identical
+	// contract. If MessageSummary ever gains a new field, both
+	// endpoints surface it automatically.
 	resp := conversationSummaryToWire(detail.ConversationSummary)
 	resp["participants"] = orEmptySlice(detail.Participants)
 	resp["labels"] = orEmptySlice(detail.Labels)
 
-	msgs := make([]map[string]interface{}, len(detail.Messages))
+	msgs := make([]messageSummary, len(detail.Messages))
 	for i, m := range detail.Messages {
-		msgs[i] = map[string]interface{}{
-			"message_id":      m.ID,
-			"direction":       m.Direction,
-			"from":            m.Sender,
-			"to":              orEmptySlice(m.ToRecipients),
-			"cc":              m.CC,
-			"reply_to":        m.ReplyTo,
-			"recipient":       m.Recipient,
-			"subject":         m.Subject,
-			"conversation_id": m.ConversationID,
-			"status":          m.InboxStatus,
-			"labels":          orEmptySlice(m.Labels),
-			"created_at":      m.CreatedAt.UTC().Format(time.RFC3339),
-		}
+		msgs[i] = messageSummaryFromIdentity(m)
 	}
 	resp["messages"] = msgs
 
@@ -2890,6 +2848,72 @@ func conversationSummaryToWire(c identity.ConversationSummary) map[string]interf
 		"latest_subject":   c.LatestSubject,
 		"latest_sender":    c.LatestSender,
 	}
+}
+
+// messageSummary is the shared wire shape used by every endpoint that
+// returns a list of message summaries — currently handleGetMessages
+// and (the embedded messages array of) handleGetConversation. Hoisted
+// to package scope from a local declaration inside handleGetMessages
+// so the two endpoints never drift on field names or omitempty rules
+// — adding a new field is a one-place edit instead of two.
+//
+// `Status` continues to carry the inbox_status value (read/unread) for
+// inbound rows for back-compat with pre-existing SDK consumers. New
+// consumers (the dashboard inbox) read the additional fields:
+// `direction`, `hitl_status` (outbound HITL lifecycle),
+// `webhook_status` / `webhook_error` (outbound delivery), `size_bytes`.
+type messageSummary struct {
+	ID             string   `json:"message_id"`
+	Direction      string   `json:"direction"`
+	From           string   `json:"from"`
+	To             []string `json:"to"`
+	CC             []string `json:"cc,omitempty"`
+	ReplyTo        []string `json:"reply_to,omitempty"`
+	Recipient      string   `json:"recipient"`
+	Subject        string   `json:"subject"`
+	ConversationID string   `json:"conversation_id,omitempty"`
+	Status         string   `json:"status"` // back-compat: inbox_status for inbound; empty for outbound
+	HITLStatus     string   `json:"hitl_status,omitempty"`
+	WebhookStatus  string   `json:"webhook_status,omitempty"`
+	WebhookError   string   `json:"webhook_error,omitempty"`
+	SizeBytes      int      `json:"size_bytes,omitempty"`
+	// Labels is always present (never nil) so clients can render it
+	// without a null-check. Empty slice for unlabelled rows — matches
+	// the DB DEFAULT '{}' invariant.
+	Labels    []string `json:"labels"`
+	CreatedAt string   `json:"created_at"`
+}
+
+// messageSummaryFromIdentity builds the wire shape from a stored row.
+// Outbound-only fields (HITLStatus / WebhookStatus / WebhookError) are
+// empty for inbound rows so the response stays compact; SizeBytes
+// passes through for both directions (set or zero from the load path).
+//
+// Callers that populate Message from a SELECT that doesn't fetch the
+// webhook join still get correct output — empty WebhookStatus is the
+// "no info" state, and the omitempty tag drops it on the wire.
+func messageSummaryFromIdentity(m identity.Message) messageSummary {
+	s := messageSummary{
+		ID:             m.ID,
+		Direction:      m.Direction,
+		From:           m.Sender,
+		To:             orEmptySlice(m.ToRecipients),
+		CC:             m.CC,
+		ReplyTo:        m.ReplyTo,
+		Recipient:      m.Recipient,
+		Subject:        m.Subject,
+		ConversationID: m.ConversationID,
+		Status:         m.InboxStatus,
+		SizeBytes:      m.SizeBytes,
+		Labels:         orEmptySlice(m.Labels),
+		CreatedAt:      m.CreatedAt.UTC().Format(time.RFC3339),
+	}
+	if m.Direction == "outbound" {
+		s.HITLStatus = m.Status
+		s.WebhookStatus = m.WebhookStatus
+		s.WebhookError = m.WebhookError
+	}
+	return s
 }
 
 // stringSlicesEqual reports whether two ordered string slices have

--- a/internal/agent/api_docs.go
+++ b/internal/agent/api_docs.go
@@ -106,10 +106,6 @@ type ListMessagesResponse struct {
 // ConversationSummary is one row in the conversations list. Aggregated
 // counts + the "latest" preview fields render an inbox-style
 // conversation list without a per-row drill-down.
-//
-// has_unread is true iff at least one INBOUND member is unread.
-// Outbound pending_approval doesn't count — this is the agent's
-// mailbox view, not the reviewer's HITL queue.
 type ConversationSummary struct {
 	ConversationID string `json:"conversation_id" example:"conv_abc123"`
 	LastMessageAt  string `json:"last_message_at" example:"2026-05-28T12:00:00Z"`
@@ -117,9 +113,14 @@ type ConversationSummary struct {
 	MessageCount   int    `json:"message_count" example:"4"`
 	InboundCount   int    `json:"inbound_count" example:"2"`
 	OutboundCount  int    `json:"outbound_count" example:"2"`
-	HasUnread      bool   `json:"has_unread" example:"true"`
-	LatestSubject  string `json:"latest_subject" example:"Re: Quarterly report"`
-	LatestSender   string `json:"latest_sender" example:"alice@example.com"`
+	// HasUnread is true iff at least one INBOUND member of this
+	// conversation is in inbox_status='unread'. Outbound rows do
+	// NOT contribute — a thread containing only your sent messages
+	// (or only HITL-pending outbound) returns false. This is the
+	// agent's mailbox view, not the reviewer's HITL queue.
+	HasUnread     bool   `json:"has_unread" example:"true"`
+	LatestSubject string `json:"latest_subject" example:"Re: Quarterly report"`
+	LatestSender  string `json:"latest_sender" example:"alice@example.com"`
 } // @name ConversationSummary
 
 // ConversationDetail extends the summary with computed aggregates

--- a/internal/agent/api_docs.go
+++ b/internal/agent/api_docs.go
@@ -103,6 +103,43 @@ type ListMessagesResponse struct {
 	NextToken string           `json:"next_token,omitempty"`
 } // @name ListMessagesResponse
 
+// ConversationSummary is one row in the conversations list. Aggregated
+// counts + the "latest" preview fields render an inbox-style
+// conversation list without a per-row drill-down.
+//
+// has_unread is true iff at least one INBOUND member is unread.
+// Outbound pending_approval doesn't count — this is the agent's
+// mailbox view, not the reviewer's HITL queue.
+type ConversationSummary struct {
+	ConversationID string `json:"conversation_id" example:"conv_abc123"`
+	LastMessageAt  string `json:"last_message_at" example:"2026-05-28T12:00:00Z"`
+	FirstMessageAt string `json:"first_message_at" example:"2026-05-20T10:00:00Z"`
+	MessageCount   int    `json:"message_count" example:"4"`
+	InboundCount   int    `json:"inbound_count" example:"2"`
+	OutboundCount  int    `json:"outbound_count" example:"2"`
+	HasUnread      bool   `json:"has_unread" example:"true"`
+	LatestSubject  string `json:"latest_subject" example:"Re: Quarterly report"`
+	LatestSender   string `json:"latest_sender" example:"alice@example.com"`
+} // @name ConversationSummary
+
+// ConversationDetail extends the summary with computed aggregates
+// (participants union, label union) and the member messages, ordered
+// chronologically (oldest first).
+type ConversationDetail struct {
+	ConversationSummary
+	Participants []string         `json:"participants"`
+	Labels       []string         `json:"labels"`
+	Messages     []MessageSummary `json:"messages"`
+} // @name ConversationDetail
+
+// ListConversationsResponse wraps the conversations list. Pagination
+// is intentionally deferred — the response is hard-capped at 100
+// conversations server-side, which covers the inbox-style use case
+// without a cursor.
+type ListConversationsResponse struct {
+	Conversations []ConversationSummary `json:"conversations"`
+} // @name ListConversationsResponse
+
 // MessageSummary is a lightweight message summary for the list endpoint.
 // To and CC are the parsed To: / Cc: headers from the original message;
 // Recipient is this delivery's per-agent target. ReplyTo is the parsed

--- a/internal/agent/conversations_api_test.go
+++ b/internal/agent/conversations_api_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"testing"
 )
 
@@ -269,6 +270,101 @@ func TestGetConversation_DetailShape(t *testing.T) {
 	for i, m := range detail.Messages {
 		if m.Labels == nil {
 			t.Errorf("messages[%d].labels = nil, want array", i)
+		}
+	}
+}
+
+func TestGetConversation_RejectsOversizedID(t *testing.T) {
+	// Defensive cap: a 300-char path param should 400 before reaching
+	// the DB. Matches the same maxFilterStr cap the list endpoint
+	// applies to the conversation_id query param.
+	f := setupConvoFixture(t, "convo-oversize")
+	longID := strings.Repeat("a", 250)
+	resp, _ := f.get(t, "/api/v1/agents/"+f.agentEmail+"/conversations/"+longID)
+	if resp.StatusCode != 400 {
+		t.Errorf("status = %d, want 400 (oversized conversation_id)", resp.StatusCode)
+	}
+}
+
+func TestGetConversation_RejectsCRLFInID(t *testing.T) {
+	// validateConversationID rejects CR/LF; the path param is no
+	// different from the query param for this guard.
+	f := setupConvoFixture(t, "convo-crlf")
+	resp, _ := f.get(t, "/api/v1/agents/"+f.agentEmail+"/conversations/conv%0D%0Ainjected")
+	if resp.StatusCode != 400 {
+		t.Errorf("status = %d, want 400 (CRLF in conversation_id)", resp.StatusCode)
+	}
+}
+
+func TestGetConversation_MessageRowHasAllSummaryFields(t *testing.T) {
+	// Contract regression: each message row in the conversation
+	// detail's `messages[]` must carry the same set of summary fields
+	// as `GET /messages`. Previously the detail handler hand-rolled
+	// a map[string]interface{} that omitted hitl_status, webhook_status,
+	// webhook_error, size_bytes, and could silently drift from
+	// MessageSummary on every list-endpoint addition. Now both paths
+	// share messageSummaryFromIdentity — this test prevents future
+	// drift by asserting that the detail-message JSON keys are a
+	// superset of the list-endpoint keys for the same row.
+	server, store, _ := setupAPI(t)
+	ctx := context.Background()
+	user, _ := store.CreateOrGetUser(ctx, "owner-convo-shape@example.com", "Owner", "google-convo-shape-2")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "convo-shape-2-key", nil)
+	store.ClaimOrCreateDomain(ctx, "convo-shape-2.example.com", user.ID)
+	store.VerifyDomain(ctx, "convo-shape-2.example.com", user.ID)
+	agent, _ := store.CreateAgent(ctx, "bot@convo-shape-2.example.com", "convo-shape-2.example.com", "", "https://example.com/webhook", "", user.ID)
+
+	msg, _ := store.CreateInboundMessage(ctx, "", agent.ID, "alice@x.com", "bot@convo-shape-2.example.com", "<m1@x>", "hi", "conv-shape-2", "unread", nil, nil, nil, nil, nil)
+	store.ModifyMessageLabels(ctx, msg.ID, agent.ID, []string{"urgent"}, nil)
+
+	// Fetch the row via the messages list.
+	reqList, _ := http.NewRequest("GET", server.URL+"/api/v1/agents/bot@convo-shape-2.example.com/messages?status=all&direction=all", nil)
+	reqList.Header.Set("Authorization", "Bearer "+apiKey.PlaintextKey)
+	respList, _ := http.DefaultClient.Do(reqList)
+	defer respList.Body.Close()
+	var listBody struct {
+		Messages []map[string]interface{} `json:"messages"`
+	}
+	json.NewDecoder(respList.Body).Decode(&listBody)
+	if len(listBody.Messages) != 1 {
+		t.Fatalf("list len = %d, want 1", len(listBody.Messages))
+	}
+	listKeys := map[string]bool{}
+	for k := range listBody.Messages[0] {
+		listKeys[k] = true
+	}
+
+	// Fetch the same row via the conversation detail.
+	reqDetail, _ := http.NewRequest("GET", server.URL+"/api/v1/agents/bot@convo-shape-2.example.com/conversations/conv-shape-2", nil)
+	reqDetail.Header.Set("Authorization", "Bearer "+apiKey.PlaintextKey)
+	respDetail, _ := http.DefaultClient.Do(reqDetail)
+	defer respDetail.Body.Close()
+	var detailBody struct {
+		Messages []map[string]interface{} `json:"messages"`
+	}
+	json.NewDecoder(respDetail.Body).Decode(&detailBody)
+	if len(detailBody.Messages) != 1 {
+		t.Fatalf("detail messages len = %d, want 1", len(detailBody.Messages))
+	}
+	detailKeys := map[string]bool{}
+	for k := range detailBody.Messages[0] {
+		detailKeys[k] = true
+	}
+
+	// Every key the list endpoint emits must also appear on the
+	// detail's member row. The reverse isn't required (the detail
+	// could emit MORE), so we only assert the superset direction.
+	for k := range listKeys {
+		if !detailKeys[k] {
+			t.Errorf("conversation detail message missing key %q (drift from MessageSummary contract)", k)
+		}
+	}
+
+	// Field-level spot checks: the keys we'd most want to know about
+	// if they ever disappeared from the conversation row.
+	for _, must := range []string{"message_id", "direction", "from", "subject", "labels", "created_at", "status"} {
+		if _, ok := detailBody.Messages[0][must]; !ok {
+			t.Errorf("conversation detail message missing critical key %q", must)
 		}
 	}
 }

--- a/internal/agent/conversations_api_test.go
+++ b/internal/agent/conversations_api_test.go
@@ -1,0 +1,301 @@
+package agent_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+)
+
+// convoFixture provisions a verified domain + agent and returns the
+// running test server, the API key, and the agent email.
+type convoFixture struct {
+	serverURL  string
+	apiKey     string
+	agentEmail string
+}
+
+func setupConvoFixture(t *testing.T, prefix string) convoFixture {
+	t.Helper()
+	server, store, _ := setupAPI(t)
+	ctx := context.Background()
+	user, _ := store.CreateOrGetUser(ctx, "owner-"+prefix+"@example.com", "Owner", "google-"+prefix)
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, prefix+"-key", nil)
+	domain := prefix + ".example.com"
+	store.ClaimOrCreateDomain(ctx, domain, user.ID)
+	store.VerifyDomain(ctx, domain, user.ID)
+	agentEmail := "bot@" + domain
+	store.CreateAgent(ctx, agentEmail, domain, "", "https://example.com/webhook", "", user.ID)
+	return convoFixture{
+		serverURL:  server.URL,
+		apiKey:     apiKey.PlaintextKey,
+		agentEmail: agentEmail,
+	}
+}
+
+func (f convoFixture) get(t *testing.T, path string) (*http.Response, []byte) {
+	t.Helper()
+	req, _ := http.NewRequest("GET", f.serverURL+path, nil)
+	req.Header.Set("Authorization", "Bearer "+f.apiKey)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET %s: %v", path, err)
+	}
+	var buf bytes.Buffer
+	buf.ReadFrom(resp.Body)
+	resp.Body.Close()
+	return resp, buf.Bytes()
+}
+
+func TestListConversations_Unauthorized(t *testing.T) {
+	server, _, _ := setupAPI(t)
+	req, _ := http.NewRequest("GET", server.URL+"/api/v1/agents/any@example.com/conversations", nil)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	if resp.StatusCode != 401 {
+		t.Errorf("status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestListConversations_AgentNotFound(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	ctx := context.Background()
+	user, _ := store.CreateOrGetUser(ctx, "owner-convo404@example.com", "Owner", "google-convo404")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "convo404-key", nil)
+	// No agent for this user
+
+	req, _ := http.NewRequest("GET", server.URL+"/api/v1/agents/missing@example.com/conversations", nil)
+	req.Header.Set("Authorization", "Bearer "+apiKey.PlaintextKey)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	if resp.StatusCode != 404 {
+		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestListConversations_GroupsAndReturnsSummaryShape(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	ctx := context.Background()
+	user, _ := store.CreateOrGetUser(ctx, "owner-convo-shape@example.com", "Owner", "google-convo-shape")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "convo-shape-key", nil)
+	store.ClaimOrCreateDomain(ctx, "convo-shape.example.com", user.ID)
+	store.VerifyDomain(ctx, "convo-shape.example.com", user.ID)
+	agent, _ := store.CreateAgent(ctx, "bot@convo-shape.example.com", "convo-shape.example.com", "", "https://example.com/webhook", "", user.ID)
+
+	// Two conversations: A (2 inbound, both unread) and B (1 inbound).
+	store.CreateInboundMessage(ctx, "", agent.ID, "alice@x.com", "bot@convo-shape.example.com", "<a1@x>", "Subj A", "conv-shape-A", "unread", nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agent.ID, "alice@x.com", "bot@convo-shape.example.com", "<a2@x>", "Subj A reply", "conv-shape-A", "unread", nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agent.ID, "bob@x.com", "bot@convo-shape.example.com", "<b1@x>", "Subj B", "conv-shape-B", "unread", nil, nil, nil, nil, nil)
+
+	req, _ := http.NewRequest("GET", server.URL+"/api/v1/agents/bot@convo-shape.example.com/conversations", nil)
+	req.Header.Set("Authorization", "Bearer "+apiKey.PlaintextKey)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	var body struct {
+		Conversations []struct {
+			ConversationID string `json:"conversation_id"`
+			MessageCount   int    `json:"message_count"`
+			InboundCount   int    `json:"inbound_count"`
+			OutboundCount  int    `json:"outbound_count"`
+			HasUnread      bool   `json:"has_unread"`
+			LatestSubject  string `json:"latest_subject"`
+			LatestSender   string `json:"latest_sender"`
+			LastMessageAt  string `json:"last_message_at"`
+		} `json:"conversations"`
+	}
+	json.NewDecoder(resp.Body).Decode(&body)
+	if len(body.Conversations) != 2 {
+		t.Fatalf("len(conversations) = %d, want 2", len(body.Conversations))
+	}
+	byID := map[string]int{}
+	for _, c := range body.Conversations {
+		byID[c.ConversationID] = c.MessageCount
+		if c.LastMessageAt == "" {
+			t.Errorf("%s: last_message_at is empty", c.ConversationID)
+		}
+		if !c.HasUnread {
+			t.Errorf("%s: has_unread = false, want true", c.ConversationID)
+		}
+	}
+	if byID["conv-shape-A"] != 2 {
+		t.Errorf("conv-shape-A count = %d, want 2", byID["conv-shape-A"])
+	}
+	if byID["conv-shape-B"] != 1 {
+		t.Errorf("conv-shape-B count = %d, want 1", byID["conv-shape-B"])
+	}
+}
+
+func TestListConversations_InvalidSinceUntil(t *testing.T) {
+	f := setupConvoFixture(t, "convo-invalid")
+	cases := []struct {
+		name string
+		qs   string
+	}{
+		{"since-bad", "since=not-a-date"},
+		{"until-bad", "until=23:00"},
+		{"since-after-until", "since=2026-12-01T00:00:00Z&until=2026-01-01T00:00:00Z"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			resp, _ := f.get(t, "/api/v1/agents/"+f.agentEmail+"/conversations?"+c.qs)
+			if resp.StatusCode != 400 {
+				t.Errorf("status = %d, want 400", resp.StatusCode)
+			}
+		})
+	}
+}
+
+func TestListConversations_ExcludesEmptyConversationID(t *testing.T) {
+	// Regression: messages with empty conversation_id are NOT
+	// "the empty conversation" — they're standalone and must not
+	// appear in any list row.
+	server, store, _ := setupAPI(t)
+	ctx := context.Background()
+	user, _ := store.CreateOrGetUser(ctx, "owner-convo-empty@example.com", "Owner", "google-convo-empty")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "convo-empty-key", nil)
+	store.ClaimOrCreateDomain(ctx, "convo-empty.example.com", user.ID)
+	store.VerifyDomain(ctx, "convo-empty.example.com", user.ID)
+	agent, _ := store.CreateAgent(ctx, "bot@convo-empty.example.com", "convo-empty.example.com", "", "https://example.com/webhook", "", user.ID)
+
+	store.CreateInboundMessage(ctx, "", agent.ID, "x@x.com", "bot@convo-empty.example.com", "<m1@x>", "no-conv", "", "unread", nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agent.ID, "x@x.com", "bot@convo-empty.example.com", "<m2@x>", "with-conv", "conv-some", "unread", nil, nil, nil, nil, nil)
+
+	req, _ := http.NewRequest("GET", server.URL+"/api/v1/agents/bot@convo-empty.example.com/conversations", nil)
+	req.Header.Set("Authorization", "Bearer "+apiKey.PlaintextKey)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	var body struct {
+		Conversations []struct {
+			ConversationID string `json:"conversation_id"`
+		} `json:"conversations"`
+	}
+	json.NewDecoder(resp.Body).Decode(&body)
+	if len(body.Conversations) != 1 {
+		t.Fatalf("len = %d, want 1 (only the message with conv-some)", len(body.Conversations))
+	}
+	if body.Conversations[0].ConversationID != "conv-some" {
+		t.Errorf("conversation_id = %q, want conv-some", body.Conversations[0].ConversationID)
+	}
+}
+
+func TestGetConversation_Unauthorized(t *testing.T) {
+	server, _, _ := setupAPI(t)
+	req, _ := http.NewRequest("GET", server.URL+"/api/v1/agents/any@example.com/conversations/conv_x", nil)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	if resp.StatusCode != 401 {
+		t.Errorf("status = %d, want 401", resp.StatusCode)
+	}
+}
+
+func TestGetConversation_NotFound(t *testing.T) {
+	f := setupConvoFixture(t, "convo-detail-404")
+	resp, _ := f.get(t, "/api/v1/agents/"+f.agentEmail+"/conversations/conv_does_not_exist")
+	if resp.StatusCode != 404 {
+		t.Errorf("status = %d, want 404", resp.StatusCode)
+	}
+}
+
+func TestGetConversation_DetailShape(t *testing.T) {
+	server, store, _ := setupAPI(t)
+	ctx := context.Background()
+	user, _ := store.CreateOrGetUser(ctx, "owner-convo-detail@example.com", "Owner", "google-convo-detail")
+	apiKey, _ := store.CreateAPIKey(ctx, user.ID, "convo-detail-key", nil)
+	store.ClaimOrCreateDomain(ctx, "convo-detail.example.com", user.ID)
+	store.VerifyDomain(ctx, "convo-detail.example.com", user.ID)
+	agent, _ := store.CreateAgent(ctx, "bot@convo-detail.example.com", "convo-detail.example.com", "", "https://example.com/webhook", "", user.ID)
+
+	m1, _ := store.CreateInboundMessage(ctx, "", agent.ID, "alice@x.com", "bot@convo-detail.example.com", "<m1@x>", "first", "conv-d", "unread", nil, nil, []string{"bot@convo-detail.example.com"}, nil, nil)
+	m2, _ := store.CreateInboundMessage(ctx, "", agent.ID, "bob@x.com", "bot@convo-detail.example.com", "<m2@x>", "second", "conv-d", "unread", nil, nil, []string{"bot@convo-detail.example.com"}, []string{"carol@x.com"}, nil)
+	store.ModifyMessageLabels(ctx, m1.ID, agent.ID, []string{"urgent"}, nil)
+	store.ModifyMessageLabels(ctx, m2.ID, agent.ID, []string{"follow-up"}, nil)
+
+	req, _ := http.NewRequest("GET", server.URL+"/api/v1/agents/bot@convo-detail.example.com/conversations/"+url.PathEscape("conv-d"), nil)
+	req.Header.Set("Authorization", "Bearer "+apiKey.PlaintextKey)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var detail struct {
+		ConversationID string   `json:"conversation_id"`
+		MessageCount   int      `json:"message_count"`
+		Participants   []string `json:"participants"`
+		Labels         []string `json:"labels"`
+		Messages       []struct {
+			MessageID string   `json:"message_id"`
+			Subject   string   `json:"subject"`
+			Labels    []string `json:"labels"`
+		} `json:"messages"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&detail); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if detail.ConversationID != "conv-d" {
+		t.Errorf("conversation_id = %q", detail.ConversationID)
+	}
+	if detail.MessageCount != 2 {
+		t.Errorf("message_count = %d, want 2", detail.MessageCount)
+	}
+	// Labels = union of member labels — sorted
+	if fmt.Sprintf("%v", detail.Labels) != "[follow-up urgent]" {
+		t.Errorf("labels = %v, want [follow-up urgent]", detail.Labels)
+	}
+	// Participants must include senders + recipient + to + cc
+	found := map[string]bool{}
+	for _, p := range detail.Participants {
+		found[p] = true
+	}
+	for _, want := range []string{"alice@x.com", "bob@x.com", "bot@convo-detail.example.com", "carol@x.com"} {
+		if !found[want] {
+			t.Errorf("participants missing %q: %v", want, detail.Participants)
+		}
+	}
+	// Messages chronological — first then second
+	if len(detail.Messages) != 2 {
+		t.Fatalf("len(messages) = %d, want 2", len(detail.Messages))
+	}
+	if detail.Messages[0].Subject != "first" || detail.Messages[1].Subject != "second" {
+		t.Errorf("messages out of order: %v / %v", detail.Messages[0].Subject, detail.Messages[1].Subject)
+	}
+	// Regression: each message row must have labels field (never null)
+	for i, m := range detail.Messages {
+		if m.Labels == nil {
+			t.Errorf("messages[%d].labels = nil, want array", i)
+		}
+	}
+}
+
+func TestGetConversation_CrossAgentReturns404(t *testing.T) {
+	// Agent B (different user) must NOT be able to read agent A's
+	// conversation, even with the right conversation_id. Same
+	// not-found masking as single-message reads.
+	server, store, _ := setupAPI(t)
+	ctx := context.Background()
+	userA, _ := store.CreateOrGetUser(ctx, "owner-convoxA@example.com", "OwnerA", "google-convoxA")
+	store.ClaimOrCreateDomain(ctx, "convoxa.example.com", userA.ID)
+	store.VerifyDomain(ctx, "convoxa.example.com", userA.ID)
+	agentA, _ := store.CreateAgent(ctx, "bot@convoxa.example.com", "convoxa.example.com", "", "https://example.com/webhook", "", userA.ID)
+	store.CreateInboundMessage(ctx, "", agentA.ID, "x@gmail.com", "bot@convoxa.example.com", "<x@x>", "secret", "conv-shared", "unread", nil, nil, nil, nil, nil)
+
+	userB, _ := store.CreateOrGetUser(ctx, "owner-convoxB@example.com", "OwnerB", "google-convoxB")
+	apiKeyB, _ := store.CreateAPIKey(ctx, userB.ID, "convoxB-key", nil)
+	store.ClaimOrCreateDomain(ctx, "convoxb.example.com", userB.ID)
+	store.VerifyDomain(ctx, "convoxb.example.com", userB.ID)
+	store.CreateAgent(ctx, "bot@convoxb.example.com", "convoxb.example.com", "", "https://example.com/webhook", "", userB.ID)
+
+	req, _ := http.NewRequest("GET", server.URL+"/api/v1/agents/bot@convoxb.example.com/conversations/conv-shared", nil)
+	req.Header.Set("Authorization", "Bearer "+apiKeyB.PlaintextKey)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	if resp.StatusCode != 404 {
+		t.Errorf("status = %d, want 404 (cross-agent must look like not-found)", resp.StatusCode)
+	}
+}

--- a/internal/identity/conversations_test.go
+++ b/internal/identity/conversations_test.go
@@ -1,0 +1,303 @@
+package identity_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+)
+
+// convoTestSetup provisions a verified domain + agent and returns the
+// agent id. Each test gets its own (user, domain, agent) so tests
+// can run in parallel without colliding on agent_id state.
+func convoTestSetup(t *testing.T, store *identity.Store, prefix string) string {
+	t.Helper()
+	ctx := context.Background()
+	user, err := store.CreateOrGetUser(ctx, "owner-"+prefix+"@example.com", "Owner", "google-"+prefix)
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	domain := prefix + ".example.com"
+	if _, err := store.ClaimOrCreateDomain(ctx, domain, user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+	if err := store.VerifyDomain(ctx, domain, user.ID); err != nil {
+		t.Fatalf("VerifyDomain: %v", err)
+	}
+	agent, err := store.CreateAgent(ctx, "bot@"+domain, domain, "", "https://example.com/webhook", "", user.ID)
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	return agent.ID
+}
+
+func TestListConversationsByAgent_GroupsByConversationID(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	agentID := convoTestSetup(t, store, "convo-group")
+
+	// Conversation A: 3 messages
+	for i := 0; i < 3; i++ {
+		_, err := store.CreateInboundMessage(ctx, "", agentID, "alice@gmail.com", "bot@convo-group.example.com",
+			fmt.Sprintf("<a%d@gmail.com>", i),
+			"Subject A", "conv-A", "", nil, nil, nil, nil, nil,
+		)
+		if err != nil {
+			t.Fatalf("CreateInboundMessage A%d: %v", i, err)
+		}
+	}
+	// Conversation B: 1 message
+	if _, err := store.CreateInboundMessage(ctx, "", agentID, "bob@gmail.com", "bot@convo-group.example.com",
+		"<b0@gmail.com>", "Subject B", "conv-B", "", nil, nil, nil, nil, nil,
+	); err != nil {
+		t.Fatalf("CreateInboundMessage B: %v", err)
+	}
+	// A message with NO conversation_id — must NOT show up in the list.
+	if _, err := store.CreateInboundMessage(ctx, "", agentID, "carol@gmail.com", "bot@convo-group.example.com",
+		"<c0@gmail.com>", "Subject C (no conv)", "", "", nil, nil, nil, nil, nil,
+	); err != nil {
+		t.Fatalf("CreateInboundMessage C: %v", err)
+	}
+
+	convos, err := store.ListConversationsByAgent(ctx, identity.ConversationListFilter{AgentID: agentID})
+	if err != nil {
+		t.Fatalf("ListConversationsByAgent: %v", err)
+	}
+	if len(convos) != 2 {
+		t.Fatalf("len(convos) = %d, want 2", len(convos))
+	}
+	got := map[string]int{}
+	for _, c := range convos {
+		got[c.ID] = c.MessageCount
+	}
+	if got["conv-A"] != 3 {
+		t.Errorf("conv-A message_count = %d, want 3", got["conv-A"])
+	}
+	if got["conv-B"] != 1 {
+		t.Errorf("conv-B message_count = %d, want 1", got["conv-B"])
+	}
+	if _, ok := got[""]; ok {
+		t.Error("empty conversation_id must not appear in list")
+	}
+}
+
+func TestListConversationsByAgent_SortsByLastMessageDesc(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	agentID := convoTestSetup(t, store, "convo-sort")
+
+	// Create A first, then B — but A is the "newer" conversation
+	// because we add another message to A after B's only one.
+	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-sort.example.com", "<a1@x>", "A", "conv-A-sort", "", nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-sort.example.com", "<b1@x>", "B", "conv-B-sort", "", nil, nil, nil, nil, nil)
+	// Bump A's last_message_at to be the newest.
+	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-sort.example.com", "<a2@x>", "A2", "conv-A-sort", "", nil, nil, nil, nil, nil)
+
+	convos, _ := store.ListConversationsByAgent(ctx, identity.ConversationListFilter{AgentID: agentID})
+	if len(convos) != 2 {
+		t.Fatalf("len(convos) = %d, want 2", len(convos))
+	}
+	if convos[0].ID != "conv-A-sort" {
+		t.Errorf("first conversation id = %q, want conv-A-sort (most recent activity)", convos[0].ID)
+	}
+	if convos[1].ID != "conv-B-sort" {
+		t.Errorf("second conversation id = %q, want conv-B-sort", convos[1].ID)
+	}
+}
+
+func TestListConversationsByAgent_LimitClamp(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	agentID := convoTestSetup(t, store, "convo-clamp")
+
+	// Caller asks for 9999; storage must clamp to ConversationListHardCap.
+	// We don't need 9999 conversations to test the clamp — we just need
+	// the query not to error and not to return more than the cap. The
+	// cap value is part of the contract.
+	if identity.ConversationListHardCap < 1 {
+		t.Fatalf("ConversationListHardCap must be > 0, got %d", identity.ConversationListHardCap)
+	}
+	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-clamp.example.com", "<a@x>", "A", "conv-clamp-A", "", nil, nil, nil, nil, nil)
+	convos, err := store.ListConversationsByAgent(ctx, identity.ConversationListFilter{AgentID: agentID, Limit: 9999})
+	if err != nil {
+		t.Fatalf("ListConversationsByAgent: %v", err)
+	}
+	if len(convos) > identity.ConversationListHardCap {
+		t.Errorf("len(convos) = %d exceeds hard cap %d", len(convos), identity.ConversationListHardCap)
+	}
+}
+
+func TestListConversationsByAgent_SinceUntilWindow(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	agentID := convoTestSetup(t, store, "convo-window")
+
+	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-window.example.com", "<old@x>", "old", "conv-old", "", nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-window.example.com", "<new@x>", "new", "conv-new", "", nil, nil, nil, nil, nil)
+
+	// since=now-1h should return both; since=future should return zero.
+	all, _ := store.ListConversationsByAgent(ctx, identity.ConversationListFilter{
+		AgentID: agentID,
+		Since:   time.Now().Add(-1 * time.Hour),
+	})
+	if len(all) != 2 {
+		t.Errorf("since=-1h returned %d convos, want 2", len(all))
+	}
+	none, _ := store.ListConversationsByAgent(ctx, identity.ConversationListFilter{
+		AgentID: agentID,
+		Since:   time.Now().Add(1 * time.Hour),
+	})
+	if len(none) != 0 {
+		t.Errorf("since=+1h returned %d convos, want 0 (future window)", len(none))
+	}
+}
+
+func TestListConversationsByAgent_AggregateFields(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	agentID := convoTestSetup(t, store, "convo-agg")
+
+	// Conversation with one inbound (explicitly unread) and one outbound.
+	// The 9th arg of CreateInboundMessage is inbox_status — pass
+	// "unread" explicitly so the has_unread aggregate is true.
+	store.CreateInboundMessage(ctx, "", agentID, "alice@gmail.com", "bot@convo-agg.example.com", "<i1@x>", "Hello", "conv-agg", "unread", nil, nil, nil, nil, nil)
+	store.CreateOutboundMessage(ctx, agentID, []string{"alice@gmail.com"}, nil, nil, "Re: Hello", "reply", "smtp", "<out@x>", "conv-agg")
+
+	convos, _ := store.ListConversationsByAgent(ctx, identity.ConversationListFilter{AgentID: agentID})
+	if len(convos) != 1 {
+		t.Fatalf("len(convos) = %d, want 1", len(convos))
+	}
+	c := convos[0]
+	if c.MessageCount != 2 {
+		t.Errorf("message_count = %d, want 2", c.MessageCount)
+	}
+	if c.InboundCount != 1 {
+		t.Errorf("inbound_count = %d, want 1", c.InboundCount)
+	}
+	if c.OutboundCount != 1 {
+		t.Errorf("outbound_count = %d, want 1", c.OutboundCount)
+	}
+	if !c.HasUnread {
+		t.Error("has_unread = false; want true (inbound was created unread)")
+	}
+	// LatestSubject + LatestSender follow MAX(created_at). Both
+	// rows were created back-to-back so either could be the latest;
+	// rather than asserting one, just confirm they're non-empty.
+	if c.LatestSubject == "" {
+		t.Error("latest_subject is empty")
+	}
+}
+
+func TestGetConversationByID_OrdersChronologically(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	agentID := convoTestSetup(t, store, "convo-order")
+
+	// Create three messages explicitly in non-monotonic order to
+	// verify the storage layer sorts on read, not write.
+	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-order.example.com", "<m1@x>", "first", "conv-ord", "", nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-order.example.com", "<m2@x>", "second", "conv-ord", "", nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-order.example.com", "<m3@x>", "third", "conv-ord", "", nil, nil, nil, nil, nil)
+
+	d, err := store.GetConversationByID(ctx, agentID, "conv-ord")
+	if err != nil {
+		t.Fatalf("GetConversationByID: %v", err)
+	}
+	if d.MessageCount != 3 {
+		t.Fatalf("MessageCount = %d, want 3", d.MessageCount)
+	}
+	subjects := []string{d.Messages[0].Subject, d.Messages[1].Subject, d.Messages[2].Subject}
+	want := []string{"first", "second", "third"}
+	if !reflect.DeepEqual(subjects, want) {
+		t.Errorf("subjects = %v, want %v (chronological ASC)", subjects, want)
+	}
+}
+
+func TestGetConversationByID_ComputesParticipantsAndLabels(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	agentID := convoTestSetup(t, store, "convo-part")
+
+	m1, _ := store.CreateInboundMessage(ctx, "", agentID, "alice@gmail.com", "bot@convo-part.example.com", "<p1@x>", "hi", "conv-part", "", nil, nil,
+		[]string{"bot@convo-part.example.com", "team@convo-part.example.com"}, nil, nil,
+	)
+	m2, _ := store.CreateInboundMessage(ctx, "", agentID, "bob@gmail.com", "bot@convo-part.example.com", "<p2@x>", "hi", "conv-part", "", nil, nil,
+		[]string{"bot@convo-part.example.com"}, []string{"carol@gmail.com"}, nil,
+	)
+	store.ModifyMessageLabels(ctx, m1.ID, agentID, []string{"urgent"}, nil)
+	store.ModifyMessageLabels(ctx, m2.ID, agentID, []string{"follow-up", "urgent"}, nil)
+
+	d, err := store.GetConversationByID(ctx, agentID, "conv-part")
+	if err != nil {
+		t.Fatalf("GetConversationByID: %v", err)
+	}
+	// Participants = union of senders + recipient + to + cc
+	gotP := append([]string(nil), d.Participants...)
+	sort.Strings(gotP)
+	wantP := []string{
+		"alice@gmail.com",
+		"bob@gmail.com",
+		"bot@convo-part.example.com",
+		"carol@gmail.com",
+		"team@convo-part.example.com",
+	}
+	if !reflect.DeepEqual(gotP, wantP) {
+		t.Errorf("participants = %v, want %v", gotP, wantP)
+	}
+	// Labels = sorted union {follow-up, urgent}
+	if !reflect.DeepEqual(d.Labels, []string{"follow-up", "urgent"}) {
+		t.Errorf("labels = %v, want [follow-up urgent]", d.Labels)
+	}
+}
+
+func TestGetConversationByID_NotFound(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	agentID := convoTestSetup(t, store, "convo-notfound")
+
+	_, err := store.GetConversationByID(ctx, agentID, "conv-does-not-exist")
+	if !errors.Is(err, identity.ErrMessageNotFound) {
+		t.Errorf("err = %v, want ErrMessageNotFound", err)
+	}
+}
+
+func TestGetConversationByID_CrossAgentIsolation(t *testing.T) {
+	// Agent A has a conversation. Agent B (different user) must NOT
+	// be able to read it — even with the right conversation_id. The
+	// boundary is enforced at the WHERE clause; cross-agent looks
+	// like not-found to avoid leaking existence via 403 vs 404.
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	agentA := convoTestSetup(t, store, "convo-iso-a")
+	agentB := convoTestSetup(t, store, "convo-iso-b")
+	store.CreateInboundMessage(ctx, "", agentA, "x@gmail.com", "bot@convo-iso-a.example.com", "<a@x>", "secret", "conv-shared", "", nil, nil, nil, nil, nil)
+
+	// Agent B reading conv-shared must get not-found, NOT the inbound from A.
+	_, err := store.GetConversationByID(ctx, agentB, "conv-shared")
+	if !errors.Is(err, identity.ErrMessageNotFound) {
+		t.Errorf("cross-agent err = %v, want ErrMessageNotFound (must not leak across agents)", err)
+	}
+	// And A still sees it.
+	d, err := store.GetConversationByID(ctx, agentA, "conv-shared")
+	if err != nil {
+		t.Fatalf("agent A read: %v", err)
+	}
+	if d.MessageCount != 1 {
+		t.Errorf("agent A sees %d messages, want 1", d.MessageCount)
+	}
+}

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -2159,6 +2159,266 @@ func (s *Store) LookupConversationID(ctx context.Context, agentID string, messag
 	return conversationID, nil
 }
 
+// --- Conversations (thin read layer over messages.conversation_id) ---
+//
+// A conversation is the set of messages an agent sees that share a
+// non-empty conversation_id. The shape is computed at read time —
+// there's no `conversations` table, no persistence cost on top of
+// the existing messages row. The trade-off is that listing requires
+// an aggregate query; the partial index from migration 022 keeps it
+// cheap on large agents.
+//
+// All Conversation* methods scope by agent_id. Cross-agent
+// conversations (a user owns two agents and uses the same
+// conversation_id) are intentionally split — a conversation is an
+// agent-level concept, not a user-level one. If we ever want a
+// user-wide "all conversations" view it gets a separate endpoint
+// (mirrors the agents+messages vs. user+pending split that already
+// exists).
+
+// ConversationSummary is one row in the list endpoint. Aggregated
+// counts + the "latest message" preview fields are enough to render
+// an inbox-style conversation list without a per-row drill-down.
+//
+// HasUnread is true iff at least one INBOUND member is in
+// inbox_status='unread'. Outbound pending_approval doesn't count —
+// the conversation list is the agent's mailbox view, not the
+// reviewer's HITL queue.
+type ConversationSummary struct {
+	ID              string    `json:"conversation_id"`
+	LastMessageAt   time.Time `json:"last_message_at"`
+	FirstMessageAt  time.Time `json:"first_message_at"`
+	MessageCount    int       `json:"message_count"`
+	InboundCount    int       `json:"inbound_count"`
+	OutboundCount   int       `json:"outbound_count"`
+	HasUnread       bool      `json:"has_unread"`
+	LatestSubject   string    `json:"latest_subject"`
+	LatestSender    string    `json:"latest_sender"`
+}
+
+// ConversationDetail extends the summary with member messages and
+// computed aggregates (participants set, label union). Messages are
+// returned chronologically (oldest first) — the rendering convention
+// for a thread view.
+type ConversationDetail struct {
+	ConversationSummary
+	Participants []string  `json:"participants"`
+	Labels       []string  `json:"labels"`
+	Messages     []Message `json:"messages"`
+}
+
+// ConversationListFilter is the input to ListConversationsByAgent.
+// Limit is capped to ConversationListHardCap at the storage layer
+// regardless of what the caller passes; pagination is intentionally
+// not in this slice (most agents have dozens of conversations, not
+// thousands) and can be added cursor-style if a deployment needs it.
+type ConversationListFilter struct {
+	AgentID string
+	Limit   int
+	// Since / Until bracket the conversation's last_message_at —
+	// "show me conversations that had activity in this window".
+	// Zero values disable each bound.
+	Since time.Time
+	Until time.Time
+}
+
+// ConversationListHardCap is the maximum number of conversations a
+// single list call returns. Higher requests are silently clamped.
+// 100 covers the inbox-style use case; a deployment that needs more
+// can either ask for higher (we'll bump it) or paginate (slice 2).
+const ConversationListHardCap = 100
+
+// ListConversationsByAgent groups the agent's non-expired messages
+// by conversation_id and returns one row per conversation sorted by
+// most-recent activity. Messages without a conversation_id are not
+// included in any conversation — they remain individually visible
+// via GetMessagesByAgent.
+func (s *Store) ListConversationsByAgent(ctx context.Context, f ConversationListFilter) ([]ConversationSummary, error) {
+	limit := f.Limit
+	if limit <= 0 || limit > ConversationListHardCap {
+		limit = ConversationListHardCap
+	}
+
+	query := `
+		SELECT
+		  conversation_id,
+		  MAX(created_at)                          AS last_message_at,
+		  MIN(created_at)                          AS first_message_at,
+		  COUNT(*)                                 AS message_count,
+		  COUNT(*) FILTER (WHERE direction='inbound')  AS inbound_count,
+		  COUNT(*) FILTER (WHERE direction='outbound') AS outbound_count,
+		  -- BOOL_OR returns NULL when every row's expression is NULL
+		  -- (e.g. all-outbound conversations where inbox_status is
+		  -- NULL — the column is nullable). COALESCE to false so
+		  -- the *bool scan never fails on legitimate edge cases.
+		  COALESCE(BOOL_OR(direction='inbound' AND inbox_status='unread'), false) AS has_unread,
+		  (ARRAY_AGG(COALESCE(subject, '') ORDER BY created_at DESC))[1] AS latest_subject,
+		  (ARRAY_AGG(COALESCE(sender, '')  ORDER BY created_at DESC))[1] AS latest_sender
+		FROM messages
+		WHERE agent_id = $1
+		  AND conversation_id <> ''
+		  AND expires_at > now()
+		GROUP BY conversation_id`
+
+	args := []interface{}{f.AgentID}
+	if !f.Since.IsZero() {
+		query += fmt.Sprintf(` HAVING MAX(created_at) >= $%d`, len(args)+1)
+		args = append(args, f.Since)
+		if !f.Until.IsZero() {
+			query += fmt.Sprintf(` AND MAX(created_at) < $%d`, len(args)+1)
+			args = append(args, f.Until)
+		}
+	} else if !f.Until.IsZero() {
+		query += fmt.Sprintf(` HAVING MAX(created_at) < $%d`, len(args)+1)
+		args = append(args, f.Until)
+	}
+	query += fmt.Sprintf(` ORDER BY MAX(created_at) DESC, conversation_id DESC LIMIT $%d`, len(args)+1)
+	args = append(args, limit)
+
+	rows, err := s.pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []ConversationSummary
+	for rows.Next() {
+		var c ConversationSummary
+		if err := rows.Scan(
+			&c.ID, &c.LastMessageAt, &c.FirstMessageAt,
+			&c.MessageCount, &c.InboundCount, &c.OutboundCount,
+			&c.HasUnread, &c.LatestSubject, &c.LatestSender,
+		); err != nil {
+			return nil, err
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+// GetConversationByID returns the aggregate summary fields plus every
+// member message, ordered oldest-first (chronological reading order).
+// Returns ErrMessageNotFound when no non-expired messages exist for
+// the given (agentID, conversationID) — mirrors the
+// "looks-like-not-found-on-cross-agent" convention used by single-
+// message reads. The same code path handles "wrong agent" and "real
+// non-existent": either way the agent has no business seeing it.
+//
+// Participants are computed as the union of sender + recipient +
+// each row's to_recipients / cc / bcc (when populated). Empty
+// strings are dropped. Labels are the union of all members'
+// labels[]; both are sorted lexicographically for stable output.
+func (s *Store) GetConversationByID(ctx context.Context, agentID, conversationID string) (*ConversationDetail, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT m.id, m.agent_id, m.direction, m.sender, m.recipient,
+		        m.to_recipients, m.cc, m.bcc, m.reply_to,
+		        m.subject, COALESCE(m.email_message_id, ''),
+		        COALESCE(m.method, ''), COALESCE(m.message_type, ''),
+		        m.conversation_id, COALESCE(m.inbox_status, ''),
+		        COALESCE(m.status, ''),
+		        m.created_at, m.expires_at,
+		        m.labels
+		 FROM messages m
+		 WHERE m.agent_id = $1
+		   AND m.conversation_id = $2
+		   AND m.expires_at > now()
+		 ORDER BY m.created_at ASC, m.id ASC`,
+		agentID, conversationID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	d := &ConversationDetail{}
+	participantSet := map[string]struct{}{}
+	labelSet := map[string]struct{}{}
+
+	for rows.Next() {
+		var m Message
+		if err := rows.Scan(
+			&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient,
+			&m.ToRecipients, &m.CC, &m.BCC, &m.ReplyTo,
+			&m.Subject, &m.EmailMessageID,
+			&m.Method, &m.Type,
+			&m.ConversationID, &m.InboxStatus,
+			&m.Status,
+			&m.CreatedAt, &m.ExpiresAt,
+			&m.Labels,
+		); err != nil {
+			return nil, err
+		}
+		m.DeliveryStatus = m.InboxStatus
+		d.Messages = append(d.Messages, m)
+
+		// Accumulate aggregates as we go — cheaper than a second
+		// pass and keeps memory bounded to the unique-strings set.
+		if m.Sender != "" {
+			participantSet[m.Sender] = struct{}{}
+		}
+		if m.Recipient != "" {
+			participantSet[m.Recipient] = struct{}{}
+		}
+		for _, a := range m.ToRecipients {
+			if a != "" {
+				participantSet[a] = struct{}{}
+			}
+		}
+		for _, a := range m.CC {
+			if a != "" {
+				participantSet[a] = struct{}{}
+			}
+		}
+		for _, a := range m.BCC {
+			if a != "" {
+				participantSet[a] = struct{}{}
+			}
+		}
+		for _, l := range m.Labels {
+			labelSet[l] = struct{}{}
+		}
+
+		// Maintain the aggregate counts inline.
+		d.MessageCount++
+		if m.Direction == "inbound" {
+			d.InboundCount++
+			if m.InboxStatus == "unread" {
+				d.HasUnread = true
+			}
+		} else if m.Direction == "outbound" {
+			d.OutboundCount++
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if d.MessageCount == 0 {
+		return nil, ErrMessageNotFound
+	}
+
+	d.ID = conversationID
+	// Messages are oldest-first so [0] is first and [n-1] is last.
+	d.FirstMessageAt = d.Messages[0].CreatedAt
+	d.LastMessageAt = d.Messages[d.MessageCount-1].CreatedAt
+	latest := d.Messages[d.MessageCount-1]
+	d.LatestSubject = latest.Subject
+	d.LatestSender = latest.Sender
+
+	d.Participants = make([]string, 0, len(participantSet))
+	for p := range participantSet {
+		d.Participants = append(d.Participants, p)
+	}
+	sort.Strings(d.Participants)
+
+	d.Labels = make([]string, 0, len(labelSet))
+	for l := range labelSet {
+		d.Labels = append(d.Labels, l)
+	}
+	sort.Strings(d.Labels)
+
+	return d, nil
+}
+
 // --- User management ---
 
 func (s *Store) CreateOrGetUser(ctx context.Context, email, name, googleSub string) (*User, error) {

--- a/mcp/src/tools/messages.ts
+++ b/mcp/src/tools/messages.ts
@@ -184,6 +184,59 @@ export function registerMessageTools(server: McpServer, client: E2AClient): void
   );
 
   server.registerTool(
+    "list_conversations",
+    {
+      title: "List conversations for the agent",
+      description:
+        "Lists the agent's conversations — groups of messages sharing a `conversation_id` — one row per conversation, sorted by most recent activity. Each row carries `message_count`, `inbound_count`, `outbound_count`, `has_unread`, and the latest message's subject + sender so you can render an inbox without drilling into each thread. The server caps the response at 100. Use this when the user wants to see threads rather than individual messages — e.g. \"what conversations are unread?\" or \"show recent threads with Alice\". To read a single conversation's messages, call `get_conversation`.",
+      inputSchema: strictInputSchema({
+        page_size: z.number().int().positive().max(100).optional(),
+        since: z
+          .string()
+          .optional()
+          .describe(
+            "RFC3339 timestamp. Only conversations whose latest message is >= since.",
+          ),
+        until: z
+          .string()
+          .optional()
+          .describe(
+            "RFC3339 timestamp. Only conversations whose latest message is < until.",
+          ),
+        agent_email: z.string().optional(),
+      }),
+    },
+    async (args) =>
+      runTool(() =>
+        client.listConversations({
+          ...(args.page_size !== undefined ? { pageSize: args.page_size } : {}),
+          ...(args.since !== undefined ? { since: args.since } : {}),
+          ...(args.until !== undefined ? { until: args.until } : {}),
+          ...(args.agent_email !== undefined ? { agentEmail: args.agent_email } : {}),
+        }),
+      ),
+  );
+
+  server.registerTool(
+    "get_conversation",
+    {
+      title: "Get a single conversation with all member messages",
+      description:
+        "Returns the full thread — aggregate counts, the participants union (sender + recipient + to + cc + bcc across members), the labels union, and every member message in chronological order (oldest first). Returns a not-found error when no non-expired messages exist for `(agent, conversation_id)`. Use this after `list_conversations` (or whenever you have a `conversation_id` from an inbound/outbound payload) to read the full thread.",
+      inputSchema: strictInputSchema({
+        conversation_id: z.string(),
+        agent_email: z.string().optional(),
+      }),
+    },
+    async (args) =>
+      runTool(() =>
+        client.getConversation(args.conversation_id, {
+          ...(args.agent_email !== undefined ? { agentEmail: args.agent_email } : {}),
+        }),
+      ),
+  );
+
+  server.registerTool(
     "list_messages",
     {
       title: "List inbound messages",

--- a/mcp/tests/http.test.ts
+++ b/mcp/tests/http.test.ts
@@ -199,6 +199,8 @@ describe("HTTP MCP server", () => {
         "reply_to_message",
         "forward_message",
         "update_message_labels",
+        "list_conversations",
+        "get_conversation",
         "list_messages",
         "get_message",
         "get_attachment_data",

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -24,6 +24,8 @@ function makeStubClient(overrides: Partial<{ agentEmail: string }> = {}): E2ACli
     reply: vi.fn(async () => ({ message_id: "msg_reply", status: "sent" })),
     forward: vi.fn(async () => ({ message_id: "msg_fwd", status: "sent" })),
     updateMessageLabels: vi.fn(async () => ({ message_id: "msg_in", labels: ["urgent"] })),
+    listConversations: vi.fn(async () => ({ conversations: [{ conversation_id: "conv_1" }] })),
+    getConversation: vi.fn(async () => ({ conversation_id: "conv_1", messages: [] })),
     listMessages: vi.fn(async () => ({ messages: [], next_token: undefined })),
     listAgents: vi.fn(async () => ({ agents: [{ email: "bot@example.com" }] })),
     registerAgent: vi.fn(async (body: Record<string, unknown>) => ({
@@ -126,6 +128,8 @@ describe("e2a MCP server", () => {
         "reply_to_message",
         "forward_message",
         "update_message_labels",
+        "list_conversations",
+        "get_conversation",
         "list_messages",
         "get_message",
         "get_attachment_data",
@@ -205,6 +209,25 @@ describe("e2a MCP server", () => {
       addLabels: ["urgent"],
       removeLabels: ["unread"],
     });
+  });
+
+  it("list_conversations forwards args to client.listConversations", async () => {
+    await client.callTool({
+      name: "list_conversations",
+      arguments: { page_size: 20, since: "2026-05-01T00:00:00Z" },
+    });
+    expect(stub.listConversations).toHaveBeenCalledWith({
+      pageSize: 20,
+      since: "2026-05-01T00:00:00Z",
+    });
+  });
+
+  it("get_conversation forwards args to client.getConversation", async () => {
+    await client.callTool({
+      name: "get_conversation",
+      arguments: { conversation_id: "conv_1" },
+    });
+    expect(stub.getConversation).toHaveBeenCalledWith("conv_1", {});
   });
 
   it("list_messages forwards filters", async () => {

--- a/migrations/022_conversation_index.sql
+++ b/migrations/022_conversation_index.sql
@@ -1,0 +1,27 @@
+-- 022_conversation_index.sql
+-- e2a:no-transaction
+--
+-- Composite index supporting the Conversations API. Both endpoints
+-- (list + detail) filter by agent_id and group/sort by conversation_id
+-- + created_at; without this they'd seq-scan an agent's entire message
+-- partition.
+--
+-- The leading agent_id column makes this also serve queries that
+-- filter on agent_id alone (Postgres can use a prefix), so it doesn't
+-- compete with the existing idx_messages_agent_created on (agent_id,
+-- created_at DESC) — the two index different access patterns and the
+-- planner picks whichever fits the predicate set.
+--
+-- created_at DESC so the per-conversation message fetch returns rows
+-- in newest-first order without a sort.
+--
+-- CREATE INDEX CONCURRENTLY required by the e2a:no-transaction
+-- directive (see internal/identity/migrate.go) so prod deploys don't
+-- block writes on the multi-million-row messages table. Single
+-- statement per the runner's contract.
+--
+-- Idempotent via IF NOT EXISTS.
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_messages_agent_conv_created
+    ON messages (agent_id, conversation_id, created_at DESC)
+    WHERE conversation_id <> '';

--- a/sdks/python/src/e2a/v1/api.py
+++ b/sdks/python/src/e2a/v1/api.py
@@ -21,10 +21,12 @@ from e2a.v1.generated import (
     Agent,
     ApprovePendingMessageRequest,
     ApprovePendingMessageResponse,
+    ConversationDetail,
     DeploymentInfo,
     Domain,
     ForwardMessageRequest,
     ListAgentsResponse,
+    ListConversationsResponse,
     ListDomainsResponse,
     ListMessagesResponse,
     ListPendingMessagesResponse,
@@ -348,6 +350,61 @@ class E2AApi:
         )
         _check_response(resp)
         return SendEmailResponse.model_validate(resp.json())
+
+    # ── Conversations ─────────────────────────────────────────────────
+
+    def list_conversations(
+        self,
+        agent_email: str,
+        page_size: Optional[int] = None,
+        since: Optional[str] = None,
+        until: Optional[str] = None,
+    ) -> ListConversationsResponse:
+        """List conversations for an agent.
+
+        Returns one row per non-empty ``conversation_id``, with
+        aggregated counts and the latest message's subject/sender.
+        Sorted by ``last_message_at`` DESC. The server caps the
+        response at 100 entries (pagination is intentionally deferred).
+
+        ``since`` / ``until`` are RFC3339 timestamps bracketing
+        ``last_message_at``.
+        """
+        params: list[tuple[str, str]] = []
+        if page_size is not None:
+            params.append(("page_size", str(page_size)))
+        if since:
+            params.append(("since", since))
+        if until:
+            params.append(("until", until))
+        resp = self._client.get(
+            f"/api/v1/agents/{_encode_email(agent_email)}/conversations",
+            params=params,
+        )
+        _check_response(resp)
+        return ListConversationsResponse.model_validate(resp.json())
+
+    def get_conversation(
+        self,
+        agent_email: str,
+        conversation_id: str,
+    ) -> ConversationDetail:
+        """Fetch a single conversation with all member messages.
+
+        The detail response includes the aggregate summary fields,
+        the participants union (sender + recipient + to + cc + bcc),
+        the labels union across members, and every member message in
+        chronological order (oldest-first).
+
+        Returns a 404-mapped ``E2AApiError`` when no non-expired
+        messages exist for ``(agent, conversation_id)``. Cross-agent
+        access is indistinguishable from not-found.
+        """
+        resp = self._client.get(
+            f"/api/v1/agents/{_encode_email(agent_email)}/conversations/{_encode_email(conversation_id)}",
+        )
+        _check_response(resp)
+        return ConversationDetail.model_validate(resp.json())
 
     # ── HITL (human-in-the-loop approval) ─────────────────────────────
 

--- a/sdks/python/src/e2a/v1/async_client.py
+++ b/sdks/python/src/e2a/v1/async_client.py
@@ -24,10 +24,12 @@ from e2a.v1.generated import (
     Agent,
     ApprovePendingMessageRequest,
     ApprovePendingMessageResponse,
+    ConversationDetail,
     DeploymentInfo,
     Domain,
     ForwardMessageRequest,
     ListAgentsResponse,
+    ListConversationsResponse,
     ListDomainsResponse,
     ListMessagesResponse,
     ListPendingMessagesResponse,
@@ -271,6 +273,42 @@ class AsyncE2AApi:
         )
         _check_response(resp)
         return SendEmailResponse.model_validate(resp.json())
+
+    # ── Conversations ─────────────────────────────────────────────
+
+    async def list_conversations(
+        self,
+        agent_email: str,
+        page_size: Optional[int] = None,
+        since: Optional[str] = None,
+        until: Optional[str] = None,
+    ) -> ListConversationsResponse:
+        """Async variant of :meth:`E2AApi.list_conversations`."""
+        params: list[tuple[str, str]] = []
+        if page_size is not None:
+            params.append(("page_size", str(page_size)))
+        if since:
+            params.append(("since", since))
+        if until:
+            params.append(("until", until))
+        resp = await self._client.get(
+            f"/api/v1/agents/{_encode_email(agent_email)}/conversations",
+            params=params,
+        )
+        _check_response(resp)
+        return ListConversationsResponse.model_validate(resp.json())
+
+    async def get_conversation(
+        self,
+        agent_email: str,
+        conversation_id: str,
+    ) -> ConversationDetail:
+        """Async variant of :meth:`E2AApi.get_conversation`."""
+        resp = await self._client.get(
+            f"/api/v1/agents/{_encode_email(agent_email)}/conversations/{_encode_email(conversation_id)}",
+        )
+        _check_response(resp)
+        return ConversationDetail.model_validate(resp.json())
 
     # ── HITL (human-in-the-loop approval) ─────────────────────────
 
@@ -594,6 +632,30 @@ class AsyncE2AClient:
         req = UpdateMessageRequest(add_labels=add_labels, remove_labels=remove_labels)
         resp = await self.api.update_message_labels(email, message_id, req)
         return list(resp.labels or [])
+
+    # ── Conversations ───────────────────────────────────────────────
+
+    async def list_conversations(
+        self,
+        page_size: Optional[int] = None,
+        since: Optional[str] = None,
+        until: Optional[str] = None,
+        agent_email: Optional[str] = None,
+    ) -> ListConversationsResponse:
+        """Async variant of :meth:`E2AClient.list_conversations`."""
+        email = self._require_agent_email(agent_email)
+        return await self.api.list_conversations(
+            email, page_size=page_size, since=since, until=until,
+        )
+
+    async def get_conversation(
+        self,
+        conversation_id: str,
+        agent_email: Optional[str] = None,
+    ) -> ConversationDetail:
+        """Async variant of :meth:`E2AClient.get_conversation`."""
+        email = self._require_agent_email(agent_email)
+        return await self.api.get_conversation(email, conversation_id)
 
     async def send(
         self,

--- a/sdks/python/src/e2a/v1/client.py
+++ b/sdks/python/src/e2a/v1/client.py
@@ -15,7 +15,9 @@ from typing import Any, Optional
 from e2a.v1.api import E2AApi
 from e2a.v1.generated import (
     ApprovePendingMessageRequest,
+    ConversationDetail,
     ForwardMessageRequest,
+    ListConversationsResponse,
     MessageDetail,
     RegisterAgentRequest,
     RegisterDomainRequest,
@@ -350,6 +352,37 @@ class E2AClient:
         req = UpdateMessageRequest(add_labels=add_labels, remove_labels=remove_labels)
         resp = self.api.update_message_labels(email, message_id, req)
         return list(resp.labels or [])
+
+    # ── Conversations ───────────────────────────────────────────────
+
+    def list_conversations(
+        self,
+        page_size: Optional[int] = None,
+        since: Optional[str] = None,
+        until: Optional[str] = None,
+        agent_email: Optional[str] = None,
+    ) -> ListConversationsResponse:
+        """List conversations for the configured agent.
+
+        One row per non-empty ``conversation_id``, sorted by most
+        recent activity. The server caps the response at 100 entries
+        — pagination is intentionally deferred for slice 1. Pass
+        ``since`` / ``until`` (RFC3339) to bracket ``last_message_at``.
+        """
+        email = self._require_agent_email(agent_email)
+        return self.api.list_conversations(
+            email, page_size=page_size, since=since, until=until,
+        )
+
+    def get_conversation(
+        self,
+        conversation_id: str,
+        agent_email: Optional[str] = None,
+    ) -> ConversationDetail:
+        """Fetch a single conversation with member messages, computed
+        participants union, and computed labels union."""
+        email = self._require_agent_email(agent_email)
+        return self.api.get_conversation(email, conversation_id)
 
     def send(
         self,

--- a/sdks/python/src/e2a/v1/generated/__init__.py
+++ b/sdks/python/src/e2a/v1/generated/__init__.py
@@ -52,6 +52,21 @@ class ApprovePendingMessageResponse(BaseModel):
     status: str | None = Field(None, examples=['sent'])
 
 
+class ConversationSummary(BaseModel):
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
+    conversation_id: str | None = Field(None, examples=['conv_abc123'])
+    first_message_at: str | None = Field(None, examples=['2026-05-20T10:00:00Z'])
+    has_unread: bool | None = Field(None, examples=[True])
+    inbound_count: int | None = Field(None, examples=[2])
+    last_message_at: str | None = Field(None, examples=['2026-05-28T12:00:00Z'])
+    latest_sender: str | None = Field(None, examples=['alice@example.com'])
+    latest_subject: str | None = Field(None, examples=['Re: Quarterly report'])
+    message_count: int | None = Field(None, examples=[4])
+    outbound_count: int | None = Field(None, examples=[2])
+
+
 class CreateSigningSecretResponse(BaseModel):
     model_config = ConfigDict(
         populate_by_name=True,
@@ -168,6 +183,13 @@ class ListAgentsResponse(BaseModel):
         populate_by_name=True,
     )
     agents: list[Agent] | None = None
+
+
+class ListConversationsResponse(BaseModel):
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
+    conversations: list[ConversationSummary] | None = None
 
 
 class ListDomainsResponse(BaseModel):
@@ -453,6 +475,24 @@ class ApprovePendingMessageRequest(BaseModel):
     cc: list[str] | None = None
     subject: str | None = None
     to: list[str] | None = None
+
+
+class ConversationDetail(BaseModel):
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
+    conversation_id: str | None = Field(None, examples=['conv_abc123'])
+    first_message_at: str | None = Field(None, examples=['2026-05-20T10:00:00Z'])
+    has_unread: bool | None = Field(None, examples=[True])
+    inbound_count: int | None = Field(None, examples=[2])
+    labels: list[str] | None = None
+    last_message_at: str | None = Field(None, examples=['2026-05-28T12:00:00Z'])
+    latest_sender: str | None = Field(None, examples=['alice@example.com'])
+    latest_subject: str | None = Field(None, examples=['Re: Quarterly report'])
+    message_count: int | None = Field(None, examples=[4])
+    messages: list[MessageSummary] | None = None
+    outbound_count: int | None = Field(None, examples=[2])
+    participants: list[str] | None = None
 
 
 class ForwardMessageRequest(BaseModel):

--- a/sdks/python/src/e2a/v1/generated/__init__.py
+++ b/sdks/python/src/e2a/v1/generated/__init__.py
@@ -58,7 +58,11 @@ class ConversationSummary(BaseModel):
     )
     conversation_id: str | None = Field(None, examples=['conv_abc123'])
     first_message_at: str | None = Field(None, examples=['2026-05-20T10:00:00Z'])
-    has_unread: bool | None = Field(None, examples=[True])
+    has_unread: bool | None = Field(
+        None,
+        description="HasUnread is true iff at least one INBOUND member of this\nconversation is in inbox_status='unread'. Outbound rows do\nNOT contribute — a thread containing only your sent messages\n(or only HITL-pending outbound) returns false. This is the\nagent's mailbox view, not the reviewer's HITL queue.",
+        examples=[True],
+    )
     inbound_count: int | None = Field(None, examples=[2])
     last_message_at: str | None = Field(None, examples=['2026-05-28T12:00:00Z'])
     latest_sender: str | None = Field(None, examples=['alice@example.com'])
@@ -483,7 +487,11 @@ class ConversationDetail(BaseModel):
     )
     conversation_id: str | None = Field(None, examples=['conv_abc123'])
     first_message_at: str | None = Field(None, examples=['2026-05-20T10:00:00Z'])
-    has_unread: bool | None = Field(None, examples=[True])
+    has_unread: bool | None = Field(
+        None,
+        description="HasUnread is true iff at least one INBOUND member of this\nconversation is in inbox_status='unread'. Outbound rows do\nNOT contribute — a thread containing only your sent messages\n(or only HITL-pending outbound) returns false. This is the\nagent's mailbox view, not the reviewer's HITL queue.",
+        examples=[True],
+    )
     inbound_count: int | None = Field(None, examples=[2])
     labels: list[str] | None = None
     last_message_at: str | None = Field(None, examples=['2026-05-28T12:00:00Z'])

--- a/sdks/python/tests/test_v1_api.py
+++ b/sdks/python/tests/test_v1_api.py
@@ -9,9 +9,11 @@ from e2a.v1.generated import (
     Agent,
     ApprovePendingMessageRequest,
     ApprovePendingMessageResponse,
+    ConversationDetail,
     Domain,
     ForwardMessageRequest,
     ListAgentsResponse,
+    ListConversationsResponse,
     ListDomainsResponse,
     ListMessagesResponse,
     ListPendingMessagesResponse,
@@ -462,6 +464,77 @@ def test_list_messages_emits_repeated_labels_query(httpx_mock):
 
     with E2AApi(api_key="k") as api:
         api.list_messages("bot@agents.e2a.dev", labels=["urgent", "follow-up"])
+
+
+def test_list_conversations(httpx_mock):
+    httpx_mock.add_response(
+        url=f"{BASE}/api/v1/agents/bot%40agents.e2a.dev/conversations?page_size=50&since=2026-05-01T00%3A00%3A00Z",
+        method="GET",
+        json={
+            "conversations": [
+                {
+                    "conversation_id": "conv_1",
+                    "last_message_at": "2026-05-28T12:00:00Z",
+                    "first_message_at": "2026-05-20T10:00:00Z",
+                    "message_count": 3,
+                    "inbound_count": 2,
+                    "outbound_count": 1,
+                    "has_unread": True,
+                    "latest_subject": "Re: hi",
+                    "latest_sender": "alice@example.com",
+                }
+            ]
+        },
+    )
+
+    with E2AApi(api_key="k") as api:
+        result = api.list_conversations(
+            "bot@agents.e2a.dev",
+            page_size=50,
+            since="2026-05-01T00:00:00Z",
+        )
+
+    assert isinstance(result, ListConversationsResponse)
+    assert len(result.conversations) == 1
+    assert result.conversations[0].conversation_id == "conv_1"
+    assert result.conversations[0].has_unread is True
+
+
+def test_get_conversation(httpx_mock):
+    httpx_mock.add_response(
+        url=f"{BASE}/api/v1/agents/bot%40agents.e2a.dev/conversations/conv_1",
+        method="GET",
+        json={
+            "conversation_id": "conv_1",
+            "last_message_at": "2026-05-28T12:00:00Z",
+            "first_message_at": "2026-05-20T10:00:00Z",
+            "message_count": 2,
+            "inbound_count": 1,
+            "outbound_count": 1,
+            "has_unread": False,
+            "latest_subject": "Re: hi",
+            "latest_sender": "alice@example.com",
+            "participants": ["alice@example.com", "bot@agents.e2a.dev"],
+            "labels": ["urgent"],
+            "messages": [
+                {
+                    "message_id": "m1",
+                    "from": "alice@example.com",
+                    "subject": "hi",
+                    "labels": ["urgent"],
+                }
+            ],
+        },
+    )
+
+    with E2AApi(api_key="k") as api:
+        result = api.get_conversation("bot@agents.e2a.dev", "conv_1")
+
+    assert isinstance(result, ConversationDetail)
+    assert result.conversation_id == "conv_1"
+    assert result.message_count == 2
+    assert result.participants == ["alice@example.com", "bot@agents.e2a.dev"]
+    assert result.labels == ["urgent"]
 
 
 def test_send_email(httpx_mock):

--- a/sdks/python/tests/test_v1_async_client.py
+++ b/sdks/python/tests/test_v1_async_client.py
@@ -252,6 +252,35 @@ async def test_get_messages_with_labels_filter(httpx_mock):
         await client.get_messages(status="all", labels=["urgent", "follow-up"])
 
 
+@pytest.mark.anyio
+async def test_list_conversations(httpx_mock):
+    httpx_mock.add_response(
+        url=f"{BASE}/api/v1/agents/bot%40agents.e2a.dev/conversations",
+        method="GET",
+        json={"conversations": [{"conversation_id": "conv_1", "message_count": 2}]},
+    )
+
+    async with AsyncE2AClient(api_key="k", agent_email="bot@agents.e2a.dev") as client:
+        result = await client.list_conversations()
+
+    assert len(result.conversations) == 1
+    assert result.conversations[0].conversation_id == "conv_1"
+
+
+@pytest.mark.anyio
+async def test_get_conversation(httpx_mock):
+    httpx_mock.add_response(
+        url=f"{BASE}/api/v1/agents/bot%40agents.e2a.dev/conversations/conv_1",
+        method="GET",
+        json={"conversation_id": "conv_1", "participants": [], "labels": [], "messages": []},
+    )
+
+    async with AsyncE2AClient(api_key="k", agent_email="bot@agents.e2a.dev") as client:
+        result = await client.get_conversation("conv_1")
+
+    assert result.conversation_id == "conv_1"
+
+
 # ── reply() ──────────────────────────────────────────────────────
 
 

--- a/sdks/python/tests/test_v1_client.py
+++ b/sdks/python/tests/test_v1_client.py
@@ -437,6 +437,41 @@ def test_reply_with_attachments(httpx_mock):
 # ── send() ───────────────────────────────────────────────────────
 
 
+def test_list_conversations(httpx_mock):
+    httpx_mock.add_response(
+        url=f"{BASE}/api/v1/agents/bot%40agents.e2a.dev/conversations",
+        method="GET",
+        json={"conversations": [{"conversation_id": "conv_1", "message_count": 3, "has_unread": True}]},
+    )
+
+    with E2AClient(api_key="k", agent_email="bot@agents.e2a.dev") as client:
+        result = client.list_conversations()
+
+    assert len(result.conversations) == 1
+    assert result.conversations[0].conversation_id == "conv_1"
+
+
+def test_get_conversation(httpx_mock):
+    httpx_mock.add_response(
+        url=f"{BASE}/api/v1/agents/bot%40agents.e2a.dev/conversations/conv_1",
+        method="GET",
+        json={
+            "conversation_id": "conv_1",
+            "message_count": 1,
+            "participants": ["alice@example.com"],
+            "labels": ["follow-up"],
+            "messages": [],
+        },
+    )
+
+    with E2AClient(api_key="k", agent_email="bot@agents.e2a.dev") as client:
+        result = client.get_conversation("conv_1")
+
+    assert result.conversation_id == "conv_1"
+    assert result.participants == ["alice@example.com"]
+    assert result.labels == ["follow-up"]
+
+
 def test_send(httpx_mock):
     httpx_mock.add_response(
         url=f"{BASE}/api/v1/send",

--- a/sdks/typescript/src/v1/api.ts
+++ b/sdks/typescript/src/v1/api.ts
@@ -237,6 +237,44 @@ export class E2AApi {
     );
   }
 
+  // ── Conversations ───────────────────────────────────────────────
+
+  /**
+   * List conversations for an agent — one row per non-empty
+   * conversation_id, with aggregated counts and the latest message's
+   * subject/sender. Sorted by `last_message_at` DESC. The response is
+   * hard-capped at 100 entries server-side; pagination is intentionally
+   * deferred for slice 1.
+   */
+  async listConversations(
+    email: string,
+    opts?: {
+      pageSize?: number;
+      /** RFC3339; only conversations whose latest message is >= since. */
+      since?: string;
+      /** RFC3339; only conversations whose latest message is < until. */
+      until?: string;
+    },
+  ): Promise<Schemas["ListConversationsResponse"]> {
+    const params = new URLSearchParams();
+    if (opts?.pageSize) params.set("page_size", String(opts.pageSize));
+    if (opts?.since) params.set("since", opts.since);
+    if (opts?.until) params.set("until", opts.until);
+    const qs = params.toString();
+    const path = `/api/v1/agents/${encodeURIComponent(email)}/conversations${qs ? `?${qs}` : ""}`;
+    return this.request("GET", path);
+  }
+
+  async getConversation(
+    email: string,
+    conversationId: string,
+  ): Promise<Schemas["ConversationDetail"]> {
+    return this.request(
+      "GET",
+      `/api/v1/agents/${encodeURIComponent(email)}/conversations/${encodeURIComponent(conversationId)}`,
+    );
+  }
+
   // ── Domains ─────────────────────────────────────────────────────
 
   async listDomains(): Promise<Schemas["ListDomainsResponse"]> {

--- a/sdks/typescript/src/v1/client.ts
+++ b/sdks/typescript/src/v1/client.ts
@@ -337,6 +337,40 @@ export class E2AClient {
     );
   }
 
+  // ── Conversations ───────────────────────────────────────────────
+
+  /**
+   * List conversations for the configured agent. Returns one summary
+   * row per conversation_id, sorted by most recent activity. The
+   * server hard-caps the response at 100 entries.
+   */
+  async listConversations(opts?: {
+    agentEmail?: string;
+    pageSize?: number;
+    since?: string;
+    until?: string;
+  }) {
+    return this.api.listConversations(this.requireEmail(opts?.agentEmail), {
+      pageSize: opts?.pageSize,
+      since: opts?.since,
+      until: opts?.until,
+    });
+  }
+
+  /**
+   * Fetch a single conversation with all member messages, computed
+   * participants union, and computed labels union (across members).
+   */
+  async getConversation(
+    conversationId: string,
+    opts?: { agentEmail?: string },
+  ) {
+    return this.api.getConversation(
+      this.requireEmail(opts?.agentEmail),
+      conversationId,
+    );
+  }
+
   // ── Domains ─────────────────────────────────────────────────────
 
   async listDomains() {

--- a/sdks/typescript/src/v1/generated/types.ts
+++ b/sdks/typescript/src/v1/generated/types.ts
@@ -307,6 +307,156 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/agents/{email}/conversations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List conversations for an agent
+         * @description Returns conversation summaries for an agent — one row per non-empty conversation_id, with aggregated counts and the latest message's subject/sender. Sorted by `last_message_at` descending. The response is hard-capped at 100 conversations (pagination is intentionally deferred for slice 1). Use `since` / `until` to bracket the active window. Messages with empty `conversation_id` are NOT in any conversation — they remain individually visible via the messages list.
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /**
+                     * @description RFC3339 timestamp; only conversations whose latest message is >= since
+                     * @example 2026-05-01T00:00:00Z
+                     */
+                    since?: string;
+                    /** @description RFC3339 timestamp; only conversations whose latest message is < until */
+                    until?: string;
+                    /** @description Max conversations to return (server clamps to 100) */
+                    page_size?: number;
+                };
+                header?: never;
+                path: {
+                    /**
+                     * @description Agent email address
+                     * @example my-bot@example.com
+                     */
+                    email: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ListConversationsResponse"];
+                    };
+                };
+                /** @description Invalid since/until */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Missing or invalid API key */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Agent not found or not owned by this user */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/agents/{email}/conversations/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get a conversation
+         * @description Returns the full conversation — aggregate counts, participant union, label union, and every member message (oldest-first). Messages share the schema of `MessageSummary` from the list endpoint. Returns 404 when no non-expired messages exist for `(agent, conversation_id)`; cross-agent access is indistinguishable from not-found.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /**
+                     * @description Agent email address
+                     * @example my-bot@example.com
+                     */
+                    email: string;
+                    /**
+                     * @description Conversation ID
+                     * @example conv_abc123
+                     */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ConversationDetail"];
+                    };
+                };
+                /** @description Missing or invalid API key */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Conversation not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/agents/{email}/messages": {
         parameters: {
             query?: never;
@@ -2069,6 +2219,49 @@ export interface components {
             /** @example sent */
             status?: string;
         };
+        ConversationDetail: {
+            /** @example conv_abc123 */
+            conversation_id?: string;
+            /** @example 2026-05-20T10:00:00Z */
+            first_message_at?: string;
+            /** @example true */
+            has_unread?: boolean;
+            /** @example 2 */
+            inbound_count?: number;
+            labels?: string[];
+            /** @example 2026-05-28T12:00:00Z */
+            last_message_at?: string;
+            /** @example alice@example.com */
+            latest_sender?: string;
+            /** @example Re: Quarterly report */
+            latest_subject?: string;
+            /** @example 4 */
+            message_count?: number;
+            messages?: components["schemas"]["MessageSummary"][];
+            /** @example 2 */
+            outbound_count?: number;
+            participants?: string[];
+        };
+        ConversationSummary: {
+            /** @example conv_abc123 */
+            conversation_id?: string;
+            /** @example 2026-05-20T10:00:00Z */
+            first_message_at?: string;
+            /** @example true */
+            has_unread?: boolean;
+            /** @example 2 */
+            inbound_count?: number;
+            /** @example 2026-05-28T12:00:00Z */
+            last_message_at?: string;
+            /** @example alice@example.com */
+            latest_sender?: string;
+            /** @example Re: Quarterly report */
+            latest_subject?: string;
+            /** @example 4 */
+            message_count?: number;
+            /** @example 2 */
+            outbound_count?: number;
+        };
         CreateSigningSecretResponse: {
             created_at?: string;
             id?: string;
@@ -2199,6 +2392,9 @@ export interface components {
         };
         ListAgentsResponse: {
             agents?: components["schemas"]["Agent"][];
+        };
+        ListConversationsResponse: {
+            conversations?: components["schemas"]["ConversationSummary"][];
         };
         ListDomainsResponse: {
             domains?: components["schemas"]["Domain"][];

--- a/sdks/typescript/src/v1/generated/types.ts
+++ b/sdks/typescript/src/v1/generated/types.ts
@@ -2224,7 +2224,14 @@ export interface components {
             conversation_id?: string;
             /** @example 2026-05-20T10:00:00Z */
             first_message_at?: string;
-            /** @example true */
+            /**
+             * @description HasUnread is true iff at least one INBOUND member of this
+             *     conversation is in inbox_status='unread'. Outbound rows do
+             *     NOT contribute — a thread containing only your sent messages
+             *     (or only HITL-pending outbound) returns false. This is the
+             *     agent's mailbox view, not the reviewer's HITL queue.
+             * @example true
+             */
             has_unread?: boolean;
             /** @example 2 */
             inbound_count?: number;
@@ -2247,7 +2254,14 @@ export interface components {
             conversation_id?: string;
             /** @example 2026-05-20T10:00:00Z */
             first_message_at?: string;
-            /** @example true */
+            /**
+             * @description HasUnread is true iff at least one INBOUND member of this
+             *     conversation is in inbox_status='unread'. Outbound rows do
+             *     NOT contribute — a thread containing only your sent messages
+             *     (or only HITL-pending outbound) returns false. This is the
+             *     agent's mailbox view, not the reviewer's HITL queue.
+             * @example true
+             */
             has_unread?: boolean;
             /** @example 2 */
             inbound_count?: number;

--- a/web/public/openapi.yaml
+++ b/web/public/openapi.yaml
@@ -93,6 +93,78 @@ definitions:
         example: sent
         type: string
     type: object
+  ConversationDetail:
+    properties:
+      conversation_id:
+        example: conv_abc123
+        type: string
+      first_message_at:
+        example: "2026-05-20T10:00:00Z"
+        type: string
+      has_unread:
+        example: true
+        type: boolean
+      inbound_count:
+        example: 2
+        type: integer
+      labels:
+        items:
+          type: string
+        type: array
+      last_message_at:
+        example: "2026-05-28T12:00:00Z"
+        type: string
+      latest_sender:
+        example: alice@example.com
+        type: string
+      latest_subject:
+        example: 'Re: Quarterly report'
+        type: string
+      message_count:
+        example: 4
+        type: integer
+      messages:
+        items:
+          $ref: '#/definitions/MessageSummary'
+        type: array
+      outbound_count:
+        example: 2
+        type: integer
+      participants:
+        items:
+          type: string
+        type: array
+    type: object
+  ConversationSummary:
+    properties:
+      conversation_id:
+        example: conv_abc123
+        type: string
+      first_message_at:
+        example: "2026-05-20T10:00:00Z"
+        type: string
+      has_unread:
+        example: true
+        type: boolean
+      inbound_count:
+        example: 2
+        type: integer
+      last_message_at:
+        example: "2026-05-28T12:00:00Z"
+        type: string
+      latest_sender:
+        example: alice@example.com
+        type: string
+      latest_subject:
+        example: 'Re: Quarterly report'
+        type: string
+      message_count:
+        example: 4
+        type: integer
+      outbound_count:
+        example: 2
+        type: integer
+    type: object
   CreateSigningSecretResponse:
     properties:
       created_at:
@@ -282,6 +354,13 @@ definitions:
       agents:
         items:
           $ref: '#/definitions/Agent'
+        type: array
+    type: object
+  ListConversationsResponse:
+    properties:
+      conversations:
+        items:
+          $ref: '#/definitions/ConversationSummary'
         type: array
     type: object
   ListDomainsResponse:
@@ -1404,6 +1483,104 @@ paths:
       summary: Update an agent
       tags:
       - Agents
+  /api/v1/agents/{email}/conversations:
+    get:
+      description: Returns conversation summaries for an agent — one row per non-empty
+        conversation_id, with aggregated counts and the latest message's subject/sender.
+        Sorted by `last_message_at` descending. The response is hard-capped at 100
+        conversations (pagination is intentionally deferred for slice 1). Use `since`
+        / `until` to bracket the active window. Messages with empty `conversation_id`
+        are NOT in any conversation — they remain individually visible via the messages
+        list.
+      parameters:
+      - description: Agent email address
+        example: my-bot@example.com
+        in: path
+        name: email
+        required: true
+        type: string
+      - description: RFC3339 timestamp; only conversations whose latest message is
+          >= since
+        example: "2026-05-01T00:00:00Z"
+        in: query
+        name: since
+        type: string
+      - description: RFC3339 timestamp; only conversations whose latest message is
+          < until
+        in: query
+        name: until
+        type: string
+      - default: 100
+        description: Max conversations to return (server clamps to 100)
+        in: query
+        maximum: 100
+        minimum: 1
+        name: page_size
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/ListConversationsResponse'
+        "400":
+          description: Invalid since/until
+          schema:
+            type: string
+        "401":
+          description: Missing or invalid API key
+          schema:
+            type: string
+        "404":
+          description: Agent not found or not owned by this user
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: List conversations for an agent
+      tags:
+      - Email
+  /api/v1/agents/{email}/conversations/{id}:
+    get:
+      description: Returns the full conversation — aggregate counts, participant union,
+        label union, and every member message (oldest-first). Messages share the schema
+        of `MessageSummary` from the list endpoint. Returns 404 when no non-expired
+        messages exist for `(agent, conversation_id)`; cross-agent access is indistinguishable
+        from not-found.
+      parameters:
+      - description: Agent email address
+        example: my-bot@example.com
+        in: path
+        name: email
+        required: true
+        type: string
+      - description: Conversation ID
+        example: conv_abc123
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/ConversationDetail'
+        "401":
+          description: Missing or invalid API key
+          schema:
+            type: string
+        "404":
+          description: Conversation not found
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Get a conversation
+      tags:
+      - Email
   /api/v1/agents/{email}/messages:
     get:
       description: Fetch messages for an agent. Returns lightweight summaries (no

--- a/web/public/openapi.yaml
+++ b/web/public/openapi.yaml
@@ -102,6 +102,12 @@ definitions:
         example: "2026-05-20T10:00:00Z"
         type: string
       has_unread:
+        description: |-
+          HasUnread is true iff at least one INBOUND member of this
+          conversation is in inbox_status='unread'. Outbound rows do
+          NOT contribute — a thread containing only your sent messages
+          (or only HITL-pending outbound) returns false. This is the
+          agent's mailbox view, not the reviewer's HITL queue.
         example: true
         type: boolean
       inbound_count:
@@ -144,6 +150,12 @@ definitions:
         example: "2026-05-20T10:00:00Z"
         type: string
       has_unread:
+        description: |-
+          HasUnread is true iff at least one INBOUND member of this
+          conversation is in inbox_status='unread'. Outbound rows do
+          NOT contribute — a thread containing only your sent messages
+          (or only HITL-pending outbound) returns false. This is the
+          agent's mailbox view, not the reviewer's HITL queue.
         example: true
         type: boolean
       inbound_count:


### PR DESCRIPTION
## Summary

Adds the Conversations API as a thin read layer over the existing `messages.conversation_id` column. Two endpoints — list with aggregated counts + a "latest message" preview, and detail with all member messages, computed participants union, and computed labels union. No new persistence; everything is computed at read time.

## Slices

**Slice A — Backend Go end-to-end** (commit \`e052690\`)
- Migration 022: partial GIN-eligible composite index \`(agent_id, conversation_id, created_at DESC) WHERE conversation_id <> ''\`. CONCURRENTLY-built behind the \`e2a:no-transaction\` directive so prod deploys don't block writes.
- \`identity.ListConversationsByAgent\` (groups + aggregates) and \`identity.GetConversationByID\` (detail with member messages, participants union, labels union).
- \`GET /api/v1/agents/{email}/conversations\` + \`/{id}\` handlers, auth + rate-limited.
- 20 tests (9 storage + 11 handler).

**Slice B — Client surfaces** (commit \`52d49a5\`, per #176 checklist)
- TS SDK: \`api.listConversations\`/\`getConversation\`, \`client.listConversations\`/\`getConversation\`.
- Python SDK sync + async: raw + high-level methods.
- CLI: \`e2a conversations list [--limit N] [--since ts] [--until ts]\`, \`e2a conversations show <id>\`.
- MCP: \`list_conversations\` + \`get_conversation\` tools (with descriptions that steer the LLM toward threads vs single messages).

## Surface checklist

- [x] Go handler + integration tests
- [x] Migration written + idempotent + safe on prod-sized tables (CONCURRENTLY index, partial WHERE)
- [x] OpenAPI spec + generated types refreshed
- [x] TypeScript SDK — \`api.ts\` (raw) **and** \`client.ts\` (high-level)
- [x] Python SDK sync — \`api.py\` (raw) **and** \`client.py\` (high-level)
- [x] Python SDK async — \`async_client.py\` (both raw and high-level)
- [x] CLI command in \`cli/src/commands/\` + wired into \`cli/src/bin/e2a.ts\`
- [x] MCP tool in \`mcp/src/tools/\` + registry assertions in \`mcp/tests/{tools,http}.test.ts\`
- [x] Tests at each surface

## Out of scope (deferred)

- Cursor-based pagination beyond 100 conversations
- \`?label=\`, \`?status=\` filters
- DELETE / PATCH on conversations
- User-scoped \`GET /conversations\` (currently agent-scoped only)

## Verification

- Go: \`internal/identity\` (28s) + \`internal/agent\` (51s) full suites green
- Python: 134 tests pass (+8 new)
- TS SDK: 85 pass
- CLI: 103 pass
- MCP: 92 pass (+2 new plumbing tests)

## Test plan

- [ ] Manual: \`e2a conversations list\` against a populated agent
- [ ] Manual: \`e2a conversations show <id>\` confirms participants + label union
- [ ] Confirm migration 022 applies cleanly on a populated dev DB (\`make migrate\`)
- [ ] Live e2e: seed a multi-message thread, hit GET /conversations, GET /conversations/{id}

🤖 Generated with [Claude Code](https://claude.com/claude-code)