### PR TITLE
Production-safe self-test, synthetic prober & deploy bake-gate (main-repo slices)

### DIFF
--- a/cmd/e2a-prober/config.go
+++ b/cmd/e2a-prober/config.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"os"
+	"time"
+)
+
+// config is the prober's runtime configuration, sourced entirely from env so
+// the same binary runs in compose, CI, and locally with no flags.
+type config struct {
+	DatabaseURL   string // seed, validate
+	BaseURL       string // run-once, serve
+	SMTPAddr      string // run-once, serve
+	AgentEmail    string
+	APIKey        string
+	WebhookSecret string
+	SinkURL       string        // what the probe webhook targets (== Listen's public addr + /sink)
+	Listen        string        // serve/run-once bind addr for the sink + status server
+	Interval      time.Duration // serve loop period
+	Timeout       time.Duration // round-trip await timeout
+}
+
+func configFromEnv() config {
+	return config{
+		DatabaseURL:   os.Getenv("E2A_DATABASE_URL"),
+		BaseURL:       os.Getenv("E2A_PROBE_BASE_URL"),
+		SMTPAddr:      os.Getenv("E2A_PROBE_SMTP_ADDR"),
+		AgentEmail:    os.Getenv("E2A_PROBE_AGENT_EMAIL"),
+		APIKey:        os.Getenv("E2A_PROBE_API_KEY"),
+		WebhookSecret: os.Getenv("E2A_PROBE_WEBHOOK_SECRET"),
+		SinkURL:       os.Getenv("E2A_PROBE_SINK_URL"),
+		Listen:        envOr("E2A_PROBE_LISTEN", ":8090"),
+		Interval:      envDuration("E2A_PROBE_INTERVAL", 30*time.Second),
+		Timeout:       envDuration("E2A_PROBE_TIMEOUT", 30*time.Second),
+	}
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func envDuration(key string, def time.Duration) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+	return def
+}

--- a/cmd/e2a-prober/main.go
+++ b/cmd/e2a-prober/main.go
@@ -1,0 +1,91 @@
+// Command e2a-prober runs the e2a critical-path self-test (internal/selftest)
+// against a live instance, four ways:
+//
+//	seed      — idempotently provision the synthetic system-class probe account,
+//	            agent, API key, and webhook (prints credentials to capture in env).
+//	validate  — pre-flight: config parses, DB reachable, migrations applied,
+//	            probe identity present. No round-trip. (vault-diagnose style.)
+//	run-once  — run the battery once, exit 0 (all pass) / 1 (any fail). For CI.
+//	serve     — loop every interval; host /sink, /healthz, /metrics, /status for
+//	            the continuous monitor and the deploy bake-gate.
+//
+// The probe runs under a system-class account, so its traffic is never metered
+// (usage.PolicyFor); self-send uses loopback (no egress); inbound is synthetic
+// mail to the probe agent (no real recipient, no owner notification).
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/migrations"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		usage()
+		os.Exit(2)
+	}
+	ctx := context.Background()
+	var err error
+	switch os.Args[1] {
+	case "seed":
+		err = cmdSeed(ctx, configFromEnv())
+	case "validate":
+		err = cmdValidate(ctx, configFromEnv())
+	case "run-once":
+		err = cmdRunOnce(ctx, configFromEnv())
+	case "serve":
+		err = cmdServe(ctx, configFromEnv())
+	case "-h", "--help", "help":
+		usage()
+		return
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command %q\n", os.Args[1])
+		usage()
+		os.Exit(2)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "e2a-prober %s: %v\n", os.Args[1], err)
+		os.Exit(1)
+	}
+}
+
+func usage() {
+	fmt.Fprint(os.Stderr, `e2a-prober — e2a critical-path self-test runner
+
+usage: e2a-prober <seed|validate|run-once|serve>
+
+env:
+  E2A_DATABASE_URL          Postgres URL (seed, validate)
+  E2A_PROBE_BASE_URL        e2a HTTP base, e.g. http://e2a:8080 (run-once, serve)
+  E2A_PROBE_SMTP_ADDR       e2a SMTP listener host:port (run-once, serve)
+  E2A_PROBE_AGENT_EMAIL     synthetic probe agent address
+  E2A_PROBE_API_KEY         probe agent API key (Bearer)
+  E2A_PROBE_WEBHOOK_SECRET  probe webhook signing secret (HMAC verify)
+  E2A_PROBE_SINK_URL        URL the probe webhook posts to (== this prober's /sink)
+  E2A_PROBE_LISTEN          serve/run-once sink bind addr (default :8090)
+  E2A_PROBE_INTERVAL        serve probe interval (default 30s)
+  E2A_PROBE_TIMEOUT         round-trip await timeout (default 30s)
+`)
+}
+
+// openPool opens a pgx pool from E2A_DATABASE_URL (seed/validate only).
+func openPool(ctx context.Context, cfg config) (*pgxpool.Pool, error) {
+	if cfg.DatabaseURL == "" {
+		return nil, fmt.Errorf("E2A_DATABASE_URL is required")
+	}
+	return pgxpool.New(ctx, cfg.DatabaseURL)
+}
+
+// migrationsApplied reports nil if every embedded migration is recorded in
+// schema_migrations, else an error listing the pending ones — reused by both
+// validate and serve's /readyz-style checks via RunMigrations(ModeVerify),
+// which never applies anything.
+func migrationsApplied(ctx context.Context, pool *pgxpool.Pool) error {
+	return identity.RunMigrations(ctx, pool, migrations.FS, identity.ModeVerify)
+}

--- a/cmd/e2a-prober/prober_test.go
+++ b/cmd/e2a-prober/prober_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/identity"
 	"github.com/Mnexa-AI/e2a/internal/selftest"
 	"github.com/Mnexa-AI/e2a/internal/testutil"
