### PR TITLE
Pre-GA launch-review fixes: contract, security, docs for v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ Two reasons:
 1. **Auditability.** Identity infrastructure for your agents should be readable code, not a vendor black box. You can verify the cosign signature on `ghcr.io/mnexa-ai/e2a`, reproduce the build, and confirm what's actually running.
 2. **Self-host as a real option.** The hosted instance at e2a.dev runs the same `ghcr.io/mnexa-ai/e2a` image you can pull right now. Convenience features on the hosted side (the shared `agents.e2a.dev` domain, managed deliverability) are config + DNS, not closed-source extras.
 
-Pricing for the hosted version isn't enabled yet. When it lands, it'll be opt-in via env var and the OSS code path stays unchanged.
+The hosted version at [e2a.dev](https://e2a.dev) has paid tiers (a free tier plus paid plans); billing is opt-in via env var on the hosted side and the OSS code path stays unchanged — self-hosting has no quotas or billing.
 
 ## Development
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -37,12 +37,13 @@ anonymous. We don't currently run a paid bounty program.
 
 | Version | Status |
 |---------|--------|
-| Latest tagged release on `main` | ✅ Receives security fixes |
-| Older minor versions | ❌ Please upgrade to the latest |
+| `1.x` (current GA line) | ✅ Receives security fixes |
+| `0.x` (pre-GA) | ❌ Please upgrade to the latest 1.x release |
 
-The project is pre-1.0; we maintain only the most recent release line.
-Self-hosters running pinned versions should plan to upgrade promptly
-when an advisory is published.
+e2a is 1.0 GA: the `1.x` release line receives security fixes, delivered
+in the latest `1.x` release (we don't backport to older `1.x` patch
+versions). Self-hosters running pinned versions should plan to upgrade
+promptly when an advisory is published.
 
 ## Scope
 

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -546,22 +546,8 @@ components:
         enabled:
           type: boolean
         events:
-          description: "Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable. All other events are stable."
+          description: "The event types this webhook matches. Open set: new event types may be added over time, so treat these as strings and tolerate unknown values. Known values: email.received, email.sent, email.delivered, email.bounced, email.complained, email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected, domain.sending_verified, domain.sending_failed, domain.suppression_added. Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable."
           items:
-            enum:
-              - email.received
-              - email.sent
-              - email.review_approved
-              - email.review_rejected
-              - domain.sending_verified
-              - domain.sending_failed
-              - email.delivered
-              - email.bounced
-              - email.complained
-              - domain.suppression_added
-              - email.flagged
-              - email.blocked
-              - email.pending_review
             type: string
           type: array
         filters:
@@ -765,11 +751,7 @@ components:
           format: date-time
           type: string
         sending_status:
-          enum:
-            - none
-            - pending
-            - verified
-            - failed
+          description: "Async SES sending-identity state. Open set; tolerate unknown values. Known values: none, pending, verified, failed."
           type: string
         verification_token:
           type: string
@@ -832,26 +814,10 @@ components:
           format: int64
           type: integer
         status:
-          enum:
-            - pending
-            - processed
-            - no_match
+          description: "Event processing state. Open set; tolerate unknown values. Known values: pending, processed, no_match."
           type: string
         type:
-          enum:
-            - email.received
-            - email.sent
-            - email.review_approved
-            - email.review_rejected
-            - domain.sending_verified
-            - domain.sending_failed
-            - email.delivered
-            - email.bounced
-            - email.complained
-            - domain.suppression_added
-            - email.flagged
-            - email.blocked
-            - email.pending_review
+          description: "Event type. Open set: new event types may be added over time, so treat as a string and tolerate unknown values. Known values: email.received, email.sent, email.delivered, email.bounced, email.complained, email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected, domain.sending_verified, domain.sending_failed, domain.suppression_added."
           type: string
       required:
         - id
@@ -1098,14 +1064,7 @@ components:
         delivery_detail:
           type: string
         delivery_status:
-          enum:
-            - queued
-            - sent
-            - delivered
-            - bounced
-            - complained
-            - deferred
-            - failed
+          description: "Outbound delivery rollup (worst recipient status by precedence; outbound only). Open set; tolerate unknown values. Known values: queued, sent, delivered, bounced, complained, deferred, failed."
           type: string
         direction:
           enum:
@@ -1133,17 +1092,10 @@ components:
             type: string
           type: array
         review_status:
-          enum:
-            - pending_review
-            - sent
-            - review_rejected
-            - review_expired_approved
-            - review_expired_rejected
+          description: "Review-hold lifecycle (outbound only). Open set; tolerate unknown values. Known values: pending_review, sent, review_rejected, review_expired_approved, review_expired_rejected."
           type: string
         sent_as:
-          enum:
-            - own_address
-            - relay
+          description: "From identity used at relay accept time (outbound only). Open set; tolerate unknown values. Known values: own_address, relay."
           type: string
         size_bytes:
           format: int64
@@ -1196,14 +1148,7 @@ components:
         delivery_detail:
           type: string
         delivery_status:
-          enum:
-            - queued
-            - sent
-            - delivered
-            - bounced
-            - complained
-            - deferred
-            - failed
+          description: "Outbound delivery rollup (worst recipient status by precedence; outbound only). Open set; tolerate unknown values. Known values: queued, sent, delivered, bounced, complained, deferred, failed."
           type: string
         direction:
           enum:
@@ -1236,17 +1181,10 @@ components:
             type: string
           type: array
         review_status:
-          enum:
-            - pending_review
-            - sent
-            - review_rejected
-            - review_expired_approved
-            - review_expired_rejected
+          description: "Review-hold lifecycle (outbound only). Open set; tolerate unknown values. Known values: pending_review, sent, review_rejected, review_expired_approved, review_expired_rejected."
           type: string
         sent_as:
-          enum:
-            - own_address
-            - relay
+          description: "From identity used at relay accept time (outbound only). Open set; tolerate unknown values. Known values: own_address, relay."
           type: string
         size_bytes:
           format: int64
@@ -1580,9 +1518,7 @@ components:
         reason:
           type: string
         status:
-          enum:
-            - pending
-            - skipped
+          description: "Open set; tolerate unknown values. Known values: pending (replay scheduled), skipped (could not enqueue — see reason)."
           type: string
         webhook_id:
           type: string
@@ -1608,9 +1544,7 @@ components:
         event_id:
           type: string
         status:
-          enum:
-            - pending
-            - scheduled
+          description: "Open set; tolerate unknown values. Known values: pending (single-webhook replay), scheduled (bulk fan-out)."
           type: string
         webhook_id:
           type: string
@@ -1710,8 +1644,7 @@ components:
         id:
           type: string
         review_status:
-          enum:
-            - pending_review
+          description: Hold state of this queue item. Open set; tolerate unknown values. Currently always pending_review (the queue lists held items).
           type: string
         subject:
           type: string
@@ -1784,22 +1717,15 @@ components:
         message_id:
           type: string
         method:
-          enum:
-            - smtp
-            - loopback
+          description: "Send transport. Open set; tolerate unknown values. Known values: smtp, loopback."
           type: string
         provider_message_id:
           type: string
         sent_as:
-          enum:
-            - own_address
-            - relay
+          description: "From identity used. Open set; tolerate unknown values. Known values: own_address, relay."
           type: string
         status:
-          enum:
-            - sent
-            - pending_review
-            - review_approved
+          description: "Outcome. Open set; tolerate unknown values. Known values: sent, pending_review, review_approved."
           type: string
       required:
         - status
@@ -2075,20 +2001,7 @@ components:
           format: date-time
           type: string
         event_type:
-          enum:
-            - email.received
-            - email.sent
-            - email.review_approved
-            - email.review_rejected
-            - domain.sending_verified
-            - domain.sending_failed
-            - email.delivered
-            - email.bounced
-            - email.complained
-            - domain.suppression_added
-            - email.flagged
-            - email.blocked
-            - email.pending_review
+          description: "The event type that triggered this delivery. Open set: new event types may be added, so treat as a string and tolerate unknown values. Known values are the webhook event catalog (email.received, email.sent, email.delivered, …, domain.*)."
           type: string
         id:
           type: string
@@ -2104,10 +2017,7 @@ components:
           format: date-time
           type: string
         status:
-          enum:
-            - pending
-            - delivered
-            - failed
+          description: "Delivery state. Open set; tolerate unknown values. Known values: pending, delivered, failed."
           type: string
       required:
         - id
@@ -2147,22 +2057,8 @@ components:
         enabled:
           type: boolean
         events:
-          description: "Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable. All other events are stable."
+          description: "The event types this webhook matches. Open set: new event types may be added over time, so treat these as strings and tolerate unknown values. Known values: email.received, email.sent, email.delivered, email.bounced, email.complained, email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected, domain.sending_verified, domain.sending_failed, domain.suppression_added. Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable."
           items:
-            enum:
-              - email.received
-              - email.sent
-              - email.review_approved
-              - email.review_rejected
-              - domain.sending_verified
-              - domain.sending_failed
-              - email.delivered
-              - email.bounced
-              - email.complained
-              - domain.suppression_added
-              - email.flagged
-              - email.blocked
-              - email.pending_review
             type: string
           type: array
         filters:

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## 1.5.0
+
+Current release. The `e2a` CLI targets the e2a v1 API and runs on the 3.x
+TypeScript SDK (`@e2a/sdk`).
+
+### Notes
+- Commands are thin wrappers over the namespaced SDK surface
+  (`client.agents`, `client.messages`, `client.domains`, `client.webhooks`,
+  `client.account`). Auth reads `E2A_API_KEY`; `--base-url` (or `E2A_BASE_URL`)
+  overrides the endpoint for self-hosted deployments.

--- a/docs/api.md
+++ b/docs/api.md
@@ -32,14 +32,48 @@ MCP tool surface), see:
   The unauthenticated exceptions are `GET /api/health`, `GET /v1/info`,
   `POST /api/feedback`, and the HITL magic-link routes (which carry a signed `t`
   token instead).
-- **Path parameters with `@`.** Agent paths are addressed by full email
-  (`/v1/agents/{email}/…`); the `@` must be URL-encoded.
+- **Path parameters with `@`/`+`.** Agent (and suppression/domain) paths are
+  addressed by a full email/host (`/v1/agents/{email}/…`). **Percent-encode the
+  segment**: `@` → `%40` and — importantly — `+` → `%2B`. A bare `+` in a path is
+  often decoded to a space by clients/proxies, which silently corrupts
+  plus-tagged addresses (`a+tag@x.com`). The official SDKs encode this for you;
+  hand-rolled clients must do it themselves.
 - **Pagination.** List endpoints return `{ items, next_cursor }`; pass
   `next_cursor` back as `?cursor=…` to page forward. The SDKs auto-page.
 - **Idempotency.** Mutating send/approve/rotate operations honor an
   `Idempotency-Key` header. See the spec for which operations accept it.
 - **Errors.** Non-2xx responses use a single `ErrorEnvelope` shape; branch on
   `error.code`.
