### PR TITLE
ci(mcp): co-version the MCP image with server releases

### DIFF
--- a/.github/workflows/publish-mcp-http.yml
+++ b/.github/workflows/publish-mcp-http.yml
@@ -2,13 +2,13 @@ name: Publish MCP HTTP server image
 
 on:
   push:
-    tags:
-      - "mcp-http-v*"
     branches: [main]
-    paths:
-      - "mcp/**"
-      - "sdks/typescript/**"
-      - ".github/workflows/publish-mcp-http.yml"
+    tags:
+      # Product releases co-version the MCP image with the server (a `v*`
+      # tag builds e2a-mcp-http:<version> alongside e2a:<version>), plus the
+      # independent MCP-only release track.
+      - "v*"
+      - "mcp-http-v*"
   workflow_dispatch:
 
 concurrency:
@@ -35,23 +35,24 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Resolve image tags
-        id: tags
-        run: |
-          set -euo pipefail
-          tags="ghcr.io/mnexa-ai/e2a-mcp-http:${{ github.sha }}"
-          if [[ "${{ github.ref }}" == refs/tags/mcp-http-v* ]]; then
-            version="${GITHUB_REF#refs/tags/mcp-http-v}"
-            tags="${tags}"$'\n'"ghcr.io/mnexa-ai/e2a-mcp-http:${version}"
-            tags="${tags}"$'\n'"ghcr.io/mnexa-ai/e2a-mcp-http:latest"
-          elif [[ "${{ github.ref }}" == refs/heads/main ]]; then
-            tags="${tags}"$'\n'"ghcr.io/mnexa-ai/e2a-mcp-http:main"
-          fi
-          {
-            echo 'value<<EOF'
-            echo "${tags}"
-            echo 'EOF'
-          } >> "$GITHUB_OUTPUT"
+      # Same tag policy as the server image (build-image.yml) so the MCP image
+      # is versioned and pinnable identically:
+      #   :main             — floating tip of main (every main push)
+      #   :sha-<commit>      — immutable per-commit (matches the server's sha- prefix)
+      #   :<version>         — on a `v*` product release (e.g. 1.0.6), co-versioned
+      #                        with the server; OR on an `mcp-http-v*` MCP-only release
+      #   :latest           — only on a release tag, never the untested tip of main
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/mnexa-ai/e2a-mcp-http
+          tags: |
+            type=raw,value=main,enable=${{ github.ref == 'refs/heads/main' }}
+            type=sha,prefix=sha-,format=long
+            type=semver,pattern={{version}},enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=match,pattern=^mcp-http-v(.*),group=1,enable=${{ startsWith(github.ref, 'refs/tags/mcp-http-v') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
 
       - name: Build and push
         uses: docker/build-push-action@v7
@@ -59,7 +60,8 @@ jobs:
           context: .
           file: mcp/Dockerfile
           push: true
-          tags: ${{ steps.tags.outputs.value }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: true


### PR DESCRIPTION
Makes a product release produce a **complete, co-versioned image set**. Today a `v*` release builds `e2a` + `e2a-web` but **not** `e2a-mcp-http` (it only triggers on `mcp-http-v*`), so prod has to ride the floating MCP `:main` and there's no MCP image pinned to a release.

Changes to `publish-mcp-http.yml`:
- **Add `v*` to the push tag triggers** → a `v1.0.6` release now builds `e2a-mcp-http:1.0.6` alongside `e2a:1.0.6`.
- **Drop the `mcp/sdks-ts` paths filter** → `v*` tags always build (paths filters otherwise apply to tag pushes too), and every main commit gets a `:sha-` image — closing the gap where a server `sha-<commit>` could lack a matching MCP image.
- **Replace the hand-rolled tag bash with `docker/metadata-action`**, using the same policy as `build-image.yml`: `:main`, `:sha-<commit>` (sha- prefixed to match the server), `:<version>` on releases, `:latest` only on a release tag. The independent `mcp-http-v*` MCP-only release track is preserved.

Pairs with an e2a-ops change that pins the deploy's `MCP_TAG` to the release version (instead of floating `:main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)