### PR TITLE
feat(auth): Slice 5a — credential scope machinery + hard ceiling (§5)

### DIFF
--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -1278,6 +1278,17 @@ Break the current `/api/v1` surface directly and move it to
     (decided: build OAuth in the e2a core): the OAuth 2.1 token endpoint +
     JWT/JWKS, the auth.md identity/claim ceremony + `act` delegation, and the
     DCR consent-screen scope split — none of which the ceiling needs to hold.
+
+    **Known confinement gap (tracked).** The ceiling is enforced on the new
+    `/v1` (Huma) surface only; the *legacy* `/api/v1` mux (being retired) still
+    accepts bearer API keys without a scope check on a few write routes —
+    message-label `PATCH`, signing-secret create, webhook `redeliver-since`.
+    Blast radius is **within the owner's own tenant** (an owner-minted
+    agent-scoped key escaping its confinement, not cross-tenant), since minting
+    is session-cookie-only. Mitigation: do **not** advertise agent-scoped keys
+    to customers until the legacy `/api/v1` write surface is retired or
+    scope-gated (a later slice). Surfaced by both independent + adversarial
+    review; both classed it a non-goal of 5a, not a regression.
 * **Slice 6 — Agent-first docs.** `e2a.md`/`llms.txt`/`setup.md`/`auth.md`,
   binary-served; `api.md` generated from the spec.
 * **Slice 7 — Inbound trust policy (decision 10), post-parity.** Builds on

--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -1259,6 +1259,25 @@ Break the current `/api/v1` surface directly and move it to
   the scope machinery** (`agent`/`account`) that §6a's tool tiers and decision
   10's trust-gated guard depend on. Depends only on Slice 1 (contract/envelope +
   host cutover); independent of 4/4b. Keep API keys throughout.
