### PR TITLE
feat(relay): Slice 7a — inbound trust policy ingestion gate (decision 10)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -48,6 +48,14 @@ components:
         inbound_7d:
           format: int64
           type: integer
+        inbound_allowlist:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        inbound_policy:
+          type: string
         last_delivery_at:
           format: date-time
           type: string
@@ -81,6 +89,7 @@ components:
         - outbound_7d
         - pending_count
         - webhook_healthy
+        - inbound_policy
       type: object
     AgentView:
       additionalProperties: false
@@ -103,6 +112,14 @@ components:
           type: integer
         id:
           type: string
+        inbound_allowlist:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        inbound_policy:
+          type: string
         name:
           type: string
       required:
@@ -115,6 +132,7 @@ components:
         - hitl_enabled
         - hitl_ttl_seconds
         - hitl_expiration_action
+        - inbound_policy
       type: object
     ApproveRequest:
       additionalProperties: false
@@ -762,6 +780,10 @@ components:
         expires_at:
           format: date-time
           type: string
+        flag_reason:
+          type: string
+        flagged:
+          type: boolean
         id:
           type: string
         inbox_status:
@@ -872,6 +894,10 @@ components:
           type: string
         direction:
           type: string
+        flag_reason:
+          type: string
+        flagged:
+          type: boolean
         from:
           type: string
         hitl_status:
@@ -947,6 +973,10 @@ components:
           type: string
         delivery_status:
           type: string
+        flag_reason:
+          type: string
+        flagged:
+          type: boolean
         from:
           type: string
         labels:
@@ -1340,6 +1370,12 @@ components:
         hitl_ttl_seconds:
           format: int64
           type: integer
+        inbound_allowlist:
+          items:
+            type: string
+          type: array
+        inbound_policy:
+          type: string
       type: object
     UpdateDomainRequest:
       additionalProperties: false

--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -1247,10 +1247,10 @@ Break the current `/api/v1` surface directly and move it to
     flat `/api/v1/messages/{id}` route rides the consumer-port slice (the TS +
     Python SDKs still call it; deleting now breaks them before they repoint to
     `/v1`).
-  * **Still deferred:** the `email.flagged` security event (it fires on a
-    policy decision → Slice 7); the ≥N-soft-bounce
+  * **Still deferred:** the ≥N-soft-bounce
     suppression threshold; the `_dmarc` policy (`p=`/strict-alignment) fetch;
     and the SNS flow's real-AWS e2e (CI uses crafted SNS payloads + fake cert).
+    (The `email.flagged` security event shipped in **Slice 7a** below.)
 * **Slice 5 — Auth: OAuth 2.1 + auth.md agent identity.** OAuth 2.1 hosted-MCP
   (PKCE + refresh), scoped API keys (`e2a_agt_`/`e2a_acct_`), and the auth.md
   agent-identity layer (`/agent/identity`, claim ceremony, jwt-bearer/claim
@@ -1261,14 +1261,39 @@ Break the current `/api/v1` surface directly and move it to
   host cutover); independent of 4/4b. Keep API keys throughout.
 * **Slice 6 — Agent-first docs.** `e2a.md`/`llms.txt`/`setup.md`/`auth.md`,
   binary-served; `api.md` generated from the spec.
-* **Slice 7 — Inbound trust policy (decision 10), post-parity.** Per-agent
-  `inbound_policy` enum (`open`/`allowlist`/`domain`/`verified_only`/`hitl`,
-  composable) + **trust-gated action authorization** (policy-driven hold of
-  suspicious outbound as `pending_approval`, keyed on the referenced message's
-  server-owned verdict; no new contract surface). Builds on decision 9's verdict
-  + the v1 injection-reduced parsed view (already in Slice 4b). **Not a parity
-  gap** — e2a's server-side HITL + auth verdicts are already strong here; this
-  packages that latent advantage into a named policy. Defer until 1–6 land.
+* **Slice 7 — Inbound trust policy (decision 10), post-parity.** Builds on
+  decision 9's verdict + the v1 injection-reduced parsed view (already in Slice
+  4b). **Not a parity gap** — e2a's server-side HITL + auth verdicts are already
+  strong here; this packages that latent advantage into a named policy.
+
+  **Reconciled to two orthogonal axes (build note).** Decision 10 says the
+  postures "compose" (e.g. `verified_only` + `hitl`), which a *single* enum
+  can't express — `hitl` is an action gate, the others are ingestion gates. So
+  the implementation models them as two independent fields rather than one enum:
+    * `inbound_policy ∈ {open, allowlist, domain, verified_only}` — the
+      **ingestion** axis (Slice 7a, shipped below).
+    * the existing `hitl_enabled` flag + sub-mode — the **action-gate** axis
+      (Slice 7b, deferred). Decision 10's "`inbound_policy: hitl`" reconciles to
+      this flag, so no enum value `hitl` exists on `inbound_policy`.
+
+  * **Slice 7a — Inbound ingestion gate.** *(Shipped.)* Per-agent
+    `inbound_policy` (`open`/`allowlist`/`domain`/`verified_only`) +
+    `inbound_allowlist[]` on `agent_identities` (migration 033, default `open`,
+    CHECK-constrained). The relay evaluates the policy on arrival against the
+    **authenticated From identity** (not the attacker-controllable Reply-To);
+    `verified_only` gates on decision 9's persisted `dmarc=pass` alignment. A
+    non-match is **flagged, never dropped** — `messages.flagged`/`flag_reason`
+    set, `email.received` still fires, and `email.flagged` additionally emits so
+    operators get a signal. Evaluator is a stdlib leaf (`internal/inboundpolicy`);
+    surfaced as `inbound_policy`/`inbound_allowlist` on `AgentView` (settable via
+    `update_agent`) and `flagged`/`flag_reason` on message reads.
+  * **Slice 7b — Trust-gated action authorization.** *(Deferred.)* Policy-driven
+    hold of suspicious outbound as `pending_approval`, keyed on the referenced
+    message's server-owned verdict (high-impact predicate: recipient domain not a
+    participant of the referenced inbound OR forward to a third party; weak
+    verdict: `dmarc != pass`). No new contract surface. Depends on the **hard
+    scope ceiling** (decision 10 / §5), which lands with **Slice 5**'s scope
+    machinery — so 7b follows 5.
 
 Slices 1–6 are independently shippable; 1–2 deliver most of the "clean and
 consistent" win. Slice 7 is a post-parity enhancement.

--- a/docs/events.md
+++ b/docs/events.md
@@ -60,6 +60,7 @@ for e in res.events:
 | Type | When it fires | Guarantee |
 |---|---|---|
 | `email.received` | Inbound SMTP message accepted | **At-least-once** end-to-end |
+| `email.flagged` | Inbound message accepted but did not match the agent's `inbound_policy` (delivered + flagged, never dropped) | **At-least-once** end-to-end |
 | `email.sent` | Outbound `/send` accepted by SES | Best-effort |
 | `email.pending_approval` | HITL-gated message held for human review | **At-least-once** |
 | `email.approved` | Reviewer approved + SES accepted | Best-effort |

