### PR TITLE
fix(outbox): pg_notify failure is a soft failure, not a tx rollback (C2)

### DIFF
--- a/internal/webhookpub/outbox.go
+++ b/internal/webhookpub/outbox.go
@@ -197,13 +197,23 @@ func writeOutboxRow(ctx context.Context, exec outboxExecutor, e Event) error {
 	// slice-2 worker's 1s fallback poll catches missed wakeups
 	// (deploy windows, LISTEN reconnect races). Payload is empty
 	// because the worker rescans the table anyway.
-	_, err = exec.Exec(ctx, `SELECT pg_notify('webhook_events_new', '')`)
-	if err != nil {
-		// NOTIFY queue overflow is the only realistic error
-		// (~8GB at default config; unreachable in practice).
-		// Treat as soft failure: log and let the tx commit.
-		// The worker's fallback poll will pick up the row.
-		return fmt.Errorf("webhookpub: pg_notify webhook_events_new: %w", err)
+	//
+	// A pg_notify error here (NOTIFY queue overflow is the realistic
+	// case; max_notify_queue_pages defaults to 1024 × 8KB = 8MB) is a
+	// SOFT failure: we log and return nil so the caller's tx still
+	// commits. The webhook_events row is what matters for at-least-
+	// once delivery; the NOTIFY is only a latency optimization that
+	// the worker's 1s fallback poll covers.
+	//
+	// Returning the error here would propagate out of writeOutboxRow,
+	// out of PublishTx, and out of the caller's WithTx — rolling back
+	// the entire trigger transaction. In the relay path that means
+	// the inbound `messages` row is also lost; SMTP returns a 4xx to
+	// the MTA which retries into the same broken state. (See PR for
+	// C2 in the audit.)
+	if _, nerr := exec.Exec(ctx, `SELECT pg_notify('webhook_events_new', '')`); nerr != nil {
+		log.Printf("[outbox] pg_notify webhook_events_new failed (event=%s, type=%s): %v — worker fallback poll will recover",
+			e.ID, e.Type, nerr)
 	}
 	return nil
 }

--- a/internal/webhookpub/outbox_test.go
+++ b/internal/webhookpub/outbox_test.go
@@ -2,6 +2,7 @@ package webhookpub
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -55,15 +56,24 @@ func TestDeterministicEventID_PipeDelimiterPreventsAmbiguity(t *testing.T) {
 }
 
 // fakeExec captures Exec calls for assertion without touching a DB.
+// `err` (if set) is returned on every call. `errOnContains` (if set)
+// is returned only on calls whose SQL contains the substring — used
+// to exercise selective failure modes like "pg_notify fails but the
+// INSERT succeeds."
 type fakeExec struct {
-	calls []string
-	args  [][]any
-	err   error
+	calls         []string
+	args          [][]any
+	err           error
+	errOnContains string
+	errSelective  error
 }
 
 func (f *fakeExec) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
 	f.calls = append(f.calls, sql)
 	f.args = append(f.args, args)
+	if f.errOnContains != "" && strings.Contains(sql, f.errOnContains) {
+		return pgconn.CommandTag{}, f.errSelective
+	}
 	if f.err != nil {
 		return pgconn.CommandTag{}, f.err
 	}
@@ -97,6 +107,78 @@ func TestWriteOutboxRow_RejectsEmptyType(t *testing.T) {
 	err := writeOutboxRow(context.Background(), fe, Event{ID: "evt_abc", UserID: "u1"})
 	if err == nil {
 		t.Fatalf("expected error on empty Type")
+	}
+}
+
+// TestWriteOutboxRow_PgNotifyFailureIsSoft pins the C2 fix: when
+// pg_notify fails (realistically: NOTIFY queue overflow at ~8MB),
+// writeOutboxRow MUST log and return nil so the caller's tx commits.
+//
+// Before the fix the pg_notify error was returned, propagating out of
+// PublishTx → out of WithTx → causing the entire trigger transaction
+// to roll back. In the relay path that meant the inbound `messages`
+// row was lost too: SMTP returned a 4xx to the MTA, MTA retried into
+// the same broken state, and inbound mail piled up undelivered while
+// the only signal was a "failed to record inbound message" log line.
+//
+// The INSERT having succeeded is enough for at-least-once: the worker's
+// 1-second fallback poll picks up the row regardless of whether the
+// NOTIFY fired. The NOTIFY is a latency optimization, not a correctness
+// primitive.
+func TestWriteOutboxRow_PgNotifyFailureIsSoft(t *testing.T) {
+	notifyErr := errors.New("ERROR: too many notifications in the NOTIFY queue (SQLSTATE 54000)")
+	fe := &fakeExec{
+		errOnContains: "pg_notify",
+		errSelective:  notifyErr,
+	}
+	e := Event{
+		ID:     "evt_notify_fail",
+		Type:   EventEmailReceived,
+		UserID: "u_42",
+	}
+	if err := writeOutboxRow(context.Background(), fe, e); err != nil {
+		t.Fatalf("writeOutboxRow should swallow pg_notify failure, got: %v", err)
+	}
+	// Both Exec calls must have been attempted — the INSERT first, then
+	// the (failing) pg_notify. The INSERT must NOT have been skipped.
+	if len(fe.calls) != 2 {
+		t.Fatalf("expected 2 Exec calls (INSERT + NOTIFY), got %d: %v", len(fe.calls), fe.calls)
+	}
+	if !strings.Contains(fe.calls[0], "INSERT INTO webhook_events") {
+		t.Errorf("first call must be the INSERT: %s", fe.calls[0])
+	}
+	if !strings.Contains(fe.calls[1], "pg_notify") {
+		t.Errorf("second call must be the pg_notify: %s", fe.calls[1])
+	}
+}
+
+// TestWriteOutboxRow_InsertFailureStillPropagates ensures the soft-
+// failure treatment for pg_notify doesn't accidentally swallow INSERT
+// errors too. A failed INSERT means the webhook_events row didn't get
+// written — at-least-once is broken, so the caller's tx MUST roll
+// back. The errSelective fake fails on the INSERT specifically.
+func TestWriteOutboxRow_InsertFailureStillPropagates(t *testing.T) {
+	insertErr := errors.New("ERROR: duplicate key value violates unique constraint")
+	fe := &fakeExec{
+		errOnContains: "INSERT INTO webhook_events",
+		errSelective:  insertErr,
+	}
+	e := Event{
+		ID:     "evt_insert_fail",
+		Type:   EventEmailReceived,
+		UserID: "u_42",
+	}
+	err := writeOutboxRow(context.Background(), fe, e)
+	if err == nil {
+		t.Fatalf("INSERT failure must propagate to caller; got nil error")
+	}
+	if !strings.Contains(err.Error(), "insert webhook_events") {
+		t.Errorf("error should mention insert: %v", err)
+	}
+	// pg_notify should NOT have been called after the INSERT failed —
+	// nothing to notify about.
+	if len(fe.calls) != 1 {
+		t.Errorf("only INSERT should have been attempted; got %d calls: %v", len(fe.calls), fe.calls)
 	}
 }
 


### PR DESCRIPTION
## Summary

Second fix from the audit. \`writeOutboxRow\`'s pg_notify call returned its error, propagating out of \`PublishTx\` → out of the caller's \`WithTx\` → rolling back the entire trigger transaction. The inline comment said the opposite of what the code did:

> \"NOTIFY queue overflow is the only realistic error … Treat as soft failure: log and let the tx commit.\"

## Blast radius

| Caller | Pre-fix behavior on pg_notify failure |
|---|---|
| **relay** (`internal/relay/server.go:377-389`) | Catastrophic. The outbox \`PublishTx\` is in the same tx as \`CreateInboundMessageInTx\`. NOTIFY fails → both rows roll back → SMTP returns 4xx → MTA retries into the same broken state. Inbound mail piles up undelivered. |
| **publishPendingApproval** (`internal/agent/api.go:313`) | Event silently dropped. The standalone outbox tx rolls back; the underlying pending-approval state was already committed in a different tx. User gets a successful API response but no \`email.pending_approval\` event fires. |
| **publishRejected** (`internal/agent/api.go:348`) | Same as pending: event silently dropped. |
| **publishApproved** (uses \`PublishBestEffortTx\`) | Already correct — best-effort variant logs and returns regardless. |

Also: the comment's claim about queue size was wrong. \`max_notify_queue_pages\` defaults to 1024 × 8KB = **8MB**, not the \"8GB\" the comment said. Under sustained high-throughput writes from many concurrent transactions, 8MB is reachable.

## The fix

\`\`\`go
if _, nerr := exec.Exec(ctx, \`SELECT pg_notify('webhook_events_new', '')\`); nerr != nil {
    log.Printf(\"[outbox] pg_notify webhook_events_new failed (event=%s, type=%s): %v — worker fallback poll will recover\",
        e.ID, e.Type, nerr)
}
return nil
\`\`\`

The webhook_events INSERT having succeeded is enough for at-least-once: the worker has a 1-second fallback poll that picks up the row regardless of whether NOTIFY fired. NOTIFY is a latency optimization (sub-100ms wake vs. up-to-1s poll wake), not a correctness primitive.

## Tests

Three tests, two new + one untouched-but-relevant happy path:

| Test | What it pins |
|---|---|
| **\`TestWriteOutboxRow_PgNotifyFailureIsSoft\`** (new) | Extends \`fakeExec\` to fail selectively on pg_notify; asserts \`writeOutboxRow\` returns nil so caller's tx commits. Both Exec calls (INSERT + NOTIFY) are still attempted. |
| **\`TestWriteOutboxRow_InsertFailureStillPropagates\`** (new) | The INSERT-failure path STILL propagates — we only softened pg_notify. Also pins that pg_notify is never called after an INSERT failure. |
| \`TestWriteOutboxRow_HappyPath_TwoExecCalls\` (existing) | Continues to pass: both Exec calls fire on the happy path. |

Plus the integration suite (\`-tags integration\`) still passes.

## Verification

- [x] \`go test ./internal/webhookpub/\` — passes
- [x] \`go test ./internal/webhookpub/ -tags integration\` — passes
- [x] Manually verified the log line is emitted with event ID + type for diagnosability

## Other findings

C1 merged in #191. C3-C5 (Critical), H1-H8 (High), plus M/L items tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)