### PR TITLE
feat(outbound): retain sent message bodies (Sent folder) + meter held bodies

### DIFF
--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -1150,7 +1150,7 @@ func (a *API) DeliverOutbound(ctx context.Context, user *identity.User, agent *i
 		log.Printf("[api] send failed: agent=%s to=%v error=%v", agent.Domain, req.To, err)
 		return nil, &OutboundError{http.StatusInternalServerError, "internal_error", fmt.Sprintf("send failed: %v", err)}
 	}
-	outMsg, err := a.store.CreateOutboundMessage(ctx, agent.ID, result.To, result.CC, result.BCC, req.Subject, msgType, result.Method, result.MessageID, req.ConversationID)
+	outMsg, err := a.store.CreateOutboundMessage(ctx, agent.ID, result.To, result.CC, result.BCC, req.Subject, msgType, result.Method, result.MessageID, req.ConversationID, result.Raw)
 	if err != nil {
 		log.Printf("[api] failed to record outbound message: %v", err)
 	}

--- a/internal/agent/hitl_api.go
+++ b/internal/agent/hitl_api.go
@@ -112,6 +112,7 @@ func (a *API) ApprovePendingCore(ctx context.Context, userID, messageID, expecte
 				To:                result.To,
 				CC:                result.CC,
 				BCC:               result.BCC,
+				Raw:               result.Raw,
 			}, nil
 		})
 	if err != nil {

--- a/internal/agent/hitl_magic_api.go
+++ b/internal/agent/hitl_magic_api.go
@@ -238,6 +238,7 @@ func (a *API) magicApprove(w http.ResponseWriter, r *http.Request, messageID, us
 				To:                result.To,
 				CC:                result.CC,
 				BCC:               result.BCC,
+				Raw:               result.Raw,
 			}, nil
 		})
 	if err != nil {

--- a/internal/agent/selfsend.go
+++ b/internal/agent/selfsend.go
@@ -71,6 +71,7 @@ func (a *API) performSelfSend(
 		"loopback",
 		providerID,
 		req.ConversationID,
+		nil, // self-send body is retained on the inbound twin row; don't double-store
 	); err != nil {
 		return "", fmt.Errorf("self-send outbound row: %w", err)
 	}

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -121,7 +121,7 @@ func TestHandleAgentActivity_WithMessages(t *testing.T) {
 
 	// Create some activity ("" id lets the store generate one).
 	store.CreateInboundMessage(ctx, "", agent.ID, "alice@gmail.com", "bot@active.example.com", "", "Hello", "", "", nil, nil, nil, false, "", nil, nil, nil)
-	store.CreateOutboundMessage(ctx, agent.ID, []string{"alice@gmail.com"}, nil, nil, "Re: Hello", "reply", "smtp", "", "")
+	store.CreateOutboundMessage(ctx, agent.ID, []string{"alice@gmail.com"}, nil, nil, "Re: Hello", "reply", "smtp", "", "", nil)
 	store.CreateInboundMessage(ctx, "", agent.ID, "bob@gmail.com", "bot@active.example.com", "", "Hi", "", "", nil, nil, nil, false, "", nil, nil, nil)
 
 	req := authedRequest("GET", "/api/dashboard/agents/agent%40active.example.com/activity", token)

--- a/internal/delivery/integration_test.go
+++ b/internal/delivery/integration_test.go
@@ -33,7 +33,7 @@ func seedOutbound(t *testing.T, store *identity.Store, prefix, providerID string
 	if _, err := store.CreateAgent(ctx, agentEmail, domain, "", "", "", user.ID); err != nil {
 		t.Fatalf("CreateAgent: %v", err)
 	}
-	msg, err := store.CreateOutboundMessage(ctx, agentEmail, to, nil, nil, "Subj", "send", "smtp", providerID, "")
+	msg, err := store.CreateOutboundMessage(ctx, agentEmail, to, nil, nil, "Subj", "send", "smtp", providerID, "", nil)
 	if err != nil {
 		t.Fatalf("CreateOutboundMessage: %v", err)
 	}
@@ -198,7 +198,7 @@ func TestConcurrentRollupMonotonic(t *testing.T) {
 
 	for i := 0; i < 25; i++ {
 		providerID := "ses-race-" + string(rune('a'+i%26)) + string(rune('a'+i/26))
-		msg, err := store.CreateOutboundMessage(ctx, agentEmail, []string{"a@x.com"}, nil, nil, "S", "send", "smtp", providerID, "")
+		msg, err := store.CreateOutboundMessage(ctx, agentEmail, []string{"a@x.com"}, nil, nil, "S", "send", "smtp", providerID, "", nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/hitlworker/worker.go
+++ b/internal/hitlworker/worker.go
@@ -143,6 +143,7 @@ func (w *Worker) autoApprove(ctx context.Context, c identity.ExpirationCandidate
 				To:                result.To,
 				CC:                result.CC,
 				BCC:               result.BCC,
+				Raw:               result.Raw,
 			}, nil
 		})
 	if err != nil {

--- a/internal/identity/conversation_webhook_status_test.go
+++ b/internal/identity/conversation_webhook_status_test.go
@@ -21,7 +21,7 @@ func TestConversationMessagesCarryWebhookStatus(t *testing.T) {
 
 	out, err := store.CreateOutboundMessage(
 		ctx, agentID, []string{"alice@gmail.com"}, nil, nil,
-		"Hi", "send", "smtp", "<wh-1@x>", "conv-wh",
+		"Hi", "send", "smtp", "<wh-1@x>", "conv-wh", nil,
 	)
 	if err != nil {
 		t.Fatalf("CreateOutboundMessage: %v", err)

--- a/internal/identity/conversations_test.go
+++ b/internal/identity/conversations_test.go
@@ -172,7 +172,7 @@ func TestListConversationsByAgent_AggregateFields(t *testing.T) {
 	// The 9th arg of CreateInboundMessage is inbox_status — pass
 	// "unread" explicitly so the has_unread aggregate is true.
 	store.CreateInboundMessage(ctx, "", agentID, "alice@gmail.com", "bot@convo-agg.example.com", "<i1@x>", "Hello", "conv-agg", "unread", nil, nil, nil, false, "", nil, nil, nil)
-	store.CreateOutboundMessage(ctx, agentID, []string{"alice@gmail.com"}, nil, nil, "Re: Hello", "reply", "smtp", "<out@x>", "conv-agg")
+	store.CreateOutboundMessage(ctx, agentID, []string{"alice@gmail.com"}, nil, nil, "Re: Hello", "reply", "smtp", "<out@x>", "conv-agg", nil)
 
 	convos, _ := store.ListConversationsByAgent(ctx, identity.ConversationListFilter{AgentID: agentID})
 	if len(convos) != 1 {

--- a/internal/identity/hitl_approve_test.go
+++ b/internal/identity/hitl_approve_test.go
@@ -135,7 +135,7 @@ func TestListPendingOutboundForUser(t *testing.T) {
 
 	// A sent message on same agent should not appear in the list
 	_, err = store.CreateOutboundMessage(ctx, a.ID,
-		[]string{"sent@example.com"}, nil, nil, "Already sent", "send", "smtp", "<p1>", "")
+		[]string{"sent@example.com"}, nil, nil, "Already sent", "send", "smtp", "<p1>", "", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -479,7 +479,7 @@ func TestApproveAndSendNotPending(t *testing.T) {
 
 	// Already-sent message
 	sent, _ := store.CreateOutboundMessage(ctx, a.ID,
-		[]string{"alice@example.com"}, nil, nil, "Already sent", "send", "smtp", "<p>", "")
+		[]string{"alice@example.com"}, nil, nil, "Already sent", "send", "smtp", "<p>", "", nil)
 
 	_, err := store.ApproveAndSend(ctx, sent.ID, user.ID, identity.PendingApprovalEdit{},
 		func(m *identity.Message) (identity.SendResult, error) {

--- a/internal/identity/hitl_expire_test.go
+++ b/internal/identity/hitl_expire_test.go
@@ -189,7 +189,7 @@ func TestExpireApproveAndSendSkipsAlreadyTerminal(t *testing.T) {
 
 	// A message already in 'sent' state — the expiration query should ignore it
 	sent, _ := store.CreateOutboundMessage(ctx, a.ID,
-		[]string{"x@example.com"}, nil, nil, "already", "send", "smtp", "<p>", "")
+		[]string{"x@example.com"}, nil, nil, "already", "send", "smtp", "<p>", "", nil)
 
 	_, err := store.ExpireApproveAndSend(ctx, sent.ID,
 		func(m *identity.Message) (identity.SendResult, error) {
@@ -300,4 +300,3 @@ func TestExpireRejectRaceReturnsErrNotPending(t *testing.T) {
 		t.Errorf("expected ErrNotPendingApproval when row already terminal, got %v", err)
 	}
 }
-

--- a/internal/identity/hitl_test.go
+++ b/internal/identity/hitl_test.go
@@ -250,7 +250,7 @@ func TestCreateOutboundMessageStatusSent(t *testing.T) {
 	store.ClaimOrCreateDomain(ctx, "ob-status.example.com", user.ID)
 	a, _ := store.CreateAgent(ctx, "bot@ob-status.example.com", "ob-status.example.com", "", "https://example.com/webhook", "", user.ID)
 
-	msg, err := store.CreateOutboundMessage(ctx, a.ID, []string{"alice@gmail.com"}, nil, nil, "Re: Hello", "reply", "smtp", "", "")
+	msg, err := store.CreateOutboundMessage(ctx, a.ID, []string{"alice@gmail.com"}, nil, nil, "Re: Hello", "reply", "smtp", "", "", nil)
 	if err != nil {
 		t.Fatalf("CreateOutboundMessage: %v", err)
 	}
@@ -481,7 +481,7 @@ func TestMessageStatusDBCheck(t *testing.T) {
 	user, _ := store.CreateOrGetUser(ctx, "owner@example.com", "Owner", "google-status-check")
 	store.ClaimOrCreateDomain(ctx, "status-check.example.com", user.ID)
 	a, _ := store.CreateAgent(ctx, "bot@status-check.example.com", "status-check.example.com", "", "https://example.com/webhook", "", user.ID)
-	msg, _ := store.CreateOutboundMessage(ctx, a.ID, []string{"alice@example.com"}, nil, nil, "x", "send", "smtp", "", "")
+	msg, _ := store.CreateOutboundMessage(ctx, a.ID, []string{"alice@example.com"}, nil, nil, "x", "send", "smtp", "", "", nil)
 
 	_, err := pool.Exec(ctx, `UPDATE messages SET status = 'bogus' WHERE id = $1`, msg.ID)
 	if err == nil {

--- a/internal/identity/messages_sender_test.go
+++ b/internal/identity/messages_sender_test.go
@@ -10,7 +10,7 @@ import (
 
 // B1 (review correctness bug): outbound messages must carry their sender (the
 // agent's own address). The outbound INSERTs never write the `sender` column,
-// so it defaults to '' and every outbound message reports from="" — a REQUIRED
+// so it defaults to ” and every outbound message reports from="" — a REQUIRED
 // wire field returning empty. This test reads an outbound message back and
 // expects the agent address.
 func TestOutboundMessageHasSender(t *testing.T) {
@@ -22,7 +22,7 @@ func TestOutboundMessageHasSender(t *testing.T) {
 
 	out, err := store.CreateOutboundMessage(
 		ctx, agentID, []string{"alice@gmail.com"}, nil, nil,
-		"Hello", "send", "smtp", "<out-sender-1@x>", "conv-sender",
+		"Hello", "send", "smtp", "<out-sender-1@x>", "conv-sender", nil,
 	)
 	if err != nil {
 		t.Fatalf("CreateOutboundMessage: %v", err)

--- a/internal/identity/outbound_retention_test.go
+++ b/internal/identity/outbound_retention_test.go
@@ -1,0 +1,102 @@
+package identity_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+)
+
+func seedRetentionAgent(t *testing.T, store *identity.Store, ctx context.Context, domain string) (userID, agentID string) {
+	t.Helper()
+	user, err := store.CreateOrGetUser(ctx, "o@"+domain, "O", "g-"+domain)
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	if _, err := store.ClaimOrCreateDomain(ctx, domain, user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+	ag, err := store.CreateAgent(ctx, "bot@"+domain, domain, "", "", "", user.ID)
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	return user.ID, ag.ID
+}
+
+// TestOutboundRetention_DirectSend: a normal send retains the composed MIME as
+// raw_message (a readable Sent folder); a self-send passes nil (body lives on the
+// inbound twin) and stores NULL.
+func TestOutboundRetention_DirectSend(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	_, agentID := seedRetentionAgent(t, store, ctx, "ret.example.com")
+
+	raw := []byte("From: bot@ret.example.com\r\nSubject: hi\r\n\r\nhello world")
+	m, err := store.CreateOutboundMessage(ctx, agentID, []string{"a@b.com"}, nil, nil, "hi", "send", "smtp", "<p@x>", "", raw)
+	if err != nil {
+		t.Fatalf("CreateOutboundMessage: %v", err)
+	}
+	got, err := store.GetMessageWithContent(ctx, m.ID, agentID)
+	if err != nil {
+		t.Fatalf("GetMessageWithContent: %v", err)
+	}
+	if string(got.RawMessage) != string(raw) {
+		t.Errorf("sent body not retained: got %d bytes, want %d", len(got.RawMessage), len(raw))
+	}
+
+	// Self-send path passes nil → NULL (the body is on the inbound twin).
+	m2, err := store.CreateOutboundMessage(ctx, agentID, []string{"a@b.com"}, nil, nil, "hi2", "send", "loopback", "<p2@x>", "", nil)
+	if err != nil {
+		t.Fatalf("CreateOutboundMessage(nil): %v", err)
+	}
+	got2, err := store.GetMessageWithContent(ctx, m2.ID, agentID)
+	if err != nil {
+		t.Fatalf("GetMessageWithContent(nil): %v", err)
+	}
+	if len(got2.RawMessage) != 0 {
+		t.Errorf("nil raw should store NULL, got %d bytes", len(got2.RawMessage))
+	}
+}
+
+// TestOutboundRetention_HITLApprove: a HITL-approved send retains the sent MIME
+// (raw_message) from the send callback, replacing the scrubbed draft columns.
+func TestOutboundRetention_HITLApprove(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	userID, agentID := seedRetentionAgent(t, store, ctx, "rethitl.example.com")
+
+	pending, err := store.CreatePendingOutboundMessage(ctx, agentID, []string{"a@b.com"}, nil, nil,
+		"subj", "body text", "", nil, "send", "", "", 3600)
+	if err != nil {
+		t.Fatalf("CreatePendingOutboundMessage: %v", err)
+	}
+
+	raw := []byte("From: bot@rethitl.example.com\r\nSubject: subj\r\n\r\nbody text")
+	sent, err := store.ApproveAndSend(ctx, pending.ID, userID, identity.PendingApprovalEdit{},
+		func(m *identity.Message) (identity.SendResult, error) {
+			return identity.SendResult{
+				ProviderMessageID: "<ses@x>",
+				Method:            "smtp",
+				To:                m.ToRecipients,
+				Raw:               raw,
+			}, nil
+		})
+	if err != nil {
+		t.Fatalf("ApproveAndSend: %v", err)
+	}
+
+	got, err := store.GetMessageWithContent(ctx, sent.ID, agentID)
+	if err != nil {
+		t.Fatalf("GetMessageWithContent: %v", err)
+	}
+	if string(got.RawMessage) != string(raw) {
+		t.Errorf("HITL-approved sent body not retained: got %d bytes, want %d", len(got.RawMessage), len(raw))
+	}
+	// The draft body columns are scrubbed (raw_message is the canonical copy).
+	if got.BodyText != "" {
+		t.Errorf("draft body_text should be scrubbed after send, got %q", got.BodyText)
+	}
+}

--- a/internal/identity/outbound_retention_test.go
+++ b/internal/identity/outbound_retention_test.go
@@ -100,3 +100,41 @@ func TestOutboundRetention_HITLApprove(t *testing.T) {
 		t.Errorf("draft body_text should be scrubbed after send, got %q", got.BodyText)
 	}
 }
+
+// TestOutboundRetention_MetersStorage is the regression guard for the storage-meter
+// gap: the HITL finalize is an UPDATE, which the account_usage trigger ignored
+// before migration 039 — so a HITL-sent body was stored off the meter. After the
+// fix, the retained raw_message must count toward storage_bytes.
+func TestOutboundRetention_MetersStorage(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	userID, agentID := seedRetentionAgent(t, store, ctx, "retmeter.example.com")
+
+	storageBytes := func() int64 {
+		var n int64
+		_ = pool.QueryRow(ctx, `SELECT COALESCE(storage_bytes, 0) FROM account_usage WHERE user_id=$1`, userID).Scan(&n)
+		return n
+	}
+
+	pending, err := store.CreatePendingOutboundMessage(ctx, agentID, []string{"a@b.com"}, nil, nil,
+		"subj", "tiny", "", nil, "send", "", "", 3600)
+	if err != nil {
+		t.Fatalf("CreatePendingOutboundMessage: %v", err)
+	}
+
+	raw := make([]byte, 100_000)
+	for i := range raw {
+		raw[i] = 'x'
+	}
+	if _, err := store.ApproveAndSend(ctx, pending.ID, userID, identity.PendingApprovalEdit{},
+		func(m *identity.Message) (identity.SendResult, error) {
+			return identity.SendResult{ProviderMessageID: "<s@x>", Method: "smtp", To: m.ToRecipients, Raw: raw}, nil
+		}); err != nil {
+		t.Fatalf("ApproveAndSend: %v", err)
+	}
+
+	if got := storageBytes(); got < 100_000 {
+		t.Errorf("storage_bytes=%d, want >=100000 — the HITL-sent raw_message must be metered", got)
+	}
+}

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -1720,7 +1720,7 @@ func (s *Store) ApproveAndSend(
 		        edited            = $10,
 		        reviewed_at       = now(),
 		        reviewed_by_user_id = $11,
-		        raw_message       = $12,
+		        raw_message       = $12::bytea,
 		        body_text         = NULL,
 		        body_html         = NULL,
 		        attachments_json  = NULL
@@ -1988,7 +1988,7 @@ func (s *Store) ExpireApproveAndSend(
 		        bcc               = $7,
 		        recipient         = $8,
 		        reviewed_at       = now(),
-		        raw_message       = $9,
+		        raw_message       = $9::bytea,
 		        body_text         = NULL,
 		        body_html         = NULL,
 		        attachments_json  = NULL

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -1173,7 +1173,7 @@ func (s *Store) GetInboundByEmailMessageID(ctx context.Context, agentID, emailMe
 // CreateOutboundMessage stores an outbound message with multi-recipient support.
 // The recipient param is kept for backward compat with the singular recipient column;
 // toRecipients, cc, and bcc are the canonical outbound-only multi-recipient fields.
-func (s *Store) CreateOutboundMessage(ctx context.Context, agentID string, toRecipients []string, cc []string, bcc []string, subject, msgType, method, providerMessageID, conversationID string) (*Message, error) {
+func (s *Store) CreateOutboundMessage(ctx context.Context, agentID string, toRecipients []string, cc []string, bcc []string, subject, msgType, method, providerMessageID, conversationID string, rawMessage []byte) (*Message, error) {
 	id := "msg_" + generateID()
 	now := time.Now()
 
@@ -1198,14 +1198,18 @@ func (s *Store) CreateOutboundMessage(ctx context.Context, agentID string, toRec
 		ToRecipients:      toRecipients,
 		CC:                cc,
 		BCC:               bcc,
+		// rawMessage is the composed MIME we actually sent — retained so the agent
+		// has a readable Sent folder (nil for self-sends, whose body lives on the
+		// inbound twin row; empty/NULL is fine).
+		RawMessage: rawMessage,
 		// The sender of an outbound message is the agent itself (agent ID == email).
 		// Persist it so the `from` wire field isn't empty for outbound (B1).
 		Sender: agentID,
 	}
 	_, err := s.pool.Exec(ctx,
-		`INSERT INTO messages (id, agent_id, direction, recipient, subject, message_type, method, provider_message_id, conversation_id, created_at, expires_at, to_recipients, cc, bcc, status, sender)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
-		m.ID, m.AgentID, m.Direction, m.Recipient, m.Subject, m.Type, m.Method, m.ProviderMessageID, m.ConversationID, m.CreatedAt, m.ExpiresAt, m.ToRecipients, m.CC, m.BCC, MessageStatusSent, m.Sender,
+		`INSERT INTO messages (id, agent_id, direction, recipient, subject, message_type, method, provider_message_id, conversation_id, created_at, expires_at, to_recipients, cc, bcc, status, sender, raw_message)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
+		m.ID, m.AgentID, m.Direction, m.Recipient, m.Subject, m.Type, m.Method, m.ProviderMessageID, m.ConversationID, m.CreatedAt, m.ExpiresAt, m.ToRecipients, m.CC, m.BCC, MessageStatusSent, m.Sender, nullIfEmptyBytes(m.RawMessage),
 	)
 	if err != nil {
 		return nil, err
@@ -1523,6 +1527,10 @@ type SendResult struct {
 	To                []string
 	CC                []string
 	BCC               []string
+	// Raw is the composed MIME that was sent, retained as the message's
+	// "Sent folder" copy (raw_message). Empty for loopback self-sends (the body
+	// lives on the inbound twin) and on already-sent replay.
+	Raw []byte
 }
 
 // ApproveAndSend finalizes a pending_approval message by running it through
@@ -1712,6 +1720,7 @@ func (s *Store) ApproveAndSend(
 		        edited            = $10,
 		        reviewed_at       = now(),
 		        reviewed_by_user_id = $11,
+		        raw_message       = $12,
 		        body_text         = NULL,
 		        body_html         = NULL,
 		        attachments_json  = NULL
@@ -1727,6 +1736,10 @@ func (s *Store) ApproveAndSend(
 		m.Subject,
 		editedByReviewer || m.Edited,
 		userID,
+		// Retain the sent MIME as the canonical Sent-folder copy, replacing the
+		// scrubbed draft columns. Empty on the rare already-sent replay path
+		// (send_attempts doesn't cache bytes) -> NULL, best-effort.
+		nullIfEmptyBytes(result.Raw),
 	)
 	if err != nil {
 		return nil, err
@@ -1975,6 +1988,7 @@ func (s *Store) ExpireApproveAndSend(
 		        bcc               = $7,
 		        recipient         = $8,
 		        reviewed_at       = now(),
+		        raw_message       = $9,
 		        body_text         = NULL,
 		        body_html         = NULL,
 		        attachments_json  = NULL
@@ -1987,6 +2001,7 @@ func (s *Store) ExpireApproveAndSend(
 		result.CC,
 		result.BCC,
 		firstOr(result.To, ""),
+		nullIfEmptyBytes(result.Raw),
 	)
 	if err != nil {
 		return nil, err
@@ -2599,7 +2614,7 @@ type ConversationListFilter struct {
 	// After* is the keyset cursor position (CV-3): the previous page's last
 	// row's (last_message_at, conversation_id). Zero AfterLastMessageAt = first
 	// page. Pass Limit+1 to detect a further page.
-	AfterLastMessageAt time.Time
+	AfterLastMessageAt  time.Time
 	AfterConversationID string
 }
 

--- a/internal/identity/store_test.go
+++ b/internal/identity/store_test.go
@@ -434,7 +434,7 @@ func TestInboundMessageRoundTripsAuthVerdict(t *testing.T) {
 	}
 
 	// Outbound rows never carry a verdict — Auth must stay nil.
-	out, err := store.CreateOutboundMessage(ctx, a.ID, []string{"bob@gmail.com"}, nil, nil, "Re: Hello", "reply", "smtp", "<prov@authverdict.example.com>", "")
+	out, err := store.CreateOutboundMessage(ctx, a.ID, []string{"bob@gmail.com"}, nil, nil, "Re: Hello", "reply", "smtp", "<prov@authverdict.example.com>", "", nil)
 	if err != nil {
 		t.Fatalf("CreateOutboundMessage: %v", err)
 	}
@@ -577,7 +577,7 @@ func TestCreateOutboundMessage(t *testing.T) {
 	store.ClaimOrCreateDomain(ctx, "outbound.example.com", user.ID)
 	a, _ := store.CreateAgent(ctx, "agent@outbound.example.com", "outbound.example.com", "", "https://example.com/webhook", "", user.ID)
 
-	msg, err := store.CreateOutboundMessage(ctx, a.ID, []string{"alice@gmail.com"}, nil, nil, "Re: Hello", "reply", "smtp", "", "")
+	msg, err := store.CreateOutboundMessage(ctx, a.ID, []string{"alice@gmail.com"}, nil, nil, "Re: Hello", "reply", "smtp", "", "", nil)
 	if err != nil {
 		t.Fatalf("CreateOutboundMessage: %v", err)
 	}
@@ -608,7 +608,7 @@ func TestListActivityByAgent(t *testing.T) {
 	a, _ := store.CreateAgent(ctx, "agent@activity.example.com", "activity.example.com", "", "https://example.com/webhook", "", user.ID)
 
 	store.CreateInboundMessage(ctx, "", a.ID, "alice@gmail.com", "bot@activity.example.com", "", "Hello", "", "", nil, nil, nil, false, "", nil, nil, nil)
-	store.CreateOutboundMessage(ctx, a.ID, []string{"alice@gmail.com"}, nil, nil, "Re: Hello", "reply", "smtp", "", "")
+	store.CreateOutboundMessage(ctx, a.ID, []string{"alice@gmail.com"}, nil, nil, "Re: Hello", "reply", "smtp", "", "", nil)
 	store.CreateInboundMessage(ctx, "", a.ID, "bob@gmail.com", "bot@activity.example.com", "", "Hi", "", "", nil, nil, nil, false, "", nil, nil, nil)
 
 	activity, err := store.ListActivityByAgent(ctx, a.ID, 50)
@@ -740,7 +740,7 @@ func TestLookupConversationID_EmailThread(t *testing.T) {
 		[]string{"alice@gmail.com"}, nil, nil, "Re: Hello",
 		"reply", "smtp",
 		"<010f019d4b3843be-53882e6f-46de-4221-a56a-ba993e8f83e8-000000>", // bare SES ID (no @region)
-		mnexa_conv_id)
+		mnexa_conv_id, nil)
 	if err != nil {
 		t.Fatalf("CreateOutboundMessage: %v", err)
 	}
@@ -778,7 +778,7 @@ func TestLookupConversationID_ExactMatch(t *testing.T) {
 		[]string{"alice@gmail.com"}, nil, nil, "Hello",
 		"send", "smtp",
 		"<abc123@us-east-2.amazonses.com>",
-		convID)
+		convID, nil)
 	if err != nil {
 		t.Fatalf("CreateOutboundMessage: %v", err)
 	}
@@ -1418,7 +1418,7 @@ func TestGetDashboardStats_DeliverySuccess(t *testing.T) {
 	for i, status := range []string{"delivered", "delivered", "failed"} {
 		m, _ := store.CreateOutboundMessage(ctx, agent.ID,
 			[]string{"alice@example.com"}, nil, nil,
-			fmt.Sprintf("subj-%d", i), "send", "smtp", "", "")
+			fmt.Sprintf("subj-%d", i), "send", "smtp", "", "", nil)
 		_, err := pool.Exec(ctx,
 			`INSERT INTO webhook_deliveries (message_id, status, attempts, last_error, created_at)
 			 VALUES ($1, $2, 1, '', now())`,
@@ -1429,7 +1429,7 @@ func TestGetDashboardStats_DeliverySuccess(t *testing.T) {
 	}
 	// One pending — must NOT affect the ratio.
 	pendingMsg, _ := store.CreateOutboundMessage(ctx, agent.ID,
-		[]string{"alice@example.com"}, nil, nil, "pending", "send", "smtp", "", "")
+		[]string{"alice@example.com"}, nil, nil, "pending", "send", "smtp", "", "", nil)
 	pool.Exec(ctx,
 		`INSERT INTO webhook_deliveries (message_id, status, attempts, last_error, created_at)
 		 VALUES ($1, 'pending', 0, '', now())`,
@@ -1473,7 +1473,7 @@ func TestListAgentsByUser_EnrichedFields(t *testing.T) {
 	pool.Exec(ctx, `UPDATE messages SET created_at = now() - interval '14 days' WHERE id = $1`, old.ID)
 
 	for i := 0; i < 3; i++ {
-		store.CreateOutboundMessage(ctx, agent.ID, []string{"alice@example.com"}, nil, nil, "out", "send", "smtp", "", "")
+		store.CreateOutboundMessage(ctx, agent.ID, []string{"alice@example.com"}, nil, nil, "out", "send", "smtp", "", "", nil)
 	}
 	pending, _ := store.CreatePendingOutboundMessage(ctx, agent.ID,
 		[]string{"bob@example.com"}, nil, nil, "held", "body", "", nil,
@@ -1481,7 +1481,7 @@ func TestListAgentsByUser_EnrichedFields(t *testing.T) {
 	_ = pending
 
 	// One delivered webhook (healthy state)
-	m, _ := store.CreateOutboundMessage(ctx, agent.ID, []string{"alice@example.com"}, nil, nil, "delivered-msg", "send", "webhook", "", "")
+	m, _ := store.CreateOutboundMessage(ctx, agent.ID, []string{"alice@example.com"}, nil, nil, "delivered-msg", "send", "webhook", "", "", nil)
 	pool.Exec(ctx,
 		`INSERT INTO webhook_deliveries (message_id, status, attempts, last_error, created_at, last_attempt_at)
 		 VALUES ($1, 'delivered', 1, '', now(), now())`,
@@ -1529,7 +1529,7 @@ func TestListAgentsByUser_WebhookUnhealthyOnRecentFailure(t *testing.T) {
 	store.VerifyDomain(ctx, "whfail.example.com", user.ID)
 	agent, _ := store.CreateAgent(ctx, "bot@whfail.example.com", "whfail.example.com", "", "https://example.com/wh", "cloud", user.ID)
 
-	m, _ := store.CreateOutboundMessage(ctx, agent.ID, []string{"alice@example.com"}, nil, nil, "failed-msg", "send", "webhook", "", "")
+	m, _ := store.CreateOutboundMessage(ctx, agent.ID, []string{"alice@example.com"}, nil, nil, "failed-msg", "send", "webhook", "", "", nil)
 	pool.Exec(ctx,
 		`INSERT INTO webhook_deliveries (message_id, status, attempts, last_error, created_at, last_attempt_at)
 		 VALUES ($1, 'failed', 3, '500 internal', now(), now() - interval '5 minutes')`,
@@ -1554,7 +1554,7 @@ func TestListAgentsByUser_OldFailureDoesNotPoisonHealth(t *testing.T) {
 	store.VerifyDomain(ctx, "wholdfail.example.com", user.ID)
 	agent, _ := store.CreateAgent(ctx, "bot@wholdfail.example.com", "wholdfail.example.com", "", "https://example.com/wh", "cloud", user.ID)
 
-	m, _ := store.CreateOutboundMessage(ctx, agent.ID, []string{"alice@example.com"}, nil, nil, "stale-fail", "send", "webhook", "", "")
+	m, _ := store.CreateOutboundMessage(ctx, agent.ID, []string{"alice@example.com"}, nil, nil, "stale-fail", "send", "webhook", "", "", nil)
 	pool.Exec(ctx,
 		`INSERT INTO webhook_deliveries (message_id, status, attempts, last_error, created_at, last_attempt_at)
 		 VALUES ($1, 'failed', 5, 'stale', now() - interval '3 days', now() - interval '3 days')`,

--- a/internal/identity/user_data_rights_test.go
+++ b/internal/identity/user_data_rights_test.go
@@ -56,7 +56,7 @@ func seedUserData(t *testing.T, store *identity.Store, ctx context.Context, labe
 	// Outbound message on the same agent.
 	if _, err := store.CreateOutboundMessage(ctx, customAgent.ID,
 		[]string{"alice@gmail.com"}, nil, nil,
-		"Re: Hi", "reply", "smtp", "<sent@e2a.example>", ""); err != nil {
+		"Re: Hi", "reply", "smtp", "<sent@e2a.example>", "", nil); err != nil {
 		t.Fatalf("seed: CreateOutboundMessage: %v", err)
 	}
 

--- a/internal/outbound/sender.go
+++ b/internal/outbound/sender.go
@@ -261,6 +261,11 @@ func (s *Sender) Send(agent *identity.AgentIdentity, req SendRequest) (*SendResu
 		}
 	}
 
+	// Snapshot the recipient-facing bytes for the retained "Sent folder" copy:
+	// DKIM-signed, but BEFORE the e2a-internal SES configuration-set header (SES
+	// strips that before delivery, so the recipient never sees it).
+	sentBody := message
+
 	// Attach the SES configuration-set header (decision 9 / Slice 4b) so SES
 	// publishes delivery/bounce/complaint events for this message. Prepended
 	// AFTER DKIM signing so it is never in the signed header set (SES strips it
@@ -282,7 +287,7 @@ func (s *Sender) Send(agent *identity.AgentIdentity, req SendRequest) (*SendResu
 		To:        to,
 		CC:        cc,
 		BCC:       bcc,
-		Raw:       message,
+		Raw:       sentBody,
 	}, nil
 }
 

--- a/internal/outbound/sender.go
+++ b/internal/outbound/sender.go
@@ -67,6 +67,10 @@ type SendResult struct {
 	To        []string `json:"-"`       // canonicalized To recipients
 	CC        []string `json:"-"`       // canonicalized CC recipients
 	BCC       []string `json:"-"`       // canonicalized BCC recipients
+	// Raw is the exact composed MIME placed on the wire (post-DKIM, post-SES
+	// header). Persisted as messages.raw_message so the agent gets a readable
+	// "Sent folder" — a mailbox keeps both sides of a conversation.
+	Raw []byte `json:"-"`
 }
 
 // ValidationError indicates a caller error (invalid addresses, no visible recipients).
@@ -278,6 +282,7 @@ func (s *Sender) Send(agent *identity.AgentIdentity, req SendRequest) (*SendResu
 		To:        to,
 		CC:        cc,
 		BCC:       bcc,
+		Raw:       message,
 	}, nil
 }
 

--- a/internal/webhook/store_test.go
+++ b/internal/webhook/store_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/Mnexa-AI/e2a/internal/identity"
 	"github.com/Mnexa-AI/e2a/internal/testutil"
 	"github.com/Mnexa-AI/e2a/internal/webhook"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 func setupDeliveryFixture(t *testing.T) (*pgxpool.Pool, *identity.Store, *webhook.DeliveryStore, *identity.AgentIdentity, *identity.Message) {
@@ -30,7 +30,7 @@ func setupDeliveryFixture(t *testing.T) (*pgxpool.Pool, *identity.Store, *webhoo
 	if err != nil {
 		t.Fatalf("CreateAgent: %v", err)
 	}
-	msg, err := identityStore.CreateOutboundMessage(ctx, agent.ID, []string{"alice@example.com"}, nil, nil, "Hello", "send", "webhook", "", "")
+	msg, err := identityStore.CreateOutboundMessage(ctx, agent.ID, []string{"alice@example.com"}, nil, nil, "Hello", "send", "webhook", "", "", nil)
 	if err != nil {
 		t.Fatalf("CreateOutboundMessage: %v", err)
 	}
@@ -83,7 +83,7 @@ func TestGetPendingDeliveriesLeasesClaimedRows(t *testing.T) {
 	for i := 0; i < 3; i++ {
 		m, err := identityStore.CreateOutboundMessage(ctx, agent.ID,
 			[]string{"alice@example.com"}, nil, nil,
-			"hi", "send", "webhook", "", "")
+			"hi", "send", "webhook", "", "", nil)
 		if err != nil {
 			t.Fatalf("CreateOutboundMessage: %v", err)
 		}
@@ -127,7 +127,7 @@ func TestGetPendingDeliveriesIsSafeForConcurrentCallers(t *testing.T) {
 	for i := 0; i < n; i++ {
 		m, err := identityStore.CreateOutboundMessage(ctx, agent.ID,
 			[]string{"alice@example.com"}, nil, nil,
-			"hi", "send", "webhook", "", "")
+			"hi", "send", "webhook", "", "", nil)
 		if err != nil {
 			t.Fatalf("CreateOutboundMessage: %v", err)
 		}

--- a/migrations/039_messages_storage_update_meter.sql
+++ b/migrations/039_messages_storage_update_meter.sql
@@ -1,0 +1,82 @@
+-- 039_messages_storage_update_meter.sql
+--
+-- The account_usage storage trigger (migration 016) fired only on INSERT and
+-- DELETE. Body content that changes via UPDATE went UNMETERED — most importantly
+-- the HITL finalizers (ApproveAndSend / ExpireApproveAndSend), which now write
+-- messages.raw_message (the retained "Sent folder" copy) via UPDATE while scrubbing
+-- the draft body columns. Result: a HITL-approved send's body was stored off the
+-- meter, so account_usage.storage_bytes drifted and the per-user storage cap could
+-- not enforce held/sent bodies.
+--
+-- Fix: recompute the per-row body size on UPDATE and apply (NEW - OLD) to the
+-- owner's storage_bytes, and fire the trigger on UPDATE as well. The INSERT/DELETE
+-- branches are unchanged. Idempotent: CREATE OR REPLACE FUNCTION + DROP/CREATE
+-- TRIGGER.
+
+CREATE OR REPLACE FUNCTION e2a_messages_storage_delta() RETURNS TRIGGER AS $$
+DECLARE
+    uid       TEXT;
+    new_bytes BIGINT;
+    old_bytes BIGINT;
+BEGIN
+    IF TG_OP = 'INSERT' THEN
+        SELECT user_id INTO uid FROM agent_identities WHERE id = NEW.agent_id;
+        IF uid IS NULL THEN
+            RETURN NEW;
+        END IF;
+        new_bytes := COALESCE(octet_length(NEW.raw_message), 0)
+                   + COALESCE(octet_length(NEW.body_text), 0)
+                   + COALESCE(octet_length(NEW.body_html), 0)
+                   + COALESCE(octet_length(NEW.attachments_json::text), 0);
+        INSERT INTO account_usage (user_id, storage_bytes)
+        VALUES (uid, new_bytes)
+        ON CONFLICT (user_id) DO UPDATE
+            SET storage_bytes = account_usage.storage_bytes + EXCLUDED.storage_bytes,
+                updated_at    = now();
+        RETURN NEW;
+
+    ELSIF TG_OP = 'UPDATE' THEN
+        -- agent_id never changes on a message UPDATE, so NEW.agent_id is correct.
+        SELECT user_id INTO uid FROM agent_identities WHERE id = NEW.agent_id;
+        IF uid IS NULL THEN
+            RETURN NEW;
+        END IF;
+        new_bytes := COALESCE(octet_length(NEW.raw_message), 0)
+                   + COALESCE(octet_length(NEW.body_text), 0)
+                   + COALESCE(octet_length(NEW.body_html), 0)
+                   + COALESCE(octet_length(NEW.attachments_json::text), 0);
+        old_bytes := COALESCE(octet_length(OLD.raw_message), 0)
+                   + COALESCE(octet_length(OLD.body_text), 0)
+                   + COALESCE(octet_length(OLD.body_html), 0)
+                   + COALESCE(octet_length(OLD.attachments_json::text), 0);
+        IF new_bytes <> old_bytes THEN
+            UPDATE account_usage
+               SET storage_bytes = GREATEST(storage_bytes + (new_bytes - old_bytes), 0),
+                   updated_at    = now()
+             WHERE user_id = uid;
+        END IF;
+        RETURN NEW;
+
+    ELSIF TG_OP = 'DELETE' THEN
+        SELECT user_id INTO uid FROM agent_identities WHERE id = OLD.agent_id;
+        IF uid IS NULL THEN
+            RETURN OLD;
+        END IF;
+        old_bytes := COALESCE(octet_length(OLD.raw_message), 0)
+                   + COALESCE(octet_length(OLD.body_text), 0)
+                   + COALESCE(octet_length(OLD.body_html), 0)
+                   + COALESCE(octet_length(OLD.attachments_json::text), 0);
+        UPDATE account_usage
+           SET storage_bytes = GREATEST(storage_bytes - old_bytes, 0),
+               updated_at    = now()
+         WHERE user_id = uid;
+        RETURN OLD;
+    END IF;
+    RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS e2a_messages_storage_delta_trg ON messages;
+CREATE TRIGGER e2a_messages_storage_delta_trg
+    AFTER INSERT OR UPDATE OR DELETE ON messages
+    FOR EACH ROW EXECUTE FUNCTION e2a_messages_storage_delta();


### PR DESCRIPTION
## What & why

e2a is the agent's **mailbox**, not a relay — so it should keep both sides of a conversation. Previously **outbound** email stored only metadata (no body), so agents could read their Inbox but not their **Sent** folder. This change retains the composed MIME as `messages.raw_message` on outbound rows, giving agents a readable Sent folder they can poll / thread / reply from.

## How

Same `messages` table, `direction='outbound'` — no new store. The composed bytes already existed in-process; this just threads them to persistence:

- `SendResult` (outbound + identity) carries `Raw []byte` = the exact wire bytes (post-DKIM, **pre** the internal `X-SES-CONFIGURATION-SET` header SES strips, so the Sent copy matches what the recipient received).
- `CreateOutboundMessage` persists `raw_message` (primary SMTP path via `api.go`).
- HITL finalizers (`ApproveAndSend` / `ExpireApproveAndSend`) retain `raw_message` from the send callback.
- **Self-send** passes `nil` — the body already lives on the inbound twin row (no double-store).

No read-path change (`GetMessageWithContent` already returns `raw_message`), no `/v1` spec/SDK change (`MessageView.raw_message` already in the contract), no new column (nullable `raw_message` already exists). Export/delete already cover it (user_data_rights cascade + scan).

## Review (independent + adversarial, both run on this branch)

Both converged on one **proven** bug; the scary classes were **refuted**:

- **HIGH (fixed)** — storage metering hole. The `account_usage` trigger fired only on INSERT/DELETE, so the HITL finalize **UPDATE** stored `raw_message` **off the meter** (proven: draft metered 4 bytes; post-approve row held 200 KB, usage stayed 4 → storage cap unenforceable for held/sent mail). **Migration 039** adds an UPDATE branch (NEW−OLD byte delta) + fires on UPDATE. Regression test guards it.
- **LOW (fixed)** — Sent-copy fidelity: `Raw` was captured after the internal SES header; now snapshotted recipient-facing.
- **Refuted by both** (with probes): cross-tenant/cross-agent read (agent-scoped reads + handler ownership check), exactly-once HITL corruption, self-send body loss, erasure coverage.
- **Deferred (documented best-effort)**: the rare `AlreadySent` replay leaves an empty Sent copy (message *was* sent; only the Sent-folder copy is missing). A CASE-guarded scrub was attempted but conflated self-send with replay and broke the self-send scrub, so reverted to the unconditional scrub.

## Tests

New `internal/identity/outbound_retention_test.go`: direct send retains body; self-send/nil → NULL; HITL-approved retains + scrubs draft; **storage-meter regression guard**. Affected packages (identity, agent, hitlworker, limits, usage, outbound, webhook, delivery) green serially.

## ⚠️ Merge notes
- **Migration numbering:** this branch is off `main` (latest `037_account_class`) and adds **`039`** (harmless `038` gap). The `038` slot is deliberately skipped to avoid colliding with PR #252 (screening), which uses `038_scan_config`.
- **Auto-deploy:** migration 039 auto-applies to prod on the next binary deploy (per CLAUDE.md). It's idempotent + non-destructive (CREATE OR REPLACE FUNCTION + DROP/CREATE TRIGGER).
- **Coordination with #252:** both PRs touch the `messages` read paths (this populates outbound `raw_message`; #252 adds held-status exclusion). They don't conflict, but whoever merges second should re-run the message read-path tests. Separately, #252 has a latent `037` collision from its rebase to fix before it merges — independent of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)