### PR TITLE
feat(webhooks): top-level webhooks-as-a-resource (all 4 slices)

### DIFF
--- a/cli/src/bin/e2a.ts
+++ b/cli/src/bin/e2a.ts
@@ -18,6 +18,16 @@ import { config } from "../commands/config.js";
 import { listen } from "../commands/listen.js";
 import { domainsList, domainsRegister, domainsVerify, domainsDelete } from "../commands/domains.js";
 import {
+  webhooksList,
+  webhooksCreate,
+  webhooksGet,
+  webhooksUpdate,
+  webhooksDelete,
+  webhooksRotateSecret,
+  webhooksTest,
+  webhooksDeliveries,
+} from "../commands/webhooks.js";
+import {
   pendingList,
   pendingShow,
   pendingApprove,
@@ -53,6 +63,14 @@ Usage:
   e2a domains register <domain>     Register a custom domain
   e2a domains verify <domain>       Verify domain DNS records
   e2a domains delete <domain>       Delete a domain
+  e2a webhooks list                                          List webhook subscribers
+  e2a webhooks create --url <url> --events <event> [...]     Create a webhook
+  e2a webhooks get <id>                                      Show one webhook
+  e2a webhooks update <id> [--url …] [--events …] [--enable|--disable]
+  e2a webhooks delete <id>                                   Delete a webhook
+  e2a webhooks rotate-secret <id>                            Rotate signing secret
+  e2a webhooks test <id> [--event …]                         Fire a synthetic event
+  e2a webhooks deliveries <id> [--limit N] [--status …]      List recent deliveries
   e2a config [list|get|set]         View or update config
 
 Options:
@@ -309,6 +327,64 @@ async function main() {
         await domainsDelete(args[1]);
       } else {
         process.stderr.write("Usage: e2a domains [list|register|verify|delete]\n");
+        process.exit(1);
+      }
+      break;
+    }
+    case "webhooks": {
+      const sub = args[0];
+      if (sub === "list") {
+        await webhooksList();
+      } else if (sub === "create") {
+        await webhooksCreate({
+          url: getFlag(args, "--url"),
+          events: getFlags(args, "--events"),
+          description: getFlag(args, "--description"),
+          agentId: getFlags(args, "--agent-id"),
+          conversationId: getFlags(args, "--conversation-id"),
+          label: getFlags(args, "--label"),
+        });
+      } else if (sub === "get") {
+        await webhooksGet(args[1]);
+      } else if (sub === "update") {
+        let enabled: boolean | undefined;
+        if (hasFlag(args, "--disable")) enabled = false;
+        else if (hasFlag(args, "--enable")) enabled = true;
+        await webhooksUpdate(args[1], {
+          url: getFlag(args, "--url"),
+          events: getFlags(args, "--events"),
+          description: getFlag(args, "--description"),
+          enabled,
+        });
+      } else if (sub === "delete") {
+        await webhooksDelete(args[1]);
+      } else if (sub === "rotate-secret") {
+        await webhooksRotateSecret(args[1]);
+      } else if (sub === "test") {
+        await webhooksTest(args[1], { event: getFlag(args, "--event") });
+      } else if (sub === "deliveries") {
+        const limitStr = getFlag(args, "--limit");
+        let limit: number | undefined;
+        if (limitStr !== undefined) {
+          const n = parseInt(limitStr, 10);
+          if (!Number.isFinite(n) || n < 1) {
+            process.stderr.write("--limit must be a positive integer\n");
+            process.exit(1);
+          }
+          limit = n;
+        }
+        const statusRaw = getFlag(args, "--status");
+        let status: "pending" | "delivered" | "failed" | undefined;
+        if (statusRaw !== undefined) {
+          if (statusRaw !== "pending" && statusRaw !== "delivered" && statusRaw !== "failed") {
+            process.stderr.write("--status must be one of pending|delivered|failed\n");
+            process.exit(1);
+          }
+          status = statusRaw;
+        }
+        await webhooksDeliveries(args[1], { limit, status });
+      } else {
+        process.stderr.write("Usage: e2a webhooks [list|create|get|update|delete|rotate-secret|test|deliveries]\n");
         process.exit(1);
       }
       break;

--- a/cli/src/commands/webhooks.ts
+++ b/cli/src/commands/webhooks.ts
@@ -1,0 +1,177 @@
+import { createClient } from "../sdk.js";
+
+// `e2a webhooks list` — one row per webhook, owner-scoped.
+export async function webhooksList(): Promise<void> {
+  const client = createClient();
+  const res = await client.api.listWebhooks();
+  const hooks = res.webhooks || [];
+  if (hooks.length === 0) {
+    process.stderr.write("No webhooks. Create one with: e2a webhooks create --url <url> --events email.received\n");
+    return;
+  }
+  for (const h of hooks) {
+    const enabled = h.enabled ? "enabled" : "disabled";
+    const events = (h.events || []).join(",");
+    process.stdout.write(`${h.id}  ${enabled}  ${h.url}  [${events}]\n`);
+  }
+}
+
+export interface WebhooksCreateOptions {
+  url?: string;
+  events?: string[];
+  description?: string;
+  agentId?: string[];
+  conversationId?: string[];
+  label?: string[];
+}
+
+// `e2a webhooks create --url <url> --events email.received [--events email.sent]
+//                     [--description "…"] [--agent-id …] [--conversation-id …] [--label …]`
+export async function webhooksCreate(opts: WebhooksCreateOptions): Promise<void> {
+  if (!opts.url) {
+    process.stderr.write("Usage: e2a webhooks create --url <url> --events <event> [--events <event> …]\n");
+    process.exit(1);
+  }
+  if (!opts.events || opts.events.length === 0) {
+    process.stderr.write("--events is required (e.g. --events email.received)\n");
+    process.exit(1);
+  }
+  const filters: { agent_ids?: string[]; conversation_ids?: string[]; labels?: string[] } = {};
+  if (opts.agentId && opts.agentId.length > 0) filters.agent_ids = opts.agentId;
+  if (opts.conversationId && opts.conversationId.length > 0) filters.conversation_ids = opts.conversationId;
+  if (opts.label && opts.label.length > 0) filters.labels = opts.label;
+
+  const client = createClient();
+  const res = await client.api.createWebhook({
+    url: opts.url,
+    events: opts.events,
+    description: opts.description ?? "",
+    filters: Object.keys(filters).length > 0 ? filters : undefined,
+  });
+  process.stdout.write(`Created: ${res.id}\n`);
+  // The plaintext secret is printed exactly once, here. Subsequent
+  // get/list calls scrub it.
+  if (res.signing_secret) {
+    process.stdout.write(`Signing secret: ${res.signing_secret}\n`);
+    process.stdout.write("Store this somewhere safe — it won't be shown again.\n");
+  }
+}
+
+export async function webhooksGet(id: string | undefined): Promise<void> {
+  if (!id) {
+    process.stderr.write("Usage: e2a webhooks get <id>\n");
+    process.exit(1);
+  }
+  const client = createClient();
+  const w = await client.api.getWebhook(id);
+  process.stdout.write(JSON.stringify(w, null, 2) + "\n");
+}
+
+export interface WebhooksUpdateOptions {
+  url?: string;
+  events?: string[];
+  description?: string;
+  enabled?: boolean;
+}
+
+// `e2a webhooks update <id> [--url …] [--events …] [--description …]
+//                            [--enable | --disable]`
+export async function webhooksUpdate(
+  id: string | undefined,
+  opts: WebhooksUpdateOptions,
+): Promise<void> {
+  if (!id) {
+    process.stderr.write("Usage: e2a webhooks update <id> [--url …] [--events …] [--enable|--disable]\n");
+    process.exit(1);
+  }
+  const body: {
+    url?: string;
+    events?: string[];
+    description?: string;
+    enabled?: boolean;
+  } = {};
+  if (opts.url !== undefined) body.url = opts.url;
+  if (opts.events !== undefined && opts.events.length > 0) body.events = opts.events;
+  if (opts.description !== undefined) body.description = opts.description;
+  if (opts.enabled !== undefined) body.enabled = opts.enabled;
+  if (Object.keys(body).length === 0) {
+    process.stderr.write("nothing to update — pass at least one of --url/--events/--description/--enable/--disable\n");
+    process.exit(1);
+  }
+  const client = createClient();
+  const w = await client.api.updateWebhook(id, body);
+  process.stdout.write(`Updated: ${w.id}  enabled=${w.enabled}\n`);
+}
+
+export async function webhooksDelete(id: string | undefined): Promise<void> {
+  if (!id) {
+    process.stderr.write("Usage: e2a webhooks delete <id>\n");
+    process.exit(1);
+  }
+  const client = createClient();
+  await client.api.deleteWebhook(id);
+  process.stdout.write(`Deleted: ${id}\n`);
+}
+
+export async function webhooksRotateSecret(id: string | undefined): Promise<void> {
+  if (!id) {
+    process.stderr.write("Usage: e2a webhooks rotate-secret <id>\n");
+    process.exit(1);
+  }
+  const client = createClient();
+  const res = await client.api.rotateWebhookSecret(id);
+  process.stdout.write(`New signing secret: ${res.signing_secret}\n`);
+  process.stdout.write(`Previous secret expires at: ${res.previous_secret_expires_at}\n`);
+  process.stdout.write("Store the new secret — it won't be shown again.\n");
+}
+
+export interface WebhooksTestOptions {
+  event?: string;
+}
+
+// `e2a webhooks test <id> [--event email.received]`
+export async function webhooksTest(
+  id: string | undefined,
+  opts: WebhooksTestOptions,
+): Promise<void> {
+  if (!id) {
+    process.stderr.write("Usage: e2a webhooks test <id> [--event <event>]\n");
+    process.exit(1);
+  }
+  const client = createClient();
+  const res = await client.api.testWebhook(id, {
+    event: opts.event ?? "",
+    data: { test: true },
+  });
+  process.stdout.write(`Scheduled test delivery: ${res.delivery_id}\n`);
+  process.stdout.write("Use `e2a webhooks deliveries " + id + "` to see status.\n");
+}
+
+export interface WebhooksDeliveriesOptions {
+  limit?: number;
+  status?: "pending" | "delivered" | "failed";
+}
+
+export async function webhooksDeliveries(
+  id: string | undefined,
+  opts: WebhooksDeliveriesOptions,
+): Promise<void> {
+  if (!id) {
+    process.stderr.write("Usage: e2a webhooks deliveries <id> [--limit N] [--status pending|delivered|failed]\n");
+    process.exit(1);
+  }
+  const client = createClient();
+  const res = await client.api.listWebhookDeliveries(id, {
+    limit: opts.limit,
+    status: opts.status,
+  });
+  const rows = res.deliveries || [];
+  if (rows.length === 0) {
+    process.stdout.write("No deliveries yet.\n");
+    return;
+  }
+  for (const r of rows) {
+    const code = r.last_status_code !== undefined ? `(${r.last_status_code})` : "";
+    process.stdout.write(`${r.id}  ${r.status}  attempts=${r.attempts}  ${r.event_type}  ${code}  ${r.created_at}\n`);
+  }
+}

--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -240,6 +240,8 @@ func main() {
 	api.SetUsageStore(usageStore)
 	api.SetInternalAPISecret(cfg.Limits.InternalAPISecret)
 	api.SetBillingHookURL(cfg.Limits.BillingHookURL)
+	api.SetSubscriberStore(subscriberStore)
+	api.SetPublisher(webhookPublisher)
 
 	api.RegisterRoutes(router)
 

--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/relay"
 	"github.com/Mnexa-AI/e2a/internal/usage"
 	"github.com/Mnexa-AI/e2a/internal/webhook"
+	"github.com/Mnexa-AI/e2a/internal/webhookpub"
 	"github.com/Mnexa-AI/e2a/internal/ws"
 	"github.com/Mnexa-AI/e2a/migrations"
 	"github.com/gorilla/mux"
@@ -133,6 +134,17 @@ func main() {
 	deliverer := webhook.NewDeliverer(cfg.IsProduction())
 	deliveryStore := webhook.NewDeliveryStore(pool)
 	persistentDeliverer := webhook.NewPersistentDeliverer(deliverer, deliveryStore)
+
+	// New webhooks-as-a-resource pipeline (slice 1 of the feature).
+	// Lives alongside the legacy single-URL path above — both fire on
+	// inbound events. The feature flag E2A_FEATURE_WEBHOOK_RESOURCE
+	// (default ON) gates the publisher only; the subscriber retry
+	// worker keeps draining any pending rows even when the flag is
+	// OFF. See tmp/e2a_webhooks_design.md for the full design.
+	webhookFlag := webhookpub.StaticFlag(os.Getenv("E2A_FEATURE_WEBHOOK_RESOURCE") != "false")
+	subscriberStore := webhook.NewSubscriberStore(pool)
+	subscriberDeliverer := webhook.NewSubscriberDeliverer(cfg.IsProduction())
+	webhookPublisher := webhookpub.New(store, webhookpub.NewDBInserter(pool), webhookFlag)
 	smtpRelay := outbound.NewSMTPRelay(&cfg.OutboundSMTP)
 	sender := outbound.NewSenderWithDKIM(smtpRelay, cfg.OutboundSMTP.FromDomain, store)
 
@@ -245,6 +257,7 @@ func main() {
 	// SMTP Relay
 	smtpServer := relay.NewServer(cfg, store, signer, persistentDeliverer, usageTracker, wsHub)
 	smtpServer.SetEnforcer(enforcer)
+	smtpServer.SetPublisher(webhookPublisher)
 
 	// Graceful shutdown
 	sigCh := make(chan os.Signal, 1)
@@ -279,13 +292,27 @@ func main() {
 	// is a follow-up.
 	var workerWG sync.WaitGroup
 
-	// Webhook delivery retry worker
+	// Webhook delivery retry worker (legacy single-URL path)
 	retryWorker := webhook.NewRetryWorker(deliveryStore, deliverer, store)
 	retryCtx, retryCancel := context.WithCancel(context.Background())
 	workerWG.Add(1)
 	go func() {
 		defer workerWG.Done()
 		retryWorker.Start(retryCtx)
+	}()
+
+	// Webhook subscriber retry worker (new webhooks-as-a-resource path).
+	// Lives alongside the legacy worker; both drain their own table.
+	// Unconditionally started — even with the feature flag OFF (publisher
+	// disabled) this worker keeps draining any rows that were inserted
+	// before the flag flipped, so flipping the flag mid-flight doesn't
+	// leak pending deliveries.
+	subRetryWorker := webhook.NewSubscriberRetryWorker(subscriberStore, subscriberDeliverer, store)
+	subRetryCtx, subRetryCancel := context.WithCancel(context.Background())
+	workerWG.Add(1)
+	go func() {
+		defer workerWG.Done()
+		subRetryWorker.Start(subRetryCtx)
 	}()
 
 	// HITL expiration worker: transitions pending_approval messages that
@@ -361,6 +388,7 @@ func main() {
 	// calls already in flight finish their current row before the
 	// goroutine exits.
 	retryCancel()
+	subRetryCancel()
 	hitlCancel()
 	cleanupCancel()
 

--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -317,6 +317,16 @@ func main() {
 		subRetryWorker.Start(subRetryCtx)
 	}()
 
+	// Auto-disable + signing-secret-grace janitor (slice 4). Same
+	// lifecycle as the retry worker — share the same cancel so a
+	// single shutdown signal stops both.
+	autoDisableWorker := webhook.NewAutoDisableWorker(store)
+	workerWG.Add(1)
+	go func() {
+		defer workerWG.Done()
+		autoDisableWorker.Start(subRetryCtx)
+	}()
+
 	// HITL expiration worker: transitions pending_approval messages that
 	// blew past their TTL into expired_approved (auto-send) or
 	// expired_rejected based on the owning agent's hitl_expiration_action.

--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -372,6 +372,12 @@ func main() {
 					log.Printf("Cleaned up %d expired webhook delivery record(s)", deleted)
 				}
 
+				if deleted, err := subscriberStore.DeleteExpiredSubscriberDeliveries(cleanupCtx); err != nil {
+					log.Printf("Failed to clean up expired webhook subscriber deliveries: %v", err)
+				} else if deleted > 0 {
+					log.Printf("Cleaned up %d expired webhook subscriber delivery record(s)", deleted)
+				}
+
 				if oauthStorage != nil {
 					if res, err := oauthStorage.CleanupExpired(cleanupCtx, time.Now()); err != nil {
 						log.Printf("Failed to clean up expired OAuth rows: %v", err)

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -29,6 +30,7 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/ratelimit"
 	"github.com/Mnexa-AI/e2a/internal/usage"
 	"github.com/Mnexa-AI/e2a/internal/webhook"
+	"github.com/Mnexa-AI/e2a/internal/webhookpub"
 	"github.com/google/go-github/v72/github"
 	"github.com/gorilla/mux"
 	"github.com/ory/fosite"
@@ -191,12 +193,35 @@ type API struct {
 	// Optional — when nil, those endpoints return 404 (the rest of
 	// the /webhooks CRUD still works, just without test + history).
 	subscriberStore *webhook.SubscriberStore
+
+	// publisher routes email.sent / email.pending_approval /
+	// email.approved / email.rejected events to the new webhooks
+	// resource. Optional — when nil, the trigger sites silently skip
+	// the publish step (the legacy webhook_url path is unaffected).
+	publisher webhookpub.Publisher
 }
 
 // SetSubscriberStore wires the subscriber-store dependency after
 // NewAPI. Same optional-setter convention as SetEnforcer / etc.
 func (a *API) SetSubscriberStore(s *webhook.SubscriberStore) {
 	a.subscriberStore = s
+}
+
+// SetPublisher wires the webhookpub.Publisher used by handlers to fan
+// outbound + HITL events to webhook subscribers. Safe to leave nil in
+// tests; trigger sites no-op when it is.
+func (a *API) SetPublisher(p webhookpub.Publisher) { a.publisher = p }
+
+// publishAsync fires an event in a fresh goroutine so the handler's
+// response is not blocked by webhook routing. Returns immediately.
+// Uses context.Background() to detach from the request — the publisher
+// is a best-effort post-commit fan-out, not part of the handler's
+// success criteria.
+func (a *API) publishAsync(e webhookpub.Event) {
+	if a.publisher == nil {
+		return
+	}
+	go a.publisher.Publish(context.Background(), e)
 }
 
 // SetApprovalSigner wires in the magic-link signer after construction so
@@ -1511,6 +1536,8 @@ func (a *API) holdForApproval(w http.ResponseWriter, r *http.Request, agent *ide
 	// finalize it even if every notification email bounces.
 	a.notifier.NotifyPendingApprovalAsync(msg, agent)
 
+	a.publishAsync(a.buildPendingApprovalEvent(agent, msg, req, msgType))
+
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
 	writeJSON(w, map[string]interface{}{
@@ -1717,6 +1744,8 @@ func (a *API) handleSendEmail(w http.ResponseWriter, r *http.Request) {
 	if outMsg != nil {
 		log.Printf("[mail:%s] dir=outbound type=send from=%s to=%v slug=%s conv_id=%s subject=%q", outMsg.ID, agent.EmailAddress(), result.To, slug, req.ConversationID, req.Subject)
 	}
+
+	a.publishAsync(a.buildSentEvent(agent, outMsg, result, req, "send"))
 
 	w.Header().Set("Content-Type", "application/json")
 	writeJSON(w, map[string]string{
@@ -2049,6 +2078,8 @@ func (a *API) handleReplyToMessage(w http.ResponseWriter, r *http.Request) {
 		log.Printf("[mail:%s] dir=outbound type=reply from=%s to=%v slug=%s conv_id=%s subject=%q in_reply_to=%s", outMsg.ID, agent.EmailAddress(), result.To, slug, req.ConversationID, subject, msgID)
 	}
 
+	a.publishAsync(a.buildSentEvent(agent, outMsg, result, sendReq, "reply"))
+
 	w.Header().Set("Content-Type", "application/json")
 	writeJSON(w, map[string]string{
 		"status":     "sent",
@@ -2247,6 +2278,8 @@ func (a *API) handleForwardMessage(w http.ResponseWriter, r *http.Request) {
 	if outMsg != nil {
 		log.Printf("[mail:%s] dir=outbound type=forward from=%s to=%v slug=%s conv_id=%s subject=%q orig=%s", outMsg.ID, agent.EmailAddress(), result.To, slug, req.ConversationID, subject, msgID)
 	}
+
+	a.publishAsync(a.buildSentEvent(agent, outMsg, result, sendReq, "forward"))
 
 	w.Header().Set("Content-Type", "application/json")
 	writeJSON(w, map[string]string{

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -28,6 +28,7 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/outbound"
 	"github.com/Mnexa-AI/e2a/internal/ratelimit"
 	"github.com/Mnexa-AI/e2a/internal/usage"
+	"github.com/Mnexa-AI/e2a/internal/webhook"
 	"github.com/google/go-github/v72/github"
 	"github.com/gorilla/mux"
 	"github.com/ory/fosite"
@@ -185,6 +186,17 @@ type API struct {
 	usageStore     *usage.Store           // optional; needed by handleGetMyLimits to surface current counts
 	internalAPISecret string              // optional; when empty, /api/internal/* endpoints return 503
 	billingHookURL string                 // optional; when set, handleDeleteUserData POSTs an HMAC-signed user-deleted notice here (sidecar's /api/internal/billing/cancel)
+	// subscriberStore powers the slice-2 webhooks-as-a-resource
+	// /webhooks/{id}/test and /webhooks/{id}/deliveries endpoints.
+	// Optional — when nil, those endpoints return 404 (the rest of
+	// the /webhooks CRUD still works, just without test + history).
+	subscriberStore *webhook.SubscriberStore
+}
+
+// SetSubscriberStore wires the subscriber-store dependency after
+// NewAPI. Same optional-setter convention as SetEnforcer / etc.
+func (a *API) SetSubscriberStore(s *webhook.SubscriberStore) {
+	a.subscriberStore = s
 }
 
 // SetApprovalSigner wires in the magic-link signer after construction so
@@ -350,6 +362,16 @@ func (a *API) RegisterRoutes(r *mux.Router) {
 	// shared domain and other deployment-specific values without requiring
 	// each user to set them by hand.
 	r.HandleFunc("/api/v1/info", a.handleInfo).Methods("GET")
+
+	// Webhooks-as-a-resource (slice 2)
+	r.HandleFunc("/api/v1/webhooks", a.handleCreateWebhook).Methods("POST")
+	r.HandleFunc("/api/v1/webhooks", a.handleListWebhooks).Methods("GET")
+	r.HandleFunc("/api/v1/webhooks/{id}", a.handleGetWebhook).Methods("GET")
+	r.HandleFunc("/api/v1/webhooks/{id}", a.handleUpdateWebhook).Methods("PATCH")
+	r.HandleFunc("/api/v1/webhooks/{id}", a.handleDeleteWebhook).Methods("DELETE")
+	r.HandleFunc("/api/v1/webhooks/{id}/rotate-secret", a.handleRotateWebhookSecret).Methods("POST")
+	r.HandleFunc("/api/v1/webhooks/{id}/test", a.handleTestWebhook).Methods("POST")
+	r.HandleFunc("/api/v1/webhooks/{id}/deliveries", a.handleListWebhookDeliveries).Methods("GET")
 
 	// --- Non-versioned operational endpoints ---
 	r.HandleFunc("/api/health", a.handleHealth).Methods("GET", "HEAD")

--- a/internal/agent/api_docs.go
+++ b/internal/agent/api_docs.go
@@ -133,6 +133,97 @@ type ConversationDetail struct {
 	Messages     []MessageSummary `json:"messages"`
 } // @name ConversationDetail
 
+// --- Webhooks-as-a-resource (slice 2) ---
+
+// WebhookFilters is the structured scope filter on a webhook. Empty /
+// missing keys mean "no constraint of that type". A webhook with
+// all-empty filters is a cross-cutting subscriber that matches every
+// event of the right type for the owning user.
+type WebhookFilters struct {
+	AgentIDs        []string `json:"agent_ids,omitempty"`
+	ConversationIDs []string `json:"conversation_ids,omitempty"`
+	Labels          []string `json:"labels,omitempty"`
+} // @name WebhookFilters
+
+// CreateWebhookRequest is the POST /api/v1/webhooks body.
+type CreateWebhookRequest struct {
+	URL         string          `json:"url" example:"https://example.com/e2a/hook"`
+	Events      []string        `json:"events" example:"email.received"`
+	Filters     *WebhookFilters `json:"filters,omitempty"`
+	Description string          `json:"description,omitempty" example:"main inbox handler"`
+} // @name CreateWebhookRequest
+
+// UpdateWebhookRequest is the PATCH body. All fields optional; only
+// fields present in the request are touched. url / events / filters
+// are full-replace when present (the sent value is canonical).
+type UpdateWebhookRequest struct {
+	URL         *string         `json:"url,omitempty"`
+	Events      *[]string       `json:"events,omitempty"`
+	Filters     *WebhookFilters `json:"filters,omitempty"`
+	Description *string         `json:"description,omitempty"`
+	Enabled     *bool           `json:"enabled,omitempty"`
+} // @name UpdateWebhookRequest
+
+// WebhookResponse is the GET / POST response shape. SigningSecret is
+// populated only on POST /webhooks and POST /webhooks/{id}/rotate-secret
+// — every other endpoint omits it so a stolen API key cannot exfiltrate
+// secrets via list/get.
+type WebhookResponse struct {
+	ID                       string         `json:"id" example:"wh_abc123"`
+	URL                      string         `json:"url"`
+	Description              string         `json:"description"`
+	Events                   []string       `json:"events"`
+	Filters                  WebhookFilters `json:"filters"`
+	SigningSecret            string         `json:"signing_secret,omitempty"` // ONLY on create + rotate
+	PreviousSecretExpiresAt  string         `json:"previous_secret_expires_at,omitempty"` // ONLY on rotate
+	Enabled                  bool           `json:"enabled"`
+	AutoDisabledAt           string         `json:"auto_disabled_at,omitempty"`
+	CreatedAt                string         `json:"created_at"`
+	LastDeliveredAt          string         `json:"last_delivered_at,omitempty"`
+} // @name WebhookResponse
+
+// ListWebhooksResponse wraps the list endpoint.
+type ListWebhooksResponse struct {
+	Webhooks []WebhookResponse `json:"webhooks"`
+} // @name ListWebhooksResponse
+
+// RotateWebhookSecretResponse carries the new plaintext secret +
+// the 24h expiry for the previous secret's grace window.
+type RotateWebhookSecretResponse struct {
+	SigningSecret           string `json:"signing_secret"`
+	PreviousSecretExpiresAt string `json:"previous_secret_expires_at"`
+} // @name RotateWebhookSecretResponse
+
+// TestWebhookRequest fires a synthetic event for development.
+type TestWebhookRequest struct {
+	Event string                 `json:"event" example:"email.received"`
+	Data  map[string]interface{} `json:"data,omitempty"`
+} // @name TestWebhookRequest
+
+// TestWebhookResponse echoes the delivery id of the synthetic event
+// so the caller can correlate it in GET /webhooks/{id}/deliveries.
+type TestWebhookResponse struct {
+	DeliveryID string `json:"delivery_id"`
+} // @name TestWebhookResponse
+
+// WebhookDeliveryResponse is one row in GET /webhooks/{id}/deliveries.
+type WebhookDeliveryResponse struct {
+	ID             string `json:"id"`
+	EventType      string `json:"event_type"`
+	Status         string `json:"status"`
+	Attempts       int    `json:"attempts"`
+	LastError      string `json:"last_error,omitempty"`
+	LastStatusCode *int   `json:"last_status_code,omitempty"`
+	LastAttemptAt  string `json:"last_attempt_at,omitempty"`
+	NextRetryAt    string `json:"next_retry_at"`
+	CreatedAt      string `json:"created_at"`
+} // @name WebhookDeliveryResponse
+
+// ListWebhookDeliveriesResponse wraps the deliveries endpoint.
+type ListWebhookDeliveriesResponse struct {
+	Deliveries []WebhookDeliveryResponse `json:"deliveries"`
+} // @name ListWebhookDeliveriesResponse
+
 // ListConversationsResponse wraps the conversations list. Pagination
 // is intentionally deferred — the response is hard-capped at 100
 // conversations server-side, which covers the inbox-style use case

--- a/internal/agent/hitl_api.go
+++ b/internal/agent/hitl_api.go
@@ -407,6 +407,8 @@ func (a *API) handleApprovePendingMessage(w http.ResponseWriter, r *http.Request
 	log.Printf("[mail:%s] dir=outbound type=%s status=sent from=%s to=%v slug=%s subject=%q edited=%v approved=user:%s",
 		sent.ID, sent.Type, agent.EmailAddress(), sent.ToRecipients, slug, sent.Subject, sent.Edited, user.ID)
 
+	a.publishAsync(a.buildApprovedEvent(agent, sent, user.ID))
+
 	w.Header().Set("Content-Type", "application/json")
 	writeJSON(w, map[string]interface{}{
 		"status":     sent.Status,
@@ -536,6 +538,8 @@ func (a *API) handleRejectPendingMessage(w http.ResponseWriter, r *http.Request)
 
 	log.Printf("[mail:%s] dir=outbound type=%s status=rejected agent=%s rejected_by=user:%s reason=%q",
 		rejected.ID, rejected.Type, rejected.AgentID, user.ID, req.Reason)
+
+	a.publishAsync(a.buildRejectedEvent(user.ID, rejected, req.Reason))
 
 	w.Header().Set("Content-Type", "application/json")
 	writeJSON(w, map[string]interface{}{

--- a/internal/agent/webhooks_api.go
+++ b/internal/agent/webhooks_api.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/outbound"
 	"github.com/Mnexa-AI/e2a/internal/webhookpub"
 	"github.com/gorilla/mux"
 )
@@ -634,6 +635,145 @@ func (a *API) handleListWebhookDeliveries(w http.ResponseWriter, r *http.Request
 	}
 	w.Header().Set("Content-Type", "application/json")
 	writeJSON(w, map[string]interface{}{"deliveries": out})
+}
+
+// --- event builders (slice 3) ---
+//
+// Each helper translates an in-process trigger into a webhookpub.Event.
+// They live here (next to the webhook resource) so the publisher's
+// envelope shape is co-located with the handler shape, and the
+// build sites in api.go / hitl_api.go stay one-line.
+
+// buildSentEvent constructs an email.sent event for /send, /reply,
+// /forward. outMsg may be nil if CreateOutboundMessage failed — in
+// that case we still publish (the SES send already happened) but with
+// an empty message_id; receivers see the event without a row to fetch.
+func (a *API) buildSentEvent(
+	agent *identity.AgentIdentity,
+	outMsg *identity.Message,
+	result *outbound.SendResult,
+	req outbound.SendRequest,
+	msgType string,
+) webhookpub.Event {
+	messageID := ""
+	if outMsg != nil {
+		messageID = outMsg.ID
+	}
+	data := map[string]interface{}{
+		"message_id":          messageID,
+		"provider_message_id": result.MessageID,
+		"method":              result.Method,
+		"from":                agent.EmailAddress(),
+		"to":                  result.To,
+		"cc":                  result.CC,
+		"bcc":                 result.BCC,
+		"subject":             req.Subject,
+		"type":                msgType,
+		"conversation_id":     req.ConversationID,
+	}
+	return webhookpub.Event{
+		ID:             generateEventIDForAgent(),
+		Type:           webhookpub.EventEmailSent,
+		CreatedAt:      time.Now().UTC(),
+		UserID:         agent.UserID,
+		AgentID:        agent.ID,
+		ConversationID: req.ConversationID,
+		MessageID:      messageID,
+		Data:           data,
+	}
+}
+
+// buildPendingApprovalEvent fires when a HITL-enabled agent holds an
+// outbound message for human review. msg is the pending row; req is
+// the composed SendRequest that produced it.
+func (a *API) buildPendingApprovalEvent(
+	agent *identity.AgentIdentity,
+	msg *identity.Message,
+	req outbound.SendRequest,
+	msgType string,
+) webhookpub.Event {
+	data := map[string]interface{}{
+		"message_id":          msg.ID,
+		"from":                agent.EmailAddress(),
+		"to":                  req.To,
+		"cc":                  req.CC,
+		"bcc":                 req.BCC,
+		"subject":             req.Subject,
+		"type":                msgType,
+		"conversation_id":     req.ConversationID,
+		"approval_expires_at": msg.ApprovalExpiresAt,
+	}
+	return webhookpub.Event{
+		ID:             generateEventIDForAgent(),
+		Type:           webhookpub.EventEmailPendingApproval,
+		CreatedAt:      time.Now().UTC(),
+		UserID:         agent.UserID,
+		AgentID:        agent.ID,
+		ConversationID: req.ConversationID,
+		MessageID:      msg.ID,
+		Data:           data,
+	}
+}
+
+// buildApprovedEvent fires after ApproveAndSend hands the message to
+// SES. sent carries the post-approve message row (now status=sent).
+func (a *API) buildApprovedEvent(
+	agent *identity.AgentIdentity,
+	sent *identity.Message,
+	reviewerUserID string,
+) webhookpub.Event {
+	data := map[string]interface{}{
+		"message_id":          sent.ID,
+		"provider_message_id": sent.ProviderMessageID,
+		"method":              sent.Method,
+		"from":                agent.EmailAddress(),
+		"to":                  sent.ToRecipients,
+		"subject":             sent.Subject,
+		"type":                sent.Type,
+		"edited":              sent.Edited,
+		"reviewed_by_user_id": reviewerUserID,
+	}
+	return webhookpub.Event{
+		ID:        generateEventIDForAgent(),
+		Type:      webhookpub.EventEmailApproved,
+		CreatedAt: time.Now().UTC(),
+		UserID:    agent.UserID,
+		AgentID:   agent.ID,
+		MessageID: sent.ID,
+		Data:      data,
+	}
+}
+
+// buildRejectedEvent fires when a reviewer rejects a pending outbound.
+// userID is the reviewer (a separate identity from the agent's owner
+// when multi-reviewer ACLs land in a future slice — today they're
+// always the same).
+func (a *API) buildRejectedEvent(
+	userID string,
+	rejected *identity.Message,
+	reason string,
+) webhookpub.Event {
+	data := map[string]interface{}{
+		"message_id":          rejected.ID,
+		"type":                rejected.Type,
+		"rejection_reason":    reason,
+		"reviewed_by_user_id": userID,
+	}
+	return webhookpub.Event{
+		ID:        generateEventIDForAgent(),
+		Type:      webhookpub.EventEmailRejected,
+		CreatedAt: time.Now().UTC(),
+		UserID:    userID,
+		AgentID:   rejected.AgentID,
+		MessageID: rejected.ID,
+		Data:      data,
+	}
+}
+
+// generateEventIDForAgent wraps webhookpub's id helper so this file
+// doesn't need to import internal/webhookpub just for the constructor.
+func generateEventIDForAgent() string {
+	return webhookpub.NewEvent("", "", nil).ID
 }
 
 // --- helpers ---

--- a/internal/agent/webhooks_api.go
+++ b/internal/agent/webhooks_api.go
@@ -1,0 +1,664 @@
+package agent
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/webhookpub"
+	"github.com/gorilla/mux"
+)
+
+// --- Webhooks-as-a-resource HTTP layer (slice 2) ---
+//
+// The handlers here serve POST/GET/LIST/PATCH/DELETE on /api/v1/webhooks
+// plus /rotate-secret, /test, /deliveries subresources. The storage
+// layer in internal/identity/webhooks.go does the per-row work; this
+// layer applies the public-facing validation rules from the design.
+
+// Per-resource caps. Mirror the design's locked values.
+const (
+	webhookMaxAgentIDs        = 50
+	webhookMaxConversationIDs = 50
+	webhookMaxLabels          = 50
+	webhookMaxFilterValueLen  = 200
+)
+
+// validateCreateUpdateRequest applies every validation rule the design
+// mandates for both POST and PATCH (full-replace fields). Returns a
+// human-readable error string (handler maps to 400) or "" if valid.
+//
+// The caller passes the already-resolved user (for the agent ownership
+// check) and the canonical filter / events slices to validate. URL
+// validation goes through the existing ValidateWebhookURL helper to
+// reuse its SSRF protections.
+func (a *API) validateWebhookFields(user *identity.User, url string, events []string, filters identity.WebhookFilters, description string) (msg string, status int) {
+	if url != "" {
+		if err := ValidateWebhookURL(url); err != nil {
+			return fmt.Sprintf("invalid url: %v", err), http.StatusBadRequest
+		}
+		if len(url) > 2048 {
+			return "url too long (max 2048 chars)", http.StatusBadRequest
+		}
+	}
+	if len(events) == 0 {
+		return "events must be a non-empty array", http.StatusBadRequest
+	}
+	seen := map[string]bool{}
+	for _, e := range events {
+		if !webhookpub.IsValidEventType(e) {
+			return fmt.Sprintf("unknown event type %q (allowed: %s)", e, strings.Join(webhookpub.AllEventTypes, ", ")), http.StatusBadRequest
+		}
+		if seen[e] {
+			continue
+		}
+		seen[e] = true
+	}
+	if len(description) > 200 {
+		return "description too long (max 200 chars)", http.StatusBadRequest
+	}
+	if strings.ContainsAny(description, "\r\n") {
+		return "description must not contain CR or LF", http.StatusBadRequest
+	}
+
+	if len(filters.AgentIDs) > webhookMaxAgentIDs {
+		return fmt.Sprintf("filters.agent_ids exceeds cap of %d", webhookMaxAgentIDs), http.StatusBadRequest
+	}
+	if len(filters.ConversationIDs) > webhookMaxConversationIDs {
+		return fmt.Sprintf("filters.conversation_ids exceeds cap of %d", webhookMaxConversationIDs), http.StatusBadRequest
+	}
+	if len(filters.Labels) > webhookMaxLabels {
+		return fmt.Sprintf("filters.labels exceeds cap of %d", webhookMaxLabels), http.StatusBadRequest
+	}
+
+	for _, agentEmail := range filters.AgentIDs {
+		// agent_ids must reference agents the caller owns. Use the
+		// existing ListAgentsByUser query rather than introducing a
+		// new one; at filter-list size ≤ 50 the cost is negligible.
+		// The check fails on the first unowned id with a clear
+		// "cross-user agent" error message.
+		if agentEmail == "" {
+			return "filters.agent_ids contains empty entry", http.StatusBadRequest
+		}
+		if len(agentEmail) > webhookMaxFilterValueLen {
+			return "filters.agent_ids entry exceeds 200 chars", http.StatusBadRequest
+		}
+	}
+	if msg, status := a.assertAgentsOwnedByUser(user.ID, filters.AgentIDs); msg != "" {
+		return msg, status
+	}
+
+	for _, c := range filters.ConversationIDs {
+		if c == "" || len(c) > webhookMaxFilterValueLen {
+			return "filters.conversation_ids contains empty entry or one over 200 chars", http.StatusBadRequest
+		}
+		// Conversation IDs are case-sensitive, charset
+		// [a-zA-Z0-9_-]+.
+		for _, r := range c {
+			ok := (r >= 'a' && r <= 'z') ||
+				(r >= 'A' && r <= 'Z') ||
+				(r >= '0' && r <= '9') ||
+				r == '-' || r == '_'
+			if !ok {
+				return fmt.Sprintf("filters.conversation_ids[%q]: invalid character", c), http.StatusBadRequest
+			}
+		}
+	}
+	for _, l := range filters.Labels {
+		if l == "" || len(l) > 64 {
+			return "filters.labels contains empty entry or one over 64 chars", http.StatusBadRequest
+		}
+		// Labels charset same as the labels feature: [a-z0-9:_-]+
+		// (lowercased — the storage layer normalizes on writes but
+		// since we don't normalize here, reject case-divergent
+		// values rather than silently bait-and-switch).
+		for _, r := range l {
+			ok := (r >= 'a' && r <= 'z') ||
+				(r >= '0' && r <= '9') ||
+				r == ':' || r == '-' || r == '_'
+			if !ok {
+				return fmt.Sprintf("filters.labels[%q]: invalid character (expected [a-z0-9:_-]+, lowercase)", l), http.StatusBadRequest
+			}
+		}
+	}
+
+	return "", 0
+}
+
+// assertAgentsOwnedByUser verifies that every email in the given slice
+// is one of the user's agents. Returns "" on success. On a non-owned
+// id, returns a clear error referencing the specific id so the caller
+// can fix the filter without guessing.
+func (a *API) assertAgentsOwnedByUser(userID string, agentEmails []string) (msg string, status int) {
+	if len(agentEmails) == 0 {
+		return "", 0
+	}
+	agents, err := a.store.ListAgentsByUser(context.Background(), userID)
+	if err != nil {
+		return "failed to verify agent ownership", http.StatusInternalServerError
+	}
+	owned := map[string]bool{}
+	for _, ag := range agents {
+		owned[ag.ID] = true
+	}
+	for _, email := range agentEmails {
+		if !owned[email] {
+			return fmt.Sprintf("filters.agent_ids[%q]: not owned by this user", email), http.StatusBadRequest
+		}
+	}
+	return "", 0
+}
+
+// --- POST /api/v1/webhooks ---
+
+// handleCreateWebhook godoc
+// @Summary      Create webhook subscriber
+// @Description  Creates a top-level webhook subscriber. The plaintext signing_secret is returned ONCE in this response and never echoed by any later GET. URL must be HTTPS and must resolve to a public IP. Per-user cap defaults to 50.
+// @Tags         webhooks
+// @Accept       json
+// @Produce      json
+// @Param        body body CreateWebhookRequest true "Webhook spec"
+// @Success      201  {object}  WebhookResponse
+// @Failure      400  {string}  string "validation error or cap reached"
+// @Failure      401  {string}  string "Unauthorized"
+// @Router       /webhooks [post]
+// @Security     BearerAuth
+func (a *API) handleCreateWebhook(w http.ResponseWriter, r *http.Request) {
+	user, err := a.authenticateUser(r)
+	if err != nil {
+		a.writeAuthError(w, r, err)
+		return
+	}
+
+	var req struct {
+		URL         string                  `json:"url"`
+		Events      []string                `json:"events"`
+		Filters     *identity.WebhookFilters `json:"filters"`
+		Description string                  `json:"description"`
+	}
+	if err := readJSON(w, r, &req, maxRequestBytesSmall); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	var filters identity.WebhookFilters
+	if req.Filters != nil {
+		filters = *req.Filters
+	}
+	if msg, code := a.validateWebhookFields(user, req.URL, req.Events, filters, req.Description); msg != "" {
+		http.Error(w, msg, code)
+		return
+	}
+
+	wh, err := a.store.CreateWebhook(r.Context(), user.ID, req.URL, req.Description, req.Events, filters)
+	if err != nil {
+		if errors.Is(err, identity.ErrWebhookCapReached) {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		log.Printf("[api] CreateWebhook: user=%s err=%v", user.ID, err)
+		http.Error(w, "failed to create webhook", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	// Plaintext SigningSecret is included ONLY on this response.
+	writeJSON(w, webhookResponseFromIdentity(wh, true))
+}
+
+// --- GET /api/v1/webhooks ---
+
+// handleListWebhooks godoc
+// @Summary      List webhook subscribers
+// @Description  Returns every webhook (enabled + disabled) owned by the caller. signing_secret is omitted.
+// @Tags         webhooks
+// @Produce      json
+// @Success      200  {object}  ListWebhooksResponse
+// @Failure      401  {string}  string "Unauthorized"
+// @Failure      429  {string}  string "Rate limited"
+// @Router       /webhooks [get]
+// @Security     BearerAuth
+func (a *API) handleListWebhooks(w http.ResponseWriter, r *http.Request) {
+	user, err := a.authenticateUser(r)
+	if err != nil {
+		a.writeAuthError(w, r, err)
+		return
+	}
+	if ok, retryAfter := a.pollLimit.AllowWithRetryAfter(user.ID); !ok {
+		writeTooManyRequests(w, retryAfter, "rate limit exceeded — max 60 requests per minute per user")
+		return
+	}
+	hooks, err := a.store.ListWebhooksByUser(r.Context(), user.ID)
+	if err != nil {
+		log.Printf("[api] ListWebhooksByUser err: user=%s err=%v", user.ID, err)
+		http.Error(w, "failed to list webhooks", http.StatusInternalServerError)
+		return
+	}
+	out := make([]map[string]interface{}, 0, len(hooks))
+	for i := range hooks {
+		out = append(out, webhookResponseFromIdentity(&hooks[i], false))
+	}
+	w.Header().Set("Content-Type", "application/json")
+	writeJSON(w, map[string]interface{}{"webhooks": out})
+}
+
+// --- GET /api/v1/webhooks/{id} ---
+
+// handleGetWebhook godoc
+// @Summary      Get webhook subscriber
+// @Tags         webhooks
+// @Produce      json
+// @Param        id path string true "Webhook ID"
+// @Success      200  {object}  WebhookResponse
+// @Failure      401  {string}  string "Unauthorized"
+// @Failure      404  {string}  string "Not found"
+// @Router       /webhooks/{id} [get]
+// @Security     BearerAuth
+func (a *API) handleGetWebhook(w http.ResponseWriter, r *http.Request) {
+	user, err := a.authenticateUser(r)
+	if err != nil {
+		a.writeAuthError(w, r, err)
+		return
+	}
+	if ok, retryAfter := a.pollLimit.AllowWithRetryAfter(user.ID); !ok {
+		writeTooManyRequests(w, retryAfter, "rate limit exceeded — max 60 requests per minute per user")
+		return
+	}
+	webhookID := mux.Vars(r)["id"]
+	wh, err := a.store.GetWebhookByID(r.Context(), webhookID, user.ID)
+	if err != nil {
+		if errors.Is(err, identity.ErrWebhookNotFound) {
+			http.Error(w, "webhook not found", http.StatusNotFound)
+			return
+		}
+		log.Printf("[api] GetWebhookByID err: %v", err)
+		http.Error(w, "failed to fetch webhook", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	writeJSON(w, webhookResponseFromIdentity(wh, false))
+}
+
+// --- PATCH /api/v1/webhooks/{id} ---
+
+// handleUpdateWebhook godoc
+// @Summary      Update webhook subscriber
+// @Description  Partial update. Fields not present are unchanged. url / events / filters are full-replace when present (no array-merge). Re-enable within 5 minutes of auto_disabled_at returns 409.
+// @Tags         webhooks
+// @Accept       json
+// @Produce      json
+// @Param        id   path string true "Webhook ID"
+// @Param        body body UpdateWebhookRequest true "Patch body"
+// @Success      200  {object}  WebhookResponse
+// @Failure      400  {string}  string "Validation error"
+// @Failure      401  {string}  string "Unauthorized"
+// @Failure      404  {string}  string "Not found"
+// @Failure      409  {string}  string "Re-enable cooldown"
+// @Router       /webhooks/{id} [patch]
+// @Security     BearerAuth
+func (a *API) handleUpdateWebhook(w http.ResponseWriter, r *http.Request) {
+	user, err := a.authenticateUser(r)
+	if err != nil {
+		a.writeAuthError(w, r, err)
+		return
+	}
+	webhookID := mux.Vars(r)["id"]
+
+	var req struct {
+		URL         *string                  `json:"url,omitempty"`
+		Events      *[]string                `json:"events,omitempty"`
+		Filters     *identity.WebhookFilters `json:"filters,omitempty"`
+		Description *string                  `json:"description,omitempty"`
+		Enabled     *bool                    `json:"enabled,omitempty"`
+	}
+	if err := readJSON(w, r, &req, maxRequestBytesSmall); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	// PATCH rejects events:[] and url:"" — caller can DELETE the
+	// webhook if they want it gone, but a webhook with no events or
+	// no URL is in a broken state.
+	if req.Events != nil && len(*req.Events) == 0 {
+		http.Error(w, "events must not be empty (PATCH with events:[] rejected; DELETE the webhook to remove it)", http.StatusBadRequest)
+		return
+	}
+	if req.URL != nil && *req.URL == "" {
+		http.Error(w, "url must not be empty", http.StatusBadRequest)
+		return
+	}
+
+	// Validate present fields against the create-time rules. We
+	// re-fetch the current row to fill in fields not being changed
+	// (validation needs the full effective state).
+	current, err := a.store.GetWebhookByID(r.Context(), webhookID, user.ID)
+	if err != nil {
+		if errors.Is(err, identity.ErrWebhookNotFound) {
+			http.Error(w, "webhook not found", http.StatusNotFound)
+			return
+		}
+		log.Printf("[api] GetWebhookByID in PATCH: %v", err)
+		http.Error(w, "failed to fetch webhook", http.StatusInternalServerError)
+		return
+	}
+	effectiveURL := current.URL
+	if req.URL != nil {
+		effectiveURL = *req.URL
+	}
+	effectiveEvents := current.Events
+	if req.Events != nil {
+		effectiveEvents = *req.Events
+	}
+	effectiveFilters := current.Filters
+	if req.Filters != nil {
+		effectiveFilters = *req.Filters
+	}
+	effectiveDesc := current.Description
+	if req.Description != nil {
+		effectiveDesc = *req.Description
+	}
+	if msg, code := a.validateWebhookFields(user, effectiveURL, effectiveEvents, effectiveFilters, effectiveDesc); msg != "" {
+		http.Error(w, msg, code)
+		return
+	}
+
+	wh, err := a.store.UpdateWebhook(r.Context(), webhookID, user.ID, identity.WebhookUpdate{
+		URL:         req.URL,
+		Events:      req.Events,
+		Filters:     req.Filters,
+		Description: req.Description,
+		Enabled:     req.Enabled,
+	})
+	if err != nil {
+		switch {
+		case errors.Is(err, identity.ErrWebhookNotFound):
+			http.Error(w, "webhook not found", http.StatusNotFound)
+		case errors.Is(err, identity.ErrWebhookCooldown):
+			// 409 Conflict matches the design's locked decision #10.
+			http.Error(w, err.Error(), http.StatusConflict)
+		default:
+			log.Printf("[api] UpdateWebhook err: %v", err)
+			http.Error(w, "failed to update webhook", http.StatusInternalServerError)
+		}
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	writeJSON(w, webhookResponseFromIdentity(wh, false))
+}
+
+// --- DELETE /api/v1/webhooks/{id} ---
+
+// handleDeleteWebhook godoc
+// @Summary      Delete webhook subscriber
+// @Description  Removes the webhook and cascades pending deliveries.
+// @Tags         webhooks
+// @Param        id path string true "Webhook ID"
+// @Success      204  "No content"
+// @Failure      401  {string}  string "Unauthorized"
+// @Failure      404  {string}  string "Not found"
+// @Router       /webhooks/{id} [delete]
+// @Security     BearerAuth
+func (a *API) handleDeleteWebhook(w http.ResponseWriter, r *http.Request) {
+	user, err := a.authenticateUser(r)
+	if err != nil {
+		a.writeAuthError(w, r, err)
+		return
+	}
+	webhookID := mux.Vars(r)["id"]
+	if err := a.store.DeleteWebhook(r.Context(), webhookID, user.ID); err != nil {
+		if errors.Is(err, identity.ErrWebhookNotFound) {
+			http.Error(w, "webhook not found", http.StatusNotFound)
+			return
+		}
+		log.Printf("[api] DeleteWebhook err: %v", err)
+		http.Error(w, "failed to delete webhook", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// --- POST /api/v1/webhooks/{id}/rotate-secret ---
+
+// handleRotateWebhookSecret godoc
+// @Summary      Rotate webhook signing secret
+// @Description  Generates a new signing secret and moves the current one into a 24h grace window during which the worker dual-signs each delivery.
+// @Tags         webhooks
+// @Produce      json
+// @Param        id path string true "Webhook ID"
+// @Success      200  {object}  RotateWebhookSecretResponse
+// @Failure      401  {string}  string "Unauthorized"
+// @Failure      404  {string}  string "Not found"
+// @Router       /webhooks/{id}/rotate-secret [post]
+// @Security     BearerAuth
+func (a *API) handleRotateWebhookSecret(w http.ResponseWriter, r *http.Request) {
+	user, err := a.authenticateUser(r)
+	if err != nil {
+		a.writeAuthError(w, r, err)
+		return
+	}
+	webhookID := mux.Vars(r)["id"]
+	newSecret, prevExpiresAt, err := a.store.RotateSecret(r.Context(), webhookID, user.ID)
+	if err != nil {
+		if errors.Is(err, identity.ErrWebhookNotFound) {
+			http.Error(w, "webhook not found", http.StatusNotFound)
+			return
+		}
+		log.Printf("[api] RotateSecret err: %v", err)
+		http.Error(w, "failed to rotate webhook secret", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	writeJSON(w, map[string]interface{}{
+		"signing_secret":             newSecret,
+		"previous_secret_expires_at": prevExpiresAt.UTC().Format(time.RFC3339),
+	})
+}
+
+// --- POST /api/v1/webhooks/{id}/test ---
+
+// handleTestWebhook godoc
+// @Summary      Fire a synthetic webhook event for development
+// @Description  Schedules a one-off delivery to the webhook with a synthetic envelope, bypassing filter matching. Returns the delivery_id so the caller can correlate it in /deliveries. Returns 409 when the webhook is disabled.
+// @Tags         webhooks
+// @Accept       json
+// @Produce      json
+// @Param        id   path string true "Webhook ID"
+// @Param        body body TestWebhookRequest true "Synthetic event"
+// @Success      200  {object}  TestWebhookResponse
+// @Failure      400  {string}  string "Bad request"
+// @Failure      401  {string}  string "Unauthorized"
+// @Failure      404  {string}  string "Not found"
+// @Failure      409  {string}  string "Webhook disabled"
+// @Router       /webhooks/{id}/test [post]
+// @Security     BearerAuth
+func (a *API) handleTestWebhook(w http.ResponseWriter, r *http.Request) {
+	if a.subscriberStore == nil {
+		http.Error(w, "test endpoint not configured", http.StatusNotFound)
+		return
+	}
+	user, err := a.authenticateUser(r)
+	if err != nil {
+		a.writeAuthError(w, r, err)
+		return
+	}
+	webhookID := mux.Vars(r)["id"]
+	wh, err := a.store.GetWebhookByID(r.Context(), webhookID, user.ID)
+	if err != nil {
+		if errors.Is(err, identity.ErrWebhookNotFound) {
+			http.Error(w, "webhook not found", http.StatusNotFound)
+			return
+		}
+		log.Printf("[api] GetWebhookByID for /test: %v", err)
+		http.Error(w, "failed to fetch webhook", http.StatusInternalServerError)
+		return
+	}
+	if !wh.Enabled {
+		// Decision: /test on a disabled webhook returns 409.
+		http.Error(w, "webhook is disabled", http.StatusConflict)
+		return
+	}
+
+	var req struct {
+		Event string                 `json:"event"`
+		Data  map[string]interface{} `json:"data"`
+	}
+	if err := readJSON(w, r, &req, maxRequestBytesSmall); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.Event == "" {
+		req.Event = webhookpub.EventEmailReceived
+	}
+	if !webhookpub.IsValidEventType(req.Event) {
+		http.Error(w, fmt.Sprintf("unknown event type %q", req.Event), http.StatusBadRequest)
+		return
+	}
+	// The /test endpoint inserts a delivery row directly — it bypasses
+	// the publisher's filter-matching logic because the test is
+	// already targeted at a specific webhook id.
+	data := req.Data
+	if data == nil {
+		data = map[string]interface{}{"test": true}
+	}
+	event := webhookpub.NewEvent(req.Event, user.ID, data)
+	envelopeJSON, err := json.Marshal(event.AsEnvelope())
+	if err != nil {
+		log.Printf("[api] /test marshal envelope: %v", err)
+		http.Error(w, "failed to marshal test event", http.StatusInternalServerError)
+		return
+	}
+
+	deliveryID, err := a.subscriberStore.InsertPendingForTest(r.Context(), wh.ID, req.Event, envelopeJSON)
+	if err != nil {
+		log.Printf("[api] /test insert delivery: %v", err)
+		http.Error(w, "failed to schedule test delivery", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	writeJSON(w, map[string]interface{}{"delivery_id": deliveryID})
+}
+
+// --- GET /api/v1/webhooks/{id}/deliveries ---
+
+// handleListWebhookDeliveries godoc
+// @Summary      List recent webhook deliveries
+// @Description  Returns the most recent delivery attempts for the webhook (capped at 100). Optional status query restricts to pending|delivered|failed.
+// @Tags         webhooks
+// @Produce      json
+// @Param        id     path  string true  "Webhook ID"
+// @Param        limit  query int    false "Page size (default 20, max 100)"
+// @Param        status query string false "Filter by status: pending|delivered|failed"
+// @Success      200  {object}  ListWebhookDeliveriesResponse
+// @Failure      400  {string}  string "Bad query"
+// @Failure      401  {string}  string "Unauthorized"
+// @Failure      404  {string}  string "Not found"
+// @Failure      429  {string}  string "Rate limited"
+// @Router       /webhooks/{id}/deliveries [get]
+// @Security     BearerAuth
+func (a *API) handleListWebhookDeliveries(w http.ResponseWriter, r *http.Request) {
+	if a.subscriberStore == nil {
+		http.Error(w, "deliveries endpoint not configured", http.StatusNotFound)
+		return
+	}
+	user, err := a.authenticateUser(r)
+	if err != nil {
+		a.writeAuthError(w, r, err)
+		return
+	}
+	if ok, retryAfter := a.pollLimit.AllowWithRetryAfter(user.ID); !ok {
+		writeTooManyRequests(w, retryAfter, "rate limit exceeded — max 60 requests per minute per user")
+		return
+	}
+	webhookID := mux.Vars(r)["id"]
+	// Confirm ownership before reading delivery rows.
+	if _, err := a.store.GetWebhookByID(r.Context(), webhookID, user.ID); err != nil {
+		if errors.Is(err, identity.ErrWebhookNotFound) {
+			http.Error(w, "webhook not found", http.StatusNotFound)
+			return
+		}
+		log.Printf("[api] GetWebhookByID for /deliveries: %v", err)
+		http.Error(w, "failed to fetch webhook", http.StatusInternalServerError)
+		return
+	}
+
+	limit := 20
+	if s := strings.TrimSpace(r.URL.Query().Get("limit")); s != "" {
+		n, err := strconv.Atoi(s)
+		if err != nil || n < 1 || n > 100 {
+			http.Error(w, "limit must be an integer in [1, 100]", http.StatusBadRequest)
+			return
+		}
+		limit = n
+	}
+	status := strings.TrimSpace(r.URL.Query().Get("status"))
+	if status != "" && status != "pending" && status != "delivered" && status != "failed" {
+		http.Error(w, "status must be one of pending|delivered|failed", http.StatusBadRequest)
+		return
+	}
+
+	rows, err := a.subscriberStore.ListDeliveriesByWebhook(r.Context(), webhookID, status, limit)
+	if err != nil {
+		log.Printf("[api] ListDeliveriesByWebhook err: %v", err)
+		http.Error(w, "failed to list deliveries", http.StatusInternalServerError)
+		return
+	}
+
+	out := make([]map[string]interface{}, 0, len(rows))
+	for _, d := range rows {
+		row := map[string]interface{}{
+			"id":          d.ID,
+			"event_type":  d.EventType,
+			"status":      d.Status,
+			"attempts":    d.Attempts,
+			"next_retry_at": d.NextRetryAt.UTC().Format(time.RFC3339),
+			"created_at":  d.CreatedAt.UTC().Format(time.RFC3339),
+		}
+		if d.LastError != "" {
+			row["last_error"] = d.LastError
+		}
+		if d.LastStatusCode != nil {
+			row["last_status_code"] = *d.LastStatusCode
+		}
+		if d.LastAttemptAt != nil {
+			row["last_attempt_at"] = d.LastAttemptAt.UTC().Format(time.RFC3339)
+		}
+		out = append(out, row)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	writeJSON(w, map[string]interface{}{"deliveries": out})
+}
+
+// --- helpers ---
+
+// webhookResponseFromIdentity builds the wire response from a stored
+// row. When includeSecret is true, the signing_secret plaintext is
+// included (POST + rotate). Every other endpoint omits it.
+func webhookResponseFromIdentity(wh *identity.Webhook, includeSecret bool) map[string]interface{} {
+	out := map[string]interface{}{
+		"id":          wh.ID,
+		"url":         wh.URL,
+		"description": wh.Description,
+		"events":      wh.Events,
+		"filters":     wh.Filters,
+		"enabled":     wh.Enabled,
+		"created_at":  wh.CreatedAt.UTC().Format(time.RFC3339),
+	}
+	if includeSecret {
+		out["signing_secret"] = wh.SigningSecret
+	}
+	if wh.AutoDisabledAt != nil {
+		out["auto_disabled_at"] = wh.AutoDisabledAt.UTC().Format(time.RFC3339)
+	}
+	if wh.LastDeliveredAt != nil {
+		out["last_delivered_at"] = wh.LastDeliveredAt.UTC().Format(time.RFC3339)
+	}
+	return out
+}

--- a/internal/agent/webhooks_api_test.go
+++ b/internal/agent/webhooks_api_test.go
@@ -343,8 +343,8 @@ func TestWebhooksAPI_Test_SchedulesDelivery(t *testing.T) {
 	var got map[string]interface{}
 	json.Unmarshal(raw, &got)
 	deliveryID, _ := got["delivery_id"].(string)
-	if !strings.HasPrefix(deliveryID, "wdl_") {
-		t.Errorf("delivery_id = %v, want wdl_ prefix", deliveryID)
+	if !strings.HasPrefix(deliveryID, "whd_") {
+		t.Errorf("delivery_id = %v, want whd_ prefix", deliveryID)
 	}
 }
 

--- a/internal/agent/webhooks_api_test.go
+++ b/internal/agent/webhooks_api_test.go
@@ -1,0 +1,398 @@
+package agent_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/agent"
+	"github.com/Mnexa-AI/e2a/internal/config"
+	"github.com/Mnexa-AI/e2a/internal/idempotency"
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/outbound"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+	"github.com/Mnexa-AI/e2a/internal/usage"
+	"github.com/Mnexa-AI/e2a/internal/webhook"
+
+	"github.com/gorilla/mux"
+	"net/http/httptest"
+)
+
+// setupWebhooksAPI wires the API the same way setupAPI does but also
+// attaches a SubscriberStore — slice-2's /test and /deliveries handlers
+// 404 if the subscriber store is not wired.
+func setupWebhooksAPI(t *testing.T) (server *httptest.Server, store *identity.Store, sub *webhook.SubscriberStore) {
+	t.Helper()
+	pool := testutil.TestDB(t)
+	store = identity.NewStore(pool)
+	smtpRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{})
+	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
+	noopUsage := usage.NewNoopUsageTracker()
+	api := agent.NewAPI(store, sender, smtpRelay, nil, noopUsage, "e2a.dev", "test.e2a.dev", "agents.e2a.dev", "", false)
+	api.SetIdempotencyStore(idempotency.NewStore(pool))
+	sub = webhook.NewSubscriberStore(pool)
+	api.SetSubscriberStore(sub)
+	router := mux.NewRouter()
+	api.RegisterRoutes(router)
+	server = httptest.NewServer(router)
+	t.Cleanup(server.Close)
+	return server, store, sub
+}
+
+// whFixture provisions one user + api key for webhook tests.
+type whFixture struct {
+	server *httptest.Server
+	store  *identity.Store
+	apiKey string
+	userID string
+}
+
+func setupWHFixture(t *testing.T, prefix string) whFixture {
+	t.Helper()
+	server, store, _ := setupWebhooksAPI(t)
+	ctx := context.Background()
+	user, err := store.CreateOrGetUser(ctx, "owner-"+prefix+"@example.com", "Owner", "google-"+prefix)
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	key, err := store.CreateAPIKey(ctx, user.ID, prefix+"-key", nil)
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+	return whFixture{server: server, store: store, apiKey: key.PlaintextKey, userID: user.ID}
+}
+
+func (f whFixture) do(t *testing.T, method, path, body string) (*http.Response, []byte) {
+	t.Helper()
+	var rdr *bytes.Buffer
+	if body != "" {
+		rdr = bytes.NewBufferString(body)
+	} else {
+		rdr = bytes.NewBuffer(nil)
+	}
+	req, _ := http.NewRequest(method, f.server.URL+path, rdr)
+	req.Header.Set("Authorization", "Bearer "+f.apiKey)
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, path, err)
+	}
+	var buf bytes.Buffer
+	buf.ReadFrom(resp.Body)
+	resp.Body.Close()
+	return resp, buf.Bytes()
+}
+
+// --- Auth ---
+
+func TestWebhooksAPI_RequiresAuth(t *testing.T) {
+	server, _, _ := setupWebhooksAPI(t)
+	for _, p := range []struct{ method, path string }{
+		{"POST", "/api/v1/webhooks"},
+		{"GET", "/api/v1/webhooks"},
+		{"GET", "/api/v1/webhooks/wh_abc"},
+		{"PATCH", "/api/v1/webhooks/wh_abc"},
+		{"DELETE", "/api/v1/webhooks/wh_abc"},
+		{"POST", "/api/v1/webhooks/wh_abc/rotate-secret"},
+		{"POST", "/api/v1/webhooks/wh_abc/test"},
+		{"GET", "/api/v1/webhooks/wh_abc/deliveries"},
+	} {
+		req, _ := http.NewRequest(p.method, server.URL+p.path, strings.NewReader("{}"))
+		resp, _ := http.DefaultClient.Do(req)
+		if resp.StatusCode != 401 {
+			t.Errorf("%s %s: status = %d, want 401", p.method, p.path, resp.StatusCode)
+		}
+		resp.Body.Close()
+	}
+}
+
+// --- Create ---
+
+func TestWebhooksAPI_Create_Success(t *testing.T) {
+	f := setupWHFixture(t, "wh-create-ok")
+	body := `{"url": "https://example.com/wh", "events": ["email.received"], "description": "test"}`
+	resp, raw := f.do(t, "POST", "/api/v1/webhooks", body)
+	if resp.StatusCode != 201 {
+		t.Fatalf("status = %d body=%s", resp.StatusCode, string(raw))
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatal(err)
+	}
+	if id, _ := got["id"].(string); !strings.HasPrefix(id, "wh_") {
+		t.Errorf("id = %v, want wh_ prefix", got["id"])
+	}
+	if secret, _ := got["signing_secret"].(string); !strings.HasPrefix(secret, "whsec_") {
+		t.Errorf("signing_secret missing or wrong format: %v", got["signing_secret"])
+	}
+	if got["enabled"] != true {
+		t.Errorf("enabled = %v, want true", got["enabled"])
+	}
+}
+
+func TestWebhooksAPI_Create_RejectsHTTP(t *testing.T) {
+	f := setupWHFixture(t, "wh-create-http")
+	body := `{"url": "http://example.com/wh", "events": ["email.received"]}`
+	resp, _ := f.do(t, "POST", "/api/v1/webhooks", body)
+	if resp.StatusCode != 400 {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestWebhooksAPI_Create_RejectsUnknownEvent(t *testing.T) {
+	f := setupWHFixture(t, "wh-create-evt")
+	body := `{"url": "https://example.com/wh", "events": ["email.bogus"]}`
+	resp, raw := f.do(t, "POST", "/api/v1/webhooks", body)
+	if resp.StatusCode != 400 {
+		t.Errorf("status = %d body=%s, want 400", resp.StatusCode, string(raw))
+	}
+}
+
+func TestWebhooksAPI_Create_RejectsEmptyEvents(t *testing.T) {
+	f := setupWHFixture(t, "wh-create-empty-evt")
+	body := `{"url": "https://example.com/wh", "events": []}`
+	resp, _ := f.do(t, "POST", "/api/v1/webhooks", body)
+	if resp.StatusCode != 400 {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+func TestWebhooksAPI_Create_RejectsCrossUserAgentID(t *testing.T) {
+	f := setupWHFixture(t, "wh-create-xuser-agent")
+	// Create a SECOND user and their agent — the fixture user must
+	// not be allowed to reference it in filters.agent_ids.
+	ctx := context.Background()
+	otherUser, _ := f.store.CreateOrGetUser(ctx, "other-wh-create-xuser@example.com", "Other", "google-other-xuser")
+	f.store.ClaimOrCreateDomain(ctx, "other-xuser.example.com", otherUser.ID)
+	f.store.VerifyDomain(ctx, "other-xuser.example.com", otherUser.ID)
+	otherAgent, _ := f.store.CreateAgent(ctx, "bot@other-xuser.example.com", "other-xuser.example.com", "", "https://example.com/webhook", "", otherUser.ID)
+
+	body := fmt.Sprintf(`{"url": "https://example.com/wh", "events": ["email.received"], "filters": {"agent_ids": [%q]}}`, otherAgent.ID)
+	resp, raw := f.do(t, "POST", "/api/v1/webhooks", body)
+	if resp.StatusCode != 400 {
+		t.Errorf("status = %d body=%s, want 400 (cross-user agent)", resp.StatusCode, string(raw))
+	}
+}
+
+// --- List / Get ---
+
+func TestWebhooksAPI_ListAndGet_OmitSecret(t *testing.T) {
+	f := setupWHFixture(t, "wh-list")
+	create := `{"url": "https://example.com/wh", "events": ["email.received"]}`
+	resp, raw := f.do(t, "POST", "/api/v1/webhooks", create)
+	if resp.StatusCode != 201 {
+		t.Fatalf("create: %d %s", resp.StatusCode, string(raw))
+	}
+	var created map[string]interface{}
+	json.Unmarshal(raw, &created)
+	whID := created["id"].(string)
+
+	// LIST
+	resp, raw = f.do(t, "GET", "/api/v1/webhooks", "")
+	if resp.StatusCode != 200 {
+		t.Fatalf("list: %d", resp.StatusCode)
+	}
+	var listed map[string]interface{}
+	json.Unmarshal(raw, &listed)
+	hooks, _ := listed["webhooks"].([]interface{})
+	if len(hooks) != 1 {
+		t.Fatalf("want 1 webhook, got %d", len(hooks))
+	}
+	if first, _ := hooks[0].(map[string]interface{}); first["signing_secret"] != nil {
+		t.Errorf("LIST should scrub signing_secret, got %v", first["signing_secret"])
+	}
+
+	// GET
+	resp, raw = f.do(t, "GET", "/api/v1/webhooks/"+whID, "")
+	if resp.StatusCode != 200 {
+		t.Fatalf("get: %d", resp.StatusCode)
+	}
+	var fetched map[string]interface{}
+	json.Unmarshal(raw, &fetched)
+	if fetched["signing_secret"] != nil {
+		t.Errorf("GET should scrub signing_secret, got %v", fetched["signing_secret"])
+	}
+}
+
+func TestWebhooksAPI_Get_CrossUser404(t *testing.T) {
+	f := setupWHFixture(t, "wh-get-xuser")
+	// Create as user A.
+	create := `{"url": "https://example.com/wh", "events": ["email.received"]}`
+	_, raw := f.do(t, "POST", "/api/v1/webhooks", create)
+	var created map[string]interface{}
+	json.Unmarshal(raw, &created)
+	whID := created["id"].(string)
+
+	// Make a second user fixture sharing the same server.
+	ctx := context.Background()
+	otherUser, _ := f.store.CreateOrGetUser(ctx, "other-wh-get@example.com", "Other", "google-other-wh-get")
+	otherKey, _ := f.store.CreateAPIKey(ctx, otherUser.ID, "other-key", nil)
+	req, _ := http.NewRequest("GET", f.server.URL+"/api/v1/webhooks/"+whID, nil)
+	req.Header.Set("Authorization", "Bearer "+otherKey.PlaintextKey)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	if resp.StatusCode != 404 {
+		t.Errorf("cross-user GET status = %d, want 404", resp.StatusCode)
+	}
+}
+
+// --- Patch ---
+
+func TestWebhooksAPI_Patch_PartialUpdate(t *testing.T) {
+	f := setupWHFixture(t, "wh-patch")
+	create := `{"url": "https://example.com/wh", "events": ["email.received"], "description": "old"}`
+	_, raw := f.do(t, "POST", "/api/v1/webhooks", create)
+	var created map[string]interface{}
+	json.Unmarshal(raw, &created)
+	whID := created["id"].(string)
+
+	patch := `{"description": "new desc", "enabled": false}`
+	resp, raw := f.do(t, "PATCH", "/api/v1/webhooks/"+whID, patch)
+	if resp.StatusCode != 200 {
+		t.Fatalf("patch: %d %s", resp.StatusCode, string(raw))
+	}
+	var updated map[string]interface{}
+	json.Unmarshal(raw, &updated)
+	if updated["description"] != "new desc" {
+		t.Errorf("description = %v, want 'new desc'", updated["description"])
+	}
+	if updated["enabled"] != false {
+		t.Errorf("enabled = %v, want false", updated["enabled"])
+	}
+}
+
+func TestWebhooksAPI_Patch_RejectsEmptyEvents(t *testing.T) {
+	f := setupWHFixture(t, "wh-patch-emptyev")
+	_, raw := f.do(t, "POST", "/api/v1/webhooks", `{"url":"https://example.com/wh","events":["email.received"]}`)
+	var created map[string]interface{}
+	json.Unmarshal(raw, &created)
+	whID := created["id"].(string)
+	resp, _ := f.do(t, "PATCH", "/api/v1/webhooks/"+whID, `{"events": []}`)
+	if resp.StatusCode != 400 {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+}
+
+// --- Delete ---
+
+func TestWebhooksAPI_Delete(t *testing.T) {
+	f := setupWHFixture(t, "wh-del")
+	_, raw := f.do(t, "POST", "/api/v1/webhooks", `{"url":"https://example.com/wh","events":["email.received"]}`)
+	var created map[string]interface{}
+	json.Unmarshal(raw, &created)
+	whID := created["id"].(string)
+	resp, _ := f.do(t, "DELETE", "/api/v1/webhooks/"+whID, "")
+	if resp.StatusCode != 204 {
+		t.Errorf("delete status = %d, want 204", resp.StatusCode)
+	}
+	// Second delete -> 404
+	resp, _ = f.do(t, "DELETE", "/api/v1/webhooks/"+whID, "")
+	if resp.StatusCode != 404 {
+		t.Errorf("idempotent delete status = %d, want 404", resp.StatusCode)
+	}
+}
+
+// --- Rotate secret ---
+
+func TestWebhooksAPI_RotateSecret_ReturnsNewPlaintext(t *testing.T) {
+	f := setupWHFixture(t, "wh-rotate")
+	_, raw := f.do(t, "POST", "/api/v1/webhooks", `{"url":"https://example.com/wh","events":["email.received"]}`)
+	var created map[string]interface{}
+	json.Unmarshal(raw, &created)
+	whID := created["id"].(string)
+	origSecret := created["signing_secret"].(string)
+
+	resp, raw := f.do(t, "POST", "/api/v1/webhooks/"+whID+"/rotate-secret", "")
+	if resp.StatusCode != 200 {
+		t.Fatalf("rotate: %d %s", resp.StatusCode, string(raw))
+	}
+	var got map[string]interface{}
+	json.Unmarshal(raw, &got)
+	newSecret, _ := got["signing_secret"].(string)
+	if !strings.HasPrefix(newSecret, "whsec_") {
+		t.Errorf("new secret missing whsec_ prefix: %s", newSecret)
+	}
+	if newSecret == origSecret {
+		t.Errorf("rotate returned the same secret")
+	}
+	if _, ok := got["previous_secret_expires_at"].(string); !ok {
+		t.Errorf("previous_secret_expires_at missing or not string")
+	}
+}
+
+// --- Test endpoint ---
+
+func TestWebhooksAPI_Test_SchedulesDelivery(t *testing.T) {
+	f := setupWHFixture(t, "wh-test")
+	_, raw := f.do(t, "POST", "/api/v1/webhooks", `{"url":"https://example.com/wh","events":["email.received"]}`)
+	var created map[string]interface{}
+	json.Unmarshal(raw, &created)
+	whID := created["id"].(string)
+
+	resp, raw := f.do(t, "POST", "/api/v1/webhooks/"+whID+"/test",
+		`{"event": "email.received", "data": {"foo": "bar"}}`)
+	if resp.StatusCode != 200 {
+		t.Fatalf("test: %d %s", resp.StatusCode, string(raw))
+	}
+	var got map[string]interface{}
+	json.Unmarshal(raw, &got)
+	deliveryID, _ := got["delivery_id"].(string)
+	if !strings.HasPrefix(deliveryID, "wdl_") {
+		t.Errorf("delivery_id = %v, want wdl_ prefix", deliveryID)
+	}
+}
+
+func TestWebhooksAPI_Test_DisabledWebhookReturns409(t *testing.T) {
+	f := setupWHFixture(t, "wh-test-disabled")
+	_, raw := f.do(t, "POST", "/api/v1/webhooks", `{"url":"https://example.com/wh","events":["email.received"]}`)
+	var created map[string]interface{}
+	json.Unmarshal(raw, &created)
+	whID := created["id"].(string)
+	// Disable.
+	f.do(t, "PATCH", "/api/v1/webhooks/"+whID, `{"enabled": false}`)
+	resp, _ := f.do(t, "POST", "/api/v1/webhooks/"+whID+"/test", `{}`)
+	if resp.StatusCode != 409 {
+		t.Errorf("status = %d, want 409", resp.StatusCode)
+	}
+}
+
+// --- Deliveries list ---
+
+func TestWebhooksAPI_Deliveries_Lists(t *testing.T) {
+	f := setupWHFixture(t, "wh-deliveries")
+	_, raw := f.do(t, "POST", "/api/v1/webhooks", `{"url":"https://example.com/wh","events":["email.received"]}`)
+	var created map[string]interface{}
+	json.Unmarshal(raw, &created)
+	whID := created["id"].(string)
+
+	// Trigger /test to seed a row.
+	f.do(t, "POST", "/api/v1/webhooks/"+whID+"/test", `{}`)
+	resp, raw := f.do(t, "GET", "/api/v1/webhooks/"+whID+"/deliveries", "")
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d body=%s", resp.StatusCode, string(raw))
+	}
+	var got map[string]interface{}
+	json.Unmarshal(raw, &got)
+	dels, _ := got["deliveries"].([]interface{})
+	if len(dels) < 1 {
+		t.Errorf("expected at least 1 delivery, got %d", len(dels))
+	}
+}
+
+func TestWebhooksAPI_Deliveries_RejectsBadStatus(t *testing.T) {
+	f := setupWHFixture(t, "wh-deliveries-badstatus")
+	_, raw := f.do(t, "POST", "/api/v1/webhooks", `{"url":"https://example.com/wh","events":["email.received"]}`)
+	var created map[string]interface{}
+	json.Unmarshal(raw, &created)
+	whID := created["id"].(string)
+	resp, _ := f.do(t, "GET", "/api/v1/webhooks/"+whID+"/deliveries?status=bogus", "")
+	if resp.StatusCode != 400 {
+		t.Errorf("status = %d, want 400", resp.StatusCode)
+	}
+}

--- a/internal/agent/webhooks_events_test.go
+++ b/internal/agent/webhooks_events_test.go
@@ -1,0 +1,171 @@
+package agent
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/outbound"
+	"github.com/Mnexa-AI/e2a/internal/webhookpub"
+)
+
+// fakePublisher captures Publish calls so the tests can assert on the
+// envelope without spinning up a DB.
+type fakePublisher struct {
+	mu     sync.Mutex
+	events []webhookpub.Event
+}
+
+func (f *fakePublisher) Publish(_ context.Context, e webhookpub.Event) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.events = append(f.events, e)
+}
+
+func (f *fakePublisher) wait(t *testing.T, n int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		f.mu.Lock()
+		l := len(f.events)
+		f.mu.Unlock()
+		if l >= n {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("publisher: timed out waiting for %d events (got %d)", n, len(f.events))
+}
+
+func TestPublishAsync_NilPublisherIsNoOp(t *testing.T) {
+	a := &API{}
+	// Should not panic.
+	a.publishAsync(webhookpub.Event{Type: "email.sent"})
+}
+
+func TestBuildSentEvent_PopulatesEnvelope(t *testing.T) {
+	a := &API{}
+	agent := &identity.AgentIdentity{
+		ID:     "bot@x.example.com",
+		Domain: "x.example.com",
+		UserID: "u_1",
+	}
+	outMsg := &identity.Message{ID: "msg_1"}
+	res := &outbound.SendResult{
+		MessageID: "ses_1",
+		Method:    "smtp",
+		To:        []string{"alice@example.com"},
+	}
+	req := outbound.SendRequest{
+		To:             []string{"alice@example.com"},
+		Subject:        "hello",
+		ConversationID: "conv_42",
+	}
+	ev := a.buildSentEvent(agent, outMsg, res, req, "send")
+	if ev.Type != webhookpub.EventEmailSent {
+		t.Errorf("Type = %q, want email.sent", ev.Type)
+	}
+	if ev.UserID != "u_1" {
+		t.Errorf("UserID = %q, want u_1", ev.UserID)
+	}
+	if ev.AgentID != agent.ID {
+		t.Errorf("AgentID = %q, want %q", ev.AgentID, agent.ID)
+	}
+	if ev.MessageID != "msg_1" {
+		t.Errorf("MessageID = %q, want msg_1", ev.MessageID)
+	}
+	if ev.ConversationID != "conv_42" {
+		t.Errorf("ConversationID = %q, want conv_42", ev.ConversationID)
+	}
+	data, ok := ev.Data.(map[string]interface{})
+	if !ok {
+		t.Fatalf("Data is not a map: %T", ev.Data)
+	}
+	if data["subject"] != "hello" {
+		t.Errorf("subject = %v, want hello", data["subject"])
+	}
+}
+
+func TestBuildSentEvent_NilOutMsgUsesEmptyMessageID(t *testing.T) {
+	a := &API{}
+	agent := &identity.AgentIdentity{ID: "bot@x.example.com", UserID: "u_1"}
+	res := &outbound.SendResult{MessageID: "ses_2", Method: "smtp"}
+	ev := a.buildSentEvent(agent, nil, res, outbound.SendRequest{}, "send")
+	if ev.MessageID != "" {
+		t.Errorf("MessageID should be empty when outMsg is nil, got %q", ev.MessageID)
+	}
+}
+
+func TestBuildPendingApprovalEvent(t *testing.T) {
+	a := &API{}
+	agent := &identity.AgentIdentity{ID: "bot@x.example.com", UserID: "u_1"}
+	expiry := time.Now().Add(1 * time.Hour)
+	msg := &identity.Message{ID: "pend_1", ApprovalExpiresAt: &expiry}
+	req := outbound.SendRequest{To: []string{"alice@example.com"}, Subject: "review me"}
+	ev := a.buildPendingApprovalEvent(agent, msg, req, "send")
+	if ev.Type != webhookpub.EventEmailPendingApproval {
+		t.Errorf("Type = %q, want email.pending_approval", ev.Type)
+	}
+	if ev.MessageID != "pend_1" {
+		t.Errorf("MessageID = %q, want pend_1", ev.MessageID)
+	}
+	if ev.UserID != "u_1" {
+		t.Errorf("UserID = %q", ev.UserID)
+	}
+}
+
+func TestBuildApprovedEvent(t *testing.T) {
+	a := &API{}
+	agent := &identity.AgentIdentity{ID: "bot@x.example.com", UserID: "u_1"}
+	sent := &identity.Message{
+		ID:                "msg_a",
+		Subject:           "hi",
+		Type:              "send",
+		ProviderMessageID: "ses_a",
+		Method:            "smtp",
+		ToRecipients:      []string{"alice@example.com"},
+		Edited:            true,
+	}
+	ev := a.buildApprovedEvent(agent, sent, "u_reviewer")
+	if ev.Type != webhookpub.EventEmailApproved {
+		t.Errorf("Type = %q", ev.Type)
+	}
+	if ev.MessageID != "msg_a" {
+		t.Errorf("MessageID = %q", ev.MessageID)
+	}
+	data := ev.Data.(map[string]interface{})
+	if data["edited"] != true {
+		t.Errorf("edited = %v, want true", data["edited"])
+	}
+	if data["reviewed_by_user_id"] != "u_reviewer" {
+		t.Errorf("reviewed_by_user_id = %v", data["reviewed_by_user_id"])
+	}
+}
+
+func TestBuildRejectedEvent(t *testing.T) {
+	a := &API{}
+	rejected := &identity.Message{ID: "msg_r", AgentID: "bot@x.example.com", Type: "send"}
+	ev := a.buildRejectedEvent("u_reviewer", rejected, "off-policy")
+	if ev.Type != webhookpub.EventEmailRejected {
+		t.Errorf("Type = %q", ev.Type)
+	}
+	if ev.MessageID != "msg_r" {
+		t.Errorf("MessageID = %q", ev.MessageID)
+	}
+	data := ev.Data.(map[string]interface{})
+	if data["rejection_reason"] != "off-policy" {
+		t.Errorf("rejection_reason = %v", data["rejection_reason"])
+	}
+}
+
+func TestPublishAsync_DispatchesViaPublisher(t *testing.T) {
+	fp := &fakePublisher{}
+	a := &API{publisher: fp}
+	a.publishAsync(webhookpub.Event{Type: webhookpub.EventEmailSent, UserID: "u_1"})
+	fp.wait(t, 1)
+	if fp.events[0].Type != webhookpub.EventEmailSent {
+		t.Errorf("Type = %q", fp.events[0].Type)
+	}
+}

--- a/internal/identity/webhooks.go
+++ b/internal/identity/webhooks.go
@@ -337,6 +337,151 @@ func (s *Store) MaxWebhooksForUser(ctx context.Context, userID string) (int, err
 	return *n, nil
 }
 
+// WebhookUpdate carries the fields a PATCH can change. All fields are
+// pointers (or "set-or-leave" flags) so handlers can distinguish
+// "field present, set to X" from "field not present, leave unchanged".
+//
+// Per the design, url / events / filters are full-replace fields (the
+// sent value is canonical when present). Enabled is a toggle. Re-enable
+// has a 5-minute cooldown — UpdateWebhook returns ErrWebhookCooldown
+// when the caller tries to flip Enabled true within 5 minutes of
+// auto_disabled_at.
+type WebhookUpdate struct {
+	URL         *string
+	Description *string
+	Events      *[]string
+	Filters     *WebhookFilters
+	Enabled     *bool
+}
+
+// ErrWebhookCooldown is returned when a PATCH would re-enable a
+// webhook that was auto-disabled within the last 5 minutes. Slice 4
+// adds the auto-disable worker; this error type lands now so the
+// handler doesn't need to map magic strings later.
+var ErrWebhookCooldown = errors.New("webhook was auto-disabled within the last 5 minutes; wait before re-enabling")
+
+// reEnableCooldown is the minimum delay between auto_disabled_at and
+// a PATCH that flips enabled back to true. Decision #10.
+const reEnableCooldown = 5 * time.Minute
+
+// UpdateWebhook applies a partial update to a webhook. Only fields
+// with a non-nil pointer in WebhookUpdate are touched. Returns the
+// updated row.
+//
+// Validation (charset, count caps, agent ownership) is the handler's
+// job; the storage layer enforces only the re-enable cooldown and
+// the per-row CHECK constraints (events non-empty, url non-empty).
+func (s *Store) UpdateWebhook(ctx context.Context, webhookID, userID string, u WebhookUpdate) (*Webhook, error) {
+	// Re-enable cooldown — read the current state once before
+	// running the UPDATE so we can return a typed error.
+	if u.Enabled != nil && *u.Enabled {
+		var autoDisabledAt *time.Time
+		err := s.pool.QueryRow(ctx,
+			`SELECT auto_disabled_at FROM webhooks WHERE id = $1 AND user_id = $2`,
+			webhookID, userID,
+		).Scan(&autoDisabledAt)
+		if err != nil {
+			if errors.Is(err, pgx.ErrNoRows) {
+				return nil, ErrWebhookNotFound
+			}
+			return nil, err
+		}
+		if autoDisabledAt != nil && time.Since(*autoDisabledAt) < reEnableCooldown {
+			return nil, ErrWebhookCooldown
+		}
+	}
+
+	// Build a dynamic UPDATE based on which fields are present. Using
+	// COALESCE keeps the query simple at the cost of always touching
+	// every column; at slice-1 webhook counts this isn't a concern.
+	args := []interface{}{webhookID, userID}
+	sets := []string{}
+	add := func(col string, val interface{}) {
+		args = append(args, val)
+		sets = append(sets, fmt.Sprintf("%s = $%d", col, len(args)))
+	}
+	if u.URL != nil {
+		add("url", *u.URL)
+	}
+	if u.Description != nil {
+		add("description", *u.Description)
+	}
+	if u.Events != nil {
+		add("events", *u.Events)
+	}
+	if u.Filters != nil {
+		filtersJSON, err := json.Marshal(*u.Filters)
+		if err != nil {
+			return nil, fmt.Errorf("marshal filters: %w", err)
+		}
+		add("filters", filtersJSON)
+	}
+	if u.Enabled != nil {
+		add("enabled", *u.Enabled)
+		// Re-enabling clears auto_disabled_at so a subsequent fail
+		// burst can re-trip it cleanly.
+		if *u.Enabled {
+			args = append(args, nil)
+			sets = append(sets, fmt.Sprintf("auto_disabled_at = $%d", len(args)))
+		}
+	}
+
+	if len(sets) == 0 {
+		// No-op PATCH. Return the current row.
+		return s.GetWebhookByID(ctx, webhookID, userID)
+	}
+
+	query := fmt.Sprintf(
+		`UPDATE webhooks SET %s WHERE id = $1 AND user_id = $2 RETURNING id`,
+		joinComma(sets),
+	)
+	var returnedID string
+	if err := s.pool.QueryRow(ctx, query, args...).Scan(&returnedID); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrWebhookNotFound
+		}
+		return nil, err
+	}
+	return s.GetWebhookByID(ctx, webhookID, userID)
+}
+
+func joinComma(parts []string) string {
+	out := ""
+	for i, p := range parts {
+		if i > 0 {
+			out += ", "
+		}
+		out += p
+	}
+	return out
+}
+
+// RotateSecret generates a new signing secret, moves the current
+// secret into signing_secret_prev with a 24h expiry, and returns
+// the new plaintext (shown once). During the 24h grace window the
+// delivery worker dual-signs each request so receivers can verify
+// with either secret while they update their handler.
+func (s *Store) RotateSecret(ctx context.Context, webhookID, userID string) (newPlaintext string, prevExpiresAt time.Time, err error) {
+	newPlaintext = generateWebhookSecret()
+	prevExpiresAt = time.Now().Add(24 * time.Hour)
+
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE webhooks
+		 SET signing_secret_prev = signing_secret,
+		     signing_secret_prev_expires_at = $3,
+		     signing_secret = $4
+		 WHERE id = $1 AND user_id = $2`,
+		webhookID, userID, prevExpiresAt, newPlaintext,
+	)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	if tag.RowsAffected() == 0 {
+		return "", time.Time{}, ErrWebhookNotFound
+	}
+	return newPlaintext, prevExpiresAt, nil
+}
+
 // DeleteWebhook removes a webhook owned by the user. Idempotent:
 // deleting a non-existent or cross-user webhook returns
 // ErrWebhookNotFound, never silently succeeds. The ON DELETE CASCADE

--- a/internal/identity/webhooks.go
+++ b/internal/identity/webhooks.go
@@ -1,0 +1,361 @@
+package identity
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// --- Webhook resource (top-level webhooks-as-a-resource feature) ---
+//
+// A Webhook is one subscriber row in the new /api/v1/webhooks resource.
+// It is owned by a user (cross-user reads return ErrWebhookNotFound to
+// avoid leaking existence), can subscribe to one or more event types,
+// and applies scope filters (agent_ids, conversation_ids, labels) to
+// further narrow which events fire to it.
+//
+// The legacy agent_identities.webhook_url field continues to work
+// unchanged in slice 1; the publisher fires events to both pathways
+// side-by-side. See the final design at tmp/e2a_webhooks_design.md for
+// the full feature scope.
+
+// WebhookFilters is the structured form of webhooks.filters JSONB.
+// Empty / nil slices mean "no constraint of that type" — a webhook
+// with all-empty filters is a cross-cutting subscriber that matches
+// every event of the right type for the owning user.
+type WebhookFilters struct {
+	AgentIDs        []string `json:"agent_ids,omitempty"`
+	ConversationIDs []string `json:"conversation_ids,omitempty"`
+	Labels          []string `json:"labels,omitempty"`
+}
+
+// Webhook is one row in the webhooks table.
+//
+// SigningSecret carries the plaintext secret. It's populated on
+// CreateWebhook responses (the caller's one chance to see the secret)
+// and read by the delivery worker when signing the X-E2A-Signature
+// header. Public API GET endpoints in slice 2 will scrub this field
+// before responding so a stolen API key cannot exfiltrate webhook
+// secrets via list/get.
+//
+// SigningSecretPrev + SigningSecretPrevExpiresAt hold the previous
+// secret during the 24h rotation grace window; slice 4 dual-signs
+// using both during that window so receivers can roll forward.
+type Webhook struct {
+	ID                          string          `json:"id"`
+	UserID                      string          `json:"user_id"`
+	URL                         string          `json:"url"`
+	Description                 string          `json:"description"`
+	Events                      []string        `json:"events"`
+	Filters                     WebhookFilters  `json:"filters"`
+	SigningSecret               string          `json:"signing_secret,omitempty"`
+	SigningSecretPrev           string          `json:"-"`
+	SigningSecretPrevExpiresAt  *time.Time      `json:"-"`
+	Enabled                     bool            `json:"enabled"`
+	AutoDisabledAt              *time.Time      `json:"auto_disabled_at,omitempty"`
+	CreatedAt                   time.Time       `json:"created_at"`
+	LastDeliveredAt             *time.Time      `json:"last_delivered_at,omitempty"`
+}
+
+// Sentinel errors so API handlers can map error → HTTP status with
+// errors.Is rather than string-matching.
+var (
+	ErrWebhookNotFound    = errors.New("webhook not found")
+	ErrWebhookCapReached  = errors.New("webhook count limit reached for this user")
+)
+
+// generateWebhookID and generateWebhookSecret produce the prefixed IDs
+// and secrets used by the webhooks API. Both use crypto/rand and
+// panic on OS RNG failure — same pattern as generateID +
+// generateAPIKey in store.go (an all-zero secret is catastrophic).
+func generateWebhookID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		panic(fmt.Sprintf("identity: crypto/rand failed: %v", err))
+	}
+	return "wh_" + hex.EncodeToString(b)
+}
+
+// generateWebhookSecret returns a prefixed secret of the form whsec_<64-hex>.
+// The whsec_ prefix matches Stripe's convention so secret-scanning tools
+// (GitGuardian, GitHub secret scanning, etc.) can recognize the format.
+// 32 bytes of entropy is plenty for HMAC-SHA256 keying.
+func generateWebhookSecret() string {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		panic(fmt.Sprintf("identity: crypto/rand failed: %v", err))
+	}
+	return "whsec_" + hex.EncodeToString(b)
+}
+
+// CreateWebhook inserts a new row and returns it with the plaintext
+// signing secret populated. The plaintext is only available on this
+// response — subsequent GET/list calls scrub it.
+//
+// Filters validation (charset, count caps, agent ownership) is the
+// handler's job in slice 2; the storage layer only verifies the
+// per-user count cap from account_limits.max_webhooks.
+func (s *Store) CreateWebhook(ctx context.Context, userID, url, description string, events []string, filters WebhookFilters) (*Webhook, error) {
+	// Enforce the per-user cap before generating any state. Race
+	// across concurrent creates is bounded by the cap + 1 in the
+	// worst case; an exact race-free check would need SELECT FOR
+	// UPDATE on a sentinel row, which is not worth it for a cap of
+	// 50. The race-window cost is "one user briefly has 51 webhooks"
+	// — acceptable.
+	max, err := s.MaxWebhooksForUser(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	count, err := s.CountWebhooksByUser(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+	if count >= max {
+		return nil, ErrWebhookCapReached
+	}
+
+	filtersJSON, err := json.Marshal(filters)
+	if err != nil {
+		return nil, fmt.Errorf("marshal filters: %w", err)
+	}
+
+	w := &Webhook{
+		ID:            generateWebhookID(),
+		UserID:        userID,
+		URL:           url,
+		Description:   description,
+		Events:        events,
+		Filters:       filters,
+		SigningSecret: generateWebhookSecret(),
+		Enabled:       true,
+		CreatedAt:     time.Now(),
+	}
+	if _, err := s.pool.Exec(ctx,
+		`INSERT INTO webhooks (id, user_id, url, description, events, filters, signing_secret, enabled, created_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		w.ID, w.UserID, w.URL, w.Description, w.Events, filtersJSON, w.SigningSecret, w.Enabled, w.CreatedAt,
+	); err != nil {
+		return nil, fmt.Errorf("insert webhook: %w", err)
+	}
+	return w, nil
+}
+
+// GetWebhookByID returns the webhook iff it's owned by userID. Cross-
+// user reads (or missing rows) return ErrWebhookNotFound — same
+// not-found-on-cross-user convention used elsewhere in the codebase
+// (conversation reads, message reads).
+//
+// The returned Webhook has SigningSecret populated for the delivery
+// worker's benefit; the public API layer scrubs this field before
+// responding to GETs.
+func (s *Store) GetWebhookByID(ctx context.Context, webhookID, userID string) (*Webhook, error) {
+	w := &Webhook{}
+	var filtersJSON []byte
+	err := s.pool.QueryRow(ctx,
+		`SELECT id, user_id, url, description, events, filters,
+		        signing_secret, COALESCE(signing_secret_prev, ''),
+		        signing_secret_prev_expires_at,
+		        enabled, auto_disabled_at, created_at, last_delivered_at
+		 FROM webhooks WHERE id = $1 AND user_id = $2`,
+		webhookID, userID,
+	).Scan(
+		&w.ID, &w.UserID, &w.URL, &w.Description, &w.Events, &filtersJSON,
+		&w.SigningSecret, &w.SigningSecretPrev,
+		&w.SigningSecretPrevExpiresAt,
+		&w.Enabled, &w.AutoDisabledAt, &w.CreatedAt, &w.LastDeliveredAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrWebhookNotFound
+		}
+		return nil, err
+	}
+	if err := json.Unmarshal(filtersJSON, &w.Filters); err != nil {
+		return nil, fmt.Errorf("unmarshal filters: %w", err)
+	}
+	return w, nil
+}
+
+// GetWebhookByIDInternal returns the webhook by ID with no ownership
+// check. INTERNAL USE ONLY — handler code MUST use GetWebhookByID
+// which scopes by user_id. The retry worker uses this to look up the
+// URL + signing secret for a delivery row whose ownership was already
+// established when the publisher inserted it.
+//
+// The suffix Internal mirrors the convention in dkim.GetDKIMKeyInternal:
+// a method name that calls out "skipping the standard authorization
+// check" so a reviewer doesn't have to read the body to know why.
+func (s *Store) GetWebhookByIDInternal(ctx context.Context, webhookID string) (*Webhook, error) {
+	w := &Webhook{}
+	var filtersJSON []byte
+	err := s.pool.QueryRow(ctx,
+		`SELECT id, user_id, url, description, events, filters,
+		        signing_secret, COALESCE(signing_secret_prev, ''),
+		        signing_secret_prev_expires_at,
+		        enabled, auto_disabled_at, created_at, last_delivered_at
+		 FROM webhooks WHERE id = $1`,
+		webhookID,
+	).Scan(
+		&w.ID, &w.UserID, &w.URL, &w.Description, &w.Events, &filtersJSON,
+		&w.SigningSecret, &w.SigningSecretPrev,
+		&w.SigningSecretPrevExpiresAt,
+		&w.Enabled, &w.AutoDisabledAt, &w.CreatedAt, &w.LastDeliveredAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrWebhookNotFound
+		}
+		return nil, err
+	}
+	if err := json.Unmarshal(filtersJSON, &w.Filters); err != nil {
+		return nil, fmt.Errorf("unmarshal filters: %w", err)
+	}
+	return w, nil
+}
+
+// ListWebhooksByUser returns every webhook owned by the user — used
+// by the slice-2 GET /api/v1/webhooks endpoint. Storage layer surfaces
+// enabled and disabled rows alike; filter at the handler if needed.
+func (s *Store) ListWebhooksByUser(ctx context.Context, userID string) ([]Webhook, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT id, user_id, url, description, events, filters,
+		        signing_secret, COALESCE(signing_secret_prev, ''),
+		        signing_secret_prev_expires_at,
+		        enabled, auto_disabled_at, created_at, last_delivered_at
+		 FROM webhooks WHERE user_id = $1 ORDER BY created_at DESC`,
+		userID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []Webhook
+	for rows.Next() {
+		var w Webhook
+		var filtersJSON []byte
+		if err := rows.Scan(
+			&w.ID, &w.UserID, &w.URL, &w.Description, &w.Events, &filtersJSON,
+			&w.SigningSecret, &w.SigningSecretPrev,
+			&w.SigningSecretPrevExpiresAt,
+			&w.Enabled, &w.AutoDisabledAt, &w.CreatedAt, &w.LastDeliveredAt,
+		); err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal(filtersJSON, &w.Filters); err != nil {
+			return nil, fmt.Errorf("unmarshal filters: %w", err)
+		}
+		out = append(out, w)
+	}
+	return out, rows.Err()
+}
+
+// ListEnabledWebhooksForRouting is the hot-path query used by the
+// event publisher. Returns enabled webhooks for the user that
+// subscribe to the given event type. The in-process publisher then
+// applies filter matching in Go (cheaper than encoding the
+// AND-across-types + OR-within-type rule in SQL at slice-1 scale).
+//
+// The partial index idx_webhooks_user_enabled WHERE enabled = true
+// keeps this O(log n) on the common case (a user has a small number
+// of enabled webhooks).
+func (s *Store) ListEnabledWebhooksForRouting(ctx context.Context, userID, eventType string) ([]Webhook, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT id, user_id, url, description, events, filters,
+		        signing_secret, COALESCE(signing_secret_prev, ''),
+		        signing_secret_prev_expires_at,
+		        enabled, auto_disabled_at, created_at, last_delivered_at
+		 FROM webhooks
+		 WHERE user_id = $1 AND enabled = true AND $2 = ANY(events)`,
+		userID, eventType,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []Webhook
+	for rows.Next() {
+		var w Webhook
+		var filtersJSON []byte
+		if err := rows.Scan(
+			&w.ID, &w.UserID, &w.URL, &w.Description, &w.Events, &filtersJSON,
+			&w.SigningSecret, &w.SigningSecretPrev,
+			&w.SigningSecretPrevExpiresAt,
+			&w.Enabled, &w.AutoDisabledAt, &w.CreatedAt, &w.LastDeliveredAt,
+		); err != nil {
+			return nil, err
+		}
+		if err := json.Unmarshal(filtersJSON, &w.Filters); err != nil {
+			return nil, fmt.Errorf("unmarshal filters: %w", err)
+		}
+		out = append(out, w)
+	}
+	return out, rows.Err()
+}
+
+// CountWebhooksByUser returns the total number of webhooks (enabled +
+// disabled) the user owns. Used by CreateWebhook to enforce the
+// per-user cap from account_limits.max_webhooks.
+func (s *Store) CountWebhooksByUser(ctx context.Context, userID string) (int, error) {
+	var n int
+	err := s.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM webhooks WHERE user_id = $1`, userID,
+	).Scan(&n)
+	if err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+// MaxWebhooksForUser returns the per-user cap from account_limits.
+// Users without an account_limits row default to 50 — the column
+// DEFAULT, mirrored here as a fallback so the cap works on dev
+// installs that haven't seeded an account_limits row.
+const DefaultMaxWebhooks = 50
+
+func (s *Store) MaxWebhooksForUser(ctx context.Context, userID string) (int, error) {
+	var n *int
+	err := s.pool.QueryRow(ctx,
+		`SELECT max_webhooks FROM account_limits WHERE user_id = $1`, userID,
+	).Scan(&n)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return DefaultMaxWebhooks, nil
+		}
+		return 0, err
+	}
+	if n == nil {
+		return DefaultMaxWebhooks, nil
+	}
+	return *n, nil
+}
+
+// DeleteWebhook removes a webhook owned by the user. Idempotent:
+// deleting a non-existent or cross-user webhook returns
+// ErrWebhookNotFound, never silently succeeds. The ON DELETE CASCADE
+// on webhook_subscriber_deliveries.webhook_id drops pending delivery
+// rows automatically — no separate cleanup needed.
+//
+// Slice 1 includes this method (rather than deferring to slice 2's
+// handler work) because tests need it for setup teardown and the
+// implementation is trivial.
+func (s *Store) DeleteWebhook(ctx context.Context, webhookID, userID string) error {
+	tag, err := s.pool.Exec(ctx,
+		`DELETE FROM webhooks WHERE id = $1 AND user_id = $2`,
+		webhookID, userID,
+	)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrWebhookNotFound
+	}
+	return nil
+}

--- a/internal/identity/webhooks.go
+++ b/internal/identity/webhooks.go
@@ -482,6 +482,77 @@ func (s *Store) RotateSecret(ctx context.Context, webhookID, userID string) (new
 	return newPlaintext, prevExpiresAt, nil
 }
 
+// AutoDisableThreshold is the consecutive-failed-events count over
+// AutoDisableWindow that trips a webhook into the auto-disabled
+// state. Tuned per design decision #12 (10 / 72h). The reviewer
+// can re-enable via PATCH after the 5-min cooldown.
+const (
+	AutoDisableThreshold = 10
+	AutoDisableWindow    = 72 * time.Hour
+)
+
+// AutoDisableFailingWebhooks scans for webhooks whose recent delivery
+// history exceeds the failure threshold and flips them to
+// enabled=false with auto_disabled_at = now(). Returns the count of
+// webhooks newly disabled. Designed to be called periodically (e.g.
+// every 5 minutes) from a janitor goroutine.
+//
+// "Consecutive failed events" is interpreted as: in the last
+// AutoDisableWindow, at least AutoDisableThreshold rows in
+// webhook_subscriber_deliveries reached status='failed' AND zero
+// rows reached status='delivered'. The zero-delivered guard prevents
+// a noisy webhook that's still mostly working from being disabled.
+func (s *Store) AutoDisableFailingWebhooks(ctx context.Context) (int, error) {
+	rows, err := s.pool.Query(ctx,
+		`UPDATE webhooks
+		 SET enabled = false,
+		     auto_disabled_at = now()
+		 WHERE id IN (
+		     SELECT webhook_id
+		     FROM webhook_subscriber_deliveries
+		     WHERE created_at > now() - $2::interval
+		     GROUP BY webhook_id
+		     HAVING COUNT(*) FILTER (WHERE status = 'failed') >= $1
+		        AND COUNT(*) FILTER (WHERE status = 'delivered') = 0
+		 )
+		 AND enabled = true
+		 RETURNING id`,
+		AutoDisableThreshold, AutoDisableWindow,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("auto-disable scan: %w", err)
+	}
+	defer rows.Close()
+	count := 0
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			return count, err
+		}
+		count++
+	}
+	return count, rows.Err()
+}
+
+// ClearExpiredPrevSecrets nulls signing_secret_prev /
+// signing_secret_prev_expires_at on rows past their grace window.
+// Idempotent. The worker already ignores expired prev secrets at
+// signing time; this janitor is a hygiene pass so GET responses
+// don't carry a meaningless prev_expires_at.
+func (s *Store) ClearExpiredPrevSecrets(ctx context.Context) (int64, error) {
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE webhooks
+		 SET signing_secret_prev = NULL,
+		     signing_secret_prev_expires_at = NULL
+		 WHERE signing_secret_prev_expires_at IS NOT NULL
+		   AND signing_secret_prev_expires_at < now()`,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("clear expired prev secrets: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
 // DeleteWebhook removes a webhook owned by the user. Idempotent:
 // deleting a non-existent or cross-user webhook returns
 // ErrWebhookNotFound, never silently succeeds. The ON DELETE CASCADE

--- a/internal/identity/webhooks_autodisable_test.go
+++ b/internal/identity/webhooks_autodisable_test.go
@@ -1,0 +1,170 @@
+package identity_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+)
+
+func TestAutoDisableFailingWebhooks_TripsAfterThresholdFailures(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	user, _ := store.CreateOrGetUser(ctx, "wh-autodisable-fail@example.com", "Owner", "google-wh-autodisable-fail")
+
+	wh, err := store.CreateWebhook(ctx, user.ID, "https://example.com/wh", "", []string{"email.received"}, identity.WebhookFilters{})
+	if err != nil {
+		t.Fatalf("CreateWebhook: %v", err)
+	}
+
+	// 10 failed + 0 delivered → trips the auto-disable threshold.
+	for i := 0; i < 10; i++ {
+		_, err := pool.Exec(ctx,
+			`INSERT INTO webhook_subscriber_deliveries
+			    (id, webhook_id, event_type, event_payload, status)
+			 VALUES ($1, $2, 'email.received', '{}'::jsonb, 'failed')`,
+			fmt.Sprintf("whd_fail_%d_%s", i, wh.ID), wh.ID,
+		)
+		if err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	n, err := store.AutoDisableFailingWebhooks(ctx)
+	if err != nil {
+		t.Fatalf("AutoDisableFailingWebhooks: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("disabled count = %d, want 1", n)
+	}
+
+	after, err := store.GetWebhookByID(ctx, wh.ID, user.ID)
+	if err != nil {
+		t.Fatalf("GetWebhookByID: %v", err)
+	}
+	if after.Enabled {
+		t.Errorf("webhook still enabled after auto-disable")
+	}
+	if after.AutoDisabledAt == nil {
+		t.Errorf("auto_disabled_at not set")
+	}
+}
+
+func TestAutoDisableFailingWebhooks_SpareWebhooksWithDeliveries(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	user, _ := store.CreateOrGetUser(ctx, "wh-autodisable-spare@example.com", "Owner", "google-wh-autodisable-spare")
+
+	wh, err := store.CreateWebhook(ctx, user.ID, "https://example.com/wh", "", []string{"email.received"}, identity.WebhookFilters{})
+	if err != nil {
+		t.Fatalf("CreateWebhook: %v", err)
+	}
+
+	// 10 failed BUT also 1 delivered → spared. The zero-delivered
+	// guard prevents a working-but-noisy webhook from being killed.
+	for i := 0; i < 10; i++ {
+		_, err := pool.Exec(ctx,
+			`INSERT INTO webhook_subscriber_deliveries
+			    (id, webhook_id, event_type, event_payload, status)
+			 VALUES ($1, $2, 'email.received', '{}'::jsonb, 'failed')`,
+			fmt.Sprintf("whd_failmix_%d_%s", i, wh.ID), wh.ID,
+		)
+		if err != nil {
+			t.Fatalf("seed failed row: %v", err)
+		}
+	}
+	_, err = pool.Exec(ctx,
+		`INSERT INTO webhook_subscriber_deliveries
+		    (id, webhook_id, event_type, event_payload, status)
+		 VALUES ($1, $2, 'email.received', '{}'::jsonb, 'delivered')`,
+		"whd_failmix_ok_"+wh.ID, wh.ID,
+	)
+	if err != nil {
+		t.Fatalf("seed delivered row: %v", err)
+	}
+
+	n, err := store.AutoDisableFailingWebhooks(ctx)
+	if err != nil {
+		t.Fatalf("AutoDisableFailingWebhooks: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("disabled count = %d, want 0", n)
+	}
+
+	after, _ := store.GetWebhookByID(ctx, wh.ID, user.ID)
+	if !after.Enabled {
+		t.Errorf("webhook should still be enabled (had a delivery)")
+	}
+}
+
+func TestClearExpiredPrevSecrets_NullsExpiredRows(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	user, _ := store.CreateOrGetUser(ctx, "wh-clear-prev@example.com", "Owner", "google-wh-clear-prev")
+	wh, _ := store.CreateWebhook(ctx, user.ID, "https://example.com/wh", "", []string{"email.received"}, identity.WebhookFilters{})
+
+	// Stamp a prev secret with an expiry an hour in the past.
+	pastExpiry := time.Now().Add(-1 * time.Hour)
+	_, err := pool.Exec(ctx,
+		`UPDATE webhooks
+		 SET signing_secret_prev = 'whsec_expired',
+		     signing_secret_prev_expires_at = $2
+		 WHERE id = $1`,
+		wh.ID, pastExpiry,
+	)
+	if err != nil {
+		t.Fatalf("seed expired prev: %v", err)
+	}
+
+	n, err := store.ClearExpiredPrevSecrets(ctx)
+	if err != nil {
+		t.Fatalf("ClearExpiredPrevSecrets: %v", err)
+	}
+	if n < 1 {
+		t.Errorf("cleared count = %d, want >= 1", n)
+	}
+
+	after, _ := store.GetWebhookByID(ctx, wh.ID, user.ID)
+	if after.SigningSecretPrev != "" {
+		t.Errorf("SigningSecretPrev should be empty after clear, got %q", after.SigningSecretPrev)
+	}
+	if after.SigningSecretPrevExpiresAt != nil {
+		t.Errorf("expires_at should be nil after clear")
+	}
+}
+
+func TestClearExpiredPrevSecrets_KeepsActiveGraceRows(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	user, _ := store.CreateOrGetUser(ctx, "wh-keep-prev@example.com", "Owner", "google-wh-keep-prev")
+	wh, _ := store.CreateWebhook(ctx, user.ID, "https://example.com/wh", "", []string{"email.received"}, identity.WebhookFilters{})
+
+	// Stamp a prev secret with an expiry IN THE FUTURE — should be kept.
+	futureExpiry := time.Now().Add(12 * time.Hour)
+	_, err := pool.Exec(ctx,
+		`UPDATE webhooks
+		 SET signing_secret_prev = 'whsec_active',
+		     signing_secret_prev_expires_at = $2
+		 WHERE id = $1`,
+		wh.ID, futureExpiry,
+	)
+	if err != nil {
+		t.Fatalf("seed active prev: %v", err)
+	}
+
+	if _, err := store.ClearExpiredPrevSecrets(ctx); err != nil {
+		t.Fatalf("ClearExpiredPrevSecrets: %v", err)
+	}
+
+	after, _ := store.GetWebhookByID(ctx, wh.ID, user.ID)
+	if after.SigningSecretPrev == "" {
+		t.Errorf("SigningSecretPrev should be preserved while grace window is open")
+	}
+}

--- a/internal/identity/webhooks_test.go
+++ b/internal/identity/webhooks_test.go
@@ -214,6 +214,101 @@ func TestCreateWebhook_DefaultCapWhenNoAccountLimits(t *testing.T) {
 	}
 }
 
+func TestUpdateWebhook_PartialFields(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	userID := webhookTestUser(t, store, "wh-upd")
+	w, _ := store.CreateWebhook(ctx, userID, "https://a.example.com", "first", []string{"email.received"}, identity.WebhookFilters{})
+
+	newURL := "https://b.example.com"
+	newDesc := "updated"
+	got, err := store.UpdateWebhook(ctx, w.ID, userID, identity.WebhookUpdate{URL: &newURL, Description: &newDesc})
+	if err != nil {
+		t.Fatalf("UpdateWebhook: %v", err)
+	}
+	if got.URL != newURL || got.Description != newDesc {
+		t.Errorf("after update url=%q desc=%q", got.URL, got.Description)
+	}
+	// Events and filters unchanged.
+	if len(got.Events) != 1 || got.Events[0] != "email.received" {
+		t.Errorf("events drifted: %v", got.Events)
+	}
+}
+
+func TestUpdateWebhook_ReEnableCooldown(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	userID := webhookTestUser(t, store, "wh-cooldown")
+	w, _ := store.CreateWebhook(ctx, userID, "https://a.example.com", "", []string{"email.received"}, identity.WebhookFilters{})
+
+	// Simulate auto-disable that just happened.
+	_, _ = pool.Exec(ctx, `UPDATE webhooks SET enabled = false, auto_disabled_at = now() WHERE id = $1`, w.ID)
+
+	tval := true
+	_, err := store.UpdateWebhook(ctx, w.ID, userID, identity.WebhookUpdate{Enabled: &tval})
+	if !errors.Is(err, identity.ErrWebhookCooldown) {
+		t.Errorf("expected ErrWebhookCooldown, got %v", err)
+	}
+
+	// Simulate an auto_disabled_at older than 5 min — re-enable should succeed.
+	_, _ = pool.Exec(ctx, `UPDATE webhooks SET auto_disabled_at = now() - interval '10 minutes' WHERE id = $1`, w.ID)
+	got, err := store.UpdateWebhook(ctx, w.ID, userID, identity.WebhookUpdate{Enabled: &tval})
+	if err != nil {
+		t.Fatalf("re-enable after cooldown: %v", err)
+	}
+	if !got.Enabled {
+		t.Error("Enabled = false after successful re-enable")
+	}
+	if got.AutoDisabledAt != nil {
+		t.Error("auto_disabled_at not cleared after re-enable")
+	}
+}
+
+func TestRotateSecret_ReturnsNewPlaintext(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	userID := webhookTestUser(t, store, "wh-rotate")
+	w, _ := store.CreateWebhook(ctx, userID, "https://a.example.com", "", []string{"email.received"}, identity.WebhookFilters{})
+	originalSecret := w.SigningSecret
+
+	newSecret, expiresAt, err := store.RotateSecret(ctx, w.ID, userID)
+	if err != nil {
+		t.Fatalf("RotateSecret: %v", err)
+	}
+	if newSecret == "" || newSecret == originalSecret {
+		t.Errorf("new secret should differ from original: new=%q orig=%q", newSecret, originalSecret)
+	}
+	if expiresAt.IsZero() {
+		t.Error("prev_expires_at is zero")
+	}
+
+	// Read back: signing_secret should be new, signing_secret_prev should be old.
+	round, _ := store.GetWebhookByID(ctx, w.ID, userID)
+	if round.SigningSecret != newSecret {
+		t.Errorf("read-back current = %q, want %q", round.SigningSecret, newSecret)
+	}
+	if round.SigningSecretPrev != originalSecret {
+		t.Errorf("read-back prev = %q, want %q (original)", round.SigningSecretPrev, originalSecret)
+	}
+}
+
+func TestRotateSecret_CrossUserNotFound(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	userA := webhookTestUser(t, store, "wh-rot-a")
+	userB := webhookTestUser(t, store, "wh-rot-b")
+	w, _ := store.CreateWebhook(ctx, userA, "https://a.example.com", "", []string{"email.received"}, identity.WebhookFilters{})
+
+	_, _, err := store.RotateSecret(ctx, w.ID, userB)
+	if !errors.Is(err, identity.ErrWebhookNotFound) {
+		t.Errorf("cross-user rotate err = %v, want ErrWebhookNotFound", err)
+	}
+}
+
 func TestDeleteWebhook_OwnerOnly(t *testing.T) {
 	pool := testutil.TestDB(t)
 	store := identity.NewStore(pool)

--- a/internal/identity/webhooks_test.go
+++ b/internal/identity/webhooks_test.go
@@ -1,0 +1,237 @@
+package identity_test
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+)
+
+func webhookTestUser(t *testing.T, store *identity.Store, prefix string) string {
+	t.Helper()
+	ctx := context.Background()
+	u, err := store.CreateOrGetUser(ctx, "owner-"+prefix+"@example.com", "Owner", "google-"+prefix)
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	return u.ID
+}
+
+func TestCreateWebhook_RoundTrip(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	userID := webhookTestUser(t, store, "wh-create")
+
+	filters := identity.WebhookFilters{
+		AgentIDs: []string{"bot@example.com"},
+		Labels:   []string{"urgent"},
+	}
+	got, err := store.CreateWebhook(ctx, userID, "https://example.com/hook", "main", []string{"email.received"}, filters)
+	if err != nil {
+		t.Fatalf("CreateWebhook: %v", err)
+	}
+	if got.ID == "" || got.SigningSecret == "" {
+		t.Errorf("CreateWebhook returned empty id/secret: %+v", got)
+	}
+	if got.URL != "https://example.com/hook" {
+		t.Errorf("URL = %q", got.URL)
+	}
+	if !got.Enabled {
+		t.Error("Enabled = false on fresh webhook; want true")
+	}
+
+	// Round-trip via GetWebhookByID
+	round, err := store.GetWebhookByID(ctx, got.ID, userID)
+	if err != nil {
+		t.Fatalf("GetWebhookByID: %v", err)
+	}
+	if round.SigningSecret != got.SigningSecret {
+		t.Errorf("signing_secret round-trip diverged")
+	}
+	if !reflect.DeepEqual(round.Filters.AgentIDs, []string{"bot@example.com"}) {
+		t.Errorf("filters.AgentIDs round-trip = %v", round.Filters.AgentIDs)
+	}
+	if !reflect.DeepEqual(round.Events, []string{"email.received"}) {
+		t.Errorf("events round-trip = %v", round.Events)
+	}
+}
+
+func TestGetWebhookByID_CrossUserNotFound(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	userA := webhookTestUser(t, store, "wh-iso-a")
+	userB := webhookTestUser(t, store, "wh-iso-b")
+
+	w, _ := store.CreateWebhook(ctx, userA, "https://example.com/hook", "", []string{"email.received"}, identity.WebhookFilters{})
+
+	_, err := store.GetWebhookByID(ctx, w.ID, userB)
+	if !errors.Is(err, identity.ErrWebhookNotFound) {
+		t.Errorf("cross-user read err = %v, want ErrWebhookNotFound", err)
+	}
+
+	// And the owner still sees it.
+	if _, err := store.GetWebhookByID(ctx, w.ID, userA); err != nil {
+		t.Errorf("owner read err = %v, want nil", err)
+	}
+}
+
+func TestListWebhooksByUser_ScopesByOwner(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	userA := webhookTestUser(t, store, "wh-list-a")
+	userB := webhookTestUser(t, store, "wh-list-b")
+
+	store.CreateWebhook(ctx, userA, "https://a1.example.com", "", []string{"email.received"}, identity.WebhookFilters{})
+	store.CreateWebhook(ctx, userA, "https://a2.example.com", "", []string{"email.received"}, identity.WebhookFilters{})
+	store.CreateWebhook(ctx, userB, "https://b1.example.com", "", []string{"email.received"}, identity.WebhookFilters{})
+
+	listA, err := store.ListWebhooksByUser(ctx, userA)
+	if err != nil {
+		t.Fatalf("ListWebhooksByUser A: %v", err)
+	}
+	if len(listA) != 2 {
+		t.Errorf("user A sees %d webhooks, want 2", len(listA))
+	}
+	listB, _ := store.ListWebhooksByUser(ctx, userB)
+	if len(listB) != 1 {
+		t.Errorf("user B sees %d webhooks, want 1", len(listB))
+	}
+}
+
+func TestListEnabledWebhooksForRouting_MatchesEventType(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	userID := webhookTestUser(t, store, "wh-route")
+
+	store.CreateWebhook(ctx, userID, "https://recv.example.com", "", []string{"email.received"}, identity.WebhookFilters{})
+	store.CreateWebhook(ctx, userID, "https://sent.example.com", "", []string{"email.sent"}, identity.WebhookFilters{})
+	store.CreateWebhook(ctx, userID, "https://both.example.com", "", []string{"email.received", "email.sent"}, identity.WebhookFilters{})
+
+	matches, err := store.ListEnabledWebhooksForRouting(ctx, userID, "email.received")
+	if err != nil {
+		t.Fatalf("ListEnabledWebhooksForRouting: %v", err)
+	}
+	urls := []string{}
+	for _, w := range matches {
+		urls = append(urls, w.URL)
+	}
+	sort.Strings(urls)
+	want := []string{"https://both.example.com", "https://recv.example.com"}
+	if !reflect.DeepEqual(urls, want) {
+		t.Errorf("matched urls = %v, want %v", urls, want)
+	}
+}
+
+func TestListEnabledWebhooksForRouting_SkipsDisabled(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	userID := webhookTestUser(t, store, "wh-route-disabled")
+
+	w1, _ := store.CreateWebhook(ctx, userID, "https://enabled.example.com", "", []string{"email.received"}, identity.WebhookFilters{})
+	w2, _ := store.CreateWebhook(ctx, userID, "https://disabled.example.com", "", []string{"email.received"}, identity.WebhookFilters{})
+
+	// Disable w2 by direct UPDATE (slice 2 will add the proper PATCH path).
+	_, err := pool.Exec(ctx, `UPDATE webhooks SET enabled = false WHERE id = $1`, w2.ID)
+	if err != nil {
+		t.Fatalf("disable w2: %v", err)
+	}
+
+	matches, _ := store.ListEnabledWebhooksForRouting(ctx, userID, "email.received")
+	if len(matches) != 1 || matches[0].ID != w1.ID {
+		t.Errorf("expected only enabled webhook, got %d matches", len(matches))
+	}
+}
+
+func TestListEnabledWebhooksForRouting_CrossUserIsolation(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	userA := webhookTestUser(t, store, "wh-route-iso-a")
+	userB := webhookTestUser(t, store, "wh-route-iso-b")
+
+	store.CreateWebhook(ctx, userA, "https://a.example.com", "", []string{"email.received"}, identity.WebhookFilters{})
+
+	// User B asking for the same event type sees none of A's webhooks.
+	matchesB, _ := store.ListEnabledWebhooksForRouting(ctx, userB, "email.received")
+	if len(matchesB) != 0 {
+		t.Errorf("user B sees %d of A's webhooks; must be 0", len(matchesB))
+	}
+}
+
+func TestCreateWebhook_EnforcesPerUserCap(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	userID := webhookTestUser(t, store, "wh-cap")
+
+	// Lower the cap for this user so we don't have to create 50 rows.
+	// account_limits has several NOT NULL columns without defaults
+	// (max_agents, max_domains, max_messages_month, max_storage_bytes)
+	// — seed reasonable values so the row passes constraints.
+	_, err := pool.Exec(ctx,
+		`INSERT INTO account_limits (user_id, plan_code, max_agents, max_domains, max_messages_month, max_storage_bytes, max_webhooks)
+		 VALUES ($1, 'test', 10, 10, 100000, 1073741824, 2)
+		 ON CONFLICT (user_id) DO UPDATE SET max_webhooks = 2`, userID)
+	if err != nil {
+		t.Fatalf("seed account_limits: %v", err)
+	}
+
+	if _, err := store.CreateWebhook(ctx, userID, "https://a.example.com", "", []string{"email.received"}, identity.WebhookFilters{}); err != nil {
+		t.Fatalf("create 1: %v", err)
+	}
+	if _, err := store.CreateWebhook(ctx, userID, "https://b.example.com", "", []string{"email.received"}, identity.WebhookFilters{}); err != nil {
+		t.Fatalf("create 2: %v", err)
+	}
+	_, err = store.CreateWebhook(ctx, userID, "https://c.example.com", "", []string{"email.received"}, identity.WebhookFilters{})
+	if !errors.Is(err, identity.ErrWebhookCapReached) {
+		t.Errorf("create at cap+1 err = %v, want ErrWebhookCapReached", err)
+	}
+}
+
+func TestCreateWebhook_DefaultCapWhenNoAccountLimits(t *testing.T) {
+	// Users without an account_limits row should default to
+	// DefaultMaxWebhooks. Tests on a fresh DB hit this path.
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	userID := webhookTestUser(t, store, "wh-cap-default")
+
+	max, err := store.MaxWebhooksForUser(ctx, userID)
+	if err != nil {
+		t.Fatalf("MaxWebhooksForUser: %v", err)
+	}
+	if max != identity.DefaultMaxWebhooks {
+		t.Errorf("MaxWebhooksForUser without account_limits row = %d, want %d", max, identity.DefaultMaxWebhooks)
+	}
+}
+
+func TestDeleteWebhook_OwnerOnly(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	userA := webhookTestUser(t, store, "wh-del-a")
+	userB := webhookTestUser(t, store, "wh-del-b")
+	w, _ := store.CreateWebhook(ctx, userA, "https://a.example.com", "", []string{"email.received"}, identity.WebhookFilters{})
+
+	// User B can't delete.
+	if err := store.DeleteWebhook(ctx, w.ID, userB); !errors.Is(err, identity.ErrWebhookNotFound) {
+		t.Errorf("cross-user delete err = %v, want ErrWebhookNotFound", err)
+	}
+	// Owner can.
+	if err := store.DeleteWebhook(ctx, w.ID, userA); err != nil {
+		t.Errorf("owner delete err = %v, want nil", err)
+	}
+	// Second delete is idempotent: not-found, not silent success.
+	if err := store.DeleteWebhook(ctx, w.ID, userA); !errors.Is(err, identity.ErrWebhookNotFound) {
+		t.Errorf("delete-already-gone err = %v, want ErrWebhookNotFound", err)
+	}
+}

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/limits"
 	"github.com/Mnexa-AI/e2a/internal/usage"
 	"github.com/Mnexa-AI/e2a/internal/webhook"
+	"github.com/Mnexa-AI/e2a/internal/webhookpub"
 	"github.com/Mnexa-AI/e2a/internal/ws"
 	"github.com/emersion/go-smtp"
 )
@@ -30,6 +31,13 @@ type Server struct {
 	store      *identity.Store
 	signer     *headers.Signer
 	deliverer  *webhook.PersistentDeliverer
+	// publisher is the new webhooks-as-a-resource publisher. Fires
+	// email.received events to the subscriber-resource path in
+	// addition to the legacy agent_identities.webhook_url delivery
+	// above. Optional — when nil (e.g. tests that don't exercise
+	// the new path) the relay only fires the legacy path. Wiring is
+	// additive: the legacy delivery flow is unchanged.
+	publisher webhookpub.Publisher
 	hub        *ws.Hub
 	usage      usage.UsageTracker
 	enforcer   limits.Enforcer // optional; when nil, inbound caps are not enforced
@@ -41,6 +49,12 @@ type Server struct {
 	// In-Reply-To lookup so they cannot forge conversation IDs.
 	outboundFromDomain string
 }
+
+// SetPublisher wires the new webhooks-as-a-resource publisher. Same
+// optional-setter pattern as SetEnforcer — keeps NewServer's signature
+// unchanged for the existing call sites and tests that don't care
+// about the new path.
+func (s *Server) SetPublisher(p webhookpub.Publisher) { s.publisher = p }
 
 // SetEnforcer wires in the resource-limits enforcer used to reject
 // inbound recipients whose owner has hit the message-flow or storage
@@ -317,6 +331,30 @@ func (s *session) deliverToAgent(ctx context.Context, agent *identity.AgentIdent
 	log.Printf("[mail:%s] dir=inbound from=%s to=%s slug=%s conv_id=%s subject=%q mode=%s verified=%t",
 		messageID, displaySender, rcpt, slug, conversationID, s.inboundSubject, agent.AgentMode, domainAuth.DomainAuthenticated())
 
+	// Fire email.received to the new webhooks-as-a-resource path
+	// (alongside the legacy delivery below). Post-commit async per
+	// the design — runs in a goroutine and doesn't block the SMTP
+	// delivery flow. The publisher is optional (nil for tests that
+	// don't exercise the new path).
+	//
+	// For agents where the same user has both a legacy webhook_url
+	// AND a new webhook resource subscribing to email.received, both
+	// fire — back-compat is "both pathways live side by side". Slice 4
+	// will add the X-E2A-Deprecation header on the legacy path once
+	// the user has any new webhook row.
+	if s.relay.publisher != nil {
+		event := webhookpub.NewEvent(webhookpub.EventEmailReceived, agent.UserID, buildEmailReceivedPayload(
+			messageID, conversationID, displaySender, rcpt, s.inboundSubject, s.inboundThreadInfo, body, authHeaders, agent,
+		))
+		event.AgentID = agent.ID
+		event.ConversationID = conversationID
+		event.MessageID = messageID
+		// labels are unset on inbound (the labels feature applies
+		// post-receive); leave Event.Labels empty so label-filtered
+		// subscribers correctly skip (H5 null/empty semantics).
+		go s.relay.publisher.Publish(context.Background(), event)
+	}
+
 	// Local mode: message is stored, try WS notification
 	if agent.AgentMode == "local" {
 		if s.relay.hub != nil && s.relay.hub.IsConnected(agent.ID) {
@@ -346,6 +384,43 @@ func (s *session) deliverToAgent(ctx context.Context, agent *identity.AgentIdent
 		log.Printf("[mail:%s] webhook=FAILED slug=%s error=%v", messageID, slug, err)
 	} else {
 		log.Printf("[mail:%s] webhook=OK slug=%s", messageID, slug)
+	}
+}
+
+// buildEmailReceivedPayload assembles the data portion of the
+// email.received envelope sent to webhook subscribers. Mirrors the
+// shape of the legacy webhook.Payload so receivers writing against
+// either model see the same fields — sender, to/cc/reply_to lists,
+// the raw RFC 5322 body (base64-encoded for JSON-safety), and the
+// signed auth headers.
+//
+// The envelope wrapper ({event, id, created_at, data}) is added by
+// the publisher when it marshals the Event; this helper only
+// produces the data subfield.
+func buildEmailReceivedPayload(
+	messageID, conversationID, displaySender, recipient, subject string,
+	threadInfo threadInfo,
+	rawMessage []byte,
+	authHeaders map[string]string,
+	agent *identity.AgentIdentity,
+) map[string]interface{} {
+	return map[string]interface{}{
+		"message_id":      messageID,
+		"conversation_id": conversationID,
+		"agent": map[string]interface{}{
+			"id":     agent.ID,
+			"email":  agent.EmailAddress(),
+			"domain": agent.Domain,
+		},
+		"from":         displaySender,
+		"to":           threadInfo.To,
+		"cc":           threadInfo.CC,
+		"reply_to":     threadInfo.ReplyTo,
+		"recipient":    recipient,
+		"subject":      subject,
+		"raw_message":  rawMessage,
+		"auth_headers": authHeaders,
+		"received_at":  time.Now().UTC().Format(time.RFC3339),
 	}
 }
 

--- a/internal/relay/webhook_payload_test.go
+++ b/internal/relay/webhook_payload_test.go
@@ -1,0 +1,64 @@
+package relay
+
+import (
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+)
+
+// TestBuildEmailReceivedPayload_Shape verifies the data envelope sent
+// to webhooks-as-a-resource subscribers carries the same fields the
+// legacy webhook.Payload exposes, so a customer writing one webhook
+// handler against either model sees the same shape.
+func TestBuildEmailReceivedPayload_Shape(t *testing.T) {
+	threadInfo := threadInfo{
+		To:      []string{"bot@example.com"},
+		CC:      []string{"cc@example.com"},
+		ReplyTo: []string{"reply@example.com"},
+	}
+	agent := &identity.AgentIdentity{
+		ID:     "bot@example.com",
+		Domain: "example.com",
+	}
+
+	payload := buildEmailReceivedPayload(
+		"msg_123",
+		"conv_abc",
+		"alice@example.com",
+		"bot@example.com",
+		"Hello",
+		threadInfo,
+		[]byte("raw RFC 5322 bytes"),
+		map[string]string{
+			"X-E2A-Auth-Verified": "true",
+		},
+		agent,
+	)
+
+	for _, key := range []string{
+		"message_id", "conversation_id", "agent",
+		"from", "to", "cc", "reply_to", "recipient",
+		"subject", "raw_message", "auth_headers", "received_at",
+	} {
+		if _, ok := payload[key]; !ok {
+			t.Errorf("payload missing %q", key)
+		}
+	}
+
+	if payload["message_id"] != "msg_123" {
+		t.Errorf("message_id = %v", payload["message_id"])
+	}
+	if payload["from"] != "alice@example.com" {
+		t.Errorf("from = %v", payload["from"])
+	}
+	agentObj, ok := payload["agent"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("agent is not a map: %T", payload["agent"])
+	}
+	if agentObj["id"] != "bot@example.com" {
+		t.Errorf("agent.id = %v", agentObj["id"])
+	}
+	if agentObj["domain"] != "example.com" {
+		t.Errorf("agent.domain = %v", agentObj["domain"])
+	}
+}

--- a/internal/webhook/auto_disable.go
+++ b/internal/webhook/auto_disable.go
@@ -1,0 +1,59 @@
+package webhook
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+)
+
+// AutoDisableWorker scans for chronically-failing webhooks and
+// disables them, and clears expired signing_secret_prev rows past
+// their 24h grace window. Decision #12 in the design.
+//
+// The two passes share a worker because they're both cheap,
+// idempotent, and run on the same low cadence.
+type AutoDisableWorker struct {
+	store    *identity.Store
+	interval time.Duration
+}
+
+// NewAutoDisableWorker constructs the worker with the design's
+// default 5-min cadence. Tests can use Tick directly.
+func NewAutoDisableWorker(store *identity.Store) *AutoDisableWorker {
+	return &AutoDisableWorker{
+		store:    store,
+		interval: 5 * time.Minute,
+	}
+}
+
+// Start blocks on ctx — call in its own goroutine.
+func (w *AutoDisableWorker) Start(ctx context.Context) {
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+	w.Tick(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			w.Tick(ctx)
+		}
+	}
+}
+
+// Tick runs both maintenance passes once. Exposed so tests can drive
+// the worker synchronously without waiting on the ticker.
+func (w *AutoDisableWorker) Tick(ctx context.Context) {
+	if n, err := w.store.AutoDisableFailingWebhooks(ctx); err != nil {
+		log.Printf("[wsd-autodisable] AutoDisableFailingWebhooks err: %v", err)
+	} else if n > 0 {
+		log.Printf("[wsd-autodisable] disabled %d failing webhook(s)", n)
+	}
+	if n, err := w.store.ClearExpiredPrevSecrets(ctx); err != nil {
+		log.Printf("[wsd-autodisable] ClearExpiredPrevSecrets err: %v", err)
+	} else if n > 0 {
+		log.Printf("[wsd-autodisable] cleared %d expired prev secret(s)", n)
+	}
+}

--- a/internal/webhook/auto_disable_test.go
+++ b/internal/webhook/auto_disable_test.go
@@ -1,0 +1,44 @@
+package webhook_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+	"github.com/Mnexa-AI/e2a/internal/webhook"
+)
+
+// TestAutoDisableWorker_TickDisablesAFailingWebhook drives the worker
+// once and asserts both passes (auto-disable + clear-prev) run without
+// panic and that the threshold-exceeding webhook ends up disabled.
+func TestAutoDisableWorker_TickDisablesAFailingWebhook(t *testing.T) {
+	pool := testutil.TestDB(t)
+	istore := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, _ := istore.CreateOrGetUser(ctx, "ad-worker-tick@example.com", "Owner", "google-ad-worker-tick")
+	wh, _ := istore.CreateWebhook(ctx, user.ID, "https://example.com/wh", "", []string{"email.received"}, identity.WebhookFilters{})
+
+	// Seed 10 failed deliveries — at the auto-disable threshold.
+	for i := 0; i < 10; i++ {
+		_, err := pool.Exec(ctx,
+			`INSERT INTO webhook_subscriber_deliveries
+			    (id, webhook_id, event_type, event_payload, status)
+			 VALUES ($1, $2, 'email.received', '{}'::jsonb, 'failed')`,
+			fmt.Sprintf("whd_adw_fail_%d_%s", i, wh.ID), wh.ID,
+		)
+		if err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	w := webhook.NewAutoDisableWorker(istore)
+	w.Tick(ctx)
+
+	after, _ := istore.GetWebhookByID(ctx, wh.ID, user.ID)
+	if after.Enabled {
+		t.Errorf("worker.Tick should have auto-disabled the failing webhook")
+	}
+}

--- a/internal/webhook/deliverer.go
+++ b/internal/webhook/deliverer.go
@@ -80,6 +80,15 @@ func (d *Deliverer) DeliverHTTP(ctx context.Context, agent *identity.AgentIdenti
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+	// Deprecation header for the legacy agent_identities.webhook_url
+	// path. The top-level /api/v1/webhooks resource is the supported
+	// way forward; this header gives operators a long lead time to
+	// migrate before the legacy field is removed. The date is
+	// intentionally distant — six months ahead of slice 1 — so
+	// short-lived integrations still see the signal but no integration
+	// breaks today.
+	req.Header.Set("X-E2A-Deprecation", "agent_identities.webhook_url is deprecated; use /api/v1/webhooks. Sunset target: 2026-12-01.")
+	req.Header.Set("Sunset", "Tue, 01 Dec 2026 00:00:00 GMT")
 
 	// Forward auth headers
 	for k, v := range p.AuthHeaders {

--- a/internal/webhook/deliverer_test.go
+++ b/internal/webhook/deliverer_test.go
@@ -49,6 +49,12 @@ func TestDeliverSuccess(t *testing.T) {
 	if receivedHeaders.Get("X-E2A-Auth-Verified") != "true" {
 		t.Error("expected auth header to be forwarded")
 	}
+	if dep := receivedHeaders.Get("X-E2A-Deprecation"); dep == "" {
+		t.Error("expected X-E2A-Deprecation header on legacy webhook delivery")
+	}
+	if sunset := receivedHeaders.Get("Sunset"); sunset == "" {
+		t.Error("expected Sunset header on legacy webhook delivery")
+	}
 
 	// Verify the body is valid JSON
 	var p Payload

--- a/internal/webhook/subscriber_deliverer.go
+++ b/internal/webhook/subscriber_deliverer.go
@@ -1,0 +1,130 @@
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// SubscriberDeliverer performs the HTTP POST for a
+// webhook_subscriber_deliveries row, signs the request with the
+// per-webhook HMAC secret, and reports success / failure to the
+// caller. Distinct from the legacy Deliverer (which signs nothing
+// at the request level — it forwards X-E2A-Auth-* headers from the
+// payload instead).
+//
+// Slice 1 carries only the current secret. Slice 4 will extend this
+// to dual-sign during the 24h rotation grace window.
+type SubscriberDeliverer struct {
+	client       *http.Client
+	requireHTTPS bool
+}
+
+// NewSubscriberDeliverer constructs the deliverer with the 15s
+// per-attempt timeout chosen in design decision #6.
+//
+// requireHTTPS gates against plaintext URLs in production. The
+// existing ValidateWebhookURL helper at registration time also
+// enforces this; the deliverer's check is the second line of defense
+// in case validation drifts or DNS resolves a registered hostname to
+// an internal IP after the fact.
+func NewSubscriberDeliverer(requireHTTPS bool) *SubscriberDeliverer {
+	return &SubscriberDeliverer{
+		client: &http.Client{
+			Timeout: 15 * time.Second,
+			// Refuse redirects to prevent SSRF — same defense the
+			// legacy Deliverer uses. A registered HTTPS URL that
+			// 301s to 127.0.0.1 would otherwise let an attacker
+			// reach internal services.
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		},
+		requireHTTPS: requireHTTPS,
+	}
+}
+
+// DeliveryOutcome is what the deliverer returns to the caller for
+// status accounting. statusCode is 0 when there was no HTTP response
+// (connection error, timeout, DNS failure).
+type DeliveryOutcome struct {
+	Success    bool
+	StatusCode int
+	Error      string
+}
+
+// Deliver performs one POST attempt. It signs the request body with
+// the supplied HMAC secret in Stripe-style header format:
+//
+//	X-E2A-Signature: t=<unix>,v1=<hex(hmac-sha256(secret, "<t>.<body>"))>
+//
+// secretPrev (if non-empty) adds a second v1=... signature for the
+// receiver to verify against during the 24h rotation grace window.
+// Slice 1 always passes secretPrev="" (no grace logic yet); slice 4
+// wires this up.
+//
+// 2xx responses are success. Anything else (including 3xx, since
+// redirects are blocked) is a failure with the HTTP status code
+// reported back. Connection errors return Success=false and StatusCode=0.
+func (d *SubscriberDeliverer) Deliver(ctx context.Context, url string, body []byte, secret, secretPrev string) DeliveryOutcome {
+	if d.requireHTTPS && !strings.HasPrefix(url, "https://") {
+		return DeliveryOutcome{Success: false, Error: "webhook URL must use HTTPS in production"}
+	}
+
+	timestamp := time.Now().Unix()
+	signatureValue := buildSignatureHeader(timestamp, body, secret, secretPrev)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return DeliveryOutcome{Success: false, Error: fmt.Sprintf("build request: %v", err)}
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-E2A-Signature", signatureValue)
+	req.Header.Set("User-Agent", "e2a-webhooks/1")
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return DeliveryOutcome{Success: false, Error: err.Error()}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return DeliveryOutcome{Success: true, StatusCode: resp.StatusCode}
+	}
+	return DeliveryOutcome{
+		Success:    false,
+		StatusCode: resp.StatusCode,
+		Error:      fmt.Sprintf("HTTP %d", resp.StatusCode),
+	}
+}
+
+// buildSignatureHeader formats the X-E2A-Signature header value. The
+// header carries one v1= signature in the normal case, and two during
+// the rotation grace window (separated by ',') so receivers can verify
+// with either secret.
+//
+// The signed string is "<t>.<body>" — Stripe's exact format. The
+// timestamp prevents simple replay (receivers should check that t is
+// recent; the design uses a 10-minute tolerance).
+func buildSignatureHeader(timestamp int64, body []byte, secret, secretPrev string) string {
+	current := signPayload(timestamp, body, secret)
+	parts := []string{fmt.Sprintf("t=%d", timestamp), "v1=" + current}
+	if secretPrev != "" {
+		parts = append(parts, "v1="+signPayload(timestamp, body, secretPrev))
+	}
+	return strings.Join(parts, ",")
+}
+
+// signPayload computes hex(hmac-sha256(secret, "<t>.<body>")).
+func signPayload(timestamp int64, body []byte, secret string) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	fmt.Fprintf(mac, "%d.", timestamp)
+	mac.Write(body)
+	return hex.EncodeToString(mac.Sum(nil))
+}

--- a/internal/webhook/subscriber_deliverer_test.go
+++ b/internal/webhook/subscriber_deliverer_test.go
@@ -1,0 +1,159 @@
+package webhook
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSubscriberDeliverer_SignsRequest(t *testing.T) {
+	var gotSignatureHeader string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSignatureHeader = r.Header.Get("X-E2A-Signature")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	d := NewSubscriberDeliverer(false)
+	body := []byte(`{"event":"email.received","id":"evt_x"}`)
+	out := d.Deliver(context.Background(), srv.URL, body, "whsec_secret", "")
+	if !out.Success {
+		t.Fatalf("Deliver returned failure: %+v", out)
+	}
+	if out.StatusCode != 200 {
+		t.Errorf("status = %d, want 200", out.StatusCode)
+	}
+
+	if !strings.HasPrefix(gotSignatureHeader, "t=") {
+		t.Errorf("signature header missing t= prefix: %q", gotSignatureHeader)
+	}
+	if !strings.Contains(gotSignatureHeader, ",v1=") {
+		t.Errorf("signature header missing v1= clause: %q", gotSignatureHeader)
+	}
+
+	// Verify the signature is correct
+	parts := strings.Split(gotSignatureHeader, ",")
+	if len(parts) != 2 {
+		t.Fatalf("signature header expected 2 parts (t=, v1=), got %d: %q", len(parts), gotSignatureHeader)
+	}
+	tStr := strings.TrimPrefix(parts[0], "t=")
+	v1Hex := strings.TrimPrefix(parts[1], "v1=")
+	timestamp, err := strconv.ParseInt(tStr, 10, 64)
+	if err != nil {
+		t.Fatalf("parse t: %v", err)
+	}
+	mac := hmac.New(sha256.New, []byte("whsec_secret"))
+	fmt.Fprintf(mac, "%d.", timestamp)
+	mac.Write(gotBody)
+	wantHex := hex.EncodeToString(mac.Sum(nil))
+	if v1Hex != wantHex {
+		t.Errorf("signature mismatch:\n  got:  %s\n  want: %s", v1Hex, wantHex)
+	}
+}
+
+func TestSubscriberDeliverer_DualSigDuringRotationGrace(t *testing.T) {
+	var gotSig string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSig = r.Header.Get("X-E2A-Signature")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	d := NewSubscriberDeliverer(false)
+	body := []byte(`{"event":"email.received"}`)
+	out := d.Deliver(context.Background(), srv.URL, body, "whsec_new", "whsec_old")
+	if !out.Success {
+		t.Fatalf("Deliver returned failure: %+v", out)
+	}
+
+	// Header should carry two v1= clauses during the rotation window.
+	count := strings.Count(gotSig, "v1=")
+	if count != 2 {
+		t.Errorf("expected 2 v1= clauses during rotation window, got %d: %q", count, gotSig)
+	}
+}
+
+func TestSubscriberDeliverer_4xxIsFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	d := NewSubscriberDeliverer(false)
+	out := d.Deliver(context.Background(), srv.URL, []byte(`{}`), "whsec_x", "")
+	if out.Success {
+		t.Error("4xx response reported as success")
+	}
+	if out.StatusCode != 400 {
+		t.Errorf("status_code = %d, want 400", out.StatusCode)
+	}
+}
+
+func TestSubscriberDeliverer_5xxIsFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	d := NewSubscriberDeliverer(false)
+	out := d.Deliver(context.Background(), srv.URL, []byte(`{}`), "whsec_x", "")
+	if out.Success {
+		t.Error("5xx response reported as success")
+	}
+	if out.StatusCode != 503 {
+		t.Errorf("status_code = %d, want 503", out.StatusCode)
+	}
+}
+
+func TestSubscriberDeliverer_ConnectionErrorReportsZeroStatus(t *testing.T) {
+	// 192.0.2.0/24 is reserved for documentation per RFC 5737;
+	// connection attempts to it should fail without ever reaching a
+	// real service.
+	d := NewSubscriberDeliverer(false)
+	d.client.Timeout = 100 * time.Millisecond // speed up the test
+	out := d.Deliver(context.Background(), "http://192.0.2.1:8080/", []byte(`{}`), "whsec_x", "")
+	if out.Success {
+		t.Error("connection failure reported as success")
+	}
+	if out.StatusCode != 0 {
+		t.Errorf("status_code on connection error = %d, want 0", out.StatusCode)
+	}
+}
+
+func TestSubscriberDeliverer_RefusesPlaintextInProd(t *testing.T) {
+	d := NewSubscriberDeliverer(true) // requireHTTPS=true
+	out := d.Deliver(context.Background(), "http://example.com/hook", []byte(`{}`), "whsec_x", "")
+	if out.Success {
+		t.Error("plaintext URL allowed in HTTPS-required mode")
+	}
+	if !strings.Contains(out.Error, "HTTPS") {
+		t.Errorf("error message doesn't mention HTTPS: %q", out.Error)
+	}
+}
+
+func TestSubscriberDeliverer_RefusesRedirects(t *testing.T) {
+	// The deliverer's CheckRedirect: http.ErrUseLastResponse means
+	// it captures the 302 status rather than following it. Treat
+	// 3xx as a failure (not success and not a silent redirect).
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, "http://127.0.0.1:1/", http.StatusFound)
+	}))
+	defer srv.Close()
+
+	d := NewSubscriberDeliverer(false)
+	out := d.Deliver(context.Background(), srv.URL, []byte(`{}`), "whsec_x", "")
+	if out.Success {
+		t.Error("3xx response reported as success — redirects must be refused")
+	}
+}

--- a/internal/webhook/subscriber_retry.go
+++ b/internal/webhook/subscriber_retry.go
@@ -134,7 +134,16 @@ func (w *SubscriberRetryWorker) processOne(ctx context.Context, d SubscriberDeli
 		return
 	}
 
-	out := w.deliverer.Deliver(ctx, wh.URL, d.EventPayload, wh.SigningSecret, wh.SigningSecretPrev)
+	// Only honor the previous signing secret while the 24h grace
+	// window is still open. Past expiry the column is non-null in
+	// the DB until the next janitor pass nulls it out — we treat
+	// the expired value as if it had already been nulled so
+	// receivers don't get an extra v1= they don't expect.
+	prevSecret := wh.SigningSecretPrev
+	if wh.SigningSecretPrevExpiresAt != nil && time.Now().After(*wh.SigningSecretPrevExpiresAt) {
+		prevSecret = ""
+	}
+	out := w.deliverer.Deliver(ctx, wh.URL, d.EventPayload, wh.SigningSecret, prevSecret)
 	if out.Success {
 		if err := w.store.MarkDelivered(ctx, d.ID, out.StatusCode); err != nil {
 			log.Printf("[wsd-retry] MarkDelivered err delivery=%s: %v", d.ID, err)

--- a/internal/webhook/subscriber_retry.go
+++ b/internal/webhook/subscriber_retry.go
@@ -9,6 +9,13 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/identity"
 )
 
+// disabledDeferral is how far out next_retry_at is pushed when the
+// worker skips a delivery because its webhook is currently disabled.
+// Long enough that a disabled webhook's backlog doesn't churn the
+// worker every tick; short enough that re-enabling resumes delivery
+// within the operator's workflow window.
+const disabledDeferral = 1 * time.Hour
+
 // SubscriberRetryWorker drains webhook_subscriber_deliveries on a
 // tick. Distinct from the legacy RetryWorker (which drains
 // webhook_deliveries). The two workers can run side-by-side without
@@ -126,11 +133,15 @@ func (w *SubscriberRetryWorker) processOne(ctx context.Context, d SubscriberDeli
 		return
 	}
 	if !wh.Enabled {
-		// Disabled — defer to next tick so a re-enable picks it up
-		// fast. Updating next_retry_at is unnecessary; the row
-		// stays pending. Acceptable: at slice 1 a disabled webhook
-		// doesn't fire often.
-		log.Printf("[wsd-retry] webhook %s disabled, skipping delivery=%s", d.WebhookID, d.ID)
+		// Disabled — bump next_retry_at out so the row doesn't
+		// reappear on every 30s tick eating worker quota. A
+		// re-enable still picks the row up within disabledDeferral
+		// (currently 1h), which is fast enough for the operator
+		// workflow (enable → confirm webhook works).
+		log.Printf("[wsd-retry] webhook %s disabled, deferring delivery=%s by %s", d.WebhookID, d.ID, disabledDeferral)
+		if err := w.store.BumpNextRetry(ctx, d.ID, disabledDeferral); err != nil {
+			log.Printf("[wsd-retry] bump next_retry_at err delivery=%s: %v", d.ID, err)
+		}
 		return
 	}
 

--- a/internal/webhook/subscriber_retry.go
+++ b/internal/webhook/subscriber_retry.go
@@ -1,0 +1,152 @@
+package webhook
+
+import (
+	"context"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+)
+
+// SubscriberRetryWorker drains webhook_subscriber_deliveries on a
+// tick. Distinct from the legacy RetryWorker (which drains
+// webhook_deliveries). The two workers can run side-by-side without
+// stepping on each other because they read from disjoint tables.
+//
+// Decisions reflected in the design:
+//   - 8 global concurrent worker goroutines (design #6). One bad
+//     subscriber cannot pin all 8 slots because of the per-webhook
+//     inflight cap below.
+//   - Per-webhook inflight cap of 1 (H2 from the design review). A
+//     sync.Map[webhookID]→sync.Mutex serializes attempts to the same
+//     subscriber; a slow customer's webhook backlogs onto its own
+//     queue without starving fast subscribers.
+//   - 15s per-attempt HTTP timeout (carried by the SubscriberDeliverer).
+//
+// Slice 1 doesn't add the auto-disable worker or the
+// signing_secret_prev null-out pass; those land in slice 4.
+type SubscriberRetryWorker struct {
+	store         *SubscriberStore
+	deliverer     *SubscriberDeliverer
+	identityStore *identity.Store
+	interval      time.Duration
+	batchSize     int
+	concurrency   int
+
+	// perWebhookLocks serializes attempts on the same webhook. Key
+	// is webhook_id; value is *sync.Mutex. Locks are created on
+	// first use and never deleted — at slice 1 scale (50 webhooks
+	// per user × moderate user count) the memory cost is
+	// negligible. A janitor that removes stale entries can land
+	// later if needed.
+	perWebhookLocks sync.Map
+}
+
+func NewSubscriberRetryWorker(store *SubscriberStore, deliverer *SubscriberDeliverer, identityStore *identity.Store) *SubscriberRetryWorker {
+	return &SubscriberRetryWorker{
+		store:         store,
+		deliverer:     deliverer,
+		identityStore: identityStore,
+		interval:      30 * time.Second,
+		batchSize:     20,
+		concurrency:   8,
+	}
+}
+
+// Start blocks on ctx — call in its own goroutine. Same shape as the
+// legacy RetryWorker.Start. Production wiring uses Start; tests call
+// Tick directly so they don't have to wait on the 30s interval.
+func (w *SubscriberRetryWorker) Start(ctx context.Context) {
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			w.Tick(ctx)
+		}
+	}
+}
+
+// Tick processes one batch of pending deliveries. Exposed (not just
+// the private processBatch) so tests can drive the worker
+// synchronously without waiting on the ticker.
+func (w *SubscriberRetryWorker) Tick(ctx context.Context) {
+	deliveries, err := w.store.GetPending(ctx, w.batchSize)
+	if err != nil {
+		log.Printf("[wsd-retry] fetch pending err: %v", err)
+		return
+	}
+	if len(deliveries) == 0 {
+		return
+	}
+
+	// Bounded concurrent goroutines. Use a buffered semaphore so we
+	// don't spawn unbounded goroutines on a large batch.
+	sem := make(chan struct{}, w.concurrency)
+	var wg sync.WaitGroup
+	for _, d := range deliveries {
+		d := d
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+			w.processOne(ctx, d)
+		}()
+	}
+	wg.Wait()
+}
+
+func (w *SubscriberRetryWorker) processOne(ctx context.Context, d SubscriberDelivery) {
+	// Per-webhook inflight cap of 1: lock the per-webhook mutex
+	// before processing. Workers competing for the same webhook
+	// queue up here; workers handling different webhooks proceed in
+	// parallel.
+	lockI, _ := w.perWebhookLocks.LoadOrStore(d.WebhookID, &sync.Mutex{})
+	lock := lockI.(*sync.Mutex)
+	lock.Lock()
+	defer lock.Unlock()
+
+	// Re-fetch the webhook each attempt so a disabled or deleted
+	// webhook is caught here instead of POSTing to a stale URL.
+	// Cross-user concerns don't apply (the webhook lookup goes
+	// through the identityStore which only filters by id; the
+	// publisher already enforced user ownership at write time).
+	wh, err := w.identityStore.GetWebhookByIDInternal(ctx, d.WebhookID)
+	if err != nil {
+		// Webhook deleted — mark delivery failed (no future retries)
+		// and move on. The ON DELETE CASCADE means the row will
+		// vanish at the next janitor pass anyway; this just speeds
+		// it up.
+		log.Printf("[wsd-retry] webhook %s not found (likely deleted), marking failed: %v", d.WebhookID, err)
+		_ = w.store.RecordAttemptFailure(ctx, d.ID, "webhook not found", 0)
+		return
+	}
+	if !wh.Enabled {
+		// Disabled — defer to next tick so a re-enable picks it up
+		// fast. Updating next_retry_at is unnecessary; the row
+		// stays pending. Acceptable: at slice 1 a disabled webhook
+		// doesn't fire often.
+		log.Printf("[wsd-retry] webhook %s disabled, skipping delivery=%s", d.WebhookID, d.ID)
+		return
+	}
+
+	out := w.deliverer.Deliver(ctx, wh.URL, d.EventPayload, wh.SigningSecret, wh.SigningSecretPrev)
+	if out.Success {
+		if err := w.store.MarkDelivered(ctx, d.ID, out.StatusCode); err != nil {
+			log.Printf("[wsd-retry] MarkDelivered err delivery=%s: %v", d.ID, err)
+		} else {
+			log.Printf("[wsd-retry] delivered delivery=%s webhook=%s status=%d", d.ID, d.WebhookID, out.StatusCode)
+		}
+		return
+	}
+
+	if err := w.store.RecordAttemptFailure(ctx, d.ID, out.Error, out.StatusCode); err != nil {
+		log.Printf("[wsd-retry] RecordAttemptFailure err delivery=%s: %v", d.ID, err)
+	} else {
+		log.Printf("[wsd-retry] failed attempt delivery=%s webhook=%s status=%d err=%s", d.ID, d.WebhookID, out.StatusCode, out.Error)
+	}
+}

--- a/internal/webhook/subscriber_retry_test.go
+++ b/internal/webhook/subscriber_retry_test.go
@@ -1,0 +1,332 @@
+package webhook_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+	"github.com/Mnexa-AI/e2a/internal/webhook"
+)
+
+func TestSubscriberRetryWorker_TickDeliversAndMarksSuccess(t *testing.T) {
+	pool := testutil.TestDB(t)
+	istore := identity.NewStore(pool)
+	wstore := webhook.NewSubscriberStore(pool)
+	ctx := context.Background()
+
+	var receivedCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&receivedCount, 1)
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	user, _ := istore.CreateOrGetUser(ctx, "wsd-deliver@example.com", "Owner", "google-wsd-deliver")
+	wh, err := istore.CreateWebhook(ctx, user.ID, srv.URL, "", []string{"email.received"}, identity.WebhookFilters{})
+	if err != nil {
+		t.Fatalf("CreateWebhook: %v", err)
+	}
+
+	// Seed a pending delivery row.
+	envelope, _ := json.Marshal(map[string]any{"event": "email.received", "id": "evt_x"})
+	_, err = pool.Exec(ctx,
+		`INSERT INTO webhook_subscriber_deliveries (id, webhook_id, event_type, event_payload, status)
+		 VALUES ($1, $2, 'email.received', $3, 'pending')`,
+		"whd_deliver_"+wh.ID, wh.ID, envelope,
+	)
+	if err != nil {
+		t.Fatalf("seed delivery: %v", err)
+	}
+
+	deliverer := webhook.NewSubscriberDeliverer(false)
+	w := webhook.NewSubscriberRetryWorker(wstore, deliverer, istore)
+	w.Tick(ctx)
+
+	if atomic.LoadInt32(&receivedCount) != 1 {
+		t.Errorf("receiver got %d POSTs, want 1", receivedCount)
+	}
+
+	var status string
+	if err := pool.QueryRow(ctx,
+		`SELECT status FROM webhook_subscriber_deliveries WHERE id = $1`,
+		"whd_deliver_"+wh.ID,
+	).Scan(&status); err != nil {
+		t.Fatalf("read status: %v", err)
+	}
+	if status != "delivered" {
+		t.Errorf("status = %q, want delivered", status)
+	}
+}
+
+func TestSubscriberRetryWorker_TickRecordsHTTPFailure(t *testing.T) {
+	pool := testutil.TestDB(t)
+	istore := identity.NewStore(pool)
+	wstore := webhook.NewSubscriberStore(pool)
+	ctx := context.Background()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		rw.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	user, _ := istore.CreateOrGetUser(ctx, "wsd-tickfail@example.com", "Owner", "google-wsd-tickfail")
+	wh, _ := istore.CreateWebhook(ctx, user.ID, srv.URL, "", []string{"email.received"}, identity.WebhookFilters{})
+
+	envelope, _ := json.Marshal(map[string]any{"event": "email.received"})
+	_, _ = pool.Exec(ctx,
+		`INSERT INTO webhook_subscriber_deliveries (id, webhook_id, event_type, event_payload, status)
+		 VALUES ($1, $2, 'email.received', $3, 'pending')`,
+		"whd_tickfail_"+wh.ID, wh.ID, envelope,
+	)
+
+	deliverer := webhook.NewSubscriberDeliverer(false)
+	w := webhook.NewSubscriberRetryWorker(wstore, deliverer, istore)
+	w.Tick(ctx)
+
+	var status string
+	var attempts int
+	var lastStatusCode *int
+	pool.QueryRow(ctx,
+		`SELECT status, attempts, last_status_code FROM webhook_subscriber_deliveries WHERE id = $1`,
+		"whd_tickfail_"+wh.ID,
+	).Scan(&status, &attempts, &lastStatusCode)
+	if status != "pending" {
+		t.Errorf("status = %q, want pending (5xx → retry; not final fail)", status)
+	}
+	if attempts != 1 {
+		t.Errorf("attempts = %d, want 1", attempts)
+	}
+	if lastStatusCode == nil || *lastStatusCode != 503 {
+		t.Errorf("last_status_code = %v, want 503", lastStatusCode)
+	}
+}
+
+func TestSubscriberRetryWorker_SkipsDisabledWebhook(t *testing.T) {
+	pool := testutil.TestDB(t)
+	istore := identity.NewStore(pool)
+	wstore := webhook.NewSubscriberStore(pool)
+	ctx := context.Background()
+
+	var receivedCount int32
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&receivedCount, 1)
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	user, _ := istore.CreateOrGetUser(ctx, "wsd-disabled@example.com", "Owner", "google-wsd-disabled")
+	wh, _ := istore.CreateWebhook(ctx, user.ID, srv.URL, "", []string{"email.received"}, identity.WebhookFilters{})
+
+	// Disable directly via UPDATE (slice 2 will add the PATCH path).
+	_, _ = pool.Exec(ctx, `UPDATE webhooks SET enabled = false WHERE id = $1`, wh.ID)
+
+	envelope, _ := json.Marshal(map[string]any{"event": "email.received"})
+	_, _ = pool.Exec(ctx,
+		`INSERT INTO webhook_subscriber_deliveries (id, webhook_id, event_type, event_payload, status)
+		 VALUES ($1, $2, 'email.received', $3, 'pending')`,
+		"whd_dis_"+wh.ID, wh.ID, envelope,
+	)
+
+	deliverer := webhook.NewSubscriberDeliverer(false)
+	w := webhook.NewSubscriberRetryWorker(wstore, deliverer, istore)
+	w.Tick(ctx)
+
+	if atomic.LoadInt32(&receivedCount) != 0 {
+		t.Errorf("disabled webhook received %d POSTs; want 0", receivedCount)
+	}
+
+	// Row stays pending (worker just defers to next tick).
+	var status string
+	pool.QueryRow(ctx,
+		`SELECT status FROM webhook_subscriber_deliveries WHERE id = $1`,
+		"whd_dis_"+wh.ID,
+	).Scan(&status)
+	if status != "pending" {
+		t.Errorf("disabled-webhook delivery status = %q, want pending", status)
+	}
+}
+
+// TestSubscriberStore_RecordAttemptFailureClimbsToFailed exercises
+// the failure-counting path without depending on the worker: 5 calls
+// to RecordAttemptFailure (matching the default max_attempts) flip
+// the row from pending → failed at exactly the boundary.
+func TestSubscriberStore_RecordAttemptFailureClimbsToFailed(t *testing.T) {
+	pool := testutil.TestDB(t)
+	istore := identity.NewStore(pool)
+	wstore := webhook.NewSubscriberStore(pool)
+	ctx := context.Background()
+	user, _ := istore.CreateOrGetUser(ctx, "wsd-climb@example.com", "Owner", "google-wsd-climb")
+	wh, _ := istore.CreateWebhook(ctx, user.ID, "https://example.com/hook", "", []string{"email.received"}, identity.WebhookFilters{})
+
+	envelope, _ := json.Marshal(map[string]any{"event": "email.received"})
+	_, _ = pool.Exec(ctx,
+		`INSERT INTO webhook_subscriber_deliveries (id, webhook_id, event_type, event_payload, status)
+		 VALUES ($1, $2, 'email.received', $3, 'pending')`,
+		"whd_climb_"+wh.ID, wh.ID, envelope,
+	)
+
+	for i := 0; i < 4; i++ {
+		if err := wstore.RecordAttemptFailure(ctx, "whd_climb_"+wh.ID, "simulated", 500); err != nil {
+			t.Fatalf("RecordAttemptFailure %d: %v", i, err)
+		}
+		var status string
+		var attempts int
+		pool.QueryRow(ctx, `SELECT status, attempts FROM webhook_subscriber_deliveries WHERE id = $1`,
+			"whd_climb_"+wh.ID).Scan(&status, &attempts)
+		if status != "pending" {
+			t.Errorf("after attempt %d status = %q, want pending", i+1, status)
+		}
+		if attempts != i+1 {
+			t.Errorf("after attempt %d attempts = %d, want %d", i+1, attempts, i+1)
+		}
+	}
+
+	// 5th attempt → 'failed'.
+	if err := wstore.RecordAttemptFailure(ctx, "whd_climb_"+wh.ID, "final", 500); err != nil {
+		t.Fatalf("RecordAttemptFailure 5: %v", err)
+	}
+	var status string
+	pool.QueryRow(ctx, `SELECT status FROM webhook_subscriber_deliveries WHERE id = $1`,
+		"whd_climb_"+wh.ID).Scan(&status)
+	if status != "failed" {
+		t.Errorf("after max_attempts status = %q, want failed", status)
+	}
+}
+
+func TestSubscriberStore_MarkDeliveredBumpsLastDeliveredAt(t *testing.T) {
+	pool := testutil.TestDB(t)
+	istore := identity.NewStore(pool)
+	wstore := webhook.NewSubscriberStore(pool)
+	ctx := context.Background()
+	user, _ := istore.CreateOrGetUser(ctx, "wsd-bump@example.com", "Owner", "google-wsd-bump")
+	wh, _ := istore.CreateWebhook(ctx, user.ID, "https://example.com/hook", "", []string{"email.received"}, identity.WebhookFilters{})
+
+	envelope, _ := json.Marshal(map[string]any{"event": "email.received"})
+	_, _ = pool.Exec(ctx,
+		`INSERT INTO webhook_subscriber_deliveries (id, webhook_id, event_type, event_payload, status)
+		 VALUES ($1, $2, 'email.received', $3, 'pending')`,
+		"whd_bump_"+wh.ID, wh.ID, envelope,
+	)
+	if err := wstore.MarkDelivered(ctx, "whd_bump_"+wh.ID, 200); err != nil {
+		t.Fatalf("MarkDelivered: %v", err)
+	}
+	var lastDelivered *time.Time
+	pool.QueryRow(ctx, `SELECT last_delivered_at FROM webhooks WHERE id = $1`, wh.ID).Scan(&lastDelivered)
+	if lastDelivered == nil {
+		t.Error("last_delivered_at not bumped on the webhook row after MarkDelivered")
+	}
+}
+
+// TestSubscriberRetryWorker_PerWebhookInflightCap verifies decision
+// #6 / finding H2: concurrent deliveries to the same webhook
+// serialize so one slow customer can't pin all 8 worker slots.
+func TestSubscriberRetryWorker_PerWebhookInflightCap(t *testing.T) {
+	pool := testutil.TestDB(t)
+	istore := identity.NewStore(pool)
+	wstore := webhook.NewSubscriberStore(pool)
+	ctx := context.Background()
+
+	var inFlight, maxInFlight int32
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		cur := atomic.AddInt32(&inFlight, 1)
+		mu.Lock()
+		if cur > maxInFlight {
+			maxInFlight = cur
+		}
+		mu.Unlock()
+		// Hold each request long enough that concurrent attempts
+		// would clearly overlap if the cap were missing.
+		time.Sleep(150 * time.Millisecond)
+		atomic.AddInt32(&inFlight, -1)
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	user, _ := istore.CreateOrGetUser(ctx, "wsd-cap@example.com", "Owner", "google-wsd-cap")
+	wh, _ := istore.CreateWebhook(ctx, user.ID, srv.URL, "", []string{"email.received"}, identity.WebhookFilters{})
+
+	// Seed 5 pending rows for the same webhook.
+	envelope, _ := json.Marshal(map[string]any{"event": "email.received"})
+	for i := 0; i < 5; i++ {
+		id := "whd_cap_" + wh.ID + "_" + string(rune('a'+i))
+		_, _ = pool.Exec(ctx,
+			`INSERT INTO webhook_subscriber_deliveries (id, webhook_id, event_type, event_payload, status)
+			 VALUES ($1, $2, 'email.received', $3, 'pending')`,
+			id, wh.ID, envelope,
+		)
+	}
+
+	deliverer := webhook.NewSubscriberDeliverer(false)
+	w := webhook.NewSubscriberRetryWorker(wstore, deliverer, istore)
+	w.Tick(ctx)
+
+	if atomic.LoadInt32(&maxInFlight) > 1 {
+		t.Errorf("per-webhook inflight cap violated: peak concurrent = %d, want ≤ 1", maxInFlight)
+	}
+
+	// All 5 should have been delivered.
+	var delivered int
+	pool.QueryRow(ctx,
+		`SELECT count(*) FROM webhook_subscriber_deliveries
+		 WHERE webhook_id = $1 AND status = 'delivered'`, wh.ID,
+	).Scan(&delivered)
+	if delivered != 5 {
+		t.Errorf("delivered = %d, want 5 (all should complete despite serialization)", delivered)
+	}
+}
+
+// TestSubscriberRetryWorker_DifferentWebhooksParallelize verifies
+// the inverse: deliveries to DIFFERENT webhooks fan out across the
+// 8-goroutine pool, so a slow customer's webhook doesn't stall a
+// fast customer's delivery.
+func TestSubscriberRetryWorker_DifferentWebhooksParallelize(t *testing.T) {
+	pool := testutil.TestDB(t)
+	istore := identity.NewStore(pool)
+	wstore := webhook.NewSubscriberStore(pool)
+	ctx := context.Background()
+
+	var maxInFlight int32
+	var inFlight int32
+	var mu sync.Mutex
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		cur := atomic.AddInt32(&inFlight, 1)
+		mu.Lock()
+		if cur > maxInFlight {
+			maxInFlight = cur
+		}
+		mu.Unlock()
+		time.Sleep(100 * time.Millisecond)
+		atomic.AddInt32(&inFlight, -1)
+		rw.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	user, _ := istore.CreateOrGetUser(ctx, "wsd-parallel@example.com", "Owner", "google-wsd-parallel")
+	envelope, _ := json.Marshal(map[string]any{"event": "email.received"})
+	// 4 distinct webhooks, one pending delivery each — workers can
+	// run all 4 in parallel (each acquires its own per-webhook lock).
+	for i := 0; i < 4; i++ {
+		wh, _ := istore.CreateWebhook(ctx, user.ID, srv.URL, "", []string{"email.received"}, identity.WebhookFilters{})
+		_, _ = pool.Exec(ctx,
+			`INSERT INTO webhook_subscriber_deliveries (id, webhook_id, event_type, event_payload, status)
+			 VALUES ($1, $2, 'email.received', $3, 'pending')`,
+			"whd_par_"+wh.ID, wh.ID, envelope,
+		)
+	}
+
+	deliverer := webhook.NewSubscriberDeliverer(false)
+	w := webhook.NewSubscriberRetryWorker(wstore, deliverer, istore)
+	w.Tick(ctx)
+
+	if atomic.LoadInt32(&maxInFlight) < 2 {
+		t.Errorf("expected concurrent in-flight deliveries across webhooks; max = %d", maxInFlight)
+	}
+}

--- a/internal/webhook/subscriber_store.go
+++ b/internal/webhook/subscriber_store.go
@@ -40,25 +40,47 @@ func NewSubscriberStore(pool *pgxpool.Pool) *SubscriberStore {
 	return &SubscriberStore{pool: pool}
 }
 
-// GetPending pulls up to limit rows whose next_retry_at is in the
-// past, ordered by next_retry_at ASC (oldest-due first). Caller is
-// responsible for processing them and updating status — no row-level
-// lease here; the worker's per-webhook inflight cap is what prevents
-// double-processing.
+// GetPending leases up to `limit` rows whose next_retry_at is in the
+// past. The lease is implemented as a single CTE that selects-for-update
+// the candidate rows with SKIP LOCKED and pushes their next_retry_at
+// forward by LeaseDuration, so concurrent workers (in-process OR across
+// replicas) never return the same row. Mirrors the legacy
+// DeliveryStore.GetPendingDeliveries pattern.
+//
+// The lease window is what prevents double-POST in multi-replica
+// deployments. If a worker crashes mid-attempt, the row reappears once
+// the lease expires; the caller writing MarkDelivered /
+// RecordAttemptFailure inside the lease window overwrites next_retry_at
+// to the real schedule (or 'failed' status) before the lease expires.
 func (s *SubscriberStore) GetPending(ctx context.Context, limit int) ([]SubscriberDelivery, error) {
-	rows, err := s.pool.Query(ctx,
-		`SELECT id, webhook_id, event_type, event_payload, message_id,
-		        status, attempts, max_attempts, last_error,
-		        last_status_code, last_attempt_at, next_retry_at,
-		        created_at, expires_at
-		 FROM webhook_subscriber_deliveries
-		 WHERE status = 'pending' AND next_retry_at <= now()
-		 ORDER BY next_retry_at ASC
-		 LIMIT $1`, limit)
+	tx, err := s.pool.Begin(ctx)
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer tx.Rollback(ctx)
+
+	rows, err := tx.Query(ctx,
+		`WITH candidates AS (
+		    SELECT id FROM webhook_subscriber_deliveries
+		    WHERE status = 'pending' AND next_retry_at <= now()
+		    ORDER BY next_retry_at ASC
+		    LIMIT $1
+		    FOR UPDATE SKIP LOCKED
+		 )
+		 UPDATE webhook_subscriber_deliveries d
+		 SET next_retry_at = now() + ($2 * interval '1 second')
+		 FROM candidates c
+		 WHERE d.id = c.id
+		 RETURNING d.id, d.webhook_id, d.event_type, d.event_payload, d.message_id,
+		           d.status, d.attempts, d.max_attempts, d.last_error,
+		           d.last_status_code, d.last_attempt_at, d.next_retry_at,
+		           d.created_at, d.expires_at`,
+		limit, int(LeaseDuration.Seconds()),
+	)
+	if err != nil {
+		return nil, err
+	}
+
 	var out []SubscriberDelivery
 	for rows.Next() {
 		var d SubscriberDelivery
@@ -68,11 +90,19 @@ func (s *SubscriberStore) GetPending(ctx context.Context, limit int) ([]Subscrib
 			&d.LastStatusCode, &d.LastAttemptAt, &d.NextRetryAt,
 			&d.CreatedAt, &d.ExpiresAt,
 		); err != nil {
+			rows.Close()
 			return nil, err
 		}
 		out = append(out, d)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	rows.Close()
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // MarkDelivered transitions a row to status='delivered' and stamps
@@ -113,20 +143,31 @@ func (s *SubscriberStore) MarkDelivered(ctx context.Context, deliveryID string, 
 //
 // statusCode is 0 when the failure was a connection error / timeout
 // (no HTTP response received).
+//
+// SELECT and UPDATE run inside a single transaction with FOR UPDATE so
+// two workers can't race on the same row (which could happen if the
+// GetPending lease expires while an attempt is in flight). Without the
+// row lock, the read-then-write pattern under-counts attempts on
+// concurrent failure recording.
 func (s *SubscriberStore) RecordAttemptFailure(ctx context.Context, deliveryID, errMsg string, statusCode int) error {
-	// First, decide: is this attempt the final one?
-	var attempts, maxAttempts int
-	err := s.pool.QueryRow(ctx,
-		`SELECT attempts, max_attempts FROM webhook_subscriber_deliveries WHERE id = $1`,
-		deliveryID,
-	).Scan(&attempts, &maxAttempts)
+	tx, err := s.pool.Begin(ctx)
 	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	var attempts, maxAttempts int
+	if err := tx.QueryRow(ctx,
+		`SELECT attempts, max_attempts FROM webhook_subscriber_deliveries
+		 WHERE id = $1 FOR UPDATE`,
+		deliveryID,
+	).Scan(&attempts, &maxAttempts); err != nil {
 		return err
 	}
 	newAttempts := attempts + 1
 
 	if newAttempts >= maxAttempts {
-		_, err = s.pool.Exec(ctx,
+		if _, err := tx.Exec(ctx,
 			`UPDATE webhook_subscriber_deliveries
 			 SET status = 'failed',
 			     attempts = $2,
@@ -135,8 +176,10 @@ func (s *SubscriberStore) RecordAttemptFailure(ctx context.Context, deliveryID, 
 			     last_status_code = $4
 			 WHERE id = $1`,
 			deliveryID, newAttempts, errMsg, statusCode,
-		)
-		return err
+		); err != nil {
+			return err
+		}
+		return tx.Commit(ctx)
 	}
 
 	nextRetry, ok := nextRetryAt(newAttempts)
@@ -145,7 +188,7 @@ func (s *SubscriberStore) RecordAttemptFailure(ctx context.Context, deliveryID, 
 		// backoff slice. The branch above should have caught it.
 		nextRetry = time.Now().Add(1 * time.Hour)
 	}
-	_, err = s.pool.Exec(ctx,
+	if _, err := tx.Exec(ctx,
 		`UPDATE webhook_subscriber_deliveries
 		 SET attempts = $2,
 		     last_attempt_at = now(),
@@ -154,8 +197,10 @@ func (s *SubscriberStore) RecordAttemptFailure(ctx context.Context, deliveryID, 
 		     next_retry_at = $5
 		 WHERE id = $1`,
 		deliveryID, newAttempts, errMsg, statusCode, nextRetry,
-	)
-	return err
+	); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
 }
 
 // generateDeliveryID returns a prefixed id of the form wdl_<32-hex>.

--- a/internal/webhook/subscriber_store.go
+++ b/internal/webhook/subscriber_store.go
@@ -237,6 +237,21 @@ func (s *SubscriberStore) InsertPendingForTest(ctx context.Context, webhookID, e
 	return id, nil
 }
 
+// BumpNextRetry pushes the row's next_retry_at out by `after` so the
+// row doesn't reappear in GetPending on every tick. Used by the worker
+// when it skips a row without attempting delivery (e.g. webhook is
+// disabled, waiting for re-enable). Status stays 'pending' so the row
+// resumes processing once the deferred time arrives.
+func (s *SubscriberStore) BumpNextRetry(ctx context.Context, deliveryID string, after time.Duration) error {
+	_, err := s.pool.Exec(ctx,
+		`UPDATE webhook_subscriber_deliveries
+		 SET next_retry_at = now() + ($2 * interval '1 second')
+		 WHERE id = $1`,
+		deliveryID, int(after.Seconds()),
+	)
+	return err
+}
+
 // DeleteExpiredSubscriberDeliveries removes rows whose expires_at has
 // passed. Migration 025 sets a 30-day TTL on every row; without this
 // janitor the table grows monotonically and query plans degrade.

--- a/internal/webhook/subscriber_store.go
+++ b/internal/webhook/subscriber_store.go
@@ -2,6 +2,8 @@ package webhook
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"time"
 
@@ -154,4 +156,79 @@ func (s *SubscriberStore) RecordAttemptFailure(ctx context.Context, deliveryID, 
 		deliveryID, newAttempts, errMsg, statusCode, nextRetry,
 	)
 	return err
+}
+
+// generateDeliveryID returns a prefixed id of the form wdl_<32-hex>.
+// 16 bytes of entropy is more than enough — the row is short-lived
+// (30-day expiry), and the prefix follows the rest of the e2a id
+// scheme so logs and dashboards can spot a delivery id at a glance.
+func generateDeliveryID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		panic(fmt.Sprintf("webhook: crypto/rand failed: %v", err))
+	}
+	return "wdl_" + hex.EncodeToString(b)
+}
+
+// InsertPendingForTest creates a single delivery row tied to the given
+// webhook + event type with the supplied envelope bytes. The retry
+// worker picks it up on the next tick. Used by the
+// POST /api/v1/webhooks/{id}/test endpoint to schedule a one-off
+// delivery without going through the publisher's filter-matching path.
+func (s *SubscriberStore) InsertPendingForTest(ctx context.Context, webhookID, eventType string, envelope []byte) (string, error) {
+	id := generateDeliveryID()
+	_, err := s.pool.Exec(ctx,
+		`INSERT INTO webhook_subscriber_deliveries
+		     (id, webhook_id, event_type, event_payload, status, next_retry_at)
+		 VALUES ($1, $2, $3, $4, 'pending', now())`,
+		id, webhookID, eventType, envelope,
+	)
+	if err != nil {
+		return "", fmt.Errorf("insert test delivery: %w", err)
+	}
+	return id, nil
+}
+
+// ListDeliveriesByWebhook returns up to `limit` delivery rows for the
+// webhook, most-recent first. When status is non-empty, restricts to
+// that status (pending|delivered|failed). Limit is bounded by the
+// caller; this method does not enforce a cap.
+func (s *SubscriberStore) ListDeliveriesByWebhook(ctx context.Context, webhookID, status string, limit int) ([]SubscriberDelivery, error) {
+	var (
+		rowsErr error
+		out     []SubscriberDelivery
+	)
+	q := `SELECT id, webhook_id, event_type, event_payload, message_id,
+	             status, attempts, max_attempts, last_error,
+	             last_status_code, last_attempt_at, next_retry_at,
+	             created_at, expires_at
+	      FROM webhook_subscriber_deliveries
+	      WHERE webhook_id = $1`
+	args := []interface{}{webhookID}
+	if status != "" {
+		q += ` AND status = $2`
+		args = append(args, status)
+	}
+	q += ` ORDER BY created_at DESC LIMIT $` + fmt.Sprintf("%d", len(args)+1)
+	args = append(args, limit)
+
+	rows, err := s.pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var d SubscriberDelivery
+		if err := rows.Scan(
+			&d.ID, &d.WebhookID, &d.EventType, &d.EventPayload, &d.MessageID,
+			&d.Status, &d.Attempts, &d.MaxAttempts, &d.LastError,
+			&d.LastStatusCode, &d.LastAttemptAt, &d.NextRetryAt,
+			&d.CreatedAt, &d.ExpiresAt,
+		); err != nil {
+			return nil, err
+		}
+		out = append(out, d)
+	}
+	rowsErr = rows.Err()
+	return out, rowsErr
 }

--- a/internal/webhook/subscriber_store.go
+++ b/internal/webhook/subscriber_store.go
@@ -203,16 +203,19 @@ func (s *SubscriberStore) RecordAttemptFailure(ctx context.Context, deliveryID, 
 	return tx.Commit(ctx)
 }
 
-// generateDeliveryID returns a prefixed id of the form wdl_<32-hex>.
+// generateDeliveryID returns a prefixed id of the form whd_<32-hex>.
 // 16 bytes of entropy is more than enough — the row is short-lived
 // (30-day expiry), and the prefix follows the rest of the e2a id
 // scheme so logs and dashboards can spot a delivery id at a glance.
+// Matches the publisher's inline generator at webhookpub/publisher.go
+// so customers see one consistent prefix regardless of which path
+// created the row (publisher fan-out vs. /test endpoint).
 func generateDeliveryID() string {
 	b := make([]byte, 16)
 	if _, err := rand.Read(b); err != nil {
 		panic(fmt.Sprintf("webhook: crypto/rand failed: %v", err))
 	}
-	return "wdl_" + hex.EncodeToString(b)
+	return "whd_" + hex.EncodeToString(b)
 }
 
 // InsertPendingForTest creates a single delivery row tied to the given

--- a/internal/webhook/subscriber_store.go
+++ b/internal/webhook/subscriber_store.go
@@ -234,6 +234,20 @@ func (s *SubscriberStore) InsertPendingForTest(ctx context.Context, webhookID, e
 	return id, nil
 }
 
+// DeleteExpiredSubscriberDeliveries removes rows whose expires_at has
+// passed. Migration 025 sets a 30-day TTL on every row; without this
+// janitor the table grows monotonically and query plans degrade.
+// Mirrors DeliveryStore.DeleteExpiredDeliveries for the legacy table.
+func (s *SubscriberStore) DeleteExpiredSubscriberDeliveries(ctx context.Context) (int, error) {
+	tag, err := s.pool.Exec(ctx,
+		`DELETE FROM webhook_subscriber_deliveries WHERE expires_at <= now()`,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return int(tag.RowsAffected()), nil
+}
+
 // ListDeliveriesByWebhook returns up to `limit` delivery rows for the
 // webhook, most-recent first. When status is non-empty, restricts to
 // that status (pending|delivered|failed). Limit is bounded by the

--- a/internal/webhook/subscriber_store.go
+++ b/internal/webhook/subscriber_store.go
@@ -1,0 +1,157 @@
+package webhook
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// SubscriberDelivery is one row in webhook_subscriber_deliveries.
+// Distinct from the legacy Delivery struct (which is keyed by
+// message_id and tracks legacy single-URL delivery state).
+type SubscriberDelivery struct {
+	ID             string
+	WebhookID      string
+	EventType      string
+	EventPayload   []byte // pre-marshalled envelope bytes; POSTed verbatim
+	MessageID      *string
+	Status         string // pending | delivered | failed
+	Attempts       int
+	MaxAttempts    int
+	LastError      string
+	LastStatusCode *int
+	LastAttemptAt  *time.Time
+	NextRetryAt    time.Time
+	CreatedAt      time.Time
+	ExpiresAt      time.Time
+}
+
+// SubscriberStore manages webhook_subscriber_deliveries. Parallel to
+// the legacy DeliveryStore (which manages webhook_deliveries).
+type SubscriberStore struct {
+	pool *pgxpool.Pool
+}
+
+func NewSubscriberStore(pool *pgxpool.Pool) *SubscriberStore {
+	return &SubscriberStore{pool: pool}
+}
+
+// GetPending pulls up to limit rows whose next_retry_at is in the
+// past, ordered by next_retry_at ASC (oldest-due first). Caller is
+// responsible for processing them and updating status — no row-level
+// lease here; the worker's per-webhook inflight cap is what prevents
+// double-processing.
+func (s *SubscriberStore) GetPending(ctx context.Context, limit int) ([]SubscriberDelivery, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT id, webhook_id, event_type, event_payload, message_id,
+		        status, attempts, max_attempts, last_error,
+		        last_status_code, last_attempt_at, next_retry_at,
+		        created_at, expires_at
+		 FROM webhook_subscriber_deliveries
+		 WHERE status = 'pending' AND next_retry_at <= now()
+		 ORDER BY next_retry_at ASC
+		 LIMIT $1`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []SubscriberDelivery
+	for rows.Next() {
+		var d SubscriberDelivery
+		if err := rows.Scan(
+			&d.ID, &d.WebhookID, &d.EventType, &d.EventPayload, &d.MessageID,
+			&d.Status, &d.Attempts, &d.MaxAttempts, &d.LastError,
+			&d.LastStatusCode, &d.LastAttemptAt, &d.NextRetryAt,
+			&d.CreatedAt, &d.ExpiresAt,
+		); err != nil {
+			return nil, err
+		}
+		out = append(out, d)
+	}
+	return out, rows.Err()
+}
+
+// MarkDelivered transitions a row to status='delivered' and stamps
+// last_attempt_at + last_status_code. Also bumps webhooks.last_delivered_at
+// in the same transaction so list views show the freshest activity.
+func (s *SubscriberStore) MarkDelivered(ctx context.Context, deliveryID string, statusCode int) error {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	var webhookID string
+	if err := tx.QueryRow(ctx,
+		`UPDATE webhook_subscriber_deliveries
+		 SET status = 'delivered',
+		     last_attempt_at = now(),
+		     last_status_code = $2,
+		     attempts = attempts + 1
+		 WHERE id = $1
+		 RETURNING webhook_id`,
+		deliveryID, statusCode,
+	).Scan(&webhookID); err != nil {
+		return fmt.Errorf("mark delivered: %w", err)
+	}
+	if _, err := tx.Exec(ctx,
+		`UPDATE webhooks SET last_delivered_at = now() WHERE id = $1`,
+		webhookID,
+	); err != nil {
+		return fmt.Errorf("bump last_delivered_at: %w", err)
+	}
+	return tx.Commit(ctx)
+}
+
+// RecordAttemptFailure records a failed attempt, sets the next retry
+// time, and decides whether to keep the row pending (more attempts
+// remain) or transition to 'failed' (exhausted).
+//
+// statusCode is 0 when the failure was a connection error / timeout
+// (no HTTP response received).
+func (s *SubscriberStore) RecordAttemptFailure(ctx context.Context, deliveryID, errMsg string, statusCode int) error {
+	// First, decide: is this attempt the final one?
+	var attempts, maxAttempts int
+	err := s.pool.QueryRow(ctx,
+		`SELECT attempts, max_attempts FROM webhook_subscriber_deliveries WHERE id = $1`,
+		deliveryID,
+	).Scan(&attempts, &maxAttempts)
+	if err != nil {
+		return err
+	}
+	newAttempts := attempts + 1
+
+	if newAttempts >= maxAttempts {
+		_, err = s.pool.Exec(ctx,
+			`UPDATE webhook_subscriber_deliveries
+			 SET status = 'failed',
+			     attempts = $2,
+			     last_attempt_at = now(),
+			     last_error = $3,
+			     last_status_code = $4
+			 WHERE id = $1`,
+			deliveryID, newAttempts, errMsg, statusCode,
+		)
+		return err
+	}
+
+	nextRetry, ok := nextRetryAt(newAttempts)
+	if !ok {
+		// Defensive: nextRetryAt only fails if attempts exceeds the
+		// backoff slice. The branch above should have caught it.
+		nextRetry = time.Now().Add(1 * time.Hour)
+	}
+	_, err = s.pool.Exec(ctx,
+		`UPDATE webhook_subscriber_deliveries
+		 SET attempts = $2,
+		     last_attempt_at = now(),
+		     last_error = $3,
+		     last_status_code = $4,
+		     next_retry_at = $5
+		 WHERE id = $1`,
+		deliveryID, newAttempts, errMsg, statusCode, nextRetry,
+	)
+	return err
+}

--- a/internal/webhookpub/event.go
+++ b/internal/webhookpub/event.go
@@ -1,0 +1,148 @@
+// Package webhookpub publishes events from the e2a core (relay,
+// outbound sender, HITL flow) to subscribers registered via the new
+// /api/v1/webhooks resource. It runs in-process and post-commit
+// async: trigger code commits its primary DB write, then calls
+// Publisher.Publish in a goroutine. The publisher matches the event
+// against enabled subscribers (event type + filters), inserts one
+// webhook_subscriber_deliveries row per match, and returns; actual
+// HTTP delivery is the retry worker's job.
+//
+// Slice 1 only fires email.received from the relay. Slice 3 extends
+// to email.sent, email.pending_approval, email.approved, email.rejected.
+//
+// The legacy agent_identities.webhook_url path is unaffected by this
+// package — it continues to be served by internal/webhook's existing
+// PersistentDeliverer + retry worker. Both pathways fire side-by-side
+// for back-compat. See the final design at tmp/e2a_webhooks_design.md.
+package webhookpub
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"time"
+)
+
+// Event types. Keeping these as named constants (not arbitrary strings)
+// means typos at trigger sites fail at compile time. The handler-layer
+// allowlist of accepted event names mirrors this list.
+const (
+	EventEmailReceived        = "email.received"
+	EventEmailSent            = "email.sent"
+	EventEmailPendingApproval = "email.pending_approval"
+	EventEmailApproved        = "email.approved"
+	EventEmailRejected        = "email.rejected"
+)
+
+// AllEventTypes is the canonical allowlist of event names. Used by
+// the slice-2 handler validation. Adding a new event type means
+// adding a constant above AND extending this slice.
+var AllEventTypes = []string{
+	EventEmailReceived,
+	EventEmailSent,
+	EventEmailPendingApproval,
+	EventEmailApproved,
+	EventEmailRejected,
+}
+
+// IsValidEventType reports whether name is one of the catalog
+// event types. Convenience wrapper for the handler-layer validator.
+func IsValidEventType(name string) bool {
+	for _, e := range AllEventTypes {
+		if e == name {
+			return true
+		}
+	}
+	return false
+}
+
+// Event is the input to Publisher.Publish. Carries the routing keys
+// (UserID, AgentID, ConversationID, Labels) needed to apply filters
+// plus the Data payload that's serialized into the delivery row's
+// event_payload JSONB.
+//
+// MessageID is optional — set when the event has an originating
+// message row. Persisted on the delivery row with ON DELETE SET NULL
+// so the 30-day messages janitor doesn't orphan the delivery.
+type Event struct {
+	// ID is a unique identifier for this event firing. Stable across
+	// retries — receivers dedup on it.
+	ID string
+
+	// Type is one of the EventEmail* constants.
+	Type string
+
+	// CreatedAt is the time the event was published. Embedded in
+	// the wire envelope so receivers can reason about staleness.
+	CreatedAt time.Time
+
+	// UserID is the owner — used to find matching webhooks. Routing
+	// is strictly bounded to the owning user's subscribers; cross-
+	// user delivery is impossible by construction.
+	UserID string
+
+	// AgentID, ConversationID, Labels are filter-matching keys. Each
+	// is matched against the corresponding key in
+	// WebhookFilters. Empty / nil here means "the event has no value
+	// for this attribute" — see Publisher's null/empty semantics
+	// (filters that REQUIRE a value while the event has none → skip).
+	AgentID        string
+	ConversationID string
+	Labels         []string
+
+	// MessageID is the originating message row, if any. May be empty
+	// for events without a direct message backing (e.g.
+	// email.pending_approval before the held message gets promoted).
+	MessageID string
+
+	// Data is the event-specific payload. Wrapped in the envelope
+	// {event, id, created_at, data} and serialized into the delivery
+	// row's event_payload column.
+	Data any
+}
+
+// NewEvent constructs an Event with a fresh ID and now() timestamp.
+// Trigger sites use this rather than building struct literals so the
+// ID format stays consistent (evt_<32-hex>).
+func NewEvent(eventType, userID string, data any) Event {
+	return Event{
+		ID:        generateEventID(),
+		Type:      eventType,
+		CreatedAt: time.Now().UTC(),
+		UserID:    userID,
+		Data:      data,
+	}
+}
+
+// Envelope is the wire shape sent in the HTTP body to webhook
+// subscribers. Stable across retries — the event_payload JSON column
+// stores the envelope verbatim and the delivery worker POSTs it
+// unchanged.
+type Envelope struct {
+	Event     string    `json:"event"`
+	ID        string    `json:"id"`
+	CreatedAt time.Time `json:"created_at"`
+	Data      any       `json:"data"`
+}
+
+// AsEnvelope returns the wire shape for serialization.
+func (e Event) AsEnvelope() Envelope {
+	return Envelope{
+		Event:     e.Type,
+		ID:        e.ID,
+		CreatedAt: e.CreatedAt,
+		Data:      e.Data,
+	}
+}
+
+func generateEventID() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		// crypto/rand failure means the OS RNG is broken; an
+		// all-zero event ID would collide across firings. Panic so
+		// the caller surfaces a 500 rather than silently emitting
+		// non-unique IDs.
+		panic(fmt.Sprintf("webhookpub: crypto/rand failed: %v", err))
+	}
+	return "evt_" + hex.EncodeToString(b)
+}

--- a/internal/webhookpub/ids.go
+++ b/internal/webhookpub/ids.go
@@ -1,0 +1,19 @@
+package webhookpub
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+)
+
+// randHex16 returns 16 random bytes hex-encoded. Used for delivery
+// row IDs (whd_<32-hex>). Panics on OS RNG failure for the same
+// reason generateEventID does: an all-zero ID would collide across
+// firings.
+func randHex16() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		panic(fmt.Sprintf("webhookpub: crypto/rand failed: %v", err))
+	}
+	return hex.EncodeToString(b)
+}

--- a/internal/webhookpub/publisher.go
+++ b/internal/webhookpub/publisher.go
@@ -1,0 +1,221 @@
+package webhookpub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Publisher fans an Event out to matching webhook subscribers. The
+// in-process implementation:
+//   1. Looks up enabled webhooks for Event.UserID subscribed to
+//      Event.Type via identity.Store.ListEnabledWebhooksForRouting.
+//   2. Applies filter matching in Go (matches reports the rule).
+//   3. Inserts one webhook_subscriber_deliveries row per match
+//      (status=pending). Each row gets a unique whd_<random> id.
+//   4. Returns. The retry worker picks up the pending rows on its
+//      next tick and POSTs them.
+//
+// On error during enumeration / insert, the publisher logs and
+// silently drops — partial failure is preferable to losing the
+// trigger's primary state change. Crash between commit and publish
+// loses the event entirely; the deferred-items list documents this
+// as the "post-commit async" trade-off.
+type Publisher interface {
+	Publish(ctx context.Context, e Event)
+}
+
+// store is the subset of identity.Store the publisher needs. Keeping
+// it an interface lets tests pass a fake without spinning up a real
+// pool.
+type store interface {
+	ListEnabledWebhooksForRouting(ctx context.Context, userID, eventType string) ([]identity.Webhook, error)
+}
+
+// deliveryInserter is the storage primitive that creates a delivery
+// row from a matched (webhook, event) pair. Split out so the worker
+// package can implement it without webhookpub depending on
+// internal/webhook (which would create an import cycle once the
+// worker depends on the identity store).
+type deliveryInserter interface {
+	InsertPending(ctx context.Context, webhookID, eventType, messageID string, envelope []byte) error
+}
+
+// FeatureFlag is the kill switch for the new path. When false,
+// Publish becomes a no-op (no DB writes, no fan-out). The retry
+// worker is unaffected — it keeps draining any pending rows that
+// were inserted before the flag was flipped. See decision #3 in
+// the design.
+type FeatureFlag interface {
+	Enabled() bool
+}
+
+// StaticFlag is a trivially-implemented FeatureFlag for tests and
+// for production wiring that reads an env var at startup.
+type StaticFlag bool
+
+func (f StaticFlag) Enabled() bool { return bool(f) }
+
+// publisher is the production Publisher backed by the identity store
+// and a DB-backed inserter.
+type publisher struct {
+	store    store
+	inserter deliveryInserter
+	flag     FeatureFlag
+}
+
+// New constructs a Publisher.
+func New(s store, ins deliveryInserter, flag FeatureFlag) Publisher {
+	if flag == nil {
+		// Default: flag enabled. Production wiring should always
+		// pass an explicit FeatureFlag; tests sometimes don't.
+		flag = StaticFlag(true)
+	}
+	return &publisher{store: s, inserter: ins, flag: flag}
+}
+
+// Publish runs the routing + delivery-row insertion. Designed to be
+// called from a goroutine — it does not block the caller's trigger
+// path and swallows all errors after logging them.
+func (p *publisher) Publish(ctx context.Context, e Event) {
+	if !p.flag.Enabled() {
+		return
+	}
+	if e.UserID == "" || e.Type == "" {
+		log.Printf("[webhookpub] dropping event with empty UserID or Type: %+v", e)
+		return
+	}
+
+	candidates, err := p.store.ListEnabledWebhooksForRouting(ctx, e.UserID, e.Type)
+	if err != nil {
+		log.Printf("[webhookpub] ListEnabledWebhooksForRouting err: user=%s event=%s err=%v", e.UserID, e.Type, err)
+		return
+	}
+
+	if len(candidates) == 0 {
+		return
+	}
+
+	envelopeJSON, err := json.Marshal(e.AsEnvelope())
+	if err != nil {
+		log.Printf("[webhookpub] marshal envelope: event=%s err=%v", e.ID, err)
+		return
+	}
+
+	matched := 0
+	for _, w := range candidates {
+		if !matches(e, w.Filters) {
+			continue
+		}
+		if err := p.inserter.InsertPending(ctx, w.ID, e.Type, e.MessageID, envelopeJSON); err != nil {
+			log.Printf("[webhookpub] InsertPending err: webhook=%s event=%s err=%v", w.ID, e.ID, err)
+			continue
+		}
+		matched++
+	}
+
+	if matched > 0 {
+		log.Printf("[webhookpub] published event=%s type=%s user=%s subscribers=%d", e.ID, e.Type, e.UserID, matched)
+	}
+}
+
+// matches applies the filter-match rule from the design:
+//
+//   - filter type empty / nil  → no constraint for that type
+//   - filter type non-empty AND event field has a matching value → match
+//   - filter type non-empty AND event field has no matching value
+//     (including the case where the event field is itself empty) → SKIP
+//
+// AND across filter types, OR within a type. Documented consequence:
+// a "labels = [urgent]" filter does NOT match an event whose Labels
+// slice is empty/nil — i.e. unlabelled inbound mail is silently
+// skipped when the subscriber has a label filter. This is the
+// explicit semantic chosen in the design (H5).
+func matches(e Event, f identity.WebhookFilters) bool {
+	if len(f.AgentIDs) > 0 {
+		if e.AgentID == "" {
+			return false
+		}
+		if !contains(f.AgentIDs, e.AgentID) {
+			return false
+		}
+	}
+	if len(f.ConversationIDs) > 0 {
+		if e.ConversationID == "" {
+			return false
+		}
+		if !contains(f.ConversationIDs, e.ConversationID) {
+			return false
+		}
+	}
+	if len(f.Labels) > 0 {
+		if len(e.Labels) == 0 {
+			return false
+		}
+		if !intersects(f.Labels, e.Labels) {
+			return false
+		}
+	}
+	return true
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func intersects(a, b []string) bool {
+	// O(len(a) * len(b)) — fine at slice 1 scale (filters cap 50,
+	// event labels cap 100 per the labels feature design).
+	for _, x := range a {
+		for _, y := range b {
+			if x == y {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// dbInserter is the production deliveryInserter backed by pgx.
+// Held here (not in internal/webhook) so the publisher can stay
+// import-cycle-free with respect to the existing webhook package.
+// The retry worker in internal/webhook reads from the same table.
+type dbInserter struct {
+	pool *pgxpool.Pool
+}
+
+// NewDBInserter wires a production-grade inserter that writes to
+// webhook_subscriber_deliveries.
+func NewDBInserter(pool *pgxpool.Pool) deliveryInserter {
+	return &dbInserter{pool: pool}
+}
+
+func (i *dbInserter) InsertPending(ctx context.Context, webhookID, eventType, messageID string, envelope []byte) error {
+	// generateDeliveryID is intentionally inline rather than reaching
+	// into identity — keeps the cross-package edge minimal. Same
+	// pattern as generateID elsewhere.
+	id := "whd_" + randHex16()
+	var msgID *string
+	if messageID != "" {
+		msgID = &messageID
+	}
+	_, err := i.pool.Exec(ctx,
+		`INSERT INTO webhook_subscriber_deliveries
+		    (id, webhook_id, event_type, event_payload, message_id, status)
+		 VALUES ($1, $2, $3, $4, $5, 'pending')`,
+		id, webhookID, eventType, envelope, msgID,
+	)
+	if err != nil {
+		return fmt.Errorf("insert webhook_subscriber_deliveries: %w", err)
+	}
+	return nil
+}

--- a/internal/webhookpub/publisher_test.go
+++ b/internal/webhookpub/publisher_test.go
@@ -1,0 +1,365 @@
+package webhookpub
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+)
+
+// fakeStore is the minimal store interface the publisher needs. We
+// keep it in a test file so production code stays import-cycle-free
+// and tests don't drag in pgx.
+type fakeStore struct {
+	webhooks []identity.Webhook
+	listErr  error
+}
+
+func (f *fakeStore) ListEnabledWebhooksForRouting(ctx context.Context, userID, eventType string) ([]identity.Webhook, error) {
+	if f.listErr != nil {
+		return nil, f.listErr
+	}
+	var out []identity.Webhook
+	for _, w := range f.webhooks {
+		if w.UserID != userID {
+			continue
+		}
+		if !w.Enabled {
+			continue
+		}
+		for _, e := range w.Events {
+			if e == eventType {
+				out = append(out, w)
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+// fakeInserter captures the InsertPending calls so tests can assert
+// which webhook IDs got delivery rows.
+type fakeInserter struct {
+	mu        sync.Mutex
+	inserted  []insertCall
+	insertErr error
+}
+
+type insertCall struct {
+	webhookID string
+	eventType string
+	messageID string
+	envelope  []byte
+}
+
+func (f *fakeInserter) InsertPending(ctx context.Context, webhookID, eventType, messageID string, envelope []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.insertErr != nil {
+		return f.insertErr
+	}
+	f.inserted = append(f.inserted, insertCall{
+		webhookID: webhookID,
+		eventType: eventType,
+		messageID: messageID,
+		envelope:  append([]byte(nil), envelope...),
+	})
+	return nil
+}
+
+func (f *fakeInserter) IDs() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, 0, len(f.inserted))
+	for _, c := range f.inserted {
+		out = append(out, c.webhookID)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func newTestPublisher(webhooks []identity.Webhook) (Publisher, *fakeInserter) {
+	store := &fakeStore{webhooks: webhooks}
+	inserter := &fakeInserter{}
+	pub := New(store, inserter, StaticFlag(true))
+	return pub, inserter
+}
+
+func receivedEvent(userID, agentID, conversationID string, labels []string) Event {
+	return Event{
+		ID:             "evt_test",
+		Type:           EventEmailReceived,
+		CreatedAt:      time.Date(2026, 5, 30, 0, 0, 0, 0, time.UTC),
+		UserID:         userID,
+		AgentID:        agentID,
+		ConversationID: conversationID,
+		Labels:         labels,
+		Data:           map[string]any{"hello": "world"},
+	}
+}
+
+func TestPublisher_NoFiltersMatchesAll(t *testing.T) {
+	w := identity.Webhook{ID: "wh_1", UserID: "u", Events: []string{EventEmailReceived}, Enabled: true}
+	pub, ins := newTestPublisher([]identity.Webhook{w})
+
+	pub.Publish(context.Background(), receivedEvent("u", "bot@x", "conv-1", []string{"urgent"}))
+
+	if got := ins.IDs(); len(got) != 1 || got[0] != "wh_1" {
+		t.Errorf("matched = %v, want [wh_1]", got)
+	}
+}
+
+func TestPublisher_FeatureFlagDisablesPublish(t *testing.T) {
+	w := identity.Webhook{ID: "wh_1", UserID: "u", Events: []string{EventEmailReceived}, Enabled: true}
+	pub := New(&fakeStore{webhooks: []identity.Webhook{w}}, &fakeInserter{}, StaticFlag(false))
+
+	// Publish should be a no-op when the flag is off.
+	pub.Publish(context.Background(), receivedEvent("u", "bot@x", "", nil))
+	// Nothing observable from this test other than no panic — the
+	// fakeInserter never receives a call. We re-check by passing a
+	// fresh inserter and asserting it stays empty.
+	ins := &fakeInserter{}
+	pub2 := New(&fakeStore{webhooks: []identity.Webhook{w}}, ins, StaticFlag(false))
+	pub2.Publish(context.Background(), receivedEvent("u", "bot@x", "", nil))
+	if got := ins.IDs(); len(got) != 0 {
+		t.Errorf("flag-off published %d deliveries; want 0", len(got))
+	}
+}
+
+func TestPublisher_DisabledWebhookSkipped(t *testing.T) {
+	// fakeStore already filters by Enabled; this asserts the
+	// production-shaped query (ListEnabledWebhooksForRouting only
+	// returns enabled rows) is what the publisher relies on.
+	w := identity.Webhook{ID: "wh_1", UserID: "u", Events: []string{EventEmailReceived}, Enabled: false}
+	pub, ins := newTestPublisher([]identity.Webhook{w})
+	pub.Publish(context.Background(), receivedEvent("u", "bot@x", "", nil))
+	if got := ins.IDs(); len(got) != 0 {
+		t.Errorf("disabled webhook published %d times; want 0", len(got))
+	}
+}
+
+func TestPublisher_AgentIDFilter(t *testing.T) {
+	w := identity.Webhook{
+		ID:      "wh_1",
+		UserID:  "u",
+		Events:  []string{EventEmailReceived},
+		Enabled: true,
+		Filters: identity.WebhookFilters{AgentIDs: []string{"bot@x"}},
+	}
+	pub, ins := newTestPublisher([]identity.Webhook{w})
+
+	// Matching agent_id → delivered.
+	pub.Publish(context.Background(), receivedEvent("u", "bot@x", "", nil))
+	if got := ins.IDs(); len(got) != 1 {
+		t.Errorf("matching agent_id delivered %d times; want 1", len(got))
+	}
+
+	// Non-matching agent_id → skipped.
+	pub2, ins2 := newTestPublisher([]identity.Webhook{w})
+	pub2.Publish(context.Background(), receivedEvent("u", "other@x", "", nil))
+	if got := ins2.IDs(); len(got) != 0 {
+		t.Errorf("non-matching agent_id delivered %d times; want 0", len(got))
+	}
+}
+
+func TestPublisher_LabelFilter_NullEmptyEventSemantics(t *testing.T) {
+	// H5 from the design review: when filters.labels is non-empty
+	// and event.labels is nil/empty, the webhook MUST skip. Same for
+	// conversation_id and agent_id.
+	w := identity.Webhook{
+		ID:      "wh_1",
+		UserID:  "u",
+		Events:  []string{EventEmailReceived},
+		Enabled: true,
+		Filters: identity.WebhookFilters{Labels: []string{"urgent"}},
+	}
+
+	// Event with no labels (nil) — must skip.
+	pub, ins := newTestPublisher([]identity.Webhook{w})
+	pub.Publish(context.Background(), receivedEvent("u", "bot@x", "", nil))
+	if got := ins.IDs(); len(got) != 0 {
+		t.Errorf("nil labels delivered %d; want 0 (H5)", len(got))
+	}
+
+	// Event with empty labels slice — must skip.
+	pub2, ins2 := newTestPublisher([]identity.Webhook{w})
+	pub2.Publish(context.Background(), receivedEvent("u", "bot@x", "", []string{}))
+	if got := ins2.IDs(); len(got) != 0 {
+		t.Errorf("empty labels delivered %d; want 0 (H5)", len(got))
+	}
+
+	// Event with overlapping label — match.
+	pub3, ins3 := newTestPublisher([]identity.Webhook{w})
+	pub3.Publish(context.Background(), receivedEvent("u", "bot@x", "", []string{"urgent", "other"}))
+	if got := ins3.IDs(); len(got) != 1 {
+		t.Errorf("overlapping label delivered %d; want 1", len(got))
+	}
+
+	// Event with non-overlapping label — skip.
+	pub4, ins4 := newTestPublisher([]identity.Webhook{w})
+	pub4.Publish(context.Background(), receivedEvent("u", "bot@x", "", []string{"other"}))
+	if got := ins4.IDs(); len(got) != 0 {
+		t.Errorf("non-overlapping label delivered %d; want 0", len(got))
+	}
+}
+
+func TestPublisher_ConversationIDFilter_NullEmptySemantics(t *testing.T) {
+	// Same H5 rule applied to conversation_id.
+	w := identity.Webhook{
+		ID:      "wh_1",
+		UserID:  "u",
+		Events:  []string{EventEmailReceived},
+		Enabled: true,
+		Filters: identity.WebhookFilters{ConversationIDs: []string{"conv-X"}},
+	}
+
+	// Empty event conversation_id — skip.
+	pub, ins := newTestPublisher([]identity.Webhook{w})
+	pub.Publish(context.Background(), receivedEvent("u", "bot@x", "", nil))
+	if got := ins.IDs(); len(got) != 0 {
+		t.Errorf("empty conversation_id delivered %d; want 0 (H5)", len(got))
+	}
+
+	// Matching — deliver.
+	pub2, ins2 := newTestPublisher([]identity.Webhook{w})
+	pub2.Publish(context.Background(), receivedEvent("u", "bot@x", "conv-X", nil))
+	if got := ins2.IDs(); len(got) != 1 {
+		t.Errorf("matching conversation_id delivered %d; want 1", len(got))
+	}
+}
+
+func TestPublisher_ANDAcrossFilterTypes(t *testing.T) {
+	// AND across types: agent_id must match AND labels must
+	// intersect.
+	w := identity.Webhook{
+		ID:      "wh_1",
+		UserID:  "u",
+		Events:  []string{EventEmailReceived},
+		Enabled: true,
+		Filters: identity.WebhookFilters{
+			AgentIDs: []string{"bot@x"},
+			Labels:   []string{"urgent"},
+		},
+	}
+
+	// Match both → deliver.
+	pub, ins := newTestPublisher([]identity.Webhook{w})
+	pub.Publish(context.Background(), receivedEvent("u", "bot@x", "", []string{"urgent"}))
+	if got := ins.IDs(); len(got) != 1 {
+		t.Errorf("agent+label match: delivered %d; want 1", len(got))
+	}
+
+	// Match agent only, miss label → skip.
+	pub2, ins2 := newTestPublisher([]identity.Webhook{w})
+	pub2.Publish(context.Background(), receivedEvent("u", "bot@x", "", []string{"other"}))
+	if got := ins2.IDs(); len(got) != 0 {
+		t.Errorf("agent-only match: delivered %d; want 0 (AND violated)", len(got))
+	}
+
+	// Miss agent, match label → skip.
+	pub3, ins3 := newTestPublisher([]identity.Webhook{w})
+	pub3.Publish(context.Background(), receivedEvent("u", "other@x", "", []string{"urgent"}))
+	if got := ins3.IDs(); len(got) != 0 {
+		t.Errorf("label-only match: delivered %d; want 0 (AND violated)", len(got))
+	}
+}
+
+func TestPublisher_ORWithinFilterType(t *testing.T) {
+	// Multiple values within a single filter type are OR-matched:
+	// agent_id = {A, B} matches either A or B.
+	w := identity.Webhook{
+		ID:      "wh_1",
+		UserID:  "u",
+		Events:  []string{EventEmailReceived},
+		Enabled: true,
+		Filters: identity.WebhookFilters{AgentIDs: []string{"a@x", "b@x"}},
+	}
+
+	pub, ins := newTestPublisher([]identity.Webhook{w})
+	pub.Publish(context.Background(), receivedEvent("u", "a@x", "", nil))
+	pub.Publish(context.Background(), receivedEvent("u", "b@x", "", nil))
+	pub.Publish(context.Background(), receivedEvent("u", "c@x", "", nil))
+
+	// Two of three events should have produced deliveries.
+	if got := ins.IDs(); len(got) != 2 {
+		t.Errorf("OR-within-type delivered %d; want 2", len(got))
+	}
+}
+
+func TestPublisher_FansOutToMultipleSubscribers(t *testing.T) {
+	w1 := identity.Webhook{ID: "wh_1", UserID: "u", Events: []string{EventEmailReceived}, Enabled: true}
+	w2 := identity.Webhook{ID: "wh_2", UserID: "u", Events: []string{EventEmailReceived}, Enabled: true}
+	w3 := identity.Webhook{ID: "wh_3", UserID: "u", Events: []string{EventEmailReceived}, Enabled: true}
+	pub, ins := newTestPublisher([]identity.Webhook{w1, w2, w3})
+
+	pub.Publish(context.Background(), receivedEvent("u", "bot@x", "", nil))
+
+	got := ins.IDs()
+	want := []string{"wh_1", "wh_2", "wh_3"}
+	if len(got) != 3 {
+		t.Errorf("fan-out delivered to %d subscribers; want 3", len(got))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("subscriber %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestPublisher_EnvelopeShape(t *testing.T) {
+	w := identity.Webhook{ID: "wh_1", UserID: "u", Events: []string{EventEmailReceived}, Enabled: true}
+	store := &fakeStore{webhooks: []identity.Webhook{w}}
+	ins := &fakeInserter{}
+	pub := New(store, ins, StaticFlag(true))
+
+	pub.Publish(context.Background(), receivedEvent("u", "bot@x", "", nil))
+
+	if len(ins.inserted) != 1 {
+		t.Fatalf("inserted %d rows; want 1", len(ins.inserted))
+	}
+	var env Envelope
+	if err := json.Unmarshal(ins.inserted[0].envelope, &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	if env.Event != EventEmailReceived {
+		t.Errorf("envelope.event = %q, want %q", env.Event, EventEmailReceived)
+	}
+	if env.ID == "" {
+		t.Error("envelope.id is empty")
+	}
+	if env.CreatedAt.IsZero() {
+		t.Error("envelope.created_at is zero")
+	}
+}
+
+func TestPublisher_SwallowsStoreError(t *testing.T) {
+	// Publisher must not panic or block on store error — log + drop
+	// is the right behavior (the trigger's primary state change has
+	// already committed).
+	store := &fakeStore{listErr: errors.New("simulated DB error")}
+	ins := &fakeInserter{}
+	pub := New(store, ins, StaticFlag(true))
+
+	// Should not panic.
+	pub.Publish(context.Background(), receivedEvent("u", "bot@x", "", nil))
+	if got := ins.IDs(); len(got) != 0 {
+		t.Errorf("store error produced %d deliveries; want 0", len(got))
+	}
+}
+
+func TestPublisher_SwallowsInsertError(t *testing.T) {
+	w1 := identity.Webhook{ID: "wh_1", UserID: "u", Events: []string{EventEmailReceived}, Enabled: true}
+	w2 := identity.Webhook{ID: "wh_2", UserID: "u", Events: []string{EventEmailReceived}, Enabled: true}
+	store := &fakeStore{webhooks: []identity.Webhook{w1, w2}}
+	// Inserter that fails every call: publisher should log+continue
+	// per webhook, never panic.
+	ins := &fakeInserter{insertErr: errors.New("simulated DB error")}
+	pub := New(store, ins, StaticFlag(true))
+
+	pub.Publish(context.Background(), receivedEvent("u", "bot@x", "", nil))
+}

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -4,6 +4,7 @@ import { registerMessageTools } from "./tools/messages.js";
 import { registerAgentTools } from "./tools/agents.js";
 import { registerDomainTools } from "./tools/domains.js";
 import { registerHitlTools } from "./tools/hitl.js";
+import { registerWebhookTools } from "./tools/webhooks.js";
 
 export interface BuildServerOptions {
   client: E2AClient;
@@ -19,5 +20,6 @@ export function buildServer({ client, version = "0.1.0" }: BuildServerOptions): 
   registerAgentTools(server, client);
   registerDomainTools(server, client);
   registerHitlTools(server, client);
+  registerWebhookTools(server, client);
   return server;
 }

--- a/mcp/src/tools/webhooks.ts
+++ b/mcp/src/tools/webhooks.ts
@@ -1,0 +1,189 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { E2AClient } from "@e2a/sdk/v1";
+import { z } from "zod";
+import { runTool, strictInputSchema } from "./util.js";
+
+/**
+ * Webhook-subscriber tools (top-level webhooks-as-a-resource).
+ *
+ * A webhook subscriber is owned by a user, not by an agent. One user
+ * can configure many webhooks, each scoped by event-type and optional
+ * filters (agent_ids, conversation_ids, labels). Distinct from the
+ * legacy `agent_identities.webhook_url` field — that single-URL path
+ * still works for cloud-mode agents; this resource is the upgrade path
+ * for fan-out, filtered subscriptions, signing-secret rotation, and
+ * delivery history.
+ *
+ * The plaintext signing_secret is returned ONCE on create + on
+ * rotate-secret. Other reads scrub it.
+ */
+export function registerWebhookTools(server: McpServer, client: E2AClient): void {
+  const filtersSchema = z
+    .object({
+      agent_ids: z.array(z.string()).optional(),
+      conversation_ids: z.array(z.string()).optional(),
+      labels: z.array(z.string()).optional(),
+    })
+    .strict()
+    .describe(
+      "Optional scope filters. Empty / missing keys mean 'no constraint of that type'. agent_ids must reference agents owned by the caller; cross-user ids are rejected. conversation_ids / labels are exact-match.",
+    );
+
+  server.registerTool(
+    "list_webhooks",
+    {
+      title: "List webhook subscribers",
+      description:
+        "Returns every webhook subscriber owned by the authenticated user, enabled + disabled, with their event subscriptions, filters, and last-delivered timestamp. signing_secret is omitted (it is only ever returned on create + rotate). Read-only; cheap.",
+      inputSchema: strictInputSchema({}),
+    },
+    async () => runTool(() => client.listWebhooks()),
+  );
+
+  server.registerTool(
+    "get_webhook",
+    {
+      title: "Show one webhook subscriber",
+      description:
+        "Fetch a single webhook by id. signing_secret is omitted — use rotate_webhook_secret if the secret was lost.",
+      inputSchema: strictInputSchema({
+        id: z.string().min(1).describe("Webhook id (wh_…)."),
+      }),
+    },
+    async (args) => runTool(() => client.getWebhook(args.id)),
+  );
+
+  server.registerTool(
+    "create_webhook",
+    {
+      title: "Create a webhook subscriber (returns plaintext signing_secret ONCE)",
+      description:
+        "Subscribe an HTTPS URL to one or more events (email.received, email.sent, email.pending_approval, email.approved, email.rejected). URL must be HTTPS and must resolve to a public IP (SSRF guard). The response includes a plaintext signing_secret which the caller MUST persist immediately — every subsequent list/get scrubs it. Per-user cap is 50 webhooks; rotate_webhook_secret rotates the secret in place with a 24h dual-sign grace window.",
+      inputSchema: strictInputSchema({
+        url: z.string().min(1).describe("HTTPS webhook URL. Public domain only — IPs are rejected."),
+        events: z
+          .array(z.string().min(1))
+          .min(1)
+          .describe(
+            "Event types to subscribe to. Valid: email.received, email.sent, email.pending_approval, email.approved, email.rejected.",
+          ),
+        description: z.string().optional().describe("Optional free-form label (max 200 chars)."),
+        filters: filtersSchema.optional(),
+      }),
+    },
+    async (args) =>
+      runTool(() =>
+        client.createWebhook({
+          url: args.url,
+          events: args.events,
+          description: args.description,
+          filters: args.filters,
+        }),
+      ),
+  );
+
+  server.registerTool(
+    "update_webhook",
+    {
+      title: "Update a webhook subscriber",
+      description:
+        "Partial update. Fields you do NOT pass are left unchanged. url / events / filters are full-replace when present (no array merge). Use enabled:false to pause delivery without losing config; enabled:true re-enables (subject to a 5-min cooldown after auto-disable).",
+      inputSchema: strictInputSchema({
+        id: z.string().min(1).describe("Webhook id (wh_…)."),
+        url: z.string().optional(),
+        events: z.array(z.string().min(1)).optional(),
+        filters: filtersSchema.optional(),
+        description: z.string().optional(),
+        enabled: z.boolean().optional(),
+      }),
+    },
+    async (args) => {
+      const { id, ...rest } = args;
+      return runTool(() => client.updateWebhook(id, rest));
+    },
+  );
+
+  server.registerTool(
+    "delete_webhook",
+    {
+      title: "Delete a webhook subscriber (DESTRUCTIVE)",
+      description:
+        "Permanently remove a webhook subscription. CASCADES to pending delivery rows. Requires confirm:true so an LLM cannot delete on ambiguous context.",
+      inputSchema: strictInputSchema({
+        id: z.string().min(1).describe("Webhook id (wh_…)."),
+        confirm: z.literal(true).describe("Must be true to proceed."),
+      }),
+    },
+    async (args) =>
+      runTool(async () => {
+        if (args.confirm !== true) {
+          throw new Error("delete_webhook requires confirm:true.");
+        }
+        await client.deleteWebhook(args.id);
+        return { deleted: args.id };
+      }),
+  );
+
+  server.registerTool(
+    "rotate_webhook_secret",
+    {
+      title: "Rotate a webhook's signing secret (returns new plaintext ONCE)",
+      description:
+        "Generate a new signing_secret and move the current one into a 24h grace window during which the worker dual-signs each delivery (two v1= entries on X-E2A-Signature). The new plaintext is returned ONCE — every subsequent list/get scrubs it. Use when the previous secret was leaked or rotated by policy.",
+      inputSchema: strictInputSchema({
+        id: z.string().min(1).describe("Webhook id (wh_…)."),
+      }),
+    },
+    async (args) => runTool(() => client.rotateWebhookSecret(args.id)),
+  );
+
+  server.registerTool(
+    "test_webhook",
+    {
+      title: "Fire a synthetic event to a webhook for debugging",
+      description:
+        "Schedules a one-off delivery to the webhook with a synthetic envelope, bypassing filter matching. Returns the delivery_id which can be looked up via list_webhook_deliveries. Returns an error if the webhook is disabled. Cheap and safe — the synthetic event does not touch real inbound or HITL state.",
+      inputSchema: strictInputSchema({
+        id: z.string().min(1).describe("Webhook id (wh_…)."),
+        event: z
+          .string()
+          .optional()
+          .describe(
+            "Event type to simulate. Defaults to email.received when omitted.",
+          ),
+      }),
+    },
+    async (args) =>
+      runTool(() => client.testWebhook(args.id, { event: args.event })),
+  );
+
+  server.registerTool(
+    "list_webhook_deliveries",
+    {
+      title: "List recent delivery attempts for a webhook",
+      description:
+        "Returns the most recent delivery rows for the webhook (capped at 100). Each row includes status (pending|delivered|failed), attempts, last_error, last_status_code, and timestamps. Useful for debugging why a subscriber is missing events.",
+      inputSchema: strictInputSchema({
+        id: z.string().min(1).describe("Webhook id (wh_…)."),
+        limit: z
+          .number()
+          .int()
+          .min(1)
+          .max(100)
+          .optional()
+          .describe("Page size. Defaults to 20."),
+        status: z
+          .enum(["pending", "delivered", "failed"])
+          .optional()
+          .describe("Optionally restrict to one status."),
+      }),
+    },
+    async (args) =>
+      runTool(() =>
+        client.listWebhookDeliveries(args.id, {
+          limit: args.limit,
+          status: args.status,
+        }),
+      ),
+  );
+}

--- a/mcp/tests/http.test.ts
+++ b/mcp/tests/http.test.ts
@@ -217,6 +217,14 @@ describe("HTTP MCP server", () => {
         "get_pending_message",
         "approve_pending_message",
         "reject_pending_message",
+        "list_webhooks",
+        "get_webhook",
+        "create_webhook",
+        "update_webhook",
+        "delete_webhook",
+        "rotate_webhook_secret",
+        "test_webhook",
+        "list_webhook_deliveries",
       ].sort(),
     );
     await transport.close();

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -146,6 +146,14 @@ describe("e2a MCP server", () => {
         "get_pending_message",
         "approve_pending_message",
         "reject_pending_message",
+        "list_webhooks",
+        "get_webhook",
+        "create_webhook",
+        "update_webhook",
+        "delete_webhook",
+        "rotate_webhook_secret",
+        "test_webhook",
+        "list_webhook_deliveries",
       ].sort(),
     );
   });

--- a/migrations/023_webhooks.sql
+++ b/migrations/023_webhooks.sql
@@ -1,0 +1,66 @@
+-- 023_webhooks.sql
+--
+-- Top-level webhooks-as-a-resource feature, slice 1 foundation. Replaces
+-- the implicit "one URL per agent" model (agent_identities.webhook_url)
+-- with a multi-subscriber CRUD resource. The legacy field is preserved
+-- and keeps working unchanged — both delivery pathways fire side-by-side
+-- on inbound events. See the final design in tmp/e2a_webhooks_design.md
+-- for the full feature scope; this migration adds only the webhooks
+-- catalog table. Per-attempt delivery state lives in
+-- webhook_subscriber_deliveries (migration 025).
+--
+-- Decisions reflected here:
+-- - signing_secret stored plaintext, matching the existing per-agent
+--   signing-secret pattern. A separate, system-wide work item will
+--   envelope-encrypt all signing secrets before the first production
+--   customer with sensitive data ships. Don't draw a new security line
+--   webhook-specifically.
+-- - filters live as a JSONB column (not a join table). At max 50
+--   webhooks per user, in-Go filter matching over JSONB candidates is
+--   trivial and the routing code stays simple. A GIN index on filters
+--   can be added later non-breakingly if scale demands it.
+-- - signing_secret_prev + signing_secret_prev_expires_at hold the
+--   previous secret during the 24h rotation grace window. Both
+--   signatures are sent during this window so receivers can roll
+--   forward without dropping deliveries.
+-- - auto_disabled_at is nullable and set by the auto-disable worker
+--   (slice 4); the column lands here so storage doesn't churn between
+--   slices.
+--
+-- Idempotent: all CREATE statements use IF NOT EXISTS.
+
+CREATE TABLE IF NOT EXISTS webhooks (
+    id                              TEXT PRIMARY KEY,
+    user_id                         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    url                             TEXT NOT NULL CHECK (url <> '' AND length(url) <= 2048),
+    description                     TEXT NOT NULL DEFAULT '' CHECK (length(description) <= 200),
+    -- events is a non-empty array of event type names. Caller-supplied
+    -- entries are checked against an allowlist at the handler layer
+    -- (the CHECK constraint only enforces non-emptiness so a typo at
+    -- write time fails immediately rather than producing a webhook
+    -- that subscribes to nothing).
+    events                          TEXT[] NOT NULL DEFAULT '{}',
+    -- filters carries optional scope filters as a JSONB object with
+    -- keys agent_ids, conversation_ids, labels — each a string array.
+    -- An absent or empty key means "no constraint of that type".
+    -- Routing applies AND across keys, OR within a key (see design).
+    filters                         JSONB NOT NULL DEFAULT '{}'::jsonb,
+    -- Plaintext per-webhook HMAC key. Used by the delivery worker to
+    -- sign the X-E2A-Signature header. Returned to the caller ONCE on
+    -- POST /webhooks and POST /webhooks/{id}/rotate-secret; GET
+    -- endpoints never include it.
+    signing_secret                  TEXT NOT NULL,
+    signing_secret_prev             TEXT,
+    signing_secret_prev_expires_at  TIMESTAMPTZ,
+    enabled                         BOOLEAN NOT NULL DEFAULT true,
+    auto_disabled_at                TIMESTAMPTZ,
+    created_at                      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    last_delivered_at               TIMESTAMPTZ,
+    CHECK (cardinality(events) > 0)
+);
+
+-- Partial index on (user_id) WHERE enabled = true — the routing query
+-- filters on these two columns first; the partial index keeps the
+-- index small (disabled webhooks are excluded from the hot path).
+CREATE INDEX IF NOT EXISTS idx_webhooks_user_enabled
+    ON webhooks (user_id) WHERE enabled = true;

--- a/migrations/024_account_limits_max_webhooks.sql
+++ b/migrations/024_account_limits_max_webhooks.sql
@@ -1,0 +1,17 @@
+-- 024_account_limits_max_webhooks.sql
+--
+-- Per-user cap on webhook subscriber count. Reuses the existing
+-- account_limits framework (the same mechanism that gates messages
+-- per month) rather than introducing a webhook-specific config knob.
+-- Default 50 covers every customer use case we can foresee; paid
+-- plans can raise it via the account_limits row.
+--
+-- The handler layer reads this column when creating a new webhook and
+-- returns 400 with a clear message when the user is at cap.
+--
+-- ALTER TABLE ... ADD COLUMN ... DEFAULT 50 is metadata-only on
+-- Postgres 11+ (constant default). Safe on the small account_limits
+-- table regardless. Idempotent via IF NOT EXISTS.
+
+ALTER TABLE account_limits
+    ADD COLUMN IF NOT EXISTS max_webhooks INTEGER NOT NULL DEFAULT 50;

--- a/migrations/025_webhook_subscriber_deliveries.sql
+++ b/migrations/025_webhook_subscriber_deliveries.sql
@@ -1,0 +1,76 @@
+-- 025_webhook_subscriber_deliveries.sql
+--
+-- Per-attempt delivery state for the new webhooks resource path. Lives
+-- alongside (NOT replacing) the legacy webhook_deliveries table which
+-- continues to serve the agent_identities.webhook_url path unchanged.
+-- Two tables coexist intentionally:
+--
+--   webhook_deliveries:          one row per message, keyed by message_id.
+--                                Suits the legacy "one URL per agent"
+--                                model where a message has at most one
+--                                delivery attempt set.
+--   webhook_subscriber_deliveries: one row per (event, subscriber)
+--                                pair. Suits fan-out — a single inbound
+--                                produces up to N rows, one per matched
+--                                webhook subscriber.
+--
+-- message_id is nullable with ON DELETE SET NULL so the 30-day messages
+-- janitor (DeleteExpiredMessages) can drop messages without orphaning
+-- this table. event_payload is self-contained, so the delivery row
+-- remains usable for retry + history reads even after the source
+-- message is gone — at the cost of GET /deliveries showing a delivery
+-- whose underlying message has been pruned (acceptable, addressed by
+-- the slice-2 handler returning null for the message reference when
+-- message_id is null).
+--
+-- Idempotent via IF NOT EXISTS.
+
+CREATE TABLE IF NOT EXISTS webhook_subscriber_deliveries (
+    id                  TEXT PRIMARY KEY,
+    webhook_id          TEXT NOT NULL REFERENCES webhooks(id) ON DELETE CASCADE,
+    -- event_type carries the catalog name (email.received, email.sent,
+    -- email.pending_approval, email.approved, email.rejected). Stored
+    -- as a plain TEXT so adding a new event type in a future slice is
+    -- a non-breaking change.
+    event_type          TEXT NOT NULL,
+    -- event_payload is the full JSON envelope ({event, id, created_at,
+    -- data}) ready to be POSTed verbatim. Persisting the payload (not
+    -- just a reference) lets retries fire without re-deriving the
+    -- payload from upstream state — which may have changed since.
+    event_payload       JSONB NOT NULL,
+    -- message_id is the originating message for events that have one
+    -- (email.received, email.sent, email.approved). Null for events
+    -- without a direct message backing (email.pending_approval's
+    -- pending row hasn't been promoted yet; email.rejected may not
+    -- have a corresponding messages row depending on flow). The FK
+    -- ON DELETE SET NULL keeps delivery history usable past the
+    -- 30-day message TTL.
+    message_id          TEXT REFERENCES messages(id) ON DELETE SET NULL,
+    status              TEXT NOT NULL DEFAULT 'pending'
+                        CHECK (status IN ('pending', 'delivered', 'failed')),
+    attempts            INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+    max_attempts        INTEGER NOT NULL DEFAULT 5 CHECK (max_attempts > 0),
+    last_error          TEXT NOT NULL DEFAULT '',
+    last_status_code    INTEGER,
+    last_attempt_at     TIMESTAMPTZ,
+    next_retry_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    -- 30-day retention matches the legacy webhook_deliveries table. The
+    -- existing DeleteExpiredDeliveries janitor will be extended in
+    -- slice 4 to scan this table too.
+    expires_at          TIMESTAMPTZ NOT NULL DEFAULT now() + interval '30 days'
+);
+
+-- Hot path for the retry worker: find rows the worker should attempt
+-- next. Partial index restricts the index size to pending rows only
+-- (delivered + failed are read by the history endpoint via a separate
+-- index, below).
+CREATE INDEX IF NOT EXISTS idx_wsd_pending
+    ON webhook_subscriber_deliveries (next_retry_at)
+    WHERE status = 'pending';
+
+-- Hot path for GET /webhooks/{id}/deliveries: most-recent-first
+-- listing per webhook. Covers both delivered + failed without needing
+-- to scan by status.
+CREATE INDEX IF NOT EXISTS idx_wsd_webhook_created
+    ON webhook_subscriber_deliveries (webhook_id, created_at DESC);

--- a/sdks/python/src/e2a/v1/__init__.py
+++ b/sdks/python/src/e2a/v1/__init__.py
@@ -17,6 +17,7 @@ from e2a.v1.handler import (  # noqa: F401
     SendResult,
     UnverifiedEmailError,
 )
+from e2a.v1.webhook_signature import verify_webhook_signature  # noqa: F401
 
 __all__ = [
     # Raw API layers
@@ -41,4 +42,6 @@ __all__ = [
     "fetch_info_async",
     # WebSocket
     "WSNotification",
+    # Webhook signature verification (top-level webhooks resource)
+    "verify_webhook_signature",
 ]

--- a/sdks/python/src/e2a/v1/api.py
+++ b/sdks/python/src/e2a/v1/api.py
@@ -22,6 +22,7 @@ from e2a.v1.generated import (
     ApprovePendingMessageRequest,
     ApprovePendingMessageResponse,
     ConversationDetail,
+    CreateWebhookRequest,
     DeploymentInfo,
     Domain,
     ForwardMessageRequest,
@@ -30,6 +31,8 @@ from e2a.v1.generated import (
     ListDomainsResponse,
     ListMessagesResponse,
     ListPendingMessagesResponse,
+    ListWebhookDeliveriesResponse,
+    ListWebhooksResponse,
     MessageDetail,
     PendingMessageDetail,
     RegisterAgentRequest,
@@ -38,12 +41,17 @@ from e2a.v1.generated import (
     RejectPendingMessageRequest,
     RejectPendingMessageResponse,
     ReplyToMessageRequest,
+    RotateWebhookSecretResponse,
     SendEmailRequest,
     SendEmailResponse,
+    TestWebhookRequest,
+    TestWebhookResponse,
     UpdateAgentRequest,
     UpdateMessageRequest,
     UpdateMessageResponse,
+    UpdateWebhookRequest,
     VerifyDomainResponse,
+    WebhookResponse,
 )
 
 
@@ -187,6 +195,84 @@ class E2AApi:
     def delete_domain(self, domain: str) -> None:
         resp = self._client.delete(f"/api/v1/domains/{quote(domain, safe='')}")
         _check_response(resp)
+
+    # ── Webhooks (top-level resource) ────────────────────────────────
+
+    def list_webhooks(self) -> ListWebhooksResponse:
+        resp = self._client.get("/api/v1/webhooks")
+        _check_response(resp)
+        return ListWebhooksResponse.model_validate(resp.json())
+
+    def create_webhook(self, body: CreateWebhookRequest) -> WebhookResponse:
+        resp = self._client.post(
+            "/api/v1/webhooks",
+            json=body.model_dump(by_alias=True, exclude_none=True),
+        )
+        _check_response(resp)
+        return WebhookResponse.model_validate(resp.json())
+
+    def get_webhook(self, webhook_id: str) -> WebhookResponse:
+        resp = self._client.get(f"/api/v1/webhooks/{quote(webhook_id, safe='')}")
+        _check_response(resp)
+        return WebhookResponse.model_validate(resp.json())
+
+    def update_webhook(
+        self, webhook_id: str, body: UpdateWebhookRequest
+    ) -> WebhookResponse:
+        resp = self._client.patch(
+            f"/api/v1/webhooks/{quote(webhook_id, safe='')}",
+            json=body.model_dump(by_alias=True, exclude_none=True),
+        )
+        _check_response(resp)
+        return WebhookResponse.model_validate(resp.json())
+
+    def delete_webhook(self, webhook_id: str) -> None:
+        resp = self._client.delete(
+            f"/api/v1/webhooks/{quote(webhook_id, safe='')}"
+        )
+        _check_response(resp)
+
+    def rotate_webhook_secret(
+        self, webhook_id: str
+    ) -> RotateWebhookSecretResponse:
+        resp = self._client.post(
+            f"/api/v1/webhooks/{quote(webhook_id, safe='')}/rotate-secret"
+        )
+        _check_response(resp)
+        return RotateWebhookSecretResponse.model_validate(resp.json())
+
+    def test_webhook(
+        self, webhook_id: str, body: Optional[TestWebhookRequest] = None
+    ) -> TestWebhookResponse:
+        payload = (
+            body.model_dump(by_alias=True, exclude_none=True)
+            if body is not None
+            else {}
+        )
+        resp = self._client.post(
+            f"/api/v1/webhooks/{quote(webhook_id, safe='')}/test",
+            json=payload,
+        )
+        _check_response(resp)
+        return TestWebhookResponse.model_validate(resp.json())
+
+    def list_webhook_deliveries(
+        self,
+        webhook_id: str,
+        limit: Optional[int] = None,
+        status: Optional[str] = None,
+    ) -> ListWebhookDeliveriesResponse:
+        params = {}
+        if limit is not None:
+            params["limit"] = limit
+        if status is not None:
+            params["status"] = status
+        resp = self._client.get(
+            f"/api/v1/webhooks/{quote(webhook_id, safe='')}/deliveries",
+            params=params,
+        )
+        _check_response(resp)
+        return ListWebhookDeliveriesResponse.model_validate(resp.json())
 
     # ── Messages ──────────────────────────────────────────────────────
 

--- a/sdks/python/src/e2a/v1/async_client.py
+++ b/sdks/python/src/e2a/v1/async_client.py
@@ -25,6 +25,7 @@ from e2a.v1.generated import (
     ApprovePendingMessageRequest,
     ApprovePendingMessageResponse,
     ConversationDetail,
+    CreateWebhookRequest,
     DeploymentInfo,
     Domain,
     ForwardMessageRequest,
@@ -33,6 +34,8 @@ from e2a.v1.generated import (
     ListDomainsResponse,
     ListMessagesResponse,
     ListPendingMessagesResponse,
+    ListWebhookDeliveriesResponse,
+    ListWebhooksResponse,
     MessageDetail,
     PendingMessageDetail,
     RegisterAgentRequest,
@@ -41,12 +44,17 @@ from e2a.v1.generated import (
     RejectPendingMessageRequest,
     RejectPendingMessageResponse,
     ReplyToMessageRequest,
+    RotateWebhookSecretResponse,
     SendEmailRequest,
     SendEmailResponse,
+    TestWebhookRequest,
+    TestWebhookResponse,
     UpdateAgentRequest,
     UpdateMessageRequest,
     UpdateMessageResponse,
+    UpdateWebhookRequest,
     VerifyDomainResponse,
+    WebhookResponse,
 )
 from e2a.v1.generated import internal_agent
 from e2a.v1.handler import (
@@ -160,6 +168,90 @@ class AsyncE2AApi:
     async def delete_domain(self, domain: str) -> None:
         resp = await self._client.delete(f"/api/v1/domains/{quote(domain, safe='')}")
         _check_response(resp)
+
+    # ── Webhooks (top-level resource) ────────────────────────────
+
+    async def list_webhooks(self) -> ListWebhooksResponse:
+        resp = await self._client.get("/api/v1/webhooks")
+        _check_response(resp)
+        return ListWebhooksResponse.model_validate(resp.json())
+
+    async def create_webhook(
+        self, body: CreateWebhookRequest
+    ) -> WebhookResponse:
+        resp = await self._client.post(
+            "/api/v1/webhooks",
+            json=body.model_dump(by_alias=True, exclude_none=True),
+        )
+        _check_response(resp)
+        return WebhookResponse.model_validate(resp.json())
+
+    async def get_webhook(self, webhook_id: str) -> WebhookResponse:
+        resp = await self._client.get(
+            f"/api/v1/webhooks/{quote(webhook_id, safe='')}"
+        )
+        _check_response(resp)
+        return WebhookResponse.model_validate(resp.json())
+
+    async def update_webhook(
+        self, webhook_id: str, body: UpdateWebhookRequest
+    ) -> WebhookResponse:
+        resp = await self._client.patch(
+            f"/api/v1/webhooks/{quote(webhook_id, safe='')}",
+            json=body.model_dump(by_alias=True, exclude_none=True),
+        )
+        _check_response(resp)
+        return WebhookResponse.model_validate(resp.json())
+
+    async def delete_webhook(self, webhook_id: str) -> None:
+        resp = await self._client.delete(
+            f"/api/v1/webhooks/{quote(webhook_id, safe='')}"
+        )
+        _check_response(resp)
+
+    async def rotate_webhook_secret(
+        self, webhook_id: str
+    ) -> RotateWebhookSecretResponse:
+        resp = await self._client.post(
+            f"/api/v1/webhooks/{quote(webhook_id, safe='')}/rotate-secret"
+        )
+        _check_response(resp)
+        return RotateWebhookSecretResponse.model_validate(resp.json())
+
+    async def test_webhook(
+        self,
+        webhook_id: str,
+        body: Optional[TestWebhookRequest] = None,
+    ) -> TestWebhookResponse:
+        payload = (
+            body.model_dump(by_alias=True, exclude_none=True)
+            if body is not None
+            else {}
+        )
+        resp = await self._client.post(
+            f"/api/v1/webhooks/{quote(webhook_id, safe='')}/test",
+            json=payload,
+        )
+        _check_response(resp)
+        return TestWebhookResponse.model_validate(resp.json())
+
+    async def list_webhook_deliveries(
+        self,
+        webhook_id: str,
+        limit: Optional[int] = None,
+        status: Optional[str] = None,
+    ) -> ListWebhookDeliveriesResponse:
+        params = {}
+        if limit is not None:
+            params["limit"] = limit
+        if status is not None:
+            params["status"] = status
+        resp = await self._client.get(
+            f"/api/v1/webhooks/{quote(webhook_id, safe='')}/deliveries",
+            params=params,
+        )
+        _check_response(resp)
+        return ListWebhookDeliveriesResponse.model_validate(resp.json())
 
     # ── Messages ──────────────────────────────────────────────────
 
@@ -807,6 +899,80 @@ class AsyncE2AClient:
 
     async def delete_domain(self, domain: str):
         return await self.api.delete_domain(domain)
+
+    # ── Webhooks (top-level resource) ──────────────────────────────
+
+    async def list_webhooks(self):
+        return await self.api.list_webhooks()
+
+    async def create_webhook(
+        self,
+        url: str,
+        events: list[str],
+        *,
+        description: str = "",
+        filters: Optional[Any] = None,
+    ):
+        return await self.api.create_webhook(
+            CreateWebhookRequest(
+                url=url,
+                events=events,
+                description=description,
+                filters=filters,
+            )
+        )
+
+    async def get_webhook(self, webhook_id: str):
+        return await self.api.get_webhook(webhook_id)
+
+    async def update_webhook(
+        self,
+        webhook_id: str,
+        *,
+        url: Optional[str] = None,
+        events: Optional[list[str]] = None,
+        filters: Optional[Any] = None,
+        description: Optional[str] = None,
+        enabled: Optional[bool] = None,
+    ):
+        return await self.api.update_webhook(
+            webhook_id,
+            UpdateWebhookRequest(
+                url=url,
+                events=events,
+                filters=filters,
+                description=description,
+                enabled=enabled,
+            ),
+        )
+
+    async def delete_webhook(self, webhook_id: str):
+        return await self.api.delete_webhook(webhook_id)
+
+    async def rotate_webhook_secret(self, webhook_id: str):
+        return await self.api.rotate_webhook_secret(webhook_id)
+
+    async def test_webhook(
+        self,
+        webhook_id: str,
+        *,
+        event: str = "",
+        data: Optional[dict] = None,
+    ):
+        return await self.api.test_webhook(
+            webhook_id, TestWebhookRequest(event=event, data=data)
+        )
+
+    async def list_webhook_deliveries(
+        self,
+        webhook_id: str,
+        *,
+        limit: Optional[int] = None,
+        status: Optional[str] = None,
+    ):
+        return await self.api.list_webhook_deliveries(
+            webhook_id, limit=limit, status=status
+        )
 
     # ── WebSocket ─────────────────────────────────────────────────
 

--- a/sdks/python/src/e2a/v1/client.py
+++ b/sdks/python/src/e2a/v1/client.py
@@ -16,6 +16,7 @@ from e2a.v1.api import E2AApi
 from e2a.v1.generated import (
     ApprovePendingMessageRequest,
     ConversationDetail,
+    CreateWebhookRequest,
     ForwardMessageRequest,
     ListConversationsResponse,
     MessageDetail,
@@ -23,9 +24,12 @@ from e2a.v1.generated import (
     RegisterDomainRequest,
     ReplyToMessageRequest,
     SendEmailRequest,
+    TestWebhookRequest,
     UpdateAgentRequest,
     UpdateMessageRequest,
     UpdateMessageResponse,
+    UpdateWebhookRequest,
+    WebhookFilters,
 )
 from e2a.v1.generated import internal_agent
 from e2a.v1.handler import (
@@ -556,6 +560,80 @@ class E2AClient:
 
     def delete_domain(self, domain: str):
         return self.api.delete_domain(domain)
+
+    # ── Webhooks (top-level resource) ─────────────────────────────────
+
+    def list_webhooks(self):
+        return self.api.list_webhooks()
+
+    def create_webhook(
+        self,
+        url: str,
+        events: list[str],
+        *,
+        description: str = "",
+        filters: Optional[WebhookFilters] = None,
+    ):
+        return self.api.create_webhook(
+            CreateWebhookRequest(
+                url=url,
+                events=events,
+                description=description,
+                filters=filters,
+            )
+        )
+
+    def get_webhook(self, webhook_id: str):
+        return self.api.get_webhook(webhook_id)
+
+    def update_webhook(
+        self,
+        webhook_id: str,
+        *,
+        url: Optional[str] = None,
+        events: Optional[list[str]] = None,
+        filters: Optional[WebhookFilters] = None,
+        description: Optional[str] = None,
+        enabled: Optional[bool] = None,
+    ):
+        return self.api.update_webhook(
+            webhook_id,
+            UpdateWebhookRequest(
+                url=url,
+                events=events,
+                filters=filters,
+                description=description,
+                enabled=enabled,
+            ),
+        )
+
+    def delete_webhook(self, webhook_id: str):
+        return self.api.delete_webhook(webhook_id)
+
+    def rotate_webhook_secret(self, webhook_id: str):
+        return self.api.rotate_webhook_secret(webhook_id)
+
+    def test_webhook(
+        self,
+        webhook_id: str,
+        *,
+        event: str = "",
+        data: Optional[dict] = None,
+    ):
+        return self.api.test_webhook(
+            webhook_id, TestWebhookRequest(event=event, data=data)
+        )
+
+    def list_webhook_deliveries(
+        self,
+        webhook_id: str,
+        *,
+        limit: Optional[int] = None,
+        status: Optional[str] = None,
+    ):
+        return self.api.list_webhook_deliveries(
+            webhook_id, limit=limit, status=status
+        )
 
     # ── Lifecycle ─────────────────────────────────────────────────────
 

--- a/sdks/python/src/e2a/v1/generated/__init__.py
+++ b/sdks/python/src/e2a/v1/generated/__init__.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -366,6 +366,14 @@ class RejectPendingMessageResponse(BaseModel):
     status: str | None = Field(None, examples=['rejected'])
 
 
+class RotateWebhookSecretResponse(BaseModel):
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
+    previous_secret_expires_at: str | None = None
+    signing_secret: str | None = None
+
+
 class SendEmailResponse(BaseModel):
     model_config = ConfigDict(
         populate_by_name=True,
@@ -386,6 +394,21 @@ class SigningSecretSummary(BaseModel):
     name: str | None = None
     secret: str | None = None
     secret_prefix: str | None = None
+
+
+class TestWebhookRequest(BaseModel):
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
+    data: dict[str, Any] | None = None
+    event: str | None = Field(None, examples=['email.received'])
+
+
+class TestWebhookResponse(BaseModel):
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
+    delivery_id: str | None = None
 
 
 class UpdateAgentRequest(BaseModel):
@@ -468,6 +491,47 @@ class VerifyDomainResponse(BaseModel):
     verified_at: str | None = None
 
 
+class WebhookDeliveryResponse(BaseModel):
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
+    attempts: int | None = None
+    created_at: str | None = None
+    event_type: str | None = None
+    id: str | None = None
+    last_attempt_at: str | None = None
+    last_error: str | None = None
+    last_status_code: int | None = None
+    next_retry_at: str | None = None
+    status: str | None = None
+
+
+class WebhookFilters(BaseModel):
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
+    agent_ids: list[str] | None = None
+    conversation_ids: list[str] | None = None
+    labels: list[str] | None = None
+
+
+class WebhookResponse(BaseModel):
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
+    auto_disabled_at: str | None = None
+    created_at: str | None = None
+    description: str | None = None
+    enabled: bool | None = None
+    events: list[str] | None = None
+    filters: WebhookFilters | None = None
+    id: str | None = Field(None, examples=['wh_abc123'])
+    last_delivered_at: str | None = None
+    previous_secret_expires_at: str | None = Field(None, description='ONLY on rotate')
+    signing_secret: str | None = Field(None, description='ONLY on create + rotate')
+    url: str | None = None
+
+
 class ApprovePendingMessageRequest(BaseModel):
     model_config = ConfigDict(
         populate_by_name=True,
@@ -501,6 +565,16 @@ class ConversationDetail(BaseModel):
     messages: list[MessageSummary] | None = None
     outbound_count: int | None = Field(None, examples=[2])
     participants: list[str] | None = None
+
+
+class CreateWebhookRequest(BaseModel):
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
+    description: str | None = Field(None, examples=['main inbox handler'])
+    events: list[str] | None = Field(None, examples=[['email.received']])
+    filters: WebhookFilters | None = None
+    url: str | None = Field(None, examples=['https://example.com/e2a/hook'])
 
 
 class ForwardMessageRequest(BaseModel):
@@ -546,6 +620,20 @@ class ListSigningSecretsResponse(BaseModel):
         populate_by_name=True,
     )
     secrets: list[SigningSecretSummary] | None = None
+
+
+class ListWebhookDeliveriesResponse(BaseModel):
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
+    deliveries: list[WebhookDeliveryResponse] | None = None
+
+
+class ListWebhooksResponse(BaseModel):
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
+    webhooks: list[WebhookResponse] | None = None
 
 
 class PendingMessageDetail(BaseModel):
@@ -628,6 +716,17 @@ class SendEmailRequest(BaseModel):
     html_body: str | None = Field(None, examples=['<p>Hi Alice</p>'])
     subject: str | None = Field(None, examples=['Hello from my agent'])
     to: list[str] | None = Field(None, examples=[['alice@example.com']])
+
+
+class UpdateWebhookRequest(BaseModel):
+    model_config = ConfigDict(
+        populate_by_name=True,
+    )
+    description: str | None = None
+    enabled: bool | None = None
+    events: list[str] | None = None
+    filters: WebhookFilters | None = None
+    url: str | None = None
 
 
 class UserExport(BaseModel):

--- a/sdks/python/src/e2a/v1/webhook_signature.py
+++ b/sdks/python/src/e2a/v1/webhook_signature.py
@@ -1,0 +1,84 @@
+"""Webhook signature verification for the top-level webhooks resource.
+
+e2a signs each subscriber delivery with HMAC-SHA256 keyed by the
+webhook's ``signing_secret``. The signature is sent on the
+``X-E2A-Signature`` header in Stripe-style format::
+
+    X-E2A-Signature: t=<unix>,v1=<hex>[,v1=<hex>]
+
+During the 24h rotation grace window each delivery carries two
+``v1=`` pairs (one per active secret). Receivers should accept the
+request if ANY of the ``v1=`` signatures matches. The timestamp
+guards against replay — reject anything older than the configured
+tolerance (default 5 min).
+
+The signed payload is ``f"{t}.{raw_body}"``. Pass the raw request
+body bytes — re-serializing parsed JSON will not match because of
+whitespace and key-order differences.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+from typing import Optional, Union
+
+
+def verify_webhook_signature(
+    raw_body: Union[str, bytes],
+    header: str,
+    secret: str,
+    *,
+    tolerance_seconds: int = 300,
+    now: Optional[float] = None,
+) -> bool:
+    """Verify an ``X-E2A-Signature`` header.
+
+    Returns ``True`` on success and ``False`` on any failure (bad
+    format, missing pair, signature mismatch, replay). Never raises —
+    designed for use directly in an HTTP handler's branch decision.
+
+    Args:
+        raw_body: Raw HTTP request body bytes (or text).
+        header: Value of the ``X-E2A-Signature`` header.
+        secret: Webhook signing secret (``whsec_...``).
+        tolerance_seconds: Replay window. Defaults to 300 (5 min).
+        now: Test-only clock override (unix seconds). Defaults to
+            ``time.time()``.
+    """
+    t = ""
+    v1s: list[str] = []
+    for part in header.split(","):
+        trimmed = part.strip()
+        if trimmed.startswith("t="):
+            t = trimmed[2:]
+        elif trimmed.startswith("v1="):
+            v1s.append(trimmed[3:])
+    if not t or not v1s:
+        return False
+
+    try:
+        ts = float(t)
+    except ValueError:
+        return False
+    if now is None:
+        now = time.time()
+    if abs(now - ts) > tolerance_seconds:
+        return False
+
+    if isinstance(raw_body, str):
+        body_bytes = raw_body.encode("utf-8")
+    else:
+        body_bytes = raw_body
+
+    signed_payload = t.encode("ascii") + b"." + body_bytes
+    expected = hmac.new(
+        secret.encode("utf-8"), signed_payload, hashlib.sha256
+    ).hexdigest()
+    for candidate in v1s:
+        if len(candidate) != len(expected):
+            continue
+        if hmac.compare_digest(candidate, expected):
+            return True
+    return False

--- a/sdks/python/tests/test_webhook_signature.py
+++ b/sdks/python/tests/test_webhook_signature.py
@@ -1,0 +1,75 @@
+"""Unit tests for verify_webhook_signature."""
+
+import hashlib
+import hmac
+import time
+
+from e2a.v1 import verify_webhook_signature
+
+
+SECRET = "whsec_test1234567890abcdef"
+
+
+def _sign(secret: str, t: str, body: str) -> str:
+    return hmac.new(
+        secret.encode("utf-8"),
+        f"{t}.{body}".encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()
+
+
+def test_accepts_valid_signature() -> None:
+    body = '{"event":"email.received"}'
+    t = str(int(time.time()))
+    v1 = _sign(SECRET, t, body)
+    assert verify_webhook_signature(
+        body, f"t={t},v1={v1}", SECRET
+    )
+
+
+def test_rejects_tampered_body() -> None:
+    body = '{"event":"email.received"}'
+    t = str(int(time.time()))
+    v1 = _sign(SECRET, t, body)
+    assert not verify_webhook_signature(
+        '{"event":"email.received","tampered":true}',
+        f"t={t},v1={v1}",
+        SECRET,
+    )
+
+
+def test_rejects_wrong_secret() -> None:
+    body = "{}"
+    t = str(int(time.time()))
+    v1 = _sign(SECRET, t, body)
+    assert not verify_webhook_signature(
+        body, f"t={t},v1={v1}", "whsec_wrongkey"
+    )
+
+
+def test_rejects_old_timestamp_outside_tolerance() -> None:
+    body = "{}"
+    now = 1_700_000_000.0
+    t = str(int(now - 600))  # 10 min ago
+    v1 = _sign(SECRET, t, body)
+    assert not verify_webhook_signature(
+        body, f"t={t},v1={v1}", SECRET, now=now
+    )
+
+
+def test_accepts_either_v1_during_rotation_grace() -> None:
+    body = "{}"
+    t = str(int(time.time()))
+    old_secret = "whsec_old"
+    new_secret = "whsec_new"
+    v1_old = _sign(old_secret, t, body)
+    v1_new = _sign(new_secret, t, body)
+    header = f"t={t},v1={v1_old},v1={v1_new}"
+    assert verify_webhook_signature(body, header, old_secret)
+    assert verify_webhook_signature(body, header, new_secret)
+
+
+def test_rejects_malformed_header() -> None:
+    assert not verify_webhook_signature("{}", "", SECRET)
+    assert not verify_webhook_signature("{}", "t=123", SECRET)
+    assert not verify_webhook_signature("{}", "v1=abc", SECRET)

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -24,7 +24,7 @@
     "generate:types": "openapi-typescript /tmp/e2a-openapi3.yaml -o src/v1/generated/types.ts",
     "generate": "npm run generate:openapi3 && npm run generate:types",
     "test": "npm run test:unit",
-    "test:unit": "vitest run test/v1/api.test.ts test/v1/client.test.ts test/v1/verify.test.ts test/v1/ws.test.ts test/v1/idempotency.test.ts",
+    "test:unit": "vitest run test/v1/api.test.ts test/v1/client.test.ts test/v1/verify.test.ts test/v1/ws.test.ts test/v1/idempotency.test.ts test/v1/webhook-signature.test.ts",
     "test:contract": "vitest run test/v1/contract.test.ts",
     "test:live": "vitest run test/e2e.test.ts",
     "prepublishOnly": "npm run build"

--- a/sdks/typescript/src/v1/api.ts
+++ b/sdks/typescript/src/v1/api.ts
@@ -381,6 +381,69 @@ export class E2AApi {
     );
   }
 
+  // ── Webhooks (top-level webhooks-as-a-resource) ─────────────────
+
+  async listWebhooks(): Promise<Schemas["ListWebhooksResponse"]> {
+    return this.request("GET", "/api/v1/webhooks");
+  }
+
+  async createWebhook(
+    body: Schemas["CreateWebhookRequest"],
+  ): Promise<Schemas["WebhookResponse"]> {
+    return this.request("POST", "/api/v1/webhooks", body);
+  }
+
+  async getWebhook(id: string): Promise<Schemas["WebhookResponse"]> {
+    return this.request("GET", `/api/v1/webhooks/${encodeURIComponent(id)}`);
+  }
+
+  async updateWebhook(
+    id: string,
+    body: Schemas["UpdateWebhookRequest"],
+  ): Promise<Schemas["WebhookResponse"]> {
+    return this.request(
+      "PATCH",
+      `/api/v1/webhooks/${encodeURIComponent(id)}`,
+      body,
+    );
+  }
+
+  async deleteWebhook(id: string): Promise<void> {
+    await this.raw("DELETE", `/api/v1/webhooks/${encodeURIComponent(id)}`);
+  }
+
+  async rotateWebhookSecret(
+    id: string,
+  ): Promise<Schemas["RotateWebhookSecretResponse"]> {
+    return this.request(
+      "POST",
+      `/api/v1/webhooks/${encodeURIComponent(id)}/rotate-secret`,
+    );
+  }
+
+  async testWebhook(
+    id: string,
+    body: Schemas["TestWebhookRequest"] = { event: "" },
+  ): Promise<Schemas["TestWebhookResponse"]> {
+    return this.request(
+      "POST",
+      `/api/v1/webhooks/${encodeURIComponent(id)}/test`,
+      body,
+    );
+  }
+
+  async listWebhookDeliveries(
+    id: string,
+    opts?: { limit?: number; status?: "pending" | "delivered" | "failed" },
+  ): Promise<Schemas["ListWebhookDeliveriesResponse"]> {
+    const params = new URLSearchParams();
+    if (opts?.limit) params.set("limit", String(opts.limit));
+    if (opts?.status) params.set("status", opts.status);
+    const qs = params.toString();
+    const path = `/api/v1/webhooks/${encodeURIComponent(id)}/deliveries${qs ? `?${qs}` : ""}`;
+    return this.request("GET", path);
+  }
+
   // ── Deployment info ─────────────────────────────────────────────
 
   /**

--- a/sdks/typescript/src/v1/client.ts
+++ b/sdks/typescript/src/v1/client.ts
@@ -389,6 +389,59 @@ export class E2AClient {
     return this.api.verifyDomain(domain);
   }
 
+  // ── Webhooks (top-level resource) ───────────────────────────────
+
+  async listWebhooks() {
+    return this.api.listWebhooks();
+  }
+
+  async createWebhook(opts: {
+    url: string;
+    events: string[];
+    description?: string;
+    filters?: Schemas["WebhookFilters"];
+  }) {
+    return this.api.createWebhook({
+      url: opts.url,
+      events: opts.events,
+      description: opts.description ?? "",
+      filters: opts.filters,
+    });
+  }
+
+  async getWebhook(id: string) {
+    return this.api.getWebhook(id);
+  }
+
+  async updateWebhook(id: string, patch: Schemas["UpdateWebhookRequest"]) {
+    return this.api.updateWebhook(id, patch);
+  }
+
+  async deleteWebhook(id: string) {
+    return this.api.deleteWebhook(id);
+  }
+
+  async rotateWebhookSecret(id: string) {
+    return this.api.rotateWebhookSecret(id);
+  }
+
+  async testWebhook(
+    id: string,
+    opts?: { event?: string; data?: Record<string, unknown> },
+  ) {
+    return this.api.testWebhook(id, {
+      event: opts?.event ?? "",
+      data: opts?.data,
+    });
+  }
+
+  async listWebhookDeliveries(
+    id: string,
+    opts?: { limit?: number; status?: "pending" | "delivered" | "failed" },
+  ) {
+    return this.api.listWebhookDeliveries(id, opts);
+  }
+
   // ── Send ────────────────────────────────────────────────────────
 
   async send(

--- a/sdks/typescript/src/v1/generated/types.ts
+++ b/sdks/typescript/src/v1/generated/types.ts
@@ -2163,6 +2163,501 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/webhooks": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List webhook subscribers
+         * @description Returns every webhook (enabled + disabled) owned by the caller. signing_secret is omitted.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ListWebhooksResponse"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Rate limited */
+                429: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+            };
+        };
+        put?: never;
+        /**
+         * Create webhook subscriber
+         * @description Creates a top-level webhook subscriber. The plaintext signing_secret is returned ONCE in this response and never echoed by any later GET. URL must be HTTPS and must resolve to a public IP. Per-user cap defaults to 50.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            /** @description Webhook spec */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["CreateWebhookRequest"];
+                };
+            };
+            responses: {
+                /** @description Created */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["WebhookResponse"];
+                    };
+                };
+                /** @description validation error or cap reached */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/webhooks/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get webhook subscriber */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Webhook ID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["WebhookResponse"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        /**
+         * Delete webhook subscriber
+         * @description Removes the webhook and cascades pending deliveries.
+         */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Webhook ID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description No content */
+                204: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "*/*": string;
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "*/*": string;
+                    };
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        /**
+         * Update webhook subscriber
+         * @description Partial update. Fields not present are unchanged. url / events / filters are full-replace when present (no array-merge). Re-enable within 5 minutes of auto_disabled_at returns 409.
+         */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Webhook ID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            /** @description Patch body */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["UpdateWebhookRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["WebhookResponse"];
+                    };
+                };
+                /** @description Validation error */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Re-enable cooldown */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+            };
+        };
+        trace?: never;
+    };
+    "/webhooks/{id}/deliveries": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List recent webhook deliveries
+         * @description Returns the most recent delivery attempts for the webhook (capped at 100). Optional status query restricts to pending|delivered|failed.
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /** @description Page size (default 20, max 100) */
+                    limit?: number;
+                    /** @description Filter by status: pending|delivered|failed */
+                    status?: string;
+                };
+                header?: never;
+                path: {
+                    /** @description Webhook ID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["ListWebhookDeliveriesResponse"];
+                    };
+                };
+                /** @description Bad query */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Rate limited */
+                429: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/webhooks/{id}/rotate-secret": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Rotate webhook signing secret
+         * @description Generates a new signing secret and moves the current one into a 24h grace window during which the worker dual-signs each delivery.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Webhook ID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["RotateWebhookSecretResponse"];
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/webhooks/{id}/test": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Fire a synthetic webhook event for development
+         * @description Schedules a one-off delivery to the webhook with a synthetic envelope, bypassing filter matching. Returns the delivery_id so the caller can correlate it in /deliveries. Returns 409 when the webhook is disabled.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    /** @description Webhook ID */
+                    id: string;
+                };
+                cookie?: never;
+            };
+            /** @description Synthetic event */
+            requestBody: {
+                content: {
+                    "application/json": components["schemas"]["TestWebhookRequest"];
+                };
+            };
+            responses: {
+                /** @description OK */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": components["schemas"]["TestWebhookResponse"];
+                    };
+                };
+                /** @description Bad request */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Unauthorized */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Not found */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+                /** @description Webhook disabled */
+                409: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/json": string;
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -2282,6 +2777,19 @@ export interface components {
             name?: string;
             secret?: string;
             secret_prefix?: string;
+        };
+        CreateWebhookRequest: {
+            /** @example main inbox handler */
+            description?: string;
+            /**
+             * @example [
+             *       "email.received"
+             *     ]
+             */
+            events?: string[];
+            filters?: components["schemas"]["WebhookFilters"];
+            /** @example https://example.com/e2a/hook */
+            url?: string;
         };
         DNSRecord: {
             /** @example @ */
@@ -2422,6 +2930,12 @@ export interface components {
         };
         ListSigningSecretsResponse: {
             secrets?: components["schemas"]["SigningSecretSummary"][];
+        };
+        ListWebhookDeliveriesResponse: {
+            deliveries?: components["schemas"]["WebhookDeliveryResponse"][];
+        };
+        ListWebhooksResponse: {
+            webhooks?: components["schemas"]["WebhookResponse"][];
         };
         MessageDetail: {
             auth_headers?: {
@@ -2690,6 +3204,10 @@ export interface components {
             /** @example false */
             reply_all?: boolean;
         };
+        RotateWebhookSecretResponse: {
+            previous_secret_expires_at?: string;
+            signing_secret?: string;
+        };
         SendEmailRequest: {
             attachments?: components["schemas"]["internal_agent.Attachment"][];
             /**
@@ -2742,6 +3260,16 @@ export interface components {
             secret?: string;
             secret_prefix?: string;
         };
+        TestWebhookRequest: {
+            data?: {
+                [key: string]: unknown;
+            };
+            /** @example email.received */
+            event?: string;
+        };
+        TestWebhookResponse: {
+            delivery_id?: string;
+        };
         UpdateAgentRequest: {
             /** @enum {string} */
             agent_mode?: "cloud" | "local";
@@ -2773,6 +3301,13 @@ export interface components {
             labels?: string[];
             /** @example msg_abc123 */
             message_id?: string;
+        };
+        UpdateWebhookRequest: {
+            description?: string;
+            enabled?: boolean;
+            events?: string[];
+            filters?: components["schemas"]["WebhookFilters"];
+            url?: string;
         };
         UsageEventEntry: {
             agent_id?: string;
@@ -2830,6 +3365,38 @@ export interface components {
             spf?: "found" | "missing";
             verified?: boolean;
             verified_at?: string;
+        };
+        WebhookDeliveryResponse: {
+            attempts?: number;
+            created_at?: string;
+            event_type?: string;
+            id?: string;
+            last_attempt_at?: string;
+            last_error?: string;
+            last_status_code?: number;
+            next_retry_at?: string;
+            status?: string;
+        };
+        WebhookFilters: {
+            agent_ids?: string[];
+            conversation_ids?: string[];
+            labels?: string[];
+        };
+        WebhookResponse: {
+            auto_disabled_at?: string;
+            created_at?: string;
+            description?: string;
+            enabled?: boolean;
+            events?: string[];
+            filters?: components["schemas"]["WebhookFilters"];
+            /** @example wh_abc123 */
+            id?: string;
+            last_delivered_at?: string;
+            /** @description ONLY on rotate */
+            previous_secret_expires_at?: string;
+            /** @description ONLY on create + rotate */
+            signing_secret?: string;
+            url?: string;
         };
         "github_com_Mnexa-AI_e2a_internal_identity.AgentIdentity": {
             agent_mode?: string;

--- a/sdks/typescript/src/v1/index.ts
+++ b/sdks/typescript/src/v1/index.ts
@@ -11,6 +11,8 @@ export { InboundEmail, UnverifiedEmailError } from "./inbound-email.js";
 export type { Attachment, AuthHeaders, WebhookPayload } from "./inbound-email.js";
 export { WSListener, WSStream } from "./ws.js";
 export type { WSListenerOptions, WSListenerEvents, WSNotification } from "./ws.js";
+export { verifyWebhookSignature } from "./webhook-signature.js";
+export type { VerifySignatureOptions } from "./webhook-signature.js";
 
 // Friendly aliases for the most-used response shapes. These mirror the
 // types Python's SDK exports under the same names (MessageList, MessageSummary,

--- a/sdks/typescript/src/v1/webhook-signature.ts
+++ b/sdks/typescript/src/v1/webhook-signature.ts
@@ -1,0 +1,74 @@
+// Webhook signature verification for the top-level webhooks resource.
+//
+// e2a signs each subscriber delivery with HMAC-SHA256 keyed by the
+// webhook's signing_secret. The signature is sent on the X-E2A-Signature
+// header in Stripe-style format:
+//
+//   X-E2A-Signature: t=<unix>,v1=<hex>[,v1=<hex>]
+//
+// During the 24h rotation grace window each delivery carries two v1=
+// pairs (one per active secret). Receivers should accept the request if
+// ANY of the v1= signatures matches. The timestamp guards against replay
+// — reject anything older than the configured tolerance (default 5 min).
+//
+// The signed payload is `${t}.${rawBody}`. Pass the raw request body
+// bytes — JSON.stringify-ing the parsed body will not match because of
+// whitespace and key-order differences.
+
+import { createHmac, timingSafeEqual } from "crypto";
+
+export interface VerifySignatureOptions {
+  /** Raw HTTP request body bytes. */
+  rawBody: string | Buffer;
+  /** Value of the X-E2A-Signature header. */
+  header: string;
+  /** Webhook signing secret (whsec_...). */
+  secret: string;
+  /** Tolerance in seconds; defaults to 300. */
+  toleranceSeconds?: number;
+  /** Test-only clock override; defaults to Date.now(). */
+  now?: () => number;
+}
+
+/**
+ * Verify an X-E2A-Signature header. Returns true on success, false on
+ * any failure (bad format, missing pair, signature mismatch, replay).
+ * Throws nothing — designed for use directly in an HTTP handler's
+ * branch decision.
+ */
+export function verifyWebhookSignature(opts: VerifySignatureOptions): boolean {
+  const tolerance = opts.toleranceSeconds ?? 300;
+  const nowMs = opts.now ? opts.now() : Date.now();
+
+  // Parse t=... and one or more v1=... pairs.
+  let t = "";
+  const v1s: string[] = [];
+  for (const part of opts.header.split(",")) {
+    const trimmed = part.trim();
+    if (trimmed.startsWith("t=")) {
+      t = trimmed.slice(2);
+    } else if (trimmed.startsWith("v1=")) {
+      v1s.push(trimmed.slice(3));
+    }
+  }
+  if (!t || v1s.length === 0) return false;
+
+  const ts = Number(t);
+  if (!Number.isFinite(ts)) return false;
+  const ageSeconds = Math.abs(nowMs / 1000 - ts);
+  if (ageSeconds > tolerance) return false;
+
+  const body = typeof opts.rawBody === "string" ? opts.rawBody : opts.rawBody.toString("utf8");
+  const expectedHex = createHmac("sha256", opts.secret)
+    .update(`${t}.${body}`)
+    .digest("hex");
+  const expectedBytes = Buffer.from(expectedHex, "hex");
+
+  for (const candidate of v1s) {
+    if (candidate.length !== expectedHex.length) continue;
+    const candidateBytes = Buffer.from(candidate, "hex");
+    if (candidateBytes.length !== expectedBytes.length) continue;
+    if (timingSafeEqual(candidateBytes, expectedBytes)) return true;
+  }
+  return false;
+}

--- a/sdks/typescript/test/v1/webhook-signature.test.ts
+++ b/sdks/typescript/test/v1/webhook-signature.test.ts
@@ -1,0 +1,90 @@
+import { createHmac } from "node:crypto";
+import { describe, it, expect } from "vitest";
+import { verifyWebhookSignature } from "../../src/v1/webhook-signature.js";
+
+const SECRET = "whsec_test1234567890abcdef";
+
+function sign(secret: string, t: string, body: string): string {
+  return createHmac("sha256", secret).update(`${t}.${body}`).digest("hex");
+}
+
+describe("verifyWebhookSignature", () => {
+  it("accepts a correctly signed envelope", () => {
+    const body = '{"event":"email.received"}';
+    const t = Math.floor(Date.now() / 1000).toString();
+    const v1 = sign(SECRET, t, body);
+    const ok = verifyWebhookSignature({
+      rawBody: body,
+      header: `t=${t},v1=${v1}`,
+      secret: SECRET,
+    });
+    expect(ok).toBe(true);
+  });
+
+  it("rejects a tampered body", () => {
+    const body = '{"event":"email.received"}';
+    const t = Math.floor(Date.now() / 1000).toString();
+    const v1 = sign(SECRET, t, body);
+    const ok = verifyWebhookSignature({
+      rawBody: '{"event":"email.received","tampered":true}',
+      header: `t=${t},v1=${v1}`,
+      secret: SECRET,
+    });
+    expect(ok).toBe(false);
+  });
+
+  it("rejects a wrong secret", () => {
+    const body = "{}";
+    const t = Math.floor(Date.now() / 1000).toString();
+    const v1 = sign(SECRET, t, body);
+    const ok = verifyWebhookSignature({
+      rawBody: body,
+      header: `t=${t},v1=${v1}`,
+      secret: "whsec_wrongkey",
+    });
+    expect(ok).toBe(false);
+  });
+
+  it("rejects an old timestamp outside the tolerance", () => {
+    const body = "{}";
+    const now = 1_700_000_000_000;
+    const t = Math.floor((now - 10 * 60 * 1000) / 1000).toString(); // 10 min ago
+    const v1 = sign(SECRET, t, body);
+    const ok = verifyWebhookSignature({
+      rawBody: body,
+      header: `t=${t},v1=${v1}`,
+      secret: SECRET,
+      now: () => now,
+    });
+    expect(ok).toBe(false);
+  });
+
+  it("accepts either v1 during rotation grace (dual-sig)", () => {
+    const body = "{}";
+    const t = Math.floor(Date.now() / 1000).toString();
+    const oldSecret = "whsec_old";
+    const newSecret = "whsec_new";
+    const v1Old = sign(oldSecret, t, body);
+    const v1New = sign(newSecret, t, body);
+    // Receiver still using the OLD secret should accept (matches first v1).
+    const okOld = verifyWebhookSignature({
+      rawBody: body,
+      header: `t=${t},v1=${v1Old},v1=${v1New}`,
+      secret: oldSecret,
+    });
+    expect(okOld).toBe(true);
+    // Receiver using the NEW secret should also accept (matches second v1).
+    const okNew = verifyWebhookSignature({
+      rawBody: body,
+      header: `t=${t},v1=${v1Old},v1=${v1New}`,
+      secret: newSecret,
+    });
+    expect(okNew).toBe(true);
+  });
+
+  it("rejects a header with missing parts", () => {
+    expect(verifyWebhookSignature({ rawBody: "{}", header: "", secret: SECRET })).toBe(false);
+    expect(verifyWebhookSignature({ rawBody: "{}", header: "t=123", secret: SECRET })).toBe(false);
+    expect(verifyWebhookSignature({ rawBody: "{}", header: "v1=abc", secret: SECRET })).toBe(false);
+  });
+});

--- a/web/public/openapi.yaml
+++ b/web/public/openapi.yaml
@@ -190,6 +190,23 @@ definitions:
       secret_prefix:
         type: string
     type: object
+  CreateWebhookRequest:
+    properties:
+      description:
+        example: main inbox handler
+        type: string
+      events:
+        example:
+        - email.received
+        items:
+          type: string
+        type: array
+      filters:
+        $ref: '#/definitions/WebhookFilters'
+      url:
+        example: https://example.com/e2a/hook
+        type: string
+    type: object
   DNSRecord:
     properties:
       host:
@@ -403,6 +420,20 @@ definitions:
       secrets:
         items:
           $ref: '#/definitions/SigningSecretSummary'
+        type: array
+    type: object
+  ListWebhookDeliveriesResponse:
+    properties:
+      deliveries:
+        items:
+          $ref: '#/definitions/WebhookDeliveryResponse'
+        type: array
+    type: object
+  ListWebhooksResponse:
+    properties:
+      webhooks:
+        items:
+          $ref: '#/definitions/WebhookResponse'
         type: array
     type: object
   MessageDetail:
@@ -809,6 +840,13 @@ definitions:
         example: false
         type: boolean
     type: object
+  RotateWebhookSecretResponse:
+    properties:
+      previous_secret_expires_at:
+        type: string
+      signing_secret:
+        type: string
+    type: object
   SendEmailRequest:
     properties:
       attachments:
@@ -882,6 +920,20 @@ definitions:
       secret_prefix:
         type: string
     type: object
+  TestWebhookRequest:
+    properties:
+      data:
+        additionalProperties: true
+        type: object
+      event:
+        example: email.received
+        type: string
+    type: object
+  TestWebhookResponse:
+    properties:
+      delivery_id:
+        type: string
+    type: object
   UpdateAgentRequest:
     properties:
       agent_mode:
@@ -930,6 +982,21 @@ definitions:
         type: array
       message_id:
         example: msg_abc123
+        type: string
+    type: object
+  UpdateWebhookRequest:
+    properties:
+      description:
+        type: string
+      enabled:
+        type: boolean
+      events:
+        items:
+          type: string
+        type: array
+      filters:
+        $ref: '#/definitions/WebhookFilters'
+      url:
         type: string
     type: object
   UsageEventEntry:
@@ -1032,6 +1099,72 @@ definitions:
       verified:
         type: boolean
       verified_at:
+        type: string
+    type: object
+  WebhookDeliveryResponse:
+    properties:
+      attempts:
+        type: integer
+      created_at:
+        type: string
+      event_type:
+        type: string
+      id:
+        type: string
+      last_attempt_at:
+        type: string
+      last_error:
+        type: string
+      last_status_code:
+        type: integer
+      next_retry_at:
+        type: string
+      status:
+        type: string
+    type: object
+  WebhookFilters:
+    properties:
+      agent_ids:
+        items:
+          type: string
+        type: array
+      conversation_ids:
+        items:
+          type: string
+        type: array
+      labels:
+        items:
+          type: string
+        type: array
+    type: object
+  WebhookResponse:
+    properties:
+      auto_disabled_at:
+        type: string
+      created_at:
+        type: string
+      description:
+        type: string
+      enabled:
+        type: boolean
+      events:
+        items:
+          type: string
+        type: array
+      filters:
+        $ref: '#/definitions/WebhookFilters'
+      id:
+        example: wh_abc123
+        type: string
+      last_delivered_at:
+        type: string
+      previous_secret_expires_at:
+        description: ONLY on rotate
+        type: string
+      signing_secret:
+        description: ONLY on create + rotate
+        type: string
+      url:
         type: string
     type: object
   github_com_Mnexa-AI_e2a_internal_identity.AgentIdentity:
@@ -2617,6 +2750,284 @@ paths:
       summary: Delete a webhook signing secret
       tags:
       - User
+  /webhooks:
+    get:
+      description: Returns every webhook (enabled + disabled) owned by the caller.
+        signing_secret is omitted.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/ListWebhooksResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+        "429":
+          description: Rate limited
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: List webhook subscribers
+      tags:
+      - webhooks
+    post:
+      consumes:
+      - application/json
+      description: Creates a top-level webhook subscriber. The plaintext signing_secret
+        is returned ONCE in this response and never echoed by any later GET. URL must
+        be HTTPS and must resolve to a public IP. Per-user cap defaults to 50.
+      parameters:
+      - description: Webhook spec
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/CreateWebhookRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/WebhookResponse'
+        "400":
+          description: validation error or cap reached
+          schema:
+            type: string
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Create webhook subscriber
+      tags:
+      - webhooks
+  /webhooks/{id}:
+    delete:
+      description: Removes the webhook and cascades pending deliveries.
+      parameters:
+      - description: Webhook ID
+        in: path
+        name: id
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No content
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+        "404":
+          description: Not found
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Delete webhook subscriber
+      tags:
+      - webhooks
+    get:
+      parameters:
+      - description: Webhook ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/WebhookResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+        "404":
+          description: Not found
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Get webhook subscriber
+      tags:
+      - webhooks
+    patch:
+      consumes:
+      - application/json
+      description: Partial update. Fields not present are unchanged. url / events
+        / filters are full-replace when present (no array-merge). Re-enable within
+        5 minutes of auto_disabled_at returns 409.
+      parameters:
+      - description: Webhook ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Patch body
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/UpdateWebhookRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/WebhookResponse'
+        "400":
+          description: Validation error
+          schema:
+            type: string
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+        "404":
+          description: Not found
+          schema:
+            type: string
+        "409":
+          description: Re-enable cooldown
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Update webhook subscriber
+      tags:
+      - webhooks
+  /webhooks/{id}/deliveries:
+    get:
+      description: Returns the most recent delivery attempts for the webhook (capped
+        at 100). Optional status query restricts to pending|delivered|failed.
+      parameters:
+      - description: Webhook ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Page size (default 20, max 100)
+        in: query
+        name: limit
+        type: integer
+      - description: 'Filter by status: pending|delivered|failed'
+        in: query
+        name: status
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/ListWebhookDeliveriesResponse'
+        "400":
+          description: Bad query
+          schema:
+            type: string
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+        "404":
+          description: Not found
+          schema:
+            type: string
+        "429":
+          description: Rate limited
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: List recent webhook deliveries
+      tags:
+      - webhooks
+  /webhooks/{id}/rotate-secret:
+    post:
+      description: Generates a new signing secret and moves the current one into a
+        24h grace window during which the worker dual-signs each delivery.
+      parameters:
+      - description: Webhook ID
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/RotateWebhookSecretResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+        "404":
+          description: Not found
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Rotate webhook signing secret
+      tags:
+      - webhooks
+  /webhooks/{id}/test:
+    post:
+      consumes:
+      - application/json
+      description: Schedules a one-off delivery to the webhook with a synthetic envelope,
+        bypassing filter matching. Returns the delivery_id so the caller can correlate
+        it in /deliveries. Returns 409 when the webhook is disabled.
+      parameters:
+      - description: Webhook ID
+        in: path
+        name: id
+        required: true
+        type: string
+      - description: Synthetic event
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/TestWebhookRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/TestWebhookResponse'
+        "400":
+          description: Bad request
+          schema:
+            type: string
+        "401":
+          description: Unauthorized
+          schema:
+            type: string
+        "404":
+          description: Not found
+          schema:
+            type: string
+        "409":
+          description: Webhook disabled
+          schema:
+            type: string
+      security:
+      - BearerAuth: []
+      summary: Fire a synthetic webhook event for development
+      tags:
+      - webhooks
 securityDefinitions:
   BearerAuth:
     description: 'API key from the API Keys page (starts with `e2a_`). Format: `Bearer


### PR DESCRIPTION
## Summary

Implements the **top-level `webhooks-as-a-resource`** feature in 4 slices on this branch. The legacy `agent_identities.webhook_url` path continues to work unchanged; the two pathways fire side-by-side with the legacy path now flagged via `X-E2A-Deprecation` + `Sunset` headers.

- **Slice 1 — Foundation**: migrations 023/024/025, `identity.Webhook` storage, `webhookpub` event publisher (with H5 filter semantics), `webhook.SubscriberDeliverer` (HMAC-SHA256 signing, 15s timeout, redirects refused), `webhook.SubscriberRetryWorker` (8 workers, per-webhook inflight cap of 1, 30s tick). 47 tests.
- **Slice 2 — Public API + clients**: 8 HTTP handlers (`/api/v1/webhooks` CRUD + `rotate-secret` + `test` + `deliveries`), full TS SDK + Python SDK (sync + async, raw + high-level) + `verifyWebhookSignature` / `verify_webhook_signature` helpers, CLI `e2a webhooks ...`, 8 MCP tools. 16 handler tests + 6 TS + 6 Python signature tests.
- **Slice 3 — Trigger sites**: `email.sent` fires from `/send`, `/reply`, `/forward`; `email.pending_approval` from `holdForApproval`; `email.approved` from `ApproveAndSend`; `email.rejected` from the reject handler. All post-commit async via `publishAsync`. 7 builder tests.
- **Slice 4 — Hardening**: auto-disable janitor (10 failed / 72h with a zero-delivered guard), `signing_secret_prev` 24h grace + expired-secret cleanup, `X-E2A-Deprecation` + `Sunset` headers on the legacy path. 4 identity + 1 worker tests.

## Surface checklist

- [x] Go HTTP handlers + storage
- [x] TS SDK (`E2AApi` + `E2AClient` + `verifyWebhookSignature`)
- [x] Python SDK (sync + async raw + high-level + `verify_webhook_signature`)
- [x] CLI (`e2a webhooks list|create|get|update|delete|rotate-secret|test|deliveries`)
- [x] MCP tools (8 tools, `delete_webhook` gated on `confirm:true`)
- [x] OpenAPI spec regenerated (`make generate`)
- [x] Slice-level commits one-per-coherent-change
- [x] Per-slice tests added alongside implementation
- [x] Feature flag `E2A_FEATURE_WEBHOOK_RESOURCE` (default ON)

## Test plan

- [ ] `make test-unit` clean
- [ ] `make test-integration` clean (`E2A_TEST_DATABASE_URL` set)
- [ ] `npm test --workspace @e2a/sdk` clean (91 tests, includes 6 new signature tests)
- [ ] `npm test --workspace @e2a/cli` clean
- [ ] `npm test --workspace @e2a/mcp-server` clean (92 tests, with the v1 tool-set assertion expanded)
- [ ] `cd sdks/python && pytest` clean (216 tests, includes 6 new signature tests)
- [ ] Manually walk one full lifecycle: create → list → get → rotate-secret → test → deliveries → disable → re-enable → delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)