### PR TITLE
feat(api-v1): slice 4b-3 — injection-reduced parsed view + message-read unification

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -832,6 +832,25 @@ components:
         - created_at
         - expires_at
       type: object
+    MessageBodyView:
+      additionalProperties: false
+      properties:
+        html:
+          type: string
+        text:
+          type: string
+      type: object
+    MessageParsedView:
+      additionalProperties: false
+      properties:
+        text:
+          type: string
+        truncated:
+          type: boolean
+      required:
+        - text
+        - truncated
+      type: object
     MessageSummaryView:
       additionalProperties: false
       properties:
@@ -912,6 +931,8 @@ components:
           additionalProperties:
             type: string
           type: object
+        body:
+          $ref: "#/components/schemas/MessageBodyView"
         cc:
           items:
             type: string
@@ -936,6 +957,8 @@ components:
             - "null"
         message_id:
           type: string
+        parsed:
+          $ref: "#/components/schemas/MessageParsedView"
         raw_message:
           contentEncoding: base64
           type: string

--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -1234,9 +1234,21 @@ Break the current `/api/v1` surface directly and move it to
     `auth: {spf,dkim,dmarc}` verdict is persisted on inbound (migration 032,
     `messages.auth_verdict`; SPF can't be recomputed at read) and surfaced as
     `auth` on inbound message reads — the trust primitive Slice 7 enforces on.
+  * **Slice 4b-3 — parsed view + message-read unification.** *(Shipped.)*
+    `internal/mailparse` derives the injection-reduced **parsed view** from the
+    raw message (MIME-walk → prefer text/plain else HTML→text, strip quoted
+    reply/forward chains, length-cap), surfaced as `parsed: {text,truncated}` on
+    inbound message reads — a convenience; `raw_message` always present and the
+    security decision is made on `auth`+provenance, never the stripped text. The
+    unified `GET /v1/agents/{address}/messages/{id}` now serves BOTH
+    representations (decision 9): `raw_message` for sent/inbound AND the
+    held-draft `body: {text,html}` for `pending_approval` outbound — so it is the
+    single canonical read. **Deferred:** the *literal deletion* of the legacy
+    flat `/api/v1/messages/{id}` route rides the consumer-port slice (the TS +
+    Python SDKs still call it; deleting now breaks them before they repoint to
+    `/v1`).
   * **Still deferred:** the `email.flagged` security event (it fires on a
-    policy decision → Slice 7); the injection-reduced **parsed view** + unified
-    `GET /messages/{id}` flat-path removal (4b-3); the ≥N-soft-bounce
+    policy decision → Slice 7); the ≥N-soft-bounce
     suppression threshold; the `_dmarc` policy (`p=`/strict-alignment) fetch;
     and the SNS flow's real-AWS e2e (CI uses crafted SNS payloads + fake cert).
 * **Slice 5 — Auth: OAuth 2.1 + auth.md agent identity.** OAuth 2.1 hosted-MCP

--- a/internal/httpapi/messages.go
+++ b/internal/httpapi/messages.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Mnexa-AI/e2a/internal/emailauth"
 	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/mailparse"
 	"github.com/danielgtaylor/huma/v2"
 )
 
