### PR TITLE
ci: gate the internal/e2e suite on every PR (+ conversation-thread e2e test)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,37 @@ jobs:
         with:
           config: ./.testcoverage.yml
 
+  go-e2e:
+    name: Go e2e tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: e2a
+          POSTGRES_PASSWORD: e2a
+          POSTGRES_DB: e2a_test
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U e2a -d e2a_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+          cache: true
+      # The internal/e2e suite (build tag `integration`) boots the real relay +
+      # HTTP API against the test DB and drives them over SMTP/HTTP. It is NOT
+      # run by `go test ./...` (no build tag) or `make cover` (no build tag) —
+      # this job is its only CI gate.
+      - name: Run e2e suite
+        run: make test-e2e
+
   web:
     name: Web tests
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,6 +95,20 @@ jobs:
           --health-interval 5s
           --health-timeout 5s
           --health-retries 15
+      # The e2e suite exercises outbound send/reply, which the relay routes to an
+      # upstream SMTP host. Mailpit (the same catch-all used in local dev via
+      # docker-compose) stands in for SES; the tests point WithOutboundSMTP at
+      # 127.0.0.1:1025.
+      mailpit:
+        image: axllent/mailpit:v1.30.0
+        ports:
+          - 1025:1025
+          - 8025:8025
+        options: >-
+          --health-cmd "wget --quiet --spider http://localhost:8025/api/v1/info || exit 1"
+          --health-interval 5s
+          --health-timeout 2s
+          --health-retries 10
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v6

--- a/internal/e2e/webhooks_e2e_test.go
+++ b/internal/e2e/webhooks_e2e_test.go
@@ -662,3 +662,82 @@ func summarize(c []testutil.SubscriberCaptured) string {
 	}
 	return strings.Join(parts, " ")
 }