--- a/internal/agent/hitl_approval_api_test.go
+++ b/internal/agent/hitl_approval_api_test.go
@@ -219,7 +219,7 @@ func TestGetOutboundMessage_ReplyAttachesInboundContext(t *testing.T) {
 	if _, err := store.CreateInboundMessage(ctx, "", agent.ID,
 		"alice@gmail.com", "bot@inbound-ctx.example.com",
 		"<orig@gmail.com>", "Hello Bot", "", "",
-		nil, authHeaders, nil, nil, nil, nil); err != nil {
+		nil, authHeaders, nil, false, "", nil, nil, nil); err != nil {
 		t.Fatalf("seed inbound: %v", err)
 	}
 
@@ -326,7 +326,7 @@ func TestGetOutboundMessage_ReplyWithMissingInboundReturnsNilContext(t *testing.
 	inbound, err := store.CreateInboundMessage(ctx, "", agent.ID,
 		"alice@gmail.com", "bot@missing-inbound.example.com",
 		"<missing@gmail.com>", "Subject that will vanish", "", "",
-		nil, nil, nil, nil, nil, nil)
+		nil, nil, nil, false, "", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("seed inbound: %v", err)
 	}
@@ -386,7 +386,7 @@ func TestGetOutboundMessage_InboundContextIsAgentScoped(t *testing.T) {
 	if _, err := store.CreateInboundMessage(ctx, "", agentA.ID,
 		"alice@gmail.com", "bot@scoped-a.example.com",
 		"<shared-id@gmail.com>", "Subject for A", "", "",
-		nil, map[string]string{"spf": "pass"}, nil, nil, nil, nil); err != nil {
+		nil, map[string]string{"spf": "pass"}, nil, false, "", nil, nil, nil); err != nil {
 		t.Fatalf("seed inbound A: %v", err)
 	}
 
@@ -398,7 +398,7 @@ func TestGetOutboundMessage_InboundContextIsAgentScoped(t *testing.T) {
 	if _, err := store.CreateInboundMessage(ctx, "", agentB.ID,
 		"bob@gmail.com", "bot@scoped-b.example.com",
 		"<shared-id@gmail.com>", "Subject for B (must NOT leak)", "", "",
-		nil, map[string]string{"spf": "fail"}, nil, nil, nil, nil); err != nil {
+		nil, map[string]string{"spf": "fail"}, nil, false, "", nil, nil, nil); err != nil {
 		t.Fatalf("seed inbound B: %v", err)
 	}
 

--- a/internal/agent/labels_api_test.go
+++ b/internal/agent/labels_api_test.go
@@ -33,7 +33,7 @@ func setupLabelsFixture(t *testing.T, prefix string) labelsFixture {
 	store.VerifyDomain(ctx, domain, user.ID)
 	agentEmail := "bot@" + domain
 	agent, _ := store.CreateAgent(ctx, agentEmail, domain, "", "https://example.com/webhook", "", user.ID)
-	msg, _ := store.CreateInboundMessage(ctx, "", agent.ID, "alice@gmail.com", agentEmail, "<orig-"+prefix+"@gmail.com>", "Hi", "", "", nil, nil, nil, nil, nil, nil)
+	msg, _ := store.CreateInboundMessage(ctx, "", agent.ID, "alice@gmail.com", agentEmail, "<orig-"+prefix+"@gmail.com>", "Hi", "", "", nil, nil, nil, false, "", nil, nil, nil)
 	return labelsFixture{
 		server:     http.DefaultClient,
 		serverURL:  server.URL,
@@ -160,7 +160,7 @@ func TestUpdateMessageLabels_CrossAgentReturns404(t *testing.T) {
 	store.ClaimOrCreateDomain(ctx, "lblxa.example.com", userA.ID)
 	store.VerifyDomain(ctx, "lblxa.example.com", userA.ID)
 	agentA, _ := store.CreateAgent(ctx, "bot@lblxa.example.com", "lblxa.example.com", "", "https://example.com/webhook", "", userA.ID)
-	msgA, _ := store.CreateInboundMessage(ctx, "", agentA.ID, "alice@gmail.com", "bot@lblxa.example.com", "<x@gmail.com>", "Hi", "", "", nil, nil, nil, nil, nil, nil)
+	msgA, _ := store.CreateInboundMessage(ctx, "", agentA.ID, "alice@gmail.com", "bot@lblxa.example.com", "<x@gmail.com>", "Hi", "", "", nil, nil, nil, false, "", nil, nil, nil)
 
 	userB, _ := store.CreateOrGetUser(ctx, "owner-lblxB@example.com", "OwnerB", "google-lblxB")
 	apiKeyB, _ := store.CreateAPIKey(ctx, userB.ID, "lblxB-key", nil)

--- a/internal/agent/selfsend.go
+++ b/internal/agent/selfsend.go
@@ -92,6 +92,8 @@ func (a *API) performSelfSend(
 		rawMessage,
 		nil,
 		nil,
+		false,
+		"",
 		[]string{email},
 		nil,
 		nil,

--- a/internal/apiserver/apiserver.go
+++ b/internal/apiserver/apiserver.go
@@ -75,11 +75,12 @@ func BuildDeps(p Params) httpapi.Deps {
 		ListConversations: p.Store.ListConversationsByAgent,
 		GetConversation:   p.Store.GetConversationByID,
 
-		CreateAgent:        p.Store.CreateAgent,
-		LookupDomain:       p.Store.LookupDomain,
-		EnforceAgentCreate: p.Enforcer.CheckAgentCreate,
-		UpdateAgentHITL:    p.Store.UpdateAgentHITL,
-		DeleteAgent:        p.Store.DeleteAgent,
+		CreateAgent:              p.Store.CreateAgent,
+		LookupDomain:             p.Store.LookupDomain,
+		EnforceAgentCreate:       p.Enforcer.CheckAgentCreate,
+		UpdateAgentHITL:          p.Store.UpdateAgentHITL,
+		UpdateAgentInboundPolicy: p.Store.UpdateAgentInboundPolicy,
+		DeleteAgent:              p.Store.DeleteAgent,
 
 		ListDomains:         p.Store.ListDomainsByUser,
 		ClaimDomain:         p.Store.ClaimOrCreateDomain,

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -120,9 +120,9 @@ func TestHandleAgentActivity_WithMessages(t *testing.T) {
 	agent, _ := store.CreateAgent(ctx, "agent@active.example.com", "active.example.com", "", "https://example.com/webhook", "", user.ID)
 
 	// Create some activity ("" id lets the store generate one).
-	store.CreateInboundMessage(ctx, "", agent.ID, "alice@gmail.com", "bot@active.example.com", "", "Hello", "", "", nil, nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agent.ID, "alice@gmail.com", "bot@active.example.com", "", "Hello", "", "", nil, nil, nil, false, "", nil, nil, nil)
 	store.CreateOutboundMessage(ctx, agent.ID, []string{"alice@gmail.com"}, nil, nil, "Re: Hello", "reply", "smtp", "", "")
-	store.CreateInboundMessage(ctx, "", agent.ID, "bob@gmail.com", "bot@active.example.com", "", "Hi", "", "", nil, nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agent.ID, "bob@gmail.com", "bot@active.example.com", "", "Hi", "", "", nil, nil, nil, false, "", nil, nil, nil)
 
 	req := authedRequest("GET", "/api/dashboard/agents/agent%40active.example.com/activity", token)
 	w := httptest.NewRecorder()

--- a/internal/e2e/inbound_policy_e2e_test.go
+++ b/internal/e2e/inbound_policy_e2e_test.go
@@ -1,0 +1,173 @@
+//go:build integration
+
+package e2e_test
+
+import (
+	"context"
+	"net/smtp"
+	"testing"
+	"time"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Slice 7a — inbound trust policy ingestion gate (api-v1-redesign decision 10).
+//
+// The relay evaluates the agent's inbound_policy on arrival. A non-matching
+// message is FLAGGED — still delivered (email.received still fires, the row is
+// persisted) — and additionally emits email.flagged so operators get a signal.
+// Nothing is dropped. These e2e tests drive a real SMTP delivery through the
+// relay and assert both the persisted flag and the emitted events.
+
+// flaggedFixture wires a verified agent with the given ingestion policy and a
+// subscriber listening for both email.received and email.flagged. Returns the
+// pool (to read the persisted row), the agent, and the capturing receiver.
+func setupFlaggedAgent(t *testing.T, policy string, allowlist []string, email, domain string) (*testutil.E2ATestServer, *pgxpool.Pool, *identity.AgentIdentity, *testutil.SubscriberReceiverResult) {
+	t.Helper()
+	pool := testutil.TestDB(t)
+	receiver := testutil.SubscriberReceiver(t)
+	ts := testutil.TestServer(t, pool)
+
+	user, _, agent := setupDomainAndAgent(t, ts, email, domain, "", "")
+	if err := ts.Store.UpdateAgentInboundPolicy(context.Background(), agent.ID, user.ID, policy, allowlist); err != nil {
+		t.Fatalf("UpdateAgentInboundPolicy: %v", err)
+	}
+	registerWebhook(t, ts, user.ID, receiver.Server.URL+"/received",
+		[]string{"email.received", "email.flagged"}, identity.WebhookFilters{})
+	return ts, pool, agent, receiver
+}
+
+func eventTypes(caps []testutil.SubscriberCaptured) map[string]int {
+	out := map[string]int{}
+	for _, c := range caps {
+		if et, ok := c.Envelope["event"].(string); ok {
+			out[et]++
+		}
+	}
+	return out
+}
+
+func readFlagged(t *testing.T, pool *pgxpool.Pool, agentID string) (bool, string) {
+	t.Helper()
+	var flagged bool
+	var reason string
+	err := pool.QueryRow(context.Background(),
+		`SELECT flagged, COALESCE(flag_reason, '') FROM messages
+		 WHERE agent_id = $1 AND direction = 'inbound' ORDER BY created_at DESC LIMIT 1`,
+		agentID,
+	).Scan(&flagged, &reason)
+	if err != nil {
+		t.Fatalf("read flagged: %v", err)
+	}
+	return flagged, reason
+}
+
+// TestInboundPolicy_AllowlistFlagsNonMember: an allowlist-policy agent receives
+// mail from a sender NOT on the list — the message is delivered AND flagged,
+// and email.flagged fires alongside email.received.
+func TestInboundPolicy_AllowlistFlagsNonMember(t *testing.T) {
+	ts, pool, agent, receiver := setupFlaggedAgent(t, "allowlist",
+		[]string{"friend@trusted.com"}, "agent@allow.example.com", "allow.example.com")
+
+	msg := "From: stranger@evil.com\r\nTo: agent@allow.example.com\r\nSubject: Hi\r\n\r\nHello"
+	if err := smtp.SendMail(ts.SMTPAddr, nil, "stranger@evil.com", []string{"agent@allow.example.com"}, []byte(msg)); err != nil {
+		t.Fatalf("SendMail: %v", err)
+	}
+
+	tick(t, ts)
+	got := receiver.WaitFor(t, 5*time.Second, func(c []testutil.SubscriberCaptured) bool {
+		return eventTypes(c)["email.flagged"] >= 1 && eventTypes(c)["email.received"] >= 1
+	})
+	types := eventTypes(got)
+	if types["email.received"] < 1 {
+		t.Errorf("email.received not delivered (message must NOT be dropped): %v", types)
+	}
+	if types["email.flagged"] < 1 {
+		t.Errorf("email.flagged not delivered for non-allowlisted sender: %v", types)
+	}
+
+	// The persisted row must carry the flag + a reason.
+	flagged, reason := readFlagged(t, pool, agent.ID)
+	if !flagged {
+		t.Error("persisted inbound row not flagged")
+	}
+	if reason == "" {
+		t.Error("flagged row has empty flag_reason")
+	}
+}
+
+// TestInboundPolicy_AllowlistAcceptsMember: a sender ON the allowlist is NOT
+// flagged and no email.flagged is emitted.
+func TestInboundPolicy_AllowlistAcceptsMember(t *testing.T) {
+	ts, pool, agent, receiver := setupFlaggedAgent(t, "allowlist",
+		[]string{"friend@trusted.com"}, "agent@allow2.example.com", "allow2.example.com")
+
+	msg := "From: friend@trusted.com\r\nTo: agent@allow2.example.com\r\nSubject: Hi\r\n\r\nHello"
+	if err := smtp.SendMail(ts.SMTPAddr, nil, "friend@trusted.com", []string{"agent@allow2.example.com"}, []byte(msg)); err != nil {
+		t.Fatalf("SendMail: %v", err)
+	}
+
+	tick(t, ts)
+	got := receiver.WaitFor(t, 5*time.Second, func(c []testutil.SubscriberCaptured) bool {
+		return eventTypes(c)["email.received"] >= 1
+	})
+	if n := eventTypes(got)["email.flagged"]; n != 0 {
+		t.Errorf("allowlisted sender should not be flagged, got %d email.flagged", n)
+	}
+	if flagged, _ := readFlagged(t, pool, agent.ID); flagged {
+		t.Error("allowlisted sender persisted as flagged")
+	}
+}
+
+// TestInboundPolicy_EvaluatesFromNotReplyTo pins the security-critical property:
+// the policy is evaluated against the authenticated From identity, NOT the
+// attacker-controllable Reply-To. A spoofer puts a trusted address in Reply-To
+// but sends From an untrusted address — it must STILL be flagged.
+func TestInboundPolicy_EvaluatesFromNotReplyTo(t *testing.T) {
+	ts, pool, agent, receiver := setupFlaggedAgent(t, "allowlist",
+		[]string{"friend@trusted.com"}, "agent@replyto.example.com", "replyto.example.com")
+
+	// From is the untrusted sender; Reply-To claims the trusted address.
+	msg := "From: stranger@evil.com\r\n" +
+		"Reply-To: friend@trusted.com\r\n" +
+		"To: agent@replyto.example.com\r\nSubject: Hi\r\n\r\nHello"
+	if err := smtp.SendMail(ts.SMTPAddr, nil, "stranger@evil.com", []string{"agent@replyto.example.com"}, []byte(msg)); err != nil {
+		t.Fatalf("SendMail: %v", err)
+	}
+
+	tick(t, ts)
+	got := receiver.WaitFor(t, 5*time.Second, func(c []testutil.SubscriberCaptured) bool {
+		return eventTypes(c)["email.flagged"] >= 1
+	})
+	if n := eventTypes(got)["email.flagged"]; n < 1 {
+		t.Error("Reply-To spoof of a trusted address must NOT bypass the gate — expected email.flagged")
+	}
+	if flagged, _ := readFlagged(t, pool, agent.ID); !flagged {
+		t.Error("Reply-To spoof persisted as un-flagged (gate read Reply-To, not From)")
+	}
+}
+
+// TestInboundPolicy_OpenNeverFlags: the default open policy flags nothing, even
+// for an arbitrary external sender.
+func TestInboundPolicy_OpenNeverFlags(t *testing.T) {
+	ts, pool, agent, receiver := setupFlaggedAgent(t, "open",
+		nil, "agent@open.example.com", "open.example.com")
+
+	msg := "From: anyone@wherever.com\r\nTo: agent@open.example.com\r\nSubject: Hi\r\n\r\nHello"
+	if err := smtp.SendMail(ts.SMTPAddr, nil, "anyone@wherever.com", []string{"agent@open.example.com"}, []byte(msg)); err != nil {
+		t.Fatalf("SendMail: %v", err)
+	}
+
+	tick(t, ts)
+	got := receiver.WaitFor(t, 5*time.Second, func(c []testutil.SubscriberCaptured) bool {
+		return eventTypes(c)["email.received"] >= 1
+	})
+	if n := eventTypes(got)["email.flagged"]; n != 0 {
+		t.Errorf("open policy emitted %d email.flagged; want 0", n)
+	}
+	if flagged, _ := readFlagged(t, pool, agent.ID); flagged {
+		t.Error("open policy flagged a message")
+	}
+}

--- a/internal/e2e/inbound_policy_e2e_test.go
+++ b/internal/e2e/inbound_policy_e2e_test.go
@@ -49,6 +49,18 @@ func eventTypes(caps []testutil.SubscriberCaptured) map[string]int {
 	return out
 }
 
+// eventData returns the data block of the first captured envelope of the given
+// type, or nil if none was captured.
+func eventData(caps []testutil.SubscriberCaptured, eventType string) map[string]any {
+	for _, c := range caps {
+		if et, _ := c.Envelope["event"].(string); et == eventType {
+			d, _ := c.Envelope["data"].(map[string]any)
+			return d
+		}
+	}
+	return nil
+}
+
 func readFlagged(t *testing.T, pool *pgxpool.Pool, agentID string) (bool, string) {
 	t.Helper()
 	var flagged bool
@@ -146,6 +158,65 @@ func TestInboundPolicy_EvaluatesFromNotReplyTo(t *testing.T) {
 	}
 	if flagged, _ := readFlagged(t, pool, agent.ID); !flagged {
 		t.Error("Reply-To spoof persisted as un-flagged (gate read Reply-To, not From)")
+	}
+
+	// The flagged event must name the AUTHENTICATED From (the identity that
+	// failed the gate), not the trusted-looking Reply-To. Surfacing the
+	// Reply-To here would let an attacker make a rejected message look like it
+	// came from the address they impersonated (review finding #1).
+	if fe := eventData(got, "email.flagged"); fe != nil {
+		if fe["from"] != "stranger@evil.com" {
+			t.Errorf("email.flagged from = %v, want the authenticated From stranger@evil.com", fe["from"])
+		}
+		if fe["display_sender"] != "friend@trusted.com" {
+			t.Errorf("email.flagged display_sender = %v, want the Reply-To friend@trusted.com", fe["display_sender"])
+		}
+	} else {
+		t.Error("no email.flagged data captured")
+	}
+}
+
+// TestInboundPolicy_ReceivedSurfacesAuthenticatedFrom pins the surfacing
+// contract that makes the verdict honest: when the display sender (Reply-To)
+// differs from the authenticated From, email.received carries BOTH —
+// `authenticated_from` is the gated/verified identity, `from` is the reply
+// target. A consumer of a verified_only/allowlist agent must trust
+// `authenticated_from`, not `from`. Without this, an allowlisted (or
+// DMARC-aligned) From + attacker Reply-To yields an unflagged message whose
+// displayed sender is attacker-chosen (review finding #1, the unflagged inverse).
+func TestInboundPolicy_ReceivedSurfacesAuthenticatedFrom(t *testing.T) {
+	ts, pool, agent, receiver := setupFlaggedAgent(t, "allowlist",
+		[]string{"friend@trusted.com"}, "agent@authfrom.example.com", "authfrom.example.com")
+
+	// From is on the allowlist (so NOT flagged); Reply-To points elsewhere.
+	msg := "From: friend@trusted.com\r\n" +
+		"Reply-To: attacker@evil.com\r\n" +
+		"To: agent@authfrom.example.com\r\nSubject: Hi\r\n\r\nHello"
+	if err := smtp.SendMail(ts.SMTPAddr, nil, "friend@trusted.com", []string{"agent@authfrom.example.com"}, []byte(msg)); err != nil {
+		t.Fatalf("SendMail: %v", err)
+	}
+
+	tick(t, ts)
+	got := receiver.WaitFor(t, 5*time.Second, func(c []testutil.SubscriberCaptured) bool {
+		return eventTypes(c)["email.received"] >= 1
+	})
+	// Allowlisted From → not flagged.
+	if n := eventTypes(got)["email.flagged"]; n != 0 {
+		t.Errorf("allowlisted From should not be flagged, got %d email.flagged", n)
+	}
+	if flagged, _ := readFlagged(t, pool, agent.ID); flagged {
+		t.Error("allowlisted From persisted as flagged")
+	}
+	// email.received must distinguish the gated identity from the reply target.
+	re := eventData(got, "email.received")
+	if re == nil {
+		t.Fatal("no email.received data captured")
+	}
+	if re["authenticated_from"] != "friend@trusted.com" {
+		t.Errorf("authenticated_from = %v, want the gated From friend@trusted.com", re["authenticated_from"])
+	}
+	if re["from"] != "attacker@evil.com" {
+		t.Errorf("from = %v, want the reply target attacker@evil.com (display sender)", re["from"])
 	}
 }
 

--- a/internal/httpapi/agents_write.go
+++ b/internal/httpapi/agents_write.go
@@ -110,6 +110,10 @@ type UpdateAgentRequest struct {
 	HITLEnabled          *bool   `json:"hitl_enabled,omitempty"`
 	HITLTTLSeconds       *int    `json:"hitl_ttl_seconds,omitempty"`
 	HITLExpirationAction *string `json:"hitl_expiration_action,omitempty"`
+	// InboundPolicy / InboundAllowlist set the per-agent inbound ingestion gate
+	// (migration 033 / Slice 7). Pointers so absent != zero.
+	InboundPolicy    *string   `json:"inbound_policy,omitempty"`
+	InboundAllowlist *[]string `json:"inbound_allowlist,omitempty"`
 }
 
 type updateAgentInput struct {
@@ -142,6 +146,24 @@ func (s *Server) handleUpdateAgent(ctx context.Context, in *updateAgentInput) (*
 			return nil, NewError(http.StatusInternalServerError, "internal_error", "update unavailable")
 		}
 		if err := s.deps.UpdateAgentHITL(ctx, ag.ID, ag.UserID, enabled, ttl, action); err != nil {
+			return nil, NewError(http.StatusBadRequest, "invalid_request", err.Error())
+		}
+		touched = true
+	}
+
+	if req.InboundPolicy != nil || req.InboundAllowlist != nil {
+		policy := ag.InboundPolicy
+		if req.InboundPolicy != nil {
+			policy = *req.InboundPolicy
+		}
+		allowlist := ag.InboundAllowlist
+		if req.InboundAllowlist != nil {
+			allowlist = *req.InboundAllowlist
+		}
+		if s.deps.UpdateAgentInboundPolicy == nil {
+			return nil, NewError(http.StatusInternalServerError, "internal_error", "update unavailable")
+		}
+		if err := s.deps.UpdateAgentInboundPolicy(ctx, ag.ID, ag.UserID, policy, allowlist); err != nil {
 			return nil, NewError(http.StatusBadRequest, "invalid_request", err.Error())
 		}
 		touched = true

--- a/internal/httpapi/agents_write_test.go
+++ b/internal/httpapi/agents_write_test.go
@@ -2,9 +2,14 @@ package httpapi
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
+	"net/http/httptest"
 	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
 )
 
 func sendJSON(t *testing.T, method, url, bearer string, body any) (int, map[string]any) {
@@ -36,6 +41,47 @@ func TestUpdateAgentHITL(t *testing.T) {
 	// Returns the reloaded agent.
 	if body["email"] != "support@acme.com" {
 		t.Fatalf("expected reloaded agent, got %v", body)
+	}
+}
+
+// TestUpdateAgentInboundPolicy exercises the full PATCH → store → re-read →
+// AgentView round-trip for the inbound ingestion gate (Slice 7). The fake
+// store mutates a captured agent so GetAgent returns the post-update shape.
+func TestUpdateAgentInboundPolicy(t *testing.T) {
+	ag := sampleAgent()
+	ag.InboundPolicy = "open"
+	deps := Deps{
+		Authenticator: func(r *http.Request) (*identity.User, error) {
+			if r.Header.Get("Authorization") == "Bearer good" {
+				return &identity.User{ID: "u_1", Email: "owner@acme.com"}, nil
+			}
+			return nil, errors.New("unauthorized")
+		},
+		GetAgent: func(ctx context.Context, address string) (*identity.AgentIdentity, error) {
+			if address == "support@acme.com" {
+				a := ag
+				return &a, nil
+			}
+			return nil, errors.New("not found")
+		},
+		UpdateAgentInboundPolicy: func(ctx context.Context, agentID, userID, policy string, allowlist []string) error {
+			ag.InboundPolicy = policy
+			ag.InboundAllowlist = allowlist
+			return nil
+		},
+		Legacy: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusTeapot) }),
+	}
+	srv := httptest.NewServer(New(deps))
+	t.Cleanup(srv.Close)
+
+	code, body := sendJSON(t, "PATCH", srv.URL+"/v1/agents/support%40acme.com", "good", map[string]any{
+		"inbound_policy": "verified_only",
+	})
+	if code != 200 {
+		t.Fatalf("status %d body %v", code, body)
+	}
+	if body["inbound_policy"] != "verified_only" {
+		t.Fatalf("expected inbound_policy=verified_only on AgentView, got %v", body["inbound_policy"])
 	}
 }
 

--- a/internal/httpapi/httpapi.go
+++ b/internal/httpapi/httpapi.go
@@ -82,7 +82,11 @@ type Deps struct {
 	LookupDomain       DomainLookup
 	EnforceAgentCreate AgentCreateEnforcer
 	UpdateAgentHITL    AgentHITLUpdater
-	DeleteAgent        AgentDeleter
+	// UpdateAgentInboundPolicy sets the per-agent inbound ingestion gate
+	// (migration 033 / Slice 7). Returns a validation error for an unknown
+	// policy, which the handler maps to 400 invalid_request.
+	UpdateAgentInboundPolicy func(ctx context.Context, agentID, userID, policy string, allowlist []string) error
+	DeleteAgent              AgentDeleter
 
 	// domains
 	ListDomains         func(ctx context.Context, userID string) ([]identity.Domain, error)

--- a/internal/httpapi/messages.go
+++ b/internal/httpapi/messages.go
@@ -39,7 +39,12 @@ type MessageView struct {
 	DeliveryDetail string `json:"delivery_detail,omitempty"`
 	// SentAs is the From identity actually used at relay accept time.
 	// Outbound-only; omitted on inbound messages.
-	SentAs      string            `json:"sent_as,omitempty"`
+	SentAs string `json:"sent_as,omitempty"`
+	// Flagged + FlagReason carry the inbound ingestion verdict (migration 033 /
+	// Slice 7): true when the agent's inbound_policy gate flagged this message
+	// on arrival (still delivered). Inbound-relevant; omitted on unflagged rows.
+	Flagged     bool              `json:"flagged,omitempty"`
+	FlagReason  string            `json:"flag_reason,omitempty"`
 	Labels      []string          `json:"labels"`
 	CreatedAt   string            `json:"created_at"`
 	AuthHeaders map[string]string `json:"auth_headers"`
@@ -90,6 +95,8 @@ func messageViewFromIdentity(m *identity.Message) MessageView {
 		AuthHeaders:    m.AuthHeaders,
 		Auth:           m.Auth,
 		RawMessage:     m.RawMessage,
+		Flagged:        m.Flagged,
+		FlagReason:     m.FlagReason,
 	}
 	// Outbound delivery feedback (migration 031). On outbound rows
 	// identity.Message.DeliveryStatus carries the delivery rollup; on
@@ -147,12 +154,17 @@ type MessageSummaryView struct {
 	WebhookError   string   `json:"webhook_error,omitempty"`
 	// DeliveryStatus / DeliveryDetail / SentAs are the outbound delivery
 	// rollup (migration 031). Outbound-only; omitted on inbound rows.
-	DeliveryStatus string   `json:"delivery_status,omitempty"`
-	DeliveryDetail string   `json:"delivery_detail,omitempty"`
-	SentAs         string   `json:"sent_as,omitempty"`
-	SizeBytes      int      `json:"size_bytes,omitempty"`
-	Labels         []string `json:"labels"`
-	CreatedAt      string   `json:"created_at"`
+	DeliveryStatus string `json:"delivery_status,omitempty"`
+	DeliveryDetail string `json:"delivery_detail,omitempty"`
+	SentAs         string `json:"sent_as,omitempty"`
+	// Flagged + FlagReason are the inbound ingestion verdict (migration 033 /
+	// Slice 7). Surfaced in list views so flagged mail is visible without a
+	// per-message drill-down. Inbound-relevant; omitted on unflagged rows.
+	Flagged    bool     `json:"flagged,omitempty"`
+	FlagReason string   `json:"flag_reason,omitempty"`
+	SizeBytes  int      `json:"size_bytes,omitempty"`
+	Labels     []string `json:"labels"`
+	CreatedAt  string   `json:"created_at"`
 	// Auth is the structured inbound authentication verdict (migration 032).
 	// Inbound-only; omitted on outbound rows.
 	Auth *emailauth.Result `json:"auth,omitempty"`
@@ -174,6 +186,8 @@ func messageSummaryFromIdentity(m identity.Message) MessageSummaryView {
 		Labels:         orEmptyStrings(m.Labels),
 		CreatedAt:      m.CreatedAt.UTC().Format(time.RFC3339),
 		Auth:           m.Auth,
+		Flagged:        m.Flagged,
+		FlagReason:     m.FlagReason,
 	}
 	if m.Direction == "outbound" {
 		s.HITLStatus = m.Status

--- a/internal/httpapi/operations.go
+++ b/internal/httpapi/operations.go
@@ -56,6 +56,12 @@ type AgentView struct {
 	HITLEnabled          bool      `json:"hitl_enabled"`
 	HITLTTLSeconds       int       `json:"hitl_ttl_seconds"`
 	HITLExpirationAction string    `json:"hitl_expiration_action"`
+	// InboundPolicy is the per-agent inbound ingestion gate (migration 033 /
+	// Slice 7): one of open, allowlist, domain, verified_only. InboundAllowlist
+	// holds the trusted addresses (allowlist) or domains (domain); omitted when
+	// empty.
+	InboundPolicy    string   `json:"inbound_policy"`
+	InboundAllowlist []string `json:"inbound_allowlist,omitempty"`
 }
 
 // agentViewFromIdentity maps the storage record to the public view.
@@ -70,6 +76,8 @@ func agentViewFromIdentity(ag *identity.AgentIdentity) AgentView {
 		HITLEnabled:          ag.HITLEnabled,
 		HITLTTLSeconds:       ag.HITLTTLSeconds,
 		HITLExpirationAction: ag.HITLExpirationAction,
+		InboundPolicy:        ag.InboundPolicy,
+		InboundAllowlist:     ag.InboundAllowlist,
 	}
 }
 

--- a/internal/identity/conversations_test.go
+++ b/internal/identity/conversations_test.go
@@ -47,7 +47,7 @@ func TestListConversationsByAgent_GroupsByConversationID(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		_, err := store.CreateInboundMessage(ctx, "", agentID, "alice@gmail.com", "bot@convo-group.example.com",
 			fmt.Sprintf("<a%d@gmail.com>", i),
-			"Subject A", "conv-A", "", nil, nil, nil, nil, nil, nil,
+			"Subject A", "conv-A", "", nil, nil, nil, false, "", nil, nil, nil,
 		)
 		if err != nil {
 			t.Fatalf("CreateInboundMessage A%d: %v", i, err)
@@ -55,13 +55,13 @@ func TestListConversationsByAgent_GroupsByConversationID(t *testing.T) {
 	}
 	// Conversation B: 1 message
 	if _, err := store.CreateInboundMessage(ctx, "", agentID, "bob@gmail.com", "bot@convo-group.example.com",
-		"<b0@gmail.com>", "Subject B", "conv-B", "", nil, nil, nil, nil, nil, nil,
+		"<b0@gmail.com>", "Subject B", "conv-B", "", nil, nil, nil, false, "", nil, nil, nil,
 	); err != nil {
 		t.Fatalf("CreateInboundMessage B: %v", err)
 	}
 	// A message with NO conversation_id — must NOT show up in the list.
 	if _, err := store.CreateInboundMessage(ctx, "", agentID, "carol@gmail.com", "bot@convo-group.example.com",
-		"<c0@gmail.com>", "Subject C (no conv)", "", "", nil, nil, nil, nil, nil, nil,
+		"<c0@gmail.com>", "Subject C (no conv)", "", "", nil, nil, nil, false, "", nil, nil, nil,
 	); err != nil {
 		t.Fatalf("CreateInboundMessage C: %v", err)
 	}
@@ -96,10 +96,10 @@ func TestListConversationsByAgent_SortsByLastMessageDesc(t *testing.T) {
 
 	// Create A first, then B — but A is the "newer" conversation
 	// because we add another message to A after B's only one.
-	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-sort.example.com", "<a1@x>", "A", "conv-A-sort", "", nil, nil, nil, nil, nil, nil)
-	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-sort.example.com", "<b1@x>", "B", "conv-B-sort", "", nil, nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-sort.example.com", "<a1@x>", "A", "conv-A-sort", "", nil, nil, nil, false, "", nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-sort.example.com", "<b1@x>", "B", "conv-B-sort", "", nil, nil, nil, false, "", nil, nil, nil)
 	// Bump A's last_message_at to be the newest.
-	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-sort.example.com", "<a2@x>", "A2", "conv-A-sort", "", nil, nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-sort.example.com", "<a2@x>", "A2", "conv-A-sort", "", nil, nil, nil, false, "", nil, nil, nil)
 
 	convos, _ := store.ListConversationsByAgent(ctx, identity.ConversationListFilter{AgentID: agentID})
 	if len(convos) != 2 {
@@ -126,7 +126,7 @@ func TestListConversationsByAgent_LimitClamp(t *testing.T) {
 	if identity.ConversationListHardCap < 1 {
 		t.Fatalf("ConversationListHardCap must be > 0, got %d", identity.ConversationListHardCap)
 	}
-	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-clamp.example.com", "<a@x>", "A", "conv-clamp-A", "", nil, nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-clamp.example.com", "<a@x>", "A", "conv-clamp-A", "", nil, nil, nil, false, "", nil, nil, nil)
 	convos, err := store.ListConversationsByAgent(ctx, identity.ConversationListFilter{AgentID: agentID, Limit: 9999})
 	if err != nil {
 		t.Fatalf("ListConversationsByAgent: %v", err)
@@ -142,8 +142,8 @@ func TestListConversationsByAgent_SinceUntilWindow(t *testing.T) {
 	ctx := context.Background()
 	agentID := convoTestSetup(t, store, "convo-window")
 
-	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-window.example.com", "<old@x>", "old", "conv-old", "", nil, nil, nil, nil, nil, nil)
-	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-window.example.com", "<new@x>", "new", "conv-new", "", nil, nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-window.example.com", "<old@x>", "old", "conv-old", "", nil, nil, nil, false, "", nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-window.example.com", "<new@x>", "new", "conv-new", "", nil, nil, nil, false, "", nil, nil, nil)
 
 	// since=now-1h should return both; since=future should return zero.
 	all, _ := store.ListConversationsByAgent(ctx, identity.ConversationListFilter{
@@ -171,7 +171,7 @@ func TestListConversationsByAgent_AggregateFields(t *testing.T) {
 	// Conversation with one inbound (explicitly unread) and one outbound.
 	// The 9th arg of CreateInboundMessage is inbox_status — pass
 	// "unread" explicitly so the has_unread aggregate is true.
-	store.CreateInboundMessage(ctx, "", agentID, "alice@gmail.com", "bot@convo-agg.example.com", "<i1@x>", "Hello", "conv-agg", "unread", nil, nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agentID, "alice@gmail.com", "bot@convo-agg.example.com", "<i1@x>", "Hello", "conv-agg", "unread", nil, nil, nil, false, "", nil, nil, nil)
 	store.CreateOutboundMessage(ctx, agentID, []string{"alice@gmail.com"}, nil, nil, "Re: Hello", "reply", "smtp", "<out@x>", "conv-agg")
 
 	convos, _ := store.ListConversationsByAgent(ctx, identity.ConversationListFilter{AgentID: agentID})
@@ -207,9 +207,9 @@ func TestGetConversationByID_OrdersChronologically(t *testing.T) {
 
 	// Create three messages explicitly in non-monotonic order to
 	// verify the storage layer sorts on read, not write.
-	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-order.example.com", "<m1@x>", "first", "conv-ord", "", nil, nil, nil, nil, nil, nil)
-	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-order.example.com", "<m2@x>", "second", "conv-ord", "", nil, nil, nil, nil, nil, nil)
-	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-order.example.com", "<m3@x>", "third", "conv-ord", "", nil, nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-order.example.com", "<m1@x>", "first", "conv-ord", "", nil, nil, nil, false, "", nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-order.example.com", "<m2@x>", "second", "conv-ord", "", nil, nil, nil, false, "", nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agentID, "x@gmail.com", "bot@convo-order.example.com", "<m3@x>", "third", "conv-ord", "", nil, nil, nil, false, "", nil, nil, nil)
 
 	d, err := store.GetConversationByID(ctx, agentID, "conv-ord")
 	if err != nil {
@@ -231,10 +231,10 @@ func TestGetConversationByID_ComputesParticipantsAndLabels(t *testing.T) {
 	ctx := context.Background()
 	agentID := convoTestSetup(t, store, "convo-part")
 
-	m1, _ := store.CreateInboundMessage(ctx, "", agentID, "alice@gmail.com", "bot@convo-part.example.com", "<p1@x>", "hi", "conv-part", "", nil, nil, nil,
+	m1, _ := store.CreateInboundMessage(ctx, "", agentID, "alice@gmail.com", "bot@convo-part.example.com", "<p1@x>", "hi", "conv-part", "", nil, nil, nil, false, "",
 		[]string{"bot@convo-part.example.com", "team@convo-part.example.com"}, nil, nil,
 	)
-	m2, _ := store.CreateInboundMessage(ctx, "", agentID, "bob@gmail.com", "bot@convo-part.example.com", "<p2@x>", "hi", "conv-part", "", nil, nil, nil,
+	m2, _ := store.CreateInboundMessage(ctx, "", agentID, "bob@gmail.com", "bot@convo-part.example.com", "<p2@x>", "hi", "conv-part", "", nil, nil, nil, false, "",
 		[]string{"bot@convo-part.example.com"}, []string{"carol@gmail.com"}, nil,
 	)
 	store.ModifyMessageLabels(ctx, m1.ID, agentID, []string{"urgent"}, nil)
@@ -285,7 +285,7 @@ func TestGetConversationByID_CrossAgentIsolation(t *testing.T) {
 	ctx := context.Background()
 	agentA := convoTestSetup(t, store, "convo-iso-a")
 	agentB := convoTestSetup(t, store, "convo-iso-b")
-	store.CreateInboundMessage(ctx, "", agentA, "x@gmail.com", "bot@convo-iso-a.example.com", "<a@x>", "secret", "conv-shared", "", nil, nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agentA, "x@gmail.com", "bot@convo-iso-a.example.com", "<a@x>", "secret", "conv-shared", "", nil, nil, nil, false, "", nil, nil, nil)
 
 	// Agent B reading conv-shared must get not-found, NOT the inbound from A.
 	_, err := store.GetConversationByID(ctx, agentB, "conv-shared")

--- a/internal/identity/email_test.go
+++ b/internal/identity/email_test.go
@@ -1,6 +1,20 @@
 package identity
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
+
+// TestUpdateAgentInboundPolicyInvalid verifies the policy is validated before
+// any DB access (the inboundpolicy.Valid short-circuit), so a bogus policy
+// returns an error without a pool. Mirrors the gate the API maps to 400.
+func TestUpdateAgentInboundPolicyInvalid(t *testing.T) {
+	s := &Store{} // nil pool: invalid policy must return before touching it
+	err := s.UpdateAgentInboundPolicy(context.Background(), "bot@acme.com", "u_1", "bogus", nil)
+	if err == nil {
+		t.Fatal("expected error for invalid inbound_policy, got nil")
+	}
+}
 
 func TestNormalizeEmail(t *testing.T) {
 	tests := []struct {

--- a/internal/identity/inbound_policy_store_test.go
+++ b/internal/identity/inbound_policy_store_test.go
@@ -74,6 +74,43 @@ func TestUpdateAgentInboundPolicyRoundTrip(t *testing.T) {
 	}
 }
 
+// TestUpdateAgentInboundPolicyAllowlistCap: an oversized allowlist is rejected
+// before the UPDATE (review finding #3 — the relay scans it per inbound message,
+// so an unbounded list is an owner-scoped DoS).
+func TestUpdateAgentInboundPolicyAllowlistCap(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, err := store.CreateOrGetUser(ctx, "owner@cap.example.com", "Owner", "google-cap")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	if _, err := store.ClaimOrCreateDomain(ctx, "cap.example.com", user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+	agent, err := store.CreateAgent(ctx, "agent@cap.example.com", "cap.example.com", "", "", "", user.ID)
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	huge := make([]string, 1001)
+	for i := range huge {
+		huge[i] = "x@example.com"
+	}
+	if err := store.UpdateAgentInboundPolicy(ctx, agent.ID, user.ID, "allowlist", huge); err == nil {
+		t.Fatal("expected error for oversized allowlist, got nil")
+	}
+	// The agent must remain on its default (the rejected UPDATE never ran).
+	got, err := store.GetAgentByID(ctx, agent.ID)
+	if err != nil {
+		t.Fatalf("GetAgentByID: %v", err)
+	}
+	if got.InboundPolicy != "open" {
+		t.Errorf("InboundPolicy = %q after rejected oversized update, want open", got.InboundPolicy)
+	}
+}
+
 // TestUpdateAgentInboundPolicyWrongOwner: a user cannot change another user's
 // agent policy (tenant isolation — the UPDATE is scoped by user_id).
 func TestUpdateAgentInboundPolicyWrongOwner(t *testing.T) {

--- a/internal/identity/inbound_policy_store_test.go
+++ b/internal/identity/inbound_policy_store_test.go
@@ -1,0 +1,114 @@
+package identity_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+)
+
+// TestUpdateAgentInboundPolicyRoundTrip is the DB-backed surfacing contract for
+// Slice 7a: UpdateAgentInboundPolicy persists the policy + allowlist, and the
+// agent reads (GetAgentByID) surface them. A fresh agent defaults to "open"
+// with an empty allowlist.
+func TestUpdateAgentInboundPolicyRoundTrip(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, err := store.CreateOrGetUser(ctx, "owner@policy.example.com", "Owner", "google-policy-rt")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	if _, err := store.ClaimOrCreateDomain(ctx, "policy.example.com", user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+	agent, err := store.CreateAgent(ctx, "agent@policy.example.com", "policy.example.com", "", "", "", user.ID)
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	// Default posture (read from the DB, where the column DEFAULT 'open'
+	// applies — the struct returned by CreateAgent doesn't re-read it).
+	fresh, err := store.GetAgentByID(ctx, agent.ID)
+	if err != nil {
+		t.Fatalf("GetAgentByID: %v", err)
+	}
+	if fresh.InboundPolicy != "open" {
+		t.Errorf("fresh agent InboundPolicy = %q, want open", fresh.InboundPolicy)
+	}
+	if len(fresh.InboundAllowlist) != 0 {
+		t.Errorf("fresh agent InboundAllowlist = %v, want empty", fresh.InboundAllowlist)
+	}
+
+	// Set an allowlist policy.
+	allow := []string{"friend@trusted.com", "ally@partner.com"}
+	if err := store.UpdateAgentInboundPolicy(ctx, agent.ID, user.ID, "allowlist", allow); err != nil {
+		t.Fatalf("UpdateAgentInboundPolicy: %v", err)
+	}
+
+	got, err := store.GetAgentByID(ctx, agent.ID)
+	if err != nil {
+		t.Fatalf("GetAgentByID: %v", err)
+	}
+	if got.InboundPolicy != "allowlist" {
+		t.Errorf("InboundPolicy = %q, want allowlist", got.InboundPolicy)
+	}
+	if !reflect.DeepEqual(got.InboundAllowlist, allow) {
+		t.Errorf("InboundAllowlist = %v, want %v", got.InboundAllowlist, allow)
+	}
+
+	// Switching back to open clears the gate (allowlist may be left as-is or
+	// cleared; the policy is what gates). Pin the policy transition.
+	if err := store.UpdateAgentInboundPolicy(ctx, agent.ID, user.ID, "open", nil); err != nil {
+		t.Fatalf("UpdateAgentInboundPolicy(open): %v", err)
+	}
+	got2, err := store.GetAgentByID(ctx, agent.ID)
+	if err != nil {
+		t.Fatalf("GetAgentByID: %v", err)
+	}
+	if got2.InboundPolicy != "open" {
+		t.Errorf("after reset InboundPolicy = %q, want open", got2.InboundPolicy)
+	}
+}
+
+// TestUpdateAgentInboundPolicyWrongOwner: a user cannot change another user's
+// agent policy (tenant isolation — the UPDATE is scoped by user_id).
+func TestUpdateAgentInboundPolicyWrongOwner(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	owner, err := store.CreateOrGetUser(ctx, "owner@iso.example.com", "Owner", "google-iso-owner")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser owner: %v", err)
+	}
+	attacker, err := store.CreateOrGetUser(ctx, "attacker@iso.example.com", "Attacker", "google-iso-attacker")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser attacker: %v", err)
+	}
+	if _, err := store.ClaimOrCreateDomain(ctx, "iso.example.com", owner.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+	agent, err := store.CreateAgent(ctx, "agent@iso.example.com", "iso.example.com", "", "", "", owner.ID)
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	// Attacker attempts to set a policy on the owner's agent.
+	err = store.UpdateAgentInboundPolicy(ctx, agent.ID, attacker.ID, "allowlist", []string{"x@evil.com"})
+	if err == nil {
+		t.Fatal("expected error when non-owner updates inbound policy, got nil")
+	}
+
+	// Owner's agent policy must be unchanged (still open).
+	got, err := store.GetAgentByID(ctx, agent.ID)
+	if err != nil {
+		t.Fatalf("GetAgentByID: %v", err)
+	}
+	if got.InboundPolicy != "open" {
+		t.Errorf("InboundPolicy = %q after cross-tenant attempt, want open (unchanged)", got.InboundPolicy)
+	}
+}

--- a/internal/identity/labels_test.go
+++ b/internal/identity/labels_test.go
@@ -33,7 +33,7 @@ func labelsTestSetup(t *testing.T, store *identity.Store, prefix string) (msgID,
 	if err != nil {
 		t.Fatalf("CreateAgent: %v", err)
 	}
-	msg, err := store.CreateInboundMessage(ctx, "", agent.ID, "alice@gmail.com", "bot@"+domain, "<orig-"+prefix+"@gmail.com>", "Hello", "", "", nil, nil, nil, nil, nil, nil)
+	msg, err := store.CreateInboundMessage(ctx, "", agent.ID, "alice@gmail.com", "bot@"+domain, "<orig-"+prefix+"@gmail.com>", "Hello", "", "", nil, nil, nil, false, "", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("CreateInboundMessage: %v", err)
 	}
@@ -168,9 +168,9 @@ func TestGetMessagesByAgent_LabelsFilterANDMatch(t *testing.T) {
 	//   m2: [urgent]
 	//   m3: [follow-up]
 	// Filter labels=[urgent, follow-up] must return ONLY m1 (AND semantics).
-	m1, _ := store.CreateInboundMessage(ctx, "", agent.ID, "a@gmail.com", "bot@lblfilter.example.com", "<m1@gmail.com>", "M1", "", "", nil, nil, nil, nil, nil, nil)
-	m2, _ := store.CreateInboundMessage(ctx, "", agent.ID, "a@gmail.com", "bot@lblfilter.example.com", "<m2@gmail.com>", "M2", "", "", nil, nil, nil, nil, nil, nil)
-	store.CreateInboundMessage(ctx, "", agent.ID, "a@gmail.com", "bot@lblfilter.example.com", "<m3@gmail.com>", "M3", "", "", nil, nil, nil, nil, nil, nil)
+	m1, _ := store.CreateInboundMessage(ctx, "", agent.ID, "a@gmail.com", "bot@lblfilter.example.com", "<m1@gmail.com>", "M1", "", "", nil, nil, nil, false, "", nil, nil, nil)
+	m2, _ := store.CreateInboundMessage(ctx, "", agent.ID, "a@gmail.com", "bot@lblfilter.example.com", "<m2@gmail.com>", "M2", "", "", nil, nil, nil, false, "", nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", agent.ID, "a@gmail.com", "bot@lblfilter.example.com", "<m3@gmail.com>", "M3", "", "", nil, nil, nil, false, "", nil, nil, nil)
 
 	store.ModifyMessageLabels(ctx, m1.ID, agent.ID, []string{"urgent", "follow-up"}, nil)
 	store.ModifyMessageLabels(ctx, m2.ID, agent.ID, []string{"urgent"}, nil)

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Mnexa-AI/e2a/internal/dkim"
 	"github.com/Mnexa-AI/e2a/internal/emailauth"
+	"github.com/Mnexa-AI/e2a/internal/inboundpolicy"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -98,6 +99,13 @@ type AgentIdentity struct {
 	// in the last 24h. Defaults to true for agents with no deliveries
 	// yet — avoids painting fresh agents red.
 	WebhookHealthy bool `json:"webhook_healthy"`
+	// InboundPolicy is the per-agent inbound ingestion gate (migration 033 /
+	// Slice 7): one of inboundpolicy.{Open,Allowlist,Domain,VerifiedOnly}.
+	// Defaults to 'open' (the column default). InboundAllowlist holds the
+	// exact addresses (allowlist policy) or domains (domain policy) the gate
+	// trusts; empty for open/verified_only.
+	InboundPolicy    string   `json:"inbound_policy"`
+	InboundAllowlist []string `json:"inbound_allowlist,omitempty"`
 }
 
 // HITL constants mirror the CHECK constraints in migration 003_hitl.sql.
@@ -248,6 +256,13 @@ type Message struct {
 	BodyText        string          `json:"body_text,omitempty"`
 	BodyHTML        string          `json:"body_html,omitempty"`
 	AttachmentsJSON json.RawMessage `json:"attachments,omitempty"`
+
+	// Flagged + FlagReason carry the inbound ingestion verdict (migration 033 /
+	// Slice 7): true when the agent's inbound_policy gate flagged this message
+	// on arrival (still delivered, never dropped). FlagReason is the
+	// human-readable reason. Inbound-relevant; outbound rows read false/''.
+	Flagged    bool   `json:"flagged,omitempty"`
+	FlagReason string `json:"flag_reason,omitempty"`
 }
 
 // Message status values mirror the CHECK constraint in migration 003_hitl.sql.
@@ -713,12 +728,14 @@ func (s *Store) GetAgentByID(ctx context.Context, id string) (*AgentIdentity, er
 	err := s.pool.QueryRow(ctx,
 		`SELECT a.id, a.domain, a.user_id, a.name, a.public, a.created_at,
 		        a.hitl_enabled, a.hitl_ttl_seconds, a.hitl_expiration_action,
+		        COALESCE(a.inbound_policy, 'open'), a.inbound_allowlist,
 		        d.verified as domain_verified
 		 FROM agent_identities a
 		 JOIN domains d ON a.domain = d.domain
 		 WHERE a.id = $1`, id,
 	).Scan(&a.ID, &a.Domain, &a.UserID, &a.Name, &a.Public, &a.CreatedAt,
 		&a.HITLEnabled, &a.HITLTTLSeconds, &a.HITLExpirationAction,
+		&a.InboundPolicy, &a.InboundAllowlist,
 		&a.DomainVerified)
 	if err != nil {
 		return nil, err
@@ -810,6 +827,32 @@ func (s *Store) UpdateAgentHITL(ctx context.Context, agentID, userID string, ena
 	return nil
 }
 
+// UpdateAgentInboundPolicy sets the inbound ingestion gate (migration 033 /
+// Slice 7) on an agent owned by userID. The policy is validated against
+// inboundpolicy.Valid so callers get a clean error rather than a raw CHECK
+// violation. allowlist may be empty (the gate then flags everything for the
+// gating postures — fail-closed). Returns an error if the agent isn't found
+// or isn't owned by the user.
+func (s *Store) UpdateAgentInboundPolicy(ctx context.Context, agentID, userID, policy string, allowlist []string) error {
+	if !inboundpolicy.Valid(policy) {
+		return fmt.Errorf("invalid inbound_policy %q", policy)
+	}
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE agent_identities
+		    SET inbound_policy = $3,
+		        inbound_allowlist = $4
+		  WHERE id = $1 AND user_id = $2`,
+		agentID, userID, policy, allowlist,
+	)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("agent not found or not owned by user")
+	}
+	return nil
+}
+
 // ListAgentsByUser returns all agents owned by the user, joined with
 // domain verification AND enriched with per-agent stats for the
 // dashboard. Five correlated subqueries compute
@@ -821,6 +864,7 @@ func (s *Store) ListAgentsByUser(ctx context.Context, userID string) ([]AgentIde
 	rows, err := s.pool.Query(ctx,
 		`SELECT a.id, a.domain, a.user_id, a.name, a.public, a.created_at,
 		        a.hitl_enabled, a.hitl_ttl_seconds, a.hitl_expiration_action,
+		        COALESCE(a.inbound_policy, 'open'), a.inbound_allowlist,
 		        d.verified as domain_verified,
 		        (SELECT count(*) FROM messages m
 		           WHERE m.agent_id = a.id AND m.direction = 'inbound'
@@ -856,6 +900,7 @@ func (s *Store) ListAgentsByUser(ctx context.Context, userID string) ([]AgentIde
 		var lastDeliveryAt *time.Time
 		if err := rows.Scan(&a.ID, &a.Domain, &a.UserID, &a.Name, &a.Public, &a.CreatedAt,
 			&a.HITLEnabled, &a.HITLTTLSeconds, &a.HITLExpirationAction,
+			&a.InboundPolicy, &a.InboundAllowlist,
 			&a.DomainVerified,
 			&a.Inbound7d, &a.Outbound7d, &a.PendingCount,
 			&lastDeliveryAt, &a.WebhookHealthy); err != nil {
@@ -915,8 +960,8 @@ func NewMessageID() string {
 // for this row (may be one of the To: addresses, or absent from the
 // header list when the agent was Bcc'd). replyTo is the parsed Reply-To:
 // header (empty when absent — never silently falls back to sender).
-func (s *Store) CreateInboundMessage(ctx context.Context, id, agentID, senderEmail, recipient, emailMessageID, subject, conversationID, deliveryStatus string, rawMessage []byte, authHeaders map[string]string, authVerdict []byte, toRecipients, cc, replyTo []string) (*Message, error) {
-	return createInboundMessage(ctx, s.pool, id, agentID, senderEmail, recipient, emailMessageID, subject, conversationID, deliveryStatus, rawMessage, authHeaders, authVerdict, toRecipients, cc, replyTo)
+func (s *Store) CreateInboundMessage(ctx context.Context, id, agentID, senderEmail, recipient, emailMessageID, subject, conversationID, deliveryStatus string, rawMessage []byte, authHeaders map[string]string, authVerdict []byte, flagged bool, flagReason string, toRecipients, cc, replyTo []string) (*Message, error) {
+	return createInboundMessage(ctx, s.pool, id, agentID, senderEmail, recipient, emailMessageID, subject, conversationID, deliveryStatus, rawMessage, authHeaders, authVerdict, flagged, flagReason, toRecipients, cc, replyTo)
 }
 
 // WithTx opens a transaction, runs fn inside it, and commits if fn
@@ -948,8 +993,8 @@ func (s *Store) WithTx(ctx context.Context, fn func(tx pgx.Tx) error) error {
 // Mirrors the CreateAgentTx pattern at store.go:596-607 — same SQL
 // body, executed against either *pgxpool.Pool or pgx.Tx via the
 // messageExecutor interface below.
-func (s *Store) CreateInboundMessageInTx(ctx context.Context, tx pgx.Tx, id, agentID, senderEmail, recipient, emailMessageID, subject, conversationID, deliveryStatus string, rawMessage []byte, authHeaders map[string]string, authVerdict []byte, toRecipients, cc, replyTo []string) (*Message, error) {
-	return createInboundMessage(ctx, tx, id, agentID, senderEmail, recipient, emailMessageID, subject, conversationID, deliveryStatus, rawMessage, authHeaders, authVerdict, toRecipients, cc, replyTo)
+func (s *Store) CreateInboundMessageInTx(ctx context.Context, tx pgx.Tx, id, agentID, senderEmail, recipient, emailMessageID, subject, conversationID, deliveryStatus string, rawMessage []byte, authHeaders map[string]string, authVerdict []byte, flagged bool, flagReason string, toRecipients, cc, replyTo []string) (*Message, error) {
+	return createInboundMessage(ctx, tx, id, agentID, senderEmail, recipient, emailMessageID, subject, conversationID, deliveryStatus, rawMessage, authHeaders, authVerdict, flagged, flagReason, toRecipients, cc, replyTo)
 }
 
 // messageExecutor is the subset of *pgxpool.Pool and pgx.Tx that
@@ -959,7 +1004,7 @@ type messageExecutor interface {
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
 }
 
-func createInboundMessage(ctx context.Context, exec messageExecutor, id, agentID, senderEmail, recipient, emailMessageID, subject, conversationID, deliveryStatus string, rawMessage []byte, authHeaders map[string]string, authVerdict []byte, toRecipients, cc, replyTo []string) (*Message, error) {
+func createInboundMessage(ctx context.Context, exec messageExecutor, id, agentID, senderEmail, recipient, emailMessageID, subject, conversationID, deliveryStatus string, rawMessage []byte, authHeaders map[string]string, authVerdict []byte, flagged bool, flagReason string, toRecipients, cc, replyTo []string) (*Message, error) {
 	if id == "" {
 		id = NewMessageID()
 	}
@@ -989,6 +1034,8 @@ func createInboundMessage(ctx context.Context, exec messageExecutor, id, agentID
 		AuthHeaders:    authHeaders,
 		ConversationID: conversationID,
 		DeliveryStatus: deliveryStatus,
+		Flagged:        flagged,
+		FlagReason:     flagReason,
 		CreatedAt:      now,
 		ExpiresAt:      now.Add(MessageTTL),
 	}
@@ -998,9 +1045,9 @@ func createInboundMessage(ctx context.Context, exec messageExecutor, id, agentID
 		inboxStatus = &m.DeliveryStatus
 	}
 	_, err := exec.Exec(ctx,
-		`INSERT INTO messages (id, agent_id, direction, sender, recipient, to_recipients, cc, reply_to, subject, email_message_id, raw_message, auth_headers, auth_verdict, conversation_id, inbox_status, created_at, expires_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
-		m.ID, m.AgentID, m.Direction, m.Sender, m.Recipient, m.ToRecipients, m.CC, m.ReplyTo, m.Subject, m.EmailMessageID, m.RawMessage, authHeadersJSON, nullIfEmptyBytes(authVerdict), m.ConversationID, inboxStatus, m.CreatedAt, m.ExpiresAt,
+		`INSERT INTO messages (id, agent_id, direction, sender, recipient, to_recipients, cc, reply_to, subject, email_message_id, raw_message, auth_headers, auth_verdict, flagged, flag_reason, conversation_id, inbox_status, created_at, expires_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)`,
+		m.ID, m.AgentID, m.Direction, m.Sender, m.Recipient, m.ToRecipients, m.CC, m.ReplyTo, m.Subject, m.EmailMessageID, m.RawMessage, authHeadersJSON, nullIfEmptyBytes(authVerdict), m.Flagged, nullIfEmptyString(m.FlagReason), m.ConversationID, inboxStatus, m.CreatedAt, m.ExpiresAt,
 	)
 	if err != nil {
 		return nil, err
@@ -1012,9 +1059,9 @@ func (s *Store) GetInboundMessage(ctx context.Context, id string) (*Message, err
 	m := &Message{}
 	var authVerdict []byte
 	err := s.pool.QueryRow(ctx,
-		`SELECT id, agent_id, direction, sender, recipient, to_recipients, cc, reply_to, subject, email_message_id, raw_message, auth_verdict, created_at, expires_at
+		`SELECT id, agent_id, direction, sender, recipient, to_recipients, cc, reply_to, subject, email_message_id, raw_message, auth_verdict, COALESCE(flagged, false), COALESCE(flag_reason, ''), created_at, expires_at
 		 FROM messages WHERE id = $1 AND direction = 'inbound' AND expires_at > now()`, id,
-	).Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.ToRecipients, &m.CC, &m.ReplyTo, &m.Subject, &m.EmailMessageID, &m.RawMessage, &authVerdict, &m.CreatedAt, &m.ExpiresAt)
+	).Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.ToRecipients, &m.CC, &m.ReplyTo, &m.Subject, &m.EmailMessageID, &m.RawMessage, &authVerdict, &m.Flagged, &m.FlagReason, &m.CreatedAt, &m.ExpiresAt)
 	if err != nil {
 		return nil, err
 	}
@@ -2023,7 +2070,8 @@ func (s *Store) ListActivityByAgent(ctx context.Context, agentID string, limit i
 		        m.to_recipients, m.cc, m.bcc,
 		        COALESCE(m.conversation_id, ''), COALESCE(octet_length(m.raw_message), 0),
 		        m.labels,
-		        COALESCE(m.delivery_status, ''), COALESCE(m.delivery_detail, ''), COALESCE(m.sent_as, ''), m.auth_verdict
+		        COALESCE(m.delivery_status, ''), COALESCE(m.delivery_detail, ''), COALESCE(m.sent_as, ''), m.auth_verdict,
+		        COALESCE(m.flagged, false), COALESCE(m.flag_reason, '')
 		 FROM messages m
 		 LEFT JOIN webhook_deliveries wd ON wd.message_id = m.id
 		 WHERE m.agent_id = $1 AND m.expires_at > now()
@@ -2040,7 +2088,7 @@ func (s *Store) ListActivityByAgent(ctx context.Context, agentID string, limit i
 		var m Message
 		var inboxStatus, outboundDeliveryStatus string
 		var authVerdict []byte
-		if err := rows.Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.Subject, &m.EmailMessageID, &m.Method, &m.Type, &inboxStatus, &m.CreatedAt, &m.ExpiresAt, &m.WebhookStatus, &m.WebhookError, &m.WebhookAttempts, &m.ToRecipients, &m.CC, &m.BCC, &m.ConversationID, &m.SizeBytes, &m.Labels, &outboundDeliveryStatus, &m.DeliveryDetail, &m.SentAs, &authVerdict); err != nil {
+		if err := rows.Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.Subject, &m.EmailMessageID, &m.Method, &m.Type, &inboxStatus, &m.CreatedAt, &m.ExpiresAt, &m.WebhookStatus, &m.WebhookError, &m.WebhookAttempts, &m.ToRecipients, &m.CC, &m.BCC, &m.ConversationID, &m.SizeBytes, &m.Labels, &outboundDeliveryStatus, &m.DeliveryDetail, &m.SentAs, &authVerdict, &m.Flagged, &m.FlagReason); err != nil {
 			return nil, err
 		}
 		if err := unmarshalAuthVerdict(authVerdict, &m); err != nil {
@@ -2124,7 +2172,7 @@ func (s *Store) GetMessagesByAgent(ctx context.Context, f MessageListFilter) ([]
 	var query string
 	var args []interface{}
 
-	baseSelect := `SELECT m.id, m.agent_id, m.direction, m.sender, m.recipient, m.to_recipients, m.cc, m.reply_to, m.subject, m.email_message_id, m.conversation_id, COALESCE(m.inbox_status, ''), COALESCE(m.status, ''), COALESCE(wd.status, ''), COALESCE(wd.last_error, ''), COALESCE(octet_length(m.raw_message), 0), m.created_at, m.labels, COALESCE(m.delivery_status, ''), COALESCE(m.delivery_detail, ''), COALESCE(m.sent_as, ''), m.auth_verdict
+	baseSelect := `SELECT m.id, m.agent_id, m.direction, m.sender, m.recipient, m.to_recipients, m.cc, m.reply_to, m.subject, m.email_message_id, m.conversation_id, COALESCE(m.inbox_status, ''), COALESCE(m.status, ''), COALESCE(wd.status, ''), COALESCE(wd.last_error, ''), COALESCE(octet_length(m.raw_message), 0), m.created_at, m.labels, COALESCE(m.delivery_status, ''), COALESCE(m.delivery_detail, ''), COALESCE(m.sent_as, ''), m.auth_verdict, COALESCE(m.flagged, false), COALESCE(m.flag_reason, '')
 		 FROM messages m
 		 LEFT JOIN webhook_deliveries wd ON wd.message_id = m.id
 		 WHERE m.agent_id = $1 AND m.expires_at > now()`
@@ -2231,7 +2279,7 @@ func (s *Store) GetMessagesByAgent(ctx context.Context, f MessageListFilter) ([]
 			&m.Subject, &m.EmailMessageID, &m.ConversationID,
 			&m.InboxStatus, &m.Status, &m.WebhookStatus, &m.WebhookError, &m.SizeBytes,
 			&m.CreatedAt, &m.Labels,
-			&outboundDeliveryStatus, &m.DeliveryDetail, &m.SentAs, &authVerdict,
+			&outboundDeliveryStatus, &m.DeliveryDetail, &m.SentAs, &authVerdict, &m.Flagged, &m.FlagReason,
 		); err != nil {
 			return nil, err
 		}
@@ -2262,9 +2310,9 @@ func (s *Store) GetMessageWithContent(ctx context.Context, messageID, agentID st
 	err := s.pool.QueryRow(ctx,
 		`UPDATE messages SET inbox_status = CASE WHEN inbox_status = 'unread' THEN 'read' ELSE inbox_status END
 		 WHERE id = $1 AND agent_id = $2 AND expires_at > now()
-		 RETURNING id, agent_id, direction, sender, recipient, to_recipients, cc, reply_to, subject, email_message_id, conversation_id, COALESCE(inbox_status, ''), raw_message, auth_headers, auth_verdict, created_at, expires_at, labels, COALESCE(delivery_status, ''), COALESCE(delivery_detail, ''), COALESCE(sent_as, ''), COALESCE(body_text, ''), COALESCE(body_html, '')`,
+		 RETURNING id, agent_id, direction, sender, recipient, to_recipients, cc, reply_to, subject, email_message_id, conversation_id, COALESCE(inbox_status, ''), raw_message, auth_headers, auth_verdict, COALESCE(flagged, false), COALESCE(flag_reason, ''), created_at, expires_at, labels, COALESCE(delivery_status, ''), COALESCE(delivery_detail, ''), COALESCE(sent_as, ''), COALESCE(body_text, ''), COALESCE(body_html, '')`,
 		messageID, agentID,
-	).Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.ToRecipients, &m.CC, &m.ReplyTo, &m.Subject, &m.EmailMessageID, &m.ConversationID, &m.InboxStatus, &m.RawMessage, &authHeadersJSON, &authVerdict, &m.CreatedAt, &m.ExpiresAt, &m.Labels, &outboundDeliveryStatus, &m.DeliveryDetail, &m.SentAs, &m.BodyText, &m.BodyHTML)
+	).Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.ToRecipients, &m.CC, &m.ReplyTo, &m.Subject, &m.EmailMessageID, &m.ConversationID, &m.InboxStatus, &m.RawMessage, &authHeadersJSON, &authVerdict, &m.Flagged, &m.FlagReason, &m.CreatedAt, &m.ExpiresAt, &m.Labels, &outboundDeliveryStatus, &m.DeliveryDetail, &m.SentAs, &m.BodyText, &m.BodyHTML)
 	if err != nil {
 		return nil, err
 	}
@@ -2579,7 +2627,8 @@ func (s *Store) GetConversationByID(ctx context.Context, agentID, conversationID
 		        COALESCE(m.status, ''),
 		        m.created_at, m.expires_at,
 		        m.labels,
-		        COALESCE(m.delivery_status, ''), COALESCE(m.delivery_detail, ''), COALESCE(m.sent_as, ''), m.auth_verdict
+		        COALESCE(m.delivery_status, ''), COALESCE(m.delivery_detail, ''), COALESCE(m.sent_as, ''), m.auth_verdict,
+		        COALESCE(m.flagged, false), COALESCE(m.flag_reason, '')
 		 FROM messages m
 		 WHERE m.agent_id = $1
 		   AND m.conversation_id = $2
@@ -2610,6 +2659,7 @@ func (s *Store) GetConversationByID(ctx context.Context, agentID, conversationID
 			&m.CreatedAt, &m.ExpiresAt,
 			&m.Labels,
 			&outboundDeliveryStatus, &m.DeliveryDetail, &m.SentAs, &authVerdict,
+			&m.Flagged, &m.FlagReason,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -833,9 +833,17 @@ func (s *Store) UpdateAgentHITL(ctx context.Context, agentID, userID string, ena
 // violation. allowlist may be empty (the gate then flags everything for the
 // gating postures — fail-closed). Returns an error if the agent isn't found
 // or isn't owned by the user.
+// maxInboundAllowlist bounds the per-agent inbound_allowlist. The relay scans
+// it linearly on every inbound message, so an unbounded list is an owner-scoped
+// DoS vector; 1000 entries is far beyond any real allow/deny need.
+const maxInboundAllowlist = 1000
+
 func (s *Store) UpdateAgentInboundPolicy(ctx context.Context, agentID, userID, policy string, allowlist []string) error {
 	if !inboundpolicy.Valid(policy) {
 		return fmt.Errorf("invalid inbound_policy %q", policy)
+	}
+	if len(allowlist) > maxInboundAllowlist {
+		return fmt.Errorf("inbound_allowlist has %d entries, max %d", len(allowlist), maxInboundAllowlist)
 	}
 	tag, err := s.pool.Exec(ctx,
 		`UPDATE agent_identities

--- a/internal/identity/store_test.go
+++ b/internal/identity/store_test.go
@@ -353,7 +353,7 @@ func TestCreateAndGetInboundMessage(t *testing.T) {
 	store.ClaimOrCreateDomain(ctx, "inbound.example.com", user.ID)
 	a, _ := store.CreateAgent(ctx, "agent@inbound.example.com", "inbound.example.com", "", "https://example.com/webhook", "", user.ID)
 
-	msg, err := store.CreateInboundMessage(ctx, "", a.ID, "alice@gmail.com", "bot@inbound.example.com", "<abc123@gmail.com>", "Hello Bot", "", "", nil, nil, nil, nil, nil, nil)
+	msg, err := store.CreateInboundMessage(ctx, "", a.ID, "alice@gmail.com", "bot@inbound.example.com", "<abc123@gmail.com>", "Hello Bot", "", "", nil, nil, nil, false, "", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("CreateInboundMessage: %v", err)
 	}
@@ -408,7 +408,7 @@ func TestInboundMessageRoundTripsAuthVerdict(t *testing.T) {
 		t.Fatalf("marshal verdict: %v", err)
 	}
 
-	in, err := store.CreateInboundMessage(ctx, "", a.ID, "alice@gmail.com", "bot@authverdict.example.com", "<av1@gmail.com>", "Hello", "", "unread", nil, nil, verdictJSON, nil, nil, nil)
+	in, err := store.CreateInboundMessage(ctx, "", a.ID, "alice@gmail.com", "bot@authverdict.example.com", "<av1@gmail.com>", "Hello", "", "unread", nil, nil, verdictJSON, false, "", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("CreateInboundMessage: %v", err)
 	}
@@ -463,7 +463,7 @@ func TestInboundMessageRoundTripsToCcLists(t *testing.T) {
 	// and is covered transitively by other tests that pass nil here.
 	replyTo := []string{"real-user@example.com", "delegate@example.com"}
 
-	msg, err := store.CreateInboundMessage(ctx, "", a.ID, "alice@gmail.com", "bot-a@tcc.example.com", "<x@gmail.com>", "Group thread", "", "", nil, nil, nil, to, cc, replyTo)
+	msg, err := store.CreateInboundMessage(ctx, "", a.ID, "alice@gmail.com", "bot-a@tcc.example.com", "<x@gmail.com>", "Group thread", "", "", nil, nil, nil, false, "", to, cc, replyTo)
 	if err != nil {
 		t.Fatalf("CreateInboundMessage: %v", err)
 	}
@@ -535,7 +535,7 @@ func TestGetInboundMessageExpired(t *testing.T) {
 	user, _ := store.CreateOrGetUser(ctx, "owner@example.com", "Owner", "google-expired-inbound")
 	store.ClaimOrCreateDomain(ctx, "expired-inbound.example.com", user.ID)
 	a, _ := store.CreateAgent(ctx, "agent@expired-inbound.example.com", "expired-inbound.example.com", "", "https://example.com/webhook", "", user.ID)
-	msg, _ := store.CreateInboundMessage(ctx, "", a.ID, "alice@gmail.com", "bot@expired-inbound.example.com", "", "", "", "", nil, nil, nil, nil, nil, nil)
+	msg, _ := store.CreateInboundMessage(ctx, "", a.ID, "alice@gmail.com", "bot@expired-inbound.example.com", "", "", "", "", nil, nil, nil, false, "", nil, nil, nil)
 
 	// Set expiry to the past
 	pool.Exec(ctx, `UPDATE messages SET expires_at = $1 WHERE id = $2`, time.Now().Add(-1*time.Hour), msg.ID)
@@ -554,7 +554,7 @@ func TestDeleteExpiredMessages(t *testing.T) {
 	user, _ := store.CreateOrGetUser(ctx, "owner@example.com", "Owner", "google-cleanup-inbound")
 	store.ClaimOrCreateDomain(ctx, "cleanup-inbound.example.com", user.ID)
 	a, _ := store.CreateAgent(ctx, "agent@cleanup-inbound.example.com", "cleanup-inbound.example.com", "", "https://example.com/webhook", "", user.ID)
-	msg, _ := store.CreateInboundMessage(ctx, "", a.ID, "alice@gmail.com", "bot@cleanup-inbound.example.com", "", "", "", "", nil, nil, nil, nil, nil, nil)
+	msg, _ := store.CreateInboundMessage(ctx, "", a.ID, "alice@gmail.com", "bot@cleanup-inbound.example.com", "", "", "", "", nil, nil, nil, false, "", nil, nil, nil)
 
 	// Set expiry to the past
 	pool.Exec(ctx, `UPDATE messages SET expires_at = $1 WHERE id = $2`, time.Now().Add(-1*time.Hour), msg.ID)
@@ -607,9 +607,9 @@ func TestListActivityByAgent(t *testing.T) {
 	store.ClaimOrCreateDomain(ctx, "activity.example.com", user.ID)
 	a, _ := store.CreateAgent(ctx, "agent@activity.example.com", "activity.example.com", "", "https://example.com/webhook", "", user.ID)
 
-	store.CreateInboundMessage(ctx, "", a.ID, "alice@gmail.com", "bot@activity.example.com", "", "Hello", "", "", nil, nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", a.ID, "alice@gmail.com", "bot@activity.example.com", "", "Hello", "", "", nil, nil, nil, false, "", nil, nil, nil)
 	store.CreateOutboundMessage(ctx, a.ID, []string{"alice@gmail.com"}, nil, nil, "Re: Hello", "reply", "smtp", "", "")
-	store.CreateInboundMessage(ctx, "", a.ID, "bob@gmail.com", "bot@activity.example.com", "", "Hi", "", "", nil, nil, nil, nil, nil, nil)
+	store.CreateInboundMessage(ctx, "", a.ID, "bob@gmail.com", "bot@activity.example.com", "", "Hi", "", "", nil, nil, nil, false, "", nil, nil, nil)
 
 	activity, err := store.ListActivityByAgent(ctx, a.ID, 50)
 	if err != nil {
@@ -729,7 +729,7 @@ func TestLookupConversationID_EmailThread(t *testing.T) {
 		"alice@gmail.com", "bot@thread.example.com",
 		"<CAMCKtby_first@mail.gmail.com>", "Hello",
 		"", // no conversation_id on first message
-		"pending", nil, nil, nil, nil, nil, nil)
+		"pending", nil, nil, nil, false, "", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("CreateInboundMessage: %v", err)
 	}
@@ -1467,9 +1467,9 @@ func TestListAgentsByUser_EnrichedFields(t *testing.T) {
 	//   3 outbound (sent) in last 7d, 1 pending_approval
 	//   1 webhook delivery: delivered (healthy)
 	for i := 0; i < 2; i++ {
-		store.CreateInboundMessage(ctx, "", agent.ID, "alice@gmail.com", agent.EmailAddress(), "", "in fresh", "", "", nil, nil, nil, nil, nil, nil)
+		store.CreateInboundMessage(ctx, "", agent.ID, "alice@gmail.com", agent.EmailAddress(), "", "in fresh", "", "", nil, nil, nil, false, "", nil, nil, nil)
 	}
-	old, _ := store.CreateInboundMessage(ctx, "", agent.ID, "old@gmail.com", agent.EmailAddress(), "", "in old", "", "", nil, nil, nil, nil, nil, nil)
+	old, _ := store.CreateInboundMessage(ctx, "", agent.ID, "old@gmail.com", agent.EmailAddress(), "", "in old", "", "", nil, nil, nil, false, "", nil, nil, nil)
 	pool.Exec(ctx, `UPDATE messages SET created_at = now() - interval '14 days' WHERE id = $1`, old.ID)
 
 	for i := 0; i < 3; i++ {

--- a/internal/identity/user_data_rights_test.go
+++ b/internal/identity/user_data_rights_test.go
@@ -47,6 +47,7 @@ func seedUserData(t *testing.T, store *identity.Store, ctx context.Context, labe
 		[]byte("From: alice@gmail.com\r\nSubject: Hi\r\n\r\nbody"),
 		map[string]string{"X-E2A-Auth-Verified": "true"},
 		nil,
+		false, "",
 		nil, nil, []string{"real-alice@example.com"},
 	); err != nil {
 		t.Fatalf("seed: CreateInboundMessage: %v", err)

--- a/internal/inboundpolicy/policy.go
+++ b/internal/inboundpolicy/policy.go
@@ -1,0 +1,104 @@
+// Package inboundpolicy evaluates a per-agent inbound trust policy
+// (api-v1-redesign decision 10 / Slice 7). It is gateway-ENFORCED, not advisory
+// guidance an agent author can skip.
+//
+// Two orthogonal axes compose (decision 10 says the postures "compose", which a
+// single enum can't express):
+//   - Ingestion gate (this package): inbound_policy ∈ {open, allowlist, domain,
+//     verified_only}. Decides, on arrival, whether a message is trusted or
+//     FLAGGED. Flagged messages are still delivered (never dropped) + emit
+//     email.flagged so nothing disappears and operators get a signal.
+//   - Action gate (the hitl axis, Slice 7b): holds suspicious outbound as
+//     pending_approval. Reconciled from the existing hitl_enabled flag.
+//
+// This package is a stdlib-only leaf: it takes primitives (policy, allowlist,
+// sender, the DMARC verdict string) so callers (relay, store) don't couple to
+// emailauth/identity.
+package inboundpolicy
+
+import "strings"
+
+// Ingestion policy values (the inbound_policy column).
+const (
+	// Open accepts all inbound; no flagging. The default.
+	Open = "open"
+	// Allowlist accepts only senders whose exact address is on inbound_allowlist;
+	// others are flagged (a TRUST gate — known senders).
+	Allowlist = "allowlist"
+	// Domain accepts only senders whose domain is on inbound_allowlist; others
+	// are flagged (a TRUST gate — known domains).
+	Domain = "domain"
+	// VerifiedOnly accepts only DMARC-passing (aligned) mail; others are flagged.
+	// An ANTI-SPOOFING gate — it proves the mail came from the *claimed* From
+	// domain, NOT that the domain is friendly (pair with allowlist/domain or the
+	// hitl action gate for actual trust).
+	VerifiedOnly = "verified_only"
+)
+
+// Valid reports whether p is a known ingestion policy.
+func Valid(p string) bool {
+	switch p {
+	case Open, Allowlist, Domain, VerifiedOnly:
+		return true
+	}
+	return false
+}
+
+// Decision is the ingestion verdict for one inbound message.
+type Decision struct {
+	Flagged bool
+	Reason  string // human-readable; empty when not flagged
+}
+
+// EvaluateIngestion applies the agent's ingestion policy to an inbound message.
+//   - policy: the agent's inbound_policy (unknown/empty → treated as Open).
+//   - allowlist: the agent's inbound_allowlist (addresses for Allowlist,
+//     domains for Domain); matching is case-insensitive.
+//   - senderEmail: the message's display sender (From identity).
+//   - dmarcPass: whether the server-owned auth verdict has dmarc=pass
+//     (alignment — decision 9 / Slice 4b-2).
+//
+// Flagged is fail-closed for the gating postures: an empty/garbage sender, or
+// an empty allowlist, flags everything (you opted into a gate but listed no one).
+func EvaluateIngestion(policy string, allowlist []string, senderEmail string, dmarcPass bool) Decision {
+	switch policy {
+	case Allowlist:
+		if containsFold(allowlist, strings.TrimSpace(senderEmail)) {
+			return Decision{}
+		}
+		return Decision{Flagged: true, Reason: "sender not on the agent's inbound allowlist"}
+	case Domain:
+		dom := domainOf(senderEmail)
+		if dom != "" && containsFold(allowlist, dom) {
+			return Decision{}
+		}
+		return Decision{Flagged: true, Reason: "sender domain not on the agent's inbound allowlist"}
+	case VerifiedOnly:
+		if dmarcPass {
+			return Decision{}
+		}
+		return Decision{Flagged: true, Reason: "failed DMARC alignment (verified_only policy)"}
+	default: // Open or unknown → never flag
+		return Decision{}
+	}
+}
+
+func containsFold(list []string, v string) bool {
+	if v == "" {
+		return false
+	}
+	for _, item := range list {
+		if strings.EqualFold(strings.TrimSpace(item), v) {
+			return true
+		}
+	}
+	return false
+}
+
+func domainOf(email string) string {
+	at := strings.LastIndex(email, "@")
+	if at < 0 || at == len(email)-1 {
+		return ""
+	}
+	return strings.TrimSpace(email[at+1:])
+}

--- a/internal/inboundpolicy/policy_test.go
+++ b/internal/inboundpolicy/policy_test.go
@@ -1,0 +1,37 @@
+package inboundpolicy
+
+import "testing"
+
+func TestEvaluateIngestion(t *testing.T) {
+	tests := []struct {
+		name      string
+		policy    string
+		allowlist []string
+		sender    string
+		dmarcPass bool
+		flagged   bool
+	}{
+		{"open never flags", Open, nil, "anyone@evil.com", false, false},
+		{"unknown policy treated as open", "bogus", nil, "x@y.com", false, false},
+		{"allowlist match", Allowlist, []string{"boss@acme.com"}, "boss@acme.com", false, false},
+		{"allowlist case-insensitive", Allowlist, []string{"Boss@Acme.com"}, "boss@acme.com", false, false},
+		{"allowlist non-match flagged", Allowlist, []string{"boss@acme.com"}, "stranger@x.com", true, true},
+		{"allowlist empty flags all", Allowlist, nil, "boss@acme.com", false, true},
+		{"domain match", Domain, []string{"acme.com"}, "anyone@acme.com", false, false},
+		{"domain non-match flagged", Domain, []string{"acme.com"}, "x@evil.com", false, true},
+		{"domain garbage sender flagged", Domain, []string{"acme.com"}, "nodomain", false, true},
+		{"verified_only dmarc pass", VerifiedOnly, nil, "x@y.com", true, false},
+		{"verified_only dmarc fail flagged", VerifiedOnly, nil, "x@y.com", false, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d := EvaluateIngestion(tc.policy, tc.allowlist, tc.sender, tc.dmarcPass)
+			if d.Flagged != tc.flagged {
+				t.Errorf("Flagged=%v want %v (reason=%q)", d.Flagged, tc.flagged, d.Reason)
+			}
+			if d.Flagged && d.Reason == "" {
+				t.Error("flagged decision must carry a reason")
+			}
+		})
+	}
+}

--- a/internal/loopback/loopback.go
+++ b/internal/loopback/loopback.go
@@ -182,7 +182,7 @@ func ComposeMIME(agent *identity.AgentIdentity, req outbound.SendRequest, provid
 // InboundWriter is the subset of *identity.Store DeliverInbound uses.
 // Lets tests swap in fakes; production code passes the real store.
 type InboundWriter interface {
-	CreateInboundMessage(ctx context.Context, id, agentID, senderEmail, recipient, emailMessageID, subject, conversationID, deliveryStatus string, rawMessage []byte, authHeaders map[string]string, authVerdict []byte, toRecipients, cc, replyTo []string) (*identity.Message, error)
+	CreateInboundMessage(ctx context.Context, id, agentID, senderEmail, recipient, emailMessageID, subject, conversationID, deliveryStatus string, rawMessage []byte, authHeaders map[string]string, authVerdict []byte, flagged bool, flagReason string, toRecipients, cc, replyTo []string) (*identity.Message, error)
 }
 
 // DeliverInbound writes the recipient-side row for a loopback self-send
@@ -231,8 +231,10 @@ func DeliverInbound(ctx context.Context, store InboundWriter, agent *identity.Ag
 		req.ConversationID,
 		"unread",
 		rawMessage,
-		nil, // no DKIM/SPF auth headers on a synthetic loopback
-		nil, // no auth verdict on a synthetic loopback
+		nil,   // no DKIM/SPF auth headers on a synthetic loopback
+		nil,   // no auth verdict on a synthetic loopback
+		false, // not flagged: loopback self-send bypasses the inbound policy gate
+		"",    // no flag reason
 		[]string{email},
 		nil, // cc
 		nil, // reply_to

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -19,6 +19,7 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/emailauth"
 	"github.com/Mnexa-AI/e2a/internal/headers"
 	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/inboundpolicy"
 	"github.com/Mnexa-AI/e2a/internal/limits"
 	"github.com/Mnexa-AI/e2a/internal/usage"
 	"github.com/Mnexa-AI/e2a/internal/webhookpub"
@@ -323,6 +324,14 @@ func (s *session) deliverToAgent(ctx context.Context, agent *identity.AgentIdent
 		displaySender = s.inboundThreadInfo.ReplyTo[0]
 	}
 
+	// Inbound trust policy ingestion gate (decision 10 / Slice 7a). Evaluate the
+	// agent's policy against the AUTHENTICATED From identity (senderEmail — what
+	// SPF/DKIM/DMARC pertain to), NOT displaySender (Reply-To is attacker-
+	// controllable). A non-match is FLAGGED — still delivered (never dropped),
+	// marked on the row, and emits email.flagged so operators get a signal.
+	dmarcPass := domainAuth.DMARC.Status == emailauth.StatusPass
+	policyDecision := inboundpolicy.EvaluateIngestion(agent.InboundPolicy, agent.InboundAllowlist, senderEmail, dmarcPass)
+
 	// Record inbound usage (fail-open — never block inbound email)
 	if agent.UserID != "" {
 		s.relay.usage.RecordAndCheck(ctx, agent.UserID, agent.ID, agent.Domain, "inbound")
@@ -354,6 +363,28 @@ func (s *session) deliverToAgent(ctx context.Context, agent *identity.AgentIdent
 	// post-receive); leave Event.Labels empty so label-filtered
 	// subscribers correctly skip (H5 null/empty semantics).
 	event.ID = webhookpub.DeterministicEventID(messageID, webhookpub.EventEmailReceived)
+
+	// email.flagged (decision 10): fired in addition to email.received when the
+	// ingestion policy didn't match, so operators get a signal that this message
+	// is untrusted. Deterministic id keeps MTA retries idempotent.
+	var flaggedEvent *webhookpub.Event
+	if policyDecision.Flagged {
+		fe := webhookpub.NewEvent(webhookpub.EventEmailFlagged, agent.UserID, map[string]interface{}{
+			"message_id":      messageID,
+			"conversation_id": conversationID,
+			"agent":           map[string]interface{}{"id": agent.ID, "email": agent.EmailAddress(), "domain": agent.Domain},
+			"from":            displaySender,
+			"recipient":       rcpt,
+			"subject":         s.inboundSubject,
+			"policy":          agent.InboundPolicy,
+			"reason":          policyDecision.Reason,
+		})
+		fe.AgentID = agent.ID
+		fe.ConversationID = conversationID
+		fe.MessageID = messageID
+		fe.ID = webhookpub.DeterministicEventID(messageID, webhookpub.EventEmailFlagged)
+		flaggedEvent = &fe
+	}
 
 	// Record inbound message with full content. Pass messageID so the
 	// stored row uses the same ID we just bound into the auth headers.
@@ -388,18 +419,26 @@ func (s *session) deliverToAgent(ctx context.Context, agent *identity.AgentIdent
 				ctx, tx, messageID, agent.ID, displaySender, rcpt,
 				s.inboundMsgID, s.inboundSubject, conversationID,
 				deliveryStatus, body, authHeaders, authVerdictJSON,
+				policyDecision.Flagged, policyDecision.Reason,
 				s.inboundThreadInfo.To, s.inboundThreadInfo.CC, s.inboundThreadInfo.ReplyTo,
 			)
 			if txErr != nil {
 				return txErr
 			}
-			return s.relay.outbox.PublishTx(ctx, tx, event)
+			if txErr = s.relay.outbox.PublishTx(ctx, tx, event); txErr != nil {
+				return txErr
+			}
+			if flaggedEvent != nil {
+				return s.relay.outbox.PublishTx(ctx, tx, *flaggedEvent)
+			}
+			return nil
 		})
 	} else {
 		inboundMsg, err = s.relay.store.CreateInboundMessage(
 			ctx, messageID, agent.ID, displaySender, rcpt,
 			s.inboundMsgID, s.inboundSubject, conversationID,
 			deliveryStatus, body, authHeaders, authVerdictJSON,
+			policyDecision.Flagged, policyDecision.Reason,
 			s.inboundThreadInfo.To, s.inboundThreadInfo.CC, s.inboundThreadInfo.ReplyTo,
 		)
 	}
@@ -438,6 +477,9 @@ func (s *session) deliverToAgent(ctx context.Context, agent *identity.AgentIdent
 	// separately.
 	if s.relay.publisher != nil && (s.relay.outbox == nil || !s.relay.outbox.Enabled()) {
 		go s.relay.publisher.Publish(context.Background(), event)
+		if flaggedEvent != nil {
+			go s.relay.publisher.Publish(context.Background(), *flaggedEvent)
+		}
 	}
 
 	// Best-effort WebSocket notification for any connected agent. The

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -354,7 +354,7 @@ func (s *session) deliverToAgent(ctx context.Context, agent *identity.AgentIdent
 	// ON CONFLICT (id) DO NOTHING. Idempotency by construction; see
 	// design §5.1.
 	event := webhookpub.NewEvent(webhookpub.EventEmailReceived, agent.UserID, buildEmailReceivedPayload(
-		messageID, conversationID, displaySender, rcpt, s.inboundSubject, s.inboundThreadInfo, body, authHeaders, agent,
+		messageID, conversationID, displaySender, senderEmail, rcpt, s.inboundSubject, s.inboundThreadInfo, body, authHeaders, agent,
 	))
 	event.AgentID = agent.ID
 	event.ConversationID = conversationID
@@ -373,11 +373,18 @@ func (s *session) deliverToAgent(ctx context.Context, agent *identity.AgentIdent
 			"message_id":      messageID,
 			"conversation_id": conversationID,
 			"agent":           map[string]interface{}{"id": agent.ID, "email": agent.EmailAddress(), "domain": agent.Domain},
-			"from":            displaySender,
-			"recipient":       rcpt,
-			"subject":         s.inboundSubject,
-			"policy":          agent.InboundPolicy,
-			"reason":          policyDecision.Reason,
+			// from is the AUTHENTICATED From identity the policy evaluated and
+			// flagged — NOT displaySender (Reply-To), which is attacker-
+			// controllable and would name a trusted-looking address on the very
+			// message the gate rejected. display_sender/reply_to carry the
+			// reply-routing addresses separately so the signal is complete.
+			"from":           senderEmail,
+			"display_sender": displaySender,
+			"reply_to":       s.inboundThreadInfo.ReplyTo,
+			"recipient":      rcpt,
+			"subject":        s.inboundSubject,
+			"policy":         agent.InboundPolicy,
+			"reason":         policyDecision.Reason,
 		})
 		fe.AgentID = agent.ID
 		fe.ConversationID = conversationID
@@ -505,7 +512,7 @@ func (s *session) deliverToAgent(ctx context.Context, agent *identity.AgentIdent
 // the publisher when it marshals the Event; this helper only
 // produces the data subfield.
 func buildEmailReceivedPayload(
-	messageID, conversationID, displaySender, recipient, subject string,
+	messageID, conversationID, displaySender, authenticatedFrom, recipient, subject string,
 	threadInfo threadInfo,
 	rawMessage []byte,
 	authHeaders map[string]string,
@@ -519,15 +526,21 @@ func buildEmailReceivedPayload(
 			"email":  agent.EmailAddress(),
 			"domain": agent.Domain,
 		},
-		"from":         displaySender,
-		"to":           threadInfo.To,
-		"cc":           threadInfo.CC,
-		"reply_to":     threadInfo.ReplyTo,
-		"recipient":    recipient,
-		"subject":      subject,
-		"raw_message":  rawMessage,
-		"auth_headers": authHeaders,
-		"received_at":  time.Now().UTC().Format(time.RFC3339),
+		"from": displaySender,
+		// authenticated_from is the From-header identity that SPF/DKIM/DMARC
+		// and the inbound trust policy (decision 10) actually pertain to.
+		// It can differ from "from" (which prefers Reply-To for reply
+		// routing): a consumer of a verified_only/allowlist agent MUST treat
+		// authenticated_from — not from — as the gated/verified identity.
+		"authenticated_from": authenticatedFrom,
+		"to":                 threadInfo.To,
+		"cc":                 threadInfo.CC,
+		"reply_to":           threadInfo.ReplyTo,
+		"recipient":          recipient,
+		"subject":            subject,
+		"raw_message":        rawMessage,
+		"auth_headers":       authHeaders,
+		"received_at":        time.Now().UTC().Format(time.RFC3339),
 	}
 }
 

--- a/internal/relay/webhook_payload_test.go
+++ b/internal/relay/webhook_payload_test.go
@@ -24,7 +24,8 @@ func TestBuildEmailReceivedPayload_Shape(t *testing.T) {
 	payload := buildEmailReceivedPayload(
 		"msg_123",
 		"conv_abc",
-		"alice@example.com",
+		"reply@example.com", // displaySender (Reply-To preferred)
+		"alice@example.com", // authenticatedFrom (From-header identity)
 		"bot@example.com",
 		"Hello",
 		threadInfo,
@@ -37,7 +38,7 @@ func TestBuildEmailReceivedPayload_Shape(t *testing.T) {
 
 	for _, key := range []string{
 		"message_id", "conversation_id", "agent",
-		"from", "to", "cc", "reply_to", "recipient",
+		"from", "authenticated_from", "to", "cc", "reply_to", "recipient",
 		"subject", "raw_message", "auth_headers", "received_at",
 	} {
 		if _, ok := payload[key]; !ok {
@@ -48,8 +49,13 @@ func TestBuildEmailReceivedPayload_Shape(t *testing.T) {
 	if payload["message_id"] != "msg_123" {
 		t.Errorf("message_id = %v", payload["message_id"])
 	}
-	if payload["from"] != "alice@example.com" {
-		t.Errorf("from = %v", payload["from"])
+	// from is the display sender (Reply-To); authenticated_from is the From
+	// identity the policy + auth verdict pertain to — they can differ.
+	if payload["from"] != "reply@example.com" {
+		t.Errorf("from = %v, want reply@example.com (display sender)", payload["from"])
+	}
+	if payload["authenticated_from"] != "alice@example.com" {
+		t.Errorf("authenticated_from = %v, want alice@example.com (From identity)", payload["authenticated_from"])
 	}
 	agentObj, ok := payload["agent"].(map[string]interface{})
 	if !ok {

--- a/internal/webhookpub/event.go
+++ b/internal/webhookpub/event.go
@@ -45,6 +45,10 @@ const (
 	EventEmailBounced           = "email.bounced"
 	EventEmailComplained        = "email.complained"
 	EventDomainSuppressionAdded = "domain.suppression_added"
+	// Inbound trust policy (decision 10 / Slice 7): an inbound message did not
+	// match the agent's ingestion policy (allowlist/domain/verified_only). It is
+	// delivered but flagged — operators get a signal, nothing is dropped.
+	EventEmailFlagged = "email.flagged"
 )
 
 // AllEventTypes is the canonical allowlist of event names. Used by
@@ -62,6 +66,7 @@ var AllEventTypes = []string{
 	EventEmailBounced,
 	EventEmailComplained,
 	EventDomainSuppressionAdded,
+	EventEmailFlagged,
 }
 
 // IsValidEventType reports whether name is one of the catalog

--- a/internal/webhookpub/outbox_tx_integration_test.go
+++ b/internal/webhookpub/outbox_tx_integration_test.go
@@ -79,6 +79,7 @@ func TestOutbox_Integration_RelayTxShape(t *testing.T) {
 				[]byte("Subject: Test\r\n\r\nhello"),
 				map[string]string{"From": "sender@example.com"},
 				nil,
+				false, "",
 				[]string{agentEmail}, nil, nil,
 			)
 			if err != nil {
@@ -148,7 +149,7 @@ func TestOutbox_Integration_RelayTxShape(t *testing.T) {
 			_, err := store.CreateInboundMessageInTx(ctx, tx,
 				retryMessageID, agentEmail, "sender@example.com", agentEmail,
 				"<retry-1@sender.example>", "Retry", "", "unread",
-				[]byte("hello"), nil, nil, []string{agentEmail}, nil, nil,
+				[]byte("hello"), nil, nil, false, "", []string{agentEmail}, nil, nil,
 			)
 			if err != nil {
 				return err
@@ -175,7 +176,7 @@ func TestOutbox_Integration_RelayTxShape(t *testing.T) {
 			_, err := store.CreateInboundMessageInTx(ctx, tx,
 				retryMessageID, agentEmail, "sender@example.com", agentEmail,
 				"<retry-2@sender.example>", "Retry 2", "", "unread",
-				[]byte("hello again"), nil, nil, []string{agentEmail}, nil, nil,
+				[]byte("hello again"), nil, nil, false, "", []string{agentEmail}, nil, nil,
 			)
 			if err != nil {
 				return err
@@ -207,7 +208,7 @@ func TestOutbox_Integration_RelayTxShape(t *testing.T) {
 			if _, err := store.CreateInboundMessageInTx(ctx, tx,
 				failMsgID, agentEmail, "sender@example.com", agentEmail,
 				"<fail@sender.example>", "Will Fail", "", "unread",
-				[]byte("hello"), nil, nil, []string{agentEmail}, nil, nil,
+				[]byte("hello"), nil, nil, false, "", []string{agentEmail}, nil, nil,
 			); err != nil {
 				return err
 			}

--- a/migrations/033_inbound_policy.sql
+++ b/migrations/033_inbound_policy.sql
@@ -1,0 +1,28 @@
+-- 033_inbound_policy.sql
+--
+-- Inbound trust policy (decision 10 / Slice 7a — ingestion gate). A per-agent
+-- inbound_policy decides, on arrival, whether a message is trusted or FLAGGED.
+-- Flagged messages are still delivered (never dropped) and emit email.flagged.
+--
+--   open (default) — accept all
+--   allowlist      — accept only senders on inbound_allowlist (exact address)
+--   domain         — accept only senders whose domain is on inbound_allowlist
+--   verified_only  — accept only DMARC-aligned mail (anti-spoofing)
+--
+-- The hitl ACTION gate is a separate axis (the existing hitl_enabled, formalized
+-- in Slice 7b) — the two compose. Idempotent + non-destructive.
+ALTER TABLE agent_identities
+    ADD COLUMN IF NOT EXISTS inbound_policy TEXT NOT NULL DEFAULT 'open';
+ALTER TABLE agent_identities
+    ADD COLUMN IF NOT EXISTS inbound_allowlist TEXT[];
+
+DO $$ BEGIN
+    ALTER TABLE agent_identities ADD CONSTRAINT agent_identities_inbound_policy_check
+        CHECK (inbound_policy IN ('open', 'allowlist', 'domain', 'verified_only'));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- Per-message ingestion result: flagged by the policy at arrival (with a
+-- reason), surfaced on the message + via email.flagged. Inbound-only in
+-- practice; default false.
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS flagged BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS flag_reason TEXT;

--- a/tests/contract/contract_test.go
+++ b/tests/contract/contract_test.go
@@ -160,7 +160,7 @@ func (e *testEnv) injectInboundMessage(t *testing.T, agentEmail, from, subject s
 	if err != nil {
 		t.Fatalf("get agent: %v", err)
 	}
-	msg, err := e.store.CreateInboundMessage(ctx, "", ag.ID, from, agentEmail, "", subject, "", "unread", nil, nil, nil, nil, nil, nil)
+	msg, err := e.store.CreateInboundMessage(ctx, "", ag.ID, from, agentEmail, "", subject, "", "unread", nil, nil, nil, false, "", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("store message: %v", err)
 	}


### PR DESCRIPTION
## Slice 7a — Inbound trust policy ingestion gate

Implements the **ingestion axis** of api-v1-redesign decision 10 (Slice 7), gateway-ENFORCED on arrival. Per-agent `inbound_policy` ∈ `{open, allowlist, domain, verified_only}` + `inbound_allowlist[]`. A non-matching message is **FLAGGED, never dropped**: `messages.flagged`/`flag_reason` set, `email.received` still fires, and `email.flagged` additionally emits so operators get a signal.

### Two-axis reconciliation (design note)
Decision 10 says the postures "compose" (e.g. `verified_only` + `hitl`), which a *single* enum can't express — `hitl` is an action gate, the others are ingestion gates. So this models them as two independent fields:
- `inbound_policy` — the **ingestion** axis (this slice).
- the existing `hitl_enabled` flag + sub-mode — the **action-gate** axis (**Slice 7b, deferred**). Decision 10's "`inbound_policy: hitl`" reconciles to this flag; no `hitl` value exists on `inbound_policy`.

Slice 7b (trust-gated action authorization) + the **hard scope ceiling** depend on Slice 5's scope machinery, so they follow Slice 5. Design doc reconciled in this PR.

### What's in this slice
- **`internal/inboundpolicy`** — stdlib leaf evaluator (`EvaluateIngestion`), fail-closed for the gating postures (empty/garbage sender or empty allowlist flags everything).
- **migration 033** — `agent_identities.inbound_policy` (`DEFAULT 'open'`, CHECK-constrained) + `inbound_allowlist[]`; `messages.flagged`/`flag_reason`. Idempotent.
- **relay enforcement** — evaluated against the **authenticated From identity**, NOT the attacker-controllable Reply-To; `verified_only` gates on decision 9's persisted `dmarc=pass` alignment. Fires `email.flagged` (deterministic id) in both the outbox and legacy publish paths.
- **surfacing** — `inbound_policy`/`inbound_allowlist` on `AgentView` (settable via `update_agent` → `UpdateAgentInboundPolicy`, 400 on unknown policy); `flagged`/`flag_reason` on message reads. Spec regenerated (`api/openapi.yaml`).

### Verification
- `make test-unit` (incl. `TestSpecGoldenNoDrift`) ✅
- DB-backed `identity`, `relay`, `inboundpolicy`, `httpapi` (`-p 1`) ✅
- SMTP-driven e2e (`internal/e2e/inbound_policy_e2e_test.go`): allowlist flags non-member, accepts member, **Reply-To-spoof still flagged**, open never flags ✅
- Binary smoke: fresh-DB boot auto-applies migration 033, startup wiring (incl. new dep) clean; columns + CHECK constraint verified ✅

### Pre-existing issue (not in this slice)
`TestSubscriberStore_RecordAttemptFailureClimbsToFailed` (`internal/webhook`) fails on the clean tree too — migration 027 bumped `max_attempts` default 5→8 but the test still asserts "failed after 5". Unrelated to Slice 7a; flagged as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)