### PR TITLE
v1 launch prep: docs & web polish + plugin MCP wiring fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,7 +86,7 @@ curl http://localhost:8080/api/health
 # → {"status":"ok"}
 
 curl -H "Authorization: Bearer <your-key>" http://localhost:8080/v1/agents
-# → {"agents":[]}
+# → {"items":[],"next_cursor":null}
 ```
 
 ### Optional: web dashboard
@@ -271,7 +271,7 @@ Keep the description tight; the checklist is the load-bearing part.
 review harder and rollback risky. A small refactor that genuinely
 enables the feature is fine; a drive-by typo fix should be its own PR.
 
-**CI must be green.** All twelve test jobs run on every PR. If a
+**CI must be green.** All CI test jobs run on every PR. If a
 flake hits you, re-run the job rather than disabling the test.
 
 ---

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Human (Gmail/Outlook)
     │
     ▼ SMTP
 ┌──────────────┐
-│   e2a relay   │  ← MX record for your agent domain points here
+│  e2a relay   │  ← MX record for your agent domain points here
 │              │
 │  1. Verify   │  ← SPF/DKIM check on the inbound message
 │  2. Sign     │  ← HMAC-signed X-E2A-Auth-* headers
@@ -118,7 +118,7 @@ Inbound mail reaches you two complementary ways — chosen per integration, not 
 | Channel | How | Public URL needed? |
 |---------|-----|---------------------|
 | **Webhooks** | Account-level subscriptions (`POST /v1/webhooks`) — HTTPS POST per event, filterable by agent / conversation / event type | Yes |
-| **WebSocket** | Per-agent real-time notification stream (`/v1/agents/{address}/ws`) + REST fetch | No |
+| **WebSocket** | Per-agent real-time notification stream (`/v1/agents/{email}/ws`) + REST fetch | No |
 
 A disconnected WebSocket client accumulates "unread" messages; on reconnect, the server drains them as notifications. Either channel can also poll messages via the REST API. Webhooks are their own resource (`/v1/webhooks`), chosen per integration rather than set on the agent.
 
@@ -158,7 +158,10 @@ The one-call shortcut parses **and** verifies a delivery, returning a typed even
 from e2a.v1 import construct_event, E2AWebhookSignatureError
 
 # raw request body + the X-E2A-Signature header + your whsec_… secret
-event = construct_event(request_body, signature_header, webhook_secret)  # raises on bad signature
+try:
+    event = construct_event(request_body, signature_header, webhook_secret)
+except E2AWebhookSignatureError:
+    abort(400)  # bad signature — reject the delivery
 if event.type == "email.received":
     # metadata-only notification — fetch the full message (body + attachments)
     msg = await client.webhooks.fetch_message(event)
@@ -167,7 +170,13 @@ if event.type == "email.received":
 ```typescript
 import { constructEvent, E2AWebhookSignatureError } from "@e2a/sdk/v1";
 
