### PR TITLE
fix: doc drift + declare default ErrorEnvelope on custom-Responses ops

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2536,6 +2536,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/SendResultView"
           description: Accepted — held for human approval (status=pending_approval).
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error — the standard envelope; branch on error.code.
       security:
         - bearer: []
       summary: Send a new email
@@ -2754,6 +2760,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/SendResultView"
           description: Accepted — held for human approval (status=pending_approval).
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error — the standard envelope; branch on error.code.
       security:
         - bearer: []
       summary: Forward a message
@@ -2841,6 +2853,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/SendResultView"
           description: Accepted — held for human approval (status=pending_approval).
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error — the standard envelope; branch on error.code.
       security:
         - bearer: []
       summary: Reply to a message
@@ -2871,6 +2889,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/SendResultView"
           description: Accepted — held for human approval (status=pending_approval).
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error — the standard envelope; branch on error.code.
       security:
         - bearer: []
       summary: Send a test email to the agent's own address
@@ -2918,6 +2942,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorEnvelope"
           description: Conflict — the domain is already claimed by another account (code domain_taken).
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error — the standard envelope; branch on error.code.
       security:
         - bearer: []
       summary: Register a domain
@@ -3034,6 +3064,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/VerifyDomainView"
           description: Precondition Failed — the verification TXT record is not yet published.
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Error — the standard envelope; branch on error.code.
       security:
         - bearer: []
       summary: Verify a domain

--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -969,12 +969,17 @@ review diligence — a #206-style omission can't merge.
 >   with a `(retryable)` hint — so agents branch on a code, not prose; wrapper
 >   errors with no code stay plain; the message is sanitized + length-bounded and
 >   the raw body/headers are never surfaced). Adversarial review caught that
->   send/reply/forward return the raw body **string** (those ops declare no
->   `default: ErrorEnvelope`), so the TS SDK `fromApiException` now parses a
->   string body's envelope — recovering the code for every operation.
->   **Follow-up:** the Python SDK has the same string-body gap, and the proper
->   root cause is adding `default: ErrorEnvelope` to the send/reply/forward Huma
->   handlers (then regen) so every generated client parses it. **#5 attachment
+>   send/reply/forward returned the raw body **string** (those ops declared no
+>   `default: ErrorEnvelope` — a custom `Responses` map suppresses Huma's auto
+>   default), so the TS SDK `fromApiException` parses a string body's envelope to
+>   recover the code. **Root cause now fixed:** every op with a custom `Responses`
+>   map (`sendMessage`/`replyToMessage`/`forwardMessage`/`testAgent` +
+>   `registerDomain`/`verifyDomain`) re-adds `default: ErrorEnvelope` via
+>   `s.errorEnvelopeResponse()`, so the OpenAPI contract documents the error shape
+>   and generated clients deserialize the code natively. The **Python SDK already
+>   handled this** independently — `from_api_exception`'s `_parse_envelope`
+>   `json.loads`-es a raw string body, so it surfaced the code before and after the
+>   spec fix (unit- and client-tested). **#5 attachment
 >   download-URL ✅ done** (native adapter; AgentDrive/object-storage adapter +
 >   outbound presigned-upload + large-file attach-by-reference deferred as seams —
 >   see [attachment-retrieval.md](attachment-retrieval.md)). **#7 idempotency-key

