### PR TITLE
fix(web): wrap long values so DNS records and identity chips don't overflow

### DIFF
--- a/web/src/app/(app)/domains/_components/DomainCard.tsx
+++ b/web/src/app/(app)/domains/_components/DomainCard.tsx
@@ -295,12 +295,14 @@ export function DomainCard({
         <div className="min-w-0">
           <div className="flex items-center gap-2 mb-2 flex-wrap">
             <code
-              className="font-mono text-[14px] font-semibold px-2 py-0.5"
+              className="font-mono text-[14px] font-semibold px-2 py-0.5 break-all"
               style={{
                 color: "var(--fg)",
                 background: "var(--bg-elev)",
                 border: "1px solid var(--border-sub)",
                 borderRadius: "var(--r-sm)",
+                maxWidth: "100%",
+                minWidth: 0,
               }}
             >
               {domain.domain}

--- a/web/src/app/(app)/get-started/_components/DNSSetupCard.tsx
+++ b/web/src/app/(app)/get-started/_components/DNSSetupCard.tsx
@@ -63,7 +63,7 @@ export function DNSSetupCard({
       <p className="mb-7 text-[14px]" style={{ color: "var(--fg-muted)" }}>
         Add these records to{" "}
         <code
-          className="font-mono text-[12px] px-1.5 py-0.5"
+          className="font-mono text-[12px] px-1.5 py-0.5 break-all"
           style={{
             background: "var(--bg-elev)",
             border: "1px solid var(--border-sub)",

--- a/web/src/app/(app)/get-started/_components/SharedAgentForm.tsx
+++ b/web/src/app/(app)/get-started/_components/SharedAgentForm.tsx
@@ -88,7 +88,7 @@ export function SharedAgentForm({
         <p className="font-medium text-foreground mb-1">How it works</p>
         <p>
           Your inbox gets{" "}
-          <code className="text-xs bg-white/60 px-1 py-0.5 rounded">
+          <code className="text-xs bg-white/60 px-1 py-0.5 rounded break-all">
             {slug || "your-slug"}@{AGENTS_DOMAIN_DISPLAY}
           </code>
           . Emails arrive in real time via CLI, SDK, or WebSocket, or to an

--- a/web/src/app/(app)/get-started/_components/SuccessPanel.tsx
+++ b/web/src/app/(app)/get-started/_components/SuccessPanel.tsx
@@ -50,7 +50,7 @@ export function SuccessPanel({
         <span className="font-semibold">Inbox created!</span>{" "}
         Your inbox&apos;s email is{" "}
         <code
-          className="font-mono text-[12px] px-1.5 py-0.5"
+          className="font-mono text-[12px] px-1.5 py-0.5 break-all"
           style={{
             background: "var(--bg-panel)",
             color: "var(--fg)",

--- a/web/src/app/(app)/get-started/_components/VerifyDomainCard.tsx
+++ b/web/src/app/(app)/get-started/_components/VerifyDomainCard.tsx
@@ -48,7 +48,7 @@ export function VerifyDomainCard({
       <p className="mb-7 text-[14px]" style={{ color: "var(--fg-muted)" }}>
         e2a will check that your TXT record is in place for{" "}
         <code
-          className="font-mono text-[12px] px-1.5 py-0.5"
+          className="font-mono text-[12px] px-1.5 py-0.5 break-all"
           style={{
             background: "var(--bg-elev)",
             border: "1px solid var(--border-sub)",

--- a/web/src/app/(app)/inboxes/(view)/messages/view/page.tsx
+++ b/web/src/app/(app)/inboxes/(view)/messages/view/page.tsx
@@ -427,6 +427,9 @@ function FocusContent({
               padding: "3px 9px",
               borderRadius: "var(--r-sm)",
               border: "1px solid var(--border-sub)",
+              maxWidth: "100%",
+              minWidth: 0,
+              wordBreak: "break-all",
             }}
           >
             {messageId}

--- a/web/src/app/(app)/webhooks/page.tsx
+++ b/web/src/app/(app)/webhooks/page.tsx
@@ -370,7 +370,7 @@ function RevealedSecretBanner({
       <p className="text-[13px] mb-3" style={{ color: "var(--warn-strong)" }}>
         This is the only time we&apos;ll show it. It belongs to{" "}
         <code
-          className="font-mono text-[12px] px-1 py-0.5"
+          className="font-mono text-[12px] px-1 py-0.5 break-all"
           style={{
             background: "var(--bg-panel)",
             color: "var(--fg)",

--- a/web/src/app/components/Field.test.tsx
+++ b/web/src/app/components/Field.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { DNSRecord } from "./Field";
+
+// Regression guard for the Domains DNS-records overflow bug: a long, unbreakable
+// value (e.g. a DKIM public key) rendered in the copyable <code> used to push
+// past the card boundary because the flex child had no min-width:0 and the code
+// never wrapped. The fix adds `min-w-0` + `break-all`. These tests assert the
+// overflow-guard classes are present so the layout can't silently regress.
+const LONG_DKIM =
+  "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr11Mo7JbCOJrRliNihNbbmQVmxOGK3vT0kgm6Ad/bfgHguuNMn5Ku4GK6ByKdFxx2Ss7vqzPZkjg+PgHUTJpfi/zm88wU3jKfThisKeepsGoingAndGoingForAVeryLongTimeIndeed";
+
+describe("DNSField — long value overflow guard", () => {
+  it("renders the long value verbatim and keeps it copyable", () => {
+    render(
+      <DNSRecord
+        type="TXT"
+        label="Authenticate outbound mail (DKIM)"
+        fields={[{ label: "Content", value: LONG_DKIM }]}
+      />,
+    );
+    expect(screen.getByText(LONG_DKIM)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Copy" })).toBeInTheDocument();
+  });
+
+  it("wraps long values via break-all and a shrinkable flex child (min-w-0)", () => {
+    render(
+      <DNSRecord
+        type="TXT"
+        label="DKIM"
+        fields={[{ label: "Content", value: LONG_DKIM }]}
+      />,
+    );
+    const code = screen.getByText(LONG_DKIM);
+    // The value-bearing <code> must be allowed to wrap and shrink, otherwise it
+    // overflows its container on long input.
+    expect(code).toHaveClass("break-all");
+    expect(code).toHaveClass("min-w-0");
+    expect(code).toHaveClass("flex-1");
+
+    // Its flex parent must also be shrinkable (flexbox default min-width:auto
+    // would otherwise let the code push the row wider than the card).
+    expect(code.parentElement).toHaveClass("min-w-0");
+  });
+});

--- a/web/src/app/components/Field.tsx
+++ b/web/src/app/components/Field.tsx
@@ -67,8 +67,8 @@ function DNSField({ label, value }: { label: string; value: string }) {
   return (
     <>
       <span className="text-xs text-muted">{label}</span>
-      <div className="flex items-center gap-2">
-        <code className="text-sm font-mono bg-background rounded px-2 py-1 border border-border flex-1">
+      <div className="flex items-center gap-2 min-w-0">
+        <code className="text-sm font-mono bg-background rounded px-2 py-1 border border-border flex-1 min-w-0 break-all">
           {value}
         </code>
         <button

--- a/web/src/app/components/messages/AgentHeader.test.tsx
+++ b/web/src/app/components/messages/AgentHeader.test.tsx
@@ -56,6 +56,23 @@ describe("AgentHeader — test-send action (moved from the dashboard card)", () 
     ).not.toBeInTheDocument();
   });
 
+  // Regression guard: a long email address rendered in the identity-row <code>
+  // used to overflow the header. The fix caps it at maxWidth:100% and lets it
+  // wrap (wordBreak: break-all) instead of pushing past the card edge.
+  it("keeps a long inbox email from overflowing the header", () => {
+    const longEmail =
+      "a-very-long-inbox-slug-that-keeps-going@some-very-long-subdomain.acme.dev";
+    render(
+      <AgentHeader
+        agent={{ ...verified, email: longEmail }}
+        tab="messages"
+      />,
+    );
+    const code = screen.getByText(longEmail);
+    expect(code).toHaveStyle({ wordBreak: "break-all" });
+    expect(code).toHaveStyle({ maxWidth: "100%" });
+  });
+
   it("POSTs the agent test endpoint and surfaces success", async () => {
     mockFetch.mockResolvedValue({
       ok: true,

--- a/web/src/app/components/messages/AgentHeader.tsx
+++ b/web/src/app/components/messages/AgentHeader.tsx
@@ -80,6 +80,9 @@ export function AgentHeader({
                 padding: "3px 9px",
                 borderRadius: "var(--r-sm)",
                 border: "1px solid var(--border-sub)",
+                maxWidth: "100%",
+                minWidth: 0,
+                wordBreak: "break-all",
               }}
             >
               {agent.email}

--- a/web/src/app/components/messages/ThreadDetail.tsx
+++ b/web/src/app/components/messages/ThreadDetail.tsx
@@ -90,7 +90,7 @@ export function ThreadDetail({
         >
           <span aria-hidden>←</span> Inbox
         </button>
-        <div className="flex items-center" style={{ gap: 8, marginBottom: 10 }}>
+        <div className="flex items-center min-w-0" style={{ gap: 8, marginBottom: 10 }}>
           {thread.conversationId && (
             <code
               style={{
@@ -101,6 +101,8 @@ export function ThreadDetail({
                 padding: "1px 6px",
                 borderRadius: 4,
                 border: "1px solid var(--border-sub)",
+                minWidth: 0,
+                wordBreak: "break-all",
               }}
             >
               {thread.conversationId}


### PR DESCRIPTION
## Problem

On the Domains page, long DNS record content (e.g. a DKIM public key) pushed past the card boundary. Root cause: copyable `<code>` values were flex children with flexbox's default `min-width: auto` and no text wrapping, so unbreakable strings overflowed horizontally.

## Audit

Same class of bug existed across the dashboard wherever a long, unbreakable value renders in a `<code>` chip. Fixed all of them:

| Component | Long value |
|---|---|
| `Field.tsx` (DNS records — the reported one) | DKIM key |
| `messages/AgentHeader.tsx` | inbox email |
| `messages/ThreadDetail.tsx` | conversationId |
| `inboxes/.../messages/view/page.tsx` | messageId |
| `domains/DomainCard.tsx` | domain name |
| `webhooks/page.tsx` | webhook URL |
| `get-started/{SuccessPanel,VerifyDomainCard,DNSSetupCard,SharedAgentForm}.tsx` | email / domain |

**Left as-is:** the api-keys table (already wrapped in `overflow-x-auto`, scrolls within bounds) and the webhook secret `<input>` (scrolls internally).

## Fix

Wrap rather than truncate — these values need to be read/copied in full. Added `min-w-0 break-all` (or `wordBreak: break-all` + `maxWidth: 100%` for inline-style chips) so content wraps inside the card.

## Tests

- New `Field.test.tsx`: long DKIM key keeps `break-all` + `min-w-0` + `flex-1` and a shrinkable flex parent.
- Extended `AgentHeader.test.tsx`: long email keeps `wordBreak: break-all` / `maxWidth: 100%`.

Full suite green (259 passed), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)