### PR TITLE
feat(agent): Slice 7b — trust-gated action authorization (decision 10)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -40,6 +40,8 @@ components:
           type: boolean
         hitl_expiration_action:
           type: string
+        hitl_mode:
+          type: string
         hitl_ttl_seconds:
           format: int64
           type: integer
@@ -85,6 +87,7 @@ components:
         - hitl_enabled
         - hitl_ttl_seconds
         - hitl_expiration_action
+        - hitl_mode
         - inbound_7d
         - outbound_7d
         - pending_count
@@ -106,6 +109,8 @@ components:
         hitl_enabled:
           type: boolean
         hitl_expiration_action:
+          type: string
+        hitl_mode:
           type: string
         hitl_ttl_seconds:
           format: int64
@@ -132,6 +137,7 @@ components:
         - hitl_enabled
         - hitl_ttl_seconds
         - hitl_expiration_action
+        - hitl_mode
         - inbound_policy
       type: object
     ApproveRequest:
@@ -1366,6 +1372,8 @@ components:
         hitl_enabled:
           type: boolean
         hitl_expiration_action:
+          type: string
+        hitl_mode:
           type: string
         hitl_ttl_seconds:
           format: int64

--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -1381,11 +1381,17 @@ Break the current `/api/v1` surface directly and move it to
       referenced inbound's **`dmarc != pass`** (weak/spoofable; read from the
       server-owned `auth_verdict`, never client input; a missing verdict is
       fail-closed-untrusted) **and** a recipient reaches a **domain outside the
-      referenced inbound's participants** (reply to a new party / forward to a
-      third party). A trusted-thread or in-thread reply sends straight through; a
-      cold send (no referenced inbound) is never held in this mode. The hold
-      decision is threaded the referenced `*identity.Message` through
-      `DeliverOutbound`.
+      agent's own verified domain** (high-impact). A reply/forward staying within
+      the agent's own domain sends straight through; a cold send (no referenced
+      inbound) is never held in this mode. The hold decision is threaded the
+      referenced `*identity.Message` through `DeliverOutbound`.
+      **Security correction (adversarial review):** the high-impact trust anchor
+      is the **agent's own verified domain**, *not* the referenced inbound's
+      `From`/`To`/`Cc` — those are attacker-controlled on a spoofed/unauthenticated
+      message, so a spoofer who seeds `Cc: exfil@evil.com` could otherwise
+      pre-authorize their exfil domain as a "participant" and slip a forward past
+      the gate. (Reusing the participant set of a *trusted* prior thread is a
+      possible future refinement.)
     * The "untrusted input" signal is a plain bool in `actiongate` — the
       **pluggable seam** to later fold a content-level prompt-injection verdict
       (a partner scan API, under evaluation) into the same gate without rework.

--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -1367,13 +1367,32 @@ Break the current `/api/v1` surface directly and move it to
     operators get a signal. Evaluator is a stdlib leaf (`internal/inboundpolicy`);
     surfaced as `inbound_policy`/`inbound_allowlist` on `AgentView` (settable via
     `update_agent`) and `flagged`/`flag_reason` on message reads.
-  * **Slice 7b — Trust-gated action authorization.** *(Deferred.)* Policy-driven
-    hold of suspicious outbound as `pending_approval`, keyed on the referenced
-    message's server-owned verdict (high-impact predicate: recipient domain not a
-    participant of the referenced inbound OR forward to a third party; weak
-    verdict: `dmarc != pass`). No new contract surface. Depends on the **hard
-    scope ceiling** (decision 10 / §5), which lands with **Slice 5**'s scope
-    machinery — so 7b follows 5.
+  * **Slice 7b — Trust-gated action authorization.** *(Shipped.)* The HITL
+    action gate gains a sub-mode so it holds *suspicious* outbound rather than
+    *all* outbound:
+    * `agent_identities.hitl_mode ∈ {all, high_impact}` (migration 036, DEFAULT
+      `all`, CHECK-constrained). `hitl_enabled` stays the on/off switch;
+      `hitl_mode` refines *what* is held. Default `all` = pre-7b behavior, so
+      every existing HITL agent is unchanged; trust-gating is an explicit
+      `hitl_mode=high_impact` PATCH. Surfaced on `AgentView` + settable via
+      `update_agent` (independent `UpdateAgentHITLMode`, validated → 400).
+    * `internal/actiongate` (stdlib leaf, mirrors `inboundpolicy`): in
+      `high_impact`, an outbound (reply/forward) is held only when **both** — the
+      referenced inbound's **`dmarc != pass`** (weak/spoofable; read from the
+      server-owned `auth_verdict`, never client input; a missing verdict is
+      fail-closed-untrusted) **and** a recipient reaches a **domain outside the
+      referenced inbound's participants** (reply to a new party / forward to a
+      third party). A trusted-thread or in-thread reply sends straight through; a
+      cold send (no referenced inbound) is never held in this mode. The hold
+      decision is threaded the referenced `*identity.Message` through
+      `DeliverOutbound`.
+    * The "untrusted input" signal is a plain bool in `actiongate` — the
+      **pluggable seam** to later fold a content-level prompt-injection verdict
+      (a partner scan API, under evaluation) into the same gate without rework.
+      That integration is deferred; e2a core stays provider-agnostic.
+
+    Built on the 5a hard scope ceiling (decision 10 / §5). No new contract
+    surface beyond `hitl_mode`.
 
 Slices 1–6 are independently shippable; 1–2 deliver most of the "clean and
 consistent" win. Slice 7 is a post-parity enhancement.

