### PR TITLE
fix(hitlnotify): stack approval buttons so they render on mobile

### DIFF
--- a/internal/hitlnotify/notifier.go
+++ b/internal/hitlnotify/notifier.go
@@ -116,11 +116,11 @@ func (n *Notifier) NotifyPendingApproval(ctx context.Context, msg *identity.Mess
 	message, err := outbound.ComposeMultipartMessage(
 		fromHeader, []string{owner.Email}, nil,
 		subject, text, htmlBody,
-		"",            // no reply-to-message-id (fresh notification)
-		nil,           // no references chain (fresh notification)
-		n.fromDomain,  // from_domain (Message-ID generation)
-		fromAddr,      // reply_to — point replies back at the platform, not the agent
-		"",            // no conversation_id
+		"",           // no reply-to-message-id (fresh notification)
+		nil,          // no references chain (fresh notification)
+		n.fromDomain, // from_domain (Message-ID generation)
+		fromAddr,     // reply_to — point replies back at the platform, not the agent
+		"",           // no conversation_id
 	)
 	if err != nil {
 		return fmt.Errorf("notify: compose: %w", err)
@@ -278,11 +278,22 @@ func renderHTML(msg *identity.Message, agent *identity.AgentIdentity, approveURL
 	// actual approve/reject side effect only fires when the reviewer
 	// submits the form on that page — this is what keeps mail-client URL
 	// scanners from approving on the reviewer's behalf.
+	//
+	// Each button is a block-level anchor so the two stack vertically and
+	// fill the available width. Inline buttons sitting side-by-side
+	// overflowed and overlapped on narrow mobile viewports (the padded
+	// inline anchors didn't grow line height when they wrapped); stacking
+	// is robust across every width without needing @media queries, which
+	// many mail clients strip.
+	const btnStyle = `display:block;background:%s;color:%s;font-weight:500;padding:12px 18px;text-decoration:none;border-radius:6px;text-align:center;font-size:15px`
+	fmt.Fprintf(&b, `<div style="margin-top:16px">`)
 	fmt.Fprintf(&b,
-		`<p style="margin-top:16px"><a href="%s" style="background:%s;color:%s;font-weight:500;padding:10px 18px;text-decoration:none;border-radius:6px;margin-right:12px">Review &amp; approve</a>`+
-			`<a href="%s" style="background:%s;color:%s;font-weight:500;padding:10px 18px;text-decoration:none;border-radius:6px">Review &amp; reject</a></p>`,
-		html.EscapeString(approveURL), success, onAccent,
+		`<a href="%s" style="`+btnStyle+`;margin-bottom:10px">Review &amp; approve</a>`,
+		html.EscapeString(approveURL), success, onAccent)
+	fmt.Fprintf(&b,
+		`<a href="%s" style="`+btnStyle+`">Review &amp; reject</a>`,
 		html.EscapeString(rejectURL), danger, onAccent)
+	fmt.Fprintf(&b, `</div>`)
 
 	fmt.Fprintf(&b,
 		`<p style="margin-top:16px;font-size:13px;color:%s">Need to edit before approving? <a href="%s" style="color:%s">Review in the dashboard</a>.</p>`,


### PR DESCRIPTION
## Problem

The HITL approval notification email renders its **Review & approve** / **Review & reject** buttons as two inline `<a>` elements sitting side-by-side. On narrow mobile viewports the padded inline anchors wrap without growing line height, so the buttons overflow and overlap — the labels collide and parts of the buttons become unreadable / untappable.

| Before (mobile) |
|---|
| Buttons overlap, "reject" label spills below the green button (see reported screenshot) |

## Fix

Render each button as a **block-level, full-width, centered** anchor so the two stack vertically. This is robust across every viewport width without relying on `@media` queries, which many mail clients strip. Padding bumped slightly (`12px` vertical) for a comfortable mobile tap target.

All other styling (Loft palette, success/danger colors, link styling) is unchanged, and the desktop appearance remains clean — just stacked instead of side-by-side.

## Audit of similar surfaces

Checked the other server-rendered HTML surfaces for the same class of bug:

- **`internal/agent/hitl_magic_api.go`** (token-gated approve/reject confirm page) — already responsive: has `@media (max-width:480px)` with `.btn { width:100% }`. No change.
- **`internal/auth/auth.go`** (CLI login page) — single full-width button under `max-width:480px` centered shell. No change.
- Web dashboard components are Tailwind-responsive by design.

The notification email was the only affected surface.

## Testing

- `go build ./internal/hitlnotify/` ✅
- `gofmt` clean ✅
- Existing `internal/hitlnotify/notifier_test.go` assertions (button labels, magic links) still hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARwrB8GnSxKoXX3iDfzfir)_