### PR TITLE
feat(plugin): multi-client manifests + CI validation gate + install docs

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,21 @@
+{
+  "name": "e2a",
+  "interface": {
+    "displayName": "e2a"
+  },
+  "plugins": [
+    {
+      "name": "e2a",
+      "source": {
+        "source": "local",
+        "path": "./plugins/e2a"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_USE"
+      },
+      "category": "Productivity",
+      "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log."
+    }
+  ]
+}

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "e2a",
+  "owner": {
+    "name": "Mnexa AI",
+    "url": "https://e2a.dev"
+  },
+  "metadata": {
+    "description": "e2a — authenticated email gateway for AI agents (MCP server + operate-well skill).",
+    "version": "0.3.2"
+  },
+  "plugins": [
+    {
+      "name": "e2a",
+      "source": "./plugins/e2a",
+      "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log."
+    }
+  ]
+}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -260,6 +260,22 @@ jobs:
           node-version: "22"
       - run: node scripts/check-sdk-version-sync.mjs
 
+  plugin:
+    # Guardrail: the agent plugin (plugins/e2a) + its Claude/Codex/Cursor
+    # marketplace manifests must parse, keep one version across every manifest,
+    # and ship skills whose SKILL.md frontmatter satisfies Claude Code's loader
+    # constraints. A malformed manifest/skill otherwise fails silently at
+    # install time with no build error.
+    name: Plugin manifests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - run: node scripts/validate-plugin.mjs
+
   mcp:
     name: MCP server tests
     runs-on: ubuntu-latest

--- a/plugins/e2a/.codex-plugin/plugin.json
+++ b/plugins/e2a/.codex-plugin/plugin.json
@@ -1,0 +1,34 @@
+{
+  "name": "e2a",
+  "displayName": "e2a",
+  "version": "0.3.2",
+  "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 37 MCP tools over hosted streamable HTTP with OAuth.",
+  "author": {
+    "name": "Mnexa AI"
+  },
+  "homepage": "https://e2a.dev",
+  "repository": "https://github.com/Mnexa-AI/e2a",
+  "license": "Apache-2.0",
+  "keywords": [
+    "email",
+    "smtp",
+    "agents",
+    "hitl",
+    "spf",
+    "dkim",
+    "inbox",
+    "mcp",
+    "oauth"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "e2a",
+    "shortDescription": "Authenticated email for AI agents",
+    "longDescription": "Bundles the hosted e2a MCP server and an operate-well skill so an agent can send and receive real email from per-agent inboxes — with SPF/DKIM verification, human-in-the-loop review holds, custom domains, attachments, and a replayable event log.",
+    "developerName": "Mnexa AI",
+    "category": "Productivity",
+    "websiteURL": "https://e2a.dev",
+    "composerIcon": "./assets/icon.svg"
+  }
+}

--- a/plugins/e2a/.cursor-plugin/plugin.json
+++ b/plugins/e2a/.cursor-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "e2a",
+  "displayName": "e2a",
+  "version": "0.3.2",
+  "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 37 MCP tools over hosted streamable HTTP with OAuth.",
+  "author": {
+    "name": "Mnexa AI",
+    "url": "https://e2a.dev"
+  },
+  "license": "Apache-2.0",
+  "keywords": [
+    "email",
+    "smtp",
+    "agents",
+    "hitl",
+    "spf",
+    "dkim",
+    "inbox",
+    "mcp",
+    "oauth",
+    "cursor"
+  ],
+  "logo": "assets/icon.svg"
+}

