### PR TITLE
SECURITY: resolve OAuth token scope (CRITICAL) + enforce WebSocket agent confinement (HIGH)

### DIFF
--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -675,13 +675,7 @@ func (a *API) authenticatePrincipal(r *http.Request) (*identity.Principal, error
 			return p, nil
 		}
 		if strings.HasPrefix(bearer, oauth.AccessTokenPrefix) {
-			u, err := a.lookupUserByOAuthToken(r, bearer)
-			if err != nil {
-				return nil, err
-			}
-			// OAuth (fosite) access tokens are account-scoped until they carry
-			// scope claims. Until then they behave as today.
-			return &identity.Principal{User: u, Scope: identity.ScopeAccount}, nil
+			return a.principalFromOAuthToken(r, bearer)
 		}
 		return a.store.GetPrincipalByAPIKey(r.Context(), bearer)
 	}
@@ -694,14 +688,26 @@ func (a *API) authenticatePrincipal(r *http.Request) (*identity.Principal, error
 	return nil, fmt.Errorf("authorization required")
 }
 
-// lookupUserByOAuthToken validates an ate2a_-prefixed bearer via
-// fosite's IntrospectToken (which derives the signature using the
-// same strategy that issued the token, looks up the row via our
-// Storage, and checks revoked/expired). On success we read the
-// e2a-specific user_id from the session and resolve to the user
-// record. Every failure mode wraps errOAuthBearerInvalid so the
-// response layer reliably classifies these as OAuth-bearer rejections.
-func (a *API) lookupUserByOAuthToken(r *http.Request, bearer string) (*identity.User, error) {
+// principalFromOAuthToken validates an ate2a_-prefixed bearer via fosite's
+// IntrospectToken (which derives the signature using the same strategy that
+// issued the token, looks up the row via our Storage, and checks
+// revoked/expired) and resolves it to a SCOPED principal.
+//
+// The granted OAuth scope is authoritative — it is read, never assumed.
+// (CRITICAL-1 fix: this path previously hardcoded every OAuth token to
+// ScopeAccount, which defeated the public-DCR `scope=agent` cap
+// (oauth_handlers.go) and silently handed agent-tier MCP tokens full
+// account-wide admin.) Resolution:
+//   - granted `account` → account-wide admin. Only reachable via a
+//     console-issued / confidential client; public DCR can never obtain it.
+//   - granted `agent`   → confined to the consent-bound agent
+//     (session.AgentEmail), with ownership re-checked, mirroring the REST
+//     resolveOwnedAgent pin and the JWT resolveAgentAccessToken path.
+//   - neither           → fail closed (reject), never a silent elevation.
+//
+// Every failure wraps errOAuthBearerInvalid so the response layer reliably
+// classifies these as OAuth-bearer rejections and emits the OAuth challenge.
+func (a *API) principalFromOAuthToken(r *http.Request, bearer string) (*identity.Principal, error) {
 	if a.oauthProvider == nil {
 		// OAuth not enabled on this deployment. Fail closed rather
 		// than fall through to the API-key path (which would compare
@@ -738,7 +744,33 @@ func (a *API) lookupUserByOAuthToken(r *http.Request, bearer string) (*identity.
 		// row vanished out from under it).
 		return nil, fmt.Errorf("%w: user lookup: %v", errOAuthBearerInvalid, err)
 	}
-	return u, nil
+
+	granted := ar.GetGrantedScopes()
+	switch {
+	case granted.Has(identity.ScopeAccount):
+		return &identity.Principal{User: u, Scope: identity.ScopeAccount}, nil
+	case granted.Has(identity.ScopeAgent):
+		// Confine to the consent-bound agent. An agent-scoped token with no
+		// bound agent is malformed — reject rather than fall back to anything
+		// broader.
+		if sess.AgentEmail == "" {
+			return nil, fmt.Errorf("%w: agent-scoped token has no bound agent", errOAuthBearerInvalid)
+		}
+		ag, err := a.store.GetAgentByEmail(r.Context(), identity.NormalizeEmail(sess.AgentEmail))
+		if err != nil || ag == nil {
+			return nil, fmt.Errorf("%w: bound agent not found", errOAuthBearerInvalid)
+		}
+		// Ownership re-check: the bound agent must still belong to the token's
+		// user (defends against an agent reassigned/deleted-and-recreated under
+		// a different owner after consent).
+		if ag.UserID != u.ID {
+			return nil, fmt.Errorf("%w: bound agent not owned by token user", errOAuthBearerInvalid)
+		}
+		return &identity.Principal{User: u, Scope: identity.ScopeAgent, AgentID: ag.ID}, nil
+	default:
+		// Fail closed: a token that carries no recognized scope gets no access.
+		return nil, fmt.Errorf("%w: token carries no recognized scope (%v)", errOAuthBearerInvalid, []string(granted))
+	}
 }
 
 // writeAuthError writes a 401 response with an RFC 6750 §3

--- a/internal/agent/oauth_bearer_test.go
+++ b/internal/agent/oauth_bearer_test.go
@@ -399,3 +399,105 @@ func TestBearer_OAuth_AgentScope_AllowedOnOwnTier(t *testing.T) {
 		t.Fatalf("agent-scoped OAuth token should authenticate on its own tier (/v1/account); got %d", status)
 	}
 }
+
+// seedOAuthClient inserts a public PKCE OAuth client registered with the given
+// scopes. Seeding directly bypasses the DCR /register cap (which forces
+// scope=agent on public clients) — this is how we simulate the console/
+// confidential issuance path that the design reserves for account scope, and
+// how we construct a token carrying a retired/unrecognized scope.
+func seedOAuthClient(t *testing.T, f *consentFixture, clientID string, scopes []string) {
+	t.Helper()
+	if _, err := f.pool.Exec(context.Background(), `
+		INSERT INTO oauth_clients
+		    (client_id, client_name, redirect_uris, grant_types,
+		     response_types, scopes, audiences, token_endpoint_auth_method,
+		     public, created_via)
+		VALUES ($1, 'scoped test client',
+		        ARRAY['http://localhost:8765/callback'],
+		        ARRAY['authorization_code','refresh_token'], ARRAY['code'],
+		        $2, ARRAY[]::TEXT[], 'none', TRUE, 'dcr')
+		ON CONFLICT (client_id) DO NOTHING
+	`, clientID, scopes); err != nil {
+		t.Fatalf("seedOAuthClient(%s): %v", clientID, err)
+	}
+}
+
+// mintAccessWithScope runs the authorize→consent→token flow for an explicit
+// client + scope (vs. mintTokensForFixture, which is hardwired to the fixture's
+// agent-scoped client). Returns the issued access token.
+func mintAccessWithScope(t *testing.T, f *consentFixture, clientID, scope string) string {
+	t.Helper()
+	verifier, challenge := newPKCE(t)
+
+	form := authorizeParams(challenge, clientID, "s2s2s2s2s2s2s2s2")
+	form.Set("scope", scope) // override the fixture's default "agent"
+	form.Set("action", "allow")
+	form.Set("agent_choice", "create_new")
+	form.Set("new_agent_slug", "scoped-"+randHex8(t))
+	resp := f.consentPOST(t, form)
+	defer resp.Body.Close()
+	loc, _ := url.Parse(resp.Header.Get("Location"))
+	code := loc.Query().Get("code")
+	if code == "" {
+		t.Fatalf("mintAccessWithScope: no code in redirect: %s", resp.Header.Get("Location"))
+	}
+
+	tokForm := url.Values{}
+	tokForm.Set("grant_type", "authorization_code")
+	tokForm.Set("code", code)
+	tokForm.Set("client_id", clientID)
+	tokForm.Set("redirect_uri", "http://localhost:8765/callback")
+	tokForm.Set("code_verifier", verifier)
+	tokResp, err := http.Post(f.server.URL+"/oauth2/token",
+		"application/x-www-form-urlencoded", strings.NewReader(tokForm.Encode()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tokResp.Body.Close()
+	if tokResp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(tokResp.Body)
+		t.Fatalf("mintAccessWithScope: /token status=%d body=%s", tokResp.StatusCode, b)
+	}
+	var body struct {
+		AccessToken string `json:"access_token"`
+	}
+	if err := json.NewDecoder(tokResp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	return body.AccessToken
+}
+
+// TestBearer_OAuth_AccountScope_AllowedOnAccountOp exercises the account branch
+// of the scope switch: a token granted `account` (console/confidential
+// issuance) resolves to ScopeAccount and CAN perform an account-admin op. The
+// counterpart to the agent-confinement regression — proves the fix grants
+// account power only to genuinely account-granted tokens.
+func TestBearer_OAuth_AccountScope_AllowedOnAccountOp(t *testing.T) {
+	f := newConsentFixture(t)
+	seedOAuthClient(t, f, "acct_client", []string{"account"})
+	access := mintAccessWithScope(t, f, "acct_client", "account")
+
+	// GET /v1/agents is account-scope-gated (requireAccountScope).
+	status, body := getWithBearer(t, f.server.URL, "/v1/agents", access)
+	if status != http.StatusOK {
+		t.Fatalf("account-scoped OAuth token should pass an account op, got %d (body=%s)", status, body)
+	}
+}
+
+// TestBearer_OAuth_UnknownScope_Rejected exercises the fail-closed default: a
+// token carrying a retired/unrecognized scope (legacy `mcp`) must be REJECTED
+// (401), never silently elevated. Guards against the retired scope quietly
+// regaining access if the switch's default branch ever regresses.
+func TestBearer_OAuth_UnknownScope_Rejected(t *testing.T) {
+	f := newConsentFixture(t)
+	seedOAuthClient(t, f, "legacy_mcp_client", []string{"mcp"})
+	access := mintAccessWithScope(t, f, "legacy_mcp_client", "mcp")
+
+	status, wa := callAPIWithBearer(t, f.server.URL, access) // GET /v1/account
+	if status != http.StatusUnauthorized {
+		t.Fatalf("unrecognized-scope (mcp) OAuth token must be rejected (401), got %d", status)
+	}
+	if !strings.Contains(wa, `error="invalid_token"`) {
+		t.Errorf(`expected OAuth challenge error="invalid_token" for a rejected token, got %q`, wa)
+	}
+}

--- a/internal/agent/oauth_bearer_test.go
+++ b/internal/agent/oauth_bearer_test.go
@@ -3,6 +3,7 @@ package agent_test
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -75,14 +76,17 @@ func mintTokensForFixture(t *testing.T, f *consentFixture) (accessToken, refresh
 	return body.AccessToken, body.RefreshToken
 }
 
-// callAPIWithBearer hits /v1/agents with the given Authorization
+// callAPIWithBearer hits /v1/account with the given Authorization
 // value. Returns the status code and the WWW-Authenticate header.
-// /v1/agents is a simple authed endpoint that returns 200 (an
-// empty pending list) for any valid credential and 401 with the
-// RFC 6750 challenge for an invalid one.
+// /v1/account is the right validity probe because it authenticates with
+// requirePrincipal — i.e. it returns 200 for ANY valid credential
+// regardless of scope (account OR agent), and 401 with the RFC 6750
+// challenge for an invalid one. (It deliberately is NOT /v1/agents, which
+// is account-scope-gated and would 403 a valid agent-scoped token —
+// conflating credential validity with authorization.)
 func callAPIWithBearer(t *testing.T, serverURL, bearer string) (int, string) {
 	t.Helper()
-	req, _ := http.NewRequest("GET", serverURL+"/v1/agents", nil)
+	req, _ := http.NewRequest("GET", serverURL+"/v1/account", nil)
 	if bearer != "" {
 		req.Header.Set("Authorization", "Bearer "+bearer)
 	}
@@ -201,7 +205,10 @@ func TestBearer_OAuthToken_LowercaseBearer(t *testing.T) {
 	f := newConsentFixture(t)
 	access, _ := mintTokensForFixture(t, f)
 
-	req, _ := http.NewRequest("GET", f.server.URL+"/v1/agents", nil)
+	// /v1/account (requirePrincipal) is the validity probe — 200 for any valid
+	// scope. (Not /v1/agents, which is account-gated and would 403 this valid
+	// agent-scoped token, conflating scheme-parsing with authorization.)
+	req, _ := http.NewRequest("GET", f.server.URL+"/v1/account", nil)
 	req.Header.Set("Authorization", "bearer "+access) // lowercase scheme
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -338,5 +345,57 @@ func TestBearer_OAuthToken_ProviderNotWired(t *testing.T) {
 	}
 	if wa == "" {
 		t.Error("ate2a_ bearer without provider should still emit OAuth challenge (token looked like OAuth)")
+	}
+}
+
+// ──────────────────── OAuth scope resolution (CRITICAL-1) ────────────────────
+
+// getWithBearer GETs an arbitrary path with a bearer; returns status + body.
+func getWithBearer(t *testing.T, serverURL, path, bearer string) (int, string) {
+	t.Helper()
+	req, _ := http.NewRequest("GET", serverURL+path, nil)
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	return resp.StatusCode, string(b)
+}
+
+// TestBearer_OAuth_AgentScope_RejectedOnAccountOp is THE CRITICAL-1 regression.
+// An OAuth/MCP access token — which public DCR caps to scope=agent, and which
+// the consent fixture now grants as agent — must NOT be able to perform an
+// account-admin operation. Before the fix, every ate2a_ token was hardcoded to
+// ScopeAccount, so this returned 200 (full account admin); the granted agent
+// scope was silently elevated. Now the scope is honored and the account-only
+// GET /v1/agents (requireAccountScope) returns 403 forbidden.
+func TestBearer_OAuth_AgentScope_RejectedOnAccountOp(t *testing.T) {
+	f := newConsentFixture(t)
+	access, _ := mintTokensForFixture(t, f) // scope=agent, bound to the consent agent
+	if !strings.HasPrefix(access, oauth.AccessTokenPrefix) {
+		t.Fatalf("expected ate2a_ token, got %q", access)
+	}
+
+	status, body := getWithBearer(t, f.server.URL, "/v1/agents", access)
+	if status != http.StatusForbidden {
+		t.Fatalf("agent-scoped OAuth token must be 403 on an account-admin op (CRITICAL-1); got %d (body=%s)", status, body)
+	}
+	if !strings.Contains(body, "forbidden") {
+		t.Errorf("expected error.code=forbidden in the 403 body, got %s", body)
+	}
+}
+
+// TestBearer_OAuth_AgentScope_AllowedOnOwnTier confirms the fix CONFINES rather
+// than breaks: the same agent-scoped token authenticates on GET /v1/account
+// (requirePrincipal — valid for any scope), returning 200. The agent token
+// works for its own runtime tier; it's only barred from account administration.
+func TestBearer_OAuth_AgentScope_AllowedOnOwnTier(t *testing.T) {
+	f := newConsentFixture(t)
+	access, _ := mintTokensForFixture(t, f)
+	status, _ := callAPIWithBearer(t, f.server.URL, access) // GET /v1/account
+	if status != http.StatusOK {
+		t.Fatalf("agent-scoped OAuth token should authenticate on its own tier (/v1/account); got %d", status)
 	}
 }

--- a/internal/agent/oauth_consent_test.go
+++ b/internal/agent/oauth_consent_test.go
@@ -130,7 +130,7 @@ func newConsentFixture(t *testing.T) *consentFixture {
 		        ARRAY['http://localhost:8765/callback'],
 		        ARRAY['authorization_code','refresh_token'],
 		        ARRAY['code'],
-		        ARRAY['mcp'],
+		        ARRAY['agent'],
 		        ARRAY[]::TEXT[],
 		        'none', TRUE, 'dcr')
 		ON CONFLICT (client_id) DO NOTHING
@@ -200,7 +200,7 @@ func authorizeParams(challenge, clientID, state string) url.Values {
 	q.Set("response_type", "code")
 	q.Set("client_id", clientID)
 	q.Set("redirect_uri", "http://localhost:8765/callback")
-	q.Set("scope", "mcp")
+	q.Set("scope", "agent")
 	q.Set("state", state)
 	q.Set("code_challenge", challenge)
 	q.Set("code_challenge_method", "S256")

--- a/internal/agent/oauth_revoke_test.go
+++ b/internal/agent/oauth_revoke_test.go
@@ -23,16 +23,17 @@ func postRevoke(t *testing.T, serverURL string, form url.Values) *http.Response 
 // probeBearer reports whether the given bearer is still usable, plus
 // the WWW-Authenticate challenge the API advertises when it isn't.
 //
-// A single GET /v1/agents call now suffices: the v1 surface returns 200
-// for a valid bearer and 401 with the RFC 6750 §3.1 OAuth challenge for a
-// revoked/invalid one (the challenge is set by the apiserver's auth-
-// challenge middleware, the same builder the legacy mux used). A valid
-// bearer's 200 carries no WWW-Authenticate header — an empty string for a
-// still-valid token, exactly what the callers expect.
+// A single GET /v1/account call suffices: the v1 surface returns 200 for a
+// valid bearer of ANY scope (requirePrincipal) and 401 with the RFC 6750 §3.1
+// OAuth challenge for a revoked/invalid one (the challenge is set by the
+// apiserver's auth-challenge middleware). /v1/account — not the account-gated
+// /v1/agents — so a valid agent-scoped token reads as 200, isolating
+// revocation from authorization. A valid bearer's 200 carries no
+// WWW-Authenticate header, exactly what the callers expect.
 func probeBearer(t *testing.T, serverURL, bearer string) (status int, wwwAuth string) {
 	t.Helper()
 
-	req, _ := http.NewRequest("GET", serverURL+"/v1/agents", nil)
+	req, _ := http.NewRequest("GET", serverURL+"/v1/account", nil)
 	if bearer != "" {
 		req.Header.Set("Authorization", "Bearer "+bearer)
 	}

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -14,7 +14,10 @@ import (
 
 // HandlerStore is the subset of identity.Store that the WS handler needs.
 type HandlerStore interface {
-	GetUserByAPIKey(ctx context.Context, apiKey string) (*identity.User, error)
+	// GetPrincipalByAPIKey returns the scoped principal (User + Scope + AgentID)
+	// so the WS transport can enforce the SAME agent-scope confinement the REST
+	// API does (HIGH-1): an agent-scoped key must not open another agent's stream.
+	GetPrincipalByAPIKey(ctx context.Context, apiKey string) (*identity.Principal, error)
 	GetAgentByEmail(ctx context.Context, email string) (*identity.AgentIdentity, error)
 	GetMessagesByAgent(ctx context.Context, f identity.MessageListFilter) ([]identity.Message, error)
 }
@@ -53,8 +56,8 @@ func (h *Handler) serve(w http.ResponseWriter, r *http.Request, rawEmail string)
 		return
 	}
 
-	user, err := h.store.GetUserByAPIKey(r.Context(), token)
-	if err != nil || user == nil {
+	principal, err := h.store.GetPrincipalByAPIKey(r.Context(), token)
+	if err != nil || principal == nil || principal.User == nil {
 		http.Error(w, "invalid token", http.StatusUnauthorized)
 		return
 	}
@@ -68,7 +71,15 @@ func (h *Handler) serve(w http.ResponseWriter, r *http.Request, rawEmail string)
 		http.Error(w, "agent not found", http.StatusNotFound)
 		return
 	}
-	if agent.UserID != user.ID {
+	// Tenant ownership: the agent must belong to the credential's user.
+	if agent.UserID != principal.User.ID {
+		http.Error(w, "not authorized for this agent", http.StatusForbidden)
+		return
+	}
+	// Agent-scope confinement (HIGH-1): an agent-scoped credential is pinned to
+	// its one bound agent — it may not open a different agent's stream even
+	// within the same account. Mirrors the REST resolveOwnedAgent pin.
+	if principal.Scope == identity.ScopeAgent && principal.AgentID != agent.ID {
 		http.Error(w, "not authorized for this agent", http.StatusForbidden)
 		return
 	}
@@ -91,7 +102,7 @@ func (h *Handler) serve(w http.ResponseWriter, r *http.Request, rawEmail string)
 		return
 	}
 
-	log.Printf("[ws] connected: %s (user=%s)", email, user.ID)
+	log.Printf("[ws] connected: %s (user=%s)", email, principal.User.ID)
 
 	// Register connection; close old one if exists
 	if old := h.hub.Register(agent.ID, conn); old != nil {

--- a/internal/ws/handler_test.go
+++ b/internal/ws/handler_test.go
@@ -21,14 +21,22 @@ import (
 type mockStore struct {
 	user     *identity.User
 	userErr  error
+	scope    string // "" → unscoped (legacy/account-equivalent); ScopeAgent pins to agentID
+	agentID  string // bound agent id when scope == ScopeAgent
 	agent    *identity.AgentIdentity
 	agentErr error
 	messages []identity.Message
 	msgErr   error
 }
 
-func (m *mockStore) GetUserByAPIKey(_ context.Context, apiKey string) (*identity.User, error) {
-	return m.user, m.userErr
+func (m *mockStore) GetPrincipalByAPIKey(_ context.Context, apiKey string) (*identity.Principal, error) {
+	if m.userErr != nil {
+		return nil, m.userErr
+	}
+	if m.user == nil {
+		return nil, nil
+	}
+	return &identity.Principal{User: m.user, Scope: m.scope, AgentID: m.agentID}, nil
 }
 
 func (m *mockStore) GetAgentByEmail(_ context.Context, email string) (*identity.AgentIdentity, error) {
@@ -174,6 +182,48 @@ func TestHandler_NotOwner(t *testing.T) {
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d", resp.StatusCode)
 	}
+}
+
+// HIGH-1 regression: an agent-scoped credential pinned to agent A must NOT be
+// able to open agent B's stream, even when both agents share the same owner.
+func TestHandler_AgentScoped_WrongAgent_Forbidden(t *testing.T) {
+	hub := NewHub()
+	defer hub.Close()
+	store := &mockStore{
+		user:    newTestUser(),          // user_1
+		scope:   identity.ScopeAgent,    // agent-scoped credential…
+		agentID: "agent_OTHER",          // …bound to a different agent
+		agent:   newTestAgent("user_1"), // target agent (id agent_test), same owner
+	}
+	handler := NewHandler(hub, store)
+	srv := startServer(t, handler)
+
+	resp := doHTTP(t, srv, "bot@agents.e2a.dev", "agent_a_key")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("agent-scoped key for a different agent must be 403, got %d", resp.StatusCode)
+	}
+}
+
+// HIGH-1: an agent-scoped credential pinned to the SAME agent it targets connects.
+func TestHandler_AgentScoped_BoundAgent_Connects(t *testing.T) {
+	hub := NewHub()
+	defer hub.Close()
+	store := &mockStore{
+		user:    newTestUser(),
+		scope:   identity.ScopeAgent,
+		agentID: "agent_test", // matches newTestAgent's ID
+		agent:   newTestAgent("user_1"),
+	}
+	handler := NewHandler(hub, store)
+	srv := startServer(t, handler)
+
+	conn, _ := dialWS(t, srv, "bot@agents.e2a.dev", "agent_test_key")
+	if conn == nil {
+		t.Fatal("agent-scoped key for its own agent should connect")
+	}
+	defer conn.Close(websocket.StatusNormalClosure, "")
+	waitConnected(t, hub, "agent_test")
 }
 
 func TestHandler_SuccessfulConnect(t *testing.T) {


### PR DESCRIPTION
## Summary

An independent scope/credential audit found — and I verified at source — two privilege-escalation holes at the **non-REST credential edges**. The REST `/v1` scope ceiling (`requireAccountScope` / `resolveOwnedAgent`) and the credential-validation core are solid; the ceiling was simply never wired into the **OAuth-bearer** and **WebSocket** seams.

## 🔴 CRITICAL-1 — OAuth/MCP tokens silently elevated to account-admin
`internal/agent/api.go` hardcoded `Principal{Scope: ScopeAccount}` for **every** `ate2a_` token, ignoring the granted scope. Public DCR correctly caps clients to `scope=agent` and consent binds an agent (`oauth.Session.AgentEmail`) — but both were discarded at validation. So the **agent-tier token handed to external MCP hosts** (Claude/ChatGPT connectors) actually held **full account admin** (create/delete agents, claim/delete domains, manage webhooks, export/delete account). The §6a "least-privilege at the token" guarantee was false for the OAuth path — the primary hosted agent connection.

**Fix:** `principalFromOAuthToken` reads `ar.GetGrantedScopes()` authoritatively:
- `account` → `ScopeAccount` (only reachable via console/confidential clients)
- `agent` → `ScopeAgent` pinned to the consent-bound agent (ownership re-checked, mirroring `resolveOwnedAgent` and the JWT path)
- neither → **fail closed** (reject), never a silent elevation

## 🟠 HIGH-1 — WebSocket ignored agent-scope confinement
`internal/ws/handler.go` authed via `GetUserByAPIKey` (discards scope/AgentID) and checked only ownership, so an `e2a_agt_` key bound to `bot-a` could stream `bot-b`'s inbox within the same account. **Fix:** authenticate via `GetPrincipalByAPIKey` and apply the same agent-scope pin REST uses (`Scope==agent ⇒ AgentID == target`).

## Tests (tokens + scopes)
- **`TestBearer_OAuth_AgentScope_RejectedOnAccountOp`** — the CRITICAL-1 regression: agent OAuth token → account op (`GET /v1/agents`) → **403** (was 200/account-admin).
- **`TestBearer_OAuth_AgentScope_AllowedOnOwnTier`** — same token → `/v1/account` → 200 (confines, doesn't break).
- Consent fixture made production-faithful: grants `scope=agent` (matching the DCR cap) instead of the retired `mcp`. Bearer-validity probes repointed to `/v1/account` (both-scope) to isolate validity from authorization.
- **`TestHandler_AgentScoped_WrongAgent_Forbidden`** (403) + **`_BoundAgent_Connects`** (200) for the WS pin.

## Verification
`internal/agent`, `internal/ws`, `internal/httpapi` green against the local test DB; `make test-unit` + spec-drift green. No spec/SDK change.

## Follow-ups (audit MEDIUM — not in this PR)
- Dormant legacy-`Authenticator` account-scope fallback (`httpapi.go`) should fail closed.
- Consolidate the two auth seams + delete the unused `requireAgentAccess` helper before the freeze.

## Note
This is the prerequisite for the MCP scope-gating work (#1): the gating signal (`whoami`→`AccountView.scope`) flows through this same resolution, so it now reports the correct scope per credential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)