### PR TITLE
feat: add @e2a/ui (Loft) design-system package as a workspace

### DIFF
--- a/design-system/.design-sync/NOTES.md
+++ b/design-system/.design-sync/NOTES.md
@@ -1,0 +1,86 @@
+# design-sync notes — @e2a/ui (Loft)
+
+Durable, human-readable notes for future syncs. Committed.
+
+## Setup facts
+
+- **Monorepo layout.** This package lives inside the **e2a** git repo as an npm
+  workspace (`@e2a/ui`, declared in the repo-root `package.json` workspaces).
+  The git root is therefore `…/e2a`, NOT this folder. The converter resolves its
+  paths from the **working directory**, so always run design-sync commands from
+  **this `design-system/` directory**, not the repo root.
+- **Re-sync command (monorepo).** React is hoisted to the repo-root
+  `node_modules`, so point `--node-modules` there. From `design-system/`:
+  ```sh
+  npm run build                               # refresh dist/ first
+  # rebuild the reference explicitly under THIS package (do NOT use the
+  # git-root path the storybook §2.2 snippet suggests — that lands at e2a/.design-sync):
+  npx storybook build -c .storybook -o .design-sync/sb-reference
+  node .ds-sync/resync.mjs --config .design-sync/config.json \
+    --node-modules ../node_modules --entry ./dist/index.js \
+    --out ./ds-bundle --remote .design-sync/.cache/remote-sync.json
+  ```
+  (Re-stage `.ds-sync/` first per storybook §2.4 if it's missing — it's gitignored.)
+- **Shape:** storybook. Reference built into `.design-sync/sb-reference` from `.storybook/`.
+- **Own-source-repo build:** there is no `node_modules/@e2a/ui`, so the converter
+  runs with `--entry ./dist/index.js` (the built barrel) and `--node-modules ./node_modules`.
+  Always `npm run build` before the converter so `dist/` is fresh.
+- **CSS is flattened at build time.** `scripts/flatten-css.mjs` (wired into tsup
+  `onSuccess`) inlines `src/tokens.css` into `dist/styles.css` so the shipped
+  stylesheet is self-contained (no relative `@import` the converter would drop).
+  `[GENERAL]` If `dist/styles.css` ever `@import`s a sibling again, the converter
+  ships a bundle whose `var(--*)` are all undefined → everything renders unstyled.
+
+## Consuming from Next.js App Router
+
+- **The bundle ships `"use client"`** (tsup `banner`). The library mixes
+  interactive components (`InkConsole`, `Collapsible`) that use React hooks with
+  pure ones; esbuild strips per-file directives when bundling, so the whole entry
+  is marked a client module. Without this, importing `@e2a/ui` into a Server
+  Component fails (`"You're importing a module that depends on useEffect…"`).
+  Tradeoff: every component is a client component (no RSC for the pure ones). A
+  future refinement is per-component directive preservation (split build) so
+  `Button`/`Chip`/`Card`/etc. can stay server components.
+- The `"use client"` banner is a no-op for the design-sync esbuild bundle and for
+  Storybook (both ignore the directive). It does change `dist/index.js` bytes, so
+  the next design-sync re-sync will re-upload the bundle once — harmless.
+
+## Accepted deviations (the oracle can't see these)
+
+- **`[FONT_MISSING]` — accepted, system substitutes.** The CSS references
+  `"Geist"` (`--f-ui`) and `"JetBrains Mono"` (`--f-mono`), but this package does
+  not vendor the woff2 files (the app loads them via `next/font`). Both panels of
+  the compare oracle fall back to the same system fonts, so grades pass while
+  claude.ai/design users see system sans/mono instead of Geist/JetBrains Mono.
+  This is acceptable for now — the tokens declare close system fallbacks
+  (`-apple-system …`, `ui-monospace …`). **To make it faithful:** add the woff2s
+  (e.g. the `geist` and `@fontsource/jetbrains-mono` packages) and wire
+  `cfg.extraFonts` with matching `@font-face` blocks, then inject the same
+  `@font-face` into `.design-sync/sb-reference/iframe.html` so the oracle verifies
+  with the real fonts on both sides.
+
+## Re-sync risks (watch-list for the next run)
+
+- **Fonts:** still substituted (see above). If `cfg.extraFonts` was added since,
+  confirm the woff2 paths still resolve.
+- **ThemeToggle is a controlled fork.** The app's original consumed a
+  `ThemeProvider` context; this package's version takes `value`/`onChange` props.
+  Its stories drive it from local `useState`. If the upstream component's API
+  changes, this copy won't track it automatically.
+- **CSS-driven atoms.** The source components in `web/src/app/components/loft/`
+  mix Tailwind utility classes with CSS-variable inline styles. The copies here
+  were adapted to be fully CSS-class-driven (`loft-*` classes in `styles.css`).
+  They are visual ports, not byte-identical re-exports — re-verify against the
+  storybook render after any upstream restyle.
+- **11 components synced**, from three sources: `loft/` (`Button`, `Chip`,
+  `Dot`, `Eyebrow`, `ThemeToggle`, `InkConsole`); brand SVGs in `web/public`
+  (`Logo` — one themeable component replacing the 4 static svgs); and other
+  app components ported CSS-driven (`Field` ← `Field.tsx`, `Avatar` ←
+  `CounterpartyAvatar`, `Collapsible` ← `messages/Collapsible.tsx`); plus
+  net-new `Card`. Still NOT synced: `PageShell`/`Topbar` (responsive Tailwind
+  layout — want Tailwind in the package first) and `Sidebar` (Next.js routing +
+  auth context).
+- **`Logo` and `Avatar` are token-faithful, not file-faithful.** `Logo` is one
+  React component drawn from Loft tokens (the `web/public/*.svg` files are flat
+  recolorings of the same marks); `Avatar` needs the `--av-1..8` palette, which
+  was added to `tokens.css` (it was missing from the first extraction).

--- a/design-system/.design-sync/config.json
+++ b/design-system/.design-sync/config.json
@@ -1,0 +1,10 @@
+{
+  "projectId": "f8ae151e-dd46-4d5c-a951-932d389bf47a",
+  "pkg": "@e2a/ui",
+  "globalName": "E2aUi",
+  "shape": "storybook",
+  "storybookConfigDir": ".storybook",
+  "storybookStatic": ".design-sync/sb-reference",
+  "buildCmd": "npm run build",
+  "readmeHeader": ".design-sync/conventions.md"
+}

