### PR TITLE
test(webhooks): 10 E2E tests covering the full publisher → worker → POST chain

### DIFF
--- a/internal/e2e/webhooks_e2e_test.go
+++ b/internal/e2e/webhooks_e2e_test.go
@@ -1,0 +1,638 @@
+//go:build integration
+
+package e2e_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/smtp"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+)
+
+// Tests in this file exercise the webhooks-as-a-resource path end-to-end.
+// Distinct from e2e_test.go which covers the legacy
+// agent_identities.webhook_url path (per-agent, single URL, no filters).
+//
+// Coverage map (from the approved test plan):
+//   P1 — outbound events: email.sent, email.pending_approval,
+//         email.approved, email.rejected fire from real handler triggers
+//   P2 — inbound:         email.received fires from a real SMTP message
+//   P3 — filters:         agent_ids + conversation_ids + labels (H5)
+//   P4 — signing:         rotation grace dual-sig + disabled webhook silent
+//   P5 — auto-disable:    10 failed events flip enabled=false
+//
+// Two design decisions worth re-stating:
+//   1) Webhooks are provisioned via Store.CreateWebhook directly (NOT
+//      POST /api/v1/webhooks). The public API rejects 127.0.0.1 URLs
+//      (SSRF guard); the only way to test the worker hitting a local
+//      receiver is to bypass the handler-side validator. The handler
+//      itself has unit-test coverage at internal/agent/webhooks_api_test.go.
+//   2) Worker timing: we call SubscriberWorker.Tick(ctx) directly instead
+//      of waiting on the 30s production interval. That keeps the suite
+//      deterministic and under 60s.
+
+// authedJSON wraps an authenticated JSON request and returns the
+// response status + body. Tests assert against both.
+func authedJSON(t *testing.T, method, url, apiKey, body string) (int, []byte) {
+	t.Helper()
+	var rdr *bytes.Buffer
+	if body != "" {
+		rdr = bytes.NewBufferString(body)
+	} else {
+		rdr = bytes.NewBuffer(nil)
+	}
+	req, err := http.NewRequest(method, url, rdr)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	defer resp.Body.Close()
+	out, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, out
+}
+
+// verifyHMACv1 returns true iff at least one v1= entry in the
+// X-E2A-Signature header verifies against secret using the standard
+// "<t>.<rawBody>" payload. Mirrors the SDK helpers' behavior so a
+// test failure points at the wire protocol, not the verifier.
+func verifyHMACv1(t *testing.T, headers http.Header, rawBody []byte, secret string) bool {
+	t.Helper()
+	sig := headers.Get("X-E2A-Signature")
+	if sig == "" {
+		return false
+	}
+	var ts string
+	var v1s []string
+	for _, part := range strings.Split(sig, ",") {
+		p := strings.TrimSpace(part)
+		switch {
+		case strings.HasPrefix(p, "t="):
+			ts = strings.TrimPrefix(p, "t=")
+		case strings.HasPrefix(p, "v1="):
+			v1s = append(v1s, strings.TrimPrefix(p, "v1="))
+		}
+	}
+	if ts == "" || len(v1s) == 0 {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(ts + "."))
+	mac.Write(rawBody)
+	want := hex.EncodeToString(mac.Sum(nil))
+	for _, v := range v1s {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}
+
+// setupSubscriberOwner provisions a user + API key + a verified domain
+// + an agent on that domain. Returns the agent so the test can
+// register webhooks scoped to it. mode is "local" or "cloud"; HITL
+// flag toggles HITL on the agent.
+func setupSubscriberOwner(t *testing.T, ts *testutil.E2ATestServer, prefix string, hitl bool) (*identity.User, *identity.APIKey, *identity.AgentIdentity) {
+	t.Helper()
+	ctx := context.Background()
+	user, err := ts.Store.CreateOrGetUser(ctx, "owner-"+prefix+"@example.com", "Owner", "google-"+prefix)
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	key, err := ts.Store.CreateAPIKey(ctx, user.ID, prefix+"-key", nil)
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+	domain := prefix + ".example.com"
+	if _, err := ts.Store.ClaimOrCreateDomain(ctx, domain, user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+	if err := ts.Store.VerifyDomain(ctx, domain, user.ID); err != nil {
+		t.Fatalf("VerifyDomain: %v", err)
+	}
+	email := "bot@" + domain
+	agent, err := ts.Store.CreateAgent(ctx, email, domain, "Bot", "", "local", user.ID)
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	if hitl {
+		// Enable HITL with a reasonable TTL.
+		if err := ts.Store.UpdateAgentHITL(ctx, agent.ID, user.ID, true, 3600, "reject"); err != nil {
+			t.Fatalf("UpdateAgentHITL: %v", err)
+		}
+		// Reload so the in-test agent struct reflects HITL flag.
+		agent, err = ts.Store.GetAgentByID(ctx, agent.ID)
+		if err != nil {
+			t.Fatalf("GetAgentByID: %v", err)
+		}
+	}
+	return user, key, agent
+}
+
+// registerWebhook is the cheap path around the public-API URL
+// validator. The validator rejects 127.0.0.1 (SSRF guard); the
+// storage layer accepts any URL. The handler's validation has its
+// own unit test coverage.
+func registerWebhook(t *testing.T, ts *testutil.E2ATestServer, userID, url string, events []string, filters identity.WebhookFilters) *identity.Webhook {
+	t.Helper()
+	wh, err := ts.Store.CreateWebhook(context.Background(), userID, url, "e2e", events, filters)
+	if err != nil {
+		t.Fatalf("CreateWebhook: %v", err)
+	}
+	return wh
+}
+
+// tick drains the subscriber worker once. Tests call this between
+// trigger and assertion so they don't wait on the 30s production tick.
+func tick(t *testing.T, ts *testutil.E2ATestServer) {
+	t.Helper()
+	// publishAsync uses a goroutine — give it a beat to land the
+	// delivery row before we drain.
+	time.Sleep(50 * time.Millisecond)
+	ts.SubscriberWorker.Tick(context.Background())
+}
+
+// ----------------------------------------------------------------------
+// P1 — Outbound events
+// ----------------------------------------------------------------------
+
+func TestWebhooksE2E_EmailSent(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ts := testutil.TestServer(t, pool, testutil.WithOutboundSMTP("127.0.0.1", 1025, "test.e2a.dev"))
+	receiver := testutil.SubscriberReceiver(t)
+
+	_, key, agent := setupSubscriberOwner(t, ts, "wh-sent", false)
+	wh := registerWebhook(t, ts, agent.UserID, receiver.Server.URL+"/sent",
+		[]string{"email.sent"}, identity.WebhookFilters{})
+
+	// Trigger /send through the real HTTP API so publishAsync fires
+	// from the actual handler, not a hand-crafted publisher call.
+	body := fmt.Sprintf(`{"from":%q,"to":["alice@example.com"],"subject":"hi","body":"hello"}`, agent.EmailAddress())
+	status, _ := authedJSON(t, "POST", ts.HTTPServer.URL+"/api/v1/send", key.PlaintextKey, body)
+	if status != 200 {
+		t.Fatalf("send status=%d", status)
+	}
+
+	tick(t, ts)
+	got := receiver.WaitFor(t, 2*time.Second, func(c []testutil.SubscriberCaptured) bool { return len(c) >= 1 })
+	if len(got) != 1 {
+		t.Fatalf("got %d captures, want 1", len(got))
+	}
+	c := got[0]
+	if c.URL != "/sent" {
+		t.Errorf("path=%q want /sent", c.URL)
+	}
+	if c.Envelope["event"] != "email.sent" {
+		t.Errorf("event=%v want email.sent", c.Envelope["event"])
+	}
+	if !verifyHMACv1(t, c.Headers, c.RawBody, wh.SigningSecret) {
+		t.Errorf("HMAC v1 verification failed: sig=%q", c.Headers.Get("X-E2A-Signature"))
+	}
+}
+
+func TestWebhooksE2E_HITL_PendingApproved(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ts := testutil.TestServer(t, pool, testutil.WithOutboundSMTP("127.0.0.1", 1025, "test.e2a.dev"))
+	receiver := testutil.SubscriberReceiver(t)
+
+	_, key, agent := setupSubscriberOwner(t, ts, "wh-hitl", true)
+	pendingHook := registerWebhook(t, ts, agent.UserID, receiver.Server.URL+"/pending",
+		[]string{"email.pending_approval"}, identity.WebhookFilters{})
+	approvedHook := registerWebhook(t, ts, agent.UserID, receiver.Server.URL+"/approved",
+		[]string{"email.approved"}, identity.WebhookFilters{})
+
+	// /send → held for approval, returns 202 + message_id.
+	body := fmt.Sprintf(`{"from":%q,"to":["alice@example.com"],"subject":"draft","body":"please review"}`, agent.EmailAddress())
+	status, respBytes := authedJSON(t, "POST", ts.HTTPServer.URL+"/api/v1/send", key.PlaintextKey, body)
+	if status != 202 {
+		t.Fatalf("send status=%d body=%s want 202 (HITL hold)", status, string(respBytes))
+	}
+	var sendResp map[string]any
+	json.Unmarshal(respBytes, &sendResp)
+	msgID, _ := sendResp["message_id"].(string)
+	if msgID == "" {
+		t.Fatalf("no message_id in hold response: %s", string(respBytes))
+	}
+
+	// First tick — should deliver email.pending_approval.
+	tick(t, ts)
+	receiver.WaitFor(t, 2*time.Second, func(c []testutil.SubscriberCaptured) bool { return len(c) >= 1 })
+	got := receiver.Captured()
+	if len(got) != 1 {
+		t.Fatalf("after pending: got %d captures, want 1", len(got))
+	}
+	if got[0].URL != "/pending" || got[0].Envelope["event"] != "email.pending_approval" {
+		t.Errorf("first capture path=%q event=%v", got[0].URL, got[0].Envelope["event"])
+	}
+	if !verifyHMACv1(t, got[0].Headers, got[0].RawBody, pendingHook.SigningSecret) {
+		t.Errorf("pending HMAC verification failed")
+	}
+
+	// Approve via the API.
+	approveBody := `{}`
+	approveStatus, approveResp := authedJSON(t, "POST",
+		ts.HTTPServer.URL+"/api/v1/messages/"+msgID+"/approve",
+		key.PlaintextKey, approveBody)
+	if approveStatus != 200 {
+		t.Fatalf("approve status=%d body=%s", approveStatus, string(approveResp))
+	}
+
+	// Second tick — should deliver email.approved.
+	tick(t, ts)
+	receiver.WaitFor(t, 2*time.Second, func(c []testutil.SubscriberCaptured) bool { return len(c) >= 2 })
+	got = receiver.Captured()
+	if len(got) != 2 {
+		t.Fatalf("after approve: got %d captures, want 2", len(got))
+	}
+	approved := got[1]
+	if approved.URL != "/approved" || approved.Envelope["event"] != "email.approved" {
+		t.Errorf("second capture path=%q event=%v", approved.URL, approved.Envelope["event"])
+	}
+	if !verifyHMACv1(t, approved.Headers, approved.RawBody, approvedHook.SigningSecret) {
+		t.Errorf("approved HMAC verification failed")
+	}
+	// data.reviewed_by_user_id is set on approve (build path puts the
+	// caller's user id there). Verify the shape, not the value — the
+	// per-test user id is opaque.
+	data, _ := approved.Envelope["data"].(map[string]any)
+	if data["reviewed_by_user_id"] == "" {
+		t.Errorf("approved event missing reviewed_by_user_id: %v", data)
+	}
+}
+
+func TestWebhooksE2E_HITL_Rejected(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ts := testutil.TestServer(t, pool, testutil.WithOutboundSMTP("127.0.0.1", 1025, "test.e2a.dev"))
+	receiver := testutil.SubscriberReceiver(t)
+
+	_, key, agent := setupSubscriberOwner(t, ts, "wh-reject", true)
+	rejectedHook := registerWebhook(t, ts, agent.UserID, receiver.Server.URL+"/rejected",
+		[]string{"email.rejected"}, identity.WebhookFilters{})
+
+	body := fmt.Sprintf(`{"from":%q,"to":["alice@example.com"],"subject":"nope","body":"please reject"}`, agent.EmailAddress())
+	status, respBytes := authedJSON(t, "POST", ts.HTTPServer.URL+"/api/v1/send", key.PlaintextKey, body)
+	if status != 202 {
+		t.Fatalf("send status=%d", status)
+	}
+	var sendResp map[string]any
+	json.Unmarshal(respBytes, &sendResp)
+	msgID, _ := sendResp["message_id"].(string)
+
+	// Drain pending_approval (which we don't care about here) before
+	// rejecting, so the post-reject Captured() is the rejected event
+	// alone.
+	tick(t, ts)
+	receiver.Reset()
+
+	rejectStatus, rejectResp := authedJSON(t, "POST",
+		ts.HTTPServer.URL+"/api/v1/messages/"+msgID+"/reject",
+		key.PlaintextKey, `{"reason":"off-policy"}`)
+	if rejectStatus != 200 {
+		t.Fatalf("reject status=%d body=%s", rejectStatus, string(rejectResp))
+	}
+
+	tick(t, ts)
+	receiver.WaitFor(t, 2*time.Second, func(c []testutil.SubscriberCaptured) bool { return len(c) >= 1 })
+	got := receiver.Captured()
+	if len(got) != 1 {
+		t.Fatalf("after reject: got %d captures, want 1", len(got))
+	}
+	if got[0].URL != "/rejected" || got[0].Envelope["event"] != "email.rejected" {
+		t.Errorf("path=%q event=%v", got[0].URL, got[0].Envelope["event"])
+	}
+	if !verifyHMACv1(t, got[0].Headers, got[0].RawBody, rejectedHook.SigningSecret) {
+		t.Errorf("rejected HMAC verification failed")
+	}
+	data, _ := got[0].Envelope["data"].(map[string]any)
+	if data["rejection_reason"] != "off-policy" {
+		t.Errorf("rejection_reason=%v want off-policy", data["rejection_reason"])
+	}
+}
+
+// ----------------------------------------------------------------------
+// P2 — Inbound (email.received via SMTP)
+// ----------------------------------------------------------------------
+
+func TestWebhooksE2E_EmailReceived(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ts := testutil.TestServer(t, pool, testutil.WithOutboundSMTP("127.0.0.1", 1025, "test.e2a.dev"))
+	receiver := testutil.SubscriberReceiver(t)
+
+	_, _, agent := setupSubscriberOwner(t, ts, "wh-recv", false)
+	wh := registerWebhook(t, ts, agent.UserID, receiver.Server.URL+"/received",
+		[]string{"email.received"}, identity.WebhookFilters{})
+
+	// SMTP a message into the relay. The relay marks it unverified
+	// in dev (no SPF/DKIM for example.com) but still persists +
+	// publishes — the event fires regardless of verification status.
+	msg := "From: alice@gmail.com\r\nTo: " + agent.EmailAddress() + "\r\nSubject: Hi\r\n\r\nhello from SMTP"
+	if err := smtp.SendMail(ts.SMTPAddr, nil, "alice@gmail.com",
+		[]string{agent.EmailAddress()}, []byte(msg)); err != nil {
+		t.Fatalf("SendMail: %v", err)
+	}
+
+	tick(t, ts)
+	got := receiver.WaitFor(t, 3*time.Second, func(c []testutil.SubscriberCaptured) bool { return len(c) >= 1 })
+	if len(got) != 1 {
+		t.Fatalf("got %d captures, want 1", len(got))
+	}
+	if got[0].URL != "/received" || got[0].Envelope["event"] != "email.received" {
+		t.Errorf("path=%q event=%v", got[0].URL, got[0].Envelope["event"])
+	}
+	if !verifyHMACv1(t, got[0].Headers, got[0].RawBody, wh.SigningSecret) {
+		t.Errorf("received HMAC verification failed")
+	}
+	data, _ := got[0].Envelope["data"].(map[string]any)
+	if data["message_id"] == "" || !strings.HasPrefix(fmt.Sprint(data["message_id"]), "msg_") {
+		t.Errorf("expected msg_ id in data.message_id, got %v", data["message_id"])
+	}
+}
+
+// ----------------------------------------------------------------------
+// P3 — Filter matching
+// ----------------------------------------------------------------------
+
+func TestWebhooksE2E_FilterByAgentID(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ts := testutil.TestServer(t, pool, testutil.WithOutboundSMTP("127.0.0.1", 1025, "test.e2a.dev"))
+	receiver := testutil.SubscriberReceiver(t)
+
+	// One owner, two agents (different mailboxes on different domains
+	// so a verified-domain check passes for both).
+	_, keyA, agentA := setupSubscriberOwner(t, ts, "wh-filta", false)
+	domainB := "wh-filtb.example.com"
+	if _, err := ts.Store.ClaimOrCreateDomain(context.Background(), domainB, agentA.UserID); err != nil {
+		t.Fatalf("claim b: %v", err)
+	}
+	if err := ts.Store.VerifyDomain(context.Background(), domainB, agentA.UserID); err != nil {
+		t.Fatalf("verify b: %v", err)
+	}
+	agentB, err := ts.Store.CreateAgent(context.Background(),
+		"bot@"+domainB, domainB, "Bot B", "", "local", agentA.UserID)
+	if err != nil {
+		t.Fatalf("create agent b: %v", err)
+	}
+
+	// One webhook per agent, filtered to that agent's id.
+	whA := registerWebhook(t, ts, agentA.UserID, receiver.Server.URL+"/a",
+		[]string{"email.sent"}, identity.WebhookFilters{AgentIDs: []string{agentA.ID}})
+	whB := registerWebhook(t, ts, agentA.UserID, receiver.Server.URL+"/b",
+		[]string{"email.sent"}, identity.WebhookFilters{AgentIDs: []string{agentB.ID}})
+
+	// Send through agent A → only /a fires.
+	body := fmt.Sprintf(`{"from":%q,"to":["alice@example.com"],"subject":"from A","body":"x"}`, agentA.EmailAddress())
+	status, _ := authedJSON(t, "POST", ts.HTTPServer.URL+"/api/v1/send", keyA.PlaintextKey, body)
+	if status != 200 {
+		t.Fatalf("send-A status=%d", status)
+	}
+
+	tick(t, ts)
+	got := receiver.WaitFor(t, 2*time.Second, func(c []testutil.SubscriberCaptured) bool { return len(c) >= 1 })
+	if len(got) != 1 || got[0].URL != "/a" {
+		t.Fatalf("expected exactly /a; got %d captures: %v", len(got), summarize(got))
+	}
+	if !verifyHMACv1(t, got[0].Headers, got[0].RawBody, whA.SigningSecret) {
+		t.Errorf("A HMAC failed")
+	}
+
+	// Send through agent B → only /b fires.
+	receiver.Reset()
+	bodyB := fmt.Sprintf(`{"from":%q,"to":["bob@example.com"],"subject":"from B","body":"x"}`, agentB.EmailAddress())
+	status, _ = authedJSON(t, "POST", ts.HTTPServer.URL+"/api/v1/send", keyA.PlaintextKey, bodyB)
+	if status != 200 {
+		t.Fatalf("send-B status=%d", status)
+	}
+
+	tick(t, ts)
+	got = receiver.WaitFor(t, 2*time.Second, func(c []testutil.SubscriberCaptured) bool { return len(c) >= 1 })
+	if len(got) != 1 || got[0].URL != "/b" {
+		t.Fatalf("expected exactly /b; got %d captures: %v", len(got), summarize(got))
+	}
+	if !verifyHMACv1(t, got[0].Headers, got[0].RawBody, whB.SigningSecret) {
+		t.Errorf("B HMAC failed")
+	}
+}
+
+func TestWebhooksE2E_FilterByConversationID(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ts := testutil.TestServer(t, pool, testutil.WithOutboundSMTP("127.0.0.1", 1025, "test.e2a.dev"))
+	receiver := testutil.SubscriberReceiver(t)
+
+	_, key, agent := setupSubscriberOwner(t, ts, "wh-conv", false)
+	registerWebhook(t, ts, agent.UserID, receiver.Server.URL+"/match",
+		[]string{"email.sent"}, identity.WebhookFilters{ConversationIDs: []string{"conv-match"}})
+
+	// Send WITHOUT conversation_id — should NOT match (H5 rule:
+	// filter requires X but event has none).
+	body := fmt.Sprintf(`{"from":%q,"to":["alice@example.com"],"subject":"no conv","body":"x"}`, agent.EmailAddress())
+	status, _ := authedJSON(t, "POST", ts.HTTPServer.URL+"/api/v1/send", key.PlaintextKey, body)
+	if status != 200 {
+		t.Fatalf("send-noconv status=%d", status)
+	}
+	tick(t, ts)
+	// Use a small explicit wait then assert no posts: short timeout
+	// to avoid a flaky pass if the worker is slow.
+	receiver.WaitFor(t, 500*time.Millisecond, func(c []testutil.SubscriberCaptured) bool { return false })
+	if got := receiver.Captured(); len(got) != 0 {
+		t.Errorf("filter required conversation_id but event had none → should skip; got %v", summarize(got))
+	}
+
+	// Send WITH the matching conversation_id → fires.
+	body = fmt.Sprintf(`{"from":%q,"to":["alice@example.com"],"subject":"yes conv","body":"x","conversation_id":"conv-match"}`, agent.EmailAddress())
+	status, _ = authedJSON(t, "POST", ts.HTTPServer.URL+"/api/v1/send", key.PlaintextKey, body)
+	if status != 200 {
+		t.Fatalf("send-conv status=%d", status)
+	}
+	tick(t, ts)
+	got := receiver.WaitFor(t, 2*time.Second, func(c []testutil.SubscriberCaptured) bool { return len(c) >= 1 })
+	if len(got) != 1 || got[0].URL != "/match" {
+		t.Fatalf("expected /match; got %v", summarize(got))
+	}
+}
+
+// TestWebhooksE2E_FilterByLabelsH5 documents H5: when a filter
+// requires a value of type T but the event has no T (here, an
+// email.sent event whose envelope carries no labels), the subscriber
+// MUST be skipped. Without this rule, an "urgent-only" subscriber
+// would receive every unlabelled message — the design explicitly
+// rejects that as a foot-gun.
+func TestWebhooksE2E_FilterByLabelsH5(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ts := testutil.TestServer(t, pool, testutil.WithOutboundSMTP("127.0.0.1", 1025, "test.e2a.dev"))
+	receiver := testutil.SubscriberReceiver(t)
+
+	_, key, agent := setupSubscriberOwner(t, ts, "wh-label", false)
+	registerWebhook(t, ts, agent.UserID, receiver.Server.URL+"/labelled",
+		[]string{"email.sent"}, identity.WebhookFilters{Labels: []string{"urgent"}})
+
+	body := fmt.Sprintf(`{"from":%q,"to":["alice@example.com"],"subject":"unlabelled","body":"x"}`, agent.EmailAddress())
+	if status, _ := authedJSON(t, "POST", ts.HTTPServer.URL+"/api/v1/send", key.PlaintextKey, body); status != 200 {
+		t.Fatalf("send status=%d", status)
+	}
+	tick(t, ts)
+	receiver.WaitFor(t, 500*time.Millisecond, func(c []testutil.SubscriberCaptured) bool { return false })
+	if got := receiver.Captured(); len(got) != 0 {
+		t.Errorf("H5 violation: filter required labels but event had none → should skip; got %v", summarize(got))
+	}
+}
+
+// ----------------------------------------------------------------------
+// P4 — Signing edge cases (rotation grace + disabled webhook silent)
+// ----------------------------------------------------------------------
+
+func TestWebhooksE2E_RotationGrace_DualSig(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ts := testutil.TestServer(t, pool, testutil.WithOutboundSMTP("127.0.0.1", 1025, "test.e2a.dev"))
+	receiver := testutil.SubscriberReceiver(t)
+
+	_, key, agent := setupSubscriberOwner(t, ts, "wh-rot", false)
+	wh := registerWebhook(t, ts, agent.UserID, receiver.Server.URL+"/rot",
+		[]string{"email.sent"}, identity.WebhookFilters{})
+	oldSecret := wh.SigningSecret
+
+	// Rotate. After this, the worker should dual-sign every delivery
+	// for the 24h grace window.
+	newSecret, _, err := ts.Store.RotateSecret(context.Background(), wh.ID, agent.UserID)
+	if err != nil {
+		t.Fatalf("rotate: %v", err)
+	}
+	if newSecret == oldSecret {
+		t.Fatalf("rotation returned same secret")
+	}
+
+	body := fmt.Sprintf(`{"from":%q,"to":["alice@example.com"],"subject":"rotated","body":"x"}`, agent.EmailAddress())
+	if status, _ := authedJSON(t, "POST", ts.HTTPServer.URL+"/api/v1/send", key.PlaintextKey, body); status != 200 {
+		t.Fatalf("send status=%d", status)
+	}
+	tick(t, ts)
+	got := receiver.WaitFor(t, 2*time.Second, func(c []testutil.SubscriberCaptured) bool { return len(c) >= 1 })
+	if len(got) != 1 {
+		t.Fatalf("got %d captures, want 1", len(got))
+	}
+
+	// Parse signature; expect exactly 2 v1= entries.
+	sig := got[0].Headers.Get("X-E2A-Signature")
+	v1count := strings.Count(sig, "v1=")
+	if v1count != 2 {
+		t.Errorf("expected 2 v1= entries during rotation grace, got %d (sig=%q)", v1count, sig)
+	}
+	// Both must verify — caller migrating from old → new must still
+	// pass during the grace window.
+	if !verifyHMACv1(t, got[0].Headers, got[0].RawBody, oldSecret) {
+		t.Errorf("old secret should still verify during grace")
+	}
+	if !verifyHMACv1(t, got[0].Headers, got[0].RawBody, newSecret) {
+		t.Errorf("new secret should verify")
+	}
+}
+
+func TestWebhooksE2E_DisabledWebhookNoFire(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ts := testutil.TestServer(t, pool, testutil.WithOutboundSMTP("127.0.0.1", 1025, "test.e2a.dev"))
+	receiver := testutil.SubscriberReceiver(t)
+
+	_, key, agent := setupSubscriberOwner(t, ts, "wh-disab", false)
+	wh := registerWebhook(t, ts, agent.UserID, receiver.Server.URL+"/dis",
+		[]string{"email.sent"}, identity.WebhookFilters{})
+
+	// Disable via storage (the public API does it via PATCH, which is
+	// exercised in the handler tests).
+	enabled := false
+	if _, err := ts.Store.UpdateWebhook(context.Background(), wh.ID, agent.UserID,
+		identity.WebhookUpdate{Enabled: &enabled}); err != nil {
+		t.Fatalf("UpdateWebhook disable: %v", err)
+	}
+
+	body := fmt.Sprintf(`{"from":%q,"to":["alice@example.com"],"subject":"x","body":"x"}`, agent.EmailAddress())
+	if status, _ := authedJSON(t, "POST", ts.HTTPServer.URL+"/api/v1/send", key.PlaintextKey, body); status != 200 {
+		t.Fatalf("send status=%d", status)
+	}
+	tick(t, ts)
+	// Give the worker + publisher a beat; assert nothing arrived.
+	receiver.WaitFor(t, 500*time.Millisecond, func(c []testutil.SubscriberCaptured) bool { return false })
+	if got := receiver.Captured(); len(got) != 0 {
+		t.Errorf("disabled webhook should receive no events; got %v", summarize(got))
+	}
+}
+
+// ----------------------------------------------------------------------
+// P5 — Auto-disable
+// ----------------------------------------------------------------------
+
+func TestWebhooksE2E_AutoDisableAfterFailures(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ts := testutil.TestServer(t, pool, testutil.WithOutboundSMTP("127.0.0.1", 1025, "test.e2a.dev"))
+	receiver := testutil.SubscriberReceiver(t)
+	receiver.SetStatus("/dead", 503)
+
+	_, _, agent := setupSubscriberOwner(t, ts, "wh-autodis", false)
+	wh := registerWebhook(t, ts, agent.UserID, receiver.Server.URL+"/dead",
+		[]string{"email.sent"}, identity.WebhookFilters{})
+
+	// Seed 10 failed delivery rows directly. Going through real
+	// /send and exhausting retries would take longer than the test
+	// budget (5 attempts × backoff). The auto-disable janitor only
+	// reads the rows' final status; seeding them keeps the test
+	// deterministic.
+	ctx := context.Background()
+	for i := 0; i < 10; i++ {
+		_, err := pool.Exec(ctx,
+			`INSERT INTO webhook_subscriber_deliveries
+			    (id, webhook_id, event_type, event_payload, status, attempts, max_attempts, last_error, last_status_code)
+			 VALUES ($1, $2, 'email.sent', '{"event":"email.sent"}'::jsonb, 'failed', 5, 5, 'HTTP 503', 503)`,
+			"whd_seed_autodis_"+strconv.Itoa(i)+"_"+wh.ID, wh.ID,
+		)
+		if err != nil {
+			t.Fatalf("seed failed delivery: %v", err)
+		}
+	}
+
+	n, err := ts.Store.AutoDisableFailingWebhooks(ctx)
+	if err != nil {
+		t.Fatalf("AutoDisableFailingWebhooks: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("disabled count = %d, want 1", n)
+	}
+	after, err := ts.Store.GetWebhookByID(ctx, wh.ID, agent.UserID)
+	if err != nil {
+		t.Fatalf("GetWebhookByID: %v", err)
+	}
+	if after.Enabled {
+		t.Errorf("webhook should be disabled after threshold failures")
+	}
+	if after.AutoDisabledAt == nil {
+		t.Errorf("auto_disabled_at not set")
+	}
+}
+
+// summarize turns captured payloads into a debuggable one-line summary
+// for failed assertions. Returning the full envelope blob would dwarf
+// the actual cause.
+func summarize(c []testutil.SubscriberCaptured) string {
+	parts := make([]string, 0, len(c))
+	for _, x := range c {
+		evt, _ := x.Envelope["event"].(string)
+		parts = append(parts, x.URL+"["+evt+"]")
+	}
+	return strings.Join(parts, " ")
+}

--- a/internal/testutil/server.go
+++ b/internal/testutil/server.go
@@ -20,12 +20,36 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/relay"
 	"github.com/Mnexa-AI/e2a/internal/usage"
 	"github.com/Mnexa-AI/e2a/internal/webhook"
+	"github.com/Mnexa-AI/e2a/internal/webhookpub"
 	"github.com/Mnexa-AI/e2a/internal/ws"
 	"github.com/gorilla/mux"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 const TestHMACSecret = "test-hmac-secret-for-testing"
+
+// testServerOpts collects optional knobs callers can flip without
+// growing the TestServer call site. Add fields here rather than new
+// constructor parameters — every existing caller stays untouched.
+type testServerOpts struct {
+	outboundSMTPHost       string
+	outboundSMTPPort       int
+	outboundSMTPFromDomain string
+}
+
+type TestServerOption func(*testServerOpts)
+
+// WithOutboundSMTP wires an upstream relay for /send + HITL approve
+// paths so they don't error with "outbound SMTP relay not configured".
+// Tests that don't trigger outbound omit this. Pointing at Mailpit on
+// localhost:1025 (started via `make docker-up`) is the typical pattern.
+func WithOutboundSMTP(host string, port int, fromDomain string) TestServerOption {
+	return func(o *testServerOpts) {
+		o.outboundSMTPHost = host
+		o.outboundSMTPPort = port
+		o.outboundSMTPFromDomain = fromDomain
+	}
+}
 
 type E2ATestServer struct {
 	HTTPServer *httptest.Server
@@ -34,23 +58,60 @@ type E2ATestServer struct {
 	Signer     *headers.Signer
 	WSHub      *ws.Hub
 	smtpServer *relay.Server
+
+	// Webhooks-as-a-resource wiring (post-PR-180). Tests that exercise
+	// the new path can read these directly without re-deriving them.
+	// Publisher is wired into both the agent API (so /send etc. fire
+	// email.sent) and the SMTP server (so inbound mail fires
+	// email.received). SubscriberStore + Worker let tests insert /
+	// inspect delivery rows and force a drain without waiting on the
+	// 30s production tick.
+	Publisher       webhookpub.Publisher
+	SubscriberStore *webhook.SubscriberStore
+	SubscriberWorker *webhook.SubscriberRetryWorker
 }
 
-func TestServer(t *testing.T, pool *pgxpool.Pool) *E2ATestServer {
+func TestServer(t *testing.T, pool *pgxpool.Pool, opts ...TestServerOption) *E2ATestServer {
 	t.Helper()
+	o := testServerOpts{}
+	for _, opt := range opts {
+		opt(&o)
+	}
 
 	store := identity.NewStore(pool)
 	signer := headers.NewSigner(TestHMACSecret)
 	deliverer := webhook.NewDeliverer(false) // no HTTPS requirement in tests
 	deliveryStore := webhook.NewDeliveryStore(pool)
 	persistentDeliverer := webhook.NewPersistentDeliverer(deliverer, deliveryStore)
-	smtpRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{})
-	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
+	outboundCfg := &config.OutboundSMTPConfig{
+		Host: o.outboundSMTPHost,
+		Port: o.outboundSMTPPort,
+	}
+	fromDomain := "test.e2a.dev"
+	if o.outboundSMTPFromDomain != "" {
+		fromDomain = o.outboundSMTPFromDomain
+	}
+	smtpRelay := outbound.NewSMTPRelay(outboundCfg)
+	sender := outbound.NewSender(smtpRelay, fromDomain)
+
+	// Webhooks-resource (PR-180) wiring. The publisher fans events
+	// to enabled subscribers; the subscriber store is what the /test
+	// + /deliveries handlers read. We wire them into both the API
+	// and the relay so trigger sites fire events. The retry worker
+	// is constructed but NOT started — tests call Tick(ctx) directly
+	// for deterministic delivery without the 30s tick.
+	subscriberStore := webhook.NewSubscriberStore(pool)
+	subscriberDeliverer := webhook.NewSubscriberDeliverer(false)
+	subscriberWorker := webhook.NewSubscriberRetryWorker(subscriberStore, subscriberDeliverer, store)
+	publisher := webhookpub.New(store, webhookpub.NewDBInserter(pool), webhookpub.StaticFlag(true))
+
 	// HTTP server
 	router := mux.NewRouter()
 	noopUsage := usage.NewNoopUsageTracker()
 	api := agent.NewAPI(store, sender, smtpRelay, nil, noopUsage, "e2a.dev", "test.e2a.dev", "agents.e2a.dev", "", false)
 	api.SetIdempotencyStore(idempotency.NewStore(pool))
+	api.SetSubscriberStore(subscriberStore)
+	api.SetPublisher(publisher)
 	api.RegisterRoutes(router)
 
 	// WebSocket route for local-mode agents
@@ -76,6 +137,7 @@ func TestServer(t *testing.T, pool *pgxpool.Pool) *E2ATestServer {
 		Env: "development",
 	}
 	smtpServer := relay.NewServer(cfg, store, signer, persistentDeliverer, noopUsage, wsHub)
+	smtpServer.SetPublisher(publisher)
 
 	go func() {
 		if err := smtpServer.ListenAndServe(); err != nil {
@@ -94,12 +156,15 @@ func TestServer(t *testing.T, pool *pgxpool.Pool) *E2ATestServer {
 	}
 
 	ts := &E2ATestServer{
-		HTTPServer: httpServer,
-		SMTPAddr:   smtpAddr,
-		Store:      store,
-		Signer:     signer,
-		WSHub:      wsHub,
-		smtpServer: smtpServer,
+		HTTPServer:       httpServer,
+		SMTPAddr:         smtpAddr,
+		Store:            store,
+		Signer:           signer,
+		WSHub:            wsHub,
+		smtpServer:       smtpServer,
+		Publisher:        publisher,
+		SubscriberStore:  subscriberStore,
+		SubscriberWorker: subscriberWorker,
 	}
 
 	t.Cleanup(func() {
@@ -146,6 +211,112 @@ func (w *WebhookReceiverResult) WaitForPayloads(t *testing.T, count int, timeout
 		t.Fatalf("expected %d webhook payloads, got %d after %v", count, len(payloads), timeout)
 	}
 	return payloads
+}
+
+// SubscriberCaptured is one POST the SubscriberReceiver caught. The
+// envelope is the parsed JSON body ({event, id, created_at, data})
+// and RawBody is the verbatim bytes — useful for HMAC verification,
+// which signs `t.body` and must use the exact bytes the worker POSTed.
+type SubscriberCaptured struct {
+	URL      string
+	Envelope map[string]any
+	RawBody  []byte
+	Headers  http.Header
+}
+
+// SubscriberReceiverResult is a multi-path receiver for the new
+// webhooks-as-a-resource path. Distinct from WebhookReceiverResult
+// (which decodes the legacy webhook.Payload shape) because the new
+// envelope is {event, id, created_at, data} and we need raw bytes
+// for signature verification.
+type SubscriberReceiverResult struct {
+	Server   *httptest.Server
+	mu       sync.Mutex
+	captured []SubscriberCaptured
+	// status is per-path: if absent, 200. Used by the auto-disable
+	// test to force 503 on one route.
+	statusByPath map[string]int
+}
+
+func (s *SubscriberReceiverResult) Captured() []SubscriberCaptured {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]SubscriberCaptured, len(s.captured))
+	copy(out, s.captured)
+	return out
+}
+
+// SetStatus pins a non-200 response for the given path. Used by the
+// auto-disable test to force the worker into the failure path.
+func (s *SubscriberReceiverResult) SetStatus(path string, code int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.statusByPath == nil {
+		s.statusByPath = map[string]int{}
+	}
+	s.statusByPath[path] = code
+}
+
+// Reset clears captured payloads. Useful between phases of a long
+// test so per-phase assertions don't see prior posts.
+func (s *SubscriberReceiverResult) Reset() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.captured = nil
+}
+
+// WaitFor polls until predicate returns true or the timeout expires.
+// Returns the captured list at the moment predicate first matched (or
+// the last seen list on timeout). Tests typically call Tick(ctx) on
+// the worker once then WaitFor(..., 0) for an immediate check; the
+// timeout exists for cases where the publisher may still be in flight.
+func (s *SubscriberReceiverResult) WaitFor(t *testing.T, timeout time.Duration, predicate func([]SubscriberCaptured) bool) []SubscriberCaptured {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		got := s.Captured()
+		if predicate(got) {
+			return got
+		}
+		if time.Now().After(deadline) {
+			return got
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+// SubscriberReceiver returns a multi-path HTTP receiver wired for the
+// new webhook-resource envelope. Routes work as plain paths under the
+// receiver's base URL — e.g. receiver.Server.URL + "/sent" + ".../fail".
+func SubscriberReceiver(t *testing.T) *SubscriberReceiverResult {
+	t.Helper()
+	result := &SubscriberReceiverResult{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, "read err", 500)
+			return
+		}
+		var env map[string]any
+		_ = json.Unmarshal(raw, &env) // tolerate non-JSON for negative cases
+
+		result.mu.Lock()
+		result.captured = append(result.captured, SubscriberCaptured{
+			URL:      r.URL.Path,
+			Envelope: env,
+			RawBody:  raw,
+			Headers:  r.Header.Clone(),
+		})
+		status := 200
+		if s, ok := result.statusByPath[r.URL.Path]; ok {
+			status = s
+		}
+		result.mu.Unlock()
+		w.WriteHeader(status)
+	}))
+	result.Server = server
+	t.Cleanup(server.Close)
+	return result
 }
 
 func WebhookReceiver(t *testing.T) *WebhookReceiverResult {


### PR DESCRIPTION
## Summary

Closes the coverage gap flagged in the slice 1-4 testing sweep: every unit test covered a single link of the chain, but nothing drove a real trigger (HTTP `/send`, SMTP inbound, HITL approve/reject) all the way to a registered subscriber's HTTP receiver. This change adds **10 E2E tests** that exercise the full chain through the real handlers + publisher + worker + signing path. Full sweep runs in **~4 seconds** wall-clock.

Targets `feat/webhooks-resource` since that's where the publisher + subscriber store live; will go to `main` with the slice 1-4 PR.

## Coverage map

| Phase | Test | What it verifies |
|---|---|---|
| **P1 outbound** | `TestWebhooksE2E_EmailSent` | `/send` → `email.sent` fires from the real handler |
| | `TestWebhooksE2E_HITL_PendingApproved` | `/send` (HITL) → pending event, then `/approve` → approved event |
| | `TestWebhooksE2E_HITL_Rejected` | `/reject` → `email.rejected` with the reason in `data` |
| **P2 inbound** | `TestWebhooksE2E_EmailReceived` | Real SMTP into the relay → `email.received` with `data.message_id` |
| **P3 filters** | `TestWebhooksE2E_FilterByAgentID` | Two agents, two filtered hooks; events route to exactly one |
| | `TestWebhooksE2E_FilterByConversationID` | H5 negative (no `conversation_id` → skip) + positive |
| | `TestWebhooksE2E_FilterByLabelsH5` | H5 negative for labels (filter requires `[urgent]`, event has none → skip) |
| **P4 signing** | `TestWebhooksE2E_RotationGrace_DualSig` | After rotate, header carries two `v1=` entries; both verify against old + new secrets |
| | `TestWebhooksE2E_DisabledWebhookNoFire` | Disabled webhook receives nothing |
| **P5 hardening** | `TestWebhooksE2E_AutoDisableAfterFailures` | 10 failed delivery rows + zero-delivered → janitor flips `enabled=false` and stamps `auto_disabled_at` |

## Test infrastructure

Three additions to `internal/testutil/server.go`. Variadic options on `TestServer` — every existing caller stays untouched:

- **Publisher + subscriber-store wiring** into both the agent API and the SMTP relay so trigger sites fire events without per-test plumbing. The retry worker is constructed but **not started** — tests call `SubscriberWorker.Tick(ctx)` directly between trigger and assertion, keeping the suite deterministic and seconds (vs. waiting on the 30s production tick).
- **`WithOutboundSMTP(host, port, fromDomain)`** so tests that trigger `/send` + HITL approve can point at Mailpit (`localhost:1025` under `make docker-up`). Two pre-existing tests in `internal/e2e/e2e_test.go` (`:113`, `:183`) were skipped waiting on exactly this — they can be unskipped in a follow-up.
- **`SubscriberReceiver`** — multi-path `httptest.NewServer` that captures envelope JSON + headers + raw body per path (so multiple webhooks fan into one receiver under distinct paths), plus `SetStatus(path, code)` for the auto-disable test to force 503s.

## Design decisions worth flagging

1. **URL-validator bypass**: webhooks are provisioned via `Store.CreateWebhook` directly rather than `POST /api/v1/webhooks`. The public API rejects `127.0.0.1` URLs (SSRF guard); the only way to test the worker hitting a local receiver is to bypass the handler-side validator. The validator already has unit-test coverage at `internal/agent/webhooks_api_test.go`; this PR targets the wire path, not the validator.
2. **Tick-driven, not wall-clock**: 30s production tick → instant `Tick(ctx)` call. The two skipped tests already exist as evidence that wall-clock e2e on this codebase doesn't scale.
3. **HITL re-enable cooldown and delivery-row 30-day expiration are out of scope** — both are time-based and not worth racing for.

## Test plan

- [x] `make docker-up`; `E2A_TEST_DATABASE_URL=… go test -tags integration -count=1 ./internal/e2e/ -run TestWebhooksE2E_` — **10/10 pass in 4.9s**
- [x] Existing integration tests unaffected (`TestInboundDelivered` + `TestReplayProtection` are pre-existing flakes on `feat/webhooks-resource` HEAD, confirmed before opening this PR)
- [x] `go build ./...` clean
- [ ] Pre-merge: rebase onto `feat/webhooks-resource` after PR #180 lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)