### PR TITLE
feat(web): agentic (MCP) setup option on Get Started

### DIFF
--- a/web/src/app/(app)/get-started/_components/AddressChoice.tsx
+++ b/web/src/app/(app)/get-started/_components/AddressChoice.tsx
@@ -30,16 +30,14 @@ export function AddressChoice({
             padding: 18,
           }}
         >
-          <div className="absolute top-3.5 right-3.5">
-            <Chip tone="accent">Recommended</Chip>
-          </div>
-          <div className="flex items-center gap-2 mb-1">
+          <div className="flex items-center gap-2 mb-1 flex-wrap">
             <span
               className="text-[14px] font-semibold"
               style={{ color: "var(--fg)" }}
             >
               Shared e2a domain
             </span>
+            <Chip tone="accent">Recommended</Chip>
             <Chip tone="success" mono>
               1 min
             </Chip>

--- a/web/src/app/(app)/get-started/_components/AddressChoice.tsx
+++ b/web/src/app/(app)/get-started/_components/AddressChoice.tsx
@@ -13,7 +13,7 @@ export function AddressChoice({
 }) {
   return (
     <div>
-      <div className="grid gap-3.5 sm:grid-cols-2">
+      <div className="grid gap-3.5 sm:grid-cols-3">
         {/* Shared option */}
         <button
           type="button"
@@ -100,6 +100,49 @@ export function AddressChoice({
             <li>· Use your own domain (e.g. acme.io)</li>
             <li>· Add DNS records · verify in &lt;5min</li>
             <li>· Production-ready, brand-safe</li>
+          </ul>
+        </button>
+
+        {/* Agentic / MCP option — hand setup to the user's agent over MCP */}
+        <button
+          type="button"
+          aria-pressed={selected === "agent"}
+          onClick={() => onSelect("agent")}
+          className="relative text-left transition focus:outline-none"
+          style={{
+            background: "var(--bg-panel)",
+            border:
+              selected === "agent"
+                ? "2px solid var(--accent)"
+                : "1px solid var(--border)",
+            borderRadius: "var(--r-lg)",
+            padding: 18,
+          }}
+        >
+          <div className="flex items-center gap-2 mb-1">
+            <span
+              className="text-[14px] font-semibold"
+              style={{ color: "var(--fg)" }}
+            >
+              With an agent
+            </span>
+            <Chip tone="neutral" mono>
+              MCP
+            </Chip>
+          </div>
+          <div
+            className="font-mono text-[12px] mb-3"
+            style={{ color: "var(--fg-muted)" }}
+          >
+            headless · no forms
+          </div>
+          <ul
+            className="list-none m-0 p-0 text-[12px] leading-[1.7]"
+            style={{ color: "var(--fg-muted)" }}
+          >
+            <li>· Your agent connects over MCP</li>
+            <li>· OAuth sign-in — no API key</li>
+            <li>· Claude Code, Cursor, Desktop…</li>
           </ul>
         </button>
       </div>

--- a/web/src/app/(app)/get-started/_components/AddressChoice.tsx
+++ b/web/src/app/(app)/get-started/_components/AddressChoice.tsx
@@ -13,7 +13,7 @@ export function AddressChoice({
 }) {
   return (
     <div>
-      <div className="grid gap-3.5 sm:grid-cols-3">
+      <div className="grid gap-3.5 sm:grid-cols-2">
         {/* Shared option */}
         <button
           type="button"
@@ -98,49 +98,6 @@ export function AddressChoice({
             <li>· Use your own domain (e.g. acme.io)</li>
             <li>· Add DNS records · verify in &lt;5min</li>
             <li>· Production-ready, brand-safe</li>
-          </ul>
-        </button>
-
-        {/* Agentic / MCP option — hand setup to the user's agent over MCP */}
-        <button
-          type="button"
-          aria-pressed={selected === "agent"}
-          onClick={() => onSelect("agent")}
-          className="relative text-left transition focus:outline-none"
-          style={{
-            background: "var(--bg-panel)",
-            border:
-              selected === "agent"
-                ? "2px solid var(--accent)"
-                : "1px solid var(--border)",
-            borderRadius: "var(--r-lg)",
-            padding: 18,
-          }}
-        >
-          <div className="flex items-center gap-2 mb-1">
-            <span
-              className="text-[14px] font-semibold"
-              style={{ color: "var(--fg)" }}
-            >
-              With an agent
-            </span>
-            <Chip tone="neutral" mono>
-              MCP
-            </Chip>
-          </div>
-          <div
-            className="font-mono text-[12px] mb-3"
-            style={{ color: "var(--fg-muted)" }}
-          >
-            headless · no forms
-          </div>
-          <ul
-            className="list-none m-0 p-0 text-[12px] leading-[1.7]"
-            style={{ color: "var(--fg-muted)" }}
-          >
-            <li>· Your agent connects over MCP</li>
-            <li>· OAuth sign-in — no API key</li>
-            <li>· Claude Code, Cursor, Desktop…</li>
           </ul>
         </button>
       </div>

--- a/web/src/app/(app)/get-started/_components/AddressChoice.tsx
+++ b/web/src/app/(app)/get-started/_components/AddressChoice.tsx
@@ -3,6 +3,7 @@
 import type { AddressType } from "../../../components/onboarding/types";
 import { Chip } from "../../../components/loft/Chip";
 import { AGENTS_DOMAIN_DISPLAY } from "../../../../lib/site";
+import { SelectableCard } from "./SelectableCard";
 
 export function AddressChoice({
   selected,
@@ -12,95 +13,57 @@ export function AddressChoice({
   onSelect: (type: AddressType) => void;
 }) {
   return (
-    <div>
-      <div className="grid gap-3.5 sm:grid-cols-2">
-        {/* Shared option */}
-        <button
-          type="button"
-          aria-pressed={selected === "shared"}
-          onClick={() => onSelect("shared")}
-          className="relative text-left transition focus:outline-none"
-          style={{
-            background: "var(--bg-panel)",
-            border:
-              selected === "shared"
-                ? "2px solid var(--accent)"
-                : "2px solid var(--accent)",
-            borderRadius: "var(--r-lg)",
-            padding: 18,
-          }}
+    <div className="grid gap-3.5 sm:grid-cols-2">
+      <SelectableCard active={selected === "shared"} onClick={() => onSelect("shared")}>
+        <div className="flex items-center gap-2 mb-1 flex-wrap">
+          <span className="text-[14px] font-semibold" style={{ color: "var(--fg)" }}>
+            Shared e2a domain
+          </span>
+          <Chip tone="accent">Recommended</Chip>
+          <Chip tone="success" mono>
+            1 min
+          </Chip>
+        </div>
+        <div
+          className="font-mono text-[12px] mb-3"
+          style={{ color: "var(--accent-strong)" }}
         >
-          <div className="flex items-center gap-2 mb-1 flex-wrap">
-            <span
-              className="text-[14px] font-semibold"
-              style={{ color: "var(--fg)" }}
-            >
-              Shared e2a domain
-            </span>
-            <Chip tone="accent">Recommended</Chip>
-            <Chip tone="success" mono>
-              1 min
-            </Chip>
-          </div>
-          <div
-            className="font-mono text-[12px] mb-3"
-            style={{ color: "var(--accent-strong)" }}
-          >
-            your-slug@{AGENTS_DOMAIN_DISPLAY}
-          </div>
-          <ul
-            className="list-none m-0 p-0 text-[12px] leading-[1.7]"
-            style={{ color: "var(--fg-muted)" }}
-          >
-            <li>· Skip DNS setup entirely</li>
-            <li>· Inherits e2a&apos;s verified domain</li>
-            <li>· Best for prototypes and testing</li>
-          </ul>
-        </button>
+          your-slug@{AGENTS_DOMAIN_DISPLAY}
+        </div>
+        <ul
+          className="list-none m-0 p-0 text-[12px] leading-[1.7]"
+          style={{ color: "var(--fg-muted)" }}
+        >
+          <li>· Skip DNS setup entirely</li>
+          <li>· Inherits e2a&apos;s verified domain</li>
+          <li>· Best for prototypes and testing</li>
+        </ul>
+      </SelectableCard>
 
-        {/* Custom option */}
-        <button
-          type="button"
-          aria-pressed={selected === "custom"}
-          onClick={() => onSelect("custom")}
-          className="relative text-left transition focus:outline-none"
-          style={{
-            background: "var(--bg-panel)",
-            border:
-              selected === "custom"
-                ? "2px solid var(--accent)"
-                : "1px solid var(--border)",
-            borderRadius: "var(--r-lg)",
-            padding: 18,
-          }}
+      <SelectableCard active={selected === "custom"} onClick={() => onSelect("custom")}>
+        <div className="flex items-center gap-2 mb-1">
+          <span className="text-[14px] font-semibold" style={{ color: "var(--fg)" }}>
+            Custom domain
+          </span>
+          <Chip tone="neutral" mono>
+            ~10 min
+          </Chip>
+        </div>
+        <div
+          className="font-mono text-[12px] mb-3"
+          style={{ color: "var(--fg-muted)" }}
         >
-          <div className="flex items-center gap-2 mb-1">
-            <span
-              className="text-[14px] font-semibold"
-              style={{ color: "var(--fg)" }}
-            >
-              Custom domain
-            </span>
-            <Chip tone="neutral" mono>
-              ~10 min
-            </Chip>
-          </div>
-          <div
-            className="font-mono text-[12px] mb-3"
-            style={{ color: "var(--fg-muted)" }}
-          >
-            you@<span style={{ color: "var(--fg)" }}>yourcompany.com</span>
-          </div>
-          <ul
-            className="list-none m-0 p-0 text-[12px] leading-[1.7]"
-            style={{ color: "var(--fg-muted)" }}
-          >
-            <li>· Use your own domain (e.g. acme.io)</li>
-            <li>· Add DNS records · verify in &lt;5min</li>
-            <li>· Production-ready, brand-safe</li>
-          </ul>
-        </button>
-      </div>
+          you@<span style={{ color: "var(--fg)" }}>yourcompany.com</span>
+        </div>
+        <ul
+          className="list-none m-0 p-0 text-[12px] leading-[1.7]"
+          style={{ color: "var(--fg-muted)" }}
+        >
+          <li>· Use your own domain (e.g. acme.io)</li>
+          <li>· Add DNS records · verify in &lt;5min</li>
+          <li>· Production-ready, brand-safe</li>
+        </ul>
+      </SelectableCard>
     </div>
   );
 }

--- a/web/src/app/(app)/get-started/_components/AgentSetupCards.tsx
+++ b/web/src/app/(app)/get-started/_components/AgentSetupCards.tsx
@@ -1,0 +1,152 @@
+"use client";
+
+// Agentic onboarding: instead of the browser forms, let the user's AI agent
+// stand up an inbox headlessly over e2a's hosted MCP server. Two paths mirror
+// how agents actually connect:
+//   1. Paste a prompt into a no-terminal agent (Claude Desktop, a chat box) —
+//      it fetches the e2a skill, connects over MCP, and provisions the inbox.
+//   2. One CLI command for OAuth-capable MCP clients (Claude Code, Cursor, …).
+// e2a's MCP is hosted with OAuth 2.1, so neither path needs an API key pasted.
+
+import { useState } from "react";
+
+// Hosted, account-scoped MCP endpoint (mcp/README.md). OAuth 2.1 → the
+// `mcp add` command opens a browser consent flow; no key to copy.
+const MCP_URL = "https://api.e2a.dev/mcp";
+// Agent-facing setup doc — the same skill the landing page points to. The
+// pasted agent fetches it to learn how to connect + drive e2a.
+const SKILL_URL =
+  "https://raw.githubusercontent.com/Mnexa-AI/e2a/main/skills/using-e2a/SKILL.md";
+
+const PASTE_PROMPT = `Give yourself an email inbox with e2a. Read ${SKILL_URL}, connect to the e2a MCP server at ${MCP_URL}, then create my inbox and walk me through it.`;
+
+const CONNECT_COMMAND = `claude mcp add --transport http e2a ${MCP_URL}`;
+
+function CopyButton({ value, label }: { value: string; label: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      onClick={() => {
+        navigator.clipboard?.writeText(value);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      }}
+      className="text-[12px] px-3 py-1.5 transition"
+      style={{
+        background: "var(--bg-panel)",
+        color: "var(--fg)",
+        border: "1px solid var(--border)",
+        borderRadius: "var(--r-md)",
+      }}
+    >
+      {copied ? "Copied!" : label}
+    </button>
+  );
+}
+
+function CodeBlock({ children }: { children: React.ReactNode }) {
+  return (
+    <div
+      className="font-mono text-[12px] leading-[1.6] p-3.5 mb-2.5 overflow-x-auto whitespace-pre-wrap"
+      style={{
+        background: "var(--ink, #1c1917)",
+        color: "var(--ink-fg, #e7e5e4)",
+        borderRadius: "var(--r-md)",
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function SetupCard({
+  step,
+  title,
+  blurb,
+  children,
+}: {
+  step: string;
+  title: string;
+  blurb: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className="p-5"
+      style={{
+        background: "var(--bg-panel)",
+        border: "1px solid var(--border)",
+        borderRadius: "var(--r-lg)",
+      }}
+    >
+      <div className="text-[14px] font-semibold mb-1" style={{ color: "var(--fg)" }}>
+        {step} · {title}
+      </div>
+      <p className="text-[12px] mb-3 leading-[1.6]" style={{ color: "var(--fg-muted)" }}>
+        {blurb}
+      </p>
+      {children}
+    </div>
+  );
+}
+
+export function AgentSetupCards({ onBack }: { onBack: () => void }) {
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={onBack}
+        className="text-[12px] mb-4 inline-flex items-center gap-1 transition"
+        style={{ color: "var(--fg-muted)" }}
+      >
+        ← Back
+      </button>
+
+      <div className="flex flex-col gap-3.5">
+        <SetupCard
+          step="1"
+          title="Paste into your agent"
+          blurb={
+            <>
+              For any agent without a terminal (Claude Desktop, a chat box). It
+              fetches the e2a skill, connects over MCP, and sets up your inbox —
+              no API key, nothing on your end.
+            </>
+          }
+        >
+          <CodeBlock>{PASTE_PROMPT}</CodeBlock>
+          <CopyButton value={PASTE_PROMPT} label="Copy prompt" />
+        </SetupCard>
+
+        <SetupCard
+          step="2"
+          title="Or connect a client directly"
+          blurb={
+            <>
+              For Claude Code, Cursor, Goose, Windsurf, Zed, or any MCP client
+              that supports OAuth. One command — no API key to copy.
+            </>
+          }
+        >
+          <CodeBlock>
+            <span style={{ color: "var(--ok, #4ade80)" }}>$ </span>
+            {CONNECT_COMMAND}
+          </CodeBlock>
+          <CopyButton value={CONNECT_COMMAND} label="Copy command" />
+          <ol
+            className="mt-3.5 mb-0 text-[12px] leading-[1.8] list-decimal pl-5"
+            style={{ color: "var(--fg-muted)" }}
+          >
+            <li>Run the command — your browser opens automatically.</li>
+            <li>Sign in to e2a (the account you&apos;re in right now).</li>
+            <li>
+              Approve, then ask your agent to set up an inbox (e.g. “create me an
+              inbox on the shared domain”).
+            </li>
+          </ol>
+        </SetupCard>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/(app)/get-started/_components/SelectableCard.tsx
+++ b/web/src/app/(app)/get-started/_components/SelectableCard.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+// A selectable option card used by the onboarding choosers (setup method,
+// address type). Neutral border by default — a "Recommended" chip in the
+// content marks the suggested option, NOT a standing accent border (which
+// reads as "stuck selected"). Hover or selection adds the accent border + an
+// elevated background. Inline `background`/`border` win over Tailwind `hover:`
+// utilities, so the hover state is driven from React state. Border width is a
+// constant 2px in both states so hovering never shifts layout.
+
+import { useState } from "react";
+
+export function SelectableCard({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  const [hovered, setHovered] = useState(false);
+  const accent = active || hovered;
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={onClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      className="relative text-left transition focus:outline-none"
+      style={{
+        background: hovered ? "var(--bg-elev)" : "var(--bg-panel)",
+        border: accent ? "2px solid var(--accent)" : "2px solid var(--border)",
+        borderRadius: "var(--r-lg)",
+        padding: 18,
+        cursor: "pointer",
+      }}
+    >
+      {children}
+    </button>
+  );
+}

--- a/web/src/app/(app)/get-started/_components/SetupMethodChoice.tsx
+++ b/web/src/app/(app)/get-started/_components/SetupMethodChoice.tsx
@@ -5,8 +5,48 @@
 // path is recommended because it provisions the inbox end-to-end with no forms
 // and no API key; the web path is the click-through fallback.
 
+import { useState } from "react";
 import type { SetupMethod } from "../../../components/onboarding/types";
 import { Chip } from "../../../components/loft/Chip";
+
+// One selectable card. The recommended card carries a standing accent border;
+// hover (or selection) adds the accent + an elevated background as interactive
+// feedback. Inline `background`/`border` win over Tailwind `hover:` utilities,
+// so the hover state is driven from React state, not a `hover:` class. Border
+// width is a constant 2px in both states so hovering never shifts layout.
+function MethodCard({
+  recommended = false,
+  active,
+  onClick,
+  children,
+}: {
+  recommended?: boolean;
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  const [hovered, setHovered] = useState(false);
+  const accent = recommended || active || hovered;
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={onClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      className="relative text-left transition focus:outline-none"
+      style={{
+        background: hovered ? "var(--bg-elev)" : "var(--bg-panel)",
+        border: accent ? "2px solid var(--accent)" : "2px solid var(--border)",
+        borderRadius: "var(--r-lg)",
+        padding: 18,
+        cursor: "pointer",
+      }}
+    >
+      {children}
+    </button>
+  );
+}
 
 export function SetupMethodChoice({
   selected,
@@ -17,19 +57,7 @@ export function SetupMethodChoice({
 }) {
   return (
     <div className="grid gap-3.5 sm:grid-cols-2">
-      {/* Agent / MCP — recommended */}
-      <button
-        type="button"
-        aria-pressed={selected === "agent"}
-        onClick={() => onSelect("agent")}
-        className="relative text-left transition focus:outline-none"
-        style={{
-          background: "var(--bg-panel)",
-          border: "2px solid var(--accent)",
-          borderRadius: "var(--r-lg)",
-          padding: 18,
-        }}
-      >
+      <MethodCard recommended active={selected === "agent"} onClick={() => onSelect("agent")}>
         <div className="flex items-center gap-2 mb-1 flex-wrap">
           <span className="text-[14px] font-semibold" style={{ color: "var(--fg)" }}>
             With an agent
@@ -53,24 +81,9 @@ export function SetupMethodChoice({
           <li>· OAuth sign-in — no API key to copy</li>
           <li>· Claude Code, Cursor, Claude Desktop…</li>
         </ul>
-      </button>
+      </MethodCard>
 
-      {/* Web UI — the click-through forms */}
-      <button
-        type="button"
-        aria-pressed={selected === "web"}
-        onClick={() => onSelect("web")}
-        className="relative text-left transition focus:outline-none"
-        style={{
-          background: "var(--bg-panel)",
-          border:
-            selected === "web"
-              ? "2px solid var(--accent)"
-              : "1px solid var(--border)",
-          borderRadius: "var(--r-lg)",
-          padding: 18,
-        }}
-      >
+      <MethodCard active={selected === "web"} onClick={() => onSelect("web")}>
         <div className="flex items-center gap-2 mb-1">
           <span className="text-[14px] font-semibold" style={{ color: "var(--fg)" }}>
             Set up in the web UI
@@ -90,7 +103,7 @@ export function SetupMethodChoice({
           <li>· Fill a short form, verify in the browser</li>
           <li>· No agent required</li>
         </ul>
-      </button>
+      </MethodCard>
     </div>
   );
 }

--- a/web/src/app/(app)/get-started/_components/SetupMethodChoice.tsx
+++ b/web/src/app/(app)/get-started/_components/SetupMethodChoice.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+// Top-level onboarding fork: hand setup to an AI agent over MCP (recommended,
+// headless) or set up in the web UI (the shared/custom-domain forms). The agent
+// path is recommended because it provisions the inbox end-to-end with no forms
+// and no API key; the web path is the click-through fallback.
+
+import type { SetupMethod } from "../../../components/onboarding/types";
+import { Chip } from "../../../components/loft/Chip";
+
+export function SetupMethodChoice({
+  selected,
+  onSelect,
+}: {
+  selected: SetupMethod | null;
+  onSelect: (method: SetupMethod) => void;
+}) {
+  return (
+    <div className="grid gap-3.5 sm:grid-cols-2">
+      {/* Agent / MCP — recommended */}
+      <button
+        type="button"
+        aria-pressed={selected === "agent"}
+        onClick={() => onSelect("agent")}
+        className="relative text-left transition focus:outline-none"
+        style={{
+          background: "var(--bg-panel)",
+          border: "2px solid var(--accent)",
+          borderRadius: "var(--r-lg)",
+          padding: 18,
+        }}
+      >
+        <div className="flex items-center gap-2 mb-1 flex-wrap">
+          <span className="text-[14px] font-semibold" style={{ color: "var(--fg)" }}>
+            With an agent
+          </span>
+          <Chip tone="accent">Recommended</Chip>
+          <Chip tone="neutral" mono>
+            MCP
+          </Chip>
+        </div>
+        <div
+          className="font-mono text-[12px] mb-3"
+          style={{ color: "var(--accent-strong)" }}
+        >
+          headless · no forms
+        </div>
+        <ul
+          className="list-none m-0 p-0 text-[12px] leading-[1.7]"
+          style={{ color: "var(--fg-muted)" }}
+        >
+          <li>· Your agent connects over MCP and sets up the inbox</li>
+          <li>· OAuth sign-in — no API key to copy</li>
+          <li>· Claude Code, Cursor, Claude Desktop…</li>
+        </ul>
+      </button>
+
+      {/* Web UI — the click-through forms */}
+      <button
+        type="button"
+        aria-pressed={selected === "web"}
+        onClick={() => onSelect("web")}
+        className="relative text-left transition focus:outline-none"
+        style={{
+          background: "var(--bg-panel)",
+          border:
+            selected === "web"
+              ? "2px solid var(--accent)"
+              : "1px solid var(--border)",
+          borderRadius: "var(--r-lg)",
+          padding: 18,
+        }}
+      >
+        <div className="flex items-center gap-2 mb-1">
+          <span className="text-[14px] font-semibold" style={{ color: "var(--fg)" }}>
+            Set up in the web UI
+          </span>
+        </div>
+        <div
+          className="font-mono text-[12px] mb-3"
+          style={{ color: "var(--fg-muted)" }}
+        >
+          shared or custom domain
+        </div>
+        <ul
+          className="list-none m-0 p-0 text-[12px] leading-[1.7]"
+          style={{ color: "var(--fg-muted)" }}
+        >
+          <li>· Pick a shared e2a or your own domain</li>
+          <li>· Fill a short form, verify in the browser</li>
+          <li>· No agent required</li>
+        </ul>
+      </button>
+    </div>
+  );
+}

--- a/web/src/app/(app)/get-started/_components/SetupMethodChoice.tsx
+++ b/web/src/app/(app)/get-started/_components/SetupMethodChoice.tsx
@@ -5,47 +5,9 @@
 // path is recommended because it provisions the inbox end-to-end with no forms
 // and no API key; the web path is the click-through fallback.
 
-import { useState } from "react";
 import type { SetupMethod } from "../../../components/onboarding/types";
 import { Chip } from "../../../components/loft/Chip";
-
-// One selectable card. Neutral border by default (the "Recommended" chip, not
-// a standing accent border, marks the suggested option); hover or selection
-// adds the accent + an elevated background as interactive feedback. Inline
-// `background`/`border` win over Tailwind `hover:` utilities, so the hover
-// state is driven from React state, not a `hover:` class. Border width is a
-// constant 2px in both states so hovering never shifts layout.
-function MethodCard({
-  active,
-  onClick,
-  children,
-}: {
-  active: boolean;
-  onClick: () => void;
-  children: React.ReactNode;
-}) {
-  const [hovered, setHovered] = useState(false);
-  const accent = active || hovered;
-  return (
-    <button
-      type="button"
-      aria-pressed={active}
-      onClick={onClick}
-      onMouseEnter={() => setHovered(true)}
-      onMouseLeave={() => setHovered(false)}
-      className="relative text-left transition focus:outline-none"
-      style={{
-        background: hovered ? "var(--bg-elev)" : "var(--bg-panel)",
-        border: accent ? "2px solid var(--accent)" : "2px solid var(--border)",
-        borderRadius: "var(--r-lg)",
-        padding: 18,
-        cursor: "pointer",
-      }}
-    >
-      {children}
-    </button>
-  );
-}
+import { SelectableCard } from "./SelectableCard";
 
 export function SetupMethodChoice({
   selected,
@@ -56,7 +18,7 @@ export function SetupMethodChoice({
 }) {
   return (
     <div className="grid gap-3.5 sm:grid-cols-2">
-      <MethodCard active={selected === "agent"} onClick={() => onSelect("agent")}>
+      <SelectableCard active={selected === "agent"} onClick={() => onSelect("agent")}>
         <div className="flex items-center gap-2 mb-1 flex-wrap">
           <span className="text-[14px] font-semibold" style={{ color: "var(--fg)" }}>
             With an agent
@@ -80,9 +42,9 @@ export function SetupMethodChoice({
           <li>· OAuth sign-in — no API key to copy</li>
           <li>· Claude Code, Cursor, Claude Desktop…</li>
         </ul>
-      </MethodCard>
+      </SelectableCard>
 
-      <MethodCard active={selected === "web"} onClick={() => onSelect("web")}>
+      <SelectableCard active={selected === "web"} onClick={() => onSelect("web")}>
         <div className="flex items-center gap-2 mb-1">
           <span className="text-[14px] font-semibold" style={{ color: "var(--fg)" }}>
             Set up in the web UI
@@ -102,7 +64,7 @@ export function SetupMethodChoice({
           <li>· Fill a short form, verify in the browser</li>
           <li>· No agent required</li>
         </ul>
-      </MethodCard>
+      </SelectableCard>
     </div>
   );
 }

--- a/web/src/app/(app)/get-started/_components/SetupMethodChoice.tsx
+++ b/web/src/app/(app)/get-started/_components/SetupMethodChoice.tsx
@@ -9,24 +9,23 @@ import { useState } from "react";
 import type { SetupMethod } from "../../../components/onboarding/types";
 import { Chip } from "../../../components/loft/Chip";
 
-// One selectable card. The recommended card carries a standing accent border;
-// hover (or selection) adds the accent + an elevated background as interactive
-// feedback. Inline `background`/`border` win over Tailwind `hover:` utilities,
-// so the hover state is driven from React state, not a `hover:` class. Border
-// width is a constant 2px in both states so hovering never shifts layout.
+// One selectable card. Neutral border by default (the "Recommended" chip, not
+// a standing accent border, marks the suggested option); hover or selection
+// adds the accent + an elevated background as interactive feedback. Inline
+// `background`/`border` win over Tailwind `hover:` utilities, so the hover
+// state is driven from React state, not a `hover:` class. Border width is a
+// constant 2px in both states so hovering never shifts layout.
 function MethodCard({
-  recommended = false,
   active,
   onClick,
   children,
 }: {
-  recommended?: boolean;
   active: boolean;
   onClick: () => void;
   children: React.ReactNode;
 }) {
   const [hovered, setHovered] = useState(false);
-  const accent = recommended || active || hovered;
+  const accent = active || hovered;
   return (
     <button
       type="button"
@@ -57,7 +56,7 @@ export function SetupMethodChoice({
 }) {
   return (
     <div className="grid gap-3.5 sm:grid-cols-2">
-      <MethodCard recommended active={selected === "agent"} onClick={() => onSelect("agent")}>
+      <MethodCard active={selected === "agent"} onClick={() => onSelect("agent")}>
         <div className="flex items-center gap-2 mb-1 flex-wrap">
           <span className="text-[14px] font-semibold" style={{ color: "var(--fg)" }}>
             With an agent

--- a/web/src/app/(app)/get-started/page.test.tsx
+++ b/web/src/app/(app)/get-started/page.test.tsx
@@ -66,6 +66,16 @@ function setSearchParams(params: Record<string, string | undefined> = {}) {
   });
 }
 
+// Fresh users land on the top-level method choice (SetupMethodChoice:
+// "With an agent" / "Set up in the web UI"). The shared/custom address
+// chooser now lives one level deeper, behind "Set up in the web UI".
+// Tests that exercise the address chooser navigate through it first.
+async function chooseWebUI() {
+  await waitFor(() => expect(screen.getByText("With an agent")).toBeInTheDocument());
+  fireEvent.click(screen.getByText("Set up in the web UI"));
+  await waitFor(() => expect(screen.getByText("Shared e2a domain")).toBeInTheDocument());
+}
+
 
 const verifiedDomain = {
   domain: "verified.example.com",
@@ -145,9 +155,7 @@ describe("Address type choice", () => {
   it("renders Shared e2a domain and Custom domain options for fresh user", async () => {
     mockFreshUser();
     render(<GetStartedPage />);
-    await waitFor(() => {
-      expect(screen.getByText("Shared e2a domain")).toBeInTheDocument();
-    });
+    await chooseWebUI();
     expect(screen.getByText("Custom domain")).toBeInTheDocument();
   });
 
@@ -155,12 +163,11 @@ describe("Address type choice", () => {
     mockFreshUser();
     render(<GetStartedPage />);
 
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: /Shared e2a domain/i })).toHaveAttribute(
-        "aria-pressed",
-        "false",
-      );
-    });
+    await chooseWebUI();
+    expect(screen.getByRole("button", { name: /Shared e2a domain/i })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
     expect(screen.getByRole("button", { name: /Custom domain/i })).toHaveAttribute(
       "aria-pressed",
       "false",
@@ -170,9 +177,7 @@ describe("Address type choice", () => {
   it("does NOT show Cloud Agents or Local Agents labels", async () => {
     mockFreshUser();
     render(<GetStartedPage />);
-    await waitFor(() => {
-      expect(screen.getByText("Shared e2a domain")).toBeInTheDocument();
-    });
+    await chooseWebUI();
     expect(screen.queryByText("Cloud Agents")).not.toBeInTheDocument();
     expect(screen.queryByText("Local Agents")).not.toBeInTheDocument();
   });
@@ -181,9 +186,7 @@ describe("Address type choice", () => {
     mockFreshUser();
     render(<GetStartedPage />);
 
-    await waitFor(() => {
-      expect(screen.getByText("Shared e2a domain")).toBeInTheDocument();
-    });
+    await chooseWebUI();
     fireEvent.click(screen.getByText("Shared e2a domain"));
 
     await waitFor(() => {
@@ -196,9 +199,7 @@ describe("Address type choice", () => {
     mockFreshUser();
     render(<GetStartedPage />);
 
-    await waitFor(() => {
-      expect(screen.getByText("Custom domain")).toBeInTheDocument();
-    });
+    await chooseWebUI();
     fireEvent.click(screen.getByText("Custom domain"));
 
     await waitFor(() => {
@@ -247,8 +248,8 @@ describe("Shared local flow", () => {
     mockAgentCreation("my-bot@agents.e2a.dev");
     render(<GetStartedPage />);
 
-    // Wait for bootstrap then choose shared
-    await waitFor(() => { expect(screen.getByText("Shared e2a domain")).toBeInTheDocument(); });
+    // Wait for bootstrap then choose web UI -> shared
+    await chooseWebUI();
     fireEvent.click(screen.getByText("Shared e2a domain"));
     await waitFor(() => {
       expect(screen.getByPlaceholderText("my-agent")).toBeInTheDocument();
@@ -287,7 +288,7 @@ describe("Shared form validation", () => {
     mockFreshUser();
     render(<GetStartedPage />);
 
-    await waitFor(() => { expect(screen.getByText("Shared e2a domain")).toBeInTheDocument(); });
+    await chooseWebUI();
     fireEvent.click(screen.getByText("Shared e2a domain"));
     await waitFor(() => {
       expect(screen.getByPlaceholderText("my-agent")).toBeInTheDocument();
@@ -311,7 +312,7 @@ describe("Slug/server error handling", () => {
     mockAgentCreationFailure('slug "my-bot" is already taken');
     render(<GetStartedPage />);
 
-    await waitFor(() => { expect(screen.getByText("Shared e2a domain")).toBeInTheDocument(); });
+    await chooseWebUI();
     fireEvent.click(screen.getByText("Shared e2a domain"));
     await waitFor(() => {
       expect(screen.getByPlaceholderText("my-agent")).toBeInTheDocument();
@@ -384,8 +385,10 @@ describe("Query param support", () => {
         screen.getByText("Domain missing.example.com not found in your account"),
       ).toBeInTheDocument();
     });
-    // Should show address choice, not register step
-    expect(screen.getByText("Shared e2a domain")).toBeInTheDocument();
+    // Should fall back to the top-level method choice (router.replace to
+    // /get-started → step=choose), not the register step.
+    expect(screen.getByText("With an agent")).toBeInTheDocument();
+    expect(screen.getByText("Set up in the web UI")).toBeInTheDocument();
   });
 
   it("?domain= for unverified domain resumes at DNS+verify step", async () => {
@@ -483,8 +486,8 @@ describe("Custom-domain flow: new domain -> DNS -> verify -> local agent", () =>
     mockCustomDomainFlow();
     render(<GetStartedPage />);
 
-    // Wait for bootstrap then choose custom domain
-    await waitFor(() => { expect(screen.getByText("Custom domain")).toBeInTheDocument(); });
+    // Wait for bootstrap then choose web UI -> custom domain
+    await chooseWebUI();
     fireEvent.click(screen.getByText("Custom domain"));
 
     // Wait for domain selector to load
@@ -637,8 +640,8 @@ describe("Custom-domain flow: verification retry", () => {
 
     render(<GetStartedPage />);
 
-    // Wait for bootstrap, then custom -> register -> DNS+verify shown together
-    await waitFor(() => { expect(screen.getByText("Custom domain")).toBeInTheDocument(); });
+    // Wait for bootstrap, then web UI -> custom -> register -> DNS+verify shown together
+    await chooseWebUI();
     fireEvent.click(screen.getByText("Custom domain"));
     await waitFor(() => { expect(screen.getByText("Choose a domain")).toBeInTheDocument(); });
     await userEvent.type(screen.getByPlaceholderText("mail.yourcompany.com"), "mail.newco.com");
@@ -687,10 +690,8 @@ describe("Plain /get-started always shows address choice", () => {
 
     render(<GetStartedPage />);
 
-    await waitFor(() => {
-      expect(screen.getByText("Shared e2a domain")).toBeInTheDocument();
-      expect(screen.getByText("Custom domain")).toBeInTheDocument();
-    });
+    await chooseWebUI();
+    expect(screen.getByText("Custom domain")).toBeInTheDocument();
   });
 
   it("shows address choice even with unverified domains", async () => {
@@ -712,10 +713,8 @@ describe("Plain /get-started always shows address choice", () => {
 
     render(<GetStartedPage />);
 
-    await waitFor(() => {
-      expect(screen.getByText("Shared e2a domain")).toBeInTheDocument();
-      expect(screen.getByText("Custom domain")).toBeInTheDocument();
-    });
+    await chooseWebUI();
+    expect(screen.getByText("Custom domain")).toBeInTheDocument();
   });
 
   it("shows address choice even with verified domain and no agents", async () => {
@@ -731,10 +730,8 @@ describe("Plain /get-started always shows address choice", () => {
 
     render(<GetStartedPage />);
 
-    await waitFor(() => {
-      expect(screen.getByText("Shared e2a domain")).toBeInTheDocument();
-      expect(screen.getByText("Custom domain")).toBeInTheDocument();
-    });
+    await chooseWebUI();
+    expect(screen.getByText("Custom domain")).toBeInTheDocument();
   });
 });
 
@@ -747,7 +744,7 @@ describe("URL-driven step navigation", () => {
   it("clicking 'Shared e2a domain' pushes ?step=shared_form", async () => {
     mockFreshUser();
     render(<GetStartedPage />);
-    await screen.findByText("Shared e2a domain");
+    await chooseWebUI();
 
     fireEvent.click(screen.getByText("Shared e2a domain"));
 
@@ -761,7 +758,7 @@ describe("URL-driven step navigation", () => {
   it("clicking 'Custom domain' pushes ?step=custom_checklist", async () => {
     mockFreshUser();
     render(<GetStartedPage />);
-    await screen.findByText("Custom domain");
+    await chooseWebUI();
 
     fireEvent.click(screen.getByText("Custom domain"));
 
@@ -864,8 +861,10 @@ describe("URL-driven step navigation", () => {
     setSearchParams({ step: "success" });
     mockFreshUser();
     render(<GetStartedPage />);
-    // No SuccessPanel — chooser instead, because there's no agent in
-    // local state (typical on refresh / direct URL hit).
-    expect(screen.getByText("Shared e2a domain")).toBeInTheDocument();
+    // No SuccessPanel — the top-level method choice instead, because
+    // there's no agent in local state (typical on refresh / direct URL
+    // hit). The success fallback renders SetupMethodChoice.
+    expect(screen.getByText("With an agent")).toBeInTheDocument();
+    expect(screen.getByText("Set up in the web UI")).toBeInTheDocument();
   });
 });

--- a/web/src/app/(app)/get-started/page.test.tsx
+++ b/web/src/app/(app)/get-started/page.test.tsx
@@ -205,6 +205,39 @@ describe("Address type choice", () => {
       expect(screen.getByText("Choose a domain")).toBeInTheDocument();
     });
   });
+
+  it("shows the agentic MCP setup when With an agent is clicked", async () => {
+    mockFreshUser();
+    render(<GetStartedPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("With an agent")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByText("With an agent"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Paste into your agent/i)).toBeInTheDocument();
+    });
+    // Both connect paths present, addressed at the hosted MCP endpoint.
+    expect(screen.getByText("Copy prompt")).toBeInTheDocument();
+    expect(screen.getByText("Copy command")).toBeInTheDocument();
+    expect(
+      screen.getByText(/claude mcp add --transport http e2a https:\/\/api\.e2a\.dev\/mcp/),
+    ).toBeInTheDocument();
+  });
+
+  it("copies the connect command to the clipboard", async () => {
+    mockFreshUser();
+    render(<GetStartedPage />);
+    await waitFor(() => expect(screen.getByText("With an agent")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("With an agent"));
+    await waitFor(() => expect(screen.getByText("Copy command")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByText("Copy command"));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining("claude mcp add --transport http e2a https://api.e2a.dev/mcp"),
+    );
+  });
 });
 
 // ── Shared local flow ────────────────────────────────────

--- a/web/src/app/(app)/get-started/page.tsx
+++ b/web/src/app/(app)/get-started/page.tsx
@@ -8,18 +8,20 @@ import { PageShell } from "../../components/loft/PageShell";
 import { AddressChoice } from "./_components/AddressChoice";
 import { SharedAgentForm } from "./_components/SharedAgentForm";
 import { CustomDomainChecklist } from "./_components/CustomDomainChecklist";
+import { AgentSetupCards } from "./_components/AgentSetupCards";
 import { SuccessPanel } from "./_components/SuccessPanel";
 import type { AddressType } from "../../components/onboarding/types";
 import type { DomainInfo } from "../../components/onboarding/types";
 import type { AgentData } from "../../components/types";
 
-type Step = "choose" | "shared_form" | "custom_checklist" | "success";
+type Step = "choose" | "shared_form" | "custom_checklist" | "agent_mcp" | "success";
 
 function isStep(value: string | null): value is Step {
   return (
     value === "choose" ||
     value === "shared_form" ||
     value === "custom_checklist" ||
+    value === "agent_mcp" ||
     value === "success"
   );
 }
@@ -131,11 +133,12 @@ export default function GetStartedPage() {
     setAddressType(type);
     setError("");
     track("address_type_selected", { type });
-    router.push(
-      type === "shared"
-        ? "/get-started?step=shared_form"
-        : "/get-started?step=custom_checklist",
-    );
+    const stepFor: Record<AddressType, Step> = {
+      shared: "shared_form",
+      custom: "custom_checklist",
+      agent: "agent_mcp",
+    };
+    router.push(`/get-started?step=${stepFor[type]}`);
   };
 
   const handleBackToChoose = () => {
@@ -213,6 +216,8 @@ export default function GetStartedPage() {
           }}
         />
       )}
+
+      {step === "agent_mcp" && <AgentSetupCards onBack={handleBackToChoose} />}
 
       {/* Success is the only step that needs an agent in local state.
           If a user lands on ?step=success without state (refresh, share,

--- a/web/src/app/(app)/get-started/page.tsx
+++ b/web/src/app/(app)/get-started/page.tsx
@@ -5,20 +5,30 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { listDomains } from "../../components/onboarding/api";
 import { track } from "../../components/onboarding/analytics";
 import { PageShell } from "../../components/loft/PageShell";
+import { SetupMethodChoice } from "./_components/SetupMethodChoice";
 import { AddressChoice } from "./_components/AddressChoice";
 import { SharedAgentForm } from "./_components/SharedAgentForm";
 import { CustomDomainChecklist } from "./_components/CustomDomainChecklist";
 import { AgentSetupCards } from "./_components/AgentSetupCards";
 import { SuccessPanel } from "./_components/SuccessPanel";
-import type { AddressType } from "../../components/onboarding/types";
+import type { AddressType, SetupMethod } from "../../components/onboarding/types";
 import type { DomainInfo } from "../../components/onboarding/types";
 import type { AgentData } from "../../components/types";
 
-type Step = "choose" | "shared_form" | "custom_checklist" | "agent_mcp" | "success";
+// "choose" = top-level method (agent vs web); "address" = the web sub-chooser
+// (shared vs custom). The agent path jumps straight from choose → agent_mcp.
+type Step =
+  | "choose"
+  | "address"
+  | "shared_form"
+  | "custom_checklist"
+  | "agent_mcp"
+  | "success";
 
 function isStep(value: string | null): value is Step {
   return (
     value === "choose" ||
+    value === "address" ||
     value === "shared_form" ||
     value === "custom_checklist" ||
     value === "agent_mcp" ||
@@ -50,6 +60,7 @@ export default function GetStartedPage() {
   const initialMode = searchParams.get("mode") === "shared" ? "shared" : null;
   const initialDomain = searchParams.get("domain");
 
+  const [method, setMethod] = useState<SetupMethod | null>(null);
   const [addressType, setAddressType] = useState<AddressType | null>(null);
   const [agent, setAgent] = useState<AgentData | null>(null);
   const [domainData, setDomainData] = useState<DomainInfo | null>(null);
@@ -129,16 +140,22 @@ export default function GetStartedPage() {
     }
   }, [step, agent, bootstrapping, router]);
 
+  // Top-level fork: agent (MCP) jumps straight to the headless cards; web opens
+  // the shared/custom address chooser.
+  const handleMethodChoice = (m: SetupMethod) => {
+    setMethod(m);
+    setError("");
+    track("setup_method_selected", { method: m });
+    router.push(`/get-started?step=${m === "agent" ? "agent_mcp" : "address"}`);
+  };
+
   const handleAddressChoice = (type: AddressType) => {
     setAddressType(type);
     setError("");
     track("address_type_selected", { type });
-    const stepFor: Record<AddressType, Step> = {
-      shared: "shared_form",
-      custom: "custom_checklist",
-      agent: "agent_mcp",
-    };
-    router.push(`/get-started?step=${stepFor[type]}`);
+    router.push(
+      `/get-started?step=${type === "shared" ? "shared_form" : "custom_checklist"}`,
+    );
   };
 
   const handleBackToChoose = () => {
@@ -176,10 +193,7 @@ export default function GetStartedPage() {
     >
       {step === "choose" && (
         <>
-          <AddressChoice
-            selected={addressType}
-            onSelect={handleAddressChoice}
-          />
+          <SetupMethodChoice selected={method} onSelect={handleMethodChoice} />
           {error && (
             <div
               className="mt-6 p-3 text-[13px]"
@@ -193,6 +207,20 @@ export default function GetStartedPage() {
               {error}
             </div>
           )}
+        </>
+      )}
+
+      {step === "address" && (
+        <>
+          <button
+            type="button"
+            onClick={handleBackToChoose}
+            className="text-[12px] mb-4 inline-flex items-center gap-1 transition"
+            style={{ color: "var(--fg-muted)" }}
+          >
+            ← Back
+          </button>
+          <AddressChoice selected={addressType} onSelect={handleAddressChoice} />
         </>
       )}
 
@@ -225,7 +253,7 @@ export default function GetStartedPage() {
           than rendering an empty success panel. */}
       {step === "success" && agent && <SuccessPanel agent={agent} />}
       {step === "success" && !agent && (
-        <AddressChoice selected={null} onSelect={handleAddressChoice} />
+        <SetupMethodChoice selected={null} onSelect={handleMethodChoice} />
       )}
     </PageShell>
   );

--- a/web/src/app/components/onboarding/analytics.ts
+++ b/web/src/app/components/onboarding/analytics.ts
@@ -10,6 +10,7 @@ export type OnboardingEvent =
   | "domain_verify_failed"
   | "agent_creation_started"
   | "agent_creation_succeeded"
+  | "setup_method_selected"
   | "address_type_selected"
   | "onboarding_resume_shown"
   | "onboarding_resume_selected";

--- a/web/src/app/components/onboarding/types.ts
+++ b/web/src/app/components/onboarding/types.ts
@@ -1,8 +1,11 @@
 // Onboarding domain model types.
 // These map to the backend API shapes but are owned by the UI layer.
 
-/** Setup path — shared e2a slug, custom domain, or hand off to an agent (MCP). */
-export type AddressType = "shared" | "custom" | "agent";
+/** Web-UI address path — shared e2a slug vs custom domain (under SetupMethod=web). */
+export type AddressType = "shared" | "custom";
+
+/** Top-level setup method — hand off to an agent over MCP, or use the web UI. */
+export type SetupMethod = "agent" | "web";
 
 /** Domain verification status for the checklist model. */
 export type DomainStatus = "unverified" | "verified";

--- a/web/src/app/components/onboarding/types.ts
+++ b/web/src/app/components/onboarding/types.ts
@@ -1,8 +1,8 @@
 // Onboarding domain model types.
 // These map to the backend API shapes but are owned by the UI layer.
 
-/** Address type — shared e2a slug vs custom domain. */
-export type AddressType = "shared" | "custom";
+/** Setup path — shared e2a slug, custom domain, or hand off to an agent (MCP). */
+export type AddressType = "shared" | "custom" | "agent";
 
 /** Domain verification status for the checklist model. */
 export type DomainStatus = "unverified" | "verified";

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -236,3 +236,33 @@ body {
     min-height: 44px;
   }
 }
+
+/* Every button reacts like a button. Two parts:
+ *  1. cursor: pointer on interactive controls — a bare <button> inherits the
+ *     text/arrow cursor in several UAs, which doesn't read as clickable.
+ *  2. a uniform hover/active affordance via filter: brightness(). filter is
+ *     used deliberately: most app buttons set background/border via INLINE
+ *     styles, which override Tailwind `hover:` utilities — but inline styles
+ *     don't touch `filter`, so this gives a consistent press/hover signal to
+ *     ALL buttons (including ones with no per-component hover state) without
+ *     editing each call site. Disabled controls opt out.
+ * Scoped to the authenticated app surface; marketing/docs keep their own. */
+[data-app-surface] button:not(:disabled),
+[data-app-surface] a[role="button"],
+[data-app-surface] [role="button"]:not([aria-disabled="true"]) {
+  cursor: pointer;
+  transition: filter 0.12s ease;
+}
+[data-app-surface] button:not(:disabled):hover,
+[data-app-surface] a[role="button"]:hover,
+[data-app-surface] [role="button"]:not([aria-disabled="true"]):hover {
+  filter: brightness(0.96);
+}
+[data-app-surface] button:not(:disabled):active,
+[data-app-surface] a[role="button"]:active,
+[data-app-surface] [role="button"]:not([aria-disabled="true"]):active {
+  filter: brightness(0.92);
+}
+[data-app-surface] button:disabled {
+  cursor: not-allowed;
+}

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -237,20 +237,32 @@ body {
   }
 }
 
-/* Every button reacts like a button. Two parts:
- *  1. cursor: pointer on interactive controls — a bare <button> inherits the
- *     text/arrow cursor in several UAs, which doesn't read as clickable.
- *  2. a uniform hover/active affordance via filter: brightness(). filter is
- *     used deliberately: most app buttons set background/border via INLINE
- *     styles, which override Tailwind `hover:` utilities — but inline styles
- *     don't touch `filter`, so this gives a consistent press/hover signal to
- *     ALL buttons (including ones with no per-component hover state) without
- *     editing each call site. Disabled controls opt out.
- * Scoped to the authenticated app surface; marketing/docs keep their own. */
+/* Every button reacts like a button.
+ *
+ * Part 1 — cursor: pointer, GLOBAL (not scoped). A bare <button> inherits the
+ * text/arrow cursor in several UAs, which doesn't read as clickable. This is
+ * deliberately unscoped so it also covers controls that render OUTSIDE the
+ * [data-app-surface] subtree — modals/dialogs portaled to <body>, and the
+ * auth/landing/error/oauth pages. Disabled controls opt out. */
+button:not(:disabled),
+a[role="button"],
+[role="button"]:not([aria-disabled="true"]) {
+  cursor: pointer;
+}
+button:disabled,
+[role="button"][aria-disabled="true"] {
+  cursor: not-allowed;
+}
+
+/* Part 2 — a uniform hover/active affordance via filter: brightness(), scoped
+ * to the authenticated app surface (marketing/docs keep their own hovers).
+ * filter is used deliberately: most app buttons set background/border via
+ * INLINE styles, which override Tailwind `hover:` utilities — but inline styles
+ * don't touch `filter`, so this lands a consistent press/hover signal on ALL
+ * app buttons (even ones with no per-component hover state). */
 [data-app-surface] button:not(:disabled),
 [data-app-surface] a[role="button"],
 [data-app-surface] [role="button"]:not([aria-disabled="true"]) {
-  cursor: pointer;
   transition: filter 0.12s ease;
 }
 [data-app-surface] button:not(:disabled):hover,
@@ -262,7 +274,4 @@ body {
 [data-app-surface] a[role="button"]:active,
 [data-app-surface] [role="button"]:not([aria-disabled="true"]):active {
   filter: brightness(0.92);
-}
-[data-app-surface] button:disabled {
-  cursor: not-allowed;
 }


### PR DESCRIPTION
Adds an agentic onboarding path so users running AI agents can set up e2a **headlessly over MCP** instead of the web form — requested to mirror the AgentDrive-style "paste a prompt / run one command" flow.

## What
The Get-Started chooser gains a third card — **"With an agent (MCP)"** — next to *Shared domain* / *Custom domain*. Selecting it reveals two cards (new `AgentSetupCards` component):

1. **Paste into your agent** — a prompt for no-terminal agents (Claude Desktop, a chat box): it fetches `skills/using-e2a/SKILL.md`, connects to the hosted MCP server, and provisions the inbox. *Copy prompt.*
2. **Or connect a client directly** — `claude mcp add --transport http e2a https://api.e2a.dev/mcp` for OAuth-capable MCP clients (Claude Code, Cursor, Goose, Windsurf, Zed). One command, browser OAuth, **no API key**. *Copy command* + the 3-step run/sign-in/approve flow.

This works because e2a's MCP is already hosted (`https://api.e2a.dev/mcp`) with OAuth 2.1, and the MCP admin tools can create the inbox/domain — so the agent does the provisioning the form would have.

## Changes
- New `_components/AgentSetupCards.tsx` (two cards + copy-to-clipboard).
- `AddressType` gains `"agent"`; new `agent_mcp` onboarding step; chooser routes to it.
- Third card in `AddressChoice` (grid → 3 cols).

## Verification
tsc clean; **237 web tests** (2 new: chooser→MCP cards render + clipboard copy).

## Notes
- The paste-prompt fetches the skill via GitHub raw and points at `https://api.e2a.dev/mcp` (prod). If you'd prefer a hosted clean doc URL (e.g. `https://e2a.dev/e2a.md`) instead of GitHub raw, that's a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)