### PR TITLE
feat(relay): opt-in require-authenticated inbound gate (#318)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -125,6 +125,8 @@ components:
           type: string
         inbound_policy_action:
           type: string
+        inbound_require_auth:
+          type: boolean
         inbound_scan:
           type: string
         inbound_scan_block_threshold:
@@ -193,6 +195,7 @@ components:
         - pending_count
         - webhook_healthy
         - inbound_policy
+        - inbound_require_auth
         - inbound_policy_action
         - outbound_policy
         - outbound_policy_action
@@ -1485,6 +1488,9 @@ components:
             - allowlist
             - domain
           type: string
+        require_authenticated:
+          description: "Inbound gate only: when true, flag any sender whose From is not DMARC-aligned-authenticated, regardless of policy. Default false. Ignored on the outbound gate."
+          type: boolean
       type: object
     ProtectionHoldsView:
       additionalProperties: false

--- a/internal/e2e/inbound_policy_e2e_test.go
+++ b/internal/e2e/inbound_policy_e2e_test.go
@@ -133,6 +133,47 @@ func TestInboundPolicy_AllowlistAcceptsMember(t *testing.T) {
 	}
 }
 
+// TestInboundPolicy_RequireAuthFlagsUnauthenticated: with the opt-in
+// inbound_require_auth flag set (#318), an allowlisted sender whose From is NOT
+// DMARC-aligned-authenticated (the e2e harness injects locally-unsigned mail, so
+// DMARC=fail) is FLAGGED — a spoofed allowlisted address cannot be trusted. This
+// is the opt-in inverse of TestInboundPolicy_AllowlistAcceptsMember, where the
+// same unauthenticated sender is NOT flagged because require_auth defaults off.
+func TestInboundPolicy_RequireAuthFlagsUnauthenticated(t *testing.T) {
+	ts, pool, agent, receiver := setupFlaggedAgent(t, "allowlist",
+		[]string{"friend@trusted.com"}, "agent@reqauth.example.com", "reqauth.example.com")
+
+	// Opt the agent into authenticated-sender enforcement.
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE agent_identities SET inbound_require_auth = true WHERE id = $1`, agent.ID); err != nil {
+		t.Fatalf("set inbound_require_auth: %v", err)
+	}
+
+	msg := "From: friend@trusted.com\r\nTo: agent@reqauth.example.com\r\nSubject: Hi\r\n\r\nHello"
+	if err := smtp.SendMail(ts.SMTPAddr, nil, "friend@trusted.com", []string{"agent@reqauth.example.com"}, []byte(msg)); err != nil {
+		t.Fatalf("SendMail: %v", err)
+	}
+
+	tick(t, ts)
+	got := receiver.WaitFor(t, 5*time.Second, func(c []testutil.SubscriberCaptured) bool {
+		return eventTypes(c)["email.received"] >= 1
+	})
+	// Delivered (never dropped) but flagged for failing authentication.
+	if types := eventTypes(got); types["email.received"] < 1 {
+		t.Errorf("message must still be delivered: %v", types)
+	}
+	if n := eventTypes(got)["email.flagged"]; n != 1 {
+		t.Errorf("require_auth: unauthenticated allowlisted sender should be flagged, got %d email.flagged", n)
+	}
+	flagged, reason := readFlagged(t, pool, agent.ID)
+	if !flagged {
+		t.Error("require_auth: unauthenticated sender not persisted as flagged")
+	}
+	if reason == "" {
+		t.Error("flagged row must carry a reason")
+	}
+}
+
 // TestInboundPolicy_EvaluatesFromNotReplyTo pins the security-critical property:
 // the policy is evaluated against the authenticated From identity, NOT the
 // attacker-controllable Reply-To. A spoofer puts a trusted address in Reply-To

--- a/internal/httpapi/protection.go
+++ b/internal/httpapi/protection.go
@@ -35,10 +35,17 @@ const protectionBetaDoc = "Beta: the agent protection config is unstable — its
 // allowlist/domain gate and is flagged (fail closed); under "open" it still passes.
 // Net: per-agent inbound allowlisting is reliable for sending-verified senders;
 // unverified intra-system senders are uniformly gated, not silently admitted.
+//
+// require_authenticated (#318) is the opt-in, composable anti-spoofing flag: when
+// set on the INBOUND gate, a From that is not DMARC-aligned-authenticated is flagged
+// regardless of policy (so a spoofed allowlisted address can't be trusted). Default
+// false keeps non-DMARC mail (forwards, lists) unflagged. Inbound gate only —
+// ignored on the outbound gate.
 type ProtectionGateView struct {
-	Policy    string   `json:"policy,omitempty" enum:"open,allowlist,domain" default:"open" doc:"Trust gate: open (all), domain (listed domains), allowlist (listed addresses)."`
-	Allowlist []string `json:"allowlist,omitempty" nullable:"false" maxItems:"1000" doc:"Addresses (allowlist) or domains (domain) the gate trusts; ignored for open."`
-	Action    string   `json:"action,omitempty" enum:"flag,review,block" default:"flag" doc:"What a gate non-match does: flag (deliver + annotate), review (hold), block."`
+	Policy              string   `json:"policy,omitempty" enum:"open,allowlist,domain" default:"open" doc:"Trust gate: open (all), domain (listed domains), allowlist (listed addresses)."`
+	Allowlist           []string `json:"allowlist,omitempty" nullable:"false" maxItems:"1000" doc:"Addresses (allowlist) or domains (domain) the gate trusts; ignored for open."`
+	Action              string   `json:"action,omitempty" enum:"flag,review,block" default:"flag" doc:"What a gate non-match does: flag (deliver + annotate), review (hold), block."`
+	RequireAuthenticated bool    `json:"require_authenticated,omitempty" doc:"Inbound gate only: when true, flag any sender whose From is not DMARC-aligned-authenticated, regardless of policy. Default false. Ignored on the outbound gate."`
 }
 
 // ProtectionScanView is one direction's content scan, as a semantic sensitivity
@@ -72,7 +79,7 @@ type ProtectionConfigView struct {
 func protectionViewFromIdentity(ag *identity.AgentIdentity) ProtectionConfigView {
 	return ProtectionConfigView{
 		Inbound: ProtectionDirectionView{
-			Gate: ProtectionGateView{Policy: ag.InboundPolicy, Allowlist: orEmpty(ag.InboundAllowlist), Action: ag.InboundPolicyAction},
+			Gate: ProtectionGateView{Policy: ag.InboundPolicy, Allowlist: orEmpty(ag.InboundAllowlist), Action: ag.InboundPolicyAction, RequireAuthenticated: ag.InboundRequireAuth},
 			Scan: ProtectionScanView{Sensitivity: ag.InboundScanSensitivity},
 		},
 		Outbound: ProtectionDirectionView{
@@ -88,6 +95,7 @@ func protectionConfigFromView(v ProtectionConfigView) identity.ProtectionConfig 
 		InboundGatePolicy:       v.Inbound.Gate.Policy,
 		InboundAllowlist:        v.Inbound.Gate.Allowlist,
 		InboundGateAction:       v.Inbound.Gate.Action,
+		InboundRequireAuth:      v.Inbound.Gate.RequireAuthenticated,
 		InboundScanSensitivity:  v.Inbound.Scan.Sensitivity,
 		OutboundGatePolicy:      v.Outbound.Gate.Policy,
 		OutboundAllowlist:       v.Outbound.Gate.Allowlist,

--- a/internal/identity/protection.go
+++ b/internal/identity/protection.go
@@ -51,6 +51,7 @@ type ProtectionConfig struct {
 	InboundGatePolicy       string
 	InboundAllowlist        []string
 	InboundGateAction       string
+	InboundRequireAuth      bool
 	InboundScanSensitivity  string
 	OutboundGatePolicy      string
 	OutboundAllowlist       []string
@@ -135,7 +136,8 @@ func (s *Store) UpdateAgentProtection(ctx context.Context, agentID, userID strin
 		    outbound_policy = $10, outbound_allowlist = $11, outbound_policy_action = $12,
 		    outbound_scan = $13, outbound_scan_review_threshold = $14, outbound_scan_block_threshold = $15,
 		    outbound_scan_sensitivity = $16,
-		    hitl_ttl_seconds = $17, hitl_expiration_action = $18
+		    hitl_ttl_seconds = $17, hitl_expiration_action = $18,
+		    inbound_require_auth = $19
 		  WHERE id = $1 AND user_id = $2`,
 		agentID, userID,
 		c.InboundGatePolicy, inAllow, c.InboundGateAction,
@@ -145,6 +147,7 @@ func (s *Store) UpdateAgentProtection(ctx context.Context, agentID, userID strin
 		outB.scan, outB.review, outB.block,
 		c.OutboundScanSensitivity,
 		c.HITLTTLSeconds, c.HITLExpirationAction,
+		c.InboundRequireAuth,
 	)
 	if err != nil {
 		return err

--- a/internal/identity/protection_test.go
+++ b/internal/identity/protection_test.go
@@ -44,11 +44,15 @@ func TestUpdateAgentProtectionRoundTrip(t *testing.T) {
 	if fresh.InboundScanSensitivity != identity.SensitivityOff || fresh.OutboundScanSensitivity != identity.SensitivityOff {
 		t.Errorf("default sensitivity = %q/%q, want off/off", fresh.InboundScanSensitivity, fresh.OutboundScanSensitivity)
 	}
+	if fresh.InboundRequireAuth {
+		t.Error("fresh agent should default inbound_require_auth=false (#318)")
+	}
 
 	cfg := identity.ProtectionConfig{
 		InboundGatePolicy:       "allowlist",
 		InboundAllowlist:        []string{"partner@acme.com"},
 		InboundGateAction:       "review",
+		InboundRequireAuth:      true,
 		InboundScanSensitivity:  identity.SensitivityHigh,
 		OutboundGatePolicy:      "domain",
 		OutboundAllowlist:       []string{"acme.com"},
@@ -74,6 +78,9 @@ func TestUpdateAgentProtectionRoundTrip(t *testing.T) {
 	}
 	if len(got.InboundAllowlist) != 1 || got.InboundAllowlist[0] != "partner@acme.com" {
 		t.Errorf("inbound allowlist not persisted: %v", got.InboundAllowlist)
+	}
+	if !got.InboundRequireAuth {
+		t.Error("inbound_require_auth not persisted (#318)")
 	}
 	// Sensitivity (source of truth) persisted.
 	if got.InboundScanSensitivity != identity.SensitivityHigh || got.OutboundScanSensitivity != identity.SensitivityOff {

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -124,6 +124,10 @@ type AgentIdentity struct {
 	// trusts; empty for open.
 	InboundPolicy    string   `json:"inbound_policy"`
 	InboundAllowlist []string `json:"inbound_allowlist,omitempty"`
+	// InboundRequireAuth (migration 050 / #318) is the opt-in additive flag that
+	// requires an inbound sender's From to be DMARC-aligned-authenticated before it
+	// is trusted. Composes with InboundPolicy; defaults false (column default).
+	InboundRequireAuth bool `json:"inbound_require_auth"`
 	// Screening config (migration 038 / Slice 3). The producer-policy actions
 	// decide what a gate/scan violation does (flag|review|block); outbound_policy +
 	// outbound_allowlist are the egress recipient gate (open|allowlist|domain);
@@ -759,7 +763,7 @@ func (s *Store) GetAgentByID(ctx context.Context, id string) (*AgentIdentity, er
 		`SELECT a.id, a.domain, a.user_id, a.name, a.public, a.created_at,
 		        a.hitl_ttl_seconds, a.hitl_expiration_action,
 		        COALESCE(a.inbound_policy, 'open'), a.inbound_allowlist,
-		        a.inbound_policy_action,
+		        a.inbound_policy_action, COALESCE(a.inbound_require_auth, false),
 		        a.outbound_policy, a.outbound_allowlist, a.outbound_policy_action,
 		        a.inbound_scan, a.inbound_scan_review_threshold, a.inbound_scan_block_threshold,
 		        a.outbound_scan, a.outbound_scan_review_threshold, a.outbound_scan_block_threshold,
@@ -772,7 +776,7 @@ func (s *Store) GetAgentByID(ctx context.Context, id string) (*AgentIdentity, er
 	).Scan(&a.ID, &a.Domain, &a.UserID, &a.Name, &a.Public, &a.CreatedAt,
 		&a.HITLTTLSeconds, &a.HITLExpirationAction,
 		&a.InboundPolicy, &a.InboundAllowlist,
-		&a.InboundPolicyAction,
+		&a.InboundPolicyAction, &a.InboundRequireAuth,
 		&a.OutboundPolicy, &a.OutboundAllowlist, &a.OutboundPolicyAction,
 		&a.InboundScan, &a.InboundScanReviewThreshold, &a.InboundScanBlockThreshold,
 		&a.OutboundScan, &a.OutboundScanReviewThreshold, &a.OutboundScanBlockThreshold,
@@ -936,7 +940,7 @@ func (s *Store) ListAgentsByUser(ctx context.Context, userID string) ([]AgentIde
 		`SELECT a.id, a.domain, a.user_id, a.name, a.public, a.created_at,
 		        a.hitl_ttl_seconds, a.hitl_expiration_action,
 		        COALESCE(a.inbound_policy, 'open'), a.inbound_allowlist,
-		        a.inbound_policy_action,
+		        a.inbound_policy_action, COALESCE(a.inbound_require_auth, false),
 		        a.outbound_policy, a.outbound_allowlist, a.outbound_policy_action,
 		        a.inbound_scan, a.inbound_scan_review_threshold, a.inbound_scan_block_threshold,
 		        a.outbound_scan, a.outbound_scan_review_threshold, a.outbound_scan_block_threshold,
@@ -977,7 +981,7 @@ func (s *Store) ListAgentsByUser(ctx context.Context, userID string) ([]AgentIde
 		if err := rows.Scan(&a.ID, &a.Domain, &a.UserID, &a.Name, &a.Public, &a.CreatedAt,
 			&a.HITLTTLSeconds, &a.HITLExpirationAction,
 			&a.InboundPolicy, &a.InboundAllowlist,
-			&a.InboundPolicyAction,
+			&a.InboundPolicyAction, &a.InboundRequireAuth,
 			&a.OutboundPolicy, &a.OutboundAllowlist, &a.OutboundPolicyAction,
 			&a.InboundScan, &a.InboundScanReviewThreshold, &a.InboundScanBlockThreshold,
 			&a.OutboundScan, &a.OutboundScanReviewThreshold, &a.OutboundScanBlockThreshold,

--- a/internal/inboundpolicy/policy.go
+++ b/internal/inboundpolicy/policy.go
@@ -48,46 +48,73 @@ type Decision struct {
 	Reason  string // human-readable; empty when not flagged
 }
 
-// unresolvableSenderReason is the fail-closed flag reason for a sender with no
-// specific authenticated identity (shared-relay "via e2a" mail) under a gating
-// policy — see senderResolvable in the relay and issue #299.
-const unresolvableSenderReason = "sender has no resolvable per-agent identity (shared relay), so it cannot match a per-agent inbound gate"
+// Fail-closed flag reasons.
+const (
+	// unresolvableSenderReason: the From has no per-agent identity — shared-relay
+	// "via e2a" mail (#299). See senderResolvable in the relay.
+	unresolvableSenderReason = "sender has no resolvable per-agent identity (shared relay), so it cannot match a per-agent inbound gate"
+	// unauthenticatedSenderReason: require_authenticated is set and the From is not
+	// DMARC-aligned-authenticated, so it may be spoofed and is not trusted (#318).
+	unauthenticatedSenderReason = "sender From identity is not DMARC-authenticated and the gate requires authentication"
+)
+
+// Request is the per-message input to EvaluateIngestion. A struct (not positional
+// args) because the gate composes several orthogonal predicates.
+type Request struct {
+	// Policy is the agent's inbound_policy (unknown/empty → treated as Open).
+	Policy string
+	// Allowlist is the agent's inbound_allowlist (addresses for Allowlist, domains
+	// for Domain); matching is case-insensitive.
+	Allowlist []string
+	// SenderEmail is the message's From identity (the authenticated-from, not
+	// Reply-To).
+	SenderEmail string
+	// SenderResolvable: false for mail relayed under the shared "via e2a" address,
+	// which authenticates but carries no per-agent identity (#299). An unresolvable
+	// sender can never satisfy a per-agent allowlist/domain gate.
+	SenderResolvable bool
+	// SenderAuthenticated: whether SenderEmail is DMARC-aligned-authenticated
+	// (RFC 7489). Only consulted when RequireAuth is set.
+	SenderAuthenticated bool
+	// RequireAuth is the agent's opt-in inbound_require_auth flag (#318). When set,
+	// an unauthenticated From is flagged regardless of policy — the composable,
+	// additive anti-spoofing posture. Off by default (backward-compatible).
+	RequireAuth bool
+}
 
 // EvaluateIngestion applies the agent's ingestion policy to an inbound message.
-//   - policy: the agent's inbound_policy (unknown/empty → treated as Open).
-//   - allowlist: the agent's inbound_allowlist (addresses for Allowlist,
-//     domains for Domain); matching is case-insensitive.
-//   - senderEmail: the message's display sender (From identity).
-//   - senderResolvable: whether senderEmail maps to a SPECIFIC authenticated
-//     sender. False for mail relayed under the shared "via e2a" address, which
-//     authenticates (DMARC passes for the relay domain) but carries no per-agent
-//     identity (#299). An unresolvable sender can never legitimately satisfy a
-//     per-agent allowlist/domain gate, so it is treated as a non-match. Open is
-//     unaffected — open means open.
 //
 // Flagged is fail-closed for the gating postures: an empty/garbage sender, an
-// empty allowlist, or an unresolvable sender flags everything (you opted into a
-// gate but the sender cannot be matched).
-func EvaluateIngestion(policy string, allowlist []string, senderEmail string, senderResolvable bool) Decision {
-	switch policy {
+// empty allowlist, an unresolvable sender, or (when RequireAuth is set) an
+// unauthenticated sender flags everything. Open never flags on policy alone, but
+// RequireAuth still applies (it is an additive precondition across all policies).
+func EvaluateIngestion(r Request) Decision {
+	// Additive anti-spoofing precondition (#318): an opted-in agent never trusts an
+	// unauthenticated From, on any policy. Open + require_auth ≈ the old
+	// verified_only posture; allowlist/domain + require_auth additionally checks the
+	// list for authenticated mail below.
+	if r.RequireAuth && !r.SenderAuthenticated {
+		return Decision{Flagged: true, Reason: unauthenticatedSenderReason}
+	}
+	switch r.Policy {
 	case Allowlist:
-		if !senderResolvable {
+		if !r.SenderResolvable {
 			return Decision{Flagged: true, Reason: unresolvableSenderReason}
 		}
-		if containsFold(allowlist, strings.TrimSpace(senderEmail)) {
+		if containsFold(r.Allowlist, strings.TrimSpace(r.SenderEmail)) {
 			return Decision{}
 		}
 		return Decision{Flagged: true, Reason: "sender not on the agent's inbound allowlist"}
 	case Domain:
-		if !senderResolvable {
+		if !r.SenderResolvable {
 			return Decision{Flagged: true, Reason: unresolvableSenderReason}
 		}
-		dom := domainOf(senderEmail)
-		if dom != "" && containsFold(allowlist, dom) {
+		dom := domainOf(r.SenderEmail)
+		if dom != "" && containsFold(r.Allowlist, dom) {
 			return Decision{}
 		}
 		return Decision{Flagged: true, Reason: "sender domain not on the agent's inbound allowlist"}
-	default: // Open or unknown → never flag
+	default: // Open or unknown → never flag on policy (RequireAuth handled above)
 		return Decision{}
 	}
 }

--- a/internal/inboundpolicy/policy_test.go
+++ b/internal/inboundpolicy/policy_test.go
@@ -4,32 +4,51 @@ import "testing"
 
 func TestEvaluateIngestion(t *testing.T) {
 	tests := []struct {
-		name       string
-		policy     string
-		allowlist  []string
-		sender     string
-		resolvable bool
-		flagged    bool
+		name          string
+		policy        string
+		allowlist     []string
+		sender        string
+		resolvable    bool
+		authenticated bool
+		requireAuth   bool
+		flagged       bool
 	}{
-		{"open never flags", Open, nil, "anyone@evil.com", true, false},
-		{"unknown policy treated as open", "bogus", nil, "x@y.com", true, false},
-		{"allowlist match", Allowlist, []string{"boss@acme.com"}, "boss@acme.com", true, false},
-		{"allowlist case-insensitive", Allowlist, []string{"Boss@Acme.com"}, "boss@acme.com", true, false},
-		{"allowlist non-match flagged", Allowlist, []string{"boss@acme.com"}, "stranger@x.com", true, true},
-		{"allowlist empty flags all", Allowlist, nil, "boss@acme.com", true, true},
-		{"domain match", Domain, []string{"acme.com"}, "anyone@acme.com", true, false},
-		{"domain non-match flagged", Domain, []string{"acme.com"}, "x@evil.com", true, true},
-		{"domain garbage sender flagged", Domain, []string{"acme.com"}, "nodomain", true, true},
+		{"open never flags", Open, nil, "anyone@evil.com", true, true, false, false},
+		{"unknown policy treated as open", "bogus", nil, "x@y.com", true, true, false, false},
+		{"allowlist match", Allowlist, []string{"boss@acme.com"}, "boss@acme.com", true, true, false, false},
+		{"allowlist case-insensitive", Allowlist, []string{"Boss@Acme.com"}, "boss@acme.com", true, true, false, false},
+		{"allowlist non-match flagged", Allowlist, []string{"boss@acme.com"}, "stranger@x.com", true, true, false, true},
+		{"allowlist empty flags all", Allowlist, nil, "boss@acme.com", true, true, false, true},
+		{"domain match", Domain, []string{"acme.com"}, "anyone@acme.com", true, true, false, false},
+		{"domain non-match flagged", Domain, []string{"acme.com"}, "x@evil.com", true, true, false, true},
+		{"domain garbage sender flagged", Domain, []string{"acme.com"}, "nodomain", true, true, false, true},
 		// #299: a sender with no resolvable per-agent identity (shared relay) can
 		// never satisfy a gating policy, even if the allowlist names its address
 		// or domain. Open still passes — open means open.
-		{"allowlist unresolvable flagged despite address match", Allowlist, []string{"agent@send.e2a.dev"}, "agent@send.e2a.dev", false, true},
-		{"domain unresolvable flagged despite domain match", Domain, []string{"send.e2a.dev"}, "agent@send.e2a.dev", false, true},
-		{"open unresolvable still passes", Open, nil, "agent@send.e2a.dev", false, false},
+		{"allowlist unresolvable flagged despite address match", Allowlist, []string{"agent@send.e2a.dev"}, "agent@send.e2a.dev", false, true, false, true},
+		{"domain unresolvable flagged despite domain match", Domain, []string{"send.e2a.dev"}, "agent@send.e2a.dev", false, true, false, true},
+		{"open unresolvable still passes", Open, nil, "agent@send.e2a.dev", false, true, false, false},
+		// #318: require_authenticated is an additive opt-in. When off (default), an
+		// unauthenticated allowlisted sender still matches (backward-compatible).
+		// When on, an unauthenticated From is flagged regardless of policy, but an
+		// authenticated allowlisted sender still passes.
+		{"require_auth off: unauthenticated allowlist match passes", Allowlist, []string{"friend@trusted.com"}, "friend@trusted.com", true, false, false, false},
+		{"require_auth on: unauthenticated allowlist match flagged", Allowlist, []string{"friend@trusted.com"}, "friend@trusted.com", true, false, true, true},
+		{"require_auth on: authenticated allowlist match passes", Allowlist, []string{"friend@trusted.com"}, "friend@trusted.com", true, true, true, false},
+		{"require_auth on: unauthenticated under open flagged", Open, nil, "anyone@nowhere.com", true, false, true, true},
+		{"require_auth on: authenticated under open passes", Open, nil, "anyone@nowhere.com", true, true, true, false},
+		{"require_auth on: domain match but unauthenticated flagged", Domain, []string{"trusted.com"}, "friend@trusted.com", true, false, true, true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			d := EvaluateIngestion(tc.policy, tc.allowlist, tc.sender, tc.resolvable)
+			d := EvaluateIngestion(Request{
+				Policy:              tc.policy,
+				Allowlist:           tc.allowlist,
+				SenderEmail:         tc.sender,
+				SenderResolvable:    tc.resolvable,
+				SenderAuthenticated: tc.authenticated,
+				RequireAuth:         tc.requireAuth,
+			})
 			if d.Flagged != tc.flagged {
 				t.Errorf("Flagged=%v want %v (reason=%q)", d.Flagged, tc.flagged, d.Reason)
 			}

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -299,14 +299,24 @@ func (s *session) deliverToAgent(ctx context.Context, agent *identity.AgentIdent
 	}
 
 	// Inbound trust policy ingestion gate (decision 10 / Slice 7a). Evaluate the
-	// agent's policy against the AUTHENTICATED From identity (senderEmail — what
-	// SPF/DKIM/DMARC pertain to), NOT displaySender (Reply-To is attacker-
-	// controllable). A non-match is FLAGGED — still delivered (never dropped),
-	// marked on the row, and emits email.flagged so operators get a signal.
+	// agent's policy against the From identity (senderEmail), NOT displaySender
+	// (Reply-To is attacker-controllable). A non-match is FLAGGED — still delivered
+	// (never dropped), marked on the row, and emits email.flagged so operators get
+	// a signal.
 	//
-	// senderResolvable fails the gate closed for shared-relay "via e2a" mail,
-	// which authenticates but carries no per-agent identity (#299).
-	policyDecision := inboundpolicy.EvaluateIngestion(agent.InboundPolicy, agent.InboundAllowlist, senderEmail, s.senderResolvable(senderEmail))
+	// senderResolvable fails the gate closed for shared-relay "via e2a" mail, which
+	// authenticates but carries no per-agent identity (#299). When the agent opts in
+	// to inbound_require_auth (#318), an unauthenticated From is flagged regardless
+	// of policy — use the aligned DMARC verdict, not DomainAuthenticated() (SPF/DKIM
+	// pass without From-alignment is still spoofable).
+	policyDecision := inboundpolicy.EvaluateIngestion(inboundpolicy.Request{
+		Policy:              agent.InboundPolicy,
+		Allowlist:           agent.InboundAllowlist,
+		SenderEmail:         senderEmail,
+		SenderResolvable:    s.senderResolvable(senderEmail),
+		SenderAuthenticated: domainAuth != nil && domainAuth.DMARC.Status == emailauth.StatusPass,
+		RequireAuth:         agent.InboundRequireAuth,
+	})
 
 	// Content screening (Slice 4): run the per-agent inbound scan and record the
 	// audit trail (protection_events) + the denormalized verdict. Detection +

--- a/migrations/050_inbound_require_auth.sql
+++ b/migrations/050_inbound_require_auth.sql
@@ -1,0 +1,21 @@
+-- 050_inbound_require_auth.sql
+--
+-- Opt-in per-agent inbound-gate flag: require the sender's From identity to be
+-- DMARC-aligned-authenticated before it is trusted. This is the composable,
+-- additive return of the dropped `verified_only` posture (migration 047) — it
+-- COMPOSES with the trust ladder instead of replacing it:
+--
+--   inbound_require_auth = false (default)
+--       gate behaves exactly as today (open | allowlist | domain).
+--   inbound_require_auth = true
+--       an unauthenticated (spoofable) From is FLAGGED regardless of policy;
+--       under allowlist/domain the list is still checked for authenticated mail.
+--
+-- Default false preserves backward-compatible behavior — legitimate mail that is
+-- not DMARC-aligned (forwards, lists, domains without DMARC) is not flagged unless
+-- an operator opts in. Closes the From-spoofing gap on the allowlist gate (#318).
+--
+-- Idempotent + non-destructive: ADD COLUMN with a constant default does not
+-- rewrite the table (Postgres 11+).
+ALTER TABLE agent_identities
+    ADD COLUMN IF NOT EXISTS inbound_require_auth BOOLEAN NOT NULL DEFAULT false;

--- a/sdks/python/src/e2a/v1/generated/models/agent_identity.py
+++ b/sdks/python/src/e2a/v1/generated/models/agent_identity.py
@@ -36,6 +36,7 @@ class AgentIdentity(BaseModel):
     inbound_allowlist: Optional[List[StrictStr]] = None
     inbound_policy: StrictStr
     inbound_policy_action: StrictStr
+    inbound_require_auth: StrictBool
     inbound_scan: StrictStr
     inbound_scan_block_threshold: Union[StrictFloat, StrictInt]
     inbound_scan_review_threshold: Union[StrictFloat, StrictInt]
@@ -56,7 +57,7 @@ class AgentIdentity(BaseModel):
     review_ttl_seconds: StrictInt
     user_id: StrictStr
     webhook_healthy: StrictBool
-    __properties: ClassVar[List[str]] = ["created_at", "domain", "domain_verified", "email", "id", "inbound_7d", "inbound_allowlist", "inbound_policy", "inbound_policy_action", "inbound_scan", "inbound_scan_block_threshold", "inbound_scan_review_threshold", "inbound_scan_sensitivity", "last_delivery_at", "name", "outbound_7d", "outbound_allowlist", "outbound_policy", "outbound_policy_action", "outbound_scan", "outbound_scan_block_threshold", "outbound_scan_review_threshold", "outbound_scan_sensitivity", "pending_count", "public", "review_expiration_action", "review_ttl_seconds", "user_id", "webhook_healthy"]
+    __properties: ClassVar[List[str]] = ["created_at", "domain", "domain_verified", "email", "id", "inbound_7d", "inbound_allowlist", "inbound_policy", "inbound_policy_action", "inbound_require_auth", "inbound_scan", "inbound_scan_block_threshold", "inbound_scan_review_threshold", "inbound_scan_sensitivity", "last_delivery_at", "name", "outbound_7d", "outbound_allowlist", "outbound_policy", "outbound_policy_action", "outbound_scan", "outbound_scan_block_threshold", "outbound_scan_review_threshold", "outbound_scan_sensitivity", "pending_count", "public", "review_expiration_action", "review_ttl_seconds", "user_id", "webhook_healthy"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -128,6 +129,7 @@ class AgentIdentity(BaseModel):
             "inbound_allowlist": obj.get("inbound_allowlist"),
             "inbound_policy": obj.get("inbound_policy"),
             "inbound_policy_action": obj.get("inbound_policy_action"),
+            "inbound_require_auth": obj.get("inbound_require_auth"),
             "inbound_scan": obj.get("inbound_scan"),
             "inbound_scan_block_threshold": obj.get("inbound_scan_block_threshold"),
             "inbound_scan_review_threshold": obj.get("inbound_scan_review_threshold"),

--- a/sdks/python/src/e2a/v1/generated/models/protection_gate_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/protection_gate_view.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, Field, StrictStr, field_validator
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr, field_validator
 from typing import Any, ClassVar, Dict, List, Optional
 from typing_extensions import Annotated
 from typing import Optional, Set
@@ -30,7 +30,8 @@ class ProtectionGateView(BaseModel):
     action: Optional[StrictStr] = Field(default='flag', description="What a gate non-match does: flag (deliver + annotate), review (hold), block.")
     allowlist: Optional[Annotated[List[StrictStr], Field(max_length=1000)]] = Field(default=None, description="Addresses (allowlist) or domains (domain) the gate trusts; ignored for open.")
     policy: Optional[StrictStr] = Field(default='open', description="Trust gate: open (all), domain (listed domains), allowlist (listed addresses).")
-    __properties: ClassVar[List[str]] = ["action", "allowlist", "policy"]
+    require_authenticated: Optional[StrictBool] = Field(default=None, description="Inbound gate only: when true, flag any sender whose From is not DMARC-aligned-authenticated, regardless of policy. Default false. Ignored on the outbound gate.")
+    __properties: ClassVar[List[str]] = ["action", "allowlist", "policy", "require_authenticated"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -85,7 +86,8 @@ class ProtectionGateView(BaseModel):
         _obj = cls.model_validate({
             "action": obj.get("action") if obj.get("action") is not None else 'flag',
             "allowlist": obj.get("allowlist"),
-            "policy": obj.get("policy") if obj.get("policy") is not None else 'open'
+            "policy": obj.get("policy") if obj.get("policy") is not None else 'open',
+            "require_authenticated": obj.get("require_authenticated")
         })
         return _obj
 

--- a/sdks/typescript/src/v1/generated/models/AgentIdentity.ts
+++ b/sdks/typescript/src/v1/generated/models/AgentIdentity.ts
@@ -22,6 +22,7 @@ export class AgentIdentity {
     'inboundAllowlist'?: Array<string> | null;
     'inboundPolicy': string;
     'inboundPolicyAction': string;
+    'inboundRequireAuth': boolean;
     'inboundScan': string;
     'inboundScanBlockThreshold': number;
     'inboundScanReviewThreshold': number;
@@ -100,6 +101,12 @@ export class AgentIdentity {
             "name": "inboundPolicyAction",
             "baseName": "inbound_policy_action",
             "type": "string",
+            "format": ""
+        },
+        {
+            "name": "inboundRequireAuth",
+            "baseName": "inbound_require_auth",
+            "type": "boolean",
             "format": ""
         },
         {

--- a/sdks/typescript/src/v1/generated/models/ObjectSerializer.ts
+++ b/sdks/typescript/src/v1/generated/models/ObjectSerializer.ts
@@ -129,7 +129,7 @@ import { PageWebhookView } from '../models/PageWebhookView.js';
 import { ProtectionConfigView } from '../models/ProtectionConfigView.js';
 import { ProtectionDirectionView } from '../models/ProtectionDirectionView.js';
 import { ProtectionEventExportEntry } from '../models/ProtectionEventExportEntry.js';
-import { ProtectionGateView, ProtectionGateViewActionEnum   , ProtectionGateViewPolicyEnum   } from '../models/ProtectionGateView.js';
+import { ProtectionGateView, ProtectionGateViewActionEnum   , ProtectionGateViewPolicyEnum    } from '../models/ProtectionGateView.js';
 import { ProtectionHoldsView, ProtectionHoldsViewOnExpiryEnum    } from '../models/ProtectionHoldsView.js';
 import { ProtectionScanView, ProtectionScanViewSensitivityEnum   } from '../models/ProtectionScanView.js';
 import { RedeliverDelivery } from '../models/RedeliverDelivery.js';

--- a/sdks/typescript/src/v1/generated/models/ProtectionGateView.ts
+++ b/sdks/typescript/src/v1/generated/models/ProtectionGateView.ts
@@ -25,6 +25,10 @@ export class ProtectionGateView {
     * Trust gate: open (all), domain (listed domains), allowlist (listed addresses).
     */
     'policy'?: ProtectionGateViewPolicyEnum;
+    /**
+    * Inbound gate only: when true, flag any sender whose From is not DMARC-aligned-authenticated, regardless of policy. Default false. Ignored on the outbound gate.
+    */
+    'requireAuthenticated'?: boolean;
 
     static readonly discriminator: string | undefined = undefined;
 
@@ -47,6 +51,12 @@ export class ProtectionGateView {
             "name": "policy",
             "baseName": "policy",
             "type": "ProtectionGateViewPolicyEnum",
+            "format": ""
+        },
+        {
+            "name": "requireAuthenticated",
+            "baseName": "require_authenticated",
+            "type": "boolean",
             "format": ""
         }    ];
 


### PR DESCRIPTION
Closes #318. Follow-up to #316 (#299).

## Problem
The inbound trust gate (`allowlist`/`domain`) matches on the message `From` without consulting DMARC, so a spoofed `From: ceo@allowlisted-corp.com` (SPF/DKIM/DMARC all failing) is delivered as a **trusted, allowlisted** sender with no `email.flagged`. Surfaced by the adversarial review of #316.

An **always-on** DMARC requirement is too aggressive — it flags *every* legitimate allowlisted sender that isn't DMARC-aligned (forwarded mail, mailing lists, domains without DMARC). We tried that in #316 and it broke the e2e inbound-policy suite for exactly that reason.

## Fix — opt-in, composable `require_authenticated`
A per-agent **`inbound_require_auth`** flag (default `false` → fully backward-compatible). It's the additive return of the `verified_only` posture that migration 047 anticipated ("may return later as a composable, additive policy"). When `true`, an inbound `From` that is not **DMARC-aligned-authenticated** (RFC 7489) is flagged **regardless of policy**:

| Policy | `require_auth=false` (default) | `require_auth=true` |
|---|---|---|
| `open` | accept all | flag unauthenticated (≈ old `verified_only`) |
| `allowlist`/`domain` | match as today | match **and** require authentication |

Uses the **aligned** DMARC verdict (`DMARC == pass`), not `DomainAuthenticated()` (SPF/DKIM pass without From-alignment is still spoofable). The gate **flags, never rejects** — unauthenticated mail is delivered-flagged, not bounced — so opting in doesn't break indirect mail the way a hard DMARC reject would.

## Changes
- **`migrations/050_inbound_require_auth.sql`** — `inbound_require_auth BOOLEAN NOT NULL DEFAULT false` (idempotent, non-rewriting).
- **`internal/identity`** — `AgentIdentity` + `ProtectionConfig` field, both SELECT/Scan paths, `UpdateAgentProtection` write, DB round-trip test.
- **`internal/httpapi/protection.go`** — `ProtectionGateView.require_authenticated` (inbound gate only; ignored on outbound). **OpenAPI + TS/Python SDK bases regenerated** (`make generate`).
- **`internal/inboundpolicy`** — `EvaluateIngestion` now takes a `Request` struct; `RequireAuth` + `SenderAuthenticated` as an additive precondition across all policies.
- **`internal/relay/server.go`** — derives `senderAuthenticated` from `domainAuth.DMARC == pass`.
- **Tests** — unit matrix (opt-in on/off, spoofed-From, open+require_auth) + e2e (`TestInboundPolicy_RequireAuthFlagsUnauthenticated`: opt-in flags an unauthenticated allowlisted sender end-to-end; the default-off `AllowlistAcceptsMember` still passes).

## Verification
`go build ./...`, `go vet`, unit (`inboundpolicy`/`relay`/`httpapi` incl. the spec-golden drift gate), DB-backed `identity` round-trip, and the `internal/e2e` inbound-policy suite all pass. `api/openapi.yaml` + both SDK bases regenerated, so the spec/SDK drift gates are satisfied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
