### PR TITLE
docs(readme): polish pass — GA notice, lead with Quickstart, two-way diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,7 @@ What you get on top of bare SMTP:
 
 ## Quickstart
 
-### Use it with your AI agent (recommended)
-
-Install the e2a plugin — it registers the hosted [MCP server](#mcp-server) and an operate-well skill, so your agent can send, receive, reply in-thread, and hold mail for review out of the box. On first tool use it runs an OAuth flow in your browser — no API key to paste.
+The fastest path is to give your AI agent an inbox directly. Install the e2a plugin — it registers the hosted [MCP server](#mcp-server) and an operate-well skill, so your agent can send, receive, reply in-thread, and hold mail for review out of the box. On first tool use it runs an OAuth flow in your browser — no API key to paste.
 
 **Claude Code**
 
@@ -68,67 +66,12 @@ Then launch `codex`, run `/plugins`, and install **e2a**.
 
 **Other MCP clients** (Zed, Goose, Windsurf, Claude Desktop, raw `mcp.json`) — point straight at `https://api.e2a.dev/mcp`; ready-to-paste configs are in [plugins/e2a/clients/](plugins/e2a/clients). See [plugins/e2a/README.md](plugins/e2a/README.md) for the full per-client guide.
 
-### Self-host (Docker)
-
-Requires Docker.
-
-```bash
-git clone https://github.com/Mnexa-AI/e2a.git
-cd e2a
-docker compose up -d
-```
-
-Postgres comes up first (migrations run automatically), then the API server, then the dashboard. Three host ports:
-
-- `:8080` — HTTP API
-- `:2525` — SMTP relay
-- `:3000` — Dashboard (Caddy + Next.js, proxies `/api/*` to the API server)
-
-Health check:
-
-```bash
-curl http://localhost:8080/api/health
-# {"status":"ok"}
-```
-
-Open `http://localhost:3000` in a browser to view the dashboard. Sign-in requires Google OAuth credentials configured in `config.yaml`; for an API-only smoke test you can skip the dashboard and use the bootstrap flow below.
-
-Create your first user and API key (no OAuth required):
-
-```bash
-docker compose exec e2a e2a -config /etc/e2a/config.yaml -bootstrap-email you@example.com
-# User:    you@example.com (id=...)
-# API key: e2a_...
-```
-
-Save the key — it's only shown once. Register an agent and confirm it works:
-
-```bash
-KEY=e2a_...
-curl -X POST http://localhost:8080/v1/agents \
-  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
-  -d '{"email":"my-bot@agents.e2a.dev"}'   # an email on the deployment shared domain (or a domain you've verified)
-
-curl -H "Authorization: Bearer $KEY" http://localhost:8080/v1/agents
-```
-
-To receive real inbound mail, point a domain's MX record at your relay host:
-
-- **A**: `your-domain.com` → server IP
-- **MX**: `your-domain.com` → `your-domain.com` (priority 10)
-
-Then register and verify the domain through the API (see [Domains](docs/api.md)). Without DNS, the API still works for testing — but external email won't reach your relay.
-
-> **Upgrades and migrations.** The e2a binary embeds `migrations/*.sql` and **auto-applies any pending ones at startup** (tracked in a `schema_migrations` table). When you upgrade e2a, restarting the container applies new schema migrations automatically — no manual step. `E2A_MIGRATION_MODE` controls this: `auto` (default, applies pending), `verify` (refuse startup and report pending), or `skip` (emergency surgery). Migrations are idempotent and non-destructive, so re-applying is safe.
->
-> (The compose file also mounts `migrations/` into Postgres' init directory, but that path only runs on first start with an empty data volume — the binary's startup auto-apply is what keeps an upgraded deployment current.)
-
 ## Use it
 
 You can either use the hosted instance or self-host.
 
 - **Hosted** — sign up at [e2a.dev](https://e2a.dev). Includes the shared `agents.e2a.dev` domain for instant slug-based onboarding (no DNS setup), a dashboard, the hosted MCP server, and managed deliverability.
-- **Self-host** — see [Quickstart](#quickstart) and [Deployment](#deployment). Every feature works the same; the shared-domain slug shortcut just needs you to point a mail domain at your relay and set `shared_domain` in `config.yaml`.
+- **Self-host** — see [Self-host (Docker)](#self-host-docker) and [Deployment](#deployment). Every feature works the same; the shared-domain slug shortcut just needs you to point a mail domain at your relay and set `shared_domain` in `config.yaml`.
 
 ## How it works
 
@@ -452,6 +395,61 @@ make migrate             # apply SQL migrations to local DB
 ```
 
 See [CLAUDE.md](CLAUDE.md) for the full developer guide (architecture, tests, code generation, conventions).
+
+## Self-host (Docker)
+
+Requires Docker.
+
+```bash
+git clone https://github.com/Mnexa-AI/e2a.git
+cd e2a
+docker compose up -d
+```
+
+Postgres comes up first (migrations run automatically), then the API server, then the dashboard. Three host ports:
+
+- `:8080` — HTTP API
+- `:2525` — SMTP relay
+- `:3000` — Dashboard (Caddy + Next.js, proxies `/api/*` to the API server)
+
+Health check:
+
+```bash
+curl http://localhost:8080/api/health
+# {"status":"ok"}
+```
+
+Open `http://localhost:3000` in a browser to view the dashboard. Sign-in requires Google OAuth credentials configured in `config.yaml`; for an API-only smoke test you can skip the dashboard and use the bootstrap flow below.
+
+Create your first user and API key (no OAuth required):
+
+```bash
+docker compose exec e2a e2a -config /etc/e2a/config.yaml -bootstrap-email you@example.com
+# User:    you@example.com (id=...)
+# API key: e2a_...
+```
+
+Save the key — it's only shown once. Register an agent and confirm it works:
+
+```bash
+KEY=e2a_...
+curl -X POST http://localhost:8080/v1/agents \
+  -H "Authorization: Bearer $KEY" -H "Content-Type: application/json" \
+  -d '{"email":"my-bot@agents.e2a.dev"}'   # an email on the deployment shared domain (or a domain you've verified)
+
+curl -H "Authorization: Bearer $KEY" http://localhost:8080/v1/agents
+```
+
+To receive real inbound mail, point a domain's MX record at your relay host:
+
+- **A**: `your-domain.com` → server IP
+- **MX**: `your-domain.com` → `your-domain.com` (priority 10)
+
+Then register and verify the domain through the API (see [Domains](docs/api.md)). Without DNS, the API still works for testing — but external email won't reach your relay.
+
+> **Upgrades and migrations.** The e2a binary embeds `migrations/*.sql` and **auto-applies any pending ones at startup** (tracked in a `schema_migrations` table). When you upgrade e2a, restarting the container applies new schema migrations automatically — no manual step. `E2A_MIGRATION_MODE` controls this: `auto` (default, applies pending), `verify` (refuse startup and report pending), or `skip` (emergency surgery). Migrations are idempotent and non-destructive, so re-applying is safe.
+>
+> (The compose file also mounts `migrations/` into Postgres' init directory, but that path only runs on first start with an empty data volume — the binary's startup auto-apply is what keeps an upgraded deployment current.)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Receive inbound over **webhook · WebSocket · REST · MCP**. Send through an **
 
 ---
 
+> [!IMPORTANT]
+> **e2a v1.0 reaches GA in mid-July 2026.** The `/v1` API and SDKs are in release-candidate shape today — any breaking changes land *before* GA, after which the interface is stable. Pin your SDK versions and watch [Releases](https://github.com/Mnexa-AI/e2a/releases).
+
 e2a is an **authenticated email gateway for AI agents**. It receives inbound mail, verifies the sender (SPF/DKIM), and delivers it to your agent as structured data with HMAC-signed `X-E2A-Auth-*` headers — over whichever channel fits your runtime. Outbound goes back out through an HTTP API, with an optional human-in-the-loop approval gate.
 
 **Four ways to plug an agent in:**

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Inbound mail reaches you several complementary ways — **chosen per integration
 
 Notifications carry lightweight metadata (message id, sender, subject); you fetch the full body + attachments over REST when you want them. A disconnected WebSocket client accumulates "unread" messages; on reconnect, the server drains them as notifications.
 
-Webhooks are an **account-level resource** (`/v1/webhooks`), chosen per integration rather than configured on the agent — the legacy per-agent `agent_mode` / `webhook_url` fields were removed.
+Webhooks are an **account-level resource** (`/v1/webhooks`), chosen per integration rather than configured on the agent.
 
 ### Auth headers
 

--- a/README.md
+++ b/README.md
@@ -334,7 +334,7 @@ Four things that aren't possible to bolt on without significant rework:
 
 2. **Conversation threading on every reply.** Whether a human replies from Gmail or another e2a agent replies via the API, the inbound message arrives at the agent with a stable `conversation_id` already mapped to the original thread. For human senders, the relay does standard `In-Reply-To` / `References` lookup scoped to the recipient agent's own messages. For agent-to-agent where both sides are on e2a, it also trusts an `X-E2A-Conversation-Id` header it controls (envelope-from is its own domain), which survives clients that rewrite threading headers. SendGrid/Resend never see inbound mail — they aren't receivers — so neither path is available without you building both yourself.
 
-3. **Slug provisioning on a shared domain.** Operators set `shared_domain: agents.e2a.dev` and users `POST {"slug": "my-agent"}` to immediately get `my-agent@agents.e2a.dev` with no DNS configuration. Possible because e2a *is* the SMTP relay claiming the domain — Resend / SendGrid are providers, not platforms, and can't multi-tenant a shared address space without you running the relay yourself.
+3. **Slug provisioning on a shared domain.** Operators set `shared_domain: agents.e2a.dev` and users `POST {"email": "my-agent@agents.e2a.dev"}` to immediately register an agent on the shared domain with no DNS configuration. Possible because e2a *is* the SMTP relay claiming the domain — Resend / SendGrid are providers, not platforms, and can't multi-tenant a shared address space without you running the relay yourself.
 
 4. **Built-in review hold + auto-expiration.** A per-agent protection policy (outbound gate action `review`, or the content scan) holds mail in `pending_review` state. Reviewers approve via dashboard, magic-link email, the MCP tools, or the API; a background worker auto-acts on expired holds based on the `holds.on_expiry` config. Magic-link tokens are HMAC-encoded — stateless, no session backend. With Resend / SendGrid you'd hold the message in your own DB, build the timer, the approval UI, and the stateless review tokens.
 
@@ -348,11 +348,11 @@ e2a doesn't replace webhooks or MCP — your agent *receives* email through them
 
 ### What stops an attacker from spoofing the `X-E2A-Auth-*` headers?
 
-The relay strips any incoming `X-E2A-Auth-*` from inbound messages and re-signs with HMAC-SHA256 against `signing.hmac_secret`. The signed canonical binds `Sender + Verified + Body-Hash + Message-Id` together — replay attempts, body swaps, and sender-only forgery all fail validation. Each delivery is bound to *that specific message body*, not just the sender claim, so a captured `(headers, signature)` tuple can't be lifted onto a different message.
+The relay never trusts inbound `X-E2A-Auth-*` headers — it derives the auth claim from scratch and signs it with HMAC-SHA256 against `signing.hmac_secret`, so any values a sender injects are ignored (read the signed `auth_headers` field, not raw message headers). The signed canonical binds `Sender + Verified + Body-Hash + Message-Id` together — replay attempts, body swaps, and sender-only forgery all fail validation. Each delivery is bound to *that specific message body*, not just the sender claim, so a captured `(headers, signature)` tuple can't be lifted onto a different message.
 
 For a **webhook subscriber**, though, the protection you actually rely on is the delivery's **envelope signature** (`X-E2A-Signature`, verified with your `whsec_`): a forged POST to your URL fails envelope verification regardless of what `X-E2A-Auth-*` values it carries. The inner re-signing above is for the *relayed-header* trust model — consumers that hold the deployment HMAC secret and receive `X-E2A-Auth-*` as message headers — which a `/v1/webhooks` subscriber is not.
 
-Receivers verify with the SDK — `construct_event(body, header, secret)` / `constructEvent(body, header, secret)` does parse + HMAC verify in one call (or `verify_webhook_signature(...)` / `verifyWebhookSignature(...)` if you only need the boolean check). No API call back to e2a needed. If a signing secret leaks, rotate it via the dashboard and old signatures stop verifying. If it's *stolen from the relay*, the attacker has bigger access than headers anyway.
+Receivers verify with the SDK — `construct_event(body, header, secret)` / `constructEvent(body, header, secret)` does parse + HMAC verify in one call (or `verify_webhook_signature(...)` / `verifyWebhookSignature(...)` if you only need the boolean check). No API call back to e2a needed. If a signing secret leaks, rotate it via the dashboard; the previous secret keeps verifying through a 24h grace window, then stops. If it's *stolen from the relay*, the attacker has bigger access than headers anyway.
 
 ### Isn't this just SMTP with extra steps?
 
@@ -379,7 +379,7 @@ Two reasons:
 1. **Auditability.** Identity infrastructure for your agents should be readable code, not a vendor black box. You can verify the cosign signature on `ghcr.io/mnexa-ai/e2a`, reproduce the build, and confirm what's actually running.
 2. **Self-host as a real option.** The hosted instance at e2a.dev runs the same `ghcr.io/mnexa-ai/e2a` image you can pull right now. Convenience features on the hosted side (the shared `agents.e2a.dev` domain, managed deliverability) are config + DNS, not closed-source extras.
 
-The hosted version at [e2a.dev](https://e2a.dev) has paid tiers (a free tier plus paid plans); billing is opt-in via env var on the hosted side and the OSS code path stays unchanged — self-hosting has no quotas or billing.
+The hosted version at [e2a.dev](https://e2a.dev) has paid tiers (a free tier plus paid plans); billing is opt-in on the hosted side — config (settable via env) points the OSS server at an external limits/billing sidecar, and the OSS code path stays unchanged. Self-hosting runs on generous default limits with no billing.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -133,23 +133,22 @@ You can either use the hosted instance or self-host.
 ## How it works
 
 ```
-Human (Gmail/Outlook)
-    │
-    ▼ SMTP
-┌──────────────┐
-│  e2a relay   │  ← MX record for your agent domain points here
-│              │
-│  1. Verify   │  ← SPF/DKIM check on the inbound message
-│  2. Sign     │  ← HMAC-signed X-E2A-Auth-* headers
-│  3. Deliver  │
-└──────────────┘
-    │
-    ├──▶ Webhook subscription: HTTPS POST to your endpoint
-    │
-    └──▶ Store → agent fetches over WebSocket, REST poll, or MCP tools (no public URL)
-              │
-              ▼
-         e2a listen (CLI) · client.listen() (SDK) · list_messages (MCP)
+   Human (Gmail/Outlook)  ·  another e2a agent
+          │   ▲
+  inbound │   │ outbound
+    SMTP  ▼   │ upstream SMTP (to humans) / relay (to agents)
+   ┌───────────────┐
+   │   e2a relay   │  ← MX for your agent domain points here
+   │               │
+   │   inbound  ↓  │  ← verify (SPF/DKIM) · sign (X-E2A-Auth-*) · deliver
+   │   outbound ↑  │  ← optional HITL hold · send
+   └───────────────┘
+          │   ▲
+  deliver │   │ send · reply · forward (HTTP API)
+          ▼   │
+   ┌───────────────┐
+   │   your agent  │  ← webhook / WebSocket / REST poll / MCP · SDK · CLI
+   └───────────────┘
 ```
 
 Inbound flow: SMTP → SPF/DKIM check → agent lookup → HMAC-sign auth headers → webhook / WebSocket / REST / MCP delivery.

--- a/README.md
+++ b/README.md
@@ -43,39 +43,6 @@ What you get on top of bare SMTP:
 - **Human in the loop** — opt-in approval gate that holds outbound mail until a reviewer approves via dashboard, magic-link email, the MCP tools, or the API
 - **Conversation threading** — a stable `conversation_id` that survives the email ↔ structured-data boundary
 
-## Use it
-
-You can either use the hosted instance or self-host.
-
-- **Hosted** — sign up at [e2a.dev](https://e2a.dev). Includes the shared `agents.e2a.dev` domain for instant slug-based onboarding (no DNS setup), a dashboard, the hosted MCP server, and managed deliverability.
-- **Self-host** — see [Quickstart](#quickstart) and [Deployment](#deployment). Every feature works the same; the shared-domain slug shortcut just needs you to point a mail domain at your relay and set `shared_domain` in `config.yaml`.
-
-## How it works
-
-```
-Human (Gmail/Outlook)
-    │
-    ▼ SMTP
-┌──────────────┐
-│  e2a relay   │  ← MX record for your agent domain points here
-│              │
-│  1. Verify   │  ← SPF/DKIM check on the inbound message
-│  2. Sign     │  ← HMAC-signed X-E2A-Auth-* headers
-│  3. Deliver  │
-└──────────────┘
-    │
-    ├──▶ Webhook subscription: HTTPS POST to your endpoint
-    │
-    └──▶ Store → agent fetches over WebSocket, REST poll, or MCP tools (no public URL)
-              │
-              ▼
-         e2a listen (CLI) · client.listen() (SDK) · list_messages (MCP)
-```
-
-Inbound flow: SMTP → SPF/DKIM check → agent lookup → HMAC-sign auth headers → webhook / WebSocket / REST / MCP delivery.
-
-Outbound flow: API call → optional HITL hold → SMTP relay (agent-to-agent) or upstream SMTP (agent-to-human).
-
 ## Quickstart
 
 ### Use it with your AI agent (recommended)
@@ -155,6 +122,39 @@ Then register and verify the domain through the API (see [Domains](docs/api.md))
 > **Upgrades and migrations.** The e2a binary embeds `migrations/*.sql` and **auto-applies any pending ones at startup** (tracked in a `schema_migrations` table). When you upgrade e2a, restarting the container applies new schema migrations automatically — no manual step. `E2A_MIGRATION_MODE` controls this: `auto` (default, applies pending), `verify` (refuse startup and report pending), or `skip` (emergency surgery). Migrations are idempotent and non-destructive, so re-applying is safe.
 >
 > (The compose file also mounts `migrations/` into Postgres' init directory, but that path only runs on first start with an empty data volume — the binary's startup auto-apply is what keeps an upgraded deployment current.)
+
+## Use it
+
+You can either use the hosted instance or self-host.
+
+- **Hosted** — sign up at [e2a.dev](https://e2a.dev). Includes the shared `agents.e2a.dev` domain for instant slug-based onboarding (no DNS setup), a dashboard, the hosted MCP server, and managed deliverability.
+- **Self-host** — see [Quickstart](#quickstart) and [Deployment](#deployment). Every feature works the same; the shared-domain slug shortcut just needs you to point a mail domain at your relay and set `shared_domain` in `config.yaml`.
+
+## How it works
+
+```
+Human (Gmail/Outlook)
+    │
+    ▼ SMTP
+┌──────────────┐
+│  e2a relay   │  ← MX record for your agent domain points here
+│              │
+│  1. Verify   │  ← SPF/DKIM check on the inbound message
+│  2. Sign     │  ← HMAC-signed X-E2A-Auth-* headers
+│  3. Deliver  │
+└──────────────┘
+    │
+    ├──▶ Webhook subscription: HTTPS POST to your endpoint
+    │
+    └──▶ Store → agent fetches over WebSocket, REST poll, or MCP tools (no public URL)
+              │
+              ▼
+         e2a listen (CLI) · client.listen() (SDK) · list_messages (MCP)
+```
+
+Inbound flow: SMTP → SPF/DKIM check → agent lookup → HMAC-sign auth headers → webhook / WebSocket / REST / MCP delivery.
+
+Outbound flow: API call → optional HITL hold → SMTP relay (agent-to-agent) or upstream SMTP (agent-to-human).
 
 ## Concepts
 


### PR DESCRIPTION
README polish pass (three changes):

**1. Pre-GA notice** — a `> [!IMPORTANT]` banner under the hero:
> **e2a v1.0 reaches GA in mid-July 2026.** The `/v1` API and SDKs are in release-candidate shape today — any breaking changes land *before* GA, after which the interface is stable. Pin your SDK versions and watch Releases.

Soft timeline (no hard date to slip on) + RC framing so early adopters pin. Swap to a GA announcement on launch day.

**2. Lead with Quickstart** — move `## Quickstart` above `## Use it` / `## How it works` so first-time readers hit the get-started path first. New order: Quickstart → Use it → How it works → Concepts.

**3. Two-way How-it-works diagram** — the ASCII diagram now shows the **outbound** path too: two lanes between external senders / e2a relay / your agent — inbound down (SMTP → verify/sign/deliver → webhook/WS/REST/MCP), outbound up (HTTP API send/reply/forward → optional HITL hold → upstream SMTP or relay).

🤖 Generated with [Claude Code](https://claude.com/claude-code)