### PR TITLE
fix(ci): make plugins/e2a/.mcp.json optional in plugin validator

### DIFF
--- a/scripts/validate-plugin.mjs
+++ b/scripts/validate-plugin.mjs
@@ -173,12 +173,16 @@ for (const dir of skillDirs) {
   }
 }
 
-// --- 5: standalone .mcp.json -------------------------------------------------
+// --- 5: standalone .mcp.json (optional) --------------------------------------
 
+// The e2a server is declared inline in .claude-plugin/plugin.json, so a
+// standalone .mcp.json is not required. Validate it only if it exists.
 const mcpPath = join(PLUGIN_DIR, ".mcp.json");
-const mcp = readJSON(mcpPath);
-if (mcp && (!mcp.mcpServers || Object.keys(mcp.mcpServers).length === 0)) {
-  fail(`${rel(mcpPath)}: "mcpServers" must define at least one server`);
+if (existsSync(mcpPath)) {
+  const mcp = readJSON(mcpPath);
+  if (mcp && (!mcp.mcpServers || Object.keys(mcp.mcpServers).length === 0)) {
+    fail(`${rel(mcpPath)}: "mcpServers" must define at least one server`);
+  }
 }
 
 // --- report ------------------------------------------------------------------


### PR DESCRIPTION
## What

`scripts/validate-plugin.mjs` section 5 reads `plugins/e2a/.mcp.json` unconditionally. #339 (`5100a62`) deleted that file on purpose — the `e2a` server is declared inline in `.claude-plugin/plugin.json`, so the standalone manifest was a duplicate/drift risk — but didn't update the validator. `readJSON()` turns the resulting `ENOENT` into a validation failure, so the **Plugin manifests** job has been red on `main` since that commit:

```
✗ Plugin validation failed:
  - plugins/e2a/.mcp.json: ENOENT: no such file or directory, open '.../plugins/e2a/.mcp.json'
```

## Fix

Guard the read with `existsSync` so the standalone `.mcp.json` is validated only when present (its content checks still apply if a future plugin ships one).

## Verification

`node scripts/validate-plugin.mjs` now passes locally:

```
✓ Plugin valid: 1 skill(s), version 0.3.2, manifests in sync across Claude/Codex/Cursor
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)