### PR TITLE
fix(outbox): janitor preserves pending webhook_events rows (C1)

### DIFF
--- a/internal/webhookpub/outbox.go
+++ b/internal/webhookpub/outbox.go
@@ -90,20 +90,34 @@ func (o *outbox) PublishTx(ctx context.Context, tx pgx.Tx, e Event) error {
 	return writeOutboxRow(ctx, tx, e)
 }
 
-// DeleteExpiredWebhookEvents removes rows whose expires_at has passed.
-// Migration 026 sets a 30-day TTL on every event row; without this
-// janitor the table grows monotonically and the (user_id, created_at)
-// index degrades. Mirrors webhook.SubscriberStore.DeleteExpiredSubscriberDeliveries
-// for the parallel slice-2 delivery table.
+// DeleteExpiredWebhookEvents removes terminal rows whose expires_at has
+// passed. Migration 026 sets a 30-day TTL on every event row; without
+// this janitor the table grows monotonically and the (user_id,
+// created_at) index degrades. Mirrors
+// webhook.SubscriberStore.DeleteExpiredSubscriberDeliveries for the
+// parallel slice-2 delivery table.
 //
-// Returns the number of rows deleted. Safe to run concurrently with the
-// outbox worker — the WHERE predicate excludes rows the worker would
-// lease (status='pending' AND next_poll_at <= now() implies expires_at
-// is in the future for any row the worker would touch, since the
-// trigger writes both with similar lifetimes).
+// Returns the number of rows deleted.
+//
+// The status guard is load-bearing. The outbox is at-least-once by
+// design — see worker.go's recordFailure docstring: "there is NO
+// terminal 'failed' state on the outbox … we let the row stay pending
+// until human intervention or a successful retry." If we delete
+// pending rows at 30 days the retry-forever guarantee silently breaks,
+// dropping events that never reached any webhook. A row only becomes
+// eligible for the sweep once the worker has marked it terminal
+// (`processed` after a successful fan-out, `no_match` when no enabled
+// webhook subscribed).
+//
+// Trade-off: a row that's broken on the retry path (e.g. a downstream
+// SELECT panics every iteration) will accumulate forever rather than
+// fall out at day 30. That's the "page ops after many attempts" case
+// recordFailure calls out — preferable to silent loss.
 func (o *outbox) DeleteExpiredWebhookEvents(ctx context.Context) (int, error) {
 	tag, err := o.pool.Exec(ctx,
-		`DELETE FROM webhook_events WHERE expires_at <= now()`,
+		`DELETE FROM webhook_events
+		 WHERE expires_at <= now()
+		   AND status <> 'pending'`,
 	)
 	if err != nil {
 		return 0, fmt.Errorf("delete expired webhook_events: %w", err)

--- a/internal/webhookpub/outbox_integration_test.go
+++ b/internal/webhookpub/outbox_integration_test.go
@@ -264,8 +264,23 @@ func TestOutbox_Integration_FlagOffNoWrite(t *testing.T) {
 }
 
 // TestOutbox_Integration_JanitorDeletesExpired exercises the slice-A
-// janitor: rows past expires_at are removed; rows within retention
-// stay. Critical for unbounded-growth prevention on the outbox table.
+// janitor on a matrix of (status, expires_at) combinations. The
+// invariant the janitor must preserve:
+//
+//   - Terminal rows (status ∈ {processed, no_match}) past expires_at
+//     are deleted.
+//   - Pending rows past expires_at are NOT deleted, even when they're
+//     overdue. The outbox is at-least-once by design (worker.go's
+//     recordFailure: "no terminal 'failed' state … row stays pending
+//     until human intervention or a successful retry"). Deleting them
+//     at day 30 silently breaks the retry-forever guarantee and drops
+//     events that never reached any webhook.
+//   - Rows within retention are untouched regardless of status.
+//
+// Critical for unbounded-growth prevention on the outbox table AND
+// for the at-least-once delivery guarantee. Before the status guard
+// was added, a row that failed every fan-out attempt would sit
+// pending for 30 days and then be silently destroyed.
 func TestOutbox_Integration_JanitorDeletesExpired(t *testing.T) {
 	pool := testutil.TestDB(t)
 	ctx := context.Background()
@@ -283,21 +298,37 @@ func TestOutbox_Integration_JanitorDeletesExpired(t *testing.T) {
 		_, _ = pool.Exec(ctx, `DELETE FROM users WHERE id = $1`, userID)
 	})
 
-	expiredID := webhookpub.DeterministicEventID("msg_expired_jan", webhookpub.EventEmailReceived)
-	freshID := webhookpub.DeterministicEventID("msg_fresh_jan", webhookpub.EventEmailReceived)
-	for _, row := range []struct {
-		id        string
-		expiresAt string
+	// Seed the full (status × expires_at) matrix. Each row is keyed by
+	// a deterministic ID so the post-sweep assertions can target it
+	// individually.
+	rows := []struct {
+		label       string
+		status      string
+		expiresAt   string
+		shouldKeep  bool
 	}{
-		{expiredID, "now() - interval '1 day'"},
-		{freshID, "now() + interval '1 day'"},
-	} {
+		// Terminal + expired → DELETE.
+		{"processed_expired", "processed", "now() - interval '1 day'", false},
+		{"no_match_expired", "no_match", "now() - interval '1 day'", false},
+		// Pending + expired → KEEP. This is the load-bearing assertion
+		// for the C1 fix. Pre-fix this row would have been silently
+		// destroyed, breaking the at-least-once retry-forever
+		// guarantee.
+		{"pending_expired", "pending", "now() - interval '1 day'", true},
+		// Within-retention rows are untouched regardless of status.
+		{"processed_fresh", "processed", "now() + interval '1 day'", true},
+		{"pending_fresh", "pending", "now() + interval '1 day'", true},
+	}
+	ids := make(map[string]string, len(rows))
+	for _, row := range rows {
+		id := webhookpub.DeterministicEventID("msg_jan_"+row.label, webhookpub.EventEmailReceived)
+		ids[row.label] = id
 		_, err := pool.Exec(ctx,
 			`INSERT INTO webhook_events (id, user_id, type, envelope, status, expires_at)
-			 VALUES ($1, $2, $3, '{}'::jsonb, 'pending', `+row.expiresAt+`)`,
-			row.id, userID, webhookpub.EventEmailReceived)
+			 VALUES ($1, $2, $3, '{}'::jsonb, $4, `+row.expiresAt+`)`,
+			id, userID, webhookpub.EventEmailReceived, row.status)
 		if err != nil {
-			t.Fatalf("seed %s: %v", row.id, err)
+			t.Fatalf("seed %s: %v", row.label, err)
 		}
 	}
 
@@ -306,18 +337,30 @@ func TestOutbox_Integration_JanitorDeletesExpired(t *testing.T) {
 	if err != nil {
 		t.Fatalf("DeleteExpiredWebhookEvents: %v", err)
 	}
-	if deleted != 1 {
-		t.Errorf("deleted = %d; want 1", deleted)
+	// Exactly two rows match (expires_at <= now() AND status <> 'pending'):
+	// processed_expired and no_match_expired.
+	if deleted != 2 {
+		t.Errorf("deleted = %d; want 2 (processed_expired + no_match_expired)", deleted)
 	}
 
-	var freshCount, expiredCount int
-	pool.QueryRow(ctx, `SELECT count(*) FROM webhook_events WHERE id = $1`, freshID).Scan(&freshCount)
-	pool.QueryRow(ctx, `SELECT count(*) FROM webhook_events WHERE id = $1`, expiredID).Scan(&expiredCount)
-	if freshCount != 1 {
-		t.Errorf("fresh count = %d; want 1", freshCount)
-	}
-	if expiredCount != 0 {
-		t.Errorf("expired count = %d; want 0", expiredCount)
+	for _, row := range rows {
+		var count int
+		if err := pool.QueryRow(ctx,
+			`SELECT count(*) FROM webhook_events WHERE id = $1`, ids[row.label],
+		).Scan(&count); err != nil {
+			t.Fatalf("count %s: %v", row.label, err)
+		}
+		wantCount := 0
+		if row.shouldKeep {
+			wantCount = 1
+		}
+		if count != wantCount {
+			verdict := "should have been deleted"
+			if row.shouldKeep {
+				verdict = "should have been kept"
+			}
+			t.Errorf("%s: count = %d, want %d (%s)", row.label, count, wantCount, verdict)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

First fix from the audit. The outbox janitor was silently destroying pending \`webhook_events\` rows past their 30-day TTL, breaking the at-least-once retry-forever guarantee the outbox design is built around.

## The bug

\`\`\`go
DELETE FROM webhook_events WHERE expires_at <= now()  // no status guard
\`\`\`

The inline comment ([outbox.go:99-103](https://github.com/Mnexa-AI/e2a/blob/main/internal/webhookpub/outbox.go#L99-L103)) claimed this was safe because \"next_poll_at <= now() implies expires_at is in the future for any row the worker would touch.\" That's true *at insert time*, but \`next_poll_at\` gets bumped on every retry while \`expires_at\` is never updated. Day 30 wins.

Meanwhile \`recordFailure\` ([worker.go:417-421](https://github.com/Mnexa-AI/e2a/blob/main/internal/webhookpub/worker.go#L417-L421)) is explicit:

> \"Per design §4.4 there is NO terminal 'failed' state on the outbox — at-least-once requires that we retry indefinitely. After many attempts we'd page ops; today we log and let the row stay pending until human intervention or a successful retry.\"

So a row that fails fan-out for any reason (transient DB error, downstream panic, etc.) stays pending and retries every ~60s — and is then silently destroyed on day 30 with no alert.

## The fix

Two-line predicate change:

\`\`\`go
DELETE FROM webhook_events
WHERE expires_at <= now()
  AND status <> 'pending'
\`\`\`

Only terminal rows (\`processed\`, \`no_match\`) are eligible for sweep. The full status enum in migration 026 is \`('pending', 'processed', 'no_match')\`; this guard is forward-compatible if we add more terminal states.

### Trade-off (called out in the new comment)

A row that's permanently broken on the retry path will accumulate forever rather than fall out at day 30. That's the \"page ops after many attempts\" case the design already documents — preferable to silent data loss.

## Tests

\`TestOutbox_Integration_JanitorDeletesExpired\` previously seeded both rows as \`pending\` and asserted the expired one **is** deleted — it codified the bug.

Rewritten to exercise the full (status × expires_at) matrix:

| Row | Status | expires_at | Expected |
|---|---|---|---|
| processed_expired | processed | -1d | deleted |
| no_match_expired | no_match | -1d | deleted |
| **pending_expired** | **pending** | **-1d** | **KEPT** ← load-bearing |
| processed_fresh | processed | +1d | kept |
| pending_fresh | pending | +1d | kept |

Test asserts \`deleted = 2\` (down from 3 pre-fix) and verifies each row individually.

## Verification

- [x] \`go test ./internal/webhookpub/ -tags integration\` — passes
- [x] Full \`webhookpub\` suite (unit + integration) — passes
- [x] Pre-fix: same test fails on \`deleted = 3, want 2\` and on the \`pending_expired\` row-keep assertion

## Other findings

The audit surfaced C2-C5 (critical), H1-H8 (high), and a long tail of medium/low items. Tracking separately; this PR is C1 only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)