--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -23,12 +23,15 @@
 > — `conversations.list` now returns an `AutoPager` (PR #238); and Decision 3's
 > proposed `from`/`reply_to` outbound body fields did **not** land — `from` was
 > **dropped** as redundant with the route (the sender is structurally the path
-> agent; PR #238), and `reply_to` is **deferred**, not rejected. **Still
-> pending:** the MCP tool-surface re-curation to the §6a target (the SDK
-> *transport* was repointed onto `/v1`, but the tool names/args in
-> `mcp/src/tools/` remain the pre-redesign set — tracked as a separate round).
-> The event name `email.rejected` shipped as-is (decision 9's
-> `email.approval_rejected` rename did not land).
+> agent; PR #238), and `reply_to` is **deferred**, not rejected. The **MCP
+> tool-surface re-curation to the §6a target shipped** — the tool names/args in
+> `mcp/src/tools/` were reshaped onto `/v1` (`send_message`/`reply_to_message`,
+> cursor pagination, structured error `code`s, `get_attachment` download URLs;
+> the SDK *transport* was repointed in the earlier round). The rejected-decision
+> event ships as **`email.approval_rejected`** (decision 9's rename **landed** —
+> `api/openapi.yaml` + the webhook-subscription and `/v1/events` enums all use it;
+> the `email.rejected` strings left in `internal/agent/api.go` are stale code
+> comments, not the wire value, which is `webhookpub.EventEmailRejected`).
 
 ## 1. Problem statement
 

--- a/internal/httpapi/domains.go
+++ b/internal/httpapi/domains.go
@@ -157,6 +157,7 @@ func (s *Server) registerDomains() {
 		Responses: map[string]*huma.Response{
 			"409": s.jsonResponse(reflect.TypeOf(ErrorEnvelope{}), "ErrorEnvelope",
 				"Conflict — the domain is already claimed by another account (code domain_taken)."),
+			"default": s.errorEnvelopeResponse(),
 		},
 	}, s.handleRegisterDomain)
 
@@ -180,6 +181,7 @@ func (s *Server) registerDomains() {
 		Responses: map[string]*huma.Response{
 			"412": s.jsonResponse(reflect.TypeOf(VerifyDomainView{}), "VerifyDomainView",
 				"Precondition Failed — the verification TXT record is not yet published."),
+			"default": s.errorEnvelopeResponse(),
 		},
 	}, s.handleVerifyDomain)
 }

--- a/internal/httpapi/outbound.go
+++ b/internal/httpapi/outbound.go
@@ -29,6 +29,16 @@ func (s *Server) jsonResponse(bodyType reflect.Type, schemaName, description str
 	}
 }
 
+// errorEnvelopeResponse is the generic `default` error response (ErrorEnvelope).
+// Huma auto-adds it to every operation, but declaring a custom `Responses` map
+// SUPPRESSES that auto default — so any op with a custom map must re-add this, or
+// its OpenAPI contract omits the error shape and generated clients fall back to
+// raw-string error bodies (losing the machine `code`; api-v1-redesign §6a #4).
+func (s *Server) errorEnvelopeResponse() *huma.Response {
+	return s.jsonResponse(reflect.TypeOf(ErrorEnvelope{}), "ErrorEnvelope",
+		"Error — the standard envelope; branch on error.code.")
+}
+
 // SendResultView is the single outbound result for send/reply/forward/approve/
 // test (MSG-9). Per scenario:
 //   - sent:  status="sent" + message_id (the e2a msg_ id) + provider_message_id
