### PR TITLE
feat(api-v1): slice 4b-2 — structured inbound auth {spf,dkim,dmarc}

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -180,6 +180,16 @@ components:
         - content_type
         - data
       type: object
+    CheckResult:
+      additionalProperties: false
+      properties:
+        detail:
+          type: string
+        status:
+          type: string
+      required:
+        - status
+      type: object
     ConversationDetailView:
       additionalProperties: false
       properties:
@@ -712,6 +722,8 @@ components:
           format: date-time
           type: string
         attachments: {}
+        auth:
+          $ref: "#/components/schemas/Result"
         auth_headers:
           additionalProperties:
             type: string
@@ -823,6 +835,8 @@ components:
     MessageSummaryView:
       additionalProperties: false
       properties:
+        auth:
+          $ref: "#/components/schemas/Result"
         cc:
           items:
             type: string
@@ -892,6 +906,8 @@ components:
     MessageView:
       additionalProperties: false
       properties:
+        auth:
+          $ref: "#/components/schemas/Result"
         auth_headers:
           additionalProperties:
             type: string
@@ -1149,6 +1165,20 @@ components:
           type: string
         reply_all:
           type: boolean
+      type: object
+    Result:
+      additionalProperties: false
+      properties:
+        dkim:
+          $ref: "#/components/schemas/CheckResult"
+        dmarc:
+          $ref: "#/components/schemas/CheckResult"
+        spf:
+          $ref: "#/components/schemas/CheckResult"
+      required:
+        - spf
+        - dkim
+        - dmarc
       type: object
     RotateSecretOutputBody:
       additionalProperties: false

--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -1226,11 +1226,19 @@ Break the current `/api/v1` surface directly and move it to
     overloaded by direction: inbound rows carry `inbox_status` (legacy polling
     SDK) under it, outbound rows carry the new lifecycle. A row is inbound XOR
     outbound, so they never collide per-row.
