### PR TITLE
chore(plugin): tidy e2a plugin manifest + skill frontmatter

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,7 +6,8 @@
     "url": "https://e2a.dev"
   },
   "metadata": {
-    "description": "e2a plugins for Claude Code — authenticated email for AI agents"
+    "description": "e2a plugins for Claude Code — authenticated email for AI agents",
+    "version": "0.3.2"
   },
   "plugins": [
     {

--- a/plugins/e2a/.claude-plugin/plugin.json
+++ b/plugins/e2a/.claude-plugin/plugin.json
@@ -1,5 +1,6 @@
 {
   "name": "e2a",
+  "displayName": "e2a",
   "version": "0.3.2",
   "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 37 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
@@ -20,10 +21,5 @@
     "mcp",
     "oauth"
   ],
-  "mcpServers": {
-    "e2a": {
-      "type": "http",
-      "url": "https://api.e2a.dev/mcp"
-    }
-  }
+  "icon": "./assets/icon.svg"
 }

--- a/plugins/e2a/assets/icon.svg
+++ b/plugins/e2a/assets/icon.svg
@@ -1,0 +1,6 @@
+<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="e2a">
+  <rect width="128" height="128" rx="28" fill="#0B0B0F"/>
+  <rect x="24" y="38" width="80" height="56" rx="10" fill="none" stroke="#FFFFFF" stroke-width="6"/>
+  <path d="M27 44 L64 72 L101 44" fill="none" stroke="#FFFFFF" stroke-width="6" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="100" cy="40" r="14" fill="#4ADE80" stroke="#0B0B0F" stroke-width="5"/>
+</svg>

--- a/plugins/e2a/skills/e2a/SKILL.md
+++ b/plugins/e2a/skills/e2a/SKILL.md
@@ -1,5 +1,6 @@
 ---
-description: Mental model and common workflows for operating e2a (email for AI agents) well — send/receive email, the human-in-the-loop review hold, agent + domain management, attachments, threading. Read this before driving the e2a MCP tools. Pretraining assumes "human reading their inbox", but with e2a YOU are the agent and the inbox IS the agent. Covers send_message vs reply_to_message threading, the pending_review HITL status, multi-agent disambiguation, custom-domain DNS flow, the protection (screening + review) config, and other gotchas.
+name: e2a
+description: Use when operating e2a (email for AI agents) over its MCP tools — sending or receiving email, replying in-thread, handling the human-in-the-loop review hold (pending_review), managing agents and custom domains, or working with attachments. With e2a YOU are the agent and the inbox IS the agent (not a human reading their mail). Covers send_message vs reply_to_message threading, multi-agent disambiguation, the custom-domain DNS flow, the protection (screening + review) config, and common gotchas.
 version: 11
 ---
 


### PR DESCRIPTION
Hygiene pass on the e2a Claude Code plugin, informed by the [val-town/plugins](https://github.com/val-town/plugins) reference layout.

## Changes
- **Remove duplicate MCP server definition** — the inline `mcpServers` block in `plugin.json` was byte-identical to the standalone `.mcp.json`, which Claude Code already auto-loads. Keeping both risked registering the `e2a` server twice. `.mcp.json` is now the single source (matches val-town's pattern — their Claude `plugin.json` carries no `mcpServers`).
- **Skill frontmatter** — added explicit `name: e2a` and rewrote `description` into the "Use when…" trigger form Claude Code uses to decide skill loading.
- **Branding** — added `displayName` and an `icon` (`assets/icon.svg`) to `plugin.json`.
- **Version hygiene** — added `version` to `marketplace.json` metadata so it tracks the `plugin.json` semver (`0.3.2`).

## Not included
- The skill's internal `version: 11` content counter is left as-is (nothing reads it; it's a separate content-revision marker, not the plugin release semver).
- Deferred follow-ups (not in this PR): CI skill-frontmatter validation gate, multi-client manifests (Codex/Cursor), install README.

All JSON parses; the SVG is well-formed; skill frontmatter validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)