### PR TITLE
fix(readme): make wordmark visible in GitHub dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 <div align="center">
 
-<img src="assets/e2a-wordmark.png" width="320" alt="e2a">
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="assets/e2a-wordmark-dark.svg">
+  <img src="assets/e2a-wordmark-light.svg" width="320" alt="e2a">
+</picture>
 
 ### Give your AI agents a real, authenticated email address.
 

--- a/assets/e2a-wordmark-dark.svg
+++ b/assets/e2a-wordmark-dark.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="200" viewBox="0 0 640 200" role="img" aria-label="e2a">
+  <text x="320" y="148" text-anchor="middle" font-family="Geist, 'Inter', ui-sans-serif, system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif" font-weight="600" font-size="176" letter-spacing="-12" fill="#E8E3D8"><tspan>e</tspan><tspan fill="#E08A60">2</tspan><tspan>a</tspan></text>
+</svg>

--- a/assets/e2a-wordmark-light.svg
+++ b/assets/e2a-wordmark-light.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="640" height="200" viewBox="0 0 640 200" role="img" aria-label="e2a">
+  <text x="320" y="148" text-anchor="middle" font-family="Geist, 'Inter', ui-sans-serif, system-ui, -apple-system, 'Helvetica Neue', Arial, sans-serif" font-weight="600" font-size="176" letter-spacing="-12" fill="#1A1714"><tspan>e</tspan><tspan fill="#C56C42">2</tspan><tspan>a</tspan></text>
+</svg>


### PR DESCRIPTION
## Problem

The README hero used `assets/e2a-wordmark.png` — dark text on a transparent background — so on GitHub's **dark theme** the logo was invisible (see the black-on-black hero).

## Fix

Switch to GitHub's official theme-adaptive `<picture>` pattern with two transparent SVG wordmarks that mirror the existing brand geometry/font (`web/public/logo-wordmark*.svg`), differing only in fill:

- `assets/e2a-wordmark-light.svg` — dark ink (`#1A1714` + `#C56C42`) for **light** mode
- `assets/e2a-wordmark-dark.svg` — cream (`#E8E3D8` + `#E08A60`) for **dark** mode

```html
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="assets/e2a-wordmark-dark.svg">
  <img src="assets/e2a-wordmark-light.svg" width="320" alt="e2a">
</picture>
```

Both SVGs validate as XML. The wordmark is now visible and on-brand in both themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)