--- a/design-system/.design-sync/conventions.md
+++ b/design-system/.design-sync/conventions.md
@@ -1,0 +1,79 @@
+# Building with @e2a/ui (Loft)
+
+Loft is the e2a design system. Build UIs from its components and style your own
+layout with its design tokens. There is **no provider or wrapper to set up** —
+components are self-contained and styled from CSS variables, so they render
+correctly as soon as the stylesheet is present (it is already bound for you).
+
+## Theme & dark mode
+
+All color/spacing/type comes from CSS custom properties defined on `:root`.
+Dark mode is a single class on an ancestor: put `class="dark"` on a wrapping
+element (or `<html>`) and every token — and therefore every component and any
+layout you build with tokens — flips automatically. Never hardcode hex colors;
+reference the tokens so light/dark both work.
+
+## The styling idiom — use tokens, not utility classes
+
+Loft is a **token system**, not a Tailwind-style utility-class kit. Components
+carry their own styling internally (`loft-*` classes you don't author). For YOUR
+own layout glue (wrappers, grids, spacing), write plain CSS/inline styles that
+reference Loft tokens. The real vocabulary:
+
+| Concern | Tokens (use `var(--…)`) |
+|---|---|
+| Surfaces | `--bg` (app), `--bg-panel` (cards), `--bg-elev` (raised), `--bg-sunken` |
+| Text | `--fg`, `--fg-strong`, `--fg-muted`, `--fg-subtle` |
+| Borders | `--border`, `--border-sub`, `--border-strong` |
+| Accent (ember) | `--accent`, `--accent-fill`, `--accent-strong`, `--accent-soft`, `--accent-fg` |
+| Semantic | `--success`, `--warn`, `--danger`, `--info` (+ `-bg`, `-strong` pairs) |
+| Ink (agent console) | `--ink`, `--ink-elev`, `--ink-fg`, `--ink-fg-muted`, `--spectral`, `--machine` |
+| Radii | `--r-sm` `--r-md` `--r-lg` `--r-xl` |
+| Spacing (4px grid) | `--sp-1`…`--sp-8` |
+| Type | `--f-ui`, `--f-mono`, `--f-editorial`; sizes `--fs-body` `--fs-small` `--fs-h1` `--fs-h2` … |
+
+## Components
+
+`Button` (variants `primary` / `ghost` / `mono`), `Chip` (tone
+`success`/`warn`/`info`/`accent`/`danger`/`neutral`, plus `mono`), `Dot` (status
+tone), `Eyebrow` (uppercase mono kicker), `ThemeToggle` (controlled — pass
+`value` + `onChange`), `InkConsole` (dark code/console surface; takes `lines`),
+`Logo` (the e2a brand mark — `variant` `wordmark`/`mark`, `tone`
+`color`/`mono`/`ink`, themeable, sized by `height`), `Field` (labeled text
+input; controlled `value`/`onChange`), `Avatar` (initials square, deterministic
+`--av-*` color from `email`/`name`), `Collapsible` (disclosure with `label` +
+`children`), `Card` (the panel surface container — wrap content blocks in it).
+Read each component's `.prompt.md` for props and examples, and its `.d.ts` for
+the exact API. The stylesheet (`styles.css`, which defines all the tokens above)
+is the authority on the visual language — read it before inventing styling.
+
+## Idiomatic example
+
+```tsx
+import { Button, Chip, Eyebrow } from "@e2a/ui";
+
+function MessageCard() {
+  return (
+    <div
+      style={{
+        background: "var(--bg-panel)",
+        border: "1px solid var(--border)",
+        borderRadius: "var(--r-lg)",
+        padding: "var(--sp-4)",
+        display: "flex",
+        flexDirection: "column",
+        gap: "var(--sp-3)",
+      }}
+    >
+      <Eyebrow>Inbound mail</Eyebrow>
+      <div style={{ display: "flex", alignItems: "center", gap: "var(--sp-2)" }}>
+        <Chip tone="success">delivered</Chip>
+        <span style={{ color: "var(--fg-muted)", fontSize: "var(--fs-small)" }}>
+          2 min ago
+        </span>
+      </div>
+      <Button variant="primary">Reply</Button>
+    </div>
+  );
+}
+```

--- a/design-system/.gitignore
+++ b/design-system/.gitignore
@@ -1,0 +1,13 @@
+node_modules/
+dist/
+storybook-static/
+*.log
+.DS_Store
+
+# design-sync transient/work state (the durable set under .design-sync/ is committed)
+.design-sync/sb-reference/
+.design-sync/learnings/
+.design-sync/.cache/
+.design-sync/node_modules
+.ds-sync/
+ds-bundle/

--- a/design-system/.storybook/main.ts
+++ b/design-system/.storybook/main.ts
@@ -1,0 +1,12 @@
+import type { StorybookConfig } from "@storybook/react-vite";
+
+const config: StorybookConfig = {
+  stories: ["../src/**/*.stories.@(ts|tsx)"],
+  addons: [],
+  framework: {
+    name: "@storybook/react-vite",
+    options: {},
+  },
+};
+
+export default config;

--- a/design-system/.storybook/preview.ts
+++ b/design-system/.storybook/preview.ts
@@ -1,0 +1,21 @@
+import type { Preview } from "@storybook/react-vite";
+
+// Load the design system's styles into every story so components render
+// with real Loft tokens. `styles.css` @imports `tokens.css`.
+import "../src/styles.css";
+
+const preview: Preview = {
+  parameters: {
+    controls: { matchers: { color: /(background|color)$/i, date: /Date$/i } },
+    backgrounds: {
+      default: "loft",
+      values: [
+        { name: "loft", value: "#FAF7F2" },
+        { name: "panel", value: "#FFFFFF" },
+        { name: "ink", value: "#1A1714" },
+      ],
+    },
+  },
+};
+
+export default preview;

--- a/design-system/README.md
+++ b/design-system/README.md
@@ -1,0 +1,82 @@
+# @e2a/ui — Loft design system
+
+A standalone, buildable React component library for e2a's "Loft" design
+language. This package is the source of truth for the shared UI atoms and
+their design tokens, extracted from the web app so they can be reused,
+documented in Storybook, and synced to claude.ai/design.
+
+## What's here
+
+```
+design-system/
+├── src/
+│   ├── index.ts          # public API — re-exports every component
+│   ├── tokens.css        # Loft design tokens (colors, type, spacing) — light + .dark
+│   ├── styles.css        # @imports tokens.css + base + one class per component
+│   ├── Button/           # Button.tsx + Button.stories.tsx
+│   ├── Chip/
+│   ├── Dot/
+│   ├── Eyebrow/
+│   ├── ThemeToggle/      # controlled segmented theme control
+│   ├── InkConsole/       # agent-native dark code console
+│   ├── Logo/             # e2a wordmark + boxed monogram (themeable)
+│   ├── Field/            # labeled text input
+│   ├── Avatar/           # deterministic-color initials avatar
+│   ├── Collapsible/      # disclosure section
+│   └── Card/             # surface container
+├── .storybook/           # Storybook config (react-vite)
+├── tsup.config.ts        # build → dist/
+└── package.json
+```
+
+## Develop
+
+```bash
+npm install              # install deps
+npm run storybook        # component workshop at http://localhost:6006
+npm run build            # compile to dist/ (index.js + .d.ts + tokens.css + styles.css)
+npm run typecheck        # tsc --noEmit
+```
+
+## Use it
+
+```tsx
+import { Button, Chip } from "@e2a/ui";
+import "@e2a/ui/styles.css";   // once, at your app root
+
+export function Example() {
+  return (
+    <div>
+      <Chip tone="success">delivered</Chip>
+      <Button variant="primary">Send email</Button>
+    </div>
+  );
+}
+```
+
+Dark mode: add `class="dark"` to `<html>` — every token flips automatically.
+
+## A note on styling
+
+The original components in `web/src/app/components/loft/` mix CSS-variable
+inline styles with Tailwind utility classes. To keep this package free of a
+Tailwind build, the atoms here are adapted to be **fully CSS-driven**: they
+emit semantic class names (`loft-btn`, `loft-chip`, …) defined in `styles.css`,
+using the same Loft tokens, so the look is identical but the package stands
+alone. If you'd rather copy components verbatim, add Tailwind 4 to this package
+and import the token bridge instead.
+
+## Adding a component
+
+1. `src/Thing/Thing.tsx` — a prop-driven component using `loft-*` classes.
+2. Add its styles to `src/styles.css`.
+3. `src/Thing/Thing.stories.tsx` — one story per meaningful state.
+4. Re-export it from `src/index.ts`.
+5. `npm run build` and you're done.
+
+Good next extraction candidates from the app: `PageShell` and `Topbar` (these
+lean on responsive Tailwind utilities — easiest once this package adopts
+Tailwind), and `Sidebar` (depends on Next.js routing + auth/pending-count
+context — decouple those first). `ThemeToggle` was extracted as a *controlled*
+component (it took its state from a React context in the app); wire its
+`value`/`onChange` to your own theme state.

--- a/design-system/package.json
+++ b/design-system/package.json
@@ -2,7 +2,7 @@
   "name": "@e2a/ui",
   "version": "0.1.0",
   "description": "Loft — the e2a design system. Standalone, buildable React component library.",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "type": "module",
   "sideEffects": [
     "*.css"

--- a/design-system/package.json
+++ b/design-system/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@e2a/ui",
+  "version": "0.1.0",
+  "description": "Loft — the e2a design system. Standalone, buildable React component library.",
+  "license": "MIT",
+  "type": "module",
+  "sideEffects": [
+    "*.css"
+  ],
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    },
+    "./styles.css": "./dist/styles.css",
+    "./tokens.css": "./dist/tokens.css"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "storybook": "storybook dev -p 6006",
+    "build-storybook": "storybook build",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "react": ">=18",
+    "react-dom": ">=18"
+  },
+  "devDependencies": {
+    "@storybook/react": "^8.6.14",
+    "@storybook/react-vite": "^8.6.14",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "@vitejs/plugin-react": "^4.3.4",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "storybook": "^8.6.14",
+    "tsup": "^8.3.5",
+    "typescript": "^5.7.2",
+    "vite": "^6.0.0"
+  }
+}

