### PR TITLE
feat(api): Slice 2 — resource cleanup (outbound under agent, /account, e2e→/v1)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1466,6 +1466,83 @@ info:
   version: 1.0.0
 openapi: 3.1.0
 paths:
+  /v1/account:
+    delete:
+      description: Permanently deletes the account and cascades all owned data. Requires ?confirm=DELETE.
+      operationId: deleteAccount
+      parameters:
+        - description: Must be DELETE — this is irreversible.
+          explode: false
+          in: query
+          name: confirm
+          schema:
+            description: Must be DELETE — this is irreversible.
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeleteUserDataResult"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+      security:
+        - bearer: []
+      summary: Delete your account + all data (irreversible)
+      tags:
+        - account
+    get:
+      description: The authenticated account's plan caps and current usage. (Deployment discovery — shared domain, slug registration — is the separate public GET /v1/info.)
+      operationId: getAccount
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LimitsView"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+      security:
+        - bearer: []
+      summary: "Get account: plan limits + usage"
+      tags:
+        - account
+  /v1/account/export:
+    get:
+      description: A JSON dump of every record the authenticated account owns.
+      operationId: exportAccount
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserExport"
+          description: OK
+          headers:
+            Content-Disposition:
+              schema:
+                type: string
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+      security:
+        - bearer: []
+      summary: Export your data (GDPR right-of-access)
+      tags:
+        - account
   /v1/agents:
     get:
       description: List the agents owned by the authenticated account.
@@ -2409,84 +2486,6 @@ paths:
       summary: Deployment info
       tags:
         - meta
-  /v1/users/me:
-    delete:
-      description: Permanently deletes the account and cascades all owned data. Requires ?confirm=DELETE.
-      operationId: deleteAccount
-      parameters:
-        - description: Must be DELETE — this is irreversible.
-          explode: false
-          in: query
-          name: confirm
-          schema:
-            description: Must be DELETE — this is irreversible.
-            type: string
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/DeleteUserDataResult"
-          description: OK
-        default:
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorEnvelope"
-          description: Error
-      security:
-        - bearer: []
-      summary: Delete your account + all data (irreversible)
-      tags:
-        - account
-  /v1/users/me/export:
-    get:
-      description: A JSON dump of every record the authenticated account owns.
-      operationId: exportUserData
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/UserExport"
-          description: OK
-          headers:
-            Content-Disposition:
-              schema:
-                type: string
-        default:
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorEnvelope"
-          description: Error
-      security:
-        - bearer: []
-      summary: Export your data (GDPR right-of-access)
-      tags:
-        - account
-  /v1/users/me/limits:
-    get:
-      description: The authenticated account's plan caps and current usage.
-      operationId: getMyLimits
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/LimitsView"
-          description: OK
-        default:
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorEnvelope"
-          description: Error
-      security:
-        - bearer: []
-      summary: Get plan limits + usage
-      tags:
-        - account
   /v1/webhooks:
     get:
       operationId: listWebhooks

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1809,6 +1809,48 @@ paths:
       summary: List messages
       tags:
         - messages
+    post:
+      description: Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_approval when the agent has HITL enabled. Honors Idempotency-Key.
+      operationId: sendMessage
+      parameters:
+        - in: path
+          name: address
+          required: true
+          schema:
+            type: string
+        - in: header
+          name: Idempotency-Key
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SendEmailRequest"
+          application/octet-stream:
+            schema:
+              contentMediaType: application/octet-stream
+              format: binary
+              type: string
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SendResultView"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+      security:
+        - bearer: []
+      summary: Send a new email
+      tags:
+        - messages
   /v1/agents/{address}/messages/{id}:
     get:
       description: Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. Includes the raw message and inbound auth headers.
@@ -2367,44 +2409,6 @@ paths:
       summary: Deployment info
       tags:
         - meta
-  /v1/send:
-    post:
-      description: Send a new email from an agent you own. 202 + pending_approval when the agent has HITL enabled. Honors Idempotency-Key.
-      operationId: sendMessage
-      parameters:
-        - in: header
-          name: Idempotency-Key
-          schema:
-            type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/SendEmailRequest"
-          application/octet-stream:
-            schema:
-              contentMediaType: application/octet-stream
-              format: binary
-              type: string
-        required: true
-      responses:
-        "200":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SendResultView"
-          description: OK
-        default:
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorEnvelope"
-          description: Error
-      security:
-        - bearer: []
-      summary: Send a new email
-      tags:
-        - messages
   /v1/users/me:
     delete:
       description: Permanently deletes the account and cascades all owned data. Requires ?confirm=DELETE.

--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -113,7 +113,7 @@ relative to that base):
 | **domains** | `GET/POST /domains` · `GET/PATCH/DELETE /domains/{domain}` (DELETE also **deprovisions the SES sending identity** — decision 4) · `POST /domains/{domain}/verify` (ownership + nudges a sending-identity re-check). The domain resource carries two independent statuses: `verified` (inbound/ownership, DNS TXT) and `sending_status ∈ {none,pending,verified,failed}` + `sending_error?` + `dns_records` + `last_checked_at?` (async SES sending identity — see §4 decision 4). `GET /domains/{domain}` is the poll target; no separate status endpoint. Inbound `verified` is **re-checkable** — a periodic ownership re-probe (and `POST /verify`) can flip it back to `false` if the DNS TXT/MX later disappears; it is not sticky-once-true. |
 | **webhooks** | `GET/POST /webhooks` · `GET/PATCH/DELETE /webhooks/{id}` · `…/deliveries` (read-only debug view) · `…/test` · `…/rotate-secret`. **Redelivery is event-scoped** (`POST /events/{id}/redeliver`), not a per-webhook endpoint — one canonical place (§3 principle 2). |
 | **events** (delivery log) | `GET /events` · `GET /events/{id}` · `POST /events/{id}/redeliver`. Canonical event vocabulary: `email.received` · `email.sent` · **`email.delivered`** · **`email.bounced`** · **`email.complained`** · `email.flagged` (inbound rejected/flagged by policy — decision 9/10) · `email.pending_approval` · `email.approved` · `email.approval_rejected` (renamed from `email.rejected` to avoid collision with inbound-flagged) · `domain.sending_verified` · `domain.sending_failed` · `domain.suppression_added` · `agent.credential_revoked`. (`deferred`/`failed` `delivery_status` have no push event — poll.) |
-| **account** | `GET /account` (replaces `/info` + `/users/me/limits`; **scope-filtered** — `scope=agent` sees only its bound agent + limits, §6a) · `GET /account/export` · `DELETE /account`. **API-key + signing-secret CRUD are console-only** (human session), not `/v1` endpoints (§5). |
+| **account** | `GET /account` (replaces `/users/me/limits` — the authenticated identity + plan + limits + usage; **scope-filtered** — `scope=agent` sees only its bound agent + limits, §6a) · `GET /account/export` · `DELETE /account`. **`GET /info` is NOT folded in** — it stays a **separate, public (unauthenticated)** deployment-discovery endpoint (shared domain, slug-registration-enabled, public URL) that clients read *pre-auth* to learn how to onboard; account data is authenticated and per-principal, deployment metadata is neither, so they can't share a route. **API-key + signing-secret CRUD are console-only** (human session), not `/v1` endpoints (§5). |
 
 ### Resource relationships
 
@@ -265,15 +265,26 @@ relative to that base):
      the identity's e2a-owned creation tag/timestamp predates the current
      reconcile cycle. Re-registering a deleted domain re-creates the identity
      cleanly and the reaper must not touch it.
-5. **One HITL transition, prefetch-safe.** Collapse the nested approve/reject
-   AND the top-level magic-link into a single `approval` sub-resource
-   (`POST …/messages/{id}/approval {decision}`). The human magic link is
-   `GET /approvals/{token}` rendering an **HTML confirmation page with NO
-   side effect**; its buttons `POST /approvals/{token} {decision}` into the
-   same transition. **Never a mutating GET** — email scanners/link-prefetchers
-   would auto-approve/reject. Short-TTL capability; single-use is enforced by the
-   state machine (message leaves `pending_approval`; second decision 409s), not by
-   the token itself.
+5. **HITL: two explicit transitions, prefetch-safe.** A held draft
+   (`status=pending_approval`) is resolved by a human reviewer via **two
+   explicit sub-resources** — `POST …/messages/{id}/approve` and
+   `POST …/messages/{id}/reject`. **(Revised from the earlier "single
+   `approval {decision}`" plan — same reasoning as decision 3: the decision is
+   the whole point of the call, and two explicit operations make
+   approve-vs-reject a route/tool choice, not a body field an LLM could set
+   wrong. The footgun is weaker here than for send/reply/forward because the
+   primary consumer is a *human* clicking a button, but explicit is still the
+   safer, already-shipped shape.)** Held drafts are listed via
+   `GET …/messages?status=pending_approval` and read via the message GET (a held
+   draft is just a message). **Human magic link:** `GET /approvals/{token}`
+   renders an **HTML confirmation page with NO side effect** (prefetch-safe);
+   its two buttons `POST` into the same two transitions. **Never a mutating
+   GET** — email scanners/link-prefetchers would auto-approve/reject. Short-TTL
+   capability; **single-use is enforced by the state machine** (the message
+   leaves `pending_approval` on the first decision; a second 409s), not by the
+   token. **Status: the nested `approve`/`reject` ship on `/v1` today; the
+   magic-link pages + the account-wide `pending` list remain on legacy `/api/v1`
+   pending a separate port (they are human-facing HTML / a list, not agent JSON).**
 6. **One error envelope** (audit current handlers and standardize):
    `{ "error": { "code": "MACHINE_BRANCHABLE", "message": "human text",
    "details": {…} } }`, with stable `code` values documented in the spec.
@@ -1110,8 +1121,9 @@ Applying 1 + 6: a runtime agent sees ~13 tools; the full self-host surface 31.
 | host + prefix `…/api/v1/*` | **move** | dedicated host `api.e2a.dev`, prefix `/v1` (base `https://api.e2a.dev/v1`) |
 | `GET/POST /approve`, `/reject`, `/pending` | **collapse** | `POST …/messages/{id}/approval` + magic-link GET alias |
 | `POST …/messages/{id}/approve|reject` | **collapse** | same `approval` sub-resource |
-| `GET /info`, `GET /users/me/limits` | **merge** | `GET /account` |
-| `/users/me/*` | **rename** | `/account/*` |
+| `GET /users/me/limits` | **rename** | `GET /account` (identity + plan + limits + usage) |
+| `GET /info` | **keep** | stays a separate **public** deployment-discovery endpoint — NOT folded into `/account` |
+| `/users/me/*` | **rename** | `/account/*` (`/account/export`, `DELETE /account`) |
 | `create_agent` (slug path + `agent_mode`; MCP omitted `email` pre-#206) | **change** | full-email `address` only (drop slug), no mode |
 | `POST /send` body | **extend** | add `from`, `reply_to` |
 | `agent_mode` column + CHECK | **drop** | no modes; inbound via poll / `ws` / `/webhooks` |

--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -278,7 +278,26 @@ relative to that base):
    `{ "error": { "code": "MACHINE_BRANCHABLE", "message": "human text",
    "details": {…} } }`, with stable `code` values documented in the spec.
 7. **One pagination scheme** — opaque cursor (`?cursor=…&limit=…`) returning
-   `{ items: [...], next_cursor: "…"|null }` across all list endpoints.
+   `{ items: [...], next_cursor: "…"|null }` across all paginated list endpoints.
+
+   **Why cursor, not offset/`page_size`.** The dominant collection here is an
+   **inbox** — high insert rate, agents scanning forward. Offset pagination
+   (`page`/`page_size`) is *unstable under concurrent writes*: a message arriving
+   mid-scan shifts every row, so the client silently skips or double-reads items;
+   it also degrades on deep pages (`OFFSET n` scans-and-discards). A cursor
+   anchored to `(created_at, id)` is stable across inserts and uses the index
+   at any depth. The trade — no jump-to-page and no cheap total count — is one
+   agents don't need (they stream "the next batch," they don't ask for "page 7").
+
+   **Naming.** `limit` (not `page_size`) because `page_size` is page-number
+   vocabulary that would mis-signal pages that don't exist under a cursor.
+   `items` (not a per-resource key like `messages`) so one generic paginator
+   walks **any** list. **Known inconsistency to resolve:** only the genuinely
+   cursor-paginated lists (messages, conversations, events) use `{items,
+   next_cursor}`; the small fixed lists (`listAgents`/`listDomains`/
+   `listWebhooks`) currently return named keys (`{agents}`/…) and aren't
+   paginated — so a generic `items` paginator works on the former, not the
+   latter. Either paginate those too (→ `items`) or accept the documented split.
 8. **Idempotency** — `Idempotency-Key` header (or body key) honored on all
    POSTs with side effects (send, create agent, webhook create, redeliver).
    Dedup key = `(principal, route, **request-body hash**)` — the body hash is

--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -1117,7 +1117,7 @@ Applying 1 + 6: a runtime agent sees ~13 tools; the full self-host surface 31.
 | `POST /send` | **move** | `POST /agents/{address}/messages` (new-thread case — nest under the agent) |
 | `POST /agents/{e}/messages/{id}/reply` | **keep (re-place)** | `POST /agents/{address}/messages/{id}/reply` — explicit reply op (target in path), not folded into the send body |
 | `POST /agents/{e}/messages/{id}/forward` | **keep (re-place)** | `POST /agents/{address}/messages/{id}/forward` — explicit forward op (target in path) |
