### PR TITLE
fix(web): render inbound email body from parsed text, not raw MIME

### DIFF
--- a/web/src/app/(app)/inboxes/(view)/messages/view/page.test.tsx
+++ b/web/src/app/(app)/inboxes/(view)/messages/view/page.test.tsx
@@ -207,6 +207,31 @@ describe("AgentMessageFocusPage", () => {
     expect(screen.getByText(/Attached is the renewal contract/)).toBeInTheDocument();
   });
 
+  it("prefers the backend-parsed text over the raw MIME body for inbound", async () => {
+    // Regression: inbound rows carry the clean body in `parsed.text` (text/plain
+    // or HTML→text, quoted-printable decoded). The bug rendered the raw MIME
+    // body instead — showing literal <div>/<br> markup and `=` QP soft-breaks.
+    setSearchParams({ email: "support@acme.io", id: "msg_in2", direction: "inbound" });
+    mockDetail({
+      ...INBOUND_DETAIL,
+      message_id: "msg_in2",
+      parsed: { text: "Decoded body via parsed.text" },
+      raw_message: btoa(
+        "Content-Type: text/html\r\n" +
+          "Content-Transfer-Encoding: quoted-printable\r\n\r\n" +
+          "<div>Raw MIME body should not show<br>=</div>",
+      ),
+    });
+
+    render(<AgentMessageFocusPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("message-focus")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Decoded body via parsed\.text/)).toBeInTheDocument();
+    expect(screen.queryByText(/Raw MIME body should not show/)).not.toBeInTheDocument();
+  });
+
   // Regression: GET /agents/{email}/messages/{id} flips inbox_status
   // unread → read as a server-side side effect. The focus page must
   // invalidate the per-agent inbox SWR cache when that happens, or

--- a/web/src/app/(app)/inboxes/(view)/messages/view/page.tsx
+++ b/web/src/app/(app)/inboxes/(view)/messages/view/page.tsx
@@ -572,7 +572,9 @@ function BodyCard({
 }) {
   const bodyText = useMemo(() => {
     if (msg.direction === "outbound") return msg.data.body_text ?? "";
-    return decodeInboundBody(msg.data.raw_message);
+    // Prefer the backend-parsed text (QP/base64 decoded, HTML→text); the raw
+    // decode is a last-resort fallback that shows MIME framing.
+    return msg.data.parsed?.text || decodeInboundBody(msg.data.raw_message);
   }, [msg]);
 
   const isOutbound = msg.direction === "outbound";

--- a/web/src/app/components/messages/ThreadBubble.tsx
+++ b/web/src/app/components/messages/ThreadBubble.tsx
@@ -13,7 +13,6 @@ import { Chip } from "../loft/Chip";
 import { Dot } from "../loft/Dot";
 import { CounterpartyAvatar } from "./CounterpartyAvatar";
 import { getMessageDetail } from "../onboarding/api";
-import { formatRelativeAge } from "../../../lib/relativeTime";
 import type { MessageSummary } from "../types";
 import type { Counterparty } from "./threading";
 
@@ -81,7 +80,13 @@ export function ThreadBubble({
     if (detail.direction === "outbound") {
       body = detail.data.body_text ?? "";
     } else {
-      body = detail.data.body?.text || decodeRawBody(detail.data.raw_message) || "";
+      // Prefer the backend-parsed text (text/plain, else HTML→text, QP/base64
+      // decoded). Fall back to the raw decode only if it's somehow absent.
+      body =
+        detail.data.parsed?.text ||
+        detail.data.body?.text ||
+        decodeRawBody(detail.data.raw_message) ||
+        "";
     }
   }
   const showBody = body.trim() !== "";

--- a/web/src/app/components/onboarding/api.ts
+++ b/web/src/app/components/onboarding/api.ts
@@ -320,6 +320,7 @@ export async function getMessageDetail(
       status: w.delivery_status ?? "",
       created_at: w.created_at,
       auth_headers: w.auth_headers ?? {},
+      parsed: w.parsed,
       body: w.body,
       raw_message: w.raw_message ?? "",
     },

--- a/web/src/app/components/types.ts
+++ b/web/src/app/components/types.ts
@@ -141,10 +141,14 @@ export type InboundMessageDetail = {
   status: string;
   created_at: string;
   auth_headers: Record<string, string>;
-  // Parsed body, when the backend could extract a text/plain part.
+  // Backend-parsed body (preferred): the text/plain part, else the HTML
+  // rendered to text, with quoted-printable/base64 decoded and quoted reply
+  // chains stripped. Render this rather than the raw bytes.
+  parsed?: { text?: string };
+  // Held-draft body shape (outbound). Inbound rows carry `parsed` instead.
   body?: { text?: string; html?: string };
-  // Raw RFC-5322 bytes, base64-encoded by the JSON layer. The focus page
-  // decodes this as a fallback when `body.text` is absent.
+  // Raw RFC-5322 bytes, base64-encoded by the JSON layer. Decoded only as a
+  // last-resort fallback when neither `parsed.text` nor `body.text` is present.
   raw_message: string;
 };
 


### PR DESCRIPTION
## Problem
Inbound emails rendered as raw MIME in the conversation view — literal `<div>`/`<br>` markup and quoted-printable `=` soft-breaks instead of readable text.

## Root cause (frontend-only)
The backend already returns a clean parsed body in **`parsed.text`** (`mailparse.ParsedBody`: prefers `text/plain`, else renders HTML→text, decodes quoted-printable/base64, strips quoted reply chains). But:
- `getMessageDetail`'s inbound mapping dropped `w.parsed` and `InboundMessageDetail` had no `parsed` field, and
- `ThreadBubble` / the focus view read `body?.text` (only populated for outbound held drafts) → always fell through to a client-side `decodeRawBody(raw_message)` that emits the raw MIME body.

## Fix
- Thread `parsed` through `getMessageDetail` + add it to `InboundMessageDetail`.
- `ThreadBubble` and the message focus view prefer `parsed.text`; the raw decode stays only as a last-resort fallback.
- Regression test (`view/page.test.tsx`): `parsed.text` is rendered and the raw HTML/QP body is not.
- Removed a dead `formatRelativeAge` import in `ThreadBubble`.

## Verification
`tsc` clean; `npm test` 238/238 (incl. new regression); `npm run lint` 0 errors; `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)