### PR TITLE
chore(spec): harden api/openapi.yaml for SDK codegen (Slice 8 prep)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -109,8 +109,14 @@ components:
         hitl_enabled:
           type: boolean
         hitl_expiration_action:
+          enum:
+            - approve
+            - reject
           type: string
         hitl_mode:
+          enum:
+            - all
+            - high_impact
           type: string
         hitl_ttl_seconds:
           format: int64
@@ -124,6 +130,11 @@ components:
             - array
             - "null"
         inbound_policy:
+          enum:
+            - open
+            - allowlist
+            - domain
+            - verified_only
           type: string
         name:
           type: string
@@ -599,6 +610,19 @@ components:
         status:
           type: string
         type:
+          enum:
+            - email.received
+            - email.sent
+            - email.pending_approval
+            - email.approved
+            - email.rejected
+            - domain.sending_verified
+            - domain.sending_failed
+            - email.delivered
+            - email.bounced
+            - email.complained
+            - domain.suppression_added
+            - email.flagged
           type: string
       required:
         - id
@@ -893,10 +917,19 @@ components:
         conversation_id:
           type: string
         created_at:
+          format: date-time
           type: string
         delivery_detail:
           type: string
         delivery_status:
+          enum:
+            - queued
+            - sent
+            - delivered
+            - bounced
+            - complained
+            - deferred
+            - failed
           type: string
         direction:
           type: string
@@ -925,6 +958,9 @@ components:
             - array
             - "null"
         sent_as:
+          enum:
+            - own_address
+            - relay
           type: string
         size_bytes:
           format: int64
@@ -974,10 +1010,19 @@ components:
         conversation_id:
           type: string
         created_at:
+          format: date-time
           type: string
         delivery_detail:
           type: string
         delivery_status:
+          enum:
+            - queued
+            - sent
+            - delivered
+            - bounced
+            - complained
+            - deferred
+            - failed
           type: string
         flag_reason:
           type: string
@@ -1007,6 +1052,9 @@ components:
             - array
             - "null"
         sent_as:
+          enum:
+            - own_address
+            - relay
           type: string
         status:
           type: string
@@ -1533,6 +1581,19 @@ components:
         created_at:
           type: string
         event_type:
+          enum:
+            - email.received
+            - email.sent
+            - email.pending_approval
+            - email.approved
+            - email.rejected
+            - domain.sending_verified
+            - domain.sending_failed
+            - email.delivered
+            - email.bounced
+            - email.complained
+            - domain.suppression_added
+            - email.flagged
           type: string
         id:
           type: string
@@ -2929,3 +2990,6 @@ paths:
       summary: Fire a synthetic event
       tags:
         - webhooks
+servers:
+  - description: Production
+    url: https://api.e2a.dev

--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -1400,8 +1400,82 @@ Break the current `/api/v1` surface directly and move it to
     Built on the 5a hard scope ceiling (decision 10 / §5). No new contract
     surface beyond `hitl_mode`.
 
