### PR TITLE
docs: reconcile all documentation with the shipped /v1 redesign (audit fixes)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,7 +85,7 @@ it later (only the hash is stored).
 curl http://localhost:8080/api/health
 # → {"status":"ok"}
 
-curl -H "Authorization: Bearer <your-key>" http://localhost:8080/api/v1/agents
+curl -H "Authorization: Bearer <your-key>" http://localhost:8080/v1/agents
 # → {"agents":[]}
 ```
 
@@ -188,17 +188,22 @@ change: the Go handler, OpenAPI spec, TypeScript SDK (raw + high-level),
 Python SDK sync (raw + high-level), Python SDK async (raw + high-level),
 CLI, MCP server, and the web dashboard. Each surface has its own tests.
 
-Generated code lives in `sdks/{typescript,python}/.../generated/`.
-After editing Go swag annotations:
+The `/v1` OpenAPI document at `api/openapi.yaml` is emitted directly
+from the live Huma handlers, and generated SDK code lives in
+`sdks/{typescript,python}/.../generated/`. After changing a `/v1`
+handler:
 
 ```bash
-make swagger        # regenerates web/public/openapi.yaml
-make generate-sdk   # regenerates generated/ for TS + Python
-make generate       # both
+make spec           # regenerates api/openapi.yaml from the live handlers
+make generate-sdk   # regenerates generated/ for TS + Python from the spec
+make generate       # both of the above
 ```
 
-CI fails the PR if these are out of date — run them and commit the
-diff. The PR template ([`.github/pull_request_template.md`](.github/pull_request_template.md))
+Commit `api/openapi.yaml` and the regenerated `sdks/**/generated/`
+bases. CI gates this with `spec-check` (the committed spec must
+byte-equal what the handlers emit) and `generate-sdk-check` — run
+`make generate` and commit the diff or the PR fails. The PR template
+([`.github/pull_request_template.md`](.github/pull_request_template.md))
 includes a checkbox list of every client surface; tick what's in scope
 and explain anything intentionally skipped.
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build run test test-unit test-integration test-e2e clean docker-up docker-down migrate swagger swagger-check spec spec-check generate generate-check generate-sdk generate-sdk-check generate-sdk-ts generate-sdk-py
+.PHONY: build run test test-unit test-integration test-e2e clean docker-up docker-down migrate spec spec-check generate generate-check generate-sdk generate-sdk-check generate-sdk-ts generate-sdk-py
 
 # OpenAPI Generator for the /v1 SDK base. Pinned to a released tag (never
 # :latest/SNAPSHOT) so output is reproducible for the drift gate. Run via
@@ -38,19 +38,11 @@ migrate:
 		psql "postgres://e2a:e2a@localhost:5433/e2a?sslmode=disable" -f "$$f"; \
 	done
 
-swagger:
-	swag init --generalInfo cmd/e2a/main.go --parseDependency --parseInternal --output web/public --outputTypes yaml
-	mv web/public/swagger.yaml web/public/openapi.yaml
-
-swagger-check:
-	swag init --generalInfo cmd/e2a/main.go --parseDependency --parseInternal --output /tmp/swag-check --outputTypes yaml
-	diff -u web/public/openapi.yaml /tmp/swag-check/swagger.yaml
-
 # spec regenerates the /v1 OpenAPI 3.1 document (api/openapi.yaml) directly
-# from the live Huma handlers — the source of truth for SDK codegen + docs.
-# This replaces the legacy swag-annotation pipeline (the `swagger` target
-# above) as resources finish moving onto /v1; the SDK-codegen switchover to
-# this file is tracked separately.
+# from the live Huma handlers — the single source of truth for SDK codegen and
+# the rendered API reference. (The dashboard's API-reference page copies
+# api/openapi.yaml into web/public/openapi.yaml at build time via the web
+# `sync-openapi` script. The old swag-annotation pipeline has been removed.)
 spec:
 	go test ./internal/httpapi/ -run TestSpecGoldenNoDrift -update-spec -count=1
 	@echo "==> Regenerated api/openapi.yaml from the /v1 handlers"

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ All endpoints are under `/v1` unless noted. Auth is `Authorization: Bearer <api_
 
 The surface covers domain registration + verification, agent CRUD, inbound/outbound messages, HITL approve/reject (API key or signed magic-link token), GDPR-style export and deletion, and a WebSocket channel for local-mode agents.
 
-See [docs/api.md](docs/api.md) for the full endpoint reference, or [`web/public/openapi.yaml`](web/public/openapi.yaml) for the machine-readable spec.
+See [docs/api.md](docs/api.md) for the full endpoint reference, or [`api/openapi.yaml`](api/openapi.yaml) for the machine-readable spec.
 
 ## CLI
 
@@ -295,7 +295,7 @@ Report security issues privately — see [SECURITY.md](SECURITY.md) for the disc
 
 ## Data handling
 
-Message envelopes and inbound bodies live in Postgres for 30 days by default; outbound bodies are scrubbed at terminal HITL transition; API keys are stored as hashes; attachments go in JSONB rows (no S3/GCS). Application logs include sender/recipient addresses (standard MTA practice) but never bodies, attachments, raw keys, or HMAC secrets. Users can self-export (`GET /users/me/export`) and self-delete (`DELETE /users/me`) for GDPR Art. 15 / Art. 17 / CCPA.
+Message envelopes and inbound bodies live in Postgres for 10 days by default; outbound bodies are scrubbed at terminal HITL transition; API keys are stored as hashes; attachments go in JSONB rows (no S3/GCS). Application logs include sender/recipient addresses (standard MTA practice) but never bodies, attachments, raw keys, or HMAC secrets. Users can self-export (`GET /v1/account/export`) and self-delete (`DELETE /v1/account?confirm=DELETE`) for GDPR Art. 15 / Art. 17 / CCPA.
 
 See [docs/data-handling.md](docs/data-handling.md) for the full retention table, log fields, user-rights endpoints, and the operator-side responsibilities (backups, TLS, at-rest encryption, log redaction, compliance).
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -146,6 +146,69 @@ e2a send --to alice@example.com --subject "Hello" --body "Hi Alice!"
 e2a send --to alice@example.com --subject "Hello" --body "..." --agent bot@agents.e2a.dev
 ```
 
+### `e2a forward <message-id>`
+
+Forward an inbound message to another address, preserving the original content.
+
+```bash
+e2a forward msg_abc123 --to alice@example.com
+e2a forward msg_abc123 --to alice@example.com --cc bob@example.com --body "FYI"
+```
+
+### `e2a labels <message-id>`
+
+Add or remove labels on a message.
+
+```bash
+e2a labels msg_abc123 --add important --add follow-up
+e2a labels msg_abc123 --remove follow-up
+```
+
+### `e2a pending`
+
+Manage outbound mail held for human approval (HITL).
+
+```bash
+e2a pending list                      # List pending messages
+e2a pending show <message-id>         # Show a held draft in full
+e2a pending approve <message-id>      # Send a held message (use --edit to revise first)
+e2a pending reject <message-id> --reason "..."  # Discard a held message
+```
+
+### `e2a conversations`
+
+List and inspect conversation threads.
+
+```bash
+e2a conversations list                # List conversations
+e2a conversations show <conversation-id>  # Show messages in a thread
+```
+
+### `e2a events`
+
+Inspect and redeliver webhook events.
+
+```bash
+e2a events list                       # List recent events
+e2a events get <event-id>             # Show one event
+e2a events redeliver <event-id>       # Re-send a webhook event
+```
+
+### `e2a webhooks`
+
+Manage webhook subscriptions.
+
+```bash
+e2a webhooks list                     # List webhook subscriptions
+e2a webhooks create --url <url> --events <event> [--events <event> ...]
+e2a webhooks get <id>                 # Show one subscription
+e2a webhooks update <id> [--url ...] [--events ...] [--enable|--disable]
+e2a webhooks delete <id>              # Remove a subscription
+e2a webhooks rotate-secret <id>       # Rotate the signing secret
+e2a webhooks test <id> [--event <event>]  # Send a test delivery
+e2a webhooks deliveries <id> [--limit N] [--status pending|delivered|failed]
+```
+
 ### `e2a domains list`
 
 List your custom domains and their verification status.
@@ -211,7 +274,7 @@ Config is stored in `~/.e2a/config.json` as JSON. Environment variables override
 The `listen` command connects to e2a's WebSocket endpoint:
 
 ```
-wss://e2a.dev/api/v1/agents/{email}/ws?token={api_key}
+wss://e2a.dev/v1/agents/{email}/ws?token={api_key}
 ```
 
 The server sends lightweight JSON notifications (message_id, from, subject, received_at) when emails arrive. The CLI fetches full message content via the REST API as needed (`--json` and `--forward` modes). This keeps the WebSocket connection fast and avoids large attachments blocking notifications.

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,9 +2,9 @@
 
 All endpoints are under `/v1` unless noted. Auth is `Authorization: Bearer <api_key>` except where called out. Path parameters containing `@` (agent emails) must be URL-encoded.
 
-> **Note:** the canonical, authoritative `/v1` surface is the generated OpenAPI spec at [`api/openapi.yaml`](../api/openapi.yaml). This hand-written overview predates the v1 redesign and still lists some pre-redesign flat paths (e.g. `/send`, `/messages/{id}`) that are now agent-scoped (`/v1/agents/{address}/messages…`); a full rewrite is tracked separately. Use the OpenAPI spec when in doubt.
+> **Note:** the canonical, authoritative `/v1` surface is the generated OpenAPI spec at [`api/openapi.yaml`](../api/openapi.yaml). This hand-written overview is a convenience summary; if anything here disagrees with the spec, the spec wins.
 
-For the machine-readable spec, see [`web/public/openapi.yaml`](../web/public/openapi.yaml).
+For the machine-readable spec, see [`api/openapi.yaml`](../api/openapi.yaml).
 
 ## Domains
 
@@ -19,37 +19,33 @@ For the machine-readable spec, see [`web/public/openapi.yaml`](../web/public/ope
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `POST` | `/agents` | Register an agent. Use `email` for a custom domain (must be verified) or `slug` for a shared-domain registration (only when the deployment has `shared_domain` configured) |
+| `POST` | `/agents` | Register an agent. Body `{email \| slug, name?}` — use `email` for a custom domain (must be verified) or `slug` for a shared-domain registration (only when the deployment has `shared_domain` configured) |
 | `GET` | `/agents` | List agents owned by the authenticated user |
-| `GET` | `/agents/{email}` | Get agent details |
-| `PUT` | `/agents/{email}` | Update agent (webhook URL, mode, HITL settings) |
-| `DELETE` | `/agents/{email}` | Delete an agent |
-| `POST` | `/agents/{email}/test` | Send a test email through the agent |
+| `GET` | `/agents/{address}` | Get agent details |
+| `PATCH` | `/agents/{address}` | Update an agent's HITL settings |
+| `DELETE` | `/agents/{address}` | Delete an agent |
+| `POST` | `/agents/{address}/test` | Send a test email to the agent's own address |
 
-## Messages — inbound (per-agent)
+## Messages (per-agent)
 
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/agents/{email}/messages` | List inbound messages for the agent |
-| `GET` | `/agents/{email}/messages/{id}` | Fetch a single inbound message. Side effect: any `unread` row flips to `read` on read, regardless of agent mode. |
-| `POST` | `/agents/{email}/messages/{id}/reply` | Reply to an inbound message |
-
-## Messages — outbound / HITL
+The message surface is agent-scoped: every message endpoint hangs off `/agents/{address}/messages`. Sending is `POST` to the collection (the agent in the path is the sender — there is no `from` field); `reply`, `forward`, `approve`, and `reject` are sub-resources of a single message.
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `POST` | `/send` | Send an email (held with `202 Accepted` if HITL enabled on the agent) |
-| `GET` | `/messages` | List outbound messages owned by the user. Only `status=pending_approval` is accepted (the default); any other value returns `400`. |
-| `GET` | `/messages/{id}` | Get a single outbound message |
-| `POST` | `/messages/{id}/approve` | Approve a `pending_approval` message |
-| `POST` | `/messages/{id}/reject` | Reject a `pending_approval` message |
+| `GET` | `/agents/{address}/messages` | List the agent's messages (inbound + outbound). Filters: `direction`, `status`, `cursor`, `limit` (max 200, default 50). Returns `{items, next_cursor}`. Held outbound drafts appear as `status=pending_approval`. |
+| `POST` | `/agents/{address}/messages` | Send a new email from the agent (a new thread). Body `{to, subject, body, html_body?, cc?, bcc?}` — no `from`. Held with `202 Accepted` if HITL is enabled on the agent. |
+| `GET` | `/agents/{address}/messages/{id}` | Fetch a single message (inbound or outbound). Side effect: any `unread` inbound row flips to `read` on read, regardless of agent mode. |
+| `POST` | `/agents/{address}/messages/{id}/reply` | Reply to an inbound message |
+| `POST` | `/agents/{address}/messages/{id}/forward` | Forward a message to new recipients |
+| `POST` | `/agents/{address}/messages/{id}/approve` | Approve a `pending_approval` message |
+| `POST` | `/agents/{address}/messages/{id}/reject` | Reject a `pending_approval` message |
 
-## User (data rights)
+## Account (data rights)
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET` | `/users/me/export` | Returns a JSON dump of the authenticated user's profile, agents, domains, API key metadata, messages, and usage events. Right-of-access export (GDPR Art. 15 / CCPA equivalent). |
-| `DELETE` | `/users/me?confirm=DELETE` | Permanently deletes the authenticated user and all associated data in one Postgres transaction. Right-of-deletion (GDPR Art. 17 / CCPA "Do Not Sell or Share"). Requires `confirm=DELETE` query parameter as a guardrail; returns per-table row counts so the caller can audit the cascade. |
+| `GET` | `/account/export` | Returns a JSON dump of the authenticated account's profile, agents, domains, API key metadata, messages, and usage events. Right-of-access export (GDPR Art. 15 / CCPA equivalent). |
+| `DELETE` | `/account?confirm=DELETE` | Permanently deletes the authenticated account and all associated data in one Postgres transaction. Right-of-deletion (GDPR Art. 17 / CCPA "Do Not Sell or Share"). Requires `confirm=DELETE` query parameter as a guardrail; returns per-table row counts so the caller can audit the cascade. |
 
 Both endpoints require a valid API key or session. The export omits internal identifiers (Google subject, API key hashes, session tokens) — see [data-handling.md](data-handling.md) for the full data model.
 
@@ -65,18 +61,18 @@ The SDKs read the secret from `E2A_WEBHOOK_SECRET` by default (with `E2A_HMAC_SE
 
 ## HITL magic links
 
-These endpoints accept a signed `token` query parameter (from notification emails) instead of an API key, so reviewers can approve from any mail client without auth.
+These endpoints accept a signed `t` query parameter (from notification emails) instead of an API key, so reviewers can approve from any mail client without auth.
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET`/`POST` | `/approve?token=…` | Approve a pending message via signed token |
-| `GET`/`POST` | `/reject?token=…` | Reject a pending message via signed token |
+| `GET`/`POST` | `/approve?t=…` | Approve a pending message via signed token |
+| `GET`/`POST` | `/reject?t=…` | Reject a pending message via signed token |
 
 ## Real-time delivery
 
 | Method | Path | Description |
 |--------|------|-------------|
-| `GET` | `/agents/{email}/ws?token={api_key}` | WebSocket for local-mode agents. Auth via query param (WebSocket clients can't set headers during upgrade). |
+| `GET` | `/agents/{address}/ws?token={api_key}` | WebSocket for local-mode agents. Auth via query param (WebSocket clients can't set headers during upgrade). |
 
 The server pushes lightweight JSON notifications (metadata only):
 
@@ -91,7 +87,7 @@ The server pushes lightweight JSON notifications (metadata only):
 }
 ```
 
-Fetch full content via `GET /agents/{email}/messages/{id}`. The full payload includes the parsed `to` (list), `cc` (list), and `reply_to` (list) headers from the original message; the lightweight notification omits them since the agent fetches the body anyway. `reply_to` is the addresses the sender wants replies sent to — useful when `from` is a no-reply notifications mailbox; empty list when the header was absent (the server never silently falls back to `from`). On connect, all unread messages are drained as notifications automatically.
+Fetch full content via `GET /agents/{address}/messages/{id}`. The full payload includes the parsed `to` (list), `cc` (list), and `reply_to` (list) headers from the original message; the lightweight notification omits them since the agent fetches the body anyway. `reply_to` is the addresses the sender wants replies sent to — useful when `from` is a no-reply notifications mailbox; empty list when the header was absent (the server never silently falls back to `from`). On connect, all unread messages are drained as notifications automatically.
 
 ## Other
 