-  * **Deferred to follow-up slices (4b-2/4b-3):** structured inbound
-    `auth: {spf,dkim,dmarc}` (DMARC eval) + the `email.flagged` security event;
-    the injection-reduced **parsed view** + the unified `GET /messages/{id}`
-    (flat-path removal); the ≥N-soft-bounce suppression threshold; and the SNS
-    flow's real-AWS e2e (CI uses crafted SNS payloads + a fake cert fetcher).
+  * **Slice 4b-2 — structured inbound auth.** *(Shipped.)* `emailauth` now
+    derives a **DMARC** verdict (relaxed organizational-domain alignment via
+    `publicsuffix`: a passing DKIM whose `d=` aligns, or a passing SPF whose
+    envelope domain aligns, with the From-header domain — no `_dmarc` policy
+    fetch, since the policy governs enforcement, not the verdict). The full
+    `auth: {spf,dkim,dmarc}` verdict is persisted on inbound (migration 032,
+    `messages.auth_verdict`; SPF can't be recomputed at read) and surfaced as
+    `auth` on inbound message reads — the trust primitive Slice 7 enforces on.
+  * **Still deferred:** the `email.flagged` security event (it fires on a
+    policy decision → Slice 7); the injection-reduced **parsed view** + unified
+    `GET /messages/{id}` flat-path removal (4b-3); the ≥N-soft-bounce
+    suppression threshold; the `_dmarc` policy (`p=`/strict-alignment) fetch;
+    and the SNS flow's real-AWS e2e (CI uses crafted SNS payloads + fake cert).
 * **Slice 5 — Auth: OAuth 2.1 + auth.md agent identity.** OAuth 2.1 hosted-MCP
   (PKCE + refresh), scoped API keys (`e2a_agt_`/`e2a_acct_`), and the auth.md
   agent-identity layer (`/agent/identity`, claim ceremony, jwt-bearer/claim

--- a/internal/agent/hitl_approval_api_test.go
+++ b/internal/agent/hitl_approval_api_test.go
@@ -219,7 +219,7 @@ func TestGetOutboundMessage_ReplyAttachesInboundContext(t *testing.T) {
 	if _, err := store.CreateInboundMessage(ctx, "", agent.ID,
 		"alice@gmail.com", "bot@inbound-ctx.example.com",
 		"<orig@gmail.com>", "Hello Bot", "", "",
-		nil, authHeaders, nil, nil, nil); err != nil {
+		nil, authHeaders, nil, nil, nil, nil); err != nil {
 		t.Fatalf("seed inbound: %v", err)
 	}
 
@@ -326,7 +326,7 @@ func TestGetOutboundMessage_ReplyWithMissingInboundReturnsNilContext(t *testing.
 	inbound, err := store.CreateInboundMessage(ctx, "", agent.ID,
 		"alice@gmail.com", "bot@missing-inbound.example.com",
 		"<missing@gmail.com>", "Subject that will vanish", "", "",
-		nil, nil, nil, nil, nil)
+		nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("seed inbound: %v", err)
 	}
@@ -386,7 +386,7 @@ func TestGetOutboundMessage_InboundContextIsAgentScoped(t *testing.T) {
 	if _, err := store.CreateInboundMessage(ctx, "", agentA.ID,
 		"alice@gmail.com", "bot@scoped-a.example.com",
 		"<shared-id@gmail.com>", "Subject for A", "", "",
-		nil, map[string]string{"spf": "pass"}, nil, nil, nil); err != nil {
+		nil, map[string]string{"spf": "pass"}, nil, nil, nil, nil); err != nil {
 		t.Fatalf("seed inbound A: %v", err)
 	}
 
@@ -398,7 +398,7 @@ func TestGetOutboundMessage_InboundContextIsAgentScoped(t *testing.T) {
 	if _, err := store.CreateInboundMessage(ctx, "", agentB.ID,
 		"bob@gmail.com", "bot@scoped-b.example.com",
 		"<shared-id@gmail.com>", "Subject for B (must NOT leak)", "", "",
-		nil, map[string]string{"spf": "fail"}, nil, nil, nil); err != nil {
+		nil, map[string]string{"spf": "fail"}, nil, nil, nil, nil); err != nil {
 		t.Fatalf("seed inbound B: %v", err)
 	}
 

--- a/internal/agent/labels_api_test.go
+++ b/internal/agent/labels_api_test.go
@@ -15,11 +15,11 @@ import (
 // message ready for label mutations. Returns the server, store, api
 // key, agent email, and a single message id.
 type labelsFixture struct {
-	server    *http.Client
-	serverURL string
-	apiKey    string
+	server     *http.Client
+	serverURL  string
+	apiKey     string
 	agentEmail string
-	msgID     string
+	msgID      string
 }
 
 func setupLabelsFixture(t *testing.T, prefix string) labelsFixture {
@@ -33,7 +33,7 @@ func setupLabelsFixture(t *testing.T, prefix string) labelsFixture {
 	store.VerifyDomain(ctx, domain, user.ID)
 	agentEmail := "bot@" + domain
 	agent, _ := store.CreateAgent(ctx, agentEmail, domain, "", "https://example.com/webhook", "", user.ID)
-	msg, _ := store.CreateInboundMessage(ctx, "", agent.ID, "alice@gmail.com", agentEmail, "<orig-"+prefix+"@gmail.com>", "Hi", "", "", nil, nil, nil, nil, nil)
+	msg, _ := store.CreateInboundMessage(ctx, "", agent.ID, "alice@gmail.com", agentEmail, "<orig-"+prefix+"@gmail.com>", "Hi", "", "", nil, nil, nil, nil, nil, nil)
 	return labelsFixture{
 		server:     http.DefaultClient,
 		serverURL:  server.URL,
@@ -91,8 +91,8 @@ func TestUpdateMessageLabels_RejectsSystemPrefix(t *testing.T) {
 func TestUpdateMessageLabels_RejectsInvalidCharset(t *testing.T) {
 	f := setupLabelsFixture(t, "lbl-charset")
 	cases := []struct {
-		name  string
-		body  string
+		name string
+		body string
 	}{
 		{"space", `{"add_labels":["hello world"]}`},
 		{"slash", `{"add_labels":["foo/bar"]}`},
@@ -160,7 +160,7 @@ func TestUpdateMessageLabels_CrossAgentReturns404(t *testing.T) {
 	store.ClaimOrCreateDomain(ctx, "lblxa.example.com", userA.ID)
 	store.VerifyDomain(ctx, "lblxa.example.com", userA.ID)
 	agentA, _ := store.CreateAgent(ctx, "bot@lblxa.example.com", "lblxa.example.com", "", "https://example.com/webhook", "", userA.ID)
-	msgA, _ := store.CreateInboundMessage(ctx, "", agentA.ID, "alice@gmail.com", "bot@lblxa.example.com", "<x@gmail.com>", "Hi", "", "", nil, nil, nil, nil, nil)
+	msgA, _ := store.CreateInboundMessage(ctx, "", agentA.ID, "alice@gmail.com", "bot@lblxa.example.com", "<x@gmail.com>", "Hi", "", "", nil, nil, nil, nil, nil, nil)
 
 	userB, _ := store.CreateOrGetUser(ctx, "owner-lblxB@example.com", "OwnerB", "google-lblxB")
 	apiKeyB, _ := store.CreateAPIKey(ctx, userB.ID, "lblxB-key", nil)

--- a/internal/agent/selfsend.go
+++ b/internal/agent/selfsend.go
@@ -91,6 +91,7 @@ func (a *API) performSelfSend(
 		"unread",
 		rawMessage,
 		nil,
+		nil,
 		[]string{email},
 		nil,
 		nil,

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -120,9 +120,9 @@ func TestHandleAgentActivity_WithMessages(t *testing.T) {
 	agent, _ := store.CreateAgent(ctx, "agent@active.example.com", "active.example.com", "", "https://example.com/webhook", "", user.ID)
 
 	// Create some activity ("" id lets the store generate one).
-	store.CreateInboundMessage(ctx, "", agent.ID, "alice@gmail.com", "bot@active.example.com", "", "Hello", "", "", nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agent.ID, "alice@gmail.com", "bot@active.example.com", "", "Hello", "", "", nil, nil, nil, nil, nil, nil)
 	store.CreateOutboundMessage(ctx, agent.ID, []string{"alice@gmail.com"}, nil, nil, "Re: Hello", "reply", "smtp", "", "")
-	store.CreateInboundMessage(ctx, "", agent.ID, "bob@gmail.com", "bot@active.example.com", "", "Hi", "", "", nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agent.ID, "bob@gmail.com", "bot@active.example.com", "", "Hi", "", "", nil, nil, nil, nil, nil, nil)
 
 	req := authedRequest("GET", "/api/dashboard/agents/agent%40active.example.com/activity", token)
 	w := httptest.NewRecorder()
@@ -149,7 +149,6 @@ func TestHandleAgentActivity_WithMessages(t *testing.T) {
 		t.Errorf("third entry: direction=%q subject=%q", activity[2].Direction, activity[2].Subject)
 	}
 }
-
 
 // --- API key endpoints (Item #3) ---
 

--- a/internal/emailauth/checker.go
+++ b/internal/emailauth/checker.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"net/mail"
 	"strings"
 
 	"blitiri.com.ar/go/spf"
 	"github.com/emersion/go-msgauth/dkim"
+	"golang.org/x/net/publicsuffix"
 )
 
 // CheckStatus represents the result of an authentication check.
@@ -29,10 +31,13 @@ type CheckResult struct {
 	Detail string      `json:"detail,omitempty"`
 }
 
-// Result aggregates SPF and DKIM check results.
+// Result aggregates SPF, DKIM, and DMARC check results. It is the inbound
+// trust primitive surfaced as `auth: {spf,dkim,dmarc}` on inbound messages and
+// (Slice 7) enforced on by the inbound policy.
 type Result struct {
-	SPF  CheckResult `json:"spf"`
-	DKIM CheckResult `json:"dkim"`
+	SPF   CheckResult `json:"spf"`
+	DKIM  CheckResult `json:"dkim"`
+	DMARC CheckResult `json:"dmarc"`
 }
 
 // DomainAuthenticated returns true if at least one domain-level check passed.
@@ -45,6 +50,7 @@ func (r *Result) Summary() string {
 	parts := []string{
 		fmt.Sprintf("spf=%s", r.SPF.Status),
 		fmt.Sprintf("dkim=%s", r.DKIM.Status),
+		fmt.Sprintf("dmarc=%s", r.DMARC.Status),
 	}
 	return strings.Join(parts, "; ")
 }
@@ -56,12 +62,76 @@ func (r *Result) Summary() string {
 func Check(remoteIP net.IP, senderEmail string, rawMessage []byte) *Result {
 	result := &Result{}
 
-	// Run SPF and DKIM checks
+	// Run SPF and DKIM checks, then derive DMARC from their alignment.
 	result.SPF = checkSPF(remoteIP, senderEmail)
-	result.DKIM = checkDKIM(rawMessage)
+	var dkimDomain string
+	result.DKIM, dkimDomain = checkDKIM(rawMessage)
+	result.DMARC = checkDMARC(rawMessage, senderEmail, result.SPF, result.DKIM, dkimDomain)
 
-	log.Printf("Email auth for %s from %s: SPF=%s DKIM=%s", senderEmail, remoteIP, result.SPF.Status, result.DKIM.Status)
+	log.Printf("Email auth for %s from %s: SPF=%s DKIM=%s DMARC=%s", senderEmail, remoteIP, result.SPF.Status, result.DKIM.Status, result.DMARC.Status)
 	return result
+}
+
+// checkDMARC derives a DMARC verdict from the SPF/DKIM results plus identifier
+// alignment (RFC 7489): DMARC passes when an authenticated identifier is
+// ALIGNED with the From-header domain — i.e. a passing DKIM whose d= aligns, or
+// a passing SPF whose envelope (MAIL FROM) domain aligns. We use relaxed
+// alignment (organizational-domain match, the DMARC default) and do NOT fetch
+// the _dmarc policy record: the policy governs what to DO on failure
+// (quarantine/reject — Slice 7's job), not the pass/fail verdict, which is what
+// the trust primitive needs. No aligned pass while some auth was attempted →
+// fail; nothing attempted / no From domain → none.
+func checkDMARC(rawMessage []byte, envelopeSender string, spf, dkim CheckResult, dkimDomain string) CheckResult {
+	fromDomain := fromHeaderDomain(rawMessage)
+	if fromDomain == "" {
+		return CheckResult{Status: StatusNone, Detail: "no From-header domain to align against"}
+	}
+	if dkim.Status == StatusPass && aligned(dkimDomain, fromDomain) {
+		return CheckResult{Status: StatusPass, Detail: fmt.Sprintf("dkim-aligned (d=%s, from=%s)", dkimDomain, fromDomain)}
+	}
+	if spf.Status == StatusPass && aligned(extractDomain(envelopeSender), fromDomain) {
+		return CheckResult{Status: StatusPass, Detail: fmt.Sprintf("spf-aligned (mailfrom=%s, from=%s)", extractDomain(envelopeSender), fromDomain)}
+	}
+	if spf.Status == StatusNone && dkim.Status == StatusNone {
+		return CheckResult{Status: StatusNone, Detail: "no SPF or DKIM to align"}
+	}
+	return CheckResult{Status: StatusFail, Detail: "no aligned authenticated identifier for " + fromDomain}
+}
+
+// aligned reports relaxed (organizational-domain) alignment between two
+// domains, the DMARC default. Exact match always aligns; otherwise their
+// eTLD+1 must match (so mail.example.com aligns with example.com).
+func aligned(a, b string) bool {
+	a, b = strings.ToLower(strings.TrimSpace(a)), strings.ToLower(strings.TrimSpace(b))
+	if a == "" || b == "" {
+		return false
+	}
+	if a == b {
+		return true
+	}
+	oa, ob := orgDomain(a), orgDomain(b)
+	return oa != "" && oa == ob
+}
+
+func orgDomain(d string) string {
+	if e, err := publicsuffix.EffectiveTLDPlusOne(d); err == nil {
+		return e
+	}
+	return d
+}
+
+// fromHeaderDomain extracts the domain of the RFC 5322 From header (the
+// identifier DMARC aligns against). Empty if absent/unparseable.
+func fromHeaderDomain(rawMessage []byte) string {
+	msg, err := mail.ReadMessage(bytes.NewReader(rawMessage))
+	if err != nil {
+		return ""
+	}
+	addr, err := mail.ParseAddress(msg.Header.Get("From"))
+	if err != nil {
+		return ""
+	}
+	return extractDomain(addr.Address)
 }
 
 func checkSPF(remoteIP net.IP, senderEmail string) CheckResult {
@@ -97,7 +167,10 @@ func checkSPF(remoteIP net.IP, senderEmail string) CheckResult {
 	}
 }
 
-func checkDKIM(rawMessage []byte) CheckResult {
+// checkDKIM verifies DKIM and returns the result plus the signing domain (d=)
+// of the passing signature (empty when none passed) — needed for DMARC
+// alignment.
+func checkDKIM(rawMessage []byte) (CheckResult, string) {
 	// RFC 6376 §3.5 defines the `l=` tag (body length limit). Honoring
 	// it lets an attacker append arbitrary unsigned content (HTML,
 	// prompt-injection payloads) to a legitimately-signed message, and
@@ -109,28 +182,28 @@ func checkDKIM(rawMessage []byte) CheckResult {
 	// rare in modern signing configs (Gmail, M365, SES all omit it by
 	// default).
 	if dkimSignatureHasBodyLengthTag(rawMessage) {
-		return CheckResult{Status: StatusFail, Detail: "DKIM-Signature includes l= body-length tag (refused: would allow tail-content injection)"}
+		return CheckResult{Status: StatusFail, Detail: "DKIM-Signature includes l= body-length tag (refused: would allow tail-content injection)"}, ""
 	}
 
 	verifications, err := dkim.Verify(bytes.NewReader(rawMessage))
 	if err != nil {
-		return CheckResult{Status: StatusTempError, Detail: err.Error()}
+		return CheckResult{Status: StatusTempError, Detail: err.Error()}, ""
 	}
 
 	if len(verifications) == 0 {
-		return CheckResult{Status: StatusNone, Detail: "no DKIM signature found"}
+		return CheckResult{Status: StatusNone, Detail: "no DKIM signature found"}, ""
 	}
 
 	// At least one DKIM signature must pass
 	for _, v := range verifications {
 		if v.Err == nil {
-			return CheckResult{Status: StatusPass, Detail: fmt.Sprintf("domain %s", v.Domain)}
+			return CheckResult{Status: StatusPass, Detail: fmt.Sprintf("domain %s", v.Domain)}, v.Domain
 		}
 	}
 
 	// All signatures failed
 	firstErr := verifications[0].Err
-	return CheckResult{Status: StatusFail, Detail: firstErr.Error()}
+	return CheckResult{Status: StatusFail, Detail: firstErr.Error()}, ""
 }
 
 // dkimSignatureHasBodyLengthTag reports whether any DKIM-Signature

--- a/internal/emailauth/checker.go
+++ b/internal/emailauth/checker.go
@@ -99,11 +99,24 @@ func checkDMARC(rawMessage []byte, envelopeSender string, spf, dkim CheckResult,
 }
 
 // aligned reports relaxed (organizational-domain) alignment between two
-// domains, the DMARC default. Exact match always aligns; otherwise their
-// eTLD+1 must match (so mail.example.com aligns with example.com).
+// domains, the DMARC default. Exact match aligns; otherwise their eTLD+1 must
+// match (so mail.example.com aligns with example.com).
+//
+// Guards (adversarial review): trailing dots are normalized so the absolute
+// form acme.com. aligns with acme.com; a domain that is ITSELF a public suffix
+// (e.g. github.io, co.uk) never aligns — there is no organization to attribute
+// it to, so a bare-suffix From with a matching d= must not earn a pass.
+//
+// LIMITATION (relaxed alignment, by design): two distinct tenants under a
+// non-PSL shared parent (e.g. a.wordpress.com vs b.wordpress.com) share an
+// eTLD+1 and therefore align. This is the standard relaxed-DMARC shared-hosting
+// gap; strict alignment (a deferred _dmarc-policy fetch) would close it.
 func aligned(a, b string) bool {
-	a, b = strings.ToLower(strings.TrimSpace(a)), strings.ToLower(strings.TrimSpace(b))
+	a, b = normDomain(a), normDomain(b)
 	if a == "" || b == "" {
+		return false
+	}
+	if isPublicSuffix(a) || isPublicSuffix(b) {
 		return false
 	}
 	if a == b {
@@ -111,6 +124,17 @@ func aligned(a, b string) bool {
 	}
 	oa, ob := orgDomain(a), orgDomain(b)
 	return oa != "" && oa == ob
+}
+
+func normDomain(d string) string {
+	return strings.TrimSuffix(strings.ToLower(strings.TrimSpace(d)), ".")
+}
+
+// isPublicSuffix reports whether d is itself a public suffix (ICANN or private),
+// i.e. it has no registrable label of its own.
+func isPublicSuffix(d string) bool {
+	suffix, _ := publicsuffix.PublicSuffix(d)
+	return suffix == d
 }
 
 func orgDomain(d string) string {

--- a/internal/emailauth/checker_test.go
+++ b/internal/emailauth/checker_test.go
@@ -68,12 +68,13 @@ func TestDomainAuthenticatedBothFail(t *testing.T) {
 
 func TestSummaryFormat(t *testing.T) {
 	r := &Result{
-		SPF:  CheckResult{Status: StatusPass},
-		DKIM: CheckResult{Status: StatusNone},
+		SPF:   CheckResult{Status: StatusPass},
+		DKIM:  CheckResult{Status: StatusNone},
+		DMARC: CheckResult{Status: StatusFail},
 	}
 	summary := r.Summary()
-	if summary != "spf=pass; dkim=none" {
-		t.Errorf("summary = %q, want %q", summary, "spf=pass; dkim=none")
+	if summary != "spf=pass; dkim=none; dmarc=fail" {
+		t.Errorf("summary = %q, want %q", summary, "spf=pass; dkim=none; dmarc=fail")
 	}
 }
 
@@ -97,7 +98,7 @@ func TestCheckDKIMLengthTagRefused(t *testing.T) {
 		"\r\n" +
 		"AAAAAAAAAA[attacker-appended-content-past-signed-length]")
 
-	result := checkDKIM(msg)
+	result, _ := checkDKIM(msg)
 	if result.Status != StatusFail {
 		t.Errorf("DKIM status = %q, want %q (l= must trigger refusal)", result.Status, StatusFail)
 	}
@@ -123,7 +124,7 @@ func TestCheckDKIMNoLengthTagFallsThroughToVerify(t *testing.T) {
 		"\r\n" +
 		"body")
 
-	result := checkDKIM(msg)
+	result, _ := checkDKIM(msg)
 	if result.Status == StatusFail && strings.Contains(result.Detail, "l= body-length tag") {
 		t.Errorf("DKIM refused with l= detail despite no l= tag in header: %q", result.Detail)
 	}
@@ -205,5 +206,42 @@ func TestExtractDomain(t *testing.T) {
 		if got != tt.domain {
 			t.Errorf("extractDomain(%q) = %q, want %q", tt.email, got, tt.domain)
 		}
+	}
+}
+
+// TestCheckDMARC covers the alignment verdict (relaxed org-domain) without
+// needing live SPF/DKIM: it drives checkDMARC directly with crafted inputs.
+func TestCheckDMARC(t *testing.T) {
+	from := func(d string) []byte {
+		return []byte("From: Sender <s@" + d + ">\r\nTo: a@b.com\r\nSubject: x\r\n\r\nhi")
+	}
+	pass := CheckResult{Status: StatusPass}
+	none := CheckResult{Status: StatusNone}
+
+	tests := []struct {
+		name       string
+		raw        []byte
+		envelope   string
+		spf, dkim  CheckResult
+		dkimDomain string
+		wantStatus CheckStatus
+	}{
+		{"dkim aligned exact", from("acme.com"), "bounce@x.com", none, pass, "acme.com", StatusPass},
+		{"dkim aligned subdomain (relaxed org)", from("acme.com"), "bounce@x.com", none, pass, "mail.acme.com", StatusPass},
+		{"dkim pass but unaligned", from("acme.com"), "bounce@x.com", none, pass, "evil.com", StatusFail},
+		{"spf aligned", from("acme.com"), "notify@acme.com", pass, none, "", StatusPass},
+		{"spf pass but unaligned envelope", from("acme.com"), "bounce@sendgrid.net", pass, none, "", StatusFail},
+		{"spf aligned via org domain", from("acme.com"), "bounce@mail.acme.com", pass, none, "", StatusPass},
+		{"neither aligned → fail", from("acme.com"), "x@other.com", pass, pass, "other.com", StatusFail},
+		{"nothing attempted → none", from("acme.com"), "x@other.com", none, none, "", StatusNone},
+		{"no From domain → none", []byte("To: a@b.com\r\n\r\nhi"), "x@acme.com", pass, none, "", StatusNone},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := checkDMARC(tc.raw, tc.envelope, tc.spf, tc.dkim, tc.dkimDomain)
+			if got.Status != tc.wantStatus {
+				t.Errorf("DMARC = %q (%s), want %q", got.Status, got.Detail, tc.wantStatus)
+			}
+		})
 	}
 }

--- a/internal/emailauth/checker_test.go
+++ b/internal/emailauth/checker_test.go
@@ -235,6 +235,16 @@ func TestCheckDMARC(t *testing.T) {
 		{"neither aligned → fail", from("acme.com"), "x@other.com", pass, pass, "other.com", StatusFail},
 		{"nothing attempted → none", from("acme.com"), "x@other.com", none, none, "", StatusNone},
 		{"no From domain → none", []byte("To: a@b.com\r\n\r\nhi"), "x@acme.com", pass, none, "", StatusNone},
+		// Hardening (adversarial review): a From that is itself a public suffix
+		// must NOT self-align even with a matching d= (no org to attribute to).
+		{"public-suffix From does not self-align", from("github.io"), "x@y.com", none, pass, "github.io", StatusFail},
+		// Trailing-dot (absolute form) From: net/mail rejects it → conservative
+		// none (not a spoof). normDomain still strips trailing dots on any
+		// identifier that does reach alignment (e.g. a d= value).
+		{"trailing-dot From → conservative none", from("acme.com."), "x@y.com", none, pass, "acme.com", StatusNone},
+		// Documented relaxed-alignment limitation: distinct tenants under a
+		// non-PSL shared parent align (a.wordpress.com ~ b.wordpress.com).
+		{"shared non-PSL parent aligns (known relaxed gap)", from("a.wordpress.com"), "x@y.com", none, pass, "b.wordpress.com", StatusPass},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/httpapi/messages.go
+++ b/internal/httpapi/messages.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Mnexa-AI/e2a/internal/emailauth"
 	"github.com/Mnexa-AI/e2a/internal/identity"
 	"github.com/danielgtaylor/huma/v2"
 )
@@ -41,7 +42,11 @@ type MessageView struct {
 	Labels      []string          `json:"labels"`
 	CreatedAt   string            `json:"created_at"`
 	AuthHeaders map[string]string `json:"auth_headers"`
-	RawMessage  []byte            `json:"raw_message"`
+	// Auth is the structured inbound authentication verdict (SPF/DKIM/DMARC,
+	// each with status + detail) from migration 032. Inbound-only; omitted on
+	// outbound messages, which carry no verdict.
+	Auth       *emailauth.Result `json:"auth,omitempty"`
+	RawMessage []byte            `json:"raw_message"`
 }
 
 func messageViewFromIdentity(m *identity.Message) MessageView {
@@ -58,6 +63,7 @@ func messageViewFromIdentity(m *identity.Message) MessageView {
 		Labels:         orEmptyStrings(m.Labels),
 		CreatedAt:      m.CreatedAt.UTC().Format(time.RFC3339),
 		AuthHeaders:    m.AuthHeaders,
+		Auth:           m.Auth,
 		RawMessage:     m.RawMessage,
 	}
 	// Outbound delivery feedback (migration 031). On outbound rows
@@ -110,6 +116,9 @@ type MessageSummaryView struct {
 	SizeBytes      int      `json:"size_bytes,omitempty"`
 	Labels         []string `json:"labels"`
 	CreatedAt      string   `json:"created_at"`
+	// Auth is the structured inbound authentication verdict (migration 032).
+	// Inbound-only; omitted on outbound rows.
+	Auth *emailauth.Result `json:"auth,omitempty"`
 }
 
 func messageSummaryFromIdentity(m identity.Message) MessageSummaryView {
@@ -127,6 +136,7 @@ func messageSummaryFromIdentity(m identity.Message) MessageSummaryView {
 		SizeBytes:      m.SizeBytes,
 		Labels:         orEmptyStrings(m.Labels),
 		CreatedAt:      m.CreatedAt.UTC().Format(time.RFC3339),
+		Auth:           m.Auth,
 	}
 	if m.Direction == "outbound" {
 		s.HITLStatus = m.Status

--- a/internal/identity/conversations_test.go
+++ b/internal/identity/conversations_test.go
@@ -47,7 +47,7 @@ func TestListConversationsByAgent_GroupsByConversationID(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		_, err := store.CreateInboundMessage(ctx, "", agentID, "alice@gmail.com", "bot@convo-group.example.com",
 			fmt.Sprintf("<a%d@gmail.com>", i),
-			"Subject A", "conv-A", "", nil, nil, nil, nil, nil,
+			"Subject A", "conv-A", "", nil, nil, nil, nil, nil, nil,
 		)
 		if err != nil {
 			t.Fatalf("CreateInboundMessage A%d: %v", i, err)
@@ -55,13 +55,13 @@ func TestListConversationsByAgent_GroupsByConversationID(t *testing.T) {
 	}
 	// Conversation B: 1 message
 	if _, err := store.CreateInboundMessage(ctx, "", agentID, "bob@gmail.com", "bot@convo-group.example.com",
-		"<b0@gmail.com>", "Subject B", "conv-B", "", nil, nil, nil, nil, nil,
+		"<b0@gmail.com>", "Subject B", "conv-B", "", nil, nil, nil, nil, nil, nil,
 	); err != nil {
 		t.Fatalf("CreateInboundMessage B: %v", err)
 	}
 	// A message with NO conversation_id — must NOT show up in the list.
 	if _, err := store.CreateInboundMessage(ctx, "", agentID, "carol@gmail.com", "bot@convo-group.example.com",
-		"<c0@gmail.com>", "Subject C (no conv)", "", "", nil, nil, nil, nil, nil,
+		"<c0@gmail.com>", "Subject C (no conv)", "", "", nil, nil, nil, nil, nil, nil,
 	); err != nil {
 		t.Fatalf("CreateInboundMessage C: %v", err)
 	}
@@ -96,10 +96,10 @@ func TestListConversationsByAgent_SortsByLastMessageDesc(t *testing.T) {
 
 	// Create A first, then B — but A is the "newer" conversation
 	// because we add another message to A after B's only one.
-	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-sort.example.com", "<a1@x>", "A", "conv-A-sort", "", nil, nil, nil, nil, nil)
-	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-sort.example.com", "<b1@x>", "B", "conv-B-sort", "", nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-sort.example.com", "<a1@x>", "A", "conv-A-sort", "", nil, nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-sort.example.com", "<b1@x>", "B", "conv-B-sort", "", nil, nil, nil, nil, nil, nil)
 	// Bump A's last_message_at to be the newest.
-	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-sort.example.com", "<a2@x>", "A2", "conv-A-sort", "", nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-sort.example.com", "<a2@x>", "A2", "conv-A-sort", "", nil, nil, nil, nil, nil, nil)
 
 	convos, _ := store.ListConversationsByAgent(ctx, identity.ConversationListFilter{AgentID: agentID})
 	if len(convos) != 2 {
@@ -126,7 +126,7 @@ func TestListConversationsByAgent_LimitClamp(t *testing.T) {
 	if identity.ConversationListHardCap < 1 {
 		t.Fatalf("ConversationListHardCap must be > 0, got %d", identity.ConversationListHardCap)
 	}
-	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-clamp.example.com", "<a@x>", "A", "conv-clamp-A", "", nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-clamp.example.com", "<a@x>", "A", "conv-clamp-A", "", nil, nil, nil, nil, nil, nil)
 	convos, err := store.ListConversationsByAgent(ctx, identity.ConversationListFilter{AgentID: agentID, Limit: 9999})
 	if err != nil {
 		t.Fatalf("ListConversationsByAgent: %v", err)
@@ -142,8 +142,8 @@ func TestListConversationsByAgent_SinceUntilWindow(t *testing.T) {
 	ctx := context.Background()
 	agentID := convoTestSetup(t, store, "convo-window")
 
-	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-window.example.com", "<old@x>", "old", "conv-old", "", nil, nil, nil, nil, nil)
-	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-window.example.com", "<new@x>", "new", "conv-new", "", nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-window.example.com", "<old@x>", "old", "conv-old", "", nil, nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-window.example.com", "<new@x>", "new", "conv-new", "", nil, nil, nil, nil, nil, nil)
 
 	// since=now-1h should return both; since=future should return zero.
 	all, _ := store.ListConversationsByAgent(ctx, identity.ConversationListFilter{
@@ -171,7 +171,7 @@ func TestListConversationsByAgent_AggregateFields(t *testing.T) {
 	// Conversation with one inbound (explicitly unread) and one outbound.
 	// The 9th arg of CreateInboundMessage is inbox_status — pass
 	// "unread" explicitly so the has_unread aggregate is true.
-	store.CreateInboundMessage(ctx, "", agentID, "alice@gmail.com", "bot@convo-agg.example.com", "<i1@x>", "Hello", "conv-agg", "unread", nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agentID, "alice@gmail.com", "bot@convo-agg.example.com", "<i1@x>", "Hello", "conv-agg", "unread", nil, nil, nil, nil, nil, nil)
 	store.CreateOutboundMessage(ctx, agentID, []string{"alice@gmail.com"}, nil, nil, "Re: Hello", "reply", "smtp", "<out@x>", "conv-agg")
 
 	convos, _ := store.ListConversationsByAgent(ctx, identity.ConversationListFilter{AgentID: agentID})
@@ -207,9 +207,9 @@ func TestGetConversationByID_OrdersChronologically(t *testing.T) {
 
 	// Create three messages explicitly in non-monotonic order to
 	// verify the storage layer sorts on read, not write.
-	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-order.example.com", "<m1@x>", "first", "conv-ord", "", nil, nil, nil, nil, nil)
-	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-order.example.com", "<m2@x>", "second", "conv-ord", "", nil, nil, nil, nil, nil)
-	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-order.example.com", "<m3@x>", "third", "conv-ord", "", nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-order.example.com", "<m1@x>", "first", "conv-ord", "", nil, nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-order.example.com", "<m2@x>", "second", "conv-ord", "", nil, nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-order.example.com", "<m3@x>", "third", "conv-ord", "", nil, nil, nil, nil, nil, nil)
 
 	d, err := store.GetConversationByID(ctx, agentID, "conv-ord")
 	if err != nil {
@@ -231,10 +231,10 @@ func TestGetConversationByID_ComputesParticipantsAndLabels(t *testing.T) {
 	ctx := context.Background()
 	agentID := convoTestSetup(t, store, "convo-part")
 
-	m1, _ := store.CreateInboundMessage(ctx, "", agentID, "alice@gmail.com", "bot@convo-part.example.com", "<p1@x>", "hi", "conv-part", "", nil, nil,
+	m1, _ := store.CreateInboundMessage(ctx, "", agentID, "alice@gmail.com", "bot@convo-part.example.com", "<p1@x>", "hi", "conv-part", "", nil, nil, nil,
 		[]string{"bot@convo-part.example.com", "team@convo-part.example.com"}, nil, nil,
 	)
-	m2, _ := store.CreateInboundMessage(ctx, "", agentID, "bob@gmail.com", "bot@convo-part.example.com", "<p2@x>", "hi", "conv-part", "", nil, nil,
+	m2, _ := store.CreateInboundMessage(ctx, "", agentID, "bob@gmail.com", "bot@convo-part.example.com", "<p2@x>", "hi", "conv-part", "", nil, nil, nil,
 		[]string{"bot@convo-part.example.com"}, []string{"carol@gmail.com"}, nil,
 	)
 	store.ModifyMessageLabels(ctx, m1.ID, agentID, []string{"urgent"}, nil)
@@ -285,7 +285,7 @@ func TestGetConversationByID_CrossAgentIsolation(t *testing.T) {
 	ctx := context.Background()
 	agentA := convoTestSetup(t, store, "convo-iso-a")
 	agentB := convoTestSetup(t, store, "convo-iso-b")
-	store.CreateInboundMessage(ctx, "", agentA, "x@gmail.com", "bot@convo-iso-a.example.com", "<a@x>", "secret", "conv-shared", "", nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agentA, "x@gmail.com", "bot@convo-iso-a.example.com", "<a@x>", "secret", "conv-shared", "", nil, nil, nil, nil, nil, nil)
 
 	// Agent B reading conv-shared must get not-found, NOT the inbound from A.
 	_, err := store.GetConversationByID(ctx, agentB, "conv-shared")

--- a/internal/identity/labels_test.go
+++ b/internal/identity/labels_test.go
@@ -33,7 +33,7 @@ func labelsTestSetup(t *testing.T, store *identity.Store, prefix string) (msgID,
 	if err != nil {
 		t.Fatalf("CreateAgent: %v", err)
 	}
-	msg, err := store.CreateInboundMessage(ctx, "", agent.ID, "alice@gmail.com", "bot@"+domain, "<orig-"+prefix+"@gmail.com>", "Hello", "", "", nil, nil, nil, nil, nil)
+	msg, err := store.CreateInboundMessage(ctx, "", agent.ID, "alice@gmail.com", "bot@"+domain, "<orig-"+prefix+"@gmail.com>", "Hello", "", "", nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("CreateInboundMessage: %v", err)
 	}
@@ -168,9 +168,9 @@ func TestGetMessagesByAgent_LabelsFilterANDMatch(t *testing.T) {
 	//   m2: [urgent]
 	//   m3: [follow-up]
 	// Filter labels=[urgent, follow-up] must return ONLY m1 (AND semantics).
-	m1, _ := store.CreateInboundMessage(ctx, "", agent.ID, "a@gmail.com", "bot@lblfilter.example.com", "<m1@gmail.com>", "M1", "", "", nil, nil, nil, nil, nil)
-	m2, _ := store.CreateInboundMessage(ctx, "", agent.ID, "a@gmail.com", "bot@lblfilter.example.com", "<m2@gmail.com>", "M2", "", "", nil, nil, nil, nil, nil)
-	store.CreateInboundMessage(ctx, "", agent.ID, "a@gmail.com", "bot@lblfilter.example.com", "<m3@gmail.com>", "M3", "", "", nil, nil, nil, nil, nil)
+	m1, _ := store.CreateInboundMessage(ctx, "", agent.ID, "a@gmail.com", "bot@lblfilter.example.com", "<m1@gmail.com>", "M1", "", "", nil, nil, nil, nil, nil, nil)
+	m2, _ := store.CreateInboundMessage(ctx, "", agent.ID, "a@gmail.com", "bot@lblfilter.example.com", "<m2@gmail.com>", "M2", "", "", nil, nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agent.ID, "a@gmail.com", "bot@lblfilter.example.com", "<m3@gmail.com>", "M3", "", "", nil, nil, nil, nil, nil, nil)
 
 	store.ModifyMessageLabels(ctx, m1.ID, agent.ID, []string{"urgent", "follow-up"}, nil)
 	store.ModifyMessageLabels(ctx, m2.ID, agent.ID, []string{"urgent"}, nil)

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Mnexa-AI/e2a/internal/dkim"
+	"github.com/Mnexa-AI/e2a/internal/emailauth"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -165,7 +166,12 @@ type Message struct {
 	Type              string            `json:"type,omitempty"`
 	RawMessage        []byte            `json:"raw_message,omitempty"`
 	AuthHeaders       map[string]string `json:"auth_headers,omitempty"`
-	ConversationID    string            `json:"conversation_id,omitempty"`
+	// Auth carries the parsed inbound authentication verdict
+	// (messages.auth_verdict from migration 032): SPF/DKIM/DMARC each with
+	// a status and detail. Populated on inbound read paths when the column
+	// is non-null; nil on outbound rows (which never have a verdict).
+	Auth           *emailauth.Result `json:"auth,omitempty"`
+	ConversationID string            `json:"conversation_id,omitempty"`
 	// DeliveryStatus is overloaded by direction. On inbound rows it carries
 	// the inbox read/unread status (messages.inbox_status) under this legacy
 	// JSON key. On outbound rows it carries the outbound delivery rollup
@@ -909,8 +915,8 @@ func NewMessageID() string {
 // for this row (may be one of the To: addresses, or absent from the
 // header list when the agent was Bcc'd). replyTo is the parsed Reply-To:
 // header (empty when absent — never silently falls back to sender).
-func (s *Store) CreateInboundMessage(ctx context.Context, id, agentID, senderEmail, recipient, emailMessageID, subject, conversationID, deliveryStatus string, rawMessage []byte, authHeaders map[string]string, toRecipients, cc, replyTo []string) (*Message, error) {
-	return createInboundMessage(ctx, s.pool, id, agentID, senderEmail, recipient, emailMessageID, subject, conversationID, deliveryStatus, rawMessage, authHeaders, toRecipients, cc, replyTo)
+func (s *Store) CreateInboundMessage(ctx context.Context, id, agentID, senderEmail, recipient, emailMessageID, subject, conversationID, deliveryStatus string, rawMessage []byte, authHeaders map[string]string, authVerdict []byte, toRecipients, cc, replyTo []string) (*Message, error) {
+	return createInboundMessage(ctx, s.pool, id, agentID, senderEmail, recipient, emailMessageID, subject, conversationID, deliveryStatus, rawMessage, authHeaders, authVerdict, toRecipients, cc, replyTo)
 }
 
 // WithTx opens a transaction, runs fn inside it, and commits if fn
@@ -942,8 +948,8 @@ func (s *Store) WithTx(ctx context.Context, fn func(tx pgx.Tx) error) error {
 // Mirrors the CreateAgentTx pattern at store.go:596-607 — same SQL
 // body, executed against either *pgxpool.Pool or pgx.Tx via the
 // messageExecutor interface below.
-func (s *Store) CreateInboundMessageInTx(ctx context.Context, tx pgx.Tx, id, agentID, senderEmail, recipient, emailMessageID, subject, conversationID, deliveryStatus string, rawMessage []byte, authHeaders map[string]string, toRecipients, cc, replyTo []string) (*Message, error) {
-	return createInboundMessage(ctx, tx, id, agentID, senderEmail, recipient, emailMessageID, subject, conversationID, deliveryStatus, rawMessage, authHeaders, toRecipients, cc, replyTo)
+func (s *Store) CreateInboundMessageInTx(ctx context.Context, tx pgx.Tx, id, agentID, senderEmail, recipient, emailMessageID, subject, conversationID, deliveryStatus string, rawMessage []byte, authHeaders map[string]string, authVerdict []byte, toRecipients, cc, replyTo []string) (*Message, error) {
+	return createInboundMessage(ctx, tx, id, agentID, senderEmail, recipient, emailMessageID, subject, conversationID, deliveryStatus, rawMessage, authHeaders, authVerdict, toRecipients, cc, replyTo)
 }
 
 // messageExecutor is the subset of *pgxpool.Pool and pgx.Tx that
@@ -953,7 +959,7 @@ type messageExecutor interface {
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }
 
-func createInboundMessage(ctx context.Context, exec messageExecutor, id, agentID, senderEmail, recipient, emailMessageID, subject, conversationID, deliveryStatus string, rawMessage []byte, authHeaders map[string]string, toRecipients, cc, replyTo []string) (*Message, error) {
+func createInboundMessage(ctx context.Context, exec messageExecutor, id, agentID, senderEmail, recipient, emailMessageID, subject, conversationID, deliveryStatus string, rawMessage []byte, authHeaders map[string]string, authVerdict []byte, toRecipients, cc, replyTo []string) (*Message, error) {
 	if id == "" {
 		id = NewMessageID()
 	}
@@ -992,9 +998,9 @@ func createInboundMessage(ctx context.Context, exec messageExecutor, id, agentID
 		inboxStatus = &m.DeliveryStatus
 	}
 	_, err := exec.Exec(ctx,
-		`INSERT INTO messages (id, agent_id, direction, sender, recipient, to_recipients, cc, reply_to, subject, email_message_id, raw_message, auth_headers, conversation_id, inbox_status, created_at, expires_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
-		m.ID, m.AgentID, m.Direction, m.Sender, m.Recipient, m.ToRecipients, m.CC, m.ReplyTo, m.Subject, m.EmailMessageID, m.RawMessage, authHeadersJSON, m.ConversationID, inboxStatus, m.CreatedAt, m.ExpiresAt,
+		`INSERT INTO messages (id, agent_id, direction, sender, recipient, to_recipients, cc, reply_to, subject, email_message_id, raw_message, auth_headers, auth_verdict, conversation_id, inbox_status, created_at, expires_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
+		m.ID, m.AgentID, m.Direction, m.Sender, m.Recipient, m.ToRecipients, m.CC, m.ReplyTo, m.Subject, m.EmailMessageID, m.RawMessage, authHeadersJSON, nullIfEmptyBytes(authVerdict), m.ConversationID, inboxStatus, m.CreatedAt, m.ExpiresAt,
 	)
 	if err != nil {
 		return nil, err
@@ -1004,14 +1010,33 @@ func createInboundMessage(ctx context.Context, exec messageExecutor, id, agentID
 
 func (s *Store) GetInboundMessage(ctx context.Context, id string) (*Message, error) {
 	m := &Message{}
+	var authVerdict []byte
 	err := s.pool.QueryRow(ctx,
-		`SELECT id, agent_id, direction, sender, recipient, to_recipients, cc, reply_to, subject, email_message_id, raw_message, created_at, expires_at
+		`SELECT id, agent_id, direction, sender, recipient, to_recipients, cc, reply_to, subject, email_message_id, raw_message, auth_verdict, created_at, expires_at
 		 FROM messages WHERE id = $1 AND direction = 'inbound' AND expires_at > now()`, id,
-	).Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.ToRecipients, &m.CC, &m.ReplyTo, &m.Subject, &m.EmailMessageID, &m.RawMessage, &m.CreatedAt, &m.ExpiresAt)
+	).Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.ToRecipients, &m.CC, &m.ReplyTo, &m.Subject, &m.EmailMessageID, &m.RawMessage, &authVerdict, &m.CreatedAt, &m.ExpiresAt)
 	if err != nil {
 		return nil, err
 	}
+	if err := unmarshalAuthVerdict(authVerdict, m); err != nil {
+		return nil, err
+	}
 	return m, nil
+}
+
+// unmarshalAuthVerdict parses the messages.auth_verdict JSONB column into
+// m.Auth. A NULL/empty column (every outbound row, and inbound rows written
+// before migration 032) leaves m.Auth nil.
+func unmarshalAuthVerdict(b []byte, m *Message) error {
+	if len(b) == 0 {
+		return nil
+	}
+	var r emailauth.Result
+	if err := json.Unmarshal(b, &r); err != nil {
+		return fmt.Errorf("unmarshal auth verdict: %w", err)
+	}
+	m.Auth = &r
+	return nil
 }
 
 // GetInboundByEmailMessageID looks up an inbound message by its RFC 5322
@@ -1998,7 +2023,7 @@ func (s *Store) ListActivityByAgent(ctx context.Context, agentID string, limit i
 		        m.to_recipients, m.cc, m.bcc,
 		        COALESCE(m.conversation_id, ''), COALESCE(octet_length(m.raw_message), 0),
 		        m.labels,
-		        COALESCE(m.delivery_status, ''), COALESCE(m.delivery_detail, ''), COALESCE(m.sent_as, '')
+		        COALESCE(m.delivery_status, ''), COALESCE(m.delivery_detail, ''), COALESCE(m.sent_as, ''), m.auth_verdict
 		 FROM messages m
 		 LEFT JOIN webhook_deliveries wd ON wd.message_id = m.id
 		 WHERE m.agent_id = $1 AND m.expires_at > now()
@@ -2014,7 +2039,11 @@ func (s *Store) ListActivityByAgent(ctx context.Context, agentID string, limit i
 	for rows.Next() {
 		var m Message
 		var inboxStatus, outboundDeliveryStatus string
-		if err := rows.Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.Subject, &m.EmailMessageID, &m.Method, &m.Type, &inboxStatus, &m.CreatedAt, &m.ExpiresAt, &m.WebhookStatus, &m.WebhookError, &m.WebhookAttempts, &m.ToRecipients, &m.CC, &m.BCC, &m.ConversationID, &m.SizeBytes, &m.Labels, &outboundDeliveryStatus, &m.DeliveryDetail, &m.SentAs); err != nil {
+		var authVerdict []byte
+		if err := rows.Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.Subject, &m.EmailMessageID, &m.Method, &m.Type, &inboxStatus, &m.CreatedAt, &m.ExpiresAt, &m.WebhookStatus, &m.WebhookError, &m.WebhookAttempts, &m.ToRecipients, &m.CC, &m.BCC, &m.ConversationID, &m.SizeBytes, &m.Labels, &outboundDeliveryStatus, &m.DeliveryDetail, &m.SentAs, &authVerdict); err != nil {
+			return nil, err
+		}
+		if err := unmarshalAuthVerdict(authVerdict, &m); err != nil {
 			return nil, err
 		}
 		// DeliveryStatus is overloaded by direction (see Message.DeliveryStatus):
@@ -2095,7 +2124,7 @@ func (s *Store) GetMessagesByAgent(ctx context.Context, f MessageListFilter) ([]
 	var query string
 	var args []interface{}
 
-	baseSelect := `SELECT m.id, m.agent_id, m.direction, m.sender, m.recipient, m.to_recipients, m.cc, m.reply_to, m.subject, m.email_message_id, m.conversation_id, COALESCE(m.inbox_status, ''), COALESCE(m.status, ''), COALESCE(wd.status, ''), COALESCE(wd.last_error, ''), COALESCE(octet_length(m.raw_message), 0), m.created_at, m.labels, COALESCE(m.delivery_status, ''), COALESCE(m.delivery_detail, ''), COALESCE(m.sent_as, '')
+	baseSelect := `SELECT m.id, m.agent_id, m.direction, m.sender, m.recipient, m.to_recipients, m.cc, m.reply_to, m.subject, m.email_message_id, m.conversation_id, COALESCE(m.inbox_status, ''), COALESCE(m.status, ''), COALESCE(wd.status, ''), COALESCE(wd.last_error, ''), COALESCE(octet_length(m.raw_message), 0), m.created_at, m.labels, COALESCE(m.delivery_status, ''), COALESCE(m.delivery_detail, ''), COALESCE(m.sent_as, ''), m.auth_verdict
 		 FROM messages m
 		 LEFT JOIN webhook_deliveries wd ON wd.message_id = m.id
 		 WHERE m.agent_id = $1 AND m.expires_at > now()`
@@ -2196,13 +2225,17 @@ func (s *Store) GetMessagesByAgent(ctx context.Context, f MessageListFilter) ([]
 	for rows.Next() {
 		var m Message
 		var outboundDeliveryStatus string
+		var authVerdict []byte
 		if err := rows.Scan(
 			&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.ToRecipients, &m.CC, &m.ReplyTo,
 			&m.Subject, &m.EmailMessageID, &m.ConversationID,
 			&m.InboxStatus, &m.Status, &m.WebhookStatus, &m.WebhookError, &m.SizeBytes,
 			&m.CreatedAt, &m.Labels,
-			&outboundDeliveryStatus, &m.DeliveryDetail, &m.SentAs,
+			&outboundDeliveryStatus, &m.DeliveryDetail, &m.SentAs, &authVerdict,
 		); err != nil {
+			return nil, err
+		}
+		if err := unmarshalAuthVerdict(authVerdict, &m); err != nil {
 			return nil, err
 		}
 		// DeliveryStatus is overloaded by direction: inbound rows carry the
@@ -2224,13 +2257,14 @@ func (s *Store) GetMessagesByAgent(ctx context.Context, f MessageListFilter) ([]
 func (s *Store) GetMessageWithContent(ctx context.Context, messageID, agentID string) (*Message, error) {
 	m := &Message{}
 	var authHeadersJSON []byte
+	var authVerdict []byte
 	var outboundDeliveryStatus string
 	err := s.pool.QueryRow(ctx,
 		`UPDATE messages SET inbox_status = CASE WHEN inbox_status = 'unread' THEN 'read' ELSE inbox_status END
 		 WHERE id = $1 AND agent_id = $2 AND expires_at > now()
-		 RETURNING id, agent_id, direction, sender, recipient, to_recipients, cc, reply_to, subject, email_message_id, conversation_id, COALESCE(inbox_status, ''), raw_message, auth_headers, created_at, expires_at, labels, COALESCE(delivery_status, ''), COALESCE(delivery_detail, ''), COALESCE(sent_as, '')`,
+		 RETURNING id, agent_id, direction, sender, recipient, to_recipients, cc, reply_to, subject, email_message_id, conversation_id, COALESCE(inbox_status, ''), raw_message, auth_headers, auth_verdict, created_at, expires_at, labels, COALESCE(delivery_status, ''), COALESCE(delivery_detail, ''), COALESCE(sent_as, '')`,
 		messageID, agentID,
-	).Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.ToRecipients, &m.CC, &m.ReplyTo, &m.Subject, &m.EmailMessageID, &m.ConversationID, &m.InboxStatus, &m.RawMessage, &authHeadersJSON, &m.CreatedAt, &m.ExpiresAt, &m.Labels, &outboundDeliveryStatus, &m.DeliveryDetail, &m.SentAs)
+	).Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.ToRecipients, &m.CC, &m.ReplyTo, &m.Subject, &m.EmailMessageID, &m.ConversationID, &m.InboxStatus, &m.RawMessage, &authHeadersJSON, &authVerdict, &m.CreatedAt, &m.ExpiresAt, &m.Labels, &outboundDeliveryStatus, &m.DeliveryDetail, &m.SentAs)
 	if err != nil {
 		return nil, err
 	}
@@ -2245,6 +2279,9 @@ func (s *Store) GetMessageWithContent(ctx context.Context, messageID, agentID st
 		if err := json.Unmarshal(authHeadersJSON, &m.AuthHeaders); err != nil {
 			return nil, fmt.Errorf("unmarshal auth headers: %w", err)
 		}
+	}
+	if err := unmarshalAuthVerdict(authVerdict, m); err != nil {
+		return nil, err
 	}
 	return m, nil
 }
@@ -2542,7 +2579,7 @@ func (s *Store) GetConversationByID(ctx context.Context, agentID, conversationID
 		        COALESCE(m.status, ''),
 		        m.created_at, m.expires_at,
 		        m.labels,
-		        COALESCE(m.delivery_status, ''), COALESCE(m.delivery_detail, ''), COALESCE(m.sent_as, '')
+		        COALESCE(m.delivery_status, ''), COALESCE(m.delivery_detail, ''), COALESCE(m.sent_as, ''), m.auth_verdict
 		 FROM messages m
 		 WHERE m.agent_id = $1
 		   AND m.conversation_id = $2
@@ -2562,6 +2599,7 @@ func (s *Store) GetConversationByID(ctx context.Context, agentID, conversationID
 	for rows.Next() {
 		var m Message
 		var outboundDeliveryStatus string
+		var authVerdict []byte
 		if err := rows.Scan(
 			&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient,
 			&m.ToRecipients, &m.CC, &m.BCC, &m.ReplyTo,
@@ -2571,8 +2609,11 @@ func (s *Store) GetConversationByID(ctx context.Context, agentID, conversationID
 			&m.Status,
 			&m.CreatedAt, &m.ExpiresAt,
 			&m.Labels,
-			&outboundDeliveryStatus, &m.DeliveryDetail, &m.SentAs,
+			&outboundDeliveryStatus, &m.DeliveryDetail, &m.SentAs, &authVerdict,
 		); err != nil {
+			return nil, err
+		}
+		if err := unmarshalAuthVerdict(authVerdict, &m); err != nil {
 			return nil, err
 		}
 		// DeliveryStatus is overloaded by direction (see Message.DeliveryStatus):

--- a/internal/identity/store_test.go
+++ b/internal/identity/store_test.go
@@ -10,6 +10,9 @@ import (
 	"testing"
 	"time"
 
+	"encoding/json"
+
+	"github.com/Mnexa-AI/e2a/internal/emailauth"
 	"github.com/Mnexa-AI/e2a/internal/identity"
 	"github.com/Mnexa-AI/e2a/internal/testutil"
 )
@@ -350,7 +353,7 @@ func TestCreateAndGetInboundMessage(t *testing.T) {
 	store.ClaimOrCreateDomain(ctx, "inbound.example.com", user.ID)
 	a, _ := store.CreateAgent(ctx, "agent@inbound.example.com", "inbound.example.com", "", "https://example.com/webhook", "", user.ID)
 
-	msg, err := store.CreateInboundMessage(ctx, "", a.ID, "alice@gmail.com", "bot@inbound.example.com", "<abc123@gmail.com>", "Hello Bot", "", "", nil, nil, nil, nil, nil)
+	msg, err := store.CreateInboundMessage(ctx, "", a.ID, "alice@gmail.com", "bot@inbound.example.com", "<abc123@gmail.com>", "Hello Bot", "", "", nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("CreateInboundMessage: %v", err)
 	}
@@ -382,6 +385,68 @@ func TestCreateAndGetInboundMessage(t *testing.T) {
 	}
 }
 
+// TestInboundMessageRoundTripsAuthVerdict asserts the structured inbound
+// auth verdict (messages.auth_verdict, migration 032) persists and reads
+// back through the message read paths, and that an outbound message has no
+// verdict (nil Auth).
+func TestInboundMessageRoundTripsAuthVerdict(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "av-owner@example.com", "Owner", "google-authverdict")
+	store.ClaimOrCreateDomain(ctx, "authverdict.example.com", user.ID)
+	a, _ := store.CreateAgent(ctx, "bot@authverdict.example.com", "authverdict.example.com", "", "https://example.com/webhook", "", user.ID)
+
+	verdict := emailauth.Result{
+		SPF:   emailauth.CheckResult{Status: emailauth.StatusPass, Detail: "spf-pass detail"},
+		DKIM:  emailauth.CheckResult{Status: emailauth.StatusFail, Detail: "dkim-fail detail"},
+		DMARC: emailauth.CheckResult{Status: emailauth.StatusNone, Detail: "no alignment"},
+	}
+	verdictJSON, err := json.Marshal(verdict)
+	if err != nil {
+		t.Fatalf("marshal verdict: %v", err)
+	}
+
+	in, err := store.CreateInboundMessage(ctx, "", a.ID, "alice@gmail.com", "bot@authverdict.example.com", "<av1@gmail.com>", "Hello", "", "unread", nil, nil, verdictJSON, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("CreateInboundMessage: %v", err)
+	}
+
+	got, err := store.GetMessageWithContent(ctx, in.ID, a.ID)
+	if err != nil {
+		t.Fatalf("GetMessageWithContent: %v", err)
+	}
+	if got.Auth == nil {
+		t.Fatalf("inbound Auth is nil, want populated verdict")
+	}
+	if got.Auth.SPF.Status != emailauth.StatusPass {
+		t.Errorf("SPF.Status = %q, want %q", got.Auth.SPF.Status, emailauth.StatusPass)
+	}
+	if got.Auth.DKIM.Status != emailauth.StatusFail {
+		t.Errorf("DKIM.Status = %q, want %q", got.Auth.DKIM.Status, emailauth.StatusFail)
+	}
+	if got.Auth.DMARC.Status != emailauth.StatusNone {
+		t.Errorf("DMARC.Status = %q, want %q", got.Auth.DMARC.Status, emailauth.StatusNone)
+	}
+	if got.Auth.SPF.Detail != "spf-pass detail" {
+		t.Errorf("SPF.Detail = %q", got.Auth.SPF.Detail)
+	}
+
+	// Outbound rows never carry a verdict — Auth must stay nil.
+	out, err := store.CreateOutboundMessage(ctx, a.ID, []string{"bob@gmail.com"}, nil, nil, "Re: Hello", "reply", "smtp", "<prov@authverdict.example.com>", "")
+	if err != nil {
+		t.Fatalf("CreateOutboundMessage: %v", err)
+	}
+	gotOut, err := store.GetMessageWithContent(ctx, out.ID, a.ID)
+	if err != nil {
+		t.Fatalf("GetMessageWithContent outbound: %v", err)
+	}
+	if gotOut.Auth != nil {
+		t.Errorf("outbound Auth = %+v, want nil", gotOut.Auth)
+	}
+}
+
 func TestInboundMessageRoundTripsToCcLists(t *testing.T) {
 	pool := testutil.TestDB(t)
 	store := identity.NewStore(pool)
@@ -398,7 +463,7 @@ func TestInboundMessageRoundTripsToCcLists(t *testing.T) {
 	// and is covered transitively by other tests that pass nil here.
 	replyTo := []string{"real-user@example.com", "delegate@example.com"}
 
-	msg, err := store.CreateInboundMessage(ctx, "", a.ID, "alice@gmail.com", "bot-a@tcc.example.com", "<x@gmail.com>", "Group thread", "", "", nil, nil, to, cc, replyTo)
+	msg, err := store.CreateInboundMessage(ctx, "", a.ID, "alice@gmail.com", "bot-a@tcc.example.com", "<x@gmail.com>", "Group thread", "", "", nil, nil, nil, to, cc, replyTo)
 	if err != nil {
 		t.Fatalf("CreateInboundMessage: %v", err)
 	}
@@ -470,7 +535,7 @@ func TestGetInboundMessageExpired(t *testing.T) {
 	user, _ := store.CreateOrGetUser(ctx, "owner@example.com", "Owner", "google-expired-inbound")
 	store.ClaimOrCreateDomain(ctx, "expired-inbound.example.com", user.ID)
 	a, _ := store.CreateAgent(ctx, "agent@expired-inbound.example.com", "expired-inbound.example.com", "", "https://example.com/webhook", "", user.ID)
-	msg, _ := store.CreateInboundMessage(ctx, "", a.ID, "alice@gmail.com", "bot@expired-inbound.example.com", "", "", "", "", nil, nil, nil, nil, nil)
+	msg, _ := store.CreateInboundMessage(ctx, "", a.ID, "alice@gmail.com", "bot@expired-inbound.example.com", "", "", "", "", nil, nil, nil, nil, nil, nil)
 
 	// Set expiry to the past
 	pool.Exec(ctx, `UPDATE messages SET expires_at = $1 WHERE id = $2`, time.Now().Add(-1*time.Hour), msg.ID)
@@ -489,7 +554,7 @@ func TestDeleteExpiredMessages(t *testing.T) {
 	user, _ := store.CreateOrGetUser(ctx, "owner@example.com", "Owner", "google-cleanup-inbound")
 	store.ClaimOrCreateDomain(ctx, "cleanup-inbound.example.com", user.ID)
 	a, _ := store.CreateAgent(ctx, "agent@cleanup-inbound.example.com", "cleanup-inbound.example.com", "", "https://example.com/webhook", "", user.ID)
-	msg, _ := store.CreateInboundMessage(ctx, "", a.ID, "alice@gmail.com", "bot@cleanup-inbound.example.com", "", "", "", "", nil, nil, nil, nil, nil)
+	msg, _ := store.CreateInboundMessage(ctx, "", a.ID, "alice@gmail.com", "bot@cleanup-inbound.example.com", "", "", "", "", nil, nil, nil, nil, nil, nil)
 
 	// Set expiry to the past
 	pool.Exec(ctx, `UPDATE messages SET expires_at = $1 WHERE id = $2`, time.Now().Add(-1*time.Hour), msg.ID)
@@ -542,9 +607,9 @@ func TestListActivityByAgent(t *testing.T) {
 	store.ClaimOrCreateDomain(ctx, "activity.example.com", user.ID)
 	a, _ := store.CreateAgent(ctx, "agent@activity.example.com", "activity.example.com", "", "https://example.com/webhook", "", user.ID)
 
-	store.CreateInboundMessage(ctx, "", a.ID, "alice@gmail.com", "bot@activity.example.com", "", "Hello", "", "", nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", a.ID, "alice@gmail.com", "bot@activity.example.com", "", "Hello", "", "", nil, nil, nil, nil, nil, nil)
 	store.CreateOutboundMessage(ctx, a.ID, []string{"alice@gmail.com"}, nil, nil, "Re: Hello", "reply", "smtp", "", "")
-	store.CreateInboundMessage(ctx, "", a.ID, "bob@gmail.com", "bot@activity.example.com", "", "Hi", "", "", nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", a.ID, "bob@gmail.com", "bot@activity.example.com", "", "Hi", "", "", nil, nil, nil, nil, nil, nil)
 
 	activity, err := store.ListActivityByAgent(ctx, a.ID, 50)
 	if err != nil {
@@ -664,7 +729,7 @@ func TestLookupConversationID_EmailThread(t *testing.T) {
 		"alice@gmail.com", "bot@thread.example.com",
 		"<CAMCKtby_first@mail.gmail.com>", "Hello",
 		"", // no conversation_id on first message
-		"pending", nil, nil, nil, nil, nil)
+		"pending", nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("CreateInboundMessage: %v", err)
 	}
@@ -1402,9 +1467,9 @@ func TestListAgentsByUser_EnrichedFields(t *testing.T) {
 	//   3 outbound (sent) in last 7d, 1 pending_approval
 	//   1 webhook delivery: delivered (healthy)
 	for i := 0; i < 2; i++ {
-		store.CreateInboundMessage(ctx, "", agent.ID, "alice@gmail.com", agent.EmailAddress(), "", "in fresh", "", "", nil, nil, nil, nil, nil)
+		store.CreateInboundMessage(ctx, "", agent.ID, "alice@gmail.com", agent.EmailAddress(), "", "in fresh", "", "", nil, nil, nil, nil, nil, nil)
 	}
-	old, _ := store.CreateInboundMessage(ctx, "", agent.ID, "old@gmail.com", agent.EmailAddress(), "", "in old", "", "", nil, nil, nil, nil, nil)
+	old, _ := store.CreateInboundMessage(ctx, "", agent.ID, "old@gmail.com", agent.EmailAddress(), "", "in old", "", "", nil, nil, nil, nil, nil, nil)
 	pool.Exec(ctx, `UPDATE messages SET created_at = now() - interval '14 days' WHERE id = $1`, old.ID)
 
 	for i := 0; i < 3; i++ {

--- a/internal/identity/user_data_rights_test.go
+++ b/internal/identity/user_data_rights_test.go
@@ -46,6 +46,7 @@ func seedUserData(t *testing.T, store *identity.Store, ctx context.Context, labe
 		"<orig@gmail.com>", "Hi there", "", "delivered",
 		[]byte("From: alice@gmail.com\r\nSubject: Hi\r\n\r\nbody"),
 		map[string]string{"X-E2A-Auth-Verified": "true"},
+		nil,
 		nil, nil, []string{"real-alice@example.com"},
 	); err != nil {
 		t.Fatalf("seed: CreateInboundMessage: %v", err)

--- a/internal/loopback/loopback.go
+++ b/internal/loopback/loopback.go
@@ -182,7 +182,7 @@ func ComposeMIME(agent *identity.AgentIdentity, req outbound.SendRequest, provid
 // InboundWriter is the subset of *identity.Store DeliverInbound uses.
 // Lets tests swap in fakes; production code passes the real store.
 type InboundWriter interface {
-	CreateInboundMessage(ctx context.Context, id, agentID, senderEmail, recipient, emailMessageID, subject, conversationID, deliveryStatus string, rawMessage []byte, authHeaders map[string]string, toRecipients, cc, replyTo []string) (*identity.Message, error)
+	CreateInboundMessage(ctx context.Context, id, agentID, senderEmail, recipient, emailMessageID, subject, conversationID, deliveryStatus string, rawMessage []byte, authHeaders map[string]string, authVerdict []byte, toRecipients, cc, replyTo []string) (*identity.Message, error)
 }
 
 // DeliverInbound writes the recipient-side row for a loopback self-send
@@ -232,6 +232,7 @@ func DeliverInbound(ctx context.Context, store InboundWriter, agent *identity.Ag
 		"unread",
 		rawMessage,
 		nil, // no DKIM/SPF auth headers on a synthetic loopback
+		nil, // no auth verdict on a synthetic loopback
 		[]string{email},
 		nil, // cc
 		nil, // reply_to

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -6,6 +6,7 @@ import (
 	crand "crypto/rand"
 	"crypto/tls"
 	"encoding/hex"
+	"encoding/json"
 	"io"
 	"log"
 	"mime"
@@ -366,6 +367,13 @@ func (s *session) deliverToAgent(ctx context.Context, agent *identity.AgentIdent
 	//       in-process publisher.Publish goroutine fires post-commit.
 	//       Preserves pre-design behavior so deployments that haven't
 	//       wired the outbox don't regress.
+	// Structured inbound auth verdict {spf,dkim,dmarc} persisted alongside the
+	// signed X-E2A-Auth-* blob (decision 9 / Slice 4b-2) — the trust primitive
+	// surfaced on the message and enforced on by the Slice 7 inbound policy.
+	// SPF can't be recomputed at read (the connecting IP isn't stored), so store
+	// it now. Best-effort marshal: a failure just omits the verdict.
+	authVerdictJSON, _ := json.Marshal(domainAuth)
+
 	var inboundMsg *identity.Message
 	var err error
 	if s.relay.outbox != nil {
@@ -374,7 +382,7 @@ func (s *session) deliverToAgent(ctx context.Context, agent *identity.AgentIdent
 			inboundMsg, txErr = s.relay.store.CreateInboundMessageInTx(
 				ctx, tx, messageID, agent.ID, displaySender, rcpt,
 				s.inboundMsgID, s.inboundSubject, conversationID,
-				deliveryStatus, body, authHeaders,
+				deliveryStatus, body, authHeaders, authVerdictJSON,
 				s.inboundThreadInfo.To, s.inboundThreadInfo.CC, s.inboundThreadInfo.ReplyTo,
 			)
 			if txErr != nil {
@@ -386,7 +394,7 @@ func (s *session) deliverToAgent(ctx context.Context, agent *identity.AgentIdent
 		inboundMsg, err = s.relay.store.CreateInboundMessage(
 			ctx, messageID, agent.ID, displaySender, rcpt,
 			s.inboundMsgID, s.inboundSubject, conversationID,
-			deliveryStatus, body, authHeaders,
+			deliveryStatus, body, authHeaders, authVerdictJSON,
 			s.inboundThreadInfo.To, s.inboundThreadInfo.CC, s.inboundThreadInfo.ReplyTo,
 		)
 	}

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -228,11 +228,16 @@ func (s *session) Data(r io.Reader) error {
 	return s.deliverMessages(ctx, senderEmail, body)
 }
 
-// deliverMessages runs SPF/DKIM checks and delivers to agents via webhook.
+// deliverMessages runs SPF/DKIM/DMARC checks and delivers to agents via webhook.
 func (s *session) deliverMessages(ctx context.Context, senderEmail string, body []byte) error {
-	// Run SPF/DKIM checks on the inbound message
-	domainAuth := emailauth.Check(s.remoteIP, senderEmail, body)
-	log.Printf("[%s] [%s] domain auth from %s: %s", s.id, senderEmail, s.remoteIP, domainAuth.Summary())
+	// Authenticate against the TRUE SMTP envelope MAIL FROM (s.from), not the
+	// display senderEmail (which prefers the From header). SPF is an
+	// envelope-identity check (RFC 7208), and DMARC alignment must compare the
+	// real envelope domain against the From-header domain — passing the
+	// From-derived senderEmail here would make SPF-alignment a tautology
+	// (adversarial review F5). DKIM + From extraction come from the body.
+	domainAuth := emailauth.Check(s.remoteIP, extractEmail(s.from), body)
+	log.Printf("[%s] [%s] domain auth from %s (envelope %s): %s", s.id, senderEmail, s.remoteIP, s.from, domainAuth.Summary())
 
 	delivered := 0
 	for _, rcpt := range s.recipients {

--- a/internal/webhookpub/outbox_tx_integration_test.go
+++ b/internal/webhookpub/outbox_tx_integration_test.go
@@ -78,6 +78,7 @@ func TestOutbox_Integration_RelayTxShape(t *testing.T) {
 				"<email-id@sender.example>", "Test", "", "unread",
 				[]byte("Subject: Test\r\n\r\nhello"),
 				map[string]string{"From": "sender@example.com"},
+				nil,
 				[]string{agentEmail}, nil, nil,
 			)
 			if err != nil {
@@ -147,7 +148,7 @@ func TestOutbox_Integration_RelayTxShape(t *testing.T) {
 			_, err := store.CreateInboundMessageInTx(ctx, tx,
 				retryMessageID, agentEmail, "sender@example.com", agentEmail,
 				"<retry-1@sender.example>", "Retry", "", "unread",
-				[]byte("hello"), nil, []string{agentEmail}, nil, nil,
+				[]byte("hello"), nil, nil, []string{agentEmail}, nil, nil,
 			)
 			if err != nil {
 				return err
@@ -174,7 +175,7 @@ func TestOutbox_Integration_RelayTxShape(t *testing.T) {
 			_, err := store.CreateInboundMessageInTx(ctx, tx,
 				retryMessageID, agentEmail, "sender@example.com", agentEmail,
 				"<retry-2@sender.example>", "Retry 2", "", "unread",
-				[]byte("hello again"), nil, []string{agentEmail}, nil, nil,
+				[]byte("hello again"), nil, nil, []string{agentEmail}, nil, nil,
 			)
 			if err != nil {
 				return err
@@ -206,7 +207,7 @@ func TestOutbox_Integration_RelayTxShape(t *testing.T) {
 			if _, err := store.CreateInboundMessageInTx(ctx, tx,
 				failMsgID, agentEmail, "sender@example.com", agentEmail,
 				"<fail@sender.example>", "Will Fail", "", "unread",
-				[]byte("hello"), nil, []string{agentEmail}, nil, nil,
+				[]byte("hello"), nil, nil, []string{agentEmail}, nil, nil,
 			); err != nil {
 				return err
 			}

--- a/migrations/032_inbound_auth_verdict.sql
+++ b/migrations/032_inbound_auth_verdict.sql
@@ -1,0 +1,12 @@
+-- 032_inbound_auth_verdict.sql
+--
+-- Structured inbound authentication verdict (decision 9 / Slice 4b-2). The
+-- relay already signs an X-E2A-Auth-* header blob into messages.auth_headers;
+-- this adds the structured {spf,dkim,dmarc} verdict (with DMARC newly
+-- evaluated) as a first-class field so agents — and the Slice 7 inbound policy
+-- — can reason on the trust primitive directly instead of parsing the blob.
+--
+-- SPF can't be recomputed at read time (it needs the connecting IP, which is
+-- not stored), so the verdict is persisted at inbound time. Inbound-only;
+-- NULL on outbound rows. Idempotent + non-destructive.
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS auth_verdict JSONB;

--- a/tests/contract/contract_test.go
+++ b/tests/contract/contract_test.go
@@ -160,7 +160,7 @@ func (e *testEnv) injectInboundMessage(t *testing.T, agentEmail, from, subject s
 	if err != nil {
 		t.Fatalf("get agent: %v", err)
 	}
-	msg, err := e.store.CreateInboundMessage(ctx, "", ag.ID, from, agentEmail, "", subject, "", "unread", nil, nil, nil, nil, nil)
+	msg, err := e.store.CreateInboundMessage(ctx, "", ag.ID, from, agentEmail, "", subject, "", "unread", nil, nil, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("store message: %v", err)
 	}


### PR DESCRIPTION
## Slice 4b-2 — structured inbound auth (api-v1-redesign §4 decision 9)

Surface the inbound authentication verdict as a first-class `auth: {spf,dkim,dmarc}` field on inbound messages, not just the signed `X-E2A-Auth-*` blob. This is the **trust primitive** the Slice 7 inbound policy will enforce on.

### emailauth: DMARC evaluation (new)
The relay already computed SPF + DKIM; this adds **DMARC** from identifier alignment (RFC 7489): DMARC passes when a passing DKIM whose `d=` aligns, **or** a passing SPF whose envelope (MAIL FROM) domain aligns, with the **From-header** domain. **Relaxed** organizational-domain alignment via `golang.org/x/net/publicsuffix` (so `mail.acme.com` aligns with `acme.com`). No `_dmarc` policy fetch — the policy governs *enforcement* (Slice 7), not the pass/fail verdict the trust primitive needs. `checkDKIM` now returns the signing domain; `Summary()` includes `dmarc=`.

### Persistence + surfacing
- **migration 032**: `messages.auth_verdict JSONB`. SPF can't be recomputed at read (the connecting IP isn't stored), so the relay persists the marshaled `emailauth.Result` on inbound (`CreateInboundMessage[InTx]` gain an `authVerdict` arg; loopback/self-send pass nil).
- `Message.Auth (*emailauth.Result)` is read back on the inbound-capable paths (`GetMessageWithContent`, `GetMessagesByAgent`, `GetConversationByID`, `ListActivityByAgent`, `GetInboundMessage`) and surfaced as `auth` on the `/v1` message views. **Nil on outbound** (no per-row leak).

## Verification
- `go build`, `go vet`, spec-drift gate, **full integration suite** (`-tags integration -p 1`) green — except the pre-existing `TestSubscriberStore_RecordAttemptFailureClimbsToFailed` (red on clean `main`).
- **emailauth unit tests**: DMARC alignment matrix (dkim-aligned exact/subdomain, dkim-pass-unaligned→fail, spf-aligned, spf-pass-unaligned→fail, relaxed org-domain, none, no-From→none). **DB round-trip**: inbound message persisted with a verdict reads back `Auth.SPF/DKIM/DMARC`; outbound reads back nil `Auth`.
- **Real-binary smoke**: migration 032 applies on a fresh boot; `auth_verdict` column present (and absent from the public spec — no DB-column leak).

## Deferred (design §9)
`email.flagged` fires on a policy decision → **Slice 7**; the injection-reduced **parsed view** + unified `GET /messages/{id}` flat-path removal → **4b-3**; the `_dmarc` policy (`p=`/strict-alignment) fetch; ≥N-soft-bounce suppression threshold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)