@@ -47,6 +48,30 @@ type MessageView struct {
 	// outbound messages, which carry no verdict.
 	Auth       *emailauth.Result `json:"auth,omitempty"`
 	RawMessage []byte            `json:"raw_message"`
+	// Parsed is the injection-reduced view (decision 9 / Slice 4b-3): the raw
+	// message rendered to text with quoted reply/forward chains stripped and a
+	// length cap, for the agent to feed a model by default. Inbound-only; a
+	// CONVENIENCE — `raw_message` is always present and the security decision is
+	// made on `auth` + provenance, never on this stripped text.
+	Parsed *MessageParsedView `json:"parsed,omitempty"`
+	// Body is the mutable draft body for a held outbound message
+	// (status=pending_approval), which has no raw_message yet. This is the
+	// second representation the unified read exposes (decision 9): held drafts
+	// carry body_text/body_html, sent/inbound carry raw_message. Omitted when
+	// empty (sent/inbound rows).
+	Body *MessageBodyView `json:"body,omitempty"`
+}
+
+// MessageParsedView is the parsed-body payload (see MessageView.Parsed).
+type MessageParsedView struct {
+	Text      string `json:"text"`
+	Truncated bool   `json:"truncated"`
+}
+
+// MessageBodyView is the held-draft body (see MessageView.Body).
+type MessageBodyView struct {
+	Text string `json:"text,omitempty"`
+	HTML string `json:"html,omitempty"`
 }
 
 func messageViewFromIdentity(m *identity.Message) MessageView {
@@ -73,6 +98,16 @@ func messageViewFromIdentity(m *identity.Message) MessageView {
 		v.DeliveryStatus = m.DeliveryStatus
 		v.DeliveryDetail = m.DeliveryDetail
 		v.SentAs = m.SentAs
+	}
+	// Parsed view (decision 9): inbound-only, derived from the raw message.
+	if m.Direction == "inbound" && len(m.RawMessage) > 0 {
+		text, truncated := mailparse.ParsedBody(m.RawMessage, mailparse.DefaultMaxBytes)
+		v.Parsed = &MessageParsedView{Text: text, Truncated: truncated}
+	}
+	// Held-draft body (decision 9 unification): the second representation a
+	// pending_approval outbound message carries instead of raw_message.
+	if m.BodyText != "" || m.BodyHTML != "" {
+		v.Body = &MessageBodyView{Text: m.BodyText, HTML: m.BodyHTML}
 	}
 	return v
 }

--- a/internal/httpapi/messages.go
+++ b/internal/httpapi/messages.go
@@ -105,8 +105,10 @@ func messageViewFromIdentity(m *identity.Message) MessageView {
 		v.Parsed = &MessageParsedView{Text: text, Truncated: truncated}
 	}
 	// Held-draft body (decision 9 unification): the second representation a
