### PR TITLE
fix(outbound): auto-generate conversation_id so replies thread (#328)

### DIFF
--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -171,7 +171,7 @@ type API struct {
 	// via GET /v1/info so CLI/SDK clients can populate absolute
 	// links without each user configuring it. Empty when the operator
 	// hasn't set http.public_url.
-	publicURL         string
+	publicURL string
 	// apiURL is the externally visible base URL of the programmatic API —
 	// the OAuth issuer identity and the base for the token/registration/
 	// revocation/jwks endpoints. Defaults to publicURL; SetAPIURL overrides
@@ -519,25 +519,25 @@ func (a *API) SetDomainTeardownHook(h func(ctx context.Context, tx pgx.Tx, domai
 
 func NewAPI(store *identity.Store, sender *outbound.Sender, smtpRelay *outbound.SMTPRelay, userAuth *auth.UserAuth, usage usage.UsageTracker, smtpDomain, fromDomain, sharedDomain, publicURL string, production bool) *API {
 	return &API{
-		store:         store,
-		sender:        sender,
-		screen:        piguard.NewEngine(piguard.EngineConfig{}, piguard.NewHeuristicsDetector()),
-		smtpRelay:     smtpRelay,
-		userAuth:      userAuth,
-		usage:         usage,
-		smtpDomain:    smtpDomain,
-		fromDomain:    fromDomain,
-		sharedDomain:  sharedDomain,
-		publicURL:     publicURL,
+		store:        store,
+		sender:       sender,
+		screen:       piguard.NewEngine(piguard.EngineConfig{}, piguard.NewHeuristicsDetector()),
+		smtpRelay:    smtpRelay,
+		userAuth:     userAuth,
+		usage:        usage,
+		smtpDomain:   smtpDomain,
+		fromDomain:   fromDomain,
+		sharedDomain: sharedDomain,
+		publicURL:    publicURL,
 		// Default the API/issuer URL to the web URL; SetAPIURL overrides it
 		// for split web/API-host deployments.
 		apiURL:        publicURL,
 		production:    production,
-		sendLimit:     ratelimit.New(1*time.Minute, 60), // 60 sends per agent per minute
-		regLimit:      ratelimit.New(1*time.Hour, 200),  // 200 registrations per IP per hour
-		pollLimit:     ratelimit.New(1*time.Minute, 60), // 60 poll requests per user per minute
-		feedbackLimit: ratelimit.New(1*time.Hour, 10),   // 10 feedback submissions per IP per hour
-		dcrLimit:      ratelimit.New(1*time.Hour, 10),   // 10 OAuth client registrations per IP per hour
+		sendLimit:     ratelimit.New(1*time.Minute, 60),  // 60 sends per agent per minute
+		regLimit:      ratelimit.New(1*time.Hour, 200),   // 200 registrations per IP per hour
+		pollLimit:     ratelimit.New(1*time.Minute, 60),  // 60 poll requests per user per minute
+		feedbackLimit: ratelimit.New(1*time.Hour, 10),    // 10 feedback submissions per IP per hour
+		dcrLimit:      ratelimit.New(1*time.Hour, 10),    // 10 OAuth client registrations per IP per hour
 		downloadLimit: ratelimit.New(1*time.Minute, 120), // 120 attachment downloads per IP per minute
 	}
 }
@@ -1123,6 +1123,25 @@ func (a *API) checkSuppression(ctx context.Context, userID string, req outbound.
 // live delivery path exists exactly once (api-v1-redesign — outbound
 // extraction). On a nil-error return the side effect has committed, so the
 // idempotency key must be Completed (cached), never Released.
+// resolveOutboundConversationID picks the thread id for an outbound message, in
+// precedence order (#328):
+//  1. an explicit caller-supplied id wins;
+//  2. a reply inherits the conversation of the message it answers (referenced),
+//     so a multi-turn thread stays grouped — a forward does NOT inherit, since a
+//     forward starts a new thread;
+//  3. otherwise a fresh anchor is minted so this message becomes the root the
+//     relay's In-Reply-To lookup threads later inbound replies onto. Without an
+//     anchor an external reply recovers an empty id and the thread fragments.
+func resolveOutboundConversationID(explicit, msgType string, referenced *identity.Message) string {
+	if explicit != "" {
+		return explicit
+	}
+	if msgType == "reply" && referenced != nil && referenced.ConversationID != "" {
+		return referenced.ConversationID
+	}
+	return identity.NewConversationID()
+}
+
 func (a *API) DeliverOutbound(ctx context.Context, user *identity.User, agent *identity.AgentIdentity, req outbound.SendRequest, msgType, replyToEmailMessageID string, referenced *identity.Message) (*OutboundResult, *OutboundError) {
 	// Suppression enforcement (decision 9 / Slice 4b): fail fast if any
 	// recipient is on this tenant's suppression list. Enforced fresh on every
@@ -1131,6 +1150,12 @@ func (a *API) DeliverOutbound(ctx context.Context, user *identity.User, agent *i
 	if supErr := a.checkSuppression(ctx, user.ID, req); supErr != nil {
 		return nil, supErr
 	}
+
+	// Conversation threading (#328): resolve the thread id once, here, so every
+	// downstream use — the X-E2A-Conversation-Id header (compose), the
+	// held-for-review row, the stored outbound row, and the email.sent event — sees
+	// the same value.
+	req.ConversationID = resolveOutboundConversationID(req.ConversationID, msgType, referenced)
 
 	// Outbound screening (Slice 5): the recipient gate (outbound_policy) + content
 	// scan (outbound_scan) combine into one applied action. block ⇒ refuse;

--- a/internal/agent/conversation_threading_test.go
+++ b/internal/agent/conversation_threading_test.go
@@ -1,0 +1,48 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+)
+
+// resolveOutboundConversationID is the #328 fix: an outbound send that omits a
+// conversation_id must still get a stable thread anchor (and a reply must join
+// the thread it answers) so the relay's In-Reply-To lookup has something to
+// recover. This pins the precedence: explicit > inherit-on-reply > mint.
+func TestResolveOutboundConversationID(t *testing.T) {
+	parent := &identity.Message{ConversationID: "conv_parent"}
+	firstContact := &identity.Message{ConversationID: ""} // human-initiated inbound has no thread
+
+	// 1. An explicit caller-supplied id always wins.
+	if got := resolveOutboundConversationID("conv_explicit", "reply", parent); got != "conv_explicit" {
+		t.Errorf("explicit id should win, got %q", got)
+	}
+
+	// 2. A reply inherits the referenced message's conversation.
+	if got := resolveOutboundConversationID("", "reply", parent); got != "conv_parent" {
+		t.Errorf("reply should inherit referenced conv, got %q want conv_parent", got)
+	}
+
+	// 2b. A reply to a first-contact inbound (no conv) falls through to a fresh
+	// anchor — the agent "stamps its own id" that later follow-ups thread onto.
+	if got := resolveOutboundConversationID("", "reply", firstContact); !strings.HasPrefix(got, "conv_") {
+		t.Errorf("reply to no-thread inbound should mint, got %q", got)
+	}
+
+	// 3. A forward does NOT inherit — it starts a new thread.
+	if got := resolveOutboundConversationID("", "forward", parent); got == "conv_parent" || !strings.HasPrefix(got, "conv_") {
+		t.Errorf("forward must not inherit referenced conv, got %q", got)
+	}
+
+	// 3b. A plain send mints a fresh anchor (the bug was: it stayed empty).
+	got1 := resolveOutboundConversationID("", "send", nil)
+	got2 := resolveOutboundConversationID("", "send", nil)
+	if !strings.HasPrefix(got1, "conv_") || got1 == "" {
+		t.Errorf("send should mint a conv_ anchor, got %q", got1)
+	}
+	if got1 == got2 {
+		t.Errorf("each minted anchor should be unique, got %q twice", got1)
+	}
+}

--- a/internal/e2e/conversation_threading_e2e_test.go
+++ b/internal/e2e/conversation_threading_e2e_test.go
@@ -1,0 +1,157 @@
+//go:build integration
+
+package e2e_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/smtp"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+)
+
+type threadSendResp struct {
+	Status            string `json:"status"`
+	MessageID         string `json:"message_id"`
+	ProviderMessageID string `json:"provider_message_id"`
+}
+
+func parseThreadSend(t *testing.T, body []byte) threadSendResp {
+	t.Helper()
+	var r threadSendResp
+	if err := json.Unmarshal(body, &r); err != nil {
+		t.Fatalf("parse send response %q: %v", body, err)
+	}
+	if r.Status != "sent" {
+		t.Fatalf("send not sent: status=%q body=%s", r.Status, body)
+	}
+	return r
+}
+
+func convOf(t *testing.T, ts *testutil.E2ATestServer, agentID, msgID string) string {
+	t.Helper()
+	m, err := ts.Store.GetMessageWithContent(context.Background(), msgID, agentID)
+	if err != nil || m == nil {
+		t.Fatalf("GetMessageWithContent(%s): %v", msgID, err)
+	}
+	return m.ConversationID
+}
+
+func latestInbound(t *testing.T, ts *testutil.E2ATestServer, agentID string) identity.Message {
+	t.Helper()
+	msgs, err := ts.Store.GetMessagesByAgent(context.Background(),
+		identity.MessageListFilter{AgentID: agentID, Direction: "inbound", Limit: 20})
+	if err != nil {
+		t.Fatalf("GetMessagesByAgent: %v", err)
+	}
+	if len(msgs) == 0 {
+		t.Fatalf("no inbound messages for %s", agentID)
+	}
+	return msgs[0] // newest-first
+}
+
+func subResource(base, agentEmail, msgID, action string) string {
+	return base + "/v1/agents/" + url.PathEscape(agentEmail) + "/messages/" + msgID + "/" + action
+}
+
+// TestConversationThreadingE2E_OutboundRooted is the #328 fix end to end,
+// through the real API + relay + resolveConversationID:
+//  1. an agent send that omits conversation_id is minted a thread anchor;
+//  2. an external reply referencing that send (In-Reply-To the
+//     provider_message_id the recipient replies to) threads back onto the same
+//     conversation;
+//  3. the agent's own reply, with no id, INHERITS the thread (does not fork).
+func TestConversationThreadingE2E_OutboundRooted(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ts := testutil.TestServer(t, pool, testutil.WithOutboundSMTP("127.0.0.1", 1025, "test.e2a.dev"))
+	_, key, agent := setupDomainAndAgent(t, ts, "agent@thr1.example.com", "thr1.example.com", "", "")
+
+	// (1) Agent sends first, NO conversation_id.
+	status, body := authedJSON(t, "POST", sendURL(ts.HTTPServer.URL, agent.EmailAddress()), key.PlaintextKey,
+		`{"to":["alice@gmail.com"],"subject":"Project kickoff","body":"Let's start."}`)
+	if status != 200 {
+		t.Fatalf("send status=%d body=%s", status, body)
+	}
+	out := parseThreadSend(t, body)
+
+	c1 := convOf(t, ts, agent.ID, out.MessageID)
+	if !strings.HasPrefix(c1, "conv_") {
+		t.Fatalf("outbound conversation_id = %q, want an auto-generated conv_ anchor (#328 fix A)", c1)
+	}
+	if out.ProviderMessageID == "" {
+		t.Fatalf("send response missing provider_message_id (the reply anchor)")
+	}
+
+	// (2) Alice replies, referencing the agent's message. The relay must recover
+	// the agent's conversation_id via the In-Reply-To lookup.
+	reply := "From: alice@gmail.com\r\nTo: agent@thr1.example.com\r\n" +
+		"Subject: Re: Project kickoff\r\nMessage-ID: <alice-1@gmail.com>\r\n" +
+		"In-Reply-To: " + out.ProviderMessageID + "\r\n" +
+		"References: " + out.ProviderMessageID + "\r\n\r\nSounds good."
+	if err := smtp.SendMail(ts.SMTPAddr, nil, "alice@gmail.com", []string{"agent@thr1.example.com"}, []byte(reply)); err != nil {
+		t.Fatalf("SendMail reply: %v", err)
+	}
+	tick(t, ts)
+
+	in := latestInbound(t, ts, agent.ID)
+	if in.ConversationID != c1 {
+		t.Fatalf("inbound reply conversation_id = %q, want %q (must thread onto the agent's anchor)", in.ConversationID, c1)
+	}
+
+	// (3) Agent replies to Alice with NO conversation_id — must inherit the thread.
+	status, body = authedJSON(t, "POST", subResource(ts.HTTPServer.URL, agent.EmailAddress(), in.ID, "reply"),
+		key.PlaintextKey, `{"body":"On it."}`)
+	if status != 200 {
+		t.Fatalf("reply status=%d body=%s", status, body)
+	}
+	rep := parseThreadSend(t, body)
+	if c := convOf(t, ts, agent.ID, rep.MessageID); c != c1 {
+		t.Fatalf("agent reply conversation_id = %q, want %q (reply must inherit the thread, #328 fix B)", c, c1)
+	}
+}
+
+// TestConversationThreadingE2E_ExplicitForwardFirstContact covers the rest of
+// the precedence ladder and the unchanged first-contact rule:
+//   - an explicit conversation_id is preserved verbatim;
+//   - a first-contact inbound (no References) keeps conversation_id="" by design;
+//   - a forward starts a NEW thread (it does not inherit the forwarded message).
+func TestConversationThreadingE2E_ExplicitForwardFirstContact(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ts := testutil.TestServer(t, pool, testutil.WithOutboundSMTP("127.0.0.1", 1025, "test.e2a.dev"))
+	_, key, agent := setupDomainAndAgent(t, ts, "agent@thr2.example.com", "thr2.example.com", "", "")
+
+	// Explicit id is preserved.
+	status, body := authedJSON(t, "POST", sendURL(ts.HTTPServer.URL, agent.EmailAddress()), key.PlaintextKey,
+		`{"to":["x@gmail.com"],"subject":"s","body":"b","conversation_id":"conv_explicit_xyz"}`)
+	if status != 200 {
+		t.Fatalf("explicit send status=%d %s", status, body)
+	}
+	if c := convOf(t, ts, agent.ID, parseThreadSend(t, body).MessageID); c != "conv_explicit_xyz" {
+		t.Fatalf("explicit conversation_id = %q, want conv_explicit_xyz (precedence 1)", c)
+	}
+
+	// First-contact inbound (no References) → "".
+	inbound := "From: bob@gmail.com\r\nTo: agent@thr2.example.com\r\nSubject: FYI\r\nMessage-ID: <bob-1@gmail.com>\r\n\r\nlook at this"
+	if err := smtp.SendMail(ts.SMTPAddr, nil, "bob@gmail.com", []string{"agent@thr2.example.com"}, []byte(inbound)); err != nil {
+		t.Fatalf("SendMail inbound: %v", err)
+	}
+	tick(t, ts)
+	in := latestInbound(t, ts, agent.ID)
+	if in.ConversationID != "" {
+		t.Fatalf("first-contact inbound conversation_id = %q, want \"\" (design unchanged)", in.ConversationID)
+	}
+
+	// Forward starts a new thread (does not inherit the inbound's — here empty — id).
+	status, body = authedJSON(t, "POST", subResource(ts.HTTPServer.URL, agent.EmailAddress(), in.ID, "forward"),
+		key.PlaintextKey, `{"to":["carol@gmail.com"],"body":"fyi"}`)
+	if status != 200 {
+		t.Fatalf("forward status=%d %s", status, body)
+	}
+	if c := convOf(t, ts, agent.ID, parseThreadSend(t, body).MessageID); !strings.HasPrefix(c, "conv_") {
+		t.Fatalf("forward conversation_id = %q, want a fresh conv_ anchor (a forward starts a new thread)", c)
+	}
+}

--- a/internal/httpapi/outbound.go
+++ b/internal/httpapi/outbound.go
@@ -277,7 +277,10 @@ func (s *Server) handleReply(ctx context.Context, in *replyInput) (*sendOutput, 
 		To: replyTo, CC: rr.CC, BCC: b.BCC, Subject: subject, Body: b.Body, HTMLBody: b.HTMLBody,
 		ReplyToMessageID: inbound.EmailMessageID,
 		References:       outbound.BuildReferencesChain(inbound.RawMessage, inbound.EmailMessageID),
-		ConversationID:   b.ConversationID, Attachments: b.Attachments,
+		// conversation_id resolution (caller id > inherit-from-referenced > mint)
+		// is centralized in DeliverOutbound, which receives this inbound as the
+		// referenced message — so the reply inherits its thread there (#328).
+		ConversationID: b.ConversationID, Attachments: b.Attachments,
 	}
 	req.CC = agent.StripAgentSelfAliases(req.CC, ag.EmailAddress())
 	req.BCC = agent.StripAgentSelfAliases(req.BCC, ag.EmailAddress())

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -1287,10 +1287,10 @@ func (s *Store) GetInboundMessage(ctx context.Context, id string) (*Message, err
 	m := &Message{}
 	var authVerdict []byte
 	err := s.pool.QueryRow(ctx,
-		`SELECT id, agent_id, direction, sender, recipient, to_recipients, cc, reply_to, subject, email_message_id, raw_message, auth_verdict, COALESCE(flagged, false), COALESCE(flag_reason, ''), created_at, expires_at
+		`SELECT id, agent_id, direction, sender, recipient, to_recipients, cc, reply_to, subject, email_message_id, raw_message, auth_verdict, COALESCE(flagged, false), COALESCE(flag_reason, ''), COALESCE(conversation_id, ''), created_at, expires_at
 		 FROM messages WHERE id = $1 AND direction = 'inbound' AND expires_at > now()
 		   AND status NOT IN (`+heldInboundStatuses+`)`, id,
-	).Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.ToRecipients, &m.CC, &m.ReplyTo, &m.Subject, &m.EmailMessageID, &m.RawMessage, &authVerdict, &m.Flagged, &m.FlagReason, &m.CreatedAt, &m.ExpiresAt)
+	).Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.ToRecipients, &m.CC, &m.ReplyTo, &m.Subject, &m.EmailMessageID, &m.RawMessage, &authVerdict, &m.Flagged, &m.FlagReason, &m.ConversationID, &m.CreatedAt, &m.ExpiresAt)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -641,7 +641,7 @@ func (s *Store) SendingProvisionInputs(ctx context.Context, domain string) (sele
 // mailFromStatus are the per-axis SES breakdown (migration 049); an empty
 // string for either is written as SQL NULL so the read path falls back to the
 // all-or-nothing sending_status rollup (and the CHECK constraint, which allows
-// NULL but not '', is satisfied).
+// NULL but not ”, is satisfied).
 func (s *Store) SetSendingStatus(ctx context.Context, domain, status, dkimStatus, mailFromStatus, errMsg string, recordsJSON []byte) error {
 	var errPtr *string
 	if errMsg != "" {
@@ -1144,6 +1144,15 @@ const MessageTTL = 10 * 24 * time.Hour // 10 days
 // so the ID is part of the canonical string fed to HMAC.
 func NewMessageID() string {
 	return "msg_" + generateID()
+}
+
+// NewConversationID returns a fresh conversation (thread) ID. An outbound send
+// that omits a conversation_id gets one minted here so the message becomes a
+// thread anchor: external replies reference this message's Message-ID, and the
+// relay's In-Reply-To lookup recovers the conversation_id from it. Without an
+// anchor the lookup finds an empty id and the thread fragments (#328).
+func NewConversationID() string {
+	return "conv_" + generateID()
 }
 
 // CreateInboundMessage stores an inbound message. If id is empty a new


### PR DESCRIPTION
Closes #328.

## Problem
A send that omitted `conversation_id` was stored with an empty id, so it was never a thread anchor. When an external recipient replied, the relay's `In-Reply-To` lookup found an empty `conversation_id` and the reply landed as a **separate inbox entry** instead of grouping. `send_message`'s doc promised *"server generates one if omitted"* — it didn't.

## Fix
Resolve the thread id once in `DeliverOutbound` (the shared send/reply/forward funnel), in precedence order:
1. an explicit caller id wins;
2. a **reply inherits** the referenced message's conversation (multi-turn threads stay grouped; a forward does **not** inherit — new thread);
3. otherwise **mint** a fresh `conv_` anchor (`identity.NewConversationID`).

The set value flows to the `X-E2A-Conversation-Id` header, the HITL hold row, the stored outbound row, and the `email.sent` event.

## Design note
This is e2a's existing **hybrid** model, now made to work: mint-and-carry an id (Outlook `Thread-Index`-style) for same-platform traffic, plus standard `In-Reply-To`/`References` graph recovery (Gmail-style) for external replies. First-contact inbound keeps `conversation_id=""` **by design** (the relay is unchanged) — the agent's reply stamps the anchor that follow-ups thread onto, matching the model `TestWebhooksE2E_ConversationThreadedFromAgentReply` already documents.

## Tests
`TestResolveOutboundConversationID` pins the precedence; the conversation e2e + full agent/httpapi/identity suites pass. No OpenAPI schema change (`conversation_id` is an existing field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)