+
+## Versioning & stability
+
+The `/v1` surface is the **stable, generally-available contract** as of e2a 1.0.
+Our commitment, and what you can rely on:
+
+- **No breaking changes within `/v1`.** We will not remove an endpoint, remove a
+  response field, rename anything, tighten a type, or change documented semantics
+  under `/v1`. A breaking change means a new major version path (`/v2`), and the
+  two would run side by side during a published migration window.
+- **Additive changes can happen anytime** and are *not* breaking: new endpoints,
+  new optional request fields, and **new response fields**. Clients must ignore
+  fields they don't recognize.
+- **Enums in responses are open.** Treat any `type` / `*_status` / `event_type`
+  value as an open string set: we may introduce new values (e.g. a new event
+  type or delivery state) without a major bump, so a client **must not crash on
+  an unknown value** — handle it as a default/passthrough case. (The official
+  SDKs already do this.) Enum values you *send* in requests are validated and
+  rejected if unknown — that's intentional and not a stability concern.
+- **Version discovery.** `GET /v1/info` reports the running API version (and
+  deployment flags such as whether shared-domain slug registration is enabled),
+  so clients can adapt instead of hard-coding assumptions.
+- **Deprecation & sunset.** If we ever need to wind something down, it stays
+  functional and is marked `deprecated` in the OpenAPI spec; we will not remove
+  it within `/v1`. Endpoints currently marked deprecated (the agent-path
+  `…/messages/{id}/approve|reject`, superseded by `/v1/reviews/{id}/approve|reject`)
+  keep working for the life of `/v1`.
+
+The canonical machine-readable contract is always
+[`api/openapi.yaml`](../api/openapi.yaml); CI fails if it drifts from the server.
 
 ## Resources
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -62,6 +62,12 @@ for e in client.events.list(type="email.received", limit=20):
 | `email.review_approved` | Review approved (outbound: sent; inbound: released to the inbox) | Best-effort |
 | `email.review_rejected` | Review rejected (outbound: discarded; inbound: dropped) | **At-least-once** |
 | `email.blocked` | Message refused by screening (inbound accept-then-quarantine / outbound 403) | **At-least-once** |
+| `email.delivered` | Outbound message accepted for delivery by the recipient's server (per-recipient async outcome) | Best-effort |
+| `email.bounced` | Outbound message bounced for a recipient (hard/soft delivery failure) | Best-effort |
+| `email.complained` | Recipient marked an outbound message as spam (feedback-loop complaint) | Best-effort |
+| `domain.suppression_added` | An address was auto-suppressed after a bounce/complaint (account-scoped despite the `domain.` prefix) | Best-effort |
+| `domain.sending_verified` | A domain's async SES sending identity reached the verified terminal state | Best-effort |
+| `domain.sending_failed` | A domain's async SES sending identity reached a failed terminal state | Best-effort |
 
 The review-hold + screening events (`email.flagged`, `email.blocked`, `email.pending_review`, `email.review_approved`, `email.review_rejected`) are **beta** — their payloads may change before they are declared stable.
 

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -1530,13 +1530,11 @@ func validateDomain(domain string) (string, error) {
 	return ascii, nil
 }
 
+// clientIP keys the per-IP limiters on the same trusted source as the
+// DCR limiter: CF-Connecting-IP only, never the client-controlled
+// X-Forwarded-For (see dcrSourceIP for the full rationale and the
+// origin-firewall caveat). Delegating keeps every per-IP surface
+// identical and impossible to drift apart.
 func clientIP(r *http.Request) string {
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		if ip, _, ok := strings.Cut(xff, ","); ok {
-			return strings.TrimSpace(ip)
-		}
-		return strings.TrimSpace(xff)
-	}
-	host, _, _ := net.SplitHostPort(r.RemoteAddr)
-	return host
+	return dcrSourceIP(r)
 }

