### PR TITLE
fix(plugin/tether): silent-failure fixes from the harness journey review

### DIFF
--- a/plugins/e2a/skills/tether/SKILL.md
+++ b/plugins/e2a/skills/tether/SKILL.md
@@ -73,8 +73,11 @@ Credentials resolve in order: explicit env vars → `~/.e2a-tether.env` →
 A smoother CLI path is coming.)
 
 > The tether agent must have send-side protection / HITL **off**, or each update
-> is held as an approval email instead of reaching you. `tether.sh` warns on
-> stderr if it sees `pending_review`.
+> is held for review instead of reaching you. `tether.sh` now detects this on
+> every send: a held intro makes `start` **refuse to arm**, and a held
+> `update`/`ask` prints a `HELD for review (pending_review)` warning and exits
+> non-zero — so a held session fails loudly instead of "reporting" into a queue
+> the user never sees.
 
 ## First run (new user) — set them up, then tether
 
@@ -108,18 +111,29 @@ Let `T="${CLAUDE_PLUGIN_ROOT}/skills/tether/tether.sh"`.
    2h, 8h/overnight, or until they say stop). They're present at this step, so a
    normal question is fine.
 2. **Start**: `"$T" start <email> --for <duration>` (or `--until <ISO>`; omit
-   both for until-stop) — sends the intro, opens the thread, arms, records the window.
+   both for until-stop) — sends the intro, opens the thread, arms, records the
+   window. `--for` takes a **single unit** (`30m`, `2h`, `8h`, `1d`); a compound
+   like `1h30m` is rejected rather than silently treated as no-limit. If the intro
+   comes back **held for review** (`pending_review`), `start` refuses to arm and
+   tells you to turn protection off — a held intro means the user never got it.
 3. **Work**, and **send updates as you see fit**: `"$T" update "<what changed / what you need>"`.
    Good moments: finished a slice, made a decision that's worth surfacing, hit a
    blocker, or before a long unattended stretch. Skip trivial turns. For a rich
    update (diagram, table, formatting), write the HTML to a file and run
    `"$T" update --html <file>` — a plain-text fallback is auto-derived (or pass
-   `--text "<fallback>"`).
+   `--text "<fallback>"`). If `update` prints a `HELD for review (pending_review)`
+   warning (exit 2), the update did **not** reach the user — stop and fix
+   protection before continuing; don't keep "reporting" into a review queue.
 4. **Need a decision from the user? Ask by email — never the terminal.** Run
    `"$T" ask "<question>"` (in the background); it emails the question and blocks
    until the user replies, then prints the answer. **Do not** use AskUserQuestion
    or a bare terminal prompt while tethered — an AFK user can't answer it and the
