### PR TITLE
chore(sdk): bump SDKs to 4.0.1 (v1.0.6 release)

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "e2a"
-version = "4.0.0"
+version = "4.0.1"
 description = "Python SDK for the e2a protocol — email-to-agent authentication"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/sdk",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "TypeScript SDK for e2a — email for AI agents",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
Bumps `@e2a/sdk` (npm) and `e2a` (PyPI) from 4.0.0 → **4.0.1** so the additive SDK changes accumulated since the v1.0.5/4.0.0 release can be published:

- metadata-only `email.received` notify→fetch helper + `EmailReceivedPayload` type (#321)
- per-axis SES sending status (#309)
- DKIM verify work (#312)

No public SDK symbols were removed or changed (verified against `ts-sdk-v4.0.0`) — purely additive. Tagged 4.0.1 per maintainer call (pre-GA, no external consumers yet).

Part of the **v1.0.6** release. After merge: tag `ts-sdk-v4.0.1` + `python-v4.0.1` (npm + PyPI), then cut the `v1.0.6` server release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)