### PR TITLE
docs(e2a/tether): shared-domain default, new-user onboarding, threading fix

### DIFF
--- a/plugins/e2a/skills/e2a/SKILL.md
+++ b/plugins/e2a/skills/e2a/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: e2a
 description: Use when operating e2a (email for AI agents) over its MCP tools — sending or receiving email, replying in-thread, handling the human-in-the-loop review hold (pending_review), managing agents and custom domains, or working with attachments — OR when integrating e2a into your own software/service (the developer email-API use case: API keys, SDKs, webhooks). With e2a YOU are the agent and the inbox IS the agent (not a human reading their mail). Covers send_message vs reply_to_message threading, multi-agent disambiguation, the custom-domain DNS flow, the protection (screening + review) config, programmatic integration, and common gotchas.
-version: 12
+version: 13
 ---
 
 # Using e2a
 
-<!-- version: 12 -->
+<!-- version: 13 -->
 
 e2a is an authenticated email gateway for AI agents. It gives an agent a real email address (`agent@agents.e2a.dev` or `agent@your-domain.com`), verifies sender identity (SPF/DKIM), threads conversations, and optionally holds outbound mail for human review.
 
@@ -23,21 +23,35 @@ The mental model below holds regardless of surface. Tool descriptions teach the 
 
 ## The mental model
 
-Six load-bearing facts. Internalize these before you start calling tools.
+Seven load-bearing facts. Internalize these before you start calling tools.
 
 1. **An agent is an email address.** `support-bot@agents.e2a.dev` is an agent. When you send mail, the recipient sees a message FROM that address — not from "the user." When you list messages, you are reading the agent's own inbox, not the user's personal mail. You are not a secretary; you are the mailbox owner.
 
 2. **Replies preserve threads; new sends do not.** `reply_to_message` carries the `In-Reply-To` and `References` headers from the original message, so the response lands in the same email thread. A fresh `send_message` creates a new thread every time. If a user (or an inbound message) is asking you to respond to something specific, reply with the original `message_id` — even when you could synthesize an equivalent body as a new send. Thread fragmentation is the #1 visible symptom of getting this wrong.
 
+   **Two threading systems, and they don't share a key.** e2a threads on `conversation_id` (it's what `list_conversations`/`get_conversation` group by). The recipient's mail client — Gmail, Outlook, Apple Mail — ignores `conversation_id` entirely and threads on the wire headers instead: `In-Reply-To`/`References` plus a **stable `Subject`**. `reply_to_message` sets those headers correctly, so it threads in *both* systems. A `send_message` — even one you tag with the same `conversation_id` — carries no `References` and lets you pick a new subject: e2a still files it in the same conversation, but the user's inbox shows a *separate* thread. This is the trap — the `conversation_id` looks like it threads because e2a's own views stay tidy, while Gmail splits the exchange in two. Within one ongoing exchange: reply, and keep the subject stable.
+
 3. **`pending_review` is success, not failure.** When the agent's protection config holds outbound mail, a send returns `{ status: "pending_review", message_id: "msg_..." }`. The message was accepted by the server and is being held for a human to review. Do NOT retry. Do NOT report this as an error to the user. Tell them the draft was queued for review, and (if asked) check on it via the pending tools.
 
 4. **Multi-agent accounts need `agent_email` per call.** If the account owns exactly one agent (the common case), tools auto-resolve to it — `whoami` is the cheapest way to confirm. If the account owns more than one, you'll get "agentEmail required." The fix is to enumerate once (`list_agents`), then pass `agent_email` explicitly to subsequent calls. Don't guess; don't pick at random; don't ask the user to pick if context already makes the choice obvious (e.g. they said "my support inbox").
 
-5. **Custom domains are a two-step async dance.** `register_domain` returns DNS records (MX + TXT) to publish — it does NOT make the domain live. The user (or a DNS-provider MCP, if one is loaded) must add those records out-of-band, wait for DNS propagation (minutes to hours), then `verify_domain`. Verification is idempotent and safe to retry. Until verification succeeds, the domain cannot send or receive mail. Don't promise the user their domain works the moment registration returns.
+5. **Most users don't need a custom domain — default to the shared one.** Every account can create agents on the shared `agents.e2a.dev` domain with zero DNS setup: `create_agent` with just a local part (e.g. `support-bot`) yields `support-bot@agents.e2a.dev`, live immediately. This is the right default for onboarding and for anyone who doesn't already **own** a domain. Only reach for a custom domain when the user explicitly owns a domain and wants branded addresses — if they don't own one, stay on `agents.e2a.dev` and skip the domain flow entirely. Don't send a user who just wants to get started down the DNS dance.
 
