### PR TITLE
feat(mcp): scope-gate tools + annotations (§6a #1/#2) + account-scope HITL approve/reject

### DIFF
--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -952,9 +952,10 @@ review diligence — a #206-style omission can't merge.
 >   the tier map is `mcp/src/tools/tiers.ts`). **Correction to the runtime-tier
 >   list in the prose below:** `approve_message`/`reject_message` are **admin
 >   (account-scope), not runtime** — letting the gated agent approve its own held
->   outbound is self-approval and defeats HITL. Backend account-scope enforcement
->   on the approve/reject handlers is tracked in the HITL + message-screening
->   workstream. **#2 tool annotations ✅ done**
+>   outbound is self-approval and defeats HITL. Enforced end-to-end: the backend
+>   approve/reject handlers (`internal/httpapi/hitl.go`) require account scope
+>   (403 for agent-scoped); the human magic-link flow is a separate token-gated
+>   handler and is unaffected. **#2 tool annotations ✅ done**
 >   (`readOnlyHint`/`destructiveHint`/`idempotentHint` on every tool); **#4
 >   structured error `code`, #5 attachment download-URL, #7 idempotency-key on
 >   create tools — still PENDING** (not in GA). #3 (one pagination shape) is

--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -946,11 +946,19 @@ review diligence — a #206-style omission can't merge.
 >   the dedicated `…/attachments/{index}` endpoint + signed-URL idea (update #5) was
 >   **not** built.
 > - **Recommended design updates status:** #8 (vocabulary) ✅ done; #6 (fold
->   deliveries) ✅ rejected (see above); **#1 scope/tier-gating, #2 tool annotations,
->   #4 structured error `code`, #5 attachment download-URL, #7 idempotency-key on
->   create tools — all PENDING** (not in GA). #3 (one pagination shape) is partial:
->   the SDK AutoPager normalizes cursors, but MCP tool schemas still expose
->   `token`/`page_size`.
+>   deliveries) ✅ rejected (see above); **#1 scope/tier-gating ✅ done** (agent
+>   scope → 16 runtime tools, account → all 35; gated at one seam in
+>   `server.ts` off the credential scope resolved by `whoami` at session init —
+>   the tier map is `mcp/src/tools/tiers.ts`); **#2 tool annotations ✅ done**
+>   (`readOnlyHint`/`destructiveHint`/`idempotentHint` on every tool); **#4
+>   structured error `code`, #5 attachment download-URL, #7 idempotency-key on
+>   create tools — still PENDING** (not in GA). #3 (one pagination shape) is
+>   partial: the SDK AutoPager normalizes cursors, but MCP tool schemas still
+>   expose `token`/`page_size`.
+>
+>   Scope-gating note: gating is a decision-space/UX optimization, not the
+>   security boundary — the backend enforces scope per-handler (the OAuth/WS
+>   scope fix, PR #251), so a mis-listed tool is never load-bearing.
 >
 > The drift-gate mapping (tool → `operationId`) is authoritative for the live
 > surface; the tables below are kept for design rationale.

--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -947,9 +947,14 @@ review diligence — a #206-style omission can't merge.
 >   **not** built.
 > - **Recommended design updates status:** #8 (vocabulary) ✅ done; #6 (fold
 >   deliveries) ✅ rejected (see above); **#1 scope/tier-gating ✅ done** (agent
->   scope → 16 runtime tools, account → all 35; gated at one seam in
+>   scope → 14 runtime tools, account → all 35; gated at one seam in
 >   `server.ts` off the credential scope resolved by `whoami` at session init —
->   the tier map is `mcp/src/tools/tiers.ts`); **#2 tool annotations ✅ done**
+>   the tier map is `mcp/src/tools/tiers.ts`). **Correction to the runtime-tier
+>   list in the prose below:** `approve_message`/`reject_message` are **admin
+>   (account-scope), not runtime** — letting the gated agent approve its own held
+>   outbound is self-approval and defeats HITL. Backend account-scope enforcement
+>   on the approve/reject handlers is tracked in the HITL + message-screening
+>   workstream. **#2 tool annotations ✅ done**
 >   (`readOnlyHint`/`destructiveHint`/`idempotentHint` on every tool); **#4
 >   structured error `code`, #5 attachment download-URL, #7 idempotency-key on
 >   create tools — still PENDING** (not in GA). #3 (one pagination shape) is