--- a/internal/actiongate/actiongate.go
+++ b/internal/actiongate/actiongate.go
@@ -1,0 +1,95 @@
+// Package actiongate is the trust-gated outbound action authorization
+// (api-v1-redesign decision 10 / Slice 7b). It is the OUTBOUND/action axis,
+// orthogonal to the inbound ingestion gate (internal/inboundpolicy): given that
+// HITL is enabled, it decides whether a specific outbound action must be HELD
+// for human approval (pending_approval) rather than sent automatically.
+//
+// The gate composes two signals:
+//   - untrusted input: the inbound message the action is reacting to is not
+//     trustworthy. Today that's the server-owned DMARC verdict (dmarc != pass);
+//     the signal is taken as a plain bool so a content-level prompt-injection
+//     verdict (or any future provider) can OR into it WITHOUT changing this
+//     package — the pluggable seam.
+//   - high impact: the action reaches outside the referenced conversation — a
+//     recipient on a domain that wasn't a participant of the inbound (a reply to
+//     a new party, or a forward to a third party).
+//
+// Hold iff both hold AND the agent is in high_impact mode. In all mode every
+// outbound is held (the pre-7b behavior). This package is a stdlib-only leaf:
+// callers pass primitives (the mode, the two signals, address lists) so it
+// stays decoupled from emailauth/identity.
+package actiongate
+
+import "strings"
+
+// HITL sub-mode values (the agent_identities.hitl_mode column).
+const (
+	// ModeAll holds every outbound when HITL is enabled (pre-7b behavior, the
+	// default so existing HITL agents are unchanged).
+	ModeAll = "all"
+	// ModeHighImpact holds only a high-impact action taken on untrusted input.
+	ModeHighImpact = "high_impact"
+)
+
+// Valid reports whether m is a known hitl_mode.
+func Valid(m string) bool { return m == ModeAll || m == ModeHighImpact }
+
+// Decision is the gate verdict for one outbound action.
+type Decision struct {
+	Hold   bool
+	Reason string // human-readable; empty when not held
+}
+
+// Evaluate decides whether an outbound action is held for approval. The caller
+// has already confirmed HITL is enabled; this only chooses based on the mode.
+//
+//   - mode: the agent's hitl_mode.
+//   - hasReferencedInput: the action reacts to a referenced inbound message
+//     (reply/forward). A fresh cold send has none — there is no untrusted input
+//     to react to, so high_impact mode never holds it.
+//   - untrustedInput: that referenced input is untrusted (today: dmarc != pass).
+//   - highImpact: the action reaches outside the referenced participants.
+func Evaluate(mode string, hasReferencedInput, untrustedInput, highImpact bool) Decision {
+	switch mode {
+	case ModeHighImpact:
+		if hasReferencedInput && untrustedInput && highImpact {
+			return Decision{Hold: true, Reason: "high-impact action on unauthenticated inbound (hitl_mode=high_impact)"}
+		}
+		return Decision{}
+	case ModeAll:
+		return Decision{Hold: true, Reason: "all outbound held for approval (hitl_mode=all)"}
+	default:
+		// Unknown mode → fail closed to holding (never silently send when the
+		// agent opted into HITL but the mode is unrecognized).
+		return Decision{Hold: true, Reason: "unrecognized hitl_mode; holding for approval"}
+	}
+}
+
+// HighImpact reports whether any outbound recipient targets a domain that was
+// NOT a participant of the referenced inbound — i.e. the action reaches a new
+// party (a reply to a new domain, or a forward to a third party). A recipient
+// with no parseable domain counts as high-impact (fail-closed). Matching is
+// case-insensitive on the domain.
+func HighImpact(participantAddrs, recipientAddrs []string) bool {
+	pd := map[string]bool{}
+	for _, a := range participantAddrs {
+		if d := domainOf(a); d != "" {
+			pd[d] = true
+		}
+	}
+	for _, r := range recipientAddrs {
+		d := domainOf(r)
+		if d == "" || !pd[d] {
+			return true
+		}
+	}
+	return false
+}
+
+func domainOf(email string) string {
+	at := strings.LastIndex(email, "@")
+	if at < 0 || at == len(email)-1 {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(email[at+1:]))
+}

--- a/internal/actiongate/actiongate_test.go
+++ b/internal/actiongate/actiongate_test.go
@@ -1,0 +1,73 @@
+package actiongate
+
+import "testing"
+
+func TestEvaluate_AllModeHoldsEverything(t *testing.T) {
+	// all mode holds regardless of trust signals.
+	for _, tc := range []struct{ ref, untrusted, impact bool }{
+		{false, false, false}, {true, false, false}, {true, true, true},
+	} {
+		if d := Evaluate(ModeAll, tc.ref, tc.untrusted, tc.impact); !d.Hold {
+			t.Errorf("all mode must hold (%+v)", tc)
+		}
+	}
+}
+
+func TestEvaluate_HighImpactMode(t *testing.T) {
+	cases := []struct {
+		name                         string
+		ref, untrusted, impact, hold bool
+	}{
+		{"untrusted + high-impact → hold", true, true, true, true},
+		{"trusted input → send", true, false, true, false},
+		{"low-impact (in-thread) → send", true, true, false, false},
+		{"no referenced input (cold send) → send", false, true, true, false},
+		{"trusted + low-impact → send", true, false, false, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			d := Evaluate(ModeHighImpact, c.ref, c.untrusted, c.impact)
+			if d.Hold != c.hold {
+				t.Errorf("Hold = %v, want %v", d.Hold, c.hold)
+			}
+		})
+	}
+}
+
+// TestEvaluate_UnknownModeFailsClosed: a garbage mode holds (never silently
+// sends when the agent opted into HITL).
+func TestEvaluate_UnknownModeFailsClosed(t *testing.T) {
+	if d := Evaluate("bogus", true, false, false); !d.Hold {
+		t.Error("unknown mode must fail closed to holding")
+	}
+}
+
+func TestHighImpact(t *testing.T) {
+	participants := []string{"boss@acme.com", "support@acme.com", "cc@acme.com"}
+	cases := []struct {
+		name       string
+		recipients []string
+		want       bool
+	}{
+		{"reply within participant domains", []string{"boss@acme.com"}, false},
+		{"reply to new participant same domain", []string{"newperson@acme.com"}, false},
+		{"reply adds external domain", []string{"boss@acme.com", "outsider@evil.com"}, true},
+		{"forward to third party", []string{"legal@external.com"}, true},
+		{"case-insensitive domain match", []string{"boss@ACME.com"}, false},
+		{"garbage recipient fails closed", []string{"not-an-email"}, true},
+		{"empty recipients", []string{}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := HighImpact(participants, c.recipients); got != c.want {
+				t.Errorf("HighImpact(%v) = %v, want %v", c.recipients, got, c.want)
+			}
+		})
+	}
+}
+
+func TestValid(t *testing.T) {
+	if !Valid(ModeAll) || !Valid(ModeHighImpact) || Valid("nope") || Valid("") {
+		t.Error("Valid mismatch")
+	}
+}

