### PR TITLE
docs: add CONTRIBUTING.md with local-development guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,284 @@
+# Contributing to e2a
+
+Thanks for considering a contribution. e2a is a polyglot monorepo
+(Go backend + TypeScript CLI/SDK + Python SDK + Next.js dashboard +
+MCP server) and the bar for a friction-free first PR is mostly about
+getting a working local environment.
+
+This document covers:
+
+- [Prerequisites](#prerequisites)
+- [First run](#first-run)
+- [Project layout](#project-layout)
+- [Running tests](#running-tests)
+- [Making changes that touch the API](#making-changes-that-touch-the-api)
+- [Database migrations](#database-migrations)
+- [Commit + PR conventions](#commit--pr-conventions)
+- [Where to ask](#where-to-ask)
+
+For deeper architecture detail and command reference, see
+[CLAUDE.md](./CLAUDE.md) (it doubles as Claude Code agent context but
+the architecture and commands sections are useful regardless of how
+you read it).
+
+---
+
+## Prerequisites
+
+| Tool | Version | Why |
+|---|---|---|
+| Go | 1.25 | backend |
+| Node | 24+ | CLI, TypeScript SDK, MCP server, web dashboard |
+| Python | 3.10+ | Python SDK |
+| Docker (Desktop or engine) | any recent | local Postgres + Mailpit |
+
+You don't need all four to contribute — touching only the TS SDK
+doesn't require Python, etc. But you do need Docker for any change
+that runs the backend.
+
+---
+
+## First run
+
+The fastest path to a running backend with working outbound mail:
+
+```bash
+# 1. clone + bootstrap configs
+git clone https://github.com/Mnexa-AI/e2a.git
+cd e2a
+cp config.example.yaml config.yaml
+
+# 2. start Postgres (:5433) + Mailpit (:1025 SMTP, :8025 UI)
+make docker-up
+
+# 3. point outbound at Mailpit so HITL approvals + test-email work
+#    Edit config.yaml under `outbound_smtp:`:
+#      host: "localhost"
+#      port: 1025
+#      from_domain: "e2a.localhost"
+#    (Captured outbound mail will appear at http://localhost:8025.)
+
+# 4. build + run the backend
+make run
+```
+
+The first run auto-applies all migrations against the local Postgres
+(`E2A_MIGRATION_MODE=auto` is the default). The API is now at
+`http://localhost:8080`; the SMTP relay is on `:2525`.
+
+### Bootstrap your first user
+
+The dashboard uses Google OAuth, which is more setup than most
+contributors want for a first run. The bootstrap CLI flag creates a
+user + API key in one step without an OAuth handshake:
+
+```bash
+./bin/e2a -config config.yaml -bootstrap-email you@example.com
+```
+
+The command prints the plaintext API key. Save it — you can't recover
+it later (only the hash is stored).
+
+### Verify the install
+
+```bash
+curl http://localhost:8080/api/health
+# → {"status":"ok"}
+
+curl -H "Authorization: Bearer <your-key>" http://localhost:8080/api/v1/agents
+# → {"agents":[]}
+```
+
+### Optional: web dashboard
+
+If you want the Next.js dashboard too:
+
+```bash
+cd web
+npm install
+npm run dev    # http://localhost:3000, proxies /api/* to :8080
+```
+
+Google OAuth credentials are required for sign-in — set
+`E2A_GOOGLE_CLIENT_ID` and `E2A_GOOGLE_CLIENT_SECRET` in `config.yaml`.
+For API-only contributions you can skip the dashboard.
+
+---
+
+## Project layout
+
+| Path | What's there |
+|---|---|
+| `cmd/e2a/` | Backend binary entry point |
+| `internal/relay/` | SMTP server, inbound mail |
+| `internal/emailauth/` | SPF / DKIM verification |
+| `internal/agent/` | Agent CRUD, HITL, REST API |
+| `internal/identity/` | Domain ownership, message store |
+| `internal/headers/` | HMAC-signed `X-E2A-Auth-*` headers |
+| `internal/webhook/` | Outbound webhook delivery + retry |
+| `internal/webhookpub/` | Stripe-tier durable outbox |
+| `internal/ws/` | WebSocket hub for real-time push |
+| `internal/outbound/` | Compose + send via upstream SMTP |
+| `internal/billing/` | Stripe + usage metering |
+| `internal/auth/` | API key + user auth |
+| `internal/config/` | YAML config + env var overrides |
+| `cli/` | `e2a` CLI (TypeScript) |
+| `sdks/typescript/` | `@e2a/sdk` |
+| `sdks/python/` | Python `e2a` package |
+| `mcp/` | `@e2a/mcp-server` Model Context Protocol surface |
+| `web/` | Next.js 16 dashboard |
+| `migrations/` | SQL migrations, embedded into the binary |
+| `docs/` | API reference, deployment, design docs |
+
+`CLAUDE.md` has a deeper write-up of the inbound flow and the SDK
+type-generation pipeline.
+
+---
+
+## Running tests
+
+The Go suite is split into three tiers because integration tests are
+slow and need a database.
+
+```bash
+make test-unit          # no DB needed — fast
+make test-integration   # needs Postgres on :5433 (make docker-up)
+make test-e2e           # build tag 'integration', runs internal/e2e/*
+make test               # all three, with -p 1 to avoid DB-state races
+```
+
+Run a single Go test against the local DB:
+
+```bash
+E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable" \
+  go test ./internal/agent/ -run TestApprovePendingMessage_AgentScopedPath_Succeeds -v
+```
+
+Other surfaces:
+
+```bash
+# TypeScript SDK
+npm test --workspace @e2a/sdk
+npm run test:contract --workspace @e2a/sdk    # needs live server
+
+# CLI
+npm test --workspace @e2a/cli
+
+# MCP server
+npm test --workspace @e2a/mcp-server
+
+# Python SDK
+cd sdks/python && pip install -e ".[dev]" && pytest tests/ -v
+
+# Web dashboard (Jest)
+cd web && npm test
+```
+
+If you change the SMTP relay or anything that interacts with the
+database, prefer adding an integration test in
+`internal/relay/`, `internal/agent/`, or `internal/e2e/` — unit tests
+alone don't catch schema drift.
+
+---
+
+## Making changes that touch the API
+
+e2a maintains parity across **eight client surfaces** for every API
+change: the Go handler, OpenAPI spec, TypeScript SDK (raw + high-level),
+Python SDK sync (raw + high-level), Python SDK async (raw + high-level),
+CLI, MCP server, and the web dashboard. Each surface has its own tests.
+
+Generated code lives in `sdks/{typescript,python}/.../generated/`.
+After editing Go swag annotations:
+
+```bash
+make swagger        # regenerates web/public/openapi.yaml
+make generate-sdk   # regenerates generated/ for TS + Python
+make generate       # both
+```
+
+CI fails the PR if these are out of date — run them and commit the
+diff. The PR template ([`.github/pull_request_template.md`](.github/pull_request_template.md))
+includes a checkbox list of every client surface; tick what's in scope
+and explain anything intentionally skipped.
+
+---
+
+## Database migrations
+
+Migrations live in `migrations/*.sql` and are **embedded into the
+binary** (`migrations/embed.go`). On startup the binary applies any
+pending migrations against a `schema_migrations` tracker table.
+
+**Rules every migration must follow:**
+
+1. **Idempotent** — `CREATE TABLE IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`,
+   `CREATE INDEX IF NOT EXISTS`. Migrations have to be re-runnable.
+2. **Non-destructive on prod-sized tables** — `ADD COLUMN` is safe;
+   `ALTER COLUMN TYPE` can rewrite the entire table and lock it. Avoid
+   on `messages` and `usage_events` especially.
+3. **Numbered sequentially** — `0NN_short_description.sql`. Don't
+   renumber existing files.
+4. **Forward-only** — there are no down migrations. If you need to
+   undo something, write a new migration that does it.
+
+Add or update tests in any Go package that writes raw SQL against the
+touched table. Higher-level e2e coverage doesn't catch query drift
+because the migration runner is idempotent — runtime SQL will compile
+and silently misbehave.
+
+Local control:
+
+```bash
+make migrate        # apply pending migrations manually
+# E2A_MIGRATION_MODE=auto    (default) — apply on startup
+# E2A_MIGRATION_MODE=verify  — refuse to start if any are pending
+# E2A_MIGRATION_MODE=skip    — emergency surgery only
+```
+
+---
+
+## Commit + PR conventions
+
+**Commit messages** follow a `type(scope): subject` shape with a
+short imperative subject. The format is not formally
+Conventional-Commits (no `!:` breaking markers, no `BREAKING CHANGE`
+footers), just a consistent convention enforced by review.
+
+```
+type(scope): short imperative summary (≤ 72 chars)
+
+Optional body paragraphs explaining *why*, not what (the diff is the
+what). Wrap at 72 chars. Reference issues with #123. End with a
+Co-Authored-By footer for AI co-author when applicable.
+```
+
+Types observed in the repo: `feat`, `fix`, `chore`, `docs`, `test`,
+`refactor`, `deps`, `release`. Scopes are package- or surface-shaped
+(e.g. `feat(api)`, `fix(web)`, `chore(retention)`, `test(e2e-prod)`).
+Skim `git log --oneline -30` before opening your first PR — that
+beats any written rule.
+
+**PRs** use the template at [`.github/pull_request_template.md`](.github/pull_request_template.md).
+Keep the description tight; the checklist is the load-bearing part.
+
+**One PR per feature.** Don't bundle unrelated cleanup — that makes
+review harder and rollback risky. A small refactor that genuinely
+enables the feature is fine; a drive-by typo fix should be its own PR.
+
+**CI must be green.** All twelve test jobs run on every PR. If a
+flake hits you, re-run the job rather than disabling the test.
+
+---
+
+## Where to ask
+
+- **Bug reports** — open a [GitHub issue](https://github.com/Mnexa-AI/e2a/issues)
+- **Feature ideas / design discussion** — open a [GitHub discussion](https://github.com/Mnexa-AI/e2a/discussions)
+- **Security issues** — see [SECURITY.md](./SECURITY.md). Don't open a
+  public issue for security reports.
+
+A good bug report includes: e2a version (`./bin/e2a -version` or the
+git SHA), the exact command, the relevant log lines, and what you
+expected vs. what happened. For SMTP / inbound issues, the
+`[mail:<id>]` log line is the most useful thing to paste.


### PR DESCRIPTION
## Summary

Adds a root-level \`CONTRIBUTING.md\` so first-time human contributors don't have to piece together the local-dev path from README, \`CLAUDE.md\`, and config.example.yaml comments.

Specifically captures:

- Prereqs (Go 1.25, Node 24+, Python 3.10+, Docker)
- First-run flow with the **Mailpit recipe spelled out in step 3** — this was buried in config.example.yaml's comments
- The \`-bootstrap-email\` shortcut to skip OAuth for the first user
- Three Go test tiers + TS/Python/CLI/MCP/web suite commands
- The 8-surface API parity rule (links to the PR template)
- Migration idempotency + non-destructive rules
- Commit shape (\`type(scope): subject\`) described as the observed convention, not claimed as formal Conventional Commits
- Routing for bugs, ideas, and security reports

Points readers at \`CLAUDE.md\` for deeper architecture detail.

## Test plan

- [x] No code changes, doc-only
- [x] Verified file is at repo root (GitHub auto-renders it as a \"Contributing\" link on the repo home and PR creation flow)
- [x] All asserted facts verified: \`SECURITY.md\` exists, \`-bootstrap-email\` flag exists in \`cmd/e2a/main.go\`, GitHub Discussions is enabled on the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)