### PR TITLE
feat(api-v1): slice 4b — delivery feedback (SES/SNS) + suppression list

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -737,6 +737,8 @@ components:
         created_at:
           format: date-time
           type: string
+        delivery_detail:
+          type: string
         delivery_status:
           type: string
         direction:
@@ -784,6 +786,8 @@ components:
           type: string
         sender:
           type: string
+        sent_as:
+          type: string
         size_bytes:
           format: int64
           type: integer
@@ -829,6 +833,10 @@ components:
           type: string
         created_at:
           type: string
+        delivery_detail:
+          type: string
+        delivery_status:
+          type: string
         direction:
           type: string
         from:
@@ -851,6 +859,8 @@ components:
           type:
             - array
             - "null"
+        sent_as:
+          type: string
         size_bytes:
           format: int64
           type: integer
@@ -896,6 +906,10 @@ components:
           type: string
         created_at:
           type: string
+        delivery_detail:
+          type: string
+        delivery_status:
+          type: string
         from:
           type: string
         labels:
@@ -917,6 +931,8 @@ components:
           type:
             - array
             - "null"
+        sent_as:
+          type: string
         status:
           type: string
         subject:
@@ -1212,6 +1228,37 @@ components:
         - type
         - name
         - value
+      type: object
+    Suppression:
+      additionalProperties: false
+      properties:
+        address:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        reason:
+          type: string
+        source:
+          type: string
+        source_message_id:
+          type: string
+      required:
+        - address
+        - source
+        - created_at
+      type: object
+    SuppressionsOutputBody:
+      additionalProperties: false
+      properties:
+        suppressions:
+          items:
+            $ref: "#/components/schemas/Suppression"
+          type:
+            - array
+            - "null"
+      required:
+        - suppressions
       type: object
     TestWebhookOutputBody:
       additionalProperties: false
@@ -1557,6 +1604,52 @@ paths:
       security:
         - bearer: []
       summary: Export your data (GDPR right-of-access)
+      tags:
+        - account
+  /v1/account/suppressions:
+    get:
+      description: Addresses e2a will refuse to send to (auto-added on a hard bounce or complaint, or added manually). Sends to a suppressed address fail with recipient_suppressed.
+      operationId: listSuppressions
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuppressionsOutputBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+      security:
+        - bearer: []
+      summary: List suppressed recipient addresses
+      tags:
+        - account
+  /v1/account/suppressions/{address}:
+    delete:
+      description: Un-suppress a recipient. A previously-blocked send to it then succeeds (idempotency keys are released, so no fresh key is needed).
+      operationId: deleteSuppression
+      parameters:
+        - in: path
+          name: address
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: No Content
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+      security:
+        - bearer: []
+      summary: Remove an address from the suppression list
       tags:
         - account
   /v1/agents:

--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/approvaltoken"
 	"github.com/Mnexa-AI/e2a/internal/auth"
 	"github.com/Mnexa-AI/e2a/internal/config"
+	"github.com/Mnexa-AI/e2a/internal/delivery"
 	"github.com/Mnexa-AI/e2a/internal/headers"
 	"github.com/Mnexa-AI/e2a/internal/hitlnotify"
 	"github.com/Mnexa-AI/e2a/internal/hitlworker"
