### PR TITLE
feat(v1): label PATCH /v1/agents/{address}/messages/{id} (Slice 8 S1)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1439,6 +1439,37 @@ components:
         is_primary:
           type: boolean
       type: object
+    UpdateMessageRequest:
+      additionalProperties: false
+      properties:
+        add_labels:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        remove_labels:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+      type: object
+    UpdateMessageResultView:
+      additionalProperties: false
+      properties:
+        labels:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        message_id:
+          type: string
+      required:
+        - message_id
+        - labels
+      type: object
     UpdateWebhookRequest:
       additionalProperties: false
       properties:
@@ -2230,6 +2261,44 @@ paths:
       security:
         - bearer: []
       summary: Get a message
+      tags:
+        - messages
+    patch:
+      description: Apply a labels delta (`add_labels` / `remove_labels`) to a message the caller owns; returns the post-update label set. Each list is capped at 50 entries; labels are lowercase `[a-z0-9:_-]+` up to 64 chars; the `e2a:` prefix is reserved for system labels. A message carries at most 100 labels. An empty delta is a read of the current labels.
+      operationId: updateMessage
+      parameters:
+        - in: path
+          name: address
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateMessageRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UpdateMessageResultView"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+      security:
+        - bearer: []
+      summary: Update a message (labels)
       tags:
         - messages
   /v1/agents/{address}/messages/{id}/approve:

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -1267,12 +1267,12 @@ func (a *API) handleUpdateMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	addLabels, err := normalizeAndValidateLabelList(req.AddLabels, "add")
+	addLabels, err := NormalizeAndValidateLabelList(req.AddLabels, "add")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	removeLabels, err := normalizeAndValidateLabelList(req.RemoveLabels, "remove")
+	removeLabels, err := NormalizeAndValidateLabelList(req.RemoveLabels, "remove")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
@@ -1503,11 +1503,11 @@ func normalizeAndValidateLabel(raw string, allowSystemPrefix bool) (string, erro
 	return l, nil
 }
 
-// normalizeAndValidateLabelList runs each entry through
+// NormalizeAndValidateLabelList runs each entry through
 // normalizeAndValidateLabel, dedups within the slice, and rejects if
 // the slice is empty after trimming or exceeds the per-op cap. The
 // `op` argument is used only to shape the error message.
