### PR TITLE
chore(retention): cut message retention from 30 to 10 days

### DIFF
--- a/docs/data-handling.md
+++ b/docs/data-handling.md
@@ -8,8 +8,8 @@ For vulnerability reporting and the security model, see [SECURITY.md](../SECURIT
 
 | Data | Where | Retention |
 |---|---|---|
-| Inbound + outbound message envelopes (sender, recipient, subject, conversation_id, timestamps) | Postgres `messages` | Default 30 days; `expires_at` per row, hourly cleanup worker |
-| Inbound message bodies (raw RFC822 in `raw_message`) | Postgres `messages` | Same 30-day default |
+| Inbound + outbound message envelopes (sender, recipient, subject, conversation_id, timestamps) | Postgres `messages` | Default 10 days; `expires_at` per row, hourly cleanup worker. Chosen to exceed the 7-day HITL max TTL with a 3-day audit buffer. |
+| Inbound message bodies (raw RFC822 in `raw_message`) | Postgres `messages` | Same 10-day default |
 | Outbound message bodies (only while in `pending_approval`) | Postgres `messages.body_text` / `body_html` / `attachments_json` | **Scrubbed on terminal HITL transition** (approve/reject/expire) — only metadata persists after that |
 | Attachments | Postgres rows (`attachments_json`, JSONB) | Same lifetime as the parent message — no S3/GCS |
 | Agent + domain ownership records | Postgres `agent_identities`, `domains` | Until the user deletes the agent/domain or the account |

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -759,7 +759,20 @@ func (s *Store) DeleteAgent(ctx context.Context, agentID, userID string) error {
 
 // --- Messages ---
 
-const MessageTTL = 30 * 24 * time.Hour // 30 days
+// MessageTTL is the per-row lifetime for `messages`. The janitor at
+// DeleteExpiredMessages drops rows whose expires_at has passed.
+//
+// 10 days is chosen to strictly exceed HITLMaxTTLSeconds (7 days) with
+// a 3-day buffer. The buffer guarantees:
+//   - the HITL worker (60s cadence) always wins the race against the
+//     messages janitor (hourly cadence) on max-HITL pending rows;
+//   - terminal HITL rows retain ≥3 days of post-resolution audit
+//     visibility before the metadata row is dropped;
+//   - reply-composition can load a parent inbound up to 10 days old
+//     for quoting context.
+// If HITLMaxTTLSeconds is ever raised, raise this too — keep
+// MessageTTL > HITLMaxTTLSeconds by at least 1 day.
+const MessageTTL = 10 * 24 * time.Hour // 10 days
 
 // NewMessageID returns a fresh internal message ID. Callers can use this
 // to generate the ID up-front when they need it before storing — for

--- a/internal/webhookpub/event.go
+++ b/internal/webhookpub/event.go
@@ -64,7 +64,7 @@ func IsValidEventType(name string) bool {
 //
 // MessageID is optional — set when the event has an originating
 // message row. Persisted on the delivery row with ON DELETE SET NULL
-// so the 30-day messages janitor doesn't orphan the delivery.
+// so the messages janitor (10-day TTL) doesn't orphan the delivery.
 type Event struct {
 	// ID is a unique identifier for this event firing. Stable across
 	// retries — receivers dedup on it.


### PR DESCRIPTION
## Summary

Default \`messages\` retention drops from 30 days to **10 days** for both inbound and outbound. The customer's webhook payload is the canonical archive; our DB is the short operational window for replay, debugging, HITL composition, and audit.

- \`internal/identity/store.go\` — \`MessageTTL = 10 * 24 * time.Hour\` with a doc comment explaining the HITL invariant
- \`internal/webhookpub/event.go\` — doc comment updated
- \`docs/data-handling.md\` — customer-facing retention table updated

## Why 10, not 7

\`HITLMaxTTLSeconds = 604800 = 7 days\` ([store.go:97](https://github.com/Mnexa-AI/e2a/blob/main/internal/identity/store.go#L97)). A 7-day MessageTTL would put the HITL deadline and the messages-janitor deadline at the **same instant** for any max-HITL pending row, racing the 60s HITL worker against the hourly janitor.

If the janitor wins:
- the pending HITL row is silently DELETE'd
- no \`email.expired_rejected\` / \`email.expired_approved\` event ever fires
- the reviewer's notification link goes 404 with no useful error

10 days gives the HITL worker a **3-day buffer** so the race window is effectively zero, AND keeps at least 3 days of post-resolution audit visibility on every terminal HITL row. Storage cost is ~43% above 7d but still ~3× cheaper than the original 30d.

If \`HITLMaxTTLSeconds\` is ever raised, \`MessageTTL\` must be raised in lockstep — documented inline in the new comment.

## Backwards-compatibility

In-flight rows keep their original 30-day \`expires_at\` and age out on the original schedule. Only newly inserted rows pick up the shorter TTL. No migration needed — \`expires_at\` is computed in Go at insert time, and the DEFAULT in \`001_init.sql\` is dead code (every INSERT supplies the column explicitly).

## Out of scope

These TTLs are intentionally unchanged — different surfaces, different reasons:
- Webhook events log (\`webhook_events\`, 30d)
- Webhook subscriber deliveries (\`webhook_subscriber_deliveries\`, 90d via the retry envelope)
- OAuth sessions / refresh tokens (30d)

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go test ./internal/identity/\` — passes
- [x] \`go test ./internal/hitlworker/\` — 8/8 passing (verified worker still finalizes pending rows correctly under the new TTL)
- [x] \`web\` jest suite: 261/261 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)