### PR TITLE
Fix/rest low severity nits 92

### DIFF
--- a/mcp/src/bin/http.ts
+++ b/mcp/src/bin/http.ts
@@ -9,6 +9,7 @@ interface BinConfig {
   maxSessions: number;
   publicUrl?: string;
   authorizationServerUrl?: string;
+  trustProxy: boolean | number | string;
 }
 
 class ConfigError extends Error {}
@@ -50,6 +51,21 @@ function parsePort(name: string, raw: string, def: number): number {
     throw new ConfigError(`${name} must be 0..65535; got ${JSON.stringify(raw)}`);
   }
   return n;
+}
+
+// parseTrustProxy maps E2A_TRUST_PROXY to the value Express's `trust
+// proxy` setting expects. Default "loopback": only a same-host proxy (the
+// prod Caddy front, forwarding over localhost) is trusted for
+// X-Forwarded-* headers. "true"/"false" become booleans; a bare integer
+// is a hop count (Express reads a numeric *string* as a subnet, so it must
+// be converted); anything else passes through as a preset name
+// ("loopback"/"uniquelocal"/...) or a CSV of IPs/subnets.
+function parseTrustProxy(raw: string): boolean | number | string {
+  if (raw === "") return "loopback";
+  if (raw === "true") return true;
+  if (raw === "false") return false;
+  if (/^\d+$/.test(raw)) return Number(raw);
+  return raw;
 }
 
 function parseHostList(raw: string, def: string): string[] {
@@ -94,6 +110,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): BinConfig {
     maxSessions: parsePositiveInt("MCP_MAX_SESSIONS", env.MCP_MAX_SESSIONS ?? "", 500),
     publicUrl: env.MCP_PUBLIC_URL || undefined,
     authorizationServerUrl: env.MCP_AUTHORIZATION_SERVER_URL || undefined,
+    trustProxy: parseTrustProxy(env.E2A_TRUST_PROXY ?? ""),
   };
 }
 
