### PR TITLE
Gate events API on the outbox flag (501 when disabled)

### DIFF
--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -438,6 +438,7 @@ func main() {
 		SharedDomain:    cfg.SharedDomain,
 		PublicURL:       cfg.HTTP.PublicURL,
 		SigningSecret:   cfg.Signing.HMACSecret,
+		EventsEnabled:   webhookOutbox.Enabled(),
 		Production:      cfg.IsProduction(),
 		Legacy:          router,
 		WSHandle:        wsHandler.ServeWithEmail,

--- a/internal/apiserver/apiserver.go
+++ b/internal/apiserver/apiserver.go
@@ -54,6 +54,12 @@ type Params struct {
 	// are left unwired.
 	SigningSecret string
 
+	// EventsEnabled mirrors WEBHOOKS_OUTBOX_ENABLED (the outbox's flag). When
+	// false the webhook_events durable log is never written, so the events
+	// list/get/redeliver endpoints return 501 events_log_disabled instead of an
+	// empty result. Webhook delivery is unaffected.
+	EventsEnabled bool
+
 	// Legacy is the gorilla/mux handler the chi root falls back to for any
 	// route not on /v1. WSHandle serves the /v1 WebSocket upgrade.
 	Legacy   http.Handler
@@ -91,24 +97,25 @@ func BuildDeps(p Params) httpapi.Deps {
 		ListConversations: p.Store.ListConversationsByAgent,
 		GetConversation:   p.Store.GetConversationByID,
 
-		CreateAgent:              p.Store.CreateAgent,
-		LookupDomain:             p.Store.LookupDomain,
-		EnforceAgentCreate:       p.Enforcer.CheckAgentCreate,
-		UpdateAgentName:          p.Store.UpdateAgentName,
-		UpdateAgentProtection:    p.Store.UpdateAgentProtection,
-		DeleteAgent:              p.Store.DeleteAgent,
+		CreateAgent:           p.Store.CreateAgent,
+		LookupDomain:          p.Store.LookupDomain,
+		EnforceAgentCreate:    p.Enforcer.CheckAgentCreate,
+		UpdateAgentName:       p.Store.UpdateAgentName,
+		UpdateAgentProtection: p.Store.UpdateAgentProtection,
+		DeleteAgent:           p.Store.DeleteAgent,
 
-		ListDomains:         p.Store.ListDomainsByUser,
-		ClaimDomain:         p.Store.ClaimOrCreateDomain,
-		EnforceDomainCreate: p.Enforcer.CheckDomainCreate,
-		DeleteDomain:        deleteDomainFunc(p),
-		HasAgentsOnDomain:   p.Store.HasAgentsOnDomain,
-		SMTPDomain:          p.SMTPDomain,
-		SESRegion:           p.SESRegion,
-		CursorSecret:        p.SigningSecret,
-		Idempotency:         p.Idempotency,
-		DeliverOutbound:     p.API.DeliverOutbound,
-		SendTest:            p.API.SendTestCore,
+		ListDomains:          p.Store.ListDomainsByUser,
+		ClaimDomain:          p.Store.ClaimOrCreateDomain,
+		EnforceDomainCreate:  p.Enforcer.CheckDomainCreate,
+		DeleteDomain:         deleteDomainFunc(p),
+		HasAgentsOnDomain:    p.Store.HasAgentsOnDomain,
+		SMTPDomain:           p.SMTPDomain,
+		SESRegion:            p.SESRegion,
+		CursorSecret:         p.SigningSecret,
+		EventsEnabled:        p.EventsEnabled,
+		Idempotency:          p.Idempotency,
+		DeliverOutbound:      p.API.DeliverOutbound,
+		SendTest:             p.API.SendTestCore,
 		ApprovePending:       p.API.ApprovePendingCore,
 		SendLimit:            p.API.SendLimitAllow,
 		PollLimit:            p.API.PollLimitAllow,
@@ -120,13 +127,13 @@ func BuildDeps(p Params) httpapi.Deps {
 		RejectInboundReview:  p.API.RejectInboundReviewCore,
 		ListReviews:          p.Store.ListReviews,
 		GetReviewWithContent: p.Store.GetReviewWithContent,
-		EnforceMessageSend:  p.Enforcer.CheckMessageSend,
-		GetInboundMessage:   p.Store.GetInboundMessage,
-		GetLimits:           p.Enforcer.Get,
-		ExportUserData:      p.API.ExportUserDataCore,
-		DeleteUserData:      p.API.DeleteUserDataCore,
-		ListSuppressions:    p.Store.ListSuppressions,
-		RemoveSuppression:   p.Store.RemoveSuppression,
+		EnforceMessageSend:   p.Enforcer.CheckMessageSend,
+		GetInboundMessage:    p.Store.GetInboundMessage,
+		GetLimits:            p.Enforcer.Get,
+		ExportUserData:       p.API.ExportUserDataCore,
+		DeleteUserData:       p.API.DeleteUserDataCore,
+		ListSuppressions:     p.Store.ListSuppressions,
+		RemoveSuppression:    p.Store.RemoveSuppression,
 		GetUsage: func(ctx context.Context, userID string) httpapi.LimitsUsageView {
 			var u httpapi.LimitsUsageView
 			if n, err := p.UsageStore.CountAgentsByUser(ctx, userID); err == nil {

--- a/internal/httpapi/events.go
+++ b/internal/httpapi/events.go
@@ -120,6 +120,9 @@ func (s *Server) handleRedeliverEvent(ctx context.Context, in *RedeliverEventInp
 	if err != nil {
 		return nil, err
 	}
+	if err := s.requireEventsEnabled(); err != nil {
+		return nil, err
+	}
 	if s.deps.LoadReplayEvent == nil || s.deps.InsertReplayDelivery == nil {
 		return nil, NewError(http.StatusNotFound, "not_found", "events API not configured")
 	}
@@ -197,9 +200,26 @@ func containsStr(ss []string, want string) bool {
 	return false
 }
 
+// requireEventsEnabled returns a 501 when the durable event log isn't
+// populated on this deployment (WEBHOOKS_OUTBOX_ENABLED off). Without this the
+// list/get/redeliver handlers would query the empty webhook_events table and
+// return "no events" — indistinguishable from a deployment where events simply
+// haven't happened. The explicit error makes the disabled state legible.
+// Webhook *delivery* is unaffected; the legacy publisher handles it.
+func (s *Server) requireEventsEnabled() error {
+	if !s.deps.EventsEnabled {
+		return NewError(http.StatusNotImplemented, "events_log_disabled",
+			"the event log (list/get/redeliver events) is not enabled on this deployment; webhook delivery is unaffected")
+	}
+	return nil
+}
+
 func (s *Server) handleListEvents(ctx context.Context, in *ListEventsInput) (*listEventsOutput, error) {
 	user, err := s.requireAccountUser(ctx)
 	if err != nil {
+		return nil, err
+	}
+	if err := s.requireEventsEnabled(); err != nil {
 		return nil, err
 	}
 	if s.deps.ListEvents == nil {
@@ -262,6 +282,9 @@ func (s *Server) handleGetEvent(ctx context.Context, in *struct {
 }) (*eventOutput, error) {
 	user, err := s.requireAccountUser(ctx)
 	if err != nil {
+		return nil, err
+	}
+	if err := s.requireEventsEnabled(); err != nil {
 		return nil, err
 	}
 	if s.deps.GetEvent2 == nil {

--- a/internal/httpapi/events_test.go
+++ b/internal/httpapi/events_test.go
@@ -1,6 +1,13 @@
 package httpapi
 
-import "testing"
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+)
 
 func TestListEventsNoOverflow(t *testing.T) {
 	srv := testServer(t)
@@ -112,5 +119,33 @@ func TestRedeliverEventNotFound(t *testing.T) {
 	code, _ := postJSON(t, srv.URL+"/v1/events/evt_missing/redeliver", "good", map[string]any{})
 	if code != 404 {
 		t.Fatalf("want 404, got %d", code)
+	}
+}
+
+// TestEventsDisabledReturns501 pins the gate: when the durable event log is
+// off (EventsEnabled=false, i.e. WEBHOOKS_OUTBOX_ENABLED unset in prod), the
+// list/get/redeliver endpoints must return 501 events_log_disabled rather than
+// querying the empty webhook_events table and masquerading as "no events".
+func TestEventsDisabledReturns501(t *testing.T) {
+	srv := httptest.NewServer(New(Deps{
+		EventsEnabled: false,
+		Authenticator: func(r *http.Request) (*identity.User, error) {
+			if r.Header.Get("Authorization") == "Bearer good" {
+				return &identity.User{ID: "u_1", Email: "owner@acme.com"}, nil
+			}
+			return nil, errors.New("unauthorized")
+		},
+	}))
+	defer srv.Close()
+
+	for _, path := range []string{"/v1/events?limit=5", "/v1/events/evt_a"} {
+		code, body := getJSON(t, srv.URL+path, "good")
+		if code != 501 || errCode(body) != "events_log_disabled" {
+			t.Fatalf("GET %s: want 501 events_log_disabled, got %d %v", path, code, body)
+		}
+	}
+	code, body := postJSON(t, srv.URL+"/v1/events/evt_a/redeliver", "good", map[string]any{})
+	if code != 501 || errCode(body) != "events_log_disabled" {
+		t.Fatalf("redeliver: want 501 events_log_disabled, got %d %v", code, body)
 	}
 }

--- a/internal/httpapi/httpapi.go
+++ b/internal/httpapi/httpapi.go
@@ -201,6 +201,15 @@ type Deps struct {
 	LoadReplayEvent      func(ctx context.Context, userID, eventID string) (*agent.ReplayEvent, error)
 	InsertReplayDelivery func(ctx context.Context, eventID, webhookID, eventType string, messageID *string, envelope []byte) (string, error)
 
+	// EventsEnabled reflects whether the durable event log (the
+	// webhook_events outbox) is populated on this deployment — i.e. the
+	// WEBHOOKS_OUTBOX_ENABLED flag. When false the legacy publisher delivers
+	// webhooks straight to webhook_subscriber_deliveries and webhook_events is
+	// never written, so list/get/redeliver would silently return empty. The
+	// events handlers gate on this and return 501 events_log_disabled instead
+	// of masquerading as "no events". Webhook delivery is unaffected either way.
+	EventsEnabled bool
+
 	// webhooks
 	CreateWebhook func(ctx context.Context, userID, url, description string, events []string, filters identity.WebhookFilters) (*identity.Webhook, error)
 	ListWebhooks  func(ctx context.Context, userID string) ([]identity.Webhook, error)

--- a/internal/httpapi/operations_test.go
+++ b/internal/httpapi/operations_test.go
@@ -235,6 +235,7 @@ func testServer(t *testing.T) *httptest.Server {
 		DeleteUserData: func(ctx context.Context, user *identity.User) (*identity.DeleteUserDataResult, error) {
 			return &identity.DeleteUserDataResult{}, nil
 		},
+		EventsEnabled: true,
 		ListEvents: func(ctx context.Context, q EventQuery) ([]agent.EventJSON, error) {
 			// Two events, honoring Limit + cursor (CursorID) so the
 			// cursor round-trip is exercised.

--- a/internal/testutil/contract_server.go
+++ b/internal/testutil/contract_server.go
@@ -78,7 +78,8 @@ func StartContractServer(ctx context.Context, dbURL string) (*ContractServer, er
 		SubscriberStore: subscriberStore, Idempotency: idempotencyStore, Pool: pool,
 		SMTPDomain: "test.e2a.dev", SharedDomain: "agents.e2a.dev",
 		PublicURL: "http://127.0.0.1", Production: false,
-		Legacy: router, WSHandle: wsHandler.ServeWithEmail,
+		EventsEnabled: true,
+		Legacy:        router, WSHandle: wsHandler.ServeWithEmail,
 	})
 
 	httpLn, err := net.Listen("tcp", "127.0.0.1:0")

--- a/internal/testutil/events_harness.go
+++ b/internal/testutil/events_harness.go
@@ -60,7 +60,8 @@ func NewEventsAPIHarness(t *testing.T, pool *pgxpool.Pool, store *identity.Store
 		SubscriberStore: subscriberStore, Idempotency: idempotencyStore, Pool: pool,
 		SMTPDomain: "test.e2a.dev", SharedDomain: "agents.e2a.dev",
 		PublicURL: "http://127.0.0.1", Production: false,
-		Legacy: router,
+		EventsEnabled: outbox.Enabled(),
+		Legacy:        router,
 	})
 
 	srv := httptest.NewServer(v1)

--- a/internal/testutil/server.go
+++ b/internal/testutil/server.go
@@ -134,7 +134,8 @@ func TestServer(t *testing.T, pool *pgxpool.Pool, opts ...TestServerOption) *E2A
 		SubscriberStore: subscriberStore, Idempotency: idempotencyStore, Pool: pool,
 		SMTPDomain: "test.e2a.dev", SharedDomain: "agents.e2a.dev",
 		PublicURL: "http://127.0.0.1", Production: false,
-		Legacy: router, WSHandle: wsHandler.ServeWithEmail,
+		EventsEnabled: true,
+		Legacy:        router, WSHandle: wsHandler.ServeWithEmail,
 	})
 
 	httpServer := httptest.NewServer(v1)


### PR DESCRIPTION
## Problem
`GET /v1/events`, `/v1/events/{id}`, and `/v1/events/{id}/redeliver` (MCP: `list_events`, `get_event`, `redeliver_event`) read **only** from the `webhook_events` outbox. That table is only written when `WEBHOOKS_OUTBOX_ENABLED` is on — and it's **off by default in v1** (and unset in `e2a-ops`, so off in prod).

When the outbox is off, the **legacy publisher** delivers webhooks straight to `webhook_subscriber_deliveries` (delivery works fine), but `webhook_events` is never populated. So these three endpoints **silently return empty / 404**, indistinguishable from "no events happened." During end-to-end testing this read as a broken/empty events API even though ~40 events had just been generated and delivered.

## Fix
Add `Deps.EventsEnabled` (wired from `webhookOutbox.Enabled()` through `apiserver.Params`) and have all three handlers return **`501 events_log_disabled`** with a clear message when it's off, instead of querying the empty table:

> the event log (list/get/redeliver events) is not enabled on this deployment; webhook delivery is unaffected

This removes the silent-empty trap. **Webhook delivery is unchanged.** When the outbox is later enabled (`WEBHOOKS_OUTBOX_ENABLED=true`), the endpoints light up automatically.

## Changes
- `httpapi.Deps.EventsEnabled` + `requireEventsEnabled()` helper; gate added to `handleListEvents` / `handleGetEvent` / `handleRedeliverEvent`.
- `apiserver.Params.EventsEnabled` → `BuildDeps`; `main.go` passes `webhookOutbox.Enabled()`.
- Tests: existing events handler tests set `EventsEnabled: true`; new `TestEventsDisabledReturns501` pins the 501 on all three endpoints when off.

## Verification
- `go build ./...`, `go vet`, `go test ./internal/httpapi/...` all pass.
- Spec-golden drift gate green (runtime error, no OpenAPI schema change).

## Follow-up (not in this PR)
The real cure is enabling the outbox in prod (a deliberate delivery-path migration). This PR just stops the dishonest empty responses until then. The MCP tool descriptions for `list_events`/`get_event`/`redeliver_event` could also note the dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)