### PR TITLE
fix(httpapi): reject malformed-base64 attachments with 400, not 500

### DIFF
--- a/internal/httpapi/outbound.go
+++ b/internal/httpapi/outbound.go
@@ -2,6 +2,8 @@ package httpapi
 
 import (
 	"context"
+	"encoding/base64"
+	"fmt"
 	"net/http"
 	"reflect"
 	"strings"
@@ -374,9 +376,39 @@ func (s *Server) validateOutboundBody(subject, body string, to, cc, bcc []string
 	return nil
 }
 
+// validateAttachments rejects any attachment whose Data is not decodable
+// base64. The composer passes att.Data through verbatim into the MIME body
+// (Content-Transfer-Encoding: base64), so malformed base64 otherwise slips past
+// every check and only fails downstream at the SMTP relay — surfacing to the
+// caller as a generic 500 instead of a clear 400. Whitespace (line-wrapping) is
+// stripped first to match how mail decoders treat base64 bodies, so a caller
+// that pre-wraps its base64 is not falsely rejected.
+func validateAttachments(atts []outbound.Attachment) *ErrorEnvelope {
+	for i, att := range atts {
+		clean := strings.Map(func(r rune) rune {
+			if r == '\r' || r == '\n' || r == ' ' || r == '\t' {
+				return -1
+			}
+			return r
+		}, att.Data)
+		if _, err := base64.StdEncoding.DecodeString(clean); err != nil {
+			name := att.Filename
+			if name == "" {
+				name = fmt.Sprintf("#%d", i)
+			}
+			return NewError(http.StatusBadRequest, "invalid_attachment",
+				fmt.Sprintf("attachment %q: data is not valid base64", name))
+		}
+	}
+	return nil
+}
+
 // deliver runs the domain-verified + enforce-cap checks then DeliverOutbound
 // under the idempotency handshake, mapping the OutboundResult to the wire view.
 func (s *Server) deliver(ctx context.Context, user *identity.User, ag *identity.AgentIdentity, req outbound.SendRequest, msgType, replyTo, route, idemKey string, rawBody []byte, referenced *identity.Message) (*sendOutput, error) {
+	if env := validateAttachments(req.Attachments); env != nil {
+		return nil, env
+	}
 	if env := s.checkSendLimit(ag.ID); env != nil {
 		return nil, env
 	}

--- a/internal/httpapi/outbound_attachment_validation_test.go
+++ b/internal/httpapi/outbound_attachment_validation_test.go
@@ -1,0 +1,49 @@
+package httpapi
+
+import "testing"
+
+// A send whose attachment data is not valid base64 must be rejected with
+// 400 invalid_attachment at the boundary. Without this the malformed data is
+// passed verbatim into the MIME body and only fails downstream at the SMTP
+// relay, surfacing to the caller as a generic 500.
+func TestSendRejectsBadBase64Attachment(t *testing.T) {
+	srv := testServer(t)
+	code, body := postJSON(t, srv.URL+sendURL, "good", map[string]any{
+		"to": []string{"r@x.com"}, "subject": "Hi", "body": "hello",
+		"attachments": []map[string]any{
+			{"filename": "bad.bin", "content_type": "application/octet-stream", "data": "!!!not-base64!!!"},
+		},
+	})
+	if code != 400 || errCode(body) != "invalid_attachment" {
+		t.Fatalf("want 400 invalid_attachment, got %d %v", code, body)
+	}
+}
+
+// A valid base64 attachment passes validation. The embedded newline exercises
+// the whitespace tolerance (callers may pre-wrap their base64 per RFC 2045).
+func TestSendAcceptsValidBase64Attachment(t *testing.T) {
+	srv := testServer(t)
+	code, _ := postJSON(t, srv.URL+sendURL, "good", map[string]any{
+		"to": []string{"r@x.com"}, "subject": "Hi", "body": "hello",
+		"attachments": []map[string]any{
+			{"filename": "ok.txt", "content_type": "text/plain", "data": "aGVsbG8K\n"},
+		},
+	})
+	if code != 200 {
+		t.Fatalf("valid base64 attachment: want 200, got %d", code)
+	}
+}
+
+// The reply path shares the same funnel, so it enforces the same check.
+func TestReplyRejectsBadBase64Attachment(t *testing.T) {
+	srv := testServer(t)
+	code, body := postJSON(t, srv.URL+"/v1/agents/support%40acme.com/messages/msg_in1/reply", "good", map[string]any{
+		"body": "re",
+		"attachments": []map[string]any{
+			{"filename": "bad.bin", "content_type": "application/octet-stream", "data": "@@notbase64@@"},
+		},
+	})
+	if code != 400 || errCode(body) != "invalid_attachment" {
+		t.Fatalf("reply: want 400 invalid_attachment, got %d %v", code, body)
+	}
+}


### PR DESCRIPTION
## Problem
A send with an attachment whose `data` isn't valid base64 returned **`500 internal_error`** — a client mistake surfaced as a server error. Found during GA e2e testing.

## Root cause
The composer passes `att.Data` **verbatim** into the MIME body (`Content-Transfer-Encoding: base64`) — it never decodes it. The scan/extract path *does* decode but swallows the error (`if err != nil { return string(raw) }`). So malformed base64 reached the SMTP relay/SES, whose rejection comes back as a plain Go error — and `DeliverOutbound` maps any non-`ValidationError` send failure to `500`.

## Fix
Validate each attachment's base64 at the shared send/reply/forward funnel (`deliver`) and return **`400 invalid_attachment`** before it reaches SES. Whitespace is stripped first so RFC-2045 line-wrapped base64 isn't falsely rejected.

## Tests
`TestSendRejectsBadBase64Attachment`, `TestSendAcceptsValidBase64Attachment`, `TestReplyRejectsBadBase64Attachment`. Runtime error only — no OpenAPI schema change (spec-golden unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)