### PR TITLE
feat(api): finish Slice 1 — /v1 cutover (gaps + removal) [stacked on #208]

### DIFF
--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -320,6 +320,8 @@ func main() {
 		Idempotency:         idempotencyStore,
 		DeliverOutbound:     api.DeliverOutbound,
 		SendTest:            api.SendTestCore,
+		ApprovePending:      api.ApprovePendingCore,
+		RejectPending:       api.RejectPendingCore,
 		EnforceMessageSend:  enforcer.CheckMessageSend,
 		GetInboundMessage:   store.GetInboundMessage,
 		GetLimits:           enforcer.Get,

--- a/docs/design/v1-cutover-plan.md
+++ b/docs/design/v1-cutover-plan.md
@@ -1,0 +1,80 @@
+# Slice 1 — `/v1` cutover plan (finish Slice 1)
+
+| | |
+|---|---|
+| **Status** | Planned |
+| **Depends on** | PR #208 (the additive `/v1` surface) |
+| **Branch** | `feat/api-v1-cutover` (stacked on `feat/api-v1-slice1-contract`) |
+| **Breaking** | YES — removes legacy `/api/v1`, breaks the internal AgentDrive consumer |
+
+PR #208 added the `/v1` surface **alongside** legacy `/api/v1` (strangler). This
+plan finishes Slice 1 by flipping `/v1` to the live path and deleting legacy.
+Scoping the removal surfaced that #208's additive surface is **~90% complete** —
+three legacy bearer capabilities have no `/v1` equivalent yet and must be ported
+**before** anything is removed.
+
+## Phase A — close the `/v1` functional gaps (must land before any removal)
+
+### A1. HITL approve / reject (the held-draft decision) — **highest priority**
+Without this, a `/v1` HITL agent cannot release a `pending_approval` draft.
+- Extract `ApprovePendingCore(ctx, userID, messageID, expectedAgentID, edits) (*identity.Message, *OutboundError)` from `handleApprovePendingMessage` (hitl_api.go): load preview → 404; `expectedAgentID` mismatch → 404; not-pending → 409; load agent + domain-verify → 403; `store.ApproveAndSend(...)` with the existing send callback (`buildSendRequestFromMessage` + `attachReferencesChain` + self-send loopback / `sender.Send`); usage + `publishApproved`. Map `ValidationError`→400.
+- Extract `RejectPendingCore(ctx, userID, messageID, expectedAgentID, reason) (*identity.Message, *OutboundError)` from `handleRejectPendingMessage`.
+- Rewire both legacy handlers through the cores (idempotency guard stays on the legacy approve).
+- Add `POST /v1/agents/{address}/messages/{id}/approve` and `.../reject` (Slice 1 keeps the **separate** verbs; the `approval` sub-resource collapse is Slice 2). Approve runs under `runIdempotent` (it triggers an SES send). Body = the reviewer-override `approveRequest` shape.
+- **Verify:** `go test ./internal/agent/` (hitl_api_test, hitl_approval_api_test) green + new httpapi tests (approve→sent, not-pending→409, non-owned→404, reject).
+
+### A2. WebSocket transport — `GET /v1/agents/{address}/ws`
+Legacy `api.RegisterWSRoute` registers `/api/v1/agents/{email}/ws` on the mux.
+chi can host the same `ws.Handler.Handle` at `/v1/...`. Register it on the chi
+root in `httpapi.New` (or keep `RegisterWSRoute` and also mount `/v1/.../ws`).
+Token auth via `?token=` is unchanged. **Verify:** the existing ws e2e + a
+connect check over `/v1`.
+
+### A3. Magic-link approval (browser HTML, prefetch-safe)
+Lower priority (operator/browser flow, `noMcp`). Either keep the legacy
+`/approve`/`/reject` HTML handlers on the retained console surface, or port to
+`GET /v1/approvals/{token}` (HTML, **no side effect**) + `POST /v1/approvals/{token}`
+per design decision 5. Recommended: defer the *redesigned* `/approvals/{token}`
+shape to Slice 2; for Slice 1 keep the legacy magic-link handlers on the
+retained (non-`/api/v1`) surface so nothing breaks.
+
+## Phase B — parity hardening on `/v1`
+- **Rate limiting**: apply `pollLimit` (per-user reads), `sendLimit` (per-agent
+  outbound), `regLimit` (per-IP agent create) — inject the `*ratelimit.Limiter`s;
+  on block return `429` with code `rate_limited` + `Retry-After` and the IETF
+  `RateLimit-Limit/Remaining/Reset` headers (header conventions §). These are
+  only live once `/v1` is the path, so they land here, just before the flip.
+
+## Phase C — consumer cutover (cross-repo, coordinated)
+- **AgentDrive** (`/Users/joshzhang/Desktop/agentdrive`) calls `/api/v1/...`. Move
+  its e2a client to `/v1/...` and the new shapes (cursor pagination
+  `{items,next_cursor}`, send/reply/forward responses). This is a **separate repo
+  + separate PR**, merged in lockstep with Phase D. **Needs explicit go-ahead.**
+- Self-host docs / CLI / SDK consumers: update base path.
+
+## Phase D — destructive removal (last)
+- Delete the legacy `/api/v1` **bearer** route registrations from
+  `agent.RegisterRoutes` and their handlers. **Keep**: `/api/oauth/*`,
+  `/api/auth/*`, `/api/dashboard/*`, `/api/keys*`, `/.well-known/*`,
+  `/api/health`, `/api/feedback`, `/api/internal/*`, and `/api/v1/users/me/
+  signing-secrets*` (console/session per §5).
+- **Tests**: the ~22 agent `*_test.go` files that POST to `/api/v1/...` (≈12k
+  lines total) test the *legacy HTTP layer*, now redundant with the httpapi
+  tests + the preserved store/core tests. Delete the HTTP-handler tests as each
+  handler is removed; **keep** store/core tests (internal/identity, the
+  extracted-core tests). Do this resource-by-resource, building green after each.
+- Drop the strangler `Legacy` fallback for bearer routes; chi serves `/v1` +
+  the retained console/oauth surface.
+
+## Phase E — spec / SDK / CI / host
+- **Spec source of truth** flips to the Huma-generated `/v1/openapi.yaml`;
+  retire the legacy `swag` annotations for the bearer surface.
+- **SDK regen** (TS + Python) from the new spec; commit the regenerated output.
+- **Contract-drift CI gate** (§6): emit spec fresh in CI, SDK regen-diff, MCP
+  request-validation + coverage + tool↔operationId map.
+- **Host/config cutover** (§9a): `E2A_PUBLIC_URL`/`MCP_ALLOWED_HOSTS`/
+  `MCP_PUBLIC_URL` → `api.e2a.dev`; Caddy path-routes `/v1`, `/mcp`.
+
+## Sequencing
+A (gaps) → B (rate-limit) → C+D in lockstep (AgentDrive + removal) → E (spec/SDK/
+CI/host). A and B are non-breaking and can land first. C+D are the breaking flip.

--- a/internal/agent/hitl_api.go
+++ b/internal/agent/hitl_api.go
@@ -9,9 +9,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/gorilla/mux"
 	"github.com/Mnexa-AI/e2a/internal/identity"
 	"github.com/Mnexa-AI/e2a/internal/outbound"
+	"github.com/gorilla/mux"
 )
 
 // verifyURLAgentEmail enforces the agent-scoped path's URL invariant.
@@ -315,99 +315,53 @@ func (req approveRequest) toEdit() (identity.PendingApprovalEdit, error) {
 // @Failure      422 {string} string "Idempotency-Key reused with a different request body"
 // @Param        Idempotency-Key header string false "Caller-generated unique key (recommend UUIDv4). Approve fires a real outbound send (SES); on retry with the same key + same body the server replays the original response instead of double-sending. A different body returns 422."
 // @Router       /api/v1/agents/{email}/messages/{id}/approve [post]
-func (a *API) handleApprovePendingMessage(w http.ResponseWriter, r *http.Request) {
-	user, err := a.authenticateUser(r)
+// ApproveOverrides are the optional reviewer edits applied on approve
+// (exported alias of the internal body type so the v1 httpapi layer can build
+// them).
+type ApproveOverrides = approveRequest
+
+// ApprovePendingCore is the HTTP-free core of the HITL approve→send: it
+// verifies the held message (ownership-scoped + pending + optional
+// expected-agent-email match + domain-verified), then runs ApproveAndSend
+// with the shared send callback (self-send loopback / SES), records usage,
+// and publishes the approved event. Both the legacy handler and the v1 layer
+// call it. expectedAgentEmail (when non-empty) must equal the message's
+// agent's email — mirrors the legacy verifyURLAgentEmail URL guard.
+// On a nil-error return the SES send has committed; the idempotency key must
+// be Completed (cached), never Released.
+func (a *API) ApprovePendingCore(ctx context.Context, userID, messageID, expectedAgentEmail string, ovr ApproveOverrides) (*identity.Message, *OutboundError) {
+	edits, err := ovr.toEdit()
 	if err != nil {
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
-		return
+		return nil, &OutboundError{http.StatusBadRequest, "invalid_request", "invalid attachments"}
 	}
-
-	messageID := mux.Vars(r)["id"]
-
-	// Read the body up front so the idempotency guard can hash it. Approve
-	// is side-effectful (it triggers an SES send) so a retry without the
-	// guard would double-send; symmetric with handleSendEmail /
-	// handleReplyToMessage.
-	bodyBytes, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxRequestBytesSmall))
+	preview, err := a.store.GetOutboundMessageForUser(ctx, messageID, userID)
 	if err != nil {
-		http.Error(w, "invalid request body", http.StatusBadRequest)
-		return
-	}
-
-	replayed, captureW, finalize := a.idempotencyGuard(w, r, user.ID, bodyBytes)
-	if replayed {
-		return
-	}
-	defer finalize()
-	w = captureW
-
-	var req approveRequest
-	// Empty body is allowed (approve-as-is). Only error if body is present
-	// but malformed. We deliberately do NOT gate on r.ContentLength > 0
-	// because Transfer-Encoding: chunked yields ContentLength == -1; that
-	// would silently drop the reviewer's overrides (subject/body/to/cc/bcc/
-	// attachment edits) and send the stored draft as-is.
-	if len(bodyBytes) > 0 {
-		if err := json.Unmarshal(bodyBytes, &req); err != nil {
-			http.Error(w, "invalid request body", http.StatusBadRequest)
-			return
-		}
-	}
-	edits, err := req.toEdit()
-	if err != nil {
-		http.Error(w, "invalid attachments", http.StatusBadRequest)
-		return
-	}
-
-	// Pre-flight load: verify ownership + pending status + URL agent match
-	// + domain verification. The URL agent-match guard uses the same
-	// verifyURLAgentEmail helper as get/reject so any future change to
-	// that contract (telemetry, logging, status code) ripples through
-	// all three handlers in lockstep.
-	preview, err := a.store.GetOutboundMessageForUser(r.Context(), messageID, user.ID)
-	if err != nil {
-		http.Error(w, "message not found", http.StatusNotFound)
-		return
+		return nil, &OutboundError{http.StatusNotFound, "not_found", "message not found"}
 	}
 	if preview.Status != identity.MessageStatusPendingApproval {
-		http.Error(w, "message is not pending approval", http.StatusConflict)
-		return
+		return nil, &OutboundError{http.StatusConflict, "message_not_pending", "message is not pending approval"}
 	}
-	if !a.verifyURLAgentEmail(r.Context(), w, r, preview.AgentID) {
-		return
-	}
-
-	// Approve also needs the agent's DomainVerified flag. verifyURLAgentEmail
-	// has already loaded the agent into the store cache in the typical path,
-	// but the helper doesn't surface the row — load it explicitly here.
-	// (Splitting "ownership check" from "send-readiness check" keeps each
-	// handler's preconditions explicit even though it costs a second
-	// GetAgentByID under the hood.)
-	agent, err := a.store.GetAgentByID(r.Context(), preview.AgentID)
+	agent, err := a.store.GetAgentByID(ctx, preview.AgentID)
 	if err != nil {
 		log.Printf("[api] approve: get agent %s: %v", preview.AgentID, err)
-		http.Error(w, "agent lookup failed", http.StatusInternalServerError)
-		return
+		return nil, &OutboundError{http.StatusInternalServerError, "internal_error", "agent lookup failed"}
+	}
+	if expectedAgentEmail != "" && agent.Email != expectedAgentEmail {
+		return nil, &OutboundError{http.StatusNotFound, "not_found", "message not found"}
 	}
 	if !agent.DomainVerified {
-		http.Error(w, "agent domain must be verified before sending", http.StatusForbidden)
-		return
+		return nil, &OutboundError{http.StatusForbidden, "domain_not_verified", "agent domain must be verified before sending"}
 	}
 
-	sent, err := a.store.ApproveAndSend(r.Context(), messageID, user.ID, edits,
+	sent, err := a.store.ApproveAndSend(ctx, messageID, userID, edits,
 		func(locked *identity.Message) (identity.SendResult, error) {
 			sendReq, err := buildSendRequestFromMessage(locked)
 			if err != nil {
 				return identity.SendResult{}, err
 			}
-			attachReferencesChain(r.Context(), a.store, agent.ID, &sendReq)
-			// Self-sends bypass the SMTP relay — outbound.Sender would
-			// strip the agent's own address from the recipient list and
-			// error "no valid recipients". Loopback writes the inbound
-			// row directly and reports method=loopback on the now-sent
-			// outbound row, matching the non-HITL self-send shape.
+			attachReferencesChain(ctx, a.store, agent.ID, &sendReq)
 			if isSelfSend(sendReq, agent.EmailAddress()) {
-				return a.selfSendApprovalDelivery(r.Context(), agent, sendReq)
+				return a.selfSendApprovalDelivery(ctx, agent, sendReq)
 			}
 			result, err := a.sender.Send(agent, sendReq)
 			if err != nil {
@@ -424,48 +378,72 @@ func (a *API) handleApprovePendingMessage(w http.ResponseWriter, r *http.Request
 	if err != nil {
 		switch {
 		case errors.Is(err, identity.ErrMessageNotFound):
-			http.Error(w, "message not found", http.StatusNotFound)
+			return nil, &OutboundError{http.StatusNotFound, "not_found", "message not found"}
 		case errors.Is(err, identity.ErrNotPendingApproval):
-			http.Error(w, "message is not pending approval", http.StatusConflict)
+			return nil, &OutboundError{http.StatusConflict, "message_not_pending", "message is not pending approval"}
 		default:
 			var ve *outbound.ValidationError
 			if errors.As(err, &ve) {
-				http.Error(w, ve.Error(), http.StatusBadRequest)
-				return
+				return nil, &OutboundError{http.StatusBadRequest, "invalid_request", ve.Error()}
 			}
 			log.Printf("[api] approve-send failed: agent=%s msg=%s err=%v", agent.ID, messageID, err)
-			http.Error(w, "send failed", http.StatusInternalServerError)
+			return nil, &OutboundError{http.StatusInternalServerError, "internal_error", "send failed"}
 		}
-		return
 	}
-	// SES has accepted the send and the outbound row has transitioned
-	// to 'sent' with body scrubbed. Past this point any handler-side
-	// failure (usage recording, log write, response flush) must NOT
-	// release the idempotency key — a retry would either re-fire SES
-	// or short-circuit via send_attempts and return a 200 with a
-	// different body than the first call's 5xx. Mirrors the
-	// markSideEffectCommitted call at internal/agent/api.go:1413,1440
-	// for send and 1713,1737 for reply.
-	markSideEffectCommitted(w)
 
-	// Record usage only after the message actually leaves the gateway.
-	if _, err := a.usage.RecordAndCheck(r.Context(), user.ID, agent.ID, agent.Domain, "outbound"); err != nil {
+	if _, err := a.usage.RecordAndCheck(ctx, userID, agent.ID, agent.Domain, "outbound"); err != nil {
 		log.Printf("[api] usage recording error: %v", err)
 	}
-
 	slug, _, _ := strings.Cut(agent.EmailAddress(), "@")
 	log.Printf("[mail:%s] dir=outbound type=%s status=sent from=%s to=%v slug=%s subject=%q edited=%v approved=user:%s",
-		sent.ID, sent.Type, agent.EmailAddress(), sent.ToRecipients, slug, sent.Subject, sent.Edited, user.ID)
+		sent.ID, sent.Type, agent.EmailAddress(), sent.ToRecipients, slug, sent.Subject, sent.Edited, userID)
+	a.publishApproved(ctx, a.buildApprovedEvent(agent, sent, userID), sent)
+	return sent, nil
+}
 
-	a.publishApproved(r.Context(), a.buildApprovedEvent(agent, sent, user.ID), sent)
+func (a *API) handleApprovePendingMessage(w http.ResponseWriter, r *http.Request) {
+	user, err := a.authenticateUser(r)
+	if err != nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+	messageID := mux.Vars(r)["id"]
 
+	// Read the body up front so the idempotency guard can hash it. Approve
+	// is side-effectful (triggers an SES send) so a retry without the guard
+	// would double-send.
+	bodyBytes, err := io.ReadAll(http.MaxBytesReader(w, r.Body, maxRequestBytesSmall))
+	if err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	replayed, captureW, finalize := a.idempotencyGuard(w, r, user.ID, bodyBytes)
+	if replayed {
+		return
+	}
+	defer finalize()
+	w = captureW
+
+	var req approveRequest
+	if len(bodyBytes) > 0 {
+		if err := json.Unmarshal(bodyBytes, &req); err != nil {
+			http.Error(w, "invalid request body", http.StatusBadRequest)
+			return
+		}
+	}
+	sent, derr := a.ApprovePendingCore(r.Context(), user.ID, messageID, mux.Vars(r)["email"], req)
+	if derr != nil {
+		http.Error(w, derr.Msg, derr.Status)
+		return
+	}
+	markSideEffectCommitted(w)
 	w.Header().Set("Content-Type", "application/json")
 	writeJSON(w, map[string]interface{}{
-		"status":     sent.Status,
-		"message_id": sent.ID,
+		"status":              sent.Status,
+		"message_id":          sent.ID,
 		"provider_message_id": sent.ProviderMessageID,
-		"method":     sent.Method,
-		"edited":     sent.Edited,
+		"method":              sent.Method,
+		"edited":              sent.Edited,
 	})
 }
 
@@ -573,46 +551,47 @@ func (a *API) handleRejectPendingMessage(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// Agent-scoped path: enforce that the {email} URL segment matches
-	// the message's owning agent. We load the message first (a check
-	// the legacy path skipped — RejectPending does its own ownership
-	// scoping in the WHERE clause) so the URL contract can be validated
-	// before the row transitions. Mismatch returns 404 to match the
-	// flat-path "not yours" semantics.
-	if urlEmail := mux.Vars(r)["email"]; urlEmail != "" {
-		preview, err := a.store.GetOutboundMessageForUser(r.Context(), messageID, user.ID)
-		if err != nil {
-			http.Error(w, "message not found", http.StatusNotFound)
-			return
-		}
-		if !a.verifyURLAgentEmail(r.Context(), w, r, preview.AgentID) {
-			return
-		}
-	}
-
-	rejected, err := a.store.RejectPending(r.Context(), messageID, user.ID, req.Reason)
-	if err != nil {
-		switch {
-		case errors.Is(err, identity.ErrMessageNotFound):
-			http.Error(w, "message not found", http.StatusNotFound)
-		case errors.Is(err, identity.ErrNotPendingApproval):
-			http.Error(w, "message is not pending approval", http.StatusConflict)
-		default:
-			log.Printf("[api] reject: %v", err)
-			http.Error(w, "failed to reject message", http.StatusInternalServerError)
-		}
+	rejected, derr := a.RejectPendingCore(r.Context(), user.ID, messageID, mux.Vars(r)["email"], req.Reason)
+	if derr != nil {
+		http.Error(w, derr.Msg, derr.Status)
 		return
 	}
-
-	log.Printf("[mail:%s] dir=outbound type=%s status=rejected agent=%s rejected_by=user:%s reason=%q",
-		rejected.ID, rejected.Type, rejected.AgentID, user.ID, req.Reason)
-
-	a.publishRejected(r.Context(), a.buildRejectedEvent(user.ID, rejected, req.Reason), rejected.ID)
-
 	w.Header().Set("Content-Type", "application/json")
 	writeJSON(w, map[string]interface{}{
 		"status":           rejected.Status,
 		"message_id":       rejected.ID,
 		"rejection_reason": rejected.RejectionReason,
 	})
+}
+
+// RejectPendingCore is the HTTP-free core of HITL reject: optional
+// expected-agent-email match (mirrors the legacy URL guard), then
+// RejectPending + publish. Shared by the legacy handler and the v1 layer.
+func (a *API) RejectPendingCore(ctx context.Context, userID, messageID, expectedAgentEmail, reason string) (*identity.Message, *OutboundError) {
+	if expectedAgentEmail != "" {
+		preview, err := a.store.GetOutboundMessageForUser(ctx, messageID, userID)
+		if err != nil {
+			return nil, &OutboundError{http.StatusNotFound, "not_found", "message not found"}
+		}
+		agent, err := a.store.GetAgentByID(ctx, preview.AgentID)
+		if err != nil || agent.Email != expectedAgentEmail {
+			return nil, &OutboundError{http.StatusNotFound, "not_found", "message not found"}
+		}
+	}
+	rejected, err := a.store.RejectPending(ctx, messageID, userID, reason)
+	if err != nil {
+		switch {
+		case errors.Is(err, identity.ErrMessageNotFound):
+			return nil, &OutboundError{http.StatusNotFound, "not_found", "message not found"}
+		case errors.Is(err, identity.ErrNotPendingApproval):
+			return nil, &OutboundError{http.StatusConflict, "message_not_pending", "message is not pending approval"}
+		default:
+			log.Printf("[api] reject: %v", err)
+			return nil, &OutboundError{http.StatusInternalServerError, "internal_error", "failed to reject message"}
+		}
+	}
+	log.Printf("[mail:%s] dir=outbound type=%s status=rejected agent=%s rejected_by=user:%s reason=%q",
+		rejected.ID, rejected.Type, rejected.AgentID, userID, reason)
+	a.publishRejected(ctx, a.buildRejectedEvent(userID, rejected, reason), rejected.ID)
+	return rejected, nil
 }

--- a/internal/httpapi/hitl.go
+++ b/internal/httpapi/hitl.go
@@ -1,0 +1,114 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Mnexa-AI/e2a/internal/agent"
+	"github.com/danielgtaylor/huma/v2"
+)
+
+// ApproveResultView is the approve→sent response (mirrors the legacy body).
+type ApproveResultView struct {
+	Status            string `json:"status"`
+	MessageID         string `json:"message_id"`
+	ProviderMessageID string `json:"provider_message_id,omitempty"`
+	Method            string `json:"method,omitempty"`
+	Edited            bool   `json:"edited"`
+}
+
+type approveInput struct {
+	Address        string `path:"address"`
+	ID             string `path:"id"`
+	RawBody        []byte
+	IdempotencyKey string `header:"Idempotency-Key"`
+	Body           agent.ApproveOverrides
+}
+
+type approveOutput struct {
+	Body ApproveResultView
+}
+
+// RejectResultView mirrors the legacy reject body.
+type RejectResultView struct {
+	Status          string `json:"status"`
+	MessageID       string `json:"message_id"`
+	RejectionReason string `json:"rejection_reason,omitempty"`
+}
+
+type rejectInput struct {
+	Address string `path:"address"`
+	ID      string `path:"id"`
+	Body    struct {
+		Reason string `json:"reason,omitempty"`
+	}
+}
+
+type rejectOutput struct {
+	Body RejectResultView
+}
+
+func (s *Server) registerHITL() {
+	huma.Register(s.API, huma.Operation{
+		OperationID: "approveMessage", Method: http.MethodPost, Path: "/v1/agents/{address}/messages/{id}/approve",
+		Summary: "Approve a held message", Tags: []string{"messages"},
+		Description: "Approve a pending_approval draft (with optional reviewer overrides) and send it. Honors Idempotency-Key (the approve triggers an SES send).",
+		Security:    []map[string][]string{{"bearer": {}}},
+	}, s.handleApprove)
+
+	huma.Register(s.API, huma.Operation{
+		OperationID: "rejectMessage", Method: http.MethodPost, Path: "/v1/agents/{address}/messages/{id}/reject",
+		Summary: "Reject a held message", Tags: []string{"messages"},
+		Description: "Reject a pending_approval draft so it is never sent.",
+		Security:    []map[string][]string{{"bearer": {}}},
+	}, s.handleReject)
+}
+
+func (s *Server) handleApprove(ctx context.Context, in *approveInput) (*approveOutput, error) {
+	ag, err := s.resolveOwnedAgent(ctx, in.Address)
+	if err != nil {
+		return nil, err
+	}
+	user, uerr := s.requireUser(ctx)
+	if uerr != nil {
+		return nil, uerr
+	}
+	if s.deps.ApprovePending == nil {
+		return nil, NewError(http.StatusInternalServerError, "internal_error", "approve unavailable")
+	}
+	_, view, err := runIdempotent(s, ctx, user.ID, in.IdempotencyKey, "/v1/approve/"+in.ID, in.RawBody, func() (int, ApproveResultView, error) {
+		sent, derr := s.deps.ApprovePending(ctx, user.ID, in.ID, ag.Email, in.Body)
+		if derr != nil {
+			return 0, ApproveResultView{}, NewError(derr.Status, derr.Code, derr.Msg)
+		}
+		return http.StatusOK, ApproveResultView{
+			Status: sent.Status, MessageID: sent.ID, ProviderMessageID: sent.ProviderMessageID,
+			Method: sent.Method, Edited: sent.Edited,
+		}, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &approveOutput{Body: view}, nil
+}
+
+func (s *Server) handleReject(ctx context.Context, in *rejectInput) (*rejectOutput, error) {
+	ag, err := s.resolveOwnedAgent(ctx, in.Address)
+	if err != nil {
+		return nil, err
+	}
+	user, uerr := s.requireUser(ctx)
+	if uerr != nil {
+		return nil, uerr
+	}
+	if s.deps.RejectPending == nil {
+		return nil, NewError(http.StatusInternalServerError, "internal_error", "reject unavailable")
+	}
+	rejected, derr := s.deps.RejectPending(ctx, user.ID, in.ID, ag.Email, in.Body.Reason)
+	if derr != nil {
+		return nil, NewError(derr.Status, derr.Code, derr.Msg)
+	}
+	return &rejectOutput{Body: RejectResultView{
+		Status: rejected.Status, MessageID: rejected.ID, RejectionReason: rejected.RejectionReason,
+	}}, nil
+}

--- a/internal/httpapi/hitl_test.go
+++ b/internal/httpapi/hitl_test.go
@@ -1,0 +1,64 @@
+package httpapi
+
+import "testing"
+
+func TestApproveSent(t *testing.T) {
+	srv := testServer(t)
+	code, body := postJSON(t, srv.URL+"/v1/agents/support%40acme.com/messages/msg_pending/approve", "good", map[string]any{})
+	if code != 200 || body["status"] != "sent" || body["message_id"] != "msg_pending" {
+		t.Fatalf("want 200 sent, got %d %v", code, body)
+	}
+	if body["provider_message_id"] != "<prov@ses>" {
+		t.Fatalf("expected provider_message_id, got %v", body)
+	}
+}
+
+func TestApproveWithOverrides(t *testing.T) {
+	srv := testServer(t)
+	// reviewer overrides ride in the body
+	code, _ := postJSON(t, srv.URL+"/v1/agents/support%40acme.com/messages/msg_pending/approve", "good",
+		map[string]any{"subject": "edited", "to": []string{"a@x.com"}})
+	if code != 200 {
+		t.Fatalf("want 200, got %d", code)
+	}
+}
+
+func TestApproveNotPending(t *testing.T) {
+	srv := testServer(t)
+	code, body := postJSON(t, srv.URL+"/v1/agents/support%40acme.com/messages/msg_notpending/approve", "good", map[string]any{})
+	if code != 409 || errCode(body) != "message_not_pending" {
+		t.Fatalf("want 409 message_not_pending, got %d %v", code, body)
+	}
+}
+
+func TestApproveNotFound(t *testing.T) {
+	srv := testServer(t)
+	code, _ := postJSON(t, srv.URL+"/v1/agents/support%40acme.com/messages/msg_missing/approve", "good", map[string]any{})
+	if code != 404 {
+		t.Fatalf("want 404, got %d", code)
+	}
+}
+
+func TestApproveNotOwnedAgent(t *testing.T) {
+	srv := testServer(t)
+	code, _ := postJSON(t, srv.URL+"/v1/agents/other%40acme.com/messages/msg_pending/approve", "good", map[string]any{})
+	if code != 403 {
+		t.Fatalf("want 403, got %d", code)
+	}
+}
+
+func TestReject(t *testing.T) {
+	srv := testServer(t)
+	code, body := postJSON(t, srv.URL+"/v1/agents/support%40acme.com/messages/msg_pending/reject", "good", map[string]any{"reason": "not now"})
+	if code != 200 || body["status"] != "rejected" || body["rejection_reason"] != "not now" {
+		t.Fatalf("want 200 rejected, got %d %v", code, body)
+	}
+}
+
+func TestRejectNotFound(t *testing.T) {
+	srv := testServer(t)
+	code, _ := postJSON(t, srv.URL+"/v1/agents/support%40acme.com/messages/msg_missing/reject", "good", map[string]any{})
+	if code != 404 {
+		t.Fatalf("want 404, got %d", code)
+	}
+}

--- a/internal/httpapi/httpapi.go
+++ b/internal/httpapi/httpapi.go
@@ -103,8 +103,11 @@ type Deps struct {
 	Idempotency IdemStore
 
 	// outbound (the shared live delivery path extracted from agent.API)
-	DeliverOutbound    func(ctx context.Context, user *identity.User, ag *identity.AgentIdentity, req outbound.SendRequest, msgType, replyToEmailMessageID string) (*agent.OutboundResult, *agent.OutboundError)
-	SendTest           func(ctx context.Context, ag *identity.AgentIdentity) (*agent.OutboundResult, *agent.OutboundError)
+	DeliverOutbound func(ctx context.Context, user *identity.User, ag *identity.AgentIdentity, req outbound.SendRequest, msgType, replyToEmailMessageID string) (*agent.OutboundResult, *agent.OutboundError)
+	SendTest        func(ctx context.Context, ag *identity.AgentIdentity) (*agent.OutboundResult, *agent.OutboundError)
+	// HITL approve/reject (the held-draft decision)
+	ApprovePending     func(ctx context.Context, userID, messageID, expectedAgentEmail string, ovr agent.ApproveOverrides) (*identity.Message, *agent.OutboundError)
+	RejectPending      func(ctx context.Context, userID, messageID, expectedAgentEmail, reason string) (*identity.Message, *agent.OutboundError)
 	EnforceMessageSend func(ctx context.Context, userID string) error
 	// GetInboundMessage loads an inbound message for reply/forward.
 	GetInboundMessage func(ctx context.Context, messageID string) (*identity.Message, error)
@@ -237,6 +240,7 @@ func (s *Server) registerOperations() {
 	s.registerEvents()
 	s.registerAccount()
 	s.registerOutbound()
+	s.registerHITL()
 }
 
 // reqCtxKey carries the raw *http.Request through to Huma handlers so they

--- a/internal/httpapi/httpapi.go
+++ b/internal/httpapi/httpapi.go
@@ -152,6 +152,11 @@ type Deps struct {
 	SharedDomain string
 	PublicURL    string
 
+	// WSHandle serves the WebSocket upgrade for an agent address (the real-
+	// time inbound transport). Injected so httpapi need not depend on the ws
+	// package; the real one is ws.Handler.ServeWithEmail.
+	WSHandle func(w http.ResponseWriter, r *http.Request, address string)
+
 	// Legacy is the existing gorilla/mux handler. The chi root falls back
 	// to it for every route not yet ported onto Huma (the strangler), so
 	// the service stays fully functional through the multi-sub-slice port.
@@ -206,6 +211,14 @@ func New(deps Deps) *Server {
 
 	s := &Server{Router: root, API: api, deps: deps}
 	s.registerOperations()
+
+	// WebSocket transport — registered directly on chi (not Huma; it's a raw
+	// upgrade, not a JSON operation). First-class /v1 inbound transport.
+	if deps.WSHandle != nil {
+		root.Get("/v1/agents/{address}/ws", func(w http.ResponseWriter, r *http.Request) {
+			deps.WSHandle(w, r, chi.URLParam(r, "address"))
+		})
+	}
 
 	if deps.Legacy != nil {
 		root.NotFound(deps.Legacy.ServeHTTP)

--- a/internal/httpapi/operations_test.go
+++ b/internal/httpapi/operations_test.go
@@ -280,6 +280,22 @@ func testServer(t *testing.T) *httptest.Server {
 		SendTest: func(ctx context.Context, ag *identity.AgentIdentity) (*agent.OutboundResult, *agent.OutboundError) {
 			return &agent.OutboundResult{MessageID: "msg_test_1", Method: "smtp"}, nil
 		},
+		ApprovePending: func(ctx context.Context, userID, messageID, expectedAgentEmail string, ovr agent.ApproveOverrides) (*identity.Message, *agent.OutboundError) {
+			switch messageID {
+			case "msg_pending":
+				return &identity.Message{ID: "msg_pending", Status: "sent", ProviderMessageID: "<prov@ses>", Method: "smtp"}, nil
+			case "msg_notpending":
+				return nil, &agent.OutboundError{Status: http.StatusConflict, Code: "message_not_pending", Msg: "message is not pending approval"}
+			default:
+				return nil, &agent.OutboundError{Status: http.StatusNotFound, Code: "not_found", Msg: "message not found"}
+			}
+		},
+		RejectPending: func(ctx context.Context, userID, messageID, expectedAgentEmail, reason string) (*identity.Message, *agent.OutboundError) {
+			if messageID == "msg_pending" {
+				return &identity.Message{ID: "msg_pending", Status: "rejected", RejectionReason: reason}, nil
+			}
+			return nil, &agent.OutboundError{Status: http.StatusNotFound, Code: "not_found", Msg: "message not found"}
+		},
 		GetInboundMessage: func(ctx context.Context, messageID string) (*identity.Message, error) {
 			if messageID == "msg_in1" {
 				return &identity.Message{

--- a/internal/httpapi/spec_test.go
+++ b/internal/httpapi/spec_test.go
@@ -52,6 +52,8 @@ func TestSpecGeneratedFromHandlers(t *testing.T) {
 		"operationId: sendMessage",
 		"operationId: replyToMessage",
 		"operationId: forwardMessage",
+		"operationId: approveMessage",
+		"operationId: rejectMessage",
 		"operationId: testAgent",
 		"/v1/send",
 		"/v1/users/me/limits",

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/gorilla/mux"
 	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/gorilla/mux"
 	"nhooyr.io/websocket"
 )
 
@@ -31,7 +31,20 @@ func NewHandler(hub *Hub, store HandlerStore) *Handler {
 
 // Handle is the HTTP handler for WebSocket upgrade requests.
 // Route: GET /api/v1/agents/{email}/ws?token={api_key}
+// Handle reads the agent email from the gorilla/mux route var (legacy
+// /api/v1/agents/{email}/ws).
 func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) {
+	h.serve(w, r, mux.Vars(r)["email"])
+}
+
+// ServeWithEmail handles the WebSocket upgrade for an explicitly-provided
+// agent email, so non-mux routers (chi at /v1/agents/{address}/ws) can host
+// the same transport.
+func (h *Handler) ServeWithEmail(w http.ResponseWriter, r *http.Request, rawEmail string) {
+	h.serve(w, r, rawEmail)
+}
+
+func (h *Handler) serve(w http.ResponseWriter, r *http.Request, rawEmail string) {
 	// Authenticate via query param (WebSocket clients can't set headers during upgrade)
 	token := r.URL.Query().Get("token")
 	if token == "" {
@@ -48,7 +61,7 @@ func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) {
 	// Resolve agent and verify ownership. Canonicalize the email so that
 	// `ws://.../UPPER@x.dev/ws?token=…` resolves identically to the
 	// lower-case form — matches the REST API's `normalizeEmail` policy.
-	email := identity.NormalizeEmail(mux.Vars(r)["email"])
+	email := identity.NormalizeEmail(rawEmail)
 	agent, err := h.store.GetAgentByEmail(r.Context(), email)
 	if err != nil {
 		http.Error(w, "agent not found", http.StatusNotFound)


### PR DESCRIPTION
Finishes Slice 1 by flipping `/v1` live and removing legacy `/api/v1`. **Stacked on #208** (base = its branch). Plan: `docs/design/v1-cutover-plan.md`.

**Scoping discovery:** #208's additive surface is ~90% complete — three legacy bearer capabilities have **no `/v1` equivalent yet** and must be ported before removal:
1. **HITL approve/reject** — `POST /v1/agents/{address}/messages/{id}/approve|reject` (how a held draft gets sent). Capability gap.
2. **WebSocket** `GET /v1/agents/{address}/ws` — real-time inbound transport.
3. **Magic-link** approval browser flow.

**Sequencing:** A (close gaps, non-breaking) → B (rate-limit parity) → **C+D breaking flip**: update the cross-repo **AgentDrive** consumer to `/v1` + delete legacy `/api/v1` bearer routes + remove the now-redundant legacy HTTP-handler tests (keep store/core tests) → E (spec source-of-truth + SDK regen + contract-drift CI gate + host/config cutover).

C+D are breaking and cross-repo (AgentDrive in lockstep) — they need explicit go-ahead before execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)