+
+// ----------------------------------------------------------------------
+// P6 — conversation_id is agent-owned and maintained across the thread
+// ----------------------------------------------------------------------
+
+// TestWebhooksE2E_ConversationThreadedFromAgentReply proves the
+// agent-owned conversation model end to end: first-contact inbound has no
+// thread context (conversation_id=""), but once the agent has replied with
+// its OWN id (stored on the outbound with that reply's Message-ID in
+// provider_message_id), an external follow-up that References the reply is
+// threaded back to the agent's id — and the email.received webhook echoes
+// that id so the agent re-maps to its internal conversation.
+//
+// The agent's reply is recorded via the store rather than POSTed: replying
+// to an external recipient needs an upstream SMTP relay the CI harness
+// doesn't wire (the skipped TestOutbound* tests), and Mailpit's
+// 250-response provider_message_id is not a real Message-ID, so it makes a
+// poor References anchor. The row written here is the shape the reply
+// handler persists, with the clean Message-ID an SES send would yield. The
+// threading itself — the behavior under test — runs through the real relay
+// + resolveConversationID.
+func TestWebhooksE2E_ConversationThreadedFromAgentReply(t *testing.T) {
+	pool := testutil.TestDB(t)
+	receiver := testutil.SubscriberReceiver(t)
+	ts := testutil.TestServer(t, pool)
+	ctx := context.Background()
+
+	user, _, agent := setupDomainAndAgent(t, ts, "agent@conv.example.com", "conv.example.com", "", "")
+	registerWebhook(t, ts, user.ID, receiver.Server.URL+"/received",
+		[]string{"email.received"}, identity.WebhookFilters{})
+
+	// (1) First-contact inbound — no References, no prior thread → "".
+	msg1 := "From: alice@gmail.com\r\nTo: agent@conv.example.com\r\n" +
+		"Subject: Project kickoff\r\nMessage-ID: <kick-1@gmail.com>\r\n\r\nLet's start."
+	if err := smtp.SendMail(ts.SMTPAddr, nil, "alice@gmail.com", []string{"agent@conv.example.com"}, []byte(msg1)); err != nil {
+		t.Fatalf("SendMail #1: %v", err)
+	}
+	tick(t, ts)
+	got := receiver.WaitFor(t, 5*time.Second, func(c []testutil.SubscriberCaptured) bool { return len(c) >= 1 })
+	if len(got) != 1 {
+		t.Fatalf("first inbound: got %d captures, want 1", len(got))
+	}
+	d1, _ := got[0].Envelope["data"].(map[string]any)
+	if cv := fmt.Sprint(d1["conversation_id"]); cv != "" {
+		t.Errorf("first-contact conversation_id = %q, want \"\" (no thread context yet)", cv)
+	}
+
+	// (2) The agent replies, stamping its own conversation id. Recorded
+	// directly (see doc comment) with the reply's Message-ID in
+	// provider_message_id — exactly what an external client will reference.
+	const agentConvID = "conv_agent_thread_1"
+	const replyMsgID = "<agent-reply-1@conv.example.com>"
+	if _, err := ts.Store.CreateOutboundMessage(ctx, agent.ID,
+		[]string{"alice@gmail.com"}, nil, nil, "Re: Project kickoff",
+		"reply", "smtp", replyMsgID, agentConvID, nil); err != nil {
+		t.Fatalf("record agent reply: %v", err)
+	}
+
+	// (3) Alice replies to the agent's reply (References it, Gmail-style).
+	// The relay must resolve the agent's conversation_id and the webhook
+	// must carry it back.
+	receiver.Reset()
+	msg2 := "From: alice@gmail.com\r\nTo: agent@conv.example.com\r\n" +
+		"Subject: Re: Project kickoff\r\nMessage-ID: <kick-2@gmail.com>\r\n" +
+		"In-Reply-To: " + replyMsgID + "\r\n" +
+		"References: <kick-1@gmail.com> " + replyMsgID + "\r\n\r\nFollowing up."
+	if err := smtp.SendMail(ts.SMTPAddr, nil, "alice@gmail.com", []string{"agent@conv.example.com"}, []byte(msg2)); err != nil {
+		t.Fatalf("SendMail #2: %v", err)
+	}
+	tick(t, ts)
+	got2 := receiver.WaitFor(t, 5*time.Second, func(c []testutil.SubscriberCaptured) bool { return len(c) >= 1 })
+	if len(got2) != 1 {
+		t.Fatalf("follow-up inbound: got %d captures, want 1", len(got2))
+	}
+	d2, _ := got2[0].Envelope["data"].(map[string]any)
+	if cv := fmt.Sprint(d2["conversation_id"]); cv != agentConvID {
+		t.Errorf("follow-up conversation_id = %q, want %q (threaded back to the agent's id)", cv, agentConvID)
+	}
+}


### PR DESCRIPTION
## Problem
The `internal/e2e` suite (build tag `integration`) **ran nowhere in CI**. The `go` job runs `go test ./...` (no build tag → e2e files compiled out), and `go-coverage` runs `make cover` (`go test ./internal/...`, also no tag). No job invoked `make test-e2e`/`make test`. So all 8 e2e files — including the comprehensive `webhooks_e2e_test.go` (delivery, HMAC, filters, retry/auto-disable, rotation, HITL) — gated nothing.

## Change
- **New `go-e2e` job** in `test.yml`: Postgres service + `make test-e2e` (`go test -tags integration -p 1 ./internal/e2e/`). The whole e2e suite now gates every PR.
- **New test** `TestWebhooksE2E_ConversationThreadedFromAgentReply`: the one gap from a recent manual e2e session. Proves the **agent-owned `conversation_id`** model over the wire — first-contact inbound has no thread context (`conversation_id=""`); once the agent replies with its own id (stored on the outbound with that reply's Message-ID in `provider_message_id`), an external follow-up that `References` the reply is threaded back to the agent's id and the `email.received` webhook echoes it. The agent's reply is recorded via the store (replying to an external recipient needs an upstream relay CI lacks, and Mailpit's 250-response `provider_message_id` is not a real Message-ID — a poor `References` anchor); the threading runs through the real relay + `resolveConversationID`.

## Verification
- `make test-e2e` green locally (`ok internal/e2e 22s`), including the new test.
- YAML validated; `go-e2e` runs `make test-e2e` against the same `e2a_test` Postgres service the other DB-backed jobs use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)