### PR TITLE
feat: remove "via e2a" — custom MAIL FROM alignment (sender identity Track B)

### DIFF
--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -258,8 +258,9 @@ relative to that base):
      **Limitation — forwarding/lists:** a forwarder/mailing-list that rewrites
      headers/body breaks the DKIM signature, and since SPF is unaligned by design
      there's nothing left to align → DMARC `fail` at the final hop. v1 documents
-     this; **ARC sealing** and/or the optional custom-`MAIL FROM` subdomain (below,
-     for SPF alignment) are the mitigations, deferred. Also: the DKIM **selector
+     this; **ARC sealing** remains the mitigation for this forwarding case
+     (deferred). (The custom `MAIL FROM` subdomain for outbound SPF alignment has
+     since **shipped** — see `sender-identity-mailfrom.md`.) Also: the DKIM **selector
      rotates monthly** (`e2a{YYYYMM}`) — keep the prior selector's DNS record
      published until in-flight mail signed under it has drained (don't pull it on
      rotation day).
@@ -1337,9 +1338,11 @@ Break the current `/api/v1` surface directly and move it to
     delete makes orphans rare. (2) The real `sesv2` provider is **not e2e-tested
     against AWS** here — CI/tests use the in-memory `FakeProvider`; the BYODKIM
     key handed to SES is converted PKCS#1→PKCS#8 base64, to validate against
-    live SES before enabling `sender_identity.ses_region` in prod. (3) The
-    optional custom `MAIL FROM` subdomain (SPF alignment) and ARC sealing remain
-    deferred per decision 4.
+    live SES before enabling `sender_identity.ses_region` in prod. (3) The custom
+    `MAIL FROM` subdomain (SPF alignment / "remove via e2a") has **shipped**
+    (Track B — `internal/mailfrom` + `PutEmailIdentityMailFromAttributes`; see
+    `sender-identity-mailfrom.md`), dormant behind the same `ses_region` gate
+    pending the live-SES validation above. **ARC sealing** remains deferred.
 * **Slice 4b — Delivery feedback (decision 9).** *(Delivery-feedback core
   shipped; the rest split into follow-ups.)* `internal/delivery`: an SES-over-SNS
   consumer at `POST /api/internal/ses/notifications` (fail-closed SNS signature

--- a/docs/design/sender-identity-mailfrom.md
+++ b/docs/design/sender-identity-mailfrom.md
@@ -54,8 +54,10 @@ for verified domains; (b) needed an aligned Return-Path.
   both idempotent; the `verified` skip-guard already exists).
 - No migration: no domain was `verified` before (path dormant), so redefining
   `verified` to require MAIL FROM has no existing rows to reconcile.
-- On verify, the MX/SPF records (shown while `pending`) clear (Status returns no
-  records) — they're "what to publish" guidance, not needed once live.
+- The MX/SPF records are **preserved across verify** — `Status()` re-emits them on
+  every poll, so a verified domain's view keeps showing the records the customer
+  must KEEP published (removing them later silently loses SPF alignment). (Adjusted
+  from the original "clear on verify" after review.)
 
 ## Verification
 - Unit: `mapSESStatus` across both axes; `Provision` configures MAIL FROM + emits