-func normalizeAndValidateLabelList(raw []string, op string) ([]string, error) {
+func NormalizeAndValidateLabelList(raw []string, op string) ([]string, error) {
 	if len(raw) > MaxLabelsPerOp {
 		return nil, fmt.Errorf("%s_labels exceeds per-request cap of %d", op, MaxLabelsPerOp)
 	}

--- a/internal/apiserver/apiserver.go
+++ b/internal/apiserver/apiserver.go
@@ -72,6 +72,7 @@ func BuildDeps(p Params) httpapi.Deps {
 		GetAgent:               p.Store.GetAgentByEmail,
 		GetMessage:             p.Store.GetMessageWithContent,
 		ListMessages:           p.Store.GetMessagesByAgent,
+		ModifyMessageLabels:    p.Store.ModifyMessageLabels,
 
 		ListConversations: p.Store.ListConversationsByAgent,
 		GetConversation:   p.Store.GetConversationByID,

--- a/internal/httpapi/httpapi.go
+++ b/internal/httpapi/httpapi.go
@@ -83,6 +83,9 @@ type Deps struct {
 	GetAgent               AgentGetter
 	GetMessage             MessageGetter
 	ListMessages           MessageLister
+	// ModifyMessageLabels applies a labels delta to a message scoped to an
+	// agent, returning the post-update set. Mirrors store.ModifyMessageLabels.
+	ModifyMessageLabels func(ctx context.Context, messageID, agentID string, add, remove []string) ([]string, error)
 
 	ListConversations ConversationLister
 	GetConversation   ConversationGetter

--- a/internal/httpapi/messages.go
+++ b/internal/httpapi/messages.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Mnexa-AI/e2a/internal/agent"
 	"github.com/Mnexa-AI/e2a/internal/emailauth"
 	"github.com/Mnexa-AI/e2a/internal/identity"
 	"github.com/Mnexa-AI/e2a/internal/mailparse"
@@ -276,6 +277,78 @@ func (s *Server) registerMessages() {
 		}
 		return &messageOutput{Body: messageViewFromIdentity(msg)}, nil
 	})
+
+	huma.Register(s.API, huma.Operation{
+		OperationID: "updateMessage",
+		Method:      http.MethodPatch,
+		Path:        "/v1/agents/{address}/messages/{id}",
+		Summary:     "Update a message (labels)",
+		Description: "Apply a labels delta (`add_labels` / `remove_labels`) to a message the caller owns; returns the post-update label set. Each list is capped at 50 entries; labels are lowercase `[a-z0-9:_-]+` up to 64 chars; the `e2a:` prefix is reserved for system labels. A message carries at most 100 labels. An empty delta is a read of the current labels.",
+		Tags:        []string{"messages"},
+		Security:    []map[string][]string{{"bearer": {}}},
+	}, s.handleUpdateMessage)
+}
+
+// UpdateMessageRequest is the labels-delta body for PATCH …/messages/{id}.
+// A label in both add and remove is removed (remove wins, per the store).
+type UpdateMessageRequest struct {
+	AddLabels    []string `json:"add_labels,omitempty"`
+	RemoveLabels []string `json:"remove_labels,omitempty"`
+}
+
+type updateMessageInput struct {
+	Address string `path:"address"`
+	ID      string `path:"id"`
+	Body    UpdateMessageRequest
+}
+
+// UpdateMessageResultView echoes the post-update label set so callers can
+// reflect state without a follow-up fetch.
+type UpdateMessageResultView struct {
+	MessageID string   `json:"message_id"`
+	Labels    []string `json:"labels"`
+}
+
+type updateMessageOutput struct {
+	Body UpdateMessageResultView
+}
+
+// handleUpdateMessage applies a labels delta (ports the legacy
+// PATCH /api/v1/agents/{email}/messages/{id}). This is a per-agent operation,
+// so an agent-scoped credential may label its own messages — it goes through
+// resolveOwnedAgent (which pins an agent-scoped credential to its bound agent),
+// NOT requireAccountScope. Label rules are validated via the shared
+// agent.NormalizeAndValidateLabelList so they can't drift from the legacy
+// surface; the store enforces the per-message cap.
+func (s *Server) handleUpdateMessage(ctx context.Context, in *updateMessageInput) (*updateMessageOutput, error) {
+	ag, err := s.resolveOwnedAgent(ctx, in.Address)
+	if err != nil {
+		return nil, err
+	}
+	if s.deps.ModifyMessageLabels == nil {
+		return nil, NewError(http.StatusInternalServerError, "internal_error", "label update unavailable")
+	}
+	add, verr := agent.NormalizeAndValidateLabelList(in.Body.AddLabels, "add")
+	if verr != nil {
+		return nil, NewError(http.StatusBadRequest, "invalid_request", verr.Error())
+	}
+	remove, verr := agent.NormalizeAndValidateLabelList(in.Body.RemoveLabels, "remove")
+	if verr != nil {
+		return nil, NewError(http.StatusBadRequest, "invalid_request", verr.Error())
+	}
+	final, err := s.deps.ModifyMessageLabels(ctx, in.ID, ag.ID, add, remove)
+	if err != nil {
+		switch {
+		case errors.Is(err, identity.ErrMessageNotFound):
+			return nil, NewError(http.StatusNotFound, "not_found", "message not found")
+		case errors.Is(err, identity.ErrLabelLimitExceeded):
+			return nil, NewError(http.StatusBadRequest, "invalid_request",
+				fmt.Sprintf("label limit exceeded — a message may carry at most %d labels", identity.MaxLabelsPerMessage))
+		default:
+			return nil, NewError(http.StatusInternalServerError, "internal_error", "failed to update labels")
+		}
+	}
+	return &updateMessageOutput{Body: UpdateMessageResultView{MessageID: in.ID, Labels: orEmptyStrings(final)}}, nil
 }
 
 // handleListMessages ports the legacy list handler: same filter semantics

--- a/internal/httpapi/messages_labels_test.go
+++ b/internal/httpapi/messages_labels_test.go
@@ -1,0 +1,123 @@
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+)
+
+// labelDeps builds a server whose ModifyMessageLabels fake maps message ids to
+// outcomes: "msg_cap" → cap exceeded, "msg_missing" → not found, anything else
+// → echo the add list as the post-update set.
+func labelDeps() Deps {
+	return Deps{
+		Authenticator: func(r *http.Request) (*identity.User, error) {
+			if r.Header.Get("Authorization") == "Bearer good" {
+				return &identity.User{ID: "u_1", Email: "owner@acme.com"}, nil
+			}
+			return nil, errors.New("unauthorized")
+		},
+		GetAgent: func(ctx context.Context, address string) (*identity.AgentIdentity, error) {
+			if address == "support@acme.com" {
+				a := sampleAgent()
+				return &a, nil
+			}
+			return nil, errors.New("not found")
+		},
+		ModifyMessageLabels: func(ctx context.Context, messageID, agentID string, add, remove []string) ([]string, error) {
+			if agentID != "support@acme.com" {
+				return nil, errors.New("unexpected agent")
+			}
+			switch messageID {
+			case "msg_cap":
+				return nil, identity.ErrLabelLimitExceeded
+			case "msg_missing":
+				return nil, identity.ErrMessageNotFound
+			default:
+				return add, nil
+			}
+		},
+		Legacy: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusTeapot) }),
+	}
+}
+
+func TestUpdateMessageLabels_AddRemove(t *testing.T) {
+	srv := httptest.NewServer(New(labelDeps()))
+	t.Cleanup(srv.Close)
+	code, body := sendJSON(t, "PATCH", srv.URL+"/v1/agents/support%40acme.com/messages/msg_a", "good", map[string]any{
+		"add_labels": []string{"urgent", "vip"},
+	})
+	if code != 200 {
+		t.Fatalf("status %d body %v", code, body)
+	}
+	if body["message_id"] != "msg_a" {
+		t.Fatalf("message_id = %v, want msg_a", body["message_id"])
+	}
+	labels, _ := body["labels"].([]any)
+	if len(labels) != 2 || labels[0] != "urgent" {
+		t.Fatalf("labels = %v, want [urgent vip]", body["labels"])
+	}
+}
+
+func TestUpdateMessageLabels_CapExceededIs400(t *testing.T) {
+	srv := httptest.NewServer(New(labelDeps()))
+	t.Cleanup(srv.Close)
+	code, body := sendJSON(t, "PATCH", srv.URL+"/v1/agents/support%40acme.com/messages/msg_cap", "good", map[string]any{
+		"add_labels": []string{"x"},
+	})
+	if code != 400 {
+		t.Fatalf("cap exceeded: status %d (want 400) body %v", code, body)
+	}
+}
+
+func TestUpdateMessageLabels_NotFoundIs404(t *testing.T) {
+	srv := httptest.NewServer(New(labelDeps()))
+	t.Cleanup(srv.Close)
+	code, body := sendJSON(t, "PATCH", srv.URL+"/v1/agents/support%40acme.com/messages/msg_missing", "good", map[string]any{
+		"add_labels": []string{"x"},
+	})
+	if code != 404 {
+		t.Fatalf("missing message: status %d (want 404) body %v", code, body)
+	}
+}
+
+// An invalid label is rejected by shared validation (400) before the store is
+// touched — proves the label rules don't diverge from the legacy surface.
+func TestUpdateMessageLabels_InvalidLabelIs400(t *testing.T) {
+	srv := httptest.NewServer(New(labelDeps()))
+	t.Cleanup(srv.Close)
+	code, body := sendJSON(t, "PATCH", srv.URL+"/v1/agents/support%40acme.com/messages/msg_a", "good", map[string]any{
+		"add_labels": []string{"BAD LABEL!"},
+	})
+	if code != 400 {
+		t.Fatalf("invalid label: status %d (want 400) body %v", code, body)
+	}
+}
+
+// Per-agent op: an agent-scoped credential bound to this agent may label its
+// own messages (it is NOT account-only). resolveOwnedAgent pins the binding.
+func TestUpdateMessageLabels_AgentScopedAllowedOnOwnAgent(t *testing.T) {
+	deps := labelDeps()
+	deps.PrincipalAuthenticator = func(r *http.Request) (*identity.Principal, error) {
+		if r.Header.Get("Authorization") == "Bearer agent" {
+			return &identity.Principal{
+				User:    &identity.User{ID: "u_1", Email: "owner@acme.com"},
+				Scope:   identity.ScopeAgent,
+				AgentID: "support@acme.com",
+			}, nil
+		}
+		return nil, errors.New("unauthorized")
+	}
+	srv := httptest.NewServer(New(deps))
+	t.Cleanup(srv.Close)
+	code, body := sendJSON(t, "PATCH", srv.URL+"/v1/agents/support%40acme.com/messages/msg_a", "agent", map[string]any{
+		"add_labels": []string{"urgent"},
+	})
+	if code != 200 {
+		t.Fatalf("agent-scoped own-agent label: status %d (want 200) body %v", code, body)
+	}
+}