-const event = constructEvent(req.body, req.header("X-E2A-Signature")!, webhookSecret); // throws on bad signature
+let event;
+try {
+  event = constructEvent(req.body, req.header("X-E2A-Signature")!, webhookSecret);
+} catch (err) {
+  if (err instanceof E2AWebhookSignatureError) return res.status(400).end(); // bad signature
+  throw err;
+}
 if (event.type === "email.received") {
   // metadata-only notification — fetch the full message (body + attachments)
   const msg = await client.webhooks.fetchMessage(event);
@@ -193,10 +202,10 @@ When an agent's protection config holds an outbound message for review, `send` a
 
 Reviewers can approve or reject via:
 
-- **Dashboard / API** — the account-scoped review queue `POST /v1/reviews/{id}/approve` or `/reject` (id-addressed, no inbox email needed; lists held items across all the account's inboxes via `GET /v1/reviews`). This is the primary path. The agent-path `POST /v1/agents/{address}/messages/{id}/approve|reject` is **deprecated** but still works identically for back-compat.
+- **Dashboard / API** — the account-scoped review queue `POST /v1/reviews/{id}/approve` or `/reject` (id-addressed, no inbox email needed; lists held items across all the account's inboxes via `GET /v1/reviews`). This is the primary path. The agent-path `POST /v1/agents/{email}/messages/{id}/approve|reject` is **deprecated** but still works identically for back-compat.
 - **Magic-link email** — sent automatically when a hold fires; one-click `GET /v1/approve?t=…` and `/v1/reject?t=…` URLs (requires `E2A_PUBLIC_URL` and outbound SMTP configured)
 
-Enable review holds on an agent via `PUT /v1/agents/{address}/protection`: set the outbound gate action to `review` (or turn on the content scan), plus the hold TTL (`holds.ttl_seconds`) and its expiry behavior (`holds.on_expiry` = `approve` or `reject`). Posture lives entirely on the protection sub-resource.
+Enable review holds on an agent via `PUT /v1/agents/{email}/protection`: set the outbound gate action to `review` (or turn on the content scan), plus the hold TTL (`holds.ttl_seconds`) and its expiry behavior (`holds.on_expiry` = `approve` or `reject`). Posture lives entirely on the protection sub-resource.
 
 ## API
 
@@ -248,7 +257,7 @@ client = E2AClient()                                       # reads E2A_API_KEY
 event = construct_event(request_body, signature_header, webhook_secret)  # parse + HMAC-verify
 if event.type == "email.received":
     # event.data is metadata only — replying needs just the recipient + message_id
-    # it carries (fetch the body with client.webhooks.fetch_message(event) if needed)
+    # fetch the full body with client.webhooks.fetch_message(event) if needed
     meta = event.data
     await client.messages.reply(meta["recipient"], meta["message_id"],
                                 {"body": "Got it!", "conversation_id": "conv_123"})
@@ -313,7 +322,7 @@ See [docs/data-handling.md](docs/data-handling.md) for the full retention table,
 
 Four things that aren't possible to bolt on without significant rework:
 
-1. **Local-mode agents with no public URL.** Agents authenticate with their API key, open a WebSocket to `/v1/agents/{address}/ws`, and inbound mail arrives as JSON over that connection — no webhook URL, no ngrok, no port forward. Useful for agents on developer laptops, edge devices, or behind corporate firewalls. SendGrid/Resend are webhook-only by design. A polling REST API is available as fallback.
+1. **Local-mode agents with no public URL.** Agents authenticate with their API key, open a WebSocket to `/v1/agents/{email}/ws`, and inbound mail arrives as JSON over that connection — no webhook URL, no ngrok, no port forward. Useful for agents on developer laptops, edge devices, or behind corporate firewalls. SendGrid/Resend are webhook-only by design. A polling REST API is available as fallback.
 
 2. **Conversation threading on every reply.** Whether a human replies from Gmail or another e2a agent replies via the API, the inbound message arrives at the agent with a stable `conversation_id` already mapped to the original thread. For human senders, the relay does standard `In-Reply-To` / `References` lookup scoped to the recipient agent's own messages. For agent-to-agent where both sides are on e2a, it also trusts an `X-E2A-Conversation-Id` header it controls (envelope-from is its own domain), which survives clients that rewrite threading headers. SendGrid/Resend never see inbound mail — they aren't receivers — so neither path is available without you building both yourself.
 
@@ -373,7 +382,7 @@ make test                # all Go tests (needs Postgres on :5433)
 make test-unit           # Go unit tests only (no DB)
 make test-integration    # integration tests (needs Postgres)
 make test-e2e            # e2e tests (needs Postgres)
-make docker-up           # start local Postgres via docker compose
+make docker-up           # start local Postgres + Mailpit via docker compose
 make migrate             # apply SQL migrations to local DB
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,8 +15,8 @@ Email **security@mnexa.ai** with:
 
 - A description of the issue
 - Steps to reproduce (or a proof-of-concept)
-- The version / commit you observed it on (run `e2a -version` or check
-  `VERSION` in the repo)
+- The version / commit you observed it on (the git SHA, release tag, or
+  the `VERSION` file)
 - Any mitigations you suggest
 
 You can also use GitHub's [private vulnerability reporting](https://github.com/Mnexa-AI/e2a/security/advisories/new)

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,12 +1,19 @@
 # Changelog
 
+## 1.5.1
+
+Current release. Republishes the CLI with a corrected `@e2a/sdk` dependency
+range (`^4.0.0`); the previously published 1.5.0 still declared `^3.0.0`, so a
+fresh `npm i -g @e2a/cli` could resolve an SDK major incompatible with the
+current API. No CLI behavior changes.
+
 ## 1.5.0
 
-Current release. The `e2a` CLI targets the e2a v1 API and runs on the 3.x
-TypeScript SDK (`@e2a/sdk`).
+The `e2a` CLI targets the e2a v1 API and runs on the 4.x TypeScript SDK
+(`@e2a/sdk`).
 
 ### Notes
 - Commands are thin wrappers over the namespaced SDK surface
   (`client.agents`, `client.messages`, `client.domains`, `client.webhooks`,
-  `client.account`). Auth reads `E2A_API_KEY`; `--base-url` (or `E2A_BASE_URL`)
-  overrides the endpoint for self-hosted deployments.
+  `client.account`). Auth reads `E2A_API_KEY`; `E2A_URL` overrides the endpoint
+  for self-hosted deployments (default `https://api.e2a.dev`).

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -16,4 +16,7 @@ The `e2a` CLI targets the e2a v1 API and runs on the 4.x TypeScript SDK
 - Commands are thin wrappers over the namespaced SDK surface
   (`client.agents`, `client.messages`, `client.domains`, `client.webhooks`,
   `client.account`). Auth reads `E2A_API_KEY`; `E2A_URL` overrides the endpoint
-  for self-hosted deployments (default `https://api.e2a.dev`).
+  for self-hosted deployments (default `https://e2a.dev`, the hosted product's
+  unified host — it serves the `e2a login` browser flow and proxies the `/v1`
+  API). Direct SDK users (no browser login) can point at the API host
+  `https://api.e2a.dev` instead.

--- a/cli/src/__tests__/config.test.ts
+++ b/cli/src/__tests__/config.test.ts
@@ -37,7 +37,7 @@ describe("loadConfig", () => {
 
     const config = loadConfig();
     expect(config.api_key).toBe("");
-    expect(config.api_url).toBe("https://api.e2a.dev");
+    expect(config.api_url).toBe("https://e2a.dev");
     expect(config.agent_email).toBe("");
   });
 

--- a/cli/src/__tests__/config.test.ts
+++ b/cli/src/__tests__/config.test.ts
@@ -37,7 +37,7 @@ describe("loadConfig", () => {
 
     const config = loadConfig();
     expect(config.api_key).toBe("");
-    expect(config.api_url).toBe("https://e2a.dev");
+    expect(config.api_url).toBe("https://api.e2a.dev");
     expect(config.agent_email).toBe("");
   });
 

--- a/cli/src/__tests__/login.test.ts
+++ b/cli/src/__tests__/login.test.ts
@@ -171,7 +171,7 @@ describe("login", () => {
       agent_email: "",
       shared_domain: "agents.e2a.dev",
     });
-    expect(mockStderr).toHaveBeenCalledWith("No agents found yet. Run: e2a agents register <slug>\n");
+    expect(mockStderr).toHaveBeenCalledWith("No agents found yet. Create one at https://e2a.dev/get-started\n");
   });
 
   it("unrefs the browser child process so Node can exit", async () => {

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -284,6 +284,6 @@ export async function login(): Promise<void> {
   if (agentEmail) {
     process.stdout.write(`Active agent: ${agentEmail}\n`);
   } else {
-    process.stderr.write("No agents found yet. Run: e2a agents register <slug>\n");
+    process.stderr.write(`No agents found yet. Create one at ${config.api_url.replace(/\/+$/, "")}/get-started\n`);
   }
 }

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -20,7 +20,7 @@ export interface Config {
 
 const CONFIG_DIR = join(homedir(), ".e2a");
 const CONFIG_PATH = join(CONFIG_DIR, "config.json");
-const DEFAULT_URL = "https://api.e2a.dev";
+const DEFAULT_URL = "https://e2a.dev";
 const DEFAULT_SHARED_DOMAIN = "agents.e2a.dev";
 
 export function loadConfig(): Config {

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -20,7 +20,7 @@ export interface Config {
 
 const CONFIG_DIR = join(homedir(), ".e2a");
 const CONFIG_PATH = join(CONFIG_DIR, "config.json");
-const DEFAULT_URL = "https://e2a.dev";
+const DEFAULT_URL = "https://api.e2a.dev";
 const DEFAULT_SHARED_DOMAIN = "agents.e2a.dev";
 
 export function loadConfig(): Config {

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -7,13 +7,12 @@ export interface Config {
   api_url: string;
   agent_email: string;
   /**
-   * Shared mail domain the deployment uses for slug-based agent registration
-   * (e.g. "agents.example.com"). The CLI uses this to expand bare slugs into
-   * full email addresses when calling agent-scoped commands like
-   * `e2a agents update my-bot`. Self-hosters with a different shared domain
-   * should override via `E2A_SHARED_DOMAIN` or `e2a config set
-   * shared_domain ...`. Defaults to the hosted product's shared domain so
-   * the public deployment works zero-config.
+   * Shared mail domain the deployment uses for slug-based agent addresses
+   * (e.g. "agents.example.com"), auto-discovered from `GET /v1/info` on
+   * `e2a login` and cached here. Self-hosters with a different shared domain
+   * can override via `E2A_SHARED_DOMAIN` or `e2a config set shared_domain ...`.
+   * Defaults to the hosted product's shared domain so the public deployment
+   * works zero-config.
    */
   shared_domain: string;
 }

--- a/docs/api.md
+++ b/docs/api.md
@@ -193,7 +193,7 @@ To verify an inbound webhook payload, pass the webhook's signing secret to the S
 helper — `construct_event(body, header, secret)` /
 `constructEvent(body, header, secret)` does parse + verify in one call. See the
 [Python](../sdks/python/README.md#quick-start) and
-[TypeScript](../sdks/typescript/README.md#webhook-cloud-agents) SDK READMEs.
+[TypeScript](../sdks/typescript/README.md#verify-a-webhook) SDK READMEs.
 
 <a id="webhook-signing-secrets"></a>
 > **Signing.** Webhook deliveries are signed per-webhook with the `whsec_`

--- a/docs/data-handling.md
+++ b/docs/data-handling.md
@@ -13,7 +13,7 @@ For vulnerability reporting and the security model, see [SECURITY.md](../SECURIT
 | Outbound message bodies (only while in `pending_review`) | Postgres `messages.body_text` / `body_html` / `attachments_json` | **Scrubbed on terminal review transition** (approve/reject/expire) — only metadata persists after that |
 | Attachments | Postgres rows (`attachments_json`, JSONB) | Same lifetime as the parent message — no S3/GCS |
 | Agent + domain ownership records | Postgres `agent_identities`, `domains` | Until the user deletes the agent/domain or the account |
-| API keys | Postgres `api_keys`, **hash only** (SHA over the plaintext) | Until revoked or the user is deleted; plaintext exists only in the create response and is never persisted |
+| API keys | Postgres `api_keys`, **hash only** (hex-encoded SHA-256 of the plaintext) | Until revoked or the user is deleted; plaintext exists only in the create response and is never persisted |
 | OAuth sessions | Postgres `user_sessions` | 30 days; cleanup worker removes expired rows hourly |
 | Usage events / summaries (only when `E2A_USAGE_TRACKING=true`) | Postgres `usage_events`, `usage_summaries` | Indefinite by default — operator can purge or override |
 | Per-webhook signing secret (`whsec_…`) | Postgres, **plaintext** | Until the webhook is deleted. Returned once at creation; rotate via `POST /v1/webhooks/{id}/rotate-secret` (the previous secret stays valid for a 24h grace window). |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -53,7 +53,7 @@ If you leave `shared_domain` empty, slug registration is disabled and every agen
 End-users only need to know the deployment URL — the rest is auto-discovered.
 
 ```bash
-export E2A_URL=https://api.e2a.example.com   # default: https://api.e2a.dev
+export E2A_URL=https://e2a.example.com   # default: https://e2a.dev
 e2a login                                # browser flow; saves api key + auto-discovers shared domain
 ```
 
@@ -61,7 +61,7 @@ The CLI hits `GET /v1/info` on login and caches `shared_domain` to `~/.e2a/confi
 
 | Variable | Description |
 |---|---|
-| `E2A_URL` | API base URL (default `https://api.e2a.dev`) |
+| `E2A_URL` | CLI base URL (default `https://e2a.dev`) — the unified host that serves the `e2a login` browser flow and proxies the `/v1` API |
 | `E2A_API_KEY` | Bypass `e2a login` — useful in CI |
 | `E2A_SHARED_DOMAIN` | Force the shared domain instead of auto-discovering it |
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -57,7 +57,7 @@ export E2A_URL=https://e2a.example.com   # default: https://e2a.dev
 e2a login                                # browser flow; saves api key + auto-discovers shared domain
 ```
 
-The CLI hits `GET /v1/info` on login and caches `shared_domain` to `~/.e2a/config.json`, so commands like `e2a agents update my-bot` resolve to the right address on any deployment without further config. Escape hatches if you need to override or skip the discovery step:
+The CLI hits `GET /v1/info` on login and caches `shared_domain` to `~/.e2a/config.json`, so it resolves agent addresses to the right shared domain on any deployment without further config. Escape hatches if you need to override or skip the discovery step:
 
 | Variable | Description |
 |---|---|

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -53,7 +53,7 @@ If you leave `shared_domain` empty, slug registration is disabled and every agen
 End-users only need to know the deployment URL — the rest is auto-discovered.
 
 ```bash
-export E2A_URL=https://e2a.example.com   # default: https://e2a.dev
+export E2A_URL=https://api.e2a.example.com   # default: https://api.e2a.dev
 e2a login                                # browser flow; saves api key + auto-discovers shared domain
 ```
 
@@ -61,7 +61,7 @@ The CLI hits `GET /v1/info` on login and caches `shared_domain` to `~/.e2a/confi
 
 | Variable | Description |
 |---|---|
-| `E2A_URL` | API base URL (default `https://e2a.dev`) |
+| `E2A_URL` | API base URL (default `https://api.e2a.dev`) |
 | `E2A_API_KEY` | Bypass `e2a login` — useful in CI |
 | `E2A_SHARED_DOMAIN` | Force the shared domain instead of auto-discovering it |
 

--- a/examples/adk-cloud-webhook/README.md
+++ b/examples/adk-cloud-webhook/README.md
@@ -36,6 +36,10 @@ e2a relay -> SMTP -> human
 - A Google AI Studio API key for Gemini —
   [aistudio.google.com/apikey](https://aistudio.google.com/apikey).
 
+> **ADK line:** this example pins ADK 1.x (`google-adk>=1.31,<2`); the MCP
+> quick-start example under [`mcp/examples/adk`](../../mcp/examples/adk/)
+> targets ADK 2.x. They intentionally track different ADK releases.
+
 ## Setup
 
 ```bash

--- a/examples/adk-cloud-webhook/pyproject.toml
+++ b/examples/adk-cloud-webhook/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
   # google-adk 2.0 is in pre-release as of writing and may reorganize imports.
   # Pin to the 1.x line until 2.0 ships and the code is verified against it.
   "google-adk>=1.31,<2",
-  "e2a>=3,<4",
+  "e2a>=4,<5",
   "fastapi>=0.115",
   "uvicorn[standard]>=0.30",
   "python-dotenv>=1.0",

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -27,7 +27,7 @@ An agent-scoped credential resolves its agent server-side. Account-scoped caller
 import os
 
 from google.adk.agents import Agent
-from google.adk.tools.mcp_tool import McpToolset
+from google.adk.tools.mcp_tool.mcp_toolset import McpToolset
 from google.adk.tools.mcp_tool.mcp_session_manager import StreamableHTTPConnectionParams
 
 root_agent = Agent(
@@ -116,7 +116,7 @@ Hosts that support OAuth connectors can instead add `https://api.e2a.dev/mcp` as
 
 The server exposes up to **37** tools spanning agents, messages, human-in-the-loop
 approval, attachments, domains, events, and webhooks. **The visible set depends on
-your credential's scope (§6a):** an **agent**-scoped credential sees the 14
+your credential's scope:** an **agent**-scoped credential sees the 14
 runtime/inbox tools (read, send, reply, and view its pending queue); an
 **account**-scoped credential also sees the 23 admin/setup tools (agent/domain/
 webhook/event management — **and HITL approve/reject, which is an account-owner

--- a/mcp/examples/README.md
+++ b/mcp/examples/README.md
@@ -12,7 +12,7 @@ End-to-end demos showing how to wire the e2a MCP surface into popular agent fram
 
 ## One hosted endpoint, same tool surface
 
-Each example exercises the same 33 e2a tools against the hosted MCP server. The Python framework examples ship an `agent.py` script; the Codex example ships a TOML block (Codex is itself the agent, so you configure it instead of writing a script).
+Each example exercises the same e2a tool surface (37 tools; the visible set depends on your key's scope) against the hosted MCP server. The Python framework examples ship an `agent.py` script; the Codex example ships a TOML block (Codex is itself the agent, so you configure it instead of writing a script).
 
 Every example connects to `https://api.e2a.dev/mcp` over Streamable HTTP with your API key in the `Authorization` header. No Node toolchain or local build is needed, and updates land without rebuilding the agent's image — so it works equally well on a laptop or on serverless runtimes (Cloud Run, Lambda, Vercel).
 

--- a/mcp/examples/adk/README.md
+++ b/mcp/examples/adk/README.md
@@ -1,6 +1,6 @@
 # Google ADK × e2a
 
-Google ADK [`Agent`](https://google.github.io/adk-docs/) powered by Gemini that uses the hosted e2a [MCP server](https://api.e2a.dev/mcp) for the e2a tool surface.
+Google ADK [`Agent`](https://adk.dev/) powered by Gemini that uses the hosted e2a [MCP server](https://api.e2a.dev/mcp) for the e2a tool surface.
 
 `agent.py` wires `McpToolset` + `StreamableHTTPConnectionParams` to the hosted endpoint at `https://api.e2a.dev/mcp`. This works locally and for ADK agents deployed to [Cloud Run](https://docs.cloud.google.com/run/docs/host-mcp-servers).
 
@@ -9,6 +9,8 @@ Google ADK [`Agent`](https://google.github.io/adk-docs/) powered by Gemini that 
 - Python 3.10+
 - An [e2a API key](https://e2a.dev)
 - A [Google AI Studio key](https://aistudio.google.com/apikey) for Gemini
+
+> **ADK line:** this example targets ADK 2.x (`google-adk>=2.0`). The webhook example under [`examples/adk-cloud-webhook`](../../../examples/adk-cloud-webhook/) pins the 1.x line — they intentionally track different ADK releases.
 
 ## Run
 

--- a/mcp/examples/adk/agent.py
+++ b/mcp/examples/adk/agent.py
@@ -29,9 +29,9 @@ root_agent = Agent(
     instruction=(
         "You manage email through the e2a tools. Call whoami once to "
         "find your inbox address. Use list_messages and get_message to "
-        "read; use reply_to_message (not send_email) when replying to "
-        "an existing thread so In-Reply-To and References headers are "
-        "preserved."
+        "read; use reply_to_message when replying to an existing thread "
+        "(preserves In-Reply-To and References headers), and send_message "
+        "to start a new thread."
     ),
     tools=[
         McpToolset(

--- a/mcp/examples/codex/README.md
+++ b/mcp/examples/codex/README.md
@@ -2,7 +2,7 @@
 
 [Codex CLI](https://github.com/openai/codex) is OpenAI's terminal coding agent (peer to Claude Code). It speaks MCP natively — you declare servers in `~/.codex/config.toml` and Codex connects to them at session start, then surfaces their tools to whatever model you're running.
 
-Unlike the [LangChain](../langchain/), [Google ADK](../adk/), and [OpenAI Agents SDK](../openai-agents/) examples — which are Python scripts you run — Codex is itself the agent. The "example" here is the TOML you paste into your Codex config to add e2a's 33 MCP tools.
+Unlike the [LangChain](../langchain/), [Google ADK](../adk/), and [OpenAI Agents SDK](../openai-agents/) examples — which are Python scripts you run — Codex is itself the agent. The "example" here is the TOML you paste into your Codex config to add e2a's MCP tools (37 total; the visible set depends on your key's scope).
 
 Codex opens a Streamable HTTP session to the hosted endpoint at `https://api.e2a.dev/mcp` with your API key in the `Authorization: Bearer …` header — no Node toolchain on the host (works on CI runners, dev containers, remote app servers, etc.).
 

--- a/mcp/examples/crewai/agent.py
+++ b/mcp/examples/crewai/agent.py
@@ -22,8 +22,9 @@ from crewai_tools import MCPServerAdapter
 BACKSTORY = (
     "You manage email through the e2a tools. Call whoami once to find "
     "your inbox address. Use list_messages and get_message to read; "
-    "use reply_to_message (not send_email) when replying to an existing "
-    "thread so In-Reply-To and References headers are preserved."
+    "use reply_to_message when replying to an existing thread (preserves "
+    "In-Reply-To and References headers), and send_message to start a new "
+    "thread."
 )
 
 

--- a/mcp/examples/langchain/agent.py
+++ b/mcp/examples/langchain/agent.py
@@ -24,8 +24,9 @@ from langgraph.prebuilt import create_react_agent
 SYSTEM_PROMPT = (
     "You manage email through the e2a tools. Call whoami once to find "
     "your inbox address. Use list_messages and get_message to read; "
-    "use reply_to_message (not send_email) when replying to an existing "
-    "thread so In-Reply-To and References headers are preserved."
+    "use reply_to_message when replying to an existing thread (preserves "
+    "In-Reply-To and References headers), and send_message to start a new "
+    "thread."
 )
 
 

--- a/mcp/examples/openai-agents/agent.py
+++ b/mcp/examples/openai-agents/agent.py
@@ -40,7 +40,8 @@ async def main(prompt: str) -> None:
             instructions=(
                 "Manage email through the e2a tools. Use whoami once to "
                 "find the inbox; list_messages + get_message to read; "
-                "reply_to_message (not send_email) to reply in-thread."
+                "reply_to_message to reply in-thread, and send_message to "
+                "start a new one."
             ),
             mcp_servers=[e2a],
         )

--- a/plugins/e2a/.claude-plugin/plugin.json
+++ b/plugins/e2a/.claude-plugin/plugin.json
@@ -21,5 +21,6 @@
     "mcp",
     "oauth"
   ],
-  "icon": "./assets/icon.svg"
+  "icon": "./assets/icon.svg",
+  "mcpServers": "./.mcp.json"
 }

--- a/plugins/e2a/.cursor-plugin/plugin.json
+++ b/plugins/e2a/.cursor-plugin/plugin.json
@@ -20,5 +20,6 @@
     "oauth",
     "cursor"
   ],
-  "logo": "assets/icon.svg"
+  "logo": "assets/icon.svg",
+  "mcpServers": "./.mcp.json"
 }

--- a/plugins/e2a/.mcp.json
+++ b/plugins/e2a/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "e2a": {
+      "type": "http",
+      "url": "https://api.e2a.dev/mcp"
+    }
+  }
+}

--- a/plugins/e2a/README.md
+++ b/plugins/e2a/README.md
@@ -68,7 +68,7 @@ The skill is authored in `skills/<name>/SKILL.md` with YAML frontmatter:
 ---
 name: e2a
 description: Use when operating e2a over its MCP tools — sending/receiving email, ...
-version: 11
+version: 12
 ---
 
 ...guide body...

--- a/scripts/validate-plugin.mjs
+++ b/scripts/validate-plugin.mjs
@@ -173,11 +173,20 @@ for (const dir of skillDirs) {
   }
 }
 
-// --- 5: standalone .mcp.json (optional) --------------------------------------
+// --- 5: standalone .mcp.json wiring ------------------------------------------
 
-// The e2a server is declared inline in .claude-plugin/plugin.json, so a
-// standalone .mcp.json is not required. Validate it only if it exists.
+// The e2a server is declared in a single plugins/e2a/.mcp.json that every
+// client manifest references via "mcpServers": "./.mcp.json". If a manifest
+// points at the file, the file must exist and define at least one server —
+// otherwise the plugin installs but silently registers zero MCP tools.
 const mcpPath = join(PLUGIN_DIR, ".mcp.json");
+const referencesMcpFile = PLUGIN_MANIFESTS.some(({ file }) => {
+  const m = readJSON(file);
+  return typeof m?.mcpServers === "string";
+});
+if (referencesMcpFile && !existsSync(mcpPath)) {
+  fail(`${rel(mcpPath)}: referenced by a client manifest ("mcpServers": "./.mcp.json") but the file is missing`);
+}
 if (existsSync(mcpPath)) {
   const mcp = readJSON(mcpPath);
   if (mcp && (!mcp.mcpServers || Object.keys(mcp.mcpServers).length === 0)) {

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 4.0.1
+
+Additive, no breaking changes.
+
+### Added
+- `email.received` is a metadata-only notification; `webhooks.fetch_message(event)`
+  + the `EmailReceivedPayload` type fetch the full message (body + attachments)
+  on demand (#321).
+- Per-axis SES sending status surfaced on the domain/sending types (#309).
+- DKIM verification support (#312).
+
 ## 4.0.0
 
 Breaking: the domain DNS-records shape changed (server #304).

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -9,7 +9,19 @@ pip install e2a          # add the [ws] extra for client.listen(): pip install "
 ```
 
 The SDK major version tracks the SDK package's own breaking changes and is
-independent of the API version path (`/v1`): SDK 3.x targets the e2a v1 API.
+independent of the API version path (`/v1`): SDK 4.x targets the e2a v1 API.
+
+## Upgrading to 4.0
+
+4.0 is a breaking change to the domain DNS-records shape (server #304).
+`DomainView.dns_records` is now a single purpose-tagged `list[DNSRecord]`
+instead of the old `dns_records.{ mx, txt, dkim }` object (and the separate
+`sending_dns_records` list is gone). Each record carries `type`, `name`,
+`value`, `priority`, `purpose`, and a per-record `status`. Address records by
+`purpose` (`ownership`, `inbound_mx`, `dkim`, `mail_from_mx`, `mail_from_spf`)
+rather than `dns_records.mx`/`.txt`/`.dkim` — the MAIL FROM records now live in
+the same list. `purpose` and `status` are open sets, so tolerate unknown
+values. No other public symbols changed.
 
 ## Upgrading from 2.x to 3.0
 
@@ -141,6 +153,29 @@ async for notif in client.listen("bot@agents.e2a.dev"):  # falls back to E2A_AGE
 `client.listen(address)` returns a `WSStream` (async-iterable of
 `WSNotification`) that reconnects with exponential backoff. Requires the `[ws]`
 extra (`pip install "e2a[ws]"`).
+
+## Conversation threading
+
+`conversation_id` is an opaque string that ties multiple emails to one thread
+across the email boundary. Pass it on any `send` / `reply` (as a body field) and
+e2a surfaces it on the recipient's inbound — via `In-Reply-To` for humans, or a
+forge-resistant `X-E2A-Conversation-Id` header for same-platform agent-to-agent
+mail. It is not a security boundary; for sender identity check the message's
+`auth`. On first contact from a human it arrives `None` — assign one yourself if
+you want to thread.
+
+```python
+await client.messages.send(address, {
+    "to": ["alice@example.com"],
+    "subject": "Hello",
+    "body": "Hi from my agent!",
+    "conversation_id": "thread-42",
+})
+
+# Filter an inbox down to a single thread:
+async for m in client.messages.list(address, conversation_id="thread-42"):
+    ...
+```
 
 ## License
 

--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 4.0.1
+
+Additive, no breaking changes.
+
+### Added
+- `email.received` is a metadata-only notification; `webhooks.fetchMessage(event)`
+  + the `EmailReceivedPayload` type fetch the full message (body + attachments)
+  on demand (#321).
+- Per-axis SES sending status surfaced on the domain/sending types (#309).
+- DKIM verification support (#312).
+
 ## 4.0.0
 
 Breaking: the domain DNS-records shape changed (server #304).

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -9,7 +9,19 @@ npm install @e2a/sdk
 ```
 
 The SDK major version tracks the SDK package's own breaking changes and is
-independent of the API version path (`/v1`): SDK 3.x targets the e2a v1 API.
+independent of the API version path (`/v1`): SDK 4.x targets the e2a v1 API.
+
+## Upgrading to 4.0
+
+4.0 is a breaking change to the domain DNS-records shape (server #304).
+`DomainView.dns_records` is now a single purpose-tagged `DNSRecord[]` array
+instead of the old `dns_records.{ mx, txt, dkim }` object (and the separate
+`sending_dns_records` array is gone). Each record carries `type`, `name`,
+`value`, `priority`, `purpose`, and a per-record `status`. Address records by
+`purpose` (`ownership`, `inbound_mx`, `dkim`, `mail_from_mx`, `mail_from_spf`)
+rather than `dns_records.mx`/`.txt`/`.dkim` — the MAIL FROM records now live in
+the same array. `purpose` and `status` are open sets, so tolerate unknown
+values. No other public symbols changed.
 
 ## Upgrading from 2.x to 3.0
 
@@ -89,7 +101,7 @@ match the signature.
 ```typescript
 import { constructEvent, E2AWebhookSignatureError } from "@e2a/sdk/v1";
 
-app.post("/webhook", express.raw({ type: "application/json" }), (req, res) => {
+app.post("/webhook", express.raw({ type: "application/json" }), async (req, res) => {
   let event;
   try {
     event = constructEvent(req.body, req.header("X-E2A-Signature"), process.env.E2A_WEBHOOK_SECRET);

--- a/web/src/app/(app)/inboxes/(view)/messages/view/page.tsx
+++ b/web/src/app/(app)/inboxes/(view)/messages/view/page.tsx
@@ -547,7 +547,7 @@ function FocusContent({
           )}
           <LifecycleSection msg={msg} hitlEnabled={hitlEnabled} />
           {isPending && msg.direction === "outbound" && (
-            <CliHint messageId={msg.data.id} />
+            <ApproveHint messageId={msg.data.id} />
           )}
         </aside>
       </div>
@@ -1070,7 +1070,7 @@ function LifecycleSection({ msg, hitlEnabled }: { msg: LoadedMessage; hitlEnable
   );
 }
 
-function CliHint({ messageId }: { messageId: string }) {
+function ApproveHint({ messageId }: { messageId: string }) {
   return (
     <div
       style={{
@@ -1080,7 +1080,7 @@ function CliHint({ messageId }: { messageId: string }) {
         padding: "0 4px",
       }}
     >
-      or via CLI:
+      or via SDK:
       <div
         style={{
           marginTop: 6,
@@ -1091,7 +1091,7 @@ function CliHint({ messageId }: { messageId: string }) {
           color: "var(--fg)",
         }}
       >
-        e2a pending approve {messageId}
+        await client.reviews.approve(&quot;{messageId}&quot;)
       </div>
     </div>
   );

--- a/web/src/app/(app)/reviews/_components/PendingRow.tsx
+++ b/web/src/app/(app)/reviews/_components/PendingRow.tsx
@@ -440,7 +440,7 @@ export function PendingRow({
                     className="font-mono text-[11px] hidden md:inline"
                     style={{ color: "var(--fg-subtle)" }}
                   >
-                    e2a pending approve {id}
+                    client.reviews.approve(&quot;{id}&quot;)
                   </code>
                 </div>
               )}

--- a/web/src/app/blog/email-agent-with-google-adk/page.mdx
+++ b/web/src/app/blog/email-agent-with-google-adk/page.mdx
@@ -57,7 +57,7 @@ pip install -e .
 cp .env.example .env
 ```
 
-The `pyproject.toml` pulls in `google-adk>=1.31`, `e2a>=3.0`, and FastAPI. Edit `.env` with your three secrets when prompted.
+The `pyproject.toml` pulls in `google-adk>=1.31`, `e2a>=4.0`, and FastAPI. Edit `.env` with your three secrets when prompted.
 
 ## Step 2: Register the agent
 

--- a/web/src/app/blog/email-for-openclaw-agents/page.mdx
+++ b/web/src/app/blog/email-for-openclaw-agents/page.mdx
@@ -57,10 +57,7 @@ e2a login
 
 ## Step 2: Register the agent
 
-```bash
-e2a agents register research
-# → Registered: research@agents.e2a.dev
-```
+Create the agent in the dashboard at [e2a.dev/get-started](https://e2a.dev/get-started) (or via the MCP `create_agent` tool / the SDK) — pick a slug like `research` and you'll get `research@agents.e2a.dev`. The CLI itself only handles auth and listening, not agent creation.
 
 The slug becomes the local-part of your agent's address. There's no cloud-vs-local "mode" — webhook vs WebSocket is just a delivery choice. Here we never subscribe a webhook; instead `e2a listen` opens a WebSocket, so e2a holds mail server-side and pushes it down the stream when your listener connects. That's what keeps the whole setup public-URL-free.
 
@@ -152,4 +149,4 @@ Threading, sender auth, reply-routing — all handled by the gateway so OpenClaw
 - **Add tools.** OpenClaw supports tool calls via the Responses API. Your agent can query calendars, book meetings, or hand off to a human — all triggered by email.
 - **Wire up human-in-the-loop review.** For high-stakes replies, you can hold OpenClaw's outbound for a quick approval before it goes out the door.
 
-If you hit snags — the CLI logs are verbose, and the [API reference](/api-docs) covers the webhook / reply endpoints if you want to build your own listener. There's a free tier and the whole flow above costs nothing during the beta.
+If you hit snags — the CLI logs are verbose, and the [API reference](/api-docs) covers the webhook / reply endpoints if you want to build your own listener. There's a free tier and the whole flow above costs nothing to get started.

--- a/web/src/app/blog/human-in-the-loop-for-agent-email/page.mdx
+++ b/web/src/app/blog/human-in-the-loop-for-agent-email/page.mdx
@@ -28,7 +28,7 @@ export const metadata = {
 
 Giving your AI agent an email address is a quietly big step. It means your agent can now reach your customers, your vendors, your boss — the same people you reach. That's the point. It's also the part that makes even the most bullish builder hesitate the first time.
 
-We heard a version of the same question from early beta users:
+We heard a version of the same question from early users:
 
 > I want my agent to send email. I don't want my agent to send *that* email.
 
@@ -38,11 +38,11 @@ Today we're shipping the answer: **human-in-the-loop approval**. It's a per-agen
 
 When an agent has HITL on, every outbound path pauses:
 
-- Fresh sends from `POST /v1/agents/{address}/messages`
+- Fresh sends from `POST /v1/agents/{email}/messages`
 - Replies to inbound mail from `POST /v1/.../reply`
 - Test sends from the dashboard
 
-The API still accepts the request — it just responds `202 Accepted` with `status: "pending_approval"` instead of the usual `200 OK` + `"sent"`. The message lands in a holding table with a TTL; your SDK call returns immediately so the rest of your agent's logic doesn't block.
+The API still accepts the request — it just responds `202 Accepted` with `status: "pending_review"` instead of the usual `200 OK` + `"sent"`. The message lands in a holding table with a TTL; your SDK call returns immediately so the rest of your agent's logic doesn't block.
 
 Nothing changes for agents that don't have HITL on. Same 200, same SES delivery, same latency.
 
@@ -62,64 +62,62 @@ Clicking a button takes you to a one-page, no-JavaScript confirmation view. Full
 
 ### The dashboard
 
-Or skip the email entirely. Go to **Dashboard → Pending**:
+Or skip the email entirely. Go to the **review queue** in the dashboard:
 
 - List view sorted by soonest-expiring first
 - Click any row to open the edit form
 - Change subject, recipients, body, HTML — whatever
 - Approve with edits (the server records `edited: true` so you have an audit trail) or reject with an optional reason
 
-Dashboard edits go through the same `POST /v1/agents/{address}/messages/{id}/approve` endpoint as everything else; edits are sent as a field-diff so the `edited` flag only flips when you actually changed something.
+Dashboard edits go through the same `POST /v1/reviews/{id}/approve` endpoint as everything else; edits are sent as a field-diff so the `edited` flag only flips when you actually changed something.
 
-### The CLI
+### The SDK
 
-Prefer a terminal?
+Prefer driving it from code? With an account-scoped key the review queue is `client.reviews`:
 
-```bash
-# list what's waiting
-e2a pending list
+```python
+# list what's waiting (both directions)
+held = await client.reviews.list().to_list()
 
-# inspect one
-e2a pending show msg_abc123
+# approve as-is (outbound: sends; inbound: releases to the inbox)
+await client.reviews.approve("msg_abc123")
 
-# approve as-is
-e2a pending approve msg_abc123
-
-# approve with edits — opens $EDITOR
-e2a pending approve msg_abc123 --edit
+# approve with edits — pass field overrides
+await client.reviews.approve("msg_abc123", {"body": "Revised copy."})
 
 # reject with a reason
-e2a pending reject msg_def456 --reason "wrong tone"
+await client.reviews.reject("msg_def456", {"reason": "wrong tone"})
 ```
 
-Same permissions, same endpoints, same audit trail.
+Same permissions, same endpoints, same audit trail. The TypeScript SDK mirrors it (`client.reviews.list().toArray()`, `client.reviews.approve(id)`).
 
 ## Turning it on
 
-One command:
+HITL lives on the agent's **protection config** — the `/v1/agents/{email}/protection` sub-resource (`ttl_seconds` + `on_expiry` for the outbound hold). Set it from the dashboard, or from code:
 
-```bash
-e2a agents update my-agent --hitl \
-  --hitl-ttl 3600 \
-  --hitl-expiration-action reject
+```python
+# read, flip the outbound hold on, write it back (account-scoped key)
+protection = await client.agents.get_protection("my-agent@agents.e2a.dev")
+# ...enable the outbound hold with ttl_seconds=3600, on_expiry="reject"...
+await client.agents.replace_protection("my-agent@agents.e2a.dev", protection)
 ```
 
-`--hitl-ttl` sets how long a message stays pending before the platform finalizes it automatically (capped at 7 days). `--hitl-expiration-action` decides what that finalization looks like:
+`ttl_seconds` sets how long a message stays in review before the platform finalizes it automatically (capped at 7 days). `on_expiry` decides what that finalization looks like:
 
 - `reject` — after TTL, the message is dropped. Safest default; matches "if I don't look in an hour, assume I didn't want this sent."
-- `approve` — after TTL, the message goes out automatically. Useful for `e2a agents update my-agent --hitl --hitl-ttl 30 --hitl-expiration-action approve` — a 30-second review window gives you a "reject undo" but keeps the agent responsive.
+- `approve` — after TTL, the message goes out automatically. A short window (say `ttl_seconds: 30`, `on_expiry: "approve"`) gives you a "reject undo" but keeps the agent responsive.
 
-Or toggle from the dashboard: **Agents → (your agent) → HITL → Edit**.
+Or toggle it from the dashboard: open the agent and edit its protection settings.
 
 ## What happens if you ignore it
 
-A background worker sweeps every minute. It looks for rows whose `approval_expires_at` is in the past and applies the agent's configured expiration action. Rows hit the state you chose (`expired_approved` or `expired_rejected`) and their body is scrubbed from storage. Multi-instance deploys use `FOR UPDATE SKIP LOCKED` so two workers can't race on the same row.
+A background worker sweeps every minute. It looks for rows whose `approval_expires_at` is in the past and applies the agent's configured expiration action. Rows hit the state you chose (`review_expired_approved` or `review_expired_rejected`) and their body is scrubbed from storage. Multi-instance deploys use `FOR UPDATE SKIP LOCKED` so two workers can't race on the same row.
 
-If the auto-approve send itself fails (SES down, for example), the row transitions to `expired_rejected` with the error recorded as the rejection reason rather than looping forever.
+If the auto-approve send itself fails (SES down, for example), the row transitions to `review_expired_rejected` with the error recorded as the rejection reason rather than looping forever.
 
 ## Retention, concretely
 
-Enabling HITL stores the full composed message — subject, body, HTML, attachments — in Postgres up to `hitl_ttl_seconds`. On every terminal transition (sent, rejected, expired_*) the server immediately scrubs those columns to NULL. Headers and metadata stay for the normal 30-day message-TTL window; bodies do not.
+Enabling HITL stores the full composed message — subject, body, HTML, attachments — in Postgres up to `hitl_ttl_seconds`. On every terminal transition (sent, review_rejected, review_expired_*) the server immediately scrubs those columns to NULL. Headers and metadata stay for the normal 30-day message-TTL window; bodies do not.
 
 TTL is server-capped at 604800 seconds (7 days) so the maximum exposure is bounded regardless of agent config. And, again: the notification email carries recipients and subject only. Body content stays server-side, behind the token-gated confirmation page.
 
@@ -132,13 +130,13 @@ TTL is server-capped at 604800 seconds (7 days) so the maximum exposure is bound
 
 ## The API surface
 
-Every action is mirrored across the dashboard, CLI, and API. If you want to build your own approval UI:
+Every action is mirrored across the dashboard, SDK, and API. If you want to build your own approval UI:
 
-- `GET /v1/agents/{address}/messages?direction=outbound` — held drafts surface as `status="pending_approval"`
-- `GET /v1/agents/{address}/messages/{id}` — full detail (body included while pending)
-- `POST /v1/agents/{address}/messages/{id}/approve` — optional body overrides
-- `POST /v1/agents/{address}/messages/{id}/reject` — optional reason
-- `PATCH /v1/agents/{address}` — toggle HITL on/off + configure TTL and expiration action
+- `GET /v1/reviews` — held messages (both directions) surface as `status="pending_review"`
+- `GET /v1/agents/{email}/messages/{id}` — full detail (body included while in review)
+- `POST /v1/reviews/{id}/approve` — optional body overrides
+- `POST /v1/reviews/{id}/reject` — optional reason
+- `GET` / `PUT /v1/agents/{email}/protection` — configure the holds, TTL, and expiration action (`PATCH /v1/agents/{email}` only updates the display name)
 
 Full spec in the [API reference](/api-docs).
 
@@ -146,16 +144,19 @@ Full spec in the [API reference](/api-docs).
 
 Off by default. Toggle it on one agent, send a message to yourself, and watch the flow end-to-end:
 
-```bash
-# from a fresh shell with the CLI installed
-e2a agents update my-agent --hitl --hitl-ttl 3600
-e2a send --to you@yourdomain.com --subject "test" --body "anyone home?"
-# → Holding for approval: msg_abc123
+```python
+async with E2AClient(api_key="e2a_...") as client:
+    # protection is on → this send comes back held, not sent
+    result = await client.messages.send(
+        "my-agent@agents.e2a.dev",
+        {"to": ["you@yourdomain.com"], "subject": "test", "body": "anyone home?"},
+    )
+    # result.status == "pending_review", e.g. msg_abc123
 ```
 
 Check your inbox for the approval email. Click through, look at the confirmation page, approve. The message shows up in the recipient's inbox a second later.
 
-Then turn it off and watch the same `send` command return `sent` in one shot.
+Then turn the hold off and watch the same `send` come back `sent` in one shot.
 
 That's the whole feature. Per-agent, reversible, opt-in.
 

--- a/web/src/app/error.tsx
+++ b/web/src/app/error.tsx
@@ -79,7 +79,7 @@ export default function GlobalError({
           Try again
         </button>
         <Link
-          href="/inboxes"
+          href="/"
           className="inline-flex items-center px-4 py-2.5 text-[14px] font-medium"
           style={{
             background: "var(--bg-panel)",
@@ -88,7 +88,7 @@ export default function GlobalError({
             borderRadius: "var(--r-md)",
           }}
         >
-          Go to dashboard
+          Back home
         </Link>
       </div>
     </div>

--- a/web/src/app/not-found.tsx
+++ b/web/src/app/not-found.tsx
@@ -45,18 +45,32 @@ export default function NotFound() {
       >
         {pathname || "/"}
       </p>
-      <Link
-        href="/inboxes"
-        className="inline-flex items-center gap-2 px-4 py-2.5 text-[14px] font-medium"
-        style={{
-          background: "var(--accent-fill)",
-          color: "var(--accent-fg)",
-          borderRadius: "var(--r-md)",
-        }}
-      >
-        Back to dashboard
-        <span className="font-mono">→</span>
-      </Link>
+      <div className="flex flex-wrap gap-2 justify-center">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 px-4 py-2.5 text-[14px] font-medium"
+          style={{
+            background: "var(--accent-fill)",
+            color: "var(--accent-fg)",
+            borderRadius: "var(--r-md)",
+          }}
+        >
+          Back home
+          <span className="font-mono">→</span>
+        </Link>
+        <Link
+          href="/inboxes"
+          className="inline-flex items-center px-4 py-2.5 text-[14px] font-medium"
+          style={{
+            background: "var(--bg-panel)",
+            color: "var(--fg)",
+            border: "1px solid var(--border)",
+            borderRadius: "var(--r-md)",
+          }}
+        >
+          Go to dashboard
+        </Link>
+      </div>
     </div>
   );
 }

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -86,7 +86,7 @@ export default function Home() {
               className="hidden md:inline font-mono text-[11px]"
               style={{ color: "var(--fg-subtle)", letterSpacing: "0.04em" }}
             >
-              v0.4 · beta
+              v1.0
             </span>
           </div>
 
@@ -256,7 +256,7 @@ export default function Home() {
                 style={{ background: "var(--success)" }}
               />
             </span>
-            Now in public beta · free
+            Now generally available · free to start
           </p>
           <h1
             className="mx-auto mb-6 leading-[1.05]"
@@ -390,9 +390,9 @@ export default function Home() {
                 num: "01",
                 title: "Register your agent",
                 desc: AGENTS_DOMAIN
-                  ? `Sign in, pick a slug, and you've got my-agent@${AGENTS_DOMAIN}. Or BYO domain — verify by DNS TXT.`
-                  : "Sign in and bring your own domain — register it once and verify the DNS records.",
-                tag: "e2a agents register my-agent",
+                  ? `Sign in at e2a.dev/get-started, pick a slug, and you've got my-agent@${AGENTS_DOMAIN}. Or BYO domain — verify by DNS TXT. (Also creatable via MCP or the SDK.)`
+                  : "Sign in at e2a.dev/get-started and bring your own domain — register it once and verify the DNS records. (Also creatable via MCP or the SDK.)",
+                tag: "e2a.dev/get-started",
               },
               {
                 num: "02",
@@ -530,8 +530,8 @@ export default function Home() {
                   <Tok c="accent">npm install</Tok> -g @e2a/cli
                 </Line>
                 <Line>&nbsp;</Line>
-                <Line c="comment"># register your agent</Line>
-                <Line>e2a agents register my-agent</Line>
+                <Line c="comment"># sign in (register your agent at e2a.dev/get-started)</Line>
+                <Line>e2a login</Line>
                 <Line>&nbsp;</Line>
                 <Line c="comment"># listen for inbound email, forward to your local server</Line>
                 <Line>
@@ -541,16 +541,14 @@ export default function Home() {
             )}
             {activeTab === "claude" && (
               <>
-                <Line c="comment"># drop the e2a skill into your Claude Code project</Line>
-                <Line>mkdir -p .claude/skills/e2a</Line>
-                <Line>curl -o .claude/skills/e2a/SKILL.md \</Line>
-                <Line>&nbsp;&nbsp;https://raw.githubusercontent.com/Mnexa-AI/e2a/main/plugins/e2a/skills/e2a/SKILL.md</Line>
+                <Line c="comment"># connect Claude Code to e2a over MCP (OAuth in the browser)</Line>
+                <Line>claude mcp add <Tok c="flag">--transport</Tok> http <Tok c="flag">--scope</Tok> user \</Line>
+                <Line>&nbsp;&nbsp;e2a https://api.e2a.dev/mcp</Line>
                 <Line>&nbsp;</Line>
-                <Line c="comment"># then tell Claude Code:</Line>
-                <Line>/e2a register my-agent</Line>
-                <Line>/e2a listen</Line>
+                <Line c="comment"># then just ask Claude in plain language:</Line>
+                <Line c="comment">#   &quot;Create an email agent and listen for new mail.&quot;</Line>
                 <Line>&nbsp;</Line>
-                <Line c="comment"># works with OpenClaw, Gemini CLI, any skill-aware agent</Line>
+                <Line c="comment"># works with Cursor, Codex, Windsurf — any MCP-aware agent</Line>
               </>
             )}
             {activeTab === "python" && (
@@ -582,7 +580,7 @@ export default function Home() {
                 <Line c="comment"># 1. create the agent</Line>
                 <Line>curl -X POST https://api.e2a.dev/v1/agents \</Line>
                 <Line>&nbsp;&nbsp;-H <Tok c="string">{`"Authorization: Bearer $E2A_API_KEY"`}</Tok> \</Line>
-                <Line>&nbsp;&nbsp;-d <Tok c="string">{`'{"slug":"my-agent"}'`}</Tok></Line>
+                <Line>&nbsp;&nbsp;-d <Tok c="string">{`'{"email":"my-agent@agents.e2a.dev"}'`}</Tok></Line>
                 <Line>&nbsp;</Line>
                 <Line c="comment"># 2. subscribe a webhook to receive inbound mail</Line>
                 <Line>curl -X POST https://api.e2a.dev/v1/webhooks \</Line>
@@ -624,7 +622,7 @@ export default function Home() {
               className="mb-5 leading-[1.65]"
               style={{ fontSize: 13, color: "var(--fg-muted)" }}
             >
-              Per-agent, opt-in, off by default. Configurable TTL with auto-approve or auto-reject on expiry. Reviewable from the dashboard, CLI, or one-click magic links in your inbox.
+              Per-agent, opt-in, off by default. Configurable TTL with auto-approve or auto-reject on expiry. Reviewable from the dashboard, SDK, or one-click magic links in your inbox.
             </p>
             <div className="flex flex-wrap items-center gap-2.5">
               <Link
@@ -654,24 +652,20 @@ export default function Home() {
             </div>
           </div>
 
-          <CodeBlock title="hitl.sh · cli">
-            <Line c="comment"># hold outbound for review</Line>
-            <Line>
-              <Tok c="prompt">$</Tok>e2a agents update my-agent <Tok c="flag">--hitl</Tok> \
-            </Line>
-            <Line>
-              &nbsp;&nbsp;<Tok c="flag">--hitl-ttl</Tok> 3600 <Tok c="flag">--hitl-expiration-action</Tok> reject
-            </Line>
+          <CodeBlock title="hitl.ts · sdk">
+            <Line c="comment">{"// Turn on HITL in the dashboard, or hold outbound for"}</Line>
+            <Line c="comment">{"// review via the agent's protection config."}</Line>
             <Line>&nbsp;</Line>
-            <Line c="comment"># review held messages from your terminal</Line>
+            <Line c="comment">{"// review held messages with an account-scoped key"}</Line>
             <Line>
-              <Tok c="prompt">$</Tok>e2a pending list
+              <Tok c="keyword">const</Tok> held = <Tok c="keyword">await</Tok> client.reviews.<Tok c="fn">list</Tok>().<Tok c="fn">toArray</Tok>();
             </Line>
             <Line c="dim">&nbsp;&nbsp;msg_abc123  customer@acme.io   <Tok c="warn">in 47m</Tok></Line>
             <Line c="dim">&nbsp;&nbsp;msg_def456  legal@stripe.com   <Tok c="warn">in 2h 12m</Tok></Line>
             <Line>&nbsp;</Line>
+            <Line c="comment">{"// approve (sends it) or reject with a reason"}</Line>
             <Line>
-              <Tok c="prompt">$</Tok>e2a pending approve msg_abc123 <Tok c="flag">--edit</Tok>
+              <Tok c="keyword">await</Tok> client.reviews.<Tok c="fn">approve</Tok>(<Tok c="string">&quot;msg_abc123&quot;</Tok>);
             </Line>
             <Line c="success">&nbsp;&nbsp;→ approved · delivering now</Line>
           </CodeBlock>
@@ -782,7 +776,7 @@ export default function Home() {
             className="mb-7 leading-[1.55]"
             style={{ fontSize: 15, color: "var(--fg-muted)" }}
           >
-            Free during beta. No credit card. Up and running in under two minutes.
+            Free to start. No credit card. Up and running in under two minutes.
           </p>
           <div className="inline-flex flex-wrap items-center justify-center gap-2.5">
             <Link


### PR DESCRIPTION
Pre-GA polish pass across all public-facing surfaces (repo docs, SDK/CLI/MCP READMEs, examples, plugin manifests, web app). Reviewed via fan-out review agents, then fixed and verified.

## 🔴 P0 blockers fixed
- **Plugin registered zero MCP tools.** The Claude manifest had no `mcpServers`, the Codex manifest pointed at a deleted `./.mcp.json`, and Cursor had no MCP wiring. Restored a single `plugins/e2a/.mcp.json` (`https://api.e2a.dev/mcp`) referenced by all three client manifests, and hardened `validate-plugin.mjs` to fail CI on a missing referenced `.mcp.json` (closes the silent-failure gap that let this ship).
- **Marketing/blog advertised CLI commands that don't exist** (`e2a agents register`, `e2a pending`, `e2a send`, fake `/e2a` slash commands, `{"slug":...}` create body). Replaced with the real flows (dashboard / MCP / SDK; `e2a login` + `e2a listen --forward`; `client.reviews.*`).

## 🟠 P1 / 🟡 P2 fixed
- **API host:** CLI `DEFAULT_URL` + `deployment.md` corrected `e2a.dev` → `api.e2a.dev` (the API; `e2a.dev` is the web app). Test updated.
- **SDK version drift:** "3.x" → "4.x", added 4.0 upgrade notes + `4.0.1` / `1.5.1` changelog entries; removed the non-existent `--base-url` / `E2A_BASE_URL` doc.
- **GA framing:** removed all "beta" language → v1.0 / "generally available" / "free to start".
- **HITL blog** rewritten to the current model (`pending_review`, `/protection`, `review_expired_*`, `client.reviews`).
- Tool count 33→37, list-response shape, broken README anchor, `e2a -version` removal, SHA→SHA-256, `{address}`→`{email}`, example pins `e2a>=4`, `send_email`→`send_message`/`reply_to_message`, error pages link home, and ~10 more.

## ✅ Verification
- Plugin validator: pass
- CLI: build + 54 tests pass
- Web: build prerenders all pages; lint 0 errors
- Edited Python examples compile

## Notes for reviewers
- **GA copy timing:** the "generally available / v1.0" web copy is staged here but should go live **at GA announcement** (~mid-July), not before.
- **CLI default change** (`api.e2a.dev`) ships on the next `@e2a/cli` publish.
- **`web/public/openapi.yaml`** had pre-existing uncommitted edits unrelated to this work — intentionally **not** included.
- Left as-is intentionally: `adk run agent.py` invocation (couldn't verify the correct form without running ADK), the Cloud Run docs URL (current one resolves), and `sdk.md`'s webhook-payload wording (verified correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)