+	"github.com/Mnexa-AI/e2a/migrations"
 )
 
 func TestSeedProbe_ProvisionsSystemAccountIdempotently(t *testing.T) {
@@ -166,4 +167,86 @@ func TestHandleMetrics_NoRuns(t *testing.T) {
 
 func itoa(n int64) string {
 	return strconv.FormatInt(n, 10)
+}
+
+func TestRequireRunConfig(t *testing.T) {
+	if err := requireRunConfig(config{}); err == nil {
+		t.Error("empty config should be rejected")
+	}
+	full := config{BaseURL: "http://x", SMTPAddr: "x:25", AgentEmail: "a@x", APIKey: "k", WebhookSecret: "s"}
+	if err := requireRunConfig(full); err != nil {
+		t.Errorf("complete config rejected: %v", err)
+	}
+	// Missing one field is still rejected and names it.
+	missing := full
+	missing.APIKey = ""
+	if err := requireRunConfig(missing); err == nil || !strings.Contains(err.Error(), "E2A_PROBE_API_KEY") {
+		t.Errorf("missing API key: err = %v, want it named", err)
+	}
+}
+
+// TestRunOnce_RecordsFailure drives a real runOnce against a server that fails
+// every request and confirms the failure flows through to the ring, /status
+// (healthy=false), and /metrics (success 0) — the signals the deploy bake-gate
+// and monitor consume.
+func TestRunOnce_RecordsFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	p := newProber(config{
+		BaseURL: srv.URL, SMTPAddr: "127.0.0.1:1", AgentEmail: "agent@probe.test",
+		APIKey: "k", WebhookSecret: "s", Timeout: 200 * time.Millisecond,
+	})
+	r := p.runOnce(context.Background())
+	if r.OK {
+		t.Fatal("runOnce against a 500 server should not be OK")
+	}
+	if len(p.ring) != 1 {
+		t.Fatalf("ring has %d runs, want 1", len(p.ring))
+	}
+
+	// /status reflects unhealthy, zero consecutive green.
+	rec := httptest.NewRecorder()
+	p.handleStatus(rec, httptest.NewRequest(http.MethodGet, "/status?since=0", nil))
+	var st struct {
+		ConsecutiveGreen int  `json:"consecutive_green"`
+		Healthy          bool `json:"healthy"`
+	}
+	_ = json.Unmarshal(rec.Body.Bytes(), &st)
+	if st.Healthy || st.ConsecutiveGreen != 0 {
+		t.Errorf("status: healthy=%v consecutive_green=%d, want false/0", st.Healthy, st.ConsecutiveGreen)
+	}
+
+	// /metrics reports the failed run.
+	rec2 := httptest.NewRecorder()
+	p.handleMetrics(rec2, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	if !strings.Contains(rec2.Body.String(), "e2a_selftest_success 0") {
+		t.Errorf("metrics missing success 0:\n%s", rec2.Body.String())
+	}
+}
+
+func TestCmdValidate_Failures(t *testing.T) {
+	ctx := context.Background()
+
+	// Missing agent email → rejected before any DB work.
+	if err := cmdValidate(ctx, config{}); err == nil {
+		t.Error("validate without agent email should fail")
+	}
+
+	// DB reachable + migrations recorded, but the probe identity is absent.
+	// RunMigrations populates schema_migrations (testutil applies DDL only) so
+	// cmdValidate's migrations-applied check passes and reaches the identity check.
+	pool := testutil.TestDB(t)
+	if err := identity.RunMigrations(ctx, pool, migrations.FS, identity.ModeAuto); err != nil {
+		t.Fatalf("record migrations: %v", err)
+	}
+	err := cmdValidate(ctx, config{
+		DatabaseURL: testutil.TestDBURL(),
+		AgentEmail:  "missing@nowhere.test",
+	})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("validate with missing identity: err = %v, want a not-found error", err)
+	}
 }

--- a/cmd/e2a-prober/prober_test.go
+++ b/cmd/e2a-prober/prober_test.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/selftest"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+)
+
+func TestSeedProbe_ProvisionsSystemAccountIdempotently(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	const agentEmail = "agent@probe.prober-test"
+	const sinkURL = "http://prober:8090/sink"
+
+	res, err := seedProbe(ctx, store, agentEmail, sinkURL)
+	if err != nil {
+		t.Fatalf("seedProbe: %v", err)
+	}
+	if res.APIKey == "" {
+		t.Error("expected an API key on first seed")
+	}
+	if res.WebhookSecret == "" {
+		t.Error("expected a webhook secret on first seed")
+	}
+
+	agent, err := store.GetAgentByID(ctx, agentEmail)
+	if err != nil {
+		t.Fatalf("GetAgentByID: %v", err)
+	}
+	var class string
+	if err := pool.QueryRow(ctx, `SELECT account_class FROM users WHERE id = $1`, agent.UserID).Scan(&class); err != nil {
+		t.Fatalf("read account_class: %v", err)
+	}
+	if class != "system" {
+		t.Errorf("account_class = %q, want system", class)
+	}
+
+	// Re-run: idempotent. No duplicate agent; webhook reused (secret empty).
+	res2, err := seedProbe(ctx, store, agentEmail, sinkURL)
+	if err != nil {
+		t.Fatalf("seedProbe re-run: %v", err)
+	}
+	if res2.WebhookSecret != "" {
+		t.Error("re-seed should reuse the existing webhook (empty secret)")
+	}
+	whs, err := store.ListWebhooksByUser(ctx, agent.UserID)
+	if err != nil {
+		t.Fatalf("ListWebhooksByUser: %v", err)
+	}
+	count := 0
+	for _, wh := range whs {
+		if wh.URL == sinkURL {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("webhooks targeting sink = %d, want 1 (no duplicate on re-seed)", count)
+	}
+	var agents int
+	if err := pool.QueryRow(ctx, `SELECT COUNT(*) FROM agent_identities WHERE user_id = $1`, agent.UserID).Scan(&agents); err != nil {
+		t.Fatalf("count agents: %v", err)
+	}
+	if agents != 1 {
+		t.Errorf("agent count = %d, want 1 (no duplicate on re-seed)", agents)
+	}
+}
+
+func TestHandleStatus_ConsecutiveGreen(t *testing.T) {
+	p := newProber(config{})
+	base := time.Unix(1_700_000_000, 0)
+	// oldest → newest: green, red, green, green  → tail consecutive_green = 2
+	p.ring = []run{
+		{At: base, OK: true},
+		{At: base.Add(1 * time.Second), OK: false},
+		{At: base.Add(2 * time.Second), OK: true},
+		{At: base.Add(3 * time.Second), OK: true},
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/status?since=0", nil)
+	p.handleStatus(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status code = %d", rec.Code)
+	}
+	var out struct {
+		ConsecutiveGreen int  `json:"consecutive_green"`
+		Healthy          bool `json:"healthy"`
+		Runs             []struct {
+			OK bool `json:"ok"`
+		} `json:"runs"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.ConsecutiveGreen != 2 {
+		t.Errorf("consecutive_green = %d, want 2", out.ConsecutiveGreen)
+	}
+	if !out.Healthy {
+		t.Error("healthy = false, want true (last run green)")
+	}
+	if len(out.Runs) != 4 {
+		t.Errorf("runs = %d, want 4", len(out.Runs))
+	}
+
+	// since filter excludes earlier runs.
+	rec2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodGet, "/status?since="+itoa(base.Add(2*time.Second).Unix()-1), nil)
+	p.handleStatus(rec2, req2)
+	var out2 struct {
+		Runs []struct{} `json:"runs"`
+	}
+	_ = json.Unmarshal(rec2.Body.Bytes(), &out2)
+	if len(out2.Runs) != 2 {
+		t.Errorf("since-filtered runs = %d, want 2", len(out2.Runs))
+	}
+}
+
+func TestHandleMetrics(t *testing.T) {
+	p := newProber(config{})
+	p.ring = []run{{
+		At: time.Unix(1_700_000_000, 0),
+		OK: true,
+		Results: []selftest.Result{
+			{Name: "liveness", Status: selftest.StatusPass, DurationMS: 10},
+			{Name: "inbound_round_trip", Status: selftest.StatusPass, DurationMS: 200},
+		},
+	}}
+	rec := httptest.NewRecorder()
+	p.handleMetrics(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body := rec.Body.String()
+	for _, want := range []string{
+		"e2a_selftest_success 1",
+		`e2a_selftest_scenario_success{scenario="liveness"} 1`,
+		`e2a_selftest_scenario_success{scenario="inbound_round_trip"} 1`,
+		"e2a_selftest_duration_seconds 0.210",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("metrics missing %q\n---\n%s", want, body)
+		}
+	}
+}
+
+func TestHandleMetrics_NoRuns(t *testing.T) {
+	p := newProber(config{})
+	rec := httptest.NewRecorder()
+	p.handleMetrics(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	if !strings.Contains(rec.Body.String(), "e2a_selftest_success 0") {
+		t.Errorf("expected success 0 with no runs, got:\n%s", rec.Body.String())
+	}
+}
+
+func itoa(n int64) string {
+	return strconv.FormatInt(n, 10)
+}

--- a/cmd/e2a-prober/prober_test.go
+++ b/cmd/e2a-prober/prober_test.go
@@ -54,6 +54,9 @@ func TestSeedProbe_ProvisionsSystemAccountIdempotently(t *testing.T) {
 	if res2.WebhookSecret != "" {
 		t.Error("re-seed should reuse the existing webhook (empty secret)")
 	}
+	if res2.APIKey != "" {
+		t.Error("re-seed should not mint a new API key when one exists (empty key)")
+	}
 	whs, err := store.ListWebhooksByUser(ctx, agent.UserID)
 	if err != nil {
 		t.Fatalf("ListWebhooksByUser: %v", err)

--- a/cmd/e2a-prober/seed.go
+++ b/cmd/e2a-prober/seed.go
@@ -1,0 +1,123 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+)
+
+const (
+	probeUserEmail  = "prober@e2a.system"
+	probeUserName   = "e2a prober"
+	probeGoogleSub  = "e2a-prober-system" // fixed → CreateOrGetUser is idempotent
+	probeWebhookDsc = "e2a-prober selftest sink"
+)
+
+// seedResult holds the credentials a freshly-seeded probe needs. The API key and
+// webhook secret are only recoverable at creation, so the operator must capture
+// them into the prober's env (E2A_PROBE_API_KEY / E2A_PROBE_WEBHOOK_SECRET).
+type seedResult struct {
+	AgentEmail    string
+	APIKey        string // empty if not (re)created this run
+	WebhookSecret string // empty if the webhook already existed
+}
+
+// seedProbe idempotently provisions the synthetic probe account and identity:
+// a system-class user, a verified domain, the probe agent (open inbound policy,
+// HITL off — both defaults), an API key, and a webhook → sinkURL. The user,
+// domain, and agent are find-or-create; the API key is always (re)created; the
+// webhook is created only if none already targets sinkURL.
+func seedProbe(ctx context.Context, store *identity.Store, agentEmail, sinkURL string) (*seedResult, error) {
+	parts := strings.SplitN(agentEmail, "@", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return nil, fmt.Errorf("invalid agent email %q", agentEmail)
+	}
+	domain := parts[1]
+
+	user, err := store.CreateOrGetUser(ctx, probeUserEmail, probeUserName, probeGoogleSub)
+	if err != nil {
+		return nil, fmt.Errorf("create probe user: %w", err)
+	}
+	if err := store.SetAccountClass(ctx, user.ID, "system"); err != nil {
+		return nil, fmt.Errorf("set system class: %w", err)
+	}
+
+	dom, err := store.ClaimOrCreateDomain(ctx, domain, user.ID)
+	if err != nil {
+		return nil, fmt.Errorf("claim domain %s: %w", domain, err)
+	}
+	// VerifyDomain is not idempotent (it errors on an already-verified domain),
+	// so only verify when needed — keeps re-seeding safe.
+	if !dom.Verified {
+		if err := store.VerifyDomain(ctx, domain, user.ID); err != nil {
+			return nil, fmt.Errorf("verify domain %s: %w", domain, err)
+		}
+	}
+
+	if _, err := store.GetAgentByID(ctx, agentEmail); err != nil {
+		// Not found → create. (GetAgentByID returns an error for a missing agent.)
+		if _, cerr := store.CreateAgent(ctx, agentEmail, domain, "e2a prober", "", "cloud", user.ID); cerr != nil {
+			return nil, fmt.Errorf("create probe agent: %w", cerr)
+		}
+	}
+
+	res := &seedResult{AgentEmail: agentEmail}
+
+	key, err := store.CreateAPIKey(ctx, user.ID, "e2a-prober", nil)
+	if err != nil {
+		return nil, fmt.Errorf("create api key: %w", err)
+	}
+	res.APIKey = key.PlaintextKey
+
+	existing, err := store.ListWebhooksByUser(ctx, user.ID)
+	if err != nil {
+		return nil, fmt.Errorf("list webhooks: %w", err)
+	}
+	var found bool
+	for _, wh := range existing {
+		if wh.URL == sinkURL {
+			found = true
+			break
+		}
+	}
+	if !found {
+		wh, err := store.CreateWebhook(ctx, user.ID, sinkURL, probeWebhookDsc,
+			[]string{"email.received"}, identity.WebhookFilters{})
+		if err != nil {
+			return nil, fmt.Errorf("create webhook: %w", err)
+		}
+		res.WebhookSecret = wh.SigningSecret
+	}
+	return res, nil
+}
+
+// cmdSeed provisions the probe identity and prints credentials to capture in env.
+func cmdSeed(ctx context.Context, cfg config) error {
+	if cfg.AgentEmail == "" {
+		return fmt.Errorf("E2A_PROBE_AGENT_EMAIL is required")
+	}
+	if cfg.SinkURL == "" {
+		return fmt.Errorf("E2A_PROBE_SINK_URL is required (the webhook target)")
+	}
+	pool, err := openPool(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	defer pool.Close()
+	store := identity.NewStore(pool)
+
+	res, err := seedProbe(ctx, store, cfg.AgentEmail, cfg.SinkURL)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("probe agent:    %s\n", res.AgentEmail)
+	fmt.Printf("E2A_PROBE_API_KEY=%s\n", res.APIKey)
+	if res.WebhookSecret != "" {
+		fmt.Printf("E2A_PROBE_WEBHOOK_SECRET=%s\n", res.WebhookSecret)
+	} else {
+		fmt.Printf("# webhook to %s already existed; reuse its stored secret\n", cfg.SinkURL)
+	}
+	return nil
+}

--- a/cmd/e2a-prober/seed.go
+++ b/cmd/e2a-prober/seed.go
@@ -65,11 +65,20 @@ func seedProbe(ctx context.Context, store *identity.Store, agentEmail, sinkURL s
 
 	res := &seedResult{AgentEmail: agentEmail}
 
-	key, err := store.CreateAPIKey(ctx, user.ID, "e2a-prober", nil)
+	// Create an API key only if the probe user has none — re-seeding otherwise
+	// accumulates orphan keys (the plaintext is unrecoverable, so an existing
+	// key can't be re-displayed; the operator reuses the one captured first).
+	keys, err := store.ListAPIKeys(ctx, user.ID)
 	if err != nil {
-		return nil, fmt.Errorf("create api key: %w", err)
+		return nil, fmt.Errorf("list api keys: %w", err)
 	}
-	res.APIKey = key.PlaintextKey
+	if len(keys) == 0 {
+		key, err := store.CreateAPIKey(ctx, user.ID, "e2a-prober", nil)
+		if err != nil {
+			return nil, fmt.Errorf("create api key: %w", err)
+		}
+		res.APIKey = key.PlaintextKey
+	}
 
 	existing, err := store.ListWebhooksByUser(ctx, user.ID)
 	if err != nil {
@@ -113,7 +122,11 @@ func cmdSeed(ctx context.Context, cfg config) error {
 		return err
 	}
 	fmt.Printf("probe agent:    %s\n", res.AgentEmail)
-	fmt.Printf("E2A_PROBE_API_KEY=%s\n", res.APIKey)
+	if res.APIKey != "" {
+		fmt.Printf("E2A_PROBE_API_KEY=%s\n", res.APIKey)
+	} else {
+		fmt.Printf("# probe user already has an API key; reuse the one captured at first seed\n")
+	}
 	if res.WebhookSecret != "" {
 		fmt.Printf("E2A_PROBE_WEBHOOK_SECRET=%s\n", res.WebhookSecret)
 	} else {

--- a/cmd/e2a-prober/serve.go
+++ b/cmd/e2a-prober/serve.go
@@ -44,6 +44,7 @@ func (p *prober) probe() *selftest.Probe {
 		SMTPAddr:      p.cfg.SMTPAddr,
 		WebhookSecret: p.cfg.WebhookSecret,
 		Sink:          p.sink,
+		Timeout:       p.cfg.Timeout,
 	}
 }
 

--- a/cmd/e2a-prober/serve.go
+++ b/cmd/e2a-prober/serve.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/selftest"
+)
+
+// run is one full battery execution with a timestamp.
+type run struct {
+	At      time.Time         `json:"at"`
+	OK      bool              `json:"ok"`
+	Results []selftest.Result `json:"results"`
+}
+
+// prober holds the shared sink and a ring of recent runs for /metrics + /status.
+type prober struct {
+	cfg  config
+	sink *selftest.HTTPSink
+
+	mu   sync.Mutex
+	ring []run // most-recent-last, capped
+}
+
+const ringCap = 50
+
+func newProber(cfg config) *prober {
+	return &prober{cfg: cfg, sink: selftest.NewHTTPSink()}
+}
+
+func (p *prober) probe() *selftest.Probe {
+	return &selftest.Probe{
+		HTTPBaseURL:   p.cfg.BaseURL,
+		APIKey:        p.cfg.APIKey,
+		AgentEmail:    p.cfg.AgentEmail,
+		SMTPAddr:      p.cfg.SMTPAddr,
+		WebhookSecret: p.cfg.WebhookSecret,
+		Sink:          p.sink,
+	}
+}
+
+func (p *prober) runOnce(ctx context.Context) run {
+	results := selftest.Run(ctx, p.probe(), selftest.All, true /* smokeOnly */)
+	r := run{At: time.Now(), OK: selftest.Worst(results) == selftest.StatusPass, Results: results}
+	p.mu.Lock()
+	p.ring = append(p.ring, r)
+	if len(p.ring) > ringCap {
+		p.ring = p.ring[len(p.ring)-ringCap:]
+	}
+	p.mu.Unlock()
+	return r
+}
+
+// requireRunConfig validates the env needed to talk to a live instance.
+func requireRunConfig(cfg config) error {
+	missing := []string{}
+	for k, v := range map[string]string{
+		"E2A_PROBE_BASE_URL":       cfg.BaseURL,
+		"E2A_PROBE_SMTP_ADDR":      cfg.SMTPAddr,
+		"E2A_PROBE_AGENT_EMAIL":    cfg.AgentEmail,
+		"E2A_PROBE_API_KEY":        cfg.APIKey,
+		"E2A_PROBE_WEBHOOK_SECRET": cfg.WebhookSecret,
+	} {
+		if v == "" {
+			missing = append(missing, k)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("missing required env: %v", missing)
+	}
+	return nil
+}
+
+// cmdRunOnce runs the battery once and exits non-zero on any failure. It hosts
+// the sink on cfg.Listen so the probe webhook (seeded → cfg.SinkURL) can reach it.
+func cmdRunOnce(ctx context.Context, cfg config) error {
+	if err := requireRunConfig(cfg); err != nil {
+		return err
+	}
+	p := newProber(cfg)
+	srv := &http.Server{Addr: cfg.Listen, Handler: p.mux()}
+	go srv.ListenAndServe()
+	defer srv.Close()
+
+	r := p.runOnce(ctx)
+	for _, res := range r.Results {
+		fmt.Printf("%-22s %-4s %5dms  %s\n", res.Name, res.Status, res.DurationMS, res.Detail)
+	}
+	if !r.OK {
+		return fmt.Errorf("self-test failed")
+	}
+	return nil
+}
+
+// cmdServe loops the battery on an interval and serves /sink, /healthz,
+// /metrics, /status. Runs forever (until the process is signalled).
+func cmdServe(ctx context.Context, cfg config) error {
+	if err := requireRunConfig(cfg); err != nil {
+		return err
+	}
+	p := newProber(cfg)
+	srv := &http.Server{Addr: cfg.Listen, Handler: p.mux()}
+	go func() {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("[prober] serve: %v", err)
+		}
+	}()
+	log.Printf("[prober] serving on %s, probing %s every %s", cfg.Listen, cfg.BaseURL, cfg.Interval)
+
+	tk := time.NewTicker(cfg.Interval)
+	defer tk.Stop()
+	p.runOnce(ctx) // probe immediately, don't wait a full interval
+	for {
+		select {
+		case <-ctx.Done():
+			return srv.Close()
+		case <-tk.C:
+			r := p.runOnce(ctx)
+			if !r.OK {
+				log.Printf("[prober] probe FAILED: %s", firstFailure(r.Results))
+			}
+		}
+	}
+}
+
+// cmdValidate is a pre-flight: config parses, DB reachable, migrations applied,
+// probe identity present. No round-trip.
+func cmdValidate(ctx context.Context, cfg config) error {
+	if cfg.AgentEmail == "" {
+		return fmt.Errorf("E2A_PROBE_AGENT_EMAIL is required")
+	}
+	pool, err := openPool(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("db connect: %w", err)
+	}
+	defer pool.Close()
+	if err := pool.Ping(ctx); err != nil {
+		return fmt.Errorf("db ping: %w", err)
+	}
+	if err := migrationsApplied(ctx, pool); err != nil {
+		return fmt.Errorf("migrations: %w", err)
+	}
+	if _, err := identity.NewStore(pool).GetAgentByID(ctx, cfg.AgentEmail); err != nil {
+		return fmt.Errorf("probe agent %s not found (run `e2a-prober seed`): %w", cfg.AgentEmail, err)
+	}
+	fmt.Println("validate: ok (db reachable, migrations applied, probe identity present)")
+	return nil
+}
+
+func (p *prober) mux() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.Handle("/sink", p.sink)
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "ok")
+	})
+	mux.HandleFunc("/status", p.handleStatus)
+	mux.HandleFunc("/metrics", p.handleMetrics)
+	return mux
+}
+
+// handleStatus reports recent runs (optionally since a unix timestamp) and the
+// count of consecutive green runs at the tail — the deploy bake-gate polls this
+// and promotes once consecutive_green ≥ N.
+func (p *prober) handleStatus(w http.ResponseWriter, r *http.Request) {
+	var since time.Time
+	if s := r.URL.Query().Get("since"); s != "" {
+		if sec, err := strconv.ParseInt(s, 10, 64); err == nil {
+			since = time.Unix(sec, 0)
+		}
+	}
+	p.mu.Lock()
+	var runs []run
+	for _, rn := range p.ring {
+		if rn.At.After(since) {
+			runs = append(runs, rn)
+		}
+	}
+	p.mu.Unlock()
+
+	consecutive := 0
+	for i := len(runs) - 1; i >= 0; i-- {
+		if runs[i].OK {
+			consecutive++
+		} else {
+			break
+		}
+	}
+	out := map[string]any{
+		"since":             since.Unix(),
+		"runs":              runs,
+		"consecutive_green": consecutive,
+		"healthy":           len(runs) > 0 && runs[len(runs)-1].OK,
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(out)
+}
+
+// handleMetrics emits Prometheus text for the latest run.
+func (p *prober) handleMetrics(w http.ResponseWriter, _ *http.Request) {
+	p.mu.Lock()
+	var last *run
+	if len(p.ring) > 0 {
+		last = &p.ring[len(p.ring)-1]
+	}
+	p.mu.Unlock()
+
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4")
+	fmt.Fprintln(w, "# HELP e2a_selftest_success Whether the last probe run fully passed (1) or not (0).")
+	fmt.Fprintln(w, "# TYPE e2a_selftest_success gauge")
+	if last == nil {
+		fmt.Fprintln(w, "e2a_selftest_success 0")
+		return
+	}
+	fmt.Fprintf(w, "e2a_selftest_success %d\n", b2i(last.OK))
+	fmt.Fprintln(w, "# HELP e2a_selftest_scenario_success Per-scenario result of the last run (1 pass, 0 otherwise).")
+	fmt.Fprintln(w, "# TYPE e2a_selftest_scenario_success gauge")
+	var total time.Duration
+	for _, res := range last.Results {
+		fmt.Fprintf(w, "e2a_selftest_scenario_success{scenario=%q} %d\n", res.Name, b2i(res.Status == selftest.StatusPass))
+		total += time.Duration(res.DurationMS) * time.Millisecond
+	}
+	fmt.Fprintln(w, "# HELP e2a_selftest_duration_seconds Total duration of the last probe run.")
+	fmt.Fprintln(w, "# TYPE e2a_selftest_duration_seconds gauge")
+	fmt.Fprintf(w, "e2a_selftest_duration_seconds %.3f\n", total.Seconds())
+}
+
+func firstFailure(results []selftest.Result) string {
+	for _, r := range results {
+		if r.Status != selftest.StatusPass {
+			return fmt.Sprintf("%s: %s", r.Name, r.Detail)
+		}
+	}
+	return ""
+}
+
+func b2i(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -383,6 +383,11 @@ func main() {
 
 	api.RegisterRoutes(router)
 
+	// /readyz — instance-local readiness (DB reachable + migrations applied).
+	// Distinct from /api/health (shallow liveness); operational, not part of the
+	// /v1 contract, so it lives on this mux and never enters api/openapi.yaml.
+	router.HandleFunc("/readyz", readyzHandler(pool)).Methods(http.MethodGet)
+
 	// Public SES-over-SNS delivery notifications endpoint (decision 9 / Slice
 	// 4b). Fail-closed: the SNS signature is verified and the TopicArn must be
 	// in the configured allow-list (empty allow-list → every message is

--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -390,7 +390,7 @@ func main() {
 	// /selftest — deep dependency diagnostics (health+json), auth-gated by the
 	// internal API secret. Operational, not part of the /v1 contract. The full
 	// SMTP→webhook round-trip lives in the external e2a-prober, not here.
-	router.HandleFunc("/selftest", selftestHandler(pool, cfg.SMTP.ListenAddr, cfg.Limits.InternalAPISecret)).Methods(http.MethodGet)
+	router.HandleFunc("/selftest", selftestHandler(pool, cfg.SMTP.ListenAddr, cfg.Limits.InternalAPISecret, !cfg.IsProduction())).Methods(http.MethodGet)
 
 	// Public SES-over-SNS delivery notifications endpoint (decision 9 / Slice
 	// 4b). Fail-closed: the SNS signature is verified and the TopicArn must be

--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -387,6 +387,10 @@ func main() {
 	// Distinct from /api/health (shallow liveness); operational, not part of the
 	// /v1 contract, so it lives on this mux and never enters api/openapi.yaml.
 	router.HandleFunc("/readyz", readyzHandler(pool)).Methods(http.MethodGet)
+	// /selftest — deep dependency diagnostics (health+json), auth-gated by the
+	// internal API secret. Operational, not part of the /v1 contract. The full
+	// SMTP→webhook round-trip lives in the external e2a-prober, not here.
+	router.HandleFunc("/selftest", selftestHandler(pool, cfg.SMTP.ListenAddr, cfg.Limits.InternalAPISecret)).Methods(http.MethodGet)
 
 	// Public SES-over-SNS delivery notifications endpoint (decision 9 / Slice
 	// 4b). Fail-closed: the SNS signature is verified and the TopicArn must be

--- a/cmd/e2a/readyz.go
+++ b/cmd/e2a/readyz.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Mnexa-AI/e2a/migrations"
+)
+
+// readyzHandler reports instance-local readiness: the DB is reachable and the
+// latest embedded migration is recorded as applied. Unlike /api/health (shallow
+// liveness — never restart on a DB blip), /readyz signals "ready to serve" and
+// is the direct guard against the deploy-but-migration-didn't-apply failure
+// mode. It must NOT exercise downstream/round-trip dependencies — that is
+// /selftest's job (see docs/design/prober-selftest.md).
+func readyzHandler(pool *pgxpool.Pool) http.HandlerFunc {
+	latest := latestMigration()
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
+		defer cancel()
+
+		if err := pool.Ping(ctx); err != nil {
+			writeNotReady(w, "database unreachable")
+			return
+		}
+		if latest != "" {
+			var applied bool
+			err := pool.QueryRow(ctx,
+				`SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE filename = $1)`, latest,
+			).Scan(&applied)
+			if err != nil || !applied {
+				writeNotReady(w, "migrations not applied")
+				return
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprint(w, `{"status":"ready"}`)
+	}
+}
+
+func writeNotReady(w http.ResponseWriter, reason string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusServiceUnavailable)
+	fmt.Fprintf(w, `{"status":"not_ready","reason":%q}`, reason)
+}
+
+// latestMigration returns the highest-sorted embedded migration filename (e.g.
+// "037_account_class.sql"), or "" if none are embedded. Numbered filenames sort
+// lexically in apply order, matching what RunMigrations records.
+func latestMigration() string {
+	entries, err := fs.ReadDir(migrations.FS, ".")
+	if err != nil {
+		return ""
+	}
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), ".sql") {
+			names = append(names, e.Name())
+		}
+	}
+	if len(names) == 0 {
+		return ""
+	}
+	sort.Strings(names)
+	return names[len(names)-1]
+}

--- a/cmd/e2a/readyz.go
+++ b/cmd/e2a/readyz.go
@@ -30,15 +30,9 @@ func readyzHandler(pool *pgxpool.Pool) http.HandlerFunc {
 			writeNotReady(w, "database unreachable")
 			return
 		}
-		if latest != "" {
-			var applied bool
-			err := pool.QueryRow(ctx,
-				`SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE filename = $1)`, latest,
-			).Scan(&applied)
-			if err != nil || !applied {
-				writeNotReady(w, "migrations not applied")
-				return
-			}
+		if applied, err := latestMigrationApplied(ctx, pool, latest); err != nil || !applied {
+			writeNotReady(w, "migrations not applied")
+			return
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
@@ -50,6 +44,20 @@ func writeNotReady(w http.ResponseWriter, reason string) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusServiceUnavailable)
 	fmt.Fprintf(w, `{"status":"not_ready","reason":%q}`, reason)
+}
+
+// latestMigrationApplied reports whether the given migration filename is
+// recorded in schema_migrations. An empty filename (no embedded migrations)
+// trivially counts as applied.
+func latestMigrationApplied(ctx context.Context, pool *pgxpool.Pool, latest string) (bool, error) {
+	if latest == "" {
+		return true, nil
+	}
+	var applied bool
+	err := pool.QueryRow(ctx,
+		`SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE filename = $1)`, latest,
+	).Scan(&applied)
+	return applied, err
 }
 
 // latestMigration returns the highest-sorted embedded migration filename (e.g.

--- a/cmd/e2a/readyz_test.go
+++ b/cmd/e2a/readyz_test.go
@@ -1,14 +1,34 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
 	"github.com/Mnexa-AI/e2a/internal/testutil"
+	"github.com/Mnexa-AI/e2a/migrations"
 )
+
+// migratedTestDB returns a test pool with the schema_migrations tracker
+// populated the way production does. testutil.TestDB applies migration DDL via
+// raw Exec but does NOT record schema_migrations, so the /readyz and /selftest
+// migration-applied checks (which query that tracker, as they do in prod) need
+// this. RunMigrations re-applies the already-present (idempotent) migrations and
+// records each filename.
+func migratedTestDB(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	pool := testutil.TestDB(t)
+	if err := identity.RunMigrations(context.Background(), pool, migrations.FS, identity.ModeAuto); err != nil {
+		t.Fatalf("record migrations: %v", err)
+	}
+	return pool
+}
 
 func TestLatestMigration(t *testing.T) {
 	got := latestMigration()
@@ -25,7 +45,7 @@ func TestLatestMigration(t *testing.T) {
 }
 
 func TestReadyzHandler_Ready(t *testing.T) {
-	pool := testutil.TestDB(t) // applies all embedded migrations
+	pool := migratedTestDB(t)
 	rec := httptest.NewRecorder()
 	readyzHandler(pool)(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
 
@@ -38,5 +58,27 @@ func TestReadyzHandler_Ready(t *testing.T) {
 	}
 	if out.Status != "ready" {
 		t.Errorf("status = %q, want ready", out.Status)
+	}
+}
+
+func TestReadyzHandler_DBUnreachable(t *testing.T) {
+	// A closed pool makes Ping fail → /readyz reports 503 not_ready. Use a
+	// dedicated pool (not the shared test pool) so closing it is safe.
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, testutil.TestDBURL())
+	if err != nil {
+		t.Fatalf("open pool: %v", err)
+	}
+	pool.Close()
+
+	rec := httptest.NewRecorder()
+	readyzHandler(pool)(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+	var out struct{ Status, Reason string }
+	_ = json.Unmarshal(rec.Body.Bytes(), &out)
+	if out.Status != "not_ready" {
+		t.Errorf("status = %q, want not_ready (reason=%q)", out.Status, out.Reason)
 	}
 }

--- a/cmd/e2a/readyz_test.go
+++ b/cmd/e2a/readyz_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+)
+
+func TestLatestMigration(t *testing.T) {
+	got := latestMigration()
+	if got == "" {
+		t.Fatal("latestMigration() = empty, want a migration filename")
+	}
+	if !strings.HasSuffix(got, ".sql") {
+		t.Errorf("latestMigration() = %q, want a .sql filename", got)
+	}
+	// 037 is the floor at the time of writing; later migrations sort after it.
+	if got < "037_account_class.sql" {
+		t.Errorf("latestMigration() = %q, want >= 037_account_class.sql", got)
+	}
+}
+
+func TestReadyzHandler_Ready(t *testing.T) {
+	pool := testutil.TestDB(t) // applies all embedded migrations
+	rec := httptest.NewRecorder()
+	readyzHandler(pool)(rec, httptest.NewRequest(http.MethodGet, "/readyz", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var out struct{ Status string }
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.Status != "ready" {
+		t.Errorf("status = %q, want ready", out.Status)
+	}
+}

--- a/cmd/e2a/selftest_endpoint.go
+++ b/cmd/e2a/selftest_endpoint.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"crypto/subtle"
+	"encoding/json"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// selftestHandler serves /selftest: deep dependency diagnostics in IETF
+// health+json shape (draft-inadarei-api-health-check) — database reachable,
+// migrations applied, SMTP listener bound. It deliberately does NOT run the
+// full SMTP→webhook round-trip (that is the external e2a-prober's job, which
+// needs probe credentials and an internal sink); keeping the round-trip out of
+// the server avoids embedding credentials and weakening the webhook deliverer's
+// HTTPS requirement. Auth-gated by the internal API secret when one is
+// configured (the output reveals topology); open in dev when unset.
+func selftestHandler(pool *pgxpool.Pool, smtpAddr, internalSecret string) http.HandlerFunc {
+	latest := latestMigration()
+	return func(w http.ResponseWriter, r *http.Request) {
+		if internalSecret != "" && !bearerEquals(r, internalSecret) {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
+		defer cancel()
+
+		checks := map[string]string{
+			"database:reachable": checkStatus(pool.Ping(ctx) == nil),
+			"smtp:listening":     checkStatus(dialOK(smtpAddr)),
+			"migrations:applied": checkStatus(migrationsOK(ctx, pool, latest)),
+		}
+		overall := "pass"
+		for _, s := range checks {
+			if s != "pass" {
+				overall = "fail"
+				break
+			}
+		}
+
+		// IETF health+json: checks keyed "component:measurement" → array of
+		// detail objects, each with a status.
+		detail := map[string]any{}
+		for k, s := range checks {
+			detail[k] = []map[string]string{{"status": s}}
+		}
+		w.Header().Set("Content-Type", "application/health+json")
+		if overall != "pass" {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": overall, "checks": detail})
+	}
+}
+
+func migrationsOK(ctx context.Context, pool *pgxpool.Pool, latest string) bool {
+	applied, err := latestMigrationApplied(ctx, pool, latest)
+	return err == nil && applied
+}
+
+func checkStatus(ok bool) string {
+	if ok {
+		return "pass"
+	}
+	return "fail"
+}
+
+// dialOK reports whether the SMTP listener accepts a TCP connection. A bare
+// ":2525" addr is dialed against loopback.
+func dialOK(addr string) bool {
+	if strings.HasPrefix(addr, ":") {
+		addr = "127.0.0.1" + addr
+	}
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}
+
+func bearerEquals(r *http.Request, secret string) bool {
+	got := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+	return subtle.ConstantTimeCompare([]byte(got), []byte(secret)) == 1
+}

--- a/cmd/e2a/selftest_endpoint.go
+++ b/cmd/e2a/selftest_endpoint.go
@@ -19,12 +19,21 @@ import (
 // needs probe credentials and an internal sink); keeping the round-trip out of
 // the server avoids embedding credentials and weakening the webhook deliverer's
 // HTTPS requirement. Auth-gated by the internal API secret when one is
-// configured (the output reveals topology); open in dev when unset.
-func selftestHandler(pool *pgxpool.Pool, smtpAddr, internalSecret string) http.HandlerFunc {
+// configured (the output reveals topology). Fail-closed like /api/internal/*:
+// when no secret is configured, the endpoint is open only in development and
+// returns 503 in production (never serve diagnostics unauthenticated in prod).
+func selftestHandler(pool *pgxpool.Pool, smtpAddr, internalSecret string, devMode bool) http.HandlerFunc {
 	latest := latestMigration()
 	return func(w http.ResponseWriter, r *http.Request) {
-		if internalSecret != "" && !bearerEquals(r, internalSecret) {
-			w.WriteHeader(http.StatusUnauthorized)
+		switch {
+		case internalSecret != "":
+			if !bearerEquals(r, internalSecret) {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+		case !devMode:
+			// No secret configured in production → fail closed.
+			writeNotReady(w, "selftest requires E2A_INTERNAL_API_SECRET")
 			return
 		}
 		ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
@@ -75,6 +84,7 @@ func dialOK(addr string) bool {
 	if strings.HasPrefix(addr, ":") {
 		addr = "127.0.0.1" + addr
 	}
+	addr = strings.Replace(addr, "0.0.0.0:", "127.0.0.1:", 1)
 	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
 	if err != nil {
 		return false

--- a/cmd/e2a/selftest_endpoint_test.go
+++ b/cmd/e2a/selftest_endpoint_test.go
@@ -36,7 +36,7 @@ func decodeSelftest(t *testing.T, body []byte) (string, map[string]any) {
 
 func TestSelftestHandler_AllPass(t *testing.T) {
 	pool := testutil.TestDB(t)
-	h := selftestHandler(pool, listeningAddr(t), "" /* no auth */)
+	h := selftestHandler(pool, listeningAddr(t), "" /* no auth */, true /* dev */)
 	rec := httptest.NewRecorder()
 	h(rec, httptest.NewRequest(http.MethodGet, "/selftest", nil))
 
@@ -60,7 +60,7 @@ func TestSelftestHandler_AllPass(t *testing.T) {
 func TestSelftestHandler_SMTPDown(t *testing.T) {
 	pool := testutil.TestDB(t)
 	// 127.0.0.1:1 — nothing listening → dial fails.
-	h := selftestHandler(pool, "127.0.0.1:1", "")
+	h := selftestHandler(pool, "127.0.0.1:1", "", true /* dev */)
 	rec := httptest.NewRecorder()
 	h(rec, httptest.NewRequest(http.MethodGet, "/selftest", nil))
 
@@ -76,7 +76,7 @@ func TestSelftestHandler_SMTPDown(t *testing.T) {
 func TestSelftestHandler_AuthGate(t *testing.T) {
 	pool := testutil.TestDB(t)
 	const secret = "topsecret"
-	h := selftestHandler(pool, listeningAddr(t), secret)
+	h := selftestHandler(pool, listeningAddr(t), secret, false /* prod */)
 
 	// No bearer → 401.
 	rec := httptest.NewRecorder()
@@ -92,5 +92,28 @@ func TestSelftestHandler_AuthGate(t *testing.T) {
 	h(rec2, req)
 	if rec2.Code != http.StatusOK {
 		t.Fatalf("authed status = %d, want 200; body=%s", rec2.Code, rec2.Body.String())
+	}
+}
+
+// TestSelftestHandler_ProdNoSecretFailsClosed guards the adversarial-review
+// finding: with no internal secret configured, /selftest must NOT serve
+// diagnostics unauthenticated in production — it fails closed (503), matching
+// the /api/internal/* convention. In development the same config stays open.
+func TestSelftestHandler_ProdNoSecretFailsClosed(t *testing.T) {
+	pool := testutil.TestDB(t)
+	addr := listeningAddr(t)
+
+	prod := selftestHandler(pool, addr, "" /* no secret */, false /* prod */)
+	rec := httptest.NewRecorder()
+	prod(rec, httptest.NewRequest(http.MethodGet, "/selftest", nil))
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Errorf("prod + no secret: status = %d, want 503 (fail closed)", rec.Code)
+	}
+
+	dev := selftestHandler(pool, addr, "" /* no secret */, true /* dev */)
+	rec2 := httptest.NewRecorder()
+	dev(rec2, httptest.NewRequest(http.MethodGet, "/selftest", nil))
+	if rec2.Code != http.StatusOK {
+		t.Errorf("dev + no secret: status = %d, want 200 (open in dev)", rec2.Code)
 	}
 }

--- a/cmd/e2a/selftest_endpoint_test.go
+++ b/cmd/e2a/selftest_endpoint_test.go
@@ -6,8 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	"github.com/Mnexa-AI/e2a/internal/testutil"
 )
 
 // listeningAddr returns a TCP address with a socket in the listen state (closed
@@ -35,7 +33,7 @@ func decodeSelftest(t *testing.T, body []byte) (string, map[string]any) {
 }
 
 func TestSelftestHandler_AllPass(t *testing.T) {
-	pool := testutil.TestDB(t)
+	pool := migratedTestDB(t)
 	h := selftestHandler(pool, listeningAddr(t), "" /* no auth */, true /* dev */)
 	rec := httptest.NewRecorder()
 	h(rec, httptest.NewRequest(http.MethodGet, "/selftest", nil))
@@ -58,7 +56,7 @@ func TestSelftestHandler_AllPass(t *testing.T) {
 }
 
 func TestSelftestHandler_SMTPDown(t *testing.T) {
-	pool := testutil.TestDB(t)
+	pool := migratedTestDB(t)
 	// 127.0.0.1:1 — nothing listening → dial fails.
 	h := selftestHandler(pool, "127.0.0.1:1", "", true /* dev */)
 	rec := httptest.NewRecorder()
@@ -74,7 +72,7 @@ func TestSelftestHandler_SMTPDown(t *testing.T) {
 }
 
 func TestSelftestHandler_AuthGate(t *testing.T) {
-	pool := testutil.TestDB(t)
+	pool := migratedTestDB(t)
 	const secret = "topsecret"
 	h := selftestHandler(pool, listeningAddr(t), secret, false /* prod */)
 
@@ -100,7 +98,7 @@ func TestSelftestHandler_AuthGate(t *testing.T) {
 // diagnostics unauthenticated in production — it fails closed (503), matching
 // the /api/internal/* convention. In development the same config stays open.
 func TestSelftestHandler_ProdNoSecretFailsClosed(t *testing.T) {
-	pool := testutil.TestDB(t)
+	pool := migratedTestDB(t)
 	addr := listeningAddr(t)
 
 	prod := selftestHandler(pool, addr, "" /* no secret */, false /* prod */)

--- a/cmd/e2a/selftest_endpoint_test.go
+++ b/cmd/e2a/selftest_endpoint_test.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+)
+
+// listeningAddr returns a TCP address with a socket in the listen state (closed
+// at test end) — enough for the /selftest smtp dial check to succeed.
+func listeningAddr(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	return ln.Addr().String()
+}
+
+func decodeSelftest(t *testing.T, body []byte) (string, map[string]any) {
+	t.Helper()
+	var out struct {
+		Status string         `json:"status"`
+		Checks map[string]any `json:"checks"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("decode: %v; body=%s", err, body)
+	}
+	return out.Status, out.Checks
+}
+
+func TestSelftestHandler_AllPass(t *testing.T) {
+	pool := testutil.TestDB(t)
+	h := selftestHandler(pool, listeningAddr(t), "" /* no auth */)
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest(http.MethodGet, "/selftest", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/health+json" {
+		t.Errorf("content-type = %q, want application/health+json", ct)
+	}
+	status, checks := decodeSelftest(t, rec.Body.Bytes())
+	if status != "pass" {
+		t.Errorf("status = %q, want pass", status)
+	}
+	for _, k := range []string{"database:reachable", "smtp:listening", "migrations:applied"} {
+		if _, ok := checks[k]; !ok {
+			t.Errorf("missing check %q", k)
+		}
+	}
+}
+
+func TestSelftestHandler_SMTPDown(t *testing.T) {
+	pool := testutil.TestDB(t)
+	// 127.0.0.1:1 — nothing listening → dial fails.
+	h := selftestHandler(pool, "127.0.0.1:1", "")
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest(http.MethodGet, "/selftest", nil))
+
+	if rec.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", rec.Code)
+	}
+	status, _ := decodeSelftest(t, rec.Body.Bytes())
+	if status != "fail" {
+		t.Errorf("status = %q, want fail", status)
+	}
+}
+
+func TestSelftestHandler_AuthGate(t *testing.T) {
+	pool := testutil.TestDB(t)
+	const secret = "topsecret"
+	h := selftestHandler(pool, listeningAddr(t), secret)
+
+	// No bearer → 401.
+	rec := httptest.NewRecorder()
+	h(rec, httptest.NewRequest(http.MethodGet, "/selftest", nil))
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("no-auth status = %d, want 401", rec.Code)
+	}
+
+	// Correct bearer → 200.
+	rec2 := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/selftest", nil)
+	req.Header.Set("Authorization", "Bearer "+secret)
+	h(rec2, req)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("authed status = %d, want 200; body=%s", rec2.Code, rec2.Body.String())
+	}
+}

