### PR TITLE
feat(cli,mcp): repoint @e2a/cli + @e2a/mcp-server to the 3.0 SDK (slice 8d-ts)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/Mnexa-AI/e2a/tree/main/cli",
   "bugs": "https://github.com/Mnexa-AI/e2a/issues",
   "dependencies": {
-    "@e2a/sdk": "^2.4.0"
+    "@e2a/sdk": "^3.0.0"
   },
   "devDependencies": {
     "@types/node": "^25.9.2",

--- a/cli/src/__tests__/agents.test.ts
+++ b/cli/src/__tests__/agents.test.ts
@@ -1,18 +1,24 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-const mockListAgents = vi.fn();
-const mockRegisterAgent = vi.fn();
-const mockDeleteAgent = vi.fn();
-const mockUpdateAgent = vi.fn();
+const mockList = vi.fn();
+const mockCreate = vi.fn();
+const mockDelete = vi.fn();
+const mockUpdate = vi.fn();
+const mockInfo = vi.fn();
+
+// AutoPager stub: list() returns an object exposing toArray().
+function pager(items: unknown[]) {
+  return { toArray: vi.fn(async () => items) };
+}
 
 vi.mock("../sdk.js", () => ({
   createClient: vi.fn(() => ({
-    agentEmail: "bot@agents.e2a.dev",
-    updateAgent: mockUpdateAgent,
-    api: {
-      listAgents: mockListAgents,
-      registerAgent: mockRegisterAgent,
-      deleteAgent: mockDeleteAgent,
+    info: mockInfo,
+    agents: {
+      list: mockList,
+      create: mockCreate,
+      update: mockUpdate,
+      delete: mockDelete,
     },
   })),
 }));
@@ -43,7 +49,7 @@ describe("agentsList", () => {
   beforeEach(() => {
     mockStdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
     mockStderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-    mockListAgents.mockReset();
+    mockList.mockReset();
   });
 
   afterEach(() => {
@@ -53,21 +59,21 @@ describe("agentsList", () => {
   });
 
   it("lists agents with active marker", async () => {
-    mockListAgents.mockResolvedValue({
-      agents: [
-        { email: "bot@agents.e2a.dev", agent_mode: "local" },
-        { email: "other@agents.e2a.dev", agent_mode: "cloud" },
-      ],
-    });
+    mockList.mockReturnValue(
+      pager([
+        { email: "bot@agents.e2a.dev", hitlEnabled: false },
+        { email: "other@agents.e2a.dev", hitlEnabled: true },
+      ]),
+    );
 
     await agentsList(undefined);
 
-    expect(mockStdout).toHaveBeenCalledWith("bot@agents.e2a.dev  local (active)\n");
-    expect(mockStdout).toHaveBeenCalledWith("other@agents.e2a.dev  cloud\n");
+    expect(mockStdout).toHaveBeenCalledWith("bot@agents.e2a.dev  no-hitl (active)\n");
+    expect(mockStdout).toHaveBeenCalledWith("other@agents.e2a.dev  hitl\n");
   });
 
   it("shows message when no agents exist", async () => {
-    mockListAgents.mockResolvedValue({ agents: [] });
+    mockList.mockReturnValue(pager([]));
 
     await agentsList(undefined);
 
@@ -88,7 +94,7 @@ describe("agentsRegister", () => {
     mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit");
     });
-    mockRegisterAgent.mockReset();
+    mockCreate.mockReset();
   });
 
   afterEach(() => {
@@ -104,7 +110,7 @@ describe("agentsRegister", () => {
   });
 
   it("registers agent and saves email", async () => {
-    mockRegisterAgent.mockResolvedValue({
+    mockCreate.mockResolvedValue({
       id: "agent_123",
       email: "my-bot@agents.e2a.dev",
       domain: "agents.e2a.dev",
@@ -112,9 +118,9 @@ describe("agentsRegister", () => {
 
     await agentsRegister("my-bot");
 
-    expect(mockRegisterAgent).toHaveBeenCalledWith({
+    expect(mockCreate).toHaveBeenCalledWith({
       slug: "my-bot",
-      agent_mode: "local",
+      name: undefined,
     });
     expect(saveConfig).toHaveBeenCalledWith({ agent_email: "my-bot@agents.e2a.dev" });
     expect(mockStdout).toHaveBeenCalledWith("Registered: my-bot@agents.e2a.dev\n");
@@ -132,7 +138,7 @@ describe("agentsDelete", () => {
     mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit");
     });
-    mockDeleteAgent.mockReset();
+    mockDelete.mockReset();
   });
 
   afterEach(() => {
@@ -148,34 +154,34 @@ describe("agentsDelete", () => {
   });
 
   it("deletes agent and confirms", async () => {
-    mockDeleteAgent.mockResolvedValue(undefined);
+    mockDelete.mockResolvedValue(undefined);
 
     await agentsDelete("other@agents.e2a.dev");
 
-    expect(mockDeleteAgent).toHaveBeenCalledWith("other@agents.e2a.dev");
+    expect(mockDelete).toHaveBeenCalledWith("other@agents.e2a.dev");
     expect(mockStdout).toHaveBeenCalledWith("Deleted: other@agents.e2a.dev\n");
   });
 
   it("expands slug to full email for shared domain", async () => {
-    mockDeleteAgent.mockResolvedValue(undefined);
+    mockDelete.mockResolvedValue(undefined);
 
     await agentsDelete("my-bot");
 
-    expect(mockDeleteAgent).toHaveBeenCalledWith("my-bot@agents.e2a.dev");
+    expect(mockDelete).toHaveBeenCalledWith("my-bot@agents.e2a.dev");
     expect(mockStdout).toHaveBeenCalledWith("Deleted: my-bot@agents.e2a.dev\n");
   });
 
   it("preserves full email for custom domains", async () => {
-    mockDeleteAgent.mockResolvedValue(undefined);
+    mockDelete.mockResolvedValue(undefined);
 
     await agentsDelete("support@custom.example.com");
 
-    expect(mockDeleteAgent).toHaveBeenCalledWith("support@custom.example.com");
+    expect(mockDelete).toHaveBeenCalledWith("support@custom.example.com");
     expect(mockStdout).toHaveBeenCalledWith("Deleted: support@custom.example.com\n");
   });
 
   it("clears config when deleting active agent", async () => {
-    mockDeleteAgent.mockResolvedValue(undefined);
+    mockDelete.mockResolvedValue(undefined);
 
     await agentsDelete("bot@agents.e2a.dev");
 
@@ -195,7 +201,7 @@ describe("agentsUpdate", () => {
     mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit");
     });
-    mockUpdateAgent.mockReset();
+    mockUpdate.mockReset();
   });
 
   afterEach(() => {
@@ -213,12 +219,11 @@ describe("agentsUpdate", () => {
   });
 
   it("sends HITL enable + settings and prints the confirmed state", async () => {
-    mockUpdateAgent.mockResolvedValueOnce({
+    mockUpdate.mockResolvedValueOnce({
       email: "my-bot@agents.e2a.dev",
-      agent_mode: "local",
-      hitl_enabled: true,
-      hitl_ttl_seconds: 3600,
-      hitl_expiration_action: "approve",
+      hitlEnabled: true,
+      hitlTtlSeconds: 3600,
+      hitlExpirationAction: "approve",
     });
 
     await agentsUpdate("my-bot", {
@@ -227,14 +232,11 @@ describe("agentsUpdate", () => {
       hitlExpirationAction: "approve",
     });
 
-    expect(mockUpdateAgent).toHaveBeenCalledWith(
-      {
-        hitl_enabled: true,
-        hitl_ttl_seconds: 3600,
-        hitl_expiration_action: "approve",
-      },
-      { agentEmail: "my-bot@agents.e2a.dev" },
-    );
+    expect(mockUpdate).toHaveBeenCalledWith("my-bot@agents.e2a.dev", {
+      hitlEnabled: true,
+      hitlTtlSeconds: 3600,
+      hitlExpirationAction: "approve",
+    });
     const out = mockStdout.mock.calls.map((c: unknown[]) => String(c[0])).join("");
     expect(out).toContain("Updated: my-bot@agents.e2a.dev");
     expect(out).toContain("enabled");
@@ -242,25 +244,25 @@ describe("agentsUpdate", () => {
   });
 
   it("expands bare slug to shared-domain email", async () => {
-    mockUpdateAgent.mockResolvedValueOnce({
+    mockUpdate.mockResolvedValueOnce({
       email: "abc@agents.e2a.dev",
-      hitl_enabled: false,
+      hitlEnabled: false,
     });
 
     await agentsUpdate("abc", { hitlEnabled: false });
 
-    const [, ctx] = mockUpdateAgent.mock.calls[0];
-    expect(ctx).toEqual({ agentEmail: "abc@agents.e2a.dev" });
+    const [address] = mockUpdate.mock.calls[0];
+    expect(address).toBe("abc@agents.e2a.dev");
   });
 
   it("preserves full email for custom domains", async () => {
-    mockUpdateAgent.mockResolvedValueOnce({
+    mockUpdate.mockResolvedValueOnce({
       email: "support@acme.com",
-      hitl_enabled: true,
+      hitlEnabled: true,
     });
 
     await agentsUpdate("support@acme.com", { hitlEnabled: true });
-    const [, ctx] = mockUpdateAgent.mock.calls[0];
-    expect(ctx).toEqual({ agentEmail: "support@acme.com" });
+    const [address] = mockUpdate.mock.calls[0];
+    expect(address).toBe("support@acme.com");
   });
 });

--- a/cli/src/__tests__/commands.test.ts
+++ b/cli/src/__tests__/commands.test.ts
@@ -2,17 +2,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const mockSend = vi.fn();
 const mockReply = vi.fn();
-const mockRegisterAgent = vi.fn();
+const mockCreate = vi.fn();
 
 vi.mock("../sdk.js", () => ({
   createClient: vi.fn(() => ({
-    agentEmail: "bot@agents.e2a.dev",
-    send: mockSend,
-    reply: mockReply,
-    api: {
-      registerAgent: mockRegisterAgent,
-    },
+    messages: { send: mockSend, reply: mockReply },
+    agents: { create: mockCreate },
   })),
+  requireAgentEmail: vi.fn(() => "bot@agents.e2a.dev"),
 }));
 
 vi.mock("../config.js", () => ({
@@ -20,6 +17,7 @@ vi.mock("../config.js", () => ({
     api_key: "e2a_testkey",
     api_url: "https://e2a.dev",
     agent_email: "bot@agents.e2a.dev",
+    shared_domain: "agents.e2a.dev",
   })),
   requireApiKey: vi.fn(() => "e2a_testkey"),
   saveConfig: vi.fn(),
@@ -55,27 +53,43 @@ describe("send", () => {
   });
 
   it("sends email via SDK", async () => {
-    mockSend.mockResolvedValue({ status: "sent", message_id: "msg_sent_1" });
+    mockSend.mockResolvedValue({ status: "sent", messageId: "msg_sent_1" });
 
     const { send } = await import("../commands/send.js");
     await send(["user@example.com"], "Hello", "Body text", {});
 
     expect(mockSend).toHaveBeenCalledWith(
-      ["user@example.com"], "Hello", "Body text",
-      { htmlBody: undefined, cc: undefined, bcc: undefined },
+      "bot@agents.e2a.dev",
+      {
+        to: ["user@example.com"],
+        subject: "Hello",
+        body: "Body text",
+        htmlBody: undefined,
+        cc: undefined,
+        bcc: undefined,
+      },
+      undefined,
     );
     expect(mockStdout).toHaveBeenCalledWith("Sent: msg_sent_1\n");
   });
 
   it("allows CC-only send (no --to)", async () => {
-    mockSend.mockResolvedValue({ status: "sent", message_id: "msg_cc_1" });
+    mockSend.mockResolvedValue({ status: "sent", messageId: "msg_cc_1" });
 
     const { send } = await import("../commands/send.js");
     await send([], "Hello", "Body", { cc: ["alice@example.com"] });
 
     expect(mockSend).toHaveBeenCalledWith(
-      [], "Hello", "Body",
-      { htmlBody: undefined, cc: ["alice@example.com"], bcc: undefined },
+      "bot@agents.e2a.dev",
+      {
+        to: undefined,
+        subject: "Hello",
+        body: "Body",
+        htmlBody: undefined,
+        cc: ["alice@example.com"],
+        bcc: undefined,
+      },
+      undefined,
     );
     expect(mockStdout).toHaveBeenCalledWith("Sent: msg_cc_1\n");
   });
@@ -115,14 +129,23 @@ describe("reply", () => {
   });
 
   it("sends reply via SDK", async () => {
-    mockReply.mockResolvedValue({ status: "sent", message_id: "msg_reply_1" });
+    mockReply.mockResolvedValue({ status: "sent", messageId: "msg_reply_1" });
 
     const { reply } = await import("../commands/reply.js");
     await reply("msg_123", "Thanks!", {});
 
-    expect(mockReply).toHaveBeenCalledWith("msg_123", "Thanks!", {
-      htmlBody: undefined, replyAll: undefined, cc: undefined, bcc: undefined,
-    });
+    expect(mockReply).toHaveBeenCalledWith(
+      "bot@agents.e2a.dev",
+      "msg_123",
+      {
+        body: "Thanks!",
+        htmlBody: undefined,
+        replyAll: undefined,
+        cc: undefined,
+        bcc: undefined,
+      },
+      undefined,
+    );
     expect(mockStdout).toHaveBeenCalledWith("Sent: msg_reply_1\n");
   });
 });
@@ -138,7 +161,7 @@ describe("register", () => {
     mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit");
     });
-    mockRegisterAgent.mockReset();
+    mockCreate.mockReset();
   });
 
   afterEach(() => {
@@ -149,7 +172,7 @@ describe("register", () => {
   });
 
   it("registers agent and saves email to config", async () => {
-    mockRegisterAgent.mockResolvedValue({
+    mockCreate.mockResolvedValue({
       id: "agent_123",
       email: "my-bot@agents.e2a.dev",
       domain: "agents.e2a.dev",
@@ -158,9 +181,9 @@ describe("register", () => {
     const { agentsRegister } = await import("../commands/agents.js");
     await agentsRegister("my-bot");
 
-    expect(mockRegisterAgent).toHaveBeenCalledWith({
+    expect(mockCreate).toHaveBeenCalledWith({
       slug: "my-bot",
-      agent_mode: "local",
+      name: undefined,
     });
     expect(saveConfig).toHaveBeenCalledWith({ agent_email: "my-bot@agents.e2a.dev" });
     expect(mockStdout).toHaveBeenCalledWith("Registered: my-bot@agents.e2a.dev\n");

--- a/cli/src/__tests__/domains.test.ts
+++ b/cli/src/__tests__/domains.test.ts
@@ -1,17 +1,21 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-const mockListDomains = vi.fn();
-const mockRegisterDomain = vi.fn();
-const mockVerifyDomain = vi.fn();
-const mockDeleteDomain = vi.fn();
+const mockList = vi.fn();
+const mockCreate = vi.fn();
+const mockVerify = vi.fn();
+const mockDelete = vi.fn();
+
+function pager(items: unknown[]) {
+  return { toArray: vi.fn(async () => items) };
+}
 
 vi.mock("../sdk.js", () => ({
   createClient: vi.fn(() => ({
-    api: {
-      listDomains: mockListDomains,
-      registerDomain: mockRegisterDomain,
-      verifyDomain: mockVerifyDomain,
-      deleteDomain: mockDeleteDomain,
+    domains: {
+      list: mockList,
+      create: mockCreate,
+      verify: mockVerify,
+      delete: mockDelete,
     },
   })),
 }));
@@ -39,7 +43,7 @@ describe("domainsList", () => {
   beforeEach(() => {
     mockStdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
     mockStderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-    mockListDomains.mockReset();
+    mockList.mockReset();
   });
 
   afterEach(() => {
@@ -49,12 +53,12 @@ describe("domainsList", () => {
   });
 
   it("lists domains with verification status", async () => {
-    mockListDomains.mockResolvedValue({
-      domains: [
+    mockList.mockReturnValue(
+      pager([
         { domain: "mycompany.com", verified: true },
         { domain: "staging.dev", verified: false },
-      ],
-    });
+      ]),
+    );
 
     await domainsList();
 
@@ -63,7 +67,7 @@ describe("domainsList", () => {
   });
 
   it("shows message when no domains", async () => {
-    mockListDomains.mockResolvedValue({ domains: [] });
+    mockList.mockReturnValue(pager([]));
 
     await domainsList();
 
@@ -84,7 +88,7 @@ describe("domainsRegister", () => {
     mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit");
     });
-    mockRegisterDomain.mockReset();
+    mockCreate.mockReset();
   });
 
   afterEach(() => {
@@ -100,9 +104,9 @@ describe("domainsRegister", () => {
   });
 
   it("registers domain and shows DNS records", async () => {
-    mockRegisterDomain.mockResolvedValue({
+    mockCreate.mockResolvedValue({
       domain: "mycompany.com",
-      dns_records: {
+      dnsRecords: {
         mx: { host: "mycompany.com", value: "mx.e2a.dev", priority: 10 },
         txt: { host: "mycompany.com", value: "e2a-verify=abc123" },
       },
@@ -110,7 +114,7 @@ describe("domainsRegister", () => {
 
     await domainsRegister("mycompany.com");
 
-    expect(mockRegisterDomain).toHaveBeenCalledWith({ domain: "mycompany.com" });
+    expect(mockCreate).toHaveBeenCalledWith({ domain: "mycompany.com" });
     expect(mockStdout).toHaveBeenCalledWith("Registered: mycompany.com\n");
     expect(mockStdout).toHaveBeenCalledWith(
       expect.stringContaining("MX"),
@@ -132,7 +136,7 @@ describe("domainsVerify", () => {
     mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit");
     });
-    mockVerifyDomain.mockReset();
+    mockVerify.mockReset();
   });
 
   afterEach(() => {
@@ -147,7 +151,7 @@ describe("domainsVerify", () => {
   });
 
   it("shows verified status", async () => {
-    mockVerifyDomain.mockResolvedValue({ domain: "mycompany.com", verified: true });
+    mockVerify.mockResolvedValue({ domain: "mycompany.com", verified: true });
 
     await domainsVerify("mycompany.com");
 
@@ -155,7 +159,7 @@ describe("domainsVerify", () => {
   });
 
   it("shows not-yet-verified status", async () => {
-    mockVerifyDomain.mockResolvedValue({ domain: "mycompany.com", verified: false });
+    mockVerify.mockResolvedValue({ domain: "mycompany.com", verified: false });
 
     await domainsVerify("mycompany.com");
 
@@ -174,7 +178,7 @@ describe("domainsDelete", () => {
     mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit");
     });
-    mockDeleteDomain.mockReset();
+    mockDelete.mockReset();
   });
 
   afterEach(() => {
@@ -189,11 +193,11 @@ describe("domainsDelete", () => {
   });
 
   it("deletes domain and confirms", async () => {
-    mockDeleteDomain.mockResolvedValue(undefined);
+    mockDelete.mockResolvedValue(undefined);
 
     await domainsDelete("mycompany.com");
 
-    expect(mockDeleteDomain).toHaveBeenCalledWith("mycompany.com");
+    expect(mockDelete).toHaveBeenCalledWith("mycompany.com");
     expect(mockStdout).toHaveBeenCalledWith("Deleted: mycompany.com\n");
   });
 });

--- a/cli/src/__tests__/listen.test.ts
+++ b/cli/src/__tests__/listen.test.ts
@@ -137,10 +137,7 @@ describe("listen notification handling", () => {
 
   it("prints a human-readable notification by default", async () => {
     const client = {
-      api: {
-        getMessage: vi.fn(),
-      },
-      reply: vi.fn(),
+      messages: { get: vi.fn(), reply: vi.fn() },
     } as any;
 
     await handleNotification(
@@ -153,22 +150,19 @@ describe("listen notification handling", () => {
     expect(mockStdout).toHaveBeenCalledWith(
       expect.stringContaining("From: alice@example.com | Subject: Hello"),
     );
-    expect(client.api.getMessage).not.toHaveBeenCalled();
+    expect(client.messages.get).not.toHaveBeenCalled();
   });
 
   it("fetches and prints raw JSON for --json mode", async () => {
     const full = {
-      message_id: "msg_123",
-      from: "alice@example.com",
-      to: "bot@agents.e2a.dev",
+      messageId: "msg_123",
+      _from: "alice@example.com",
+      recipient: "bot@agents.e2a.dev",
       subject: "Hello",
-      raw_message: "U3ViamVjdDogSGVsbG8NCg0KSGkgdGhlcmUh",
+      rawMessage: "U3ViamVjdDogSGVsbG8NCg0KSGkgdGhlcmUh",
     };
     const client = {
-      api: {
-        getMessage: vi.fn().mockResolvedValue(full),
-      },
-      reply: vi.fn(),
+      messages: { get: vi.fn().mockResolvedValue(full), reply: vi.fn() },
     } as any;
 
     await handleNotification(
@@ -178,17 +172,17 @@ describe("listen notification handling", () => {
       { json: true },
     );
 
-    expect(client.api.getMessage).toHaveBeenCalledWith("bot@agents.e2a.dev", "msg_123");
+    expect(client.messages.get).toHaveBeenCalledWith("bot@agents.e2a.dev", "msg_123");
     expect(mockStdout).toHaveBeenCalledWith(`${JSON.stringify(full)}\n`);
   });
 
   it("forwards exact raw JSON to a generic webhook", async () => {
     const full = {
-      message_id: "msg_123",
-      from: "alice@example.com",
-      to: "bot@agents.e2a.dev",
+      messageId: "msg_123",
+      _from: "alice@example.com",
+      recipient: "bot@agents.e2a.dev",
       subject: "Hello",
-      raw_message: "U3ViamVjdDogSGVsbG8NCg0KSGkgdGhlcmUh",
+      rawMessage: "U3ViamVjdDogSGVsbG8NCg0KSGkgdGhlcmUh",
     };
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
@@ -198,10 +192,7 @@ describe("listen notification handling", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const client = {
-      api: {
-        getMessage: vi.fn().mockResolvedValue(full),
-      },
-      reply: vi.fn(),
+      messages: { get: vi.fn().mockResolvedValue(full), reply: vi.fn() },
     } as any;
 
     await forwardMessage(
@@ -212,7 +203,7 @@ describe("listen notification handling", () => {
       "secret",
     );
 
-    expect(client.api.getMessage).toHaveBeenCalledWith("bot@agents.e2a.dev", "msg_123");
+    expect(client.messages.get).toHaveBeenCalledWith("bot@agents.e2a.dev", "msg_123");
     expect(fetchMock).toHaveBeenCalledWith(
       "https://example.com/webhook",
       expect.objectContaining({
@@ -224,20 +215,23 @@ describe("listen notification handling", () => {
         body: JSON.stringify(full),
       }),
     );
-    expect(client.reply).not.toHaveBeenCalled();
+    expect(client.messages.reply).not.toHaveBeenCalled();
     expect(mockStderr).toHaveBeenCalledWith(
       "Forwarded msg_123 to https://example.com/webhook\n",
     );
   });
 
   it("forwards to OpenClaw and auto-replies when text is returned", async () => {
+    // No parsed/body text — exercise the rawMessage decode fallback.
     const raw = "Subject: Hello\r\n\r\nHi there!";
     const full = {
-      message_id: "msg_123",
-      from: "alice@example.com",
-      to: "bot@agents.e2a.dev",
+      messageId: "msg_123",
+      _from: "alice@example.com",
+      recipient: "bot@agents.e2a.dev",
       subject: "Hello",
-      raw_message: Buffer.from(raw, "utf-8").toString("base64"),
+      body: { text: "", html: "" },
+      parsed: { text: "", truncated: false },
+      rawMessage: Buffer.from(raw, "utf-8").toString("base64"),
     };
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
@@ -256,13 +250,13 @@ describe("listen notification handling", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const client = {
-      api: {
-        getMessage: vi.fn().mockResolvedValue(full),
+      messages: {
+        get: vi.fn().mockResolvedValue(full),
+        reply: vi.fn().mockResolvedValue({
+          status: "sent",
+          messageId: "msg_reply_1",
+        }),
       },
-      reply: vi.fn().mockResolvedValue({
-        status: "sent",
-        message_id: "msg_reply_1",
-      }),
     } as any;
 
     await forwardMessage(
@@ -287,7 +281,11 @@ describe("listen notification handling", () => {
         }),
       }),
     );
-    expect(client.reply).toHaveBeenCalledWith("msg_123", "Thanks for the email.");
+    expect(client.messages.reply).toHaveBeenCalledWith(
+      "bot@agents.e2a.dev",
+      "msg_123",
+      { body: "Thanks for the email." },
+    );
     expect(mockStderr).toHaveBeenCalledWith(
       "Replied to alice@example.com (msg_123)\n",
     );

--- a/cli/src/__tests__/login.test.ts
+++ b/cli/src/__tests__/login.test.ts
@@ -5,7 +5,8 @@ const mockExecFile = vi.fn();
 const mockLoadConfig = vi.fn();
 const mockSaveConfig = vi.fn();
 const mockCreateServer = vi.fn();
-const mockFetchInfo = vi.fn();
+const mockFetch = vi.fn();
+const originalFetch = globalThis.fetch;
 
 let currentServerHandler: ((req: any, res: any) => void | Promise<void>) | null = null;
 
@@ -42,19 +43,15 @@ vi.mock("../config.js", () => ({
   saveConfig: mockSaveConfig,
 }));
 
-// Stub out the SDK so login's preflight /info fetch doesn't hit a real
-// network. Each test that cares about the discovered shared_domain sets
-// the resolved value via mockFetchInfo.
-vi.mock("@e2a/sdk", async () => {
-  const actual = await vi.importActual<typeof import("@e2a/sdk")>("@e2a/sdk");
+// login probes GET /v1/info with a raw fetch (pre-auth, before a key exists),
+// so we stub the global fetch. infoResponse() builds the success shape; tests
+// override per scenario (unreachable -> reject; older deployment -> ok:false).
+function infoResponse(sharedDomain: string) {
   return {
-    ...actual,
-    E2AApi: {
-      ...actual.E2AApi,
-      fetchInfo: mockFetchInfo,
-    },
+    ok: true,
+    json: async () => ({ shared_domain: sharedDomain, slug_registration_enabled: true }),
   };
-});
+}
 
 async function simulateBrowserCallback(payload: Record<string, string>) {
   if (!currentServerHandler) {
@@ -102,13 +99,11 @@ describe("login", () => {
     mockSaveConfig.mockReset();
     mockExecFile.mockReset();
     mockCreateServer.mockClear();
-    mockFetchInfo.mockReset();
-    // Default: deployment exposes the hosted shared domain. Override
-    // per-test for self-host / older-deployment / unreachable scenarios.
-    mockFetchInfo.mockResolvedValue({
-      shared_domain: "agents.e2a.dev",
-      slug_registration_enabled: true,
-    });
+    mockFetch.mockReset();
+    // Default: deployment exposes the hosted shared domain. Override per-test
+    // for self-host / older-deployment / unreachable scenarios.
+    mockFetch.mockResolvedValue(infoResponse("agents.e2a.dev"));
+    globalThis.fetch = mockFetch as unknown as typeof fetch;
 
     mockLoadConfig.mockReturnValue({
       api_key: "",
@@ -121,6 +116,7 @@ describe("login", () => {
   afterEach(() => {
     mockStdout.mockRestore();
     mockStderr.mockRestore();
+    globalThis.fetch = originalFetch;
     vi.clearAllMocks();
   });
 
@@ -201,10 +197,10 @@ describe("login", () => {
   });
 
   it("fast-fails before opening the browser when the server is unreachable", async () => {
-    // Simulate a network failure (connection refused, DNS, etc.) — fetch
-    // throws TypeError, which is NOT an E2AApiError, so login() should
-    // abort before kicking off the browser flow.
-    mockFetchInfo.mockRejectedValueOnce(new TypeError("fetch failed"));
+    // Simulate a network failure (connection refused, DNS, etc.) — info()
+    // throws E2AConnectionError, so login() should abort before kicking off
+    // the browser flow.
+    mockFetch.mockRejectedValueOnce(new TypeError("fetch failed"));
 
     const { login } = await import("../commands/login.js");
     await expect(login()).rejects.toThrow(/could not reach https:\/\/e2a\.dev/);
@@ -213,11 +209,10 @@ describe("login", () => {
     expect(mockSaveConfig).not.toHaveBeenCalled();
   });
 
-  it("continues login when /info responds with non-2xx (older deployment)", async () => {
-    // Server is reachable but doesn't expose /info. Login should proceed
-    // and just skip the shared_domain field in saveConfig.
-    const { E2AApiError } = await import("@e2a/sdk");
-    mockFetchInfo.mockRejectedValueOnce(new E2AApiError(404, "not found"));
+  it("continues login when info() responds with an HTTP error (older deployment)", async () => {
+    // Server is reachable but doesn't expose the info endpoint. Login
+    // should proceed and just skip the shared_domain field in saveConfig.
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 404, json: async () => ({}) });
     mockExecFile.mockImplementation((_cmd: string, args: string[], cb?: (err: Error | null) => void) => {
       const loginUrl = new URL(args[args.length - 1]);
       const cliState = loginUrl.searchParams.get("cli_state");
@@ -270,10 +265,7 @@ describe("login", () => {
   });
 
   it("confirms the discovered shared domain in the success output", async () => {
-    mockFetchInfo.mockResolvedValueOnce({
-      shared_domain: "agents.acme.test",
-      slug_registration_enabled: true,
-    });
+    mockFetch.mockResolvedValueOnce(infoResponse("agents.acme.test"));
     mockLoadConfig.mockReturnValue({
       api_key: "",
       api_url: "https://e2a.acme.test",

--- a/cli/src/__tests__/pending.test.ts
+++ b/cli/src/__tests__/pending.test.ts
@@ -1,21 +1,26 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-// Mock the high-level SDK methods the CLI now calls. Each test installs a
-// fresh resolved value so we can assert exactly what the CLI sent and
-// renders what the server would return.
-const mockListPending = vi.fn();
-const mockGetPending = vi.fn();
+// Mock the namespaced messages resource the CLI now calls. Pending drafts
+// surface as outbound messages with status="pending_approval".
+const mockList = vi.fn();
+const mockGet = vi.fn();
 const mockApprove = vi.fn();
 const mockReject = vi.fn();
 
+function pager(items: unknown[]) {
+  return { toArray: vi.fn(async () => items) };
+}
+
 vi.mock("../sdk.js", () => ({
   createClient: vi.fn(() => ({
-    agentEmail: "bot@agents.e2a.dev",
-    listPendingMessages: mockListPending,
-    getPendingMessage: mockGetPending,
-    approveMessage: mockApprove,
-    rejectMessage: mockReject,
+    messages: {
+      list: mockList,
+      get: mockGet,
+      approve: mockApprove,
+      reject: mockReject,
+    },
   })),
+  requireAgentEmail: vi.fn(() => "bot@agents.e2a.dev"),
 }));
 
 vi.mock("../config.js", () => ({
@@ -40,7 +45,7 @@ describe("pendingList", () => {
 
   beforeEach(() => {
     stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-    mockListPending.mockReset();
+    mockList.mockReset();
   });
   afterEach(() => {
     stdout.mockRestore();
@@ -48,32 +53,38 @@ describe("pendingList", () => {
   });
 
   it("prints a line per pending message", async () => {
-    mockListPending.mockResolvedValueOnce({
-      messages: [
+    mockList.mockReturnValue(
+      pager([
         {
-          id: "msg_abc",
-          agent_id: "bot@x.com",
+          messageId: "msg_abc",
+          _from: "bot@x.com",
           subject: "hello",
-          type: "send",
           to: ["alice@example.com"],
           status: "pending_approval",
-          approval_expires_at: new Date(Date.now() + 60 * 60_000).toISOString(),
-          created_at: new Date().toISOString(),
         },
-      ],
-    });
+        // A sent outbound message should be filtered out.
+        {
+          messageId: "msg_sent",
+          _from: "bot@x.com",
+          subject: "already sent",
+          to: ["bob@example.com"],
+          status: "sent",
+        },
+      ]),
+    );
 
     await pendingList();
-    expect(mockListPending).toHaveBeenCalled();
+    expect(mockList).toHaveBeenCalledWith("bot@agents.e2a.dev", { direction: "outbound" });
     const output = stdout.mock.calls.map((c: unknown[]) => String(c[0])).join("");
     expect(output).toContain("msg_abc");
     expect(output).toContain("bot@x.com");
     expect(output).toContain("alice@example.com");
     expect(output).toContain("hello");
+    expect(output).not.toContain("msg_sent");
   });
 
   it('shows "no pending" message when list is empty', async () => {
-    mockListPending.mockResolvedValueOnce({ messages: [] });
+    mockList.mockReturnValue(pager([]));
     await pendingList();
     expect(stdout).toHaveBeenCalledWith("No messages pending approval.\n");
   });
@@ -90,7 +101,7 @@ describe("pendingShow", () => {
     mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
       throw new Error("process.exit");
     });
-    mockGetPending.mockReset();
+    mockGet.mockReset();
   });
   afterEach(() => {
     stdout.mockRestore();
@@ -105,20 +116,19 @@ describe("pendingShow", () => {
   });
 
   it("prints all headers + body for a pending message", async () => {
-    mockGetPending.mockResolvedValueOnce({
-      id: "msg_x",
-      agent_id: "bot@x.com",
+    mockGet.mockResolvedValueOnce({
+      messageId: "msg_x",
+      _from: "bot@x.com",
       subject: "hello",
-      type: "send",
       to: ["alice@example.com"],
       cc: ["carol@example.com"],
       status: "pending_approval",
-      body_text: "hi there",
-      created_at: new Date().toISOString(),
+      body: { text: "hi there", html: "" },
+      parsed: { text: "hi there", truncated: false },
     });
 
     await pendingShow("msg_x");
-    expect(mockGetPending).toHaveBeenCalledWith("msg_x");
+    expect(mockGet).toHaveBeenCalledWith("bot@agents.e2a.dev", "msg_x");
     const output = stdout.mock.calls.map((c: unknown[]) => String(c[0])).join("");
     expect(output).toContain("ID:");
     expect(output).toContain("msg_x");
@@ -140,7 +150,7 @@ describe("pendingApprove", () => {
       throw new Error("process.exit");
     });
     mockApprove.mockReset();
-    mockGetPending.mockReset();
+    mockGet.mockReset();
   });
   afterEach(() => {
     stdout.mockRestore();
@@ -154,30 +164,25 @@ describe("pendingApprove", () => {
     expect(stderr).toHaveBeenCalledWith(expect.stringContaining("Usage"));
   });
 
-  it("approve-as-is fetches the pending detail for agent_id, then approves", async () => {
-    // CLI now always fetches the message first to discover the owning
-    // agent (needed for the agent-scoped /agents/{email}/messages/...
-    // endpoint). Approve-as-is still sends an empty override object.
-    mockGetPending.mockResolvedValueOnce({
-      id: "msg_x",
-      agent_id: "bot@agents.e2a.dev",
+  it("approve-as-is fetches the message to confirm it is held, then approves", async () => {
+    mockGet.mockResolvedValueOnce({
+      messageId: "msg_x",
       status: "pending_approval",
       subject: "hi",
-      type: "send",
       to: ["alice@example.com"],
     });
     mockApprove.mockResolvedValueOnce({
       status: "sent",
-      message_id: "msg_x",
-      provider_message_id: "<ses-id@amazonses.com>",
+      messageId: "msg_x",
+      providerMessageId: "<ses-id@amazonses.com>",
       method: "smtp",
       edited: false,
     });
 
     await pendingApprove("msg_x", {});
 
-    expect(mockGetPending).toHaveBeenCalledWith("msg_x");
-    expect(mockApprove).toHaveBeenCalledWith("bot@agents.e2a.dev", "msg_x", {});
+    expect(mockGet).toHaveBeenCalledWith("bot@agents.e2a.dev", "msg_x");
+    expect(mockApprove).toHaveBeenCalledWith("bot@agents.e2a.dev", "msg_x", {}, undefined);
     const out = stdout.mock.calls.map((c: unknown[]) => String(c[0])).join("");
     expect(out).toContain("Approved: msg_x");
     expect(out).toContain("<ses-id@amazonses.com>");
@@ -185,18 +190,16 @@ describe("pendingApprove", () => {
   });
 
   it('annotates "with edits" when server reports edited', async () => {
-    mockGetPending.mockResolvedValueOnce({
-      id: "msg_x",
-      agent_id: "bot@agents.e2a.dev",
+    mockGet.mockResolvedValueOnce({
+      messageId: "msg_x",
       status: "pending_approval",
       subject: "hi",
-      type: "send",
       to: ["alice@example.com"],
     });
     mockApprove.mockResolvedValueOnce({
       status: "sent",
-      message_id: "msg_x",
-      provider_message_id: "<ses@amazonses.com>",
+      messageId: "msg_x",
+      providerMessageId: "<ses@amazonses.com>",
       method: "smtp",
       edited: true,
     });
@@ -207,12 +210,10 @@ describe("pendingApprove", () => {
   });
 
   it("refuses to approve when the row has already transitioned", async () => {
-    mockGetPending.mockResolvedValueOnce({
-      id: "msg_x",
-      agent_id: "bot@agents.e2a.dev",
+    mockGet.mockResolvedValueOnce({
+      messageId: "msg_x",
       status: "sent",
       subject: "hi",
-      type: "send",
       to: ["alice@example.com"],
     });
 
@@ -234,7 +235,6 @@ describe("pendingReject", () => {
       throw new Error("process.exit");
     });
     mockReject.mockReset();
-    mockGetPending.mockReset();
   });
   afterEach(() => {
     stdout.mockRestore();
@@ -248,38 +248,21 @@ describe("pendingReject", () => {
     expect(stderr).toHaveBeenCalledWith(expect.stringContaining("Usage"));
   });
 
-  it("looks up the owning agent then forwards the reason to the SDK", async () => {
-    mockGetPending.mockResolvedValueOnce({
-      id: "msg_x",
-      agent_id: "bot@agents.e2a.dev",
-      status: "pending_approval",
-      subject: "hi",
-      type: "send",
-      to: ["alice@example.com"],
-    });
+  it("forwards the reason to the SDK for the active agent", async () => {
     mockReject.mockResolvedValueOnce({
       status: "rejected",
-      message_id: "msg_x",
-      rejection_reason: "nope",
+      messageId: "msg_x",
+      rejectionReason: "nope",
     });
 
     await pendingReject("msg_x", "nope");
-    expect(mockGetPending).toHaveBeenCalledWith("msg_x");
-    expect(mockReject).toHaveBeenCalledWith("bot@agents.e2a.dev", "msg_x", "nope");
+    expect(mockReject).toHaveBeenCalledWith("bot@agents.e2a.dev", "msg_x", { reason: "nope" });
     expect(stdout).toHaveBeenCalledWith("Rejected: msg_x\n");
   });
 
   it("passes an empty reason when omitted", async () => {
-    mockGetPending.mockResolvedValueOnce({
-      id: "msg_x",
-      agent_id: "bot@agents.e2a.dev",
-      status: "pending_approval",
-      subject: "hi",
-      type: "send",
-      to: ["alice@example.com"],
-    });
-    mockReject.mockResolvedValueOnce({ status: "rejected", message_id: "msg_x" });
+    mockReject.mockResolvedValueOnce({ status: "rejected", messageId: "msg_x" });
     await pendingReject("msg_x", undefined);
-    expect(mockReject).toHaveBeenCalledWith("bot@agents.e2a.dev", "msg_x", "");
+    expect(mockReject).toHaveBeenCalledWith("bot@agents.e2a.dev", "msg_x", { reason: "" });
   });
 });

--- a/cli/src/__tests__/read.test.ts
+++ b/cli/src/__tests__/read.test.ts
@@ -4,9 +4,9 @@ const mockGetMessage = vi.fn();
 
 vi.mock("../sdk.js", () => ({
   createClient: vi.fn(() => ({
-    agentEmail: "bot@agents.e2a.dev",
-    getMessage: mockGetMessage,
+    messages: { get: mockGetMessage },
   })),
+  requireAgentEmail: vi.fn(() => "bot@agents.e2a.dev"),
 }));
 
 vi.mock("../config.js", () => ({
@@ -19,6 +19,24 @@ vi.mock("../config.js", () => ({
 }));
 
 import { read } from "../commands/read.js";
+
+// Build a MessageView-shaped object. `_from` is the generated TS property
+// name for the wire field `from`; the body lives under `body`/`parsed`.
+function messageView(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    messageId: "msg_123",
+    _from: "alice@example.com",
+    recipient: "bot@agents.e2a.dev",
+    to: ["bot@agents.e2a.dev"],
+    cc: [],
+    replyTo: [],
+    subject: "Hello",
+    body: { text: "Hi there!", html: "" },
+    parsed: { text: "Hi there!", truncated: false },
+    createdAt: "2025-01-15T10:30:00Z",
+    ...overrides,
+  };
+}
 
 describe("read", () => {
   let mockStdout: ReturnType<typeof vi.spyOn>;
@@ -46,22 +64,12 @@ describe("read", () => {
     expect(mockStderr).toHaveBeenCalledWith("Usage: e2a read <message-id>\n");
   });
 
-  it("displays parsed InboundEmail fields including date", async () => {
-    mockGetMessage.mockResolvedValue({
-      messageId: "msg_123",
-      sender: "alice@example.com",
-      recipient: "bot@agents.e2a.dev",
-      to: ["bot@agents.e2a.dev"],
-      cc: [],
-      replyTo: [],
-      subject: "Hello",
-      textBody: "Hi there!",
-      receivedAt: "2025-01-15T10:30:00Z",
-    });
+  it("displays parsed MessageView fields including date", async () => {
+    mockGetMessage.mockResolvedValue(messageView());
 
     await read("msg_123", undefined);
 
-    expect(mockGetMessage).toHaveBeenCalledWith("msg_123");
+    expect(mockGetMessage).toHaveBeenCalledWith("bot@agents.e2a.dev", "msg_123");
     expect(mockStdout).toHaveBeenCalledWith("Message ID: msg_123\n");
     expect(mockStdout).toHaveBeenCalledWith("From: alice@example.com\n");
     expect(mockStdout).toHaveBeenCalledWith("Date: 2025-01-15T10:30:00Z\n");
@@ -75,18 +83,18 @@ describe("read", () => {
   });
 
   it("prints Also-To and Cc when the message had other recipients", async () => {
-    mockGetMessage.mockResolvedValue({
-      messageId: "msg_group",
-      sender: "alice@example.com",
-      recipient: "bot-a@agents.e2a.dev",
-      // Server-emitted To: header has the agent itself plus another bot.
-      to: ["bot-a@agents.e2a.dev", "bot-b@agents.e2a.dev"],
-      cc: ["watcher@example.com"],
-      replyTo: [],
-      subject: "Group",
-      textBody: "",
-      receivedAt: null,
-    });
+    mockGetMessage.mockResolvedValue(
+      messageView({
+        messageId: "msg_group",
+        recipient: "bot-a@agents.e2a.dev",
+        to: ["bot-a@agents.e2a.dev", "bot-b@agents.e2a.dev"],
+        cc: ["watcher@example.com"],
+        subject: "Group",
+        body: { text: "", html: "" },
+        parsed: { text: "", truncated: false },
+        createdAt: null,
+      }),
+    );
 
     await read("msg_group", undefined);
 
@@ -95,17 +103,18 @@ describe("read", () => {
   });
 
   it("prints Also-To when the agent was Bcc'd (not in the To: header)", async () => {
-    mockGetMessage.mockResolvedValue({
-      messageId: "msg_bcc",
-      sender: "alice@example.com",
-      recipient: "bot-bcc@agents.e2a.dev",
-      to: ["bot-a@agents.e2a.dev", "bot-b@agents.e2a.dev"],
-      cc: [],
-      replyTo: [],
-      subject: "BCC",
-      textBody: "",
-      receivedAt: null,
-    });
+    mockGetMessage.mockResolvedValue(
+      messageView({
+        messageId: "msg_bcc",
+        recipient: "bot-bcc@agents.e2a.dev",
+        to: ["bot-a@agents.e2a.dev", "bot-b@agents.e2a.dev"],
+        cc: [],
+        subject: "BCC",
+        body: { text: "", html: "" },
+        parsed: { text: "", truncated: false },
+        createdAt: null,
+      }),
+    );
 
     await read("msg_bcc", undefined);
 
@@ -114,18 +123,17 @@ describe("read", () => {
     );
   });
 
-  it("shows 'unknown' when receivedAt is null", async () => {
-    mockGetMessage.mockResolvedValue({
-      messageId: "msg_456",
-      sender: "bob@example.com",
-      recipient: "bot@agents.e2a.dev",
-      to: ["bot@agents.e2a.dev"],
-      cc: [],
-      replyTo: [],
-      subject: "Test",
-      textBody: "",
-      receivedAt: null,
-    });
+  it("shows 'unknown' when createdAt is null", async () => {
+    mockGetMessage.mockResolvedValue(
+      messageView({
+        messageId: "msg_456",
+        _from: "bob@example.com",
+        subject: "Test",
+        body: { text: "", html: "" },
+        parsed: { text: "", truncated: false },
+        createdAt: null,
+      }),
+    );
 
     await read("msg_456", undefined);
 
@@ -134,17 +142,17 @@ describe("read", () => {
 
   it("prints Reply-To when the sender requested a different reply mailbox", async () => {
     // Motivating case: notifications@... with Reply-To: <real-user>.
-    mockGetMessage.mockResolvedValue({
-      messageId: "msg_granola",
-      sender: "notifications@mail.granola.ai",
-      recipient: "bot@agents.e2a.dev",
-      to: ["bot@agents.e2a.dev"],
-      cc: [],
-      replyTo: ["real-user@example.com"],
-      subject: "Meeting summary",
-      textBody: "",
-      receivedAt: null,
-    });
+    mockGetMessage.mockResolvedValue(
+      messageView({
+        messageId: "msg_granola",
+        _from: "notifications@mail.granola.ai",
+        replyTo: ["real-user@example.com"],
+        subject: "Meeting summary",
+        body: { text: "", html: "" },
+        parsed: { text: "", truncated: false },
+        createdAt: null,
+      }),
+    );
 
     await read("msg_granola", undefined);
 

--- a/cli/src/bin/e2a.ts
+++ b/cli/src/bin/e2a.ts
@@ -45,7 +45,7 @@ Usage:
   e2a login                         Log in via browser and save config
   e2a agents list                   List your agents
   e2a agents register <slug>        Register an agent on the deployment's shared domain
-  e2a agents update <email> ...     Update agent settings (HITL, webhook)
+  e2a agents update <email> ...     Update agent settings (HITL)
   e2a agents delete <email>         Delete an agent
   e2a pending list                  List messages held for human approval
   e2a pending show <id>             Show a held message's full detail
@@ -172,7 +172,6 @@ async function main() {
           hitlEnabled,
           hitlTTLSeconds,
           hitlExpirationAction,
-          webhookUrl: getFlag(args, "--webhook-url"),
         });
       } else if (sub === "delete") {
         await agentsDelete(args[1]);
@@ -185,9 +184,9 @@ async function main() {
     case "pending": {
       const sub = args[0];
       if (sub === "list") {
-        await pendingList();
+        await pendingList(getFlag(args, "--agent"));
       } else if (sub === "show") {
-        await pendingShow(args[1]);
+        await pendingShow(args[1], getFlag(args, "--agent"));
       } else if (sub === "approve") {
         // Default the idempotency key to the message_id when the user
         // doesn't pass one. Approve fires SES, and a fresh per-call
@@ -200,9 +199,10 @@ async function main() {
         await pendingApprove(args[1], {
           edit: hasFlag(args, "--edit"),
           idempotencyKey: getFlag(args, "--idempotency-key") ?? args[1],
+          from: getFlag(args, "--agent"),
         });
       } else if (sub === "reject") {
-        await pendingReject(args[1], getFlag(args, "--reason"));
+        await pendingReject(args[1], getFlag(args, "--reason"), getFlag(args, "--agent"));
       } else {
         process.stderr.write("Usage: e2a pending [list|show|approve|reject]\n");
         process.exit(1);

--- a/cli/src/commands/agents.ts
+++ b/cli/src/commands/agents.ts
@@ -1,4 +1,4 @@
-import { E2AApi } from "@e2a/sdk";
+import type { UpdateAgentRequest } from "@e2a/sdk/v1";
 import { loadConfig, saveConfig } from "../config.js";
 import { createClient } from "../sdk.js";
 
@@ -7,9 +7,9 @@ import { createClient } from "../sdk.js";
  * shared domain. Inputs that already contain "@" pass through. Reads from
  * config first; if the field is missing (e.g. user upgraded from a CLI
  * version before the field existed and never re-logged-in) it discovers
- * the value from `/api/v1/info` and caches it for next time. Throws when
- * discovery fails *and* nothing is cached, since we can't safely guess
- * the right domain for the deployment.
+ * the value from the deployment's `info()` and caches it for next time.
+ * Throws when discovery fails *and* nothing is cached, since we can't
+ * safely guess the right domain for the deployment.
  */
 async function resolveAgentEmail(emailOrSlug: string): Promise<string> {
   if (emailOrSlug.includes("@")) return emailOrSlug;
@@ -19,14 +19,14 @@ async function resolveAgentEmail(emailOrSlug: string): Promise<string> {
   }
   // Cache miss — discover and persist.
   try {
-    const info = await E2AApi.fetchInfo(config.api_url);
-    if (!info.shared_domain) {
+    const info = await createClient().info();
+    if (!info.sharedDomain) {
       throw new Error(
         "this deployment doesn't expose a shared domain — pass the agent's full email instead",
       );
     }
-    saveConfig({ shared_domain: info.shared_domain });
-    return `${emailOrSlug}@${info.shared_domain}`;
+    saveConfig({ shared_domain: info.sharedDomain });
+    return `${emailOrSlug}@${info.sharedDomain}`;
   } catch (err) {
     const detail = err instanceof Error ? err.message : String(err);
     throw new Error(
@@ -38,20 +38,20 @@ async function resolveAgentEmail(emailOrSlug: string): Promise<string> {
 export async function agentsList(from: string | undefined): Promise<void> {
   const client = createClient({ from });
 
-  const res = await client.api.listAgents();
-  const agents = res.agents || [];
+  const agents = await client.agents.list().toArray({ limit: 1000 });
 
   if (agents.length === 0) {
     process.stderr.write("No agents registered. Run: e2a agents register <slug>\n");
     return;
   }
 
-  const currentEmail = client.agentEmail;
+  const config = loadConfig();
+  const currentEmail = from || config.agent_email;
 
   for (const agent of agents) {
     const marker = agent.email === currentEmail ? " (active)" : "";
-    const mode = agent.agent_mode === "local" ? "local" : "cloud";
-    process.stdout.write(`${agent.email}  ${mode}${marker}\n`);
+    const hitl = agent.hitlEnabled ? "hitl" : "no-hitl";
+    process.stdout.write(`${agent.email}  ${hitl}${marker}\n`);
   }
 }
 
@@ -64,10 +64,9 @@ export async function agentsRegister(slug: string | undefined, name?: string): P
 
   const client = createClient();
 
-  const res = await client.api.registerAgent({
+  const res = await client.agents.create({
     slug,
     name: name || undefined,
-    agent_mode: "local",
   });
 
   saveConfig({ agent_email: res.email });
@@ -85,7 +84,6 @@ export interface AgentsUpdateOpts {
   hitlEnabled?: boolean;
   hitlTTLSeconds?: number;
   hitlExpirationAction?: "approve" | "reject";
-  webhookUrl?: string;
 }
 
 export async function agentsUpdate(
@@ -94,7 +92,7 @@ export async function agentsUpdate(
 ): Promise<void> {
   if (!emailOrSlug) {
     process.stderr.write(
-      'Usage: e2a agents update <email-or-slug> [--hitl | --no-hitl] [--hitl-ttl <seconds>] [--hitl-expiration-action approve|reject] [--webhook-url <url>]\n',
+      'Usage: e2a agents update <email-or-slug> [--hitl | --no-hitl] [--hitl-ttl <seconds>] [--hitl-expiration-action approve|reject]\n',
     );
     process.exit(1);
   }
@@ -102,34 +100,30 @@ export async function agentsUpdate(
 
   // Build the request body from only the flags the user actually passed
   // so missing flags preserve their current server-side value.
-  const body: Record<string, unknown> = {};
-  if (opts.hitlEnabled !== undefined) body.hitl_enabled = opts.hitlEnabled;
-  if (opts.hitlTTLSeconds !== undefined) body.hitl_ttl_seconds = opts.hitlTTLSeconds;
+  const body: UpdateAgentRequest = {};
+  if (opts.hitlEnabled !== undefined) body.hitlEnabled = opts.hitlEnabled;
+  if (opts.hitlTTLSeconds !== undefined) body.hitlTtlSeconds = opts.hitlTTLSeconds;
   if (opts.hitlExpirationAction !== undefined) {
-    body.hitl_expiration_action = opts.hitlExpirationAction;
+    body.hitlExpirationAction = opts.hitlExpirationAction;
   }
-  if (opts.webhookUrl !== undefined) body.webhook_url = opts.webhookUrl;
 
   if (Object.keys(body).length === 0) {
     process.stderr.write(
-      "No changes requested. Pass at least one flag (e.g. --hitl, --hitl-ttl, --webhook-url).\n",
+      "No changes requested. Pass at least one flag (e.g. --hitl, --hitl-ttl).\n",
     );
     process.exit(1);
   }
 
   const client = createClient();
-  const updated = await client.updateAgent(body, { agentEmail: email });
+  const updated = await client.agents.update(email, body);
 
   process.stdout.write(`Updated: ${updated.email}\n`);
-  const hitlStatus = updated.hitl_enabled
-    ? `enabled · ${updated.hitl_ttl_seconds}s · auto-${updated.hitl_expiration_action}`
+  const hitlStatus = updated.hitlEnabled
+    ? `enabled · ${updated.hitlTtlSeconds}s · auto-${updated.hitlExpirationAction}`
     : "disabled";
   process.stdout.write(`  HITL:        ${hitlStatus}\n`);
-  if (updated.webhook_url) {
-    process.stdout.write(`  Webhook:     ${updated.webhook_url}\n`);
-  }
-  if (updated.agent_mode) {
-    process.stdout.write(`  Agent mode:  ${updated.agent_mode}\n`);
+  if (updated.inboundPolicy) {
+    process.stdout.write(`  Inbound:     ${updated.inboundPolicy}\n`);
   }
 }
 
@@ -145,12 +139,13 @@ export async function agentsDelete(emailOrSlug: string | undefined): Promise<voi
 
   const client = createClient();
 
-  await client.api.deleteAgent(email);
+  await client.agents.delete(email);
 
   process.stdout.write(`Deleted: ${email}\n`);
 
   // Clear from config if it was the active agent
-  if (client.agentEmail === email) {
+  const config = loadConfig();
+  if (config.agent_email === email) {
     saveConfig({ agent_email: "" });
     process.stderr.write("Cleared active agent from config.\n");
   }

--- a/cli/src/commands/conversations.ts
+++ b/cli/src/commands/conversations.ts
@@ -1,4 +1,4 @@
-import { createClient } from "../sdk.js";
+import { createClient, requireAgentEmail } from "../sdk.js";
 
 export async function conversationsList(opts: {
   pageSize?: number;
@@ -7,34 +7,30 @@ export async function conversationsList(opts: {
   from?: string;
 }): Promise<void> {
   const client = createClient({ from: opts.from });
-  if (!client.agentEmail) {
-    process.stderr.write("No agent email. Set one with: e2a config set agent_email <email>\n");
-    process.exit(1);
-  }
+  const address = requireAgentEmail(opts.from);
 
-  const res = await client.listConversations({
-    pageSize: opts.pageSize,
+  const convos = await client.conversations.list(address, {
+    limit: opts.pageSize,
     since: opts.since,
     until: opts.until,
   });
-  const convos = res.conversations ?? [];
   if (convos.length === 0) {
     process.stdout.write("No conversations.\n");
     return;
   }
 
   // Compute ID column width from actual data (never truncate IDs).
-  const idW = Math.max(15, ...convos.map((c) => (c.conversation_id || "").length)) + 2;
+  const idW = Math.max(15, ...convos.map((c) => (c.conversationId || "").length)) + 2;
   const subjW = 40;
   process.stdout.write(
     `${"CONVERSATION ID".padEnd(idW)} ${"MSGS".padStart(5)}  ${"UNREAD".padEnd(7)} ${"SUBJECT".padEnd(subjW)} LAST ACTIVITY\n`,
   );
   for (const c of convos) {
-    const id = (c.conversation_id || "").padEnd(idW);
-    const msgs = String(c.message_count ?? 0).padStart(5);
-    const unread = (c.has_unread ? "yes" : "no").padEnd(7);
-    const subj = (c.latest_subject || "").padEnd(subjW).slice(0, subjW);
-    process.stdout.write(`${id} ${msgs}  ${unread} ${subj} ${c.last_message_at || ""}\n`);
+    const id = (c.conversationId || "").padEnd(idW);
+    const msgs = String(c.messageCount ?? 0).padStart(5);
+    const unread = (c.hasUnread ? "yes" : "no").padEnd(7);
+    const subj = (c.latestSubject || "").padEnd(subjW).slice(0, subjW);
+    process.stdout.write(`${id} ${msgs}  ${unread} ${subj} ${formatDate(c.lastMessageAt)}\n`);
   }
   process.stdout.write(`\n${convos.length} conversations\n`);
 }
@@ -48,21 +44,18 @@ export async function conversationsShow(
     process.exit(1);
   }
   const client = createClient({ from: opts.from });
-  if (!client.agentEmail) {
-    process.stderr.write("No agent email. Set one with: e2a config set agent_email <email>\n");
-    process.exit(1);
-  }
+  const address = requireAgentEmail(opts.from);
 
-  const detail = await client.getConversation(conversationId);
-  process.stdout.write(`Conversation:  ${detail.conversation_id}\n`);
-  process.stdout.write(`Messages:      ${detail.message_count ?? 0} `);
-  process.stdout.write(`(inbound: ${detail.inbound_count ?? 0}, outbound: ${detail.outbound_count ?? 0})\n`);
-  process.stdout.write(`Unread:        ${detail.has_unread ? "yes" : "no"}\n`);
-  if (detail.first_message_at) {
-    process.stdout.write(`First message: ${detail.first_message_at}\n`);
+  const detail = await client.conversations.get(address, conversationId);
+  process.stdout.write(`Conversation:  ${detail.conversationId}\n`);
+  process.stdout.write(`Messages:      ${detail.messageCount ?? 0} `);
+  process.stdout.write(`(inbound: ${detail.inboundCount ?? 0}, outbound: ${detail.outboundCount ?? 0})\n`);
+  process.stdout.write(`Unread:        ${detail.hasUnread ? "yes" : "no"}\n`);
+  if (detail.firstMessageAt) {
+    process.stdout.write(`First message: ${formatDate(detail.firstMessageAt)}\n`);
   }
-  if (detail.last_message_at) {
-    process.stdout.write(`Last message:  ${detail.last_message_at}\n`);
+  if (detail.lastMessageAt) {
+    process.stdout.write(`Last message:  ${formatDate(detail.lastMessageAt)}\n`);
   }
   if (detail.participants && detail.participants.length) {
     process.stdout.write(`Participants:  ${detail.participants.join(", ")}\n`);
@@ -76,17 +69,25 @@ export async function conversationsShow(
   if (msgs.length === 0) {
     return;
   }
-  const idW = Math.max(15, ...msgs.map((m) => (m.message_id || "").length)) + 2;
+  const idW = Math.max(15, ...msgs.map((m) => (m.messageId || "").length)) + 2;
   const fromW = 25;
   const subjW = 35;
   process.stdout.write(
     `${"ID".padEnd(idW)} ${"DIR".padEnd(4)} ${"FROM".padEnd(fromW)} ${"SUBJECT".padEnd(subjW)} CREATED\n`,
   );
   for (const m of msgs) {
-    const id = (m.message_id || "").padEnd(idW);
+    const id = (m.messageId || "").padEnd(idW);
     const dir = (m.direction || "?").padEnd(4);
-    const from = (m.from || "").padEnd(fromW).slice(0, fromW);
+    const from = (m._from || "").padEnd(fromW).slice(0, fromW);
     const subj = (m.subject || "").padEnd(subjW).slice(0, subjW);
-    process.stdout.write(`${id} ${dir} ${from} ${subj} ${m.created_at || ""}\n`);
+    process.stdout.write(`${id} ${dir} ${from} ${subj} ${formatDate(m.createdAt)}\n`);
   }
+}
+
+// The generated models type date-time fields as `Date`. Render them back
+// to ISO strings for stable, scriptable CLI output.
+function formatDate(d: Date | string | null | undefined): string {
+  if (!d) return "";
+  if (d instanceof Date) return d.toISOString();
+  return String(d);
 }

--- a/cli/src/commands/domains.ts
+++ b/cli/src/commands/domains.ts
@@ -3,8 +3,7 @@ import { createClient } from "../sdk.js";
 export async function domainsList(): Promise<void> {
   const client = createClient();
 
-  const res = await client.api.listDomains();
-  const domains = res.domains || [];
+  const domains = await client.domains.list().toArray({ limit: 1000 });
 
   if (domains.length === 0) {
     process.stderr.write("No domains registered. Run: e2a domains register <domain>\n");
@@ -26,14 +25,14 @@ export async function domainsRegister(domain: string | undefined): Promise<void>
 
   const client = createClient();
 
-  const res = await client.api.registerDomain({ domain });
+  const res = await client.domains.create({ domain });
 
   process.stdout.write(`Registered: ${res.domain}\n`);
 
-  if (res.dns_records) {
+  if (res.dnsRecords) {
     process.stdout.write("\nAdd these DNS records to verify ownership:\n\n");
-    const mx = res.dns_records.mx;
-    const txt = res.dns_records.txt;
+    const mx = res.dnsRecords.mx;
+    const txt = res.dnsRecords.txt;
     if (mx) {
       process.stdout.write(`  MX  ${mx.host}  ${mx.value}  (priority ${mx.priority ?? 10})\n`);
     }
@@ -52,7 +51,7 @@ export async function domainsVerify(domain: string | undefined): Promise<void> {
 
   const client = createClient();
 
-  const res = await client.api.verifyDomain(domain);
+  const res = await client.domains.verify(domain);
 
   if (res.verified) {
     process.stdout.write(`Verified: ${res.domain}\n`);
@@ -70,7 +69,7 @@ export async function domainsDelete(domain: string | undefined): Promise<void> {
 
   const client = createClient();
 
-  await client.api.deleteDomain(domain);
+  await client.domains.delete(domain);
 
   process.stdout.write(`Deleted: ${domain}\n`);
 }

--- a/cli/src/commands/events.ts
+++ b/cli/src/commands/events.ts
@@ -1,6 +1,6 @@
 import { createClient } from "../sdk.js";
 
-// CLI commands for the slice 6/7 customer-facing events API.
+// CLI commands for the customer-facing events API.
 //   e2a events list [--type T] [--agent A] [--since RFC3339] [--limit N]
 //   e2a events get <event-id>
 //   e2a events redeliver <event-id> [--webhook <wh-id>]
@@ -16,34 +16,34 @@ export async function listEvents(opts: {
   token?: string;
 }): Promise<void> {
   const client = createClient({});
-  const res = await client.api.listEvents({
-    type: opts.type,
-    agentId: opts.agentId,
-    conversationId: opts.conversationId,
-    messageId: opts.messageId,
-    since: opts.since,
-    until: opts.until,
-    pageSize: opts.limit ?? 20,
-    token: opts.token,
-  });
-  if (!res.events || res.events.length === 0) {
+  const limit = opts.limit ?? 20;
+  const events = await client.events
+    .list({
+      type: opts.type,
+      agentId: opts.agentId,
+      conversationId: opts.conversationId,
+      messageId: opts.messageId,
+      since: opts.since,
+      until: opts.until,
+      limit,
+    })
+    .toArray({ limit });
+  if (events.length === 0) {
     process.stdout.write("No events in this window.\n");
     return;
   }
-  for (const e of res.events) {
-    const agent = e.agent_id ?? "-";
+  for (const e of events) {
+    const agent = e.agentId ?? "-";
+    const created = e.createdAt instanceof Date ? e.createdAt.toISOString() : String(e.createdAt ?? "");
     process.stdout.write(
-      `${e.created_at}  ${e.id}  ${(e.type ?? "").padEnd(24)}  ${(e.status ?? "").padEnd(10)}  agent=${agent}\n`,
+      `${created}  ${e.id}  ${(e.type ?? "").padEnd(24)}  ${(e.status ?? "").padEnd(10)}  agent=${agent}\n`,
     );
-  }
-  if (res.next_token) {
-    process.stdout.write(`\nNext page: --token ${res.next_token}\n`);
   }
 }
 
 export async function getEvent(eventId: string): Promise<void> {
   const client = createClient({});
-  const e = await client.api.getEvent(eventId);
+  const e = await client.events.get(eventId);
   process.stdout.write(JSON.stringify(e, null, 2) + "\n");
 }
 
@@ -52,6 +52,6 @@ export async function redeliverEvent(
   opts: { webhookId?: string },
 ): Promise<void> {
   const client = createClient({});
-  const res = await client.api.redeliverEvent(eventId, { webhookId: opts.webhookId });
+  const res = await client.events.redeliver(eventId, { webhookId: opts.webhookId });
   process.stdout.write(JSON.stringify(res, null, 2) + "\n");
 }

--- a/cli/src/commands/events.ts
+++ b/cli/src/commands/events.ts
@@ -17,6 +17,9 @@ export async function listEvents(opts: {
 }): Promise<void> {
   const client = createClient({});
   const limit = opts.limit ?? 20;
+  if (!Number.isFinite(limit) || limit < 1) {
+    throw new Error("--limit must be a positive integer");
+  }
   const events = await client.events
     .list({
       type: opts.type,

--- a/cli/src/commands/forward.ts
+++ b/cli/src/commands/forward.ts
@@ -1,4 +1,5 @@
-import { createClient } from "../sdk.js";
+import type { ForwardRequest, RequestOptions } from "@e2a/sdk/v1";
+import { createClient, requireAgentEmail } from "../sdk.js";
 
 export async function forward(
   messageId: string | undefined,
@@ -24,21 +25,20 @@ export async function forward(
   }
 
   const client = createClient({ from: opts.from });
+  const address = requireAgentEmail(opts.from);
 
-  if (!client.agentEmail) {
-    process.stderr.write(
-      "No agent email configured. Run 'e2a register' first or use --agent.\n",
-    );
-    process.exit(1);
-  }
-
-  const res = await client.forward(messageId, opts.to, {
+  const reqBody: ForwardRequest = {
+    to: opts.to,
     cc: opts.cc?.length ? opts.cc : undefined,
     bcc: opts.bcc?.length ? opts.bcc : undefined,
     body: opts.body,
     htmlBody: opts.htmlBody,
-    idempotencyKey: opts.idempotencyKey,
-  });
+  };
+  const reqOpts: RequestOptions | undefined = opts.idempotencyKey
+    ? { idempotencyKey: opts.idempotencyKey }
+    : undefined;
 
-  process.stdout.write(`Sent: ${res.message_id}\n`);
+  const res = await client.messages.forward(address, messageId, reqBody, reqOpts);
+
+  process.stdout.write(`Sent: ${res.messageId}\n`);
 }

--- a/cli/src/commands/inbox.ts
+++ b/cli/src/commands/inbox.ts
@@ -1,9 +1,10 @@
-import { createClient } from "../sdk.js";
+import type { ListMessagesParams } from "@e2a/sdk/v1";
+import { createClient, requireAgentEmail } from "../sdk.js";
 
 export async function inbox(
-  status: string,
+  status: "unread" | "read" | "all",
   limit: number,
-  token: string | undefined,
+  _token: string | undefined,
   agentFrom: string | undefined,
   sort?: "asc" | "desc",
   filters?: {
@@ -16,16 +17,10 @@ export async function inbox(
   },
 ): Promise<void> {
   const client = createClient({ from: agentFrom });
+  const address = requireAgentEmail(agentFrom);
 
-  if (!client.agentEmail) {
-    process.stderr.write("No agent email. Set one with: e2a config set agent_email <email>\n");
-    process.exit(1);
-  }
-
-  const res = await client.api.listMessages(client.agentEmail, {
+  const params: ListMessagesParams = {
     status,
-    pageSize: limit,
-    token,
     sort,
     from: filters?.from,
     subjectContains: filters?.subjectContains,
@@ -33,31 +28,31 @@ export async function inbox(
     since: filters?.since,
     until: filters?.until,
     labels: filters?.labels && filters.labels.length ? filters.labels : undefined,
-  });
+    limit,
+  };
 
-  if (!res.messages || res.messages.length === 0) {
+  const messages = await client.messages.list(address, params).toArray({ limit });
+
+  if (messages.length === 0) {
     process.stdout.write("No messages.\n");
     return;
   }
 
   // Compute ID column width from actual data (never truncate IDs)
-  const idW = Math.max(4, ...res.messages.map((m: { message_id?: string }) => (m.message_id || "").length)) + 2;
+  const idW = Math.max(4, ...messages.map((m) => (m.messageId || "").length)) + 2;
   const fromW = 25;
   const subjW = 30;
   process.stdout.write(
     `${"ID".padEnd(idW)} ${"FROM".padEnd(fromW)} ${"SUBJECT".padEnd(subjW)} RECEIVED\n`,
   );
 
-  for (const msg of res.messages) {
-    const id = (msg.message_id || "").padEnd(idW);
-    const from = (msg.from || "").padEnd(fromW).slice(0, fromW);
+  for (const msg of messages) {
+    const id = (msg.messageId || "").padEnd(idW);
+    const from = (msg._from || "").padEnd(fromW).slice(0, fromW);
     const subj = (msg.subject || "").padEnd(subjW).slice(0, subjW);
-    process.stdout.write(`${id} ${from} ${subj} ${msg.created_at || ""}\n`);
+    const received = msg.createdAt instanceof Date ? msg.createdAt.toISOString() : String(msg.createdAt ?? "");
+    process.stdout.write(`${id} ${from} ${subj} ${received}\n`);
   }
 
-  process.stdout.write(`\n${res.messages.length} messages`);
-  if (res.next_token) {
-    process.stdout.write(` (use --token ${res.next_token} for next page)`);
-  }
-  process.stdout.write("\n");
+  process.stdout.write(`\n${messages.length} messages\n`);
 }

--- a/cli/src/commands/labels.ts
+++ b/cli/src/commands/labels.ts
@@ -1,4 +1,5 @@
-import { createClient } from "../sdk.js";
+import type { UpdateMessageRequest } from "@e2a/sdk/v1";
+import { createClient, requireAgentEmail } from "../sdk.js";
 
 export async function labels(
   messageId: string | undefined,
@@ -20,18 +21,14 @@ export async function labels(
   }
 
   const client = createClient({ from: opts.from });
+  const address = requireAgentEmail(opts.from);
 
-  if (!client.agentEmail) {
-    process.stderr.write(
-      "No agent email configured. Run 'e2a register' first or use --agent.\n",
-    );
-    process.exit(1);
-  }
-
-  const res = await client.updateMessageLabels(messageId, {
+  const body: UpdateMessageRequest = {
     addLabels: opts.add.length ? opts.add : undefined,
     removeLabels: opts.remove.length ? opts.remove : undefined,
-  });
+  };
 
-  process.stdout.write(`${res.message_id}: ${(res.labels ?? []).join(", ") || "(none)"}\n`);
+  const res = await client.messages.updateLabels(address, messageId, body);
+
+  process.stdout.write(`${res.messageId}: ${(res.labels ?? []).join(", ") || "(none)"}\n`);
 }

--- a/cli/src/commands/listen.ts
+++ b/cli/src/commands/listen.ts
@@ -126,7 +126,10 @@ export async function forwardMessage(
       headers["Authorization"] = `Bearer ${forwardToken}`;
     }
   } else {
-    // Generic forward — send exact raw JSON
+    // Generic forward — POST the full v1 MessageView as JSON. NOTE: in 3.0 this
+    // is the SDK's camelCase model shape (messageId, createdAt, …), not the
+    // legacy snake_case wire JSON; --forward consumers updating to the 3.0 CLI
+    // should read the v1 field names.
     fetchBody = JSON.stringify(full);
     if (forwardToken) {
       headers["Authorization"] = `Bearer ${forwardToken}`;

--- a/cli/src/commands/listen.ts
+++ b/cli/src/commands/listen.ts
@@ -1,5 +1,5 @@
 import type { E2AClient, WSNotification } from "@e2a/sdk/v1";
-import { createClient } from "../sdk.js";
+import { createClient, requireAgentEmail } from "../sdk.js";
 
 export interface ListenOptions {
   agent?: string;
@@ -10,22 +10,14 @@ export interface ListenOptions {
 
 export async function listen(opts: ListenOptions): Promise<void> {
   const client = createClient({ from: opts.agent });
-
-  if (!client.agentEmail) {
-    process.stderr.write(
-      "No agent email. Use --agent or run: e2a register <slug>\n",
-    );
-    process.exit(1);
-  }
-
-  const agentEmail = client.agentEmail;
+  const agentEmail = requireAgentEmail(opts.agent);
 
   process.stderr.write(`Listening for emails to ${agentEmail}...\n`);
 
   // client.listen() returns a WSStream — both AsyncIterable<WSNotification>
   // and EventEmitter. We use both: events for connection lifecycle, the
   // for-await loop for the happy path.
-  const stream = client.listen({ agentEmail });
+  const stream = client.listen(agentEmail);
 
   stream.on("open", () => {
     process.stderr.write("Connected.\n");
@@ -64,7 +56,7 @@ export async function handleNotification(
   opts: Pick<ListenOptions, "json" | "forward" | "forwardToken">,
 ): Promise<void> {
   if (opts.json) {
-    const full = await client.api.getMessage(agentEmail, notification.message_id);
+    const full = await client.messages.get(agentEmail, notification.message_id);
     process.stdout.write(JSON.stringify(full) + "\n");
     return;
   }
@@ -102,8 +94,8 @@ export async function forwardMessage(
   forwardUrl: string,
   forwardToken?: string,
 ): Promise<void> {
-  // Fetch full message (raw JSON shape for forwarding)
-  const full = await client.api.getMessage(agentEmail, notification.message_id);
+  // Fetch full message (MessageView).
+  const full = await client.messages.get(agentEmail, notification.message_id);
 
   let fetchBody: string;
   const headers: Record<string, string> = {
@@ -111,11 +103,12 @@ export async function forwardMessage(
   };
 
   if (isOpenClawUrl(forwardUrl)) {
-    // Decode raw_message to extract text body for OpenClaw
-    let body = "";
-    if (full.raw_message) {
+    // Prefer the server's parsed/plain-text body; fall back to decoding
+    // the raw RFC 2822 message for OpenClaw.
+    let body = full.parsed?.text || full.body?.text || "";
+    if (!body && full.rawMessage) {
       try {
-        const decoded = Buffer.from(full.raw_message, "base64").toString("utf-8");
+        const decoded = Buffer.from(full.rawMessage, "base64").toString("utf-8");
         body = extractTextFromRaw(decoded);
       } catch {
         // Fall back to empty body
@@ -162,7 +155,9 @@ export async function forwardMessage(
     const responseText = await extractResponseText(res);
     if (responseText) {
       try {
-        await client.reply(notification.message_id, responseText);
+        await client.messages.reply(agentEmail, notification.message_id, {
+          body: responseText,
+        });
         process.stderr.write(
           `Replied to ${notification.from} (${notification.message_id})\n`,
         );

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -1,7 +1,6 @@
 import { execFile } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { createServer, type IncomingMessage, type Server } from "node:http";
-import { E2AApi, E2AApiError } from "@e2a/sdk";
 import { loadConfig, saveConfig } from "../config.js";
 
 /**
@@ -239,32 +238,34 @@ async function waitForBrowserLogin(apiUrl: string, timeoutMs = LOGIN_TIMEOUT_MS)
 export async function login(): Promise<void> {
   const config = loadConfig();
 
-  // Preflight: hit /api/v1/info before opening the browser. Two wins —
+  // Preflight: hit the deployment's public info endpoint before opening
+  // the browser. Two wins —
   //   1. Fast-fail when the server is unreachable instead of opening a
   //      browser tab that loads nothing and timing out 2 minutes later.
   //   2. Captures shared_domain in the same request so we don't need a
   //      separate fetch after login completes.
-  // Distinguish E2AApiError (server up, /info absent — older deployment)
-  // from other errors (connection refused, DNS, timeout): only the
-  // latter should abort login.
+  // `/v1/info` is unauthenticated and login runs before we have a key, so we
+  // probe it with a raw fetch rather than the SDK client (which requires an
+  // apiKey to construct). Distinguish a connection failure (refused, DNS,
+  // timeout) — which should abort — from an HTTP-level error (server up, /info
+  // absent on an older deployment), which should let login continue.
   let discoveredSharedDomain: string | undefined;
   try {
-    const info = await E2AApi.fetchInfo(config.api_url);
-    if (info.shared_domain) {
-      discoveredSharedDomain = info.shared_domain;
+    const resp = await fetch(`${config.api_url.replace(/\/+$/, "")}/v1/info`);
+    if (resp.ok) {
+      const info = (await resp.json()) as { shared_domain?: string };
+      if (info.shared_domain) {
+        discoveredSharedDomain = info.shared_domain;
+      }
     }
+    // A non-ok response means the server is up but /info is unavailable
+    // (older deployment) — continue with login without shared_domain.
   } catch (err) {
-    if (!(err instanceof E2AApiError)) {
-      const detail = err instanceof Error ? err.message : String(err);
-      throw new Error(
-        `could not reach ${config.api_url}: ${detail}. ` +
-          `Check the server is running and E2A_URL is correct.`,
-      );
-    }
-    // Server responded with non-2xx — it's up, just doesn't expose /info
-    // (older deployment). Continue with login; we just won't discover
-    // shared_domain. Users on this path can still set it manually via
-    // E2A_SHARED_DOMAIN or `e2a config set shared_domain ...`.
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `could not reach ${config.api_url}: ${detail}. ` +
+        `Check the server is running and E2A_URL is correct.`,
+    );
   }
 
   const { apiKey, agentEmail } = await waitForBrowserLogin(config.api_url);

--- a/cli/src/commands/pending.ts
+++ b/cli/src/commands/pending.ts
@@ -2,83 +2,60 @@ import { spawnSync } from "node:child_process";
 import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { components } from "@e2a/sdk/v1";
-import { createClient } from "../sdk.js";
+import type { ApproveRequest, MessageView, RequestOptions } from "@e2a/sdk/v1";
+import { createClient, requireAgentEmail } from "../sdk.js";
 
-type Schemas = components["schemas"];
-type PendingSummary = Schemas["PendingMessageSummary"];
-type PendingDetail = Schemas["PendingMessageDetail"];
-type ApproveOverrides = Schemas["ApprovePendingMessageRequest"];
+// The status value the server uses for outbound drafts held for human
+// approval. Held drafts surface as outbound messages carrying this status.
+const PENDING_STATUS = "pending_approval";
 
-// formatExpiresIn renders a compact "in 2h 15m" / "expired" label so
-// `pending list` output is scannable at a terminal width without
-// forcing the reviewer to compare timestamps in their head.
-function formatExpiresIn(iso?: string): string {
-  if (!iso) return "—";
-  const diffMs = new Date(iso).getTime() - Date.now();
-  if (diffMs <= 0) return "expired";
-  const mins = Math.floor(diffMs / 60_000);
-  if (mins < 60) return `in ${mins}m`;
-  const hours = Math.floor(mins / 60);
-  const m = mins % 60;
-  if (hours < 24) return m === 0 ? `in ${hours}h` : `in ${hours}h ${m}m`;
-  const days = Math.floor(hours / 24);
-  const h = hours % 24;
-  return h === 0 ? `in ${days}d` : `in ${days}d ${h}h`;
-}
-
-export async function pendingList(): Promise<void> {
-  const client = createClient();
-  const res = await client.listPendingMessages();
-  const msgs = (res.messages ?? []) as PendingSummary[];
+export async function pendingList(from?: string): Promise<void> {
+  const client = createClient({ from });
+  const address = requireAgentEmail(from);
+  // The v1 surface has no cross-agent pending endpoint. Held outbound
+  // drafts appear in the per-agent message list with
+  // status="pending_approval"; list the agent's outbound messages and
+  // filter to the held ones.
+  const outbound = await client.messages
+    .list(address, { direction: "outbound" })
+    .toArray({ limit: 1000 });
+  const msgs = outbound.filter((m) => m.status === PENDING_STATUS);
   if (msgs.length === 0) {
     process.stdout.write("No messages pending approval.\n");
     return;
   }
   for (const m of msgs) {
     const recipients = [...(m.to ?? []), ...(m.cc ?? [])].join(", ") || "(no recipients)";
-    const expires = formatExpiresIn(m.approval_expires_at);
     process.stdout.write(
-      `${m.id}  ${m.agent_id} → ${recipients}  "${m.subject}"  ${expires}\n`,
+      `${m.messageId}  ${m._from ?? address} → ${recipients}  "${m.subject}"\n`,
     );
   }
 }
 
-export async function pendingShow(id: string | undefined): Promise<void> {
+export async function pendingShow(id: string | undefined, from?: string): Promise<void> {
   if (!id) {
     process.stderr.write("Usage: e2a pending show <message-id>\n");
     process.exit(1);
   }
-  const client = createClient();
-  const m = (await client.getPendingMessage(id)) as PendingDetail;
+  const client = createClient({ from });
+  const address = requireAgentEmail(from);
+  const m = await client.messages.get(address, id);
   const lines: string[] = [];
-  lines.push(`ID:        ${m.id}`);
-  lines.push(`Agent:     ${m.agent_id}`);
+  lines.push(`ID:        ${m.messageId}`);
+  lines.push(`Agent:     ${address}`);
   lines.push(`Status:    ${m.status}`);
-  if (m.type) lines.push(`Type:      ${m.type}`);
   lines.push(`To:        ${(m.to ?? []).join(", ")}`);
   if (m.cc?.length) lines.push(`Cc:        ${m.cc.join(", ")}`);
-  if (m.bcc?.length) lines.push(`Bcc:       ${m.bcc.join(", ")}`);
   lines.push(`Subject:   ${m.subject}`);
-  if (m.conversation_id) lines.push(`ConvID:    ${m.conversation_id}`);
-  if (m.approval_expires_at) {
-    lines.push(`Expires:   ${m.approval_expires_at} (${formatExpiresIn(m.approval_expires_at)})`);
-  }
-  if (m.edited) lines.push(`Edited:    true`);
+  if (m.conversationId) lines.push(`ConvID:    ${m.conversationId}`);
   lines.push("");
   lines.push("--- Body ---");
-  lines.push(m.body_text ?? "(no plain body — body was scrubbed or HTML-only)");
-  if (m.body_html) {
+  const bodyText = m.parsed?.text || m.body?.text;
+  lines.push(bodyText ?? "(no plain body — body was scrubbed or HTML-only)");
+  if (m.body?.html) {
     lines.push("");
     lines.push("--- HTML body ---");
-    lines.push(m.body_html);
-  }
-  if (m.attachments?.length) {
-    lines.push("");
-    lines.push("--- Attachments ---");
-    for (const a of m.attachments) {
-      lines.push(`  ${a.filename}  (${a.content_type})`);
-    }
+    lines.push(m.body.html);
   }
   process.stdout.write(lines.join("\n") + "\n");
 }
@@ -88,7 +65,7 @@ export async function pendingShow(id: string | undefined): Promise<void> {
 // each field is a single line prefixed with a known label, and the body
 // lives below a fenced separator. Keeps the UX readable and the parser
 // trivial.
-function editableDocFromMessage(m: PendingDetail): string {
+function editableDocFromMessage(m: MessageView): string {
   return [
     `# Edit fields below and save to approve with changes.`,
     `# Lines starting with '#' are ignored. Do not rename the field labels.`,
@@ -96,10 +73,9 @@ function editableDocFromMessage(m: PendingDetail): string {
     `subject: ${m.subject ?? ""}`,
     `to: ${(m.to ?? []).join(", ")}`,
     `cc: ${(m.cc ?? []).join(", ")}`,
-    `bcc: ${(m.bcc ?? []).join(", ")}`,
     ``,
     `--- body ---`,
-    m.body_text ?? "",
+    (m.parsed?.text || m.body?.text) ?? "",
   ].join("\n");
 }
 
@@ -155,20 +131,21 @@ function parseEditableDoc(doc: string): {
 // Keeps the server-side `edited` flag truthful.
 function diffOverrides(
   parsed: ReturnType<typeof parseEditableDoc>,
-  original: PendingDetail,
-): ApproveOverrides {
-  const out: ApproveOverrides = {};
+  original: MessageView,
+): ApproveRequest {
+  const out: ApproveRequest = {};
+  const originalBody = (original.parsed?.text || original.body?.text) ?? "";
   if (parsed.subject !== undefined && parsed.subject !== (original.subject ?? "")) {
     out.subject = parsed.subject;
   }
-  if (parsed.body !== undefined && parsed.body !== (original.body_text ?? "")) {
-    out.body_text = parsed.body;
+  if (parsed.body !== undefined && parsed.body !== originalBody) {
+    out.bodyText = parsed.body;
   }
   const arrEq = (a: string[] | undefined, b: string[] | undefined) =>
     JSON.stringify(a ?? []) === JSON.stringify(b ?? []);
-  if (parsed.to && !arrEq(parsed.to, original.to)) out.to = parsed.to;
-  if (parsed.cc && !arrEq(parsed.cc, original.cc)) out.cc = parsed.cc;
-  if (parsed.bcc && !arrEq(parsed.bcc, original.bcc)) out.bcc = parsed.bcc;
+  if (parsed.to && !arrEq(parsed.to, original.to ?? undefined)) out.to = parsed.to;
+  if (parsed.cc && !arrEq(parsed.cc, original.cc ?? undefined)) out.cc = parsed.cc;
+  if (parsed.bcc && parsed.bcc.length) out.bcc = parsed.bcc;
   return out;
 }
 
@@ -188,69 +165,54 @@ function openEditor(initial: string): string {
 
 export async function pendingApprove(
   id: string | undefined,
-  opts: { edit?: boolean; idempotencyKey?: string },
+  opts: { edit?: boolean; idempotencyKey?: string; from?: string },
 ): Promise<void> {
   if (!id) {
     process.stderr.write("Usage: e2a pending approve <message-id> [--edit] [--idempotency-key <key>]\n");
     process.exit(1);
   }
 
-  const client = createClient();
+  const client = createClient({ from: opts.from });
+  const address = requireAgentEmail(opts.from);
 
-  // We need the message's owning agent email to call the agent-scoped
-  // approve endpoint. Fetch the detail unconditionally — even on the
-  // non-edit path — because the alternative (asking the user to pass
-  // --agent) is brittle and easy to typo. The lookup is a single GET
-  // and gates a side-effectful POST, so the extra round trip pays for
-  // itself in fewer 404s.
-  const original = (await client.getPendingMessage(id)) as PendingDetail;
-  if (original.status !== "pending_approval") {
+  // Fetch the message first to confirm it is still held. The lookup is a
+  // single GET and gates a side-effectful POST, so the extra round trip
+  // pays for itself in fewer surprises.
+  const original = await client.messages.get(address, id);
+  if (original.status !== PENDING_STATUS) {
     process.stderr.write(
       `Cannot ${opts.edit ? "edit" : "approve"}: message is ${original.status}, not pending.\n`,
     );
     process.exit(1);
   }
-  // PendingMessageDetail.agent_id is `string | undefined` in the
-  // generated OpenAPI types — the field is non-optional on the wire
-  // but swag emits it as optional. The status guard above already
-  // proves the row exists, so a missing agent_id here is a server
-  // bug; bail loudly rather than crashing in the URL builder.
-  if (!original.agent_id) {
-    process.stderr.write(`Server returned a pending message without an agent_id (id=${id}).\n`);
-    process.exit(1);
-  }
-  const agentEmail = original.agent_id;
 
-  let overrides: ApproveOverrides = {};
+  let overrides: ApproveRequest = {};
   if (opts.edit) {
     const edited = openEditor(editableDocFromMessage(original));
     overrides = diffOverrides(parseEditableDoc(edited), original);
   }
 
-  const res = opts.idempotencyKey !== undefined
-    ? await client.approveMessage(agentEmail, id, overrides, { idempotencyKey: opts.idempotencyKey })
-    : await client.approveMessage(agentEmail, id, overrides);
+  const reqOpts: RequestOptions | undefined = opts.idempotencyKey !== undefined
+    ? { idempotencyKey: opts.idempotencyKey }
+    : undefined;
+  const res = await client.messages.approve(address, id, overrides, reqOpts);
   const editedNote = res.edited ? " (with edits)" : "";
   process.stdout.write(
-    `Approved: ${res.message_id} → ${res.provider_message_id ?? ""}${editedNote}\n`,
+    `Approved: ${res.messageId} → ${res.providerMessageId ?? ""}${editedNote}\n`,
   );
 }
 
 export async function pendingReject(
   id: string | undefined,
   reason: string | undefined,
+  from?: string,
 ): Promise<void> {
   if (!id) {
     process.stderr.write('Usage: e2a pending reject <message-id> [--reason "..."]\n');
     process.exit(1);
   }
-  const client = createClient();
-  // Same agent-email-discovery pattern as approve.
-  const original = (await client.getPendingMessage(id)) as PendingDetail;
-  if (!original.agent_id) {
-    process.stderr.write(`Server returned a pending message without an agent_id (id=${id}).\n`);
-    process.exit(1);
-  }
-  await client.rejectMessage(original.agent_id, id, reason ?? "");
+  const client = createClient({ from });
+  const address = requireAgentEmail(from);
+  await client.messages.reject(address, id, { reason: reason ?? "" });
   process.stdout.write(`Rejected: ${id}\n`);
 }

--- a/cli/src/commands/read.ts
+++ b/cli/src/commands/read.ts
@@ -1,4 +1,4 @@
-import { createClient } from "../sdk.js";
+import { createClient, requireAgentEmail } from "../sdk.js";
 
 export async function read(messageId: string | undefined, from: string | undefined): Promise<void> {
   if (!messageId) {
@@ -7,38 +7,43 @@ export async function read(messageId: string | undefined, from: string | undefin
   }
 
   const client = createClient({ from });
+  const address = requireAgentEmail(from);
 
-  if (!client.agentEmail) {
-    process.stderr.write("No agent email. Set one with: e2a config set agent_email <email>\n");
-    process.exit(1);
-  }
+  // messages.get returns a MessageView (the bearer token already
+  // authenticated the channel) — no `verifySignature` step needed, no
+  // second roundtrip for the raw detail.
+  const msg = await client.messages.get(address, messageId);
 
-  // getMessage returns a pre-verified InboundEmail (the bearer token
-  // already authenticated the channel) — no `verifySignature` step
-  // needed, no second roundtrip for the raw detail.
-  const email = await client.getMessage(messageId);
+  const recipient = msg.recipient ?? "";
+  const to = msg.to ?? [];
+  const cc = msg.cc ?? [];
+  const replyTo = msg.replyTo ?? [];
 
-  process.stdout.write(`Message ID: ${email.messageId}\n`);
-  process.stdout.write(`From: ${email.sender}\n`);
-  process.stdout.write(`To: ${email.recipient}\n`);
+  process.stdout.write(`Message ID: ${msg.messageId}\n`);
+  process.stdout.write(`From: ${msg._from}\n`);
+  process.stdout.write(`To: ${recipient}\n`);
   // Other addresses from the original To: header (the message may have been
   // addressed to several agents at once; this row is one of those fan-outs).
-  const recipientLower = email.recipient.toLowerCase();
-  const otherTo = email.to.filter((a) => a.toLowerCase() !== recipientLower);
+  const recipientLower = recipient.toLowerCase();
+  const otherTo = to.filter((a) => a.toLowerCase() !== recipientLower);
   if (otherTo.length > 0) {
     process.stdout.write(`Also-To: ${otherTo.join(", ")}\n`);
   }
-  if (email.cc.length > 0) {
-    process.stdout.write(`Cc: ${email.cc.join(", ")}\n`);
+  if (cc.length > 0) {
+    process.stdout.write(`Cc: ${cc.join(", ")}\n`);
   }
-  if (email.replyTo.length > 0) {
-    process.stdout.write(`Reply-To: ${email.replyTo.join(", ")}\n`);
+  if (replyTo.length > 0) {
+    process.stdout.write(`Reply-To: ${replyTo.join(", ")}\n`);
   }
-  process.stdout.write(`Date: ${email.receivedAt ?? "unknown"}\n`);
-  process.stdout.write(`Subject: ${email.subject}\n`);
+  const received = msg.createdAt instanceof Date ? msg.createdAt.toISOString() : (msg.createdAt ?? null);
+  process.stdout.write(`Date: ${received ?? "unknown"}\n`);
+  process.stdout.write(`Subject: ${msg.subject}\n`);
   process.stdout.write("\n");
 
-  if (email.textBody) {
-    process.stdout.write(email.textBody + "\n");
+  // Prefer the parsed (best-effort plain-text) body, falling back to the
+  // raw text body the server extracted.
+  const textBody = msg.parsed?.text || msg.body?.text;
+  if (textBody) {
+    process.stdout.write(textBody + "\n");
   }
 }

--- a/cli/src/commands/reply.ts
+++ b/cli/src/commands/reply.ts
@@ -1,4 +1,5 @@
-import { createClient } from "../sdk.js";
+import type { ReplyRequest, RequestOptions } from "@e2a/sdk/v1";
+import { createClient, requireAgentEmail } from "../sdk.js";
 
 export async function reply(
   messageId: string | undefined,
@@ -24,21 +25,20 @@ export async function reply(
   }
 
   const client = createClient({ from: opts.from });
+  const address = requireAgentEmail(opts.from);
 
-  if (!client.agentEmail) {
-    process.stderr.write(
-      "No agent email configured. Run 'e2a register' first or use --agent.\n",
-    );
-    process.exit(1);
-  }
-
-  const res = await client.reply(messageId, body, {
+  const reqBody: ReplyRequest = {
+    body,
     htmlBody: opts.htmlBody,
     replyAll: opts.replyAll,
     cc: opts.cc?.length ? opts.cc : undefined,
     bcc: opts.bcc?.length ? opts.bcc : undefined,
-    idempotencyKey: opts.idempotencyKey,
-  });
+  };
+  const reqOpts: RequestOptions | undefined = opts.idempotencyKey
+    ? { idempotencyKey: opts.idempotencyKey }
+    : undefined;
 
-  process.stdout.write(`Sent: ${res.message_id}\n`);
+  const res = await client.messages.reply(address, messageId, reqBody, reqOpts);
+
+  process.stdout.write(`Sent: ${res.messageId}\n`);
 }

--- a/cli/src/commands/send.ts
+++ b/cli/src/commands/send.ts
@@ -1,4 +1,5 @@
-import { createClient } from "../sdk.js";
+import type { SendEmailRequest, RequestOptions } from "@e2a/sdk/v1";
+import { createClient, requireAgentEmail } from "../sdk.js";
 
 export async function send(
   to: string[],
@@ -21,20 +22,21 @@ export async function send(
   }
 
   const client = createClient({ from: opts.from });
+  const address = requireAgentEmail(opts.from);
 
-  if (!client.agentEmail) {
-    process.stderr.write(
-      "No agent email configured. Run 'e2a register' first or use --agent.\n",
-    );
-    process.exit(1);
-  }
-
-  const res = await client.send(to, subject, body, {
+  const reqBody: SendEmailRequest = {
+    to: to.length ? to : undefined,
+    subject,
+    body,
     htmlBody: opts.htmlBody,
     cc: opts.cc?.length ? opts.cc : undefined,
     bcc: opts.bcc?.length ? opts.bcc : undefined,
-    idempotencyKey: opts.idempotencyKey,
-  });
+  };
+  const reqOpts: RequestOptions | undefined = opts.idempotencyKey
+    ? { idempotencyKey: opts.idempotencyKey }
+    : undefined;
 
-  process.stdout.write(`Sent: ${res.message_id}\n`);
+  const res = await client.messages.send(address, reqBody, reqOpts);
+
+  process.stdout.write(`Sent: ${res.messageId}\n`);
 }

--- a/cli/src/commands/webhooks.ts
+++ b/cli/src/commands/webhooks.ts
@@ -1,10 +1,21 @@
+import type {
+  CreateWebhookRequest,
+  UpdateWebhookRequest,
+  WebhookFiltersView,
+} from "@e2a/sdk/v1";
 import { createClient } from "../sdk.js";
+
+// The generated models type date-time fields as `Date`. Render them back
+// to ISO strings for stable, scriptable CLI output.
+function fmtDate(d: Date | string | null | undefined): string {
+  if (!d) return "";
+  return d instanceof Date ? d.toISOString() : String(d);
+}
 
 // `e2a webhooks list` — one row per webhook, owner-scoped.
 export async function webhooksList(): Promise<void> {
   const client = createClient();
-  const res = await client.api.listWebhooks();
-  const hooks = res.webhooks || [];
+  const hooks = await client.webhooks.list().toArray({ limit: 1000 });
   if (hooks.length === 0) {
     process.stderr.write("No webhooks. Create one with: e2a webhooks create --url <url> --events email.received\n");
     return;
@@ -36,23 +47,25 @@ export async function webhooksCreate(opts: WebhooksCreateOptions): Promise<void>
     process.stderr.write("--events is required (e.g. --events email.received)\n");
     process.exit(1);
   }
-  const filters: { agent_ids?: string[]; conversation_ids?: string[]; labels?: string[] } = {};
-  if (opts.agentId && opts.agentId.length > 0) filters.agent_ids = opts.agentId;
-  if (opts.conversationId && opts.conversationId.length > 0) filters.conversation_ids = opts.conversationId;
+  const filters: WebhookFiltersView = {};
+  if (opts.agentId && opts.agentId.length > 0) filters.agentIds = opts.agentId;
+  if (opts.conversationId && opts.conversationId.length > 0) filters.conversationIds = opts.conversationId;
   if (opts.label && opts.label.length > 0) filters.labels = opts.label;
 
-  const client = createClient();
-  const res = await client.api.createWebhook({
+  const body: CreateWebhookRequest = {
     url: opts.url,
     events: opts.events,
     description: opts.description ?? "",
     filters: Object.keys(filters).length > 0 ? filters : undefined,
-  });
+  };
+
+  const client = createClient();
+  const res = await client.webhooks.create(body);
   process.stdout.write(`Created: ${res.id}\n`);
   // The plaintext secret is printed exactly once, here. Subsequent
   // get/list calls scrub it.
-  if (res.signing_secret) {
-    process.stdout.write(`Signing secret: ${res.signing_secret}\n`);
+  if (res.signingSecret) {
+    process.stdout.write(`Signing secret: ${res.signingSecret}\n`);
     process.stdout.write("Store this somewhere safe — it won't be shown again.\n");
   }
 }
@@ -63,7 +76,7 @@ export async function webhooksGet(id: string | undefined): Promise<void> {
     process.exit(1);
   }
   const client = createClient();
-  const w = await client.api.getWebhook(id);
+  const w = await client.webhooks.get(id);
   process.stdout.write(JSON.stringify(w, null, 2) + "\n");
 }
 
@@ -84,12 +97,7 @@ export async function webhooksUpdate(
     process.stderr.write("Usage: e2a webhooks update <id> [--url …] [--events …] [--enable|--disable]\n");
     process.exit(1);
   }
-  const body: {
-    url?: string;
-    events?: string[];
-    description?: string;
-    enabled?: boolean;
-  } = {};
+  const body: UpdateWebhookRequest = {};
   if (opts.url !== undefined) body.url = opts.url;
   if (opts.events !== undefined && opts.events.length > 0) body.events = opts.events;
   if (opts.description !== undefined) body.description = opts.description;
@@ -99,7 +107,7 @@ export async function webhooksUpdate(
     process.exit(1);
   }
   const client = createClient();
-  const w = await client.api.updateWebhook(id, body);
+  const w = await client.webhooks.update(id, body);
   process.stdout.write(`Updated: ${w.id}  enabled=${w.enabled}\n`);
 }
 
@@ -109,7 +117,7 @@ export async function webhooksDelete(id: string | undefined): Promise<void> {
     process.exit(1);
   }
   const client = createClient();
-  await client.api.deleteWebhook(id);
+  await client.webhooks.delete(id);
   process.stdout.write(`Deleted: ${id}\n`);
 }
 
@@ -119,9 +127,9 @@ export async function webhooksRotateSecret(id: string | undefined): Promise<void
     process.exit(1);
   }
   const client = createClient();
-  const res = await client.api.rotateWebhookSecret(id);
-  process.stdout.write(`New signing secret: ${res.signing_secret}\n`);
-  process.stdout.write(`Previous secret expires at: ${res.previous_secret_expires_at}\n`);
+  const res = await client.webhooks.rotateSecret(id);
+  process.stdout.write(`New signing secret: ${res.signingSecret}\n`);
+  process.stdout.write(`Previous secret expires at: ${res.previousSecretExpiresAt}\n`);
   process.stdout.write("Store the new secret — it won't be shown again.\n");
 }
 
@@ -139,11 +147,11 @@ export async function webhooksTest(
     process.exit(1);
   }
   const client = createClient();
-  const res = await client.api.testWebhook(id, {
+  const res = await client.webhooks.test(id, {
     event: opts.event ?? "",
     data: { test: true },
   });
-  process.stdout.write(`Scheduled test delivery: ${res.delivery_id}\n`);
+  process.stdout.write(`Scheduled test delivery: ${res.deliveryId}\n`);
   process.stdout.write("Use `e2a webhooks deliveries " + id + "` to see status.\n");
 }
 
@@ -161,17 +169,16 @@ export async function webhooksDeliveries(
     process.exit(1);
   }
   const client = createClient();
-  const res = await client.api.listWebhookDeliveries(id, {
-    limit: opts.limit,
-    status: opts.status,
-  });
-  const rows = res.deliveries || [];
+  const limit = opts.limit ?? 50;
+  const rows = await client.webhooks
+    .deliveries(id, { limit, status: opts.status })
+    .toArray({ limit });
   if (rows.length === 0) {
     process.stdout.write("No deliveries yet.\n");
     return;
   }
   for (const r of rows) {
-    const code = r.last_status_code !== undefined ? `(${r.last_status_code})` : "";
-    process.stdout.write(`${r.id}  ${r.status}  attempts=${r.attempts}  ${r.event_type}  ${code}  ${r.created_at}\n`);
+    const code = r.lastStatusCode !== undefined ? `(${r.lastStatusCode})` : "";
+    process.stdout.write(`${r.id}  ${r.status}  attempts=${r.attempts}  ${r.eventType}  ${code}  ${fmtDate(r.createdAt)}\n`);
   }
 }

--- a/cli/src/sdk.ts
+++ b/cli/src/sdk.ts
@@ -1,11 +1,10 @@
 import { E2AClient } from "@e2a/sdk/v1";
 import { loadConfig, requireApiKey } from "./config.js";
 
-export function createClient(opts?: { from?: string }): E2AClient {
+export function createClient(_opts?: { from?: string }): E2AClient {
   const config = loadConfig();
   const apiKey = requireApiKey(config);
-  const agentEmail = opts?.from || config.agent_email;
-  return new E2AClient({ apiKey, baseUrl: config.api_url, agentEmail });
+  return new E2AClient({ apiKey, baseUrl: config.api_url });
 }
 
 export function requireAgentEmail(fromOverride?: string): string {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -43,7 +43,7 @@
   "homepage": "https://github.com/Mnexa-AI/e2a/tree/main/mcp",
   "bugs": "https://github.com/Mnexa-AI/e2a/issues",
   "dependencies": {
-    "@e2a/sdk": "^2.4.0",
+    "@e2a/sdk": "^3.0.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.5",
     "express": "^5.0.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -47,11 +47,13 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "cors": "^2.8.5",
     "express": "^5.0.0",
+    "mailparser": "^3.9.8",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",
+    "@types/mailparser": "^3.4.6",
     "@types/node": "^25.9.2",
     "supertest": "^7.0.0",
     "@types/supertest": "^7.2.0",

--- a/mcp/src/client.ts
+++ b/mcp/src/client.ts
@@ -1,10 +1,400 @@
 import { E2AClient } from "@e2a/sdk/v1";
+import type {
+  AgentView,
+  CreateAgentResponse,
+  MessageView,
+  MessageSummaryView,
+  SendResultView,
+  ApproveResultView,
+  RejectResultView,
+  UpdateMessageResultView,
+  ConversationSummaryView,
+  ConversationDetailView,
+  DomainView,
+  VerifyDomainView,
+  EventJSON,
+  RedeliverView,
+  WebhookView,
+  RotateSecretOutputBody,
+  TestWebhookOutputBody,
+  WebhookDeliveryView,
+  Attachment,
+} from "@e2a/sdk/v1";
 import type { McpConfig } from "./config.js";
 
-export function makeClient(cfg: McpConfig): E2AClient {
-  return new E2AClient({
+// Outbound drafts held for human approval surface in the message list
+// with this status (see api/openapi.yaml listMessages: "Held outbound
+// drafts appear as status=pending_approval"). There is no dedicated
+// status query param for them, so HITL listing filters outbound rows
+// on this value.
+export const PENDING_APPROVAL_STATUS = "pending_approval";
+
+const DEFAULT_LIST_LIMIT = 1000;
+
+/** Per-call options for unsafe writes. */
+export interface SendOpts {
+  idempotencyKey?: string;
+}
+
+/**
+ * Thin MCP-facing wrapper over the namespaced v1 {@link E2AClient}.
+ *
+ * The MCP tools and the HTTP session layer used to lean on the retired
+ * flat SDK surface (`client.send`, `client.api.*`, `client.agentEmail`).
+ * The v1 client is namespaced (`client.agents`, `.messages`, …) and
+ * every per-agent method takes an explicit address as its first arg.
+ *
+ * This wrapper concentrates the address-resolution policy (a single
+ * default agent email pinned at session init / via E2A_AGENT_EMAIL) and
+ * the small amount of shape-mapping the tools need, so each tool stays a
+ * thin pass-through and the tool contracts (names, schemas) are
+ * unchanged. The session prefetch in http-server.ts still constructs one
+ * of these per session and may re-pin a resolved single-agent default.
+ */
+export class McpClient {
+  readonly sdk: E2AClient;
+  /** Default per-agent address; mirrors the old flat `agentEmail`. */
+  readonly agentEmail: string;
+
+  constructor(sdk: E2AClient, agentEmail = "") {
+    this.sdk = sdk;
+    this.agentEmail = agentEmail;
+  }
+
+  // resolveAddress picks the explicit per-call address, falling back to
+  // the pinned default. Throws a directive error when neither resolves.
+  private resolveAddress(explicit?: string): string {
+    const addr = explicit || this.agentEmail;
+    if (!addr) {
+      throw new Error(
+        "agent_email is required (no E2A_AGENT_EMAIL in environment).",
+      );
+    }
+    return addr;
+  }
+
+  // ── Agents ──────────────────────────────────────────────────────
+
+  async listAgents(): Promise<AgentView[]> {
+    return this.sdk.agents.list().toArray({ limit: DEFAULT_LIST_LIMIT });
+  }
+
+  getAgent(address: string): Promise<AgentView> {
+    return this.sdk.agents.get(address);
+  }
+
+  createAgent(body: { slug: string; name?: string }): Promise<CreateAgentResponse> {
+    return this.sdk.agents.create(body);
+  }
+
+  updateAgent(
+    patch: {
+      hitlEnabled?: boolean;
+      hitlTtlSeconds?: number;
+      hitlExpirationAction?: string;
+    },
+    explicitAddress?: string,
+  ): Promise<AgentView> {
+    return this.sdk.agents.update(this.resolveAddress(explicitAddress), patch);
+  }
+
+  async deleteAgent(explicitAddress?: string): Promise<string> {
+    const address = this.resolveAddress(explicitAddress);
+    await this.sdk.agents.delete(address);
+    return address;
+  }
+
+  // ── Messages ────────────────────────────────────────────────────
+
+  send(
+    body: {
+      to: Array<string>;
+      subject: string;
+      body: string;
+      htmlBody?: string;
+      cc?: Array<string>;
+      bcc?: Array<string>;
+      attachments?: Array<Attachment>;
+      conversationId?: string;
+    },
+    opts: SendOpts = {},
+    explicitAddress?: string,
+  ): Promise<SendResultView> {
+    return this.sdk.messages.send(this.resolveAddress(explicitAddress), body, opts);
+  }
+
+  reply(
+    messageId: string,
+    body: {
+      body: string;
+      htmlBody?: string;
+      replyAll?: boolean;
+      cc?: Array<string>;
+      bcc?: Array<string>;
+      attachments?: Array<Attachment>;
+      conversationId?: string;
+    },
+    opts: SendOpts = {},
+    explicitAddress?: string,
+  ): Promise<SendResultView> {
+    return this.sdk.messages.reply(
+      this.resolveAddress(explicitAddress),
+      messageId,
+      body,
+      opts,
+    );
+  }
+
+  forward(
+    messageId: string,
+    to: Array<string>,
+    body: {
+      body?: string;
+      htmlBody?: string;
+      cc?: Array<string>;
+      bcc?: Array<string>;
+      attachments?: Array<Attachment>;
+      conversationId?: string;
+    },
+    opts: SendOpts = {},
+    explicitAddress?: string,
+  ): Promise<SendResultView> {
+    return this.sdk.messages.forward(
+      this.resolveAddress(explicitAddress),
+      messageId,
+      { to, ...body },
+      opts,
+    );
+  }
+
+  updateMessageLabels(
+    messageId: string,
+    body: { addLabels?: Array<string>; removeLabels?: Array<string> },
+    explicitAddress?: string,
+  ): Promise<UpdateMessageResultView> {
+    return this.sdk.messages.updateLabels(
+      this.resolveAddress(explicitAddress),
+      messageId,
+      body,
+    );
+  }
+
+  getMessage(messageId: string, explicitAddress?: string): Promise<MessageView> {
+    return this.sdk.messages.get(this.resolveAddress(explicitAddress), messageId);
+  }
+
+  async listMessages(params: {
+    status?: "unread" | "read" | "all";
+    sort?: "asc" | "desc";
+    from?: string;
+    subjectContains?: string;
+    conversationId?: string;
+    since?: string;
+    until?: string;
+    labels?: Array<string>;
+    limit?: number;
+    explicitAddress?: string;
+  }): Promise<MessageSummaryView[]> {
+    const { explicitAddress, limit, ...rest } = params;
+    return this.sdk.messages
+      .list(this.resolveAddress(explicitAddress), rest)
+      .toArray({ limit: limit ?? DEFAULT_LIST_LIMIT });
+  }
+
+  // ── Conversations ───────────────────────────────────────────────
+
+  listConversations(
+    params: { since?: string; until?: string; limit?: number },
+    explicitAddress?: string,
+  ): Promise<ConversationSummaryView[]> {
+    return this.sdk.conversations.list(this.resolveAddress(explicitAddress), params);
+  }
+
+  getConversation(
+    conversationId: string,
+    explicitAddress?: string,
+  ): Promise<ConversationDetailView> {
+    return this.sdk.conversations.get(
+      this.resolveAddress(explicitAddress),
+      conversationId,
+    );
+  }
+
+  // ── HITL (pending outbound) ─────────────────────────────────────
+
+  // Pending drafts surface as outbound messages with status=pending_approval.
+  // There is no dedicated "pending" status filter, so we list outbound and
+  // filter on the status field. Searches across every owned agent when no
+  // default address is pinned so the queue is visible without a default.
+  async listPendingMessages(): Promise<MessageSummaryView[]> {
+    const addresses = this.agentEmail
+      ? [this.agentEmail]
+      : (await this.listAgents()).map((a) => a.email);
+    const out: MessageSummaryView[] = [];
+    for (const address of addresses) {
+      const rows = await this.sdk.messages
+        .list(address, { direction: "outbound", status: "all" })
+        .toArray({ limit: DEFAULT_LIST_LIMIT });
+      for (const r of rows) {
+        if (r.status === PENDING_APPROVAL_STATUS) out.push(r);
+      }
+    }
+    return out;
+  }
+
+  // Resolve the agent that owns a pending message by scanning the pending
+  // queue. The approve/reject endpoints are agent-scoped, so we need the
+  // owning address; for a pinned-default session this is one list call.
+  private async ownerOfPending(messageId: string): Promise<string> {
+    const addresses = this.agentEmail
+      ? [this.agentEmail]
+      : (await this.listAgents()).map((a) => a.email);
+    for (const address of addresses) {
+      const rows = await this.sdk.messages
+        .list(address, { direction: "outbound", status: "all" })
+        .toArray({ limit: DEFAULT_LIST_LIMIT });
+      if (rows.some((r) => r.messageId === messageId)) return address;
+    }
+    throw new Error(
+      `pending message ${messageId} not found on any owned agent (it may have already been approved, rejected, or expired).`,
+    );
+  }
+
+  async getPendingMessage(messageId: string): Promise<MessageView> {
+    const address = await this.ownerOfPending(messageId);
+    return this.sdk.messages.get(address, messageId);
+  }
+
+  async approveMessage(
+    messageId: string,
+    overrides: {
+      subject?: string;
+      bodyText?: string;
+      bodyHtml?: string;
+      to?: Array<string>;
+      cc?: Array<string>;
+      bcc?: Array<string>;
+      attachments?: Array<Attachment>;
+    },
+    opts?: SendOpts,
+  ): Promise<ApproveResultView> {
+    const address = await this.ownerOfPending(messageId);
+    return opts
+      ? this.sdk.messages.approve(address, messageId, overrides, opts)
+      : this.sdk.messages.approve(address, messageId, overrides);
+  }
+
+  async rejectMessage(messageId: string, reason?: string): Promise<RejectResultView> {
+    const address = await this.ownerOfPending(messageId);
+    return this.sdk.messages.reject(
+      address,
+      messageId,
+      reason !== undefined ? { reason } : {},
+    );
+  }
+
+  // ── Domains ─────────────────────────────────────────────────────
+
+  listDomains(): Promise<DomainView[]> {
+    return this.sdk.domains.list().toArray({ limit: DEFAULT_LIST_LIMIT });
+  }
+
+  registerDomain(domain: string): Promise<DomainView> {
+    return this.sdk.domains.create({ domain });
+  }
+
+  verifyDomain(domain: string): Promise<VerifyDomainView> {
+    return this.sdk.domains.verify(domain);
+  }
+
+  async deleteDomain(domain: string): Promise<void> {
+    await this.sdk.domains.delete(domain);
+  }
+
+  // ── Webhooks ────────────────────────────────────────────────────
+
+  listWebhooks(): Promise<WebhookView[]> {
+    return this.sdk.webhooks.list().toArray({ limit: DEFAULT_LIST_LIMIT });
+  }
+
+  getWebhook(id: string): Promise<WebhookView> {
+    return this.sdk.webhooks.get(id);
+  }
+
+  createWebhook(body: {
+    url: string;
+    events: Array<string>;
+    description?: string;
+    filters?: { agentIds?: Array<string>; conversationIds?: Array<string>; labels?: Array<string> };
+  }): Promise<WebhookView> {
+    return this.sdk.webhooks.create(body);
+  }
+
+  updateWebhook(
+    id: string,
+    patch: {
+      url?: string;
+      events?: Array<string>;
+      description?: string;
+      enabled?: boolean;
+      filters?: { agentIds?: Array<string>; conversationIds?: Array<string>; labels?: Array<string> };
+    },
+  ): Promise<WebhookView> {
+    return this.sdk.webhooks.update(id, patch);
+  }
+
+  async deleteWebhook(id: string): Promise<void> {
+    await this.sdk.webhooks.delete(id);
+  }
+
+  rotateWebhookSecret(id: string): Promise<RotateSecretOutputBody> {
+    return this.sdk.webhooks.rotateSecret(id);
+  }
+
+  testWebhook(id: string, body: { event?: string }): Promise<TestWebhookOutputBody> {
+    return this.sdk.webhooks.test(id, body);
+  }
+
+  listWebhookDeliveries(
+    id: string,
+    params: { status?: "pending" | "delivered" | "failed"; limit?: number },
+  ): Promise<WebhookDeliveryView[]> {
+    return this.sdk.webhooks
+      .deliveries(id, params)
+      .toArray({ limit: params.limit ?? DEFAULT_LIST_LIMIT });
+  }
+
+  // ── Events ──────────────────────────────────────────────────────
+
+  listEvents(params: {
+    type?: string;
+    agentId?: string;
+    conversationId?: string;
+    messageId?: string;
+    since?: string;
+    until?: string;
+    limit?: number;
+  }): Promise<EventJSON[]> {
+    const { limit, ...rest } = params;
+    return this.sdk.events.list(rest).toArray({ limit: limit ?? DEFAULT_LIST_LIMIT });
+  }
+
+  getEvent(id: string): Promise<EventJSON> {
+    return this.sdk.events.get(id);
+  }
+
+  redeliverEvent(id: string, webhookId?: string): Promise<RedeliverView> {
+    return this.sdk.events.redeliver(
+      id,
+      webhookId !== undefined ? { webhookId } : {},
+    );
+  }
+}
+
+export function makeClient(cfg: McpConfig): McpClient {
+  const sdk = new E2AClient({
     apiKey: cfg.apiKey,
     ...(cfg.baseUrl ? { baseUrl: cfg.baseUrl } : {}),
-    ...(cfg.agentEmail ? { agentEmail: cfg.agentEmail } : {}),
   });
+  return new McpClient(sdk, cfg.agentEmail ?? "");
 }

--- a/mcp/src/http-server.ts
+++ b/mcp/src/http-server.ts
@@ -5,6 +5,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { E2AClient } from "@e2a/sdk/v1";
 import { buildServer } from "./server.js";
+import { McpClient } from "./client.js";
 import { Sessions, fingerprintBearer } from "./session.js";
 
 export interface HttpServerOptions {
@@ -47,7 +48,7 @@ export interface HttpServerOptions {
    * want to exercise the prefetch path can pass it through to their
    * stub; tests that only care about the bearer can ignore it.
    */
-  clientFactory?: (bearer: string, opts?: { agentEmail?: string }) => E2AClient;
+  clientFactory?: (bearer: string, opts?: { agentEmail?: string }) => McpClient;
 }
 
 interface BuiltApp {
@@ -212,7 +213,7 @@ async function handleClientRequest(
   }
 
   if (!entry && isInitializeRequest(req.body)) {
-    let client: E2AClient;
+    let client: McpClient;
     try {
       client = await buildSessionClient(opts, bearer);
     } catch (err) {
@@ -345,8 +346,8 @@ async function handleStreamingOrDelete(
 export async function buildSessionClient(
   opts: HttpServerOptions,
   bearer: string,
-): Promise<E2AClient> {
-  const make = (agentEmail?: string): E2AClient => {
+): Promise<McpClient> {
+  const make = (agentEmail?: string): McpClient => {
     if (opts.clientFactory) {
       // Preserve the no-arg-factory shape for callers (and tests) that
       // don't care about the resolved email. Pass the email through
@@ -355,13 +356,16 @@ export async function buildSessionClient(
         ? opts.clientFactory(bearer, { agentEmail })
         : opts.clientFactory(bearer);
     }
-    return new E2AClient({ apiKey: bearer, baseUrl: opts.baseUrl, agentEmail });
+    return new McpClient(
+      new E2AClient({ apiKey: bearer, baseUrl: opts.baseUrl }),
+      agentEmail ?? "",
+    );
   };
 
   const client = make();
   let resolved: string | undefined;
   try {
-    const { agents } = await client.listAgents();
+    const agents = await client.listAgents();
     // Env-var path already populated agentEmail — operator opted in
     // explicitly, don't second-guess it with auto-resolution.
     if (!client.agentEmail && Array.isArray(agents) && agents.length === 1) {

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { E2AClient } from "@e2a/sdk/v1";
+import type { McpClient } from "./client.js";
 import { registerMessageTools } from "./tools/messages.js";
 import { registerAgentTools } from "./tools/agents.js";
 import { registerDomainTools } from "./tools/domains.js";
@@ -8,7 +8,7 @@ import { registerWebhookTools } from "./tools/webhooks.js";
 import { registerEventTools } from "./tools/events.js";
 
 export interface BuildServerOptions {
-  client: E2AClient;
+  client: McpClient;
   version?: string;
 }
 

--- a/mcp/src/tools/agents.ts
+++ b/mcp/src/tools/agents.ts
@@ -1,9 +1,9 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { E2AClient } from "@e2a/sdk/v1";
+import type { McpClient } from "../client.js";
 import { z } from "zod";
 import { runTool, strictInputSchema } from "./util.js";
 
-export function registerAgentTools(server: McpServer, client: E2AClient): void {
+export function registerAgentTools(server: McpServer, client: McpClient): void {
   server.registerTool(
     "list_agents",
     {
@@ -12,7 +12,7 @@ export function registerAgentTools(server: McpServer, client: E2AClient): void {
         "List every agent inbox owned by the authenticated user. Useful for orientation — which inbox to send `from` or query messages against. Read-only.",
       inputSchema: strictInputSchema({}),
     },
-    async () => runTool(() => client.listAgents()),
+    async () => runTool(async () => ({ agents: await client.listAgents() })),
   );
 
   server.registerTool(
@@ -34,7 +34,7 @@ export function registerAgentTools(server: McpServer, client: E2AClient): void {
         // "from field required only when user has multiple agents"
         // behavior on the backend. For 0 or 2+ agents the LLM needs
         // explicit input, so we error with a directive next-step.
-        const { agents } = await client.listAgents();
+        const agents = await client.listAgents();
         if (!agents || agents.length === 0) {
           throw new Error(
             "no agents on this account. Use `create_agent` to register one before sending mail.",
@@ -86,11 +86,15 @@ export function registerAgentTools(server: McpServer, client: E2AClient): void {
     },
     async (args) =>
       runTool(() =>
-        client.registerAgent({
+        // v1 agent-create takes slug + name only. Per-agent delivery
+        // mode and webhook binding were removed from the agent shape in
+        // the v1 redesign — push delivery is now a top-level webhooks
+        // resource (create_webhook). agent_mode / webhook_url are still
+        // accepted in the input schema for contract stability but no
+        // longer forwarded; use create_webhook for push subscriptions.
+        client.createAgent({
           slug: args.slug,
-          agent_mode: args.agent_mode ?? "local",
           ...(args.name !== undefined ? { name: args.name } : {}),
-          ...(args.webhook_url !== undefined ? { webhook_url: args.webhook_url } : {}),
         }),
       ),
   );
@@ -146,10 +150,24 @@ export function registerAgentTools(server: McpServer, client: E2AClient): void {
     },
     async (args) =>
       runTool(() => {
-        const { agent_email, ...body } = args;
-        return client.updateAgent(body, {
-          ...(agent_email !== undefined ? { agentEmail: agent_email } : {}),
-        });
+        // v1 update takes camelCase HITL fields. agent_mode / webhook_url
+        // are accepted in the schema for contract stability but no longer
+        // part of the agent shape (push delivery is a top-level webhooks
+        // resource now); they are not forwarded.
+        const patch: {
+          hitlEnabled?: boolean;
+          hitlTtlSeconds?: number;
+          hitlExpirationAction?: string;
+        } = {
+          ...(args.hitl_enabled !== undefined ? { hitlEnabled: args.hitl_enabled } : {}),
+          ...(args.hitl_ttl_seconds !== undefined
+            ? { hitlTtlSeconds: args.hitl_ttl_seconds }
+            : {}),
+          ...(args.hitl_expiration_action !== undefined
+            ? { hitlExpirationAction: args.hitl_expiration_action }
+            : {}),
+        };
+        return client.updateAgent(patch, args.agent_email);
       }),
   );
 
@@ -181,8 +199,8 @@ export function registerAgentTools(server: McpServer, client: E2AClient): void {
             "delete_agent requires confirm:true — refusing to proceed without explicit confirmation.",
           );
         }
-        await client.deleteAgent(args.agent_email);
-        return { deleted: args.agent_email ?? client.agentEmail };
+        const deleted = await client.deleteAgent(args.agent_email);
+        return { deleted };
       }),
   );
 }

--- a/mcp/src/tools/domains.ts
+++ b/mcp/src/tools/domains.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { E2AClient } from "@e2a/sdk/v1";
+import type { McpClient } from "../client.js";
 import { z } from "zod";
 import { runTool, strictInputSchema } from "./util.js";
 
@@ -15,7 +15,7 @@ import { runTool, strictInputSchema } from "./util.js";
  * confirm gate so the schema validator catches LLM hallucinations
  * before any HTTP call runs.
  */
-export function registerDomainTools(server: McpServer, client: E2AClient): void {
+export function registerDomainTools(server: McpServer, client: McpClient): void {
   server.registerTool(
     "list_domains",
     {
@@ -24,7 +24,7 @@ export function registerDomainTools(server: McpServer, client: E2AClient): void 
         "List every custom mail domain registered under the authenticated user, with verification status (verified / pending DNS / failed) and the verification token for each. Useful to discover which domains can already send/receive mail and which still need DNS records to be added. Read-only; cheap to call.",
       inputSchema: strictInputSchema({}),
     },
-    async () => runTool(() => client.listDomains()),
+    async () => runTool(async () => ({ domains: await client.listDomains() })),
   );
 
   server.registerTool(

--- a/mcp/src/tools/events.ts
+++ b/mcp/src/tools/events.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { E2AClient } from "@e2a/sdk/v1";
+import type { McpClient } from "../client.js";
 import { z } from "zod";
 import { runTool, strictInputSchema } from "./util.js";
 
@@ -12,7 +12,7 @@ import { runTool, strictInputSchema } from "./util.js";
 // auth-bound to the API key the MCP server was launched with — the
 // LLM cannot list events for other accounts.
 
-export function registerEventTools(server: McpServer, client: E2AClient): void {
+export function registerEventTools(server: McpServer, client: McpClient): void {
   server.registerTool(
     "list_events",
     {
@@ -39,18 +39,23 @@ export function registerEventTools(server: McpServer, client: E2AClient): void {
       }),
     },
     async (args) =>
-      runTool(() =>
-        client.api.listEvents({
-          type: args.type,
-          agentId: args.agent_id,
-          conversationId: args.conversation_id,
-          messageId: args.message_id,
-          since: args.since,
-          until: args.until,
-          pageSize: args.page_size,
-          token: args.token,
+      // The v1 client auto-paginates; we collect up to `page_size` rows
+      // (the SDK walks cursors internally). `token` is accepted in the
+      // schema for contract stability but no longer needed — the pager
+      // handles cursoring transparently.
+      runTool(async () => ({
+        events: await client.listEvents({
+          ...(args.type !== undefined ? { type: args.type } : {}),
+          ...(args.agent_id !== undefined ? { agentId: args.agent_id } : {}),
+          ...(args.conversation_id !== undefined
+            ? { conversationId: args.conversation_id }
+            : {}),
+          ...(args.message_id !== undefined ? { messageId: args.message_id } : {}),
+          ...(args.since !== undefined ? { since: args.since } : {}),
+          ...(args.until !== undefined ? { until: args.until } : {}),
+          ...(args.page_size !== undefined ? { limit: args.page_size } : {}),
         }),
-      ),
+      })),
   );
 
   server.registerTool(
@@ -63,7 +68,7 @@ export function registerEventTools(server: McpServer, client: E2AClient): void {
         event_id: z.string().describe("Stable event id (evt_<32hex>)."),
       }),
     },
-    async (args) => runTool(() => client.api.getEvent(args.event_id)),
+    async (args) => runTool(() => client.getEvent(args.event_id)),
   );
 
   server.registerTool(
@@ -83,8 +88,6 @@ export function registerEventTools(server: McpServer, client: E2AClient): void {
       }),
     },
     async (args) =>
-      runTool(() =>
-        client.api.redeliverEvent(args.event_id, { webhookId: args.webhook_id }),
-      ),
+      runTool(() => client.redeliverEvent(args.event_id, args.webhook_id)),
   );
 }

--- a/mcp/src/tools/hitl.ts
+++ b/mcp/src/tools/hitl.ts
@@ -1,10 +1,10 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { E2AClient } from "@e2a/sdk/v1";
+import type { McpClient } from "../client.js";
 import { z } from "zod";
 import { runTool, strictInputSchema } from "./util.js";
 import { attachmentsArraySchema } from "./attachments.js";
 
-export function registerHitlTools(server: McpServer, client: E2AClient): void {
+export function registerHitlTools(server: McpServer, client: McpClient): void {
   server.registerTool(
     "list_pending_messages",
     {
@@ -13,7 +13,7 @@ export function registerHitlTools(server: McpServer, client: E2AClient): void {
         "Use when the user asks what's awaiting approval, or after a `send_email`/`reply_to_message` returned `pending_approval` and they want to see the queue. Lists held outbound messages from HITL-enabled agents sorted by soonest-expiring first. Body content is summary-only — call `get_pending_message` for the full draft of one. Read-only; cheap, but don't poll it on a loop.",
       inputSchema: strictInputSchema({}),
     },
-    async () => runTool(() => client.listPendingMessages()),
+    async () => runTool(async () => ({ messages: await client.listPendingMessages() })),
   );
 
   server.registerTool(
@@ -28,6 +28,35 @@ export function registerHitlTools(server: McpServer, client: E2AClient): void {
     },
     async (args) => runTool(() => client.getPendingMessage(args.message_id)),
   );
+
+  // Map the snake_case approve override args to the SDK's ApproveRequest
+  // (camelCase body fields). An explicitly-passed empty attachments array
+  // must survive as a strip override, so map by key-presence.
+  const mapOverrides = (overrides: {
+    subject?: string;
+    body_text?: string;
+    body_html?: string;
+    to?: string[];
+    cc?: string[];
+    bcc?: string[];
+    attachments?: Array<{ filename: string; content_type: string; data: string }>;
+  }) => ({
+    ...(overrides.subject !== undefined ? { subject: overrides.subject } : {}),
+    ...(overrides.body_text !== undefined ? { bodyText: overrides.body_text } : {}),
+    ...(overrides.body_html !== undefined ? { bodyHtml: overrides.body_html } : {}),
+    ...(overrides.to !== undefined ? { to: overrides.to } : {}),
+    ...(overrides.cc !== undefined ? { cc: overrides.cc } : {}),
+    ...(overrides.bcc !== undefined ? { bcc: overrides.bcc } : {}),
+    ...(overrides.attachments !== undefined
+      ? {
+          attachments: overrides.attachments.map((a) => ({
+            filename: a.filename,
+            contentType: a.content_type,
+            data: a.data,
+          })),
+        }
+      : {}),
+  });
 
   server.registerTool(
     "approve_pending_message",
@@ -54,17 +83,15 @@ export function registerHitlTools(server: McpServer, client: E2AClient): void {
     },
     async (args) => {
       const { message_id, idempotency_key, ...overrides } = args;
-      // The approve endpoint is agent-scoped; discover the owning
-      // agent via the message detail before calling. One extra GET
-      // gating one side-effectful POST is a fair trade for keeping
-      // the MCP tool surface minimal (caller passes only message_id).
-      return runTool(async () => {
-        const detail = await client.getPendingMessage(message_id);
-        const agentEmail = (detail as { agent_id: string }).agent_id;
-        return idempotency_key !== undefined
-          ? client.approveMessage(agentEmail, message_id, overrides, { idempotencyKey: idempotency_key })
-          : client.approveMessage(agentEmail, message_id, overrides);
-      });
+      // The approve endpoint is agent-scoped; the client discovers the
+      // owning agent (via the pending queue) before calling, keeping the
+      // MCP tool surface minimal (caller passes only message_id).
+      const mapped = mapOverrides(overrides);
+      return runTool(() =>
+        idempotency_key !== undefined
+          ? client.approveMessage(message_id, mapped, { idempotencyKey: idempotency_key })
+          : client.approveMessage(message_id, mapped),
+      );
     },
   );
 
@@ -80,10 +107,6 @@ export function registerHitlTools(server: McpServer, client: E2AClient): void {
       }),
     },
     async (args) =>
-      runTool(async () => {
-        const detail = await client.getPendingMessage(args.message_id);
-        const agentEmail = (detail as { agent_id: string }).agent_id;
-        return client.rejectMessage(agentEmail, args.message_id, args.reason);
-      }),
+      runTool(() => client.rejectMessage(args.message_id, args.reason)),
   );
 }

--- a/mcp/src/tools/messages.ts
+++ b/mcp/src/tools/messages.ts
@@ -33,7 +33,10 @@ interface ParsedAttachment {
 // [] when there is no raw MIME (e.g. a body-only summary view).
 async function parseAttachments(email: MessageView): Promise<ParsedAttachment[]> {
   if (!email.rawMessage) return [];
-  const parsed = await simpleParser(email.rawMessage);
+  // rawMessage is base64-encoded on the wire (contentEncoding: base64); decode
+  // to the raw RFC822 bytes before parsing — simpleParser on the base64 text
+  // finds nothing.
+  const parsed = await simpleParser(Buffer.from(email.rawMessage, "base64"));
   return (parsed.attachments ?? []).map((a, i) => ({
     filename: a.filename ?? `attachment-${i}`,
     contentType: a.contentType ?? "application/octet-stream",
@@ -413,7 +416,9 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
           reply_to: email.replyTo,
           subject: email.subject,
           status: email.status,
-          body_text: email.body?.text,
+          // Inbound messages carry the decoded text in `parsed`; only outbound
+          // held drafts populate `body` (mirror the CLI's read fallback).
+          body_text: email.parsed?.text ?? email.body?.text,
           body_html: email.body?.html,
           received_at: email.createdAt,
           attachments: attachments.map((a, index) => ({

--- a/mcp/src/tools/messages.ts
+++ b/mcp/src/tools/messages.ts
@@ -1,10 +1,48 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { E2AClient } from "@e2a/sdk/v1";
+import { simpleParser } from "mailparser";
+import type { McpClient, SendOpts } from "../client.js";
+import type { MessageView } from "@e2a/sdk/v1";
 import { z } from "zod";
 import { runTool, strictInputSchema } from "./util.js";
-import { attachmentsArraySchema } from "./attachments.js";
+import { attachmentsArraySchema, type AttachmentInput } from "./attachments.js";
 
-export function registerMessageTools(server: McpServer, client: E2AClient): void {
+// Map the snake_case attachment wire shape (filename, content_type, data)
+// to the SDK Attachment model (filename, contentType, data).
+function mapAttachments(
+  atts?: AttachmentInput[],
+): Array<{ filename: string; contentType: string; data: string }> | undefined {
+  if (atts === undefined) return undefined;
+  return atts.map((a) => ({
+    filename: a.filename,
+    contentType: a.content_type,
+    data: a.data,
+  }));
+}
+
+// Decoded attachment from the message's raw MIME.
+interface ParsedAttachment {
+  filename: string;
+  contentType: string;
+  size: number;
+  content: Buffer;
+}
+
+// The v1 MessageView no longer exposes decoded attachments inline (the
+// flat SDK's InboundEmail did). It carries the full MIME blob in
+// `rawMessage`, so we decode attachments on demand from that. Returns
+// [] when there is no raw MIME (e.g. a body-only summary view).
+async function parseAttachments(email: MessageView): Promise<ParsedAttachment[]> {
+  if (!email.rawMessage) return [];
+  const parsed = await simpleParser(email.rawMessage);
+  return (parsed.attachments ?? []).map((a, i) => ({
+    filename: a.filename ?? `attachment-${i}`,
+    contentType: a.contentType ?? "application/octet-stream",
+    size: a.size ?? a.content.length,
+    content: a.content,
+  }));
+}
+
+export function registerMessageTools(server: McpServer, client: McpClient): void {
   server.registerTool(
     "send_email",
     {
@@ -38,21 +76,30 @@ export function registerMessageTools(server: McpServer, client: E2AClient): void
       }),
     },
     async (args) =>
-      runTool(() =>
-        client.send(args.to, args.subject, args.body, {
-          ...(args.html_body !== undefined ? { htmlBody: args.html_body } : {}),
-          ...(args.cc !== undefined ? { cc: args.cc } : {}),
-          ...(args.bcc !== undefined ? { bcc: args.bcc } : {}),
-          ...(args.attachments !== undefined ? { attachments: args.attachments } : {}),
-          ...(args.conversation_id !== undefined
-            ? { conversationId: args.conversation_id }
-            : {}),
-          ...(args.idempotency_key !== undefined
+      runTool(() => {
+        const opts: SendOpts =
+          args.idempotency_key !== undefined
             ? { idempotencyKey: args.idempotency_key }
-            : {}),
-          ...(args.agent_email !== undefined ? { agentEmail: args.agent_email } : {}),
-        }),
-      ),
+            : {};
+        return client.send(
+          {
+            to: args.to,
+            subject: args.subject,
+            body: args.body,
+            ...(args.html_body !== undefined ? { htmlBody: args.html_body } : {}),
+            ...(args.cc !== undefined ? { cc: args.cc } : {}),
+            ...(args.bcc !== undefined ? { bcc: args.bcc } : {}),
+            ...(mapAttachments(args.attachments) !== undefined
+              ? { attachments: mapAttachments(args.attachments) }
+              : {}),
+            ...(args.conversation_id !== undefined
+              ? { conversationId: args.conversation_id }
+              : {}),
+          },
+          opts,
+          args.agent_email,
+        );
+      }),
   );
 
   server.registerTool(
@@ -83,22 +130,30 @@ export function registerMessageTools(server: McpServer, client: E2AClient): void
       }),
     },
     async (args) =>
-      runTool(() =>
-        client.reply(args.message_id, args.body, {
-          ...(args.html_body !== undefined ? { htmlBody: args.html_body } : {}),
-          ...(args.reply_all !== undefined ? { replyAll: args.reply_all } : {}),
-          ...(args.cc !== undefined ? { cc: args.cc } : {}),
-          ...(args.bcc !== undefined ? { bcc: args.bcc } : {}),
-          ...(args.attachments !== undefined ? { attachments: args.attachments } : {}),
-          ...(args.conversation_id !== undefined
-            ? { conversationId: args.conversation_id }
-            : {}),
-          ...(args.idempotency_key !== undefined
+      runTool(() => {
+        const opts: SendOpts =
+          args.idempotency_key !== undefined
             ? { idempotencyKey: args.idempotency_key }
-            : {}),
-          ...(args.agent_email !== undefined ? { agentEmail: args.agent_email } : {}),
-        }),
-      ),
+            : {};
+        return client.reply(
+          args.message_id,
+          {
+            body: args.body,
+            ...(args.html_body !== undefined ? { htmlBody: args.html_body } : {}),
+            ...(args.reply_all !== undefined ? { replyAll: args.reply_all } : {}),
+            ...(args.cc !== undefined ? { cc: args.cc } : {}),
+            ...(args.bcc !== undefined ? { bcc: args.bcc } : {}),
+            ...(mapAttachments(args.attachments) !== undefined
+              ? { attachments: mapAttachments(args.attachments) }
+              : {}),
+            ...(args.conversation_id !== undefined
+              ? { conversationId: args.conversation_id }
+              : {}),
+          },
+          opts,
+          args.agent_email,
+        );
+      }),
   );
 
   server.registerTool(
@@ -136,22 +191,30 @@ export function registerMessageTools(server: McpServer, client: E2AClient): void
       }),
     },
     async (args) =>
-      runTool(() =>
-        client.forward(args.message_id, args.to, {
-          ...(args.body !== undefined ? { body: args.body } : {}),
-          ...(args.html_body !== undefined ? { htmlBody: args.html_body } : {}),
-          ...(args.cc !== undefined ? { cc: args.cc } : {}),
-          ...(args.bcc !== undefined ? { bcc: args.bcc } : {}),
-          ...(args.attachments !== undefined ? { attachments: args.attachments } : {}),
-          ...(args.conversation_id !== undefined
-            ? { conversationId: args.conversation_id }
-            : {}),
-          ...(args.idempotency_key !== undefined
+      runTool(() => {
+        const opts: SendOpts =
+          args.idempotency_key !== undefined
             ? { idempotencyKey: args.idempotency_key }
-            : {}),
-          ...(args.agent_email !== undefined ? { agentEmail: args.agent_email } : {}),
-        }),
-      ),
+            : {};
+        return client.forward(
+          args.message_id,
+          args.to,
+          {
+            ...(args.body !== undefined ? { body: args.body } : {}),
+            ...(args.html_body !== undefined ? { htmlBody: args.html_body } : {}),
+            ...(args.cc !== undefined ? { cc: args.cc } : {}),
+            ...(args.bcc !== undefined ? { bcc: args.bcc } : {}),
+            ...(mapAttachments(args.attachments) !== undefined
+              ? { attachments: mapAttachments(args.attachments) }
+              : {}),
+            ...(args.conversation_id !== undefined
+              ? { conversationId: args.conversation_id }
+              : {}),
+          },
+          opts,
+          args.agent_email,
+        );
+      }),
   );
 
   server.registerTool(
@@ -175,11 +238,14 @@ export function registerMessageTools(server: McpServer, client: E2AClient): void
     },
     async (args) =>
       runTool(() =>
-        client.updateMessageLabels(args.message_id, {
-          ...(args.add_labels !== undefined ? { addLabels: args.add_labels } : {}),
-          ...(args.remove_labels !== undefined ? { removeLabels: args.remove_labels } : {}),
-          ...(args.agent_email !== undefined ? { agentEmail: args.agent_email } : {}),
-        }),
+        client.updateMessageLabels(
+          args.message_id,
+          {
+            ...(args.add_labels !== undefined ? { addLabels: args.add_labels } : {}),
+            ...(args.remove_labels !== undefined ? { removeLabels: args.remove_labels } : {}),
+          },
+          args.agent_email,
+        ),
       ),
   );
 
@@ -207,14 +273,16 @@ export function registerMessageTools(server: McpServer, client: E2AClient): void
       }),
     },
     async (args) =>
-      runTool(() =>
-        client.listConversations({
-          ...(args.page_size !== undefined ? { pageSize: args.page_size } : {}),
-          ...(args.since !== undefined ? { since: args.since } : {}),
-          ...(args.until !== undefined ? { until: args.until } : {}),
-          ...(args.agent_email !== undefined ? { agentEmail: args.agent_email } : {}),
-        }),
-      ),
+      runTool(async () => ({
+        conversations: await client.listConversations(
+          {
+            ...(args.page_size !== undefined ? { limit: args.page_size } : {}),
+            ...(args.since !== undefined ? { since: args.since } : {}),
+            ...(args.until !== undefined ? { until: args.until } : {}),
+          },
+          args.agent_email,
+        ),
+      })),
   );
 
   server.registerTool(
@@ -229,11 +297,7 @@ export function registerMessageTools(server: McpServer, client: E2AClient): void
       }),
     },
     async (args) =>
-      runTool(() =>
-        client.getConversation(args.conversation_id, {
-          ...(args.agent_email !== undefined ? { agentEmail: args.agent_email } : {}),
-        }),
-      ),
+      runTool(() => client.getConversation(args.conversation_id, args.agent_email)),
   );
 
   server.registerTool(
@@ -293,10 +357,13 @@ export function registerMessageTools(server: McpServer, client: E2AClient): void
       }),
     },
     async (args) =>
-      runTool(() =>
-        client.listMessages({
+      // The v1 client auto-paginates; `token` is accepted in the schema
+      // for contract stability but unused — the pager walks cursors
+      // internally up to `page_size` rows.
+      runTool(async () => ({
+        messages: await client.listMessages({
           ...(args.status !== undefined ? { status: args.status } : {}),
-          ...(args.page_size !== undefined ? { pageSize: args.page_size } : {}),
+          ...(args.page_size !== undefined ? { limit: args.page_size } : {}),
           ...(args.sort !== undefined ? { sort: args.sort } : {}),
           ...(args.from !== undefined ? { from: args.from } : {}),
           ...(args.subject_contains !== undefined
@@ -308,10 +375,9 @@ export function registerMessageTools(server: McpServer, client: E2AClient): void
           ...(args.since !== undefined ? { since: args.since } : {}),
           ...(args.until !== undefined ? { until: args.until } : {}),
           ...(args.labels !== undefined ? { labels: args.labels } : {}),
-          ...(args.token !== undefined ? { token: args.token } : {}),
-          ...(args.agent_email !== undefined ? { agentEmail: args.agent_email } : {}),
+          ...(args.agent_email !== undefined ? { explicitAddress: args.agent_email } : {}),
         }),
-      ),
+      })),
   );
 
   server.registerTool(
@@ -327,34 +393,30 @@ export function registerMessageTools(server: McpServer, client: E2AClient): void
     },
     async (args) =>
       runTool(async () => {
-        const agentEmail = args.agent_email ?? client.agentEmail;
-        if (!agentEmail) {
-          throw new Error(
-            "agent_email is required (no E2A_AGENT_EMAIL in environment).",
-          );
-        }
-        // Hit the high-level client so we get the parsed InboundEmail
-        // (MIME-decoded attachments, decoded text+html bodies). The
-        // bearer authenticated this channel — pre-verified is the
-        // correct trust level for getMessage's return value.
-        const email = await client.getMessage(args.message_id, agentEmail);
-        // Plain JSON shape: every getter (which throws if unverified)
-        // wrapped in a single object. Omit `raw_message` entirely —
-        // the LLM should never see the full MIME blob unless it
-        // explicitly asks for an attachment via get_attachment_data.
+        // McpClient.getMessage resolves the address (explicit arg →
+        // pinned default) and throws a directive error when neither is
+        // available, so we don't pre-check here.
+        const email = await client.getMessage(args.message_id, args.agent_email);
+        // Attachment metadata is decoded from the raw MIME (the v1
+        // MessageView no longer exposes attachments inline). Bytes are
+        // NOT returned here — call get_attachment_data for one. Omit
+        // `raw_message` entirely so the LLM never sees the full MIME
+        // blob unless it explicitly fetches an attachment.
+        const attachments = await parseAttachments(email);
         return {
           message_id: email.messageId,
           conversation_id: email.conversationId,
-          from: email.sender,
+          from: email._from,
           recipient: email.recipient,
           to: email.to,
           cc: email.cc,
           reply_to: email.replyTo,
           subject: email.subject,
-          body_text: email.textBody,
-          body_html: email.htmlBody,
-          received_at: email.receivedAt,
-          attachments: email.attachments.map((a, index) => ({
+          status: email.status,
+          body_text: email.body?.text,
+          body_html: email.body?.html,
+          received_at: email.createdAt,
+          attachments: attachments.map((a, index) => ({
             index,
             filename: a.filename,
             content_type: a.contentType,
@@ -397,20 +459,15 @@ export function registerMessageTools(server: McpServer, client: E2AClient): void
     },
     async (args) =>
       runTool(async () => {
-        const agentEmail = args.agent_email ?? client.agentEmail;
-        if (!agentEmail) {
-          throw new Error(
-            "agent_email is required (no E2A_AGENT_EMAIL in environment).",
-          );
-        }
-        const email = await client.getMessage(args.message_id, agentEmail);
-        const list = email.attachments;
+        // McpClient.getMessage resolves + validates the address.
+        const email = await client.getMessage(args.message_id, args.agent_email);
+        const list = await parseAttachments(email);
         if (args.attachment_index < 0 || args.attachment_index >= list.length) {
           throw new Error(
             `attachment_index ${args.attachment_index} out of range (message has ${list.length} attachment${list.length === 1 ? "" : "s"})`,
           );
         }
-        const a = list[args.attachment_index];
+        const a = list[args.attachment_index]!;
         if (a.size > MAX_INLINE_BYTES) {
           throw new Error(
             `attachment too large for inline retrieval: ${a.size} bytes (max ${MAX_INLINE_BYTES}). Ask a host-side tool to write the raw_message MIME to disk and extract this attachment out of band.`,
@@ -423,7 +480,7 @@ export function registerMessageTools(server: McpServer, client: E2AClient): void
           // Buffer → standard-alphabet base64. This matches the wire
           // shape send_email/reply_to_message expect on the way back
           // out, so a forward-attachment workflow is a verbatim copy.
-          data: a.data.toString("base64"),
+          data: a.content.toString("base64"),
         };
       }),
   );

--- a/mcp/src/tools/webhooks.ts
+++ b/mcp/src/tools/webhooks.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import type { E2AClient } from "@e2a/sdk/v1";
+import type { McpClient } from "../client.js";
 import { z } from "zod";
 import { runTool, strictInputSchema } from "./util.js";
 
@@ -17,7 +17,7 @@ import { runTool, strictInputSchema } from "./util.js";
  * The plaintext signing_secret is returned ONCE on create + on
  * rotate-secret. Other reads scrub it.
  */
-export function registerWebhookTools(server: McpServer, client: E2AClient): void {
+export function registerWebhookTools(server: McpServer, client: McpClient): void {
   const filtersSchema = z
     .object({
       agent_ids: z.array(z.string()).optional(),
@@ -29,6 +29,20 @@ export function registerWebhookTools(server: McpServer, client: E2AClient): void
       "Optional scope filters. Empty / missing keys mean 'no constraint of that type'. agent_ids must reference agents owned by the caller; cross-user ids are rejected. conversation_ids / labels are exact-match.",
     );
 
+  // Map the snake_case tool filter shape to the SDK's camelCase
+  // WebhookFiltersView. Returns undefined for an absent filter so we
+  // don't send an empty object.
+  const mapFilters = (
+    f?: { agent_ids?: string[]; conversation_ids?: string[]; labels?: string[] },
+  ): { agentIds?: string[]; conversationIds?: string[]; labels?: string[] } | undefined => {
+    if (!f) return undefined;
+    return {
+      ...(f.agent_ids !== undefined ? { agentIds: f.agent_ids } : {}),
+      ...(f.conversation_ids !== undefined ? { conversationIds: f.conversation_ids } : {}),
+      ...(f.labels !== undefined ? { labels: f.labels } : {}),
+    };
+  };
+
   server.registerTool(
     "list_webhooks",
     {
@@ -37,7 +51,7 @@ export function registerWebhookTools(server: McpServer, client: E2AClient): void
         "Returns every webhook subscriber owned by the authenticated user, enabled + disabled, with their event subscriptions, filters, and last-delivered timestamp. signing_secret is omitted (it is only ever returned on create + rotate). Read-only; cheap.",
       inputSchema: strictInputSchema({}),
     },
-    async () => runTool(() => client.listWebhooks()),
+    async () => runTool(async () => ({ webhooks: await client.listWebhooks() })),
   );
 
   server.registerTool(
@@ -76,8 +90,8 @@ export function registerWebhookTools(server: McpServer, client: E2AClient): void
         client.createWebhook({
           url: args.url,
           events: args.events,
-          description: args.description,
-          filters: args.filters,
+          ...(args.description !== undefined ? { description: args.description } : {}),
+          ...(mapFilters(args.filters) ? { filters: mapFilters(args.filters) } : {}),
         }),
       ),
   );
@@ -98,8 +112,14 @@ export function registerWebhookTools(server: McpServer, client: E2AClient): void
       }),
     },
     async (args) => {
-      const { id, ...rest } = args;
-      return runTool(() => client.updateWebhook(id, rest));
+      const { id, filters, ...rest } = args;
+      const mapped = mapFilters(filters);
+      return runTool(() =>
+        client.updateWebhook(id, {
+          ...rest,
+          ...(mapped ? { filters: mapped } : {}),
+        }),
+      );
     },
   );
 

--- a/mcp/tests/events-streamable-http.test.ts
+++ b/mcp/tests/events-streamable-http.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import type { E2AClient } from "@e2a/sdk/v1";
+import type { McpClient } from "../src/client.js";
 import { startHttpServer } from "../src/http-server.js";
 
 // Events tools exercised through the streamable-http MCP transport
@@ -10,48 +10,43 @@ import { startHttpServer } from "../src/http-server.js";
 // real HTTP layer — catches auth header parsing, JSON-RPC framing,
 // and session lifecycle bugs that InMemoryTransport masks.
 
-function makeStubClient(): E2AClient {
+function makeStubClient(): McpClient {
   const stub = {
     agentEmail: "bot@example.com",
-    api: {
-      getMessage: vi.fn(async () => ({ message_id: "m" })),
-      getAgent: vi.fn(async () => ({ id: "x@y", email: "x@y" })),
-      listAgents: vi.fn(async () => ({ agents: [{ email: "bot@example.com" }] })),
-      listEvents: vi.fn(async () => ({
-        events: [
-          {
-            id: "evt_http",
-            type: "email.received",
-            schema_version: 1,
-            created_at: "2026-06-01T12:00:00Z",
-            status: "processed",
-            data: { from: "alice@example.com" },
-          },
-        ],
-        next_token: "",
-      })),
-      getEvent: vi.fn(async (id: string) => ({
-        id,
+    getMessage: vi.fn(async () => ({ messageId: "m" })),
+    getAgent: vi.fn(async () => ({ id: "x@y", email: "x@y" })),
+    listAgents: vi.fn(async () => [{ email: "bot@example.com" }]),
+    listEvents: vi.fn(async () => [
+      {
+        id: "evt_http",
         type: "email.received",
-        schema_version: 1,
-        created_at: "2026-06-01T12:00:00Z",
+        schemaVersion: 1,
+        createdAt: "2026-06-01T12:00:00Z",
         status: "processed",
-        data: {},
-        delivery_status: { matched_webhooks: 1, delivered: 1, pending: 0, failed: 0 },
-      })),
-      redeliverEvent: vi.fn(async (id: string, opts?: { webhookId?: string }) => ({
-        event_id: id,
-        webhook_id: opts?.webhookId ?? "",
-        delivery_id: "whd_replay_http",
-        status: "pending",
-      })),
-    },
+        data: { from: "alice@example.com" },
+      },
+    ]),
+    getEvent: vi.fn(async (id: string) => ({
+      id,
+      type: "email.received",
+      schemaVersion: 1,
+      createdAt: "2026-06-01T12:00:00Z",
+      status: "processed",
+      data: {},
+      deliveryStatus: { matchedWebhooks: 1, delivered: 1, pending: 0, failed: 0 },
+    })),
+    redeliverEvent: vi.fn(async (id: string, webhookId?: string) => ({
+      eventId: id,
+      webhookId: webhookId ?? "",
+      deliveryId: "whd_replay_http",
+      status: "pending",
+    })),
   };
-  return stub as unknown as E2AClient;
+  return stub as unknown as McpClient;
 }
 
 describe("MCP events tools over streamable-http", () => {
-  let stub: E2AClient;
+  let stub: McpClient;
   let close: () => Promise<void>;
   let url: string;
 
@@ -90,7 +85,7 @@ describe("MCP events tools over streamable-http", () => {
     const result = await client.callTool({ name: "list_events", arguments: {} });
     const parsed = parseToolResult(result);
     expect((parsed.events as Array<{ id: string }>)[0].id).toBe("evt_http");
-    expect(stub.api.listEvents).toHaveBeenCalledOnce();
+    expect(stub.listEvents).toHaveBeenCalledOnce();
     await client.close();
   });
 
@@ -102,7 +97,7 @@ describe("MCP events tools over streamable-http", () => {
     });
     const parsed = parseToolResult(result);
     expect(parsed.id).toBe("evt_via_http");
-    expect(stub.api.getEvent).toHaveBeenCalledWith("evt_via_http");
+    expect(stub.getEvent).toHaveBeenCalledWith("evt_via_http");
     await client.close();
   });
 
@@ -113,8 +108,8 @@ describe("MCP events tools over streamable-http", () => {
       arguments: { event_id: "evt_x", webhook_id: "wh_y" },
     });
     const parsed = parseToolResult(result);
-    expect(parsed.delivery_id).toBe("whd_replay_http");
-    expect(stub.api.redeliverEvent).toHaveBeenCalledWith("evt_x", { webhookId: "wh_y" });
+    expect(parsed.deliveryId).toBe("whd_replay_http");
+    expect(stub.redeliverEvent).toHaveBeenCalledWith("evt_x", "wh_y");
     await client.close();
   });
 

--- a/mcp/tests/events.test.ts
+++ b/mcp/tests/events.test.ts
@@ -1,59 +1,49 @@
 import { describe, expect, it, beforeEach, vi } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import type { E2AClient } from "@e2a/sdk/v1";
+import type { McpClient } from "../src/client.js";
 import { buildServer } from "../src/server.js";
 
-// Slice 8 MCP tool tests for list_events / get_event / redeliver_event.
-// Pattern mirrors tools.test.ts — in-memory transport, stub E2AClient,
-// assert wire shape passed to the SDK + the tool result.
+// MCP tool tests for list_events / get_event / redeliver_event.
+// Pattern mirrors tools.test.ts — in-memory transport, stub McpClient,
+// assert wire shape passed to the wrapper + the tool result. The
+// wrapper auto-paginates, so list_events returns a flat array (the
+// cursor token is handled inside the SDK pager, not surfaced).
 
-function makeStubClient(): E2AClient {
+function makeStubClient(): McpClient {
   const stub = {
     agentEmail: "bot@example.com",
-    api: {
-      // Existing methods the tools may touch transitively.
-      getMessage: vi.fn(async () => ({ message_id: "m" })),
-      getAgent: vi.fn(async () => ({ id: "x@y", email: "x@y" })),
-      // Events methods.
-      listEvents: vi.fn(async (params?: Record<string, unknown>) => ({
-        events: [
-          {
-            id: "evt_abc",
-            type: "email.received",
-            schema_version: 1,
-            created_at: "2026-06-01T12:00:00Z",
-            status: "processed",
-            data: { from: "alice@example.com" },
-            _captured: params, // smuggle the params back for assertion
-          },
-        ],
-        next_token: "next_cursor",
-      })),
-      getEvent: vi.fn(async (id: string) => ({
-        id,
+    // Events methods on the wrapper.
+    listEvents: vi.fn(async (_params?: Record<string, unknown>) => [
+      {
+        id: "evt_abc",
         type: "email.received",
-        schema_version: 1,
-        created_at: "2026-06-01T12:00:00Z",
+        schemaVersion: 1,
+        createdAt: "2026-06-01T12:00:00Z",
         status: "processed",
-        data: {},
-        delivery_status: { matched_webhooks: 1, delivered: 1, pending: 0, failed: 0 },
-      })),
-      redeliverEvent: vi.fn(
-        async (id: string, opts?: { webhookId?: string }) => ({
-          event_id: id,
-          webhook_id: opts?.webhookId ?? "",
-          delivery_id: "whd_replay_xyz",
-          status: "pending",
-          _capturedOpts: opts,
-        }),
-      ),
-    },
+        data: { from: "alice@example.com" },
+      },
+    ]),
+    getEvent: vi.fn(async (id: string) => ({
+      id,
+      type: "email.received",
+      schemaVersion: 1,
+      createdAt: "2026-06-01T12:00:00Z",
+      status: "processed",
+      data: {},
+      deliveryStatus: { matchedWebhooks: 1, delivered: 1, pending: 0, failed: 0 },
+    })),
+    redeliverEvent: vi.fn(async (id: string, webhookId?: string) => ({
+      eventId: id,
+      webhookId: webhookId ?? "",
+      deliveryId: "whd_replay_xyz",
+      status: "pending",
+    })),
   };
-  return stub as unknown as E2AClient;
+  return stub as unknown as McpClient;
 }
 
-async function buildClient(stub: E2AClient): Promise<Client> {
+async function buildClient(stub: McpClient): Promise<Client> {
   const server = buildServer({ client: stub, version: "test" });
   const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
   await server.connect(serverTransport);
@@ -69,7 +59,7 @@ function parseToolResult(result: unknown): Record<string, unknown> {
 }
 
 describe("MCP events tools", () => {
-  let stub: E2AClient;
+  let stub: McpClient;
 
   beforeEach(() => {
     stub = makeStubClient();
@@ -83,17 +73,17 @@ describe("MCP events tools", () => {
       expect(names).toContain("list_events");
     });
 
-    it("invokes client.api.listEvents with no params", async () => {
+    it("invokes client.listEvents with no params", async () => {
       const client = await buildClient(stub);
       const result = await client.callTool({ name: "list_events", arguments: {} });
       const parsed = parseToolResult(result);
       expect(parsed.events).toBeDefined();
       const events = parsed.events as Array<{ id: string }>;
       expect(events[0].id).toBe("evt_abc");
-      expect(stub.api.listEvents).toHaveBeenCalledOnce();
+      expect(stub.listEvents).toHaveBeenCalledOnce();
     });
 
-    it("forwards all filter params to the SDK", async () => {
+    it("forwards all filter params to the wrapper (page_size → limit)", async () => {
       const client = await buildClient(stub);
       await client.callTool({
         name: "list_events",
@@ -108,23 +98,17 @@ describe("MCP events tools", () => {
           token: "opaque",
         },
       });
-      expect(stub.api.listEvents).toHaveBeenCalledWith({
+      // `token` is accepted in the schema for contract stability but the
+      // auto-pager handles cursoring internally, so it is not forwarded.
+      expect(stub.listEvents).toHaveBeenCalledWith({
         type: "email.received",
         agentId: "ag_x",
         conversationId: "conv_y",
         messageId: "msg_z",
         since: "2026-06-01T00:00:00Z",
         until: "2026-06-02T00:00:00Z",
-        pageSize: 25,
-        token: "opaque",
+        limit: 25,
       });
-    });
-
-    it("includes next_token in result for pagination", async () => {
-      const client = await buildClient(stub);
-      const result = await client.callTool({ name: "list_events", arguments: {} });
-      const parsed = parseToolResult(result);
-      expect(parsed.next_token).toBe("next_cursor");
     });
   });
 
@@ -135,7 +119,7 @@ describe("MCP events tools", () => {
       expect(tools.map((t) => t.name)).toContain("get_event");
     });
 
-    it("calls client.api.getEvent with the event_id", async () => {
+    it("calls client.getEvent with the event_id", async () => {
       const client = await buildClient(stub);
       const result = await client.callTool({
         name: "get_event",
@@ -143,17 +127,17 @@ describe("MCP events tools", () => {
       });
       const parsed = parseToolResult(result);
       expect(parsed.id).toBe("evt_xyz");
-      expect(stub.api.getEvent).toHaveBeenCalledWith("evt_xyz");
+      expect(stub.getEvent).toHaveBeenCalledWith("evt_xyz");
     });
 
-    it("surfaces delivery_status in the response", async () => {
+    it("surfaces deliveryStatus in the response", async () => {
       const client = await buildClient(stub);
       const result = await client.callTool({
         name: "get_event",
         arguments: { event_id: "evt_xyz" },
       });
       const parsed = parseToolResult(result);
-      const ds = parsed.delivery_status as Record<string, number>;
+      const ds = parsed.deliveryStatus as Record<string, number>;
       expect(ds.delivered).toBe(1);
     });
   });
@@ -165,15 +149,13 @@ describe("MCP events tools", () => {
       expect(tools.map((t) => t.name)).toContain("redeliver_event");
     });
 
-    it("targeted: forwards webhook_id to the SDK", async () => {
+    it("targeted: forwards webhook_id to the wrapper", async () => {
       const client = await buildClient(stub);
       await client.callTool({
         name: "redeliver_event",
         arguments: { event_id: "evt_abc", webhook_id: "wh_target" },
       });
-      expect(stub.api.redeliverEvent).toHaveBeenCalledWith("evt_abc", {
-        webhookId: "wh_target",
-      });
+      expect(stub.redeliverEvent).toHaveBeenCalledWith("evt_abc", "wh_target");
     });
 
     it("fan-out: omits webhook_id when not provided", async () => {
@@ -182,9 +164,7 @@ describe("MCP events tools", () => {
         name: "redeliver_event",
         arguments: { event_id: "evt_abc" },
       });
-      expect(stub.api.redeliverEvent).toHaveBeenCalledWith("evt_abc", {
-        webhookId: undefined,
-      });
+      expect(stub.redeliverEvent).toHaveBeenCalledWith("evt_abc", undefined);
     });
 
     it("returns the new delivery_id", async () => {
@@ -194,7 +174,7 @@ describe("MCP events tools", () => {
         arguments: { event_id: "evt_abc", webhook_id: "wh_x" },
       });
       const parsed = parseToolResult(result);
-      expect(parsed.delivery_id).toBe("whd_replay_xyz");
+      expect(parsed.deliveryId).toBe("whd_replay_xyz");
     });
   });
 
@@ -226,7 +206,7 @@ describe("MCP events tools", () => {
         const parsed = parseToolResult(r);
         expect((parsed.events as unknown[]).length).toBe(1);
       }
-      expect(stub.api.listEvents).toHaveBeenCalledTimes(20);
+      expect(stub.listEvents).toHaveBeenCalledTimes(20);
     });
 
     it("handles concurrent mix of all three tools", async () => {
@@ -241,9 +221,9 @@ describe("MCP events tools", () => {
         client.callTool({ name: "list_events", arguments: {} }),
         client.callTool({ name: "get_event", arguments: { event_id: "evt_c" } }),
       ]);
-      expect(stub.api.listEvents).toHaveBeenCalledTimes(2);
-      expect(stub.api.getEvent).toHaveBeenCalledTimes(2);
-      expect(stub.api.redeliverEvent).toHaveBeenCalledTimes(1);
+      expect(stub.listEvents).toHaveBeenCalledTimes(2);
+      expect(stub.getEvent).toHaveBeenCalledTimes(2);
+      expect(stub.redeliverEvent).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/mcp/tests/http.test.ts
+++ b/mcp/tests/http.test.ts
@@ -1,30 +1,29 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import type { E2AClient } from "@e2a/sdk/v1";
+import type { McpClient } from "../src/client.js";
 import { startHttpServer } from "../src/http-server.js";
 import { Sessions } from "../src/session.js";
 
-// Reuse the same stub shape from tools.test.ts. Only the methods the
-// tools actually call need to be present.
-function makeStubClient(): E2AClient {
+// Stub the McpClient wrapper — only the methods the tools and the
+// session prefetch (listAgents / agentEmail) actually touch. List
+// methods return flat arrays (the wrapper collapses the SDK pager).
+function makeStubClient(): McpClient {
   const stub = {
     agentEmail: "bot@example.com",
-    api: {
-      getMessage: vi.fn(async (_e: string, id: string) => ({ message_id: id })),
-      getAgent: vi.fn(async (e: string) => ({ id: e, email: e })),
-    },
-    send: vi.fn(async () => ({ message_id: "msg_sent", status: "sent" })),
-    reply: vi.fn(async () => ({ message_id: "msg_reply", status: "sent" })),
-    listMessages: vi.fn(async () => ({ messages: [] })),
-    listAgents: vi.fn(async () => ({ agents: [] })),
-    registerAgent: vi.fn(async () => ({ email: "x@y", id: "x", domain: "y" })),
-    listPendingMessages: vi.fn(async () => ({ messages: [] })),
-    getPendingMessage: vi.fn(async () => ({ id: "p", status: "pending_approval" })),
-    approveMessage: vi.fn(async () => ({ message_id: "x", status: "sent" })),
-    rejectMessage: vi.fn(async () => ({ message_id: "x", status: "rejected" })),
+    getMessage: vi.fn(async (id: string) => ({ messageId: id })),
+    getAgent: vi.fn(async (e: string) => ({ id: e, email: e })),
+    send: vi.fn(async () => ({ messageId: "msg_sent", status: "sent" })),
+    reply: vi.fn(async () => ({ messageId: "msg_reply", status: "sent" })),
+    listMessages: vi.fn(async () => []),
+    listAgents: vi.fn(async () => []),
+    createAgent: vi.fn(async () => ({ email: "x@y", id: "x", domain: "y" })),
+    listPendingMessages: vi.fn(async () => []),
+    getPendingMessage: vi.fn(async () => ({ messageId: "p", status: "pending_approval" })),
+    approveMessage: vi.fn(async () => ({ messageId: "x", status: "sent" })),
+    rejectMessage: vi.fn(async () => ({ messageId: "x", status: "rejected" })),
   };
-  return stub as unknown as E2AClient;
+  return stub as unknown as McpClient;
 }
 
 function makeHttpError(statusCode: number): Error & { statusCode: number } {
@@ -34,7 +33,7 @@ function makeHttpError(statusCode: number): Error & { statusCode: number } {
 }
 
 describe("HTTP MCP server", () => {
-  let stub: E2AClient;
+  let stub: McpClient;
   let close: () => Promise<void>;
   let url: string;
 
@@ -95,7 +94,7 @@ describe("HTTP MCP server", () => {
     const invalidStub = makeStubClient();
     invalidStub.listAgents = vi.fn(async () => {
       throw makeHttpError(401);
-    }) as E2AClient["listAgents"];
+    }) as McpClient["listAgents"];
     const { close: c, port } = await startHttpServer(0, {
       baseUrl: "http://e2a.local",
       allowedHosts: ["127.0.0.1", "localhost"],
@@ -297,23 +296,22 @@ describe("HTTP MCP server", () => {
       initialEmail?: string;
       agents: Array<{ email: string }>;
       listAgentsThrows?: boolean;
-    }): E2AClient {
+    }): McpClient {
       return {
         agentEmail: opts.initialEmail ?? "",
-        api: {},
         send: vi.fn(),
         reply: vi.fn(),
-        listMessages: vi.fn(async () => ({ messages: [] })),
+        listMessages: vi.fn(async () => []),
         listAgents: vi.fn(async () => {
           if (opts.listAgentsThrows) throw new Error("upstream 500");
-          return { agents: opts.agents };
+          return opts.agents;
         }),
-        registerAgent: vi.fn(),
-        listPendingMessages: vi.fn(async () => ({ messages: [] })),
+        createAgent: vi.fn(),
+        listPendingMessages: vi.fn(async () => []),
         getPendingMessage: vi.fn(),
         approveMessage: vi.fn(),
         rejectMessage: vi.fn(),
-      } as unknown as E2AClient;
+      } as unknown as McpClient;
     }
 
     it("resolves agent_email when listAgents returns exactly one agent", async () => {

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -1,34 +1,53 @@
 import { describe, expect, it, beforeEach, vi } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import type { E2AClient } from "@e2a/sdk/v1";
+import { simpleParser } from "mailparser";
+import type { McpClient } from "../src/client.js";
 import { buildServer } from "../src/server.js";
 
-// Minimal stub of E2AClient — only the methods our tools actually call.
-function makeStubClient(overrides: Partial<{ agentEmail: string }> = {}): E2AClient {
+// Build a small RFC822 blob with one attachment so the MessageView's
+// `rawMessage` decodes to a known attachment set (the v1 MessageView no
+// longer carries decoded attachments — the tools parse rawMessage).
+function rawWith(text: string, filename: string, contentType: string, body: Buffer): string {
+  const b64 = body.toString("base64");
+  return [
+    "From: alice@example.com",
+    "To: bot@example.com",
+    "Subject: hi",
+    'Content-Type: multipart/mixed; boundary="BNDRY"',
+    "",
+    "--BNDRY",
+    "Content-Type: text/plain",
+    "",
+    text,
+    "--BNDRY",
+    `Content-Type: ${contentType}`,
+    "Content-Transfer-Encoding: base64",
+    `Content-Disposition: attachment; filename="${filename}"`,
+    "",
+    b64,
+    "--BNDRY--",
+    "",
+  ].join("\r\n");
+}
+
+const pdfBytes = Buffer.from("%PDF-1.4 fake pdf bytes");
+
+// Minimal stub of McpClient — only the methods our tools call. The
+// wrapper concentrates SDK calls and address resolution, so tests stub
+// it directly rather than the namespaced SDK underneath.
+function makeStubClient(overrides: Partial<{ agentEmail: string }> = {}): McpClient {
   const stub = {
     agentEmail: overrides.agentEmail ?? "bot@example.com",
-    api: {
-      getMessage: vi.fn(async (_email: string, id: string) => ({
-        message_id: id,
-        from: "alice@example.com",
-        subject: "hi",
-      })),
-      getAgent: vi.fn(async (email: string) => ({
-        id: email,
-        email,
-        agent_mode: "local",
-      })),
-    },
-    send: vi.fn(async () => ({ message_id: "msg_sent", status: "sent" })),
-    reply: vi.fn(async () => ({ message_id: "msg_reply", status: "sent" })),
-    forward: vi.fn(async () => ({ message_id: "msg_fwd", status: "sent" })),
-    updateMessageLabels: vi.fn(async () => ({ message_id: "msg_in", labels: ["urgent"] })),
-    listConversations: vi.fn(async () => ({ conversations: [{ conversation_id: "conv_1" }] })),
-    getConversation: vi.fn(async () => ({ conversation_id: "conv_1", messages: [] })),
-    listMessages: vi.fn(async () => ({ messages: [], next_token: undefined })),
-    listAgents: vi.fn(async () => ({ agents: [{ email: "bot@example.com" }] })),
-    registerAgent: vi.fn(async (body: Record<string, unknown>) => ({
+    send: vi.fn(async () => ({ messageId: "msg_sent", status: "sent" })),
+    reply: vi.fn(async () => ({ messageId: "msg_reply", status: "sent" })),
+    forward: vi.fn(async () => ({ messageId: "msg_fwd", status: "sent" })),
+    updateMessageLabels: vi.fn(async () => ({ messageId: "msg_in", labels: ["urgent"] })),
+    listConversations: vi.fn(async () => [{ conversationId: "conv_1" }]),
+    getConversation: vi.fn(async () => ({ conversationId: "conv_1", messages: [] })),
+    listMessages: vi.fn(async () => []),
+    listAgents: vi.fn(async () => [{ email: "bot@example.com" }]),
+    createAgent: vi.fn(async (body: { slug: string }) => ({
       email: `${body.slug}@agents.example.com`,
       domain: "agents.example.com",
       id: `${body.slug}@agents.example.com`,
@@ -36,25 +55,22 @@ function makeStubClient(overrides: Partial<{ agentEmail: string }> = {}): E2ACli
     getAgent: vi.fn(async (email: string) => ({
       id: email,
       email,
-      agent_mode: "local",
-      hitl_enabled: false,
+      hitlEnabled: false,
     })),
     updateAgent: vi.fn(async (body: Record<string, unknown>) => ({
       id: "bot@example.com",
       email: "bot@example.com",
       ...body,
     })),
-    deleteAgent: vi.fn(async () => undefined),
-    listDomains: vi.fn(async () => ({
-      domains: [
-        { domain: "mail.acme.com", verified: true, verification_token: "tok1" },
-      ],
-    })),
+    deleteAgent: vi.fn(async (addr?: string) => addr ?? "bot@example.com"),
+    listDomains: vi.fn(async () => [
+      { domain: "mail.acme.com", verified: true, verificationToken: "tok1" },
+    ]),
     registerDomain: vi.fn(async (domain: string) => ({
       domain,
       verified: false,
-      verification_token: "tok_new",
-      dns_records: {
+      verificationToken: "tok_new",
+      dnsRecords: {
         mx: { host: domain, value: "mx.e2a.dev", priority: 10 },
         txt: { host: domain, value: "e2a-verify=tok_new" },
       },
@@ -62,54 +78,38 @@ function makeStubClient(overrides: Partial<{ agentEmail: string }> = {}): E2ACli
     verifyDomain: vi.fn(async (domain: string) => ({
       domain,
       verified: true,
-      verification_token: "tok_new",
+      verificationToken: "tok_new",
     })),
     deleteDomain: vi.fn(async () => undefined),
-    // Stand-in for the SDK's client.getMessage() which returns an
-    // InboundEmail with verified=true (the REST channel is bearer-
-    // authenticated so the SDK marks pre-verified). The production
-    // tool reads the getters which on the real class throw if
-    // unverified — but TypeScript's structural typing doesn't
-    // distinguish data properties from getters, so this plain
-    // object satisfies the call site. Attachments default to one
-    // small PDF; tests override via mockResolvedValueOnce.
-    getMessage: vi.fn(async (id: string, _email?: string) => ({
+    // Stand-in for McpClient.getMessage() which returns a v1
+    // MessageView. Attachments are decoded by the tool from
+    // `rawMessage`; the default raw carries one small PDF.
+    getMessage: vi.fn(async (id: string, _addr?: string) => ({
       messageId: id,
       conversationId: "conv_x",
-      sender: "alice@example.com",
+      _from: "alice@example.com",
       recipient: "bot@example.com",
       to: ["bot@example.com"],
       cc: [],
       replyTo: [],
       subject: "hi",
-      textBody: "hello world",
-      htmlBody: null,
-      receivedAt: "2026-05-20T10:00:00Z",
-      attachments: [
-        {
-          filename: "report.pdf",
-          contentType: "application/pdf",
-          data: Buffer.from("%PDF-1.4 fake pdf bytes"),
-          size: 23,
-        },
-      ],
+      status: "read",
+      body: { text: "hello world", html: undefined },
+      createdAt: "2026-05-20T10:00:00Z",
+      rawMessage: rawWith("hello world", "report.pdf", "application/pdf", pdfBytes),
     })),
-    listPendingMessages: vi.fn(async () => ({ messages: [] })),
-    // agent_id is required by the approve/reject tool wrappers, which
-    // do a pre-flight detail fetch to discover the owning agent for
-    // the agent-scoped backend endpoint.
+    listPendingMessages: vi.fn(async () => []),
     getPendingMessage: vi.fn(async (id: string) => ({
-      id,
+      messageId: id,
       status: "pending_approval",
-      agent_id: "bot@agents.e2a.dev",
     })),
-    approveMessage: vi.fn(async () => ({ message_id: "msg_x", status: "sent" })),
-    rejectMessage: vi.fn(async () => ({ message_id: "msg_x", status: "rejected" })),
+    approveMessage: vi.fn(async () => ({ messageId: "msg_x", status: "sent" })),
+    rejectMessage: vi.fn(async () => ({ messageId: "msg_x", status: "rejected" })),
   };
-  return stub as unknown as E2AClient;
+  return stub as unknown as McpClient;
 }
 
-async function connect(stub: E2AClient): Promise<Client> {
+async function connect(stub: McpClient): Promise<Client> {
   const server = buildServer({ client: stub, version: "0.0.0-test" });
   const client = new Client({ name: "test-client", version: "0.0.0" });
   const [clientT, serverT] = InMemoryTransport.createLinkedPair();
@@ -118,7 +118,7 @@ async function connect(stub: E2AClient): Promise<Client> {
 }
 
 describe("e2a MCP server", () => {
-  let stub: E2AClient;
+  let stub: McpClient;
   let client: Client;
 
   beforeEach(async () => {
@@ -179,10 +179,9 @@ describe("e2a MCP server", () => {
       },
     });
     expect(stub.send).toHaveBeenCalledWith(
-      ["alice@example.com"],
-      "hi",
-      "hello",
-      { cc: ["bob@example.com"] },
+      { to: ["alice@example.com"], subject: "hi", body: "hello", cc: ["bob@example.com"] },
+      {},
+      undefined,
     );
   });
 
@@ -195,7 +194,12 @@ describe("e2a MCP server", () => {
         reply_all: true,
       },
     });
-    expect(stub.reply).toHaveBeenCalledWith("msg_in", "thanks", { replyAll: true });
+    expect(stub.reply).toHaveBeenCalledWith(
+      "msg_in",
+      { body: "thanks", replyAll: true },
+      {},
+      undefined,
+    );
   });
 
   it("forward_message forwards args to client.forward", async () => {
@@ -211,6 +215,8 @@ describe("e2a MCP server", () => {
       "msg_in",
       ["destination@example.com"],
       { body: "FYI" },
+      {},
+      undefined,
     );
   });
 
@@ -223,10 +229,11 @@ describe("e2a MCP server", () => {
         remove_labels: ["unread"],
       },
     });
-    expect(stub.updateMessageLabels).toHaveBeenCalledWith("msg_in", {
-      addLabels: ["urgent"],
-      removeLabels: ["unread"],
-    });
+    expect(stub.updateMessageLabels).toHaveBeenCalledWith(
+      "msg_in",
+      { addLabels: ["urgent"], removeLabels: ["unread"] },
+      undefined,
+    );
   });
 
   it("list_conversations forwards args to client.listConversations", async () => {
@@ -234,10 +241,10 @@ describe("e2a MCP server", () => {
       name: "list_conversations",
       arguments: { page_size: 20, since: "2026-05-01T00:00:00Z" },
     });
-    expect(stub.listConversations).toHaveBeenCalledWith({
-      pageSize: 20,
-      since: "2026-05-01T00:00:00Z",
-    });
+    expect(stub.listConversations).toHaveBeenCalledWith(
+      { limit: 20, since: "2026-05-01T00:00:00Z" },
+      undefined,
+    );
   });
 
   it("get_conversation forwards args to client.getConversation", async () => {
@@ -245,7 +252,7 @@ describe("e2a MCP server", () => {
       name: "get_conversation",
       arguments: { conversation_id: "conv_1" },
     });
-    expect(stub.getConversation).toHaveBeenCalledWith("conv_1", {});
+    expect(stub.getConversation).toHaveBeenCalledWith("conv_1", undefined);
   });
 
   it("list_messages forwards filters", async () => {
@@ -255,7 +262,7 @@ describe("e2a MCP server", () => {
     });
     expect(stub.listMessages).toHaveBeenCalledWith({
       status: "unread",
-      pageSize: 10,
+      limit: 10,
     });
   });
 
@@ -264,11 +271,11 @@ describe("e2a MCP server", () => {
       name: "get_message",
       arguments: { message_id: "msg_abc" },
     });
-    // High-level client.getMessage (the parsed InboundEmail path) —
-    // not client.api.getMessage. The MCP server is responsible for
-    // unwrapping to plain JSON so the LLM gets a digestible shape
-    // without the raw_message MIME blob.
-    expect(stub.getMessage).toHaveBeenCalledWith("msg_abc", "bot@example.com");
+    // McpClient.getMessage resolves the address internally; the tool
+    // passes the explicit arg (undefined here → pinned default in the
+    // wrapper). The MCP server unwraps the MessageView to plain JSON,
+    // decoding attachment metadata from rawMessage.
+    expect(stub.getMessage).toHaveBeenCalledWith("msg_abc", undefined);
     const content = res.content as Array<{ type: string; text: string }>;
     const parsed = JSON.parse(content[0]!.text) as Record<string, unknown>;
     expect(parsed.message_id).toBe("msg_abc");
@@ -294,7 +301,7 @@ describe("e2a MCP server", () => {
       name: "get_attachment_data",
       arguments: { message_id: "msg_abc", attachment_index: 0 },
     });
-    expect(stub.getMessage).toHaveBeenCalledWith("msg_abc", "bot@example.com");
+    expect(stub.getMessage).toHaveBeenCalledWith("msg_abc", undefined);
     const content = res.content as Array<{ type: string; text: string }>;
     const parsed = JSON.parse(content[0]!.text) as Record<string, unknown>;
     expect(parsed.filename).toBe("report.pdf");
@@ -317,27 +324,22 @@ describe("e2a MCP server", () => {
   });
 
   it("get_attachment_data refuses attachments above the 2 MB inline cap", async () => {
-    // One-shot override: pretend the message has a 5 MB attachment.
+    // One-shot override: a message whose raw MIME carries a 3 MB
+    // attachment (decoded), above the 2 MB inline cap.
+    const big = Buffer.alloc(3 * 1024 * 1024, 0x41);
     (stub.getMessage as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       messageId: "msg_big",
       conversationId: null,
-      sender: "alice@example.com",
+      _from: "alice@example.com",
       recipient: "bot@example.com",
       to: ["bot@example.com"],
       cc: [],
       replyTo: [],
       subject: "huge",
-      textBody: "",
-      htmlBody: null,
-      receivedAt: null,
-      attachments: [
-        {
-          filename: "big.zip",
-          contentType: "application/zip",
-          data: Buffer.alloc(0),
-          size: 5 * 1024 * 1024,
-        },
-      ],
+      status: "read",
+      body: { text: "", html: undefined },
+      createdAt: null,
+      rawMessage: rawWith("", "big.zip", "application/zip", big),
     });
     const res = await client.callTool({
       name: "get_attachment_data",
@@ -362,9 +364,9 @@ describe("e2a MCP server", () => {
     // one agent rather than error. Mirrors send_email's "from
     // required only when multiple agents" auto-from behavior.
     const bareStub = makeStubClient({ agentEmail: "" });
-    (bareStub.listAgents as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      agents: [{ id: "solo@example.com", email: "solo@example.com" }],
-    });
+    (bareStub.listAgents as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      { id: "solo@example.com", email: "solo@example.com" },
+    ]);
     const bareClient = await connect(bareStub);
     const res = await bareClient.callTool({ name: "whoami", arguments: {} });
     expect(res.isError).toBeFalsy();
@@ -376,12 +378,10 @@ describe("e2a MCP server", () => {
     // available agent emails in the error so the LLM can act
     // without a follow-up list_agents call.
     const bareStub = makeStubClient({ agentEmail: "" });
-    (bareStub.listAgents as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      agents: [
-        { id: "support@x.com", email: "support@x.com" },
-        { id: "sales@x.com", email: "sales@x.com" },
-      ],
-    });
+    (bareStub.listAgents as ReturnType<typeof vi.fn>).mockResolvedValueOnce([
+      { id: "support@x.com", email: "support@x.com" },
+      { id: "sales@x.com", email: "sales@x.com" },
+    ]);
     const bareClient = await connect(bareStub);
     const res = await bareClient.callTool({ name: "whoami", arguments: {} });
     expect(res.isError).toBe(true);
@@ -394,9 +394,7 @@ describe("e2a MCP server", () => {
 
   it("whoami errors when the account has zero agents and prompts to create one", async () => {
     const bareStub = makeStubClient({ agentEmail: "" });
-    (bareStub.listAgents as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      agents: [],
-    });
+    (bareStub.listAgents as ReturnType<typeof vi.fn>).mockResolvedValueOnce([]);
     const bareClient = await connect(bareStub);
     const res = await bareClient.callTool({ name: "whoami", arguments: {} });
     expect(res.isError).toBe(true);
@@ -404,18 +402,19 @@ describe("e2a MCP server", () => {
     expect(content[0]?.text).toMatch(/create_agent/);
   });
 
-  it("create_agent defaults agent_mode to local", async () => {
+  it("create_agent forwards the slug only when name omitted", async () => {
     await client.callTool({
       name: "create_agent",
       arguments: { slug: "new-bot" },
     });
-    expect(stub.registerAgent).toHaveBeenCalledWith({
-      slug: "new-bot",
-      agent_mode: "local",
-    });
+    // v1 agent-create takes slug + name only. agent_mode / webhook_url
+    // are accepted in the schema for contract stability but no longer
+    // part of the agent shape (push delivery is a top-level webhooks
+    // resource), so they are not forwarded.
+    expect(stub.createAgent).toHaveBeenCalledWith({ slug: "new-bot" });
   });
 
-  it("create_agent forwards cloud-mode webhook", async () => {
+  it("create_agent forwards name and ignores retired cloud-mode fields", async () => {
     await client.callTool({
       name: "create_agent",
       arguments: {
@@ -425,37 +424,39 @@ describe("e2a MCP server", () => {
         name: "Cloud Bot",
       },
     });
-    expect(stub.registerAgent).toHaveBeenCalledWith({
+    // agent_mode / webhook_url dropped — only slug + name reach the SDK.
+    expect(stub.createAgent).toHaveBeenCalledWith({
       slug: "cloud-bot",
-      agent_mode: "cloud",
       name: "Cloud Bot",
-      webhook_url: "https://example.com/hook",
     });
   });
 
-  it("update_agent forwards body fields and uses env email by default", async () => {
+  it("update_agent maps HITL fields to camelCase and uses env email by default", async () => {
     await client.callTool({
       name: "update_agent",
       arguments: { hitl_enabled: true, hitl_ttl_seconds: 3600 },
     });
     expect(stub.updateAgent).toHaveBeenCalledWith(
-      { hitl_enabled: true, hitl_ttl_seconds: 3600 },
-      {}, // no agent_email override → falls back to env-scoped agentEmail in the SDK
+      { hitlEnabled: true, hitlTtlSeconds: 3600 },
+      undefined, // no explicit agent_email → wrapper resolves the pinned default
     );
   });
 
-  it("update_agent threads explicit agent_email into opts.agentEmail", async () => {
+  it("update_agent threads explicit agent_email and drops retired fields", async () => {
     await client.callTool({
       name: "update_agent",
       arguments: {
         agent_email: "other@example.com",
         agent_mode: "cloud",
         webhook_url: "https://example.com/hook",
+        hitl_expiration_action: "reject",
       },
     });
+    // agent_mode / webhook_url no longer part of the agent shape — only
+    // the mapped HITL fields reach the SDK; the address is passed through.
     expect(stub.updateAgent).toHaveBeenCalledWith(
-      { agent_mode: "cloud", webhook_url: "https://example.com/hook" },
-      { agentEmail: "other@example.com" },
+      { hitlExpirationAction: "reject" },
+      "other@example.com",
     );
   });
 
@@ -508,7 +509,7 @@ describe("e2a MCP server", () => {
     // The returned shape must surface the DNS records so the LLM can
     // hand them to a DNS-provider MCP. If a future SDK change drops
     // them from the response, this test trips immediately.
-    expect(content[0]?.text).toContain("dns_records");
+    expect(content[0]?.text).toContain("dnsRecords");
     expect(content[0]?.text).toContain("mx.e2a.dev");
     expect(content[0]?.text).toContain("tok_new");
   });
@@ -555,7 +556,7 @@ describe("e2a MCP server", () => {
     expect(stub.getPendingMessage).toHaveBeenCalledWith("msg_p");
   });
 
-  it("approve_pending_message strips message_id and forwards overrides", async () => {
+  it("approve_pending_message strips message_id and maps overrides to camelCase", async () => {
     await client.callTool({
       name: "approve_pending_message",
       arguments: {
@@ -564,9 +565,11 @@ describe("e2a MCP server", () => {
         body_text: "edited body",
       },
     });
-    expect(stub.approveMessage).toHaveBeenCalledWith("bot@agents.e2a.dev", "msg_p", {
+    // The wrapper resolves the owning agent internally, so the tool no
+    // longer passes an address; body_text → bodyText (ApproveRequest).
+    expect(stub.approveMessage).toHaveBeenCalledWith("msg_p", {
       subject: "edited subject",
-      body_text: "edited body",
+      bodyText: "edited body",
     });
   });
 
@@ -575,7 +578,7 @@ describe("e2a MCP server", () => {
       name: "approve_pending_message",
       arguments: { message_id: "msg_p" },
     });
-    expect(stub.approveMessage).toHaveBeenCalledWith("bot@agents.e2a.dev", "msg_p", {});
+    expect(stub.approveMessage).toHaveBeenCalledWith("msg_p", {});
   });
 
   // Regression: when idempotency_key is omitted, the MCP layer must
@@ -589,14 +592,16 @@ describe("e2a MCP server", () => {
   // on args and is strict on argument count, so this test fails if a
   // 4th arg leaks in. Mirrors the same guard on send / reply tests
   // above (lines 145 / 163).
-  it("approve_pending_message omits 4th-arg opts when idempotency_key is unset", async () => {
+  it("approve_pending_message omits 3rd-arg opts when idempotency_key is unset", async () => {
     await client.callTool({
       name: "approve_pending_message",
       arguments: { message_id: "msg_p", subject: "edited" },
     });
-    expect(stub.approveMessage).toHaveBeenCalledWith("bot@agents.e2a.dev", "msg_p", { subject: "edited" });
+    expect(stub.approveMessage).toHaveBeenCalledWith("msg_p", { subject: "edited" });
+    // Two args only — no { idempotencyKey: undefined } leaking in as a
+    // 3rd arg (different semantics for an auto-mint helper downstream).
     const lastCall = (stub.approveMessage as unknown as { mock: { calls: unknown[][] } }).mock.calls.at(-1);
-    expect(lastCall?.length).toBe(3);
+    expect(lastCall?.length).toBe(2);
   });
 
   // Approve fires SES so an idempotency_key argument has to reach the
@@ -613,7 +618,6 @@ describe("e2a MCP server", () => {
       },
     });
     expect(stub.approveMessage).toHaveBeenCalledWith(
-      "bot@agents.e2a.dev",
       "msg_p",
       { subject: "edited" },
       { idempotencyKey: "approve-key-123" },
@@ -633,10 +637,9 @@ describe("e2a MCP server", () => {
       },
     });
     expect(stub.send).toHaveBeenCalledWith(
-      ["alice@example.com"],
-      "x",
-      "y",
-      expect.objectContaining({ idempotencyKey: "send-key-9" }),
+      expect.objectContaining({ to: ["alice@example.com"], subject: "x", body: "y" }),
+      { idempotencyKey: "send-key-9" },
+      undefined,
     );
   });
 
@@ -651,8 +654,9 @@ describe("e2a MCP server", () => {
     });
     expect(stub.reply).toHaveBeenCalledWith(
       "msg_in_xyz",
-      "reply",
-      expect.objectContaining({ idempotencyKey: "reply-key-9" }),
+      expect.objectContaining({ body: "reply" }),
+      { idempotencyKey: "reply-key-9" },
+      undefined,
     );
   });
 
@@ -670,8 +674,14 @@ describe("e2a MCP server", () => {
     content_type: "text/plain",
     data: helloBase64,
   };
+  // The wire shape after the tool's snake→camel mapping.
+  const sdkAttachment = {
+    filename: "note.txt",
+    contentType: "text/plain",
+    data: helloBase64,
+  };
 
-  it("send_email forwards attachments verbatim to client.send", async () => {
+  it("send_email maps attachments to the SDK shape on client.send", async () => {
     await client.callTool({
       name: "send_email",
       arguments: {
@@ -682,14 +692,13 @@ describe("e2a MCP server", () => {
       },
     });
     expect(stub.send).toHaveBeenCalledWith(
-      ["alice@example.com"],
-      "with file",
-      "see attached",
-      { attachments: [sampleAttachment] },
+      expect.objectContaining({ attachments: [sdkAttachment] }),
+      {},
+      undefined,
     );
   });
 
-  it("reply_to_message forwards attachments verbatim to client.reply", async () => {
+  it("reply_to_message maps attachments to the SDK shape on client.reply", async () => {
     await client.callTool({
       name: "reply_to_message",
       arguments: {
@@ -698,9 +707,12 @@ describe("e2a MCP server", () => {
         attachments: [sampleAttachment],
       },
     });
-    expect(stub.reply).toHaveBeenCalledWith("msg_in", "reply with file", {
-      attachments: [sampleAttachment],
-    });
+    expect(stub.reply).toHaveBeenCalledWith(
+      "msg_in",
+      expect.objectContaining({ body: "reply with file", attachments: [sdkAttachment] }),
+      {},
+      undefined,
+    );
   });
 
   it("approve_pending_message accepts an attachments override (HITL reviewer adds a file)", async () => {
@@ -711,8 +723,8 @@ describe("e2a MCP server", () => {
         attachments: [sampleAttachment],
       },
     });
-    expect(stub.approveMessage).toHaveBeenCalledWith("bot@agents.e2a.dev", "msg_p", {
-      attachments: [sampleAttachment],
+    expect(stub.approveMessage).toHaveBeenCalledWith("msg_p", {
+      attachments: [sdkAttachment],
     });
   });
 
@@ -725,7 +737,7 @@ describe("e2a MCP server", () => {
       name: "approve_pending_message",
       arguments: { message_id: "msg_p", attachments: [] },
     });
-    expect(stub.approveMessage).toHaveBeenCalledWith("bot@agents.e2a.dev", "msg_p", { attachments: [] });
+    expect(stub.approveMessage).toHaveBeenCalledWith("msg_p", { attachments: [] });
   });
 
   it("send_email rejects base64 with whitespace (URL-safe or LLM-truncated patterns)", async () => {
@@ -794,7 +806,7 @@ describe("e2a MCP server", () => {
       name: "reject_pending_message",
       arguments: { message_id: "msg_p", reason: "wrong recipient" },
     });
-    expect(stub.rejectMessage).toHaveBeenCalledWith("bot@agents.e2a.dev", "msg_p", "wrong recipient");
+    expect(stub.rejectMessage).toHaveBeenCalledWith("msg_p", "wrong recipient");
   });
 
   it("surfaces SDK errors as isError results", async () => {

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -10,7 +10,7 @@ import { buildServer } from "../src/server.js";
 // longer carries decoded attachments — the tools parse rawMessage).
 function rawWith(text: string, filename: string, contentType: string, body: Buffer): string {
   const b64 = body.toString("base64");
-  return [
+  const rfc822 = [
     "From: alice@example.com",
     "To: bot@example.com",
     "Subject: hi",
@@ -29,6 +29,9 @@ function rawWith(text: string, filename: string, contentType: string, body: Buff
     "--BNDRY--",
     "",
   ].join("\r\n");
+  // The server base64-encodes raw_message on the wire; the fixture must match
+  // so the tool's decode path is exercised (a plaintext blob would hide it).
+  return Buffer.from(rfc822, "utf8").toString("base64");
 }
 
 const pdfBytes = Buffer.from("%PDF-1.4 fake pdf bytes");
@@ -94,7 +97,10 @@ function makeStubClient(overrides: Partial<{ agentEmail: string }> = {}): McpCli
       replyTo: [],
       subject: "hi",
       status: "read",
-      body: { text: "hello world", html: undefined },
+      // Inbound messages carry decoded text in `parsed`, NOT `body` (the server
+      // only sets `body` for outbound held drafts). Match the real wire shape.
+      parsed: { text: "hello world" },
+      body: undefined,
       createdAt: "2026-05-20T10:00:00Z",
       rawMessage: rawWith("hello world", "report.pdf", "application/pdf", pdfBytes),
     })),


### PR DESCRIPTION
## Slice 8d-ts — repoint the TS consumers to the 3.0 SDK

Stacked on #227 (the 3.0 TS SDK). Migrates `@e2a/cli` and `@e2a/mcp-server` off the retired flat surface (`E2AApi`, `client.api.*`, `client.agentEmail`, flat methods, `InboundEmail`, `components` types, `E2AApiError`) to the namespaced `E2AClient`. **This flips the `CLI tests` + `MCP server tests` checks (red on #227 by design) green.** Base auto-retargets to `main` once #227 merges.

### CLI (`bcee216`)
- Every command → namespaced resources (`agents`/`messages`/`conversations`/`domains`/`events`/`webhooks`/`account`) with explicit `address` args and `AutoPager` lists.
- `read`/`inbox` render `MessageView` (`subject`/`from`/`body`/`parsed`) instead of the retired `InboundEmail`.
- `pending` lists outbound messages with `status="pending_approval"` per agent; approve/reject via `messages.approve/reject`.
- `login` probes the unauthenticated `GET /v1/info` with a **raw fetch** — the 3.0 client requires an apiKey to construct, which login lacks pre-auth. (Fixed during review: the initial repoint constructed a keyless client, which throws; a mocked unit test hid it, the real-binary e2e + manual review caught it.)
- Dropped the retired per-agent `--webhook-url` / `agent_mode` (webhooks are a separate resource now).
- **tsc clean · 104 tests · build clean.**

### MCP (`85ba11b`)
- New `McpClient` wrapper holding the namespaced `E2AClient` + a resolved default address; centralizes address resolution + shape-mapping so tool contracts (names + schemas) are unchanged.
- `messages` tools map `MessageView`; attachment metadata/bytes decoded from `rawMessage` via `mailparser` (added as a dep — v1 has no inline attachments).
- `hitl` tools list pending as `status="pending_approval"` outbound; approve/reject via `messages.approve/reject`.
- Errors branch on `E2AError` (status/code).
- **tsc clean · 118 tests · build clean.**

### Verification
- Combined `tsc` clean for both workspaces.
- **Over-the-wire CLI e2e** against a freshly-built `./bin/e2a` (fresh Postgres + Mailpit): `agents register/list`, `domains list`, `inbox`, `send` (real outbound to Mailpit), `webhooks create/list`, and the `read` error path all behave correctly; server log clean (no 5xx/panic). MCP's repoint is covered by its 118 unit tests (over-the-wire MCP needs a client harness; the same SDK call paths are exercised by the CLI e2e).

### Behavior notes (consumer-visible)
- CLI `agents register` no longer accepts `--webhook-url`; `agent_mode` is gone (use the `webhooks` resource).
- `pending`/HITL is now per-agent (resolved via `--agent`/saved agent), since v1 has no cross-agent pending endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)