### PR TITLE
feat(oauth): scope-picker on the consent screen (agent | account, loopback-gated)

### DIFF
--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -732,8 +732,9 @@ func (a *API) authenticatePrincipal(r *http.Request) (*identity.Principal, error
 // ScopeAccount, which defeated the public-DCR `scope=agent` cap
 // (oauth_handlers.go) and silently handed agent-tier MCP tokens full
 // account-wide admin.) Resolution:
-//   - granted `account` → account-wide admin. Only reachable via a
-//     console-issued / confidential client; public DCR can never obtain it.
+//   - granted `account` → account-wide admin. Reachable only when the user
+//     explicitly picks account on the consent screen for an all-loopback
+//     client (the scope-picker); never autonomously by a client.
 //   - granted `agent`   → confined to the consent-bound agent
 //     (session.AgentEmail), with ownership re-checked, mirroring the REST
 //     resolveOwnedAgent pin and the JWT resolveAgentAccessToken path.

--- a/internal/agent/oauth_bearer_test.go
+++ b/internal/agent/oauth_bearer_test.go
@@ -423,14 +423,18 @@ func seedOAuthClient(t *testing.T, f *consentFixture, clientID string, scopes []
 }
 
 // mintAccessWithScope runs the authorize→consent→token flow for an explicit
-// client + scope (vs. mintTokensForFixture, which is hardwired to the fixture's
-// agent-scoped client). Returns the issued access token.
+// client + consent-grantable scope (agent|account). The consent screen is the
+// scope authority, so it drives the grant via scope_choice (not the requested
+// `scope` param). Returns the issued access token. To mint a token carrying a
+// scope the consent screen does NOT offer (a retired/unknown scope), use
+// mintAuthCode + a token exchange, which bypasses the consent gate.
 func mintAccessWithScope(t *testing.T, f *consentFixture, clientID, scope string) string {
 	t.Helper()
 	verifier, challenge := newPKCE(t)
 
 	form := authorizeParams(challenge, clientID, "s2s2s2s2s2s2s2s2")
 	form.Set("scope", scope) // override the fixture's default "agent"
+	form.Set("scope_choice", scope)
 	form.Set("action", "allow")
 	form.Set("agent_choice", "create_new")
 	form.Set("new_agent_slug", "scoped-"+randHex8(t))
@@ -491,7 +495,34 @@ func TestBearer_OAuth_AccountScope_AllowedOnAccountOp(t *testing.T) {
 func TestBearer_OAuth_UnknownScope_Rejected(t *testing.T) {
 	f := newConsentFixture(t)
 	seedOAuthClient(t, f, "legacy_mcp_client", []string{"mcp"})
-	access := mintAccessWithScope(t, f, "legacy_mcp_client", "mcp")
+	// The consent screen no longer grants anything but agent/account, so mint
+	// the unrecognized-scope token the only way one could still exist: directly
+	// via the provider (mintAuthCode grants "mcp"), bypassing the consent gate.
+	// This isolates the principal resolver's fail-closed default — a legacy or
+	// out-of-band token carrying a retired scope must still be rejected.
+	redirectURI := "http://localhost:8765/callback"
+	verifier, challenge := newPKCE(t)
+	code := mintAuthCode(t, f.provider, "legacy_mcp_client", f.userID, redirectURI, challenge)
+	tokForm := url.Values{}
+	tokForm.Set("grant_type", "authorization_code")
+	tokForm.Set("code", code)
+	tokForm.Set("client_id", "legacy_mcp_client")
+	tokForm.Set("redirect_uri", redirectURI)
+	tokForm.Set("code_verifier", verifier)
+	tokResp, err := http.Post(f.server.URL+"/oauth2/token", "application/x-www-form-urlencoded", strings.NewReader(tokForm.Encode()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tokResp.Body.Close()
+	if tokResp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(tokResp.Body)
+		t.Fatalf("mint mcp token: /token status=%d body=%s", tokResp.StatusCode, b)
+	}
+	var tb struct {
+		AccessToken string `json:"access_token"`
+	}
+	json.NewDecoder(tokResp.Body).Decode(&tb)
+	access := tb.AccessToken
 
 	status, wa := callAPIWithBearer(t, f.server.URL, access) // GET /v1/account
 	if status != http.StatusUnauthorized {

--- a/internal/agent/oauth_consent_test.go
+++ b/internal/agent/oauth_consent_test.go
@@ -130,7 +130,7 @@ func newConsentFixture(t *testing.T) *consentFixture {
 		        ARRAY['http://localhost:8765/callback'],
 		        ARRAY['authorization_code','refresh_token'],
 		        ARRAY['code'],
-		        ARRAY['agent'],
+		        ARRAY['agent','account'],
 		        ARRAY[]::TEXT[],
 		        'none', TRUE, 'dcr')
 		ON CONFLICT (client_id) DO NOTHING

--- a/internal/agent/oauth_handlers.go
+++ b/internal/agent/oauth_handlers.go
@@ -181,6 +181,12 @@ func dcrSourceIP(r *http.Request) string {
 // (127.0.0.0/8, ::1). Used both by validateRedirectURI (which loopback http
 // hosts are allowed) and by the account-scope gate (account may only be
 // granted to a native app that receives its callback on loopback).
+//
+// Deliberately NARROWER than fosite's IsLocalhost: it does NOT accept the
+// ".localhost" suffix (e.g. app.localhost). The cost is only that account
+// scope is unavailable to a tool using such a redirect (fail-closed, a
+// conservative UX edge); it is never a security gap. Keep it strict — a
+// suffix rule is where loopback look-alike bypasses tend to creep in.
 func isLoopbackHost(host string) bool {
 	if host == "localhost" {
 		return true
@@ -967,11 +973,16 @@ func (a *API) issueOAuthCode(ctx context.Context, w http.ResponseWriter, r *http
 // consented to on the consent screen — not the scope the client requested.
 // The consent screen is e2a's scope authority (it already picks the agent),
 // so a user who chooses "account" on a loopback client gets account even
-// though the public DCR client could only request "agent". fosite drops scope
-// between authorize and the issued tokens unless explicitly granted; we also
-// add it to the requested set so granted ⊆ requested holds for any fosite
-// handler that checks it (the client-scope ExactScopeStrategy already ran at
-// /authorize and is not re-run here).
+// though the public DCR client only requested "agent".
+//
+// AppendRequestedScope is LOAD-BEARING, not cosmetic: fosite's
+// AuthorizeExplicitGrantHandler re-validates every *requested* scope against
+// client.GetScopes() (ExactScopeStrategy) inside NewAuthorizeResponse — which
+// runs AFTER this. So appending the consented scope to the requested set is
+// what subjects it to that check, and that check is precisely what enforces
+// granted ⊆ client.scopes: account is granted only if the client row carries
+// it (which DCR writes only for all-loopback clients). Remove the append and
+// account-scope containment silently breaks — keep it.
 func grantConsentedScope(ar fosite.AuthorizeRequester, scope string) {
 	if !ar.GetRequestedScopes().Has(scope) {
 		ar.AppendRequestedScope(scope)

--- a/internal/agent/oauth_handlers.go
+++ b/internal/agent/oauth_handlers.go
@@ -369,15 +369,36 @@ func (a *API) handleOAuthRegister(w http.ResponseWriter, r *http.Request) {
 			`only token_endpoint_auth_method="none" (public clients with PKCE) is supported`)
 		return
 	}
-	// Scope cap (Slice 5b / design §5): dynamically-registered clients are
-	// public (token_endpoint_auth_method=none), so they may request ONLY
-	// scope="agent" (runtime/inbox tier). scope="account" (admin) requires a
-	// pre-registered confidential client or console issuance — never via public
-	// DCR, so a leaked DCR client can't escalate to account-wide admin.
-	if req.Scope != "agent" {
+	// Scope ceiling (Slice 5b / design §5 + scope-picker). A public DCR
+	// client's REGISTERED scopes are the maximum a user can later approve on
+	// the consent screen — not what the client gets autonomously (consent is
+	// mandatory and grants nothing on its own). "account" (workspace admin) is
+	// offered only to clients whose redirect_uris are ALL loopback: a native
+	// app whose callback lands on the user's own machine. A hosted/remote
+	// client (https redirect) can't receive a localhost callback, so it stays
+	// agent-only and can never be socially-engineered into an account grant.
+	// fosite's ExactScopeStrategy enforces granted ⊆ registered, so account
+	// must be on the client row for the consent screen to grant it.
+	accountEligible := true
+	for _, ru := range req.RedirectURIs {
+		if !isLoopbackRedirect(ru) {
+			accountEligible = false
+			break
+		}
+	}
+	for _, sc := range strings.Fields(req.Scope) {
+		if sc == identity.ScopeAgent || (sc == identity.ScopeAccount && accountEligible) {
+			continue
+		}
 		writeOAuthError(w, http.StatusBadRequest, "invalid_client_metadata",
-			`dynamically-registered public clients may request only scope="agent"; scope="account" requires console issuance`)
+			`unsupported scope `+strconv.Quote(sc)+`; public clients may request "agent" (and "account" only when all redirect_uris are loopback)`)
 		return
+	}
+	// Persist the full eligible ceiling, not just what was requested, so the
+	// consent screen can offer account on loopback clients without a re-register.
+	scopeCeiling := []string{identity.ScopeAgent}
+	if accountEligible {
+		scopeCeiling = append(scopeCeiling, identity.ScopeAccount)
 	}
 
 	// Generate the client_id and persist. The DB CHECK constraints
@@ -394,7 +415,7 @@ func (a *API) handleOAuthRegister(w http.ResponseWriter, r *http.Request) {
 		     public, created_via)
 		VALUES ($1, $2, $3, $4, $5, $6, ARRAY[]::TEXT[], $7, TRUE, 'dcr')
 	`, clientID, req.ClientName, req.RedirectURIs, req.GrantTypes,
-		req.ResponseTypes, []string{req.Scope}, req.TokenEndpointAuthMethod); err != nil {
+		req.ResponseTypes, scopeCeiling, req.TokenEndpointAuthMethod); err != nil {
 		log.Printf("[oauth] DCR insert failed: %v", err)
 		writeOAuthError(w, http.StatusInternalServerError, "server_error", "failed to register client")
 		return
@@ -426,6 +447,12 @@ type OAuthClientPublicMetadata struct {
 	RedirectURIs     []string `json:"redirect_uris"`
 	Scopes           []string `json:"scopes"`
 	ClientIDIssuedAt int64    `json:"client_id_issued_at"`
+	// AccountEligible reports whether the consent screen may offer account
+	// (workspace-admin) scope for this client: true iff EVERY registered
+	// redirect_uri is loopback. Drives the consent UI (the Account option is
+	// disabled otherwise); the consent handler re-checks the specific inbound
+	// redirect at grant time, so this is UX, not the security boundary.
+	AccountEligible bool `json:"account_eligible"`
 }
 
 // handleOAuthGetClient is the public read endpoint the consent UI
@@ -487,12 +514,20 @@ func (a *API) handleOAuthGetClient(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "public, max-age=60")
+	accountEligible := len(redirects) > 0
+	for _, ru := range redirects {
+		if !isLoopbackRedirect(ru) {
+			accountEligible = false
+			break
+		}
+	}
 	_ = json.NewEncoder(w).Encode(OAuthClientPublicMetadata{
 		ClientID:         clientID,
 		ClientName:       name,
 		RedirectURIs:     redirects,
 		Scopes:           scopes,
 		ClientIDIssuedAt: createdAt.Unix(),
+		AccountEligible:  accountEligible,
 	})
 }
 
@@ -821,8 +856,42 @@ func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Resolve which agent the OAuth grant pins to. Either an existing
-	// inbox the user already owns, or a freshly auto-created one on
+	// Scope the user consented to. The consent screen is e2a's scope
+	// authority: "agent" (default) binds the grant to one inbox; "account"
+	// is full workspace admin. account is gated to LOOPBACK redirect_uris —
+	// a local tool whose callback lands on the user's own machine — so a
+	// hosted/remote client (which can't receive a localhost callback) can't
+	// be socially-engineered into an account grant. The gate is enforced
+	// here, server-side and fail-closed, independent of the page's UI.
+	scopeChoice := r.PostFormValue("scope_choice")
+	if scopeChoice == "" {
+		scopeChoice = identity.ScopeAgent
+	}
+	switch scopeChoice {
+	case identity.ScopeAccount:
+		if !isLoopbackRedirect(ar.GetRedirectURI().String()) {
+			a.oauthProvider.WriteAuthorizeError(ctx, w, ar,
+				fosite.ErrInvalidScope.WithHint(
+					"account scope may only be granted to a client with a loopback (http://localhost) redirect_uri"))
+			return
+		}
+		// account is not inbox-bound: empty AgentEmail, account scope. The
+		// principal resolver maps (account, no agent) to an account principal,
+		// exactly like an e2a_acct_ key; any agent_choice is ignored.
+		if err := a.issueOAuthCode(ctx, w, r, ar, user.ID, "", identity.ScopeAccount); err != nil {
+			log.Printf("[oauth] /consent issue (account) failed: %v", err)
+			a.oauthProvider.WriteAuthorizeError(ctx, w, ar, err)
+		}
+		return
+	case identity.ScopeAgent:
+		// fall through to the inbox-binding logic below
+	default:
+		http.Error(w, `scope_choice must be "agent" or "account"`, http.StatusBadRequest)
+		return
+	}
+
+	// Resolve which agent the (agent-scoped) OAuth grant pins to. Either an
+	// existing inbox the user already owns, or a freshly auto-created one on
 	// the shared domain.
 	agentChoice := r.PostFormValue("agent_choice")
 	switch {
@@ -839,7 +908,7 @@ func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
 		}
 		// No agent creation needed — drop straight into the code-
 		// issue path with the resolved email on the session.
-		if err := a.issueOAuthCode(ctx, w, r, ar, user.ID, email); err != nil {
+		if err := a.issueOAuthCode(ctx, w, r, ar, user.ID, email, identity.ScopeAgent); err != nil {
 			log.Printf("[oauth] /consent issue (existing agent) failed: %v", err)
 			a.oauthProvider.WriteAuthorizeError(ctx, w, ar, err)
 		}
@@ -858,7 +927,7 @@ func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		agentEmail := slug + "@" + a.sharedDomain
-		if err := a.issueOAuthCodeWithNewAgent(ctx, w, r, ar, user.ID, agentEmail); err != nil {
+		if err := a.issueOAuthCodeWithNewAgent(ctx, w, r, ar, user.ID, agentEmail, identity.ScopeAgent); err != nil {
 			log.Printf("[oauth] /consent issue (new agent) failed: %v", err)
 			a.oauthProvider.WriteAuthorizeError(ctx, w, ar, err)
 		}
@@ -872,18 +941,14 @@ func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
 // our Storage on the pool (no cross-package tx needed). After fosite's
 // NewAuthorizeResponse we write the redirect ourselves so we can
 // append the RFC 9207 iss parameter — fosite v0.49.0 doesn't emit it.
-func (a *API) issueOAuthCode(ctx context.Context, w http.ResponseWriter, r *http.Request, ar fosite.AuthorizeRequester, userID, agentEmail string) error {
+func (a *API) issueOAuthCode(ctx context.Context, w http.ResponseWriter, r *http.Request, ar fosite.AuthorizeRequester, userID, agentEmail, scope string) error {
 	sess := &oauth.Session{
 		UserID:     userID,
 		AgentEmail: agentEmail,
 		Subject:    userID,
 	}
 	ar.SetSession(sess)
-	// fosite drops the requested scope between authorize and the
-	// issued tokens unless we explicitly grant it.
-	for _, sc := range ar.GetRequestedScopes() {
-		ar.GrantScope(sc)
-	}
+	grantConsentedScope(ar, scope)
 
 	resp, err := a.oauthProvider.NewAuthorizeResponse(ctx, ar, sess)
 	if err != nil {
@@ -898,7 +963,23 @@ func (a *API) issueOAuthCode(ctx context.Context, w http.ResponseWriter, r *http
 // shared Storage pool; both writes join it via the oauth.WithTx
 // context helper. A partial failure rolls back so we never leak an
 // agent without the matching code (or vice versa).
-func (a *API) issueOAuthCodeWithNewAgent(ctx context.Context, w http.ResponseWriter, r *http.Request, ar fosite.AuthorizeRequester, userID, agentEmail string) error {
+// grantConsentedScope sets the access grant to EXACTLY the scope the user
+// consented to on the consent screen — not the scope the client requested.
+// The consent screen is e2a's scope authority (it already picks the agent),
+// so a user who chooses "account" on a loopback client gets account even
+// though the public DCR client could only request "agent". fosite drops scope
+// between authorize and the issued tokens unless explicitly granted; we also
+// add it to the requested set so granted ⊆ requested holds for any fosite
+// handler that checks it (the client-scope ExactScopeStrategy already ran at
+// /authorize and is not re-run here).
+func grantConsentedScope(ar fosite.AuthorizeRequester, scope string) {
+	if !ar.GetRequestedScopes().Has(scope) {
+		ar.AppendRequestedScope(scope)
+	}
+	ar.GrantScope(scope)
+}
+
+func (a *API) issueOAuthCodeWithNewAgent(ctx context.Context, w http.ResponseWriter, r *http.Request, ar fosite.AuthorizeRequester, userID, agentEmail, scope string) error {
 	pool := a.oauthStorage.Pool()
 	tx, err := pool.BeginTx(ctx, pgx.TxOptions{})
 	if err != nil {
@@ -926,9 +1007,7 @@ func (a *API) issueOAuthCodeWithNewAgent(ctx context.Context, w http.ResponseWri
 		Subject:    userID,
 	}
 	ar.SetSession(sess)
-	for _, sc := range ar.GetRequestedScopes() {
-		ar.GrantScope(sc)
-	}
+	grantConsentedScope(ar, scope)
 	resp, err := a.oauthProvider.NewAuthorizeResponse(txCtx, ar, sess)
 	if err != nil {
 		return err

--- a/internal/agent/oauth_handlers.go
+++ b/internal/agent/oauth_handlers.go
@@ -176,6 +176,34 @@ func dcrSourceIP(r *http.Request) string {
 //   - single-label custom schemes (myapp:) — RFC 7595 §3.8 reserves
 //     these for future IANA registration, and they bypass the OS-level
 //     scheme registry collision protections RFC 8252 §7.1 relies on
+// isLoopbackHost reports whether a redirect_uri hostname is a loopback
+// target: the literal "localhost" or any IP that net considers loopback
+// (127.0.0.0/8, ::1). Used both by validateRedirectURI (which loopback http
+// hosts are allowed) and by the account-scope gate (account may only be
+// granted to a native app that receives its callback on loopback).
+func isLoopbackHost(host string) bool {
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+// isLoopbackRedirect reports whether a full redirect_uri is an http loopback
+// URL (http://localhost[:port]/…, http://127.0.0.1[:port]/…, http://[::1]…).
+// https URLs return false even though they're valid redirect targets — the
+// point of this gate is "the callback lands on the user's own machine", which
+// only http-loopback guarantees. This is the structural control that lets the
+// consent screen offer account scope to local tools (Claude Code, Cursor) while
+// a hosted/remote client — which can't receive a localhost callback — can't.
+func isLoopbackRedirect(raw string) bool {
+	u, err := url.Parse(raw)
+	if err != nil || u.Scheme != "http" {
+		return false
+	}
+	return isLoopbackHost(u.Hostname())
+}
+
 func validateRedirectURI(raw string) error {
 	if raw == "" {
 		return errors.New("redirect_uri cannot be empty")
@@ -199,12 +227,7 @@ func validateRedirectURI(raw string) error {
 		}
 		return nil
 	case "http":
-		host := u.Hostname()
-		if host == "localhost" {
-			return nil
-		}
-		ip := net.ParseIP(host)
-		if ip != nil && ip.IsLoopback() {
+		if isLoopbackHost(u.Hostname()) {
 			return nil
 		}
 		return errors.New("http redirect_uri must use a loopback host (localhost, 127.0.0.1, or ::1)")

--- a/internal/agent/oauth_loopback_test.go
+++ b/internal/agent/oauth_loopback_test.go
@@ -1,0 +1,41 @@
+package agent
+
+import "testing"
+
+func TestIsLoopbackRedirect(t *testing.T) {
+	cases := []struct {
+		uri  string
+		want bool
+	}{
+		// loopback http → true (the account-scope gate passes)
+		{"http://localhost/callback", true},
+		{"http://localhost:64793/callback", true},
+		{"http://127.0.0.1/callback", true},
+		{"http://127.0.0.1:8080/cb", true},
+		{"http://[::1]/callback", true},
+		{"http://[::1]:5173/cb", true},
+		{"http://127.0.0.2/cb", true}, // all of 127.0.0.0/8 is loopback
+
+		// https → false even if host is localhost (no guarantee the
+		// callback lands on the user's machine)
+		{"https://localhost/callback", false},
+		{"https://app.example.com/callback", false},
+
+		// non-loopback http → false
+		{"http://example.com/callback", false},
+		{"http://0.0.0.0/callback", false},
+		{"http://10.0.0.5/callback", false},
+		{"http://169.254.169.254/callback", false}, // link-local metadata, not loopback
+
+		// junk → false (fail closed)
+		{"", false},
+		{"::::not a uri", false},
+		{"javascript:alert(1)", false},
+		{"file:///etc/passwd", false},
+	}
+	for _, c := range cases {
+		if got := isLoopbackRedirect(c.uri); got != c.want {
+			t.Errorf("isLoopbackRedirect(%q) = %v, want %v", c.uri, got, c.want)
+		}
+	}
+}

--- a/internal/agent/oauth_scope_picker_test.go
+++ b/internal/agent/oauth_scope_picker_test.go
@@ -1,0 +1,214 @@
+package agent_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// exchangeCode swaps an authorization code for a token pair via /oauth2/token.
+func (f *consentFixture) exchangeCode(t *testing.T, code, verifier, redirectURI string) (accessToken, refreshToken, scope string) {
+	t.Helper()
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("client_id", f.clientID)
+	form.Set("redirect_uri", redirectURI)
+	form.Set("code_verifier", verifier)
+	resp, err := http.Post(f.server.URL+"/oauth2/token", "application/x-www-form-urlencoded", strings.NewReader(form.Encode()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("token exchange status = %d, want 200", resp.StatusCode)
+	}
+	var body struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		Scope        string `json:"scope"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	return body.AccessToken, body.RefreshToken, body.Scope
+}
+
+// whoami calls GET /v1/account with the bearer and returns (scope, agentAddress).
+func (f *consentFixture) whoami(t *testing.T, bearer string) (scope, agentAddress string) {
+	t.Helper()
+	req, _ := http.NewRequest("GET", f.server.URL+"/v1/account", nil)
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("/v1/account status = %d, want 200 (bearer should resolve)", resp.StatusCode)
+	}
+	var body struct {
+		Scope        string `json:"scope"`
+		AgentAddress string `json:"agent_address"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	return body.Scope, body.AgentAddress
+}
+
+// TestHTTP_Consent_Account_Loopback grants account scope when the user picks it
+// on a loopback client, and the resulting token resolves to an account
+// principal (no bound agent) — exactly like an e2a_acct_ key.
+func TestHTTP_Consent_Account_Loopback(t *testing.T) {
+	f := newConsentFixture(t)
+	verifier, challenge := newPKCE(t)
+	redirectURI := "http://localhost:8765/callback"
+
+	form := authorizeParams(challenge, f.clientID, "s1s1s1s1s1s1s1s1")
+	form.Set("action", "allow")
+	form.Set("scope_choice", "account")
+	// No agent_choice — account isn't inbox-bound.
+
+	resp := f.consentPOST(t, form)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusSeeOther {
+		t.Fatalf("status = %d, want 303 (account on loopback is allowed)", resp.StatusCode)
+	}
+	loc, _ := url.Parse(resp.Header.Get("Location"))
+	code := loc.Query().Get("code")
+	if code == "" {
+		t.Fatalf("expected code in redirect, got error=%q", loc.Query().Get("error"))
+	}
+
+	access, _, scope := f.exchangeCode(t, code, verifier, redirectURI)
+	if !strings.Contains(scope, "account") {
+		t.Errorf("token scope = %q, want it to contain account", scope)
+	}
+	gotScope, agentAddr := f.whoami(t, access)
+	if gotScope != "account" {
+		t.Errorf("whoami scope = %q, want account", gotScope)
+	}
+	if agentAddr != "" {
+		t.Errorf("account principal must have no bound agent; got agent_address=%q", agentAddr)
+	}
+}
+
+// TestHTTP_Consent_Account_NonLoopback_Rejected — the loopback gate fails closed
+// for a client whose redirect is https (a hosted/remote client that couldn't
+// receive a localhost callback). No code is issued.
+func TestHTTP_Consent_Account_NonLoopback_Rejected(t *testing.T) {
+	f := newConsentFixture(t)
+	ctx := context.Background()
+	// Seed a public client registered with an https (non-loopback) redirect.
+	httpsClient := "mcp_hosted_test"
+	httpsRedirect := "https://app.example.com/callback"
+	if _, err := f.pool.Exec(ctx, `
+		INSERT INTO oauth_clients
+		    (client_id, client_name, redirect_uris, grant_types, response_types,
+		     scopes, audiences, token_endpoint_auth_method, public, created_via)
+		VALUES ($1, 'hosted test client', ARRAY[$2],
+		        ARRAY['authorization_code','refresh_token'], ARRAY['code'],
+		        ARRAY['agent'], ARRAY[]::TEXT[], 'none', TRUE, 'dcr')
+		ON CONFLICT (client_id) DO NOTHING`, httpsClient, httpsRedirect); err != nil {
+		t.Fatalf("seed https client: %v", err)
+	}
+
+	_, challenge := newPKCE(t)
+	form := authorizeParams(challenge, httpsClient, "s1s1s1s1s1s1s1s1")
+	form.Set("redirect_uri", httpsRedirect)
+	form.Set("action", "allow")
+	form.Set("scope_choice", "account")
+
+	resp := f.consentPOST(t, form)
+	defer resp.Body.Close()
+	// fosite redirects errors to the (validated) redirect_uri with error params.
+	loc, _ := url.Parse(resp.Header.Get("Location"))
+	if loc.Query().Get("code") != "" {
+		t.Fatalf("account must be rejected on a non-loopback redirect, but a code was issued")
+	}
+	if e := loc.Query().Get("error"); e != "invalid_scope" {
+		t.Errorf("error = %q, want invalid_scope", e)
+	}
+}
+
+// TestHTTP_Consent_DefaultScope_IsAgent — a consent POST that omits scope_choice
+// defaults to agent (the safe default) and binds to the chosen inbox.
+func TestHTTP_Consent_DefaultScope_IsAgent(t *testing.T) {
+	f := newConsentFixture(t)
+	verifier, challenge := newPKCE(t)
+	redirectURI := "http://localhost:8765/callback"
+
+	form := authorizeParams(challenge, f.clientID, "s1s1s1s1s1s1s1s1")
+	form.Set("action", "allow")
+	form.Set("agent_choice", "create_new")
+	form.Set("new_agent_slug", "defaultscopebot")
+	// scope_choice intentionally omitted.
+
+	resp := f.consentPOST(t, form)
+	defer resp.Body.Close()
+	loc, _ := url.Parse(resp.Header.Get("Location"))
+	code := loc.Query().Get("code")
+	if code == "" {
+		t.Fatalf("expected code, got error=%q", loc.Query().Get("error"))
+	}
+	access, _, scope := f.exchangeCode(t, code, verifier, redirectURI)
+	if scope != "agent" {
+		t.Errorf("default token scope = %q, want agent", scope)
+	}
+	gotScope, agentAddr := f.whoami(t, access)
+	if gotScope != "agent" {
+		t.Errorf("whoami scope = %q, want agent", gotScope)
+	}
+	if agentAddr == "" {
+		t.Error("agent principal must carry a bound agent_address")
+	}
+}
+
+// TestHTTP_Consent_Account_RefreshKeepsScope — refreshing an account token keeps
+// account scope; it must never silently change tier.
+func TestHTTP_Consent_Account_RefreshKeepsScope(t *testing.T) {
+	f := newConsentFixture(t)
+	verifier, challenge := newPKCE(t)
+	redirectURI := "http://localhost:8765/callback"
+
+	form := authorizeParams(challenge, f.clientID, "s1s1s1s1s1s1s1s1")
+	form.Set("action", "allow")
+	form.Set("scope_choice", "account")
+	resp := f.consentPOST(t, form)
+	defer resp.Body.Close()
+	loc, _ := url.Parse(resp.Header.Get("Location"))
+	code := loc.Query().Get("code")
+	if code == "" {
+		t.Fatalf("expected code, got error=%q", loc.Query().Get("error"))
+	}
+	_, refresh, _ := f.exchangeCode(t, code, verifier, redirectURI)
+
+	// Refresh exchange.
+	rf := url.Values{}
+	rf.Set("grant_type", "refresh_token")
+	rf.Set("refresh_token", refresh)
+	rf.Set("client_id", f.clientID)
+	r2, err := http.Post(f.server.URL+"/oauth2/token", "application/x-www-form-urlencoded", strings.NewReader(rf.Encode()))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r2.Body.Close()
+	if r2.StatusCode != http.StatusOK {
+		t.Fatalf("refresh status = %d, want 200", r2.StatusCode)
+	}
+	var body struct {
+		AccessToken string `json:"access_token"`
+		Scope       string `json:"scope"`
+	}
+	json.NewDecoder(r2.Body).Decode(&body)
+	if !strings.Contains(body.Scope, "account") {
+		t.Errorf("refreshed token scope = %q, want account preserved", body.Scope)
+	}
+	if s, _ := f.whoami(t, body.AccessToken); s != "account" {
+		t.Errorf("refreshed token whoami scope = %q, want account", s)
+	}
+}

--- a/internal/agent/oauth_scope_picker_test.go
+++ b/internal/agent/oauth_scope_picker_test.go
@@ -135,6 +135,47 @@ func TestHTTP_Consent_Account_NonLoopback_Rejected(t *testing.T) {
 	}
 }
 
+// TestHTTP_Consent_Account_MixedRedirect_RejectedByScopeCeiling proves the
+// second defense layer: a client with BOTH a loopback and an https redirect is
+// NOT account-eligible (DCR writes only [agent]), so even when the inbound
+// redirect is the loopback one — passing the consent handler's own loopback
+// gate — fosite's ExactScopeStrategy rejects the account grant because account
+// is not on the client row. This is the enforcement path the DCR-ceiling
+// deviation rests on; the handler gate alone is insufficient here.
+func TestHTTP_Consent_Account_MixedRedirect_RejectedByScopeCeiling(t *testing.T) {
+	f := newConsentFixture(t)
+	ctx := context.Background()
+	mixedClient := "mcp_mixed_test"
+	loopbackRedirect := "http://localhost:8765/callback"
+	if _, err := f.pool.Exec(ctx, `
+		INSERT INTO oauth_clients
+		    (client_id, client_name, redirect_uris, grant_types, response_types,
+		     scopes, audiences, token_endpoint_auth_method, public, created_via)
+		VALUES ($1, 'mixed redirect client', ARRAY[$2,$3],
+		        ARRAY['authorization_code','refresh_token'], ARRAY['code'],
+		        ARRAY['agent'], ARRAY[]::TEXT[], 'none', TRUE, 'dcr')
+		ON CONFLICT (client_id) DO NOTHING`,
+		mixedClient, loopbackRedirect, "https://app.example.com/callback"); err != nil {
+		t.Fatalf("seed mixed client: %v", err)
+	}
+
+	_, challenge := newPKCE(t)
+	form := authorizeParams(challenge, mixedClient, "s1s1s1s1s1s1s1s1")
+	form.Set("redirect_uri", loopbackRedirect) // inbound redirect IS loopback → passes the handler gate
+	form.Set("action", "allow")
+	form.Set("scope_choice", "account")
+
+	resp := f.consentPOST(t, form)
+	defer resp.Body.Close()
+	loc, _ := url.Parse(resp.Header.Get("Location"))
+	if loc.Query().Get("code") != "" {
+		t.Fatalf("mixed-redirect client must not get account even on the loopback redirect")
+	}
+	if e := loc.Query().Get("error"); e != "invalid_scope" {
+		t.Errorf("error = %q, want invalid_scope (fosite scope-ceiling rejection)", e)
+	}
+}
+
 // TestHTTP_Consent_DefaultScope_IsAgent — a consent POST that omits scope_choice
 // defaults to agent (the safe default) and binds to the chosen inbox.
 func TestHTTP_Consent_DefaultScope_IsAgent(t *testing.T) {

--- a/mcp/src/http-server.ts
+++ b/mcp/src/http-server.ts
@@ -136,10 +136,11 @@ export function buildApp(opts: HttpServerOptions): BuiltApp {
       resource,
       authorization_servers: [opts.authorizationServerUrl ?? opts.baseUrl],
       // Scope vocabulary tracks the AS (Slice 5b): the lone "mcp" scope is
-      // retired. MCP clients connect as public DCR clients, which are capped at
-      // scope="agent" by the authorization server, so advertise that here so the
-      // protected-resource and AS metadata agree.
-      scopes_supported: ["agent"],
+      // retired. MCP clients connect as public DCR clients; the consent screen
+      // grants "agent" (single inbox) by default and "account" (workspace admin)
+      // when the user explicitly opts in on a loopback client — so both are
+      // advertised here so the protected-resource and AS metadata agree.
+      scopes_supported: ["agent", "account"],
       bearer_methods_supported: ["header"],
     });
   });

--- a/mcp/tests/http.test.ts
+++ b/mcp/tests/http.test.ts
@@ -667,7 +667,7 @@ describe("HTTP MCP server", () => {
     expect(disc.status).toBe(200);
     const meta = await disc.json();
     expect(meta.resource).toBe("http://localhost:8765");
-    expect(meta.scopes_supported).toEqual(["agent"]);
+    expect(meta.scopes_supported).toEqual(["agent", "account"]);
 
     // 401 on /mcp without bearer: WWW-Authenticate's resource_metadata
     // URL must use publicUrl, not "https://127.0.0.1:port".

--- a/web/src/app/oauth/consent/page.test.tsx
+++ b/web/src/app/oauth/consent/page.test.tsx
@@ -67,14 +67,19 @@ function mockClientAndAgents(opts: {
   clientStatus?: number;
   clientBody?: object;
   agents?: object[];
+  accountEligible?: boolean;
 }) {
   const clientStatus = opts.clientStatus ?? 200;
+  const accountEligible = opts.accountEligible ?? true;
   const clientBody = opts.clientBody ?? {
     client_id: "mcp_abc123",
     client_name: "Test MCP Client",
-    redirect_uris: ["http://localhost:8765/cb"],
-    scopes: ["agent"],
+    redirect_uris: accountEligible
+      ? ["http://localhost:8765/cb"]
+      : ["https://app.example.com/cb"],
+    scopes: accountEligible ? ["agent", "account"] : ["agent"],
     client_id_issued_at: 1700000000,
+    account_eligible: accountEligible,
   };
   const agents = opts.agents ?? [];
   mockFetch.mockImplementation((url: string) => {
@@ -311,5 +316,61 @@ describe("ConsentPage", () => {
     const resource = form.querySelector('input[name="resource"]') as HTMLInputElement;
     expect(resource).toBeTruthy();
     expect(resource.value).toBe("https://api.e2a.dev");
+  });
+
+  test("scope picker offers Agent (default) + Account; Account selectable on a loopback (account_eligible) client", async () => {
+    __setSearchParams(VALID_QS);
+    mockClientAndAgents({ agents: [], accountEligible: true });
+    render(<ConsentPage />);
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /Authorize Test MCP Client/i })).toBeInTheDocument();
+    });
+    const agentRadio = screen.getByRole("radio", { name: /act as one inbox/i }) as HTMLInputElement;
+    const accountRadio = screen.getByRole("radio", { name: /full workspace admin/i }) as HTMLInputElement;
+    expect(agentRadio.checked).toBe(true); // least-privilege default
+    expect(agentRadio.name).toBe("scope_choice");
+    expect(accountRadio.disabled).toBe(false);
+    expect(accountRadio.value).toBe("account");
+    expect(accountRadio.name).toBe("scope_choice");
+  });
+
+  test("Account scope is disabled (with a loopback reason) when account_eligible is false", async () => {
+    __setSearchParams(VALID_QS);
+    mockClientAndAgents({
+      agents: [],
+      // matching loopback redirect to avoid the mismatch banner; the server
+      // still reports the client ineligible (the field is what the UI honors).
+      clientBody: {
+        client_id: "mcp_abc123",
+        client_name: "Test MCP Client",
+        redirect_uris: ["http://localhost:8765/cb"],
+        scopes: ["agent"],
+        client_id_issued_at: 1700000000,
+        account_eligible: false,
+      },
+    });
+    render(<ConsentPage />);
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /Authorize Test MCP Client/i })).toBeInTheDocument();
+    });
+    const accountRadio = screen.getByRole("radio", { name: /full workspace admin/i }) as HTMLInputElement;
+    expect(accountRadio.disabled).toBe(true);
+    expect(screen.getByText(/only offered to local tools/i)).toBeInTheDocument();
+  });
+
+  test("selecting Account hides the inbox picker (scope_choice=account is what submits)", async () => {
+    __setSearchParams(VALID_QS);
+    mockClientAndAgents({ agents: [], accountEligible: true });
+    render(<ConsentPage />);
+    await waitFor(() => {
+      expect(screen.getByRole("heading", { name: /Authorize Test MCP Client/i })).toBeInTheDocument();
+    });
+    // Agent default → inbox picker present.
+    expect(screen.getByText(/Choose an inbox/i)).toBeInTheDocument();
+    const accountRadio = screen.getByRole("radio", { name: /full workspace admin/i }) as HTMLInputElement;
+    await userEvent.click(accountRadio);
+    expect(accountRadio.checked).toBe(true);
+    // Account → inbox picker gone (account isn't inbox-bound).
+    expect(screen.queryByText(/Choose an inbox/i)).not.toBeInTheDocument();
   });
 });

--- a/web/src/app/oauth/consent/page.tsx
+++ b/web/src/app/oauth/consent/page.tsx
@@ -25,6 +25,11 @@ type ClientMeta = {
   redirect_uris: string[];
   scopes: string[];
   client_id_issued_at: number;
+  // True iff every registered redirect_uri is loopback — i.e. the consent
+  // screen may offer account (workspace-admin) scope. The backend re-checks
+  // at grant time, so this only drives whether the Account option is
+  // selectable in the UI.
+  account_eligible: boolean;
 };
 
 // Slug rules mirror validateSlug in internal/agent/api.go (length
@@ -251,6 +256,12 @@ function ConsentForm({
   const defaultSlug = useMemo(() => deriveDefaultSlug(client.client_name), [client.client_name]);
   const [slug, setSlug] = useState<string>(defaultSlug);
 
+  // Scope the user is granting. Default to the least-privilege "agent". The
+  // backend re-validates the loopback gate on "account", so this is UX.
+  const [scopeChoice, setScopeChoice] = useState<"agent" | "account">("agent");
+  const accountEligible = client.account_eligible;
+  const pickingAccount = scopeChoice === "account";
+
   const creating = agentChoice === "create_new";
   const slugValid = !creating || SLUG_PATTERN.test(slug);
   // Verify the inbound redirect_uri matches one of the values the
@@ -265,7 +276,8 @@ function ConsentForm({
     inboundRedirect !== "" &&
     client.redirect_uris.length > 0 &&
     !client.redirect_uris.includes(inboundRedirect);
-  const submitDisabled = !slugValid || redirectMismatch;
+  // Account scope binds to no inbox, so the slug is irrelevant then.
+  const submitDisabled = redirectMismatch || (!pickingAccount && !slugValid);
 
   // The hidden inputs re-emit every OAuth param we received. We use
   // params (the readback of useSearchParams) rather than re-deriving
@@ -306,6 +318,82 @@ function ConsentForm({
           <input key={k} type="hidden" name={k} value={v} />
         ))}
 
+        <fieldset className="border border-border rounded-md p-4">
+          <legend className="text-sm font-medium px-2">Access level</legend>
+
+          <label className="flex items-start gap-2 py-1 cursor-pointer">
+            <input
+              type="radio"
+              name="scope_choice"
+              value="agent"
+              checked={!pickingAccount}
+              onChange={() => setScopeChoice("agent")}
+              className="mt-1"
+            />
+            <span className="text-sm">
+              <span className="font-medium">Agent — act as one inbox</span>
+              <span className="block text-xs text-muted">
+                Send &amp; receive email as the inbox you pick below. Cannot
+                manage other inboxes, domains, webhooks, or API keys.
+              </span>
+            </span>
+          </label>
+
+          <label
+            className={`flex items-start gap-2 py-1 ${
+              accountEligible ? "cursor-pointer" : "opacity-60 cursor-not-allowed"
+            }`}
+          >
+            <input
+              type="radio"
+              name="scope_choice"
+              value="account"
+              checked={pickingAccount}
+              disabled={!accountEligible}
+              onChange={() => setScopeChoice("account")}
+              className="mt-1"
+            />
+            <span className="text-sm">
+              <span
+                className="font-medium"
+                style={pickingAccount ? { color: "var(--danger-strong)" } : undefined}
+              >
+                Account — full workspace admin ⚠
+              </span>
+              <span className="block text-xs text-muted">
+                Everything Agent can do, plus: create/delete inboxes, manage
+                domains &amp; webhooks, mint API keys, resolve reviews, and
+                account settings. Grant only to tools you run yourself.
+              </span>
+              {!accountEligible && (
+                <span className="block text-xs mt-0.5" style={{ color: "var(--danger-strong)" }}>
+                  Unavailable: account scope is only offered to local tools whose
+                  redirect URL is loopback (http://localhost). This client&apos;s
+                  redirect is{" "}
+                  <span className="font-mono break-all">{inboundRedirect}</span>.
+                </span>
+              )}
+            </span>
+          </label>
+        </fieldset>
+
+        {pickingAccount && (
+          <div
+            role="alert"
+            className="p-3 text-xs border rounded"
+            style={{
+              background: "var(--danger-bg)",
+              color: "var(--danger-strong)",
+              borderColor: "var(--danger-bg)",
+            }}
+          >
+            <strong>{client.client_name}</strong> will be able to administer your
+            entire e2a workspace. Only continue if you started this from a tool
+            you run and trust.
+          </div>
+        )}
+
+        {!pickingAccount && (
         <fieldset className="border border-border rounded-md p-4">
           <legend className="text-sm font-medium px-2">Choose an inbox</legend>
 
@@ -356,10 +444,11 @@ function ConsentForm({
             </div>
           )}
         </fieldset>
+        )}
 
         <div className="text-xs text-muted">
           <strong>Scope:</strong>{" "}
-          {client.scopes.length > 0 ? client.scopes.join(" ") : "(none)"}
+          <span className="font-mono">{pickingAccount ? "account" : "agent"}</span>
           <br />
           <strong>Redirect:</strong>{" "}
           <span className="font-mono break-all">{params["redirect_uri"]}</span>

--- a/web/src/app/oauth/consent/page.tsx
+++ b/web/src/app/oauth/consent/page.tsx
@@ -368,9 +368,13 @@ function ConsentForm({
               {!accountEligible && (
                 <span className="block text-xs mt-0.5" style={{ color: "var(--danger-strong)" }}>
                   Unavailable: account scope is only offered to local tools whose
-                  redirect URL is loopback (http://localhost). This client&apos;s
-                  redirect is{" "}
-                  <span className="font-mono break-all">{inboundRedirect}</span>.
+                  redirect URL is loopback (http://localhost).
+                  {inboundRedirect !== "" && (
+                    <>
+                      {" "}This client&apos;s redirect is{" "}
+                      <span className="font-mono break-all">{inboundRedirect}</span>.
+                    </>
+                  )}
                 </span>
               )}
             </span>


### PR DESCRIPTION
Lets a user choose **agent** (single inbox) vs **account** (workspace admin) scope on the OAuth consent screen, with a clear permission breakdown — so an MCP agent can self-serve admin (webhooks/domains) instead of being capped at agent-only. Account is **gated to loopback redirect clients** (local tools), preserving the no-escalation-from-a-hosted-client property.

Implements the approved design. Backend-only behavior change; ships later as a server release + the e2a-ops config is already in place (api_url switch). **Do not merge/deploy from this PR.**

## Slices
- **A** `isLoopbackRedirect` helper (extracted from `validateRedirectURI`) + table test
- **B/C** consent handler reads `scope_choice`; `account` is fail-closed loopback-gated; issuance grants the *consented* scope (the principal resolver already maps account+no-agent → account principal)
- **D** `/oauth2/clients/{id}` returns `account_eligible` (all redirect_uris loopback)
- **E** consent page: Access-level radio group (Agent default / Account warning-styled, disabled when not eligible); selecting Account hides the inbox picker
- **F** MCP protected-resource `scopes_supported` → `["agent","account"]`

## ⚠️ Necessary deviation from design decision 3
The design said "leave DCR as-is (agent-only)". But fosite's `ExactScopeStrategy` enforces *granted ⊆ client.scopes*, so account must be on the client row for consent to grant it. **DCR now registers the loopback-eligible ceiling**: all-loopback redirect_uris → `[agent,account]`, else `[agent]`. The ceiling is only the *max a user can approve* — consent is still mandatory and loopback-gated, so the security property is unchanged. (Surfaced to the owner mid-build; approved.)

## Security model
- `account` requires **both** an explicit user pick **and** a loopback inbound redirect, re-checked server-side at grant time (fail-closed; the page UI is convenience only).
- A hosted/remote client (https redirect) can't receive a localhost callback → stays agent-only, can't be phished into an account grant.
- High-risk warning styling on the Account option; redirect destination shown prominently.

## Tests
- Go: `isLoopbackRedirect` table; account-on-loopback → account principal (no agent); account-on-https → `invalid_scope` (no code); missing `scope_choice` → agent; refresh preserves scope; resolver fail-closed on unknown scope (now minted out-of-band). Full `internal/agent` oauth suite green (isolated; the parallel-run `1600 columns` noise is shared-test-DB pollution, unrelated).
- Web: 3 new consent-page tests + existing 8 green.
- MCP: 137 tests green.
- No `/v1` OpenAPI change (the `/oauth2/*` + consent handlers are the legacy mux, not the Huma surface).

## Future
`scope_choice` maps to a *set* of `GrantScope` calls, so evolving to granular capability scopes (`webhooks`/`domains` as separate grants) is additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)