### PR TITLE
feat(auth): Slice 5b-1 — auth foundation (RS256 signing + JWKS + /oauth2 surface)

### DIFF
--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/Mnexa-AI/e2a/internal/agent"
+	"github.com/Mnexa-AI/e2a/internal/agentauth"
 	"github.com/Mnexa-AI/e2a/internal/apiserver"
 	"github.com/Mnexa-AI/e2a/internal/approvaltoken"
 	"github.com/Mnexa-AI/e2a/internal/auth"
@@ -280,6 +281,19 @@ func main() {
 	// don't have to configure a second key.
 	approvalSigner := approvaltoken.NewSigner(cfg.Signing.HMACSecret)
 	api.SetApprovalSigner(approvalSigner)
+	// auth.md agent-token signer (Slice 5b). A malformed key is fatal (fail
+	// fast at startup); an empty key yields a disabled signer (JWKS serves an
+	// empty set) so deployments not using agent identity run unchanged.
+	jwtSigner, err := agentauth.NewSigner(cfg.OAuth.SigningKey, cfg.OAuth.SigningKID)
+	if err != nil {
+		log.Fatalf("Failed to load OAuth signing key: %v", err)
+	}
+	if jwtSigner.Enabled() {
+		log.Printf("[agentauth] JWT signing enabled (kid=%s)", jwtSigner.KeyID())
+	} else {
+		log.Printf("[agentauth] JWT signing disabled (E2A_OAUTH_SIGNING_KEY not set); /.well-known/jwks.json serves an empty set")
+	}
+	api.SetSigner(jwtSigner)
 	// HITL reviewer-notification emails. Requires both a configured
 	// outbound SMTP relay (to actually send) and a public base URL (so
 	// the magic links in the email are absolute and clickable from any
@@ -298,7 +312,7 @@ func main() {
 	// HMAC secret (signing.hmac_secret) for token HMAC signing and the
 	// public URL as the canonical issuer. Without PublicURL, RFC 9207
 	// `iss` emission + discovery would emit empty/inconsistent values
-	// — skip wiring so /api/oauth/* return 404 and operators get a
+	// — skip wiring so /oauth2/* return 404 and operators get a
 	// loud signal that the deployment needs http.public_url set.
 	var oauthStorage *oauth.Storage
 	if cfg.HTTP.PublicURL == "" {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -27,6 +27,16 @@ oauth:
   google_client_id: ""
   google_client_secret: ""
   redirect_url: "http://localhost:3000/api/auth/callback"
+  # auth.md agent-identity token signing (Slice 5b). PEM-encoded RSA private
+  # key (PKCS#1 or PKCS#8); the public half is published at
+  # /.well-known/jwks.json so agents can verify e2a-minted JWTs. Empty leaves
+  # the agent-auth surface disabled (JWKS serves {"keys":[]}). Override via
+  # E2A_OAUTH_SIGNING_KEY. Never generated or persisted by e2a.
+  signing_key: ""
+  # kid advertised in the JWKS and stamped on every issued JWT (default "v1").
+  # Rotation: advertise a new kid, then retire the old after the longest token
+  # TTL. Override via E2A_OAUTH_SIGNING_KID.
+  signing_kid: "v1"
 
 signing:
   # Generate with: openssl rand -hex 32

--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -1289,6 +1289,34 @@ Break the current `/api/v1` surface directly and move it to
     to customers until the legacy `/api/v1` write surface is retired or
     scope-gated (a later slice). Surfaced by both independent + adversarial
     review; both classed it a non-goal of 5a, not a regression.
+
+  * **Slice 5b-1 — Auth foundation (signing + JWKS + surface).** *(Shipped.)*
+    The pre-token-issuing foundation the agent-identity paths build on:
+    * `internal/agentauth` — RS256 JWT signer loaded from a PEM private key
+      (`E2A_OAUTH_SIGNING_KEY` + `E2A_OAUTH_SIGNING_KID`, default kid `v1`),
+      mirroring the sibling agentdrive deployment. The key is operator-supplied,
+      never generated or persisted by e2a; an empty key leaves the surface
+      **disabled** (sign → `ErrSigningDisabled`, JWKS → empty set), so
+      deployments not using agent identity run unchanged. A malformed key is
+      fatal at startup (fail fast).
+    * `GET /.well-known/jwks.json` — publishes the public key (kid, `use=sig`,
+      RS256); serves `{"keys":[]}` when unconfigured (never 404).
+    * **Route rename** `/api/oauth/*` → `/oauth2/*` (root, unversioned; **no
+      back-compat alias** per §1 — decided). Updated the discovery doc, the login
+      `return_to` allow-list, and the web consent page in lockstep.
+    * Discovery: endpoint URLs → `/oauth2/*`; added `jwks_uri`;
+      `scopes_supported` `["mcp"]` → `["agent","account"]`; **DCR public clients
+      capped at `scope=agent`** (account requires console issuance). The
+      `agent_auth` discovery block + `jwt-bearer` grant are **deferred to 5b-2**
+      (advertising endpoints that don't exist yet would lie to clients).
+
+    **Deferred to later 5b sub-slices:** 5b-2 autonomous path (`POST
+    /agent/identity`, JWKS registration gated by domain ownership, the custom
+    `grant_type=jwt-bearer` token handler + the `agent_auth` discovery block);
+    5b-3 claim ceremony (email-OTP, `claim` grant); 5b-4 `act` delegation +
+    compromised-key kill switch + `agent.credential_revoked`. WorkOS AuthKit
+    human sign-in stays independent of the agent-token layer (pluggable, hosted
+    default) and off 5b's critical path.
 * **Slice 6 — Agent-first docs.** `e2a.md`/`llms.txt`/`setup.md`/`auth.md`,
   binary-served; `api.md` generated from the spec.
 * **Slice 7 — Inbound trust policy (decision 10), post-parity.** Builds on

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/emersion/go-msgauth v0.7.0
 	github.com/emersion/go-smtp v0.24.0
 	github.com/go-chi/chi/v5 v5.3.0
+	github.com/go-jose/go-jose/v3 v3.0.3
 	github.com/google/go-github/v72 v72.0.0
 	github.com/gorilla/mux v1.8.1
 	github.com/jackc/pgx/v5 v5.10.0
@@ -50,7 +51,6 @@ require (
 	github.com/emersion/go-sasl v0.0.0-20241020182733-b788ff22d5a6 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
-	github.com/go-jose/go-jose/v3 v3.0.3 // indirect
 	github.com/go-logr/logr v1.3.0 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gobuffalo/pop/v6 v6.1.1 // indirect

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Mnexa-AI/e2a/internal/agentauth"
 	"github.com/Mnexa-AI/e2a/internal/approvaltoken"
 	"github.com/Mnexa-AI/e2a/internal/auth"
 	"github.com/Mnexa-AI/e2a/internal/dkim"
@@ -175,8 +176,9 @@ type API struct {
 	dcrLimit          *ratelimit.Limiter    // OAuth Dynamic Client Registration — anonymous endpoint, per-IP
 	approvalSigner    *approvaltoken.Signer // optional; if nil, magic-link endpoints return 404
 	notifier          *hitlnotify.Notifier  // optional; if nil, holdForApproval doesn't send notification email
-	oauthProvider     fosite.OAuth2Provider // optional; if nil, /api/oauth/* endpoints return 404
+	oauthProvider     fosite.OAuth2Provider // optional; if nil, /oauth2/* endpoints return 404
 	oauthStorage      *oauth.Storage        // optional; consent handler needs Pool() for cross-package tx
+	signer            *agentauth.Signer     // optional; nil ⇒ JWKS serves an empty set (agent-auth disabled)
 	idempotency       *idempotency.Store    // optional; when nil, Idempotency-Key header is ignored
 	enforcer          limits.Enforcer       // optional; when nil, all limit checks are skipped (effectively unlimited)
 	usageStore        *usage.Store          // optional; needed by handleGetMyLimits to surface current counts
@@ -416,11 +418,16 @@ func (a *API) SetApprovalSigner(s *approvaltoken.Signer) { a.approvalSigner = s 
 func (a *API) SetNotifier(n *hitlnotify.Notifier) { a.notifier = n }
 
 // SetOAuthProvider wires in the fosite-backed OAuth provider. When
-// nil, /api/oauth/* endpoints return 404 (matches the
+// nil, /oauth2/* endpoints return 404 (matches the
 // SetApprovalSigner / SetNotifier pattern of "optional capability,
 // silently absent when not wired"). Operators who don't want OAuth
 // enabled simply don't call this.
 func (a *API) SetOAuthProvider(p fosite.OAuth2Provider) { a.oauthProvider = p }
+
+// SetSigner wires the RS256 agent-token signer (Slice 5b). Optional — when nil
+// or disabled, /.well-known/jwks.json serves an empty key set and the
+// agent-identity token paths (later sub-slices) report "not enabled".
+func (a *API) SetSigner(s *agentauth.Signer) { a.signer = s }
 
 // SetOAuthStorage wires in the OAuth storage handle separately from
 // the provider. The consent handler needs Pool() to begin a pgx tx
@@ -585,16 +592,20 @@ func (a *API) RegisterRoutes(r *mux.Router) {
 	r.HandleFunc("/api/health", a.handleHealth).Methods("GET", "HEAD")
 	r.HandleFunc("/api/feedback", a.handleFeedback).Methods("POST")
 
-	// OAuth 2.1 / RFC 6749 endpoints. Handlers 404 when
-	// SetOAuthProvider wasn't called, so registering unconditionally
-	// is safe.
-	r.HandleFunc("/api/oauth/authorize", a.handleOAuthAuthorize).Methods("GET")
-	r.HandleFunc("/api/oauth/consent", a.handleOAuthConsent).Methods("POST")
-	r.HandleFunc("/api/oauth/token", a.handleOAuthToken).Methods("POST")
-	r.HandleFunc("/api/oauth/revoke", a.handleOAuthRevoke).Methods("POST")
-	r.HandleFunc("/api/oauth/register", a.handleOAuthRegister).Methods("POST")
-	r.HandleFunc("/api/oauth/clients/{client_id}", a.handleOAuthGetClient).Methods("GET")
+	// OAuth 2.1 / RFC 6749 endpoints, root + unversioned (Slice 5b: renamed
+	// from /oauth2/* to /oauth2/* to conform to the auth.md spec — no
+	// back-compat alias). Handlers 404 when SetOAuthProvider wasn't called, so
+	// registering unconditionally is safe.
+	r.HandleFunc("/oauth2/authorize", a.handleOAuthAuthorize).Methods("GET")
+	r.HandleFunc("/oauth2/consent", a.handleOAuthConsent).Methods("POST")
+	r.HandleFunc("/oauth2/token", a.handleOAuthToken).Methods("POST")
+	r.HandleFunc("/oauth2/revoke", a.handleOAuthRevoke).Methods("POST")
+	r.HandleFunc("/oauth2/register", a.handleOAuthRegister).Methods("POST")
+	r.HandleFunc("/oauth2/clients/{client_id}", a.handleOAuthGetClient).Methods("GET")
 	r.HandleFunc("/.well-known/oauth-authorization-server", a.handleOAuthDiscovery).Methods("GET")
+	// Public JWKS for verifying e2a-minted agent JWTs (Slice 5b). Always
+	// registered; serves {"keys":[]} when no signing key is configured.
+	r.HandleFunc("/.well-known/jwks.json", a.handleJWKS).Methods("GET")
 
 	// User auth (Google OAuth for agent developers)
 	if a.userAuth != nil {

--- a/internal/agent/jwks_test.go
+++ b/internal/agent/jwks_test.go
@@ -1,0 +1,108 @@
+package agent_test
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/agent"
+	"github.com/Mnexa-AI/e2a/internal/agentauth"
+	"github.com/Mnexa-AI/e2a/internal/config"
+	"github.com/Mnexa-AI/e2a/internal/outbound"
+	"github.com/Mnexa-AI/e2a/internal/usage"
+	"github.com/gorilla/mux"
+)
+
+// jwksServer builds an httptest server exposing /.well-known/jwks.json with the
+// given signer wired (nil ⇒ none). No DB needed — JWKS doesn't touch storage.
+func jwksServer(t *testing.T, signer *agentauth.Signer) *httptest.Server {
+	t.Helper()
+	smtpRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{})
+	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
+	api := agent.NewAPI(nil, sender, smtpRelay, nil, usage.NewNoopUsageTracker(),
+		"e2a.dev", "test.e2a.dev", "agents.e2a.dev", "https://test.e2a.dev", false)
+	if signer != nil {
+		api.SetSigner(signer)
+	}
+	router := mux.NewRouter()
+	api.RegisterRoutes(router)
+	srv := httptest.NewServer(router)
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func genPEM(t *testing.T) string {
+	t.Helper()
+	k, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	der := x509.MarshalPKCS1PrivateKey(k)
+	return string(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: der}))
+}
+
+// TestJWKS_Enabled: a configured signer publishes exactly its public key, with
+// kid + use=sig + alg=RS256, and no private material.
+func TestJWKS_Enabled(t *testing.T) {
+	signer, err := agentauth.NewSigner(genPEM(t), "v1")
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	srv := jwksServer(t, signer)
+
+	resp, err := http.Get(srv.URL + "/.well-known/jwks.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var doc struct {
+		Keys []map[string]any `json:"keys"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(doc.Keys) != 1 {
+		t.Fatalf("keys = %d, want 1", len(doc.Keys))
+	}
+	k := doc.Keys[0]
+	if k["kid"] != "v1" || k["use"] != "sig" || k["alg"] != "RS256" || k["kty"] != "RSA" {
+		t.Errorf("jwk header fields = %v, want kid=v1 use=sig alg=RS256 kty=RSA", k)
+	}
+	// Must NOT leak the private exponent.
+	if _, leaked := k["d"]; leaked {
+		t.Error("published JWK leaked private key material (field 'd')")
+	}
+}
+
+// TestJWKS_Disabled: with no signing key, the endpoint still serves valid JSON
+// with an empty key set (never 404), so verifiers get a definite "no keys".
+func TestJWKS_Disabled(t *testing.T) {
+	disabled, _ := agentauth.NewSigner("", "")
+	srv := jwksServer(t, disabled)
+
+	resp, err := http.Get(srv.URL + "/.well-known/jwks.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (empty set, not 404)", resp.StatusCode)
+	}
+	var doc struct {
+		Keys []json.RawMessage `json:"keys"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(doc.Keys) != 0 {
+		t.Errorf("disabled JWKS keys = %d, want 0", len(doc.Keys))
+	}
+}

--- a/internal/agent/oauth_bearer_test.go
+++ b/internal/agent/oauth_bearer_test.go
@@ -50,7 +50,7 @@ func mintTokensForFixture(t *testing.T, f *consentFixture) (accessToken, refresh
 	tokForm.Set("client_id", f.clientID)
 	tokForm.Set("redirect_uri", "http://localhost:8765/callback")
 	tokForm.Set("code_verifier", verifier)
-	tokResp, err := http.Post(f.server.URL+"/api/oauth/token",
+	tokResp, err := http.Post(f.server.URL+"/oauth2/token",
 		"application/x-www-form-urlencoded", strings.NewReader(tokForm.Encode()))
 	if err != nil {
 		t.Fatal(err)

--- a/internal/agent/oauth_consent_test.go
+++ b/internal/agent/oauth_consent_test.go
@@ -115,12 +115,12 @@ func newConsentFixture(t *testing.T) *consentFixture {
 	}
 }
 
-// authorizeRequest sends a GET /api/oauth/authorize. When session=true
+// authorizeRequest sends a GET /oauth2/authorize. When session=true
 // the request carries the user session cookie; otherwise it goes in
 // anonymously to test the "no session → login" path.
 func (f *consentFixture) authorizeRequest(t *testing.T, q url.Values, session bool) *http.Response {
 	t.Helper()
-	req, err := http.NewRequest("GET", f.server.URL+"/api/oauth/authorize?"+q.Encode(), nil)
+	req, err := http.NewRequest("GET", f.server.URL+"/oauth2/authorize?"+q.Encode(), nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -138,7 +138,7 @@ func (f *consentFixture) authorizeRequest(t *testing.T, q url.Values, session bo
 // default (consent requires it).
 func (f *consentFixture) consentPOST(t *testing.T, form url.Values) *http.Response {
 	t.Helper()
-	req, err := http.NewRequest("POST", f.server.URL+"/api/oauth/consent",
+	req, err := http.NewRequest("POST", f.server.URL+"/oauth2/consent",
 		strings.NewReader(form.Encode()))
 	if err != nil {
 		t.Fatal(err)
@@ -197,7 +197,7 @@ func TestHTTP_Authorize_NoSession(t *testing.T) {
 		t.Errorf("Location path = %q, want /api/auth/login", loc.Path)
 	}
 	returnTo := loc.Query().Get("return_to")
-	if !strings.HasPrefix(returnTo, "/api/oauth/authorize") {
+	if !strings.HasPrefix(returnTo, "/oauth2/authorize") {
 		t.Errorf("return_to should preserve the authorize request URI: got %q", returnTo)
 	}
 	if !strings.Contains(returnTo, "client_id=") || !strings.Contains(returnTo, "code_challenge=") {
@@ -395,7 +395,7 @@ func TestHTTP_Consent_NoSession(t *testing.T) {
 	form.Set("new_agent_slug", "x")
 
 	// Direct POST without the helper (no cookie).
-	resp, err := http.Post(f.server.URL+"/api/oauth/consent",
+	resp, err := http.Post(f.server.URL+"/oauth2/consent",
 		"application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
 	if err != nil {
 		t.Fatal(err)
@@ -485,7 +485,7 @@ func TestHTTP_FullE2E_AuthorizeConsentToken(t *testing.T) {
 	tokForm.Set("client_id", f.clientID)
 	tokForm.Set("redirect_uri", "http://localhost:8765/callback")
 	tokForm.Set("code_verifier", verifier)
-	resp3, err := http.Post(f.server.URL+"/api/oauth/token",
+	resp3, err := http.Post(f.server.URL+"/oauth2/token",
 		"application/x-www-form-urlencoded", strings.NewReader(tokForm.Encode()))
 	if err != nil {
 		t.Fatal(err)

--- a/internal/agent/oauth_discovery_test.go
+++ b/internal/agent/oauth_discovery_test.go
@@ -44,16 +44,16 @@ func TestHTTP_Discovery_Happy(t *testing.T) {
 	if meta.Issuer != "https://test.e2a.dev" {
 		t.Errorf("issuer = %q, want https://test.e2a.dev", meta.Issuer)
 	}
-	if meta.AuthorizationEndpoint != "https://test.e2a.dev/api/oauth/authorize" {
+	if meta.AuthorizationEndpoint != "https://test.e2a.dev/oauth2/authorize" {
 		t.Errorf("authorization_endpoint = %q", meta.AuthorizationEndpoint)
 	}
-	if meta.TokenEndpoint != "https://test.e2a.dev/api/oauth/token" {
+	if meta.TokenEndpoint != "https://test.e2a.dev/oauth2/token" {
 		t.Errorf("token_endpoint = %q", meta.TokenEndpoint)
 	}
-	if meta.RegistrationEndpoint != "https://test.e2a.dev/api/oauth/register" {
+	if meta.RegistrationEndpoint != "https://test.e2a.dev/oauth2/register" {
 		t.Errorf("registration_endpoint = %q", meta.RegistrationEndpoint)
 	}
-	if meta.RevocationEndpoint != "https://test.e2a.dev/api/oauth/revoke" {
+	if meta.RevocationEndpoint != "https://test.e2a.dev/oauth2/revoke" {
 		t.Errorf("revocation_endpoint = %q", meta.RevocationEndpoint)
 	}
 	// Capability lists must match what the server actually implements
@@ -74,6 +74,19 @@ func TestHTTP_Discovery_Happy(t *testing.T) {
 	}
 	if !meta.AuthorizationResponseIssParameterSupported {
 		t.Error("authorization_response_iss_parameter_supported should be true (RFC 9207)")
+	}
+	// Scope vocabulary is the §6a tier model (Slice 5b): the lone legacy "mcp"
+	// scope is retired in favor of agent/account.
+	wantScopes := map[string]bool{"agent": true, "account": true}
+	for _, s := range meta.ScopesSupported {
+		delete(wantScopes, s)
+	}
+	if len(wantScopes) != 0 || len(meta.ScopesSupported) != 2 {
+		t.Errorf("scopes_supported = %v, want [agent account]", meta.ScopesSupported)
+	}
+	// jwks_uri must point at the public key set agents verify e2a JWTs against.
+	if meta.JWKSURI != "https://test.e2a.dev/.well-known/jwks.json" {
+		t.Errorf("jwks_uri = %q, want .../.well-known/jwks.json", meta.JWKSURI)
 	}
 }
 

--- a/internal/agent/oauth_handlers.go
+++ b/internal/agent/oauth_handlers.go
@@ -17,12 +17,13 @@ import (
 
 	"github.com/Mnexa-AI/e2a/internal/identity"
 	"github.com/Mnexa-AI/e2a/internal/oauth"
+	jose "github.com/go-jose/go-jose/v3"
 	"github.com/gorilla/mux"
 	"github.com/jackc/pgx/v5"
 	"github.com/ory/fosite"
 )
 
-// handleOAuthToken is the /api/oauth/token endpoint. Thin wrapper
+// handleOAuthToken is the /oauth2/token endpoint. Thin wrapper
 // over fosite's NewAccessRequest → NewAccessResponse → WriteAccess-
 // Response chain. Everything interesting (grant_type dispatch, PKCE
 // verification, refresh rotation with reuse defense, RFC 6749 §5.1
@@ -69,7 +70,7 @@ func (a *API) handleOAuthToken(w http.ResponseWriter, r *http.Request) {
 // ───────────────────────── DCR (RFC 7591) ─────────────────────────
 
 // OAuthRegisterRequest is the RFC 7591 §2 client metadata POSTed to
-// /api/oauth/register. Unknown fields are tolerated (forward-compat
+// /oauth2/register. Unknown fields are tolerated (forward-compat
 // with RFC 7591 extensions) but ignored.
 type OAuthRegisterRequest struct {
 	ClientName              string   `json:"client_name"`
@@ -312,7 +313,7 @@ func (a *API) handleOAuthRegister(w http.ResponseWriter, r *http.Request) {
 		req.TokenEndpointAuthMethod = "none"
 	}
 	if req.Scope == "" {
-		req.Scope = "mcp"
+		req.Scope = "agent"
 	}
 
 	// Capability enforcement — reject anything outside what we
@@ -337,9 +338,14 @@ func (a *API) handleOAuthRegister(w http.ResponseWriter, r *http.Request) {
 			`only token_endpoint_auth_method="none" (public clients with PKCE) is supported`)
 		return
 	}
-	if req.Scope != "mcp" {
+	// Scope cap (Slice 5b / design §5): dynamically-registered clients are
+	// public (token_endpoint_auth_method=none), so they may request ONLY
+	// scope="agent" (runtime/inbox tier). scope="account" (admin) requires a
+	// pre-registered confidential client or console issuance — never via public
+	// DCR, so a leaked DCR client can't escalate to account-wide admin.
+	if req.Scope != "agent" {
 		writeOAuthError(w, http.StatusBadRequest, "invalid_client_metadata",
-			`only scope="mcp" is supported`)
+			`dynamically-registered public clients may request only scope="agent"; scope="account" requires console issuance`)
 		return
 	}
 
@@ -491,6 +497,10 @@ type OAuthMetadata struct {
 	TokenEndpointAuthMethodsSupported      []string `json:"token_endpoint_auth_methods_supported"`
 	RevocationEndpointAuthMethodsSupported []string `json:"revocation_endpoint_auth_methods_supported"`
 	ScopesSupported                        []string `json:"scopes_supported"`
+	// JWKSURI points at the public key set agents verify e2a-minted JWTs
+	// against (Slice 5b). Always present once a signer surface exists; the
+	// endpoint serves {"keys":[]} when no signing key is configured.
+	JWKSURI string `json:"jwks_uri,omitempty"`
 	// RFC 9207 §3 — advertises that authorize responses carry `iss`
 	// (we emit it manually in writeAuthorizeRedirect since fosite
 	// v0.49 doesn't ship native RFC 9207 support).
@@ -515,19 +525,24 @@ func (a *API) handleOAuthDiscovery(w http.ResponseWriter, r *http.Request) {
 	base := strings.TrimRight(a.publicURL, "/")
 	meta := OAuthMetadata{
 		Issuer:                 base,
-		AuthorizationEndpoint:  base + "/api/oauth/authorize",
-		TokenEndpoint:          base + "/api/oauth/token",
-		RegistrationEndpoint:   base + "/api/oauth/register",
-		RevocationEndpoint:     base + "/api/oauth/revoke",
+		AuthorizationEndpoint:  base + "/oauth2/authorize",
+		TokenEndpoint:          base + "/oauth2/token",
+		RegistrationEndpoint:   base + "/oauth2/register",
+		RevocationEndpoint:     base + "/oauth2/revoke",
 		ResponseTypesSupported: []string{"code"},
 		// response_mode=query is the only mode we emit at the redirect
 		// URI; explicit so strict MCP clients don't try "fragment".
-		ResponseModesSupported:                     []string{"query"},
-		GrantTypesSupported:                        []string{"authorization_code", "refresh_token"},
-		CodeChallengeMethodsSupported:              []string{"S256"},
-		TokenEndpointAuthMethodsSupported:          []string{"none"},
-		RevocationEndpointAuthMethodsSupported:     []string{"none"},
-		ScopesSupported:                            []string{"mcp"},
+		ResponseModesSupported:                 []string{"query"},
+		GrantTypesSupported:                    []string{"authorization_code", "refresh_token"},
+		CodeChallengeMethodsSupported:          []string{"S256"},
+		TokenEndpointAuthMethodsSupported:      []string{"none"},
+		RevocationEndpointAuthMethodsSupported: []string{"none"},
+		// Scope vocabulary is the §6a tier model (Slice 5b): agent (runtime/
+		// inbox, the DCR-public default) and account (admin). The lone legacy
+		// "mcp" scope is retired. The auth.md agent_auth discovery block +
+		// jwt-bearer grant arrive with the identity endpoints (5b-2).
+		ScopesSupported: []string{"agent", "account"},
+		JWKSURI:         base + "/.well-known/jwks.json",
 		AuthorizationResponseIssParameterSupported: true,
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -535,7 +550,25 @@ func (a *API) handleOAuthDiscovery(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(meta)
 }
 
-// handleOAuthRevoke is the /api/oauth/revoke endpoint (RFC 7009).
+// handleJWKS serves /.well-known/jwks.json — the public RS256 key(s) agents use
+// to verify e2a-minted JWTs (Slice 5b). Unauthenticated by design (a JWKS is
+// public). Always available: when no signing key is configured it serves a
+// valid empty set ({"keys":[]}) rather than 404, so a verifier gets a definite
+// "no keys" answer instead of an ambiguous routing failure. Cached 1h like the
+// discovery doc; rotation publishes a new kid which clients pick up within TTL.
+func (a *API) handleJWKS(w http.ResponseWriter, r *http.Request) {
+	var jwks jose.JSONWebKeySet
+	if a.signer != nil {
+		jwks = a.signer.PublicJWKS()
+	} else {
+		jwks = jose.JSONWebKeySet{Keys: []jose.JSONWebKey{}}
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "public, max-age=3600")
+	_ = json.NewEncoder(w).Encode(jwks)
+}
+
+// handleOAuthRevoke is the /oauth2/revoke endpoint (RFC 7009).
 // Thin shim over fosite's NewRevocationRequest → WriteRevocationResponse:
 //
 //   - parses + validates the token + token_type_hint per RFC 7009 §2.1
@@ -598,7 +631,7 @@ func logTokenError(req fosite.AccessRequester, stage string, err error) {
 //     in a later slice); operators see a log line on every such
 //     redirect so the missing piece is visible.
 //  3. With a session, 302 to {publicURL}/oauth/consent?<params>. The
-//     consent UI in web/ POSTs back to /api/oauth/consent.
+//     consent UI in web/ POSTs back to /oauth2/consent.
 func (a *API) handleOAuthAuthorize(w http.ResponseWriter, r *http.Request) {
 	if a.oauthProvider == nil {
 		http.NotFound(w, r)
@@ -628,7 +661,7 @@ func (a *API) handleOAuthAuthorize(w http.ResponseWriter, r *http.Request) {
 		// Bounce through Google login, then resume back here. We only
 		// pass the path portion (not host/scheme) so the same-origin
 		// invariant of validateReturnToPath holds. After callback the
-		// user lands back on /api/oauth/authorize with the same params
+		// user lands back on /oauth2/authorize with the same params
 		// and the now-valid session cookie.
 		loginURL, _ := url.Parse(strings.TrimRight(a.publicURL, "/") + "/api/auth/login")
 		q := loginURL.Query()

--- a/internal/agent/oauth_register_test.go
+++ b/internal/agent/oauth_register_test.go
@@ -53,7 +53,7 @@ func postRegister(t *testing.T, srv *httptest.Server, body any) *http.Response {
 	if err != nil {
 		t.Fatal(err)
 	}
-	resp, err := http.Post(srv.URL+"/api/oauth/register", "application/json", bytes.NewReader(buf))
+	resp, err := http.Post(srv.URL+"/oauth2/register", "application/json", bytes.NewReader(buf))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,8 +108,8 @@ func TestHTTP_Register_Happy(t *testing.T) {
 	if got.TokenEndpointAuthMethod != "none" {
 		t.Errorf("token_endpoint_auth_method = %q, want none", got.TokenEndpointAuthMethod)
 	}
-	if got.Scope != "mcp" {
-		t.Errorf("scope = %q, want mcp", got.Scope)
+	if got.Scope != "agent" {
+		t.Errorf("scope = %q, want agent", got.Scope)
 	}
 }
 
@@ -301,7 +301,7 @@ func TestHTTP_Register_TooManyRedirectURIs(t *testing.T) {
 // TestHTTP_Register_InvalidJSON.
 func TestHTTP_Register_InvalidJSON(t *testing.T) {
 	srv := newDCRServer(t)
-	resp, err := http.Post(srv.URL+"/api/oauth/register", "application/json", strings.NewReader("not json"))
+	resp, err := http.Post(srv.URL+"/oauth2/register", "application/json", strings.NewReader("not json"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -342,7 +342,7 @@ func TestHTTP_Register_XFFCannotBypass(t *testing.T) {
 			ClientName:   fmt.Sprintf("xff-%d", i),
 			RedirectURIs: []string{"https://example.com/cb"},
 		})
-		req, _ := http.NewRequest("POST", srv.URL+"/api/oauth/register", bytes.NewReader(buf))
+		req, _ := http.NewRequest("POST", srv.URL+"/oauth2/register", bytes.NewReader(buf))
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("X-Forwarded-For", xff)
 		resp, err := http.DefaultClient.Do(req)
@@ -390,7 +390,7 @@ func TestHTTP_Register_NotConfigured(t *testing.T) {
 // Use context.Background helper without polluting the test surface.
 var _ = context.Background
 
-// TestHTTP_GetClient_PublicMetadata covers the GET /api/oauth/clients/{id}
+// TestHTTP_GetClient_PublicMetadata covers the GET /oauth2/clients/{id}
 // lookup the consent UI calls to render the friendly client_name.
 // Asserts: 200 + correct fields on a real client, 404 on unknown, 404
 // when OAuth is not wired, no secret fields in the JSON body, and the
@@ -410,7 +410,7 @@ func TestHTTP_GetClient_PublicMetadata(t *testing.T) {
 	}
 
 	t.Run("happy", func(t *testing.T) {
-		resp, err := http.Get(srv.URL + "/api/oauth/clients/" + reg.ClientID)
+		resp, err := http.Get(srv.URL + "/oauth2/clients/" + reg.ClientID)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -435,8 +435,8 @@ func TestHTTP_GetClient_PublicMetadata(t *testing.T) {
 		if !equalStringSlice(got.RedirectURIs, []string{"https://app.example.com/oauth/cb"}) {
 			t.Errorf("redirect_uris = %v", got.RedirectURIs)
 		}
-		if !equalStringSlice(got.Scopes, []string{"mcp"}) {
-			t.Errorf("scopes = %v, want [mcp]", got.Scopes)
+		if !equalStringSlice(got.Scopes, []string{"agent"}) {
+			t.Errorf("scopes = %v, want [agent]", got.Scopes)
 		}
 		if got.ClientIDIssuedAt == 0 {
 			t.Error("client_id_issued_at must be non-zero")
@@ -447,7 +447,7 @@ func TestHTTP_GetClient_PublicMetadata(t *testing.T) {
 		// Defensive: even though OAuthClientPublicMetadata's Go type
 		// doesn't have a secret field, the JSON body could in theory
 		// carry one via misconfigured serialization. Grep the raw body.
-		resp, _ := http.Get(srv.URL + "/api/oauth/clients/" + reg.ClientID)
+		resp, _ := http.Get(srv.URL + "/oauth2/clients/" + reg.ClientID)
 		defer resp.Body.Close()
 		body, _ := io.ReadAll(resp.Body)
 		raw := strings.ToLower(string(body))
@@ -459,7 +459,7 @@ func TestHTTP_GetClient_PublicMetadata(t *testing.T) {
 	})
 
 	t.Run("unknown client_id 404", func(t *testing.T) {
-		resp, _ := http.Get(srv.URL + "/api/oauth/clients/mcp_does_not_exist")
+		resp, _ := http.Get(srv.URL + "/oauth2/clients/mcp_does_not_exist")
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusNotFound {
 			t.Errorf("unknown client status = %d, want 404", resp.StatusCode)
@@ -470,7 +470,7 @@ func TestHTTP_GetClient_PublicMetadata(t *testing.T) {
 		// gorilla/mux requires the path segment to be present, so a
 		// trailing slash or empty segment falls through to the default
 		// router 404.
-		resp, _ := http.Get(srv.URL + "/api/oauth/clients/")
+		resp, _ := http.Get(srv.URL + "/oauth2/clients/")
 		defer resp.Body.Close()
 		if resp.StatusCode != http.StatusNotFound {
 			t.Errorf("empty client_id status = %d, want 404", resp.StatusCode)
@@ -494,7 +494,7 @@ func TestHTTP_GetClient_NotConfigured(t *testing.T) {
 	srv := httptest.NewServer(router)
 	defer srv.Close()
 
-	resp, err := http.Get(srv.URL + "/api/oauth/clients/mcp_anything")
+	resp, err := http.Get(srv.URL + "/oauth2/clients/mcp_anything")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -512,10 +512,10 @@ func TestHTTP_GetClient_NotConfigured(t *testing.T) {
 func TestHTTP_GetClient_RateLimited(t *testing.T) {
 	srv := newDCRServer(t)
 	// Each DCR-server has its own rate limiter at 10/IP/hr. Burn through
-	// the budget with GET /api/oauth/clients/<random>; the 11th call
+	// the budget with GET /oauth2/clients/<random>; the 11th call
 	// from the same IP must 429.
 	for i := 0; i < 10; i++ {
-		resp, err := http.Get(srv.URL + "/api/oauth/clients/mcp_doesnotexist_" + fmt.Sprintf("%02d", i))
+		resp, err := http.Get(srv.URL + "/oauth2/clients/mcp_doesnotexist_" + fmt.Sprintf("%02d", i))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -526,7 +526,7 @@ func TestHTTP_GetClient_RateLimited(t *testing.T) {
 			t.Fatalf("hit rate limit early on call %d", i+1)
 		}
 	}
-	resp, err := http.Get(srv.URL + "/api/oauth/clients/mcp_doesnotexist_11")
+	resp, err := http.Get(srv.URL + "/oauth2/clients/mcp_doesnotexist_11")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/agent/oauth_revoke_test.go
+++ b/internal/agent/oauth_revoke_test.go
@@ -12,7 +12,7 @@ import (
 // 7009 §2 requires.
 func postRevoke(t *testing.T, serverURL string, form url.Values) *http.Response {
 	t.Helper()
-	resp, err := http.Post(serverURL+"/api/oauth/revoke",
+	resp, err := http.Post(serverURL+"/oauth2/revoke",
 		"application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
 	if err != nil {
 		t.Fatal(err)

--- a/internal/agent/oauth_token_test.go
+++ b/internal/agent/oauth_token_test.go
@@ -126,7 +126,7 @@ func mintAuthCode(t *testing.T, provider fosite.OAuth2Provider, clientID, userID
 	q.Set("code_challenge", challenge)
 	q.Set("code_challenge_method", "S256")
 
-	authReq, _ := http.NewRequest("GET", "https://test.e2a.dev/api/oauth/authorize?"+q.Encode(), nil)
+	authReq, _ := http.NewRequest("GET", "https://test.e2a.dev/oauth2/authorize?"+q.Encode(), nil)
 	ar, err := provider.NewAuthorizeRequest(ctx, authReq)
 	if err != nil {
 		t.Fatalf("NewAuthorizeRequest: %v", err)
@@ -151,7 +151,7 @@ func mintAuthCode(t *testing.T, provider fosite.OAuth2Provider, clientID, userID
 	return code
 }
 
-// TestHTTP_Token_AuthCode covers the happy path: POST /api/oauth/token
+// TestHTTP_Token_AuthCode covers the happy path: POST /oauth2/token
 // with an auth_code grant + PKCE verifier yields an access+refresh
 // token JSON envelope with the right fields and the no-store header.
 func TestHTTP_Token_AuthCode(t *testing.T) {
@@ -167,7 +167,7 @@ func TestHTTP_Token_AuthCode(t *testing.T) {
 	form.Set("redirect_uri", redirectURI)
 	form.Set("code_verifier", verifier)
 
-	resp, err := http.Post(server.URL+"/api/oauth/token",
+	resp, err := http.Post(server.URL+"/oauth2/token",
 		"application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
 	if err != nil {
 		t.Fatal(err)
@@ -224,7 +224,7 @@ func TestHTTP_Token_RefreshGrant(t *testing.T) {
 	form.Set("client_id", clientID)
 	form.Set("redirect_uri", redirectURI)
 	form.Set("code_verifier", verifier)
-	resp, err := http.Post(server.URL+"/api/oauth/token",
+	resp, err := http.Post(server.URL+"/oauth2/token",
 		"application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
 	if err != nil {
 		t.Fatal(err)
@@ -241,7 +241,7 @@ func TestHTTP_Token_RefreshGrant(t *testing.T) {
 	form.Set("grant_type", "refresh_token")
 	form.Set("refresh_token", first.RefreshToken)
 	form.Set("client_id", clientID)
-	resp2, err := http.Post(server.URL+"/api/oauth/token",
+	resp2, err := http.Post(server.URL+"/oauth2/token",
 		"application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
 	if err != nil {
 		t.Fatal(err)
@@ -280,7 +280,7 @@ func TestHTTP_Token_BadPKCE(t *testing.T) {
 	form.Set("redirect_uri", redirectURI)
 	form.Set("code_verifier", "not-the-right-verifier-not-the-right-verifier")
 
-	resp, err := http.Post(server.URL+"/api/oauth/token",
+	resp, err := http.Post(server.URL+"/oauth2/token",
 		"application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
 	if err != nil {
 		t.Fatal(err)
@@ -315,7 +315,7 @@ func TestHTTP_Token_CodeReplay(t *testing.T) {
 	form.Set("code_verifier", verifier)
 
 	// First exchange wins.
-	resp, err := http.Post(server.URL+"/api/oauth/token",
+	resp, err := http.Post(server.URL+"/oauth2/token",
 		"application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
 	if err != nil {
 		t.Fatal(err)
@@ -330,7 +330,7 @@ func TestHTTP_Token_CodeReplay(t *testing.T) {
 	resp.Body.Close()
 
 	// Replay: same code, same verifier. Must fail.
-	resp2, err := http.Post(server.URL+"/api/oauth/token",
+	resp2, err := http.Post(server.URL+"/oauth2/token",
 		"application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
 	if err != nil {
 		t.Fatal(err)
@@ -390,7 +390,7 @@ func TestHTTP_Token_NotConfigured(t *testing.T) {
 	server := httptest.NewServer(router)
 	defer server.Close()
 
-	resp, err := http.Post(server.URL+"/api/oauth/token",
+	resp, err := http.Post(server.URL+"/oauth2/token",
 		"application/x-www-form-urlencoded", strings.NewReader("grant_type=authorization_code"))
 	if err != nil {
 		t.Fatal(err)

--- a/internal/agentauth/signing.go
+++ b/internal/agentauth/signing.go
@@ -1,0 +1,144 @@
+// Package agentauth is the auth.md agent-identity layer (api-v1-redesign §5 /
+// Slice 5b). This file is the signing foundation (5b-1): an RS256 JWT signer
+// loaded from a PEM private key, plus the public JWKS published at
+// /.well-known/jwks.json that agents verify e2a-minted tokens against.
+//
+// Key management mirrors the sibling agentdrive deployment: the private key is
+// supplied as a PEM string via config/env (E2A_OAUTH_SIGNING_KEY), never
+// generated or persisted by e2a, with a `kid` (E2A_OAUTH_SIGNING_KID, default
+// "v1") advertised in the JWKS and stamped on every token. An empty key leaves
+// the agent-auth surface DISABLED: the JWKS serves an empty key set and any
+// attempt to sign returns ErrSigningDisabled, so dev/self-host deployments that
+// don't use agent identity run unchanged. Rotation = advertise a new kid, then
+// retire the old after the longest token TTL.
+package agentauth
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+
+	jose "github.com/go-jose/go-jose/v3"
+	"github.com/go-jose/go-jose/v3/jwt"
+)
+
+// SigningAlg is the only algorithm e2a issues — RS256, what auth.md's reference
+// implementation emits and what every JWKS consumer expects.
+const SigningAlg = jose.RS256
+
+// ErrSigningDisabled is returned by Sign when no signing key is configured.
+// Handlers translate it into a 501/"agent auth not enabled" response rather
+// than a 500, so an unconfigured deployment fails cleanly.
+var ErrSigningDisabled = errors.New("agentauth: signing key not configured")
+
+// Signer holds the parsed RSA private key and its key id. The zero value (and a
+// Signer built from an empty PEM) is a valid, DISABLED signer.
+type Signer struct {
+	priv *rsa.PrivateKey
+	kid  string
+}
+
+// NewSigner builds a Signer from a PEM-encoded RSA private key (PKCS#1 or
+// PKCS#8) and a kid. An empty pemKey yields a disabled signer (no error) so the
+// surface can be off by default; a non-empty but malformed key is a hard error
+// so a misconfigured deployment fails fast at startup rather than at first sign.
+func NewSigner(pemKey, kid string) (*Signer, error) {
+	if pemKey == "" {
+		return &Signer{}, nil
+	}
+	if kid == "" {
+		kid = "v1"
+	}
+	priv, err := parseRSAPrivateKey(pemKey)
+	if err != nil {
+		return nil, err
+	}
+	return &Signer{priv: priv, kid: kid}, nil
+}
+
+// Enabled reports whether a signing key is configured.
+func (s *Signer) Enabled() bool { return s != nil && s.priv != nil }
+
+// KeyID returns the kid stamped on issued tokens (empty when disabled).
+func (s *Signer) KeyID() string {
+	if !s.Enabled() {
+		return ""
+	}
+	return s.kid
+}
+
+// Sign issues an RS256 JWT carrying the given claims, with the kid in the
+// header so verifiers can select the right JWKS entry. Returns
+// ErrSigningDisabled when no key is configured.
+func (s *Signer) Sign(claims jwt.Claims, private map[string]interface{}) (string, error) {
+	if !s.Enabled() {
+		return "", ErrSigningDisabled
+	}
+	sig, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: SigningAlg, Key: jose.JSONWebKey{Key: s.priv, KeyID: s.kid}},
+		(&jose.SignerOptions{}).WithType("JWT"),
+	)
+	if err != nil {
+		return "", fmt.Errorf("agentauth: build signer: %w", err)
+	}
+	builder := jwt.Signed(sig).Claims(claims)
+	if len(private) > 0 {
+		builder = builder.Claims(private)
+	}
+	out, err := builder.CompactSerialize()
+	if err != nil {
+		return "", fmt.Errorf("agentauth: serialize jwt: %w", err)
+	}
+	return out, nil
+}
+
+// PublicJWKS returns the public half as a JWK set for /.well-known/jwks.json.
+// When disabled it returns an empty (non-nil) set so the endpoint always serves
+// valid JSON ({"keys":[]}).
+func (s *Signer) PublicJWKS() jose.JSONWebKeySet {
+	if !s.Enabled() {
+		return jose.JSONWebKeySet{Keys: []jose.JSONWebKey{}}
+	}
+	return jose.JSONWebKeySet{Keys: []jose.JSONWebKey{{
+		Key:       s.priv.Public(),
+		KeyID:     s.kid,
+		Algorithm: string(SigningAlg),
+		Use:       "sig",
+	}}}
+}
+
+// parseRSAPrivateKey accepts PKCS#1 ("RSA PRIVATE KEY") or PKCS#8 ("PRIVATE
+// KEY") PEM blocks and returns the RSA key. A PKCS#8 block carrying a non-RSA
+// key is rejected (RS256 requires RSA).
+func parseRSAPrivateKey(pemKey string) (*rsa.PrivateKey, error) {
+	block, _ := pem.Decode([]byte(pemKey))
+	if block == nil {
+		return nil, errors.New("agentauth: signing key is not valid PEM")
+	}
+	var key *rsa.PrivateKey
+	if k, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		key = k
+	} else {
+		keyAny, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("agentauth: parse private key (tried PKCS#1 and PKCS#8): %w", err)
+		}
+		rsaKey, ok := keyAny.(*rsa.PrivateKey)
+		if !ok {
+			return nil, fmt.Errorf("agentauth: signing key is %T, want *rsa.PrivateKey (RS256)", keyAny)
+		}
+		key = rsaKey
+	}
+	// Reject weak moduli: RS256 with a < 2048-bit key is forgeable. A
+	// misconfigured operator key must fail CLOSED at startup, not silently sign
+	// with a breakable key (minMODBits matches NIST SP 800-131A).
+	if key.N.BitLen() < minModulusBits {
+		return nil, fmt.Errorf("agentauth: RSA key is %d-bit, want >= %d (RS256)", key.N.BitLen(), minModulusBits)
+	}
+	return key, nil
+}
+
+// minModulusBits is the smallest RSA modulus accepted for RS256 signing.
+const minModulusBits = 2048

--- a/internal/agentauth/signing_test.go
+++ b/internal/agentauth/signing_test.go
@@ -1,0 +1,172 @@
+package agentauth
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+	"time"
+
+	jose "github.com/go-jose/go-jose/v3"
+	"github.com/go-jose/go-jose/v3/jwt"
+)
+
+func genPKCS1PEM(t *testing.T) (string, *rsa.PrivateKey) {
+	t.Helper()
+	k, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	der := x509.MarshalPKCS1PrivateKey(k)
+	p := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: der})
+	return string(p), k
+}
+
+func genPKCS8PEM(t *testing.T) string {
+	t.Helper()
+	k, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(k)
+	if err != nil {
+		t.Fatalf("marshal pkcs8: %v", err)
+	}
+	p := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	return string(p)
+}
+
+// TestSign_RoundTrip: a token signed by the Signer verifies against the public
+// JWKS it publishes, carries the kid in its header, and round-trips claims.
+func TestSign_RoundTrip(t *testing.T) {
+	pemKey, _ := genPKCS1PEM(t)
+	s, err := NewSigner(pemKey, "v1")
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	if !s.Enabled() || s.KeyID() != "v1" {
+		t.Fatalf("expected enabled signer with kid v1, got enabled=%v kid=%q", s.Enabled(), s.KeyID())
+	}
+
+	claims := jwt.Claims{Subject: "support@acme.com", Audience: jwt.Audience{"https://api.e2a.dev"}, Expiry: jwt.NewNumericDate(time.Unix(2000000000, 0))}
+	tok, err := s.Sign(claims, map[string]interface{}{"scope": "agent"})
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+
+	parsed, err := jwt.ParseSigned(tok)
+	if err != nil {
+		t.Fatalf("ParseSigned: %v", err)
+	}
+	if len(parsed.Headers) == 0 || parsed.Headers[0].KeyID != "v1" {
+		t.Errorf("expected kid v1 in header, got %+v", parsed.Headers)
+	}
+
+	// Verify against the published JWKS.
+	jwks := s.PublicJWKS()
+	if len(jwks.Keys) != 1 {
+		t.Fatalf("expected 1 public key, got %d", len(jwks.Keys))
+	}
+	var got jwt.Claims
+	var priv map[string]interface{}
+	if err := parsed.Claims(jwks.Keys[0].Key, &got, &priv); err != nil {
+		t.Fatalf("verify with public JWK: %v", err)
+	}
+	if got.Subject != "support@acme.com" {
+		t.Errorf("sub = %q, want support@acme.com", got.Subject)
+	}
+	if priv["scope"] != "agent" {
+		t.Errorf("scope = %v, want agent", priv["scope"])
+	}
+	// Public JWK must be public-only (no private material) and tagged for sig.
+	if jwks.Keys[0].IsPublic() == false {
+		t.Error("published JWK must be public-only")
+	}
+	if jwks.Keys[0].Use != "sig" || jwks.Keys[0].KeyID != "v1" {
+		t.Errorf("published JWK use/kid = %q/%q, want sig/v1", jwks.Keys[0].Use, jwks.Keys[0].KeyID)
+	}
+}
+
+func TestSign_PKCS8Accepted(t *testing.T) {
+	s, err := NewSigner(genPKCS8PEM(t), "v1")
+	if err != nil {
+		t.Fatalf("NewSigner(PKCS8): %v", err)
+	}
+	if _, err := s.Sign(jwt.Claims{Subject: "x"}, nil); err != nil {
+		t.Fatalf("Sign with PKCS8 key: %v", err)
+	}
+}
+
+// TestDisabledSigner: an empty PEM yields a disabled signer that errs on sign
+// and serves an empty (non-nil) JWKS — the off-by-default posture.
+func TestDisabledSigner(t *testing.T) {
+	s, err := NewSigner("", "")
+	if err != nil {
+		t.Fatalf("NewSigner(empty): unexpected error %v", err)
+	}
+	if s.Enabled() {
+		t.Error("empty-key signer must be disabled")
+	}
+	if _, err := s.Sign(jwt.Claims{Subject: "x"}, nil); err != ErrSigningDisabled {
+		t.Errorf("Sign on disabled signer = %v, want ErrSigningDisabled", err)
+	}
+	jwks := s.PublicJWKS()
+	if jwks.Keys == nil || len(jwks.Keys) != 0 {
+		t.Errorf("disabled JWKS must be empty non-nil, got %+v", jwks.Keys)
+	}
+}
+
+// TestMalformedKeyHardError: a non-empty but invalid key is a startup error
+// (fail fast), not a silently-disabled signer.
+func TestMalformedKeyHardError(t *testing.T) {
+	if _, err := NewSigner("not a pem", "v1"); err == nil {
+		t.Error("expected error for malformed PEM")
+	}
+	// A well-formed PEM block whose bytes are not a valid key must be rejected.
+	// Built at runtime (rather than an embedded key-armor literal) so secret
+	// scanners don't false-positive on the test source.
+	garbagePEM := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: []byte("not-a-real-key")}))
+	if _, err := NewSigner(garbagePEM, "v1"); err == nil {
+		t.Error("expected error for malformed key bytes inside a valid PEM block")
+	}
+}
+
+// TestRejectsWeakKey: a syntactically valid but too-small RSA key (1024-bit)
+// must fail closed — RS256 with a weak modulus is forgeable (review finding).
+func TestRejectsWeakKey(t *testing.T) {
+	k, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	pemKey := string(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(k)}))
+	if _, err := NewSigner(pemKey, "v1"); err == nil {
+		t.Error("expected error for 1024-bit RSA key (< 2048 min)")
+	}
+}
+
+// TestRejectsECKey: a valid PKCS#8 EC key exercises the non-RSA type-assertion
+// branch — RS256 requires RSA, so it must be rejected (review finding).
+func TestRejectsECKey(t *testing.T) {
+	ec, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("gen ec: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(ec)
+	if err != nil {
+		t.Fatalf("marshal ec pkcs8: %v", err)
+	}
+	pemKey := string(pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}))
+	if _, err := NewSigner(pemKey, "v1"); err == nil {
+		t.Error("expected error for EC key (RS256 requires RSA)")
+	}
+}
+
+// guard against accidental alg drift.
+func TestSigningAlgIsRS256(t *testing.T) {
+	if SigningAlg != jose.RS256 {
+		t.Errorf("SigningAlg = %v, want RS256", SigningAlg)
+	}
+}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -262,8 +262,8 @@ func (ua *UserAuth) writeCLIHandoffPage(w http.ResponseWriter, r *http.Request, 
 // CLI login params (cli_callback, cli_state) are encoded into the OAuth state
 // parameter so they survive the redirect through Google without relying on cookies.
 // return_to (optional) is a same-origin server path the user resumes on after
-// callback success — only paths under /api/oauth/ are permitted, used to bounce
-// MCP OAuth clients back into /api/oauth/authorize after a session is created.
+// callback success — only paths under /oauth2/ are permitted, used to bounce
+// MCP OAuth clients back into /oauth2/authorize after a session is created.
 func (ua *UserAuth) HandleLogin(w http.ResponseWriter, r *http.Request) {
 	cliCallback := r.URL.Query().Get("cli_callback")
 	cliState := r.URL.Query().Get("cli_state")
@@ -301,11 +301,12 @@ func (ua *UserAuth) HandleLogin(w http.ResponseWriter, r *http.Request) {
 // validateReturnToPath enforces the same-origin / known-prefix allow-list
 // for return_to values. Accepting an arbitrary URL would turn /api/auth/login
 // into an open redirector that an attacker could chain with phishing-class
-// social engineering. Limiting to /api/oauth/-prefixed server paths means
-// the bounce can only land inside the OAuth flow we own.
+// social engineering. Limiting to /oauth2/-prefixed server paths means
+// the bounce can only land inside the OAuth flow we own (Slice 5b renamed the
+// OAuth surface from /oauth2/* to /oauth2/*).
 func validateReturnToPath(raw string) error {
-	if !strings.HasPrefix(raw, "/api/oauth/") {
-		return errors.New("return_to must be a server path starting with /api/oauth/")
+	if !strings.HasPrefix(raw, "/oauth2/") {
+		return errors.New("return_to must be a server path starting with /oauth2/")
 	}
 	if strings.ContainsAny(raw, "\\\n\r\x00") {
 		return errors.New("return_to contains forbidden characters")
@@ -319,18 +320,18 @@ func validateReturnToPath(raw string) error {
 		return errors.New("return_to must be a path with no scheme or authority")
 	}
 	// Reject path traversal that survives the HasPrefix check by being
-	// collapsed by the browser. e.g. raw "/api/oauth/../../dashboard"
+	// collapsed by the browser. e.g. raw "/oauth2/../../dashboard"
 	// matches the prefix but http.Redirect emits a Location header that
 	// the browser resolves to "/dashboard" — escaping the allow-list.
 	// path.Clean folds the "../" segments and we re-check the prefix on
 	// the normalized form.
 	cleaned := path.Clean(u.Path)
-	if !strings.HasPrefix(cleaned, "/api/oauth/") && cleaned != "/api/oauth" {
+	if !strings.HasPrefix(cleaned, "/oauth2/") && cleaned != "/oauth2" {
 		return errors.New("return_to escapes the allow-list after normalization")
 	}
 	// Also reject empty segments which a future router refactor might
-	// treat as authority. "/api/oauth//foo" survives path.Clean as
-	// "/api/oauth/foo" but the raw value carries the empty segment
+	// treat as authority. "/oauth2//foo" survives path.Clean as
+	// "/oauth2/foo" but the raw value carries the empty segment
 	// which some HTTP stacks parse differently — fail closed.
 	if strings.Contains(u.Path, "//") {
 		return errors.New("return_to must not contain empty path segments")
@@ -414,7 +415,7 @@ func (ua *UserAuth) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// If this login was triggered by an /api/oauth/ flow that wanted the
+	// If this login was triggered by an /oauth2/ flow that wanted the
 	// user to land back where they started, bounce to that path. The
 	// allow-list was enforced at HandleLogin time; re-validate defensively
 	// in case state was tampered with somehow (the OAuth state is integrity-

--- a/internal/auth/cli_login_test.go
+++ b/internal/auth/cli_login_test.go
@@ -109,12 +109,12 @@ func TestHandleLogin_WebLoginOmitsCliParams(t *testing.T) {
 }
 
 // TestHandleLogin_EncodesReturnToInOAuthState: /api/auth/login?return_to=
-// /api/oauth/authorize?... encodes that path into the Google OAuth state
+// /oauth2/authorize?... encodes that path into the Google OAuth state
 // so HandleCallback can bounce the user back into the MCP authorize flow.
 func TestHandleLogin_EncodesReturnToInOAuthState(t *testing.T) {
 	ua, _, _ := setupUserAuth(t)
 
-	returnTo := "/api/oauth/authorize?client_id=mcp_abc&response_type=code&state=xyz"
+	returnTo := "/oauth2/authorize?client_id=mcp_abc&response_type=code&state=xyz"
 	req := httptest.NewRequest(
 		http.MethodGet,
 		"/api/auth/login?return_to="+url.QueryEscape(returnTo),
@@ -152,14 +152,14 @@ func TestHandleLogin_RejectsReturnToOutsideAllowList(t *testing.T) {
 	bad := []string{
 		"/dashboard",                                    // wrong prefix
 		"/api/v1/agents",                                // wrong prefix
-		"https://evil.com/api/oauth/authorize",          // absolute
-		"//evil.com/api/oauth/authorize",                // protocol-relative
-		"/api/oauth/authorize\nSet-Cookie: x=y",         // header injection
+		"https://evil.com/oauth2/authorize",          // absolute
+		"//evil.com/oauth2/authorize",                // protocol-relative
+		"/oauth2/authorize\nSet-Cookie: x=y",         // header injection
 		"\\api\\oauth\\authorize",                       // backslash bypass
-		"http://localhost/api/oauth/authorize",          // scheme present
-		"/api/oauth/../../dashboard",                    // path traversal escaping the allow-list
-		"/api/oauth/../v1/agents",                       // path traversal into another API surface
-		"/api/oauth//evil.com/path",                     // empty segment after prefix
+		"http://localhost/oauth2/authorize",          // scheme present
+		"/oauth2/../../dashboard",                    // path traversal escaping the allow-list
+		"/oauth2/../v1/agents",                       // path traversal into another API surface
+		"/oauth2//evil.com/path",                     // empty segment after prefix
 	}
 	for _, rt := range bad {
 		t.Run(rt, func(t *testing.T) {
@@ -329,7 +329,7 @@ func TestHandleCallback_ReturnTo_BouncesUser(t *testing.T) {
 	ua, _, srv := setupUserAuthWithFakeOAuth(t)
 
 	nonce := "nonce-rt-bounce"
-	returnTo := "/api/oauth/authorize?client_id=mcp_abc&state=xyz"
+	returnTo := "/oauth2/authorize?client_id=mcp_abc&state=xyz"
 	state := auth.EncodeOAuthState(&auth.OAuthState{
 		Nonce:    nonce,
 		ReturnTo: returnTo,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -81,6 +81,16 @@ type OAuthConfig struct {
 	GoogleClientID     string `yaml:"google_client_id"`
 	GoogleClientSecret string `yaml:"google_client_secret"`
 	RedirectURL        string `yaml:"redirect_url"`
+	// SigningKey is the PEM-encoded RSA private key (PKCS#1 or PKCS#8) used to
+	// sign auth.md agent-identity JWTs + access tokens (Slice 5b). The public
+	// half is published at /.well-known/jwks.json. Empty ⇒ the agent-auth
+	// surface is disabled (JWKS serves an empty set). Supplied via
+	// E2A_OAUTH_SIGNING_KEY; never generated or persisted by e2a.
+	SigningKey string `yaml:"signing_key"`
+	// SigningKID is the key id advertised in the JWKS and stamped on every
+	// issued JWT (E2A_OAUTH_SIGNING_KID; default "v1"). Rotation advertises a
+	// new kid, then retires the old after the longest token TTL.
+	SigningKID string `yaml:"signing_kid"`
 }
 
 type SigningConfig struct {
@@ -205,6 +215,12 @@ func Load(path string) (*Config, error) {
 	}
 	if v := os.Getenv("E2A_OAUTH_REDIRECT_URL"); v != "" {
 		cfg.OAuth.RedirectURL = v
+	}
+	if v := os.Getenv("E2A_OAUTH_SIGNING_KEY"); v != "" {
+		cfg.OAuth.SigningKey = v
+	}
+	if v := os.Getenv("E2A_OAUTH_SIGNING_KID"); v != "" {
+		cfg.OAuth.SigningKID = v
 	}
 	if v := os.Getenv("E2A_OUTBOUND_SMTP_HOST"); v != "" {
 		cfg.OutboundSMTP.Host = v

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -78,10 +78,20 @@ signing:
 	t.Setenv("E2A_HMAC_SECRET", "override-secret")
 	t.Setenv("E2A_OUTBOUND_SMTP_USERNAME", "smtp-user")
 	t.Setenv("E2A_OUTBOUND_SMTP_PASSWORD", "smtp-pass")
+	// A non-PEM sentinel: the config layer only copies the string through to
+	// cfg.OAuth.SigningKey (parsing happens later in agentauth.NewSigner), so
+	// this needs no real key — and deliberately omits the "BEGIN ... PRIVATE
+	// KEY" armor so secret scanners don't false-positive on a test fixture.
+	t.Setenv("E2A_OAUTH_SIGNING_KEY", "signing-key-sentinel-not-a-real-pem")
+	t.Setenv("E2A_OAUTH_SIGNING_KID", "k7")
 
 	cfg, err := Load(cfgPath)
 	if err != nil {
 		t.Fatalf("Load failed: %v", err)
+	}
+
+	if cfg.OAuth.SigningKey == "" || cfg.OAuth.SigningKID != "k7" {
+		t.Errorf("expected env override for OAuth signing key/kid, got key=%q kid=%q", cfg.OAuth.SigningKey, cfg.OAuth.SigningKID)
 	}
 
 	if cfg.Database.URL != "postgres://override" {

--- a/mcp/src/http-server.ts
+++ b/mcp/src/http-server.ts
@@ -133,7 +133,11 @@ export function buildApp(opts: HttpServerOptions): BuiltApp {
     res.json({
       resource,
       authorization_servers: [opts.authorizationServerUrl ?? opts.baseUrl],
-      scopes_supported: ["mcp"],
+      // Scope vocabulary tracks the AS (Slice 5b): the lone "mcp" scope is
+      // retired. MCP clients connect as public DCR clients, which are capped at
+      // scope="agent" by the authorization server, so advertise that here so the
+      // protected-resource and AS metadata agree.
+      scopes_supported: ["agent"],
       bearer_methods_supported: ["header"],
     });
   });

--- a/mcp/tests/http.test.ts
+++ b/mcp/tests/http.test.ts
@@ -596,8 +596,9 @@ describe("HTTP MCP server", () => {
     // resource/resource_metadata values reflect the externally-
     // reachable URL exactly (the DNS-rebinding allowlist still gates
     // /mcp on the Host header — local dev adds 127.0.0.1 there too).
-    // Also pins the local "mcp" scope so the consent UI's scope-list
-    // aligns with the e2a backend.
+    // Also pins the advertised "agent" scope so the consent UI's scope-list
+    // aligns with the e2a backend (Slice 5b retired the lone "mcp" scope;
+    // MCP clients connect as public DCR clients, capped at scope=agent).
     await close();
     const { close: c, port } = await startHttpServer(0, {
       baseUrl: "http://e2a.local",
@@ -613,7 +614,7 @@ describe("HTTP MCP server", () => {
     expect(disc.status).toBe(200);
     const meta = await disc.json();
     expect(meta.resource).toBe("http://localhost:8765");
-    expect(meta.scopes_supported).toEqual(["mcp"]);
+    expect(meta.scopes_supported).toEqual(["agent"]);
 
     // 401 on /mcp without bearer: WWW-Authenticate's resource_metadata
     // URL must use publicUrl, not "https://127.0.0.1:port".

--- a/web/Caddyfile
+++ b/web/Caddyfile
@@ -26,11 +26,22 @@
         reverse_proxy {$E2A_BACKEND:http://e2a:8080}
     }
 
-    # RFC 8414 OAuth authorization-server metadata. Lives at the
-    # well-known path (NOT under /api/*) per spec, so it needs its
-    # own proxy rule. Without this the web frontend would return
-    # a 404 HTML page when OAuth clients probe for discovery.
+    # OAuth 2.1 surface (Slice 5b renamed it from /api/oauth/* to /oauth2/*,
+    # which the /api/* rule above no longer covers). Authorize / token /
+    # consent / revoke / register / clients all live here and must reach the
+    # backend, or the entire OAuth flow 404s behind the proxy.
+    handle /oauth2/* {
+        reverse_proxy {$E2A_BACKEND:http://e2a:8080}
+    }
+
+    # Discovery + JWKS metadata. Live at well-known paths (NOT under /api/*)
+    # per spec, so they need their own proxy rules. Without these the web
+    # frontend returns a 404 HTML page when OAuth clients probe for the
+    # authorization-server metadata or the JWKS that verifies e2a-minted JWTs.
     handle /.well-known/oauth-authorization-server {
+        reverse_proxy {$E2A_BACKEND:http://e2a:8080}
+    }
+    handle /.well-known/jwks.json {
         reverse_proxy {$E2A_BACKEND:http://e2a:8080}
     }
 

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -11,6 +11,12 @@ const nextConfig: NextConfig = {
   ...(isDev && {
     rewrites: async () => [
       { source: "/api/:path*", destination: "http://localhost:8080/api/:path*" },
+      // OAuth surface moved to /oauth2/* (Slice 5b) — proxy it (and the JWKS +
+      // AS discovery docs the backend owns) to the Go server in dev, mirroring
+      // the Caddyfile in prod. Without these the consent UI + token flow 404.
+      { source: "/oauth2/:path*", destination: "http://localhost:8080/oauth2/:path*" },
+      { source: "/.well-known/jwks.json", destination: "http://localhost:8080/.well-known/jwks.json" },
+      { source: "/.well-known/oauth-authorization-server", destination: "http://localhost:8080/.well-known/oauth-authorization-server" },
     ],
   }),
 };

--- a/web/public/auth.md
+++ b/web/public/auth.md
@@ -9,7 +9,7 @@ Two hosts are relevant:
 
 ## Current state
 
-e2a already implements the OAuth 2.0 surface that MCP clients depend on: RFC 8414 authorization-server metadata at [`/.well-known/oauth-authorization-server`](https://e2a.dev/.well-known/oauth-authorization-server), RFC 7591 Dynamic Client Registration at `/api/oauth/register` (rate-limited per IP), `authorization_code` + `refresh_token` grants with PKCE S256, RFC 7009 revocation, and RFC 6750 Bearer challenges on 401s. MCP clients can register and onboard without any human-supplied secret — the user only sees a browser consent screen.
+e2a already implements the OAuth 2.0 surface that MCP clients depend on: RFC 8414 authorization-server metadata at [`/.well-known/oauth-authorization-server`](https://e2a.dev/.well-known/oauth-authorization-server), RFC 7591 Dynamic Client Registration at `/oauth2/register` (rate-limited per IP), `authorization_code` + `refresh_token` grants with PKCE S256, RFC 7009 revocation, and RFC 6750 Bearer challenges on 401s. MCP clients can register and onboard without any human-supplied secret — the user only sees a browser consent screen.
 
 What e2a does **not** yet implement is the WorkOS [auth.md](https://github.com/workos/auth.md) flow specifically: there is no `/agent/auth` endpoint, no `agent_auth` block in the AS metadata, no RFC 9728 protected-resource metadata document, no ID-JAG verification, and no email-OTP claim ceremony. See [Agent identity](#agent-identity) for where we're heading — e2a's product (agent email addresses verified end-to-end) is unusually well-positioned to act as an identity provider in this protocol, and that's the direction we're building.
 
@@ -38,7 +38,7 @@ If you are an MCP client, you do not need an API key. Run the standard discovery
 
 1. **Discover** — `GET https://e2a.dev/.well-known/oauth-authorization-server`. Read `registration_endpoint`, `authorization_endpoint`, `token_endpoint`. Scope to request: `mcp`.
 2. **Register** — `POST` your client metadata to `registration_endpoint` (RFC 7591). You'll receive a `client_id`. Token endpoint auth method is `none` — you are a public client.
-3. **Authorize** — redirect the user to `authorization_endpoint` with `response_type=code`, your `client_id`, `redirect_uri`, `scope=mcp`, and PKCE S256 (`code_challenge`, `code_challenge_method=S256`). The user logs in to e2a and consents.
+3. **Authorize** — redirect the user to `authorization_endpoint` with `response_type=code`, your `client_id`, `redirect_uri`, `scope=agent`, and PKCE S256 (`code_challenge`, `code_challenge_method=S256`). The user logs in to e2a and consents.
 4. **Token exchange** — `POST` `code` + `code_verifier` to `token_endpoint`. You receive `access_token` (prefix `ate2a_…`) and `refresh_token`.
 5. **Use** — present the access token as a bearer; refresh with the refresh token before `expires_in`.
 
@@ -159,7 +159,7 @@ No code reading, no copy-paste, no transcript leakage. This is uniquely possible
 
 What e2a publishes today:
 
-- **RFC 8414 authorization-server metadata** at [`https://e2a.dev/.well-known/oauth-authorization-server`](https://e2a.dev/.well-known/oauth-authorization-server) — advertises `authorization_endpoint`, `token_endpoint`, `registration_endpoint`, `revocation_endpoint`, supported grants (`authorization_code`, `refresh_token`), PKCE (`S256`), scope (`mcp`), and the RFC 9207 `iss` parameter.
+- **RFC 8414 authorization-server metadata** at [`https://e2a.dev/.well-known/oauth-authorization-server`](https://e2a.dev/.well-known/oauth-authorization-server) — advertises `authorization_endpoint`, `token_endpoint`, `registration_endpoint`, `revocation_endpoint`, supported grants (`authorization_code`, `refresh_token`), PKCE (`S256`), scopes (`agent`, `account`), and the RFC 9207 `iss` parameter.
 - **RFC 6750 Bearer challenges** on every 401 from `/api/v1/...` — `WWW-Authenticate: Bearer realm="e2a"` for unknown/missing credentials, plus RFC 6750 §3.1 error params for OAuth-bearer failures.
 
 What's missing for full auth.md compliance:
@@ -173,7 +173,7 @@ These will land together. When they do, this document will be updated and the AS
 
 ## Revocation
 
-The user revokes API keys in the e2a dashboard. OAuth access tokens are revoked via `POST /api/oauth/revoke` (RFC 7009) or by the user disconnecting the client in the dashboard. Either way, you will discover revocation as a `401` on a previously-working credential — drop it and re-acquire from the same source you loaded it from. Once e2a issues ID-JAGs, providers will be able to POST logout tokens to a `revocation_uri` advertised in AS metadata; that is not in scope for the current credential paths.
+The user revokes API keys in the e2a dashboard. OAuth access tokens are revoked via `POST /oauth2/revoke` (RFC 7009) or by the user disconnecting the client in the dashboard. Either way, you will discover revocation as a `401` on a previously-working credential — drop it and re-acquire from the same source you loaded it from. Once e2a issues ID-JAGs, providers will be able to POST logout tokens to a `revocation_uri` advertised in AS metadata; that is not in scope for the current credential paths.
 
 ## References
 

--- a/web/src/app/oauth/consent/page.test.tsx
+++ b/web/src/app/oauth/consent/page.test.tsx
@@ -61,7 +61,7 @@ const VALID_QS =
   "&code_challenge=test_challenge_value" +
   "&code_challenge_method=S256" +
   "&state=opaque-state-xyz" +
-  "&scope=mcp";
+  "&scope=agent";
 
 function mockClientAndAgents(opts: {
   clientStatus?: number;
@@ -73,12 +73,12 @@ function mockClientAndAgents(opts: {
     client_id: "mcp_abc123",
     client_name: "Test MCP Client",
     redirect_uris: ["http://localhost:8765/cb"],
-    scopes: ["mcp"],
+    scopes: ["agent"],
     client_id_issued_at: 1700000000,
   };
   const agents = opts.agents ?? [];
   mockFetch.mockImplementation((url: string) => {
-    if (url.startsWith("/api/oauth/clients/")) {
+    if (url.startsWith("/oauth2/clients/")) {
       return Promise.resolve({
         ok: clientStatus === 200,
         status: clientStatus,
@@ -176,7 +176,7 @@ describe("ConsentPage", () => {
     const form = container.querySelector("form") as HTMLFormElement;
     expect(form).toBeTruthy();
     expect(form.method.toLowerCase()).toBe("post");
-    expect(form.getAttribute("action")).toBe("/api/oauth/consent");
+    expect(form.getAttribute("action")).toBe("/oauth2/consent");
 
     // Every OAuth param ends up as a hidden input.
     const hiddenByName = new Map<string, string>();
@@ -190,7 +190,7 @@ describe("ConsentPage", () => {
     expect(hiddenByName.get("code_challenge")).toBe("test_challenge_value");
     expect(hiddenByName.get("code_challenge_method")).toBe("S256");
     expect(hiddenByName.get("state")).toBe("opaque-state-xyz");
-    expect(hiddenByName.get("scope")).toBe("mcp");
+    expect(hiddenByName.get("scope")).toBe("agent");
 
     // With no existing agents, create_new is the default.
     const createRadio = screen.getByRole("radio", { name: /Create a new inbox/i }) as HTMLInputElement;

--- a/web/src/app/oauth/consent/page.tsx
+++ b/web/src/app/oauth/consent/page.tsx
@@ -8,7 +8,7 @@ import type { DashboardAgent } from "../../components/types";
 
 // Required OAuth params the consent screen needs. If any is missing
 // we refuse to render the form — the request didn't come from a real
-// /api/oauth/authorize and pushing forward would either tamper-fail
+// /oauth2/authorize and pushing forward would either tamper-fail
 // at the backend or, worse, submit half-baked params that fosite
 // silently defaults.
 const REQUIRED_PARAMS = [
@@ -86,7 +86,7 @@ function ConsentInner() {
     // the cancelled flag prevents a stale resolution from clobbering
     // a fresh one. Worst case (rare): user sees the previous error
     // for the brief window before the new fetch settles — acceptable.
-    fetch(`/api/oauth/clients/${encodeURIComponent(clientID)}`, {
+    fetch(`/oauth2/clients/${encodeURIComponent(clientID)}`, {
       credentials: "include",
     })
       .then(async (r) => {
@@ -149,7 +149,7 @@ function ConsentInner() {
         </ul>
         <p className="text-muted text-sm">
           This screen is reached from{" "}
-          <code>/api/oauth/authorize</code>. If you arrived here directly,
+          <code>/oauth2/authorize</code>. If you arrived here directly,
           start the flow from your MCP client.
         </p>
       </ConsentShell>
@@ -161,12 +161,12 @@ function ConsentInner() {
   }
 
   // Not signed in → bounce through Google login carrying return_to so
-  // the user lands back on /api/oauth/authorize (which then re-renders
+  // the user lands back on /oauth2/authorize (which then re-renders
   // this page with a session). We construct return_to from the same
   // params so the round-trip preserves everything.
   if (!user) {
     const qs = new URLSearchParams(params).toString();
-    const returnTo = `/api/oauth/authorize?${qs}`;
+    const returnTo = `/oauth2/authorize?${qs}`;
     const loginURL = `/api/auth/login?return_to=${encodeURIComponent(returnTo)}`;
     return (
       <ConsentShell>
@@ -196,7 +196,7 @@ function ConsentInner() {
         <p className="text-muted text-sm mb-4">{clientError}</p>
         <p className="text-muted text-sm">
           The client must register via{" "}
-          <code>/api/oauth/register</code> before requesting authorization.
+          <code>/oauth2/register</code> before requesting authorization.
         </p>
       </ConsentShell>
     );
@@ -301,7 +301,7 @@ function ConsentForm({
         </div>
       )}
 
-      <form method="POST" action="/api/oauth/consent" className="space-y-4">
+      <form method="POST" action="/oauth2/consent" className="space-y-4">
         {Object.entries(params).map(([k, v]) => (
           <input key={k} type="hidden" name={k} value={v} />
         ))}


### PR DESCRIPTION
## Slice 5b-1 — Auth foundation

The pre-token-issuing foundation the auth.md agent-identity paths build on (design §5 / Slice 5b). Two product decisions, both made by the maintainer: **signing key via env/PEM** (mirrors the sibling agentdrive deployment) and **clean route rename, no back-compat alias**.

### What's in this slice
- **`internal/agentauth`** — RS256 JWT signer loaded from a PEM private key (`E2A_OAUTH_SIGNING_KEY` + `E2A_OAUTH_SIGNING_KID`, default kid `v1`). Operator-supplied, **never generated or persisted** by e2a. Empty key ⇒ surface **disabled** (`sign → ErrSigningDisabled`, JWKS → empty set) so deployments not using agent identity run unchanged; a malformed key is **fatal at startup** (fail fast). PKCS#1 + PKCS#8 accepted; non-RSA rejected.
- **`GET /.well-known/jwks.json`** — publishes the public key (kid, `use=sig`, RS256, **public-only**); serves `{"keys":[]}` when unconfigured (never 404).
- **Route rename** `/api/oauth/*` → `/oauth2/*` (root, unversioned; **no alias** per §1). Updated the discovery doc, the login `return_to` allow-list (`validateReturnToPath`), and the web consent page (fetch/returnTo/form action) in lockstep.
- **Discovery** — endpoints → `/oauth2/*`; added `jwks_uri`; `scopes_supported` `["mcp"]` → `["agent","account"]`; **DCR public clients capped at `scope="agent"`** (account requires console issuance).

### Deferred to later 5b sub-slices (NOT advertised prematurely)
The `agent_auth` discovery block + `jwt-bearer` grant wait for **5b-2** (advertising identity/claim endpoints while they 404 would lie to clients). 5b-2 autonomous path (`POST /agent/identity`, JWKS registration gated by domain ownership, the custom jwt-bearer token handler); 5b-3 claim ceremony; 5b-4 `act` delegation + kill switch. WorkOS AuthKit human sign-in stays independent of the agent-token layer.

### Verification
- `agentauth`, `config`, `agent`, `auth`, `oauth` (`-p 1`) ✅; `TestSpecGoldenNoDrift` ✅; web consent test ✅ (8/8).
- **Real-binary over-the-wire e2e** (fresh DB + RSA key on :8092): JWKS publishes public-only key (kid/RS256/no `d`); discovery shows `/oauth2/*` + `[agent,account]` + `jwks_uri`; old `/api/oauth/register` → **404**; `/oauth2/register` scope=agent → **201**; scope=account → **400** (capped). Disabled-key path → empty JWKS (unit-covered over HTTP). Server log clean.
- Tests: sign/verify round-trip (PKCS#1+#8, disabled, malformed, public-only JWK); HTTP JWKS enabled/disabled; discovery scopes+jwks_uri; DCR scope cap; config env override.

### Breaking change (intended, §1)
The OAuth surface moved to `/oauth2/*` with no alias — any MCP client already connected at `/api/oauth/*` must re-discover. Per the maintainer's explicit decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)