--- a/docs/design/sender-identity-mailfrom.md
+++ b/docs/design/sender-identity-mailfrom.md
@@ -1,0 +1,77 @@
+# Remove "via e2a" — custom MAIL FROM alignment
+
+Status: **Track B shipped** (the MAIL FROM mechanic, behind the existing dormant
+`sender_identity.ses_region` gate). **Track A** (live-SES validation + enabling
+`ses_region` in prod) is the remaining ops gate.
+
+## Problem
+Outbound mail showed "via e2a" two ways: (a) a literal `"Name via e2a"` display
+name e2a wrote for non-verified domains, and (b) Gmail's auto **"via / mailed-by
+e2a.dev"** label, driven by the envelope **MAIL FROM (Return-Path)** which was
+always e2a-owned — even for DKIM-aligned own-address sends. (a) was already gone
+for verified domains; (b) needed an aligned Return-Path.
+
+## What shipped (Track B)
+- **`internal/mailfrom`** — the shared subdomain convention: `Domain("acme.com")
+  = "bounce.acme.com"`, `EnvelopeSender = "bounces@bounce.acme.com"`. One source
+  of truth for the SES MAIL FROM config, the published DNS records, and the
+  envelope sender. Leaf package (zero internal deps) so `outbound` uses it without
+  importing `senderidentity`.
+- **SES provider** (`internal/senderidentity/ses.go`): `Provision` now also calls
+  `PutEmailIdentityMailFromAttributes(MailFromDomain=bounce.<domain>,
+  BehaviorOnMxFailure=USE_DEFAULT_VALUE)` after `CreateEmailIdentity` (incl. the
+  idempotent `AlreadyExists` path), and returns the **MX + SPF** DNS records
+  (region-targeted: `10 feedback-smtp.<region>.amazonses.com` + `v=spf1
+  include:amazonses.com ~all`). Records flow unchanged via `SetSendingStatus` →
+  `sending_dns_records` → the domain view.
+- **`mapSESStatus`** now requires the MAIL FROM axis: `verified` ⇔ sending-verified
+  **AND** DKIM `SUCCESS` **AND** MAIL FROM `SUCCESS` (**all-or-nothing**, design
+  Q2). A hard failure on either DKIM or MAIL FROM is terminal. So reaching
+  `verified` means there is genuinely no "via e2a".
+- **Send path** (`internal/outbound/sender.go`): the sending-verified gate is
+  resolved once; a verified domain's Return-Path becomes
+  `bounces@bounce.<domain>` (aligned → SPF passes on the From org-domain → no
+  "via"), else the e2a relay envelope + "via e2a" rewrite (**fail-closed**,
+  unchanged). Bounces still reach SES's feedback handler via the subdomain MX, so
+  e2a keeps capturing them.
+- `FakeProvider` mirrors the records.
+
+## Decisions (from design Q&A)
+- **Q2 all-or-nothing** — no DKIM-only intermediate tier; `verified` requires both
+  axes. The intermediate state passes DMARC (via DKIM) but still shows "via", so
+  it doesn't meet the goal and isn't exposed.
+- **Q3 `USE_DEFAULT_VALUE`** on MX failure — deliverability-safe (SES falls back to
+  its own MAIL FROM rather than dropping mail; the send path only uses the aligned
+  envelope when `verified`, which requires the MX).
+- **Q1/Q6 deviation from the design:** the subdomain label ships as a **fixed
+  convention const (`bounce`)**, derived (no schema change). A per-deployment
+  config knob is a trivial future addition (thread one string to the SES provider
+  + the Sender); deferred to keep v1 minimal.
+
+## Edge cases / invariants
+- Fail-closed: any non-`verified` state → e2a relay envelope + "via" From.
+- `Provision` idempotent (CreateEmailIdentity `AlreadyExists` + `PutEmailIdentity…`
+  both idempotent; the `verified` skip-guard already exists).
+- No migration: no domain was `verified` before (path dormant), so redefining
+  `verified` to require MAIL FROM has no existing rows to reconcile.
+- On verify, the MX/SPF records (shown while `pending`) clear (Status returns no
+  records) — they're "what to publish" guidance, not needed once live.
+
+## Verification
+- Unit: `mapSESStatus` across both axes; `Provision` configures MAIL FROM + emits
+  MX/SPF (incl. `AlreadyExists`); `mailfrom` convention; `envelopeSender`
+  (verified → aligned, else relay/fail-closed).
+- Local-service e2e (real binary + Mailpit): seeded a `sending_status=verified`
+  domain and a `none` domain; over real SMTP confirmed verified → `From:
+  bot@acme.e2etest` (no "via") + `Return-Path: bounces@bounce.acme.e2etest`;
+  fail-closed → `From: … via e2a <agent@relay>` + relay Return-Path. (Seeding
+  `sending_status` stands in for the SES reconciler, which needs live AWS.)
+
+## Deferred
+- **Track A** — validate the real `sesv2` path (CreateEmailIdentity +
+  PutEmailIdentityMailFromAttributes + GetEmailIdentity + the BYODKIM
+  PKCS#1→PKCS#8 key) against a live SES account; then set `sender_identity.ses_region`
+  in prod. Confirm in Gmail: no "via", aligned `mailed-by`, DMARC pass on SPF+DKIM.
+- Per-deployment configurable subdomain label (Q1).
+- **ARC sealing** + `_dmarc` policy fetch (separate inbound-auth deferrals) — out
+  of scope.

--- a/internal/mailfrom/mailfrom.go
+++ b/internal/mailfrom/mailfrom.go
@@ -1,0 +1,25 @@
+// Package mailfrom defines the custom MAIL FROM subdomain convention shared by
+// sender-identity provisioning (which configures it in SES and emits its DNS
+// records) and the outbound sender (which uses it as the aligned Return-Path).
+//
+// One source of truth so three things always agree: what e2a tells SES the
+// MAIL FROM domain is, the MX/SPF records e2a asks the customer to publish, and
+// the envelope sender the relay actually uses. When a domain is sending-verified
+// the Return-Path becomes `bounces@bounce.<domain>` — aligned to the From
+// org-domain — so SPF aligns and the "via e2a" / "mailed-by" label disappears.
+package mailfrom
+
+// Label is the subdomain prefix for the custom MAIL FROM domain. A fixed
+// convention for v1 (a per-deployment config knob is a trivial future addition —
+// thread one string to NewSender + the SES provider).
+const Label = "bounce"
+
+// Domain returns the custom MAIL FROM domain for a sending domain, e.g.
+// Domain("acme.com") == "bounce.acme.com".
+func Domain(domain string) string { return Label + "." + domain }
+
+// EnvelopeSender returns the SMTP MAIL FROM (Return-Path) address used for a
+// verified domain's outbound mail, e.g. "bounces@bounce.acme.com". The local
+// part is arbitrary for SES (bounces route via the subdomain's MX to SES's
+// feedback handler); `bounces` is conventional and human-legible.
+func EnvelopeSender(domain string) string { return "bounces@" + Domain(domain) }

--- a/internal/mailfrom/mailfrom_test.go
+++ b/internal/mailfrom/mailfrom_test.go
@@ -1,0 +1,16 @@
+package mailfrom
+
+import "testing"
+
+func TestConvention(t *testing.T) {
+	if got := Domain("acme.com"); got != "bounce.acme.com" {
+		t.Errorf("Domain = %q, want bounce.acme.com", got)
+	}
+	if got := EnvelopeSender("acme.com"); got != "bounces@bounce.acme.com" {
+		t.Errorf("EnvelopeSender = %q, want bounces@bounce.acme.com", got)
+	}
+	// Subdomain of a subdomain stays well-formed (agent on a deeper domain).
+	if got := Domain("mail.acme.co.uk"); got != "bounce.mail.acme.co.uk" {
+		t.Errorf("Domain = %q", got)
+	}
+}

--- a/internal/outbound/from_gating_test.go
+++ b/internal/outbound/from_gating_test.go
@@ -22,6 +22,19 @@ func verifiedAgent() *identity.AgentIdentity {
 	return &identity.AgentIdentity{ID: "bot@acme.com", Domain: "acme.com", DomainVerified: true}
 }
 
+// TestEnvelopeSender is the "remove via e2a" invariant: a verified domain's
+// Return-Path is the aligned custom MAIL FROM (bounces@bounce.<domain>) so SPF
+// aligns and no "via e2a" shows; every non-verified path stays on the e2a relay
+// envelope (fail-closed), which is what keeps the "via" rewrite for those.
+func TestEnvelopeSender(t *testing.T) {
+	if got := envelopeSender(true, "acme.com", "send.e2a.dev"); got != "bounces@bounce.acme.com" {
+		t.Errorf("verified envelope = %q, want bounces@bounce.acme.com", got)
+	}
+	if got := envelopeSender(false, "acme.com", "send.e2a.dev"); got != "agent@send.e2a.dev" {
+		t.Errorf("unverified envelope = %q, want agent@send.e2a.dev (relay, fail-closed)", got)
+	}
+}
+
 // TestUseOwnAddressFrom_FailClosed is the decision-4 invariant: the own-address
 // From is used ONLY when the lookup is wired AND reports "verified" for a
 // verified custom domain. Every other path falls back to the relay From.

--- a/internal/outbound/sender.go
+++ b/internal/outbound/sender.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Mnexa-AI/e2a/internal/dkim"
 	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/mailfrom"
 )
 
 // DKIMKeyLookup returns the DKIM selector and PKCS#1 DER private key
