### PR TITLE
feat(sdk): add request timeout config to TS + Python E2AClient

### DIFF
--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -107,10 +107,12 @@ a `/v1` operation; per-agent methods take the agent `address` first.
 
 `api_key` falls back to `E2A_API_KEY`; `base_url` to `E2A_BASE_URL` then
 `https://api.e2a.dev`. `timeout_ms` is the per-request timeout (default 30s); a
-timed-out request retries like any other connection failure. Pass `timeout_ms=0`
-or `None` to fall back to the transport default. Use it as an async context
-manager (or call `await client.aclose()`) to close the underlying HTTP
-connections.
+timed-out request retries like any other connection failure. Passing
+`timeout_ms=0` or `None` removes the SDK's override and falls back to the HTTP
+transport's built-in **300s** ceiling — it does **not** make requests unbounded
+(this differs from the TypeScript SDK, where `timeoutMs: 0` is fully unbounded).
+Use it as an async context manager (or call `await client.aclose()`) to close
+the underlying HTTP connections.
 
 ### Errors
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -103,11 +103,14 @@ During a rotation you can pass a list of secrets — accepted if any matches:
 `client.account.suppressions`), plus `await client.info()`. Each method maps to
 a `/v1` operation; per-agent methods take the agent `address` first.
 
-### `E2AClient(api_key=None, *, base_url=None, max_retries=2, max_elapsed_ms=None)`
+### `E2AClient(api_key=None, *, base_url=None, max_retries=2, max_elapsed_ms=None, timeout_ms=30000)`
 
 `api_key` falls back to `E2A_API_KEY`; `base_url` to `E2A_BASE_URL` then
-`https://api.e2a.dev`. Use it as an async context manager (or call
-`await client.aclose()`) to close the underlying HTTP connections.
+`https://api.e2a.dev`. `timeout_ms` is the per-request timeout (default 30s); a
+timed-out request retries like any other connection failure. Pass `timeout_ms=0`
+or `None` to fall back to the transport default. Use it as an async context
+manager (or call `await client.aclose()`) to close the underlying HTTP
+connections.
 
 ### Errors
 

--- a/sdks/python/src/e2a/v1/client.py
+++ b/sdks/python/src/e2a/v1/client.py
@@ -123,6 +123,7 @@ class E2AClient:
         base_url: Optional[str] = None,
         max_retries: int = 2,
         max_elapsed_ms: Optional[float] = None,
+        timeout_ms: Optional[float] = 30_000.0,
         _retry_config: Optional[RetryConfig] = None,
     ) -> None:
         key = api_key or _env("E2A_API_KEY")
@@ -141,6 +142,24 @@ class E2AClient:
 
         config = Configuration(host=self._base_url, access_token=key)
         self._api_client = ApiClient(config)
+
+        # Per-request timeout (default 30s). The generated httpx transport applies
+        # `_request_timeout or 300s` per call; we inject our default when the caller
+        # didn't pass one, so every request is bounded without threading a timeout
+        # through each resource method. A timeout raises httpx.TimeoutException (a
+        # TransportError), which the retry layer treats as a retryable connection
+        # failure. Pass timeout_ms=None or 0 to fall back to the transport default.
+        self._timeout_s = (timeout_ms / 1000.0) if timeout_ms and timeout_ms > 0 else None
+        if self._timeout_s is not None:
+            _rest = self._api_client.rest_client
+            _orig_request = _rest.request
+
+            async def _request_with_default_timeout(*args: Any, **kwargs: Any) -> Any:
+                if kwargs.get("_request_timeout") is None:
+                    kwargs["_request_timeout"] = self._timeout_s
+                return await _orig_request(*args, **kwargs)
+
+            _rest.request = _request_with_default_timeout  # type: ignore[method-assign]
 
         self.agents = AgentsResource(AgentsApi(self._api_client), self)
         self.messages = MessagesResource(MessagesApi(self._api_client), self)

--- a/sdks/python/src/e2a/v1/client.py
+++ b/sdks/python/src/e2a/v1/client.py
@@ -154,6 +154,13 @@ class E2AClient:
             _rest = self._api_client.rest_client
             _orig_request = _rest.request
 