--- a/internal/agent/action_gate_test.go
+++ b/internal/agent/action_gate_test.go
@@ -43,8 +43,8 @@ func TestActionGateHold_HighImpactMode(t *testing.T) {
 		hold bool
 	}{
 		{"weak verdict + forward to third party → hold", weak, outbound.SendRequest{To: []string{"legal@external.com"}}, true},
-		{"weak verdict + reply within thread → send", weak, outbound.SendRequest{To: []string{"boss@acme.com"}}, false},
-		{"weak verdict + reply to new same-domain → send", weak, outbound.SendRequest{To: []string{"hr@acme.com"}}, false},
+		{"weak verdict + reply to agent's own domain → send", weak, outbound.SendRequest{To: []string{"boss@acme.com"}}, false},
+		{"weak verdict + send to other agent-domain addr → send", weak, outbound.SendRequest{To: []string{"hr@acme.com"}}, false},
 		{"strong verdict + forward to third party → send", strong, outbound.SendRequest{To: []string{"legal@external.com"}}, false},
 		{"weak verdict + cc adds external → hold", weak, outbound.SendRequest{To: []string{"boss@acme.com"}, CC: []string{"x@evil.com"}}, true},
 		{"cold send (no referenced) → send", nil, outbound.SendRequest{To: []string{"anyone@wherever.com"}}, false},
@@ -53,6 +53,48 @@ func TestActionGateHold_HighImpactMode(t *testing.T) {
 		t.Run(c.name, func(t *testing.T) {
 			if got := actionGateHold(ag, c.req, c.ref).Hold; got != c.hold {
 				t.Errorf("Hold = %v, want %v", got, c.hold)
+			}
+		})
+	}
+}
+
+// TestActionGateHold_SpoofedParticipantsCannotPreAuthorize is the regression
+// for the adversarial-review CRITICAL: the trust anchor is the agent's OWN
+// domain, never the untrusted inbound's headers. A spoofer who seeds the
+// From/To/Cc with their exfil domain must NOT thereby make a forward/reply to
+// that domain "in-thread" and slip it past the gate.
+func TestActionGateHold_SpoofedParticipantsCannotPreAuthorize(t *testing.T) {
+	ag := agentWith(actiongate.ModeHighImpact)
+	cases := []struct {
+		name string
+		ref  *identity.Message
+		req  outbound.SendRequest
+	}{
+		{
+			"spoofed From=exfil domain, reply there → hold",
+			refMsg(t, emailauth.StatusFail, "attacker@evil.com", []string{"bot@acme.com"}, nil),
+			outbound.SendRequest{To: []string{"attacker@evil.com"}},
+		},
+		{
+			"spoofed Cc=exfil domain, forward there → hold",
+			refMsg(t, emailauth.StatusFail, "boss@acme.com", []string{"bot@acme.com"}, []string{"exfil@evil.com"}),
+			outbound.SendRequest{To: []string{"exfil@evil.com"}},
+		},
+		{
+			"spoofed To=exfil domain, forward there → hold",
+			refMsg(t, emailauth.StatusFail, "boss@acme.com", []string{"bot@acme.com", "exfil@evil.com"}, nil),
+			outbound.SendRequest{To: []string{"exfil@evil.com"}},
+		},
+		{
+			"exfil via BCC → hold",
+			refMsg(t, emailauth.StatusFail, "boss@acme.com", []string{"bot@acme.com"}, nil),
+			outbound.SendRequest{To: []string{"boss@acme.com"}, BCC: []string{"exfil@evil.com"}},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if !actionGateHold(ag, c.req, c.ref).Hold {
+				t.Errorf("spoofed-participant exfil to a new domain must be HELD, was not")
 			}
 		})
 	}