@@ -74,6 +75,24 @@ import (
 // senderidentity.EventFirer hook: it publishes domain.sending_verified /
 // domain.sending_failed to the owning user's webhook subscribers when a
 // domain's sending identity reaches a terminal state (decision 4 / Slice 4).
+// deliveryEventFirer adapts the webhooks publisher to delivery.Firer: it
+// publishes email.delivered/bounced/complained + domain.suppression_added to
+// the owning user's subscribers (decision 9 / Slice 4b). The event id is
+// derived deterministically from dedupKey so duplicate SNS notifications
+// produce the same id — receivers dedup on it (at-least-once delivery).
+func deliveryEventFirer(pub webhookpub.Publisher) delivery.Firer {
+	return func(ctx context.Context, userID, agentID, eventType string, data map[string]any, dedupKey string) {
+		pub.Publish(ctx, webhookpub.Event{
+			ID:        webhookpub.DeterministicEventID(dedupKey),
+			Type:      eventType,
+			CreatedAt: time.Now().UTC(),
+			UserID:    userID,
+			AgentID:   agentID,
+			Data:      data,
+		})
+	}
+}
+
 func senderIdentityEventFirer(pub webhookpub.Publisher) senderidentity.EventFirer {
 	return func(ctx context.Context, domain, userID string, status senderidentity.Status, errMsg string) {
 		eventType := webhookpub.EventDomainSendingVerified
@@ -207,6 +226,10 @@ func main() {
 	// when "verified" (fail-closed; a missing/none/pending/failed status keeps
 	// the relay From). Wiring this is behavior-neutral until a domain verifies.
 	sender.SetSendingStatusLookup(store)
+	// Delivery feedback (decision 9 / Slice 4b): tag outbound with the SES
+	// configuration set so SES publishes delivery/bounce/complaint events.
+	// Empty = off (no header, no events).
+	sender.SetSESConfigurationSet(cfg.DeliveryFeedback.SESConfigurationSet)
 
 	// Sender-identity manager (decision 4 / Slice 4). Only wired when SES is
 	// configured: domain verify enqueues a BYODKIM provision job + reconciler;
@@ -345,6 +368,14 @@ func main() {
 	api.SetMetrics(metrics)
 
 	api.RegisterRoutes(router)
+
+	// Public SES-over-SNS delivery notifications endpoint (decision 9 / Slice
+	// 4b). Fail-closed: the SNS signature is verified and the TopicArn must be
+	// in the configured allow-list (empty allow-list → every message is
+	// rejected, so this is inert until ops wires the topic).
+	deliveryConsumer := delivery.NewConsumer(store, deliveryEventFirer(webhookPublisher))
+	deliveryVerifier := delivery.NewVerifier(cfg.DeliveryFeedback.SNSTopicARNs, delivery.HTTPCertFetcher)
+	router.HandleFunc("/api/internal/ses/notifications", delivery.Handler(deliveryVerifier, deliveryConsumer)).Methods(http.MethodPost)
 
 	// WebSocket live-tail route, open to any agent
 	wsHub := ws.NewHub()

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -66,6 +66,23 @@ outbound_smtp:
 sender_identity:
   ses_region: ""  # e.g. "us-east-1"
 
+# Outbound delivery feedback (decision 9 / Slice 4b). When ses_configuration_set
+# is set, outbound mail is tagged with X-SES-CONFIGURATION-SET so SES publishes
+# delivery/bounce/complaint events to an SNS topic; e2a's public endpoint
+# POST /api/internal/ses/notifications consumes them (SNS signature verified,
+# fail-closed) to drive messages.delivery_status, fire
+# email.delivered/bounced/complained, and auto-suppress hard-bounced/complained
+# recipients. sns_topic_arns is the allow-list of SNS topics that endpoint
+# accepts — EMPTY = reject everything (so the endpoint is inert until ops wires
+# the topic). Both empty (the default) disables delivery feedback entirely.
+# Override with E2A_DELIVERY_SES_CONFIGURATION_SET and E2A_DELIVERY_SNS_TOPIC_ARNS
+# (comma-separated). Setup: create an SES configuration set with an SNS event
+# destination (delivery+bounce+complaint), then subscribe e2a's endpoint to that
+# topic and list its ARN here.
+delivery_feedback:
+  ses_configuration_set: ""   # e.g. "e2a-delivery"
+  sns_topic_arns: []          # e.g. ["arn:aws:sns:us-east-2:123456789012:e2a-ses-events"]
+
 # Per-user resource caps applied when a user has no row in the
 # account_limits table. Hosted-service deployments overwrite these per
 # user via an external provisioner (the e2a-billing sidecar, an admin

--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -1202,12 +1202,35 @@ Break the current `/api/v1` surface directly and move it to
     live SES before enabling `sender_identity.ses_region` in prod. (3) The
     optional custom `MAIL FROM` subdomain (SPF alignment) and ARC sealing remain
     deferred per decision 4.
-* **Slice 4b — Delivery feedback (decision 9).** SES SNS consumer →
-  `delivery_status` lifecycle on outbound messages + `email.delivered`/
-  `bounced`/`complained` events + suppression list (with account/console
-  read+remove) + structured inbound `auth: {spf,dkim,dmarc}` (DMARC eval).
-  Depends on Slice 4's VERP Return-Path. **Table stakes** for an email API —
-  ship alongside Slice 4, not after.
+* **Slice 4b — Delivery feedback (decision 9).** *(Delivery-feedback core
+  shipped; the rest split into follow-ups.)* `internal/delivery`: an SES-over-SNS
+  consumer at `POST /api/internal/ses/notifications` (fail-closed SNS signature
+  verification — host-allow-listed `SigningCertURL`, TopicArn allow-list, SHA1/256
+  PKCS1v15, auto-confirm `SubscriptionConfirmation`) drives the
+  `messages.delivery_status` lifecycle (`{queued,sent,delivered,bounced,
+  complained,deferred,failed}`, migration 031) with **monotonic** precedence
+  (`complained>bounced>delivered>deferred>sent>queued`) so out-of-order/duplicate
+  events can't regress a terminal status, a **per-recipient breakdown**
+  (`message_recipients`) with the message field as the worst-status rollup, and
+  `sent_as ∈ {own_address,relay}`. Fires `email.delivered`/`bounced`/`complained`
+  + `domain.suppression_added`. **Suppression list** per `(account,address)`
+  (`suppressions`), auto-added on a hard (Permanent) bounce or a complaint —
+  never a soft/transient bounce (DoS guard) — enforced fresh at send time
+  (`recipient_suppressed`, never idempotency-cached), with `GET /v1/account/
+  suppressions` + `DELETE /v1/account/suppressions/{address}`.
+  * **Correlation by `provider_message_id`** (the SES message id captured at
+    send), not the VERP token — SNS notifications carry the real SES id and are
+    signature-verified, so the VERP HMAC is unnecessary for the SNS path (kept as
+    deferred hardening for an inbound-relay bounce path).
+  * **`messages.delivery_status` reuses the existing `delivery_status` JSON key**,
+    overloaded by direction: inbound rows carry `inbox_status` (legacy polling
+    SDK) under it, outbound rows carry the new lifecycle. A row is inbound XOR
+    outbound, so they never collide per-row.
+  * **Deferred to follow-up slices (4b-2/4b-3):** structured inbound
+    `auth: {spf,dkim,dmarc}` (DMARC eval) + the `email.flagged` security event;
+    the injection-reduced **parsed view** + the unified `GET /messages/{id}`
+    (flat-path removal); the ≥N-soft-bounce suppression threshold; and the SNS
+    flow's real-AWS e2e (CI uses crafted SNS payloads + a fake cert fetcher).
 * **Slice 5 — Auth: OAuth 2.1 + auth.md agent identity.** OAuth 2.1 hosted-MCP
   (PKCE + refresh), scoped API keys (`e2a_agt_`/`e2a_acct_`), and the auth.md
   agent-identity layer (`/agent/identity`, claim ceremony, jwt-bearer/claim

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -958,6 +958,32 @@ type OutboundError struct {
 
 func (e *OutboundError) Error() string { return e.Msg }
 
+// checkSuppression rejects a send when any recipient (To/CC/BCC) is on the
+// tenant's suppression list (decision 9). Returns a structured
+// recipient_suppressed 422. Fails OPEN on a store error — a suppression-DB
+// hiccup must not block legitimate mail; the list is protective, not a hard
+// gate, and the storage trigger / SES account-level list backstop it.
+func (a *API) checkSuppression(ctx context.Context, userID string, req outbound.SendRequest) *OutboundError {
+	addrs := make([]string, 0, len(req.To)+len(req.CC)+len(req.BCC))
+	addrs = append(addrs, req.To...)
+	addrs = append(addrs, req.CC...)
+	addrs = append(addrs, req.BCC...)
+	if len(addrs) == 0 {
+		return nil
+	}
+	suppressed, err := a.store.SuppressedAddresses(ctx, userID, addrs)
+	if err != nil {
+		log.Printf("[api] suppression check failed (allowing send): %v", err)
+		return nil
+	}
+	if len(suppressed) > 0 {
+		return &OutboundError{http.StatusUnprocessableEntity, "recipient_suppressed",
+			"recipient(s) on the suppression list: " + strings.Join(suppressed, ", ") +
+				" — remove via DELETE /v1/account/suppressions/{address}"}
+	}
+	return nil
+}
+
 // DeliverOutbound is the shared send/reply/forward delivery tail, HTTP-free:
 // HITL hold (HoldForApprovalCore), else self-send loopback, else SES send +
 // record outbound + publish sent event. The caller has already authed,
@@ -968,6 +994,14 @@ func (e *OutboundError) Error() string { return e.Msg }
 // extraction). On a nil-error return the side effect has committed, so the
 // idempotency key must be Completed (cached), never Released.
 func (a *API) DeliverOutbound(ctx context.Context, user *identity.User, agent *identity.AgentIdentity, req outbound.SendRequest, msgType, replyToEmailMessageID string) (*OutboundResult, *OutboundError) {
+	// Suppression enforcement (decision 9 / Slice 4b): fail fast if any
+	// recipient is on this tenant's suppression list. Enforced fresh on every
+	// attempt and NOT cached under the idempotency key (it's a clearable state,
+	// released like every other error).
+	if supErr := a.checkSuppression(ctx, user.ID, req); supErr != nil {
+		return nil, supErr
+	}
+
 	if agent.HITLEnabled {
 		msg, err := a.HoldForApprovalCore(ctx, agent, req, msgType, replyToEmailMessageID)
 		if err != nil {
@@ -1010,6 +1044,12 @@ func (a *API) DeliverOutbound(ctx context.Context, user *identity.User, agent *i
 	}
 	slug, _, _ := strings.Cut(agent.EmailAddress(), "@")
 	if outMsg != nil {
+		// Record the delivery lifecycle (decision 9): delivery_status='sent',
+		// which From identity was used, and the per-recipient breakdown the SES
+		// notifications consumer transitions as feedback arrives.
+		if err := a.store.MarkMessageSent(ctx, outMsg.ID, result.SentAs, result.To, result.CC, result.BCC); err != nil {
+			log.Printf("[api] mark sent (delivery_status): %v", err)
+		}
 		log.Printf("[mail:%s] dir=outbound type=%s from=%s to=%v slug=%s conv_id=%s subject=%q", outMsg.ID, msgType, agent.EmailAddress(), result.To, slug, req.ConversationID, req.Subject)
 	}
 	a.publishSent(ctx, a.buildSentEvent(agent, outMsg, result, req, msgType), outMsg)

--- a/internal/apiserver/apiserver.go
+++ b/internal/apiserver/apiserver.go
@@ -101,6 +101,8 @@ func BuildDeps(p Params) httpapi.Deps {
 		GetLimits:           p.Enforcer.Get,
 		ExportUserData:      p.API.ExportUserDataCore,
 		DeleteUserData:      p.API.DeleteUserDataCore,
+		ListSuppressions:    p.Store.ListSuppressions,
+		RemoveSuppression:   p.Store.RemoveSuppression,
 		GetUsage: func(ctx context.Context, userID string) httpapi.LimitsUsageView {
 			var u httpapi.LimitsUsageView
 			if n, err := p.UsageStore.CountAgentsByUser(ctx, userID); err == nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,9 +5,22 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
+
+// splitAndTrim splits a comma-separated env value into a clean slice (trimmed,
+// no empties). Used for list-valued overrides like SNS topic ARNs.
+func splitAndTrim(s string) []string {
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
 
 // placeholderHMACSecret is the example value shipped in config.example.yaml.
 // It must be overridden in any production deployment — the server refuses
@@ -21,15 +34,16 @@ const placeholderHMACSecret = "change-me-in-production"
 const minHMACSecretBytes = 32
 
 type Config struct {
-	SMTP           SMTPConfig           `yaml:"smtp"`
-	HTTP           HTTPConfig           `yaml:"http"`
-	Database       DatabaseConfig       `yaml:"database"`
-	OAuth          OAuthConfig          `yaml:"oauth"`
-	Signing        SigningConfig        `yaml:"signing"`
-	OutboundSMTP   OutboundSMTPConfig   `yaml:"outbound_smtp"`
-	SenderIdentity SenderIdentityConfig `yaml:"sender_identity"`
-	Limits         LimitsConfig         `yaml:"limits"`
-	Env            string               `yaml:"env"` // "development" or "production"
+	SMTP             SMTPConfig             `yaml:"smtp"`
+	HTTP             HTTPConfig             `yaml:"http"`
+	Database         DatabaseConfig         `yaml:"database"`
+	OAuth            OAuthConfig            `yaml:"oauth"`
+	Signing          SigningConfig          `yaml:"signing"`
+	OutboundSMTP     OutboundSMTPConfig     `yaml:"outbound_smtp"`
+	SenderIdentity   SenderIdentityConfig   `yaml:"sender_identity"`
+	DeliveryFeedback DeliveryFeedbackConfig `yaml:"delivery_feedback"`
+	Limits           LimitsConfig           `yaml:"limits"`
+	Env              string                 `yaml:"env"` // "development" or "production"
 	// SharedDomain enables slug-based agent registration. When set
 	// (e.g. "agents.example.com"), users can register agents with just a
 	// slug and get `<slug>@<shared_domain>` provisioned without DNS
@@ -79,6 +93,18 @@ type OutboundSMTPConfig struct {
 	Username   string `yaml:"username"`
 	Password   string `yaml:"password"`
 	FromDomain string `yaml:"from_domain"`
+}
+
+// DeliveryFeedbackConfig controls outbound delivery feedback (decision 9 /
+// Slice 4b). When SESConfigurationSet is set, outbound mail is tagged so SES
+// publishes delivery/bounce/complaint events; SNSTopicARNs is the fail-closed
+// allow-list of SNS topics the public notifications endpoint accepts (empty =
+// reject all). Both empty (the default) disables the feature: no event header,
+// the endpoint rejects everything. Override with
+// E2A_DELIVERY_SES_CONFIGURATION_SET and E2A_DELIVERY_SNS_TOPIC_ARNS (comma-separated).
+type DeliveryFeedbackConfig struct {
+	SESConfigurationSet string   `yaml:"ses_configuration_set"`
+	SNSTopicARNs        []string `yaml:"sns_topic_arns"`
 }
 
 // SenderIdentityConfig controls custom-domain sender identity (decision 4 /
@@ -205,6 +231,12 @@ func Load(path string) (*Config, error) {
 	}
 	if v := os.Getenv("E2A_SENDER_IDENTITY_SES_REGION"); v != "" {
 		cfg.SenderIdentity.SESRegion = v
+	}
+	if v := os.Getenv("E2A_DELIVERY_SES_CONFIGURATION_SET"); v != "" {
+		cfg.DeliveryFeedback.SESConfigurationSet = v
+	}
+	if v := os.Getenv("E2A_DELIVERY_SNS_TOPIC_ARNS"); v != "" {
+		cfg.DeliveryFeedback.SNSTopicARNs = splitAndTrim(v)
 	}
 
 	if err := cfg.Validate(); err != nil {

--- a/internal/delivery/consumer.go
+++ b/internal/delivery/consumer.go
@@ -1,0 +1,126 @@
+package delivery
+
+import (
+	"context"
+	"log"
+)
+
+// Store is the narrow persistence surface the consumer needs. *identity.Store
+// satisfies it.
+type Store interface {
+	// CorrelateBySESMessageID finds the outbound message + owning user + agent
+	// by the SES-assigned provider_message_id captured at send time. found=false
+	// when the id is unknown (message expired, or an event for another deployment).
+	CorrelateBySESMessageID(ctx context.Context, sesMessageID string) (messageID, userID, agentID string, found bool, err error)
+	// RecordDeliveryOutcome upserts the per-recipient status monotonically and
+	// recomputes the message rollup (worst status by precedence). Idempotent:
+	// a duplicate/older event is a no-op.
+	RecordDeliveryOutcome(ctx context.Context, messageID, address string, status Status, detail string) error
+	// AddSuppression idempotently inserts a (user, address) suppression.
+	// added=false when it already existed (so the event fires at most once).
+	AddSuppression(ctx context.Context, userID, address, reason, source, sourceMessageID string) (added bool, err error)
+}
+
+// Firer publishes a delivery/suppression webhook event to the owning user's
+// subscribers. agentID lets subscribers with an agent_ids filter match (empty
+// for account-scoped events like suppression). dedupKey makes redeliveries
+// idempotent (the publisher derives a stable event id from it). Injected as a
+// closure so this package does not depend on webhookpub.
+type Firer func(ctx context.Context, userID, agentID, eventType string, data map[string]any, dedupKey string)
+
+// Event push types for delivery outcomes (decision 9 vocabulary).
+const (
+	EventEmailDelivered     = "email.delivered"
+	EventEmailBounced       = "email.bounced"
+	EventEmailComplained    = "email.complained"
+	EventSuppressionAdded   = "domain.suppression_added" // account-scoped despite the prefix (design vocab)
+	suppressionSourceBounce = "bounce"
+	suppressionSourceCompl  = "complaint"
+)
+
+// pushEventFor maps a recipient status to its webhook event type, or "" for
+// statuses with no push event (queued/sent/deferred/failed — poll instead).
+func pushEventFor(s Status) string {
+	switch s {
+	case StatusDelivered:
+		return EventEmailDelivered
+	case StatusBounced:
+		return EventEmailBounced
+	case StatusComplained:
+		return EventEmailComplained
+	}
+	return ""
+}
+
+// Consumer applies a parsed SES Event to the store: per-recipient transitions,
+// delivery events, and auto-suppression. It is idempotent end-to-end (safe to
+// process the same SNS notification twice — at-least-once delivery).
+type Consumer struct {
+	store Store
+	fire  Firer
+}
+
+// NewConsumer builds the consumer. fire may be nil (no events).
+func NewConsumer(store Store, fire Firer) *Consumer {
+	return &Consumer{store: store, fire: fire}
+}
+
+// Process applies one normalized SES event. Unknown/uncorrelated messages and
+// event kinds with no recipient outcomes are no-ops (returns nil) — an SNS
+// notification e2a can't act on must still be ACKed so SES stops retrying.
+func (c *Consumer) Process(ctx context.Context, ev *Event) error {
+	if ev == nil || len(ev.Recipients) == 0 {
+		return nil
+	}
+	messageID, userID, agentID, found, err := c.store.CorrelateBySESMessageID(ctx, ev.SESMessageID)
+	if err != nil {
+		return err
+	}
+	if !found {
+		log.Printf("[delivery] SES %s for unknown message id=%s (expired/foreign); acking", ev.Kind, ev.SESMessageID)
+		return nil
+	}
+
+	for _, r := range ev.Recipients {
+		if r.Address == "" || !r.Status.Valid() {
+			continue
+		}
+		if err := c.store.RecordDeliveryOutcome(ctx, messageID, r.Address, r.Status, r.Detail); err != nil {
+			return err
+		}
+		if evType := pushEventFor(r.Status); evType != "" && c.fire != nil {
+			c.fire(ctx, userID, agentID, evType, map[string]any{
+				"message_id": messageID,
+				"recipient":  r.Address,
+				"status":     string(r.Status),
+				"detail":     r.Detail,
+			}, evType+"|"+messageID+"|"+r.Address)
+		}
+		if r.Suppress {
+			c.suppress(ctx, userID, messageID, r)
+		}
+	}
+	return nil
+}
+
+func (c *Consumer) suppress(ctx context.Context, userID, messageID string, r RecipientOutcome) {
+	source := suppressionSourceBounce
+	if r.Status == StatusComplained {
+		source = suppressionSourceCompl
+	}
+	added, err := c.store.AddSuppression(ctx, userID, r.Address, r.Detail, source, messageID)
+	if err != nil {
+		log.Printf("[delivery] suppress %s for user=%s: %v", r.Address, userID, err)
+		return
+	}
+	if added && c.fire != nil {
+		// Auto-suppression emits an event so the tenant is alerted, not silently
+		// cut off (decision 9). Account-scoped → empty agentID.
+		c.fire(ctx, userID, "", EventSuppressionAdded, map[string]any{
+			"address":    r.Address,
+			"reason":     r.Detail,
+			"source":     source,
+			"message_id": messageID,
+		}, EventSuppressionAdded+"|"+userID+"|"+r.Address)
+	}
+}

--- a/internal/delivery/consumer_test.go
+++ b/internal/delivery/consumer_test.go
@@ -1,0 +1,160 @@
+package delivery
+
+import (
+	"context"
+	"testing"
+)
+
+// fakeConsumerStore is an in-memory delivery.Store.
+type fakeConsumerStore struct {
+	// correlation: sesMessageID → (messageID, userID, agentID)
+	corr map[string][3]string
+	// recorded outcomes + suppressions
+	outcomes    [][3]string // {messageID, address, status}
+	suppressed  map[string]bool
+	suppressErr error
+	addSuppErr  error
+	alreadySupp map[string]bool // (user|address) already suppressed → added=false
+}
+
+func newFakeConsumerStore() *fakeConsumerStore {
+	return &fakeConsumerStore{corr: map[string][3]string{}, suppressed: map[string]bool{}, alreadySupp: map[string]bool{}}
+}
+
+func (f *fakeConsumerStore) CorrelateBySESMessageID(ctx context.Context, id string) (string, string, string, bool, error) {
+	v, ok := f.corr[id]
+	return v[0], v[1], v[2], ok, nil
+}
+func (f *fakeConsumerStore) RecordDeliveryOutcome(ctx context.Context, messageID, address string, st Status, detail string) error {
+	f.outcomes = append(f.outcomes, [3]string{messageID, address, string(st)})
+	return nil
+}
+func (f *fakeConsumerStore) AddSuppression(ctx context.Context, userID, address, reason, source, srcMsg string) (bool, error) {
+	if f.addSuppErr != nil {
+		return false, f.addSuppErr
+	}
+	key := userID + "|" + address
+	if f.alreadySupp[key] {
+		return false, nil
+	}
+	f.suppressed[key] = true
+	return true, nil
+}
+
+type firedEvent struct {
+	userID, agentID, eventType string
+	data                       map[string]any
+}
+
+func recordingFirer() (Firer, *[]firedEvent) {
+	var events []firedEvent
+	f := func(ctx context.Context, userID, agentID, eventType string, data map[string]any, dedupKey string) {
+		events = append(events, firedEvent{userID, agentID, eventType, data})
+	}
+	return f, &events
+}
+
+func TestConsumerProcess(t *testing.T) {
+	t.Run("uncorrelated message is a no-op ack", func(t *testing.T) {
+		store := newFakeConsumerStore()
+		fire, events := recordingFirer()
+		c := NewConsumer(store, fire)
+		err := c.Process(context.Background(), &Event{
+			Kind: KindDelivery, SESMessageID: "unknown",
+			Recipients: []RecipientOutcome{{Address: "a@x.com", Status: StatusDelivered}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(store.outcomes) != 0 || len(*events) != 0 {
+			t.Fatal("nothing should be recorded for an uncorrelated message")
+		}
+	})
+
+	t.Run("delivery records outcome + fires email.delivered with agent id", func(t *testing.T) {
+		store := newFakeConsumerStore()
+		store.corr["ses-1"] = [3]string{"msg_1", "u_1", "bot@x.com"}
+		fire, events := recordingFirer()
+		c := NewConsumer(store, fire)
+		err := c.Process(context.Background(), &Event{
+			Kind: KindDelivery, SESMessageID: "ses-1",
+			Recipients: []RecipientOutcome{{Address: "a@x.com", Status: StatusDelivered}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(store.outcomes) != 1 || store.outcomes[0] != [3]string{"msg_1", "a@x.com", "delivered"} {
+			t.Fatalf("outcomes=%v", store.outcomes)
+		}
+		if len(*events) != 1 {
+			t.Fatalf("events=%v", *events)
+		}
+		e := (*events)[0]
+		if e.eventType != EventEmailDelivered || e.userID != "u_1" || e.agentID != "bot@x.com" {
+			t.Fatalf("event=%+v", e)
+		}
+	})
+
+	t.Run("hard bounce records + fires bounced + suppresses + fires suppression", func(t *testing.T) {
+		store := newFakeConsumerStore()
+		store.corr["ses-2"] = [3]string{"msg_2", "u_2", "bot@x.com"}
+		fire, events := recordingFirer()
+		c := NewConsumer(store, fire)
+		_ = c.Process(context.Background(), &Event{
+			Kind: KindBounce, SESMessageID: "ses-2",
+			Recipients: []RecipientOutcome{{Address: "b@x.com", Status: StatusBounced, Detail: "550", Suppress: true}},
+		})
+		if !store.suppressed["u_2|b@x.com"] {
+			t.Fatal("address should be suppressed")
+		}
+		var types []string
+		for _, e := range *events {
+			types = append(types, e.eventType)
+		}
+		if !contains(types, EventEmailBounced) || !contains(types, EventSuppressionAdded) {
+			t.Fatalf("expected bounced + suppression_added, got %v", types)
+		}
+	})
+
+	t.Run("complaint suppresses with no agent id on the suppression event", func(t *testing.T) {
+		store := newFakeConsumerStore()
+		store.corr["ses-3"] = [3]string{"msg_3", "u_3", "bot@x.com"}
+		fire, events := recordingFirer()
+		c := NewConsumer(store, fire)
+		_ = c.Process(context.Background(), &Event{
+			Kind: KindComplaint, SESMessageID: "ses-3",
+			Recipients: []RecipientOutcome{{Address: "c@x.com", Status: StatusComplained, Suppress: true}},
+		})
+		for _, e := range *events {
+			if e.eventType == EventSuppressionAdded && e.agentID != "" {
+				t.Errorf("suppression event is account-scoped; agentID should be empty, got %q", e.agentID)
+			}
+		}
+	})
+
+	t.Run("re-suppression fires the event at most once", func(t *testing.T) {
+		store := newFakeConsumerStore()
+		store.corr["ses-4"] = [3]string{"msg_4", "u_4", "bot@x.com"}
+		store.alreadySupp["u_4|d@x.com"] = true // already on the list
+		fire, events := recordingFirer()
+		c := NewConsumer(store, fire)
+		_ = c.Process(context.Background(), &Event{
+			Kind: KindComplaint, SESMessageID: "ses-4",
+			Recipients: []RecipientOutcome{{Address: "d@x.com", Status: StatusComplained, Suppress: true}},
+		})
+		for _, e := range *events {
+			if e.eventType == EventSuppressionAdded {
+				t.Error("suppression_added must not fire when the address was already suppressed")
+			}
+		}
+	})
+}
+
+func contains(ss []string, s string) bool {
+	for _, x := range ss {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/delivery/handler.go
+++ b/internal/delivery/handler.go
@@ -1,0 +1,101 @@
+package delivery
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log"
+	"net/http"
+	"time"
+)
+
+// maxSNSBody caps the SNS POST body. SES notifications are small; this guards
+// against a junk flood on the public endpoint.
+const maxSNSBody = 256 * 1024
+
+// Handler returns the HTTP handler for the public SES-over-SNS notifications
+// endpoint. Every request is fail-closed: the SNS signature is verified before
+// anything is acted on (the endpoint is public). It auto-confirms a
+// SubscriptionConfirmation (GET the allow-listed SubscribeURL) and feeds a
+// Notification's SES event to the Consumer.
+//
+// Responses: 403 on a failed signature; 400 on unparseable JSON; 200 on a
+// handled or safely-ignored message (so SES stops retrying); 500 only when the
+// Consumer hits a real error worth a retry.
+func Handler(v *Verifier, c *Consumer) http.HandlerFunc {
+	client := &http.Client{Timeout: 10 * time.Second}
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		body, err := io.ReadAll(io.LimitReader(r.Body, maxSNSBody))
+		if err != nil {
+			http.Error(w, "read error", http.StatusBadRequest)
+			return
+		}
+		var m SNSMessage
+		if err := json.Unmarshal(body, &m); err != nil {
+			http.Error(w, "bad json", http.StatusBadRequest)
+			return
+		}
+		// Fail-closed: verify the SNS signature before acting on anything.
+		if err := v.Verify(r.Context(), &m); err != nil {
+			log.Printf("[delivery] SNS signature verification failed: %v", err)
+			http.Error(w, "forbidden", http.StatusForbidden)
+			return
+		}
+
+		switch m.Type {
+		case "SubscriptionConfirmation":
+			if url, ok := ConfirmSubscriptionURL(&m); ok {
+				if err := confirmSubscription(r.Context(), client, url); err != nil {
+					log.Printf("[delivery] subscription confirm failed: %v", err)
+				} else {
+					log.Printf("[delivery] confirmed SNS subscription for topic %s", m.TopicArn)
+				}
+			}
+			w.WriteHeader(http.StatusOK)
+		case "Notification":
+			ev, err := ParseSESNotification([]byte(m.Message))
+			if err != nil {
+				// Malformed/unactionable SES payload — ack so SES stops retrying
+				// (retrying won't fix bad data); log for visibility.
+				log.Printf("[delivery] parse SES notification: %v", err)
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			if err := c.Process(r.Context(), ev); err != nil {
+				log.Printf("[delivery] process %s: %v", ev.Kind, err)
+				http.Error(w, "processing error", http.StatusInternalServerError) // SES retries
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		default: // UnsubscribeConfirmation, etc.
+			w.WriteHeader(http.StatusOK)
+		}
+	}
+}
+
+// confirmSubscription GETs the (already host-allow-listed) SubscribeURL to
+// confirm the SNS subscription.
+func confirmSubscription(ctx context.Context, client *http.Client, url string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, io.LimitReader(resp.Body, 64*1024))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return &httpStatusError{resp.StatusCode}
+	}
+	return nil
+}
+
+type httpStatusError struct{ code int }
+
+func (e *httpStatusError) Error() string { return "confirm subscription: non-2xx status" }

--- a/internal/delivery/handler.go
+++ b/internal/delivery/handler.go
@@ -23,7 +23,13 @@ const maxSNSBody = 256 * 1024
 // handled or safely-ignored message (so SES stops retrying); 500 only when the
 // Consumer hits a real error worth a retry.
 func Handler(v *Verifier, c *Consumer) http.HandlerFunc {
-	client := &http.Client{Timeout: 10 * time.Second}
+	// No redirect-following: the SubscribeURL host is allow-listed
+	// (sns.*.amazonaws.com) before the GET, and we must not let a redirect carry
+	// the request to a non-allow-listed (internal) host — SSRF defense in depth.
+	client := &http.Client{
+		Timeout:       10 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
 	return func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)

--- a/internal/delivery/handler_test.go
+++ b/internal/delivery/handler_test.go
@@ -1,0 +1,42 @@
+package delivery
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// failing verifier path: a TopicArn not in the allow-list is rejected before
+// any cert fetch, so the handler returns 403 without network.
+func TestHandlerRejectsUnverified(t *testing.T) {
+	v := NewVerifier([]string{"arn:aws:sns:us-east-2:1:allowed"}, nil)
+	h := Handler(v, NewConsumer(nil, nil))
+	body := `{"Type":"Notification","TopicArn":"arn:aws:sns:us-east-2:1:EVIL","MessageId":"m","Message":"{}","Timestamp":"t","SignatureVersion":"1","Signature":"x","SigningCertURL":"https://sns.us-east-2.amazonaws.com/c.pem"}`
+	r := httptest.NewRequest(http.MethodPost, "/api/internal/ses/notifications", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h(w, r)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("unverified message: status=%d, want 403", w.Code)
+	}
+}
+
+func TestHandlerRejectsBadJSON(t *testing.T) {
+	h := Handler(NewVerifier(nil, nil), NewConsumer(nil, nil))
+	r := httptest.NewRequest(http.MethodPost, "/x", strings.NewReader("{not json"))
+	w := httptest.NewRecorder()
+	h(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("bad json: status=%d, want 400", w.Code)
+	}
+}
+
+func TestHandlerRejectsGET(t *testing.T) {
+	h := Handler(NewVerifier(nil, nil), NewConsumer(nil, nil))
+	r := httptest.NewRequest(http.MethodGet, "/x", nil)
+	w := httptest.NewRecorder()
+	h(w, r)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("GET: status=%d, want 405", w.Code)
+	}
+}

--- a/internal/delivery/integration_test.go
+++ b/internal/delivery/integration_test.go
@@ -1,0 +1,152 @@
+//go:build integration
+
+package delivery_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/delivery"
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+)
+
+// seedOutbound creates a user + verified domain + agent + one outbound message
+// with the given SES provider id, marked sent to `to`. Returns userID,
+// messageID, agentEmail.
+func seedOutbound(t *testing.T, store *identity.Store, prefix, providerID string, to []string) (string, string, string) {
+	t.Helper()
+	ctx := context.Background()
+	user, err := store.CreateOrGetUser(ctx, "owner-"+prefix+"@example.com", "Owner", "g-"+prefix)
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	domain := prefix + ".example.com"
+	if _, err := store.ClaimOrCreateDomain(ctx, domain, user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+	if err := store.VerifyDomain(ctx, domain, user.ID); err != nil {
+		t.Fatalf("VerifyDomain: %v", err)
+	}
+	agentEmail := "bot@" + domain
+	if _, err := store.CreateAgent(ctx, agentEmail, domain, "", "", "", user.ID); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	msg, err := store.CreateOutboundMessage(ctx, agentEmail, to, nil, nil, "Subj", "send", "smtp", providerID, "")
+	if err != nil {
+		t.Fatalf("CreateOutboundMessage: %v", err)
+	}
+	if err := store.MarkMessageSent(ctx, msg.ID, "relay", to, nil, nil); err != nil {
+		t.Fatalf("MarkMessageSent: %v", err)
+	}
+	return user.ID, msg.ID, agentEmail
+}
+
+func deliveryStatus(t *testing.T, store *identity.Store, messageID, agentEmail string) string {
+	t.Helper()
+	msg, err := store.GetMessageWithContent(context.Background(), messageID, agentEmail)
+	if err != nil {
+		t.Fatalf("read message: %v", err)
+	}
+	return msg.DeliveryStatus
+}
+
+func TestDeliveryPipeline_DeliveredThenBounceSuppresses(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	store := identity.NewStore(pool)
+
+	userID, msgID, agentEmail := seedOutbound(t, store, "dlv", "ses-msg-1", []string{"a@x.com"})
+
+	// Initial rollup is 'sent'.
+	if got := deliveryStatus(t, store, msgID, agentEmail); got != "sent" {
+		t.Fatalf("initial delivery_status=%q, want sent", got)
+	}
+
+	consumer := delivery.NewConsumer(store, nil)
+
+	// Delivery → delivered.
+	if err := consumer.Process(ctx, &delivery.Event{
+		Kind: delivery.KindDelivery, SESMessageID: "ses-msg-1",
+		Recipients: []delivery.RecipientOutcome{{Address: "a@x.com", Status: delivery.StatusDelivered}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := deliveryStatus(t, store, msgID, agentEmail); got != "delivered" {
+		t.Fatalf("after delivery: delivery_status=%q, want delivered", got)
+	}
+
+	// A later, lower-rank deferred must NOT regress a delivered rollup (monotonic).
+	_ = consumer.Process(ctx, &delivery.Event{
+		Kind: delivery.KindDeliveryDelay, SESMessageID: "ses-msg-1",
+		Recipients: []delivery.RecipientOutcome{{Address: "a@x.com", Status: delivery.StatusDeferred}},
+	})
+	if got := deliveryStatus(t, store, msgID, agentEmail); got != "delivered" {
+		t.Fatalf("monotonic violated: delivery_status=%q, want still delivered", got)
+	}
+
+	// A hard bounce wins over delivered AND suppresses the address.
+	if err := consumer.Process(ctx, &delivery.Event{
+		Kind: delivery.KindBounce, SESMessageID: "ses-msg-1",
+		Recipients: []delivery.RecipientOutcome{{Address: "a@x.com", Status: delivery.StatusBounced, Detail: "550", Suppress: true}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := deliveryStatus(t, store, msgID, agentEmail); got != "bounced" {
+		t.Fatalf("after bounce: delivery_status=%q, want bounced", got)
+	}
+	supp, err := store.SuppressedAddresses(ctx, userID, []string{"a@x.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(supp) != 1 || supp[0] != "a@x.com" {
+		t.Fatalf("expected a@x.com suppressed, got %v", supp)
+	}
+}
+
+func TestDeliveryPipeline_PerRecipientRollup(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	store := identity.NewStore(pool)
+
+	_, msgID, agentEmail := seedOutbound(t, store, "multi", "ses-msg-2", []string{"good@x.com", "bad@x.com"})
+	consumer := delivery.NewConsumer(store, nil)
+
+	// good delivers, bad bounces → rollup is the worst (bounced).
+	_ = consumer.Process(ctx, &delivery.Event{Kind: delivery.KindDelivery, SESMessageID: "ses-msg-2",
+		Recipients: []delivery.RecipientOutcome{{Address: "good@x.com", Status: delivery.StatusDelivered}}})
+	_ = consumer.Process(ctx, &delivery.Event{Kind: delivery.KindBounce, SESMessageID: "ses-msg-2",
+		Recipients: []delivery.RecipientOutcome{{Address: "bad@x.com", Status: delivery.StatusBounced, Suppress: true}}})
+
+	if got := deliveryStatus(t, store, msgID, agentEmail); got != "bounced" {
+		t.Fatalf("rollup=%q, want bounced (worst across recipients)", got)
+	}
+}
+
+func TestSuppressionCRUD(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	store := identity.NewStore(pool)
+	user, _ := store.CreateOrGetUser(ctx, "supp@example.com", "S", "g-supp")
+
+	added, err := store.AddSuppression(ctx, user.ID, "X@x.com", "manual block", "manual", "")
+	if err != nil || !added {
+		t.Fatalf("AddSuppression added=%v err=%v", added, err)
+	}
+	// Idempotent: second add returns added=false.
+	added2, _ := store.AddSuppression(ctx, user.ID, "x@x.com", "again", "manual", "")
+	if added2 {
+		t.Fatal("re-adding the same (normalized) address should return added=false")
+	}
+	list, _ := store.ListSuppressions(ctx, user.ID)
+	if len(list) != 1 || list[0].Address != "x@x.com" {
+		t.Fatalf("list=%v", list)
+	}
+	found, _ := store.RemoveSuppression(ctx, user.ID, "x@x.com")
+	if !found {
+		t.Fatal("RemoveSuppression should report found")
+	}
+	if supp, _ := store.SuppressedAddresses(ctx, user.ID, []string{"x@x.com"}); len(supp) != 0 {
+		t.Fatalf("address should be un-suppressed, got %v", supp)
+	}
+}

--- a/internal/delivery/integration_test.go
+++ b/internal/delivery/integration_test.go
@@ -150,3 +150,102 @@ func TestSuppressionCRUD(t *testing.T) {
 		t.Fatalf("address should be un-suppressed, got %v", supp)
 	}
 }
+
+// TestCorrelationMatchesBracketedSESID pins the review BLOCKER: SES stores the
+// provider id angle-bracketed (and sometimes @region.amazonses.com-suffixed),
+// but the SNS notification carries the BARE id. Correlation must match across
+// those shapes — an exact-equality match would silently drop all feedback.
+func TestCorrelationMatchesBracketedSESID(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	store := identity.NewStore(pool)
+
+	// Store the realistic bracketed+suffixed shape; correlate with the bare id.
+	_, msgID, agentEmail := seedOutbound(t, store, "corr", "<010f0193abc-000000@us-east-2.amazonses.com>", []string{"a@x.com"})
+
+	mID, _, _, found, err := store.CorrelateBySESMessageID(ctx, "010f0193abc-000000")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || mID != msgID {
+		t.Fatalf("bare-id correlation against bracketed stored id failed: found=%v id=%q want %q", found, mID, msgID)
+	}
+
+	// And the full pipeline must transition delivery_status via the bare id.
+	if err := delivery.NewConsumer(store, nil).Process(ctx, &delivery.Event{
+		Kind: delivery.KindDelivery, SESMessageID: "010f0193abc-000000",
+		Recipients: []delivery.RecipientOutcome{{Address: "a@x.com", Status: delivery.StatusDelivered}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := deliveryStatus(t, store, msgID, agentEmail); got != "delivered" {
+		t.Fatalf("delivery_status=%q, want delivered (bare-id correlation)", got)
+	}
+}
+
+// TestConcurrentRollupMonotonic pins the review race fix: concurrent SES events
+// for the same recipient (one delivered, one bounced) must converge to the
+// worst status (bounced) — the message-row lock serializes the merge.
+func TestConcurrentRollupMonotonic(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	store := identity.NewStore(pool)
+	consumer := delivery.NewConsumer(store, nil)
+
+	// Seed the user/domain/agent once; create a distinct message per iteration.
+	_, _, agentEmail := seedOutbound(t, store, "race", "ses-race-seed", []string{"a@x.com"})
+
+	for i := 0; i < 25; i++ {
+		providerID := "ses-race-" + string(rune('a'+i%26)) + string(rune('a'+i/26))
+		msg, err := store.CreateOutboundMessage(ctx, agentEmail, []string{"a@x.com"}, nil, nil, "S", "send", "smtp", providerID, "")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := store.MarkMessageSent(ctx, msg.ID, "relay", []string{"a@x.com"}, nil, nil); err != nil {
+			t.Fatal(err)
+		}
+		done := make(chan error, 2)
+		go func() {
+			done <- consumer.Process(ctx, &delivery.Event{Kind: delivery.KindDelivery, SESMessageID: providerID,
+				Recipients: []delivery.RecipientOutcome{{Address: "a@x.com", Status: delivery.StatusDelivered}}})
+		}()
+		go func() {
+			done <- consumer.Process(ctx, &delivery.Event{Kind: delivery.KindBounce, SESMessageID: providerID,
+				Recipients: []delivery.RecipientOutcome{{Address: "a@x.com", Status: delivery.StatusBounced, Detail: "550"}}})
+		}()
+		if err := <-done; err != nil {
+			t.Fatal(err)
+		}
+		if err := <-done; err != nil {
+			t.Fatal(err)
+		}
+		if got := deliveryStatus(t, store, msg.ID, agentEmail); got != "bounced" {
+			t.Fatalf("iter %d: rollup=%q, want bounced (concurrent monotonic)", i, got)
+		}
+	}
+}
+
+// TestDetailNotClobberedByLaterEvent pins the review low fix: a later
+// lower-rank event carrying a detail must not overwrite the terminal
+// diagnostic.
+func TestDetailNotClobberedByLaterEvent(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	store := identity.NewStore(pool)
+	_, msgID, _ := seedOutbound(t, store, "detail", "ses-detail", []string{"a@x.com"})
+	consumer := delivery.NewConsumer(store, nil)
+
+	_ = consumer.Process(ctx, &delivery.Event{Kind: delivery.KindBounce, SESMessageID: "ses-detail",
+		Recipients: []delivery.RecipientOutcome{{Address: "a@x.com", Status: delivery.StatusBounced, Detail: "550 mailbox full"}}})
+	// A late delivered (lower rank) with its own detail must not clobber.
+	_ = consumer.Process(ctx, &delivery.Event{Kind: delivery.KindDelivery, SESMessageID: "ses-detail",
+		Recipients: []delivery.RecipientOutcome{{Address: "a@x.com", Status: delivery.StatusDelivered, Detail: "ok"}}})
+
+	var detail string
+	if err := pool.QueryRow(ctx, "SELECT COALESCE(detail,'') FROM message_recipients WHERE message_id=$1 AND address='a@x.com'", msgID).Scan(&detail); err != nil {
+		t.Fatal(err)
+	}
+	if detail != "550 mailbox full" {
+		t.Fatalf("detail=%q, want the preserved bounce reason", detail)
+	}
+}

--- a/internal/delivery/ses.go
+++ b/internal/delivery/ses.go
@@ -1,0 +1,148 @@
+package delivery
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// EventKind is the normalized SES event category.
+type EventKind string
+
+const (
+	KindDelivery      EventKind = "Delivery"
+	KindBounce        EventKind = "Bounce"
+	KindComplaint     EventKind = "Complaint"
+	KindDeliveryDelay EventKind = "DeliveryDelay"
+	KindSend          EventKind = "Send"
+	KindReject        EventKind = "Reject"
+	KindOther         EventKind = "Other"
+)
+
+// RecipientOutcome is the delivery result for one address from one SES event.
+type RecipientOutcome struct {
+	Address  string
+	Status   Status
+	Detail   string
+	Suppress bool // hard bounce or complaint → add to the suppression list
+}
+
+// Event is a normalized SES notification: which message, which event, and the
+// per-recipient outcomes. The message rollup is the worst status across
+// Recipients by Merge precedence.
+type Event struct {
+	Kind         EventKind
+	SESMessageID string // the mail.messageId — correlates to messages.provider_message_id
+	Recipients   []RecipientOutcome
+}
+
+// sesNotification is the SES event JSON carried in the SNS Message field.
+// Config-set event publishing uses `eventType`; legacy identity notifications
+// use `notificationType` — accept either.
+type sesNotification struct {
+	EventType        string `json:"eventType"`
+	NotificationType string `json:"notificationType"`
+	Mail             struct {
+		MessageID   string   `json:"messageId"`
+		Destination []string `json:"destination"`
+	} `json:"mail"`
+	Bounce *struct {
+		BounceType        string `json:"bounceType"` // Permanent | Transient | Undetermined
+		BounceSubType     string `json:"bounceSubType"`
+		BouncedRecipients []struct {
+			EmailAddress   string `json:"emailAddress"`
+			DiagnosticCode string `json:"diagnosticCode"`
+		} `json:"bouncedRecipients"`
+	} `json:"bounce"`
+	Complaint *struct {
+		ComplainedRecipients []struct {
+			EmailAddress string `json:"emailAddress"`
+		} `json:"complainedRecipients"`
+		ComplaintFeedbackType string `json:"complaintFeedbackType"`
+	} `json:"complaint"`
+	Delivery *struct {
+		Recipients []string `json:"recipients"`
+	} `json:"delivery"`
+	DeliveryDelay *struct {
+		DelayedRecipients []struct {
+			EmailAddress   string `json:"emailAddress"`
+			DiagnosticCode string `json:"diagnosticCode"`
+		} `json:"delayedRecipients"`
+	} `json:"deliveryDelay"`
+}
+
+// ParseSESNotification parses the SES event JSON (the decoded SNS Message
+// body) into a normalized Event. Returns an error for malformed JSON or a
+// missing message id; an unrecognized event kind yields KindOther with no
+// recipient outcomes (caller no-ops).
+func ParseSESNotification(messageBody []byte) (*Event, error) {
+	var n sesNotification
+	if err := json.Unmarshal(messageBody, &n); err != nil {
+		return nil, fmt.Errorf("parse SES notification: %w", err)
+	}
+	typ := n.EventType
+	if typ == "" {
+		typ = n.NotificationType
+	}
+	if n.Mail.MessageID == "" {
+		return nil, fmt.Errorf("SES notification missing mail.messageId")
+	}
+	ev := &Event{SESMessageID: n.Mail.MessageID}
+
+	switch typ {
+	case "Delivery":
+		ev.Kind = KindDelivery
+		recips := n.Mail.Destination
+		if n.Delivery != nil && len(n.Delivery.Recipients) > 0 {
+			recips = n.Delivery.Recipients
+		}
+		for _, a := range recips {
+			ev.Recipients = append(ev.Recipients, RecipientOutcome{Address: norm(a), Status: StatusDelivered})
+		}
+	case "Bounce":
+		ev.Kind = KindBounce
+		if n.Bounce != nil {
+			// Only a Permanent (hard) bounce suppresses; Transient/Undetermined
+			// are recorded as bounced but not auto-suppressed (decision 9: never
+			// suppress on a single unverified/soft signal).
+			hard := strings.EqualFold(n.Bounce.BounceType, "Permanent")
+			for _, r := range n.Bounce.BouncedRecipients {
+				ev.Recipients = append(ev.Recipients, RecipientOutcome{
+					Address: norm(r.EmailAddress), Status: StatusBounced,
+					Detail: r.DiagnosticCode, Suppress: hard,
+				})
+			}
+		}
+	case "Complaint":
+		ev.Kind = KindComplaint
+		if n.Complaint != nil {
+			for _, r := range n.Complaint.ComplainedRecipients {
+				ev.Recipients = append(ev.Recipients, RecipientOutcome{
+					Address: norm(r.EmailAddress), Status: StatusComplained,
+					Detail: n.Complaint.ComplaintFeedbackType, Suppress: true,
+				})
+			}
+		}
+	case "DeliveryDelay":
+		ev.Kind = KindDeliveryDelay
+		if n.DeliveryDelay != nil {
+			for _, r := range n.DeliveryDelay.DelayedRecipients {
+				ev.Recipients = append(ev.Recipients, RecipientOutcome{
+					Address: norm(r.EmailAddress), Status: StatusDeferred, Detail: r.DiagnosticCode,
+				})
+			}
+		}
+	case "Send":
+		ev.Kind = KindSend
+	case "Reject":
+		ev.Kind = KindReject
+		for _, a := range n.Mail.Destination {
+			ev.Recipients = append(ev.Recipients, RecipientOutcome{Address: norm(a), Status: StatusFailed})
+		}
+	default:
+		ev.Kind = KindOther
+	}
+	return ev, nil
+}
+
+func norm(addr string) string { return strings.ToLower(strings.TrimSpace(addr)) }

--- a/internal/delivery/ses_test.go
+++ b/internal/delivery/ses_test.go
@@ -1,0 +1,103 @@
+package delivery
+
+import "testing"
+
+func TestParseSESNotification(t *testing.T) {
+	t.Run("delivery", func(t *testing.T) {
+		ev, err := ParseSESNotification([]byte(`{
+			"eventType":"Delivery",
+			"mail":{"messageId":"ses-1","destination":["a@x.com"]},
+			"delivery":{"recipients":["a@x.com"]}
+		}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ev.Kind != KindDelivery || ev.SESMessageID != "ses-1" {
+			t.Fatalf("got kind=%s id=%s", ev.Kind, ev.SESMessageID)
+		}
+		if len(ev.Recipients) != 1 || ev.Recipients[0].Status != StatusDelivered || ev.Recipients[0].Suppress {
+			t.Fatalf("recipients=%+v", ev.Recipients)
+		}
+	})
+
+	t.Run("permanent bounce suppresses", func(t *testing.T) {
+		ev, _ := ParseSESNotification([]byte(`{
+			"eventType":"Bounce",
+			"mail":{"messageId":"ses-2"},
+			"bounce":{"bounceType":"Permanent","bouncedRecipients":[{"emailAddress":"B@x.com","diagnosticCode":"550 no such user"}]}
+		}`))
+		if ev.Kind != KindBounce || len(ev.Recipients) != 1 {
+			t.Fatalf("ev=%+v", ev)
+		}
+		r := ev.Recipients[0]
+		if r.Address != "b@x.com" || r.Status != StatusBounced || !r.Suppress || r.Detail != "550 no such user" {
+			t.Fatalf("recipient=%+v (address must be lowercased, suppress=true)", r)
+		}
+	})
+
+	t.Run("transient bounce does NOT suppress", func(t *testing.T) {
+		ev, _ := ParseSESNotification([]byte(`{
+			"eventType":"Bounce",
+			"mail":{"messageId":"ses-3"},
+			"bounce":{"bounceType":"Transient","bouncedRecipients":[{"emailAddress":"c@x.com"}]}
+		}`))
+		if ev.Recipients[0].Suppress {
+			t.Fatal("a transient (soft) bounce must not auto-suppress")
+		}
+		if ev.Recipients[0].Status != StatusBounced {
+			t.Fatalf("status=%s", ev.Recipients[0].Status)
+		}
+	})
+
+	t.Run("complaint suppresses", func(t *testing.T) {
+		ev, _ := ParseSESNotification([]byte(`{
+			"eventType":"Complaint",
+			"mail":{"messageId":"ses-4"},
+			"complaint":{"complainedRecipients":[{"emailAddress":"d@x.com"}],"complaintFeedbackType":"abuse"}
+		}`))
+		r := ev.Recipients[0]
+		if ev.Kind != KindComplaint || r.Status != StatusComplained || !r.Suppress || r.Detail != "abuse" {
+			t.Fatalf("recipient=%+v", r)
+		}
+	})
+
+	t.Run("delivery delay → deferred, no suppress", func(t *testing.T) {
+		ev, _ := ParseSESNotification([]byte(`{
+			"eventType":"DeliveryDelay",
+			"mail":{"messageId":"ses-5"},
+			"deliveryDelay":{"delayedRecipients":[{"emailAddress":"e@x.com"}]}
+		}`))
+		if ev.Recipients[0].Status != StatusDeferred || ev.Recipients[0].Suppress {
+			t.Fatalf("recipient=%+v", ev.Recipients[0])
+		}
+	})
+
+	t.Run("legacy notificationType key", func(t *testing.T) {
+		ev, err := ParseSESNotification([]byte(`{
+			"notificationType":"Delivery",
+			"mail":{"messageId":"ses-6","destination":["f@x.com"]}
+		}`))
+		if err != nil || ev.Kind != KindDelivery {
+			t.Fatalf("ev=%+v err=%v", ev, err)
+		}
+	})
+
+	t.Run("missing message id errors", func(t *testing.T) {
+		if _, err := ParseSESNotification([]byte(`{"eventType":"Delivery","mail":{}}`)); err == nil {
+			t.Fatal("expected error for missing mail.messageId")
+		}
+	})
+
+	t.Run("unknown kind → Other, no recipients", func(t *testing.T) {
+		ev, err := ParseSESNotification([]byte(`{"eventType":"Open","mail":{"messageId":"ses-7"}}`))
+		if err != nil || ev.Kind != KindOther || len(ev.Recipients) != 0 {
+			t.Fatalf("ev=%+v err=%v", ev, err)
+		}
+	})
+
+	t.Run("malformed json errors", func(t *testing.T) {
+		if _, err := ParseSESNotification([]byte(`{not json`)); err == nil {
+			t.Fatal("expected error")
+		}
+	})
+}

--- a/internal/delivery/sns.go
+++ b/internal/delivery/sns.go
@@ -48,7 +48,13 @@ var snsHostRE = regexp.MustCompile(`^sns\.[a-z0-9-]+\.amazonaws\.com$`)
 // timeout that returns the PEM cert bytes. It rejects non-2xx responses. The
 // URL must already have passed the host allow-list (see validSigningCertHost).
 func HTTPCertFetcher(ctx context.Context, certURL string) ([]byte, error) {
-	c := &http.Client{Timeout: 10 * time.Second}
+	// No redirect-following: the cert URL host is already allow-listed
+	// (sns.*.amazonaws.com); a redirect must not carry the fetch to an internal
+	// host — SSRF defense in depth.
+	c := &http.Client{
+		Timeout:       10 * time.Second,
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, certURL, nil)
 	if err != nil {
 		return nil, fmt.Errorf("build cert request: %w", err)

--- a/internal/delivery/sns.go
+++ b/internal/delivery/sns.go
@@ -1,0 +1,244 @@
+package delivery
+
+import (
+	"context"
+	"crypto"
+	"crypto/rsa"
+	"crypto/sha1" //nolint:gosec // SNS SignatureVersion 1 mandates SHA1; AWS controls the signing.
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"regexp"
+	"time"
+)
+
+// SNSMessage is the standard Amazon SNS HTTP/S POST body. The SES delivery
+// notifications arrive wrapped in this envelope; Message carries the SES event
+// JSON (see ParseSESNotification). Field tags match the SNS wire format.
+type SNSMessage struct {
+	Type             string `json:"Type"` // Notification | SubscriptionConfirmation | UnsubscribeConfirmation
+	MessageId        string `json:"MessageId"`
+	TopicArn         string `json:"TopicArn"`
+	Subject          string `json:"Subject,omitempty"` // Notifications only, optional
+	Message          string `json:"Message"`
+	Timestamp        string `json:"Timestamp"`
+	SignatureVersion string `json:"SignatureVersion"`
+	Signature        string `json:"Signature"`
+	SigningCertURL   string `json:"SigningCertURL"`
+	// SubscribeURL and Token are present only on SubscriptionConfirmation and
+	// UnsubscribeConfirmation envelopes.
+	SubscribeURL string `json:"SubscribeURL,omitempty"`
+	Token        string `json:"Token,omitempty"`
+}
+
+// CertFetcher fetches the bytes of an SNS signing certificate (PEM). Injected as
+// a seam so the signature path is testable without network access.
+type CertFetcher func(ctx context.Context, url string) ([]byte, error)
+
+// snsHostRE is the SSRF guard for SigningCertURL / SubscribeURL hosts: only the
+// canonical regional SNS endpoints (e.g. sns.us-east-2.amazonaws.com).
+var snsHostRE = regexp.MustCompile(`^sns\.[a-z0-9-]+\.amazonaws\.com$`)
+
+// HTTPCertFetcher is the production CertFetcher: an HTTPS GET with a short
+// timeout that returns the PEM cert bytes. It rejects non-2xx responses. The
+// URL must already have passed the host allow-list (see validSigningCertHost).
+func HTTPCertFetcher(ctx context.Context, certURL string) ([]byte, error) {
+	c := &http.Client{Timeout: 10 * time.Second}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, certURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build cert request: %w", err)
+	}
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch signing cert: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("fetch signing cert: status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read signing cert: %w", err)
+	}
+	return body, nil
+}
+
+// Verifier validates the authenticity of an SNS message. Because the SES event
+// ingress is a public, unauthenticated HTTP endpoint, signature verification is
+// a fail-closed security boundary: any failure rejects the message.
+type Verifier struct {
+	allowed map[string]struct{} // allow-listed TopicArns; empty ⇒ reject all
+	fetch   CertFetcher
+}
+
+// NewVerifier builds a Verifier. allowedTopicARNs is the set of SNS topics e2a
+// trusts; an empty set rejects every message (fail closed). fetch retrieves the
+// signing certificate (use HTTPCertFetcher in production).
+func NewVerifier(allowedTopicARNs []string, fetch CertFetcher) *Verifier {
+	allowed := make(map[string]struct{}, len(allowedTopicARNs))
+	for _, a := range allowedTopicARNs {
+		allowed[a] = struct{}{}
+	}
+	return &Verifier{allowed: allowed, fetch: fetch}
+}
+
+// Verify checks an SNS message fail-closed and returns nil only if it is
+// authentic and from a trusted topic. The checks run in order so the cheap,
+// no-network guards (topic allow-list, URL host) reject before any fetch.
+func (v *Verifier) Verify(ctx context.Context, m *SNSMessage) error {
+	if m == nil {
+		return fmt.Errorf("sns: nil message")
+	}
+
+	// (a) TopicArn allow-list. An empty allow-list rejects everything.
+	if _, ok := v.allowed[m.TopicArn]; !ok {
+		return fmt.Errorf("sns: topic not allowed: %q", m.TopicArn)
+	}
+
+	// (b) SigningCertURL must be an absolute HTTPS URL on a canonical SNS host.
+	certURL, err := url.Parse(m.SigningCertURL)
+	if err != nil {
+		return fmt.Errorf("sns: parse SigningCertURL: %w", err)
+	}
+	if !validSigningCertHost(certURL) {
+		return fmt.Errorf("sns: SigningCertURL host not allowed: %q", m.SigningCertURL)
+	}
+
+	// (c) Fetch + parse the signing certificate, extract its RSA public key.
+	pemBytes, err := v.fetch(ctx, m.SigningCertURL)
+	if err != nil {
+		return fmt.Errorf("sns: fetch signing cert: %w", err)
+	}
+	pub, err := rsaPublicKeyFromPEM(pemBytes)
+	if err != nil {
+		return fmt.Errorf("sns: %w", err)
+	}
+
+	// (d) Canonical string-to-sign (field set + order depend on Type).
+	canonical, err := canonicalStringToSign(m)
+	if err != nil {
+		return fmt.Errorf("sns: %w", err)
+	}
+
+	// (e) Hash per SignatureVersion, base64-decode Signature, verify PKCS1v15.
+	hashAlg, digest, err := hashForVersion(m.SignatureVersion, []byte(canonical))
+	if err != nil {
+		return fmt.Errorf("sns: %w", err)
+	}
+	sig, err := base64.StdEncoding.DecodeString(m.Signature)
+	if err != nil {
+		return fmt.Errorf("sns: decode signature: %w", err)
+	}
+	if err := rsa.VerifyPKCS1v15(pub, hashAlg, digest, sig); err != nil {
+		return fmt.Errorf("sns: signature verification failed: %w", err)
+	}
+	return nil
+}
+
+// IsSubscriptionConfirmation reports whether m is a topic subscription handshake
+// that the HTTP handler should confirm.
+func (v *Verifier) IsSubscriptionConfirmation(m *SNSMessage) bool {
+	return m != nil && m.Type == "SubscriptionConfirmation"
+}
+
+// ConfirmSubscriptionURL returns the SubscribeURL to GET (out of band) to
+// confirm a subscription, but only for a SubscriptionConfirmation envelope whose
+// SubscribeURL is an allow-listed HTTPS sns.*.amazonaws.com host (SSRF guard).
+// It does not perform the GET — the caller does, after Verify has passed.
+func ConfirmSubscriptionURL(m *SNSMessage) (string, bool) {
+	if m == nil || m.Type != "SubscriptionConfirmation" || m.SubscribeURL == "" {
+		return "", false
+	}
+	u, err := url.Parse(m.SubscribeURL)
+	if err != nil || !validSigningCertHost(u) {
+		return "", false
+	}
+	return m.SubscribeURL, true
+}
+
+// validSigningCertHost is the SSRF guard for SNS-supplied URLs: an absolute
+// HTTPS URL, no userinfo, the default port, and a canonical SNS host.
+func validSigningCertHost(u *url.URL) bool {
+	if u == nil || u.Scheme != "https" || u.Host == "" {
+		return false
+	}
+	if u.User != nil {
+		return false
+	}
+	if u.Port() != "" { // any explicit port (even :443) is non-canonical for SNS URLs
+		return false
+	}
+	return snsHostRE.MatchString(u.Hostname())
+}
+
+// canonicalStringToSign builds the AWS SNS string-to-sign: the signed fields in
+// a Type-specific order, each emitted as "key\nvalue\n".
+func canonicalStringToSign(m *SNSMessage) (string, error) {
+	var fields []string
+	switch m.Type {
+	case "Notification":
+		// Subject is included only when present.
+		fields = []string{"Message", m.Message, "MessageId", m.MessageId}
+		if m.Subject != "" {
+			fields = append(fields, "Subject", m.Subject)
+		}
+		fields = append(fields, "Timestamp", m.Timestamp, "TopicArn", m.TopicArn, "Type", m.Type)
+	case "SubscriptionConfirmation", "UnsubscribeConfirmation":
+		fields = []string{
+			"Message", m.Message,
+			"MessageId", m.MessageId,
+			"SubscribeURL", m.SubscribeURL,
+			"Timestamp", m.Timestamp,
+			"Token", m.Token,
+			"TopicArn", m.TopicArn,
+			"Type", m.Type,
+		}
+	default:
+		return "", fmt.Errorf("unsupported message type: %q", m.Type)
+	}
+	out := make([]byte, 0, 256)
+	for i := 0; i < len(fields); i += 2 {
+		out = append(out, fields[i]...)
+		out = append(out, '\n')
+		out = append(out, fields[i+1]...)
+		out = append(out, '\n')
+	}
+	return string(out), nil
+}
+
+// hashForVersion maps the SNS SignatureVersion to its hash algorithm and returns
+// the digest of data. "1" ⇒ SHA1, "2" ⇒ SHA256; anything else is rejected.
+func hashForVersion(version string, data []byte) (crypto.Hash, []byte, error) {
+	switch version {
+	case "1":
+		sum := sha1.Sum(data) //nolint:gosec // AWS SNS v1 signatures are SHA1.
+		return crypto.SHA1, sum[:], nil
+	case "2":
+		sum := sha256.Sum256(data)
+		return crypto.SHA256, sum[:], nil
+	default:
+		return 0, nil, fmt.Errorf("unsupported SignatureVersion: %q", version)
+	}
+}
+
+// rsaPublicKeyFromPEM decodes a PEM certificate and extracts its RSA public key.
+func rsaPublicKeyFromPEM(pemBytes []byte) (*rsa.PublicKey, error) {
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, fmt.Errorf("decode signing cert PEM")
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse signing cert: %w", err)
+	}
+	pub, ok := cert.PublicKey.(*rsa.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("signing cert public key is not RSA")
+	}
+	return pub, nil
+}

--- a/internal/delivery/sns_test.go
+++ b/internal/delivery/sns_test.go
@@ -1,0 +1,221 @@
+package delivery
+
+import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha1" //nolint:gosec // testing the SNS v1 (SHA1) signing path.
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"math/big"
+	"net/url"
+	"testing"
+	"time"
+)
+
+const testTopicARN = "arn:aws:sns:us-east-2:123456789012:e2a-delivery"
+
+// testCert generates an RSA key + self-signed cert and returns the key plus a
+// CertFetcher that serves the PEM-encoded cert.
+func testCert(t *testing.T) (*rsa.PrivateKey, CertFetcher) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "sns.amazonaws.com"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	fetch := func(_ context.Context, _ string) ([]byte, error) { return pemBytes, nil }
+	return key, fetch
+}
+
+// sign signs the canonical string of m with key using the algorithm for
+// SignatureVersion and writes the base64 signature into m.Signature.
+func sign(t *testing.T, key *rsa.PrivateKey, m *SNSMessage) {
+	t.Helper()
+	canonical, err := canonicalStringToSign(m)
+	if err != nil {
+		t.Fatalf("canonical: %v", err)
+	}
+	var hash crypto.Hash
+	var digest []byte
+	switch m.SignatureVersion {
+	case "1":
+		sum := sha1.Sum([]byte(canonical)) //nolint:gosec // v1 path under test.
+		hash, digest = crypto.SHA1, sum[:]
+	case "2":
+		sum := sha256.Sum256([]byte(canonical))
+		hash, digest = crypto.SHA256, sum[:]
+	default:
+		t.Fatalf("test sign: unsupported version %q", m.SignatureVersion)
+	}
+	sig, err := rsa.SignPKCS1v15(rand.Reader, key, hash, digest)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	m.Signature = base64.StdEncoding.EncodeToString(sig)
+}
+
+func notification(version string) *SNSMessage {
+	return &SNSMessage{
+		Type:             "Notification",
+		MessageId:        "msg-1",
+		TopicArn:         testTopicARN,
+		Subject:          "delivery",
+		Message:          `{"eventType":"Delivery"}`,
+		Timestamp:        "2026-06-15T00:00:00.000Z",
+		SignatureVersion: version,
+		SigningCertURL:   "https://sns.us-east-2.amazonaws.com/SimpleNotificationService-x.pem",
+	}
+}
+
+func TestSNSVerifyNotification(t *testing.T) {
+	for _, version := range []string{"1", "2"} {
+		t.Run("v"+version, func(t *testing.T) {
+			key, fetch := testCert(t)
+			m := notification(version)
+			sign(t, key, m)
+			v := NewVerifier([]string{testTopicARN}, fetch)
+			if err := v.Verify(context.Background(), m); err != nil {
+				t.Fatalf("expected valid signature, got: %v", err)
+			}
+		})
+	}
+}
+
+func TestSNSVerifyTamperedMessage(t *testing.T) {
+	key, fetch := testCert(t)
+	m := notification("1")
+	sign(t, key, m)
+	m.Message = `{"eventType":"Bounce"}` // changed after signing
+	v := NewVerifier([]string{testTopicARN}, fetch)
+	if err := v.Verify(context.Background(), m); err == nil {
+		t.Fatal("expected verification failure for tampered Message")
+	}
+}
+
+func TestSNSVerifyGarbageSignature(t *testing.T) {
+	key, fetch := testCert(t)
+	m := notification("2")
+	sign(t, key, m)
+	m.Signature = base64.StdEncoding.EncodeToString([]byte("not a real signature"))
+	v := NewVerifier([]string{testTopicARN}, fetch)
+	if err := v.Verify(context.Background(), m); err == nil {
+		t.Fatal("expected verification failure for garbage signature")
+	}
+
+	// Also: non-base64 signature.
+	m2 := notification("2")
+	sign(t, key, m2)
+	m2.Signature = "!!!not base64!!!"
+	if err := v.Verify(context.Background(), m2); err == nil {
+		t.Fatal("expected verification failure for non-base64 signature")
+	}
+}
+
+func TestSNSValidSigningCertHost(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want bool
+	}{
+		{"https://sns.us-east-2.amazonaws.com/x.pem", true},
+		{"https://sns.eu-west-1.amazonaws.com/SimpleNotificationService.pem", true},
+		{"http://sns.us-east-2.amazonaws.com/x.pem", false},
+		{"https://evil.com/x.pem", false},
+		{"https://sns.us-east-2.amazonaws.com.evil.com/x.pem", false},
+		{"https://user:pass@sns.us-east-2.amazonaws.com/x.pem", false},
+		{"https://example.amazonaws.com/x.pem", false},
+		{"https://sns.us-east-2.amazonaws.com:8443/x.pem", false},
+	}
+	for _, c := range cases {
+		t.Run(c.raw, func(t *testing.T) {
+			u, err := url.Parse(c.raw)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if got := validSigningCertHost(u); got != c.want {
+				t.Fatalf("validSigningCertHost(%q) = %v, want %v", c.raw, got, c.want)
+			}
+		})
+	}
+}
+
+func TestSNSVerifyTopicNotAllowed(t *testing.T) {
+	key, fetch := testCert(t)
+	m := notification("1")
+	m.TopicArn = "arn:aws:sns:us-east-2:000000000000:other"
+	sign(t, key, m)
+	v := NewVerifier([]string{testTopicARN}, fetch)
+	if err := v.Verify(context.Background(), m); err == nil {
+		t.Fatal("expected rejection: topic not in allow-list")
+	}
+}
+
+func TestSNSVerifyEmptyAllowListRejects(t *testing.T) {
+	key, fetch := testCert(t)
+	m := notification("1")
+	sign(t, key, m)
+	// Empty allow-list ⇒ fail closed even with an otherwise-valid signature.
+	v := NewVerifier(nil, fetch)
+	if err := v.Verify(context.Background(), m); err == nil {
+		t.Fatal("expected rejection: empty allow-list must reject all")
+	}
+}
+
+func TestSNSVerifyUnsupportedSignatureVersion(t *testing.T) {
+	key, fetch := testCert(t)
+	m := notification("1")
+	sign(t, key, m) // signature itself is fine; version field is what's rejected
+	m.SignatureVersion = "3"
+	v := NewVerifier([]string{testTopicARN}, fetch)
+	if err := v.Verify(context.Background(), m); err == nil {
+		t.Fatal("expected rejection: unsupported SignatureVersion")
+	}
+}
+
+func TestSNSSubscriptionConfirmation(t *testing.T) {
+	key, fetch := testCert(t)
+	m := &SNSMessage{
+		Type:             "SubscriptionConfirmation",
+		MessageId:        "msg-sub-1",
+		TopicArn:         testTopicARN,
+		Message:          "You have chosen to subscribe...",
+		Token:            "tok-123",
+		SubscribeURL:     "https://sns.us-east-2.amazonaws.com/?Action=ConfirmSubscription&Token=tok-123",
+		Timestamp:        "2026-06-15T00:00:00.000Z",
+		SignatureVersion: "1",
+		SigningCertURL:   "https://sns.us-east-2.amazonaws.com/SimpleNotificationService-x.pem",
+	}
+	sign(t, key, m)
+	v := NewVerifier([]string{testTopicARN}, fetch)
+	if err := v.Verify(context.Background(), m); err != nil {
+		t.Fatalf("expected valid subscription confirmation, got: %v", err)
+	}
+	if !v.IsSubscriptionConfirmation(m) {
+		t.Fatal("IsSubscriptionConfirmation should be true")
+	}
+
+	got, ok := ConfirmSubscriptionURL(m)
+	if !ok || got != m.SubscribeURL {
+		t.Fatalf("ConfirmSubscriptionURL = (%q, %v), want (%q, true)", got, ok, m.SubscribeURL)
+	}
+
+	// A SubscribeURL on a non-allow-listed host must be refused.
+	m.SubscribeURL = "https://evil.com/?Action=ConfirmSubscription"
+	if _, ok := ConfirmSubscriptionURL(m); ok {
+		t.Fatal("ConfirmSubscriptionURL must reject a non-allow-listed host")
+	}
+}

--- a/internal/delivery/status.go
+++ b/internal/delivery/status.go
@@ -1,0 +1,68 @@
+// Package delivery implements outbound delivery feedback (decision 9 /
+// Slice 4b): the async delivery lifecycle SES reports per message and per
+// recipient, plus a per-tenant suppression list. The SES notifications are
+// ingested over SNS (see sns.go / consumer.go); the AWS surface stays at the
+// edge so the transition/suppression logic is testable without AWS.
+package delivery
+
+// Status is the outbound delivery lifecycle of a message (or a single
+// recipient of it). It maps 1:1 onto messages.delivery_status /
+// message_recipients.status.
+type Status string
+
+const (
+	StatusQueued     Status = "queued"     // accepted into the outbound path, not yet relayed
+	StatusSent       Status = "sent"       // accepted by the relay (SES) — NON-terminal
+	StatusDeferred   Status = "deferred"   // transient delay (SES deliveryDelay); poll, no event
+	StatusDelivered  Status = "delivered"  // SES confirmed delivery to the recipient MTA
+	StatusBounced    Status = "bounced"    // hard/soft bounce
+	StatusComplained Status = "complained" // recipient marked spam (FBL complaint)
+	StatusFailed     Status = "failed"     // local send failure (never reached the relay)
+)
+
+// rank orders statuses by the decision-9 monotonic precedence
+//
+//	complained > bounced > delivered > deferred > sent > queued
+//
+// plus `failed` as a terminal local outcome above all SES feedback. Higher
+// rank wins a merge, so out-of-order or duplicate SNS events can never regress
+// a terminal status (a late `delivered` never clobbers a `complained`).
+var rank = map[Status]int{
+	StatusQueued:     0,
+	StatusSent:       1,
+	StatusDeferred:   2,
+	StatusDelivered:  3,
+	StatusBounced:    4,
+	StatusComplained: 5,
+	StatusFailed:     6,
+}
+
+// Valid reports whether s is a known status.
+func (s Status) Valid() bool {
+	_, ok := rank[s]
+	return ok
+}
+
+// Terminal reports whether s is a final state that should never transition
+// further. (`sent`/`queued`/`deferred` are non-terminal; the rest are final.)
+func (s Status) Terminal() bool {
+	switch s {
+	case StatusDelivered, StatusBounced, StatusComplained, StatusFailed:
+		return true
+	}
+	return false
+}
+
+// Merge returns the status that should result from observing `incoming` while
+// currently at `current`, applying the monotonic precedence: the higher-ranked
+// status wins, so a transition only ever moves "up". An unknown current (e.g.
+// empty) is treated as the lowest rank so any valid incoming status applies.
+func Merge(current, incoming Status) Status {
+	if !incoming.Valid() {
+		return current
+	}
+	if rank[incoming] > rank[current] {
+		return incoming
+	}
+	return current
+}

--- a/internal/delivery/status_test.go
+++ b/internal/delivery/status_test.go
@@ -1,0 +1,47 @@
+package delivery
+
+import "testing"
+
+func TestMergeMonotonic(t *testing.T) {
+	tests := []struct {
+		name              string
+		current, incoming Status
+		want              Status
+	}{
+		{"queued→sent", StatusQueued, StatusSent, StatusSent},
+		{"sent→delivered", StatusSent, StatusDelivered, StatusDelivered},
+		{"sent→bounced", StatusSent, StatusBounced, StatusBounced},
+		{"delivered→bounced (bounce wins)", StatusDelivered, StatusBounced, StatusBounced},
+		{"bounced→complained (complaint wins)", StatusBounced, StatusComplained, StatusComplained},
+		// The load-bearing invariant: a late lower-rank event never regresses a terminal status.
+		{"complained NOT clobbered by late delivered", StatusComplained, StatusDelivered, StatusComplained},
+		{"bounced NOT clobbered by late delivered", StatusBounced, StatusDelivered, StatusBounced},
+		{"delivered NOT regressed by late deferred", StatusDelivered, StatusDeferred, StatusDelivered},
+		{"deferred→delivered (resolution wins)", StatusDeferred, StatusDelivered, StatusDelivered},
+		{"duplicate delivered is idempotent", StatusDelivered, StatusDelivered, StatusDelivered},
+		{"empty current accepts any valid", Status(""), StatusSent, StatusSent},
+		{"invalid incoming is ignored", StatusDelivered, Status("garbage"), StatusDelivered},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Merge(tc.current, tc.incoming); got != tc.want {
+				t.Errorf("Merge(%q,%q) = %q, want %q", tc.current, tc.incoming, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStatusTerminal(t *testing.T) {
+	terminal := []Status{StatusDelivered, StatusBounced, StatusComplained, StatusFailed}
+	nonTerminal := []Status{StatusQueued, StatusSent, StatusDeferred}
+	for _, s := range terminal {
+		if !s.Terminal() {
+			t.Errorf("%q should be terminal", s)
+		}
+	}
+	for _, s := range nonTerminal {
+		if s.Terminal() {
+			t.Errorf("%q should not be terminal", s)
+		}
+	}
+}

--- a/internal/httpapi/account.go
+++ b/internal/httpapi/account.go
@@ -54,6 +54,67 @@ func (s *Server) registerAccount() {
 		Description: "Permanently deletes the account and cascades all owned data. Requires ?confirm=DELETE.",
 		Security:    []map[string][]string{{"bearer": {}}},
 	}, s.handleDeleteAccount)
+
+	huma.Register(s.API, huma.Operation{
+		OperationID: "listSuppressions", Method: http.MethodGet, Path: "/v1/account/suppressions",
+		Summary: "List suppressed recipient addresses", Tags: []string{"account"},
+		Description: "Addresses e2a will refuse to send to (auto-added on a hard bounce or complaint, or added manually). Sends to a suppressed address fail with recipient_suppressed.",
+		Security:    []map[string][]string{{"bearer": {}}},
+	}, s.handleListSuppressions)
+
+	huma.Register(s.API, huma.Operation{
+		OperationID: "deleteSuppression", Method: http.MethodDelete, Path: "/v1/account/suppressions/{address}",
+		Summary: "Remove an address from the suppression list", Tags: []string{"account"},
+		Description: "Un-suppress a recipient. A previously-blocked send to it then succeeds (idempotency keys are released, so no fresh key is needed).",
+		Security:    []map[string][]string{{"bearer": {}}}, DefaultStatus: http.StatusNoContent,
+	}, s.handleDeleteSuppression)
+}
+
+type suppressionsOutput struct {
+	Body struct {
+		Suppressions []identity.Suppression `json:"suppressions"`
+	}
+}
+
+func (s *Server) handleListSuppressions(ctx context.Context, _ *struct{}) (*suppressionsOutput, error) {
+	user, err := s.requireUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if s.deps.ListSuppressions == nil {
+		return nil, NewError(http.StatusNotImplemented, "not_implemented", "suppressions are not available on this deployment")
+	}
+	list, err := s.deps.ListSuppressions(ctx, user.ID)
+	if err != nil {
+		return nil, NewError(http.StatusInternalServerError, "internal_error", "failed to list suppressions")
+	}
+	out := &suppressionsOutput{}
+	out.Body.Suppressions = make([]identity.Suppression, 0, len(list))
+	out.Body.Suppressions = append(out.Body.Suppressions, list...)
+	return out, nil
+}
+
+type deleteSuppressionInput struct {
+	Address string `path:"address"`
+}
+type deleteSuppressionOutput struct{ Status int }
+
+func (s *Server) handleDeleteSuppression(ctx context.Context, in *deleteSuppressionInput) (*deleteSuppressionOutput, error) {
+	user, err := s.requireUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if s.deps.RemoveSuppression == nil {
+		return nil, NewError(http.StatusNotImplemented, "not_implemented", "suppressions are not available on this deployment")
+	}
+	found, err := s.deps.RemoveSuppression(ctx, user.ID, in.Address)
+	if err != nil {
+		return nil, NewError(http.StatusInternalServerError, "internal_error", "failed to remove suppression")
+	}
+	if !found {
+		return nil, NewError(http.StatusNotFound, "not_found", "address not on the suppression list")
+	}
+	return &deleteSuppressionOutput{Status: http.StatusNoContent}, nil
 }
 
 type exportOutput struct {

--- a/internal/httpapi/httpapi.go
+++ b/internal/httpapi/httpapi.go
@@ -123,7 +123,12 @@ type Deps struct {
 	GetLimits      func(ctx context.Context, userID string) (limits.Limits, error)
 	GetUsage       func(ctx context.Context, userID string) LimitsUsageView
 	ExportUserData func(ctx context.Context, userID string) (*identity.UserExport, error)
-	DeleteUserData func(ctx context.Context, user *identity.User) (*identity.DeleteUserDataResult, error)
+
+	// Suppression list (decision 9 / Slice 4b). Optional — nil deployments
+	// return 501 from the /v1/account/suppressions endpoints.
+	ListSuppressions  func(ctx context.Context, userID string) ([]identity.Suppression, error)
+	RemoveSuppression func(ctx context.Context, userID, address string) (bool, error)
+	DeleteUserData    func(ctx context.Context, user *identity.User) (*identity.DeleteUserDataResult, error)
 
 	// events (delivery log). EventQuery carries the filters + cursor
 	// position; the closures bind the events pool in main.

--- a/internal/httpapi/messages.go
+++ b/internal/httpapi/messages.go
@@ -19,23 +19,33 @@ import (
 // absent cc/reply_to/auth_headers/raw_message. `status` carries the legacy
 // delivery_status alias verbatim (the read_status rename is a later slice).
 type MessageView struct {
-	MessageID      string            `json:"message_id"`
-	From           string            `json:"from"`
-	To             []string          `json:"to"`
-	CC             []string          `json:"cc"`
-	ReplyTo        []string          `json:"reply_to"`
-	Recipient      string            `json:"recipient"`
-	Subject        string            `json:"subject"`
-	ConversationID string            `json:"conversation_id"`
-	Status         string            `json:"status"`
-	Labels         []string          `json:"labels"`
-	CreatedAt      string            `json:"created_at"`
-	AuthHeaders    map[string]string `json:"auth_headers"`
-	RawMessage     []byte            `json:"raw_message"`
+	MessageID      string   `json:"message_id"`
+	From           string   `json:"from"`
+	To             []string `json:"to"`
+	CC             []string `json:"cc"`
+	ReplyTo        []string `json:"reply_to"`
+	Recipient      string   `json:"recipient"`
+	Subject        string   `json:"subject"`
+	ConversationID string   `json:"conversation_id"`
+	Status         string   `json:"status"`
+	// DeliveryStatus is the outbound delivery rollup (migration 031:
+	// 'sent', 'delivered', 'bounced', …) — the worst recipient status by
+	// precedence. Outbound-only; omitted on inbound messages.
+	DeliveryStatus string `json:"delivery_status,omitempty"`
+	// DeliveryDetail is the human-readable diagnostic for the delivery
+	// rollup (e.g. bounce sub-type / SMTP response). Outbound-only.
+	DeliveryDetail string `json:"delivery_detail,omitempty"`
+	// SentAs is the From identity actually used at relay accept time.
+	// Outbound-only; omitted on inbound messages.
+	SentAs      string            `json:"sent_as,omitempty"`
+	Labels      []string          `json:"labels"`
+	CreatedAt   string            `json:"created_at"`
+	AuthHeaders map[string]string `json:"auth_headers"`
+	RawMessage  []byte            `json:"raw_message"`
 }
 
 func messageViewFromIdentity(m *identity.Message) MessageView {
-	return MessageView{
+	v := MessageView{
 		MessageID:      m.ID,
 		From:           m.Sender,
 		To:             orEmptyStrings(m.ToRecipients),
@@ -50,6 +60,15 @@ func messageViewFromIdentity(m *identity.Message) MessageView {
 		AuthHeaders:    m.AuthHeaders,
 		RawMessage:     m.RawMessage,
 	}
+	// Outbound delivery feedback (migration 031). On outbound rows
+	// identity.Message.DeliveryStatus carries the delivery rollup; on
+	// inbound rows it carries inbox_status, so these stay empty there.
+	if m.Direction == "outbound" {
+		v.DeliveryStatus = m.DeliveryStatus
+		v.DeliveryDetail = m.DeliveryDetail
+		v.SentAs = m.SentAs
+	}
+	return v
 }
 
 // MessageIDParam is the path input for single-message operations.
@@ -83,6 +102,11 @@ type MessageSummaryView struct {
 	HITLStatus     string   `json:"hitl_status,omitempty"`
 	WebhookStatus  string   `json:"webhook_status,omitempty"`
 	WebhookError   string   `json:"webhook_error,omitempty"`
+	// DeliveryStatus / DeliveryDetail / SentAs are the outbound delivery
+	// rollup (migration 031). Outbound-only; omitted on inbound rows.
+	DeliveryStatus string   `json:"delivery_status,omitempty"`
+	DeliveryDetail string   `json:"delivery_detail,omitempty"`
+	SentAs         string   `json:"sent_as,omitempty"`
 	SizeBytes      int      `json:"size_bytes,omitempty"`
 	Labels         []string `json:"labels"`
 	CreatedAt      string   `json:"created_at"`
@@ -108,6 +132,12 @@ func messageSummaryFromIdentity(m identity.Message) MessageSummaryView {
 		s.HITLStatus = m.Status
 		s.WebhookStatus = m.WebhookStatus
 		s.WebhookError = m.WebhookError
+		// On outbound rows identity.Message.DeliveryStatus carries the
+		// delivery rollup (migration 031); inbound rows carry inbox_status,
+		// already surfaced as Status above.
+		s.DeliveryStatus = m.DeliveryStatus
+		s.DeliveryDetail = m.DeliveryDetail
+		s.SentAs = m.SentAs
 	}
 	return s
 }

--- a/internal/identity/delivery_store.go
+++ b/internal/identity/delivery_store.go
@@ -1,0 +1,248 @@
+package identity
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/Mnexa-AI/e2a/internal/delivery"
+	"github.com/jackc/pgx/v5"
+)
+
+// --- Delivery feedback (decision 9 / Slice 4b) ---
+//
+// These back internal/delivery's Consumer.Store and the send path + the
+// /v1/account/suppressions endpoints. delivery is a stdlib-only leaf package,
+// so identity importing it (for delivery.Status / delivery.Merge) adds no heavy
+// deps — unlike senderidentity, no adapter is needed.
+
+// CorrelateBySESMessageID finds the outbound message + owning user by the
+// SES-assigned provider_message_id captured at send time. found=false when the
+// id is unknown (expired message, or an event for a different deployment).
+func (s *Store) CorrelateBySESMessageID(ctx context.Context, sesMessageID string) (messageID, userID, agentID string, found bool, err error) {
+	if sesMessageID == "" {
+		return "", "", "", false, nil
+	}
+	err = s.pool.QueryRow(ctx,
+		`SELECT m.id, a.user_id, m.agent_id
+		   FROM messages m
+		   JOIN agent_identities a ON a.id = m.agent_id
+		  WHERE m.provider_message_id = $1 AND m.direction = 'outbound'
+		  LIMIT 1`,
+		sesMessageID,
+	).Scan(&messageID, &userID, &agentID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return "", "", "", false, nil
+	}
+	if err != nil {
+		return "", "", "", false, err
+	}
+	return messageID, userID, agentID, true, nil
+}
+
+// RecordDeliveryOutcome upserts one recipient's status monotonically (by the
+// delivery precedence) and recomputes the message's rollup delivery_status as
+// the worst status across its recipients. Runs in a tx with FOR UPDATE so
+// concurrent SNS events can't race the merge. Idempotent: a duplicate or older
+// event is a no-op for the status (detail still refreshes on an equal/higher).
+func (s *Store) RecordDeliveryOutcome(ctx context.Context, messageID, address string, status delivery.Status, detail string) error {
+	addr := NormalizeEmail(address)
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	var cur string
+	err = tx.QueryRow(ctx,
+		`SELECT status FROM message_recipients WHERE message_id = $1 AND address = $2 FOR UPDATE`,
+		messageID, addr,
+	).Scan(&cur)
+	switch {
+	case errors.Is(err, pgx.ErrNoRows):
+		// Recipient row not pre-populated (e.g. SES reports an address the send
+		// path didn't record) — insert it at the observed status.
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO message_recipients (id, message_id, address, status, detail)
+			 VALUES ($1, $2, $3, $4, $5)
+			 ON CONFLICT (message_id, address) DO NOTHING`,
+			"rcpt_"+generateID(), messageID, addr, string(status), nullIfEmpty(detail),
+		); err != nil {
+			return err
+		}
+	case err != nil:
+		return err
+	default:
+		merged := delivery.Merge(delivery.Status(cur), status)
+		if _, err := tx.Exec(ctx,
+			`UPDATE message_recipients SET status = $3, detail = COALESCE($4, detail), updated_at = now()
+			  WHERE message_id = $1 AND address = $2`,
+			messageID, addr, string(merged), nullIfEmpty(detail),
+		); err != nil {
+			return err
+		}
+	}
+
+	// Recompute the rollup = worst recipient status by precedence. Few
+	// recipients per message, so reduce in Go to keep the rank logic in one
+	// place (delivery.Merge).
+	rows, err := tx.Query(ctx, `SELECT status FROM message_recipients WHERE message_id = $1`, messageID)
+	if err != nil {
+		return err
+	}
+	var rollup delivery.Status
+	for rows.Next() {
+		var st string
+		if err := rows.Scan(&st); err != nil {
+			rows.Close()
+			return err
+		}
+		rollup = delivery.Merge(rollup, delivery.Status(st))
+	}
+	rows.Close()
+	if rollup != "" {
+		if _, err := tx.Exec(ctx,
+			`UPDATE messages SET delivery_status = $2 WHERE id = $1`, messageID, string(rollup),
+		); err != nil {
+			return err
+		}
+	}
+	return tx.Commit(ctx)
+}
+
+// MarkMessageSent records that an outbound message was accepted by the relay:
+// delivery_status='sent', the From identity actually used, and one
+// message_recipients row per recipient (to/cc/bcc) at 'sent'. Called after a
+// successful relay accept. Idempotent on the recipient rows.
+func (s *Store) MarkMessageSent(ctx context.Context, messageID, sentAs string, to, cc, bcc []string) error {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	if _, err := tx.Exec(ctx,
+		`UPDATE messages SET delivery_status = 'sent', sent_as = $2 WHERE id = $1`,
+		messageID, nullIfEmpty(sentAs),
+	); err != nil {
+		return err
+	}
+	add := func(addrs []string, kind string) error {
+		for _, a := range addrs {
+			addr := NormalizeEmail(a)
+			if addr == "" {
+				continue
+			}
+			if _, err := tx.Exec(ctx,
+				`INSERT INTO message_recipients (id, message_id, address, kind, status)
+				 VALUES ($1, $2, $3, $4, 'sent')
+				 ON CONFLICT (message_id, address) DO NOTHING`,
+				"rcpt_"+generateID(), messageID, addr, kind,
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if err := add(to, "to"); err != nil {
+		return err
+	}
+	if err := add(cc, "cc"); err != nil {
+		return err
+	}
+	if err := add(bcc, "bcc"); err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+// --- Suppression list ---
+
+// Suppression is one (user, address) entry on the per-tenant suppression list.
+type Suppression struct {
+	Address         string    `json:"address"`
+	Reason          string    `json:"reason,omitempty"`
+	Source          string    `json:"source"` // bounce | complaint | manual
+	SourceMessageID string    `json:"source_message_id,omitempty"`
+	CreatedAt       time.Time `json:"created_at"`
+}
+
+// AddSuppression idempotently inserts a (user, address) suppression. added is
+// false when it already existed, so the caller fires domain.suppression_added
+// at most once per address.
+func (s *Store) AddSuppression(ctx context.Context, userID, address, reason, source, sourceMessageID string) (bool, error) {
+	tag, err := s.pool.Exec(ctx,
+		`INSERT INTO suppressions (id, user_id, address, reason, source, source_message_id)
+		 VALUES ($1, $2, $3, $4, $5, $6)
+		 ON CONFLICT (user_id, address) DO NOTHING`,
+		"supp_"+generateID(), userID, NormalizeEmail(address), reason, source, nullIfEmpty(sourceMessageID),
+	)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+// SuppressedAddresses returns the subset of addrs that are suppressed for the
+// user — the send-time enforcement read. Empty input → empty result.
+func (s *Store) SuppressedAddresses(ctx context.Context, userID string, addrs []string) ([]string, error) {
+	if len(addrs) == 0 {
+		return nil, nil
+	}
+	norm := make([]string, 0, len(addrs))
+	for _, a := range addrs {
+		norm = append(norm, NormalizeEmail(a))
+	}
+	rows, err := s.pool.Query(ctx,
+		`SELECT address FROM suppressions WHERE user_id = $1 AND address = ANY($2)`,
+		userID, norm,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []string
+	for rows.Next() {
+		var a string
+		if err := rows.Scan(&a); err != nil {
+			return nil, err
+		}
+		out = append(out, a)
+	}
+	return out, rows.Err()
+}
+
+// ListSuppressions returns the user's suppression list, newest first.
+func (s *Store) ListSuppressions(ctx context.Context, userID string) ([]Suppression, error) {
+	rows, err := s.pool.Query(ctx,
+		`SELECT address, reason, source, COALESCE(source_message_id, ''), created_at
+		   FROM suppressions WHERE user_id = $1 ORDER BY created_at DESC`,
+		userID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Suppression
+	for rows.Next() {
+		var sp Suppression
+		if err := rows.Scan(&sp.Address, &sp.Reason, &sp.Source, &sp.SourceMessageID, &sp.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, sp)
+	}
+	return out, rows.Err()
+}
+
+// RemoveSuppression deletes a (user, address) suppression. found=false when no
+// such entry existed.
+func (s *Store) RemoveSuppression(ctx context.Context, userID, address string) (bool, error) {
+	tag, err := s.pool.Exec(ctx,
+		`DELETE FROM suppressions WHERE user_id = $1 AND address = $2`,
+		userID, NormalizeEmail(address),
+	)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() > 0, nil
+}

--- a/internal/identity/delivery_store.go
+++ b/internal/identity/delivery_store.go
@@ -19,6 +19,12 @@ import (
 // CorrelateBySESMessageID finds the outbound message + owning user by the
 // SES-assigned provider_message_id captured at send time. found=false when the
 // id is unknown (expired message, or an event for a different deployment).
+//
+// The SNS notification carries the BARE SES id (e.g. 010f0193…-000000), but the
+// send path stores it angle-bracketed and sometimes with an @region.amazonses.com
+// suffix (parseMessageIDFromResponse) — same discrepancy LookupConversationID
+// works around. Match all three stored shapes against the bare id: exact,
+// <id>, and <id@…>. SES ids are [A-Za-z0-9-] so they carry no LIKE metacharacters.
 func (s *Store) CorrelateBySESMessageID(ctx context.Context, sesMessageID string) (messageID, userID, agentID string, found bool, err error) {
 	if sesMessageID == "" {
 		return "", "", "", false, nil
@@ -27,7 +33,10 @@ func (s *Store) CorrelateBySESMessageID(ctx context.Context, sesMessageID string
 		`SELECT m.id, a.user_id, m.agent_id
 		   FROM messages m
 		   JOIN agent_identities a ON a.id = m.agent_id
-		  WHERE m.provider_message_id = $1 AND m.direction = 'outbound'
+		  WHERE m.direction = 'outbound'
+		    AND ( m.provider_message_id = $1
+		       OR m.provider_message_id = '<' || $1 || '>'
+		       OR m.provider_message_id LIKE '<' || $1 || '@%' )
 		  LIMIT 1`,
 		sesMessageID,
 	).Scan(&messageID, &userID, &agentID)
@@ -53,19 +62,34 @@ func (s *Store) RecordDeliveryOutcome(ctx context.Context, messageID, address st
 	}
 	defer tx.Rollback(ctx)
 
+	// Lock the message row to serialize ALL events for this message (every
+	// recipient). SES fans out delivery + bounce/complaint for the same message
+	// concurrently; without this, two events for different recipients (or two
+	// first-events for an un-pre-populated recipient) race the rollup write and
+	// the insert ON CONFLICT path, dropping a terminal status. The lock makes
+	// the read-merge-write below strictly monotonic per message.
+	var lockedID string
+	err = tx.QueryRow(ctx, `SELECT id FROM messages WHERE id = $1 FOR UPDATE`, messageID).Scan(&lockedID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil // message deleted between correlation and now
+	}
+	if err != nil {
+		return err
+	}
+
 	var cur string
 	err = tx.QueryRow(ctx,
-		`SELECT status FROM message_recipients WHERE message_id = $1 AND address = $2 FOR UPDATE`,
+		`SELECT status FROM message_recipients WHERE message_id = $1 AND address = $2`,
 		messageID, addr,
 	).Scan(&cur)
 	switch {
 	case errors.Is(err, pgx.ErrNoRows):
 		// Recipient row not pre-populated (e.g. SES reports an address the send
-		// path didn't record) — insert it at the observed status.
+		// path didn't record). Serialized by the message-row lock, so no insert
+		// race.
 		if _, err := tx.Exec(ctx,
 			`INSERT INTO message_recipients (id, message_id, address, status, detail)
-			 VALUES ($1, $2, $3, $4, $5)
-			 ON CONFLICT (message_id, address) DO NOTHING`,
+			 VALUES ($1, $2, $3, $4, $5)`,
 			"rcpt_"+generateID(), messageID, addr, string(status), nullIfEmpty(detail),
 		); err != nil {
 			return err
@@ -74,12 +98,18 @@ func (s *Store) RecordDeliveryOutcome(ctx context.Context, messageID, address st
 		return err
 	default:
 		merged := delivery.Merge(delivery.Status(cur), status)
-		if _, err := tx.Exec(ctx,
-			`UPDATE message_recipients SET status = $3, detail = COALESCE($4, detail), updated_at = now()
-			  WHERE message_id = $1 AND address = $2`,
-			messageID, addr, string(merged), nullIfEmpty(detail),
-		); err != nil {
-			return err
+		// Only write when the status actually advances — a duplicate/lower-rank
+		// event must not regress the status NOR clobber the diagnostic detail
+		// (a late `delivered` carrying a detail must not overwrite the bounce
+		// reason).
+		if merged != delivery.Status(cur) {
+			if _, err := tx.Exec(ctx,
+				`UPDATE message_recipients SET status = $3, detail = COALESCE($4, detail), updated_at = now()
+				  WHERE message_id = $1 AND address = $2`,
+				messageID, addr, string(merged), nullIfEmpty(detail),
+			); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -166,12 +166,26 @@ type Message struct {
 	RawMessage        []byte            `json:"raw_message,omitempty"`
 	AuthHeaders       map[string]string `json:"auth_headers,omitempty"`
 	ConversationID    string            `json:"conversation_id,omitempty"`
-	DeliveryStatus    string            `json:"delivery_status,omitempty"`
-	CreatedAt         time.Time         `json:"created_at"`
-	ExpiresAt         time.Time         `json:"expires_at"`
-	WebhookStatus     string            `json:"webhook_status,omitempty"`
-	WebhookError      string            `json:"webhook_error,omitempty"`
-	WebhookAttempts   int               `json:"webhook_attempts,omitempty"`
+	// DeliveryStatus is overloaded by direction. On inbound rows it carries
+	// the inbox read/unread status (messages.inbox_status) under this legacy
+	// JSON key. On outbound rows it carries the outbound delivery rollup
+	// (messages.delivery_status from migration 031: 'sent', 'delivered',
+	// 'bounced', …) — the worst recipient status by precedence. A message is
+	// either inbound or outbound, so the two sources never collide per-row.
+	DeliveryStatus string `json:"delivery_status,omitempty"`
+	// DeliveryDetail is the human-readable diagnostic for the outbound
+	// delivery rollup (e.g. an SES bounce sub-type / SMTP response).
+	// Outbound-only; empty on inbound rows. Source: messages.delivery_detail.
+	DeliveryDetail string `json:"delivery_detail,omitempty"`
+	// SentAs is the From identity actually used when the outbound message was
+	// accepted by the relay. Outbound-only; empty on inbound rows. Source:
+	// messages.sent_as.
+	SentAs          string    `json:"sent_as,omitempty"`
+	CreatedAt       time.Time `json:"created_at"`
+	ExpiresAt       time.Time `json:"expires_at"`
+	WebhookStatus   string    `json:"webhook_status,omitempty"`
+	WebhookError    string    `json:"webhook_error,omitempty"`
+	WebhookAttempts int       `json:"webhook_attempts,omitempty"`
 	// SizeBytes is the byte length of raw_message. Populated by load paths
 	// that compute it (e.g. GetMessagesByAgent for the dashboard inbox).
 	// Zero on load paths that don't — the inbox renders "—" in that case.
@@ -1274,7 +1288,8 @@ func (s *Store) GetOutboundMessageForUser(ctx context.Context, messageID, userID
 		        m.status, m.approval_expires_at, m.reviewed_at,
 		        m.rejection_reason, m.edited,
 		        m.body_text, m.body_html, m.attachments_json,
-		        m.reviewed_by_user_id, r.name
+		        m.reviewed_by_user_id, r.name,
+		        COALESCE(m.delivery_status, ''), COALESCE(m.delivery_detail, ''), COALESCE(m.sent_as, '')
 		 FROM messages m
 		 JOIN agent_identities a ON a.id = m.agent_id
 		 LEFT JOIN users r ON r.id = m.reviewed_by_user_id
@@ -1290,6 +1305,7 @@ func (s *Store) GetOutboundMessageForUser(ctx context.Context, messageID, userID
 		&rejectionReason, &m.Edited,
 		&bodyText, &bodyHTML, &attachments,
 		&reviewedByID, &reviewedByName,
+		&m.DeliveryStatus, &m.DeliveryDetail, &m.SentAs,
 	)
 	if err != nil {
 		return nil, ErrMessageNotFound
@@ -1336,7 +1352,8 @@ func (s *Store) ListPendingOutboundForUser(ctx context.Context, userID string, l
 		        COALESCE(m.message_type, ''),
 		        m.conversation_id, m.created_at,
 		        m.to_recipients, m.cc, m.bcc,
-		        m.status, m.approval_expires_at
+		        m.status, m.approval_expires_at,
+		        COALESCE(m.delivery_status, ''), COALESCE(m.delivery_detail, ''), COALESCE(m.sent_as, '')
 		 FROM messages m
 		 JOIN agent_identities a ON a.id = m.agent_id
 		 WHERE a.user_id = $1 AND m.status = 'pending_approval'
@@ -1358,6 +1375,7 @@ func (s *Store) ListPendingOutboundForUser(ctx context.Context, userID string, l
 			&m.ConversationID, &m.CreatedAt,
 			&m.ToRecipients, &m.CC, &m.BCC,
 			&m.Status, &approvalExpires,
+			&m.DeliveryStatus, &m.DeliveryDetail, &m.SentAs,
 		); err != nil {
 			return nil, err
 		}
@@ -1979,7 +1997,8 @@ func (s *Store) ListActivityByAgent(ctx context.Context, agentID string, limit i
 		        COALESCE(wd.status, ''), COALESCE(wd.last_error, ''), COALESCE(wd.attempts, 0),
 		        m.to_recipients, m.cc, m.bcc,
 		        COALESCE(m.conversation_id, ''), COALESCE(octet_length(m.raw_message), 0),
-		        m.labels
+		        m.labels,
+		        COALESCE(m.delivery_status, ''), COALESCE(m.delivery_detail, ''), COALESCE(m.sent_as, '')
 		 FROM messages m
 		 LEFT JOIN webhook_deliveries wd ON wd.message_id = m.id
 		 WHERE m.agent_id = $1 AND m.expires_at > now()
@@ -1994,8 +2013,17 @@ func (s *Store) ListActivityByAgent(ctx context.Context, agentID string, limit i
 	var messages []Message
 	for rows.Next() {
 		var m Message
-		if err := rows.Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.Subject, &m.EmailMessageID, &m.Method, &m.Type, &m.DeliveryStatus, &m.CreatedAt, &m.ExpiresAt, &m.WebhookStatus, &m.WebhookError, &m.WebhookAttempts, &m.ToRecipients, &m.CC, &m.BCC, &m.ConversationID, &m.SizeBytes, &m.Labels); err != nil {
+		var inboxStatus, outboundDeliveryStatus string
+		if err := rows.Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.Subject, &m.EmailMessageID, &m.Method, &m.Type, &inboxStatus, &m.CreatedAt, &m.ExpiresAt, &m.WebhookStatus, &m.WebhookError, &m.WebhookAttempts, &m.ToRecipients, &m.CC, &m.BCC, &m.ConversationID, &m.SizeBytes, &m.Labels, &outboundDeliveryStatus, &m.DeliveryDetail, &m.SentAs); err != nil {
 			return nil, err
+		}
+		// DeliveryStatus is overloaded by direction (see Message.DeliveryStatus):
+		// inbound carries inbox_status, outbound carries the delivery rollup.
+		m.InboxStatus = inboxStatus
+		if m.Direction == "outbound" {
+			m.DeliveryStatus = outboundDeliveryStatus
+		} else {
+			m.DeliveryStatus = inboxStatus
 		}
 		messages = append(messages, m)
 	}
@@ -2067,7 +2095,7 @@ func (s *Store) GetMessagesByAgent(ctx context.Context, f MessageListFilter) ([]
 	var query string
 	var args []interface{}
 
-	baseSelect := `SELECT m.id, m.agent_id, m.direction, m.sender, m.recipient, m.to_recipients, m.cc, m.reply_to, m.subject, m.email_message_id, m.conversation_id, COALESCE(m.inbox_status, ''), COALESCE(m.status, ''), COALESCE(wd.status, ''), COALESCE(wd.last_error, ''), COALESCE(octet_length(m.raw_message), 0), m.created_at, m.labels
+	baseSelect := `SELECT m.id, m.agent_id, m.direction, m.sender, m.recipient, m.to_recipients, m.cc, m.reply_to, m.subject, m.email_message_id, m.conversation_id, COALESCE(m.inbox_status, ''), COALESCE(m.status, ''), COALESCE(wd.status, ''), COALESCE(wd.last_error, ''), COALESCE(octet_length(m.raw_message), 0), m.created_at, m.labels, COALESCE(m.delivery_status, ''), COALESCE(m.delivery_detail, ''), COALESCE(m.sent_as, '')
 		 FROM messages m
 		 LEFT JOIN webhook_deliveries wd ON wd.message_id = m.id
 		 WHERE m.agent_id = $1 AND m.expires_at > now()`
@@ -2167,17 +2195,25 @@ func (s *Store) GetMessagesByAgent(ctx context.Context, f MessageListFilter) ([]
 	var messages []Message
 	for rows.Next() {
 		var m Message
+		var outboundDeliveryStatus string
 		if err := rows.Scan(
 			&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.ToRecipients, &m.CC, &m.ReplyTo,
 			&m.Subject, &m.EmailMessageID, &m.ConversationID,
 			&m.InboxStatus, &m.Status, &m.WebhookStatus, &m.WebhookError, &m.SizeBytes,
 			&m.CreatedAt, &m.Labels,
+			&outboundDeliveryStatus, &m.DeliveryDetail, &m.SentAs,
 		); err != nil {
 			return nil, err
 		}
-		// Keep DeliveryStatus populated for back-compat — the polling SDK
-		// path scans it under the old JSON key.
-		m.DeliveryStatus = m.InboxStatus
+		// DeliveryStatus is overloaded by direction: inbound rows carry the
+		// inbox read/unread status under the legacy JSON key (the polling SDK
+		// reads it there); outbound rows carry the messages.delivery_status
+		// rollup. A row is one direction, so the sources never collide.
+		if m.Direction == "outbound" {
+			m.DeliveryStatus = outboundDeliveryStatus
+		} else {
+			m.DeliveryStatus = m.InboxStatus
+		}
 		messages = append(messages, m)
 	}
 	return messages, rows.Err()
@@ -2188,14 +2224,22 @@ func (s *Store) GetMessagesByAgent(ctx context.Context, f MessageListFilter) ([]
 func (s *Store) GetMessageWithContent(ctx context.Context, messageID, agentID string) (*Message, error) {
 	m := &Message{}
 	var authHeadersJSON []byte
+	var outboundDeliveryStatus string
 	err := s.pool.QueryRow(ctx,
 		`UPDATE messages SET inbox_status = CASE WHEN inbox_status = 'unread' THEN 'read' ELSE inbox_status END
 		 WHERE id = $1 AND agent_id = $2 AND expires_at > now()
-		 RETURNING id, agent_id, direction, sender, recipient, to_recipients, cc, reply_to, subject, email_message_id, conversation_id, COALESCE(inbox_status, ''), raw_message, auth_headers, created_at, expires_at, labels`,
+		 RETURNING id, agent_id, direction, sender, recipient, to_recipients, cc, reply_to, subject, email_message_id, conversation_id, COALESCE(inbox_status, ''), raw_message, auth_headers, created_at, expires_at, labels, COALESCE(delivery_status, ''), COALESCE(delivery_detail, ''), COALESCE(sent_as, '')`,
 		messageID, agentID,
-	).Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.ToRecipients, &m.CC, &m.ReplyTo, &m.Subject, &m.EmailMessageID, &m.ConversationID, &m.DeliveryStatus, &m.RawMessage, &authHeadersJSON, &m.CreatedAt, &m.ExpiresAt, &m.Labels)
+	).Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.ToRecipients, &m.CC, &m.ReplyTo, &m.Subject, &m.EmailMessageID, &m.ConversationID, &m.InboxStatus, &m.RawMessage, &authHeadersJSON, &m.CreatedAt, &m.ExpiresAt, &m.Labels, &outboundDeliveryStatus, &m.DeliveryDetail, &m.SentAs)
 	if err != nil {
 		return nil, err
+	}
+	// DeliveryStatus is overloaded by direction (see Message.DeliveryStatus):
+	// inbound carries inbox_status, outbound carries the delivery rollup.
+	if m.Direction == "outbound" {
+		m.DeliveryStatus = outboundDeliveryStatus
+	} else {
+		m.DeliveryStatus = m.InboxStatus
 	}
 	if authHeadersJSON != nil {
 		if err := json.Unmarshal(authHeadersJSON, &m.AuthHeaders); err != nil {
@@ -2497,7 +2541,8 @@ func (s *Store) GetConversationByID(ctx context.Context, agentID, conversationID
 		        m.conversation_id, COALESCE(m.inbox_status, ''),
 		        COALESCE(m.status, ''),
 		        m.created_at, m.expires_at,
-		        m.labels
+		        m.labels,
+		        COALESCE(m.delivery_status, ''), COALESCE(m.delivery_detail, ''), COALESCE(m.sent_as, '')
 		 FROM messages m
 		 WHERE m.agent_id = $1
 		   AND m.conversation_id = $2
@@ -2516,6 +2561,7 @@ func (s *Store) GetConversationByID(ctx context.Context, agentID, conversationID
 
 	for rows.Next() {
 		var m Message
+		var outboundDeliveryStatus string
 		if err := rows.Scan(
 			&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient,
 			&m.ToRecipients, &m.CC, &m.BCC, &m.ReplyTo,
@@ -2525,10 +2571,17 @@ func (s *Store) GetConversationByID(ctx context.Context, agentID, conversationID
 			&m.Status,
 			&m.CreatedAt, &m.ExpiresAt,
 			&m.Labels,
+			&outboundDeliveryStatus, &m.DeliveryDetail, &m.SentAs,
 		); err != nil {
 			return nil, err
 		}
-		m.DeliveryStatus = m.InboxStatus
+		// DeliveryStatus is overloaded by direction (see Message.DeliveryStatus):
+		// inbound carries inbox_status, outbound carries the delivery rollup.
+		if m.Direction == "outbound" {
+			m.DeliveryStatus = outboundDeliveryStatus
+		} else {
+			m.DeliveryStatus = m.InboxStatus
+		}
 		d.Messages = append(d.Messages, m)
 
 		// Accumulate aggregates as we go — cheaper than a second

--- a/internal/outbound/sender.go
+++ b/internal/outbound/sender.go
@@ -62,10 +62,11 @@ type SendRequest struct {
 // canonicalized recipient lists for persistence.
 type SendResult struct {
 	MessageID string   `json:"message_id"`
-	Method    string   `json:"method"` // "smtp"
-	To        []string `json:"-"`      // canonicalized To recipients
-	CC        []string `json:"-"`      // canonicalized CC recipients
-	BCC       []string `json:"-"`      // canonicalized BCC recipients
+	Method    string   `json:"method"`  // "smtp"
+	SentAs    string   `json:"sent_as"` // "own_address" | "relay" (decision 4 fallback)
+	To        []string `json:"-"`       // canonicalized To recipients
+	CC        []string `json:"-"`       // canonicalized CC recipients
+	BCC       []string `json:"-"`       // canonicalized BCC recipients
 }
 
 // ValidationError indicates a caller error (invalid addresses, no visible recipients).
@@ -99,7 +100,16 @@ type Sender struct {
 	// non-verified status all fall back to the relay From (fail-closed): we
 	// never send unaligned mail under a customer domain.
 	sendingStatus SendingStatusLookup
+	// sesConfigSet, when set, is added as the X-SES-CONFIGURATION-SET header so
+	// SES publishes delivery/bounce/complaint events (decision 9 / Slice 4b).
+	// Empty (the default) = no header, no events — dev/self-host without SES.
+	sesConfigSet string
 }
+
+// SetSESConfigurationSet enables SES event publishing for outbound mail by
+// tagging each message with the given configuration set. Optional-setter
+// pattern; empty leaves event publishing off.
+func (s *Sender) SetSESConfigurationSet(name string) { s.sesConfigSet = name }
 
 // SendingStatusLookup returns a domain's sending_status string
 // ("none"|"pending"|"verified"|"failed"). *identity.Store satisfies it.
@@ -210,8 +220,10 @@ func (s *Sender) Send(agent *identity.AgentIdentity, req SendRequest) (*SendResu
 	// (DKIM-aligned → DMARC passes, replies reach the agent directly); else
 	// the relay "… via e2a" rewrite (fail-closed default).
 	var headerFrom string
+	sentAs := "relay"
 	if s.useOwnAddressFrom(agent) {
 		headerFrom = fmt.Sprintf("%q <%s>", displayName, agent.EmailAddress())
+		sentAs = "own_address"
 	} else {
 		headerFrom = fmt.Sprintf("%q <%s>", displayName+" via e2a", envelopeFrom)
 	}
@@ -245,6 +257,15 @@ func (s *Sender) Send(agent *identity.AgentIdentity, req SendRequest) (*SendResu
 		}
 	}
 
+	// Attach the SES configuration-set header (decision 9 / Slice 4b) so SES
+	// publishes delivery/bounce/complaint events for this message. Prepended
+	// AFTER DKIM signing so it is never in the signed header set (SES strips it
+	// before delivery; signing it would break the signature). Empty when SES
+	// event publishing is not configured (dev/self-host) — no header, no events.
+	if s.sesConfigSet != "" {
+		message = append([]byte("X-SES-CONFIGURATION-SET: "+s.sesConfigSet+"\r\n"), message...)
+	}
+
 	sesMessageID, err := s.smtpRelay.Send(envelopeFrom, envelope, message)
 	if err != nil {
 		return nil, fmt.Errorf("smtp relay: %w", err)
@@ -253,6 +274,7 @@ func (s *Sender) Send(agent *identity.AgentIdentity, req SendRequest) (*SendResu
 	return &SendResult{
 		MessageID: sesMessageID,
 		Method:    "smtp",
+		SentAs:    sentAs,
 		To:        to,
 		CC:        cc,
 		BCC:       bcc,

--- a/internal/webhookpub/event.go
+++ b/internal/webhookpub/event.go
@@ -38,6 +38,13 @@ const (
 	// GET /domains/{domain} for sending_status.
 	EventDomainSendingVerified = "domain.sending_verified"
 	EventDomainSendingFailed   = "domain.sending_failed"
+	// Delivery feedback (decision 9 / Slice 4b): async outcome of an outbound
+	// message, per recipient. domain.suppression_added is account-scoped
+	// (despite the prefix) — fired when an address is auto-suppressed.
+	EventEmailDelivered         = "email.delivered"
+	EventEmailBounced           = "email.bounced"
+	EventEmailComplained        = "email.complained"
+	EventDomainSuppressionAdded = "domain.suppression_added"
 )
 
 // AllEventTypes is the canonical allowlist of event names. Used by
@@ -51,6 +58,10 @@ var AllEventTypes = []string{
 	EventEmailRejected,
 	EventDomainSendingVerified,
 	EventDomainSendingFailed,
+	EventEmailDelivered,
+	EventEmailBounced,
+	EventEmailComplained,
+	EventDomainSuppressionAdded,
 }
 
 // IsValidEventType reports whether name is one of the catalog

--- a/migrations/031_delivery_feedback.sql
+++ b/migrations/031_delivery_feedback.sql
@@ -1,0 +1,70 @@
+-- 031_delivery_feedback.sql
+--
+-- Delivery feedback (decision 9 / Slice 4b). `send` returning accepted-by-relay
+-- is not delivered; this closes the loop by recording the async delivery
+-- outcome SES reports (via SNS) per outbound message and per recipient, plus a
+-- per-tenant suppression list.
+--
+-- Three additions, all idempotent + non-destructive (ADD COLUMN/CREATE TABLE
+-- IF NOT EXISTS; CHECKs under guards). No ALTER TYPE, no rewrites.
+
+-- 1) Outbound delivery lifecycle on the messages row (a convenience rollup;
+--    the authoritative per-recipient breakdown lives in message_recipients).
+--    NULLable: inbound messages and not-yet-sent drafts carry no delivery_status.
+--    `sent_as` records which From identity was actually used (decision 4
+--    fallback) so "delivered" is never mis-attributed.
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS delivery_status TEXT;
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS delivery_detail TEXT;
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS sent_as         TEXT;
+
+DO $$ BEGIN
+    ALTER TABLE messages ADD CONSTRAINT messages_delivery_status_check
+        CHECK (delivery_status IS NULL OR delivery_status IN
+            ('queued','sent','delivered','bounced','complained','deferred','failed'));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+    ALTER TABLE messages ADD CONSTRAINT messages_sent_as_check
+        CHECK (sent_as IS NULL OR sent_as IN ('own_address','relay'));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- The SES notifications consumer correlates events back to a message by the
+-- SES-assigned id captured at send time. Index it for that lookup.
+CREATE INDEX IF NOT EXISTS idx_messages_provider_message_id
+    ON messages (provider_message_id)
+    WHERE provider_message_id <> '';
+
+-- 2) Per-recipient delivery breakdown. A single message to N recipients can
+--    deliver to one and bounce/complain to another; SES emits feedback
+--    per-recipient. One row per (message, address); the message rollup is the
+--    worst status across these by the decision-9 precedence.
+CREATE TABLE IF NOT EXISTS message_recipients (
+    id          TEXT PRIMARY KEY,
+    message_id  TEXT NOT NULL REFERENCES messages(id) ON DELETE CASCADE,
+    address     TEXT NOT NULL,
+    kind        TEXT NOT NULL DEFAULT 'to' CHECK (kind IN ('to','cc','bcc')),
+    status      TEXT NOT NULL DEFAULT 'sent'
+                CHECK (status IN ('queued','sent','delivered','bounced','complained','deferred','failed')),
+    detail      TEXT,
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (message_id, address)
+);
+
+CREATE INDEX IF NOT EXISTS idx_message_recipients_message ON message_recipients (message_id);
+
+-- 3) Per-tenant suppression list. Keyed per (user, address) — NEVER global: a
+--    complaint from one tenant must not deny delivery for another. Send-time
+--    enforcement reads this; auto-suppression on a hard bounce / corroborated
+--    complaint inserts here and emits domain.suppression_added.
+CREATE TABLE IF NOT EXISTS suppressions (
+    id                TEXT PRIMARY KEY,
+    user_id           TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    address           TEXT NOT NULL,
+    reason            TEXT NOT NULL DEFAULT '',
+    source            TEXT NOT NULL DEFAULT 'bounce' CHECK (source IN ('bounce','complaint','manual')),
+    source_message_id TEXT,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (user_id, address)
+);
+
+CREATE INDEX IF NOT EXISTS idx_suppressions_user ON suppressions (user_id);


### PR DESCRIPTION
## Slice 4b — Delivery feedback (api-v1-redesign §4 decision 9)

`send` returning *accepted-by-relay* isn't *delivered*. This consumes SES's async delivery/bounce/complaint feedback, tracks `delivery_status` per message **and per recipient**, and maintains a **per-tenant suppression list**.

### New package `internal/delivery`
- **SES-over-SNS consumer** at `POST /api/internal/ses/notifications`. **Fail-closed**: SNS signature verified (host-allow-listed `SigningCertURL` → SSRF guard, `TopicArn` allow-list, SHA1/256 PKCS1v15, injectable cert fetcher), auto-confirms `SubscriptionConfirmation`.
- Parses SES events → per-recipient outcomes; **correlates by `provider_message_id`** (the SES id captured at send — SNS carries the real id + is signature-verified, so no VERP HMAC needed for this path).
- **Monotonic** `delivery_status` transitions (`complained>bounced>delivered>deferred>sent>queued`) — out-of-order/duplicate events can't regress a terminal status.

### Schema — migration `031` (idempotent)
`messages.delivery_status`/`delivery_detail`/`sent_as`; `message_recipients` (per-recipient breakdown; the message field is the worst-status rollup); `suppressions` (per `(user,address)`).

### Behavior
- **send path**: `delivery_status='sent'` + `sent_as ∈ {own_address,relay}` (from Slice 4) + per-recipient rows; outbound tagged `X-SES-CONFIGURATION-SET` so SES emits events.
- **auto-suppress** on a hard (Permanent) bounce or a complaint — **never a soft bounce** (suppression-as-DoS guard); emits `domain.suppression_added`.
- **send-time enforcement**: `recipient_suppressed` (422), enforced fresh every attempt and **never idempotency-cached** (clearable state). `GET /v1/account/suppressions` + `DELETE /v1/account/suppressions/{address}`.
- events `email.delivered`/`bounced`/`complained` + `domain.suppression_added` (deterministic ids → receivers dedup); `delivery_status`/`detail`/`sent_as` on message read views (the `delivery_status` JSON key is overloaded by direction — inbound = `inbox_status` legacy, outbound = the lifecycle; a row is inbound XOR outbound so no per-row collision).

### Config
`delivery_feedback.ses_configuration_set` + `sns_topic_arns` (`E2A_DELIVERY_*`). **Empty (default) = off** — no event header, the endpoint rejects everything (empty allow-list). So this is behavior-neutral until ops wires SES.

## Scope note
Decision 9 is several sub-slices; this ships the **delivery-feedback core + suppression** (the "table stakes"). Deferred to follow-ups (recorded in design §9): inbound `auth{spf,dkim,dmarc}` + `email.flagged` (4b-2); injection-reduced parsed view + unified `GET /messages/{id}` (4b-3); ≥N soft-bounce threshold; real-AWS/SNS e2e.

## Verification
- `go build`, `go vet`, `go mod tidy` (no new non-stdlib deps — `delivery` is stdlib-only), spec-drift gate, **full integration suite** (`-tags integration -p 1`) green — except the pre-existing `TestSubscriberStore_RecordAttemptFailureClimbsToFailed` (red on clean `main`).
- **delivery unit tests**: monotonic precedence, SES parser (delivery/permanent-vs-transient bounce/complaint/delay/reject), consumer (correlation/events/suppression/idempotent), **SNS verifier (17 cases — signature, SSRF host guard, topic allow-list, SubscriptionConfirmation)**, handler fail-closed (403/400/405).
- **DB-backed integration**: delivered→deferred(no-regress)→bounce(suppress), per-recipient rollup = worst, suppression CRUD.
- **Real-binary smoke**: migration 031 applies, the SES endpoint is live + fail-closed (400 bad-JSON), `/v1/account/suppressions` auth-gated (401).

🤖 Generated with [Claude Code](https://claude.com/claude-code)