### PR TITLE
feat(v1,mcp): rename hitl_→review_ wire fields + expose Sent folder over MCP

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -75,11 +75,6 @@ components:
           type: boolean
         email:
           type: string
-        hitl_expiration_action:
-          type: string
-        hitl_ttl_seconds:
-          format: int64
-          type: integer
         id:
           type: string
         inbound_7d:
@@ -138,6 +133,11 @@ components:
           type: integer
         public:
           type: boolean
+        review_expiration_action:
+          type: string
+        review_ttl_seconds:
+          format: int64
+          type: integer
         user_id:
           type: string
         webhook_healthy:
@@ -151,8 +151,8 @@ components:
         - public
         - created_at
         - user_id
-        - hitl_ttl_seconds
-        - hitl_expiration_action
+        - review_ttl_seconds
+        - review_expiration_action
         - inbound_7d
         - outbound_7d
         - pending_count
@@ -1027,14 +1027,6 @@ components:
           type: boolean
         from:
           type: string
-        hitl_status:
-          enum:
-            - pending_review
-            - sent
-            - review_rejected
-            - review_expired_approved
-            - review_expired_rejected
-          type: string
         labels:
           items:
             type: string
@@ -1049,6 +1041,14 @@ components:
           items:
             type: string
           type: array
+        review_status:
+          enum:
+            - pending_review
+            - sent
+            - review_rejected
+            - review_expired_approved
+            - review_expired_rejected
+          type: string
         sent_as:
           enum:
             - own_address
@@ -1125,14 +1125,6 @@ components:
           type: boolean
         from:
           type: string
-        hitl_status:
-          enum:
-            - pending_review
-            - sent
-            - review_rejected
-            - review_expired_approved
-            - review_expired_rejected
-          type: string
         labels:
           items:
             type: string
@@ -1152,6 +1144,14 @@ components:
           items:
             type: string
           type: array
+        review_status:
+          enum:
+            - pending_review
+            - sent
+            - review_rejected
+            - review_expired_approved
+            - review_expired_rejected
+          type: string
         sent_as:
           enum:
             - own_address

