### PR TITLE
docs(mcp): default `claude mcp add` to user (global) scope

### DIFF
--- a/plugins/e2a/.mcp.json
+++ b/plugins/e2a/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "e2a": {
-      "type": "http",
-      "url": "https://api.e2a.dev/mcp"
-    }
-  }
-}

--- a/web/public/e2a.md
+++ b/web/public/e2a.md
@@ -25,9 +25,11 @@ Pick the row that fits you:
 - **You're an agent with a terminal** (Claude Code, Cursor, Goose, Windsurf,
   Zed) → connect over MCP in one command:
   ```
-  claude mcp add --transport http e2a https://api.e2a.dev/mcp
+  claude mcp add --transport http --scope user e2a https://api.e2a.dev/mcp
   ```
-  A browser opens for OAuth sign-in — no API key to paste.
+  `--scope user` installs e2a globally so it's available in every project (drop
+  it to scope the server to just the current directory). A browser opens for
+  OAuth sign-in — no API key to paste.
 - **You're an agent without a terminal** (Claude Desktop, a chat box) → ask your
   host to add the MCP connector `https://api.e2a.dev/mcp` and authorize in the
   browser, then come back here.

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -21,7 +21,7 @@
 ## MCP & plugin
 
 - [Claude Code plugin + skill](https://github.com/Mnexa-AI/e2a/tree/main/plugins/e2a): The `e2a` plugin bundles the hosted MCP server config and the `e2a` skill (mental model, gotchas, worked examples).
-- MCP endpoint: `https://api.e2a.dev/mcp` (Streamable HTTP, OAuth 2.1). Add with `claude mcp add --transport http e2a https://api.e2a.dev/mcp`. Per-client config (Cursor, VS Code, Codex, …) is in [e2a.md](https://e2a.dev/e2a.md).
+- MCP endpoint: `https://api.e2a.dev/mcp` (Streamable HTTP, OAuth 2.1). Add with `claude mcp add --transport http --scope user e2a https://api.e2a.dev/mcp` (`--scope user` installs it globally; drop it for current-directory only). Per-client config (Cursor, VS Code, Codex, …) is in [e2a.md](https://e2a.dev/e2a.md).
 
 ## Source
 


### PR DESCRIPTION
## What

- **Docs default to global scope.** The hosted-MCP quick-start in `web/public/e2a.md` and `web/public/llms.txt` now passes `--scope user`, so `claude mcp add` installs the e2a server **globally** (available in every project) instead of the default current-directory-only `local` scope. Both note that dropping the flag scopes it to the current directory.
- **Drop duplicate plugin MCP config.** `plugins/e2a/.mcp.json` declared the same `e2a` server already declared inline in `.claude-plugin/plugin.json`. A root `.mcp.json` is auto-discovered *and* the inline manifest is read, so both were loaded and merged — a drift risk for one server name. Kept the inline `plugin.json` declaration as the single source of truth (no behavior change today; the two were identical).

## Why

A user installing e2a via the documented one-liner was silently getting a directory-scoped server, so the MCP tools vanished when they `cd`'d into another project. Defaulting the docs to `--scope user` matches the expected "install once, available everywhere" behavior.

## Notes

- No plugin version bump (no functional change to the plugin).
- Plugins themselves have no scope flag — a plugin's MCP servers inherit the scope of wherever the plugin is *enabled* (user vs. project settings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)