--- a/design-system/scripts/flatten-css.mjs
+++ b/design-system/scripts/flatten-css.mjs
@@ -1,0 +1,31 @@
+// Emit self-contained CSS into dist/.
+//
+// Source keeps tokens and component styles in separate files (styles.css
+// pulls tokens via `@import "./tokens.css"`), which Vite/Storybook resolve
+// fine. But a downstream consumer that only copies dist/styles.css (e.g. the
+// design-sync converter) won't follow that relative import — so the tokens,
+// and every var(--*) reference, would go missing.
+//
+// To stay robust, we FLATTEN: inline tokens.css into dist/styles.css so the
+// shipped stylesheet has no external @import. We still emit dist/tokens.css
+// separately for consumers who want only the tokens.
+import { readFileSync, writeFileSync, copyFileSync } from "node:fs";
+
+const tokens = readFileSync("src/tokens.css", "utf8");
+const styles = readFileSync("src/styles.css", "utf8");
+
+const flattened = styles.replace(
+  /@import\s+["']\.\/tokens\.css["'];?/,
+  `/* tokens.css inlined at build time — see scripts/flatten-css.mjs */\n${tokens}`,
+);
+
+if (flattened === styles) {
+  throw new Error(
+    "flatten-css: did not find `@import \"./tokens.css\"` in src/styles.css — " +
+      "the inline anchor is gone; update this script.",
+  );
+}
+
+writeFileSync("dist/styles.css", flattened);
+copyFileSync("src/tokens.css", "dist/tokens.css");
+console.log("flatten-css: wrote self-contained dist/styles.css + dist/tokens.css");

--- a/design-system/src/Avatar/Avatar.stories.tsx
+++ b/design-system/src/Avatar/Avatar.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Avatar } from "./Avatar";
+
+const meta = {
+  title: "Atoms/Avatar",
+  component: Avatar,
+  tags: ["autodocs"],
+} satisfies Meta<typeof Avatar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { name: "Ada Lovelace", email: "ada@acme.com", size: 32 },
+};
+
+export const FromEmail: Story = {
+  args: { email: "founder@example.com", size: 32 },
+};
+
+export const Row: Story = {
+  args: { email: "a@a.com" },
+  render: () => (
+    <div style={{ display: "flex", gap: 8 }}>
+      <Avatar name="Ada Lovelace" email="ada@acme.com" size={28} />
+      <Avatar name="Grace Hopper" email="grace@navy.mil" size={28} />
+      <Avatar email="support@e2a.dev" size={28} />
+      <Avatar name="Kit" email="kit@studio.io" size={28} />
+    </div>
+  ),
+};

--- a/design-system/src/Avatar/Avatar.tsx
+++ b/design-system/src/Avatar/Avatar.tsx
@@ -1,0 +1,61 @@
+export type AvatarProps = {
+  /** Display name; used for initials and (if no email) the color seed. */
+  name?: string;
+  /** Email; used as the color seed and for initials when no name is given. */
+  email?: string;
+  /** Pixel size of the square. Defaults to 24. */
+  size?: number;
+};
+
+// Deterministic bucket in [1, 8] from a short string (FNV-ish). The same
+// seed always maps to the same --av color, so a person reads consistently
+// across the UI.
+function hashTo8(input: string): number {
+  let h = 0;
+  for (let i = 0; i < input.length; i++) {
+    h = (h * 31 + input.charCodeAt(i)) | 0;
+  }
+  return (((h % 8) + 8) % 8) + 1;
+}
+
+function initials(name?: string, email?: string): string {
+  if (name) {
+    const parts = name.trim().split(/\s+/);
+    if (parts.length >= 2) {
+      return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+    }
+    return parts[0].slice(0, 2).toUpperCase();
+  }
+  const local = (email ?? "").split("@")[0] || email || "?";
+  return local.slice(0, 2).toUpperCase();
+}
+
+/**
+ * Square avatar with a deterministic color from the Loft `--av-1…8` palette,
+ * seeded by email (or name), showing the person's initials.
+ */
+export function Avatar({ name, email, size = 24 }: AvatarProps) {
+  const seed = (email || name || "").toLowerCase();
+  const bucket = hashTo8(seed);
+  return (
+    <span
+      aria-hidden
+      style={{
+        width: size,
+        height: size,
+        borderRadius: 4,
+        background: `var(--av-${bucket})`,
+        color: "#fff",
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        fontSize: Math.round(size * 0.42),
+        fontWeight: 700,
+        flexShrink: 0,
+        letterSpacing: "0.02em",
+      }}
+    >
+      {initials(name, email)}
+    </span>
+  );
+}

--- a/design-system/src/Avatar/Avatar.tsx
+++ b/design-system/src/Avatar/Avatar.tsx
@@ -19,8 +19,9 @@ function hashTo8(input: string): number {
 }
 
 function initials(name?: string, email?: string): string {
-  if (name) {
-    const parts = name.trim().split(/\s+/);
+  const trimmed = name?.trim();
+  if (trimmed) {
+    const parts = trimmed.split(/\s+/);
     if (parts.length >= 2) {
       return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
     }

--- a/design-system/src/Button/Button.stories.tsx
+++ b/design-system/src/Button/Button.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Button } from "./Button";
+
+const meta = {
+  title: "Atoms/Button",
+  component: Button,
+  tags: ["autodocs"],
+  argTypes: {
+    variant: { control: "inline-radio", options: ["primary", "ghost", "mono"] },
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: { variant: "primary", children: "Send email" },
+};
+
+export const Ghost: Story = {
+  args: { variant: "ghost", children: "Cancel" },
+};
+
+export const Mono: Story = {
+  args: { variant: "mono", children: "agent.run()" },
+};
+
+export const Disabled: Story = {
+  args: { variant: "primary", children: "Send email", disabled: true },
+};

--- a/design-system/src/Button/Button.tsx
+++ b/design-system/src/Button/Button.tsx
@@ -1,0 +1,30 @@
+import type { ButtonHTMLAttributes } from "react";
+
+export type ButtonVariant = "primary" | "ghost" | "mono";
+
+export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
+  /** Visual style. `primary` = ember fill, `ghost` = bordered, `mono` = ink/console. */
+  variant?: ButtonVariant;
+};
+
+/**
+ * Loft button. Three variants drawn entirely from design tokens, so it
+ * re-themes automatically under `.dark`. Forwards all native button props.
+ */
+export function Button({
+  variant = "primary",
+  className = "",
+  type = "button",
+  children,
+  ...rest
+}: ButtonProps) {
+  return (
+    <button
+      type={type}
+      className={`loft-btn loft-btn--${variant} ${className}`.trim()}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+}

--- a/design-system/src/Card/Card.stories.tsx
+++ b/design-system/src/Card/Card.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Card } from "./Card";
+import { Eyebrow } from "../Eyebrow/Eyebrow";
+import { Chip } from "../Chip/Chip";
+
+const meta = {
+  title: "Surfaces/Card",
+  component: Card,
+  tags: ["autodocs"],
+} satisfies Meta<typeof Card>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <Card style={{ width: 320 }}>
+      <Eyebrow>Inbound mail</Eyebrow>
+      <div style={{ marginTop: 8, display: "flex", alignItems: "center", gap: 8 }}>
+        <Chip tone="success">delivered</Chip>
+        <span style={{ color: "var(--fg-muted)", fontSize: 12 }}>2 min ago</span>
+      </div>
+    </Card>
+  ),
+};
+
+export const Plain: Story = {
+  render: () => (
+    <Card style={{ width: 320 }}>
+      <p style={{ margin: 0, color: "var(--fg)" }}>A simple surface container.</p>
+    </Card>
+  ),
+};

--- a/design-system/src/Card/Card.tsx
+++ b/design-system/src/Card/Card.tsx
@@ -1,0 +1,15 @@
+import type { HTMLAttributes } from "react";
+
+export type CardProps = HTMLAttributes<HTMLDivElement>;
+
+/**
+ * Surface container — the panel background, border, and radius that wrap most
+ * content blocks. Forwards native div props; compose freely inside.
+ */
+export function Card({ className = "", children, ...props }: CardProps) {
+  return (
+    <div className={`loft-card ${className}`.trim()} {...props}>
+      {children}
+    </div>
+  );
+}