+* **Slice 8 — Consumer port (SDK regen + `/v1` repoint + legacy retirement).**
+  *(Planned.)* Switch SDK codegen from the legacy swag pipeline
+  (`swag init` → Swagger 2.0 → `swagger2openapi` → `openapi-typescript` /
+  `datamodel-codegen`) to **OpenAPI Generator** consuming the Huma-emitted
+  `api/openapi.yaml` (3.1) directly, then repoint web/MCP/CLI from `/api/v1` to
+  `/v1` and retire the legacy strangler. Validated by a generation spike +
+  independent and adversarial review (2026-06); findings folded in below.
+
+  **Generator selection (validated, pinned).**
+    * **TypeScript: the `typescript` generator — NOT `typescript-fetch`.** The
+      `typescript-fetch` output **fails to compile** (TS2590 "union type too
+      complex" from per-field `instanceOf` guards on wide models like
+      `AgentIdentity`; unfixable by tsconfig flags). The modular `typescript`
+      generator compiles clean and is *more* capable: `pre`/`post` **middleware**
+      hooks (the injection point for retries / idempotency / logging), a typed
+      **`ApiException<ErrorEnvelope>`** that wires the `default` error response
+      (so `error.code`/`request_id` are typed — `typescript-fetch` dropped them),
+      per-op bearer auth, configurable `baseServer`, and Promise/Observable/
+      ObjectParam client flavors.
+    * **Python: the `python` generator** (pydantic v2 + urllib3) — works as-is:
+      typed status-mapped exception hierarchy, safe-by-default retries
+      (urllib3 v2 excludes POST, so no duplicate-send on 5xx), `from`→`var_from`
+      alias round-trips correctly.
+    * **Pin the image to a released tag** (e.g. `openapitools/openapi-generator-cli:v7.16.0`,
+      not `:latest`/SNAPSHOT) and assert the version in the regen-diff gate.
+      Output is **deterministic** (regen twice = byte-identical), so
+      `git diff --exit-code` is a sound gate once the version is pinned.
+
+  **Fix the spec FIRST (the real value is here, not the generator).** Both
+  reviews converged: today's `api/openapi.yaml` under-specifies fields that
+  degrade *any* generated SDK. Before regenerating, add to the Huma view/input
+  structs and re-run `make spec`:
+    * **`enum:` tags** on the constrained body fields that currently emit as bare
+      `string`: `hitl_mode {all,high_impact}`, `inbound_policy
+      {open,allowlist,domain,verified_only}`, `delivery_status`, `sent_as
+      {own_address,relay}`, message `status`, webhook `event_type` (validate the
+      last against `webhookpub.AllEventTypes` so it can't drift) → union types in
+      TS, `Enum` in Python.
+    * **`required:`** on request bodies (`SendEmailRequest` has none, so
+      `to`/`subject`/`body` generate optional — losing the compile-time recipient
+      check) and drop the `,null` on arrays that mean "omit when empty."
+    * **`format: date-time`** on `MessageView`/`MessageSummaryView` `created_at`
+      (missing it → typed `string` on those models but `Date`/`datetime`
+      elsewhere — a latent `.getTime()` crash).
+    * **`servers:`** block (today absent → both SDKs default to
+      `http://localhost`, a Bearer-over-cleartext footgun).
+
+  **What stays first-class hand-written (NOT "thin ergonomics").** The generator
+  only sees the REST subset Huma emits; these are not in `api/openapi.yaml` and
+  must be hand-built and preserved via `.openapi-generator-ignore`:
+    * the **WebSocket** live-tail client (real-time delivery),
+    * the **agent-identity / OAuth token** client (`/agent/identity`,
+      `/oauth2/token` jwt-bearer, JWKS — Slice 5b, already shipped server-side),
+    * **HMAC webhook verification** + inbound `.parse()` / `.reply()` / `.forward()`
+      ergonomics, and
+    * a **Python error-envelope mapping** (the `python` generator collapses
+      `{error:{code,request_id}}` to the HTTP status, leaving `error.code` only in
+      the raw `.body`; TS is already covered by `ApiException<ErrorEnvelope>`).
+    Re-homing the ergonomic layer onto the generated `*Api` classes is a
+    **rewrite, not a swap** — budget it as the slice's real cost.
+    *(Optional: stub `/oauth2/token` + `/agent/identity` into the spec so at
+    least their request/response models are generated and drift-tested.)*
+
+  **Sequencing (legacy dies last).** (a) Fix the spec (enums/required/servers/
+  format) and regen; (b) ship/deploy `/v1` parity for every route the SDKs need;
+  (c) regenerate the SDK base against `/v1` + rewrite the ergonomic layer;
+  (d) repoint web + MCP + CLI from `/api/v1` to `/v1`; (e) **last**, delete the
+  flat `/api/v1/messages/{id}` and the remaining legacy mux write surface
+  (§11 strangler residue) — which also closes the Slice-5a confinement gap and
+  unblocks advertising `e2a_agt_` keys. Never combine "introduce generated base"
+  with "delete legacy" in one PR; isolate the mechanical codegen-source switch
+  (large auto-generated diff) into its own PR.
+
 Slices 1–6 are independently shippable; 1–2 deliver most of the "clean and
-consistent" win. Slice 7 is a post-parity enhancement.
+consistent" win. Slice 7 is a post-parity enhancement; Slice 8 (consumer port)
+is the cleanup that retires the legacy surface.
 
 ## 9a. Configuration & env-var surface
 
@@ -1500,8 +1574,12 @@ E2A_SMTP_URL          # only if sending mail
    typed handlers); no hand-authoring (no spec toolchain exists today). SDKs are
    generated (OpenAPI Generator); the **MCP surface is hand-curated and
    contract-locked**, not generated (§6a — tool↔`operationId` map + coverage
-   gate). Open sub-point: confirm the py/ts SDK generator config under
-   OpenAPI Generator.
+   gate). *Resolved (Slice 8, validated 2026-06):* TS uses the **`typescript`**
+   generator (not `typescript-fetch`, which fails TS2590), Python the **`python`**
+   (pydantic v2) generator, pinned to a released `openapi-generator-cli` tag;
+   spec must gain `enum`/`required`/`servers`/`format` first, and WS +
+   agent-identity/OAuth + the Python error-envelope mapping stay hand-written.
+   See Slice 8 for the full plan.
 3. ~~Magic-link alias shape~~ — **resolved:** one transition
    (`POST …/messages/{id}/approval {decision}`); the human magic link is
    `GET /approvals/{token}` → HTML confirmation page (no side effect),