### PR DESCRIPTION
## What
First slice of the remaining consumer-port work (Slice 8 / `docs/design/sdk-interface-v1.md`). Ports the legacy labels-delta endpoint onto the typed `/v1` surface so the SDK's `messages.updateLabels` has a `/v1` target — the one parity-audit gap we decided to **port** (the other two, account `/pending` + webhook `redeliver-since`, are dropped).

- **New op** `updateMessage`: `PATCH /v1/agents/{address}/messages/{id}`, body `{add_labels, remove_labels}`, returns `{message_id, labels}`. Empty delta = read of current labels.
- **Per-agent op** — `resolveOwnedAgent` (an agent-scoped credential may label its own messages); **not** account-only.
- Reuses `store.ModifyMessageLabels` (cap enforced there) and **exports `agent.NormalizeAndValidateLabelList`** so label rules can't drift from the legacy handler.
- Error mapping: `ErrMessageNotFound`→404, `ErrLabelLimitExceeded`→400, invalid label→400 (before the store), else 500.
- `Deps` gains `ModifyMessageLabels`; wired in apiserver; **spec regenerated**.

## Verification
- `go build ./...` clean; `agent` package builds (export rename, all callers updated).
- `make spec` → `TestSpecGoldenNoDrift` green; PATCH op + `UpdateMessageRequest` present in `api/openapi.yaml`.
- Full `internal/httpapi` unit suite green. New tests run **over httptest HTTP**: add/remove→200; cap→400; missing→404; invalid label→400; agent-scoped credential allowed on its own agent.

## Notes
- Labels-only (read-status is out of scope — the legacy handler is labels-only too).
- Consolidated over-the-wire e2e (real binary + DB) + dual adversarial review run at the wiring milestone (after 8b/8c), per the slice plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)