--- a/docs/design/prober-selftest.md
+++ b/docs/design/prober-selftest.md
@@ -2,10 +2,26 @@
 
 | | |
 |---|---|
-| **Status** | Proposed (2026-06-20) |
+| **Status** | Partially implemented (2026-06-20) — main-repo slices landed; ops slices + deferrals below |
 | **Spans** | `e2a` (Go backend) + `e2a-ops` (deploy/infra) |
 | **Risk** | MEDIUM — touches metering/billing gate, outbound send wiring, and the prod deploy gate; must not pollute usage/analytics, send real mail, or email agent owners |
-| **GA scope** | account-class gate + `Sender` interface + `scenarios`/`selftest` package + `cmd/e2a-prober` + fail-safe bake-gate. The `e2a` `/metrics` 5xx signal is a fast-follow. |
+| **GA scope** | account-class gate + `scenarios`/`selftest` package + `cmd/e2a-prober` + `/readyz` + `/selftest` + fail-safe bake-gate. The `e2a` `/metrics` 5xx signal is a fast-follow. |
+
+## Implementation status (as built)
+
+Landed on `design/prober-selftest` (main repo), each slice committed + verified:
+
+- **Slice 1 — account-class metering gate.** `migrations/037_account_class.sql` (`users.account_class`), `usage.PolicyFor` + gate in `RecordAndCheck`. Verified: zero `usage_events` for a `system` account, in-process and over the wire.
+- **Slice 3a — `internal/selftest`.** The `[]Scenario` battery (liveness, auth read, inbound SMTP→webhook + HMAC, self-send loopback) + `HTTPSink`. Verified against a real in-process server.
+- **Slice 3b — `cmd/e2a-prober`.** `seed`/`validate`/`run-once`/`serve` (+ `/sink` `/healthz` `/metrics` `/status`). Verified over the wire against the real `e2a` binary.
+- **Slice 3c — `/readyz`** (DB + migrations-applied) and **`/selftest`** (dependency diagnostics, health+json, auth-gated) on the non-Huma mux.
+
+**Deviations from the original plan (decided during implementation):**
+- **`Sender` interface (D2) deferred.** It rewrites the live SES send path and is not required by the prober (inbound uses the real listener; outbound uses loopback). Tracked as an optional, separately-reviewed follow-up.
+- **In-server `/selftest` is dependency-diagnostics, not the full round-trip.** Implementation revealed the full in-server round-trip would require injecting probe credentials into the server's env (unrecoverable from the DB) and an HTTPS exemption in the webhook deliverer for the internal sink. The full round-trip already lives in the external `e2a-prober` (verified), so `/selftest` does deep dependency checks instead. See §D3.
+- **Ops slices 4 & 5 (compose service, `deploy.yml` bake-gate) not yet landed** — config-only, not deploy-verifiable in this environment.
+
+**Known follow-up (prod wiring):** the webhook subscriber deliverer requires HTTPS in production, but the prober's internal sink is plain HTTP — the ops wiring needs a deliverer exemption (or TLS) for the internal sink before the round-trip works against prod.
 
 ## Problem
 