--- a/internal/httpapi/messages.go
+++ b/internal/httpapi/messages.go
@@ -36,11 +36,11 @@ type MessageView struct {
 	// webhook_status — the conflation that caused bug B2. Left open (not an enum)
 	// because outbound rows carry "".
 	Status string `json:"read_status"`
-	// HITLStatus is the human-in-the-loop lifecycle (e.g. pending_review) —
-	// outbound only, mirroring MessageSummaryView. Distinct from read_status,
-	// delivery_status, and webhook_status (each a separate axis). Closed set =
-	// migration 003 CHECK.
-	HITLStatus string `json:"hitl_status,omitempty" enum:"pending_review,sent,review_rejected,review_expired_approved,review_expired_rejected"`
+	// HITLStatus is the review-hold lifecycle (e.g. pending_review) — outbound
+	// only, mirroring MessageSummaryView. Exposed as `review_status` (the holds
+	// vocabulary unified on `review` in migration 044). Distinct from read_status,
+	// delivery_status, and webhook_status (each a separate axis).
+	HITLStatus string `json:"review_status,omitempty" enum:"pending_review,sent,review_rejected,review_expired_approved,review_expired_rejected"`
 	// WebhookStatus / WebhookError mirror MessageSummaryView so the detail view
 	// is a strict superset of the list item (a client fetching one message keeps
 	// the webhook delivery context). Apply to both directions; omitempty hides
@@ -215,7 +215,7 @@ type MessageSummaryView struct {
 	ConversationID string   `json:"conversation_id,omitempty"`
 	// Status is the inbox read-state, exposed as `read_status` (MSG-1).
 	Status string `json:"read_status"`
-	HITLStatus     string   `json:"hitl_status,omitempty" enum:"pending_review,sent,review_rejected,review_expired_approved,review_expired_rejected"`
+	HITLStatus     string   `json:"review_status,omitempty" enum:"pending_review,sent,review_rejected,review_expired_approved,review_expired_rejected"`
 	WebhookStatus  string   `json:"webhook_status,omitempty"`
 	WebhookError   string   `json:"webhook_error,omitempty"`
 	// DeliveryStatus / DeliveryDetail / SentAs are the outbound delivery

--- a/internal/httpapi/protection_test.go
+++ b/internal/httpapi/protection_test.go
@@ -147,7 +147,7 @@ func TestAgentViewOmitsScanThresholds(t *testing.T) {
 		"inbound_scan", "outbound_scan", "inbound_policy", "outbound_policy",
 		"inbound_policy_action", "outbound_policy_action",
 		"inbound_scan_sensitivity", "outbound_scan_sensitivity",
-		"hitl_ttl_seconds", "hitl_expiration_action",
+		"review_ttl_seconds", "review_expiration_action",
 	}
 	for _, k := range leaky {
 		if _, present := body[k]; present {

--- a/internal/httpapi/spec_review_test.go
+++ b/internal/httpapi/spec_review_test.go
@@ -154,8 +154,8 @@ func TestSpecStatusEnums(t *testing.T) {
 	}{
 		{"MessageView", "direction", []string{"inbound", "outbound"}},
 		{"MessageSummaryView", "direction", []string{"inbound", "outbound"}},
-		{"MessageView", "hitl_status", []string{"pending_review", "sent", "review_rejected", "review_expired_approved", "review_expired_rejected"}},
-		{"MessageSummaryView", "hitl_status", []string{"pending_review", "sent", "review_rejected", "review_expired_approved", "review_expired_rejected"}},
+		{"MessageView", "review_status", []string{"pending_review", "sent", "review_rejected", "review_expired_approved", "review_expired_rejected"}},
+		{"MessageSummaryView", "review_status", []string{"pending_review", "sent", "review_rejected", "review_expired_approved", "review_expired_rejected"}},
 		{"SendResultView", "status", []string{"sent", "pending_review", "review_approved"}},
 		{"EventJSON", "status", []string{"pending", "processed", "no_match"}},
 		{"RedeliverView", "status", []string{"pending", "scheduled"}},

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -87,8 +87,8 @@ type AgentIdentity struct {
 	// were retired (Slice 5b/5c, columns dropped in migration 043) — outbound_policy
 	// + outbound_scan own holds now. These two knobs govern how the review queue
 	// behaves (TTL + expiry action) for both directions.
-	HITLTTLSeconds       int    `json:"hitl_ttl_seconds"`
-	HITLExpirationAction string `json:"hitl_expiration_action"`
+	HITLTTLSeconds       int    `json:"review_ttl_seconds"`
+	HITLExpirationAction string `json:"review_expiration_action"`
 	// Dashboard enrichment fields. Computed at read
 	// time by ListAgentsByUser via correlated subqueries — other load
 	// paths (GetAgentByID / GetAgentByEmail) leave them at zero values,

--- a/mcp/src/client.ts
+++ b/mcp/src/client.ts
@@ -33,7 +33,7 @@ import type { Scope } from "./tools/tiers.js";
 // Outbound drafts held for human review surface in the message list with
 // this status (the hold vocabulary was unified on `pending_review` across
 // both directions — see api/openapi.yaml). There is no dedicated status
-// query param for them, so HITL listing filters outbound rows on this value.
+// query param for them, so the review queue filters outbound rows on this value.
 export const PENDING_REVIEW_STATUS = "pending_review";
 
 const DEFAULT_LIST_LIMIT = 1000;
@@ -232,6 +232,7 @@ export class McpClient {
   // Cursor pagination (§6a #3): returns ONE page + next_cursor. `limit` is the
   // page size; pass a prior response's next_cursor as `cursor` for the next page.
   listMessages(params: {
+    direction?: "inbound" | "outbound" | "all";
     readStatus?: "unread" | "read" | "all";
     sort?: "asc" | "desc";
     from?: string;
@@ -268,7 +269,7 @@ export class McpClient {
     );
   }
 
-  // ── HITL (pending outbound) ─────────────────────────────────────
+  // ── Review queue (pending outbound) ─────────────────────────────
 
   // Pending drafts surface as outbound messages with status=pending_review.
   // There is no dedicated "pending" status filter, so we list outbound and
@@ -284,9 +285,9 @@ export class McpClient {
         .list(address, { direction: "outbound" })
         .toArray({ limit: DEFAULT_LIST_LIMIT });
       for (const r of rows) {
-        // Held drafts carry the HITL lifecycle in hitl_status (read_status is
-        // the inbox read-state, "" for outbound). MSG-1.
-        if (r.hitlStatus === PENDING_REVIEW_STATUS) out.push(r);
+        // Held drafts carry the review-hold lifecycle in review_status
+        // (read_status is the inbox read-state, "" for outbound). MSG-1.
+        if (r.reviewStatus === PENDING_REVIEW_STATUS) out.push(r);
       }
     }
     return out;

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -3,7 +3,7 @@ import type { McpClient } from "./client.js";
 import { registerMessageTools } from "./tools/messages.js";
 import { registerAgentTools } from "./tools/agents.js";
 import { registerDomainTools } from "./tools/domains.js";
-import { registerHitlTools } from "./tools/hitl.js";
+import { registerReviewTools } from "./tools/review.js";
 import { registerWebhookTools } from "./tools/webhooks.js";
 import { registerEventTools } from "./tools/events.js";
 import { toolNamesForScope } from "./tools/tiers.js";
@@ -44,7 +44,7 @@ export function buildServer({ client, version = "0.1.0" }: BuildServerOptions): 
   registerMessageTools(server, client);
   registerAgentTools(server, client);
   registerDomainTools(server, client);
-  registerHitlTools(server, client);
+  registerReviewTools(server, client);
   registerWebhookTools(server, client);
   registerEventTools(server, client);
   return server;

--- a/mcp/src/tools/messages.ts
+++ b/mcp/src/tools/messages.ts
@@ -24,7 +24,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
       title: "Send email",
       annotations: { destructiveHint: false },
       description:
-        "Use when starting a NEW email thread to a fresh recipient. To respond to a message you can see in `list_messages`, use `reply_to_message` instead — it preserves the In-Reply-To / References headers so the reply lands in the same thread, which this tool deliberately does not do. Attach files via `attachments`; pass base64 strings produced by other tools (e.g. `get_attachment`) verbatim — don't hand-encode raw text. **`pending_review` is not failure.** If the agent has HITL enabled, the response is `{ status: \"pending_review\", message_id: ... }`; the message is held for human review — do not retry. Check on it with `list_messages` (held drafts show hitl_status=pending_review) / `get_message`.",
+        "Use when starting a NEW email thread to a fresh recipient. To respond to a message you can see in `list_messages`, use `reply_to_message` instead — it preserves the In-Reply-To / References headers so the reply lands in the same thread, which this tool deliberately does not do. Attach files via `attachments`; pass base64 strings produced by other tools (e.g. `get_attachment`) verbatim — don't hand-encode raw text. **`pending_review` is not failure.** If the agent's review policy holds the send, the response is `{ status: \"pending_review\", message_id: ... }`; the message is held for human review — do not retry. Check on it with `list_messages` (held drafts show review_status=pending_review) / `get_message`.",
       inputSchema: strictInputSchema({
         to: z.array(z.string()).describe("Recipient email addresses (one or more)."),
         subject: z.string(),
@@ -84,7 +84,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
       title: "Reply to a received message",
       annotations: { destructiveHint: false },
       description:
-        "Use whenever you're responding to a message you can see in the inbox — preserves the In-Reply-To and References headers so the reply joins the original email thread instead of starting a new one. Prefer this over `send_message` for any response to an inbound; thread fragmentation (broken conversation view in the recipient's mail client) is the most visible symptom of using `send_message` by mistake. Pass `reply_all: true` to copy the original Cc list; subject is auto-derived as `Re: …` by the server. Same HITL caveat as `send_message`: a `pending_review` status is success, not failure.",
+        "Use whenever you're responding to a message you can see in the inbox — preserves the In-Reply-To and References headers so the reply joins the original email thread instead of starting a new one. Prefer this over `send_message` for any response to an inbound; thread fragmentation (broken conversation view in the recipient's mail client) is the most visible symptom of using `send_message` by mistake. Pass `reply_all: true` to copy the original Cc list; subject is auto-derived as `Re: …` by the server. Same review caveat as `send_message`: a `pending_review` status is success, not failure.",
       inputSchema: strictInputSchema({
         message_id: z.string().describe("ID of the inbound message to reply to (e.g. msg_…)."),
         body: z.string().describe("Plain-text reply body."),
@@ -139,7 +139,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
       title: "Forward an inbound message",
       annotations: { destructiveHint: false },
       description:
-        "Forward a message the agent has received to one or more new recipients. The server auto-prepends a Gmail-style header block (From/Date/Subject/To/Cc) and the original body to whatever optional comment you pass in `body`/`html_body`. **Unlike `reply_to_message`, a forward is a NEW thread** — no In-Reply-To / References headers are emitted, so the recipient sees a fresh conversation. Use this when the user asks to share a received email with someone else; use `reply_to_message` when continuing the existing conversation. Same HITL behavior as send/reply: `pending_review` is success, not failure.",
+        "Forward a message the agent has received to one or more new recipients. The server auto-prepends a Gmail-style header block (From/Date/Subject/To/Cc) and the original body to whatever optional comment you pass in `body`/`html_body`. **Unlike `reply_to_message`, a forward is a NEW thread** — no In-Reply-To / References headers are emitted, so the recipient sees a fresh conversation. Use this when the user asks to share a received email with someone else; use `reply_to_message` when continuing the existing conversation. Same review behavior as send/reply: `pending_review` is success, not failure.",
       inputSchema: strictInputSchema({
         message_id: z.string().describe("ID of the inbound message to forward (e.g. msg_…)."),
         to: z.array(z.string()).describe("Forward target addresses (one or more)."),
@@ -288,11 +288,17 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
   server.registerTool(
     "list_messages",
     {
-      title: "List inbound messages",
+      title: "List messages (inbox or sent)",
       annotations: { readOnlyHint: true },
       description:
-        "List messages the agent has received, newest first by default. Filter by `read_status` (unread/read/all; default unread). **Cursor-paginated:** returns one page in `messages` plus a `next_cursor` when more remain — pass it back as `cursor` for the next page (keep the same filters + sort). Pass `sort: \"asc\"` for FIFO order (oldest unread first) to drain the inbox in arrival order. **Search filters** (`from`, `subject_contains`, `conversation_id`, `since`, `until`) narrow server-side — use them instead of paging the whole inbox. Returns summaries only — use `get_message` for the full body.",
+        "List the agent's messages, newest first by default. Use `direction` to pick the folder: `inbound` (the Inbox — received mail, the default), `outbound` (the Sent folder — mail this agent sent, including held drafts), or `all` (both). Filter received mail by `read_status` (unread/read/all; default unread — applies to inbound only; sent mail has no read-state). **Cursor-paginated:** returns one page in `messages` plus a `next_cursor` when more remain — pass it back as `cursor` for the next page (keep the same filters + sort). Pass `sort: \"asc\"` for FIFO order (oldest first) to drain in arrival order. **Search filters** (`from`, `subject_contains`, `conversation_id`, `since`, `until`) narrow server-side — use them instead of paging the whole folder. Returns summaries only — use `get_message` for the full body.",
       inputSchema: strictInputSchema({
+        direction: z
+          .enum(["inbound", "outbound", "all"])
+          .optional()
+          .describe(
+            "Which folder to list: `inbound` = Inbox (received, default), `outbound` = Sent (this agent's sent mail + held drafts), `all` = both.",
+          ),
         read_status: z.enum(["unread", "read", "all"]).optional(),
         ...paginationInput,
         sort: z
@@ -344,6 +350,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
     async (args) =>
       runTool(async () => {
         const page = await client.listMessages({
+          ...(args.direction !== undefined ? { direction: args.direction } : {}),
           ...(args.read_status !== undefined ? { readStatus: args.read_status } : {}),
           ...(args.cursor !== undefined ? { cursor: args.cursor } : {}),
           ...(args.limit !== undefined ? { limit: args.limit } : {}),

--- a/mcp/src/tools/review.ts
+++ b/mcp/src/tools/review.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { runTool, strictInputSchema } from "./util.js";
 import { attachmentsArraySchema } from "./attachments.js";
 
-export function registerHitlTools(server: McpServer, client: McpClient): void {
+export function registerReviewTools(server: McpServer, client: McpClient): void {
   server.registerTool(
     "list_pending_messages",
     {

--- a/mcp/src/tools/tiers.ts
+++ b/mcp/src/tools/tiers.ts
@@ -35,7 +35,7 @@ export const RUNTIME_TOOLS: ReadonlySet<string> = new Set([
   "forward_message",
   // NOTE: approve_message / reject_message are deliberately NOT here — they are
   // admin/account-scope (below). Letting the gated agent approve its own held
-  // outbound would be self-approval and defeat the HITL gate; approval is an
+  // outbound would be self-approval and defeat the review gate; approval is an
   // account-owner / human action (or the magic-link browser flow). An
   // agent-scoped credential can send (which gets held) and SEE its pending
   // queue (list_pending_messages / get_pending_message), but not release it.
@@ -53,10 +53,10 @@ export const ADMIN_TOOLS: ReadonlySet<string> = new Set([
   "get_protection",
   "update_protection",
   "delete_agent",
-  // HITL approval is an account-owner / human review action — NOT something the
+  // Review approval is an account-owner / human review action — NOT something the
   // gated agent may do to its own held outbound (that would be self-approval,
-  // defeating HITL). The backend enforces this too: the approve/reject handlers
-  // (internal/httpapi/hitl.go) require account scope (403 for agent-scoped).
+  // defeating the review gate). The backend enforces this too: the approve/reject
+  // handlers (internal/httpapi/hitl.go) require account scope (403 for agent-scoped).
   "approve_message",
   "reject_message",
   "list_domains",

--- a/mcp/src/tools/webhooks.ts
+++ b/mcp/src/tools/webhooks.ts
@@ -169,7 +169,7 @@ export function registerWebhookTools(server: McpServer, client: McpClient): void
       title: "Fire a synthetic event to a webhook for debugging",
       annotations: { destructiveHint: false },
       description:
-        "Schedules a one-off delivery to the webhook with a synthetic envelope, bypassing filter matching. Returns the delivery_id; inspect the outcome (status/attempts/last_error) via `list_webhook_deliveries`. Returns an error if the webhook is disabled. Cheap and safe — the synthetic event does not touch real inbound or HITL state.",
+        "Schedules a one-off delivery to the webhook with a synthetic envelope, bypassing filter matching. Returns the delivery_id; inspect the outcome (status/attempts/last_error) via `list_webhook_deliveries`. Returns an error if the webhook is disabled. Cheap and safe — the synthetic event does not touch real inbound or review state.",
       inputSchema: strictInputSchema({
         id: z.string().min(1).describe("Webhook id (wh_…)."),
         event: z

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -8,7 +8,7 @@ import { assertToolTiersComplete, toolNamesForScope, RUNTIME_TOOLS } from "../sr
 import { registerMessageTools } from "../src/tools/messages.js";
 import { registerAgentTools } from "../src/tools/agents.js";
 import { registerDomainTools } from "../src/tools/domains.js";
-import { registerHitlTools } from "../src/tools/hitl.js";
+import { registerReviewTools } from "../src/tools/review.js";
 import { registerWebhookTools } from "../src/tools/webhooks.js";
 import { registerEventTools } from "../src/tools/events.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
@@ -161,7 +161,7 @@ function makeStubClient(
     listPendingMessages: vi.fn(async () => []),
     getPendingMessage: vi.fn(async (id: string) => ({
       messageId: id,
-      hitlStatus: "pending_review",
+      reviewStatus: "pending_review",
     })),
     approveMessage: vi.fn(async () => ({ messageId: "msg_x", status: "sent" })),
     rejectMessage: vi.fn(async () => ({ messageId: "msg_x", status: "rejected" })),
@@ -250,7 +250,7 @@ describe("e2a MCP server", () => {
     registerMessageTools(recorder, stub);
     registerAgentTools(recorder, stub);
     registerDomainTools(recorder, stub);
-    registerHitlTools(recorder, stub);
+    registerReviewTools(recorder, stub);
     registerWebhookTools(recorder, stub);
     registerEventTools(recorder, stub);
 

--- a/sdks/python/src/e2a/v1/generated/models/agent_identity.py
+++ b/sdks/python/src/e2a/v1/generated/models/agent_identity.py
@@ -31,8 +31,6 @@ class AgentIdentity(BaseModel):
     domain: StrictStr
     domain_verified: StrictBool
     email: StrictStr
-    hitl_expiration_action: StrictStr
-    hitl_ttl_seconds: StrictInt
     id: StrictStr
     inbound_7d: StrictInt
     inbound_allowlist: Optional[List[StrictStr]] = None
@@ -54,9 +52,11 @@ class AgentIdentity(BaseModel):
     outbound_scan_sensitivity: StrictStr
     pending_count: StrictInt
     public: StrictBool
+    review_expiration_action: StrictStr
+    review_ttl_seconds: StrictInt
     user_id: StrictStr
     webhook_healthy: StrictBool
-    __properties: ClassVar[List[str]] = ["created_at", "domain", "domain_verified", "email", "hitl_expiration_action", "hitl_ttl_seconds", "id", "inbound_7d", "inbound_allowlist", "inbound_policy", "inbound_policy_action", "inbound_scan", "inbound_scan_block_threshold", "inbound_scan_review_threshold", "inbound_scan_sensitivity", "last_delivery_at", "name", "outbound_7d", "outbound_allowlist", "outbound_policy", "outbound_policy_action", "outbound_scan", "outbound_scan_block_threshold", "outbound_scan_review_threshold", "outbound_scan_sensitivity", "pending_count", "public", "user_id", "webhook_healthy"]
+    __properties: ClassVar[List[str]] = ["created_at", "domain", "domain_verified", "email", "id", "inbound_7d", "inbound_allowlist", "inbound_policy", "inbound_policy_action", "inbound_scan", "inbound_scan_block_threshold", "inbound_scan_review_threshold", "inbound_scan_sensitivity", "last_delivery_at", "name", "outbound_7d", "outbound_allowlist", "outbound_policy", "outbound_policy_action", "outbound_scan", "outbound_scan_block_threshold", "outbound_scan_review_threshold", "outbound_scan_sensitivity", "pending_count", "public", "review_expiration_action", "review_ttl_seconds", "user_id", "webhook_healthy"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -123,8 +123,6 @@ class AgentIdentity(BaseModel):
             "domain": obj.get("domain"),
             "domain_verified": obj.get("domain_verified"),
             "email": obj.get("email"),
-            "hitl_expiration_action": obj.get("hitl_expiration_action"),
-            "hitl_ttl_seconds": obj.get("hitl_ttl_seconds"),
             "id": obj.get("id"),
             "inbound_7d": obj.get("inbound_7d"),
             "inbound_allowlist": obj.get("inbound_allowlist"),
@@ -146,6 +144,8 @@ class AgentIdentity(BaseModel):
             "outbound_scan_sensitivity": obj.get("outbound_scan_sensitivity"),
             "pending_count": obj.get("pending_count"),
             "public": obj.get("public"),
+            "review_expiration_action": obj.get("review_expiration_action"),
+            "review_ttl_seconds": obj.get("review_ttl_seconds"),
             "user_id": obj.get("user_id"),
             "webhook_healthy": obj.get("webhook_healthy")
         })

--- a/sdks/python/src/e2a/v1/generated/models/message_summary_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/message_summary_view.py
@@ -38,19 +38,19 @@ class MessageSummaryView(BaseModel):
     flag_reason: Optional[StrictStr] = None
     flagged: Optional[StrictBool] = None
     var_from: StrictStr = Field(alias="from")
-    hitl_status: Optional[StrictStr] = None
     labels: List[StrictStr]
     message_id: StrictStr
     read_status: StrictStr
     recipient: StrictStr
     reply_to: Optional[List[StrictStr]] = None
+    review_status: Optional[StrictStr] = None
     sent_as: Optional[StrictStr] = None
     size_bytes: Optional[StrictInt] = None
     subject: StrictStr
     to: List[StrictStr]
     webhook_error: Optional[StrictStr] = None
     webhook_status: Optional[StrictStr] = None
-    __properties: ClassVar[List[str]] = ["auth", "cc", "conversation_id", "created_at", "delivery_detail", "delivery_status", "direction", "flag_reason", "flagged", "from", "hitl_status", "labels", "message_id", "read_status", "recipient", "reply_to", "sent_as", "size_bytes", "subject", "to", "webhook_error", "webhook_status"]
+    __properties: ClassVar[List[str]] = ["auth", "cc", "conversation_id", "created_at", "delivery_detail", "delivery_status", "direction", "flag_reason", "flagged", "from", "labels", "message_id", "read_status", "recipient", "reply_to", "review_status", "sent_as", "size_bytes", "subject", "to", "webhook_error", "webhook_status"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -116,12 +116,12 @@ class MessageSummaryView(BaseModel):
             "flag_reason": obj.get("flag_reason"),
             "flagged": obj.get("flagged"),
             "from": obj.get("from"),
-            "hitl_status": obj.get("hitl_status"),
             "labels": obj.get("labels"),
             "message_id": obj.get("message_id"),
             "read_status": obj.get("read_status"),
             "recipient": obj.get("recipient"),
             "reply_to": obj.get("reply_to"),
+            "review_status": obj.get("review_status"),
             "sent_as": obj.get("sent_as"),
             "size_bytes": obj.get("size_bytes"),
             "subject": obj.get("subject"),

--- a/sdks/python/src/e2a/v1/generated/models/message_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/message_view.py
@@ -44,7 +44,6 @@ class MessageView(BaseModel):
     flag_reason: Optional[StrictStr] = None
     flagged: Optional[StrictBool] = None
     var_from: StrictStr = Field(alias="from")
-    hitl_status: Optional[StrictStr] = None
     labels: List[StrictStr]
     message_id: StrictStr
     parsed: Optional[MessageParsedView] = None
@@ -52,13 +51,14 @@ class MessageView(BaseModel):
     read_status: StrictStr
     recipient: StrictStr
     reply_to: List[StrictStr]
+    review_status: Optional[StrictStr] = None
     sent_as: Optional[StrictStr] = None
     size_bytes: Optional[StrictInt] = None
     subject: StrictStr
     to: List[StrictStr]
     webhook_error: Optional[StrictStr] = None
     webhook_status: Optional[StrictStr] = None
-    __properties: ClassVar[List[str]] = ["attachments", "auth", "auth_headers", "body", "cc", "conversation_id", "created_at", "delivery_detail", "delivery_status", "direction", "flag_reason", "flagged", "from", "hitl_status", "labels", "message_id", "parsed", "raw_message", "read_status", "recipient", "reply_to", "sent_as", "size_bytes", "subject", "to", "webhook_error", "webhook_status"]
+    __properties: ClassVar[List[str]] = ["attachments", "auth", "auth_headers", "body", "cc", "conversation_id", "created_at", "delivery_detail", "delivery_status", "direction", "flag_reason", "flagged", "from", "labels", "message_id", "parsed", "raw_message", "read_status", "recipient", "reply_to", "review_status", "sent_as", "size_bytes", "subject", "to", "webhook_error", "webhook_status"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -140,7 +140,6 @@ class MessageView(BaseModel):
             "flag_reason": obj.get("flag_reason"),
             "flagged": obj.get("flagged"),
             "from": obj.get("from"),
-            "hitl_status": obj.get("hitl_status"),
             "labels": obj.get("labels"),
             "message_id": obj.get("message_id"),
             "parsed": MessageParsedView.from_dict(obj["parsed"]) if obj.get("parsed") is not None else None,
@@ -148,6 +147,7 @@ class MessageView(BaseModel):
             "read_status": obj.get("read_status"),
             "recipient": obj.get("recipient"),
             "reply_to": obj.get("reply_to"),
+            "review_status": obj.get("review_status"),
             "sent_as": obj.get("sent_as"),
             "size_bytes": obj.get("size_bytes"),
             "subject": obj.get("subject"),

--- a/sdks/typescript/src/v1/generated/models/AgentIdentity.ts
+++ b/sdks/typescript/src/v1/generated/models/AgentIdentity.ts
@@ -17,8 +17,6 @@ export class AgentIdentity {
     'domain': string;
     'domainVerified': boolean;
     'email': string;
-    'hitlExpirationAction': string;
-    'hitlTtlSeconds': number;
     'id': string;
     'inbound7d': number;
     'inboundAllowlist'?: Array<string> | null;
@@ -40,6 +38,8 @@ export class AgentIdentity {
     'outboundScanSensitivity': string;
     'pendingCount': number;
     '_public': boolean;
+    'reviewExpirationAction': string;
+    'reviewTtlSeconds': number;
     'userId': string;
     'webhookHealthy': boolean;
 
@@ -71,18 +71,6 @@ export class AgentIdentity {
             "baseName": "email",
             "type": "string",
             "format": ""
-        },
-        {
-            "name": "hitlExpirationAction",
-            "baseName": "hitl_expiration_action",
-            "type": "string",
-            "format": ""
-        },
-        {
-            "name": "hitlTtlSeconds",
-            "baseName": "hitl_ttl_seconds",
-            "type": "number",
-            "format": "int64"
         },
         {
             "name": "id",
@@ -209,6 +197,18 @@ export class AgentIdentity {
             "baseName": "public",
             "type": "boolean",
             "format": ""
+        },
+        {
+            "name": "reviewExpirationAction",
+            "baseName": "review_expiration_action",
+            "type": "string",
+            "format": ""
+        },
+        {
+            "name": "reviewTtlSeconds",
+            "baseName": "review_ttl_seconds",
+            "type": "number",
+            "format": "int64"
         },
         {
             "name": "userId",

--- a/sdks/typescript/src/v1/generated/models/MessageSummaryView.ts
+++ b/sdks/typescript/src/v1/generated/models/MessageSummaryView.ts
@@ -24,12 +24,12 @@ export class MessageSummaryView {
     'flagReason'?: string;
     'flagged'?: boolean;
     '_from': string;
-    'hitlStatus'?: MessageSummaryViewHitlStatusEnum;
     'labels': Array<string>;
     'messageId': string;
     'readStatus': string;
     'recipient': string;
     'replyTo'?: Array<string>;
+    'reviewStatus'?: MessageSummaryViewReviewStatusEnum;
     'sentAs'?: MessageSummaryViewSentAsEnum;
     'sizeBytes'?: number;
     'subject': string;
@@ -103,12 +103,6 @@ export class MessageSummaryView {
             "format": ""
         },
         {
-            "name": "hitlStatus",
-            "baseName": "hitl_status",
-            "type": "MessageSummaryViewHitlStatusEnum",
-            "format": ""
-        },
-        {
             "name": "labels",
             "baseName": "labels",
             "type": "Array<string>",
@@ -136,6 +130,12 @@ export class MessageSummaryView {
             "name": "replyTo",
             "baseName": "reply_to",
             "type": "Array<string>",
+            "format": ""
+        },
+        {
+            "name": "reviewStatus",
+            "baseName": "review_status",
+            "type": "MessageSummaryViewReviewStatusEnum",
             "format": ""
         },
         {
@@ -196,7 +196,7 @@ export enum MessageSummaryViewDirectionEnum {
     Inbound = 'inbound',
     Outbound = 'outbound'
 }
-export enum MessageSummaryViewHitlStatusEnum {
+export enum MessageSummaryViewReviewStatusEnum {
     PendingReview = 'pending_review',
     Sent = 'sent',
     ReviewRejected = 'review_rejected',

--- a/sdks/typescript/src/v1/generated/models/MessageView.ts
+++ b/sdks/typescript/src/v1/generated/models/MessageView.ts
@@ -30,7 +30,6 @@ export class MessageView {
     'flagReason'?: string;
     'flagged'?: boolean;
     '_from': string;
-    'hitlStatus'?: MessageViewHitlStatusEnum;
     'labels': Array<string>;
     'messageId': string;
     'parsed'?: MessageParsedView;
@@ -38,6 +37,7 @@ export class MessageView {
     'readStatus': string;
     'recipient': string;
     'replyTo': Array<string>;
+    'reviewStatus'?: MessageViewReviewStatusEnum;
     'sentAs'?: MessageViewSentAsEnum;
     'sizeBytes'?: number;
     'subject': string;
@@ -129,12 +129,6 @@ export class MessageView {
             "format": ""
         },
         {
-            "name": "hitlStatus",
-            "baseName": "hitl_status",
-            "type": "MessageViewHitlStatusEnum",
-            "format": ""
-        },
-        {
             "name": "labels",
             "baseName": "labels",
             "type": "Array<string>",
@@ -174,6 +168,12 @@ export class MessageView {
             "name": "replyTo",
             "baseName": "reply_to",
             "type": "Array<string>",
+            "format": ""
+        },
+        {
+            "name": "reviewStatus",
+            "baseName": "review_status",
+            "type": "MessageViewReviewStatusEnum",
             "format": ""
         },
         {
@@ -234,7 +234,7 @@ export enum MessageViewDirectionEnum {
     Inbound = 'inbound',
     Outbound = 'outbound'
 }
-export enum MessageViewHitlStatusEnum {
+export enum MessageViewReviewStatusEnum {
     PendingReview = 'pending_review',
     Sent = 'sent',
     ReviewRejected = 'review_rejected',

--- a/sdks/typescript/src/v1/generated/models/ObjectSerializer.ts
+++ b/sdks/typescript/src/v1/generated/models/ObjectSerializer.ts
@@ -108,8 +108,8 @@ import { LimitsUsageView } from '../models/LimitsUsageView.js';
 import { Message } from '../models/Message.js';
 import { MessageBodyView } from '../models/MessageBodyView.js';
 import { MessageParsedView } from '../models/MessageParsedView.js';
-import { MessageSummaryView     , MessageSummaryViewDeliveryStatusEnum  , MessageSummaryViewDirectionEnum     , MessageSummaryViewHitlStatusEnum       , MessageSummaryViewSentAsEnum        } from '../models/MessageSummaryView.js';
-import { MessageView        , MessageViewDeliveryStatusEnum  , MessageViewDirectionEnum     , MessageViewHitlStatusEnum         , MessageViewSentAsEnum        } from '../models/MessageView.js';
+import { MessageSummaryView     , MessageSummaryViewDeliveryStatusEnum  , MessageSummaryViewDirectionEnum          , MessageSummaryViewReviewStatusEnum  , MessageSummaryViewSentAsEnum        } from '../models/MessageSummaryView.js';
+import { MessageView        , MessageViewDeliveryStatusEnum  , MessageViewDirectionEnum            , MessageViewReviewStatusEnum  , MessageViewSentAsEnum        } from '../models/MessageView.js';
 import { OAuthConnectionEntry } from '../models/OAuthConnectionEntry.js';
 import { PageAgentView } from '../models/PageAgentView.js';
 import { PageConversationSummaryView } from '../models/PageConversationSummaryView.js';
@@ -175,11 +175,11 @@ let enumsMap: Set<string> = new Set<string>([
     "EventJSONTypeEnum",
     "MessageSummaryViewDeliveryStatusEnum",
     "MessageSummaryViewDirectionEnum",
-    "MessageSummaryViewHitlStatusEnum",
+    "MessageSummaryViewReviewStatusEnum",
     "MessageSummaryViewSentAsEnum",
     "MessageViewDeliveryStatusEnum",
     "MessageViewDirectionEnum",
-    "MessageViewHitlStatusEnum",
+    "MessageViewReviewStatusEnum",
     "MessageViewSentAsEnum",
     "ProtectionGateViewActionEnum",
     "ProtectionGateViewPolicyEnum",


### PR DESCRIPTION
Two GA-contract polish changes before the `/v1` surface is frozen. **Web layer intentionally deferred** (per stabilization order: API/SDK/MCP first).

## 1. Rename the misnamed `hitl_*` wire fields → `review_*`
The holds vocabulary was unified on `review` (migrations 044/046, #266–#268) — the *values* already moved (`pending_review`, `review_rejected`, …) but the *field names* still said `hitl_`. This freezes the misnomer out of the GA contract:

- `MessageView` / `MessageSummaryView`: `hitl_status` → **`review_status`**
- `AgentIdentity` (GDPR export): `hitl_ttl_seconds` → **`review_ttl_seconds`**, `hitl_expiration_action` → **`review_expiration_action`**

Only JSON tags changed; internal Go identifiers and DB columns are intentionally left as `HITL*`/`hitl_*` (invisible to the contract, **no migration**). Regenerated `api/openapi.yaml` + TS/Py SDK bases.

## 2. Expose the Sent folder to agents over MCP
The HTTP API already supported `direction=inbound|outbound|all`, but the MCP `list_messages` tool was inbound-only — so an agent couldn't read its own sent mail (which the server retains, #256). Added `direction` and retitled to "List messages (inbox or sent)". Closes the Gmail-inbox gap.

## 3. Purge HITL vocabulary from the MCP layer
`hitl.ts` → `review.ts`, `registerHitlTools` → `registerReviewTools`, client `hitlStatus` → `reviewStatus`, reworded tool prose. (The real `internal/httpapi/hitl.go` path reference is kept accurate.)

## Verification
- Go build + contract tests (drift gate, status enums, view-leak guards): ✅
- `make spec-check` + `make generate-sdk-check` (drift gates): ✅ no diff
- TS SDK tests ✅ 98 · MCP tests ✅ 134

## Caveats
- **Breaking wire change.** Renames response field names. Pre-GA / single active operator, so blast radius is ~zero.
- **Web not updated.** The dashboard reads these fields; its pending/messages views break until a web fast-follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)