### PR TITLE
fix(mcp): use ASCII hyphens in "no session" error for log-pipeline safety

### DIFF
--- a/mcp/src/http-server.ts
+++ b/mcp/src/http-server.ts
@@ -262,7 +262,7 @@ async function handleClientRequest(
     return;
   }
   if (!entry) {
-    res.status(400).json(jsonRpcError(req.body, -32000, "no session — send initialize first"));
+    res.status(400).json(jsonRpcError(req.body, -32000, "no session -- send initialize first"));
     return;
   }
 


### PR DESCRIPTION
## Summary

  The JSON-RPC error returned on a `/mcp` request with no session id used a
  U+2014 em-dash (`"no session — send initialize first"`), which can be mangled
  by ASCII-only log pipelines. Replace it with two ASCII hyphens (`--`).

  String-only change — no API shape, endpoint, or contract change.

  Refs #92 (low-severity nits).

  ## Operational risk

  None. Single-character change to the wording of an existing error message; no
  user data, side effects, auth, billing, or external integrations touched.
  Nothing to roll back beyond reverting the commit.

  ## Test plan

  - [x] `npm run build --workspace @e2a/mcp-server` — compiles clean
  - [x] `npm test --workspace @e2a/mcp-server` — 118/118 pass