### PR TITLE
feat(holds): unify hold vocabulary on pending_review — slices 1–2 (status + events)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1101,11 +1101,11 @@ components:
           type: string
         hitl_status:
           enum:
-            - pending_approval
+            - pending_review
             - sent
-            - rejected
-            - expired_approved
-            - expired_rejected
+            - review_rejected
+            - review_expired_approved
+            - review_expired_rejected
           type: string
         labels:
           items:
@@ -1199,11 +1199,11 @@ components:
           type: string
         hitl_status:
           enum:
-            - pending_approval
+            - pending_review
             - sent
-            - rejected
-            - expired_approved
-            - expired_rejected
+            - review_rejected
+            - review_expired_approved
+            - review_expired_rejected
           type: string
         labels:
           items:
@@ -1587,7 +1587,7 @@ components:
         status:
           enum:
             - sent
-            - pending_approval
+            - pending_review
           type: string
       required:
         - status

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2394,7 +2394,7 @@ paths:
         - conversations
   /v1/agents/{email}/messages:
     get:
-      description: List an agent's messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_approval.
+      description: List an agent's messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review.
       operationId: listMessages
       parameters:
         - in: path
@@ -2511,7 +2511,7 @@ paths:
       tags:
         - messages
     post:
-      description: Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_approval when the agent has HITL enabled. Honors Idempotency-Key.
+      description: Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_review when the agent has HITL enabled. Honors Idempotency-Key.
       operationId: sendMessage
       parameters:
         - in: path
@@ -2546,7 +2546,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SendResultView"
-          description: Accepted — held for human approval (status=pending_approval).
+          description: Accepted — held for human approval (status=pending_review).
         default:
           content:
             application/json:
@@ -2635,7 +2635,7 @@ paths:
         - messages
   /v1/agents/{email}/messages/{id}/approve:
     post:
-      description: Approve a pending_approval draft (with optional reviewer overrides) and send it. Honors Idempotency-Key (the approve triggers an SES send).
+      description: Approve a pending_review draft (with optional reviewer overrides) and send it. Honors Idempotency-Key (the approve triggers an SES send).
       operationId: approveMessage
       parameters:
         - in: path
@@ -2770,7 +2770,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SendResultView"
-          description: Accepted — held for human approval (status=pending_approval).
+          description: Accepted — held for human approval (status=pending_review).
         default:
           content:
             application/json:
@@ -2784,7 +2784,7 @@ paths:
         - messages
   /v1/agents/{email}/messages/{id}/reject:
     post:
-      description: Reject a pending_approval draft so it is never sent.
+      description: Reject a pending_review draft so it is never sent.
       operationId: rejectMessage
       parameters:
         - in: path
@@ -2863,7 +2863,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SendResultView"
-          description: Accepted — held for human approval (status=pending_approval).
+          description: Accepted — held for human approval (status=pending_review).
         default:
           content:
             application/json:
@@ -2899,7 +2899,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SendResultView"
-          description: Accepted — held for human approval (status=pending_approval).
+          description: Accepted — held for human approval (status=pending_review).
         default:
           content:
             application/json:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -481,14 +481,13 @@ components:
         description:
           type: string
         events:
-          description: "Beta: email.flagged, email.blocked, and email.pending_review (screening dispositions) are unstable — their payload may change before they are declared stable. All other events are stable."
+          description: "Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable. All other events are stable."
           items:
             enum:
               - email.received
               - email.sent
-              - email.pending_approval
-              - email.approval_accepted
-              - email.approval_rejected
+              - email.review_approved
+              - email.review_rejected
               - domain.sending_verified
               - domain.sending_failed
               - email.delivered
@@ -522,14 +521,13 @@ components:
         enabled:
           type: boolean
         events:
-          description: "Beta: email.flagged, email.blocked, and email.pending_review (screening dispositions) are unstable — their payload may change before they are declared stable. All other events are stable."
+          description: "Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable. All other events are stable."
           items:
             enum:
               - email.received
               - email.sent
-              - email.pending_approval
-              - email.approval_accepted
-              - email.approval_rejected
+              - email.review_approved
+              - email.review_rejected
               - domain.sending_verified
               - domain.sending_failed
               - email.delivered
@@ -821,9 +819,8 @@ components:
           enum:
             - email.received
             - email.sent
-            - email.pending_approval
-            - email.approval_accepted
-            - email.approval_rejected
+            - email.review_approved
+            - email.review_rejected
             - domain.sending_verified
             - domain.sending_failed
             - email.delivered
@@ -1636,9 +1633,8 @@ components:
           enum:
             - email.received
             - email.sent
-            - email.pending_approval
-            - email.approval_accepted
-            - email.approval_rejected
+            - email.review_approved
+            - email.review_rejected
             - domain.sending_verified
             - domain.sending_failed
             - email.delivered
@@ -1764,14 +1760,13 @@ components:
         enabled:
           type: boolean
         events:
-          description: "Beta: email.flagged, email.blocked, and email.pending_review (screening dispositions) are unstable — their payload may change before they are declared stable. All other events are stable."
+          description: "Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable. All other events are stable."
           items:
             enum:
               - email.received
               - email.sent
-              - email.pending_approval
-              - email.approval_accepted
-              - email.approval_rejected
+              - email.review_approved
+              - email.review_rejected
               - domain.sending_verified
               - domain.sending_failed
               - email.delivered
@@ -1906,9 +1901,8 @@ components:
           enum:
             - email.received
             - email.sent
-            - email.pending_approval
-            - email.approval_accepted
-            - email.approval_rejected
+            - email.review_approved
+            - email.review_rejected
             - domain.sending_verified
             - domain.sending_failed
             - email.delivered
@@ -1976,14 +1970,13 @@ components:
         enabled:
           type: boolean
         events:
-          description: "Beta: email.flagged, email.blocked, and email.pending_review (screening dispositions) are unstable — their payload may change before they are declared stable. All other events are stable."
+          description: "Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable. All other events are stable."
           items:
             enum:
               - email.received
               - email.sent
-              - email.pending_approval
-              - email.approval_accepted
-              - email.approval_rejected
+              - email.review_approved
+              - email.review_rejected
               - domain.sending_verified
               - domain.sending_failed
               - email.delivered