--- a/internal/httpapi/hitl.go
+++ b/internal/httpapi/hitl.go
@@ -62,13 +62,19 @@ func (s *Server) registerHITL() {
 }
 
 func (s *Server) handleApprove(ctx context.Context, in *approveInput) (*approveOutput, error) {
-	ag, err := s.resolveOwnedAgent(ctx, in.Address)
+	// HITL approval is an account-owner action. An agent-scoped credential
+	// approving its OWN held outbound is self-approval, which defeats the
+	// human-in-the-loop gate — so require account scope (403 for agent-scoped).
+	// The human magic-link flow is a separate, token-gated handler and is
+	// unaffected.
+	p, err := s.requireAccountScope(ctx)
 	if err != nil {
 		return nil, err
 	}
-	user, uerr := s.requireUser(ctx)
-	if uerr != nil {
-		return nil, uerr
+	user := p.User
+	ag, err := s.resolveOwnedAgent(ctx, in.Address)
+	if err != nil {
+		return nil, err
 	}
 	if env := s.checkSendLimit(ag.ID); env != nil {
 		return nil, env
@@ -94,13 +100,16 @@ func (s *Server) handleApprove(ctx context.Context, in *approveInput) (*approveO
 }
 
 func (s *Server) handleReject(ctx context.Context, in *rejectInput) (*rejectOutput, error) {
-	ag, err := s.resolveOwnedAgent(ctx, in.Address)
+	// Account-owner action — see handleApprove. Rejecting (discarding) a held
+	// draft is part of the HITL decision, so it is also account-scope only.
+	p, err := s.requireAccountScope(ctx)
 	if err != nil {
 		return nil, err
 	}
-	user, uerr := s.requireUser(ctx)
-	if uerr != nil {
-		return nil, uerr
+	user := p.User
+	ag, err := s.resolveOwnedAgent(ctx, in.Address)
+	if err != nil {
+		return nil, err
 	}
 	if s.deps.RejectPending == nil {
 		return nil, NewError(http.StatusInternalServerError, "internal_error", "reject unavailable")

--- a/internal/httpapi/scope_test.go
+++ b/internal/httpapi/scope_test.go
@@ -103,6 +103,24 @@ func TestScope_UpdateAgentIsAccountOnly(t *testing.T) {
 	}
 }
 
+// TestScope_ApproveRejectIsAccountOnly: HITL approve/reject is barred for an
+// agent-scoped credential EVEN ON ITS OWN BOUND AGENT — self-approval would
+// defeat the human-in-the-loop gate. (The human magic-link flow is a separate,
+// token-gated handler and is unaffected.) requireAccountScope runs first, so the
+// 403 fires before any approve/reject dependency is consulted.
+func TestScope_ApproveRejectIsAccountOnly(t *testing.T) {
+	srv := scopeTestServer(t)
+	for _, path := range []string{
+		"/v1/agents/support%40acme.com/messages/msg_1/approve",
+		"/v1/agents/support%40acme.com/messages/msg_1/reject",
+	} {
+		code, body := sendJSON(t, "POST", srv.URL+path, "agtSupport", map[string]any{})
+		if code != 403 || errCode(body) != "forbidden" {
+			t.Errorf("agent key POST %s (own bound agent): status %d body %v, want 403 forbidden", path, code, body)
+		}
+	}
+}
+
 // TestScope_AgentKeyPinnedToBoundAgent: a per-agent runtime route lets an
 // agent-scoped credential act as its bound agent but 403s on any other agent;
 // an account-scoped credential reaches both.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -130,9 +130,16 @@ shows the set your scope allows, with per-tool descriptions.
 | --- | --- |
 | `whoami` | Get the authenticated account's identity — user, scope, plan/limits; for an agent-scoped credential, also the bound agent address. |
 | `list_agents` | List every agent inbox owned by the authenticated user. |
-| `create_agent` | Register a new inbox using a slug on the shared domain. Defaults to `local` mode — no webhook required. See note below for cloud mode. |
+| `create_agent` | Register a new agent by its full email address — on a verified domain you own, or the deployment's shared domain. No delivery "mode": inbound is always available via `list_messages` (poll) or a `create_webhook` subscription. (Admin/account-scoped.) |
 
-> **Cloud-mode agents must verify webhook signatures.** When you create an agent with `agent_mode: "cloud"`, e2a HMAC-signs every webhook delivery against your account's webhook signing secret (`E2A_WEBHOOK_SECRET`, shown in the [e2a dashboard](https://e2a.dev)). Your webhook handler must verify the signature on every request — the [e2a SDK](https://www.npmjs.com/package/@e2a/sdk) exposes `constructEvent(rawBody, signatureHeader, secret)` which verifies the signature and returns a typed event in one call (throws on a bad signature). Local-mode agents (the default) avoid this entirely by polling via `list_messages`.
+> **Webhook deliveries are signed — verify them.** Push delivery is a top-level
+> resource (`create_webhook`), not a per-agent mode. e2a HMAC-signs every webhook
+> delivery against the webhook's signing secret (returned once from `create_webhook`
+> / `rotate_webhook_secret`). Your handler must verify the signature on every
+> request — the [e2a SDK](https://www.npmjs.com/package/@e2a/sdk) exposes
+> `constructEvent(rawBody, signatureHeader, secret)` which verifies and returns a
+> typed event in one call (throws on a bad signature). Or skip webhooks entirely
+> and poll via `list_messages`.
 
 ### Messages
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -116,9 +116,11 @@ Hosts that support OAuth connectors can instead add `https://api.e2a.dev/mcp` as
 
 The server exposes up to **35** tools spanning agents, messages, human-in-the-loop
 approval, attachments, domains, events, and webhooks. **The visible set depends on
-your credential's scope (§6a):** an **agent**-scoped credential sees the ~16
-runtime/inbox tools (read, send, reply, approve); an **account**-scoped credential
-also sees the admin/setup tools (agent/domain/webhook/event management) — all 35.
+your credential's scope (§6a):** an **agent**-scoped credential sees the 14
+runtime/inbox tools (read, send, reply, and view its pending queue); an
+**account**-scoped credential also sees the admin/setup tools (agent/domain/
+webhook/event management — **and HITL approve/reject, which is an account-owner
+action, never agent self-approval**) — all 35.
 Every tool carries MCP annotations (`readOnlyHint`/`destructiveHint`/
 `idempotentHint`) so hosts can auto-approve reads and flag destructive actions.
 The tables below highlight the most commonly used ones — your MCP host's tool list

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -114,16 +114,21 @@ Hosts that support OAuth connectors can instead add `https://api.e2a.dev/mcp` as
 
 ## Tools
 
-The server registers **33** tools spanning agents, messages, human-in-the-loop
-approval, attachments, domains, events, and webhooks. The tables below highlight
-the most commonly used ones — your MCP host's tool list shows the full set with
-per-tool descriptions.
+The server exposes up to **35** tools spanning agents, messages, human-in-the-loop
+approval, attachments, domains, events, and webhooks. **The visible set depends on
+your credential's scope (§6a):** an **agent**-scoped credential sees the ~16
+runtime/inbox tools (read, send, reply, approve); an **account**-scoped credential
+also sees the admin/setup tools (agent/domain/webhook/event management) — all 35.
+Every tool carries MCP annotations (`readOnlyHint`/`destructiveHint`/
+`idempotentHint`) so hosts can auto-approve reads and flag destructive actions.
+The tables below highlight the most commonly used ones — your MCP host's tool list
+shows the set your scope allows, with per-tool descriptions.
 
 ### Identity
 
 | Tool | Description |
 | --- | --- |
-| `whoami` | Get the calling agent's full record (resolved from an agent-scoped credential). |
+| `whoami` | Get the authenticated account's identity — user, scope, plan/limits; for an agent-scoped credential, also the bound agent address. |
 | `list_agents` | List every agent inbox owned by the authenticated user. |
 | `create_agent` | Register a new inbox using a slug on the shared domain. Defaults to `local` mode — no webhook required. See note below for cloud mode. |
 

--- a/mcp/src/client.ts
+++ b/mcp/src/client.ts
@@ -25,6 +25,7 @@ import type {
   TestWebhookRequest,
 } from "@e2a/sdk/v1";
 import type { McpConfig } from "./config.js";
+import type { Scope } from "./tools/tiers.js";
 
 // Outbound drafts held for human approval surface in the message list
 // with this status (see api/openapi.yaml listMessages: "Held outbound
@@ -59,10 +60,18 @@ export class McpClient {
   readonly sdk: E2AClient;
   /** Default per-agent address; mirrors the old flat `agentEmail`. */
   readonly agentEmail: string;
+  /**
+   * The connecting credential's scope (§6a tier-gating signal). Resolved at
+   * session init from whoami (GET /account). Defaults to "account" (full
+   * surface) so direct constructions / tests are unchanged; buildSessionClient
+   * sets the real value per credential.
+   */
+  readonly scope: Scope;
 
-  constructor(sdk: E2AClient, agentEmail = "") {
+  constructor(sdk: E2AClient, agentEmail = "", scope: Scope = "account") {
     this.sdk = sdk;
     this.agentEmail = agentEmail;
+    this.scope = scope;
   }
 
   // resolveAddress picks the explicit per-call address, falling back to

--- a/mcp/src/http-server.ts
+++ b/mcp/src/http-server.ts
@@ -6,6 +6,7 @@ import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { E2AClient } from "@e2a/sdk/v1";
 import { buildServer } from "./server.js";
 import { McpClient } from "./client.js";
+import type { Scope } from "./tools/tiers.js";
 import { Sessions, fingerprintBearer } from "./session.js";
 
 export interface HttpServerOptions {
@@ -48,7 +49,7 @@ export interface HttpServerOptions {
    * want to exercise the prefetch path can pass it through to their
    * stub; tests that only care about the bearer can ignore it.
    */
-  clientFactory?: (bearer: string, opts?: { agentEmail?: string }) => McpClient;
+  clientFactory?: (bearer: string, opts?: { agentEmail?: string; scope?: Scope }) => McpClient;
 }
 
 interface BuiltApp {
@@ -348,39 +349,47 @@ export async function buildSessionClient(
   opts: HttpServerOptions,
   bearer: string,
 ): Promise<McpClient> {
-  const make = (agentEmail?: string): McpClient => {
+  const make = (agentEmail?: string, scope?: Scope): McpClient => {
     if (opts.clientFactory) {
       // Preserve the no-arg-factory shape for callers (and tests) that
-      // don't care about the resolved email. Pass the email through
-      // only when we actually have one.
-      return agentEmail
-        ? opts.clientFactory(bearer, { agentEmail })
+      // don't care about the resolved email/scope. Pass them through only
+      // when we actually have them.
+      return agentEmail || scope
+        ? opts.clientFactory(bearer, { ...(agentEmail ? { agentEmail } : {}), ...(scope ? { scope } : {}) })
         : opts.clientFactory(bearer);
     }
     return new McpClient(
       new E2AClient({ apiKey: bearer, baseUrl: opts.baseUrl }),
       agentEmail ?? "",
+      scope ?? "account",
     );
   };
 
-  const client = make();
-  let resolved: string | undefined;
+  // Resolve scope + the credential-bound agent from whoami (GET /account),
+  // which the backend scope-filters per credential (§6a). This drives both
+  // tool-tier gating (server.ts) and the per-agent default:
+  //   - agent scope   → pin the bound agent (whoami.agentAddress); the
+  //     credential IS that agent. Surface = runtime tier.
+  //   - account scope → no default agent (per §6a, explicit `email` required —
+  //     the old single-agent auto-resolve is dropped). Surface = full.
+  const probe = make();
+  let scope: Scope = "agent"; // fail-closed default (least privilege) if whoami can't be read
+  let agentEmail: string | undefined;
   try {
-    const agents = await client.listAgents();
-    // Env-var path already populated agentEmail — operator opted in
-    // explicitly, don't second-guess it with auto-resolution.
-    if (!client.agentEmail && Array.isArray(agents) && agents.length === 1) {
-      resolved = agents[0]?.email;
+    const me = await probe.whoami();
+    scope = me.scope === "account" ? "account" : "agent";
+    if (scope === "agent" && me.agentAddress) {
+      agentEmail = me.agentAddress;
     }
   } catch (err) {
     if (isUnauthorizedError(err)) {
       throw new InvalidBearerError();
     }
-    // Non-auth failures remain best-effort. A transient backend hiccup
-    // shouldn't break MCP initialize; worst case, the user sees the
-    // same "agentEmail is required" error they'd see today.
+    // Non-auth failure (transient backend hiccup): don't break MCP initialize.
+    // Fall back to the least-privilege runtime tier with no default agent — the
+    // backend still enforces scope, and the session self-corrects on reconnect.
   }
-  return resolved ? make(resolved) : client;
+  return make(agentEmail, scope);
 }
 
 function isUnauthorizedError(err: unknown): boolean {

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -6,10 +6,30 @@ import { registerDomainTools } from "./tools/domains.js";
 import { registerHitlTools } from "./tools/hitl.js";
 import { registerWebhookTools } from "./tools/webhooks.js";
 import { registerEventTools } from "./tools/events.js";
+import { toolNamesForScope } from "./tools/tiers.js";
 
 export interface BuildServerOptions {
   client: McpClient;
   version?: string;
+}
+
+// gateRegistration intercepts server.registerTool so a session only registers
+// the tools its credential scope is allowed to see (§6a). One seam gates every
+// tool — the per-resource register*Tools functions stay scope-agnostic, and the
+// tier classification lives solely in tiers.ts. Tools outside the allowed set
+// are silently skipped (not registered → not listed → not callable). This is a
+// surface/decision-space optimization; the backend still enforces scope, so a
+// skipped tool is never the security boundary.
+function gateRegistration(server: McpServer, allowed: ReadonlySet<string>): void {
+  const original = server.registerTool.bind(server) as (...a: unknown[]) => unknown;
+  server.registerTool = ((name: string, ...rest: unknown[]) => {
+    if (!allowed.has(name)) {
+      // Skip: not wired into the server's tool list. Returns undefined; the
+      // register*Tools callers don't use the return value.
+      return undefined as unknown as ReturnType<McpServer["registerTool"]>;
+    }
+    return original(name, ...rest) as ReturnType<McpServer["registerTool"]>;
+  }) as McpServer["registerTool"];
 }
 
 export function buildServer({ client, version = "0.1.0" }: BuildServerOptions): McpServer {
@@ -17,6 +37,10 @@ export function buildServer({ client, version = "0.1.0" }: BuildServerOptions): 
     name: "e2a",
     version,
   });
+  // Scope-gate the surface to the connecting credential's tier (client.scope,
+  // resolved at session init via whoami). account → full surface; agent →
+  // runtime/inbox subset.
+  gateRegistration(server, toolNamesForScope(client.scope));
   registerMessageTools(server, client);
   registerAgentTools(server, client);
   registerDomainTools(server, client);

--- a/mcp/src/tools/agents.ts
+++ b/mcp/src/tools/agents.ts
@@ -8,6 +8,7 @@ export function registerAgentTools(server: McpServer, client: McpClient): void {
     "list_agents",
     {
       title: "List agents",
+      annotations: { readOnlyHint: true },
       description:
         "List every agent inbox owned by the authenticated user. Useful for orientation — which inbox to send `from` or query messages against. Read-only.",
       inputSchema: strictInputSchema({}),
@@ -19,6 +20,7 @@ export function registerAgentTools(server: McpServer, client: McpClient): void {
     "get_agent",
     {
       title: "Get one agent's configuration",
+      annotations: { readOnlyHint: true },
       description:
         "Fetch a single agent by its email address — full config: name, HITL settings (hitl_enabled/hitl_mode/hitl_ttl_seconds/hitl_expiration_action), inbound policy (inbound_policy/inbound_allowlist), and sending status. Use to inspect or confirm one agent's settings without listing every agent. Read-only.",
       inputSchema: strictInputSchema({
@@ -35,6 +37,7 @@ export function registerAgentTools(server: McpServer, client: McpClient): void {
     "whoami",
     {
       title: "Get the authenticated account's identity",
+      annotations: { readOnlyHint: true },
       description:
         "Use first when starting work on e2a to learn WHO you are: the authenticated user (email), the credential's scope (`account` or `agent`), and your plan + usage limits. For an agent-scoped credential it also returns `agent_address` — the single agent that credential IS. Account-scoped credentials own many agents; discover them with `list_agents`. This is identity, not an agent — it never guesses a 'default' agent.",
       inputSchema: strictInputSchema({}),
@@ -46,6 +49,7 @@ export function registerAgentTools(server: McpServer, client: McpClient): void {
     "create_agent",
     {
       title: "Create a new agent inbox",
+      annotations: { destructiveHint: false },
       description:
         "Register a new agent by its full email address. For a custom domain, the domain must be one you've registered and verified (`register_domain` → `verify_domain` → poll `get_domain` for sending). For the deployment's shared domain, just use an email on it (e.g. support-bot@<shared-domain>). Inbound is always available via `list_messages` (poll) or a `create_webhook` subscription — there is no delivery 'mode' to choose. Returns the full agent.",
       inputSchema: strictInputSchema({
@@ -74,6 +78,7 @@ export function registerAgentTools(server: McpServer, client: McpClient): void {
     "update_agent",
     {
       title: "Update an agent's configuration",
+      annotations: { idempotentHint: true, destructiveHint: false },
       description:
         "Mutate an agent's HITL and inbound-policy settings. **The path to enable HITL approval gates** (HITL is NOT in create_agent): set `hitl_enabled: true`, optionally with `hitl_ttl_seconds`, `hitl_expiration_action`, and `hitl_mode` (`all` holds every outbound; `high_impact` holds only high-impact actions). Also sets the inbound trust gate: `inbound_policy` (`open`/`allowlist`/`domain`/`verified_only`) + `inbound_allowlist`. Omitted fields keep their current value; an explicit zero is honored (e.g. `hitl_ttl_seconds: 0`).",
       inputSchema: strictInputSchema({
@@ -147,6 +152,7 @@ export function registerAgentTools(server: McpServer, client: McpClient): void {
     "delete_agent",
     {
       title: "Delete an agent inbox (DESTRUCTIVE)",
+      annotations: { destructiveHint: true, idempotentHint: true },
       description:
         "Permanently delete the agent identity and CASCADE-remove every message, pending outbound, and webhook-delivery record bound to it. Irreversible. Existing OAuth tokens bound to this agent are revoked automatically. Requires `confirm: true` — set it explicitly to acknowledge the destructive action.",
       inputSchema: strictInputSchema({

--- a/mcp/src/tools/domains.ts
+++ b/mcp/src/tools/domains.ts
@@ -20,6 +20,7 @@ export function registerDomainTools(server: McpServer, client: McpClient): void 
     "list_domains",
     {
       title: "List domains",
+      annotations: { readOnlyHint: true },
       description:
         "List every custom mail domain registered under the authenticated user, with verification status (verified / pending DNS / failed) and the verification token for each. Useful to discover which domains can already send/receive mail and which still need DNS records to be added. Read-only; cheap to call.",
       inputSchema: strictInputSchema({}),
@@ -31,6 +32,7 @@ export function registerDomainTools(server: McpServer, client: McpClient): void 
     "register_domain",
     {
       title: "Register a custom mail domain (returns DNS records to publish)",
+      annotations: { idempotentHint: true, destructiveHint: false },
       description:
         "Use to start the custom-domain flow. **This is step 1 of an asynchronous two-step process**: this tool returns the MX + TXT records the user must publish on their DNS provider; it does NOT make the domain live. Step 2 is `verify_domain` — but only AFTER the records are published AND DNS propagation has completed (typically minutes, occasionally hours). Do not call `verify_domain` immediately, and do not promise the user the domain works yet. **Composition tip**: if a DNS-provider MCP (Cloudflare, Route 53, NS1, …) is loaded in the same host, hand the returned records to its `create_dns_record`-style tool, then surface the wait expectation to the user. If no DNS MCP is available, show the records verbatim and ask the user to add them manually. The domain is created in an unverified state — `delete_domain` is the reverse op. Idempotent against an existing-but-unverified row.",
       inputSchema: strictInputSchema({
@@ -49,6 +51,7 @@ export function registerDomainTools(server: McpServer, client: McpClient): void 
     "get_domain",
     {
       title: "Get one domain (poll sending status)",
+      annotations: { readOnlyHint: true },
       description:
         "Fetch a single domain by name. This is the poll target after `verify_domain`: it surfaces both `verified` (inbound ownership) and `sending_status` (none/pending/verified/failed — the async SES sending identity that lets agents on this domain send as their own address), plus `sending_error` and the `dns_records`/`sending_dns_records` to publish. Poll until `sending_status` is `verified` before expecting own-domain From on outbound; don't poll in a tight loop.",
       inputSchema: strictInputSchema({
@@ -62,6 +65,7 @@ export function registerDomainTools(server: McpServer, client: McpClient): void 
     "verify_domain",
     {
       title: "Verify a custom mail domain's DNS records",
+      annotations: { idempotentHint: true, destructiveHint: false },
       description:
         "Use as step 2 of the custom-domain flow, AFTER `register_domain` returned records AND the user (or a DNS MCP) published them AND DNS has had time to propagate (minutes to hours). Probes DNS for the issued MX + TXT records and flips the domain's `verified` bit on success. Idempotent — safe to retry as propagation completes. If `verified: false` comes back, the response includes the resolved-record state for diagnostics; surface that to the user rather than retrying in a tight loop. Don't poll; let the user drive the recheck.",
       inputSchema: strictInputSchema({
@@ -78,6 +82,7 @@ export function registerDomainTools(server: McpServer, client: McpClient): void 
     "delete_domain",
     {
       title: "Delete a custom mail domain (DESTRUCTIVE)",
+      annotations: { destructiveHint: true, idempotentHint: true },
       description:
         "Permanently remove a domain registration. CASCADES to every agent on that domain and every message/pending-outbound/webhook-delivery bound to those agents. Irreversible. Existing OAuth tokens bound to those agents are revoked. Requires `confirm: true` — set it explicitly to acknowledge the destructive scope.",
       inputSchema: strictInputSchema({

--- a/mcp/src/tools/events.ts
+++ b/mcp/src/tools/events.ts
@@ -17,6 +17,7 @@ export function registerEventTools(server: McpServer, client: McpClient): void {
     "list_events",
     {
       title: "List webhook events",
+      annotations: { readOnlyHint: true },
       description:
         "List the durable webhook event log in reverse-chronological order. Useful for reconciliation (\"did our webhook receiver see this event?\") and for debugging delivery state. Events past the 30-day retention boundary are not returned. Cursor-paginated via `token` / `next_token` — pass the previous response's `next_token` to walk further back. Returns each event's `data` payload plus a `delivery_status` summary of how many subscribers have received it.",
       inputSchema: strictInputSchema({
@@ -62,6 +63,7 @@ export function registerEventTools(server: McpServer, client: McpClient): void {
     "get_event",
     {
       title: "Get one webhook event",
+      annotations: { readOnlyHint: true },
       description:
         "Fetch a single event by id. The response includes the full envelope payload AND a `delivery_status` block showing how many of the matched webhooks have delivered/pending/failed. Use this to triage \"did this specific event reach my receiver?\" Returns an error with status 410 if the event has passed the 30-day retention boundary (replay is no longer possible).",
       inputSchema: strictInputSchema({
@@ -75,6 +77,7 @@ export function registerEventTools(server: McpServer, client: McpClient): void {
     "redeliver_event",
     {
       title: "Replay a webhook event",
+      annotations: { destructiveHint: false },
       description:
         "Re-fire a previously-emitted event to a webhook. Pass `webhook_id` to target one subscriber. Omit `webhook_id` to fan out to every webhook that originally matched the event (per the snapshot at fan-out time; does NOT re-evaluate against the current subscriber set, by design). **Important:** the replay uses the SAME envelope id as the original delivery. Customer-side receivers that dedupe on event id will discard the replay as already-processed — replay is recovery, not re-delivery. Use this for outage recovery, not for \"send this event twice on purpose.\"",
       inputSchema: strictInputSchema({

--- a/mcp/src/tools/hitl.ts
+++ b/mcp/src/tools/hitl.ts
@@ -9,6 +9,7 @@ export function registerHitlTools(server: McpServer, client: McpClient): void {
     "list_pending_messages",
     {
       title: "List outbound messages awaiting approval",
+      annotations: { readOnlyHint: true },
       description:
         "Use when the user asks what's awaiting approval, or after a `send_message`/`reply_to_message` returned `pending_approval` and they want to see the queue. Lists held outbound messages from HITL-enabled agents sorted by soonest-expiring first. Body content is summary-only — call `get_pending_message` for the full draft of one. Read-only; cheap, but don't poll it on a loop.",
       inputSchema: strictInputSchema({}),
@@ -20,6 +21,7 @@ export function registerHitlTools(server: McpServer, client: McpClient): void {
     "get_pending_message",
     {
       title: "Get a pending-approval message",
+      annotations: { readOnlyHint: true },
       description:
         "Fetch the full draft (subject, recipients, body, attachments) of one outbound message awaiting human approval. Body content is only present while the message is `pending_approval` — after a terminal transition the server scrubs it.",
       inputSchema: strictInputSchema({
@@ -62,6 +64,7 @@ export function registerHitlTools(server: McpServer, client: McpClient): void {
     "approve_message",
     {
       title: "Approve a pending outbound message",
+      annotations: { destructiveHint: false },
       description:
         "Use to release a held outbound message — typically after the user reviewed it via `get_pending_message`. Approve-as-is by passing only `message_id`; apply reviewer edits by supplying any subset of subject / body_text / body_html / to / cc / bcc / attachments (those override the stored draft before send). Field semantics: omit a field to keep the draft's value; pass it (including empty `attachments: []` to strip all attachments) to override. Returns 409 if the message is no longer pending.",
       inputSchema: strictInputSchema({
@@ -99,6 +102,7 @@ export function registerHitlTools(server: McpServer, client: McpClient): void {
     "reject_message",
     {
       title: "Reject a pending outbound message",
+      annotations: { destructiveHint: false },
       description:
         "Discard a held outbound message. The message is never sent and body columns are scrubbed; the optional `reason` is stored for audit. Returns 409 if the message is no longer pending.",
       inputSchema: strictInputSchema({

--- a/mcp/src/tools/messages.ts
+++ b/mcp/src/tools/messages.ts
@@ -50,6 +50,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
     "send_message",
     {
       title: "Send email",
+      annotations: { destructiveHint: false },
       description:
         "Use when starting a NEW email thread to a fresh recipient. To respond to a message you can see in `list_messages`, use `reply_to_message` instead — it preserves the In-Reply-To / References headers so the reply lands in the same thread, which this tool deliberately does not do. Attach files via `attachments`; pass base64 strings produced by other tools (e.g. `get_attachment`) verbatim — don't hand-encode raw text. **`pending_approval` is not failure.** If the agent has HITL enabled, the response is `{ status: \"pending_approval\", message_id: ... }`; the message is held for human review — do not retry. Check on it with `list_messages` (held drafts show hitl_status=pending_approval) / `get_message`.",
       inputSchema: strictInputSchema({
@@ -109,6 +110,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
     "reply_to_message",
     {
       title: "Reply to a received message",
+      annotations: { destructiveHint: false },
       description:
         "Use whenever you're responding to a message you can see in the inbox — preserves the In-Reply-To and References headers so the reply joins the original email thread instead of starting a new one. Prefer this over `send_message` for any response to an inbound; thread fragmentation (broken conversation view in the recipient's mail client) is the most visible symptom of using `send_message` by mistake. Pass `reply_all: true` to copy the original Cc list; subject is auto-derived as `Re: …` by the server. Same HITL caveat as `send_message`: a `pending_approval` status is success, not failure.",
       inputSchema: strictInputSchema({
@@ -163,6 +165,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
     "forward_message",
     {
       title: "Forward an inbound message",
+      annotations: { destructiveHint: false },
       description:
         "Forward a message the agent has received to one or more new recipients. The server auto-prepends a Gmail-style header block (From/Date/Subject/To/Cc) and the original body to whatever optional comment you pass in `body`/`html_body`. **Unlike `reply_to_message`, a forward is a NEW thread** — no In-Reply-To / References headers are emitted, so the recipient sees a fresh conversation. Use this when the user asks to share a received email with someone else; use `reply_to_message` when continuing the existing conversation. Same HITL behavior as send/reply: `pending_approval` is success, not failure.",
       inputSchema: strictInputSchema({
@@ -226,6 +229,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
     "update_message_labels",
     {
       title: "Add or remove labels on an inbound message",
+      annotations: { idempotentHint: true, destructiveHint: false },
       description:
         "Apply a labels delta — `add_labels` and/or `remove_labels`. Labels are lowercase strings drawn from `[a-z0-9:_-]+`, capped at 64 chars each; the `e2a:` prefix is reserved for server-applied system labels and rejected on writes. A label appearing in both lists is removed (remove wins). Per-request cap is 50 entries per list; per-message cap is 100 total labels. The response includes the post-update label set so you can echo back to the user without a follow-up read. Use this when the user wants to categorize a message (e.g. `add: urgent`) or clear a tag (`remove: follow-up`).",
       inputSchema: strictInputSchema({
@@ -258,6 +262,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
     "list_conversations",
     {
       title: "List conversations for the agent",
+      annotations: { readOnlyHint: true },
       description:
         "Lists the agent's conversations — groups of messages sharing a `conversation_id` — one row per conversation, sorted by most recent activity. Each row carries `message_count`, `inbound_count`, `outbound_count`, `has_unread`, and the latest message's subject + sender so you can render an inbox without drilling into each thread. The server caps the response at 100. Use this when the user wants to see threads rather than individual messages — e.g. \"what conversations are unread?\" or \"show recent threads with Alice\". To read a single conversation's messages, call `get_conversation`.",
       inputSchema: strictInputSchema({
@@ -294,6 +299,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
     "get_conversation",
     {
       title: "Get a single conversation with all member messages",
+      annotations: { readOnlyHint: true },
       description:
         "Returns the full thread — aggregate counts, the participants union (sender + recipient + to + cc + bcc across members), the labels union, and every member message in chronological order (oldest first). Returns a not-found error when no non-expired messages exist for `(agent, conversation_id)`. Use this after `list_conversations` (or whenever you have a `conversation_id` from an inbound/outbound payload) to read the full thread.",
       inputSchema: strictInputSchema({
@@ -309,6 +315,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
     "list_messages",
     {
       title: "List inbound messages",
+      annotations: { readOnlyHint: true },
       description:
         "List messages the agent has received, newest first by default. Filter by `read_status` (unread/read/all; default unread) and cap results with `page_size`. Pass `sort: \"asc\"` for FIFO order (oldest unread first) when the caller wants to drain the inbox in arrival order. **Search filters** (`from`, `subject_contains`, `conversation_id`, `since`, `until`) narrow the result set server-side — use them instead of paginating the full inbox client-side. Returns summaries only — use `get_message` for the full body.",
       inputSchema: strictInputSchema({
@@ -389,6 +396,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
     "get_message",
     {
       title: "Get a message",
+      annotations: { readOnlyHint: true },
       description:
         "Use after `list_messages` to read one inbound message in full — body (text + html), headers, conversation id, and attachment metadata. Pass the `message_id` from the list response. Attachment bytes are NOT included (would blow context for any non-trivial PDF); the response lists each attachment's filename, content_type, and 0-based `index` plus size_bytes. To get the actual bytes of one attachment (inspect, forward, hand off), call `get_attachment` with that index. The raw MIME blob is also omitted for the same reason.",
       inputSchema: strictInputSchema({
@@ -445,6 +453,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
     "get_attachment",
     {
       title: "Fetch one attachment's bytes from an inbound message",
+      annotations: { readOnlyHint: true },
       description:
         "Returns the base64-encoded content of one attachment from an inbound message. Use this when you want to inspect, forward, or hand off an attachment surfaced by `get_message`. Indexes are 0-based and stable within a message (see `attachments[].index` from get_message). To forward to another recipient, pass the returned `{filename, content_type, data}` verbatim as an entry in `send_message`'s or `reply_to_message`'s `attachments[]` array. Refuses attachments larger than 2 MB after decoding — these are too big for inline retrieval and the LLM context cost would be prohibitive.",
       inputSchema: strictInputSchema({

--- a/mcp/src/tools/tiers.ts
+++ b/mcp/src/tools/tiers.ts
@@ -33,8 +33,12 @@ export const RUNTIME_TOOLS: ReadonlySet<string> = new Set([
   "send_message",
   "reply_to_message",
   "forward_message",
-  "approve_message",
-  "reject_message",
+  // NOTE: approve_message / reject_message are deliberately NOT here — they are
+  // admin/account-scope (below). Letting the gated agent approve its own held
+  // outbound would be self-approval and defeat the HITL gate; approval is an
+  // account-owner / human action (or the magic-link browser flow). An
+  // agent-scoped credential can send (which gets held) and SEE its pending
+  // queue (list_pending_messages / get_pending_message), but not release it.
   "list_pending_messages",
   "get_pending_message",
 ]);
@@ -44,6 +48,12 @@ export const ADMIN_TOOLS: ReadonlySet<string> = new Set([
   "create_agent",
   "update_agent",
   "delete_agent",
+  // HITL approval is an account-owner / human review action — NOT something the
+  // gated agent may do to its own held outbound (that would be self-approval,
+  // defeating HITL). Backend enforcement of account-scope on the approve/reject
+  // handlers is tracked in the HITL + message-screening workstream.
+  "approve_message",
+  "reject_message",
   "list_domains",
   "get_domain",
   "register_domain",

--- a/mcp/src/tools/tiers.ts
+++ b/mcp/src/tools/tiers.ts
@@ -50,8 +50,8 @@ export const ADMIN_TOOLS: ReadonlySet<string> = new Set([
   "delete_agent",
   // HITL approval is an account-owner / human review action — NOT something the
   // gated agent may do to its own held outbound (that would be self-approval,
-  // defeating HITL). Backend enforcement of account-scope on the approve/reject
-  // handlers is tracked in the HITL + message-screening workstream.
+  // defeating HITL). The backend enforces this too: the approve/reject handlers
+  // (internal/httpapi/hitl.go) require account scope (403 for agent-scoped).
   "approve_message",
   "reject_message",
   "list_domains",

--- a/mcp/src/tools/tiers.ts
+++ b/mcp/src/tools/tiers.ts
@@ -13,7 +13,11 @@
 // records each tool's tier next to its operationId".
 //
 // INVARIANT: every registered tool name MUST appear in exactly one set below.
-// A new tool with no tier is a bug — `assertToolTiersComplete` (tested) guards it.
+// A new tool with no tier would be silently gated out of EVERY scope (it's not
+// in any allowed set), so it'd vanish without a dedicated failure. The exported
+// `assertToolTiersComplete` makes that loud: a test collects the actual
+// registered tool names and asserts the tier map covers them exactly (see
+// tools.test.ts "every registered tool has exactly one tier").
 
 /** Runtime/inbox tools — visible to BOTH agent- and account-scoped credentials. */
 export const RUNTIME_TOOLS: ReadonlySet<string> = new Set([
@@ -77,4 +81,24 @@ export function toolNamesForScope(scope: Scope | string): ReadonlySet<string> {
 /** True if `name` is allowed for `scope`. */
 export function toolAllowedForScope(name: string, scope: Scope | string): boolean {
   return toolNamesForScope(scope).has(name);
+}
+
+/**
+ * Drift guard: assert the tier map covers the actually-registered tools EXACTLY.
+ * Throws if any registered tool is untiered (would be silently hidden from every
+ * scope), double-tiered, or if a tier lists a name that isn't registered
+ * (phantom). Call from a test with the real registered tool names.
+ */
+export function assertToolTiersComplete(registered: Iterable<string>): void {
+  const reg = new Set(registered);
+  const untiered = [...reg].filter((n) => !RUNTIME_TOOLS.has(n) && !ADMIN_TOOLS.has(n));
+  const doubled = [...reg].filter((n) => RUNTIME_TOOLS.has(n) && ADMIN_TOOLS.has(n));
+  const phantom = [...RUNTIME_TOOLS, ...ADMIN_TOOLS].filter((n) => !reg.has(n));
+  const problems: string[] = [];
+  if (untiered.length) problems.push(`untiered (hidden from all scopes): ${untiered.join(", ")}`);
+  if (doubled.length) problems.push(`in both tiers: ${doubled.join(", ")}`);
+  if (phantom.length) problems.push(`tiered but not registered: ${phantom.join(", ")}`);
+  if (problems.length) {
+    throw new Error(`tool tier map out of sync — ${problems.join("; ")}`);
+  }
 }

--- a/mcp/src/tools/tiers.ts
+++ b/mcp/src/tools/tiers.ts
@@ -1,0 +1,80 @@
+// Tool tier map — the single source of truth for §6a scope-gating.
+//
+// The MCP surface splits by persona, exposed per credential scope (§5/§6a):
+//   - runtime (scope=agent): what a deployed agent uses every turn. An
+//     `agent`-scoped credential sees ONLY these.
+//   - admin   (scope=account): provisioning/setup. An `account`-scoped
+//     credential sees runtime + admin (the full surface).
+//
+// This is a UX / decision-space optimization, NOT the security boundary — the
+// backend enforces scope per-handler regardless (an agent-scoped credential is
+// 403'd on account ops even if a tool were mis-listed). Keeping the classifica-
+// tion here (one auditable place) mirrors the design's "the drift-gate map
+// records each tool's tier next to its operationId".
+//
+// INVARIANT: every registered tool name MUST appear in exactly one set below.
+// A new tool with no tier is a bug — `assertToolTiersComplete` (tested) guards it.
+
+/** Runtime/inbox tools — visible to BOTH agent- and account-scoped credentials. */
+export const RUNTIME_TOOLS: ReadonlySet<string> = new Set([
+  "whoami",
+  "list_agents",
+  "get_agent",
+  "list_messages",
+  "get_message",
+  "get_attachment",
+  "update_message_labels",
+  "list_conversations",
+  "get_conversation",
+  "send_message",
+  "reply_to_message",
+  "forward_message",
+  "approve_message",
+  "reject_message",
+  "list_pending_messages",
+  "get_pending_message",
+]);
+
+/** Admin/setup tools — visible ONLY to account-scoped credentials. */
+export const ADMIN_TOOLS: ReadonlySet<string> = new Set([
+  "create_agent",
+  "update_agent",
+  "delete_agent",
+  "list_domains",
+  "get_domain",
+  "register_domain",
+  "verify_domain",
+  "delete_domain",
+  "list_webhooks",
+  "get_webhook",
+  "create_webhook",
+  "update_webhook",
+  "delete_webhook",
+  "rotate_webhook_secret",
+  "test_webhook",
+  "list_webhook_deliveries",
+  "list_events",
+  "get_event",
+  "redeliver_event",
+]);
+
+export type Scope = "account" | "agent";
+
+/**
+ * The set of tool names a given credential scope may see.
+ * - `agent`   → runtime only.
+ * - `account` → runtime + admin (full surface).
+ * Any unrecognized scope falls back to runtime (least privilege).
+ */
+export function toolNamesForScope(scope: Scope | string): ReadonlySet<string> {
+  if (scope === "account") {
+    return new Set([...RUNTIME_TOOLS, ...ADMIN_TOOLS]);
+  }
+  // agent, or anything unexpected → least privilege.
+  return RUNTIME_TOOLS;
+}
+
+/** True if `name` is allowed for `scope`. */
+export function toolAllowedForScope(name: string, scope: Scope | string): boolean {
+  return toolNamesForScope(scope).has(name);
+}

--- a/mcp/src/tools/webhooks.ts
+++ b/mcp/src/tools/webhooks.ts
@@ -47,6 +47,7 @@ export function registerWebhookTools(server: McpServer, client: McpClient): void
     "list_webhooks",
     {
       title: "List webhook subscribers",
+      annotations: { readOnlyHint: true },
       description:
         "Returns every webhook subscriber owned by the authenticated user, enabled + disabled, with their event subscriptions, filters, and last-delivered timestamp. signing_secret is omitted (it is only ever returned on create + rotate). Read-only; cheap.",
       inputSchema: strictInputSchema({}),
@@ -58,6 +59,7 @@ export function registerWebhookTools(server: McpServer, client: McpClient): void
     "get_webhook",
     {
       title: "Show one webhook subscriber",
+      annotations: { readOnlyHint: true },
       description:
         "Fetch a single webhook by id. signing_secret is omitted — use rotate_webhook_secret if the secret was lost.",
       inputSchema: strictInputSchema({
@@ -71,6 +73,7 @@ export function registerWebhookTools(server: McpServer, client: McpClient): void
     "create_webhook",
     {
       title: "Create a webhook subscriber (returns plaintext signing_secret ONCE)",
+      annotations: { destructiveHint: false },
       description:
         "Subscribe an HTTPS URL to one or more events. URL must be HTTPS and must resolve to a public IP (SSRF guard). The response includes a plaintext signing_secret which the caller MUST persist immediately — every subsequent list/get scrubs it. Per-user cap is 50 webhooks; rotate_webhook_secret rotates the secret in place with a 24h dual-sign grace window.",
       inputSchema: strictInputSchema({
@@ -100,6 +103,7 @@ export function registerWebhookTools(server: McpServer, client: McpClient): void
     "update_webhook",
     {
       title: "Update a webhook subscriber",
+      annotations: { idempotentHint: true, destructiveHint: false },
       description:
         "Partial update. Fields you do NOT pass are left unchanged. url / events / filters are full-replace when present (no array merge). Use enabled:false to pause delivery without losing config; enabled:true re-enables (subject to a 5-min cooldown after auto-disable).",
       inputSchema: strictInputSchema({
@@ -127,6 +131,7 @@ export function registerWebhookTools(server: McpServer, client: McpClient): void
     "delete_webhook",
     {
       title: "Delete a webhook subscriber (DESTRUCTIVE)",
+      annotations: { destructiveHint: true, idempotentHint: true },
       description:
         "Permanently remove a webhook subscription. CASCADES to pending delivery rows. Requires confirm:true so an LLM cannot delete on ambiguous context.",
       inputSchema: strictInputSchema({
@@ -148,6 +153,7 @@ export function registerWebhookTools(server: McpServer, client: McpClient): void
     "rotate_webhook_secret",
     {
       title: "Rotate a webhook's signing secret (returns new plaintext ONCE)",
+      annotations: { destructiveHint: false },
       description:
         "Generate a new signing_secret and move the current one into a 24h grace window during which the worker dual-signs each delivery (two v1= entries on X-E2A-Signature). The new plaintext is returned ONCE — every subsequent list/get scrubs it. Use when the previous secret was leaked or rotated by policy.",
       inputSchema: strictInputSchema({
@@ -161,6 +167,7 @@ export function registerWebhookTools(server: McpServer, client: McpClient): void
     "test_webhook",
     {
       title: "Fire a synthetic event to a webhook for debugging",
+      annotations: { destructiveHint: false },
       description:
         "Schedules a one-off delivery to the webhook with a synthetic envelope, bypassing filter matching. Returns the delivery_id; inspect the outcome (status/attempts/last_error) via `list_webhook_deliveries`. Returns an error if the webhook is disabled. Cheap and safe — the synthetic event does not touch real inbound or HITL state.",
       inputSchema: strictInputSchema({
@@ -181,6 +188,7 @@ export function registerWebhookTools(server: McpServer, client: McpClient): void
     "list_webhook_deliveries",
     {
       title: "List recent delivery attempts for a webhook",
+      annotations: { readOnlyHint: true },
       description:
         "Returns the most recent delivery rows for one webhook. Each row includes status (pending|delivered|failed), attempts, last_error, last_status_code, and timestamps. The way to debug why a subscriber is missing events, or to check the outcome of a `test_webhook` call. Read-only. Distinct from `list_events` (the account-wide event log); this is the per-webhook delivery ledger.",
       inputSchema: strictInputSchema({

--- a/mcp/tests/events-streamable-http.test.ts
+++ b/mcp/tests/events-streamable-http.test.ts
@@ -13,6 +13,7 @@ import { startHttpServer } from "../src/http-server.js";
 function makeStubClient(): McpClient {
   const stub = {
     agentEmail: "bot@example.com",
+    scope: "account" as const,
     getMessage: vi.fn(async () => ({ messageId: "m" })),
     getAgent: vi.fn(async () => ({ id: "x@y", email: "x@y" })),
     listAgents: vi.fn(async () => [{ email: "bot@example.com" }]),

--- a/mcp/tests/events.test.ts
+++ b/mcp/tests/events.test.ts
@@ -13,6 +13,7 @@ import { buildServer } from "../src/server.js";
 function makeStubClient(): McpClient {
   const stub = {
     agentEmail: "bot@example.com",
+    scope: "account" as const,
     // Events methods on the wrapper.
     listEvents: vi.fn(async (_params?: Record<string, unknown>) => [
       {

--- a/mcp/tests/http.test.ts
+++ b/mcp/tests/http.test.ts
@@ -11,6 +11,8 @@ import { Sessions } from "../src/session.js";
 function makeStubClient(): McpClient {
   const stub = {
     agentEmail: "bot@example.com",
+    scope: "account" as const,
+    whoami: vi.fn(async () => ({ user: "owner@example.com", scope: "account", agentAddress: undefined })),
     getMessage: vi.fn(async (id: string) => ({ messageId: id })),
     getAgent: vi.fn(async (e: string) => ({ id: e, email: e })),
     send: vi.fn(async () => ({ messageId: "msg_sent", status: "sent" })),
@@ -92,9 +94,9 @@ describe("HTTP MCP server", () => {
     await close();
     const sessions = new Sessions({ idleTimeoutMs: 60_000, maxSessions: 10 });
     const invalidStub = makeStubClient();
-    invalidStub.listAgents = vi.fn(async () => {
+    invalidStub.whoami = vi.fn(async () => {
       throw makeHttpError(401);
-    }) as McpClient["listAgents"];
+    }) as McpClient["whoami"];
     const { close: c, port } = await startHttpServer(0, {
       baseUrl: "http://e2a.local",
       allowedHosts: ["127.0.0.1", "localhost"],
@@ -129,7 +131,7 @@ describe("HTTP MCP server", () => {
     );
     expect(res.headers.get("mcp-session-id")).toBeNull();
     expect(sessions.size()).toBe(0);
-    expect(invalidStub.listAgents).toHaveBeenCalledOnce();
+    expect(invalidStub.whoami).toHaveBeenCalledOnce();
     const body = await res.json();
     expect(body.error.message).toMatch(/invalid bearer/);
   });
@@ -287,135 +289,113 @@ describe("HTTP MCP server", () => {
     await transport.close();
   });
 
-  describe("session-init agent prefetch", () => {
-    // The prefetch resolves a default agent_email at session-init when
-    // (a) E2A_AGENT_EMAIL is unset on the constructed client, and
-    // (b) listAgents() yields exactly one agent.
-    // We drive it via clientFactory so we can stub listAgents and
-    // observe whether the resolved email gets passed back through.
+  describe("session-init scope + agent resolution", () => {
+    // buildSessionClient resolves the credential's scope and bound agent from
+    // whoami (GET /account): agent scope pins the bound agent (whoami
+    // agent_address) and exposes the runtime tier; account scope has no default
+    // agent and exposes the full surface. We drive it via clientFactory to
+    // observe what the final client is constructed with. The factory is called
+    // twice: the whoami probe (bearer only), then the final client
+    // (bearer + resolved {agentEmail?, scope}).
 
     function makeProbeClient(opts: {
-      initialEmail?: string;
-      agents: Array<{ email: string }>;
-      listAgentsThrows?: boolean;
+      scope?: "account" | "agent";
+      agentAddress?: string;
+      whoamiThrows?: boolean | "unauthorized";
     }): McpClient {
       return {
-        agentEmail: opts.initialEmail ?? "",
-        send: vi.fn(),
-        reply: vi.fn(),
-        listMessages: vi.fn(async () => []),
-        listAgents: vi.fn(async () => {
-          if (opts.listAgentsThrows) throw new Error("upstream 500");
-          return opts.agents;
+        agentEmail: "",
+        scope: opts.scope ?? "account",
+        whoami: vi.fn(async () => {
+          if (opts.whoamiThrows === "unauthorized") throw makeHttpError(401);
+          if (opts.whoamiThrows) throw new Error("upstream 500");
+          return {
+            user: "owner@example.com",
+            scope: opts.scope ?? "account",
+            agentAddress: opts.agentAddress,
+          };
         }),
-        createAgent: vi.fn(),
-        listPendingMessages: vi.fn(async () => []),
-        getPendingMessage: vi.fn(),
-        approveMessage: vi.fn(),
-        rejectMessage: vi.fn(),
+        listMessages: vi.fn(async () => []),
+        listAgents: vi.fn(async () => []),
       } as unknown as McpClient;
     }
 
-    it("resolves agent_email when listAgents returns exactly one agent", async () => {
-      const probe = makeProbeClient({ agents: [{ email: "solo@bot.example.com" }] });
-      const final = makeProbeClient({
-        initialEmail: "solo@bot.example.com",
-        agents: [{ email: "solo@bot.example.com" }],
-      });
-      const factory = vi.fn((_bearer: string, factoryOpts?: { agentEmail?: string }) =>
-        factoryOpts?.agentEmail ? final : probe,
-      );
-
+    async function startWithFactory(
+      factory: (bearer: string, o?: { agentEmail?: string; scope?: string }) => McpClient,
+    ) {
       await close();
       const { close: c, port } = await startHttpServer(0, {
         baseUrl: "http://e2a.local",
         allowedHosts: ["127.0.0.1", "localhost"],
-        clientFactory: factory,
+        clientFactory: factory as never,
       });
       close = c;
       url = `http://127.0.0.1:${port}/mcp`;
+    }
+
+    it("agent scope pins the credential-bound agent from whoami", async () => {
+      const probe = makeProbeClient({ scope: "agent", agentAddress: "solo@bot.example.com" });
+      const factory = vi.fn(() => probe);
+      await startWithFactory(factory);
 
       const { transport } = await connect();
-      // Factory called twice: probe construction (no agentEmail), then
-      // final construction with the resolved email.
+      expect(probe.whoami).toHaveBeenCalledOnce();
+      // Probe (bearer only), then final with the resolved agent + scope.
       expect(factory).toHaveBeenCalledTimes(2);
       expect(factory.mock.calls[0]).toEqual(["e2a_test"]);
       expect(factory.mock.calls[1]).toEqual([
         "e2a_test",
-        { agentEmail: "solo@bot.example.com" },
+        { agentEmail: "solo@bot.example.com", scope: "agent" },
       ]);
-      expect(probe.listAgents).toHaveBeenCalledOnce();
       await transport.close();
     });
 
-    it("validates the bearer but skips reconstruction when agentEmail is already set", async () => {
-      // Stub from beforeEach already has agentEmail "bot@example.com".
-      const factory = vi.fn(() => stub);
-      await close();
-      const { close: c, port } = await startHttpServer(0, {
-        baseUrl: "http://e2a.local",
-        allowedHosts: ["127.0.0.1", "localhost"],
-        clientFactory: factory,
-      });
-      close = c;
-      url = `http://127.0.0.1:${port}/mcp`;
+    it("account scope resolves to the full surface with no default agent", async () => {
+      const probe = makeProbeClient({ scope: "account" });
+      const factory = vi.fn(() => probe);
+      await startWithFactory(factory);
 
       const { transport } = await connect();
-      // Factory called once with just the bearer — no resolved email
-      // since the env-var path (constructor) already populated it.
-      expect(factory).toHaveBeenCalledTimes(1);
-      expect(factory.mock.calls[0]).toEqual(["e2a_test"]);
-      // listAgents still validates the bearer once at session init,
-      // but does not trigger a second construction for auto-resolution.
-      expect(stub.listAgents).toHaveBeenCalledOnce();
+      expect(factory).toHaveBeenCalledTimes(2);
+      // No agentEmail for account scope — explicit email required per §6a.
+      expect(factory.mock.calls[1]).toEqual(["e2a_test", { scope: "account" }]);
       await transport.close();
     });
 
-    it("leaves agentEmail empty when the account has multiple agents", async () => {
-      const probe = makeProbeClient({
-        agents: [
-          { email: "a@bot.example.com" },
-          { email: "b@bot.example.com" },
-        ],
-      });
+    it("whoami non-auth failure falls back to least-privilege agent scope (session still inits)", async () => {
+      const probe = makeProbeClient({ whoamiThrows: true });
       const factory = vi.fn(() => probe);
-      await close();
-      const { close: c, port } = await startHttpServer(0, {
-        baseUrl: "http://e2a.local",
-        allowedHosts: ["127.0.0.1", "localhost"],
-        clientFactory: factory,
-      });
-      close = c;
-      url = `http://127.0.0.1:${port}/mcp`;
+      await startWithFactory(factory);
 
-      const { transport } = await connect();
-      // Factory called exactly once — probe ran, but no resolution
-      // (>1 agent), so the second construction was skipped.
-      expect(factory).toHaveBeenCalledTimes(1);
-      expect(probe.listAgents).toHaveBeenCalledOnce();
-      await transport.close();
-    });
-
-    it("does not block session init when listAgents throws", async () => {
-      const probe = makeProbeClient({ agents: [], listAgentsThrows: true });
-      const factory = vi.fn(() => probe);
-      await close();
-      const { close: c, port } = await startHttpServer(0, {
-        baseUrl: "http://e2a.local",
-        allowedHosts: ["127.0.0.1", "localhost"],
-        clientFactory: factory,
-      });
-      close = c;
-      url = `http://127.0.0.1:${port}/mcp`;
-
-      // Initialize should succeed even though the prefetch errored.
       const { client, transport } = await connect();
       const { tools } = await client.listTools();
-      expect(tools.length).toBeGreaterThan(0);
-      expect(probe.listAgents).toHaveBeenCalledOnce();
-      // No re-construction since resolution failed.
-      expect(factory).toHaveBeenCalledTimes(1);
+      expect(tools.length).toBeGreaterThan(0); // initialize not blocked
+      // Fail-closed: runtime/agent scope, no default agent.
+      expect(factory.mock.calls[1]).toEqual(["e2a_test", { scope: "agent" }]);
       await transport.close();
+    });
+
+    it("whoami 401 rejects session init as invalid bearer", async () => {
+      const probe = makeProbeClient({ whoamiThrows: "unauthorized" });
+      const factory = vi.fn(() => probe);
+      await startWithFactory(factory);
+
+      const res = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+          Authorization: "Bearer bogus_token",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "x", version: "0" } },
+        }),
+      });
+      expect(res.status).toBe(401);
+      expect(probe.whoami).toHaveBeenCalledOnce();
     });
   });
 

--- a/mcp/tests/http.test.ts
+++ b/mcp/tests/http.test.ts
@@ -289,6 +289,37 @@ describe("HTTP MCP server", () => {
     await transport.close();
   });
 
+  it("over the wire, an agent-scoped session lists only the runtime tier", async () => {
+    // End-to-end scope-gating across the real Streamable-HTTP transport: a
+    // session whose whoami reports agent scope sees the 16 runtime tools and
+    // none of the admin tools — proven over JSON-RPC, not just in-process.
+    await close();
+    const agentStub = makeStubClient();
+    (agentStub as { scope: string }).scope = "agent";
+    agentStub.whoami = vi.fn(async () => ({
+      user: "owner@example.com",
+      scope: "agent",
+      agentAddress: "bot@example.com",
+    })) as McpClient["whoami"];
+    const { close: c, port } = await startHttpServer(0, {
+      baseUrl: "http://e2a.local",
+      allowedHosts: ["127.0.0.1", "localhost"],
+      // Factory returns the agent-scoped stub for both probe and final make().
+      clientFactory: () => agentStub,
+    });
+    close = c;
+    url = `http://127.0.0.1:${port}/mcp`;
+
+    const { client, transport } = await connect();
+    const names = new Set((await client.listTools()).tools.map((t) => t.name));
+    expect(names.size).toBe(16);
+    expect(names.has("send_message")).toBe(true); // runtime present
+    expect(names.has("create_agent")).toBe(false); // admin hidden
+    expect(names.has("delete_domain")).toBe(false);
+    expect(names.has("list_webhooks")).toBe(false);
+    await transport.close();
+  });
+
   describe("session-init scope + agent resolution", () => {
     // buildSessionClient resolves the credential's scope and bound agent from
     // whoami (GET /account): agent scope pins the bound agent (whoami

--- a/mcp/tests/http.test.ts
+++ b/mcp/tests/http.test.ts
@@ -312,11 +312,14 @@ describe("HTTP MCP server", () => {
 
     const { client, transport } = await connect();
     const names = new Set((await client.listTools()).tools.map((t) => t.name));
-    expect(names.size).toBe(16);
+    expect(names.size).toBe(14);
     expect(names.has("send_message")).toBe(true); // runtime present
     expect(names.has("create_agent")).toBe(false); // admin hidden
     expect(names.has("delete_domain")).toBe(false);
     expect(names.has("list_webhooks")).toBe(false);
+    // approve/reject are account-scope (self-approval would defeat HITL).
+    expect(names.has("approve_message")).toBe(false);
+    expect(names.has("reject_message")).toBe(false);
     await transport.close();
   });
 

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -250,22 +250,24 @@ describe("e2a MCP server", () => {
     expect(tools).toHaveLength(35);
   });
 
-  it("agent scope exposes only the 16 runtime tools — admin tools hidden", async () => {
+  it("agent scope exposes only the 14 runtime tools — admin tools hidden", async () => {
     const ag = await connect(makeStubClient({ scope: "agent" }));
     const names = new Set((await ag.listTools()).tools.map((t) => t.name));
-    expect(names.size).toBe(16);
-    // Runtime tools present:
+    expect(names.size).toBe(14);
+    // Runtime tools present (an agent can send + read its own pending queue,
+    // but NOT approve/reject — that's an account-owner action, see below):
     for (const n of [
       "whoami", "list_agents", "get_agent", "list_messages", "get_message",
       "get_attachment", "update_message_labels", "list_conversations",
       "get_conversation", "send_message", "reply_to_message", "forward_message",
-      "approve_message", "reject_message", "list_pending_messages", "get_pending_message",
+      "list_pending_messages", "get_pending_message",
     ]) {
       expect(names.has(n), `runtime tool ${n} should be visible to agent scope`).toBe(true);
     }
-    // Admin tools hidden:
+    // Admin tools hidden — incl. approve/reject: self-approval would defeat HITL.
     for (const n of [
       "create_agent", "update_agent", "delete_agent",
+      "approve_message", "reject_message",
       "list_domains", "get_domain", "register_domain", "verify_domain", "delete_domain",
       "list_webhooks", "get_webhook", "create_webhook", "update_webhook",
       "delete_webhook", "rotate_webhook_secret", "test_webhook", "list_webhook_deliveries",

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -4,6 +4,14 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { simpleParser } from "mailparser";
 import type { McpClient } from "../src/client.js";
 import { buildServer } from "../src/server.js";
+import { assertToolTiersComplete, toolNamesForScope, RUNTIME_TOOLS } from "../src/tools/tiers.js";
+import { registerMessageTools } from "../src/tools/messages.js";
+import { registerAgentTools } from "../src/tools/agents.js";
+import { registerDomainTools } from "../src/tools/domains.js";
+import { registerHitlTools } from "../src/tools/hitl.js";
+import { registerWebhookTools } from "../src/tools/webhooks.js";
+import { registerEventTools } from "../src/tools/events.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 // Build a small RFC822 blob with one attachment so the MessageView's
 // `rawMessage` decodes to a known attachment set (the v1 MessageView no
@@ -204,6 +212,37 @@ describe("e2a MCP server", () => {
 
   // ── §6a scope/tier gating ──────────────────────────────────────────
   // account scope sees the full surface; agent scope sees only the runtime tier.
+
+  it("every registered tool has exactly one tier (drift guard)", () => {
+    // Collect the TRUE registered set by running the register*Tools functions
+    // against a name-recording fake server — BEFORE gating, so an untiered tool
+    // (which the gate would otherwise silently hide) is still caught.
+    const names: string[] = [];
+    const recorder = {
+      registerTool: (name: string) => {
+        names.push(name);
+        return undefined;
+      },
+    } as unknown as McpServer;
+    const stub = makeStubClient();
+    registerMessageTools(recorder, stub);
+    registerAgentTools(recorder, stub);
+    registerDomainTools(recorder, stub);
+    registerHitlTools(recorder, stub);
+    registerWebhookTools(recorder, stub);
+    registerEventTools(recorder, stub);
+
+    expect(names).toHaveLength(35);
+    // Throws if any registered tool is untiered / double-tiered / phantom.
+    expect(() => assertToolTiersComplete(names)).not.toThrow();
+  });
+
+  it("unrecognized scope falls back to the runtime tier (least privilege)", () => {
+    expect(toolNamesForScope("bogus")).toBe(RUNTIME_TOOLS);
+    expect(toolNamesForScope("")).toBe(RUNTIME_TOOLS);
+    expect(toolNamesForScope("agent")).toBe(RUNTIME_TOOLS);
+    expect(toolNamesForScope("account").size).toBe(35);
+  });
 
   it("account scope exposes all 35 tools (runtime + admin)", async () => {
     const acct = await connect(makeStubClient({ scope: "account" }));

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -253,6 +253,39 @@ describe("e2a MCP server", () => {
       .toHaveLength(0);
   });
 
+  // ── §6a tool annotations (#2) ───────────────────────────────────────
+
+  it("every tool carries MCP annotations with the correct hints", async () => {
+    const { tools } = await client.listTools(); // account scope → all 35
+    const byName = new Map(tools.map((t) => [t.name, t.annotations ?? {}]));
+
+    // Every tool has an annotations object.
+    for (const t of tools) {
+      expect(t.annotations, `${t.name} should carry annotations`).toBeDefined();
+    }
+
+    // Reads → readOnlyHint.
+    for (const n of ["list_messages", "get_message", "whoami", "list_domains", "get_event", "list_webhook_deliveries"]) {
+      expect(byName.get(n)?.readOnlyHint, `${n} readOnlyHint`).toBe(true);
+    }
+    // Deletes → destructive + idempotent.
+    for (const n of ["delete_agent", "delete_domain", "delete_webhook"]) {
+      expect(byName.get(n)?.destructiveHint, `${n} destructiveHint`).toBe(true);
+      expect(byName.get(n)?.idempotentHint, `${n} idempotentHint`).toBe(true);
+    }
+    // Idempotent non-destructive updates.
+    for (const n of ["update_agent", "update_webhook", "update_message_labels", "verify_domain", "register_domain"]) {
+      expect(byName.get(n)?.idempotentHint, `${n} idempotentHint`).toBe(true);
+      expect(byName.get(n)?.destructiveHint, `${n} destructiveHint`).toBe(false);
+    }
+    // Non-destructive writes (create/send) are explicitly non-destructive,
+    // and NOT read-only.
+    for (const n of ["create_agent", "send_message", "approve_message", "create_webhook"]) {
+      expect(byName.get(n)?.destructiveHint, `${n} destructiveHint`).toBe(false);
+      expect(byName.get(n)?.readOnlyHint ?? false, `${n} not read-only`).toBe(false);
+    }
+  });
+
   it("send_message forwards args to client.send", async () => {
     await client.callTool({
       name: "send_message",

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -39,9 +39,14 @@ const pdfBytes = Buffer.from("%PDF-1.4 fake pdf bytes");
 // Minimal stub of McpClient — only the methods our tools call. The
 // wrapper concentrates SDK calls and address resolution, so tests stub
 // it directly rather than the namespaced SDK underneath.
-function makeStubClient(overrides: Partial<{ agentEmail: string }> = {}): McpClient {
+function makeStubClient(
+  overrides: Partial<{ agentEmail: string; scope: "account" | "agent" }> = {},
+): McpClient {
   const stub = {
     agentEmail: overrides.agentEmail ?? "bot@example.com",
+    // scope drives §6a tier-gating in buildServer. Default to account (full
+    // surface) so behavior tests see every tool; gating tests pass "agent".
+    scope: overrides.scope ?? "account",
     send: vi.fn(async () => ({ messageId: "msg_sent", status: "sent" })),
     reply: vi.fn(async () => ({ messageId: "msg_reply", status: "sent" })),
     forward: vi.fn(async () => ({ messageId: "msg_fwd", status: "sent" })),
@@ -195,6 +200,57 @@ describe("e2a MCP server", () => {
         "redeliver_event",
       ].sort(),
     );
+  });
+
+  // ── §6a scope/tier gating ──────────────────────────────────────────
+  // account scope sees the full surface; agent scope sees only the runtime tier.
+
+  it("account scope exposes all 35 tools (runtime + admin)", async () => {
+    const acct = await connect(makeStubClient({ scope: "account" }));
+    const { tools } = await acct.listTools();
+    expect(tools).toHaveLength(35);
+  });
+
+  it("agent scope exposes only the 16 runtime tools — admin tools hidden", async () => {
+    const ag = await connect(makeStubClient({ scope: "agent" }));
+    const names = new Set((await ag.listTools()).tools.map((t) => t.name));
+    expect(names.size).toBe(16);
+    // Runtime tools present:
+    for (const n of [
+      "whoami", "list_agents", "get_agent", "list_messages", "get_message",
+      "get_attachment", "update_message_labels", "list_conversations",
+      "get_conversation", "send_message", "reply_to_message", "forward_message",
+      "approve_message", "reject_message", "list_pending_messages", "get_pending_message",
+    ]) {
+      expect(names.has(n), `runtime tool ${n} should be visible to agent scope`).toBe(true);
+    }
+    // Admin tools hidden:
+    for (const n of [
+      "create_agent", "update_agent", "delete_agent",
+      "list_domains", "get_domain", "register_domain", "verify_domain", "delete_domain",
+      "list_webhooks", "get_webhook", "create_webhook", "update_webhook",
+      "delete_webhook", "rotate_webhook_secret", "test_webhook", "list_webhook_deliveries",
+      "list_events", "get_event", "redeliver_event",
+    ]) {
+      expect(names.has(n), `admin tool ${n} must be hidden from agent scope`).toBe(false);
+    }
+  });
+
+  it("agent scope cannot call a hidden admin tool (errors + handler never runs)", async () => {
+    const agentStub = makeStubClient({ scope: "agent" });
+    const ag = await connect(agentStub);
+    let errored = false;
+    try {
+      const r = await ag.callTool({ name: "create_agent", arguments: { email: "x@y.dev" } });
+      errored = (r as { isError?: boolean })?.isError === true;
+    } catch {
+      errored = true; // unknown-tool protocol error
+    }
+    expect(errored, "calling a hidden admin tool must error").toBe(true);
+    // The wrapper method must never have been reached — hidden means uncallable,
+    // not merely unlisted.
+    expect((agentStub.createAgent as unknown as { mock: { calls: unknown[] } }).mock.calls)
+      .toHaveLength(0);
   });
 
   it("send_message forwards args to client.send", async () => {


### PR DESCRIPTION
## Summary

Implements §6a MCP enhancements **#1 (scope-gating)** and **#2 (annotations)**, and — surfaced during review — closes a **HITL self-approval hole** end-to-end. Mostly `mcp/`, plus one backend auth fix.

### #1 Scope-gating
A credential sees only its tier's tools: `agent` → **14 runtime/inbox tools**, `account` → **all 35**. Scope resolved from `whoami` (GET /account) at session init; gated at one seam in `server.ts`; tier map = `mcp/src/tools/tiers.ts` (with a real `assertToolTiersComplete` drift guard). Hidden tools are unlisted **and** uncallable.

### #2 Annotations
`readOnlyHint`/`destructiveHint`/`idempotentHint` on all 35 tools.

### HITL self-approval fix (added during review)
`approve_message`/`reject_message` were in the agent-visible tier, and the backend `handleApprove`/`handleReject` used `resolveOwnedAgent` (permits agent scope) — so a gated agent could **approve its own held outbound**, defeating HITL. Fixed end-to-end:
- **MCP:** approve/reject moved runtime → admin tier (agent scope can send + view its pending queue, not release it).
- **Backend (`internal/httpapi/hitl.go`):** both handlers now `requireAccountScope` → **403 for agent-scoped credentials, even on their own bound agent**. The human magic-link flow is a separate token-gated handler, unaffected.

## Notable behavior changes
- `buildSessionClient` resolves scope + bound agent from `whoami` (replaces the `listAgents` single-agent guess); single-agent auto-resolve dropped for account scope (explicit `email` per §6a); non-auth `whoami` failure → fail-closed to runtime tier.
- **Agent-scoped credentials can no longer approve/reject** (403). Account scope + human magic-link unchanged.

## Safety / review
MCP gating is UX; the backend is the boundary. Independent + adversarial review (read-only): adversarial **proved** (in-process + real HTTP) a hidden admin tool can't be invoked, fail-closed scope across 18 inputs, no client-controllable scope, session bearer-binding holds — **no security findings**. Independent: pass-with-risks; both flagged a phantom guard comment → **fixed** with a real drift guard + test.

## Verification
- **123 MCP tests** (incl. account=35 / agent=14, hidden-tool-uncallable, annotations, over-the-wire scope gating, session-init resolution).
- **httpapi suite green** incl. `TestScope_ApproveRejectIsAccountOnly` (agent→403 on own agent); existing account-scope approve/reject still 200; spec drift clean.
- SDK + CLI build clean.

## Deferred
§6a #4 (error code), #5 (attachment download-URL), #7 (idempotency-key on creates). Broader #247-era README drift beyond the `create_agent` row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)