@@ -118,7 +128,7 @@ func (s *Server) registerOutbound() {
 		Description:  "Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_approval when the agent has HITL enabled. Honors Idempotency-Key.",
 		Security:     []map[string][]string{{"bearer": {}}},
 		MaxBodyBytes: maxOutboundBytes,
-		Responses:    map[string]*huma.Response{"202": held202()},
+		Responses:    map[string]*huma.Response{"202": held202(), "default": s.errorEnvelopeResponse()},
 	}, s.handleCreateMessage)
 
 	huma.Register(s.API, huma.Operation{
@@ -127,7 +137,7 @@ func (s *Server) registerOutbound() {
 		Description:  "Reply to an inbound message; recipients/threading are derived from the original. 202 when held for HITL.",
 		Security:     []map[string][]string{{"bearer": {}}},
 		MaxBodyBytes: maxOutboundBytes,
-		Responses:    map[string]*huma.Response{"202": held202()},
+		Responses:    map[string]*huma.Response{"202": held202(), "default": s.errorEnvelopeResponse()},
 	}, s.handleReply)
 
 	huma.Register(s.API, huma.Operation{
@@ -136,7 +146,7 @@ func (s *Server) registerOutbound() {
 		Description:  "Forward an inbound message to new recipients; the original is quoted. 202 when held for HITL.",
 		Security:     []map[string][]string{{"bearer": {}}},
 		MaxBodyBytes: maxOutboundBytes,
-		Responses:    map[string]*huma.Response{"202": held202()},
+		Responses:    map[string]*huma.Response{"202": held202(), "default": s.errorEnvelopeResponse()},
 	}, s.handleForward)
 
 	huma.Register(s.API, huma.Operation{
@@ -144,7 +154,7 @@ func (s *Server) registerOutbound() {
 		Summary: "Send a test email to the agent's own address", Tags: []string{"agents"},
 		Description: "Send a platform test email to the agent's own address to confirm inbound delivery. 202 when held for HITL.",
 		Security:    []map[string][]string{{"bearer": {}}},
-		Responses:   map[string]*huma.Response{"202": held202()},
+		Responses:   map[string]*huma.Response{"202": held202(), "default": s.errorEnvelopeResponse()},
 	}, s.handleTestSend)
 }
 

--- a/sdks/python/tests/test_v1_client.py
+++ b/sdks/python/tests/test_v1_client.py
@@ -13,6 +13,7 @@ from e2a.v1.errors import (
     E2AConflictError,
     E2AError,
     E2ANotFoundError,
+    E2APermissionError,
     E2AValidationError,
 )
 from e2a.v1.generated.models import (
@@ -162,6 +163,22 @@ async def test_get_attachment_hits_endpoint_and_maps_view(httpx_mock):
     assert req.method == "GET"
     assert "/messages/msg_1/attachments/0" in str(req.url)
     assert "inline=true" in str(req.url)
+
+
+@pytest.mark.anyio
+async def test_send_error_surfaces_machine_code(httpx_mock):
+    # send/reply/forward now declare default: ErrorEnvelope (the custom Responses
+    # map had suppressed Huma's auto default). The SDK must surface the machine
+    # `code` for the send-family, not a generic/raw error. Guards §6a #4.
+    httpx_mock.add_response(
+        status_code=403,
+        json={"error": {"code": "sending_not_verified", "message": "domain not verified", "request_id": "req_1"}},
+    )
+    async with _client() as c:
+        with pytest.raises(E2APermissionError) as ei:
+            await c.messages.send("bot@test.dev", {"to": ["a@x.com"], "subject": "Hi", "body": "Hello"})
+    assert ei.value.code == "sending_not_verified"
+    assert ei.value.status == 403
 
 
 @pytest.mark.anyio

--- a/sdks/typescript/src/v1/generated/apis/AgentsApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/AgentsApi.ts
@@ -442,6 +442,13 @@ export class AgentsApiResponseProcessor {
             ) as SendResultView;
             return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
+        if (isCodeInRange("0", response.httpStatusCode)) {
+            const body: ErrorEnvelope = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "ErrorEnvelope", ""
+            ) as ErrorEnvelope;
+            throw new ApiException<ErrorEnvelope>(response.httpStatusCode, "Error — the standard envelope; branch on error.code.", body, response.headers);
+        }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {

--- a/sdks/typescript/src/v1/generated/apis/DomainsApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/DomainsApi.ts
@@ -401,6 +401,13 @@ export class DomainsApiResponseProcessor {
             ) as ErrorEnvelope;
             throw new ApiException<ErrorEnvelope>(response.httpStatusCode, "Conflict — the domain is already claimed by another account (code domain_taken).", body, response.headers);
         }
+        if (isCodeInRange("0", response.httpStatusCode)) {
+            const body: ErrorEnvelope = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "ErrorEnvelope", ""
+            ) as ErrorEnvelope;
+            throw new ApiException<ErrorEnvelope>(response.httpStatusCode, "Error — the standard envelope; branch on error.code.", body, response.headers);
+        }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
@@ -472,6 +479,13 @@ export class DomainsApiResponseProcessor {
                 "VerifyDomainView", ""
             ) as VerifyDomainView;
             throw new ApiException<VerifyDomainView>(response.httpStatusCode, "Precondition Failed — the verification TXT record is not yet published.", body, response.headers);
+        }
+        if (isCodeInRange("0", response.httpStatusCode)) {
+            const body: ErrorEnvelope = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "ErrorEnvelope", ""
+            ) as ErrorEnvelope;
+            throw new ApiException<ErrorEnvelope>(response.httpStatusCode, "Error — the standard envelope; branch on error.code.", body, response.headers);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/sdks/typescript/src/v1/generated/apis/MessagesApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/MessagesApi.ts
@@ -716,6 +716,13 @@ export class MessagesApiResponseProcessor {
             ) as SendResultView;
             return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
