### PR TITLE
feat(web): render inbound + outbound email bodies as HTML

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1042,6 +1042,8 @@ components:
     MessageParsedView:
       additionalProperties: false
       properties:
+        html:
+          type: string
         text:
           type: string
         truncated:

--- a/internal/httpapi/messages.go
+++ b/internal/httpapi/messages.go
@@ -75,11 +75,12 @@ type MessageView struct {
 	// outbound messages, which carry no verdict.
 	Auth       *AuthVerdict `json:"auth,omitempty"`
 	RawMessage []byte       `json:"raw_message"`
-	// Parsed is the injection-reduced view (decision 9 / Slice 4b-3): the raw
-	// message rendered to text with quoted reply/forward chains stripped and a
-	// length cap, for the agent to feed a model by default. Inbound-only; a
-	// CONVENIENCE — `raw_message` is always present and the security decision is
-	// made on `auth` + provenance, never on this stripped text.
+	// Parsed is the derived view (decision 9 / Slice 4b-3): the raw message
+	// rendered to text (`text`, quoted chains stripped + length-capped, for the
+	// agent to feed a model by default) plus the decoded HTML part (`html`, for
+	// display). Present on any message carrying raw MIME — inbound and sent
+	// outbound. A CONVENIENCE — `raw_message` is always present and the security
+	// decision is made on `auth` + provenance, never on this derived body.
 	Parsed *MessageParsedView `json:"parsed,omitempty"`
 	// Body is the mutable draft body for a held outbound message
 	// (status=pending_review), which has no raw_message yet. This is the
@@ -106,8 +107,17 @@ type AttachmentMetaView struct {
 
 // MessageParsedView is the parsed-body payload (see MessageView.Parsed).
 type MessageParsedView struct {
-	Text      string `json:"text"`
-	Truncated bool   `json:"truncated"`
+	// Text is the injection-reduced plain body: text/plain preferred (else
+	// HTML→text), quoted reply/forward chains stripped, length-capped. This is
+	// what an agent feeds a model by default.
+	Text string `json:"text"`
+	// Truncated is true when the length cap cut `text`.
+	Truncated bool `json:"truncated"`
+	// HTML is the decoded text/html part for display, present only when the
+	// message carries an HTML part. Full fidelity (NOT quote-stripped, unlike
+	// `text`) — render it sanitized/sandboxed; it is untrusted sender content.
+	// Omitted for text-only messages; `raw_message` stays the canonical copy.
+	HTML string `json:"html,omitempty"`
 }
 
 // MessageBodyView is the held-draft body (see MessageView.Body).
@@ -157,10 +167,13 @@ func messageViewFromIdentity(m *identity.Message) MessageView {
 		// view; on inbound rows `status` is not the HITL value (review F1).
 		v.HITLStatus = m.Status
 	}
-	// Parsed view (decision 9): inbound-only, derived from the raw message.
-	if m.Direction == "inbound" && len(m.RawMessage) > 0 {
-		text, truncated := mailparse.ParsedBody(m.RawMessage, mailparse.DefaultMaxBytes)
-		v.Parsed = &MessageParsedView{Text: text, Truncated: truncated}
+	// Parsed view (decision 9): derived from the raw message — any direction
+	// that carries one (inbound + sent outbound, whose draft body columns were
+	// scrubbed in favor of the sent MIME). Held outbound drafts have no
+	// raw_message and surface their body via `body` below instead.
+	if len(m.RawMessage) > 0 {
+		pv := mailparse.Parse(m.RawMessage, mailparse.DefaultMaxBytes)
+		v.Parsed = &MessageParsedView{Text: pv.Text, Truncated: pv.Truncated, HTML: pv.HTML}
 	}
 	// Attachment metadata (§6a #5): parsed from raw_message for ANY direction
 	// that has one (inbound + sent outbound). Always an array; the bytes are

--- a/internal/httpapi/messages_parsed_test.go
+++ b/internal/httpapi/messages_parsed_test.go
@@ -6,7 +6,8 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/identity"
 )
 
-// Inbound messages get a parsed view (quoted reply stripped); outbound don't.
+// Any message carrying raw MIME gets a parsed view (quoted reply stripped) —
+// inbound and sent outbound alike. Held drafts (no raw) don't.
 func TestMessageViewParsed(t *testing.T) {
 	raw := []byte("From: a@x.com\r\nContent-Type: text/plain\r\n\r\nMy reply.\r\n\r\n" +
 		"On Mon, Bob <b@y.com> wrote:\r\n> quoted original\r\n")
@@ -21,17 +22,45 @@ func TestMessageViewParsed(t *testing.T) {
 		t.Fatalf("parsed.text = %q, want quoted-stripped %q", in.Parsed.Text, "My reply.")
 	}
 
+	// Sent outbound carries raw MIME (draft body columns are scrubbed at send),
+	// so it now gets the same parsed view — fixing the empty-body thread render.
 	out := messageViewFromIdentity(&identity.Message{
 		ID: "msg_2", Direction: "outbound", RawMessage: raw,
 	})
-	if out.Parsed != nil {
-		t.Fatalf("outbound message must not carry a parsed view, got %+v", out.Parsed)
+	if out.Parsed == nil {
+		t.Fatal("sent outbound (with raw MIME) should have a parsed view")
+	}
+	if out.Parsed.Text != "My reply." {
+		t.Fatalf("outbound parsed.text = %q, want %q", out.Parsed.Text, "My reply.")
 	}
 
-	// Inbound with no raw → no parsed view (nothing to parse).
+	// Messages with no raw → no parsed view (nothing to parse).
 	none := messageViewFromIdentity(&identity.Message{ID: "msg_3", Direction: "inbound"})
 	if none.Parsed != nil {
-		t.Fatal("inbound with empty raw should have no parsed view")
+		t.Fatal("message with empty raw should have no parsed view")
+	}
+}
+
+// parsed.html carries the decoded text/html part for display; text-only
+// messages omit it.
+func TestMessageViewParsedHTML(t *testing.T) {
+	htmlRaw := []byte("From: a@x.com\r\nContent-Type: multipart/alternative; boundary=B\r\n\r\n" +
+		"--B\r\nContent-Type: text/plain\r\n\r\nplain body\r\n" +
+		"--B\r\nContent-Type: text/html\r\n\r\n<div>rich <b>body</b></div>\r\n--B--\r\n")
+	v := messageViewFromIdentity(&identity.Message{
+		ID: "msg_h", Direction: "inbound", Sender: "a@x.com", RawMessage: htmlRaw,
+	})
+	if v.Parsed == nil || v.Parsed.HTML != "<div>rich <b>body</b></div>" {
+		t.Fatalf("parsed.html = %+v, want decoded HTML part", v.Parsed)
+	}
+
+	// Text-only message: html omitted (empty).
+	textOnly := messageViewFromIdentity(&identity.Message{
+		ID: "msg_t", Direction: "inbound", Sender: "a@x.com",
+		RawMessage: []byte("From: a@x.com\r\nContent-Type: text/plain\r\n\r\njust text"),
+	})
+	if textOnly.Parsed == nil || textOnly.Parsed.HTML != "" {
+		t.Fatalf("text-only parsed.html should be empty, got %+v", textOnly.Parsed)
 	}
 }
 

--- a/internal/mailparse/parse.go
+++ b/internal/mailparse/parse.go
@@ -1,8 +1,9 @@
-// Package mailparse produces the injection-reduced "parsed view" of an inbound
-// email (decision 9 / Slice 4b-3): the text an agent feeds to a model by
-// default, derived server-side from the raw RFC 5322 message — prefer the
-// text/plain part (else HTML→text), strip quoted reply chains / forwarded
-// headers, and cap the length (a token-stuffing guard).
+// Package mailparse produces the "parsed view" of a raw RFC 5322 message —
+// inbound mail and the retained copy of sent outbound mail (decision 9 / Slice
+// 4b-3). It derives two representations server-side: the injection-reduced text
+// an agent feeds to a model by default (prefer the text/plain part, else
+// HTML→text, strip quoted reply chains / forwarded headers, cap the length as a
+// token-stuffing guard), and the decoded text/html part for human display.
 //
 // It is a CONVENIENCE, not a security control: the raw message is always
 // available, and the security decision is made on structured metadata (the
@@ -144,6 +145,13 @@ func walkParts(contentType, cte string, body io.Reader, depth int) (plain, htmlT
 			part, err := mr.NextPart()
 			if err != nil {
 				break
+			}
+			// Skip parts the sender flagged as attachments — they're files
+			// (fetched via the attachment endpoint), not the displayable body.
+			// Without this an attached .html file would surface as parsed.html.
+			if disp, _, derr := mime.ParseMediaType(part.Header.Get("Content-Disposition")); derr == nil && disp == "attachment" {
+				part.Close()
+				continue
 			}
 			p, h, hr := walkParts(part.Header.Get("Content-Type"), part.Header.Get("Content-Transfer-Encoding"), part, depth+1)
 			if plain == "" && p != "" {

--- a/internal/mailparse/parse.go
+++ b/internal/mailparse/parse.go
@@ -30,6 +30,13 @@ import (
 // small enough to blunt token-stuffing. Callers may override.
 const DefaultMaxBytes = 16 * 1024
 
+// MaxHTMLBytes caps the display HTML (ParsedView.HTML). Unlike the text view —
+// which is capped tight as a token-stuffing guard for model input — the HTML is
+// for human display, so the bound is generous: just a backstop against a
+// pathological multi-MB part bloating every detail response. raw_message stays
+// the full-fidelity escape hatch.
+const MaxHTMLBytes = 1 << 20 // 1 MiB
+
 // maxMIMEDepth bounds multipart-nesting recursion. mime/multipart re-scans
 // buffered data at each level, so an attacker-nested message is O(depth²) — a
 // ~2MB email (under the 10MB inbound cap) could otherwise pin a request
@@ -38,65 +45,99 @@ const DefaultMaxBytes = 16 * 1024
 // (empty), consistent with the package's "over-stripping is acceptable" stance.
 const maxMIMEDepth = 32
 
-// ParsedBody extracts the best human-readable text from a raw RFC 5322 message,
-// strips quoted reply/forward chains, and truncates to maxBytes. truncated is
-// true when the cap cut content. maxBytes <= 0 uses DefaultMaxBytes.
-func ParsedBody(raw []byte, maxBytes int) (text string, truncated bool) {
+// ParsedView is the derived view of a raw RFC 5322 message: the
+// injection-reduced Text an agent feeds a model by default, plus the decoded
+// HTML part for human display.
+type ParsedView struct {
+	// Text is the injection-reduced plain text: text/plain preferred (else
+	// HTML→text), quoted reply/forward chains stripped, capped at maxBytes.
+	Text string
+	// Truncated is true when the cap cut Text.
+	Truncated bool
+	// HTML is the decoded text/html part for display, or "" when the message
+	// carries no HTML part. Full fidelity (NOT quote-stripped, unlike Text) and
+	// capped at MaxHTMLBytes; raw_message stays the canonical copy.
+	HTML string
+}
+
+// Parse extracts the derived view from a raw RFC 5322 message in a single MIME
+// walk. maxBytes <= 0 uses DefaultMaxBytes (applies to Text only). Best-effort:
+// a parse failure yields the best content available, never an error.
+func Parse(raw []byte, maxBytes int) ParsedView {
 	if maxBytes <= 0 {
 		maxBytes = DefaultMaxBytes
 	}
-	body := extractText(raw)
-	body = stripQuotedReplies(body)
-	body = normalizeWhitespace(body)
-	if len(body) > maxBytes {
-		// Truncate on a rune boundary.
-		cut := maxBytes
-		for cut > 0 && !utf8RuneStart(body[cut]) {
-			cut--
-		}
-		return strings.TrimSpace(body[:cut]), true
+	bestText, htmlRaw := extractText(raw)
+	text := normalizeWhitespace(stripQuotedReplies(bestText))
+	truncated := false
+	if len(text) > maxBytes {
+		text = strings.TrimSpace(text[:runeBoundary(text, maxBytes)])
+		truncated = true
 	}
-	return body, false
+	html := htmlRaw
+	if len(html) > MaxHTMLBytes {
+		html = html[:runeBoundary(html, MaxHTMLBytes)]
+	}
+	return ParsedView{Text: text, Truncated: truncated, HTML: html}
+}
+
+// ParsedBody extracts the injection-reduced text (see ParsedView.Text).
+// truncated is true when the cap cut content. maxBytes <= 0 uses DefaultMaxBytes.
+// Retained for callers that only need the text; callers wanting HTML use Parse.
+func ParsedBody(raw []byte, maxBytes int) (text string, truncated bool) {
+	v := Parse(raw, maxBytes)
+	return v.Text, v.Truncated
+}
+
+// runeBoundary returns the largest index <= n that doesn't split a UTF-8 rune,
+// so truncating at it never yields an invalid encoding.
+func runeBoundary(s string, n int) int {
+	for n > 0 && !utf8RuneStart(s[n]) {
+		n--
+	}
+	return n
 }
 
 func utf8RuneStart(b byte) bool { return b&0xC0 != 0x80 }
 
-// extractText walks the MIME tree and returns the best text representation:
+// extractText walks the MIME tree and returns the best text representation —
 // the first text/plain part, or (failing that) the first text/html rendered to
-// text. Falls back to the raw body if MIME parsing fails.
-func extractText(raw []byte) string {
+// text — together with the first text/html part decoded but NOT rendered to
+// text (htmlRaw, for display). Falls back to the raw body if MIME parsing fails.
+func extractText(raw []byte) (text, htmlRaw string) {
 	msg, err := mail.ReadMessage(bytes.NewReader(raw))
 	if err != nil {
-		return string(raw)
+		return string(raw), ""
 	}
-	plain, htmlText := walkParts(msg.Header.Get("Content-Type"), msg.Header.Get("Content-Transfer-Encoding"), msg.Body, 0)
+	plain, htmlText, htmlRaw := walkParts(msg.Header.Get("Content-Type"), msg.Header.Get("Content-Transfer-Encoding"), msg.Body, 0)
 	if plain != "" {
-		return plain
+		return plain, htmlRaw
 	}
 	if htmlText != "" {
-		return htmlText
+		return htmlText, htmlRaw
 	}
 	// No recognized text part — return the decoded top-level body.
 	b, _ := io.ReadAll(msg.Body)
-	return string(b)
+	return string(b), htmlRaw
 }
 
-// walkParts returns the first text/plain and first text/html-as-text found
-// anywhere in the (possibly nested multipart) body.
-func walkParts(contentType, cte string, body io.Reader, depth int) (plain, htmlText string) {
+// walkParts returns the first text/plain, the first text/html rendered to text,
+// and the first text/html decoded as-is (htmlRaw) found anywhere in the
+// (possibly nested multipart) body.
+func walkParts(contentType, cte string, body io.Reader, depth int) (plain, htmlText, htmlRaw string) {
 	mediaType, params, err := mime.ParseMediaType(contentType)
 	if err != nil {
 		// No/!invalid Content-Type → treat as text/plain.
-		return decode(body, cte), ""
+		return decode(body, cte), "", ""
 	}
 	switch {
 	case strings.HasPrefix(mediaType, "multipart/"):
 		if depth >= maxMIMEDepth {
-			return "", "" // bail on pathological nesting (see maxMIMEDepth)
+			return "", "", "" // bail on pathological nesting (see maxMIMEDepth)
 		}
 		boundary := params["boundary"]
 		if boundary == "" {
-			return "", ""
+			return "", "", ""
 		}
 		mr := multipart.NewReader(body, boundary)
 		for {
@@ -104,25 +145,33 @@ func walkParts(contentType, cte string, body io.Reader, depth int) (plain, htmlT
 			if err != nil {
 				break
 			}
-			p, h := walkParts(part.Header.Get("Content-Type"), part.Header.Get("Content-Transfer-Encoding"), part, depth+1)
+			p, h, hr := walkParts(part.Header.Get("Content-Type"), part.Header.Get("Content-Transfer-Encoding"), part, depth+1)
 			if plain == "" && p != "" {
 				plain = p
 			}
 			if htmlText == "" && h != "" {
 				htmlText = h
 			}
+			if htmlRaw == "" && hr != "" {
+				htmlRaw = hr
+			}
 			part.Close()
-			if plain != "" {
-				break // text/plain is preferred; stop early
+			// Stop once both representations are in hand. Unlike the old
+			// text-only walk we can't stop at text/plain alone — the text/html
+			// sibling (typically later in a multipart/alternative) is the
+			// display body we still need.
+			if plain != "" && htmlRaw != "" {
+				break
 			}
 		}
-		return plain, htmlText
+		return plain, htmlText, htmlRaw
 	case mediaType == "text/plain":
-		return decode(body, cte), ""
+		return decode(body, cte), "", ""
 	case mediaType == "text/html":
-		return "", htmlToText(decode(body, cte))
+		decoded := decode(body, cte)
+		return "", htmlToText(decoded), decoded
 	default:
-		return "", ""
+		return "", "", ""
 	}
 }
 

--- a/internal/mailparse/parse_test.go
+++ b/internal/mailparse/parse_test.go
@@ -161,6 +161,34 @@ func TestParseHTML(t *testing.T) {
 		}
 	})
 
+	t.Run("attached .html file is not surfaced as the display body", func(t *testing.T) {
+		// multipart/mixed: a text/plain body + a text/html ATTACHMENT. The
+		// attachment must not become parsed.html (it's a file, not the body).
+		raw := "From: a@x.com\r\nContent-Type: multipart/mixed; boundary=M\r\n\r\n" +
+			"--M\r\nContent-Type: text/plain\r\n\r\nThe real body.\r\n" +
+			"--M\r\nContent-Type: text/html\r\nContent-Disposition: attachment; filename=report.html\r\n\r\n" +
+			"<h1>Attached report</h1>\r\n--M--\r\n"
+		v := Parse([]byte(raw), 0)
+		if v.Text != "The real body." {
+			t.Fatalf("text: got %q, want the plain body", v.Text)
+		}
+		if v.HTML != "" {
+			t.Fatalf("html attachment must not surface as display body, got %q", v.HTML)
+		}
+	})
+
+	t.Run("inline text/html sibling of an attachment still wins", func(t *testing.T) {
+		// multipart/mixed: text/html body (no disposition) + a non-HTML
+		// attachment. The body HTML must still be selected.
+		raw := "From: a@x.com\r\nContent-Type: multipart/mixed; boundary=M\r\n\r\n" +
+			"--M\r\nContent-Type: text/html\r\n\r\n<p>Body here</p>\r\n" +
+			"--M\r\nContent-Type: application/pdf\r\nContent-Disposition: attachment; filename=x.pdf\r\n\r\n%PDF-1.4\r\n--M--\r\n"
+		v := Parse([]byte(raw), 0)
+		if v.HTML != "<p>Body here</p>" {
+			t.Fatalf("html body: got %q", v.HTML)
+		}
+	})
+
 	t.Run("HTML capped at MaxHTMLBytes", func(t *testing.T) {
 		body := "<p>" + strings.Repeat("a", MaxHTMLBytes+1000) + "</p>"
 		raw := "From: a@x.com\r\nContent-Type: text/html\r\n\r\n" + body

--- a/internal/mailparse/parse_test.go
+++ b/internal/mailparse/parse_test.go
@@ -117,3 +117,56 @@ func TestBase64Decoded(t *testing.T) {
 		t.Fatalf("base64 decode: got %q", got)
 	}
 }
+
+func TestParseHTML(t *testing.T) {
+	t.Run("text/html part surfaces decoded HTML, text flattened", func(t *testing.T) {
+		raw := "From: a@x.com\r\nContent-Type: text/html\r\n\r\n<div>Hello<br><b>World</b></div>"
+		v := Parse([]byte(raw), 0)
+		if v.HTML != "<div>Hello<br><b>World</b></div>" {
+			t.Fatalf("HTML not preserved verbatim, got %q", v.HTML)
+		}
+		// Text view stays the flattened, tag-free representation.
+		if strings.Contains(v.Text, "<") || !strings.Contains(v.Text, "World") {
+			t.Fatalf("text should be flattened, got %q", v.Text)
+		}
+	})
+
+	t.Run("multipart/alternative: text from plain, html from html part", func(t *testing.T) {
+		raw := "From: a@x.com\r\nContent-Type: multipart/alternative; boundary=B\r\n\r\n" +
+			"--B\r\nContent-Type: text/plain\r\n\r\nPlain version.\r\n" +
+			"--B\r\nContent-Type: text/html\r\n\r\n<p>HTML <i>version</i></p>\r\n--B--\r\n"
+		v := Parse([]byte(raw), 0)
+		if v.Text != "Plain version." {
+			t.Fatalf("text: got %q, want plain part", v.Text)
+		}
+		if v.HTML != "<p>HTML <i>version</i></p>" {
+			t.Fatalf("html: got %q", v.HTML)
+		}
+	})
+
+	t.Run("quoted-printable HTML decoded", func(t *testing.T) {
+		// Mirrors the screenshot bug: soft-break '=' and entity must decode.
+		raw := "From: a@x.com\r\nContent-Type: text/html\r\nContent-Transfer-Encoding: quoted-printable\r\n\r\n<div>Caf=C3=A9 =\r\ntime</div>"
+		v := Parse([]byte(raw), 0)
+		if v.HTML != "<div>Café time</div>" {
+			t.Fatalf("QP HTML decode: got %q", v.HTML)
+		}
+	})
+
+	t.Run("plain-text-only message has no HTML", func(t *testing.T) {
+		raw := "From: a@x.com\r\nContent-Type: text/plain\r\n\r\nJust text.\r\n"
+		v := Parse([]byte(raw), 0)
+		if v.HTML != "" {
+			t.Fatalf("expected empty HTML for text-only message, got %q", v.HTML)
+		}
+	})
+
+	t.Run("HTML capped at MaxHTMLBytes", func(t *testing.T) {
+		body := "<p>" + strings.Repeat("a", MaxHTMLBytes+1000) + "</p>"
+		raw := "From: a@x.com\r\nContent-Type: text/html\r\n\r\n" + body
+		v := Parse([]byte(raw), 0)
+		if len(v.HTML) > MaxHTMLBytes {
+			t.Fatalf("HTML not capped: len=%d", len(v.HTML))
+		}
+	})
+}

--- a/sdks/python/src/e2a/v1/generated/models/message_parsed_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/message_parsed_view.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 from pydantic import BaseModel, ConfigDict, StrictBool, StrictStr
-from typing import Any, ClassVar, Dict, List
+from typing import Any, ClassVar, Dict, List, Optional
 from typing import Optional, Set
 from typing_extensions import Self
 
@@ -26,9 +26,10 @@ class MessageParsedView(BaseModel):
     """
     MessageParsedView
     """ # noqa: E501
+    html: Optional[StrictStr] = None
     text: StrictStr
     truncated: StrictBool
-    __properties: ClassVar[List[str]] = ["text", "truncated"]
+    __properties: ClassVar[List[str]] = ["html", "text", "truncated"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -81,6 +82,7 @@ class MessageParsedView(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
+            "html": obj.get("html"),
             "text": obj.get("text"),
             "truncated": obj.get("truncated")
         })

--- a/sdks/typescript/src/v1/generated/models/MessageParsedView.ts
+++ b/sdks/typescript/src/v1/generated/models/MessageParsedView.ts
@@ -13,6 +13,7 @@
 import { HttpFile } from '../http/http.js';
 
 export class MessageParsedView {
+    'html'?: string;
     'text': string;
     'truncated': boolean;
 
@@ -21,6 +22,12 @@ export class MessageParsedView {
     static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
+        {
+            "name": "html",
+            "baseName": "html",
+            "type": "string",
+            "format": ""
+        },
         {
             "name": "text",
             "baseName": "text",

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "dompurify": "^3.4.11",
         "next": "^16.2.9",
         "react": "19.2.7",
         "react-dom": "19.2.7",
@@ -2252,9 +2253,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2270,9 +2268,6 @@
       "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2290,9 +2285,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2308,9 +2300,6 @@
       "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2601,9 +2590,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2621,9 +2607,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2641,9 +2624,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2661,9 +2641,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3185,6 +3162,13 @@
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/unist": {
       "version": "3.0.3",
@@ -4975,6 +4959,15 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -8798,9 +8791,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8822,9 +8812,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8846,9 +8833,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8870,9 +8854,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "dompurify": "^3.4.11",
     "next": "^16.2.9",
     "react": "19.2.7",
     "react-dom": "19.2.7",

--- a/web/public/openapi.yaml
+++ b/web/public/openapi.yaml
@@ -1042,6 +1042,8 @@ components:
     MessageParsedView:
       additionalProperties: false
       properties:
+        html:
+          type: string
         text:
           type: string
         truncated:

--- a/web/src/app/(app)/inboxes/(view)/messages/view/page.test.tsx
+++ b/web/src/app/(app)/inboxes/(view)/messages/view/page.test.tsx
@@ -207,6 +207,54 @@ describe("AgentMessageFocusPage", () => {
     expect(screen.getByText(/Attached is the renewal contract/)).toBeInTheDocument();
   });
 
+  it("prefers the backend-parsed text over the raw MIME body for inbound", async () => {
+    // Regression (#294): inbound rows carry the clean body in `parsed.text`
+    // (text/plain or HTML→text, quoted-printable decoded). The bug rendered the
+    // raw MIME body instead — showing literal <div>/<br> markup and `=` QP
+    // soft-breaks.
+    setSearchParams({ email: "support@acme.io", id: "msg_in2", direction: "inbound" });
+    mockDetail({
+      ...INBOUND_DETAIL,
+      message_id: "msg_in2",
+      parsed: { text: "Decoded body via parsed.text" },
+      raw_message: btoa(
+        "Content-Type: text/html\r\n" +
+          "Content-Transfer-Encoding: quoted-printable\r\n\r\n" +
+          "<div>Raw MIME body should not show<br>=</div>",
+      ),
+    });
+
+    render(<AgentMessageFocusPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("message-focus")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Decoded body via parsed\.text/)).toBeInTheDocument();
+    expect(screen.queryByText(/Raw MIME body should not show/)).not.toBeInTheDocument();
+  });
+
+  it("renders an HTML inbound body in a sandboxed iframe, not as raw markup", async () => {
+    // parsed.html carries the decoded text/html part; the body card renders it
+    // sanitized inside a sandboxed <iframe>, never as escaped <div>/<br> text.
+    setSearchParams({ email: "support@acme.io", id: "msg_in3", direction: "inbound" });
+    mockDetail({
+      ...INBOUND_DETAIL,
+      message_id: "msg_in3",
+      parsed: { text: "Hello there", html: "<div>Hello <b>there</b></div>" },
+    });
+
+    render(<AgentMessageFocusPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("message-focus")).toBeInTheDocument();
+    });
+    const frame = screen.getByTitle("Email body") as HTMLIFrameElement;
+    expect(frame.getAttribute("sandbox")).toBe("allow-same-origin allow-popups");
+    expect(frame.srcdoc).toContain("Hello <b>there</b>");
+    // No literal markup leaked into the page as text.
+    expect(screen.queryByText(/<div>Hello/)).not.toBeInTheDocument();
+  });
+
   // Regression: GET /agents/{email}/messages/{id} flips inbox_status
   // unread → read as a server-side side effect. The focus page must
   // invalidate the per-agent inbox SWR cache when that happens, or

--- a/web/src/app/(app)/inboxes/(view)/messages/view/page.tsx
+++ b/web/src/app/(app)/inboxes/(view)/messages/view/page.tsx
@@ -31,6 +31,7 @@ import { Dot } from "../../../../../components/loft/Dot";
 import { Eyebrow } from "../../../../../components/loft/Eyebrow";
 import { InkConsole, type InkLine } from "../../../../../components/loft/InkConsole";
 import { Collapsible } from "../../../../../components/messages/Collapsible";
+import { EmailHtmlBody } from "../../../../../components/messages/EmailHtmlBody";
 import { MessageDirectionIcon } from "../../../../../components/messages/MessageDirectionIcon";
 import {
   MessageLifecycleTimeline,
@@ -572,7 +573,16 @@ function BodyCard({
 }) {
   const bodyText = useMemo(() => {
     if (msg.direction === "outbound") return msg.data.body_text ?? "";
-    return decodeInboundBody(msg.data.raw_message);
+    // Prefer the backend-parsed text (QP/base64 decoded, HTML→text); the raw
+    // decode is a last-resort fallback that shows MIME framing.
+    return msg.data.parsed?.text || decodeInboundBody(msg.data.raw_message);
+  }, [msg]);
+  // Rich HTML body, when the message carries one — rendered sanitized in a
+  // sandboxed iframe. Outbound drafts/sends use body_html; inbound uses
+  // parsed.html (the decoded text/html part).
+  const bodyHtml = useMemo(() => {
+    if (msg.direction === "outbound") return msg.data.body_html ?? "";
+    return msg.data.parsed?.html ?? "";
   }, [msg]);
 
   const isOutbound = msg.direction === "outbound";
@@ -618,13 +628,15 @@ function BodyCard({
             fontSize: 14,
             lineHeight: 1.65,
             color: "var(--fg)",
-            whiteSpace: "pre-wrap",
+            whiteSpace: bodyHtml.trim() !== "" ? "normal" : "pre-wrap",
           }}
         >
           {isTerminal ? (
             <span style={{ color: "var(--fg-muted)", fontStyle: "italic" }}>
               Body no longer available (scrubbed after delivery).
             </span>
+          ) : bodyHtml.trim() !== "" ? (
+            <EmailHtmlBody html={bodyHtml} />
           ) : (
             bodyText || (
               <span style={{ color: "var(--fg-muted)", fontStyle: "italic" }}>

--- a/web/src/app/components/messages/EmailHtmlBody.test.tsx
+++ b/web/src/app/components/messages/EmailHtmlBody.test.tsx
@@ -1,0 +1,89 @@
+// EmailHtmlBody renders UNTRUSTED inbound email HTML. These tests pin the two
+// security controls — DOMPurify sanitization and the iframe CSP / remote-image
+// blocking — plus the "Load images" opt-in, since a silent regression in any of
+// them reintroduces XSS or tracking-pixel leakage.
+
+import { render, screen, fireEvent } from "@testing-library/react";
+import { EmailHtmlBody } from "./EmailHtmlBody";
+
+function srcdocOf(): string {
+  const frame = screen.getByTitle("Email body") as HTMLIFrameElement;
+  return frame.getAttribute("srcdoc") ?? "";
+}
+
+describe("EmailHtmlBody", () => {
+  it("strips scripts, event handlers, and javascript: URLs", () => {
+    render(
+      <EmailHtmlBody
+        html={
+          '<div>ok <b>bold</b>' +
+          '<script>window.pwned=1</script>' +
+          '<img src="x" onerror="alert(1)">' +
+          '<a href="javascript:alert(1)">x</a>' +
+          "<iframe src=\"http://evil\"></iframe></div>"
+        }
+      />,
+    );
+    const doc = srcdocOf();
+    expect(doc).toContain("<b>bold</b>"); // benign markup survives
+    expect(doc).not.toContain("<script");
+    expect(doc).not.toContain("onerror");
+    expect(doc).not.toContain("javascript:");
+    expect(doc).not.toContain("<iframe");
+  });
+
+  it("renders the iframe sandboxed with no script execution", () => {
+    render(<EmailHtmlBody html="<p>hi</p>" />);
+    const frame = screen.getByTitle("Email body") as HTMLIFrameElement;
+    expect(frame.getAttribute("sandbox")).toBe("allow-same-origin allow-popups");
+    expect(frame.getAttribute("sandbox")).not.toContain("allow-scripts");
+  });
+
+  it("injects a restrictive CSP that blocks remote fetches when images are off", () => {
+    render(<EmailHtmlBody html="<p>hi</p>" />);
+    const doc = srcdocOf();
+    expect(doc).toContain("Content-Security-Policy");
+    expect(doc).toContain("default-src 'none'");
+    // images blocked => only data: images, never http/https
+    expect(doc).toMatch(/img-src data:/);
+    expect(doc).not.toMatch(/img-src[^;"]*https?:/);
+  });
+
+  it("blocks a remote tracking image by default and shows the banner", () => {
+    render(<EmailHtmlBody html={'<img src="http://track.example.com/p.gif">'} />);
+    const doc = srcdocOf();
+    expect(doc).not.toContain("track.example.com");
+    expect(screen.getByText(/Remote images blocked/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Load images/i })).toBeInTheDocument();
+  });
+
+  it("blocks non-<img> remote vectors (td background, video poster) too", () => {
+    render(
+      <EmailHtmlBody
+        html={
+          '<table><tr><td background="http://evil/bg.png">x</td></tr></table>' +
+          '<video poster="http://evil/poster.png"></video>'
+        }
+      />,
+    );
+    const doc = srcdocOf();
+    expect(doc).not.toContain("evil/bg.png");
+    expect(doc).not.toContain("evil/poster.png");
+    // and the banner fires (blockedRemote was set), no false reassurance
+    expect(screen.getByText(/Remote images blocked/i)).toBeInTheDocument();
+  });
+
+  it("loads images after the user opts in", () => {
+    render(<EmailHtmlBody html={'<img src="http://track.example.com/p.gif">'} />);
+    fireEvent.click(screen.getByRole("button", { name: /Load images/i }));
+    const doc = srcdocOf();
+    expect(doc).toContain("track.example.com"); // src restored
+    expect(doc).toMatch(/img-src[^;"]*https?:/); // CSP now permits remote images
+    expect(screen.queryByText(/Remote images blocked/i)).not.toBeInTheDocument();
+  });
+
+  it("shows no banner when there is nothing remote to block", () => {
+    render(<EmailHtmlBody html="<p>just <b>text</b></p>" />);
+    expect(screen.queryByText(/Remote images blocked/i)).not.toBeInTheDocument();
+  });
+});

--- a/web/src/app/components/messages/EmailHtmlBody.tsx
+++ b/web/src/app/components/messages/EmailHtmlBody.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+// Renders an untrusted email HTML body safely. Two layers of defense:
+//   1. DOMPurify strips scripts, event handlers, and dangerous tags/attrs.
+//   2. The cleaned markup is rendered inside a sandboxed <iframe srcdoc> with
+//      NO allow-scripts — so even if something slipped past the sanitizer it
+//      cannot execute, touch cookies, or reach the dashboard DOM.
+// Remote images are blocked by default (tracking-pixel / read-receipt defense,
+// the Gmail convention) and loaded only when the user opts in.
+//
+// The iframe keeps `allow-same-origin` (so we can measure its content height to
+// auto-size) and `allow-popups` (so sanitized links can open in a new tab via
+// the injected `<base target="_blank">`). It deliberately omits allow-scripts
+// and allow-forms.
+
+import DOMPurify from "dompurify";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+// sanitizeEmail cleans the raw email HTML. When showImages is false it also
+// neutralizes remote image sources (img src/srcset and CSS url() backgrounds),
+// reporting whether anything was actually blocked so the caller can offer a
+// "Load images" affordance only when it matters.
+function sanitizeEmail(
+  html: string,
+  showImages: boolean,
+): { clean: string; blockedRemote: boolean } {
+  let blockedRemote = false;
+
+  DOMPurify.addHook("afterSanitizeAttributes", (node) => {
+    const el = node as Element;
+    // Force links to open in a new tab and drop the referrer/opener.
+    if (el.tagName === "A") {
+      el.setAttribute("target", "_blank");
+      el.setAttribute("rel", "noopener noreferrer nofollow");
+    }
+    if (!showImages) {
+      if (el.tagName === "IMG") {
+        if (el.getAttribute("src") || el.getAttribute("srcset")) {
+          blockedRemote = true;
+        }
+        el.removeAttribute("src");
+        el.removeAttribute("srcset");
+      }
+      const style = el.getAttribute?.("style");
+      if (style && /url\s*\(/i.test(style)) {
+        blockedRemote = true;
+        el.setAttribute("style", style.replace(/url\s*\([^)]*\)/gi, "none"));
+      }
+    }
+  });
+
+  const clean = DOMPurify.sanitize(html, {
+    USE_PROFILES: { html: true },
+    FORBID_TAGS: ["script", "iframe", "object", "embed", "form", "input", "button", "base"],
+    ADD_ATTR: ["target"],
+  });
+
+  DOMPurify.removeHook("afterSanitizeAttributes");
+  return { clean: String(clean), blockedRemote };
+}
+
+// wrapDocument builds the full srcdoc: a forced-light surface (email HTML
+// assumes a white background regardless of the dashboard theme), responsive
+// images, and a base target so links open in a new tab.
+function wrapDocument(innerHTML: string): string {
+  return (
+    "<!doctype html><html><head><meta charset=\"utf-8\">" +
+    "<meta name=\"referrer\" content=\"no-referrer\">" +
+    "<base target=\"_blank\">" +
+    "<style>" +
+    "html,body{margin:0;padding:0;}" +
+    "body{background:#fff;color:#1a1a1a;" +
+    "font:13.5px/1.6 -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;" +
+    "word-break:break-word;overflow-wrap:anywhere;}" +
+    "img{max-width:100%;height:auto;}" +
+    "table{max-width:100%;}" +
+    "a{color:#2563eb;}" +
+    "</style></head><body>" +
+    innerHTML +
+    "</body></html>"
+  );
+}
+
+export function EmailHtmlBody({ html }: { html: string }) {
+  const [showImages, setShowImages] = useState(false);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  const { clean, blockedRemote } = useMemo(
+    () => sanitizeEmail(html, showImages),
+    [html, showImages],
+  );
+  const srcDoc = useMemo(() => wrapDocument(clean), [clean]);
+
+  // Auto-size the iframe to its content. Needs allow-same-origin to read the
+  // content document; re-measures on reflow (e.g. late-loading images).
+  useEffect(() => {
+    const frame = iframeRef.current;
+    if (!frame) return;
+    let observer: ResizeObserver | undefined;
+    const fit = () => {
+      try {
+        const doc = frame.contentDocument;
+        if (doc?.documentElement) {
+          frame.style.height = `${doc.documentElement.scrollHeight}px`;
+        }
+      } catch {
+        /* cross-origin guard; ignore */
+      }
+    };
+    const onLoad = () => {
+      fit();
+      try {
+        const doc = frame.contentDocument;
+        if (doc?.documentElement && typeof ResizeObserver !== "undefined") {
+          observer = new ResizeObserver(fit);
+          observer.observe(doc.documentElement);
+        }
+      } catch {
+        /* ignore */
+      }
+    };
+    frame.addEventListener("load", onLoad);
+    fit();
+    return () => {
+      frame.removeEventListener("load", onLoad);
+      observer?.disconnect();
+    };
+  }, [srcDoc]);
+
+  return (
+    <div>
+      {blockedRemote && !showImages && (
+        <div
+          className="flex items-center"
+          style={{
+            gap: 10,
+            marginBottom: 10,
+            padding: "7px 11px",
+            fontSize: 12,
+            color: "var(--fg-muted)",
+            background: "var(--bg-elev)",
+            border: "1px solid var(--border-sub)",
+            borderRadius: "var(--r-sm)",
+          }}
+        >
+          <span>Remote images blocked to protect your privacy.</span>
+          <button
+            type="button"
+            onClick={() => setShowImages(true)}
+            style={{
+              color: "var(--accent-strong)",
+              background: "transparent",
+              border: "none",
+              padding: 0,
+              cursor: "pointer",
+              fontWeight: 600,
+            }}
+          >
+            Load images
+          </button>
+        </div>
+      )}
+      <iframe
+        ref={iframeRef}
+        title="Email body"
+        sandbox="allow-same-origin allow-popups"
+        srcDoc={srcDoc}
+        style={{
+          display: "block",
+          width: "100%",
+          border: "none",
+          background: "#fff",
+          borderRadius: "var(--r-sm)",
+        }}
+      />
+    </div>
+  );
+}

--- a/web/src/app/components/messages/EmailHtmlBody.tsx
+++ b/web/src/app/components/messages/EmailHtmlBody.tsx
@@ -34,12 +34,15 @@ function sanitizeEmail(
       el.setAttribute("rel", "noopener noreferrer nofollow");
     }
     if (!showImages) {
-      if (el.tagName === "IMG") {
-        if (el.getAttribute("src") || el.getAttribute("srcset")) {
+      // Strip every remote-resource carrier so the "Load images" banner is
+      // honest (blockedRemote reflects what was actually present). This is the
+      // belt; the CSP injected in wrapDocument is the authoritative block that
+      // also covers CSS-escaped url() and any vector missed here.
+      for (const attr of ["src", "srcset", "background", "poster"] as const) {
+        if (el.getAttribute?.(attr)) {
           blockedRemote = true;
+          el.removeAttribute(attr);
         }
-        el.removeAttribute("src");
-        el.removeAttribute("srcset");
       }
       const style = el.getAttribute?.("style");
       if (style && /url\s*\(/i.test(style)) {
@@ -62,9 +65,20 @@ function sanitizeEmail(
 // wrapDocument builds the full srcdoc: a forced-light surface (email HTML
 // assumes a white background regardless of the dashboard theme), responsive
 // images, and a base target so links open in a new tab.
-function wrapDocument(innerHTML: string): string {
+//
+// The Content-Security-Policy is the AUTHORITATIVE control, not the DOMPurify
+// hook: `default-src 'none'` blocks scripts/frames/objects/fetches outright,
+// and when images are blocked `img-src data:` (no http/https) defeats every
+// remote-resource vector at once — <img>, CSS url() (including CSS-escaped
+// forms), <td background>, <video poster>, <source srcset>, web fonts — so the
+// tracking-pixel block can't be bypassed by markup the hook didn't anticipate.
+function wrapDocument(innerHTML: string, showImages: boolean): string {
+  const csp = showImages
+    ? "default-src 'none'; img-src http: https: data:; media-src http: https: data:; style-src 'unsafe-inline'; font-src http: https: data:"
+    : "default-src 'none'; img-src data:; style-src 'unsafe-inline'; font-src data:";
   return (
     "<!doctype html><html><head><meta charset=\"utf-8\">" +
+    "<meta http-equiv=\"Content-Security-Policy\" content=\"" + csp + "\">" +
     "<meta name=\"referrer\" content=\"no-referrer\">" +
     "<base target=\"_blank\">" +
     "<style>" +
@@ -89,7 +103,7 @@ export function EmailHtmlBody({ html }: { html: string }) {
     () => sanitizeEmail(html, showImages),
     [html, showImages],
   );
-  const srcDoc = useMemo(() => wrapDocument(clean), [clean]);
+  const srcDoc = useMemo(() => wrapDocument(clean, showImages), [clean, showImages]);
 
   // Auto-size the iframe to its content. Needs allow-same-origin to read the
   // content document; re-measures on reflow (e.g. late-loading images).

--- a/web/src/app/components/messages/ThreadBubble.test.tsx
+++ b/web/src/app/components/messages/ThreadBubble.test.tsx
@@ -1,0 +1,59 @@
+// ThreadBubble body-selection precedence: a message's rich HTML (parsed.html)
+// is rendered in the sandboxed EmailHtmlBody iframe; otherwise the plain
+// parsed.text is shown as escaped text. Pins the fallback order so a regression
+// can't silently drop back to rendering raw MIME.
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { ThreadBubble } from "./ThreadBubble";
+import { getMessageDetail } from "../onboarding/api";
+import type { MessageSummary } from "../types";
+
+jest.mock("../onboarding/api", () => ({
+  getMessageDetail: jest.fn(),
+}));
+const mockGet = getMessageDetail as jest.MockedFunction<typeof getMessageDetail>;
+
+// Each test uses a distinct message_id: useSWR keys the body cache by id and
+// that cache is process-global, so reusing an id would leak one test's body
+// into the next.
+function msg(id: string): MessageSummary {
+  return {
+    message_id: id,
+    direction: "inbound",
+    from: "james@x.com",
+    to: ["support@acme.dev"],
+    recipient: "support@acme.dev",
+    subject: "Hi",
+    status: "",
+    created_at: new Date().toISOString(),
+  };
+}
+const CP = { email: "james@x.com", name: "James" };
+
+function inbound(data: Record<string, unknown>) {
+  mockGet.mockResolvedValue({ direction: "inbound", data } as never);
+}
+
+afterEach(() => mockGet.mockReset());
+
+describe("ThreadBubble body precedence", () => {
+  it("renders parsed.html in the sandboxed iframe when present", async () => {
+    inbound({ parsed: { text: "flat text", html: "<p>rich <b>html</b></p>" }, raw_message: "" });
+    render(<ThreadBubble message={msg("msg_html")} counterparty={CP} agentEmail="support@acme.dev" />);
+    await waitFor(() => {
+      const frame = screen.getByTitle("Email body") as HTMLIFrameElement;
+      expect(frame.getAttribute("srcdoc")).toContain("rich <b>html</b>");
+    });
+    // The flattened text is not also rendered as escaped page text.
+    expect(screen.queryByText("flat text")).not.toBeInTheDocument();
+  });
+
+  it("falls back to parsed.text (no iframe) when there is no HTML part", async () => {
+    inbound({ parsed: { text: "just the plain body" }, raw_message: "" });
+    render(<ThreadBubble message={msg("msg_text")} counterparty={CP} agentEmail="support@acme.dev" />);
+    await waitFor(() => {
+      expect(screen.getByText("just the plain body")).toBeInTheDocument();
+    });
+    expect(screen.queryByTitle("Email body")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/app/components/messages/ThreadBubble.tsx
+++ b/web/src/app/components/messages/ThreadBubble.tsx
@@ -12,8 +12,8 @@ import useSWR from "swr";
 import { Chip } from "../loft/Chip";
 import { Dot } from "../loft/Dot";
 import { CounterpartyAvatar } from "./CounterpartyAvatar";
+import { EmailHtmlBody } from "./EmailHtmlBody";
 import { getMessageDetail } from "../onboarding/api";
-import { formatRelativeAge } from "../../../lib/relativeTime";
 import type { MessageSummary } from "../types";
 import type { Counterparty } from "./threading";
 
@@ -76,15 +76,25 @@ export function ThreadBubble({
     () => getMessageDetail(agentEmail, message.message_id, message.direction),
   );
 
-  let body = "";
+  // Resolve both representations: a rich HTML body (rendered sanitized in a
+  // sandboxed iframe) when the message has one, else the plain text. Prefer the
+  // backend-parsed bodies (QP/base64 decoded); the raw decode is last resort.
+  let textBody = "";
+  let htmlBody = "";
   if (detail) {
     if (detail.direction === "outbound") {
-      body = detail.data.body_text ?? "";
+      textBody = detail.data.body_text ?? "";
+      htmlBody = detail.data.body_html ?? "";
     } else {
-      body = detail.data.body?.text || decodeRawBody(detail.data.raw_message) || "";
+      htmlBody = detail.data.parsed?.html ?? "";
+      textBody =
+        detail.data.parsed?.text ||
+        detail.data.body?.text ||
+        decodeRawBody(detail.data.raw_message) ||
+        "";
     }
   }
-  const showBody = body.trim() !== "";
+  const showBody = htmlBody.trim() !== "" || textBody.trim() !== "";
 
   const senderName = isInbound ? counterparty.name : "Inbox";
   const senderEmail = isInbound ? counterparty.email : agentEmail;
@@ -225,18 +235,21 @@ export function ThreadBubble({
             fontSize: 13.5,
             lineHeight: 1.6,
             color: "var(--fg)",
-            whiteSpace: "pre-wrap",
             wordBreak: "break-word",
           }}
         >
-          {showBody ? (
-            body
-          ) : isLoading ? (
-            <span style={{ color: "var(--fg-subtle)" }}>Loading…</span>
+          {!showBody ? (
+            isLoading ? (
+              <span style={{ color: "var(--fg-subtle)" }}>Loading…</span>
+            ) : (
+              <span style={{ fontStyle: "italic", color: "var(--fg-muted)" }}>
+                {message.subject || "(no content)"}
+              </span>
+            )
+          ) : htmlBody.trim() !== "" ? (
+            <EmailHtmlBody html={htmlBody} />
           ) : (
-            <span style={{ fontStyle: "italic", color: "var(--fg-muted)" }}>
-              {message.subject || "(no content)"}
-            </span>
+            <div style={{ whiteSpace: "pre-wrap" }}>{textBody}</div>
           )}
         </div>
       </div>

--- a/web/src/app/components/onboarding/api.ts
+++ b/web/src/app/components/onboarding/api.ts
@@ -229,8 +229,9 @@ type MessageViewWire = {
   created_at: string;
   auth_headers?: Record<string, string>;
   body?: { text?: string; html?: string };
-  // Inbound parsed/injection-reduced text (held inbound has no draft body).
-  parsed?: { text?: string };
+  // Backend-derived body: `text` (injection-reduced) for any message with raw
+  // MIME, plus `html` (decoded text/html part) for rich display when present.
+  parsed?: { text?: string; html?: string };
   raw_message?: string;
 };
 
@@ -255,11 +256,11 @@ function projectPending(
     // the delivery rollup is empty until it's approved + sent.
     status: w.review_status ?? "",
     created_at: w.created_at,
-    // Outbound drafts carry an editable `body`; inbound holds carry the
-    // received content as `parsed.text` (no draft body). Fall back so the
-    // reviewer sees the message either way.
+    // Outbound drafts carry an editable `body`; sent outbound and inbound holds
+    // carry the content as `parsed` (the draft columns are scrubbed at send).
+    // Fall back so the body shows either way.
     body_text: w.body?.text ?? w.parsed?.text,
-    body_html: w.body?.html,
+    body_html: w.body?.html ?? w.parsed?.html,
   };
 }
 
@@ -320,6 +321,7 @@ export async function getMessageDetail(
       status: w.delivery_status ?? "",
       created_at: w.created_at,
       auth_headers: w.auth_headers ?? {},
+      parsed: w.parsed,
       body: w.body,
       raw_message: w.raw_message ?? "",
     },

--- a/web/src/app/components/types.ts
+++ b/web/src/app/components/types.ts
@@ -141,10 +141,16 @@ export type InboundMessageDetail = {
   status: string;
   created_at: string;
   auth_headers: Record<string, string>;
-  // Parsed body, when the backend could extract a text/plain part.
+  // Backend-derived body (preferred): `text` is the injection-reduced plain
+  // body (text/plain, else HTML→text, QP/base64 decoded, quoted chains
+  // stripped); `html` is the decoded text/html part for rich display, present
+  // only when the message has an HTML part. Render these rather than the raw
+  // bytes.
+  parsed?: { text?: string; html?: string };
+  // Held-draft body shape (outbound). Inbound rows carry `parsed` instead.
   body?: { text?: string; html?: string };
-  // Raw RFC-5322 bytes, base64-encoded by the JSON layer. The focus page
-  // decodes this as a fallback when `body.text` is absent.
+  // Raw RFC-5322 bytes, base64-encoded by the JSON layer. Decoded only as a
+  // last-resort fallback when neither `parsed.html` nor `parsed.text` is present.
   raw_message: string;
 };
 


### PR DESCRIPTION
## What & why

Inbound (and sent-outbound) message bodies were only available as raw MIME or the flattened parsed *text*, so the dashboard rendered literal `<div>`/`<br>` markup and quoted-printable `=` soft-breaks. This exposes the decoded **HTML** part and renders it safely.

**Supersedes #294** — folds in its `parsed.text` fix (and removes its now-dead import), then goes further to render rich HTML.

## Backend
- **mailparse**: extract the decoded `text/html` part in the same MIME walk (new `Parse()`/`ParsedView` = Text + Truncated + HTML; `ParsedBody` kept as a thin wrapper). HTML capped at `MaxHTMLBytes` (1 MiB); `raw_message` stays the full-fidelity copy.
- **httpapi**: add `parsed.html` (omitempty) and populate `parsed` for **any** message carrying raw MIME — inbound **and** sent outbound (also fixes the previously-empty sent-body render). `parsed.text` semantics are unchanged (injection-reduced model input).
- Regenerated `api/openapi.yaml` + TS/Python SDK bases (`parsed.html` is an optional `string`).

## Frontend
- New **`EmailHtmlBody`**: DOMPurify-sanitized HTML inside a **sandboxed `<iframe srcdoc>`** (no `allow-scripts`), **remote images blocked by default** with a "Load images" toggle, forced-light surface, auto-height.
- `ThreadBubble` + focus-page `BodyCard` prefer `parsed.html` → iframe, else `parsed.text`, else raw decode.

## Convention
Matches SendGrid/Resend, which expose `text` + `html` as peer fields on received mail.

## Testing
- `make test-unit`, `spec-check`, `generate-sdk-check` green; mailparse + httpapi tests added (inbound HTML, sent-outbound HTML, text-only omission, cap, QP/base64 decode).
- 247 web tests pass (incl. #294 regression + new HTML/iframe sandbox tests); lint clean.
- Verified end-to-end against a local stack with a seeded HTML conversation thread.

## Notes
- A multi-agent review + adversarial verification pass is running; any confirmed findings will land as follow-up commits on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)