--- a/plugins/e2a/README.md
+++ b/plugins/e2a/README.md
@@ -1,0 +1,97 @@
+# e2a plugin
+
+Gives an AI coding agent a real, authenticated email inbox. Installing this
+plugin registers the hosted **e2a MCP server** (`https://api.e2a.dev/mcp`,
+Streamable HTTP + OAuth 2.1) and an **operate-well skill** so the agent can send
+and receive email, reply in-thread, hold outbound mail for human review (HITL),
+manage agents and custom domains, and work with attachments.
+
+On first use of an MCP tool the agent runs the OAuth flow in your browser — no
+API key to paste. (For headless/CI, an account API key works too; see
+[`clients/`](./clients).)
+
+## Install
+
+The same plugin ships native manifests for Claude Code, Codex, and Cursor.
+
+### Claude Code
+
+```
+claude plugin marketplace add Mnexa-AI/e2a
+claude plugin install e2a@e2a
+```
+
+### Codex
+
+```
+codex plugin marketplace add Mnexa-AI/e2a
+```
+
+Then launch `codex`, run `/plugins`, search for **e2a**, and install — it walks
+you through the OAuth path. (Codex desktop: **Plugins → Add more + →** paste
+`https://github.com/Mnexa-AI/e2a`.)
+
+### Cursor
+
+In Cursor, run `/add-plugin e2a`, or paste `https://github.com/Mnexa-AI/e2a`
+into the marketplace search in Cursor Settings and add it.
+
+### Other MCP clients (manual)
+
+Clients without native plugin support (Zed, Goose, Windsurf, Claude Desktop, raw
+`mcp.json`) can point straight at the hosted server. Ready-to-paste configs are
+in [`clients/`](./clients); the full per-client guide is at
+<https://e2a.dev/e2a.md>.
+
+## What's inside
+
+```
+plugins/e2a/
+├── .claude-plugin/plugin.json   # Claude Code manifest
+├── .codex-plugin/plugin.json    # Codex manifest (skills + mcpServers + interface)
+├── .cursor-plugin/plugin.json   # Cursor manifest
+├── .mcp.json                    # the hosted MCP server (single source of truth)
+├── assets/icon.svg
+├── skills/e2a/SKILL.md          # the "operate-well" skill (surfaces as /e2a)
+└── clients/                     # manual paste-in configs for non-plugin clients
+```
+
+The marketplace manifests that expose this plugin live at the repo root:
+`.claude-plugin/marketplace.json`, `.cursor-plugin/marketplace.json`, and
+`.agents/plugins/marketplace.json` (Codex).
+
+## Developing
+
+The skill is authored in `skills/<name>/SKILL.md` with YAML frontmatter:
+
+```markdown
+---
+name: e2a
+description: Use when operating e2a over its MCP tools — sending/receiving email, ...
+version: 11
+---
+
+...guide body...
+```
+
+- `name` (required) — must match the directory; lowercase letters, digits,
+  hyphens; ≤64 chars.
+- `description` (required) — write it as "Use when…"; this is how Claude Code
+  decides to load the skill. ≤1024 chars.
+
+`node scripts/validate-plugin.mjs` (run by the **Plugin manifests** CI job)
+validates every manifest parses, that the version is identical across all
+Claude/Codex/Cursor manifests, that marketplace `source` paths resolve, and that
+each `SKILL.md` satisfies Claude Code's frontmatter constraints. A change that
+wouldn't load fails CI.
+
+When bumping the plugin version, update `.claude-plugin/plugin.json` (the source
+of truth) **and** the other manifests + marketplace metadata to match — the
+validator fails on drift.
+
+## Reference
+
+- Connect / clients / first inbox: <https://e2a.dev/e2a.md>
+- Auth (OAuth 2.1 DCR + PKCE, API keys, scopes): <https://e2a.dev/auth.md>
+- Webhook + SDK code: <https://e2a.dev/sdk.md>
+- Docs index: <https://e2a.dev> (machine-readable: <https://e2a.dev/llms.txt>)

--- a/plugins/e2a/clients/README.md
+++ b/plugins/e2a/clients/README.md
@@ -16,5 +16,6 @@ stdio-only clients (Codex, Zed) wrap it with `npx -y mcp-remote …`.
 **Full per-client guide** — Zed, Goose, headless API-key auth, and more:
 https://e2a.dev/e2a.md (the "Connecting other MCP clients" section)
 