--- a/docs/design/prober-selftest.md
+++ b/docs/design/prober-selftest.md
@@ -160,13 +160,18 @@ so the existing janitor reaps them.
 
 ### `cmd/e2a-prober` (main repo)
 
-One binary, two modes (mirrors `cmd/e2a-contract-server`):
+One binary, several modes (mirrors `cmd/e2a-contract-server`):
 - **`serve`** — loop every `PROBE_INTERVAL` (start 30s); hosts `/sink` (webhook
   callback), `/healthz` (prober liveness), `/metrics` (Prometheus), and
   `/status?since=<ts>` (recent results + rolling success rate) for the gate.
 - **`run-once`** — single battery run, exit 0/non-0 (local/CI). The gate does **not**
   use this; it queries the always-on `serve` instance so probe logic lives once.
 - **`seed`** — idempotent provisioning above.
+- **`validate`** — *pre-flight*, no round-trip: parse config, check DB reachability
+  and **migrations-applied**, and confirm the probe identity/webhook exist. This is
+  the install-time validator self-hosters run *before* a full start (the
+  `vault operator diagnose` / `consul validate` split between install-time validation
+  and runtime health). Distinct from `run-once`, which exercises the live loop.
 
 **Battery v1** (`internal/selftest.All`, ~6): liveness; auth+read
 (`GET /v1/agents/probe@agents.e2a.dev`); **inbound round-trip** (`smtp.SendMail`
@@ -189,6 +194,11 @@ scrapes it for the gate's 5xx signal — catches regressions on *real* traffic.
   is live. `E2A_PROBE_API_KEY` added to `/opt/e2a/.env`.
 - **Continuous monitor**: UptimeRobot / GCP Cloud Monitoring scrape
   `127.0.0.1:8090/metrics`; alert on probe failure/latency; prober-down pages.
+  **Alert discipline** (distinct from the gate's N-consecutive-green): page only
+  after **M consecutive failed probes** (start M=2) with a per-probe `PROBE_TIMEOUT`,
+  so a single transient blip doesn't wake on-call ("the internet is flaky — retry
+  before alerting"). The gate gates on *green-after-deploy*; the monitor pages on
+  *sustained-red*.
 - **Deploy bake-gate** — extend `deploy.yml` *after* the existing `/api/health` pass:
   1. record `deploy_ts`;
   2. for ≤ `BAKE_SECONDS` (start 300) poll `http://localhost:8090/status?since=<deploy_ts>`,
@@ -196,6 +206,23 @@ scrapes it for the gate's 5xx signal — catches regressions on *real* traffic.
   3. on breach → reuse the existing `:rollback` re-tag + `up -d --pull never` + re-poll path;
   4. **fail-safe**: if the prober is unreachable/inconclusive, fall back to today's
      liveness-only behavior and log loudly.
+
+### API surface impact
+
+**No changes to the public `/v1` contract or the SDKs.** The prober is only a
+*client* of existing endpoints (`GET /v1/agents/{email}`, `GET .../messages`, the
+`POST` send) — no `/v1` request/response shapes change, so `api/openapi.yaml` stays
+byte-identical and `TestSpecGoldenNoDrift` / `make spec-check` stay green with no
+SDK regen.
+
+Two rules keep that true:
+- **New endpoints (`/readyz`, `/selftest`) are operational, not `/v1`.** Register
+  them on the **non-Huma mux** (the gorilla/mux fallback where `/api/health` already
+  lives, `cmd/e2a/main.go:556`), **not** the Huma `/v1` router — so they never enter
+  `api/openapi.yaml` or the SDK pipeline. (`/metrics`, the fast-follow, likewise.)
+- **`account_class` stays server-side only.** It must not appear in any `/v1`
+  agent/account response body; it is read by the metering gate alone. Surfacing it
+  would be a (technically additive) contract change touching the spec + SDKs — avoid.
 
 ## Edge cases and failure handling
 

--- a/docs/design/prober-selftest.md
+++ b/docs/design/prober-selftest.md
@@ -189,12 +189,14 @@ One binary, several modes (mirrors `cmd/e2a-contract-server`):
   `vault operator diagnose` / `consul validate` split between install-time validation
   and runtime health). Distinct from `run-once`, which exercises the live loop.
 
-**Battery v1** (`internal/selftest.All`, ~6): liveness; auth+read
-(`GET /v1/agents/probe@agents.e2a.dev`); **inbound round-trip** (`smtp.SendMail`
-a unique nonce to `e2a:2525` → await webhook at `/sink` within `PROBE_TIMEOUT` →
-verify nonce correlation + HMAC); persistence read (message present); self-send via
-`NopSender` (outbound API + compose path, no egress); *(phase 2)* 5xx SLI from
-`e2a:/metrics`.
+**Battery v1** (`internal/selftest.All`, as built): liveness; auth+read
+(`GET /v1/agents/{probe}`); **inbound round-trip** (`smtp.SendMail` a unique nonce
+to the SMTP listener → await webhook at `/sink` within the round-trip timeout →
+verify nonce correlation + HMAC); self-send loopback (outbound API + compose path,
+method=loopback, no egress); and **agent_lifecycle** (create → get → delete an
+ephemeral agent on the probe's verified domain — the only mutating scenario,
+self-cleaning via a deferred best-effort delete, no email/owner-notify/metering).
+*(fast-follow)* 5xx SLI from `e2a:/metrics`.
 
 ### SLI exposure on `e2a` (phase 2 / fast-follow)
 

--- a/docs/design/prober-selftest.md
+++ b/docs/design/prober-selftest.md
@@ -1,0 +1,252 @@
+# Production-safe self-test, synthetic prober & deploy bake-gate
+
+| | |
+|---|---|
+| **Status** | Proposed (2026-06-20) |
+| **Spans** | `e2a` (Go backend) + `e2a-ops` (deploy/infra) |
+| **Risk** | MEDIUM — touches metering/billing gate, outbound send wiring, and the prod deploy gate; must not pollute usage/analytics, send real mail, or email agent owners |
+| **GA scope** | account-class gate + `Sender` interface + `scenarios`/`selftest` package + `cmd/e2a-prober` + fail-safe bake-gate. The `e2a` `/metrics` 5xx signal is a fast-follow. |
+
+## Problem
+
+`deploy.yml` gates a release on `curl -sf http://localhost:8080/api/health` for 30×1s.
+That endpoint (`internal/agent/api.go:1200`, wired at `cmd/e2a/main.go:556`) is
+**liveness only** — no DB, no mail path. A release can pass it while inbound
+mail→webhook delivery, auth, or the DB are broken (this is how the 2026-05-19
+`list_messages` incident — an unapplied migration — reached prod). We need:
+
+1. A continuous signal that the **real product paths** work in prod.
+2. A deploy gate that consumes that signal and **auto-rolls-back** on a regression.
+
+…without sending real email, emailing agent owners (the HITL landmine, see
+`feedback_hitl_sends_notify`), burning SES/Resend IP reputation, or polluting
+`usage_events` / `usage_summaries` / analytics.
+
+## Goals and non-goals
+
+**Goals**
+- One **critical-path round-trip** definition (`SMTP → emailauth → agent lookup → DB → outbox → webhook delivery → HMAC verify`) reused by e2e tests, a self-host CLI, and the prod prober/gate — no duplication.
+- **Zero external side effects by default**: outbound exercised without egress; no owner notifications; no metering/billing/analytics writes for probe traffic.
+- Extend the existing `deploy.yml` rollback machinery rather than replace it; **fail-safe** (a broken prober must not permanently block deploys).
+- Leave the OSS genuinely more testable and give self-hosters a deployment validator (open-core/self-host value, see `project_opencore_strategy`).
+
+**Non-goals**
+- Comprehensive correctness testing — stays in CI (`internal/e2e`, contract tests).
+- True traffic-splitting canary — separate, later effort (single VM today).
+- A full metrics/observability platform; real inbox-placement/deliverability testing (optional low-freq canary, see Open questions).
+- WebSocket-path probing in v1 (extensible scenario, phase 2).
+
+## Decisions (research-backed)
+
+Three decisions were settled against OSS best-practice research; they revise an
+earlier sketch that used a per-agent `synthetic` boolean and a loopback trick.
+
+### D1 — Account `class` enum, not a per-record `synthetic` boolean
+
+Billing and quota are **per-account** (`usage_summaries` is keyed by `user_id`),
+so "this is not a real customer" is a property of the **account**, not each agent.
+
+- Add **`account_class`** to the user/account: `standard | internal | system | demo`,
+  default `standard`, `NOT NULL`. **Orthogonal to the paid plan** — do *not*
+  invent an "internal plan" (that still routes usage through metering/analytics).
+- Precedent: Lago's `customer_account_type` ENUM kept separate from plan; Stripe's
+  `livemode`/sandbox separation. Anti-pattern avoided: a single `is_test`/`synthetic`
+  boolean → "boolean blindness", impossible states, and an expensive late
+  boolean→enum migration on a `usage_events`/`messages`-scale table.
+- **Centralize the decision**: a single `meteringPolicy(class) -> {meter, bill, analytics}`
+  resolved at the *one* point usage is written — **before** the insert, so the
+  daily-summary rollup never counts it. This replaces scattering `if synthetic`
+  across the relay/outbound/storage write paths ("shotgun surgery").
+
+```go
+// internal/usage (or internal/limits) — single source of truth.
+type AccountClass string
+const (
+    ClassStandard AccountClass = "standard"
+    ClassInternal AccountClass = "internal"
+    ClassSystem   AccountClass = "system" // synthetic-monitoring probe traffic
+    ClassDemo     AccountClass = "demo"
+)
+
+type MeteringPolicy struct{ Meter, Bill, Analytics bool }
+
+func PolicyFor(c AccountClass) MeteringPolicy {
+    switch c {
+    case ClassSystem, ClassInternal, ClassDemo:
+        return MeteringPolicy{Meter: false, Bill: false, Analytics: false}
+    default:
+        return MeteringPolicy{Meter: true, Bill: true, Analytics: true}
+    }
+}
+```
+
+`usage.RecordAndCheck` resolves the account class once and short-circuits when
+`!policy.Meter` (returns allowed, records nothing, consumes no quota). The probe
+account is `system`-class, so it is excluded by the **same gate** as internal
+dogfood traffic — no parallel `synthetic` concept. Optional defense-in-depth: stamp
+probe requests with a header (the Datadog/Checkly tag-at-edge pattern).
+
+Analytics: in `e2a-ops/analytics/views.sql`, join account class and filter
+`WHERE class = 'standard'` on message-count views (usage-based views are already
+clean since no usage rows are written for non-`standard` classes).
+
+### D2 — Consumer-side `Sender` interface, not a loopback special-case
+
+Today `internal/outbound.Sender` is a concrete struct wrapping `*SMTPRelay`; the
+real-vs-fake relay is a config toggle. Replace with a narrow consumer-side
+interface + two adapters (the dead-uniform Go OSS idiom — Grafana, Bytebase, ntfy):
+
+```go
+// internal/outbound — interface defined where it is consumed.
+type Sender interface { Send(ctx context.Context, msg Message) (*SendResult, error) }
+
+// Real adapter: existing *SMTPRelay-backed sender satisfies Sender.
+// CapturingSender — tests assert on .Sent.
+// NopSender — the prober: exercises the real compose + DKIM-sign + route path
+//             with ZERO egress and ZERO HITL owner-email, by construction.
+```
+
+This makes outbound safety a **wiring choice**, not a code branch, and defuses the
+HITL owner-notification landmine. Add a **conformance test** so the fake doesn't
+drift from the real sender (Google SWE guidance). This supersedes using
+`internal/loopback` as the prober's outbound-safety mechanism.
+
+### D3 — One round-trip, three consumers; health endpoints split by depth
+
+No email OSS ships a self-contained inject→deliver→verify-signature loop
+(Mail-in-a-Box/Mailcow/Postal do static DNS/config checks only). e2a owns both
+ends, so this is both a differentiator and a self-host validator.
+
+- Put the round-trip in a **non-`_test.go` `internal/selftest` (scenarios) package**
+  with a per-scenario **`SmokeSafe`** flag (the Kubernetes `e2e.test` /
+  Vault `operator diagnose` + `/sys/health` reuse pattern). Consumed by:
+  (a) `internal/e2e` tests, (b) `e2a selftest` CLI, (c) `cmd/e2a-prober`/the gate.
+  `SmokeSafe` is load-bearing — only inbound round-trip and read-only scenarios run
+  against prod.
+- **Health-endpoint depth split** (cascading-failure foot-gun):
+  - `/api/health` (`/livez`) stays **shallow** — liveness, no Postgres. **Never deepen it.**
+  - add **`/readyz`** — instance-local readiness (migrations applied, config loaded,
+    listeners bound, not draining). A runtime "migrations applied" check here is the
+    direct fix for the 2026-05-19 class of incident.
+  - add an auth-gated **`/selftest`** — deep round-trip + dependency diagnostics,
+    consumed by monitoring/the gate, **never** by an orchestrator restart/route loop.
+- Output: IETF `application/health+json` (`status: pass/warn/fail`, per-component
+  `checks{}` with `observedUnit: "ms"`) **plus** a process exit code; emit
+  `selftest_success` + `selftest_duration_seconds`; redact secrets (the loop touches
+  HMAC/DKIM keys).
+
+```go
+// internal/selftest
+type Scenario struct {
+    Name      string
+    SmokeSafe bool // safe against prod: read-only / round-trip, no owner-emailing
+    Run       func(ctx context.Context, c *Client) Result // Result: pass|warn|fail + ms + detail
+}
+var All = []Scenario{ /* liveness, authRead, inboundRoundTrip, persistRead, loopbackSend, ... */ }
+```
+
+## Proposed design
+
+### Probe account & identity (seed, idempotent)
+
+A `system`-class account; a slug agent `probe@agents.e2a.dev` (shared domain → no
+DNS verification) with `inbound_policy='open'` (so unverified probe mail isn't
+rejected/dropped) and `HITLEnabled=false`; an API key → `E2A_PROBE_API_KEY`; one
+durable webhook subscriber for `email.received` filtered to the probe agent, URL
+`http://prober:8090/sink`, **excluded from auto-disable** (else a sink outage
+disables it permanently: 10 fails/72h with zero delivered). Provisioned by
+`e2a-prober seed` (idempotent). Synthetic inbound messages get a short `expires_at`
+so the existing janitor reaps them.
+
+### `cmd/e2a-prober` (main repo)
+
+One binary, two modes (mirrors `cmd/e2a-contract-server`):
+- **`serve`** — loop every `PROBE_INTERVAL` (start 30s); hosts `/sink` (webhook
+  callback), `/healthz` (prober liveness), `/metrics` (Prometheus), and
+  `/status?since=<ts>` (recent results + rolling success rate) for the gate.
+- **`run-once`** — single battery run, exit 0/non-0 (local/CI). The gate does **not**
+  use this; it queries the always-on `serve` instance so probe logic lives once.
+- **`seed`** — idempotent provisioning above.
+
+**Battery v1** (`internal/selftest.All`, ~6): liveness; auth+read
+(`GET /v1/agents/probe@agents.e2a.dev`); **inbound round-trip** (`smtp.SendMail`
+a unique nonce to `e2a:2525` → await webhook at `/sink` within `PROBE_TIMEOUT` →
+verify nonce correlation + HMAC); persistence read (message present); self-send via
+`NopSender` (outbound API + compose path, no egress); *(phase 2)* 5xx SLI from
+`e2a:/metrics`.
+
+### SLI exposure on `e2a` (phase 2 / fast-follow)
+
+A chi/Huma middleware counting requests by route+status + latency, on an internal
+`GET /metrics`, built on the existing `internal/telemetry` abstraction. The prober
+scrapes it for the gate's 5xx signal — catches regressions on *real* traffic.
+
+### Wiring (e2a-ops)
+
+- 5th compose service `prober` (`e2a-prober serve`), internal, port published to
+  **loopback only** (`127.0.0.1:8090:8090` — reachable by the VM deploy script,
+  never by Caddy/public). Runs across `e2a` restarts and observes whichever version
+  is live. `E2A_PROBE_API_KEY` added to `/opt/e2a/.env`.
+- **Continuous monitor**: UptimeRobot / GCP Cloud Monitoring scrape
+  `127.0.0.1:8090/metrics`; alert on probe failure/latency; prober-down pages.
+- **Deploy bake-gate** — extend `deploy.yml` *after* the existing `/api/health` pass:
+  1. record `deploy_ts`;
+  2. for ≤ `BAKE_SECONDS` (start 300) poll `http://localhost:8090/status?since=<deploy_ts>`,
+     requiring **N consecutive green probes** (start N=3) and *(phase 2)* 5xx < threshold;
+  3. on breach → reuse the existing `:rollback` re-tag + `up -d --pull never` + re-poll path;
+  4. **fail-safe**: if the prober is unreachable/inconclusive, fall back to today's
+     liveness-only behavior and log loudly.
+
+## Edge cases and failure handling
+
+- **Quota false alarms** → solved by D1 (probe traffic never metered, never counts against quota).
+- **SPF/DKIM fail on synthetic inbound** → expected; `inbound_policy='open'` keeps it delivered (the existing `internal/e2e/webhooks_e2e_test.go` round-trip confirms unverified mail still fires the webhook). Don't assert auth=pass.
+- **Retry-worker cadence** → round-trip latency includes the `SubscriberRetryWorker` poll interval; set `PROBE_TIMEOUT` ≥ that + margin (confirm exact interval during impl; it's a tuning knob).
+- **Synthetic webhook auto-disabled** → exclude it from `AutoDisableFailingWebhooks` and/or re-enable on prober start.
+- **Prober as SPOF for deploys** → fail-safe gate (inconclusive ≠ block).
+- **Nonce cross-talk** → correlate each send to its delivery by unique Message-ID; ignore unrelated deliveries; don't over-assert on volatile fields (timestamps, generated IDs) → flapping.
+- **Sink reachability** → `e2a` resolves `prober` on the shared compose network; if prober is down, only synthetic deliveries fail (no customer impact).
+- **Deep checks behind liveness/readiness** → forbidden (cascading restart/eviction); the round-trip lives only on `/selftest` + the prober.
+
+## Scalability and extensibility notes
+
+- The battery is a `[]Scenario` — add WebSocket-receive, the deliverability canary, or new SLIs without touching the harness.
+- `account_class` + `meteringPolicy` is reusable for demo accounts, load tests, and analytics hygiene beyond probing.
+- `/status` decouples the gate from probe internals — a future real canary (second `e2a` behind Caddy weighted upstreams) consumes the same endpoint.
+- `/metrics` on `e2a` seeds real observability (the `telemetry` abstraction anticipates Prometheus).
+- Go 1.25 `testing/synctest` gives deterministic fake time with no `Clock` interface; keep the `Start`/`Tick`/`processOne` worker split; replace e2e `time.Sleep`/`WaitFor` polling with a completion signal (river-style `TestSignal`, no-op in prod).
+
+## Verification strategy
+
+- **Unit**: `meteringPolicy` per class; `Sender` interface + `CapturingSender`/`NopSender` conformance test; nonce correlation; HMAC verify; `/status` window logic.
+- **Integration** (against `cmd/e2a-contract-server`): run `e2a-prober run-once` end-to-end; assert all checks pass **and that no `usage_events`/`usage_summaries` rows are written for the `system` account** (the regression that matters most).
+- **Gate simulation**: point the bake-gate at a deliberately broken build (webhook worker disabled) → confirm rollback; at a healthy build → confirm promote; kill the prober → confirm fail-safe fallback.
+- **Migration**: idempotency (re-run) + a DB-backed test for any package writing the account-class column (per CLAUDE.md schema-change rule).
+- **Manual**: one staged deploy confirming the rollback re-tag / `--pull never` path still works with the added bake step.
+
+## Slices (dependency order)
+
+1. **Account-class gate + `Sender` interface** (`e2a`) — idempotent migration adding
+   `account_class`; thread onto the account; `meteringPolicy` single gate in
+   `usage.RecordAndCheck`; `Sender` interface + `NopSender`/`CapturingSender` +
+   conformance test; analytics view filter. Test: zero usage rows for `system` class.
+2. **`internal/selftest` + `cmd/e2a-prober`** (`e2a`) — scenarios package (`SmokeSafe`),
+   battery 1–5, `seed`/`run-once`/`serve`, `/sink` `/healthz` `/metrics` `/status`.
+   Add `/readyz` (migrations-applied check); leave `/api/health` shallow. Verify
+   `run-once` against `e2a-contract-server`. Confirm `SubscriberRetryWorker` interval
+   → set `PROBE_TIMEOUT`.
+3. **`prober` compose service** (`e2a-ops`) — `e2a-prober serve`, loopback-only port,
+   `E2A_PROBE_API_KEY` into `/opt/e2a/.env`, analytics view filter.
+4. **Bake-gate in `deploy.yml`** (`e2a-ops`) — `/status?since=` poll, N consecutive
+   green, reuse `:rollback` path, fail-safe. Stage-test rollback + promote.
+
+**Fast-follow (post-GA)**: `e2a` `/metrics` 5xx instrumentation (battery #6 + gate
+signal); opt-in, rate-limited real-send deliverability canary (separate from the
+per-cycle battery).
+
+## Open questions
+
+- `SubscriberRetryWorker` poll interval — confirm exact value during slice 2 to set `PROBE_TIMEOUT`.
+- `BAKE_SECONDS` / consecutive-green `N` / 5xx threshold — starting point 300s / 3 / 2%; tune on staging.
+- Deliverability canary cadence (hourly?) and the owned sink address — deferred to fast-follow.
+- Whether to expose `e2a selftest` as a CLI subcommand in the OSS binary at GA or fast-follow (self-host value vs. GA surface area).

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -2852,6 +2852,16 @@ func (s *Store) CreateOrGetUser(ctx context.Context, email, name, googleSub stri
 	return u, nil
 }
 
+// SetAccountClass sets a user's account_class (standard|internal|system|demo).
+// Used by the prober's seed to mark the synthetic probe account as system so its
+// traffic is never metered (see usage.PolicyFor). The CHECK constraint in
+// migration 037 rejects any other value.
+func (s *Store) SetAccountClass(ctx context.Context, userID, class string) error {
+	_, err := s.pool.Exec(ctx,
+		`UPDATE users SET account_class = $2 WHERE id = $1`, userID, class)
+	return err
+}
+
 // BootstrapUser finds a user by email, or creates one with a synthetic
 // google_subject if none exists. Used by the -bootstrap-email CLI flag
 // for self-host first-run, where there's no Google OAuth flow yet.

--- a/internal/selftest/export_test.go
+++ b/internal/selftest/export_test.go
@@ -1,0 +1,5 @@
+package selftest
+
+// VerifyHMACForTest exposes the unexported verifyHMAC for the external test
+// package (Go's sanctioned export_test.go hook).
+var VerifyHMACForTest = verifyHMAC

--- a/internal/selftest/scenarios.go
+++ b/internal/selftest/scenarios.go
@@ -18,10 +18,11 @@ import (
 	"time"
 )
 
-// roundTripTimeout bounds how long the inbound round-trip waits for the webhook
-// callback. It must exceed the SubscriberRetryWorker poll interval in
-// production; the prober makes it configurable (see cmd/e2a-prober).
-const roundTripTimeout = 30 * time.Second
+// defaultRoundTripTimeout bounds how long the inbound round-trip waits for the
+// webhook callback when Probe.Timeout is unset. It must exceed the
+// SubscriberRetryWorker poll interval in production; the prober overrides it via
+// E2A_PROBE_TIMEOUT (Probe.Timeout).
+const defaultRoundTripTimeout = 30 * time.Second
 
 // All is the critical-path battery. Every scenario here is SmokeSafe: read-only,
 // a loopback (no egress), or the inbound round-trip (synthetic mail to the probe
@@ -102,7 +103,7 @@ func scenarioInboundRoundTrip(ctx context.Context, p *Probe) Result {
 
 	d, err := p.Sink.Await(ctx, func(d Delivery) bool {
 		return bytes.Contains(d.Body, []byte(nonce))
-	}, roundTripTimeout)
+	}, p.roundTripTimeout())
 	if err != nil {
 		return fail("await webhook for nonce %s: %v", nonce, err)
 	}

--- a/internal/selftest/scenarios.go
+++ b/internal/selftest/scenarios.go
@@ -1,0 +1,190 @@
+package selftest
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/smtp"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// roundTripTimeout bounds how long the inbound round-trip waits for the webhook
+// callback. It must exceed the SubscriberRetryWorker poll interval in
+// production; the prober makes it configurable (see cmd/e2a-prober).
+const roundTripTimeout = 30 * time.Second
+
+// All is the critical-path battery. Every scenario here is SmokeSafe: read-only,
+// a loopback (no egress), or the inbound round-trip (synthetic mail to the probe
+// agent, no real recipient). None meters (the probe runs under a system-class
+// account) and none emails an owner.
+var All = []Scenario{
+	{Name: "liveness", SmokeSafe: true, Run: scenarioLiveness},
+	{Name: "auth_read", SmokeSafe: true, Run: scenarioAuthRead},
+	{Name: "inbound_round_trip", SmokeSafe: true, Run: scenarioInboundRoundTrip},
+	{Name: "self_send_loopback", SmokeSafe: true, Run: scenarioSelfSendLoopback},
+}
+
+func pass(detail string) Result { return Result{Status: StatusPass, Detail: detail} }
+func fail(format string, a ...any) Result {
+	return Result{Status: StatusFail, Detail: fmt.Sprintf(format, a...)}
+}
+
+// scenarioLiveness: GET /api/health is up and reports ok. Shallow by design —
+// no dependency checks (those belong to /readyz and /selftest).
+func scenarioLiveness(ctx context.Context, p *Probe) Result {
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, p.HTTPBaseURL+"/api/health", nil)
+	resp, err := p.httpClient().Do(req)
+	if err != nil {
+		return fail("GET /api/health: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode != http.StatusOK {
+		return fail("GET /api/health: HTTP %d", resp.StatusCode)
+	}
+	if !bytes.Contains(body, []byte("ok")) {
+		return fail("GET /api/health: unexpected body %q", string(body))
+	}
+	return pass("health ok")
+}
+
+// scenarioAuthRead: an authenticated read of the probe agent. Exercises API key
+// auth + a DB read. The email is percent-encoded — a real client must do this
+// (the in-process test client would otherwise hide the encoding bug).
+func scenarioAuthRead(ctx context.Context, p *Probe) Result {
+	u := p.HTTPBaseURL + "/v1/agents/" + url.PathEscape(p.AgentEmail)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	req.Header.Set("Authorization", "Bearer "+p.APIKey)
+	resp, err := p.httpClient().Do(req)
+	if err != nil {
+		return fail("GET agent: %v", err)
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode != http.StatusOK {
+		return fail("GET agent: HTTP %d", resp.StatusCode)
+	}
+	return pass("authenticated read ok")
+}
+
+// scenarioInboundRoundTrip is the core check: inject a unique inbound message
+// over real SMTP and confirm it comes back out the webhook with a valid HMAC.
+// Covers the SMTP listener, emailauth, agent lookup, DB write, outbox, the
+// subscriber worker, webhook HTTP delivery, and signing.
+func scenarioInboundRoundTrip(ctx context.Context, p *Probe) Result {
+	if p.Sink == nil {
+		return fail("no sink configured")
+	}
+	nonce, err := randHex(16)
+	if err != nil {
+		return fail("nonce: %v", err)
+	}
+	msg := fmt.Sprintf("From: e2a-selftest <selftest@e2a-selftest.invalid>\r\n"+
+		"To: %s\r\n"+
+		"Subject: e2a-selftest %s\r\n"+
+		"Message-ID: <%s@e2a-selftest.invalid>\r\n"+
+		"\r\n"+
+		"e2a selftest round-trip %s\r\n", p.AgentEmail, nonce, nonce, nonce)
+
+	if err := smtp.SendMail(p.SMTPAddr, nil, "selftest@e2a-selftest.invalid", []string{p.AgentEmail}, []byte(msg)); err != nil {
+		return fail("SMTP send: %v", err)
+	}
+
+	d, err := p.Sink.Await(ctx, func(d Delivery) bool {
+		return bytes.Contains(d.Body, []byte(nonce))
+	}, roundTripTimeout)
+	if err != nil {
+		return fail("await webhook for nonce %s: %v", nonce, err)
+	}
+	if !verifyHMAC(d.Headers.Get("X-E2A-Signature"), d.Body, p.WebhookSecret) {
+		return fail("webhook HMAC verification failed")
+	}
+	return pass("inbound round-trip + HMAC ok")
+}
+
+// scenarioSelfSendLoopback: the probe agent sends to itself. Self-send routes
+// through the loopback path (method=loopback) — no SMTP egress, no HITL owner
+// notification — exercising the outbound API + compose path safely.
+func scenarioSelfSendLoopback(ctx context.Context, p *Probe) Result {
+	u := p.HTTPBaseURL + "/v1/agents/" + url.PathEscape(p.AgentEmail) + "/messages"
+	payload := map[string]any{
+		"to":      []string{p.AgentEmail},
+		"subject": "e2a-selftest loopback",
+		"body":    "e2a selftest loopback",
+	}
+	b, _ := json.Marshal(payload)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(b))
+	req.Header.Set("Authorization", "Bearer "+p.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := p.httpClient().Do(req)
+	if err != nil {
+		return fail("self-send: %v", err)
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode != http.StatusOK {
+		return fail("self-send: HTTP %d", resp.StatusCode)
+	}
+	var out struct {
+		Method string `json:"method"`
+	}
+	_ = json.Unmarshal(raw, &out)
+	if out.Method != "loopback" {
+		return fail("self-send method=%q, want loopback (no egress)", out.Method)
+	}
+	return pass("self-send loopback ok")
+}
+
+// verifyHMAC checks the X-E2A-Signature header against the body using the
+// webhook secret. Header format: t=<unix>,v1=<hex>[,v1=<hex>]; signed string is
+// "<t>.<body>" (hmac-sha256, hex). Any v1 matching is accepted (rotation grace).
+func verifyHMAC(header string, body []byte, secret string) bool {
+	if header == "" || secret == "" {
+		return false
+	}
+	var ts string
+	var sigs []string
+	for _, part := range strings.Split(header, ",") {
+		part = strings.TrimSpace(part)
+		switch {
+		case strings.HasPrefix(part, "t="):
+			ts = strings.TrimPrefix(part, "t=")
+		case strings.HasPrefix(part, "v1="):
+			sigs = append(sigs, strings.TrimPrefix(part, "v1="))
+		}
+	}
+	if ts == "" || len(sigs) == 0 {
+		return false
+	}
+	if _, err := strconv.ParseInt(ts, 10, 64); err != nil {
+		return false
+	}
+	mac := hmac.New(sha256.New, []byte(secret))
+	fmt.Fprintf(mac, "%s.", ts)
+	mac.Write(body)
+	want := hex.EncodeToString(mac.Sum(nil))
+	for _, s := range sigs {
+		if hmac.Equal([]byte(s), []byte(want)) {
+			return true
+		}
+	}
+	return false
+}
+
+func randHex(n int) (string, error) {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/internal/selftest/scenarios.go
+++ b/internal/selftest/scenarios.go
@@ -33,6 +33,12 @@ var All = []Scenario{
 	{Name: "auth_read", SmokeSafe: true, Run: scenarioAuthRead},
 	{Name: "inbound_round_trip", SmokeSafe: true, Run: scenarioInboundRoundTrip},
 	{Name: "self_send_loopback", SmokeSafe: true, Run: scenarioSelfSendLoopback},
+	// agent_lifecycle MUTATES prod (creates then deletes an ephemeral agent on
+	// the probe's verified domain) but is self-cleaning — no email, no owner
+	// notification, no metering (system-class account). SmokeSafe, but the
+	// create/delete churn is heavier than the read-only checks; an operator who
+	// wants a purely read-only prod battery can drop it.
+	{Name: "agent_lifecycle", SmokeSafe: true, Run: scenarioAgentLifecycle},
 }
 
 func pass(detail string) Result { return Result{Status: StatusPass, Detail: detail} }
@@ -144,6 +150,86 @@ func scenarioSelfSendLoopback(ctx context.Context, p *Probe) Result {
 		return fail("self-send method=%q, want loopback (no egress)", out.Method)
 	}
 	return pass("self-send loopback ok")
+}
+
+// scenarioAgentLifecycle exercises the create/get/delete agent endpoints with a
+// unique, self-cleaning ephemeral agent on the probe's verified domain. It is
+// the only mutating scenario; a deferred best-effort delete guarantees cleanup
+// even if an assertion fails partway through.
+func scenarioAgentLifecycle(ctx context.Context, p *Probe) Result {
+	at := strings.LastIndex(p.AgentEmail, "@")
+	if at < 0 {
+		return fail("probe agent email %q has no domain", p.AgentEmail)
+	}
+	domain := p.AgentEmail[at+1:]
+	nonce, err := randHex(8)
+	if err != nil {
+		return fail("nonce: %v", err)
+	}
+	email := "probe-life-" + nonce + "@" + domain
+	agentURL := p.HTTPBaseURL + "/v1/agents/" + url.PathEscape(email)
+
+	// CREATE → 201.
+	body, _ := json.Marshal(map[string]string{"email": email, "name": "e2a selftest lifecycle"})
+	st, _, err := p.do(ctx, http.MethodPost, p.HTTPBaseURL+"/v1/agents", body)
+	if err != nil {
+		return fail("create: %v", err)
+	}
+	if st != http.StatusCreated {
+		return fail("create agent: HTTP %d, want 201", st)
+	}
+	// Safety net: ensure the ephemeral agent is removed even on an early return
+	// below. Best-effort, fresh context so it runs even if ctx is done.
+	defer func() {
+		cctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_, _, _ = p.do(cctx, http.MethodDelete, agentURL+"?confirm=DELETE", nil)
+	}()
+
+	// GET → 200.
+	if st, _, err := p.do(ctx, http.MethodGet, agentURL, nil); err != nil {
+		return fail("get created agent: %v", err)
+	} else if st != http.StatusOK {
+		return fail("get created agent: HTTP %d, want 200", st)
+	}
+
+	// DELETE (confirmed) → 204.
+	if st, _, err := p.do(ctx, http.MethodDelete, agentURL+"?confirm=DELETE", nil); err != nil {
+		return fail("delete agent: %v", err)
+	} else if st != http.StatusNoContent {
+		return fail("delete agent: HTTP %d, want 204", st)
+	}
+
+	// Confirm it's gone — a follow-up GET must not return 200.
+	if st, _, err := p.do(ctx, http.MethodGet, agentURL, nil); err != nil {
+		return fail("get after delete: %v", err)
+	} else if st == http.StatusOK {
+		return fail("agent still readable after delete (HTTP 200)")
+	}
+	return pass("agent create→get→delete ok")
+}
+
+// do issues an authenticated request and returns the status, body, and error.
+func (p *Probe) do(ctx context.Context, method, u string, body []byte) (int, []byte, error) {
+	var rdr io.Reader
+	if body != nil {
+		rdr = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, u, rdr)
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+p.APIKey)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	resp, err := p.httpClient().Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	out, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	return resp.StatusCode, out, nil
 }
 
 // verifyHMAC checks the X-E2A-Signature header against the body using the

--- a/internal/selftest/scenarios_internal_test.go
+++ b/internal/selftest/scenarios_internal_test.go
@@ -1,0 +1,118 @@
+package selftest
+
+// Internal failure-path tests: assert each scenario reports StatusFail when the
+// thing it checks is broken. This is the monitor's whole job — a scenario that
+// only ever returns pass on the happy path could mask a real outage. Driven by
+// httptest mocks (no DB) so each failure mode is isolated.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func failProbe(baseURL, smtpAddr string, sink *HTTPSink) *Probe {
+	return &Probe{
+		HTTPBaseURL:   baseURL,
+		APIKey:        "k",
+		AgentEmail:    "agent@probe.test",
+		SMTPAddr:      smtpAddr,
+		WebhookSecret: "whsec_test",
+		Sink:          sink,
+		Timeout:       200 * time.Millisecond,
+	}
+}
+
+func mustFail(t *testing.T, name string, r Result) {
+	t.Helper()
+	if r.Status != StatusFail {
+		t.Errorf("%s: status = %s (%q), want fail", name, r.Status, r.Detail)
+	}
+}
+
+func TestScenarioLiveness_Fail(t *testing.T) {
+	// Non-200 health.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	mustFail(t, "health 500", scenarioLiveness(context.Background(), failProbe(srv.URL, "", nil)))
+
+	// 200 but wrong body.
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(`{"status":"degraded"}`))
+	}))
+	defer srv2.Close()
+	mustFail(t, "health wrong body", scenarioLiveness(context.Background(), failProbe(srv2.URL, "", nil)))
+
+	// Unreachable server.
+	mustFail(t, "health unreachable", scenarioLiveness(context.Background(), failProbe("http://127.0.0.1:1", "", nil)))
+}
+
+func TestScenarioAuthRead_Fail(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+	mustFail(t, "auth 401", scenarioAuthRead(context.Background(), failProbe(srv.URL, "", nil)))
+}
+
+func TestScenarioSelfSendLoopback_Fail(t *testing.T) {
+	// 200 but method != loopback → a real send would have egressed.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(`{"method":"smtp"}`))
+	}))
+	defer srv.Close()
+	mustFail(t, "self-send smtp not loopback", scenarioSelfSendLoopback(context.Background(), failProbe(srv.URL, "", nil)))
+}
+
+func TestScenarioAgentLifecycle_Fail(t *testing.T) {
+	// Create returns 500 → scenario fails before any cleanup is registered.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	mustFail(t, "create 500", scenarioAgentLifecycle(context.Background(), failProbe(srv.URL, "", nil)))
+}
+
+func TestScenarioInboundRoundTrip_Fail(t *testing.T) {
+	// SMTP listener unreachable → send fails.
+	mustFail(t, "smtp unreachable",
+		scenarioInboundRoundTrip(context.Background(), failProbe("http://127.0.0.1:1", "127.0.0.1:1", NewHTTPSink())))
+
+	// No sink configured → fail fast.
+	mustFail(t, "no sink",
+		scenarioInboundRoundTrip(context.Background(), failProbe("http://127.0.0.1:1", "127.0.0.1:1", nil)))
+}
+
+func TestSinkAwait_Timeout(t *testing.T) {
+	// The round-trip relies on Await timing out (StatusFail) when no webhook
+	// arrives. Assert that mechanism directly.
+	sink := NewHTTPSink()
+	_, err := sink.Await(context.Background(), func(Delivery) bool { return true }, 50*time.Millisecond)
+	if err == nil {
+		t.Fatal("Await returned nil error with no delivery, want timeout")
+	}
+}
+
+func TestRunWorst_WithFailure(t *testing.T) {
+	// Run aggregates a failing scenario; Worst reports fail.
+	scenarios := []Scenario{
+		{Name: "ok", SmokeSafe: true, Run: func(context.Context, *Probe) Result { return pass("ok") }},
+		{Name: "bad", SmokeSafe: true, Run: func(context.Context, *Probe) Result { return fail("boom") }},
+		{Name: "unsafe", SmokeSafe: false, Run: func(context.Context, *Probe) Result { return pass("skipme") }},
+	}
+	results := Run(context.Background(), failProbe("http://127.0.0.1:1", "", nil), scenarios, true /* smokeOnly */)
+	if len(results) != 2 {
+		t.Fatalf("ran %d scenarios, want 2 (unsafe one skipped under smokeOnly)", len(results))
+	}
+	if Worst(results) != StatusFail {
+		t.Errorf("Worst = %s, want fail", Worst(results))
+	}
+	// Worst of empty is fail ("no checks ran" is not healthy).
+	if Worst(nil) != StatusFail {
+		t.Errorf("Worst(nil) = %s, want fail", Worst(nil))
+	}
+}

