### PR TITLE
test(e2e-prod): migrate prod verification suite to the agent-scoped /v1 API

### DIFF
--- a/tests/e2e-prod/.gitignore
+++ b/tests/e2e-prod/.gitignore
@@ -1,1 +1,2 @@
 reports/
+node_modules/

--- a/tests/e2e-prod/harness/cleanup.ts
+++ b/tests/e2e-prod/harness/cleanup.ts
@@ -1,6 +1,6 @@
 import type { ApiClient } from "./client.ts";
 
-type Kind = "agent" | "domain" | "signing_secret";
+type Kind = "agent" | "domain";
 
 interface Tracked {
   kind: Kind;
@@ -46,11 +46,9 @@ export async function cleanup(client: ApiClient, opts: { force?: boolean } = {})
 function pathFor(t: Tracked): string {
   switch (t.kind) {
     case "agent":
-      return `/api/v1/agents/${encodeURIComponent(t.id)}`;
+      return `/v1/agents/${encodeURIComponent(t.id)}`;
     case "domain":
-      return `/api/v1/domains/${encodeURIComponent(t.id)}`;
-    case "signing_secret":
-      return `/api/v1/users/me/signing-secrets/${encodeURIComponent(t.id)}`;
+      return `/v1/domains/${encodeURIComponent(t.id)}`;
   }
 }
 

--- a/tests/e2e-prod/package.json
+++ b/tests/e2e-prod/package.json
@@ -4,6 +4,11 @@
   "type": "module",
   "scripts": {
     "smoke": "node smoke.ts",
-    "test": "node --test --test-reporter=spec suites/*.test.ts"
+    "test": "node --test --test-reporter=spec suites/*.test.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.2",
+    "typescript": "^5.4"
   }
 }

--- a/tests/e2e-prod/smoke.ts
+++ b/tests/e2e-prod/smoke.ts
@@ -8,24 +8,22 @@ console.log(`Shared domain: ${client.env.sharedDomain}`);
 console.log(`Rate limit: ${client.env.rateLimitRps} RPS`);
 console.log("");
 
-const info = await client.get("/api/v1/info", { expect: 200 });
-console.log(`GET /api/v1/info  ${info.status}  ${info.latencyMs.toFixed(0)}ms`);
+const info = await client.get("/v1/info", { expect: 200 });
+console.log(`GET /v1/info  ${info.status}  ${info.latencyMs.toFixed(0)}ms`);
 console.log(`  ${JSON.stringify(info.body)}`);
 
-const agent = await client.get(`/api/v1/agents/${encodeURIComponent(client.env.primaryAgentEmail)}`, { expect: 200 });
+const agent = await client.get(`/v1/agents/${encodeURIComponent(client.env.primaryAgentEmail)}`, { expect: 200 });
 console.log(`GET /agents/${client.env.primaryAgentEmail}  ${agent.status}  ${agent.latencyMs.toFixed(0)}ms`);
 console.log(`  ${JSON.stringify(agent.body)}`);
 
-const agents = await client.get<{ agents?: unknown[] }>("/api/v1/agents", { expect: 200 });
+const agents = await client.get<{ agents?: unknown[] }>("/v1/agents", { expect: 200 });
 console.log(`GET /agents  ${agents.status}  ${agents.latencyMs.toFixed(0)}ms  count=${agents.body?.agents?.length ?? "?"}`);
 
-const domains = await client.get<{ domains?: unknown[] }>("/api/v1/domains", { expect: 200 });
+const domains = await client.get<{ domains?: unknown[] }>("/v1/domains", { expect: 200 });
 console.log(`GET /domains  ${domains.status}  ${domains.latencyMs.toFixed(0)}ms  count=${domains.body?.domains?.length ?? "?"}`);
 
-const secrets = await client.get<{ secrets?: unknown[] }>("/api/v1/users/me/signing-secrets", { expect: 200 });
-console.log(`GET /users/me/signing-secrets  ${secrets.status}  ${secrets.latencyMs.toFixed(0)}ms  count=${secrets.body?.secrets?.length ?? "?"}`);
-
-const msgs = await client.get<{ messages?: unknown[] }>("/api/v1/messages", { query: { limit: 5 }, expect: 200 });
-console.log(`GET /messages?limit=5  ${msgs.status}  ${msgs.latencyMs.toFixed(0)}ms  count=${msgs.body?.messages?.length ?? "?"}`);
+const msgsPath = `/v1/agents/${encodeURIComponent(client.env.primaryAgentEmail)}/messages`;
+const msgs = await client.get<{ items?: unknown[] }>(msgsPath, { query: { limit: 5 }, expect: 200 });
+console.log(`GET /agents/${client.env.primaryAgentEmail}/messages?limit=5  ${msgs.status}  ${msgs.latencyMs.toFixed(0)}ms  count=${msgs.body?.items?.length ?? "?"}`);
 
 console.log("\nSmoke OK");

