### PR TITLE
feat(plugin): ship /agentify as an installable skill in the e2a plugin (v0.4.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "e2a plugins for Claude Code — authenticated email for AI agents",
-    "version": "0.3.2"
+    "version": "0.4.0"
   },
   "plugins": [
     {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "e2a — authenticated email gateway for AI agents (MCP server + operate-well skill).",
-    "version": "0.3.2"
+    "version": "0.4.0"
   },
   "plugins": [
     {

--- a/docs/design/autonomous-repo-framework.md
+++ b/docs/design/autonomous-repo-framework.md
@@ -515,6 +515,25 @@ splat); `submit_feedback` wraps the e2a call so a failure can't disclose the
 intake address; and `apply_addons` rejects non-`[a-z0-9-]` addon names (cp
 escaping `tools/`). Each fix has a regression test.
 
+### §10 addenda (plugin packaging)
+
+`/agentify` is shipped as a **skill in the e2a Claude Code plugin** so it's
+installable, not just copy-able:
+
+- The deploy procedure lives at `plugins/e2a/skills/agentify/SKILL.md` (a
+  second skill alongside the existing `skills/e2a/`); the plugin's marketplace
+  entry is unchanged, version bumped `0.3.2 → 0.4.0` across all manifests
+  (`scripts/validate-plugin.mjs` enforces the sync + the frontmatter rules).
+- The scaffolder + templates stay at `plugins/e2a/agentify/` (so CI and the
+  test suite are unchanged); the skill references them via
+  **`${CLAUDE_PLUGIN_ROOT}/agentify/`** — the whole plugin ships to the install
+  cache, so the bundled `agentify-render.sh` / `templates/` / `references/`
+  resolve at runtime.
+- Install: `/plugin marketplace add Mnexa-AI/e2a` → `/plugin install e2a` →
+  `/agentify` is available (plus the e2a MCP tools). The §4.5 "home:
+  `plugins/e2a/agentify/`" note refers to the tooling dir; the user-facing
+  skill is the plugin skill above.
+
 ## 10. Implementation reconciliation (`feat/agentify-feedback-loop`)
 
 Deviations recorded at build time (slice 1 — intake + triage):

--- a/plugins/e2a/.claude-plugin/plugin.json
+++ b/plugins/e2a/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 37 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "Mnexa AI",

--- a/plugins/e2a/.codex-plugin/plugin.json
+++ b/plugins/e2a/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 37 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "Mnexa AI"

--- a/plugins/e2a/.cursor-plugin/plugin.json
+++ b/plugins/e2a/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 37 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "Mnexa AI",

--- a/plugins/e2a/skills/agentify/SKILL.md
+++ b/plugins/e2a/skills/agentify/SKILL.md
@@ -6,11 +6,15 @@ description: Deploy the autonomous-repo feedback loop into a GitHub repo. Scaffo
 # agentify — deploy the autonomous-repo feedback loop
 
 `/agentify` installs the framework into a target repo: feedback in →
-triaged GitHub issue → human-gated fix PR → filer notified. It **bundles
-the framework as templates** (this skill's `templates/`), so grabbing this
-skill is grabbing the framework. The install lands as a **PR the repo owner
-reviews and merges** — the install itself goes through the same human gate
-the framework runs on.
+triaged GitHub issue → human-gated fix PR → filer notified. It **bundles the
+framework as templates**, so installing this plugin is grabbing the
+framework. The install lands as a **PR the repo owner reviews and merges** —
+the install itself goes through the same human gate the framework runs on.
+
+> **Where the tooling lives.** The scaffolder and templates ship in this
+> plugin at `${CLAUDE_PLUGIN_ROOT}/agentify/` — `agentify-render.sh`,
+> `templates/`, `references/`. Reference them with that variable (it resolves
+> to the plugin's install path); run commands from there.
 
 > **v0 scope.** The full loop ships: **triage/intake** (email → triaged
 > issue), **comms** (filer acks + the fix-gate approval email + verified-reply
@@ -23,7 +27,7 @@ the framework runs on.
 
 ## What gets scaffolded into the target repo
 
-| from `templates/` | to the target repo |
+| from `${CLAUDE_PLUGIN_ROOT}/agentify/templates/` | to the target repo |
 |---|---|
 | `autonomous-repo.config.yml.tmpl` | `autonomous-repo.config.yml` (the only file the adopter owns) |
 | `runtime-skill/**` | `.claude/skills/autonomous-repo/**` |
@@ -42,7 +46,7 @@ the framework runs on.
    recommended), `ANS_APPROVER_ADDRESS`, `ANS_VERIFY_SETUP_SCRIPT`. (The bot
    login can be filled later from the checklist; secrets are never gathered
    here.)
-3. **Render.** Run `agentify-render.sh --to <target-repo-root>`. It fills
+3. **Render.** Run `"${CLAUDE_PLUGIN_ROOT}/agentify/agentify-render.sh" --to <target-repo-root>`. It fills
    `autonomous-repo.config.yml` from the `ANS_*` answers (failing loudly on
    any unfilled placeholder) and scaffolds the runtime skill, the scripts,
    and the four workflows into their real paths
@@ -52,7 +56,8 @@ the framework runs on.
    `always_hitl`, the filled `bot_login`) — pass `--force` only to regenerate
    the config. Then **tune** the rendered config's `always_hitl` list for the
    product's sensitive surfaces, and sanity-check: `scripts/*.sh _selftest`
-   all green and the config parses. **Optional addons** (`templates/addons/`)
+   all green and the config parses. **Optional addons**
+   (`${CLAUDE_PLUGIN_ROOT}/agentify/templates/addons/`)
    — e.g. `submit-feedback-mcp` (a `submit_feedback` MCP tool that
    email-bridges into the support mailbox) — are opted in via
    `ANS_ADDONS="<name> ..."`; the render scaffolds each to `tools/<name>/` and
@@ -81,8 +86,10 @@ variable to pause everything. Run the loop interactively any time with the
 
 ## References
 
-- `references/setup-checklist.md` — the one-time identity/secret setup.
-- `references/adapters.md` — the TicketStore / CommsChannel / Intake
-  adapter contracts and which are implemented.
-- `references/security-invariants.md` — the defaults an adopter must not
-  misconfigure away.
+(all under `${CLAUDE_PLUGIN_ROOT}/agentify/references/`)
+
+- `setup-checklist.md` — the one-time identity/secret setup.
+- `adapters.md` — the TicketStore / CommsChannel / Intake adapter contracts
+  and which are implemented.
+- `security-invariants.md` — the defaults an adopter must not misconfigure
+  away.


### PR DESCRIPTION
## What

Makes `/agentify` **installable** — it ships as a second skill in the e2a Claude Code plugin, alongside the existing `skills/e2a/`. Before this, the deploy flow was copy-only (drop the directory into `~/.claude/skills/`).

## How it works

- New skill at **`plugins/e2a/skills/agentify/SKILL.md`** (auto-discovered — no `plugin.json` change needed for skills).
- The scaffolder + templates **stay at `plugins/e2a/agentify/`** (so the CI workflows + test suite are untouched); the skill references them via **`${CLAUDE_PLUGIN_ROOT}/agentify/`**. The whole plugin ships to the local install cache, so the bundled `agentify-render.sh` / `templates/` / `references/` resolve at runtime.
- Plugin **version bumped `0.3.2 → 0.4.0`** across all six manifests (`.claude` / `.codex` / `.cursor` `plugin.json` + the claude/cursor marketplace metadata) so `scripts/validate-plugin.mjs` stays in sync.

## Install

```
/plugin marketplace add Mnexa-AI/e2a
/plugin install e2a
```
→ `/agentify` is available (alongside the e2a MCP tools), which then scaffolds the feedback-loop framework into a target repo.

## Validation
- `node scripts/validate-plugin.mjs` → ✓ 2 skills, manifests in sync
- the agentify test suite still passes (only the SKILL.md moved; tooling/tests unchanged)

Confirmed the plugin mechanics against the official docs first: the whole plugin source is copied to `~/.claude/plugins/cache` on install, and `${CLAUDE_PLUGIN_ROOT}` resolves to that path — so a skill can reference sibling plugin files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
