### PR TITLE
feat(auth): Slice 5b-2 — autonomous agent token path (auth.md jwt-bearer)

### DIFF
--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -1310,13 +1310,35 @@ Break the current `/api/v1` surface directly and move it to
       `agent_auth` discovery block + `jwt-bearer` grant are **deferred to 5b-2**
       (advertising endpoints that don't exist yet would lie to clients).
 
-    **Deferred to later 5b sub-slices:** 5b-2 autonomous path (`POST
-    /agent/identity`, JWKS registration gated by domain ownership, the custom
-    `grant_type=jwt-bearer` token handler + the `agent_auth` discovery block);
-    5b-3 claim ceremony (email-OTP, `claim` grant); 5b-4 `act` delegation +
-    compromised-key kill switch + `agent.credential_revoked`. WorkOS AuthKit
-    human sign-in stays independent of the agent-token layer (pluggable, hosted
-    default) and off 5b's critical path.
+  * **Slice 5b-2 — Autonomous agent token path.** *(Shipped.)* The auth.md
+    jwt-bearer rails, server-signed model (decided: e2a follows **canonical
+    auth.md** — anonymous/claim/ID-JAG entry points into one server-signed token
+    system — **not** §5's self-signed-agent-key bridge, which agentdrive also
+    skipped and which deviates from the spec we adopt):
+    * `POST /agent/identity` — **bootstrap adapted for e2a's domain model**:
+      agentdrive's ownerless "anonymous self-provision" is unsafe for e2a (an
+      identity is an email on a *verified domain*), so the bootstrap credential
+      is the Slice-5a `e2a_agt_` key. Present it → receive a server-signed
+      `identity_assertion` JWT (`sub`=agent email, `scope=agent`,
+      `assertion_version`, 30-day TTL).
+    * `POST /oauth2/token` `grant_type=jwt-bearer` — the custom token handler
+      (fosite has no jwt-bearer): verify the assertion, re-check
+      `assertion_version` against the live row, mint a short-lived (15-min)
+      `access_token` JWT. No refresh — re-present the assertion.
+    * **Resource server accepts the `access_token`** as an `agent`-scoped
+      principal (composes with the 5a hard ceiling: an agent JWT is 403'd on
+      account-only routes, 200 on its own agent — proven over the wire).
+    * `agent_identities.assertion_version` (migration 035) is the **kill
+      switch**; discovery now carries the `agent_auth` block + the jwt-bearer
+      grant (advertised only when a signing key is configured). Proxies
+      (`Caddyfile`/`next.config`) route `/agent/identity`.
+
+    **Deferred to later 5b sub-slices:** 5b-3 claim ceremony (the human-connected
+    path: `user_code`/consent page + `claim` grant — same server-signed rails);
+    5b-4 ID-JAG provider assertions + `act` delegation + compromised-key revoke
+    event (`agent.credential_revoked`). WorkOS AuthKit human sign-in stays
+    independent of the agent-token layer (pluggable, hosted default) and off 5b's
+    critical path.
 * **Slice 6 — Agent-first docs.** `e2a.md`/`llms.txt`/`setup.md`/`auth.md`,
   binary-served; `api.md` generated from the spec.
 * **Slice 7 — Inbound trust policy (decision 10), post-parity.** Builds on

