### PR TITLE
fix(web): shared-domain inbox create sends email, not the dropped slug field

### DIFF
--- a/web/src/app/(app)/get-started/_components/SharedAgentForm.tsx
+++ b/web/src/app/(app)/get-started/_components/SharedAgentForm.tsx
@@ -6,7 +6,7 @@ import { createAgent } from "../../../components/onboarding/api";
 import { isValidSlug } from "../../../components/onboarding/state";
 import { track } from "../../../components/onboarding/analytics";
 import type { AgentData } from "../../../components/types";
-import { AGENTS_DOMAIN_DISPLAY } from "../../../../lib/site";
+import { AGENTS_DOMAIN, AGENTS_DOMAIN_DISPLAY } from "../../../../lib/site";
 import { invalidateAgents } from "../../../../lib/swrKeys";
 
 export function SharedAgentForm({
@@ -34,11 +34,20 @@ export function SharedAgentForm({
       return;
     }
 
+    // /v1 registers agents by full email; a shared-domain agent is just an
+    // email on the deployment's shared domain (the legacy `slug` field is
+    // gone). AGENTS_DOMAIN empty means the deployment has no shared domain,
+    // so this form can't produce a valid address.
+    if (!AGENTS_DOMAIN) {
+      setError("This deployment has no shared agent domain configured.");
+      return;
+    }
+
     setLoading(true);
     track("agent_creation_started", { shared_or_custom: "shared" });
     try {
       const result = await createAgent({
-        slug,
+        email: `${slug}@${AGENTS_DOMAIN}`,
         ...(name ? { name } : {}),
       });
       track("agent_creation_succeeded", { shared_or_custom: "shared" });

--- a/web/src/app/(app)/get-started/page.test.tsx
+++ b/web/src/app/(app)/get-started/page.test.tsx
@@ -281,7 +281,7 @@ describe("Shared local flow", () => {
         "/v1/agents",
         expect.objectContaining({
           method: "POST",
-          body: JSON.stringify({ slug: "my-bot" }),
+          body: JSON.stringify({ email: "my-bot@agents.e2a.dev" }),
         }),
       );
     });

--- a/web/src/app/components/onboarding/api.ts
+++ b/web/src/app/components/onboarding/api.ts
@@ -91,9 +91,11 @@ export async function listAgents(): Promise<DashboardAgent[]> {
   return data.items ?? [];
 }
 
+// POST /v1/agents registers by full email only — a shared-domain agent is
+// an email on the deployment's shared domain; the legacy `slug` field was
+// dropped from the API and is rejected as an unexpected property.
 export async function createAgent(params: {
-  slug?: string;
-  email?: string;
+  email: string;
   name?: string;
 }): Promise<AgentCreateResponse> {
   return request<AgentCreateResponse>("/v1/agents", {


### PR DESCRIPTION
## Summary
The dashboard's shared-domain "Create your inbox" form failed on every submit with a 422:

```
{"error":{"code":"unprocessable_entity","message":"validation failed","details":[
  {"message":"expected required property email to be present","location":"body",...},
  {"message":"unexpected property","location":"body.slug",...}]}}
```

`POST /v1/agents` registers by full email only — the legacy `slug` field was dropped from the API (`internal/httpapi/agents_write.go`) and is rejected as an unexpected property. The custom-domain form was migrated to send `email`, but `SharedAgentForm` still sent `{slug, name}`.

## Changes
- `SharedAgentForm` builds the full address from the slug + shared domain (`NEXT_PUBLIC_AGENTS_DOMAIN`) and sends `{email, name}`; surfaces a clear error if the deployment has no shared domain configured instead of sending a broken request.
- `createAgent` in `onboarding/api.ts` now requires `email` (dropped the dead `slug` param) so this can't regress silently.
- Updated the get-started test to assert the new body shape.

## Testing
- Reproduced the exact 422 against the Go handler with the dashboard's original body via the `httpapi` test harness (throwaway test, not committed).
- All 265 web Jest tests pass (30 suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)