--- a/design-system/src/Chip/Chip.stories.tsx
+++ b/design-system/src/Chip/Chip.stories.tsx
@@ -1,0 +1,25 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Chip } from "./Chip";
+
+const meta = {
+  title: "Atoms/Chip",
+  component: Chip,
+  tags: ["autodocs"],
+  argTypes: {
+    tone: {
+      control: "inline-radio",
+      options: ["success", "warn", "info", "accent", "danger", "neutral"],
+    },
+    mono: { control: "boolean" },
+  },
+} satisfies Meta<typeof Chip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Delivered: Story = { args: { tone: "success", children: "delivered" } };
+export const Pending: Story = { args: { tone: "warn", children: "pending review" } };
+export const Bounced: Story = { args: { tone: "danger", children: "bounced" } };
+export const MessageId: Story = {
+  args: { tone: "neutral", mono: true, children: "msg_abc123" },
+};

--- a/design-system/src/Chip/Chip.tsx
+++ b/design-system/src/Chip/Chip.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react";
+
+export type ChipTone =
+  | "success"
+  | "warn"
+  | "info"
+  | "accent"
+  | "danger"
+  | "neutral";
+
+export type ChipProps = {
+  children: ReactNode;
+  /** Semantic color. Defaults to `neutral`. */
+  tone?: ChipTone;
+  /** Render in the monospace face (for ids, codes, statuses). */
+  mono?: boolean;
+  className?: string;
+};
+
+/** Small rounded status/label pill, tinted by semantic tone. */
+export function Chip({
+  children,
+  tone = "neutral",
+  mono = false,
+  className = "",
+}: ChipProps) {
+  return (
+    <span
+      className={`loft-chip loft-chip--${tone}${mono ? " loft-chip--mono" : ""} ${className}`.trim()}
+    >
+      {children}
+    </span>
+  );
+}

--- a/design-system/src/Collapsible/Collapsible.stories.tsx
+++ b/design-system/src/Collapsible/Collapsible.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Collapsible } from "./Collapsible";
+
+const meta = {
+  title: "Surfaces/Collapsible",
+  component: Collapsible,
+  tags: ["autodocs"],
+} satisfies Meta<typeof Collapsible>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const body = (
+  <div style={{ padding: "12px 18px", fontSize: 13, color: "var(--fg-muted)" }}>
+    Received: by mx.e2a.dev with SMTP id abc123
+    <br />
+    SPF: pass · DKIM: pass · DMARC: pass
+  </div>
+);
+
+export const Closed: Story = {
+  args: { label: "Full headers", meta: "12 lines", children: body },
+  render: (a) => (
+    <div style={{ width: 420 }}>
+      <Collapsible {...a} />
+    </div>
+  ),
+};
+
+export const Open: Story = {
+  args: { label: "Full headers", meta: "12 lines", defaultOpen: true, children: body },
+  render: (a) => (
+    <div style={{ width: 420 }}>
+      <Collapsible {...a} />
+    </div>
+  ),
+};

--- a/design-system/src/Collapsible/Collapsible.tsx
+++ b/design-system/src/Collapsible/Collapsible.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState, useSyncExternalStore, type ReactNode } from "react";
+import { Eyebrow } from "../Eyebrow/Eyebrow";
+
+export type CollapsibleProps = {
+  /** Eyebrow label on the left of the trigger. */
+  label: string;
+  /** Optional mono meta line on the right of the trigger. */
+  meta?: ReactNode;
+  defaultOpen?: boolean;
+  /** Controlled mode — when provided, `open` overrides internal state. */
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  children: ReactNode;
+};
+
+// useSyncExternalStore subscribes to the matchMedia query without effect
+// ping-pong — keeps the chevron's animation honest to prefers-reduced-motion.
+function usePrefersReducedMotion(): boolean {
+  return useSyncExternalStore(
+    subscribeReducedMotion,
+    getReducedMotionSnapshot,
+    getReducedMotionServerSnapshot,
+  );
+}
+function subscribeReducedMotion(onChange: () => void): () => void {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return () => {};
+  }
+  const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+  mq.addEventListener("change", onChange);
+  return () => mq.removeEventListener("change", onChange);
+}
+function getReducedMotionSnapshot(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    return false;
+  }
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}
+function getReducedMotionServerSnapshot(): boolean {
+  return false;
+}
+
+/** Header-with-chevron disclosure section. Controlled or uncontrolled. */
+export function Collapsible({
+  label,
+  meta,
+  defaultOpen = false,
+  open: controlledOpen,
+  onOpenChange,
+  children,
+}: CollapsibleProps) {
+  const [uncontrolled, setUncontrolled] = useState(defaultOpen);
+  const open = controlledOpen ?? uncontrolled;
+  const reduced = usePrefersReducedMotion();
+
+  const setOpen = (next: boolean) => {
+    if (controlledOpen === undefined) setUncontrolled(next);
+    onOpenChange?.(next);
+  };
+
+  return (
+    <section className="loft-collapsible">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        aria-expanded={open}
+        className={`loft-collapsible__trigger${open ? " loft-collapsible__trigger--open" : ""}`}
+      >
+        <span
+          aria-hidden
+          className="loft-collapsible__chevron"
+          style={{
+            transform: open ? "rotate(90deg)" : "rotate(0deg)",
+            transition: reduced ? "none" : "transform 120ms ease",
+          }}
+        >
+          ▶
+        </span>
+        <Eyebrow>{label}</Eyebrow>
+        <span className="loft-collapsible__spacer" />
+        {meta && <span className="loft-collapsible__meta">{meta}</span>}
+      </button>
+      {open && children}
+    </section>
+  );
+}

--- a/design-system/src/Dot/Dot.stories.tsx
+++ b/design-system/src/Dot/Dot.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Dot } from "./Dot";
+
+const meta = {
+  title: "Atoms/Dot",
+  component: Dot,
+  tags: ["autodocs"],
+  argTypes: {
+    tone: {
+      control: "inline-radio",
+      options: ["success", "warn", "accent", "danger", "neutral"],
+    },
+  },
+} satisfies Meta<typeof Dot>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Online: Story = { args: { tone: "success" } };
+export const Degraded: Story = { args: { tone: "warn" } };
+export const Down: Story = { args: { tone: "danger" } };

--- a/design-system/src/Dot/Dot.tsx
+++ b/design-system/src/Dot/Dot.tsx
@@ -1,0 +1,11 @@
+export type DotTone = "success" | "warn" | "accent" | "danger" | "neutral";
+
+export type DotProps = {
+  /** Status color. Defaults to `success`. */
+  tone?: DotTone;
+};
+
+/** Tiny status dot — decorative, pair it with a text label for meaning. */
+export function Dot({ tone = "success" }: DotProps) {
+  return <span aria-hidden className={`loft-dot loft-dot--${tone}`} />;
+}

--- a/design-system/src/Eyebrow/Eyebrow.stories.tsx
+++ b/design-system/src/Eyebrow/Eyebrow.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Eyebrow } from "./Eyebrow";
+
+const meta = {
+  title: "Atoms/Eyebrow",
+  component: Eyebrow,
+  tags: ["autodocs"],
+} satisfies Meta<typeof Eyebrow>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = { args: { children: "Getting started" } };
+export const Section: Story = { args: { children: "Inbound mail" } };

--- a/design-system/src/Eyebrow/Eyebrow.tsx
+++ b/design-system/src/Eyebrow/Eyebrow.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+
+export type EyebrowProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+/** Small uppercase mono kicker that sits above a heading. */
+export function Eyebrow({ children, className = "" }: EyebrowProps) {
+  return (
+    <span className={`loft-eyebrow ${className}`.trim()}>{children}</span>
+  );
+}

--- a/design-system/src/Field/Field.stories.tsx
+++ b/design-system/src/Field/Field.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { Field } from "./Field";
+
+const meta = {
+  title: "Forms/Field",
+  component: Field,
+  tags: ["autodocs"],
+} satisfies Meta<typeof Field>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+function Demo(args: { label: string; hint?: string; placeholder?: string; initial?: string }) {
+  const [v, setV] = useState(args.initial ?? "");
+  return (
+    <div style={{ width: 320 }}>
+      <Field label={args.label} hint={args.hint} placeholder={args.placeholder} value={v} onChange={setV} />
+    </div>
+  );
+}
+
+export const Default: Story = {
+  args: { label: "Agent name", value: "", onChange: () => {} },
+  render: () => <Demo label="Agent name" placeholder="support-bot" />,
+};
+
+export const WithHint: Story = {
+  args: { label: "Forward address", value: "", onChange: () => {} },
+  render: () => (
+    <Demo
+      label="Forward address"
+      placeholder="agent@acme.com"
+      hint="Inbound mail is signed and delivered to this endpoint."
+    />
+  ),
+};
+
+export const Filled: Story = {
+  args: { label: "Reply-to", value: "", onChange: () => {} },
+  render: () => <Demo label="Reply-to" initial="founder@acme.com" />,
+};

