### PR TITLE
fix(logs): log actual message status/event instead of stale hardcoded vocab

### DIFF
--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -379,7 +379,7 @@ func (a *API) publishApproved(ctx context.Context, e webhookpub.Event, sentMsg *
 			return nil
 		})
 		if err != nil {
-			log.Printf("[api] outbox tx for email.approved err: %v", err)
+			log.Printf("[api] outbox tx for %s err: %v", e.Type, err)
 			outboxWrote = false
 		}
 	}
@@ -400,7 +400,7 @@ func (a *API) publishRejected(ctx context.Context, e webhookpub.Event, rejectedM
 			return a.outbox.PublishTx(ctx, tx, e)
 		})
 		if err != nil {
-			log.Printf("[api] outbox tx for email.rejected err: %v", err)
+			log.Printf("[api] outbox tx for %s err: %v", e.Type, err)
 		} else {
 			outboxWrote = true
 		}
@@ -1001,8 +1001,8 @@ func (a *API) HoldForApprovalCore(ctx context.Context, agent *identity.AgentIden
 	}
 
 	slug, _, _ := strings.Cut(agent.EmailAddress(), "@")
-	log.Printf("[mail:%s] dir=outbound type=%s status=pending_approval from=%s to=%v slug=%s conv_id=%s subject=%q approval_expires_at=%s",
-		msg.ID, msgType, agent.EmailAddress(), req.To, slug, req.ConversationID, req.Subject, msg.ApprovalExpiresAt.Format(time.RFC3339))
+	log.Printf("[mail:%s] dir=outbound type=%s status=%s from=%s to=%v slug=%s conv_id=%s subject=%q approval_expires_at=%s",
+		msg.ID, msgType, msg.Status, agent.EmailAddress(), req.To, slug, req.ConversationID, req.Subject, msg.ApprovalExpiresAt.Format(time.RFC3339))
 
 	// Fire the reviewer notification asynchronously. Failures are logged
 	// inside the notifier and must never block the response — the pending

--- a/internal/agent/hitl_api.go
+++ b/internal/agent/hitl_api.go
@@ -255,7 +255,7 @@ func (a *API) ApproveInboundReviewCore(ctx context.Context, userID string, msg *
 		return &OutboundError{http.StatusInternalServerError, "internal_error", "failed to approve message"}
 	}
 	log.Printf("[mail:%s] dir=inbound type=%s status=%s agent=%s approved_by=user:%s",
-		msg.ID, msg.Type, msg.Status, msg.AgentID, userID)
+		msg.ID, msg.Type, identity.MessageStatusReviewApproved, msg.AgentID, userID)
 	// Post-side-effect publish (the release row is already committed): reuse the
 	// approved-event plumbing (deterministic id off the message id → MTA/retry
 	// idempotent). A minimal *identity.Message carries the id publishApproved needs.
@@ -289,7 +289,7 @@ func (a *API) RejectInboundReviewCore(ctx context.Context, userID, reason string
 		return &OutboundError{http.StatusInternalServerError, "internal_error", "failed to reject message"}
 	}
 	log.Printf("[mail:%s] dir=inbound type=%s status=%s agent=%s rejected_by=user:%s reason=%q",
-		msg.ID, msg.Type, msg.Status, msg.AgentID, userID, reason)
+		msg.ID, msg.Type, identity.MessageStatusReviewRejected, msg.AgentID, userID, reason)
 	a.publishRejected(ctx, a.buildInboundRejectedEvent(msg, a.reviewOwnerID(ctx, msg.AgentID, userID), userID, reason), msg.ID)
 	return nil
 }

--- a/internal/agent/hitl_api.go
+++ b/internal/agent/hitl_api.go
@@ -135,8 +135,8 @@ func (a *API) ApprovePendingCore(ctx context.Context, userID, messageID, expecte
 		log.Printf("[api] usage recording error: %v", err)
 	}
 	slug, _, _ := strings.Cut(agent.EmailAddress(), "@")
