### PR TITLE
feat(plugin): add the tether skill — email handoff for long-running sessions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "e2a plugins for Claude Code — authenticated email for AI agents",
-    "version": "0.4.1"
+    "version": "0.4.2"
   },
   "plugins": [
     {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "e2a — authenticated email gateway for AI agents (MCP server + operate-well skill).",
-    "version": "0.4.1"
+    "version": "0.4.2"
   },
   "plugins": [
     {

--- a/plugins/e2a/.claude-plugin/plugin.json
+++ b/plugins/e2a/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 37 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "Mnexa AI",

--- a/plugins/e2a/.codex-plugin/plugin.json
+++ b/plugins/e2a/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 37 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "Mnexa AI"

--- a/plugins/e2a/.cursor-plugin/plugin.json
+++ b/plugins/e2a/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 37 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "Mnexa AI",

--- a/plugins/e2a/README.md
+++ b/plugins/e2a/README.md
@@ -53,6 +53,8 @@ plugins/e2a/
 ├── .mcp.json                    # the hosted MCP server (single source of truth)
 ├── assets/icon.svg
 ├── skills/e2a/SKILL.md          # the "operate-well" skill (surfaces as /e2a)
+├── skills/agentify/SKILL.md     # deploy the autonomous-repo feedback loop (/agentify)
+├── skills/tether/SKILL.md       # email handoff for long-running sessions (/tether)
 └── clients/                     # manual paste-in configs for non-plugin clients
 ```
 

--- a/plugins/e2a/skills/tether/SKILL.md
+++ b/plugins/e2a/skills/tether/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: tether
+description: Beta — Stay in the loop over email during a long-running coding session. The agent sends threaded status updates to your inbox as it sees fit and picks up your emailed replies (questions/instructions) within a few minutes, so you can steer a working agent while AFK. Transport is e2a. Use when you want to walk away from a session but keep commanding it from your inbox.
+---
+
+# tether — steer a long-running session from your inbox
+
+> **Beta.** The transport (e2a) and the flow are real; polish (adaptive
+> backoff, richer digests) is still open.
+
+`/tether` keeps you connected to a working session over email. The agent emails
+you updates **when it judges there's something worth reporting** (not on a
+timer, not every turn), and checks your inbox on an interval so your replies —
+questions or new instructions — are picked up within a few minutes. Reply
+`stop` to end.
+
+## Architecture (why this shape)
+
+Coding agents are turn-based; nothing native listens to an inbox mid-session. So
+the two directions use different mechanisms:
+
+- **Send = agent-driven.** The agent calls `tether.sh update "…"` at meaningful
+  moments (finished a slice, hit a blocker, needs a decision). Cadence is the
+  model's judgment → no per-turn spam, nothing to throttle.
+- **Receive = poll-driven.** The agent calls `tether.sh poll` on an interval to
+  fetch replies. **Keep the session alive with `/loop`** so polling continues
+  while the agent would otherwise be idle — this is the only way a reply sent
+  *after* the agent goes idle gets picked up (no hook fires while idle).
+- **Blocked-alert = hook (optional).** A `Notification` hook emails you when the
+  agent is stuck on a permission prompt and can't proceed at all.
+
+## Setup (once)
+
+```bash
+cp "${CLAUDE_PLUGIN_ROOT}/skills/tether/tether.env.example" ~/.e2a-tether.env
+chmod 600 ~/.e2a-tether.env    # fill E2A_API_KEY + E2A_AGENT_EMAIL (agent protection OFF)
+# optional blocked-alert hook:
+"${CLAUDE_PLUGIN_ROOT}/skills/tether/install.sh" --to <repo-root>
+```
+
+> The tether agent must have send-side protection / HITL **off**, or each update
+> is held as an approval email instead of reaching you. `tether.sh` warns on
+> stderr if it sees `pending_review`.
+
+## Runtime flow (what the agent does when `/tether` is invoked)
+
+Let `T="${CLAUDE_PLUGIN_ROOT}/skills/tether/tether.sh"`.
+
+1. **Ask** the user's email address.
+2. **Start**: `"$T" start <email>` — sends the intro email, opens the thread, arms.
+3. **Work**, and **send updates as you see fit**: `"$T" update "<what changed / what you need>"`.
+   Good moments: finished a slice, made a decision that's worth surfacing, hit a
+   blocker, or before a long unattended stretch. Skip trivial turns.
+4. **Poll on an interval**: run `"$T" poll`; if it prints a reply, treat it as a
+   new instruction and act on it (then `update` with the result). To keep polling
+   while idle, run the session under **`/loop <interval>`** (or self-schedule the
+   next poll). See the interval guidance below.
+5. **Stop** when the user replies `stop`/`done`, or the work is complete:
+   `"$T" stop`.
+
+## Interval guidance
+
+The poll interval is the reply latency while the agent is idle, traded against
+token cost (each tick is a turn). Recommended:
+
+| situation | interval |
+|---|---|
+| **Attended-ish / expecting a reply soon** (just sent an update) | **2–3 min** |
+| **Default** | **3 min** |
+| **Fully AFK, latency-tolerant** | **5–10 min** |
+| floor (Claude Code `/loop` minimum) | 1 min |
+
+Nice-to-have (adaptive backoff): poll every ~2 min right after sending an
+update, then back off toward ~10 min after prolonged silence — responsive when a
+reply is likely, cheap when it isn't. While the agent is actively working it also
+catches replies at natural checkpoints, so the interval mainly governs the idle
+gap.
+
+## Durability note
+
+`/loop` keeps the session alive only while the terminal is open. To keep
+listening after you close the laptop, the always-on path is an **e2a webhook
+firing a cloud Routine** — but that runs a *fresh* session (loses the live
+working context). Left as a follow-on.
+
+## Files
+
+| file | role |
+|---|---|
+| `tether.sh` | runtime CLI: `start` / `update` / `poll` / `status` / `stop` |
+| `lib.sh` | config + e2a send/reply/poll helpers |
+| `hooks/tether-notify.sh` | optional Notification hook (blocked-alert) |
+| `install.sh` | wire/unwire the Notification hook; `_selftest` |
+| `tether.env.example` | credentials template |

--- a/plugins/e2a/skills/tether/hooks/tether-notify.sh
+++ b/plugins/e2a/skills/tether/hooks/tether-notify.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# tether-notify.sh — optional Claude Code Notification hook.
+#
+# Fires when the agent is blocked (needs permission) or goes idle. If a tether
+# is armed, it emails you into the thread so you know the agent wants attention
+# even when you're away. No-ops when not armed / not configured. Always exits 0.
+set -uo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+. "${here}/../lib.sh"
+
+payload="$(cat)"
+message="$(printf '%s' "$payload" | python3 -c 'import json,sys
+try:print(json.load(sys.stdin).get("message","") or "")
+except Exception:print("")')"
+[ -n "$message" ] || message="The agent needs your attention."
+
+t_load_config || exit 0
+[ "$(t_state_get armed)" = "1" ] || exit 0
+
+rid="$(t_state_get last_message_id)"
+[ -n "$rid" ] || exit 0
+t_api_reply "$rid" "⏸️ Needs you: ${message}
+
+Reply to this thread and I'll pick it up at the next check." >/dev/null 2>&1 || true
+exit 0

--- a/plugins/e2a/skills/tether/install.sh
+++ b/plugins/e2a/skills/tether/install.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# install.sh — optional: wire the Notification hook into a repo's
+# .claude/settings.local.json. Sending/receiving need NO hook (the agent calls
+# tether.sh directly), so this is only for the "agent is blocked, email me"
+# alert. Idempotent.
+#
+#   install.sh [--to <repo-root>]      # default: current directory
+#   install.sh --uninstall [--to <repo-root>]
+#   install.sh _selftest
+set -euo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+notify="${here}/hooks/tether-notify.sh"
+
+target="$PWD"; mode="install"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --to) target="$2"; shift 2;;
+    --uninstall) mode="uninstall"; shift;;
+    _selftest) mode="selftest"; shift;;
+    *) echo "unknown arg: $1" >&2; exit 2;;
+  esac
+done
+
+if [ "$mode" = "selftest" ]; then
+  bash "${here}/tether.sh" _selftest
+  printf '{"message":"x"}' | env -u E2A_API_KEY -u E2A_AGENT_EMAIL HOME=/nonexistent \
+    TETHER_STATE=/tmp/tether-notify-selftest.json bash "$notify" && echo "# notify hook OK (exit 0)"
+  rm -f /tmp/tether-notify-selftest.json
+  exit 0
+fi
+
+settings="${target}/.claude/settings.local.json"
+mkdir -p "${target}/.claude"
+[ -f "$settings" ] || echo '{}' > "$settings"
+
+NOTIFY="$notify" MODE="$mode" python3 - "$settings" <<'PY'
+import json,os,sys
+f=sys.argv[1];d=json.load(open(f));notify=os.environ["NOTIFY"];mode=os.environ["MODE"]
+hooks=d.setdefault("hooks",{})
+hooks["Notification"]=[g for g in hooks.get("Notification",[])
+                       if not any(h.get("command")==notify for h in g.get("hooks",[]))]
+if not hooks["Notification"]:del hooks["Notification"]
+if mode=="install":
+    hooks.setdefault("Notification",[]).append({"hooks":[{"type":"command","command":notify}]})
+if not hooks:d.pop("hooks",None)
+json.dump(d,open(f,"w"),indent=2)
+print(("installed" if mode=="install" else "uninstalled")+" Notification hook → "+f)
+PY

--- a/plugins/e2a/skills/tether/lib.sh
+++ b/plugins/e2a/skills/tether/lib.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# lib.sh — shared config + e2a helpers for the tether skill.
+#
+# Config comes from the environment, falling back to ~/.e2a-tether.env.
+# Required: E2A_API_KEY, E2A_AGENT_EMAIL. The recipient is supplied at
+# `tether.sh start <email>` and kept in the state file.
+
+t_load_config() {
+  # 1) explicit tether config
+  if [ -z "${E2A_API_KEY:-}" ] && [ -f "${HOME}/.e2a-tether.env" ]; then
+    # shellcheck disable=SC1091
+    set -a; . "${HOME}/.e2a-tether.env"; set +a
+  fi
+  # 2) reuse the CLI's agent creds from `e2a login` (~/.e2a/config.json)
+  if [ -z "${E2A_API_KEY:-}" ] && [ -f "${HOME}/.e2a/config.json" ]; then
+    eval "$(python3 -c 'import json,shlex,os
+try:
+  d=json.load(open(os.path.expanduser("~/.e2a/config.json")))
+  if d.get("api_key"):     print("export E2A_API_KEY="+shlex.quote(d["api_key"]))
+  if d.get("agent_email"): print("export E2A_AGENT_EMAIL="+shlex.quote(d["agent_email"]))
+  if d.get("api_url"):     print("export E2A_BASE_URL="+shlex.quote(d["api_url"].rstrip("/")))
+except Exception:pass')"
+  fi
+  E2A_BASE_URL="${E2A_BASE_URL:-https://api.e2a.dev}"
+  [ -n "${E2A_API_KEY:-}" ] && [ -n "${E2A_AGENT_EMAIL:-}" ]
+}
+
+t_now_iso()  { python3 -c 'import datetime;print(datetime.datetime.now(datetime.timezone.utc).isoformat())'; }
+t_urlencode(){ python3 -c 'import sys,urllib.parse;print(urllib.parse.quote(sys.argv[1],safe=""))' "$1"; }
+
+# --- state -------------------------------------------------------------------
+
+t_state_path() { echo "${TETHER_STATE:-$HOME/.e2a-tether/state.json}"; }
+
+t_state_get() {
+  local f; f="$(t_state_path)"; [ -f "$f" ] || return 0
+  python3 -c 'import json,sys
+try:print(json.load(open(sys.argv[1])).get(sys.argv[2],"") or "")
+except Exception:pass' "$f" "$1"
+}
+
+t_state_set() {  # t_state_set k1 v1 [k2 v2 ...]
+  local f; f="$(t_state_path)"; mkdir -p "$(dirname "$f")"
+  python3 -c 'import json,sys,os
+f=sys.argv[1];kv=sys.argv[2:]
+d={}
+if os.path.exists(f):
+  try:d=json.load(open(f))
+  except Exception:d={}
+for i in range(0,len(kv),2):d[kv[i]]=kv[i+1]
+json.dump(d,open(f,"w"),indent=2)' "$f" "$@"
+}
+
+t_state_clear() { rm -f "$(t_state_path)"; }
+
+# --- e2a API -----------------------------------------------------------------
+
+# t_api_send <to> <subject> <body> <conversation_id> → prints message_id
+t_api_send() {
+  local email resp status
+  email="$(t_urlencode "$E2A_AGENT_EMAIL")"
+  local payload
+  payload="$(python3 -c 'import json,sys
+print(json.dumps({"to":[sys.argv[1]],"subject":sys.argv[2],"body":sys.argv[3],"conversation_id":sys.argv[4]}))' \
+    "$1" "$2" "$3" "$4")"
+  resp="$(curl -sS -m 30 -X POST \
+    -H "Authorization: Bearer ${E2A_API_KEY}" -H "Content-Type: application/json" \
+    -d "$payload" "${E2A_BASE_URL}/v1/agents/${email}/messages" 2>/dev/null)" || return 1
+  status="$(printf '%s' "$resp" | python3 -c 'import json,sys
+try:print(json.load(sys.stdin).get("status",""))
+except Exception:print("")')"
+  [ "$status" = "pending_review" ] && echo "tether: WARNING send held (pending_review) — disable protection on ${E2A_AGENT_EMAIL}" >&2
+  printf '%s' "$resp" | python3 -c 'import json,sys
+try:print(json.load(sys.stdin).get("message_id",""))
+except Exception:print("")'
+}
+
+# t_api_reply <in_reply_to_id> <body> → prints new message_id
+t_api_reply() {
+  local email resp
+  email="$(t_urlencode "$E2A_AGENT_EMAIL")"
+  resp="$(curl -sS -m 30 -X POST \
+    -H "Authorization: Bearer ${E2A_API_KEY}" -H "Content-Type: application/json" \
+    -d "$(python3 -c 'import json,sys;print(json.dumps({"body":sys.argv[1]}))' "$2")" \
+    "${E2A_BASE_URL}/v1/agents/${email}/messages/${1}/reply" 2>/dev/null)" || return 1
+  printf '%s' "$resp" | python3 -c 'import json,sys
+try:print(json.load(sys.stdin).get("message_id",""))
+except Exception:print("")'
+}
+
+# t_api_poll <conversation_id> <since_iso> → TSV lines: id<TAB>from<TAB>created_at (inbound, oldest first)
+t_api_poll() {
+  local email resp
+  email="$(t_urlencode "$E2A_AGENT_EMAIL")"
+  resp="$(curl -sS -m 30 -G \
+    -H "Authorization: Bearer ${E2A_API_KEY}" \
+    --data-urlencode "direction=inbound" --data-urlencode "read_status=all" \
+    --data-urlencode "sort=asc" --data-urlencode "limit=20" \
+    --data-urlencode "conversation_id=${1}" --data-urlencode "since=${2}" \
+    "${E2A_BASE_URL}/v1/agents/${email}/messages" 2>/dev/null)" || return 1
+  printf '%s' "$resp" | python3 -c 'import json,sys
+try:
+  for m in json.load(sys.stdin).get("items",[]):
+    print("\t".join([m.get("message_id",""),m.get("from",""),m.get("created_at","")]))
+except Exception:pass'
+}
+
+# t_api_body <message_id> → command text (parsed.text preferred; quoted history stripped)
+t_api_body() {
+  local email resp
+  email="$(t_urlencode "$E2A_AGENT_EMAIL")"
+  resp="$(curl -sS -m 30 -H "Authorization: Bearer ${E2A_API_KEY}" \
+    "${E2A_BASE_URL}/v1/agents/${email}/messages/${1}" 2>/dev/null)" || return 1
+  printf '%s' "$resp" | python3 -c 'import json,sys
+try:
+  d=json.load(sys.stdin)
+  p=(d.get("parsed") or {}).get("text") or ""
+  b=(d.get("body") or {}).get("text") or ""
+  print((p or b).strip())
+except Exception:print("")'
+}

--- a/plugins/e2a/skills/tether/tether.env.example
+++ b/plugins/e2a/skills/tether/tether.env.example
@@ -1,0 +1,11 @@
+# e2a tether — copy to ~/.e2a-tether.env (chmod 600) and fill in.
+# tether.sh no-ops unless E2A_API_KEY + E2A_AGENT_EMAIL are set.
+# Your own email is supplied at `tether.sh start <email>`, not here.
+
+# Required
+export E2A_API_KEY="e2a_..."                 # an agent-scoped e2a API key
+export E2A_AGENT_EMAIL="tether@you.example"   # the sending/receiving agent (protection/HITL OFF)
+
+# Optional — usually unnecessary: if you've run `e2a login`, tether reuses
+# ~/.e2a/config.json (api_key + agent_email + api_url) automatically.
+export E2A_BASE_URL="https://api.e2a.dev"       # self-host: your API base

--- a/plugins/e2a/skills/tether/tether.sh
+++ b/plugins/e2a/skills/tether/tether.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# tether.sh — the runtime CLI the agent calls to stay in touch over email.
+#
+#   tether.sh start <your-email>   send the intro email, open the thread, arm
+#   tether.sh update "<message>"   send a threaded update ("as you see fit")
+#   tether.sh poll                 print any new replies since last poll (exit 0)
+#   tether.sh status               show tether state
+#   tether.sh stop                 disarm and clear state
+#   tether.sh _selftest            unconfigured dry-run + syntax check
+#
+# Sending is agent-driven: call `update` when there's something worth reporting.
+# Receiving is poll-driven: call `poll` on an interval (keep the session alive
+# with /loop) so replies sent while idle are still picked up.
+set -uo pipefail
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib.sh
+. "${here}/lib.sh"
+
+cmd="${1:-}"; shift || true
+
+need_config() { t_load_config || { echo "tether: not configured (need E2A_API_KEY + E2A_AGENT_EMAIL; see tether.env.example)"; exit 1; }; }
+need_armed()  { [ "$(t_state_get armed)" = "1" ] || { echo "tether: not started — run 'tether.sh start <email>' first"; exit 1; }; }
+
+case "$cmd" in
+  start)
+    need_config
+    to="${1:-}"; [ -n "$to" ] || { echo "usage: tether.sh start <your-email>"; exit 2; }
+    proj="$(basename "$PWD")"
+    conv="tether-$(date +%s)-$$"
+    intro="🪢 Tethered — ${proj}
+
+This session is now tethered. I'll send updates to this thread as I make
+meaningful progress, and I'll pick up your replies (usually within a few
+minutes). Reply any time with a question or instruction; reply \"stop\" to end.
+
+— your coding agent"
+    mid="$(t_api_send "$to" "Tether: ${proj}" "$intro" "$conv")"
+    [ -n "$mid" ] || { echo "tether: intro send failed (check creds / base url / agent protection)"; exit 1; }
+    t_state_set armed 1 to "$to" conversation_id "$conv" last_message_id "$mid" \
+      last_poll "$(t_now_iso)" project "$proj" started_at "$(t_now_iso)"
+    echo "tether: started — thread ${conv} → ${to} (intro sent, ${mid})"
+    ;;
+
+  update)
+    need_config; need_armed
+    msg="${1:-}"; [ -n "$msg" ] || { echo "usage: tether.sh update \"<message>\""; exit 2; }
+    rid="$(t_state_get last_message_id)"
+    mid="$(t_api_reply "$rid" "$msg")"
+    if [ -z "$mid" ]; then echo "tether: update send failed"; exit 1; fi
+    t_state_set last_message_id "$mid"
+    echo "tether: update sent (${mid})"
+    ;;
+
+  poll)
+    need_config; need_armed
+    conv="$(t_state_get conversation_id)"; since="$(t_state_get last_poll)"
+    checkpoint="$(t_now_iso)"
+    rows="$(t_api_poll "$conv" "$since")"
+    # advance the cursor regardless so we never re-report the same reply
+    t_state_set last_poll "$checkpoint"
+    [ -n "$rows" ] || { echo "(no new replies)"; exit 0; }
+    n=0
+    while IFS=$'\t' read -r id from created; do
+      [ -n "$id" ] || continue
+      body="$(t_api_body "$id")"
+      [ -n "$body" ] || continue
+      n=$((n+1))
+      echo "── reply from ${from} @ ${created} ──"
+      echo "$body"
+      echo
+      t_state_set last_message_id "$id"   # thread the next update off the user's latest
+    done <<< "$rows"
+    [ "$n" -gt 0 ] || echo "(no new replies)"
+    ;;
+
+  status)
+    if t_load_config; then echo "config: OK (agent ${E2A_AGENT_EMAIL}, base ${E2A_BASE_URL})"; else echo "config: MISSING"; fi
+    if [ "$(t_state_get armed)" = "1" ]; then
+      echo "armed:  yes"
+      echo "thread: $(t_state_get conversation_id) → $(t_state_get to)"
+      echo "since:  $(t_state_get last_poll)"
+    else
+      echo "armed:  no"
+    fi
+    ;;
+
+  stop)
+    if [ "$(t_state_get armed)" = "1" ] && t_load_config; then
+      rid="$(t_state_get last_message_id)"
+      [ -n "$rid" ] && t_api_reply "$rid" "Tether ended. Session is no longer listening." >/dev/null 2>&1 || true
+    fi
+    t_state_clear
+    echo "tether: stopped"
+    ;;
+
+  _selftest)
+    echo "# unconfigured status (must not crash):"
+    env -u E2A_API_KEY -u E2A_AGENT_EMAIL HOME=/nonexistent TETHER_STATE=/tmp/tether-selftest.json \
+      bash "${here}/tether.sh" status
+    rm -f /tmp/tether-selftest.json
+    bash -n "${here}/lib.sh" && bash -n "${here}/tether.sh" && echo "# syntax OK"
+    ;;
+
+  ""|help|-h|--help)
+    grep '^#' "${here}/tether.sh" | sed 's/^# \{0,1\}//' | sed -n '2,20p'
+    ;;
+
+  *) echo "tether: unknown command '$cmd' (try: start|update|poll|status|stop)"; exit 2;;
+esac


### PR DESCRIPTION
## What

Adds a **Beta `tether` skill** to the e2a plugin. During a long-running coding session, the agent emails threaded status updates to the user *as it sees fit* and polls for emailed replies — so a user who's AFK can steer the agent from their inbox. Reply `stop` to end.

## Architecture

Coding agents are turn-based; nothing native listens to an inbox mid-session. So the two directions use different mechanisms:

- **Send = agent-driven** — the agent calls `tether.sh update "…"` at meaningful moments (model's judgment sets cadence → no per-turn spam).
- **Receive = poll-driven** — `tether.sh poll` on an interval; keep the session alive with `/loop` so replies sent while idle are still picked up (no hook fires while idle).
- **Blocked-alert = optional Notification hook** — emails when the agent is stuck on a permission prompt.

## Credentials

Reuses the CLI's agent creds from `e2a login` (`~/.e2a/config.json`) — no separate `.env` needed. Falls back to `~/.e2a-tether.env` / env vars. Uses the static, agent-scoped CLI api_key (the right credential for shell/hook context; the MCP OAuth token is client-managed and not reusable here).

## Files

| file | role |
|---|---|
| `skills/tether/tether.sh` | runtime CLI: `start` / `update` / `poll` / `status` / `stop` |
| `skills/tether/lib.sh` | config + e2a send/reply/poll helpers |
| `skills/tether/hooks/tether-notify.sh` | optional Notification hook |
| `skills/tether/install.sh` | wire/unwire the hook; `_selftest` |
| `skills/tether/tether.env.example` | credentials template |

## Housekeeping

- Bumps plugin to **0.4.2** across all client + marketplace manifests (validator enforces parity).
- Lists agentify + tether in the README tree.

## Testing

- `node scripts/validate-plugin.mjs` → *3 skills, version 0.4.2, manifests in sync*.
- `install.sh _selftest` green (hooks no-op unconfigured; syntax OK).
- Offline end-to-end via stubbed `curl`: `start → update → poll → stop` with no duplicate reply reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)