--- a/internal/selftest/selftest.go
+++ b/internal/selftest/selftest.go
@@ -52,13 +52,14 @@ type Scenario struct {
 // is transport-only config plus collaborators; it holds no test scaffolding so
 // both the shipped prober and the in-process tests construct it directly.
 type Probe struct {
-	HTTPBaseURL   string       // e.g. http://e2a:8080 — API + /api/health
-	APIKey        string       // probe agent's API key (Bearer)
-	AgentEmail    string       // the synthetic probe agent address
-	SMTPAddr      string       // host:port of the inbound SMTP listener
-	WebhookSecret string       // signing secret of the probe webhook (HMAC verify)
-	Sink          *HTTPSink    // receives the webhook callback for the round-trip
-	HTTP          *http.Client // nil → defaultHTTPClient
+	HTTPBaseURL   string        // e.g. http://e2a:8080 — API + /api/health
+	APIKey        string        // probe agent's API key (Bearer)
+	AgentEmail    string        // the synthetic probe agent address
+	SMTPAddr      string        // host:port of the inbound SMTP listener
+	WebhookSecret string        // signing secret of the probe webhook (HMAC verify)
+	Sink          *HTTPSink     // receives the webhook callback for the round-trip
+	HTTP          *http.Client  // nil → defaultHTTPClient
+	Timeout       time.Duration // round-trip await timeout; 0 → defaultRoundTripTimeout
 }
 
 func (p *Probe) httpClient() *http.Client {
@@ -66,6 +67,16 @@ func (p *Probe) httpClient() *http.Client {
 		return p.HTTP
 	}
 	return defaultHTTPClient
+}
+
+// roundTripTimeout is the await bound for the inbound round-trip. It must exceed
+// the SubscriberRetryWorker poll interval in production; the prober sets it from
+// E2A_PROBE_TIMEOUT.
+func (p *Probe) roundTripTimeout() time.Duration {
+	if p.Timeout > 0 {
+		return p.Timeout
+	}
+	return defaultRoundTripTimeout
 }
 
 var defaultHTTPClient = &http.Client{Timeout: 10 * time.Second}

--- a/internal/selftest/selftest.go
+++ b/internal/selftest/selftest.go
@@ -1,0 +1,110 @@
+// Package selftest defines the e2a critical-path self-test: a small battery of
+// scenarios that exercise the real product paths (liveness, authenticated read,
+// the inbound SMTP→webhook round-trip with HMAC verification, and a self-send
+// loopback) against a running instance.
+//
+// The same battery is consumed three ways (see docs/design/prober-selftest.md):
+//   - the e2e tests (in-process, against testutil.TestServer);
+//   - the `e2a selftest` CLI (self-hosters validating an install);
+//   - cmd/e2a-prober (continuous prod monitor + deploy bake-gate signal).
+//
+// Scenarios are data (a []Scenario), so adding a check is a list edit. Each
+// scenario carries a SmokeSafe flag: only read-only / round-trip / loopback
+// scenarios that cause no real-world side effect (no external email, no owner
+// notifications, no metering) may run against production. The prober runs only
+// the SmokeSafe subset against live prod; the full set runs in-process.
+package selftest
+
+import (
+	"context"
+	"net/http"
+	"time"
+)
+
+// Status is the tri-state result of a single scenario, mirroring the IETF
+// health-check vocabulary (draft-inadarei-api-health-check).
+type Status string
+
+const (
+	StatusPass Status = "pass"
+	StatusWarn Status = "warn"
+	StatusFail Status = "fail"
+)
+
+// Result is the outcome of one scenario run.
+type Result struct {
+	Name       string `json:"name"`
+	Status     Status `json:"status"`
+	DurationMS int64  `json:"duration_ms"`
+	Detail     string `json:"detail,omitempty"` // human-readable; never contains secrets
+}
+
+// Scenario is one critical-path check. Run is given the resolved Probe and
+// returns a Result; it must not panic on failure — return StatusFail with a
+// Detail instead.
+type Scenario struct {
+	Name      string
+	SmokeSafe bool
+	Run       func(ctx context.Context, p *Probe) Result
+}
+
+// Probe carries everything a scenario needs to talk to a running instance. It
+// is transport-only config plus collaborators; it holds no test scaffolding so
+// both the shipped prober and the in-process tests construct it directly.
+type Probe struct {
+	HTTPBaseURL   string       // e.g. http://e2a:8080 — API + /api/health
+	APIKey        string       // probe agent's API key (Bearer)
+	AgentEmail    string       // the synthetic probe agent address
+	SMTPAddr      string       // host:port of the inbound SMTP listener
+	WebhookSecret string       // signing secret of the probe webhook (HMAC verify)
+	Sink          *HTTPSink    // receives the webhook callback for the round-trip
+	HTTP          *http.Client // nil → defaultHTTPClient
+}
+
+func (p *Probe) httpClient() *http.Client {
+	if p.HTTP != nil {
+		return p.HTTP
+	}
+	return defaultHTTPClient
+}
+
+var defaultHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
+// Run executes the given scenarios in order and returns their results. When
+// smokeOnly is true, scenarios with SmokeSafe=false are skipped (use this when
+// running against production). Run never aborts early — every scenario runs so
+// the caller sees the full picture in one pass.
+func Run(ctx context.Context, p *Probe, scenarios []Scenario, smokeOnly bool) []Result {
+	results := make([]Result, 0, len(scenarios))
+	for _, sc := range scenarios {
+		if smokeOnly && !sc.SmokeSafe {
+			continue
+		}
+		start := time.Now()
+		res := sc.Run(ctx, p)
+		res.Name = sc.Name
+		if res.DurationMS == 0 {
+			res.DurationMS = time.Since(start).Milliseconds()
+		}
+		results = append(results, res)
+	}
+	return results
+}
+
+// Worst returns the most severe status across results (fail > warn > pass).
+// An empty slice is treated as fail — "no checks ran" is not healthy.
+func Worst(results []Result) Status {
+	if len(results) == 0 {
+		return StatusFail
+	}
+	worst := StatusPass
+	for _, r := range results {
+		switch r.Status {
+		case StatusFail:
+			return StatusFail
+		case StatusWarn:
+			worst = StatusWarn
+		}
+	}
+	return worst
+}

--- a/internal/selftest/selftest_test.go
+++ b/internal/selftest/selftest_test.go
@@ -107,6 +107,17 @@ func TestSelftestAll_AgainstRealServer(t *testing.T) {
 	if events != 0 {
 		t.Errorf("system probe account wrote %d usage_events, want 0", events)
 	}
+
+	// agent_lifecycle must be self-cleaning: after the battery only the original
+	// probe agent remains — the ephemeral create→delete left no orphan.
+	var agents int
+	if err := pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM agent_identities WHERE user_id = $1`, user.ID).Scan(&agents); err != nil {
+		t.Fatalf("count agents: %v", err)
+	}
+	if agents != 1 {
+		t.Errorf("probe account has %d agents after battery, want 1 (agent_lifecycle left an orphan)", agents)
+	}
 }
 
 // TestVerifyHMAC_RejectsBadSignature is a unit guard on the HMAC check used by

--- a/internal/selftest/selftest_test.go
+++ b/internal/selftest/selftest_test.go
@@ -1,0 +1,128 @@
+package selftest_test
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/selftest"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+)
+
+// TestSelftestAll_AgainstRealServer boots a real in-process server (HTTP + SMTP
+// + subscriber worker) and runs the full battery against it through a synthetic
+// system-class probe agent — the same way the shipped prober runs against prod.
+// A background ticker stands in for the always-on production SubscriberRetryWorker.
+func TestSelftestAll_AgainstRealServer(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ts := testutil.TestServer(t, pool, testutil.WithOutboundSMTP("127.0.0.1", 1025, "test.e2a.dev"))
+	ctx := context.Background()
+
+	// --- seed a system-class probe account + agent ---
+	user, err := ts.Store.CreateOrGetUser(ctx, "probe@e2a-selftest.test", "Probe", "google-probe-selftest")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE users SET account_class = 'system' WHERE id = $1`, user.ID); err != nil {
+		t.Fatalf("set system class: %v", err)
+	}
+	key, err := ts.Store.CreateAPIKey(ctx, user.ID, "probe-key", nil)
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+	domain := "probe.e2a-selftest.test"
+	if _, err := ts.Store.ClaimOrCreateDomain(ctx, domain, user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+	if err := ts.Store.VerifyDomain(ctx, domain, user.ID); err != nil {
+		t.Fatalf("VerifyDomain: %v", err)
+	}
+	agentEmail := "agent@" + domain
+	agent, err := ts.Store.CreateAgent(ctx, agentEmail, domain, "Probe Agent", "", "local", user.ID)
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	// --- sink + webhook pointing at it ---
+	sink := selftest.NewHTTPSink()
+	sinkSrv := httptest.NewServer(sink)
+	defer sinkSrv.Close()
+	wh, err := ts.Store.CreateWebhook(ctx, user.ID, sinkSrv.URL+"/sink", "selftest",
+		[]string{"email.received"}, identity.WebhookFilters{})
+	if err != nil {
+		t.Fatalf("CreateWebhook: %v", err)
+	}
+
+	// --- stand in for the always-on subscriber worker ---
+	tickCtx, stop := context.WithCancel(ctx)
+	defer stop()
+	go func() {
+		tk := time.NewTicker(50 * time.Millisecond)
+		defer tk.Stop()
+		for {
+			select {
+			case <-tickCtx.Done():
+				return
+			case <-tk.C:
+				ts.SubscriberWorker.Tick(tickCtx)
+			}
+		}
+	}()
+
+	probe := &selftest.Probe{
+		HTTPBaseURL:   ts.HTTPServer.URL,
+		APIKey:        key.PlaintextKey,
+		AgentEmail:    agent.EmailAddress(),
+		SMTPAddr:      ts.SMTPAddr,
+		WebhookSecret: wh.SigningSecret,
+		Sink:          sink,
+	}
+
+	results := selftest.Run(ctx, probe, selftest.All, true /* smokeOnly */)
+	if len(results) != len(selftest.All) {
+		t.Fatalf("ran %d scenarios, want %d", len(results), len(selftest.All))
+	}
+	for _, r := range results {
+		if r.Status != selftest.StatusPass {
+			t.Errorf("scenario %q = %s: %s", r.Name, r.Status, r.Detail)
+		}
+	}
+	if w := selftest.Worst(results); w != selftest.StatusPass {
+		t.Errorf("Worst() = %s, want pass", w)
+	}
+
+	// The probe ran under a system-class account: no usage must have been
+	// recorded despite the inbound round-trip + self-send.
+	var events int
+	if err := pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM usage_events WHERE user_id = $1`, user.ID).Scan(&events); err != nil {
+		t.Fatalf("count usage_events: %v", err)
+	}
+	if events != 0 {
+		t.Errorf("system probe account wrote %d usage_events, want 0", events)
+	}
+}
+
+// TestVerifyHMAC_RejectsBadSignature is a unit guard on the HMAC check used by
+// the round-trip scenario.
+func TestVerifyHMAC_unit(t *testing.T) {
+	// A known-good signature is exercised end-to-end in the server test above;
+	// here we assert the negative paths the round-trip relies on.
+	body := []byte(`{"type":"email.received"}`)
+	cases := []struct {
+		name, header, secret string
+	}{
+		{"empty header", "", "sek"},
+		{"empty secret", "t=1,v1=deadbeef", ""},
+		{"no v1", "t=1", "sek"},
+		{"no t", "v1=deadbeef", "sek"},
+		{"bad hex sig", "t=1,v1=notamatch", "sek"},
+	}
+	for _, c := range cases {
+		if selftest.VerifyHMACForTest(c.header, body, c.secret) {
+			t.Errorf("%s: verifyHMAC returned true, want false", c.name)
+		}
+	}
+}

--- a/internal/selftest/selftest_test.go
+++ b/internal/selftest/selftest_test.go
@@ -2,6 +2,10 @@ package selftest_test
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
 	"net/http/httptest"
 	"testing"
 	"time"
@@ -124,5 +128,37 @@ func TestVerifyHMAC_unit(t *testing.T) {
 		if selftest.VerifyHMACForTest(c.header, body, c.secret) {
 			t.Errorf("%s: verifyHMAC returned true, want false", c.name)
 		}
+	}
+}
+
+// TestVerifyHMAC_positive covers the happy path and the rotation-grace branch
+// (two v1= clauses, only the second matching) without needing a DB — the
+// deliverer emits two signatures during the 24h secret-rotation window.
+func TestVerifyHMAC_positive(t *testing.T) {
+	const secret = "whsec_realone"
+	body := []byte(`{"type":"email.received","subject":"e2a-selftest abc"}`)
+	ts := int64(1_700_000_123)
+	sign := func(sec string) string {
+		mac := hmac.New(sha256.New, []byte(sec))
+		fmt.Fprintf(mac, "%d.", ts)
+		mac.Write(body)
+		return hex.EncodeToString(mac.Sum(nil))
+	}
+
+	// Single valid signature.
+	hdr := fmt.Sprintf("t=%d,v1=%s", ts, sign(secret))
+	if !selftest.VerifyHMACForTest(hdr, body, secret) {
+		t.Error("valid single signature should verify")
+	}
+
+	// Rotation grace: old (non-matching) + new (matching) — must accept.
+	hdr2 := fmt.Sprintf("t=%d,v1=%s,v1=%s", ts, sign("whsec_oldsecret"), sign(secret))
+	if !selftest.VerifyHMACForTest(hdr2, body, secret) {
+		t.Error("rotation-grace second signature should verify")
+	}
+
+	// A tampered body must NOT verify against the original signature.
+	if selftest.VerifyHMACForTest(hdr, []byte("tampered"), secret) {
+		t.Error("tampered body must not verify")
 	}
 }

--- a/internal/selftest/sink.go
+++ b/internal/selftest/sink.go
@@ -1,0 +1,74 @@
+package selftest
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Delivery is one webhook callback captured by an HTTPSink.
+type Delivery struct {
+	Headers http.Header
+	Body    []byte
+}
+
+// HTTPSink is an http.Handler that captures webhook deliveries and lets a
+// scenario await one matching a predicate. The shipped prober mounts it at
+// /sink on its internal server; the in-process tests mount it on an
+// httptest.Server. It is safe for concurrent use.
+type HTTPSink struct {
+	mu      sync.Mutex
+	got     []Delivery
+	waiters []chan struct{}
+}
+
+// NewHTTPSink returns an empty sink.
+func NewHTTPSink() *HTTPSink { return &HTTPSink{} }
+
+// ServeHTTP records the delivery and returns 200. Body read failures are
+// recorded as empty deliveries (the awaiting scenario will simply not match
+// and time out, surfacing the problem) rather than 500s.
+func (s *HTTPSink) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+	s.mu.Lock()
+	s.got = append(s.got, Delivery{Headers: r.Header.Clone(), Body: body})
+	for _, ch := range s.waiters {
+		close(ch)
+	}
+	s.waiters = nil
+	s.mu.Unlock()
+	w.WriteHeader(http.StatusOK)
+}
+
+// Await returns the first delivery (new or already-buffered) for which match
+// returns true, or an error if ctx/timeout elapses first. It scans the buffer
+// on every new delivery so out-of-order arrivals are handled.
+func (s *HTTPSink) Await(ctx context.Context, match func(Delivery) bool, timeout time.Duration) (*Delivery, error) {
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	scanned := 0
+	for {
+		s.mu.Lock()
+		for ; scanned < len(s.got); scanned++ {
+			if match(s.got[scanned]) {
+				d := s.got[scanned]
+				s.mu.Unlock()
+				return &d, nil
+			}
+		}
+		ch := make(chan struct{})
+		s.waiters = append(s.waiters, ch)
+		s.mu.Unlock()
+
+		select {
+		case <-ch:
+			// new delivery arrived → loop and rescan from `scanned`
+		case <-deadline.C:
+			return nil, context.DeadlineExceeded
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+}

--- a/internal/usage/policy.go
+++ b/internal/usage/policy.go
@@ -1,0 +1,41 @@
+package usage
+
+// AccountClass classifies an account for metering/billing/analytics. It is the
+// single source of truth read by the metering gate (see RecordAndCheck), kept
+// orthogonal to the paid plan/tier. Mirrors the CHECK constraint in
+// migrations/037_account_class.sql.
+type AccountClass string
+
+const (
+	// ClassStandard is a real customer: metered, billed, counted in analytics.
+	// The default for every account.
+	ClassStandard AccountClass = "standard"
+	// ClassInternal is internal dogfooding.
+	ClassInternal AccountClass = "internal"
+	// ClassSystem is synthetic-monitoring probe traffic.
+	ClassSystem AccountClass = "system"
+	// ClassDemo is a demo account.
+	ClassDemo AccountClass = "demo"
+)
+
+// MeteringPolicy is the resolved decision for an account class. Resolved once at
+// the metering gate rather than re-derived at each write path.
+type MeteringPolicy struct {
+	Meter     bool // record usage_events + usage_summaries (and thus count against quota)
+	Bill      bool // include in billing
+	Analytics bool // include in product analytics
+}
+
+// PolicyFor returns the metering policy for an account class. Only standard
+// accounts are metered/billed/analyzed; every non-standard class (internal,
+// system, demo) is excluded on all three axes. An unknown/empty value
+// fail-closed defaults to standard so a misclassified account is never silently
+// exempted from billing.
+func PolicyFor(c AccountClass) MeteringPolicy {
+	switch c {
+	case ClassInternal, ClassSystem, ClassDemo:
+		return MeteringPolicy{Meter: false, Bill: false, Analytics: false}
+	default: // ClassStandard and any unrecognized value
+		return MeteringPolicy{Meter: true, Bill: true, Analytics: true}
+	}
+}

--- a/internal/usage/policy_test.go
+++ b/internal/usage/policy_test.go
@@ -1,0 +1,32 @@
+package usage_test
+
+import (
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/usage"
+)
+
+func TestPolicyFor(t *testing.T) {
+	cases := []struct {
+		class      usage.AccountClass
+		wantMeter  bool
+		wantBill   bool
+		wantAnalyt bool
+	}{
+		{usage.ClassStandard, true, true, true},
+		{usage.ClassInternal, false, false, false},
+		{usage.ClassSystem, false, false, false},
+		{usage.ClassDemo, false, false, false},
+		// Unknown / empty fails closed to standard (meter) — a misclassified
+		// account must never be silently exempted from billing.
+		{usage.AccountClass(""), true, true, true},
+		{usage.AccountClass("bogus"), true, true, true},
+	}
+	for _, c := range cases {
+		got := usage.PolicyFor(c.class)
+		if got.Meter != c.wantMeter || got.Bill != c.wantBill || got.Analytics != c.wantAnalyt {
+			t.Errorf("PolicyFor(%q) = %+v, want meter=%v bill=%v analytics=%v",
+				c.class, got, c.wantMeter, c.wantBill, c.wantAnalyt)
+		}
+	}
+}

--- a/internal/usage/store.go
+++ b/internal/usage/store.go
@@ -89,6 +89,25 @@ func (s *Store) IncrementUsageSummary(ctx context.Context, userID, bucketDate, d
 	return err
 }
 
+// GetAccountClass returns the account class for a user. A missing user (no row)
+// resolves to ClassStandard so the metering gate fails toward metering — a
+// real customer must never be silently exempted from billing because of a
+// transient lookup miss. The PK lookup on users is cheap; account class is read
+// once per metered message.
+func (s *Store) GetAccountClass(ctx context.Context, userID string) (AccountClass, error) {
+	var class string
+	err := s.pool.QueryRow(ctx,
+		`SELECT account_class FROM users WHERE id = $1`, userID,
+	).Scan(&class)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ClassStandard, nil
+		}
+		return ClassStandard, err
+	}
+	return AccountClass(class), nil
+}
+
 func (s *Store) CountAgentsByUser(ctx context.Context, userID string) (int, error) {
 	var count int
 	err := s.pool.QueryRow(ctx,

--- a/internal/usage/usage.go
+++ b/internal/usage/usage.go
@@ -21,6 +21,20 @@ func NewUsageTracker(store *Store) *LiveUsageTracker {
 }
 
 func (t *LiveUsageTracker) RecordAndCheck(ctx context.Context, userID, agentID, domain, direction string) (bool, error) {
+	// Metering gate: resolve the account class once and short-circuit
+	// non-standard accounts (internal/system/demo) BEFORE any write, so probe
+	// and internal traffic never lands in usage_events/usage_summaries and thus
+	// never counts against quota. On a lookup error we fail toward metering
+	// (GetAccountClass returns ClassStandard) — a real customer is never
+	// silently exempted from billing.
+	class, err := t.store.GetAccountClass(ctx, userID)
+	if err != nil {
+		log.Printf("[billing] account class lookup failed for user %s, metering as standard: %v", userID, err)
+	}
+	if !PolicyFor(class).Meter {
+		return true, nil
+	}
+
 	// Record the event
 	event := &UsageEvent{
 		UserID:    userID,

--- a/internal/usage/usage_test.go
+++ b/internal/usage/usage_test.go
@@ -2,11 +2,14 @@ package usage_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
-	"github.com/Mnexa-AI/e2a/internal/usage"
+	"github.com/jackc/pgx/v5"
+
 	"github.com/Mnexa-AI/e2a/internal/identity"
 	"github.com/Mnexa-AI/e2a/internal/testutil"
+	"github.com/Mnexa-AI/e2a/internal/usage"
 )
 
 // -- NoopUsageTracker tests (no DB needed) --
@@ -87,6 +90,71 @@ func TestLiveUsageTracker_AlwaysAllows(t *testing.T) {
 	allowed, err = tracker.RecordAndCheck(ctx, user.ID, "agent1", "test.com", "outbound")
 	if err != nil || !allowed {
 		t.Errorf("outbound should always be allowed: allowed=%v, err=%v", allowed, err)
+	}
+}
+
+// TestLiveUsageTracker_SystemClassNotMetered is the load-bearing assertion for
+// the metering gate: a system-class account (synthetic probe traffic) writes
+// ZERO usage_events and ZERO usage_summaries, so it never accrues quota. A
+// standard account in the same test writes both (regression guard that the gate
+// only short-circuits non-standard classes).
+func TestLiveUsageTracker_SystemClassNotMetered(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := usage.NewStore(pool)
+	idStore := identity.NewStore(pool)
+	tracker := usage.NewUsageTracker(store)
+	ctx := context.Background()
+
+	countEvents := func(userID string) int {
+		var n int
+		if err := pool.QueryRow(ctx,
+			`SELECT COUNT(*) FROM usage_events WHERE user_id = $1`, userID).Scan(&n); err != nil {
+			t.Fatalf("count usage_events: %v", err)
+		}
+		return n
+	}
+
+	// system-class account: gate short-circuits, no rows written.
+	sysUser, err := idStore.CreateOrGetUser(ctx, "probe-system@example.com", "Probe System", "google-probe-system")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser system: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE users SET account_class = 'system' WHERE id = $1`, sysUser.ID); err != nil {
+		t.Fatalf("set system class: %v", err)
+	}
+
+	for _, dir := range []string{"inbound", "outbound"} {
+		allowed, err := tracker.RecordAndCheck(ctx, sysUser.ID, "agent-sys", "probe.example.com", dir)
+		if err != nil || !allowed {
+			t.Errorf("system %s RecordAndCheck: allowed=%v err=%v", dir, allowed, err)
+		}
+	}
+	if n := countEvents(sysUser.ID); n != 0 {
+		t.Errorf("system account wrote %d usage_events, want 0", n)
+	}
+	if _, err := store.GetUsageSummary(ctx, sysUser.ID, usage.CurrentDate()); !errors.Is(err, pgx.ErrNoRows) {
+		t.Errorf("system account usage_summaries lookup err = %v, want ErrNoRows (no summary written)", err)
+	}
+
+	// standard-class account (regression): gate does NOT short-circuit.
+	stdUser, err := idStore.CreateOrGetUser(ctx, "probe-standard@example.com", "Probe Standard", "google-probe-standard")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser standard: %v", err)
+	}
+	for _, dir := range []string{"inbound", "outbound"} {
+		if _, err := tracker.RecordAndCheck(ctx, stdUser.ID, "agent-std", "real.example.com", dir); err != nil {
+			t.Fatalf("standard %s RecordAndCheck: %v", dir, err)
+		}
+	}
+	if n := countEvents(stdUser.ID); n != 2 {
+		t.Errorf("standard account wrote %d usage_events, want 2", n)
+	}
+	sum, err := store.GetUsageSummary(ctx, stdUser.ID, usage.CurrentDate())
+	if err != nil {
+		t.Fatalf("standard GetUsageSummary: %v", err)
+	}
+	if sum.TotalCount != 2 {
+		t.Errorf("standard account summary TotalCount = %d, want 2", sum.TotalCount)
 	}
 }
 