--- a/tests/e2e-prod/suites/01-basic.test.ts
+++ b/tests/e2e-prod/suites/01-basic.test.ts
@@ -20,7 +20,7 @@ after(async () => {
 
 test("info: public deployment metadata is returned", async () => {
   const r = await client.get<{ shared_domain: string; slug_registration_enabled: boolean; public_url: string }>(
-    "/api/v1/info",
+    "/v1/info",
   );
   assert.equal(r.status, 200);
   assert.ok(r.body?.shared_domain, "shared_domain present");
@@ -30,7 +30,7 @@ test("info: public deployment metadata is returned", async () => {
 
 test("agents: list returns user's agents with required fields", async () => {
   const r = await client.get<{ agents: Array<{ email: string; domain: string; agent_mode: string }> }>(
-    "/api/v1/agents",
+    "/v1/agents",
   );
   assert.equal(r.status, 200);
   assert.ok(Array.isArray(r.body?.agents));
@@ -44,7 +44,7 @@ test("agents: list returns user's agents with required fields", async () => {
 test("agents: get primary agent by email", async () => {
   const email = client.env.primaryAgentEmail;
   const r = await client.get<{ email: string; domain: string; domain_verified: boolean }>(
-    `/api/v1/agents/${encodeURIComponent(email)}`,
+    `/v1/agents/${encodeURIComponent(email)}`,
   );
   assert.equal(r.status, 200);
   assert.equal(r.body?.email, email);
@@ -52,17 +52,17 @@ test("agents: get primary agent by email", async () => {
 });
 
 test("agents: get nonexistent agent returns 403 (anti-enumeration; matches spec)", async () => {
-  const r = await client.get(`/api/v1/agents/nonexistent-${Date.now()}@agents.e2a.dev`);
+  const r = await client.get(`/v1/agents/nonexistent-${Date.now()}@agents.e2a.dev`);
   assert.equal(r.status, 403, `spec only documents 200/401/403 — expected 403 for unknown, got ${r.status}`);
 });
 
 test("agents: get malformed email returns 4xx", async () => {
-  const r = await client.get(`/api/v1/agents/not-an-email`);
+  const r = await client.get(`/v1/agents/not-an-email`);
   assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}`);
 });
 
 test("agents: POST without agent_mode defaults to cloud and 400s (DX finding)", async () => {
-  const r = await client.post("/api/v1/agents", { body: { slug: uniqueSlug("nomode"), name: "no mode" } });
+  const r = await client.post("/v1/agents", { body: { slug: uniqueSlug("nomode"), name: "no mode" } });
   if (r.status === 201) {
     info(SUITE, "no-mode-default", "POST /agents without agent_mode succeeded — default behavior should be documented");
   } else {
@@ -77,7 +77,7 @@ test("agents: POST without agent_mode defaults to cloud and 400s (DX finding)", 
 
 test("agents: create + read + delete (slug on shared domain)", async () => {
   const slug = uniqueSlug();
-  const create = await client.post<{ email: string; id: string; domain: string }>("/api/v1/agents", {
+  const create = await client.post<{ email: string; id: string; domain: string }>("/v1/agents", {
     body: { slug, name: `e2e ${slug}`, agent_mode: "local" },
   });
   assert.equal(create.status, 201, `create slug-agent expected 201, got ${create.status}: ${create.raw.slice(0, 200)}`);
@@ -87,32 +87,32 @@ test("agents: create + read + delete (slug on shared domain)", async () => {
   track("agent", email);
 
   const got = await client.get<{ email: string; domain_verified: boolean }>(
-    `/api/v1/agents/${encodeURIComponent(email)}`,
+    `/v1/agents/${encodeURIComponent(email)}`,
   );
   assert.equal(got.status, 200);
   assert.equal(got.body?.email, email);
   assert.equal(got.body?.domain_verified, true, "slug-domain agent should be auto-verified");
 
-  const del = await client.delete(`/api/v1/agents/${encodeURIComponent(email)}`);
+  const del = await client.delete(`/v1/agents/${encodeURIComponent(email)}`);
   assert.ok(del.status === 204 || del.status === 200, `delete expected 200/204, got ${del.status}`);
 
-  const after = await client.get(`/api/v1/agents/${encodeURIComponent(email)}`);
+  const after = await client.get(`/v1/agents/${encodeURIComponent(email)}`);
   assert.equal(after.status, 403, `deleted agent should 403 (anti-enumeration), got ${after.status}`);
 });
 
 test("agents: create with missing slug AND email returns 4xx", async () => {
-  const r = await client.post("/api/v1/agents", { body: { name: "no identifier" } });
+  const r = await client.post("/v1/agents", { body: { name: "no identifier" } });
   assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
 test("agents: create with duplicate slug returns 409 (or 4xx)", async () => {
   const slug = uniqueSlug();
-  const first = await client.post<{ email: string }>("/api/v1/agents", {
+  const first = await client.post<{ email: string }>("/v1/agents", {
     body: { slug, name: "first", agent_mode: "local" },
   });
   assert.equal(first.status, 201);
   track("agent", first.body!.email);
-  const second = await client.post("/api/v1/agents", { body: { slug, name: "second", agent_mode: "local" } });
+  const second = await client.post("/v1/agents", { body: { slug, name: "second", agent_mode: "local" } });
   assert.ok(second.status >= 400 && second.status < 500, `dup slug expected 4xx, got ${second.status}`);
   if (second.status !== 409) {
     info(SUITE, "dup-slug-code", `spec documents 409 for "Agent already exists" but got ${second.status}: ${second.raw.slice(0, 120)}`);
@@ -121,28 +121,28 @@ test("agents: create with duplicate slug returns 409 (or 4xx)", async () => {
 
 test("agents: update hitl_enabled via PUT persists", async () => {
   const slug = uniqueSlug();
-  const c = await client.post<{ email: string }>("/api/v1/agents", {
+  const c = await client.post<{ email: string }>("/v1/agents", {
     body: { slug, name: "update target", agent_mode: "local" },
   });
   assert.equal(c.status, 201);
   const email = c.body!.email;
   track("agent", email);
 
-  const upd = await client.put(`/api/v1/agents/${encodeURIComponent(email)}`, { body: { hitl_enabled: true } });
+  const upd = await client.put(`/v1/agents/${encodeURIComponent(email)}`, { body: { hitl_enabled: true } });
   assert.equal(upd.status, 200, `update expected 200, got ${upd.status}: ${upd.raw.slice(0, 200)}`);
 
-  const g = await client.get<{ hitl_enabled: boolean }>(`/api/v1/agents/${encodeURIComponent(email)}`);
+  const g = await client.get<{ hitl_enabled: boolean }>(`/v1/agents/${encodeURIComponent(email)}`);
   assert.equal(g.body?.hitl_enabled, true, "hitl_enabled update persisted");
 });
 
 test("agents: update with invalid agent_mode enum returns 4xx", async () => {
   const slug = uniqueSlug();
-  const c = await client.post<{ email: string }>("/api/v1/agents", {
+  const c = await client.post<{ email: string }>("/v1/agents", {
     body: { slug, name: "invalid mode", agent_mode: "local" },
   });
   assert.equal(c.status, 201);
   track("agent", c.body!.email);
-  const r = await client.put(`/api/v1/agents/${encodeURIComponent(c.body!.email)}`, {
+  const r = await client.put(`/v1/agents/${encodeURIComponent(c.body!.email)}`, {
     body: { agent_mode: "not-a-real-mode" },
   });
   assert.ok(r.status >= 400 && r.status < 500, `expected 4xx for bad enum, got ${r.status}: ${r.raw.slice(0, 200)}`);
@@ -150,25 +150,27 @@ test("agents: update with invalid agent_mode enum returns 4xx", async () => {
 
 test("send: HITL-enabled agent returns 202 pending_approval", async () => {
   const slug = uniqueSlug("hitl");
-  const c = await client.post<{ email: string }>("/api/v1/agents", {
+  const c = await client.post<{ email: string }>("/v1/agents", {
     body: { slug, name: "hitl", agent_mode: "local" },
   });
   assert.equal(c.status, 201);
   const email = c.body!.email;
   track("agent", email);
-  const u = await client.put(`/api/v1/agents/${encodeURIComponent(email)}`, {
+  const u = await client.put(`/v1/agents/${encodeURIComponent(email)}`, {
     body: { hitl_enabled: true, hitl_expiration_action: "reject", hitl_ttl_seconds: 60 },
   });
   assert.equal(u.status, 200);
 
-  const send = await client.post<{ message_id: string; status: string }>("/api/v1/send", {
-    body: {
-      from: email,
-      to: [SINK_EMAIL],
-      subject: uniqueSubject("hitl pending"),
-      body: "test body — should never go out, immediately rejected",
+  const send = await client.post<{ message_id: string; status: string }>(
+    `/v1/agents/${encodeURIComponent(email)}/messages`,
+    {
+      body: {
+        to: [SINK_EMAIL],
+        subject: uniqueSubject("hitl pending"),
+        body: "test body — should never go out, immediately rejected",
+      },
     },
-  });
+  );
   assert.ok(
     send.status === 202 || send.status === 200,
     `expected 202/200, got ${send.status}: ${send.raw.slice(0, 200)}`,
@@ -180,51 +182,48 @@ test("send: HITL-enabled agent returns 202 pending_approval", async () => {
   assert.equal(send.body?.status, "pending_approval", "status field should be pending_approval");
   assert.ok(send.body?.message_id?.startsWith("msg_"), "message_id has msg_ prefix");
 
-  const reject = await client.post(`/api/v1/messages/${send.body!.message_id}/reject`, {
-    body: { reason: "e2e test rejection" },
-  });
+  const reject = await client.post(
+    `/v1/agents/${encodeURIComponent(email)}/messages/${send.body!.message_id}/reject`,
+    {
+      body: { reason: "e2e test rejection" },
+    },
+  );
   assert.ok(reject.status === 200, `reject expected 200, got ${reject.status}: ${reject.raw.slice(0, 200)}`);
 });
 
 test("send: missing 'to' returns 4xx", async () => {
-  const r = await client.post("/api/v1/send", {
-    body: { from: client.env.primaryAgentEmail, subject: "no to", body: "hi" },
+  const r = await client.post(`/v1/agents/${encodeURIComponent(client.env.primaryAgentEmail)}/messages`, {
+    body: { subject: "no to", body: "hi" },
   });
   assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
-test("send: unowned 'from' returns 4xx (auth/scope guard)", async () => {
-  const r = await client.post("/api/v1/send", {
-    body: { from: "someone-else@example.com", to: [SINK_EMAIL], subject: "spoof", body: "hi" },
+test("send: unowned sending agent returns 4xx (auth/scope guard)", async () => {
+  // The sending agent is threaded through the path; sending as an agent the
+  // caller doesn't own must be rejected (no cross-tenant impersonation).
+  const r = await client.post(`/v1/agents/${encodeURIComponent("someone-else@example.com")}/messages`, {
+    body: { to: [SINK_EMAIL], subject: "spoof", body: "hi" },
   });
   assert.ok(r.status >= 400 && r.status < 500, `expected 4xx (cannot send as non-owned), got ${r.status}`);
 });
 
-test("messages: list with limit + pagination tokens", async () => {
-  const r = await client.get<{ messages: unknown[]; next_token?: string }>("/api/v1/messages", {
-    query: { limit: 5 },
-  });
-  assert.equal(r.status, 200);
-  assert.ok(Array.isArray(r.body?.messages));
-  if (r.body!.messages.length >= 5) {
-    assert.ok(r.body!.next_token === undefined || typeof r.body!.next_token === "string", "next_token is string|absent");
-  }
-});
-
-test("signing-secrets: list returns documented shape", async () => {
-  const r = await client.get<{ secrets: Array<{ id: string; created_at: string }> }>(
-    "/api/v1/users/me/signing-secrets",
+test("messages: list with limit + pagination cursor", async () => {
+  const r = await client.get<{ items: unknown[]; next_cursor?: string | null }>(
+    `/v1/agents/${encodeURIComponent(client.env.primaryAgentEmail)}/messages`,
+    { query: { limit: 5 } },
   );
   assert.equal(r.status, 200);
-  assert.ok(Array.isArray(r.body?.secrets));
-  for (const s of r.body!.secrets) {
-    assert.ok(s.id, "secret has id");
-    assert.ok(s.created_at, "secret has created_at");
+  assert.ok(Array.isArray(r.body?.items));
+  if (r.body!.items.length >= 5) {
+    assert.ok(
+      r.body!.next_cursor === undefined || r.body!.next_cursor === null || typeof r.body!.next_cursor === "string",
+      "next_cursor is string|null|absent",
+    );
   }
 });
 
 test("domains: list returns documented shape", async () => {
-  const r = await client.get<{ domains: Array<{ domain: string }> }>("/api/v1/domains");
+  const r = await client.get<{ domains: Array<{ domain: string }> }>("/v1/domains");
   assert.equal(r.status, 200);
   assert.ok(Array.isArray(r.body?.domains));
 });

--- a/tests/e2e-prod/suites/02-authz.test.ts
+++ b/tests/e2e-prod/suites/02-authz.test.ts
@@ -15,24 +15,24 @@ after(async () => {
 });
 
 test("authz: no Authorization header returns 401 on list agents", async () => {
-  const r = await client.get("/api/v1/agents", { apiKey: null });
+  const r = await client.get("/v1/agents", { apiKey: null });
   assert.equal(r.status, 401, `no key expected 401, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
 test("authz: malformed Authorization header returns 401", async () => {
-  const r = await client.get("/api/v1/agents", { apiKey: null, headers: { Authorization: "NotBearer foo" } });
+  const r = await client.get("/v1/agents", { apiKey: null, headers: { Authorization: "NotBearer foo" } });
   assert.equal(r.status, 401, `bad scheme expected 401, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
 test("authz: random API key with valid prefix returns 401", async () => {
-  const r = await client.get("/api/v1/agents", {
+  const r = await client.get("/v1/agents", {
     apiKey: "e2a_0000000000000000000000000000000000000000000000000000000000000000",
   });
   assert.equal(r.status, 401, `bogus key expected 401, got ${r.status}`);
 });
 
 test("authz: random API key without 'e2a_' prefix returns 401", async () => {
-  const r = await client.get("/api/v1/agents", { apiKey: "not-an-e2a-key" });
+  const r = await client.get("/v1/agents", { apiKey: "not-an-e2a-key" });
   assert.equal(r.status, 401, `bad prefix expected 401, got ${r.status}`);
 });
 
@@ -41,8 +41,8 @@ test("authz: 401 body does NOT leak hint about key validity", async () => {
   // is unrelated garbage. A correct auth gate must return byte-identical
   // 401 responses for both so an attacker can't distinguish "key shape
   // is right but invalid" from "completely malformed input."
-  const r1 = await client.get("/api/v1/agents", { apiKey: "e2a_00000000000000000000000000000000" });
-  const r2 = await client.get("/api/v1/agents", { apiKey: "garbage" });
+  const r1 = await client.get("/v1/agents", { apiKey: "e2a_00000000000000000000000000000000" });
+  const r2 = await client.get("/v1/agents", { apiKey: "garbage" });
   assert.equal(r1.status, 401, `r1 expected 401, got ${r1.status}`);
   assert.equal(r2.status, 401, `r2 expected 401, got ${r2.status}`);
   if (r1.raw !== r2.raw) {
@@ -58,32 +58,36 @@ test("authz: 401 body does NOT leak hint about key validity", async () => {
   info(SUITE, "401-uniform", "401 bodies are identical for malformed vs bogus-but-shaped — good (no oracle)");
 });
 
-test("authz: bogus 'from' on /send returns 4xx (cannot impersonate)", async () => {
-  const r = await client.post("/api/v1/send", {
-    body: {
-      from: "not-mine@some-random-domain-i-dont-own-987654.com",
-      to: ["blackhole@e2a.dev"],
-      subject: "spoof attempt",
-      body: "this should be rejected",
+test("authz: send as an unowned agent returns 4xx (cannot impersonate)", async () => {
+  // The sending agent is named in the path; sending as one the caller
+  // doesn't own must be rejected.
+  const r = await client.post(
+    `/v1/agents/${encodeURIComponent("not-mine@some-random-domain-i-dont-own-987654.com")}/messages`,
+    {
+      body: {
+        to: ["blackhole@e2a.dev"],
+        subject: "spoof attempt",
+        body: "this should be rejected",
+      },
     },
-  });
+  );
   assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
 test("authz: GET /agents/<email-i-dont-own> returns 403 (no info leak)", async () => {
-  const r = await client.get(`/api/v1/agents/${encodeURIComponent("nobody@example.com")}`);
+  const r = await client.get(`/v1/agents/${encodeURIComponent("nobody@example.com")}`);
   assert.equal(r.status, 403, `expected 403, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
 test("authz: PUT /agents/<email-i-dont-own> returns 403 or 4xx", async () => {
-  const r = await client.put(`/api/v1/agents/${encodeURIComponent("nobody@example.com")}`, {
+  const r = await client.put(`/v1/agents/${encodeURIComponent("nobody@example.com")}`, {
     body: { hitl_enabled: true },
   });
   assert.ok(r.status === 403 || (r.status >= 400 && r.status < 500), `expected 4xx, got ${r.status}`);
 });
 
 test("authz: DELETE /agents/<email-i-dont-own> returns 403 or 4xx (no cross-tenant delete)", async () => {
-  const r = await client.delete(`/api/v1/agents/${encodeURIComponent("nobody@example.com")}`);
+  const r = await client.delete(`/v1/agents/${encodeURIComponent("nobody@example.com")}`);
   // assert.ok throws on a non-4xx response — the explicit 200/204 check
   // that used to live below was dead code (unreachable past the assert).
   // The fail-tag is preserved for triage clarity if the assert ever fires.
@@ -95,37 +99,35 @@ test("authz: DELETE /agents/<email-i-dont-own> returns 403 or 4xx (no cross-tena
 });
 
 test("authz: GET /agents/<email>/messages of unowned agent returns 4xx", async () => {
-  const r = await client.get(`/api/v1/agents/${encodeURIComponent("nobody@example.com")}/messages`);
+  const r = await client.get(`/v1/agents/${encodeURIComponent("nobody@example.com")}/messages`);
   assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
 test("authz: GET /messages/<bogus-id> returns 4xx, not 200", async () => {
-  const r = await client.get(`/api/v1/messages/msg_does_not_exist_${Date.now()}`);
+  const agent = encodeURIComponent(client.env.primaryAgentEmail);
+  const r = await client.get(`/v1/agents/${agent}/messages/msg_does_not_exist_${Date.now()}`);
   assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
 test("authz: POST /messages/<bogus>/approve returns 4xx", async () => {
-  const r = await client.post(`/api/v1/messages/msg_bogus_${Date.now()}/approve`, { body: {} });
+  const agent = encodeURIComponent(client.env.primaryAgentEmail);
+  const r = await client.post(`/v1/agents/${agent}/messages/msg_bogus_${Date.now()}/approve`, { body: {} });
   assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}`);
 });
 
 test("authz: POST /messages/<bogus>/reject returns 4xx", async () => {
-  const r = await client.post(`/api/v1/messages/msg_bogus_${Date.now()}/reject`, { body: { reason: "n/a" } });
-  assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}`);
-});
-
-test("authz: signing-secret DELETE of bogus id returns 4xx (no cross-tenant leak)", async () => {
-  const r = await client.delete(`/api/v1/users/me/signing-secrets/sec_bogus_${Date.now()}`);
+  const agent = encodeURIComponent(client.env.primaryAgentEmail);
+  const r = await client.post(`/v1/agents/${agent}/messages/msg_bogus_${Date.now()}/reject`, { body: { reason: "n/a" } });
   assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}`);
 });
 
 test("authz: can act on own agent (positive control)", async () => {
   const slug = uniqueSlug("authz");
-  const c = await client.post<{ email: string }>("/api/v1/agents", {
+  const c = await client.post<{ email: string }>("/v1/agents", {
     body: { slug, name: "authz pos", agent_mode: "local" },
   });
   assert.equal(c.status, 201);
   track("agent", c.body!.email);
-  const g = await client.get(`/api/v1/agents/${encodeURIComponent(c.body!.email)}`);
+  const g = await client.get(`/v1/agents/${encodeURIComponent(c.body!.email)}`);
   assert.equal(g.status, 200);
 });

--- a/tests/e2e-prod/suites/03-concurrency.test.ts
+++ b/tests/e2e-prod/suites/03-concurrency.test.ts
@@ -20,7 +20,7 @@ test("concurrency: 5 parallel creates with distinct slugs all succeed", async ()
   const slugs = Array.from({ length: 5 }, () => uniqueSlug("par"));
   const results = await Promise.all(
     slugs.map((slug) =>
-      burst.post<{ email: string }>("/api/v1/agents", { body: { slug, name: "par", agent_mode: "local" } }),
+      burst.post<{ email: string }>("/v1/agents", { body: { slug, name: "par", agent_mode: "local" } }),
     ),
   );
   for (const r of results) {
@@ -33,7 +33,7 @@ test("concurrency: 5 parallel creates with the SAME slug — exactly one wins, r
   const slug = uniqueSlug("race");
   const results = await Promise.all(
     Array.from({ length: 5 }, () =>
-      burst.post<{ email: string }>("/api/v1/agents", { body: { slug, name: "race", agent_mode: "local" } }),
+      burst.post<{ email: string }>("/v1/agents", { body: { slug, name: "race", agent_mode: "local" } }),
     ),
   );
   const successes = results.filter((r) => r.status === 201);
@@ -56,7 +56,7 @@ test("concurrency: 5 parallel creates with the SAME slug — exactly one wins, r
 
 test("concurrency: parallel reads of same agent return consistent body", async () => {
   const slug = uniqueSlug("cr");
-  const c = await client.post<{ email: string }>("/api/v1/agents", {
+  const c = await client.post<{ email: string }>("/v1/agents", {
     body: { slug, name: "consistency", agent_mode: "local" },
   });
   assert.equal(c.status, 201);
@@ -64,7 +64,7 @@ test("concurrency: parallel reads of same agent return consistent body", async (
   track("agent", email);
 
   const reads = await Promise.all(
-    Array.from({ length: 8 }, () => burst.get<{ email: string; hitl_enabled: boolean }>(`/api/v1/agents/${encodeURIComponent(email)}`)),
+    Array.from({ length: 8 }, () => burst.get<{ email: string; hitl_enabled: boolean }>(`/v1/agents/${encodeURIComponent(email)}`)),
   );
   for (const r of reads) {
     assert.equal(r.status, 200);
@@ -76,7 +76,7 @@ test("concurrency: parallel reads of same agent return consistent body", async (
 
 test("concurrency: parallel PUT toggles converge to a final state (no 500)", async () => {
   const slug = uniqueSlug("toggle");
-  const c = await client.post<{ email: string }>("/api/v1/agents", {
+  const c = await client.post<{ email: string }>("/v1/agents", {
     body: { slug, name: "toggle", agent_mode: "local" },
   });
   assert.equal(c.status, 201);
@@ -84,10 +84,10 @@ test("concurrency: parallel PUT toggles converge to a final state (no 500)", asy
   track("agent", email);
 
   const ops = await Promise.all([
-    burst.put(`/api/v1/agents/${encodeURIComponent(email)}`, { body: { hitl_enabled: true } }),
-    burst.put(`/api/v1/agents/${encodeURIComponent(email)}`, { body: { hitl_enabled: false } }),
-    burst.put(`/api/v1/agents/${encodeURIComponent(email)}`, { body: { hitl_enabled: true } }),
-    burst.put(`/api/v1/agents/${encodeURIComponent(email)}`, { body: { hitl_enabled: false } }),
+    burst.put(`/v1/agents/${encodeURIComponent(email)}`, { body: { hitl_enabled: true } }),
+    burst.put(`/v1/agents/${encodeURIComponent(email)}`, { body: { hitl_enabled: false } }),
+    burst.put(`/v1/agents/${encodeURIComponent(email)}`, { body: { hitl_enabled: true } }),
+    burst.put(`/v1/agents/${encodeURIComponent(email)}`, { body: { hitl_enabled: false } }),
   ]);
   for (const r of ops) {
     if (r.status >= 500) {
@@ -96,7 +96,7 @@ test("concurrency: parallel PUT toggles converge to a final state (no 500)", asy
     assert.ok(r.status < 500, `no 5xx under contention, got ${r.status}`);
   }
   // Final state should be one of the toggled values, not corrupted.
-  const final = await client.get<{ hitl_enabled: boolean }>(`/api/v1/agents/${encodeURIComponent(email)}`);
+  const final = await client.get<{ hitl_enabled: boolean }>(`/v1/agents/${encodeURIComponent(email)}`);
   assert.equal(final.status, 200);
   assert.equal(typeof final.body?.hitl_enabled, "boolean");
 });
@@ -111,7 +111,7 @@ test("concurrency: parallel DELETE of the same agent is idempotent under content
   // 2xx and only emitted info(). If you want to lock in first-writer-wins
   // specifically, tighten the assertion to ok.length === 1.
   const slug = uniqueSlug("del");
-  const c = await client.post<{ email: string }>("/api/v1/agents", {
+  const c = await client.post<{ email: string }>("/v1/agents", {
     body: { slug, name: "del", agent_mode: "local" },
   });
   assert.equal(c.status, 201);
@@ -119,7 +119,7 @@ test("concurrency: parallel DELETE of the same agent is idempotent under content
   // Don't track — this test consumes it.
 
   const results = await Promise.all(
-    Array.from({ length: 4 }, () => burst.delete(`/api/v1/agents/${encodeURIComponent(email)}`)),
+    Array.from({ length: 4 }, () => burst.delete(`/v1/agents/${encodeURIComponent(email)}`)),
   );
   const ok = results.filter((r) => r.status === 200 || r.status === 204);
   const fivexx = results.filter((r) => r.status >= 500);
@@ -128,7 +128,7 @@ test("concurrency: parallel DELETE of the same agent is idempotent under content
   // Final state check: a GET after all the parallel deletes must say 403
   // (anti-enumeration on deleted) — confirms the agent is actually gone
   // regardless of which delete "won."
-  const after = await client.get(`/api/v1/agents/${encodeURIComponent(email)}`);
+  const after = await client.get(`/v1/agents/${encodeURIComponent(email)}`);
   assert.equal(after.status, 403, `after parallel delete, GET expected 403, got ${after.status}`);
   if (ok.length > 1) {
     info(SUITE, "delete-idempotent", `${ok.length} parallel deletes returned 2xx — server treats DELETE as idempotent`);
@@ -139,13 +139,13 @@ test("concurrency: parallel DELETE of the same agent is idempotent under content
 
 test("concurrency: 8 parallel sends from HITL agent — all queue (no dropped/duplicated)", async () => {
   const slug = uniqueSlug("hitlconc");
-  const c = await client.post<{ email: string }>("/api/v1/agents", {
+  const c = await client.post<{ email: string }>("/v1/agents", {
     body: { slug, name: "hitl-conc", agent_mode: "local" },
   });
   assert.equal(c.status, 201);
   const email = c.body!.email;
   track("agent", email);
-  const u = await client.put(`/api/v1/agents/${encodeURIComponent(email)}`, {
+  const u = await client.put(`/v1/agents/${encodeURIComponent(email)}`, {
     body: { hitl_enabled: true, hitl_expiration_action: "reject", hitl_ttl_seconds: 60 },
   });
   assert.equal(u.status, 200);
@@ -153,9 +153,8 @@ test("concurrency: 8 parallel sends from HITL agent — all queue (no dropped/du
   const N = 8;
   const sends = await Promise.all(
     Array.from({ length: N }, (_, i) =>
-      burst.post<{ message_id: string; status: string }>("/api/v1/send", {
+      burst.post<{ message_id: string; status: string }>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
         body: {
-          from: email,
           to: ["blackhole@e2a.dev"],
           subject: `parallel ${i}`,
           body: `parallel send #${i}`,
@@ -174,6 +173,6 @@ test("concurrency: 8 parallel sends from HITL agent — all queue (no dropped/du
 
   // Best-effort reject all so no actual mail leaves the system.
   for (const id of ids) {
-    await client.post(`/api/v1/messages/${id}/reject`, { body: { reason: "e2e cleanup" } });
+    await client.post(`/v1/agents/${encodeURIComponent(email)}/messages/${id}/reject`, { body: { reason: "e2e cleanup" } });
   }
 });

--- a/tests/e2e-prod/suites/04-quota.test.ts
+++ b/tests/e2e-prod/suites/04-quota.test.ts
@@ -16,15 +16,15 @@ after(async () => {
   writeReport(`./reports/04-quota.json`);
 });
 
-test("quota: send /api/v1/send rapidly until first 429 (spec says 60/min/agent)", async () => {
+test("quota: send /v1/agents/{email}/messages rapidly until first 429 (spec says 60/min/agent)", async () => {
   const slug = uniqueSlug("quota");
-  const c = await client.post<{ email: string }>("/api/v1/agents", {
+  const c = await client.post<{ email: string }>("/v1/agents", {
     body: { slug, name: "quota", agent_mode: "local" },
   });
   assert.equal(c.status, 201);
   const email = c.body!.email;
   track("agent", email);
-  await client.put(`/api/v1/agents/${encodeURIComponent(email)}`, {
+  await client.put(`/v1/agents/${encodeURIComponent(email)}`, {
     body: { hitl_enabled: true, hitl_expiration_action: "reject", hitl_ttl_seconds: 60 },
   });
 
@@ -33,8 +33,8 @@ test("quota: send /api/v1/send rapidly until first 429 (spec says 60/min/agent)"
 
   const MAX_PROBE = 70;
   for (let i = 0; i < MAX_PROBE; i++) {
-    const r = await burst.post<{ message_id: string; status: string }>("/api/v1/send", {
-      body: { from: email, to: ["blackhole@e2a.dev"], subject: `probe ${i}`, body: "x" },
+    const r = await burst.post<{ message_id: string; status: string }>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
+      body: { to: ["blackhole@e2a.dev"], subject: `probe ${i}`, body: "x" },
     });
     if (r.status === 429) {
       limited = { status: r.status, retryAfter: r.headers["retry-after"], index: i };
@@ -61,7 +61,7 @@ test("quota: send /api/v1/send rapidly until first 429 (spec says 60/min/agent)"
 
   // Reject everything we queued so no actual mail leaves the system.
   for (const id of ids) {
-    await burst.post(`/api/v1/messages/${id}/reject`, { body: { reason: "e2e cleanup" } });
+    await burst.post(`/v1/agents/${encodeURIComponent(email)}/messages/${id}/reject`, { body: { reason: "e2e cleanup" } });
   }
 });
 
@@ -70,7 +70,7 @@ test("quota: 429 on /agents create is documented and observable under repeated c
   let createdLimit: number | null = null;
   let lastCreatedEmail: string | null = null;
   for (let i = 0; i < 15; i++) {
-    const r = await burst.post<{ email: string }>("/api/v1/agents", {
+    const r = await burst.post<{ email: string }>("/v1/agents", {
       body: { slug: uniqueSlug(`q${i}`), name: "q", agent_mode: "local" },
     });
     if (r.body?.email) {
@@ -100,8 +100,8 @@ test("quota: 429 on /agents create is documented and observable under repeated c
 
 test("quota: rate-limited send still allows reads from same key (non-blocking)", async () => {
   // Even when a send-quota is exhausted, GETs on the same key should keep working.
-  const r = await burst.get("/api/v1/info");
+  const r = await burst.get("/v1/info");
   assert.equal(r.status, 200, "info endpoint should remain accessible regardless of send quota");
-  const a = await burst.get("/api/v1/agents");
+  const a = await burst.get("/v1/agents");
   assert.equal(a.status, 200, "list agents should remain accessible");
 });

--- a/tests/e2e-prod/suites/05-security.test.ts
+++ b/tests/e2e-prod/suites/05-security.test.ts
@@ -14,47 +14,15 @@ after(async () => {
   writeReport(`./reports/05-security.json`);
 });
 
-test("security: signing-secrets list exposes plaintext secret (documented; verify scoping)", async () => {
-  const r = await client.get<{ secrets: Array<{ id: string; secret?: string; prefix?: string }> }>(
-    "/api/v1/users/me/signing-secrets",
-  );
-  assert.equal(r.status, 200);
-  for (const s of r.body!.secrets) {
-    if (s.secret) {
-      assert.ok(s.secret.length > 16, "plaintext secret should be substantial entropy");
-    } else {
-      info(SUITE, "secret-not-in-list", `secret ${s.id} listed without plaintext field — endpoint may only return prefix`);
-    }
-  }
-});
-
-test("security: signing-secret create + delete (cleanup roundtrip)", async () => {
-  const c = await client.post<{ id: string; secret?: string }>("/api/v1/users/me/signing-secrets", {
-    body: { name: "e2e test" },
-  });
-  assert.ok(c.status === 200 || c.status === 201, `expected 2xx, got ${c.status}: ${c.raw.slice(0, 200)}`);
-  if (c.body?.id) track("signing_secret", c.body.id);
-  if (c.body?.secret) {
-    assert.ok(c.body.secret.length > 16, "freshly-created secret has substantial entropy");
-  } else {
-    info(SUITE, "create-secret-no-plaintext", "POST /signing-secrets did not return plaintext — verify users can retrieve later");
-  }
-});
-
-test("security: signing-secret DELETE with bogus id returns 4xx (no cross-tenant lookup)", async () => {
-  const r = await client.delete(`/api/v1/users/me/signing-secrets/sec_definitely_not_real_${Date.now()}`);
-  assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
-});
-
 test("security: agent name field doesn't leak HTML/script into stored body", async () => {
   const slug = uniqueSlug("xss");
   const payload = `<script>alert("xss")</script>&"<><`;
-  const c = await client.post<{ email: string }>("/api/v1/agents", {
+  const c = await client.post<{ email: string }>("/v1/agents", {
     body: { slug, name: payload, agent_mode: "local" },
   });
   assert.equal(c.status, 201, c.raw.slice(0, 200));
   track("agent", c.body!.email);
-  const g = await client.get<{ name: string }>(`/api/v1/agents/${encodeURIComponent(c.body!.email)}`);
+  const g = await client.get<{ name: string }>(`/v1/agents/${encodeURIComponent(c.body!.email)}`);
   assert.equal(g.status, 200);
   // Response is JSON — characters should be present literally, NOT HTML-escaped (JSON handles escaping).
   // The risk is if the server were silently HTML-encoding into storage; that would harm clients.
@@ -70,7 +38,7 @@ test("security: agent name field doesn't leak HTML/script into stored body", asy
 });
 
 test("security: slug accepts only safe characters (no spaces/slashes injected)", async () => {
-  const r = await client.post("/api/v1/agents", {
+  const r = await client.post("/v1/agents", {
     body: { slug: "evil slug with spaces /and/slashes", name: "x", agent_mode: "local" },
   });
   if (r.status === 201) {
@@ -82,18 +50,18 @@ test("security: slug accepts only safe characters (no spaces/slashes injected)",
 
 test("security: extremely long subject is bounded (no 500)", async () => {
   const slug = uniqueSlug("longsubj");
-  const c = await client.post<{ email: string }>("/api/v1/agents", {
+  const c = await client.post<{ email: string }>("/v1/agents", {
     body: { slug, name: "long", agent_mode: "local" },
   });
   assert.equal(c.status, 201);
   track("agent", c.body!.email);
-  await client.put(`/api/v1/agents/${encodeURIComponent(c.body!.email)}`, {
+  await client.put(`/v1/agents/${encodeURIComponent(c.body!.email)}`, {
     body: { hitl_enabled: true, hitl_expiration_action: "reject" },
   });
 
   const subject = "A".repeat(10_000);
-  const r = await client.post<{ message_id: string }>("/api/v1/send", {
-    body: { from: c.body!.email, to: ["blackhole@e2a.dev"], subject, body: "x" },
+  const r = await client.post<{ message_id: string }>(`/v1/agents/${encodeURIComponent(c.body!.email)}/messages`, {
+    body: { to: ["blackhole@e2a.dev"], subject, body: "x" },
   });
   if (r.status >= 500) {
     fail(SUITE, "long-subject-500", `10k-char subject caused ${r.status}: ${r.raw.slice(0, 200)}`);
@@ -101,24 +69,23 @@ test("security: extremely long subject is bounded (no 500)", async () => {
   assert.ok(r.status < 500, `expected 4xx or 2xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
   if ((r.status === 200 || r.status === 202) && r.body?.message_id) {
     // Clean up any queued mail.
-    await client.post(`/api/v1/messages/${r.body.message_id}/reject`, { body: { reason: "e2e long-subject cleanup" } });
+    await client.post(`/v1/agents/${encodeURIComponent(c.body!.email)}/messages/${r.body.message_id}/reject`, { body: { reason: "e2e long-subject cleanup" } });
   }
 });
 
 test("security: CRLF injection in subject rejected or sanitized (no header smuggling)", async () => {
   const slug = uniqueSlug("crlf");
-  const c = await client.post<{ email: string }>("/api/v1/agents", {
+  const c = await client.post<{ email: string }>("/v1/agents", {
     body: { slug, name: "crlf", agent_mode: "local" },
   });
   assert.equal(c.status, 201);
   track("agent", c.body!.email);
-  await client.put(`/api/v1/agents/${encodeURIComponent(c.body!.email)}`, {
+  await client.put(`/v1/agents/${encodeURIComponent(c.body!.email)}`, {
     body: { hitl_enabled: true, hitl_expiration_action: "reject" },
   });
 
-  const r = await client.post<{ message_id: string }>("/api/v1/send", {
+  const r = await client.post<{ message_id: string }>(`/v1/agents/${encodeURIComponent(c.body!.email)}/messages`, {
     body: {
-      from: c.body!.email,
       to: ["blackhole@e2a.dev"],
       subject: "Hello\r\nBcc: attacker@evil.com\r\nX-Smuggled: yes",
       body: "x",
@@ -130,7 +97,7 @@ test("security: CRLF injection in subject rejected or sanitized (no header smugg
   if (r.status === 200 || r.status === 202) {
     info(SUITE, "crlf-accepted", `CRLF in subject accepted (${r.status}). Server should sanitize before SMTP — verify in outbound path.`);
     if (r.body?.message_id) {
-      await client.post(`/api/v1/messages/${r.body.message_id}/reject`, { body: { reason: "e2e crlf cleanup" } });
+      await client.post(`/v1/agents/${encodeURIComponent(c.body!.email)}/messages/${r.body.message_id}/reject`, { body: { reason: "e2e crlf cleanup" } });
     }
   } else {
     info(SUITE, "crlf-rejected", `CRLF in subject rejected with ${r.status} — good`);
@@ -139,7 +106,7 @@ test("security: CRLF injection in subject rejected or sanitized (no header smugg
 
 test("security: export endpoint returns user's data only", async () => {
   const r = await client.get<{ user?: { email?: string }; agents?: unknown[]; messages?: unknown[] }>(
-    "/api/v1/users/me/export",
+    "/v1/account/export",
   );
   assert.equal(r.status, 200, `export expected 200, got ${r.status}: ${r.raw.slice(0, 200)}`);
   assert.ok(r.body, "export returns body");
@@ -151,8 +118,8 @@ test("security: case-insensitive email path doesn't bypass ownership", async () 
   const email = client.env.primaryAgentEmail;
   const upper = email.toUpperCase();
   const lower = email.toLowerCase();
-  const a = await client.get(`/api/v1/agents/${encodeURIComponent(lower)}`);
-  const b = await client.get(`/api/v1/agents/${encodeURIComponent(upper)}`);
+  const a = await client.get(`/v1/agents/${encodeURIComponent(lower)}`);
+  const b = await client.get(`/v1/agents/${encodeURIComponent(upper)}`);
   // Both should return same outcome (consistent normalization), neither should be 5xx.
   assert.ok(a.status < 500, `lowercase: ${a.status}`);
   assert.ok(b.status < 500, `uppercase: ${b.status}`);
@@ -163,18 +130,17 @@ test("security: case-insensitive email path doesn't bypass ownership", async () 
 
 test("security: send body with HTML — html_body distinct from body", async () => {
   const slug = uniqueSlug("html");
-  const c = await client.post<{ email: string }>("/api/v1/agents", {
+  const c = await client.post<{ email: string }>("/v1/agents", {
     body: { slug, name: "html", agent_mode: "local" },
   });
   assert.equal(c.status, 201);
   track("agent", c.body!.email);
-  await client.put(`/api/v1/agents/${encodeURIComponent(c.body!.email)}`, {
+  await client.put(`/v1/agents/${encodeURIComponent(c.body!.email)}`, {
     body: { hitl_enabled: true, hitl_expiration_action: "reject" },
   });
 
-  const r = await client.post<{ message_id: string; status: string }>("/api/v1/send", {
+  const r = await client.post<{ message_id: string; status: string }>(`/v1/agents/${encodeURIComponent(c.body!.email)}/messages`, {
     body: {
-      from: c.body!.email,
       to: ["blackhole@e2a.dev"],
       subject: "html test",
       body: "plain text alt",
@@ -183,6 +149,6 @@ test("security: send body with HTML — html_body distinct from body", async () 
   });
   assert.ok(r.status === 200 || r.status === 202, `expected 200/202, got ${r.status}: ${r.raw.slice(0, 200)}`);
   if (r.body?.message_id) {
-    await client.post(`/api/v1/messages/${r.body.message_id}/reject`, { body: { reason: "e2e html cleanup" } });
+    await client.post(`/v1/agents/${encodeURIComponent(c.body!.email)}/messages/${r.body.message_id}/reject`, { body: { reason: "e2e html cleanup" } });
   }
 });

--- a/tests/e2e-prod/suites/06-reliability.test.ts
+++ b/tests/e2e-prod/suites/06-reliability.test.ts
@@ -13,7 +13,7 @@ let sharedAgentEmail = "";
 before(async () => {
   // Single agent shared across reliability tests to avoid hitting the agent-creation rate limit.
   const slug = uniqueSlug("rel");
-  const c = await client.post<{ email: string }>("/api/v1/agents", {
+  const c = await client.post<{ email: string }>("/v1/agents", {
     body: { slug, name: "rel-shared", agent_mode: "local" },
   });
   if (c.status !== 201) {
@@ -31,7 +31,7 @@ after(async () => {
 
 function wsUrl(email: string): string {
   const base = client.env.apiUrl.replace(/^http/, "ws");
-  return `${base}/api/v1/agents/${encodeURIComponent(email)}/ws`;
+  return `${base}/v1/agents/${encodeURIComponent(email)}/ws`;
 }
 
 function openWS(url: string, key?: string | null, timeoutMs = 5_000): Promise<WebSocket> {
@@ -149,12 +149,12 @@ test("reliability: two concurrent WS sessions to same agent", async () => {
 
 test("reliability: idempotent PUT — applying same payload twice yields same state", async () => {
   const payload = { hitl_enabled: true, hitl_expiration_action: "reject", hitl_ttl_seconds: 120 };
-  const first = await client.put(`/api/v1/agents/${encodeURIComponent(sharedAgentEmail)}`, { body: payload });
-  const second = await client.put(`/api/v1/agents/${encodeURIComponent(sharedAgentEmail)}`, { body: payload });
+  const first = await client.put(`/v1/agents/${encodeURIComponent(sharedAgentEmail)}`, { body: payload });
+  const second = await client.put(`/v1/agents/${encodeURIComponent(sharedAgentEmail)}`, { body: payload });
   assert.equal(first.status, 200);
   assert.equal(second.status, 200);
   const g = await client.get<{ hitl_enabled: boolean; hitl_ttl_seconds: number; hitl_expiration_action: string }>(
-    `/api/v1/agents/${encodeURIComponent(sharedAgentEmail)}`,
+    `/v1/agents/${encodeURIComponent(sharedAgentEmail)}`,
   );
   assert.equal(g.body?.hitl_enabled, true);
   assert.equal(g.body?.hitl_ttl_seconds, 120);
@@ -162,25 +162,25 @@ test("reliability: idempotent PUT — applying same payload twice yields same st
 });
 
 test("reliability: server timestamps are RFC3339-parseable", async () => {
-  const r = await client.get<{ created_at: string }>(`/api/v1/agents/${encodeURIComponent(sharedAgentEmail)}`);
+  const r = await client.get<{ created_at: string }>(`/v1/agents/${encodeURIComponent(sharedAgentEmail)}`);
   assert.ok(r.body?.created_at);
   const t = new Date(r.body!.created_at).valueOf();
   assert.ok(!Number.isNaN(t), `created_at should parse as date: ${r.body?.created_at}`);
   assert.ok(t > 0 && t < Date.now() + 60_000, "created_at is plausibly recent");
 });
 
-test("reliability: GET /messages with bogus next_token returns 4xx, not 500", async () => {
-  const r = await client.get("/api/v1/messages", {
-    query: { limit: 5, next_token: "completely-invalid-token-xx" },
+test("reliability: GET /messages with bogus cursor returns 4xx, not 500", async () => {
+  const r = await client.get(`/v1/agents/${encodeURIComponent(sharedAgentEmail)}/messages`, {
+    query: { limit: 5, cursor: "completely-invalid-token-xx" },
   });
   if (r.status >= 500) {
-    fail(SUITE, "pagination-500", `bogus next_token caused ${r.status}: ${r.raw.slice(0, 200)}`);
+    fail(SUITE, "pagination-500", `bogus cursor caused ${r.status}: ${r.raw.slice(0, 200)}`);
   }
   assert.ok(r.status < 500, `expected <500, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
 test("reliability: GET /messages with negative limit returns 4xx, not 500", async () => {
-  const r = await client.get("/api/v1/messages", { query: { limit: -5 } });
+  const r = await client.get(`/v1/agents/${encodeURIComponent(sharedAgentEmail)}/messages`, { query: { limit: -5 } });
   if (r.status >= 500) {
     fail(SUITE, "negative-limit-500", `negative limit caused ${r.status}: ${r.raw.slice(0, 200)}`);
   }
@@ -188,14 +188,14 @@ test("reliability: GET /messages with negative limit returns 4xx, not 500", asyn
 });
 
 test("reliability: GET /messages with absurdly large limit returns 4xx or capped result, not 500", async () => {
-  const r = await client.get<{ messages: unknown[] }>("/api/v1/messages", { query: { limit: 1_000_000 } });
+  const r = await client.get<{ items: unknown[] }>(`/v1/agents/${encodeURIComponent(sharedAgentEmail)}/messages`, { query: { limit: 1_000_000 } });
   if (r.status >= 500) {
     fail(SUITE, "huge-limit-500", `huge limit caused ${r.status}: ${r.raw.slice(0, 200)}`);
   }
   assert.ok(r.status < 500, `expected <500, got ${r.status}`);
-  if (r.status === 200 && Array.isArray(r.body?.messages) && r.body!.messages.length > 1000) {
-    info(SUITE, "limit-uncapped", `server returned ${r.body!.messages.length} items for limit=1M — no server-side cap`);
+  if (r.status === 200 && Array.isArray(r.body?.items) && r.body!.items.length > 1000) {
+    info(SUITE, "limit-uncapped", `server returned ${r.body!.items.length} items for limit=1M — no server-side cap`);
   } else if (r.status === 200) {
-    info(SUITE, "limit-capped", `server capped result to ${r.body?.messages.length ?? "?"} items for limit=1M`);
+    info(SUITE, "limit-capped", `server capped result to ${r.body?.items.length ?? "?"} items for limit=1M`);
   }
 });

--- a/tests/e2e-prod/suites/07-error-contract.test.ts
+++ b/tests/e2e-prod/suites/07-error-contract.test.ts
@@ -27,20 +27,20 @@ function noteShape(label: string, r: RawResponse) {
 }
 
 test("error-contract: malformed JSON body returns 4xx, not 5xx", async () => {
-  const r = await client.post("/api/v1/agents", { body: "{not json", headers: { "Content-Type": "application/json" } });
+  const r = await client.post("/v1/agents", { body: "{not json", headers: { "Content-Type": "application/json" } });
   noteShape("post-agents-bad-json", r);
   if (r.status >= 500) fail(SUITE, "bad-json-500", `malformed JSON caused ${r.status}: ${r.raw.slice(0, 200)}`);
   assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}`);
 });
 
 test("error-contract: empty body on POST /agents returns 4xx", async () => {
-  const r = await client.post("/api/v1/agents", { body: "", headers: { "Content-Type": "application/json" } });
+  const r = await client.post("/v1/agents", { body: "", headers: { "Content-Type": "application/json" } });
   noteShape("post-agents-empty", r);
   assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
 test("error-contract: wrong content-type on POST /agents returns 4xx", async () => {
-  const r = await client.post("/api/v1/agents", {
+  const r = await client.post("/v1/agents", {
     body: "slug=foo&name=bar",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
   });
@@ -49,36 +49,36 @@ test("error-contract: wrong content-type on POST /agents returns 4xx", async () 
 });
 
 test("error-contract: GET /info ignores body+method shenanigans", async () => {
-  const r = await client.get("/api/v1/info");
+  const r = await client.get("/v1/info");
   assert.equal(r.status, 200);
 });
 
 test("error-contract: POST /info returns 4xx or 405 (read-only endpoint)", async () => {
-  const r = await client.post("/api/v1/info", { body: {} });
+  const r = await client.post("/v1/info", { body: {} });
   noteShape("post-info", r);
   assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
-test("error-contract: PUT /api/v1/messages (no such method) returns 405 or 4xx", async () => {
-  const r = await client.put("/api/v1/messages", { body: {} });
+test("error-contract: PUT /v1/agents/{email}/messages (no such method) returns 405 or 4xx", async () => {
+  const r = await client.put(`/v1/agents/${encodeURIComponent(client.env.primaryAgentEmail)}/messages`, { body: {} });
   noteShape("put-messages", r);
   assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}`);
 });
 
-test("error-contract: DELETE /api/v1/messages (no such method) returns 4xx", async () => {
-  const r = await client.delete("/api/v1/messages");
+test("error-contract: DELETE /v1/agents/{email}/messages (no such method) returns 4xx", async () => {
+  const r = await client.delete(`/v1/agents/${encodeURIComponent(client.env.primaryAgentEmail)}/messages`);
   noteShape("delete-messages", r);
   assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}`);
 });
 
 test("error-contract: GET nonexistent path returns 404", async () => {
-  const r = await client.get("/api/v1/this/does/not/exist");
+  const r = await client.get("/v1/this/does/not/exist");
   noteShape("nonexistent-path", r);
   assert.equal(r.status, 404, `expected 404, got ${r.status}`);
 });
 
 test("error-contract: traversal attempt returns 4xx, not file leak", async () => {
-  const r = await client.get("/api/v1/agents/..%2F..%2Fetc%2Fpasswd");
+  const r = await client.get("/v1/agents/..%2F..%2Fetc%2Fpasswd");
   if (r.status === 200) {
     fail(SUITE, "traversal-200", "path traversal returned 200 — possible bug");
   }
@@ -87,48 +87,49 @@ test("error-contract: traversal attempt returns 4xx, not file leak", async () =>
 
 test("error-contract: very long email path is bounded (no 500)", async () => {
   const long = "a".repeat(2000) + "@example.com";
-  const r = await client.get(`/api/v1/agents/${encodeURIComponent(long)}`);
+  const r = await client.get(`/v1/agents/${encodeURIComponent(long)}`);
   if (r.status >= 500) fail(SUITE, "long-email-500", `${r.status}: ${r.raw.slice(0, 200)}`);
   assert.ok(r.status < 500, `expected <500, got ${r.status}`);
 });
 
 test("error-contract: invalid query types on /messages?limit=abc handled gracefully", async () => {
-  const r = await client.get("/api/v1/messages?limit=abc");
+  const r = await client.get(`/v1/agents/${encodeURIComponent(client.env.primaryAgentEmail)}/messages?limit=abc`);
   if (r.status >= 500) fail(SUITE, "bad-limit-500", `${r.status}: ${r.raw.slice(0, 200)}`);
   assert.ok(r.status < 500, `expected <500, got ${r.status}`);
 });
 
 test("error-contract: PATCH on /domains/<bogus> returns 4xx", async () => {
-  const r = await client.patch(`/api/v1/domains/bogus-${Date.now()}.example.com`, { body: {} });
+  const r = await client.patch(`/v1/domains/bogus-${Date.now()}.example.com`, { body: {} });
   noteShape("patch-bogus-domain", r);
   assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
 test("error-contract: POST /domains/<bogus>/verify returns 4xx", async () => {
-  const r = await client.post(`/api/v1/domains/bogus-${Date.now()}.example.com/verify`, { body: {} });
+  const r = await client.post(`/v1/domains/bogus-${Date.now()}.example.com/verify`, { body: {} });
   noteShape("verify-bogus-domain", r);
   assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
-test("error-contract: invalid email path in /send.from", async () => {
-  const r = await client.post("/api/v1/send", {
-    body: { from: "not-an-email", to: ["someone@example.com"], subject: "x", body: "x" },
+test("error-contract: invalid sending-agent email in path", async () => {
+  // The sender is named in the path; a malformed sender address must 4xx.
+  const r = await client.post(`/v1/agents/${encodeURIComponent("not-an-email")}/messages`, {
+    body: { to: ["someone@example.com"], subject: "x", body: "x" },
   });
   noteShape("send-bad-from", r);
   assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
 test("error-contract: send with empty 'to' array returns 4xx", async () => {
-  const r = await client.post("/api/v1/send", {
-    body: { from: client.env.primaryAgentEmail, to: [], subject: "x", body: "x" },
+  const r = await client.post(`/v1/agents/${encodeURIComponent(client.env.primaryAgentEmail)}/messages`, {
+    body: { to: [], subject: "x", body: "x" },
   });
   noteShape("send-empty-to", r);
   assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
 test("error-contract: send with invalid recipient address returns 4xx (no smtp call)", async () => {
-  const r = await client.post("/api/v1/send", {
-    body: { from: client.env.primaryAgentEmail, to: ["definitely not an email"], subject: "x", body: "x" },
+  const r = await client.post(`/v1/agents/${encodeURIComponent(client.env.primaryAgentEmail)}/messages`, {
+    body: { to: ["definitely not an email"], subject: "x", body: "x" },
   });
   noteShape("send-bad-recipient", r);
   assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);

--- a/tests/e2e-prod/suites/09-postfix.test.ts
+++ b/tests/e2e-prod/suites/09-postfix.test.ts
@@ -16,7 +16,7 @@ after(async () => {
 
 test("postfix #3: POST /agents without agent_mode returns 400 (was implicit default to cloud)", async () => {
   const slug = uniqueSlug("nomode");
-  const r = await client.post("/api/v1/agents", { body: { slug, name: "no mode" } });
+  const r = await client.post("/v1/agents", { body: { slug, name: "no mode" } });
   assert.equal(r.status, 400, `expected 400, got ${r.status}: ${r.raw.slice(0, 200)}`);
   // Body should mention agent_mode explicitly.
   assert.ok(/agent_mode/i.test(r.raw), `expected error mentioning agent_mode, got: ${r.raw.slice(0, 200)}`);
@@ -25,14 +25,14 @@ test("postfix #3: POST /agents without agent_mode returns 400 (was implicit defa
 
 test("postfix #3: invalid agent_mode value returns 400", async () => {
   const slug = uniqueSlug("badmode");
-  const r = await client.post("/api/v1/agents", {
+  const r = await client.post("/v1/agents", {
     body: { slug, name: "bad mode", agent_mode: "neither-local-nor-cloud" },
   });
   assert.equal(r.status, 400, `expected 400, got ${r.status}`);
 });
 
 test("postfix #4: GET nonexistent path returns 404 with text/plain body", async () => {
-  const r = await client.get("/api/v1/this/does/not/exist");
+  const r = await client.get("/v1/this/does/not/exist");
   assert.equal(r.status, 404, `expected 404, got ${r.status}`);
   const ct = r.headers["content-type"] ?? "";
   assert.ok(ct.startsWith("text/plain"), `expected text/plain, got "${ct}"`);
@@ -41,7 +41,7 @@ test("postfix #4: GET nonexistent path returns 404 with text/plain body", async 
 });
 
 test("postfix #4: wrong-method on /info returns 405 with text/plain body (was empty)", async () => {
-  const r = await client.post("/api/v1/info", { body: {} });
+  const r = await client.post("/v1/info", { body: {} });
   assert.equal(r.status, 405, `expected 405, got ${r.status}`);
   const ct = r.headers["content-type"] ?? "";
   assert.ok(ct.startsWith("text/plain"), `expected text/plain, got "${ct}"`);
@@ -50,7 +50,8 @@ test("postfix #4: wrong-method on /info returns 405 with text/plain body (was em
 });
 
 test("postfix #4: wrong-method on /messages returns 405 with body", async () => {
-  const r = await client.put("/api/v1/messages", { body: {} });
+  const email = client.env.primaryAgentEmail;
+  const r = await client.put(`/v1/agents/${encodeURIComponent(email)}/messages`, { body: {} });
   assert.equal(r.status, 405, `expected 405, got ${r.status}`);
   const ct = r.headers["content-type"] ?? "";
   assert.ok(ct.startsWith("text/plain"), `expected text/plain, got "${ct}"`);
@@ -58,8 +59,8 @@ test("postfix #4: wrong-method on /messages returns 405 with body", async () => 
 
 test("postfix #6: GET /agents/{email} is case-insensitive (lowercase + uppercase match)", async () => {
   const email = client.env.primaryAgentEmail;
-  const lower = await client.get(`/api/v1/agents/${encodeURIComponent(email.toLowerCase())}`);
-  const upper = await client.get(`/api/v1/agents/${encodeURIComponent(email.toUpperCase())}`);
+  const lower = await client.get(`/v1/agents/${encodeURIComponent(email.toLowerCase())}`);
+  const upper = await client.get(`/v1/agents/${encodeURIComponent(email.toUpperCase())}`);
   assert.equal(lower.status, 200, "lowercase form should resolve");
   assert.equal(upper.status, 200, `uppercase form should also resolve, got ${upper.status}: ${upper.raw.slice(0, 200)}`);
   if (lower.body && upper.body) {
@@ -75,14 +76,13 @@ test("postfix #6: GET /agents/{email} with mixed-case still matches", async () =
   const local = email.split("@")[0];
   const domain = email.split("@")[1];
   const mixed = local.toUpperCase() + "@" + domain.toLowerCase();
-  const r = await client.get(`/api/v1/agents/${encodeURIComponent(mixed)}`);
+  const r = await client.get(`/v1/agents/${encodeURIComponent(mixed)}`);
   assert.equal(r.status, 200, `mixed-case email should match, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
 test("postfix #7: /send with CRLF in subject is rejected at the API (400)", async () => {
-  const r = await client.post("/api/v1/send", {
+  const r = await client.post(`/v1/agents/${encodeURIComponent(client.env.primaryAgentEmail)}/messages`, {
     body: {
-      from: client.env.primaryAgentEmail,
       to: ["blackhole@e2a.dev"],
       subject: "Hello\r\nBcc: attacker@evil.com",
       body: "x",
@@ -94,9 +94,8 @@ test("postfix #7: /send with CRLF in subject is rejected at the API (400)", asyn
 });
 
 test("postfix #7: bare LF in subject is also rejected (no carriage return)", async () => {
-  const r = await client.post("/api/v1/send", {
+  const r = await client.post(`/v1/agents/${encodeURIComponent(client.env.primaryAgentEmail)}/messages`, {
     body: {
-      from: client.env.primaryAgentEmail,
       to: ["blackhole@e2a.dev"],
       subject: "Hello\nX-Smuggled: yes",
       body: "x",
@@ -118,7 +117,7 @@ test("postfix #1 #2: /agents 429 includes Retry-After header (active probe — d
   let saw429 = false;
   let retryAfter: string | undefined;
   for (let i = 0; i < 25; i++) {
-    const r = await client.post<{ email?: string }>("/api/v1/agents", {
+    const r = await client.post<{ email?: string }>("/v1/agents", {
       body: { slug: uniqueSlug(`pf${i}`), name: "pf", agent_mode: "local" },
     });
     if (r.status === 429) {

--- a/tests/e2e-prod/suites/10-domains.test.ts
+++ b/tests/e2e-prod/suites/10-domains.test.ts
@@ -23,7 +23,7 @@ after(async () => {
 test("domains: register returns 201 with DNS records + zero-counted Domain", async () => {
   const domain = fakeDomain("reg");
   const r = await client.post<{ domain: string; dns_records?: { txt?: unknown; mx?: unknown; spf?: unknown; dkim?: unknown }; agent_count?: number }>(
-    "/api/v1/domains",
+    "/v1/domains",
     { body: { domain } },
   );
   if (r.status !== 201) {
@@ -31,7 +31,7 @@ test("domains: register returns 201 with DNS records + zero-counted Domain", asy
     // Hard assert — the primary register test of the domains suite must
     // fail loudly if POST /domains regresses, not just record a JSON
     // finding behind a green node:test dot.
-    assert.fail(`POST /api/v1/domains expected 201, got ${r.status}: ${r.raw.slice(0, 200)}`);
+    assert.fail(`POST /v1/domains expected 201, got ${r.status}: ${r.raw.slice(0, 200)}`);
   }
   track("domain", domain);
   assert.equal(r.body?.domain, domain, "echoed domain matches");
@@ -44,26 +44,26 @@ test("domains: register returns 201 with DNS records + zero-counted Domain", asy
 
 test("domains: GET /domains/{domain} returns same record after register", async () => {
   const domain = fakeDomain("get");
-  const c = await client.post("/api/v1/domains", { body: { domain } });
+  const c = await client.post("/v1/domains", { body: { domain } });
   if (c.status !== 201) {
     info(SUITE, "register-skipped", `register returned ${c.status} — skipping get probe: ${c.raw.slice(0, 200)}`);
     return;
   }
   track("domain", domain);
-  const g = await client.get<{ domain: string; dns_records?: unknown }>(`/api/v1/domains/${encodeURIComponent(domain)}`);
+  const g = await client.get<{ domain: string; dns_records?: unknown }>(`/v1/domains/${encodeURIComponent(domain)}`);
   assert.equal(g.status, 200, `GET expected 200, got ${g.status}: ${g.raw.slice(0, 200)}`);
   assert.equal(g.body?.domain, domain);
 });
 
 test("domains: list includes newly-registered domain", async () => {
   const domain = fakeDomain("list");
-  const c = await client.post("/api/v1/domains", { body: { domain } });
+  const c = await client.post("/v1/domains", { body: { domain } });
   if (c.status !== 201) {
     info(SUITE, "list-skipped", `register returned ${c.status} — skipping list probe`);
     return;
   }
   track("domain", domain);
-  const list = await client.get<{ domains: Array<{ domain: string }> }>("/api/v1/domains");
+  const list = await client.get<{ domains: Array<{ domain: string }> }>("/v1/domains");
   assert.equal(list.status, 200);
   const found = list.body?.domains.some((d) => d.domain === domain);
   assert.ok(found, `freshly-registered ${domain} not in list response`);
@@ -71,14 +71,14 @@ test("domains: list includes newly-registered domain", async () => {
 
 test("domains: verify unowned-DNS domain returns 412 (TXT missing) with per-record diagnostic", async () => {
   const domain = fakeDomain("verify");
-  const c = await client.post("/api/v1/domains", { body: { domain } });
+  const c = await client.post("/v1/domains", { body: { domain } });
   if (c.status !== 201) {
     info(SUITE, "verify-skipped", `register returned ${c.status} — skipping verify`);
     return;
   }
   track("domain", domain);
   const v = await client.post<{ domain: string; mx?: unknown; spf?: unknown; dkim?: unknown }>(
-    `/api/v1/domains/${encodeURIComponent(domain)}/verify`,
+    `/v1/domains/${encodeURIComponent(domain)}/verify`,
     { body: {} },
   );
   // Spec: 200 if verified, 412 if TXT missing. Real DNS for our fake domain has no
@@ -98,21 +98,21 @@ test("domains: verify unowned-DNS domain returns 412 (TXT missing) with per-reco
 
 test("domains: DELETE returns 204 and removes from list", async () => {
   const domain = fakeDomain("del");
-  const c = await client.post("/api/v1/domains", { body: { domain } });
+  const c = await client.post("/v1/domains", { body: { domain } });
   if (c.status !== 201) {
     info(SUITE, "delete-skipped", `register returned ${c.status} — skipping delete probe`);
     return;
   }
   // Don't track — this test consumes it.
-  const del = await client.delete(`/api/v1/domains/${encodeURIComponent(domain)}`);
+  const del = await client.delete(`/v1/domains/${encodeURIComponent(domain)}`);
   assert.equal(del.status, 204, `DELETE expected 204, got ${del.status}: ${del.raw.slice(0, 200)}`);
-  const after = await client.get(`/api/v1/domains/${encodeURIComponent(domain)}`);
+  const after = await client.get(`/v1/domains/${encodeURIComponent(domain)}`);
   assert.ok(after.status === 404 || after.status === 403, `deleted domain should 404/403, got ${after.status}`);
 });
 
 test("domains: DELETE of a domain with agents on it fails (400)", async () => {
   const domain = fakeDomain("inuse");
-  const c = await client.post("/api/v1/domains", { body: { domain } });
+  const c = await client.post("/v1/domains", { body: { domain } });
   if (c.status !== 201) {
     info(SUITE, "in-use-skipped", `register returned ${c.status} — skipping in-use probe`);
     return;
@@ -129,24 +129,24 @@ test("domains: DELETE of a domain with agents on it fails (400)", async () => {
 });
 
 test("domains: register malformed domain returns 4xx", async () => {
-  const r = await client.post("/api/v1/domains", { body: { domain: "not a domain, just garbage" } });
+  const r = await client.post("/v1/domains", { body: { domain: "not a domain, just garbage" } });
   assert.ok(r.status >= 400 && r.status < 500, `expected 4xx for bad domain, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
 test("domains: register empty body returns 4xx", async () => {
-  const r = await client.post("/api/v1/domains", { body: {} });
+  const r = await client.post("/v1/domains", { body: {} });
   assert.ok(r.status >= 400 && r.status < 500, `expected 4xx for empty body, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
 test("domains: register duplicate returns 4xx (probably 409)", async () => {
   const domain = fakeDomain("dup");
-  const first = await client.post("/api/v1/domains", { body: { domain } });
+  const first = await client.post("/v1/domains", { body: { domain } });
   if (first.status !== 201) {
     info(SUITE, "dup-skipped", `first register returned ${first.status} — skipping dup probe`);
     return;
   }
   track("domain", domain);
-  const second = await client.post("/api/v1/domains", { body: { domain } });
+  const second = await client.post("/v1/domains", { body: { domain } });
   assert.ok(second.status >= 400 && second.status < 500, `dup expected 4xx, got ${second.status}: ${second.raw.slice(0, 200)}`);
   if (second.status !== 409) {
     info(SUITE, "dup-non-409", `duplicate domain register returned ${second.status} instead of 409: ${second.raw.slice(0, 200)}`);
@@ -154,12 +154,12 @@ test("domains: register duplicate returns 4xx (probably 409)", async () => {
 });
 
 test("domains: GET unowned domain returns 4xx (no info leak)", async () => {
-  const r = await client.get(`/api/v1/domains/${encodeURIComponent("not-mine-domain-987654321.example.com")}`);
+  const r = await client.get(`/v1/domains/${encodeURIComponent("not-mine-domain-987654321.example.com")}`);
   assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
 test("domains: DELETE unowned domain returns 4xx (no cross-tenant delete)", async () => {
-  const r = await client.delete(`/api/v1/domains/${encodeURIComponent("not-mine-domain-987654321.example.com")}`);
+  const r = await client.delete(`/v1/domains/${encodeURIComponent("not-mine-domain-987654321.example.com")}`);
   if (r.status === 200 || r.status === 204) {
     fail(SUITE, "cross-tenant-domain-delete", "CRITICAL: deleted a domain we don't own");
   }
@@ -167,12 +167,12 @@ test("domains: DELETE unowned domain returns 4xx (no cross-tenant delete)", asyn
 });
 
 test("domains: verify nonexistent domain returns 404", async () => {
-  const r = await client.post(`/api/v1/domains/${encodeURIComponent("definitely-not-registered-" + Date.now() + ".example.com")}/verify`, { body: {} });
+  const r = await client.post(`/v1/domains/${encodeURIComponent("definitely-not-registered-" + Date.now() + ".example.com")}/verify`, { body: {} });
   assert.ok(r.status === 404 || (r.status >= 400 && r.status < 500), `expected 404/4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
 test("domains: PATCH on nonexistent domain returns 4xx", async () => {
-  const r = await client.patch(`/api/v1/domains/${encodeURIComponent("definitely-not-registered-" + Date.now() + ".example.com")}`, {
+  const r = await client.patch(`/v1/domains/${encodeURIComponent("definitely-not-registered-" + Date.now() + ".example.com")}`, {
     body: { is_primary: true },
   });
   assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);

--- a/tests/e2e-prod/suites/11-messaging.test.ts
+++ b/tests/e2e-prod/suites/11-messaging.test.ts
@@ -16,66 +16,67 @@ after(async () => {
 
 async function createHitlAgent(name: string): Promise<string> {
   const slug = uniqueSlug(name);
-  const c = await client.post<{ email: string }>("/api/v1/agents", {
+  const c = await client.post<{ email: string }>("/v1/agents", {
     body: { slug, name, agent_mode: "local" },
   });
   if (c.status !== 201) throw new Error(`create agent failed: ${c.status} ${c.raw.slice(0, 200)}`);
   const email = c.body!.email;
   track("agent", email);
-  const u = await client.put(`/api/v1/agents/${encodeURIComponent(email)}`, {
+  const u = await client.put(`/v1/agents/${encodeURIComponent(email)}`, {
     body: { hitl_enabled: true, hitl_expiration_action: "reject", hitl_ttl_seconds: 120 },
   });
   if (u.status !== 200) throw new Error(`enable HITL failed: ${u.status} ${u.raw.slice(0, 200)}`);
   return email;
 }
 
-test("messaging: pagination roundtrip — limit=3 then follow next_token; no duplicate ids", async () => {
+test("messaging: pagination roundtrip — limit=3 then follow cursor; no duplicate ids", async () => {
   // Queue a few HITL messages so we have something to paginate against.
   const email = await createHitlAgent("pag");
   const queued: string[] = [];
   for (let i = 0; i < 5; i++) {
-    const s = await client.post<{ message_id: string }>("/api/v1/send", {
-      body: { from: email, to: [SINK_EMAIL], subject: uniqueSubject(`pag ${i}`), body: "x" },
+    const s = await client.post<{ message_id: string }>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
+      body: { to: [SINK_EMAIL], subject: uniqueSubject(`pag ${i}`), body: "x" },
     });
     if (s.body?.message_id) queued.push(s.body.message_id);
   }
 
-  const page1 = await client.get<{ messages: Array<{ id: string }>; next_token?: string }>(
-    "/api/v1/messages",
-    { query: { limit: 3 } },
+  const page1 = await client.get<{ items: Array<{ id: string }>; next_cursor?: string | null }>(
+    `/v1/agents/${encodeURIComponent(email)}/messages`,
+    { query: { limit: 3, direction: "all" } },
   );
   assert.equal(page1.status, 200);
-  assert.ok(Array.isArray(page1.body?.messages));
-  if (!page1.body?.next_token) {
+  assert.ok(Array.isArray(page1.body?.items));
+  if (!page1.body?.next_cursor) {
     info(SUITE, "pagination-single-page", "fewer than 3+1 messages in inbox — pagination not exercised");
     // Cleanup queued.
-    for (const id of queued) await client.post(`/api/v1/messages/${id}/reject`, { body: { reason: "e2e pagination cleanup" } });
+    for (const id of queued) await client.post(`/v1/agents/${encodeURIComponent(email)}/messages/${id}/reject`, { body: { reason: "e2e pagination cleanup" } });
     return;
   }
-  const page2 = await client.get<{ messages: Array<{ id: string }>; next_token?: string }>(
-    "/api/v1/messages",
-    { query: { limit: 3, next_token: page1.body.next_token } },
+  const page2 = await client.get<{ items: Array<{ id: string }>; next_cursor?: string | null }>(
+    `/v1/agents/${encodeURIComponent(email)}/messages`,
+    { query: { limit: 3, cursor: page1.body.next_cursor, direction: "all" } },
   );
   assert.equal(page2.status, 200, `page2 status ${page2.status}: ${page2.raw.slice(0, 200)}`);
-  const ids1 = new Set((page1.body!.messages ?? []).map((m) => m.id));
-  const ids2 = new Set((page2.body!.messages ?? []).map((m) => m.id));
+  const ids1 = new Set((page1.body!.items ?? []).map((m) => m.id));
+  const ids2 = new Set((page2.body!.items ?? []).map((m) => m.id));
   const overlap = [...ids1].filter((id) => ids2.has(id));
   if (overlap.length > 0) {
     fail(SUITE, "pagination-duplicate-ids", `${overlap.length} ids appear on both pages: ${overlap.slice(0, 5).join(",")}`);
     // Cleanup before throwing so we don't leak HITL-held messages.
-    for (const id of queued) await client.post(`/api/v1/messages/${id}/reject`, { body: { reason: "e2e pagination cleanup" } });
+    for (const id of queued) await client.post(`/v1/agents/${encodeURIComponent(email)}/messages/${id}/reject`, { body: { reason: "e2e pagination cleanup" } });
     assert.fail(`pagination roundtrip returned ${overlap.length} duplicate id(s) — pagination is broken`);
   }
   // Cleanup.
-  for (const id of queued) await client.post(`/api/v1/messages/${id}/reject`, { body: { reason: "e2e pagination cleanup" } });
+  for (const id of queued) await client.post(`/v1/agents/${encodeURIComponent(email)}/messages/${id}/reject`, { body: { reason: "e2e pagination cleanup" } });
 });
 
 test("messaging: Idempotency-Key replay — same key+body returns same message_id", async () => {
   const email = await createHitlAgent("idem");
   const idemKey = uniqueIdempotencyKey();
-  const body = { from: email, to: [SINK_EMAIL], subject: uniqueSubject("idem"), body: "idempotency test" };
+  const sendPath = `/v1/agents/${encodeURIComponent(email)}/messages`;
+  const body = { to: [SINK_EMAIL], subject: uniqueSubject("idem"), body: "idempotency test" };
 
-  const r1 = await client.post<{ message_id: string; status: string }>("/api/v1/send", {
+  const r1 = await client.post<{ message_id: string; status: string }>(sendPath, {
     body,
     headers: { "Idempotency-Key": idemKey },
   });
@@ -83,7 +84,7 @@ test("messaging: Idempotency-Key replay — same key+body returns same message_i
   assert.ok(r1.body?.message_id, "first send returned message_id");
   const firstId = r1.body!.message_id;
 
-  const r2 = await client.post<{ message_id: string; status: string }>("/api/v1/send", {
+  const r2 = await client.post<{ message_id: string; status: string }>(sendPath, {
     body,
     headers: { "Idempotency-Key": idemKey },
   });
@@ -95,16 +96,16 @@ test("messaging: Idempotency-Key replay — same key+body returns same message_i
     );
     // Hard assert — Idempotency-Key semantics are a financial-stakes
     // contract (double-send protection on approve). Don't paper over.
-    await client.post(`/api/v1/messages/${firstId}/reject`, { body: { reason: "e2e idem cleanup pre-fail" } });
+    await client.post(`/v1/agents/${encodeURIComponent(email)}/messages/${firstId}/reject`, { body: { reason: "e2e idem cleanup pre-fail" } });
     if (r2.body?.message_id) {
-      await client.post(`/api/v1/messages/${r2.body.message_id}/reject`, { body: { reason: "e2e idem cleanup pre-fail" } });
+      await client.post(`/v1/agents/${encodeURIComponent(email)}/messages/${r2.body.message_id}/reject`, { body: { reason: "e2e idem cleanup pre-fail" } });
     }
     assert.fail(`Idempotency-Key replay broken: ${firstId} !== ${r2.body?.message_id}`);
   }
   info(SUITE, "idem-key-replayed", `Idempotency-Key replay correct: same key+body → same message_id ${firstId}`);
 
   // Different body, same key → 422 per spec.
-  const r3 = await client.post("/api/v1/send", {
+  const r3 = await client.post(sendPath, {
     body: { ...body, subject: uniqueSubject("idem mutated") },
     headers: { "Idempotency-Key": idemKey },
   });
@@ -112,13 +113,13 @@ test("messaging: Idempotency-Key replay — same key+body returns same message_i
     info(SUITE, "idem-diff-body-non-422", `same key + DIFFERENT body returned ${r3.status} instead of 422: ${r3.raw.slice(0, 200)}`);
   }
 
-  await client.post(`/api/v1/messages/${firstId}/reject`, { body: { reason: "e2e idem cleanup" } });
+  await client.post(`/v1/agents/${encodeURIComponent(email)}/messages/${firstId}/reject`, { body: { reason: "e2e idem cleanup" } });
 });
 
 test("messaging: /agents/{email}/test on HITL agent returns 202 with message_id (and is rejectable)", async () => {
   const email = await createHitlAgent("test-ep");
   const r = await client.post<{ status?: string; message_id?: string } | Record<string, string>>(
-    `/api/v1/agents/${encodeURIComponent(email)}/test`,
+    `/v1/agents/${encodeURIComponent(email)}/test`,
     { body: {} },
   );
   if (r.status === 403) {
@@ -135,7 +136,7 @@ test("messaging: /agents/{email}/test on HITL agent returns 202 with message_id 
   }
   const msgId = (r.body as { message_id?: string })?.message_id;
   if (msgId) {
-    const rej = await client.post(`/api/v1/messages/${msgId}/reject`, { body: { reason: "e2e /test cleanup" } });
+    const rej = await client.post(`/v1/agents/${encodeURIComponent(email)}/messages/${msgId}/reject`, { body: { reason: "e2e /test cleanup" } });
     assert.ok(rej.status === 200, `failed to reject /test message: ${rej.status} ${rej.raw.slice(0, 200)}`);
   } else {
     info(SUITE, "test-no-msgid", "response body did not include message_id");
@@ -144,8 +145,8 @@ test("messaging: /agents/{email}/test on HITL agent returns 202 with message_id 
 
 test("messaging: HITL approve flow — send queues, approve sends, status→sent", async () => {
   const email = await createHitlAgent("appr");
-  const s = await client.post<{ message_id: string; status: string }>("/api/v1/send", {
-    body: { from: email, to: [SINK_EMAIL], subject: uniqueSubject("approve"), body: "approve me" },
+  const s = await client.post<{ message_id: string; status: string }>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
+    body: { to: [SINK_EMAIL], subject: uniqueSubject("approve"), body: "approve me" },
   });
   if (s.status !== 202) {
     info(SUITE, "approve-no-202", `expected 202 from HITL send, got ${s.status}: ${s.raw.slice(0, 200)}`);
@@ -155,7 +156,7 @@ test("messaging: HITL approve flow — send queues, approve sends, status→sent
   const id = s.body!.message_id;
 
   // Approve — empty body approves as-is. Goes out via SMTP to blackhole sink.
-  const ap = await client.post<{ message_id: string; status: string }>(`/api/v1/messages/${id}/approve`, { body: {} });
+  const ap = await client.post<{ message_id: string; status: string }>(`/v1/agents/${encodeURIComponent(email)}/messages/${id}/approve`, { body: {} });
   if (ap.status !== 200) {
     fail(SUITE, "approve-non-200", `approve returned ${ap.status}: ${ap.raw.slice(0, 200)}`);
     return;
@@ -166,7 +167,7 @@ test("messaging: HITL approve flow — send queues, approve sends, status→sent
   info(SUITE, "approve-final-status", `approve returned status="${finalStatus}"`);
 
   // Re-approve must fail with 409 (already sent).
-  const ap2 = await client.post(`/api/v1/messages/${id}/approve`, { body: {} });
+  const ap2 = await client.post(`/v1/agents/${encodeURIComponent(email)}/messages/${id}/approve`, { body: {} });
   if (ap2.status !== 409) {
     info(SUITE, "double-approve-non-409", `re-approve of sent message returned ${ap2.status} instead of 409: ${ap2.raw.slice(0, 200)}`);
   }
@@ -174,8 +175,8 @@ test("messaging: HITL approve flow — send queues, approve sends, status→sent
 
 test("messaging: reject of a sent message returns 409 (state guard)", async () => {
   const email = await createHitlAgent("rej");
-  const s = await client.post<{ message_id: string }>("/api/v1/send", {
-    body: { from: email, to: [SINK_EMAIL], subject: uniqueSubject("reject after send"), body: "x" },
+  const s = await client.post<{ message_id: string }>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
+    body: { to: [SINK_EMAIL], subject: uniqueSubject("reject after send"), body: "x" },
   });
   if (s.status !== 202 || !s.body?.message_id) {
     info(SUITE, "rej-after-send-skipped", `setup HITL send returned ${s.status}: ${s.raw.slice(0, 200)}`);
@@ -183,13 +184,13 @@ test("messaging: reject of a sent message returns 409 (state guard)", async () =
   }
   const id = s.body.message_id;
   // First approve so it transitions to sent.
-  const ap = await client.post(`/api/v1/messages/${id}/approve`, { body: {} });
+  const ap = await client.post(`/v1/agents/${encodeURIComponent(email)}/messages/${id}/approve`, { body: {} });
   if (ap.status !== 200) {
     info(SUITE, "rej-after-send-approve-failed", `approve returned ${ap.status}, can't test reject-after-send`);
     return;
   }
   // Now reject the same message — must 409.
-  const rej = await client.post(`/api/v1/messages/${id}/reject`, { body: { reason: "should fail" } });
+  const rej = await client.post(`/v1/agents/${encodeURIComponent(email)}/messages/${id}/reject`, { body: { reason: "should fail" } });
   if (rej.status !== 409) {
     info(SUITE, "reject-after-send-non-409", `expected 409 for reject after send, got ${rej.status}: ${rej.raw.slice(0, 200)}`);
   }
@@ -197,8 +198,8 @@ test("messaging: reject of a sent message returns 409 (state guard)", async () =
 
 test("messaging: approve with field overrides applies them before send", async () => {
   const email = await createHitlAgent("appov");
-  const s = await client.post<{ message_id: string }>("/api/v1/send", {
-    body: { from: email, to: [SINK_EMAIL], subject: uniqueSubject("original"), body: "original body" },
+  const s = await client.post<{ message_id: string }>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
+    body: { to: [SINK_EMAIL], subject: uniqueSubject("original"), body: "original body" },
   });
   if (s.status !== 202 || !s.body?.message_id) {
     info(SUITE, "approve-override-skipped", `setup send returned ${s.status}`);
@@ -207,7 +208,7 @@ test("messaging: approve with field overrides applies them before send", async (
   const id = s.body.message_id;
   // Override subject + body on approve. Spec: any subset of subject/body/body_html/to/cc/bcc/attachments.
   const ap = await client.post<{ message_id: string; status: string }>(
-    `/api/v1/messages/${id}/approve`,
+    `/v1/agents/${encodeURIComponent(email)}/messages/${id}/approve`,
     { body: { subject: "overridden subject (approve-time)", body_text: "overridden body" } },
   );
   if (ap.status !== 200) {
@@ -217,7 +218,7 @@ test("messaging: approve with field overrides applies them before send", async (
   // Fetch the message to see whether the override was actually persisted to the
   // sent record. Note: body columns are scrubbed on send per the approve description;
   // subject may remain.
-  const g = await client.get<{ subject?: string; status?: string }>(`/api/v1/messages/${id}`);
+  const g = await client.get<{ subject?: string; status?: string }>(`/v1/agents/${encodeURIComponent(email)}/messages/${id}`);
   if (g.status === 200) {
     info(SUITE, "approve-override-readback", `final subject after override approve: "${g.body?.subject ?? "(absent)"}", status="${g.body?.status}"`);
   } else {
@@ -228,7 +229,7 @@ test("messaging: approve with field overrides applies them before send", async (
 test("messaging: reply to bogus message ID returns 404", async () => {
   const email = client.env.primaryAgentEmail;
   const r = await client.post(
-    `/api/v1/agents/${encodeURIComponent(email)}/messages/msg_does_not_exist_${Date.now()}/reply`,
+    `/v1/agents/${encodeURIComponent(email)}/messages/msg_does_not_exist_${Date.now()}/reply`,
     { body: { body: "won't be delivered" } },
   );
   assert.ok(r.status === 404 || (r.status >= 400 && r.status < 500), `expected 4xx (404), got ${r.status}: ${r.raw.slice(0, 200)}`);
@@ -242,17 +243,17 @@ test("messaging: reply with empty body returns 400", async () => {
   // "empty body returns 400" branch. Now: pull from the agent-scoped
   // inbound listing, skip cleanly if none exist.
   const email = client.env.primaryAgentEmail;
-  const list = await client.get<{ messages: Array<{ id: string; direction?: string }> }>(
-    `/api/v1/agents/${encodeURIComponent(email)}/messages`,
+  const list = await client.get<{ items: Array<{ id: string; direction?: string }> }>(
+    `/v1/agents/${encodeURIComponent(email)}/messages`,
     { query: { limit: 5, direction: "inbound" } },
   );
-  const candidate = list.body?.messages?.find((m) => m.direction === "inbound" || m.direction === undefined);
+  const candidate = list.body?.items?.find((m) => m.direction === "inbound" || m.direction === undefined);
   if (!candidate) {
     info(SUITE, "reply-empty-skipped", `no inbound messages on ${email} — cannot exercise empty-body reply check`);
     return;
   }
   const r = await client.post(
-    `/api/v1/agents/${encodeURIComponent(email)}/messages/${encodeURIComponent(candidate.id)}/reply`,
+    `/v1/agents/${encodeURIComponent(email)}/messages/${encodeURIComponent(candidate.id)}/reply`,
     { body: {} },
   );
   // Now that we picked from the agent-scoped inbound list, 400 is the
@@ -268,17 +269,20 @@ test("messaging: reply with empty body returns 400", async () => {
 
 test("messaging: /messages search filters — surface what's supported", async () => {
   // Probe each known/likely filter to see what the server actually accepts.
-  const probes = [
-    { name: "agent_email", q: { agent_email: client.env.primaryAgentEmail, limit: 5 } },
-    { name: "status=pending_approval", q: { status: "pending_approval", limit: 5 } },
+  // Now agent-scoped: the agent is in the path, so the former agent_email
+  // filter is exercised as the implicit-scope baseline.
+  const email = client.env.primaryAgentEmail;
+  const probes: Array<{ name: string; q: Record<string, string | number> }> = [
+    { name: "baseline (implicit agent scope)", q: { limit: 5 } },
+    { name: "status=all", q: { status: "all", limit: 5 } },
     { name: "direction=outbound", q: { direction: "outbound", limit: 5 } },
     { name: "direction=inbound", q: { direction: "inbound", limit: 5 } },
     { name: "since=2024-01-01", q: { since: "2024-01-01T00:00:00Z", limit: 5 } },
   ];
   const observed: string[] = [];
   for (const p of probes) {
-    const r = await client.get<{ messages: unknown[] }>("/api/v1/messages", { query: p.q as Record<string, string | number> });
-    observed.push(`${p.name}=${r.status}/${Array.isArray(r.body?.messages) ? r.body.messages.length : "?"}`);
+    const r = await client.get<{ items: unknown[] }>(`/v1/agents/${encodeURIComponent(email)}/messages`, { query: p.q });
+    observed.push(`${p.name}=${r.status}/${Array.isArray(r.body?.items) ? r.body.items.length : "?"}`);
     if (r.status >= 500) {
       fail(SUITE, `filter-5xx-${p.name}`, `${p.name} caused ${r.status}: ${r.raw.slice(0, 200)}`);
     }
@@ -287,24 +291,24 @@ test("messaging: /messages search filters — surface what's supported", async (
 });
 
 test("messaging: GET /messages/{id} of nonexistent message returns 4xx", async () => {
-  const r = await client.get(`/api/v1/messages/msg_nonexistent_${Date.now()}`);
+  const email = client.env.primaryAgentEmail;
+  const r = await client.get(`/v1/agents/${encodeURIComponent(email)}/messages/msg_nonexistent_${Date.now()}`);
   assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
 test("messaging: GET /agents/{email}/messages returns documented shape", async () => {
   const email = client.env.primaryAgentEmail;
-  const r = await client.get<{ messages?: unknown[] }>(`/api/v1/agents/${encodeURIComponent(email)}/messages`, {
+  const r = await client.get<{ items?: unknown[] }>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
     query: { limit: 5 },
   });
   assert.equal(r.status, 200, `expected 200, got ${r.status}: ${r.raw.slice(0, 200)}`);
-  assert.ok(Array.isArray(r.body?.messages), "messages array present");
+  assert.ok(Array.isArray(r.body?.items), "items array present");
 });
 
 test("messaging: send with reply_to (header round-trip) is accepted", async () => {
   const email = await createHitlAgent("replyto");
-  const r = await client.post<{ message_id: string }>("/api/v1/send", {
+  const r = await client.post<{ message_id: string }>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
     body: {
-      from: email,
       to: [SINK_EMAIL],
       subject: uniqueSubject("with reply_to"),
       body: "x",
@@ -317,6 +321,6 @@ test("messaging: send with reply_to (header round-trip) is accepted", async () =
   }
   assert.ok(r.status === 200 || r.status === 202, `expected 200/202, got ${r.status}`);
   if (r.body?.message_id) {
-    await client.post(`/api/v1/messages/${r.body.message_id}/reject`, { body: { reason: "e2e reply_to cleanup" } });
+    await client.post(`/v1/agents/${encodeURIComponent(email)}/messages/${r.body.message_id}/reject`, { body: { reason: "e2e reply_to cleanup" } });
   }
 });

--- a/tests/e2e-prod/suites/12-mcp-extended.test.ts
+++ b/tests/e2e-prod/suites/12-mcp-extended.test.ts
@@ -35,13 +35,13 @@ function extractText(r: { content?: Array<{ type: string; text?: string }> }): s
 
 async function ensureHitlAgent(): Promise<string> {
   const slug = uniqueSlug("mcpe");
-  const c = await apiClient.post<{ email: string }>("/api/v1/agents", {
+  const c = await apiClient.post<{ email: string }>("/v1/agents", {
     body: { slug, name: "mcp ext", agent_mode: "local" },
   });
   if (c.status !== 201) throw new Error(`create agent: ${c.status} ${c.raw.slice(0, 200)}`);
   const email = c.body!.email;
   track("agent", email);
-  const u = await apiClient.put(`/api/v1/agents/${encodeURIComponent(email)}`, {
+  const u = await apiClient.put(`/v1/agents/${encodeURIComponent(email)}`, {
     body: { hitl_enabled: true, hitl_expiration_action: "reject", hitl_ttl_seconds: 120 },
   });
   if (u.status !== 200) throw new Error(`enable HITL: ${u.status}`);
@@ -97,7 +97,7 @@ test("mcp-ext: send_email tool happy path with HITL agent queues message", async
     info(SUITE, "mcp-send-not-pending", `expected pending_approval for HITL, got "${parsed.status}"`);
   }
   // Clean up via API.
-  await apiClient.post(`/api/v1/messages/${parsed.message_id}/reject`, { body: { reason: "e2e mcp send cleanup" } });
+  await apiClient.post(`/v1/agents/${encodeURIComponent(email)}/messages/${parsed.message_id}/reject`, { body: { reason: "e2e mcp send cleanup" } });
 });
 
 test("mcp-ext: list_pending_messages and get_pending_message round-trip", async () => {
@@ -110,8 +110,8 @@ test("mcp-ext: list_pending_messages and get_pending_message round-trip", async 
   }
   const email = await ensureHitlAgent();
   // Queue one via API (so we know we have something to inspect).
-  const s = await apiClient.post<{ message_id: string }>("/api/v1/send", {
-    body: { from: email, to: [SINK_EMAIL], subject: uniqueSubject("mcp pending"), body: "x" },
+  const s = await apiClient.post<{ message_id: string }>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
+    body: { to: [SINK_EMAIL], subject: uniqueSubject("mcp pending"), body: "x" },
   });
   if (s.status !== 202 || !s.body?.message_id) {
     info(SUITE, "pending-setup-failed", `send returned ${s.status}, can't probe pending tools`);
@@ -146,7 +146,7 @@ test("mcp-ext: list_pending_messages and get_pending_message round-trip", async 
   }
 
   // Cleanup
-  await apiClient.post(`/api/v1/messages/${id}/reject`, { body: { reason: "e2e mcp pending cleanup" } });
+  await apiClient.post(`/v1/agents/${encodeURIComponent(email)}/messages/${id}/reject`, { body: { reason: "e2e mcp pending cleanup" } });
 });
 
 test("mcp-ext: reject_pending_message via MCP transitions the message", async () => {
@@ -156,8 +156,8 @@ test("mcp-ext: reject_pending_message via MCP transitions the message", async ()
     return;
   }
   const email = await ensureHitlAgent();
-  const s = await apiClient.post<{ message_id: string }>("/api/v1/send", {
-    body: { from: email, to: [SINK_EMAIL], subject: uniqueSubject("mcp reject"), body: "x" },
+  const s = await apiClient.post<{ message_id: string }>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
+    body: { to: [SINK_EMAIL], subject: uniqueSubject("mcp reject"), body: "x" },
   });
   if (s.status !== 202 || !s.body?.message_id) {
     info(SUITE, "reject-setup-failed", `send returned ${s.status}`);
@@ -183,8 +183,8 @@ test("mcp-ext: approve_pending_message via MCP sends the message", async () => {
     return;
   }
   const email = await ensureHitlAgent();
-  const s = await apiClient.post<{ message_id: string }>("/api/v1/send", {
-    body: { from: email, to: [SINK_EMAIL], subject: uniqueSubject("mcp approve"), body: "x" },
+  const s = await apiClient.post<{ message_id: string }>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
+    body: { to: [SINK_EMAIL], subject: uniqueSubject("mcp approve"), body: "x" },
   });
   if (s.status !== 202 || !s.body?.message_id) {
     info(SUITE, "approve-setup-failed", `send returned ${s.status}`);
@@ -210,16 +210,16 @@ test("mcp-ext: get_message returns shape and only own messages", async () => {
     return;
   }
   // The MCP get_message tool fetches via the AGENT-scoped endpoint
-  // GET /api/v1/agents/{agent_email}/messages/{id} — anti-enumeration
+  // GET /v1/agents/{agent_email}/messages/{id} — anti-enumeration
   // 404s on any message that doesn't belong to the pinned agent. We
   // pull candidate IDs from the same scope so the test exercises the
   // happy path instead of accidentally tripping the cross-agent guard.
   const pinnedAgent = apiClient.env.primaryAgentEmail;
-  const listMsgs = await apiClient.get<{ messages: Array<{ id: string }> }>(
-    `/api/v1/agents/${encodeURIComponent(pinnedAgent)}/messages`,
+  const listMsgs = await apiClient.get<{ items: Array<{ id: string }> }>(
+    `/v1/agents/${encodeURIComponent(pinnedAgent)}/messages`,
     { query: { limit: 1 } },
   );
-  const id = listMsgs.body?.messages?.[0]?.id;
+  const id = listMsgs.body?.items?.[0]?.id;
   if (!id) {
     info(SUITE, "get-msg-no-fixture", `no messages in agent ${pinnedAgent}'s inbox — cannot probe get_message happy path`);
     return;
@@ -259,7 +259,7 @@ test("mcp-ext: cross-tool consistency — list_agents matches API surface", asyn
   const r = await callTool(mcp, "list_agents");
   const text = extractText(r);
   const mcpAgents = (JSON.parse(text) as { agents: Array<{ email: string }> }).agents.map((a) => a.email).sort();
-  const apiResp = await apiClient.get<{ agents: Array<{ email: string }> }>("/api/v1/agents");
+  const apiResp = await apiClient.get<{ agents: Array<{ email: string }> }>("/v1/agents");
   const apiAgents = (apiResp.body?.agents ?? []).map((a) => a.email).sort();
   if (mcpAgents.length !== apiAgents.length || JSON.stringify(mcpAgents) !== JSON.stringify(apiAgents)) {
     info(

--- a/tests/e2e-prod/suites/13-billing-surface.test.ts
+++ b/tests/e2e-prod/suites/13-billing-surface.test.ts
@@ -14,19 +14,19 @@ after(async () => {
 });
 
 // These tests verify the BILLING API CONTRACT without actually touching Stripe:
-// - The shape of /api/v1/users/me/limits (always available, dashboard depends on it)
+// - The shape of /v1/account (always available, dashboard depends on it)
 // - The HTTP method discipline on /api/billing/* (POST-only on mutating endpoints
 //   was a deliberate CSRF defense — confirm GET still 4xx's)
 // - That /pricing is statically served and reachable
 // Actual checkout/portal/webhook behavior is deferred to the live billing day.
 
-test("billing: GET /api/v1/users/me/limits returns documented LimitsInfo shape", async () => {
+test("billing: GET /v1/account returns documented AccountView shape", async () => {
   const r = await client.get<{
     plan_code?: string;
     upgrade_url?: string;
     limits?: { max_agents?: number; max_domains?: number; max_messages_month?: number; max_storage_bytes?: number };
     usage?: { agents?: number; domains?: number; messages_month?: number; storage_bytes?: number };
-  }>("/api/v1/users/me/limits");
+  }>("/v1/account");
 
   if (r.status === 503) {
     info(SUITE, "limits-503", "limits subsystem reports not configured — billing primitive not wired up on this deployment");
@@ -35,11 +35,11 @@ test("billing: GET /api/v1/users/me/limits returns documented LimitsInfo shape",
   assert.equal(r.status, 200, `expected 200, got ${r.status}: ${r.raw.slice(0, 300)}`);
   // plan_code is required for the dashboard to render the upgrade affordance.
   if (!r.body?.plan_code) {
-    fail(SUITE, "limits-missing-plan-code", `LimitsInfo missing plan_code: ${r.raw.slice(0, 300)}`);
+    fail(SUITE, "limits-missing-plan-code", `AccountView missing plan_code: ${r.raw.slice(0, 300)}`);
   }
   // limits block — required by dashboard caps panel.
   if (!r.body?.limits) {
-    fail(SUITE, "limits-missing-limits-block", `LimitsInfo missing 'limits' block: ${r.raw.slice(0, 300)}`);
+    fail(SUITE, "limits-missing-limits-block", `AccountView missing 'limits' block: ${r.raw.slice(0, 300)}`);
   } else {
     for (const k of ["max_agents", "max_domains", "max_messages_month", "max_storage_bytes"] as const) {
       if (typeof r.body.limits[k] !== "number") {
@@ -49,7 +49,7 @@ test("billing: GET /api/v1/users/me/limits returns documented LimitsInfo shape",
   }
   // usage block — required by dashboard "you've used X" surface.
   if (!r.body?.usage) {
-    fail(SUITE, "limits-missing-usage-block", "LimitsInfo missing 'usage' block — dashboard caps panel breaks");
+    fail(SUITE, "limits-missing-usage-block", "AccountView missing 'usage' block — dashboard caps panel breaks");
   } else {
     for (const k of ["agents", "domains", "messages_month", "storage_bytes"] as const) {
       if (typeof r.body.usage[k] !== "number") {
@@ -60,18 +60,18 @@ test("billing: GET /api/v1/users/me/limits returns documented LimitsInfo shape",
   info(SUITE, "limits-snapshot", `plan_code="${r.body?.plan_code}" agents ${r.body?.usage?.agents}/${r.body?.limits?.max_agents}, msgs ${r.body?.usage?.messages_month}/${r.body?.limits?.max_messages_month}, storage ${r.body?.usage?.storage_bytes}/${r.body?.limits?.max_storage_bytes}`);
 });
 
-test("billing: GET /api/v1/users/me/limits requires auth (401)", async () => {
-  const r = await client.get("/api/v1/users/me/limits", { apiKey: null });
+test("billing: GET /v1/account requires auth (401)", async () => {
+  const r = await client.get("/v1/account", { apiKey: null });
   assert.equal(r.status, 401, `expected 401, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
 test("billing: usage.agents counts roughly match the actual /agents list", async () => {
-  const limits = await client.get<{ usage?: { agents?: number } }>("/api/v1/users/me/limits");
+  const limits = await client.get<{ usage?: { agents?: number } }>("/v1/account");
   if (limits.status !== 200 || typeof limits.body?.usage?.agents !== "number") {
     info(SUITE, "usage-skip", `limits unavailable (${limits.status}), skipping usage-vs-list check`);
     return;
   }
-  const agents = await client.get<{ agents: unknown[] }>("/api/v1/agents");
+  const agents = await client.get<{ agents: unknown[] }>("/v1/agents");
   const actual = agents.body?.agents?.length ?? 0;
   const reported = limits.body.usage.agents!;
   const drift = Math.abs(reported - actual);

--- a/tests/e2e-prod/suites/14-v030-features.test.ts
+++ b/tests/e2e-prod/suites/14-v030-features.test.ts
@@ -1,11 +1,11 @@
-// Prod coverage for the surface introduced in v0.3.0:
-//   - Events API (list / get / redeliver / redeliver-since)         PR #184
+// Prod coverage for the surface introduced in v0.3.0, repointed to /v1:
+//   - Events API (list / get / redeliver)                           PR #184
 //   - Conversations API (list / get under agent scope)              PR #177
 //   - Message forward (/messages/{id}/forward)                       PR #171
 //   - Message labels (PATCH + ?labels= filter on /messages)          PR #173, #174
 //   - Message search filters (?from, ?to, ?subject, ?since, ?until)  PR #154
 //   - Domains CRUD completion (PATCH /domains/{domain})              PR #165
-//   - Per-user resource limits (GET /users/me/limits)                PR #158
+//   - Per-account resource limits (GET /v1/account)                  PR #158
 //
 // Coverage shape is deliberately read-heavy: shape + auth + 4xx
 // validation paths. The outbox/event-emission code path requires
@@ -42,97 +42,66 @@ after(async () => {
 // ─── Events API ───────────────────────────────────────────────────
 
 test("events: list returns documented envelope shape", async () => {
-  const r = await client.get<{ events: unknown[] | null; next_token: string | null }>("/api/v1/events");
+  const r = await client.get<{ items: unknown[] | null; next_cursor: string | null }>("/v1/events");
   assert.equal(r.status, 200, `GET /events expected 200, got ${r.status}: ${r.raw.slice(0, 200)}`);
   assert.ok(r.body, "body is parsed JSON");
   // Go marshals an empty slice as `null` not `[]`; both are valid
-  // empty-state encodings. next_token is "" when no more pages.
+  // empty-state encodings. next_cursor is null when no more pages.
   assert.ok(
-    r.body!.events === null || Array.isArray(r.body!.events),
-    `events should be array or null, got ${typeof r.body!.events}`,
+    r.body!.items === null || Array.isArray(r.body!.items),
+    `items should be array or null, got ${typeof r.body!.items}`,
   );
-  assert.ok("next_token" in r.body!, "next_token field present on response");
+  assert.ok("next_cursor" in r.body!, "next_cursor field present on response");
 });
 
 test("events: list without auth → 401", async () => {
-  const r = await client.get("/api/v1/events", { apiKey: null });
+  const r = await client.get("/v1/events", { apiKey: null });
   assert.equal(r.status, 401, `expected 401, got ${r.status}`);
 });
 
 test("events: list accepts all documented filter params without 400", async () => {
   // Send every filter the design specifies; any 400 here indicates
   // a regression in the query parser.
-  const r = await client.get("/api/v1/events", {
+  const r = await client.get("/v1/events", {
     query: {
       type: "email.received",
       agent_id: "test-mcp@agents.e2a.dev",
       since: "2026-01-01T00:00:00Z",
       until: "2026-12-31T23:59:59Z",
-      page_size: 10,
+      limit: 10,
     },
   });
   assert.equal(r.status, 200, `multi-filter GET /events expected 200, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
-test("events: list with page_size > max clamps or 400s, never crashes", async () => {
-  const r = await client.get("/api/v1/events", { query: { page_size: 9999 } });
+test("events: list with limit > max clamps or 400s, never crashes", async () => {
+  const r = await client.get("/v1/events", { query: { limit: 9999 } });
   assert.ok(r.status === 200 || r.status === 400, `expected 200/400, got ${r.status}`);
 });
 
 test("events: get nonexistent event → 404", async () => {
-  const r = await client.get(`/api/v1/events/evt_nonexistent${Date.now()}`);
+  const r = await client.get(`/v1/events/evt_nonexistent${Date.now()}`);
   assert.equal(r.status, 404, `expected 404, got ${r.status}`);
 });
 
 test("events: get without auth → 401", async () => {
-  const r = await client.get(`/api/v1/events/evt_x`, { apiKey: null });
+  const r = await client.get(`/v1/events/evt_x`, { apiKey: null });
   assert.equal(r.status, 401, `expected 401, got ${r.status}`);
 });
 
 test("events: redeliver nonexistent event → 404", async () => {
-  const r = await client.post(`/api/v1/events/evt_nonexistent${Date.now()}/redeliver`, {
+  const r = await client.post(`/v1/events/evt_nonexistent${Date.now()}/redeliver`, {
     body: { webhook_id: "wh_anything" },
   });
   assert.equal(r.status, 404, `expected 404, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
 test("events: redeliver without auth → 401", async () => {
-  const r = await client.post(`/api/v1/events/evt_x/redeliver`, {
+  const r = await client.post(`/v1/events/evt_x/redeliver`, {
     apiKey: null,
     body: { webhook_id: "wh_x" },
   });
   assert.equal(r.status, 401, `expected 401, got ${r.status}`);
-});
-
-test("webhooks: redeliver-since nonexistent webhook is benign (no 5xx)", async () => {
-  // Documented prod behavior: returns 200 with scheduled=0 when the
-  // webhook id doesn't match, rather than 4xx. That diverges from the
-  // anti-enumeration pattern used elsewhere (e.g. /agents/{id}), so
-  // it's worth surfacing as a finding — but it's not a regression,
-  // it's how the endpoint shipped in v0.3.0. Accept any non-5xx.
-  const r = await client.post(`/api/v1/webhooks/wh_nonexistent${Date.now()}/redeliver-since`, {
-    body: { since: new Date(Date.now() - 86400000).toISOString() },
-  });
-  assert.ok(r.status < 500, `expected <500, got ${r.status}: ${r.raw.slice(0, 200)}`);
-  if (r.status === 200) {
-    const body = r.body as { scheduled?: number; skipped_already_pending?: number } | null;
-    assert.equal(body?.scheduled, 0, "nonexistent webhook should schedule 0 redeliveries");
-    info(SUITE, "redeliver-since-shape", "endpoint returns 200/scheduled=0 for unknown webhook (no anti-enumeration)");
-  }
-});
-
-test("webhooks: redeliver-since rejects since > 7 days back (range cap)", async () => {
-  // Per the design, redeliver-since is capped at 7 days. We can't
-  // test against a real webhook without creating one; verify the
-  // validator runs early enough that the cap check fires even on
-  // a missing webhook id. If 404 fires first (route ordering), the
-  // test still passes — both are documented behaviors. The intent
-  // is "never 5xx", which is the actual invariant.
-  const since = new Date(Date.now() - 30 * 86400000).toISOString();
-  const r = await client.post(`/api/v1/webhooks/wh_anything/redeliver-since`, {
-    body: { since },
-  });
-  assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
 // ─── Conversations API ────────────────────────────────────────────
@@ -140,7 +109,7 @@ test("webhooks: redeliver-since rejects since > 7 days back (range cap)", async 
 test("conversations: list under primary agent returns array shape", async () => {
   const email = client.env.primaryAgentEmail;
   const r = await client.get<{ conversations: unknown[] }>(
-    `/api/v1/agents/${encodeURIComponent(email)}/conversations`,
+    `/v1/agents/${encodeURIComponent(email)}/conversations`,
   );
   assert.equal(r.status, 200, `expected 200, got ${r.status}: ${r.raw.slice(0, 200)}`);
   assert.ok(Array.isArray(r.body?.conversations), "conversations is array");
@@ -148,7 +117,7 @@ test("conversations: list under primary agent returns array shape", async () => 
 
 test("conversations: list without auth → 401", async () => {
   const email = client.env.primaryAgentEmail;
-  const r = await client.get(`/api/v1/agents/${encodeURIComponent(email)}/conversations`, { apiKey: null });
+  const r = await client.get(`/v1/agents/${encodeURIComponent(email)}/conversations`, { apiKey: null });
   assert.equal(r.status, 401, `expected 401, got ${r.status}`);
 });
 
@@ -157,7 +126,7 @@ test("conversations: list under nonexistent agent → 404 or 403", async () => {
   // sub-resource paths (conversations, messages) return 404 for an
   // unknown agent. Inconsistency worth tracking, accepted as-shipped.
   const r = await client.get(
-    `/api/v1/agents/nonexistent-${Date.now()}@agents.e2a.dev/conversations`,
+    `/v1/agents/nonexistent-${Date.now()}@agents.e2a.dev/conversations`,
   );
   assert.ok(r.status === 404 || r.status === 403, `expected 404/403, got ${r.status}`);
 });
@@ -165,7 +134,7 @@ test("conversations: list under nonexistent agent → 404 or 403", async () => {
 test("conversations: get nonexistent conversation → 404", async () => {
   const email = client.env.primaryAgentEmail;
   const r = await client.get(
-    `/api/v1/agents/${encodeURIComponent(email)}/conversations/conv_nonexistent${Date.now()}`,
+    `/v1/agents/${encodeURIComponent(email)}/conversations/conv_nonexistent${Date.now()}`,
   );
   assert.equal(r.status, 404, `expected 404, got ${r.status}`);
 });
@@ -175,7 +144,7 @@ test("conversations: get nonexistent conversation → 404", async () => {
 test("forward: nonexistent message → 404", async () => {
   const email = client.env.primaryAgentEmail;
   const r = await client.post(
-    `/api/v1/agents/${encodeURIComponent(email)}/messages/msg_nonexistent${Date.now()}/forward`,
+    `/v1/agents/${encodeURIComponent(email)}/messages/msg_nonexistent${Date.now()}/forward`,
     { body: { to: ["sink@e2a.dev"] } },
   );
   assert.equal(r.status, 404, `expected 404, got ${r.status}: ${r.raw.slice(0, 200)}`);
@@ -184,7 +153,7 @@ test("forward: nonexistent message → 404", async () => {
 test("forward: missing 'to' field → 400", async () => {
   const email = client.env.primaryAgentEmail;
   const r = await client.post(
-    `/api/v1/agents/${encodeURIComponent(email)}/messages/msg_anything/forward`,
+    `/v1/agents/${encodeURIComponent(email)}/messages/msg_anything/forward`,
     { body: {} },
   );
   assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}`);
@@ -193,7 +162,7 @@ test("forward: missing 'to' field → 400", async () => {
 test("forward: without auth → 401", async () => {
   const email = client.env.primaryAgentEmail;
   const r = await client.post(
-    `/api/v1/agents/${encodeURIComponent(email)}/messages/msg_x/forward`,
+    `/v1/agents/${encodeURIComponent(email)}/messages/msg_x/forward`,
     { apiKey: null, body: { to: ["sink@e2a.dev"] } },
   );
   assert.equal(r.status, 401, `expected 401, got ${r.status}`);
@@ -202,7 +171,7 @@ test("forward: without auth → 401", async () => {
 test("labels: PATCH nonexistent message → 404", async () => {
   const email = client.env.primaryAgentEmail;
   const r = await client.patch(
-    `/api/v1/agents/${encodeURIComponent(email)}/messages/msg_nonexistent${Date.now()}`,
+    `/v1/agents/${encodeURIComponent(email)}/messages/msg_nonexistent${Date.now()}`,
     { body: { labels: ["urgent"] } },
   );
   assert.equal(r.status, 404, `expected 404, got ${r.status}: ${r.raw.slice(0, 200)}`);
@@ -213,7 +182,7 @@ test("labels: PATCH rejects label with invalid chars (charset cap)", async () =>
   // The validator runs before the row lookup, so this fails 400
   // even on a nonexistent message id.
   const r = await client.patch(
-    `/api/v1/agents/${encodeURIComponent(email)}/messages/msg_anything`,
+    `/v1/agents/${encodeURIComponent(email)}/messages/msg_anything`,
     { body: { labels: ["HAS SPACES & SYMBOLS!"] } },
   );
   assert.ok(r.status === 400 || r.status === 404, `expected 400/404, got ${r.status}: ${r.raw.slice(0, 200)}`);
@@ -222,18 +191,18 @@ test("labels: PATCH rejects label with invalid chars (charset cap)", async () =>
 test("labels: PATCH rejects reserved 'e2a:' prefix from caller writes", async () => {
   const email = client.env.primaryAgentEmail;
   const r = await client.patch(
-    `/api/v1/agents/${encodeURIComponent(email)}/messages/msg_anything`,
+    `/v1/agents/${encodeURIComponent(email)}/messages/msg_anything`,
     { body: { labels: ["e2a:reserved"] } },
   );
   assert.ok(r.status === 400 || r.status === 404, `expected 400/404, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
 test("agent messages: ?labels= filter accepted without error", async () => {
-  // The labels filter lives on the per-agent inbox path, not on the
-  // user-scoped HITL list at /api/v1/messages.
+  // The labels filter lives on the per-agent inbox path
+  // (GET /v1/agents/{address}/messages).
   const email = client.env.primaryAgentEmail;
   const r = await client.get(
-    `/api/v1/agents/${encodeURIComponent(email)}/messages`,
+    `/v1/agents/${encodeURIComponent(email)}/messages`,
     { query: { labels: "urgent" } },
   );
   assert.equal(r.status, 200, `expected 200, got ${r.status}: ${r.raw.slice(0, 200)}`);
@@ -243,7 +212,7 @@ test("agent messages: too many ?labels= values → 400 (cap=50)", async () => {
   const email = client.env.primaryAgentEmail;
   // MaxLabelsPerOp = 50; send 51 to trip the cap.
   const url =
-    `/api/v1/agents/${encodeURIComponent(email)}/messages?` +
+    `/v1/agents/${encodeURIComponent(email)}/messages?` +
     Array.from({ length: 51 }, (_, i) => `labels=l${i}`).join("&");
   const r = await client.get(url);
   assert.equal(r.status, 400, `expected 400, got ${r.status}: ${r.raw.slice(0, 200)}`);
@@ -254,7 +223,7 @@ test("agent messages: too many ?labels= values → 400 (cap=50)", async () => {
 test("agent messages: search filters accepted (from, to, subject, conversation_id, since, until)", async () => {
   // PR #154 search filters live on the per-agent inbox path.
   const email = client.env.primaryAgentEmail;
-  const r = await client.get(`/api/v1/agents/${encodeURIComponent(email)}/messages`, {
+  const r = await client.get(`/v1/agents/${encodeURIComponent(email)}/messages`, {
     query: {
       from: "alice@example.com",
       to: "bob@example.com",
@@ -271,7 +240,7 @@ test("agent messages: search filters accepted (from, to, subject, conversation_i
 test("agent messages: invalid since timestamp handled (400 or graceful 200)", async () => {
   const email = client.env.primaryAgentEmail;
   const r = await client.get(
-    `/api/v1/agents/${encodeURIComponent(email)}/messages`,
+    `/v1/agents/${encodeURIComponent(email)}/messages`,
     { query: { since: "not-a-timestamp" } },
   );
   assert.ok(r.status === 400 || r.status === 200, `expected 400 or graceful 200, got ${r.status}`);
@@ -284,32 +253,32 @@ test("domains: PATCH nonexistent domain with valid body → 404 or 403", async (
   // documented "make me primary" body to skip the validator's
   // is_primary=false early-reject. The path itself shouldn't match
   // any owned domain, so we expect not-found semantics.
-  const r = await client.patch(`/api/v1/domains/nonexistent-${Date.now()}.example.com`, {
+  const r = await client.patch(`/v1/domains/nonexistent-${Date.now()}.example.com`, {
     body: { is_primary: true },
   });
   assert.ok(r.status === 404 || r.status === 403, `expected 404/403, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
 test("domains: PATCH without auth → 401", async () => {
-  const r = await client.patch(`/api/v1/domains/example.com`, { apiKey: null, body: {} });
+  const r = await client.patch(`/v1/domains/example.com`, { apiKey: null, body: {} });
   assert.equal(r.status, 401, `expected 401, got ${r.status}`);
 });
 
 test("domains: DELETE nonexistent domain → 404 or 403", async () => {
-  const r = await client.delete(`/api/v1/domains/nonexistent-${Date.now()}.example.com`);
+  const r = await client.delete(`/v1/domains/nonexistent-${Date.now()}.example.com`);
   assert.ok(r.status === 404 || r.status === 403, `expected 404/403, got ${r.status}`);
 });
 
 // ─── Per-user resource limits (PR #158) ───────────────────────────
 
-test("limits: GET /users/me/limits returns documented shape", async () => {
+test("limits: GET /v1/account returns documented shape", async () => {
   type LimitsResp = {
     plan_code: string;
     limits: Record<string, number>;
     usage: Record<string, number>;
     upgrade_url?: string;
   };
-  const r = await client.get<LimitsResp>("/api/v1/users/me/limits");
+  const r = await client.get<LimitsResp>("/v1/account");
   assert.equal(r.status, 200, `expected 200, got ${r.status}: ${r.raw.slice(0, 200)}`);
   assert.ok(r.body, "body parsed");
   assert.equal(typeof r.body!.plan_code, "string", "plan_code is a string");
@@ -330,32 +299,7 @@ test("limits: GET /users/me/limits returns documented shape", async () => {
   }
 });
 
-test("limits: GET /users/me/limits without auth → 401", async () => {
-  const r = await client.get("/api/v1/users/me/limits", { apiKey: null });
+test("limits: GET /v1/account without auth → 401", async () => {
+  const r = await client.get("/v1/account", { apiKey: null });
   assert.equal(r.status, 401, `expected 401, got ${r.status}`);
-});
-
-// ─── Cross-cutting: retention indirectly (PR #186) ────────────────
-
-test("pending list smoke (canonical /api/v1/pending serves cleanly)", async () => {
-  // The 10-day TTL change only affects rows created against the new
-  // binary. We can't directly assert TTL without a write — but we
-  // can verify the canonical pending-list endpoint still serves
-  // cleanly post-deploy, which is the practical regression signal.
-  //
-  // v0.4.0 renamed /api/v1/messages → /api/v1/pending; the legacy
-  // path is verified separately by `pending: legacy /messages list
-  // returns 404` below.
-  const r = await client.get<{ messages: unknown[] }>("/api/v1/pending");
-  assert.equal(r.status, 200);
-  assert.ok(Array.isArray(r.body?.messages), "messages is array");
-});
-
-test("pending: legacy /api/v1/messages list returns 404 (no silent alias)", async () => {
-  // v0.4.0 removed the legacy list path. A caller pinned to an older
-  // SDK will see 404 here, not a successful response — which is the
-  // intended breakage signal so the SDK update isn't silently
-  // delayed.
-  const r = await client.get("/api/v1/messages");
-  assert.equal(r.status, 404, `legacy list path should 404, got ${r.status}`);
 });

--- a/tests/e2e-prod/tsconfig.json
+++ b/tests/e2e-prod/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "target": "es2022",
+    "lib": ["es2023", "dom", "dom.iterable"],
+    "allowImportingTsExtensions": true,
+    "noEmit": true,
+    "types": ["node"],
+    "skipLibCheck": true
+  },
+  "include": ["**/*.ts"]
+}


### PR DESCRIPTION
The required pre-deploy follow-up flagged in #235 (design §13.3). The manual prod verification suite (`tests/e2e-prod`, run against `https://e2a.dev`, **not CI-gated**) still called the retired `/api/v1` surface — it works today via the legacy fallback but **breaks once #235 deploys**. This migrates it to `/v1`.

## Structural, not a prefix swap
`/v1` is fully **agent-scoped**, so the messaging/HITL flows are restructured:
- `POST /api/v1/send {from,…}` → `POST /v1/agents/{address}/messages {…}` (agent in path; `from` dropped)
- `/api/v1/messages/{id}[/approve|/reject]` → `/v1/agents/{address}/messages/{id}[…]`
- account-wide `GET /api/v1/messages|pending` → per-agent `GET /v1/agents/{address}/messages` (+ `direction` to see outbound drafts)
- pagination standardized: `{messages|events, next_token}` + `page_size` → `{items, next_cursor}` + `cursor`/`limit`
- `GET /api/v1/users/me/limits` → `GET /v1/account`; `/users/me/export` → `/v1/account/export`
- `/api/v1/{agents,domains,events,info}` → `/v1/*`; WS alias + magic-link → `/v1`

## Deleted (no `/v1` equivalent)
Per-user signing-secrets CRUD, `webhooks/{id}/redeliver-since` (bulk replay), and the obsolete legacy-alias/rename assertion tests. MCP stdio tool calls and operational `/api/billing/*` paths are unchanged.

## Verification
- Added `tsconfig.json` + a `typecheck` script (the suite had **neither** — which is why a cross-file pagination-envelope inconsistency slipped through initially; now caught + fixed). `node_modules` gitignored.
- `npm run typecheck` passes; **every `/v1` path verified against `api/openapi.yaml`**.
- Not run live (targets prod) — verified by typecheck + spec conformance. A future CI job could run `npm run typecheck` to gate drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)