### PR TITLE
feat(oauth): add api_url config — serve the OAuth issuer on the API host

### DIFF
--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -277,6 +277,11 @@ func main() {
 	// HTTP API
 	router := mux.NewRouter()
 	api := agent.NewAPI(store, sender, smtpRelay, userAuth, usageTracker, cfg.SMTP.Domain, cfg.OutboundSMTP.FromDomain, cfg.SharedDomain, cfg.HTTP.PublicURL, cfg.IsProduction())
+	// The programmatic API host (OAuth issuer + token/jwks). Defaults to
+	// public_url; set api_url to serve the API/MCP on a different host than
+	// the web app (the authorization_endpoint + login/consent stay on
+	// public_url because they need the web app's session cookie).
+	api.SetAPIURL(cfg.HTTP.APIURL)
 	// HITL magic-link token signer reuses the shared HMAC secret so operators
 	// don't have to configure a second key.
 	approvalSigner := approvaltoken.NewSigner(cfg.Signing.HMACSecret)
@@ -319,7 +324,10 @@ func main() {
 		log.Printf("[oauth] provider disabled: http.public_url is not set (required for issuer identity)")
 	} else {
 		oauthStorage = oauth.NewStorage(pool)
-		oauthProvider, err := oauth.NewProvider(oauthStorage, cfg.HTTP.PublicURL, []byte(cfg.Signing.HMACSecret))
+		// Issuer = api_url (defaults to public_url). fosite stamps it into
+		// token `iss` and the RFC 9207 response, so it must match what
+		// discovery advertises and what agentAuthIssuer signs/verifies.
+		oauthProvider, err := oauth.NewProvider(oauthStorage, cfg.HTTP.APIURL, []byte(cfg.Signing.HMACSecret))
 		if err != nil {
 			log.Fatalf("[oauth] provider wiring failed: %v", err)
 		}
@@ -327,7 +335,7 @@ func main() {
 		// Consent handler also needs the storage pool for the cross-
 		// package transaction (agent insert + auth-code insert atomic).
 		api.SetOAuthStorage(oauthStorage)
-		log.Printf("[oauth] provider enabled: issuer=%s", cfg.HTTP.PublicURL)
+		log.Printf("[oauth] provider enabled: issuer=%s", cfg.HTTP.APIURL)
 	}
 
 	// Idempotency-Key support on POST /v1/agents/{email}/messages (send) and .../reply.

--- a/internal/agent/agent_identity.go
+++ b/internal/agent/agent_identity.go
@@ -30,9 +30,12 @@ import (
 // falling through to fosite's authorization_code/refresh_token handling.
 const jwtBearerGrantType = "urn:ietf:params:oauth:grant-type:jwt-bearer"
 
-// agentAuthIssuer is the iss/aud bound into every minted token — the AS public
-// URL, trailing slash trimmed so it's byte-stable with the discovery doc.
-func (a *API) agentAuthIssuer() string { return strings.TrimRight(a.publicURL, "/") }
+// agentAuthIssuer is the iss/aud bound into every minted token — the API base
+// URL (apiURL, which defaults to publicURL), trailing slash trimmed so it's
+// byte-stable with the discovery doc's issuer. It signs AND verifies, so a
+// deployment that changes api_url re-keys its token audience: tokens minted
+// under the old issuer stop validating and clients must re-auth.
+func (a *API) agentAuthIssuer() string { return strings.TrimRight(a.apiURL, "/") }
 
 // agentAuthReady reports whether the agent-identity surface is usable: a signing
 // key AND a public URL (needed for iss/aud) must both be configured.

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -172,6 +172,13 @@ type API struct {
 	// links without each user configuring it. Empty when the operator
 	// hasn't set http.public_url.
 	publicURL         string
+	// apiURL is the externally visible base URL of the programmatic API —
+	// the OAuth issuer identity and the base for the token/registration/
+	// revocation/jwks endpoints. Defaults to publicURL; SetAPIURL overrides
+	// it when the deployment serves the API on a different host than the web
+	// app (e.g. api.e2a.dev vs e2a.dev). The OAuth authorization_endpoint
+	// and login/consent pages stay on publicURL (the browser-facing web app).
+	apiURL            string
 	production        bool
 	sendLimit         *ratelimit.Limiter
 	regLimit          *ratelimit.Limiter
@@ -522,6 +529,9 @@ func NewAPI(store *identity.Store, sender *outbound.Sender, smtpRelay *outbound.
 		fromDomain:    fromDomain,
 		sharedDomain:  sharedDomain,
 		publicURL:     publicURL,
+		// Default the API/issuer URL to the web URL; SetAPIURL overrides it
+		// for split web/API-host deployments.
+		apiURL:        publicURL,
 		production:    production,
 		sendLimit:     ratelimit.New(1*time.Minute, 60), // 60 sends per agent per minute
 		regLimit:      ratelimit.New(1*time.Hour, 200),  // 200 registrations per IP per hour
@@ -529,6 +539,18 @@ func NewAPI(store *identity.Store, sender *outbound.Sender, smtpRelay *outbound.
 		feedbackLimit: ratelimit.New(1*time.Hour, 10),   // 10 feedback submissions per IP per hour
 		dcrLimit:      ratelimit.New(1*time.Hour, 10),   // 10 OAuth client registrations per IP per hour
 		downloadLimit: ratelimit.New(1*time.Minute, 120), // 120 attachment downloads per IP per minute
+	}
+}
+
+// SetAPIURL overrides the API/issuer base URL (default: publicURL). Set it
+// when the programmatic API + MCP are served on a different host than the web
+// app — that host becomes the OAuth issuer and the base for the token/
+// registration/revocation/jwks endpoints, while authorization_endpoint and
+// the login/consent pages stay on publicURL. A no-op for the empty string so
+// callers can pass an unset config value safely.
+func (a *API) SetAPIURL(u string) {
+	if u != "" {
+		a.apiURL = u
 	}
 }
 

--- a/internal/agent/oauth_discovery_test.go
+++ b/internal/agent/oauth_discovery_test.go
@@ -90,6 +90,68 @@ func TestHTTP_Discovery_Happy(t *testing.T) {
 	}
 }
 
+// TestHTTP_Discovery_SplitAPIURL pins the api_url split: when the API/MCP host
+// differs from the web app host, the issuer + token/register/revoke/jwks live
+// on api_url, while authorization_endpoint stays on public_url (the browser
+// login/consent UI + session cookie live there). This is the agentdrive shape
+// — issuer with the API, login page on the web domain.
+func TestHTTP_Discovery_SplitAPIURL(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	smtpRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{})
+	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
+
+	const webURL = "https://e2a.dev"
+	const apiURL = "https://api.e2a.dev"
+	api := agent.NewAPI(store, sender, smtpRelay, nil, usage.NewNoopUsageTracker(),
+		"e2a.dev", "test.e2a.dev", "agents.e2a.dev", webURL, false)
+	api.SetAPIURL(apiURL)
+
+	storage := oauth.NewStorage(pool)
+	provider, err := oauth.NewProvider(storage, apiURL, []byte("test-secret-test-secret-test-sec"))
+	if err != nil {
+		t.Fatalf("NewProvider: %v", err)
+	}
+	api.SetOAuthProvider(provider)
+	api.SetOAuthStorage(storage)
+
+	router := mux.NewRouter()
+	api.RegisterRoutes(router)
+	srv := httptest.NewServer(router)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/.well-known/oauth-authorization-server")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var meta agent.OAuthMetadata
+	if err := json.NewDecoder(resp.Body).Decode(&meta); err != nil {
+		t.Fatal(err)
+	}
+
+	// issuer + programmatic endpoints live on the API host (api_url).
+	if meta.Issuer != apiURL {
+		t.Errorf("issuer = %q, want %q (api_url)", meta.Issuer, apiURL)
+	}
+	for name, got := range map[string]string{
+		"token_endpoint":        meta.TokenEndpoint,
+		"registration_endpoint": meta.RegistrationEndpoint,
+		"revocation_endpoint":   meta.RevocationEndpoint,
+		"jwks_uri":              meta.JWKSURI,
+	} {
+		if !strings.HasPrefix(got, apiURL+"/") {
+			t.Errorf("%s = %q, want it on api_url %q", name, got, apiURL)
+		}
+	}
+	// the browser-facing authorize endpoint stays on the web app host — it
+	// needs the e2a.dev session cookie + login/consent UI, which don't travel
+	// cross-origin to api.e2a.dev.
+	if meta.AuthorizationEndpoint != webURL+"/oauth2/authorize" {
+		t.Errorf("authorization_endpoint = %q, want it on public_url %q", meta.AuthorizationEndpoint, webURL)
+	}
+}
+
 // TestHTTP_Discovery_TrailingSlashStripped: a publicURL configured
 // with a trailing slash must NOT produce double-slashed endpoint
 // URLs. RFC 8414 §2 requires issuer be byte-for-byte stable.

--- a/internal/agent/oauth_handlers.go
+++ b/internal/agent/oauth_handlers.go
@@ -553,13 +553,19 @@ func (a *API) handleOAuthDiscovery(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
-	base := strings.TrimRight(a.publicURL, "/")
+	// apiBase is the issuer + programmatic endpoints (token/register/revoke/
+	// jwks/identity) — they live with the API host (apiURL). webBase is the
+	// browser-facing authorization_endpoint — it stays on the web app
+	// (publicURL) where the login/consent UI lives. When api_url is unset
+	// the two are identical (single-host), preserving historical behaviour.
+	apiBase := strings.TrimRight(a.apiURL, "/")
+	webBase := strings.TrimRight(a.publicURL, "/")
 	meta := OAuthMetadata{
-		Issuer:                 base,
-		AuthorizationEndpoint:  base + "/oauth2/authorize",
-		TokenEndpoint:          base + "/oauth2/token",
-		RegistrationEndpoint:   base + "/oauth2/register",
-		RevocationEndpoint:     base + "/oauth2/revoke",
+		Issuer:                 apiBase,
+		AuthorizationEndpoint:  webBase + "/oauth2/authorize",
+		TokenEndpoint:          apiBase + "/oauth2/token",
+		RegistrationEndpoint:   apiBase + "/oauth2/register",
+		RevocationEndpoint:     apiBase + "/oauth2/revoke",
 		ResponseTypesSupported: []string{"code"},
 		// response_mode=query is the only mode we emit at the redirect
 		// URI; explicit so strict MCP clients don't try "fragment".
@@ -572,7 +578,7 @@ func (a *API) handleOAuthDiscovery(w http.ResponseWriter, r *http.Request) {
 		// inbox, the DCR-public default) and account (admin). The lone legacy
 		// "mcp" scope is retired.
 		ScopesSupported: []string{"agent", "account"},
-		JWKSURI:         base + "/.well-known/jwks.json",
+		JWKSURI:         apiBase + "/.well-known/jwks.json",
 		AuthorizationResponseIssParameterSupported: true,
 	}
 	// auth.md agent-identity surface (Slice 5b-2) — advertised only when a
@@ -580,7 +586,7 @@ func (a *API) handleOAuthDiscovery(w http.ResponseWriter, r *http.Request) {
 	if a.agentAuthReady() {
 		meta.GrantTypesSupported = append(meta.GrantTypesSupported, jwtBearerGrantType)
 		meta.AgentAuth = &agentAuthMetadata{
-			IdentityEndpoint:       base + "/agent/identity",
+			IdentityEndpoint:       apiBase + "/agent/identity",
 			IdentityTypesSupported: []string{"identity_assertion"},
 			// AssertionTypesSupported left empty until 5b-4 intakes ID-JAG.
 		}
@@ -939,8 +945,8 @@ func (a *API) writeAuthorizeRedirect(w http.ResponseWriter, r *http.Request, ar 
 		}
 	}
 	// RFC 9207 §2 — tell mix-up-aware clients which AS produced this
-	// response. publicURL is what discovery advertises as `issuer`.
-	q.Set("iss", strings.TrimRight(a.publicURL, "/"))
+	// response. Must byte-match the `issuer` discovery advertises (apiURL).
+	q.Set("iss", strings.TrimRight(a.apiURL, "/"))
 	redirect.RawQuery = q.Encode()
 	http.Redirect(w, r, redirect.String(), http.StatusSeeOther)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -66,11 +66,21 @@ type SMTPConfig struct {
 
 type HTTPConfig struct {
 	ListenAddr string `yaml:"listen_addr"`
-	// PublicURL is the externally visible base URL of the API, used to
-	// build absolute links in notification emails (e.g. HITL magic-link
-	// approve/reject). Example: "https://e2a.example.com". If empty,
-	// features that need absolute URLs gracefully degrade.
+	// PublicURL is the externally visible base URL of the *web app* — the
+	// domain that serves the dashboard, HITL magic-link pages, and the
+	// OAuth login/consent UI. Absolute links in notification emails and the
+	// OAuth authorization_endpoint are built from it. Example:
+	// "https://e2a.example.com". If empty, features that need absolute URLs
+	// gracefully degrade.
 	PublicURL string `yaml:"public_url"`
+	// APIURL is the externally visible base URL of the *programmatic API* —
+	// the host the SDKs/MCP target (e.g. "https://api.e2a.dev"). It is the
+	// OAuth issuer identity and the base for the token/registration/
+	// revocation/jwks endpoints, so it should match the host the MCP
+	// resource is served from (RFC 9728: clients expect the issuer to live
+	// with the API). Defaults to PublicURL when unset, so single-host
+	// deployments and self-hosters need not set it.
+	APIURL string `yaml:"api_url"`
 }
 
 type DatabaseConfig struct {
@@ -254,6 +264,9 @@ func Load(path string) (*Config, error) {
 	if v := os.Getenv("E2A_PUBLIC_URL"); v != "" {
 		cfg.HTTP.PublicURL = v
 	}
+	if v := os.Getenv("E2A_API_URL"); v != "" {
+		cfg.HTTP.APIURL = v
+	}
 	if v := os.Getenv("E2A_SHARED_DOMAIN"); v != "" {
 		cfg.SharedDomain = v
 	}
@@ -274,6 +287,14 @@ func Load(path string) (*Config, error) {
 	if cfg.OutboundSMTP.RequireTLS == nil {
 		v := cfg.IsProduction()
 		cfg.OutboundSMTP.RequireTLS = &v
+	}
+
+	// Default the API URL (OAuth issuer + token/jwks host) to the web
+	// PublicURL when unset, so single-host deployments and self-hosters get
+	// the historical behaviour (issuer == public_url) with no new config.
+	// Split deployments (web on one host, API/MCP on another) set api_url.
+	if cfg.HTTP.APIURL == "" {
+		cfg.HTTP.APIURL = cfg.HTTP.PublicURL
 	}
 
 	if err := cfg.Validate(); err != nil {


### PR DESCRIPTION
## Why
The MCP OAuth **issuer** is pinned to `public_url` (the web app domain, `e2a.dev`), but the MCP **resource** is served from `api.e2a.dev`. That split — issuer on a *different* host than the resource — is the off-the-happy-path RFC 9728 variant and trips MCP clients (it's why the browser sign-in fails). Working references confirm the convention is the opposite:

- **agentdrive**: issuer `api.agentdrive.run` (= MCP host), `authorization_endpoint` on the apex `agentdrive.run`
- **Anthropic**: issuer + endpoints on `api.anthropic.com`

The seam to split is **the login page → web domain; the issuer stays with the API.**

## What
Add an **`api_url`** config (`HTTP.APIURL`, env `E2A_API_URL`) — the externally visible base URL of the programmatic API. It becomes:
- the OAuth **issuer** + `token`/`registration`/`revocation`/`jwks`/`agent-identity` endpoints in discovery
- the fosite provider issuer + `agentAuthIssuer()` (token `iss`/`aud`)
- the RFC 9207 `iss` in the authorization response

The **`authorization_endpoint`** and login/consent redirects **stay on `public_url`** — that step is browser-facing and reads the web app's `e2a_session` cookie, which doesn't travel cross-origin to the API host (same reason the dashboard must call `e2a.dev/v1`). This is exactly agentdrive's shape.

## Backward compatible by default
`api_url` **defaults to `public_url`** when unset → single-host deployments and self-hosters are unaffected (issuer == public_url, historical behaviour). The new `TestHTTP_Discovery_SplitAPIURL` pins the split; the existing happy-path test confirms the default.

## ⚠️ Token re-keying
`agentAuthIssuer()` signs **and** verifies tokens, so changing `api_url` re-keys the token audience — tokens minted under the old issuer stop validating and clients re-auth. **Moot for e2a prod**: OAuth was non-functional there (the `/oauth2/*` endpoints 404'd), so there are no live tokens to break.

## Deploy (companion e2a-ops PR, separate)
- `config.prod.yaml`: `http.api_url: https://api.e2a.dev`
- compose: `MCP_AUTHORIZATION_SERVER_URL: https://api.e2a.dev`
- Caddy `api.e2a.dev`: route AS-metadata + `/oauth2/{token,register,revoke}` + `jwks.json` → backend; `e2a.dev` keeps `/oauth2/authorize` + login/consent

## Tests
`go build ./...` clean; `internal/config`, `internal/oauth`, and the OAuth discovery suite pass (incl. the new split test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)