-6. **HITL lives in the protection config.** A new agent has no review hold by default. To turn one on, set the agent's protection posture (see below).
+6. **Custom domains are a two-step async dance.** `register_domain` returns DNS records (MX + TXT) to publish — it does NOT make the domain live. The user (or a DNS-provider MCP, if one is loaded) must add those records out-of-band, wait for DNS propagation (minutes to hours), then `verify_domain`. Verification is idempotent and safe to retry. Until verification succeeds, the domain cannot send or receive mail. Don't promise the user their domain works the moment registration returns.
+
+7. **HITL lives in the protection config.** A new agent has no review hold by default. To turn one on, set the agent's protection posture (see below).
 
 ## Common workflows
+
+### First run: onboard a new user before anything else
+
+Before driving any e2a task or harness, check whether this is a **new/unconfigured user** and, if so, get them to a working setup instead of failing partway. One cheap probe answers it: call `whoami`.
+
+- **`whoami` errors with auth/connection failure** → not connected over MCP yet. Point the user at connecting the e2a plugin and completing OAuth: open **https://e2a.dev/e2a.md** (the connect guide) and, in Claude Code, run `/plugin` to authenticate. Interactive auth is theirs to complete — hand them the step, don't try to drive it. Once connected, continue.
+- **`whoami` succeeds but the account has no agent** (or `list_agents` is empty) → connected, but no inbox exists. Create their first one on the shared domain with `create_agent` (local part only → `name@agents.e2a.dev`, live immediately — see mental-model fact #5). No custom domain, no DNS.
+- **`whoami` returns an agent** → already set up; proceed straight to the task.
+
+The through-line: for a first-time user, **help them stand up a functional e2a setup first** (connect → create a shared-domain inbox), then run the harness — rather than assuming credentials and erroring. Default new inboxes to `agents.e2a.dev`; only involve a custom domain if the user owns one and asks for it.
 
 ### Triage the inbox
 
@@ -80,6 +94,8 @@ Posture lives on the protection sub-resource — `update_protection` (MCP) / `PU
 - Read the current posture with `get_protection`. Both are account-scope only. Confirm the exact shape with `tools/list` / the OpenAPI contract — the protection config is beta and may change.
 
 ### Add a custom domain (e.g. `mail.acme.com`)
+
+**First: does the user actually own this domain?** If they just want to get started and don't own a domain, skip this entirely — create the agent on the shared `agents.e2a.dev` (mental-model fact #5), which is live with no DNS. Only run the flow below when the user owns the domain and wants branded addresses.
 
 1. `register_domain` with the FQDN — returns MX + TXT records and an unverified domain row.
 2. Hand the records to the user (or to a DNS-provider MCP — Cloudflare, Route 53, etc. — if one is loaded; call its `create_dns_record`-style tool with the returned values).

--- a/plugins/e2a/skills/tether/SKILL.md
+++ b/plugins/e2a/skills/tether/SKILL.md
@@ -14,6 +14,13 @@ timer, not every turn), and checks your inbox on an interval so your replies —
 questions or new instructions — are picked up within a few minutes. Reply
 `stop` to end.
 
+> **Transport primer.** tether rides on e2a. The e2a *operate-well manual* —
+> the `e2a` skill (`${CLAUDE_PLUGIN_ROOT}/skills/e2a/SKILL.md`) — carries the
+> mental model this skill assumes: how threading really works (reply headers +
+> stable subject, **not** `conversation_id`), when a shared `agents.e2a.dev`
+> address is all you need vs. a custom domain, and the `pending_review`/HITL
+> gotcha. Read it if you're new to e2a; tether does not re-explain those.
+
 ## Architecture (why this shape)
 
 Coding agents are turn-based; nothing native listens to an inbox mid-session. So
@@ -46,7 +53,10 @@ inbox — least privilege, so a leaked key can't touch the rest of the account.
 
 1. **Get an agent-scoped API key from the e2a website:**
    **https://e2a.dev/api-keys** — create or pick an agent and generate a key
-   scoped to it. Note the agent's email address too.
+   scoped to it. Note the agent's email address too. If you don't already own a
+   domain, create the agent on the **shared `agents.e2a.dev`** domain (the
+   default — `name@agents.e2a.dev`, live immediately, no DNS). A custom domain is
+   only worth the setup if you own one and want branded addresses.
 2. **Save the credentials:**
    ```bash
    cp "${CLAUDE_PLUGIN_ROOT}/skills/tether/tether.env.example" ~/.e2a-tether.env
@@ -66,10 +76,34 @@ A smoother CLI path is coming.)
 > is held as an approval email instead of reaching you. `tether.sh` warns on
 > stderr if it sees `pending_review`.
 