+
+  * **Slice 5a — Scope machinery (the hard ceiling).** *(Shipped.)* The
+    `agent`/`account` scope axis, reuse-agnostic and independent of how tokens
+    are minted. `api_keys` gains `scope` (DEFAULT `account`, CHECK-constrained)
+    + `agent_id` with a row-level CHECK `(scope='agent') == (agent_id IS NOT
+    NULL)` (migration 034); existing `e2a_…` keys backfill to `account` so no
+    key loses authority. New keys carry a scope-revealing prefix (`e2a_acct_…` /
+    `e2a_agt_…`); legacy keys still validate (hash is over the whole string).
+    The single auth seam now resolves a `Principal{User, Scope, AgentID}`
+    (`GetPrincipalByAPIKey`; OAuth/session callers are `account` until 5b adds
+    scope claims). The v1 layer enforces the **hard ceiling**: account-only
+    operations (agent create/update/delete, domains, API-key & account mgmt,
+    webhooks, the account event log) reject agent-scoped credentials (403
+    `forbidden`); per-agent operations pin an agent-scoped credential to its one
+    bound agent via the shared `resolveOwnedAgent` choke point. Agent-scoped
+    keys are mintable via `POST /api/keys` (`scope`/`agent`). **Deferred to 5b**
+    (decided: build OAuth in the e2a core): the OAuth 2.1 token endpoint +
+    JWT/JWKS, the auth.md identity/claim ceremony + `act` delegation, and the
+    DCR consent-screen scope split — none of which the ceiling needs to hold.
 * **Slice 6 — Agent-first docs.** `e2a.md`/`llms.txt`/`setup.md`/`auth.md`,
   binary-served; `api.md` generated from the spec.
 * **Slice 7 — Inbound trust policy (decision 10), post-parity.** Builds on

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -661,22 +661,50 @@ func stripBearerScheme(h string) string {
 // resolution path (API key, OAuth bearer, session cookie) instead of
 // forking a second one. There is one place credentials are checked.
 func (a *API) AuthenticateUser(r *http.Request) (*identity.User, error) {
-	return a.authenticateUser(r)
+	p, err := a.authenticatePrincipal(r)
+	if err != nil {
+		return nil, err
+	}
+	return p.User, nil
 }
 
+// AuthenticatePrincipal is the scope-aware seam (Slice 5a): same credential
+// resolution as AuthenticateUser, but returns the full principal (user + scope
+// + bound agent) so the v1 layer can enforce the hard scope ceiling. There is
+// still exactly one place credentials are checked.
+func (a *API) AuthenticatePrincipal(r *http.Request) (*identity.Principal, error) {
+	return a.authenticatePrincipal(r)
+}
+
+// authenticateUser is the user-only convenience over authenticatePrincipal,
+// retained for the legacy /api/v1 handlers that don't enforce scope.
 func (a *API) authenticateUser(r *http.Request) (*identity.User, error) {
+	p, err := a.authenticatePrincipal(r)
+	if err != nil {
+		return nil, err
+	}
+	return p.User, nil
+}
+
+func (a *API) authenticatePrincipal(r *http.Request) (*identity.Principal, error) {
 	authHeader := r.Header.Get("Authorization")
 	if authHeader != "" {
 		bearer := stripBearerScheme(authHeader)
 		if strings.HasPrefix(bearer, oauth.AccessTokenPrefix) {
-			return a.lookupUserByOAuthToken(r, bearer)
+			u, err := a.lookupUserByOAuthToken(r, bearer)
+			if err != nil {
+				return nil, err
+			}
+			// OAuth access tokens are account-scoped until Slice 5b adds
+			// scope claims to the token. Until then they behave as today.
+			return &identity.Principal{User: u, Scope: identity.ScopeAccount}, nil
 		}
-		return a.store.GetUserByAPIKey(r.Context(), bearer)
+		return a.store.GetPrincipalByAPIKey(r.Context(), bearer)
 	}
-	// Fall back to session cookie auth
+	// Fall back to session cookie auth — the web dashboard owner, account scope.
 	if a.userAuth != nil {
 		if user := a.userAuth.AuthenticateRequest(r); user != nil {
-			return user, nil
+			return &identity.Principal{User: user, Scope: identity.ScopeAccount}, nil
 		}
 	}
 	return nil, fmt.Errorf("authorization required")
@@ -1133,7 +1161,7 @@ type updateMessageRequest struct {
 // @Failure      404 {string} string "Message not found or does not belong to this agent"
 // @Router       /api/v1/agents/{email}/messages/{id} [patch]
 func (a *API) handleUpdateMessage(w http.ResponseWriter, r *http.Request) {
-	user, err := a.authenticateUser(r)
+	user, err := a.AuthenticateUser(r)
 	if err != nil {
 		a.writeAuthError(w, r, err)
 		return

--- a/internal/apiserver/apiserver.go
+++ b/internal/apiserver/apiserver.go
@@ -66,11 +66,12 @@ type SenderIdentityEnqueuer interface {
 // definition of the /v1 wiring so production and tests cannot diverge.
 func BuildDeps(p Params) httpapi.Deps {
 	return httpapi.Deps{
-		Authenticator: p.API.AuthenticateUser,
-		ListAgents:    p.Store.ListAgentsByUser,
-		GetAgent:      p.Store.GetAgentByEmail,
-		GetMessage:    p.Store.GetMessageWithContent,
-		ListMessages:  p.Store.GetMessagesByAgent,
+		Authenticator:          p.API.AuthenticateUser,
+		PrincipalAuthenticator: p.API.AuthenticatePrincipal,
+		ListAgents:             p.Store.ListAgentsByUser,
+		GetAgent:               p.Store.GetAgentByEmail,
+		GetMessage:             p.Store.GetMessageWithContent,
+		ListMessages:           p.Store.GetMessagesByAgent,
 
 		ListConversations: p.Store.ListConversationsByAgent,
 		GetConversation:   p.Store.GetConversationByID,

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -760,6 +760,12 @@ func (ua *UserAuth) HandleCreateAPIKey(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		Name      string  `json:"name"`
 		ExpiresAt *string `json:"expires_at,omitempty"` // optional ISO 8601 timestamp
+		// Scope (Slice 5a) selects the credential's blast radius. Omitted/""
+		// defaults to account (backward compatible). "agent" requires Agent to
+		// name one of the caller's agents by email; the minted key can act ONLY
+		// as that agent.
+		Scope string `json:"scope,omitempty"`
+		Agent string `json:"agent,omitempty"` // agent email, required when scope=agent
 	}
 	json.NewDecoder(r.Body).Decode(&req)
 
@@ -780,7 +786,33 @@ func (ua *UserAuth) HandleCreateAPIKey(w http.ResponseWriter, r *http.Request) {
 		expiresAt = &t
 	}
 
-	key, err := ua.store.CreateAPIKey(r.Context(), user.ID, req.Name, expiresAt)
+	// Default to an account-scoped key (the pre-Slice-5a behavior). When the
+	// caller asks for an agent-scoped key, resolve the named agent to its id —
+	// CreateScopedAPIKey re-checks ownership, so a wrong/foreign agent is
+	// rejected rather than minting an over-broad or cross-tenant key.
+	scope := req.Scope
+	if scope == "" {
+		scope = identity.ScopeAccount
+	}
+	if !identity.ValidScope(scope) {
+		http.Error(w, "scope must be 'account' or 'agent'", http.StatusBadRequest)
+		return
+	}
+	var agentID string
+	if scope == identity.ScopeAgent {
+		if req.Agent == "" {
+			http.Error(w, "agent (email) is required when scope=agent", http.StatusBadRequest)
+			return
+		}
+		ag, err := ua.store.GetAgentByEmail(r.Context(), identity.NormalizeEmail(req.Agent))
+		if err != nil || ag == nil || ag.UserID != user.ID {
+			http.Error(w, "agent not found", http.StatusBadRequest)
+			return
+		}
+		agentID = ag.ID
+	}
+
+	key, err := ua.store.CreateScopedAPIKey(r.Context(), user.ID, req.Name, scope, agentID, expiresAt)
 	if err != nil {
 		http.Error(w, "failed to create API key", http.StatusInternalServerError)
 		return

--- a/internal/httpapi/account.go
+++ b/internal/httpapi/account.go
@@ -77,7 +77,7 @@ type suppressionsOutput struct {
 }
 
 func (s *Server) handleListSuppressions(ctx context.Context, _ *struct{}) (*suppressionsOutput, error) {
-	user, err := s.requireUser(ctx)
+	user, err := s.requireAccountUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +100,7 @@ type deleteSuppressionInput struct {
 type deleteSuppressionOutput struct{ Status int }
 
 func (s *Server) handleDeleteSuppression(ctx context.Context, in *deleteSuppressionInput) (*deleteSuppressionOutput, error) {
-	user, err := s.requireUser(ctx)
+	user, err := s.requireAccountUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +123,7 @@ type exportOutput struct {
 }
 
 func (s *Server) handleExportUserData(ctx context.Context, _ *struct{}) (*exportOutput, error) {
-	user, err := s.requireUser(ctx)
+	user, err := s.requireAccountUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +149,7 @@ type deleteAccountOutput struct {
 }
 
 func (s *Server) handleDeleteAccount(ctx context.Context, in *deleteAccountInput) (*deleteAccountOutput, error) {
-	user, err := s.requireUser(ctx)
+	user, err := s.requireAccountUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -167,7 +167,7 @@ func (s *Server) handleDeleteAccount(ctx context.Context, in *deleteAccountInput
 }
 
 func (s *Server) handleGetMyLimits(ctx context.Context, _ *struct{}) (*limitsOutput, error) {
-	user, err := s.requireUser(ctx)
+	user, err := s.requireAccountUser(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/httpapi/agents_write.go
+++ b/internal/httpapi/agents_write.go
@@ -122,6 +122,12 @@ type updateAgentInput struct {
 }
 
 func (s *Server) handleUpdateAgent(ctx context.Context, in *updateAgentInput) (*agentOutput, error) {
+	// Mutating agent config (HITL, inbound_policy) is account administration —
+	// an agent-scoped credential must not change its own security posture
+	// (Slice 5a hard ceiling), so this is account-only even for the bound agent.
+	if _, err := s.requireAccountScope(ctx); err != nil {
+		return nil, err
+	}
 	ag, err := s.resolveOwnedAgent(ctx, in.Address)
 	if err != nil {
 		return nil, err
@@ -188,6 +194,11 @@ type deleteAgentOutput struct {
 }
 
 func (s *Server) handleDeleteAgent(ctx context.Context, in *AddressParam) (*deleteAgentOutput, error) {
+	// Deleting an agent is account administration — barred for agent-scoped
+	// credentials even on their own bound agent (Slice 5a hard ceiling).
+	if _, err := s.requireAccountScope(ctx); err != nil {
+		return nil, err
+	}
 	ag, err := s.resolveOwnedAgent(ctx, in.Address)
 	if err != nil {
 		return nil, err
@@ -204,7 +215,7 @@ func (s *Server) handleDeleteAgent(ctx context.Context, in *AddressParam) (*dele
 }
 
 func (s *Server) handleCreateAgent(ctx context.Context, in *createAgentInput) (*createAgentOutput, error) {
-	user, err := s.requireUser(ctx)
+	user, err := s.requireAccountUser(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/httpapi/domains.go
+++ b/internal/httpapi/domains.go
@@ -183,7 +183,7 @@ type verifyDomainOutput struct {
 }
 
 func (s *Server) handleVerifyDomain(ctx context.Context, in *DomainParam) (*verifyDomainOutput, error) {
-	user, err := s.requireUser(ctx)
+	user, err := s.requireAccountUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -233,7 +233,7 @@ func (s *Server) handleVerifyDomain(ctx context.Context, in *DomainParam) (*veri
 }
 
 func (s *Server) handleListDomains(ctx context.Context, _ *struct{}) (*listDomainsOutput, error) {
-	user, err := s.requireUser(ctx)
+	user, err := s.requireAccountUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +250,7 @@ func (s *Server) handleListDomains(ctx context.Context, _ *struct{}) (*listDomai
 }
 
 func (s *Server) handleGetDomain(ctx context.Context, in *DomainParam) (*domainOutput, error) {
-	user, err := s.requireUser(ctx)
+	user, err := s.requireAccountUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -273,7 +273,7 @@ type registerDomainInput struct {
 }
 
 func (s *Server) handleRegisterDomain(ctx context.Context, in *registerDomainInput) (*domainCreateOutput, error) {
-	user, err := s.requireUser(ctx)
+	user, err := s.requireAccountUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -310,7 +310,7 @@ type updateDomainInput struct {
 }
 
 func (s *Server) handleUpdateDomain(ctx context.Context, in *updateDomainInput) (*domainOutput, error) {
-	user, err := s.requireUser(ctx)
+	user, err := s.requireAccountUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -336,7 +336,7 @@ func (s *Server) handleUpdateDomain(ctx context.Context, in *updateDomainInput) 
 type deleteDomainOutput struct{}
 
 func (s *Server) handleDeleteDomain(ctx context.Context, in *DomainParam) (*deleteDomainOutput, error) {
-	user, err := s.requireUser(ctx)
+	user, err := s.requireAccountUser(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/httpapi/events.go
+++ b/internal/httpapi/events.go
@@ -99,7 +99,7 @@ type redeliverOutput struct {
 }
 
 func (s *Server) handleRedeliverEvent(ctx context.Context, in *RedeliverEventInput) (*redeliverOutput, error) {
-	user, err := s.requireUser(ctx)
+	user, err := s.requireAccountUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +172,7 @@ func containsStr(ss []string, want string) bool {
 }
 
 func (s *Server) handleListEvents(ctx context.Context, in *ListEventsInput) (*listEventsOutput, error) {
-	user, err := s.requireUser(ctx)
+	user, err := s.requireAccountUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -219,7 +219,7 @@ func (s *Server) handleListEvents(ctx context.Context, in *ListEventsInput) (*li
 func (s *Server) handleGetEvent(ctx context.Context, in *struct {
 	ID string `path:"id"`
 }) (*eventOutput, error) {
-	user, err := s.requireUser(ctx)
+	user, err := s.requireAccountUser(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/httpapi/httpapi.go
+++ b/internal/httpapi/httpapi.go
@@ -2,6 +2,7 @@ package httpapi
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -15,11 +16,18 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-// Authenticator resolves the calling principal from the raw request. It is
+// Authenticator resolves the calling user from the raw request. It is
 // injected so this package reuses the *single* auth path that already lives
 // in the agent layer (API key, OAuth bearer, session cookie) instead of
 // forking a second one — there is exactly one place credentials are checked.
 type Authenticator func(r *http.Request) (*identity.User, error)
+
+// PrincipalAuthenticator is the scope-aware seam (Slice 5a): the same single
+// auth path, but returning the full principal (user + credential scope + bound
+// agent) so the v1 handlers can enforce the hard scope ceiling (design §5).
+// When set it supersedes Authenticator; when nil the server wraps Authenticator
+// and treats every caller as account-scoped (pre-Slice-5a behavior).
+type PrincipalAuthenticator func(r *http.Request) (*identity.Principal, error)
 
 // AgentLister returns the agents owned by a user. Injected as a narrow
 // function so the foundation slice doesn't depend on the whole store; the
@@ -69,11 +77,12 @@ type (
 // Deps are the collaborators the v1 layer needs. Everything is injected so
 // the package has no hidden globals and is straightforward to test.
 type Deps struct {
-	Authenticator Authenticator
-	ListAgents    AgentLister
-	GetAgent      AgentGetter
-	GetMessage    MessageGetter
-	ListMessages  MessageLister
+	Authenticator          Authenticator
+	PrincipalAuthenticator PrincipalAuthenticator
+	ListAgents             AgentLister
+	GetAgent               AgentGetter
+	GetMessage             MessageGetter
+	ListMessages           MessageLister
 
 	ListConversations ConversationLister
 	GetConversation   ConversationGetter
@@ -308,18 +317,46 @@ func RequestFromContext(ctx context.Context) *http.Request {
 // requireUser authenticates the caller or returns a 401 envelope carrying
 // the machine-branchable "unauthorized" code.
 func (s *Server) requireUser(ctx context.Context) (*identity.User, error) {
+	p, err := s.requirePrincipal(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return p.User, nil
+}
+
+// requirePrincipal authenticates the caller and returns the full principal
+// (user + scope + bound agent), or a 401 envelope. The scope-aware basis for
+// the hard scope ceiling (requireAccountScope / requireAgentAccess).
+func (s *Server) requirePrincipal(ctx context.Context) (*identity.Principal, error) {
 	// The rate-limit middleware may have already authenticated this request
 	// on the read path; reuse that principal instead of hitting auth twice.
-	if u := userFromContext(ctx); u != nil {
-		return u, nil
+	if p := principalFromContext(ctx); p != nil {
+		return p, nil
 	}
 	r := RequestFromContext(ctx)
-	if r == nil || s.deps.Authenticator == nil {
+	if r == nil {
 		return nil, NewError(http.StatusInternalServerError, "internal_error", "authentication unavailable")
 	}
-	user, err := s.deps.Authenticator(r)
+	p, err := s.resolvePrincipal(r)
 	if err != nil {
 		return nil, NewError(http.StatusUnauthorized, "unauthorized", "authentication required")
 	}
-	return user, nil
+	return p, nil
+}
+
+// resolvePrincipal runs the injected auth path. It prefers the scope-aware
+// PrincipalAuthenticator; if only the legacy Authenticator is wired it treats
+// the caller as account-scoped (pre-Slice-5a behavior — no scope ceiling).
+func (s *Server) resolvePrincipal(r *http.Request) (*identity.Principal, error) {
+	if s.deps.PrincipalAuthenticator != nil {
+		return s.deps.PrincipalAuthenticator(r)
+	}
+	if s.deps.Authenticator == nil {
+		return nil, fmt.Errorf("authentication unavailable")
+	}
+	u, err := s.deps.Authenticator(r)
+	if err != nil {
+		return nil, err
+	}
+	return &identity.Principal{User: u, Scope: identity.ScopeAccount}, nil
 }

--- a/internal/httpapi/operations.go
+++ b/internal/httpapi/operations.go
@@ -108,7 +108,7 @@ func (s *Server) registerAgents() {
 		Tags:        []string{"agents"},
 		Security:    []map[string][]string{{"bearer": {}}},
 	}, func(ctx context.Context, _ *struct{}) (*listAgentsOutput, error) {
-		user, err := s.requireUser(ctx)
+		user, err := s.requireAccountUser(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -147,7 +147,7 @@ func (s *Server) registerAgents() {
 // or non-owned agent is reported as 403 (the legacy surface does not
 // distinguish the two, and preserving that is a Slice-1 non-goal to change).
 func (s *Server) resolveOwnedAgent(ctx context.Context, address string) (*identity.AgentIdentity, error) {
-	user, err := s.requireUser(ctx)
+	p, err := s.requirePrincipal(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -155,8 +155,16 @@ func (s *Server) resolveOwnedAgent(ctx context.Context, address string) (*identi
 		return nil, NewError(http.StatusInternalServerError, "internal_error", "agent lookup unavailable")
 	}
 	ag, err := s.deps.GetAgent(ctx, identity.NormalizeEmail(address))
-	if err != nil || ag == nil || ag.UserID != user.ID {
+	if err != nil || ag == nil || ag.UserID != p.User.ID {
 		return nil, NewError(http.StatusForbidden, "forbidden", "agent not found")
+	}
+	// Hard scope ceiling (Slice 5a): an agent-scoped credential is pinned to a
+	// single agent. Even though the owner owns this agent, a credential bound
+	// to a DIFFERENT agent must not act here. Account-scoped credentials pass.
+	// This is the one choke point for every per-agent operation.
+	if p.Scope == identity.ScopeAgent && p.AgentID != ag.ID {
+		return nil, NewError(http.StatusForbidden, "forbidden",
+			"this agent-scoped credential is bound to a different agent")
 	}
 	return ag, nil
 }

--- a/internal/httpapi/ratelimit.go
+++ b/internal/httpapi/ratelimit.go
@@ -59,17 +59,17 @@ func (s *Server) rateLimit(ctx huma.Context, next func(huma.Context)) {
 			next(ctx)
 			return
 		}
-		user, err := s.deps.Authenticator(r)
+		p, err := s.resolvePrincipal(r)
 		if err != nil {
 			// Unauthenticated: let the handler emit the canonical 401 rather
 			// than masking a missing credential as a rate-limit decision.
 			next(ctx)
 			return
 		}
-		snap, key = s.deps.PollLimit, user.ID
+		snap, key = s.deps.PollLimit, p.User.ID
 		// Reuse the principal so the handler does not authenticate a second
 		// time on the hot read path.
-		ctx = huma.WithContext(ctx, withUser(ctx.Context(), user))
+		ctx = huma.WithContext(ctx, withPrincipal(ctx.Context(), p))
 	case op.OperationID == "createAgent" && s.deps.RegLimit != nil:
 		r := RequestFromContext(ctx.Context())
 		if r == nil {
@@ -110,17 +110,24 @@ func writeEnvelope(ctx huma.Context, env *ErrorEnvelope) {
 	_ = json.NewEncoder(ctx.BodyWriter()).Encode(env)
 }
 
-// userCtxKey carries a principal resolved by the rate-limit middleware so the
-// downstream handler's requireUser can skip a second Authenticator call.
-type userCtxKey struct{}
+// principalCtxKey carries a principal resolved by the rate-limit middleware so
+// the downstream handler's requireUser/requirePrincipal can skip a second auth.
+type principalCtxKey struct{}
 
-func withUser(ctx context.Context, u *identity.User) context.Context {
-	return context.WithValue(ctx, userCtxKey{}, u)
+func withPrincipal(ctx context.Context, p *identity.Principal) context.Context {
+	return context.WithValue(ctx, principalCtxKey{}, p)
+}
+
+func principalFromContext(ctx context.Context) *identity.Principal {
+	if p, ok := ctx.Value(principalCtxKey{}).(*identity.Principal); ok {
+		return p
+	}
+	return nil
 }
 
 func userFromContext(ctx context.Context) *identity.User {
-	if u, ok := ctx.Value(userCtxKey{}).(*identity.User); ok {
-		return u
+	if p := principalFromContext(ctx); p != nil {
+		return p.User
 	}
 	return nil
 }

--- a/internal/httpapi/scope.go
+++ b/internal/httpapi/scope.go
@@ -1,0 +1,64 @@
+package httpapi
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+)
+
+// Scope enforcement — the hard scope ceiling (Slice 5a / design §5 / decision
+// 10). A credential's scope, not its auth method, bounds its blast radius:
+//
+//   - account scope: account-wide admin (agent/domain/key management, account
+//     settings). Reaches everything the owner owns.
+//   - agent scope: bound to a single agent (runtime/inbox tier). May act ONLY
+//     as that one agent, and is barred from account-only operations.
+//
+// These helpers are the single choke points handlers call so the ceiling is
+// enforced uniformly. They return a 403 envelope (machine code "forbidden"),
+// distinct from the 401 "unauthorized" a missing/invalid credential yields.
+
+// requireAccountScope authenticates the caller and rejects agent-scoped
+// credentials with 403. Use on account-only operations (create/delete agent,
+// domain claim/verify/delete, API-key and account management) — the structural
+// guarantee that a leaked agent credential cannot widen its own authority.
+func (s *Server) requireAccountScope(ctx context.Context) (*identity.Principal, error) {
+	p, err := s.requirePrincipal(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if p.Scope != identity.ScopeAccount {
+		return nil, NewError(http.StatusForbidden, "forbidden",
+			"this operation requires an account-scoped credential; agent-scoped credentials cannot perform account administration")
+	}
+	return p, nil
+}
+
+// requireAccountUser is the user-returning convenience over requireAccountScope
+// for the many account-admin handlers that only need user.ID — a clean drop-in
+// for requireUser on operations the agent tier must not reach.
+func (s *Server) requireAccountUser(ctx context.Context) (*identity.User, error) {
+	p, err := s.requireAccountScope(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return p.User, nil
+}
+
+// requireAgentAccess authenticates the caller and confirms it may act as
+// agentID. Account-scoped credentials may act as any agent they own (ownership
+// is still checked separately by the handler). An agent-scoped credential is
+// pinned: it may act ONLY as the single agent it is bound to — any other agent
+// is 403, even if the same owner owns both.
+func (s *Server) requireAgentAccess(ctx context.Context, agentID string) (*identity.Principal, error) {
+	p, err := s.requirePrincipal(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if p.Scope == identity.ScopeAgent && p.AgentID != agentID {
+		return nil, NewError(http.StatusForbidden, "forbidden",
+			"this agent-scoped credential is bound to a different agent")
+	}
+	return p, nil
+}

--- a/internal/httpapi/scope_test.go
+++ b/internal/httpapi/scope_test.go
@@ -1,0 +1,154 @@
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+)
+
+// Slice 5a — the hard scope ceiling. This exercises the 403 matrix over the
+// real v1 handlers: account-only routes reject agent-scoped credentials;
+// per-agent routes pin an agent-scoped credential to its bound agent; an
+// account-scoped credential passes everywhere it owns.
+
+func scopeTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	u := &identity.User{ID: "u_1", Email: "owner@acme.com"}
+	deps := Deps{
+		// Scope-aware auth keyed by bearer:
+		//   acct        → account scope
+		//   agtSupport  → agent scope bound to support@acme.com
+		//   agtOther    → agent scope bound to other@acme.com
+		PrincipalAuthenticator: func(r *http.Request) (*identity.Principal, error) {
+			switch r.Header.Get("Authorization") {
+			case "Bearer acct":
+				return &identity.Principal{User: u, Scope: identity.ScopeAccount}, nil
+			case "Bearer agtSupport":
+				return &identity.Principal{User: u, Scope: identity.ScopeAgent, AgentID: "support@acme.com"}, nil
+			case "Bearer agtOther":
+				return &identity.Principal{User: u, Scope: identity.ScopeAgent, AgentID: "other@acme.com"}, nil
+			}
+			return nil, errors.New("unauthorized")
+		},
+		ListAgents: func(ctx context.Context, userID string) ([]identity.AgentIdentity, error) {
+			return []identity.AgentIdentity{sampleAgent()}, nil
+		},
+		GetAgent: func(ctx context.Context, address string) (*identity.AgentIdentity, error) {
+			switch address {
+			case "support@acme.com":
+				a := sampleAgent()
+				return &a, nil
+			case "other@acme.com":
+				a := sampleAgent()
+				a.ID = "other@acme.com"
+				return &a, nil
+			}
+			return nil, errors.New("not found")
+		},
+		UpdateAgentHITL: func(ctx context.Context, agentID, userID string, enabled bool, ttl int, action string) error {
+			return nil
+		},
+		DeleteAgent: func(ctx context.Context, agentID, userID string) error { return nil },
+		Legacy:      http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusTeapot) }),
+	}
+	srv := httptest.NewServer(New(deps))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestScope_AccountOnlyRoutesRejectAgentKeys(t *testing.T) {
+	srv := scopeTestServer(t)
+
+	cases := []struct {
+		name, method, path, bearer string
+		wantStatus                 int
+	}{
+		// List agents is account-admin discovery.
+		{"list/account-ok", "GET", "/v1/agents", "acct", 200},
+		{"list/agent-403", "GET", "/v1/agents", "agtSupport", 403},
+		// Delete agent is admin even on the bound agent.
+		{"delete/account-ok", "DELETE", "/v1/agents/support%40acme.com", "acct", 200},
+		{"delete/agent-bound-403", "DELETE", "/v1/agents/support%40acme.com", "agtSupport", 403},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			code, body := sendJSON(t, c.method, srv.URL+c.path, c.bearer, nil)
+			if code != c.wantStatus {
+				t.Fatalf("%s %s as %s: status %d, want %d (body %v)", c.method, c.path, c.bearer, code, c.wantStatus, body)
+			}
+			if c.wantStatus == 403 && errCode(body) != "forbidden" {
+				t.Errorf("expected error code 'forbidden', got %v", body)
+			}
+		})
+	}
+}
+
+// TestScope_UpdateAgentIsAccountOnly: mutating agent config is barred for an
+// agent-scoped credential even on its own bound agent.
+func TestScope_UpdateAgentIsAccountOnly(t *testing.T) {
+	srv := scopeTestServer(t)
+	body := map[string]any{"hitl_enabled": true, "hitl_ttl_seconds": 3600, "hitl_expiration_action": "reject"}
+
+	code, _ := sendJSON(t, "PATCH", srv.URL+"/v1/agents/support%40acme.com", "acct", body)
+	if code != 200 {
+		t.Errorf("account key PATCH agent: status %d, want 200", code)
+	}
+	code, resp := sendJSON(t, "PATCH", srv.URL+"/v1/agents/support%40acme.com", "agtSupport", body)
+	if code != 403 || errCode(resp) != "forbidden" {
+		t.Errorf("agent key PATCH own agent: status %d body %v, want 403 forbidden", code, resp)
+	}
+}
+
+// TestScope_AgentKeyPinnedToBoundAgent: a per-agent runtime route lets an
+// agent-scoped credential act as its bound agent but 403s on any other agent;
+// an account-scoped credential reaches both.
+func TestScope_AgentKeyPinnedToBoundAgent(t *testing.T) {
+	srv := scopeTestServer(t)
+
+	cases := []struct {
+		name, path, bearer string
+		wantStatus         int
+	}{
+		{"bound-agent-ok", "/v1/agents/support%40acme.com", "agtSupport", 200},
+		{"other-agent-403", "/v1/agents/other%40acme.com", "agtSupport", 403},
+		{"account-reaches-support", "/v1/agents/support%40acme.com", "acct", 200},
+		{"account-reaches-other", "/v1/agents/other%40acme.com", "acct", 200},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			code, body := sendJSON(t, "GET", srv.URL+c.path, c.bearer, nil)
+			if code != c.wantStatus {
+				t.Fatalf("GET %s as %s: status %d, want %d (body %v)", c.path, c.bearer, code, c.wantStatus, body)
+			}
+		})
+	}
+}
+
+// TestScope_LegacyAuthenticatorIsAccount: with only the legacy Authenticator
+// wired (no PrincipalAuthenticator), every caller is treated as account-scoped
+// — the pre-Slice-5a behavior, so the ceiling never falsely 403s old deployments.
+func TestScope_LegacyAuthenticatorIsAccount(t *testing.T) {
+	deps := Deps{
+		Authenticator: func(r *http.Request) (*identity.User, error) {
+			if r.Header.Get("Authorization") == "Bearer good" {
+				return &identity.User{ID: "u_1"}, nil
+			}
+			return nil, errors.New("unauthorized")
+		},
+		ListAgents: func(ctx context.Context, userID string) ([]identity.AgentIdentity, error) {
+			return []identity.AgentIdentity{sampleAgent()}, nil
+		},
+		Legacy: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusTeapot) }),
+	}
+	srv := httptest.NewServer(New(deps))
+	t.Cleanup(srv.Close)
+
+	code, body := sendJSON(t, "GET", srv.URL+"/v1/agents", "good", nil)
+	if code != 200 {
+		t.Fatalf("legacy authenticator on account route: status %d, want 200 (body %v)", code, body)
+	}
+}

--- a/internal/httpapi/webhooks.go
+++ b/internal/httpapi/webhooks.go
@@ -258,7 +258,7 @@ type testWebhookOutput struct {
 }
 
 func (s *Server) handleTestWebhook(ctx context.Context, in *testWebhookInput) (*testWebhookOutput, error) {
-	user, err := s.requireUser(ctx)
+	user, err := s.requireAccountUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -319,7 +319,7 @@ type listDeliveriesOutput struct {
 }
 
 func (s *Server) handleListWebhookDeliveries(ctx context.Context, in *ListDeliveriesInput) (*listDeliveriesOutput, error) {
-	user, err := s.requireUser(ctx)
+	user, err := s.requireAccountUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -370,7 +370,7 @@ type updateWebhookInput struct {
 }
 
 func (s *Server) handleUpdateWebhook(ctx context.Context, in *updateWebhookInput) (*webhookOutput, error) {
-	user, err := s.requireUser(ctx)
+	user, err := s.requireAccountUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -435,7 +435,7 @@ type rotateSecretOutput struct {
 }
 
 func (s *Server) handleRotateWebhookSecret(ctx context.Context, in *WebhookIDParam) (*rotateSecretOutput, error) {
-	user, err := s.requireUser(ctx)
+	user, err := s.requireAccountUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -453,7 +453,7 @@ func (s *Server) handleRotateWebhookSecret(ctx context.Context, in *WebhookIDPar
 }
 
 func (s *Server) handleCreateWebhook(ctx context.Context, in *createWebhookInput) (*webhookCreateOutput, error) {
-	user, err := s.requireUser(ctx)
+	user, err := s.requireAccountUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -479,7 +479,7 @@ func (s *Server) handleCreateWebhook(ctx context.Context, in *createWebhookInput
 }
 
 func (s *Server) handleListWebhooks(ctx context.Context, _ *struct{}) (*listWebhooksOutput, error) {
-	user, err := s.requireUser(ctx)
+	user, err := s.requireAccountUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -496,7 +496,7 @@ func (s *Server) handleListWebhooks(ctx context.Context, _ *struct{}) (*listWebh
 }
 
 func (s *Server) handleGetWebhook(ctx context.Context, in *WebhookIDParam) (*webhookOutput, error) {
-	user, err := s.requireUser(ctx)
+	user, err := s.requireAccountUser(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -510,7 +510,7 @@ func (s *Server) handleGetWebhook(ctx context.Context, in *WebhookIDParam) (*web
 type deleteWebhookOutput struct{}
 
 func (s *Server) handleDeleteWebhook(ctx context.Context, in *WebhookIDParam) (*deleteWebhookOutput, error) {
-	user, err := s.requireUser(ctx)
+	user, err := s.requireAccountUser(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/identity/api_key_scope_test.go
+++ b/internal/identity/api_key_scope_test.go
@@ -1,0 +1,150 @@
+package identity_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+)
+
+// Slice 5a — scope machinery. These DB-backed tests pin the credential-scope
+// contract: minting, prefixes, the resolved principal, legacy backfill, and the
+// cross-user / binding guards.
+
+func setupScopeUserAgent(t *testing.T, slug string) (*identity.Store, *identity.User, *identity.AgentIdentity) {
+	t.Helper()
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	user, err := store.CreateOrGetUser(ctx, "owner-"+slug+"@example.com", "Owner", "google-"+slug)
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	dom := slug + ".example.com"
+	if _, err := store.ClaimOrCreateDomain(ctx, dom, user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+	ag, err := store.CreateAgent(ctx, "agent@"+dom, dom, "", "", "", user.ID)
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	return store, user, ag
+}
+
+func TestCreateAPIKey_DefaultsToAccountScope(t *testing.T) {
+	store, user, _ := setupScopeUserAgent(t, "scope-acct")
+	ctx := context.Background()
+
+	key, err := store.CreateAPIKey(ctx, user.ID, "default", nil)
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+	if key.Scope != identity.ScopeAccount {
+		t.Errorf("scope = %q, want account", key.Scope)
+	}
+	if key.AgentID != nil {
+		t.Errorf("account key AgentID = %v, want nil", key.AgentID)
+	}
+	if !strings.HasPrefix(key.PlaintextKey, "e2a_acct_") {
+		t.Errorf("account key prefix = %q, want e2a_acct_", key.PlaintextKey[:12])
+	}
+
+	p, err := store.GetPrincipalByAPIKey(ctx, key.PlaintextKey)
+	if err != nil {
+		t.Fatalf("GetPrincipalByAPIKey: %v", err)
+	}
+	if p.Scope != identity.ScopeAccount || p.AgentID != "" || p.User.ID != user.ID {
+		t.Errorf("principal = %+v, want account/empty-agent/%s", p, user.ID)
+	}
+}
+
+func TestCreateScopedAPIKey_Agent(t *testing.T) {
+	store, user, ag := setupScopeUserAgent(t, "scope-agent")
+	ctx := context.Background()
+
+	key, err := store.CreateScopedAPIKey(ctx, user.ID, "runtime", identity.ScopeAgent, ag.ID, nil)
+	if err != nil {
+		t.Fatalf("CreateScopedAPIKey(agent): %v", err)
+	}
+	if key.Scope != identity.ScopeAgent {
+		t.Errorf("scope = %q, want agent", key.Scope)
+	}
+	if key.AgentID == nil || *key.AgentID != ag.ID {
+		t.Errorf("agent key AgentID = %v, want %s", key.AgentID, ag.ID)
+	}
+	if !strings.HasPrefix(key.PlaintextKey, "e2a_agt_") {
+		t.Errorf("agent key prefix = %q, want e2a_agt_", key.PlaintextKey[:11])
+	}
+
+	p, err := store.GetPrincipalByAPIKey(ctx, key.PlaintextKey)
+	if err != nil {
+		t.Fatalf("GetPrincipalByAPIKey: %v", err)
+	}
+	if p.Scope != identity.ScopeAgent || p.AgentID != ag.ID {
+		t.Errorf("principal = %+v, want agent scope bound to %s", p, ag.ID)
+	}
+}
+
+// TestCreateScopedAPIKey_Guards: an agent key must name an owned agent; an
+// account key must not name one; unknown scope is rejected.
+func TestCreateScopedAPIKey_Guards(t *testing.T) {
+	store, user, ag := setupScopeUserAgent(t, "scope-guard")
+	ctx := context.Background()
+
+	// agent scope, no agent id → error
+	if _, err := store.CreateScopedAPIKey(ctx, user.ID, "x", identity.ScopeAgent, "", nil); err == nil {
+		t.Error("expected error for agent scope without agent_id")
+	}
+	// account scope, with agent id → error
+	if _, err := store.CreateScopedAPIKey(ctx, user.ID, "x", identity.ScopeAccount, ag.ID, nil); err == nil {
+		t.Error("expected error for account scope naming an agent")
+	}
+	// unknown scope → error
+	if _, err := store.CreateScopedAPIKey(ctx, user.ID, "x", "root", "", nil); err == nil {
+		t.Error("expected error for unknown scope")
+	}
+
+	// agent scope bound to ANOTHER user's agent → error (cross-tenant guard)
+	store2, user2, _ := setupScopeUserAgent(t, "scope-guard2")
+	_ = store2
+	if _, err := store.CreateScopedAPIKey(ctx, user2.ID, "x", identity.ScopeAgent, ag.ID, nil); err == nil {
+		t.Error("expected error binding a key to another user's agent")
+	}
+}
+
+// TestLegacyKeyResolvesAccount: a pre-Slice-5a row with NULL scope resolves to
+// account (the backfill guarantee — no key silently loses authority).
+func TestLegacyKeyResolvesAccount(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	user, err := store.CreateOrGetUser(ctx, "legacy@example.com", "Owner", "google-legacy")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	// Simulate a legacy key inserted the pre-Slice-5a way: the INSERT does not
+	// mention the scope column at all, so migration 034's NOT NULL DEFAULT
+	// 'account' backfills it — the guarantee that no existing key loses
+	// authority on deploy. Hash the plaintext exactly as the store does.
+	plaintext := "e2a_legacykey_deadbeef"
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO api_keys (id, user_id, name, key_prefix, key_hash, created_at)
+		 VALUES ($1, $2, $3, $4, encode(sha256($5::bytea), 'hex'), now())`,
+		"apk_legacy", user.ID, "legacy", "e2a_legacy", plaintext,
+	); err != nil {
+		t.Fatalf("insert legacy key: %v", err)
+	}
+
+	p, err := store.GetPrincipalByAPIKey(ctx, plaintext)
+	if err != nil {
+		t.Fatalf("GetPrincipalByAPIKey(legacy): %v", err)
+	}
+	if p.Scope != identity.ScopeAccount {
+		t.Errorf("legacy key scope = %q, want account (backfill)", p.Scope)
+	}
+	if p.User.ID != user.ID {
+		t.Errorf("legacy key user = %s, want %s", p.User.ID, user.ID)
+	}
+}

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -2837,7 +2837,7 @@ func (s *Store) UpdateUserName(ctx context.Context, userID, name string) (*User,
 const SessionTTL = 7 * 24 * time.Hour
 
 func (s *Store) CreateUserSession(ctx context.Context, userID string) (string, error) {
-	token := generateAPIKey() // reuse for randomness
+	token := "sess_" + randomHex32() // opaque session cookie value
 	expiresAt := time.Now().Add(SessionTTL)
 	_, err := s.pool.Exec(ctx,
 		`INSERT INTO user_sessions (token, user_id, created_at, expires_at) VALUES ($1, $2, $3, $4)`,
@@ -3045,6 +3045,30 @@ func deltaPct(current, previous int) int {
 
 // --- Per-user API keys ---
 
+// Credential scope (Slice 5a / design §5). The scope a credential carries —
+// not the auth method — determines its blast radius.
+const (
+	// ScopeAccount is account-wide admin: agent/domain/key management, account
+	// settings. The pre-redesign default; what an `e2a_acct_…` key holds.
+	ScopeAccount = "account"
+	// ScopeAgent is bound to a single agent (runtime/inbox tier): the credential
+	// IS the agent. Pinned to one agent_id and barred from account-only ops.
+	ScopeAgent = "agent"
+)
+
+// ValidScope reports whether s is a known credential scope.
+func ValidScope(s string) bool { return s == ScopeAccount || s == ScopeAgent }
+
+// Principal is the authenticated caller resolved from a credential: the owning
+// user plus the credential's scope and (for agent-scoped credentials) the agent
+// it is bound to. The scope/agent binding is what the v1 handlers enforce the
+// hard scope ceiling against (design §5 / decision 10).
+type Principal struct {
+	User    *User
+	Scope   string // ScopeAccount | ScopeAgent
+	AgentID string // non-empty only when Scope == ScopeAgent
+}
+
 type APIKey struct {
 	ID           string    `json:"id"`
 	UserID       string    `json:"user_id"`
@@ -3052,6 +3076,11 @@ type APIKey struct {
 	KeyPrefix    string    `json:"key_prefix"`
 	PlaintextKey string    `json:"key,omitempty"` // only set once at creation, never stored
 	CreatedAt    time.Time `json:"created_at"`
+	// Scope is the credential's blast radius (ScopeAccount | ScopeAgent).
+	// Backfilled to ScopeAccount for pre-Slice-5a keys.
+	Scope string `json:"scope"`
+	// AgentID is the bound agent for ScopeAgent keys; nil for account keys.
+	AgentID *string `json:"agent_id,omitempty"`
 	// LastUsedAt is updated by GetUserByAPIKey on every successful
 	// AuthenticateRequest. NULL on keys that have never been used.
 	LastUsedAt *time.Time `json:"last_used_at,omitempty"`
@@ -3066,16 +3095,54 @@ func hashAPIKey(plaintext string) string {
 	return hex.EncodeToString(h[:])
 }
 
-// CreateAPIKey issues a fresh API key for the user. expiresAt is the
-// optional hard expiration; pass nil to issue a never-expiring key (the
-// backward-compatible default).
+// CreateAPIKey issues a fresh ACCOUNT-scoped API key for the user. expiresAt is
+// the optional hard expiration; pass nil to issue a never-expiring key (the
+// backward-compatible default). This is the account-tier convenience wrapper
+// over CreateScopedAPIKey — the self-host default key.
 func (s *Store) CreateAPIKey(ctx context.Context, userID, name string, expiresAt *time.Time) (*APIKey, error) {
+	return s.CreateScopedAPIKey(ctx, userID, name, ScopeAccount, "", expiresAt)
+}
+
+// CreateScopedAPIKey issues a fresh API key with an explicit scope (Slice 5a).
+//   - ScopeAccount: account-wide admin; agentID must be empty; prefix e2a_acct_.
+//   - ScopeAgent: bound to agentID (which must be a non-empty agent owned by the
+//     user); prefix e2a_agt_. The key can only act as that one agent.
+//
+// The visible prefix makes a key's blast radius obvious at a glance, and the DB
+// CHECK (scope='agent') == (agent_id IS NOT NULL) backstops the binding.
+func (s *Store) CreateScopedAPIKey(ctx context.Context, userID, name, scope, agentID string, expiresAt *time.Time) (*APIKey, error) {
+	if !ValidScope(scope) {
+		return nil, fmt.Errorf("invalid credential scope %q", scope)
+	}
+	if scope == ScopeAgent && agentID == "" {
+		return nil, fmt.Errorf("agent-scoped key requires an agent_id")
+	}
+	if scope == ScopeAccount && agentID != "" {
+		return nil, fmt.Errorf("account-scoped key must not name an agent")
+	}
+	// For an agent-scoped key, the named agent must exist and be owned by the
+	// same user — otherwise a caller could mint a key bound to someone else's
+	// agent (the FK alone wouldn't catch cross-user binding).
+	if scope == ScopeAgent {
+		owns, err := s.userOwnsAgent(ctx, agentID, userID)
+		if err != nil {
+			return nil, err
+		}
+		if !owns {
+			return nil, fmt.Errorf("agent %q not found or not owned by user", agentID)
+		}
+	}
+
 	id := "apk_" + generateID()
-	plaintext := generateAPIKey()
+	plaintext := generateAPIKey(scope)
 	keyHash := hashAPIKey(plaintext)
-	// Show first 8 chars as prefix (e.g. "e2a_abcd...")
-	prefix := plaintext[:12]
+	// Show the scoped prefix + a few key chars (e.g. "e2a_agt_abcd…").
+	prefix := plaintext[:16]
 	now := time.Now()
+	var agentCol *string
+	if scope == ScopeAgent {
+		agentCol = &agentID
+	}
 	ak := &APIKey{
 		ID:           id,
 		UserID:       userID,
@@ -3083,11 +3150,14 @@ func (s *Store) CreateAPIKey(ctx context.Context, userID, name string, expiresAt
 		KeyPrefix:    prefix,
 		PlaintextKey: plaintext,
 		CreatedAt:    now,
+		Scope:        scope,
+		AgentID:      agentCol,
 		ExpiresAt:    expiresAt,
 	}
 	_, err := s.pool.Exec(ctx,
-		`INSERT INTO api_keys (id, user_id, name, key_prefix, key_hash, created_at, expires_at) VALUES ($1, $2, $3, $4, $5, $6, $7)`,
-		ak.ID, ak.UserID, ak.Name, ak.KeyPrefix, keyHash, ak.CreatedAt, ak.ExpiresAt,
+		`INSERT INTO api_keys (id, user_id, name, key_prefix, key_hash, scope, agent_id, created_at, expires_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		ak.ID, ak.UserID, ak.Name, ak.KeyPrefix, keyHash, ak.Scope, agentCol, ak.CreatedAt, ak.ExpiresAt,
 	)
 	if err != nil {
 		return nil, err
@@ -3095,9 +3165,20 @@ func (s *Store) CreateAPIKey(ctx context.Context, userID, name string, expiresAt
 	return ak, nil
 }
 
+// userOwnsAgent reports whether agentID exists and is owned by userID.
+func (s *Store) userOwnsAgent(ctx context.Context, agentID, userID string) (bool, error) {
+	var exists bool
+	err := s.pool.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM agent_identities WHERE id = $1 AND user_id = $2)`,
+		agentID, userID,
+	).Scan(&exists)
+	return exists, err
+}
+
 func (s *Store) ListAPIKeys(ctx context.Context, userID string) ([]APIKey, error) {
 	rows, err := s.pool.Query(ctx,
-		`SELECT id, user_id, name, key_prefix, created_at, last_used_at, expires_at FROM api_keys WHERE user_id = $1 AND revoked_at IS NULL ORDER BY created_at DESC`,
+		`SELECT id, user_id, name, key_prefix, COALESCE(scope, 'account'), agent_id, created_at, last_used_at, expires_at
+		   FROM api_keys WHERE user_id = $1 AND revoked_at IS NULL ORDER BY created_at DESC`,
 		userID,
 	)
 	if err != nil {
@@ -3107,7 +3188,7 @@ func (s *Store) ListAPIKeys(ctx context.Context, userID string) ([]APIKey, error
 	var keys []APIKey
 	for rows.Next() {
 		var k APIKey
-		if err := rows.Scan(&k.ID, &k.UserID, &k.Name, &k.KeyPrefix, &k.CreatedAt, &k.LastUsedAt, &k.ExpiresAt); err != nil {
+		if err := rows.Scan(&k.ID, &k.UserID, &k.Name, &k.KeyPrefix, &k.Scope, &k.AgentID, &k.CreatedAt, &k.LastUsedAt, &k.ExpiresAt); err != nil {
 			return nil, err
 		}
 		keys = append(keys, k)
@@ -3138,23 +3219,42 @@ func (s *Store) DeleteAPIKey(ctx context.Context, keyID, userID string) error {
 // the future, evaluated against now() in the same query so there's no
 // clock skew between row read and check.
 func (s *Store) GetUserByAPIKey(ctx context.Context, apiKey string) (*User, error) {
+	p, err := s.GetPrincipalByAPIKey(ctx, apiKey)
+	if err != nil {
+		return nil, err
+	}
+	return p.User, nil
+}
+
+// GetPrincipalByAPIKey authenticates a bearer token and returns the full
+// principal — the owning user PLUS the key's scope and bound agent (Slice 5a).
+// Same validation/last_used semantics as GetUserByAPIKey (it delegates here).
+// A legacy key with a NULL scope column resolves to ScopeAccount, preserving
+// pre-redesign authority.
+func (s *Store) GetPrincipalByAPIKey(ctx context.Context, apiKey string) (*Principal, error) {
 	keyHash := hashAPIKey(apiKey)
 	u := &User{}
+	var scope string
+	var agentID *string
 	err := s.pool.QueryRow(ctx,
 		`WITH touched AS (
 		   UPDATE api_keys SET last_used_at = now()
 		   WHERE key_hash = $1
 		     AND revoked_at IS NULL
 		     AND (expires_at IS NULL OR expires_at > now())
-		   RETURNING user_id
+		   RETURNING user_id, COALESCE(scope, 'account') AS scope, agent_id
 		 )
-		 SELECT u.id, u.email, u.name, u.google_subject, u.created_at
+		 SELECT u.id, u.email, u.name, u.google_subject, u.created_at, t.scope, t.agent_id
 		 FROM touched t JOIN users u ON u.id = t.user_id`, keyHash,
-	).Scan(&u.ID, &u.Email, &u.Name, &u.GoogleSubject, &u.CreatedAt)
+	).Scan(&u.ID, &u.Email, &u.Name, &u.GoogleSubject, &u.CreatedAt, &scope, &agentID)
 	if err != nil {
 		return nil, err
 	}
-	return u, nil
+	p := &Principal{User: u, Scope: scope}
+	if agentID != nil {
+		p.AgentID = *agentID
+	}
+	return p, nil
 }
 
 func generateID() string {
@@ -3168,14 +3268,34 @@ func generateID() string {
 	return hex.EncodeToString(b)
 }
 
-func generateAPIKey() string {
+// generateAPIKey mints a random key with a scope-revealing prefix (Slice 5a):
+// e2a_acct_… for account keys, e2a_agt_… for agent keys. The prefix is cosmetic
+// for validation (keys are matched by hash of the full string), but makes a
+// key's blast radius obvious wherever it's pasted or logged. Legacy `e2a_…`
+// keys minted before this change keep validating — the hash is over the whole
+// string, so the prefix change only affects newly minted keys.
+func generateAPIKey(scope string) string {
 	b := make([]byte, 32)
 	if _, err := rand.Read(b); err != nil {
 		// Same reasoning as generateID — an all-zero API key would be
 		// catastrophic (predictable auth credential).
 		panic(fmt.Sprintf("identity: crypto/rand failed: %v", err))
 	}
-	return "e2a_" + hex.EncodeToString(b)
+	prefix := "e2a_acct_"
+	if scope == ScopeAgent {
+		prefix = "e2a_agt_"
+	}
+	return prefix + hex.EncodeToString(b)
+}
+
+// randomHex32 returns 32 bytes of crypto-random data hex-encoded. Shared by the
+// session-token path; panics on RNG failure (same reasoning as generateID).
+func randomHex32() string {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		panic(fmt.Sprintf("identity: crypto/rand failed: %v", err))
+	}
+	return hex.EncodeToString(b)
 }
 
 // --- Webhook signing secrets ---

--- a/migrations/034_api_key_scope.sql
+++ b/migrations/034_api_key_scope.sql
@@ -1,0 +1,32 @@
+-- 034_api_key_scope.sql
+--
+-- Scope machinery (Slice 5a / design §5). Every credential carries one of two
+-- scopes, and that scope — not the auth method — determines the blast radius:
+--
+--   account — account-wide admin (agent/domain/key management, account settings).
+--             The pre-redesign behavior; what an `e2a_acct_…` key holds.
+--   agent   — bound to a single agent (runtime/inbox tier). What a deployed agent
+--             holds; pinned to agent_id and barred from account-only operations.
+--
+-- Backfill is the safe path: existing `e2a_…` keys default to 'account', so no
+-- key's authority changes on deploy. agent_id is set only for agent-scoped keys
+-- and cascades if the bound agent is deleted. Idempotent + non-destructive
+-- (metadata-only ADD COLUMN on PG11+; no table rewrite).
+ALTER TABLE api_keys
+    ADD COLUMN IF NOT EXISTS scope TEXT NOT NULL DEFAULT 'account';
+ALTER TABLE api_keys
+    ADD COLUMN IF NOT EXISTS agent_id TEXT REFERENCES agent_identities(id) ON DELETE CASCADE;
+
+DO $$ BEGIN
+    ALTER TABLE api_keys ADD CONSTRAINT api_keys_scope_check
+        CHECK (scope IN ('account', 'agent'));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+-- An agent-scoped key MUST name its agent; an account-scoped key MUST NOT.
+-- This is the row-level invariant behind the runtime enforcement.
+DO $$ BEGIN
+    ALTER TABLE api_keys ADD CONSTRAINT api_keys_agent_scope_binding
+        CHECK ((scope = 'agent') = (agent_id IS NOT NULL));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE INDEX IF NOT EXISTS idx_api_keys_agent ON api_keys(agent_id) WHERE agent_id IS NOT NULL;


### PR DESCRIPTION
## Slice 5a — Credential scope machinery (the hard ceiling)

Delivers the `agent`/`account` **scope axis** from design §5 — reuse-agnostic and independent of how tokens are minted (the OAuth 2.1 token endpoint + auth.md identity is **Slice 5b**, decided to build in-core). A credential's **scope, not its auth method**, bounds its blast radius. This is the load-bearing dependency that unblocks **Slice 7b**'s trust-gated action gate.

### What's in this slice
- **migration 034**: `api_keys.scope` (`DEFAULT 'account'`, CHECK `account|agent`) + `agent_id`, with a row-level CHECK `(scope='agent') == (agent_id IS NOT NULL)`. Existing `e2a_…` keys **backfill to `account`** — no key loses authority on deploy. Idempotent + non-destructive.
- **minting**: `CreateScopedAPIKey` + scope-revealing prefixes (`e2a_acct_…` / `e2a_agt_…`); legacy `e2a_…` keys still validate (hash is over the whole string). `POST /api/keys` gains `scope`/`agent` so agent-scoped keys are mintable; cross-user agent binding is rejected.
- **resolution**: the single auth seam resolves a `Principal{User, Scope, AgentID}` (`GetPrincipalByAPIKey` / `AuthenticatePrincipal`). OAuth-bearer and session-cookie callers are `account`-scoped until 5b adds scope claims.
- **hard ceiling (v1)**: account-only operations (agent create/update/delete, domains, account + API-key mgmt, webhooks, the account event log) reject agent-scoped credentials with **403 `forbidden`**; per-agent operations **pin** an agent-scoped credential to its one bound agent via the shared `resolveOwnedAgent` choke point. When only the legacy `Authenticator` is wired (no `PrincipalAuthenticator`), every caller is account-scoped — **pre-Slice-5a behavior preserved**.

### Verification
- `identity`, `auth`, `agent`, `httpapi`, `apiserver`, `e2e` (`-p 1`, integration) ✅
- `TestSpecGoldenNoDrift` ✅ (key mgmt is on the legacy mux, not the v1 spec — no drift)
- Binary smoke: fresh-DB boot auto-applies migration 034; both CHECK constraints land ✅
- Tests: store-level scope round-trip (account/agent prefixes, principal resolution, **legacy backfill→account**, binding + cross-tenant guards); httpapi **403 matrix** (account-only rejects agent keys; agent key pinned to bound agent; account reaches all; legacy authenticator = account).

### Deferred to Slice 5b (build OAuth in e2a core)
OAuth 2.1 token endpoint + JWT/JWKS, the auth.md identity/claim ceremony + `act` delegation, and the DCR consent-screen scope split — none of which the ceiling needs to hold. Design doc reconciled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)