### PR TITLE
fix(relay): fail inbound gate closed for shared-relay senders (#299)

### DIFF
--- a/internal/httpapi/protection.go
+++ b/internal/httpapi/protection.go
@@ -25,6 +25,16 @@ const protectionBetaDoc = "Beta: the agent protection config is unstable — its
 // gate/scan object and get the safe-permissive default. The three TOP-LEVEL
 // keys (inbound/outbound/holds) stay required (design D3) — a missing section
 // is a 422, not a silent reset.
+//
+// INBOUND gate identity note (#299): the inbound allowlist/domain gate matches on
+// the message's From address, which only carries a specific per-agent identity for
+// senders on a sending-verified domain. Mail from agents NOT yet sending-verified
+// is relayed under the shared "via e2a" address (internal/outbound/sender.go) — it
+// authenticates but is the same address for every such agent. The relay treats that
+// shared sender as unresolvable (see senderResolvable), so it can never satisfy an
+// allowlist/domain gate and is flagged (fail closed); under "open" it still passes.
+// Net: per-agent inbound allowlisting is reliable for sending-verified senders;
+// unverified intra-system senders are uniformly gated, not silently admitted.
 type ProtectionGateView struct {
 	Policy    string   `json:"policy,omitempty" enum:"open,allowlist,domain" default:"open" doc:"Trust gate: open (all), domain (listed domains), allowlist (listed addresses)."`
 	Allowlist []string `json:"allowlist,omitempty" nullable:"false" maxItems:"1000" doc:"Addresses (allowlist) or domains (domain) the gate trusts; ignored for open."`

--- a/internal/inboundpolicy/policy.go
+++ b/internal/inboundpolicy/policy.go
@@ -48,22 +48,40 @@ type Decision struct {
 	Reason  string // human-readable; empty when not flagged
 }
 
+// unresolvableSenderReason is the fail-closed flag reason for a sender with no
+// specific authenticated identity (shared-relay "via e2a" mail) under a gating
+// policy — see senderResolvable in the relay and issue #299.
+const unresolvableSenderReason = "sender has no resolvable per-agent identity (shared relay), so it cannot match a per-agent inbound gate"
+
 // EvaluateIngestion applies the agent's ingestion policy to an inbound message.
 //   - policy: the agent's inbound_policy (unknown/empty → treated as Open).
 //   - allowlist: the agent's inbound_allowlist (addresses for Allowlist,
 //     domains for Domain); matching is case-insensitive.
 //   - senderEmail: the message's display sender (From identity).
+//   - senderResolvable: whether senderEmail maps to a SPECIFIC authenticated
+//     sender. False for mail relayed under the shared "via e2a" address, which
+//     authenticates (DMARC passes for the relay domain) but carries no per-agent
+//     identity (#299). An unresolvable sender can never legitimately satisfy a
+//     per-agent allowlist/domain gate, so it is treated as a non-match. Open is
+//     unaffected — open means open.
 //
-// Flagged is fail-closed for the gating postures: an empty/garbage sender, or
-// an empty allowlist, flags everything (you opted into a gate but listed no one).
-func EvaluateIngestion(policy string, allowlist []string, senderEmail string) Decision {
+// Flagged is fail-closed for the gating postures: an empty/garbage sender, an
+// empty allowlist, or an unresolvable sender flags everything (you opted into a
+// gate but the sender cannot be matched).
+func EvaluateIngestion(policy string, allowlist []string, senderEmail string, senderResolvable bool) Decision {
 	switch policy {
 	case Allowlist:
+		if !senderResolvable {
+			return Decision{Flagged: true, Reason: unresolvableSenderReason}
+		}
 		if containsFold(allowlist, strings.TrimSpace(senderEmail)) {
 			return Decision{}
 		}
 		return Decision{Flagged: true, Reason: "sender not on the agent's inbound allowlist"}
 	case Domain:
+		if !senderResolvable {
+			return Decision{Flagged: true, Reason: unresolvableSenderReason}
+		}
 		dom := domainOf(senderEmail)
 		if dom != "" && containsFold(allowlist, dom) {
 			return Decision{}

--- a/internal/inboundpolicy/policy_test.go
+++ b/internal/inboundpolicy/policy_test.go
@@ -4,25 +4,32 @@ import "testing"
 
 func TestEvaluateIngestion(t *testing.T) {
 	tests := []struct {
-		name      string
-		policy    string
-		allowlist []string
-		sender    string
-		flagged   bool
+		name       string
+		policy     string
+		allowlist  []string
+		sender     string
+		resolvable bool
+		flagged    bool
 	}{
-		{"open never flags", Open, nil, "anyone@evil.com", false},
-		{"unknown policy treated as open", "bogus", nil, "x@y.com", false},
-		{"allowlist match", Allowlist, []string{"boss@acme.com"}, "boss@acme.com", false},
-		{"allowlist case-insensitive", Allowlist, []string{"Boss@Acme.com"}, "boss@acme.com", false},
-		{"allowlist non-match flagged", Allowlist, []string{"boss@acme.com"}, "stranger@x.com", true},
-		{"allowlist empty flags all", Allowlist, nil, "boss@acme.com", true},
-		{"domain match", Domain, []string{"acme.com"}, "anyone@acme.com", false},
-		{"domain non-match flagged", Domain, []string{"acme.com"}, "x@evil.com", true},
-		{"domain garbage sender flagged", Domain, []string{"acme.com"}, "nodomain", true},
+		{"open never flags", Open, nil, "anyone@evil.com", true, false},
+		{"unknown policy treated as open", "bogus", nil, "x@y.com", true, false},
+		{"allowlist match", Allowlist, []string{"boss@acme.com"}, "boss@acme.com", true, false},
+		{"allowlist case-insensitive", Allowlist, []string{"Boss@Acme.com"}, "boss@acme.com", true, false},
+		{"allowlist non-match flagged", Allowlist, []string{"boss@acme.com"}, "stranger@x.com", true, true},
+		{"allowlist empty flags all", Allowlist, nil, "boss@acme.com", true, true},
+		{"domain match", Domain, []string{"acme.com"}, "anyone@acme.com", true, false},
+		{"domain non-match flagged", Domain, []string{"acme.com"}, "x@evil.com", true, true},
+		{"domain garbage sender flagged", Domain, []string{"acme.com"}, "nodomain", true, true},
+		// #299: a sender with no resolvable per-agent identity (shared relay) can
+		// never satisfy a gating policy, even if the allowlist names its address
+		// or domain. Open still passes — open means open.
+		{"allowlist unresolvable flagged despite address match", Allowlist, []string{"agent@send.e2a.dev"}, "agent@send.e2a.dev", false, true},
+		{"domain unresolvable flagged despite domain match", Domain, []string{"send.e2a.dev"}, "agent@send.e2a.dev", false, true},
+		{"open unresolvable still passes", Open, nil, "agent@send.e2a.dev", false, false},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			d := EvaluateIngestion(tc.policy, tc.allowlist, tc.sender)
+			d := EvaluateIngestion(tc.policy, tc.allowlist, tc.sender, tc.resolvable)
 			if d.Flagged != tc.flagged {
 				t.Errorf("Flagged=%v want %v (reason=%q)", d.Flagged, tc.flagged, d.Reason)
 			}

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -303,7 +303,10 @@ func (s *session) deliverToAgent(ctx context.Context, agent *identity.AgentIdent
 	// SPF/DKIM/DMARC pertain to), NOT displaySender (Reply-To is attacker-
 	// controllable). A non-match is FLAGGED — still delivered (never dropped),
 	// marked on the row, and emits email.flagged so operators get a signal.
-	policyDecision := inboundpolicy.EvaluateIngestion(agent.InboundPolicy, agent.InboundAllowlist, senderEmail)
+	//
+	// senderResolvable fails the gate closed for shared-relay "via e2a" mail,
+	// which authenticates but carries no per-agent identity (#299).
+	policyDecision := inboundpolicy.EvaluateIngestion(agent.InboundPolicy, agent.InboundAllowlist, senderEmail, s.senderResolvable(senderEmail))
 
 	// Content screening (Slice 4): run the per-agent inbound scan and record the
 	// audit trail (protection_events) + the denormalized verdict. Detection +
@@ -681,6 +684,29 @@ func (s *session) envelopeFromTrusted() bool {
 	envDomain := strings.ToLower(extractDomain(s.from))
 	trusted := strings.ToLower(s.relay.outboundFromDomain)
 	return envDomain == trusted || strings.HasSuffix(envDomain, "."+trusted)
+}
+
+// senderResolvable reports whether the inbound From identity maps to a SPECIFIC
+// authenticated sender, so a per-agent inbound allowlist/domain gate can match it.
+//
+// Mail relayed for a non-sending-verified agent goes out under the shared
+// "agent@<outboundFromDomain>" address (internal/outbound/sender.go): it
+// authenticates against the relay domain (DMARC passes) but is the SAME address
+// for every such agent, so it carries no per-agent identity. Treating it as
+// resolvable would let any allowlist that names the relay domain (or that shared
+// address) admit every unverified agent indiscriminately — and would never admit
+// the specific agent the operator meant. So we report it unresolvable and the
+// gate fails closed under allowlist/domain (open is unaffected). #299.
+//
+// Matches the exact relay domain OR any subdomain, mirroring envelopeFromTrusted:
+// a verified agent always sends from its own custom domain, never the relay's.
+func (s *session) senderResolvable(senderEmail string) bool {
+	if s.relay.outboundFromDomain == "" {
+		return true
+	}
+	dom := strings.ToLower(extractDomain(senderEmail))
+	relay := strings.ToLower(s.relay.outboundFromDomain)
+	return dom != relay && !strings.HasSuffix(dom, "."+relay)
 }
 
 func extractEmail(addr string) string {

--- a/internal/relay/server_test.go
+++ b/internal/relay/server_test.go
@@ -185,6 +185,40 @@ func TestEnvelopeFromTrustedUnconfigured(t *testing.T) {
 	}
 }
 
+func TestSenderResolvable(t *testing.T) {
+	// #299: the shared "via e2a" relay sender (agent@<outboundFromDomain>) carries
+	// no per-agent identity, so the inbound gate must treat it as unresolvable.
+	s := &session{
+		relay: &Server{outboundFromDomain: "send.e2a.dev"},
+	}
+	cases := []struct {
+		sender string
+		want   bool
+	}{
+		{"alice@acme.com", true},               // external sender — resolvable
+		{"bob@customer-domain.com", true},      // sending-verified agent's own domain
+		{"agent@send.e2a.dev", false},          // shared relay collapse — unresolvable
+		{"agent@Send.E2A.Dev", false},          // case-insensitive
+		{"x@mail.send.e2a.dev", false},         // subdomain of the relay domain
+		{"agent@othersend.e2a.dev", true},      // suffix-match attack — not actually a subdomain
+		{"nodomain", true},                     // garbage; let normal matching/flagging handle it
+	}
+	for _, c := range cases {
+		if got := s.senderResolvable(c.sender); got != c.want {
+			t.Errorf("senderResolvable(%q) = %v, want %v", c.sender, got, c.want)
+		}
+	}
+}
+
+func TestSenderResolvableUnconfigured(t *testing.T) {
+	// With no outboundFromDomain there is no shared-relay address to recognize, so
+	// every sender is treated as resolvable (no spurious flagging).
+	s := &session{relay: &Server{outboundFromDomain: ""}}
+	if !s.senderResolvable("agent@send.e2a.dev") {
+		t.Error("unconfigured relay should treat all senders as resolvable")
+	}
+}
+
 func TestExtractThreadInfoMissingHeaders(t *testing.T) {
 	raw := []byte("From: alice@example.com\r\n\r\nBody only\r\n")
 


### PR DESCRIPTION
Closes #299.

## Problem
The inbound trust gate (`allowlist`/`domain`) matches on the message **From** identity. Mail relayed for a **non-sending-verified** agent goes out under the shared `agent@<outboundFromDomain>` address (`internal/outbound/sender.go`) — it authenticates (DMARC passes for the relay domain) but is the **same address for every such agent**, so it has no per-agent identity.

Before this PR:
- A full-address allowlist entry (`alice@agents.e2a.dev`) **never matched** the shared sender → the intended sender was always flagged.
- Domain-allowlisting the relay domain (`send.e2a.dev`) **silently admitted every unverified agent** indiscriminately.

## Fix
Treat a sender whose From domain is the relay's own outbound domain (or a subdomain) as **unresolvable**, and **fail the gate closed** under `allowlist`/`domain`. `open` is unaffected — open means open.

| Sender | `open` | `allowlist`/`domain` |
|---|---|---|
| External / sending-verified agent (own domain) | pass | matched normally |
| Unverified intra-system (`agent@send.e2a.dev`) | pass | **flagged** (can't satisfy the gate even if the relay domain/address is listed) |

Flagged still means **delivered + annotated + `email.flagged`** — never dropped.

## Changes
- `internal/inboundpolicy/policy.go` — `EvaluateIngestion` gains `senderResolvable`; fails closed under `allowlist`/`domain` when false.
- `internal/relay/server.go` — new `session.senderResolvable()` recognizes the shared-relay address, mirroring `envelopeFromTrusted`'s domain/subdomain matching.
- `internal/httpapi/protection.go` — gate doc comment updated.
- Tests at both layers (open-still-passes + the domain-hole regression).

## Scope (split out)
This PR is **only** the shared-relay correctness fix. A separate concern surfaced during review — the gate matches the From header without consulting DMARC, so a spoofed `From: ceo@allowlisted.com` could pass — is tracked in #318. It was deliberately **not** folded in here: requiring a DMARC-aligned pass for an allowlist match would flag *every* allowlisted sender that isn't DMARC-aligned (forwarded/list mail, domains without DMARC), a broad backward-compat change better delivered as an opt-in posture. Selectively *allowing* a specific unverified agent (trusted `X-E2A-Sender-Agent` header) also remains future work.

## Verification
`go build ./...`, `go vet`, relay/inboundpolicy/httpapi unit tests, and the `internal/e2e` inbound-policy suite all pass. No `doc:` tags changed, so the OpenAPI spec/SDK drift gate is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