-**Claude Code** users don't need any of this — installing this plugin wires the
-MCP server in via `.claude-plugin/plugin.json`.
+**Claude Code / Codex / Cursor** users don't need any of this — install the
+plugin instead (it registers the MCP server via the plugin's `.mcp.json`). See
+[`../README.md`](../README.md) for the one-command install per client.

--- a/scripts/validate-plugin.mjs
+++ b/scripts/validate-plugin.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+// Guardrail for the e2a agent plugin (plugins/e2a) and its marketplace
+// manifests. A malformed manifest or skill silently fails to load in the
+// target client (Claude Code / Codex / Cursor) with no build error — this
+// script is the gate that turns those into a CI failure instead.
+//
+// It checks, dependency-free:
+//   1. Every marketplace.json + plugin.json parses and carries required fields.
+//   2. The plugin version is identical across all client manifests and the
+//      marketplace metadata (the .claude-plugin plugin.json is the source of
+//      truth) — so a bump can't land in one manifest and skew the others.
+//   3. Every marketplace `source` points at a real plugin directory.
+//   4. Each skill's SKILL.md frontmatter satisfies Claude Code's constraints:
+//      `name` present, matches its directory, lowercase/digits/hyphens, ≤64
+//      chars; `description` present, ≤1024 chars.
+//   5. Each manifest's referenced icon/logo file exists on disk.
+//
+// Run by the `plugin` job in .github/workflows/test.yml.
+
+import { readFileSync, existsSync, readdirSync, statSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const PLUGIN_DIR = join(ROOT, "plugins", "e2a");
+
+// Claude Code skill-name rules: lowercase letters, digits, hyphens; ≤64 chars.
+const NAME_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const MAX_NAME = 64;
+// Claude Code budgets name + description together; stay well under.
+const MAX_DESCRIPTION = 1024;
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---/;
+
+const errors = [];
+const fail = (msg) => errors.push(msg);
+
+const rel = (p) => p.slice(ROOT.length + 1);
+
+function readJSON(absPath) {
+  try {
+    return JSON.parse(readFileSync(absPath, "utf8"));
+  } catch (err) {
+    fail(`${rel(absPath)}: ${err.message}`);
+    return null;
+  }
+}
+
+// --- 1 + 2: plugin manifests + version consistency ---------------------------
+
+// The .claude-plugin manifest is the version source of truth.
+const claudeManifestPath = join(PLUGIN_DIR, ".claude-plugin", "plugin.json");
+const claudeManifest = readJSON(claudeManifestPath);
+const canonicalVersion = claudeManifest?.version;
+
+if (!canonicalVersion || typeof canonicalVersion !== "string") {
+  fail(`${rel(claudeManifestPath)}: missing string "version"`);
+}
+
+// Every client plugin manifest: { file, dottedVersionKey, requiredFields }.
+const PLUGIN_MANIFESTS = [
+  { file: claudeManifestPath, versionKey: "version" },
+  { file: join(PLUGIN_DIR, ".codex-plugin", "plugin.json"), versionKey: "version" },
+  { file: join(PLUGIN_DIR, ".cursor-plugin", "plugin.json"), versionKey: "version" },
+];
+
+// Marketplace manifests across clients: { file, source-relative-to-repo, version? }.
+const MARKETPLACE_MANIFESTS = [
+  { file: join(ROOT, ".claude-plugin", "marketplace.json"), versionKey: "metadata.version", versionOptional: true },
+  { file: join(ROOT, ".cursor-plugin", "marketplace.json"), versionKey: "metadata.version" },
+  { file: join(ROOT, ".agents", "plugins", "marketplace.json"), versionKey: null },
+];
+
+const getAt = (obj, key) => key.split(".").reduce((o, k) => (o == null ? o : o[k]), obj);
+
+for (const { file, versionKey } of PLUGIN_MANIFESTS) {
+  const m = readJSON(file);
+  if (!m) continue;
+  for (const field of ["name", "description", "version"]) {
+    if (!m[field]) fail(`${rel(file)}: missing required field "${field}"`);
+  }
+  const v = getAt(m, versionKey);
+  if (canonicalVersion && v !== canonicalVersion) {
+    fail(`${rel(file)}: version "${v}" != canonical "${canonicalVersion}" (.claude-plugin is source of truth)`);
+  }
+  // Icon/logo references must resolve.
+  for (const iconKey of ["icon", "logo"]) {
+    const ref = m[iconKey] ?? m.interface?.composerIcon;
+    if (ref) {
+      const abs = join(dirname(file), "..", ref.replace(/^\.\//, ""));
+      // manifests live in plugins/e2a/<client-dir>/; icon path is plugin-root-relative.
+      const iconAbs = join(PLUGIN_DIR, ref.replace(/^\.\//, ""));
+      if (!existsSync(iconAbs) && !existsSync(abs)) {
+        fail(`${rel(file)}: ${iconKey} "${ref}" not found`);
+      }
+    }
+  }
+}
+
+// --- 3: marketplace manifests parse, sources resolve, versions consistent ----
+
+for (const { file, versionKey, versionOptional } of MARKETPLACE_MANIFESTS) {
+  if (!existsSync(file)) {
+    fail(`missing marketplace manifest: ${rel(file)}`);
+    continue;
+  }
+  const m = readJSON(file);
+  if (!m) continue;
+  if (!Array.isArray(m.plugins) || m.plugins.length === 0) {
+    fail(`${rel(file)}: "plugins" must be a non-empty array`);
+    continue;
+  }
+  for (const p of m.plugins) {
+    // source is either a string path or { source, path }.
+    const srcPath = typeof p.source === "string" ? p.source : p.source?.path;
+    if (!srcPath) {
+      fail(`${rel(file)}: plugin "${p.name}" has no source path`);
+      continue;
+    }
+    const abs = join(ROOT, srcPath.replace(/^\.\//, ""));
+    if (!existsSync(abs) || !statSync(abs).isDirectory()) {
+      fail(`${rel(file)}: plugin "${p.name}" source "${srcPath}" is not a directory`);
+    }
+  }
+  if (versionKey) {
+    const v = getAt(m, versionKey);
+    if (versionOptional && v === undefined) continue;
+    if (canonicalVersion && v !== canonicalVersion) {
+      fail(`${rel(file)}: ${versionKey} "${v}" != canonical "${canonicalVersion}"`);
+    }
+  }
+}
+
+// --- 4: SKILL.md frontmatter -------------------------------------------------
+
+const skillsDir = join(PLUGIN_DIR, "skills");
+const skillDirs = existsSync(skillsDir)
+  ? readdirSync(skillsDir, { withFileTypes: true }).filter((d) => d.isDirectory()).map((d) => d.name)
+  : [];
+
+if (skillDirs.length === 0) fail(`no skills found under ${rel(skillsDir)}`);
+
+for (const dir of skillDirs) {
+  const file = join(skillsDir, dir, "SKILL.md");
+  if (!existsSync(file)) {
+    fail(`${dir}: missing SKILL.md`);
+    continue;
+  }
+  const match = readFileSync(file, "utf8").match(FRONTMATTER_RE);
+  if (!match) {
+    fail(`${dir}: missing YAML frontmatter (--- ... ---)`);
+    continue;
+  }
+  // Minimal top-level "key: value" parse — sufficient for name/description.
+  const fm = {};
+  for (const line of match[1].split(/\r?\n/)) {
+    const m = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/);
+    if (m) fm[m[1]] = m[2].trim();
+  }
+
+  const { name, description } = fm;
+  if (!name) {
+    fail(`${dir}: SKILL.md frontmatter missing "name"`);
+  } else {
+    if (name !== dir) fail(`${dir}: skill name "${name}" must match its directory`);
+    if (!NAME_RE.test(name)) fail(`${dir}: name "${name}" must be lowercase letters, digits, and hyphens`);
+    if (name.length > MAX_NAME) fail(`${dir}: name "${name}" exceeds ${MAX_NAME} chars`);
+  }
+  if (!description) {
+    fail(`${dir}: SKILL.md frontmatter missing "description"`);
+  } else if (description.length > MAX_DESCRIPTION) {
+    fail(`${dir}: description is ${description.length} chars (max ${MAX_DESCRIPTION})`);
+  }
+}
+
+// --- 5: standalone .mcp.json -------------------------------------------------
+
+const mcpPath = join(PLUGIN_DIR, ".mcp.json");
+const mcp = readJSON(mcpPath);
+if (mcp && (!mcp.mcpServers || Object.keys(mcp.mcpServers).length === 0)) {
+  fail(`${rel(mcpPath)}: "mcpServers" must define at least one server`);
+}
+
+// --- report ------------------------------------------------------------------
+
+if (errors.length > 0) {
+  console.error(`\n✗ Plugin validation failed:\n${errors.map((e) => `  - ${e}`).join("\n")}\n`);
+  process.exit(1);
+}
+console.log(`✓ Plugin valid: ${skillDirs.length} skill(s), version ${canonicalVersion}, manifests in sync across Claude/Codex/Cursor`);


### PR DESCRIPTION
Follow-up to #335. Extends the e2a agent plugin beyond Claude Code, following the [val-town/plugins](https://github.com/val-town/plugins) reference layout. Covers items 6–8 from the plugin review.

## 7 — Multi-client install
- `plugins/e2a/.codex-plugin/plugin.json` + `.agents/plugins/marketplace.json` (Codex native marketplace).
- `plugins/e2a/.cursor-plugin/plugin.json` + `.cursor-plugin/marketplace.json` (Cursor).
- Both reuse the existing skill and the hosted MCP server via `./.mcp.json`, promoting the per-client snippets under `clients/` into real one-command installs.

## 6 — CI validation gate
- `scripts/validate-plugin.mjs` (dependency-free, mirrors `check-sdk-version-sync.mjs`): every manifest parses, the version is identical across all Claude/Codex/Cursor manifests + marketplace metadata, marketplace `source` paths resolve, icons exist, and each `SKILL.md` frontmatter satisfies Claude Code's loader constraints (name matches dir, lowercase/hyphen ≤64, description ≤1024).
- Wired in as the **Plugin manifests** job in `test.yml`. Verified locally: passes clean, and fails on an injected version drift.

## 8 — Install docs
- `plugins/e2a/README.md`: per-client install commands, layout, and the authoring + version-bump contract the validator enforces.
- `clients/README.md`: fixed the stale "wired via plugin.json" note (MCP server is now sourced solely from `.mcp.json` after #335) and pointed at the new guide.

## Deferred
- **9** — submitting to the official Claude marketplace (`@claude-plugins-official`) is an external submission to Anthropic, not a code change. Noted for you to pursue if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)