### PR TITLE
docs(api): note the inbound gate's From-authentication limitation (#318)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1472,7 +1472,7 @@ components:
             - block
           type: string
         allowlist:
-          description: Addresses (allowlist) or domains (domain) the gate trusts; ignored for open.
+          description: "Addresses (allowlist) or domains (domain) the gate trusts; ignored for open. Inbound: matched against the message From AS PRESENTED — a match does not by itself prove the sender is authentic (a forged From that fails SPF/DKIM/DMARC can still match). For spoofing-sensitive trust, also check the message authentication result."
           items:
             type: string
           maxItems: 1000

--- a/internal/httpapi/protection.go
+++ b/internal/httpapi/protection.go
@@ -35,9 +35,18 @@ const protectionBetaDoc = "Beta: the agent protection config is unstable — its
 // allowlist/domain gate and is flagged (fail closed); under "open" it still passes.
 // Net: per-agent inbound allowlisting is reliable for sending-verified senders;
 // unverified intra-system senders are uniformly gated, not silently admitted.
+//
+// INBOUND authentication limitation (#318): the allowlist/domain gate matches the
+// From address AS PRESENTED — it does not by itself require the From to be
+// DMARC-aligned-authenticated. An external message that forges From to a listed
+// address/domain but fails SPF/DKIM/DMARC can therefore satisfy the gate. The
+// authentication verdict is delivered separately (the X-E2A-Auth-* headers /
+// webhook auth fields), so a consumer that needs anti-spoofing must check it in
+// addition to the gate. A DMARC-gated posture may return later as a composable,
+// additive flag (the protection config is beta — its shape may still change).
 type ProtectionGateView struct {
 	Policy    string   `json:"policy,omitempty" enum:"open,allowlist,domain" default:"open" doc:"Trust gate: open (all), domain (listed domains), allowlist (listed addresses)."`
-	Allowlist []string `json:"allowlist,omitempty" nullable:"false" maxItems:"1000" doc:"Addresses (allowlist) or domains (domain) the gate trusts; ignored for open."`
+	Allowlist []string `json:"allowlist,omitempty" nullable:"false" maxItems:"1000" doc:"Addresses (allowlist) or domains (domain) the gate trusts; ignored for open. Inbound: matched against the message From AS PRESENTED — a match does not by itself prove the sender is authentic (a forged From that fails SPF/DKIM/DMARC can still match). For spoofing-sensitive trust, also check the message authentication result."`
 	Action    string   `json:"action,omitempty" enum:"flag,review,block" default:"flag" doc:"What a gate non-match does: flag (deliver + annotate), review (hold), block."`
 }
 

--- a/sdks/python/src/e2a/v1/generated/models/protection_gate_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/protection_gate_view.py
@@ -28,7 +28,7 @@ class ProtectionGateView(BaseModel):
     ProtectionGateView
     """ # noqa: E501
     action: Optional[StrictStr] = Field(default='flag', description="What a gate non-match does: flag (deliver + annotate), review (hold), block.")
-    allowlist: Optional[Annotated[List[StrictStr], Field(max_length=1000)]] = Field(default=None, description="Addresses (allowlist) or domains (domain) the gate trusts; ignored for open.")
+    allowlist: Optional[Annotated[List[StrictStr], Field(max_length=1000)]] = Field(default=None, description="Addresses (allowlist) or domains (domain) the gate trusts; ignored for open. Inbound: matched against the message From AS PRESENTED — a match does not by itself prove the sender is authentic (a forged From that fails SPF/DKIM/DMARC can still match). For spoofing-sensitive trust, also check the message authentication result.")
     policy: Optional[StrictStr] = Field(default='open', description="Trust gate: open (all), domain (listed domains), allowlist (listed addresses).")
     __properties: ClassVar[List[str]] = ["action", "allowlist", "policy"]
 

--- a/sdks/typescript/src/v1/generated/models/ProtectionGateView.ts
+++ b/sdks/typescript/src/v1/generated/models/ProtectionGateView.ts
@@ -18,7 +18,7 @@ export class ProtectionGateView {
     */
     'action'?: ProtectionGateViewActionEnum;
     /**
-    * Addresses (allowlist) or domains (domain) the gate trusts; ignored for open.
+    * Addresses (allowlist) or domains (domain) the gate trusts; ignored for open. Inbound: matched against the message From AS PRESENTED — a match does not by itself prove the sender is authentic (a forged From that fails SPF/DKIM/DMARC can still match). For spoofing-sensitive trust, also check the message authentication result.
     */
     'allowlist'?: Array<string>;
     /**


### PR DESCRIPTION
Closes #318 by **documenting** the limitation instead of shipping a DMARC-enforcement feature (see closed #319 for the opt-in-toggle alternative).

## Background
The inbound allowlist/domain gate matches the message `From` **as presented** and does not by itself require DMARC alignment — so a forged `From` that matches a listed address/domain but fails SPF/DKIM/DMARC can satisfy the gate (found in the #316 adversarial review).

We chose **not** to enforce DMARC, because:
- Always-on would flag legitimate non-DMARC mail (forwards, lists, no-DMARC domains) — it broke the e2e suite when tried in #316.
- An opt-in toggle (#319) adds DB + API + SDK surface for a beta resource.
- The protection config is explicitly **beta** ("shape may change before stable"), so a composable DMARC-gated posture can return later as a **non-breaking additive flag** whenever there's demand.

## Change (doc-only)
- `internal/httpapi/protection.go` — the `allowlist` field doc and the `ProtectionGateView` package comment now state that an inbound match is on the From as presented, does not prove authenticity, and that spoofing-sensitive consumers should also check the message authentication result (`X-E2A-Auth-*` / webhook auth fields).
- Regenerated `api/openapi.yaml` + TS/Python SDK bases so the note reaches SDK consumers.

No behavior change. Spec-golden test passes; spec + SDK drift gates satisfied.