-	// pending_approval outbound message carries instead of raw_message.
-	if m.BodyText != "" || m.BodyHTML != "" {
+	// pending_approval outbound message carries instead of raw_message. Gated on
+	// outbound direction so it can never surface on an inbound row even if a
+	// future load path populates the body columns.
+	if m.Direction == "outbound" && (m.BodyText != "" || m.BodyHTML != "") {
 		v.Body = &MessageBodyView{Text: m.BodyText, HTML: m.BodyHTML}
 	}
 	return v

--- a/internal/httpapi/messages_parsed_test.go
+++ b/internal/httpapi/messages_parsed_test.go
@@ -1,0 +1,53 @@
+package httpapi
+
+import (
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+)
+
+// Inbound messages get a parsed view (quoted reply stripped); outbound don't.
+func TestMessageViewParsed(t *testing.T) {
+	raw := []byte("From: a@x.com\r\nContent-Type: text/plain\r\n\r\nMy reply.\r\n\r\n" +
+		"On Mon, Bob <b@y.com> wrote:\r\n> quoted original\r\n")
+
+	in := messageViewFromIdentity(&identity.Message{
+		ID: "msg_1", Direction: "inbound", Sender: "a@x.com", RawMessage: raw,
+	})
+	if in.Parsed == nil {
+		t.Fatal("inbound message should have a parsed view")
+	}
+	if in.Parsed.Text != "My reply." {
+		t.Fatalf("parsed.text = %q, want quoted-stripped %q", in.Parsed.Text, "My reply.")
+	}
+
+	out := messageViewFromIdentity(&identity.Message{
+		ID: "msg_2", Direction: "outbound", RawMessage: raw,
+	})
+	if out.Parsed != nil {
+		t.Fatalf("outbound message must not carry a parsed view, got %+v", out.Parsed)
+	}
+
+	// Inbound with no raw → no parsed view (nothing to parse).
+	none := messageViewFromIdentity(&identity.Message{ID: "msg_3", Direction: "inbound"})
+	if none.Parsed != nil {
+		t.Fatal("inbound with empty raw should have no parsed view")
+	}
+}
+
+// Held-draft (pending_approval) messages expose body_text/html via Body, the
+// second representation the unified read serves (sent/inbound use raw_message).
+func TestMessageViewHeldDraftBody(t *testing.T) {
+	draft := messageViewFromIdentity(&identity.Message{
+		ID: "msg_d", Direction: "outbound", Status: "pending_approval",
+		BodyText: "draft text", BodyHTML: "<p>draft</p>",
+	})
+	if draft.Body == nil || draft.Body.Text != "draft text" || draft.Body.HTML != "<p>draft</p>" {
+		t.Fatalf("held draft should expose body, got %+v", draft.Body)
+	}
+	// A sent/inbound message (no body columns) has no Body.
+	sent := messageViewFromIdentity(&identity.Message{ID: "msg_s", Direction: "inbound", RawMessage: []byte("From: a@x\r\n\r\nhi")})
+	if sent.Body != nil {
+		t.Fatalf("inbound/sent must not carry a draft Body, got %+v", sent.Body)
+	}
+}

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -2262,9 +2262,9 @@ func (s *Store) GetMessageWithContent(ctx context.Context, messageID, agentID st
 	err := s.pool.QueryRow(ctx,
 		`UPDATE messages SET inbox_status = CASE WHEN inbox_status = 'unread' THEN 'read' ELSE inbox_status END
 		 WHERE id = $1 AND agent_id = $2 AND expires_at > now()
-		 RETURNING id, agent_id, direction, sender, recipient, to_recipients, cc, reply_to, subject, email_message_id, conversation_id, COALESCE(inbox_status, ''), raw_message, auth_headers, auth_verdict, created_at, expires_at, labels, COALESCE(delivery_status, ''), COALESCE(delivery_detail, ''), COALESCE(sent_as, '')`,
+		 RETURNING id, agent_id, direction, sender, recipient, to_recipients, cc, reply_to, subject, email_message_id, conversation_id, COALESCE(inbox_status, ''), raw_message, auth_headers, auth_verdict, created_at, expires_at, labels, COALESCE(delivery_status, ''), COALESCE(delivery_detail, ''), COALESCE(sent_as, ''), COALESCE(body_text, ''), COALESCE(body_html, '')`,
 		messageID, agentID,
-	).Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.ToRecipients, &m.CC, &m.ReplyTo, &m.Subject, &m.EmailMessageID, &m.ConversationID, &m.InboxStatus, &m.RawMessage, &authHeadersJSON, &authVerdict, &m.CreatedAt, &m.ExpiresAt, &m.Labels, &outboundDeliveryStatus, &m.DeliveryDetail, &m.SentAs)
+	).Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.ToRecipients, &m.CC, &m.ReplyTo, &m.Subject, &m.EmailMessageID, &m.ConversationID, &m.InboxStatus, &m.RawMessage, &authHeadersJSON, &authVerdict, &m.CreatedAt, &m.ExpiresAt, &m.Labels, &outboundDeliveryStatus, &m.DeliveryDetail, &m.SentAs, &m.BodyText, &m.BodyHTML)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mailparse/parse.go
+++ b/internal/mailparse/parse.go
@@ -30,6 +30,14 @@ import (
 // small enough to blunt token-stuffing. Callers may override.
 const DefaultMaxBytes = 16 * 1024
 
+// maxMIMEDepth bounds multipart-nesting recursion. mime/multipart re-scans
+// buffered data at each level, so an attacker-nested message is O(depth²) — a
+// ~2MB email (under the 10MB inbound cap) could otherwise pin a request
+// goroutine for minutes, and the parsed view is computed synchronously on every
+// read. Real mail nests a handful of levels; past this we bail to best-effort
+// (empty), consistent with the package's "over-stripping is acceptable" stance.
+const maxMIMEDepth = 32
+
 // ParsedBody extracts the best human-readable text from a raw RFC 5322 message,
 // strips quoted reply/forward chains, and truncates to maxBytes. truncated is
 // true when the cap cut content. maxBytes <= 0 uses DefaultMaxBytes.
@@ -61,7 +69,7 @@ func extractText(raw []byte) string {
 	if err != nil {
 		return string(raw)
 	}
-	plain, htmlText := walkParts(msg.Header.Get("Content-Type"), msg.Header.Get("Content-Transfer-Encoding"), msg.Body)
+	plain, htmlText := walkParts(msg.Header.Get("Content-Type"), msg.Header.Get("Content-Transfer-Encoding"), msg.Body, 0)
 	if plain != "" {
 		return plain
 	}
@@ -75,7 +83,7 @@ func extractText(raw []byte) string {
 
 // walkParts returns the first text/plain and first text/html-as-text found
 // anywhere in the (possibly nested multipart) body.
-func walkParts(contentType, cte string, body io.Reader) (plain, htmlText string) {
+func walkParts(contentType, cte string, body io.Reader, depth int) (plain, htmlText string) {
 	mediaType, params, err := mime.ParseMediaType(contentType)
 	if err != nil {
 		// No/!invalid Content-Type → treat as text/plain.
@@ -83,6 +91,9 @@ func walkParts(contentType, cte string, body io.Reader) (plain, htmlText string)
 	}
 	switch {
 	case strings.HasPrefix(mediaType, "multipart/"):
+		if depth >= maxMIMEDepth {
+			return "", "" // bail on pathological nesting (see maxMIMEDepth)
+		}
 		boundary := params["boundary"]
 		if boundary == "" {
 			return "", ""
@@ -93,7 +104,7 @@ func walkParts(contentType, cte string, body io.Reader) (plain, htmlText string)
 			if err != nil {
 				break
 			}
-			p, h := walkParts(part.Header.Get("Content-Type"), part.Header.Get("Content-Transfer-Encoding"), part)
+			p, h := walkParts(part.Header.Get("Content-Type"), part.Header.Get("Content-Transfer-Encoding"), part, depth+1)
 			if plain == "" && p != "" {
 				plain = p
 			}

--- a/internal/mailparse/parse.go
+++ b/internal/mailparse/parse.go
@@ -1,0 +1,225 @@
+// Package mailparse produces the injection-reduced "parsed view" of an inbound
+// email (decision 9 / Slice 4b-3): the text an agent feeds to a model by
+// default, derived server-side from the raw RFC 5322 message — prefer the
+// text/plain part (else HTML→text), strip quoted reply chains / forwarded
+// headers, and cap the length (a token-stuffing guard).
+//
+// It is a CONVENIENCE, not a security control: the raw message is always
+// available, and the security decision is made on structured metadata (the
+// auth verdict + sender provenance, which survive as fields), never on this
+// stripped text. So over-stripping is acceptable — the caller can fall back to
+// raw. Best-effort throughout: a parse failure yields the best text available
+// (possibly empty), never an error.
+package mailparse
+
+import (
+	"bytes"
+	"encoding/base64"
+	"io"
+	"mime"
+	"mime/multipart"
+	"mime/quotedprintable"
+	"net/mail"
+	"regexp"
+	"strings"
+
+	"golang.org/x/net/html"
+)
+
+// DefaultMaxBytes caps the parsed text. Generous enough for real messages,
+// small enough to blunt token-stuffing. Callers may override.
+const DefaultMaxBytes = 16 * 1024
+
+// ParsedBody extracts the best human-readable text from a raw RFC 5322 message,
+// strips quoted reply/forward chains, and truncates to maxBytes. truncated is
+// true when the cap cut content. maxBytes <= 0 uses DefaultMaxBytes.
+func ParsedBody(raw []byte, maxBytes int) (text string, truncated bool) {
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxBytes
+	}
+	body := extractText(raw)
+	body = stripQuotedReplies(body)
+	body = normalizeWhitespace(body)
+	if len(body) > maxBytes {
+		// Truncate on a rune boundary.
+		cut := maxBytes
+		for cut > 0 && !utf8RuneStart(body[cut]) {
+			cut--
+		}
+		return strings.TrimSpace(body[:cut]), true
+	}
+	return body, false
+}
+
+func utf8RuneStart(b byte) bool { return b&0xC0 != 0x80 }
+
+// extractText walks the MIME tree and returns the best text representation:
+// the first text/plain part, or (failing that) the first text/html rendered to
+// text. Falls back to the raw body if MIME parsing fails.
+func extractText(raw []byte) string {
+	msg, err := mail.ReadMessage(bytes.NewReader(raw))
+	if err != nil {
+		return string(raw)
+	}
+	plain, htmlText := walkParts(msg.Header.Get("Content-Type"), msg.Header.Get("Content-Transfer-Encoding"), msg.Body)
+	if plain != "" {
+		return plain
+	}
+	if htmlText != "" {
+		return htmlText
+	}
+	// No recognized text part — return the decoded top-level body.
+	b, _ := io.ReadAll(msg.Body)
+	return string(b)
+}
+
+// walkParts returns the first text/plain and first text/html-as-text found
+// anywhere in the (possibly nested multipart) body.
+func walkParts(contentType, cte string, body io.Reader) (plain, htmlText string) {
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err != nil {
+		// No/!invalid Content-Type → treat as text/plain.
+		return decode(body, cte), ""
+	}
+	switch {
+	case strings.HasPrefix(mediaType, "multipart/"):
+		boundary := params["boundary"]
+		if boundary == "" {
+			return "", ""
+		}
+		mr := multipart.NewReader(body, boundary)
+		for {
+			part, err := mr.NextPart()
+			if err != nil {
+				break
+			}
+			p, h := walkParts(part.Header.Get("Content-Type"), part.Header.Get("Content-Transfer-Encoding"), part)
+			if plain == "" && p != "" {
+				plain = p
+			}
+			if htmlText == "" && h != "" {
+				htmlText = h
+			}
+			part.Close()
+			if plain != "" {
+				break // text/plain is preferred; stop early
+			}
+		}
+		return plain, htmlText
+	case mediaType == "text/plain":
+		return decode(body, cte), ""
+	case mediaType == "text/html":
+		return "", htmlToText(decode(body, cte))
+	default:
+		return "", ""
+	}
+}
+
+// decode reads a body applying its Content-Transfer-Encoding (base64 /
+// quoted-printable / identity).
+func decode(body io.Reader, cte string) string {
+	switch strings.ToLower(strings.TrimSpace(cte)) {
+	case "quoted-printable":
+		b, _ := io.ReadAll(quotedprintable.NewReader(body))
+		return string(b)
+	case "base64":
+		raw, _ := io.ReadAll(body)
+		// base64 bodies are line-wrapped; strip all whitespace then decode.
+		clean := strings.Map(func(r rune) rune {
+			if r == '\r' || r == '\n' || r == ' ' || r == '\t' {
+				return -1
+			}
+			return r
+		}, string(raw))
+		dec, err := base64.StdEncoding.DecodeString(clean)
+		if err != nil {
+			return string(raw)
+		}
+		return string(dec)
+	default:
+		b, _ := io.ReadAll(body)
+		return string(b)
+	}
+}
+
+// htmlToText renders HTML to plain text: drops script/style, inserts newlines
+// at block boundaries, and decodes entities (via the tokenizer).
+func htmlToText(h string) string {
+	z := html.NewTokenizer(strings.NewReader(h))
+	var sb strings.Builder
+	skip := 0 // depth inside script/style
+	for {
+		tt := z.Next()
+		switch tt {
+		case html.ErrorToken:
+			return sb.String()
+		case html.StartTagToken, html.SelfClosingTagToken:
+			name, _ := z.TagName()
+			tag := string(name)
+			switch tag {
+			case "script", "style", "head":
+				if tt == html.StartTagToken {
+					skip++
+				}
+			case "br", "p", "div", "tr", "li", "h1", "h2", "h3", "h4", "h5", "h6", "blockquote":
+				sb.WriteByte('\n')
+			}
+		case html.EndTagToken:
+			name, _ := z.TagName()
+			switch string(name) {
+			case "script", "style", "head":
+				if skip > 0 {
+					skip--
+				}
+			case "p", "div", "tr", "li", "blockquote":
+				sb.WriteByte('\n')
+			}
+		case html.TextToken:
+			if skip == 0 {
+				sb.Write(z.Text())
+			}
+		}
+	}
+}
+
+// quoteMarker matches the start of a quoted reply / forwarded block. Anything
+// from the first match onward is dropped.
+var quoteMarker = regexp.MustCompile(`(?im)^\s*(` +
+	`>.*$` + // a quoted line
+	`|On .+ wrote:\s*$` + // Gmail/Apple "On <date>, <name> wrote:"
+	`|-{2,}\s*Original Message\s*-{2,}\s*$` + // Outlook
+	`|-{2,}\s*Forwarded message\s*-{2,}\s*$` + // forwarded
+	`|_{10,}\s*$` + // Outlook divider line
+	`|From:\s.+\sSent:\s` + // Outlook forwarded header (From: … Sent: …)
+	`)`)
+
+// stripQuotedReplies cuts the text at the first quoted-reply / forwarded marker
+// and removes any trailing ">"-quoted lines. Conservative: only well-known
+// markers trigger a cut (over-stripping is acceptable; raw is always available).
+func stripQuotedReplies(text string) string {
+	if loc := quoteMarker.FindStringIndex(text); loc != nil {
+		text = text[:loc[0]]
+	}
+	return strings.TrimRight(text, " \t\r\n")
+}
+
+// normalizeWhitespace collapses runs of blank lines and trims trailing spaces
+// per line, so the parsed view is compact without losing paragraph structure.
+func normalizeWhitespace(s string) string {
+	lines := strings.Split(s, "\n")
+	out := make([]string, 0, len(lines))
+	blank := 0
+	for _, ln := range lines {
+		ln = strings.TrimRight(ln, " \t\r")
+		if ln == "" {
+			blank++
+			if blank > 1 {
+				continue // collapse 2+ blank lines into one
+			}
+		} else {
+			blank = 0
+		}
+		out = append(out, ln)
+	}
+	return strings.TrimSpace(strings.Join(out, "\n"))
+}

--- a/internal/mailparse/parse_test.go
+++ b/internal/mailparse/parse_test.go
@@ -1,8 +1,10 @@
 package mailparse
 
-import "strings"
-
-import "testing"
+import (
+	"strings"
+	"testing"
+	"time"
+)
 
 func TestParsedBody(t *testing.T) {
 	t.Run("plain text passes through", func(t *testing.T) {
@@ -73,4 +75,45 @@ func TestParsedBody(t *testing.T) {
 			t.Fatal("expected best-effort text, got empty")
 		}
 	})
+}
+
+// TestDeepNestingBounded pins the adversarial DoS fix: a deeply nested
+// multipart message must parse quickly (depth-capped), not blow up O(depth²).
+func TestDeepNestingBounded(t *testing.T) {
+	var sb strings.Builder
+	sb.WriteString("From: a@x.com\r\nContent-Type: multipart/mixed; boundary=b0\r\n\r\n")
+	for i := 0; i < 5000; i++ {
+		sb.WriteString("--b0\r\nContent-Type: multipart/mixed; boundary=b0\r\n\r\n")
+	}
+	sb.WriteString("--b0\r\nContent-Type: text/plain\r\n\r\ndeep\r\n")
+	done := make(chan struct{})
+	go func() { _, _ = ParsedBody([]byte(sb.String()), 0); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("ParsedBody did not return within 3s on deeply nested multipart (DoS guard missing)")
+	}
+}
+
+// TestNestedMultipartRecoversInnerText: mixed wrapping alternative → inner plain.
+func TestNestedMultipartRecoversInnerText(t *testing.T) {
+	raw := "From: a@x.com\r\nContent-Type: multipart/mixed; boundary=OUT\r\n\r\n" +
+		"--OUT\r\nContent-Type: multipart/alternative; boundary=IN\r\n\r\n" +
+		"--IN\r\nContent-Type: text/plain\r\n\r\ninner plain\r\n" +
+		"--IN\r\nContent-Type: text/html\r\n\r\n<p>inner html</p>\r\n--IN--\r\n" +
+		"--OUT--\r\n"
+	got, _ := ParsedBody([]byte(raw), 0)
+	if got != "inner plain" {
+		t.Fatalf("nested multipart: got %q, want %q", got, "inner plain")
+	}
+}
+
+// TestBase64Decoded: a base64 text/plain part is decoded.
+func TestBase64Decoded(t *testing.T) {
+	// "Hello base64" base64 = SGVsbG8gYmFzZTY0
+	raw := "From: a@x.com\r\nContent-Type: text/plain\r\nContent-Transfer-Encoding: base64\r\n\r\nSGVsbG8gYmFzZTY0\r\n"
+	got, _ := ParsedBody([]byte(raw), 0)
+	if got != "Hello base64" {
+		t.Fatalf("base64 decode: got %q", got)
+	}
 }

--- a/internal/mailparse/parse_test.go
+++ b/internal/mailparse/parse_test.go
@@ -1,0 +1,76 @@
+package mailparse
+
+import "strings"
+
+import "testing"
+
+func TestParsedBody(t *testing.T) {
+	t.Run("plain text passes through", func(t *testing.T) {
+		raw := "From: a@x.com\r\nTo: b@y.com\r\nSubject: Hi\r\nContent-Type: text/plain\r\n\r\nHello there.\r\n"
+		got, trunc := ParsedBody([]byte(raw), 0)
+		if got != "Hello there." || trunc {
+			t.Fatalf("got %q trunc=%v", got, trunc)
+		}
+	})
+
+	t.Run("html rendered to text", func(t *testing.T) {
+		raw := "From: a@x.com\r\nContent-Type: text/html\r\n\r\n<html><body><p>Hello</p><script>evil()</script><p>World</p></body></html>"
+		got, _ := ParsedBody([]byte(raw), 0)
+		if !strings.Contains(got, "Hello") || !strings.Contains(got, "World") {
+			t.Fatalf("expected Hello/World, got %q", got)
+		}
+		if strings.Contains(got, "evil") {
+			t.Fatalf("script content must be dropped, got %q", got)
+		}
+	})
+
+	t.Run("multipart prefers text/plain", func(t *testing.T) {
+		raw := "From: a@x.com\r\nContent-Type: multipart/alternative; boundary=B\r\n\r\n" +
+			"--B\r\nContent-Type: text/plain\r\n\r\nPlain version.\r\n" +
+			"--B\r\nContent-Type: text/html\r\n\r\n<p>HTML version</p>\r\n--B--\r\n"
+		got, _ := ParsedBody([]byte(raw), 0)
+		if got != "Plain version." {
+			t.Fatalf("expected plain part, got %q", got)
+		}
+	})
+
+	t.Run("quoted-printable decoded", func(t *testing.T) {
+		raw := "From: a@x.com\r\nContent-Type: text/plain\r\nContent-Transfer-Encoding: quoted-printable\r\n\r\nCaf=C3=A9 time"
+		got, _ := ParsedBody([]byte(raw), 0)
+		if got != "Café time" {
+			t.Fatalf("expected decoded café, got %q", got)
+		}
+	})
+
+	t.Run("strips quoted reply (On ... wrote:)", func(t *testing.T) {
+		raw := "From: a@x.com\r\nContent-Type: text/plain\r\n\r\nMy reply.\r\n\r\nOn Mon, Jan 1, 2026, Bob <b@y.com> wrote:\r\n> original\r\n> more original\r\n"
+		got, _ := ParsedBody([]byte(raw), 0)
+		if got != "My reply." {
+			t.Fatalf("expected only the reply, got %q", got)
+		}
+	})
+
+	t.Run("strips Outlook original-message block", func(t *testing.T) {
+		raw := "From: a@x.com\r\nContent-Type: text/plain\r\n\r\nTop post.\r\n\r\n-----Original Message-----\r\nFrom: someone\r\nblah\r\n"
+		got, _ := ParsedBody([]byte(raw), 0)
+		if got != "Top post." {
+			t.Fatalf("expected top post, got %q", got)
+		}
+	})
+
+	t.Run("length cap truncates", func(t *testing.T) {
+		body := strings.Repeat("a", 100)
+		raw := "From: a@x.com\r\nContent-Type: text/plain\r\n\r\n" + body
+		got, trunc := ParsedBody([]byte(raw), 20)
+		if !trunc || len(got) > 20 {
+			t.Fatalf("expected truncation to <=20, got len=%d trunc=%v", len(got), trunc)
+		}
+	})
+
+	t.Run("malformed message degrades to raw, no panic", func(t *testing.T) {
+		got, _ := ParsedBody([]byte("not a real email at all"), 0)
+		if got == "" {
+			t.Fatal("expected best-effort text, got empty")
+		}
+	})
+}


### PR DESCRIPTION
## Slice 4b-3 — parsed view + message-read unification (api-v1-redesign §4 decision 9)

Finishes the inbound-hygiene + unified-read portions of decision 9.

### Parsed view (`internal/mailparse`)
Derives the **injection-reduced** text an agent feeds a model by default, from the raw RFC 5322 message: MIME-walk (prefer `text/plain`, else **HTML→text** via `x/net/html`), decode base64/quoted-printable, **strip quoted reply chains / forwarded headers** ("On … wrote:", Outlook `-----Original Message-----`, dividers), collapse whitespace, **length cap** (16KB default — token-stuffing guard). Best-effort: a malformed message degrades to raw, never errors.

Surfaced as **`parsed: {text, truncated}`** on inbound message reads. Per decision 9 it's a **convenience, not a security control** — `raw_message` is always present and the security decision is made on `auth` + provenance (structured fields), **never** on the stripped text. Over-stripping is acceptable (raw is the fallback).

### Message-read unification
`GET /v1/agents/{address}/messages/{id}` now exposes **both representations** the design requires: `raw_message` for sent/inbound **and** the held-draft `body: {text, html}` for `pending_approval` outbound (`GetMessageWithContent` now reads `body_text`/`body_html`). So `/v1` is the single canonical read for every message kind.

### Scope decision
The **literal deletion** of the legacy flat `/api/v1/messages/{id}` route is **deferred to the consumer-port slice** — the TS + Python SDKs still call it, so removing it now breaks them before they repoint to `/v1`. The `/v1` read is already feature-complete, so the flat path is redundant; deleting it is a clean follow-up once the SDKs move.

## Verification
- `go build`, `go vet`, spec-drift gate, **full integration suite** (`-tags integration -p 1`) green — except the pre-existing `TestSubscriberStore_RecordAttemptFailureClimbsToFailed` (red on clean `main`). `e2e` + `tests/contract` pass (no contract break).
- **mailparse unit tests**: plain / HTML→text (script dropped) / multipart-prefers-plain / quoted-printable / quote-strip (Gmail + Outlook) / length-cap / malformed-degrades.
- **view wiring**: inbound→`parsed`, outbound→none, held-draft→`body`, sent/inbound→no `body`.
- **Real-binary smoke**: boots clean; served `/v1/openapi.yaml` carries the new `parsed`/`body` schemas.
- **Additive only** — no migration, no endpoint change, no breaking change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)