--- a/internal/agent/agent_identity.go
+++ b/internal/agent/agent_identity.go
@@ -168,6 +168,13 @@ func (a *API) resolveAgentAccessToken(r *http.Request, bearer string) (*identity
 	if err != nil || ag == nil {
 		return nil, true, errors.New("agent not found for access token")
 	}
+	// Kill switch, re-checked per request (the agent row is already loaded, so
+	// this is free): a bumped assertion_version invalidates outstanding access
+	// tokens immediately rather than only starving new mints — revocation is
+	// instant, not bounded by the 15-min token TTL.
+	if ag.AssertionVersion != claims.AssertionVersion {
+		return nil, true, errors.New("access token revoked (stale assertion_version)")
+	}
 	user, err := a.store.GetUserByID(r.Context(), ag.UserID)
 	if err != nil || user == nil {
 		return nil, true, errors.New("owner not found for access token")

--- a/internal/agent/agent_identity.go
+++ b/internal/agent/agent_identity.go
@@ -1,0 +1,183 @@
+package agent
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Mnexa-AI/e2a/internal/agentauth"
+	"github.com/Mnexa-AI/e2a/internal/identity"
+)
+
+// auth.md autonomous agent-identity path (Slice 5b-2). Two endpoints implement
+// the token rails on top of the 5b-1 signer:
+//
+//   POST /agent/identity         — bootstrap: an agent presents its e2a_agt_ key
+//                                  and receives a long-lived identity_assertion.
+//   POST /oauth2/token           — grant_type=jwt-bearer: present the assertion,
+//   (grant_type=jwt-bearer)        receive a short-lived access_token.
+//
+// e2a-specific adaptation of auth.md: agentdrive's "anonymous" path lets anyone
+// self-provision an identity, which e2a cannot allow — its identities are
+// emails on verified domains. So the bootstrap credential is the agent-scoped
+// API key from Slice 5a (already gated by domain ownership at mint time), not
+// an ownerless self-registration.
+
+// jwtBearerGrantType is the RFC 7523 grant URN auth.md uses for the autonomous
+// path. fosite doesn't ship it, so the token endpoint dispatches it here before
+// falling through to fosite's authorization_code/refresh_token handling.
+const jwtBearerGrantType = "urn:ietf:params:oauth:grant-type:jwt-bearer"
+
+// agentAuthIssuer is the iss/aud bound into every minted token — the AS public
+// URL, trailing slash trimmed so it's byte-stable with the discovery doc.
+func (a *API) agentAuthIssuer() string { return strings.TrimRight(a.publicURL, "/") }
+
+// agentAuthReady reports whether the agent-identity surface is usable: a signing
+// key AND a public URL (needed for iss/aud) must both be configured.
+func (a *API) agentAuthReady() bool {
+	return a.signer != nil && a.signer.Enabled() && a.publicURL != ""
+}
+
+type identityAssertionResponse struct {
+	IdentityAssertion string `json:"identity_assertion"`
+	TokenType         string `json:"token_type"`
+	Subject           string `json:"sub"`
+	ExpiresAt         string `json:"expires_at"`
+}
+
+// handleAgentIdentity is POST /agent/identity. In Slice 5b-2 it serves the
+// bootstrap: authenticate the caller's agent-scoped credential and mint an
+// identity_assertion for that one agent. (anonymous/ID-JAG registration types
+// are later sub-slices; an unknown/auth-less request is rejected, not
+// silently self-provisioned.)
+func (a *API) handleAgentIdentity(w http.ResponseWriter, r *http.Request) {
+	if !a.agentAuthReady() {
+		writeOAuthError(w, http.StatusNotImplemented, "not_implemented",
+			"agent identity is not enabled on this deployment")
+		return
+	}
+	// Bootstrap auth: the agent presents its e2a_agt_ key (Slice 5a). The
+	// credential must be agent-scoped and bound to a specific agent — an
+	// account-scoped key has no single agent to assert for.
+	p, err := a.authenticatePrincipal(r)
+	if err != nil {
+		a.writeAuthError(w, r, err)
+		return
+	}
+	if p.Scope != identity.ScopeAgent || p.AgentID == "" {
+		writeOAuthError(w, http.StatusForbidden, "forbidden",
+			"agent identity requires an agent-scoped credential bound to one agent")
+		return
+	}
+
+	// Load the agent for its current assertion_version (the kill-switch
+	// counter stamped into the token).
+	ag, err := a.store.GetAgentByID(r.Context(), p.AgentID)
+	if err != nil || ag == nil || ag.UserID != p.User.ID {
+		writeOAuthError(w, http.StatusForbidden, "forbidden", "agent not found")
+		return
+	}
+
+	assertion, exp, err := a.signer.SignIdentityAssertion(ag.ID, identity.ScopeAgent, ag.AssertionVersion, a.agentAuthIssuer())
+	if err != nil {
+		writeOAuthError(w, http.StatusInternalServerError, "server_error", "failed to mint identity assertion")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	_ = json.NewEncoder(w).Encode(identityAssertionResponse{
+		IdentityAssertion: assertion,
+		TokenType:         "N_A", // an assertion is presented at /oauth2/token, not used as a bearer
+		Subject:           ag.ID,
+		ExpiresAt:         exp.UTC().Format(time.RFC3339),
+	})
+}
+
+type accessTokenResponse struct {
+	AccessToken string `json:"access_token"`
+	TokenType   string `json:"token_type"`
+	ExpiresIn   int    `json:"expires_in"`
+	Scope       string `json:"scope"`
+}
+
+// handleJWTBearerGrant implements grant_type=jwt-bearer at /oauth2/token: verify
+// the presented identity_assertion, re-check its assertion_version against the
+// live agent row (the kill switch), and mint a short-lived access_token.
+// Returns RFC 6749 §5.2 error bodies.
+func (a *API) handleJWTBearerGrant(w http.ResponseWriter, r *http.Request) {
+	if !a.agentAuthReady() {
+		writeOAuthError(w, http.StatusNotImplemented, "unsupported_grant_type",
+			"agent identity is not enabled on this deployment")
+		return
+	}
+	assertion := strings.TrimSpace(r.PostForm.Get("assertion"))
+	if assertion == "" {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_request", "assertion is required")
+		return
+	}
+	claims, err := a.signer.VerifyToken(assertion, agentauth.TypIdentityAssertion, a.agentAuthIssuer())
+	if err != nil {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "identity assertion is invalid or expired")
+		return
+	}
+	// Freshness / kill switch: the assertion's assertion_version must match the
+	// live agent row. A bump (revocation) makes every prior assertion stale.
+	ag, err := a.store.GetAgentByID(r.Context(), claims.Subject)
+	if err != nil || ag == nil {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "agent not found")
+		return
+	}
+	if ag.AssertionVersion != claims.AssertionVersion {
+		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "assertion is stale; re-acquire an identity assertion")
+		return
+	}
+
+	token, exp, err := a.signer.SignAccessToken(ag.ID, identity.ScopeAgent, ag.AssertionVersion, a.agentAuthIssuer())
+	if err != nil {
+		writeOAuthError(w, http.StatusInternalServerError, "server_error", "failed to mint access token")
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	_ = json.NewEncoder(w).Encode(accessTokenResponse{
+		AccessToken: token,
+		TokenType:   "Bearer",
+		ExpiresIn:   int(time.Until(exp).Seconds()),
+		Scope:       identity.ScopeAgent,
+	})
+}
+
+// resolveAgentAccessToken verifies an e2a-minted access_token JWT and resolves
+// it to an agent-scoped principal. Returns (nil, false, nil) when the bearer is
+// not one of our JWTs (so the caller can fall through to API-key/OAuth paths);
+// returns an error only when it IS our JWT but fails verification or lookup.
+func (a *API) resolveAgentAccessToken(r *http.Request, bearer string) (*identity.Principal, bool, error) {
+	if !a.agentAuthReady() || !looksLikeJWT(bearer) {
+		return nil, false, nil
+	}
+	claims, err := a.signer.VerifyToken(bearer, agentauth.TypAccessToken, a.agentAuthIssuer())
+	if err != nil {
+		// It parses as a JWT but isn't a valid e2a access token — reject
+		// rather than fall through (a tampered/expired token is a 401, not an
+		// API-key probe).
+		return nil, true, errors.New("invalid agent access token")
+	}
+	ag, err := a.store.GetAgentByID(r.Context(), claims.Subject)
+	if err != nil || ag == nil {
+		return nil, true, errors.New("agent not found for access token")
+	}
+	user, err := a.store.GetUserByID(r.Context(), ag.UserID)
+	if err != nil || user == nil {
+		return nil, true, errors.New("owner not found for access token")
+	}
+	return &identity.Principal{User: user, Scope: identity.ScopeAgent, AgentID: ag.ID}, true, nil
+}
+
+// looksLikeJWT is a cheap pre-filter: a compact JWS is three base64url segments
+// separated by dots and (for our RS256 tokens) starts with the "eyJ" header.
+// Avoids running full verification on API keys / opaque OAuth tokens.
+func looksLikeJWT(s string) bool {
+	return strings.HasPrefix(s, "eyJ") && strings.Count(s, ".") == 2
+}

--- a/internal/agent/agent_identity_test.go
+++ b/internal/agent/agent_identity_test.go
@@ -191,6 +191,51 @@ func TestAgentIdentity_StaleAssertionRejected(t *testing.T) {
 	}
 }
 
