### PR TITLE
feat(web): add light/dark/system theme toggle to sidebar

### DIFF
--- a/web/src/app/components/loft/Sidebar.tsx
+++ b/web/src/app/components/loft/Sidebar.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import type { ReactNode } from "react";
 import { useAuth } from "../AuthProvider";
 import { usePendingCount } from "../hooks/usePendingCount";
+import { ThemeToggle } from "./ThemeToggle";
 
 type IconKey = "plus" | "grid" | "clock" | "globe" | "key" | "settings" | "msg" | "shield" | "card";
 
@@ -314,6 +315,12 @@ export function Sidebar({
           label="Send feedback"
           pathname={pathname}
         />
+
+        {/* Theme toggle — light / dark / system, persisted to localStorage
+            by ThemeProvider. */}
+        <div className="mt-2.5">
+          <ThemeToggle />
+        </div>
 
         {/* User card */}
         {user && (

--- a/web/src/app/components/loft/ThemeToggle.tsx
+++ b/web/src/app/components/loft/ThemeToggle.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useTheme, type Theme } from "../ThemeProvider";
+
+// Three-way segmented control mirroring the ThemeProvider's Theme union.
+// "system" follows the OS `prefers-color-scheme`; "light"/"dark" pin it.
+// Icons are 1.6-weight strokes to match the sidebar nav glyphs.
+const OPTIONS: { value: Theme; label: string; icon: ReactNode }[] = [
+  {
+    value: "system",
+    label: "System theme",
+    icon: (
+      <>
+        <rect x="3" y="4" width="18" height="12" rx="2" />
+        <path d="M8 20h8M12 16v4" />
+      </>
+    ),
+  },
+  {
+    value: "light",
+    label: "Light theme",
+    icon: (
+      <>
+        <circle cx="12" cy="12" r="4" />
+        <path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" />
+      </>
+    ),
+  },
+  {
+    value: "dark",
+    label: "Dark theme",
+    icon: <path d="M21 12.8A9 9 0 1111.2 3a7 7 0 009.8 9.8z" />,
+  },
+];
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Color theme"
+      className="flex items-center gap-0.5 p-0.5"
+      style={{
+        border: "1px solid var(--border-sub)",
+        borderRadius: "var(--r-md)",
+      }}
+    >
+      {OPTIONS.map((opt) => {
+        const active = theme === opt.value;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            aria-label={opt.label}
+            title={opt.label}
+            onClick={() => setTheme(opt.value)}
+            className="flex-1 flex items-center justify-center py-1.5 transition"
+            style={{
+              borderRadius: "calc(var(--r-md) - 2px)",
+              color: active ? "var(--fg)" : "var(--fg-muted)",
+              background: active ? "var(--bg-elev)" : "transparent",
+              boxShadow: active ? "inset 0 0 0 1px var(--border)" : "none",
+            }}
+          >
+            <svg
+              width="15"
+              height="15"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden
+            >
+              {opt.icon}
+            </svg>
+          </button>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## What

Adds a UI control for the theme. The web app already had a fully-wired `ThemeProvider` (light/dark/system, `.dark` class on `<html>`, persisted to `localStorage`, live-follows OS `prefers-color-scheme`) but **no button** to drive it. This adds one.

## Changes

- **`ThemeToggle.tsx`** (new) — three-way segmented control (System / Light / Dark) calling `useTheme().setTheme(...)`. Rendered as an accessible `radiogroup` (`role="radio"`, `aria-checked`, `aria-label`, tooltips), styled with the existing Loft design tokens and 1.6-weight SVG icons to match the sidebar nav glyphs.
- **`Sidebar.tsx`** — mounts the toggle in the bottom section, below "Send feedback" and above the user card. The Sidebar is reused for both the desktop rail and the mobile slide-in sheet, so the toggle appears in both.

## Behavior

- **Light / Dark** pin the theme; **System** follows the OS and live-updates on OS switches.
- Choice persists in `localStorage` and syncs across tabs (existing provider wiring).

## Scope note

This lives in the authenticated app shell (`(app)` layout). Marketing/docs/blog pages don't render the Sidebar, so they still honor the stored preference but have no control of their own — can add one to those headers in a follow-up if wanted.

## Verification

- `tsc --noEmit` — clean
- `eslint` on both files — clean
- `Sidebar.test.tsx` — 10/10 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)