-   session stalls.
+   session stalls. `ask` coordinates with `listen` automatically (it holds a lock
+   so a background `listen` pauses and can't swallow your answer). Handle its exit
+   codes: **exit 3** = timed out with no reply (default 30m) — re-`ask`, send a
+   nudge `update`, or keep working and listening, but never fall back to a
+   terminal prompt; **exit 4** = the question was held for review and never
+   reached the user (fix protection).
 5. **Listen for the whole window**: run `"$T" listen` **in the background**. It
    polls cheaply (curl, no tokens) and exits with either:
    - `REPLY_RECEIVED:` + the message → act on it (then `update` with the result),

--- a/plugins/e2a/skills/tether/lib.sh
+++ b/plugins/e2a/skills/tether/lib.sh
@@ -6,13 +6,17 @@
 # `tether.sh start <email>` and kept in the state file.
 
 t_load_config() {
+  # Explicit env vars win; each fallback source fills only the vars still missing
+  # (so exporting just E2A_API_KEY in the env doesn't skip an email set in the file).
+  local envk="${E2A_API_KEY:-}" enve="${E2A_AGENT_EMAIL:-}" envu="${E2A_BASE_URL:-}"
+
   # 1) explicit tether config
-  if [ -z "${E2A_API_KEY:-}" ] && [ -f "${HOME}/.e2a-tether.env" ]; then
+  if { [ -z "${E2A_API_KEY:-}" ] || [ -z "${E2A_AGENT_EMAIL:-}" ]; } && [ -f "${HOME}/.e2a-tether.env" ]; then
     # shellcheck disable=SC1091
     set -a; . "${HOME}/.e2a-tether.env"; set +a
   fi
   # 2) reuse the CLI's agent creds from `e2a login` (~/.e2a/config.json)
-  if [ -z "${E2A_API_KEY:-}" ] && [ -f "${HOME}/.e2a/config.json" ]; then
+  if { [ -z "${E2A_API_KEY:-}" ] || [ -z "${E2A_AGENT_EMAIL:-}" ]; } && [ -f "${HOME}/.e2a/config.json" ]; then
     eval "$(python3 -c 'import json,shlex,os
 try:
   d=json.load(open(os.path.expanduser("~/.e2a/config.json")))
@@ -21,6 +25,17 @@ try:
   if d.get("api_url"):     print("export E2A_BASE_URL="+shlex.quote(d["api_url"].rstrip("/")))
 except Exception:pass')"
   fi
+  # explicit env always wins over whatever a fallback source supplied
+  [ -n "$envk" ] && E2A_API_KEY="$envk"
+  [ -n "$enve" ] && E2A_AGENT_EMAIL="$enve"
+  [ -n "$envu" ] && E2A_BASE_URL="$envu"
+
+  # Treat the copied-but-unfilled tether.env.example placeholders as unset, so a
+  # user who ran `cp … tether.env.example` without editing gets `config: MISSING`
+  # (the new-user signal) instead of a bogus `config: OK` that fails at `start`.
+  case "${E2A_API_KEY:-}" in *...*) E2A_API_KEY="";; esac
+  case "${E2A_AGENT_EMAIL:-}" in *@*.example|*.example) E2A_AGENT_EMAIL="";; esac
+
   E2A_BASE_URL="${E2A_BASE_URL:-https://api.e2a.dev}"
   [ -n "${E2A_API_KEY:-}" ] && [ -n "${E2A_AGENT_EMAIL:-}" ]
 }
@@ -51,18 +66,32 @@ for i in range(0,len(kv),2):d[kv[i]]=kv[i+1]
 json.dump(d,open(f,"w"),indent=2)' "$f" "$@"
 }
 
-t_state_clear() { rm -f "$(t_state_path)"; }
+t_state_clear() { rm -f "$(t_state_path)" "$(t_ask_lock_path)"; }
+
+# --- ask/listen mutex --------------------------------------------------------
+# `ask` and `listen` both poll the same inbox and share one dedup cursor, so if
+# they run at once whichever polls first consumes the reply — a running `listen`
+# would eat the answer `ask` is blocking for, and `ask` would spin to timeout.
+# While an `ask` is in flight it holds this lock; `listen` sees it and pauses
+# polling so the answer flows to the blocked `ask`.
+
+t_ask_lock_path() { echo "$(dirname "$(t_state_path)")/ask.lock"; }
+t_ask_begin()  { local f; f="$(t_ask_lock_path)"; mkdir -p "$(dirname "$f")"; : > "$f"; }
+t_ask_end()    { rm -f "$(t_ask_lock_path)"; }
+t_ask_active() { [ -f "$(t_ask_lock_path)" ]; }
 
 # --- duration / expiry -------------------------------------------------------
 
-# t_duration_to_expiry <dur> → ISO expires_at (empty = no expiry / "until stop")
-# accepts: 30m, 2h, 8h, 1d ; "" / forever / until-stop → empty
+# t_duration_to_expiry <dur> → ISO expires_at (empty = no expiry / "until stop";
+# "INVALID" = unparseable, so the caller can reject it instead of silently
+# treating a mistyped "1h30m"/"90 min" as an unbounded window).
+# accepts a SINGLE unit: 30m, 2h, 8h, 1d ; "" / forever / until-stop → empty
 t_duration_to_expiry() {
   python3 -c 'import sys,datetime,re
 d=(sys.argv[1] if len(sys.argv)>1 else "").strip().lower()
 if not d or d in ("forever","none","off","until-stop","stop"):print("");raise SystemExit
 m=re.fullmatch(r"(\d+)\s*([mhd])",d)
-if not m:print("");raise SystemExit
+if not m:print("INVALID");raise SystemExit
 secs=int(m.group(1))*{"m":60,"h":3600,"d":86400}[m.group(2)]
 print((datetime.datetime.now(datetime.timezone.utc)+datetime.timedelta(seconds=secs)).isoformat())' "$1"
 }
@@ -80,9 +109,11 @@ except Exception:print(2147483647)' "$exp"
 
 # --- e2a API -----------------------------------------------------------------
 
