### PR TITLE
chore(sdk): bump SDKs to 4.0.0 (v1.0.5 release)

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 4.0.0
+
+Breaking: the domain DNS-records shape changed (server #304).
+
+### Changed
+- **`DomainView.dns_records` is now a single purpose-tagged array
+  (`list[DNSRecord]`).** Each record carries `type`, `name`, `value`,
+  `priority`, `purpose`, and `status`. Replaces the old
+  `dns_records.{ mx, txt, dkim }` object and the separate `sending_dns_records`
+  list. Address records by `purpose` (`ownership`, `inbound_mx`, `dkim`,
+  `mail_from_mx`, `mail_from_spf`) rather than `dns_records.mx`/`.txt`/`.dkim`.
+  The MAIL FROM records live in the same list (returned at registration when the
+  sending feature is enabled), and each record now has a per-record `status`
+  (`verified`/`pending`/`missing`/`failed`). `purpose` and `status` are open
+  sets — tolerate unknown values.
+
 ## 3.0.0
 
 Breaking redesign. The SDK is now a namespaced, **async-only** `E2AClient`

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "e2a"
-version = "3.0.0"
+version = "4.0.0"
 description = "Python SDK for the e2a protocol — email-to-agent authentication"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 4.0.0
+
+Breaking: the domain DNS-records shape changed (server #304).
+
+### Changed
+- **`DomainView.dns_records` is now a single purpose-tagged array
+  (`DNSRecord[]`).** Each record carries `type`, `name`, `value`, `priority`,
+  `purpose`, and `status`. Replaces the old `dns_records.{ mx, txt, dkim }`
+  object and the separate `sending_dns_records` array. Address records by
+  `purpose` (`ownership`, `inbound_mx`, `dkim`, `mail_from_mx`, `mail_from_spf`)
+  rather than `dns_records.mx`/`.txt`/`.dkim`. The MAIL FROM records live in the
+  same array (returned at registration when the sending feature is enabled), and
+  each record now has a per-record `status`
+  (`verified`/`pending`/`missing`/`failed`). `purpose` and `status` are open
+  sets — tolerate unknown values.
+
 ## 3.0.0
 
 Breaking redesign. The SDK now wraps a generated `/v1` client behind a

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/sdk",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "TypeScript SDK for e2a — email for AI agents",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
SDK major bump for the **v1.0.5** release. #304 made the domain `dns_records` API a single purpose-tagged array (breaking for `DomainView` consumers), so the TS + Python SDKs go **3.0.0 → 4.0.0**. Tagged + published via `ts-sdk-v4.0.0` / `python-v4.0.0` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)