### PR TITLE
feat(attachments): rate-limit the raw download route (per-IP)

### DIFF
--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -178,6 +178,7 @@ type API struct {
 	pollLimit         *ratelimit.Limiter
 	feedbackLimit     *ratelimit.Limiter
 	dcrLimit          *ratelimit.Limiter    // OAuth Dynamic Client Registration — anonymous endpoint, per-IP
+	downloadLimit     *ratelimit.Limiter    // attachment byte-download — capability-token route (no bearer), per-IP
 	approvalSigner    *approvaltoken.Signer // optional; if nil, magic-link endpoints return 404
 	notifier          *hitlnotify.Notifier  // optional; if nil, holdForApproval doesn't send notification email
 	oauthProvider     fosite.OAuth2Provider // optional; if nil, /oauth2/* endpoints return 404
@@ -474,6 +475,13 @@ func (a *API) RegLimitAllow(key string) (bool, time.Duration, int, int, int) {
 	return a.regLimit.AllowSnapshot(key)
 }
 
+// DownloadLimitAllow exposes the per-IP attachment-download limiter (key = client
+// ip). The download route is a raw capability-token endpoint outside the Huma
+// rate-limit middleware, so it calls this directly. Returns the IETF snapshot.
+func (a *API) DownloadLimitAllow(key string) (bool, time.Duration, int, int, int) {
+	return a.downloadLimit.AllowSnapshot(key)
+}
+
 // SetUsageStore wires in the usage store used by handleGetMyLimits to
 // surface the user's current counts (agents, domains, messages this
 // month, storage bytes) alongside the resolved caps. Separate from the
@@ -520,6 +528,7 @@ func NewAPI(store *identity.Store, sender *outbound.Sender, smtpRelay *outbound.
 		pollLimit:     ratelimit.New(1*time.Minute, 60), // 60 poll requests per user per minute
 		feedbackLimit: ratelimit.New(1*time.Hour, 10),   // 10 feedback submissions per IP per hour
 		dcrLimit:      ratelimit.New(1*time.Hour, 10),   // 10 OAuth client registrations per IP per hour
+		downloadLimit: ratelimit.New(1*time.Minute, 120), // 120 attachment downloads per IP per minute
 	}
 }
 

--- a/internal/apiserver/apiserver.go
+++ b/internal/apiserver/apiserver.go
@@ -106,6 +106,7 @@ func BuildDeps(p Params) httpapi.Deps {
 		SendLimit:            p.API.SendLimitAllow,
 		PollLimit:            p.API.PollLimitAllow,
 		RegLimit:             p.API.RegLimitAllow,
+		DownloadLimit:        p.API.DownloadLimitAllow,
 		RejectPending:        p.API.RejectPendingCore,
 		GetReviewMessage:     p.Store.GetReviewMessage,
 		ApproveInboundReview: p.API.ApproveInboundReviewCore,

--- a/internal/httpapi/attachment_endpoint_test.go
+++ b/internal/httpapi/attachment_endpoint_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/ratelimit"
 )
 
 // attMultipart: text body + base64 PDF (index 0) + named inline png (index 1).
@@ -36,7 +37,7 @@ func attBig() []byte {
 		"--B--\r\n")
 }
 
-func attTestServer(t *testing.T) *httptest.Server {
+func attTestServer(t *testing.T, opts ...func(*Deps)) *httptest.Server {
 	t.Helper()
 	u := &identity.User{ID: "u_1", Email: "owner@acme.com"}
 	deps := Deps{
@@ -78,6 +79,9 @@ func attTestServer(t *testing.T) *httptest.Server {
 		},
 		AttachmentStore: NewNativeAttachmentStore("test-secret-test-secret", "http://att.test"),
 		Legacy:          http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusTeapot) }),
+	}
+	for _, o := range opts {
+		o(&deps)
 	}
 	srv := httptest.NewServer(New(deps).Router)
 	t.Cleanup(srv.Close)
@@ -206,6 +210,57 @@ func TestAttachment_DownloadRoute(t *testing.T) {
 	r3.Body.Close()
 	if r3.StatusCode != http.StatusForbidden {
 		t.Errorf("index-mismatched token want 403, got %d", r3.StatusCode)
+	}
+}
+
+// TestAttachment_DownloadRateLimited: the raw download route (outside the Huma
+// rate-limit middleware) is throttled per-IP. The 3rd request over a cap of 2 is
+// a 429 carrying Retry-After + RateLimit-* headers and the e2a error envelope.
+func TestAttachment_DownloadRateLimited(t *testing.T) {
+	lim := ratelimit.New(time.Minute, 2) // 2 downloads per IP per minute
+	srv := attTestServer(t, func(d *Deps) { d.DownloadLimit = lim.AllowSnapshot })
+
+	_, meta := getJSONAtt(t, srv.URL+"/v1/agents/support%40acme.com/messages/msg_att/attachments/0", "acct")
+	dlPath := downloadPathFromURL(t, meta["download_url"].(string))
+
+	// First two downloads succeed.
+	for i := 0; i < 2; i++ {
+		r, err := http.Get(srv.URL + dlPath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_, _ = io.ReadAll(r.Body)
+		r.Body.Close()
+		if r.StatusCode != http.StatusOK {
+			t.Fatalf("download %d: want 200, got %d", i, r.StatusCode)
+		}
+		if r.Header.Get("RateLimit-Limit") == "" {
+			t.Errorf("download %d: missing RateLimit-Limit header", i)
+		}
+	}
+
+	// Third is throttled.
+	r3, err := http.Get(srv.URL + dlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r3.Body.Close()
+	if r3.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("3rd download: want 429, got %d", r3.StatusCode)
+	}
+	if r3.Header.Get("Retry-After") == "" {
+		t.Error("429 missing Retry-After header")
+	}
+	if ct := r3.Header.Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Errorf("429 content-type = %q, want JSON envelope", ct)
+	}
+	var env map[string]any
+	if err := json.NewDecoder(r3.Body).Decode(&env); err != nil {
+		t.Fatalf("decode 429 body: %v", err)
+	}
+	e, _ := env["error"].(map[string]any)
+	if e == nil || e["code"] != "rate_limited" {
+		t.Errorf("429 body must be the e2a envelope with code=rate_limited, got %v", env)
 	}
 }
 