--- a/migrations/037_account_class.sql
+++ b/migrations/037_account_class.sql
@@ -1,0 +1,25 @@
+-- 037_account_class.sql
+--
+-- Account classification (prober-selftest design, slice 1). A per-account
+-- `account_class` is the single source of truth for "what kind of account this
+-- is", ORTHOGONAL to the paid plan/tier (which decides quota size). The metering
+-- gate (usage.PolicyFor) resolves billability from this class at the one point
+-- usage is recorded, so non-standard accounts never write usage_events /
+-- usage_summaries and never accrue quota.
+--
+--   standard (default) — a real customer; metered, billed, in analytics
+--   internal           — internal dogfooding; not metered/billed/analytics
+--   system             — synthetic-monitoring probe traffic; not metered/billed/analytics
+--   demo               — demo accounts; not metered/billed/analytics
+--
+-- Lives on users (usage/quota are keyed by user_id). Idempotent + non-destructive:
+-- ADD COLUMN ... DEFAULT on the small users table does not rewrite messages /
+-- usage_events. account_class is server-side only — it is never surfaced in any
+-- /v1 response (see docs/design/prober-selftest.md "API surface impact").
+ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS account_class TEXT NOT NULL DEFAULT 'standard';
+
+DO $$ BEGIN
+    ALTER TABLE users ADD CONSTRAINT users_account_class_check
+        CHECK (account_class IN ('standard', 'internal', 'system', 'demo'));
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;


