### PR TITLE
fix(mcp): let create_agent target a verified custom domain

### DIFF
--- a/mcp/src/tools/agents.ts
+++ b/mcp/src/tools/agents.ts
@@ -57,20 +57,31 @@ export function registerAgentTools(server: McpServer, client: E2AClient): void {
   server.registerTool(
     "create_agent",
     {
-      title: "Create a new agent inbox on the shared domain",
+      title: "Create a new agent inbox (shared or custom domain)",
       description:
-        "Register a new agent using a slug on the deployment's shared domain (e.g. slug 'support-bot' → support-bot@<shared-domain>). Defaults to `local` mode so the agent receives mail via `list_messages` polling — no webhook server required. Pass `agent_mode: 'cloud'` and `webhook_url` for push delivery; in that case the webhook handler MUST HMAC-verify every delivery against the account's webhook signing secret (`E2A_WEBHOOK_SECRET`, shown in the dashboard) — the e2a SDK exposes `parseWebhook(body, secret)` for this. For a custom (non-shared) domain, use `register_domain` to start the verification flow. Slug must be lowercase letters, numbers, and hyphens.",
+        "Register a new agent inbox. Pass EXACTLY ONE of `slug` or `email`:\n" +
+        "• `slug` — a local part on the deployment's shared domain (e.g. slug 'support' → support@<shared-domain>). Instant; no DNS needed. Lowercase letters, numbers, and hyphens.\n" +
+        "• `email` — a full address on a custom domain you have ALREADY registered and verified via `register_domain` + `verify_domain` (e.g. 'support@yourdomain.com'). The API rejects it if the domain isn't verified for your account.\n" +
+        "Defaults to `local` mode so the agent receives mail via `list_messages` polling — no webhook server required. Pass `agent_mode: 'cloud'` and `webhook_url` for push delivery; in that case the webhook handler MUST HMAC-verify every delivery against the account's webhook signing secret (`E2A_WEBHOOK_SECRET`, shown in the dashboard) — the e2a SDK exposes `parseWebhook(body, secret)` for this.",
       inputSchema: strictInputSchema({
         slug: z
           .string()
           .regex(/^[a-z0-9][a-z0-9-]*$/)
+          .optional()
           .describe(
-            "Local part of the new email address. Lowercase letters, numbers, and hyphens; must start with a letter or number.",
+            "Local part of an inbox on the shared domain. Lowercase letters, numbers, and hyphens; must start with a letter or number. Mutually exclusive with `email`.",
+          ),
+        email: z
+          .string()
+          .email()
+          .optional()
+          .describe(
+            "Full address on a custom domain already registered + verified for your account (e.g. 'support@yourdomain.com'). Mutually exclusive with `slug`.",
           ),
         name: z
           .string()
           .optional()
-          .describe("Display name for the agent. Defaults to the slug."),
+          .describe("Display name for the agent. Defaults to the slug / local part."),
         agent_mode: z
           .enum(["local", "cloud"])
           .optional()
@@ -85,14 +96,30 @@ export function registerAgentTools(server: McpServer, client: E2AClient): void {
       }),
     },
     async (args) =>
-      runTool(() =>
-        client.registerAgent({
-          slug: args.slug,
+      runTool(() => {
+        // The API accepts `slug` XOR `email` (slug → shared domain, email →
+        // custom domain; see RegisterAgentRequest). Enforce exactly-one here
+        // so an ambiguous or empty call fails with a directive message rather
+        // than the API's terser "email is required" / silent slug-precedence.
+        // Every call this lets through behaves identically on the API — we
+        // only reject the ambiguous both/neither case earlier.
+        const hasSlug = args.slug !== undefined;
+        const hasEmail = args.email !== undefined;
+        if (hasSlug === hasEmail) {
+          throw new Error(
+            hasSlug
+              ? "pass exactly one of `slug` (shared domain) or `email` (custom domain), not both"
+              : "one of `slug` or `email` is required: `slug` for an inbox on the shared domain (e.g. 'support'), or `email` for a custom domain you have already registered + verified (e.g. 'support@yourdomain.com')",
+          );
+        }
+        return client.registerAgent({
           agent_mode: args.agent_mode ?? "local",
+          ...(args.slug !== undefined ? { slug: args.slug } : {}),
+          ...(args.email !== undefined ? { email: args.email } : {}),
           ...(args.name !== undefined ? { name: args.name } : {}),
           ...(args.webhook_url !== undefined ? { webhook_url: args.webhook_url } : {}),
-        }),
-      ),
+        });
+      }),
   );
 
   server.registerTool(

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -28,11 +28,14 @@ function makeStubClient(overrides: Partial<{ agentEmail: string }> = {}): E2ACli
     getConversation: vi.fn(async () => ({ conversation_id: "conv_1", messages: [] })),
     listMessages: vi.fn(async () => ({ messages: [], next_token: undefined })),
     listAgents: vi.fn(async () => ({ agents: [{ email: "bot@example.com" }] })),
-    registerAgent: vi.fn(async (body: Record<string, unknown>) => ({
-      email: `${body.slug}@agents.example.com`,
-      domain: "agents.example.com",
-      id: `${body.slug}@agents.example.com`,
-    })),
+    registerAgent: vi.fn(async (body: Record<string, unknown>) => {
+      const email = body.email ?? `${body.slug}@agents.example.com`;
+      return {
+        email,
+        domain: String(email).split("@")[1],
+        id: email,
+      };
+    }),
     getAgent: vi.fn(async (email: string) => ({
       id: email,
       email,
@@ -431,6 +434,40 @@ describe("e2a MCP server", () => {
       name: "Cloud Bot",
       webhook_url: "https://example.com/hook",
     });
+  });
+
+  it("create_agent forwards email for a custom-domain inbox", async () => {
+    await client.callTool({
+      name: "create_agent",
+      arguments: { email: "support@yourdomain.com", name: "Support" },
+    });
+    expect(stub.registerAgent).toHaveBeenCalledWith({
+      email: "support@yourdomain.com",
+      agent_mode: "local",
+      name: "Support",
+    });
+  });
+
+  it("create_agent rejects when neither slug nor email is given", async () => {
+    const res = await client.callTool({
+      name: "create_agent",
+      arguments: { name: "Nameless" },
+    });
+    const content = res.content as Array<{ text: string }>;
+    expect(res.isError).toBe(true);
+    expect(content[0]?.text).toMatch(/one of `slug` or `email` is required/);
+    expect(stub.registerAgent).not.toHaveBeenCalled();
+  });
+
+  it("create_agent rejects when both slug and email are given", async () => {
+    const res = await client.callTool({
+      name: "create_agent",
+      arguments: { slug: "support", email: "support@yourdomain.com" },
+    });
+    const content = res.content as Array<{ text: string }>;
+    expect(res.isError).toBe(true);
+    expect(content[0]?.text).toMatch(/exactly one of `slug`.*or `email`.*not both/);
+    expect(stub.registerAgent).not.toHaveBeenCalled();
   });
 
   it("update_agent forwards body fields and uses env email by default", async () => {


### PR DESCRIPTION
## Problem

The MCP `create_agent` tool only exposed `slug`, which the backend forces onto the shared domain (`agents.e2a.dev`, `internal/agent/api.go:851-862`). So through MCP you could `register_domain` → `verify_domain` a custom domain, but then had **no MCP path to create an inbox on it** — the tool dead-ends on its own happy path. Binding `support@agentdrive.run` (a verified custom domain) required dropping to the raw REST API with a CLI key.

This is a pure MCP-layer divergence: the REST contract `RegisterAgentRequest` and the TS SDK's `client.registerAgent` **already accept `email`** for custom-domain agents (`sdks/typescript/src/v1/generated/types.ts`, `client.ts:134-143`). Only the MCP tool's zod schema had drifted by omitting it. **No API or SDK change is needed.**

## Change

- Add optional `email` alongside `slug`; make `slug` optional. `email` = a full address on a custom domain already registered + verified for the account.
- Enforce **exactly-one-of `slug`/`email`** in the handler with a directive error. This is superset-safe: every call it lets through behaves identically on the API; it only rejects the ambiguous both/neither case earlier, with a clearer message than the API's bare `400 "email is required"` / silent slug-precedence.
- Retitle/redescribe the tool — it no longer advertises itself as shared-domain-only, which is the framing that hid the capability.

## Tests

`mcp/tests/tools.test.ts`: custom-domain `email` forwarding, plus both-given and neither-given rejection. Full suite: **122 passed**. `tsc` build clean.

## Not included (tracked separately)

This fixes the capability gap. Broader items surfaced in the same review — the "via e2a" sending model, MCP-vs-REST credential split, `verify_domain` flagging SPF that custom domains don't need, and a contract test asserting MCP request bodies validate against the API schema (the durable anti-drift guard) — are left for follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)