### PR TITLE
fix(web): drop duplicated agent ID from dashboard card + agent header

### DIFF
--- a/web/src/app/(app)/dashboard/_components/AgentCard.tsx
+++ b/web/src/app/(app)/dashboard/_components/AgentCard.tsx
@@ -95,8 +95,7 @@ export function AgentCard({
               letterSpacing: "0.02em",
             }}
           >
-            agent_{agent.id} · created{" "}
-            {new Date(agent.created_at).toLocaleDateString()}
+            created {new Date(agent.created_at).toLocaleDateString()}
           </p>
 
         </div>

--- a/web/src/app/components/messages/AgentHeader.tsx
+++ b/web/src/app/components/messages/AgentHeader.tsx
@@ -59,7 +59,7 @@ export function AgentHeader({
       {/* Identity row */}
       <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-3 mb-3">
         <div className="min-w-0 flex-1">
-          <Eyebrow>Agent · {agent.id}</Eyebrow>
+          <Eyebrow>Agent</Eyebrow>
           <div className="flex items-center gap-3 mt-2 mb-1.5 flex-wrap">
             <CounterpartyAvatar email={agent.email} name={agent.name} size={28} />
             <h1


### PR DESCRIPTION
## Summary

The dashboard agent card rendered the email twice — once as the prominent chip, and again as a misleading \`agent_<email>\` mono line. The literal \`agent_\` prefix is hardcoded in JSX, while \`agent.id\` IS the email (see \`store.go:613\`, where agent rows use their email address as the primary key — agents are the only resource that don't follow the \`{type}_{random}\` convention).

The per-agent header eyebrow (\`Agent · <email>\`) had the same redundancy with the email chip rendered below it.

This PR drops the duplicated string from both surfaces. The pill chip remains the canonical email display.

## Before / after

Dashboard card meta line:
- Before: \`agent_test-mcp@agents.e2a.dev · created 5/18/2026\`
- After: \`created 5/18/2026\`

Per-agent header eyebrow:
- Before: \`AGENT · TEST-MCP@AGENTS.E2A.DEV\`
- After: \`AGENT\`

## Test plan

- [x] \`web\` jest suite: 261/261 passing
- [x] No tests reference the removed strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)