+## First run (new user) — set them up, then tether
+
+Before tethering, confirm the harness can actually send. Run `"$T" status`
+(where `T` is defined below). If it reports **`config: MISSING`**, this is a
+first-time user — **help them get to a working setup instead of just failing**:
+
+1. **Is e2a connected at all?** If they've never used e2a, get them connected
+   first: open **https://e2a.dev** to sign up, and complete the plugin's MCP
+   OAuth (`/plugin` in Claude Code). If the e2a MCP tools (`mcp__e2a__*`) are
+   available, you can then create their first inbox directly with `create_agent`
+   on the shared `agents.e2a.dev` domain — no domain, no DNS. Interactive
+   sign-in/OAuth is theirs to complete: hand them the step, don't drive it.
+2. **Mint the tether key.** tether's poller is a plain-`curl` script, so it needs
+   an **agent-scoped API key** (`e2a_agt_…`), which the MCP OAuth session doesn't
+   provide. Send them to **https://e2a.dev/api-keys** to generate a key scoped to
+   that agent, then save it per **Setup** above (`~/.e2a-tether.env`).
+3. **Re-check.** `"$T" status` should now print `config: OK (agent …)`. Proceed
+   to the runtime flow.
+
+If `status` already prints `config: OK`, skip this — they're a returning user.
+Don't put a configured user through onboarding.
+
 ## Runtime flow (what the agent does when `/tether` is invoked)
 
 Let `T="${CLAUDE_PLUGIN_ROOT}/skills/tether/tether.sh"`.
 
+0. **Preflight.** Run `"$T" status`. If `config: MISSING`, do **First run (new
+   user)** above before continuing — don't call `start` and let it error out.
 1. **Ask** the user's email address **and how long to stay tethered** (e.g. 30m,
    2h, 8h/overnight, or until they say stop). They're present at this step, so a
    normal question is fine.
@@ -125,7 +159,14 @@ Write for that medium, not for a CLI.
 - **Acknowledge fast.** When a reply comes in, a quick "on it — doing X" beats
   silence; there's inherent email latency, so don't leave the user wondering if
   you heard them.
-- Everything stays in one thread automatically (updates reply into it).
+- **Keep it in one thread — always `update`, never a fresh send.** `tether.sh`
+  threads by *replying* (In-Reply-To/References + a stable subject), which is what
+  Gmail/Outlook actually stitch on. e2a threads on `conversation_id`, but Gmail
+  ignores that — so a fresh send in the same e2a conversation still lands as a
+  *second* thread in the user's inbox (the split Gmail showed). While tethered,
+  send every update through `"$T" update` (it replies into the thread); do **not**
+  reach for the e2a MCP `send_message` or start a new subject to reach the user
+  mid-session. One session = one thread = one subject.
 
 ## Poll interval & knobs
 

--- a/web/public/e2a.md
+++ b/web/public/e2a.md
@@ -102,7 +102,12 @@ current signatures and treat that as the source of truth. The surface, by area:
 - **You are the agent; the inbox is yours.** Don't model a separate "user
   mailbox."
 - **Threading.** Answer with `reply_to_message` (not a fresh `send`) to stay in
-  the same conversation — e2a carries `conversation_id` across turns.
+  the same conversation. e2a threads on `conversation_id`, but the recipient's
+  mail client (Gmail/Outlook) ignores that and threads on the reply's
+  `In-Reply-To`/`References` headers plus a stable subject — which
+  `reply_to_message` sets. So a fresh `send` (even with the same
+  `conversation_id`, or a changed subject) stays in the same e2a conversation but
+  shows up as a separate thread in the user's inbox.
 - **HITL.** A send may come back `pending_review` instead of `sent`. That's the
   human-approval gate, not an error; it resolves when a human approves/rejects
   (or the review TTL expires).


### PR DESCRIPTION
Addresses onboarding friction found during a new-user tether run (shared-domain confusion + a Gmail thread split).

## Changes

**Shared-domain default** (`plugins/e2a/skills/e2a/SKILL.md`)
- New mental-model fact: most users don't need a custom domain — create agents on the shared `agents.e2a.dev` (zero DNS, live immediately). The custom-domain workflow now gates on the user actually *owning* the domain, so a first-timer isn't sent down the DNS dance.

**New-user detection / guided onboarding**
- `e2a` skill: a "First run" workflow — probe with `whoami`, then connect over MCP (OAuth) → create a shared-domain inbox → proceed. Stand up a working setup before running any task instead of assuming creds.
- `tether` skill: a `status` preflight (step 0) + a "First run (new user)" section that walks signup/OAuth and minting the agent-scoped key, rather than letting `start` error on missing config.

**Threading correctness** (`e2a` skill, `tether` skill, hosted `web/public/e2a.md`)
- Clarify the two independent threading systems: **e2a threads on `conversation_id`, but Gmail/Outlook ignore it** and thread on `In-Reply-To`/`References` + a stable subject. `reply_to_message` threads in both; a fresh `send` (even in the same e2a conversation, or with a changed subject) shows as a *separate* thread in the user's inbox — the exact split a new user hit.

**Cross-reference**
- `tether` now points at the top-level `e2a` skill for the shared mental model instead of duplicating it.

Docs-only. `tether.sh _selftest` passes; skill fact numbering renumbered cleanly (1–7). `web/out/e2a.md` is gitignored (regenerated on build) so only the `web/public/` source is edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)