### PR TITLE
fix(web): hide HITL step for HITL-off agents, fix delivered timestamp

### DIFF
--- a/web/src/app/(app)/dashboard/agents/messages/view/page.test.tsx
+++ b/web/src/app/(app)/dashboard/agents/messages/view/page.test.tsx
@@ -7,7 +7,7 @@ import { render as rawRender } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { mutate } from "swr";
 import AgentMessageFocusPage from "./page";
-import { pendingMessageKey } from "../../../../../../lib/swrKeys";
+import { agentsKey, pendingMessageKey } from "../../../../../../lib/swrKeys";
 
 const mockUseSearchParams = jest.fn();
 const mockRouterPush = jest.fn();
@@ -374,12 +374,21 @@ describe("AgentMessageFocusPage", () => {
   // the textarea would be empty and the assertion would fail.
   it("seeds the textarea from pre-populated SWR cache without firing a fetch (true cache-hit regression)", async () => {
     setSearchParams({ email: "support@acme.io", id: "msg_pending" });
-    // Pre-seed the cache the page is about to subscribe to. The
+    // Pre-seed both caches the page subscribes to. The
     // jest.setup.ts afterEach nukes the module-level cache between
-    // tests, so this seed is isolated to this test.
+    // tests, so these seeds are isolated to this test. The agents
+    // cache is now read by LifecycleSection to decide whether to
+    // render the HITL step — without seeding it the page would
+    // trigger a /api/dashboard/agents fetch and defeat the cache-
+    // hit reproduction below.
     await mutate(
       pendingMessageKey("msg_pending"),
       OUTBOUND_PENDING,
+      { revalidate: false },
+    );
+    await mutate(
+      agentsKey,
+      [{ id: "ag_1", email: "support@acme.io", hitl_enabled: true }],
       { revalidate: false },
     );
     // Fetch must NOT be called: any call indicates the page hit the

--- a/web/src/app/(app)/dashboard/agents/messages/view/page.tsx
+++ b/web/src/app/(app)/dashboard/agents/messages/view/page.tsx
@@ -22,6 +22,7 @@ import {
   getPendingMessage,
   rejectPendingMessage,
 } from "../../../../../components/onboarding/api";
+import { useAgents } from "../../../../../components/hooks/useAgents";
 import type {
   InboundMessageDetail,
   PendingMessageDetail,
@@ -146,6 +147,12 @@ function FocusContent({
   initialHeadersOpen: boolean;
 }) {
   const router = useRouter();
+
+  // Agent lookup is needed for the lifecycle panel to know whether to
+  // render the "Held for HITL approval" step. Both this and AgentLayout
+  // share the same SWR key so the second consumer hits cache for free.
+  const { agents } = useAgents();
+  const hitlEnabled = agents.find((a) => a.email === email)?.hitl_enabled ?? true;
 
   // Try outbound first (focus is most often a Pending draft from the
   // inbox callout); fall back to inbound only on 404. A 500/401/etc.
@@ -557,7 +564,7 @@ function FocusContent({
               )}
             </>
           )}
-          <LifecycleSection msg={msg} />
+          <LifecycleSection msg={msg} hitlEnabled={hitlEnabled} />
           {isPending && msg.direction === "outbound" && (
             <CliHint messageId={msg.data.id} />
           )}
@@ -1013,7 +1020,7 @@ function ActionCard({
   );
 }
 
-function LifecycleSection({ msg }: { msg: LoadedMessage }) {
+function LifecycleSection({ msg, hitlEnabled }: { msg: LoadedMessage; hitlEnabled: boolean }) {
   // Inbound messages don't go through the HITL lifecycle — show a small
   // "received" summary instead of the timeline.
   if (msg.direction === "inbound") {
@@ -1051,11 +1058,16 @@ function LifecycleSection({ msg }: { msg: LoadedMessage }) {
     ttlHint: d.approval_expires_at
       ? `TTL ${formatExpiresIn(d.approval_expires_at) ?? "—"}`
       : undefined,
+    hitlEnabled,
   });
+  // Collapsible meta tracks the latest meaningful event. For HITL-off
+  // agents the held step doesn't exist, so we summarize sent/created
+  // directly instead of the misleading "resolved" fallback.
+  const sentAt = d.reviewed_at ?? (!hitlEnabled ? d.created_at : null);
   const heldSummary = d.status === "pending_approval"
     ? `held · ${formatExpiresIn(d.approval_expires_at) ?? "—"} left`
-    : d.reviewed_at
-      ? `resolved ${formatRelativeAge(d.reviewed_at)}`
+    : sentAt
+      ? `${hitlEnabled ? "resolved" : "sent"} ${formatRelativeAge(sentAt)}`
       : "resolved";
 
   return (

--- a/web/src/app/components/messages/MessageLifecycleTimeline.test.ts
+++ b/web/src/app/components/messages/MessageLifecycleTimeline.test.ts
@@ -77,6 +77,37 @@ describe("deriveLifecycleSteps", () => {
     expect(last.caption).toContain("auto-rejected");
   });
 
+  it("hitlEnabled=false → skips the Held step and uses draftedAt as the delivered timestamp", () => {
+    const steps = deriveLifecycleSteps({
+      status: "sent",
+      draftedAt: "2026-05-24T14:18:09Z",
+      hitlEnabled: false,
+    });
+    expect(steps.map((s) => s.label)).toEqual([
+      "Agent drafted reply",
+      "Sent to recipient",
+    ]);
+    const sent = steps[steps.length - 1];
+    expect(sent.caption).toMatch(/delivered$/);
+    // Caption must carry a real timestamp, not the "—" placeholder
+    // that this fix is replacing.
+    expect(sent.caption).not.toMatch(/^—/);
+  });
+
+  it("hitlEnabled=false w/ inbound parent → Inbound + Drafted + Sent, no Held", () => {
+    const steps = deriveLifecycleSteps({
+      status: "sent",
+      draftedAt: "2026-05-24T14:18:09Z",
+      inboundReceivedAt: "2026-05-24T14:05:12Z",
+      hitlEnabled: false,
+    });
+    expect(steps.map((s) => s.label)).toEqual([
+      "Inbound received",
+      "Agent drafted reply",
+      "Sent to recipient",
+    ]);
+  });
+
   it("Held step is always present; status drives current/terminal caption", () => {
     const pending = deriveLifecycleSteps({
       status: "pending_approval",

--- a/web/src/app/components/messages/MessageLifecycleTimeline.tsx
+++ b/web/src/app/components/messages/MessageLifecycleTimeline.tsx
@@ -122,6 +122,11 @@ export type LifecycleInput = {
   reviewedAt?: string | null;
   /** Optional TTL hint for the pending step. */
   ttlHint?: string;
+  /** Whether the owning agent has HITL enabled. When false the held
+   *  step is omitted and the delivered timestamp falls back to
+   *  `draftedAt` (messages go straight from draft → sent). Defaults
+   *  to true to preserve the historical contract. */
+  hitlEnabled?: boolean;
 };
 
 function fmtClock(iso: string): string {
@@ -132,6 +137,7 @@ function fmtClock(iso: string): string {
 
 export function deriveLifecycleSteps(input: LifecycleInput): LifecycleStep[] {
   const steps: LifecycleStep[] = [];
+  const hitlEnabled = input.hitlEnabled ?? true;
 
   if (input.inboundReceivedAt) {
     steps.push({
@@ -153,21 +159,28 @@ export function deriveLifecycleSteps(input: LifecycleInput): LifecycleStep[] {
     input.status === "expired_approved" ||
     input.status === "expired_rejected";
 
-  steps.push({
-    label: "Held for HITL approval",
-    caption: terminal
-      ? input.reviewedAt
-        ? `${fmtClock(input.reviewedAt)} · resolved`
-        : "resolved"
-      : `${input.ttlHint ?? "TTL"} · auto-reject on expiry`,
-    kind: "warn",
-    current: input.status === "pending_approval",
-  });
+  if (hitlEnabled) {
+    steps.push({
+      label: "Held for HITL approval",
+      caption: terminal
+        ? input.reviewedAt
+          ? `${fmtClock(input.reviewedAt)} · resolved`
+          : "resolved"
+        : `${input.ttlHint ?? "TTL"} · auto-reject on expiry`,
+      kind: "warn",
+      current: input.status === "pending_approval",
+    });
+  }
+
+  // When HITL is off the message goes straight from draft → SMTP, so
+  // the draft timestamp is the best signal we have for "delivered."
+  // When HITL is on we still prefer reviewedAt (approval = send-time).
+  const sentAt = input.reviewedAt ?? (hitlEnabled ? null : input.draftedAt);
 
   if (input.status === "sent" || input.status === "expired_approved") {
     steps.push({
       label: "Sent to recipient",
-      caption: `${input.reviewedAt ? fmtClock(input.reviewedAt) : "—"} · ${input.status === "expired_approved" ? "auto-approved" : "delivered"}`,
+      caption: `${sentAt ? fmtClock(sentAt) : "—"} · ${input.status === "expired_approved" ? "auto-approved" : "delivered"}`,
       kind: "success",
     });
   } else if (input.status === "rejected" || input.status === "expired_rejected") {


### PR DESCRIPTION
## Summary

The Lifecycle panel on the agent message focus page (`/dashboard/agents/messages/view`) had two issues for HITL-disabled agents:

1. **Phantom "Held for HITL approval" step** — `deriveLifecycleSteps` unconditionally pushed the held step regardless of whether the owning agent had HITL enabled. Users saw a step that never actually happened.
2. **"— · delivered" caption** — the final step used `reviewed_at` (only set by the HITL flow) as the delivered timestamp with no fallback. HITL-off messages always rendered as a literal em-dash.

## Changes

- `deriveLifecycleSteps` accepts a new `hitlEnabled` field (defaults to `true` to preserve the historical contract). When `false`, the held step is omitted and `draftedAt` (i.e. `messages.created_at`) is used as the delivered timestamp since HITL-off sends are queued the moment they're drafted.
- The focus page reads `hitl_enabled` from the cached agent via `useAgents()`. Same SWR key as the layout, so no extra fetch in practice.
- The collapsible meta reads `sent <Nh> ago` for HITL-off agents instead of the misleading bare "resolved".

## Test plan

- [x] `web` jest suite: 261/261 passing (25 suites)
- [x] Two new `deriveLifecycleSteps` cases pinning HITL-off rendering: plain + with inbound parent
- [x] Focus-page cache-hit regression test updated to pre-seed `agentsKey` so the new lookup doesn't trip its `expect(mockFetch).not.toHaveBeenCalled()` assertion
- [x] Walked through every status × HITL combo against backend writers; confirmed `reviewed_at` is set by all four terminal transitions (`ApproveAndSend`, `ExpireApproveAndSend`, `RejectPending`, `ExpireReject`), so HITL-on captions remain correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)