### PR TITLE
feat(api): post-review hardening — MessageView trust fields + design doc F1–F9

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1024,11 +1024,15 @@ components:
             - deferred
             - failed
           type: string
+        direction:
+          type: string
         flag_reason:
           type: string
         flagged:
           type: boolean
         from:
+          type: string
+        hitl_status:
           type: string
         labels:
           items:
@@ -1075,6 +1079,7 @@ components:
         - recipient
         - subject
         - conversation_id
+        - direction
         - status
         - labels
         - created_at

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -608,6 +608,10 @@ components:
           format: int64
           type: integer
         status:
+          enum:
+            - pending
+            - processed
+            - no_match
           type: string
         type:
           enum:
@@ -731,9 +735,7 @@ components:
         agents:
           items:
             $ref: "#/components/schemas/AgentView"
-          type:
-            - array
-            - "null"
+          type: array
       required:
         - agents
       type: object
@@ -743,9 +745,7 @@ components:
         domains:
           items:
             $ref: "#/components/schemas/DomainView"
-          type:
-            - array
-            - "null"
+          type: array
       required:
         - domains
       type: object
@@ -755,9 +755,7 @@ components:
         webhooks:
           items:
             $ref: "#/components/schemas/WebhookView"
-          type:
-            - array
-            - "null"
+          type: array
       required:
         - webhooks
       type: object
@@ -932,6 +930,9 @@ components:
             - failed
           type: string
         direction:
+          enum:
+            - inbound
+            - outbound
           type: string
         flag_reason:
           type: string
@@ -940,6 +941,12 @@ components:
         from:
           type: string
         hitl_status:
+          enum:
+            - pending_approval
+            - sent
+            - rejected
+            - expired_approved
+            - expired_rejected
           type: string
         labels:
           items:
@@ -1025,6 +1032,9 @@ components:
             - failed
           type: string
         direction:
+          enum:
+            - inbound
+            - outbound
           type: string
         flag_reason:
           type: string
@@ -1033,6 +1043,12 @@ components:
         from:
           type: string
         hitl_status:
+          enum:
+            - pending_approval
+            - sent
+            - rejected
+            - expired_approved
+            - expired_rejected
           type: string
         labels:
           items:
@@ -1119,9 +1135,7 @@ components:
         items:
           items:
             $ref: "#/components/schemas/ConversationSummaryView"
-          type:
-            - array
-            - "null"
+          type: array
         next_cursor:
           type:
             - string
@@ -1136,9 +1150,7 @@ components:
         items:
           items:
             $ref: "#/components/schemas/EventJSON"
-          type:
-            - array
-            - "null"
+          type: array
         next_cursor:
           type:
             - string
@@ -1153,9 +1165,7 @@ components:
         items:
           items:
             $ref: "#/components/schemas/MessageSummaryView"
-          type:
-            - array
-            - "null"
+          type: array
         next_cursor:
           type:
             - string
@@ -1170,9 +1180,7 @@ components:
         items:
           items:
             $ref: "#/components/schemas/WebhookDeliveryView"
-          type:
-            - array
-            - "null"
+          type: array
         next_cursor:
           type:
             - string
@@ -1189,6 +1197,9 @@ components:
         reason:
           type: string
         status:
+          enum:
+            - pending
+            - skipped
           type: string
         webhook_id:
           type: string
@@ -1216,6 +1227,9 @@ components:
         event_id:
           type: string
         status:
+          enum:
+            - pending
+            - scheduled
           type: string
         webhook_id:
           type: string
@@ -1352,6 +1366,9 @@ components:
         method:
           type: string
         status:
+          enum:
+            - sent
+            - pending_approval
           type: string
       required:
         - status
@@ -1396,9 +1413,7 @@ components:
         suppressions:
           items:
             $ref: "#/components/schemas/Suppression"
-          type:
-            - array
-            - "null"
+          type: array
       required:
         - suppressions
       type: object
@@ -1615,6 +1630,7 @@ components:
           format: int64
           type: integer
         created_at:
+          format: date-time
           type: string
         event_type:
           enum:
@@ -1634,6 +1650,7 @@ components:
         id:
           type: string
         last_attempt_at:
+          format: date-time
           type: string
         last_error:
           type: string
@@ -1641,8 +1658,13 @@ components:
           format: int64
           type: integer
         next_retry_at:
+          format: date-time
           type: string
         status:
+          enum:
+            - pending
+            - delivered
+            - failed
           type: string
       required:
         - id
@@ -1678,8 +1700,10 @@ components:
       additionalProperties: false
       properties:
         auto_disabled_at:
+          format: date-time
           type: string
         created_at:
+          format: date-time
           type: string
         description:
           type: string
@@ -1696,8 +1720,7 @@ components:
         id:
           type: string
         last_delivered_at:
-          type: string
-        previous_secret_expires_at:
+          format: date-time
           type: string
         signing_secret:
           type: string
@@ -2220,12 +2243,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/SendResultView"
           description: OK
-        default:
+        "202":
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorEnvelope"
-          description: Error
+                $ref: "#/components/schemas/SendResultView"
+          description: Accepted — held for human approval (status=pending_approval).
       security:
         - bearer: []
       summary: Send a new email
@@ -2391,12 +2414,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/SendResultView"
           description: OK
-        default:
+        "202":
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorEnvelope"
-          description: Error
+                $ref: "#/components/schemas/SendResultView"
+          description: Accepted — held for human approval (status=pending_approval).
       security:
         - bearer: []
       summary: Forward a message
@@ -2478,12 +2501,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/SendResultView"
           description: OK
-        default:
+        "202":
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorEnvelope"
-          description: Error
+                $ref: "#/components/schemas/SendResultView"
+          description: Accepted — held for human approval (status=pending_approval).
       security:
         - bearer: []
       summary: Reply to a message
@@ -2508,12 +2531,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/SendResultView"
           description: OK
-        default:
+        "202":
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorEnvelope"
-          description: Error
+                $ref: "#/components/schemas/SendResultView"
+          description: Accepted — held for human approval (status=pending_approval).
       security:
         - bearer: []
       summary: Send a test email to the agent's own address
@@ -2555,12 +2578,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/DomainView"
           description: Created
-        default:
+        "409":
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorEnvelope"
-          description: Error
+          description: Conflict — the domain is already claimed by another account (code domain_taken).
       security:
         - bearer: []
       summary: Register a domain
@@ -2664,12 +2687,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/VerifyDomainView"
           description: OK
-        default:
+        "412":
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/ErrorEnvelope"
-          description: Error
+                $ref: "#/components/schemas/VerifyDomainView"
+          description: Precondition Failed — the verification TXT record is not yet published.
       security:
         - bearer: []
       summary: Verify a domain

--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -1670,3 +1670,110 @@ approve/reject and the WebSocket upgrade served under `/v1`.
    poll/registration paths set). Both are minor; left as a tracked follow-up
    because moving the limit past `EnforceMessageSend` on the hot send path
    warrants its own change.