+        if (isCodeInRange("0", response.httpStatusCode)) {
+            const body: ErrorEnvelope = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "ErrorEnvelope", ""
+            ) as ErrorEnvelope;
+            throw new ApiException<ErrorEnvelope>(response.httpStatusCode, "Error — the standard envelope; branch on error.code.", body, response.headers);
+        }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
@@ -896,6 +903,13 @@ export class MessagesApiResponseProcessor {
             ) as SendResultView;
             return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
+        if (isCodeInRange("0", response.httpStatusCode)) {
+            const body: ErrorEnvelope = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "ErrorEnvelope", ""
+            ) as ErrorEnvelope;
+            throw new ApiException<ErrorEnvelope>(response.httpStatusCode, "Error — the standard envelope; branch on error.code.", body, response.headers);
+        }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml
         if (response.httpStatusCode >= 200 && response.httpStatusCode <= 299) {
@@ -931,6 +945,13 @@ export class MessagesApiResponseProcessor {
                 "SendResultView", ""
             ) as SendResultView;
             return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
+        }
+        if (isCodeInRange("0", response.httpStatusCode)) {
+            const body: ErrorEnvelope = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "ErrorEnvelope", ""
+            ) as ErrorEnvelope;
+            throw new ApiException<ErrorEnvelope>(response.httpStatusCode, "Error — the standard envelope; branch on error.code.", body, response.headers);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml


### PR DESCRIPTION
Two related cleanups from the "is everything done?" pass.

## 1. Doc drift (commit `ceab89e`, docs-only)
Corrected two stale/wrong claims in the v1-redesign "as-built" banner:
- "Still pending: MCP tool-surface re-curation" → it **shipped** (tools reshaped onto `/v1`).
- "email.rejected shipped (the email.approval_rejected rename did not land)" → **backwards**: the wire event is `email.approval_rejected` (`api/openapi.yaml` + webhook/event enums + `webhookpub.EventEmailRejected` all use it; the `email.rejected` strings in `internal/agent/api.go` are stale code comments).

## 2. Root-cause error-envelope fix (commit `b146415`)
A custom huma `Responses` map **suppresses** Huma's auto `default: ErrorEnvelope`, so `sendMessage`/`replyToMessage`/`forwardMessage`/`testAgent` + `registerDomain`/`verifyDomain` declared **no** error response — the OpenAPI contract omitted the error shape and the TS generated client fell back to raw-string error bodies (losing the machine `code`; §6a #4). Added `s.errorEnvelopeResponse()` and re-added `"default": ErrorEnvelope` to all six ops.

**Finding:** the **Python SDK already surfaced the code** — `from_api_exception`'s `_parse_envelope` `json.loads`-es a raw string body, so it was never affected (the doc's "Python string-body gap" follow-up was stale). Verified empirically + added a client-level regression test; the unit-level string-body path was already covered.

Regenerated `api/openapi.yaml` + TS SDK base (Python base byte-identical — its error handling is generator-agnostic).

## Verification
Go httpapi + spec-golden green; spec-check + generate-sdk-check pass; TS 97, MCP 134, Python 149.

🤖 Generated with [Claude Code](https://claude.com/claude-code)