### PR TITLE
feat(web/billing): show all tiers + quotas from the sidecar catalog (SSOT)

### DIFF
--- a/web/src/app/(app)/billing/page.catalog.test.tsx
+++ b/web/src/app/(app)/billing/page.catalog.test.tsx
@@ -1,0 +1,238 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { SWRConfig } from "swr";
+
+// Mock next/link so PageShell / Topbar links don't resolve router state.
+jest.mock("next/link", () => {
+  return function MockLink({
+    href,
+    children,
+    ...rest
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [k: string]: unknown;
+  }) {
+    return (
+      <a href={href} {...rest}>
+        {children}
+      </a>
+    );
+  };
+});
+
+// BILLING_API is captured at module-evaluation time from this env var
+// (and inlined by Next in prod). Set it BEFORE requiring the page so the
+// module sees a configured sidecar — hence `require` here rather than a
+// top-level `import`, which would be hoisted above this assignment.
+// This is a separate test file from page.test.tsx precisely so the two
+// don't fight over the value (Jest gives each test file its own env).
+process.env.NEXT_PUBLIC_BILLING_API = "https://billing.test";
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const BillingPage = require("./page").default as React.ComponentType;
+
+const PLAN_URL = "https://billing.test/api/billing/plan";
+const CHECKOUT_URL = "https://billing.test/api/billing/checkout";
+const PORTAL_URL = "https://billing.test/api/billing/portal";
+
+// The catalog the sidecar's plans package advertises (Free/Pro/Scale).
+const CATALOG = [
+  {
+    code: "free",
+    display_name: "Free",
+    monthly_price_cents: 0,
+    max_agents: 3,
+    max_domains: 1,
+    max_messages_month: 3000,
+    max_storage_bytes: 1 << 30,
+  },
+  {
+    code: "pro",
+    display_name: "Pro",
+    monthly_price_cents: 2000,
+    max_agents: 25,
+    max_domains: 10,
+    max_messages_month: 50000,
+    max_storage_bytes: 10 * (1 << 30),
+  },
+  {
+    code: "scale",
+    display_name: "Scale",
+    monthly_price_cents: 9900,
+    max_agents: 250,
+    max_domains: 50,
+    max_messages_month: 500000,
+    max_storage_bytes: 100 * (1 << 30),
+  },
+];
+
+const FREE_LIMITS = {
+  plan_code: "free",
+  limits: {
+    max_agents: 3,
+    max_domains: 1,
+    max_messages_month: 3000,
+    max_storage_bytes: 1 << 30,
+  },
+  usage: { agents: 1, domains: 0, messages_month: 120, storage_bytes: 1024 },
+  upgrade_url: "",
+};
+
+const PRO_LIMITS = {
+  plan_code: "pro",
+  limits: {
+    max_agents: 25,
+    max_domains: 10,
+    max_messages_month: 50000,
+    max_storage_bytes: 10 * (1 << 30),
+  },
+  usage: { agents: 4, domains: 2, messages_month: 9000, storage_bytes: 2048 },
+  // upgrade_url present == active subscription; it is also the portal POST target.
+  upgrade_url: PORTAL_URL,
+};
+
+const mockFetch = jest.fn();
+beforeEach(() => {
+  mockFetch.mockReset();
+  global.fetch = mockFetch;
+});
+
+// jsdom's window.location is non-configurable and doesn't implement
+// navigation, so we can't observe the final `window.location.href = url`
+// redirect directly. The meaningful behavior is which billing endpoint
+// gets POSTed (and with what body) — that's what the tests assert. The
+// page's redirect assignment is a no-op in jsdom (logged, not thrown),
+// so postBilling still completes its happy path. Mock alert so an
+// unexpected error path doesn't surface a jsdom dialog.
+beforeAll(() => {
+  window.alert = jest.fn();
+});
+
+type StageOpts = {
+  limits: unknown;
+  plan?: unknown; // catalog/current payload; omit to 500 the plan fetch
+  planFails?: boolean;
+  checkoutUrl?: string;
+  portalUrl?: string;
+};
+
+function stage(opts: StageOpts) {
+  mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+    if (url === "/v1/account") {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(opts.limits) });
+    }
+    if (url === PLAN_URL) {
+      if (opts.planFails) {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          text: () => Promise.resolve("boom"),
+        });
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(opts.plan) });
+    }
+    if (url === CHECKOUT_URL && init?.method === "POST") {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ url: opts.checkoutUrl ?? "https://stripe.test/checkout" }),
+      });
+    }
+    if (url === PORTAL_URL && init?.method === "POST") {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ url: opts.portalUrl ?? "https://stripe.test/portal" }),
+      });
+    }
+    return Promise.resolve({ ok: false, text: () => Promise.resolve("404") });
+  });
+}
+
+function renderPage() {
+  return render(
+    <SWRConfig value={{ provider: () => new Map(), dedupingInterval: 0 }}>
+      <BillingPage />
+    </SWRConfig>,
+  );
+}
+
+describe("BillingPage — tier comparison", () => {
+  it("renders every catalog tier with its quota and prices", async () => {
+    stage({ limits: FREE_LIMITS, plan: { catalog: CATALOG, current: { code: "free", status: "inactive", has_stripe_customer: false } } });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("Plans")).toBeInTheDocument());
+    // All three tiers present. "Free" also appears in the current-plan
+    // banner for this user, so it legitimately matches twice.
+    expect(screen.getAllByText("Free").length).toBeGreaterThan(0);
+    expect(screen.getByText("Pro")).toBeInTheDocument();
+    expect(screen.getByText("Scale")).toBeInTheDocument();
+    // Prices from cents.
+    expect(screen.getByText("$20/mo")).toBeInTheDocument();
+    expect(screen.getByText("$99/mo")).toBeInTheDocument();
+    // Quota numbers from the catalog (Scale's caps).
+    expect(screen.getByText("250")).toBeInTheDocument();
+    expect(screen.getByText("500,000")).toBeInTheDocument();
+    expect(screen.getByText("100.00 GB")).toBeInTheDocument();
+  });
+
+  it("marks the current tier and offers Upgrade CTAs to a free user", async () => {
+    stage({ limits: FREE_LIMITS, plan: { catalog: CATALOG, current: { code: "free", status: "inactive", has_stripe_customer: false } } });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("Current")).toBeInTheDocument());
+    // Free is current → upgrade CTAs only for the paid tiers.
+    expect(screen.getByRole("button", { name: "Upgrade to Pro" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Upgrade to Scale" })).toBeInTheDocument();
+    // Free tier shows no action button.
+    expect(screen.queryByRole("button", { name: /Upgrade to Free|Downgrade|Switch to Free/ })).not.toBeInTheDocument();
+  });
+
+  it("upgrade routes a free user to Checkout with the chosen plan", async () => {
+    stage({ limits: FREE_LIMITS, plan: { catalog: CATALOG, current: { code: "free", status: "inactive", has_stripe_customer: false } } });
+    renderPage();
+
+    const btn = await screen.findByRole("button", { name: "Upgrade to Scale" });
+    await userEvent.click(btn);
+
+    // Routes to Checkout (not portal) carrying the selected plan code.
+    await waitFor(() =>
+      expect(mockFetch.mock.calls.some(([u]) => u === CHECKOUT_URL)).toBe(true),
+    );
+    const call = mockFetch.mock.calls.find(([u]) => u === CHECKOUT_URL);
+    expect(call![1].method).toBe("POST");
+    expect(JSON.parse(call![1].body)).toEqual({ plan: "scale" });
+    expect(mockFetch.mock.calls.some(([u]) => u === PORTAL_URL)).toBe(false);
+  });
+
+  it("offers Switch/Downgrade via the portal for an active subscriber", async () => {
+    stage({ limits: PRO_LIMITS, plan: { catalog: CATALOG, current: { code: "pro", status: "active", has_stripe_customer: true } } });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("Current")).toBeInTheDocument());
+    // Pro is current (no button); Scale = switch up, Free = downgrade.
+    const switchBtn = screen.getByRole("button", { name: "Switch to Scale" });
+    expect(switchBtn).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Downgrade" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Switch to Pro|Upgrade/ })).not.toBeInTheDocument();
+
+    // A switch routes to the Stripe portal (upgrade_url), not checkout.
+    await userEvent.click(switchBtn);
+    await waitFor(() =>
+      expect(
+        mockFetch.mock.calls.some(([u, i]) => u === PORTAL_URL && i?.method === "POST"),
+      ).toBe(true),
+    );
+    expect(mockFetch.mock.calls.some(([u]) => u === CHECKOUT_URL)).toBe(false);
+  });
+
+  it("degrades gracefully when the plan catalog fails to load", async () => {
+    stage({ limits: FREE_LIMITS, planFails: true });
+    renderPage();
+
+    // Usage still renders (it comes from /v1/account, a separate fetch).
+    await waitFor(() => expect(screen.getByText("Inboxes")).toBeInTheDocument());
+    // The Plans section shows a retry notice rather than tier cards.
+    expect(screen.getByText(/Couldn't load plans/i)).toBeInTheDocument();
+    expect(screen.queryByText("Scale")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/app/(app)/billing/page.catalog.test.tsx
+++ b/web/src/app/(app)/billing/page.catalog.test.tsx
@@ -225,6 +225,24 @@ describe("BillingPage — tier comparison", () => {
     expect(mockFetch.mock.calls.some(([u]) => u === CHECKOUT_URL)).toBe(false);
   });
 
+  it("offers no plan-change actions when the current plan can't be determined", async () => {
+    // Fail-safe path: both the sidecar's current.code and the OSS
+    // plan_code are empty, so currentCode resolves to "". No tier should
+    // be marked current and no Upgrade/Switch/Downgrade button should
+    // render — we don't act on an unknown current plan.
+    stage({
+      limits: { ...FREE_LIMITS, plan_code: "" },
+      plan: { catalog: CATALOG, current: { code: "", status: "inactive", has_stripe_customer: false } },
+    });
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("Plans")).toBeInTheDocument());
+    expect(screen.queryByText("Current")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Upgrade|Switch|Downgrade/ }),
+    ).not.toBeInTheDocument();
+  });
+
   it("degrades gracefully when the plan catalog fails to load", async () => {
     stage({ limits: FREE_LIMITS, planFails: true });
     renderPage();

--- a/web/src/app/(app)/billing/page.test.tsx
+++ b/web/src/app/(app)/billing/page.test.tsx
@@ -100,6 +100,11 @@ describe("BillingPage", () => {
     await waitFor(() => screen.getByText(/Default/i));
     expect(screen.queryByText(/Upgrade/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Manage billing/i)).not.toBeInTheDocument();
+    // The plan comparison is also a sidecar-only surface — with no
+    // BILLING_API there's no catalog to fetch, so the Plans section and
+    // its tier cards must not render.
+    expect(screen.queryByText("Plans")).not.toBeInTheDocument();
+    expect(screen.queryByText("Scale")).not.toBeInTheDocument();
   });
 
   it("renders error state when the API returns non-2xx", async () => {

--- a/web/src/app/(app)/billing/page.tsx
+++ b/web/src/app/(app)/billing/page.tsx
@@ -38,6 +38,8 @@ type PlanEntry = {
   max_agents: number;
   max_domains: number;
   max_messages_month: number;
+  // int64 on the Go side; safe as a JS number — the largest tier cap
+  // (~100 GiB ≈ 1.07e11) is far below Number.MAX_SAFE_INTEGER (2^53).
   max_storage_bytes: number;
 };
 
@@ -166,7 +168,7 @@ function UsageRow({ label, current, limit, pct }: UsageRowProps) {
 // already their plan, nothing to buy).
 type PlanCTA = {
   label: string;
-  onClick?: () => void;
+  onClick: () => void;
   disabled: boolean;
 };
 
@@ -221,7 +223,7 @@ function PlanCard({
       {cta && (
         <button
           type="button"
-          disabled={cta.disabled || !cta.onClick}
+          disabled={cta.disabled}
           onClick={cta.onClick}
           className="mt-auto px-3 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent/90 transition disabled:opacity-50 disabled:cursor-not-allowed"
         >
@@ -327,6 +329,13 @@ export default function BillingPage() {
   const hasSub = !!data?.upgrade_url;
 
   function ctaFor(tier: PlanEntry): PlanCTA | null {
+    // Fail safe: if we couldn't determine the user's current plan (both
+    // the sidecar and OSS plan code missing/empty), offer no plan-change
+    // actions rather than risk mislabeling — better to show no button
+    // than to send someone to Checkout for a plan they may already hold.
+    if (!currentCode) {
+      return null;
+    }
     // The current tier is marked with a "Current" badge and offers no
     // action button — there's nothing to do on the plan you're already on.
     if (tier.code === currentCode) {

--- a/web/src/app/(app)/billing/page.tsx
+++ b/web/src/app/(app)/billing/page.tsx
@@ -25,11 +25,40 @@ type LimitsInfo = {
   upgrade_url: string;
 };
 
+// PlanInfo mirrors the response of GET /api/billing/plan on the hosted
+// billing sidecar. The sidecar's plans package is the single source of
+// truth for what each tier includes and what it costs; we render the
+// comparison straight from it so the dashboard can never drift from the
+// caps the webhook actually provisions. Stripe price IDs stay
+// server-side — the client only ever sends a plan `code`.
+type PlanEntry = {
+  code: string;
+  display_name: string;
+  monthly_price_cents: number;
+  max_agents: number;
+  max_domains: number;
+  max_messages_month: number;
+  max_storage_bytes: number;
+};
+
+type CurrentState = {
+  code: string;
+  status: string;
+  current_period_end?: string;
+  has_stripe_customer: boolean;
+};
+
+type PlanInfo = {
+  catalog: PlanEntry[];
+  current: CurrentState;
+};
+
 // BILLING_API is the base URL of the external limits provisioner (the
 // hosted billing sidecar). When empty the dashboard renders the usage
-// surface without Upgrade / Manage Billing affordances — appropriate
-// for self-host deployments that don't run a paid tier. Set at build
-// time via NEXT_PUBLIC_BILLING_API; populated in the prod web image.
+// surface without the plan comparison or Upgrade / Manage Billing
+// affordances — appropriate for self-host deployments that don't run a
+// paid tier. Set at build time via NEXT_PUBLIC_BILLING_API; populated in
+// the prod web image.
 const BILLING_API = (process.env.NEXT_PUBLIC_BILLING_API ?? "").replace(/\/$/, "");
 
 async function fetchLimits(): Promise<LimitsInfo> {
@@ -37,6 +66,15 @@ async function fetchLimits(): Promise<LimitsInfo> {
   if (!res.ok) {
     const body = await res.text().catch(() => "");
     throw new Error(`limits: HTTP ${res.status}${body ? ` — ${body}` : ""}`);
+  }
+  return res.json();
+}
+
+async function fetchPlan(url: string): Promise<PlanInfo> {
+  const res = await fetch(url, { credentials: "include" });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`plan: HTTP ${res.status}${body ? ` — ${body}` : ""}`);
   }
   return res.json();
 }
@@ -56,6 +94,27 @@ function formatNumber(n: number): string {
   return n.toLocaleString();
 }
 
+// formatPrice turns the catalog's integer cents into the dashboard's
+// price label. $0 reads "Free"; whole-dollar amounts drop the trailing
+// ".00" so "$20/mo" not "$20.00/mo".
+function formatPrice(cents: number): string {
+  if (cents <= 0) return "Free";
+  const dollars = cents / 100;
+  const amount = Number.isInteger(dollars) ? `$${dollars}` : `$${dollars.toFixed(2)}`;
+  return `${amount}/mo`;
+}
+
+// QUOTA_DIMS is the data-driven list of caps we show per tier. Each
+// dimension formats its own cell from a PlanEntry, so adding a future
+// cap (webhooks, seats, …) is one entry here plus the matching field on
+// PlanEntry — no per-tier markup to touch.
+const QUOTA_DIMS: { label: string; format: (p: PlanEntry) => string }[] = [
+  { label: "Inboxes", format: (p) => formatNumber(p.max_agents) },
+  { label: "Domains", format: (p) => formatNumber(p.max_domains) },
+  { label: "Messages / mo", format: (p) => formatNumber(p.max_messages_month) },
+  { label: "Storage", format: (p) => formatBytes(p.max_storage_bytes) },
+];
+
 // pctTone picks the bar color based on how close to the cap the user
 // is. <70% neutral, 70-90% warning, >=90% danger. Tones reuse existing
 // CSS vars so the dashboard's theme tokens own the actual colors.
@@ -64,17 +123,6 @@ function pctTone(pct: number): "neutral" | "warn" | "danger" {
   if (pct >= 70) return "warn";
   return "neutral";
 }
-
-// PLAN_CATALOG mirrors the operator-side plan catalog at
-// e2a-ops/billing/internal/plans/plans.go. Hardcoded here because the
-// dashboard isn't yet wired to the sidecar's GET /api/billing/plan
-// listing endpoint — and even if it were, the values are stable enough
-// that an extra round-trip on the upgrade page isn't worth it. If you
-// change a cap on either side, update both files in the same PR.
-const PLAN_CATALOG = [
-  { code: "pro", name: "Pro", price: "$20/mo", chips: ["25 inboxes", "10 domains", "50k msgs/mo", "10 GiB"] },
-  { code: "scale", name: "Scale", price: "$99/mo", chips: ["250 inboxes", "50 domains", "500k msgs/mo", "100 GiB"] },
-] as const;
 
 type UsageRowProps = {
   label: string;
@@ -113,17 +161,99 @@ function UsageRow({ label, current, limit, pct }: UsageRowProps) {
   );
 }
 
+// PlanCTA describes the action button on one tier card. `null` means the
+// tier shows no button (e.g. the Free tier for a brand-new user — it's
+// already their plan, nothing to buy).
+type PlanCTA = {
+  label: string;
+  onClick?: () => void;
+  disabled: boolean;
+};
+
+function PlanCard({
+  tier,
+  isCurrent,
+  cta,
+}: {
+  tier: PlanEntry;
+  isCurrent: boolean;
+  cta: PlanCTA | null;
+}) {
+  return (
+    <div
+      className="rounded-lg border p-4 flex flex-col gap-3"
+      style={{
+        // The current tier gets the accent border + a tinted surface so
+        // it reads as "you are here" at a glance.
+        borderColor: isCurrent ? "var(--accent)" : "var(--border)",
+        background: isCurrent ? "var(--surface)" : "var(--bg-elev)",
+      }}
+      aria-current={isCurrent ? "true" : undefined}
+    >
+      <div>
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-sm font-semibold text-foreground">
+            {tier.display_name}
+          </span>
+          {isCurrent && (
+            <span
+              className="text-[10px] uppercase tracking-wide rounded px-1.5 py-0.5"
+              style={{ background: "var(--accent)", color: "white" }}
+            >
+              Current
+            </span>
+          )}
+        </div>
+        <div className="text-xs text-muted mt-0.5">
+          {formatPrice(tier.monthly_price_cents)}
+        </div>
+      </div>
+
+      <dl className="text-xs text-muted space-y-1">
+        {QUOTA_DIMS.map((d) => (
+          <div key={d.label} className="flex items-baseline justify-between gap-2">
+            <dt>{d.label}</dt>
+            <dd className="text-foreground font-medium">{d.format(tier)}</dd>
+          </div>
+        ))}
+      </dl>
+
+      {cta && (
+        <button
+          type="button"
+          disabled={cta.disabled || !cta.onClick}
+          onClick={cta.onClick}
+          className="mt-auto px-3 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent/90 transition disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          {cta.label}
+        </button>
+      )}
+    </div>
+  );
+}
+
 export default function BillingPage() {
   const { data, error, isLoading, mutate } = useSWR<LimitsInfo>(
     "limits",
     fetchLimits,
   );
 
-  // Track the specific action in flight so each button can show its own
-  // "Opening…" label while disabling the others. Two upgrade variants
-  // because the page renders a Pro and a Scale CTA side-by-side.
-  type PendingAction = "upgrade-pro" | "upgrade-scale" | "portal";
-  const [actionPending, setActionPending] = useState<PendingAction | null>(null);
+  // The plan catalog comes from the sidecar's source of truth. Gated on
+  // BILLING_API so self-host builds (no sidecar) skip the fetch entirely
+  // — SWR treats a null key as "don't fetch".
+  const {
+    data: planData,
+    error: planError,
+    mutate: mutatePlan,
+  } = useSWR<PlanInfo>(
+    BILLING_API ? `${BILLING_API}/api/billing/plan` : null,
+    fetchPlan,
+  );
+
+  // Track which specific button is in flight so it can show "Opening…"
+  // while the others disable. Tier CTAs are keyed `tier-<code>`; the
+  // banner's Manage-billing button is "manage".
+  const [actionPending, setActionPending] = useState<string | null>(null);
 
   // Both Upgrade and Manage Billing POST to the sidecar and follow the
   // returned `url`. POST (not GET) because the OSS session cookie is
@@ -135,7 +265,7 @@ export default function BillingPage() {
   //
   // `body` carries the plan selector for /api/billing/checkout (sidecar
   // defaults to Pro when absent). /api/billing/portal ignores it.
-  async function postBilling(endpoint: string, kind: PendingAction, body?: unknown) {
+  async function postBilling(endpoint: string, kind: string, body?: unknown) {
     setActionPending(kind);
     try {
       const res = await fetch(endpoint, {
@@ -171,16 +301,73 @@ export default function BillingPage() {
   // stuck after a Back navigation.
   useEffect(() => {
     const onShow = (e: PageTransitionEvent) => {
-      if (e.persisted) void mutate();
+      if (e.persisted) {
+        void mutate();
+        void mutatePlan();
+      }
     };
     window.addEventListener("pageshow", onShow);
     return () => window.removeEventListener("pageshow", onShow);
-  }, [mutate]);
+  }, [mutate, mutatePlan]);
 
   // Compute usage percentages once data is loaded. Guard zero limits
   // (treat as 0% rather than NaN/Infinity) so a misconfigured row with
   // max_*=0 doesn't paint a full red bar.
   const pct = (used: number, cap: number) => (cap > 0 ? (used / cap) * 100 : 0);
+
+  // Current tier: prefer the sidecar's billing truth, fall back to the
+  // OSS-enforced plan_code so the banner still labels correctly when the
+  // catalog fetch hasn't landed (or isn't present on self-host).
+  const currentCode = planData?.current.code ?? data?.plan_code ?? "";
+
+  // hasSub: the user has an active Stripe subscription. upgrade_url is
+  // only populated by the OSS server when a subscription exists, and it
+  // *is* the portal POST target — so it doubles as the "has subscription"
+  // signal and the endpoint for plan changes / cancellation.
+  const hasSub = !!data?.upgrade_url;
+
+  function ctaFor(tier: PlanEntry): PlanCTA | null {
+    // The current tier is marked with a "Current" badge and offers no
+    // action button — there's nothing to do on the plan you're already on.
+    if (tier.code === currentCode) {
+      return null;
+    }
+    if (hasSub) {
+      // Existing subscribers change or cancel their plan through the
+      // Stripe Billing Portal (it owns proration). Both "switch up/down"
+      // and "downgrade to Free" route there.
+      const label =
+        tier.monthly_price_cents <= 0 ? "Downgrade" : `Switch to ${tier.display_name}`;
+      const key = `tier-${tier.code}`;
+      return {
+        label: actionPending === key ? "Opening…" : label,
+        onClick: () => postBilling(data!.upgrade_url, key),
+        disabled: actionPending !== null,
+      };
+    }
+    // No subscription yet. The Free tier is already their plan (handled
+    // above as current), so only paid tiers get an Upgrade CTA → Checkout.
+    if (tier.monthly_price_cents <= 0) {
+      return null;
+    }
+    const key = `tier-${tier.code}`;
+    return {
+      label: actionPending === key ? "Opening…" : `Upgrade to ${tier.display_name}`,
+      onClick: () =>
+        postBilling(`${BILLING_API}/api/billing/checkout`, key, { plan: tier.code }),
+      disabled: actionPending !== null,
+    };
+  }
+
+  // Human label for the current plan in the banner. "default" is the
+  // operator-configured self-host plan (not a catalog tier); otherwise
+  // prefer the catalog's display name, falling back to the raw code.
+  const currentPlanLabel =
+    data?.plan_code === "default"
+      ? "Default (operator-configured)"
+      : planData?.catalog.find((p) => p.code === currentCode)?.display_name ??
+        data?.plan_code ??
+        "";
 
   return (
     <PageShell
@@ -222,74 +409,77 @@ export default function BillingPage() {
                   Current plan
                 </div>
                 <div className="text-lg font-semibold text-foreground mt-1">
-                  {data.plan_code === "default"
-                    ? "Default (operator-configured)"
-                    : data.plan_code}
+                  {currentPlanLabel}
                 </div>
               </div>
               {BILLING_API && data.upgrade_url && (
                 // upgrade_url present → user has an active Stripe
                 // subscription. Clicking POSTs to the sidecar, which
                 // returns a fresh Stripe Billing Portal URL. From the
-                // Portal, users can switch plans (Pro ↔ Scale) and
-                // cancel — that's why we don't render separate
-                // upgrade-to-Scale buttons for paid users.
+                // Portal, users switch plans (Pro ↔ Scale) and cancel.
                 <div className="flex items-center gap-2 flex-wrap justify-end">
                   <button
                     type="button"
                     disabled={actionPending !== null}
-                    onClick={() => postBilling(data.upgrade_url, "portal")}
+                    onClick={() => postBilling(data.upgrade_url, "manage")}
                     className="px-3 py-1.5 rounded-md text-sm border hover:bg-background transition disabled:opacity-50 disabled:cursor-not-allowed"
                     style={{ borderColor: "var(--border)", color: "var(--fg)" }}
                   >
-                    {actionPending === "portal" ? "Opening…" : "Manage billing"}
+                    {actionPending === "manage" ? "Opening…" : "Manage billing"}
                   </button>
                 </div>
               )}
             </div>
-
-            {/* Plan picker for free users: render Pro + Scale side-by-side
-                with the caps each tier includes spelled out, so users
-                aren't picking blind from "Upgrade to Pro · $20/mo" alone.
-                Hidden once the user has an active subscription — they
-                manage plan changes through the Stripe Billing Portal. */}
-            {BILLING_API && !data.upgrade_url && (
-              <div className="mt-5 grid gap-3 sm:grid-cols-2">
-                {PLAN_CATALOG.map((p) => {
-                  const pendingKey = `upgrade-${p.code}` as PendingAction;
-                  return (
-                    <div
-                      key={p.code}
-                      className="rounded-lg border p-4 flex flex-col gap-3"
-                      style={{ borderColor: "var(--border)", background: "var(--bg-elev)" }}
-                    >
-                      <div>
-                        <div className="text-sm font-semibold text-foreground">{p.name}</div>
-                        <div className="text-xs text-muted mt-0.5">{p.price}</div>
-                      </div>
-                      <ul className="text-xs text-muted space-y-1">
-                        {p.chips.map((c) => (
-                          <li key={c}>· {c}</li>
-                        ))}
-                      </ul>
-                      <button
-                        type="button"
-                        disabled={actionPending !== null}
-                        onClick={() =>
-                          postBilling(`${BILLING_API}/api/billing/checkout`, pendingKey, {
-                            plan: p.code,
-                          })
-                        }
-                        className="mt-auto px-3 py-1.5 rounded-md text-sm font-medium bg-accent text-white hover:bg-accent/90 transition disabled:opacity-50 disabled:cursor-not-allowed"
-                      >
-                        {actionPending === pendingKey ? "Opening…" : `Upgrade to ${p.name}`}
-                      </button>
-                    </div>
-                  );
-                })}
-              </div>
-            )}
           </section>
+
+          {/* Plan comparison: every tier and its quota, sourced from the
+              sidecar catalog (the SSOT). Hidden on self-host (no
+              BILLING_API). The current tier is highlighted; each tier
+              carries the right CTA for the user's subscription state. */}
+          {BILLING_API && (
+            <section
+              className="rounded-xl border p-5 space-y-4"
+              style={{ borderColor: "var(--border)", background: "var(--surface)" }}
+            >
+              <div>
+                <div className="text-xs uppercase tracking-wide text-muted">
+                  Plans
+                </div>
+                <div className="text-sm text-muted mt-1">
+                  Compare what each tier includes.
+                </div>
+              </div>
+
+              {planError && (
+                <div className="text-sm text-muted">
+                  Couldn&apos;t load plans.{" "}
+                  <button
+                    onClick={() => mutatePlan()}
+                    className="underline hover:text-foreground transition"
+                  >
+                    Retry
+                  </button>
+                </div>
+              )}
+
+              {!planError && !planData && (
+                <div className="text-sm text-muted">Loading plans…</div>
+              )}
+
+              {planData && (
+                <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+                  {planData.catalog.map((tier) => (
+                    <PlanCard
+                      key={tier.code}
+                      tier={tier}
+                      isCurrent={tier.code === currentCode}
+                      cta={ctaFor(tier)}
+                    />
+                  ))}
+                </div>
+              )}
+            </section>
+          )}
 
           {/* Usage card */}
           <section


### PR DESCRIPTION
## What

Reworks the in-app billing page (`web/src/app/(app)/billing/page.tsx`) to show **every plan tier and its quota** clearly, sourced from the billing sidecar's single source of truth instead of a hardcoded list.

### Before
- Hardcoded a 2-tier catalog (Pro + Scale only — **Free never shown**) that could silently drift from `e2a-ops/billing/internal/plans/plans.go`.
- No side-by-side quota comparison; free users got a picker, paid users only "Manage billing".

### After
- Fetches `GET /api/billing/plan` (the sidecar SSOT) and renders **all tiers (Free/Pro/Scale)** with agents / domains / messages-per-month / storage + price.
- **Current tier highlighted** with a badge.
- Per-tier CTAs: free users **Upgrade via Checkout**; active subscribers **Switch / Downgrade via the Stripe Billing Portal** (Stripe owns proration).
- **Self-host** (no `NEXT_PUBLIC_BILLING_API`): plan comparison + upgrade affordances hidden; usage still renders.
- **Graceful degradation**: if the catalog fetch fails, a retry notice shows and the usage card still renders.
- Removes the hardcoded `PLAN_CATALOG` and its "keep both files in sync" drift hazard.

## Scope / non-goals
- Frontend only (single repo). The optional "Cancels on … vs Renews on …" backend change (needs an `e2a-ops` migration + webhook field) is **deferred** to a follow-up.
- No new tiers/prices, no in-app plan switching (paid changes go through the portal), marketing pricing page untouched.

## Tests
- New `page.catalog.test.tsx`: all-tier render + quota/price formatting, current-tier marking, upgrade→Checkout (asserts plan in POST body), switch/downgrade→portal routing, catalog-fetch-failure degradation.
- Extended `page.test.tsx`: Plans section stays hidden on self-host.
- Full web suite green (264 tests), `eslint` + `tsc --noEmit` clean, production `next build` prerenders `/billing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)