-	log.Printf("[mail:%s] dir=outbound type=%s status=sent from=%s to=%v slug=%s subject=%q edited=%v approved=user:%s",
-		sent.ID, sent.Type, agent.EmailAddress(), sent.ToRecipients, slug, sent.Subject, sent.Edited, userID)
+	log.Printf("[mail:%s] dir=outbound type=%s status=%s from=%s to=%v slug=%s subject=%q edited=%v approved=user:%s",
+		sent.ID, sent.Type, sent.Status, agent.EmailAddress(), sent.ToRecipients, slug, sent.Subject, sent.Edited, userID)
 	a.publishApproved(ctx, a.buildApprovedEvent(agent, sent, userID), sent)
 	return sent, nil
 }
@@ -230,8 +230,8 @@ func (a *API) RejectPendingCore(ctx context.Context, userID, messageID, expected
 			return nil, &OutboundError{http.StatusInternalServerError, "internal_error", "failed to reject message"}
 		}
 	}
-	log.Printf("[mail:%s] dir=outbound type=%s status=rejected agent=%s rejected_by=user:%s reason=%q",
-		rejected.ID, rejected.Type, rejected.AgentID, userID, reason)
+	log.Printf("[mail:%s] dir=outbound type=%s status=%s agent=%s rejected_by=user:%s reason=%q",
+		rejected.ID, rejected.Type, rejected.Status, rejected.AgentID, userID, reason)
 	a.publishRejected(ctx, a.buildRejectedEvent(userID, rejected, reason), rejected.ID)
 	return rejected, nil
 }
@@ -254,8 +254,8 @@ func (a *API) ApproveInboundReviewCore(ctx context.Context, userID string, msg *
 		log.Printf("[api] approve inbound review %s: %v", msg.ID, err)
 		return &OutboundError{http.StatusInternalServerError, "internal_error", "failed to approve message"}
 	}
-	log.Printf("[mail:%s] dir=inbound type=%s status=review_approved agent=%s approved_by=user:%s",
-		msg.ID, msg.Type, msg.AgentID, userID)
+	log.Printf("[mail:%s] dir=inbound type=%s status=%s agent=%s approved_by=user:%s",
+		msg.ID, msg.Type, msg.Status, msg.AgentID, userID)
 	// Post-side-effect publish (the release row is already committed): reuse the
 	// approved-event plumbing (deterministic id off the message id → MTA/retry
 	// idempotent). A minimal *identity.Message carries the id publishApproved needs.
@@ -288,8 +288,8 @@ func (a *API) RejectInboundReviewCore(ctx context.Context, userID, reason string
 		log.Printf("[api] reject inbound review %s: %v", msg.ID, err)
 		return &OutboundError{http.StatusInternalServerError, "internal_error", "failed to reject message"}
 	}
-	log.Printf("[mail:%s] dir=inbound type=%s status=review_rejected agent=%s rejected_by=user:%s reason=%q",
-		msg.ID, msg.Type, msg.AgentID, userID, reason)
+	log.Printf("[mail:%s] dir=inbound type=%s status=%s agent=%s rejected_by=user:%s reason=%q",
+		msg.ID, msg.Type, msg.Status, msg.AgentID, userID, reason)
 	a.publishRejected(ctx, a.buildInboundRejectedEvent(msg, a.reviewOwnerID(ctx, msg.AgentID, userID), userID, reason), msg.ID)
 	return nil
 }

