### PR TITLE
chore(delivery): serve SES feedback at /webhooks/ses

### DIFF
--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -406,7 +406,11 @@ func main() {
 	// rejected, so this is inert until ops wires the topic).
 	deliveryConsumer := delivery.NewConsumer(store, deliveryEventFirer(webhookPublisher))
 	deliveryVerifier := delivery.NewVerifier(cfg.DeliveryFeedback.SNSTopicARNs, delivery.HTTPCertFetcher)
-	router.HandleFunc("/api/internal/ses/notifications", delivery.Handler(deliveryVerifier, deliveryConsumer)).Methods(http.MethodPost)
+	// Public webhook receiver for AWS SNS (SES delivery/bounce/complaint). Named
+	// /webhooks/<provider> — it's an inbound third-party callback, not an internal
+	// RPC, and must be internet-reachable for SNS to POST to it. Protected by the
+	// SNS signature + TopicArn allow-list above, not by network isolation.
+	router.HandleFunc("/webhooks/ses", delivery.Handler(deliveryVerifier, deliveryConsumer)).Methods(http.MethodPost)
 
 	// WebSocket live-tail transport. Registered as a first-class /v1 route
 	// on the chi root via WSHandle below (see apiserver.Params); the hub +

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -79,7 +79,7 @@ sender_identity:
 # Outbound delivery feedback (decision 9 / Slice 4b). When ses_configuration_set
 # is set, outbound mail is tagged with X-SES-CONFIGURATION-SET so SES publishes
 # delivery/bounce/complaint events to an SNS topic; e2a's public endpoint
-# POST /api/internal/ses/notifications consumes them (SNS signature verified,
+# POST /webhooks/ses consumes them (SNS signature verified,
 # fail-closed) to drive messages.delivery_status, fire
 # email.delivered/bounced/complained, and auto-suppress hard-bounced/complained
 # recipients. sns_topic_arns is the allow-list of SNS topics that endpoint

--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -1345,7 +1345,7 @@ Break the current `/api/v1` surface directly and move it to
     pending the live-SES validation above. **ARC sealing** remains deferred.
 * **Slice 4b — Delivery feedback (decision 9).** *(Delivery-feedback core
   shipped; the rest split into follow-ups.)* `internal/delivery`: an SES-over-SNS
-  consumer at `POST /api/internal/ses/notifications` (fail-closed SNS signature
+  consumer at `POST /webhooks/ses` (fail-closed SNS signature
   verification — host-allow-listed `SigningCertURL`, TopicArn allow-list, SHA1/256
   PKCS1v15, auto-confirm `SubscriptionConfirmation`) drives the
   `messages.delivery_status` lifecycle (`{queued,sent,delivered,bounced,

--- a/internal/delivery/handler_test.go
+++ b/internal/delivery/handler_test.go
@@ -13,7 +13,7 @@ func TestHandlerRejectsUnverified(t *testing.T) {
 	v := NewVerifier([]string{"arn:aws:sns:us-east-2:1:allowed"}, nil)
 	h := Handler(v, NewConsumer(nil, nil))
 	body := `{"Type":"Notification","TopicArn":"arn:aws:sns:us-east-2:1:EVIL","MessageId":"m","Message":"{}","Timestamp":"t","SignatureVersion":"1","Signature":"x","SigningCertURL":"https://sns.us-east-2.amazonaws.com/c.pem"}`
-	r := httptest.NewRequest(http.MethodPost, "/api/internal/ses/notifications", strings.NewReader(body))
+	r := httptest.NewRequest(http.MethodPost, "/webhooks/ses", strings.NewReader(body))
 	w := httptest.NewRecorder()
 	h(w, r)
 	if w.Code != http.StatusForbidden {


### PR DESCRIPTION
Renames the SES/SNS delivery-feedback callback from `/api/internal/ses/notifications` to the conventional `/webhooks/ses`.

**Why:** it's an inbound third-party webhook receiver (AWS SNS → server), not an internal RPC — it *must* be internet-reachable, and is protected by SNS signature verification + a TopicArn allow-list, not by network isolation. `/webhooks/<provider>` reads honestly and groups future provider callbacks.

**Clean rename** — nothing is subscribed to SNS yet, so no alias / dual-route is needed; the old path is removed outright.

Scope: route mount (`cmd/e2a/main.go`), the handler test, and two doc-comment references. Handler logic unchanged. `go build` + `go test ./internal/delivery/` green.

**Companion:** e2a-ops needs a `handle /webhooks/*` Caddy block (the prod Caddyfile has no `/webhooks/*` route today, only `/api/*`) — separate e2a-ops PR. Deploy both together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)