+// TestAgentIdentity_AccessTokenRevokedOnVersionBump: bumping assertion_version
+// invalidates an already-minted access_token at the resource server on the very
+// next request — revocation is instant, not bounded by the 15-min TTL (review
+// fix; the agent row is loaded during resolution, so the check is free).
+func TestAgentIdentity_AccessTokenRevokedOnVersionBump(t *testing.T) {
+	f := newAgentIDFixture(t)
+
+	// Mint assertion → access_token.
+	req, _ := http.NewRequest("POST", f.srv.URL+"/agent/identity", nil)
+	req.Header.Set("Authorization", "Bearer "+f.apiKey)
+	resp, _ := http.DefaultClient.Do(req)
+	var idResp struct {
+		IdentityAssertion string `json:"identity_assertion"`
+	}
+	json.NewDecoder(resp.Body).Decode(&idResp)
+	resp.Body.Close()
+	form := url.Values{"grant_type": {"urn:ietf:params:oauth:grant-type:jwt-bearer"}, "assertion": {idResp.IdentityAssertion}}
+	resp2, _ := http.PostForm(f.srv.URL+"/oauth2/token", form)
+	var tokResp struct {
+		AccessToken string `json:"access_token"`
+	}
+	json.NewDecoder(resp2.Body).Decode(&tokResp)
+	resp2.Body.Close()
+
+	// The token works before revocation.
+	areq, _ := http.NewRequest("GET", "/", nil)
+	areq.Header.Set("Authorization", "Bearer "+tokResp.AccessToken)
+	if _, err := f.api.AuthenticatePrincipal(areq); err != nil {
+		t.Fatalf("access token should be valid pre-revocation: %v", err)
+	}
+
+	// Kill switch: bump assertion_version.
+	if _, err := f.pool.Exec(context.Background(),
+		`UPDATE agent_identities SET assertion_version = assertion_version + 1 WHERE id = $1`, f.agent.ID); err != nil {
+		t.Fatalf("bump: %v", err)
+	}
+
+	// The already-minted access token is now rejected immediately.
+	areq2, _ := http.NewRequest("GET", "/", nil)
+	areq2.Header.Set("Authorization", "Bearer "+tokResp.AccessToken)
+	if _, err := f.api.AuthenticatePrincipal(areq2); err == nil {
+		t.Error("access token must be revoked instantly on assertion_version bump")
+	}
+}
+
 // TestAgentIdentity_TamperedAccessTokenRejected: a JWT we didn't sign (or a
 // mangled one) is rejected at the resource server, not treated as an API key.
 func TestAgentIdentity_TamperedAccessTokenRejected(t *testing.T) {

--- a/internal/agent/agent_identity_test.go
+++ b/internal/agent/agent_identity_test.go
@@ -1,0 +1,215 @@
+package agent_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/agent"
+	"github.com/Mnexa-AI/e2a/internal/agentauth"
+	"github.com/Mnexa-AI/e2a/internal/config"
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/outbound"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+	"github.com/Mnexa-AI/e2a/internal/usage"
+	"github.com/gorilla/mux"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Slice 5b-2 — the autonomous agent-identity flow, DB-backed end to end:
+//   e2a_agt_ key → POST /agent/identity → identity_assertion
+//                → POST /oauth2/token (jwt-bearer) → access_token
+//                → access_token resolves to the agent principal.
+
+type agentIDFixture struct {
+	srv    *httptest.Server
+	store  *identity.Store
+	pool   *pgxpool.Pool
+	api    *agent.API
+	agent  *identity.AgentIdentity
+	user   *identity.User
+	apiKey string // plaintext e2a_agt_ key bound to the agent
+}
+
+func newAgentIDFixture(t *testing.T) *agentIDFixture {
+	t.Helper()
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	smtpRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{})
+	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
+	api := agent.NewAPI(store, sender, smtpRelay, nil, usage.NewNoopUsageTracker(),
+		"e2a.dev", "test.e2a.dev", "agents.e2a.dev", "https://test.e2a.dev", false)
+
+	// Real RS256 signer — the agent-identity surface requires it.
+	pemKey := testRSAPEM(t)
+	signer, err := agentauth.NewSigner(pemKey, "v1")
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	api.SetSigner(signer)
+
+	router := mux.NewRouter()
+	api.RegisterRoutes(router)
+	srv := httptest.NewServer(router)
+	t.Cleanup(srv.Close)
+
+	ctx := context.Background()
+	user, err := store.CreateOrGetUser(ctx, "owner@authflow.example.com", "Owner", "google-authflow")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	if _, err := store.ClaimOrCreateDomain(ctx, "authflow.example.com", user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+	ag, err := store.CreateAgent(ctx, "bot@authflow.example.com", "authflow.example.com", "", "", "", user.ID)
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	key, err := store.CreateScopedAPIKey(ctx, user.ID, "runtime", identity.ScopeAgent, ag.ID, nil)
+	if err != nil {
+		t.Fatalf("CreateScopedAPIKey: %v", err)
+	}
+	return &agentIDFixture{srv: srv, store: store, pool: pool, api: api, agent: ag, user: user, apiKey: key.PlaintextKey}
+}
+
+// TestAgentIdentity_FullFlow drives the whole autonomous path over HTTP.
+func TestAgentIdentity_FullFlow(t *testing.T) {
+	f := newAgentIDFixture(t)
+
+	// 1. Bootstrap: present the e2a_agt_ key → identity_assertion.
+	req, _ := http.NewRequest("POST", f.srv.URL+"/agent/identity", nil)
+	req.Header.Set("Authorization", "Bearer "+f.apiKey)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("/agent/identity status %d", resp.StatusCode)
+	}
+	var idResp struct {
+		IdentityAssertion string `json:"identity_assertion"`
+		Subject           string `json:"sub"`
+	}
+	json.NewDecoder(resp.Body).Decode(&idResp)
+	resp.Body.Close()
+	if idResp.IdentityAssertion == "" || idResp.Subject != "bot@authflow.example.com" {
+		t.Fatalf("bad identity response: %+v", idResp)
+	}
+
+	// 2. Exchange the assertion for an access_token (jwt-bearer).
+	form := url.Values{"grant_type": {"urn:ietf:params:oauth:grant-type:jwt-bearer"}, "assertion": {idResp.IdentityAssertion}}
+	resp2, err := http.PostForm(f.srv.URL+"/oauth2/token", form)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp2.StatusCode != 200 {
+		t.Fatalf("/oauth2/token status %d", resp2.StatusCode)
+	}
+	var tokResp struct {
+		AccessToken string `json:"access_token"`
+		TokenType   string `json:"token_type"`
+		ExpiresIn   int    `json:"expires_in"`
+		Scope       string `json:"scope"`
+	}
+	json.NewDecoder(resp2.Body).Decode(&tokResp)
+	resp2.Body.Close()
+	if tokResp.AccessToken == "" || tokResp.TokenType != "Bearer" || tokResp.Scope != "agent" {
+		t.Fatalf("bad token response: %+v", tokResp)
+	}
+	if tokResp.ExpiresIn < 60 || tokResp.ExpiresIn > 16*60 {
+		t.Errorf("expires_in = %d, want ~900s", tokResp.ExpiresIn)
+	}
+
+	// 3. The access_token resolves to the bound agent principal.
+	areq, _ := http.NewRequest("GET", "/", nil)
+	areq.Header.Set("Authorization", "Bearer "+tokResp.AccessToken)
+	p, err := f.api.AuthenticatePrincipal(areq)
+	if err != nil {
+		t.Fatalf("AuthenticatePrincipal(access_token): %v", err)
+	}
+	if p.Scope != identity.ScopeAgent || p.AgentID != "bot@authflow.example.com" || p.User.ID != f.user.ID {
+		t.Errorf("principal = %+v, want agent-scoped bound to bot@authflow.example.com", p)
+	}
+}
+
+// TestAgentIdentity_AccountKeyRejected: an account-scoped key cannot mint an
+// identity_assertion (no single agent to assert for).
+func TestAgentIdentity_AccountKeyRejected(t *testing.T) {
+	f := newAgentIDFixture(t)
+	acctKey, err := f.store.CreateAPIKey(context.Background(), f.user.ID, "acct", nil)
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+	req, _ := http.NewRequest("POST", f.srv.URL+"/agent/identity", nil)
+	req.Header.Set("Authorization", "Bearer "+acctKey.PlaintextKey)
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+	if resp.StatusCode != 403 {
+		t.Errorf("account key on /agent/identity: status %d, want 403", resp.StatusCode)
+	}
+}
+
+// TestAgentIdentity_StaleAssertionRejected: bumping assertion_version (the kill
+// switch) invalidates an already-issued identity_assertion at exchange time.
+func TestAgentIdentity_StaleAssertionRejected(t *testing.T) {
+	f := newAgentIDFixture(t)
+
+	req, _ := http.NewRequest("POST", f.srv.URL+"/agent/identity", nil)
+	req.Header.Set("Authorization", "Bearer "+f.apiKey)
+	resp, _ := http.DefaultClient.Do(req)
+	var idResp struct {
+		IdentityAssertion string `json:"identity_assertion"`
+	}
+	json.NewDecoder(resp.Body).Decode(&idResp)
+	resp.Body.Close()
+
+	// Kill switch: bump the agent's assertion_version out from under the token.
+	if _, err := f.pool.Exec(context.Background(),
+		`UPDATE agent_identities SET assertion_version = assertion_version + 1 WHERE id = $1`, f.agent.ID); err != nil {
+		t.Fatalf("bump assertion_version: %v", err)
+	}
+
+	form := url.Values{"grant_type": {"urn:ietf:params:oauth:grant-type:jwt-bearer"}, "assertion": {idResp.IdentityAssertion}}
+	resp2, _ := http.PostForm(f.srv.URL+"/oauth2/token", form)
+	defer resp2.Body.Close()
+	if resp2.StatusCode != 400 {
+		t.Fatalf("stale assertion exchange: status %d, want 400", resp2.StatusCode)
+	}
+	var errResp struct {
+		Error string `json:"error"`
+	}
+	json.NewDecoder(resp2.Body).Decode(&errResp)
+	if errResp.Error != "invalid_grant" {
+		t.Errorf("error = %q, want invalid_grant", errResp.Error)
+	}
+}
+
+// TestAgentIdentity_TamperedAccessTokenRejected: a JWT we didn't sign (or a
+// mangled one) is rejected at the resource server, not treated as an API key.
+func TestAgentIdentity_TamperedAccessTokenRejected(t *testing.T) {
+	f := newAgentIDFixture(t)
+	// A JWT-shaped but bogus bearer.
+	bogus := "eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiJhdHRhY2tlckBldmlsLmNvbSJ9.bad-signature"
+	areq, _ := http.NewRequest("GET", "/", nil)
+	areq.Header.Set("Authorization", "Bearer "+bogus)
+	if _, err := f.api.AuthenticatePrincipal(areq); err == nil {
+		t.Error("tampered JWT must be rejected, not accepted")
+	}
+}
+
+// testRSAPEM generates a throwaway 2048-bit RSA key in PKCS#1 PEM.
+func testRSAPEM(t *testing.T) string {
+	t.Helper()
+	k, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	return string(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(k)}))
+}

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -606,6 +606,10 @@ func (a *API) RegisterRoutes(r *mux.Router) {
 	// Public JWKS for verifying e2a-minted agent JWTs (Slice 5b). Always
 	// registered; serves {"keys":[]} when no signing key is configured.
 	r.HandleFunc("/.well-known/jwks.json", a.handleJWKS).Methods("GET")
+	// auth.md agent-identity bootstrap (Slice 5b-2): present an agent-scoped
+	// credential, receive an identity_assertion to exchange at /oauth2/token
+	// (grant_type=jwt-bearer). 501 when no signing key is configured.
+	r.HandleFunc("/agent/identity", a.handleAgentIdentity).Methods("POST")
 
 	// User auth (Google OAuth for agent developers)
 	if a.userAuth != nil {
@@ -701,13 +705,23 @@ func (a *API) authenticatePrincipal(r *http.Request) (*identity.Principal, error
 	authHeader := r.Header.Get("Authorization")
 	if authHeader != "" {
 		bearer := stripBearerScheme(authHeader)
+		// auth.md agent access token (Slice 5b-2): an RS256 JWT we minted,
+		// resolving to an agent-scoped principal. Checked before the API-key
+		// path since a JWT is never a valid API key. A bearer that looks like
+		// our JWT but fails verification is rejected here (not fall-through).
+		if p, ours, err := a.resolveAgentAccessToken(r, bearer); ours {
+			if err != nil {
+				return nil, err
+			}
+			return p, nil
+		}
 		if strings.HasPrefix(bearer, oauth.AccessTokenPrefix) {
 			u, err := a.lookupUserByOAuthToken(r, bearer)
 			if err != nil {
 				return nil, err
 			}
-			// OAuth access tokens are account-scoped until Slice 5b adds
-			// scope claims to the token. Until then they behave as today.
+			// OAuth (fosite) access tokens are account-scoped until they carry
+			// scope claims. Until then they behave as today.
 			return &identity.Principal{User: u, Scope: identity.ScopeAccount}, nil
 		}
 		return a.store.GetPrincipalByAPIKey(r.Context(), bearer)

--- a/internal/agent/oauth_handlers.go
+++ b/internal/agent/oauth_handlers.go
@@ -35,6 +35,14 @@ import (
 // not calling SetOAuthProvider). Matches the discovery / DCR / etc.
 // 404-when-not-configured pattern from the hand-rolled branch.
 func (a *API) handleOAuthToken(w http.ResponseWriter, r *http.Request) {
+	// Agent-identity grant (Slice 5b-2): dispatch grant_type=jwt-bearer here
+	// before fosite, which doesn't implement it. ParseForm is idempotent —
+	// fosite re-reads the same cached r.PostForm — so peeking at grant_type
+	// first is safe. This path works even when fosite OAuth isn't wired.
+	if err := r.ParseForm(); err == nil && r.PostForm.Get("grant_type") == jwtBearerGrantType {
+		a.handleJWTBearerGrant(w, r)
+		return
+	}
 	if a.oauthProvider == nil {
 		http.NotFound(w, r)
 		return
@@ -501,10 +509,22 @@ type OAuthMetadata struct {
 	// against (Slice 5b). Always present once a signer surface exists; the
 	// endpoint serves {"keys":[]} when no signing key is configured.
 	JWKSURI string `json:"jwks_uri,omitempty"`
+	// AgentAuth is the auth.md agent-identity discovery block (Slice 5b-2).
+	// Present only when the agent-identity surface is enabled (a signing key is
+	// configured) — advertising endpoints that 501 would mislead clients.
+	AgentAuth *agentAuthMetadata `json:"agent_auth,omitempty"`
 	// RFC 9207 §3 — advertises that authorize responses carry `iss`
 	// (we emit it manually in writeAuthorizeRedirect since fosite
 	// v0.49 doesn't ship native RFC 9207 support).
 	AuthorizationResponseIssParameterSupported bool `json:"authorization_response_iss_parameter_supported,omitempty"`
+}
+
+// agentAuthMetadata is the auth.md `agent_auth` discovery block (Slice 5b-2).
+// Advertised only when the agent-identity surface is live.
+type agentAuthMetadata struct {
+	IdentityEndpoint        string   `json:"identity_endpoint"`
+	IdentityTypesSupported  []string `json:"identity_types_supported"`
+	AssertionTypesSupported []string `json:"assertion_types_supported"`
 }
 
 // handleOAuthDiscovery serves the RFC 8414 metadata document.
@@ -539,11 +559,22 @@ func (a *API) handleOAuthDiscovery(w http.ResponseWriter, r *http.Request) {
 		RevocationEndpointAuthMethodsSupported: []string{"none"},
 		// Scope vocabulary is the §6a tier model (Slice 5b): agent (runtime/
 		// inbox, the DCR-public default) and account (admin). The lone legacy
-		// "mcp" scope is retired. The auth.md agent_auth discovery block +
-		// jwt-bearer grant arrive with the identity endpoints (5b-2).
+		// "mcp" scope is retired.
 		ScopesSupported: []string{"agent", "account"},
 		JWKSURI:         base + "/.well-known/jwks.json",
 		AuthorizationResponseIssParameterSupported: true,
+	}
+	// auth.md agent-identity surface (Slice 5b-2) — advertised only when a
+	// signing key is configured, so we never announce endpoints that 501.
+	if a.agentAuthReady() {
+		meta.GrantTypesSupported = append(meta.GrantTypesSupported, jwtBearerGrantType)
+		meta.AgentAuth = &agentAuthMetadata{
+			IdentityEndpoint:       base + "/agent/identity",
+			IdentityTypesSupported: []string{"identity_assertion"},
+			// ID-JAG provider assertions are forward-compat (a later 5b
+			// sub-slice); advertise the type so clients can detect support.
+			AssertionTypesSupported: []string{"urn:ietf:params:oauth:token-type:id-jag"},
+		}
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "public, max-age=3600")

--- a/internal/agent/oauth_handlers.go
+++ b/internal/agent/oauth_handlers.go
@@ -522,9 +522,13 @@ type OAuthMetadata struct {
 // agentAuthMetadata is the auth.md `agent_auth` discovery block (Slice 5b-2).
 // Advertised only when the agent-identity surface is live.
 type agentAuthMetadata struct {
-	IdentityEndpoint        string   `json:"identity_endpoint"`
-	IdentityTypesSupported  []string `json:"identity_types_supported"`
-	AssertionTypesSupported []string `json:"assertion_types_supported"`
+	IdentityEndpoint       string   `json:"identity_endpoint"`
+	IdentityTypesSupported []string `json:"identity_types_supported"`
+	// AssertionTypesSupported lists provider-assertion types (e.g. ID-JAG)
+	// accepted at /agent/identity. Omitted until 5b-4 actually intakes them —
+	// advertising a type that currently 400s would mislead feature-detecting
+	// clients.
+	AssertionTypesSupported []string `json:"assertion_types_supported,omitempty"`
 }
 
 // handleOAuthDiscovery serves the RFC 8414 metadata document.
@@ -538,6 +542,13 @@ type agentAuthMetadata struct {
 // confusion). 404 when OAuth isn't configured (provider not wired) so
 // the announcement matches actual behavior.
 func (a *API) handleOAuthDiscovery(w http.ResponseWriter, r *http.Request) {
+	// Gated on the fosite provider, which in production is co-wired with the
+	// agent-auth signer: cmd/e2a wires BOTH only when http.public_url is set
+	// (and the signer additionally requires agentAuthReady ⊇ publicURL). So a
+	// "signer enabled but provider nil" deployment can't occur in prod — the
+	// only place that config exists is test harnesses that SetSigner without
+	// SetOAuthProvider, which don't hit discovery. Thus this guard never hides
+	// a live agent-auth surface in practice.
 	if a.oauthProvider == nil || a.publicURL == "" {
 		http.NotFound(w, r)
 		return
@@ -571,9 +582,7 @@ func (a *API) handleOAuthDiscovery(w http.ResponseWriter, r *http.Request) {
 		meta.AgentAuth = &agentAuthMetadata{
 			IdentityEndpoint:       base + "/agent/identity",
 			IdentityTypesSupported: []string{"identity_assertion"},
-			// ID-JAG provider assertions are forward-compat (a later 5b
-			// sub-slice); advertise the type so clients can detect support.
-			AssertionTypesSupported: []string{"urn:ietf:params:oauth:token-type:id-jag"},
+			// AssertionTypesSupported left empty until 5b-4 intakes ID-JAG.
 		}
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/agentauth/tokens.go
+++ b/internal/agentauth/tokens.go
@@ -1,0 +1,156 @@
+package agentauth
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/go-jose/go-jose/v3/jwt"
+)
+
+// auth.md token model (Slice 5b-2). e2a issues two server-signed RS256 JWTs:
+//
+//   - identity_assertion — the long-lived credential an agent holds (typ
+//     "identity_assertion"). Minted at POST /agent/identity once the agent has
+//     proven who it is (Slice 5b-2 bootstraps this with the agent's e2a_agt_
+//     key). Re-presented at the token endpoint to mint access tokens.
+//   - access_token — the short-lived bearer (typ "access_token") the agent
+//     actually calls the API with. Minted at POST /oauth2/token via
+//     grant_type=jwt-bearer.
+//
+// Both carry the agent's email as `sub`, the granted `scope` (always "agent" on
+// this path), and the `assertion_version` of the agent row — the kill switch: a
+// bump invalidates every assertion/token mintable from the old version.
+const (
+	TypIdentityAssertion = "identity_assertion"
+	TypAccessToken       = "access_token"
+
+	// IdentityAssertionTTL bounds the long-lived credential. Re-mintable any
+	// time from the agent's e2a_agt_ key, so it need not be long; 30 days
+	// matches the auth.md reference's anonymous assertion.
+	IdentityAssertionTTL = 30 * 24 * time.Hour
+	// AccessTokenTTL keeps the bearer short so a leak self-heals quickly. The
+	// agent re-exchanges its identity_assertion when it expires.
+	AccessTokenTTL = 15 * time.Minute
+
+	// clockSkew tolerates small clock drift between signer and verifier.
+	clockSkew = 60 * time.Second
+)
+
+// ErrTokenInvalid wraps every verification failure so callers can map the whole
+// class to a 401/invalid_grant without leaking which check failed.
+var ErrTokenInvalid = errors.New("agentauth: token invalid")
+
+// tokenPrivateClaims are e2a's non-registered claims, embedded alongside the
+// standard jwt.Claims (iss/sub/aud/exp/iat).
+type tokenPrivateClaims struct {
+	Type             string `json:"typ"`
+	Scope            string `json:"scope"`
+	AssertionVersion int    `json:"assertion_version"`
+}
+
+// VerifiedClaims is the validated, typed result of VerifyToken.
+type VerifiedClaims struct {
+	Subject          string
+	Scope            string
+	AssertionVersion int
+	Type             string
+	Expiry           time.Time
+}
+
+// SignIdentityAssertion mints a long-lived identity_assertion for sub (the
+// agent email), bound to issuer (= the AS public URL, used as both iss and
+// aud). Returns the token and its absolute expiry.
+func (s *Signer) SignIdentityAssertion(sub, scope string, assertionVersion int, issuer string) (string, time.Time, error) {
+	return s.signTyped(TypIdentityAssertion, sub, scope, assertionVersion, issuer, IdentityAssertionTTL)
+}
+
+// SignAccessToken mints a short-lived access_token for sub. Same issuer/aud
+// binding as the assertion. Returns the token and its absolute expiry.
+func (s *Signer) SignAccessToken(sub, scope string, assertionVersion int, issuer string) (string, time.Time, error) {
+	return s.signTyped(TypAccessToken, sub, scope, assertionVersion, issuer, AccessTokenTTL)
+}
+
+func (s *Signer) signTyped(typ, sub, scope string, assertionVersion int, issuer string, ttl time.Duration) (string, time.Time, error) {
+	if !s.Enabled() {
+		return "", time.Time{}, ErrSigningDisabled
+	}
+	now := time.Now()
+	exp := now.Add(ttl)
+	std := jwt.Claims{
+		Issuer:    issuer,
+		Subject:   sub,
+		Audience:  jwt.Audience{issuer},
+		IssuedAt:  jwt.NewNumericDate(now),
+		NotBefore: jwt.NewNumericDate(now),
+		Expiry:    jwt.NewNumericDate(exp),
+		ID:        generateJTI(),
+	}
+	priv := map[string]interface{}{
+		"typ":               typ,
+		"scope":             scope,
+		"assertion_version": assertionVersion,
+	}
+	tok, err := s.Sign(std, priv)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	return tok, exp, nil
+}
+
+// VerifyToken validates an e2a-minted JWT: RS256 signature against the local
+// public key, iss == issuer, aud contains issuer, not expired (with skew), and
+// typ == expectedType. On success returns the typed claims; every failure wraps
+// ErrTokenInvalid. assertion_version freshness is the caller's job (it needs the
+// live agent row).
+func (s *Signer) VerifyToken(token, expectedType, issuer string) (*VerifiedClaims, error) {
+	if !s.Enabled() {
+		return nil, ErrSigningDisabled
+	}
+	parsed, err := jwt.ParseSigned(token)
+	if err != nil {
+		return nil, fmt.Errorf("%w: parse: %v", ErrTokenInvalid, err)
+	}
+	var std jwt.Claims
+	var priv tokenPrivateClaims
+	if err := parsed.Claims(s.priv.Public(), &std, &priv); err != nil {
+		// Signature mismatch or malformed — invalid.
+		return nil, fmt.Errorf("%w: signature: %v", ErrTokenInvalid, err)
+	}
+	if err := std.ValidateWithLeeway(jwt.Expected{
+		Issuer:   issuer,
+		Audience: jwt.Audience{issuer},
+		Time:     time.Now(),
+	}, clockSkew); err != nil {
+		return nil, fmt.Errorf("%w: claims: %v", ErrTokenInvalid, err)
+	}
+	if priv.Type != expectedType {
+		return nil, fmt.Errorf("%w: typ %q, want %q", ErrTokenInvalid, priv.Type, expectedType)
+	}
+	if std.Subject == "" {
+		return nil, fmt.Errorf("%w: missing sub", ErrTokenInvalid)
+	}
+	var exp time.Time
+	if std.Expiry != nil {
+		exp = std.Expiry.Time()
+	}
+	return &VerifiedClaims{
+		Subject:          std.Subject,
+		Scope:            priv.Scope,
+		AssertionVersion: priv.AssertionVersion,
+		Type:             priv.Type,
+		Expiry:           exp,
+	}, nil
+}
+
+// generateJTI returns a unique token id. crypto/rand failure panics (an
+// all-zero jti would collide across tokens) — same posture as the key RNG.
+func generateJTI() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		panic(fmt.Sprintf("agentauth: crypto/rand failed: %v", err))
+	}
+	return "jti_" + hex.EncodeToString(b)
+}

--- a/internal/agentauth/tokens_test.go
+++ b/internal/agentauth/tokens_test.go
@@ -1,0 +1,109 @@
+package agentauth
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+const testIssuer = "https://api.e2a.dev"
+
+func testSigner(t *testing.T) *Signer {
+	t.Helper()
+	pem, _ := genPKCS1PEM(t)
+	s, err := NewSigner(pem, "v1")
+	if err != nil {
+		t.Fatalf("NewSigner: %v", err)
+	}
+	return s
+}
+
+func TestSignVerify_IdentityAssertion(t *testing.T) {
+	s := testSigner(t)
+	tok, exp, err := s.SignIdentityAssertion("support@acme.com", "agent", 3, testIssuer)
+	if err != nil {
+		t.Fatalf("SignIdentityAssertion: %v", err)
+	}
+	if time.Until(exp) < 29*24*time.Hour {
+		t.Errorf("identity_assertion TTL too short: %v", time.Until(exp))
+	}
+	got, err := s.VerifyToken(tok, TypIdentityAssertion, testIssuer)
+	if err != nil {
+		t.Fatalf("VerifyToken: %v", err)
+	}
+	if got.Subject != "support@acme.com" || got.Scope != "agent" || got.AssertionVersion != 3 || got.Type != TypIdentityAssertion {
+		t.Errorf("claims = %+v", got)
+	}
+}
+
+func TestSignVerify_AccessToken(t *testing.T) {
+	s := testSigner(t)
+	tok, exp, err := s.SignAccessToken("bot@acme.com", "agent", 1, testIssuer)
+	if err != nil {
+		t.Fatalf("SignAccessToken: %v", err)
+	}
+	if d := time.Until(exp); d > 16*time.Minute || d < 14*time.Minute {
+		t.Errorf("access_token TTL = %v, want ~15m", d)
+	}
+	got, err := s.VerifyToken(tok, TypAccessToken, testIssuer)
+	if err != nil {
+		t.Fatalf("VerifyToken: %v", err)
+	}
+	if got.Subject != "bot@acme.com" || got.Type != TypAccessToken {
+		t.Errorf("claims = %+v", got)
+	}
+}
+
+// TestVerify_TypeConfusion: an access_token must NOT verify as an
+// identity_assertion (and vice versa) — the typ claim is load-bearing, so a
+// short-lived access token can't be replayed as the long-lived credential.
+func TestVerify_TypeConfusion(t *testing.T) {
+	s := testSigner(t)
+	at, _, _ := s.SignAccessToken("x@acme.com", "agent", 1, testIssuer)
+	if _, err := s.VerifyToken(at, TypIdentityAssertion, testIssuer); err == nil {
+		t.Error("access_token must not verify as identity_assertion")
+	}
+	ia, _, _ := s.SignIdentityAssertion("x@acme.com", "agent", 1, testIssuer)
+	if _, err := s.VerifyToken(ia, TypAccessToken, testIssuer); err == nil {
+		t.Error("identity_assertion must not verify as access_token")
+	}
+}
+
+// TestVerify_WrongIssuerOrAudience: a token minted for a different AS host must
+// be rejected (prevents cross-deployment token replay).
+func TestVerify_WrongIssuerOrAudience(t *testing.T) {
+	s := testSigner(t)
+	tok, _, _ := s.SignAccessToken("x@acme.com", "agent", 1, testIssuer)
+	if _, err := s.VerifyToken(tok, TypAccessToken, "https://evil.example.com"); err == nil {
+		t.Error("token must not verify against a different issuer/audience")
+	}
+}
+
+// TestVerify_WrongKey: a token signed by a different key must not verify.
+func TestVerify_WrongKey(t *testing.T) {
+	s1 := testSigner(t)
+	s2 := testSigner(t)
+	tok, _, _ := s1.SignAccessToken("x@acme.com", "agent", 1, testIssuer)
+	if _, err := s2.VerifyToken(tok, TypAccessToken, testIssuer); err == nil {
+		t.Error("token signed by another key must not verify")
+	}
+}
+
+func TestVerify_DisabledSigner(t *testing.T) {
+	disabled, _ := NewSigner("", "")
+	if _, _, err := disabled.SignAccessToken("x", "agent", 1, testIssuer); err != ErrSigningDisabled {
+		t.Errorf("sign on disabled = %v, want ErrSigningDisabled", err)
+	}
+	if _, err := disabled.VerifyToken("whatever", TypAccessToken, testIssuer); err != ErrSigningDisabled {
+		t.Errorf("verify on disabled = %v, want ErrSigningDisabled", err)
+	}
+}
+
+func TestVerify_GarbageToken(t *testing.T) {
+	s := testSigner(t)
+	for _, bad := range []string{"", "not-a-jwt", "a.b.c", strings.Repeat("x", 50)} {
+		if _, err := s.VerifyToken(bad, TypAccessToken, testIssuer); err == nil {
+			t.Errorf("garbage %q verified", bad)
+		}
+	}
+}

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -106,6 +106,10 @@ type AgentIdentity struct {
 	// trusts; empty for open/verified_only.
 	InboundPolicy    string   `json:"inbound_policy"`
 	InboundAllowlist []string `json:"inbound_allowlist,omitempty"`
+	// AssertionVersion is the auth.md kill-switch counter (migration 035 /
+	// Slice 5b-2): stamped into minted identity_assertion/access_token JWTs and
+	// re-checked at the token endpoint; a bump invalidates prior tokens.
+	AssertionVersion int `json:"-"`
 }
 
 // HITL constants mirror the CHECK constraints in migration 003_hitl.sql.
@@ -729,6 +733,7 @@ func (s *Store) GetAgentByID(ctx context.Context, id string) (*AgentIdentity, er
 		`SELECT a.id, a.domain, a.user_id, a.name, a.public, a.created_at,
 		        a.hitl_enabled, a.hitl_ttl_seconds, a.hitl_expiration_action,
 		        COALESCE(a.inbound_policy, 'open'), a.inbound_allowlist,
+		        COALESCE(a.assertion_version, 1),
 		        d.verified as domain_verified
 		 FROM agent_identities a
 		 JOIN domains d ON a.domain = d.domain
@@ -736,6 +741,7 @@ func (s *Store) GetAgentByID(ctx context.Context, id string) (*AgentIdentity, er
 	).Scan(&a.ID, &a.Domain, &a.UserID, &a.Name, &a.Public, &a.CreatedAt,
 		&a.HITLEnabled, &a.HITLTTLSeconds, &a.HITLExpirationAction,
 		&a.InboundPolicy, &a.InboundAllowlist,
+		&a.AssertionVersion,
 		&a.DomainVerified)
 	if err != nil {
 		return nil, err

--- a/migrations/035_agent_assertion_version.sql
+++ b/migrations/035_agent_assertion_version.sql
@@ -1,0 +1,12 @@
+-- 035_agent_assertion_version.sql
+--
+-- auth.md agent-token kill switch (Slice 5b-2). assertion_version is stamped
+-- into every identity_assertion + access_token e2a mints for an agent. The
+-- token endpoint rejects a presented assertion whose version != the live row,
+-- so bumping this column immediately invalidates every token mintable from the
+-- old version (the compromised-key / "log this agent out everywhere" lever) —
+-- required because assertion-minted access tokens are short-lived with no
+-- refresh to starve. Starts at 1; monotonically bumped on revoke.
+-- Idempotent + non-destructive (metadata-only ADD COLUMN on PG11+).
+ALTER TABLE agent_identities
+    ADD COLUMN IF NOT EXISTS assertion_version INTEGER NOT NULL DEFAULT 1;

--- a/web/Caddyfile
+++ b/web/Caddyfile
@@ -34,6 +34,12 @@
         reverse_proxy {$E2A_BACKEND:http://e2a:8080}
     }
 
+    # auth.md agent-identity bootstrap (Slice 5b-2). Backend-owned API path, not
+    # under /api/* — needs its own proxy rule or POST /agent/identity 404s.
+    handle /agent/identity {
+        reverse_proxy {$E2A_BACKEND:http://e2a:8080}
+    }
+
     # Discovery + JWKS metadata. Live at well-known paths (NOT under /api/*)
     # per spec, so they need their own proxy rules. Without these the web
     # frontend returns a 404 HTML page when OAuth clients probe for the

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -15,6 +15,7 @@ const nextConfig: NextConfig = {
       // AS discovery docs the backend owns) to the Go server in dev, mirroring
       // the Caddyfile in prod. Without these the consent UI + token flow 404.
       { source: "/oauth2/:path*", destination: "http://localhost:8080/oauth2/:path*" },
+      { source: "/agent/identity", destination: "http://localhost:8080/agent/identity" },
       { source: "/.well-known/jwks.json", destination: "http://localhost:8080/.well-known/jwks.json" },
       { source: "/.well-known/oauth-authorization-server", destination: "http://localhost:8080/.well-known/oauth-authorization-server" },
     ],


### PR DESCRIPTION
## Slice 5b-2 — Autonomous agent token path

The auth.md **server-signed token rails** (jwt-bearer). Decided with the maintainer: e2a follows **canonical auth.md** (the agentdrive model — anonymous/claim/ID-JAG entry points into one server-signed token system), **not** §5's self-signed-agent-key bridge (which agentdrive also skipped and which deviates from the spec we adopt). An agent trades a long-lived credential for short-lived JWT access tokens.

### Flow
1. Agent presents its **Slice-5a `e2a_agt_` key** → `POST /agent/identity` → server-signed **`identity_assertion`** JWT (`sub`=agent email, `scope=agent`, `assertion_version`, 30-day).
2. Agent presents the assertion → `POST /oauth2/token` `grant_type=jwt-bearer` → short-lived (15-min) **`access_token`** JWT. No refresh — re-present the assertion.
3. The **resource server accepts the `access_token`** as an `agent`-scoped principal — **composes with the 5a hard ceiling** (agent JWT → 403 on account-only routes, 200 on its own agent).
4. `agent_identities.assertion_version` (migration 035) is the **kill switch**; discovery carries the `agent_auth` block + jwt-bearer grant (only when a signing key is configured).

### e2a-specific adaptation
agentdrive's ownerless "anonymous self-provision" is unsafe for e2a — an identity is an **email on a verified domain**. So the bootstrap credential is the 5a `e2a_agt_` key (already gated by domain ownership at mint), not an ownerless self-registration.

### Verification
- `agentauth`, `agent`, `identity`, `httpapi`, `auth`, `oauth`, `e2e` (`-p 1`) ✅; `TestSpecGoldenNoDrift` ✅.
- **Real-binary over-the-wire e2e**: key → `/agent/identity` (assertion) → `/oauth2/token` jwt-bearer (access_token) → **`GET /v1/agents/{self}` + `/messages` = 200**, **`GET /v1/agents` (list, admin) = 403**; discovery advertises jwt-bearer + `agent_auth`; log clean.
- Tests: mint/verify (round-trip, **type-confusion**, wrong issuer/key, disabled, garbage); DB-backed full flow (key→assertion→token→principal; account-key reject; **stale-assertion kill switch**; tampered-JWT reject).
- **Proxies fixed proactively** — `/agent/identity` added to `Caddyfile` + `next.config` (learned from the 5b-1 review; a new top-level route otherwise 404s behind the proxy).

### Deferred (later 5b sub-slices)
5b-3 claim ceremony (human-connected `user_code`/consent + `claim` grant, same rails); 5b-4 ID-JAG provider assertions + `act` delegation + `agent.credential_revoked`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)