### PR TITLE
feat(plugin/tether): duration windows + keep-awake

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "e2a plugins for Claude Code — authenticated email for AI agents",
-    "version": "0.4.4"
+    "version": "0.4.5"
   },
   "plugins": [
     {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "e2a — authenticated email gateway for AI agents (MCP server + operate-well skill).",
-    "version": "0.4.4"
+    "version": "0.4.5"
   },
   "plugins": [
     {

--- a/plugins/e2a/.claude-plugin/plugin.json
+++ b/plugins/e2a/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 37 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "Mnexa AI",

--- a/plugins/e2a/.codex-plugin/plugin.json
+++ b/plugins/e2a/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 37 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "Mnexa AI"

--- a/plugins/e2a/.cursor-plugin/plugin.json
+++ b/plugins/e2a/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 37 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "Mnexa AI",

--- a/plugins/e2a/skills/tether/SKILL.md
+++ b/plugins/e2a/skills/tether/SKILL.md
@@ -22,10 +22,10 @@ the two directions use different mechanisms:
 - **Send = agent-driven.** The agent calls `tether.sh update "…"` at meaningful
   moments (finished a slice, hit a blocker, needs a decision). Cadence is the
   model's judgment → no per-turn spam, nothing to throttle.
-- **Receive = poll-driven.** The agent calls `tether.sh poll` on an interval to
-  fetch replies. **Keep the session alive with `/loop`** so polling continues
-  while the agent would otherwise be idle — this is the only way a reply sent
-  *after* the agent goes idle gets picked up (no hook fires while idle).
+- **Receive = poll-driven.** The agent runs `tether.sh listen` — a cheap,
+  curl-only poll loop (no LLM tokens per check) that runs for the duration set at
+  `start --for`. It wakes the agent *only* when a reply actually arrives (or the
+  window ends). See **Durability tiers** for keeping it alive across idle/sleep.
 - **Questions = ask by email.** When the agent needs a decision or clarification
   from you, it must **not** use a terminal prompt / AskUserQuestion — you're AFK
   and can't see it, which would stall the whole session. It calls
@@ -41,12 +41,26 @@ the two directions use different mechanisms:
 
 ## Setup (once)
 
-```bash
-cp "${CLAUDE_PLUGIN_ROOT}/skills/tether/tether.env.example" ~/.e2a-tether.env
-chmod 600 ~/.e2a-tether.env    # fill E2A_API_KEY + E2A_AGENT_EMAIL (agent protection OFF)
-# optional blocked-alert hook:
-"${CLAUDE_PLUGIN_ROOT}/skills/tether/install.sh" --to <repo-root>
-```
+Tether needs an **agent-scoped** e2a API key (`e2a_agt_…`) bound to a single
+inbox — least privilege, so a leaked key can't touch the rest of the account.
+
+1. **Get an agent-scoped API key from the e2a website:**
+   **https://e2a.dev/api-keys** — create or pick an agent and generate a key
+   scoped to it. Note the agent's email address too.
+2. **Save the credentials:**
+   ```bash
+   cp "${CLAUDE_PLUGIN_ROOT}/skills/tether/tether.env.example" ~/.e2a-tether.env
+   chmod 600 ~/.e2a-tether.env   # fill E2A_API_KEY (e2a_agt_…) + E2A_AGENT_EMAIL
+   ```
+3. **(Optional) blocked-alert hook:**
+   ```bash
+   "${CLAUDE_PLUGIN_ROOT}/skills/tether/install.sh" --to <repo-root>
+   ```
+
+Credentials resolve in order: explicit env vars → `~/.e2a-tether.env` →
+`~/.e2a/config.json`. (That last one, written by `e2a login`, is an
+**account-scoped** key — broader than tether needs; prefer the agent key above.
+A smoother CLI path is coming.)
 
 > The tether agent must have send-side protection / HITL **off**, or each update
 > is held as an approval email instead of reaching you. `tether.sh` warns on
@@ -59,8 +73,8 @@ Let `T="${CLAUDE_PLUGIN_ROOT}/skills/tether/tether.sh"`.
 1. **Ask** the user's email address **and how long to stay tethered** (e.g. 30m,
    2h, 8h/overnight, or until they say stop). They're present at this step, so a
    normal question is fine.
-2. **Start**: `"$T" start <email> --for <duration>` (omit `--for` for
-   until-stop) — sends the intro, opens the thread, arms, and records the window.
+2. **Start**: `"$T" start <email> --for <duration>` (or `--until <ISO>`; omit
+   both for until-stop) — sends the intro, opens the thread, arms, records the window.
 3. **Work**, and **send updates as you see fit**: `"$T" update "<what changed / what you need>"`.
    Good moments: finished a slice, made a decision that's worth surfacing, hit a
    blocker, or before a long unattended stretch. Skip trivial turns. For a rich
@@ -82,23 +96,52 @@ Let `T="${CLAUDE_PLUGIN_ROOT}/skills/tether/tether.sh"`.
 6. **Stop** when the user replies `stop`/`done`, the window expires, or the work
    is complete: `"$T" stop`.
 
-## Interval guidance
+## Writing good emails
 
-The poll interval is the reply latency while the agent is idle, traded against
-token cost (each tick is a turn). Recommended:
+The recipient is a **person reading email (often on a phone)**, not a terminal.
+Write for that medium, not for a CLI.
 
-| situation | interval |
-|---|---|
-| **Attended-ish / expecting a reply soon** (just sent an update) | **2–3 min** |
-| **Default** | **3 min** |
-| **Fully AFK, latency-tolerant** | **5–10 min** |
-| floor (Claude Code `/loop` minimum) | 1 min |
+**Plain text (default — use for most updates):**
+- Lead with the takeaway (what changed / what you need), then details. Keep it
+  short and scannable.
+- **No markdown** — `**bold**`, `` `code` ``, `#` headings render as literal
+  characters in a plain-text email. Use plain prose and simple `-` bullets.
+- Be concrete: name the file / PR / decision ("merged #357"), not "did some work".
+- If you need something, end with **one clear ask** ("Reply A or B?").
+- No large code/log dumps — summarize or link. Don't paste stack traces.
 
-Nice-to-have (adaptive backoff): poll every ~2 min right after sending an
-update, then back off toward ~10 min after prolonged silence — responsive when a
-reply is likely, cheap when it isn't. While the agent is actively working it also
-catches replies at natural checkpoints, so the interval mainly governs the idle
-gap.
+**HTML (`update --html <file>` — use when structure earns it):**
+- Reach for it for a diagram, table, before/after, or a multi-section status —
+  not for a one-liner.
+- **Mobile-first** (learned the hard way): `max-width:~480px`, **inline styles
+  only** (email strips `<style>`/`<head>`), readable sizes (14–15px), and a
+  **vertical/stacked layout**. Avoid wide tables and big ASCII in `<pre>` — they
+  force horizontal scroll and shrink to unreadable on phones.
+- Prefer real elements (stacked `<div>` boxes, small `<table>`s) over ASCII art.
+- Use a system font stack; keep colors subtle. `update` auto-derives the
+  plain-text fallback, so HTML sends are always safe.
+
+**Both:**
+- **Acknowledge fast.** When a reply comes in, a quick "on it — doing X" beats
+  silence; there's inherent email latency, so don't leave the user wondering if
+  you heard them.
+- Everything stays in one thread automatically (updates reply into it).
+
+## Poll interval & knobs
+
+`listen`/`poll` hit the inbox with a plain `curl` — **no LLM tokens per check** —
+so polling can be frequent. The agent is only woken (a real turn) when a reply
+actually lands.
+
+| env var | default | effect |
+|---|---|---|
+| `E2A_TETHER_POLL_INTERVAL` | `20` (s) | how often `listen`/`ask` check the inbox |
+| `E2A_TETHER_ASK_TIMEOUT` | `1800` (s) | how long `ask` blocks for an answer before giving up |
+| `E2A_BASE_URL` | `https://api.e2a.dev` | API base (set for self-host) |
+
+The only thing that costs a turn per tick is a `/loop` **heartbeat** (tier 2
+below) — keep that coarse (e.g. 30m). Reply latency ≈ the poll interval, and
+it's cheap, so 20–30s is fine.
 
 ## Durability tiers
 

--- a/plugins/e2a/skills/tether/SKILL.md
+++ b/plugins/e2a/skills/tether/SKILL.md
@@ -56,8 +56,11 @@ chmod 600 ~/.e2a-tether.env    # fill E2A_API_KEY + E2A_AGENT_EMAIL (agent prote
 
 Let `T="${CLAUDE_PLUGIN_ROOT}/skills/tether/tether.sh"`.
 
-1. **Ask** the user's email address.
-2. **Start**: `"$T" start <email>` — sends the intro email, opens the thread, arms.
+1. **Ask** the user's email address **and how long to stay tethered** (e.g. 30m,
+   2h, 8h/overnight, or until they say stop). They're present at this step, so a
+   normal question is fine.
+2. **Start**: `"$T" start <email> --for <duration>` (omit `--for` for
+   until-stop) — sends the intro, opens the thread, arms, and records the window.
 3. **Work**, and **send updates as you see fit**: `"$T" update "<what changed / what you need>"`.
    Good moments: finished a slice, made a decision that's worth surfacing, hit a
    blocker, or before a long unattended stretch. Skip trivial turns. For a rich
@@ -69,13 +72,15 @@ Let `T="${CLAUDE_PLUGIN_ROOT}/skills/tether/tether.sh"`.
    until the user replies, then prints the answer. **Do not** use AskUserQuestion
    or a bare terminal prompt while tethered — an AFK user can't answer it and the
    session stalls.
-5. **Poll on an interval**: run `"$T" poll`; if it prints a reply, treat it as a
-   new instruction and act on it (then `update` with the result). To keep polling
-   while idle, run the session under **`/loop <interval>`** (or self-schedule the
-   next poll). See the interval guidance below. (Replies are deduped by
-   message-id and survive e2a's async parse, so none are dropped or repeated.)
-6. **Stop** when the user replies `stop`/`done`, or the work is complete:
-   `"$T" stop`.
+5. **Listen for the whole window**: run `"$T" listen` **in the background**. It
+   polls cheaply (curl, no tokens) and exits with either:
+   - `REPLY_RECEIVED:` + the message → act on it (then `update` with the result),
+     and **relaunch `listen`** for the remaining window; or
+   - `TETHER_EXPIRED` → the window is up; run `"$T" stop`.
+   Replies are deduped by message-id and survive e2a's async parse, so none are
+   dropped or repeated. (`poll` is the same one-shot check if you want it manually.)
+6. **Stop** when the user replies `stop`/`done`, the window expires, or the work
+   is complete: `"$T" stop`.
 
 ## Interval guidance
 
@@ -95,18 +100,27 @@ reply is likely, cheap when it isn't. While the agent is actively working it als
 catches replies at natural checkpoints, so the interval mainly governs the idle
 gap.
 
-## Durability note
+## Durability tiers
 
-`/loop` keeps the session alive only while the terminal is open. To keep
-listening after you close the laptop, the always-on path is an **e2a webhook
-firing a cloud Routine** — but that runs a *fresh* session (loses the live
-working context). Left as a follow-on.
+1. **In-session (default):** `listen` polls for the whole `--for` window —
+   automatic while the terminal stays open, and cheap (curl only, no tokens).
+   This is what the duration setup buys you: one long-lived poller, not manual
+   restarts. Add **`listen --awake`** to keep the machine from *idle*-sleeping
+   during the window (macOS `caffeinate`, auto-released when listening ends).
+   Note: `--awake` does **not** survive *closing the lid* (macOS clamshell still
+   sleeps) — that's tier 3.
+2. **Heartbeat (optional):** a slow `/loop` (e.g. every 30m) can relaunch
+   `listen` if it dies and keep the session warm. `/loop` wakes the *agent* (a
+   full turn each tick) — use it as a supervisor, not the poller.
+3. **Always-on (survives a closed laptop):** nothing in-session outlives a
+   closed terminal, regardless of duration — that needs an **e2a webhook firing
+   a cloud Routine** (a *fresh* session per fire, loses live context). Follow-on.
 
 ## Files
 
 | file | role |
 |---|---|
-| `tether.sh` | runtime CLI: `start` / `update` / `ask` / `poll` / `status` / `stop` |
+| `tether.sh` | runtime CLI: `start [--for]` / `update` / `ask` / `listen` / `poll` / `status` / `stop` |
 | `lib.sh` | config + e2a send/reply/poll helpers |
 | `hooks/tether-notify.sh` | optional Notification hook (blocked-alert) |
 | `install.sh` | wire/unwire the Notification hook; `_selftest` |

--- a/plugins/e2a/skills/tether/lib.sh
+++ b/plugins/e2a/skills/tether/lib.sh
@@ -53,6 +53,31 @@ json.dump(d,open(f,"w"),indent=2)' "$f" "$@"
 
 t_state_clear() { rm -f "$(t_state_path)"; }
 
+# --- duration / expiry -------------------------------------------------------
+
+# t_duration_to_expiry <dur> → ISO expires_at (empty = no expiry / "until stop")
+# accepts: 30m, 2h, 8h, 1d ; "" / forever / until-stop → empty
+t_duration_to_expiry() {
+  python3 -c 'import sys,datetime,re
+d=(sys.argv[1] if len(sys.argv)>1 else "").strip().lower()
+if not d or d in ("forever","none","off","until-stop","stop"):print("");raise SystemExit
+m=re.fullmatch(r"(\d+)\s*([mhd])",d)
+if not m:print("");raise SystemExit
+secs=int(m.group(1))*{"m":60,"h":3600,"d":86400}[m.group(2)]
+print((datetime.datetime.now(datetime.timezone.utc)+datetime.timedelta(seconds=secs)).isoformat())' "$1"
+}
+
+# t_remaining_seconds → seconds until expires_at; huge sentinel if no expiry
+t_remaining_seconds() {
+  local exp; exp="$(t_state_get expires_at)"
+  [ -n "$exp" ] || { echo 2147483647; return; }
+  python3 -c 'import sys,datetime
+try:
+  t=datetime.datetime.fromisoformat(sys.argv[1].replace("Z","+00:00"))
+  print(int((t-datetime.datetime.now(datetime.timezone.utc)).total_seconds()))
+except Exception:print(2147483647)' "$exp"
+}
+
 # --- e2a API -----------------------------------------------------------------
 
 # t_api_send <to> <subject> <body> <conversation_id> → prints message_id

--- a/plugins/e2a/skills/tether/tether.env.example
+++ b/plugins/e2a/skills/tether/tether.env.example
@@ -2,10 +2,13 @@
 # tether.sh no-ops unless E2A_API_KEY + E2A_AGENT_EMAIL are set.
 # Your own email is supplied at `tether.sh start <email>`, not here.
 
-# Required
-export E2A_API_KEY="e2a_..."                 # an agent-scoped e2a API key
+# Required — get an agent-scoped key (e2a_agt_…) at https://e2a.dev/api-keys
+export E2A_API_KEY="e2a_agt_..."             # agent-scoped e2a API key
 export E2A_AGENT_EMAIL="tether@you.example"   # the sending/receiving agent (protection/HITL OFF)
 
-# Optional — usually unnecessary: if you've run `e2a login`, tether reuses
-# ~/.e2a/config.json (api_key + agent_email + api_url) automatically.
+# Optional
 export E2A_BASE_URL="https://api.e2a.dev"       # self-host: your API base
+export E2A_TETHER_POLL_INTERVAL="20"            # seconds between inbox checks (listen/ask)
+export E2A_TETHER_ASK_TIMEOUT="1800"            # seconds `ask` blocks for an answer
+# Fallback: if these are unset, tether reads ~/.e2a/config.json from `e2a login`
+# (an account-scoped key — broader than tether needs; prefer the agent key above).

--- a/plugins/e2a/skills/tether/tether.sh
+++ b/plugins/e2a/skills/tether/tether.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 # tether.sh — the runtime CLI the agent calls to stay in touch over email.
 #
-#   tether.sh start <your-email>   send the intro email, open the thread, arm
+#   tether.sh start <email> [--for 2h|8h|30m|1d] [--until <ISO>]  open + arm
 #   tether.sh update "<message>"   send a threaded update ("as you see fit")
 #   tether.sh update --html <file> send an HTML update (+ auto text fallback)
 #   tether.sh ask "<question>"     email a question and BLOCK until the reply
+#   tether.sh listen [--awake]     poll until a reply OR the window ends (bg it)
 #   tether.sh poll                 print any new replies since last poll (exit 0)
 #   tether.sh status               show tether state
 #   tether.sh stop                 disarm and clear state
@@ -25,22 +26,35 @@ need_armed()  { [ "$(t_state_get armed)" = "1" ] || { echo "tether: not started 
 
 case "$cmd" in
   start)
+    # start <email> [--for 30m|2h|8h|1d] [--until <ISO>]
     need_config
-    to="${1:-}"; [ -n "$to" ] || { echo "usage: tether.sh start <your-email>"; exit 2; }
+    to=""; forarg=""; untilarg=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --for) forarg="${2:-}"; shift 2;;
+        --until) untilarg="${2:-}"; shift 2;;
+        *) to="$1"; shift;;
+      esac
+    done
+    [ -n "$to" ] || { echo "usage: tether.sh start <your-email> [--for 2h|8h|30m|1d] [--until <ISO>]"; exit 2; }
+    expires=""
+    if [ -n "$untilarg" ]; then expires="$untilarg"
+    elif [ -n "$forarg" ]; then expires="$(t_duration_to_expiry "$forarg")"; fi
+    window="${forarg:-${untilarg:-until you say stop}}"
     proj="$(basename "$PWD")"
     conv="tether-$(date +%s)-$$"
     intro="🪢 Tethered — ${proj}
 