--- a/internal/agent/hitl_magic_api.go
+++ b/internal/agent/hitl_magic_api.go
@@ -269,8 +269,8 @@ func (a *API) magicApprove(w http.ResponseWriter, r *http.Request, messageID, us
 	if _, err := a.usage.RecordAndCheck(r.Context(), userID, agent.ID, agent.Domain, "outbound"); err != nil {
 		log.Printf("[api] magic-approve usage error: %v", err)
 	}
-	log.Printf("[mail:%s] dir=outbound type=%s status=sent agent=%s to=%v approved=magic-link:user:%s",
-		sent.ID, sent.Type, agent.EmailAddress(), sent.ToRecipients, userID)
+	log.Printf("[mail:%s] dir=outbound type=%s status=%s agent=%s to=%v approved=magic-link:user:%s",
+		sent.ID, sent.Type, sent.Status, agent.EmailAddress(), sent.ToRecipients, userID)
 
 	writeMagicMessage(w, http.StatusOK,
 		"Approved",
@@ -294,8 +294,8 @@ func (a *API) magicReject(w http.ResponseWriter, r *http.Request, messageID, use
 		}
 		return
 	}
-	log.Printf("[mail:%s] dir=outbound type=%s status=rejected rejected_by=magic-link:user:%s reason=%q",
-		rejected.ID, rejected.Type, userID, reason)
+	log.Printf("[mail:%s] dir=outbound type=%s status=%s rejected_by=magic-link:user:%s reason=%q",
+		rejected.ID, rejected.Type, rejected.Status, userID, reason)
 
 	writeMagicMessage(w, http.StatusOK, "Rejected",
 		"The message has been discarded and will not be sent.")

--- a/internal/hitlworker/worker.go
+++ b/internal/hitlworker/worker.go
@@ -236,8 +236,8 @@ func (w *Worker) autoApprove(ctx context.Context, c identity.ExpirationCandidate
 	if _, err := w.usage.RecordAndCheck(ctx, agent.UserID, agent.ID, agent.Domain, "outbound"); err != nil {
 		log.Printf("[hitl-worker] usage recording error: %v", err)
 	}
-	log.Printf("[mail:%s] dir=outbound type=%s status=expired_approved agent=%s to=%v auto_sent=true",
-		sent.ID, sent.Type, agent.ID, sent.ToRecipients)
+	log.Printf("[mail:%s] dir=outbound type=%s status=%s agent=%s to=%v auto_sent=true",
+		sent.ID, sent.Type, sent.Status, agent.ID, sent.ToRecipients)
 	// Mirror the user-driven approve: fire email.review_approved (the send
 	// already happened; this is the post-side-effect notification).
 	w.emitOutboundApproved(agent, sent)
@@ -259,8 +259,8 @@ func (w *Worker) autoReject(ctx context.Context, messageID, reason string) {
 			messageID, reason, err)
 		return
 	}
-	log.Printf("[mail:%s] dir=outbound type=%s status=expired_rejected agent=%s reason=%q auto_rejected=true",
-		rejected.ID, rejected.Type, rejected.AgentID, reason)
+	log.Printf("[mail:%s] dir=outbound type=%s status=%s agent=%s reason=%q auto_rejected=true",
+		rejected.ID, rejected.Type, rejected.Status, rejected.AgentID, reason)
 	w.emitOutboundRejected(ctx, rejected, reason)
 }
 


### PR DESCRIPTION
The HITL/review log lines hardcoded status + event strings that drifted out of sync with the unified-holds rename (#266) — so logs printed the *old* status while the API/DB used the new one (e.g. `status=pending_approval` for a row that's actually `pending_review`). Surfaced live in the contract-server logs during PR #274 verification.

## Wider log audit
Scanned every `log.*`/`Printf`/`slog.*` in `internal/` + `cmd/` for retired vocab. Findings (all in the HITL/review path; the rest of the codebase's logs were clean — no stale `agent_mode`/`hitl_enabled`/`screening_events`/`/api/v1`/retired-event-name logs):

| Site | Was | Actual |
|---|---|---|
| `agent/api.go` (held send) | `status=pending_approval` | `pending_review` |
| `hitlworker/worker.go` (TTL auto-send) | `status=expired_approved` | `sent` |
| `hitlworker/worker.go` (TTL auto-reject) | `status=expired_rejected` | `review_expired_rejected` |
| `agent/hitl_api.go` + `hitl_magic_api.go` (outbound reject) | `status=rejected` | `review_rejected` |
| `agent/api.go` ×2 (outbox error) | `email.approved` / `email.rejected` | `email.review_approved` / `email.review_rejected` |

## Fix
Root-cause fix: log the **actual** row field (`msg`/`sent`/`rejected` `.Status`) and the real event (`e.Type`) instead of a hardcoded literal, so these can't drift again. Also converted the remaining correct-but-hardcoded `[mail:]` status logs (`sent`, `review_approved`, `review_rejected`) to the dynamic field for consistency.

**Log-only — no behavior change.** `go build ./...` + `go vet` clean (no Printf arg issues); `hitlworker` tests pass; final sweep confirms zero hardcoded `status=` literals remain in `[mail:]` logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)