--- a/internal/agent/events_api.go
+++ b/internal/agent/events_api.go
@@ -33,13 +33,13 @@ func (a *API) SetPoolForEvents(p *pgxpool.Pool) { a.eventsPool = p }
 // GET /events/{id}. Mirrors design §4.6.
 type eventJSON struct {
 	ID             string                 `json:"id"`
-	Type           string                 `json:"type" enum:"email.received,email.sent,email.review_approved,email.review_rejected,domain.sending_verified,domain.sending_failed,email.delivered,email.bounced,email.complained,domain.suppression_added,email.flagged,email.blocked,email.pending_review"`
+	Type           string                 `json:"type" doc:"Event type. Open set: new event types may be added over time, so treat as a string and tolerate unknown values. Known values: email.received, email.sent, email.delivered, email.bounced, email.complained, email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected, domain.sending_verified, domain.sending_failed, domain.suppression_added."`
 	SchemaVersion  int                    `json:"schema_version"`
 	CreatedAt      time.Time              `json:"created_at"`
 	AgentID        *string                `json:"agent_id,omitempty"`
 	ConversationID *string                `json:"conversation_id,omitempty"`
 	MessageID      *string                `json:"message_id,omitempty"`
-	Status         string                 `json:"status" enum:"pending,processed,no_match"`
+	Status         string                 `json:"status" doc:"Event processing state. Open set; tolerate unknown values. Known values: pending, processed, no_match."`
 	Data           map[string]interface{} `json:"data"`
 	DeliveryStatus *deliveryStatusJSON    `json:"delivery_status,omitempty"`
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -103,6 +103,13 @@ type OutboundSMTPConfig struct {
 	Username   string `yaml:"username"`
 	Password   string `yaml:"password"`
 	FromDomain string `yaml:"from_domain"`
+	// RequireTLS fails the send if STARTTLS can't be negotiated, instead
+	// of silently relaying in cleartext (a network attacker can strip the
+	// STARTTLS capability from the server's EHLO to force this). Pointer
+	// so an unset value can default to true in production while staying
+	// off for dev relays (e.g. Mailpit on :1025 with no TLS). Regardless
+	// of this flag, PLAIN auth is never sent over a cleartext connection.
+	RequireTLS *bool `yaml:"require_tls"`
 }
 
 // DeliveryFeedbackConfig controls outbound delivery feedback (decision 9 /
@@ -239,6 +246,11 @@ func Load(path string) (*Config, error) {
 	if v := os.Getenv("E2A_OUTBOUND_SMTP_FROM_DOMAIN"); v != "" {
 		cfg.OutboundSMTP.FromDomain = v
 	}
+	if v := os.Getenv("E2A_OUTBOUND_SMTP_REQUIRE_TLS"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			cfg.OutboundSMTP.RequireTLS = &b
+		}
+	}
 	if v := os.Getenv("E2A_PUBLIC_URL"); v != "" {
 		cfg.HTTP.PublicURL = v
 	}
@@ -253,6 +265,15 @@ func Load(path string) (*Config, error) {
 	}
 	if v := os.Getenv("E2A_DELIVERY_SNS_TOPIC_ARNS"); v != "" {
 		cfg.DeliveryFeedback.SNSTopicARNs = splitAndTrim(v)
+	}
+
+	// Default outbound TLS enforcement to on in production when not set
+	// explicitly. SES on :587/:465 always advertises STARTTLS, so this is
+	// a no-op for the real prod path and only fails closed if the TLS
+	// capability disappears (misconfig or active stripping attack).
+	if cfg.OutboundSMTP.RequireTLS == nil {
+		v := cfg.IsProduction()
+		cfg.OutboundSMTP.RequireTLS = &v
 	}
 
 	if err := cfg.Validate(); err != nil {

--- a/internal/httpapi/domains.go
+++ b/internal/httpapi/domains.go
@@ -42,7 +42,7 @@ type DomainView struct {
 	// (inbound ownership): the async SES sending identity that lets agents
 	// on this domain send as their own address. Poll GET /domains/{domain}
 	// to watch SendingStatus go pending → verified|failed.
-	SendingStatus        string                 `json:"sending_status" enum:"none,pending,verified,failed"`
+	SendingStatus        string                 `json:"sending_status" doc:"Async SES sending-identity state. Open set; tolerate unknown values. Known values: none, pending, verified, failed."`
 	SendingError         string                 `json:"sending_error,omitempty"`
 	SendingDNSRecords    []SendingDNSRecordView `json:"sending_dns_records,omitempty" nullable:"false"`
 	SendingLastCheckedAt *time.Time             `json:"sending_last_checked_at,omitempty"`

--- a/internal/httpapi/event_enum_drift_test.go
+++ b/internal/httpapi/event_enum_drift_test.go
@@ -9,17 +9,25 @@ import (
 )
 
 // TestWebhookEventEnumMatchesCatalog is the drift gate for the webhook event
-// vocabulary. The subscribable event-type enum is hand-copied into several Huma
-// struct tags (CreateWebhookRequest.events, UpdateWebhookRequest.events, the
-// test-webhook event, WebhookDeliveryView.event_type, EventJSON.type, …) with
-// nothing keeping them in sync with the canonical webhookpub.AllEventTypes. A new
-// event added to the catalog but forgotten in one tag would be silently
-// unsubscribable / unfilterable on that surface — the #7 GA-blocker class, which
-// TestSpecGoldenNoDrift cannot catch (handler and golden drift together).
+// vocabulary. The subscribable event-type enum is hand-copied into the REQUEST
+// Huma struct tags (CreateWebhookRequest.events, UpdateWebhookRequest.events, the
+// test-webhook event) with nothing keeping them in sync with the canonical
+// webhookpub.AllEventTypes. A new event added to the catalog but forgotten in one
+// tag would be silently unsubscribable / unfilterable on that surface — the #7
+// GA-blocker class, which TestSpecGoldenNoDrift cannot catch (handler and golden
+// drift together).
+//
+// RESPONSE-side event fields (WebhookView.events, WebhookDeliveryView.event_type,
+// EventJSON.type) are deliberately NOT closed enums — they are open strings so the
+// server can emit a newly-added event type without breaking strict spec-generated
+// clients (the GA stability contract; see docs/api.md "Versioning & stability").
+// So this gate governs only the REQUEST-side copies, where a closed enum is
+// correct: we validate and reject an unknown event type a client tries to
+// subscribe to or test with.
 //
 // This renders the live spec, finds EVERY enum that is an event enum (one that
 // contains email.received), and asserts it equals AllEventTypes exactly — so any
-// drift fails CI regardless of which copy fell out of sync.
+// drift in a request-side copy fails CI regardless of which copy fell out of sync.
 func TestWebhookEventEnumMatchesCatalog(t *testing.T) {
 	doc := renderSpec(t)
 	want := append([]string(nil), webhookpub.AllEventTypes...)
@@ -44,11 +52,15 @@ func TestWebhookEventEnumMatchesCatalog(t *testing.T) {
 	if found == 0 {
 		t.Fatal("found no event enums in the spec — the spec walk or the marker is wrong")
 	}
-	// The known copies are EventJSON.type plus the webhook request/response tags.
-	// A copy that lost its enum tag (degrading to a free-form string) would drop
-	// the count — catch that too.
-	if found < 5 {
-		t.Errorf("expected at least 5 event-enum copies in the spec, found %d — a copy may have lost its enum tag", found)
+	// The remaining closed copies are the 3 REQUEST-side tags:
+	// CreateWebhookRequest.events, UpdateWebhookRequest.events, and the
+	// test-webhook event. A request-side copy that lost its enum tag (degrading
+	// to a free-form string that no longer validates subscriptions) would drop
+	// the count — catch that too. (Response-side copies are intentionally open and
+	// must NOT be counted here; if you add a new request surface that subscribes
+	// to / filters by event type, bump this.)
+	if found < 3 {
+		t.Errorf("expected at least 3 request-side event-enum copies in the spec, found %d — a request copy may have lost its enum tag", found)
 	}
 }
 

--- a/internal/httpapi/events.go
+++ b/internal/httpapi/events.go
@@ -88,7 +88,7 @@ type RedeliverView struct {
 	WebhookID  string `json:"webhook_id,omitempty"`
 	// Status is "pending" for a single-webhook replay (one scheduled delivery)
 	// or "scheduled" for a bulk fan-out (see Deliveries for per-subscriber state).
-	Status     string              `json:"status" enum:"pending,scheduled"`
+	Status     string              `json:"status" doc:"Open set; tolerate unknown values. Known values: pending (single-webhook replay), scheduled (bulk fan-out)."`
 	Deliveries []RedeliverDelivery `json:"deliveries,omitempty" nullable:"false"`
 }
 
@@ -97,7 +97,7 @@ type RedeliverDelivery struct {
 	DeliveryID string `json:"delivery_id,omitempty"`
 	// Status is "pending" when the replay was scheduled, or "skipped" when this
 	// subscriber's delivery could not be enqueued (see Reason).
-	Status string `json:"status" enum:"pending,skipped"`
+	Status string `json:"status" doc:"Open set; tolerate unknown values. Known values: pending (replay scheduled), skipped (could not enqueue — see reason)."`
 	Reason string `json:"reason,omitempty"`
 }
 

--- a/internal/httpapi/messages.go
+++ b/internal/httpapi/messages.go
@@ -40,7 +40,7 @@ type MessageView struct {
 	// only, mirroring MessageSummaryView. Exposed as `review_status` (the holds
 	// vocabulary unified on `review` in migration 044). Distinct from read_status,
 	// delivery_status, and webhook_status (each a separate axis).
-	HITLStatus string `json:"review_status,omitempty" enum:"pending_review,sent,review_rejected,review_expired_approved,review_expired_rejected"`
+	HITLStatus string `json:"review_status,omitempty" doc:"Review-hold lifecycle (outbound only). Open set; tolerate unknown values. Known values: pending_review, sent, review_rejected, review_expired_approved, review_expired_rejected."`
 	// WebhookStatus / WebhookError mirror MessageSummaryView so the detail view
 	// is a strict superset of the list item (a client fetching one message keeps
 	// the webhook delivery context). Apply to both directions; omitempty hides
@@ -52,13 +52,13 @@ type MessageView struct {
 	// DeliveryStatus is the outbound delivery rollup (migration 031:
 	// 'sent', 'delivered', 'bounced', …) — the worst recipient status by
 	// precedence. Outbound-only; omitted on inbound messages.
-	DeliveryStatus string `json:"delivery_status,omitempty" enum:"queued,sent,delivered,bounced,complained,deferred,failed"`
+	DeliveryStatus string `json:"delivery_status,omitempty" doc:"Outbound delivery rollup (worst recipient status by precedence; outbound only). Open set; tolerate unknown values. Known values: queued, sent, delivered, bounced, complained, deferred, failed."`
 	// DeliveryDetail is the human-readable diagnostic for the delivery
 	// rollup (e.g. bounce sub-type / SMTP response). Outbound-only.
 	DeliveryDetail string `json:"delivery_detail,omitempty"`
 	// SentAs is the From identity actually used at relay accept time.
 	// Outbound-only; omitted on inbound messages.
-	SentAs string `json:"sent_as,omitempty" enum:"own_address,relay"`
+	SentAs string `json:"sent_as,omitempty" doc:"From identity used at relay accept time (outbound only). Open set; tolerate unknown values. Known values: own_address, relay."`
 	// Flagged + FlagReason carry the inbound ingestion verdict (migration 033 /
 	// Slice 7): true when the agent's inbound_policy gate flagged this message
 	// on arrival (still delivered). Inbound-relevant; omitted on unflagged rows.
@@ -215,14 +215,14 @@ type MessageSummaryView struct {
 	ConversationID string   `json:"conversation_id,omitempty"`
 	// Status is the inbox read-state, exposed as `read_status` (MSG-1).
 	Status string `json:"read_status"`
-	HITLStatus     string   `json:"review_status,omitempty" enum:"pending_review,sent,review_rejected,review_expired_approved,review_expired_rejected"`
+	HITLStatus     string   `json:"review_status,omitempty" doc:"Review-hold lifecycle (outbound only). Open set; tolerate unknown values. Known values: pending_review, sent, review_rejected, review_expired_approved, review_expired_rejected."`
 	WebhookStatus  string   `json:"webhook_status,omitempty"`
 	WebhookError   string   `json:"webhook_error,omitempty"`
 	// DeliveryStatus / DeliveryDetail / SentAs are the outbound delivery
 	// rollup (migration 031). Outbound-only; omitted on inbound rows.
-	DeliveryStatus string `json:"delivery_status,omitempty" enum:"queued,sent,delivered,bounced,complained,deferred,failed"`
+	DeliveryStatus string `json:"delivery_status,omitempty" doc:"Outbound delivery rollup (worst recipient status by precedence; outbound only). Open set; tolerate unknown values. Known values: queued, sent, delivered, bounced, complained, deferred, failed."`
 	DeliveryDetail string `json:"delivery_detail,omitempty"`
-	SentAs         string `json:"sent_as,omitempty" enum:"own_address,relay"`
+	SentAs         string `json:"sent_as,omitempty" doc:"From identity used at relay accept time (outbound only). Open set; tolerate unknown values. Known values: own_address, relay."`
 	// Flagged + FlagReason are the inbound ingestion verdict (migration 033 /
 	// Slice 7). Surfaced in list views so flagged mail is visible without a
 	// per-message drill-down. Inbound-relevant; omitted on unflagged rows.

--- a/internal/httpapi/outbound.go
+++ b/internal/httpapi/outbound.go
@@ -53,11 +53,11 @@ type SendResultView struct {
 	// review_approved is the inbound-release outcome of POST .../approve (an
 	// inbound hold released to the agent's inbox — no send). sent/pending_review
 	// are the send/outbound-approve outcomes.
-	Status            string     `json:"status" enum:"sent,pending_review,review_approved"`
+	Status            string     `json:"status" doc:"Outcome. Open set; tolerate unknown values. Known values: sent, pending_review, review_approved."`
 	MessageID         string     `json:"message_id"`
 	ProviderMessageID string     `json:"provider_message_id,omitempty"`
-	SentAs            string     `json:"sent_as,omitempty" enum:"own_address,relay"`
-	Method            string     `json:"method,omitempty" enum:"smtp,loopback"`
+	SentAs            string     `json:"sent_as,omitempty" doc:"From identity used. Open set; tolerate unknown values. Known values: own_address, relay."`
+	Method            string     `json:"method,omitempty" doc:"Send transport. Open set; tolerate unknown values. Known values: smtp, loopback."`
 	ApprovalExpiresAt *time.Time `json:"approval_expires_at,omitempty"`
 	// Edited is set only by approve (true/false = did the reviewer edit the
 	// draft before sending); omitted on the plain send path.

--- a/internal/httpapi/ratelimit.go
+++ b/internal/httpapi/ratelimit.go
@@ -132,16 +132,24 @@ func userFromContext(ctx context.Context) *identity.User {
 	return nil
 }
 
-// clientIP extracts the caller IP for per-IP limiting, honoring a single
-// X-Forwarded-For hop (mirrors agent.clientIP so both surfaces key the
-// registration limiter identically).
+// clientIP extracts the caller IP for per-IP limiting. It trusts only
+// CF-Connecting-IP (set by Cloudflare and stripped from inbound requests
+// at the edge), NOT X-Forwarded-For: an attacker can prepend an arbitrary
+// XFF entry and Cloudflare appends the real client IP rather than
+// replacing it, so the leftmost XFF value — which this used to key on —
+// is fully client-controlled and lets one attacker mint unlimited per-IP
+// budget on every limiter (agent registration, attachment-token
+// throttle, feedback). CF-Connecting-IP is spoofable only by someone who
+// can reach the origin directly, so the origin must be firewalled to
+// Cloudflare's ranges. Falls back to RemoteAddr (dev / non-CF) but never
+// to XFF. Mirrors agent.clientIP and oauth dcrSourceIP so every per-IP
+// limiter keys identically.
 func clientIP(r *http.Request) string {
-	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
-		if ip, _, ok := strings.Cut(xff, ","); ok {
-			return strings.TrimSpace(ip)
-		}
-		return strings.TrimSpace(xff)
+	if ip := strings.TrimSpace(r.Header.Get("CF-Connecting-IP")); ip != "" {
+		return ip
 	}
-	host, _, _ := net.SplitHostPort(r.RemoteAddr)
-	return host
+	if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return host
+	}
+	return r.RemoteAddr
 }

--- a/internal/httpapi/ratelimit_test.go
+++ b/internal/httpapi/ratelimit_test.go
@@ -203,3 +203,40 @@ func TestSendRateLimited(t *testing.T) {
 		t.Fatalf("expected retry_after_seconds=7 in details, got %v", body)
 	}
 }
+
+// TestClientIPIgnoresXForwardedFor locks in the per-IP-limiter security
+// contract: the caller key comes from CF-Connecting-IP (edge-set, not
+// client-controllable), never from a forgeable X-Forwarded-For. A
+// regression here re-opens the rate-limit bypass where an attacker
+// rotates XFF to get unlimited budget on the registration / attachment /
+// feedback limiters.
+func TestClientIPIgnoresXForwardedFor(t *testing.T) {
+	cases := []struct {
+		name string
+		cf   string
+		xff  string
+		addr string
+		want string
+	}{
+		{"xff is ignored entirely", "", "1.2.3.4", "10.0.0.1:5555", "10.0.0.1"},
+		{"forged xff cannot override cf", "9.9.9.9", "1.2.3.4, 9.9.9.9", "10.0.0.1:5555", "9.9.9.9"},
+		{"cf preferred over remoteaddr", "9.9.9.9", "", "10.0.0.1:5555", "9.9.9.9"},
+		{"remoteaddr fallback when no cf", "", "", "10.0.0.1:5555", "10.0.0.1"},
+		{"bracketed ipv6 remoteaddr", "", "", "[::1]:5555", "::1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			r.RemoteAddr = tc.addr
+			if tc.cf != "" {
+				r.Header.Set("CF-Connecting-IP", tc.cf)
+			}
+			if tc.xff != "" {
+				r.Header.Set("X-Forwarded-For", tc.xff)
+			}
+			if got := clientIP(r); got != tc.want {
+				t.Fatalf("clientIP = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/httpapi/reviews.go
+++ b/internal/httpapi/reviews.go
@@ -31,7 +31,7 @@ type ReviewView struct {
 	To             []string  `json:"to" nullable:"false"`
 	Subject        string    `json:"subject"`
 	ConversationID string    `json:"conversation_id,omitempty"`
-	ReviewStatus   string    `json:"review_status" enum:"pending_review"`
+	ReviewStatus   string    `json:"review_status" doc:"Hold state of this queue item. Open set; tolerate unknown values. Currently always pending_review (the queue lists held items)."`
 	Flagged        bool      `json:"flagged,omitempty"`
 	FlagReason     string    `json:"flag_reason,omitempty"`
 	CreatedAt      time.Time `json:"created_at"`

--- a/internal/httpapi/spec_review_test.go
+++ b/internal/httpapi/spec_review_test.go
@@ -143,29 +143,63 @@ func TestSpecRegisterDomain409Declared(t *testing.T) {
 	}
 }
 
-// MED-5 — status-ish fields must carry enums matching the values the server emits.
+// MED-5 — response enum policy for GA (see docs/api.md "Versioning & stability"):
+//   - A field whose value set is genuinely closed forever (direction: a message is
+//     inbound or outbound, period) carries a closed enum.
+//   - A field whose value set the server may grow (delivery/review/send/event
+//     status, sending_status, sent_as, method, event types) is an OPEN string with
+//     no enum, so adding a value later doesn't break strict spec-generated clients.
+// This test pins both halves so neither regresses: an open field must not silently
+// re-acquire a closed enum, and direction must not lose its enum.
 func TestSpecStatusEnums(t *testing.T) {
 	doc := renderSpec(t)
 
-	cases := []struct {
+	// Closed-forever enums (must carry the exact enum).
+	closed := []struct {
 		schema string
 		field  string
 		want   []string
 	}{
 		{"MessageView", "direction", []string{"inbound", "outbound"}},
 		{"MessageSummaryView", "direction", []string{"inbound", "outbound"}},
-		{"MessageView", "review_status", []string{"pending_review", "sent", "review_rejected", "review_expired_approved", "review_expired_rejected"}},
-		{"MessageSummaryView", "review_status", []string{"pending_review", "sent", "review_rejected", "review_expired_approved", "review_expired_rejected"}},
-		{"SendResultView", "status", []string{"sent", "pending_review", "review_approved"}},
-		{"EventJSON", "status", []string{"pending", "processed", "no_match"}},
-		{"RedeliverView", "status", []string{"pending", "scheduled"}},
-		{"WebhookDeliveryView", "status", []string{"pending", "delivered", "failed"}},
 	}
-	for _, c := range cases {
+	for _, c := range closed {
 		props := schemaProps(t, doc, c.schema)
 		got := enumOf(props, c.field)
 		if !setEqual(got, c.want...) {
-			t.Errorf("%s.%s enum = %v, want %v", c.schema, c.field, got, c.want)
+			t.Errorf("%s.%s enum = %v, want closed enum %v", c.schema, c.field, got, c.want)
+		}
+	}
+
+	// Open (growable) response fields — must be plain strings with NO enum, so a
+	// new server value doesn't break a frozen strict client. Re-closing any of
+	// these is a breaking change for the GA contract.
+	open := []struct {
+		schema string
+		field  string
+	}{
+		{"MessageView", "review_status"},
+		{"MessageSummaryView", "review_status"},
+		{"MessageView", "delivery_status"},
+		{"MessageSummaryView", "delivery_status"},
+		{"MessageView", "sent_as"},
+		{"MessageSummaryView", "sent_as"},
+		{"SendResultView", "status"},
+		{"SendResultView", "sent_as"},
+		{"SendResultView", "method"},
+		{"EventJSON", "status"},
+		{"EventJSON", "type"},
+		{"RedeliverView", "status"},
+		{"RedeliverDelivery", "status"},
+		{"WebhookDeliveryView", "status"},
+		{"WebhookDeliveryView", "event_type"},
+		{"DomainView", "sending_status"},
+		{"ReviewView", "review_status"},
+	}
+	for _, c := range open {
+		props := schemaProps(t, doc, c.schema)
+		if got := enumOf(props, c.field); len(got) != 0 {
+			t.Errorf("%s.%s must be an OPEN string (no enum) for GA forward-compat, but has enum %v", c.schema, c.field, got)
 		}
 	}
 }

--- a/internal/httpapi/webhooks.go
+++ b/internal/httpapi/webhooks.go
@@ -38,7 +38,7 @@ type WebhookView struct {
 	ID              string             `json:"id"`
 	URL             string             `json:"url"`
 	Description     string             `json:"description"`
-	Events          []string           `json:"events" nullable:"false" enum:"email.received,email.sent,email.review_approved,email.review_rejected,domain.sending_verified,domain.sending_failed,email.delivered,email.bounced,email.complained,domain.suppression_added,email.flagged,email.blocked,email.pending_review" doc:"Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable. All other events are stable."`
+	Events          []string           `json:"events" nullable:"false" doc:"The event types this webhook matches. Open set: new event types may be added over time, so treat these as strings and tolerate unknown values. Known values: email.received, email.sent, email.delivered, email.bounced, email.complained, email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected, domain.sending_verified, domain.sending_failed, domain.suppression_added. Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable."`
 	Filters         WebhookFiltersView `json:"filters"`
 	Enabled         bool               `json:"enabled"`
 	AutoDisabledAt  string             `json:"auto_disabled_at,omitempty" format:"date-time"`
@@ -306,8 +306,8 @@ func (s *Server) handleTestWebhook(ctx context.Context, in *testWebhookInput) (*
 // WebhookDeliveryView mirrors the legacy per-delivery wire shape.
 type WebhookDeliveryView struct {
 	ID             string `json:"id"`
-	EventType      string `json:"event_type" enum:"email.received,email.sent,email.review_approved,email.review_rejected,domain.sending_verified,domain.sending_failed,email.delivered,email.bounced,email.complained,domain.suppression_added,email.flagged,email.blocked,email.pending_review"`
-	Status         string `json:"status" enum:"pending,delivered,failed"`
+	EventType      string `json:"event_type" doc:"The event type that triggered this delivery. Open set: new event types may be added, so treat as a string and tolerate unknown values. Known values are the webhook event catalog (email.received, email.sent, email.delivered, …, domain.*)."`
+	Status         string `json:"status" doc:"Delivery state. Open set; tolerate unknown values. Known values: pending, delivered, failed."`
 	Attempts       int    `json:"attempts"`
 	LastError      string `json:"last_error,omitempty"`
 	LastStatusCode *int   `json:"last_status_code,omitempty"`

--- a/internal/outbound/smtp_relay.go
+++ b/internal/outbound/smtp_relay.go
@@ -82,15 +82,30 @@ func (r *SMTPRelay) sendOnce(envelopeFrom string, recipients []string, message [
 	}
 	defer c.Close()
 
-	// STARTTLS — only if the server advertises it
+	// STARTTLS. Negotiate whenever the server advertises it; track
+	// whether the connection actually became encrypted so we can fail
+	// closed below. A network attacker can strip the STARTTLS capability
+	// from the EHLO response to force a cleartext relay — RequireTLS
+	// turns that into a hard error instead of a silent downgrade.
+	tlsActive := false
 	if ok, _ := c.Extension("STARTTLS"); ok {
 		if err := c.StartTLS(&tls.Config{ServerName: r.cfg.Host}); err != nil {
 			return "", fmt.Errorf("starttls: %w", err)
 		}
+		tlsActive = true
+	}
+	if r.cfg.RequireTLS != nil && *r.cfg.RequireTLS && !tlsActive {
+		return "", fmt.Errorf("outbound smtp: server did not offer STARTTLS and require_tls is set; refusing to relay in cleartext")
 	}
 
-	// Auth
+	// Auth. Never send PLAIN credentials over an unencrypted connection,
+	// regardless of RequireTLS — that would leak the relay username and
+	// password to anyone on the path. This is a hard floor below the
+	// RequireTLS policy.
 	if r.cfg.Username != "" {
+		if !tlsActive {
+			return "", fmt.Errorf("outbound smtp: refusing to send PLAIN auth over an unencrypted connection")
+		}
 		auth := smtp.PlainAuth("", r.cfg.Username, r.cfg.Password, r.cfg.Host)
 		if err := c.Auth(auth); err != nil {
 			return "", fmt.Errorf("auth: %w", err)

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -8,6 +8,9 @@ Async Python SDK for [e2a](https://e2a.dev) — email for AI agents.
 pip install e2a          # add the [ws] extra for client.listen(): pip install "e2a[ws]"
 ```
 
+The SDK major version tracks the SDK package's own breaking changes and is
+independent of the API version path (`/v1`): SDK 3.x targets the e2a v1 API.
+
 ## Upgrading from 2.x to 3.0
 
 3.0 is a breaking redesign. The SDK now wraps a generated `/v1` client behind a

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.9"
 authors = [{ name = "Mnexa AI", email = "josh@mnexa.ai" }]
 keywords = ["email", "agent", "authentication", "e2a", "webhook"]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
@@ -33,6 +33,12 @@ dependencies = [
     "urllib3>=1.25",
     "typing-extensions>=4.7",
 ]
+
+[tool.hatch.build.targets.wheel]
+# src layout: ship the e2a package (incl. PEP 561 py.typed markers at every
+# hand-written level, not just the generated sub-package).
+packages = ["src/e2a"]
+artifacts = ["src/e2a/py.typed", "src/e2a/v1/py.typed", "src/e2a/v1/generated/py.typed"]
 
 [project.urls]
 Homepage = "https://e2a.dev"

--- a/sdks/python/src/e2a/v1/generated/models/create_webhook_response.py
+++ b/sdks/python/src/e2a/v1/generated/models/create_webhook_response.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 from datetime import datetime
-from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from e2a.v1.generated.models.webhook_filters_view import WebhookFiltersView
 from typing import Optional, Set
@@ -32,7 +32,7 @@ class CreateWebhookResponse(BaseModel):
     created_at: datetime
     description: StrictStr
     enabled: StrictBool
-    events: List[StrictStr] = Field(description="Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable. All other events are stable.")
+    events: List[StrictStr] = Field(description="The event types this webhook matches. Open set: new event types may be added over time, so treat these as strings and tolerate unknown values. Known values: email.received, email.sent, email.delivered, email.bounced, email.complained, email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected, domain.sending_verified, domain.sending_failed, domain.suppression_added. Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable.")
     filters: WebhookFiltersView
     id: StrictStr
     last_delivered_at: Optional[datetime] = None

--- a/sdks/python/src/e2a/v1/generated/models/domain_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/domain_view.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 from datetime import datetime
-from pydantic import BaseModel, ConfigDict, StrictBool, StrictInt, StrictStr, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from e2a.v1.generated.models.dns_records_view import DNSRecordsView
 from e2a.v1.generated.models.sending_dns_record_view import SendingDNSRecordView
@@ -37,7 +37,7 @@ class DomainView(BaseModel):
     sending_dns_records: Optional[List[SendingDNSRecordView]] = None
     sending_error: Optional[StrictStr] = None
     sending_last_checked_at: Optional[datetime] = None
-    sending_status: StrictStr
+    sending_status: StrictStr = Field(description="Async SES sending-identity state. Open set; tolerate unknown values. Known values: none, pending, verified, failed.")
     verification_token: StrictStr
     verified: StrictBool
     verified_at: Optional[datetime] = None

--- a/sdks/python/src/e2a/v1/generated/models/event_json.py
+++ b/sdks/python/src/e2a/v1/generated/models/event_json.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 from datetime import datetime
-from pydantic import BaseModel, ConfigDict, StrictInt, StrictStr, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from e2a.v1.generated.models.delivery_status_json import DeliveryStatusJSON
 from typing import Optional, Set
@@ -36,8 +36,8 @@ class EventJSON(BaseModel):
     id: StrictStr
     message_id: Optional[StrictStr] = None
     schema_version: StrictInt
-    status: StrictStr
-    type: StrictStr
+    status: StrictStr = Field(description="Event processing state. Open set; tolerate unknown values. Known values: pending, processed, no_match.")
+    type: StrictStr = Field(description="Event type. Open set: new event types may be added over time, so treat as a string and tolerate unknown values. Known values: email.received, email.sent, email.delivered, email.bounced, email.complained, email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected, domain.sending_verified, domain.sending_failed, domain.suppression_added.")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["agent_id", "conversation_id", "created_at", "data", "delivery_status", "id", "message_id", "schema_version", "status", "type"]
 

--- a/sdks/python/src/e2a/v1/generated/models/message_summary_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/message_summary_view.py
@@ -33,7 +33,7 @@ class MessageSummaryView(BaseModel):
     conversation_id: Optional[StrictStr] = None
     created_at: datetime
     delivery_detail: Optional[StrictStr] = None
-    delivery_status: Optional[StrictStr] = None
+    delivery_status: Optional[StrictStr] = Field(default=None, description="Outbound delivery rollup (worst recipient status by precedence; outbound only). Open set; tolerate unknown values. Known values: queued, sent, delivered, bounced, complained, deferred, failed.")
     direction: StrictStr
     flag_reason: Optional[StrictStr] = None
     flagged: Optional[StrictBool] = None
@@ -43,8 +43,8 @@ class MessageSummaryView(BaseModel):
     read_status: StrictStr
     recipient: StrictStr
     reply_to: Optional[List[StrictStr]] = None
-    review_status: Optional[StrictStr] = None
-    sent_as: Optional[StrictStr] = None
+    review_status: Optional[StrictStr] = Field(default=None, description="Review-hold lifecycle (outbound only). Open set; tolerate unknown values. Known values: pending_review, sent, review_rejected, review_expired_approved, review_expired_rejected.")
+    sent_as: Optional[StrictStr] = Field(default=None, description="From identity used at relay accept time (outbound only). Open set; tolerate unknown values. Known values: own_address, relay.")
     size_bytes: Optional[StrictInt] = None
     subject: StrictStr
     to: List[StrictStr]

--- a/sdks/python/src/e2a/v1/generated/models/message_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/message_view.py
@@ -39,7 +39,7 @@ class MessageView(BaseModel):
     conversation_id: StrictStr
     created_at: datetime
     delivery_detail: Optional[StrictStr] = None
-    delivery_status: Optional[StrictStr] = None
+    delivery_status: Optional[StrictStr] = Field(default=None, description="Outbound delivery rollup (worst recipient status by precedence; outbound only). Open set; tolerate unknown values. Known values: queued, sent, delivered, bounced, complained, deferred, failed.")
     direction: StrictStr
     flag_reason: Optional[StrictStr] = None
     flagged: Optional[StrictBool] = None
@@ -51,8 +51,8 @@ class MessageView(BaseModel):
     read_status: StrictStr
     recipient: StrictStr
     reply_to: List[StrictStr]
-    review_status: Optional[StrictStr] = None
-    sent_as: Optional[StrictStr] = None
+    review_status: Optional[StrictStr] = Field(default=None, description="Review-hold lifecycle (outbound only). Open set; tolerate unknown values. Known values: pending_review, sent, review_rejected, review_expired_approved, review_expired_rejected.")
+    sent_as: Optional[StrictStr] = Field(default=None, description="From identity used at relay accept time (outbound only). Open set; tolerate unknown values. Known values: own_address, relay.")
     size_bytes: Optional[StrictInt] = None
     subject: StrictStr
     to: List[StrictStr]

--- a/sdks/python/src/e2a/v1/generated/models/redeliver_delivery.py
+++ b/sdks/python/src/e2a/v1/generated/models/redeliver_delivery.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, StrictStr, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from typing import Optional, Set
 from typing_extensions import Self
@@ -28,7 +28,7 @@ class RedeliverDelivery(BaseModel):
     """ # noqa: E501
     delivery_id: Optional[StrictStr] = None
     reason: Optional[StrictStr] = None
-    status: StrictStr
+    status: StrictStr = Field(description="Open set; tolerate unknown values. Known values: pending (replay scheduled), skipped (could not enqueue — see reason).")
     webhook_id: StrictStr
     __properties: ClassVar[List[str]] = ["delivery_id", "reason", "status", "webhook_id"]
 

--- a/sdks/python/src/e2a/v1/generated/models/redeliver_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/redeliver_view.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, StrictStr, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from e2a.v1.generated.models.redeliver_delivery import RedeliverDelivery
 from typing import Optional, Set
@@ -30,7 +30,7 @@ class RedeliverView(BaseModel):
     deliveries: Optional[List[RedeliverDelivery]] = None
     delivery_id: Optional[StrictStr] = None
     event_id: StrictStr
-    status: StrictStr
+    status: StrictStr = Field(description="Open set; tolerate unknown values. Known values: pending (single-webhook replay), scheduled (bulk fan-out).")
     webhook_id: Optional[StrictStr] = None
     __properties: ClassVar[List[str]] = ["deliveries", "delivery_id", "event_id", "status", "webhook_id"]
 

--- a/sdks/python/src/e2a/v1/generated/models/review_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/review_view.py
@@ -35,7 +35,7 @@ class ReviewView(BaseModel):
     flagged: Optional[StrictBool] = None
     var_from: StrictStr = Field(alias="from")
     id: StrictStr
-    review_status: StrictStr
+    review_status: StrictStr = Field(description="Hold state of this queue item. Open set; tolerate unknown values. Currently always pending_review (the queue lists held items).")
     subject: StrictStr
     to: List[StrictStr]
     __properties: ClassVar[List[str]] = ["agent", "conversation_id", "created_at", "direction", "flag_reason", "flagged", "from", "id", "review_status", "subject", "to"]

--- a/sdks/python/src/e2a/v1/generated/models/send_result_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/send_result_view.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 from datetime import datetime
-from pydantic import BaseModel, ConfigDict, StrictBool, StrictStr, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from typing import Optional, Set
 from typing_extensions import Self
@@ -30,10 +30,10 @@ class SendResultView(BaseModel):
     approval_expires_at: Optional[datetime] = None
     edited: Optional[StrictBool] = None
     message_id: StrictStr
-    method: Optional[StrictStr] = None
+    method: Optional[StrictStr] = Field(default=None, description="Send transport. Open set; tolerate unknown values. Known values: smtp, loopback.")
     provider_message_id: Optional[StrictStr] = None
-    sent_as: Optional[StrictStr] = None
-    status: StrictStr
+    sent_as: Optional[StrictStr] = Field(default=None, description="From identity used. Open set; tolerate unknown values. Known values: own_address, relay.")
+    status: StrictStr = Field(description="Outcome. Open set; tolerate unknown values. Known values: sent, pending_review, review_approved.")
     __properties: ClassVar[List[str]] = ["approval_expires_at", "edited", "message_id", "method", "provider_message_id", "sent_as", "status"]
 
     model_config = ConfigDict(

--- a/sdks/python/src/e2a/v1/generated/models/webhook_delivery_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/webhook_delivery_view.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 from datetime import datetime
-from pydantic import BaseModel, ConfigDict, StrictInt, StrictStr, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from typing import Optional, Set
 from typing_extensions import Self
@@ -29,13 +29,13 @@ class WebhookDeliveryView(BaseModel):
     """ # noqa: E501
     attempts: StrictInt
     created_at: datetime
-    event_type: StrictStr
+    event_type: StrictStr = Field(description="The event type that triggered this delivery. Open set: new event types may be added, so treat as a string and tolerate unknown values. Known values are the webhook event catalog (email.received, email.sent, email.delivered, …, domain.*).")
     id: StrictStr
     last_attempt_at: Optional[datetime] = None
     last_error: Optional[StrictStr] = None
     last_status_code: Optional[StrictInt] = None
     next_retry_at: datetime
-    status: StrictStr
+    status: StrictStr = Field(description="Delivery state. Open set; tolerate unknown values. Known values: pending, delivered, failed.")
     __properties: ClassVar[List[str]] = ["attempts", "created_at", "event_type", "id", "last_attempt_at", "last_error", "last_status_code", "next_retry_at", "status"]
 
     model_config = ConfigDict(

--- a/sdks/python/src/e2a/v1/generated/models/webhook_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/webhook_view.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 from datetime import datetime
-from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from e2a.v1.generated.models.webhook_filters_view import WebhookFiltersView
 from typing import Optional, Set
@@ -32,7 +32,7 @@ class WebhookView(BaseModel):
     created_at: datetime
     description: StrictStr
     enabled: StrictBool
-    events: List[StrictStr] = Field(description="Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable. All other events are stable.")
+    events: List[StrictStr] = Field(description="The event types this webhook matches. Open set: new event types may be added over time, so treat these as strings and tolerate unknown values. Known values: email.received, email.sent, email.delivered, email.bounced, email.complained, email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected, domain.sending_verified, domain.sending_failed, domain.suppression_added. Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable.")
     filters: WebhookFiltersView
     id: StrictStr
     last_delivered_at: Optional[datetime] = None

--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+## 3.0.0
+
+Breaking redesign. The SDK now wraps a generated `/v1` client behind a
+namespaced, resource-oriented `E2AClient`, with a typed error hierarchy,
+automatic retries + idempotency, and auto-pagination. Targets the e2a v1 API.
+
+### Changed
+- **Namespaced resources.** Flat methods are gone. Resources are grouped under
+  the client: `client.agents`, `client.messages`, `client.conversations`,
+  `client.domains`, `client.events`, `client.webhooks`, `client.account`.
+  Per-agent methods take the agent `address` as the first argument
+  (`client.messages.send(address, {...})`,
+  `client.messages.list(address).toArray({ limit })`,
+  `client.messages.get(address, id)`,
+  `client.messages.reply(address, id, {...})`).
+- **Webhook verification.** Verify and decode a delivery with the standalone
+  `constructEvent(rawBody, signatureHeader, secret)`, which checks the
+  `X-E2A-Signature` header and returns a typed `WebhookEvent` (throwing
+  `E2AWebhookSignatureError` on a bad signature). Per-webhook `whsec_…` secrets,
+  Stripe-style.
+- **Typed errors.** Failures throw `E2AError` subclasses (`E2ANotFoundError`,
+  `E2AConflictError`, `E2AValidationError`, `E2ARateLimitError`,
+  `E2AWebhookSignatureError`, …) carrying `.code`, `.status`, `.requestId`, and
+  `.retryable`.
+
+### Removed
+- The flat methods `getMessages` / `getMessage` / `send` / `reply` and the
+  per-call address inference. Pass the agent `address` explicitly.
+- `client.parse` / `client.parseWebhook` and `InboundEmail`. Replaced by
+  `constructEvent`.

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -8,6 +8,9 @@ TypeScript/Node.js SDK for [e2a](https://e2a.dev) — email for AI agents.
 npm install @e2a/sdk
 ```
 
+The SDK major version tracks the SDK package's own breaking changes and is
+independent of the API version path (`/v1`): SDK 3.x targets the e2a v1 API.
+
 ## Upgrading from 2.x to 3.0
 
 3.0 is a breaking redesign. The SDK now wraps a generated `/v1` client behind a

--- a/sdks/typescript/src/v1/generated/models/CreateWebhookResponse.ts
+++ b/sdks/typescript/src/v1/generated/models/CreateWebhookResponse.ts
@@ -19,9 +19,9 @@ export class CreateWebhookResponse {
     'description': string;
     'enabled': boolean;
     /**
-    * Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable. All other events are stable.
+    * The event types this webhook matches. Open set: new event types may be added over time, so treat these as strings and tolerate unknown values. Known values: email.received, email.sent, email.delivered, email.bounced, email.complained, email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected, domain.sending_verified, domain.sending_failed, domain.suppression_added. Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable.
     */
-    'events': Array<CreateWebhookResponseEventsEnum>;
+    'events': Array<string>;
     'filters': WebhookFiltersView;
     'id': string;
     'lastDeliveredAt'?: Date;
@@ -60,7 +60,7 @@ export class CreateWebhookResponse {
         {
             "name": "events",
             "baseName": "events",
-            "type": "Array<CreateWebhookResponseEventsEnum>",
+            "type": "Array<string>",
             "format": ""
         },
         {
@@ -101,20 +101,3 @@ export class CreateWebhookResponse {
     public constructor() {
     }
 }
-
-export enum CreateWebhookResponseEventsEnum {
-    EmailReceived = 'email.received',
-    EmailSent = 'email.sent',
-    EmailReviewApproved = 'email.review_approved',
-    EmailReviewRejected = 'email.review_rejected',
-    DomainSendingVerified = 'domain.sending_verified',
-    DomainSendingFailed = 'domain.sending_failed',
-    EmailDelivered = 'email.delivered',
-    EmailBounced = 'email.bounced',
-    EmailComplained = 'email.complained',
-    DomainSuppressionAdded = 'domain.suppression_added',
-    EmailFlagged = 'email.flagged',
-    EmailBlocked = 'email.blocked',
-    EmailPendingReview = 'email.pending_review'
-}
-

--- a/sdks/typescript/src/v1/generated/models/DomainView.ts
+++ b/sdks/typescript/src/v1/generated/models/DomainView.ts
@@ -23,7 +23,10 @@ export class DomainView {
     'sendingDnsRecords'?: Array<SendingDNSRecordView>;
     'sendingError'?: string;
     'sendingLastCheckedAt'?: Date;
-    'sendingStatus': DomainViewSendingStatusEnum;
+    /**
+    * Async SES sending-identity state. Open set; tolerate unknown values. Known values: none, pending, verified, failed.
+    */
+    'sendingStatus': string;
     'verificationToken': string;
     'verified': boolean;
     'verifiedAt'?: Date;
@@ -84,7 +87,7 @@ export class DomainView {
         {
             "name": "sendingStatus",
             "baseName": "sending_status",
-            "type": "DomainViewSendingStatusEnum",
+            "type": "string",
             "format": ""
         },
         {
@@ -113,11 +116,3 @@ export class DomainView {
     public constructor() {
     }
 }
-
-export enum DomainViewSendingStatusEnum {
-    None = 'none',
-    Pending = 'pending',
-    Verified = 'verified',
-    Failed = 'failed'
-}
-

--- a/sdks/typescript/src/v1/generated/models/EventJSON.ts
+++ b/sdks/typescript/src/v1/generated/models/EventJSON.ts
@@ -22,8 +22,14 @@ export class EventJSON {
     'id': string;
     'messageId'?: string;
     'schemaVersion': number;
-    'status': EventJSONStatusEnum;
-    'type': EventJSONTypeEnum;
+    /**
+    * Event processing state. Open set; tolerate unknown values. Known values: pending, processed, no_match.
+    */
+    'status': string;
+    /**
+    * Event type. Open set: new event types may be added over time, so treat as a string and tolerate unknown values. Known values: email.received, email.sent, email.delivered, email.bounced, email.complained, email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected, domain.sending_verified, domain.sending_failed, domain.suppression_added.
+    */
+    'type': string;
 
     static readonly discriminator: string | undefined = undefined;
 
@@ -81,13 +87,13 @@ export class EventJSON {
         {
             "name": "status",
             "baseName": "status",
-            "type": "EventJSONStatusEnum",
+            "type": "string",
             "format": ""
         },
         {
             "name": "type",
             "baseName": "type",
-            "type": "EventJSONTypeEnum",
+            "type": "string",
             "format": ""
         }    ];
 
@@ -98,25 +104,3 @@ export class EventJSON {
     public constructor() {
     }
 }
-
-export enum EventJSONStatusEnum {
-    Pending = 'pending',
-    Processed = 'processed',
-    NoMatch = 'no_match'
-}
-export enum EventJSONTypeEnum {
-    EmailReceived = 'email.received',
-    EmailSent = 'email.sent',
-    EmailReviewApproved = 'email.review_approved',
-    EmailReviewRejected = 'email.review_rejected',
-    DomainSendingVerified = 'domain.sending_verified',
-    DomainSendingFailed = 'domain.sending_failed',
-    EmailDelivered = 'email.delivered',
-    EmailBounced = 'email.bounced',
-    EmailComplained = 'email.complained',
-    DomainSuppressionAdded = 'domain.suppression_added',
-    EmailFlagged = 'email.flagged',
-    EmailBlocked = 'email.blocked',
-    EmailPendingReview = 'email.pending_review'
-}
-

--- a/sdks/typescript/src/v1/generated/models/MessageSummaryView.ts
+++ b/sdks/typescript/src/v1/generated/models/MessageSummaryView.ts
@@ -19,7 +19,10 @@ export class MessageSummaryView {
     'conversationId'?: string;
     'createdAt': Date;
     'deliveryDetail'?: string;
-    'deliveryStatus'?: MessageSummaryViewDeliveryStatusEnum;
+    /**
+    * Outbound delivery rollup (worst recipient status by precedence; outbound only). Open set; tolerate unknown values. Known values: queued, sent, delivered, bounced, complained, deferred, failed.
+    */
+    'deliveryStatus'?: string;
     'direction': MessageSummaryViewDirectionEnum;
     'flagReason'?: string;
     'flagged'?: boolean;
@@ -29,8 +32,14 @@ export class MessageSummaryView {
     'readStatus': string;
     'recipient': string;
     'replyTo'?: Array<string>;
-    'reviewStatus'?: MessageSummaryViewReviewStatusEnum;
-    'sentAs'?: MessageSummaryViewSentAsEnum;
+    /**
+    * Review-hold lifecycle (outbound only). Open set; tolerate unknown values. Known values: pending_review, sent, review_rejected, review_expired_approved, review_expired_rejected.
+    */
+    'reviewStatus'?: string;
+    /**
+    * From identity used at relay accept time (outbound only). Open set; tolerate unknown values. Known values: own_address, relay.
+    */
+    'sentAs'?: string;
     'sizeBytes'?: number;
     'subject': string;
     'to': Array<string>;
@@ -75,7 +84,7 @@ export class MessageSummaryView {
         {
             "name": "deliveryStatus",
             "baseName": "delivery_status",
-            "type": "MessageSummaryViewDeliveryStatusEnum",
+            "type": "string",
             "format": ""
         },
         {
@@ -135,13 +144,13 @@ export class MessageSummaryView {
         {
             "name": "reviewStatus",
             "baseName": "review_status",
-            "type": "MessageSummaryViewReviewStatusEnum",
+            "type": "string",
             "format": ""
         },
         {
             "name": "sentAs",
             "baseName": "sent_as",
-            "type": "MessageSummaryViewSentAsEnum",
+            "type": "string",
             "format": ""
         },
         {
@@ -183,28 +192,8 @@ export class MessageSummaryView {
     }
 }
 
-export enum MessageSummaryViewDeliveryStatusEnum {
-    Queued = 'queued',
-    Sent = 'sent',
-    Delivered = 'delivered',
-    Bounced = 'bounced',
-    Complained = 'complained',
-    Deferred = 'deferred',
-    Failed = 'failed'
-}
 export enum MessageSummaryViewDirectionEnum {
     Inbound = 'inbound',
     Outbound = 'outbound'
-}
-export enum MessageSummaryViewReviewStatusEnum {
-    PendingReview = 'pending_review',
-    Sent = 'sent',
-    ReviewRejected = 'review_rejected',
-    ReviewExpiredApproved = 'review_expired_approved',
-    ReviewExpiredRejected = 'review_expired_rejected'
-}
-export enum MessageSummaryViewSentAsEnum {
-    OwnAddress = 'own_address',
-    Relay = 'relay'
 }
 

--- a/sdks/typescript/src/v1/generated/models/MessageView.ts
+++ b/sdks/typescript/src/v1/generated/models/MessageView.ts
@@ -25,7 +25,10 @@ export class MessageView {
     'conversationId': string;
     'createdAt': Date;
     'deliveryDetail'?: string;
-    'deliveryStatus'?: MessageViewDeliveryStatusEnum;
+    /**
+    * Outbound delivery rollup (worst recipient status by precedence; outbound only). Open set; tolerate unknown values. Known values: queued, sent, delivered, bounced, complained, deferred, failed.
+    */
+    'deliveryStatus'?: string;
     'direction': MessageViewDirectionEnum;
     'flagReason'?: string;
     'flagged'?: boolean;
@@ -37,8 +40,14 @@ export class MessageView {
     'readStatus': string;
     'recipient': string;
     'replyTo': Array<string>;
-    'reviewStatus'?: MessageViewReviewStatusEnum;
-    'sentAs'?: MessageViewSentAsEnum;
+    /**
+    * Review-hold lifecycle (outbound only). Open set; tolerate unknown values. Known values: pending_review, sent, review_rejected, review_expired_approved, review_expired_rejected.
+    */
+    'reviewStatus'?: string;
+    /**
+    * From identity used at relay accept time (outbound only). Open set; tolerate unknown values. Known values: own_address, relay.
+    */
+    'sentAs'?: string;
     'sizeBytes'?: number;
     'subject': string;
     'to': Array<string>;
@@ -101,7 +110,7 @@ export class MessageView {
         {
             "name": "deliveryStatus",
             "baseName": "delivery_status",
-            "type": "MessageViewDeliveryStatusEnum",
+            "type": "string",
             "format": ""
         },
         {
@@ -173,13 +182,13 @@ export class MessageView {
         {
             "name": "reviewStatus",
             "baseName": "review_status",
-            "type": "MessageViewReviewStatusEnum",
+            "type": "string",
             "format": ""
         },
         {
             "name": "sentAs",
             "baseName": "sent_as",
-            "type": "MessageViewSentAsEnum",
+            "type": "string",
             "format": ""
         },
         {
@@ -221,28 +230,8 @@ export class MessageView {
     }
 }
 
-export enum MessageViewDeliveryStatusEnum {
-    Queued = 'queued',
-    Sent = 'sent',
-    Delivered = 'delivered',
-    Bounced = 'bounced',
-    Complained = 'complained',
-    Deferred = 'deferred',
-    Failed = 'failed'
-}
 export enum MessageViewDirectionEnum {
     Inbound = 'inbound',
     Outbound = 'outbound'
-}
-export enum MessageViewReviewStatusEnum {
-    PendingReview = 'pending_review',
-    Sent = 'sent',
-    ReviewRejected = 'review_rejected',
-    ReviewExpiredApproved = 'review_expired_approved',
-    ReviewExpiredRejected = 'review_expired_rejected'
-}
-export enum MessageViewSentAsEnum {
-    OwnAddress = 'own_address',
-    Relay = 'relay'
 }
 

--- a/sdks/typescript/src/v1/generated/models/ObjectSerializer.ts
+++ b/sdks/typescript/src/v1/generated/models/ObjectSerializer.ts
@@ -99,25 +99,25 @@ import { CreateAPIKeyRequest   , CreateAPIKeyRequestScopeEnum   } from '../model
 import { CreateAPIKeyResponse        , CreateAPIKeyResponseScopeEnum   } from '../models/CreateAPIKeyResponse.js';
 import { CreateAgentRequest } from '../models/CreateAgentRequest.js';
 import { CreateWebhookRequest , CreateWebhookRequestEventsEnum     } from '../models/CreateWebhookRequest.js';
-import { CreateWebhookResponse    , CreateWebhookResponseEventsEnum        } from '../models/CreateWebhookResponse.js';
+import { CreateWebhookResponse } from '../models/CreateWebhookResponse.js';
 import { DNSRecordView } from '../models/DNSRecordView.js';
 import { DNSRecordsView } from '../models/DNSRecordsView.js';
 import { DeleteUserDataResult } from '../models/DeleteUserDataResult.js';
 import { DeliveryStatusJSON } from '../models/DeliveryStatusJSON.js';
 import { DeploymentInfoView } from '../models/DeploymentInfoView.js';
 import { Domain } from '../models/Domain.js';
-import { DomainView        , DomainViewSendingStatusEnum      } from '../models/DomainView.js';
+import { DomainView } from '../models/DomainView.js';
 import { ErrorBody } from '../models/ErrorBody.js';
 import { ErrorEnvelope } from '../models/ErrorEnvelope.js';
-import { EventJSON        , EventJSONStatusEnum  , EventJSONTypeEnum   } from '../models/EventJSON.js';
+import { EventJSON } from '../models/EventJSON.js';
 import { ForwardRequest } from '../models/ForwardRequest.js';
 import { LimitsCapsView } from '../models/LimitsCapsView.js';
 import { LimitsUsageView } from '../models/LimitsUsageView.js';
 import { Message } from '../models/Message.js';
 import { MessageBodyView } from '../models/MessageBodyView.js';
 import { MessageParsedView } from '../models/MessageParsedView.js';
-import { MessageSummaryView     , MessageSummaryViewDeliveryStatusEnum  , MessageSummaryViewDirectionEnum          , MessageSummaryViewReviewStatusEnum  , MessageSummaryViewSentAsEnum        } from '../models/MessageSummaryView.js';
-import { MessageView        , MessageViewDeliveryStatusEnum  , MessageViewDirectionEnum            , MessageViewReviewStatusEnum  , MessageViewSentAsEnum        } from '../models/MessageView.js';
+import { MessageSummaryView      , MessageSummaryViewDirectionEnum                  } from '../models/MessageSummaryView.js';
+import { MessageView         , MessageViewDirectionEnum                    } from '../models/MessageView.js';
 import { OAuthConnectionEntry } from '../models/OAuthConnectionEntry.js';
 import { PageAPIKeyView } from '../models/PageAPIKeyView.js';
 import { PageAgentView } from '../models/PageAgentView.js';
@@ -135,18 +135,18 @@ import { ProtectionEventExportEntry } from '../models/ProtectionEventExportEntry
 import { ProtectionGateView, ProtectionGateViewActionEnum   , ProtectionGateViewPolicyEnum   } from '../models/ProtectionGateView.js';
 import { ProtectionHoldsView, ProtectionHoldsViewOnExpiryEnum    } from '../models/ProtectionHoldsView.js';
 import { ProtectionScanView, ProtectionScanViewSensitivityEnum   } from '../models/ProtectionScanView.js';
-import { RedeliverDelivery  , RedeliverDeliveryStatusEnum    } from '../models/RedeliverDelivery.js';
+import { RedeliverDelivery } from '../models/RedeliverDelivery.js';
 import { RedeliverEventRequest } from '../models/RedeliverEventRequest.js';
-import { RedeliverView   , RedeliverViewStatusEnum    } from '../models/RedeliverView.js';
+import { RedeliverView } from '../models/RedeliverView.js';
 import { RegisterDomainRequest } from '../models/RegisterDomainRequest.js';
 import { RejectRequest } from '../models/RejectRequest.js';
 import { RejectResultView } from '../models/RejectResultView.js';
 import { ReplyRequest } from '../models/ReplyRequest.js';
 import { Result } from '../models/Result.js';
-import { ReviewView   , ReviewViewDirectionEnum      , ReviewViewReviewStatusEnum     } from '../models/ReviewView.js';
+import { ReviewView   , ReviewViewDirectionEnum          } from '../models/ReviewView.js';
 import { RotateSecretResponse } from '../models/RotateSecretResponse.js';
 import { SendEmailRequest } from '../models/SendEmailRequest.js';
-import { SendResultView   , SendResultViewMethodEnum   , SendResultViewSentAsEnum  , SendResultViewStatusEnum   } from '../models/SendResultView.js';
+import { SendResultView } from '../models/SendResultView.js';
 import { SendingDNSRecordView } from '../models/SendingDNSRecordView.js';
 import { Suppression } from '../models/Suppression.js';
 import { SuppressionExportEntry } from '../models/SuppressionExportEntry.js';
@@ -160,9 +160,9 @@ import { UsageEventEntry } from '../models/UsageEventEntry.js';
 import { UserExport } from '../models/UserExport.js';
 import { UserExportUser } from '../models/UserExportUser.js';
 import { VerifyDomainView } from '../models/VerifyDomainView.js';
-import { WebhookDeliveryView  , WebhookDeliveryViewEventTypeEnum       , WebhookDeliveryViewStatusEnum   } from '../models/WebhookDeliveryView.js';
+import { WebhookDeliveryView } from '../models/WebhookDeliveryView.js';
 import { WebhookFiltersView } from '../models/WebhookFiltersView.js';
-import { WebhookView    , WebhookViewEventsEnum       } from '../models/WebhookView.js';
+import { WebhookView } from '../models/WebhookView.js';
 
 /* tslint:disable:no-unused-variable */
 let primitives = [
@@ -182,34 +182,15 @@ let enumsMap: Set<string> = new Set<string>([
     "CreateAPIKeyRequestScopeEnum",
     "CreateAPIKeyResponseScopeEnum",
     "CreateWebhookRequestEventsEnum",
-    "CreateWebhookResponseEventsEnum",
-    "DomainViewSendingStatusEnum",
-    "EventJSONStatusEnum",
-    "EventJSONTypeEnum",
-    "MessageSummaryViewDeliveryStatusEnum",
     "MessageSummaryViewDirectionEnum",
-    "MessageSummaryViewReviewStatusEnum",
-    "MessageSummaryViewSentAsEnum",
-    "MessageViewDeliveryStatusEnum",
     "MessageViewDirectionEnum",
-    "MessageViewReviewStatusEnum",
-    "MessageViewSentAsEnum",
     "ProtectionGateViewActionEnum",
     "ProtectionGateViewPolicyEnum",
     "ProtectionHoldsViewOnExpiryEnum",
     "ProtectionScanViewSensitivityEnum",
-    "RedeliverDeliveryStatusEnum",
-    "RedeliverViewStatusEnum",
     "ReviewViewDirectionEnum",
-    "ReviewViewReviewStatusEnum",
-    "SendResultViewMethodEnum",
-    "SendResultViewSentAsEnum",
-    "SendResultViewStatusEnum",
     "TestWebhookRequestEventEnum",
     "UpdateWebhookRequestEventsEnum",
-    "WebhookDeliveryViewEventTypeEnum",
-    "WebhookDeliveryViewStatusEnum",
-    "WebhookViewEventsEnum",
 ]);
 
 let typeMap: {[index: string]: any} = {

--- a/sdks/typescript/src/v1/generated/models/RedeliverDelivery.ts
+++ b/sdks/typescript/src/v1/generated/models/RedeliverDelivery.ts
@@ -15,7 +15,10 @@ import { HttpFile } from '../http/http.js';
 export class RedeliverDelivery {
     'deliveryId'?: string;
     'reason'?: string;
-    'status': RedeliverDeliveryStatusEnum;
+    /**
+    * Open set; tolerate unknown values. Known values: pending (replay scheduled), skipped (could not enqueue — see reason).
+    */
+    'status': string;
     'webhookId': string;
 
     static readonly discriminator: string | undefined = undefined;
@@ -38,7 +41,7 @@ export class RedeliverDelivery {
         {
             "name": "status",
             "baseName": "status",
-            "type": "RedeliverDeliveryStatusEnum",
+            "type": "string",
             "format": ""
         },
         {
@@ -55,9 +58,3 @@ export class RedeliverDelivery {
     public constructor() {
     }
 }
-
-export enum RedeliverDeliveryStatusEnum {
-    Pending = 'pending',
-    Skipped = 'skipped'
-}
-

--- a/sdks/typescript/src/v1/generated/models/RedeliverView.ts
+++ b/sdks/typescript/src/v1/generated/models/RedeliverView.ts
@@ -17,7 +17,10 @@ export class RedeliverView {
     'deliveries'?: Array<RedeliverDelivery>;
     'deliveryId'?: string;
     'eventId': string;
-    'status': RedeliverViewStatusEnum;
+    /**
+    * Open set; tolerate unknown values. Known values: pending (single-webhook replay), scheduled (bulk fan-out).
+    */
+    'status': string;
     'webhookId'?: string;
 
     static readonly discriminator: string | undefined = undefined;
@@ -46,7 +49,7 @@ export class RedeliverView {
         {
             "name": "status",
             "baseName": "status",
-            "type": "RedeliverViewStatusEnum",
+            "type": "string",
             "format": ""
         },
         {
@@ -63,9 +66,3 @@ export class RedeliverView {
     public constructor() {
     }
 }
-
-export enum RedeliverViewStatusEnum {
-    Pending = 'pending',
-    Scheduled = 'scheduled'
-}
-

--- a/sdks/typescript/src/v1/generated/models/ReviewView.ts
+++ b/sdks/typescript/src/v1/generated/models/ReviewView.ts
@@ -24,7 +24,10 @@ export class ReviewView {
     'flagged'?: boolean;
     '_from': string;
     'id': string;
-    'reviewStatus': ReviewViewReviewStatusEnum;
+    /**
+    * Hold state of this queue item. Open set; tolerate unknown values. Currently always pending_review (the queue lists held items).
+    */
+    'reviewStatus': string;
     'subject': string;
     'to': Array<string>;
 
@@ -84,7 +87,7 @@ export class ReviewView {
         {
             "name": "reviewStatus",
             "baseName": "review_status",
-            "type": "ReviewViewReviewStatusEnum",
+            "type": "string",
             "format": ""
         },
         {
@@ -111,8 +114,5 @@ export class ReviewView {
 export enum ReviewViewDirectionEnum {
     Inbound = 'inbound',
     Outbound = 'outbound'
-}
-export enum ReviewViewReviewStatusEnum {
-    PendingReview = 'pending_review'
 }
 

--- a/sdks/typescript/src/v1/generated/models/SendResultView.ts
+++ b/sdks/typescript/src/v1/generated/models/SendResultView.ts
@@ -16,10 +16,19 @@ export class SendResultView {
     'approvalExpiresAt'?: Date;
     'edited'?: boolean;
     'messageId': string;
-    'method'?: SendResultViewMethodEnum;
+    /**
+    * Send transport. Open set; tolerate unknown values. Known values: smtp, loopback.
+    */
+    'method'?: string;
     'providerMessageId'?: string;
-    'sentAs'?: SendResultViewSentAsEnum;
-    'status': SendResultViewStatusEnum;
+    /**
+    * From identity used. Open set; tolerate unknown values. Known values: own_address, relay.
+    */
+    'sentAs'?: string;
+    /**
+    * Outcome. Open set; tolerate unknown values. Known values: sent, pending_review, review_approved.
+    */
+    'status': string;
 
     static readonly discriminator: string | undefined = undefined;
 
@@ -47,7 +56,7 @@ export class SendResultView {
         {
             "name": "method",
             "baseName": "method",
-            "type": "SendResultViewMethodEnum",
+            "type": "string",
             "format": ""
         },
         {
@@ -59,13 +68,13 @@ export class SendResultView {
         {
             "name": "sentAs",
             "baseName": "sent_as",
-            "type": "SendResultViewSentAsEnum",
+            "type": "string",
             "format": ""
         },
         {
             "name": "status",
             "baseName": "status",
-            "type": "SendResultViewStatusEnum",
+            "type": "string",
             "format": ""
         }    ];
 
@@ -76,18 +85,3 @@ export class SendResultView {
     public constructor() {
     }
 }
-
-export enum SendResultViewMethodEnum {
-    Smtp = 'smtp',
-    Loopback = 'loopback'
-}
-export enum SendResultViewSentAsEnum {
-    OwnAddress = 'own_address',
-    Relay = 'relay'
-}
-export enum SendResultViewStatusEnum {
-    Sent = 'sent',
-    PendingReview = 'pending_review',
-    ReviewApproved = 'review_approved'
-}
-

--- a/sdks/typescript/src/v1/generated/models/WebhookDeliveryView.ts
+++ b/sdks/typescript/src/v1/generated/models/WebhookDeliveryView.ts
@@ -15,13 +15,19 @@ import { HttpFile } from '../http/http.js';
 export class WebhookDeliveryView {
     'attempts': number;
     'createdAt': Date;
-    'eventType': WebhookDeliveryViewEventTypeEnum;
+    /**
+    * The event type that triggered this delivery. Open set: new event types may be added, so treat as a string and tolerate unknown values. Known values are the webhook event catalog (email.received, email.sent, email.delivered, …, domain.*).
+    */
+    'eventType': string;
     'id': string;
     'lastAttemptAt'?: Date;
     'lastError'?: string;
     'lastStatusCode'?: number;
     'nextRetryAt': Date;
-    'status': WebhookDeliveryViewStatusEnum;
+    /**
+    * Delivery state. Open set; tolerate unknown values. Known values: pending, delivered, failed.
+    */
+    'status': string;
 
     static readonly discriminator: string | undefined = undefined;
 
@@ -43,7 +49,7 @@ export class WebhookDeliveryView {
         {
             "name": "eventType",
             "baseName": "event_type",
-            "type": "WebhookDeliveryViewEventTypeEnum",
+            "type": "string",
             "format": ""
         },
         {
@@ -79,7 +85,7 @@ export class WebhookDeliveryView {
         {
             "name": "status",
             "baseName": "status",
-            "type": "WebhookDeliveryViewStatusEnum",
+            "type": "string",
             "format": ""
         }    ];
 
@@ -90,25 +96,3 @@ export class WebhookDeliveryView {
     public constructor() {
     }
 }
-
-export enum WebhookDeliveryViewEventTypeEnum {
-    EmailReceived = 'email.received',
-    EmailSent = 'email.sent',
-    EmailReviewApproved = 'email.review_approved',
-    EmailReviewRejected = 'email.review_rejected',
-    DomainSendingVerified = 'domain.sending_verified',
-    DomainSendingFailed = 'domain.sending_failed',
-    EmailDelivered = 'email.delivered',
-    EmailBounced = 'email.bounced',
-    EmailComplained = 'email.complained',
-    DomainSuppressionAdded = 'domain.suppression_added',
-    EmailFlagged = 'email.flagged',
-    EmailBlocked = 'email.blocked',
-    EmailPendingReview = 'email.pending_review'
-}
-export enum WebhookDeliveryViewStatusEnum {
-    Pending = 'pending',
-    Delivered = 'delivered',
-    Failed = 'failed'
-}
-

--- a/sdks/typescript/src/v1/generated/models/WebhookView.ts
+++ b/sdks/typescript/src/v1/generated/models/WebhookView.ts
@@ -19,9 +19,9 @@ export class WebhookView {
     'description': string;
     'enabled': boolean;
     /**
-    * Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable. All other events are stable.
+    * The event types this webhook matches. Open set: new event types may be added over time, so treat these as strings and tolerate unknown values. Known values: email.received, email.sent, email.delivered, email.bounced, email.complained, email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected, domain.sending_verified, domain.sending_failed, domain.suppression_added. Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable.
     */
-    'events': Array<WebhookViewEventsEnum>;
+    'events': Array<string>;
     'filters': WebhookFiltersView;
     'id': string;
     'lastDeliveredAt'?: Date;
@@ -59,7 +59,7 @@ export class WebhookView {
         {
             "name": "events",
             "baseName": "events",
-            "type": "Array<WebhookViewEventsEnum>",
+            "type": "Array<string>",
             "format": ""
         },
         {
@@ -94,20 +94,3 @@ export class WebhookView {
     public constructor() {
     }
 }
-
-export enum WebhookViewEventsEnum {
-    EmailReceived = 'email.received',
-    EmailSent = 'email.sent',
-    EmailReviewApproved = 'email.review_approved',
-    EmailReviewRejected = 'email.review_rejected',
-    DomainSendingVerified = 'domain.sending_verified',
-    DomainSendingFailed = 'domain.sending_failed',
-    EmailDelivered = 'email.delivered',
-    EmailBounced = 'email.bounced',
-    EmailComplained = 'email.complained',
-    DomainSuppressionAdded = 'domain.suppression_added',
-    EmailFlagged = 'email.flagged',
-    EmailBlocked = 'email.blocked',
-    EmailPendingReview = 'email.pending_review'
-}
-


### PR DESCRIPTION
Fixes the blockers from the pre-GA launch review before freezing the v1 contract. Paired with the hosted-side `Mnexa-AI/e2a-ops#139` (lands the `api.e2a.dev` ingress the SDKs already default to).

Three commits, by concern:

## 1. `fix(security)` — XFF rate-limit bypass + outbound SMTP TLS
- **XFF bypass (HIGH):** per-IP limiters keyed on the leftmost `X-Forwarded-For`, which is client-controllable behind Cloudflare — an attacker could rotate it for unlimited per-IP budget. Both `clientIP` helpers now trust only `CF-Connecting-IP` (matching the existing oauth `dcrSourceIP`), never XFF. Regression test added. *Requires the origin be firewalled to Cloudflare ranges — see e2a-ops.*
- **SMTP cleartext downgrade:** opportunistic STARTTLS could be stripped to force PLAIN auth + body over cleartext. Adds `OutboundSMTP.RequireTLS` (defaults on in prod) and never sends PLAIN auth unencrypted regardless.

## 2. `feat(api)!` — open response-side enums (the freeze-risk fix)
Closed enums in **responses** are a v2-forcer: a strict/spec-generated client crashes on any value not in the frozen list, so adding an event type or delivery state later would be breaking. This opens every growable response enum to a plain string (known values documented), while **keeping request/query enums closed** (rejecting unknown input is correct) and binary `direction` closed.

Regenerated `api/openapi.yaml` + both SDK bases (closed enum types collapse to `string`; `strip-enum-validators` ran on 13 Python models). Drift + spec-review tests updated to enforce the new contract (request-side stays synced & closed; the 17 opened response fields must stay open). The `!` marks that generated SDK enum *types* are removed — the hand-written ergonomic layer never exposed them, so no hand-written API changes.

## 3. `docs(ga)` — stability policy, version story, packaging
- `docs/api.md`: new **Versioning & stability** section (no breaking changes within `/v1`; response enums are open; deprecation = kept for life of `/v1`); stronger path-encoding note (`+`→`%2B`).
- `docs/events.md`: all 13 event types (was 7). `SECURITY.md`: 1.x GA (was pre-1.0). `README`: billing is live.
- SDKs: document SDK-major-independent-of-API-version; Python `Beta`→`Production/Stable`; add `py.typed` to the hand-written packages (+ wheel packaging); TS + CLI changelogs.

## Verification
- Go `httpapi` / `agent` / `contract` suites green (contract run isolated — full-suite parallel run hits shared-test-DB contention, unrelated).
- TS SDK: build + 101 tests. Python SDK: 158 tests. Spec + generated-code freshness gates pass.
- Request-side validation enums verified intact.

## Deferred (not in this PR)
- `/v1/agents/{id}` opaque-id alias — won't-do for v1 (email is immutable; an `{id}` route is always additive later).
- Billing `account_limits` two-write divergence — needs its own PR + test surface (interacts with the webhook dedup flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)