--- a/design-system/src/Field/Field.tsx
+++ b/design-system/src/Field/Field.tsx
@@ -1,0 +1,35 @@
+import type { InputHTMLAttributes } from "react";
+
+export type FieldProps = {
+  /** Label rendered above the input. */
+  label: string;
+  /** Optional helper text below the input. */
+  hint?: string;
+  value: string;
+  onChange: (value: string) => void;
+} & Omit<InputHTMLAttributes<HTMLInputElement>, "value" | "onChange">;
+
+/** Labeled text input with an optional hint. Controlled via `value`/`onChange`. */
+export function Field({
+  label,
+  hint,
+  value,
+  onChange,
+  className = "",
+  type = "text",
+  ...props
+}: FieldProps) {
+  return (
+    <label className={`loft-field ${className}`.trim()}>
+      <span className="loft-field__label">{label}</span>
+      <input
+        {...props}
+        type={type}
+        className="loft-field__input"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      {hint && <span className="loft-field__hint">{hint}</span>}
+    </label>
+  );
+}

--- a/design-system/src/InkConsole/InkConsole.stories.tsx
+++ b/design-system/src/InkConsole/InkConsole.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { InkConsole } from "./InkConsole";
+
+const meta = {
+  title: "Surfaces/InkConsole",
+  component: InkConsole,
+  tags: ["autodocs"],
+  parameters: { backgrounds: { default: "panel" } },
+} satisfies Meta<typeof InkConsole>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Curl: Story = {
+  args: {
+    title: "send an email",
+    lang: "bash",
+    lines: [
+      { c: "comment", text: "# POST a message as your agent" },
+      { c: "prompt", text: "curl -X POST https://api.e2a.dev/v1/messages \\" },
+      { c: "string", text: '  -H "Authorization: Bearer $E2A_KEY" \\' },
+      { c: "string", text: '  -d \'{"to":"founder@acme.com","subject":"hi"}\'' },
+    ],
+  },
+};
+
+export const Output: Story = {
+  args: {
+    title: "response",
+    lang: "json",
+    copy: false,
+    lines: [
+      { c: "plain", text: "{" },
+      { c: "accent", text: '  "id": "msg_abc123",' },
+      { c: "string", text: '  "status": "queued"' },
+      { c: "plain", text: "}" },
+    ],
+  },
+};