-| `GET /messages/{id}` (flat) | **remove** | use `GET /agents/{address}/messages/{id}` |
+| `GET /messages/{id}` (flat) | **remove (deferred → Slice 4b)** | use `GET /agents/{address}/messages/{id}`. Held drafts store the body as `body_text`/`body_html` columns (mutable, reviewable, scrubbed on terminal transition), while sent/inbound carry `raw_message` — so the unified read must expose BOTH representations. That message-read shape is decision 9 / Slice 4b territory (the parsed view); removing the flat path before then would design the shape twice. Until 4b, the flat `/api/v1/messages/{id}` stays as strangler residue. |
 | host + prefix `…/api/v1/*` | **move** | dedicated host `api.e2a.dev`, prefix `/v1` (base `https://api.e2a.dev/v1`) |
 | `GET/POST /approve`, `/reject`, `/pending` | **collapse** | `POST …/messages/{id}/approval` + magic-link GET alias |
 | `POST …/messages/{id}/approve|reject` | **collapse** | same `approval` sub-resource |
@@ -1150,11 +1150,13 @@ Break the current `/api/v1` surface directly and move it to
   agent** (`POST /agents/{address}/messages`) and retire top-level `/v1/send`,
   keeping reply/forward as **explicit sub-resources** (`…/messages/{id}/reply`,
   `…/messages/{id}/forward`) — decision 3 (explicit operations, not body
-  discriminators). Then single message address; collapse HITL to `approval`;
-  `/account`. Update MCP + SDKs from the spec; update the internal consumer in
-  lockstep (the `send` path moves). (The shipped `/v1` already has reply/forward
-  nested, so this slice is mostly: relocate `send`, retire `/v1/send`, and the
-  HITL/`/account` consolidation.)
+  discriminators). **Done.** `/account` rename (`/users/me/*` → `/account`,
+  `/info` stays public). **Done.** HITL stays two explicit transitions
+  (decision 5 revised) — **done-as-shipped**. **Single message address —
+  deferred to Slice 4b:** removing the flat `/messages/{id}` needs the unified
+  read to expose both the held-draft `body_text`/`body_html` and the sent/inbound
+  `raw_message`, which is the message-read shape decision 9 designs (don't build
+  it twice). MCP + SDK regen from the spec is the separate consumer port.
 * **Slice 3 — Agent model.** `address` unification; drop `agent_mode`;
   optional webhook. Migration drops the column + CHECK.
 * **Slice 4 — Sender identity (provision *and* teardown).** `SenderIdentityProvider`

--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -106,7 +106,7 @@ relative to that base):
 | **agents** | `GET/POST /agents` · `GET/PATCH/DELETE /agents/{address}` · `POST /agents/{address}/test` (top-level, keyed by full email; create enforces caller owns the verified domain). **DELETE semantics:** discards held drafts (`status=pending_approval`), removes the agent from any webhook `agent_ids` filter, revokes its agent-scoped credentials, and purges/retains inbound per the retention policy — but does **not** touch the domain's SES sending identity (per-domain; decision 4). |
 | **domain's agents** (filtered view) | `GET /domains/{domain}/agents` — list agents on a domain (management view; not a separate identity namespace) |
 | **messages** (per agent; inbound + outbound) | `GET /agents/{address}/messages` (filters incl. `direction`, `status`, `delivery_status`; held outbound drafts = `status=pending_approval`) · `GET …/messages/{id}` · `GET …/messages/{id}/attachments/{index}` · `PATCH …/messages/{id}` (labels/read). Outbound messages carry **`delivery_status ∈ {queued,sent,delivered,bounced,complained,deferred,failed}`** + `delivery_detail?` + `sent_as ∈ {own_address,relay}` (decision 9). Inbound messages carry structured `auth: {spf,dkim,dmarc}`. **Note:** there is **no** `messages.delivery_status` column today — the inbox read/unread column is `inbox_status` (`migrations/001_init.sql`), so the new outbound `delivery_status` collides with nothing and is **added fresh** (no rename needed). `delivery_status` currently exists only as a JSON *response* field name (webhook-delivery state in `events_api`); that is a distinct concept and stays. (Optionally rename `inbox_status` → `read_status` purely for clarity, but that is taste, not a collision fix.) |
-| **outbound** (unified) | `POST /agents/{address}/messages` — one endpoint for *new thread, reply, and forward*, disambiguated by body (`in_reply_to` / `forward_of` absent ⇒ new) |
+| **outbound** (consistent placement, explicit operations) | `POST /agents/{address}/messages` (new thread) · `POST …/messages/{id}/reply` · `POST …/messages/{id}/forward` — all nested under the agent; the operation is **explicit in the route** (not inferred from body fields), with the referenced message as a path param on reply/forward (decision 3) |
 | **conversations** (derived thread view) | `GET /agents/{address}/conversations` · `GET …/conversations/{id}` |
 | **stream** (inbound transport) | `GET /agents/{address}/ws` — WebSocket; first-class + documented (today it's side-registered + mode-gated) |
 | **approvals (HITL)** | `POST /agents/{address}/messages/{id}/approval {decision: approve\|reject}` — the one transition (agents; API-key/OAuth). Held drafts are listed via `GET …/messages?status=pending_approval` and read via the message GET (a held draft is just a message). Human magic link: `GET /approvals/{token}` renders an **HTML confirmation page with NO side effect** (prefetch-safe), whose buttons `POST /approvals/{token} {decision}` into the same transition (short-TTL capability; **single-use is enforced by the state machine** — the message leaves `pending_approval` on first decision and a second POST 409s — not by the token, which re-verifies within its TTL). **Never a mutating GET** — email scanners/prefetchers would auto-trigger it. |
@@ -129,9 +129,11 @@ relative to that base):
   `conversations` table**; it's a read-only aggregate over
   `messages.conversation_id` (`store.go`: "thin read layer"). Threading
   establishes membership: inbound replies join via `In-Reply-To`/`References`;
-  an outbound message with `in_reply_to` joins its thread, otherwise the
-  server assigns a fresh `conversation_id`. Messages are canonical;
-  conversations are the inbox/thread view over them.
+  an outbound **reply** (`POST …/messages/{id}/reply`) joins the referenced
+  message's thread, while a new send or a **forward** gets a fresh
+  `conversation_id`. `conversation_id` may also be passed explicitly on any
+  outbound call to bind it to a thread. Messages are canonical; conversations
+  are the inbox/thread view over them.
 
 ### Key contract decisions
 
@@ -170,11 +172,36 @@ relative to that base):
    states the guarantee explicitly. Secret rotation's 24h dual-sign grace is a
    convenience, not free: a leaked *old* secret stays valid for that window —
    document it, keep the window short.
-3. **Outbound is one endpoint.** `POST /agents/{address}/messages` with a
-   body carrying `to`, `subject`, `body`/`html`, optional `in_reply_to`
-   (reply), `forward_of` (forward), `cc`/`bcc`, `attachments`,
-   `idempotency_key`, and — new — `from` (defaults to the agent address) and
-   `reply_to`. Eliminates the top-level `/send` vs nested `/reply` split.
+3. **Outbound — consistent placement, explicit operations.** The real
+   inconsistency to fix is *placement*: send was top-level (`/send`) while
+   reply/forward were nested. Fix it by nesting all three **under the agent**,
+   but keep the operation **explicit in the route** rather than collapsing to
+   one body-discriminated endpoint:
+   * **send (new thread):** `POST /agents/{address}/messages`
+   * **reply:** `POST /agents/{address}/messages/{id}/reply` (referenced
+     message is the **path param**; `reply_all?`)
+   * **forward:** `POST /agents/{address}/messages/{id}/forward`
+
+   Shared body: `to`, `subject`, `body`/`html`, `cc`/`bcc`, `attachments`,
+   `idempotency_key`, `conversation_id?`, and — new — `from` (defaults to the
+   agent address) and `reply_to` (the Reply-To header). Reply derives
+   `to`/`subject` from the referenced message; forward requires `to`.
+
+   **Why explicit operations over a unified, body-discriminated endpoint
+   (revised from the earlier "one endpoint" plan):** the agent-facing surface is
+   tools/SDK methods, where both shapes expose three named affordances anyway —
+   so unification buys the *agent* nothing. Where the wire shape *does* bite
+   agents is failure mode: a unified endpoint infers "reply vs send" from the
+   **presence of an optional body field** (`in_reply_to`), and LLM callers
+   routinely **drop optional fields** → a meant-to-be reply silently sends as a
+   **new email** (thread broken, no error). Routing the operation structurally
+   makes that misfire impossible (wrong target → loud 404, not a silent
+   send), schema-forces the referenced id, and keeps idempotency keys naturally
+   route-scoped. The closest agent-first peer (AgentMail) uses exactly this
+   path-based reply. We therefore **drop the `in_reply_to`/`forward_of` body
+   discriminators** (and with them the `in_reply_to` vs `reply_to` naming
+   collision — only `reply_to`, the header, remains). This still **eliminates
+   the top-level `/send`**; it just doesn't fold reply/forward into the send body.
 4. **Custom-domain sender identity (async) — send as your own address.** When
    the agent's domain is *sending-verified*, outbound `From` = **the agent's own
    address verbatim** (`"Display Name" <agent@customdomain>`). The current
