### PR TITLE
chore(cli): bump @e2a/cli to 1.5.1 (ship the @e2a/sdk ^4.0.0 fix)

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/cli",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "CLI for e2a — email for AI agents",
   "bin": {
     "e2a": "./dist/bin/e2a.js"


### PR DESCRIPTION
The `v1.0.6` release-triggered CLI publish failed because `@e2a/cli` was still `1.5.0` (already on npm). The published `1.5.0` carries a **stale `@e2a/sdk ^3.0.0`** dependency range — #310 fixed it to `^4.0.0` in-tree but didn't bump the CLI, so a fresh `npm i -g @e2a/cli` pulls an incompatible SDK major.

Bumps to **1.5.1** so the corrected range ships. After merge I'll publish via `publish-cli` (`workflow_dispatch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)