### PR TITLE
feat: reply to and forward the agent's own outbound messages

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2870,7 +2870,7 @@ paths:
         - messages
   /v1/agents/{email}/messages/{id}/forward:
     post:
-      description: Forward an inbound message to new recipients; the original is quoted and its attachments are carried over by default. Any attachments[] you supply are added on top of the originals. 202 when held for HITL.
+      description: Forward a message (inbound or outbound) to new recipients; the original is quoted and its attachments are carried over by default. Any attachments[] you supply are added on top of the originals. 202 when held for HITL.
       operationId: forwardMessage
       parameters:
         - in: path
@@ -2964,7 +2964,7 @@ paths:
         - messages
   /v1/agents/{email}/messages/{id}/reply:
     post:
-      description: Reply to an inbound message; recipients/threading are derived from the original. 202 when held for HITL.
+      description: Reply to a message (inbound or outbound); recipients and threading are derived from the original. Replying to a message the agent received targets its sender; replying to a message the agent sent continues the thread to its original recipients (`reply_all` also re-includes the original Cc). 202 when held for HITL.
       operationId: replyToMessage
       parameters:
         - in: path

--- a/internal/agent/attach_references_test.go
+++ b/internal/agent/attach_references_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/outbound"
 )
 
-// fakeInboundLookup is a stub that satisfies hitlInboundLookup so we can
+// fakeInboundLookup is a stub that satisfies hitlParentLookup so we can
 // drive attachReferencesChain without a live Postgres. Each test sets up
 // the fields it cares about; everything else is zero-valued.
 type fakeInboundLookup struct {
@@ -23,7 +23,7 @@ type fakeInboundLookup struct {
 	returnErr          error
 }
 
-func (f *fakeInboundLookup) GetInboundByEmailMessageID(_ context.Context, agentID, emailMessageID string) (*identity.Message, error) {
+func (f *fakeInboundLookup) GetMessageByEmailMessageID(_ context.Context, agentID, emailMessageID string) (*identity.Message, error) {
 	f.calledWith.agentID = agentID
 	f.calledWith.emailMessageID = emailMessageID
 	return f.returnInbound, f.returnErr
@@ -91,6 +91,25 @@ func TestAttachReferencesChain_InboundMissingNoErr(t *testing.T) {
 
 	if req.References != nil {
 		t.Errorf("References = %v, want nil", req.References)
+	}
+}
+
+func TestAttachReferencesChain_OutboundParent_BuildsChain(t *testing.T) {
+	// A held reply whose parent is an OUTBOUND message the agent sent
+	// (reply-to-own-message). The direction-agnostic lookup resolves it and
+	// the References chain is rebuilt exactly as for an inbound parent —
+	// previously this no-op'd because the lookup filtered direction='inbound'.
+	parentRaw := []byte("References: <orig@x>\r\nFrom: agent@e2a\r\nTo: bob@x\r\n\r\nsent body")
+	lookup := &fakeInboundLookup{
+		returnInbound: &identity.Message{Direction: "outbound", RawMessage: parentRaw},
+	}
+	req := outbound.SendRequest{ReplyToMessageID: "<sent@e2a>"}
+
+	attachReferencesChain(context.Background(), lookup, "agent-1", &req)
+
+	want := []string{"<orig@x>", "<sent@e2a>"}
+	if !reflect.DeepEqual(req.References, want) {
+		t.Errorf("References = %v, want %v", req.References, want)
 	}
 }
 

--- a/internal/agent/hitl_api.go
+++ b/internal/agent/hitl_api.go
@@ -153,22 +153,24 @@ func (a *API) ApprovePendingCore(ctx context.Context, userID, messageID, expecte
 // case we silently fall back to legacy single-id behavior — better
 // than refusing the send. Callers must keep ReplyToMessageID populated
 // regardless; only References is filled in here.
-func attachReferencesChain(ctx context.Context, store hitlInboundLookup, agentID string, req *outbound.SendRequest) {
+func attachReferencesChain(ctx context.Context, store hitlParentLookup, agentID string, req *outbound.SendRequest) {
 	if req.ReplyToMessageID == "" {
 		return
 	}
-	inbound, err := store.GetInboundByEmailMessageID(ctx, agentID, req.ReplyToMessageID)
-	if err != nil || inbound == nil {
+	// Direction-agnostic: a held reply's parent may be an outbound the agent
+	// sent (reply-to-own-message), not only a received inbound.
+	parent, err := store.GetMessageByEmailMessageID(ctx, agentID, req.ReplyToMessageID)
+	if err != nil || parent == nil {
 		return
 	}
-	req.References = outbound.BuildReferencesChain(inbound.RawMessage, req.ReplyToMessageID)
+	req.References = outbound.BuildReferencesChain(parent.RawMessage, req.ReplyToMessageID)
 }
 
-// hitlInboundLookup is the narrow store contract attachReferencesChain
+// hitlParentLookup is the narrow store contract attachReferencesChain
 // needs. Defined as an interface so tests can stub it without spinning
 // up the full identity store.
-type hitlInboundLookup interface {
-	GetInboundByEmailMessageID(ctx context.Context, agentID, emailMessageID string) (*identity.Message, error)
+type hitlParentLookup interface {
+	GetMessageByEmailMessageID(ctx context.Context, agentID, emailMessageID string) (*identity.Message, error)
 }
 
 // buildSendRequestFromMessage reconstructs a SendRequest from a stored

--- a/internal/apiserver/apiserver.go
+++ b/internal/apiserver/apiserver.go
@@ -128,7 +128,7 @@ func BuildDeps(p Params) httpapi.Deps {
 		ListReviews:          p.Store.ListReviews,
 		GetReviewWithContent: p.Store.GetReviewWithContent,
 		EnforceMessageSend:   p.Enforcer.CheckMessageSend,
-		GetInboundMessage:    p.Store.GetInboundMessage,
+		GetRepliableMessage:  p.Store.GetRepliableMessage,
 		GetLimits:            p.Enforcer.Get,
 		ExportUserData:       p.API.ExportUserDataCore,
 		DeleteUserData:       p.API.DeleteUserDataCore,

--- a/internal/e2e/reply_outbound_e2e_test.go
+++ b/internal/e2e/reply_outbound_e2e_test.go
@@ -1,0 +1,104 @@
+//go:build integration
+
+package e2e_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+)
+
+// TestReplyForwardOutboundE2E drives the reply-to-/forward-your-own-outbound
+// feature through the real API + store + relay:
+//   - an agent sends a message (outbound) to alice, cc carol;
+//   - GET returns that outbound message (200);
+//   - POST /reply on that OUTBOUND id now succeeds (previously 404) and the
+//     reply is addressed to the original recipient (alice), inheriting the
+//     thread;
+//   - reply_all re-includes the original cc (carol) plus any new cc;
+//   - POST /forward on the outbound id succeeds and starts a new thread;
+//   - a bogus id still 404s.
+func TestReplyForwardOutboundE2E(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ts := testutil.TestServer(t, pool, testutil.WithOutboundSMTP("127.0.0.1", 1025, "test.e2a.dev"))
+	_, key, agent := setupDomainAndAgent(t, ts, "agent@rout.example.com", "rout.example.com", "", "")
+	ctx := context.Background()
+
+	// (1) Agent sends first — an outbound message to alice, cc carol.
+	status, body := authedJSON(t, "POST", sendURL(ts.HTTPServer.URL, agent.EmailAddress()), key.PlaintextKey,
+		`{"to":["alice@gmail.com"],"cc":["carol@gmail.com"],"subject":"Kickoff","body":"Let's start."}`)
+	if status != 200 {
+		t.Fatalf("send status=%d body=%s", status, body)
+	}
+	sent := parseThreadSend(t, body)
+	sentConv := convOf(t, ts, agent.ID, sent.MessageID)
+
+	// (2) GET the outbound message — must resolve (this is the asymmetry the
+	// reply path used to violate).
+	status, gbody := authedJSON(t, "GET",
+		ts.HTTPServer.URL+"/v1/agents/"+agent.EmailAddress()+"/messages/"+sent.MessageID, key.PlaintextKey, "")
+	if status != 200 {
+		t.Fatalf("GET outbound status=%d body=%s", status, gbody)
+	}
+
+	// (3) Reply to the agent's OWN outbound message. Was 404; now 200, addressed
+	// to the original recipient and threaded onto the same conversation.
+	status, body = authedJSON(t, "POST", subResource(ts.HTTPServer.URL, agent.EmailAddress(), sent.MessageID, "reply"),
+		key.PlaintextKey, `{"body":"following up"}`)
+	if status != 200 {
+		t.Fatalf("reply-to-outbound status=%d body=%s", status, body)
+	}
+	rep := parseThreadSend(t, body)
+
+	repMsg, err := ts.Store.GetMessageWithContent(ctx, rep.MessageID, agent.ID)
+	if err != nil {
+		t.Fatalf("load reply row: %v", err)
+	}
+	if !reflect.DeepEqual(repMsg.ToRecipients, []string{"alice@gmail.com"}) {
+		t.Errorf("reply To = %v, want original recipient [alice@gmail.com]", repMsg.ToRecipients)
+	}
+	if len(repMsg.CC) != 0 {
+		t.Errorf("plain reply CC = %v, want empty", repMsg.CC)
+	}
+	if repMsg.ConversationID != sentConv {
+		t.Errorf("reply conversation_id = %q, want %q (reply must inherit the outbound's thread)", repMsg.ConversationID, sentConv)
+	}
+
+	// (4) reply_all re-includes the original cc (carol) and merges a new cc.
+	status, body = authedJSON(t, "POST", subResource(ts.HTTPServer.URL, agent.EmailAddress(), sent.MessageID, "reply"),
+		key.PlaintextKey, `{"body":"all","reply_all":true,"cc":["erin@gmail.com"]}`)
+	if status != 200 {
+		t.Fatalf("reply_all-to-outbound status=%d body=%s", status, body)
+	}
+	repAll := parseThreadSend(t, body)
+	repAllMsg, err := ts.Store.GetMessageWithContent(ctx, repAll.MessageID, agent.ID)
+	if err != nil {
+		t.Fatalf("load reply_all row: %v", err)
+	}
+	if !reflect.DeepEqual(repAllMsg.ToRecipients, []string{"alice@gmail.com"}) {
+		t.Errorf("reply_all To = %v, want [alice@gmail.com]", repAllMsg.ToRecipients)
+	}
+	if !reflect.DeepEqual(repAllMsg.CC, []string{"carol@gmail.com", "erin@gmail.com"}) {
+		t.Errorf("reply_all CC = %v, want [carol@gmail.com erin@gmail.com]", repAllMsg.CC)
+	}
+
+	// (5) Forward the agent's own outbound to a new recipient — new thread.
+	status, body = authedJSON(t, "POST", subResource(ts.HTTPServer.URL, agent.EmailAddress(), sent.MessageID, "forward"),
+		key.PlaintextKey, `{"to":["dave@gmail.com"],"body":"fyi"}`)
+	if status != 200 {
+		t.Fatalf("forward-outbound status=%d body=%s", status, body)
+	}
+	fwd := parseThreadSend(t, body)
+	if c := convOf(t, ts, agent.ID, fwd.MessageID); c == sentConv {
+		t.Errorf("forward conversation_id = %q, want a fresh thread (forward must not inherit)", c)
+	}
+
+	// (6) Reply to a non-existent id still 404s.
+	status, body = authedJSON(t, "POST", subResource(ts.HTTPServer.URL, agent.EmailAddress(), "msg_does_not_exist", "reply"),
+		key.PlaintextKey, `{"body":"x"}`)
+	if status != 404 {
+		t.Fatalf("reply to missing id status=%d body=%s, want 404", status, body)
+	}
+}

--- a/internal/e2e/reply_outbound_e2e_test.go
+++ b/internal/e2e/reply_outbound_e2e_test.go
@@ -5,6 +5,7 @@ package e2e_test
 import (
 	"context"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/Mnexa-AI/e2a/internal/testutil"
@@ -64,6 +65,17 @@ func TestReplyForwardOutboundE2E(t *testing.T) {
 	}
 	if repMsg.ConversationID != sentConv {
 		t.Errorf("reply conversation_id = %q, want %q (reply must inherit the outbound's thread)", repMsg.ConversationID, sentConv)
+	}
+	// The reply must carry RFC threading headers anchored on the PARENT's
+	// Message-ID (the relay-assigned provider_message_id, since outbound rows
+	// have no email_message_id). Without this the recipient's mail client forks
+	// the thread — the whole point of "continues the thread".
+	if sent.ProviderMessageID == "" {
+		t.Fatal("precondition: send did not surface a provider_message_id to thread on")
+	}
+	if raw := string(repMsg.RawMessage); !strings.Contains(raw, "In-Reply-To: "+sent.ProviderMessageID) {
+		t.Errorf("reply raw missing In-Reply-To anchored on parent %q; raw headers=\n%s",
+			sent.ProviderMessageID, raw[:min(len(raw), 600)])
 	}
 
 	// (4) reply_all re-includes the original cc (carol) and merges a new cc.

--- a/internal/hitlworker/worker.go
+++ b/internal/hitlworker/worker.go
@@ -265,20 +265,21 @@ func (w *Worker) autoReject(ctx context.Context, messageID, reason string) {
 }
 
 // attachReferencesChain rebuilds the References chain on a HITL-approved
-// SendRequest by looking up the parent inbound's raw message via
-// email_message_id. Duplicates the equivalent helper in internal/agent
-// for the same reason sendRequestFromStoredMessage does — keep this
-// low-level package free of upward imports. See that helper's docstring
-// for the full rationale.
+// SendRequest by looking up the parent message's raw message via
+// email_message_id. The lookup is direction-agnostic: a held reply's parent
+// may be an outbound the agent sent (reply-to-own-message), not only a
+// received inbound. Duplicates the equivalent helper in internal/agent for the
+// same reason sendRequestFromStoredMessage does — keep this low-level package
+// free of upward imports. See that helper's docstring for the full rationale.
 func (w *Worker) attachReferencesChain(ctx context.Context, agentID string, req *outbound.SendRequest) {
 	if req.ReplyToMessageID == "" {
 		return
 	}
-	inbound, err := w.store.GetInboundByEmailMessageID(ctx, agentID, req.ReplyToMessageID)
-	if err != nil || inbound == nil {
+	parent, err := w.store.GetMessageByEmailMessageID(ctx, agentID, req.ReplyToMessageID)
+	if err != nil || parent == nil {
 		return
 	}
-	req.References = outbound.BuildReferencesChain(inbound.RawMessage, req.ReplyToMessageID)
+	req.References = outbound.BuildReferencesChain(parent.RawMessage, req.ReplyToMessageID)
 }
 
 // sendRequestFromStoredMessage reconstructs a SendRequest from a locked

--- a/internal/httpapi/httpapi.go
+++ b/internal/httpapi/httpapi.go
@@ -175,8 +175,13 @@ type Deps struct {
 	// The download route is a raw chi handler outside the Huma rate-limit
 	// middleware, so it consults this directly. Optional — nil disables it.
 	DownloadLimit RateSnapshot
-	// GetInboundMessage loads an inbound message for reply/forward.
-	GetInboundMessage func(ctx context.Context, messageID string) (*identity.Message, error)
+	// GetRepliableMessage loads a message that can be replied to or forwarded —
+	// either an inbound the agent received or an outbound the agent sent — as
+	// long as it is live (not expired) and not held/rejected in review. The
+	// reply/forward handlers use this so an agent can continue a thread off its
+	// own sent message (Gmail-style), which GetInboundMessage's direction filter
+	// forbids.
+	GetRepliableMessage func(ctx context.Context, messageID string) (*identity.Message, error)
 
 	// AttachmentStore mints/verifies short-lived attachment downloads (§6a #5).
 	// Native by default; when nil, the attachment endpoints are unavailable.

--- a/internal/httpapi/operations_test.go
+++ b/internal/httpapi/operations_test.go
@@ -382,7 +382,7 @@ func testServer(t *testing.T) *httptest.Server {
 			}
 			return nil
 		},
-		GetInboundMessage: func(ctx context.Context, messageID string) (*identity.Message, error) {
+		GetRepliableMessage: func(ctx context.Context, messageID string) (*identity.Message, error) {
 			if messageID == "msg_in1" {
 				return &identity.Message{
 					ID: "msg_in1", AgentID: "support@acme.com", Sender: "alice@x.com",

--- a/internal/httpapi/outbound.go
+++ b/internal/httpapi/outbound.go
@@ -139,7 +139,7 @@ func (s *Server) registerOutbound() {
 	huma.Register(s.API, huma.Operation{
 		OperationID: "replyToMessage", Method: http.MethodPost, Path: "/v1/agents/{email}/messages/{id}/reply",
 		Summary: "Reply to a message", Tags: []string{"messages"},
-		Description:  "Reply to an inbound message; recipients/threading are derived from the original. 202 when held for HITL.",
+		Description:  "Reply to a message (inbound or outbound); recipients and threading are derived from the original. Replying to a message the agent received targets its sender; replying to a message the agent sent continues the thread to its original recipients (`reply_all` also re-includes the original Cc). 202 when held for HITL.",
 		Security:     []map[string][]string{{"bearer": {}}},
 		MaxBodyBytes: maxOutboundBytes,
 		Responses:    map[string]*huma.Response{"202": held202(), "default": s.errorEnvelopeResponse()},
@@ -148,7 +148,7 @@ func (s *Server) registerOutbound() {
 	huma.Register(s.API, huma.Operation{
 		OperationID: "forwardMessage", Method: http.MethodPost, Path: "/v1/agents/{email}/messages/{id}/forward",
 		Summary: "Forward a message", Tags: []string{"messages"},
-		Description:  "Forward an inbound message to new recipients; the original is quoted and its attachments are carried over by default. Any attachments[] you supply are added on top of the originals. 202 when held for HITL.",
+		Description:  "Forward a message (inbound or outbound) to new recipients; the original is quoted and its attachments are carried over by default. Any attachments[] you supply are added on top of the originals. 202 when held for HITL.",
 		Security:     []map[string][]string{{"bearer": {}}},
 		MaxBodyBytes: maxOutboundBytes,
 		Responses:    map[string]*huma.Response{"202": held202(), "default": s.errorEnvelopeResponse()},
@@ -218,9 +218,10 @@ type replyInput struct {
 	Body           ReplyRequest
 }
 
-// loadInbound resolves the owned agent + the inbound message (404 if missing
-// or not on this agent).
-func (s *Server) loadInbound(ctx context.Context, address, msgID string) (*identity.AgentIdentity, *identity.Message, *identity.User, error) {
+// loadRepliableMessage resolves the owned agent + the reply/forward target
+// message — inbound or outbound — (404 if missing, expired/held, or not on
+// this agent).
+func (s *Server) loadRepliableMessage(ctx context.Context, address, msgID string) (*identity.AgentIdentity, *identity.Message, *identity.User, error) {
 	ag, err := s.resolveOwnedAgent(ctx, address)
 	if err != nil {
 		return nil, nil, nil, err
@@ -229,18 +230,18 @@ func (s *Server) loadInbound(ctx context.Context, address, msgID string) (*ident
 	if uerr != nil {
 		return nil, nil, nil, uerr
 	}
-	if s.deps.GetInboundMessage == nil {
+	if s.deps.GetRepliableMessage == nil {
 		return nil, nil, nil, NewError(http.StatusInternalServerError, "internal_error", "outbound unavailable")
 	}
-	in, err := s.deps.GetInboundMessage(ctx, msgID)
-	if err != nil || in == nil || in.AgentID != ag.ID {
+	msg, err := s.deps.GetRepliableMessage(ctx, msgID)
+	if err != nil || msg == nil || msg.AgentID != ag.ID {
 		return nil, nil, nil, NewError(http.StatusNotFound, "not_found", "message not found")
 	}
-	return ag, in, user, nil
+	return ag, msg, user, nil
 }
 
 func (s *Server) handleReply(ctx context.Context, in *replyInput) (*sendOutput, error) {
-	ag, inbound, user, err := s.loadInbound(ctx, in.Address, in.ID)
+	ag, msg, user, err := s.loadRepliableMessage(ctx, in.Address, in.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -249,7 +250,7 @@ func (s *Server) handleReply(ctx context.Context, in *replyInput) (*sendOutput, 
 		return nil, NewError(http.StatusBadRequest, "invalid_request", "body is required")
 	}
 	// Validate only the user-supplied CC/BCC; the implicit To comes from the
-	// (already-validated) inbound message — mirrors the legacy handler.
+	// (already-validated) referenced message — mirrors the legacy handler.
 	if env := recipientCountError(b.CC, b.BCC); env != nil {
 		return nil, env
 	}
@@ -261,26 +262,27 @@ func (s *Server) handleReply(ctx context.Context, in *replyInput) (*sendOutput, 
 	}
 	// Build the reply request via the same outbound helpers the legacy
 	// handler uses (subject normalization, recipient parsing, References).
-	subject := inbound.Subject
+	subject := msg.Subject
 	if subject != "" && !strings.HasPrefix(strings.ToLower(subject), "re: ") {
 		subject = "Re: " + subject
 	} else if subject == "" {
 		subject = "Re: your message"
 	}
-	rr, e := outbound.ParseReplyRecipients(inbound.RawMessage, b.ReplyAll, b.CC)
+	// Recipient derivation branches on direction. Replying to a message the
+	// agent RECEIVED targets its sender (Reply-To/From). Replying to a message
+	// the agent SENT continues the thread to its original recipients (To, plus
+	// Cc on reply_all) — reply-to-From would just address the agent itself.
+	// BCC is never carried in either case.
+	rr, e := s.replyRecipients(msg, b.ReplyAll, b.CC)
 	if e != nil {
-		return nil, NewError(http.StatusBadRequest, "invalid_recipient", e.Error())
-	}
-	replyTo := rr.To
-	if len(replyTo) == 0 {
-		replyTo = []string{inbound.Sender}
+		return nil, e
 	}
 	req := outbound.SendRequest{
-		To: replyTo, CC: rr.CC, BCC: b.BCC, Subject: subject, Body: b.Body, HTMLBody: b.HTMLBody,
-		ReplyToMessageID: inbound.EmailMessageID,
-		References:       outbound.BuildReferencesChain(inbound.RawMessage, inbound.EmailMessageID),
+		To: rr.To, CC: rr.CC, BCC: b.BCC, Subject: subject, Body: b.Body, HTMLBody: b.HTMLBody,
+		ReplyToMessageID: msg.EmailMessageID,
+		References:       outbound.BuildReferencesChain(msg.RawMessage, msg.EmailMessageID),
 		// conversation_id resolution (caller id > inherit-from-referenced > mint)
-		// is centralized in DeliverOutbound, which receives this inbound as the
+		// is centralized in DeliverOutbound, which receives this message as the
 		// referenced message — so the reply inherits its thread there (#328).
 		ConversationID: b.ConversationID, Attachments: b.Attachments,
 	}
@@ -294,7 +296,32 @@ func (s *Server) handleReply(ctx context.Context, in *replyInput) (*sendOutput, 
 	if env := recipientCountError(req.To, req.CC, req.BCC); env != nil {
 		return nil, env
 	}
-	return s.deliver(ctx, user, ag, req, "reply", inbound.EmailMessageID, "/v1/reply/"+in.ID, in.IdempotencyKey, in.RawBody, inbound)
+	return s.deliver(ctx, user, ag, req, "reply", msg.EmailMessageID, "/v1/reply/"+in.ID, in.IdempotencyKey, in.RawBody, msg)
+}
+
+// replyRecipients resolves a reply's To/CC from the referenced message,
+// branching on direction. An inbound (received) message replies to its sender;
+// an outbound (sent) message continues the thread to its original recipients.
+// Returns a 400 envelope for an outbound target with no recorded recipients —
+// falling back to the message's Sender there would address the agent itself, so
+// we fail closed rather than emit a self-addressed reply.
+func (s *Server) replyRecipients(msg *identity.Message, replyAll bool, extraCC []string) (*outbound.ReplyRecipients, *ErrorEnvelope) {
+	if msg.Direction == "outbound" {
+		rr := outbound.ReplyRecipientsForOutbound(msg.ToRecipients, msg.CC, extraCC, replyAll)
+		if len(rr.To) == 0 {
+			return nil, NewError(http.StatusBadRequest, "invalid_recipient",
+				"cannot reply: the original message has no recorded recipients")
+		}
+		return rr, nil
+	}
+	rr, err := outbound.ParseReplyRecipients(msg.RawMessage, replyAll, extraCC)
+	if err != nil {
+		return nil, NewError(http.StatusBadRequest, "invalid_recipient", err.Error())
+	}
+	if len(rr.To) == 0 {
+		rr.To = []string{msg.Sender}
+	}
+	return rr, nil
 }
 
 // ForwardRequest mirrors the legacy forward body.
@@ -317,7 +344,7 @@ type forwardInput struct {
 }
 
 func (s *Server) handleForward(ctx context.Context, in *forwardInput) (*sendOutput, error) {
-	ag, inbound, user, err := s.loadInbound(ctx, in.Address, in.ID)
+	ag, msg, user, err := s.loadRepliableMessage(ctx, in.Address, in.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -334,8 +361,8 @@ func (s *Server) handleForward(ctx context.Context, in *forwardInput) (*sendOutp
 	if e := validateConversationID(b.ConversationID); e != nil {
 		return nil, NewError(http.StatusBadRequest, "invalid_request", e.Error())
 	}
-	subject := outbound.BuildForwardSubject(inbound.Subject)
-	fwdCtx := outbound.ExtractForwardContext(inbound.RawMessage)
+	subject := outbound.BuildForwardSubject(msg.Subject)
+	fwdCtx := outbound.ExtractForwardContext(msg.RawMessage)
 	composedBody := outbound.BuildForwardBody(b.Body, fwdCtx)
 	var composedHTML string
 	if b.HTMLBody != "" || fwdCtx.HTML != "" || fwdCtx.Text != "" {
@@ -345,7 +372,7 @@ func (s *Server) handleForward(ctx context.Context, in *forwardInput) (*sendOutp
 	// forward should ship the original files the way mail clients do, without
 	// the caller re-fetching and re-encoding each one. Caller-supplied
 	// attachments are additive on top of the originals.
-	attachments := outbound.ForwardAttachments(inbound.RawMessage)
+	attachments := outbound.ForwardAttachments(msg.RawMessage)
 	attachments = append(attachments, b.Attachments...)
 	req := outbound.SendRequest{
 		To: b.To, CC: b.CC, BCC: b.BCC, Subject: subject, Body: composedBody, HTMLBody: composedHTML,
@@ -353,7 +380,7 @@ func (s *Server) handleForward(ctx context.Context, in *forwardInput) (*sendOutp
 	}
 	req.CC = agent.StripAgentSelfAliases(req.CC, ag.EmailAddress())
 	req.BCC = agent.StripAgentSelfAliases(req.BCC, ag.EmailAddress())
-	return s.deliver(ctx, user, ag, req, "forward", inbound.EmailMessageID, "/v1/forward/"+in.ID, in.IdempotencyKey, in.RawBody, inbound)
+	return s.deliver(ctx, user, ag, req, "forward", msg.EmailMessageID, "/v1/forward/"+in.ID, in.IdempotencyKey, in.RawBody, msg)
 }
 
 // validateOutboundBody runs the shared pre-send validation.

--- a/internal/httpapi/outbound.go
+++ b/internal/httpapi/outbound.go
@@ -277,10 +277,16 @@ func (s *Server) handleReply(ctx context.Context, in *replyInput) (*sendOutput, 
 	if e != nil {
 		return nil, e
 	}
+	// Anchor threading on the parent's RFC Message-ID. For an inbound that's the
+	// sender's Message-ID (email_message_id); for the agent's own outbound it's
+	// the relay-assigned provider_message_id — email_message_id is empty there,
+	// so using it would drop In-Reply-To/References and fork the recipient's
+	// thread (see identity.Message.ThreadMessageID).
+	parentMessageID := msg.ThreadMessageID()
 	req := outbound.SendRequest{
 		To: rr.To, CC: rr.CC, BCC: b.BCC, Subject: subject, Body: b.Body, HTMLBody: b.HTMLBody,
-		ReplyToMessageID: msg.EmailMessageID,
-		References:       outbound.BuildReferencesChain(msg.RawMessage, msg.EmailMessageID),
+		ReplyToMessageID: parentMessageID,
+		References:       outbound.BuildReferencesChain(msg.RawMessage, parentMessageID),
 		// conversation_id resolution (caller id > inherit-from-referenced > mint)
 		// is centralized in DeliverOutbound, which receives this message as the
 		// referenced message — so the reply inherits its thread there (#328).
@@ -296,7 +302,7 @@ func (s *Server) handleReply(ctx context.Context, in *replyInput) (*sendOutput, 
 	if env := recipientCountError(req.To, req.CC, req.BCC); env != nil {
 		return nil, env
 	}
-	return s.deliver(ctx, user, ag, req, "reply", msg.EmailMessageID, "/v1/reply/"+in.ID, in.IdempotencyKey, in.RawBody, msg)
+	return s.deliver(ctx, user, ag, req, "reply", parentMessageID, "/v1/reply/"+in.ID, in.IdempotencyKey, in.RawBody, msg)
 }
 
 // replyRecipients resolves a reply's To/CC from the referenced message,
@@ -380,7 +386,7 @@ func (s *Server) handleForward(ctx context.Context, in *forwardInput) (*sendOutp
 	}
 	req.CC = agent.StripAgentSelfAliases(req.CC, ag.EmailAddress())
 	req.BCC = agent.StripAgentSelfAliases(req.BCC, ag.EmailAddress())
-	return s.deliver(ctx, user, ag, req, "forward", msg.EmailMessageID, "/v1/forward/"+in.ID, in.IdempotencyKey, in.RawBody, msg)
+	return s.deliver(ctx, user, ag, req, "forward", msg.ThreadMessageID(), "/v1/forward/"+in.ID, in.IdempotencyKey, in.RawBody, msg)
 }
 
 // validateOutboundBody runs the shared pre-send validation.

--- a/internal/httpapi/outbound_forward_attach_test.go
+++ b/internal/httpapi/outbound_forward_attach_test.go
@@ -48,7 +48,7 @@ func TestForwardCarriesOriginalAttachments(t *testing.T) {
 			}
 			return nil, errors.New("not found")
 		},
-		GetInboundMessage: func(ctx context.Context, messageID string) (*identity.Message, error) {
+		GetRepliableMessage: func(ctx context.Context, messageID string) (*identity.Message, error) {
 			if messageID == "msg_att" {
 				return &identity.Message{
 					ID: "msg_att", AgentID: "support@acme.com", Sender: "alice@x.com",

--- a/internal/httpapi/outbound_reply_direction_test.go
+++ b/internal/httpapi/outbound_reply_direction_test.go
@@ -47,18 +47,20 @@ func replyDirTestServer(t *testing.T, fixtures map[string]*identity.Message, cap
 	return srv
 }
 
-// outboundFixture is a message the agent itself sent, as stored: recipients in
-// the to_recipients/cc columns and a composed raw message with its Message-ID.
+// outboundFixture is a message the agent itself sent, as actually stored:
+// recipients in the to_recipients/cc columns, NO email_message_id (the composer
+// omits Message-ID; the relay-assigned id lives in provider_message_id), and a
+// composed raw message without a Message-ID header. This mirrors what
+// CreateOutboundMessage persists so the threading assertions aren't fiction.
 func outboundFixture() *identity.Message {
 	raw := []byte("From: support@acme.com\r\n" +
 		"To: bob@x.com, carol@x.com\r\n" +
 		"Cc: dave@x.com\r\n" +
-		"Subject: Project update\r\n" +
-		"Message-ID: <sent-1@acme.com>\r\n\r\nhello team")
+		"Subject: Project update\r\n\r\nhello team")
 	return &identity.Message{
 		ID: "msg_out1", AgentID: "support@acme.com", Direction: "outbound",
 		Sender: "support@acme.com", Subject: "Project update",
-		EmailMessageID: "<sent-1@acme.com>", ConversationID: "conv_out",
+		ProviderMessageID: "<sent-1@acme.com>", ConversationID: "conv_out",
 		ToRecipients: []string{"bob@x.com", "carol@x.com"},
 		CC:           []string{"dave@x.com"},
 		RawMessage:   raw,
@@ -131,6 +133,25 @@ func TestReplyToOutbound_NoRecipients_400(t *testing.T) {
 	}
 	if captured.To != nil {
 		t.Errorf("DeliverOutbound should not have been called; captured.To = %v", captured.To)
+	}
+}
+
+// A message owned by a DIFFERENT agent must 404 even though the id resolves in
+// the (id-only) store lookup — the handler's agent-ownership guard is the only
+// thing scoping the id-only query.
+func TestReplyToOutbound_CrossAgent_404(t *testing.T) {
+	var captured outbound.SendRequest
+	fix := outboundFixture()
+	fix.AgentID = "other@acme.com" // not the path agent (support@acme.com)
+	srv := replyDirTestServer(t, map[string]*identity.Message{"msg_out1": fix}, &captured)
+
+	status, _ := postJSON(t, srv.URL+"/v1/agents/support%40acme.com/messages/msg_out1/reply", "good",
+		map[string]any{"body": "hi"})
+	if status != http.StatusNotFound {
+		t.Fatalf("reply to another agent's message: want 404, got %d", status)
+	}
+	if captured.To != nil {
+		t.Errorf("DeliverOutbound must not run for a cross-agent target; captured.To = %v", captured.To)
 	}
 }
 

--- a/internal/httpapi/outbound_reply_direction_test.go
+++ b/internal/httpapi/outbound_reply_direction_test.go
@@ -1,0 +1,175 @@
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/agent"
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/outbound"
+)
+
+// replyDirTestServer builds a minimal /v1 server whose GetRepliableMessage
+// stub returns a fixture keyed by id, and whose DeliverOutbound captures the
+// composed SendRequest so tests can assert the derived recipients/threading.
+// It exercises the reply-to-/forward-outbound path end to end over HTTP.
+func replyDirTestServer(t *testing.T, fixtures map[string]*identity.Message, captured *outbound.SendRequest) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(New(Deps{
+		Authenticator: func(r *http.Request) (*identity.User, error) {
+			if r.Header.Get("Authorization") == "Bearer good" {
+				return &identity.User{ID: "u_1", Email: "owner@acme.com"}, nil
+			}
+			return nil, errors.New("unauthorized")
+		},
+		GetAgent: func(ctx context.Context, address string) (*identity.AgentIdentity, error) {
+			if address == "support@acme.com" {
+				return &identity.AgentIdentity{ID: "support@acme.com", Email: "support@acme.com", UserID: "u_1", DomainVerified: true}, nil
+			}
+			return nil, errors.New("not found")
+		},
+		GetRepliableMessage: func(ctx context.Context, messageID string) (*identity.Message, error) {
+			if m, ok := fixtures[messageID]; ok {
+				return m, nil
+			}
+			return nil, errors.New("not found")
+		},
+		DeliverOutbound: func(ctx context.Context, u *identity.User, ag *identity.AgentIdentity, req outbound.SendRequest, mt, rt string, ref *identity.Message) (*agent.OutboundResult, *agent.OutboundError) {
+			*captured = req
+			return &agent.OutboundResult{MessageID: "msg_sent_1", Method: "smtp"}, nil
+		},
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// outboundFixture is a message the agent itself sent, as stored: recipients in
+// the to_recipients/cc columns and a composed raw message with its Message-ID.
+func outboundFixture() *identity.Message {
+	raw := []byte("From: support@acme.com\r\n" +
+		"To: bob@x.com, carol@x.com\r\n" +
+		"Cc: dave@x.com\r\n" +
+		"Subject: Project update\r\n" +
+		"Message-ID: <sent-1@acme.com>\r\n\r\nhello team")
+	return &identity.Message{
+		ID: "msg_out1", AgentID: "support@acme.com", Direction: "outbound",
+		Sender: "support@acme.com", Subject: "Project update",
+		EmailMessageID: "<sent-1@acme.com>", ConversationID: "conv_out",
+		ToRecipients: []string{"bob@x.com", "carol@x.com"},
+		CC:           []string{"dave@x.com"},
+		RawMessage:   raw,
+	}
+}
+
+// Reply to the agent's own outbound message → To = original To, no Cc (plain
+// reply), threaded onto the outbound's Message-ID. This is the core bug fix:
+// before, this 404'd because the lookup filtered direction='inbound'.
+func TestReplyToOutbound_TargetsOriginalRecipients(t *testing.T) {
+	var captured outbound.SendRequest
+	srv := replyDirTestServer(t, map[string]*identity.Message{"msg_out1": outboundFixture()}, &captured)
+
+	status, _ := postJSON(t, srv.URL+"/v1/agents/support%40acme.com/messages/msg_out1/reply", "good",
+		map[string]any{"body": "following up"})
+	if status != 200 {
+		t.Fatalf("reply to outbound: want 200, got %d", status)
+	}
+	if !reflect.DeepEqual(captured.To, []string{"bob@x.com", "carol@x.com"}) {
+		t.Errorf("To = %v, want original To [bob@x.com carol@x.com]", captured.To)
+	}
+	if len(captured.CC) != 0 {
+		t.Errorf("CC = %v, want empty on plain reply", captured.CC)
+	}
+	if captured.ReplyToMessageID != "<sent-1@acme.com>" {
+		t.Errorf("ReplyToMessageID = %q, want the outbound Message-ID", captured.ReplyToMessageID)
+	}
+	if captured.Subject != "Re: Project update" {
+		t.Errorf("Subject = %q, want Re: Project update", captured.Subject)
+	}
+	if len(captured.References) == 0 || captured.References[len(captured.References)-1] != "<sent-1@acme.com>" {
+		t.Errorf("References = %v, want chain ending in the outbound Message-ID", captured.References)
+	}
+}
+
+// reply_all to your own outbound adds the original Cc; the caller's extra Cc is
+// merged. BCC is never carried.
+func TestReplyAllToOutbound_AddsOriginalCC(t *testing.T) {
+	var captured outbound.SendRequest
+	srv := replyDirTestServer(t, map[string]*identity.Message{"msg_out1": outboundFixture()}, &captured)
+
+	status, _ := postJSON(t, srv.URL+"/v1/agents/support%40acme.com/messages/msg_out1/reply", "good",
+		map[string]any{"body": "all", "reply_all": true, "cc": []string{"erin@x.com"}})
+	if status != 200 {
+		t.Fatalf("reply_all to outbound: want 200, got %d", status)
+	}
+	if !reflect.DeepEqual(captured.To, []string{"bob@x.com", "carol@x.com"}) {
+		t.Errorf("To = %v, want original To", captured.To)
+	}
+	// Original Cc (dave) + caller Cc (erin), self-alias stripping does not touch
+	// these external addresses.
+	if !reflect.DeepEqual(captured.CC, []string{"dave@x.com", "erin@x.com"}) {
+		t.Errorf("CC = %v, want [dave@x.com erin@x.com]", captured.CC)
+	}
+}
+
+// An outbound target with no recorded recipients must fail closed with 400,
+// never fall back to the agent's own address (a self-send loop).
+func TestReplyToOutbound_NoRecipients_400(t *testing.T) {
+	var captured outbound.SendRequest
+	fix := outboundFixture()
+	fix.ToRecipients = nil
+	fix.CC = nil
+	srv := replyDirTestServer(t, map[string]*identity.Message{"msg_out1": fix}, &captured)
+
+	status, _ := postJSON(t, srv.URL+"/v1/agents/support%40acme.com/messages/msg_out1/reply", "good",
+		map[string]any{"body": "hi"})
+	if status != http.StatusBadRequest {
+		t.Fatalf("reply to recipient-less outbound: want 400, got %d", status)
+	}
+	if captured.To != nil {
+		t.Errorf("DeliverOutbound should not have been called; captured.To = %v", captured.To)
+	}
+}
+
+// Forwarding the agent's own outbound message works and threads as a NEW mail
+// (recipients come from the request body, subject is Fwd:).
+func TestForwardOutbound_Works(t *testing.T) {
+	var captured outbound.SendRequest
+	srv := replyDirTestServer(t, map[string]*identity.Message{"msg_out1": outboundFixture()}, &captured)
+
+	status, _ := postJSON(t, srv.URL+"/v1/agents/support%40acme.com/messages/msg_out1/forward", "good",
+		map[string]any{"to": []string{"newperson@x.com"}, "body": "fyi"})
+	if status != 200 {
+		t.Fatalf("forward outbound: want 200, got %d", status)
+	}
+	if !reflect.DeepEqual(captured.To, []string{"newperson@x.com"}) {
+		t.Errorf("To = %v, want caller-supplied [newperson@x.com]", captured.To)
+	}
+	if captured.Subject != "Fwd: Project update" {
+		t.Errorf("Subject = %q, want Fwd: Project update", captured.Subject)
+	}
+}
+
+// Regression: replying to a received (inbound) message is unchanged — targets
+// the original sender via From, not the To column.
+func TestReplyToInbound_Unchanged(t *testing.T) {
+	var captured outbound.SendRequest
+	inbound := &identity.Message{
+		ID: "msg_in1", AgentID: "support@acme.com", Direction: "inbound",
+		Sender: "alice@x.com", Subject: "Question", EmailMessageID: "<abc@x.com>",
+		RawMessage: []byte("From: alice@x.com\r\nTo: support@acme.com\r\nSubject: Question\r\nMessage-ID: <abc@x.com>\r\n\r\nhi"),
+	}
+	srv := replyDirTestServer(t, map[string]*identity.Message{"msg_in1": inbound}, &captured)
+
+	status, _ := postJSON(t, srv.URL+"/v1/agents/support%40acme.com/messages/msg_in1/reply", "good",
+		map[string]any{"body": "answer"})
+	if status != 200 {
+		t.Fatalf("reply to inbound: want 200, got %d", status)
+	}
+	if !reflect.DeepEqual(captured.To, []string{"alice@x.com"}) {
+		t.Errorf("To = %v, want inbound sender [alice@x.com]", captured.To)
+	}
+}

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -1300,6 +1300,35 @@ func (s *Store) GetInboundMessage(ctx context.Context, id string) (*Message, err
 	return m, nil
 }
 
+// GetRepliableMessage loads a message that can be the target of a reply or
+// forward, regardless of direction: an inbound the agent received or an
+// outbound the agent sent. It is the direction-agnostic sibling of
+// GetInboundMessage — same columns, but without the `direction = 'inbound'`
+// predicate — so an agent can continue a thread off its own sent message
+// (mirrors how mail clients let you reply to a message in your Sent folder).
+//
+// The held-status exclusion is kept for BOTH directions: a message still in
+// review (pending/rejected/expired) has not actually been delivered, so it is
+// not a legitimate reply/forward anchor. `expires_at > now()` keeps expired
+// rows out the same way GetInboundMessage does. Callers still scope the result
+// to the owning agent (id-only lookup here does not).
+func (s *Store) GetRepliableMessage(ctx context.Context, id string) (*Message, error) {
+	m := &Message{}
+	var authVerdict []byte
+	err := s.pool.QueryRow(ctx,
+		`SELECT id, agent_id, direction, sender, recipient, to_recipients, cc, reply_to, subject, email_message_id, raw_message, auth_verdict, COALESCE(flagged, false), COALESCE(flag_reason, ''), COALESCE(conversation_id, ''), created_at, expires_at
+		 FROM messages WHERE id = $1 AND expires_at > now()
+		   AND status NOT IN (`+heldInboundStatuses+`)`, id,
+	).Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.ToRecipients, &m.CC, &m.ReplyTo, &m.Subject, &m.EmailMessageID, &m.RawMessage, &authVerdict, &m.Flagged, &m.FlagReason, &m.ConversationID, &m.CreatedAt, &m.ExpiresAt)
+	if err != nil {
+		return nil, err
+	}
+	if err := unmarshalAuthVerdict(authVerdict, m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
 // unmarshalAuthVerdict parses the messages.auth_verdict JSONB column into
 // m.Auth. A NULL/empty column (every outbound row, and inbound rows written
 // before migration 032) leaves m.Auth nil.
@@ -1337,6 +1366,37 @@ func (s *Store) GetInboundByEmailMessageID(ctx context.Context, agentID, emailMe
 		 FROM messages
 		 WHERE agent_id = $1
 		   AND direction = 'inbound'
+		   AND email_message_id = $2
+		   AND expires_at > now()
+		   AND status NOT IN (`+heldInboundStatuses+`)
+		 ORDER BY created_at DESC LIMIT 1`,
+		agentID, emailMessageID,
+	).Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.ToRecipients, &m.CC, &m.ReplyTo, &m.Subject, &m.EmailMessageID, &m.RawMessage, &authHeaders, &m.CreatedAt, &m.ExpiresAt)
+	if err != nil {
+		return nil, err
+	}
+	m.AuthHeaders = authHeaders
+	return m, nil
+}
+
+// GetMessageByEmailMessageID looks up a message by its RFC 5322 Message-ID for
+// the given agent, regardless of direction. It is the direction-agnostic
+// sibling of GetInboundByEmailMessageID: the HITL approve path uses it to
+// rebuild the References chain of a held reply, and the reply's parent can be
+// an outbound the agent sent (reply-to-own-message), not just a received
+// inbound. Same expiry/held exclusions apply. Returns sql.ErrNoRows when the
+// parent has expired or was never persisted; callers must tolerate that and
+// fall back to legacy single-id threading.
+func (s *Store) GetMessageByEmailMessageID(ctx context.Context, agentID, emailMessageID string) (*Message, error) {
+	if emailMessageID == "" {
+		return nil, fmt.Errorf("empty email_message_id")
+	}
+	m := &Message{}
+	var authHeaders map[string]string
+	err := s.pool.QueryRow(ctx,
+		`SELECT id, agent_id, direction, sender, recipient, to_recipients, cc, reply_to, subject, email_message_id, raw_message, auth_headers, created_at, expires_at
+		 FROM messages
+		 WHERE agent_id = $1
 		   AND email_message_id = $2
 		   AND expires_at > now()
 		   AND status NOT IN (`+heldInboundStatuses+`)

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -1300,12 +1300,29 @@ func (s *Store) GetInboundMessage(ctx context.Context, id string) (*Message, err
 	return m, nil
 }
 
+// ThreadMessageID returns the RFC 5322 Message-ID to anchor a reply's
+// In-Reply-To / References on. An inbound message carries the sender's
+// Message-ID in email_message_id; an outbound message the agent sent has no
+// email_message_id (the composer omits Message-ID — see
+// internal/outbound/compose.go) and instead carries the relay/SES-assigned
+// Message-ID, angle-bracketed, in provider_message_id. Threading off the wrong
+// field forks the recipient's mail thread, so callers replying to their own
+// outbound must use this rather than EmailMessageID directly.
+func (m *Message) ThreadMessageID() string {
+	if m.Direction == "outbound" {
+		return m.ProviderMessageID
+	}
+	return m.EmailMessageID
+}
+
 // GetRepliableMessage loads a message that can be the target of a reply or
 // forward, regardless of direction: an inbound the agent received or an
 // outbound the agent sent. It is the direction-agnostic sibling of
-// GetInboundMessage — same columns, but without the `direction = 'inbound'`
-// predicate — so an agent can continue a thread off its own sent message
-// (mirrors how mail clients let you reply to a message in your Sent folder).
+// GetInboundMessage — same columns (plus provider_message_id, which carries
+// the outbound Message-ID for threading; see ThreadMessageID) — but without
+// the `direction = 'inbound'` predicate, so an agent can continue a thread off
+// its own sent message (mirrors how mail clients let you reply to a message in
+// your Sent folder).
 //
 // The held-status exclusion is kept for BOTH directions: a message still in
 // review (pending/rejected/expired) has not actually been delivered, so it is
@@ -1316,10 +1333,10 @@ func (s *Store) GetRepliableMessage(ctx context.Context, id string) (*Message, e
 	m := &Message{}
 	var authVerdict []byte
 	err := s.pool.QueryRow(ctx,
-		`SELECT id, agent_id, direction, sender, recipient, to_recipients, cc, reply_to, subject, email_message_id, raw_message, auth_verdict, COALESCE(flagged, false), COALESCE(flag_reason, ''), COALESCE(conversation_id, ''), created_at, expires_at
+		`SELECT id, agent_id, direction, sender, recipient, to_recipients, cc, reply_to, subject, email_message_id, COALESCE(provider_message_id, ''), raw_message, auth_verdict, COALESCE(flagged, false), COALESCE(flag_reason, ''), COALESCE(conversation_id, ''), created_at, expires_at
 		 FROM messages WHERE id = $1 AND expires_at > now()
 		   AND status NOT IN (`+heldInboundStatuses+`)`, id,
-	).Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.ToRecipients, &m.CC, &m.ReplyTo, &m.Subject, &m.EmailMessageID, &m.RawMessage, &authVerdict, &m.Flagged, &m.FlagReason, &m.ConversationID, &m.CreatedAt, &m.ExpiresAt)
+	).Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.ToRecipients, &m.CC, &m.ReplyTo, &m.Subject, &m.EmailMessageID, &m.ProviderMessageID, &m.RawMessage, &authVerdict, &m.Flagged, &m.FlagReason, &m.ConversationID, &m.CreatedAt, &m.ExpiresAt)
 	if err != nil {
 		return nil, err
 	}
@@ -1384,12 +1401,18 @@ func (s *Store) GetInboundByEmailMessageID(ctx context.Context, agentID, emailMe
 // sibling of GetInboundByEmailMessageID: the HITL approve path uses it to
 // rebuild the References chain of a held reply, and the reply's parent can be
 // an outbound the agent sent (reply-to-own-message), not just a received
-// inbound. Same expiry/held exclusions apply. Returns sql.ErrNoRows when the
+// inbound.
+//
+// The id is matched against email_message_id (where inbound rows carry the
+// sender's Message-ID) OR provider_message_id (where outbound rows carry the
+// relay/SES-assigned Message-ID — outbound rows have no email_message_id, see
+// ThreadMessageID), so a held reply threaded onto either kind of parent
+// resolves. Same expiry/held exclusions apply. Returns sql.ErrNoRows when the
 // parent has expired or was never persisted; callers must tolerate that and
 // fall back to legacy single-id threading.
-func (s *Store) GetMessageByEmailMessageID(ctx context.Context, agentID, emailMessageID string) (*Message, error) {
-	if emailMessageID == "" {
-		return nil, fmt.Errorf("empty email_message_id")
+func (s *Store) GetMessageByEmailMessageID(ctx context.Context, agentID, messageID string) (*Message, error) {
+	if messageID == "" {
+		return nil, fmt.Errorf("empty message id")
 	}
 	m := &Message{}
 	var authHeaders map[string]string
@@ -1397,11 +1420,11 @@ func (s *Store) GetMessageByEmailMessageID(ctx context.Context, agentID, emailMe
 		`SELECT id, agent_id, direction, sender, recipient, to_recipients, cc, reply_to, subject, email_message_id, raw_message, auth_headers, created_at, expires_at
 		 FROM messages
 		 WHERE agent_id = $1
-		   AND email_message_id = $2
+		   AND (email_message_id = $2 OR provider_message_id = $2)
 		   AND expires_at > now()
 		   AND status NOT IN (`+heldInboundStatuses+`)
 		 ORDER BY created_at DESC LIMIT 1`,
-		agentID, emailMessageID,
+		agentID, messageID,
 	).Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.ToRecipients, &m.CC, &m.ReplyTo, &m.Subject, &m.EmailMessageID, &m.RawMessage, &authHeaders, &m.CreatedAt, &m.ExpiresAt)
 	if err != nil {
 		return nil, err

--- a/internal/identity/store_test.go
+++ b/internal/identity/store_test.go
@@ -572,11 +572,49 @@ func TestGetRepliableMessage_ReturnsOutbound(t *testing.T) {
 	if len(got.CC) != 1 || got.CC[0] != "carol@gmail.com" {
 		t.Errorf("CC = %v, want [carol@gmail.com]", got.CC)
 	}
+	// provider_message_id is the outbound's RFC Message-ID (email_message_id is
+	// empty for outbound), and ThreadMessageID resolves to it — this is what the
+	// reply path anchors In-Reply-To/References on.
+	if got.ProviderMessageID != "<sent-1@repliable-out.example.com>" {
+		t.Errorf("ProviderMessageID = %q, want the sent Message-ID", got.ProviderMessageID)
+	}
+	if got.ThreadMessageID() != "<sent-1@repliable-out.example.com>" {
+		t.Errorf("ThreadMessageID() = %q, want provider_message_id for outbound", got.ThreadMessageID())
+	}
 
 	// The legacy inbound-only lookup must still refuse the same outbound id —
 	// this is exactly the asymmetry the feature relies on.
 	if _, err := store.GetInboundMessage(ctx, out.ID); err == nil {
 		t.Error("GetInboundMessage returned an outbound message (direction filter regressed)")
+	}
+}
+
+func TestGetMessageByEmailMessageID_ResolvesOutboundByProviderID(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "owner@example.com", "Owner", "google-parentlookup")
+	store.ClaimOrCreateDomain(ctx, "parentlookup.example.com", user.ID)
+	a, _ := store.CreateAgent(ctx, "agent@parentlookup.example.com", "parentlookup.example.com", "", "https://example.com/webhook", "", user.ID)
+
+	// An outbound the agent sent: its RFC Message-ID lives in provider_message_id,
+	// not email_message_id. The HITL approve-time References rebuild must resolve
+	// the parent by that id (a held reply-to-own-message threads on it).
+	providerID := "<sent-p@parentlookup.example.com>"
+	out, _ := store.CreateOutboundMessage(ctx, a.ID, []string{"bob@gmail.com"}, nil, nil, "Update", "send", "smtp", providerID, "", []byte("raw"))
+
+	got, err := store.GetMessageByEmailMessageID(ctx, a.ID, providerID)
+	if err != nil {
+		t.Fatalf("GetMessageByEmailMessageID(providerID): %v", err)
+	}
+	if got.ID != out.ID {
+		t.Errorf("resolved id = %q, want the outbound %q", got.ID, out.ID)
+	}
+
+	// A different agent must not resolve it (agent-scoped).
+	if _, err := store.GetMessageByEmailMessageID(ctx, "someone-else", providerID); err == nil {
+		t.Error("GetMessageByEmailMessageID resolved across agents")
 	}
 }
 

--- a/internal/identity/store_test.go
+++ b/internal/identity/store_test.go
@@ -544,6 +544,66 @@ func TestGetInboundMessageExpired(t *testing.T) {
 	}
 }
 
+func TestGetRepliableMessage_ReturnsOutbound(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "owner@example.com", "Owner", "google-repliable-out")
+	store.ClaimOrCreateDomain(ctx, "repliable-out.example.com", user.ID)
+	a, _ := store.CreateAgent(ctx, "agent@repliable-out.example.com", "repliable-out.example.com", "", "https://example.com/webhook", "", user.ID)
+
+	out, err := store.CreateOutboundMessage(ctx, a.ID, []string{"bob@gmail.com"}, []string{"carol@gmail.com"}, nil, "Update", "send", "smtp", "<sent-1@repliable-out.example.com>", "conv_x", []byte("raw"))
+	if err != nil {
+		t.Fatalf("CreateOutboundMessage: %v", err)
+	}
+
+	// GetRepliableMessage resolves the outbound row with its recipients intact.
+	got, err := store.GetRepliableMessage(ctx, out.ID)
+	if err != nil {
+		t.Fatalf("GetRepliableMessage(outbound): %v", err)
+	}
+	if got.Direction != "outbound" {
+		t.Errorf("Direction = %q, want outbound", got.Direction)
+	}
+	if len(got.ToRecipients) != 1 || got.ToRecipients[0] != "bob@gmail.com" {
+		t.Errorf("ToRecipients = %v, want [bob@gmail.com]", got.ToRecipients)
+	}
+	if len(got.CC) != 1 || got.CC[0] != "carol@gmail.com" {
+		t.Errorf("CC = %v, want [carol@gmail.com]", got.CC)
+	}
+
+	// The legacy inbound-only lookup must still refuse the same outbound id —
+	// this is exactly the asymmetry the feature relies on.
+	if _, err := store.GetInboundMessage(ctx, out.ID); err == nil {
+		t.Error("GetInboundMessage returned an outbound message (direction filter regressed)")
+	}
+}
+
+func TestGetRepliableMessage_ExcludesHeldAndExpired(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "owner@example.com", "Owner", "google-repliable-held")
+	store.ClaimOrCreateDomain(ctx, "repliable-held.example.com", user.ID)
+	a, _ := store.CreateAgent(ctx, "agent@repliable-held.example.com", "repliable-held.example.com", "", "https://example.com/webhook", "", user.ID)
+
+	out, _ := store.CreateOutboundMessage(ctx, a.ID, []string{"bob@gmail.com"}, nil, nil, "Update", "send", "smtp", "", "", nil)
+
+	// A message still in review (not yet delivered) is not a valid reply target.
+	pool.Exec(ctx, `UPDATE messages SET status = 'pending_review' WHERE id = $1`, out.ID)
+	if _, err := store.GetRepliableMessage(ctx, out.ID); err == nil {
+		t.Error("GetRepliableMessage returned a held (pending_review) message")
+	}
+
+	// An expired message is likewise excluded.
+	pool.Exec(ctx, `UPDATE messages SET status = 'sent', expires_at = $1 WHERE id = $2`, time.Now().Add(-1*time.Hour), out.ID)
+	if _, err := store.GetRepliableMessage(ctx, out.ID); err == nil {
+		t.Error("GetRepliableMessage returned an expired message")
+	}
+}
+
 func TestDeleteExpiredMessages(t *testing.T) {
 	pool := testutil.TestDB(t)
 	store := identity.NewStore(pool)

--- a/internal/outbound/reply.go
+++ b/internal/outbound/reply.go
@@ -59,14 +59,42 @@ func ParseReplyRecipients(rawMessage []byte, replyAll bool, extraCC []string) (*
 	}
 
 	// Merge explicit CC from request (always, even without raw message)
+	result.CC = append(result.CC, mergeExtraCC(extraCC)...)
+
+	return result, nil
+}
+
+// ReplyRecipientsForOutbound resolves reply recipients for a message the agent
+// itself SENT. Unlike ParseReplyRecipients (which targets the original
+// sender via Reply-To/From), a reply to your own message continues the thread
+// to the people you sent it to: To = the original To, and — on reply_all — the
+// original Cc is added to Cc. The original Bcc is deliberately never carried
+// (a reply must not re-expose blind recipients). Explicit extraCC from the
+// request is merged into Cc. The values come from the stored outbound row's
+// recipient columns, which are the authoritative record of what was sent.
+//
+// Downstream Sender.Send() still normalizes, dedupes, and strips the agent's
+// own address, so this returns the recipients as-stored.
+func ReplyRecipientsForOutbound(origTo, origCC, extraCC []string, replyAll bool) *ReplyRecipients {
+	result := &ReplyRecipients{To: append([]string(nil), origTo...)}
+	if replyAll {
+		result.CC = append(result.CC, origCC...)
+	}
+	result.CC = append(result.CC, mergeExtraCC(extraCC)...)
+	return result
+}
+
+// mergeExtraCC trims, drops empties, and lowercases caller-supplied CC
+// addresses — the shared normalization both reply paths apply.
+func mergeExtraCC(extraCC []string) []string {
+	var out []string
 	for _, addr := range extraCC {
 		addr = strings.TrimSpace(addr)
 		if addr != "" {
-			result.CC = append(result.CC, strings.ToLower(addr))
+			out = append(out, strings.ToLower(addr))
 		}
 	}
-
-	return result, nil
+	return out
 }
 
 // BuildReferencesChain returns the References chain to write on a reply,

--- a/internal/outbound/reply_test.go
+++ b/internal/outbound/reply_test.go
@@ -266,3 +266,54 @@ func TestBuildReferencesChain_MultiPartyThreadFork(t *testing.T) {
 		t.Errorf("got %v, want %v", got, want)
 	}
 }
+
+func TestReplyRecipientsForOutbound_Reply(t *testing.T) {
+	// Plain reply to your own sent message: To = original To, no Cc carried.
+	rr := ReplyRecipientsForOutbound(
+		[]string{"bob@x.com", "carol@x.com"},
+		[]string{"dave@x.com"},
+		nil, false,
+	)
+	if !reflect.DeepEqual(rr.To, []string{"bob@x.com", "carol@x.com"}) {
+		t.Errorf("To = %v, want original To", rr.To)
+	}
+	if len(rr.CC) != 0 {
+		t.Errorf("CC = %v, want empty on non-reply_all", rr.CC)
+	}
+}
+
+func TestReplyRecipientsForOutbound_ReplyAll(t *testing.T) {
+	// reply_all adds the original Cc; extraCC is merged and lowercased.
+	rr := ReplyRecipientsForOutbound(
+		[]string{"bob@x.com"},
+		[]string{"dave@x.com"},
+		[]string{"  Eve@X.com  "},
+		true,
+	)
+	if !reflect.DeepEqual(rr.To, []string{"bob@x.com"}) {
+		t.Errorf("To = %v, want [bob@x.com]", rr.To)
+	}
+	if !reflect.DeepEqual(rr.CC, []string{"dave@x.com", "eve@x.com"}) {
+		t.Errorf("CC = %v, want [dave@x.com eve@x.com]", rr.CC)
+	}
+}
+
+func TestReplyRecipientsForOutbound_EmptyTo(t *testing.T) {
+	// No recorded recipients: To is empty so the handler can fail closed
+	// rather than address the agent itself.
+	rr := ReplyRecipientsForOutbound(nil, nil, nil, false)
+	if len(rr.To) != 0 {
+		t.Errorf("To = %v, want empty", rr.To)
+	}
+}
+
+func TestReplyRecipientsForOutbound_DoesNotMutateInputs(t *testing.T) {
+	origTo := []string{"bob@x.com"}
+	origCC := []string{"dave@x.com"}
+	rr := ReplyRecipientsForOutbound(origTo, origCC, []string{"eve@x.com"}, true)
+	rr.To = append(rr.To, "mutated@x.com")
+	rr.CC = append(rr.CC, "mutated@x.com")
+	if len(origTo) != 1 || len(origCC) != 1 {
+		t.Errorf("inputs mutated: origTo=%v origCC=%v", origTo, origCC)
+	}
+}

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -149,7 +149,7 @@ shows the set your scope allows, with per-tool descriptions.
 | Tool | Description |
 | --- | --- |
 | `send_message` | Send a new email. When the agent's outbound policy or content scan holds it for review, the message is held and returns `status: pending_review` instead of `sent`. |
-| `reply_to_message` | Reply to an inbound message. Preserves In-Reply-To / References for thread continuity. |
+| `reply_to_message` | Reply to a message — one the agent received (replies to its sender) or one it sent (continues the thread to the original recipients). Preserves In-Reply-To / References for thread continuity. |
 | `list_messages` | List inbound mail. Filter by `read_status` (unread / read / all); cursor-paginated (`cursor` + `limit` in, `next_cursor` out). |
 | `get_message` | Fetch full body, headers, and attachment metadata for one message. |
 | `get_attachment` | Get one attachment's metadata + a short-lived `download_url` (fetch the bytes out of band); `inline: true` returns base64 `data` for small files (≤256 KB). |

--- a/mcp/src/tools/messages.ts
+++ b/mcp/src/tools/messages.ts
@@ -81,12 +81,12 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
   server.registerTool(
     "reply_to_message",
     {
-      title: "Reply to a received message",
+      title: "Reply to a message",
       annotations: { destructiveHint: false },
       description:
-        "Use whenever you're responding to a message you can see in the inbox — preserves the In-Reply-To and References headers so the reply joins the original email thread instead of starting a new one. Prefer this over `send_message` for any response to an inbound; thread fragmentation (broken conversation view in the recipient's mail client) is the most visible symptom of using `send_message` by mistake. Pass `reply_all: true` to copy the original Cc list; subject is auto-derived as `Re: …` by the server. Same review caveat as `send_message`: a `pending_review` status is success, not failure.",
+        "Use whenever you're responding to a message you can see — preserves the In-Reply-To and References headers so the reply joins the original email thread instead of starting a new one. Works on both a message the agent RECEIVED (replies to its sender) and a message the agent SENT (continues the thread to its original recipients, i.e. a Gmail-style follow-up on your own message). Prefer this over `send_message` for any in-thread response; thread fragmentation (broken conversation view in the recipient's mail client) is the most visible symptom of using `send_message` by mistake. Pass `reply_all: true` to copy the original Cc list; subject is auto-derived as `Re: …` by the server. Same review caveat as `send_message`: a `pending_review` status is success, not failure.",
       inputSchema: strictInputSchema({
-        message_id: z.string().describe("ID of the inbound message to reply to (e.g. msg_…)."),
+        message_id: z.string().describe("ID of the message to reply to — inbound or one the agent sent (e.g. msg_…)."),
         body: z.string().describe("Plain-text reply body."),
         html_body: z.string().optional(),
         reply_all: z
@@ -136,12 +136,12 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
   server.registerTool(
     "forward_message",
     {
-      title: "Forward an inbound message",
+      title: "Forward a message",
       annotations: { destructiveHint: false },
       description:
-        "Forward a message the agent has received to one or more new recipients. The server auto-prepends a Gmail-style header block (From/Date/Subject/To/Cc) and the original body to whatever optional comment you pass in `body`/`html_body`, **and carries over the original message's attachments by default** — you do NOT need to re-fetch them via `get_attachment`. Anything you pass in `attachments[]` is added on top of the originals. **Unlike `reply_to_message`, a forward is a NEW thread** — no In-Reply-To / References headers are emitted, so the recipient sees a fresh conversation. Use this when the user asks to share a received email with someone else; use `reply_to_message` when continuing the existing conversation. Same review behavior as send/reply: `pending_review` is success, not failure.",
+        "Forward a message the agent has received OR one it sent to one or more new recipients. The server auto-prepends a Gmail-style header block (From/Date/Subject/To/Cc) and the original body to whatever optional comment you pass in `body`/`html_body`, **and carries over the original message's attachments by default** — you do NOT need to re-fetch them via `get_attachment`. Anything you pass in `attachments[]` is added on top of the originals. **Unlike `reply_to_message`, a forward is a NEW thread** — no In-Reply-To / References headers are emitted, so the recipient sees a fresh conversation. Use this when the user asks to share an email with someone else; use `reply_to_message` when continuing the existing conversation. Same review behavior as send/reply: `pending_review` is success, not failure.",
       inputSchema: strictInputSchema({
-        message_id: z.string().describe("ID of the inbound message to forward (e.g. msg_…)."),
+        message_id: z.string().describe("ID of the message to forward — inbound or one the agent sent (e.g. msg_…)."),
         to: z.array(z.string()).describe("Forward target addresses (one or more)."),
         cc: z.array(z.string()).optional(),
         bcc: z.array(z.string()).optional(),

--- a/sdks/python/src/e2a/v1/generated/api/messages_api.py
+++ b/sdks/python/src/e2a/v1/generated/api/messages_api.py
@@ -395,7 +395,7 @@ class MessagesApi:
     ) -> SendResultView:
         """Forward a message
 
-        Forward an inbound message to new recipients; the original is quoted and its attachments are carried over by default. Any attachments[] you supply are added on top of the originals. 202 when held for HITL.
+        Forward a message (inbound or outbound) to new recipients; the original is quoted and its attachments are carried over by default. Any attachments[] you supply are added on top of the originals. 202 when held for HITL.
 
         :param email: (required)
         :type email: str
@@ -475,7 +475,7 @@ class MessagesApi:
     ) -> ApiResponse[SendResultView]:
         """Forward a message
 
-        Forward an inbound message to new recipients; the original is quoted and its attachments are carried over by default. Any attachments[] you supply are added on top of the originals. 202 when held for HITL.
+        Forward a message (inbound or outbound) to new recipients; the original is quoted and its attachments are carried over by default. Any attachments[] you supply are added on top of the originals. 202 when held for HITL.
 
         :param email: (required)
         :type email: str
@@ -555,7 +555,7 @@ class MessagesApi:
     ) -> RESTResponseType:
         """Forward a message
 
-        Forward an inbound message to new recipients; the original is quoted and its attachments are carried over by default. Any attachments[] you supply are added on top of the originals. 202 when held for HITL.
+        Forward a message (inbound or outbound) to new recipients; the original is quoted and its attachments are carried over by default. Any attachments[] you supply are added on top of the originals. 202 when held for HITL.
 
         :param email: (required)
         :type email: str
@@ -2058,7 +2058,7 @@ class MessagesApi:
     ) -> SendResultView:
         """Reply to a message
 
-        Reply to an inbound message; recipients/threading are derived from the original. 202 when held for HITL.
+        Reply to a message (inbound or outbound); recipients and threading are derived from the original. Replying to a message the agent received targets its sender; replying to a message the agent sent continues the thread to its original recipients (`reply_all` also re-includes the original Cc). 202 when held for HITL.
 
         :param email: (required)
         :type email: str
@@ -2138,7 +2138,7 @@ class MessagesApi:
     ) -> ApiResponse[SendResultView]:
         """Reply to a message
 
-        Reply to an inbound message; recipients/threading are derived from the original. 202 when held for HITL.
+        Reply to a message (inbound or outbound); recipients and threading are derived from the original. Replying to a message the agent received targets its sender; replying to a message the agent sent continues the thread to its original recipients (`reply_all` also re-includes the original Cc). 202 when held for HITL.
 
         :param email: (required)
         :type email: str
@@ -2218,7 +2218,7 @@ class MessagesApi:
     ) -> RESTResponseType:
         """Reply to a message
 
-        Reply to an inbound message; recipients/threading are derived from the original. 202 when held for HITL.
+        Reply to a message (inbound or outbound); recipients and threading are derived from the original. Replying to a message the agent received targets its sender; replying to a message the agent sent continues the thread to its original recipients (`reply_all` also re-includes the original Cc). 202 when held for HITL.
 
         :param email: (required)
         :type email: str

--- a/sdks/typescript/src/v1/generated/apis/MessagesApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/MessagesApi.ts
@@ -101,7 +101,7 @@ export class MessagesApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
-     * Forward an inbound message to new recipients; the original is quoted and its attachments are carried over by default. Any attachments[] you supply are added on top of the originals. 202 when held for HITL.
+     * Forward a message (inbound or outbound) to new recipients; the original is quoted and its attachments are carried over by default. Any attachments[] you supply are added on top of the originals. 202 when held for HITL.
      * Forward a message
      * @param email 
      * @param id 
@@ -460,7 +460,7 @@ export class MessagesApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
-     * Reply to an inbound message; recipients/threading are derived from the original. 202 when held for HITL.
+     * Reply to a message (inbound or outbound); recipients and threading are derived from the original. Replying to a message the agent received targets its sender; replying to a message the agent sent continues the thread to its original recipients (`reply_all` also re-includes the original Cc). 202 when held for HITL.
      * Reply to a message
      * @param email 
      * @param id 

--- a/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
@@ -1278,7 +1278,7 @@ export class ObjectMessagesApi {
     }
 
     /**
-     * Forward an inbound message to new recipients; the original is quoted and its attachments are carried over by default. Any attachments[] you supply are added on top of the originals. 202 when held for HITL.
+     * Forward a message (inbound or outbound) to new recipients; the original is quoted and its attachments are carried over by default. Any attachments[] you supply are added on top of the originals. 202 when held for HITL.
      * Forward a message
      * @param param the request object
      */
@@ -1287,7 +1287,7 @@ export class ObjectMessagesApi {
     }
 
     /**
-     * Forward an inbound message to new recipients; the original is quoted and its attachments are carried over by default. Any attachments[] you supply are added on top of the originals. 202 when held for HITL.
+     * Forward a message (inbound or outbound) to new recipients; the original is quoted and its attachments are carried over by default. Any attachments[] you supply are added on top of the originals. 202 when held for HITL.
      * Forward a message
      * @param param the request object
      */
@@ -1368,7 +1368,7 @@ export class ObjectMessagesApi {
     }
 
     /**
-     * Reply to an inbound message; recipients/threading are derived from the original. 202 when held for HITL.
+     * Reply to a message (inbound or outbound); recipients and threading are derived from the original. Replying to a message the agent received targets its sender; replying to a message the agent sent continues the thread to its original recipients (`reply_all` also re-includes the original Cc). 202 when held for HITL.
      * Reply to a message
      * @param param the request object
      */
@@ -1377,7 +1377,7 @@ export class ObjectMessagesApi {
     }
 
     /**
-     * Reply to an inbound message; recipients/threading are derived from the original. 202 when held for HITL.
+     * Reply to a message (inbound or outbound); recipients and threading are derived from the original. Replying to a message the agent received targets its sender; replying to a message the agent sent continues the thread to its original recipients (`reply_all` also re-includes the original Cc). 202 when held for HITL.
      * Reply to a message
      * @param param the request object
      */

--- a/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
@@ -1131,7 +1131,7 @@ export class ObservableMessagesApi {
     }
 
     /**
-     * Forward an inbound message to new recipients; the original is quoted and its attachments are carried over by default. Any attachments[] you supply are added on top of the originals. 202 when held for HITL.
+     * Forward a message (inbound or outbound) to new recipients; the original is quoted and its attachments are carried over by default. Any attachments[] you supply are added on top of the originals. 202 when held for HITL.
      * Forward a message
      * @param email
      * @param id
@@ -1159,7 +1159,7 @@ export class ObservableMessagesApi {
     }
 
     /**
-     * Forward an inbound message to new recipients; the original is quoted and its attachments are carried over by default. Any attachments[] you supply are added on top of the originals. 202 when held for HITL.
+     * Forward a message (inbound or outbound) to new recipients; the original is quoted and its attachments are carried over by default. Any attachments[] you supply are added on top of the originals. 202 when held for HITL.
      * Forward a message
      * @param email
      * @param id
@@ -1341,7 +1341,7 @@ export class ObservableMessagesApi {
     }
 
     /**
-     * Reply to an inbound message; recipients/threading are derived from the original. 202 when held for HITL.
+     * Reply to a message (inbound or outbound); recipients and threading are derived from the original. Replying to a message the agent received targets its sender; replying to a message the agent sent continues the thread to its original recipients (`reply_all` also re-includes the original Cc). 202 when held for HITL.
      * Reply to a message
      * @param email
      * @param id
@@ -1369,7 +1369,7 @@ export class ObservableMessagesApi {
     }
 
     /**
-     * Reply to an inbound message; recipients/threading are derived from the original. 202 when held for HITL.
+     * Reply to a message (inbound or outbound); recipients and threading are derived from the original. Replying to a message the agent received targets its sender; replying to a message the agent sent continues the thread to its original recipients (`reply_all` also re-includes the original Cc). 202 when held for HITL.
      * Reply to a message
      * @param email
      * @param id

--- a/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
@@ -808,7 +808,7 @@ export class PromiseMessagesApi {
     }
 
     /**
-     * Forward an inbound message to new recipients; the original is quoted and its attachments are carried over by default. Any attachments[] you supply are added on top of the originals. 202 when held for HITL.
+     * Forward a message (inbound or outbound) to new recipients; the original is quoted and its attachments are carried over by default. Any attachments[] you supply are added on top of the originals. 202 when held for HITL.
      * Forward a message
      * @param email
      * @param id
@@ -822,7 +822,7 @@ export class PromiseMessagesApi {
     }
 
     /**
-     * Forward an inbound message to new recipients; the original is quoted and its attachments are carried over by default. Any attachments[] you supply are added on top of the originals. 202 when held for HITL.
+     * Forward a message (inbound or outbound) to new recipients; the original is quoted and its attachments are carried over by default. Any attachments[] you supply are added on top of the originals. 202 when held for HITL.
      * Forward a message
      * @param email
      * @param id
@@ -958,7 +958,7 @@ export class PromiseMessagesApi {
     }
 
     /**
-     * Reply to an inbound message; recipients/threading are derived from the original. 202 when held for HITL.
+     * Reply to a message (inbound or outbound); recipients and threading are derived from the original. Replying to a message the agent received targets its sender; replying to a message the agent sent continues the thread to its original recipients (`reply_all` also re-includes the original Cc). 202 when held for HITL.
      * Reply to a message
      * @param email
      * @param id
@@ -972,7 +972,7 @@ export class PromiseMessagesApi {
     }
 
     /**
-     * Reply to an inbound message; recipients/threading are derived from the original. 202 when held for HITL.
+     * Reply to a message (inbound or outbound); recipients and threading are derived from the original. Replying to a message the agent received targets its sender; replying to a message the agent sent continues the thread to its original recipients (`reply_all` also re-includes the original Cc). 202 when held for HITL.
      * Reply to a message
      * @param email
      * @param id


### PR DESCRIPTION
## Problem

`POST /v1/agents/{email}/messages/{id}/reply` (and `/forward`) returned `404 not_found` when `{id}` was an **outbound** message the agent sent — even though `GET .../messages/{id}` returns that same message. Root cause: the reply/forward handlers resolved the target through `Store.GetInboundMessage`, whose query hard-filters `direction = 'inbound'`, while GET uses the direction-agnostic `GetMessageWithContent`.

## Fix

Adopt the mail-client rule: **replying to a message you sent continues the thread to its original recipients** (reply → original `To`; `reply_all` → `To` + original `Cc`), not reply-to-`From` (which is the agent itself → a self-addressed loop).

- **Store** — new `GetRepliableMessage` (any-direction sibling of `GetInboundMessage`, keeps the expiry + held-status exclusions) and `GetMessageByEmailMessageID` (direction-agnostic sibling for the HITL references rebuild). `messages.status` is `NOT NULL DEFAULT 'sent'`, so the `status NOT IN (...)` predicate never goes NULL and a normal sent outbound stays repliable.
- **httpapi** — `loadInbound` → `loadRepliableMessage`; reply recipients branch on direction (`replyRecipients` / `outbound.ReplyRecipientsForOutbound`). An outbound target with **no recorded recipients returns 400**, never a self-send. BCC is never carried. Agent-ownership guard and 404-on-miss preserved. Forward needs no recipient branch (recipients come from the request body).
- **HITL** — `attachReferencesChain` (both the `internal/agent` and `internal/hitlworker` copies) now rebuilds the References chain from an outbound parent too, so a held reply-to-own-message keeps its full chain on approval instead of forking multi-party threads.
- **Spec/SDK/docs** — reply/forward operation descriptions updated; `api/openapi.yaml` + TS/Python SDK bases regenerated; MCP `reply_to_message`/`forward_message` tool descriptions updated to say inbound-or-outbound.

## Decisions locked
1. reply = original `To`, reply_all = `To`+`Cc`, BCC never carried.
2. Outbound target with no recorded recipients → `400 invalid_recipient` (never self-send).
3. New, honestly-named `GetRepliableMessage` dep (legacy `GetInboundMessage` store method retained).
4. Direction-agnostic HITL references rebuild included (correctness-complete).

## Verification
- `make test-unit` (full), `make spec-check`, `make generate-sdk-check` — green.
- DB-backed suites: `internal/identity`, `internal/agent`, `internal/hitlworker` — green.
- New unit/handler tests: outbound recipient helper; reply/reply_all/forward-to-outbound + no-recipient 400 + inbound-unchanged regression (real HTTP); HITL outbound-parent references.
- **Full-stack e2e** (`internal/e2e`, real API + Postgres + SMTP relay): send → GET → reply → reply_all → forward → 404, asserting the reply targets the original recipient, reply_all re-adds the original Cc, the reply inherits the outbound's conversation, forward starts a new thread.
- MCP server `tsc` build — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)