--- a/docs/data-handling.md
+++ b/docs/data-handling.md
@@ -16,8 +16,9 @@ For vulnerability reporting and the security model, see [SECURITY.md](../SECURIT
 | API keys | Postgres `api_keys`, **hash only** (SHA over the plaintext) | Until revoked or the user is deleted; plaintext exists only in the create response and is never persisted |
 | OAuth sessions | Postgres `user_sessions` | 30 days; cleanup worker removes expired rows hourly |
 | Usage events / summaries (only when `E2A_USAGE_TRACKING=true`) | Postgres `usage_events`, `usage_summaries` | Indefinite by default — operator can purge or override |
-| Per-user webhook signing secrets | Postgres `webhook_signing_secrets`, **plaintext** (the relay needs the value to sign — hashing them like API keys would break HMAC). Up to 5 per user. | Until the user explicitly deletes the secret or the account. Plaintext is returned exactly once at creation; subsequent reads only see a 12-char prefix. |
-| Deployment-wide HMAC signing secret (legacy fallback) | Operator's env (`E2A_HMAC_SECRET`); never written to DB | Lifetime of the deployment. Used only as a verify-side fallback for HITL approval tokens issued before the per-user-secret migration; new tokens use the user's own secret. |
+| Per-user inbound-webhook signing secret | Postgres `webhook_signing_secrets`, **plaintext** (the relay needs the value to sign — hashing them like API keys would break HMAC). Auto-provisioned at signup; the relay falls back to the deployment-wide signer if a user has none. | Until the account is deleted. There is no per-user signing-secrets management API. |
+| Per-webhook signing secret (`whsec_…`) | Postgres, **plaintext** | Until the webhook is deleted. Returned once at creation; rotate via `POST /v1/webhooks/{id}/rotate-secret` (the previous secret stays valid for a 24h grace window). |
+| Deployment-wide HMAC signing secret (operator key / legacy fallback) | Operator's env (`E2A_HMAC_SECRET`); never written to DB | Lifetime of the deployment. The operator's deployment key; also the verify-side fallback when a user has no per-user secret. SDKs verify inbound deliveries with `E2A_WEBHOOK_SECRET`, not this. |
 
 ## What's logged
 
@@ -31,8 +32,8 @@ Application logs do **not** include message bodies, attachment contents, raw API
 
 The API exposes the two operations that GDPR Art. 15 / Art. 17 (and CCPA equivalents) require:
 
-- **`GET /api/v1/users/me/export`** — returns a JSON dump of everything the authenticated user owns. Profile, agents, domains, API key metadata, all messages with bodies, usage events. Internal identifiers (Google subject, key hashes, session tokens) are excluded.
-- **`DELETE /api/v1/users/me?confirm=DELETE`** — wipes the user and every related row in a single Postgres transaction (cascade through `agent_identities → messages → webhook_deliveries`, plus explicit deletion of `usage_events` which has `ON DELETE SET NULL` rather than CASCADE so it survives by default). Returns per-table row counts so the caller can audit what was removed.
+- **`GET /v1/account/export`** — returns a JSON dump of everything the authenticated account owns. Profile, agents, domains, API key metadata, all messages with bodies, usage events. Internal identifiers (Google subject, key hashes, session tokens) are excluded.
+- **`DELETE /v1/account?confirm=DELETE`** — wipes the account and every related row in a single Postgres transaction (cascade through `agent_identities → messages → webhook_deliveries`, plus explicit deletion of `usage_events` which has `ON DELETE SET NULL` rather than CASCADE so it survives by default). Returns per-table row counts so the caller can audit what was removed.
 
 Both are scoped to the authenticated user — there's no path to target someone else's data.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -57,7 +57,7 @@ export E2A_URL=https://e2a.example.com   # default: https://e2a.dev
 e2a login                                # browser flow; saves api key + auto-discovers shared domain
 ```
 
-The CLI hits `GET /api/v1/info` on login and caches `shared_domain` to `~/.e2a/config.json`, so commands like `e2a agents update my-bot` resolve to the right address on any deployment without further config. Escape hatches if you need to override or skip the discovery step:
+The CLI hits `GET /v1/info` on login and caches `shared_domain` to `~/.e2a/config.json`, so commands like `e2a agents update my-bot` resolve to the right address on any deployment without further config. Escape hatches if you need to override or skip the discovery step:
 
 | Variable | Description |
 |---|---|

--- a/docs/design/2026-06-01-stripe-tier-webhooks.md
+++ b/docs/design/2026-06-01-stripe-tier-webhooks.md
@@ -1,8 +1,17 @@
 # Stripe-tier webhook system for e2a
 
-**Status:** Draft — awaiting review
+**Status:** Partially superseded by the `/v1` redesign (2026-06-01 design).
 **Date:** 2026-06-01
 **Builds on:** PR #180 (`feat/webhooks-resource`), now merged with the four blocker fixes.
+
+> **⚠️ Predates the `/v1` redesign.** The outbox *architecture* (§4.1–4.5) is the
+> shipped mechanism, but the API-surface details here are stale: endpoints are
+> `/v1/events`·`/v1/webhooks` (not `/api/v1/...`); pagination is `cursor`/`limit`/
+> `next_cursor` (not `page_size`/`token`); errors use the JSON envelope
+> `{error:{code,message,details,request_id}}` (not plain-text bodies); the bulk
+> `redeliver-since` endpoint (§4.6) was **dropped** (only per-event
+> `POST /v1/events/{id}/redeliver` ships); and `WEBHOOKS_OUTBOX_ENABLED` is now
+> permanently on. The `email.rejected` event name shipped as written.
 
 ---
 

--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -2,11 +2,30 @@
 
 | | |
 |---|---|
-| **Status** | Proposed |
-| **Date** | 2026-06-13 |
+| **Status** | Implemented & shipped (2026-06). Legacy `/api/v1` retired (§13). |
+| **Date** | 2026-06-13 (design) · 2026-06 (as-built §11/§13) |
 | **Audience** | e2a maintainers; SDK + MCP authors; downstream agent developers |
 | **Role** | Reshape the existing `/api/v1` surface into one clean, consistent, agent-first contract — with the OpenAPI spec as the single source of truth that the MCP server, SDKs, and docs are generated from and drift-tested against. |
-| **Related** | `docs/api.md` (current REST surface) · `docs/events.md` (webhook events) · PR #206 (MCP↔API drift) |
+| **Related** | `docs/api.md` (REST surface) · `docs/events.md` (webhook events) · PR #206 (MCP↔API drift) |
+
+> **⚠️ As-built note (read first).** This document was written across the
+> redesign; §1–§12 capture the design *as it evolved* and contain interim
+> "strangler residue / deferred / remains on legacy `/api/v1`" language that the
+> final implementation **superseded**. For the shipped state, **§13 and
+> `api/openapi.yaml` are authoritative.** Since those earlier sections were
+> written: the legacy `/api/v1` surface was **fully retired**; the HITL
+> magic-link pages moved to **`/v1/approve`·`/v1/reject`**; the account-wide
+> `pending` list, the flat `GET /messages/{id}`, and the per-user signing-secrets
+> management API were **dropped**; `send` ships **nested** at
+> `POST /v1/agents/{address}/messages` (no top-level `/v1/send`); HITL ships as
+> the two routes **`…/approve` + `…/reject`** (not a single `approval`
+> sub-resource); and decisions 4/9/10 **shipped**. **Still pending:** the MCP
+> tool-surface re-curation to the §6a target (the SDK *transport* was repointed
+> onto `/v1`, but the tool names/args in `mcp/src/tools/` remain the pre-redesign
+> set — tracked as a separate round) and F4 (uniform `AutoPager` —
+> `conversations.list` still returns a plain array). The event name
+> `email.rejected` shipped as-is (decision 9's `email.approval_rejected` rename
+> did not land).
 
 ## 1. Problem statement
 
@@ -282,9 +301,10 @@ relative to that base):
    GET** — email scanners/link-prefetchers would auto-approve/reject. Short-TTL
    capability; **single-use is enforced by the state machine** (the message
    leaves `pending_approval` on the first decision; a second 409s), not by the
-   token. **Status: the nested `approve`/`reject` ship on `/v1` today; the
-   magic-link pages + the account-wide `pending` list remain on legacy `/api/v1`
-   pending a separate port (they are human-facing HTML / a list, not agent JSON).**
+   token. **Status (as-built, §13): the nested `approve`/`reject` ship on `/v1`;
+   the magic-link pages moved to `/v1/approve`·`/v1/reject` (token-gated HTML);
+   the account-wide `pending` list was dropped — clients compose it from
+   `GET /v1/agents` + per-agent message lists.**
 6. **One error envelope** (audit current handlers and standardize):
    `{ "error": { "code": "MACHINE_BRANCHABLE", "message": "human text",
    "details": {…} } }`, with stable `code` values documented in the spec.
@@ -1117,10 +1137,10 @@ Applying 1 + 6: a runtime agent sees ~13 tools; the full self-host surface 31.
 | `POST /send` | **move** | `POST /agents/{address}/messages` (new-thread case — nest under the agent) |
 | `POST /agents/{e}/messages/{id}/reply` | **keep (re-place)** | `POST /agents/{address}/messages/{id}/reply` — explicit reply op (target in path), not folded into the send body |
 | `POST /agents/{e}/messages/{id}/forward` | **keep (re-place)** | `POST /agents/{address}/messages/{id}/forward` — explicit forward op (target in path) |
-| `GET /messages/{id}` (flat) | **remove (deferred → Slice 4b)** | use `GET /agents/{address}/messages/{id}`. Held drafts store the body as `body_text`/`body_html` columns (mutable, reviewable, scrubbed on terminal transition), while sent/inbound carry `raw_message` — so the unified read must expose BOTH representations. That message-read shape is decision 9 / Slice 4b territory (the parsed view); removing the flat path before then would design the shape twice. Until 4b, the flat `/api/v1/messages/{id}` stays as strangler residue. |
+| `GET /messages/{id}` (flat) | **removed (Slice 8e)** ✅ | use `GET /agents/{address}/messages/{id}`. Held drafts store the body as `body_text`/`body_html` columns (mutable, reviewable, scrubbed on terminal transition), while sent/inbound carry `raw_message`, so the unified read exposes BOTH (the parsed view, Slice 4b-3). The flat `/api/v1/messages/{id}` was deleted in 8e once 4b-3 shipped the read shape. |
 | host + prefix `…/api/v1/*` | **move** | dedicated host `api.e2a.dev`, prefix `/v1` (base `https://api.e2a.dev/v1`) |
-| `GET/POST /approve`, `/reject`, `/pending` | **collapse** | `POST …/messages/{id}/approval` + magic-link GET alias |
-| `POST …/messages/{id}/approve|reject` | **collapse** | same `approval` sub-resource |
+| `GET/POST /approve`, `/reject`, `/pending` | **shipped (Slice 8e)** ✅ | the JSON HITL decision is two agent-scoped routes `…/messages/{id}/approve` + `…/reject` (NOT the single `approval` sub-resource this row originally proposed); the human magic-link moved to `/v1/approve`·`/v1/reject`; `/pending` was dropped (compose from per-agent lists). |
+| `POST …/messages/{id}/approve|reject` | **shipped as two routes** ✅ | `…/approve` + `…/reject` (`approveMessage`/`rejectMessage`). |
 | `GET /users/me/limits` | **rename** | `GET /account` (identity + plan + limits + usage) |
 | `GET /info` | **keep** | stays a separate **public** deployment-discovery endpoint — NOT folded into `/account` |
 | `/users/me/*` | **rename** | `/account/*` (`/account/export`, `DELETE /account`) |
@@ -1597,6 +1617,14 @@ exact backoff schedule + signature-rotation grace window for webhooks.
 
 ## 11. Cutover — as built (2026-06)
 
+> **⚠️ Snapshot of the `feat/api-v1-cutover` branch (≈ Slice 1), superseded by
+> §13.** Everything this section lists as "NOT fully built yet" / "unbuilt" /
+> "target spec, not shipped" subsequently **shipped**: `send` is now nested at
+> `POST /v1/agents/{address}/messages` (no top-level `/v1/send`), HITL ships as
+> `…/approve` + `…/reject`, and decisions 4/9/10 (sender identity, delivery
+> feedback + structured inbound `auth`, inbound policy) landed. Read the rest of
+> §11 as historical record; §13 + `api/openapi.yaml` are the as-built truth.
+
 Reconciles this design to what shipped on the `feat/api-v1-cutover` branch.
 
 **Scope, stated plainly:** the shipped `/v1` is the **contract + host/strangler
@@ -1853,9 +1881,19 @@ policy).
 
 ## 13. Slice 8e — retire the legacy `/api/v1` surface + flatten the SDK `oag/` subpath (2026-06)
 
-With every consumer (web, CLI, MCP, both SDKs) cut over to `/v1`, the legacy
-`gorilla/mux` `/api/v1` strangler residue was deleted and the generated SDK base
-was un-nested. Done as one PR.
+With every consumer (web, CLI, MCP, both SDKs) cut over to `/v1` at the
+**transport** layer (the cli + MCP server were repointed onto the 3.0 SDK in
+#232), the legacy `gorilla/mux` `/api/v1` strangler residue was deleted and the
+generated SDK base was un-nested. Done as one PR.
+
+> **Note — MCP *tool surface* re-curation still pending.** "MCP cut over" above
+> means the MCP server now calls `/v1` via the 3.0 SDK. The MCP **tool catalogue**
+> (`mcp/src/tools/`) has NOT yet been re-curated to the §6a target: it still ships
+> the pre-redesign tool names/args (`send_email`, `list_pending_messages`,
+> `approve_pending_message`, `create_agent` with `slug`/`agent_mode`/`webhook_url`,
+> `E2A_AGENT_EMAIL` auto-resolve), some of which send fields the Slice-3 backend
+> already dropped (migration 029). Re-curating the tool interface to §6a is a
+> tracked separate round.
 
 ### 13.1 Server — legacy `/api/v1` deleted
 The chi root is the process handler; Huma `/v1` operations are mounted on it and

--- a/docs/design/outbound-v1-extraction.md
+++ b/docs/design/outbound-v1-extraction.md
@@ -1,8 +1,13 @@
 # Outbound `/v1` — `deliverOutbound` extraction plan
 
+> **✅ Shipped — historical plan.** The `DeliverOutbound` core extraction landed,
+> and `send` ships nested at `POST /v1/agents/{address}/messages` (the unified
+> shape this doc framed as "Slice 2"). Kept as the original extraction plan; see
+> api-v1-redesign §9/§11 for the as-built.
+
 | | |
 |---|---|
-| **Status** | Planned (gated on focused execution) |
+| **Status** | Done (shipped 2026-06) |
 | **Part of** | Slice 1 (api-v1-redesign), PR #208 |
 | **Risk** | HIGH — live email/SES (money), HITL owner-notification, idempotency |
 

--- a/docs/design/v1-cutover-plan.md
+++ b/docs/design/v1-cutover-plan.md
@@ -1,8 +1,13 @@
 # Slice 1 — `/v1` cutover plan (finish Slice 1)
 
+> **✅ Shipped — historical plan.** Every phase below completed: the `/v1`
+> cutover, legacy `/api/v1` removal, and SDK 3.0 consumer port all landed. See
+> `api-v1-redesign.md` §11 (as-built) + §13 (legacy retire) for the shipped
+> state; this file is kept as the original execution plan.
+
 | | |
 |---|---|
-| **Status** | Planned |
+| **Status** | Done (shipped 2026-06) — superseded by api-v1-redesign §11/§13 |
 | **Depends on** | PR #208 (the additive `/v1` surface) |
 | **Branch** | `feat/api-v1-cutover` (stacked on `feat/api-v1-slice1-contract`) |
 | **Breaking** | YES — removes legacy `/api/v1`, breaks the internal AgentDrive consumer |

--- a/docs/events.md
+++ b/docs/events.md
@@ -31,16 +31,13 @@ import { E2AClient } from "@e2a/sdk/v1";
 const client = new E2AClient({ apiKey: process.env.E2A_API_KEY });
 
 // Walk the last 24h of email.received events.
-let token: string | undefined;
-do {
-  const res = await client.api.listEvents({
+const events = await client.events
+  .list({
     type: "email.received",
     since: new Date(Date.now() - 24 * 3600 * 1000).toISOString(),
-    token,
-  });
-  for (const e of res.events) console.log(e.id, e.type, e.created_at);
-  token = res.next_token;
-} while (token);
+  })
+  .toArray(); // auto-pages via next_cursor
+for (const e of events) console.log(e.id, e.type, e.created_at);
 ```
 
 In Python:
@@ -50,8 +47,7 @@ from e2a.v1 import E2AClient
 import os
 
 client = E2AClient(api_key=os.environ["E2A_API_KEY"])
-res = client.api.list_events(type="email.received", page_size=20)
-for e in res.events:
+for e in client.events.list(type="email.received", limit=20):
     print(e.id, e.type, e.created_at)
 ```
 
@@ -70,24 +66,24 @@ for e in res.events:
 
 ## Cursor pagination
 
-`GET /v1/events` returns a `next_token` when more pages are available. Pass it back via `?token=…` to walk forward in time. Use `since` / `until` (RFC3339) to bracket a specific window — both are optional and stack with the cursor.
+`GET /v1/events` returns a `next_cursor` when more pages are available. Pass it back via `?cursor=…` to walk forward in time. Use `since` / `until` (RFC3339) to bracket a specific window — both are optional and stack with the cursor.
 
 ```bash
 # Get the first page.
 RESP=$(curl -s -H "Authorization: Bearer $E2A_API_KEY" \
-  "https://e2a.dev/v1/events?page_size=50")
-TOKEN=$(echo "$RESP" | jq -r '.next_token')
+  "https://e2a.dev/v1/events?limit=50")
+CURSOR=$(echo "$RESP" | jq -r '.next_cursor')
 
 # Walk forward.
-while [ "$TOKEN" != "null" ] && [ -n "$TOKEN" ]; do
+while [ "$CURSOR" != "null" ] && [ -n "$CURSOR" ]; do
   RESP=$(curl -s -H "Authorization: Bearer $E2A_API_KEY" \
-    "https://e2a.dev/v1/events?page_size=50&token=$TOKEN")
+    "https://e2a.dev/v1/events?limit=50&cursor=$CURSOR")
   # process events…
-  TOKEN=$(echo "$RESP" | jq -r '.next_token')
+  CURSOR=$(echo "$RESP" | jq -r '.next_cursor')
 done
 ```
 
-Page size is 1–100 (default 50). Events past the 30-day retention boundary are not returned; querying their id directly returns **410 Gone**.
+Page size (`limit`) is 1–200 (default 50). Events past the 30-day retention boundary are not returned; querying their id directly returns **410 Gone**.
 
 ## Reconciliation pattern
 
@@ -101,10 +97,9 @@ If your webhook receiver went down for an hour, the steps to reconcile are:
 ```python
 # Pseudocode for the reconciliation flow.
 processed = set(load_processed_event_ids_from_my_db())
-res = client.api.list_events(since=outage_start, until=outage_end)
-for e in res.events:
+for e in client.events.list(since=outage_start, until=outage_end):
     if e.id not in processed:
-        client.api.redeliver_event(e.id, webhook_id="wh_my_handler")
+        client.events.redeliver(e.id, webhook_id="wh_my_handler")
 ```
 
 ## Replay
@@ -145,5 +140,5 @@ Replay requires the source event to still exist. If you need a longer reconcilia
 
 ## See also
 
-- [Webhooks overview](webhooks.md) — subscriber model, signing, retry policy.
+- [API reference — Webhooks](api.md#webhook-signing-secrets) — subscriber model, signing, retry policy.
 - [Design: Stripe-tier webhooks](design/2026-06-01-stripe-tier-webhooks.md) — full rationale for the outbox + event log architecture.

--- a/examples/adk-cloud-webhook/README.md
+++ b/examples/adk-cloud-webhook/README.md
@@ -14,10 +14,10 @@ e2a relay
     v  HTTPS POST /webhook (signed)
 this app
     |
-    +-- parse_webhook (parse + verify HMAC)
+    +-- construct_event (verify HMAC + decode to a typed event)
     +-- look up / create ADK session keyed by conversation_id
     +-- runner.run_async(...)
-    +-- email.reply(text, conversation_id=...)
+    +-- client.messages.reply(address, message_id, {body, conversation_id})
     |
     v
 e2a relay -> SMTP -> human
@@ -69,14 +69,19 @@ ngrok http 18080
 # Forwarding  https://abc123.ngrok.io -> http://localhost:18080
 ```
 
-Set that public URL on your agent (replace `<YOUR_AGENT_EMAIL>` and
-`<YOUR_API_KEY>`):
+Subscribe that public URL to your agent's inbound mail. Webhooks are a separate
+resource (`/v1/webhooks`) — pass the agent's address as a filter (replace
+`<YOUR_AGENT_EMAIL>` and `<YOUR_API_KEY>`):
 
 ```bash
-curl -X PUT https://e2a.dev/api/v1/agents/<YOUR_AGENT_EMAIL> \
+curl -X POST https://e2a.dev/v1/webhooks \
   -H "Authorization: Bearer <YOUR_API_KEY>" \
   -H "Content-Type: application/json" \
-  -d '{"webhook_url":"https://abc123.ngrok.io/webhook"}'
+  -d '{
+    "url": "https://abc123.ngrok.io/webhook",
+    "events": ["email.received"],
+    "filters": {"agent_ids": ["<YOUR_AGENT_EMAIL>"]}
+  }'
 ```
 
 ## Try it
@@ -95,9 +100,10 @@ propagating an opaque `conversation_id` through each round-trip:
 1. **First inbound** has `conversation_id = None` (the human just
    started a thread). The webhook mints `conv_<random>` and uses it as
    the ADK `session_id` when creating the session.
-2. The webhook calls `email.reply(text, conversation_id=conv_<random>)`.
-   e2a stamps `X-E2A-Conversation-Id: conv_<random>` on the outbound
-   message and remembers the binding to the message ID.
+2. The webhook calls `client.messages.reply(address, message_id,
+   {"body": text, "conversation_id": "conv_<random>"})`. e2a stamps
+   `X-E2A-Conversation-Id: conv_<random>` on the outbound message and
+   remembers the binding to the message ID.
 3. **Subsequent inbound** (the human replies in their mail client) lands
    with the same `conversation_id` set — recovered from `In-Reply-To` /
    `References` lookup. The webhook calls `get_session` with that ID and
@@ -122,10 +128,13 @@ field on the parsed payload.
   SQLite) — see [ADK sessions docs](https://adk.dev/sessions/session/).
 - **Tools.** The agent has no tools beyond text generation. Add them to
   `agent.py` once the email loop works end-to-end.
-- **Attachments.** `email.attachments` is exposed by the SDK but ignored
-  here. ADK's `Content` supports inline data parts if you want to feed
-  attachments to a vision model.
+- **Attachments.** Attachment metadata lives on the `MessageView` you
+  fetch with `client.messages.get(address, message_id)` (the typed event
+  from `construct_event` carries the message payload); this example
+  ignores it. ADK's `Content` supports inline data parts if you want to
+  feed attachments to a vision model.
 - **HITL.** The agent replies immediately. If you want human approval
   before the reply goes out, enable HITL on the agent
   ([docs](https://github.com/Mnexa-AI/e2a/blob/main/README.md)) and the
-  `email.reply()` call returns 202 with the reply held for review.
+  `client.messages.reply(...)` call returns `status: "pending_approval"`
+  with the reply held for review.

--- a/internal/agent/user_data_rights_api.go
+++ b/internal/agent/user_data_rights_api.go
@@ -21,16 +21,8 @@ import (
 // CCPA equivalent). Output is deterministic-ordered (created_at) so a
 // caller diffing exports across time gets stable results.
 //
-// @Summary      Export your data
-// @Description  Returns a JSON dump of every record the authenticated user owns: profile, agents, domains, API key metadata, messages (with bodies), and usage events. API key plaintexts are not included — they were never stored. Internal identifiers (google_subject, session tokens, key hashes) are excluded.
-// @Tags         User
-// @Produce      json
-// @Security     BearerAuth
-// @Success      200 {object} UserExport
-// @Failure      401 {string} string "Missing or invalid API key"
-// @Router       /api/v1/users/me/export [get]
 // ExportUserDataCore assembles the full user-data export (store export +
-// OAuth connections). HTTP-free; shared by the legacy handler and the v1 layer.
+// OAuth connections). HTTP-free; serves GET /v1/account/export.
 func (a *API) ExportUserDataCore(ctx context.Context, userID string) (*identity.UserExport, error) {
 	dump, err := a.store.ExportUserData(ctx, userID)
 	if err != nil {
@@ -69,19 +61,9 @@ func (a *API) ExportUserDataCore(ctx context.Context, userID string) (*identity.
 // confirmation matches the pattern other destructive APIs use
 // (Stripe's account close, GitHub's repo delete).
 //
-// @Summary      Delete your account and all associated data
-// @Description  Permanently deletes the authenticated user along with their agents, domains, messages, API keys, sessions, and usage data. **Irreversible.** Requires `confirm=DELETE` query parameter as a guardrail. Returns per-table counts of removed rows so the caller can audit the cascade.
-// @Tags         User
-// @Produce      json
-// @Security     BearerAuth
-// @Param        confirm query string true "Must equal 'DELETE' to proceed"
-// @Success      200 {object} DeleteUserDataResult
-// @Failure      400 {string} string "Missing or invalid confirm parameter"
-// @Failure      401 {string} string "Missing or invalid API key"
-// @Router       /api/v1/users/me [delete]
 // DeleteUserDataCore counts OAuth rows for the audit line, best-effort
 // notifies the external billing hook, then runs the cascading delete and
-// merges the counts. HTTP-free; shared by the legacy handler and the v1 layer.
+// merges the counts. HTTP-free; serves DELETE /v1/account?confirm=DELETE.
 func (a *API) DeleteUserDataCore(ctx context.Context, user *identity.User) (*identity.DeleteUserDataResult, error) {
 	// Count OAuth token rows BEFORE the DELETE so the audit report is correct
 	// (small benign race vs CASCADE accepted, per the original handler).

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -121,6 +121,11 @@ Add to the MCP config (`claude_desktop_config.json`, `cline_mcp_settings.json`, 
 
 ## Tools
 
+The server registers **33** tools spanning agents, messages, human-in-the-loop
+approval, attachments, domains, events, and webhooks. The tables below highlight
+the most commonly used ones — your MCP host's tool list shows the full set with
+per-tool descriptions.
+
 ### Identity
 
 | Tool | Description |
@@ -129,7 +134,7 @@ Add to the MCP config (`claude_desktop_config.json`, `cline_mcp_settings.json`, 
 | `list_agents` | List every agent inbox owned by the authenticated user. |
 | `create_agent` | Register a new inbox using a slug on the shared domain. Defaults to `local` mode — no webhook required. See note below for cloud mode. |
 
-> **Cloud-mode agents must verify webhook signatures.** When you create an agent with `agent_mode: "cloud"`, e2a HMAC-signs every webhook delivery against your account's webhook signing secret (`E2A_WEBHOOK_SECRET`, shown in the [e2a dashboard](https://e2a.dev)). Your webhook handler must verify the signature on every request — the [e2a SDK](https://www.npmjs.com/package/@e2a/sdk) exposes `parseWebhook(body, secret)` which parses and verifies in one call. Local-mode agents (the default) avoid this entirely by polling via `list_messages`.
+> **Cloud-mode agents must verify webhook signatures.** When you create an agent with `agent_mode: "cloud"`, e2a HMAC-signs every webhook delivery against your account's webhook signing secret (`E2A_WEBHOOK_SECRET`, shown in the [e2a dashboard](https://e2a.dev)). Your webhook handler must verify the signature on every request — the [e2a SDK](https://www.npmjs.com/package/@e2a/sdk) exposes `constructEvent(rawBody, signatureHeader, secret)` which verifies the signature and returns a typed event in one call (throws on a bad signature). Local-mode agents (the default) avoid this entirely by polling via `list_messages`.
 
 ### Messages
 

--- a/mcp/examples/README.md
+++ b/mcp/examples/README.md
@@ -12,7 +12,7 @@ End-to-end demos showing how to wire the e2a MCP surface into popular agent fram
 
 ## Two transports, same tool surface
 
-Each example exercises the same 18 e2a tools. The Python framework examples ship two scripts; the Codex example ships two TOML blocks (Codex is itself the agent, so you configure it instead of writing a script).
+Each example exercises the same 33 e2a tools. The Python framework examples ship two scripts; the Codex example ships two TOML blocks (Codex is itself the agent, so you configure it instead of writing a script).
 
 - **Stdio variant** consumes the published [@e2a/mcp-server](https://www.npmjs.com/package/@e2a/mcp-server) from npm via `npx -y` — no local build needed. Best for laptop / local dev.
 - **Hosted variant** connects to `https://mcp.e2a.dev/mcp` over Streamable HTTP with your API key in the `Authorization` header. Best when:

--- a/mcp/examples/codex/README.md
+++ b/mcp/examples/codex/README.md
@@ -2,7 +2,7 @@
 
 [Codex CLI](https://github.com/openai/codex) is OpenAI's terminal coding agent (peer to Claude Code). It speaks MCP natively — you declare servers in `~/.codex/config.toml` and Codex connects to them at session start, then surfaces their tools to whatever model you're running.
 
-Unlike the [LangChain](../langchain/), [Google ADK](../adk/), and [OpenAI Agents SDK](../openai-agents/) examples — which are Python scripts you run — Codex is itself the agent. The "example" here is the TOML you paste into your Codex config to add e2a's 18 MCP tools.
+Unlike the [LangChain](../langchain/), [Google ADK](../adk/), and [OpenAI Agents SDK](../openai-agents/) examples — which are Python scripts you run — Codex is itself the agent. The "example" here is the TOML you paste into your Codex config to add e2a's 33 MCP tools.
 
 Two transport options, both first-class in Codex:
 

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## 3.0.0
+
+Breaking redesign. The SDK is now a namespaced, **async-only** `E2AClient`
+wrapping a generated client over the agent-scoped `/v1` API surface, with a
+typed error hierarchy, automatic retries + idempotency, and async
+auto-pagination.
+
+### Changed
+- **Namespaced, async-only surface.** Resources are grouped under the client:
+  `client.agents`, `client.messages`, `client.conversations`, `client.domains`,
+  `client.events`, `client.webhooks`, `client.account`. Per-agent methods take
+  the agent `address` as the first argument
+  (`await client.messages.send(address, {...})`,
+  `await client.messages.list(address).to_list(limit=...)`,
+  `await client.messages.get(address, id)`,
+  `await client.messages.reply(address, id, {...})`). Use the client as an async
+  context manager (`async with E2AClient() as client:`).
+- **Webhook verification.** Verify and decode a delivery with the standalone
+  `construct_event(raw_body, signature_header, secret)`, which checks the
+  `X-E2A-Signature` header and returns a typed event (raising
+  `E2AWebhookSignatureError` on a bad signature). Per-webhook `whsec_…` secrets,
+  Stripe-style.
+- **Typed errors.** Failures raise `E2AError` subclasses (`E2ANotFoundError`,
+  `E2AConflictError`, `E2AValidationError`, `E2ARateLimitError`,
+  `E2AWebhookSignatureError`, …) carrying `.code`, `.status`, `.request_id`, and
+  `.retryable`.
+
+### Removed
+- The flat methods `send` / `reply` / `get_messages` / `get_message` and the
+  per-call `agent_email` inference. Pass the agent `address` explicitly.
+- The lower-level `E2AApi` class.
+- The synchronous client — the SDK is async-only.
+- `InboundEmail` / `AsyncInboundEmail` and the `parse_webhook` / `parse` +
+  `verify_signature()` flow. Replaced by `construct_event`. There is no
+  unverified-email type and no field-access gating.
+
 ## 2.5.0
 
 ### Added

--- a/skills/using-e2a/SKILL.md
+++ b/skills/using-e2a/SKILL.md
@@ -10,7 +10,7 @@ version: 10
 e2a is an authenticated email gateway for AI agents. It gives an agent a real email address (`agent@agents.e2a.dev` or `agent@your-domain.com`), verifies sender identity (SPF/DKIM), threads conversations, and optionally pauses outbound mail for human review.
 
 This skill works two ways:
-- **Via the Claude Code plugin (MCP).** Tools appear in the menu as `mcp__e2a__*` — 18 of them covering agents, messages, HITL, and domains.
+- **Via the Claude Code plugin (MCP).** Tools appear in the menu as `mcp__e2a__*` — 33 of them covering agents, messages, HITL, attachments, domains, events, and webhooks.
 - **Via the `e2a` CLI / SDKs.** Same operations, different surface: `e2a` commands on the shell, or the TypeScript / Python SDK in your own webhook handler.
 
 The mental model and gotchas are identical across both surfaces. Workflow steps below call out the MCP tool name and the CLI equivalent — pick whichever fits the current session.
@@ -146,29 +146,35 @@ pip install e2a
 ```
 
 ```python
-import e2a
+import os
+
+from e2a.v1 import E2AClient, construct_event, E2AWebhookSignatureError
 from fastapi import FastAPI, HTTPException, Request
 
 app = FastAPI()
+SECRET = os.environ["E2A_WEBHOOK_SECRET"]  # whsec_…
 
-# agent_email is optional — auto-resolves from the payload in webhook mode.
-client = e2a.E2AClient(api_key="e2a_...")  # or set E2A_API_KEY
+# The SDK is async-only and namespaced. There is no agent_email constructor arg.
+client = E2AClient(api_key=os.environ["E2A_API_KEY"])  # or E2AClient() reads E2A_API_KEY
 
 @app.post("/webhook")
 async def webhook(request: Request):
-    # parse_webhook = parse + HMAC-verify in one call.
-    # Reads E2A_WEBHOOK_SECRET from the env — set it or first request raises.
+    # construct_event = verify the X-E2A-Signature header + decode to a typed
+    # event in one call. Pass the RAW body — re-serialized JSON won't match.
     try:
-        email = client.parse_webhook(await request.body())
-    except PermissionError:
-        raise HTTPException(401, "bad signature")
+        event = construct_event(
+            await request.body(), request.headers["X-E2A-Signature"], SECRET
+        )
+    except E2AWebhookSignatureError:
+        raise HTTPException(400, "bad signature")
 
-    print(f"From: {email.sender}")
-    print(f"Subject: {email.subject}")
-    print(f"Body: {email.text_body}")
+    if event.type == "email.received":
+        msg = event.data  # the inbound message payload
+        print(f"From: {msg.from_}")
+        print(f"Subject: {msg.subject}")
 
-    # Threaded reply — agent_email auto-resolves from email.recipient
-    email.reply("Thanks for your email!")
+        # Threaded reply — pass the agent address explicitly.
+        await client.messages.reply(msg.recipient, msg.message_id, {"body": "Thanks for your email!"})
     return {"ok": True}
 ```
 
@@ -179,23 +185,28 @@ npm install @e2a/sdk
 ```
 
 ```typescript
-import { E2AClient } from "@e2a/sdk";
+import { E2AClient, constructEvent, E2AWebhookSignatureError } from "@e2a/sdk/v1";
 import express from "express";
 
 const app = express();
-app.use(express.json());
 
 const client = new E2AClient({ apiKey: process.env.E2A_API_KEY! });
+const SECRET = process.env.E2A_WEBHOOK_SECRET!; // whsec_…
 
-app.post("/webhook", async (req, res) => {
-  let email;
+// Use the raw body parser — re-stringified JSON won't match the signature.
+app.post("/webhook", express.raw({ type: "application/json" }), async (req, res) => {
+  let event;
   try {
-    email = await client.parseWebhook(req.body);
-  } catch {
-    return res.status(401).end();
+    event = constructEvent(req.body, req.header("X-E2A-Signature"), SECRET);
+  } catch (e) {
+    if (e instanceof E2AWebhookSignatureError) return res.status(400).end();
+    throw e;
   }
-  console.log(`From: ${email.sender} — ${email.subject}`);
-  await email.reply("Thanks for your email!");
+  if (event.type === "email.received") {
+    const msg = event.data; // the inbound message payload
+    console.log(`From: ${msg.from} — ${msg.subject}`);
+    await client.messages.reply(msg.recipient, msg.messageId, { body: "Thanks for your email!" });
+  }
   res.json({ ok: true });
 });
 
@@ -222,7 +233,7 @@ Inbound payload shape:
 }
 ```
 
-`to` and `cc` are the parsed headers from the original message; `recipient` is this delivery's per-agent target. The SDK gates field access behind verification — accessing `email.sender` etc. on an unverified payload raises `UnverifiedEmailError`. `parse_webhook` / `parseWebhook` handles the verify step. `client.parse(...)` returns an unverified email and requires `email.verify_signature()` / `email.verifySignature()` before claim fields are readable. Check `email.is_verified` / `email.isVerified` to confirm.
+`to` and `cc` are the parsed headers from the original message; `recipient` is this delivery's per-agent target. `construct_event` / `constructEvent` verifies the `X-E2A-Signature` header against your `whsec_…` secret and **throws** (`E2AWebhookSignatureError`) on a bad signature — so if it returns, the payload is authentic and you can read its fields directly. There is no separate "verify then read" gate and no unverified-email type; verification and decoding happen in the one call. During a secret rotation you can pass a list/array of secrets — accepted if any matches.
 
 ### Local agent with WebSocket bridge (optional)
 
@@ -255,9 +266,9 @@ There's no MCP equivalent — this is a CLI-only pattern. Useful for local devel
 ## Reference
 
 - Config file (CLI): `~/.e2a/config.json` — JSON with `api_key`, `api_url`, `agent_email`, `shared_domain`.
-- Env vars that override config: `E2A_API_KEY`, `E2A_URL`, `E2A_SHARED_DOMAIN` (CLI). `E2A_AGENT_EMAIL` is honored by the Python/TS SDK constructors when you don't pass `agent_email` explicitly. `E2A_WEBHOOK_SECRET` is read by `parse_webhook` / `parseWebhook` and `verify_signature()` / `verifySignature()` for inbound HMAC verification.
+- Env vars that override config: `E2A_API_KEY`, `E2A_URL`, `E2A_SHARED_DOMAIN` (CLI). `E2A_AGENT_EMAIL` is honored by `client.listen(...)` as the default agent address when you don't pass one — it is NOT a constructor argument. `E2A_WEBHOOK_SECRET` holds the `whsec_…` signing secret you pass to `construct_event` / `constructEvent` for inbound HMAC verification.
 - Plugin homepage: https://e2a.dev
-- 18 MCP tools: agents (5), messages (5), HITL (4), domains (4), plus `get_attachment_data` (shared).
+- 33 MCP tools spanning agents, messages, HITL, attachments, domains, events, and webhooks.
 - Tool descriptions teach behavior; this skill teaches the mental model. When in doubt, read the tool's own `description` for the precise contract.
 - CLI: https://www.npmjs.com/package/@e2a/cli
 - TypeScript SDK: https://www.npmjs.com/package/@e2a/sdk

--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,10 @@
   "private": true,
   "license": "Apache-2.0",
   "scripts": {
+    "sync-openapi": "cp ../api/openapi.yaml public/openapi.yaml",
+    "predev": "npm run sync-openapi",
     "dev": "next dev",
+    "prebuild": "npm run sync-openapi",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",

--- a/web/package.json
+++ b/web/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "Apache-2.0",
   "scripts": {
-    "sync-openapi": "cp ../api/openapi.yaml public/openapi.yaml",
+    "sync-openapi": "cp ../api/openapi.yaml public/openapi.yaml 2>/dev/null || echo 'sync-openapi: ../api/openapi.yaml not in build context (e.g. the web Docker image) — using the committed public/openapi.yaml'",
     "predev": "npm run sync-openapi",
     "dev": "next dev",
     "prebuild": "npm run sync-openapi",

--- a/web/public/auth.md
+++ b/web/public/auth.md
@@ -4,7 +4,7 @@ You are an agent that wants to use e2a — the authenticated email gateway for A
 
 Two hosts are relevant:
 
-- **API** — `https://e2a.dev` — the resource server you will call (`/api/v1/...`).
+- **API** — `https://e2a.dev` — the resource server you will call (`/v1/...`).
 - **Dashboard** — `https://e2a.dev` — where the user manages agents, domains, API keys, and billing.
 
 ## Current state
@@ -25,7 +25,7 @@ If any of these is already configured, use it and stop. Do not ask the user for 
 
 ## Credentials
 
-e2a accepts two credential shapes at every `/api/v1/...` endpoint, dispatched by token prefix:
+e2a accepts two credential shapes at every `/v1/...` endpoint, dispatched by token prefix:
 
 - **OAuth access token** (`ate2a_…`) — issued by the e2a OAuth server to a registered client after the user consents in a browser. Use this if you are an MCP client.
 - **API key** (`e2a_…`) — issued by the user directly from the dashboard, supplied to your environment out of band. Use this if you are a CLI, script, server-side integration, or direct API consumer.
@@ -42,7 +42,7 @@ If you are an MCP client, you do not need an API key. Run the standard discovery
 4. **Token exchange** — `POST` `code` + `code_verifier` to `token_endpoint`. You receive `access_token` (prefix `ate2a_…`) and `refresh_token`.
 5. **Use** — present the access token as a bearer; refresh with the refresh token before `expires_in`.
 
-Access tokens carry the user identity that consented to your client; every `/api/v1/...` call is scoped to that user.
+Access tokens carry the user identity that consented to your client; every `/v1/...` call is scoped to that user.
 
 ### Path B — Direct API consumer via API key
 
@@ -70,17 +70,16 @@ API keys do not expire on their own. Treat a `401` on a previously-working key a
 
 ### How to use the credential
 
-Whether `access_token` or `api_key`, present it as a bearer token. Example send:
+Whether `access_token` or `api_key`, present it as a bearer token. The message surface is agent-scoped — the sending agent is in the path (URL-encode the `@`), so there is no `from` field in the body. Example send:
 
 ```http
-POST /api/v1/send HTTP/1.1
+POST /v1/agents/bot%40agents.e2a.dev/messages HTTP/1.1
 Host: e2a.dev
 Authorization: Bearer $CREDENTIAL
 Content-Type: application/json
 Idempotency-Key: <UUIDv4>
 
 {
-  "from": "bot@agents.e2a.dev",
   "to": ["alice@example.com"],
   "subject": "Hello from your agent",
   "body": "Plain-text body. Required.",
@@ -92,11 +91,11 @@ The plain-text body field is `body` (required). The HTML alternative is `html_bo
 
 Read the credential from the environment at the moment of the call. Do not copy it into variables you log, do not echo it back to the user, do not include it in commit messages, PR descriptions, error reports, or screenshots. If you are running a shell command, never interpolate the credential inline — reference the environment variable so it does not appear in command history.
 
-Set an `Idempotency-Key` (UUIDv4 recommended) per logical operation on side-effectful calls (`/send`, replies, HITL approve). Reuse the **same** key on transport retries (network failures, timeouts) — the server replays the original response. Same key with a different body returns `422`; a genuinely new operation needs a fresh key.
+Set an `Idempotency-Key` (UUIDv4 recommended) per logical operation on side-effectful calls (sends, replies, HITL approve). Reuse the **same** key on transport retries (network failures, timeouts) — the server replays the original response. Same key with a different body returns `422`; a genuinely new operation needs a fresh key.
 
 ### HITL: handling 202 pending_approval
 
-If the agent owner has enabled human-in-the-loop review, `/api/v1/send` (and `/reply`) will return **`202 Accepted`** with `status: "pending_approval"` instead of dispatching the message:
+If the agent owner has enabled human-in-the-loop review, a send (and `reply`/`forward`) will return **`202 Accepted`** with `status: "pending_approval"` instead of dispatching the message:
 
 ```json
 {
@@ -106,19 +105,19 @@ If the agent owner has enabled human-in-the-loop review, `/api/v1/send` (and `/r
 }
 ```
 
-The message is held until a human approves it via the dashboard, CLI, or magic link, or until `approval_expires_at` fires the configured expiration action. Do not retry the send — that would queue a duplicate. To learn the outcome, poll `GET /api/v1/messages/{id}` (status transitions to `sent`, `rejected`, or `expired`), or surface the situation to the calling user and stop.
+The message is held until a human approves it via the dashboard, CLI, or magic link, or until `approval_expires_at` fires the configured expiration action. Do not retry the send — that would queue a duplicate. To learn the outcome, poll `GET /v1/agents/{address}/messages/{id}` (status transitions to `sent`, `rejected`, or `expired`), or surface the situation to the calling user and stop.
 
 ### Errors
 
 | Status | Where | Meaning | What to do |
 | --- | --- | --- | --- |
-| `400` | `/send`, `/reply` | Missing `subject` or `body`; malformed recipient; CRLF in subject. | Fix the payload before retrying. |
+| `400` | send, reply | Missing `subject` or `body`; malformed recipient; CRLF in subject. | Fix the payload before retrying. |
 | `401` first use | any | Credential missing, malformed, revoked, or for a different environment. | Ask the user to confirm the value in their `E2A_API_KEY` / config is current and active in the dashboard. MCP clients should restart at discovery. |
 | `401` on previously-working credential | any | Revoked or rotated. | Drop the cached value. API-key consumers re-read from the same source you loaded it from. MCP clients refresh, then re-run the authorization-code flow if refresh fails. |
-| `403` | `/send`, `/reply` | Agent's sending domain is not verified. | Ask the user to register and verify the domain in the dashboard (`POST /api/v1/domains` then `POST /api/v1/domains/{domain}/verify`). |
-| `409` | `/send`, `/reply`, `/messages/{id}/approve` | An in-flight request with this `Idempotency-Key` is still being processed, or the message is no longer in the expected state. | Wait and re-poll `GET /api/v1/messages/{id}`. |
-| `422` | `/send`, `/reply` | `Idempotency-Key` reused with a different body. | Mint a fresh key for the new payload. |
-| `429` | any | Rate limited (60 sends/agent/minute on `/send`; 200 agent registrations/IP/hour on `/agents`). | Back off; honor `Retry-After` (delay-seconds form). |
+| `403` | send, reply | Agent's sending domain is not verified. | Ask the user to register and verify the domain in the dashboard (`POST /v1/domains` then `POST /v1/domains/{domain}/verify`). |
+| `409` | send, reply, approve | An in-flight request with this `Idempotency-Key` is still being processed, or the message is no longer in the expected state. | Wait and re-poll `GET /v1/agents/{address}/messages/{id}`. |
+| `422` | send, reply | `Idempotency-Key` reused with a different body. | Mint a fresh key for the new payload. |
+| `429` | any | Rate limited (60 sends/agent/minute; 200 agent registrations/IP/hour on `/v1/agents`). | Back off; honor `Retry-After` (delay-seconds form). |
 
 The `WWW-Authenticate` header on 401 responses tells you whether the failing credential was an OAuth token (carries RFC 6750 §3.1 `error="invalid_token"` params) or an API key (bare `Bearer realm="e2a"`). MCP clients should branch on this.
 
@@ -160,7 +159,7 @@ No code reading, no copy-paste, no transcript leakage. This is uniquely possible
 What e2a publishes today:
 
 - **RFC 8414 authorization-server metadata** at [`https://e2a.dev/.well-known/oauth-authorization-server`](https://e2a.dev/.well-known/oauth-authorization-server) — advertises `authorization_endpoint`, `token_endpoint`, `registration_endpoint`, `revocation_endpoint`, supported grants (`authorization_code`, `refresh_token`), PKCE (`S256`), scopes (`agent`, `account`), and the RFC 9207 `iss` parameter.
-- **RFC 6750 Bearer challenges** on every 401 from `/api/v1/...` — `WWW-Authenticate: Bearer realm="e2a"` for unknown/missing credentials, plus RFC 6750 §3.1 error params for OAuth-bearer failures.
+- **RFC 6750 Bearer challenges** on every 401 from `/v1/...` — `WWW-Authenticate: Bearer realm="e2a"` for unknown/missing credentials, plus RFC 6750 §3.1 error params for OAuth-bearer failures.
 
 What's missing for full auth.md compliance:
 

--- a/web/public/openapi.yaml
+++ b/web/public/openapi.yaml
@@ -1,3307 +1,3092 @@
-basePath: /
-definitions:
-  APIKeyExportEntry:
-    properties:
-      created_at:
-        type: string
-      id:
-        type: string
-      key_prefix:
-        type: string
-      last_used_at:
-        type: string
-      name:
-        type: string
-      revoked_at:
-        type: string
-    type: object
-  Agent:
-    properties:
-      agent_mode:
-        enum:
-        - cloud
-        - local
-        example: cloud
-        type: string
-      created_at:
-        type: string
-      domain:
-        example: agents.example.com
-        type: string
-      domain_verified:
-        type: boolean
-      email:
-        example: my-bot@example.com
-        type: string
-      hitl_enabled:
-        type: boolean
-      hitl_expiration_action:
-        enum:
-        - approve
-        - reject
-        example: reject
-        type: string
-      hitl_ttl_seconds:
-        example: 604800
-        type: integer
-      id:
-        example: ag_abc123
-        type: string
-      name:
-        example: My Bot
-        type: string
-      webhook_url:
-        type: string
-    type: object
-  ApprovePendingMessageRequest:
-    properties:
-      attachments:
-        items:
-          $ref: '#/definitions/internal_agent.Attachment'
-        type: array
-      bcc:
-        items:
+components:
+  schemas:
+    APIKeyExportEntry:
+      additionalProperties: false
+      properties:
+        created_at:
+          format: date-time
           type: string
-        type: array
-      body_html:
-        type: string
-      body_text:
-        type: string
-      cc:
-        items:
+        id:
           type: string
-        type: array
-      subject:
-        type: string
-      to:
-        items:
+        key_prefix:
           type: string
-        type: array
-    type: object
-  ApprovePendingMessageResponse:
-    properties:
-      edited:
-        type: boolean
-      message_id:
-        type: string
-      method:
-        example: smtp
-        type: string
-      provider_message_id:
-        type: string
-      status:
-        example: sent
-        type: string
-    type: object
-  ConversationDetail:
-    properties:
-      conversation_id:
-        example: conv_abc123
-        type: string
-      first_message_at:
-        example: "2026-05-20T10:00:00Z"
-        type: string
-      has_unread:
-        description: |-
-          HasUnread is true iff at least one INBOUND member of this
-          conversation is in inbox_status='unread'. Outbound rows do
-          NOT contribute — a thread containing only your sent messages
-          (or only HITL-pending outbound) returns false. This is the
-          agent's mailbox view, not the reviewer's HITL queue.
-        example: true
-        type: boolean
-      inbound_count:
-        example: 2
-        type: integer
-      labels:
-        items:
+        last_used_at:
+          format: date-time
           type: string
-        type: array
-      last_message_at:
-        example: "2026-05-28T12:00:00Z"
-        type: string
-      latest_sender:
-        example: alice@example.com
-        type: string
-      latest_subject:
-        example: 'Re: Quarterly report'
-        type: string
-      message_count:
-        example: 4
-        type: integer
-      messages:
-        items:
-          $ref: '#/definitions/MessageSummary'
-        type: array
-      outbound_count:
-        example: 2
-        type: integer
-      participants:
-        items:
+        name:
           type: string
-        type: array
-    type: object
-  ConversationSummary:
-    properties:
-      conversation_id:
-        example: conv_abc123
-        type: string
-      first_message_at:
-        example: "2026-05-20T10:00:00Z"
-        type: string
-      has_unread:
-        description: |-
-          HasUnread is true iff at least one INBOUND member of this
-          conversation is in inbox_status='unread'. Outbound rows do
-          NOT contribute — a thread containing only your sent messages
-          (or only HITL-pending outbound) returns false. This is the
-          agent's mailbox view, not the reviewer's HITL queue.
-        example: true
-        type: boolean
-      inbound_count:
-        example: 2
-        type: integer
-      last_message_at:
-        example: "2026-05-28T12:00:00Z"
-        type: string
-      latest_sender:
-        example: alice@example.com
-        type: string
-      latest_subject:
-        example: 'Re: Quarterly report'
-        type: string
-      message_count:
-        example: 4
-        type: integer
-      outbound_count:
-        example: 2
-        type: integer
-    type: object
-  CreateSigningSecretResponse:
-    properties:
-      created_at:
-        type: string
-      id:
-        type: string
-      name:
-        type: string
-      secret:
-        type: string
-      secret_prefix:
-        type: string
-    type: object
-  CreateWebhookRequest:
-    properties:
-      description:
-        example: main inbox handler
-        type: string
-      events:
-        example:
-        - email.received
-        items:
+        revoked_at:
+          format: date-time
           type: string
-        type: array
-      filters:
-        $ref: '#/definitions/WebhookFilters'
-      url:
-        example: https://example.com/e2a/hook
-        type: string
-    type: object
-  DNSRecord:
-    properties:
-      host:
-        example: '@'
-        type: string
-      priority:
-        example: 10
-        type: integer
-      value:
-        example: mx.example.com
-        type: string
-    type: object
-  DNSRecords:
-    properties:
-      dkim:
-        $ref: '#/definitions/DNSRecord'
-      mx:
-        $ref: '#/definitions/DNSRecord'
-      txt:
-        $ref: '#/definitions/DNSRecord'
-    type: object
-  DeleteUserDataResult:
-    properties:
-      agents_deleted:
-        type: integer
-      api_keys_deleted:
-        type: integer
-      domains_deleted:
-        type: integer
-      messages_deleted:
-        type: integer
-      oauth_access_tokens_deleted:
-        type: integer
-      oauth_auth_codes_deleted:
-        type: integer
-      oauth_refresh_tokens_deleted:
-        type: integer
-      sessions_deleted:
-        type: integer
-      usage_events_deleted:
-        type: integer
-      usage_summaries_deleted:
-        type: integer
-      user_deleted:
-        type: boolean
-    type: object
-  DeliveryStatus:
-    properties:
-      delivered:
-        type: integer
-      failed:
-        type: integer
-      matched_webhooks:
-        type: integer
-      pending:
-        type: integer
-    type: object
-  DeploymentInfo:
-    properties:
-      public_url:
-        description: |-
-          PublicURL is the externally visible base URL of the API itself —
-          the same value the operator sets in `http.public_url`. Empty when
-          not configured.
-        example: https://e2a.example.com
-        type: string
-      shared_domain:
-        description: |-
-          SharedDomain is the mail domain backing slug-based agent registration
-          on this deployment (e.g. "agents.example.com"). Empty when the
-          operator hasn't configured one — in that case slug registration is
-          disabled and every agent must use a custom domain.
-        example: agents.example.com
-        type: string
-      slug_registration_enabled:
-        description: |-
-          SlugRegistrationEnabled mirrors `shared_domain != ""` for clients
-          that prefer a boolean. Equivalent to checking SharedDomain directly.
-        example: true
-        type: boolean
-    type: object
-  Domain:
-    properties:
-      agent_count:
-        description: |-
-          AgentCount is populated by list endpoints. Single-domain endpoints
-          (register, verify) leave it zero — the count would require an
-          extra query that callers can derive from the agents list anyway.
-        type: integer
-      created_at:
-        type: string
-      dns_records:
-        $ref: '#/definitions/DNSRecords'
-      domain:
-        example: yourdomain.com
-        type: string
-      is_primary:
-        description: |-
-          IsPrimary marks the user's default domain — at most one per
-          user, enforced server-side via SetDomainPrimary. The redesign's
-          Domains list renders this as a "Primary" chip.
-        type: boolean
-      last_checked_at:
-        description: |-
-          LastCheckedAt is the timestamp of the most recent
-          /api/v1/domains/{domain}/verify probe (success or failure).
-          Distinct from VerifiedAt, which only updates on success.
-        type: string
-      verification_token:
-        example: e2a-verify=abc123
-        type: string
-      verified:
-        type: boolean
-      verified_at:
-        type: string
-    type: object
-  ForwardMessageRequest:
-    properties:
-      attachments:
-        items:
-          $ref: '#/definitions/internal_agent.Attachment'
-        type: array
-      bcc:
-        example:
-        - carol@example.com
-        items:
+      required:
+        - id
+        - name
+        - key_prefix
+        - created_at
+      type: object
+    AgentIdentity:
+      additionalProperties: false
+      properties:
+        created_at:
+          format: date-time
           type: string
-        type: array
-      body:
-        example: FYI — see below
-        type: string
-      cc:
-        example:
-        - bob@example.com
-        items:
+        domain:
           type: string
-        type: array
-      conversation_id:
-        type: string
-      html_body:
-        example: <p>FYI — see below</p>
-        type: string
-      to:
-        example:
-        - alice@example.com
-        items:
+        domain_verified:
+          type: boolean
+        email:
           type: string
-        type: array
-    type: object
-  LimitsCaps:
-    properties:
-      max_agents:
-        type: integer
-      max_domains:
-        type: integer
-      max_messages_month:
-        type: integer
-      max_storage_bytes:
-        type: integer
-    type: object
-  LimitsInfo:
-    properties:
-      limits:
-        $ref: '#/definitions/LimitsCaps'
-      plan_code:
-        type: string
-      upgrade_url:
-        type: string
-      usage:
-        $ref: '#/definitions/LimitsUsage'
-    type: object
-  LimitsUsage:
-    properties:
-      agents:
-        type: integer
-      domains:
-        type: integer
-      messages_month:
-        type: integer
-      storage_bytes:
-        type: integer
-    type: object
-  ListAgentsResponse:
-    properties:
-      agents:
-        items:
-          $ref: '#/definitions/Agent'
-        type: array
-    type: object
-  ListConversationsResponse:
-    properties:
-      conversations:
-        items:
-          $ref: '#/definitions/ConversationSummary'
-        type: array
-    type: object
-  ListDomainsResponse:
-    properties:
-      domains:
-        items:
-          $ref: '#/definitions/Domain'
-        type: array
-    type: object
-  ListEventsResponse:
-    properties:
-      events:
-        items:
-          $ref: '#/definitions/WebhookEvent'
-        type: array
-      next_token:
-        type: string
-    type: object
-  ListMessagesResponse:
-    properties:
-      messages:
-        items:
-          $ref: '#/definitions/MessageSummary'
-        type: array
-      next_token:
-        type: string
-    type: object
-  ListPendingMessagesResponse:
-    properties:
-      messages:
-        items:
-          $ref: '#/definitions/PendingMessageSummary'
-        type: array
-    type: object
-  ListSigningSecretsResponse:
-    properties:
-      secrets:
-        items:
-          $ref: '#/definitions/SigningSecretSummary'
-        type: array
-    type: object
-  ListWebhookDeliveriesResponse:
-    properties:
-      deliveries:
-        items:
-          $ref: '#/definitions/WebhookDeliveryResponse'
-        type: array
-    type: object
-  ListWebhooksResponse:
-    properties:
-      webhooks:
-        items:
-          $ref: '#/definitions/WebhookResponse'
-        type: array
-    type: object
-  MessageDetail:
-    properties:
-      auth_headers:
-        additionalProperties:
+        hitl_enabled:
+          type: boolean
+        hitl_expiration_action:
           type: string
-        type: object
-      cc:
-        items:
+        hitl_mode:
           type: string
-        type: array
-      conversation_id:
-        type: string
-      created_at:
-        type: string
-      from:
-        example: alice@example.com
-        type: string
-      labels:
-        description: |-
-          Labels are caller-applied string tags. See MessageSummary.Labels
-          for the validation rules. Empty array when no labels are set —
-          never null.
-        items:
+        hitl_ttl_seconds:
+          format: int64
+          type: integer
+        id:
           type: string
-        type: array
-      message_id:
-        example: msg_abc123
-        type: string
-      raw_message:
-        type: string
-      recipient:
-        example: my-bot@example.com
-        type: string
-      reply_to:
-        items:
+        inbound_7d:
+          format: int64
+          type: integer
+        inbound_allowlist:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        inbound_policy:
           type: string
-        type: array
-      status:
-        example: read
-        type: string
-      subject:
-        example: Hello
-        type: string
-      to:
-        example:
-        - my-bot@example.com
-        items:
+        last_delivery_at:
+          format: date-time
           type: string
-        type: array
-    type: object
-  MessageSummary:
-    properties:
-      cc:
-        items:
+        name:
           type: string
-        type: array
-      conversation_id:
-        type: string
-      created_at:
-        example: "2025-01-15T10:30:00Z"
-        type: string
-      direction:
-        enum:
-        - inbound
-        - outbound
-        example: inbound
-        type: string
-      from:
-        example: alice@example.com
-        type: string
-      hitl_status:
-        enum:
-        - pending_approval
-        - sent
-        - rejected
-        - expired_approved
-        - expired_rejected
-        example: sent
-        type: string
-      labels:
-        description: |-
-          Labels are caller-applied string tags. Always lowercase, charset
-          `[a-z0-9:_-]+`, ≤ 64 chars each, ≤ 100 per message. The `e2a:`
-          prefix is reserved for server-applied system labels. Empty array
-          when no labels are set — never null.
-        items:
+        outbound_7d:
+          format: int64
+          type: integer
+        pending_count:
+          format: int64
+          type: integer
+        public:
+          type: boolean
+        user_id:
           type: string
-        type: array
-      message_id:
-        example: msg_abc123
-        type: string
-      recipient:
-        example: my-bot@example.com
-        type: string
-      reply_to:
-        items:
+        webhook_healthy:
+          type: boolean
+      required:
+        - id
+        - domain
+        - email
+        - name
+        - domain_verified
+        - public
+        - created_at
+        - user_id
+        - hitl_enabled
+        - hitl_ttl_seconds
+        - hitl_expiration_action
+        - hitl_mode
+        - inbound_7d
+        - outbound_7d
+        - pending_count
+        - webhook_healthy
+        - inbound_policy
+      type: object
+    AgentView:
+      additionalProperties: false
+      properties:
+        created_at:
+          format: date-time
           type: string
-        type: array
-      size_bytes:
-        example: 4231
-        type: integer
-      status:
-        description: |-
-          Status carries the inbound inbox_status value (`unread` | `read`).
-          Empty string for outbound rows — clients filtering on Status must
-          gate on `Direction == "inbound"` first. The enum was removed from
-          the swag annotation deliberately so SDK generators don't emit a
-          `Literal["unread", "read"]` that breaks at runtime.
-        type: string
-      subject:
-        example: Hello
-        type: string
-      to:
-        example:
-        - my-bot@example.com
-        items:
+        domain:
           type: string
-        type: array
-      webhook_error:
-        type: string
-      webhook_status:
-        enum:
-        - pending
+        domain_verified:
+          type: boolean
+        email:
+          type: string
+        hitl_enabled:
+          type: boolean
+        hitl_expiration_action:
+          enum:
+            - approve
+            - reject
+          type: string
+        hitl_mode:
+          enum:
+            - all
+            - high_impact
+          type: string
+        hitl_ttl_seconds:
+          format: int64
+          type: integer
+        id:
+          type: string
+        inbound_allowlist:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        inbound_policy:
+          enum:
+            - open
+            - allowlist
+            - domain
+            - verified_only
+          type: string
+        name:
+          type: string
+      required:
+        - id
+        - domain
+        - email
+        - name
+        - domain_verified
+        - created_at
+        - hitl_enabled
+        - hitl_ttl_seconds
+        - hitl_expiration_action
+        - hitl_mode
+        - inbound_policy
+      type: object
+    ApproveRequest:
+      additionalProperties: false
+      properties:
+        attachments:
+          items:
+            $ref: "#/components/schemas/Attachment"
+          type: array
+        bcc:
+          items:
+            type: string
+          type: array
+        body_html:
+          type: string
+        body_text:
+          type: string
+        cc:
+          items:
+            type: string
+          type: array
+        subject:
+          type: string
+        to:
+          items:
+            type: string
+          type: array
+      type: object
+    ApproveResultView:
+      additionalProperties: false
+      properties:
+        edited:
+          type: boolean
+        message_id:
+          type: string
+        method:
+          type: string
+        provider_message_id:
+          type: string
+        status:
+          type: string
+      required:
+        - status
+        - message_id
+        - edited
+      type: object
+    Attachment:
+      additionalProperties: false
+      properties:
+        content_type:
+          examples:
+            - application/pdf
+          type: string
+        data:
+          examples:
+            - base64-encoded-content
+          type: string
+        filename:
+          examples:
+            - report.pdf
+          type: string
+      required:
+        - filename
+        - content_type
+        - data
+      type: object
+    CheckResult:
+      additionalProperties: false
+      properties:
+        detail:
+          type: string
+        status:
+          type: string
+      required:
+        - status
+      type: object
+    ConversationDetailView:
+      additionalProperties: false
+      properties:
+        conversation_id:
+          type: string
+        first_message_at:
+          type: string
+        has_unread:
+          type: boolean
+        inbound_count:
+          format: int64
+          type: integer
+        labels:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        last_message_at:
+          type: string
+        latest_sender:
+          type: string
+        latest_subject:
+          type: string
+        message_count:
+          format: int64
+          type: integer
+        messages:
+          items:
+            $ref: "#/components/schemas/MessageSummaryView"
+          type:
+            - array
+            - "null"
+        outbound_count:
+          format: int64
+          type: integer
+        participants:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+      required:
+        - participants
+        - labels
+        - messages
+        - conversation_id
+        - last_message_at
+        - first_message_at
+        - message_count
+        - inbound_count
+        - outbound_count
+        - has_unread
+        - latest_subject
+        - latest_sender
+      type: object
+    ConversationSummaryView:
+      additionalProperties: false
+      properties:
+        conversation_id:
+          type: string
+        first_message_at:
+          type: string
+        has_unread:
+          type: boolean
+        inbound_count:
+          format: int64
+          type: integer
+        last_message_at:
+          type: string
+        latest_sender:
+          type: string
+        latest_subject:
+          type: string
+        message_count:
+          format: int64
+          type: integer
+        outbound_count:
+          format: int64
+          type: integer
+      required:
+        - conversation_id
+        - last_message_at
+        - first_message_at
+        - message_count
+        - inbound_count
+        - outbound_count
+        - has_unread
+        - latest_subject
+        - latest_sender
+      type: object
+    CreateAgentRequest:
+      additionalProperties: false
+      properties:
+        email:
+          type: string
+        name:
+          type: string
+        slug:
+          type: string
+      type: object
+    CreateAgentResponse:
+      additionalProperties: false
+      properties:
+        domain:
+          type: string
+        email:
+          type: string
+        id:
+          type: string
+      required:
+        - id
+        - domain
+        - email
+      type: object
+    CreateWebhookRequest:
+      additionalProperties: false
+      properties:
+        description:
+          type: string
+        events:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        filters:
+          $ref: "#/components/schemas/WebhookFiltersView"
+        url:
+          type: string
+      type: object
+    DNSRecordView:
+      additionalProperties: false
+      properties:
+        host:
+          type: string
+        priority:
+          format: int64
+          type: integer
+        value:
+          type: string
+      required:
+        - host
+        - value
+      type: object
+    DNSRecordsView:
+      additionalProperties: false
+      properties:
+        dkim:
+          $ref: "#/components/schemas/DNSRecordView"
+        mx:
+          $ref: "#/components/schemas/DNSRecordView"
+        txt:
+          $ref: "#/components/schemas/DNSRecordView"
+      required:
+        - mx
+        - txt
+      type: object
+    DeleteAgentOutputBody:
+      additionalProperties: false
+      properties:
+        status:
+          type: string
+      required:
+        - status
+      type: object
+    DeleteUserDataResult:
+      additionalProperties: false
+      properties:
+        agents_deleted:
+          format: int64
+          type: integer
+        api_keys_deleted:
+          format: int64
+          type: integer
+        domains_deleted:
+          format: int64
+          type: integer
+        messages_deleted:
+          format: int64
+          type: integer
+        oauth_access_tokens_deleted:
+          format: int64
+          type: integer
+        oauth_auth_codes_deleted:
+          format: int64
+          type: integer
+        oauth_refresh_tokens_deleted:
+          format: int64
+          type: integer
+        sessions_deleted:
+          format: int64
+          type: integer
+        usage_events_deleted:
+          format: int64
+          type: integer
+        usage_summaries_deleted:
+          format: int64
+          type: integer
+        user_deleted:
+          type: boolean
+      required:
+        - usage_events_deleted
+        - usage_summaries_deleted
+        - messages_deleted
+        - agents_deleted
+        - domains_deleted
+        - api_keys_deleted
+        - sessions_deleted
+        - user_deleted
+      type: object
+    DeliveryStatusJSON:
+      additionalProperties: false
+      properties:
+        delivered:
+          format: int64
+          type: integer
+        failed:
+          format: int64
+          type: integer
+        matched_webhooks:
+          format: int64
+          type: integer
+        pending:
+          format: int64
+          type: integer
+      required:
+        - matched_webhooks
         - delivered
+        - pending
         - failed
-        example: delivered
-        type: string
-    type: object
-  OAuthConnectionEntry:
-    properties:
-      agent_email:
-        type: string
-      client_id:
-        type: string
-      client_name:
-        type: string
-      expires_at:
-        type: string
-      issued_at:
-        type: string
-      revoked_at:
-        type: string
-      scope:
-        type: string
-    type: object
-  PendingMessageDetail:
-    properties:
-      agent_id:
-        example: my-bot@example.com
-        type: string
-      approval_expires_at:
-        example: "2025-01-15T10:30:00Z"
-        type: string
-      attachments:
-        items:
-          $ref: '#/definitions/internal_agent.Attachment'
-        type: array
-      bcc:
-        items:
+      type: object
+    DeploymentInfoView:
+      additionalProperties: false
+      properties:
+        public_url:
           type: string
-        type: array
-      body_html:
-        type: string
-      body_text:
-        type: string
-      cc:
-        items:
+        shared_domain:
           type: string
-        type: array
-      conversation_id:
-        type: string
-      created_at:
-        type: string
-      direction:
-        example: outbound
-        type: string
-      edited:
-        type: boolean
-      email_message_id:
-        example: <orig@gmail.com>
-        type: string
-      id:
-        example: msg_abc123
-        type: string
-      inbound:
-        allOf:
-        - $ref: '#/definitions/PendingMessageInboundContext'
-        description: |-
-          InboundContext is attached when this is a reply — provides the
-          SPF/DKIM/DMARC provenance + sender/subject of the inbound message
-          being replied to so the review panel can render the context pane.
-      method:
-        example: smtp
-        type: string
-      provider_message_id:
-        type: string
-      rejection_reason:
-        type: string
-      reviewed_at:
-        example: "2025-01-15T10:35:00Z"
-        type: string
-      reviewed_by_name:
-        description: |-
-          ReviewedByName is the JOIN'd display name from the reviewer's
-          users row. NULL when reviewed_by_user_id is null (worker) or when
-          the reviewer's user account has since been deleted (the FK has
-          ON DELETE SET NULL specifically so this doesn't poison the audit
-          trail).
-        example: Jamie
-        type: string
-      reviewed_by_user_id:
-        description: |-
-          ReviewedByUserID identifies the human reviewer for approved or
-          rejected messages. NULL on TTL-expired transitions (worker
-          auto-approve / auto-reject) where no human reviewed the message.
-        example: usr_abc123
-        type: string
-      status:
-        enum:
-        - sent
-        - pending_approval
-        - rejected
-        - expired_approved
-        - expired_rejected
-        example: pending_approval
-        type: string
-      subject:
-        example: 'Re: contract details'
-        type: string
-      to:
-        example:
-        - alice@example.com
-        items:
-          type: string
-        type: array
-      type:
-        enum:
-        - send
-        - reply
-        - test
-        - forward
-        example: send
-        type: string
-    type: object
-  PendingMessageInboundContext:
-    properties:
-      auth_headers:
-        additionalProperties:
-          type: string
-        description: |-
-          AuthHeaders carries the SPF/DKIM/DMARC validation results captured
-          at inbound time. Keys are conventionally "spf", "dkim", "dmarc"
-          each with values "pass" | "fail" | "neutral" | etc. The dashboard
-          renders these as found/missing chips on the provenance pane.
-        type: object
-      created_at:
-        example: "2025-01-15T10:25:00Z"
-        type: string
-      sender:
-        example: alice@gmail.com
-        type: string
-      subject:
-        example: contract details
-        type: string
-    type: object
-  PendingMessageSummary:
-    properties:
-      agent_id:
-        example: my-bot@example.com
-        type: string
-      approval_expires_at:
-        example: "2025-01-15T10:30:00Z"
-        type: string
-      bcc:
-        items:
-          type: string
-        type: array
-      cc:
-        items:
-          type: string
-        type: array
-      conversation_id:
-        type: string
-      created_at:
-        type: string
-      direction:
-        example: outbound
-        type: string
-      id:
-        example: msg_abc123
-        type: string
-      status:
-        enum:
-        - sent
-        - pending_approval
-        - rejected
-        - expired_approved
-        - expired_rejected
-        example: pending_approval
-        type: string
-      subject:
-        example: 'Re: contract details'
-        type: string
-      to:
-        example:
-        - alice@example.com
-        items:
-          type: string
-        type: array
-      type:
-        enum:
-        - send
-        - reply
-        - test
-        - forward
-        example: send
-        type: string
-    type: object
-  RedeliverDeliveryResult:
-    properties:
-      delivery_id:
-        type: string
-      reason:
-        type: string
-      status:
-        type: string
-      webhook_id:
-        type: string
-    type: object
-  RedeliverRequest:
-    properties:
-      webhook_id:
-        type: string
-    type: object
-  RedeliverResponse:
-    properties:
-      deliveries:
-        items:
-          $ref: '#/definitions/RedeliverDeliveryResult'
-        type: array
-      delivery_id:
-        type: string
-      event_id:
-        type: string
-      status:
-        type: string
-      webhook_id:
-        type: string
-    type: object
-  RedeliverSinceRequest:
-    properties:
-      since:
-        type: string
-    type: object
-  RedeliverSinceResponse:
-    properties:
-      scheduled:
-        type: integer
-      since:
-        type: string
-      skipped_already_pending:
-        type: integer
-      webhook_id:
-        type: string
-    type: object
-  RegisterAgentRequest:
-    properties:
-      agent_mode:
-        description: AgentMode selects how inbound mail is delivered. Required; must
-          be "local" or "cloud". See the type-level docs for the difference.
-        enum:
-        - local
-        - cloud
-        example: local
-        type: string
-      email:
-        example: my-bot@yourdomain.com
-        type: string
-      name:
-        example: My Bot
-        type: string
-      slug:
-        example: my-bot
-        type: string
-      webhook_url:
-        example: https://example.com/e2a/webhook
-        type: string
-    required:
-    - agent_mode
-    type: object
-  RegisterAgentResponse:
-    properties:
-      domain:
-        type: string
-      email:
-        type: string
-      id:
-        type: string
-    type: object
-  RegisterDomainRequest:
-    properties:
-      domain:
-        example: yourdomain.com
-        type: string
-    type: object
-  RejectPendingMessageRequest:
-    properties:
-      reason:
-        example: wrong recipient
-        type: string
-    type: object
-  RejectPendingMessageResponse:
-    properties:
-      message_id:
-        type: string
-      rejection_reason:
-        type: string
-      status:
-        example: rejected
-        type: string
-    type: object
-  ReplyToMessageRequest:
-    properties:
-      attachments:
-        items:
-          $ref: '#/definitions/internal_agent.Attachment'
-        type: array
-      bcc:
-        example:
-        - carol@example.com
-        items:
-          type: string
-        type: array
-      body:
-        example: Thanks for your email!
-        type: string
-      cc:
-        example:
-        - bob@example.com
-        items:
-          type: string
-        type: array
-      conversation_id:
-        type: string
-      html_body:
-        example: <p>Thanks for your email!</p>
-        type: string
-      reply_all:
-        example: false
-        type: boolean
-    type: object
-  RotateWebhookSecretResponse:
-    properties:
-      previous_secret_expires_at:
-        type: string
-      signing_secret:
-        type: string
-    type: object
-  SendEmailRequest:
-    properties:
-      attachments:
-        items:
-          $ref: '#/definitions/internal_agent.Attachment'
-        type: array
-      bcc:
-        example:
-        - carol@example.com
-        items:
-          type: string
-        type: array
-      body:
-        example: Hi Alice, this is my agent reaching out.
-        type: string
-      cc:
-        example:
-        - bob@example.com
-        items:
-          type: string
-        type: array
-      conversation_id:
-        example: conv_abc123
-        type: string
-      from:
-        example: my-bot@example.com
-        type: string
-      html_body:
-        example: <p>Hi Alice</p>
-        type: string
-      subject:
-        example: Hello from my agent
-        type: string
-      to:
-        example:
-        - alice@example.com
-        items:
-          type: string
-        type: array
-    type: object
-  SendEmailResponse:
-    properties:
-      approval_expires_at:
-        example: "2025-01-15T10:30:00Z"
-        type: string
-      message_id:
-        example: msg_abc123
-        type: string
-      method:
-        example: smtp
-        type: string
-      status:
-        enum:
-        - sent
-        - pending_approval
-        example: sent
-        type: string
-    type: object
-  SigningSecretSummary:
-    properties:
-      created_at:
-        type: string
-      id:
-        type: string
-      last_signed_at:
-        type: string
-      name:
-        type: string
-      secret:
-        type: string
-      secret_prefix:
-        type: string
-    type: object
-  TestWebhookRequest:
-    properties:
-      data:
-        additionalProperties: true
-        type: object
-      event:
-        example: email.received
-        type: string
-    type: object
-  TestWebhookResponse:
-    properties:
-      delivery_id:
-        type: string
-    type: object
-  UpdateAgentRequest:
-    properties:
-      agent_mode:
-        enum:
-        - cloud
-        - local
-        type: string
-      hitl_enabled:
-        type: boolean
-      hitl_expiration_action:
-        enum:
-        - approve
-        - reject
-        type: string
-      hitl_ttl_seconds:
-        example: 604800
-        type: integer
-      webhook_url:
-        type: string
-    type: object
-  UpdateDomainRequest:
-    properties:
-      is_primary:
-        type: boolean
-    type: object
-  UpdateMessageRequest:
-    properties:
-      add_labels:
-        example:
-        - urgent
-        items:
-          type: string
-        type: array
-      remove_labels:
-        example:
-        - unread
-        items:
-          type: string
-        type: array
-    type: object
-  UpdateMessageResponse:
-    properties:
-      labels:
-        items:
-          type: string
-        type: array
-      message_id:
-        example: msg_abc123
-        type: string
-    type: object
-  UpdateWebhookRequest:
-    properties:
-      description:
-        type: string
-      enabled:
-        type: boolean
-      events:
-        items:
-          type: string
-        type: array
-      filters:
-        $ref: '#/definitions/WebhookFilters'
-      url:
-        type: string
-    type: object
-  UsageEventEntry:
-    properties:
-      agent_id:
-        type: string
-      created_at:
-        type: string
-      direction:
-        type: string
-      domain:
-        type: string
-      event_type:
-        type: string
-      id:
-        type: string
-    type: object
-  UserExport:
-    properties:
-      agents:
-        items:
-          $ref: '#/definitions/github_com_Mnexa-AI_e2a_internal_identity.AgentIdentity'
-        type: array
-      api_keys:
-        items:
-          $ref: '#/definitions/APIKeyExportEntry'
-        type: array
-      domains:
-        items:
-          $ref: '#/definitions/github_com_Mnexa-AI_e2a_internal_identity.Domain'
-        type: array
-      generated_at:
-        type: string
-      messages:
-        items:
-          $ref: '#/definitions/github_com_Mnexa-AI_e2a_internal_identity.Message'
-        type: array
-      oauth_connections:
-        items:
-          $ref: '#/definitions/OAuthConnectionEntry'
-        type: array
-      schema_version:
-        type: string
-      usage_events:
-        items:
-          $ref: '#/definitions/UsageEventEntry'
-        type: array
-      user:
-        $ref: '#/definitions/UserExportUser'
-    type: object
-  UserExportUser:
-    properties:
-      created_at:
-        type: string
-      email:
-        type: string
-      id:
-        type: string
-      name:
-        type: string
-    type: object
-  VerifyDomainResponse:
-    properties:
-      dkim:
-        description: |-
-          DKIM status: "found" iff the published TXT record at
-          "{selector}._domainkey.{domain}" matches the per-domain public
-          key stored at registration time. "missing" iff a keypair is
-          stored but the TXT record isn't published yet. "deferred" iff
-          no keypair is stored — pre-migration rows that haven't been
-          re-claimed since #5 shipped. A fresh-claimed domain always has
-          a keypair, so "deferred" only appears on legacy data.
-        enum:
-        - found
-        - missing
-        - deferred
-        example: found
-        type: string
-      domain:
-        example: yourdomain.com
-        type: string
-      mx:
-        description: |-
-          MX status: "found" iff at least one MX record points at the
-          deployment's smtp domain. "missing" otherwise.
-        enum:
-        - found
-        - missing
-        example: found
-        type: string
-      spf:
-        description: |-
-          SPF status: "found" iff a v=spf1 TXT record includes the
-          deployment's send domain. "missing" otherwise.
-        enum:
-        - found
-        - missing
-        example: found
-        type: string
-      verified:
-        type: boolean
-      verified_at:
-        type: string
-    type: object
-  WebhookDeliveryResponse:
-    properties:
-      attempts:
-        type: integer
-      created_at:
-        type: string
-      event_type:
-        type: string
-      id:
-        type: string
-      last_attempt_at:
-        type: string
-      last_error:
-        type: string
-      last_status_code:
-        type: integer
-      next_retry_at:
-        type: string
-      status:
-        type: string
-    type: object
-  WebhookEvent:
-    properties:
-      agent_id:
-        type: string
-      conversation_id:
-        type: string
-      created_at:
-        type: string
-      data:
-        additionalProperties: true
-        type: object
-      delivery_status:
-        $ref: '#/definitions/DeliveryStatus'
-      id:
-        type: string
-      message_id:
-        type: string
-      schema_version:
-        type: integer
-      status:
-        type: string
-      type:
-        type: string
-    type: object
-  WebhookFilters:
-    properties:
-      agent_ids:
-        items:
-          type: string
-        type: array
-      conversation_ids:
-        items:
-          type: string
-        type: array
-      labels:
-        items:
-          type: string
-        type: array
-    type: object
-  WebhookResponse:
-    properties:
-      auto_disabled_at:
-        type: string
-      created_at:
-        type: string
-      description:
-        type: string
-      enabled:
-        type: boolean
-      events:
-        items:
-          type: string
-        type: array
-      filters:
-        $ref: '#/definitions/WebhookFilters'
-      id:
-        example: wh_abc123
-        type: string
-      last_delivered_at:
-        type: string
-      previous_secret_expires_at:
-        description: ONLY on rotate
-        type: string
-      signing_secret:
-        description: ONLY on create + rotate
-        type: string
-      url:
-        type: string
-    type: object
-  github_com_Mnexa-AI_e2a_internal_identity.AgentIdentity:
-    properties:
-      agent_mode:
-        type: string
-      created_at:
-        type: string
-      domain:
-        type: string
-      domain_verified:
-        type: boolean
-      email:
-        type: string
-      hitl_enabled:
-        type: boolean
-      hitl_expiration_action:
-        type: string
-      hitl_ttl_seconds:
-        type: integer
-      id:
-        type: string
-      inbound_7d:
-        description: |-
-          Dashboard enrichment fields. Computed at read
-          time by ListAgentsByUser via correlated subqueries — other load
-          paths (GetAgentByID / GetAgentByEmail) leave them at zero values,
-          same pattern as Domain.AgentCount. Switch to denormalized columns
-          if the read cost ever bites.
-        type: integer
-      last_delivery_at:
-        type: string
-      name:
-        type: string
-      outbound_7d:
-        type: integer
-      pending_count:
-        type: integer
-      public:
-        type: boolean
-      user_id:
-        type: string
-      webhook_healthy:
-        description: |-
-          WebhookHealthy is false iff there's been a failed webhook delivery
-          in the last 24h. Defaults to true for agents with no deliveries
-          yet — avoids painting fresh agents red. Meaningless for
-          agent_mode='local'; the frontend hides the badge in that case.
-        type: boolean
-      webhook_url:
-        type: string
-    type: object
-  github_com_Mnexa-AI_e2a_internal_identity.Domain:
-    properties:
-      agent_count:
-        description: |-
-          AgentCount is computed at read time by ListDomainsByUser and is
-          not a persisted column. Single-domain LookupDomain leaves it at
-          the zero value — callers that need the count call the list path
-          (this column-versus-aggregate split avoids changing every store
-          signature to thread an agent-counter through).
-        type: integer
-      created_at:
-        type: string
-      dkim_public_key:
-        type: string
-      dkim_selector:
-        description: |-
-          DKIM keypair fields. The selector + public key
-          are user-facing — the dashboard shows them so users can copy the
-          DNS TXT record. The private key is intentionally NOT in the JSON
-          shape; it's only read by the outbound signer via
-          GetDKIMKey(domain). Domains created before migration 014 ran
-          keep all three NULL until the next ClaimOrCreate or backfill.
-        type: string
-      domain:
-        type: string
-      is_primary:
-        description: |-
-          IsPrimary marks the user's default domain. At most one TRUE per
-          user (enforced by a partial unique index in migration 013).
-        type: boolean
-      last_checked_at:
-        description: |-
-          LastCheckedAt is updated whenever the verification probe runs,
-          successful or not. NULL until the first probe — distinct from
-          "probed and failed" which is captured by `verified=false` + a
-          non-null LastCheckedAt.
-        type: string
-      user_id:
-        type: string
-      verification_token:
-        type: string
-      verified:
-        type: boolean
-      verified_at:
-        type: string
-    type: object
-  github_com_Mnexa-AI_e2a_internal_identity.Message:
-    properties:
-      agent_id:
-        type: string
-      approval_expires_at:
-        type: string
-      attachments:
-        items:
+        slug_registration_enabled:
+          type: boolean
+      required:
+        - shared_domain
+        - slug_registration_enabled
+      type: object
+    Domain:
+      additionalProperties: false
+      properties:
+        agent_count:
+          format: int64
           type: integer
-        type: array
-      auth_headers:
-        additionalProperties:
+        created_at:
+          format: date-time
           type: string
-        type: object
-      bcc:
-        items:
+        dkim_public_key:
           type: string
-        type: array
-      body_html:
-        type: string
-      body_text:
-        type: string
-      cc:
-        items:
+        dkim_selector:
           type: string
-        type: array
-      conversation_id:
-        type: string
-      created_at:
-        type: string
-      delivery_status:
-        type: string
-      direction:
-        type: string
-      edited:
-        type: boolean
-      email_message_id:
-        type: string
-      expires_at:
-        type: string
-      id:
-        type: string
-      inbox_status:
-        description: |-
-          InboxStatus mirrors messages.inbox_status ('unread' | 'read') for
-          inbound rows. Kept separate from DeliveryStatus (which currently
-          carries the same value under a confusing JSON key — see line 161)
-          so the dashboard's inbox can read it under a non-overloaded key.
-          Empty on outbound rows. Populated by GetMessagesByAgent.
-        type: string
-      labels:
-        description: |-
-          Labels are user-applied string tags (`urgent`, `follow-up`, …).
-          Always lowercase, charset `[a-z0-9:_-]+`, ≤ 64 chars per label,
-          capped at 100 per message. Empty slice means no labels — the DB
-          default is `'{}'` so this is never null on read. Labels with the
-          `e2a:` prefix are reserved for server-applied system labels;
-          caller writes that try to set them are rejected at the API layer.
-        items:
+        domain:
           type: string
-        type: array
-      method:
-        type: string
-      provider_message_id:
-        type: string
-      raw_message:
-        items:
+        is_primary:
+          type: boolean
+        last_checked_at:
+          format: date-time
+          type: string
+        sending_error:
+          type: string
+        sending_last_checked_at:
+          format: date-time
+          type: string
+        sending_status:
+          type: string
+        user_id:
+          type: string
+        verification_token:
+          type: string
+        verified:
+          type: boolean
+        verified_at:
+          format: date-time
+          type: string
+      required:
+        - domain
+        - verified
+        - verification_token
+        - created_at
+        - is_primary
+        - agent_count
+        - sending_status
+      type: object
+    DomainView:
+      additionalProperties: false
+      properties:
+        agent_count:
+          format: int64
           type: integer
-        type: array
-      recipient:
-        type: string
-      rejection_reason:
-        type: string
-      reply_to:
-        description: |-
-          ReplyTo is the parsed Reply-To: header on inbound messages — empty
-          when the header was absent. Distinct from Sender so consumers can
-          recover the original From: of forwarded / notification mail whose
-          Reply-To points at a different mailbox. Outbound-irrelevant.
-        items:
+        created_at:
+          format: date-time
           type: string
-        type: array
-      reviewed_at:
-        type: string
-      reviewed_by_name:
-        description: |-
-          ReviewedByName is the JOIN'd display name from the reviewer's
-          users row, populated only by GetOutboundMessageForUser. List
-          endpoints leave this empty to avoid a join-per-row cost — the
-          pending-detail page is where reviewer attribution matters.
-        type: string
-      reviewed_by_user_id:
-        description: |-
-          ReviewedByUserID identifies the human reviewer who approved or
-          rejected this message. NULL on worker-triggered transitions
-          (TTL auto-approve / auto-reject) — operator-visible signal "no
-          human looked at this." Set by ApproveAndSend and RejectPending,
-          left null by ExpireApproveAndSend / ExpireReject.
-        type: string
-      sender:
-        type: string
-      size_bytes:
-        description: |-
-          SizeBytes is the byte length of raw_message. Populated by load paths
-          that compute it (e.g. GetMessagesByAgent for the dashboard inbox).
-          Zero on load paths that don't — the inbox renders "—" in that case.
-        type: integer
-      status:
-        description: |-
-          HITL approval fields. Status defaults to 'sent'; body and attachments
-          are populated only while a message is in 'pending_approval', and are
-          scrubbed on any terminal transition.
-        type: string
-      subject:
-        type: string
-      to_recipients:
-        description: |-
-          Multi-recipient fields. For outbound, these are the addressed
-          To/Cc/Bcc recipients of the send. For inbound, ToRecipients and CC
-          are the parsed To: and Cc: headers of the original message (the
-          per-delivery target for this row is in Recipient). BCC is
-          outbound-only.
-        items:
+        dns_records:
+          $ref: "#/components/schemas/DNSRecordsView"
+        domain:
           type: string
-        type: array
-      type:
-        type: string
-      webhook_attempts:
-        type: integer
-      webhook_error:
-        type: string
-      webhook_status:
-        type: string
-    type: object
-  internal_agent.Attachment:
-    properties:
-      content_type:
-        example: application/pdf
-        type: string
-      data:
-        description: base64-encoded
-        example: base64-encoded-content
-        type: string
-      filename:
-        example: report.pdf
-        type: string
-    type: object
-  internal_agent.CreateSigningSecretRequest:
-    properties:
-      name:
-        description: |-
-          Optional human-readable label so users can tell secrets apart in
-          the dashboard (e.g. "prod", "staging", "rollover-2026-04").
-        type: string
-    type: object
-host: localhost:8080
+        is_primary:
+          type: boolean
+        last_checked_at:
+          format: date-time
+          type: string
+        sending_dns_records:
+          items:
+            $ref: "#/components/schemas/SendingDNSRecordView"
+          type:
+            - array
+            - "null"
+        sending_error:
+          type: string
+        sending_last_checked_at:
+          format: date-time
+          type: string
+        sending_status:
+          type: string
+        verification_token:
+          type: string
+        verified:
+          type: boolean
+        verified_at:
+          format: date-time
+          type: string
+      required:
+        - domain
+        - verified
+        - verification_token
+        - dns_records
+        - created_at
+        - is_primary
+        - agent_count
+        - sending_status
+      type: object
+    ErrorBody:
+      additionalProperties: false
+      properties:
+        code:
+          type: string
+        details: {}
+        message:
+          type: string
+        request_id:
+          type: string
+      required:
+        - code
+        - message
+      type: object
+    ErrorEnvelope:
+      additionalProperties: false
+      properties:
+        error:
+          $ref: "#/components/schemas/ErrorBody"
+      required:
+        - error
+      type: object
+    EventJSON:
+      additionalProperties: false
+      properties:
+        agent_id:
+          type: string
+        conversation_id:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        data:
+          additionalProperties: {}
+          type: object
+        delivery_status:
+          $ref: "#/components/schemas/DeliveryStatusJSON"
+        id:
+          type: string
+        message_id:
+          type: string
+        schema_version:
+          format: int64
+          type: integer
+        status:
+          enum:
+            - pending
+            - processed
+            - no_match
+          type: string
+        type:
+          enum:
+            - email.received
+            - email.sent
+            - email.pending_approval
+            - email.approved
+            - email.rejected
+            - domain.sending_verified
+            - domain.sending_failed
+            - email.delivered
+            - email.bounced
+            - email.complained
+            - domain.suppression_added
+            - email.flagged
+          type: string
+      required:
+        - id
+        - type
+        - schema_version
+        - created_at
+        - status
+        - data
+      type: object
+    ForwardRequest:
+      additionalProperties: false
+      properties:
+        attachments:
+          items:
+            $ref: "#/components/schemas/Attachment"
+          type:
+            - array
+            - "null"
+        bcc:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        body:
+          type: string
+        cc:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        conversation_id:
+          type: string
+        html_body:
+          type: string
+        to:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+      type: object
+    LimitsCapsView:
+      additionalProperties: false
+      properties:
+        max_agents:
+          format: int64
+          type: integer
+        max_domains:
+          format: int64
+          type: integer
+        max_messages_month:
+          format: int64
+          type: integer
+        max_storage_bytes:
+          format: int64
+          type: integer
+      required:
+        - max_agents
+        - max_domains
+        - max_messages_month
+        - max_storage_bytes
+      type: object
+    LimitsUsageView:
+      additionalProperties: false
+      properties:
+        agents:
+          format: int64
+          type: integer
+        domains:
+          format: int64
+          type: integer
+        messages_month:
+          format: int64
+          type: integer
+        storage_bytes:
+          format: int64
+          type: integer
+      required:
+        - agents
+        - domains
+        - messages_month
+        - storage_bytes
+      type: object
+    LimitsView:
+      additionalProperties: false
+      properties:
+        limits:
+          $ref: "#/components/schemas/LimitsCapsView"
+        plan_code:
+          type: string
+        upgrade_url:
+          type: string
+        usage:
+          $ref: "#/components/schemas/LimitsUsageView"
+      required:
+        - plan_code
+        - limits
+        - usage
+        - upgrade_url
+      type: object
+    ListAgentsOutputBody:
+      additionalProperties: false
+      properties:
+        agents:
+          items:
+            $ref: "#/components/schemas/AgentView"
+          type: array
+      required:
+        - agents
+      type: object
+    ListDomainsOutputBody:
+      additionalProperties: false
+      properties:
+        domains:
+          items:
+            $ref: "#/components/schemas/DomainView"
+          type: array
+      required:
+        - domains
+      type: object
+    ListWebhooksOutputBody:
+      additionalProperties: false
+      properties:
+        webhooks:
+          items:
+            $ref: "#/components/schemas/WebhookView"
+          type: array
+      required:
+        - webhooks
+      type: object
+    Message:
+      additionalProperties: false
+      properties:
+        agent_id:
+          type: string
+        approval_expires_at:
+          format: date-time
+          type: string
+        attachments: {}
+        auth:
+          $ref: "#/components/schemas/Result"
+        auth_headers:
+          additionalProperties:
+            type: string
+          type: object
+        bcc:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        body_html:
+          type: string
+        body_text:
+          type: string
+        cc:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        conversation_id:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        delivery_detail:
+          type: string
+        delivery_status:
+          type: string
+        direction:
+          type: string
+        edited:
+          type: boolean
+        email_message_id:
+          type: string
+        expires_at:
+          format: date-time
+          type: string
+        flag_reason:
+          type: string
+        flagged:
+          type: boolean
+        id:
+          type: string
+        inbox_status:
+          type: string
+        labels:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        method:
+          type: string
+        provider_message_id:
+          type: string
+        raw_message:
+          contentEncoding: base64
+          type: string
+        recipient:
+          type: string
+        rejection_reason:
+          type: string
+        reply_to:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        reviewed_at:
+          format: date-time
+          type: string
+        reviewed_by_name:
+          type: string
+        reviewed_by_user_id:
+          type: string
+        sender:
+          type: string
+        sent_as:
+          type: string
+        size_bytes:
+          format: int64
+          type: integer
+        status:
+          type: string
+        subject:
+          type: string
+        to_recipients:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        type:
+          type: string
+        webhook_attempts:
+          format: int64
+          type: integer
+        webhook_error:
+          type: string
+        webhook_status:
+          type: string
+      required:
+        - id
+        - agent_id
+        - direction
+        - sender
+        - recipient
+        - subject
+        - created_at
+        - expires_at
+      type: object
+    MessageBodyView:
+      additionalProperties: false
+      properties:
+        html:
+          type: string
+        text:
+          type: string
+      type: object
+    MessageParsedView:
+      additionalProperties: false
+      properties:
+        text:
+          type: string
+        truncated:
+          type: boolean
+      required:
+        - text
+        - truncated
+      type: object
+    MessageSummaryView:
+      additionalProperties: false
+      properties:
+        auth:
+          $ref: "#/components/schemas/Result"
+        cc:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        conversation_id:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        delivery_detail:
+          type: string
+        delivery_status:
+          enum:
+            - queued
+            - sent
+            - delivered
+            - bounced
+            - complained
+            - deferred
+            - failed
+          type: string
+        direction:
+          enum:
+            - inbound
+            - outbound
+          type: string
+        flag_reason:
+          type: string
+        flagged:
+          type: boolean
+        from:
+          type: string
+        hitl_status:
+          enum:
+            - pending_approval
+            - sent
+            - rejected
+            - expired_approved
+            - expired_rejected
+          type: string
+        labels:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        message_id:
+          type: string
+        recipient:
+          type: string
+        reply_to:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        sent_as:
+          enum:
+            - own_address
+            - relay
+          type: string
+        size_bytes:
+          format: int64
+          type: integer
+        status:
+          type: string
+        subject:
+          type: string
+        to:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        webhook_error:
+          type: string
+        webhook_status:
+          type: string
+      required:
+        - message_id
+        - direction
+        - from
+        - to
+        - recipient
+        - subject
+        - status
+        - labels
+        - created_at
+      type: object
+    MessageView:
+      additionalProperties: false
+      properties:
+        auth:
+          $ref: "#/components/schemas/Result"
+        auth_headers:
+          additionalProperties:
+            type: string
+          type: object
+        body:
+          $ref: "#/components/schemas/MessageBodyView"
+        cc:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        conversation_id:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        delivery_detail:
+          type: string
+        delivery_status:
+          enum:
+            - queued
+            - sent
+            - delivered
+            - bounced
+            - complained
+            - deferred
+            - failed
+          type: string
+        direction:
+          enum:
+            - inbound
+            - outbound
+          type: string
+        flag_reason:
+          type: string
+        flagged:
+          type: boolean
+        from:
+          type: string
+        hitl_status:
+          enum:
+            - pending_approval
+            - sent
+            - rejected
+            - expired_approved
+            - expired_rejected
+          type: string
+        labels:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        message_id:
+          type: string
+        parsed:
+          $ref: "#/components/schemas/MessageParsedView"
+        raw_message:
+          contentEncoding: base64
+          type: string
+        recipient:
+          type: string
+        reply_to:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        sent_as:
+          enum:
+            - own_address
+            - relay
+          type: string
+        status:
+          type: string
+        subject:
+          type: string
+        to:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+      required:
+        - message_id
+        - from
+        - to
+        - cc
+        - reply_to
+        - recipient
+        - subject
+        - conversation_id
+        - direction
+        - status
+        - labels
+        - created_at
+        - auth_headers
+        - raw_message
+      type: object
+    OAuthConnectionEntry:
+      additionalProperties: false
+      properties:
+        agent_email:
+          type: string
+        client_id:
+          type: string
+        client_name:
+          type: string
+        expires_at:
+          format: date-time
+          type: string
+        issued_at:
+          format: date-time
+          type: string
+        revoked_at:
+          format: date-time
+          type: string
+        scope:
+          type: string
+      required:
+        - client_id
+        - client_name
+        - agent_email
+        - scope
+        - issued_at
+      type: object
+    PageConversationSummaryView:
+      additionalProperties: false
+      properties:
+        items:
+          items:
+            $ref: "#/components/schemas/ConversationSummaryView"
+          type: array
+        next_cursor:
+          type:
+            - string
+            - "null"
+      required:
+        - items
+        - next_cursor
+      type: object
+    PageEventJSON:
+      additionalProperties: false
+      properties:
+        items:
+          items:
+            $ref: "#/components/schemas/EventJSON"
+          type: array
+        next_cursor:
+          type:
+            - string
+            - "null"
+      required:
+        - items
+        - next_cursor
+      type: object
+    PageMessageSummaryView:
+      additionalProperties: false
+      properties:
+        items:
+          items:
+            $ref: "#/components/schemas/MessageSummaryView"
+          type: array
+        next_cursor:
+          type:
+            - string
+            - "null"
+      required:
+        - items
+        - next_cursor
+      type: object
+    PageWebhookDeliveryView:
+      additionalProperties: false
+      properties:
+        items:
+          items:
+            $ref: "#/components/schemas/WebhookDeliveryView"
+          type: array
+        next_cursor:
+          type:
+            - string
+            - "null"
+      required:
+        - items
+        - next_cursor
+      type: object
+    RedeliverDelivery:
+      additionalProperties: false
+      properties:
+        delivery_id:
+          type: string
+        reason:
+          type: string
+        status:
+          enum:
+            - pending
+            - skipped
+          type: string
+        webhook_id:
+          type: string
+      required:
+        - webhook_id
+        - status
+      type: object
+    RedeliverEventInputBody:
+      additionalProperties: false
+      properties:
+        webhook_id:
+          type: string
+      type: object
+    RedeliverView:
+      additionalProperties: false
+      properties:
+        deliveries:
+          items:
+            $ref: "#/components/schemas/RedeliverDelivery"
+          type:
+            - array
+            - "null"
+        delivery_id:
+          type: string
+        event_id:
+          type: string
+        status:
+          enum:
+            - pending
+            - scheduled
+          type: string
+        webhook_id:
+          type: string
+      required:
+        - event_id
+        - status
+      type: object
+    RegisterDomainRequest:
+      additionalProperties: false
+      properties:
+        domain:
+          type: string
+      type: object
+    RejectInputBody:
+      additionalProperties: false
+      properties:
+        reason:
+          type: string
+      type: object
+    RejectResultView:
+      additionalProperties: false
+      properties:
+        message_id:
+          type: string
+        rejection_reason:
+          type: string
+        status:
+          type: string
+      required:
+        - status
+        - message_id
+      type: object
+    ReplyRequest:
+      additionalProperties: false
+      properties:
+        attachments:
+          items:
+            $ref: "#/components/schemas/Attachment"
+          type:
+            - array
+            - "null"
+        bcc:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        body:
+          type: string
+        cc:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        conversation_id:
+          type: string
+        html_body:
+          type: string
+        reply_all:
+          type: boolean
+      type: object
+    Result:
+      additionalProperties: false
+      properties:
+        dkim:
+          $ref: "#/components/schemas/CheckResult"
+        dmarc:
+          $ref: "#/components/schemas/CheckResult"
+        spf:
+          $ref: "#/components/schemas/CheckResult"
+      required:
+        - spf
+        - dkim
+        - dmarc
+      type: object
+    RotateSecretOutputBody:
+      additionalProperties: false
+      properties:
+        previous_secret_expires_at:
+          type: string
+        signing_secret:
+          type: string
+      required:
+        - signing_secret
+        - previous_secret_expires_at
+      type: object
+    SendEmailRequest:
+      additionalProperties: false
+      properties:
+        attachments:
+          items:
+            $ref: "#/components/schemas/Attachment"
+          type:
+            - array
+            - "null"
+        bcc:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        body:
+          type: string
+        cc:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        conversation_id:
+          type: string
+        from:
+          type: string
+        html_body:
+          type: string
+        subject:
+          type: string
+        to:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+      type: object
+    SendResultView:
+      additionalProperties: false
+      properties:
+        approval_expires_at:
+          format: date-time
+          type: string
+        message_id:
+          type: string
+        method:
+          type: string
+        status:
+          enum:
+            - sent
+            - pending_approval
+          type: string
+      required:
+        - status
+        - message_id
+      type: object
+    SendingDNSRecordView:
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+        type:
+          type: string
+        value:
+          type: string
+      required:
+        - type
+        - name
+        - value
+      type: object
+    Suppression:
+      additionalProperties: false
+      properties:
+        address:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        reason:
+          type: string
+        source:
+          type: string
+        source_message_id:
+          type: string
+      required:
+        - address
+        - source
+        - created_at
+      type: object
+    SuppressionsOutputBody:
+      additionalProperties: false
+      properties:
+        suppressions:
+          items:
+            $ref: "#/components/schemas/Suppression"
+          type: array
+      required:
+        - suppressions
+      type: object
+    TestWebhookOutputBody:
+      additionalProperties: false
+      properties:
+        delivery_id:
+          type: string
+      required:
+        - delivery_id
+      type: object
+    TestWebhookRequest:
+      additionalProperties: false
+      properties:
+        data:
+          additionalProperties: {}
+          type: object
+        event:
+          type: string
+      type: object
+    UpdateAgentRequest:
+      additionalProperties: false
+      properties:
+        hitl_enabled:
+          type: boolean
+        hitl_expiration_action:
+          type: string
+        hitl_mode:
+          type: string
+        hitl_ttl_seconds:
+          format: int64
+          type: integer
+        inbound_allowlist:
+          items:
+            type: string
+          type: array
+        inbound_policy:
+          type: string
+      type: object
+    UpdateDomainRequest:
+      additionalProperties: false
+      properties:
+        is_primary:
+          type: boolean
+      type: object
+    UpdateMessageRequest:
+      additionalProperties: false
+      properties:
+        add_labels:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        remove_labels:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+      type: object
+    UpdateMessageResultView:
+      additionalProperties: false
+      properties:
+        labels:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        message_id:
+          type: string
+      required:
+        - message_id
+        - labels
+      type: object
+    UpdateWebhookRequest:
+      additionalProperties: false
+      properties:
+        description:
+          type: string
+        enabled:
+          type: boolean
+        events:
+          items:
+            type: string
+          type: array
+        filters:
+          $ref: "#/components/schemas/WebhookFiltersView"
+        url:
+          type: string
+      type: object
+    UsageEventEntry:
+      additionalProperties: false
+      properties:
+        agent_id:
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        direction:
+          type: string
+        domain:
+          type: string
+        event_type:
+          type: string
+        id:
+          type: string
+      required:
+        - id
+        - agent_id
+        - domain
+        - direction
+        - event_type
+        - created_at
+      type: object
+    UserExport:
+      additionalProperties: false
+      properties:
+        agents:
+          items:
+            $ref: "#/components/schemas/AgentIdentity"
+          type:
+            - array
+            - "null"
+        api_keys:
+          items:
+            $ref: "#/components/schemas/APIKeyExportEntry"
+          type:
+            - array
+            - "null"
+        domains:
+          items:
+            $ref: "#/components/schemas/Domain"
+          type:
+            - array
+            - "null"
+        generated_at:
+          format: date-time
+          type: string
+        messages:
+          items:
+            $ref: "#/components/schemas/Message"
+          type:
+            - array
+            - "null"
+        oauth_connections:
+          items:
+            $ref: "#/components/schemas/OAuthConnectionEntry"
+          type:
+            - array
+            - "null"
+        schema_version:
+          type: string
+        usage_events:
+          items:
+            $ref: "#/components/schemas/UsageEventEntry"
+          type:
+            - array
+            - "null"
+        user:
+          $ref: "#/components/schemas/UserExportUser"
+      required:
+        - generated_at
+        - schema_version
+        - user
+        - domains
+        - agents
+        - api_keys
+        - messages
+      type: object
+    UserExportUser:
+      additionalProperties: false
+      properties:
+        created_at:
+          format: date-time
+          type: string
+        email:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+      required:
+        - id
+        - email
+        - name
+        - created_at
+      type: object
+    VerifyDomainView:
+      additionalProperties: false
+      properties:
+        dkim:
+          type: string
+        domain:
+          type: string
+        mx:
+          type: string
+        spf:
+          type: string
+        verified:
+          type: boolean
+        verified_at:
+          format: date-time
+          type: string
+      required:
+        - domain
+        - verified
+      type: object
+    WebhookDeliveryView:
+      additionalProperties: false
+      properties:
+        attempts:
+          format: int64
+          type: integer
+        created_at:
+          format: date-time
+          type: string
+        event_type:
+          enum:
+            - email.received
+            - email.sent
+            - email.pending_approval
+            - email.approved
+            - email.rejected
+            - domain.sending_verified
+            - domain.sending_failed
+            - email.delivered
+            - email.bounced
+            - email.complained
+            - domain.suppression_added
+            - email.flagged
+          type: string
+        id:
+          type: string
+        last_attempt_at:
+          format: date-time
+          type: string
+        last_error:
+          type: string
+        last_status_code:
+          format: int64
+          type: integer
+        next_retry_at:
+          format: date-time
+          type: string
+        status:
+          enum:
+            - pending
+            - delivered
+            - failed
+          type: string
+      required:
+        - id
+        - event_type
+        - status
+        - attempts
+        - next_retry_at
+        - created_at
+      type: object
+    WebhookFiltersView:
+      additionalProperties: false
+      properties:
+        agent_ids:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        conversation_ids:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        labels:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+      type: object
+    WebhookView:
+      additionalProperties: false
+      properties:
+        auto_disabled_at:
+          format: date-time
+          type: string
+        created_at:
+          format: date-time
+          type: string
+        description:
+          type: string
+        enabled:
+          type: boolean
+        events:
+          items:
+            type: string
+          type:
+            - array
+            - "null"
+        filters:
+          $ref: "#/components/schemas/WebhookFiltersView"
+        id:
+          type: string
+        last_delivered_at:
+          format: date-time
+          type: string
+        signing_secret:
+          type: string
+        url:
+          type: string
+      required:
+        - id
+        - url
+        - description
+        - events
+        - filters
+        - enabled
+        - created_at
+      type: object
+  securitySchemes:
+    bearer:
+      description: "API key (e2a_…) or OAuth 2.1 access token, sent as `Authorization: Bearer <token>`."
+      scheme: bearer
+      type: http
 info:
-  contact:
-    url: https://github.com/Mnexa-AI/e2a
-  description: |-
-    Email for AI agents. e2a delivers emails to your agent via webhooks or WebSocket and lets your agent send emails back.
-
-    ## Authentication
-
-    All requests require your API key as a Bearer token:
-
-    ```
-    Authorization: Bearer e2a_your_api_key
-    ```
-
-    Create an API key on the API Keys page of the e2a instance you are connecting to.
-
-    ## How it works
-
-    **Cloud agents** (webhook delivery):
-    1. Register your agent and set a webhook URL
-    2. When someone emails your agent, e2a POSTs a webhook to your endpoint
-    3. Reply via the API or send new emails
-
-    **Local agents** (WebSocket delivery):
-    1. Register your agent with a slug on the deployment's shared domain (when slug registration is enabled)
-    2. Connect via WebSocket to receive real-time notifications
-    3. Fetch full message content via the API, reply or send new emails
+  description: e2a — authenticated email gateway for AI agents. v1 contract.
   title: e2a API
-  version: "1.0"
+  version: 1.0.0
+openapi: 3.1.0
 paths:
-  /api/v1/agents:
-    get:
-      description: Returns all agents owned by the authenticated user.
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/ListAgentsResponse'
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-      security:
-      - BearerAuth: []
-      summary: List your registered agents
-      tags:
-      - Agents
-    post:
-      consumes:
-      - application/json
-      description: Register a new agent with a custom domain or, on deployments where
-        slug registration is enabled, a slug on the shared domain. Use `slug` for
-        instant onboarding (no DNS needed), or `email` for a custom domain (requires
-        domain to be registered and verified first). `agent_mode` is required and
-        must be "local" (inbound delivered via WebSocket / pollable REST) or "cloud"
-        (inbound POSTed to `webhook_url`). Rate limited to 200 registrations per source
-        IP per hour; 429 responses carry a `Retry-After` header in delay-seconds form.
-      parameters:
-      - description: Agent registration details
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/RegisterAgentRequest'
-      produces:
-      - application/json
-      responses:
-        "201":
-          description: Created
-          schema:
-            $ref: '#/definitions/RegisterAgentResponse'
-        "400":
-          description: Invalid request
-          schema:
-            type: string
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-        "409":
-          description: Agent already exists
-          schema:
-            type: string
-        "429":
-          description: Rate limit exceeded — see Retry-After header
-          schema:
-            type: string
-      security:
-      - BearerAuth: []
-      summary: Register a new agent
-      tags:
-      - Agents
-  /api/v1/agents/{email}:
+  /v1/account:
     delete:
-      description: Delete an agent owned by the authenticated user. The agent email
-        is cleared from any local config.
+      description: Permanently deletes the account and cascades all owned data. Requires ?confirm=DELETE.
+      operationId: deleteAccount
       parameters:
-      - description: Agent email address
-        example: my-bot@example.com
-        in: path
-        name: email
-        required: true
-        type: string
-      produces:
-      - application/json
+        - description: Must be DELETE — this is irreversible.
+          explode: false
+          in: query
+          name: confirm
+          schema:
+            description: Must be DELETE — this is irreversible.
+            type: string
       responses:
         "200":
-          description: 'status: deleted'
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-        "403":
-          description: Agent not owned by this user
-          schema:
-            type: string
-        "500":
-          description: Internal server error
-          schema:
-            type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeleteUserDataResult"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
       security:
-      - BearerAuth: []
-      summary: Delete an agent
+        - bearer: []
+      summary: Delete your account + all data (irreversible)
       tags:
-      - Agents
+        - account
     get:
-      description: Fetch details for a specific agent owned by the authenticated user.
-      parameters:
-      - description: Agent email address
-        example: my-bot@example.com
-        in: path
-        name: email
-        required: true
-        type: string
-      produces:
-      - application/json
+      description: The authenticated account's plan caps and current usage. (Deployment discovery — shared domain, slug registration — is the separate public GET /v1/info.)
+      operationId: getAccount
       responses:
         "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LimitsView"
           description: OK
-          schema:
-            $ref: '#/definitions/Agent'
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-        "403":
-          description: Agent not owned by this user
-          schema:
-            type: string
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
       security:
-      - BearerAuth: []
-      summary: Get agent details
+        - bearer: []
+      summary: "Get account: plan limits + usage"
       tags:
-      - Agents
-    put:
-      consumes:
-      - application/json
-      description: Updates an agent you own. Fields are optional; only the ones you
-        send are applied, so callers can PATCH a single setting (for example, toggle
-        HITL on) without re-supplying the others. When changing to cloud mode, webhook_url
-        becomes required. HITL TTL is server-capped at 604800 seconds (7 days). Returns
-        the post-update agent state so callers can confirm what landed.
-      parameters:
-      - description: Agent email address
-        example: my-bot@example.com
-        in: path
-        name: email
-        required: true
-        type: string
-      - description: Fields to update
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/UpdateAgentRequest'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/Agent'
-        "400":
-          description: Validation error (e.g. bad agent_mode, TTL out of range)
-          schema:
-            type: string
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-        "403":
-          description: Agent not owned by this user
-          schema:
-            type: string
-        "404":
-          description: Agent not found
-          schema:
-            type: string
-      security:
-      - BearerAuth: []
-      summary: Update an agent
-      tags:
-      - Agents
-  /api/v1/agents/{email}/conversations:
+        - account
+  /v1/account/export:
     get:
-      description: Returns conversation summaries for an agent — one row per non-empty
-        conversation_id, with aggregated counts and the latest message's subject/sender.
-        Sorted by `last_message_at` descending. The response is hard-capped at 100
-        conversations (pagination is intentionally deferred for slice 1). Use `since`
-        / `until` to bracket the active window. Messages with empty `conversation_id`
-        are NOT in any conversation — they remain individually visible via the messages
-        list.
-      parameters:
-      - description: Agent email address
-        example: my-bot@example.com
-        in: path
-        name: email
-        required: true
-        type: string
-      - description: RFC3339 timestamp; only conversations whose latest message is
-          >= since
-        example: "2026-05-01T00:00:00Z"
-        in: query
-        name: since
-        type: string
-      - description: RFC3339 timestamp; only conversations whose latest message is
-          < until
-        in: query
-        name: until
-        type: string
-      - default: 100
-        description: Max conversations to return (server clamps to 100)
-        in: query
-        maximum: 100
-        minimum: 1
-        name: page_size
-        type: integer
-      produces:
-      - application/json
+      description: A JSON dump of every record the authenticated account owns.
+      operationId: exportAccount
       responses:
         "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserExport"
           description: OK
-          schema:
-            $ref: '#/definitions/ListConversationsResponse'
-        "400":
-          description: Invalid since/until
-          schema:
-            type: string
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-        "404":
-          description: Agent not found or not owned by this user
-          schema:
-            type: string
+          headers:
+            Content-Disposition:
+              schema:
+                type: string
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
       security:
-      - BearerAuth: []
-      summary: List conversations for an agent
+        - bearer: []
+      summary: Export your data (GDPR right-of-access)
       tags:
-      - Email
-  /api/v1/agents/{email}/conversations/{id}:
+        - account
+  /v1/account/suppressions:
     get:
-      description: Returns the full conversation — aggregate counts, participant union,
-        label union, and every member message (oldest-first). Messages share the schema
-        of `MessageSummary` from the list endpoint. Returns 404 when no non-expired
-        messages exist for `(agent, conversation_id)`; cross-agent access is indistinguishable
-        from not-found.
-      parameters:
-      - description: Agent email address
-        example: my-bot@example.com
-        in: path
-        name: email
-        required: true
-        type: string
-      - description: Conversation ID
-        example: conv_abc123
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/json
+      description: Addresses e2a will refuse to send to (auto-added on a hard bounce or complaint, or added manually). Sends to a suppressed address fail with recipient_suppressed.
+      operationId: listSuppressions
       responses:
         "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SuppressionsOutputBody"
           description: OK
-          schema:
-            $ref: '#/definitions/ConversationDetail'
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-        "404":
-          description: Conversation not found
-          schema:
-            type: string
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
       security:
-      - BearerAuth: []
-      summary: Get a conversation
+        - bearer: []
+      summary: List suppressed recipient addresses
       tags:
-      - Email
-  /api/v1/agents/{email}/messages:
-    get:
-      description: Fetch messages for an agent. Returns lightweight summaries (no
-        raw message content). Supports opaque token-based pagination via `page_size`
-        and `token`. **Default sort is newest-first** across all directions — pass
-        `?sort=asc` to flip to oldest-first when you need FIFO polling semantics (drain
-        the inbox in arrival order). `direction` defaults to `inbound` for SDK back-compat.
-        **Search filters** (`from`, `subject_contains`, `conversation_id`, `since`,
-        `until`) narrow the result set server-side; substring filters are case-insensitive
-        (Postgres ILIKE). Filter values are encoded into `next_token`, so continuation
-        requests must keep the same filters or restart the query.
-      parameters:
-      - description: Agent email address
-        example: my-bot@example.com
-        in: path
-        name: email
-        required: true
-        type: string
-      - default: inbound
-        description: Filter by message direction
-        enum:
-        - inbound
-        - outbound
-        - all
-        in: query
-        name: direction
-        type: string
-      - default: unread
-        description: Filter by inbox status (only meaningful when direction includes
-          inbound)
-        enum:
-        - unread
-        - read
-        - all
-        in: query
-        name: status
-        type: string
-      - default: 50
-        description: Number of messages per page (1-100)
-        in: query
-        maximum: 100
-        minimum: 1
-        name: page_size
-        type: integer
-      - default: desc
-        description: Sort order by created_at. Default `desc` (newest first); pass
-          `asc` for FIFO polling.
-        enum:
-        - asc
-        - desc
-        in: query
-        name: sort
-        type: string
-      - description: Case-insensitive substring match on the sender column. Max 200
-          chars.
-        in: query
-        name: from
-        type: string
-      - description: Case-insensitive substring match on the subject column. Max 200
-          chars.
-        in: query
-        name: subject_contains
-        type: string
-      - description: Exact match on conversation_id — narrow to a single thread.
-        in: query
-        name: conversation_id
-        type: string
-      - description: RFC3339 timestamp; only messages with created_at >= since are
-          returned.
-        in: query
-        name: since
-        type: string
-      - description: RFC3339 timestamp; only messages with created_at < until are
-          returned.
-        in: query
-        name: until
-        type: string
-      - description: Opaque pagination token from a previous response's next_token
-        in: query
-        name: token
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/ListMessagesResponse'
-        "400":
-          description: Invalid status, pagination token, or filter mismatch
-          schema:
-            type: string
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-        "404":
-          description: Agent not found or not owned by this user
-          schema:
-            type: string
-      security:
-      - BearerAuth: []
-      summary: List messages for an agent
-      tags:
-      - Email
-  /api/v1/agents/{email}/messages/{id}:
-    get:
-      description: Fetch full message content including raw RFC 2822 email and auth
-        headers. If the message is unread, this request marks it as read.
-      parameters:
-      - description: Agent email address
-        example: my-bot@example.com
-        in: path
-        name: email
-        required: true
-        type: string
-      - description: Message ID
-        example: msg_abc123
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/MessageDetail'
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-        "404":
-          description: Message not found
-          schema:
-            type: string
-      security:
-      - BearerAuth: []
-      summary: Get a single message
-      tags:
-      - Email
-    patch:
-      consumes:
-      - application/json
-      description: Apply a delta to a message's labels. Pass `add_labels` and/or `remove_labels`
-        — each capped at 50 entries per request. Labels are lowercase strings drawn
-        from `[a-z0-9:_-]+` up to 64 chars; the `e2a:` prefix is reserved for server-applied
-        system labels and rejected on user writes. The total label count per message
-        is capped at 100. A label appearing in both add and remove is removed (remove
-        wins). Returns the post-update label set so callers can echo state without
-        a fetch.
-      parameters:
-      - description: Agent email address
-        example: my-bot@example.com
-        in: path
-        name: email
-        required: true
-        type: string
-      - description: Message ID
-        example: msg_abc123
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Label delta
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/UpdateMessageRequest'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/UpdateMessageResponse'
-        "400":
-          description: Invalid label or per-message cap exceeded
-          schema:
-            type: string
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-        "404":
-          description: Message not found or does not belong to this agent
-          schema:
-            type: string
-      security:
-      - BearerAuth: []
-      summary: Update a message (labels)
-      tags:
-      - Email
-  /api/v1/agents/{email}/messages/{id}/approve:
-    post:
-      consumes:
-      - application/json
-      description: Sends a pending-approval message via the upstream SMTP relay and
-        transitions it to `sent`. The request body is optional — passing any subset
-        of subject / body_text / body_html / to / cc / bcc / attachments overrides
-        the stored draft before send. An empty body approves the draft as-is. On successful
-        send, the server scrubs body columns and records the provider-assigned Message-ID.
-      parameters:
-      - description: Owning agent email
-        example: bot@agents.e2a.dev
-        in: path
-        name: email
-        required: true
-        type: string
-      - description: Message ID
-        example: msg_abc123
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Optional field overrides
-        in: body
-        name: request
-        schema:
-          $ref: '#/definitions/ApprovePendingMessageRequest'
-      - description: Caller-generated unique key (recommend UUIDv4). Approve fires
-          a real outbound send (SES); on retry with the same key + same body the server
-          replays the original response instead of double-sending. A different body
-          returns 422.
-        in: header
-        name: Idempotency-Key
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/ApprovePendingMessageResponse'
-        "400":
-          description: Invalid request or SMTP validation error
-          schema:
-            type: string
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-        "403":
-          description: Agent domain not verified
-          schema:
-            type: string
-        "404":
-          description: Message not found, not owned by this user, or {email} doesn't
-            match the message's owning agent
-          schema:
-            type: string
-        "409":
-          description: Message is no longer pending approval, or another request with
-            this Idempotency-Key is in progress
-          schema:
-            type: string
-        "422":
-          description: Idempotency-Key reused with a different request body
-          schema:
-            type: string
-      security:
-      - BearerAuth: []
-      summary: Approve a held outbound message
-      tags:
-      - HITL
-  /api/v1/agents/{email}/messages/{id}/forward:
-    post:
-      consumes:
-      - application/json
-      description: Forward a previously received email to one or more new recipients.
-        The server prepends the caller's optional comment, then a Gmail-style "Forwarded
-        message" block with the original headers and best-effort extracted body. A
-        forward is treated as a NEW thread — no In-Reply-To/References headers are
-        emitted; pass conversation_id to bind it to an existing thread explicitly.
-        Rate limited to 60 sends per agent per minute; 429 responses carry a `Retry-After`
-        header in delay-seconds form. When the owning agent has HITL enabled, the
-        server returns 202 Accepted with status="pending_approval".
-      parameters:
-      - description: Agent email address
-        example: my-bot@example.com
-        in: path
-        name: email
-        required: true
-        type: string
-      - description: Message ID from the inbound payload
-        example: msg_abc123
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Forward content
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/ForwardMessageRequest'
-      - description: Caller-generated unique key (recommend UUIDv4). Retries with
-          the same key + same body replay the original response; with a different
-          body return 422.
-        in: header
-        name: Idempotency-Key
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: Forward sent immediately
-          schema:
-            $ref: '#/definitions/SendEmailResponse'
-        "202":
-          description: Forward held for human approval
-          schema:
-            $ref: '#/definitions/SendEmailResponse'
-        "400":
-          description: Missing or invalid fields
-          schema:
-            type: string
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-        "403":
-          description: Agent domain not verified
-          schema:
-            type: string
-        "404":
-          description: Message not found or does not belong to this agent
-          schema:
-            type: string
-        "409":
-          description: Another request with this Idempotency-Key is in progress
-          schema:
-            type: string
-        "422":
-          description: Idempotency-Key reused with a different request body
-          schema:
-            type: string
-        "429":
-          description: Rate limit exceeded
-          schema:
-            type: string
-      security:
-      - BearerAuth: []
-      summary: Forward an inbound email
-      tags:
-      - Email
-  /api/v1/agents/{email}/messages/{id}/reject:
-    post:
-      consumes:
-      - application/json
-      description: Transitions a pending-approval message to `rejected`; the message
-        is never sent. Body columns are scrubbed. An optional reason is stored for
-        audit purposes. Returns 409 if the message has already been sent, rejected,
-        or expired.
-      parameters:
-      - description: Message ID
-        example: msg_abc123
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Optional rejection reason
-        in: body
-        name: request
-        schema:
-          $ref: '#/definitions/RejectPendingMessageRequest'
-      - description: Owning agent email
-        example: bot@agents.e2a.dev
-        in: path
-        name: email
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/RejectPendingMessageResponse'
-        "400":
-          description: Invalid request body
-          schema:
-            type: string
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-        "404":
-          description: Message not found, not owned by this user, or {email} doesn't
-            match the message's owning agent
-          schema:
-            type: string
-        "409":
-          description: Message is no longer pending approval
-          schema:
-            type: string
-      security:
-      - BearerAuth: []
-      summary: Reject a held outbound message
-      tags:
-      - HITL
-  /api/v1/agents/{email}/messages/{id}/reply:
-    post:
-      consumes:
-      - application/json
-      description: Reply to a previously received email using its message ID. The
-        reply is sent as a real email back to the original sender, with proper threading
-        headers (In-Reply-To, References). Pass conversation_id to tag the reply with
-        your thread ID — the recipient will see it on their inbound payload. Rate
-        limited to 60 sends per agent per minute; 429 responses carry a `Retry-After`
-        header in delay-seconds form. When the owning agent has HITL enabled, the
-        server returns 202 Accepted and status="pending_approval" instead of sending
-        immediately.
-      parameters:
-      - description: Agent email address
-        example: my-bot@example.com
-        in: path
-        name: email
-        required: true
-        type: string
-      - description: Message ID from the inbound payload
-        example: msg_abc123
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Reply content
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/ReplyToMessageRequest'
-      - description: Caller-generated unique key (recommend UUIDv4). Retries with
-          the same key + same body replay the original response; with a different
-          body return 422.
-        in: header
-        name: Idempotency-Key
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: Reply sent immediately
-          schema:
-            $ref: '#/definitions/SendEmailResponse'
-        "202":
-          description: Reply held for human approval
-          schema:
-            $ref: '#/definitions/SendEmailResponse'
-        "400":
-          description: Missing body
-          schema:
-            type: string
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-        "403":
-          description: Agent domain not verified
-          schema:
-            type: string
-        "404":
-          description: Message not found or does not belong to this agent
-          schema:
-            type: string
-        "409":
-          description: Another request with this Idempotency-Key is in progress
-          schema:
-            type: string
-        "422":
-          description: Idempotency-Key reused with a different request body
-          schema:
-            type: string
-        "429":
-          description: Rate limit exceeded
-          schema:
-            type: string
-      security:
-      - BearerAuth: []
-      summary: Reply to an inbound email
-      tags:
-      - Email
-  /api/v1/agents/{email}/test:
-    post:
-      description: Send a test email from the platform to the agent's own address.
-        Useful for verifying inbound delivery is wired up correctly. Requires the
-        agent's domain to be verified. If the agent has HITL enabled the message is
-        held for approval and the response is 202.
-      parameters:
-      - description: Agent email address
-        example: my-bot@example.com
-        in: path
-        name: email
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: status and message_id
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "202":
-          description: message_id (held for HITL approval)
-          schema:
-            additionalProperties:
-              type: string
-            type: object
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-        "403":
-          description: Agent domain not verified
-          schema:
-            type: string
-        "404":
-          description: Agent not found
-          schema:
-            type: string
-        "500":
-          description: Failed to send test email
-          schema:
-            type: string
-      security:
-      - BearerAuth: []
-      summary: Send a test email
-      tags:
-      - Agents
-  /api/v1/domains:
-    get:
-      description: Returns all domains owned by the authenticated user.
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/ListDomainsResponse'
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-      security:
-      - BearerAuth: []
-      summary: List your domains
-      tags:
-      - Domains
-    post:
-      consumes:
-      - application/json
-      description: Register a custom domain for use with agents. Returns DNS records
-        to configure and a verification token.
-      parameters:
-      - description: Domain to register
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/RegisterDomainRequest'
-      produces:
-      - application/json
-      responses:
-        "201":
-          description: Created
-          schema:
-            $ref: '#/definitions/Domain'
-        "400":
-          description: Invalid request
-          schema:
-            type: string
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-      security:
-      - BearerAuth: []
-      summary: Register a domain
-      tags:
-      - Domains
-  /api/v1/domains/{domain}:
+        - account
+  /v1/account/suppressions/{address}:
     delete:
-      description: Delete a domain. Fails if agents still exist on this domain.
+      description: Un-suppress a recipient. A previously-blocked send to it then succeeds (idempotency keys are released, so no fresh key is needed).
+      operationId: deleteSuppression
       parameters:
-      - description: Domain name
-        in: path
-        name: domain
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "204":
-          description: Domain deleted
-        "400":
-          description: Agents still exist on this domain
+        - in: path
+          name: address
+          required: true
           schema:
             type: string
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-        "404":
-          description: Domain not found
-          schema:
-            type: string
-      security:
-      - BearerAuth: []
-      summary: Delete a domain
-      tags:
-      - Domains
-    get:
-      description: Returns the authenticated user's view of a single domain
-      parameters:
-      - description: Domain name
-        in: path
-        name: domain
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/Domain'
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-        "404":
-          description: Domain not found
-          schema:
-            type: string
-      security:
-      - BearerAuth: []
-      summary: Get a domain
-      tags:
-      - Domains
-    patch:
-      consumes:
-      - application/json
-      description: Update mutable fields on a domain. The only supported field today
-        is `is_primary` — passing `true` promotes this domain and clears the flag
-        from any previously-primary domain in a single transaction. Passing `false`
-        is a no-op (use SetDomainPrimary on a different domain to demote this one).
-      parameters:
-      - description: Domain name
-        in: path
-        name: domain
-        required: true
-        type: string
-      - description: Fields to update
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/UpdateDomainRequest'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/Domain'
-        "400":
-          description: Invalid request
-          schema:
-            type: string
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-        "404":
-          description: Domain not found
-          schema:
-            type: string
-      security:
-      - BearerAuth: []
-      summary: Update a domain
-      tags:
-      - Domains
-  /api/v1/domains/{domain}/verify:
-    post:
-      description: Verify domain ownership (TXT record) and run per-record probes
-        for MX/SPF/DKIM. Returns 200 with the per-record breakdown when ownership
-        is verified, 412 when the TXT token is missing. DKIM reports "found" or "missing"
-        against the per-domain public key registered at claim time; "deferred" is
-        returned only for pre-migration domains that have no stored keypair yet.
-      parameters:
-      - description: Domain name
-        in: path
-        name: domain
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/VerifyDomainResponse'
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-        "404":
-          description: Domain not found
-          schema:
-            type: string
-        "412":
-          description: TXT record not found — body includes per-record diagnostic
-          schema:
-            $ref: '#/definitions/VerifyDomainResponse'
-      security:
-      - BearerAuth: []
-      summary: Verify domain ownership + DNS diagnostic
-      tags:
-      - Domains
-  /api/v1/events:
-    get:
-      description: Returns webhook events in reverse-chronological order. Cursor-paginated
-        via `token` / `next_token`. Events past the 30-day retention are not returned.
-      parameters:
-      - description: Exact event-type filter (e.g. email.received)
-        in: query
-        name: type
-        type: string
-      - description: Filter to events for a specific agent
-        in: query
-        name: agent_id
-        type: string
-      - description: Filter to events on one conversation
-        in: query
-        name: conversation_id
-        type: string
-      - description: Filter to events on one message
-        in: query
-        name: message_id
-        type: string
-      - description: RFC3339 timestamp; only events with created_at >= since
-        in: query
-        name: since
-        type: string
-      - description: RFC3339 timestamp; only events with created_at < until
-        in: query
-        name: until
-        type: string
-      - description: Page size 1-100; default 50
-        in: query
-        name: page_size
-        type: integer
-      - description: Opaque cursor from a previous response's next_token
-        in: query
-        name: token
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/ListEventsResponse'
-        "400":
-          description: Invalid query parameter
-          schema:
-            type: string
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-      security:
-      - BearerAuth: []
-      summary: List webhook events
-      tags:
-      - Events
-  /api/v1/events/{id}:
-    get:
-      description: Returns the full webhook event including delivery_status counts.
-        410 Gone when the event is past the 30-day retention boundary.
-      parameters:
-      - description: Event ID (evt_<32hex>)
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/WebhookEvent'
-        "404":
-          description: Event not found or not owned by caller
-          schema:
-            type: string
-        "410":
-          description: Event past 30-day retention
-          schema:
-            type: string
-      security:
-      - BearerAuth: []
-      summary: Get a single event
-      tags:
-      - Events
-  /api/v1/events/{id}/redeliver:
-    post:
-      consumes:
-      - application/json
-      description: Replay an event to one webhook (body `{webhook_id}`) or to every
-        originally-matched webhook (empty body). Reuses the original event id so consumer
-        dedup discards the replay if already processed.
-      parameters:
-      - description: Event ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: '{webhook_id} for targeted replay; empty for fan-out'
-        in: body
-        name: body
-        schema:
-          $ref: '#/definitions/RedeliverRequest'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/RedeliverResponse'
-        "404":
-          description: Event not found
-          schema:
-            type: string
-        "409":
-          description: Webhook not in originally-matched set
-          schema:
-            type: string
-        "410":
-          description: Event past retention
-          schema:
-            type: string
-      security:
-      - BearerAuth: []
-      summary: Replay a webhook event
-      tags:
-      - Events
-  /api/v1/info:
-    get:
-      description: Returns deployment-specific configuration (shared domain, etc.)
-        so CLI/SDK clients can self-configure. Unauthenticated.
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/DeploymentInfo'
-      summary: Deployment info
-      tags:
-      - System
-  /api/v1/messages/{id}:
-    get:
-      description: Returns the full pending-approval detail — recipients, subject,
-        body, attachments, and HITL metadata — for one of the authenticated user's
-        outbound messages. After terminal transitions (sent, rejected, expired_*)
-        the server scrubs body columns, so this endpoint returns the headers without
-        content for non-pending rows.
-      parameters:
-      - description: Message ID
-        example: msg_abc123
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/PendingMessageDetail'
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-        "404":
-          description: Message not found or not owned by this user
-          schema:
-            type: string
-      security:
-      - BearerAuth: []
-      summary: Fetch a held outbound message
-      tags:
-      - HITL
-  /api/v1/pending:
-    get:
-      description: Returns all pending_approval messages across every agent owned
-        by the authenticated user, sorted by expiring-soonest first. Body and attachments
-        are omitted — use the detail endpoint for full content. This is the only status
-        value supported on this endpoint today.
-      parameters:
-      - description: Filter by status (only pending_approval is supported)
-        enum:
-        - pending_approval
-        in: query
-        name: status
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/ListPendingMessagesResponse'
-        "400":
-          description: Unsupported status
-          schema:
-            type: string
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-      security:
-      - BearerAuth: []
-      summary: List messages waiting for HITL approval
-      tags:
-      - HITL
-  /api/v1/send:
-    post:
-      consumes:
-      - application/json
-      description: Send an email from your agent to any recipient. Your agent must
-        be domain-verified. Messages are delivered via SMTP. Rate limited to 60 sends
-        per agent per minute; 429 responses carry a `Retry-After` header in delay-seconds
-        form. Pass conversation_id to tag the message as part of a thread. When the
-        owning agent has HITL (human-in-the-loop) enabled, the server responds with
-        202 Accepted and status="pending_approval" instead — the message is held until
-        a reviewer approves it via the dashboard, CLI, or magic link, or until the
-        approval TTL expires and the configured expiration action fires.
-      parameters:
-      - description: Email to send
-        in: body
-        name: request
-        required: true
-        schema:
-          $ref: '#/definitions/SendEmailRequest'
-      - description: Caller-generated unique key (recommend UUIDv4). Retries with
-          the same key + same body replay the original response; with a different
-          body return 422.
-        in: header
-        name: Idempotency-Key
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: Message sent immediately
-          schema:
-            $ref: '#/definitions/SendEmailResponse'
-        "202":
-          description: Message held for human approval
-          schema:
-            $ref: '#/definitions/SendEmailResponse'
-        "400":
-          description: Missing required fields
-          schema:
-            type: string
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-        "403":
-          description: Agent domain not verified
-          schema:
-            type: string
-        "409":
-          description: Another request with this Idempotency-Key is in progress
-          schema:
-            type: string
-        "422":
-          description: Idempotency-Key reused with a different request body
-          schema:
-            type: string
-        "429":
-          description: Rate limit exceeded
-          schema:
-            type: string
-      security:
-      - BearerAuth: []
-      summary: Send a new email
-      tags:
-      - Email
-  /api/v1/users/me:
-    delete:
-      description: Permanently deletes the authenticated user along with their agents,
-        domains, messages, API keys, sessions, and usage data. **Irreversible.** Requires
-        `confirm=DELETE` query parameter as a guardrail. Returns per-table counts
-        of removed rows so the caller can audit the cascade.
-      parameters:
-      - description: Must equal 'DELETE' to proceed
-        in: query
-        name: confirm
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/DeleteUserDataResult'
-        "400":
-          description: Missing or invalid confirm parameter
-          schema:
-            type: string
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-      security:
-      - BearerAuth: []
-      summary: Delete your account and all associated data
-      tags:
-      - User
-  /api/v1/users/me/export:
-    get:
-      description: 'Returns a JSON dump of every record the authenticated user owns:
-        profile, agents, domains, API key metadata, messages (with bodies), and usage
-        events. API key plaintexts are not included — they were never stored. Internal
-        identifiers (google_subject, session tokens, key hashes) are excluded.'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/UserExport'
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-      security:
-      - BearerAuth: []
-      summary: Export your data
-      tags:
-      - User
-  /api/v1/users/me/limits:
-    get:
-      description: Returns the resolved per-user caps (from account_limits or operator
-        defaults) plus the user's current usage. Dashboard uses this to render the
-        upgrade affordance and the "you've used X of Y" surface.
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/LimitsInfo'
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-        "503":
-          description: Limits subsystem not configured
-          schema:
-            type: string
-      security:
-      - BearerAuth: []
-      summary: Get the current user's limits and usage
-      tags:
-      - Users
-  /api/v1/users/me/signing-secrets:
-    get:
-      description: Returns the authenticated user's webhook signing secrets (metadata,
-        12-char prefix, and full plaintext secret). Sorted most-recent-first; the
-        most-recent secret is what the e2a relay uses for new signatures.
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/ListSigningSecretsResponse'
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-      security:
-      - BearerAuth: []
-      summary: List your webhook signing secrets
-      tags:
-      - User
-    post:
-      consumes:
-      - application/json
-      description: Mints a new HMAC signing secret for the authenticated user. The
-        full plaintext `secret` is returned only in this response — save it now, you
-        cannot retrieve it later. Hard cap is 5 active secrets per user; delete one
-        before creating another.
-      parameters:
-      - description: Optional name/label
-        in: body
-        name: body
-        schema:
-          $ref: '#/definitions/internal_agent.CreateSigningSecretRequest'
-      produces:
-      - application/json
-      responses:
-        "201":
-          description: Created
-          schema:
-            $ref: '#/definitions/CreateSigningSecretResponse'
-        "400":
-          description: Bad request (e.g. cap reached)
-          schema:
-            type: string
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-      security:
-      - BearerAuth: []
-      summary: Create a new webhook signing secret
-      tags:
-      - User
-  /api/v1/users/me/signing-secrets/{id}:
-    delete:
-      description: Deletes the named secret. Refuses if it would leave the user with
-        zero secrets — create a replacement first. After delete, any in-flight HITL
-        approval magic-link tokens signed under the deleted secret stop verifying.
-      parameters:
-      - description: Signing secret ID (e.g. wsec_abc123...)
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/json
       responses:
         "204":
           description: No Content
-          schema:
-            type: string
-        "400":
-          description: Cannot delete last secret
-          schema:
-            type: string
-        "401":
-          description: Missing or invalid API key
-          schema:
-            type: string
-        "404":
-          description: Secret not found
-          schema:
-            type: string
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
       security:
-      - BearerAuth: []
-      summary: Delete a webhook signing secret
+        - bearer: []
+      summary: Remove an address from the suppression list
       tags:
-      - User
-  /api/v1/webhooks/{id}/redeliver-since:
-    post:
-      consumes:
-      - application/json
-      description: Re-fires every event the webhook originally matched since `since`
-        (RFC3339). Window capped at 7 days. Skips events that already have a pending
-        delivery for this webhook.
-      parameters:
-      - description: Webhook ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Replay window
-        in: body
-        name: body
-        required: true
-        schema:
-          $ref: '#/definitions/RedeliverSinceRequest'
-      produces:
-      - application/json
-      responses:
-        "200":
-          description: OK
-          schema:
-            $ref: '#/definitions/RedeliverSinceResponse'
-        "400":
-          description: since out of window or malformed
-          schema:
-            type: string
-      security:
-      - BearerAuth: []
-      summary: Bulk-replay events for a webhook
-      tags:
-      - Webhooks
-  /webhooks:
+        - account
+  /v1/agents:
     get:
-      description: Returns every webhook (enabled + disabled) owned by the caller.
-        signing_secret is omitted.
-      produces:
-      - application/json
+      description: List the agents owned by the authenticated account.
+      operationId: listAgents
       responses:
         "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListAgentsOutputBody"
           description: OK
-          schema:
-            $ref: '#/definitions/ListWebhooksResponse'
-        "401":
-          description: Unauthorized
-          schema:
-            type: string
-        "429":
-          description: Rate limited
-          schema:
-            type: string
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
       security:
-      - BearerAuth: []
-      summary: List webhook subscribers
+        - bearer: []
+      summary: List agents
       tags:
-      - webhooks
+        - agents
     post:
-      consumes:
-      - application/json
-      description: Creates a top-level webhook subscriber. The plaintext signing_secret
-        is returned ONCE in this response and never echoed by any later GET. URL must
-        be HTTPS and must resolve to a public IP. Per-user cap defaults to 50.
-      parameters:
-      - description: Webhook spec
-        in: body
-        name: body
+      description: Register an agent on a verified domain the caller owns (or, when slug registration is enabled, on the shared domain).
+      operationId: createAgent
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateAgentRequest"
         required: true
-        schema:
-          $ref: '#/definitions/CreateWebhookRequest'
-      produces:
-      - application/json
       responses:
         "201":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CreateAgentResponse"
           description: Created
-          schema:
-            $ref: '#/definitions/WebhookResponse'
-        "400":
-          description: validation error or cap reached
-          schema:
-            type: string
-        "401":
-          description: Unauthorized
-          schema:
-            type: string
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
       security:
-      - BearerAuth: []
-      summary: Create webhook subscriber
+        - bearer: []
+      summary: Create an agent
       tags:
-      - webhooks
-  /webhooks/{id}:
+        - agents
+  /v1/agents/{address}:
     delete:
-      description: Removes the webhook and cascades pending deliveries.
+      description: Delete an agent the caller owns.
+      operationId: deleteAgent
       parameters:
-      - description: Webhook ID
-        in: path
-        name: id
+        - description: The agent's full email address, e.g. support@acme.com.
+          in: path
+          name: address
+          required: true
+          schema:
+            description: The agent's full email address, e.g. support@acme.com.
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeleteAgentOutputBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+      security:
+        - bearer: []
+      summary: Delete an agent
+      tags:
+        - agents
+    get:
+      description: Fetch a single agent the authenticated account owns, by full email address.
+      operationId: getAgent
+      parameters:
+        - description: The agent's full email address, e.g. support@acme.com.
+          in: path
+          name: address
+          required: true
+          schema:
+            description: The agent's full email address, e.g. support@acme.com.
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentView"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+      security:
+        - bearer: []
+      summary: Get an agent
+      tags:
+        - agents
+    patch:
+      description: Patch an agent's HITL settings. Returns the post-update agent.
+      operationId: updateAgent
+      parameters:
+        - in: path
+          name: address
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateAgentRequest"
         required: true
-        type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentView"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+      security:
+        - bearer: []
+      summary: Update an agent
+      tags:
+        - agents
+  /v1/agents/{address}/conversations:
+    get:
+      description: List an agent's conversation threads (derived from messages.conversation_id).
+      operationId: listConversations
+      parameters:
+        - in: path
+          name: address
+          required: true
+          schema:
+            type: string
+        - description: RFC3339.
+          explode: false
+          in: query
+          name: since
+          schema:
+            description: RFC3339.
+            type: string
+        - description: RFC3339.
+          explode: false
+          in: query
+          name: until
+          schema:
+            description: RFC3339.
+            type: string
+        - explode: false
+          in: query
+          name: limit
+          schema:
+            default: 100
+            format: int64
+            maximum: 200
+            minimum: 1
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PageConversationSummaryView"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+      security:
+        - bearer: []
+      summary: List conversations
+      tags:
+        - conversations
+  /v1/agents/{address}/conversations/{id}:
+    get:
+      description: Fetch a single conversation thread with its participants, labels, and member messages.
+      operationId: getConversation
+      parameters:
+        - in: path
+          name: address
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConversationDetailView"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+      security:
+        - bearer: []
+      summary: Get a conversation
+      tags:
+        - conversations
+  /v1/agents/{address}/messages:
+    get:
+      description: List an agent's messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_approval.
+      operationId: listMessages
+      parameters:
+        - in: path
+          name: address
+          required: true
+          schema:
+            type: string
+        - description: Defaults to inbound.
+          explode: false
+          in: query
+          name: direction
+          schema:
+            description: Defaults to inbound.
+            enum:
+              - inbound
+              - outbound
+              - all
+            type: string
+        - description: Inbound only. Defaults to unread for inbound, all otherwise.
+          explode: false
+          in: query
+          name: status
+          schema:
+            description: Inbound only. Defaults to unread for inbound, all otherwise.
+            enum:
+              - unread
+              - read
+              - all
+            type: string
+        - description: Defaults to desc (newest first).
+          explode: false
+          in: query
+          name: sort
+          schema:
+            description: Defaults to desc (newest first).
+            enum:
+              - asc
+              - desc
+            type: string
+        - description: Case-insensitive substring match on sender.
+          explode: false
+          in: query
+          name: from
+          schema:
+            description: Case-insensitive substring match on sender.
+            type: string
+        - description: Case-insensitive substring match on subject.
+          explode: false
+          in: query
+          name: subject_contains
+          schema:
+            description: Case-insensitive substring match on subject.
+            type: string
+        - explode: false
+          in: query
+          name: conversation_id
+          schema:
+            type: string
+        - description: Repeatable; AND-matched.
+          explode: false
+          in: query
+          name: labels
+          schema:
+            description: Repeatable; AND-matched.
+            items:
+              type: string
+            type:
+              - array
+              - "null"
+        - description: RFC3339; created_at >= since.
+          explode: false
+          in: query
+          name: since
+          schema:
+            description: RFC3339; created_at >= since.
+            type: string
+        - description: RFC3339; created_at < until.
+          explode: false
+          in: query
+          name: until
+          schema:
+            description: RFC3339; created_at < until.
+            type: string
+        - explode: false
+          in: query
+          name: cursor
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: limit
+          schema:
+            default: 50
+            format: int64
+            maximum: 100
+            minimum: 1
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PageMessageSummaryView"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+      security:
+        - bearer: []
+      summary: List messages
+      tags:
+        - messages
+    post:
+      description: Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_approval when the agent has HITL enabled. Honors Idempotency-Key.
+      operationId: sendMessage
+      parameters:
+        - in: path
+          name: address
+          required: true
+          schema:
+            type: string
+        - in: header
+          name: Idempotency-Key
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SendEmailRequest"
+          application/octet-stream:
+            schema:
+              contentMediaType: application/octet-stream
+              format: binary
+              type: string
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SendResultView"
+          description: OK
+        "202":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SendResultView"
+          description: Accepted — held for human approval (status=pending_approval).
+      security:
+        - bearer: []
+      summary: Send a new email
+      tags:
+        - messages
+  /v1/agents/{address}/messages/{id}:
+    get:
+      description: Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. Includes the raw message and inbound auth headers.
+      operationId: getMessage
+      parameters:
+        - description: The agent's full email address.
+          in: path
+          name: address
+          required: true
+          schema:
+            description: The agent's full email address.
+            type: string
+        - description: The message id, e.g. msg_abc123.
+          in: path
+          name: id
+          required: true
+          schema:
+            description: The message id, e.g. msg_abc123.
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MessageView"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+      security:
+        - bearer: []
+      summary: Get a message
+      tags:
+        - messages
+    patch:
+      description: Apply a labels delta (`add_labels` / `remove_labels`) to a message the caller owns; returns the post-update label set. Each list is capped at 50 entries; labels are lowercase `[a-z0-9:_-]+` up to 64 chars; the `e2a:` prefix is reserved for system labels. A message carries at most 100 labels. An empty delta is a read of the current labels.
+      operationId: updateMessage
+      parameters:
+        - in: path
+          name: address
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateMessageRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UpdateMessageResultView"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+      security:
+        - bearer: []
+      summary: Update a message (labels)
+      tags:
+        - messages
+  /v1/agents/{address}/messages/{id}/approve:
+    post:
+      description: Approve a pending_approval draft (with optional reviewer overrides) and send it. Honors Idempotency-Key (the approve triggers an SES send).
+      operationId: approveMessage
+      parameters:
+        - in: path
+          name: address
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - in: header
+          name: Idempotency-Key
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ApproveRequest"
+          application/octet-stream:
+            schema:
+              contentMediaType: application/octet-stream
+              format: binary
+              type: string
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApproveResultView"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+      security:
+        - bearer: []
+      summary: Approve a held message
+      tags:
+        - messages
+  /v1/agents/{address}/messages/{id}/forward:
+    post:
+      description: Forward an inbound message to new recipients; the original is quoted. 202 when held for HITL.
+      operationId: forwardMessage
+      parameters:
+        - in: path
+          name: address
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - in: header
+          name: Idempotency-Key
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ForwardRequest"
+          application/octet-stream:
+            schema:
+              contentMediaType: application/octet-stream
+              format: binary
+              type: string
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SendResultView"
+          description: OK
+        "202":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SendResultView"
+          description: Accepted — held for human approval (status=pending_approval).
+      security:
+        - bearer: []
+      summary: Forward a message
+      tags:
+        - messages
+  /v1/agents/{address}/messages/{id}/reject:
+    post:
+      description: Reject a pending_approval draft so it is never sent.
+      operationId: rejectMessage
+      parameters:
+        - in: path
+          name: address
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RejectInputBody"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RejectResultView"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+      security:
+        - bearer: []
+      summary: Reject a held message
+      tags:
+        - messages
+  /v1/agents/{address}/messages/{id}/reply:
+    post:
+      description: Reply to an inbound message; recipients/threading are derived from the original. 202 when held for HITL.
+      operationId: replyToMessage
+      parameters:
+        - in: path
+          name: address
+          required: true
+          schema:
+            type: string
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - in: header
+          name: Idempotency-Key
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ReplyRequest"
+          application/octet-stream:
+            schema:
+              contentMediaType: application/octet-stream
+              format: binary
+              type: string
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SendResultView"
+          description: OK
+        "202":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SendResultView"
+          description: Accepted — held for human approval (status=pending_approval).
+      security:
+        - bearer: []
+      summary: Reply to a message
+      tags:
+        - messages
+  /v1/agents/{address}/test:
+    post:
+      description: Send a platform test email to the agent's own address to confirm inbound delivery. 202 when held for HITL.
+      operationId: testAgent
+      parameters:
+        - description: The agent's full email address, e.g. support@acme.com.
+          in: path
+          name: address
+          required: true
+          schema:
+            description: The agent's full email address, e.g. support@acme.com.
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SendResultView"
+          description: OK
+        "202":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SendResultView"
+          description: Accepted — held for human approval (status=pending_approval).
+      security:
+        - bearer: []
+      summary: Send a test email to the agent's own address
+      tags:
+        - agents
+  /v1/domains:
+    get:
+      operationId: listDomains
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListDomainsOutputBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+      security:
+        - bearer: []
+      summary: List domains
+      tags:
+        - domains
+    post:
+      operationId: registerDomain
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RegisterDomainRequest"
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DomainView"
+          description: Created
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Conflict — the domain is already claimed by another account (code domain_taken).
+      security:
+        - bearer: []
+      summary: Register a domain
+      tags:
+        - domains
+  /v1/domains/{domain}:
+    delete:
+      operationId: deleteDomain
+      parameters:
+        - in: path
+          name: domain
+          required: true
+          schema:
+            type: string
       responses:
         "204":
-          description: No content
-        "401":
-          description: Unauthorized
-          schema:
-            type: string
-        "404":
-          description: Not found
-          schema:
-            type: string
+          description: No Content
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
       security:
-      - BearerAuth: []
-      summary: Delete webhook subscriber
+        - bearer: []
+      summary: Delete a domain
       tags:
-      - webhooks
+        - domains
     get:
+      operationId: getDomain
       parameters:
-      - description: Webhook ID
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/json
+        - in: path
+          name: domain
+          required: true
+          schema:
+            type: string
       responses:
         "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DomainView"
           description: OK
-          schema:
-            $ref: '#/definitions/WebhookResponse'
-        "401":
-          description: Unauthorized
-          schema:
-            type: string
-        "404":
-          description: Not found
-          schema:
-            type: string
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
       security:
-      - BearerAuth: []
-      summary: Get webhook subscriber
+        - bearer: []
+      summary: Get a domain
       tags:
-      - webhooks
+        - domains
     patch:
-      consumes:
-      - application/json
-      description: Partial update. Fields not present are unchanged. url / events
-        / filters are full-replace when present (no array-merge). Re-enable within
-        5 minutes of auto_disabled_at returns 409.
+      operationId: updateDomain
       parameters:
-      - description: Webhook ID
-        in: path
-        name: id
+        - in: path
+          name: domain
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateDomainRequest"
         required: true
-        type: string
-      - description: Patch body
-        in: body
-        name: body
-        required: true
-        schema:
-          $ref: '#/definitions/UpdateWebhookRequest'
-      produces:
-      - application/json
       responses:
         "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DomainView"
           description: OK
-          schema:
-            $ref: '#/definitions/WebhookResponse'
-        "400":
-          description: Validation error
-          schema:
-            type: string
-        "401":
-          description: Unauthorized
-          schema:
-            type: string
-        "404":
-          description: Not found
-          schema:
-            type: string
-        "409":
-          description: Re-enable cooldown
-          schema:
-            type: string
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
       security:
-      - BearerAuth: []
-      summary: Update webhook subscriber
+        - bearer: []
+      summary: Update a domain (set primary)
       tags:
-      - webhooks
-  /webhooks/{id}/deliveries:
+        - domains
+  /v1/domains/{domain}/verify:
+    post:
+      description: Probe the domain's published DNS and, when the verification TXT is present, mark it verified. Returns the per-record diagnostic; a missing TXT yields 412.
+      operationId: verifyDomain
+      parameters:
+        - in: path
+          name: domain
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VerifyDomainView"
+          description: OK
+        "412":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/VerifyDomainView"
+          description: Precondition Failed — the verification TXT record is not yet published.
+      security:
+        - bearer: []
+      summary: Verify a domain
+      tags:
+        - domains
+  /v1/events:
     get:
-      description: Returns the most recent delivery attempts for the webhook (capped
-        at 100). Optional status query restricts to pending|delivered|failed.
+      description: The webhook-event delivery log, filterable by type/agent/conversation/message and time range, with cursor pagination.
+      operationId: listEvents
       parameters:
-      - description: Webhook ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Page size (default 20, max 100)
-        in: query
-        name: limit
-        type: integer
-      - description: 'Filter by status: pending|delivered|failed'
-        in: query
-        name: status
-        type: string
-      produces:
-      - application/json
+        - explode: false
+          in: query
+          name: type
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: agent_id
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: conversation_id
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: message_id
+          schema:
+            type: string
+        - description: RFC3339.
+          explode: false
+          in: query
+          name: since
+          schema:
+            description: RFC3339.
+            type: string
+        - description: RFC3339.
+          explode: false
+          in: query
+          name: until
+          schema:
+            description: RFC3339.
+            type: string
+        - explode: false
+          in: query
+          name: cursor
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: limit
+          schema:
+            default: 50
+            format: int64
+            maximum: 200
+            minimum: 1
+            type: integer
       responses:
         "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PageEventJSON"
           description: OK
-          schema:
-            $ref: '#/definitions/ListWebhookDeliveriesResponse'
-        "400":
-          description: Bad query
-          schema:
-            type: string
-        "401":
-          description: Unauthorized
-          schema:
-            type: string
-        "404":
-          description: Not found
-          schema:
-            type: string
-        "429":
-          description: Rate limited
-          schema:
-            type: string
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
       security:
-      - BearerAuth: []
-      summary: List recent webhook deliveries
+        - bearer: []
+      summary: List events
       tags:
-      - webhooks
-  /webhooks/{id}/rotate-secret:
+        - events
+  /v1/events/{id}:
+    get:
+      operationId: getEvent
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EventJSON"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+      security:
+        - bearer: []
+      summary: Get an event
+      tags:
+        - events
+  /v1/events/{id}/redeliver:
     post:
-      description: Generates a new signing secret and moves the current one into a
-        24h grace window during which the worker dual-signs each delivery.
+      description: Re-enqueue webhook delivery for an event. With a webhook_id, replays to that subscriber; without, fans out to every originally-matched subscriber. Auto-deduplicated within a short window — receivers must dedup on event id.
+      operationId: redeliverEvent
       parameters:
-      - description: Webhook ID
-        in: path
-        name: id
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RedeliverEventInputBody"
         required: true
-        type: string
-      produces:
-      - application/json
       responses:
         "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RedeliverView"
           description: OK
-          schema:
-            $ref: '#/definitions/RotateWebhookSecretResponse'
-        "401":
-          description: Unauthorized
-          schema:
-            type: string
-        "404":
-          description: Not found
-          schema:
-            type: string
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
       security:
-      - BearerAuth: []
-      summary: Rotate webhook signing secret
+        - bearer: []
+      summary: Redeliver an event
       tags:
-      - webhooks
-  /webhooks/{id}/test:
+        - events
+  /v1/info:
+    get:
+      description: "Public deployment metadata: the shared agent domain (if slug registration is enabled) and the public base URL. Unauthenticated."
+      operationId: getInfo
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeploymentInfoView"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+      summary: Deployment info
+      tags:
+        - meta
+  /v1/webhooks:
+    get:
+      operationId: listWebhooks
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ListWebhooksOutputBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+      security:
+        - bearer: []
+      summary: List webhooks
+      tags:
+        - webhooks
     post:
-      consumes:
-      - application/json
-      description: Schedules a one-off delivery to the webhook with a synthetic envelope,
-        bypassing filter matching. Returns the delivery_id so the caller can correlate
-        it in /deliveries. Returns 409 when the webhook is disabled.
+      operationId: createWebhook
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateWebhookRequest"
+        required: true
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WebhookView"
+          description: Created
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+      security:
+        - bearer: []
+      summary: Create a webhook
+      tags:
+        - webhooks
+  /v1/webhooks/{id}:
+    delete:
+      operationId: deleteWebhook
       parameters:
-      - description: Webhook ID
-        in: path
-        name: id
-        required: true
-        type: string
-      - description: Synthetic event
-        in: body
-        name: body
-        required: true
-        schema:
-          $ref: '#/definitions/TestWebhookRequest'
-      produces:
-      - application/json
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: No Content
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+      security:
+        - bearer: []
+      summary: Delete a webhook
+      tags:
+        - webhooks
+    get:
+      operationId: getWebhook
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
       responses:
         "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WebhookView"
           description: OK
-          schema:
-            $ref: '#/definitions/TestWebhookResponse'
-        "400":
-          description: Bad request
-          schema:
-            type: string
-        "401":
-          description: Unauthorized
-          schema:
-            type: string
-        "404":
-          description: Not found
-          schema:
-            type: string
-        "409":
-          description: Webhook disabled
-          schema:
-            type: string
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
       security:
-      - BearerAuth: []
-      summary: Fire a synthetic webhook event for development
+        - bearer: []
+      summary: Get a webhook
       tags:
-      - webhooks
-securityDefinitions:
-  BearerAuth:
-    description: 'API key from the API Keys page (starts with `e2a_`). Format: `Bearer
-      e2a_your_key`'
-    in: header
-    name: Authorization
-    type: apiKey
-swagger: "2.0"
+        - webhooks
+    patch:
+      description: Partial update. url/events/filters are full-replace when present. Re-enabling within the auto-disable cooldown returns 409.
+      operationId: updateWebhook
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateWebhookRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WebhookView"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+      security:
+        - bearer: []
+      summary: Update a webhook
+      tags:
+        - webhooks
+  /v1/webhooks/{id}/deliveries:
+    get:
+      description: The per-webhook delivery log (read-only debug view).
+      operationId: listWebhookDeliveries
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - explode: false
+          in: query
+          name: status
+          schema:
+            enum:
+              - pending
+              - delivered
+              - failed
+            type: string
+        - explode: false
+          in: query
+          name: limit
+          schema:
+            default: 50
+            format: int64
+            maximum: 100
+            minimum: 1
+            type: integer
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PageWebhookDeliveryView"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+      security:
+        - bearer: []
+      summary: List webhook deliveries
+      tags:
+        - webhooks
+  /v1/webhooks/{id}/rotate-secret:
+    post:
+      description: Mint a new signing secret; the previous one stays valid for a 24h grace window. Returns the new secret (shown once).
+      operationId: rotateWebhookSecret
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RotateSecretOutputBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+      security:
+        - bearer: []
+      summary: Rotate a webhook signing secret
+      tags:
+        - webhooks
+  /v1/webhooks/{id}/test:
+    post:
+      description: Schedule a one-off synthetic delivery to this webhook for development. Returns the delivery id.
+      operationId: testWebhook
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/TestWebhookRequest"
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TestWebhookOutputBody"
+          description: OK
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error
+      security:
+        - bearer: []
+      summary: Fire a synthetic event
+      tags:
+        - webhooks
+servers:
+  - description: Production
+    url: https://api.e2a.dev

--- a/web/src/app/(app)/webhook-secrets/page.tsx
+++ b/web/src/app/(app)/webhook-secrets/page.tsx
@@ -144,9 +144,8 @@ export default function WebhooksPage() {
       subtitle={
         <>
           <span style={{ display: "block" }}>
-            <strong style={{ color: "var(--fg)" }}>For cloud agents only.</strong>{" "}
-            When your agent runs behind a webhook
-            (<code style={inlineCodeStyle}>agent_mode=cloud</code>), e2a
+            <strong style={{ color: "var(--fg)" }}>For webhook delivery.</strong>{" "}
+            When your agent receives mail via a webhook subscription, e2a
             HMAC-signs every payload it POSTs to the endpoint with that
             webhook&apos;s signing secret so your handler can confirm the
             request really came from e2a.
@@ -154,7 +153,8 @@ export default function WebhooksPage() {
           <span style={{ display: "block", marginTop: 10 }}>
             The signing secret is shown <strong style={{ color: "var(--fg)" }}>once</strong>{" "}
             when you create or rotate a webhook — copy it then. Pass it to{" "}
-            <code style={inlineCodeStyle}>verify_signature()</code> in the
+            <code style={inlineCodeStyle}>constructEvent()</code> /{" "}
+            <code style={inlineCodeStyle}>construct_event()</code> in the
             SDK to validate. Rotation keeps the previous secret valid for a
             short overlap so you can swap it in without dropping deliveries.
           </span>
@@ -364,7 +364,7 @@ function RevealedSecretBanner({
             borderRadius: "var(--r-sm)",
           }}
         >
-          E2A_HMAC_SECRET
+          E2A_WEBHOOK_SECRET
         </code>
         ).
       </p>

--- a/web/src/app/blog/email-agent-with-google-adk/page.mdx
+++ b/web/src/app/blog/email-agent-with-google-adk/page.mdx
@@ -43,7 +43,7 @@ The whole webhook is ~30 lines of business logic. ADK does the memory work; e2a 
 ## Prerequisites
 
 - Python 3.10+
-- A free e2a account at [e2a.dev](https://e2a.dev) — you'll register a **cloud-mode** agent (one that receives mail via HTTPS webhook, not WebSocket).
+- A free e2a account at [e2a.dev](https://e2a.dev) — you'll register an agent and subscribe a **webhook** so it receives mail via HTTPS POST (rather than a WebSocket stream).
 - A Google AI Studio API key — [aistudio.google.com/apikey](https://aistudio.google.com/apikey).
 - [ngrok](https://ngrok.com/) or [cloudflared](https://github.com/cloudflare/cloudflared) for exposing the local webhook during development.
 
@@ -57,11 +57,11 @@ pip install -e .
 cp .env.example .env
 ```
 
-The `pyproject.toml` pulls in `google-adk>=1.31`, `e2a>=1.4`, and FastAPI. Edit `.env` with your three secrets when prompted.
+The `pyproject.toml` pulls in `google-adk>=1.31`, `e2a>=3.0`, and FastAPI. Edit `.env` with your three secrets when prompted.
 
-## Step 2: Register a cloud-mode agent
+## Step 2: Register the agent
 
-In the e2a dashboard, register an agent with `agent_mode: cloud`. You'll get an email address (e.g. `assistant@agents.e2a.dev`) and an API key. The webhook URL field can stay empty for now — we'll fill it in once we have a public URL.
+In the e2a dashboard (or `POST /v1/agents`), register an agent. You'll get an email address (e.g. `assistant@agents.e2a.dev`) and an API key. There's no cloud-vs-local "mode" — whether the agent receives over a webhook or a WebSocket is just a delivery choice you make next. We'll subscribe a webhook once we have a public URL.
 
 ## Step 3: Run the webhook locally
 
@@ -83,14 +83,16 @@ ngrok http 18080
 # Forwarding  https://abc123.ngrok.io -> http://localhost:18080
 ```
 
-Set that public URL on your agent (replace `<EMAIL>` and `<API_KEY>`; the `@` in `EMAIL` must be URL-encoded as `%40`):
+Subscribe a webhook at that public URL (replace `<API_KEY>`). Webhooks are an account-level resource — one subscription can fan out to every agent you own, filtered by event type:
 
 ```bash
-curl -X PATCH "https://e2a.dev/v1/agents/assistant%40agents.e2a.dev" \
+curl -X POST "https://api.e2a.dev/v1/webhooks" \
   -H "Authorization: Bearer <API_KEY>" \
   -H "Content-Type: application/json" \
-  -d '{"webhook_url":"https://abc123.ngrok.io/webhook"}'
+  -d '{"url":"https://abc123.ngrok.io/webhook","events":["email.received"]}'
 ```
+
+The response includes a signing secret (`whsec_...`). Save it as `E2A_WEBHOOK_SECRET` — you'll verify each delivery against it below.
 
 ## Step 5: Send the first email
 
@@ -137,7 +139,7 @@ session = sessions.create_session(..., session_id=conv_<random>)
 runner.run_async(...)                       # ADK records turn 1
         │
         v
-email.reply(text, conversation_id=conv_<random>)
+client.messages.reply(addr, msg_id, {"body": text, "conversation_id": conv_<random>})
         │       e2a stamps X-E2A-Conversation-Id on the outbound
         v
 ... human replies in their mail client ...
@@ -155,7 +157,7 @@ runner.run_async(...)                       # ADK has full prior context
 The webhook does the binding in two lines:
 
 ```python
-conversation_id = email.conversation_id or f"conv_{uuid.uuid4().hex[:12]}"
+conversation_id = msg.get("conversation_id") or f"conv_{uuid.uuid4().hex[:12]}"
 
 session = await sessions.get_session(app_name=APP_NAME, user_id=user_id, session_id=conversation_id)
 if session is None:
@@ -166,21 +168,29 @@ That's it. Any agent framework that lets you supply your own session ID can be w
 
 ## Always verify the HMAC
 
-The first thing the webhook does after parsing the payload is:
+The first thing the webhook does — before reading anything off the payload — is verify the signature with `construct_event`, passing the **raw** request body:
 
 ```python
-if not email.verify_signature(HMAC_SECRET):
+from e2a.v1 import construct_event
+from e2a.v1.errors import E2AWebhookSignatureError
+
+raw = await request.body()
+try:
+    event = construct_event(raw, request.headers["X-E2A-Signature"], E2A_WEBHOOK_SECRET)
+except E2AWebhookSignatureError:
     raise HTTPException(status_code=401, detail="bad signature")
+
+msg = event.data  # the verified inbound message payload
 ```
 
-This isn't optional. Anyone on the internet can POST to your public webhook URL — the HMAC signature is what proves the payload came from your e2a relay and not from someone trying to inject a fake email into your agent's session. If you skip the verify, every claim on the payload (sender, recipient, message id, body) becomes attacker-controlled. The SDK's `verify_signature` checks the HMAC against the body hash and rejects replays older than 5 minutes, all in one call.
+This isn't optional. Anyone on the internet can POST to your public webhook URL — the HMAC signature is what proves the payload came from your e2a relay and not from someone trying to inject a fake email into your agent's session. If you skip the verify, every claim on the payload (sender, recipient, message id, body) becomes attacker-controlled. `construct_event` checks the HMAC over `{timestamp}.{raw_body}`, rejects replays older than 5 minutes, and parses the verified envelope — all in one call. Pass the raw bytes; re-serializing parsed JSON changes the whitespace and the signature won't match.
 
 ## What this example deliberately doesn't show
 
 - **Persistence + multi-worker safety.** `InMemorySessionService` loses everything on restart. It also lives in *one* Python process — running `uvicorn ... --workers 4` shards sessions per-worker. For anything beyond the demo, use `DatabaseSessionService` (Postgres / SQLite) — see [ADK sessions docs](https://adk.dev/sessions/session/).
 - **Tools.** The agent has no tools — just text generation. Add them in `agent.py` once the email loop works.
-- **Attachments.** `email.attachments` is exposed by the SDK but ignored here. ADK's `Content` supports inline data parts if you want to feed PDFs or images to a vision model.
-- **Human-in-the-loop.** The agent replies immediately. If you want approval before each outbound, [enable HITL on the agent](/blog/human-in-the-loop-for-agent-email) and the `email.reply()` call returns 202 with the message held for review.
+- **Attachments.** The fetched `MessageView.attachments` are exposed by the SDK but ignored here. ADK's `Content` supports inline data parts if you want to feed PDFs or images to a vision model.
+- **Human-in-the-loop.** The agent replies immediately. If you want approval before each outbound, [enable HITL on the agent](/blog/human-in-the-loop-for-agent-email) and the `client.messages.reply(...)` call returns 202 with the message held for review.
 
 ## What to build next
 

--- a/web/src/app/blog/email-for-openclaw-agents/page.mdx
+++ b/web/src/app/blog/email-for-openclaw-agents/page.mdx
@@ -55,14 +55,14 @@ e2a login
 
 `e2a login` opens a browser, drops you through OAuth, and writes your API key to `~/.e2a/config.json`. That's the only setup the CLI needs.
 
-## Step 2: Register a local-mode agent
+## Step 2: Register the agent
 
 ```bash
 e2a agents register research
-# → Registered: research@agents.e2a.dev (agent_mode=local)
+# → Registered: research@agents.e2a.dev
 ```
 
-The slug becomes the local-part of your agent's address. `local` mode tells e2a to hold mail server-side and push it over WebSocket when your listener connects, instead of POSTing to a webhook URL. That's what keeps the whole setup public-URL-free.
+The slug becomes the local-part of your agent's address. There's no cloud-vs-local "mode" — webhook vs WebSocket is just a delivery choice. Here we never subscribe a webhook; instead `e2a listen` opens a WebSocket, so e2a holds mail server-side and pushes it down the stream when your listener connects. That's what keeps the whole setup public-URL-free.
 
 ## Step 3: Grab your OpenClaw gateway token
 

--- a/web/src/app/blog/send-email-from-python-agent/page.mdx
+++ b/web/src/app/blog/send-email-from-python-agent/page.mdx
@@ -42,18 +42,20 @@ pip install e2a
 
 ## Send an email
 
-Three lines:
+The SDK is async-only. A few lines:
 
 ```python
 from e2a.v1 import E2AClient
 
-client = E2AClient(api_key="e2a_...")
-
-client.send(
-    to=["alice@example.com"],
-    subject="Quick question",
-    body="Hi Alice — I'm your scheduling assistant. Got a second for a quick sync?",
-)
+async with E2AClient(api_key="e2a_...") as client:
+    await client.messages.send(
+        "research-assistant@agents.e2a.dev",
+        {
+            "to": ["alice@example.com"],
+            "subject": "Quick question",
+            "body": "Hi Alice — I'm your scheduling assistant. Got a second for a quick sync?",
+        },
+    )
 ```
 
 That's it. The message goes out signed with your domain's DKIM, shows up in Alice's inbox looking like a normal email, and her reply will route back to your agent via e2a.
@@ -62,62 +64,77 @@ That's it. The message goes out signed with your domain's DKIM, shows up in Alic
 
 Two modes, depending on whether your agent has a public URL:
 
-**Cloud mode (webhook)** — when Alice replies, e2a POSTs the email to your server:
+**Webhook delivery** — subscribe a webhook (`POST /v1/webhooks`), and when Alice replies, e2a POSTs the signed event to your server. Verify the signature with `construct_event` (it raises on a bad signature or a replay):
 
 ```python
+from e2a.v1 import E2AClient, construct_event
+
 @app.post("/webhook")
 async def inbox(request):
-    email = client.parse(await request.body())
-    print(f"{email.sender}: {email.subject}")
-    await email.reply(f"Got it. Does Thursday 2pm work?")
+    raw = await request.body()
+    event = construct_event(raw, request.headers["X-E2A-Signature"], WEBHOOK_SECRET)
+    msg = event.data
+    print(f"{msg['from']}: {msg['subject']}")
+    async with E2AClient(api_key="e2a_...") as client:
+        await client.messages.reply(
+            msg["recipient"], msg["message_id"], {"body": "Got it. Does Thursday 2pm work?"}
+        )
     return {"ok": True}
 ```
 
-**Local mode (WebSocket)** — no public URL needed. Great for running agents on your laptop or behind a firewall:
+**WebSocket delivery** — no public URL needed. Great for running agents on your laptop or behind a firewall:
 
 ```python
-from e2a.v1 import AsyncE2AClient
+from e2a.v1 import E2AClient
 
-async with AsyncE2AClient(api_key="e2a_...") as client:
-    async for email in client.listen("research-assistant@agents.e2a.dev"):
-        print(f"{email.sender}: {email.subject}")
-        await email.reply("Got it, on it.")
+async with E2AClient(api_key="e2a_...") as client:
+    async for notif in client.listen("research-assistant@agents.e2a.dev"):
+        msg = await client.messages.get(notif.recipient, notif.message_id)
+        print(f"{notif.from_}: {notif.subject}")
+        await client.messages.reply(notif.recipient, notif.message_id, {"body": "Got it, on it."})
 ```
 
-`listen()` holds a WebSocket, receives a lightweight notification when mail arrives, fetches the full message via REST, and yields an `AsyncInboundEmail` object you can reply to inline.
+`listen()` holds a WebSocket and yields a lightweight `WSNotification` when mail arrives (message_id, from_, subject, conversation_id). Fetch the full body with `client.messages.get(...)` and respond with `client.messages.reply(...)`.
 
 ## Thread conversations across turns
 
 Multi-turn threading is the difference between an agent that sends isolated emails and one that maintains context. Pass `conversation_id` on each outbound and you'll see it back on subsequent inbounds in the same thread:
 
 ```python
-async for email in client.listen("research-assistant@agents.e2a.dev"):
-    convo_id = email.conversation_id or new_id()
+async for notif in client.listen("research-assistant@agents.e2a.dev"):
+    convo_id = notif.conversation_id or new_id()
 
-    draft = await compose_reply(email, history=load_history(convo_id))
-    await email.reply(draft, conversation_id=convo_id)
+    msg = await client.messages.get(notif.recipient, notif.message_id)
+    draft = await compose_reply(msg, history=load_history(convo_id))
+    await client.messages.reply(
+        notif.recipient, notif.message_id, {"body": draft, "conversation_id": convo_id}
+    )
 ```
 
 Works across humans replying from Gmail and other e2a agents replying via the platform. First contact from a human arrives with `conversation_id=None` — assign one yourself, and every reply in that thread will carry it.
 
 ## Verify the sender
 
-Every inbound includes signed auth headers showing SPF/DKIM results. Use them to decide how much to trust the message:
+Inbound messages carry SPF/DKIM results so you can decide how much to trust them, and webhook deliveries are signed end-to-end. Always verify the signature on a webhook before acting on the payload — `construct_event` does it for you and raises on a bad signature or a replay older than five minutes:
 
 ```python
-if email.is_verified:
-    # SPF/DKIM passed; sender domain is authenticated
-    handle(email)
-else:
-    # Could be a spoof — route to quarantine or ask for confirmation
-    flag_for_review(email)
+from e2a.v1 import E2AClient, construct_event
+from e2a.v1.errors import E2AWebhookSignatureError
+
+try:
+    event = construct_event(raw_body, signature_header, WEBHOOK_SECRET)
+except E2AWebhookSignatureError:
+    # Could be a spoof — reject it
+    return Response(status_code=401)
+
+handle(event)
 ```
 
-The signature is HMAC-SHA256 over a canonical string; you can verify it yourself against your webhook secret if you want defense in depth.
+The signature is HMAC-SHA256 over `{timestamp}.{raw_body}`, keyed by your webhook's signing secret (`whsec_...`).
 
 ## What you can build from here
 
-The three primitives — `send`, `listen`/webhook, and `conversation_id` threading — cover most agent-in-your-inbox use cases. A few ideas:
+The three primitives — `messages.send`, `listen`/webhook, and `conversation_id` threading — cover most agent-in-your-inbox use cases. A few ideas:
 
 - A scheduling assistant that you CC on meeting threads; it coordinates with the other side and books calendar holds.
 - A customer-support triage agent that handles first replies and escalates to humans when confidence drops.

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useState } from "react";
 import { useAuth } from "./components/AuthProvider";
 import { Eyebrow } from "./components/loft/Eyebrow";
-import { SITE_URL, AGENTS_DOMAIN } from "../lib/site";
+import { AGENTS_DOMAIN } from "../lib/site";
 
 type Tab = "cli" | "claude" | "python" | "webhook";
 
@@ -556,31 +556,38 @@ export default function Home() {
             {activeTab === "python" && (
               <>
                 <Line>
-                  <Tok c="keyword">from</Tok> e2a.v1 <Tok c="keyword">import</Tok> AsyncE2AClient
+                  <Tok c="keyword">from</Tok> e2a.v1 <Tok c="keyword">import</Tok> E2AClient
                 </Line>
                 <Line>&nbsp;</Line>
+                <Line c="comment"># conversation_id threads multi-turn replies</Line>
                 <Line>
-                  client = <Tok c="fn">AsyncE2AClient</Tok>(api_key=<Tok c="string">&quot;e2a_…&quot;</Tok>)
-                </Line>
-                <Line>&nbsp;</Line>
-                <Line c="comment"># sender identity verified; conversation_id threads multi-turn replies</Line>
-                <Line>
-                  <Tok c="keyword">async for</Tok> msg <Tok c="keyword">in</Tok> client.<Tok c="fn">listen</Tok>(<Tok c="string">{`"my-agent@${exampleAgentDomain}"`}</Tok>):
+                  <Tok c="keyword">async with</Tok> <Tok c="fn">E2AClient</Tok>(api_key=<Tok c="string">&quot;e2a_…&quot;</Tok>) <Tok c="keyword">as</Tok> client:
                 </Line>
                 <Line>
-                  &nbsp;&nbsp;<Tok c="fn">print</Tok>(msg.is_verified, msg.subject, msg.conversation_id)
+                  &nbsp;&nbsp;<Tok c="keyword">async for</Tok> n <Tok c="keyword">in</Tok> client.<Tok c="fn">listen</Tok>(<Tok c="string">{`"my-agent@${exampleAgentDomain}"`}</Tok>):
                 </Line>
                 <Line>
-                  &nbsp;&nbsp;<Tok c="keyword">await</Tok> msg.<Tok c="fn">reply</Tok>(<Tok c="string">&quot;Got it, on it.&quot;</Tok>, conversation_id=msg.conversation_id)
+                  &nbsp;&nbsp;&nbsp;&nbsp;msg = <Tok c="keyword">await</Tok> client.messages.<Tok c="fn">get</Tok>(n.recipient, n.message_id)
+                </Line>
+                <Line>
+                  &nbsp;&nbsp;&nbsp;&nbsp;<Tok c="fn">print</Tok>(msg.subject, n.conversation_id)
+                </Line>
+                <Line>
+                  &nbsp;&nbsp;&nbsp;&nbsp;<Tok c="keyword">await</Tok> client.messages.<Tok c="fn">reply</Tok>(n.recipient, n.message_id, {`{`}<Tok c="string">&quot;body&quot;</Tok>: <Tok c="string">&quot;Got it, on it.&quot;</Tok>{`}`})
                 </Line>
               </>
             )}
             {activeTab === "webhook" && (
               <>
-                <Line c="comment"># register a cloud agent with a webhook URL</Line>
-                <Line>curl -X POST {SITE_URL}/v1/agents \</Line>
+                <Line c="comment"># 1. create the agent</Line>
+                <Line>curl -X POST https://api.e2a.dev/v1/agents \</Line>
                 <Line>&nbsp;&nbsp;-H <Tok c="string">{`"Authorization: Bearer $E2A_API_KEY"`}</Tok> \</Line>
-                <Line>&nbsp;&nbsp;-d <Tok c="string">{`'{"slug":"my-agent","webhook_url":"https://your-app.com/inbox"}'`}</Tok></Line>
+                <Line>&nbsp;&nbsp;-d <Tok c="string">{`'{"slug":"my-agent"}'`}</Tok></Line>
+                <Line>&nbsp;</Line>
+                <Line c="comment"># 2. subscribe a webhook to receive inbound mail</Line>
+                <Line>curl -X POST https://api.e2a.dev/v1/webhooks \</Line>
+                <Line>&nbsp;&nbsp;-H <Tok c="string">{`"Authorization: Bearer $E2A_API_KEY"`}</Tok> \</Line>
+                <Line>&nbsp;&nbsp;-d <Tok c="string">{`'{"url":"https://your-app.com/inbox","events":["email.received"]}'`}</Tok></Line>
                 <Line>&nbsp;</Line>
                 <Line c="comment"># e2a POSTs verified payloads to your endpoint with HMAC signature</Line>
               </>


### PR DESCRIPTION
A thorough audit (5 parallel auditors across every doc surface — core docs, SDK/CLI/MCP, web marketing/blog, the dashboard's API reference, and the design docs) found widespread drift vs the shipped `/v1` agent-scoped redesign + 3.0 SDK. This fixes all **documentation** findings. (The MCP *tool-interface* code issues it surfaced are deferred to a separate round.)

## Highest-impact
- **API-reference page was publicly serving a dead spec.** `web/public/openapi.yaml` was a frozen Swagger-2.0 `/api/v1` dump (localhost host; deleted signing-secrets/redeliver-since/flat-messages/pending). Now it's a copy of the live `api/openapi.yaml` (3.1), kept fresh by a web `sync-openapi` prebuild; the dead `swagger`/`swagger-check` Makefile targets + the last 2 stale `@Router` stubs are retired.
- **Systemic pre-3.0 SDK examples** (`AsyncE2AClient`, `client.send`, `client.parse`, `parseWebhook`, `email.reply`/`verify_signature`) on the landing page + 3 blog posts + SKILL.md + adk example + mcp README → the real async-only `E2AClient` + `client.messages.*` + `construct_event`.
- **`web/public/auth.md`** was entirely on `/api/v1` (incl. a `send` with a `from` body).
- **Dropped agent-create fields** (`agent_mode`/`webhook_url`, migration 029) → create-agent + `/v1/webhooks` subscription.

## Also fixed
README retention 30→**10 days**; `/users/me/*`→`/v1/account`; `events.md` pagination (`page_size`/`token`/`next_token`→`limit`/`cursor`/`next_cursor`/`items`, max 200) + dead `webhooks.md` link; CLI README WS URL + missing commands; tool counts "18/11"→**33**; `webhook-secrets` banner env var `E2A_HMAC_SECRET`→`E2A_WEBHOOK_SECRET`; Python `CHANGELOG` 3.0 entry; spec pointers → `api/openapi.yaml`; CONTRIBUTING swag→spec pipeline.

## Design docs reconciled
Added an authoritative **as-built banner** to `api-v1-redesign.md` (§13 + `api/openapi.yaml` are the truth), fixed the worst self-contradicting passages (decision-5 status, §8 gap-table rows, §11 snapshot), narrowed §13's "MCP cut over" to the transport layer (tool re-curation still pending), and stamped the 3 satellite design docs as shipped/superseded.

## Verification
- `go build ./...` clean; spec drift gate green; `web/public/openapi.yaml` == `api/openapi.yaml`.
- Residual scan: zero `/api/v1` or pre-3.0 flat-SDK references in user-facing docs/web/examples.
- The three doc-fix passes were each followed by a residual-grep + typecheck.

## Deferred (your note)
The MCP **tool interface** (`create_agent` still sends the dropped `agent_mode`/`webhook_url`; old tool names; `E2A_AGENT_EMAIL` auto-resolve) — a separate round; its tool-facing docs were left in lockstep with the current tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)