-This session is now tethered. I'll send updates to this thread as I make
-meaningful progress, and I'll pick up your replies (usually within a few
-minutes). Reply any time with a question or instruction; reply \"stop\" to end.
+This session is now tethered (${window}). I'll send updates to this thread as I
+make meaningful progress, and I'll pick up your replies. Reply any time with a
+question or instruction; reply \"stop\" to end early.
 
 — your coding agent"
     mid="$(t_api_send "$to" "Tether: ${proj}" "$intro" "$conv")"
     [ -n "$mid" ] || { echo "tether: intro send failed (check creds / base url / agent protection)"; exit 1; }
     t_state_set armed 1 to "$to" conversation_id "$conv" last_message_id "$mid" \
-      last_poll "$(t_now_iso)" project "$proj" started_at "$(t_now_iso)"
-    echo "tether: started — thread ${conv} → ${to} (intro sent, ${mid})"
+      last_poll "$(t_now_iso)" project "$proj" started_at "$(t_now_iso)" expires_at "$expires"
+    echo "tether: started — thread ${conv} → ${to} (intro ${mid}); window: ${window}${expires:+ (until ${expires})}"
     ;;
 
   update)
@@ -76,6 +90,36 @@ minutes). Reply any time with a question or instruction; reply \"stop\" to end.
     t_poll_once
     ;;
 
