### PR TITLE
feat(mcp): emit structured JSON logs from the HTTP server bin (#92)

### DIFF
--- a/mcp/src/bin/http.ts
+++ b/mcp/src/bin/http.ts
@@ -13,6 +13,26 @@ interface BinConfig {
 
 class ConfigError extends Error {}
 
+type LogSeverity = "INFO" | "WARNING" | "ERROR";
+
+// logJson emits one operational event as a single-line JSON object on
+// stderr. GCE Cloud Logging parses a single-line JSON payload into
+// structured `jsonPayload` fields and honors two special keys: `severity`
+// (sets the entry's log level) and `message` (the human-readable summary
+// shown in the console). Keeping each event on one line also means
+// multi-line content like a stack trace in `error` stays a single log
+// entry instead of being split into several fragmented ones. The result
+// is both human-skimmable (via `message`) and queryable (filter on
+// `severity`, `event`, or any structured field).
+function logJson(
+  severity: LogSeverity,
+  event: string,
+  message: string,
+  fields: Record<string, unknown> = {},
+): void {
+  process.stderr.write(`${JSON.stringify({ severity, event, message, ...fields })}\n`);
+}
+
 function parsePositiveInt(name: string, raw: string, def: number): number {
   if (raw === "") return def;
   const n = Number(raw);
@@ -52,8 +72,10 @@ function resolveBaseUrl(env: NodeJS.ProcessEnv): string {
   if (canonical) return canonical;
   if (legacy) {
     if (!resolveBaseUrl.warned) {
-      process.stderr.write(
-        "[e2a-mcp-http] E2A_BASE_URL is deprecated; rename it to E2A_URL (both names work today).\n",
+      logJson(
+        "WARNING",
+        "e2a_base_url_deprecated",
+        "E2A_BASE_URL is deprecated; rename it to E2A_URL (both names work today).",
       );
       resolveBaseUrl.warned = true;
     }
@@ -75,7 +97,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): BinConfig {
   };
 }
 
-export { ConfigError };
+export { ConfigError, logJson };
 
 async function main(): Promise<void> {
   let cfg: BinConfig;
@@ -83,7 +105,7 @@ async function main(): Promise<void> {
     cfg = loadConfig();
   } catch (err) {
     if (err instanceof ConfigError) {
-      process.stderr.write(`e2a-mcp-http config error: ${err.message}\n`);
+      logJson("ERROR", "config_error", `config error: ${err.message}`, { error: err.message });
       process.exit(2);
     }
     throw err;
@@ -97,9 +119,11 @@ async function main(): Promise<void> {
     publicUrl: cfg.publicUrl,
     authorizationServerUrl: cfg.authorizationServerUrl,
   });
-  process.stderr.write(
-    `e2a-mcp-http listening on :${bound} (base ${cfg.baseUrl}, hosts ${cfg.allowedHosts.join(",")})\n`,
-  );
+  logJson("INFO", "listening", `e2a-mcp-http listening on :${bound}`, {
+    port: bound,
+    baseUrl: cfg.baseUrl,
+    allowedHosts: cfg.allowedHosts,
+  });
 
   // Graceful shutdown: stop accepting new connections, drain active
   // sessions, then exit. Hard ceiling at 30s to avoid hanging deploys.
@@ -107,9 +131,9 @@ async function main(): Promise<void> {
   const shutdown = async (signal: NodeJS.Signals) => {
     if (closing) return;
     closing = true;
-    process.stderr.write(`received ${signal}, draining...\n`);
+    logJson("INFO", "draining", `received ${signal}, draining...`, { signal });
     const drainTimeout = setTimeout(() => {
-      process.stderr.write("drain timeout, forcing exit\n");
+      logJson("ERROR", "drain_timeout", "drain timeout, forcing exit");
       process.exit(1);
     }, 30_000);
     drainTimeout.unref();
@@ -120,7 +144,7 @@ async function main(): Promise<void> {
     } catch (err) {
       clearTimeout(drainTimeout);
       const message = err instanceof Error ? err.message : String(err);
-      process.stderr.write(`shutdown error: ${message}\n`);
+      logJson("ERROR", "shutdown_error", `shutdown error: ${message}`, { error: message });
       process.exit(1);
     }
   };
@@ -134,7 +158,7 @@ const isMain = import.meta.url === `file://${process.argv[1]}`;
 if (isMain) {
   main().catch((err) => {
     const message = err instanceof Error ? err.stack ?? err.message : String(err);
-    process.stderr.write(`e2a-mcp-http fatal: ${message}\n`);
+    logJson("ERROR", "fatal", `e2a-mcp-http fatal: ${message}`, { error: message });
     process.exit(1);
   });
 }

--- a/mcp/tests/bin-http.test.ts
+++ b/mcp/tests/bin-http.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { ConfigError, loadConfig } from "../src/bin/http.js";
+import { ConfigError, loadConfig, logJson } from "../src/bin/http.js";
 
 describe("bin/http loadConfig", () => {
   it("returns defaults when env is empty", () => {
@@ -30,10 +30,19 @@ describe("bin/http loadConfig", () => {
     });
   });
 
-  it("falls back to E2A_BASE_URL when E2A_URL is unset", () => {
-    const warn = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+  it("falls back to E2A_BASE_URL when E2A_URL is unset (structured deprecation log)", () => {
+    const lines: string[] = [];
+    const warn = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      lines.push(String(chunk));
+      return true;
+    });
     const cfg = loadConfig({ E2A_BASE_URL: "https://legacy.example.com" });
     expect(cfg.baseUrl).toBe("https://legacy.example.com");
+    // The deprecation notice is emitted as one structured JSON line that
+    // Cloud Logging can parse — severity + event + a human-readable message.
+    const entry = JSON.parse(lines.at(-1)!);
+    expect(entry).toMatchObject({ severity: "WARNING", event: "e2a_base_url_deprecated" });
+    expect(typeof entry.message).toBe("string");
     warn.mockRestore();
   });
 
@@ -82,5 +91,33 @@ describe("bin/http loadConfig", () => {
   it("allows port 0 (OS-assigned)", () => {
     const cfg = loadConfig({ PORT: "0" });
     expect(cfg.port).toBe(0);
+  });
+});
+
+describe("logJson", () => {
+  it("emits a single-line JSON object with severity, event, message and fields", () => {
+    const lines: string[] = [];
+    const spy = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      lines.push(String(chunk));
+      return true;
+    });
+    logJson("INFO", "listening", "e2a-mcp-http listening on :3000", {
+      port: 3000,
+      allowedHosts: ["mcp.e2a.dev"],
+    });
+    spy.mockRestore();
+
+    expect(lines).toHaveLength(1);
+    // Exactly one line: trailing newline, no embedded newlines (so Cloud
+    // Logging treats it as a single structured entry).
+    expect(lines[0].endsWith("\n")).toBe(true);
+    expect(lines[0].trimEnd()).not.toContain("\n");
+    expect(JSON.parse(lines[0])).toEqual({
+      severity: "INFO",
+      event: "listening",
+      message: "e2a-mcp-http listening on :3000",
+      port: 3000,
+      allowedHosts: ["mcp.e2a.dev"],
+    });
   });
 });


### PR DESCRIPTION
## Summary

  Closes one item from #92 (MCP HTTP server v0.2 polish): the `e2a-mcp-http` bin emitted operational events as plain text to stderr (`e2a-mcp-http
  listening on :3000 …`, `received SIGTERM, draining...`, etc.). On GCE these are captured by Cloud Logging, which stores plain text as an opaque
  `textPayload` — not filterable by field, and multi-line content (e.g. a fatal stack trace) is split into separate fragmented entries.

  This switches every operational line to a single-line JSON object via a small `logJson(severity, event, message, fields)` helper. Cloud Logging
  parses these into structured `jsonPayload` and honors the `severity` (log level) and `message` (console summary) special fields — so logs stay
  human-skimmable *and* become queryable (filter on `severity`, `event`, `port`, `error`, …). Scope is the HTTP server bin only.

  Example, before → after:

  e2a-mcp-http listening on :3000 (base https://e2a.dev, hosts mcp.e2a.dev)
  ```json
  {"severity":"INFO","event":"listening","message":"e2a-mcp-http listening on
  :3000","port":3000,"baseUrl":"https://e2a.dev","allowedHosts":["mcp.e2a.dev"]}
```

 ## Operational risk

  Low. No data, auth, billing, or external integrations touched — output format only.

  - Log format change: anything that grep'd the old plain-text lines (dashboards, alerts, saved queries) will need updating to match the JSON
  fields. No code consumes these lines; they're operator-facing only.
  - Scope: HTTP server bin (mcp/src/bin/http.ts) only. The stdio server (index.ts/config.ts) is intentionally left as plain text — it runs locally
  inside a user's MCP host and is read by a human at a terminal, where JSON would be a regression.
  - Severity mapping: e2a_base_url_deprecated → WARNING; config_error / drain_timeout / shutdown_error / fatal → ERROR; listening / draining → INFO.
  - Rollback: revert the commit; no migrations or persisted state involved.

 ## Test plan

  - [x] npm run build --workspace @e2a/mcp-server — clean (no tsc errors)
  - [x] npm test --workspace @e2a/mcp-server — 119 passing (8 files)
  - [x] New logJson unit test: asserts a single line (trailing newline, no embedded newlines) parsing to {severity, event, message, ...fields}
  - [x] Tightened the E2A_BASE_URL deprecation test to assert the emitted line parses as JSON with severity:"WARNING" + the event name
