### PR TITLE
Sign pagination cursors (HMAC) — close #144 M2

### DIFF
--- a/internal/apiserver/apiserver.go
+++ b/internal/apiserver/apiserver.go
@@ -98,6 +98,7 @@ func BuildDeps(p Params) httpapi.Deps {
 		DeleteDomain:        deleteDomainFunc(p),
 		HasAgentsOnDomain:   p.Store.HasAgentsOnDomain,
 		SMTPDomain:          p.SMTPDomain,
+		CursorSecret:        p.SigningSecret,
 		Idempotency:         p.Idempotency,
 		DeliverOutbound:     p.API.DeliverOutbound,
 		SendTest:            p.API.SendTestCore,

--- a/internal/httpapi/account.go
+++ b/internal/httpapi/account.go
@@ -117,7 +117,7 @@ func (s *Server) handleListSuppressions(ctx context.Context, in *listSuppression
 	var afterAddress string
 	if in.Cursor != "" {
 		var cur suppressionsCursor
-		if err := DecodeCursor(in.Cursor, &cur); err != nil {
+		if err := DecodeCursor([]string{s.deps.CursorSecret}, in.Cursor, &cur); err != nil {
 			return nil, NewError(http.StatusBadRequest, "invalid_cursor", "invalid pagination cursor")
 		}
 		afterCreatedAt = cur.CreatedAt
@@ -139,7 +139,7 @@ func (s *Server) handleListSuppressions(ctx context.Context, in *listSuppression
 	var nextCursor string
 	if hasMore {
 		last := list[len(list)-1]
-		nextCursor, err = EncodeCursor(suppressionsCursor{CreatedAt: last.CreatedAt, Address: last.Address})
+		nextCursor, err = EncodeCursor(s.deps.CursorSecret, suppressionsCursor{CreatedAt: last.CreatedAt, Address: last.Address})
 		if err != nil {
 			return nil, NewError(http.StatusInternalServerError, "internal_error", "failed to build pagination cursor")
 		}

--- a/internal/httpapi/conversations.go
+++ b/internal/httpapi/conversations.go
@@ -132,7 +132,7 @@ func (s *Server) handleListConversations(ctx context.Context, in *ListConversati
 	var afterID string
 	if in.Cursor != "" {
 		var cur conversationsCursor
-		if err := DecodeCursor(in.Cursor, &cur); err != nil {
+		if err := DecodeCursor([]string{s.deps.CursorSecret}, in.Cursor, &cur); err != nil {
 			return nil, NewError(http.StatusBadRequest, "invalid_cursor", "invalid pagination cursor")
 		}
 		if cur.AgentID != ag.ID || cur.Since != rfc3339OrEmpty(since) || cur.Until != rfc3339OrEmpty(until) {
@@ -169,7 +169,7 @@ func (s *Server) handleListConversations(ctx context.Context, in *ListConversati
 	var nextCursor string
 	if hasMore {
 		last := convos[len(convos)-1]
-		nextCursor, err = EncodeCursor(conversationsCursor{
+		nextCursor, err = EncodeCursor(s.deps.CursorSecret, conversationsCursor{
 			LastMessageAt:  last.LastMessageAt,
 			ConversationID: last.ID,
 			AgentID:        ag.ID,

--- a/internal/httpapi/events.go
+++ b/internal/httpapi/events.go
@@ -219,7 +219,7 @@ func (s *Server) handleListEvents(ctx context.Context, in *ListEventsInput) (*li
 	}
 	var cur eventsCursor
 	if in.Cursor != "" {
-		if err := DecodeCursor(in.Cursor, &cur); err != nil {
+		if err := DecodeCursor([]string{s.deps.CursorSecret}, in.Cursor, &cur); err != nil {
 			return nil, NewError(http.StatusBadRequest, "invalid_cursor", "invalid pagination cursor")
 		}
 		if cur.Ty != in.Type || cur.Ag != in.AgentID || cur.Co != in.ConversationID ||
@@ -245,7 +245,7 @@ func (s *Server) handleListEvents(ctx context.Context, in *ListEventsInput) (*li
 	var nextCursor string
 	if hasMore {
 		last := events[len(events)-1]
-		nextCursor, err = EncodeCursor(eventsCursor{
+		nextCursor, err = EncodeCursor(s.deps.CursorSecret, eventsCursor{
 			C: last.CreatedAt, I: last.ID,
 			Ty: in.Type, Ag: in.AgentID, Co: in.ConversationID, Ms: in.MessageID,
 			Si: rfc3339PtrOrEmpty(since), Un: rfc3339PtrOrEmpty(until),

--- a/internal/httpapi/httpapi.go
+++ b/internal/httpapi/httpapi.go
@@ -119,6 +119,15 @@ type Deps struct {
 	// domain must publish (config smtp.domain).
 	SMTPDomain string
 
+	// CursorSecret is the deployment HMAC secret (config.Signing.HMACSecret)
+	// used to sign/verify pagination cursors so they are tamper-evident
+	// (issue #144 M2). The same key approvaltoken and the X-E2A-Auth-* email
+	// headers use — no new key. Handlers pass it to EncodeCursor and wrap it
+	// in a 1-element slice for DecodeCursor (whose verify loop supports N for
+	// a future secret rotation). Empty in minimal test setups, which is fine:
+	// encode and verify stay consistent under the same (empty) key.
+	CursorSecret string
+
 	// Idempotency is the retry-safety store for unsafe writes (send/reply/
 	// forward/redeliver). Optional — nil disables the Idempotency-Key path.
 	Idempotency IdemStore

--- a/internal/httpapi/messages.go
+++ b/internal/httpapi/messages.go
@@ -508,7 +508,7 @@ func (s *Server) handleListMessages(ctx context.Context, in *ListMessagesInput) 
 	var afterID string
 	if in.Cursor != "" {
 		var cur messagesCursor
-		if err := DecodeCursor(in.Cursor, &cur); err != nil {
+		if err := DecodeCursor([]string{s.deps.CursorSecret}, in.Cursor, &cur); err != nil {
 			return nil, NewError(http.StatusBadRequest, "invalid_cursor", "invalid pagination cursor")
 		}
 		if cur.AgentID != ag.ID || cur.Status != status || cur.Direction != direction || cur.Sort != sort ||
@@ -560,7 +560,7 @@ func (s *Server) handleListMessages(ctx context.Context, in *ListMessagesInput) 
 	var nextCursor string
 	if hasMore {
 		last := msgs[len(msgs)-1]
-		nextCursor, err = EncodeCursor(messagesCursor{
+		nextCursor, err = EncodeCursor(s.deps.CursorSecret, messagesCursor{
 			CreatedAt: last.CreatedAt, ID: last.ID,
 			Status: status, Direction: direction, AgentID: ag.ID, Sort: sort,
 			From: in.From, SubjectContains: in.SubjectContains, ConversationID: in.ConversationID,

--- a/internal/httpapi/pagination.go
+++ b/internal/httpapi/pagination.go
@@ -1,9 +1,12 @@
 package httpapi
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"strings"
 )
 
 // Page is the one list-response shape across every v1 collection
@@ -46,26 +49,71 @@ type PageParams struct {
 var ErrInvalidCursor = errors.New("invalid pagination cursor")
 
 // EncodeCursor serializes an arbitrary cursor payload (the position +
-// filter snapshot a resource needs to resume) into the opaque, URL-safe
-// string clients echo back. The payload shape is private to each resource;
-// clients must treat the cursor as opaque.
-func EncodeCursor(payload any) (string, error) {
+// filter snapshot a resource needs to resume) into the opaque, URL-safe,
+// tamper-evident string clients echo back.
+//
+// The cursor is HMAC-signed (issue #144, finding M2): a client can no
+// longer decode the base64, edit a field, and re-encode it — any such edit
+// breaks the signature and DecodeCursor rejects it. The cursor remains
+// opaque to clients; the payload shape stays private to each resource.
+//
+// Format:
+//
+//	base64url(json_payload) + "." + base64url(hmac_sha256(secret, base64url(json_payload)))
+//
+// The MAC is computed over the LITERAL emitted base64url(json) segment (not
+// a re-marshaled struct) so encode and verify are byte-canonical and cannot
+// drift. secret is the deployment HMAC secret (config.Signing.HMACSecret) —
+// the same key approvaltoken and the X-E2A-Auth-* email headers already use,
+// so there is no new key to manage.
+func EncodeCursor(secret string, payload any) (string, error) {
 	raw, err := json.Marshal(payload)
 	if err != nil {
 		return "", err
 	}
-	return base64.RawURLEncoding.EncodeToString(raw), nil
+	encoded := base64.RawURLEncoding.EncodeToString(raw)
+	sig := cursorMAC([]byte(secret), []byte(encoded))
+	return encoded + "." + base64.RawURLEncoding.EncodeToString(sig), nil
 }
 
-// DecodeCursor reverses EncodeCursor into dst. A malformed cursor yields
-// ErrInvalidCursor rather than a generic JSON error so callers branch on a
-// stable sentinel. An empty cursor is treated as "start from the
-// beginning" — dst is left untouched and nil is returned.
-func DecodeCursor(cursor string, dst any) error {
+// DecodeCursor verifies a cursor's HMAC and reverses it into dst. A
+// malformed, tampered, or wrong-secret cursor yields ErrInvalidCursor
+// rather than a generic error so callers branch on a stable sentinel. An
+// empty cursor is treated as "start from the beginning" — dst is left
+// untouched and nil is returned.
+//
+// secrets is tried in order and the signature is compared in constant time
+// (hmac.Equal, mirroring approvaltoken.Verify). Accepting a slice supports
+// HMAC-secret rotation: a cursor signed under an old secret keeps verifying
+// until that secret is retired. Today callers pass a single-element slice.
+//
+// Old unsigned cursors (plain base64url(json) with no "." signature segment,
+// as emitted before issue #144 M2) no longer verify and are hard-rejected
+// with ErrInvalidCursor. Cursors are ephemeral, so a client mid-pagination
+// simply restarts the query.
+func DecodeCursor(secrets []string, cursor string, dst any) error {
 	if cursor == "" {
 		return nil
 	}
-	raw, err := base64.RawURLEncoding.DecodeString(cursor)
+	parts := strings.SplitN(cursor, ".", 2)
+	if len(parts) != 2 {
+		return ErrInvalidCursor
+	}
+	providedSig, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return ErrInvalidCursor
+	}
+	matched := false
+	for _, secret := range secrets {
+		if hmac.Equal(providedSig, cursorMAC([]byte(secret), []byte(parts[0]))) {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return ErrInvalidCursor
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(parts[0])
 	if err != nil {
 		return ErrInvalidCursor
 	}
@@ -73,4 +121,12 @@ func DecodeCursor(cursor string, dst any) error {
 		return ErrInvalidCursor
 	}
 	return nil
+}
+
+// cursorMAC computes HMAC-SHA256 of payload under secret. Mirrors
+// approvaltoken.signMAC so the two signing paths stay convention-identical.
+func cursorMAC(secret, payload []byte) []byte {
+	mac := hmac.New(sha256.New, secret)
+	mac.Write(payload)
+	return mac.Sum(nil)
 }

--- a/internal/httpapi/pagination_test.go
+++ b/internal/httpapi/pagination_test.go
@@ -2,8 +2,13 @@ package httpapi
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 )
+
+// testSecret is a stand-in for the deployment HMAC secret used to sign
+// pagination cursors in these unit tests.
+const testSecret = "0123456789abcdef0123456789abcdef"
 
 func TestCursorRoundTrip(t *testing.T) {
 	type cur struct {
@@ -11,15 +16,19 @@ func TestCursorRoundTrip(t *testing.T) {
 		Dir   string `json:"dir"`
 	}
 	in := cur{After: "msg_123", Dir: "inbound"}
-	enc, err := EncodeCursor(in)
+	enc, err := EncodeCursor(testSecret, in)
 	if err != nil {
 		t.Fatalf("encode: %v", err)
 	}
 	if enc == "" {
 		t.Fatal("expected non-empty cursor")
 	}
+	// The signed cursor is payload + "." + signature.
+	if strings.Count(enc, ".") != 1 {
+		t.Fatalf("expected exactly one '.' separator, got %q", enc)
+	}
 	var out cur
-	if err := DecodeCursor(enc, &out); err != nil {
+	if err := DecodeCursor([]string{testSecret}, enc, &out); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
 	if out != in {
@@ -28,22 +37,95 @@ func TestCursorRoundTrip(t *testing.T) {
 }
 
 func TestDecodeCursorEmptyIsNoop(t *testing.T) {
-	var out struct{ A string }
-	if err := DecodeCursor("", &out); err != nil {
+	out := struct{ A string }{A: "untouched"}
+	if err := DecodeCursor([]string{testSecret}, "", &out); err != nil {
 		t.Fatalf("empty cursor should be a no-op, got %v", err)
+	}
+	if out.A != "untouched" {
+		t.Fatalf("empty cursor must leave dst untouched, got %+v", out)
 	}
 }
 
 func TestDecodeCursorMalformed(t *testing.T) {
 	var out struct{ A string }
-	// Not valid base64url.
-	if err := DecodeCursor("!!!not-base64!!!", &out); err != ErrInvalidCursor {
+	// Not valid base64url and no signature segment.
+	if err := DecodeCursor([]string{testSecret}, "!!!not-base64!!!", &out); err != ErrInvalidCursor {
 		t.Fatalf("want ErrInvalidCursor, got %v", err)
 	}
-	// Valid base64url, but not valid JSON for dst.
-	bad := EncodeMust(t, "a string, not the struct")
-	if err := DecodeCursor(bad, &out); err != ErrInvalidCursor {
+	// Valid base64url payload + valid signature, but the payload is not the
+	// dst struct shape (a bare string).
+	bad := EncodeMust(t, testSecret, "a string, not the struct")
+	if err := DecodeCursor([]string{testSecret}, bad, &out); err != ErrInvalidCursor {
 		t.Fatalf("want ErrInvalidCursor on bad json, got %v", err)
+	}
+}
+
+func TestDecodeCursorTamperedPayload(t *testing.T) {
+	type cur struct {
+		Agent string `json:"agent"`
+	}
+	enc := EncodeMust(t, testSecret, cur{Agent: "agent_a"})
+	// Flip a byte in the base64 payload segment (before the '.'); the
+	// signature no longer matches.
+	dot := strings.IndexByte(enc, '.')
+	if dot <= 0 {
+		t.Fatalf("expected a signature separator in %q", enc)
+	}
+	b := []byte(enc)
+	// Swap the first payload byte for a different base64url char.
+	if b[0] == 'A' {
+		b[0] = 'B'
+	} else {
+		b[0] = 'A'
+	}
+	var out cur
+	if err := DecodeCursor([]string{testSecret}, string(b), &out); err != ErrInvalidCursor {
+		t.Fatalf("tampered payload: want ErrInvalidCursor, got %v", err)
+	}
+}
+
+func TestDecodeCursorWrongSecret(t *testing.T) {
+	type cur struct {
+		A string `json:"a"`
+	}
+	enc := EncodeMust(t, testSecret, cur{A: "x"})
+	var out cur
+	if err := DecodeCursor([]string{"a-different-secret-value-here-3232"}, enc, &out); err != ErrInvalidCursor {
+		t.Fatalf("wrong secret: want ErrInvalidCursor, got %v", err)
+	}
+}
+
+func TestDecodeCursorOldUnsignedFormatRejected(t *testing.T) {
+	// An old-style cursor is plain base64url(json) with no "." + signature.
+	type cur struct {
+		A string `json:"a"`
+	}
+	signed := EncodeMust(t, testSecret, cur{A: "x"})
+	unsigned, _, ok := strings.Cut(signed, ".")
+	if !ok {
+		t.Fatalf("expected a signature separator in %q", signed)
+	}
+	var out cur
+	if err := DecodeCursor([]string{testSecret}, unsigned, &out); err != ErrInvalidCursor {
+		t.Fatalf("old unsigned cursor: want ErrInvalidCursor, got %v", err)
+	}
+}
+
+func TestDecodeCursorMultiSecretRotation(t *testing.T) {
+	type cur struct {
+		A string `json:"a"`
+	}
+	const secretA = "secret-A-padding-padding-padding-32"
+	const secretB = "secret-B-padding-padding-padding-32"
+	// Sign with B; verify against [A, B] — a rotation where B is the newest
+	// secret and A is still accepted.
+	enc := EncodeMust(t, secretB, cur{A: "rotated"})
+	var out cur
+	if err := DecodeCursor([]string{secretA, secretB}, enc, &out); err != nil {
+		t.Fatalf("multi-secret verify: %v", err)
+	}
+	if out.A != "rotated" {
+		t.Fatalf("round-trip mismatch: got %+v", out)
 	}
 }
 
@@ -63,9 +145,9 @@ func TestNewPageNullVsEmpty(t *testing.T) {
 }
 
 // EncodeMust is a test helper that encodes a cursor or fails the test.
-func EncodeMust(t *testing.T, payload any) string {
+func EncodeMust(t *testing.T, secret string, payload any) string {
 	t.Helper()
-	s, err := EncodeCursor(payload)
+	s, err := EncodeCursor(secret, payload)
 	if err != nil {
 		t.Fatalf("encode: %v", err)
 	}


### PR DESCRIPTION
## Summary

Pagination cursors were `base64url(json)` with **no integrity protection**, so a client could decode the cursor, edit any field (e.g. swap in another agent's id or a different filter snapshot), and re-encode it. This is finding **M2** of issue #144.

This PR makes cursors **tamper-evident** by HMAC-signing them, mirroring the existing `internal/approvaltoken` Sign/Verify conventions (crypto/hmac, sha256, base64.RawURLEncoding, constant-time `hmac.Equal`, N-secret verify loop for rotation).

## New cursor format

```
base64url(json_payload) + "." + base64url(hmac_sha256(secret, base64url(json_payload)))
```

The MAC is computed over the **literal emitted `base64url(json)` segment** (not a re-marshaled struct) so encode and verify are byte-canonical and cannot drift. The signing key is the existing deployment HMAC secret `config.Signing.HMACSecret` — the same key `approvaltoken` and the `X-E2A-Auth-*` email headers already use. **No new key introduced.**

## Wiring

The secret did not previously reach the httpapi handlers (it only flowed to the attachment store). This PR threads it through:

- `EncodeCursor(secret string, payload any)` — signs.
- `DecodeCursor(secrets []string, cursor string, dst any)` — verifies against each secret with constant-time `hmac.Equal`. The loop is N-capable so a future HMAC-secret rotation doesn't break in-flight cursors; today callers pass a 1-element slice.
- Added `Deps.CursorSecret`, populated from `apiserver.Params.SigningSecret` in `BuildDeps`.

### Call sites updated (the full paginating surface)

| File | Endpoint |
|------|----------|
| `internal/httpapi/messages.go` | list messages |
| `internal/httpapi/events.go` | list events |
| `internal/httpapi/conversations.go` | list conversations |
| `internal/httpapi/account.go` | list suppressions |

Each now passes `s.deps.CursorSecret` to `EncodeCursor` and `[]string{s.deps.CursorSecret}` to `DecodeCursor`. (webhooks/domains/operations are single-page and have no cursor.)

## Backward incompatibility (by design)

Old **unsigned** cursors (plain `base64url(json)`, no `.` signature segment) and any **tampered / wrong-secret** cursor are hard-rejected with `ErrInvalidCursor` → 400 `invalid_cursor`. Cursors are ephemeral, so a client mid-pagination simply restarts the query. An empty cursor still means "start from the beginning" (unchanged).

## Defense-in-depth retained

All existing per-resource consistency checks are kept untouched: the messages/events/conversations "cursor was created with different filters" / agent-id checks remain as a second layer behind the signature. (The suppressions cursor has no filters by design, so it has no such check — it is now signed like the others.)

## Tests added

`internal/httpapi/pagination_test.go`:
- round-trip (encode → decode with same secret returns original payload)
- tampered payload (flip a byte in the base64 segment) → `ErrInvalidCursor`
- wrong secret → `ErrInvalidCursor`
- old/unsigned format (no `.` + sig) → `ErrInvalidCursor`
- empty cursor → nil error, dst untouched
- multi-secret rotation: cursor signed with B verifies when secrets = [A, B]

`go test ./internal/httpapi/... ./internal/approvaltoken/...` passes; `go build ./...` and `go vet` clean.

Closes the M2 finding of #144.

🤖 Generated with [Claude Code](https://claude.com/claude-code)