### PR TITLE
feat(piguard-eval): add --dump-segments to emit the canonical detector input

### DIFF
--- a/cmd/piguard-eval/main.go
+++ b/cmd/piguard-eval/main.go
@@ -54,11 +54,28 @@ type predictionRecord struct {
 	Error      string             `json:"error,omitempty"`
 }
 
+// segmentDumpRecord is the canonical detector-input dump consumed by the Python
+// eval harness via PIGUARD_SEGMENTS (one line per message, keyed by id).
+type segmentOut struct {
+	Type    string `json:"type"`
+	Content string `json:"content"`
+	Ref     string `json:"ref"`
+}
+
+type segmentDumpRecord struct {
+	ID       string         `json:"id"`
+	Segments []segmentOut   `json:"segments"`
+	Signals  signalsSummary `json:"signals"`
+	Error    string         `json:"error,omitempty"`
+}
+
 func main() {
 	manifestPath := flag.String("manifest", "", "manifest JSONL path (default: stdin)")
 	baseDir := flag.String("base-dir", ".", "root for resolving eml_path fields")
 	reviewThreshold := flag.Float64("review-threshold", 0.35, "score ≥ this → review")
 	blockThreshold := flag.Float64("block-threshold", 0.75, "score ≥ this → block")
+	dumpSegments := flag.Bool("dump-segments", false,
+		"emit {id,segments,signals} from Extract (canonical detector input) instead of verdicts")
 	flag.Parse()
 
 	var scanner *bufio.Scanner
@@ -90,7 +107,11 @@ func main() {
 			fmt.Fprintf(os.Stderr, "skip malformed line: %v\n", err)
 			continue
 		}
-		emit(out, evalEntry(ctx, engine, entry, *baseDir, *reviewThreshold, *blockThreshold))
+		if *dumpSegments {
+			emitJSON(out, dumpEntry(entry, *baseDir))
+		} else {
+			emit(out, evalEntry(ctx, engine, entry, *baseDir, *reviewThreshold, *blockThreshold))
+		}
 	}
 	if err := scanner.Err(); err != nil {
 		log.Fatalf("scan: %v", err)
@@ -145,4 +166,38 @@ func emit(w *bufio.Writer, rec predictionRecord) {
 	b, _ := json.Marshal(rec)
 	w.Write(b)
 	w.WriteByte('\n')
+}
+
+func emitJSON(w *bufio.Writer, v any) {
+	b, _ := json.Marshal(v)
+	w.Write(b)
+	w.WriteByte('\n')
+}
+
+// dumpEntry emits the canonical segments + signals piguard's Extract produces
+// for an .eml — the exact input the engine's detectors screen.
+func dumpEntry(entry manifestEntry, baseDir string) segmentDumpRecord {
+	rawEML, err := os.ReadFile(filepath.Join(baseDir, entry.EMLPath))
+	if err != nil {
+		return segmentDumpRecord{ID: entry.ID, Error: fmt.Sprintf("read eml: %v", err)}
+	}
+	segs, signals, _ := piguard.Extract(rawEML, 0)
+	out := make([]segmentOut, len(segs))
+	for i, s := range segs {
+		out[i] = segmentOut{Type: string(s.Type), Content: s.Content, Ref: s.Ref}
+	}
+	return segmentDumpRecord{
+		ID:       entry.ID,
+		Segments: out,
+		Signals: signalsSummary{
+			UnicodeTags:      signals.UnicodeTags,
+			ZeroWidth:        signals.ZeroWidth,
+			HiddenCSSText:    signals.HiddenCSSText,
+			HomoglyphRatio:   signals.HomoglyphRatio,
+			PlainHTMLDiverge: signals.PlainHTMLDiverge,
+			FragmentedURL:    signals.FragmentedURL,
+			Truncated:        signals.Truncated,
+			Unscannable:      signals.Unscannable,
+		},
+	}
 }


### PR DESCRIPTION
## What
Adds a `--dump-segments` flag to `piguard-eval`. With it, the tool emits one
`{id, segments, signals}` JSON record per message — the output of `piguard.Extract`,
i.e. the exact text the engine's detectors screen — instead of the usual verdict records.

## Why
The offline eval harness (`e2a-paper/eval`) already documents and consumes this via
`PIGUARD_SEGMENTS` (its `run_eval` docstring literally shows `piguard-eval --dump-segments`),
so every detector is scored on piguard's canonical view. But the flag was **never in
the committed source** (`cmd/piguard-eval/main.go` had only `--manifest/--base-dir/
--review-threshold/--block-threshold`) — `git log -S"dump-segments"` is empty. The
segment dump the benchmark depends on was therefore only producible by an uncommitted
local change, a reproducibility gap. This restores it in-source.

## Validation
- gofmt-clean, builds.
- `--dump-segments` reproduces the existing dump **byte-for-byte** on known cases
  (keys + segments + signals all match) → confirmed canonical.

## Notes
- Default behavior unchanged (verdict output); `--dump-segments` is opt-in.
- New `segmentDumpRecord`/`segmentOut` serialize segments as lowercase `type/content/ref`
  to match the harness schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)