+  listen)
+    # Deadline-bounded poller. Polls until a reply (prints REPLY_RECEIVED + exits)
+    # or until the window (expires_at) ends (prints TETHER_EXPIRED + exits). Run
+    # it in the BACKGROUND: on a reply-exit, act then relaunch for the remaining
+    # window; on TETHER_EXPIRED, run `stop`. Cheap (curl only, no tokens).
+    #   --awake  keep the machine from IDLE-sleeping while listening (macOS
+    #            caffeinate; released when listen exits). Does NOT survive the
+    #            lid closing.
+    need_config; need_armed
+    awake=0
+    while [ $# -gt 0 ]; do case "$1" in --awake) awake=1; shift;; *) shift;; esac; done
+    if [ "$awake" = "1" ]; then
+      if command -v caffeinate >/dev/null 2>&1; then
+        caffeinate -i -w "$$" >/dev/null 2>&1 &   # dies with this listen process
+        echo "tether: keeping the machine awake (caffeinate, idle-sleep off) while listening" >&2
+      else
+        echo "tether: --awake unsupported here (no caffeinate); machine may idle-sleep" >&2
+      fi
+    fi
+    interval="${E2A_TETHER_POLL_INTERVAL:-20}"
+    while :; do
+      rem="$(t_remaining_seconds)"
+      if [ "$rem" -le 0 ]; then echo "TETHER_EXPIRED"; exit 0; fi
+      out="$(t_poll_once)"
+      if [ "$out" != "(no new replies)" ]; then echo "REPLY_RECEIVED:"; echo "$out"; exit 0; fi
+      s="$interval"; [ "$rem" -lt "$s" ] && s="$rem"
+      sleep "$s"
+    done
+    ;;
+
   ask)
     # Email a question into the thread and BLOCK until the user replies, then
     # print the answer. This is how a tethered agent asks the user anything —