-# t_api_send <to> <subject> <body> <conversation_id> → prints message_id
+# t_api_send <to> <subject> <body> <conversation_id> → prints message_id;
+# returns 2 (and warns on stderr) if the send was HELD (pending_review) so the
+# caller can refuse to arm / not report a phantom "sent".
 t_api_send() {
-  local email resp status
+  local email resp status mid
   email="$(t_urlencode "$E2A_AGENT_EMAIL")"
   local payload
   payload="$(python3 -c 'import json,sys
@@ -94,15 +125,22 @@ print(json.dumps({"to":[sys.argv[1]],"subject":sys.argv[2],"body":sys.argv[3],"c
   status="$(printf '%s' "$resp" | python3 -c 'import json,sys
 try:print(json.load(sys.stdin).get("status",""))
 except Exception:print("")')"
-  [ "$status" = "pending_review" ] && echo "tether: WARNING send held (pending_review) — disable protection on ${E2A_AGENT_EMAIL}" >&2
-  printf '%s' "$resp" | python3 -c 'import json,sys
+  mid="$(printf '%s' "$resp" | python3 -c 'import json,sys
 try:print(json.load(sys.stdin).get("message_id",""))
-except Exception:print("")'
+except Exception:print("")')"
+  printf '%s' "$mid"
+  if [ "$status" = "pending_review" ]; then
+    echo "tether: WARNING send held (pending_review) — disable protection on ${E2A_AGENT_EMAIL}" >&2
+    return 2
+  fi
 }
 
-# t_api_reply <in_reply_to_id> <body> [html_body] → prints new message_id
+# t_api_reply <in_reply_to_id> <body> [html_body] → prints new message_id;
+# returns 2 (and warns on stderr) if the reply was HELD (pending_review). The
+# reply path — every update/ask/stop — used to drop `status`, so a held update
+# printed a phantom "sent" while the user's inbox stayed empty.
 t_api_reply() {
-  local email resp
+  local email resp status mid
   email="$(t_urlencode "$E2A_AGENT_EMAIL")"
   resp="$(curl -sS -m 30 -X POST \
     -H "Authorization: Bearer ${E2A_API_KEY}" -H "Content-Type: application/json" \
@@ -111,9 +149,17 @@ p={"body":sys.argv[1]}
 if len(sys.argv)>2 and sys.argv[2]:p["html_body"]=sys.argv[2]
 print(json.dumps(p))' "$2" "${3:-}")" \
     "${E2A_BASE_URL}/v1/agents/${email}/messages/${1}/reply" 2>/dev/null)" || return 1
-  printf '%s' "$resp" | python3 -c 'import json,sys
+  status="$(printf '%s' "$resp" | python3 -c 'import json,sys
+try:print(json.load(sys.stdin).get("status",""))
+except Exception:print("")')"
+  mid="$(printf '%s' "$resp" | python3 -c 'import json,sys
 try:print(json.load(sys.stdin).get("message_id",""))
-except Exception:print("")'
+except Exception:print("")')"
+  printf '%s' "$mid"
+  if [ "$status" = "pending_review" ]; then
+    echo "tether: WARNING reply held (pending_review) — disable protection on ${E2A_AGENT_EMAIL}" >&2
+    return 2
+  fi
 }
 
 # strip HTML tags → a plain-text fallback (crude but fine for email body)

--- a/plugins/e2a/skills/tether/tether.sh
+++ b/plugins/e2a/skills/tether/tether.sh
@@ -39,7 +39,10 @@ case "$cmd" in
     [ -n "$to" ] || { echo "usage: tether.sh start <your-email> [--for 2h|8h|30m|1d] [--until <ISO>]"; exit 2; }
     expires=""
     if [ -n "$untilarg" ]; then expires="$untilarg"
-    elif [ -n "$forarg" ]; then expires="$(t_duration_to_expiry "$forarg")"; fi
+    elif [ -n "$forarg" ]; then
+      expires="$(t_duration_to_expiry "$forarg")"
+      [ "$expires" = "INVALID" ] && { echo "tether: can't parse --for '$forarg' — use a single unit (30m, 2h, 8h, 1d). Omit --for for no time limit."; exit 2; }
+    fi
     window="${forarg:-${untilarg:-until you say stop}}"
     proj="$(basename "$PWD")"
     conv="tether-$(date +%s)-$$"
@@ -50,8 +53,13 @@ make meaningful progress, and I'll pick up your replies. Reply any time with a
 question or instruction; reply \"stop\" to end early.
 
 — your coding agent"
-    mid="$(t_api_send "$to" "Tether: ${proj}" "$intro" "$conv")"
+    mid="$(t_api_send "$to" "Tether: ${proj}" "$intro" "$conv")"; rc=$?
     [ -n "$mid" ] || { echo "tether: intro send failed (check creds / base url / agent protection)"; exit 1; }
+    if [ "$rc" = "2" ]; then
+      echo "tether: intro was HELD for review (pending_review) — the user won't receive it, so NOT arming."
+      echo "        Turn send-side protection/HITL OFF on ${E2A_AGENT_EMAIL}, then run start again."
+      exit 1
+    fi
     t_state_set armed 1 to "$to" conversation_id "$conv" last_message_id "$mid" \
       last_poll "$(t_now_iso)" project "$proj" started_at "$(t_now_iso)" expires_at "$expires"
     echo "tether: started — thread ${conv} → ${to} (intro ${mid}); window: ${window}${expires:+ (until ${expires})}"
@@ -79,9 +87,13 @@ question or instruction; reply \"stop\" to end early.
     fi
     [ -n "$msg" ] || { echo "usage: tether.sh update \"<text>\"  |  update --html <file> [--text \"<fallback>\"]"; exit 2; }
     rid="$(t_state_get last_message_id)"
-    mid="$(t_api_reply "$rid" "$msg" "$html")"
+    mid="$(t_api_reply "$rid" "$msg" "$html")"; rc=$?
     if [ -z "$mid" ]; then echo "tether: update send failed"; exit 1; fi
     t_state_set last_message_id "$mid"
+    if [ "$rc" = "2" ]; then
+      echo "tether: WARNING update HELD for review (pending_review) — it did NOT reach the user. Disable send-side protection on ${E2A_AGENT_EMAIL}."
+      exit 2
+    fi
     echo "tether: update sent (${mid})$([ -n "$html" ] && echo ' [html]')"
     ;;
 
@@ -113,6 +125,11 @@ question or instruction; reply \"stop\" to end early.
     while :; do
       rem="$(t_remaining_seconds)"
       if [ "$rem" -le 0 ]; then echo "TETHER_EXPIRED"; exit 0; fi
+      # An `ask` is blocking on the same inbox — don't poll, or we'd consume the
+      # answer it's waiting for. Idle until the ask releases the lock.
+      if t_ask_active; then
+        s="$interval"; [ "$rem" -lt "$s" ] && s="$rem"; sleep "$s"; continue
+      fi
       out="$(t_poll_once)"
       if [ "$out" != "(no new replies)" ]; then echo "REPLY_RECEIVED:"; echo "$out"; exit 0; fi
       s="$interval"; [ "$rem" -lt "$s" ] && s="$rem"
@@ -127,12 +144,20 @@ question or instruction; reply \"stop\" to end early.
     # background and wait for the completion notification.
     need_config; need_armed
     q="${1:-}"; [ -n "$q" ] || { echo "usage: tether.sh ask \"<question>\""; exit 2; }
+    # Hold the ask lock for this whole invocation so a background `listen` pauses
+    # and doesn't steal the answer; released on any exit (reply, timeout, error).
+    trap 't_ask_end' EXIT INT TERM
+    t_ask_begin
     rid="$(t_state_get last_message_id)"
     mid="$(t_api_reply "$rid" "❓ ${q}
 
-(Reply to this email with your answer — I'll wait for it.)")"
+(Reply to this email with your answer — I'll wait for it.)")"; rc=$?
     [ -n "$mid" ] || { echo "tether: ask send failed"; exit 1; }
     t_state_set last_message_id "$mid"
+    if [ "$rc" = "2" ]; then
+      echo "tether: WARNING question HELD for review (pending_review) — it did NOT reach the user, so not waiting. Disable send-side protection on ${E2A_AGENT_EMAIL}."
+      exit 4
+    fi
     echo "tether: question sent (${mid}); waiting for your reply…"
     max="${E2A_TETHER_ASK_TIMEOUT:-1800}"; interval="${E2A_TETHER_POLL_INTERVAL:-20}"; elapsed=0
     while [ "$elapsed" -lt "$max" ]; do
@@ -175,7 +200,31 @@ question or instruction; reply \"stop\" to end early.
     env -u E2A_API_KEY -u E2A_AGENT_EMAIL HOME=/nonexistent TETHER_STATE=/tmp/tether-selftest.json \
       bash "${here}/tether.sh" status
     rm -f /tmp/tether-selftest.json
+
+    fail=0
+    ck() { if [ "$2" = "$3" ]; then echo "ok: $1"; else echo "FAIL: $1 (want [$3] got [$2])"; fail=1; fi; }
+
+    echo "# duration parser:"
+    ck "2h parses"        "$([ -n "$(t_duration_to_expiry 2h)" ] && echo good)" "good"
+    ck "'' → until-stop"  "$(t_duration_to_expiry '')"     ""
+    ck "1h30m → INVALID"  "$(t_duration_to_expiry '1h30m')" "INVALID"
+    ck "'90 min'→INVALID" "$(t_duration_to_expiry '90 min')" "INVALID"
+
+    echo "# placeholder creds are treated as MISSING:"
+    ph="$(env E2A_API_KEY='e2a_agt_...' E2A_AGENT_EMAIL='tether@you.example' \
+      HOME=/nonexistent bash "${here}/tether.sh" status | grep -c 'config: MISSING')"
+    ck "unfilled template → MISSING" "$ph" "1"
+
+    echo "# ask/listen mutex:"
+    ( export TETHER_STATE=/tmp/tether-selftest-lock.json
+      t_ask_active && { echo "FAIL: lock present before begin"; exit 1; }
+      t_ask_begin;  t_ask_active || { echo "FAIL: lock absent after begin"; exit 1; }
+      t_ask_end;   ! t_ask_active || { echo "FAIL: lock present after end"; exit 1; }
+      echo "ok: ask lock begin/active/end" ) || fail=1
+    rm -f /tmp/tether-selftest-lock.json /tmp/ask.lock
+
     bash -n "${here}/lib.sh" && bash -n "${here}/tether.sh" && echo "# syntax OK"
+    [ "$fail" = "0" ] && echo "# selftest PASS" || { echo "# selftest FAIL"; exit 1; }
     ;;
 
   ""|help|-h|--help)


### PR DESCRIPTION
Applies the confirmed, no-external-dependency runtime fixes surfaced by the multi-agent user-journey review of the tether harness. All four made a new user's *first* tethered session fail silently. Covered by the extended `tether.sh _selftest` (duration parser, placeholder-cred gate, ask/listen mutex).

## Fixes

1. **`ask` + `listen` reply-stealing** — they share one dedup cursor, so a background `listen` would consume the answer `ask` blocks for, and `ask` spun to its 30m timeout. Added a filesystem mutex (`lib.sh` `t_ask_*`): `ask` holds a lock for its lifetime (trap-released on any exit); `listen` pauses polling while it's held. Also removes the concurrent state-write race.

2. **Placeholder creds passed the `config: MISSING` gate** — the copied-but-unfilled `tether.env.example` values (`e2a_agt_...`, `*.example`) passed the non-empty check as `config: OK`, then died cryptically at `start`. `t_load_config` now treats them as unset → correct new-user signal. Also fixes per-source precedence (each fallback fills only still-missing vars; explicit env always wins).

3. **`pending_review` silently swallowing the session** — the reply path dropped `status`, so a held `update` printed a phantom "sent" while the user's inbox stayed empty. `t_api_send`/`t_api_reply` now return `2` on a hold; `start` **refuses to arm** on a held intro; `update`/`ask` warn and exit non-zero. *(Note: could not verify from the repo that `…/reply` returns `pending_review` like `send` does — the check is defensive and harmless if it doesn't.)*

4. **Duration parser swallowing `1h30m`** — a compound/mistyped `--for` silently became an unbounded window while the intro email promised a bounded one. `t_duration_to_expiry` now returns `INVALID`; `start` rejects it with a clear message.

## Docs
SKILL runtime-flow updated: single-unit `--for`, held-send behavior, `ask`↔`listen` coordination, and `ask` exit codes (3 = timeout, 4 = held), including the "never fall back to a terminal prompt on timeout" rule.

## Deliberately deferred (separate PRs)
- `stop` auto-detection + silent-death-on-sleep (need a supervisor/trap design)
- doc-only consistency batch (`/plugin` vs `claude mcp add`, `whoami` multi-agent branch, key prefix)
- strategic onboarding fix: CLI `keys create` SDK wrapper

🤖 Generated with [Claude Code](https://claude.com/claude-code)