### PR TITLE
feat(plugin/tether): attach files to updates and asks (--attach)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "e2a plugins for Claude Code — authenticated email for AI agents",
-    "version": "0.4.5"
+    "version": "0.4.6"
   },
   "plugins": [
     {

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "e2a — authenticated email gateway for AI agents (MCP server + operate-well skill).",
-    "version": "0.4.5"
+    "version": "0.4.6"
   },
   "plugins": [
     {

--- a/plugins/e2a/.claude-plugin/plugin.json
+++ b/plugins/e2a/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 37 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "Mnexa AI",

--- a/plugins/e2a/.codex-plugin/plugin.json
+++ b/plugins/e2a/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 37 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "Mnexa AI"

--- a/plugins/e2a/.cursor-plugin/plugin.json
+++ b/plugins/e2a/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 37 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "Mnexa AI",

--- a/plugins/e2a/skills/tether/SKILL.md
+++ b/plugins/e2a/skills/tether/SKILL.md
@@ -126,14 +126,20 @@ Let `T="${CLAUDE_PLUGIN_ROOT}/skills/tether/tether.sh"`.
    far better in mail clients: write the HTML to a file and run
    `"$T" update --html <file>` — a plain-text fallback is auto-derived (or pass
    `--text "<fallback>"`). Plain `"$T" update "<text>"` is for quick one-liner
-   acks only. Good moments: finished a slice, made a decision that's worth
-   surfacing, hit a blocker, or before a long unattended stretch. Skip trivial
+   acks only. To send a file (a rendered PDF, a screenshot, a small log), add
+   `--attach <file>` — repeatable, on either form, capped at 15 MB total per
+   send (**exit 3** = file not found, **exit 4** = over the cap; past the cap,
+   upload the file somewhere and send a link instead). Good moments: finished a
+   slice, made a decision that's worth surfacing, hit a blocker, or before a
+   long unattended stretch. Skip trivial
    turns. If `update` prints a `HELD for review (pending_review)`
    warning (exit 2), the update did **not** reach the user — stop and fix
    protection before continuing; don't keep "reporting" into a review queue.
 4. **Need a decision from the user? Ask by email — never the terminal.** Run
    `"$T" ask "<question>"` (in the background); it emails the question and blocks
-   until the user replies, then prints the answer. **Do not** use AskUserQuestion
+   until the user replies, then prints the answer. `--attach <file>` works here
+   too — attach the artifact the decision hinges on (a diff, a mockup) rather
+   than describing it. **Do not** use AskUserQuestion
    or a bare terminal prompt while tethered — an AFK user can't answer it and the
    session stalls. `ask` coordinates with `listen` automatically (it holds a lock
    so a background `listen` pauses and can't swallow your answer). Handle its exit
@@ -173,14 +179,18 @@ Write for that medium, not for a CLI.
   single-sentence status. Anything with structure should be HTML.
 - **No markdown** — `**bold**`, `` `code` ``, `#` headings render as literal
   characters in a plain-text email. Use plain prose.
-- Note: `ask` is plain-text only — keep questions short and prose-only there.
+- Note: `ask` bodies are plain-text only (no `--html`) — keep questions short
+  and prose-only there. `--attach` does work on `ask`: attach the artifact the
+  decision hinges on (a diff, a mockup) rather than describing it.
 
 **Both:**
 - Lead with the takeaway (what changed / what you need), then details. Keep it
   short and scannable.
 - Be concrete: name the file / PR / decision ("merged #357"), not "did some work".
 - If you need something, end with **one clear ask** ("Reply A or B?").
-- No large code/log dumps — summarize or link. Don't paste stack traces.
+- No large code/log dumps — summarize or link. Don't paste stack traces. If the
+  artifact itself matters (a rendered PDF, a screenshot, a report), send it as
+  an attachment (`--attach`) instead of inlining it.
 - **Acknowledge fast.** When a reply comes in, a quick "on it — doing X" beats
   silence; there's inherent email latency, so don't leave the user wondering if
   you heard them.
@@ -229,7 +239,7 @@ it's cheap, so 20–30s is fine.
 
 | file | role |
 |---|---|
-| `tether.sh` | runtime CLI: `start [--title] [--for]` / `update` / `ask` / `listen` / `poll` / `status` / `stop` |
+| `tether.sh` | runtime CLI: `start [--title] [--for]` / `update [--html] [--attach]` / `ask [--attach]` / `listen` / `poll` / `status` / `stop` |
 | `lib.sh` | config + e2a send/reply/poll helpers |
 | `hooks/tether-notify.sh` | optional Notification hook (blocked-alert) |
 | `install.sh` | wire/unwire the Notification hook; `_selftest` |

--- a/plugins/e2a/skills/tether/lib.sh
+++ b/plugins/e2a/skills/tether/lib.sh
@@ -135,20 +135,62 @@ except Exception:print("")')"
   fi
 }
 
-# t_api_reply <in_reply_to_id> <body> [html_body] → prints new message_id;
+# Attachment cap: 15 MB of raw bytes total per send. Base64 inflates ~4/3 and
+# the server rejects requests over 25 MB, so 15 MB raw (~20 MB encoded) leaves
+# headroom for the body; typical mail providers cap around 25 MB too.
+T_ATTACH_MAX_BYTES=$((15 * 1024 * 1024))
+
+# t_attach_check <file>... → 0 ok; 3 a file is missing; 4 over the total cap.
+# Validates BEFORE encoding so callers can fail fast with a clear message.
+t_attach_check() {
+  python3 -c 'import sys,os
+maxb=int(sys.argv[1]); total=0
+for f in sys.argv[2:]:
+    if not os.path.isfile(f):
+        sys.stderr.write("tether: attachment not found: %s\n"%f); sys.exit(3)
+    total+=os.path.getsize(f)
+if total>maxb:
+    sys.stderr.write("tether: attachments total %d bytes — over the %d MB cap; send a link instead\n"%(total,maxb//1048576)); sys.exit(4)' \
+    "$T_ATTACH_MAX_BYTES" "$@"
+}
+
+# t_reply_payload <out_file> <body> <html> [file...] — write the reply JSON
+# payload to <out_file>. Each file becomes {filename, content_type, data(b64)}
+# per the API's attachments[] schema; MIME type is guessed from the filename
+# (fallback application/octet-stream).
+t_reply_payload() {
+  python3 -c 'import json,sys,base64,mimetypes,os
+out,body,html=sys.argv[1],sys.argv[2],sys.argv[3]
+p={"body":body}
+if html: p["html_body"]=html
+atts=[]
+for f in sys.argv[4:]:
+    atts.append({"filename":os.path.basename(f),
+                 "content_type":mimetypes.guess_type(f)[0] or "application/octet-stream",
+                 "data":base64.b64encode(open(f,"rb").read()).decode()})
+if atts: p["attachments"]=atts
+json.dump(p,open(out,"w"))' "$@"
+}
+
+# t_api_reply <in_reply_to_id> <body> [html_body] [attach_file ...] → prints new message_id;
 # returns 2 (and warns on stderr) if the reply was HELD (pending_review). The
 # reply path — every update/ask/stop — used to drop `status`, so a held update
 # printed a phantom "sent" while the user's inbox stayed empty.
+# Optional args past html_body are file paths attached to the reply. The payload
+# goes to curl via a temp file, never argv — a multi-MB base64 attachment would
+# blow past ARG_MAX if passed as a command-line argument.
 t_api_reply() {
-  local email resp status mid
+  local email resp status mid rid body html pf
+  rid="$1"; body="$2"; html="${3:-}"
+  shift 2; [ $# -gt 0 ] && shift   # remaining args = attachment file paths
   email="$(t_urlencode "$E2A_AGENT_EMAIL")"
-  resp="$(curl -sS -m 30 -X POST \
+  pf="$(mktemp "${TMPDIR:-/tmp}/tether-payload.XXXXXX")" || return 1
+  t_reply_payload "$pf" "$body" "$html" "$@" || { rm -f "$pf"; return 1; }
+  resp="$(curl -sS -m 120 -X POST \
     -H "Authorization: Bearer ${E2A_API_KEY}" -H "Content-Type: application/json" \
-    -d "$(python3 -c 'import json,sys
-p={"body":sys.argv[1]}
-if len(sys.argv)>2 and sys.argv[2]:p["html_body"]=sys.argv[2]
-print(json.dumps(p))' "$2" "${3:-}")" \
-    "${E2A_BASE_URL}/v1/agents/${email}/messages/${1}/reply" 2>/dev/null)" || return 1
+    --data-binary "@${pf}" \
+    "${E2A_BASE_URL}/v1/agents/${email}/messages/${rid}/reply" 2>/dev/null)" || { rm -f "$pf"; return 1; }
+  rm -f "$pf"
   status="$(printf '%s' "$resp" | python3 -c 'import json,sys
 try:print(json.load(sys.stdin).get("status",""))
 except Exception:print("")')"

--- a/plugins/e2a/skills/tether/lib.sh
+++ b/plugins/e2a/skills/tether/lib.sh
@@ -198,10 +198,43 @@ except Exception:print("")')"
 try:print(json.load(sys.stdin).get("message_id",""))
 except Exception:print("")')"
   printf '%s' "$mid"
+  if [ -z "$mid" ]; then
+    # Distinguish "this anchor is not repliable" (404) from other failures so
+    # t_reply_anchored can fall back to another anchor instead of giving up.
+    local ecode
+    ecode="$(printf '%s' "$resp" | python3 -c 'import json,sys
+try:print((json.load(sys.stdin).get("error") or {}).get("code",""))
+except Exception:print("")')"
+    [ "$ecode" = "not_found" ] && return 3
+    return 1
+  fi
   if [ "$status" = "pending_review" ]; then
     echo "tether: WARNING reply held (pending_review) — disable protection on ${E2A_AGENT_EMAIL}" >&2
     return 2
   fi
+}
+
+# t_reply_anchored <body> <html> [attach_file ...] → send a threaded reply,
+# trying anchors in order: the last message in the thread (best Gmail
+# threading), then the user's last inbound reply, then the intro. Hosted APIs
+# that predate reply-to-own-outbound (#360) 404 when the anchor is a
+# reply-created outbound message — without this fallback, the SECOND of two
+# consecutive updates with no user reply in between is silently undeliverable.
+# Prints the new message_id; propagates t_api_reply's return code.
+t_reply_anchored() {
+  local body="$1" html="${2:-}"
+  shift 1; [ $# -gt 0 ] && shift
+  local tried="" rid mid rc
+  for rid in "$(t_state_get last_message_id)" "$(t_state_get last_inbound_id)" "$(t_state_get intro_id)"; do
+    [ -n "$rid" ] || continue
+    case " $tried " in *" $rid "*) continue;; esac
+    tried="$tried $rid"
+    mid="$(t_api_reply "$rid" "$body" "$html" "$@")"; rc=$?
+    [ "$rc" = "3" ] && continue   # anchor not repliable here — try the next one
+    printf '%s' "$mid"; return $rc
+  done
+  echo "tether: no repliable anchor (tried:${tried})" >&2
+  return 3
 }
 
 # strip HTML tags → a plain-text fallback (crude but fine for email body)
@@ -303,7 +336,10 @@ t_poll_once() {
     fi
     t_seen_add "$id"; advance="$created"; n=$((n+1))
     printf '── reply from %s @ %s ──\n%s\n\n' "$from" "$created" "$body"
-    t_state_set last_message_id "$id"
+    # last_inbound_id is the always-repliable fallback anchor for
+    # t_reply_anchored (an inbound message is a valid reply target on every
+    # API version; the agent's own reply-created outbound may not be).
+    t_state_set last_message_id "$id" last_inbound_id "$id"
   done <<< "$rows"
   t_state_set last_poll "$advance"
   [ "$n" -gt 0 ] || echo "(no new replies)"

--- a/plugins/e2a/skills/tether/tether.sh
+++ b/plugins/e2a/skills/tether/tether.sh
@@ -67,6 +67,7 @@ question or instruction; reply \"stop\" to end early.
       exit 1
     fi
     t_state_set armed 1 to "$to" conversation_id "$conv" last_message_id "$mid" \
+      intro_id "$mid" \
       last_poll "$(t_now_iso)" project "$proj" started_at "$(t_now_iso)" expires_at "$expires"
     echo "tether: started — thread ${conv} → ${to} (intro ${mid}); window: ${window}${expires:+ (until ${expires})}"
     ;;
@@ -95,8 +96,7 @@ question or instruction; reply \"stop\" to end early.
     fi
     [ -n "$msg" ] || { echo "usage: tether.sh update \"<text>\"  |  update --html <file> [--text \"<fallback>\"]  (either form: [--attach <file>]...)"; exit 2; }
     if [ "${#attach[@]}" -gt 0 ]; then t_attach_check "${attach[@]}" || exit $?; fi
-    rid="$(t_state_get last_message_id)"
-    mid="$(t_api_reply "$rid" "$msg" "$html" ${attach[@]+"${attach[@]}"})"; rc=$?
+    mid="$(t_reply_anchored "$msg" "$html" ${attach[@]+"${attach[@]}"})"; rc=$?
     if [ -z "$mid" ]; then echo "tether: update send failed"; exit 1; fi
     t_state_set last_message_id "$mid"
     if [ "$rc" = "2" ]; then
@@ -165,8 +165,7 @@ question or instruction; reply \"stop\" to end early.
     # and doesn't steal the answer; released on any exit (reply, timeout, error).
     trap 't_ask_end' EXIT INT TERM
     t_ask_begin
-    rid="$(t_state_get last_message_id)"
-    mid="$(t_api_reply "$rid" "❓ ${q}
+    mid="$(t_reply_anchored "❓ ${q}
 
 (Reply to this email with your answer — I'll wait for it.)" "" ${attach[@]+"${attach[@]}"})"; rc=$?
     [ -n "$mid" ] || { echo "tether: ask send failed"; exit 1; }
@@ -205,8 +204,7 @@ question or instruction; reply \"stop\" to end early.
 
   stop)
     if [ "$(t_state_get armed)" = "1" ] && t_load_config; then
-      rid="$(t_state_get last_message_id)"
-      [ -n "$rid" ] && t_api_reply "$rid" "Tether ended. Session is no longer listening." >/dev/null 2>&1 || true
+      t_reply_anchored "Tether ended. Session is no longer listening." >/dev/null 2>&1 || true
     fi
     t_state_clear
     echo "tether: stopped"

--- a/plugins/e2a/skills/tether/tether.sh
+++ b/plugins/e2a/skills/tether/tether.sh
@@ -139,8 +139,12 @@ question or instruction; reply \"stop\" to end early.
       if t_ask_active; then
         s="$interval"; [ "$rem" -lt "$s" ] && s="$rem"; sleep "$s"; continue
       fi
-      out="$(t_poll_once)"
-      if [ "$out" != "(no new replies)" ]; then echo "REPLY_RECEIVED:"; echo "$out"; exit 0; fi
+      out="$(t_poll_once)" || out=""
+      # Empty out = a transient poll failure (curl blip), NOT a reply — without
+      # this guard it exits REPLY_RECEIVED with nothing, killing the listen.
+      if [ -n "$out" ] && [ "$out" != "(no new replies)" ]; then
+        echo "REPLY_RECEIVED:"; echo "$out"; exit 0
+      fi
       s="$interval"; [ "$rem" -lt "$s" ] && s="$rem"
       sleep "$s"
     done
@@ -178,8 +182,9 @@ question or instruction; reply \"stop\" to end early.
     max="${E2A_TETHER_ASK_TIMEOUT:-1800}"; interval="${E2A_TETHER_POLL_INTERVAL:-20}"; elapsed=0
     while [ "$elapsed" -lt "$max" ]; do
       sleep "$interval"; elapsed=$((elapsed + interval))
-      out="$(t_poll_once)"
-      [ "$out" = "(no new replies)" ] || { echo "$out"; exit 0; }
+      out="$(t_poll_once)" || out=""
+      # Empty out = transient poll failure, not an answer (same guard as listen).
+      if [ -n "$out" ] && [ "$out" != "(no new replies)" ]; then echo "$out"; exit 0; fi
     done
     echo "tether: ask timed out after ${max}s with no answer"; exit 3
     ;;

--- a/plugins/e2a/skills/tether/tether.sh
+++ b/plugins/e2a/skills/tether/tether.sh
@@ -4,7 +4,8 @@
 #   tether.sh start <email> [--title "<work>"] [--for 2h|8h|30m|1d] [--until <ISO>]  open + arm
 #   tether.sh update "<message>"   send a threaded update ("as you see fit")
 #   tether.sh update --html <file> send an HTML update (+ auto text fallback)
-#   tether.sh ask "<question>"     email a question and BLOCK until the reply
+#   tether.sh update --attach <f>  attach a file (repeatable; 15 MB total cap)
+#   tether.sh ask "<question>" [--attach <f>]...  email a question and BLOCK until the reply
 #   tether.sh listen [--awake]     poll until a reply OR the window ends (bg it)
 #   tether.sh poll                 print any new replies since last poll (exit 0)
 #   tether.sh status               show tether state
@@ -73,12 +74,14 @@ question or instruction; reply \"stop\" to end early.
   update)
     # update "<text>"                       plain-text update
     # update --html <file> [--text "<t>"]   HTML update (+ optional text fallback)
+    # either form: [--attach <file>]...     attach files (repeatable)
     need_config; need_armed
-    htmlfile=""; textarg=""; msg=""
+    htmlfile=""; textarg=""; msg=""; attach=()
     while [ $# -gt 0 ]; do
       case "$1" in
         --html) htmlfile="${2:-}"; shift 2;;
         --text) textarg="${2:-}"; shift 2;;
+        --attach) attach+=("${2:-}"); shift 2;;
         *) msg="$1"; shift;;
       esac
     done
@@ -90,16 +93,17 @@ question or instruction; reply \"stop\" to end early.
       [ -n "$msg" ] || msg="$textarg"
       [ -n "$msg" ] || msg="$(printf '%s' "$html" | t_html_to_text)"
     fi
-    [ -n "$msg" ] || { echo "usage: tether.sh update \"<text>\"  |  update --html <file> [--text \"<fallback>\"]"; exit 2; }
+    [ -n "$msg" ] || { echo "usage: tether.sh update \"<text>\"  |  update --html <file> [--text \"<fallback>\"]  (either form: [--attach <file>]...)"; exit 2; }
+    if [ "${#attach[@]}" -gt 0 ]; then t_attach_check "${attach[@]}" || exit $?; fi
     rid="$(t_state_get last_message_id)"
-    mid="$(t_api_reply "$rid" "$msg" "$html")"; rc=$?
+    mid="$(t_api_reply "$rid" "$msg" "$html" ${attach[@]+"${attach[@]}"})"; rc=$?
     if [ -z "$mid" ]; then echo "tether: update send failed"; exit 1; fi
     t_state_set last_message_id "$mid"
     if [ "$rc" = "2" ]; then
       echo "tether: WARNING update HELD for review (pending_review) — it did NOT reach the user. Disable send-side protection on ${E2A_AGENT_EMAIL}."
       exit 2
     fi
-    echo "tether: update sent (${mid})$([ -n "$html" ] && echo ' [html]')"
+    echo "tether: update sent (${mid})$([ -n "$html" ] && echo ' [html]')$([ "${#attach[@]}" -gt 0 ] && echo " [${#attach[@]} attachment(s)]")"
     ;;
 
   poll)
@@ -148,7 +152,15 @@ question or instruction; reply \"stop\" to end early.
     # over email, never a terminal prompt the AFK user can't see. Run it in the
     # background and wait for the completion notification.
     need_config; need_armed
-    q="${1:-}"; [ -n "$q" ] || { echo "usage: tether.sh ask \"<question>\""; exit 2; }
+    q=""; attach=()
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --attach) attach+=("${2:-}"); shift 2;;
+        *) q="$1"; shift;;
+      esac
+    done
+    [ -n "$q" ] || { echo "usage: tether.sh ask \"<question>\" [--attach <file>]..."; exit 2; }
+    if [ "${#attach[@]}" -gt 0 ]; then t_attach_check "${attach[@]}" || exit $?; fi
     # Hold the ask lock for this whole invocation so a background `listen` pauses
     # and doesn't steal the answer; released on any exit (reply, timeout, error).
     trap 't_ask_end' EXIT INT TERM
@@ -156,7 +168,7 @@ question or instruction; reply \"stop\" to end early.
     rid="$(t_state_get last_message_id)"
     mid="$(t_api_reply "$rid" "❓ ${q}
 
-(Reply to this email with your answer — I'll wait for it.)")"; rc=$?
+(Reply to this email with your answer — I'll wait for it.)" "" ${attach[@]+"${attach[@]}"})"; rc=$?
     [ -n "$mid" ] || { echo "tether: ask send failed"; exit 1; }
     t_state_set last_message_id "$mid"
     if [ "$rc" = "2" ]; then
@@ -227,6 +239,26 @@ question or instruction; reply \"stop\" to end early.
       t_ask_end;   ! t_ask_active || { echo "FAIL: lock present after end"; exit 1; }
       echo "ok: ask lock begin/active/end" ) || fail=1
     rm -f /tmp/tether-selftest-lock.json /tmp/ask.lock
+
+    echo "# attachments:"
+    af=/tmp/tether-selftest-att.txt; printf 'hello attachment' > "$af"
+    pj=/tmp/tether-selftest-payload.json
+    t_reply_payload "$pj" "the body" "" "$af" || { echo "FAIL: payload build errored"; fail=1; }
+    ck "payload: body + encoded attachment" "$(python3 -c 'import json,base64
+d=json.load(open("/tmp/tether-selftest-payload.json"));a=d["attachments"][0]
+print(d["body"]=="the body" and "html_body" not in d
+      and a["filename"]=="tether-selftest-att.txt" and a["content_type"]=="text/plain"
+      and base64.b64decode(a["data"]).decode()=="hello attachment")')" "True"
+    t_reply_payload "$pj" "b" "<b>h</b>" || { echo "FAIL: no-attachment payload errored"; fail=1; }
+    ck "payload: no files → no attachments key" "$(python3 -c 'import json
+d=json.load(open("/tmp/tether-selftest-payload.json"))
+print("attachments" not in d and d["html_body"]=="<b>h</b>")')" "True"
+    t_attach_check "$af" || { echo "FAIL: attach check on a real file"; fail=1; }
+    t_attach_check /nonexistent-tether-file 2>/dev/null; ck "missing file → exit 3" "$?" "3"
+    big=/tmp/tether-selftest-big.bin
+    python3 -c 'f=open("/tmp/tether-selftest-big.bin","wb");f.seek(16*1024*1024-1);f.write(b"\0")'
+    t_attach_check "$big" 2>/dev/null; ck "16 MB → exit 4 (over cap)" "$?" "4"
+    rm -f "$af" "$pj" "$big"
 
     bash -n "${here}/lib.sh" && bash -n "${here}/tether.sh" && echo "# syntax OK"
     [ "$fail" = "0" ] && echo "# selftest PASS" || { echo "# selftest FAIL"; exit 1; }


### PR DESCRIPTION
## What

Two things, both dogfooded live on the tether session that requested them:

1. **File attachments** on the tether harness's outbound surfaces (requested by Josh over the tether thread itself):
   - `tether.sh update [--attach <file>]...` — repeatable, composes with `--html` / `--text`
   - `tether.sh ask [--attach <file>]...` — attach the artifact a decision hinges on (a diff, a mockup) instead of describing it
2. **A delivery bug found while shipping #1**: the harness anchors every update on its own previous outbound message, but a hosted API that predates reply-to-own-outbound (#360) returns `not_found` for reply-created outbound anchors — so the **second of two consecutive updates with no user reply in between silently never reaches the user**. Updates now fall back to a repliable anchor.

## How

**Attachments** — the e2a API already accepts `attachments[]` (`{filename, content_type, data}`, base64) on the reply route; this is pure harness plumbing:

- **`lib.sh`**: new `t_attach_check` (fail-fast validation: exit 3 = file missing, exit 4 = over cap) and `t_reply_payload` (builds the reply JSON with base64-encoded attachments; MIME guessed from filename, fallback `application/octet-stream`). The payload goes to curl via a temp file (`--data-binary @file`) — **never argv**, since a multi-MB base64 string would blow past ARG_MAX. Reply timeout 30s → 120s for multi-MB uploads.
- **Cap**: 15 MB raw total per send — base64 inflates ~4/3 against the server's 25 MB request limit (`maxRequestBytesSend`), leaving headroom for the body. Past the cap the error says to send a link instead.
- **`tether.sh`**: flag parsing on `update` and `ask`, validation before any encoding or network call, `[N attachment(s)]` in the success line.
- **`SKILL.md`**: documents `--attach` in the runtime flow and the writing-good-emails guidance.

**Anchor fallback**:

- `t_api_reply` returns 3 on a `not_found` anchor (vs 1 for other failures)
- new `t_reply_anchored` tries `last_message_id` → `last_inbound_id` → `intro_id` (deduped); `update` / `ask` / `stop` all send through it
- `start` records `intro_id`; `t_poll_once` records `last_inbound_id`

Plugin version 0.4.5 → 0.4.6 (all three manifests), matching prior tether feature PRs (#356, #357).

## Testing

`tether.sh _selftest` extended and passing:
- payload builder: body + encoded attachment (filename / MIME / base64 round-trip), and no-files → no `attachments` key
- validator: missing file → exit 3; 16 MB file → exit 4

**Live end-to-end**: the PR-announcement email itself was sent through the new code path — its outbound anchor 404'd on the hosted API (the exact bug above), fell back to the user's last inbound reply, and delivered with a PDF attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)