@@ -105,6 +149,13 @@ minutes). Reply any time with a question or instruction; reply \"stop\" to end.
       echo "armed:  yes"
       echo "thread: $(t_state_get conversation_id) → $(t_state_get to)"
       echo "since:  $(t_state_get last_poll)"
+      exp="$(t_state_get expires_at)"
+      if [ -n "$exp" ]; then
+        rem="$(t_remaining_seconds)"
+        if [ "$rem" -gt 0 ]; then echo "window: until ${exp} (${rem}s left)"; else echo "window: EXPIRED (${exp})"; fi
+      else
+        echo "window: until you stop"
+      fi
     else
       echo "armed:  no"
     fi


### PR DESCRIPTION
Follow-up to #354/#355/#356, from the live run (an unattended session silently stopped listening overnight).

## Why
The receive-leg relied on hand-restarted ~12-min pollers, so leaving a session unattended meant it quietly stopped listening. The fix: take a **duration up front** and let the harness self-manage the window.

## What
- **`start <email> [--for 30m|2h|8h|1d] [--until <ISO>]`** — records `expires_at`.
- **`listen`** — deadline-bounded poller. Polls cheaply (curl, no LLM tokens) and exits:
  - `REPLY_RECEIVED:` + message → agent acts, then relaunches for the remaining window;
  - `TETHER_EXPIRED` → agent runs `stop`.
  Replies are deduped by message-id + parse-race safe (from #355).
- **`listen --awake`** — keeps the machine from *idle*-sleeping during the window via macOS `caffeinate` (tied to the listen process, auto-released). **Honest limit:** does not survive *closing the lid* (clamshell still sleeps); that boundary needs the cloud routine.
- **`status`** shows the window + time left; SKILL.md asks "how long?" at `start` and documents three **durability tiers** (in-session `listen` → `/loop` heartbeat → cloud routine).

## Testing
- `start --for 2h` → `status` shows `~7199s left`.
- `listen` → `REPLY_RECEIVED:` on a stubbed reply; `TETHER_EXPIRED` when the window is past.
- `listen --awake` → engages `caffeinate` and auto-releases (no leftover process).
- `validate-plugin.mjs`: 3 skills, v0.4.5, manifests in sync.

Bumps plugin to **0.4.5**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)