@@ -121,6 +138,7 @@ async function main(): Promise<void> {
     resolveCacheMaxEntries: cfg.maxSessions,
     publicUrl: cfg.publicUrl,
     authorizationServerUrl: cfg.authorizationServerUrl,
+    trustProxy: cfg.trustProxy,
   });
   logJson("INFO", "listening", `e2a-mcp-http listening on :${bound}`, {
     port: bound,

--- a/mcp/src/http-server.ts
+++ b/mcp/src/http-server.ts
@@ -30,8 +30,14 @@ export interface HttpServerOptions {
    * client needs the host-reachable URL (http://localhost:8080). Set
    * this to override what's advertised in protected-resource metadata
    * without changing where the SDK forwards bearer tokens.
-   */
+  */
   authorizationServerUrl?: string;
+  /**
+   * Express `trust proxy` setting. Controls which hops' `X-Forwarded-*`
+   * headers are honored when computing externally visible discovery URLs.
+   * Defaults to `"loopback"`, matching the production Caddy topology.
+   */
+  trustProxy?: boolean | number | string;
   /** Optional shared resolution cache (defaults to a fresh one). */
   resolveCache?: ResolveCache;
   /** How long a resolved bearer→principal entry stays cached (ms). */
@@ -77,6 +83,9 @@ export function buildApp(opts: HttpServerOptions): BuiltApp {
     });
 
   const app = express();
+  // Set this before any route reads req.protocol. The default trusts only the
+  // same-host production proxy, so public clients cannot spoof the scheme.
+  app.set("trust proxy", opts.trustProxy ?? "loopback");
   // The body limit must clear the attachment contract: the tools advertise up
   // to 10 MB/attachment and 25 MB combined (see tools/attachments.ts), which
   // base64-encode to ~34 MB on the wire, plus the JSON-RPC envelope. A 1 MB cap
@@ -120,8 +129,8 @@ export function buildApp(opts: HttpServerOptions): BuiltApp {
   //   1. publicUrl set explicitly: trust it verbatim (local-dev http,
   //      or any deployment behind a fronting proxy that knows its own
   //      external URL better than we do).
-  //   2. unset + Host header present + Host in allowlist: synthesize
-  //      `https://{Host}`. This is the prod-default Caddy-fronted path.
+  //   2. unset + Host header present + Host in allowlist: synthesize the URL
+  //      from the trusted request protocol and Host.
   //   3. unset + Host missing/disallowed: caller wrapped function
   //      rejects with 421 before reaching here.
   const resolveResourceUrl = (req: Request): string | null => {
@@ -132,7 +141,7 @@ export function buildApp(opts: HttpServerOptions): BuiltApp {
     if (!host) return null;
     const bare = host.split(":")[0]!.toLowerCase();
     if (!allowedHosts.has(bare)) return null;
-    return `https://${host}`;
+    return `${externalScheme(req)}://${host}`;
   };
 
   app.get("/.well-known/oauth-protected-resource", (req, res) => {
@@ -196,13 +205,18 @@ function methodNotAllowed(_req: Request, res: Response): void {
     .json(jsonRpcError(null, -32000, "Method not allowed: the e2a MCP server is stateless"));
 }
 
+// req.protocol honors X-Forwarded-Proto only for hops allowed by `trust proxy`.
+function externalScheme(req: Request): string {
+  return req.protocol === "https" ? "https" : "http";
+}
+
 // resourceMetadataURL returns the value the `WWW-Authenticate` header
 // should advertise. Honors publicUrl when set (local-dev http), falls
-// back to https+Host otherwise (prod behind Caddy).
+// back to the trusted request scheme + Host otherwise.
 function resourceMetadataURL(req: Request, opts: HttpServerOptions): string {
   const base = opts.publicUrl
     ? opts.publicUrl.replace(/\/+$/, "")
-    : `https://${req.headers.host}`;
+    : `${externalScheme(req)}://${req.headers.host}`;
   return `${base}/.well-known/oauth-protected-resource`;
 }
 

--- a/mcp/tests/bin-http.test.ts
+++ b/mcp/tests/bin-http.test.ts
@@ -10,6 +10,7 @@ describe("bin/http loadConfig", () => {
       allowedHosts: ["api.e2a.dev"],
       sessionIdleMs: 5 * 60_000,
       maxSessions: 500,
+      trustProxy: "loopback",
     });
   });
 
@@ -27,6 +28,7 @@ describe("bin/http loadConfig", () => {
       allowedHosts: ["api.e2a.dev", "mcp-staging.e2a.dev"],
       sessionIdleMs: 60_000,
       maxSessions: 100,
+      trustProxy: "loopback",
     });
   });
 
@@ -91,6 +93,26 @@ describe("bin/http loadConfig", () => {
   it("allows port 0 (OS-assigned)", () => {
     const cfg = loadConfig({ PORT: "0" });
     expect(cfg.port).toBe(0);
+  });
+
+  it("defaults E2A_TRUST_PROXY to loopback", () => {
+    expect(loadConfig({}).trustProxy).toBe("loopback");
+  });
+
+  it("parses E2A_TRUST_PROXY booleans", () => {
+    expect(loadConfig({ E2A_TRUST_PROXY: "true" }).trustProxy).toBe(true);
+    expect(loadConfig({ E2A_TRUST_PROXY: "false" }).trustProxy).toBe(false);
+  });
+
+  it("parses a bare integer E2A_TRUST_PROXY as a hop count", () => {
+    // Express reads a numeric *string* as a subnet, so it must become a
+    // real number to mean "trust N hops".
+    expect(loadConfig({ E2A_TRUST_PROXY: "1" }).trustProxy).toBe(1);
+  });
+
+  it("passes through a preset / subnet E2A_TRUST_PROXY verbatim", () => {
+    expect(loadConfig({ E2A_TRUST_PROXY: "uniquelocal" }).trustProxy).toBe("uniquelocal");
+    expect(loadConfig({ E2A_TRUST_PROXY: "10.0.0.0/8" }).trustProxy).toBe("10.0.0.0/8");
   });
 });
 

--- a/mcp/tests/http.test.ts
+++ b/mcp/tests/http.test.ts
@@ -242,6 +242,41 @@ describe("HTTP MCP server", () => {
     expect(body.bearer_methods_supported).toEqual(["header"]);
   });
 
+  it("discovery scheme falls back to the connection scheme without X-Forwarded-Proto", async () => {
+    const origin = url.replace("/mcp", "");
+    const res = await fetch(`${origin}/.well-known/oauth-protected-resource`);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.resource).toBe(origin);
+  });
+
+  it("honors X-Forwarded-Proto from a trusted loopback proxy", async () => {
+    const origin = url.replace("/mcp", "");
+    const res = await fetch(`${origin}/.well-known/oauth-protected-resource`, {
+      headers: { "X-Forwarded-Proto": "https" },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.resource).toBe(origin.replace(/^http:/, "https:"));
+  });
+
+  it("ignores X-Forwarded-Proto when the proxy is not trusted", async () => {
+    await close();
+    const { close: c, port } = await startHttpServer(0, {
+      baseUrl: "http://e2a.local",
+      allowedHosts: ["127.0.0.1", "localhost"],
+      trustProxy: false,
+      clientFactory: () => stub,
+    });
+    close = c;
+    const res = await fetch(`http://127.0.0.1:${port}/.well-known/oauth-protected-resource`, {
+      headers: { "X-Forwarded-Proto": "https" },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.resource).toBe(`http://127.0.0.1:${port}`);
+  });
+
   it("lists every registered tool after initialize", async () => {
     const { client, transport } = await connect();
     const { tools } = await client.listTools();


### PR DESCRIPTION
## Summary

  Two low-severity follow-up nits from #92 (MCP HTTP server v0.2 polish):

  1. **`evictOldest` swallows close errors** — the LRU eviction in `Sessions` fire-and-forgot the delete with `void this.delete(id)` and, unlike the
  sibling `gc()`/`shutdown()` paths, never attached a `.catch()`. A rejecting `transport.close()` would surface as an unhandled promise rejection
  (which can terminate the process under Node's default behavior). Now caught and logged to stderr at warn.

  2. **Hardcoded `https://` discovery scheme** — the OAuth protected-resource discovery URLs (`resource` field and `WWW-Authenticate:
  resource_metadata`) were hardcoded to `https://{Host}`, which is correct behind the prod Caddy front but wrong for any non-TLS deployment that
  doesn't set `MCP_PUBLIC_URL`. The scheme is now derived from `X-Forwarded-Proto` via Express's `trust proxy`, defaulting to `"loopback"`
  (configurable with the new `E2A_TRUST_PROXY` env var).

  This is a **correctness fix**, not a security fix: the old hardcoded scheme had no spoofing risk (a constant can't be forged). The `trust proxy:
  loopback` gate is included so that reading `X-Forwarded-Proto` can't be abused by a forged header from an untrusted hop — it preserves the old
  code's un-spoofability while gaining accuracy. In prod (Caddy terminates TLS, forwards over localhost with `X-Forwarded-Proto: https`) the
  advertised URL is unchanged.

  ## Operational risk

  Low. No data, auth, billing, or external integrations touched.

  - **Behavior change:** a deployment that serves plain HTTP *without* setting `MCP_PUBLIC_URL` will now advertise `http://...` in discovery (the
  real scheme) instead of `https://...`. This is strictly more correct; the only deployments affected were already misconfigured (advertising https
  they couldn't serve). `MCP_PUBLIC_URL` continues to override everything.
  - **Prod unchanged:** Caddy sends `X-Forwarded-Proto: https` over loopback → `trust proxy: "loopback"` honors it → advertised URL stays
  `https://...`.
  - **New knob:** `E2A_TRUST_PROXY` (default `"loopback"`); operators behind a non-loopback proxy set it to their proxy's address/subnet, a hop
  count, or a preset.
  - **Out-of-repo assumption:** the default relies on Caddy forwarding over localhost and *replacing* (not appending) `X-Forwarded-Proto` — that
  config lives in `e2a-ops`, not here. Worth a glance on that side.
  - **Rollback:** revert the commits; no migrations or persisted state involved.

  ## Test plan

  - [x] `npm run build --workspace @e2a/mcp-server` — clean (no `tsc` errors)
  - [x] `npm test --workspace @e2a/mcp-server` — 126 passing (8 files)
  - [x] `evictOldest` regression: new test evicts an entry whose `close()` rejects; asserts the entry is still removed and the warning is logged (no unhandled rejection)
  - [x] Discovery scheme: no `X-Forwarded-Proto` → falls back to the real connection scheme
  - [x] Discovery scheme: trusted (loopback) `X-Forwarded-Proto: https` → advertised as `https`
  - [x] Discovery scheme: `trustProxy: false` + spoofed `X-Forwarded-Proto: https` → header dropped, falls back to `http`
  - [x] `parseTrustProxy` config: default `loopback`, booleans, integer hop-count, preset/CIDR passthrough
