### PR TITLE
fix(oauth): align scope comment + tests to the real agent/account vocabulary

### DIFF
--- a/internal/oauth/provider.go
+++ b/internal/oauth/provider.go
@@ -109,10 +109,11 @@ func NewProvider(storage *Storage, issuerURL string, hmacSecret []byte) (fosite.
 		EnforcePKCEForPublicClients:    true,
 		EnablePKCEPlainChallengeMethod: false,
 
-		// Scope matching: e2a's single scope is "mcp"; ExactScope means
-		// the requested scope must literally equal a registered scope.
-		// HierarchicScope (the alternative) would let "mcp:inbox" match
-		// "mcp" as a parent — we don't want that drift today.
+		// Scope matching: e2a's scopes are "agent" (runtime/inbox tier, the
+		// DCR-public default) and "account" (admin). ExactScope means a
+		// requested scope must literally equal one the client registered;
+		// HierarchicScope (the alternative) would let "agent:inbox" match
+		// "agent" as a parent — we don't want that drift today.
 		ScopeStrategy:            fosite.ExactScopeStrategy,
 		AudienceMatchingStrategy: fosite.DefaultAudienceMatchingStrategy,
 

--- a/internal/oauth/provider_test.go
+++ b/internal/oauth/provider_test.go
@@ -49,7 +49,7 @@ func newProviderFixture(t *testing.T) (fosite.OAuth2Provider, *oauth.Storage, *p
 		        ARRAY['http://localhost:8765/callback'],
 		        ARRAY['authorization_code','refresh_token'],
 		        ARRAY['code'],
-		        ARRAY['mcp'],
+		        ARRAY['agent'],
 		        ARRAY[]::TEXT[],
 		        'none', TRUE, 'dcr')
 		ON CONFLICT (client_id) DO NOTHING
@@ -115,7 +115,7 @@ func TestProvider_AuthCode_RoundTrip(t *testing.T) {
 	q.Set("response_type", "code")
 	q.Set("client_id", clientID)
 	q.Set("redirect_uri", redirectURI)
-	q.Set("scope", "mcp")
+	q.Set("scope", "agent")
 	q.Set("state", "abc123abc123abc123")
 	q.Set("code_challenge", challenge)
 	q.Set("code_challenge_method", "S256")
@@ -141,7 +141,7 @@ func TestProvider_AuthCode_RoundTrip(t *testing.T) {
 	ar.SetSession(sess)
 	// Grant the requested scope. Without this fosite would drop the
 	// scope between authorize and the issued tokens.
-	ar.GrantScope("mcp")
+	ar.GrantScope("agent")
 
 	// Have fosite write the response — this is what materializes the
 	// authorize code (and stores it via our Storage). We use a
@@ -268,7 +268,7 @@ func TestProvider_AuthCode_BadPKCE(t *testing.T) {
 	q.Set("response_type", "code")
 	q.Set("client_id", clientID)
 	q.Set("redirect_uri", redirectURI)
-	q.Set("scope", "mcp")
+	q.Set("scope", "agent")
 	q.Set("state", "abc123abc123abc123")
 	q.Set("code_challenge", challenge)
 	q.Set("code_challenge_method", "S256")
@@ -278,7 +278,7 @@ func TestProvider_AuthCode_BadPKCE(t *testing.T) {
 		t.Fatalf("NewAuthorizeRequest: %v", err)
 	}
 	ar.SetSession(&oauth.Session{UserID: userID, AgentEmail: "a@b.c", Subject: userID})
-	ar.GrantScope("mcp")
+	ar.GrantScope("agent")
 	resp, err := provider.NewAuthorizeResponse(ctx, ar, ar.GetSession())
 	if err != nil {
 		t.Fatalf("NewAuthorizeResponse: %v", err)
@@ -319,7 +319,7 @@ func TestProvider_PKCEPlainRejected(t *testing.T) {
 	q.Set("response_type", "code")
 	q.Set("client_id", clientID)
 	q.Set("redirect_uri", redirectURI)
-	q.Set("scope", "mcp")
+	q.Set("scope", "agent")
 	q.Set("state", "abc123abc123abc123")
 	q.Set("code_challenge", challenge)
 	q.Set("code_challenge_method", "plain")
@@ -330,7 +330,7 @@ func TestProvider_PKCEPlainRejected(t *testing.T) {
 		t.Fatalf("NewAuthorizeRequest unexpectedly rejected the request before PKCE check: %v", err)
 	}
 	ar.SetSession(&oauth.Session{UserID: userID, AgentEmail: "a@b.c", Subject: userID})
-	ar.GrantScope("mcp")
+	ar.GrantScope("agent")
 
 	_, err = provider.NewAuthorizeResponse(ctx, ar, ar.GetSession())
 	if err == nil {

--- a/internal/oauth/retention_test.go
+++ b/internal/oauth/retention_test.go
@@ -144,16 +144,16 @@ func TestCleanupExpired_PrunesAbandonedDCRClients(t *testing.T) {
 		     public, created_via, created_at)
 		VALUES
 		    ('mcp_old_abandoned', 'old abandoned', ARRAY['http://localhost/cb'],
-		     ARRAY['authorization_code'], ARRAY['code'], ARRAY['mcp'], ARRAY[]::TEXT[],
+		     ARRAY['authorization_code'], ARRAY['code'], ARRAY['agent'], ARRAY[]::TEXT[],
 		     'none', TRUE, 'dcr', $1),
 		    ('mcp_old_with_token', 'old still in use', ARRAY['http://localhost/cb'],
-		     ARRAY['authorization_code'], ARRAY['code'], ARRAY['mcp'], ARRAY[]::TEXT[],
+		     ARRAY['authorization_code'], ARRAY['code'], ARRAY['agent'], ARRAY[]::TEXT[],
 		     'none', TRUE, 'dcr', $1),
 		    ('mcp_young_abandoned', 'young abandoned', ARRAY['http://localhost/cb'],
-		     ARRAY['authorization_code'], ARRAY['code'], ARRAY['mcp'], ARRAY[]::TEXT[],
+		     ARRAY['authorization_code'], ARRAY['code'], ARRAY['agent'], ARRAY[]::TEXT[],
 		     'none', TRUE, 'dcr', $2),
 		    ('mcp_admin_old', 'operator curated', ARRAY['http://localhost/cb'],
-		     ARRAY['authorization_code'], ARRAY['code'], ARRAY['mcp'], ARRAY[]::TEXT[],
+		     ARRAY['authorization_code'], ARRAY['code'], ARRAY['agent'], ARRAY[]::TEXT[],
 		     'none', TRUE, 'admin', $1)
 	`, old, young)
 
@@ -253,9 +253,9 @@ func TestExportConnectionsForUser(t *testing.T) {
 		t.Fatalf("want 3 consents for userA (a/b/c@e.dev), got %d: %+v", len(got), got)
 	}
 	byEmail := map[string]ConnectionEntryFields{
-		"a@e.dev": {wantRevoked: false, wantClientID: clientID, wantClientName: "test client", wantScope: "mcp"},
-		"b@e.dev": {wantRevoked: true, wantClientID: clientID, wantClientName: "test client", wantScope: "mcp"},
-		"c@e.dev": {wantRevoked: false, wantClientID: clientID, wantClientName: "test client", wantScope: "mcp"},
+		"a@e.dev": {wantRevoked: false, wantClientID: clientID, wantClientName: "test client", wantScope: "agent"},
+		"b@e.dev": {wantRevoked: true, wantClientID: clientID, wantClientName: "test client", wantScope: "agent"},
+		"c@e.dev": {wantRevoked: false, wantClientID: clientID, wantClientName: "test client", wantScope: "agent"},
 	}
 	for _, c := range got {
 		want, ok := byEmail[c.AgentEmail]

--- a/internal/oauth/storage_test.go
+++ b/internal/oauth/storage_test.go
@@ -28,7 +28,7 @@ func seedClient(t *testing.T, pool *pgxpool.Pool, clientID string) {
 		     response_types, scopes, audiences, token_endpoint_auth_method,
 		     public, created_via)
 		VALUES ($1, $2, ARRAY['http://localhost/cb'], ARRAY['authorization_code','refresh_token'],
-		        ARRAY['code'], ARRAY['mcp'], ARRAY[]::TEXT[], 'none',
+		        ARRAY['code'], ARRAY['agent'], ARRAY[]::TEXT[], 'none',
 		        TRUE, 'dcr')
 	`, clientID, "test client")
 	if err != nil {
@@ -55,8 +55,8 @@ func newRequester(id, clientID, userID string, now time.Time) fosite.Requester {
 		ID:             id,
 		RequestedAt:    now,
 		Client:         c,
-		RequestedScope: fosite.Arguments{"mcp"},
-		GrantedScope:   fosite.Arguments{"mcp"},
+		RequestedScope: fosite.Arguments{"agent"},
+		GrantedScope:   fosite.Arguments{"agent"},
 		Form:           map[string][]string{},
 		Session: &oauth.Session{
 			UserID:     userID,


### PR DESCRIPTION
Follow-up from the docs sweep: the OAuth provider comment + tests referenced the retired `mcp` scope; production uses `agent`/`account`. No runtime bug (ExactScopeStrategy validates per-client; DCR registers `agent`), but the comment misled and the tests exercised a scope the server never issues. Updated provider.go comment + provider/storage/retention tests to `agent`. oauth + agent suites green; build clean.