### PR TITLE
feat(web): custom-domain sending onboarding UI (#113)

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -71,7 +71,10 @@ outbound_smtp:
 # "none" and outbound keeps the relay "… via e2a" From — the fail-closed
 # default for dev/self-host without SES. Needs AWS credentials in the ambient
 # environment (env vars / instance role) with ses:CreateEmailIdentity,
-# GetEmailIdentity, DeleteEmailIdentity, ListEmailIdentities.
+# ses:PutEmailIdentityMailFromAttributes, ses:GetEmailIdentity,
+# ses:DeleteEmailIdentity, ses:ListEmailIdentities. (Provisioning calls
+# PutEmailIdentityMailFromAttributes for the custom MAIL FROM — a role missing
+# it fails at that step even though CreateEmailIdentity succeeds.)
 # Override with E2A_SENDER_IDENTITY_SES_REGION.
 sender_identity:
   ses_region: ""  # e.g. "us-east-1"

--- a/web/src/app/(app)/domains/_components/DomainCard.tsx
+++ b/web/src/app/(app)/domains/_components/DomainCard.tsx
@@ -59,7 +59,6 @@ function SendingStatusChip({
         Sending enabled
       </Chip>
     );
-  if (status === "pending") return <Chip tone="info">Verifying…</Chip>;
   if (status === "failed")
     return (
       <Chip tone="danger">
@@ -67,14 +66,19 @@ function SendingStatusChip({
         Failed
       </Chip>
     );
-  return <Chip tone="neutral">Not set up</Chip>;
+  // pending OR any unknown/future value: the chip only renders when records
+  // exist (provisioned), so a neutral in-progress label reads truer than
+  // "Not set up". "verified"/"failed" are handled above.
+  return <Chip tone="info">Verifying…</Chip>;
 }
 
 // splitMX parses the backend's combined "10 host.example.com" MX value into the
-// (priority, host) pair most DNS providers ask for as separate fields.
-function splitMX(value: string): { priority: string; host: string } {
+// (priority, host) pair most DNS providers ask for as separate fields. Returns
+// null if the value isn't "<priority> <host>" so the caller can fall back to a
+// single Content field rather than fabricating a priority.
+function splitMX(value: string): { priority: string; host: string } | null {
   const m = value.match(/^\s*(\d+)\s+(.+?)\.?\s*$/);
-  return m ? { priority: m[1], host: m[2] } : { priority: "10", host: value };
+  return m ? { priority: m[1], host: m[2] } : null;
 }
 
 export function DomainCard({

--- a/web/src/app/(app)/domains/_components/DomainCard.tsx
+++ b/web/src/app/(app)/domains/_components/DomainCard.tsx
@@ -10,6 +10,7 @@ import {
 } from "../../../components/onboarding/api";
 import type {
   DomainInfo,
+  DomainSendingStatus,
   VerifyDomainResponse,
 } from "../../../components/onboarding/types";
 import { track } from "../../../components/onboarding/analytics";
@@ -40,6 +41,40 @@ function RecordStatusChip({
       Missing
     </Chip>
   );
+}
+
+// SendingStatusChip reflects the async SES sending-identity verification for
+// the WHOLE domain (all-or-nothing: DKIM + custom MAIL FROM together), not a
+// single record — so it lives in the section header, not per-row. Mirrors the
+// `sending_status` column. Unknown values fall through to neutral (open set).
+function SendingStatusChip({
+  status,
+}: {
+  status: DomainSendingStatus | undefined;
+}) {
+  if (status === "verified")
+    return (
+      <Chip tone="success">
+        <Dot tone="success" />
+        Sending enabled
+      </Chip>
+    );
+  if (status === "pending") return <Chip tone="info">Verifying…</Chip>;
+  if (status === "failed")
+    return (
+      <Chip tone="danger">
+        <Dot tone="danger" />
+        Failed
+      </Chip>
+    );
+  return <Chip tone="neutral">Not set up</Chip>;
+}
+
+// splitMX parses the backend's combined "10 host.example.com" MX value into the
+// (priority, host) pair most DNS providers ask for as separate fields.
+function splitMX(value: string): { priority: string; host: string } {
+  const m = value.match(/^\s*(\d+)\s+(.+?)\.?\s*$/);
+  return m ? { priority: m[1], host: m[2] } : { priority: "10", host: value };
 }
 
 export function DomainCard({
@@ -377,6 +412,100 @@ export function DomainCard({
                   { label: "Content", value: domain.dns_records.dkim.value },
                 ]}
               />
+            </div>
+          )}
+
+          {/* Outbound sending (decision 4 / Slice 4). Rendered only when the
+              backend has provisioned a sending identity (sending_dns_records
+              present) — so when the feature is gated off (ses_region unset),
+              this whole block is absent and the card is unchanged. These are
+              the custom MAIL FROM subdomain's MX + SPF; the DKIM record above
+              is reused via BYODKIM. SES verifies them as a unit, surfaced by
+              the single status chip (no per-record probe). */}
+          {(domain.sending_dns_records?.length ?? 0) > 0 && (
+            <div
+              className="space-y-3 pt-4"
+              style={{ borderTop: "1px solid var(--border)" }}
+            >
+              <div className="flex items-center gap-2 flex-wrap">
+                <p
+                  className="font-mono text-[10px] uppercase font-semibold"
+                  style={{
+                    color: "var(--fg-subtle)",
+                    letterSpacing: "0.08em",
+                  }}
+                >
+                  Outbound sending
+                </p>
+                <SendingStatusChip status={domain.sending_status} />
+              </div>
+              <p className="text-[12px]" style={{ color: "var(--fg-muted)" }}>
+                Publish these so mail sends as{" "}
+                <code className="font-mono">@{domain.domain}</code> with no
+                “via e2a”. The DKIM record above is also required.
+              </p>
+
+              {domain.sending_status === "failed" && domain.sending_error && (
+                <div
+                  className="p-3 text-[12px]"
+                  style={{
+                    background: "var(--danger-bg)",
+                    color: "var(--danger-strong)",
+                    border: "1px solid var(--danger-bg)",
+                    borderRadius: "var(--r-md)",
+                  }}
+                >
+                  {domain.sending_error}
+                </div>
+              )}
+
+              {domain.sending_dns_records!.map((rec, i) => {
+                const isMX = rec.type.toUpperCase() === "MX";
+                const mx = isMX ? splitMX(rec.value) : null;
+                return (
+                  <div key={`${rec.type}-${rec.name}-${i}`} className="space-y-2">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span
+                        className="font-mono text-[11px] px-2 py-0.5"
+                        style={{
+                          background: "var(--bg-elev)",
+                          border: "1px solid var(--border-sub)",
+                          borderRadius: "var(--r-sm)",
+                          color: "var(--fg)",
+                          minWidth: 36,
+                          textAlign: "center",
+                        }}
+                      >
+                        {rec.type}
+                      </span>
+                      <span
+                        className="text-[12px]"
+                        style={{ color: "var(--fg-muted)" }}
+                      >
+                        {isMX
+                          ? "Return path for bounces (MAIL FROM)"
+                          : "Authorize sending (SPF)"}
+                      </span>
+                    </div>
+                    <DNSRecord
+                      type=""
+                      label=""
+                      fields={
+                        mx
+                          ? [
+                              { label: "Name", value: rec.name },
+                              { label: "Mail server", value: mx.host },
+                              { label: "Priority", value: mx.priority },
+                            ]
+                          : [
+                              { label: "Name", value: rec.name },
+                              { label: "Content", value: rec.value },
+                            ]
+                      }
+                    />
+                  </div>
+                );
+              })}
             </div>
           )}
 

--- a/web/src/app/(app)/domains/page.test.tsx
+++ b/web/src/app/(app)/domains/page.test.tsx
@@ -53,6 +53,26 @@ const verifiedDomain = {
   verified_at: "2026-01-15T00:00:00Z",
 };
 
+// A verified domain whose SES sending identity has been provisioned (the
+// feature is on). Carries the 2 custom MAIL FROM records the backend serves.
+const sendingDomain = {
+  ...verifiedDomain,
+  domain: "sending.example.com",
+  sending_status: "pending",
+  sending_dns_records: [
+    {
+      type: "MX",
+      name: "bounce.sending.example.com",
+      value: "10 feedback-smtp.us-east-1.amazonses.com",
+    },
+    {
+      type: "TXT",
+      name: "bounce.sending.example.com",
+      value: "v=spf1 include:amazonses.com ~all",
+    },
+  ],
+};
+
 const sampleAgent = {
   id: "ag_123",
   domain: "verified.example.com",
@@ -188,6 +208,77 @@ describe("Domains page — with domains", () => {
     expect(
       screen.getByText(/Prove domain ownership/),
     ).toBeInTheDocument();
+  });
+});
+
+describe("Domains page — outbound sending records", () => {
+  it("renders the MAIL FROM records + a 'Verifying…' chip for a pending sending identity", async () => {
+    mockDomainsAndAgents([sendingDomain], []);
+    render(<DomainsPage />);
+    await waitFor(() => {
+      expect(screen.getByText("sending.example.com")).toBeInTheDocument();
+    });
+
+    // Hidden until the DNS section is expanded.
+    expect(screen.queryByText("Outbound sending")).not.toBeInTheDocument();
+    await userEvent.click(screen.getByText("View DNS records"));
+
+    expect(screen.getByText("Outbound sending")).toBeInTheDocument();
+    expect(screen.getByText("Verifying…")).toBeInTheDocument();
+    // The 2 MAIL FROM records: MX host (priority split out) + SPF TXT value.
+    expect(
+      screen.getByText("feedback-smtp.us-east-1.amazonses.com"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("v=spf1 include:amazonses.com ~all"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Return path for bounces (MAIL FROM)"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Authorize sending (SPF)")).toBeInTheDocument();
+  });
+
+  it("shows 'Sending enabled' when the sending identity is verified", async () => {
+    mockDomainsAndAgents(
+      [{ ...sendingDomain, sending_status: "verified" }],
+      [],
+    );
+    render(<DomainsPage />);
+    await waitFor(() => {
+      expect(screen.getByText("sending.example.com")).toBeInTheDocument();
+    });
+    await userEvent.click(screen.getByText("View DNS records"));
+    expect(screen.getByText("Sending enabled")).toBeInTheDocument();
+  });
+
+  it("surfaces sending_error when verification failed", async () => {
+    mockDomainsAndAgents(
+      [
+        {
+          ...sendingDomain,
+          sending_status: "failed",
+          sending_error: "MAIL FROM MX not found",
+        },
+      ],
+      [],
+    );
+    render(<DomainsPage />);
+    await waitFor(() => {
+      expect(screen.getByText("sending.example.com")).toBeInTheDocument();
+    });
+    await userEvent.click(screen.getByText("View DNS records"));
+    expect(screen.getByText("Failed")).toBeInTheDocument();
+    expect(screen.getByText("MAIL FROM MX not found")).toBeInTheDocument();
+  });
+
+  it("renders no sending section when the feature is off (no sending records)", async () => {
+    mockDomainsAndAgents([verifiedDomain], []);
+    render(<DomainsPage />);
+    await waitFor(() => {
+      expect(screen.getByText("verified.example.com")).toBeInTheDocument();
+    });
+    await userEvent.click(screen.getByText("View DNS records"));
+    expect(screen.queryByText("Outbound sending")).not.toBeInTheDocument();
   });
 });
 

--- a/web/src/app/(app)/domains/page.test.tsx
+++ b/web/src/app/(app)/domains/page.test.tsx
@@ -229,6 +229,11 @@ describe("Domains page — outbound sending records", () => {
     expect(
       screen.getByText("feedback-smtp.us-east-1.amazonses.com"),
     ).toBeInTheDocument();
+    // The MX priority is split into its own field — the backend's combined
+    // "10 feedback-smtp…" value is never shown as one string.
+    expect(
+      screen.queryByText("10 feedback-smtp.us-east-1.amazonses.com"),
+    ).not.toBeInTheDocument();
     expect(
       screen.getByText("v=spf1 include:amazonses.com ~all"),
     ).toBeInTheDocument();
@@ -269,6 +274,22 @@ describe("Domains page — outbound sending records", () => {
     await userEvent.click(screen.getByText("View DNS records"));
     expect(screen.getByText("Failed")).toBeInTheDocument();
     expect(screen.getByText("MAIL FROM MX not found")).toBeInTheDocument();
+  });
+
+  it("degrades to the neutral 'Verifying…' chip for an unknown sending_status", async () => {
+    // Open set — a future status the UI doesn't know must not read "Not set up"
+    // next to a populated record list.
+    mockDomainsAndAgents(
+      [{ ...sendingDomain, sending_status: "provisioning" }],
+      [],
+    );
+    render(<DomainsPage />);
+    await waitFor(() => {
+      expect(screen.getByText("sending.example.com")).toBeInTheDocument();
+    });
+    await userEvent.click(screen.getByText("View DNS records"));
+    expect(screen.getByText("Outbound sending")).toBeInTheDocument();
+    expect(screen.getByText("Verifying…")).toBeInTheDocument();
   });
 
   it("renders no sending section when the feature is off (no sending records)", async () => {

--- a/web/src/app/components/onboarding/types.ts
+++ b/web/src/app/components/onboarding/types.ts
@@ -20,6 +20,24 @@ export type ChecklistStep =
   | "domain_verified"
   | "agent_created";
 
+/** Async SES sending-identity state (decision 4 / Slice 4), independent of
+ *  inbound `verified`. Drives the "send as your own address" onboarding:
+ *  none → not provisioned (feature off, or pre-verify); pending → registered,
+ *  awaiting SES; verified → own-address From is live (no "via e2a"); failed →
+ *  verification failed or timed out (see `sending_error`). Open set — tolerate
+ *  unknown values. */
+export type DomainSendingStatus = "none" | "pending" | "verified" | "failed";
+
+/** A DNS record the customer publishes to enable own-domain sending. Mirrors
+ *  the backend `sending_dns_records[]` (senderidentity.DNSRecord): the custom
+ *  MAIL FROM subdomain's MX + SPF. The DKIM record is the existing per-domain
+ *  one, reused via BYODKIM, so it is NOT repeated here. */
+export type SendingDNSRecord = {
+  type: string; // "MX" | "TXT"
+  name: string;
+  value: string;
+};
+
 /** Domain as returned by GET /v1/domains. */
 export type DomainInfo = {
   domain: string;
@@ -38,6 +56,13 @@ export type DomainInfo = {
   // (success or failure); agent_count is computed at read time.
   last_checked_at?: string | null;
   agent_count?: number;
+  // Sender identity (decision 4 / Slice 4), independent of `verified`.
+  // Absent/none + empty sending_dns_records when the feature is off
+  // (ses_region unset) — the UI renders no sending section in that case.
+  sending_status?: DomainSendingStatus;
+  sending_error?: string;
+  sending_dns_records?: SendingDNSRecord[];
+  sending_last_checked_at?: string | null;
 };
 
 /** Response from POST /v1/domains/{domain}/verify — per-record


### PR DESCRIPTION
Closes the last gap in **#113** (Resend-style per-customer SES sender identity). The backend is fully built + now **validated against live SES** (Provision → DNS → `verified` in ~90s); this surfaces the sending setup in the dashboard.

## What changed
`DomainCard`'s expanded DNS section gains an **"Outbound sending"** block:
- the **2 custom MAIL FROM records** the backend serves in `sending_dns_records` — `bounce.<domain>` MX → `feedback-smtp.<region>.amazonses.com` (priority split out) + the SPF TXT,
- a single **SES status chip** — `Verifying…` / `Sending enabled` / `Failed` (+ `sending_error`) / `Not set up`. SES verifies DKIM + MAIL FROM **as a unit**, so the status is per-domain, not per-record (no per-row probe — matching `mapSESStatus`),
- a note that the existing **DKIM record is reused** (BYODKIM), so it isn't repeated.

## Invariant / safety
Rendered **only when `sending_dns_records` is present**. When the feature is gated off (`ses_region` unset — current prod), there are no such records, so **the card is byte-for-byte unchanged**. No behavioral change ships until the flag is flipped.

## Data layer
`onboarding/types.ts` gains `DomainSendingStatus` + `SendingDNSRecord` and the `sending_*` fields on `DomainInfo`. `listDomains` casts the JSON, so no `api.ts` change.

## Also
`config.example.yaml`: add `ses:PutEmailIdentityMailFromAttributes` to the documented SES IAM perms — the live validation proved `Provision()` calls it (a role missing it fails at the MAIL FROM step even though `CreateEmailIdentity` succeeds).

## Tests
4 new `page.test.tsx` cases (pending records + chip / verified / failed+error / feature-off renders nothing). Full web suite **244/244**, `tsc` clean, eslint clean.

## Not in this PR (remaining #113 ship steps)
- Flip `sender_identity.ses_region: us-east-1` in e2a-ops `config.prod.yaml` (turns the backend on).
- Scope the prod AWS role to the 5 SES perms (currently root keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)