@@ -142,6 +143,17 @@ func (s *Sender) useOwnAddressFrom(agent *identity.AgentIdentity) bool {
 	return status == "verified"
 }
 
+// envelopeSender returns the SMTP MAIL FROM (Return-Path) for an outbound
+// message: the aligned custom MAIL FROM (bounces@bounce.<domain>) when the
+// domain is sending-verified, else the e2a-owned relay address (fail-closed).
+// Pure (no store hit) so it's unit-testable; `own` is resolved once by Send.
+func envelopeSender(own bool, agentDomain, fromDomain string) string {
+	if own {
+		return mailfrom.EnvelopeSender(agentDomain)
+	}
+	return fmt.Sprintf("agent@%s", fromDomain)
+}
+
 func NewSender(smtpRelay *SMTPRelay, fromDomain string) *Sender {
 	return &Sender{
 		smtpRelay:  smtpRelay,
@@ -215,17 +227,22 @@ func (s *Sender) Send(agent *identity.AgentIdentity, req SendRequest) (*SendResu
 	if displayName == "" {
 		displayName = agent.EmailAddress()
 	}
-	// Envelope MAIL FROM stays an e2a-owned relay address regardless of the
-	// header From: it is the Return-Path, so e2a captures bounces/complaints
-	// and SPF passes for the relay (decision 4). DMARC still passes via the
-	// DKIM signature, which is aligned to the agent's custom domain below.
-	envelopeFrom := fmt.Sprintf("agent@%s", s.fromDomain)
-	// Header From: the agent's OWN address once the domain is sending-verified
-	// (DKIM-aligned → DMARC passes, replies reach the agent directly); else
-	// the relay "… via e2a" rewrite (fail-closed default).
+	// Resolve the sending-verified gate once (it hits the sending_status store),
+	// then derive both the header From and the envelope Return-Path from it.
+	own := s.useOwnAddressFrom(agent)
+	// Envelope MAIL FROM (Return-Path): the aligned custom MAIL FROM
+	// (bounce.<domain>) for a verified domain — SPF authenticates the From
+	// org-domain → no Gmail "via e2a" — else the e2a-owned relay address
+	// (fail-closed: SPF passes for the relay, e2a captures bounces). Verified now
+	// requires the custom MAIL FROM to be live, so the subdomain's MX exists and
+	// bounces still reach SES's feedback handler.
+	envelopeFrom := envelopeSender(own, agent.Domain, s.fromDomain)
+	// Header From: the agent's OWN address once sending-verified (DKIM-aligned →
+	// DMARC passes, replies reach the agent directly); else the "… via e2a"
+	// rewrite (fail-closed default).
 	var headerFrom string
 	sentAs := "relay"
-	if s.useOwnAddressFrom(agent) {
+	if own {
 		headerFrom = fmt.Sprintf("%q <%s>", displayName, agent.EmailAddress())
 		sentAs = "own_address"
 	} else {

--- a/internal/senderidentity/fake.go
+++ b/internal/senderidentity/fake.go
@@ -110,7 +110,9 @@ func (f *FakeProvider) Provision(ctx context.Context, domain, dkimSelector strin
 		return Result{}, f.provisionErr
 	}
 	f.identities[domain] = true
-	return Result{Status: StatusPending}, nil
+	// Mirror the SES provider: provisioning emits the custom MAIL FROM records
+	// the customer must publish (region is illustrative for tests).
+	return Result{Status: StatusPending, DNSRecords: mailFromRecords(domain, "us-east-1")}, nil
 }
 
 func (f *FakeProvider) Status(ctx context.Context, domain string) (Result, error) {

--- a/internal/senderidentity/provider.go
+++ b/internal/senderidentity/provider.go
@@ -49,9 +49,9 @@ func (s Status) Valid() bool {
 
 // DNSRecord is a single record the customer must publish for the sending
 // identity. With BYODKIM the customer already published the per-domain DKIM
-// record during register/verify, so this is usually empty; it exists for a
-// future custom MAIL FROM subdomain (SPF alignment) and to surface anything
-// SES reports as still-required.
+// record during register/verify; this now carries the custom MAIL FROM
+// subdomain's MX + SPF records (Return-Path alignment — see ses.go
+// mailFromRecords) and surfaces anything SES reports as still-required.
 type DNSRecord struct {
 	Type  string `json:"type"`  // "TXT" | "CNAME" | "MX"
 	Name  string `json:"name"`  // record host

--- a/internal/senderidentity/ses.go
+++ b/internal/senderidentity/ses.go
@@ -10,6 +10,8 @@ import (
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sesv2"
 	ststypes "github.com/aws/aws-sdk-go-v2/service/sesv2/types"
+
+	"github.com/Mnexa-AI/e2a/internal/mailfrom"
 )
 
 // sesAPI is the slice of the SES v2 client the provider uses. Narrowing to an
@@ -17,6 +19,7 @@ import (
 // AWS-touching calls themselves are exercised only against live SES).
 type sesAPI interface {
 	CreateEmailIdentity(ctx context.Context, in *sesv2.CreateEmailIdentityInput, optFns ...func(*sesv2.Options)) (*sesv2.CreateEmailIdentityOutput, error)
+	PutEmailIdentityMailFromAttributes(ctx context.Context, in *sesv2.PutEmailIdentityMailFromAttributesInput, optFns ...func(*sesv2.Options)) (*sesv2.PutEmailIdentityMailFromAttributesOutput, error)
 	GetEmailIdentity(ctx context.Context, in *sesv2.GetEmailIdentityInput, optFns ...func(*sesv2.Options)) (*sesv2.GetEmailIdentityOutput, error)
 	DeleteEmailIdentity(ctx context.Context, in *sesv2.DeleteEmailIdentityInput, optFns ...func(*sesv2.Options)) (*sesv2.DeleteEmailIdentityOutput, error)
 	ListEmailIdentities(ctx context.Context, in *sesv2.ListEmailIdentitiesInput, optFns ...func(*sesv2.Options)) (*sesv2.ListEmailIdentitiesOutput, error)
@@ -25,14 +28,20 @@ type sesAPI interface {
 // SESProvider is the real Provider backed by AWS SES v2. It registers
 // domain sending identities with BYODKIM, reusing e2a's per-domain DKIM key
 // so the DKIM d= aligns with the From domain (DMARC passes on DKIM
-// alignment). NOTE: only exercised against live AWS — CI/tests use
-// FakeProvider; the status-mapping helpers below are unit-tested with a stub.
+// alignment), and configures a custom MAIL FROM subdomain (bounce.<domain>) so
+// the Return-Path aligns too (SPF passes on the From org-domain → no "via e2a").
+// NOTE: only exercised against live AWS — CI/tests use FakeProvider; the
+// status-mapping helpers below are unit-tested with a stub.
 type SESProvider struct {
-	api sesAPI
+	api    sesAPI
+	region string // for the custom MAIL FROM MX target (feedback-smtp.<region>.amazonses.com)
 }
 
-// NewSESProvider wraps a pre-built SES API (or stub).
-func NewSESProvider(api sesAPI) *SESProvider { return &SESProvider{api: api} }
+// NewSESProvider wraps a pre-built SES API (or stub). region feeds the MAIL FROM
+// MX record target.
+func NewSESProvider(api sesAPI, region string) *SESProvider {
+	return &SESProvider{api: api, region: region}
+}
 
 // NewSESProviderFromConfig builds a provider from ambient AWS config
 // (env/instance role) for the given region.
@@ -41,7 +50,7 @@ func NewSESProviderFromConfig(ctx context.Context, region string) (*SESProvider,
 	if err != nil {
 		return nil, fmt.Errorf("load aws config: %w", err)
 	}
-	return &SESProvider{api: sesv2.NewFromConfig(cfg)}, nil
+	return &SESProvider{api: sesv2.NewFromConfig(cfg), region: region}, nil
 }
 
 func (p *SESProvider) Provision(ctx context.Context, domain, dkimSelector string, dkimPrivateKeyDER []byte) (Result, error) {
@@ -60,14 +69,39 @@ func (p *SESProvider) Provision(ctx context.Context, domain, dkimSelector string
 	})
 	if err != nil {
 		// AlreadyExists is success (idempotent): the identity is registered;
-		// fall through to a Status poll shape by returning pending.
+		// fall through to also (re)configure the custom MAIL FROM below.
 		var already *ststypes.AlreadyExistsException
-		if errors.As(err, &already) {
-			return Result{Status: StatusPending}, nil
+		if !errors.As(err, &already) {
+			return Result{}, err // transient/permission — retry
 		}
+	}
+
+	// Configure the custom MAIL FROM subdomain (Return-Path alignment). Idempotent.
+	// USE_DEFAULT_VALUE: if the customer's MX later breaks, SES falls back to its
+	// own MAIL FROM rather than dropping mail — deliverability-safe (the send path
+	// only uses the aligned envelope once status==verified, which requires the MX).
+	mfDomain := mailfrom.Domain(domain)
+	if _, err := p.api.PutEmailIdentityMailFromAttributes(ctx, &sesv2.PutEmailIdentityMailFromAttributesInput{
+		EmailIdentity:       &domain,
+		MailFromDomain:      &mfDomain,
+		BehaviorOnMxFailure: ststypes.BehaviorOnMxFailureUseDefaultValue,
+	}); err != nil {
 		return Result{}, err // transient/permission — retry
 	}
-	return Result{Status: StatusPending}, nil
+
+	return Result{Status: StatusPending, DNSRecords: mailFromRecords(domain, p.region)}, nil
+}
+
+// mailFromRecords are the two records the customer must publish for the custom
+// MAIL FROM subdomain: an MX to SES's regional feedback handler and an SPF TXT
+// so SPF authenticates (and aligns to) the From org-domain. Shared by the SES
+// provider and the FakeProvider so tests assert the real shape.
+func mailFromRecords(domain, region string) []DNSRecord {
+	mf := mailfrom.Domain(domain)
+	return []DNSRecord{
+		{Type: "MX", Name: mf, Value: fmt.Sprintf("10 feedback-smtp.%s.amazonses.com", region)},
+		{Type: "TXT", Name: mf, Value: "v=spf1 include:amazonses.com ~all"},
+	}
 }
 
 func (p *SESProvider) Status(ctx context.Context, domain string) (Result, error) {
@@ -114,26 +148,27 @@ func (p *SESProvider) List(ctx context.Context) ([]string, error) {
 	}
 }
 
-// mapSESStatus folds SES's two-axis verification state (sending-verified +
-// DKIM status) onto our Status. Verified requires BOTH the identity to be
-// verified for sending AND DKIM to have succeeded (so the aligned signature
-// actually works). A hard DKIM failure is terminal; anything else is pending.
+// mapSESStatus folds SES's verification axes onto our Status. Verified requires
+// ALL of: the identity verified for sending, DKIM succeeded (aligned signature),
+// AND the custom MAIL FROM succeeded (aligned Return-Path) — all-or-nothing
+// (design Q2), so reaching `verified` means there is genuinely no "via e2a". A
+// hard failure on either DKIM or MAIL FROM is terminal; anything else is pending.
 func mapSESStatus(out *sesv2.GetEmailIdentityOutput) Status {
 	dkim := ststypes.DkimStatusNotStarted
 	if out.DkimAttributes != nil {
 		dkim = out.DkimAttributes.Status
 	}
-	switch dkim {
-	case ststypes.DkimStatusSuccess:
-		if out.VerifiedForSendingStatus {
-			return StatusVerified
-		}
-		return StatusPending
-	case ststypes.DkimStatusFailed:
-		return StatusFailed
-	default: // PENDING / TEMPORARY_FAILURE / NOT_STARTED
-		return StatusPending
+	mf := ststypes.MailFromDomainStatusPending
+	if out.MailFromAttributes != nil {
+		mf = out.MailFromAttributes.MailFromDomainStatus
 	}
+	if dkim == ststypes.DkimStatusFailed || mf == ststypes.MailFromDomainStatusFailed {
+		return StatusFailed
+	}
+	if dkim == ststypes.DkimStatusSuccess && out.VerifiedForSendingStatus && mf == ststypes.MailFromDomainStatusSuccess {
+		return StatusVerified
+	}
+	return StatusPending
 }
 
 // pkcs8Base64 converts a stored PKCS#1 DER RSA private key to the single-line

--- a/internal/senderidentity/ses.go
+++ b/internal/senderidentity/ses.go
@@ -113,7 +113,10 @@ func (p *SESProvider) Status(ctx context.Context, domain string) (Result, error)
 		}
 		return Result{}, err
 	}
-	return Result{Status: mapSESStatus(out)}, nil
+	// Re-emit the MAIL FROM records on every poll so the verify/failed transition
+	// preserves them (ReconcileWorker writes res.DNSRecords) — a verified domain's
+	// view keeps showing the MX/SPF the customer must KEEP published.
+	return Result{Status: mapSESStatus(out), DNSRecords: mailFromRecords(domain, p.region)}, nil
 }
 
 func (p *SESProvider) Deprovision(ctx context.Context, domain string) error {

--- a/internal/senderidentity/ses_test.go
+++ b/internal/senderidentity/ses_test.go
@@ -20,20 +20,40 @@ func TestMapSESStatus(t *testing.T) {
 		want Status
 	}{
 		{
-			name: "dkim success + verified for sending → verified",
+			name: "all three (sending + dkim + mailfrom) success → verified",
 			out: &sesv2.GetEmailIdentityOutput{
 				VerifiedForSendingStatus: true,
 				DkimAttributes:           &ststypes.DkimAttributes{Status: ststypes.DkimStatusSuccess},
+				MailFromAttributes:       &ststypes.MailFromAttributes{MailFromDomainStatus: ststypes.MailFromDomainStatusSuccess},
 			},
 			want: StatusVerified,
 		},
 		{
-			name: "dkim success but not verified for sending → pending",
+			name: "dkim success + verified for sending but mailfrom pending → pending (all-or-nothing)",
+			out: &sesv2.GetEmailIdentityOutput{
+				VerifiedForSendingStatus: true,
+				DkimAttributes:           &ststypes.DkimAttributes{Status: ststypes.DkimStatusSuccess},
+				MailFromAttributes:       &ststypes.MailFromAttributes{MailFromDomainStatus: ststypes.MailFromDomainStatusPending},
+			},
+			want: StatusPending,
+		},
+		{
+			name: "dkim+mailfrom success but not verified for sending → pending",
 			out: &sesv2.GetEmailIdentityOutput{
 				VerifiedForSendingStatus: false,
 				DkimAttributes:           &ststypes.DkimAttributes{Status: ststypes.DkimStatusSuccess},
+				MailFromAttributes:       &ststypes.MailFromAttributes{MailFromDomainStatus: ststypes.MailFromDomainStatusSuccess},
 			},
 			want: StatusPending,
+		},
+		{
+			name: "mailfrom failed → failed (even with dkim ok)",
+			out: &sesv2.GetEmailIdentityOutput{
+				VerifiedForSendingStatus: true,
+				DkimAttributes:           &ststypes.DkimAttributes{Status: ststypes.DkimStatusSuccess},
+				MailFromAttributes:       &ststypes.MailFromAttributes{MailFromDomainStatus: ststypes.MailFromDomainStatusFailed},
+			},
+			want: StatusFailed,
 		},
 		{
 			name: "dkim failed → failed",
@@ -99,12 +119,30 @@ func TestPKCS8Base64(t *testing.T) {
 // stubSESAPI implements sesAPI; only the methods under test return real
 // behavior, the rest panic if unexpectedly called.
 type stubSESAPI struct {
-	getErr error
-	delErr error
+	getErr    error
+	delErr    error
+	createErr error
+	putErr    error
+
+	// recorders for the Provision path.
+	createInput   *sesv2.CreateEmailIdentityInput
+	mailFromInput *sesv2.PutEmailIdentityMailFromAttributesInput
 }
 
 func (s *stubSESAPI) CreateEmailIdentity(ctx context.Context, in *sesv2.CreateEmailIdentityInput, optFns ...func(*sesv2.Options)) (*sesv2.CreateEmailIdentityOutput, error) {
-	panic("not used")
+	s.createInput = in
+	if s.createErr != nil {
+		return nil, s.createErr
+	}
+	return &sesv2.CreateEmailIdentityOutput{}, nil
+}
+
+func (s *stubSESAPI) PutEmailIdentityMailFromAttributes(ctx context.Context, in *sesv2.PutEmailIdentityMailFromAttributesInput, optFns ...func(*sesv2.Options)) (*sesv2.PutEmailIdentityMailFromAttributesOutput, error) {
+	s.mailFromInput = in
+	if s.putErr != nil {
+		return nil, s.putErr
+	}
+	return &sesv2.PutEmailIdentityMailFromAttributesOutput{}, nil
 }
 
 func (s *stubSESAPI) GetEmailIdentity(ctx context.Context, in *sesv2.GetEmailIdentityInput, optFns ...func(*sesv2.Options)) (*sesv2.GetEmailIdentityOutput, error) {
@@ -125,9 +163,67 @@ func (s *stubSESAPI) ListEmailIdentities(ctx context.Context, in *sesv2.ListEmai
 	panic("not used")
 }
 
+func TestSESProvider_ProvisionConfiguresMailFrom(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	pkcs1 := x509.MarshalPKCS1PrivateKey(key)
+	stub := &stubSESAPI{}
+	p := NewSESProvider(stub, "eu-west-1")
+
+	res, err := p.Provision(context.Background(), "acme.com", "e2a202606", pkcs1)
+	if err != nil {
+		t.Fatalf("Provision error: %v", err)
+	}
+	if res.Status != StatusPending {
+		t.Fatalf("want pending after provision, got %q", res.Status)
+	}
+	// Configured the custom MAIL FROM on the identity.
+	if stub.mailFromInput == nil || stub.mailFromInput.MailFromDomain == nil ||
+		*stub.mailFromInput.MailFromDomain != "bounce.acme.com" {
+		t.Fatalf("want MAIL FROM bounce.acme.com, got %+v", stub.mailFromInput)
+	}
+	if stub.mailFromInput.BehaviorOnMxFailure != ststypes.BehaviorOnMxFailureUseDefaultValue {
+		t.Errorf("want USE_DEFAULT_VALUE behavior, got %v", stub.mailFromInput.BehaviorOnMxFailure)
+	}
+	// Returned the MX + SPF records (region-targeted) for the customer to publish.
+	if len(res.DNSRecords) != 2 {
+		t.Fatalf("want 2 DNS records, got %d: %+v", len(res.DNSRecords), res.DNSRecords)
+	}
+	var mx, txt *DNSRecord
+	for i := range res.DNSRecords {
+		switch res.DNSRecords[i].Type {
+		case "MX":
+			mx = &res.DNSRecords[i]
+		case "TXT":
+			txt = &res.DNSRecords[i]
+		}
+	}
+	if mx == nil || mx.Name != "bounce.acme.com" || mx.Value != "10 feedback-smtp.eu-west-1.amazonses.com" {
+		t.Errorf("MX record wrong: %+v", mx)
+	}
+	if txt == nil || txt.Name != "bounce.acme.com" || txt.Value != "v=spf1 include:amazonses.com ~all" {
+		t.Errorf("SPF TXT record wrong: %+v", txt)
+	}
+}
+
+func TestSESProvider_ProvisionAlreadyExistsStillSetsMailFrom(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	pkcs1 := x509.MarshalPKCS1PrivateKey(key)
+	// CreateEmailIdentity returns AlreadyExists (idempotent re-provision); MAIL
+	// FROM must still be (re)configured.
+	stub := &stubSESAPI{createErr: &ststypes.AlreadyExistsException{}}
+	p := NewSESProvider(stub, "us-east-1")
+	res, err := p.Provision(context.Background(), "acme.com", "sel", pkcs1)
+	if err != nil {
+		t.Fatalf("Provision error: %v", err)
+	}
+	if res.Status != StatusPending || stub.mailFromInput == nil {
+		t.Fatalf("AlreadyExists must still set MAIL FROM; status=%q mailFrom=%+v", res.Status, stub.mailFromInput)
+	}
+}
+
 func TestSESProvider_NotFoundMapping(t *testing.T) {
 	t.Run("Status maps NotFoundException to ErrIdentityNotFound", func(t *testing.T) {
-		p := NewSESProvider(&stubSESAPI{getErr: &ststypes.NotFoundException{}})
+		p := NewSESProvider(&stubSESAPI{getErr: &ststypes.NotFoundException{}}, "us-east-1")
 		_, err := p.Status(context.Background(), "example.com")
 		if !errors.Is(err, ErrIdentityNotFound) {
 			t.Fatalf("expected ErrIdentityNotFound, got %v", err)
@@ -135,7 +231,7 @@ func TestSESProvider_NotFoundMapping(t *testing.T) {
 	})
 
 	t.Run("Deprovision treats NotFoundException as success", func(t *testing.T) {
-		p := NewSESProvider(&stubSESAPI{delErr: &ststypes.NotFoundException{}})
+		p := NewSESProvider(&stubSESAPI{delErr: &ststypes.NotFoundException{}}, "us-east-1")
 		if err := p.Deprovision(context.Background(), "example.com"); err != nil {
 			t.Fatalf("expected nil for missing identity, got %v", err)
 		}
@@ -143,7 +239,7 @@ func TestSESProvider_NotFoundMapping(t *testing.T) {
 
 	t.Run("Status propagates other errors", func(t *testing.T) {
 		boom := errors.New("throttled")
-		p := NewSESProvider(&stubSESAPI{getErr: boom})
+		p := NewSESProvider(&stubSESAPI{getErr: boom}, "us-east-1")
 		if _, err := p.Status(context.Background(), "example.com"); !errors.Is(err, boom) {
 			t.Fatalf("expected boom to propagate, got %v", err)
 		}

--- a/internal/senderidentity/ses_test.go
+++ b/internal/senderidentity/ses_test.go
@@ -56,6 +56,24 @@ func TestMapSESStatus(t *testing.T) {
 			want: StatusFailed,
 		},
 		{
+			name: "dkim temporary_failure → pending (transient, not stranded as failed)",
+			out: &sesv2.GetEmailIdentityOutput{
+				VerifiedForSendingStatus: true,
+				DkimAttributes:           &ststypes.DkimAttributes{Status: ststypes.DkimStatusTemporaryFailure},
+				MailFromAttributes:       &ststypes.MailFromAttributes{MailFromDomainStatus: ststypes.MailFromDomainStatusSuccess},
+			},
+			want: StatusPending,
+		},
+		{
+			name: "mailfrom temporary_failure → pending (transient, not stranded)",
+			out: &sesv2.GetEmailIdentityOutput{
+				VerifiedForSendingStatus: true,
+				DkimAttributes:           &ststypes.DkimAttributes{Status: ststypes.DkimStatusSuccess},
+				MailFromAttributes:       &ststypes.MailFromAttributes{MailFromDomainStatus: ststypes.MailFromDomainStatusTemporaryFailure},
+			},
+			want: StatusPending,
+		},
+		{
 			name: "dkim failed → failed",
 			out: &sesv2.GetEmailIdentityOutput{
 				VerifiedForSendingStatus: true,
@@ -218,6 +236,36 @@ func TestSESProvider_ProvisionAlreadyExistsStillSetsMailFrom(t *testing.T) {
 	}
 	if res.Status != StatusPending || stub.mailFromInput == nil {
 		t.Fatalf("AlreadyExists must still set MAIL FROM; status=%q mailFrom=%+v", res.Status, stub.mailFromInput)
+	}
+}
+
+func TestSESProvider_ProvisionPropagatesMailFromError(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	pkcs1 := x509.MarshalPKCS1PrivateKey(key)
+	// CreateEmailIdentity ok, but the MAIL FROM call fails (transient) → Provision
+	// must surface the error so River retries (not silently return pending).
+	stub := &stubSESAPI{putErr: errors.New("throttled")}
+	p := NewSESProvider(stub, "us-east-1")
+	if _, err := p.Provision(context.Background(), "acme.com", "sel", pkcs1); err == nil {
+		t.Fatal("expected PutEmailIdentityMailFromAttributes error to propagate")
+	}
+}
+
+func TestSESProvider_StatusReturnsMailFromRecords(t *testing.T) {
+	// Status re-emits the MAIL FROM records so the verify/failed transition
+	// preserves them (records aren't wiped when a domain goes verified).
+	p := NewSESProvider(&stubSESAPI{}, "eu-west-1")
+	res, err := p.Status(context.Background(), "acme.com")
+	if err != nil {
+		t.Fatalf("Status error: %v", err)
+	}
+	if len(res.DNSRecords) != 2 {
+		t.Fatalf("want 2 records from Status, got %d", len(res.DNSRecords))
+	}
+	for _, r := range res.DNSRecords {
+		if r.Name != "bounce.acme.com" {
+			t.Errorf("record name = %q, want bounce.acme.com", r.Name)
+		}
 	}
 }
 


### PR DESCRIPTION
Implements the code (Track B) for removing **"via e2a"** from outbound mail: a verified custom domain now sends with the agent's own `From` **and** an aligned Return-Path, so SPF aligns and Gmail's "via / mailed-by e2a" label disappears (DKIM already aligned the signature).

## Slices
1. **Provisioning** — `internal/mailfrom` (shared `bounce.<domain>` convention); `SESProvider.Provision` configures the custom MAIL FROM (`PutEmailIdentityMailFromAttributes`, `USE_DEFAULT_VALUE`) + emits the MX/SPF DNS records; `mapSESStatus` requires the MAIL FROM axis too (`verified` ⇔ sending + DKIM + MAIL FROM all SUCCESS — **all-or-nothing**, design Q2).
2. **Sending** — `sender.go`: a verified domain's Return-Path becomes `bounces@bounce.<domain>` (else the e2a relay envelope + "via e2a", fail-closed). Pure, unit-tested `envelopeSender`.

## Decisions
all-or-nothing `verified` (no DKIM-only tier); `USE_DEFAULT_VALUE` on MX failure (deliverability-safe); subdomain label ships as a fixed `bounce` convention (config knob deferred).

## Verification
- Unit: `mapSESStatus` (both axes), `Provision` (MAIL FROM + records, incl. `AlreadyExists`), `mailfrom`, `envelopeSender`. Touched-package suite + `httpapi` spec-golden green; no spec/SDK change (internal Go only).
- **Local-service e2e** (real binary + Mailpit): seeded `sending_status=verified` vs `none`; over real SMTP confirmed verified → `From: bot@acme.e2etest` (no "via") + `Return-Path: bounces@bounce.acme.e2etest`; fail-closed → `From: … via e2a <agent@relay>` + relay Return-Path. Logs clean.

## Deferred
**Track A** — validate the real `sesv2` + BYODKIM path against live AWS, then enable `sender_identity.ses_region` in prod (this feature is dormant behind that gate). Per-deployment configurable label. ARC sealing (separate). See `docs/design/sender-identity-mailfrom.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)