--- a/internal/agent/action_gate_test.go
+++ b/internal/agent/action_gate_test.go
@@ -1,0 +1,91 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/actiongate"
+	"github.com/Mnexa-AI/e2a/internal/emailauth"
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/outbound"
+)
+
+// Slice 7b — the trust-gated hold decision. White-box tests of actionGateHold
+// mapping a referenced inbound's DMARC verdict + participants to a hold/send
+// decision under each hitl_mode. (The pure predicate is covered in
+// internal/actiongate; this pins the e2a-specific signal extraction.)
+
+func refMsg(t *testing.T, dmarc emailauth.CheckStatus, sender string, to, cc []string) *identity.Message {
+	t.Helper()
+	return &identity.Message{
+		Sender:       sender,
+		ToRecipients: to,
+		CC:           cc,
+		Auth:         &emailauth.Result{DMARC: emailauth.CheckResult{Status: dmarc}},
+	}
+}
+
+func agentWith(mode string) *identity.AgentIdentity {
+	a := &identity.AgentIdentity{ID: "bot@acme.com", Domain: "acme.com", HITLEnabled: true, HITLMode: mode}
+	return a
+}
+
+func TestActionGateHold_HighImpactMode(t *testing.T) {
+	ag := agentWith(actiongate.ModeHighImpact)
+	// Referenced inbound from a spoofable sender (dmarc fail), thread participants
+	// are all @acme.com.
+	weak := refMsg(t, emailauth.StatusFail, "boss@acme.com", []string{"bot@acme.com"}, nil)
+	strong := refMsg(t, emailauth.StatusPass, "boss@acme.com", []string{"bot@acme.com"}, nil)
+
+	cases := []struct {
+		name string
+		ref  *identity.Message
+		req  outbound.SendRequest
+		hold bool
+	}{
+		{"weak verdict + forward to third party → hold", weak, outbound.SendRequest{To: []string{"legal@external.com"}}, true},
+		{"weak verdict + reply within thread → send", weak, outbound.SendRequest{To: []string{"boss@acme.com"}}, false},
+		{"weak verdict + reply to new same-domain → send", weak, outbound.SendRequest{To: []string{"hr@acme.com"}}, false},
+		{"strong verdict + forward to third party → send", strong, outbound.SendRequest{To: []string{"legal@external.com"}}, false},
+		{"weak verdict + cc adds external → hold", weak, outbound.SendRequest{To: []string{"boss@acme.com"}, CC: []string{"x@evil.com"}}, true},
+		{"cold send (no referenced) → send", nil, outbound.SendRequest{To: []string{"anyone@wherever.com"}}, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := actionGateHold(ag, c.req, c.ref).Hold; got != c.hold {
+				t.Errorf("Hold = %v, want %v", got, c.hold)
+			}
+		})
+	}
+}
+
+// TestActionGateHold_AllMode: hold-all is unchanged — every outbound is held,
+// even a trusted in-thread reply or a cold send.
+func TestActionGateHold_AllMode(t *testing.T) {
+	ag := agentWith(actiongate.ModeAll)
+	strong := refMsg(t, emailauth.StatusPass, "boss@acme.com", []string{"bot@acme.com"}, nil)
+	if !actionGateHold(ag, outbound.SendRequest{To: []string{"boss@acme.com"}}, strong).Hold {
+		t.Error("all mode must hold a trusted in-thread reply")
+	}
+	if !actionGateHold(ag, outbound.SendRequest{To: []string{"x@acme.com"}}, nil).Hold {
+		t.Error("all mode must hold a cold send")
+	}
+}
+
+// TestActionGateHold_EmptyModeDefaultsAll: a blank hitl_mode (pre-migration
+// rows COALESCE to 'all') behaves as hold-all.
+func TestActionGateHold_EmptyModeDefaultsAll(t *testing.T) {
+	ag := agentWith("")
+	if !actionGateHold(ag, outbound.SendRequest{To: []string{"boss@acme.com"}}, nil).Hold {
+		t.Error("empty hitl_mode must default to hold-all")
+	}
+}
+
+// TestActionGateHold_MissingVerdictIsUntrusted: a referenced inbound with no
+// stored auth verdict is treated as untrusted (fail-closed) → high-impact held.
+func TestActionGateHold_MissingVerdictIsUntrusted(t *testing.T) {
+	ag := agentWith(actiongate.ModeHighImpact)
+	noVerdict := &identity.Message{Sender: "boss@acme.com", ToRecipients: []string{"bot@acme.com"}} // Auth == nil
+	if !actionGateHold(ag, outbound.SendRequest{To: []string{"legal@external.com"}}, noVerdict).Hold {
+		t.Error("missing verdict must be treated as untrusted (fail-closed) and held when high-impact")
+	}
+}

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -1060,13 +1060,15 @@ func actionGateHold(agent *identity.AgentIdentity, req outbound.SendRequest, ref
 	untrusted := referenced == nil || referenced.Auth == nil ||
 		referenced.Auth.DMARC.Status != emailauth.StatusPass
 
-	var participants []string
-	if referenced != nil {
-		participants = append(participants, referenced.Sender)
-		participants = append(participants, referenced.ToRecipients...)
-		participants = append(participants, referenced.CC...)
-	}
-	participants = append(participants, agent.EmailAddress())
+	// Trust anchor for the high-impact check is the agent's OWN verified domain
+	// — NOT the referenced inbound's From/To/Cc. high_impact only ever holds on
+	// an untrusted (DMARC-fail) inbound, whose headers are attacker-controlled:
+	// a spoofer who adds `Cc: exfil@evil.com` would otherwise pre-authorize
+	// their own exfil domain as a "participant" and slip a forward past the gate
+	// (adversarial review). So an untrusted inbound expands the trusted set by
+	// nothing; any recipient off the agent's domain is high-impact. (Reusing a
+	// *trusted* prior thread's participants is a possible future refinement.)
+	participants := []string{agent.EmailAddress()}
 
 	recipients := make([]string, 0, len(req.To)+len(req.CC)+len(req.BCC))
 	recipients = append(recipients, req.To...)

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -16,10 +16,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Mnexa-AI/e2a/internal/actiongate"
 	"github.com/Mnexa-AI/e2a/internal/agentauth"
 	"github.com/Mnexa-AI/e2a/internal/approvaltoken"
 	"github.com/Mnexa-AI/e2a/internal/auth"
 	"github.com/Mnexa-AI/e2a/internal/dkim"
+	"github.com/Mnexa-AI/e2a/internal/emailauth"
 	"github.com/Mnexa-AI/e2a/internal/hitlnotify"
 	"github.com/Mnexa-AI/e2a/internal/idempotency"
 	"github.com/Mnexa-AI/e2a/internal/identity"
@@ -1037,6 +1039,43 @@ func (a *API) checkSuppression(ctx context.Context, userID string, req outbound.
 	return nil
 }
 
+// actionGateHold computes the Slice 7b trust-gated hold decision. The caller
+// has already confirmed HITL is enabled; this only chooses based on the
+// agent's hitl_mode and the trust signals.
+//
+//   - referenced: the inbound message this action reacts to (reply/forward);
+//     nil for a cold send/test, which has no untrusted input to react to.
+//   - untrusted input (today): the referenced inbound's DMARC verdict is not a
+//     pass — i.e. we can't confirm it really came from the claimed sender. A
+//     missing verdict is treated as untrusted (fail-closed). This is the
+//     pluggable seam: a content-level prompt-injection verdict can later OR
+//     into this signal without touching actiongate.
+//   - high impact: a recipient reaches a domain that wasn't a participant of
+//     the referenced inbound (reply to a new party / forward to a third party).
+func actionGateHold(agent *identity.AgentIdentity, req outbound.SendRequest, referenced *identity.Message) actiongate.Decision {
+	mode := agent.HITLMode
+	if mode == "" {
+		mode = actiongate.ModeAll
+	}
+	untrusted := referenced == nil || referenced.Auth == nil ||
+		referenced.Auth.DMARC.Status != emailauth.StatusPass
+
+	var participants []string
+	if referenced != nil {
+		participants = append(participants, referenced.Sender)
+		participants = append(participants, referenced.ToRecipients...)
+		participants = append(participants, referenced.CC...)
+	}
+	participants = append(participants, agent.EmailAddress())
+
+	recipients := make([]string, 0, len(req.To)+len(req.CC)+len(req.BCC))
+	recipients = append(recipients, req.To...)
+	recipients = append(recipients, req.CC...)
+	recipients = append(recipients, req.BCC...)
+
+	return actiongate.Evaluate(mode, referenced != nil, untrusted, actiongate.HighImpact(participants, recipients))
+}
+
 // DeliverOutbound is the shared send/reply/forward delivery tail, HTTP-free:
 // HITL hold (HoldForApprovalCore), else self-send loopback, else SES send +
 // record outbound + publish sent event. The caller has already authed,
@@ -1046,7 +1085,7 @@ func (a *API) checkSuppression(ctx context.Context, userID string, req outbound.
 // live delivery path exists exactly once (api-v1-redesign — outbound
 // extraction). On a nil-error return the side effect has committed, so the
 // idempotency key must be Completed (cached), never Released.
-func (a *API) DeliverOutbound(ctx context.Context, user *identity.User, agent *identity.AgentIdentity, req outbound.SendRequest, msgType, replyToEmailMessageID string) (*OutboundResult, *OutboundError) {
+func (a *API) DeliverOutbound(ctx context.Context, user *identity.User, agent *identity.AgentIdentity, req outbound.SendRequest, msgType, replyToEmailMessageID string, referenced *identity.Message) (*OutboundResult, *OutboundError) {
 	// Suppression enforcement (decision 9 / Slice 4b): fail fast if any
 	// recipient is on this tenant's suppression list. Enforced fresh on every
 	// attempt and NOT cached under the idempotency key (it's a clearable state,
@@ -1055,7 +1094,12 @@ func (a *API) DeliverOutbound(ctx context.Context, user *identity.User, agent *i
 		return nil, supErr
 	}
 
-	if agent.HITLEnabled {
+	// Trust-gated action authorization (decision 10 / Slice 7b): when HITL is
+	// on, the sub-mode decides WHAT is held — all outbound (hitl_mode=all), or
+	// only a high-impact action taken on untrusted inbound (high_impact).
+	// `referenced` is the inbound message this action reacts to (reply/forward);
+	// nil for a cold send.
+	if agent.HITLEnabled && actionGateHold(agent, req, referenced).Hold {
 		msg, err := a.HoldForApprovalCore(ctx, agent, req, msgType, replyToEmailMessageID)
 		if err != nil {
 			if errors.Is(err, errHoldAttachments) {
@@ -1120,8 +1164,12 @@ func (a *API) SendTestCore(ctx context.Context, agent *identity.AgentIdentity) (
 	subject := "Test email from e2a"
 	body := fmt.Sprintf("This is a test email for %s.\n\nYour agent is set up and ready to receive emails.", agent.EmailAddress())
 
-	if agent.HITLEnabled {
-		msg, err := a.HoldForApprovalCore(ctx, agent, outbound.SendRequest{To: to, Subject: subject, Body: body}, "test", "")
+	// A platform test is a cold self-send (no referenced inbound), so in
+	// hitl_mode=high_impact it isn't held (nothing untrusted to react to); in
+	// hitl_mode=all it's held like any outbound.
+	testReq := outbound.SendRequest{To: to, Subject: subject, Body: body}
+	if agent.HITLEnabled && actionGateHold(agent, testReq, nil).Hold {
+		msg, err := a.HoldForApprovalCore(ctx, agent, testReq, "test", "")
 		if err != nil {
 			return nil, &OutboundError{http.StatusInternalServerError, "internal_error", "failed to hold message for approval"}
 		}

--- a/internal/agent/selfsend_test.go
+++ b/internal/agent/selfsend_test.go
@@ -101,7 +101,7 @@ func TestSelfSend_HappyPath(t *testing.T) {
 
 	res, oerr := api.DeliverOutbound(ctx, user, ag, outbound.SendRequest{
 		To: []string{ag.EmailAddress()}, Subject: "note to self", Body: "remember to refill coffee",
-	}, "send", "")
+	}, "send", "", nil)
 	if oerr != nil {
 		t.Fatalf("DeliverOutbound: status=%d code=%s msg=%s", oerr.Status, oerr.Code, oerr.Msg)
 	}
@@ -161,7 +161,7 @@ func TestSelfSend_PreservesAttachmentsInMIME(t *testing.T) {
 		Attachments: []outbound.Attachment{{
 			Filename: "note.txt", ContentType: "text/plain", Data: "aGVsbG8gZmlsZQ==",
 		}},
-	}, "send", "")
+	}, "send", "", nil)
 	if oerr != nil {
 		t.Fatalf("DeliverOutbound: status=%d msg=%s", oerr.Status, oerr.Msg)
 	}
@@ -210,7 +210,7 @@ func TestSelfSend_NoAttachmentsUsesSinglePart(t *testing.T) {
 
 	if _, oerr := api.DeliverOutbound(ctx, user, ag, outbound.SendRequest{
 		To: []string{ag.EmailAddress()}, Subject: "plain", Body: "hi me",
-	}, "send", ""); oerr != nil {
+	}, "send", "", nil); oerr != nil {
 		t.Fatalf("DeliverOutbound: status=%d msg=%s", oerr.Status, oerr.Msg)
 	}
 

--- a/internal/apiserver/apiserver.go
+++ b/internal/apiserver/apiserver.go
@@ -80,6 +80,7 @@ func BuildDeps(p Params) httpapi.Deps {
 		LookupDomain:             p.Store.LookupDomain,
 		EnforceAgentCreate:       p.Enforcer.CheckAgentCreate,
 		UpdateAgentHITL:          p.Store.UpdateAgentHITL,
+		UpdateAgentHITLMode:      p.Store.UpdateAgentHITLMode,
 		UpdateAgentInboundPolicy: p.Store.UpdateAgentInboundPolicy,
 		DeleteAgent:              p.Store.DeleteAgent,
 

--- a/internal/httpapi/agents_write.go
+++ b/internal/httpapi/agents_write.go
@@ -110,6 +110,9 @@ type UpdateAgentRequest struct {
 	HITLEnabled          *bool   `json:"hitl_enabled,omitempty"`
 	HITLTTLSeconds       *int    `json:"hitl_ttl_seconds,omitempty"`
 	HITLExpirationAction *string `json:"hitl_expiration_action,omitempty"`
+	// HITLMode is the action-gate sub-mode (Slice 7b): "all" | "high_impact".
+	// Settable independently of the other HITL fields.
+	HITLMode *string `json:"hitl_mode,omitempty"`
 	// InboundPolicy / InboundAllowlist set the per-agent inbound ingestion gate
 	// (migration 033 / Slice 7). Pointers so absent != zero.
 	InboundPolicy    *string   `json:"inbound_policy,omitempty"`
@@ -152,6 +155,16 @@ func (s *Server) handleUpdateAgent(ctx context.Context, in *updateAgentInput) (*
 			return nil, NewError(http.StatusInternalServerError, "internal_error", "update unavailable")
 		}
 		if err := s.deps.UpdateAgentHITL(ctx, ag.ID, ag.UserID, enabled, ttl, action); err != nil {
+			return nil, NewError(http.StatusBadRequest, "invalid_request", err.Error())
+		}
+		touched = true
+	}
+
+	if req.HITLMode != nil {
+		if s.deps.UpdateAgentHITLMode == nil {
+			return nil, NewError(http.StatusInternalServerError, "internal_error", "update unavailable")
+		}
+		if err := s.deps.UpdateAgentHITLMode(ctx, ag.ID, ag.UserID, *req.HITLMode); err != nil {
 			return nil, NewError(http.StatusBadRequest, "invalid_request", err.Error())
 		}
 		touched = true

--- a/internal/httpapi/agents_write_test.go
+++ b/internal/httpapi/agents_write_test.go
@@ -85,6 +85,49 @@ func TestUpdateAgentInboundPolicy(t *testing.T) {
 	}
 }
 
+// TestUpdateAgentHITLMode exercises the PATCH → store → AgentView round-trip
+// for the Slice 7b action-gate sub-mode, and the 400 on an invalid mode.
+func TestUpdateAgentHITLMode(t *testing.T) {
+	ag := sampleAgent()
+	ag.HITLMode = "all"
+	deps := Deps{
+		Authenticator: func(r *http.Request) (*identity.User, error) {
+			if r.Header.Get("Authorization") == "Bearer good" {
+				return &identity.User{ID: "u_1", Email: "owner@acme.com"}, nil
+			}
+			return nil, errors.New("unauthorized")
+		},
+		GetAgent: func(ctx context.Context, address string) (*identity.AgentIdentity, error) {
+			if address == "support@acme.com" {
+				a := ag
+				return &a, nil
+			}
+			return nil, errors.New("not found")
+		},
+		UpdateAgentHITLMode: func(ctx context.Context, agentID, userID, mode string) error {
+			if mode != "all" && mode != "high_impact" {
+				return errors.New("invalid hitl_mode " + mode)
+			}
+			ag.HITLMode = mode
+			return nil
+		},
+		Legacy: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusTeapot) }),
+	}
+	srv := httptest.NewServer(New(deps))
+	t.Cleanup(srv.Close)
+
+	// Valid mode round-trips onto the AgentView.
+	code, body := sendJSON(t, "PATCH", srv.URL+"/v1/agents/support%40acme.com", "good", map[string]any{"hitl_mode": "high_impact"})
+	if code != 200 || body["hitl_mode"] != "high_impact" {
+		t.Fatalf("expected 200 + hitl_mode=high_impact, got %d %v", code, body)
+	}
+	// Invalid mode → 400 invalid_request.
+	code, body = sendJSON(t, "PATCH", srv.URL+"/v1/agents/support%40acme.com", "good", map[string]any{"hitl_mode": "bogus"})
+	if code != 400 || errCode(body) != "invalid_request" {
+		t.Fatalf("expected 400 invalid_request for bogus mode, got %d %v", code, body)
+	}
+}
+
 func TestUpdateAgentNoFields(t *testing.T) {
 	srv := testServer(t)
 	code, body := sendJSON(t, "PATCH", srv.URL+"/v1/agents/support%40acme.com", "good", map[string]any{})

--- a/internal/httpapi/httpapi.go
+++ b/internal/httpapi/httpapi.go
@@ -91,6 +91,9 @@ type Deps struct {
 	LookupDomain       DomainLookup
 	EnforceAgentCreate AgentCreateEnforcer
 	UpdateAgentHITL    AgentHITLUpdater
+	// UpdateAgentHITLMode sets the action-gate sub-mode (Slice 7b). Returns a
+	// validation error for an unknown mode (handler maps to 400).
+	UpdateAgentHITLMode func(ctx context.Context, agentID, userID, mode string) error
 	// UpdateAgentInboundPolicy sets the per-agent inbound ingestion gate
 	// (migration 033 / Slice 7). Returns a validation error for an unknown
 	// policy, which the handler maps to 400 invalid_request.
@@ -114,7 +117,7 @@ type Deps struct {
 	Idempotency IdemStore
 
 	// outbound (the shared live delivery path extracted from agent.API)
-	DeliverOutbound func(ctx context.Context, user *identity.User, ag *identity.AgentIdentity, req outbound.SendRequest, msgType, replyToEmailMessageID string) (*agent.OutboundResult, *agent.OutboundError)
+	DeliverOutbound func(ctx context.Context, user *identity.User, ag *identity.AgentIdentity, req outbound.SendRequest, msgType, replyToEmailMessageID string, referenced *identity.Message) (*agent.OutboundResult, *agent.OutboundError)
 	SendTest        func(ctx context.Context, ag *identity.AgentIdentity) (*agent.OutboundResult, *agent.OutboundError)
 	// HITL approve/reject (the held-draft decision)
 	ApprovePending     func(ctx context.Context, userID, messageID, expectedAgentEmail string, ovr agent.ApproveOverrides) (*identity.Message, *agent.OutboundError)

--- a/internal/httpapi/operations.go
+++ b/internal/httpapi/operations.go
@@ -56,6 +56,10 @@ type AgentView struct {
 	HITLEnabled          bool      `json:"hitl_enabled"`
 	HITLTTLSeconds       int       `json:"hitl_ttl_seconds"`
 	HITLExpirationAction string    `json:"hitl_expiration_action"`
+	// HITLMode is the action-gate sub-mode (Slice 7b): "all" (hold every
+	// outbound when HITL is on) or "high_impact" (hold only a high-impact action
+	// on unauthenticated inbound). Meaningful only when hitl_enabled.
+	HITLMode string `json:"hitl_mode"`
 	// InboundPolicy is the per-agent inbound ingestion gate (migration 033 /
 	// Slice 7): one of open, allowlist, domain, verified_only. InboundAllowlist
 	// holds the trusted addresses (allowlist) or domains (domain); omitted when
@@ -76,6 +80,7 @@ func agentViewFromIdentity(ag *identity.AgentIdentity) AgentView {
 		HITLEnabled:          ag.HITLEnabled,
 		HITLTTLSeconds:       ag.HITLTTLSeconds,
 		HITLExpirationAction: ag.HITLExpirationAction,
+		HITLMode:             ag.HITLMode,
 		InboundPolicy:        ag.InboundPolicy,
 		InboundAllowlist:     ag.InboundAllowlist,
 	}

--- a/internal/httpapi/operations_test.go
+++ b/internal/httpapi/operations_test.go
@@ -305,7 +305,7 @@ func testServer(t *testing.T) *httptest.Server {
 			}
 			return nil, errors.New("not found")
 		},
-		DeliverOutbound: func(ctx context.Context, user *identity.User, ag *identity.AgentIdentity, req outbound.SendRequest, msgType, replyTo string) (*agent.OutboundResult, *agent.OutboundError) {
+		DeliverOutbound: func(ctx context.Context, user *identity.User, ag *identity.AgentIdentity, req outbound.SendRequest, msgType, replyTo string, referenced *identity.Message) (*agent.OutboundResult, *agent.OutboundError) {
 			switch {
 			case strings.Contains(req.Subject, "HOLD"):
 				exp := time.Unix(1700090000, 0).UTC()

--- a/internal/httpapi/outbound.go
+++ b/internal/httpapi/outbound.go
@@ -202,7 +202,7 @@ func (s *Server) handleReply(ctx context.Context, in *replyInput) (*sendOutput, 
 	}
 	req.CC = agent.StripAgentSelfAliases(req.CC, ag.EmailAddress())
 	req.BCC = agent.StripAgentSelfAliases(req.BCC, ag.EmailAddress())
-	return s.deliver(ctx, user, ag, req, "reply", inbound.EmailMessageID, "/v1/reply/"+in.ID, in.IdempotencyKey, in.RawBody)
+	return s.deliver(ctx, user, ag, req, "reply", inbound.EmailMessageID, "/v1/reply/"+in.ID, in.IdempotencyKey, in.RawBody, inbound)
 }
 
 // ForwardRequest mirrors the legacy forward body.
@@ -252,7 +252,7 @@ func (s *Server) handleForward(ctx context.Context, in *forwardInput) (*sendOutp
 	}
 	req.CC = agent.StripAgentSelfAliases(req.CC, ag.EmailAddress())
 	req.BCC = agent.StripAgentSelfAliases(req.BCC, ag.EmailAddress())
-	return s.deliver(ctx, user, ag, req, "forward", inbound.EmailMessageID, "/v1/forward/"+in.ID, in.IdempotencyKey, in.RawBody)
+	return s.deliver(ctx, user, ag, req, "forward", inbound.EmailMessageID, "/v1/forward/"+in.ID, in.IdempotencyKey, in.RawBody, inbound)
 }
 
 // validateOutboundBody runs the shared pre-send validation.
@@ -277,7 +277,7 @@ func (s *Server) validateOutboundBody(subject, body string, to, cc, bcc []string
 
 // deliver runs the domain-verified + enforce-cap checks then DeliverOutbound
 // under the idempotency handshake, mapping the OutboundResult to the wire view.
-func (s *Server) deliver(ctx context.Context, user *identity.User, ag *identity.AgentIdentity, req outbound.SendRequest, msgType, replyTo, route, idemKey string, rawBody []byte) (*sendOutput, error) {
+func (s *Server) deliver(ctx context.Context, user *identity.User, ag *identity.AgentIdentity, req outbound.SendRequest, msgType, replyTo, route, idemKey string, rawBody []byte, referenced *identity.Message) (*sendOutput, error) {
 	if env := s.checkSendLimit(ag.ID); env != nil {
 		return nil, env
 	}
@@ -296,7 +296,7 @@ func (s *Server) deliver(ctx context.Context, user *identity.User, ag *identity.
 		return nil, NewError(http.StatusInternalServerError, "internal_error", "outbound delivery unavailable")
 	}
 	status, view, err := runIdempotent(s, ctx, user.ID, idemKey, route, rawBody, func() (int, SendResultView, error) {
-		res, derr := s.deps.DeliverOutbound(ctx, user, ag, req, msgType, replyTo)
+		res, derr := s.deps.DeliverOutbound(ctx, user, ag, req, msgType, replyTo, referenced)
 		if derr != nil {
 			return 0, SendResultView{}, NewError(derr.Status, derr.Code, derr.Msg)
 		}
@@ -360,5 +360,7 @@ func (s *Server) handleCreateMessage(ctx context.Context, in *createMessageInput
 	// could collide on an identical key+body (the body hash alone no longer
 	// separates them).
 	route := "/v1/agents/" + ag.ID + "/messages"
-	return s.deliver(ctx, user, ag, req, "send", "", route, in.IdempotencyKey, in.RawBody)
+	// A cold send has no referenced inbound — passes nil, so high_impact mode
+	// never holds it (no untrusted input being acted on).
+	return s.deliver(ctx, user, ag, req, "send", "", route, in.IdempotencyKey, in.RawBody, nil)
 }

--- a/internal/httpapi/outbound_idem_test.go
+++ b/internal/httpapi/outbound_idem_test.go
@@ -52,7 +52,7 @@ func TestSendIdempotencyRouteIncludesAgent(t *testing.T) {
 			return nil, errors.New("not found")
 		},
 		Idempotency: rec,
-		DeliverOutbound: func(ctx context.Context, u *identity.User, ag *identity.AgentIdentity, req outbound.SendRequest, mt, rt string) (*agent.OutboundResult, *agent.OutboundError) {
+		DeliverOutbound: func(ctx context.Context, u *identity.User, ag *identity.AgentIdentity, req outbound.SendRequest, mt, rt string, ref *identity.Message) (*agent.OutboundResult, *agent.OutboundError) {
 			return &agent.OutboundResult{MessageID: "m", Method: "smtp"}, nil
 		},
 	}))

--- a/internal/httpapi/ratelimit_test.go
+++ b/internal/httpapi/ratelimit_test.go
@@ -180,7 +180,7 @@ func serverWithSendLimit(t *testing.T) *httptest.Server {
 			return &identity.AgentIdentity{ID: "support@acme.com", Email: "support@acme.com", UserID: "u_1", DomainVerified: true}, nil
 		},
 		SendLimit: func(key string) (bool, time.Duration) { return false, 7 * time.Second },
-		DeliverOutbound: func(ctx context.Context, u *identity.User, ag *identity.AgentIdentity, req outbound.SendRequest, mt, rt string) (*agent.OutboundResult, *agent.OutboundError) {
+		DeliverOutbound: func(ctx context.Context, u *identity.User, ag *identity.AgentIdentity, req outbound.SendRequest, mt, rt string, ref *identity.Message) (*agent.OutboundResult, *agent.OutboundError) {
 			t.Error("DeliverOutbound must NOT be reached when rate-limited")
 			return &agent.OutboundResult{}, nil
 		},

--- a/internal/identity/hitl_test.go
+++ b/internal/identity/hitl_test.go
@@ -102,6 +102,44 @@ func TestUpdateAgentHITL(t *testing.T) {
 	}
 }
 
+// TestUpdateAgentHITLMode covers the Slice 7b sub-mode setter: default 'all',
+// round-trip to 'high_impact', invalid mode rejected, cross-tenant rejected.
+func TestUpdateAgentHITLMode(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	user, _ := store.CreateOrGetUser(ctx, "owner@hitlmode.example.com", "Owner", "google-hitlmode")
+	store.ClaimOrCreateDomain(ctx, "hitlmode.example.com", user.ID)
+	a, _ := store.CreateAgent(ctx, "bot@hitlmode.example.com", "hitlmode.example.com", "", "", "", user.ID)
+
+	// Fresh agent defaults to 'all' (column default, read via GetAgentByID).
+	got, _ := store.GetAgentByID(ctx, a.ID)
+	if got.HITLMode != "all" {
+		t.Errorf("fresh HITLMode = %q, want all", got.HITLMode)
+	}
+
+	if err := store.UpdateAgentHITLMode(ctx, a.ID, user.ID, "high_impact"); err != nil {
+		t.Fatalf("UpdateAgentHITLMode: %v", err)
+	}
+	got, _ = store.GetAgentByID(ctx, a.ID)
+	if got.HITLMode != "high_impact" {
+		t.Errorf("HITLMode = %q, want high_impact", got.HITLMode)
+	}
+
+	// Invalid mode → clean error, no mutation.
+	if err := store.UpdateAgentHITLMode(ctx, a.ID, user.ID, "bogus"); err == nil {
+		t.Error("expected error for invalid hitl_mode")
+	}
+	// Cross-tenant → error, no mutation.
+	if err := store.UpdateAgentHITLMode(ctx, a.ID, "other-user", "all"); err == nil {
+		t.Error("expected error updating another user's agent")
+	}
+	got, _ = store.GetAgentByID(ctx, a.ID)
+	if got.HITLMode != "high_impact" {
+		t.Errorf("HITLMode mutated by rejected updates: %q", got.HITLMode)
+	}
+}
+
 func TestUpdateAgentHITLValidation(t *testing.T) {
 	pool := testutil.TestDB(t)
 	store := identity.NewStore(pool)

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Mnexa-AI/e2a/internal/actiongate"
 	"github.com/Mnexa-AI/e2a/internal/dkim"
 	"github.com/Mnexa-AI/e2a/internal/emailauth"
 	"github.com/Mnexa-AI/e2a/internal/inboundpolicy"
@@ -86,6 +87,10 @@ type AgentIdentity struct {
 	HITLEnabled          bool      `json:"hitl_enabled"`
 	HITLTTLSeconds       int       `json:"hitl_ttl_seconds"`
 	HITLExpirationAction string    `json:"hitl_expiration_action"`
+	// HITLMode is the action-gate sub-mode (migration 036 / Slice 7b): "all"
+	// (hold every outbound when HITL is on; the default) or "high_impact" (hold
+	// only a high-impact action on untrusted inbound). Ignored when HITL is off.
+	HITLMode string `json:"hitl_mode"`
 	// Dashboard enrichment fields. Computed at read
 	// time by ListAgentsByUser via correlated subqueries — other load
 	// paths (GetAgentByID / GetAgentByEmail) leave them at zero values,
@@ -732,6 +737,7 @@ func (s *Store) GetAgentByID(ctx context.Context, id string) (*AgentIdentity, er
 	err := s.pool.QueryRow(ctx,
 		`SELECT a.id, a.domain, a.user_id, a.name, a.public, a.created_at,
 		        a.hitl_enabled, a.hitl_ttl_seconds, a.hitl_expiration_action,
+		        COALESCE(a.hitl_mode, 'all'),
 		        COALESCE(a.inbound_policy, 'open'), a.inbound_allowlist,
 		        COALESCE(a.assertion_version, 1),
 		        d.verified as domain_verified
@@ -740,6 +746,7 @@ func (s *Store) GetAgentByID(ctx context.Context, id string) (*AgentIdentity, er
 		 WHERE a.id = $1`, id,
 	).Scan(&a.ID, &a.Domain, &a.UserID, &a.Name, &a.Public, &a.CreatedAt,
 		&a.HITLEnabled, &a.HITLTTLSeconds, &a.HITLExpirationAction,
+		&a.HITLMode,
 		&a.InboundPolicy, &a.InboundAllowlist,
 		&a.AssertionVersion,
 		&a.DomainVerified)
@@ -823,6 +830,27 @@ func (s *Store) UpdateAgentHITL(ctx context.Context, agentID, userID string, ena
 		        hitl_expiration_action = $3
 		  WHERE id = $4 AND user_id = $5`,
 		enabled, ttlSeconds, expirationAction, agentID, userID,
+	)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("agent not found or not owned by user")
+	}
+	return nil
+}
+
+// UpdateAgentHITLMode sets the action-gate sub-mode (migration 036 / Slice 7b)
+// on an agent owned by userID. Independent of UpdateAgentHITL so a PATCH can set
+// hitl_mode without re-sending the other HITL fields (additive-PATCH model). An
+// unknown mode is rejected with a clean error rather than a raw CHECK violation.
+func (s *Store) UpdateAgentHITLMode(ctx context.Context, agentID, userID, mode string) error {
+	if !actiongate.Valid(mode) {
+		return fmt.Errorf("invalid hitl_mode %q", mode)
+	}
+	tag, err := s.pool.Exec(ctx,
+		`UPDATE agent_identities SET hitl_mode = $3 WHERE id = $1 AND user_id = $2`,
+		agentID, userID, mode,
 	)
 	if err != nil {
 		return err

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -906,6 +906,7 @@ func (s *Store) ListAgentsByUser(ctx context.Context, userID string) ([]AgentIde
 	rows, err := s.pool.Query(ctx,
 		`SELECT a.id, a.domain, a.user_id, a.name, a.public, a.created_at,
 		        a.hitl_enabled, a.hitl_ttl_seconds, a.hitl_expiration_action,
+		        COALESCE(a.hitl_mode, 'all'),
 		        COALESCE(a.inbound_policy, 'open'), a.inbound_allowlist,
 		        d.verified as domain_verified,
 		        (SELECT count(*) FROM messages m
@@ -942,6 +943,7 @@ func (s *Store) ListAgentsByUser(ctx context.Context, userID string) ([]AgentIde
 		var lastDeliveryAt *time.Time
 		if err := rows.Scan(&a.ID, &a.Domain, &a.UserID, &a.Name, &a.Public, &a.CreatedAt,
 			&a.HITLEnabled, &a.HITLTTLSeconds, &a.HITLExpirationAction,
+			&a.HITLMode,
 			&a.InboundPolicy, &a.InboundAllowlist,
 			&a.DomainVerified,
 			&a.Inbound7d, &a.Outbound7d, &a.PendingCount,

--- a/migrations/036_hitl_mode.sql
+++ b/migrations/036_hitl_mode.sql
@@ -1,0 +1,20 @@
+-- 036_hitl_mode.sql
+--
+-- HITL action-gate sub-mode (decision 10 / Slice 7b). hitl_enabled stays the
+-- on/off switch; hitl_mode refines WHAT gets held when it's on:
+--
+--   all          — hold every outbound for approval (the pre-7b behavior).
+--   high_impact  — hold only a high-impact action taken on untrusted input
+--                  (recipient outside the referenced inbound's participants AND
+--                  that inbound failed DMARC).
+--
+-- Default 'all' so every existing hitl_enabled agent is byte-for-byte unchanged;
+-- opting into trust-gating is an explicit hitl_mode='high_impact' update.
+-- Idempotent + non-destructive (metadata-only ADD COLUMN on PG11+).
+ALTER TABLE agent_identities
+    ADD COLUMN IF NOT EXISTS hitl_mode TEXT NOT NULL DEFAULT 'all';
+
+DO $$ BEGIN
+    ALTER TABLE agent_identities ADD CONSTRAINT agent_identities_hitl_mode_check
+        CHECK (hitl_mode IN ('all', 'high_impact'));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;


### PR DESCRIPTION
## Slice 7b — Trust-gated action authorization

The HITL action gate gains a **sub-mode** so it holds *suspicious* outbound rather than *all* outbound — the outbound/action axis of decision 10, composing with the 5a hard scope ceiling. **DMARC-based today**, with the "untrusted input" signal modeled as a **pluggable seam** so a content-level prompt-injection verdict (partner scan API, under evaluation) can fold in later without rework.

### Behavior
- `agent_identities.hitl_mode ∈ {all, high_impact}` (migration 036, DEFAULT `all`, CHECK). `hitl_enabled` stays on/off; `hitl_mode` refines *what* is held. **Default `all` = pre-7b behavior**, so every existing HITL agent is unchanged; trust-gating is an explicit `hitl_mode=high_impact` PATCH.
- In `high_impact`, an outbound (reply/forward) is held **iff both**: the referenced inbound's **`dmarc != pass`** (weak/spoofable — read from the server-owned `auth_verdict`, never client input; a missing verdict is fail-closed-untrusted) **and** a recipient reaches a **domain outside the referenced inbound's participants** (reply to a new party / forward to a third party). Trusted-thread + in-thread replies send straight through; a cold send (no referenced inbound) is never held in this mode.

### Design
- `internal/actiongate` — stdlib leaf (mirrors `inboundpolicy`); pure decision + `HighImpact` domain logic.
- `DeliverOutbound` threads the referenced `*identity.Message` (reply/forward pass the loaded inbound; send/test pass nil). `actionGateHold` extracts the verdict + participants and calls the leaf.
- `hitl_mode` surfaced on `AgentView`, settable via `update_agent` (`UpdateAgentHITLMode`, validated → 400). Spec regenerated.

### Verification
- `actiongate`, `agent`, `identity`, `httpapi`, `auth`, `e2e` (`-p 1`) ✅; `TestSpecGoldenNoDrift` ✅.
- **Real-binary over-the-wire e2e**: unauth inbound via SMTP → `dmarc=none`; `high_impact` reply with a third-party CC = **202 held**, in-thread reply = **not held**, `hitl_mode=all` in-thread reply = **202 held**. Log clean.
- Tests: leaf mode-matrix + HighImpact + fail-closed; `actionGateHold` white-box (verdict pass/fail, in-thread vs third-party, all/high_impact/empty/missing-verdict); store round-trip + invalid + cross-tenant; httpapi PATCH + 400.

### Pluggable seam (deferred)
The `actiongate` "untrusted input" signal is a plain bool — a content prompt-injection verdict can OR into it later. That partner-scan integration is a separate, off-by-default decision; e2a core stays provider-agnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)