+
+## 12. Post-cutover architect review (2026-06) — findings & hardening
+
+After the consumer port shipped (TS SDK 3.0 #227, Python SDK 3.0 #228, cli/mcp
+#229, web dashboard #230), the `/v1` API + both 3.0 SDKs were reviewed against
+the industry gold standards (**Stripe**, **Svix**, **GitHub**) and the closest
+products (**Resend**, **AgentMail**, Postmark, Mailgun, SendGrid). The redesign
+grades well — it lands on the modern pattern (generated typed base + thin
+hand-written ergonomic layer, uniform error envelope with machine `code`, cursor
+pagination, mint-once idempotency, per-webhook HMAC with a `constructEvent`
+helper, typed error hierarchy, async-first). Two things it does that **none** of
+the surveyed products do: the **byte-equal spec drift gate** (§6) and the
+**structural scope ceiling** (agent creds can't widen authority, §5). The
+enforced **HITL approval-to-send** + the **two-axis trust model** (SPF/DKIM/DMARC
+`auth` verdict × `direction` × `hitl_status`) are a category differentiator.
+
+The review surfaced nine refinements (not foundations). They are tracked here
+with severity, the decision, and where each lands.
+
+### 12.1 Findings & dispositions
+
+**F1 — HIGH (correctness): `MessageView` (detail) must carry `direction` +
+`hitl_status`.** `MessageSummaryView` (list) exposes both, but the full
+`MessageView` drops them, so a client fetching one message loses two of the
+three trust-axis signals — this already forced the web dashboard (#230) to
+thread `direction`/`pending` through query params and breaks a deep-linked
+approve/reject. **Decision:** add both fields to `MessageView`. *Lands:* server
+(`internal/httpapi/messages.go`) + spec regen; SDKs pick it up on oag regen; the
+web query-param workaround can later simplify.
+
+**F2 — MEDIUM (error model): make SDK error mapping genuinely code-first.** Both
+SDKs document keying errors off `error.code`, but only the two idempotency codes
+do; everything else is status-driven, so a *new* semantic code on an unmodeled
+status (e.g. `domain_not_verified` on 400) degrades to a bare `E2AError`.
+**Decision:** add a `code → class` table for the common semantic codes so new
+codes degrade by family, and align the docstring with reality. *Lands:* TS
+`errors.ts` (#227) + Python `errors.py` (#228).
+
+**F3 — MEDIUM (observability): rate-limit headers consistent + in the spec.**
+`RateLimit-Limit/Remaining/Reset` are emitted only on the poll/registration
+subset (the send-path 429 omits them — §11 follow-up #4) and are **absent from
+the OpenAPI spec**. **Decision:** stamp the IETF `RateLimit-*` (+ `Retry-After`)
+headers across all rate-limited responses including the send-path 429, document
+them in the spec, and surface `retry_after`/`reset` on `E2ARateLimitError` in
+both SDKs. *Lands:* server (`ratelimit.go` + spec) + SDK error fields.
+
+**F4 — MEDIUM (DX consistency): uniform list ergonomics.** `.list()` returns a
+cursor `AutoPager` for messages/events but a single-page pager (agents, domains,
+webhooks, suppressions) or even a plain array (Python `conversations.list`) for
+the rest — three mental models for "list." **Decision:** every `.list()` returns
+an `AutoPager` (single-page ones simply terminate after page 1), uniformly
+across TS + Python. *Lands:* TS `client.ts` (#227) + Python `client.py` (#228).
+
+**F5 — MEDIUM (DX / parity, ROADMAP): inbound ergonomics — typed event payloads
++ stripped reply body.** `WebhookEvent.data` is `unknown` in both SDKs and the
+rich `InboundEmail` helper was deferred (S2). Postmark (`StrippedTextReply`) and
+AgentMail (`extracted_text`) both ship a quoted-history-stripped reply body — the
+single highest-value agent ergonomic. **Decision (roadmap):** this is the next
+slice, not a point-fix — (a) the server emits per-event-type payload schemas so
+`WebhookEvent`/`constructEvent` can be generic over `type`, and (b) a
+stripped-reply-body accessor on the inbound message. Tracked as **Slice S2 +
+the `InboundEmail` fast-follow**; not implemented in this hardening pass.
+
+**F6 — LOW-MED (security/robustness): WebSocket.** Auth rides in the URL
+(`?token=<apiKey>`) — a long-lived credential in proxy/referrer logs (carried
+over from legacy); and the Python `WSStream` swallows all exceptions into an
+endless silent reconnect, so a bad URL/credential loops forever at warning level.
+**Decision:** (a) the Python WS stream surfaces a fatal auth/4xx as a typed error
+and stops reconnecting (only transient/network failures reconnect); (b) the
+query-token auth is documented as a known limitation with a planned move to a
+header or short-lived ticket (server change, separate). *Lands:* Python
+`websocket.py` (#228) now; the header/ticket auth is a tracked server follow-up.
+
+**F7 — LOW (contract hygiene).** (a) A stale legacy `Message` schema is
+over-exposed in `components` next to the clean `MessageView`/`MessageSummaryView`;
+(b) `error.details` is typed `any` (varies array-vs-object by source);
+(c) `request_id` lives in both the envelope and the `X-Request-Id` header while
+the SDKs read only the header. **Decision:** remove the leaked `Message` schema
+from the public surface; keep `request_id` canonical in **both** (envelope is the
+contract, header is the convenience) and document that the SDKs read the header;
+leave `details` as open `any` deliberately (it carries heterogeneous
+validation/handler context) but document its two shapes. *Lands:* server/spec.
+
+**F8 — STRATEGIC (versioning).** `/v1` + the drift gate is strong, but there is
+no written evolution policy. **Decision:** **additive-only on `/v1`** — new
+optional fields and new endpoints are non-breaking and ship freely; any field
+**removal/rename or behavioral break is a `/v2` event**. A dated version-pin
+header (Stripe-style) is **deferred to pre-GA** — `/v1` + additive-only is
+sufficient while pre-GA. Recorded here as policy; no code change.
+
+**F9 — STRATEGIC (webhook ecosystem familiarity).** The custom `X-E2A-Signature`
+is correctly Stripe-shaped (`t=,v1=`) and ships `constructEvent` + multi-secret
+verify. The two modern agent-email players (Resend, AgentMail) standardized on
+**Svix** headers (`svix-id/timestamp/signature`). **Decision:** **keep** the
+well-designed custom header (no new dependency, the scheme is already correct);
+**document the Svix equivalence** in the webhook docs so integrators recognize
+the pattern. No adoption of Svix now. Recorded as decision; no code change.
+
+### 12.2 Sequencing
+
+F1, F3, F7 are **server + spec** changes (this hardening pass, mergeable to
+`main` independently of the open SDK PRs). F2, F4, F6 are **SDK-internal** and
+land on the open SDK PR branches (#227/#228). F1's SDK side is mechanical — the
+fields appear once each SDK's `oag` base is regenerated against the updated spec
+(after the server change lands / the SDK branch rebases). F5 is the next slice;
+F8/F9 are recorded decisions. None block the legacy `/api/v1` deletion (8e),
+which remains gated on merging the four consumer PRs.

--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -1709,12 +1709,19 @@ codes degrade by family, and align the docstring with reality. *Lands:* TS
 `errors.ts` (#227) + Python `errors.py` (#228).
 
 **F3 — MEDIUM (observability): rate-limit headers consistent + in the spec.**
-`RateLimit-Limit/Remaining/Reset` are emitted only on the poll/registration
-subset (the send-path 429 omits them — §11 follow-up #4) and are **absent from
-the OpenAPI spec**. **Decision:** stamp the IETF `RateLimit-*` (+ `Retry-After`)
-headers across all rate-limited responses including the send-path 429, document
-them in the spec, and surface `retry_after`/`reset` on `E2ARateLimitError` in
-both SDKs. *Lands:* server (`ratelimit.go` + spec) + SDK error fields.
+`RateLimit-Limit/Remaining/Reset` are emitted on the poll/registration subset
+via the Huma middleware, but the **send-path 429** carries its retry hint in the
+error **`details.retry_after_seconds`** rather than the `Retry-After` *header*
+(Huma error responses can't set headers directly — `checkSendLimit`,
+`outbound.go:314`), and the headers are **absent from the OpenAPI spec**.
+**Decisions:** (a) **SDK fix (done here):** `E2AError`/`E2ARateLimitError` now
+reads `details.retry_after_seconds` as a fallback when the `Retry-After` header
+is absent, so the retry layer honors the send-path limit regardless of
+header-vs-body. (b) **Server follow-up (tracked, §11 #4):** emitting the IETF
+`RateLimit-*` + `Retry-After` *headers* uniformly (incl. the send path) and
+declaring them in the spec is deferred — it requires moving the send limit past
+`EnforceMessageSend` on the hot path and a Huma header-on-error mechanism, which
+warrant their own change. *Lands:* SDK error fields now; server headers tracked.
 
 **F4 — MEDIUM (DX consistency): uniform list ergonomics.** `.list()` returns a
 cursor `AutoPager` for messages/events but a single-page pager (agents, domains,
@@ -1743,15 +1750,18 @@ query-token auth is documented as a known limitation with a planned move to a
 header or short-lived ticket (server change, separate). *Lands:* Python
 `websocket.py` (#228) now; the header/ticket auth is a tracked server follow-up.
 
-**F7 — LOW (contract hygiene).** (a) A stale legacy `Message` schema is
-over-exposed in `components` next to the clean `MessageView`/`MessageSummaryView`;
-(b) `error.details` is typed `any` (varies array-vs-object by source);
-(c) `request_id` lives in both the envelope and the `X-Request-Id` header while
-the SDKs read only the header. **Decision:** remove the leaked `Message` schema
-from the public surface; keep `request_id` canonical in **both** (envelope is the
-contract, header is the convenience) and document that the SDKs read the header;
-leave `details` as open `any` deliberately (it carries heterogeneous
-validation/handler context) but document its two shapes. *Lands:* server/spec.
+**F7 — LOW (contract hygiene).** Investigated; mostly false-positive / docs-only:
+(a) The `Message` schema flagged as a "leak" is **not** a leak — it is the
+`identity.UserExport.messages` shape behind `GET /v1/account/export`
+(`account.go:122`), i.e. the deliberate full-row dump for GDPR-style data
+export (which legitimately includes internal columns like `approval_expires_at`,
+`reviewed_by_user_id`, raw attachments). Kept as-is; removing it would break the
+export contract. (b) `error.details` stays open `any` **deliberately** — it
+carries heterogeneous context (a `[]` of field errors from Huma validation, or
+a handler `{}` like `{retry_after_seconds}`); documented, not narrowed.
+(c) `request_id` is canonical in **both** the envelope and the `X-Request-Id`
+header; the SDKs read the header (the convenience copy) — documented, no change.
+**Net:** no code change; this entry corrects the review's assumption.
 
 **F8 — STRATEGIC (versioning).** `/v1` + the drift gate is strong, but there is
 no written evolution policy. **Decision:** **additive-only on `/v1`** — new

--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -1799,3 +1799,54 @@ unified `main`); F1's SDK pickup (mechanical `oag` regen against the F1 spec onc
 #231 lands and the SDK branches rebase). F5 is the next slice; F8/F9 are recorded
 decisions. None block the legacy `/api/v1` deletion (8e), still gated on merging
 the consumer PRs.
+
+### 12.3 Endpoint-by-endpoint type review (round 2) — TDD'd
+
+A second, deeper pass reviewed every `/v1` endpoint's request/response types
+against the Go handlers + store (not just the spec). It found **four more
+F1-class correctness bugs** (a field declared/required on the wire but
+unpopulated or inconsistent across paths) plus a batch of contract-honesty gaps.
+Every fix was **test-first**: a contract/store test was written and confirmed to
+**fail for the documented reason**, then fixed to green.
+
+**Correctness bugs (all fixed, commit `1a80730`):**
+- **B1** — outbound messages returned `from: ""`: the two outbound INSERTs never
+  wrote the `sender` column. Now persist `sender = agent id` (== email).
+  (`TestOutboundMessageHasSender`.)
+- **B2** — `status` meant the delivery rollup on the detail view but the inbox
+  read-state on the list, so an outbound message's **required** `status` changed
+  on re-fetch. The detail view now reads `InboxStatus` (matching the summary);
+  the rollup stays in `delivery_status`, the HITL state in `hitl_status`.
+  (`TestMessageStatusConsistentAcrossViews`.)
+- **B3** — `EventJSON.data` (a required object) serialized as JSON `null` when a
+  stored envelope's `data` was null/absent. Both list + get now coalesce
+  `nil → {}`. (`TestEventData_NeverNull_GetAndList`.)
+- **B4a** — event `delivery_status` was populated on get but not list; `listEvents`
+  now enriches each event (parity with `getEvent`). (`TestEventDeliveryStatus_*`.)
+- **B4b** — conversation-thread messages dropped `webhook_status`/`webhook_error`
+  the standalone list carries; `GetConversationByID` now `LEFT JOIN`s
+  `webhook_deliveries`. (`TestConversationMessagesCarryWebhookStatus`.)
+
+**Contract-honesty fixes (all fixed, TDD via `spec_review_test.go` + handler tests):**
+- **MED-1/2** — declare the runtime `202` (outbound HITL hold) and `412`
+  (domain verify "TXT not published") responses that Huma omitted, so SDK
+  codegen models them.
+- **MED-3** — duplicate-domain registration now returns **`409 domain_taken`**
+  (was `400`) via a typed `identity.ErrDomainTaken` sentinel.
+- **MED-4** — a **recipient-count cap** (≤ 50 total to+cc+bcc) on
+  send/reply/forward → `400 too_many_recipients`.
+- **MED-5** — added `enum`s on `direction`, `hitl_status`, `SendResultView.status`,
+  `EventJSON.status`, `RedeliverView.status`, `WebhookDeliveryView.status`.
+  (The message-view `status` was deliberately **left open** — it carries the
+  inbox read-state, which includes `""` for outbound, not a closed set.)
+- **MED-6** — list arrays (`items` + the single-page wrappers) are no longer
+  declared nullable; they always emit `[]`, so the spec now matches the runtime.
+- **LOW-1** — removed the vestigial, never-populated
+  `WebhookView.previous_secret_expires_at` (the rotate-secret response keeps it).
+- **LOW-2** — added `format: date-time` to the webhook view timestamps.
+
+**Deliberately not changed** (recorded decisions): `error.details` stays open
+`any`; the `ApproveRequest` `body_text`/`body_html` rename (breaking — left);
+`VerifyDomainView` shape divergence (doc-only); `LimitsView` `0`=zero is the
+documented meaning (no `unlimited` sentinel — consistent with the finite-caps
+policy).

--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -1725,10 +1725,13 @@ warrant their own change. *Lands:* SDK error fields now; server headers tracked.
 
 **F4 — MEDIUM (DX consistency): uniform list ergonomics.** `.list()` returns a
 cursor `AutoPager` for messages/events but a single-page pager (agents, domains,
-webhooks, suppressions) or even a plain array (Python `conversations.list`) for
-the rest — three mental models for "list." **Decision:** every `.list()` returns
-an `AutoPager` (single-page ones simply terminate after page 1), uniformly
-across TS + Python. *Lands:* TS `client.ts` (#227) + Python `client.py` (#228).
+webhooks, suppressions) or a plain array (`conversations.list`) for the rest —
+three mental models for "list." **Decision:** every `.list()` returns an
+`AutoPager` (single-page ones terminate after page 1). **Deferred to post-merge:**
+this changes `conversations.list`'s return type, which **ripples to the cli/mcp
+consumers (#229)** — a SDK-only change would break their build. Best done as a
+small lockstep change (SDK + cli + mcp) once #227/#228/#229 are unified on
+`main`. Tracked, not in this pass.
 
 **F5 — MEDIUM (DX / parity, ROADMAP): inbound ergonomics — typed event payloads
 + stripped reply body.** `WebhookEvent.data` is `unknown` in both SDKs and the
@@ -1780,10 +1783,19 @@ the pattern. No adoption of Svix now. Recorded as decision; no code change.
 
 ### 12.2 Sequencing
 
-F1, F3, F7 are **server + spec** changes (this hardening pass, mergeable to
-`main` independently of the open SDK PRs). F2, F4, F6 are **SDK-internal** and
-land on the open SDK PR branches (#227/#228). F1's SDK side is mechanical — the
-fields appear once each SDK's `oag` base is regenerated against the updated spec
-(after the server change lands / the SDK branch rebases). F5 is the next slice;
-F8/F9 are recorded decisions. None block the legacy `/api/v1` deletion (8e),
-which remains gated on merging the four consumer PRs.
+**Server + spec (this hardening pass, PR #231, mergeable independently):** F1
+(done), F7 (doc reconciliation), F3 server-side (tracked §11 #4).
+
+**SDK-internal, land now on the open SDK branches (#227 TS / #228 Python):** F2
+(code-first error mapping, additively — preserve existing status→class results),
+F3-SDK (`E2AError` reads `details.retry_after_seconds` as a `Retry-After`
+fallback), F6 (Python `WSStream` surfaces a fatal auth/4xx as a typed error and
+stops the reconnect loop; both SDKs document the `?token=` query-auth
+limitation).
+
+**Deferred to post-merge (cross-branch / spec-dependent):** F4 (uniform
+`AutoPager` — ripples to #229 cli/mcp consumers; do as a lockstep change on a
+unified `main`); F1's SDK pickup (mechanical `oag` regen against the F1 spec once
+#231 lands and the SDK branches rebase). F5 is the next slice; F8/F9 are recorded
+decisions. None block the legacy `/api/v1` deletion (8e), still gated on merging
+the consumer PRs.

--- a/internal/agent/events_api.go
+++ b/internal/agent/events_api.go
@@ -39,7 +39,7 @@ type eventJSON struct {
 	AgentID        *string                `json:"agent_id,omitempty"`
 	ConversationID *string                `json:"conversation_id,omitempty"`
 	MessageID      *string                `json:"message_id,omitempty"`
-	Status         string                 `json:"status"`
+	Status         string                 `json:"status" enum:"pending,processed,no_match"`
 	Data           map[string]interface{} `json:"data"`
 	DeliveryStatus *deliveryStatusJSON    `json:"delivery_status,omitempty"`
 }

--- a/internal/agent/events_api.go
+++ b/internal/agent/events_api.go
@@ -125,14 +125,31 @@ func listEvents(ctx context.Context, pool *pgxpool.Pool, userID, eventType, agen
 		var env struct {
 			Data map[string]interface{} `json:"data"`
 		}
-		if err := json.Unmarshal(envelopeRaw, &env); err != nil {
-			// Tolerate older envelope shapes — return empty data.
+		// Tolerate older/malformed envelopes AND a valid envelope whose `data`
+		// is null/absent — `data` is a required object on the wire, so it must
+		// never serialize as JSON null (B3).
+		if err := json.Unmarshal(envelopeRaw, &env); err != nil || env.Data == nil {
 			env.Data = map[string]interface{}{}
 		}
 		ej.Data = env.Data
 		out = append(out, ej)
 	}
-	return out, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	rows.Close()
+	// Surface delivery_status on the list too, matching getEvent — otherwise the
+	// same event has a roll-up by id but not in the list (B4a). Bounded by the
+	// page limit; a single GROUP-BY batch is a possible perf follow-up.
+	for i := range out {
+		ds, derr := loadDeliveryStatus(ctx, pool, out[i].ID)
+		if derr != nil {
+			log.Printf("[events] loadDeliveryStatus(list): %v", derr)
+			continue
+		}
+		out[i].DeliveryStatus = ds
+	}
+	return out, nil
 }
 
 var (
@@ -170,8 +187,8 @@ func getEvent(ctx context.Context, pool *pgxpool.Pool, userID, eventID string) (
 	var env struct {
 		Data map[string]interface{} `json:"data"`
 	}
-	if err := json.Unmarshal(envelopeRaw, &env); err != nil {
-		env.Data = map[string]interface{}{}
+	if err := json.Unmarshal(envelopeRaw, &env); err != nil || env.Data == nil {
+		env.Data = map[string]interface{}{} // never serialize required `data` as null (B3)
 	}
 	ej.Data = env.Data
 

--- a/internal/agent/events_data_test.go
+++ b/internal/agent/events_data_test.go
@@ -1,0 +1,65 @@
+package agent_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Mnexa-AI/e2a/internal/agent"
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+)
+
+// B3 (review correctness bug): EventJSON.data is `required` + `type: object` in
+// the spec, but a stored envelope whose `data` is JSON null (or absent) parses
+// successfully with a nil map, so the response serializes `"data": null` —
+// violating the contract and breaking strict SDK deserializers. Drive the real
+// read paths (the exported wrappers the /v1 handlers use) against a seeded
+// null-data event.
+func TestEventData_NeverNull_GetAndList(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	store := identity.NewStore(pool)
+
+	user, err := store.CreateOrGetUser(ctx, "ev-null@example.com", "Owner", "g-ev-null")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	eventID := "evt_b3_null"
+	// A valid envelope whose `data` is explicitly null — unmarshals fine, so the
+	// "tolerate malformed" branch does NOT fire; env.Data stays nil.
+	_, err = pool.Exec(ctx,
+		`INSERT INTO webhook_events
+		   (id, user_id, type, aud, envelope, schema_version, status)
+		 VALUES ($1, $2, 'email.received', 'webhook', $3, 1, 'pending')`,
+		eventID, user.ID, []byte(`{"type":"email.received","data":null}`),
+	)
+	if err != nil {
+		t.Fatalf("seed webhook_events: %v", err)
+	}
+
+	ev, err := agent.GetEventForUser(ctx, pool, user.ID, eventID)
+	if err != nil {
+		t.Fatalf("GetEventForUser: %v", err)
+	}
+	if ev.Data == nil {
+		t.Errorf("getEvent: Data is nil → serializes as JSON `null`, violating required `data: object`")
+	}
+
+	evs, err := agent.ListEventsForUser(ctx, pool, user.ID, "", "", "", "", nil, nil, time.Time{}, "", 50)
+	if err != nil {
+		t.Fatalf("ListEventsForUser: %v", err)
+	}
+	var found bool
+	for i := range evs {
+		if evs[i].ID == eventID {
+			found = true
+			if evs[i].Data == nil {
+				t.Errorf("listEvents: Data is nil → serializes as JSON `null`, violating required `data: object`")
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("seeded event %s not returned by listEvents", eventID)
+	}
+}

--- a/internal/agent/events_delivery_status_test.go
+++ b/internal/agent/events_delivery_status_test.go
@@ -1,0 +1,70 @@
+package agent_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/Mnexa-AI/e2a/internal/agent"
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+)
+
+// B4a (review correctness bug): EventJSON.delivery_status is populated by
+// getEvent (which calls loadDeliveryStatus) but NOT by listEvents — so the same
+// event has a delivery roll-up when fetched by id and silently lacks it in the
+// list. This test seeds a delivered subscriber-delivery and expects both paths
+// to surface it.
+func TestEventDeliveryStatus_PopulatedOnListAndGet(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	store := identity.NewStore(pool)
+
+	user, err := store.CreateOrGetUser(ctx, "ev-ds@example.com", "Owner", "g-ev-ds")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	wh, err := store.CreateWebhook(ctx, user.ID, "https://example.com/hook", "", []string{"email.received"}, identity.WebhookFilters{})
+	if err != nil {
+		t.Fatalf("CreateWebhook: %v", err)
+	}
+	eventID := "evt_b4a_ds"
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO webhook_events (id, user_id, type, aud, envelope, schema_version, status)
+		 VALUES ($1, $2, 'email.received', 'webhook', $3, 1, 'processed')`,
+		eventID, user.ID, []byte(`{"type":"email.received","data":{}}`),
+	); err != nil {
+		t.Fatalf("seed webhook_events: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO webhook_subscriber_deliveries (id, webhook_id, event_type, event_payload, status, next_retry_at, event_id)
+		 VALUES ($1, $2, 'email.received', '{}', 'delivered', now(), $3)`,
+		"wsd_b4a", wh.ID, eventID,
+	); err != nil {
+		t.Fatalf("seed webhook_subscriber_deliveries: %v", err)
+	}
+
+	// Control: getEvent surfaces the delivery roll-up.
+	ev, err := agent.GetEventForUser(ctx, pool, user.ID, eventID)
+	if err != nil {
+		t.Fatalf("GetEventForUser: %v", err)
+	}
+	if ev.DeliveryStatus == nil {
+		t.Fatalf("setup check: getEvent delivery_status is nil; want populated")
+	}
+
+	// The list must surface it too (same object, same field).
+	evs, err := agent.ListEventsForUser(ctx, pool, user.ID, "", "", "", "", nil, nil, time.Time{}, "", 50)
+	if err != nil {
+		t.Fatalf("ListEventsForUser: %v", err)
+	}
+	for i := range evs {
+		if evs[i].ID == eventID {
+			if evs[i].DeliveryStatus == nil {
+				t.Errorf("listEvents delivery_status is nil for %s, but getEvent populated it — inconsistent across paths", eventID)
+			}
+			return
+		}
+	}
+	t.Fatalf("seeded event %s not returned by listEvents", eventID)
+}

--- a/internal/httpapi/account.go
+++ b/internal/httpapi/account.go
@@ -72,7 +72,7 @@ func (s *Server) registerAccount() {
 
 type suppressionsOutput struct {
 	Body struct {
-		Suppressions []identity.Suppression `json:"suppressions"`
+		Suppressions []identity.Suppression `json:"suppressions" nullable:"false"`
 	}
 }
 

--- a/internal/httpapi/domains.go
+++ b/internal/httpapi/domains.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"reflect"
 	"strings"
 	"time"
 
@@ -124,7 +125,7 @@ type VerifyDomainView struct {
 
 type listDomainsOutput struct {
 	Body struct {
-		Domains []DomainView `json:"domains"`
+		Domains []DomainView `json:"domains" nullable:"false"`
 	}
 }
 type domainOutput struct{ Body DomainView }
@@ -153,6 +154,10 @@ func (s *Server) registerDomains() {
 		OperationID: "registerDomain", Method: http.MethodPost, Path: "/v1/domains",
 		Summary: "Register a domain", Tags: []string{"domains"},
 		Security: []map[string][]string{{"bearer": {}}}, DefaultStatus: http.StatusCreated,
+		Responses: map[string]*huma.Response{
+			"409": s.jsonResponse(reflect.TypeOf(ErrorEnvelope{}), "ErrorEnvelope",
+				"Conflict — the domain is already claimed by another account (code domain_taken)."),
+		},
 	}, s.handleRegisterDomain)
 
 	huma.Register(s.API, huma.Operation{
@@ -172,6 +177,10 @@ func (s *Server) registerDomains() {
 		Summary: "Verify a domain", Tags: []string{"domains"},
 		Description: "Probe the domain's published DNS and, when the verification TXT is present, mark it verified. Returns the per-record diagnostic; a missing TXT yields 412.",
 		Security:    []map[string][]string{{"bearer": {}}},
+		Responses: map[string]*huma.Response{
+			"412": s.jsonResponse(reflect.TypeOf(VerifyDomainView{}), "VerifyDomainView",
+				"Precondition Failed — the verification TXT record is not yet published."),
+		},
 	}, s.handleVerifyDomain)
 }
 
@@ -293,7 +302,13 @@ func (s *Server) handleRegisterDomain(ctx context.Context, in *registerDomainInp
 		}
 	}
 	d, err := s.deps.ClaimDomain(ctx, normalized, user.ID)
-	if err != nil || d == nil {
+	if err != nil {
+		if errors.Is(err, identity.ErrDomainTaken) {
+			return nil, NewError(http.StatusConflict, "domain_taken", "domain is already claimed by another account")
+		}
+		return nil, NewError(http.StatusBadRequest, "domain_unavailable", "failed to register domain")
+	}
+	if d == nil {
 		return nil, NewError(http.StatusBadRequest, "domain_unavailable", "failed to register domain")
 	}
 	return &domainCreateOutput{Body: s.domainView(d)}, nil

--- a/internal/httpapi/domains_conflict_test.go
+++ b/internal/httpapi/domains_conflict_test.go
@@ -1,0 +1,17 @@
+package httpapi
+
+import (
+	"testing"
+)
+
+// MED-3 — registering a domain another user already owns must surface as 409
+// conflict (code domain_taken), not the 400 domain_unavailable used for
+// malformed/other claim failures. The testServer ClaimDomain mock returns
+// identity.ErrDomainTaken for "taken.com".
+func TestRegisterDomainTakenConflict(t *testing.T) {
+	srv := testServer(t)
+	code, body := postJSON(t, srv.URL+"/v1/domains", "good", map[string]any{"domain": "taken.com"})
+	if code != 409 || errCode(body) != "domain_taken" {
+		t.Fatalf("want 409 domain_taken, got %d %v", code, body)
+	}
+}

--- a/internal/httpapi/events.go
+++ b/internal/httpapi/events.go
@@ -73,18 +73,22 @@ func (s *Server) registerEvents() {
 
 // RedeliverView mirrors the legacy redeliverResponse.
 type RedeliverView struct {
-	DeliveryID string              `json:"delivery_id,omitempty"`
-	EventID    string              `json:"event_id"`
-	WebhookID  string              `json:"webhook_id,omitempty"`
-	Status     string              `json:"status"`
+	DeliveryID string `json:"delivery_id,omitempty"`
+	EventID    string `json:"event_id"`
+	WebhookID  string `json:"webhook_id,omitempty"`
+	// Status is "pending" for a single-webhook replay (one scheduled delivery)
+	// or "scheduled" for a bulk fan-out (see Deliveries for per-subscriber state).
+	Status     string              `json:"status" enum:"pending,scheduled"`
 	Deliveries []RedeliverDelivery `json:"deliveries,omitempty"`
 }
 
 type RedeliverDelivery struct {
 	WebhookID  string `json:"webhook_id"`
 	DeliveryID string `json:"delivery_id,omitempty"`
-	Status     string `json:"status"`
-	Reason     string `json:"reason,omitempty"`
+	// Status is "pending" when the replay was scheduled, or "skipped" when this
+	// subscriber's delivery could not be enqueued (see Reason).
+	Status string `json:"status" enum:"pending,skipped"`
+	Reason string `json:"reason,omitempty"`
 }
 
 type RedeliverEventInput struct {

--- a/internal/httpapi/messages.go
+++ b/internal/httpapi/messages.go
@@ -32,13 +32,13 @@ type MessageView struct {
 	ConversationID string   `json:"conversation_id"`
 	// Direction (inbound|outbound) — mirrors MessageSummaryView so a client
 	// fetching a single message keeps the full trust-axis context (review F1).
-	Direction string `json:"direction"`
+	Direction string `json:"direction" enum:"inbound,outbound"`
 	Status    string `json:"status"`
 	// HITLStatus is the human-in-the-loop lifecycle (e.g. pending_approval) —
 	// outbound only, mirroring MessageSummaryView. Distinct from `status`
 	// (the delivery rollup) so a held draft is identifiable on the detail view
-	// without re-deriving it (review F1).
-	HITLStatus string `json:"hitl_status,omitempty"`
+	// without re-deriving it (review F1). Closed set = migration 003 CHECK.
+	HITLStatus string `json:"hitl_status,omitempty" enum:"pending_approval,sent,rejected,expired_approved,expired_rejected"`
 	// DeliveryStatus is the outbound delivery rollup (migration 031:
 	// 'sent', 'delivered', 'bounced', …) — the worst recipient status by
 	// precedence. Outbound-only; omitted on inbound messages.
@@ -158,7 +158,7 @@ type messageOutput struct {
 // deleted at the 1Z cutover.
 type MessageSummaryView struct {
 	ID             string   `json:"message_id"`
-	Direction      string   `json:"direction"`
+	Direction      string   `json:"direction" enum:"inbound,outbound"`
 	From           string   `json:"from"`
 	To             []string `json:"to"`
 	CC             []string `json:"cc,omitempty"`
@@ -167,7 +167,7 @@ type MessageSummaryView struct {
 	Subject        string   `json:"subject"`
 	ConversationID string   `json:"conversation_id,omitempty"`
 	Status         string   `json:"status"`
-	HITLStatus     string   `json:"hitl_status,omitempty"`
+	HITLStatus     string   `json:"hitl_status,omitempty" enum:"pending_approval,sent,rejected,expired_approved,expired_rejected"`
 	WebhookStatus  string   `json:"webhook_status,omitempty"`
 	WebhookError   string   `json:"webhook_error,omitempty"`
 	// DeliveryStatus / DeliveryDetail / SentAs are the outbound delivery

--- a/internal/httpapi/messages.go
+++ b/internal/httpapi/messages.go
@@ -99,8 +99,13 @@ func messageViewFromIdentity(m *identity.Message) MessageView {
 		Subject:        m.Subject,
 		ConversationID: m.ConversationID,
 		Direction:      m.Direction,
-		Status:         m.DeliveryStatus,
-		Labels:         orEmptyStrings(m.Labels),
+		// `status` is the inbox read-state, identical to the summary view (B2);
+		// the outbound delivery rollup lives in `delivery_status`, the HITL
+		// lifecycle in `hitl_status`. (The store resolves m.DeliveryStatus to
+		// inbox_status for inbound and the rollup for outbound, so the detail
+		// view must read InboxStatus to agree with the summary.)
+		Status: m.InboxStatus,
+		Labels: orEmptyStrings(m.Labels),
 		CreatedAt:      m.CreatedAt.UTC().Format(time.RFC3339),
 		AuthHeaders:    m.AuthHeaders,
 		Auth:           m.Auth,

--- a/internal/httpapi/messages.go
+++ b/internal/httpapi/messages.go
@@ -30,7 +30,15 @@ type MessageView struct {
 	Recipient      string   `json:"recipient"`
 	Subject        string   `json:"subject"`
 	ConversationID string   `json:"conversation_id"`
-	Status         string   `json:"status"`
+	// Direction (inbound|outbound) — mirrors MessageSummaryView so a client
+	// fetching a single message keeps the full trust-axis context (review F1).
+	Direction string `json:"direction"`
+	Status    string `json:"status"`
+	// HITLStatus is the human-in-the-loop lifecycle (e.g. pending_approval) —
+	// outbound only, mirroring MessageSummaryView. Distinct from `status`
+	// (the delivery rollup) so a held draft is identifiable on the detail view
+	// without re-deriving it (review F1).
+	HITLStatus string `json:"hitl_status,omitempty"`
 	// DeliveryStatus is the outbound delivery rollup (migration 031:
 	// 'sent', 'delivered', 'bounced', …) — the worst recipient status by
 	// precedence. Outbound-only; omitted on inbound messages.
@@ -90,6 +98,7 @@ func messageViewFromIdentity(m *identity.Message) MessageView {
 		Recipient:      m.Recipient,
 		Subject:        m.Subject,
 		ConversationID: m.ConversationID,
+		Direction:      m.Direction,
 		Status:         m.DeliveryStatus,
 		Labels:         orEmptyStrings(m.Labels),
 		CreatedAt:      m.CreatedAt.UTC().Format(time.RFC3339),
@@ -106,6 +115,9 @@ func messageViewFromIdentity(m *identity.Message) MessageView {
 		v.DeliveryStatus = m.DeliveryStatus
 		v.DeliveryDetail = m.DeliveryDetail
 		v.SentAs = m.SentAs
+		// HITL lifecycle (status column) — outbound only, mirroring the summary
+		// view; on inbound rows `status` is not the HITL value (review F1).
+		v.HITLStatus = m.Status
 	}
 	// Parsed view (decision 9): inbound-only, derived from the raw message.
 	if m.Direction == "inbound" && len(m.RawMessage) > 0 {

--- a/internal/httpapi/messages_status_consistency_test.go
+++ b/internal/httpapi/messages_status_consistency_test.go
@@ -1,0 +1,53 @@
+package httpapi
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+)
+
+// B2 (review correctness bug): the `status` field must mean the same thing on
+// the list (MessageSummaryView) and detail (MessageView) for the SAME message.
+// Today the summary sets status=inbox_status while the detail sets
+// status=delivery_status, so an outbound message reports a different `status`
+// depending on which endpoint you hit — a required field that changes value on
+// re-fetch. This test pins them to agree.
+func TestMessageStatusConsistentAcrossViews_Outbound(t *testing.T) {
+	// An outbound message: inbox_status is never written for outbound rows (""),
+	// the delivery rollup is "sent", and the HITL lifecycle is "sent".
+	m := identity.Message{
+		ID:             "msg_b2",
+		Direction:      "outbound",
+		InboxStatus:    "",
+		DeliveryStatus: "sent",
+		Status:         "sent",
+		CreatedAt:      time.Unix(1700000000, 0).UTC(),
+	}
+	summary := messageSummaryFromIdentity(m)
+	detail := messageViewFromIdentity(&m)
+	if summary.Status != detail.Status {
+		t.Errorf(
+			"status differs across views for the same outbound message: summary=%q detail=%q; "+
+				"`status` must be identical on list and detail",
+			summary.Status, detail.Status,
+		)
+	}
+}
+
+// Inbound is already consistent (the store resolves DeliveryStatus=InboxStatus
+// for inbound rows) — this is a guard that the B2 fix doesn't break it.
+func TestMessageStatusConsistentAcrossViews_Inbound(t *testing.T) {
+	m := identity.Message{
+		ID:             "msg_b2_in",
+		Direction:      "inbound",
+		InboxStatus:    "unread",
+		DeliveryStatus: "unread", // store sets DeliveryStatus = InboxStatus for inbound
+		CreatedAt:      time.Unix(1700000000, 0).UTC(),
+	}
+	summary := messageSummaryFromIdentity(m)
+	detail := messageViewFromIdentity(&m)
+	if summary.Status != detail.Status {
+		t.Errorf("inbound status differs: summary=%q detail=%q", summary.Status, detail.Status)
+	}
+}

--- a/internal/httpapi/operations.go
+++ b/internal/httpapi/operations.go
@@ -88,7 +88,7 @@ func agentViewFromIdentity(ag *identity.AgentIdentity) AgentView {
 
 type listAgentsOutput struct {
 	Body struct {
-		Agents []AgentView `json:"agents"`
+		Agents []AgentView `json:"agents" nullable:"false"`
 	}
 }
 

--- a/internal/httpapi/operations_test.go
+++ b/internal/httpapi/operations_test.go
@@ -115,13 +115,17 @@ func testServer(t *testing.T) *httptest.Server {
 			if agentID == "support@acme.com" && messageID == "msg_1" {
 				return &identity.Message{
 					ID:             "msg_1",
+					Direction:      "inbound",
 					Sender:         "alice@example.com",
 					ToRecipients:   []string{"support@acme.com"},
 					Recipient:      "support@acme.com",
 					Subject:        "Help",
 					ConversationID: "conv_1",
-					DeliveryStatus: "unread",
-					CreatedAt:      time.Unix(1700000000, 0).UTC(),
+					// Real inbound rows carry the read-state in inbox_status; the
+					// store mirrors it into DeliveryStatus for inbound. `status`
+					// on the detail view is the inbox read-state (B2).
+					InboxStatus: "unread",
+					CreatedAt:   time.Unix(1700000000, 0).UTC(),
 					AuthHeaders:    map[string]string{"spf": "pass"},
 					RawMessage:     []byte("raw"),
 				}, nil

--- a/internal/httpapi/operations_test.go
+++ b/internal/httpapi/operations_test.go
@@ -151,6 +151,9 @@ func testServer(t *testing.T) *httptest.Server {
 			return []identity.Domain{{Domain: "acme.com", Verified: true, VerificationToken: "e2a-verify=tok", IsPrimary: true, AgentCount: 2}}, nil
 		},
 		ClaimDomain: func(ctx context.Context, domain, userID string) (*identity.Domain, error) {
+			if domain == "taken.com" {
+				return nil, identity.ErrDomainTaken
+			}
 			return &identity.Domain{Domain: domain, Verified: false, VerificationToken: "e2a-verify=new"}, nil
 		},
 		EnforceDomainCreate: func(ctx context.Context, userID string) error {

--- a/internal/httpapi/outbound.go
+++ b/internal/httpapi/outbound.go
@@ -3,6 +3,7 @@ package httpapi
 import (
 	"context"
 	"net/http"
+	"reflect"
 	"strings"
 	"time"
 
@@ -12,11 +13,27 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 )
 
+// jsonResponse builds an extra OpenAPI response entry for an operation whose
+// handler can return a non-default status with the given body schema. The
+// schema is registered (and reused via $ref) in the API's component registry,
+// so the declared response stays in lockstep with the Go type — no hand-edits
+// to api/openapi.yaml. Used to document the 202 (HITL hold) / 412 / 409 codes
+// the typed handlers emit but Huma can't infer from the single DefaultStatus.
+func (s *Server) jsonResponse(bodyType reflect.Type, schemaName, description string) *huma.Response {
+	schema := s.API.OpenAPI().Components.Schemas.Schema(bodyType, true, schemaName)
+	return &huma.Response{
+		Description: description,
+		Content: map[string]*huma.MediaType{
+			"application/json": {Schema: schema},
+		},
+	}
+}
+
 // SendResultView is the unified outbound response: {status, message_id,
 // method} for an immediate send/loopback, or {status:"pending_approval",
 // message_id, approval_expires_at} (202) when held for HITL approval.
 type SendResultView struct {
-	Status            string     `json:"status"`
+	Status            string     `json:"status" enum:"sent,pending_approval"`
 	MessageID         string     `json:"message_id"`
 	Method            string     `json:"method,omitempty"`
 	ApprovalExpiresAt *time.Time `json:"approval_expires_at,omitempty"`
@@ -26,6 +43,27 @@ type SendResultView struct {
 // matches the legacy 25 MB limit so attachments keep working — Huma's default
 // is only 1 MiB, which would silently reject anything but tiny mail.
 const maxOutboundBytes = 25 * 1024 * 1024
+
+// maxRecipients caps the combined to+cc+bcc fan-out of a single outbound
+// message. A body-size ceiling alone doesn't bound recipient count, so a tiny
+// body could still address thousands of addresses; this keeps a single send
+// from becoming a blast. Over the cap is a 400 too_many_recipients.
+const maxRecipients = 50
+
+// recipientCountError returns a too_many_recipients envelope when the combined
+// to+cc+bcc count exceeds maxRecipients, else nil.
+func recipientCountError(groups ...[]string) *ErrorEnvelope {
+	total := 0
+	for _, g := range groups {
+		total += len(g)
+	}
+	if total > maxRecipients {
+		return NewError(http.StatusBadRequest, "too_many_recipients",
+			"too many recipients — at most 50 across to, cc and bcc combined").
+			WithDetails(map[string]any{"max_recipients": maxRecipients, "provided": total})
+	}
+	return nil
+}
 
 // SendEmailRequest mirrors the legacy /send body.
 type SendEmailRequest struct {
@@ -53,12 +91,21 @@ type sendOutput struct {
 }
 
 func (s *Server) registerOutbound() {
+	// 202 Accepted is the HITL-hold outcome of every outbound op: the message
+	// is queued as a pending_approval draft rather than sent. Declared
+	// explicitly because Huma infers only the single DefaultStatus (200).
+	held202 := func() *huma.Response {
+		return s.jsonResponse(reflect.TypeOf(SendResultView{}), "SendResultView",
+			"Accepted — held for human approval (status=pending_approval).")
+	}
+
 	huma.Register(s.API, huma.Operation{
 		OperationID: "sendMessage", Method: http.MethodPost, Path: "/v1/agents/{address}/messages",
 		Summary: "Send a new email", Tags: []string{"messages"},
 		Description:  "Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_approval when the agent has HITL enabled. Honors Idempotency-Key.",
 		Security:     []map[string][]string{{"bearer": {}}},
 		MaxBodyBytes: maxOutboundBytes,
+		Responses:    map[string]*huma.Response{"202": held202()},
 	}, s.handleCreateMessage)
 
 	huma.Register(s.API, huma.Operation{
@@ -67,6 +114,7 @@ func (s *Server) registerOutbound() {
 		Description:  "Reply to an inbound message; recipients/threading are derived from the original. 202 when held for HITL.",
 		Security:     []map[string][]string{{"bearer": {}}},
 		MaxBodyBytes: maxOutboundBytes,
+		Responses:    map[string]*huma.Response{"202": held202()},
 	}, s.handleReply)
 
 	huma.Register(s.API, huma.Operation{
@@ -75,6 +123,7 @@ func (s *Server) registerOutbound() {
 		Description:  "Forward an inbound message to new recipients; the original is quoted. 202 when held for HITL.",
 		Security:     []map[string][]string{{"bearer": {}}},
 		MaxBodyBytes: maxOutboundBytes,
+		Responses:    map[string]*huma.Response{"202": held202()},
 	}, s.handleForward)
 
 	huma.Register(s.API, huma.Operation{
@@ -82,6 +131,7 @@ func (s *Server) registerOutbound() {
 		Summary: "Send a test email to the agent's own address", Tags: []string{"agents"},
 		Description: "Send a platform test email to the agent's own address to confirm inbound delivery. 202 when held for HITL.",
 		Security:    []map[string][]string{{"bearer": {}}},
+		Responses:   map[string]*huma.Response{"202": held202()},
 	}, s.handleTestSend)
 }
 
@@ -172,6 +222,9 @@ func (s *Server) handleReply(ctx context.Context, in *replyInput) (*sendOutput, 
 	}
 	// Validate only the user-supplied CC/BCC; the implicit To comes from the
 	// (already-validated) inbound message — mirrors the legacy handler.
+	if env := recipientCountError(b.CC, b.BCC); env != nil {
+		return nil, env
+	}
 	if e := agent.ValidateRecipients(b.CC, b.BCC); e != nil {
 		return nil, NewError(http.StatusBadRequest, "invalid_recipient", e.Error())
 	}
@@ -233,6 +286,9 @@ func (s *Server) handleForward(ctx context.Context, in *forwardInput) (*sendOutp
 	if len(b.To) == 0 && len(b.CC) == 0 {
 		return nil, NewError(http.StatusBadRequest, "invalid_request", "at least one recipient in to or cc is required")
 	}
+	if env := recipientCountError(b.To, b.CC, b.BCC); env != nil {
+		return nil, env
+	}
 	if e := agent.ValidateRecipients(b.To, b.CC, b.BCC); e != nil {
 		return nil, NewError(http.StatusBadRequest, "invalid_recipient", e.Error())
 	}
@@ -265,6 +321,9 @@ func (s *Server) validateOutboundBody(subject, body string, to, cc, bcc []string
 	}
 	if len(to) == 0 && len(cc) == 0 {
 		return NewError(http.StatusBadRequest, "invalid_request", "at least one recipient in to or cc is required")
+	}
+	if env := recipientCountError(to, cc, bcc); env != nil {
+		return env
 	}
 	if err := agent.ValidateRecipients(to, cc, bcc); err != nil {
 		return NewError(http.StatusBadRequest, "invalid_recipient", err.Error())

--- a/internal/httpapi/outbound_recipient_cap_test.go
+++ b/internal/httpapi/outbound_recipient_cap_test.go
@@ -1,0 +1,79 @@
+package httpapi
+
+import (
+	"fmt"
+	"testing"
+)
+
+// MED-4 — a send whose total to+cc+bcc recipient count exceeds the cap (50)
+// must be rejected with 400 too_many_recipients before any delivery.
+func TestSendTooManyRecipients(t *testing.T) {
+	srv := testServer(t)
+	to := make([]string, 51)
+	for i := range to {
+		to[i] = fmt.Sprintf("r%d@x.com", i)
+	}
+	code, body := postJSON(t, srv.URL+sendURL, "good", map[string]any{
+		"to": to, "subject": "Hi", "body": "hello",
+	})
+	if code != 400 || errCode(body) != "too_many_recipients" {
+		t.Fatalf("want 400 too_many_recipients, got %d %v", code, body)
+	}
+}
+
+// The cap counts to+cc+bcc together, so 50 split across the three fields must
+// pass and 51 split across them must fail.
+func TestSendRecipientCapCountsAllFields(t *testing.T) {
+	srv := testServer(t)
+	mk := func(prefix string, n int) []string {
+		out := make([]string, n)
+		for i := range out {
+			out[i] = fmt.Sprintf("%s%d@x.com", prefix, i)
+		}
+		return out
+	}
+	// 20 + 20 + 11 = 51 -> over the cap.
+	code, body := postJSON(t, srv.URL+sendURL, "good", map[string]any{
+		"to": mk("t", 20), "cc": mk("c", 20), "bcc": mk("b", 11), "subject": "Hi", "body": "hello",
+	})
+	if code != 400 || errCode(body) != "too_many_recipients" {
+		t.Fatalf("split over cap: want 400 too_many_recipients, got %d %v", code, body)
+	}
+	// 20 + 20 + 10 = 50 -> at the cap, allowed (subject HOLD avoided -> sent).
+	code, _ = postJSON(t, srv.URL+sendURL, "good", map[string]any{
+		"to": mk("t", 20), "cc": mk("c", 20), "bcc": mk("b", 10), "subject": "Hi", "body": "hello",
+	})
+	if code != 200 {
+		t.Fatalf("at cap: want 200, got %d", code)
+	}
+}
+
+// The forward validator must enforce the same cap.
+func TestForwardTooManyRecipients(t *testing.T) {
+	srv := testServer(t)
+	to := make([]string, 51)
+	for i := range to {
+		to[i] = fmt.Sprintf("r%d@x.com", i)
+	}
+	code, body := postJSON(t, srv.URL+"/v1/agents/support%40acme.com/messages/msg_in1/forward", "good", map[string]any{
+		"to": to, "body": "fwd",
+	})
+	if code != 400 || errCode(body) != "too_many_recipients" {
+		t.Fatalf("forward: want 400 too_many_recipients, got %d %v", code, body)
+	}
+}
+
+// The reply validator must enforce the same cap on user-supplied cc+bcc.
+func TestReplyTooManyRecipients(t *testing.T) {
+	srv := testServer(t)
+	cc := make([]string, 51)
+	for i := range cc {
+		cc[i] = fmt.Sprintf("r%d@x.com", i)
+	}
+	code, body := postJSON(t, srv.URL+"/v1/agents/support%40acme.com/messages/msg_in1/reply", "good", map[string]any{
+		"body": "re", "cc": cc,
+	})
+	if code != 400 || errCode(body) != "too_many_recipients" {
+		t.Fatalf("reply: want 400 too_many_recipients, got %d %v", code, body)
+	}
+}

--- a/internal/httpapi/pagination.go
+++ b/internal/httpapi/pagination.go
@@ -15,7 +15,7 @@ import (
 // It is generic over the item view type so each resource reuses the same
 // envelope without redefining it.
 type Page[T any] struct {
-	Items      []T     `json:"items"`
+	Items      []T     `json:"items" nullable:"false"`
 	NextCursor *string `json:"next_cursor"`
 }
 

--- a/internal/httpapi/spec_review_test.go
+++ b/internal/httpapi/spec_review_test.go
@@ -1,0 +1,252 @@
+package httpapi
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// renderSpec renders the live OpenAPI document and unmarshals it into a generic
+// map so the review-hardening contract tests can assert on operations + schemas
+// without a typed OpenAPI model.
+func renderSpec(t *testing.T) map[string]any {
+	t.Helper()
+	y, err := New(Deps{}).OpenAPIYAML()
+	if err != nil {
+		t.Fatalf("render spec: %v", err)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(y, &doc); err != nil {
+		t.Fatalf("unmarshal spec: %v", err)
+	}
+	return doc
+}
+
+// operationResponses finds the operation with the given operationId anywhere in
+// paths and returns its responses map.
+func operationResponses(t *testing.T, doc map[string]any, operationID string) map[string]any {
+	t.Helper()
+	paths, _ := doc["paths"].(map[string]any)
+	for _, pi := range paths {
+		item, _ := pi.(map[string]any)
+		for _, op := range item {
+			opm, ok := op.(map[string]any)
+			if !ok {
+				continue
+			}
+			if opm["operationId"] == operationID {
+				resp, _ := opm["responses"].(map[string]any)
+				return resp
+			}
+		}
+	}
+	t.Fatalf("operation %q not found in spec", operationID)
+	return nil
+}
+
+// schemaProps returns the properties map of a named component schema.
+func schemaProps(t *testing.T, doc map[string]any, schemaName string) map[string]any {
+	t.Helper()
+	comps, _ := doc["components"].(map[string]any)
+	schemas, _ := comps["schemas"].(map[string]any)
+	sc, ok := schemas[schemaName].(map[string]any)
+	if !ok {
+		t.Fatalf("schema %q not found in spec", schemaName)
+	}
+	props, _ := sc["properties"].(map[string]any)
+	return props
+}
+
+// enumOf returns the enum string slice for a property, or nil if absent.
+func enumOf(props map[string]any, field string) []string {
+	p, ok := props[field].(map[string]any)
+	if !ok {
+		return nil
+	}
+	raw, ok := p["enum"].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, v := range raw {
+		if s, ok := v.(string); ok {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+// typeIsNullable reports whether a property's type includes "null"
+// (either as a list ["array","null"] or via a separate nullable flag).
+func typeIsNullable(props map[string]any, field string) bool {
+	p, ok := props[field].(map[string]any)
+	if !ok {
+		return false
+	}
+	switch ty := p["type"].(type) {
+	case []any:
+		for _, v := range ty {
+			if v == "null" {
+				return true
+			}
+		}
+	case string:
+		if ty == "null" {
+			return true
+		}
+	}
+	return false
+}
+
+func setEqual(a []string, b ...string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	seen := map[string]bool{}
+	for _, x := range a {
+		seen[x] = true
+	}
+	for _, y := range b {
+		if !seen[y] {
+			return false
+		}
+	}
+	return true
+}
+
+// MED-1 — outbound operations must declare a 202 response (HITL hold).
+func TestSpecOutbound202Declared(t *testing.T) {
+	doc := renderSpec(t)
+	for _, opID := range []string{"sendMessage", "replyToMessage", "forwardMessage", "testAgent"} {
+		resp := operationResponses(t, doc, opID)
+		if _, ok := resp["202"]; !ok {
+			t.Errorf("operation %q is missing a 202 response (HITL hold returns 202 at runtime); declared codes: %v", opID, keysOf(resp))
+		}
+	}
+}
+
+// MED-2 — verifyDomain must declare a 412 response (TXT not yet published).
+func TestSpecVerifyDomain412Declared(t *testing.T) {
+	doc := renderSpec(t)
+	resp := operationResponses(t, doc, "verifyDomain")
+	if _, ok := resp["412"]; !ok {
+		t.Errorf("verifyDomain is missing a 412 response (missing TXT returns 412 at runtime); declared codes: %v", keysOf(resp))
+	}
+}
+
+// MED-3 — registerDomain must declare a 409 response (duplicate domain conflict).
+func TestSpecRegisterDomain409Declared(t *testing.T) {
+	doc := renderSpec(t)
+	resp := operationResponses(t, doc, "registerDomain")
+	if _, ok := resp["409"]; !ok {
+		t.Errorf("registerDomain is missing a 409 response (another owner -> conflict); declared codes: %v", keysOf(resp))
+	}
+}
+
+// MED-5 — status-ish fields must carry enums matching the values the server emits.
+func TestSpecStatusEnums(t *testing.T) {
+	doc := renderSpec(t)
+
+	cases := []struct {
+		schema string
+		field  string
+		want   []string
+	}{
+		{"MessageView", "direction", []string{"inbound", "outbound"}},
+		{"MessageSummaryView", "direction", []string{"inbound", "outbound"}},
+		{"MessageView", "hitl_status", []string{"pending_approval", "sent", "rejected", "expired_approved", "expired_rejected"}},
+		{"MessageSummaryView", "hitl_status", []string{"pending_approval", "sent", "rejected", "expired_approved", "expired_rejected"}},
+		{"SendResultView", "status", []string{"sent", "pending_approval"}},
+		{"EventJSON", "status", []string{"pending", "processed", "no_match"}},
+		{"RedeliverView", "status", []string{"pending", "scheduled"}},
+		{"WebhookDeliveryView", "status", []string{"pending", "delivered", "failed"}},
+	}
+	for _, c := range cases {
+		props := schemaProps(t, doc, c.schema)
+		got := enumOf(props, c.field)
+		if !setEqual(got, c.want...) {
+			t.Errorf("%s.%s enum = %v, want %v", c.schema, c.field, got, c.want)
+		}
+	}
+}
+
+// MED-6 — single-page wrapper arrays + Page.items must NOT be nullable.
+func TestSpecListArraysNotNullable(t *testing.T) {
+	doc := renderSpec(t)
+	cases := []struct {
+		schema string
+		field  string
+	}{
+		// single-page wrappers (Huma-named *OutputBody schemas)
+		{"ListAgentsOutputBody", "agents"},
+		{"ListDomainsOutputBody", "domains"},
+		{"ListWebhooksOutputBody", "webhooks"},
+		{"SuppressionsOutputBody", "suppressions"},
+	}
+	for _, c := range cases {
+		props := schemaProps(t, doc, c.schema)
+		if typeIsNullable(props, c.field) {
+			t.Errorf("%s.%s is declared nullable but the handler always emits []", c.schema, c.field)
+		}
+	}
+	// Page[*].items — find every schema with an "items" + "next_cursor" pair.
+	comps, _ := doc["components"].(map[string]any)
+	schemas, _ := comps["schemas"].(map[string]any)
+	checked := 0
+	for name, sc := range schemas {
+		scm, _ := sc.(map[string]any)
+		props, _ := scm["properties"].(map[string]any)
+		if props == nil {
+			continue
+		}
+		if _, hasItems := props["items"]; !hasItems {
+			continue
+		}
+		if _, hasCursor := props["next_cursor"]; !hasCursor {
+			continue
+		}
+		if typeIsNullable(props, "items") {
+			t.Errorf("page schema %s.items is declared nullable but the handler always emits []", name)
+		}
+		checked++
+	}
+	if checked == 0 {
+		t.Fatal("found no Page schemas to check — test wiring is wrong")
+	}
+}
+
+// LOW-1 — WebhookView must not declare the vestigial previous_secret_expires_at.
+func TestSpecWebhookViewNoPreviousSecretExpiry(t *testing.T) {
+	doc := renderSpec(t)
+	props := schemaProps(t, doc, "WebhookView")
+	if _, ok := props["previous_secret_expires_at"]; ok {
+		t.Errorf("WebhookView still declares previous_secret_expires_at (never populated by webhookView; rotate response carries it)")
+	}
+}
+
+// LOW-2 — webhook view timestamps must carry format: date-time.
+func TestSpecWebhookTimestampsFormatted(t *testing.T) {
+	doc := renderSpec(t)
+	check := func(schema string, fields ...string) {
+		props := schemaProps(t, doc, schema)
+		for _, f := range fields {
+			p, ok := props[f].(map[string]any)
+			if !ok {
+				continue // omitempty optional field may be absent only if removed; here all present
+			}
+			if p["format"] != "date-time" {
+				t.Errorf("%s.%s format = %v, want date-time", schema, f, p["format"])
+			}
+		}
+	}
+	check("WebhookView", "created_at", "auto_disabled_at", "last_delivered_at")
+	check("WebhookDeliveryView", "created_at", "last_attempt_at", "next_retry_at")
+}
+
+func keysOf(m map[string]any) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/httpapi/webhooks.go
+++ b/internal/httpapi/webhooks.go
@@ -41,11 +41,10 @@ type WebhookView struct {
 	Events                  []string           `json:"events"`
 	Filters                 WebhookFiltersView `json:"filters"`
 	SigningSecret           string             `json:"signing_secret,omitempty"`
-	PreviousSecretExpiresAt string             `json:"previous_secret_expires_at,omitempty"`
 	Enabled                 bool               `json:"enabled"`
-	AutoDisabledAt          string             `json:"auto_disabled_at,omitempty"`
-	CreatedAt               string             `json:"created_at"`
-	LastDeliveredAt         string             `json:"last_delivered_at,omitempty"`
+	AutoDisabledAt          string             `json:"auto_disabled_at,omitempty" format:"date-time"`
+	CreatedAt               string             `json:"created_at" format:"date-time"`
+	LastDeliveredAt         string             `json:"last_delivered_at,omitempty" format:"date-time"`
 }
 
 func webhookView(wh *identity.Webhook, includeSecret bool) WebhookView {
@@ -170,7 +169,7 @@ type webhookOutput struct{ Body WebhookView }
 type webhookCreateOutput struct{ Body WebhookView }
 type listWebhooksOutput struct {
 	Body struct {
-		Webhooks []WebhookView `json:"webhooks"`
+		Webhooks []WebhookView `json:"webhooks" nullable:"false"`
 	}
 }
 
@@ -300,13 +299,13 @@ func (s *Server) handleTestWebhook(ctx context.Context, in *testWebhookInput) (*
 type WebhookDeliveryView struct {
 	ID             string `json:"id"`
 	EventType      string `json:"event_type" enum:"email.received,email.sent,email.pending_approval,email.approved,email.rejected,domain.sending_verified,domain.sending_failed,email.delivered,email.bounced,email.complained,domain.suppression_added,email.flagged"`
-	Status         string `json:"status"`
+	Status         string `json:"status" enum:"pending,delivered,failed"`
 	Attempts       int    `json:"attempts"`
 	LastError      string `json:"last_error,omitempty"`
 	LastStatusCode *int   `json:"last_status_code,omitempty"`
-	LastAttemptAt  string `json:"last_attempt_at,omitempty"`
-	NextRetryAt    string `json:"next_retry_at"`
-	CreatedAt      string `json:"created_at"`
+	LastAttemptAt  string `json:"last_attempt_at,omitempty" format:"date-time"`
+	NextRetryAt    string `json:"next_retry_at" format:"date-time"`
+	CreatedAt      string `json:"created_at" format:"date-time"`
 }
 
 type ListDeliveriesInput struct {

--- a/internal/identity/conversation_webhook_status_test.go
+++ b/internal/identity/conversation_webhook_status_test.go
@@ -1,0 +1,73 @@
+package identity_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+)
+
+// B4b (review correctness bug): the same outbound message carries
+// webhook_status/webhook_error when listed via GetMessagesByAgent (which LEFT
+// JOINs webhook_deliveries) but NOT when read inside its conversation thread
+// via GetConversationByID (which lacks the join). Same MessageSummaryView type,
+// different payload depending on access path.
+func TestConversationMessagesCarryWebhookStatus(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	agentID := convoTestSetup(t, store, "convo-wh")
+
+	out, err := store.CreateOutboundMessage(
+		ctx, agentID, []string{"alice@gmail.com"}, nil, nil,
+		"Hi", "send", "smtp", "<wh-1@x>", "conv-wh",
+	)
+	if err != nil {
+		t.Fatalf("CreateOutboundMessage: %v", err)
+	}
+	// Seed a delivery row for the message (the legacy per-message table the
+	// list query joins on).
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO webhook_deliveries (message_id, status, attempts, last_error, created_at)
+		 VALUES ($1, 'delivered', 1, '', now())`, out.ID); err != nil {
+		t.Fatalf("seed webhook_deliveries: %v", err)
+	}
+
+	// Control: the standalone list path surfaces the delivery status.
+	msgs, err := store.GetMessagesByAgent(ctx, identity.MessageListFilter{
+		AgentID: agentID, Direction: "outbound", Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("GetMessagesByAgent: %v", err)
+	}
+	var listStatus string
+	for _, m := range msgs {
+		if m.ID == out.ID {
+			listStatus = m.WebhookStatus
+		}
+	}
+	if listStatus != "delivered" {
+		t.Fatalf("setup check: list webhook_status = %q, want %q", listStatus, "delivered")
+	}
+
+	// The conversation thread must show the SAME status for the SAME message.
+	detail, err := store.GetConversationByID(ctx, agentID, "conv-wh")
+	if err != nil {
+		t.Fatalf("GetConversationByID: %v", err)
+	}
+	var threadStatus string
+	var found bool
+	for _, m := range detail.Messages {
+		if m.ID == out.ID {
+			found = true
+			threadStatus = m.WebhookStatus
+		}
+	}
+	if !found {
+		t.Fatalf("message %s not in conversation detail", out.ID)
+	}
+	if threadStatus != "delivered" {
+		t.Errorf("conversation thread webhook_status = %q, want %q (must match the list view)", threadStatus, "delivered")
+	}
+}

--- a/internal/identity/domain_taken_test.go
+++ b/internal/identity/domain_taken_test.go
@@ -1,0 +1,34 @@
+package identity_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+)
+
+// MED-3 — a cross-user claim of a domain another user already owns must
+// return the typed sentinel identity.ErrDomainTaken so the API layer can map
+// it to 409 (conflict), distinct from the 400 used for malformed input.
+func TestClaimOrCreateDomain_CrossUserReturnsErrDomainTaken(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	userA, _ := store.CreateOrGetUser(ctx, "taken-a@example.com", "Owner A", "google-taken-a")
+	userB, _ := store.CreateOrGetUser(ctx, "taken-b@example.com", "Owner B", "google-taken-b")
+
+	if _, err := store.ClaimOrCreateDomain(ctx, "taken.example.com", userA.ID); err != nil {
+		t.Fatalf("userA ClaimOrCreateDomain: %v", err)
+	}
+
+	_, err := store.ClaimOrCreateDomain(ctx, "taken.example.com", userB.ID)
+	if err == nil {
+		t.Fatal("userB reclaim should fail when userA already owns the row")
+	}
+	if !errors.Is(err, identity.ErrDomainTaken) {
+		t.Fatalf("want errors.Is(err, ErrDomainTaken), got %v", err)
+	}
+}

--- a/internal/identity/messages_sender_test.go
+++ b/internal/identity/messages_sender_test.go
@@ -1,0 +1,59 @@
+package identity_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+)
+
+// B1 (review correctness bug): outbound messages must carry their sender (the
+// agent's own address). The outbound INSERTs never write the `sender` column,
+// so it defaults to '' and every outbound message reports from="" — a REQUIRED
+// wire field returning empty. This test reads an outbound message back and
+// expects the agent address.
+func TestOutboundMessageHasSender(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	agentID := convoTestSetup(t, store, "out-sender")
+	agentEmail := "bot@out-sender.example.com"
+
+	out, err := store.CreateOutboundMessage(
+		ctx, agentID, []string{"alice@gmail.com"}, nil, nil,
+		"Hello", "send", "smtp", "<out-sender-1@x>", "conv-sender",
+	)
+	if err != nil {
+		t.Fatalf("CreateOutboundMessage: %v", err)
+	}
+
+	// Read back via the detail path the API uses.
+	got, err := store.GetMessageWithContent(ctx, out.ID, agentID)
+	if err != nil {
+		t.Fatalf("GetMessageWithContent: %v", err)
+	}
+	if got.Sender != agentEmail {
+		t.Errorf("outbound sender = %q, want %q (the agent's own address)", got.Sender, agentEmail)
+	}
+
+	// And via the list path (MessageSummaryView.from is sourced from Sender).
+	msgs, err := store.GetMessagesByAgent(ctx, identity.MessageListFilter{
+		AgentID: agentID, Direction: "outbound", Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("GetMessagesByAgent: %v", err)
+	}
+	var found bool
+	for _, m := range msgs {
+		if m.ID == out.ID {
+			found = true
+			if m.Sender != agentEmail {
+				t.Errorf("list outbound sender = %q, want %q", m.Sender, agentEmail)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("outbound message %s not returned by GetMessagesByAgent", out.ID)
+	}
+}

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -2354,9 +2354,9 @@ func (s *Store) GetMessageWithContent(ctx context.Context, messageID, agentID st
 	err := s.pool.QueryRow(ctx,
 		`UPDATE messages SET inbox_status = CASE WHEN inbox_status = 'unread' THEN 'read' ELSE inbox_status END
 		 WHERE id = $1 AND agent_id = $2 AND expires_at > now()
-		 RETURNING id, agent_id, direction, sender, recipient, to_recipients, cc, reply_to, subject, email_message_id, conversation_id, COALESCE(inbox_status, ''), raw_message, auth_headers, auth_verdict, COALESCE(flagged, false), COALESCE(flag_reason, ''), created_at, expires_at, labels, COALESCE(delivery_status, ''), COALESCE(delivery_detail, ''), COALESCE(sent_as, ''), COALESCE(body_text, ''), COALESCE(body_html, '')`,
+		 RETURNING id, agent_id, direction, sender, recipient, to_recipients, cc, reply_to, subject, email_message_id, conversation_id, COALESCE(inbox_status, ''), raw_message, auth_headers, auth_verdict, COALESCE(flagged, false), COALESCE(flag_reason, ''), created_at, expires_at, labels, COALESCE(delivery_status, ''), COALESCE(delivery_detail, ''), COALESCE(sent_as, ''), COALESCE(body_text, ''), COALESCE(body_html, ''), COALESCE(status, '')`,
 		messageID, agentID,
-	).Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.ToRecipients, &m.CC, &m.ReplyTo, &m.Subject, &m.EmailMessageID, &m.ConversationID, &m.InboxStatus, &m.RawMessage, &authHeadersJSON, &authVerdict, &m.Flagged, &m.FlagReason, &m.CreatedAt, &m.ExpiresAt, &m.Labels, &outboundDeliveryStatus, &m.DeliveryDetail, &m.SentAs, &m.BodyText, &m.BodyHTML)
+	).Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.ToRecipients, &m.CC, &m.ReplyTo, &m.Subject, &m.EmailMessageID, &m.ConversationID, &m.InboxStatus, &m.RawMessage, &authHeadersJSON, &authVerdict, &m.Flagged, &m.FlagReason, &m.CreatedAt, &m.ExpiresAt, &m.Labels, &outboundDeliveryStatus, &m.DeliveryDetail, &m.SentAs, &m.BodyText, &m.BodyHTML, &m.Status)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -1192,11 +1192,14 @@ func (s *Store) CreateOutboundMessage(ctx context.Context, agentID string, toRec
 		ToRecipients:      toRecipients,
 		CC:                cc,
 		BCC:               bcc,
+		// The sender of an outbound message is the agent itself (agent ID == email).
+		// Persist it so the `from` wire field isn't empty for outbound (B1).
+		Sender: agentID,
 	}
 	_, err := s.pool.Exec(ctx,
-		`INSERT INTO messages (id, agent_id, direction, recipient, subject, message_type, method, provider_message_id, conversation_id, created_at, expires_at, to_recipients, cc, bcc, status)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)`,
-		m.ID, m.AgentID, m.Direction, m.Recipient, m.Subject, m.Type, m.Method, m.ProviderMessageID, m.ConversationID, m.CreatedAt, m.ExpiresAt, m.ToRecipients, m.CC, m.BCC, MessageStatusSent,
+		`INSERT INTO messages (id, agent_id, direction, recipient, subject, message_type, method, provider_message_id, conversation_id, created_at, expires_at, to_recipients, cc, bcc, status, sender)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
+		m.ID, m.AgentID, m.Direction, m.Recipient, m.Subject, m.Type, m.Method, m.ProviderMessageID, m.ConversationID, m.CreatedAt, m.ExpiresAt, m.ToRecipients, m.CC, m.BCC, MessageStatusSent, m.Sender,
 	)
 	if err != nil {
 		return nil, err
@@ -1258,6 +1261,9 @@ func (s *Store) CreatePendingOutboundMessage(ctx context.Context, agentID string
 		BodyText:          bodyText,
 		BodyHTML:          bodyHTML,
 		AttachmentsJSON:   json.RawMessage(attachmentsJSON),
+		// Sender is the agent itself (agent ID == email) so `from` isn't empty
+		// on a held draft's detail/list view (B1).
+		Sender: agentID,
 	}
 	_, err := s.pool.Exec(ctx,
 		`INSERT INTO messages (
@@ -1265,17 +1271,17 @@ func (s *Store) CreatePendingOutboundMessage(ctx context.Context, agentID string
 		    conversation_id, created_at, expires_at,
 		    to_recipients, cc, bcc,
 		    status, approval_expires_at,
-		    body_text, body_html, attachments_json)
+		    body_text, body_html, attachments_json, sender)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7,
 		         $8, $9, $10,
 		         $11, $12, $13,
 		         $14, $15,
-		         $16, $17, $18)`,
+		         $16, $17, $18, $19)`,
 		m.ID, m.AgentID, m.Direction, m.Recipient, m.Subject, m.EmailMessageID, m.Type,
 		m.ConversationID, m.CreatedAt, m.ExpiresAt,
 		m.ToRecipients, m.CC, m.BCC,
 		m.Status, m.ApprovalExpiresAt,
-		nullIfEmptyString(m.BodyText), nullIfEmptyString(m.BodyHTML), attachmentsArg,
+		nullIfEmptyString(m.BodyText), nullIfEmptyString(m.BodyHTML), attachmentsArg, m.Sender,
 	)
 	if err != nil {
 		return nil, err
@@ -2672,8 +2678,10 @@ func (s *Store) GetConversationByID(ctx context.Context, agentID, conversationID
 		        m.created_at, m.expires_at,
 		        m.labels,
 		        COALESCE(m.delivery_status, ''), COALESCE(m.delivery_detail, ''), COALESCE(m.sent_as, ''), m.auth_verdict,
-		        COALESCE(m.flagged, false), COALESCE(m.flag_reason, '')
+		        COALESCE(m.flagged, false), COALESCE(m.flag_reason, ''),
+		        COALESCE(wd.status, ''), COALESCE(wd.last_error, '')
 		 FROM messages m
+		 LEFT JOIN webhook_deliveries wd ON wd.message_id = m.id
 		 WHERE m.agent_id = $1
 		   AND m.conversation_id = $2
 		   AND m.expires_at > now()
@@ -2704,6 +2712,7 @@ func (s *Store) GetConversationByID(ctx context.Context, agentID, conversationID
 			&m.Labels,
 			&outboundDeliveryStatus, &m.DeliveryDetail, &m.SentAs, &authVerdict,
 			&m.Flagged, &m.FlagReason,
+			&m.WebhookStatus, &m.WebhookError,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -397,7 +397,7 @@ func (s *Store) ClaimOrCreateDomain(ctx context.Context, domain, userID string) 
 		return existing, nil // verified + same user
 	}
 
-	return nil, fmt.Errorf("domain not available")
+	return nil, ErrDomainTaken
 }
 
 // nullIfEmpty returns nil for empty strings so we can write SQL NULL
@@ -686,6 +686,12 @@ var ErrDomainHasAgents = fmt.Errorf("cannot delete domain: agents still exist")
 
 // ErrDomainNotFound is returned when a domain is not found or not owned by the user.
 var ErrDomainNotFound = fmt.Errorf("domain not found or not owned by user")
+
+// ErrDomainTaken is returned by ClaimOrCreateDomain when the domain row exists
+// and is owned by a different user (verified, or an unverified claim that must
+// not be squatted). The API layer maps it to 409 conflict, distinct from the
+// 400 used for malformed input.
+var ErrDomainTaken = fmt.Errorf("domain not available: already claimed by another account")
 
 // DeleteDomain deletes a domain only if owned by the user.
 // The handler should check for existing agents first.


### PR DESCRIPTION
## Post-cutover architect review — hardening pass

Folds the architect review (F1–F9) into `docs/design/api-v1-redesign.md` §12 and fixes the **server/spec** findings. SDK findings (F2/F4/F6 + F3-SDK + F1's oag pickup) land on the SDK PR branches; F5/F8/F9 are recorded decisions.

### F1 — HIGH (correctness): `MessageView` now carries `direction` + `hitl_status`
The detail view dropped both fields that `MessageSummaryView` exposes, so fetching a single message lost two of the three trust-axis signals — this forced the web dashboard (#230) to thread `direction`/`pending` through query params and broke deep-linked approve/reject.
- `GetMessageWithContent` now also scans the `status` column (HITL lifecycle) into `Message.Status` (the detail load never read it before).
- `MessageView` gains `direction` (always) + `hitl_status` (outbound-only, mirroring the summary). Spec regenerated; **drift gate + httpapi tests green.**

### F7 — corrected (false positive, no code)
The "leaked `Message` schema" is the **account-export** payload (`identity.UserExport.messages`, `GET /v1/account/export`) — the deliberate full-row data dump, not a leak; kept. `error.details` stays open `any` (heterogeneous validation/handler context); `request_id` is canonical in both the envelope + `X-Request-Id` header. Documented in §12.

### F3 — split
Send-path 429 carries `retry_after` in `details` (Huma can't set headers on error responses); the **SDK fix** (read `details.retry_after_seconds` fallback) lands on the SDK PRs, and uniform `RateLimit-*` headers + spec declaration remain the §11 #4 tracked follow-up.

### Doc (§12)
All nine findings recorded with severity, decision, and where each lands, plus the strategic calls: **F8** additive-only on `/v1` (removal/rename = `/v2`; dated version header deferred to pre-GA), **F9** keep the Stripe-shaped `X-E2A-Signature` + document the Svix equivalence, **F5** typed event payloads + stripped-reply-body are the next slice (S2 + InboundEmail fast-follow).

Independent of the consumer-port PRs; mergeable to `main` on its own. Does not affect the 8e legacy-deletion gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)