--- a/docs/design/2026-06-22-unify-holds-on-pending-review.md
+++ b/docs/design/2026-06-22-unify-holds-on-pending-review.md
@@ -1,0 +1,179 @@
+# Unify message holds on the `pending_review` vocabulary (drop `pending_approval`)
+
+**Status:** Proposed · **Date:** 2026-06-22 · **Author:** design pass (Claude)
+
+## 1. Goal
+
+Collapse the two parallel human-in-the-loop hold vocabularies — outbound
+`pending_approval` / `approval_*` and inbound `pending_review` / `review_*` —
+into **one direction-aware `review` primitive**. One status family, one webhook
+event family, one `/approve` + `/reject` surface that branches on direction.
+
+This finishes the trajectory migration `040_screening.sql` explicitly named
+("evolve the existing outbound `pending_approval` machine into a direction-aware
+queue") and closes the gap that the inbound review approve/reject store methods
+(`ApproveInboundReview` / `RejectInboundReview`) have **no wired endpoint** today —
+inbound holds currently resolve only by TTL auto-sweep.
+
+**Why now:** the `pending_approval` status and the `approval_*` events freeze at
+GA. This is the only cheap window; afterward it is a breaking change with external
+subscribers.
+
+## 2. The unifying model
+
+A held message — regardless of direction — is one primitive:
+
+> A message is **held** (`pending_review`). A human (or the TTL sweep) **approves**
+> it → it proceeds, or **rejects** it → it is dropped. "Proceeds" is
+> direction-dependent: outbound = **send via SES**; inbound = **release to the agent**.
+
+The direction-specific *side effect* of approve is preserved in full (see §6) —
+this is a vocabulary + event + dispatch unification, NOT a removal of the outbound
+send-approval machinery.
+
+## 3. Status mapping (DB)
+
+Current (`migrations/040`): outbound `sent | pending_approval | rejected |
+expired_approved | expired_rejected`; inbound `pending_review | review_approved |
+review_rejected | review_expired_approved | review_expired_rejected`.
+
+Target: outbound adopts the review vocabulary.
+
+| Outbound today | → Unified |
+|---|---|
+| `pending_approval` | `pending_review` |
+| `rejected` | `review_rejected` |
+| `expired_approved` | `review_expired_approved` |
+| `expired_rejected` | `review_expired_rejected` |
+| `sent` | `sent` (unchanged — outbound's "approved" terminal is the send itself) |
+
+Note the asymmetry that stays: **outbound approve → `sent`** (the approve triggers
+the SES send, there is no "approved-but-unsent" state), **inbound approve →
+`review_approved`** (released to inbox). The unified webhook (`email.review_approved`)
+fires for both; outbound additionally fires `email.sent`.
+
+### Migration `044_unify_holds.sql` (idempotent, non-destructive)
+
+`messages` is prod-sized — follow CLAUDE.md (no `ALTER COLUMN TYPE`; bounded backfill).
+
+1. **Backfill** (bounded — holds are a tiny, ≤10-day-TTL fraction of rows):
+   `UPDATE messages SET status = <map> WHERE direction='outbound' AND status IN
+   ('pending_approval','rejected','expired_approved','expired_rejected')`.
+2. **Swap CHECK** to the unified set. Add the new constraint `NOT VALID` then
+   `VALIDATE CONSTRAINT` separately to avoid a long table-scan lock (migration 040
+   did a plain swap; we harden it).
+3. **Index:** the existing `idx_messages_pending_review` (status='pending_review')
+   now covers both directions. Drop `idx_messages_pending_approval`.
+
+## 4. Webhook event mapping
+
+| Today | → Unified | Notes |
+|---|---|---|
+| `email.pending_approval` (outbound) | **`email.pending_review`** | already exists (inbound); now fires both directions via `direction` field |
+| `email.approval_accepted` | **`email.review_approved`** | direction-aware |
+| `email.approval_rejected` | **`email.review_rejected`** | direction-aware |
+| `email.pending_review` (inbound) | unchanged | |
+
+**Removed:** `email.pending_approval`, `email.approval_accepted`,
+`email.approval_rejected`. **Added:** `email.review_approved`,
+`email.review_rejected`. Net catalog **14 → 13**.
+
+The hold-event family becomes a clean trio — `pending_review`, `review_approved`,
+`review_rejected` — all carrying `direction`, `reason_source`, and (for
+`pending_review`) `approval_expires_at`.
+
+### Decision (Q2): keep the resolution pair
+
+Recommend **keeping both** `review_approved` and `review_rejected` rather than
+relying on `email.sent`/`email.received`:
+- **inbound-approved has no other signal** — `email.received` is suppressed while
+  held and is not re-fired on release, so without `review_approved` an approved
+  inbound message is invisible.
+- For outbound, `review_approved` (human approved) and `email.sent` (SES accepted)
+  are *different facts* — approve can succeed while the send later fails — so both
+  are useful, not redundant.
+
+## 5. Endpoint dispatch
+
+`POST /v1/agents/{email}/messages/{id}/approve` and `/reject` branch on the held
+message's **direction**:
+
+- **outbound** (`pending_review`, was `pending_approval`) → `ApprovePendingCore`
+  (SES send, idempotency, magic-link, self-approval guard) / `RejectPendingCore`.
+- **inbound** (`pending_review` from screening) → wire the today-dead
+  `ApproveInboundReview` (release to inbox) / `RejectInboundReview` (drop).
+
+This single change closes the "inbound holds have no human resolution surface" gap.
+Handler descriptions/OpenAPI updated to say "approve a held message (outbound: send;
+inbound: release)".
+
+## 6. Safety machinery to preserve (outbound approve)
+
+The outbound approve path keeps **all** of: idempotent SES send (approve triggers a
+real send), magic-link approval (`hitl_magic_api.go`), self-approval guard
+(an agent can't approve its own outbound), owner notification (`hitlnotify`),
+send-limit check. The dispatch must route outbound approve through exactly this path —
+the unification renames the wrapper, not the guarantees.
+
+## 7. Surfaces to update
+
+- **Go:** `internal/identity` (status constants, review.go + store.go approve/reject),
+  `internal/agent/hitl_api.go` + `hitl_magic_api.go`, `internal/httpapi/hitl.go`
+  (dispatch) + `messages.go`/`outbound.go` (status views), `internal/webhookpub`
+  (event consts + `AllEventTypes`), emit sites in `agent/api.go` (outbound) and
+  inbound flow, `internal/hitlworker` (the TTL sweep now resolves both directions
+  under `pending_review` — dispatch by direction), `hitlnotify`.
+- **DB:** migration 044.
+- **Spec/SDK:** regenerate `api/openapi.yaml` + TS/Python bases.
+- **MCP:** `mcp/src/tools/messages.ts`, `tiers.ts` (status strings + tool docs).
+- **Web:** dashboard status labels / approval UI.
+
+## 8. The TTL sweep (hitlworker)
+
+Today: a separate outbound `pending_approval` sweep + inbound `sweepReviews`. After
+unification both holds carry `pending_review`; the sweep selects `pending_review`
+rows and dispatches by **direction** — outbound expired → send-or-drop per policy
+(`review_expired_approved`/`review_expired_rejected`), inbound expired → release-or-drop.
+Behavior is preserved; only the selection/dispatch is unified.
+
+## 9. Backward-compat & rollout
+
+- **In-flight prod holds:** the backfill (§3.1) migrates any live `pending_approval`
+  rows to `pending_review`, so nothing is stranded. Magic-link emails already sent
+  reference an approve URL that still resolves (same message id, dispatch handles it).
+- **Subscribers:** the `approval_*` events are removed — breaking, but pre-GA and the
+  event surface was never frozen/tagged stable in a release. Acceptable in this window.
+- **Stability tag:** mark the whole `review.*` family **beta** during the unification
+  (consistent with `pending_review`); promote to stable at GA once settled.
+
+## 10. Testing
+
+- Migration: backfill maps every outbound hold/terminal correctly; CHECK accepts the
+  unified set and rejects the old values; idempotent re-run is a no-op.
+- Dispatch: outbound approve still sends (idempotency + magic-link + self-approval
+  guard intact); inbound approve releases to inbox; reject drops in both directions.
+- Events: `pending_review`/`review_approved`/`review_rejected` fire with correct
+  `direction` + `reason_source`; old `approval_*`/`pending_approval` gone everywhere;
+  drift gates green; SDK parity.
+- TTL sweep resolves both directions under `pending_review`.
+- E2E: the existing outbound HITL e2e suite, repointed to the review vocabulary, must
+  pass unchanged in behavior.
+
+## 11. Slices
+
+1. **DB + status constants** — migration 044 + `internal/identity` status vocabulary, backfill, sweep dispatch.
+2. **Events** — webhookpub consts, emit sites, enum/`AllEventTypes`, spec+SDK regen.
+3. **Endpoint dispatch** — `/approve`+`/reject` branch on direction; wire inbound review; preserve outbound machinery.
+4. **Periphery** — MCP, web, magic-link copy, notifier.
+5. **Tests + e2e** across all of the above.
+
+## 12. Open questions / risks
+
+- **Outbound `sent` vs `review_approved` asymmetry** (§3): acceptable, but confirm we
+  don't want an explicit outbound `review_approved` status before the send (the send
+  is the approval's effect, so no).
+- **Magic-link copy** references "approve"/"approval"; keep "approve" as the verb
+  (the action is still approve), only the status/event nouns move to "review".
+- **Safety-critical path:** outbound approve gates real sends — this slice needs the
+  full outbound HITL test suite green before merge; highest-risk part of the change.
+</content>

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -336,9 +336,9 @@ func (a *API) publishSent(ctx context.Context, e webhookpub.Event, outMsg *ident
 	}
 }
 
-// publishPendingApproval fires email.pending_approval via the outbox
-// (PublishTx — pre-side-effect: the pending row hasn't been sent to
-// SES yet) AND the legacy goroutine. pendingMsgID seeds the
+// publishPendingApproval fires email.pending_review (direction=outbound)
+// via the outbox (PublishTx — pre-side-effect: the pending row hasn't been
+// sent to SES yet) AND the legacy goroutine. pendingMsgID seeds the
 // deterministic event id so /send retries with the same idempotency
 // key don't fire duplicate events.
 func (a *API) publishPendingApproval(ctx context.Context, e webhookpub.Event, pendingMsgID string) {
@@ -349,7 +349,7 @@ func (a *API) publishPendingApproval(ctx context.Context, e webhookpub.Event, pe
 			return a.outbox.PublishTx(ctx, tx, e)
 		})
 		if err != nil {
-			log.Printf("[api] outbox tx for email.pending_approval err: %v", err)
+			log.Printf("[api] outbox tx for email.pending_review err: %v", err)
 		} else {
 			// err==nil means the tx committed AND PublishTx returned
 			// nil — both are required for the row to be durably

--- a/internal/agent/events_api.go
+++ b/internal/agent/events_api.go
@@ -33,7 +33,7 @@ func (a *API) SetPoolForEvents(p *pgxpool.Pool) { a.eventsPool = p }
 // GET /events/{id}. Mirrors design §4.6.
 type eventJSON struct {
 	ID             string                 `json:"id"`
-	Type           string                 `json:"type" enum:"email.received,email.sent,email.pending_approval,email.approval_accepted,email.approval_rejected,domain.sending_verified,domain.sending_failed,email.delivered,email.bounced,email.complained,domain.suppression_added,email.flagged,email.blocked,email.pending_review"`
+	Type           string                 `json:"type" enum:"email.received,email.sent,email.review_approved,email.review_rejected,domain.sending_verified,domain.sending_failed,email.delivered,email.bounced,email.complained,domain.suppression_added,email.flagged,email.blocked,email.pending_review"`
 	SchemaVersion  int                    `json:"schema_version"`
 	CreatedAt      time.Time              `json:"created_at"`
 	AgentID        *string                `json:"agent_id,omitempty"`

--- a/internal/agent/hitl_api.go
+++ b/internal/agent/hitl_api.go
@@ -77,7 +77,7 @@ func (a *API) ApprovePendingCore(ctx context.Context, userID, messageID, expecte
 	if err != nil {
 		return nil, &OutboundError{http.StatusNotFound, "not_found", "message not found"}
 	}
-	if preview.Status != identity.MessageStatusPendingApproval {
+	if preview.Status != identity.MessageStatusPendingReview {
 		return nil, &OutboundError{http.StatusConflict, "message_not_pending", "message is not pending approval"}
 	}
 	agent, err := a.store.GetAgentByID(ctx, preview.AgentID)

--- a/internal/agent/hitl_magic_api.go
+++ b/internal/agent/hitl_magic_api.go
@@ -67,7 +67,7 @@ func (a *API) renderConfirmPage(w http.ResponseWriter, r *http.Request, endpoint
 			"This message no longer exists.")
 		return
 	}
-	if msg.Status != identity.MessageStatusPendingApproval {
+	if msg.Status != identity.MessageStatusPendingReview {
 		writeMagicMessage(w, http.StatusConflict, "Already resolved",
 			"This message has already been approved, rejected, or expired.")
 		return

--- a/internal/agent/hitl_magic_api_test.go
+++ b/internal/agent/hitl_magic_api_test.go
@@ -138,7 +138,7 @@ func TestMagicLinkGETDoesNotExecute(t *testing.T) {
 
 	// Row stays pending.
 	got, _ := store.GetOutboundMessageForUser(context.Background(), msg.ID, userID)
-	if got.Status != identity.MessageStatusPendingApproval {
+	if got.Status != identity.MessageStatusPendingReview {
 		t.Errorf("status after GET = %q, want still pending_approval", got.Status)
 	}
 }
@@ -322,7 +322,7 @@ func TestMagicRejectPOSTWithReason(t *testing.T) {
 	}
 
 	got, _ := store.GetOutboundMessageForUser(context.Background(), msg.ID, userID)
-	if got.Status != identity.MessageStatusRejected {
+	if got.Status != identity.MessageStatusReviewRejected {
 		t.Errorf("status = %q, want rejected", got.Status)
 	}
 	if got.RejectionReason != "not the right tone" {

--- a/internal/agent/webhooks_api.go
+++ b/internal/agent/webhooks_api.go
@@ -78,6 +78,7 @@ func (a *API) buildPendingApprovalEvent(
 ) webhookpub.Event {
 	data := map[string]interface{}{
 		"message_id":          msg.ID,
+		"direction":           "outbound",
 		"from":                agent.EmailAddress(),
 		"to":                  req.To,
 		"cc":                  req.CC,
@@ -89,7 +90,7 @@ func (a *API) buildPendingApprovalEvent(
 	}
 	return webhookpub.Event{
 		ID:             generateEventIDForAgent(),
-		Type:           webhookpub.EventEmailPendingApproval,
+		Type:           webhookpub.EventEmailPendingReview,
 		CreatedAt:      time.Now().UTC(),
 		UserID:         agent.UserID,
 		AgentID:        agent.ID,
@@ -108,6 +109,7 @@ func (a *API) buildApprovedEvent(
 ) webhookpub.Event {
 	data := map[string]interface{}{
 		"message_id":          sent.ID,
+		"direction":           "outbound",
 		"provider_message_id": sent.ProviderMessageID,
 		"method":              sent.Method,
 		"from":                agent.EmailAddress(),
@@ -119,7 +121,7 @@ func (a *API) buildApprovedEvent(
 	}
 	return webhookpub.Event{
 		ID:        generateEventIDForAgent(),
-		Type:      webhookpub.EventEmailApproved,
+		Type:      webhookpub.EventEmailReviewApproved,
 		CreatedAt: time.Now().UTC(),
 		UserID:    agent.UserID,
 		AgentID:   agent.ID,
@@ -139,13 +141,14 @@ func (a *API) buildRejectedEvent(
 ) webhookpub.Event {
 	data := map[string]interface{}{
 		"message_id":          rejected.ID,
+		"direction":           "outbound",
 		"type":                rejected.Type,
 		"rejection_reason":    reason,
 		"reviewed_by_user_id": userID,
 	}
 	return webhookpub.Event{
 		ID:        generateEventIDForAgent(),
-		Type:      webhookpub.EventEmailRejected,
+		Type:      webhookpub.EventEmailReviewRejected,
 		CreatedAt: time.Now().UTC(),
 		UserID:    userID,
 		AgentID:   rejected.AgentID,

--- a/internal/agent/webhooks_events_test.go
+++ b/internal/agent/webhooks_events_test.go
@@ -106,8 +106,8 @@ func TestBuildPendingApprovalEvent(t *testing.T) {
 	msg := &identity.Message{ID: "pend_1", ApprovalExpiresAt: &expiry}
 	req := outbound.SendRequest{To: []string{"alice@example.com"}, Subject: "review me"}
 	ev := a.buildPendingApprovalEvent(agent, msg, req, "send")
-	if ev.Type != webhookpub.EventEmailPendingApproval {
-		t.Errorf("Type = %q, want email.pending_approval", ev.Type)
+	if ev.Type != webhookpub.EventEmailPendingReview {
+		t.Errorf("Type = %q, want email.pending_review", ev.Type)
 	}
 	if ev.MessageID != "pend_1" {
 		t.Errorf("MessageID = %q, want pend_1", ev.MessageID)
@@ -130,7 +130,7 @@ func TestBuildApprovedEvent(t *testing.T) {
 		Edited:            true,
 	}
 	ev := a.buildApprovedEvent(agent, sent, "u_reviewer")
-	if ev.Type != webhookpub.EventEmailApproved {
+	if ev.Type != webhookpub.EventEmailReviewApproved {
 		t.Errorf("Type = %q", ev.Type)
 	}
 	if ev.MessageID != "msg_a" {
@@ -149,7 +149,7 @@ func TestBuildRejectedEvent(t *testing.T) {
 	a := &API{}
 	rejected := &identity.Message{ID: "msg_r", AgentID: "bot@x.example.com", Type: "send"}
 	ev := a.buildRejectedEvent("u_reviewer", rejected, "off-policy")
-	if ev.Type != webhookpub.EventEmailRejected {
+	if ev.Type != webhookpub.EventEmailReviewRejected {
 		t.Errorf("Type = %q", ev.Type)
 	}
 	if ev.MessageID != "msg_r" {

--- a/internal/e2e/edge_cases_e2e_test.go
+++ b/internal/e2e/edge_cases_e2e_test.go
@@ -258,8 +258,8 @@ func TestEdge_HITLPendingApproval_WritesOutboxRow(t *testing.T) {
 	pendingMsgID := "pmsg_hitl_outbox"
 	fix.seedMessage(pendingMsgID, agent, "outbound")
 	event := webhookpub.Event{
-		ID:        webhookpub.DeterministicEventID(pendingMsgID, webhookpub.EventEmailPendingApproval),
-		Type:      webhookpub.EventEmailPendingApproval,
+		ID:        webhookpub.DeterministicEventID(pendingMsgID, webhookpub.EventEmailPendingReview),
+		Type:      webhookpub.EventEmailPendingReview,
 		UserID:    user,
 		AgentID:   agent,
 		MessageID: pendingMsgID,
@@ -278,7 +278,7 @@ func TestEdge_HITLPendingApproval_WritesOutboxRow(t *testing.T) {
 	if err := fix.pool.QueryRow(ctx,
 		`SELECT count(*) FROM webhook_events
 		 WHERE user_id = $1 AND type = $2 AND id = $3`,
-		user, webhookpub.EventEmailPendingApproval, event.ID,
+		user, webhookpub.EventEmailPendingReview, event.ID,
 	).Scan(&count); err != nil {
 		t.Fatalf("count: %v", err)
 	}

--- a/internal/e2e/triggers_e2e_test.go
+++ b/internal/e2e/triggers_e2e_test.go
@@ -16,7 +16,7 @@ import (
 // contract level:
 //
 //   * email.sent           → PublishBestEffortTx (post-SES, no rollback)
-//   * email.pending_approval → PublishTx (pre-side-effect, strong)
+//   * email.pending_review → PublishTx (pre-side-effect, strong)
 //   * email.approved       → PublishBestEffortTx (post-SES, no rollback)
 //   * email.rejected       → PublishTx (pre-side-effect, strong)
 //
@@ -82,7 +82,7 @@ func TestTriggers_EmailSent_BestEffortAllowsCallerToProceed(t *testing.T) {
 
 // TestTriggers_PendingApproval_StrongGuaranteeReturnsError proves that
 // when the outbox INSERT fails on a pre-side-effect trigger like
-// email.pending_approval, PublishTx surfaces the error so the caller
+// email.pending_review, PublishTx surfaces the error so the caller
 // can roll back its business state. publishPendingApproval in api.go
 // relies on this — if the outbox write fails, the pending_messages row
 // must not commit either (so retries are idempotent).
@@ -95,8 +95,8 @@ func TestTriggers_PendingApproval_StrongGuaranteeReturnsError(t *testing.T) {
 
 	missingMessageID := "msg_NOT_IN_DB_pending"
 	event := webhookpub.Event{
-		ID:        webhookpub.DeterministicEventID(missingMessageID, webhookpub.EventEmailPendingApproval),
-		Type:      webhookpub.EventEmailPendingApproval,
+		ID:        webhookpub.DeterministicEventID(missingMessageID, webhookpub.EventEmailPendingReview),
+		Type:      webhookpub.EventEmailPendingReview,
 		UserID:    user,
 		AgentID:   agent,
 		MessageID: missingMessageID,
@@ -127,8 +127,8 @@ func TestTriggers_Approved_BestEffortAfterSES(t *testing.T) {
 	agent := fix.seedAgent(user, "approved")
 
 	event := webhookpub.Event{
-		ID:     webhookpub.DeterministicEventID("msg_NOT_IN_DB_approved", webhookpub.EventEmailApproved),
-		Type:   webhookpub.EventEmailApproved,
+		ID:     webhookpub.DeterministicEventID("msg_NOT_IN_DB_approved", webhookpub.EventEmailReviewApproved),
+		Type:   webhookpub.EventEmailReviewApproved,
 		UserID: user, AgentID: agent,
 		MessageID: "msg_NOT_IN_DB_approved",
 		Data:      map[string]any{"reviewed_by_user_id": user},
@@ -160,8 +160,8 @@ func TestTriggers_Rejected_StrongGuaranteeReturnsError(t *testing.T) {
 
 	missingMessageID := "msg_NOT_IN_DB_rejected"
 	event := webhookpub.Event{
-		ID:        webhookpub.DeterministicEventID(missingMessageID, webhookpub.EventEmailRejected),
-		Type:      webhookpub.EventEmailRejected,
+		ID:        webhookpub.DeterministicEventID(missingMessageID, webhookpub.EventEmailReviewRejected),
+		Type:      webhookpub.EventEmailReviewRejected,
 		UserID:    user,
 		AgentID:   agent,
 		MessageID: missingMessageID,
@@ -191,9 +191,9 @@ func TestTriggers_DeterministicID_DistinctPerEventType(t *testing.T) {
 	for _, eventType := range []string{
 		webhookpub.EventEmailReceived,
 		webhookpub.EventEmailSent,
-		webhookpub.EventEmailPendingApproval,
-		webhookpub.EventEmailApproved,
-		webhookpub.EventEmailRejected,
+		webhookpub.EventEmailPendingReview,
+		webhookpub.EventEmailReviewApproved,
+		webhookpub.EventEmailReviewRejected,
 	} {
 		ids[eventType] = webhookpub.DeterministicEventID(messageID, eventType)
 	}

--- a/internal/e2e/webhooks_e2e_test.go
+++ b/internal/e2e/webhooks_e2e_test.go
@@ -35,7 +35,7 @@ func sendURL(base, agentEmail string) string {
 // agent_identities.webhook_url path (per-agent, single URL, no filters).
 //
 // Coverage map (from the approved test plan):
-//   P1 — outbound events: email.sent, email.pending_approval,
+//   P1 — outbound events: email.sent, email.pending_review,
 //         email.approved, email.rejected fire from real handler triggers
 //   P2 — inbound:         email.received fires from a real SMTP message
 //   P3 — filters:         agent_ids + conversation_ids + labels (H5)
@@ -143,11 +143,29 @@ func setupSubscriberOwner(t *testing.T, ts *testutil.E2ATestServer, prefix strin
 		t.Fatalf("CreateAgent: %v", err)
 	}
 	if hitl {
-		// Enable HITL with a reasonable TTL.
+		// Hold every outbound send for human review. Post-HITL-retirement (migrations
+		// 042/043) holds come from the outbound policy gate, not a hitl_enabled flag:
+		// outbound_policy=allowlist with an empty allowlist flags every recipient, and
+		// outbound_policy_action=review turns that flag into a pending_review hold.
+		if err := ts.Store.UpdateAgentScanConfig(ctx, agent.ID, user.ID, identity.ScanConfig{
+			InboundPolicyAction:         "flag",
+			OutboundPolicy:              "allowlist",
+			OutboundAllowlist:           []string{},
+			OutboundPolicyAction:        "review",
+			InboundScan:                 "off",
+			InboundScanReviewThreshold:  0.5,
+			InboundScanBlockThreshold:   0.9,
+			OutboundScan:                "off",
+			OutboundScanReviewThreshold: 0.5,
+			OutboundScanBlockThreshold:  0.9,
+		}); err != nil {
+			t.Fatalf("UpdateAgentScanConfig: %v", err)
+		}
+		// TTL + expiration action for the sweep.
 		if err := ts.Store.UpdateAgentHITL(ctx, agent.ID, user.ID, 3600, "reject"); err != nil {
 			t.Fatalf("UpdateAgentHITL: %v", err)
 		}
-		// Reload so the in-test agent struct reflects HITL flag.
+		// Reload so the in-test agent struct reflects the held-outbound config.
 		agent, err = ts.Store.GetAgentByID(ctx, agent.ID)
 		if err != nil {
 			t.Fatalf("GetAgentByID: %v", err)
@@ -224,9 +242,9 @@ func TestWebhooksE2E_HITL_PendingApproved(t *testing.T) {
 
 	_, key, agent := setupSubscriberOwner(t, ts, "wh-hitl", true)
 	pendingHook := registerWebhook(t, ts, agent.UserID, receiver.Server.URL+"/pending",
-		[]string{"email.pending_approval"}, identity.WebhookFilters{})
+		[]string{"email.pending_review"}, identity.WebhookFilters{})
 	approvedHook := registerWebhook(t, ts, agent.UserID, receiver.Server.URL+"/approved",
-		[]string{"email.approval_accepted"}, identity.WebhookFilters{})
+		[]string{"email.review_approved"}, identity.WebhookFilters{})
 
 	// send → held for approval, returns 202 + message_id.
 	body := `{"to":["alice@example.com"],"subject":"draft","body":"please review"}`
@@ -241,14 +259,14 @@ func TestWebhooksE2E_HITL_PendingApproved(t *testing.T) {
 		t.Fatalf("no message_id in hold response: %s", string(respBytes))
 	}
 
-	// First tick — should deliver email.pending_approval.
+	// First tick — should deliver email.pending_review.
 	tick(t, ts)
 	receiver.WaitFor(t, 2*time.Second, func(c []testutil.SubscriberCaptured) bool { return len(c) >= 1 })
 	got := receiver.Captured()
 	if len(got) != 1 {
 		t.Fatalf("after pending: got %d captures, want 1", len(got))
 	}
-	if got[0].URL != "/pending" || got[0].Envelope["type"] != "email.pending_approval" {
+	if got[0].URL != "/pending" || got[0].Envelope["type"] != "email.pending_review" {
 		t.Errorf("first capture path=%q event=%v", got[0].URL, got[0].Envelope["type"])
 	}
 	if !verifyHMACv1(t, got[0].Headers, got[0].RawBody, pendingHook.SigningSecret) {
@@ -272,7 +290,7 @@ func TestWebhooksE2E_HITL_PendingApproved(t *testing.T) {
 		t.Fatalf("after approve: got %d captures, want 2", len(got))
 	}
 	approved := got[1]
-	if approved.URL != "/approved" || approved.Envelope["type"] != "email.approval_accepted" {
+	if approved.URL != "/approved" || approved.Envelope["type"] != "email.review_approved" {
 		t.Errorf("second capture path=%q event=%v", approved.URL, approved.Envelope["type"])
 	}
 	if !verifyHMACv1(t, approved.Headers, approved.RawBody, approvedHook.SigningSecret) {
@@ -294,7 +312,7 @@ func TestWebhooksE2E_HITL_Rejected(t *testing.T) {
 
 	_, key, agent := setupSubscriberOwner(t, ts, "wh-reject", true)
 	rejectedHook := registerWebhook(t, ts, agent.UserID, receiver.Server.URL+"/rejected",
-		[]string{"email.approval_rejected"}, identity.WebhookFilters{})
+		[]string{"email.review_rejected"}, identity.WebhookFilters{})
 
 	body := `{"to":["alice@example.com"],"subject":"nope","body":"please reject"}`
 	status, respBytes := authedJSON(t, "POST", sendURL(ts.HTTPServer.URL, agent.EmailAddress()), key.PlaintextKey, body)
@@ -324,7 +342,7 @@ func TestWebhooksE2E_HITL_Rejected(t *testing.T) {
 	if len(got) != 1 {
 		t.Fatalf("after reject: got %d captures, want 1", len(got))
 	}
-	if got[0].URL != "/rejected" || got[0].Envelope["type"] != "email.approval_rejected" {
+	if got[0].URL != "/rejected" || got[0].Envelope["type"] != "email.review_rejected" {
 		t.Errorf("path=%q event=%v", got[0].URL, got[0].Envelope["type"])
 	}
 	if !verifyHMACv1(t, got[0].Headers, got[0].RawBody, rejectedHook.SigningSecret) {

--- a/internal/hitlworker/worker.go
+++ b/internal/hitlworker/worker.go
@@ -1,6 +1,7 @@
-// Package hitlworker runs the periodic sweep that finalizes pending_approval
-// messages whose TTL has elapsed. Each row becomes either expired_approved
-// (sent as-is) or expired_rejected based on the owning agent's
+// Package hitlworker runs the periodic sweep that finalizes pending_review
+// holds whose TTL has elapsed. Outbound holds become sent (auto-approved) or
+// review_expired_rejected; inbound holds become review_expired_approved
+// (released to the agent) or review_expired_rejected — per the owning agent's
 // hitl_expiration_action column. Body columns are scrubbed in both cases.
 package hitlworker
 
@@ -23,7 +24,7 @@ import (
 const DefaultInterval = 60 * time.Second
 
 // DefaultBatchSize caps how many rows one sweep will try to finalize. The
-// partial index on (approval_expires_at) WHERE status='pending_approval'
+// partial index on (approval_expires_at) WHERE status='pending_review'
 // keeps the list query cheap regardless of total table size.
 const DefaultBatchSize = 100
 
@@ -84,11 +85,12 @@ func (w *Worker) RunOnce(ctx context.Context) {
 	w.sweepReviews(ctx)
 }
 
-// sweepReviews auto-resolves expired inbound review holds (Slice 4b). Unlike the
-// outbound pending_approval path, there is no send to perform: approve = release
-// the held message to the agent's inbox (it becomes visible), reject = drop it.
-// The compare-and-set status guard in the store methods makes concurrent/duplicate
-// sweeps safe.
+// sweepReviews auto-resolves expired INBOUND review holds. Both directions share
+// the pending_review status (unified — design 2026-06-22); ListExpiredReviews is
+// direction='inbound'-scoped, so this never touches an outbound hold (those are the
+// `sweep` path, where approve = send). Inbound: approve = release the held message
+// to the agent's inbox (it becomes visible), reject = drop it. The compare-and-set
+// status guard in the store methods makes concurrent/duplicate sweeps safe.
 func (w *Worker) sweepReviews(ctx context.Context) {
 	candidates, err := w.store.ListExpiredReviews(ctx, w.batchSize)
 	if err != nil {

--- a/internal/hitlworker/worker_test.go
+++ b/internal/hitlworker/worker_test.go
@@ -103,8 +103,8 @@ func TestWorkerAutoRejectsExpiredPending(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if status != identity.MessageStatusExpiredRejected {
-		t.Errorf("status = %q, want %q", status, identity.MessageStatusExpiredRejected)
+	if status != identity.MessageStatusReviewExpiredRejected {
+		t.Errorf("status = %q, want %q", status, identity.MessageStatusReviewExpiredRejected)
 	}
 	if reason == nil || *reason != "ttl_expired" {
 		t.Errorf("reason = %v, want 'ttl_expired'", reason)
@@ -150,8 +150,8 @@ func TestWorkerAutoApprovesExpiredPending(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if status != identity.MessageStatusExpiredApproved {
-		t.Errorf("status = %q, want %q", status, identity.MessageStatusExpiredApproved)
+	if status != identity.MessageStatusReviewExpiredApproved {
+		t.Errorf("status = %q, want %q", status, identity.MessageStatusReviewExpiredApproved)
 	}
 	if providerID == "" {
 		t.Error("provider_message_id should be populated after auto-send")
@@ -202,8 +202,8 @@ func TestWorkerAutoApproveSelfSendDeliversViaLoopback(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if status != identity.MessageStatusExpiredApproved {
-		t.Errorf("status = %q, want %q (worker should NOT have fallen back to expired_rejected)", status, identity.MessageStatusExpiredApproved)
+	if status != identity.MessageStatusReviewExpiredApproved {
+		t.Errorf("status = %q, want %q (worker should NOT have fallen back to expired_rejected)", status, identity.MessageStatusReviewExpiredApproved)
 	}
 	if method != "loopback" {
 		t.Errorf("method = %q, want loopback", method)
@@ -253,9 +253,9 @@ func TestWorkerAutoApproveSendFailureFallsBackToRejected(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if status != identity.MessageStatusExpiredRejected {
+	if status != identity.MessageStatusReviewExpiredRejected {
 		t.Errorf("status = %q, want %q (send failure should fall back to rejected)",
-			status, identity.MessageStatusExpiredRejected)
+			status, identity.MessageStatusReviewExpiredRejected)
 	}
 	if reason == nil || !strings.Contains(*reason, "auto-approve send failed") {
 		t.Errorf("reason = %v, want containing 'auto-approve send failed'", reason)
@@ -292,7 +292,7 @@ func TestWorkerAutoApproveUnverifiedAgentRejects(t *testing.T) {
 	pool.QueryRow(ctx,
 		`SELECT status, rejection_reason FROM messages WHERE id = $1`, msg.ID,
 	).Scan(&status, &reason)
-	if status != identity.MessageStatusExpiredRejected {
+	if status != identity.MessageStatusReviewExpiredRejected {
 		t.Errorf("status = %q, want expired_rejected", status)
 	}
 	if reason == nil || !strings.Contains(*reason, "not verified") {
@@ -322,7 +322,7 @@ func TestWorkerSkipsFreshPending(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if status != identity.MessageStatusPendingApproval {
+	if status != identity.MessageStatusPendingReview {
 		t.Errorf("status = %q, should still be pending_approval", status)
 	}
 	if bodyText == nil {

--- a/internal/httpapi/hitl.go
+++ b/internal/httpapi/hitl.go
@@ -49,14 +49,14 @@ func (s *Server) registerHITL() {
 	huma.Register(s.API, huma.Operation{
 		OperationID: "approveMessage", Method: http.MethodPost, Path: "/v1/agents/{email}/messages/{id}/approve",
 		Summary: "Approve a held message", Tags: []string{"messages"},
-		Description: "Approve a pending_approval draft (with optional reviewer overrides) and send it. Honors Idempotency-Key (the approve triggers an SES send).",
+		Description: "Approve a pending_review draft (with optional reviewer overrides) and send it. Honors Idempotency-Key (the approve triggers an SES send).",
 		Security:    []map[string][]string{{"bearer": {}}},
 	}, s.handleApprove)
 
 	huma.Register(s.API, huma.Operation{
 		OperationID: "rejectMessage", Method: http.MethodPost, Path: "/v1/agents/{email}/messages/{id}/reject",
 		Summary: "Reject a held message", Tags: []string{"messages"},
-		Description: "Reject a pending_approval draft so it is never sent.",
+		Description: "Reject a pending_review draft so it is never sent.",
 		Security:    []map[string][]string{{"bearer": {}}},
 	}, s.handleReject)
 }

--- a/internal/httpapi/hitl_test.go
+++ b/internal/httpapi/hitl_test.go
@@ -50,7 +50,7 @@ func TestApproveNotOwnedAgent(t *testing.T) {
 func TestReject(t *testing.T) {
 	srv := testServer(t)
 	code, body := postJSON(t, srv.URL+"/v1/agents/support%40acme.com/messages/msg_pending/reject", "good", map[string]any{"reason": "not now"})
-	if code != 200 || body["status"] != "rejected" || body["rejection_reason"] != "not now" {
+	if code != 200 || body["status"] != "review_rejected" || body["rejection_reason"] != "not now" {
 		t.Fatalf("want 200 rejected, got %d %v", code, body)
 	}
 }

--- a/internal/httpapi/messages.go
+++ b/internal/httpapi/messages.go
@@ -36,7 +36,7 @@ type MessageView struct {
 	// webhook_status — the conflation that caused bug B2. Left open (not an enum)
 	// because outbound rows carry "".
 	Status string `json:"read_status"`
-	// HITLStatus is the human-in-the-loop lifecycle (e.g. pending_approval) —
+	// HITLStatus is the human-in-the-loop lifecycle (e.g. pending_review) —
 	// outbound only, mirroring MessageSummaryView. Distinct from read_status,
 	// delivery_status, and webhook_status (each a separate axis). Closed set =
 	// migration 003 CHECK.
@@ -82,7 +82,7 @@ type MessageView struct {
 	// made on `auth` + provenance, never on this stripped text.
 	Parsed *MessageParsedView `json:"parsed,omitempty"`
 	// Body is the mutable draft body for a held outbound message
-	// (status=pending_approval), which has no raw_message yet. This is the
+	// (status=pending_review), which has no raw_message yet. This is the
 	// second representation the unified read exposes (decision 9): held drafts
 	// carry body_text/body_html, sent/inbound carry raw_message. Omitted when
 	// empty (sent/inbound rows).
@@ -177,7 +177,7 @@ func messageViewFromIdentity(m *identity.Message) MessageView {
 		}
 	}
 	// Held-draft body (decision 9 unification): the second representation a
-	// pending_approval outbound message carries instead of raw_message. Gated on
+	// pending_review outbound message carries instead of raw_message. Gated on
 	// outbound direction so it can never surface on an inbound row even if a
 	// future load path populates the body columns.
 	if m.Direction == "outbound" && (m.BodyText != "" || m.BodyHTML != "") {
@@ -329,7 +329,7 @@ func (s *Server) registerMessages() {
 		Method:      http.MethodGet,
 		Path:        "/v1/agents/{email}/messages",
 		Summary:     "List messages",
-		Description: "List an agent's messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_approval.",
+		Description: "List an agent's messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review.",
 		Tags:        []string{"messages"},
 		Security:    []map[string][]string{{"bearer": {}}},
 	}, s.handleListMessages)

--- a/internal/httpapi/messages.go
+++ b/internal/httpapi/messages.go
@@ -40,7 +40,7 @@ type MessageView struct {
 	// outbound only, mirroring MessageSummaryView. Distinct from read_status,
 	// delivery_status, and webhook_status (each a separate axis). Closed set =
 	// migration 003 CHECK.
-	HITLStatus string `json:"hitl_status,omitempty" enum:"pending_approval,sent,rejected,expired_approved,expired_rejected"`
+	HITLStatus string `json:"hitl_status,omitempty" enum:"pending_review,sent,review_rejected,review_expired_approved,review_expired_rejected"`
 	// WebhookStatus / WebhookError mirror MessageSummaryView so the detail view
 	// is a strict superset of the list item (a client fetching one message keeps
 	// the webhook delivery context). Apply to both directions; omitempty hides
@@ -215,7 +215,7 @@ type MessageSummaryView struct {
 	ConversationID string   `json:"conversation_id,omitempty"`
 	// Status is the inbox read-state, exposed as `read_status` (MSG-1).
 	Status string `json:"read_status"`
-	HITLStatus     string   `json:"hitl_status,omitempty" enum:"pending_approval,sent,rejected,expired_approved,expired_rejected"`
+	HITLStatus     string   `json:"hitl_status,omitempty" enum:"pending_review,sent,review_rejected,review_expired_approved,review_expired_rejected"`
 	WebhookStatus  string   `json:"webhook_status,omitempty"`
 	WebhookError   string   `json:"webhook_error,omitempty"`
 	// DeliveryStatus / DeliveryDetail / SentAs are the outbound delivery

--- a/internal/httpapi/messages_parsed_test.go
+++ b/internal/httpapi/messages_parsed_test.go
@@ -58,7 +58,7 @@ func TestMessageViewCarriesWebhookStatusAndSize(t *testing.T) {
 // second representation the unified read serves (sent/inbound use raw_message).
 func TestMessageViewHeldDraftBody(t *testing.T) {
 	draft := messageViewFromIdentity(&identity.Message{
-		ID: "msg_d", Direction: "outbound", Status: "pending_approval",
+		ID: "msg_d", Direction: "outbound", Status: "pending_review",
 		BodyText: "draft text", BodyHTML: "<p>draft</p>",
 	})
 	if draft.Body == nil || draft.Body.Text != "draft text" || draft.Body.HTML != "<p>draft</p>" {

--- a/internal/httpapi/operations_test.go
+++ b/internal/httpapi/operations_test.go
@@ -320,7 +320,7 @@ func testServer(t *testing.T) *httptest.Server {
 		},
 		RejectPending: func(ctx context.Context, userID, messageID, expectedAgentEmail, reason string) (*identity.Message, *agent.OutboundError) {
 			if messageID == "msg_pending" {
-				return &identity.Message{ID: "msg_pending", Status: "rejected", RejectionReason: reason}, nil
+				return &identity.Message{ID: "msg_pending", Status: "review_rejected", RejectionReason: reason}, nil
 			}
 			return nil, &agent.OutboundError{Status: http.StatusNotFound, Code: "not_found", Msg: "message not found"}
 		},

--- a/internal/httpapi/outbound.go
+++ b/internal/httpapi/outbound.go
@@ -115,17 +115,17 @@ type sendOutput struct {
 
 func (s *Server) registerOutbound() {
 	// 202 Accepted is the HITL-hold outcome of every outbound op: the message
-	// is queued as a pending_approval draft rather than sent. Declared
+	// is queued as a pending_review draft rather than sent. Declared
 	// explicitly because Huma infers only the single DefaultStatus (200).
 	held202 := func() *huma.Response {
 		return s.jsonResponse(reflect.TypeOf(SendResultView{}), "SendResultView",
-			"Accepted — held for human approval (status=pending_approval).")
+			"Accepted — held for human approval (status=pending_review).")
 	}
 
 	huma.Register(s.API, huma.Operation{
 		OperationID: "sendMessage", Method: http.MethodPost, Path: "/v1/agents/{email}/messages",
 		Summary: "Send a new email", Tags: []string{"messages"},
-		Description:  "Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_approval when the agent has HITL enabled. Honors Idempotency-Key.",
+		Description:  "Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_review when the agent has HITL enabled. Honors Idempotency-Key.",
 		Security:     []map[string][]string{{"bearer": {}}},
 		MaxBodyBytes: maxOutboundBytes,
 		Responses:    map[string]*huma.Response{"202": held202(), "default": s.errorEnvelopeResponse()},

--- a/internal/httpapi/outbound.go
+++ b/internal/httpapi/outbound.go
@@ -43,14 +43,14 @@ func (s *Server) errorEnvelopeResponse() *huma.Response {
 // test (MSG-9). Per scenario:
 //   - sent:  status="sent" + message_id (the e2a msg_ id) + provider_message_id
 //     (SES id) + sent_as + method.
-//   - held:  status="pending_approval" + message_id + approval_expires_at.
+//   - held:  status="pending_review" + message_id + approval_expires_at.
 //   - approved+sent: the "sent" set + edited (reviewer edited the draft).
 //
 // message_id is always the e2a message id (GET-able), never the provider id —
 // the SES id is provider_message_id. `reject` keeps its own RejectResultView
 // (it is not a send).
 type SendResultView struct {
-	Status            string     `json:"status" enum:"sent,pending_approval"`
+	Status            string     `json:"status" enum:"sent,pending_review"`
 	MessageID         string     `json:"message_id"`
 	ProviderMessageID string     `json:"provider_message_id,omitempty"`
 	SentAs            string     `json:"sent_as,omitempty" enum:"own_address,relay"`
@@ -189,7 +189,7 @@ func (s *Server) handleTestSend(ctx context.Context, in *AddressParam) (*sendOut
 		return nil, NewError(derr.Status, derr.Code, derr.Msg)
 	}
 	if res.Held {
-		return &sendOutput{Status: http.StatusAccepted, Body: SendResultView{Status: "pending_approval", MessageID: res.PendingMessageID, ApprovalExpiresAt: res.ApprovalExpiresAt}}, nil
+		return &sendOutput{Status: http.StatusAccepted, Body: SendResultView{Status: "pending_review", MessageID: res.PendingMessageID, ApprovalExpiresAt: res.ApprovalExpiresAt}}, nil
 	}
 	return &sendOutput{Status: http.StatusOK, Body: SendResultView{Status: "sent", MessageID: res.MessageID, ProviderMessageID: res.ProviderMessageID, SentAs: res.SentAs, Method: res.Method}}, nil
 }
@@ -383,7 +383,7 @@ func (s *Server) deliver(ctx context.Context, user *identity.User, ag *identity.
 			return 0, SendResultView{}, NewError(derr.Status, derr.Code, derr.Msg)
 		}
 		if res.Held {
-			return http.StatusAccepted, SendResultView{Status: "pending_approval", MessageID: res.PendingMessageID, ApprovalExpiresAt: res.ApprovalExpiresAt}, nil
+			return http.StatusAccepted, SendResultView{Status: "pending_review", MessageID: res.PendingMessageID, ApprovalExpiresAt: res.ApprovalExpiresAt}, nil
 		}
 		return http.StatusOK, SendResultView{Status: "sent", MessageID: res.MessageID, ProviderMessageID: res.ProviderMessageID, SentAs: res.SentAs, Method: res.Method}, nil
 	})

--- a/internal/httpapi/outbound_test.go
+++ b/internal/httpapi/outbound_test.go
@@ -24,7 +24,7 @@ func TestSendHeldForApproval(t *testing.T) {
 	code, body := postJSON(t, srv.URL+sendURL, "good", map[string]any{
 		"to": []string{"alice@x.com"}, "subject": "HOLD please", "body": "hello",
 	})
-	if code != 202 || body["status"] != "pending_approval" || body["message_id"] != "msg_pending_1" {
+	if code != 202 || body["status"] != "pending_review" || body["message_id"] != "msg_pending_1" {
 		t.Fatalf("want 202 pending_approval, got %d %v", code, body)
 	}
 	if body["approval_expires_at"] == nil {

--- a/internal/httpapi/spec_review_test.go
+++ b/internal/httpapi/spec_review_test.go
@@ -154,9 +154,9 @@ func TestSpecStatusEnums(t *testing.T) {
 	}{
 		{"MessageView", "direction", []string{"inbound", "outbound"}},
 		{"MessageSummaryView", "direction", []string{"inbound", "outbound"}},
-		{"MessageView", "hitl_status", []string{"pending_approval", "sent", "rejected", "expired_approved", "expired_rejected"}},
-		{"MessageSummaryView", "hitl_status", []string{"pending_approval", "sent", "rejected", "expired_approved", "expired_rejected"}},
-		{"SendResultView", "status", []string{"sent", "pending_approval"}},
+		{"MessageView", "hitl_status", []string{"pending_review", "sent", "review_rejected", "review_expired_approved", "review_expired_rejected"}},
+		{"MessageSummaryView", "hitl_status", []string{"pending_review", "sent", "review_rejected", "review_expired_approved", "review_expired_rejected"}},
+		{"SendResultView", "status", []string{"sent", "pending_review"}},
 		{"EventJSON", "status", []string{"pending", "processed", "no_match"}},
 		{"RedeliverView", "status", []string{"pending", "scheduled"}},
 		{"WebhookDeliveryView", "status", []string{"pending", "delivered", "failed"}},

--- a/internal/httpapi/webhooks.go
+++ b/internal/httpapi/webhooks.go
@@ -38,7 +38,7 @@ type WebhookView struct {
 	ID              string             `json:"id"`
 	URL             string             `json:"url"`
 	Description     string             `json:"description"`
-	Events          []string           `json:"events" nullable:"false" enum:"email.received,email.sent,email.pending_approval,email.approval_accepted,email.approval_rejected,domain.sending_verified,domain.sending_failed,email.delivered,email.bounced,email.complained,domain.suppression_added,email.flagged,email.blocked,email.pending_review" doc:"Beta: email.flagged, email.blocked, and email.pending_review (screening dispositions) are unstable — their payload may change before they are declared stable. All other events are stable."`
+	Events          []string           `json:"events" nullable:"false" enum:"email.received,email.sent,email.review_approved,email.review_rejected,domain.sending_verified,domain.sending_failed,email.delivered,email.bounced,email.complained,domain.suppression_added,email.flagged,email.blocked,email.pending_review" doc:"Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable. All other events are stable."`
 	Filters         WebhookFiltersView `json:"filters"`
 	Enabled         bool               `json:"enabled"`
 	AutoDisabledAt  string             `json:"auto_disabled_at,omitempty" format:"date-time"`
@@ -182,7 +182,7 @@ type listWebhooksOutput struct {
 // webhookpub.AllEventTypes).
 type CreateWebhookRequest struct {
 	URL         string              `json:"url"`
-	Events      []string            `json:"events" nullable:"false" enum:"email.received,email.sent,email.pending_approval,email.approval_accepted,email.approval_rejected,domain.sending_verified,domain.sending_failed,email.delivered,email.bounced,email.complained,domain.suppression_added,email.flagged,email.blocked,email.pending_review" doc:"Beta: email.flagged, email.blocked, and email.pending_review (screening dispositions) are unstable — their payload may change before they are declared stable. All other events are stable."`
+	Events      []string            `json:"events" nullable:"false" enum:"email.received,email.sent,email.review_approved,email.review_rejected,domain.sending_verified,domain.sending_failed,email.delivered,email.bounced,email.complained,domain.suppression_added,email.flagged,email.blocked,email.pending_review" doc:"Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable. All other events are stable."`
 	Filters     *WebhookFiltersView `json:"filters,omitempty"`
 	Description string              `json:"description,omitempty"`
 }
@@ -249,7 +249,7 @@ func (s *Server) registerWebhooks() {
 
 // TestWebhookRequest mirrors the legacy body.
 type TestWebhookRequest struct {
-	Event string         `json:"event,omitempty" enum:"email.received,email.sent,email.pending_approval,email.approval_accepted,email.approval_rejected,domain.sending_verified,domain.sending_failed,email.delivered,email.bounced,email.complained,domain.suppression_added,email.flagged,email.blocked,email.pending_review"`
+	Event string         `json:"event,omitempty" enum:"email.received,email.sent,email.review_approved,email.review_rejected,domain.sending_verified,domain.sending_failed,email.delivered,email.bounced,email.complained,domain.suppression_added,email.flagged,email.blocked,email.pending_review"`
 	Data  map[string]any `json:"data,omitempty"`
 }
 type testWebhookInput struct {
@@ -306,7 +306,7 @@ func (s *Server) handleTestWebhook(ctx context.Context, in *testWebhookInput) (*
 // WebhookDeliveryView mirrors the legacy per-delivery wire shape.
 type WebhookDeliveryView struct {
 	ID             string `json:"id"`
-	EventType      string `json:"event_type" enum:"email.received,email.sent,email.pending_approval,email.approval_accepted,email.approval_rejected,domain.sending_verified,domain.sending_failed,email.delivered,email.bounced,email.complained,domain.suppression_added,email.flagged,email.blocked,email.pending_review"`
+	EventType      string `json:"event_type" enum:"email.received,email.sent,email.review_approved,email.review_rejected,domain.sending_verified,domain.sending_failed,email.delivered,email.bounced,email.complained,domain.suppression_added,email.flagged,email.blocked,email.pending_review"`
 	Status         string `json:"status" enum:"pending,delivered,failed"`
 	Attempts       int    `json:"attempts"`
 	LastError      string `json:"last_error,omitempty"`
@@ -369,7 +369,7 @@ func (s *Server) handleListWebhookDeliveries(ctx context.Context, in *ListDelive
 // absent != zero; url/events/filters are full-replace when present.
 type UpdateWebhookRequest struct {
 	URL         *string             `json:"url,omitempty"`
-	Events      *[]string           `json:"events,omitempty" enum:"email.received,email.sent,email.pending_approval,email.approval_accepted,email.approval_rejected,domain.sending_verified,domain.sending_failed,email.delivered,email.bounced,email.complained,domain.suppression_added,email.flagged,email.blocked,email.pending_review" doc:"Beta: email.flagged, email.blocked, and email.pending_review (screening dispositions) are unstable — their payload may change before they are declared stable. All other events are stable."`
+	Events      *[]string           `json:"events,omitempty" enum:"email.received,email.sent,email.review_approved,email.review_rejected,domain.sending_verified,domain.sending_failed,email.delivered,email.bounced,email.complained,domain.suppression_added,email.flagged,email.blocked,email.pending_review" doc:"Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable. All other events are stable."`
 	Filters     *WebhookFiltersView `json:"filters,omitempty"`
 	Description *string             `json:"description,omitempty"`
 	Enabled     *bool               `json:"enabled,omitempty"`

--- a/internal/identity/hitl_approve_test.go
+++ b/internal/identity/hitl_approve_test.go
@@ -62,7 +62,7 @@ func TestGetOutboundMessageForUser(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetOutboundMessageForUser: %v", err)
 	}
-	if got.Status != identity.MessageStatusPendingApproval {
+	if got.Status != identity.MessageStatusPendingReview {
 		t.Errorf("Status = %q", got.Status)
 	}
 	if got.Subject != "Draft" {
@@ -462,7 +462,7 @@ func TestApproveAndSendSendFailureRollsBack(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if status != identity.MessageStatusPendingApproval {
+	if status != identity.MessageStatusPendingReview {
 		t.Errorf("status = %q, want still pending_approval after send failure", status)
 	}
 	if bodyText == nil || *bodyText != "body" {
@@ -705,7 +705,7 @@ func TestRejectPendingHappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RejectPending: %v", err)
 	}
-	if got.Status != identity.MessageStatusRejected {
+	if got.Status != identity.MessageStatusReviewRejected {
 		t.Errorf("Status = %q", got.Status)
 	}
 	if got.RejectionReason != "inappropriate tone" {

--- a/internal/identity/hitl_expire_test.go
+++ b/internal/identity/hitl_expire_test.go
@@ -139,7 +139,7 @@ func TestExpireApproveAndSendHappyPath(t *testing.T) {
 	if sentSubject != "Held" {
 		t.Errorf("send got subject %q", sentSubject)
 	}
-	if sent.Status != identity.MessageStatusExpiredApproved {
+	if sent.Status != identity.MessageStatusReviewExpiredApproved {
 		t.Errorf("status = %q", sent.Status)
 	}
 
@@ -151,7 +151,7 @@ func TestExpireApproveAndSendHappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if dbStatus != identity.MessageStatusExpiredApproved {
+	if dbStatus != identity.MessageStatusReviewExpiredApproved {
 		t.Errorf("db status = %q", dbStatus)
 	}
 	if dbBodyText != nil {
@@ -232,7 +232,7 @@ func TestExpireApproveAndSendSendFailureRollsBack(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if status != identity.MessageStatusPendingApproval {
+	if status != identity.MessageStatusPendingReview {
 		t.Errorf("status = %q, want still pending after send failure", status)
 	}
 	if bodyText == nil || *bodyText != "body" {
@@ -258,7 +258,7 @@ func TestExpireRejectHappyPath(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ExpireReject: %v", err)
 	}
-	if got.Status != identity.MessageStatusExpiredRejected {
+	if got.Status != identity.MessageStatusReviewExpiredRejected {
 		t.Errorf("status = %q", got.Status)
 	}
 	if got.RejectionReason != "ttl_expired" {

--- a/internal/identity/hitl_test.go
+++ b/internal/identity/hitl_test.go
@@ -260,8 +260,8 @@ func TestCreatePendingOutboundMessage(t *testing.T) {
 	after := time.Now()
 
 	// In-memory shape
-	if msg.Status != identity.MessageStatusPendingApproval {
-		t.Errorf("Status = %q, want %q", msg.Status, identity.MessageStatusPendingApproval)
+	if msg.Status != identity.MessageStatusPendingReview {
+		t.Errorf("Status = %q, want %q", msg.Status, identity.MessageStatusPendingReview)
 	}
 	if msg.Direction != "outbound" {
 		t.Errorf("Direction = %q, want outbound", msg.Direction)
@@ -314,8 +314,8 @@ func TestCreatePendingOutboundMessage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read back pending row: %v", err)
 	}
-	if dbStatus != identity.MessageStatusPendingApproval {
-		t.Errorf("db status = %q, want %q", dbStatus, identity.MessageStatusPendingApproval)
+	if dbStatus != identity.MessageStatusPendingReview {
+		t.Errorf("db status = %q, want %q", dbStatus, identity.MessageStatusPendingReview)
 	}
 	if dbSubject != "Draft subject" {
 		t.Errorf("db subject = %q", dbSubject)
@@ -450,23 +450,36 @@ func TestMessageStatusDBCheck(t *testing.T) {
 
 // TestPendingApprovalIndex verifies the partial index created by migration 003
 // actually exists; this is a cheap sanity check that migrations applied cleanly.
-func TestPendingApprovalIndex(t *testing.T) {
+func TestPendingReviewIndex(t *testing.T) {
 	pool := testutil.TestDB(t)
 	ctx := context.Background()
 
+	// After the hold unification (migration 044) the outbound pending-sweep index is
+	// folded into idx_messages_pending_review, which spans both directions.
 	var exists bool
 	err := pool.QueryRow(ctx,
 		`SELECT EXISTS (
 		   SELECT 1 FROM pg_indexes
 		   WHERE schemaname = 'public'
 		     AND tablename = 'messages'
-		     AND indexname = 'idx_messages_pending_approval'
+		     AND indexname = 'idx_messages_pending_review'
 		 )`,
 	).Scan(&exists)
 	if err != nil {
 		t.Fatalf("pg_indexes lookup: %v", err)
 	}
 	if !exists {
-		t.Error("idx_messages_pending_approval not found — migration 003 may not have applied")
+		t.Error("idx_messages_pending_review not found — migration 040/044 may not have applied")
+	}
+
+	// The retired outbound index must be gone (migration 044 dropped it).
+	var oldExists bool
+	if err := pool.QueryRow(ctx,
+		`SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'idx_messages_pending_approval')`,
+	).Scan(&oldExists); err != nil {
+		t.Fatalf("pg_indexes lookup (old): %v", err)
+	}
+	if oldExists {
+		t.Error("idx_messages_pending_approval still present — migration 044 should have dropped it")
 	}
 }

--- a/internal/identity/review.go
+++ b/internal/identity/review.go
@@ -28,7 +28,7 @@ func (s *Store) ListExpiredReviews(ctx context.Context, limit int) ([]Expiration
 		`SELECT m.id, m.agent_id, a.hitl_expiration_action
 		 FROM messages m
 		 JOIN agent_identities a ON a.id = m.agent_id
-		 WHERE m.status = 'pending_review'
+		 WHERE m.status = 'pending_review' AND m.direction = 'inbound'
 		   AND m.approval_expires_at < now()
 		 ORDER BY m.approval_expires_at ASC
 		 LIMIT $1`, limit,

--- a/internal/identity/send_attempts_test.go
+++ b/internal/identity/send_attempts_test.go
@@ -207,7 +207,7 @@ func TestApproveAndSend_TxRollbackRetry_DoesNotCallSendTwice(t *testing.T) {
 	// with the provider id cleared.
 	if _, err := pool.Exec(ctx,
 		`UPDATE messages
-		    SET status = 'pending_approval',
+		    SET status = 'pending_review',
 		        provider_message_id = '',
 		        reviewed_at = NULL,
 		        reviewed_by_user_id = NULL,
@@ -264,7 +264,7 @@ func TestApproveAndSend_SendErrorMarksFailedAndAllowsRetry(t *testing.T) {
 	if err := pool.QueryRow(ctx, `SELECT status FROM messages WHERE id = $1`, msg.ID).Scan(&status); err != nil {
 		t.Fatalf("read status: %v", err)
 	}
-	if status != identity.MessageStatusPendingApproval {
+	if status != identity.MessageStatusPendingReview {
 		t.Errorf("messages.status = %q, want pending_approval", status)
 	}
 
@@ -336,7 +336,7 @@ func TestExpireApproveAndSend_TxRollbackRetry_DoesNotCallSendTwice(t *testing.T)
 	// re-aged so the next poll still matches.
 	if _, err := pool.Exec(ctx,
 		`UPDATE messages
-		    SET status              = 'pending_approval',
+		    SET status              = 'pending_review',
 		        provider_message_id = '',
 		        reviewed_at         = NULL,
 		        body_text           = 'body',
@@ -361,7 +361,7 @@ func TestExpireApproveAndSend_TxRollbackRetry_DoesNotCallSendTwice(t *testing.T)
 	if second.ProviderMessageID != "<ses-exp-orig@amazonses.com>" {
 		t.Errorf("retry returned ProviderMessageID = %q, want the cached <ses-exp-orig@amazonses.com>", second.ProviderMessageID)
 	}
-	if second.Status != identity.MessageStatusExpiredApproved {
+	if second.Status != identity.MessageStatusReviewExpiredApproved {
 		t.Errorf("retry returned status = %q, want expired_approved", second.Status)
 	}
 }

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -257,7 +257,7 @@ type Message struct {
 	Labels []string `json:"labels,omitempty"`
 
 	// HITL approval fields. Status defaults to 'sent'; body and attachments
-	// are populated only while a message is in 'pending_approval', and are
+	// are populated only while a message is in 'pending_review', and are
 	// scrubbed on any terminal transition.
 	Status            string     `json:"status,omitempty"`
 	ApprovalExpiresAt *time.Time `json:"approval_expires_at,omitempty"`
@@ -297,18 +297,15 @@ type Message struct {
 	ScanAction   string   `json:"scan_action,omitempty"`
 }
 
-// Message status values mirror the CHECK constraint in migration 003_hitl.sql.
+// Message status values mirror the CHECK constraint in migration 044_unify_holds.sql.
 const (
-	MessageStatusSent            = "sent"
-	MessageStatusPendingApproval = "pending_approval"
-	MessageStatusRejected        = "rejected"
-	MessageStatusExpiredApproved = "expired_approved"
-	MessageStatusExpiredRejected = "expired_rejected"
+	MessageStatusSent = "sent"
 
-	// Inbound/screening review-hold statuses (migration 037 / Slice 2): the
-	// direction-aware analogue of the outbound pending_approval lifecycle. On
-	// release, approve = deliver to the agent, reject = drop. pending_approval stays
-	// reserved for the explicit user-send-approval (edit-then-approve) flow.
+	// Unified review-hold statuses (direction-aware — design 2026-06-22). A held
+	// message is one primitive regardless of direction; on resolution, approve =
+	// send (outbound) / deliver to the agent (inbound), reject = drop. Outbound's
+	// "approved" terminal is MessageStatusSent (the approve triggers the send), so
+	// there is no separate outbound approved-but-unsent state.
 	MessageStatusPendingReview         = "pending_review"
 	MessageStatusReviewApproved        = "review_approved"
 	MessageStatusReviewRejected        = "review_rejected"
@@ -941,7 +938,7 @@ func (s *Store) ListAgentsByUser(ctx context.Context, userID string) ([]AgentIde
 		           WHERE m.agent_id = a.id AND m.direction = 'outbound'
 		             AND m.created_at > now() - interval '7 days') AS outbound_7d,
 		        (SELECT count(*) FROM messages m
-		           WHERE m.agent_id = a.id AND m.status = 'pending_approval') AS pending_count,
+		           WHERE m.agent_id = a.id AND m.status = 'pending_review' AND m.direction = 'outbound') AS pending_count,
 		        (SELECT max(m.created_at) FROM messages m
 		           WHERE m.agent_id = a.id AND m.direction = 'outbound'
 		             AND m.status = 'sent') AS last_delivery_at,
@@ -1268,7 +1265,7 @@ func (s *Store) CreateOutboundMessage(ctx context.Context, agentID string, toRec
 }
 
 // CreatePendingOutboundMessage stores a fully composed outbound email in
-// pending_approval status, including body_text, body_html, and attachments so
+// pending_review status, including body_text, body_html, and attachments so
 // that approval can reconstruct the original SendRequest (or accept edits)
 // without the caller needing to retain it. ttlSeconds sets how long the
 // message remains pending before the expiration worker resolves it.
@@ -1315,7 +1312,7 @@ func (s *Store) CreatePendingOutboundMessage(ctx context.Context, agentID string
 		ToRecipients:      toRecipients,
 		CC:                cc,
 		BCC:               bcc,
-		Status:            MessageStatusPendingApproval,
+		Status:            MessageStatusPendingReview,
 		ApprovalExpiresAt: &approvalExpiresAt,
 		BodyText:          bodyText,
 		BodyHTML:          bodyHTML,
@@ -1361,7 +1358,7 @@ func nullIfEmptyString(s string) interface{} {
 // --- HITL approval store helpers ---
 
 // ErrNotPendingApproval is returned when an approve or reject operation
-// targets a message that is not (or is no longer) in pending_approval status.
+// targets a message that is not (or is no longer) in pending_review status.
 // Handlers map this to HTTP 409 Conflict.
 var ErrNotPendingApproval = fmt.Errorf("message is not pending approval")
 
@@ -1537,7 +1534,7 @@ func (s *Store) ListPendingOutboundForUser(ctx context.Context, userID string, l
 		        COALESCE(m.delivery_status, ''), COALESCE(m.delivery_detail, ''), COALESCE(m.sent_as, '')
 		 FROM messages m
 		 JOIN agent_identities a ON a.id = m.agent_id
-		 WHERE a.user_id = $1 AND m.status = 'pending_approval'
+		 WHERE a.user_id = $1 AND m.status = 'pending_review' AND m.direction = 'outbound'
 		 ORDER BY m.approval_expires_at ASC
 		 LIMIT $2`, userID, limit,
 	)
@@ -1582,7 +1579,7 @@ type SendResult struct {
 	Raw []byte
 }
 
-// ApproveAndSend finalizes a pending_approval message by running it through
+// ApproveAndSend finalizes a pending_review message by running it through
 // a caller-supplied send function inside a transaction that holds a row lock
 // on the pending row. If send returns an error the transaction rolls back
 // and the message remains pending. On success the row is updated to
@@ -1596,7 +1593,7 @@ type SendResult struct {
 //
 // Ownership is enforced by the agent -> user join. Messages owned by
 // another user return ErrMessageNotFound. Messages whose status is not
-// 'pending_approval' return ErrNotPendingApproval. If another worker is
+// 'pending_review' return ErrNotPendingApproval. If another worker is
 // already mid-send for this message (rare; only possible after the
 // approval row lock was released without status changing — e.g. a
 // pool drop mid-send), this returns ErrSendInProgress.
@@ -1691,7 +1688,7 @@ func (s *Store) ApproveAndSend(
 	if ownerUserID != userID {
 		return nil, ErrMessageNotFound
 	}
-	if m.Status != MessageStatusPendingApproval {
+	if m.Status != MessageStatusPendingReview {
 		return nil, ErrNotPendingApproval
 	}
 	if method != nil {
@@ -1857,7 +1854,7 @@ type ExpirationCandidate struct {
 	ExpirationAction string // 'approve' or 'reject'
 }
 
-// ListExpiredPending returns pending_approval messages whose
+// ListExpiredPending returns pending_review messages whose
 // approval_expires_at is in the past, joined with their agent's
 // hitl_expiration_action. Ordered by approval_expires_at ASC so
 // earliest-expired are handled first.
@@ -1869,7 +1866,7 @@ func (s *Store) ListExpiredPending(ctx context.Context, limit int) ([]Expiration
 		`SELECT m.id, m.agent_id, a.hitl_expiration_action
 		 FROM messages m
 		 JOIN agent_identities a ON a.id = m.agent_id
-		 WHERE m.status = 'pending_approval'
+		 WHERE m.status = 'pending_review' AND m.direction = 'outbound'
 		   AND m.approval_expires_at < now()
 		 ORDER BY m.approval_expires_at ASC
 		 LIMIT $1`, limit,
@@ -1893,7 +1890,7 @@ func (s *Store) ListExpiredPending(ctx context.Context, limit int) ([]Expiration
 // no user ownership check (the caller is the expiration worker, which is
 // system-scoped), SELECT ... FOR NO KEY UPDATE SKIP LOCKED so concurrent
 // workers don't race for the same row, and the terminal status is
-// 'expired_approved' instead of 'sent'. On send failure the transaction
+// 'review_expired_approved' instead of 'sent'. On send failure the transaction
 // rolls back; the worker should then call ExpireReject to move the row
 // to a final state so the row doesn't get picked up on every sweep.
 //
@@ -1958,7 +1955,7 @@ func (s *Store) ExpireApproveAndSend(
 		 FROM messages
 		 WHERE id = $1
 		   AND direction = 'outbound'
-		   AND status = 'pending_approval'
+		   AND status = 'pending_review'
 		   AND approval_expires_at < now()
 		 FOR NO KEY UPDATE SKIP LOCKED`,
 		messageID,
@@ -2043,7 +2040,7 @@ func (s *Store) ExpireApproveAndSend(
 		        attachments_json  = NULL
 		  WHERE id = $1`,
 		messageID,
-		MessageStatusExpiredApproved,
+		MessageStatusReviewExpiredApproved,
 		result.ProviderMessageID,
 		result.Method,
 		result.To,
@@ -2060,7 +2057,7 @@ func (s *Store) ExpireApproveAndSend(
 	}
 	committed = true
 
-	m.Status = MessageStatusExpiredApproved
+	m.Status = MessageStatusReviewExpiredApproved
 	m.ProviderMessageID = result.ProviderMessageID
 	m.Method = result.Method
 	m.ToRecipients = result.To
@@ -2077,7 +2074,7 @@ func (s *Store) ExpireApproveAndSend(
 	return &m, nil
 }
 
-// ExpireReject transitions a pending_approval message to expired_rejected
+// ExpireReject transitions a pending_review message to review_expired_rejected
 // and scrubs body columns. No user ownership check — this is the worker
 // path. If the row is no longer pending (racing worker, already handled)
 // returns ErrNotPendingApproval; caller can treat as a no-op.
@@ -2090,8 +2087,8 @@ func (s *Store) ExpireReject(ctx context.Context, messageID, reason string) (*Me
 		        body_text = NULL,
 		        body_html = NULL,
 		        attachments_json = NULL
-		  WHERE id = $1 AND status = 'pending_approval'`,
-		messageID, MessageStatusExpiredRejected, reason,
+		  WHERE id = $1 AND status = 'pending_review' AND direction = 'outbound'`,
+		messageID, MessageStatusReviewExpiredRejected, reason,
 	)
 	if err != nil {
 		return nil, err
@@ -2140,7 +2137,7 @@ func (s *Store) ExpireReject(ctx context.Context, messageID, reason string) (*Me
 	return m, nil
 }
 
-// RejectPending transitions a pending_approval message to rejected,
+// RejectPending transitions a pending_review message to rejected,
 // records the reviewer's reason (empty string allowed), and scrubs
 // body_text / body_html / attachments_json. Ownership checked; missing
 // rows return ErrMessageNotFound. Non-pending rows return ErrNotPendingApproval.
@@ -2158,9 +2155,10 @@ func (s *Store) RejectPending(ctx context.Context, messageID, userID, reason str
 		        body_html = NULL,
 		        attachments_json = NULL
 		  WHERE id = $1
-		    AND status = 'pending_approval'
+		    AND status = 'pending_review'
+		    AND direction = 'outbound'
 		    AND agent_id IN (SELECT id FROM agent_identities WHERE user_id = $2)`,
-		messageID, userID, MessageStatusRejected, reason,
+		messageID, userID, MessageStatusReviewRejected, reason,
 	)
 	if err != nil {
 		return nil, err
@@ -2312,7 +2310,7 @@ func (s *Store) GetMessagesByAgent(ctx context.Context, f MessageListFilter) ([]
 	// (blocked / human-rejected), and review_expired_rejected (TTL-dropped) stay
 	// hidden; review_approved / review_expired_approved (and plain 'sent') are
 	// delivered and shown. The clause is direction-aware so outbound rows
-	// (pending_approval etc.) are unaffected.
+	// (pending_review etc.) are unaffected.
 	switch f.Direction {
 	case "outbound":
 		// no inbound rows in the result set
@@ -2638,7 +2636,7 @@ func (s *Store) LookupConversationID(ctx context.Context, agentID string, messag
 // an inbox-style conversation list without a per-row drill-down.
 //
 // HasUnread is true iff at least one INBOUND member is in
-// inbox_status='unread'. Outbound pending_approval doesn't count —
+// inbox_status='unread'. Outbound pending_review doesn't count —
 // the conversation list is the agent's mailbox view, not the
 // reviewer's HITL queue.
 type ConversationSummary struct {
@@ -3143,7 +3141,7 @@ func (s *Store) GetDashboardStats(ctx context.Context, userID string, windowDays
 
 	// 2) Pending HITL approvals across the user's agents. Joining via
 	// the agent_id keeps the per-user partial index on messages
-	// (idx_messages_pending_approval) usable.
+	// (idx_messages_pending_review) usable.
 	var pendingCount int
 	var oldestSec *int
 	err = s.pool.QueryRow(ctx,
@@ -3153,7 +3151,7 @@ func (s *Store) GetDashboardStats(ctx context.Context, userID string, windowDays
 		        END
 		 FROM messages m
 		 JOIN agent_identities a ON a.id = m.agent_id
-		 WHERE a.user_id = $1 AND m.status = 'pending_approval'`,
+		 WHERE a.user_id = $1 AND m.status = 'pending_review' AND m.direction = 'outbound'`,
 		userID).Scan(&pendingCount, &oldestSec)
 	if err != nil {
 		return nil, fmt.Errorf("pending count: %w", err)

--- a/internal/webhookpub/event.go
+++ b/internal/webhookpub/event.go
@@ -28,14 +28,17 @@ import (
 // means typos at trigger sites fail at compile time. The handler-layer
 // allowlist of accepted event names mirrors this list.
 const (
-	EventEmailReceived        = "email.received"
-	EventEmailSent            = "email.sent"
-	EventEmailPendingApproval = "email.pending_approval"
-	// HITL decision events (EV-1): symmetric, unambiguous names so neither is
-	// confused with delivery/recipient rejection (email.bounced) or inbound
-	// policy flagging (email.flagged).
-	EventEmailApproved = "email.approval_accepted"
-	EventEmailRejected = "email.approval_rejected"
+	EventEmailReceived = "email.received"
+	EventEmailSent     = "email.sent"
+	// Review-hold lifecycle (unified, direction-aware — design 2026-06-22). A held
+	// message fires email.pending_review (defined below); on resolution it fires
+	// email.review_approved (outbound: sent; inbound: released to the agent) or
+	// email.review_rejected. These replace the outbound-only pending_approval /
+	// approval_accepted / approval_rejected — outbound holds now fire the same
+	// direction-aware review events as inbound, distinguished by the `direction`
+	// field in the payload.
+	EventEmailReviewApproved = "email.review_approved"
+	EventEmailReviewRejected = "email.review_rejected"
 	// Sender identity (decision 4 / Slice 4): the async SES sending identity
 	// for a domain reached a terminal state. Lets agents skip polling
 	// GET /domains/{domain} for sending_status.
@@ -74,9 +77,8 @@ const (
 var AllEventTypes = []string{
 	EventEmailReceived,
 	EventEmailSent,
-	EventEmailPendingApproval,
-	EventEmailApproved,
-	EventEmailRejected,
+	EventEmailReviewApproved,
+	EventEmailReviewRejected,
 	EventDomainSendingVerified,
 	EventDomainSendingFailed,
 	EventEmailDelivered,

--- a/mcp/src/client.ts
+++ b/mcp/src/client.ts
@@ -29,12 +29,11 @@ import type {
 import type { McpConfig } from "./config.js";
 import type { Scope } from "./tools/tiers.js";
 
-// Outbound drafts held for human approval surface in the message list
-// with this status (see api/openapi.yaml listMessages: "Held outbound
-// drafts appear as status=pending_approval"). There is no dedicated
-// status query param for them, so HITL listing filters outbound rows
-// on this value.
-export const PENDING_APPROVAL_STATUS = "pending_approval";
+// Outbound drafts held for human review surface in the message list with
+// this status (the hold vocabulary was unified on `pending_review` across
+// both directions — see api/openapi.yaml). There is no dedicated status
+// query param for them, so HITL listing filters outbound rows on this value.
+export const PENDING_REVIEW_STATUS = "pending_review";
 
 const DEFAULT_LIST_LIMIT = 1000;
 
@@ -265,7 +264,7 @@ export class McpClient {
 
   // ── HITL (pending outbound) ─────────────────────────────────────
 
-  // Pending drafts surface as outbound messages with status=pending_approval.
+  // Pending drafts surface as outbound messages with status=pending_review.
   // There is no dedicated "pending" status filter, so we list outbound and
   // filter on the status field. Searches across every owned agent when no
   // default address is pinned so the queue is visible without a default.
@@ -281,7 +280,7 @@ export class McpClient {
       for (const r of rows) {
         // Held drafts carry the HITL lifecycle in hitl_status (read_status is
         // the inbox read-state, "" for outbound). MSG-1.
-        if (r.hitlStatus === PENDING_APPROVAL_STATUS) out.push(r);
+        if (r.hitlStatus === PENDING_REVIEW_STATUS) out.push(r);
       }
     }
     return out;

--- a/mcp/src/tools/events.ts
+++ b/mcp/src/tools/events.ts
@@ -25,7 +25,7 @@ export function registerEventTools(server: McpServer, client: McpClient): void {
           .string()
           .optional()
           .describe(
-            "Exact event type filter. Valid values: `email.received`, `email.sent`, `email.pending_approval`, `email.approval_accepted`, `email.approval_rejected`, `email.delivered`, `email.bounced`, `email.complained`, `email.flagged`, `domain.sending_verified`, `domain.sending_failed`, `domain.suppression_added`.",
+            "Exact event type filter. Valid values: `email.received`, `email.sent`, `email.pending_review`, `email.review_approved`, `email.review_rejected`, `email.blocked`, `email.delivered`, `email.bounced`, `email.complained`, `email.flagged`, `domain.sending_verified`, `domain.sending_failed`, `domain.suppression_added`.",
           ),
         agent_id: z.string().optional(),
         conversation_id: z.string().optional(),

--- a/mcp/src/tools/hitl.ts
+++ b/mcp/src/tools/hitl.ts
@@ -11,7 +11,7 @@ export function registerHitlTools(server: McpServer, client: McpClient): void {
       title: "List outbound messages awaiting approval",
       annotations: { readOnlyHint: true },
       description:
-        "Use when the user asks what's awaiting approval, or after a `send_message`/`reply_to_message` returned `pending_approval` and they want to see the queue. Lists held outbound messages from HITL-enabled agents sorted by soonest-expiring first. Body content is summary-only — call `get_pending_message` for the full draft of one. Read-only; cheap, but don't poll it on a loop.",
+        "Use when the user asks what's awaiting approval, or after a `send_message`/`reply_to_message` returned `pending_review` and they want to see the queue. Lists held outbound messages from HITL-enabled agents sorted by soonest-expiring first. Body content is summary-only — call `get_pending_message` for the full draft of one. Read-only; cheap, but don't poll it on a loop.",
       inputSchema: strictInputSchema({}),
     },
     async () => runTool(async () => ({ messages: await client.listPendingMessages() })),
@@ -23,7 +23,7 @@ export function registerHitlTools(server: McpServer, client: McpClient): void {
       title: "Get a pending-approval message",
       annotations: { readOnlyHint: true },
       description:
-        "Fetch the full draft (subject, recipients, body, attachments) of one outbound message awaiting human approval. Body content is only present while the message is `pending_approval` — after a terminal transition the server scrubs it.",
+        "Fetch the full draft (subject, recipients, body, attachments) of one outbound message awaiting human approval. Body content is only present while the message is `pending_review` — after a terminal transition the server scrubs it.",
       inputSchema: strictInputSchema({
         message_id: z.string().describe("The pending message ID (msg_…)."),
       }),

--- a/mcp/src/tools/messages.ts
+++ b/mcp/src/tools/messages.ts
@@ -24,7 +24,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
       title: "Send email",
       annotations: { destructiveHint: false },
       description:
-        "Use when starting a NEW email thread to a fresh recipient. To respond to a message you can see in `list_messages`, use `reply_to_message` instead — it preserves the In-Reply-To / References headers so the reply lands in the same thread, which this tool deliberately does not do. Attach files via `attachments`; pass base64 strings produced by other tools (e.g. `get_attachment`) verbatim — don't hand-encode raw text. **`pending_approval` is not failure.** If the agent has HITL enabled, the response is `{ status: \"pending_approval\", message_id: ... }`; the message is held for human review — do not retry. Check on it with `list_messages` (held drafts show hitl_status=pending_approval) / `get_message`.",
+        "Use when starting a NEW email thread to a fresh recipient. To respond to a message you can see in `list_messages`, use `reply_to_message` instead — it preserves the In-Reply-To / References headers so the reply lands in the same thread, which this tool deliberately does not do. Attach files via `attachments`; pass base64 strings produced by other tools (e.g. `get_attachment`) verbatim — don't hand-encode raw text. **`pending_review` is not failure.** If the agent has HITL enabled, the response is `{ status: \"pending_review\", message_id: ... }`; the message is held for human review — do not retry. Check on it with `list_messages` (held drafts show hitl_status=pending_review) / `get_message`.",
       inputSchema: strictInputSchema({
         to: z.array(z.string()).describe("Recipient email addresses (one or more)."),
         subject: z.string(),
@@ -84,7 +84,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
       title: "Reply to a received message",
       annotations: { destructiveHint: false },
       description:
-        "Use whenever you're responding to a message you can see in the inbox — preserves the In-Reply-To and References headers so the reply joins the original email thread instead of starting a new one. Prefer this over `send_message` for any response to an inbound; thread fragmentation (broken conversation view in the recipient's mail client) is the most visible symptom of using `send_message` by mistake. Pass `reply_all: true` to copy the original Cc list; subject is auto-derived as `Re: …` by the server. Same HITL caveat as `send_message`: a `pending_approval` status is success, not failure.",
+        "Use whenever you're responding to a message you can see in the inbox — preserves the In-Reply-To and References headers so the reply joins the original email thread instead of starting a new one. Prefer this over `send_message` for any response to an inbound; thread fragmentation (broken conversation view in the recipient's mail client) is the most visible symptom of using `send_message` by mistake. Pass `reply_all: true` to copy the original Cc list; subject is auto-derived as `Re: …` by the server. Same HITL caveat as `send_message`: a `pending_review` status is success, not failure.",
       inputSchema: strictInputSchema({
         message_id: z.string().describe("ID of the inbound message to reply to (e.g. msg_…)."),
         body: z.string().describe("Plain-text reply body."),
@@ -139,7 +139,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
       title: "Forward an inbound message",
       annotations: { destructiveHint: false },
       description:
-        "Forward a message the agent has received to one or more new recipients. The server auto-prepends a Gmail-style header block (From/Date/Subject/To/Cc) and the original body to whatever optional comment you pass in `body`/`html_body`. **Unlike `reply_to_message`, a forward is a NEW thread** — no In-Reply-To / References headers are emitted, so the recipient sees a fresh conversation. Use this when the user asks to share a received email with someone else; use `reply_to_message` when continuing the existing conversation. Same HITL behavior as send/reply: `pending_approval` is success, not failure.",
+        "Forward a message the agent has received to one or more new recipients. The server auto-prepends a Gmail-style header block (From/Date/Subject/To/Cc) and the original body to whatever optional comment you pass in `body`/`html_body`. **Unlike `reply_to_message`, a forward is a NEW thread** — no In-Reply-To / References headers are emitted, so the recipient sees a fresh conversation. Use this when the user asks to share a received email with someone else; use `reply_to_message` when continuing the existing conversation. Same HITL behavior as send/reply: `pending_review` is success, not failure.",
       inputSchema: strictInputSchema({
         message_id: z.string().describe("ID of the inbound message to forward (e.g. msg_…)."),
         to: z.array(z.string()).describe("Forward target addresses (one or more)."),

--- a/mcp/src/tools/webhooks.ts
+++ b/mcp/src/tools/webhooks.ts
@@ -82,7 +82,7 @@ export function registerWebhookTools(server: McpServer, client: McpClient): void
           .array(z.string().min(1))
           .min(1)
           .describe(
-            "Event types to subscribe to. Valid values: email.received, email.sent, email.pending_approval, email.approval_accepted, email.approval_rejected, email.delivered, email.bounced, email.complained, email.flagged, domain.sending_verified, domain.sending_failed, domain.suppression_added.",
+            "Event types to subscribe to. Valid values: email.received, email.sent, email.pending_review, email.review_approved, email.review_rejected, email.blocked, email.delivered, email.bounced, email.complained, email.flagged, domain.sending_verified, domain.sending_failed, domain.suppression_added.",
           ),
         description: z.string().optional().describe("Optional free-form label (max 200 chars)."),
         filters: filtersSchema.optional(),

--- a/mcp/tests/http.test.ts
+++ b/mcp/tests/http.test.ts
@@ -21,7 +21,7 @@ function makeStubClient(): McpClient {
     listAgents: vi.fn(async () => []),
     createAgent: vi.fn(async () => ({ email: "x@y", id: "x", domain: "y" })),
     listPendingMessages: vi.fn(async () => []),
-    getPendingMessage: vi.fn(async () => ({ messageId: "p", status: "pending_approval" })),
+    getPendingMessage: vi.fn(async () => ({ messageId: "p", status: "pending_review" })),
     approveMessage: vi.fn(async () => ({ messageId: "x", status: "sent" })),
     rejectMessage: vi.fn(async () => ({ messageId: "x", status: "rejected" })),
   };

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -155,7 +155,7 @@ function makeStubClient(
     listPendingMessages: vi.fn(async () => []),
     getPendingMessage: vi.fn(async (id: string) => ({
       messageId: id,
-      hitlStatus: "pending_approval",
+      hitlStatus: "pending_review",
     })),
     approveMessage: vi.fn(async () => ({ messageId: "msg_x", status: "sent" })),
     rejectMessage: vi.fn(async () => ({ messageId: "msg_x", status: "rejected" })),

--- a/migrations/044_unify_holds.sql
+++ b/migrations/044_unify_holds.sql
@@ -1,0 +1,41 @@
+-- 044_unify_holds.sql
+--
+-- Unify message holds on the `review` vocabulary (design 2026-06-22). The outbound
+-- HITL statuses (migration 003: pending_approval / rejected / expired_approved /
+-- expired_rejected) are folded into the inbound review vocabulary (migration 040:
+-- pending_review / review_rejected / review_expired_approved / review_expired_rejected)
+-- so a held message is one direction-aware primitive. Outbound's "approved" terminal
+-- stays `sent` (the approve triggers the send; there is no approved-but-unsent state).
+--
+-- Idempotent + non-destructive on the prod-sized messages table:
+--   1. Backfill is scoped to the four retiring outbound statuses (a tiny, ≤10-day-TTL
+--      slice) and is allowed under the existing 040 CHECK (which already permits the
+--      review_* targets), so it runs before the constraint swap with no gap.
+--   2. The CHECK is added NOT VALID then VALIDATE'd separately, so the validating scan
+--      takes only SHARE UPDATE EXCLUSIVE (does not block reads/writes) — avoids the
+--      long ACCESS EXCLUSIVE lock a plain ADD CONSTRAINT would take on `messages`.
+
+-- 1. Backfill the retiring outbound statuses onto the review vocabulary.
+UPDATE messages SET status = CASE status
+        WHEN 'pending_approval'  THEN 'pending_review'
+        WHEN 'rejected'          THEN 'review_rejected'
+        WHEN 'expired_approved'  THEN 'review_expired_approved'
+        WHEN 'expired_rejected'  THEN 'review_expired_rejected'
+    END
+    WHERE status IN ('pending_approval', 'rejected', 'expired_approved', 'expired_rejected');
+
+-- 2. Swap the CHECK to the unified set (drop the four retired outbound values).
+ALTER TABLE messages DROP CONSTRAINT IF EXISTS messages_status_check;
+DO $$ BEGIN
+    ALTER TABLE messages ADD CONSTRAINT messages_status_check
+        CHECK (status IN (
+            'sent',
+            'pending_review', 'review_approved', 'review_rejected',
+            'review_expired_approved', 'review_expired_rejected'
+        )) NOT VALID;
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+ALTER TABLE messages VALIDATE CONSTRAINT messages_status_check;
+
+-- 3. The outbound pending-sweep index is now covered by idx_messages_pending_review
+--    (status='pending_review' spans both directions); drop the stale outbound index.
+DROP INDEX IF EXISTS idx_messages_pending_approval;

--- a/migrations/044_unify_holds.sql
+++ b/migrations/044_unify_holds.sql
@@ -7,13 +7,17 @@
 -- so a held message is one direction-aware primitive. Outbound's "approved" terminal
 -- stays `sent` (the approve triggers the send; there is no approved-but-unsent state).
 --
--- Idempotent + non-destructive on the prod-sized messages table:
+-- Idempotent + non-destructive:
 --   1. Backfill is scoped to the four retiring outbound statuses (a tiny, ≤10-day-TTL
 --      slice) and is allowed under the existing 040 CHECK (which already permits the
 --      review_* targets), so it runs before the constraint swap with no gap.
---   2. The CHECK is added NOT VALID then VALIDATE'd separately, so the validating scan
---      takes only SHARE UPDATE EXCLUSIVE (does not block reads/writes) — avoids the
---      long ACCESS EXCLUSIVE lock a plain ADD CONSTRAINT would take on `messages`.
+--   2. ADD CONSTRAINT takes ACCESS EXCLUSIVE on `messages` for the validation scan.
+--      The migration runner wraps each file in one transaction, so a NOT VALID +
+--      separate VALIDATE split would NOT reduce that (the lock is held across both in
+--      one txn) — it is omitted here. The lock is bounded by the 10-day message TTL,
+--      which keeps the table (hence the scan) small. If `messages` ever outgrows that
+--      bound, split this into single-statement `-- e2a:no-transaction` migrations to
+--      validate lock-free.
 
 -- 1. Backfill the retiring outbound statuses onto the review vocabulary.
 UPDATE messages SET status = CASE status
@@ -32,9 +36,8 @@ DO $$ BEGIN
             'sent',
             'pending_review', 'review_approved', 'review_rejected',
             'review_expired_approved', 'review_expired_rejected'
-        )) NOT VALID;
+        ));
 EXCEPTION WHEN duplicate_object THEN NULL; END $$;
-ALTER TABLE messages VALIDATE CONSTRAINT messages_status_check;
 
 -- 3. The outbound pending-sweep index is now covered by idx_messages_pending_review
 --    (status='pending_review' spans both directions); drop the stale outbound index.

--- a/sdks/python/src/e2a/v1/generated/api/messages_api.py
+++ b/sdks/python/src/e2a/v1/generated/api/messages_api.py
@@ -72,7 +72,7 @@ class MessagesApi:
     ) -> SendResultView:
         """Approve a held message
 
-        Approve a pending_approval draft (with optional reviewer overrides) and send it. Honors Idempotency-Key (the approve triggers an SES send).
+        Approve a pending_review draft (with optional reviewer overrides) and send it. Honors Idempotency-Key (the approve triggers an SES send).
 
         :param email: (required)
         :type email: str
@@ -151,7 +151,7 @@ class MessagesApi:
     ) -> ApiResponse[SendResultView]:
         """Approve a held message
 
-        Approve a pending_approval draft (with optional reviewer overrides) and send it. Honors Idempotency-Key (the approve triggers an SES send).
+        Approve a pending_review draft (with optional reviewer overrides) and send it. Honors Idempotency-Key (the approve triggers an SES send).
 
         :param email: (required)
         :type email: str
@@ -230,7 +230,7 @@ class MessagesApi:
     ) -> RESTResponseType:
         """Approve a held message
 
-        Approve a pending_approval draft (with optional reviewer overrides) and send it. Honors Idempotency-Key (the approve triggers an SES send).
+        Approve a pending_review draft (with optional reviewer overrides) and send it. Honors Idempotency-Key (the approve triggers an SES send).
 
         :param email: (required)
         :type email: str
@@ -1307,7 +1307,7 @@ class MessagesApi:
     ) -> PageMessageSummaryView:
         """List messages
 
-        List an agent's messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_approval.
+        List an agent's messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review.
 
         :param email: (required)
         :type email: str
@@ -1418,7 +1418,7 @@ class MessagesApi:
     ) -> ApiResponse[PageMessageSummaryView]:
         """List messages
 
-        List an agent's messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_approval.
+        List an agent's messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review.
 
         :param email: (required)
         :type email: str
@@ -1529,7 +1529,7 @@ class MessagesApi:
     ) -> RESTResponseType:
         """List messages
 
-        List an agent's messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_approval.
+        List an agent's messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review.
 
         :param email: (required)
         :type email: str
@@ -1747,7 +1747,7 @@ class MessagesApi:
     ) -> RejectResultView:
         """Reject a held message
 
-        Reject a pending_approval draft so it is never sent.
+        Reject a pending_review draft so it is never sent.
 
         :param email: (required)
         :type email: str
@@ -1822,7 +1822,7 @@ class MessagesApi:
     ) -> ApiResponse[RejectResultView]:
         """Reject a held message
 
-        Reject a pending_approval draft so it is never sent.
+        Reject a pending_review draft so it is never sent.
 
         :param email: (required)
         :type email: str
@@ -1897,7 +1897,7 @@ class MessagesApi:
     ) -> RESTResponseType:
         """Reject a held message
 
-        Reject a pending_approval draft so it is never sent.
+        Reject a pending_review draft so it is never sent.
 
         :param email: (required)
         :type email: str
@@ -2374,7 +2374,7 @@ class MessagesApi:
     ) -> SendResultView:
         """Send a new email
 
-        Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_approval when the agent has HITL enabled. Honors Idempotency-Key.
+        Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_review when the agent has HITL enabled. Honors Idempotency-Key.
 
         :param email: (required)
         :type email: str
@@ -2450,7 +2450,7 @@ class MessagesApi:
     ) -> ApiResponse[SendResultView]:
         """Send a new email
 
-        Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_approval when the agent has HITL enabled. Honors Idempotency-Key.
+        Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_review when the agent has HITL enabled. Honors Idempotency-Key.
 
         :param email: (required)
         :type email: str
@@ -2526,7 +2526,7 @@ class MessagesApi:
     ) -> RESTResponseType:
         """Send a new email
 
-        Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_approval when the agent has HITL enabled. Honors Idempotency-Key.
+        Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_review when the agent has HITL enabled. Honors Idempotency-Key.
 
         :param email: (required)
         :type email: str

--- a/sdks/python/src/e2a/v1/generated/models/create_webhook_request.py
+++ b/sdks/python/src/e2a/v1/generated/models/create_webhook_request.py
@@ -28,7 +28,7 @@ class CreateWebhookRequest(BaseModel):
     CreateWebhookRequest
     """ # noqa: E501
     description: Optional[StrictStr] = None
-    events: List[StrictStr] = Field(description="Beta: email.flagged, email.blocked, and email.pending_review (screening dispositions) are unstable — their payload may change before they are declared stable. All other events are stable.")
+    events: List[StrictStr] = Field(description="Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable. All other events are stable.")
     filters: Optional[WebhookFiltersView] = None
     url: StrictStr
     __properties: ClassVar[List[str]] = ["description", "events", "filters", "url"]

--- a/sdks/python/src/e2a/v1/generated/models/create_webhook_response.py
+++ b/sdks/python/src/e2a/v1/generated/models/create_webhook_response.py
@@ -32,7 +32,7 @@ class CreateWebhookResponse(BaseModel):
     created_at: datetime
     description: StrictStr
     enabled: StrictBool
-    events: List[StrictStr] = Field(description="Beta: email.flagged, email.blocked, and email.pending_review (screening dispositions) are unstable — their payload may change before they are declared stable. All other events are stable.")
+    events: List[StrictStr] = Field(description="Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable. All other events are stable.")
     filters: WebhookFiltersView
     id: StrictStr
     last_delivered_at: Optional[datetime] = None

--- a/sdks/python/src/e2a/v1/generated/models/update_webhook_request.py
+++ b/sdks/python/src/e2a/v1/generated/models/update_webhook_request.py
@@ -29,7 +29,7 @@ class UpdateWebhookRequest(BaseModel):
     """ # noqa: E501
     description: Optional[StrictStr] = None
     enabled: Optional[StrictBool] = None
-    events: Optional[List[StrictStr]] = Field(default=None, description="Beta: email.flagged, email.blocked, and email.pending_review (screening dispositions) are unstable — their payload may change before they are declared stable. All other events are stable.")
+    events: Optional[List[StrictStr]] = Field(default=None, description="Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable. All other events are stable.")
     filters: Optional[WebhookFiltersView] = None
     url: Optional[StrictStr] = None
     __properties: ClassVar[List[str]] = ["description", "enabled", "events", "filters", "url"]

--- a/sdks/python/src/e2a/v1/generated/models/webhook_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/webhook_view.py
@@ -32,7 +32,7 @@ class WebhookView(BaseModel):
     created_at: datetime
     description: StrictStr
     enabled: StrictBool
-    events: List[StrictStr] = Field(description="Beta: email.flagged, email.blocked, and email.pending_review (screening dispositions) are unstable — their payload may change before they are declared stable. All other events are stable.")
+    events: List[StrictStr] = Field(description="Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable. All other events are stable.")
     filters: WebhookFiltersView
     id: StrictStr
     last_delivered_at: Optional[datetime] = None

--- a/sdks/typescript/src/v1/generated/apis/MessagesApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/MessagesApi.ts
@@ -28,7 +28,7 @@ import { UpdateMessageResultView } from '../models/UpdateMessageResultView.js';
 export class MessagesApiRequestFactory extends BaseAPIRequestFactory {
 
     /**
-     * Approve a pending_approval draft (with optional reviewer overrides) and send it. Honors Idempotency-Key (the approve triggers an SES send).
+     * Approve a pending_review draft (with optional reviewer overrides) and send it. Honors Idempotency-Key (the approve triggers an SES send).
      * Approve a held message
      * @param email 
      * @param id 
@@ -277,7 +277,7 @@ export class MessagesApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
-     * List an agent\'s messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_approval.
+     * List an agent\'s messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review.
      * List messages
      * @param email 
      * @param direction Defaults to inbound.
@@ -392,7 +392,7 @@ export class MessagesApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
-     * Reject a pending_approval draft so it is never sent.
+     * Reject a pending_review draft so it is never sent.
      * Reject a held message
      * @param email 
      * @param id 
@@ -527,7 +527,7 @@ export class MessagesApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
-     * Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_approval when the agent has HITL enabled. Honors Idempotency-Key.
+     * Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_review when the agent has HITL enabled. Honors Idempotency-Key.
      * Send a new email
      * @param email 
      * @param sendEmailRequest 

--- a/sdks/typescript/src/v1/generated/models/CreateWebhookRequest.ts
+++ b/sdks/typescript/src/v1/generated/models/CreateWebhookRequest.ts
@@ -16,7 +16,7 @@ import { HttpFile } from '../http/http.js';
 export class CreateWebhookRequest {
     'description'?: string;
     /**
-    * Beta: email.flagged, email.blocked, and email.pending_review (screening dispositions) are unstable — their payload may change before they are declared stable. All other events are stable.
+    * Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable. All other events are stable.
     */
     'events': Array<CreateWebhookRequestEventsEnum>;
     'filters'?: WebhookFiltersView;
@@ -63,9 +63,8 @@ export class CreateWebhookRequest {
 export enum CreateWebhookRequestEventsEnum {
     EmailReceived = 'email.received',
     EmailSent = 'email.sent',
-    EmailPendingApproval = 'email.pending_approval',
-    EmailApprovalAccepted = 'email.approval_accepted',
-    EmailApprovalRejected = 'email.approval_rejected',
+    EmailReviewApproved = 'email.review_approved',
+    EmailReviewRejected = 'email.review_rejected',
     DomainSendingVerified = 'domain.sending_verified',
     DomainSendingFailed = 'domain.sending_failed',
     EmailDelivered = 'email.delivered',

--- a/sdks/typescript/src/v1/generated/models/CreateWebhookResponse.ts
+++ b/sdks/typescript/src/v1/generated/models/CreateWebhookResponse.ts
@@ -19,7 +19,7 @@ export class CreateWebhookResponse {
     'description': string;
     'enabled': boolean;
     /**
-    * Beta: email.flagged, email.blocked, and email.pending_review (screening dispositions) are unstable — their payload may change before they are declared stable. All other events are stable.
+    * Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable. All other events are stable.
     */
     'events': Array<CreateWebhookResponseEventsEnum>;
     'filters': WebhookFiltersView;
@@ -105,9 +105,8 @@ export class CreateWebhookResponse {
 export enum CreateWebhookResponseEventsEnum {
     EmailReceived = 'email.received',
     EmailSent = 'email.sent',
-    EmailPendingApproval = 'email.pending_approval',
-    EmailApprovalAccepted = 'email.approval_accepted',
-    EmailApprovalRejected = 'email.approval_rejected',
+    EmailReviewApproved = 'email.review_approved',
+    EmailReviewRejected = 'email.review_rejected',
     DomainSendingVerified = 'domain.sending_verified',
     DomainSendingFailed = 'domain.sending_failed',
     EmailDelivered = 'email.delivered',

--- a/sdks/typescript/src/v1/generated/models/EventJSON.ts
+++ b/sdks/typescript/src/v1/generated/models/EventJSON.ts
@@ -107,9 +107,8 @@ export enum EventJSONStatusEnum {
 export enum EventJSONTypeEnum {
     EmailReceived = 'email.received',
     EmailSent = 'email.sent',
-    EmailPendingApproval = 'email.pending_approval',
-    EmailApprovalAccepted = 'email.approval_accepted',
-    EmailApprovalRejected = 'email.approval_rejected',
+    EmailReviewApproved = 'email.review_approved',
+    EmailReviewRejected = 'email.review_rejected',
     DomainSendingVerified = 'domain.sending_verified',
     DomainSendingFailed = 'domain.sending_failed',
     EmailDelivered = 'email.delivered',

--- a/sdks/typescript/src/v1/generated/models/MessageSummaryView.ts
+++ b/sdks/typescript/src/v1/generated/models/MessageSummaryView.ts
@@ -197,11 +197,11 @@ export enum MessageSummaryViewDirectionEnum {
     Outbound = 'outbound'
 }
 export enum MessageSummaryViewHitlStatusEnum {
-    PendingApproval = 'pending_approval',
+    PendingReview = 'pending_review',
     Sent = 'sent',
-    Rejected = 'rejected',
-    ExpiredApproved = 'expired_approved',
-    ExpiredRejected = 'expired_rejected'
+    ReviewRejected = 'review_rejected',
+    ReviewExpiredApproved = 'review_expired_approved',
+    ReviewExpiredRejected = 'review_expired_rejected'
 }
 export enum MessageSummaryViewSentAsEnum {
     OwnAddress = 'own_address',

--- a/sdks/typescript/src/v1/generated/models/MessageView.ts
+++ b/sdks/typescript/src/v1/generated/models/MessageView.ts
@@ -235,11 +235,11 @@ export enum MessageViewDirectionEnum {
     Outbound = 'outbound'
 }
 export enum MessageViewHitlStatusEnum {
-    PendingApproval = 'pending_approval',
+    PendingReview = 'pending_review',
     Sent = 'sent',
-    Rejected = 'rejected',
-    ExpiredApproved = 'expired_approved',
-    ExpiredRejected = 'expired_rejected'
+    ReviewRejected = 'review_rejected',
+    ReviewExpiredApproved = 'review_expired_approved',
+    ReviewExpiredRejected = 'review_expired_rejected'
 }
 export enum MessageViewSentAsEnum {
     OwnAddress = 'own_address',

--- a/sdks/typescript/src/v1/generated/models/SendResultView.ts
+++ b/sdks/typescript/src/v1/generated/models/SendResultView.ts
@@ -87,6 +87,6 @@ export enum SendResultViewSentAsEnum {
 }
 export enum SendResultViewStatusEnum {
     Sent = 'sent',
-    PendingApproval = 'pending_approval'
+    PendingReview = 'pending_review'
 }
 

--- a/sdks/typescript/src/v1/generated/models/TestWebhookRequest.ts
+++ b/sdks/typescript/src/v1/generated/models/TestWebhookRequest.ts
@@ -45,9 +45,8 @@ export class TestWebhookRequest {
 export enum TestWebhookRequestEventEnum {
     EmailReceived = 'email.received',
     EmailSent = 'email.sent',
-    EmailPendingApproval = 'email.pending_approval',
-    EmailApprovalAccepted = 'email.approval_accepted',
-    EmailApprovalRejected = 'email.approval_rejected',
+    EmailReviewApproved = 'email.review_approved',
+    EmailReviewRejected = 'email.review_rejected',
     DomainSendingVerified = 'domain.sending_verified',
     DomainSendingFailed = 'domain.sending_failed',
     EmailDelivered = 'email.delivered',

--- a/sdks/typescript/src/v1/generated/models/UpdateWebhookRequest.ts
+++ b/sdks/typescript/src/v1/generated/models/UpdateWebhookRequest.ts
@@ -17,7 +17,7 @@ export class UpdateWebhookRequest {
     'description'?: string;
     'enabled'?: boolean;
     /**
-    * Beta: email.flagged, email.blocked, and email.pending_review (screening dispositions) are unstable — their payload may change before they are declared stable. All other events are stable.
+    * Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable. All other events are stable.
     */
     'events'?: Array<UpdateWebhookRequestEventsEnum>;
     'filters'?: WebhookFiltersView;
@@ -70,9 +70,8 @@ export class UpdateWebhookRequest {
 export enum UpdateWebhookRequestEventsEnum {
     EmailReceived = 'email.received',
     EmailSent = 'email.sent',
-    EmailPendingApproval = 'email.pending_approval',
-    EmailApprovalAccepted = 'email.approval_accepted',
-    EmailApprovalRejected = 'email.approval_rejected',
+    EmailReviewApproved = 'email.review_approved',
+    EmailReviewRejected = 'email.review_rejected',
     DomainSendingVerified = 'domain.sending_verified',
     DomainSendingFailed = 'domain.sending_failed',
     EmailDelivered = 'email.delivered',

--- a/sdks/typescript/src/v1/generated/models/WebhookDeliveryView.ts
+++ b/sdks/typescript/src/v1/generated/models/WebhookDeliveryView.ts
@@ -94,9 +94,8 @@ export class WebhookDeliveryView {
 export enum WebhookDeliveryViewEventTypeEnum {
     EmailReceived = 'email.received',
     EmailSent = 'email.sent',
-    EmailPendingApproval = 'email.pending_approval',
-    EmailApprovalAccepted = 'email.approval_accepted',
-    EmailApprovalRejected = 'email.approval_rejected',
+    EmailReviewApproved = 'email.review_approved',
+    EmailReviewRejected = 'email.review_rejected',
     DomainSendingVerified = 'domain.sending_verified',
     DomainSendingFailed = 'domain.sending_failed',
     EmailDelivered = 'email.delivered',

--- a/sdks/typescript/src/v1/generated/models/WebhookView.ts
+++ b/sdks/typescript/src/v1/generated/models/WebhookView.ts
@@ -19,7 +19,7 @@ export class WebhookView {
     'description': string;
     'enabled': boolean;
     /**
-    * Beta: email.flagged, email.blocked, and email.pending_review (screening dispositions) are unstable — their payload may change before they are declared stable. All other events are stable.
+    * Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable. All other events are stable.
     */
     'events': Array<WebhookViewEventsEnum>;
     'filters': WebhookFiltersView;
@@ -98,9 +98,8 @@ export class WebhookView {
 export enum WebhookViewEventsEnum {
     EmailReceived = 'email.received',
     EmailSent = 'email.sent',
-    EmailPendingApproval = 'email.pending_approval',
-    EmailApprovalAccepted = 'email.approval_accepted',
-    EmailApprovalRejected = 'email.approval_rejected',
+    EmailReviewApproved = 'email.review_approved',
+    EmailReviewRejected = 'email.review_rejected',
     DomainSendingVerified = 'domain.sending_verified',
     DomainSendingFailed = 'domain.sending_failed',
     EmailDelivered = 'email.delivered',

--- a/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
@@ -1144,7 +1144,7 @@ export class ObjectMessagesApi {
     }
 
     /**
-     * Approve a pending_approval draft (with optional reviewer overrides) and send it. Honors Idempotency-Key (the approve triggers an SES send).
+     * Approve a pending_review draft (with optional reviewer overrides) and send it. Honors Idempotency-Key (the approve triggers an SES send).
      * Approve a held message
      * @param param the request object
      */
@@ -1153,7 +1153,7 @@ export class ObjectMessagesApi {
     }
 
     /**
-     * Approve a pending_approval draft (with optional reviewer overrides) and send it. Honors Idempotency-Key (the approve triggers an SES send).
+     * Approve a pending_review draft (with optional reviewer overrides) and send it. Honors Idempotency-Key (the approve triggers an SES send).
      * Approve a held message
      * @param param the request object
      */
@@ -1216,7 +1216,7 @@ export class ObjectMessagesApi {
     }
 
     /**
-     * List an agent\'s messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_approval.
+     * List an agent\'s messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review.
      * List messages
      * @param param the request object
      */
@@ -1225,7 +1225,7 @@ export class ObjectMessagesApi {
     }
 
     /**
-     * List an agent\'s messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_approval.
+     * List an agent\'s messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review.
      * List messages
      * @param param the request object
      */
@@ -1234,7 +1234,7 @@ export class ObjectMessagesApi {
     }
 
     /**
-     * Reject a pending_approval draft so it is never sent.
+     * Reject a pending_review draft so it is never sent.
      * Reject a held message
      * @param param the request object
      */
@@ -1243,7 +1243,7 @@ export class ObjectMessagesApi {
     }
 
     /**
-     * Reject a pending_approval draft so it is never sent.
+     * Reject a pending_review draft so it is never sent.
      * Reject a held message
      * @param param the request object
      */
@@ -1270,7 +1270,7 @@ export class ObjectMessagesApi {
     }
 
     /**
-     * Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_approval when the agent has HITL enabled. Honors Idempotency-Key.
+     * Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_review when the agent has HITL enabled. Honors Idempotency-Key.
      * Send a new email
      * @param param the request object
      */
@@ -1279,7 +1279,7 @@ export class ObjectMessagesApi {
     }
 
     /**
-     * Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_approval when the agent has HITL enabled. Honors Idempotency-Key.
+     * Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_review when the agent has HITL enabled. Honors Idempotency-Key.
      * Send a new email
      * @param param the request object
      */

--- a/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
@@ -945,7 +945,7 @@ export class ObservableMessagesApi {
     }
 
     /**
-     * Approve a pending_approval draft (with optional reviewer overrides) and send it. Honors Idempotency-Key (the approve triggers an SES send).
+     * Approve a pending_review draft (with optional reviewer overrides) and send it. Honors Idempotency-Key (the approve triggers an SES send).
      * Approve a held message
      * @param email
      * @param id
@@ -973,7 +973,7 @@ export class ObservableMessagesApi {
     }
 
     /**
-     * Approve a pending_approval draft (with optional reviewer overrides) and send it. Honors Idempotency-Key (the approve triggers an SES send).
+     * Approve a pending_review draft (with optional reviewer overrides) and send it. Honors Idempotency-Key (the approve triggers an SES send).
      * Approve a held message
      * @param email
      * @param id
@@ -1101,7 +1101,7 @@ export class ObservableMessagesApi {
     }
 
     /**
-     * List an agent\'s messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_approval.
+     * List an agent\'s messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review.
      * List messages
      * @param email
      * @param [direction] Defaults to inbound.
@@ -1137,7 +1137,7 @@ export class ObservableMessagesApi {
     }
 
     /**
-     * List an agent\'s messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_approval.
+     * List an agent\'s messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review.
      * List messages
      * @param email
      * @param [direction] Defaults to inbound.
@@ -1157,7 +1157,7 @@ export class ObservableMessagesApi {
     }
 
     /**
-     * Reject a pending_approval draft so it is never sent.
+     * Reject a pending_review draft so it is never sent.
      * Reject a held message
      * @param email
      * @param id
@@ -1184,7 +1184,7 @@ export class ObservableMessagesApi {
     }
 
     /**
-     * Reject a pending_approval draft so it is never sent.
+     * Reject a pending_review draft so it is never sent.
      * Reject a held message
      * @param email
      * @param id
@@ -1235,7 +1235,7 @@ export class ObservableMessagesApi {
     }
 
     /**
-     * Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_approval when the agent has HITL enabled. Honors Idempotency-Key.
+     * Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_review when the agent has HITL enabled. Honors Idempotency-Key.
      * Send a new email
      * @param email
      * @param sendEmailRequest
@@ -1262,7 +1262,7 @@ export class ObservableMessagesApi {
     }
 
     /**
-     * Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_approval when the agent has HITL enabled. Honors Idempotency-Key.
+     * Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_review when the agent has HITL enabled. Honors Idempotency-Key.
      * Send a new email
      * @param email
      * @param sendEmailRequest

--- a/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
@@ -682,7 +682,7 @@ export class PromiseMessagesApi {
     }
 
     /**
-     * Approve a pending_approval draft (with optional reviewer overrides) and send it. Honors Idempotency-Key (the approve triggers an SES send).
+     * Approve a pending_review draft (with optional reviewer overrides) and send it. Honors Idempotency-Key (the approve triggers an SES send).
      * Approve a held message
      * @param email
      * @param id
@@ -696,7 +696,7 @@ export class PromiseMessagesApi {
     }
 
     /**
-     * Approve a pending_approval draft (with optional reviewer overrides) and send it. Honors Idempotency-Key (the approve triggers an SES send).
+     * Approve a pending_review draft (with optional reviewer overrides) and send it. Honors Idempotency-Key (the approve triggers an SES send).
      * Approve a held message
      * @param email
      * @param id
@@ -790,7 +790,7 @@ export class PromiseMessagesApi {
     }
 
     /**
-     * List an agent\'s messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_approval.
+     * List an agent\'s messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review.
      * List messages
      * @param email
      * @param [direction] Defaults to inbound.
@@ -812,7 +812,7 @@ export class PromiseMessagesApi {
     }
 
     /**
-     * List an agent\'s messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_approval.
+     * List an agent\'s messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review.
      * List messages
      * @param email
      * @param [direction] Defaults to inbound.
@@ -834,7 +834,7 @@ export class PromiseMessagesApi {
     }
 
     /**
-     * Reject a pending_approval draft so it is never sent.
+     * Reject a pending_review draft so it is never sent.
      * Reject a held message
      * @param email
      * @param id
@@ -847,7 +847,7 @@ export class PromiseMessagesApi {
     }
 
     /**
-     * Reject a pending_approval draft so it is never sent.
+     * Reject a pending_review draft so it is never sent.
      * Reject a held message
      * @param email
      * @param id
@@ -888,7 +888,7 @@ export class PromiseMessagesApi {
     }
 
     /**
-     * Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_approval when the agent has HITL enabled. Honors Idempotency-Key.
+     * Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_review when the agent has HITL enabled. Honors Idempotency-Key.
      * Send a new email
      * @param email
      * @param sendEmailRequest
@@ -901,7 +901,7 @@ export class PromiseMessagesApi {
     }
 
     /**
-     * Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_approval when the agent has HITL enabled. Honors Idempotency-Key.
+     * Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_review when the agent has HITL enabled. Honors Idempotency-Key.
      * Send a new email
      * @param email
      * @param sendEmailRequest


### PR DESCRIPTION
## Summary

Unifies message holds on the `review` vocabulary so an outbound HITL hold and an inbound screening hold are **one direction-aware primitive**, per `docs/design/2026-06-22-unify-holds-on-pending-review.md`. This PR is **slices 1–2** of that design — the status vocabulary and the webhook events — verified end-to-end against a real Postgres. Inbound endpoint wiring (slice 3), MCP/web (slice 4), and the full e2e/review/doc gates (slice 5) are follow-ups.

Finishes the trajectory migration `040_screening.sql` named ("evolve the outbound `pending_approval` machine into a direction-aware queue"). Doing it pre-GA, while the `pending_approval` status and `approval_*` events are still unfrozen.

### Slice 1 — data layer (`3391713`)
- **`migrations/044_unify_holds.sql`**: bounded backfill of the four retiring outbound statuses → review vocabulary; CHECK swap via `NOT VALID`+`VALIDATE` (no long lock on `messages`); drop the stale `idx_messages_pending_approval` (now covered by `idx_messages_pending_review` across both directions).
- Retire the 4 outbound status constants; repoint all usages. Outbound's "approved" terminal stays `sent`.
- **Safety**: every approve/reject/expire/list query that now shares `pending_review` is explicitly direction-scoped. The critical fix — `ListExpiredReviews` had no direction filter and would otherwise have wrongly released outbound holds.
- `hitl_status` enums + `SendResultView.status` moved to the review vocabulary; spec regenerated.

### Slice 2 — events (`f82e645`)
- Remove `email.pending_approval`; rename `approval_accepted`→`email.review_approved`, `approval_rejected`→`email.review_rejected`. Outbound holds now fire the same direction-aware review events as inbound (new `direction` field).
- OpenAPI enum tags updated; review-hold family joins flagged/blocked under the beta note; spec + TS/Python SDK bases regenerated.
- Fixes a **pre-existing** e2e bug: the HITL test helper used the retired `UpdateAgentHITL` (which no longer holds a send); it now sets `outbound_policy=allowlist` + `action=review` so the tests actually exercise the hold→approve/reject→event flow.

## Behavior change (pre-GA, intentional)
- Outbound held-send status/responses report `pending_review` (was `pending_approval`); webhook events `email.review_approved`/`email.review_rejected` replace `email.approval_*`. The dropped status/events were never in a tagged release.

## Test plan
- `go build ./...` clean; spec + SDK drift gates green (regenerated).
- Against a clean Postgres: `identity`, `hitlworker`, `httpapi`, `agent`, `webhookpub` all pass — including HITL approve/reject/expire and the webhook **e2e chain** (publisher→worker→POST) in the review vocabulary.

## Known follow-ups (separate slices, not in this PR)
- **Slice 3**: branch `/approve`+`/reject` on direction and wire the inbound `ApproveInboundReview`/`RejectInboundReview` (currently dead code) — makes `email.pending_review` actionable for inbound.
- **Slice 4**: MCP tools + web dashboard status labels.
- **Slice 5**: full local-service e2e, independent + adversarial review, doc sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)