--- a/internal/httpapi/attachments.go
+++ b/internal/httpapi/attachments.go
@@ -5,6 +5,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -214,6 +215,28 @@ func (s *Server) handleGetAttachment(ctx context.Context, in *attachmentParam) (
 // keyed by agent id), so a valid token can only stream the exact attachment it
 // was minted for.
 func (s *Server) handleAttachmentDownload(w http.ResponseWriter, r *http.Request) {
+	// Per-IP rate limit FIRST. This raw capability-token route sits OUTSIDE the
+	// Huma rate-limit middleware, and each accepted hit runs GetAgent +
+	// GetMessage + a full MIME re-parse — so throttle before any of that work to
+	// bound token-replay and index/message probing. Keyed by client IP (no bearer
+	// here); shares the per-IP convention of the registration/feedback limiters.
+	if s.deps.DownloadLimit != nil {
+		ok, retryAfter, limit, remaining, reset := s.deps.DownloadLimit(clientIP(r))
+		w.Header().Set("RateLimit-Limit", strconv.Itoa(limit))
+		w.Header().Set("RateLimit-Remaining", strconv.Itoa(remaining))
+		w.Header().Set("RateLimit-Reset", strconv.Itoa(reset))
+		if !ok {
+			secs := int(retryAfter.Round(time.Second).Seconds())
+			if secs < 1 {
+				secs = 1
+			}
+			w.Header().Set("Retry-After", strconv.Itoa(secs))
+			writeRawError(w, r, http.StatusTooManyRequests, "rate_limited", "rate limit exceeded",
+				map[string]any{"retry_after_seconds": secs})
+			return
+		}
+	}
+
 	email := identity.NormalizeEmail(chi.URLParam(r, "email"))
 	id := chi.URLParam(r, "id")
 	index, err := strconv.Atoi(chi.URLParam(r, "index"))
@@ -267,4 +290,18 @@ func (s *Server) handleAttachmentDownload(w http.ResponseWriter, r *http.Request
 		w.Header().Set("Content-Disposition", "attachment")
 	}
 	_, _ = w.Write(att.Data)
+}
+
+// writeRawError writes the e2a error envelope as JSON to a raw (non-Huma)
+// ResponseWriter, stamping the request id like the Huma handler path. Used by the
+// raw attachment-download route, which can't return through Huma.
+func writeRawError(w http.ResponseWriter, r *http.Request, status int, code, msg string, details map[string]any) {
+	env := NewError(status, code, msg)
+	if details != nil {
+		env = env.WithDetails(details)
+	}
+	env.Err.RequestID = RequestIDFromContext(r.Context())
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(env)
 }

--- a/internal/httpapi/httpapi.go
+++ b/internal/httpapi/httpapi.go
@@ -150,6 +150,10 @@ type Deps struct {
 	// Optional — nil disables that limiter on the /v1 surface.
 	PollLimit RateSnapshot
 	RegLimit  RateSnapshot
+	// DownloadLimit is the per-IP attachment-download limiter (key = client ip).
+	// The download route is a raw chi handler outside the Huma rate-limit
+	// middleware, so it consults this directly. Optional — nil disables it.
+	DownloadLimit RateSnapshot
 	// GetInboundMessage loads an inbound message for reply/forward.
 	GetInboundMessage func(ctx context.Context, messageID string) (*identity.Message, error)
 


### PR DESCRIPTION
The signed attachment-**download** route is a raw chi handler registered *outside* the Huma rate-limit middleware (`httpapi.go` `root.Get(...)`), so it had **no throttle** — yet each accepted hit runs `GetAgent` + `GetMessage` + a full MIME re-parse. That makes token-replay and message+index probing a bounded-but-real DB/CPU DoS vector (audit finding).

### Change
- New **per-IP** download limiter — **120/min**, reusing the existing `ratelimit.Limiter` primitive and the per-IP convention of the registration/feedback buckets. Keyed by client IP because the route is capability-token-authed (no bearer).
- Checked **first** in the handler, before any DB/parse work, so even invalid-token spam is throttled.
- On 429: sets `RateLimit-*` + `Retry-After` headers and returns the **e2a error envelope** (new `writeRawError` helper for non-Huma routes), instead of plain text.
- Wiring: `agent.API.downloadLimit` + `DownloadLimitAllow` → `httpapi.Deps.DownloadLimit` (optional; nil disables it, so existing tests/deployments are unaffected).

### Verification
`internal/httpapi`, `internal/ratelimit`, `internal/agent` green; `go build` clean. New `TestAttachment_DownloadRateLimited`: 3rd download over a cap of 2 → 429 with the headers + `code=rate_limited` envelope; first two succeed carrying `RateLimit-*`.

### Scope note
This addresses only the **rate-limit** sub-issue of the attachment-route audit cluster. The other paths' plain-text errors (envelope bypass) and the marks-message-read side effect remain as separate follow-ups; `writeRawError` is the building block for the envelope one. Also: the per-IP key uses the shared `clientIP` (leftmost XFF), which has the known #14 spoofing caveat tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)