--- a/design-system/src/InkConsole/InkConsole.tsx
+++ b/design-system/src/InkConsole/InkConsole.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
+import { Button } from "../Button/Button";
+
+export type InkLineKind = "comment" | "prompt" | "string" | "accent" | "plain";
+
+export type InkLine =
+  | { c?: InkLineKind; text: string; fg?: string; node?: undefined }
+  | { node: ReactNode; c?: undefined; text?: undefined; fg?: undefined };
+
+export type InkConsoleProps = {
+  /** Lines to render. Each is either tokenized text (`{ text, c }`) or a raw `{ node }`. */
+  lines: InkLine[];
+  title?: string;
+  lang?: string;
+  /** Show the copy button (copies all text lines). Defaults to true. */
+  copy?: boolean;
+  height?: number | string;
+  className?: string;
+};
+
+const kindColor: Record<InkLineKind, string> = {
+  comment: "var(--ink-fg-muted)",
+  prompt: "var(--machine)",
+  string: "var(--spectral)",
+  accent: "var(--accent)",
+  plain: "var(--ink-fg)",
+};
+
+function plainText(lines: InkLine[]): string {
+  return lines
+    .map((l) => (l.node ? "" : l.text ?? ""))
+    .filter(Boolean)
+    .join("\n");
+}
+
+/**
+ * Agent-native console surface. Renders on the dark "ink" palette regardless
+ * of theme, with syntax-tinted lines and an optional copy button.
+ */
+export function InkConsole({
+  lines,
+  title,
+  lang,
+  copy = true,
+  height,
+  className = "",
+}: InkConsoleProps) {
+  const showHeader = Boolean(title || lang || copy);
+  const [copied, setCopied] = useState(false);
+  // Clear the "copied" pulse timer on unmount so a fast unmount within the
+  // 1.2s window doesn't setState on an unmounted component.
+  const copyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copyTimer.current !== null) clearTimeout(copyTimer.current);
+    };
+  }, []);
+
+  const onCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(plainText(lines));
+      setCopied(true);
+      if (copyTimer.current !== null) clearTimeout(copyTimer.current);
+      copyTimer.current = setTimeout(() => {
+        setCopied(false);
+        copyTimer.current = null;
+      }, 1200);
+    } catch {
+      // clipboard unavailable — silently ignore
+    }
+  }, [lines]);
+
+  return (
+    <div className={`loft-console ${className}`.trim()} style={{ height }}>
+      {showHeader && (
+        <div className="loft-console__header">
+          {title && <span className="loft-console__title">{title}</span>}
+          {lang && (
+            <span
+              className={`loft-console__lang${title ? " loft-console__lang--gap" : ""}`}
+            >
+              {lang}
+            </span>
+          )}
+          <span className="loft-console__spacer" />
+          {copy && (
+            <Button variant="mono" onClick={onCopy} aria-label="Copy to clipboard">
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                aria-hidden
+              >
+                <rect x="9" y="9" width="11" height="11" rx="2" />
+                <path d="M5 15V5a2 2 0 012-2h10" />
+              </svg>
+              {copied ? "copied" : "copy"}
+            </Button>
+          )}
+        </div>
+      )}
+      <div className="loft-console__body">
+        {lines.map((l, i) => {
+          if (l.node !== undefined) {
+            return <div key={i}>{l.node}</div>;
+          }
+          const color = l.fg ?? kindColor[l.c ?? "plain"];
+          return (
+            <div key={i} className="loft-console__line" style={{ color }}>
+              {l.text}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/design-system/src/Logo/Logo.stories.tsx
+++ b/design-system/src/Logo/Logo.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { Logo } from "./Logo";
+
+const meta = {
+  title: "Brand/Logo",
+  component: Logo,
+  tags: ["autodocs"],
+  argTypes: {
+    variant: { control: "inline-radio", options: ["wordmark", "mark"] },
+    tone: { control: "inline-radio", options: ["color", "mono", "ink"] },
+    height: { control: { type: "number" } },
+  },
+} satisfies Meta<typeof Logo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Wordmark: Story = {
+  args: { variant: "wordmark", tone: "color", height: 48 },
+};
+
+export const Mark: Story = {
+  args: { variant: "mark", tone: "color", height: 64 },
+};
+
+export const WordmarkInk: Story = {
+  args: { variant: "wordmark", tone: "ink", height: 48 },
+};
+
+export const Mono: Story = {
+  args: { variant: "wordmark", tone: "mono", height: 48 },
+  // currentColor — show it inheriting an accent-colored context.
+  decorators: [
+    (Story) => (
+      <span style={{ color: "var(--accent-strong)" }}>
+        <Story />
+      </span>
+    ),
+  ],
+};

--- a/design-system/src/Logo/Logo.tsx
+++ b/design-system/src/Logo/Logo.tsx
@@ -1,0 +1,117 @@
+import type { CSSProperties } from "react";
+
+export type LogoVariant = "wordmark" | "mark";
+export type LogoTone = "color" | "mono" | "ink";
+
+export type LogoProps = {
+  /** `wordmark` = the "e2a" lockup; `mark` = the boxed "2" monogram. */
+  variant?: LogoVariant;
+  /**
+   * `color` — foreground + ember accent, theme-aware.
+   * `mono`  — single `currentColor` (inherits text color).
+   * `ink`   — light lockup on the dark ink panel.
+   */
+  tone?: LogoTone;
+  /** Rendered height in px; width derives from the aspect ratio. */
+  height?: number;
+  /** Accessible label. */
+  title?: string;
+  className?: string;
+  style?: CSSProperties;
+};
+
+// Shared with the brand SVGs in web/public — Geist first, then graceful fallbacks.
+const FONT =
+  "var(--f-ui), 'Inter', ui-sans-serif, system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif";
+
+// CSS custom properties only resolve in the `style` (CSS) layer, not in SVG
+// presentation attributes — so token fills go through `style`, not `fill=""`.
+const fillStyle = (value: string): CSSProperties => ({ fill: value });
+
+/**
+ * The e2a logo. One themeable component covering the wordmark and the boxed
+ * monogram; the `color` tone is drawn from Loft tokens, so it adapts to light
+ * and dark automatically. `mono` follows `currentColor` for one-color contexts.
+ */
+export function Logo({
+  variant = "wordmark",
+  tone = "color",
+  height,
+  title = "e2a",
+  className,
+  style,
+}: LogoProps) {
+  const mono = tone === "mono";
+
+  if (variant === "mark") {
+    const h = height ?? 32;
+    return (
+      <svg
+        role="img"
+        aria-label={title}
+        className={className}
+        style={style}
+        width={h}
+        height={h}
+        viewBox="0 0 256 256"
+      >
+        <rect
+          width="256"
+          height="256"
+          rx="56"
+          style={
+            mono
+              ? { fill: "none", stroke: "currentColor", strokeWidth: 12 }
+              : { fill: "var(--ink)" }
+          }
+        />
+        <text
+          x="128"
+          y="178"
+          textAnchor="middle"
+          fontFamily={FONT}
+          fontWeight={700}
+          fontSize={200}
+          letterSpacing={-12}
+          style={fillStyle(mono ? "currentColor" : "var(--ink-fg)")}
+        >
+          2
+        </text>
+      </svg>
+    );
+  }
+
+  // wordmark — aspect ratio 640 × 200 = 3.2
+  const h = height ?? 24;
+  const w = h * 3.2;
+  const ink = tone === "ink";
+  const textFill = mono ? "currentColor" : ink ? "var(--ink-fg)" : "var(--fg)";
+  const twoFill = mono ? "currentColor" : "var(--accent)";
+  return (
+    <svg
+      role="img"
+      aria-label={title}
+      className={className}
+      style={style}
+      width={w}
+      height={h}
+      viewBox="0 0 640 200"
+    >
+      {ink && <rect width="640" height="200" style={fillStyle("var(--ink)")} />}
+      <text
+        x="320"
+        y="148"
+        textAnchor="middle"
+        fontFamily={FONT}
+        fontWeight={600}
+        fontSize={176}
+        letterSpacing={-12}
+        style={fillStyle(textFill)}
+      >
+        <tspan>e</tspan>
+        <tspan style={fillStyle(twoFill)}>2</tspan>
+        <tspan>a</tspan>
+      </text>
+    </svg>
+  );
+}

--- a/design-system/src/Logo/Logo.tsx
+++ b/design-system/src/Logo/Logo.tsx
@@ -69,11 +69,10 @@ export function Logo({
           x="128"
           y="178"
           textAnchor="middle"
-          fontFamily={FONT}
           fontWeight={700}
           fontSize={200}
           letterSpacing={-12}
-          style={fillStyle(mono ? "currentColor" : "var(--ink-fg)")}
+          style={{ ...fillStyle(mono ? "currentColor" : "var(--ink-fg)"), fontFamily: FONT }}
         >
           2
         </text>
@@ -102,11 +101,10 @@ export function Logo({
         x="320"
         y="148"
         textAnchor="middle"
-        fontFamily={FONT}
         fontWeight={600}
         fontSize={176}
         letterSpacing={-12}
-        style={fillStyle(textFill)}
+        style={{ ...fillStyle(textFill), fontFamily: FONT }}
       >
         <tspan>e</tspan>
         <tspan style={fillStyle(twoFill)}>2</tspan>

--- a/design-system/src/ThemeToggle/ThemeToggle.stories.tsx
+++ b/design-system/src/ThemeToggle/ThemeToggle.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useState } from "react";
+import { ThemeToggle, type Theme } from "./ThemeToggle";
+
+const meta = {
+  title: "Controls/ThemeToggle",
+  component: ThemeToggle,
+  tags: ["autodocs"],
+} satisfies Meta<typeof ThemeToggle>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// Controlled component — drive it from local state in the story.
+function Demo({ initial }: { initial: Theme }) {
+  const [theme, setTheme] = useState<Theme>(initial);
+  return <ThemeToggle value={theme} onChange={setTheme} />;
+}
+
+export const System: Story = {
+  args: { value: "system", onChange: () => {} },
+  render: () => <Demo initial="system" />,
+};
+
+export const Light: Story = {
+  args: { value: "light", onChange: () => {} },
+  render: () => <Demo initial="light" />,
+};
+
+export const Dark: Story = {
+  args: { value: "dark", onChange: () => {} },
+  render: () => <Demo initial="dark" />,
+};

--- a/design-system/src/ThemeToggle/ThemeToggle.tsx
+++ b/design-system/src/ThemeToggle/ThemeToggle.tsx
@@ -1,0 +1,83 @@
+import type { ReactNode } from "react";
+
+export type Theme = "system" | "light" | "dark";
+
+export type ThemeToggleProps = {
+  /** The currently selected theme. */
+  value: Theme;
+  /** Called when the user picks a different theme. */
+  onChange: (theme: Theme) => void;
+  className?: string;
+};
+
+// Three-way segmented control. Originally consumed a ThemeProvider context;
+// extracted here as a controlled component so it has no app dependency —
+// wire `value`/`onChange` to your own theme state. Icons are 1.6-weight
+// strokes to match the rest of the Loft icon set.
+const OPTIONS: { value: Theme; label: string; icon: ReactNode }[] = [
+  {
+    value: "system",
+    label: "System theme",
+    icon: (
+      <>
+        <rect x="3" y="4" width="18" height="12" rx="2" />
+        <path d="M8 20h8M12 16v4" />
+      </>
+    ),
+  },
+  {
+    value: "light",
+    label: "Light theme",
+    icon: (
+      <>
+        <circle cx="12" cy="12" r="4" />
+        <path d="M12 2v2M12 20v2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M2 12h2M20 12h2M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" />
+      </>
+    ),
+  },
+  {
+    value: "dark",
+    label: "Dark theme",
+    icon: <path d="M21 12.8A9 9 0 1111.2 3a7 7 0 009.8 9.8z" />,
+  },
+];
+
+export function ThemeToggle({ value, onChange, className = "" }: ThemeToggleProps) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Color theme"
+      className={`loft-seg ${className}`.trim()}
+    >
+      {OPTIONS.map((opt) => {
+        const active = value === opt.value;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            aria-label={opt.label}
+            title={opt.label}
+            onClick={() => onChange(opt.value)}
+            className="loft-seg__opt"
+          >
+            <svg
+              width="15"
+              height="15"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.6"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden
+            >
+              {opt.icon}
+            </svg>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/design-system/src/index.ts
+++ b/design-system/src/index.ts
@@ -1,0 +1,40 @@
+// @e2a/ui — Loft design system public API.
+// Every component the library exposes is re-exported here. Consumers also
+// import the stylesheet once:  import "@e2a/ui/styles.css";
+
+export { Button } from "./Button/Button";
+export type { ButtonProps, ButtonVariant } from "./Button/Button";
+
+export { Chip } from "./Chip/Chip";
+export type { ChipProps, ChipTone } from "./Chip/Chip";
+
+export { Dot } from "./Dot/Dot";
+export type { DotProps, DotTone } from "./Dot/Dot";
+
+export { Eyebrow } from "./Eyebrow/Eyebrow";
+export type { EyebrowProps } from "./Eyebrow/Eyebrow";
+
+export { ThemeToggle } from "./ThemeToggle/ThemeToggle";
+export type { ThemeToggleProps, Theme } from "./ThemeToggle/ThemeToggle";
+
+export { InkConsole } from "./InkConsole/InkConsole";
+export type {
+  InkConsoleProps,
+  InkLine,
+  InkLineKind,
+} from "./InkConsole/InkConsole";
+
+export { Logo } from "./Logo/Logo";
+export type { LogoProps, LogoVariant, LogoTone } from "./Logo/Logo";
+
+export { Field } from "./Field/Field";
+export type { FieldProps } from "./Field/Field";
+
+export { Avatar } from "./Avatar/Avatar";
+export type { AvatarProps } from "./Avatar/Avatar";
+
+export { Collapsible } from "./Collapsible/Collapsible";
+export type { CollapsibleProps } from "./Collapsible/Collapsible";
+
+export { Card } from "./Card/Card";
+export type { CardProps } from "./Card/Card";

--- a/design-system/src/styles.css
+++ b/design-system/src/styles.css
@@ -1,0 +1,276 @@
+/*  Loft · component styles
+ *  ───────────────────────
+ *  The single stylesheet a consumer loads once (import "@e2a/ui/styles.css").
+ *  It pulls in the tokens, sets a minimal base, then defines one class per
+ *  component. Components reference these classes (no Tailwind dependency).
+ */
+
+@import "./tokens.css";
+
+/* ── Base ── */
+body {
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--f-ui);
+  font-size: var(--fs-body);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+/* ── Button ──────────────────────────────────────────────── */
+.loft-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+  font-family: var(--f-ui);
+}
+.loft-btn:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+.loft-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.loft-btn--primary {
+  font-size: 13px;
+  font-weight: 500;
+  padding: 8px 16px;
+  border-radius: var(--r-md);
+  background: var(--accent-fill);
+  color: var(--accent-fg);
+  border: none;
+}
+.loft-btn--primary:not(:disabled):hover {
+  background: var(--accent-fill-hov);
+}
+
+.loft-btn--ghost {
+  font-size: 12px;
+  font-weight: 500;
+  padding: 7px 12px;
+  border-radius: var(--r-md);
+  background: var(--bg-panel);
+  color: var(--fg);
+  border: 1px solid var(--border);
+}
+.loft-btn--ghost:not(:disabled):hover {
+  background: var(--bg-elev);
+}
+
+.loft-btn--mono {
+  gap: 5px;
+  font-family: var(--f-mono);
+  font-size: 11px;
+  font-weight: 500;
+  padding: 4px 8px;
+  border-radius: var(--r-sm);
+  background: var(--ink-elev);
+  color: var(--ink-fg-muted);
+  border: 1px solid var(--ink-border);
+}
+
+/* ── Chip ────────────────────────────────────────────────── */
+.loft-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  font-size: 11px;
+  font-weight: 600;
+  font-family: var(--f-ui);
+}
+.loft-chip--mono {
+  font-family: var(--f-mono);
+  letter-spacing: 0.02em;
+}
+.loft-chip--success { background: var(--success-bg); color: var(--success-strong); }
+.loft-chip--warn    { background: var(--warn-bg);    color: var(--warn-strong); }
+.loft-chip--info    { background: var(--info-bg);    color: var(--info-strong); }
+.loft-chip--accent  { background: var(--accent-soft); color: var(--accent-strong); }
+.loft-chip--danger  { background: var(--danger-bg);  color: var(--danger-strong); }
+.loft-chip--neutral { background: var(--bg-elev);    color: var(--fg-muted); }
+
+/* ── Dot ─────────────────────────────────────────────────── */
+.loft-dot {
+  display: inline-block;
+  width: 7px;
+  height: 7px;
+  border-radius: 9999px;
+}
+.loft-dot--success { background: var(--success); }
+.loft-dot--warn    { background: var(--warn); }
+.loft-dot--accent  { background: var(--accent); }
+.loft-dot--danger  { background: var(--danger); }
+.loft-dot--neutral { background: var(--fg-subtle); }
+
+/* ── Eyebrow ─────────────────────────────────────────────── */
+.loft-eyebrow {
+  font-family: var(--f-mono);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent-strong);
+}
+
+/* ── ThemeToggle (segmented radio control) ───────────────── */
+.loft-seg {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 2px;
+  border: 1px solid var(--border-sub);
+  border-radius: var(--r-md);
+}
+.loft-seg__opt {
+  flex: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px;
+  border: none;
+  background: transparent;
+  color: var(--fg-muted);
+  border-radius: calc(var(--r-md) - 2px);
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.loft-seg__opt[aria-checked="true"] {
+  color: var(--fg);
+  background: var(--bg-elev);
+  box-shadow: inset 0 0 0 1px var(--border);
+}
+.loft-seg__opt:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+/* ── Field (labeled text input) ──────────────────────────── */
+.loft-field {
+  display: block;
+}
+.loft-field__label {
+  display: block;
+  font-size: 13px;
+  font-weight: 500;
+  margin-bottom: 6px;
+  color: var(--fg);
+}
+.loft-field__input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  font-size: 14px;
+  font-family: var(--f-ui);
+  background: var(--bg-panel);
+  color: var(--fg);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.loft-field__input::placeholder {
+  color: var(--fg-subtle);
+}
+.loft-field__input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: var(--focus-ring);
+}
+.loft-field__hint {
+  margin-top: 4px;
+  font-size: 12px;
+  color: var(--fg-muted);
+}
+
+/* ── Card (surface container) ────────────────────────────── */
+.loft-card {
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  padding: var(--sp-4);
+}
+
+/* ── Collapsible (disclosure section) ────────────────────── */
+.loft-collapsible {
+  background: var(--bg-panel);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  overflow: hidden;
+}
+.loft-collapsible__trigger {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  text-align: left;
+  padding: 12px 18px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+.loft-collapsible__trigger--open {
+  border-bottom: 1px solid var(--border-sub);
+}
+.loft-collapsible__chevron {
+  display: inline-block;
+  color: var(--fg-subtle);
+  font-size: 10px;
+}
+.loft-collapsible__spacer {
+  flex: 1;
+}
+.loft-collapsible__meta {
+  font-family: var(--f-mono);
+  font-size: 11px;
+  color: var(--fg-subtle);
+}
+
+/* ── InkConsole (agent-native code console) ──────────────── */
+.loft-console {
+  overflow: hidden;
+  font-family: var(--f-mono);
+  background: var(--ink);
+  border: 1px solid var(--ink-border);
+  border-radius: var(--r-lg);
+}
+.loft-console__header {
+  display: flex;
+  align-items: center;
+  padding: 8px 14px;
+  font-size: 11px;
+  letter-spacing: 0.02em;
+  border-bottom: 1px solid var(--ink-border);
+  background: var(--ink-elev);
+  color: var(--ink-fg-muted);
+}
+.loft-console__title {
+  font-weight: 500;
+  color: var(--ink-fg);
+}
+.loft-console__lang {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--spectral);
+}
+.loft-console__lang--gap {
+  margin-left: 10px;
+}
+.loft-console__spacer {
+  flex: 1;
+}
+.loft-console__body {
+  padding: 14px 16px;
+  font-size: 12.5px;
+  line-height: 1.6;
+}
+.loft-console__line {
+  white-space: pre-wrap;
+}

--- a/design-system/src/tokens.css
+++ b/design-system/src/tokens.css
@@ -1,0 +1,134 @@
+/*  Loft · design tokens (colors, type, spacing, radii, shadows)
+ *  ───────────────────────────────────────────────────────────
+ *  Lifted from the e2a web app's globals.css so this package is the
+ *  single source of truth for the design language. Light values live on
+ *  :root; the `.dark` class (set on <html>) overrides them.
+ *
+ *  Fonts are referenced by family name (Geist, JetBrains Mono, Instrument
+ *  Serif). The library does not bundle the font files — consumers load them
+ *  (e.g. next/font, @fontsource, or a <link>). System fallbacks apply
+ *  otherwise, so components still render correctly without them.
+ */
+
+:root {
+  /* ── Surfaces — Drive shell (warm cream) ── */
+  --bg:           #FAF7F2;
+  --bg-panel:     #FFFFFF;
+  --bg-elev:      #F2ECE2;
+  --bg-sunken:    #ECE4D6;
+
+  /* ── Ink (agent-native) ── */
+  --ink:          #1A1714;
+  --ink-elev:     #23201C;
+  --ink-fg:       #E8E3D8;
+  --ink-fg-muted: #8C857A;
+  --ink-border:   #2E2A24;
+
+  /* ── Text ── */
+  --fg:           #1A1714;
+  --fg-strong:    #1A1714;
+  --fg-muted:     #6E665B;
+  --fg-subtle:    #9A9082;
+
+  /* ── Borders ── */
+  --border:        #E5DED3;
+  --border-sub:    #EFE9DD;
+  --border-strong: #D5CCBC;
+
+  /* ── Accent · Ember ── */
+  --accent:           #E26534;
+  --accent-soft:      #FBE9DF;
+  --accent-strong:    #A84218;
+  --accent-fill:      #B84A20;
+  --accent-fill-hov:  #9A3D1A;
+  --accent-fg:        #FFFFFF;
+
+  /* ── Agent-context on ink ── */
+  --spectral:  #6FDDE5;
+  --machine:   #B6F36E;
+
+  /* ── Semantic colors (decorative + -strong text pair) ── */
+  --info:    #2D6CFF;  --info-bg: #E4ECFF;   --info-strong: #0050D6;
+  --warn:    #C78400;  --warn-bg: #FFF1D1;   --warn-strong: #8F5F00;
+  --danger:  #CC2E2E;  --danger-bg: #FBE3E0; --danger-strong: #A82020;
+  --success: #0F7A4D;  --success-bg: #DFF3E8; --success-strong: #0B5C3A;
+
+  /* ── Avatar palette (deterministic by hash → 1..8) ── */
+  --av-1:#A84218; --av-2:#0F7A4D; --av-3:#0050D6; --av-4:#7A4FE0;
+  --av-5:#B43E8F; --av-6:#8F5F00; --av-7:#4A4A4A; --av-8:#1A1714;
+
+  /* ── Radii ── */
+  --r-sm: 4px;
+  --r-md: 6px;
+  --r-lg: 10px;
+  --r-xl: 16px;
+
+  /* ── Shadows ── */
+  --sh-1:   0 1px 0 rgba(26,23,20,.04), 0 1px 2px rgba(26,23,20,.04);
+  --sh-2:   0 2px 8px rgba(26,23,20,.06), 0 12px 32px rgba(26,23,20,.06);
+  --sh-pop: 0 24px 48px -16px rgba(26,23,20,.18), 0 4px 12px rgba(26,23,20,.06);
+
+  /* ── Focus ── */
+  --focus-ring: 0 0 0 3px rgba(226,101,52,0.30);
+
+  /* ── Type families ── */
+  --f-ui:        "Geist", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  --f-mono:      "JetBrains Mono", "SF Mono", ui-monospace, Menlo, monospace;
+  --f-editorial: "Instrument Serif", Georgia, serif;
+
+  /* ── Type scale (semantic) ── */
+  --fs-display: 36px;  --fw-display: 700;  --tracking-display: -0.02em;
+  --fs-h1: 24px;       --fw-h1: 700;       --tracking-h1: -0.01em;
+  --fs-h2: 18px;       --fw-h2: 600;
+  --fs-h3: 15px;       --fw-h3: 600;
+  --fs-body: 14px;
+  --fs-small: 12px;
+  --fs-mono: 13px;
+  --fs-id: 11px;
+  --fs-eyebrow: 11px;
+
+  /* ── Spacing grid (4px) ── */
+  --sp-1: 4px;  --sp-2: 8px;  --sp-3: 12px; --sp-4: 16px;
+  --sp-5: 24px; --sp-6: 32px; --sp-7: 48px; --sp-8: 64px;
+}
+
+/* ── Dark theme — applied via `.dark` on <html> ── */
+.dark {
+  --bg:           #13110E;
+  --bg-panel:     #1A1714;
+  --bg-elev:      #221F1B;
+  --bg-sunken:    #0D0B09;
+
+  --ink:          #0A0907;
+  --ink-elev:     #13110E;
+  --ink-fg:       #E8E3D8;
+  --ink-fg-muted: #8C857A;
+  --ink-border:   #221F1B;
+
+  --fg:        #ECE6D9;
+  --fg-strong: #ECE6D9;
+  --fg-muted:  #A8A092;
+  --fg-subtle: #6E665B;
+
+  --border:        #2E2A24;
+  --border-sub:    #25221E;
+  --border-strong: #3A352E;
+
+  --accent:          #F08055;
+  --accent-soft:     #3A1B0E;
+  --accent-strong:   #F5A07E;
+  --accent-fill:     #E26534;
+  --accent-fill-hov: #F08055;
+  --accent-fg:       #13110E;
+
+  --info: #79B4FF; --info-bg: #0F2046; --info-strong: #A6CCFF;
+  --warn: #E4A82F; --warn-bg: #2E1F00; --warn-strong: #F2C257;
+  --danger: #FF6B6B; --danger-bg: #2E1010; --danger-strong: #FF9292;
+  --success: #5AC68A; --success-bg: #0B2418; --success-strong: #8FE0B3;
+
+  --sh-1:   0 1px 0 rgba(0,0,0,.4), 0 1px 2px rgba(0,0,0,.3);
+  --sh-2:   0 2px 8px rgba(0,0,0,.4), 0 12px 32px rgba(0,0,0,.5);
+  --sh-pop: 0 24px 48px -16px rgba(0,0,0,.6), 0 4px 12px rgba(0,0,0,.4);
+
+  --focus-ring: 0 0 0 3px rgba(240,128,85,0.45);
+}

--- a/design-system/tsconfig.json
+++ b/design-system/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "declaration": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src"]
+}

--- a/design-system/tsup.config.ts
+++ b/design-system/tsup.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from "tsup";
+
+// Build the library to dist/ as ESM + type declarations.
+//  - entry: the single public barrel (src/index.ts)
+//  - the two CSS files are copied to dist/ verbatim so consumers (and
+//    claude.ai/design) can `@import "@e2a/ui/styles.css"`.
+//  - react/react-dom stay external — they're peer deps, not bundled.
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+  external: ["react", "react-dom", "react/jsx-runtime"],
+  // The bundle includes interactive components (InkConsole, Collapsible) that
+  // use React hooks. esbuild strips per-file "use client" directives when it
+  // bundles, so mark the whole entry a client module — this lets Next App
+  // Router Server Components import and render the library. (No-op for the
+  // design-sync esbuild bundle and Storybook, which ignore the directive.)
+  banner: { js: '"use client";' },
+  // Emit self-contained CSS: dist/styles.css with tokens inlined (no external
+  // @import), plus dist/tokens.css. See scripts/flatten-css.mjs for why.
+  onSuccess: "node scripts/flatten-css.mjs",
+});

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "workspaces": [
     "cli",
     "sdks/typescript",
-    "mcp"
+    "mcp",
+    "design-system"
   ]
 }


### PR DESCRIPTION
## What

Adds **`@e2a/ui`** — the "Loft" design language extracted into a standalone, buildable npm workspace package. This is also the source of truth synced to the team's claude.ai/design project.

- 11 components: `Button`, `Chip`, `Dot`, `Eyebrow`, `ThemeToggle`, `InkConsole`, `Logo`, `Field`, `Avatar`, `Collapsible`, `Card`.
- Styled from CSS-variable design tokens (`tokens.css` / `styles.css`), so they re-theme on `.dark` automatically. No Tailwind dependency.
- Storybook stories per component; `tsup` build to `dist/`.
- Registered as a 4th npm workspace; bundle marked `"use client"` for Next App Router.
- Carries `.design-sync/` state (config, conventions header, NOTES) for re-syncs.

## Scope: package only (deliberately)

This PR was originally also going to migrate `web/` onto `@e2a/ui`. An adversarial multi-agent review returned **NO-GO** on that combined version — not for the library code (which it judged sound), but because **`web` consuming `@e2a/ui` via `file:` against a gitignored, unbuilt `dist/`** breaks on every clean surface (web CI, jest, the web Docker build context). Those are real build-wiring problems that deserve their own focused PR.

So the work was **split**: this PR lands the package alone (mergeable, no consumers), and the `web/` migration moves to a follow-up where the build/CI/Docker/jest story is the explicit subject. The migration commit is preserved on branch **`web-migration-deferred`**.

## Review findings addressed here

- **L3** — `Logo` now passes `fontFamily` via `style` (not the SVG presentation attribute) so `var(--f-ui)` resolves.
- **L4** — `Avatar` guards initials on the trimmed name (no blank avatar for a whitespace-only name).
- **N1** — license set to `Apache-2.0` to match the repo and the Apache-sourced tokens.

## Deferred to the web-migration follow-up

- **B1/B2** — build `@e2a/ui` before `web` builds (CI + Docker context); `dist/` availability.
- **H1** — CJS/jest resolution of the ESM-only `exports`.
- **M1/L1** — add `--success-strong` to `globals.css`; note the success-`Chip` color change.
- Optional: per-component `"use client"` split so the pure atoms can stay RSC.

## Verification

`npm run typecheck` + `tsup` build pass; all 11 components graded `match` against their own Storybook via design-sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)