### PR DESCRIPTION
Implements the main-repo slices of the prober-selftest design (`docs/design/prober-selftest.md`): a synthetic critical-path self-test reused by e2e tests, an `e2a selftest`-style CLI, and a production prober — all without metering probe traffic, sending real mail, or emailing agent owners.

## Slices landed (each committed + verified)
- **Slice 1 — account-class metering gate.** `users.account_class` (`standard|internal|system|demo`); `usage.PolicyFor` resolved once in `RecordAndCheck`, short-circuiting non-standard accounts before any write. Fail-safe: unknown/missing class meters as `standard` (a real customer is never silently unbilled). No enforcer change needed.
- **Slice 3a — `internal/selftest`.** `[]Scenario` battery (liveness, auth read, inbound SMTP→webhook + HMAC, self-send loopback) + `HTTPSink`. One definition reused by tests, CLI, and prober.
- **Slice 3b — `cmd/e2a-prober`.** `seed` / `validate` / `run-once` / `serve` (+ `/sink` `/healthz` `/metrics` `/status` for the continuous monitor and the deploy bake-gate).
- **Slice 3c — `/readyz`** (DB + migrations-applied; the deploy-but-migration-didn't-apply guard) and **`/selftest`** (dependency diagnostics, health+json, auth-gated, fail-closed in prod) on the non-Huma mux.

## Verification
- **Over the wire:** booted the real `e2a` binary (dev mode) and ran `e2a-prober run-once` — liveness, auth read, **inbound SMTP→webhook round-trip + HMAC** (delivered by the real subscriber worker), self-send loopback all pass; logs clean; **zero `usage_events`** for the `system`-class probe account.
- Unit + DB-backed + `-race` tests across `usage`, `selftest`, `e2a-prober`, `readyz`, `selftest` endpoint. Run DB tiers with `-p 1` (shared test DB).

## Independent + adversarial review (run on this branch)
- **Billing/metering evasion: REFUTED** — gate fails closed everywhere; `account_class` is unreachable from any user-facing path; never echoed in `/v1`.
- **Fixed:** `/selftest` now fails **closed** in prod when no internal secret is set; `E2A_PROBE_TIMEOUT` is now wired (was ignored); seed creates an API key only if none exists (bounds sprawl); positive HMAC + rotation-grace unit test; `0.0.0.0` dial guard.

## Contract
No change to the public `/v1` contract or `api/openapi.yaml`; `account_class` stays server-side only; `/readyz` + `/selftest` are on the non-Huma mux.

## Deferred (follow-ups, see design doc)
- `Sender` interface refactor (touches live SES path; not required by the prober).
- Ops slices 4 & 5 (`e2a-ops` compose service + `deploy.yml` bake-gate) — config-only, not deploy-verifiable here.
- Prod wiring: the webhook deliverer requires HTTPS, but the internal prober sink is plain HTTP — needs a deliverer exemption (or TLS) before the round-trip works against prod.
- `e2a` `/metrics` 5xx signal (fast-follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)