@@ -256,10 +283,12 @@ relative to that base):
    POSTs with side effects (send, create agent, webhook create, redeliver).
    Dedup key = `(principal, route, **request-body hash**)` — the body hash is
    **load-bearing** (it's already how the code works): same key + *different*
-   body ⇒ `422`, not a silent replay. This matters most on the **unified
-   outbound endpoint**, where send/reply/forward share one route — reusing a key
-   across a new send and a later reply must 422, never return the send's cached
-   response and drop the reply. **Canonicalization (pinned):** the hash is over
+   body ⇒ `422`, not a silent replay. With explicit per-operation routes
+   (decision 3), send/reply/forward each have a **distinct route**, so the route
+   already separates them in the dedup key — and reusing a key across two
+   *different* bodies on the same route still 422s (the body hash carries it).
+   (This is *why* a route-only key would be unsafe and the body hash stays.)
+   **Canonicalization (pinned):** the hash is over
    the **raw request bytes** (`route + "\n" + body`, `idempotency.HashRequest`),
    **not** canonicalized JSON — so a legitimate retry MUST resend byte-identical
    JSON (stable key order/whitespace) or it 422s. SDKs that auto-retry must
@@ -924,13 +953,14 @@ sees both tiers. The drift-gate map records each tool's tier next to its
 | `get_message` | `message_id`*,`address?` | `GET /agents/{address}/messages/{id}` | Flat `GET /messages/{id}` removed — one address. Also reads held outbound drafts. |
 | `get_attachment` | `message_id`*,`index`*,`address?` | `GET /agents/{address}/messages/{id}/attachments/{index}` | **Changed:** dedicated endpoint (was a full-message re-fetch). |
 | `update_message_labels` | `message_id`*,`add_labels?`,`remove_labels?`,`address?` | `PATCH /agents/{address}/messages/{id}` | Labels/read folded into the message PATCH. |
-| `send_message` | `to`*,`subject`*,`body`*,`html?`,`cc/bcc?`,`attachments?`,`from?`,`reply_to?`,`idempotency_key?`,`address?` | `POST /agents/{address}/messages` | New-thread case. **Renamed** from `send_email` to match the `message` resource. **New `from`,`reply_to`** (decision 3 / #206 coverage). |
-| `reply_to_message` | `message_id`*,`body`*,`html?`,`reply_all?`,`cc/bcc?`,`attachments?`,`reply_to?`,`idempotency_key?`,`address?` | `POST /agents/{address}/messages` | Sets `in_reply_to`. |
-| `forward_message` | `message_id`*,`to`*,`body?`,`cc/bcc?`,`attachments?`,`idempotency_key?`,`address?` | `POST /agents/{address}/messages` | Sets `forward_of`. |
+| `send_message` | `to`*,`subject`*,`body`*,`html?`,`cc/bcc?`,`attachments?`,`from?`,`reply_to?`,`conversation_id?`,`idempotency_key?`,`address?` | `POST /agents/{address}/messages` | New-thread case. **Renamed** from `send_email` to match the `message` resource. **New `from`,`reply_to`** (decision 3 / #206 coverage). |
+| `reply_to_message` | `message_id`*,`body`*,`html?`,`reply_all?`,`cc/bcc?`,`attachments?`,`reply_to?`,`idempotency_key?`,`address?` | `POST /agents/{address}/messages/{id}/reply` | Referenced message is the **path param** (`{id}`) — explicit reply operation, not a body discriminator. |
+| `forward_message` | `message_id`*,`to`*,`body?`,`cc/bcc?`,`attachments?`,`idempotency_key?`,`address?` | `POST /agents/{address}/messages/{id}/forward` | Referenced message is the **path param** (`{id}`). |
 
-> send/reply/forward all map to the single `sendMessage` operation; the body's
-> `in_reply_to`/`forward_of` selects the mode. Kept as three tools for intent
-> clarity — coverage check #4 treats them as jointly covering `sendMessage`.
+> send/reply/forward map to **three distinct operations** (`sendMessage`,
+> `replyToMessage`, `forwardMessage`), each its own route — the operation is
+> explicit, never inferred from optional body fields (decision 3). One tool per
+> operation; coverage check #4 maps each tool 1:1.
 
 **Conversations** — `list_conversations` → `GET /agents/{address}/conversations`;
 `get_conversation {conversation_id}` → `GET …/conversations/{id}`.
@@ -1054,9 +1084,9 @@ Applying 1 + 6: a runtime agent sees ~13 tools; the full self-host surface 31.
 
 | Current | Disposition | Target |
 |---|---|---|
-| `POST /send` | **move** | `POST /agents/{address}/messages` (new-thread case) |
-| `POST /agents/{e}/messages/{id}/reply` | **fold** | `POST /agents/{address}/messages` + `in_reply_to` |
-| `POST /agents/{e}/messages/{id}/forward` | **fold** | `POST /agents/{address}/messages` + `forward_of` |
+| `POST /send` | **move** | `POST /agents/{address}/messages` (new-thread case — nest under the agent) |
+| `POST /agents/{e}/messages/{id}/reply` | **keep (re-place)** | `POST /agents/{address}/messages/{id}/reply` — explicit reply op (target in path), not folded into the send body |
+| `POST /agents/{e}/messages/{id}/forward` | **keep (re-place)** | `POST /agents/{address}/messages/{id}/forward` — explicit forward op (target in path) |
 | `GET /messages/{id}` (flat) | **remove** | use `GET /agents/{address}/messages/{id}` |
 | host + prefix `…/api/v1/*` | **move** | dedicated host `api.e2a.dev`, prefix `/v1` (base `https://api.e2a.dev/v1`) |
 | `GET/POST /approve`, `/reject`, `/pending` | **collapse** | `POST …/messages/{id}/approval` + magic-link GET alias |
@@ -1085,11 +1115,15 @@ Break the current `/api/v1` surface directly and move it to
   idempotency helpers; add the spec↔server test; **perform the host/prefix
   cutover** (`/api/v1` → `https://api.e2a.dev/v1`, the §8 "host + prefix" row).
   (No behavior change yet beyond envelope/pagination + the path move.)
-* **Slice 2 — Resource cleanup.** Unify outbound under
-  `POST /agents/{address}/messages` (send/reply/forward); single message
-  address; collapse HITL to `approval`; `/account`. Update MCP + SDKs from
-  the spec; update the internal consumer in lockstep (the `send`/`reply` calls
-  move).
+* **Slice 2 — Resource cleanup.** Outbound consistency: **move `send` under the
+  agent** (`POST /agents/{address}/messages`) and retire top-level `/v1/send`,
+  keeping reply/forward as **explicit sub-resources** (`…/messages/{id}/reply`,
+  `…/messages/{id}/forward`) — decision 3 (explicit operations, not body
+  discriminators). Then single message address; collapse HITL to `approval`;
+  `/account`. Update MCP + SDKs from the spec; update the internal consumer in
+  lockstep (the `send` path moves). (The shipped `/v1` already has reply/forward
+  nested, so this slice is mostly: relocate `send`, retire `/v1/send`, and the
+  HITL/`/account` consolidation.)
 * **Slice 3 — Agent model.** `address` unification; drop `agent_mode`;
   optional webhook. Migration drops the column + CHECK.
 * **Slice 4 — Sender identity (provision *and* teardown).** `SenderIdentityProvider`
@@ -1246,12 +1280,16 @@ Reconciles this design to what shipped on the `feat/api-v1-cutover` branch.
 **Scope, stated plainly:** the shipped `/v1` is the **contract + host/strangler
 cutover** (≈ Slice 1) — it ports the **legacy request/response shapes** onto the
 new host + envelope + pagination + idempotency + rate-limit. The §4
-resource-model changes are **NOT built yet:** outbound is still **three routes**
-(`/v1/send`, `…/reply`, `…/forward`), not the unified `POST …/messages`
-(decision 3); HITL is still **two routes** (`…/approve`, `…/reject`), not the
-single `approval` transition (decision 5); and decisions 4 (sender identity),
-9 (delivery feedback / structured inbound `auth`), and 10 (inbound policy) are
-unbuilt. Read decisions 3/4/5/9/10 as **target spec, not shipped behavior**.
+resource-model changes are **NOT fully built yet:** outbound is three routes but
+`send` is still **top-level `/v1/send`** rather than nested under the agent —
+decision 3's target is to relocate `send` to `POST /agents/{address}/messages`
+while **keeping** reply/forward as the explicit sub-resources they already are
+(`…/reply`, `…/forward`), so the shipped reply/forward shape is *aligned* with
+the revised decision 3 and only `send` needs moving; HITL is still **two routes**
+(`…/approve`, `…/reject`), not the single `approval` transition (decision 5); and
+decisions 4 (sender identity), 9 (delivery feedback / structured inbound `auth`),
+and 10 (inbound policy) are unbuilt. Read decisions 3/4/5/9/10 as **target spec,
+not shipped behavior**.
 
 **Implemented as designed:** the full additive `/v1` Huma surface (34 ops:
 agents/messages/conversations/domains/webhooks/events/account/HITL/info);

--- a/docs/design/outbound-v1-extraction.md
+++ b/docs/design/outbound-v1-extraction.md
@@ -79,7 +79,7 @@ via `runIdempotent`:
 
 | `/v1` route | builds SendRequest | msgType |
 |---|---|---|
-| `POST /v1/send` | from body (`from`/`to`/subject/body/html/cc/bcc/attachments) | `send` |
+| `POST /v1/agents/{address}/messages` | sender = path agent; body (`to`/subject/body/html/cc/bcc/attachments); `from` optional, must equal the agent | `send` |
 | `POST /v1/agents/{address}/messages/{id}/reply` | from inbound + body | `reply` |
 | `POST /v1/agents/{address}/messages/{id}/forward` | from inbound + body | `forward` |
 | `POST /v1/agents/{address}/test` | server-built test message | `test` |

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/smtp"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -136,11 +137,11 @@ func TestOutboundAgentToAgent(t *testing.T) {
 	receiver := testutil.WebhookReceiver(t)
 	ts := testutil.TestServer(t, pool)
 
-	_, apiKey, _ := setupDomainAndAgent(t, ts, "agent@out-a.example.com", "out-a.example.com", "https://example.com/webhook", "cloud")
+	_, apiKey, senderAgent := setupDomainAndAgent(t, ts, "agent@out-a.example.com", "out-a.example.com", "https://example.com/webhook", "cloud")
 	_, _, _ = setupDomainAndAgent(t, ts, "agent@out-b.example.com", "out-b.example.com", receiver.Server.URL, "cloud")
 
 	sendPayload := `{"to":["agent@out-b.example.com"],"subject":"A2A","body":"Hello from A"}`
-	req, _ := http.NewRequest("POST", ts.HTTPServer.URL+"/api/v1/send", bytes.NewBufferString(sendPayload))
+	req, _ := http.NewRequest("POST", ts.HTTPServer.URL+"/v1/agents/"+url.PathEscape(senderAgent.EmailAddress())+"/messages", bytes.NewBufferString(sendPayload))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+apiKey.PlaintextKey)
 	resp, _ := http.DefaultClient.Do(req)
@@ -164,8 +165,11 @@ func TestOutboundRequiresAuth(t *testing.T) {
 	pool := testutil.TestDB(t)
 	ts := testutil.TestServer(t, pool)
 
+	// Send relocated (Slice 2): POST /v1/agents/{email}/messages. With no
+	// bearer the typed handler authenticates first and 401s before it ever
+	// resolves the path agent.
 	sendPayload := `{"to":["someone@test.com"],"subject":"Hi","body":"Hello"}`
-	req, _ := http.NewRequest("POST", ts.HTTPServer.URL+"/api/v1/send", bytes.NewBufferString(sendPayload))
+	req, _ := http.NewRequest("POST", ts.HTTPServer.URL+"/v1/agents/"+url.PathEscape("agent@noauth.example.com")+"/messages", bytes.NewBufferString(sendPayload))
 	req.Header.Set("Content-Type", "application/json")
 	resp, _ := http.DefaultClient.Do(req)
 	defer resp.Body.Close()
@@ -207,11 +211,11 @@ func TestOutboundResponseFormat(t *testing.T) {
 	receiver := testutil.WebhookReceiver(t)
 	ts := testutil.TestServer(t, pool)
 
-	_, apiKey, _ := setupDomainAndAgent(t, ts, "agent@resp-a.example.com", "resp-a.example.com", "https://example.com/w", "cloud")
+	_, apiKey, senderAgent := setupDomainAndAgent(t, ts, "agent@resp-a.example.com", "resp-a.example.com", "https://example.com/w", "cloud")
 	_, _, _ = setupDomainAndAgent(t, ts, "agent@resp-b.example.com", "resp-b.example.com", receiver.Server.URL, "cloud")
 
 	sendPayload := `{"to":["agent@resp-b.example.com"],"subject":"Test","body":"Hello"}`
-	req, _ := http.NewRequest("POST", ts.HTTPServer.URL+"/api/v1/send", bytes.NewBufferString(sendPayload))
+	req, _ := http.NewRequest("POST", ts.HTTPServer.URL+"/v1/agents/"+url.PathEscape(senderAgent.EmailAddress())+"/messages", bytes.NewBufferString(sendPayload))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+apiKey.PlaintextKey)
 	resp, _ := http.DefaultClient.Do(req)
@@ -252,49 +256,50 @@ func TestPollMode_E2E(t *testing.T) {
 	// Wait a moment for processing
 	time.Sleep(500 * time.Millisecond)
 
-	// GET /api/v1/agents/{email}/messages should return the unread message
-	req, _ := http.NewRequest("GET", ts.HTTPServer.URL+"/api/v1/agents/agent@poll.example.com/messages", nil)
+	// GET /v1/agents/{email}/messages should return the unread message.
+	// /v1 cursor page: {items:[...], next_cursor:...}.
+	req, _ := http.NewRequest("GET", ts.HTTPServer.URL+"/v1/agents/"+url.PathEscape("agent@poll.example.com")+"/messages", nil)
 	req.Header.Set("Authorization", "Bearer "+apiKey.PlaintextKey)
 	resp, _ := http.DefaultClient.Do(req)
 	defer resp.Body.Close()
 
 	if resp.StatusCode != 200 {
-		t.Fatalf("GET /api/v1/agents/{email}/messages status = %d, want 200", resp.StatusCode)
+		t.Fatalf("GET /v1/agents/{email}/messages status = %d, want 200", resp.StatusCode)
 	}
 
 	var listResp struct {
-		Messages []struct {
+		Items []struct {
 			MessageID      string   `json:"message_id"`
 			From           string   `json:"from"`
 			To             []string `json:"to"`
 			Subject        string   `json:"subject"`
 			Status         string   `json:"status"`
 			ConversationID string   `json:"conversation_id"`
-		} `json:"messages"`
-		HasMore bool `json:"has_more"`
+		} `json:"items"`
+		NextCursor *string `json:"next_cursor"`
 	}
 	json.NewDecoder(resp.Body).Decode(&listResp)
 
-	if len(listResp.Messages) != 1 {
-		t.Fatalf("expected 1 message, got %d", len(listResp.Messages))
+	if len(listResp.Items) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(listResp.Items))
 	}
-	if listResp.Messages[0].From != "alice-poll@gmail.com" {
-		t.Errorf("From = %q", listResp.Messages[0].From)
+	if listResp.Items[0].From != "alice-poll@gmail.com" {
+		t.Errorf("From = %q", listResp.Items[0].From)
 	}
-	if listResp.Messages[0].Status != "unread" {
-		t.Errorf("Status = %q, want unread", listResp.Messages[0].Status)
+	if listResp.Items[0].Status != "unread" {
+		t.Errorf("Status = %q, want unread", listResp.Items[0].Status)
 	}
 
-	msgID := listResp.Messages[0].MessageID
+	msgID := listResp.Items[0].MessageID
 
-	// GET /api/v1/agents/{email}/messages/{id} should return full content and mark as read
-	req2, _ := http.NewRequest("GET", ts.HTTPServer.URL+"/api/v1/agents/agent@poll.example.com/messages/"+msgID, nil)
+	// GET /v1/agents/{email}/messages/{id} should return full content and mark as read.
+	req2, _ := http.NewRequest("GET", ts.HTTPServer.URL+"/v1/agents/"+url.PathEscape("agent@poll.example.com")+"/messages/"+msgID, nil)
 	req2.Header.Set("Authorization", "Bearer "+apiKey.PlaintextKey)
 	resp2, _ := http.DefaultClient.Do(req2)
 	defer resp2.Body.Close()
 
 	if resp2.StatusCode != 200 {
-		t.Fatalf("GET /api/v1/agents/{email}/messages/%s status = %d, want 200", msgID, resp2.StatusCode)
+		t.Fatalf("GET /v1/agents/{email}/messages/%s status = %d, want 200", msgID, resp2.StatusCode)
 	}
 
 	var msgResp struct {
@@ -319,22 +324,22 @@ func TestPollMode_E2E(t *testing.T) {
 	}
 
 	// Subsequent GET should show no unread messages
-	req3, _ := http.NewRequest("GET", ts.HTTPServer.URL+"/api/v1/agents/agent@poll.example.com/messages?status=unread", nil)
+	req3, _ := http.NewRequest("GET", ts.HTTPServer.URL+"/v1/agents/"+url.PathEscape("agent@poll.example.com")+"/messages?status=unread", nil)
 	req3.Header.Set("Authorization", "Bearer "+apiKey.PlaintextKey)
 	resp3, _ := http.DefaultClient.Do(req3)
 	defer resp3.Body.Close()
 
 	var emptyResp struct {
-		Messages []interface{} `json:"messages"`
+		Items []interface{} `json:"items"`
 	}
 	json.NewDecoder(resp3.Body).Decode(&emptyResp)
-	if len(emptyResp.Messages) != 0 {
-		t.Errorf("expected 0 unread messages after read, got %d", len(emptyResp.Messages))
+	if len(emptyResp.Items) != 0 {
+		t.Errorf("expected 0 unread messages after read, got %d", len(emptyResp.Items))
 	}
 
-	// Reply via API should work
+	// Reply via API should work (reply path is unchanged, only de-prefixed).
 	replyPayload := `{"body":"Got your message!"}`
-	req4, _ := http.NewRequest("POST", ts.HTTPServer.URL+"/api/v1/agents/agent@poll.example.com/messages/"+msgID+"/reply", bytes.NewBufferString(replyPayload))
+	req4, _ := http.NewRequest("POST", ts.HTTPServer.URL+"/v1/agents/"+url.PathEscape("agent@poll.example.com")+"/messages/"+msgID+"/reply", bytes.NewBufferString(replyPayload))
 	req4.Header.Set("Content-Type", "application/json")
 	req4.Header.Set("Authorization", "Bearer "+apiKey.PlaintextKey)
 	resp4, _ := http.DefaultClient.Do(req4)
@@ -371,25 +376,25 @@ func TestPushToLocalSwitch_E2E(t *testing.T) {
 		t.Errorf("expected 0 webhook deliveries after switch to local, got %d", len(payloads))
 	}
 
-	// API should show the message
-	req, _ := http.NewRequest("GET", ts.HTTPServer.URL+"/api/v1/agents/agent@switch.example.com/messages", nil)
+	// API should show the message. /v1 cursor page: {items:[...]}.
+	req, _ := http.NewRequest("GET", ts.HTTPServer.URL+"/v1/agents/"+url.PathEscape("agent@switch.example.com")+"/messages", nil)
 	req.Header.Set("Authorization", "Bearer "+apiKey.PlaintextKey)
 	resp, _ := http.DefaultClient.Do(req)
 	defer resp.Body.Close()
 
 	var listResp struct {
-		Messages []struct {
+		Items []struct {
 			MessageID string `json:"message_id"`
 			Status    string `json:"status"`
-		} `json:"messages"`
+		} `json:"items"`
 	}
 	json.NewDecoder(resp.Body).Decode(&listResp)
 
-	if len(listResp.Messages) != 1 {
-		t.Fatalf("expected 1 message, got %d", len(listResp.Messages))
+	if len(listResp.Items) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(listResp.Items))
 	}
-	if listResp.Messages[0].Status != "unread" {
-		t.Errorf("Status = %q, want unread", listResp.Messages[0].Status)
+	if listResp.Items[0].Status != "unread" {
+		t.Errorf("Status = %q, want unread", listResp.Items[0].Status)
 	}
 }
 

--- a/internal/e2e/edge_cases_e2e_test.go
+++ b/internal/e2e/edge_cases_e2e_test.go
@@ -70,7 +70,7 @@ func TestEdge_RedeliverEmptyMatched_NoCrash(t *testing.T) {
 
 	// Replay with empty body: should return a deliveries array of
 	// length 0 without crashing.
-	resp := fix.httpPost("/api/v1/events/"+eventID+"/redeliver", apiKey, []byte(`{}`))
+	resp := fix.httpPost("/v1/events/"+eventID+"/redeliver", apiKey, []byte(`{}`))
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		b, _ := io.ReadAll(resp.Body)
@@ -123,7 +123,7 @@ func TestEdge_410BoundaryExactlyAtExpiresAt(t *testing.T) {
 		t.Fatalf("seed: %v", err)
 	}
 
-	resp := fix.httpGet("/api/v1/events/"+expiringNow, apiKey)
+	resp := fix.httpGet("/v1/events/"+expiringNow, apiKey)
 	if resp.StatusCode != 410 {
 		t.Errorf("expired-just-now → %d; want 410", resp.StatusCode)
 	}
@@ -149,7 +149,7 @@ func TestEdge_LargeEventPayloadRoundTrip(t *testing.T) {
 		Data: map[string]any{"body": bigString, "subject": "large"},
 	})
 
-	resp := fix.httpGet("/api/v1/events/"+eventID, apiKey)
+	resp := fix.httpGet("/v1/events/"+eventID, apiKey)
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		t.Fatalf("large get → %d", resp.StatusCode)
@@ -192,7 +192,7 @@ func TestEdge_RedeliverIdempotency_FiveMinWindow(t *testing.T) {
 
 	// First replay.
 	body := fmt.Sprintf(`{"webhook_id":"%s"}`, webhookID)
-	resp1 := fix.httpPost("/api/v1/events/"+eventID+"/redeliver", apiKey, []byte(body))
+	resp1 := fix.httpPost("/v1/events/"+eventID+"/redeliver", apiKey, []byte(body))
 	if resp1.StatusCode != 200 {
 		raw, _ := io.ReadAll(resp1.Body)
 		t.Fatalf("first replay → %d (%s)", resp1.StatusCode, raw)
@@ -206,7 +206,7 @@ func TestEdge_RedeliverIdempotency_FiveMinWindow(t *testing.T) {
 	afterFirst := receiver.Count()
 
 	// Second replay within the window.
-	resp2 := fix.httpPost("/api/v1/events/"+eventID+"/redeliver", apiKey, []byte(body))
+	resp2 := fix.httpPost("/v1/events/"+eventID+"/redeliver", apiKey, []byte(body))
 	if resp2.StatusCode != 200 {
 		raw, _ := io.ReadAll(resp2.Body)
 		t.Fatalf("second replay → %d (%s)", resp2.StatusCode, raw)
@@ -299,7 +299,7 @@ func TestEdge_ReplayUsesCurrentSecret(t *testing.T) {
 	// secret, not the previous one — even though prev is still in the
 	// rotation-grace window.
 	body := fmt.Sprintf(`{"webhook_id":"%s"}`, webhookID)
-	resp := fix.httpPost("/api/v1/events/"+eventID+"/redeliver", apiKey, []byte(body))
+	resp := fix.httpPost("/v1/events/"+eventID+"/redeliver", apiKey, []byte(body))
 	resp.Body.Close()
 	fix.drainBoth(ctx)
 
@@ -372,10 +372,10 @@ func TestEdge_InvalidCursorReturns400(t *testing.T) {
 	user := fix.seedUser("edge_cursor")
 	apiKey := fix.issueAPIKey(user)
 
-	// Malformed base64.
-	resp := fix.httpGet("/api/v1/events?token=NOT_VALID_BASE64!!!", apiKey)
+	// Malformed base64 cursor → 400 invalid_cursor.
+	resp := fix.httpGet("/v1/events?cursor=NOT_VALID_BASE64!!!", apiKey)
 	if resp.StatusCode != 400 {
-		t.Errorf("bad token → %d; want 400", resp.StatusCode)
+		t.Errorf("bad cursor → %d; want 400", resp.StatusCode)
 	}
 	resp.Body.Close()
 }

--- a/internal/e2e/events_api_e2e_test.go
+++ b/internal/e2e/events_api_e2e_test.go
@@ -354,66 +354,67 @@ func TestEventsE2E_ListAPI_FilterAndCursor(t *testing.T) {
 		})
 	}
 
-	// Unfiltered
-	resp := fix.httpGet("/api/v1/events?page_size=10", apiKey)
+	// Unfiltered. /v1 cursor page: {items:[...], next_cursor:...}; page-size
+	// param is `limit`.
+	resp := fix.httpGet("/v1/events?limit=10", apiKey)
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("status %d: %s", resp.StatusCode, body)
 	}
 	var listResp struct {
-		Events    []map[string]interface{} `json:"events"`
-		NextToken string                   `json:"next_token"`
+		Items      []map[string]interface{} `json:"items"`
+		NextCursor *string                  `json:"next_cursor"`
 	}
 	json.NewDecoder(resp.Body).Decode(&listResp)
-	if len(listResp.Events) != 5 {
-		t.Errorf("got %d events; want 5", len(listResp.Events))
+	if len(listResp.Items) != 5 {
+		t.Errorf("got %d events; want 5", len(listResp.Items))
 	}
 
 	// type=email.sent filter
-	resp2 := fix.httpGet("/api/v1/events?type=email.sent", apiKey)
+	resp2 := fix.httpGet("/v1/events?type=email.sent", apiKey)
 	defer resp2.Body.Close()
 	var typedResp struct {
-		Events []map[string]interface{} `json:"events"`
+		Items []map[string]interface{} `json:"items"`
 	}
 	json.NewDecoder(resp2.Body).Decode(&typedResp)
-	if len(typedResp.Events) != 2 {
-		t.Errorf("type filter returned %d; want 2", len(typedResp.Events))
+	if len(typedResp.Items) != 2 {
+		t.Errorf("type filter returned %d; want 2", len(typedResp.Items))
 	}
-	for _, e := range typedResp.Events {
+	for _, e := range typedResp.Items {
 		if e["type"] != "email.sent" {
 			t.Errorf("filter leaked: type=%v", e["type"])
 		}
 	}
 
-	// Cursor pagination: page_size=2, walk 3 pages.
+	// Cursor pagination: limit=2, walk pages via next_cursor.
 	seen := map[string]bool{}
-	token := ""
+	cursor := ""
 	pages := 0
 	for {
-		url := "/api/v1/events?page_size=2"
-		if token != "" {
-			url += "&token=" + token
+		url := "/v1/events?limit=2"
+		if cursor != "" {
+			url += "&cursor=" + cursor
 		}
 		r := fix.httpGet(url, apiKey)
 		var page struct {
-			Events    []map[string]interface{} `json:"events"`
-			NextToken string                   `json:"next_token"`
+			Items      []map[string]interface{} `json:"items"`
+			NextCursor *string                  `json:"next_cursor"`
 		}
 		json.NewDecoder(r.Body).Decode(&page)
 		r.Body.Close()
 		pages++
-		for _, e := range page.Events {
+		for _, e := range page.Items {
 			id := e["id"].(string)
 			if seen[id] {
 				t.Errorf("cursor duplicated event %s", id)
 			}
 			seen[id] = true
 		}
-		if page.NextToken == "" {
+		if page.NextCursor == nil || *page.NextCursor == "" {
 			break
 		}
-		token = page.NextToken
+		cursor = *page.NextCursor
 		if pages > 10 {
 			t.Fatal("cursor loop did not terminate")
 		}
@@ -429,7 +430,7 @@ func TestEventsE2E_GetReturns404And410(t *testing.T) {
 	user := fix.seedUser("e2e_get")
 	apiKey := fix.issueAPIKey(user)
 
-	resp := fix.httpGet("/api/v1/events/evt_does_not_exist", apiKey)
+	resp := fix.httpGet("/v1/events/evt_does_not_exist", apiKey)
 	if resp.StatusCode != 404 {
 		t.Errorf("missing event → %d; want 404", resp.StatusCode)
 	}
@@ -437,7 +438,7 @@ func TestEventsE2E_GetReturns404And410(t *testing.T) {
 
 	expiredID := webhookpub.DeterministicEventID("msg_expired_e2e", webhookpub.EventEmailReceived)
 	fix.seedExpiredEvent(user, expiredID, webhookpub.EventEmailReceived)
-	resp2 := fix.httpGet("/api/v1/events/"+expiredID, apiKey)
+	resp2 := fix.httpGet("/v1/events/"+expiredID, apiKey)
 	if resp2.StatusCode != 410 {
 		t.Errorf("expired event → %d; want 410", resp2.StatusCode)
 	}
@@ -473,7 +474,7 @@ func TestEventsE2E_RedeliverFanOut(t *testing.T) {
 		t.Fatalf("original delivery counts: A=%d B=%d", rcvA.Count(), rcvB.Count())
 	}
 
-	resp := fix.httpPost("/api/v1/events/"+eventID+"/redeliver", apiKey, []byte(`{}`))
+	resp := fix.httpPost("/v1/events/"+eventID+"/redeliver", apiKey, []byte(`{}`))
 	if resp.StatusCode != 200 {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("redeliver status %d: %s", resp.StatusCode, body)
@@ -572,19 +573,19 @@ func TestEventsE2E_AuthBoundaries(t *testing.T) {
 		UserID: userA, AgentID: agentA, MessageID: "msg_a_only", Data: map[string]any{},
 	})
 
-	resp := fix.httpGet("/api/v1/events", apiKeyA)
+	resp := fix.httpGet("/v1/events", apiKeyA)
 	defer resp.Body.Close()
 	var listResp struct {
-		Events []map[string]interface{} `json:"events"`
+		Items []map[string]interface{} `json:"items"`
 	}
 	json.NewDecoder(resp.Body).Decode(&listResp)
-	for _, e := range listResp.Events {
+	for _, e := range listResp.Items {
 		if e["id"] == bEventID {
 			t.Errorf("user A saw user B's event — auth boundary violated")
 		}
 	}
 
-	directResp := fix.httpGet("/api/v1/events/"+bEventID, apiKeyA)
+	directResp := fix.httpGet("/v1/events/"+bEventID, apiKeyA)
 	if directResp.StatusCode != 404 {
 		t.Errorf("cross-user GET → %d; want 404", directResp.StatusCode)
 	}
@@ -594,7 +595,7 @@ func TestEventsE2E_AuthBoundaries(t *testing.T) {
 func TestEventsE2E_MissingBearer(t *testing.T) {
 	fix := newEventsFixture(t)
 	defer fix.Close()
-	resp := fix.httpGet("/api/v1/events", "")
+	resp := fix.httpGet("/v1/events", "")
 	if resp.StatusCode != 401 {
 		t.Errorf("no bearer → %d; want 401", resp.StatusCode)
 	}
@@ -723,13 +724,13 @@ func TestEventsE2E_ConcurrentReadsConsistent(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			r := fix.httpGet("/api/v1/events?page_size=100", apiKey)
+			r := fix.httpGet("/v1/events?limit=100", apiKey)
 			defer r.Body.Close()
 			var page struct {
-				Events []map[string]interface{} `json:"events"`
+				Items []map[string]interface{} `json:"items"`
 			}
 			json.NewDecoder(r.Body).Decode(&page)
-			if len(page.Events) != expected {
+			if len(page.Items) != expected {
 				mismatches.Add(1)
 			}
 		}()

--- a/internal/e2e/webhooks_e2e_test.go
+++ b/internal/e2e/webhooks_e2e_test.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net/http"
 	"net/smtp"
+	"net/url"
 	"strconv"
 	"strings"
 	"testing"
@@ -21,6 +22,13 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/identity"
 	"github.com/Mnexa-AI/e2a/internal/testutil"
 )
+
+// sendURL builds the /v1 send endpoint for an agent. Send was relocated
+// (Slice 2): POST /v1/agents/{URL-encoded agent email}/messages, with the
+// sender taken from the path (the body no longer carries `from`).
+func sendURL(base, agentEmail string) string {
+	return base + "/v1/agents/" + url.PathEscape(agentEmail) + "/messages"
+}
 
 // Tests in this file exercise the webhooks-as-a-resource path end-to-end.
 // Distinct from e2e_test.go which covers the legacy
@@ -36,7 +44,7 @@ import (
 //
 // Two design decisions worth re-stating:
 //   1) Webhooks are provisioned via Store.CreateWebhook directly (NOT
-//      POST /api/v1/webhooks). The public API rejects 127.0.0.1 URLs
+//      POST /v1/webhooks). The public API rejects 127.0.0.1 URLs
 //      (SSRF guard); the only way to test the worker hitting a local
 //      receiver is to bypass the handler-side validator. The handler
 //      itself has unit-test coverage at internal/agent/webhooks_api_test.go.
@@ -186,8 +194,8 @@ func TestWebhooksE2E_EmailSent(t *testing.T) {
 
 	// Trigger /send through the real HTTP API so publishAsync fires
 	// from the actual handler, not a hand-crafted publisher call.
-	body := fmt.Sprintf(`{"from":%q,"to":["alice@example.com"],"subject":"hi","body":"hello"}`, agent.EmailAddress())
-	status, _ := authedJSON(t, "POST", ts.HTTPServer.URL+"/api/v1/send", key.PlaintextKey, body)
+	body := `{"to":["alice@example.com"],"subject":"hi","body":"hello"}`
+	status, _ := authedJSON(t, "POST", sendURL(ts.HTTPServer.URL, agent.EmailAddress()), key.PlaintextKey, body)
 	if status != 200 {
 		t.Fatalf("send status=%d", status)
 	}
@@ -220,9 +228,9 @@ func TestWebhooksE2E_HITL_PendingApproved(t *testing.T) {
 	approvedHook := registerWebhook(t, ts, agent.UserID, receiver.Server.URL+"/approved",
 		[]string{"email.approved"}, identity.WebhookFilters{})
 
-	// /send → held for approval, returns 202 + message_id.
-	body := fmt.Sprintf(`{"from":%q,"to":["alice@example.com"],"subject":"draft","body":"please review"}`, agent.EmailAddress())
-	status, respBytes := authedJSON(t, "POST", ts.HTTPServer.URL+"/api/v1/send", key.PlaintextKey, body)
+	// send → held for approval, returns 202 + message_id.
+	body := `{"to":["alice@example.com"],"subject":"draft","body":"please review"}`
+	status, respBytes := authedJSON(t, "POST", sendURL(ts.HTTPServer.URL, agent.EmailAddress()), key.PlaintextKey, body)
 	if status != 202 {
 		t.Fatalf("send status=%d body=%s want 202 (HITL hold)", status, string(respBytes))
 	}
@@ -250,7 +258,7 @@ func TestWebhooksE2E_HITL_PendingApproved(t *testing.T) {
 	// Approve via the API.
 	approveBody := `{}`
 	approveStatus, approveResp := authedJSON(t, "POST",
-		ts.HTTPServer.URL+"/api/v1/agents/"+agent.EmailAddress()+"/messages/"+msgID+"/approve",
+		ts.HTTPServer.URL+"/v1/agents/"+url.PathEscape(agent.EmailAddress())+"/messages/"+msgID+"/approve",
 		key.PlaintextKey, approveBody)
 	if approveStatus != 200 {
 		t.Fatalf("approve status=%d body=%s", approveStatus, string(approveResp))
@@ -288,8 +296,8 @@ func TestWebhooksE2E_HITL_Rejected(t *testing.T) {
 	rejectedHook := registerWebhook(t, ts, agent.UserID, receiver.Server.URL+"/rejected",
 		[]string{"email.rejected"}, identity.WebhookFilters{})
 
-	body := fmt.Sprintf(`{"from":%q,"to":["alice@example.com"],"subject":"nope","body":"please reject"}`, agent.EmailAddress())
-	status, respBytes := authedJSON(t, "POST", ts.HTTPServer.URL+"/api/v1/send", key.PlaintextKey, body)
+	body := `{"to":["alice@example.com"],"subject":"nope","body":"please reject"}`
+	status, respBytes := authedJSON(t, "POST", sendURL(ts.HTTPServer.URL, agent.EmailAddress()), key.PlaintextKey, body)
 	if status != 202 {
 		t.Fatalf("send status=%d", status)
 	}
@@ -304,7 +312,7 @@ func TestWebhooksE2E_HITL_Rejected(t *testing.T) {
 	receiver.Reset()
 
 	rejectStatus, rejectResp := authedJSON(t, "POST",
-		ts.HTTPServer.URL+"/api/v1/agents/"+agent.EmailAddress()+"/messages/"+msgID+"/reject",
+		ts.HTTPServer.URL+"/v1/agents/"+url.PathEscape(agent.EmailAddress())+"/messages/"+msgID+"/reject",
 		key.PlaintextKey, `{"reason":"off-policy"}`)
 	if rejectStatus != 200 {
 		t.Fatalf("reject status=%d body=%s", rejectStatus, string(rejectResp))
@@ -399,8 +407,8 @@ func TestWebhooksE2E_FilterByAgentID(t *testing.T) {
 		[]string{"email.sent"}, identity.WebhookFilters{AgentIDs: []string{agentB.ID}})
 
 	// Send through agent A → only /a fires.
-	body := fmt.Sprintf(`{"from":%q,"to":["alice@example.com"],"subject":"from A","body":"x"}`, agentA.EmailAddress())
-	status, _ := authedJSON(t, "POST", ts.HTTPServer.URL+"/api/v1/send", keyA.PlaintextKey, body)
+	body := `{"to":["alice@example.com"],"subject":"from A","body":"x"}`
+	status, _ := authedJSON(t, "POST", sendURL(ts.HTTPServer.URL, agentA.EmailAddress()), keyA.PlaintextKey, body)
 	if status != 200 {
 		t.Fatalf("send-A status=%d", status)
 	}
@@ -416,8 +424,8 @@ func TestWebhooksE2E_FilterByAgentID(t *testing.T) {
 
 	// Send through agent B → only /b fires.
 	receiver.Reset()
-	bodyB := fmt.Sprintf(`{"from":%q,"to":["bob@example.com"],"subject":"from B","body":"x"}`, agentB.EmailAddress())
-	status, _ = authedJSON(t, "POST", ts.HTTPServer.URL+"/api/v1/send", keyA.PlaintextKey, bodyB)
+	bodyB := `{"to":["bob@example.com"],"subject":"from B","body":"x"}`
+	status, _ = authedJSON(t, "POST", sendURL(ts.HTTPServer.URL, agentB.EmailAddress()), keyA.PlaintextKey, bodyB)
 	if status != 200 {
 		t.Fatalf("send-B status=%d", status)
 	}
@@ -443,8 +451,8 @@ func TestWebhooksE2E_FilterByConversationID(t *testing.T) {
 
 	// Send WITHOUT conversation_id — should NOT match (H5 rule:
 	// filter requires X but event has none).
-	body := fmt.Sprintf(`{"from":%q,"to":["alice@example.com"],"subject":"no conv","body":"x"}`, agent.EmailAddress())
-	status, _ := authedJSON(t, "POST", ts.HTTPServer.URL+"/api/v1/send", key.PlaintextKey, body)
+	body := `{"to":["alice@example.com"],"subject":"no conv","body":"x"}`
+	status, _ := authedJSON(t, "POST", sendURL(ts.HTTPServer.URL, agent.EmailAddress()), key.PlaintextKey, body)
 	if status != 200 {
 		t.Fatalf("send-noconv status=%d", status)
 	}
@@ -457,8 +465,8 @@ func TestWebhooksE2E_FilterByConversationID(t *testing.T) {
 	}
 
 	// Send WITH the matching conversation_id → fires.
-	body = fmt.Sprintf(`{"from":%q,"to":["alice@example.com"],"subject":"yes conv","body":"x","conversation_id":"conv-match"}`, agent.EmailAddress())
-	status, _ = authedJSON(t, "POST", ts.HTTPServer.URL+"/api/v1/send", key.PlaintextKey, body)
+	body = `{"to":["alice@example.com"],"subject":"yes conv","body":"x","conversation_id":"conv-match"}`
+	status, _ = authedJSON(t, "POST", sendURL(ts.HTTPServer.URL, agent.EmailAddress()), key.PlaintextKey, body)
 	if status != 200 {
 		t.Fatalf("send-conv status=%d", status)
 	}
@@ -484,8 +492,8 @@ func TestWebhooksE2E_FilterByLabelsH5(t *testing.T) {
 	registerWebhook(t, ts, agent.UserID, receiver.Server.URL+"/labelled",
 		[]string{"email.sent"}, identity.WebhookFilters{Labels: []string{"urgent"}})
 
-	body := fmt.Sprintf(`{"from":%q,"to":["alice@example.com"],"subject":"unlabelled","body":"x"}`, agent.EmailAddress())
-	if status, _ := authedJSON(t, "POST", ts.HTTPServer.URL+"/api/v1/send", key.PlaintextKey, body); status != 200 {
+	body := `{"to":["alice@example.com"],"subject":"unlabelled","body":"x"}`
+	if status, _ := authedJSON(t, "POST", sendURL(ts.HTTPServer.URL, agent.EmailAddress()), key.PlaintextKey, body); status != 200 {
 		t.Fatalf("send status=%d", status)
 	}
 	tick(t, ts)
@@ -519,8 +527,8 @@ func TestWebhooksE2E_RotationGrace_DualSig(t *testing.T) {
 		t.Fatalf("rotation returned same secret")
 	}
 
-	body := fmt.Sprintf(`{"from":%q,"to":["alice@example.com"],"subject":"rotated","body":"x"}`, agent.EmailAddress())
-	if status, _ := authedJSON(t, "POST", ts.HTTPServer.URL+"/api/v1/send", key.PlaintextKey, body); status != 200 {
+	body := `{"to":["alice@example.com"],"subject":"rotated","body":"x"}`
+	if status, _ := authedJSON(t, "POST", sendURL(ts.HTTPServer.URL, agent.EmailAddress()), key.PlaintextKey, body); status != 200 {
 		t.Fatalf("send status=%d", status)
 	}
 	tick(t, ts)
@@ -562,8 +570,8 @@ func TestWebhooksE2E_DisabledWebhookNoFire(t *testing.T) {
 		t.Fatalf("UpdateWebhook disable: %v", err)
 	}
 
-	body := fmt.Sprintf(`{"from":%q,"to":["alice@example.com"],"subject":"x","body":"x"}`, agent.EmailAddress())
-	if status, _ := authedJSON(t, "POST", ts.HTTPServer.URL+"/api/v1/send", key.PlaintextKey, body); status != 200 {
+	body := `{"to":["alice@example.com"],"subject":"x","body":"x"}`
+	if status, _ := authedJSON(t, "POST", sendURL(ts.HTTPServer.URL, agent.EmailAddress()), key.PlaintextKey, body); status != 200 {
 		t.Fatalf("send status=%d", status)
 	}
 	tick(t, ts)

--- a/internal/httpapi/account.go
+++ b/internal/httpapi/account.go
@@ -35,21 +35,21 @@ type limitsOutput struct{ Body LimitsView }
 
 func (s *Server) registerAccount() {
 	huma.Register(s.API, huma.Operation{
-		OperationID: "getMyLimits", Method: http.MethodGet, Path: "/v1/users/me/limits",
-		Summary: "Get plan limits + usage", Tags: []string{"account"},
-		Description: "The authenticated account's plan caps and current usage.",
+		OperationID: "getAccount", Method: http.MethodGet, Path: "/v1/account",
+		Summary: "Get account: plan limits + usage", Tags: []string{"account"},
+		Description: "The authenticated account's plan caps and current usage. (Deployment discovery — shared domain, slug registration — is the separate public GET /v1/info.)",
 		Security:    []map[string][]string{{"bearer": {}}},
 	}, s.handleGetMyLimits)
 
 	huma.Register(s.API, huma.Operation{
-		OperationID: "exportUserData", Method: http.MethodGet, Path: "/v1/users/me/export",
+		OperationID: "exportAccount", Method: http.MethodGet, Path: "/v1/account/export",
 		Summary: "Export your data (GDPR right-of-access)", Tags: []string{"account"},
 		Description: "A JSON dump of every record the authenticated account owns.",
 		Security:    []map[string][]string{{"bearer": {}}},
 	}, s.handleExportUserData)
 
 	huma.Register(s.API, huma.Operation{
-		OperationID: "deleteAccount", Method: http.MethodDelete, Path: "/v1/users/me",
+		OperationID: "deleteAccount", Method: http.MethodDelete, Path: "/v1/account",
 		Summary: "Delete your account + all data (irreversible)", Tags: []string{"account"},
 		Description: "Permanently deletes the account and cascades all owned data. Requires ?confirm=DELETE.",
 		Security:    []map[string][]string{{"bearer": {}}},

--- a/internal/httpapi/account_extra_test.go
+++ b/internal/httpapi/account_extra_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestExportUserData(t *testing.T) {
 	srv := testServer(t)
-	req, _ := http.NewRequest("GET", srv.URL+"/v1/users/me/export", nil)
+	req, _ := http.NewRequest("GET", srv.URL+"/v1/account/export", nil)
 	req.Header.Set("Authorization", "Bearer good")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -25,7 +25,7 @@ func TestExportUserData(t *testing.T) {
 
 func TestDeleteAccountRequiresConfirm(t *testing.T) {
 	srv := testServer(t)
-	code, body := sendJSON(t, "DELETE", srv.URL+"/v1/users/me", "good", nil)
+	code, body := sendJSON(t, "DELETE", srv.URL+"/v1/account", "good", nil)
 	if code != 400 || errCode(body) != "confirmation_required" {
 		t.Fatalf("want 400 confirmation_required, got %d %v", code, body)
 	}
@@ -33,7 +33,7 @@ func TestDeleteAccountRequiresConfirm(t *testing.T) {
 
 func TestDeleteAccountConfirmed(t *testing.T) {
 	srv := testServer(t)
-	code, _ := sendJSON(t, "DELETE", srv.URL+"/v1/users/me?confirm=DELETE", "good", nil)
+	code, _ := sendJSON(t, "DELETE", srv.URL+"/v1/account?confirm=DELETE", "good", nil)
 	if code != 200 {
 		t.Fatalf("want 200, got %d", code)
 	}
@@ -41,7 +41,7 @@ func TestDeleteAccountConfirmed(t *testing.T) {
 
 func TestDeleteAccountUnauthorized(t *testing.T) {
 	srv := testServer(t)
-	code, _ := sendJSON(t, "DELETE", srv.URL+"/v1/users/me?confirm=DELETE", "", nil)
+	code, _ := sendJSON(t, "DELETE", srv.URL+"/v1/account?confirm=DELETE", "", nil)
 	if code != 401 {
 		t.Fatalf("want 401, got %d", code)
 	}

--- a/internal/httpapi/account_test.go
+++ b/internal/httpapi/account_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestGetMyLimits(t *testing.T) {
 	srv := testServer(t)
-	code, body := getJSON(t, srv.URL+"/v1/users/me/limits", "good")
+	code, body := getJSON(t, srv.URL+"/v1/account", "good")
 	if code != 200 {
 		t.Fatalf("status %d body %v", code, body)
 	}
@@ -23,7 +23,7 @@ func TestGetMyLimits(t *testing.T) {
 
 func TestGetMyLimitsUnauthorized(t *testing.T) {
 	srv := testServer(t)
-	code, _ := getJSON(t, srv.URL+"/v1/users/me/limits", "")
+	code, _ := getJSON(t, srv.URL+"/v1/account", "")
 	if code != 401 {
 		t.Fatalf("want 401, got %d", code)
 	}

--- a/internal/httpapi/outbound.go
+++ b/internal/httpapi/outbound.go
@@ -35,7 +35,8 @@ type SendEmailRequest struct {
 	Attachments    []outbound.Attachment `json:"attachments,omitempty"`
 }
 
-type sendInput struct {
+type createMessageInput struct {
+	Address        string `path:"address"`
 	RawBody        []byte
 	IdempotencyKey string `header:"Idempotency-Key"`
 	Body           SendEmailRequest
@@ -48,11 +49,11 @@ type sendOutput struct {
 
 func (s *Server) registerOutbound() {
 	huma.Register(s.API, huma.Operation{
-		OperationID: "sendMessage", Method: http.MethodPost, Path: "/v1/send",
+		OperationID: "sendMessage", Method: http.MethodPost, Path: "/v1/agents/{address}/messages",
 		Summary: "Send a new email", Tags: []string{"messages"},
-		Description: "Send a new email from an agent you own. 202 + pending_approval when the agent has HITL enabled. Honors Idempotency-Key.",
+		Description: "Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_approval when the agent has HITL enabled. Honors Idempotency-Key.",
 		Security:    []map[string][]string{{"bearer": {}}},
-	}, s.handleSend)
+	}, s.handleCreateMessage)
 
 	huma.Register(s.API, huma.Operation{
 		OperationID: "replyToMessage", Method: http.MethodPost, Path: "/v1/agents/{address}/messages/{id}/reply",
@@ -266,27 +267,6 @@ func (s *Server) validateOutboundBody(subject, body string, to, cc, bcc []string
 	return nil
 }
 
-// resolveSendAgent resolves the sending agent from the explicit `from`
-// address, or auto-selects when the caller owns exactly one agent (legacy
-// behavior preserved for /send in Slice 1).
-func (s *Server) resolveSendAgent(ctx context.Context, user *identity.User, from string) (*identity.AgentIdentity, *ErrorEnvelope) {
-	if from != "" {
-		ag, err := s.deps.GetAgent(ctx, identity.NormalizeEmail(from))
-		if err != nil || ag == nil || ag.UserID != user.ID {
-			return nil, NewError(http.StatusBadRequest, "invalid_from", "invalid from: agent not found")
-		}
-		return ag, nil
-	}
-	agents, err := s.deps.ListAgents(ctx, user.ID)
-	if err != nil || len(agents) == 0 {
-		return nil, NewError(http.StatusBadRequest, "invalid_request", "from field required (no agents found)")
-	}
-	if len(agents) > 1 {
-		return nil, NewError(http.StatusBadRequest, "invalid_request", "from field required when user has multiple agents")
-	}
-	return &agents[0], nil
-}
-
 // deliver runs the domain-verified + enforce-cap checks then DeliverOutbound
 // under the idempotency handshake, mapping the OutboundResult to the wire view.
 func (s *Server) deliver(ctx context.Context, user *identity.User, ag *identity.AgentIdentity, req outbound.SendRequest, msgType, replyTo, route, idemKey string, rawBody []byte) (*sendOutput, error) {
@@ -344,22 +324,33 @@ func (s *Server) checkSendLimit(agentID string) *ErrorEnvelope {
 		WithDetails(map[string]any{"retry_after_seconds": secs})
 }
 
-func (s *Server) handleSend(ctx context.Context, in *sendInput) (*sendOutput, error) {
-	user, err := s.requireUser(ctx)
+func (s *Server) handleCreateMessage(ctx context.Context, in *createMessageInput) (*sendOutput, error) {
+	ag, err := s.resolveOwnedAgent(ctx, in.Address)
 	if err != nil {
 		return nil, err
+	}
+	user, uerr := s.requireUser(ctx)
+	if uerr != nil {
+		return nil, uerr
 	}
 	b := in.Body
 	if env := s.validateOutboundBody(b.Subject, b.Body, b.To, b.CC, b.BCC, b.ConversationID); env != nil {
 		return nil, env
 	}
-	ag, env := s.resolveSendAgent(ctx, user, b.From)
-	if env != nil {
-		return nil, env
+	// The sender is the path agent. A supplied `from` must be the agent's own
+	// address — never a different identity (no spoofing; decision 3: `from`
+	// defaults to the agent address). Custom-domain display From is decision 4.
+	if b.From != "" && identity.NormalizeEmail(b.From) != identity.NormalizeEmail(ag.EmailAddress()) {
+		return nil, NewError(http.StatusBadRequest, "invalid_from", "from must be the agent's own address")
 	}
 	req := outbound.SendRequest{
-		From: b.From, To: b.To, CC: b.CC, BCC: b.BCC, Subject: b.Subject,
+		From: ag.EmailAddress(), To: b.To, CC: b.CC, BCC: b.BCC, Subject: b.Subject,
 		Body: b.Body, HTMLBody: b.HTMLBody, ConversationID: b.ConversationID, Attachments: b.Attachments,
 	}
-	return s.deliver(ctx, user, ag, req, "send", "", "/v1/send", in.IdempotencyKey, in.RawBody)
+	// The agent moved from the body (`from`) to the path, so fold the agent id
+	// into the idempotency route — otherwise two agents owned by the same user
+	// could collide on an identical key+body (the body hash alone no longer
+	// separates them).
+	route := "/v1/agents/" + ag.ID + "/messages"
+	return s.deliver(ctx, user, ag, req, "send", "", route, in.IdempotencyKey, in.RawBody)
 }

--- a/internal/httpapi/outbound.go
+++ b/internal/httpapi/outbound.go
@@ -22,6 +22,11 @@ type SendResultView struct {
 	ApprovalExpiresAt *time.Time `json:"approval_expires_at,omitempty"`
 }
 
+// maxOutboundBytes caps the outbound request body (send/reply/forward). It
+// matches the legacy 25 MB limit so attachments keep working — Huma's default
+// is only 1 MiB, which would silently reject anything but tiny mail.
+const maxOutboundBytes = 25 * 1024 * 1024
+
 // SendEmailRequest mirrors the legacy /send body.
 type SendEmailRequest struct {
 	From           string                `json:"from,omitempty"`
@@ -51,22 +56,25 @@ func (s *Server) registerOutbound() {
 	huma.Register(s.API, huma.Operation{
 		OperationID: "sendMessage", Method: http.MethodPost, Path: "/v1/agents/{address}/messages",
 		Summary: "Send a new email", Tags: []string{"messages"},
-		Description: "Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_approval when the agent has HITL enabled. Honors Idempotency-Key.",
-		Security:    []map[string][]string{{"bearer": {}}},
+		Description:  "Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_approval when the agent has HITL enabled. Honors Idempotency-Key.",
+		Security:     []map[string][]string{{"bearer": {}}},
+		MaxBodyBytes: maxOutboundBytes,
 	}, s.handleCreateMessage)
 
 	huma.Register(s.API, huma.Operation{
 		OperationID: "replyToMessage", Method: http.MethodPost, Path: "/v1/agents/{address}/messages/{id}/reply",
 		Summary: "Reply to a message", Tags: []string{"messages"},
-		Description: "Reply to an inbound message; recipients/threading are derived from the original. 202 when held for HITL.",
-		Security:    []map[string][]string{{"bearer": {}}},
+		Description:  "Reply to an inbound message; recipients/threading are derived from the original. 202 when held for HITL.",
+		Security:     []map[string][]string{{"bearer": {}}},
+		MaxBodyBytes: maxOutboundBytes,
 	}, s.handleReply)
 
 	huma.Register(s.API, huma.Operation{
 		OperationID: "forwardMessage", Method: http.MethodPost, Path: "/v1/agents/{address}/messages/{id}/forward",
 		Summary: "Forward a message", Tags: []string{"messages"},
-		Description: "Forward an inbound message to new recipients; the original is quoted. 202 when held for HITL.",
-		Security:    []map[string][]string{{"bearer": {}}},
+		Description:  "Forward an inbound message to new recipients; the original is quoted. 202 when held for HITL.",
+		Security:     []map[string][]string{{"bearer": {}}},
+		MaxBodyBytes: maxOutboundBytes,
 	}, s.handleForward)
 
 	huma.Register(s.API, huma.Operation{

--- a/internal/httpapi/outbound_idem_test.go
+++ b/internal/httpapi/outbound_idem_test.go
@@ -1,0 +1,85 @@
+package httpapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/agent"
+	"github.com/Mnexa-AI/e2a/internal/idempotency"
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/outbound"
+)
+
+// pathRecordingIdem captures the route (path) handed to Claim so a test can
+// assert that two agents land under distinct idempotency routes.
+type pathRecordingIdem struct{ paths []string }
+
+func (f *pathRecordingIdem) Claim(ctx context.Context, userID, key, path, bodyHash string) (idempotency.ClaimResult, error) {
+	f.paths = append(f.paths, path)
+	return idempotency.ClaimResult{Outcome: idempotency.OutcomeAcquired}, nil
+}
+func (f *pathRecordingIdem) Complete(ctx context.Context, userID, key string, resp idempotency.CachedResponse) error {
+	return nil
+}
+func (f *pathRecordingIdem) Release(ctx context.Context, userID, key string) error { return nil }
+
+// TestSendIdempotencyRouteIncludesAgent is the regression for the cross-agent
+// replay hole introduced by moving the sender from the body (`from`) to the
+// path: two agents owned by the same user, reusing ONE Idempotency-Key + an
+// identical body, must not collide. Since the agent is no longer in the body,
+// the dedup body-hash alone wouldn't separate them — handleCreateMessage folds
+// the agent id into the idempotency route, so the two claims land under
+// different routes (→ different hash → a mismatch/422, never agent A's cached
+// response replayed for agent B).
+func TestSendIdempotencyRouteIncludesAgent(t *testing.T) {
+	rec := &pathRecordingIdem{}
+	agents := map[string]*identity.AgentIdentity{
+		"a@acme.com": {ID: "a@acme.com", Email: "a@acme.com", UserID: "u_1", DomainVerified: true},
+		"b@acme.com": {ID: "b@acme.com", Email: "b@acme.com", UserID: "u_1", DomainVerified: true},
+	}
+	srv := httptest.NewServer(New(Deps{
+		Authenticator: func(r *http.Request) (*identity.User, error) { return &identity.User{ID: "u_1"}, nil },
+		GetAgent: func(ctx context.Context, address string) (*identity.AgentIdentity, error) {
+			if a, ok := agents[address]; ok {
+				return a, nil
+			}
+			return nil, errors.New("not found")
+		},
+		Idempotency: rec,
+		DeliverOutbound: func(ctx context.Context, u *identity.User, ag *identity.AgentIdentity, req outbound.SendRequest, mt, rt string) (*agent.OutboundResult, *agent.OutboundError) {
+			return &agent.OutboundResult{MessageID: "m", Method: "smtp"}, nil
+		},
+	}))
+	t.Cleanup(srv.Close)
+
+	send := func(addr string) {
+		b, _ := json.Marshal(map[string]any{"to": []string{"x@y.com"}, "subject": "Hi", "body": "hello"})
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/agents/"+addr+"/messages", bytes.NewReader(b))
+		req.Header.Set("Authorization", "Bearer good")
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Idempotency-Key", "dupkey") // SAME key for both agents
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+	}
+	send("a%40acme.com")
+	send("b%40acme.com")
+
+	if len(rec.paths) != 2 {
+		t.Fatalf("want 2 idempotency claims, got %d (%v)", len(rec.paths), rec.paths)
+	}
+	if rec.paths[0] == rec.paths[1] {
+		t.Fatalf("two agents reusing one key must claim under DIFFERENT routes; both = %q", rec.paths[0])
+	}
+	if !strings.Contains(rec.paths[0], "a@acme.com") || !strings.Contains(rec.paths[1], "b@acme.com") {
+		t.Errorf("idempotency route should fold in the agent id, got %v", rec.paths)
+	}
+}

--- a/internal/httpapi/outbound_test.go
+++ b/internal/httpapi/outbound_test.go
@@ -1,6 +1,9 @@
 package httpapi
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // sendURL is POST /v1/agents/{address}/messages for the test agent. The sender
 // is the path agent (decision 3 — explicit operation, not a body `from`).
@@ -118,6 +121,23 @@ func TestSendOverCap(t *testing.T) {
 	})
 	if code == 402 {
 		t.Fatalf("u_1 is under cap; should not 402")
+	}
+}
+
+// TestSendLargeBodyAccepted guards the outbound body cap: Huma's default is
+// 1 MiB, which would 413 attachment-bearing mail. The send op raises it to
+// maxOutboundBytes (25 MB), so a >1 MiB body is accepted, not rejected.
+func TestSendLargeBodyAccepted(t *testing.T) {
+	srv := testServer(t)
+	big := strings.Repeat("a", 1500*1024) // ~1.5 MiB — over Huma's 1 MiB default
+	code, body := postJSON(t, srv.URL+sendURL, "good", map[string]any{
+		"to": []string{"alice@x.com"}, "subject": "Hi", "body": big,
+	})
+	if code == 413 {
+		t.Fatalf("a 1.5 MiB body must be accepted (cap raised to 25 MB), got 413")
+	}
+	if code != 200 || body["status"] != "sent" {
+		t.Fatalf("want 200 sent for a large-but-under-cap body, got %d %v", code, body)
 	}
 }
 

--- a/internal/httpapi/outbound_test.go
+++ b/internal/httpapi/outbound_test.go
@@ -2,31 +2,24 @@ package httpapi
 
 import "testing"
 
+// sendURL is POST /v1/agents/{address}/messages for the test agent. The sender
+// is the path agent (decision 3 — explicit operation, not a body `from`).
+const sendURL = "/v1/agents/support%40acme.com/messages"
+
 func TestSendSent(t *testing.T) {
 	srv := testServer(t)
-	code, body := postJSON(t, srv.URL+"/v1/send", "good", map[string]any{
-		"from": "support@acme.com", "to": []string{"alice@x.com"}, "subject": "Hi", "body": "hello",
+	code, body := postJSON(t, srv.URL+sendURL, "good", map[string]any{
+		"to": []string{"alice@x.com"}, "subject": "Hi", "body": "hello",
 	})
 	if code != 200 || body["status"] != "sent" || body["message_id"] != "msg_sent_1" || body["method"] != "smtp" {
 		t.Fatalf("want 200 sent, got %d %v", code, body)
 	}
 }
 
-func TestSendAutoResolveSingleAgent(t *testing.T) {
-	srv := testServer(t)
-	// No `from` — the caller owns exactly one agent, so it is auto-selected.
-	code, body := postJSON(t, srv.URL+"/v1/send", "good", map[string]any{
-		"to": []string{"alice@x.com"}, "subject": "Hi", "body": "hello",
-	})
-	if code != 200 || body["status"] != "sent" {
-		t.Fatalf("want 200 sent (auto-resolve), got %d %v", code, body)
-	}
-}
-
 func TestSendHeldForApproval(t *testing.T) {
 	srv := testServer(t)
-	code, body := postJSON(t, srv.URL+"/v1/send", "good", map[string]any{
-		"from": "support@acme.com", "to": []string{"alice@x.com"}, "subject": "HOLD please", "body": "hello",
+	code, body := postJSON(t, srv.URL+sendURL, "good", map[string]any{
+		"to": []string{"alice@x.com"}, "subject": "HOLD please", "body": "hello",
 	})
 	if code != 202 || body["status"] != "pending_approval" || body["message_id"] != "msg_pending_1" {
 		t.Fatalf("want 202 pending_approval, got %d %v", code, body)
@@ -41,8 +34,8 @@ func TestSendHeldForApproval(t *testing.T) {
 
 func TestSendMissingSubjectBody(t *testing.T) {
 	srv := testServer(t)
-	code, body := postJSON(t, srv.URL+"/v1/send", "good", map[string]any{
-		"from": "support@acme.com", "to": []string{"alice@x.com"}, "subject": "", "body": "",
+	code, body := postJSON(t, srv.URL+sendURL, "good", map[string]any{
+		"to": []string{"alice@x.com"}, "subject": "", "body": "",
 	})
 	if code != 400 || errCode(body) != "invalid_request" {
 		t.Fatalf("want 400 invalid_request, got %d %v", code, body)
@@ -51,8 +44,8 @@ func TestSendMissingSubjectBody(t *testing.T) {
 
 func TestSendCRLFSubjectRejected(t *testing.T) {
 	srv := testServer(t)
-	code, body := postJSON(t, srv.URL+"/v1/send", "good", map[string]any{
-		"from": "support@acme.com", "to": []string{"alice@x.com"}, "subject": "a\r\nInjected: x", "body": "hi",
+	code, body := postJSON(t, srv.URL+sendURL, "good", map[string]any{
+		"to": []string{"alice@x.com"}, "subject": "a\r\nInjected: x", "body": "hi",
 	})
 	if code != 400 {
 		t.Fatalf("want 400 for CRLF subject, got %d %v", code, body)
@@ -61,8 +54,8 @@ func TestSendCRLFSubjectRejected(t *testing.T) {
 
 func TestSendNoRecipients(t *testing.T) {
 	srv := testServer(t)
-	code, body := postJSON(t, srv.URL+"/v1/send", "good", map[string]any{
-		"from": "support@acme.com", "subject": "Hi", "body": "hello",
+	code, body := postJSON(t, srv.URL+sendURL, "good", map[string]any{
+		"subject": "Hi", "body": "hello",
 	})
 	if code != 400 {
 		t.Fatalf("want 400 no recipients, got %d %v", code, body)
@@ -71,17 +64,19 @@ func TestSendNoRecipients(t *testing.T) {
 
 func TestSendInvalidRecipient(t *testing.T) {
 	srv := testServer(t)
-	code, body := postJSON(t, srv.URL+"/v1/send", "good", map[string]any{
-		"from": "support@acme.com", "to": []string{"not-an-email"}, "subject": "Hi", "body": "hello",
+	code, body := postJSON(t, srv.URL+sendURL, "good", map[string]any{
+		"to": []string{"not-an-email"}, "subject": "Hi", "body": "hello",
 	})
 	if code != 400 || errCode(body) != "invalid_recipient" {
 		t.Fatalf("want 400 invalid_recipient, got %d %v", code, body)
 	}
 }
 
-func TestSendInvalidFrom(t *testing.T) {
+// TestSendFromMismatchRejected: the sender is the path agent; a `from` that is
+// not the agent's own address is rejected (no spoofing as another identity).
+func TestSendFromMismatchRejected(t *testing.T) {
 	srv := testServer(t)
-	code, body := postJSON(t, srv.URL+"/v1/send", "good", map[string]any{
+	code, body := postJSON(t, srv.URL+sendURL, "good", map[string]any{
 		"from": "stranger@x.com", "to": []string{"alice@x.com"}, "subject": "Hi", "body": "hello",
 	})
 	if code != 400 || errCode(body) != "invalid_from" {
@@ -89,16 +84,37 @@ func TestSendInvalidFrom(t *testing.T) {
 	}
 }
 
+// TestSendFromMatchingAgentOK: a `from` equal to the agent's own address is
+// accepted (it's the default, just stated explicitly).
+func TestSendFromMatchingAgentOK(t *testing.T) {
+	srv := testServer(t)
+	code, body := postJSON(t, srv.URL+sendURL, "good", map[string]any{
+		"from": "support@acme.com", "to": []string{"alice@x.com"}, "subject": "Hi", "body": "hello",
+	})
+	if code != 200 || body["status"] != "sent" {
+		t.Fatalf("want 200 sent, got %d %v", code, body)
+	}
+}
+
+// TestSendNotOwnedAgent: sending through an agent the caller does not own is a
+// 403 (resolveOwnedAgent), never a cross-tenant send.
+func TestSendNotOwnedAgent(t *testing.T) {
+	srv := testServer(t)
+	code, _ := postJSON(t, srv.URL+"/v1/agents/other%40nope.com/messages", "good", map[string]any{
+		"to": []string{"alice@x.com"}, "subject": "Hi", "body": "hello",
+	})
+	if code != 403 {
+		t.Fatalf("want 403 for an unowned agent, got %d", code)
+	}
+}
+
 func TestSendOverCap(t *testing.T) {
 	srv := testServer(t)
-	// overcap principal owns no agents in ListAgents, so use explicit from.
-	// resolveSendAgent(from) -> GetAgent(support@acme.com) is owned by u_1,
-	// not u_overcap, so it 400s before the cap. Use the auto-resolve path
-	// is also u_1-only. The cap check is covered by the agent-create/domain
-	// over-cap tests; here we assert the message path wires EnforceMessageSend
-	// by checking a successful send does NOT 402 for u_1.
-	code, _ := postJSON(t, srv.URL+"/v1/send", "good", map[string]any{
-		"from": "support@acme.com", "to": []string{"alice@x.com"}, "subject": "Hi", "body": "hello",
+	// The cap check is covered by the agent-create/domain over-cap tests; here
+	// we assert the message path wires EnforceMessageSend by checking a
+	// successful send does NOT 402 for u_1.
+	code, _ := postJSON(t, srv.URL+sendURL, "good", map[string]any{
+		"to": []string{"alice@x.com"}, "subject": "Hi", "body": "hello",
 	})
 	if code == 402 {
 		t.Fatalf("u_1 is under cap; should not 402")
@@ -107,7 +123,7 @@ func TestSendOverCap(t *testing.T) {
 
 func TestSendUnauthorized(t *testing.T) {
 	srv := testServer(t)
-	code, _ := postJSON(t, srv.URL+"/v1/send", "", map[string]any{
+	code, _ := postJSON(t, srv.URL+sendURL, "", map[string]any{
 		"to": []string{"alice@x.com"}, "subject": "Hi", "body": "hello",
 	})
 	if code != 401 {

--- a/internal/httpapi/ratelimit.go
+++ b/internal/httpapi/ratelimit.go
@@ -40,9 +40,9 @@ var pollLimitedOps = map[string]bool{
 // reads and the per-IP registration limiter on agent create, and stamps the
 // IETF RateLimit-Limit/Remaining/Reset headers (plus Retry-After on a 429) on
 // the response. The per-agent SEND limiter is enforced inside the outbound
-// handlers instead: its key is the resolved sender agent, which is only known
-// after the request body is parsed (POST /v1/send carries the sender in the
-// body, not the path), so it cannot be classified from the operation alone.
+// handlers instead: its key is the *resolved owned* agent (after the
+// resolveOwnedAgent ownership check), which this middleware doesn't perform —
+// so the send limit is applied in deliver()/the outbound handlers, not here.
 func (s *Server) rateLimit(ctx huma.Context, next func(huma.Context)) {
 	op := ctx.Operation()
 	if op == nil {

--- a/internal/httpapi/ratelimit_test.go
+++ b/internal/httpapi/ratelimit_test.go
@@ -191,8 +191,8 @@ func serverWithSendLimit(t *testing.T) *httptest.Server {
 
 func TestSendRateLimited(t *testing.T) {
 	srv := serverWithSendLimit(t)
-	code, body := postJSON(t, srv.URL+"/v1/send", "good", map[string]any{
-		"from": "support@acme.com", "to": []string{"a@x.com"}, "subject": "Hi", "body": "hello",
+	code, body := postJSON(t, srv.URL+"/v1/agents/support%40acme.com/messages", "good", map[string]any{
+		"to": []string{"a@x.com"}, "subject": "Hi", "body": "hello",
 	})
 	if code != 429 || errCode(body) != "rate_limited" {
 		t.Fatalf("want 429 rate_limited, got %d %v", code, body)

--- a/internal/httpapi/spec_test.go
+++ b/internal/httpapi/spec_test.go
@@ -114,6 +114,15 @@ func TestSpecGeneratedFromHandlers(t *testing.T) {
 			t.Errorf("generated spec missing %q", want)
 		}
 	}
+
+	// Retired routes must NOT reappear. /v1/send was relocated to
+	// POST /v1/agents/{address}/messages in Slice 2 (decision 3); guard against
+	// a regression that re-registers it.
+	for _, gone := range []string{"/v1/send"} {
+		if strings.Contains(spec, gone) {
+			t.Errorf("generated spec still contains retired route %q", gone)
+		}
+	}
 }
 
 // TestSpecServedOverHTTP confirms the spec is reachable at the versioned

--- a/internal/httpapi/spec_test.go
+++ b/internal/httpapi/spec_test.go
@@ -83,8 +83,8 @@ func TestSpecGeneratedFromHandlers(t *testing.T) {
 		"operationId: listEvents",
 		"operationId: getEvent",
 		"operationId: redeliverEvent",
-		"operationId: getMyLimits",
-		"operationId: exportUserData",
+		"operationId: getAccount",
+		"operationId: exportAccount",
 		"operationId: deleteAccount",
 		"operationId: sendMessage",
 		"operationId: replyToMessage",
@@ -92,7 +92,7 @@ func TestSpecGeneratedFromHandlers(t *testing.T) {
 		"operationId: approveMessage",
 		"operationId: rejectMessage",
 		"operationId: testAgent",
-		"/v1/users/me/limits",
+		"/v1/account",
 		"/v1/events",
 		"/v1/events/{id}",
 		"/v1/webhooks",
@@ -115,10 +115,11 @@ func TestSpecGeneratedFromHandlers(t *testing.T) {
 		}
 	}
 
-	// Retired routes must NOT reappear. /v1/send was relocated to
-	// POST /v1/agents/{address}/messages in Slice 2 (decision 3); guard against
-	// a regression that re-registers it.
-	for _, gone := range []string{"/v1/send"} {
+	// Retired routes must NOT reappear: /v1/send relocated to
+	// POST /v1/agents/{address}/messages (decision 3); the /v1/users/me/* cluster
+	// was renamed to /v1/account (decision 8). Guard against a regression that
+	// re-registers either.
+	for _, gone := range []string{"/v1/send", "/v1/users/me"} {
 		if strings.Contains(spec, gone) {
 			t.Errorf("generated spec still contains retired route %q", gone)
 		}

--- a/internal/httpapi/spec_test.go
+++ b/internal/httpapi/spec_test.go
@@ -92,7 +92,6 @@ func TestSpecGeneratedFromHandlers(t *testing.T) {
 		"operationId: approveMessage",
 		"operationId: rejectMessage",
 		"operationId: testAgent",
-		"/v1/send",
 		"/v1/users/me/limits",
 		"/v1/events",
 		"/v1/events/{id}",

--- a/internal/testutil/events_harness.go
+++ b/internal/testutil/events_harness.go
@@ -3,10 +3,13 @@ package testutil
 import (
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/Mnexa-AI/e2a/internal/agent"
+	"github.com/Mnexa-AI/e2a/internal/apiserver"
 	"github.com/Mnexa-AI/e2a/internal/idempotency"
 	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/limits"
 	"github.com/Mnexa-AI/e2a/internal/outbound"
 	"github.com/Mnexa-AI/e2a/internal/usage"
 	"github.com/Mnexa-AI/e2a/internal/webhook"
@@ -16,9 +19,12 @@ import (
 )
 
 // NewEventsAPIHarness spins up a minimal httptest server with the
-// agent.API wired for the slice 6/7 events API. Used by the
-// internal/e2e events tests that need to hit /api/v1/events and
-// /api/v1/events/{id}/redeliver against a real HTTP layer.
+// agent.API wired for the slice 6/7 events API. The legacy gorilla/mux
+// surface is wrapped by the typed /v1 chi root (the same apiserver
+// builder prod + TestServer use), so the e2e events tests can hit the
+// real /v1 handlers for ported routes (events, webhooks, agents) while
+// still-legacy routes (e.g. /api/v1/webhooks/{id}/redeliver-since) fall
+// through to the mux.
 //
 // Returns the *httptest.Server; caller must Close() on cleanup.
 func NewEventsAPIHarness(t *testing.T, pool *pgxpool.Pool, store *identity.Store, outbox webhookpub.Outbox) *httptest.Server {
@@ -27,15 +33,38 @@ func NewEventsAPIHarness(t *testing.T, pool *pgxpool.Pool, store *identity.Store
 	smtpRelay := outbound.NewSMTPRelay(nil)
 	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
 	noopUsage := usage.NewNoopUsageTracker()
+	subscriberStore := webhook.NewSubscriberStore(pool)
+	idempotencyStore := idempotency.NewStore(pool)
+	usageStore := usage.NewStore(pool)
+	// Generous caps — e2e exercises behavior, not quota enforcement.
+	enforcer := limits.NewEnforcer(limits.NewStore(pool), usageStore, limits.Defaults{
+		PlanCode: "test", MaxAgents: 100000, MaxDomains: 100000,
+		MaxMessagesMonth: 100000, MaxStorageBytes: 1 << 40,
+	}, time.Minute)
+
 	api := agent.NewAPI(store, sender, smtpRelay, nil, noopUsage, "e2a.dev", "test.e2a.dev", "agents.e2a.dev", "", false)
-	api.SetIdempotencyStore(idempotency.NewStore(pool))
-	api.SetSubscriberStore(webhook.NewSubscriberStore(pool))
+	api.SetIdempotencyStore(idempotencyStore)
+	api.SetSubscriberStore(subscriberStore)
 	api.SetPublisher(webhookpub.New(store, webhookpub.NewDBInserter(pool), webhookpub.StaticFlag(true)))
+	api.SetEnforcer(enforcer)
+	api.SetUsageStore(usageStore)
 	api.SetOutbox(outbox)
 	api.SetPoolForEvents(pool)
 
 	router := mux.NewRouter()
 	api.RegisterRoutes(router)
-	srv := httptest.NewServer(router)
+
+	// Wrap the legacy mux with the typed /v1 surface so the events e2e
+	// tests exercise the real /v1 handlers; still-legacy /api/v1 routes
+	// fall through to the mux.
+	v1 := apiserver.New(apiserver.Params{
+		API: api, Store: store, Enforcer: enforcer, UsageStore: usageStore,
+		SubscriberStore: subscriberStore, Idempotency: idempotencyStore, Pool: pool,
+		SMTPDomain: "test.e2a.dev", SharedDomain: "agents.e2a.dev",
+		PublicURL: "http://127.0.0.1", Production: false,
+		Legacy: router,
+	})
+
+	srv := httptest.NewServer(v1)
 	return srv
 }

--- a/internal/testutil/server.go
+++ b/internal/testutil/server.go
@@ -12,10 +12,12 @@ import (
 	"time"
 
 	"github.com/Mnexa-AI/e2a/internal/agent"
+	"github.com/Mnexa-AI/e2a/internal/apiserver"
 	"github.com/Mnexa-AI/e2a/internal/config"
 	"github.com/Mnexa-AI/e2a/internal/headers"
 	"github.com/Mnexa-AI/e2a/internal/idempotency"
 	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/limits"
 	"github.com/Mnexa-AI/e2a/internal/outbound"
 	"github.com/Mnexa-AI/e2a/internal/relay"
 	"github.com/Mnexa-AI/e2a/internal/usage"
@@ -108,10 +110,19 @@ func TestServer(t *testing.T, pool *pgxpool.Pool, opts ...TestServerOption) *E2A
 	// HTTP server
 	router := mux.NewRouter()
 	noopUsage := usage.NewNoopUsageTracker()
+	usageStore := usage.NewStore(pool)
+	// Generous caps — e2e exercises behavior, not quota enforcement.
+	enforcer := limits.NewEnforcer(limits.NewStore(pool), usageStore, limits.Defaults{
+		PlanCode: "test", MaxAgents: 100000, MaxDomains: 100000,
+		MaxMessagesMonth: 100000, MaxStorageBytes: 1 << 40,
+	}, time.Minute)
+	idempotencyStore := idempotency.NewStore(pool)
 	api := agent.NewAPI(store, sender, smtpRelay, nil, noopUsage, "e2a.dev", "test.e2a.dev", "agents.e2a.dev", "", false)
-	api.SetIdempotencyStore(idempotency.NewStore(pool))
+	api.SetIdempotencyStore(idempotencyStore)
 	api.SetSubscriberStore(subscriberStore)
 	api.SetPublisher(publisher)
+	api.SetEnforcer(enforcer)
+	api.SetUsageStore(usageStore)
 	api.RegisterRoutes(router)
 
 	// WebSocket route for local-mode agents
@@ -119,7 +130,18 @@ func TestServer(t *testing.T, pool *pgxpool.Pool, opts ...TestServerOption) *E2A
 	wsHandler := ws.NewHandler(wsHub, store)
 	api.RegisterWSRoute(router, wsHandler.Handle)
 
-	httpServer := httptest.NewServer(router)
+	// Wrap the legacy mux with the typed /v1 surface (the same apiserver
+	// builder prod + StartContractServer use) so e2e exercises the real /v1
+	// handler; the still-legacy /api/v1 routes fall through to the mux.
+	v1 := apiserver.New(apiserver.Params{
+		API: api, Store: store, Enforcer: enforcer, UsageStore: usageStore,
+		SubscriberStore: subscriberStore, Idempotency: idempotencyStore, Pool: pool,
+		SMTPDomain: "test.e2a.dev", SharedDomain: "agents.e2a.dev",
+		PublicURL: "http://127.0.0.1", Production: false,
+		Legacy: router, WSHandle: wsHandler.ServeWithEmail,
+	})
+
+	httpServer := httptest.NewServer(v1)
 
 	// SMTP server on random port
 	smtpListener, err := net.Listen("tcp", "127.0.0.1:0")

--- a/tests/contract/scenarios.yaml
+++ b/tests/contract/scenarios.yaml
@@ -271,7 +271,7 @@ scenarios:
       - id: no_auth_send
         action: request
         method: POST
-        path: /v1/send
+        path: /v1/agents/bot@example.com/messages
         body: {}
         expect:
           status: 401
@@ -313,7 +313,7 @@ scenarios:
       - id: invalid_key_send
         action: request
         method: POST
-        path: /v1/send
+        path: /v1/agents/bot@example.com/messages
         body: {}
         expect:
           status: 401
@@ -433,9 +433,8 @@ scenarios:
       - id: send_held
         action: request
         method: POST
-        path: /v1/send
+        path: /v1/agents/{agent_email}/messages
         body:
-          from: "{agent_email}"
           to:
             - alice@example.com
           subject: Hold me
@@ -489,9 +488,8 @@ scenarios:
       - id: send_held
         action: request
         method: POST
-        path: /v1/send
+        path: /v1/agents/{agent_email}/messages
         body:
-          from: "{agent_email}"
           to:
             - alice@example.com
           subject: To be rejected
@@ -561,9 +559,8 @@ scenarios:
       - id: outbound_held
         action: request
         method: POST
-        path: /v1/send
+        path: /v1/agents/{agent_email}/messages
         body:
-          from: "{agent_email}"
           to:
             - someone@example.com
           subject: an outbound row


### PR DESCRIPTION
## Slice 2 — resource cleanup

The clean-contract pieces of the redesign's Slice 2, plus the design rationale and the e2e migration. One branch / one PR per the implement workflow.

### Landed
- **Outbound under the agent** — `send` → `POST /v1/agents/{address}/messages` (sender = path agent; `from` validated, no spoof; agent folded into the idempotency route); `/v1/send` retired. Reply/forward already nested. **Decision 3** (explicit per-operation routes, *not* a body-discriminated endpoint — an LLM dropping an optional `in_reply_to` would silently turn a reply into a new send).
- **`/account`** — `/v1/users/me/{limits,export}` + `DELETE /v1/users/me` → `GET /v1/account`, `GET /v1/account/export`, `DELETE /v1/account`. `GET /v1/info` stays a **separate public** deployment-discovery endpoint (**decision 8** — account data ≠ deployment metadata).
- **HITL** — kept the **two explicit `approve`/`reject`** transitions (**decision 5 revised** from one `approval{decision}`, same reasoning as decision 3). Done-as-shipped.
- **e2e → `/v1`** — `testutil.TestServer` + `NewEventsAPIHarness` rewired to serve `/v1` (shared `apiserver.New`); all `internal/e2e` calls repointed + reshaped to the `/v1` contract. **`make test` (`-tags integration -p 1`) is green again** (the legacy-`/api/v1` breakage is resolved).
- **Design rationale written in** — decisions 3 (explicit outbound), 5 (explicit HITL), 7 (cursor-vs-offset pagination), 8 (`/account` vs public `/info`).
- **Review** — the send relocation had a full independent + adversarial pass (no security defects; from-spoof refuted, idempotency fix confirmed); body-cap + spec-retirement-guard findings fixed. `/account` (path rename) and the e2e migration are mechanical and verified.

### Verification
`internal/httpapi`, `internal/ratelimit`, `internal/agent`, `tests/contract`, `internal/e2e` all green (`-p 1`, `-tags integration`); real-binary **Mailpit e2e** of the new send path (200 sent → mail captured; `/v1/send` 404). Only the pre-existing `internal/webhook` flake remains (red on clean `main` too).

### Deferred (tracked)
- **single-message-address** → **Slice 4b**: removing flat `/api/v1/messages/{id}` needs the unified read to expose *both* the held-draft `body_text`/`body_html` and the sent/inbound `raw_message` — that message-read shape is decision 9's parsed-view work; doing it now designs it twice. Flat path stays as strangler residue until then.
- **SDK/CLI/MCP `/v1` port** (incl. this `send` path) — the separate consumer PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)