+            # Assumes the generated ApiClient calls rest_client.request(...) with
+            # `_request_timeout` as a KEYWORD (it does — see generated
+            # api_client.py). If a future openapi-generator bump passes it
+            # positionally, `.get()` would miss it and we'd re-inject as a kwarg
+            # → TypeError; `make generate-sdk-check` (CI) gates that drift, and a
+            # regen would surface it here. Keep this in sync if that call shape
+            # changes.
             async def _request_with_default_timeout(*args: Any, **kwargs: Any) -> Any:
                 if kwargs.get("_request_timeout") is None:
                     kwargs["_request_timeout"] = self._timeout_s

--- a/sdks/python/tests/test_v1_client.py
+++ b/sdks/python/tests/test_v1_client.py
@@ -5,12 +5,14 @@ stack: namespaced resource -> generated *Api -> bearer auth -> retry layer ->
 httpx -> envelope unwrap -> typed-error mapping.
 """
 
+import httpx
 import pytest
 
 from e2a.v1._retry import RetryConfig
 from e2a.v1.client import E2AClient
 from e2a.v1.errors import (
     E2AConflictError,
+    E2AConnectionError,
     E2AError,
     E2ANotFoundError,
     E2APermissionError,
@@ -126,6 +128,61 @@ def test_resources_exposed():
     for name in ("agents", "messages", "conversations", "domains", "events", "webhooks", "account", "reviews"):
         assert getattr(c, name) is not None
     assert c.account.suppressions is not None
+
+
+@pytest.mark.parametrize(
+    "timeout_ms, expected_s",
+    [
+        (None, 30.0),        # default
+        (30_000.0, 30.0),    # explicit default
+        (5_000.0, 5.0),      # custom
+        (0, None),           # disabled → transport default applies
+    ],
+)
+def test_timeout_ms_to_seconds(timeout_ms, expected_s):
+    kwargs = {} if timeout_ms is None else {"timeout_ms": timeout_ms}
+    c = E2AClient(api_key="e2a_test", base_url=BASE, **kwargs)
+    assert c._timeout_s == expected_s
+
+
+@pytest.mark.anyio
+async def test_timeout_injected_into_transport(monkeypatch):
+    # The real client wraps rest_client.request to inject _request_timeout when the
+    # caller passes none. Patch the generated transport BEFORE construction so the
+    # wrapper closes over our spy, then assert the default seconds value lands.
+    from e2a.v1.generated import rest as _rest_mod
+
+    seen = {}
+
+    async def spy(self, method, url, headers=None, body=None, post_params=None, _request_timeout=None):
+        seen["timeout"] = _request_timeout
+        raise httpx.ConnectError("boom")  # short-circuit; we only inspect the arg
+
+    monkeypatch.setattr(_rest_mod.RESTClientObject, "request", spy)
+    c = E2AClient(api_key="e2a_test", base_url=BASE, timeout_ms=5_000.0)
+    with pytest.raises(httpx.ConnectError):
+        await c._api_client.rest_client.request("GET", "http://test.local/x")
+    assert seen["timeout"] == 5.0
+
+
+@pytest.mark.anyio
+async def test_request_timeout_surfaces_as_connection_error(httpx_mock):
+    # A transport timeout (httpx.TimeoutException family) must surface as a typed,
+    # retryable connection error — same path as any connection-level failure.
+    httpx_mock.add_exception(httpx.ReadTimeout("read timed out"))
+
+    async def no_sleep(_s):
+        return None
+
+    c = E2AClient(
+        api_key="e2a_test",
+        base_url=BASE,
+        timeout_ms=50.0,
+        _retry_config=RetryConfig(max_retries=0, sleep=no_sleep),
+    )
+    async with c:
+        with pytest.raises(E2AConnectionError):
+            await c.agents.get("bot@test.dev")
 
 
 # ── auth + agents ───────────────────────────────────────────────────

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -124,6 +124,7 @@ argument.
 | `baseUrl`      | `string` | `https://api.e2a.dev`   | API base URL (override for self-host)    |
 | `maxRetries`   | `number` | `2`                     | Retries on 429/5xx/connection            |
 | `maxElapsedMs` | `number` | —                       | Optional total deadline across attempts  |
+| `timeoutMs`    | `number` | `30000`                 | Per-attempt request timeout; `0` disables |
 
 ### Errors
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -124,7 +124,14 @@ argument.
 | `baseUrl`      | `string` | `https://api.e2a.dev`   | API base URL (override for self-host)    |
 | `maxRetries`   | `number` | `2`                     | Retries on 429/5xx/connection            |
 | `maxElapsedMs` | `number` | —                       | Optional total deadline across attempts  |
-| `timeoutMs`    | `number` | `30000`                 | Per-attempt request timeout; `0` disables |
+| `timeoutMs`    | `number` | `30000`                 | Per-attempt request timeout (see below)  |
+
+`timeoutMs` bounds each individual attempt; a timed-out attempt is treated as a
+retryable connection failure, so it composes with `maxRetries`/`maxElapsedMs`.
+Setting `timeoutMs: 0` removes the SDK timeout entirely — a request is then
+bounded only by the runtime's own `fetch` default (effectively unbounded in
+Node). Note this differs from the Python SDK, where `timeout_ms=0` falls back to
+the HTTP transport's built-in 300s ceiling rather than going unbounded.
 
 ### Errors
 

--- a/sdks/typescript/src/v1/client.ts
+++ b/sdks/typescript/src/v1/client.ts
@@ -80,6 +80,10 @@ export interface E2AClientOptions {
   maxRetries?: RetryOptions["maxRetries"];
   /** Optional total deadline across attempts (ms). */
   maxElapsedMs?: RetryOptions["maxElapsedMs"];
+  /** Per-attempt request timeout in ms. Default 30000; pass 0 to disable. A
+   *  timed-out attempt is a retryable connection failure, so it composes with
+   *  maxRetries/maxElapsedMs. */
+  timeoutMs?: RetryOptions["timeoutMs"];
 }
 
 /** Per-call options for unsafe writes. */
@@ -137,6 +141,8 @@ export class E2AClient {
     const httpApi = new RetryHttpLibrary(new IsomorphicFetchHttpLibrary(), {
       maxRetries: opts.maxRetries,
       maxElapsedMs: opts.maxElapsedMs,
+      // `?? 30000` defaults the timeout; an explicit 0 disables it (0 is not nullish).
+      timeoutMs: opts.timeoutMs ?? 30000,
     });
     const config = createConfiguration({
       baseServer: new ServerConfiguration(baseUrl, {}),

--- a/sdks/typescript/src/v1/retry.ts
+++ b/sdks/typescript/src/v1/retry.ts
@@ -25,6 +25,10 @@ export interface RetryOptions {
   /** Optional total deadline across all attempts (incl. backoff), in ms. When
    *  the next sleep would exceed it, stop and return/throw the last result. */
   maxElapsedMs?: number;
+  /** Per-attempt request timeout in ms. A timed-out attempt aborts the in-flight
+   *  fetch and is surfaced as a (retryable) connection failure, so it composes
+   *  with maxRetries/maxElapsedMs. Undefined or <=0 disables. */
+  timeoutMs?: number;
   /** Injectable for tests. */
   sleep?: (ms: number) => Promise<void>;
   random?: () => number;
@@ -76,13 +80,28 @@ export class RetryHttpLibrary implements HttpLibrary {
     for (;;) {
       this.throwIfAborted(signal);
 
+      // Bound this attempt: a signal that aborts on the caller's signal OR after
+      // timeoutMs. Set on the shared RequestContext so the generated fetch layer
+      // honors it.
+      const att = this.attemptSignal(signal, this.opts.timeoutMs);
+      if (att.signal) request.setSignal(att.signal);
+
       let resp: ResponseContext | undefined;
       let connErr: unknown;
       try {
         resp = await this.inner.send(request).toPromise();
       } catch (e) {
-        connErr = e; // connection-level failure (no HTTP response)
+        // A timeout aborts the fetch; surface it as a connection-level failure
+        // (retried like any other for retry-safe requests) with a clear message
+        // rather than the opaque AbortError.
+        connErr = att.timedOut() ? new Error(`request timed out after ${this.opts.timeoutMs}ms`) : e;
+      } finally {
+        att.cleanup();
       }
+
+      // A genuine caller abort (not our timeout) stops immediately — don't
+      // reclassify it as a retryable connection error below.
+      this.throwIfAborted(signal);
 
       const isConn = resp === undefined;
       const retryable = retrySafe && (isConn || isRetryableStatus(resp!.httpStatusCode));
@@ -175,6 +194,39 @@ export class RetryHttpLibrary implements HttpLibrary {
     }
     if (!present) return; // not a server-keyed op (no stub) — never seen here when gated
     request.setHeaderParam(IDEMPOTENCY_HEADER, (this.opts.genIdempotencyKey ?? defaultUuid)());
+  }
+
+  // Per-attempt timeout. Returns a signal that aborts on the caller's signal OR
+  // after timeoutMs, a cleanup to clear the timer/listener, and a flag that
+  // distinguishes a timeout from a caller abort (so the caller's abort still
+  // propagates, while a timeout is retried). With no timeout the caller's signal
+  // passes straight through.
+  private attemptSignal(
+    caller: AbortSignal | undefined,
+    timeoutMs: number | undefined,
+  ): { signal: AbortSignal | undefined; cleanup: () => void; timedOut: () => boolean } {
+    if (!timeoutMs || timeoutMs <= 0) {
+      return { signal: caller, cleanup: () => {}, timedOut: () => false };
+    }
+    const ctrl = new AbortController();
+    let didTimeout = false;
+    const onCallerAbort = () => ctrl.abort(caller?.reason);
+    if (caller) {
+      if (caller.aborted) ctrl.abort(caller.reason);
+      else caller.addEventListener("abort", onCallerAbort, { once: true });
+    }
+    const timer = setTimeout(() => {
+      didTimeout = true;
+      ctrl.abort(new DOMException(`Request timed out after ${timeoutMs}ms`, "TimeoutError"));
+    }, timeoutMs);
+    return {
+      signal: ctrl.signal,
+      cleanup: () => {
+        clearTimeout(timer);
+        caller?.removeEventListener("abort", onCallerAbort);
+      },
+      timedOut: () => didTimeout,
+    };
   }
 
   private throwIfAborted(signal: AbortSignal | undefined): void {

--- a/sdks/typescript/test/v1/client.test.ts
+++ b/sdks/typescript/test/v1/client.test.ts
@@ -88,6 +88,22 @@ describe("E2AClient", () => {
     expect(() => new E2AClient({ baseUrl: BASE })).not.toThrow();
   });
 
+  it("maps a per-request timeout to E2AConnectionError", async () => {
+    // fetch hangs until its abort signal fires — i.e. only the per-attempt
+    // timeout can end it. Exercises the full client → retry → fetch → typed-error
+    // path (Python has the equivalent test_request_timeout_surfaces_as_connection_error).
+    globalThis.fetch = vi.fn(
+      (_url: string, init?: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          const s = init?.signal;
+          if (s?.aborted) return reject(s.reason);
+          s?.addEventListener("abort", () => reject(s.reason), { once: true });
+        }),
+    ) as unknown as typeof fetch;
+    const c = new E2AClient({ apiKey: "e2a_test", baseUrl: BASE, timeoutMs: 5, maxRetries: 0 });
+    await expect(c.agents.get("bot@test.dev")).rejects.toBeInstanceOf(E2AConnectionError);
+  });
+
   it("exposes the namespaced resources", () => {
     expect(client.agents).toBeDefined();
     expect(client.messages).toBeDefined();

--- a/sdks/typescript/test/v1/retry.test.ts
+++ b/sdks/typescript/test/v1/retry.test.ts
@@ -89,6 +89,58 @@ describe("RetryHttpLibrary retry behavior", () => {
   });
 });
 
+// A transport that hangs until the request's signal aborts, then rejects with
+// the abort reason — mirroring how fetch behaves under an AbortSignal. Lets the
+// per-attempt timeout fire against a request that never resolves on its own.
+class HangingHttp implements HttpLibrary {
+  public attempts = 0;
+  send(req: RequestContext): Observable<ResponseContext> {
+    this.attempts += 1;
+    const signal = req.getSignal?.();
+    return from(
+      new Promise<ResponseContext>((_resolve, reject) => {
+        if (signal?.aborted) return reject(signal.reason);
+        signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+      }),
+    );
+  }
+}
+
+describe("RetryHttpLibrary timeout", () => {
+  it("times out a hung retry-safe request, retries, then throws a timeout error", async () => {
+    const fake = new HangingHttp();
+    const retry = new RetryHttpLibrary(fake, { sleep: noSleep, maxRetries: 1, timeoutMs: 5 });
+    await expect(retry.send(get()).toPromise()).rejects.toThrow(/timed out/);
+    expect(fake.attempts).toBe(2); // 1 + 1 retry, each timed out
+  });
+
+  it("does NOT retry a hung bare POST on timeout (throws after one attempt)", async () => {
+    const fake = new HangingHttp();
+    const retry = new RetryHttpLibrary(fake, { sleep: noSleep, maxRetries: 2, timeoutMs: 5 });
+    await expect(retry.send(barePost()).toPromise()).rejects.toThrow(/timed out/);
+    expect(fake.attempts).toBe(1); // non-idempotent POST: not retried
+  });
+
+  it("does not time out a fast response", async () => {
+    const fake = new FakeHttp([{ status: 200 }]);
+    const retry = new RetryHttpLibrary(fake, { sleep: noSleep, timeoutMs: 1000 });
+    const resp = await retry.send(get()).toPromise();
+    expect(resp.httpStatusCode).toBe(200);
+  });
+
+  it("propagates a caller abort as an abort (not a timeout) and stops", async () => {
+    const fake = new HangingHttp();
+    const ctrl = new AbortController();
+    const req = get();
+    req.setSignal(ctrl.signal);
+    const retry = new RetryHttpLibrary(fake, { sleep: noSleep, maxRetries: 3, timeoutMs: 10000 });
+    const p = retry.send(req).toPromise();
+    ctrl.abort(new Error("caller cancelled"));
+    await expect(p).rejects.toThrow(/caller cancelled/);
+    expect(fake.attempts).toBe(1); // aborted, not retried
+  });
+});
+
 describe("RetryHttpLibrary idempotency", () => {
   it("mints an Idempotency-Key ONCE and reuses it across retries", async () => {
     let n = 0;

--- a/sdks/typescript/test/v1/retry.test.ts
+++ b/sdks/typescript/test/v1/retry.test.ts
@@ -139,6 +139,19 @@ describe("RetryHttpLibrary timeout", () => {
     await expect(p).rejects.toThrow(/caller cancelled/);
     expect(fake.attempts).toBe(1); // aborted, not retried
   });
+
+  it("timeoutMs:0 installs no timeout — request is bounded only by the caller signal", async () => {
+    const fake = new HangingHttp();
+    const ctrl = new AbortController();
+    const req = get();
+    req.setSignal(ctrl.signal);
+    const retry = new RetryHttpLibrary(fake, { sleep: noSleep, maxRetries: 3, timeoutMs: 0 });
+    const p = retry.send(req).toPromise();
+    // With no SDK timeout the hung request never self-aborts; only the caller ends it.
+    ctrl.abort(new Error("only the caller stops it"));
+    await expect(p).rejects.toThrow(/only the caller stops it/);
+    expect(fake.attempts).toBe(1);
+  });
 });
 
 describe("RetryHttpLibrary idempotency", () => {


### PR DESCRIPTION
Adds a configurable per-request timeout to both SDK clients. Until now `E2AClient` exposed `maxRetries` / `maxElapsedMs` but **no per-request timeout** — a single hung connection could hang indefinitely (TS `fetch` has no default; Python relied on the generated 300s default). New knob defaults to **30s**, kept at parity across both SDKs.

## TypeScript — `timeoutMs` (default `30000`, `0` disables)
- `RetryHttpLibrary` bounds each attempt with an `AbortSignal` that fires on the caller's signal **or** after `timeoutMs`. A timeout is surfaced as a retryable connection failure, so it composes with `maxRetries` / `maxElapsedMs`. A genuine caller abort still propagates and stops (not reclassified as a timeout).

## Python — `timeout_ms` (default `30000`, `0`/`None` → transport default)
- Injects a default `_request_timeout` into the generated httpx `rest_client.request`, so every call is bounded without threading a timeout through each resource method. httpx raises `TimeoutException` (a `TransportError`), which the retry layer already treats as a retryable connection failure.

## Scope / safety
- **Hand-written layer only** — `client.ts`/`retry.ts` and `client.py`. No generated code touched, so `make generate-sdk-check` is unaffected.
- Tests added both sides: timeout-then-retry, no-retry on a bare POST, caller-abort vs timeout (TS), config math + transport injection + end-to-end `E2AConnectionError` (Python). Full suites green: **TS 107**, **Python 170**.
- READMEs updated (TS options table; Python signature + note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)