### PR TITLE
feat(plugin/tether): one-command `tether.sh setup` (auto inbox + least-privilege key + HITL off)

### DIFF
--- a/plugins/e2a/skills/tether/SKILL.md
+++ b/plugins/e2a/skills/tether/SKILL.md
@@ -47,6 +47,25 @@ the two directions use different mechanisms:
 > to `python`. Override with `E2A_PYTHON=/path/to/python`. Run
 > `tether.sh _selftest` to confirm the interpreter actually works.
 
+### Fast path (recommended)
+
+If you have account creds — either from `e2a login` (browser OAuth, nothing to
+paste) or an `e2a_acct_…` key in `~/.e2a-tether.env` — one command does the
+whole bootstrap, no dashboard trip and no MCP server required:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/skills/tether/tether.sh" setup
+```
+
+It resolves your key, ensures an agent inbox (creating `tether-…@<shared_domain>`
+if you have none), turns HITL **off**, writes `~/.e2a-tether.env` with the full
+agent address, and confirms with `status`. Then go straight to **Runtime flow**.
+Flags: `--email you@yourdomain` to name/create a specific agent, `--new` to force
+a fresh one. The manual steps below are the fallback — e.g. when you want a
+narrower **agent-scoped** key instead of the account key `setup` reuses.
+
+### Manual setup
+
 Tether needs an **agent-scoped** e2a API key (`e2a_agt_…`) bound to a single
 inbox — least privilege, so a leaked key can't touch the rest of the account.
 
@@ -76,6 +95,11 @@ A smoother CLI path is coming.)
 
 Let `T="${CLAUDE_PLUGIN_ROOT}/skills/tether/tether.sh"`.
 
+0. **Ensure configured.** Run `"$T" status`. If it prints `config: MISSING`,
+   run `"$T" setup` (the Fast path) before anything else — it provisions the
+   inbox + credentials in one step. If setup reports no API key, tell the user
+   to run `e2a login` (or drop an `e2a_acct_…` key in `~/.e2a-tether.env`), then
+   re-run `"$T" setup`.
 1. **Ask** the user's email address **and how long to stay tethered** (e.g. 30m,
    2h, 8h/overnight, or until they say stop). They're present at this step, so a
    normal question is fine.

--- a/plugins/e2a/skills/tether/SKILL.md
+++ b/plugins/e2a/skills/tether/SKILL.md
@@ -41,6 +41,12 @@ the two directions use different mechanisms:
 
 ## Setup (once)
 
+> **Prerequisites:** `bash`, `curl`, and **Python 3** on `PATH`. The scripts
+> auto-detect the interpreter (`python3`, then `python`); on Windows/Git Bash
+> where `python3` is the non-functional Microsoft Store shim, they fall through
+> to `python`. Override with `E2A_PYTHON=/path/to/python`. Run
+> `tether.sh _selftest` to confirm the interpreter actually works.
+
 Tether needs an **agent-scoped** e2a API key (`e2a_agt_…`) bound to a single
 inbox — least privilege, so a leaked key can't touch the rest of the account.
 

--- a/plugins/e2a/skills/tether/hooks/tether-notify.sh
+++ b/plugins/e2a/skills/tether/hooks/tether-notify.sh
@@ -10,7 +10,7 @@ here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "${here}/../lib.sh"
 
 payload="$(cat)"
-message="$(printf '%s' "$payload" | python3 -c 'import json,sys
+message="$(printf '%s' "$payload" | "$PY" -c 'import json,sys
 try:print(json.load(sys.stdin).get("message","") or "")
 except Exception:print("")')"
 [ -n "$message" ] || message="The agent needs your attention."

--- a/plugins/e2a/skills/tether/install.sh
+++ b/plugins/e2a/skills/tether/install.sh
@@ -10,6 +10,8 @@
 set -euo pipefail
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 notify="${here}/hooks/tether-notify.sh"
+# shellcheck source=lib.sh
+. "${here}/lib.sh"   # for the resolved "$PY" interpreter (see lib.sh)
 
 target="$PWD"; mode="install"
 while [ $# -gt 0 ]; do
@@ -33,7 +35,7 @@ settings="${target}/.claude/settings.local.json"
 mkdir -p "${target}/.claude"
 [ -f "$settings" ] || echo '{}' > "$settings"
 
-NOTIFY="$notify" MODE="$mode" python3 - "$settings" <<'PY'
+NOTIFY="$notify" MODE="$mode" "$PY" - "$settings" <<'PY'
 import json,os,sys
 f=sys.argv[1];d=json.load(open(f));notify=os.environ["NOTIFY"];mode=os.environ["MODE"]
 hooks=d.setdefault("hooks",{})

--- a/plugins/e2a/skills/tether/lib.sh
+++ b/plugins/e2a/skills/tether/lib.sh
@@ -178,6 +178,86 @@ try:
 except Exception:print("")'
 }
 
+# --- setup / bootstrap helpers ----------------------------------------------
+# These power `tether.sh setup`: a zero-to-tethered bootstrap that needs only
+# account creds (from `e2a login` or an e2a_acct_ key) and does the rest.
+
+# Resolve just the API key + base URL — agent email NOT required (setup runs
+# before an agent is chosen). Mirrors t_load_config's sources minus the agent.
+t_resolve_key() {
+  if [ -z "${E2A_API_KEY:-}" ] && [ -f "${HOME}/.e2a-tether.env" ]; then
+    set -a; . "${HOME}/.e2a-tether.env"; set +a
+  fi
+  if [ -z "${E2A_API_KEY:-}" ] && [ -f "${HOME}/.e2a/config.json" ]; then
+    eval "$("$PY" -c 'import json,shlex,os
+try:
+  d=json.load(open(os.path.expanduser("~/.e2a/config.json")))
+  if d.get("api_key"): print("export E2A_API_KEY="+shlex.quote(d["api_key"]))
+  if d.get("api_url"): print("export E2A_BASE_URL="+shlex.quote(d["api_url"].rstrip("/")))
+except Exception: pass')"
+  fi
+  E2A_BASE_URL="${E2A_BASE_URL:-https://api.e2a.dev}"
+  [ -n "${E2A_API_KEY:-}" ]
+}
+
+# GET /v1/info → shared_domain (empty if the deployment has none)
+t_api_shared_domain() {
+  curl -sS -m 30 "${E2A_BASE_URL}/v1/info" 2>/dev/null | "$PY" -c 'import json,sys
+try: print(json.load(sys.stdin).get("shared_domain","") or "")
+except Exception: print("")'
+}
+
+# GET /v1/agents → one agent email per line
+t_api_agents() {
+  curl -sS -m 30 -H "Authorization: Bearer ${E2A_API_KEY}" "${E2A_BASE_URL}/v1/agents" 2>/dev/null | "$PY" -c 'import json,sys
+try:
+  for a in json.load(sys.stdin).get("items",[]): print(a.get("email") or a.get("id") or "")
+except Exception: pass'
+}
+
+# POST /v1/agents {email} → created email (empty on failure)
+t_api_create_agent() {
+  curl -sS -m 30 -X POST -H "Authorization: Bearer ${E2A_API_KEY}" -H "Content-Type: application/json" \
+    -d "$("$PY" -c 'import json,sys;print(json.dumps({"email":sys.argv[1]}))' "$1")" \
+    "${E2A_BASE_URL}/v1/agents" 2>/dev/null | "$PY" -c 'import json,sys
+try:
+  d=json.load(sys.stdin); print(d.get("email") or d.get("id") or "")
+except Exception: print("")'
+}
+
+# Set outbound gate=flag + scan=off on <email>. /protection is full-replace, so
+# GET the current doc, flip only the outbound knobs, PUT it back. Prints "ok".
+t_api_protection_off() {
+  local enc cur body
+  enc="$(t_urlencode "$1")"
+  cur="$(curl -sS -m 30 -H "Authorization: Bearer ${E2A_API_KEY}" "${E2A_BASE_URL}/v1/agents/${enc}/protection" 2>/dev/null)"
+  body="$(printf '%s' "$cur" | "$PY" -c 'import json,sys
+try: d=json.load(sys.stdin)
+except Exception: d={}
+if not isinstance(d,dict): d={}
+ib=d.setdefault("inbound",{}); ib.setdefault("gate",{}).setdefault("action","flag"); ib.setdefault("scan",{}).setdefault("sensitivity","off")
+ob=d.setdefault("outbound",{}); ob.setdefault("gate",{}); ob.setdefault("scan",{})
+ob["gate"]["action"]="flag"; ob["scan"]["sensitivity"]="off"
+h=d.setdefault("holds",{}); h.setdefault("ttl_seconds",604800); h.setdefault("on_expiry","reject")
+print(json.dumps(d))')"
+  curl -sS -m 30 -X PUT -H "Authorization: Bearer ${E2A_API_KEY}" -H "Content-Type: application/json" \
+    -d "$body" "${E2A_BASE_URL}/v1/agents/${enc}/protection" 2>/dev/null | "$PY" -c 'import json,sys
+try: print("ok" if json.load(sys.stdin).get("outbound",{}).get("gate",{}).get("action")=="flag" else "")
+except Exception: print("")'
+}
+
+# Write ~/.e2a-tether.env with the resolved key + agent (chmod 600 where honored)
+t_write_env() {
+  local f="${HOME}/.e2a-tether.env"
+  cat > "$f" <<EOF
+# written by tether.sh setup — $(t_now_iso)
+export E2A_API_KEY="$1"
+export E2A_AGENT_EMAIL="$2"
+export E2A_BASE_URL="${E2A_BASE_URL:-https://api.e2a.dev}"
+EOF
+  chmod 600 "$f" 2>/dev/null || true
+}
+
 # --- dedup + poll core -------------------------------------------------------
 # Replies are deduped by message-id (a `seen` set in state), NOT a bare time
 # cursor. Email parsing is async: a just-arrived reply can have an empty

--- a/plugins/e2a/skills/tether/lib.sh
+++ b/plugins/e2a/skills/tether/lib.sh
@@ -246,6 +246,36 @@ try: print("ok" if json.load(sys.stdin).get("outbound",{}).get("gate",{}).get("a
 except Exception: print("")'
 }
 
+# Resolve an ACCOUNT-scoped bootstrap key. setup needs account scope to create
+# agents + mint keys, so we can't just take whatever key is in the tether env
+# (which, after a prior setup, is an agent-scoped key that CANNOT manage keys).
+# Try ~/.e2a/config.json (e2a login), then the tether env, then $E2A_API_KEY —
+# pick the first that /v1/account reports as scope=account.
+t_resolve_bootstrap() {
+  E2A_BASE_URL="${E2A_BASE_URL:-https://api.e2a.dev}"
+  {
+    [ -f "${HOME}/.e2a/config.json" ] && "$PY" -c 'import json,os;print(json.load(open(os.path.expanduser("~/.e2a/config.json"))).get("api_key","") or "")'
+    [ -f "${HOME}/.e2a-tether.env" ] && grep -E '^export E2A_API_KEY=' "${HOME}/.e2a-tether.env" | head -1 | sed -E 's/^[^=]*=//; s/^"//; s/"$//'
+    printf '%s\n' "${E2A_API_KEY:-}"
+  } | while IFS= read -r cand; do
+      [ -n "$cand" ] || continue
+      s="$(curl -sS -m20 -H "Authorization: Bearer ${cand}" "${E2A_BASE_URL}/v1/account" 2>/dev/null | "$PY" -c 'import json,sys
+try: print(json.load(sys.stdin).get("scope",""))
+except Exception: print("")')"
+      [ "$s" = "account" ] && { printf '%s' "$cand"; break; }
+    done
+}
+
+# Mint an AGENT-scoped key bound to <agent_email> using account <bootstrap key>.
+# Prints the plaintext e2a_agt_ key (shown once), empty on failure.
+t_api_create_agent_key() {  # <bootstrap_key> <agent_email> [name]
+  curl -sS -m30 -X POST -H "Authorization: Bearer ${1}" -H "Content-Type: application/json" \
+    -d "$("$PY" -c 'import json,sys;print(json.dumps({"name":sys.argv[1],"scope":"agent","agent":sys.argv[2]}))' "${3:-tether}" "$2")" \
+    "${E2A_BASE_URL}/v1/account/api-keys" 2>/dev/null | "$PY" -c 'import json,sys
+try: print(json.load(sys.stdin).get("key","") or "")
+except Exception: print("")'
+}
+
 # Write ~/.e2a-tether.env with the resolved key + agent (chmod 600 where honored)
 t_write_env() {
   local f="${HOME}/.e2a-tether.env"

--- a/plugins/e2a/skills/tether/lib.sh
+++ b/plugins/e2a/skills/tether/lib.sh
@@ -5,6 +5,25 @@
 # Required: E2A_API_KEY, E2A_AGENT_EMAIL. The recipient is supplied at
 # `tether.sh start <email>` and kept in the state file.
 
+# --- interpreter resolution --------------------------------------------------
+# Resolve a working Python 3 once and reuse it as "$PY". We can't hardcode
+# `python3`: on Windows it's often the Microsoft Store redirector shim, which
+# is on PATH (so `command -v` finds it) but exits non-zero without running —
+# there the real interpreter is `python`. So we probe each candidate and pick
+# the first that actually executes as Python 3. Override with E2A_PYTHON.
+t_resolve_python() {
+  local c
+  for c in "${E2A_PYTHON:-}" python3 python python3.13 python3.12 python3.11; do
+    [ -n "$c" ] || continue
+    if command -v "$c" >/dev/null 2>&1 \
+       && "$c" -c 'import sys; sys.exit(0 if sys.version_info[0]==3 else 1)' >/dev/null 2>&1; then
+      command -v "$c"; return 0
+    fi
+  done
+  return 1
+}
+PY="$(t_resolve_python)" || echo "tether: no working Python 3 found on PATH (set E2A_PYTHON to your python)" >&2
+
 t_load_config() {
   # 1) explicit tether config
   if [ -z "${E2A_API_KEY:-}" ] && [ -f "${HOME}/.e2a-tether.env" ]; then
@@ -13,7 +32,7 @@ t_load_config() {
   fi
   # 2) reuse the CLI's agent creds from `e2a login` (~/.e2a/config.json)
   if [ -z "${E2A_API_KEY:-}" ] && [ -f "${HOME}/.e2a/config.json" ]; then
-    eval "$(python3 -c 'import json,shlex,os
+    eval "$("$PY" -c 'import json,shlex,os
 try:
   d=json.load(open(os.path.expanduser("~/.e2a/config.json")))
   if d.get("api_key"):     print("export E2A_API_KEY="+shlex.quote(d["api_key"]))
@@ -25,8 +44,8 @@ except Exception:pass')"
   [ -n "${E2A_API_KEY:-}" ] && [ -n "${E2A_AGENT_EMAIL:-}" ]
 }
 
-t_now_iso()  { python3 -c 'import datetime;print(datetime.datetime.now(datetime.timezone.utc).isoformat())'; }
-t_urlencode(){ python3 -c 'import sys,urllib.parse;print(urllib.parse.quote(sys.argv[1],safe=""))' "$1"; }
+t_now_iso()  { "$PY" -c 'import datetime;print(datetime.datetime.now(datetime.timezone.utc).isoformat())'; }
+t_urlencode(){ "$PY" -c 'import sys,urllib.parse;print(urllib.parse.quote(sys.argv[1],safe=""))' "$1"; }
 
 # --- state -------------------------------------------------------------------
 
@@ -34,14 +53,14 @@ t_state_path() { echo "${TETHER_STATE:-$HOME/.e2a-tether/state.json}"; }
 
 t_state_get() {
   local f; f="$(t_state_path)"; [ -f "$f" ] || return 0
-  python3 -c 'import json,sys
+  "$PY" -c 'import json,sys
 try:print(json.load(open(sys.argv[1])).get(sys.argv[2],"") or "")
 except Exception:pass' "$f" "$1"
 }
 
 t_state_set() {  # t_state_set k1 v1 [k2 v2 ...]
   local f; f="$(t_state_path)"; mkdir -p "$(dirname "$f")"
-  python3 -c 'import json,sys,os
+  "$PY" -c 'import json,sys,os
 f=sys.argv[1];kv=sys.argv[2:]
 d={}
 if os.path.exists(f):
@@ -58,7 +77,7 @@ t_state_clear() { rm -f "$(t_state_path)"; }
 # t_duration_to_expiry <dur> → ISO expires_at (empty = no expiry / "until stop")
 # accepts: 30m, 2h, 8h, 1d ; "" / forever / until-stop → empty
 t_duration_to_expiry() {
-  python3 -c 'import sys,datetime,re
+  "$PY" -c 'import sys,datetime,re
 d=(sys.argv[1] if len(sys.argv)>1 else "").strip().lower()
 if not d or d in ("forever","none","off","until-stop","stop"):print("");raise SystemExit
 m=re.fullmatch(r"(\d+)\s*([mhd])",d)
@@ -71,7 +90,7 @@ print((datetime.datetime.now(datetime.timezone.utc)+datetime.timedelta(seconds=s
 t_remaining_seconds() {
   local exp; exp="$(t_state_get expires_at)"
   [ -n "$exp" ] || { echo 2147483647; return; }
-  python3 -c 'import sys,datetime
+  "$PY" -c 'import sys,datetime
 try:
   t=datetime.datetime.fromisoformat(sys.argv[1].replace("Z","+00:00"))
   print(int((t-datetime.datetime.now(datetime.timezone.utc)).total_seconds()))
@@ -85,17 +104,17 @@ t_api_send() {
   local email resp status
   email="$(t_urlencode "$E2A_AGENT_EMAIL")"
   local payload
-  payload="$(python3 -c 'import json,sys
+  payload="$("$PY" -c 'import json,sys
 print(json.dumps({"to":[sys.argv[1]],"subject":sys.argv[2],"body":sys.argv[3],"conversation_id":sys.argv[4]}))' \
     "$1" "$2" "$3" "$4")"
   resp="$(curl -sS -m 30 -X POST \
     -H "Authorization: Bearer ${E2A_API_KEY}" -H "Content-Type: application/json" \
     -d "$payload" "${E2A_BASE_URL}/v1/agents/${email}/messages" 2>/dev/null)" || return 1
-  status="$(printf '%s' "$resp" | python3 -c 'import json,sys
+  status="$(printf '%s' "$resp" | "$PY" -c 'import json,sys
 try:print(json.load(sys.stdin).get("status",""))
 except Exception:print("")')"
   [ "$status" = "pending_review" ] && echo "tether: WARNING send held (pending_review) — disable protection on ${E2A_AGENT_EMAIL}" >&2
-  printf '%s' "$resp" | python3 -c 'import json,sys
+  printf '%s' "$resp" | "$PY" -c 'import json,sys
 try:print(json.load(sys.stdin).get("message_id",""))
 except Exception:print("")'
 }
@@ -106,19 +125,19 @@ t_api_reply() {
   email="$(t_urlencode "$E2A_AGENT_EMAIL")"
   resp="$(curl -sS -m 30 -X POST \
     -H "Authorization: Bearer ${E2A_API_KEY}" -H "Content-Type: application/json" \
-    -d "$(python3 -c 'import json,sys
+    -d "$("$PY" -c 'import json,sys
 p={"body":sys.argv[1]}
 if len(sys.argv)>2 and sys.argv[2]:p["html_body"]=sys.argv[2]
 print(json.dumps(p))' "$2" "${3:-}")" \
     "${E2A_BASE_URL}/v1/agents/${email}/messages/${1}/reply" 2>/dev/null)" || return 1
-  printf '%s' "$resp" | python3 -c 'import json,sys
+  printf '%s' "$resp" | "$PY" -c 'import json,sys
 try:print(json.load(sys.stdin).get("message_id",""))
 except Exception:print("")'
 }
 
 # strip HTML tags → a plain-text fallback (crude but fine for email body)
 t_html_to_text() {
-  python3 -c 'import sys,re,html
+  "$PY" -c 'import sys,re,html
 t=sys.stdin.read()
 t=re.sub(r"(?is)<(script|style).*?</\1>"," ",t)
 t=re.sub(r"(?i)<(br|/p|/div|/li|/tr|/h[1-6])\s*/?>","\n",t)
@@ -137,7 +156,7 @@ t_api_poll() {
     --data-urlencode "sort=asc" --data-urlencode "limit=20" \
     --data-urlencode "conversation_id=${1}" --data-urlencode "since=${2}" \
     "${E2A_BASE_URL}/v1/agents/${email}/messages" 2>/dev/null)" || return 1
-  printf '%s' "$resp" | python3 -c 'import json,sys
+  printf '%s' "$resp" | "$PY" -c 'import json,sys
 try:
   for m in json.load(sys.stdin).get("items",[]):
     print("\t".join([m.get("message_id",""),m.get("from",""),m.get("created_at","")]))
@@ -150,7 +169,7 @@ t_api_body() {
   email="$(t_urlencode "$E2A_AGENT_EMAIL")"
   resp="$(curl -sS -m 30 -H "Authorization: Bearer ${E2A_API_KEY}" \
     "${E2A_BASE_URL}/v1/agents/${email}/messages/${1}" 2>/dev/null)" || return 1
-  printf '%s' "$resp" | python3 -c 'import json,sys
+  printf '%s' "$resp" | "$PY" -c 'import json,sys
 try:
   d=json.load(sys.stdin)
   p=(d.get("parsed") or {}).get("text") or ""
@@ -168,7 +187,7 @@ except Exception:print("")'
 
 # seconds since an RFC3339 timestamp
 t_age_seconds() {
-  python3 -c 'import sys,datetime
+  "$PY" -c 'import sys,datetime
 try:
   t=datetime.datetime.fromisoformat(sys.argv[1].replace("Z","+00:00"))
   print(int((datetime.datetime.now(datetime.timezone.utc)-t).total_seconds()))
@@ -177,14 +196,14 @@ except Exception:print(0)' "$1"
 
 t_seen_has() {  # <id> → 0 if already processed
   local f; f="$(t_state_path)"; [ -f "$f" ] || return 1
-  python3 -c 'import json,sys
+  "$PY" -c 'import json,sys
 try:sys.exit(0 if sys.argv[2] in (json.load(open(sys.argv[1])).get("seen") or []) else 1)
 except Exception:sys.exit(1)' "$f" "$1"
 }
 
 t_seen_add() {  # <id> → record as processed (cap at last 500)
   local f; f="$(t_state_path)"; mkdir -p "$(dirname "$f")"
-  python3 -c 'import json,sys,os
+  "$PY" -c 'import json,sys,os
 f,i=sys.argv[1],sys.argv[2]
 d={}
 if os.path.exists(f):

--- a/plugins/e2a/skills/tether/tether.sh
+++ b/plugins/e2a/skills/tether/tether.sh
@@ -176,6 +176,14 @@ question or instruction; reply \"stop\" to end early.
       bash "${here}/tether.sh" status
     rm -f /tmp/tether-selftest.json
     bash -n "${here}/lib.sh" && bash -n "${here}/tether.sh" && echo "# syntax OK"
+    # interpreter must actually run — a real Python round-trip (catches the
+    # Windows python3-shim / missing-interpreter case that syntax checks miss).
+    echo "# interpreter: ${PY:-<none>}"
+    [ -n "${PY:-}" ] || { echo "# FAIL: no working Python 3 on PATH (set E2A_PYTHON)"; exit 1; }
+    _st="$(mktemp)"; TETHER_STATE="$_st" t_state_set probe ok >/dev/null 2>&1
+    if [ "$(TETHER_STATE="$_st" t_state_get probe)" = "ok" ]; then echo "# python round-trip OK"
+    else echo "# FAIL: Python state round-trip broke (interpreter ${PY:-<none>})"; rm -f "$_st"; exit 1; fi
+    rm -f "$_st"
     ;;
 
   ""|help|-h|--help)

--- a/plugins/e2a/skills/tether/tether.sh
+++ b/plugins/e2a/skills/tether/tether.sh
@@ -177,8 +177,11 @@ question or instruction; reply \"stop\" to end early.
     # needed. Flags: --new (always create), --email <addr> (use/create this one).
     force_new=0; want=""
     while [ $# -gt 0 ]; do case "$1" in --new) force_new=1; shift;; --email) want="${2:-}"; shift 2;; *) shift;; esac; done
-    t_resolve_key || { echo "tether setup: no API key found. Run 'e2a login' (browser, no paste) or put an e2a_acct_ key in ~/.e2a-tether.env, then re-run."; exit 1; }
-    echo "tether setup: base ${E2A_BASE_URL}"
+    E2A_BASE_URL="${E2A_BASE_URL:-https://api.e2a.dev}"
+    boot="$(t_resolve_bootstrap)"
+    [ -n "$boot" ] || { echo "tether setup: need an ACCOUNT credential (e2a_acct_… key or an 'e2a login' session). Run 'e2a login' or put an e2a_acct_ key in ~/.e2a-tether.env, then re-run."; exit 1; }
+    E2A_API_KEY="$boot"   # setup's create/mint/protection calls need account scope
+    echo "tether setup: base ${E2A_BASE_URL} (account credential resolved)"
     agent=""
     if [ -n "$want" ] && [ "$force_new" = "0" ]; then agent="$want"; fi
     if [ -z "$agent" ] && [ "$force_new" = "0" ]; then
@@ -207,11 +210,20 @@ question or instruction; reply \"stop\" to end early.
     else
       echo "tether setup: WARNING could not confirm HITL off — check protection in the dashboard" >&2
     fi
-    t_write_env "$E2A_API_KEY" "$agent"
+    # Mint a dedicated AGENT-scoped key (least privilege) and store THAT — not
+    # the broad account key — so a leaked tether key can't touch the account.
+    agtkey="$(t_api_create_agent_key "$boot" "$agent" "tether-$("$PY" -c 'import secrets;print(secrets.token_hex(2))')")"
+    if [ -n "$agtkey" ]; then
+      echo "tether setup: minted agent-scoped key (e2a_agt_…) bound to the inbox"
+    else
+      echo "tether setup: WARNING could not mint an agent key — storing the account key instead" >&2
+      agtkey="$boot"
+    fi
+    t_write_env "$agtkey" "$agent"
     echo "tether setup: wrote ${HOME}/.e2a-tether.env"
-    # export the resolved agent so the confirming subprocess doesn't inherit a
-    # stale/empty E2A_AGENT_EMAIL that t_resolve_key exported from the old file.
-    export E2A_API_KEY E2A_AGENT_EMAIL="$agent"
+    # export the resolved creds so the confirming subprocess doesn't inherit a
+    # stale/empty value from what t_resolve_bootstrap read off the old file.
+    export E2A_API_KEY="$agtkey" E2A_AGENT_EMAIL="$agent"
     bash "${here}/tether.sh" status
     echo "tether setup: ready → tether.sh start <your-email> --for 30m"
     ;;

--- a/plugins/e2a/skills/tether/tether.sh
+++ b/plugins/e2a/skills/tether/tether.sh
@@ -170,6 +170,52 @@ question or instruction; reply \"stop\" to end early.
     echo "tether: stopped"
     ;;
 
+  setup)
+    # Zero-to-tethered bootstrap. Resolves account creds (e2a login / e2a_acct_
+    # key) → ensures an agent inbox (creates one on the shared domain if none) →
+    # forces HITL off → writes ~/.e2a-tether.env. No MCP server or dashboard trip
+    # needed. Flags: --new (always create), --email <addr> (use/create this one).
+    force_new=0; want=""
+    while [ $# -gt 0 ]; do case "$1" in --new) force_new=1; shift;; --email) want="${2:-}"; shift 2;; *) shift;; esac; done
+    t_resolve_key || { echo "tether setup: no API key found. Run 'e2a login' (browser, no paste) or put an e2a_acct_ key in ~/.e2a-tether.env, then re-run."; exit 1; }
+    echo "tether setup: base ${E2A_BASE_URL}"
+    agent=""
+    if [ -n "$want" ] && [ "$force_new" = "0" ]; then agent="$want"; fi
+    if [ -z "$agent" ] && [ "$force_new" = "0" ]; then
+      ags="$(t_api_agents)"
+      agent="$(printf '%s\n' "$ags" | grep -E '^tether-' | head -1)"
+      if [ -z "$agent" ] && [ "$(printf '%s\n' "$ags" | grep -c .)" = "1" ]; then
+        agent="$(printf '%s\n' "$ags" | grep . | head -1)"
+      fi
+      [ -n "$agent" ] && echo "tether setup: reusing existing agent"
+    fi
+    if [ -z "$agent" ]; then
+      cand="$want"
+      if [ -z "$cand" ] || [ "${cand#*@}" = "$cand" ]; then
+        sd="$(t_api_shared_domain)"
+        [ -n "$sd" ] || { echo "tether setup: no shared_domain here — verify a custom domain first, then re-run with --email you@yourdomain"; exit 1; }
+        local_part="${cand:-tether-$("$PY" -c 'import secrets;print(secrets.token_hex(3))')}"
+        cand="${local_part}@${sd}"
+      fi
+      echo "tether setup: creating agent ${cand}…"
+      agent="$(t_api_create_agent "$cand")"
+      [ -n "$agent" ] || { echo "tether setup: agent create failed (slug taken/invalid, or key lacks account scope)"; exit 1; }
+    fi
+    echo "tether setup: agent = ${agent}"
+    if [ "$(t_api_protection_off "$agent")" = "ok" ]; then
+      echo "tether setup: HITL off (outbound gate=flag, scan=off)"
+    else
+      echo "tether setup: WARNING could not confirm HITL off — check protection in the dashboard" >&2
+    fi
+    t_write_env "$E2A_API_KEY" "$agent"
+    echo "tether setup: wrote ${HOME}/.e2a-tether.env"
+    # export the resolved agent so the confirming subprocess doesn't inherit a
+    # stale/empty E2A_AGENT_EMAIL that t_resolve_key exported from the old file.
+    export E2A_API_KEY E2A_AGENT_EMAIL="$agent"
+    bash "${here}/tether.sh" status
+    echo "tether setup: ready → tether.sh start <your-email> --for 30m"
+    ;;
+
   _selftest)
     echo "# unconfigured status (must not crash):"
     env -u E2A_API_KEY -u E2A_AGENT_EMAIL HOME=/nonexistent TETHER_STATE=/tmp/tether-selftest.json \


### PR DESCRIPTION
Adds `tether.sh setup` so a new user goes from signed-in to tethered in **one command**, instead of ~8 manual steps across the dashboard, MCP, and a hand-edited config file.

### What `setup` does
Given an account credential (`e2a login` session, or an `e2a_acct_` key), it:
- ensures an agent inbox — reuse an existing one, else `POST /v1/agents` a `tether-<rand>@<shared_domain>`
- turns HITL **off** (`GET`+merge+`PUT /protection`)
- **mints a least-privilege `e2a_agt_` key** bound to that inbox (`POST /v1/account/api-keys`, `scope=agent`) and stores *that* — not the broad account key — in `~/.e2a-tether.env`

`SKILL.md` gains a fast-path and a runtime step 0 that runs `setup` when `status` shows the config missing.

### Before → after
```
before:  e2a login → mcp add/OAuth → create agent → dashboard: mint key by hand
         → turn HITL off → hand-edit env (full agent address) → /tether
after:   e2a login → /tether (setup) → give email + duration → tethered
```

### Also included (prerequisite)
The setup helpers depend on it: resolve the Python interpreter instead of hardcoding `python3`, so the scripts run on Windows/Git Bash where `python3` is the non-functional MS Store shim. `_selftest` now does a real interpreter round-trip (no more false "syntax OK").

### Tested
End-to-end from a true zero state (0 agents, 0 keys) on Windows/Git Bash against hosted `api.e2a.dev`: `setup` created the inbox, minted a scoped key (`whoami` → `scope=agent`, bound to the inbox), wrote the env, and `start` delivered to a real Gmail.

Refs #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)
