### PR TITLE
docs(agentify): mark the skill Beta + bump plugin to 0.4.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "e2a plugins for Claude Code — authenticated email for AI agents",
-    "version": "0.4.0"
+    "version": "0.4.1"
   },
   "plugins": [
     {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "e2a — authenticated email gateway for AI agents (MCP server + operate-well skill).",
-    "version": "0.4.0"
+    "version": "0.4.1"
   },
   "plugins": [
     {

--- a/plugins/e2a/.claude-plugin/plugin.json
+++ b/plugins/e2a/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 37 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "Mnexa AI",

--- a/plugins/e2a/.codex-plugin/plugin.json
+++ b/plugins/e2a/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 37 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "Mnexa AI"

--- a/plugins/e2a/.cursor-plugin/plugin.json
+++ b/plugins/e2a/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 37 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "Mnexa AI",

--- a/plugins/e2a/skills/agentify/SKILL.md
+++ b/plugins/e2a/skills/agentify/SKILL.md
@@ -1,9 +1,12 @@
 ---
 name: agentify
-description: Deploy the autonomous-repo feedback loop into a GitHub repo. Scaffolds the lane workflows, the runtime skill, and one config file as a reviewed PR, then prints the one-time identity/secret setup checklist. Turns a repo into one that triages incoming feedback into issues and prepares human-gated fix PRs. Use when someone wants to make a repo self-managing / "agentify" it / install the feedback loop.
+description: Beta — Deploy the autonomous-repo feedback loop into a GitHub repo. Scaffolds the lane workflows, the runtime skill, and one config file as a reviewed PR, then prints the one-time identity/secret setup checklist. Turns a repo into one that triages incoming feedback into issues and prepares human-gated fix PRs. Use when someone wants to make a repo self-managing / "agentify" it / install the feedback loop.
 ---
 
 # agentify — deploy the autonomous-repo feedback loop
+
+> **Beta.** This skill is under active development; the setup flow may
+> change and a lower-friction "express" onboarding is being explored.
 
 `/agentify` installs the framework into a target repo: feedback in →
 triaged GitHub issue → human-gated fix PR → filer notified. It **bundles the


### PR DESCRIPTION
Flags the `agentify` skill as **Beta** while its onboarding flow is still evolving (a lower-friction "express" setup is being explored), and bumps the plugin version so the label actually reaches installs.

### 1. Mark agentify Beta (`plugins/e2a/skills/agentify/SKILL.md`)
- **`description`** now leads with `Beta —` — the string the model reads to decide when to trigger the skill and what surfaces in skill listings (the only beta signal with user-visible reach).
- **A Beta callout** under the H1 so anyone reading/running the skill sees the caveat.

There is no functional `beta` flag in the skill schema, so this labeling is the effective mechanism.

### 2. Bump plugin `0.4.0` → `0.4.1` (five manifests)
Installs load skills from a **version-pinned cache** (`~/.claude/plugins/cache/e2a/e2a/<version>/`), so a same-version source edit is invisible to anyone already on `0.4.0`. Bumping the version is the cache-busting signal that lets clients detect + fetch the new copy (with the Beta label) on their next update. Bumped:
- `plugins/e2a/.claude-plugin/plugin.json`
- `plugins/e2a/.cursor-plugin/plugin.json`
- `plugins/e2a/.codex-plugin/plugin.json`
- `.claude-plugin/marketplace.json`
- `.cursor-plugin/marketplace.json`

(`.agents/plugins/marketplace.json` has no version field — left untouched.)

**Propagation caveat:** the bump *enables* propagation but isn't an instant push — it still needs the plugin/marketplace republished and each user to update. New installs and updaters get the Beta label; anyone who never updates stays on `0.4.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)