### PR TITLE
feat(identity): envelope-encrypt DKIM private keys at rest (#144 / M4)

### DIFF
--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -174,6 +174,20 @@ func main() {
 
 	// Services
 	store := identity.NewStore(pool)
+	// Envelope-encrypt DKIM private keys at rest (#144 / M4). In production the
+	// signing secret is enforced ≥32 bytes so the cipher is always configured and
+	// the startup backfill encrypts any legacy plaintext keys; in a weak-secret
+	// dev deploy we log and fall back to plaintext storage.
+	if dkimCipher, derr := identity.NewDKIMCipher([]byte(cfg.Signing.HMACSecret)); derr != nil {
+		log.Printf("[identity] DKIM key encryption-at-rest disabled: %v", derr)
+	} else {
+		store.SetDKIMCipher(dkimCipher)
+		if n, berr := store.EncryptLegacyDKIMKeys(ctx); berr != nil {
+			log.Fatalf("DKIM key encryption backfill failed: %v", berr)
+		} else if n > 0 {
+			log.Printf("[identity] encrypted %d legacy DKIM private key(s) at rest", n)
+		}
+	}
 	if err := store.EnsureSharedDomain(ctx, cfg.SharedDomain); err != nil {
 		log.Fatalf("Failed to seed shared domain row: %v", err)
 	}

--- a/internal/identity/dkim_encryption_db_test.go
+++ b/internal/identity/dkim_encryption_db_test.go
@@ -1,0 +1,156 @@
+package identity_test
+
+import (
+	"context"
+	"crypto/x509"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func dkimMaster() []byte {
+	m := make([]byte, 32)
+	for i := range m {
+		m[i] = byte(i*7 + 3)
+	}
+	return m
+}
+
+func rawDKIMColumn(t *testing.T, pool *pgxpool.Pool, domain string) []byte {
+	t.Helper()
+	var raw []byte
+	if err := pool.QueryRow(context.Background(),
+		`SELECT dkim_private_key FROM domains WHERE domain = $1`, domain).Scan(&raw); err != nil {
+		t.Fatalf("read raw dkim column: %v", err)
+	}
+	return raw
+}
+
+// TestDKIMKeyEncryptedAtRest: with a cipher configured, ClaimOrCreateDomain stores
+// the private key encrypted (tagged 0x01, not parseable as DER), yet both internal
+// readers return the original, valid PKCS#1 key.
+func TestDKIMKeyEncryptedAtRest(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+
+	cipher, err := identity.NewDKIMCipher(dkimMaster())
+	if err != nil {
+		t.Fatalf("NewDKIMCipher: %v", err)
+	}
+	store := identity.NewStore(pool)
+	store.SetDKIMCipher(cipher)
+
+	user, err := store.CreateOrGetUser(ctx, "owner@enc.example.com", "Owner", "google-enc")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	if _, err := store.ClaimOrCreateDomain(ctx, "enc.example.com", user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+
+	// Raw column is encrypted: tagged 0x01 (DER would be 0x30) and not parseable.
+	raw := rawDKIMColumn(t, pool, "enc.example.com")
+	if len(raw) == 0 || raw[0] != 0x01 {
+		t.Fatalf("dkim_private_key not encrypted at rest: first byte = %#x", raw[0])
+	}
+	if _, err := x509.ParsePKCS1PrivateKey(raw); err == nil {
+		t.Error("encrypted column should not parse as a PKCS#1 key")
+	}
+
+	// Both readers decrypt back to a valid key.
+	for _, rd := range []struct {
+		name string
+		der  func() ([]byte, error)
+	}{
+		{"GetDKIMKeyInternal", func() ([]byte, error) {
+			_, der, err := store.GetDKIMKeyInternal(ctx, "enc.example.com")
+			return der, err
+		}},
+		{"SendingProvisionInputs", func() ([]byte, error) {
+			_, der, _, err := store.SendingProvisionInputs(ctx, "enc.example.com")
+			return der, err
+		}},
+	} {
+		der, err := rd.der()
+		if err != nil {
+			t.Fatalf("%s: %v", rd.name, err)
+		}
+		if _, err := x509.ParsePKCS1PrivateKey(der); err != nil {
+			t.Errorf("%s did not return a valid PKCS#1 key: %v", rd.name, err)
+		}
+	}
+}
+
+// TestDKIMKeyEncryptedNoCipherFailsClosed: a reader without the cipher must error
+// on an encrypted row rather than hand back ciphertext as a key.
+func TestDKIMKeyEncryptedNoCipherFailsClosed(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+
+	cipher, _ := identity.NewDKIMCipher(dkimMaster())
+	encStore := identity.NewStore(pool)
+	encStore.SetDKIMCipher(cipher)
+	user, err := encStore.CreateOrGetUser(ctx, "owner@nocipher.example.com", "Owner", "google-nc")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	if _, err := encStore.ClaimOrCreateDomain(ctx, "nocipher.example.com", user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+
+	plainStore := identity.NewStore(pool) // no cipher
+	if _, _, err := plainStore.GetDKIMKeyInternal(ctx, "nocipher.example.com"); err == nil {
+		t.Error("reading an encrypted key without a cipher must fail closed")
+	}
+}
+
+// TestEncryptLegacyDKIMKeysBackfill: a plaintext key written without a cipher is
+// re-encrypted by the backfill, still decrypts, and the backfill is idempotent.
+func TestEncryptLegacyDKIMKeysBackfill(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+
+	// 1. Write a legacy plaintext key (no cipher).
+	plainStore := identity.NewStore(pool)
+	user, err := plainStore.CreateOrGetUser(ctx, "owner@legacy.example.com", "Owner", "google-legacy")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	if _, err := plainStore.ClaimOrCreateDomain(ctx, "legacy.example.com", user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+	if raw := rawDKIMColumn(t, pool, "legacy.example.com"); raw[0] != 0x30 {
+		t.Fatalf("expected legacy plaintext DER (0x30), got first byte %#x", raw[0])
+	}
+
+	// 2. Backfill with a cipher.
+	cipher, _ := identity.NewDKIMCipher(dkimMaster())
+	encStore := identity.NewStore(pool)
+	encStore.SetDKIMCipher(cipher)
+	n, err := encStore.EncryptLegacyDKIMKeys(ctx)
+	if err != nil {
+		t.Fatalf("EncryptLegacyDKIMKeys: %v", err)
+	}
+	if n < 1 {
+		t.Fatalf("backfill encrypted %d rows, want ≥1", n)
+	}
+	if raw := rawDKIMColumn(t, pool, "legacy.example.com"); raw[0] != 0x01 {
+		t.Errorf("row not encrypted after backfill: first byte %#x", raw[0])
+	}
+	if _, der, err := encStore.GetDKIMKeyInternal(ctx, "legacy.example.com"); err != nil {
+		t.Errorf("read after backfill: %v", err)
+	} else if _, err := x509.ParsePKCS1PrivateKey(der); err != nil {
+		t.Errorf("backfilled key no longer valid: %v", err)
+	}
+
+	// 3. Idempotent: a second run touches nothing.
+	n2, err := encStore.EncryptLegacyDKIMKeys(ctx)
+	if err != nil {
+		t.Fatalf("EncryptLegacyDKIMKeys (2nd): %v", err)
+	}
+	if n2 != 0 {
+		t.Errorf("second backfill encrypted %d rows, want 0 (idempotent)", n2)
+	}
+}

--- a/internal/identity/dkimcrypt.go
+++ b/internal/identity/dkimcrypt.go
@@ -1,0 +1,99 @@
+package identity
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"io"
+
+	"golang.org/x/crypto/hkdf"
+)
+
+// DKIM private keys live in domains.dkim_private_key. At rest they are
+// envelope-encrypted with AES-256-GCM under a key derived from the master
+// Signing.HMACSecret (#144 / M4) — a DB-read compromise must not yield usable
+// "sign as any customer domain" material.
+//
+// The stored blob is self-describing so a read can tell encrypted from legacy
+// plaintext without a schema change or a side flag column:
+//
+//	encrypted: dkimBlobV1 || nonce(12) || AES-256-GCM(DER, aad=domain)
+//	legacy:    raw PKCS#1 DER — always begins 0x30 (ASN.1 SEQUENCE), never 0x01
+//
+// Because PKCS#1 DER never starts with 0x01, the version byte doubles as the
+// encrypted/plaintext discriminator. That is what lets reads tolerate a
+// half-migrated table while EncryptLegacyDKIMKeys backfills.
+//
+// OPERATIONAL CAVEATS (see runbook):
+//   - Rotating Signing.HMACSecret re-derives a different KEK, making every stored
+//     key undecryptable — signing then silently degrades to unsigned for all
+//     domains. There is no re-key tooling yet; a key-versioned KEK + re-encrypt
+//     pass is a prerequisite if secret rotation ever becomes operational. The
+//     version byte is forward-compatible with that (a future 0x02 dual-read).
+//   - Once the backfill encrypts the column, rolling back to a pre-#144 binary
+//     sends mail unsigned + breaks BYODKIM provisioning until roll-forward (no
+//     data loss — the bytes are still recoverable). Prefer roll-forward.
+const (
+	dkimBlobV1   byte = 0x01
+	dkimKEKLabel      = "e2a-dkim-key-encryption-v1"
+)
+
+// DKIMCipher envelope-encrypts DKIM private keys at rest. Construct one with
+// NewDKIMCipher and install it on the Store via SetDKIMCipher.
+type DKIMCipher struct{ aead cipher.AEAD }
+
+// NewDKIMCipher derives a dedicated 32-byte KEK from the master secret via
+// HKDF-SHA256 (mirroring oauth.deriveOAuthSigningKey: a per-purpose label so the
+// DKIM key can rotate independently of header/OAuth/HITL signing) and returns an
+// AES-256-GCM cipher. It fails closed when the master is shorter than 32 bytes —
+// the config layer only enforces that in production, so a weak dev secret must
+// not silently produce weak at-rest encryption.
+func NewDKIMCipher(master []byte) (*DKIMCipher, error) {
+	if len(master) < 32 {
+		return nil, fmt.Errorf("dkim: master secret is %d bytes, need ≥32 to derive a KEK", len(master))
+	}
+	kek := make([]byte, 32)
+	if _, err := io.ReadFull(hkdf.New(sha256.New, master, nil, []byte(dkimKEKLabel)), kek); err != nil {
+		return nil, fmt.Errorf("dkim: derive KEK: %w", err)
+	}
+	block, err := aes.NewCipher(kek)
+	if err != nil {
+		return nil, fmt.Errorf("dkim: aes cipher: %w", err)
+	}
+	aead, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, fmt.Errorf("dkim: gcm: %w", err)
+	}
+	return &DKIMCipher{aead: aead}, nil
+}
+
+// seal encrypts a private key, binding the (normalized) domain as AAD so a
+// ciphertext cannot be moved onto another domain's row and still decrypt.
+func (c *DKIMCipher) seal(der []byte, domain string) ([]byte, error) {
+	nonce := make([]byte, c.aead.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, fmt.Errorf("dkim: nonce: %w", err)
+	}
+	ct := c.aead.Seal(nil, nonce, der, []byte(domain))
+	out := make([]byte, 0, 1+len(nonce)+len(ct))
+	out = append(out, dkimBlobV1)
+	out = append(out, nonce...)
+	out = append(out, ct...)
+	return out, nil
+}
+
+// open reverses seal. Callers pass a blob whose first byte is dkimBlobV1.
+func (c *DKIMCipher) open(blob []byte, domain string) ([]byte, error) {
+	n := c.aead.NonceSize()
+	if len(blob) < 1+n {
+		return nil, errors.New("dkim: ciphertext too short")
+	}
+	der, err := c.aead.Open(nil, blob[1:1+n], blob[1+n:], []byte(domain))
+	if err != nil {
+		return nil, fmt.Errorf("dkim: decrypt: %w", err)
+	}
+	return der, nil
+}

--- a/internal/identity/dkimcrypt_test.go
+++ b/internal/identity/dkimcrypt_test.go
@@ -1,0 +1,158 @@
+package identity
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"strings"
+	"testing"
+)
+
+func testMaster(t *testing.T) []byte {
+	t.Helper()
+	m := make([]byte, 32)
+	for i := range m {
+		m[i] = byte(i + 1)
+	}
+	return m
+}
+
+func TestDKIMCipherRoundTrip(t *testing.T) {
+	c, err := NewDKIMCipher(testMaster(t))
+	if err != nil {
+		t.Fatalf("NewDKIMCipher: %v", err)
+	}
+	plaintext := []byte("PKCS1-DER-private-key-bytes")
+	blob, err := c.seal(plaintext, "acme.com")
+	if err != nil {
+		t.Fatalf("seal: %v", err)
+	}
+	// Self-describing: version tag, and the ciphertext is not the plaintext.
+	if blob[0] != dkimBlobV1 {
+		t.Errorf("blob[0] = %#x, want version tag %#x", blob[0], dkimBlobV1)
+	}
+	if bytes.Contains(blob, plaintext) {
+		t.Error("sealed blob leaks the plaintext key")
+	}
+	got, err := c.open(blob, "acme.com")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	if !bytes.Equal(got, plaintext) {
+		t.Errorf("round-trip mismatch: got %q want %q", got, plaintext)
+	}
+}
+
+func TestDKIMCipherWrongDomainAAD(t *testing.T) {
+	// The domain is bound as AAD, so a blob can't be moved to another domain row.
+	c, _ := NewDKIMCipher(testMaster(t))
+	blob, _ := c.seal([]byte("key"), "acme.com")
+	if _, err := c.open(blob, "evil.com"); err == nil {
+		t.Error("open with a different domain AAD must fail")
+	}
+}
+
+func TestDKIMCipherTamperDetected(t *testing.T) {
+	c, _ := NewDKIMCipher(testMaster(t))
+	blob, _ := c.seal([]byte("key"), "acme.com")
+	blob[len(blob)-1] ^= 0xff // flip a ciphertext/tag byte
+	if _, err := c.open(blob, "acme.com"); err == nil {
+		t.Error("open of a tampered blob must fail (GCM auth)")
+	}
+}
+
+func TestDKIMCipherWrongKEK(t *testing.T) {
+	c1, _ := NewDKIMCipher(testMaster(t))
+	other := testMaster(t)
+	other[0] ^= 0xff
+	c2, _ := NewDKIMCipher(other)
+	blob, _ := c1.seal([]byte("key"), "acme.com")
+	if _, err := c2.open(blob, "acme.com"); err == nil {
+		t.Error("open under a different KEK must fail")
+	}
+}
+
+func TestNewDKIMCipherShortMasterFailsClosed(t *testing.T) {
+	if _, err := NewDKIMCipher([]byte("too-short")); err == nil {
+		t.Error("NewDKIMCipher must reject a <32-byte master")
+	}
+}
+
+func TestDKIMCipherNonceIsRandom(t *testing.T) {
+	c, _ := NewDKIMCipher(testMaster(t))
+	b1, _ := c.seal([]byte("key"), "acme.com")
+	b2, _ := c.seal([]byte("key"), "acme.com")
+	if bytes.Equal(b1, b2) {
+		t.Error("two seals of the same input must differ (random nonce)")
+	}
+}
+
+// TestStoreUnsealDKIMLegacyPassthrough: a plaintext PKCS#1 DER row (first byte
+// 0x30, never the 0x01 tag) passes through unchanged, so reads tolerate a
+// half-migrated table.
+func TestStoreUnsealDKIMLegacyPassthrough(t *testing.T) {
+	key, err := rsa.GenerateKey(rand.Reader, 1024) // small key: test speed only
+	if err != nil {
+		t.Fatalf("rsa: %v", err)
+	}
+	der := x509.MarshalPKCS1PrivateKey(key)
+	if der[0] != 0x30 {
+		t.Fatalf("expected DER to start 0x30, got %#x", der[0])
+	}
+	s := &Store{} // no cipher configured
+	got, err := s.unsealDKIM(der, "acme.com")
+	if err != nil {
+		t.Fatalf("unsealDKIM(legacy): %v", err)
+	}
+	if !bytes.Equal(got, der) {
+		t.Error("legacy plaintext DER must pass through unchanged")
+	}
+}
+
+// TestStoreUnsealDKIMEncryptedWithoutCipherFailsClosed: an encrypted blob with no
+// cipher configured must error, never be returned as if it were a key.
+func TestStoreUnsealDKIMEncryptedWithoutCipherFailsClosed(t *testing.T) {
+	c, _ := NewDKIMCipher(testMaster(t))
+	blob, _ := c.seal([]byte("key"), "acme.com")
+	s := &Store{} // no cipher
+	if _, err := s.unsealDKIM(blob, "acme.com"); err == nil || !strings.Contains(err.Error(), "no cipher") {
+		t.Errorf("expected fail-closed 'no cipher' error, got %v", err)
+	}
+}
+
+// TestStoreSealUnsealDKIM: the store helpers round-trip through the configured
+// cipher and the stored form is encrypted (tagged, not the plaintext).
+func TestStoreSealUnsealDKIM(t *testing.T) {
+	c, _ := NewDKIMCipher(testMaster(t))
+	s := &Store{}
+	s.SetDKIMCipher(c)
+	der := []byte("PKCS1-DER")
+	sealed, err := s.sealDKIM(der, "acme.com")
+	if err != nil {
+		t.Fatalf("sealDKIM: %v", err)
+	}
+	if sealed[0] != dkimBlobV1 || bytes.Equal(sealed, der) {
+		t.Error("sealDKIM must return an encrypted, tagged blob")
+	}
+	got, err := s.unsealDKIM(sealed, "acme.com")
+	if err != nil {
+		t.Fatalf("unsealDKIM: %v", err)
+	}
+	if !bytes.Equal(got, der) {
+		t.Error("store seal/unseal round-trip mismatch")
+	}
+}
+
+// TestStoreSealDKIMNoCipherPlaintext: without a cipher the helper stores plaintext.
+func TestStoreSealDKIMNoCipherPlaintext(t *testing.T) {
+	s := &Store{}
+	der := []byte{0x30, 0x01, 0x02}
+	got, err := s.sealDKIM(der, "acme.com")
+	if err != nil {
+		t.Fatalf("sealDKIM: %v", err)
+	}
+	if !bytes.Equal(got, der) {
+		t.Error("no cipher ⇒ sealDKIM must return plaintext unchanged")
+	}
+}

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -336,10 +336,103 @@ const (
 
 type Store struct {
 	pool *pgxpool.Pool
+	// dkimCipher envelope-encrypts DKIM private keys at rest (#144 / M4).
+	// Optional: nil ⇒ keys are stored as plaintext DER (dev/test without a
+	// configured signing secret). cmd/e2a always installs it in production.
+	dkimCipher *DKIMCipher
 }
 
 func NewStore(pool *pgxpool.Pool) *Store {
 	return &Store{pool: pool}
+}
+
+// SetDKIMCipher enables envelope encryption of DKIM private keys at rest (#144).
+// Optional-setter (matches SetEnforcer/SetPublisher) so NewStore's signature —
+// and the many tests that call NewStore(pool) — stay unchanged. When unset, keys
+// are stored as plaintext DER. cmd/e2a always sets it in production, where
+// Signing.HMACSecret is enforced ≥32 bytes.
+func (s *Store) SetDKIMCipher(c *DKIMCipher) { s.dkimCipher = c }
+
+// sealDKIM encrypts a DKIM private key for storage when a cipher is configured,
+// else returns the plaintext DER unchanged. domain is bound as AAD.
+func (s *Store) sealDKIM(der []byte, domain string) ([]byte, error) {
+	if s.dkimCipher == nil || len(der) == 0 {
+		return der, nil
+	}
+	return s.dkimCipher.seal(der, domain)
+}
+
+// unsealDKIM reverses sealDKIM. Legacy plaintext rows (untagged DER) pass through
+// unchanged, so reads tolerate a half-migrated table. An encrypted blob with no
+// cipher configured is a hard error — fail closed, never return ciphertext as a
+// key. domain must be the normalized form used at seal time.
+func (s *Store) unsealDKIM(blob []byte, domain string) ([]byte, error) {
+	if len(blob) == 0 || blob[0] != dkimBlobV1 {
+		return blob, nil
+	}
+	if s.dkimCipher == nil {
+		return nil, fmt.Errorf("dkim key for %q is encrypted but no cipher is configured", domain)
+	}
+	return s.dkimCipher.open(blob, domain)
+}
+
+// EncryptLegacyDKIMKeys re-encrypts any DKIM private keys still stored as
+// plaintext DER (rows written before encryption-at-rest, #144). It is idempotent
+// and self-terminating: only untagged rows (first byte != dkimBlobV1) are
+// selected, so a second run is a no-op. No-op when no cipher is configured. The
+// domains table is small, so it is safe to run at every startup. Returns the
+// number of rows encrypted.
+func (s *Store) EncryptLegacyDKIMKeys(ctx context.Context) (int, error) {
+	if s.dkimCipher == nil {
+		return 0, nil
+	}
+	rows, err := s.pool.Query(ctx,
+		// octet_length > 0 guards get_byte, which errors on a zero-length bytea
+		// (the codebase writes NULL not empty, but be robust to out-of-band rows).
+		`SELECT domain, dkim_private_key FROM domains
+		  WHERE octet_length(dkim_private_key) > 0 AND get_byte(dkim_private_key, 0) <> $1`,
+		int(dkimBlobV1),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("dkim backfill scan: %w", err)
+	}
+	type legacyRow struct {
+		domain string
+		der    []byte
+	}
+	var legacy []legacyRow
+	for rows.Next() {
+		var r legacyRow
+		if err := rows.Scan(&r.domain, &r.der); err != nil {
+			rows.Close()
+			return 0, fmt.Errorf("dkim backfill row: %w", err)
+		}
+		legacy = append(legacy, r)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, fmt.Errorf("dkim backfill iterate: %w", err)
+	}
+
+	n := 0
+	for _, r := range legacy {
+		sealed, err := s.dkimCipher.seal(r.der, r.domain)
+		if err != nil {
+			return n, fmt.Errorf("dkim backfill seal %q: %w", r.domain, err)
+		}
+		// Re-check the tag in the WHERE so a concurrent run can't double-encrypt.
+		tag, err := s.pool.Exec(ctx,
+			`UPDATE domains SET dkim_private_key = $2
+			  WHERE domain = $1 AND octet_length(dkim_private_key) > 0
+			    AND get_byte(dkim_private_key, 0) <> $3`,
+			r.domain, sealed, int(dkimBlobV1),
+		)
+		if err != nil {
+			return n, fmt.Errorf("dkim backfill update %q: %w", r.domain, err)
+		}
+		n += int(tag.RowsAffected())
+	}
+	return n, nil
 }
 
 // --- Domain CRUD ---
@@ -398,9 +491,18 @@ func (s *Store) ClaimOrCreateDomain(ctx context.Context, domain, userID string) 
 	var dkimPubKey string
 	var dkimPrivKey []byte
 	if kp, kerr := dkim.GenerateKeypair(); kerr == nil {
-		dkimSelector = kp.Selector
-		dkimPubKey = kp.PublicKeyDNS
-		dkimPrivKey = kp.PrivateKeyDER
+		// Encrypt the private key at rest (#144). On seal failure (catastrophic
+		// RNG) drop ALL three DKIM columns so we never publish a public key /
+		// selector without a usable private key — non-fatal, same posture as a
+		// keygen failure (the signer treats a missing key as "skip DKIM").
+		sealed, serr := s.sealDKIM(kp.PrivateKeyDER, domain)
+		if serr != nil {
+			log.Printf("[identity] dkim key seal failed for %s: %v", domain, serr)
+		} else {
+			dkimSelector = kp.Selector
+			dkimPubKey = kp.PublicKeyDNS
+			dkimPrivKey = sealed
+		}
 	} else {
 		log.Printf("[identity] dkim keygen failed for %s: %v", domain, kerr)
 	}
@@ -483,11 +585,12 @@ func nullIfEmptyBytes(b []byte) interface{} {
 // treat this as "skip signing" and fall back to whatever the
 // relay-level fallback does.
 func (s *Store) GetDKIMKeyInternal(ctx context.Context, domain string) (string, []byte, error) {
+	norm := normalizeDomain(domain)
 	var selector string
 	var privKey []byte
 	err := s.pool.QueryRow(ctx,
 		`SELECT COALESCE(dkim_selector, ''), dkim_private_key FROM domains WHERE domain = $1`,
-		normalizeDomain(domain),
+		norm,
 	).Scan(&selector, &privKey)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return "", nil, nil
@@ -495,7 +598,11 @@ func (s *Store) GetDKIMKeyInternal(ctx context.Context, domain string) (string, 
 	if err != nil {
 		return "", nil, fmt.Errorf("dkim key lookup: %w", err)
 	}
-	return selector, privKey, nil
+	der, err := s.unsealDKIM(privKey, norm)
+	if err != nil {
+		return "", nil, fmt.Errorf("dkim key unseal: %w", err)
+	}
+	return selector, der, nil
 }
 
 // --- Sender identity (decision 4 / Slice 4) ---
@@ -510,15 +617,21 @@ func (s *Store) GetDKIMKeyInternal(ctx context.Context, domain string) (string, 
 // GetDKIMKeyInternal this is unscoped — call only with a server-resolved
 // domain.
 func (s *Store) SendingProvisionInputs(ctx context.Context, domain string) (selector string, privateKeyDER []byte, ok bool, err error) {
+	norm := normalizeDomain(domain)
+	var blob []byte
 	err = s.pool.QueryRow(ctx,
 		`SELECT COALESCE(dkim_selector, ''), dkim_private_key FROM domains WHERE domain = $1`,
-		normalizeDomain(domain),
-	).Scan(&selector, &privateKeyDER)
+		norm,
+	).Scan(&selector, &blob)
 	if err != nil {
 		return "", nil, false, err // includes pgx.ErrNoRows (domain gone)
 	}
-	if selector == "" || len(privateKeyDER) == 0 {
+	if selector == "" || len(blob) == 0 {
 		return "", nil, false, nil
+	}
+	privateKeyDER, err = s.unsealDKIM(blob, norm)
+	if err != nil {
+		return "", nil, false, fmt.Errorf("dkim key unseal: %w", err)
 	}
 	return selector, privateKeyDER, true, nil
 }


### PR DESCRIPTION
Implements **M4** from #144. (Does not close #144 — M3, M8, M11 remain open.)

## Problem
Per-domain DKIM RSA keys are stored as **raw PKCS#1 DER** in `domains.dkim_private_key`. A DB-read compromise (leaked backup, replica credential, snapshot, SQLi) yields **every customer's signing key** — an attacker can then mint DKIM-valid, DMARC-aligned mail as any onboarded domain, fully offline. The key can't just be dropped: it's both the local outbound signer (`GetDKIMKeyInternal`) and the SES **BYODKIM** provisioning input (`SendingProvisionInputs`).

## Fix — envelope encryption at rest
AES-256-GCM under a KEK derived from the master `Signing.HMACSecret` via HKDF-SHA256 (label `e2a-dkim-key-encryption-v1`, mirroring `oauth.deriveOAuthSigningKey` for key separation + independent rotation). Self-describing blob:

```
encrypted: 0x01 || nonce(12) || AES-256-GCM(DER, aad=domain)
legacy:    raw PKCS#1 DER — always begins 0x30, never 0x01
```

The version byte doubles as the encrypted/plaintext discriminator (DER never starts `0x01`), so reads tolerate a **half-migrated table** during rollout. The domain is bound as **GCM AAD**, so a blob can't be moved onto another domain's row and still decrypt.

## What changed (no schema change — column stays BYTEA)
- **`internal/identity/dkimcrypt.go`** (new) — `DKIMCipher`: HKDF KEK + AES-256-GCM, **fails closed** on a <32-byte master.
- **`Store`** — optional `SetDKIMCipher` (keeps `NewStore(pool)`'s signature and its many test callers intact); `seal` in `ClaimOrCreateDomain` (all-or-nothing with keygen — never a pubkey without a usable privkey); `unseal` in both readers. An encrypted blob with **no cipher configured is a hard error** (fail closed, never returns ciphertext as a key).
- **`EncryptLegacyDKIMKeys`** — idempotent, self-terminating startup backfill that re-encrypts only untagged rows (`get_byte(...,0) <> 1`). App-side because the KEK lives in app config, not SQL.
- **`cmd/e2a/main.go`** — installs the cipher + runs the backfill at startup. Weak dev secret ⇒ plaintext + warning; production enforces ≥32 bytes so it always encrypts.

## Tests
- **Unit:** round-trip; tamper / wrong-domain-AAD / wrong-KEK rejection; short-master fail-closed; random nonce; legacy-plaintext passthrough; encrypted-without-cipher fail-closed.
- **DB:** `ClaimOrCreateDomain` stores the key encrypted (column tagged `0x01`, not parseable as DER) while both readers decrypt to a valid PKCS#1 key; reader without cipher fails closed; backfill encrypts a legacy plaintext row, the key still decrypts, and a second run is a no-op.
- Regression: `internal/outbound` (signing) and `internal/senderidentity` (BYODKIM) pass unchanged on the plaintext-fallback path. `go build ./...` + `go vet` clean.

## Notes / out of scope
- **Key rotation** isn't built, but the version byte + HKDF label make a future `v2` KEK a dual-read + re-seal — no format break.
- **SES retains its copy** of the BYODKIM key — this closes the e2a-DB exposure, not the SES trust boundary.
- The **non-prod weak-secret** gap (KEK from a short dev secret) is shared with cursor/OAuth signing and better tracked as a separate cross-cutting "require real Signing.HMACSecret outside production" item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review (correctness + adversarial-crypto + regression)
Three review agents ran. Consensus: **crypto sound, mergeable, no HIGH/CRITICAL.** Adversarial confirmed nonce safety (CSPRNG per-seal), the version-byte discriminator (PKCS#1 DER always `0x30`, never `0x01`), domain-as-AAD swap prevention, HKDF key-separation, fail-closed readers, and a race-safe idempotent backfill.

**Addressed in this PR:**
- Reverted an accidental smart-quote artifact in an unrelated comment.
- Hardened the backfill predicates with `octet_length(dkim_private_key) > 0` (guards `get_byte`, which errors on a zero-length bytea → would `log.Fatalf` at startup on out-of-band data).
- Documented the two operational caveats below at the KEK definition.

**⚠️ Operational caveats (runbook):**
1. **Secret rotation is DKIM-fatal.** The KEK derives from `Signing.HMACSecret`; rotating it makes every stored DKIM key undecryptable → signing silently degrades to *unsigned* for all domains. There is no re-key tooling yet — a key-versioned KEK + re-encrypt pass is a prerequisite before that secret can be rotated. (The version byte is forward-compatible with a `0x02` dual-read.)
2. **Rollback is one-way.** Once the backfill encrypts the column, rolling back to a pre-#144 binary sends mail unsigned and breaks BYODKIM provisioning until roll-forward — **no data loss** (bytes recoverable). Prefer roll-forward.

**Deferred (documented, not blockers — out of the DB-read threat model):**
- Plaintext-downgrade tamper-evidence: a DB-*write* attacker could overwrite an encrypted row with plaintext; not a sign-as-victim break (verifiers use the owner's DNS public key). Optional future: alert on a `0x30` row in prod after backfill.
- Surface the weak-secret "encryption disabled" fallback as a metric, not just a log line.