--- a/internal/agent/events_api.go
+++ b/internal/agent/events_api.go
@@ -33,7 +33,7 @@ func (a *API) SetPoolForEvents(p *pgxpool.Pool) { a.eventsPool = p }
 // GET /events/{id}. Mirrors design §4.6.
 type eventJSON struct {
 	ID             string                 `json:"id"`
-	Type           string                 `json:"type"`
+	Type           string                 `json:"type" enum:"email.received,email.sent,email.pending_approval,email.approved,email.rejected,domain.sending_verified,domain.sending_failed,email.delivered,email.bounced,email.complained,domain.suppression_added,email.flagged"`
 	SchemaVersion  int                    `json:"schema_version"`
 	CreatedAt      time.Time              `json:"created_at"`
 	AgentID        *string                `json:"agent_id,omitempty"`

--- a/internal/httpapi/httpapi.go
+++ b/internal/httpapi/httpapi.go
@@ -231,6 +231,14 @@ func New(deps Deps) *Server {
 	config.CreateHooks = nil
 	config.Transformers = []huma.Transformer{stampRequestID}
 	config.Info.Description = "e2a — authenticated email gateway for AI agents. v1 contract."
+	// Canonical production host (api-v1-redesign §1: "Canonical base URL
+	// https://api.e2a.dev/v1"). Operations already carry the /v1 prefix, so the
+	// server URL stops at the host — otherwise clients would double it. Without a
+	// servers block, generated SDKs default to http://localhost (a
+	// Bearer-over-cleartext footgun).
+	config.Servers = []*huma.Server{
+		{URL: "https://api.e2a.dev", Description: "Production"},
+	}
 	// One auth scheme across the surface: a Bearer credential that is
 	// either an API key or an OAuth 2.1 access token (api-v1-redesign §5).
 	config.Components.SecuritySchemes = map[string]*huma.SecurityScheme{

--- a/internal/httpapi/messages.go
+++ b/internal/httpapi/messages.go
@@ -33,20 +33,20 @@ type MessageView struct {
 	// DeliveryStatus is the outbound delivery rollup (migration 031:
 	// 'sent', 'delivered', 'bounced', …) — the worst recipient status by
 	// precedence. Outbound-only; omitted on inbound messages.
-	DeliveryStatus string `json:"delivery_status,omitempty"`
+	DeliveryStatus string `json:"delivery_status,omitempty" enum:"queued,sent,delivered,bounced,complained,deferred,failed"`
 	// DeliveryDetail is the human-readable diagnostic for the delivery
 	// rollup (e.g. bounce sub-type / SMTP response). Outbound-only.
 	DeliveryDetail string `json:"delivery_detail,omitempty"`
 	// SentAs is the From identity actually used at relay accept time.
 	// Outbound-only; omitted on inbound messages.
-	SentAs string `json:"sent_as,omitempty"`
+	SentAs string `json:"sent_as,omitempty" enum:"own_address,relay"`
 	// Flagged + FlagReason carry the inbound ingestion verdict (migration 033 /
 	// Slice 7): true when the agent's inbound_policy gate flagged this message
 	// on arrival (still delivered). Inbound-relevant; omitted on unflagged rows.
 	Flagged     bool              `json:"flagged,omitempty"`
 	FlagReason  string            `json:"flag_reason,omitempty"`
 	Labels      []string          `json:"labels"`
-	CreatedAt   string            `json:"created_at"`
+	CreatedAt   string            `json:"created_at" format:"date-time"`
 	AuthHeaders map[string]string `json:"auth_headers"`
 	// Auth is the structured inbound authentication verdict (SPF/DKIM/DMARC,
 	// each with status + detail) from migration 032. Inbound-only; omitted on
@@ -154,9 +154,9 @@ type MessageSummaryView struct {
 	WebhookError   string   `json:"webhook_error,omitempty"`
 	// DeliveryStatus / DeliveryDetail / SentAs are the outbound delivery
 	// rollup (migration 031). Outbound-only; omitted on inbound rows.
-	DeliveryStatus string `json:"delivery_status,omitempty"`
+	DeliveryStatus string `json:"delivery_status,omitempty" enum:"queued,sent,delivered,bounced,complained,deferred,failed"`
 	DeliveryDetail string `json:"delivery_detail,omitempty"`
-	SentAs         string `json:"sent_as,omitempty"`
+	SentAs         string `json:"sent_as,omitempty" enum:"own_address,relay"`
 	// Flagged + FlagReason are the inbound ingestion verdict (migration 033 /
 	// Slice 7). Surfaced in list views so flagged mail is visible without a
 	// per-message drill-down. Inbound-relevant; omitted on unflagged rows.
@@ -164,7 +164,7 @@ type MessageSummaryView struct {
 	FlagReason string   `json:"flag_reason,omitempty"`
 	SizeBytes  int      `json:"size_bytes,omitempty"`
 	Labels     []string `json:"labels"`
-	CreatedAt  string   `json:"created_at"`
+	CreatedAt  string   `json:"created_at" format:"date-time"`
 	// Auth is the structured inbound authentication verdict (migration 032).
 	// Inbound-only; omitted on outbound rows.
 	Auth *emailauth.Result `json:"auth,omitempty"`

--- a/internal/httpapi/operations.go
+++ b/internal/httpapi/operations.go
@@ -55,16 +55,16 @@ type AgentView struct {
 	CreatedAt            time.Time `json:"created_at"`
 	HITLEnabled          bool      `json:"hitl_enabled"`
 	HITLTTLSeconds       int       `json:"hitl_ttl_seconds"`
-	HITLExpirationAction string    `json:"hitl_expiration_action"`
+	HITLExpirationAction string    `json:"hitl_expiration_action" enum:"approve,reject"`
 	// HITLMode is the action-gate sub-mode (Slice 7b): "all" (hold every
 	// outbound when HITL is on) or "high_impact" (hold only a high-impact action
 	// on unauthenticated inbound). Meaningful only when hitl_enabled.
-	HITLMode string `json:"hitl_mode"`
+	HITLMode string `json:"hitl_mode" enum:"all,high_impact"`
 	// InboundPolicy is the per-agent inbound ingestion gate (migration 033 /
 	// Slice 7): one of open, allowlist, domain, verified_only. InboundAllowlist
 	// holds the trusted addresses (allowlist) or domains (domain); omitted when
 	// empty.
-	InboundPolicy    string   `json:"inbound_policy"`
+	InboundPolicy    string   `json:"inbound_policy" enum:"open,allowlist,domain,verified_only"`
 	InboundAllowlist []string `json:"inbound_allowlist,omitempty"`
 }
 

--- a/internal/httpapi/webhooks.go
+++ b/internal/httpapi/webhooks.go
@@ -299,7 +299,7 @@ func (s *Server) handleTestWebhook(ctx context.Context, in *testWebhookInput) (*
 // WebhookDeliveryView mirrors the legacy per-delivery wire shape.
 type WebhookDeliveryView struct {
 	ID             string `json:"id"`
-	EventType      string `json:"event_type"`
+	EventType      string `json:"event_type" enum:"email.received,email.sent,email.pending_approval,email.approved,email.rejected,domain.sending_verified,domain.sending_failed,email.delivered,email.bounced,email.complained,domain.suppression_added,email.flagged"`
 	Status         string `json:"status"`
 	Attempts       int    `json:"attempts"`
 	LastError      string `json:"last_error,omitempty"`


### PR DESCRIPTION
## What

Adds the OpenAPI metadata that generated SDKs need, fixing gaps surfaced by the OpenAPI-Generator spike + independent/adversarial review. **Zero runtime behavior change** — all changes are response-schema metadata + the `servers` block.

### Changes
- **`enum` on response fields** that were bare `string`:
  - `AgentView`: `hitl_mode {all,high_impact}`, `inbound_policy {open,allowlist,domain,verified_only}`, `hitl_expiration_action {approve,reject}`
  - `MessageView` + `MessageSummaryView`: `delivery_status {queued,sent,delivered,bounced,complained,deferred,failed}`, `sent_as {own_address,relay}`
  - `WebhookDeliveryView` + event-log `type`: over the shipped `webhookpub.AllEventTypes`
  - → SDKs get union/enum types instead of `string`.
- **`format: date-time`** on `MessageView`/`MessageSummaryView` `created_at` (was a bare `string` while every other `created_at` is a `Date` — a latent `.getTime()`/`.year` crash for SDK consumers).
- **`servers` block** (`https://api.e2a.dev`) so generated clients don't default to `http://localhost` (a Bearer-over-cleartext footgun).

### Deliberately NOT touched
Request-body validation. Adding `enum`/`required` to `UpdateAgentRequest` / `SendEmailRequest` would make Huma reject with **422 before the handler runs**, overriding the codebase's handler-owned uniform **400** business-rule messages and changing the error contract. Request validation stays in the handlers; only response/read schemas gain the enums the SDK deserializes against. (Flagged as a separate decision if we ever want client-side request enums.)

### Also
- Records the validated consumer-port plan as **Slice 8** in `docs/design/api-v1-redesign.md` (`typescript` + `python` generators, spec-fix-first, hand-written WS/identity/error layers, legacy-dies-last sequencing) and resolves the §10 open SDK-generator sub-point.

## Verification
- `make spec` regenerated `api/openapi.yaml`; **`TestSpecGoldenNoDrift` green**.
- `go build ./...` clean; enum/format/servers verified present in the spec, and `UpdateAgentRequest.hitl_mode` confirmed still `type: string` (handler-validated).
- Scoped: enums land on response schemas only; request bodies unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)