### PR TITLE
docs(blog): align webhook examples with metadata-only email.received

### DIFF
--- a/web/src/app/blog/email-agent-with-google-adk/page.mdx
+++ b/web/src/app/blog/email-agent-with-google-adk/page.mdx
@@ -180,10 +180,10 @@ try:
 except E2AWebhookSignatureError:
     raise HTTPException(status_code=401, detail="bad signature")
 
-msg = event.data  # the verified inbound message payload
+msg = event.data  # verified metadata (ids, sender, subject); fetch the body via client.messages.get
 ```
 
-This isn't optional. Anyone on the internet can POST to your public webhook URL — the HMAC signature is what proves the payload came from your e2a relay and not from someone trying to inject a fake email into your agent's session. If you skip the verify, every claim on the payload (sender, recipient, message id, body) becomes attacker-controlled. `construct_event` checks the HMAC over `{timestamp}.{raw_body}`, rejects replays older than 5 minutes, and parses the verified envelope — all in one call. Pass the raw bytes; re-serializing parsed JSON changes the whitespace and the signature won't match.
+This isn't optional. Anyone on the internet can POST to your public webhook URL — the HMAC signature is what proves the payload came from your e2a relay and not from someone trying to inject a fake email into your agent's session. If you skip the verify, every claim on the payload (sender, recipient, message id, subject) becomes attacker-controlled — and since the agent fetches the body using the payload's `message_id`, a forged id could even point it at a different message. `construct_event` checks the HMAC over `{timestamp}.{raw_body}`, rejects replays older than 5 minutes, and parses the verified envelope — all in one call. Pass the raw bytes; re-serializing parsed JSON changes the whitespace and the signature won't match.
 
 ## What this example deliberately doesn't show
 

--- a/web/src/app/blog/send-email-from-python-agent/page.mdx
+++ b/web/src/app/blog/send-email-from-python-agent/page.mdx
@@ -73,7 +73,7 @@ from e2a.v1 import E2AClient, construct_event
 async def inbox(request):
     raw = await request.body()
     event = construct_event(raw, request.headers["X-E2A-Signature"], WEBHOOK_SECRET)
-    msg = event.data
+    msg = event.data  # metadata only (ids, sender, subject) — fetch the body via messages.get if you need it
     print(f"{msg['from']}: {msg['subject']}")
     async with E2AClient(api_key="e2a_...") as client:
         await client.messages.reply(


### PR DESCRIPTION
Follow-up to #321 (email.received is now metadata-only). The two blog posts that show webhook handling drifted:

- **email-agent-with-google-adk**: stopped calling `event.data` "the inbound message payload" (it's metadata); dropped `body` from the list of payload claims (no longer present) and noted the body is fetched via `message_id`, so a forged id is the real injection risk.
- **send-email-from-python-agent**: clarified `event.data` is metadata; fetch the body via `messages.get` if needed.

No code change — the linked runnable example (`examples/adk-cloud-webhook`) already fetches the body correctly.

**Integration check (per request):** verified the ADK + LangChain integrations are unaffected:
- `examples/adk-cloud-webhook` (webhook-based) — already reads only metadata + fetches the body via `messages.get`.
- `mcp/examples/{adk,langchain,crewai,codex,openai-agents}` — pure MCP-tool integrations; no webhook/`raw_message` coupling at all (fetch via the REST-backed `get_message` tool).

🤖 Generated with [Claude Code](https://claude.com/claude-code)