### PR TITLE
feat(cli+tether): harness primitives, login refinement, and the golden tether rewrite on the CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ Layered: generated types → `E2AApi` (raw HTTP) → `E2AClient` (high-level wit
 
 ### CLI (`cli/`)
 
-Commands: login, listen, config. Config stored in `~/.e2a/config.json`. The `listen` command supports `--forward` mode for proxying WebSocket messages to local HTTP endpoints.
+Commands: login, listen, config, whoami, send, reply, messages. Config stored in `~/.e2a/config.json`. The `listen` command supports `--forward` mode for proxying WebSocket messages to local HTTP endpoints. The messaging commands (whoami/send/reply/messages) are the scripting surface for shell-based harnesses and publish a stable exit-code contract (`cli/src/exit.ts`): 0 ok, 1 error, 2 usage, 3 held-for-review (`pending_review` — HTTP-successful but undelivered), 4 auth. Exit codes are frozen once published; add new ones, never renumber.
 
 ### Web (`web/`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,7 +119,7 @@ Layered: generated types → `E2AApi` (raw HTTP) → `E2AClient` (high-level wit
 
 ### CLI (`cli/`)
 
-Commands: login, listen, config, whoami, send, reply, messages. Config stored in `~/.e2a/config.json`. The `listen` command supports `--forward` mode for proxying WebSocket messages to local HTTP endpoints. The messaging commands (whoami/send/reply/messages) are the scripting surface for shell-based harnesses and publish a stable exit-code contract (`cli/src/exit.ts`): 0 ok, 1 error, 2 usage, 3 held-for-review (`pending_review` — HTTP-successful but undelivered), 4 auth. Exit codes are frozen once published; add new ones, never renumber.
+Commands: login, listen, config, whoami, send, reply, messages. Config stored in `~/.e2a/config.json`. The `listen` command supports `--forward` mode for proxying WebSocket messages to local HTTP endpoints. The messaging commands (whoami/send/reply/messages) are the scripting surface for shell-based harnesses and publish a stable exit-code contract (`cli/src/exit.ts`): 0 ok, 1 transient error, 2 usage, 3 held-for-review (any non-`sent` status — HTTP-successful but undelivered), 4 auth, 5 permanent request error (non-retryable 4xx). Exit codes are frozen once published; add new ones, never renumber.
 
 ### Web (`web/`)
 

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/cli",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "CLI for e2a — email for AI agents",
   "bin": {
     "e2a": "./dist/bin/e2a.js"

--- a/cli/src/__tests__/agents.test.ts
+++ b/cli/src/__tests__/agents.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockList = vi.fn();
+const mockCreate = vi.fn();
+const mockGet = vi.fn();
+
+vi.mock("../sdk.js", () => ({
+  createClient: vi.fn(() => ({
+    agents: { list: mockList, create: mockCreate, get: mockGet },
+  })),
+  requireAgentEmail: vi.fn(() => "bot@agents.e2a.dev"),
+}));
+
+const AGENT = {
+  id: "agt_1",
+  email: "tether@agents.e2a.dev",
+  name: "tether",
+  domain: "agents.e2a.dev",
+  domainVerified: true,
+  createdAt: new Date("2026-07-01T10:00:00Z"),
+};
+
+describe("agents commands", () => {
+  let mockStdout: ReturnType<typeof vi.spyOn>;
+  let mockExit: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockStdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it("create passes email + name and prints the created address", async () => {
+    mockCreate.mockResolvedValue(AGENT);
+    const { agentsCreate } = await import("../commands/agents.js");
+    await agentsCreate("tether@agents.e2a.dev", { name: "tether" });
+
+    expect(mockCreate).toHaveBeenCalledWith({ email: "tether@agents.e2a.dev", name: "tether" });
+    expect(mockStdout).toHaveBeenCalledWith("tether@agents.e2a.dev\n");
+  });
+
+  it("create without an email exits USAGE (2)", async () => {
+    const { agentsCreate } = await import("../commands/agents.js");
+    await expect(agentsCreate(undefined, {})).rejects.toThrow("process.exit");
+    expect(mockExit).toHaveBeenCalledWith(2);
+  });
+
+  it("list prints TSV (email, name, verification)", async () => {
+    mockList.mockReturnValue(
+      (async function* () {
+        yield AGENT;
+      })(),
+    );
+    const { agentsList } = await import("../commands/agents.js");
+    await agentsList({});
+
+    expect(mockStdout).toHaveBeenCalledWith("tether@agents.e2a.dev\ttether\tverified\n");
+  });
+
+  it("get prints the agent summary", async () => {
+    mockGet.mockResolvedValue(AGENT);
+    const { agentsGet } = await import("../commands/agents.js");
+    await agentsGet("tether@agents.e2a.dev", {});
+
+    const output = mockStdout.mock.calls.map((c: unknown[]) => c[0]).join("");
+    expect(output).toContain("email:    tether@agents.e2a.dev");
+    expect(output).toContain("domain:   agents.e2a.dev (verified)");
+    expect(output).toContain("created:  2026-07-01T10:00:00.000Z");
+  });
+});

--- a/cli/src/__tests__/args.test.ts
+++ b/cli/src/__tests__/args.test.ts
@@ -1,5 +1,33 @@
 import { describe, it, expect } from "vitest";
-import { getFlag, getFlags, hasFlag, parseArgs } from "../bin/e2a.js";
+import { getFlag, getFlags, hasFlag, parseArgs, getPositionals, hasBareFlag } from "../bin/e2a.js";
+
+describe("hasBareFlag", () => {
+  it("finds a flag in normal position", () => {
+    expect(hasBareFlag(["--json", "--help"], "--help")).toBe(true);
+    expect(hasBareFlag(["--help"], "--help")).toBe(true);
+  });
+
+  it("does NOT match the flag when it is the value of a value-taking flag", () => {
+    // `e2a send --body "--help"` must not hijack the command into help+exit 0.
+    expect(hasBareFlag(["--body", "--help"], "--help")).toBe(false);
+    expect(hasBareFlag(["--subject", "--version"], "--version")).toBe(false);
+  });
+
+  it("matches when preceded by a boolean flag", () => {
+    expect(hasBareFlag(["--to", "a@b.c", "--json", "--help"], "--help")).toBe(true);
+  });
+});
+
+describe("getPositionals", () => {
+  it("extracts positionals, skipping value flags and their values", () => {
+    expect(getPositionals(["msg_1", "--body", "hi", "--json"])).toEqual(["msg_1"]);
+    expect(getPositionals(["--body", "hi", "msg_1"])).toEqual(["msg_1"]);
+  });
+
+  it("returns empty when only flags are present", () => {
+    expect(getPositionals(["--body", "hi", "--json"])).toEqual([]);
+  });
+});
 
 describe("parseArgs", () => {
   it("extracts command and remaining args", () => {

--- a/cli/src/__tests__/config.test.ts
+++ b/cli/src/__tests__/config.test.ts
@@ -159,7 +159,7 @@ describe("requireApiKey", () => {
     ).toThrow("process.exit");
 
     expect(mockStderr).toHaveBeenCalledWith(
-      "Not authenticated. Run: e2a login (or set E2A_API_KEY)\n",
+      "Not authenticated. Run: e2a login (browser) or e2a login --with-key (headless), or set E2A_API_KEY\n",
     );
     // Missing credentials exit AUTH (4) per the scripting contract — not 1,
     // which scripts treat as a retryable transient error.

--- a/cli/src/__tests__/config.test.ts
+++ b/cli/src/__tests__/config.test.ts
@@ -138,7 +138,9 @@ describe("requireApiKey", () => {
     ).toThrow("process.exit");
 
     expect(mockStderr).toHaveBeenCalledWith("Not authenticated. Run: e2a login\n");
-    expect(mockExit).toHaveBeenCalledWith(1);
+    // Missing credentials exit AUTH (4) per the scripting contract — not 1,
+    // which scripts treat as a retryable transient error.
+    expect(mockExit).toHaveBeenCalledWith(4);
 
     mockExit.mockRestore();
     mockStderr.mockRestore();

--- a/cli/src/__tests__/config.test.ts
+++ b/cli/src/__tests__/config.test.ts
@@ -62,6 +62,27 @@ describe("loadConfig", () => {
     expect(config.api_key).toBe("e2a_fromenv");
     expect(config.api_url).toBe("https://custom.dev");
   });
+
+  it("honors the tether env names: E2A_BASE_URL alias and E2A_AGENT_EMAIL", () => {
+    vi.mocked(readFileSync).mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    process.env.E2A_BASE_URL = "https://api.selfhost.dev";
+    process.env.E2A_AGENT_EMAIL = "tether@agents.e2a.dev";
+    try {
+      const config = loadConfig();
+      expect(config.api_url).toBe("https://api.selfhost.dev");
+      expect(config.agent_email).toBe("tether@agents.e2a.dev");
+
+      // Canonical E2A_URL wins over the alias.
+      process.env.E2A_URL = "https://canonical.dev";
+      expect(loadConfig().api_url).toBe("https://canonical.dev");
+    } finally {
+      delete process.env.E2A_BASE_URL;
+      delete process.env.E2A_AGENT_EMAIL;
+      delete process.env.E2A_URL;
+    }
+  });
 });
 
 describe("saveConfig", () => {
@@ -137,7 +158,9 @@ describe("requireApiKey", () => {
       requireApiKey({ api_key: "", api_url: "", agent_email: "", shared_domain: "agents.e2a.dev" }),
     ).toThrow("process.exit");
 
-    expect(mockStderr).toHaveBeenCalledWith("Not authenticated. Run: e2a login\n");
+    expect(mockStderr).toHaveBeenCalledWith(
+      "Not authenticated. Run: e2a login (or set E2A_API_KEY)\n",
+    );
     // Missing credentials exit AUTH (4) per the scripting contract — not 1,
     // which scripts treat as a retryable transient error.
     expect(mockExit).toHaveBeenCalledWith(4);

--- a/cli/src/__tests__/html.test.ts
+++ b/cli/src/__tests__/html.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { htmlToText } from "../html.js";
+
+describe("htmlToText", () => {
+  it("strips tags and preserves block structure as line breaks", () => {
+    const html = "<div><p>First para</p><p>Second para</p></div>";
+    const text = htmlToText(html);
+    expect(text).toContain("First para");
+    expect(text).toContain("Second para");
+    expect(text.indexOf("First para")).toBeLessThan(text.indexOf("Second para"));
+  });
+
+  it("drops script and style contents entirely", () => {
+    const html = "<style>.x{color:red}</style><script>alert('hi')</script><p>Visible</p>";
+    const text = htmlToText(html);
+    expect(text).toBe("Visible");
+    expect(text).not.toContain("color");
+    expect(text).not.toContain("alert");
+  });
+
+  it("decodes named and numeric entities", () => {
+    expect(htmlToText("<p>a &amp; b &lt;c&gt; &#8212; d &#x2014; e</p>")).toBe(
+      "a & b <c> — d — e",
+    );
+  });
+
+  it("converts <br> to newlines", () => {
+    const text = htmlToText("line one<br>line two<br/>line three");
+    expect(text).toBe("line one\nline two\nline three");
+  });
+
+  it("collapses runs of whitespace", () => {
+    const text = htmlToText("<p>a    lot\t\tof   space</p>");
+    expect(text).toBe("a lot of space");
+  });
+
+  it("handles a realistic email snippet", () => {
+    const html = `<div style="max-width:480px"><h2>Status</h2>
+      <p>Merged <b>#357</b> &mdash; tests green.</p>
+      <ul><li>next: docs</li></ul></div>`;
+    const text = htmlToText(html);
+    expect(text).toContain("Status");
+    expect(text).toContain("Merged #357");
+    expect(text).toContain("next: docs");
+    expect(text).not.toContain("<");
+  });
+});

--- a/cli/src/__tests__/login-key.test.ts
+++ b/cli/src/__tests__/login-key.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockAccountGet = vi.fn();
+
+vi.mock("@e2a/sdk/v1", () => ({
+  // `new E2AClient(...)` requires a constructible mock (arrow fns are not).
+  E2AClient: vi.fn(function () {
+    return { account: { get: mockAccountGet } };
+  }),
+}));
+
+const mockSaveConfig = vi.fn();
+vi.mock("../config.js", () => ({
+  loadConfig: vi.fn(() => ({
+    api_key: "",
+    api_url: "https://e2a.dev",
+    agent_email: "",
+    shared_domain: "agents.e2a.dev",
+  })),
+  saveConfig: (...args: unknown[]) => mockSaveConfig(...args),
+}));
+
+const BASE_CONFIG = {
+  api_key: "",
+  api_url: "https://e2a.dev",
+  agent_email: "",
+  shared_domain: "agents.e2a.dev",
+};
+
+describe("login --with-key", () => {
+  let mockStdout: ReturnType<typeof vi.spyOn>;
+  let mockExit: ReturnType<typeof vi.spyOn>;
+  const hadKey = process.env.E2A_API_KEY;
+
+  beforeEach(() => {
+    mockStdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+    delete process.env.E2A_API_KEY;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    if (hadKey) process.env.E2A_API_KEY = hadKey;
+    else delete process.env.E2A_API_KEY;
+  });
+
+  it("validates the key via /v1/account and saves key + scope + bound agent", async () => {
+    mockAccountGet.mockResolvedValue({
+      scope: "agent",
+      agentAddress: "tether@agents.e2a.dev",
+      user: { id: "usr_1", email: "o@x.com" },
+    });
+    const { loginWithKey } = await import("../commands/login.js");
+    await loginWithKey(BASE_CONFIG, "e2a_agt_secret");
+
+    expect(mockSaveConfig).toHaveBeenCalledWith({
+      api_key: "e2a_agt_secret",
+      key_scope: "agent",
+      agent_email: "tether@agents.e2a.dev",
+    });
+    const output = mockStdout.mock.calls.map((c: unknown[]) => c[0]).join("");
+    expect(output).toContain("agent-scoped key");
+    expect(output).toContain("Bound agent: tether@agents.e2a.dev");
+  });
+
+  it("account-scoped keys save without overwriting agent_email", async () => {
+    mockAccountGet.mockResolvedValue({
+      scope: "account",
+      user: { id: "usr_1", email: "o@x.com" },
+    });
+    const { loginWithKey } = await import("../commands/login.js");
+    await loginWithKey(BASE_CONFIG, "e2a_acct_secret");
+
+    expect(mockSaveConfig).toHaveBeenCalledWith({
+      api_key: "e2a_acct_secret",
+      key_scope: "account",
+    });
+  });
+
+  it("falls back to $E2A_API_KEY when no key argument is given", async () => {
+    process.env.E2A_API_KEY = "e2a_agt_fromenv";
+    mockAccountGet.mockResolvedValue({
+      scope: "agent",
+      agentAddress: "t@agents.e2a.dev",
+      user: { id: "u", email: "o@x.com" },
+    });
+    const { loginWithKey } = await import("../commands/login.js");
+    await loginWithKey(BASE_CONFIG);
+
+    expect(mockSaveConfig.mock.calls[0][0].api_key).toBe("e2a_agt_fromenv");
+  });
+
+  it("exits USAGE (2) with no key source on a TTY", async () => {
+    const hadTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
+    try {
+      const { loginWithKey } = await import("../commands/login.js");
+      await expect(loginWithKey(BASE_CONFIG)).rejects.toThrow("process.exit");
+      expect(mockExit).toHaveBeenCalledWith(2);
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", { value: hadTTY, configurable: true });
+    }
+  });
+});

--- a/cli/src/__tests__/login-key.test.ts
+++ b/cli/src/__tests__/login-key.test.ts
@@ -81,17 +81,50 @@ describe("login --with-key", () => {
     });
   });
 
-  it("falls back to $E2A_API_KEY when no key argument is given", async () => {
+  it("falls back to $E2A_API_KEY when no key argument or stdin is given", async () => {
+    const hadTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, "isTTY", { value: true, configurable: true });
     process.env.E2A_API_KEY = "e2a_agt_fromenv";
-    mockAccountGet.mockResolvedValue({
-      scope: "agent",
-      agentAddress: "t@agents.e2a.dev",
-      user: { id: "u", email: "o@x.com" },
-    });
-    const { loginWithKey } = await import("../commands/login.js");
-    await loginWithKey(BASE_CONFIG);
+    try {
+      mockAccountGet.mockResolvedValue({
+        scope: "agent",
+        agentAddress: "t@agents.e2a.dev",
+        user: { id: "u", email: "o@x.com" },
+      });
+      const { loginWithKey } = await import("../commands/login.js");
+      await loginWithKey(BASE_CONFIG);
 
-    expect(mockSaveConfig.mock.calls[0][0].api_key).toBe("e2a_agt_fromenv");
+      expect(mockSaveConfig.mock.calls[0][0].api_key).toBe("e2a_agt_fromenv");
+    } finally {
+      Object.defineProperty(process.stdin, "isTTY", { value: hadTTY, configurable: true });
+    }
+  });
+
+  it("piped stdin OUTRANKS a stale $E2A_API_KEY (key rotation must rotate)", async () => {
+    process.env.E2A_API_KEY = "e2a_agt_staleenv";
+    const realStdin = Object.getOwnPropertyDescriptor(process, "stdin");
+    Object.defineProperty(process, "stdin", {
+      configurable: true,
+      value: {
+        isTTY: false,
+        [Symbol.asyncIterator]: async function* () {
+          yield "e2a_agt_fromstdin\n";
+        },
+      },
+    });
+    try {
+      mockAccountGet.mockResolvedValue({
+        scope: "agent",
+        agentAddress: "t@agents.e2a.dev",
+        user: { id: "u", email: "o@x.com" },
+      });
+      const { loginWithKey } = await import("../commands/login.js");
+      await loginWithKey(BASE_CONFIG);
+
+      expect(mockSaveConfig.mock.calls[0][0].api_key).toBe("e2a_agt_fromstdin");
+    } finally {
+      if (realStdin) Object.defineProperty(process, "stdin", realStdin);
+    }
   });
 
   it("exits USAGE (2) with no key source on a TTY", async () => {

--- a/cli/src/__tests__/login.test.ts
+++ b/cli/src/__tests__/login.test.ts
@@ -173,7 +173,7 @@ describe("login", () => {
       agent_email: "",
       shared_domain: "agents.e2a.dev",
     });
-    expect(mockStderr).toHaveBeenCalledWith("No agents found yet. Create one at https://e2a.dev/get-started\n");
+    expect(mockStderr).toHaveBeenCalledWith("No agents found yet. Run: e2a agents create <name>@<shared-domain> — or visit https://e2a.dev/get-started\n");
   });
 
   it("unrefs the browser child process so Node can exit", async () => {

--- a/cli/src/__tests__/login.test.ts
+++ b/cli/src/__tests__/login.test.ts
@@ -140,6 +140,7 @@ describe("login", () => {
 
     expect(mockSaveConfig).toHaveBeenCalledWith({
       api_key: "e2a_browser_key",
+      key_scope: "account",
       agent_email: "bot@agents.e2a.dev",
       shared_domain: "agents.e2a.dev",
     });
@@ -168,6 +169,7 @@ describe("login", () => {
 
     expect(mockSaveConfig).toHaveBeenCalledWith({
       api_key: "e2a_browser_key",
+      key_scope: "account",
       agent_email: "",
       shared_domain: "agents.e2a.dev",
     });
@@ -233,6 +235,7 @@ describe("login", () => {
     // shared_domain absent — older deployment couldn't be discovered
     expect(mockSaveConfig).toHaveBeenCalledWith({
       api_key: "e2a_browser_key",
+      key_scope: "account",
       agent_email: "bot@example.com",
     });
   });
@@ -291,6 +294,7 @@ describe("login", () => {
 
     expect(mockSaveConfig).toHaveBeenCalledWith({
       api_key: "e2a_self",
+      key_scope: "account",
       agent_email: "bot@agents.acme.test",
       shared_domain: "agents.acme.test",
     });

--- a/cli/src/__tests__/messages.test.ts
+++ b/cli/src/__tests__/messages.test.ts
@@ -58,6 +58,7 @@ describe("messages commands", () => {
       direction: "inbound",
       since: "2026-07-01T09:00:00Z",
       conversationId: "conv-1",
+      limit: 100, // unbounded lists page at the server max, not its 50 default
     });
     expect(mockStdout).toHaveBeenCalledWith(
       "msg_1\tyou@example.com\t2026-07-01T10:00:00.000Z\n",
@@ -131,6 +132,14 @@ describe("messages commands", () => {
   it("get exits USAGE (2) without a message id", async () => {
     const { messagesGet } = await import("../commands/messages.js");
     await expect(messagesGet(undefined, {})).rejects.toThrow("process.exit");
+    expect(mockExit).toHaveBeenCalledWith(2);
+  });
+
+  it("get exits USAGE (2) when --text and --json are combined", async () => {
+    const { messagesGet } = await import("../commands/messages.js");
+    await expect(messagesGet("msg_1", { text: true, json: true })).rejects.toThrow(
+      "process.exit",
+    );
     expect(mockExit).toHaveBeenCalledWith(2);
   });
 });

--- a/cli/src/__tests__/messages.test.ts
+++ b/cli/src/__tests__/messages.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockList = vi.fn();
+const mockGet = vi.fn();
+
+vi.mock("../sdk.js", () => ({
+  createClient: vi.fn(() => ({ messages: { list: mockList, get: mockGet } })),
+  requireAgentEmail: vi.fn(() => "bot@agents.e2a.dev"),
+}));
+
+function summaries(...items: Array<Record<string, unknown>>) {
+  return (async function* () {
+    for (const item of items) yield item;
+  })();
+}
+
+const M1 = {
+  messageId: "msg_1",
+  _from: "you@example.com",
+  createdAt: new Date("2026-07-01T10:00:00Z"),
+  subject: "re: status",
+};
+const M2 = {
+  messageId: "msg_2",
+  _from: "other@example.com",
+  createdAt: new Date("2026-07-01T10:05:00Z"),
+  subject: "re: status",
+};
+
+describe("messages commands", () => {
+  let mockStdout: ReturnType<typeof vi.spyOn>;
+  let mockExit: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockStdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it("lists messages as TSV, oldest first, with filters passed through", async () => {
+    mockList.mockReturnValue(summaries(M1, M2));
+    const { messagesList } = await import("../commands/messages.js");
+    await messagesList({
+      direction: "inbound",
+      since: "2026-07-01T09:00:00Z",
+      conversation: "conv-1",
+    });
+
+    expect(mockList).toHaveBeenCalledWith("bot@agents.e2a.dev", {
+      sort: "asc",
+      direction: "inbound",
+      since: "2026-07-01T09:00:00Z",
+      conversationId: "conv-1",
+    });
+    expect(mockStdout).toHaveBeenCalledWith(
+      "msg_1\tyou@example.com\t2026-07-01T10:00:00.000Z\n",
+    );
+    expect(mockStdout).toHaveBeenCalledWith(
+      "msg_2\tother@example.com\t2026-07-01T10:05:00.000Z\n",
+    );
+  });
+
+  it("emits NDJSON with --json", async () => {
+    mockList.mockReturnValue(summaries(M1));
+    const { messagesList } = await import("../commands/messages.js");
+    await messagesList({ json: true });
+
+    expect(mockStdout).toHaveBeenCalledWith(JSON.stringify(M1) + "\n");
+  });
+
+  it("stops after --limit items", async () => {
+    mockList.mockReturnValue(summaries(M1, M2));
+    const { messagesList } = await import("../commands/messages.js");
+    await messagesList({ limit: "1" });
+
+    const lines = mockStdout.mock.calls.map((c: unknown[]) => c[0]);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("msg_1");
+  });
+
+  it("exits USAGE (2) on a bad --direction or --limit", async () => {
+    const { messagesList } = await import("../commands/messages.js");
+    await expect(messagesList({ direction: "sideways" })).rejects.toThrow("process.exit");
+    expect(mockExit).toHaveBeenCalledWith(2);
+
+    mockExit.mockClear();
+    await expect(messagesList({ limit: "zero" })).rejects.toThrow("process.exit");
+    expect(mockExit).toHaveBeenCalledWith(2);
+  });
+
+  it("get --text prefers parsed text over raw body text", async () => {
+    mockGet.mockResolvedValue({
+      messageId: "msg_1",
+      parsed: { text: "just the reply" },
+      body: { text: "just the reply\n> quoted history" },
+    });
+    const { messagesGet } = await import("../commands/messages.js");
+    await messagesGet("msg_1", { text: true });
+
+    expect(mockGet).toHaveBeenCalledWith("bot@agents.e2a.dev", "msg_1");
+    expect(mockStdout).toHaveBeenCalledWith("just the reply\n");
+  });
+
+  it("get --text falls back to body text, then empty", async () => {
+    mockGet.mockResolvedValue({ messageId: "msg_1", body: { text: "raw body" } });
+    const { messagesGet } = await import("../commands/messages.js");
+    await messagesGet("msg_1", { text: true });
+    expect(mockStdout).toHaveBeenCalledWith("raw body\n");
+
+    mockGet.mockResolvedValue({ messageId: "msg_2" });
+    await messagesGet("msg_2", { text: true });
+    expect(mockStdout).toHaveBeenCalledWith("\n");
+  });
+
+  it("get emits full JSON without --text", async () => {
+    const full = { messageId: "msg_1", subject: "s", conversationId: "conv-1" };
+    mockGet.mockResolvedValue(full);
+    const { messagesGet } = await import("../commands/messages.js");
+    await messagesGet("msg_1", {});
+
+    expect(mockStdout).toHaveBeenCalledWith(JSON.stringify(full) + "\n");
+  });
+
+  it("get exits USAGE (2) without a message id", async () => {
+    const { messagesGet } = await import("../commands/messages.js");
+    await expect(messagesGet(undefined, {})).rejects.toThrow("process.exit");
+    expect(mockExit).toHaveBeenCalledWith(2);
+  });
+});

--- a/cli/src/__tests__/messages.test.ts
+++ b/cli/src/__tests__/messages.test.ts
@@ -55,6 +55,7 @@ describe("messages commands", () => {
 
     expect(mockList).toHaveBeenCalledWith("bot@agents.e2a.dev", {
       sort: "asc",
+      readStatus: "all", // poll-loop safe: never hide messages read elsewhere
       direction: "inbound",
       since: "2026-07-01T09:00:00Z",
       conversationId: "conv-1",
@@ -68,12 +69,27 @@ describe("messages commands", () => {
     );
   });
 
-  it("emits NDJSON with --json", async () => {
+  it("emits NDJSON with --json, renaming the generated _from to wire-stable from", async () => {
     mockList.mockReturnValue(summaries(M1));
     const { messagesList } = await import("../commands/messages.js");
     await messagesList({ json: true });
 
-    expect(mockStdout).toHaveBeenCalledWith(JSON.stringify(M1) + "\n");
+    const line = mockStdout.mock.calls[0][0] as string;
+    const parsed = JSON.parse(line);
+    expect(parsed.from).toBe("you@example.com");
+    expect(parsed._from).toBeUndefined();
+    expect(parsed.messageId).toBe("msg_1");
+    expect(parsed.createdAt).toBe("2026-07-01T10:00:00.000Z");
+  });
+
+  it("passes --read-status through and rejects invalid values", async () => {
+    mockList.mockReturnValue(summaries());
+    const { messagesList } = await import("../commands/messages.js");
+    await messagesList({ readStatus: "unread" });
+    expect(mockList.mock.calls[0][1].readStatus).toBe("unread");
+
+    await expect(messagesList({ readStatus: "sideways" })).rejects.toThrow("process.exit");
+    expect(mockExit).toHaveBeenCalledWith(2);
   });
 
   it("stops after --limit items", async () => {
@@ -117,6 +133,19 @@ describe("messages commands", () => {
 
     mockGet.mockResolvedValue({ messageId: "msg_2" });
     await messagesGet("msg_2", { text: true });
+    expect(mockStdout).toHaveBeenCalledWith("\n");
+  });
+
+  it("get --text respects an intentionally-empty parsed result (all-quoted reply)", async () => {
+    // parsed.text === "" means the parser ran and the reply was ALL quoted
+    // history — must NOT fall through to the unstripped raw body.
+    mockGet.mockResolvedValue({
+      messageId: "msg_q",
+      parsed: { text: "" },
+      body: { text: "> the entire quoted thread" },
+    });
+    const { messagesGet } = await import("../commands/messages.js");
+    await messagesGet("msg_q", { text: true });
     expect(mockStdout).toHaveBeenCalledWith("\n");
   });
 

--- a/cli/src/__tests__/messages.test.ts
+++ b/cli/src/__tests__/messages.test.ts
@@ -69,6 +69,25 @@ describe("messages commands", () => {
     );
   });
 
+  it("sanitizes TSV delimiters out of the sender-controlled From field", async () => {
+    mockList.mockReturnValue(
+      summaries({
+        messageId: "msg_evil",
+        _from: 'Evil\tName\n"attacker@x.com"',
+        createdAt: new Date("2026-07-01T10:00:00Z"),
+        subject: "s",
+      }),
+    );
+    const { messagesList } = await import("../commands/messages.js");
+    await messagesList({});
+
+    const line = mockStdout.mock.calls[0][0] as string;
+    // Exactly three fields, no injected rows: tabs/newlines collapsed.
+    expect(line.split("\t")).toHaveLength(3);
+    expect(line.trim().split("\n")).toHaveLength(1);
+    expect(line).toContain('Evil Name "attacker@x.com"');
+  });
+
   it("emits NDJSON with --json, renaming the generated _from to wire-stable from", async () => {
     mockList.mockReturnValue(summaries(M1));
     const { messagesList } = await import("../commands/messages.js");

--- a/cli/src/__tests__/protection.test.ts
+++ b/cli/src/__tests__/protection.test.ts
@@ -72,6 +72,22 @@ describe("protection commands", () => {
     expect(put.inbound.scan.sensitivity).toBe("high"); // untouched
   });
 
+  it("set --outbound-review on re-enables a disabled scan (off→on round-trip restores holding)", async () => {
+    // Under gate policy "open" every sender matches, so the gate action never
+    // fires — HITL "on" without a scan would look on while holding nothing.
+    const doc = makeDoc();
+    doc.outbound.gate.action = "flag";
+    doc.outbound.scan.sensitivity = "off";
+    mockGetProtection.mockResolvedValue(doc);
+    mockReplaceProtection.mockImplementation(async (_email: string, d: unknown) => d);
+    const { protectionSet } = await import("../commands/protection.js");
+    await protectionSet("bot@agents.e2a.dev", { outboundReview: "on" });
+
+    const put = mockReplaceProtection.mock.calls[0][1];
+    expect(put.outbound.gate.action).toBe("review");
+    expect(put.outbound.scan.sensitivity).toBe("medium");
+  });
+
   it("NEVER writes when the read fails — a transient GET error must not reset the doc", async () => {
     mockGetProtection.mockRejectedValue(new Error("boom"));
     const { protectionSet } = await import("../commands/protection.js");

--- a/cli/src/__tests__/protection.test.ts
+++ b/cli/src/__tests__/protection.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockGetProtection = vi.fn();
+const mockReplaceProtection = vi.fn();
+
+vi.mock("../sdk.js", () => ({
+  createClient: vi.fn(() => ({
+    agents: { getProtection: mockGetProtection, replaceProtection: mockReplaceProtection },
+  })),
+  requireAgentEmail: vi.fn(() => "bot@agents.e2a.dev"),
+}));
+
+// A doc with deliberately non-default values everywhere, so any knob the
+// command wasn't asked to touch shows up as a diff if it gets reset.
+function makeDoc() {
+  return {
+    inbound: {
+      gate: { policy: "open", allowlist: [], action: "review" },
+      scan: { sensitivity: "high" },
+    },
+    outbound: {
+      gate: { policy: "allowlist", allowlist: ["trusted@x.com"], action: "review" },
+      scan: { sensitivity: "medium" },
+    },
+    holds: { ttlSeconds: 3600, onExpiry: "approve" },
+  };
+}
+
+describe("protection commands", () => {
+  let mockStdout: ReturnType<typeof vi.spyOn>;
+  let mockExit: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockStdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it("set --outbound-review off flips ONLY the outbound gate action + scan", async () => {
+    mockGetProtection.mockResolvedValue(makeDoc());
+    mockReplaceProtection.mockImplementation(async (_email: string, doc: unknown) => doc);
+    const { protectionSet } = await import("../commands/protection.js");
+    await protectionSet("bot@agents.e2a.dev", { outboundReview: "off" });
+
+    const put = mockReplaceProtection.mock.calls[0][1];
+    expect(put.outbound.gate.action).toBe("flag");
+    expect(put.outbound.scan.sensitivity).toBe("off");
+    // Untouched knobs survive: gate policy/allowlist, inbound, holds.
+    expect(put.outbound.gate.policy).toBe("allowlist");
+    expect(put.outbound.gate.allowlist).toEqual(["trusted@x.com"]);
+    expect(put.inbound).toEqual(makeDoc().inbound);
+    expect(put.holds).toEqual(makeDoc().holds);
+  });
+
+  it("set --inbound-review on flips the gate action and leaves scan tuning alone", async () => {
+    const doc = makeDoc();
+    doc.inbound.gate.action = "flag";
+    mockGetProtection.mockResolvedValue(doc);
+    mockReplaceProtection.mockImplementation(async (_email: string, d: unknown) => d);
+    const { protectionSet } = await import("../commands/protection.js");
+    await protectionSet("bot@agents.e2a.dev", { inboundReview: "on" });
+
+    const put = mockReplaceProtection.mock.calls[0][1];
+    expect(put.inbound.gate.action).toBe("review");
+    expect(put.inbound.scan.sensitivity).toBe("high"); // untouched
+  });
+
+  it("NEVER writes when the read fails — a transient GET error must not reset the doc", async () => {
+    mockGetProtection.mockRejectedValue(new Error("boom"));
+    const { protectionSet } = await import("../commands/protection.js");
+
+    await expect(
+      protectionSet("bot@agents.e2a.dev", { outboundReview: "off" }),
+    ).rejects.toThrow("boom");
+    expect(mockReplaceProtection).not.toHaveBeenCalled();
+  });
+
+  it("rejects missing email, missing knobs, and bad values with USAGE (2)", async () => {
+    const { protectionSet } = await import("../commands/protection.js");
+
+    await expect(protectionSet(undefined, { outboundReview: "off" })).rejects.toThrow("process.exit");
+    await expect(protectionSet("a@b.c", {})).rejects.toThrow("process.exit");
+    await expect(protectionSet("a@b.c", { outboundReview: "sideways" })).rejects.toThrow("process.exit");
+    expect(mockExit).toHaveBeenCalledWith(2);
+    expect(mockGetProtection).not.toHaveBeenCalled();
+  });
+
+  it("get prints a human summary (and raw JSON with --json)", async () => {
+    mockGetProtection.mockResolvedValue(makeDoc());
+    const { protectionGet } = await import("../commands/protection.js");
+    await protectionGet("bot@agents.e2a.dev", {});
+
+    const output = mockStdout.mock.calls.map((c: unknown[]) => c[0]).join("");
+    expect(output).toContain("outbound: gate=allowlist/review scan=medium");
+    expect(output).toContain("inbound:  gate=open/review scan=high");
+    expect(output).toContain("holds:    ttl=3600s on_expiry=approve");
+
+    mockStdout.mockClear();
+    await protectionGet("bot@agents.e2a.dev", { json: true });
+    expect(JSON.parse(mockStdout.mock.calls[0][0] as string)).toEqual(makeDoc());
+  });
+});

--- a/cli/src/__tests__/send.test.ts
+++ b/cli/src/__tests__/send.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockSend = vi.fn();
+const mockReply = vi.fn();
+
+vi.mock("../sdk.js", () => ({
+  createClient: vi.fn(() => ({ messages: { send: mockSend, reply: mockReply } })),
+  requireAgentEmail: vi.fn((override?: string) => override || "bot@agents.e2a.dev"),
+}));
+
+const mockReadFileSync = vi.fn();
+vi.mock("node:fs", () => ({
+  readFileSync: (...args: unknown[]) => mockReadFileSync(...args),
+}));
+
+describe("send/reply commands", () => {
+  let mockStdout: ReturnType<typeof vi.spyOn>;
+  let mockStderr: ReturnType<typeof vi.spyOn>;
+  let mockExit: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockStdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    mockStderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
+      throw new Error("process.exit");
+    });
+  });
+
+  afterEach(() => {
+    mockStdout.mockRestore();
+    mockStderr.mockRestore();
+    mockExit.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it("sends a plain-text message and prints the message id", async () => {
+    mockSend.mockResolvedValue({ messageId: "msg_abc", status: "sent" });
+    const { send } = await import("../commands/send.js");
+    await send({ to: ["you@example.com"], subject: "hi", body: "hello" });
+
+    expect(mockSend).toHaveBeenCalledWith("bot@agents.e2a.dev", {
+      to: ["you@example.com"],
+      subject: "hi",
+      body: "hello",
+    });
+    expect(mockStdout).toHaveBeenCalledWith("msg_abc\n");
+    expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  it("exits HELD (3) with a warning when the send is pending_review", async () => {
+    mockSend.mockResolvedValue({ messageId: "msg_held", status: "pending_review" });
+    const { send } = await import("../commands/send.js");
+
+    await expect(
+      send({ to: ["you@example.com"], subject: "hi", body: "hello" }),
+    ).rejects.toThrow("process.exit");
+
+    // The id is still printed (the message exists, parked in the queue) …
+    expect(mockStdout).toHaveBeenCalledWith("msg_held\n");
+    // … but the held contract fires: warning + exit 3.
+    expect(mockStderr).toHaveBeenCalledWith(expect.stringContaining("pending_review"));
+    expect(mockExit).toHaveBeenCalledWith(3);
+  });
+
+  it("derives a text fallback from --html-file when no --body is given", async () => {
+    mockReadFileSync.mockReturnValue("<p>Status: <b>green</b></p>");
+    mockSend.mockResolvedValue({ messageId: "msg_h", status: "sent" });
+    const { send } = await import("../commands/send.js");
+    await send({ to: ["you@example.com"], subject: "s", htmlFile: "/tmp/u.html" });
+
+    const call = mockSend.mock.calls[0][1];
+    expect(call.htmlBody).toBe("<p>Status: <b>green</b></p>");
+    expect(call.body).toBe("Status: green");
+  });
+
+  it("passes conversation id through", async () => {
+    mockSend.mockResolvedValue({ messageId: "msg_c", status: "sent" });
+    const { send } = await import("../commands/send.js");
+    await send({
+      to: ["you@example.com"],
+      subject: "s",
+      body: "b",
+      conversationId: "conv-1",
+    });
+
+    expect(mockSend.mock.calls[0][1].conversationId).toBe("conv-1");
+  });
+
+  it("exits USAGE (2) when --to or --subject is missing", async () => {
+    const { send } = await import("../commands/send.js");
+    await expect(send({ to: [], subject: "s", body: "b" })).rejects.toThrow("process.exit");
+    expect(mockExit).toHaveBeenCalledWith(2);
+  });
+
+  it("exits USAGE (2) when no body source is given", async () => {
+    const { send } = await import("../commands/send.js");
+    await expect(send({ to: ["a@b.c"], subject: "s" })).rejects.toThrow("process.exit");
+    expect(mockExit).toHaveBeenCalledWith(2);
+  });
+
+  it("exits USAGE (2) when --html-file is unreadable", async () => {
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    const { send } = await import("../commands/send.js");
+    await expect(
+      send({ to: ["a@b.c"], subject: "s", htmlFile: "/nope.html" }),
+    ).rejects.toThrow("process.exit");
+    expect(mockExit).toHaveBeenCalledWith(2);
+    expect(mockStderr).toHaveBeenCalledWith(expect.stringContaining("/nope.html"));
+  });
+
+  it("replies in-thread and honors the held contract", async () => {
+    mockReply.mockResolvedValue({ messageId: "msg_r", status: "pending_review" });
+    const { reply } = await import("../commands/send.js");
+
+    await expect(reply("msg_orig", { body: "answer" })).rejects.toThrow("process.exit");
+    expect(mockReply).toHaveBeenCalledWith("bot@agents.e2a.dev", "msg_orig", {
+      body: "answer",
+    });
+    expect(mockExit).toHaveBeenCalledWith(3);
+  });
+
+  it("exits USAGE (2) when reply is missing the message id", async () => {
+    const { reply } = await import("../commands/send.js");
+    await expect(reply(undefined, { body: "answer" })).rejects.toThrow("process.exit");
+    expect(mockExit).toHaveBeenCalledWith(2);
+  });
+});

--- a/cli/src/__tests__/send.test.ts
+++ b/cli/src/__tests__/send.test.ts
@@ -31,6 +31,9 @@ describe("send/reply commands", () => {
     mockStderr.mockRestore();
     mockExit.mockRestore();
     vi.clearAllMocks();
+    // The held path sets process.exitCode (flush-safe) instead of exiting;
+    // reset it so a passing suite doesn't report a nonzero exit.
+    process.exitCode = 0;
   });
 
   it("sends a plain-text message and prints the message id", async () => {
@@ -47,19 +50,19 @@ describe("send/reply commands", () => {
     expect(mockExit).not.toHaveBeenCalled();
   });
 
-  it("exits HELD (3) with a warning when the send is pending_review", async () => {
+  it("sets exit code HELD (3) with a warning when the send is pending_review", async () => {
     mockSend.mockResolvedValue({ messageId: "msg_held", status: "pending_review" });
     const { send } = await import("../commands/send.js");
 
-    await expect(
-      send({ to: ["you@example.com"], subject: "hi", body: "hello" }),
-    ).rejects.toThrow("process.exit");
+    await send({ to: ["you@example.com"], subject: "hi", body: "hello" });
 
     // The id is still printed (the message exists, parked in the queue) …
     expect(mockStdout).toHaveBeenCalledWith("msg_held\n");
-    // … but the held contract fires: warning + exit 3.
+    // … and the held contract fires via exitCode (not process.exit, which
+    // could truncate the piped stdout carrying the id).
     expect(mockStderr).toHaveBeenCalledWith(expect.stringContaining("pending_review"));
-    expect(mockExit).toHaveBeenCalledWith(3);
+    expect(mockExit).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(3);
   });
 
   it("derives a text fallback from --html-file when no --body is given", async () => {
@@ -114,11 +117,23 @@ describe("send/reply commands", () => {
     mockReply.mockResolvedValue({ messageId: "msg_r", status: "pending_review" });
     const { reply } = await import("../commands/send.js");
 
-    await expect(reply("msg_orig", { body: "answer" })).rejects.toThrow("process.exit");
+    await reply("msg_orig", { body: "answer" });
     expect(mockReply).toHaveBeenCalledWith("bot@agents.e2a.dev", "msg_orig", {
       body: "answer",
     });
-    expect(mockExit).toHaveBeenCalledWith(3);
+    expect(process.exitCode).toBe(3);
+  });
+
+  it("sends markup-only HTML whose derived text fallback is empty", async () => {
+    mockReadFileSync.mockReturnValue('<img src="cid:logo"><table><tr><td></td></tr></table>');
+    mockSend.mockResolvedValue({ messageId: "msg_img", status: "sent" });
+    const { send } = await import("../commands/send.js");
+    await send({ to: ["you@example.com"], subject: "s", htmlFile: "/tmp/banner.html" });
+
+    const call = mockSend.mock.calls[0][1];
+    expect(call.body).toBe("");
+    expect(call.htmlBody).toContain("<img");
+    expect(mockExit).not.toHaveBeenCalled();
   });
 
   it("exits USAGE (2) when reply is missing the message id", async () => {

--- a/cli/src/__tests__/send.test.ts
+++ b/cli/src/__tests__/send.test.ts
@@ -41,13 +41,35 @@ describe("send/reply commands", () => {
     const { send } = await import("../commands/send.js");
     await send({ to: ["you@example.com"], subject: "hi", body: "hello" });
 
-    expect(mockSend).toHaveBeenCalledWith("bot@agents.e2a.dev", {
-      to: ["you@example.com"],
-      subject: "hi",
-      body: "hello",
-    });
+    expect(mockSend).toHaveBeenCalledWith(
+      "bot@agents.e2a.dev",
+      { to: ["you@example.com"], subject: "hi", body: "hello" },
+      undefined,
+    );
     expect(mockStdout).toHaveBeenCalledWith("msg_abc\n");
     expect(mockExit).not.toHaveBeenCalled();
+  });
+
+  it("threads --idempotency-key through to the SDK request options", async () => {
+    mockSend.mockResolvedValue({ messageId: "msg_i", status: "sent" });
+    const { send } = await import("../commands/send.js");
+    await send({
+      to: ["you@example.com"],
+      subject: "s",
+      body: "b",
+      idempotencyKey: "evt-42",
+    });
+
+    expect(mockSend.mock.calls[0][2]).toEqual({ idempotencyKey: "evt-42" });
+  });
+
+  it("treats any non-'sent' status as HELD (open-set status contract)", async () => {
+    mockSend.mockResolvedValue({ messageId: "msg_u", status: "some_future_hold" });
+    const { send } = await import("../commands/send.js");
+    await send({ to: ["you@example.com"], subject: "s", body: "b" });
+
+    expect(mockStderr).toHaveBeenCalledWith(expect.stringContaining("some_future_hold"));
+    expect(process.exitCode).toBe(3);
   });
 
   it("sets exit code HELD (3) with a warning when the send is pending_review", async () => {
@@ -118,9 +140,12 @@ describe("send/reply commands", () => {
     const { reply } = await import("../commands/send.js");
 
     await reply("msg_orig", { body: "answer" });
-    expect(mockReply).toHaveBeenCalledWith("bot@agents.e2a.dev", "msg_orig", {
-      body: "answer",
-    });
+    expect(mockReply).toHaveBeenCalledWith(
+      "bot@agents.e2a.dev",
+      "msg_orig",
+      { body: "answer" },
+      undefined,
+    );
     expect(process.exitCode).toBe(3);
   });
 

--- a/cli/src/__tests__/whoami.test.ts
+++ b/cli/src/__tests__/whoami.test.ts
@@ -7,6 +7,15 @@ vi.mock("../sdk.js", () => ({
   requireAgentEmail: vi.fn(() => "bot@agents.e2a.dev"),
 }));
 
+vi.mock("../config.js", () => ({
+  loadConfig: vi.fn(() => ({
+    api_key: "e2a_testkey",
+    api_url: "https://e2a.dev",
+    agent_email: "bot@agents.e2a.dev",
+    shared_domain: "agents.e2a.dev",
+  })),
+}));
+
 function makeAccount(overrides: Record<string, unknown> = {}) {
   return {
     user: { id: "usr_1", email: "owner@example.com" },
@@ -39,7 +48,9 @@ describe("whoami command", () => {
     const output = mockStdout.mock.calls.map((c: unknown[]) => c[0]).join("");
     expect(output).toContain("user:  owner@example.com (usr_1)");
     expect(output).toContain("scope: account");
-    expect(output).not.toContain("agent:");
+    // Account keys aren't inbox-bound; the preflight shows the config default
+    // that send/reply will actually use.
+    expect(output).toContain("agent: bot@agents.e2a.dev (default from config/E2A_AGENT_EMAIL)");
     expect(output).toContain("plan:  free");
     expect(output).toContain("usage: 2/5 agents, 17/1000 messages this month");
   });

--- a/cli/src/__tests__/whoami.test.ts
+++ b/cli/src/__tests__/whoami.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockAccountGet = vi.fn();
+
+vi.mock("../sdk.js", () => ({
+  createClient: vi.fn(() => ({ account: { get: mockAccountGet } })),
+  requireAgentEmail: vi.fn(() => "bot@agents.e2a.dev"),
+}));
+
+function makeAccount(overrides: Record<string, unknown> = {}) {
+  return {
+    user: { id: "usr_1", email: "owner@example.com" },
+    scope: "account",
+    planCode: "free",
+    upgradeUrl: "https://e2a.dev/upgrade",
+    limits: { maxAgents: 5, maxDomains: 1, maxMessagesMonth: 1000, maxStorageBytes: 0 },
+    usage: { agents: 2, domains: 0, messagesMonth: 17, storageBytes: 0 },
+    ...overrides,
+  };
+}
+
+describe("whoami command", () => {
+  let mockStdout: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockStdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    mockStdout.mockRestore();
+    vi.clearAllMocks();
+  });
+
+  it("prints identity, scope, plan, and usage for an account key", async () => {
+    mockAccountGet.mockResolvedValue(makeAccount());
+    const { whoami } = await import("../commands/whoami.js");
+    await whoami({});
+
+    const output = mockStdout.mock.calls.map((c: unknown[]) => c[0]).join("");
+    expect(output).toContain("user:  owner@example.com (usr_1)");
+    expect(output).toContain("scope: account");
+    expect(output).not.toContain("agent:");
+    expect(output).toContain("plan:  free");
+    expect(output).toContain("usage: 2/5 agents, 17/1000 messages this month");
+  });
+
+  it("shows the bound agent for an agent-scoped key", async () => {
+    mockAccountGet.mockResolvedValue(
+      makeAccount({ scope: "agent", agentAddress: "tether@agents.e2a.dev" }),
+    );
+    const { whoami } = await import("../commands/whoami.js");
+    await whoami({});
+
+    const output = mockStdout.mock.calls.map((c: unknown[]) => c[0]).join("");
+    expect(output).toContain("scope: agent");
+    expect(output).toContain("agent: tether@agents.e2a.dev");
+  });
+
+  it("emits raw JSON with --json", async () => {
+    const account = makeAccount();
+    mockAccountGet.mockResolvedValue(account);
+    const { whoami } = await import("../commands/whoami.js");
+    await whoami({ json: true });
+
+    expect(mockStdout).toHaveBeenCalledWith(JSON.stringify(account) + "\n");
+  });
+});

--- a/cli/src/bin/e2a.ts
+++ b/cli/src/bin/e2a.ts
@@ -1,15 +1,25 @@
 #!/usr/bin/env node
 
-// e2a CLI — slimmed to its non-duplicative surface (GA). Agent CRUD, messaging,
-// domains, webhooks, events, and HITL all live in the MCP tools, the SDKs, and
-// the web dashboard; the CLI keeps only what those don't cover ergonomically:
+// e2a CLI — the developer convenience surface plus the *scripting* surface.
+// Interactive management (domains, webhooks, HITL queues) lives in the MCP
+// tools, SDKs, and dashboard. The CLI covers what those can't:
 //   - login   : browser auth → ~/.e2a/config.json
 //   - listen  : real-time inbound over WebSocket, with --forward to bridge a
 //               local HTTP handler (the `stripe listen --forward-to` pattern)
 //   - config  : view/update the local config
+//   - whoami / send / reply / messages : stateless primitives for shell-script
+//     harnesses (skills, hooks, CI) with a documented exit-code contract —
+//     see EXIT in ../exit.ts. Held sends (pending_review) exit 3, because an
+//     HTTP-successful send that reached nobody must be distinguishable without
+//     parsing JSON.
 import { login } from "../commands/login.js";
 import { config } from "../commands/config.js";
 import { listen } from "../commands/listen.js";
+import { whoami } from "../commands/whoami.js";
+import { send, reply } from "../commands/send.js";
+import { messagesList, messagesGet } from "../commands/messages.js";
+import { EXIT } from "../exit.js";
+import { E2AAuthError, E2APermissionError } from "@e2a/sdk/v1";
 import { createRequire } from "module";
 
 const require = createRequire(import.meta.url);
@@ -17,11 +27,30 @@ const pkg = require("../../package.json") as { version: string };
 
 const USAGE = `e2a — email for AI agents
 
-The CLI is a thin developer convenience. Drive agents via the MCP tools or the
-SDKs (@e2a/sdk, e2a); manage domains/agents/webhooks/keys in the dashboard.
+Scriptable primitives for agent harnesses (send/reply/messages/whoami, with a
+stable exit-code contract) plus login and real-time listen. Interactive
+management (domains, webhooks, review queues) lives in the MCP tools, the SDKs
+(@e2a/sdk, e2a), and the dashboard.
 
 Usage:
   e2a login                         Log in via browser and save config
+  e2a whoami [--json]               Show key identity: user, scope, bound agent, plan
+  e2a send [options]                Send an email as the agent
+        --to <email>               Recipient (repeatable)
+        --subject <s>              Subject line
+        --body <text>              Plain-text body (or --body-file <f>)
+        --html-file <f>            HTML body; text fallback derived if no --body
+        --conversation-id <id>     Thread id for the agent's own threading
+        --agent <email>            Sending inbox (or config agent_email)
+        --json                     Print the full send result as JSON
+  e2a reply <message-id> [options]  Reply in-thread (same body options as send)
+  e2a messages list [options]       List messages, oldest first
+        --direction <d>            inbound|outbound|all
+        --since <ISO>              Only messages after this timestamp
+        --conversation <id>        Filter to one conversation
+        --limit <n>                Stop after n messages
+        --json                     NDJSON instead of TSV (id, from, created_at)
+  e2a messages get <id> [--text]    Fetch one message (--text = body text only)
   e2a listen [options]              Stream inbound email over WebSocket
         --agent <email>            Agent inbox to listen on (or config agent_email)
         --forward <url>            POST each message to a local URL (dev webhook proxy)
@@ -32,6 +61,14 @@ Usage:
 Options:
   --help     Show this help
   --version  Show version
+
+Exit codes (stable scripting contract):
+  0  success
+  1  network / server / unexpected error
+  2  usage error (bad flags or arguments)
+  3  send accepted but HELD for review (pending_review) — not delivered
+  4  bad credentials or wrong key scope
+  5  bounded wait hit its deadline
 `;
 
 function parseArgs(argv: string[]): { command: string; args: string[] } {
@@ -66,6 +103,24 @@ function hasFlag(args: string[], flag: string): boolean {
   return args.includes(flag);
 }
 
+// Flags that take no value. Everything else starting with "--" consumes the
+// next token, which getPositionals must skip to find bare arguments like a
+// message id.
+const BOOLEAN_FLAGS = new Set(["--json", "--text", "--help", "--version"]);
+
+function getPositionals(args: string[]): string[] {
+  const positionals: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg.startsWith("--")) {
+      if (!BOOLEAN_FLAGS.has(arg)) i++; // skip the flag's value
+      continue;
+    }
+    positionals.push(arg);
+  }
+  return positionals;
+}
+
 async function main() {
   const { command, args } = parseArgs(process.argv);
 
@@ -89,6 +144,54 @@ async function main() {
     case "login":
       await login();
       break;
+    case "whoami":
+      await whoami({ json: hasFlag(args, "--json") });
+      break;
+    case "send":
+      await send({
+        to: getFlags(args, "--to"),
+        subject: getFlag(args, "--subject"),
+        body: getFlag(args, "--body"),
+        bodyFile: getFlag(args, "--body-file"),
+        htmlFile: getFlag(args, "--html-file"),
+        conversationId: getFlag(args, "--conversation-id"),
+        agent: getFlag(args, "--agent"),
+        json: hasFlag(args, "--json"),
+      });
+      break;
+    case "reply":
+      await reply(getPositionals(args)[0], {
+        body: getFlag(args, "--body"),
+        bodyFile: getFlag(args, "--body-file"),
+        htmlFile: getFlag(args, "--html-file"),
+        agent: getFlag(args, "--agent"),
+        json: hasFlag(args, "--json"),
+      });
+      break;
+    case "messages": {
+      const sub = args[0];
+      const rest = args.slice(1);
+      if (sub === "list") {
+        await messagesList({
+          agent: getFlag(rest, "--agent"),
+          direction: getFlag(rest, "--direction"),
+          since: getFlag(rest, "--since"),
+          conversation: getFlag(rest, "--conversation"),
+          limit: getFlag(rest, "--limit"),
+          json: hasFlag(rest, "--json"),
+        });
+      } else if (sub === "get") {
+        await messagesGet(getPositionals(rest)[0], {
+          agent: getFlag(rest, "--agent"),
+          text: hasFlag(rest, "--text"),
+          json: hasFlag(rest, "--json"),
+        });
+      } else {
+        process.stderr.write("Usage: e2a messages [list|get <id>]\n");
+        process.exit(EXIT.USAGE);
+      }
+      break;
+    }
     case "listen":
       await listen({
         agent: getFlag(args, "--agent"),
@@ -113,8 +216,11 @@ const isTestImport = typeof process !== "undefined" && !!process.env.VITEST_WORK
 if (!isTestImport) {
   main().catch((err) => {
     process.stderr.write(`Error: ${err.message}\n`);
-    process.exit(1);
+    // Auth failures get their own exit code so scripts can distinguish "fix
+    // your key" from a transient error worth retrying.
+    const isAuth = err instanceof E2AAuthError || err instanceof E2APermissionError;
+    process.exit(isAuth ? EXIT.AUTH : EXIT.ERROR);
   });
 }
 
-export { getFlag, getFlags, hasFlag, parseArgs };
+export { getFlag, getFlags, hasFlag, parseArgs, getPositionals };

--- a/cli/src/bin/e2a.ts
+++ b/cli/src/bin/e2a.ts
@@ -19,7 +19,7 @@ import { whoami } from "../commands/whoami.js";
 import { send, reply } from "../commands/send.js";
 import { messagesList, messagesGet } from "../commands/messages.js";
 import { EXIT } from "../exit.js";
-import { E2AAuthError, E2APermissionError } from "@e2a/sdk/v1";
+import { E2AError, E2AAuthError, E2APermissionError } from "@e2a/sdk/v1";
 import { createRequire } from "module";
 
 const require = createRequire(import.meta.url);
@@ -40,17 +40,23 @@ Usage:
         --subject <s>              Subject line
         --body <text>              Plain-text body (or --body-file <f>)
         --html-file <f>            HTML body; text fallback derived if no --body
-        --conversation-id <id>     Thread id for the agent's own threading
-        --agent <email>            Sending inbox (or config agent_email)
+        --conversation-id <id>     Thread id (alias: --conversation)
+        --idempotency-key <k>      Stable key so a retried invocation can't double-send
+        --agent <email>            Sending inbox (or config agent_email / E2A_AGENT_EMAIL)
         --json                     Print the full send result as JSON
   e2a reply <message-id> [options]  Reply in-thread (same body options as send)
   e2a messages list [options]       List messages, oldest first
         --direction <d>            inbound|outbound|all
-        --since <ISO>              Only messages after this timestamp
-        --conversation <id>        Filter to one conversation
+        --since <ISO>              Messages created AT or after this timestamp
+                                   (inclusive — dedup by message id when cursoring)
+        --conversation <id>        Filter to one conversation (alias: --conversation-id)
+        --read-status <s>          unread|read|all (default all — safe for poll loops)
         --limit <n>                Stop after n messages
+        --agent <email>            Inbox to list (or config agent_email)
         --json                     NDJSON instead of TSV (id, from, created_at)
-  e2a messages get <id> [--text]    Fetch one message (--text = body text only)
+  e2a messages get <id> [--text]    Fetch one message; marks it read
+        --text                     Print body text only (parsed reply-text preferred)
+        --agent <email>            Inbox to read (or config agent_email)
   e2a listen [options]              Stream inbound email over WebSocket
         --agent <email>            Agent inbox to listen on (or config agent_email)
         --forward <url>            POST each message to a local URL (dev webhook proxy)
@@ -64,10 +70,11 @@ Options:
 
 Exit codes (stable scripting contract):
   0  success
-  1  network / server / unexpected error
+  1  transient error (network / 5xx / rate limit) — retry may help
   2  usage error (bad flags or arguments)
   3  send accepted but HELD for review (pending_review) — not delivered
   4  bad credentials or wrong key scope
+  5  permanent request error (not found / invalid / conflict) — do NOT retry
 `;
 
 function parseArgs(argv: string[]): { command: string; args: string[] } {
@@ -160,6 +167,29 @@ function getFlagsChecked(args: string[], flag: string): string[] {
   return values;
 }
 
+/**
+ * Reject flags a command doesn't know, loudly. Without this, a typo'd
+ * `--conversation-id` on `messages list` silently widens the query to the
+ * whole mailbox with exit 0 — the silent-corruption class the exit-code
+ * contract exists to prevent. Also rejects `--flag=value` (unsupported form)
+ * with a pointer at the space-separated syntax.
+ */
+function checkFlags(args: string[], allowed: string[]): void {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (!arg.startsWith("--")) continue;
+    if (arg.includes("=")) {
+      process.stderr.write(`${arg}: use space-separated values (--flag value), not --flag=value\n`);
+      process.exit(EXIT.USAGE);
+    }
+    if (!allowed.includes(arg)) {
+      process.stderr.write(`unknown flag: ${arg} (see e2a --help)\n`);
+      process.exit(EXIT.USAGE);
+    }
+    if (!BOOLEAN_FLAGS.has(arg)) i++; // skip the flag's value
+  }
+}
+
 async function main() {
   const { command, args } = parseArgs(process.argv);
 
@@ -184,26 +214,39 @@ async function main() {
       await login();
       break;
     case "whoami":
+      checkFlags(args, ["--json"]);
       await whoami({ json: hasFlag(args, "--json") });
       break;
     case "send":
+      checkFlags(args, [
+        "--to", "--subject", "--body", "--body-file", "--html-file",
+        "--conversation-id", "--conversation", "--agent", "--idempotency-key", "--json",
+      ]);
       await send({
         to: getFlagsChecked(args, "--to"),
         subject: getFlagChecked(args, "--subject"),
         body: getFlagChecked(args, "--body"),
         bodyFile: getFlagChecked(args, "--body-file"),
         htmlFile: getFlagChecked(args, "--html-file"),
-        conversationId: getFlagChecked(args, "--conversation-id"),
+        // --conversation accepted as an alias so send and messages list can't
+        // trip each other's spelling.
+        conversationId:
+          getFlagChecked(args, "--conversation-id") ?? getFlagChecked(args, "--conversation"),
         agent: getFlagChecked(args, "--agent"),
+        idempotencyKey: getFlagChecked(args, "--idempotency-key"),
         json: hasFlag(args, "--json"),
       });
       break;
     case "reply":
+      checkFlags(args, [
+        "--body", "--body-file", "--html-file", "--agent", "--idempotency-key", "--json",
+      ]);
       await reply(getPositionals(args)[0], {
         body: getFlagChecked(args, "--body"),
         bodyFile: getFlagChecked(args, "--body-file"),
         htmlFile: getFlagChecked(args, "--html-file"),
         agent: getFlagChecked(args, "--agent"),
+        idempotencyKey: getFlagChecked(args, "--idempotency-key"),
         json: hasFlag(args, "--json"),
       });
       break;
@@ -211,15 +254,22 @@ async function main() {
       const sub = args[0];
       const rest = args.slice(1);
       if (sub === "list") {
+        checkFlags(rest, [
+          "--direction", "--since", "--conversation", "--conversation-id",
+          "--read-status", "--limit", "--agent", "--json",
+        ]);
         await messagesList({
           agent: getFlagChecked(rest, "--agent"),
           direction: getFlagChecked(rest, "--direction"),
           since: getFlagChecked(rest, "--since"),
-          conversation: getFlagChecked(rest, "--conversation"),
+          conversation:
+            getFlagChecked(rest, "--conversation") ?? getFlagChecked(rest, "--conversation-id"),
+          readStatus: getFlagChecked(rest, "--read-status"),
           limit: getFlagChecked(rest, "--limit"),
           json: hasFlag(rest, "--json"),
         });
       } else if (sub === "get") {
+        checkFlags(rest, ["--text", "--json", "--agent"]);
         await messagesGet(getPositionals(rest)[0], {
           agent: getFlagChecked(rest, "--agent"),
           text: hasFlag(rest, "--text"),
@@ -232,11 +282,14 @@ async function main() {
       break;
     }
     case "listen":
+      checkFlags(args, ["--agent", "--forward", "--forward-token", "--json"]);
       await listen({
-        agent: getFlag(args, "--agent"),
+        agent: getFlagChecked(args, "--agent"),
         json: hasFlag(args, "--json"),
-        forward: getFlag(args, "--forward"),
-        forwardToken: getFlag(args, "--forward-token"),
+        // Checked variants: `listen --forward` with a missing value used to
+        // silently listen WITHOUT forwarding — the silent-drop class again.
+        forward: getFlagChecked(args, "--forward"),
+        forwardToken: getFlagChecked(args, "--forward-token"),
       });
       break;
     case "config":
@@ -254,11 +307,16 @@ const isTestImport = typeof process !== "undefined" && !!process.env.VITEST_WORK
 
 if (!isTestImport) {
   main().catch((err) => {
-    process.stderr.write(`Error: ${err.message}\n`);
-    // Auth failures get their own exit code so scripts can distinguish "fix
-    // your key" from a transient error worth retrying.
+    // Print the API error code when present so scripts can grep it even
+    // without branching on exit codes.
+    const code = err instanceof E2AError && err.code ? ` [${err.code}]` : "";
+    process.stderr.write(`Error: ${err.message}${code}\n`);
+    // Contract mapping: AUTH (4) = fix your key; REQUEST (5) = permanent
+    // request error (404/409/422 — the SDK marks these non-retryable), do NOT
+    // retry the identical invocation; ERROR (1) = transient, retry may help.
     const isAuth = err instanceof E2AAuthError || err instanceof E2APermissionError;
-    process.exit(isAuth ? EXIT.AUTH : EXIT.ERROR);
+    const isPermanent = !isAuth && err instanceof E2AError && !err.retryable;
+    process.exit(isAuth ? EXIT.AUTH : isPermanent ? EXIT.REQUEST : EXIT.ERROR);
   });
 }
 

--- a/cli/src/bin/e2a.ts
+++ b/cli/src/bin/e2a.ts
@@ -18,6 +18,9 @@ import { listen } from "../commands/listen.js";
 import { whoami } from "../commands/whoami.js";
 import { send, reply } from "../commands/send.js";
 import { messagesList, messagesGet } from "../commands/messages.js";
+import { agentsList, agentsCreate, agentsGet } from "../commands/agents.js";
+import { protectionGet, protectionSet } from "../commands/protection.js";
+import { keysCreate, keysList, keysDelete } from "../commands/keys.js";
 import { EXIT } from "../exit.js";
 import { E2AError, E2AAuthError, E2APermissionError } from "@e2a/sdk/v1";
 import { createRequire } from "module";
@@ -33,13 +36,29 @@ management (domains, webhooks, review queues) lives in the MCP tools, the SDKs
 (@e2a/sdk, e2a), and the dashboard.
 
 Usage:
-  e2a login                         Log in via browser and save config
+  e2a login                         Log in via browser (account-scoped key)
+        --agent <inbox>            Exchange for a least-privilege agent-scoped key
+                                   bound to <inbox> (bare slugs expand on the
+                                   shared domain); revokes the account bootstrap key
+        --with-key [<key>]         Headless: validate + save a key (from the arg,
+                                   $E2A_API_KEY, or stdin) — no browser needed
   e2a whoami [--json]               Show key identity: user, scope, bound agent, plan
+  e2a agents list                   List owned inboxes (account key)
+  e2a agents create <email> [--name <n>]   Create an inbox (account key)
+  e2a agents get <email>            Show one inbox
+  e2a keys create [--agent <inbox>] [--name <n>]   Mint a key; --agent = bound,
+                                   least-privilege (plaintext printed once)
+  e2a keys list / delete <id>       Inventory / revoke keys (account key)
+  e2a protection get <email>        Show the protection (screening/review) config
+  e2a protection set <email>        Flip review posture, only the named knobs
+        --outbound-review on|off   off = sends go out unheld (gate=flag, scan=off)
+        --inbound-review on|off    off = inbound delivered unheld
   e2a send [options]                Send an email as the agent
         --to <email>               Recipient (repeatable)
         --subject <s>              Subject line
         --body <text>              Plain-text body (or --body-file <f>)
         --html-file <f>            HTML body; text fallback derived if no --body
+        --attach <file>            Attach a file (repeatable)
         --conversation-id <id>     Thread id (alias: --conversation)
         --idempotency-key <k>      Stable key so a retried invocation can't double-send
         --agent <email>            Sending inbox (or config agent_email / E2A_AGENT_EMAIL)
@@ -61,6 +80,10 @@ Usage:
         --agent <email>            Agent inbox to listen on (or config agent_email)
         --forward <url>            POST each message to a local URL (dev webhook proxy)
         --forward-token <token>    Bearer token to send with --forward requests
+        --conversation <id>        Only messages in this conversation
+        --once                     Exit 0 after the first (matching) message
+        --until <ISO>              With --once: deadline; prints TIMEOUT, exits 6
+        --text                     With --once: print the message body text only
         --json                     Emit raw JSON notifications
   e2a config [list|get|set]         View or update config
 
@@ -75,6 +98,7 @@ Exit codes (stable scripting contract):
   3  send accepted but HELD for review (pending_review) — not delivered
   4  bad credentials or wrong key scope
   5  permanent request error (not found / invalid / conflict) — do NOT retry
+  6  bounded wait (listen --once --until) expired with no matching message
 `;
 
 function parseArgs(argv: string[]): { command: string; args: string[] } {
@@ -112,7 +136,7 @@ function hasFlag(args: string[], flag: string): boolean {
 // Flags that take no value. Everything else starting with "--" consumes the
 // next token, which getPositionals must skip to find bare arguments like a
 // message id.
-const BOOLEAN_FLAGS = new Set(["--json", "--text", "--help", "--version"]);
+const BOOLEAN_FLAGS = new Set(["--json", "--text", "--once", "--help", "--version"]);
 
 function getPositionals(args: string[]): string[] {
   const positionals: string[] = [];
@@ -211,19 +235,89 @@ async function main() {
 
   switch (command) {
     case "login":
-      await login();
+      checkFlags(args, ["--agent", "--with-key"]);
+      await login({
+        agent: getFlagChecked(args, "--agent"),
+        withKey: hasFlag(args, "--with-key"),
+        // Unchecked on purpose: bare `--with-key` (no value) means "take the
+        // key from $E2A_API_KEY or stdin".
+        key: getFlag(args, "--with-key"),
+      });
       break;
+    case "agents": {
+      const sub = args[0];
+      const rest = args.slice(1);
+      if (sub === "list") {
+        checkFlags(rest, ["--json"]);
+        await agentsList({ json: hasFlag(rest, "--json") });
+      } else if (sub === "create") {
+        checkFlags(rest, ["--name", "--json"]);
+        await agentsCreate(getPositionals(rest)[0], {
+          name: getFlagChecked(rest, "--name"),
+          json: hasFlag(rest, "--json"),
+        });
+      } else if (sub === "get") {
+        checkFlags(rest, ["--json"]);
+        await agentsGet(getPositionals(rest)[0], { json: hasFlag(rest, "--json") });
+      } else {
+        process.stderr.write("Usage: e2a agents [list|create <email>|get <email>]\n");
+        process.exit(EXIT.USAGE);
+      }
+      break;
+    }
+    case "keys": {
+      const sub = args[0];
+      const rest = args.slice(1);
+      if (sub === "create") {
+        checkFlags(rest, ["--name", "--agent", "--json"]);
+        await keysCreate({
+          name: getFlagChecked(rest, "--name"),
+          agent: getFlagChecked(rest, "--agent"),
+          json: hasFlag(rest, "--json"),
+        });
+      } else if (sub === "list") {
+        checkFlags(rest, ["--json"]);
+        await keysList({ json: hasFlag(rest, "--json") });
+      } else if (sub === "delete") {
+        checkFlags(rest, []);
+        await keysDelete(getPositionals(rest)[0]);
+      } else {
+        process.stderr.write("Usage: e2a keys [create [--agent <inbox>]|list|delete <id>]\n");
+        process.exit(EXIT.USAGE);
+      }
+      break;
+    }
+    case "protection": {
+      const sub = args[0];
+      const rest = args.slice(1);
+      if (sub === "get") {
+        checkFlags(rest, ["--json"]);
+        await protectionGet(getPositionals(rest)[0], { json: hasFlag(rest, "--json") });
+      } else if (sub === "set") {
+        checkFlags(rest, ["--outbound-review", "--inbound-review", "--json"]);
+        await protectionSet(getPositionals(rest)[0], {
+          outboundReview: getFlagChecked(rest, "--outbound-review"),
+          inboundReview: getFlagChecked(rest, "--inbound-review"),
+          json: hasFlag(rest, "--json"),
+        });
+      } else {
+        process.stderr.write("Usage: e2a protection [get <email>|set <email> --outbound-review on|off]\n");
+        process.exit(EXIT.USAGE);
+      }
+      break;
+    }
     case "whoami":
       checkFlags(args, ["--json"]);
       await whoami({ json: hasFlag(args, "--json") });
       break;
     case "send":
       checkFlags(args, [
-        "--to", "--subject", "--body", "--body-file", "--html-file",
+        "--to", "--subject", "--body", "--body-file", "--html-file", "--attach",
         "--conversation-id", "--conversation", "--agent", "--idempotency-key", "--json",
       ]);
       await send({
         to: getFlagsChecked(args, "--to"),
+        attach: getFlagsChecked(args, "--attach"),
         subject: getFlagChecked(args, "--subject"),
         body: getFlagChecked(args, "--body"),
         bodyFile: getFlagChecked(args, "--body-file"),
@@ -239,9 +333,10 @@ async function main() {
       break;
     case "reply":
       checkFlags(args, [
-        "--body", "--body-file", "--html-file", "--agent", "--idempotency-key", "--json",
+        "--body", "--body-file", "--html-file", "--attach", "--agent", "--idempotency-key", "--json",
       ]);
       await reply(getPositionals(args)[0], {
+        attach: getFlagsChecked(args, "--attach"),
         body: getFlagChecked(args, "--body"),
         bodyFile: getFlagChecked(args, "--body-file"),
         htmlFile: getFlagChecked(args, "--html-file"),
@@ -282,7 +377,10 @@ async function main() {
       break;
     }
     case "listen":
-      checkFlags(args, ["--agent", "--forward", "--forward-token", "--json"]);
+      checkFlags(args, [
+        "--agent", "--forward", "--forward-token", "--json",
+        "--conversation", "--conversation-id", "--once", "--until", "--text",
+      ]);
       await listen({
         agent: getFlagChecked(args, "--agent"),
         json: hasFlag(args, "--json"),
@@ -290,6 +388,11 @@ async function main() {
         // silently listen WITHOUT forwarding — the silent-drop class again.
         forward: getFlagChecked(args, "--forward"),
         forwardToken: getFlagChecked(args, "--forward-token"),
+        conversation:
+          getFlagChecked(args, "--conversation") ?? getFlagChecked(args, "--conversation-id"),
+        once: hasFlag(args, "--once"),
+        until: getFlagChecked(args, "--until"),
+        text: hasFlag(args, "--text"),
       });
       break;
     case "config":

--- a/cli/src/bin/e2a.ts
+++ b/cli/src/bin/e2a.ts
@@ -178,14 +178,21 @@ function getFlagChecked(args: string[], flag: string): string | undefined {
     process.stderr.write(`${flag} requires a value\n`);
     process.exit(EXIT.USAGE);
   }
+  // An empty string is never a meaningful flag value here, and treating it as
+  // "flag not given" downstream silently DROPS filters — `--conversation ""`
+  // used to widen a thread poll to the entire mailbox.
+  if (value === "") {
+    process.stderr.write(`${flag} requires a non-empty value\n`);
+    process.exit(EXIT.USAGE);
+  }
   return value;
 }
 
 function getFlagsChecked(args: string[], flag: string): string[] {
   const values = getFlags(args, flag);
   const occurrences = args.filter((a) => a === flag).length;
-  if (values.length !== occurrences) {
-    process.stderr.write(`${flag} requires a value\n`);
+  if (values.length !== occurrences || values.some((v) => v === "")) {
+    process.stderr.write(`${flag} requires a non-empty value\n`);
     process.exit(EXIT.USAGE);
   }
   return values;
@@ -301,7 +308,9 @@ async function main() {
           json: hasFlag(rest, "--json"),
         });
       } else {
-        process.stderr.write("Usage: e2a protection [get <email>|set <email> --outbound-review on|off]\n");
+        process.stderr.write(
+          "Usage: e2a protection [get <email>|set <email> [--outbound-review on|off] [--inbound-review on|off]]\n",
+        );
         process.exit(EXIT.USAGE);
       }
       break;

--- a/cli/src/bin/e2a.ts
+++ b/cli/src/bin/e2a.ts
@@ -68,7 +68,6 @@ Exit codes (stable scripting contract):
   2  usage error (bad flags or arguments)
   3  send accepted but HELD for review (pending_review) — not delivered
   4  bad credentials or wrong key scope
-  5  bounded wait hit its deadline
 `;
 
 function parseArgs(argv: string[]): { command: string; args: string[] } {
@@ -121,6 +120,46 @@ function getPositionals(args: string[]): string[] {
   return positionals;
 }
 
+/**
+ * True when `flag` appears as an actual flag — not as the VALUE of a
+ * preceding value-taking flag. Without this, `e2a send --body "--help"`
+ * would print usage and exit 0 with nothing sent: a silent drop.
+ */
+function hasBareFlag(args: string[], flag: string): boolean {
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] !== flag) continue;
+    const prev = i > 0 ? args[i - 1] : undefined;
+    const prevTakesValue = prev !== undefined && prev.startsWith("--") && !BOOLEAN_FLAGS.has(prev);
+    if (!prevTakesValue) return true;
+  }
+  return false;
+}
+
+/**
+ * getFlag, but a flag that is present with a missing or flag-like value is a
+ * loud usage error instead of a silent "flag not given" — a dropped
+ * --conversation-id or --limit must never quietly change what a send or list
+ * does. (Values that legitimately start with "--" go via --body-file.)
+ */
+function getFlagChecked(args: string[], flag: string): string | undefined {
+  const value = getFlag(args, flag);
+  if (value === undefined && args.includes(flag)) {
+    process.stderr.write(`${flag} requires a value\n`);
+    process.exit(EXIT.USAGE);
+  }
+  return value;
+}
+
+function getFlagsChecked(args: string[], flag: string): string[] {
+  const values = getFlags(args, flag);
+  const occurrences = args.filter((a) => a === flag).length;
+  if (values.length !== occurrences) {
+    process.stderr.write(`${flag} requires a value\n`);
+    process.exit(EXIT.USAGE);
+  }
+  return values;
+}
+
 async function main() {
   const { command, args } = parseArgs(process.argv);
 
@@ -129,13 +168,13 @@ async function main() {
     command === "help" ||
     command === "--help" ||
     command === "-h" ||
-    hasFlag(args, "--help")
+    hasBareFlag(args, "--help")
   ) {
     process.stdout.write(USAGE);
     return;
   }
 
-  if (command === "--version" || command === "-v" || hasFlag(args, "--version")) {
+  if (command === "--version" || command === "-v" || hasBareFlag(args, "--version")) {
     process.stdout.write(`e2a ${pkg.version}\n`);
     return;
   }
@@ -149,22 +188,22 @@ async function main() {
       break;
     case "send":
       await send({
-        to: getFlags(args, "--to"),
-        subject: getFlag(args, "--subject"),
-        body: getFlag(args, "--body"),
-        bodyFile: getFlag(args, "--body-file"),
-        htmlFile: getFlag(args, "--html-file"),
-        conversationId: getFlag(args, "--conversation-id"),
-        agent: getFlag(args, "--agent"),
+        to: getFlagsChecked(args, "--to"),
+        subject: getFlagChecked(args, "--subject"),
+        body: getFlagChecked(args, "--body"),
+        bodyFile: getFlagChecked(args, "--body-file"),
+        htmlFile: getFlagChecked(args, "--html-file"),
+        conversationId: getFlagChecked(args, "--conversation-id"),
+        agent: getFlagChecked(args, "--agent"),
         json: hasFlag(args, "--json"),
       });
       break;
     case "reply":
       await reply(getPositionals(args)[0], {
-        body: getFlag(args, "--body"),
-        bodyFile: getFlag(args, "--body-file"),
-        htmlFile: getFlag(args, "--html-file"),
-        agent: getFlag(args, "--agent"),
+        body: getFlagChecked(args, "--body"),
+        bodyFile: getFlagChecked(args, "--body-file"),
+        htmlFile: getFlagChecked(args, "--html-file"),
+        agent: getFlagChecked(args, "--agent"),
         json: hasFlag(args, "--json"),
       });
       break;
@@ -173,16 +212,16 @@ async function main() {
       const rest = args.slice(1);
       if (sub === "list") {
         await messagesList({
-          agent: getFlag(rest, "--agent"),
-          direction: getFlag(rest, "--direction"),
-          since: getFlag(rest, "--since"),
-          conversation: getFlag(rest, "--conversation"),
-          limit: getFlag(rest, "--limit"),
+          agent: getFlagChecked(rest, "--agent"),
+          direction: getFlagChecked(rest, "--direction"),
+          since: getFlagChecked(rest, "--since"),
+          conversation: getFlagChecked(rest, "--conversation"),
+          limit: getFlagChecked(rest, "--limit"),
           json: hasFlag(rest, "--json"),
         });
       } else if (sub === "get") {
         await messagesGet(getPositionals(rest)[0], {
-          agent: getFlag(rest, "--agent"),
+          agent: getFlagChecked(rest, "--agent"),
           text: hasFlag(rest, "--text"),
           json: hasFlag(rest, "--json"),
         });
@@ -206,7 +245,7 @@ async function main() {
     default:
       process.stderr.write(`Unknown command: ${command}\n`);
       process.stderr.write(USAGE);
-      process.exit(1);
+      process.exit(EXIT.USAGE);
   }
 }
 
@@ -223,4 +262,4 @@ if (!isTestImport) {
   });
 }
 
-export { getFlag, getFlags, hasFlag, parseArgs, getPositionals };
+export { getFlag, getFlags, hasFlag, parseArgs, getPositionals, hasBareFlag };

--- a/cli/src/commands/agents.ts
+++ b/cli/src/commands/agents.ts
@@ -1,4 +1,5 @@
 import { createClient } from "../sdk.js";
+import { loadConfig } from "../config.js";
 import { EXIT, fail } from "../exit.js";
 
 export interface AgentsListOptions {
@@ -38,9 +39,12 @@ export async function agentsCreate(
   opts: AgentsCreateOptions,
 ): Promise<void> {
   if (!email) fail(EXIT.USAGE, CREATE_USAGE);
+  // Bare names expand on the shared domain, same as `login --agent` — the two
+  // paths must not disagree on what `create myname` means.
+  const address = email.includes("@") ? email : `${email}@${loadConfig().shared_domain}`;
 
   const client = createClient();
-  const agent = await client.agents.create({ email, name: opts.name });
+  const agent = await client.agents.create({ email: address, name: opts.name });
   if (opts.json) {
     process.stdout.write(JSON.stringify(agent) + "\n");
   } else {

--- a/cli/src/commands/agents.ts
+++ b/cli/src/commands/agents.ts
@@ -1,0 +1,64 @@
+import { createClient } from "../sdk.js";
+import { EXIT, fail } from "../exit.js";
+
+export interface AgentsListOptions {
+  json?: boolean;
+}
+
+export interface AgentsCreateOptions {
+  name?: string;
+  json?: boolean;
+}
+
+export interface AgentsGetOptions {
+  json?: boolean;
+}
+
+const CREATE_USAGE = "usage: e2a agents create <email> [--name <n>] [--json]";
+const GET_USAGE = "usage: e2a agents get <email> [--json]";
+
+// Account-scope only (agent-scoped keys exit 4 with the server's message).
+// `list` closes the discovery gap: before it, nothing on the CLI could answer
+// "which inboxes do I own?" after login.
+export async function agentsList(opts: AgentsListOptions): Promise<void> {
+  const client = createClient();
+  for await (const agent of client.agents.list()) {
+    if (opts.json) {
+      process.stdout.write(JSON.stringify(agent) + "\n");
+    } else {
+      process.stdout.write(
+        `${agent.email}\t${agent.name || ""}\t${agent.domainVerified ? "verified" : "unverified"}\n`,
+      );
+    }
+  }
+}
+
+export async function agentsCreate(
+  email: string | undefined,
+  opts: AgentsCreateOptions,
+): Promise<void> {
+  if (!email) fail(EXIT.USAGE, CREATE_USAGE);
+
+  const client = createClient();
+  const agent = await client.agents.create({ email, name: opts.name });
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(agent) + "\n");
+  } else {
+    process.stdout.write(agent.email + "\n");
+  }
+}
+
+export async function agentsGet(email: string | undefined, opts: AgentsGetOptions): Promise<void> {
+  if (!email) fail(EXIT.USAGE, GET_USAGE);
+
+  const client = createClient();
+  const agent = await client.agents.get(email);
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(agent) + "\n");
+    return;
+  }
+  process.stdout.write(`email:    ${agent.email}\n`);
+  if (agent.name) process.stdout.write(`name:     ${agent.name}\n`);
+  process.stdout.write(`domain:   ${agent.domain} (${agent.domainVerified ? "verified" : "unverified"})\n`);
+  process.stdout.write(`created:  ${agent.createdAt.toISOString()}\n`);
+}

--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -1,6 +1,6 @@
 import { loadConfig, saveConfig, Config } from "../config.js";
 
-const VALID_KEYS: (keyof Config)[] = ["api_key", "api_url", "agent_email", "shared_domain"];
+const VALID_KEYS: (keyof Config)[] = ["api_key", "api_url", "agent_email", "shared_domain", "key_scope"];
 
 export async function config(args: string[]): Promise<void> {
   const subcommand = args[0];

--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -1,6 +1,7 @@
 import { loadConfig, saveConfig, Config } from "../config.js";
+import { EXIT } from "../exit.js";
 
-const VALID_KEYS: (keyof Config)[] = ["api_key", "api_url", "agent_email", "shared_domain", "key_scope"];
+const VALID_KEYS: (keyof Config)[] = ["api_key", "api_url", "agent_email", "shared_domain"];
 
 export async function config(args: string[]): Promise<void> {
   const subcommand = args[0];
@@ -14,11 +15,11 @@ export async function config(args: string[]): Promise<void> {
     const key = args[1];
     if (!key) {
       process.stderr.write("Usage: e2a config get <key>\n");
-      process.exit(1);
+      process.exit(EXIT.USAGE);
     }
     if (!VALID_KEYS.includes(key as keyof Config)) {
       process.stderr.write(`Unknown key: ${key}\nValid keys: ${VALID_KEYS.join(", ")}\n`);
-      process.exit(1);
+      process.exit(EXIT.USAGE);
     }
     const cfg = loadConfig();
     const value = cfg[key as keyof Config];
@@ -33,11 +34,11 @@ export async function config(args: string[]): Promise<void> {
     const value = args[2];
     if (!key || value === undefined) {
       process.stderr.write("Usage: e2a config set <key> <value>\n");
-      process.exit(1);
+      process.exit(EXIT.USAGE);
     }
     if (!VALID_KEYS.includes(key as keyof Config)) {
       process.stderr.write(`Unknown key: ${key}\nValid keys: ${VALID_KEYS.join(", ")}\n`);
-      process.exit(1);
+      process.exit(EXIT.USAGE);
     }
     saveConfig({ [key]: value });
     process.stdout.write(`${key}=${value}\n`);
@@ -58,7 +59,7 @@ export async function config(args: string[]): Promise<void> {
     "Usage: e2a config [list|get <key>|set <key> <value>]\n" +
       `Valid keys: ${VALID_KEYS.join(", ")}\n`,
   );
-  process.exit(1);
+  process.exit(EXIT.USAGE);
 }
 
 function showAll(): void {

--- a/cli/src/commands/config.ts
+++ b/cli/src/commands/config.ts
@@ -1,7 +1,7 @@
 import { loadConfig, saveConfig, Config } from "../config.js";
 import { EXIT } from "../exit.js";
 
-const VALID_KEYS: (keyof Config)[] = ["api_key", "api_url", "agent_email", "shared_domain"];
+const VALID_KEYS: (keyof Config)[] = ["api_key", "api_url", "agent_email", "shared_domain", "key_scope"];
 
 export async function config(args: string[]): Promise<void> {
   const subcommand = args[0];
@@ -38,6 +38,12 @@ export async function config(args: string[]): Promise<void> {
     }
     if (!VALID_KEYS.includes(key as keyof Config)) {
       process.stderr.write(`Unknown key: ${key}\nValid keys: ${VALID_KEYS.join(", ")}\n`);
+      process.exit(EXIT.USAGE);
+    }
+    // key_scope is an enum, not free text — a persisted typo would feed any
+    // future scope preflight confidently wrong data.
+    if (key === "key_scope" && value !== "account" && value !== "agent") {
+      process.stderr.write(`key_scope must be "account" or "agent"\n`);
       process.exit(EXIT.USAGE);
     }
     saveConfig({ [key]: value });

--- a/cli/src/commands/keys.ts
+++ b/cli/src/commands/keys.ts
@@ -1,0 +1,61 @@
+import type { CreateAPIKeyRequest } from "@e2a/sdk/v1";
+import { hostname } from "node:os";
+import { createClient } from "../sdk.js";
+import { EXIT, fail } from "../exit.js";
+
+export interface KeysCreateOptions {
+  name?: string;
+  /** Bind the key to this inbox (scope=agent). Omit for an account-scoped key. */
+  agent?: string;
+  json?: boolean;
+}
+
+export interface KeysListOptions {
+  json?: boolean;
+}
+
+const DELETE_USAGE = "usage: e2a keys delete <key-id>";
+
+// Account-scope only. `create --agent` is the non-interactive path to a
+// least-privilege agent key — what a harness bootstrap (tether setup) runs
+// when the account credential already exists and no browser is available.
+export async function keysCreate(opts: KeysCreateOptions): Promise<void> {
+  const client = createClient();
+  const created = await client.account.apiKeys.create({
+    name: opts.name || (opts.agent ? `agent key @${hostname()}` : `account key @${hostname()}`),
+    ...(opts.agent
+      ? { scope: "agent" as CreateAPIKeyRequest["scope"], agent: opts.agent }
+      : {}),
+  });
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(created) + "\n");
+    return;
+  }
+  // Plaintext key alone on stdout (script-friendly: KEY=$(e2a keys create …));
+  // the shown-once warning goes to stderr so it can't pollute the capture.
+  process.stdout.write(created.key + "\n");
+  process.stderr.write(
+    `Key ${created.id} created (${opts.agent ? `agent-scoped: ${opts.agent}` : "account-scoped"}). Shown once — store it now.\n`,
+  );
+}
+
+export async function keysList(opts: KeysListOptions): Promise<void> {
+  const client = createClient();
+  for await (const k of client.account.apiKeys.list()) {
+    if (opts.json) {
+      process.stdout.write(JSON.stringify(k) + "\n");
+    } else {
+      process.stdout.write(
+        `${k.id}\t${k.keyPrefix}\t${k.scope}${k.agent ? `\t${k.agent}` : "\t"}\t${k.name || ""}\n`,
+      );
+    }
+  }
+}
+
+export async function keysDelete(id: string | undefined): Promise<void> {
+  if (!id) fail(EXIT.USAGE, DELETE_USAGE);
+  const client = createClient();
+  await client.account.apiKeys.delete(id);
+  process.stdout.write(`revoked ${id}\n`);
+}

--- a/cli/src/commands/listen.ts
+++ b/cli/src/commands/listen.ts
@@ -1,6 +1,40 @@
 import type { E2AClient, WSNotification } from "@e2a/sdk/v1";
 import { createClient, requireAgentEmail } from "../sdk.js";
 import { EXIT, fail } from "../exit.js";
+import { sanitizeTsvField } from "./messages.js";
+
+const MAX_TIMEOUT_MS = 2 ** 31 - 1; // setTimeout clamps larger delays to ~1ms
+
+/**
+ * Membership check WITHOUT fetching the message: GET /messages/{id} marks a
+ * message read as a side effect, so filtering by fetching would silently
+ * consume messages from OTHER conversations out of any unread-queue consumer.
+ * list() has no side effects; scoped by conversation + a since just before
+ * the notification, it's a single small page.
+ */
+async function inConversation(
+  client: E2AClient,
+  agentEmail: string,
+  notification: WSNotification,
+  conversationId: string,
+): Promise<boolean> {
+  const receivedMs = Date.parse(notification.received_at);
+  const since = Number.isNaN(receivedMs)
+    ? undefined
+    : new Date(receivedMs - 2000).toISOString();
+  let scanned = 0;
+  for await (const m of client.messages.list(agentEmail, {
+    conversationId,
+    since,
+    readStatus: "all",
+    sort: "asc",
+    limit: 100,
+  })) {
+    if (m.messageId === notification.message_id) return true;
+    if (++scanned >= 500) break; // NaN-since safety bound
+  }
+  return false;
+}
 
 export interface ListenOptions {
   agent?: string;
@@ -43,18 +77,26 @@ export async function listen(opts: ListenOptions): Promise<void> {
   let timedOut = false;
   let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
   if (deadlineMs !== undefined) {
-    const wait = deadlineMs - Date.now();
-    if (wait <= 0) {
+    if (deadlineMs - Date.now() <= 0) {
       process.stdout.write("TIMEOUT\n");
       process.exitCode = EXIT.TIMEOUT;
       stream.close();
       return;
     }
-    deadlineTimer = setTimeout(() => {
-      timedOut = true;
-      stream.close();
-    }, wait);
-    deadlineTimer.unref?.();
+    // Chain timers instead of one setTimeout: Node clamps delays > 2^31-1 ms
+    // (~24.8 days) to ~1ms, which would fire TIMEOUT instantly for a
+    // far-future --until.
+    const armDeadline = () => {
+      const wait = (deadlineMs as number) - Date.now();
+      if (wait <= 0) {
+        timedOut = true;
+        stream.close();
+        return;
+      }
+      deadlineTimer = setTimeout(armDeadline, Math.min(wait, MAX_TIMEOUT_MS));
+      deadlineTimer.unref?.();
+    };
+    armDeadline();
   }
 
   stream.on("open", () => {
@@ -80,30 +122,35 @@ export async function listen(opts: ListenOptions): Promise<void> {
   let matched = false;
   for await (const notification of stream) {
     try {
-      // Conversation filtering needs the full message (the WS notification
-      // doesn't carry conversation_id).
-      if (opts.conversation || (opts.once && opts.text)) {
-        const full = await client.messages.get(agentEmail, notification.message_id);
-        if (opts.conversation && full.conversationId !== opts.conversation) continue;
-        if (opts.once) {
-          if (opts.text) {
-            process.stdout.write((full.parsed?.text ?? full.body?.text ?? "").trim() + "\n");
-          } else if (opts.json) {
-            process.stdout.write(JSON.stringify(full) + "\n");
-          } else {
-            process.stdout.write(
-              `${notification.message_id}\t${notification.from}\t${notification.received_at}\n`,
-            );
-          }
-          matched = true;
-          break;
-        }
+      // Filter first, via list() — never get(), which marks messages read
+      // (silently consuming OTHER conversations' messages was the bug).
+      if (opts.conversation) {
+        const ok = await inConversation(client, agentEmail, notification, opts.conversation);
+        if (!ok) continue;
       }
-      await handleNotification(client, agentEmail, notification, opts);
       if (opts.once) {
+        // --forward still delivers under --once; the blocking wait must not
+        // silently drop the webhook side channel.
+        if (opts.forward) {
+          await handleNotification(client, agentEmail, notification, opts);
+        }
+        if (opts.text) {
+          const full = await client.messages.get(agentEmail, notification.message_id);
+          process.stdout.write((full.parsed?.text ?? full.body?.text ?? "").trim() + "\n");
+        } else if (opts.json) {
+          const full = await client.messages.get(agentEmail, notification.message_id);
+          process.stdout.write(JSON.stringify(full) + "\n");
+        } else {
+          // One stable machine shape for the blocking wait, regardless of
+          // whether --conversation was used.
+          process.stdout.write(
+            `${notification.message_id}\t${sanitizeTsvField(notification.from)}\t${notification.received_at}\n`,
+          );
+        }
         matched = true;
         break;
       }
+      await handleNotification(client, agentEmail, notification, opts);
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       process.stderr.write(`Error handling message: ${message}\n`);

--- a/cli/src/commands/listen.ts
+++ b/cli/src/commands/listen.ts
@@ -1,16 +1,34 @@
 import type { E2AClient, WSNotification } from "@e2a/sdk/v1";
 import { createClient, requireAgentEmail } from "../sdk.js";
+import { EXIT, fail } from "../exit.js";
 
 export interface ListenOptions {
   agent?: string;
   json?: boolean;
   forward?: string;
   forwardToken?: string;
+  /** Only surface messages belonging to this conversation id. */
+  conversation?: string;
+  /** Exit 0 after the first (matching) message — the blocking-wait primitive. */
+  once?: boolean;
+  /** RFC3339 deadline for --once; expiry prints TIMEOUT and exits 6. */
+  until?: string;
+  /** With --once: print the message's body text instead of a summary/JSON. */
+  text?: boolean;
 }
 
 export async function listen(opts: ListenOptions): Promise<void> {
   const client = createClient();
   const agentEmail = requireAgentEmail(opts.agent);
+
+  let deadlineMs: number | undefined;
+  if (opts.until) {
+    deadlineMs = Date.parse(opts.until);
+    if (Number.isNaN(deadlineMs)) fail(EXIT.USAGE, `--until must be an RFC3339 timestamp, got: ${opts.until}`);
+  }
+  if ((opts.until || opts.text) && !opts.once) {
+    fail(EXIT.USAGE, "--until and --text require --once");
+  }
 
   process.stderr.write(`Listening for emails to ${agentEmail}...\n`);
 
@@ -18,6 +36,26 @@ export async function listen(opts: ListenOptions): Promise<void> {
   // and EventEmitter. We use both: events for connection lifecycle, the
   // for-await loop for the happy path.
   const stream = client.listen(agentEmail);
+
+  // Deadline: closing the stream ends the for-await loop; the flag tells the
+  // post-loop code this was expiry, not a server-side close. exitCode (not
+  // process.exit) so pending stdout flushes.
+  let timedOut = false;
+  let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+  if (deadlineMs !== undefined) {
+    const wait = deadlineMs - Date.now();
+    if (wait <= 0) {
+      process.stdout.write("TIMEOUT\n");
+      process.exitCode = EXIT.TIMEOUT;
+      stream.close();
+      return;
+    }
+    deadlineTimer = setTimeout(() => {
+      timedOut = true;
+      stream.close();
+    }, wait);
+    deadlineTimer.unref?.();
+  }
 
   stream.on("open", () => {
     process.stderr.write("Connected.\n");
@@ -39,12 +77,52 @@ export async function listen(opts: ListenOptions): Promise<void> {
 
   // Iterate notifications. handleNotification swallows its own errors so
   // a single bad message doesn't tear down the loop.
+  let matched = false;
   for await (const notification of stream) {
     try {
+      // Conversation filtering needs the full message (the WS notification
+      // doesn't carry conversation_id).
+      if (opts.conversation || (opts.once && opts.text)) {
+        const full = await client.messages.get(agentEmail, notification.message_id);
+        if (opts.conversation && full.conversationId !== opts.conversation) continue;
+        if (opts.once) {
+          if (opts.text) {
+            process.stdout.write((full.parsed?.text ?? full.body?.text ?? "").trim() + "\n");
+          } else if (opts.json) {
+            process.stdout.write(JSON.stringify(full) + "\n");
+          } else {
+            process.stdout.write(
+              `${notification.message_id}\t${notification.from}\t${notification.received_at}\n`,
+            );
+          }
+          matched = true;
+          break;
+        }
+      }
       await handleNotification(client, agentEmail, notification, opts);
+      if (opts.once) {
+        matched = true;
+        break;
+      }
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       process.stderr.write(`Error handling message: ${message}\n`);
+    }
+  }
+
+  if (deadlineTimer) clearTimeout(deadlineTimer);
+  stream.close();
+  if (opts.once && !matched) {
+    if (timedOut) {
+      // Clean window expiry — the documented exit-6 outcome.
+      process.stdout.write("TIMEOUT\n");
+      process.exitCode = EXIT.TIMEOUT;
+    } else {
+      // The stream ended before the deadline (handshake rejected, server
+      // close). That's a transient error, NOT a timeout — callers polling in
+      // a loop must be able to tell the difference or they spin hot.
+      process.stderr.write("stream closed before the deadline\n");
+      process.exitCode = EXIT.ERROR;
     }
   }
 }

--- a/cli/src/commands/listen.ts
+++ b/cli/src/commands/listen.ts
@@ -9,7 +9,7 @@ export interface ListenOptions {
 }
 
 export async function listen(opts: ListenOptions): Promise<void> {
-  const client = createClient({ from: opts.agent });
+  const client = createClient();
   const agentEmail = requireAgentEmail(opts.agent);
 
   process.stderr.write(`Listening for emails to ${agentEmail}...\n`);

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -2,7 +2,12 @@ import { execFile } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { createServer, type IncomingMessage, type Server } from "node:http";
 import { hostname } from "node:os";
-import { E2AClient, type CreateAPIKeyRequest } from "@e2a/sdk/v1";
+import {
+  E2AClient,
+  E2ANotFoundError,
+  E2APermissionError,
+  type CreateAPIKeyRequest,
+} from "@e2a/sdk/v1";
 import { loadConfig, saveConfig, type Config } from "../config.js";
 import { EXIT, fail } from "../exit.js";
 
@@ -255,6 +260,18 @@ export interface LoginOptions {
 export async function login(opts: LoginOptions = {}): Promise<void> {
   const config = loadConfig();
 
+  // The combination reads as "headless agent-scoped login" but the exchange
+  // needs an account credential we'd have to trust unvalidated — refuse
+  // loudly rather than silently ignoring --agent (the old behavior saved the
+  // pasted key at whatever scope it had, voiding the least-privilege promise).
+  if (opts.withKey && opts.agent) {
+    fail(
+      EXIT.USAGE,
+      "--with-key and --agent cannot be combined. Headless agent-scoped setup: " +
+        "e2a login --with-key <account-key>, then e2a keys create --agent <inbox>.",
+    );
+  }
+
   if (opts.withKey) {
     await loginWithKey(config, opts.key);
     return;
@@ -312,20 +329,27 @@ export async function login(opts: LoginOptions = {}): Promise<void> {
   if (agentEmail) {
     process.stdout.write(`Active agent: ${agentEmail}\n`);
   } else {
-    process.stderr.write(`No agents found yet. Create one at ${config.api_url.replace(/\/+$/, "")}/get-started\n`);
+    process.stderr.write(
+      `No agents found yet. Run: e2a agents create <name>@<shared-domain> — or visit ${config.api_url.replace(/\/+$/, "")}/get-started\n`,
+    );
   }
 }
 
-/** Read the key for --with-key: explicit value → $E2A_API_KEY → piped stdin. */
+/**
+ * Read the key for --with-key: explicit value → piped stdin → $E2A_API_KEY.
+ * Stdin outranks the env on purpose: `echo $NEW_KEY | e2a login --with-key`
+ * is a key ROTATION, and the box doing it very likely still has the old key
+ * exported — env-first would silently "rotate" to the stale key.
+ */
 async function resolveWithKeyInput(explicit?: string): Promise<string> {
   if (explicit) return explicit;
-  if (process.env.E2A_API_KEY) return process.env.E2A_API_KEY;
   if (!process.stdin.isTTY) {
     let data = "";
     for await (const chunk of process.stdin) data += chunk;
     const key = data.trim();
     if (key) return key;
   }
+  if (process.env.E2A_API_KEY) return process.env.E2A_API_KEY;
   return fail(
     EXIT.USAGE,
     "usage: e2a login --with-key <key>  (or pipe the key on stdin / set E2A_API_KEY)",
@@ -374,10 +398,13 @@ async function exchangeForAgentKey(
   const agentEmail = inbox.includes("@") ? inbox : `${inbox}@${domain}`;
 
   // Verify the inbox before minting: a typo must fail with the owned list,
-  // not mint a key against nothing.
+  // not mint a key against nothing. Only a definitive "doesn't exist / not
+  // yours" (404/403) takes this path — a transient error must NOT masquerade
+  // as permanent exit 5 (retry wrappers would give up on a server blip).
   try {
     await client.agents.get(agentEmail);
-  } catch {
+  } catch (err) {
+    if (!(err instanceof E2ANotFoundError || err instanceof E2APermissionError)) throw err;
     process.stderr.write(`Agent not found or not owned: ${agentEmail}\nOwned agents:\n`);
     try {
       for await (const a of client.agents.list()) {
@@ -396,6 +423,18 @@ async function exchangeForAgentKey(
     agent: agentEmail,
   });
 
+  // Persist the new key BEFORE revoking the bootstrap: the agent key's
+  // plaintext exists only in this process, so if the config write fails
+  // (read-only $HOME, ENOSPC) after a revoke, the machine would be left with
+  // ZERO working credentials. Save-then-revoke makes every failure mode
+  // recoverable — worst case an extra "CLI login" key survives server-side.
+  saveConfig({
+    api_key: created.key,
+    agent_email: agentEmail,
+    key_scope: "agent",
+    ...(sharedDomain ? { shared_domain: sharedDomain } : {}),
+  });
+
   // Revoke the bootstrap key. The handoff only gave us its plaintext, so
   // match its visible prefix against the key inventory; refuse to guess if
   // the match isn't unique — deleting the wrong credential is worse than
@@ -410,21 +449,14 @@ async function exchangeForAgentKey(
       }
     }
     if (candidates.length === 1) {
-      // The agent key can't manage keys, so revoke while we still hold the
-      // account-scoped credential.
+      // Still holding the account-scoped credential here (the agent key
+      // can't manage keys) — this must stay before the client is dropped.
       await client.account.apiKeys.delete(candidates[0]);
       revoked = true;
     }
   } catch {
     // fall through to the warning below
   }
-
-  saveConfig({
-    api_key: created.key,
-    agent_email: agentEmail,
-    key_scope: "agent",
-    ...(sharedDomain ? { shared_domain: sharedDomain } : {}),
-  });
 
   process.stdout.write(`Logged in to ${hostLabel(config.api_url)}.\n`);
   process.stdout.write(`Agent-scoped key minted for ${agentEmail} (key "cli @${hostname()}").\n`);

--- a/cli/src/commands/login.ts
+++ b/cli/src/commands/login.ts
@@ -1,7 +1,10 @@
 import { execFile } from "node:child_process";
 import { randomBytes } from "node:crypto";
 import { createServer, type IncomingMessage, type Server } from "node:http";
-import { loadConfig, saveConfig } from "../config.js";
+import { hostname } from "node:os";
+import { E2AClient, type CreateAPIKeyRequest } from "@e2a/sdk/v1";
+import { loadConfig, saveConfig, type Config } from "../config.js";
+import { EXIT, fail } from "../exit.js";
 
 /**
  * Render the URL's host for human-facing log lines. Falls back to the raw
@@ -235,8 +238,27 @@ async function waitForBrowserLogin(apiUrl: string, timeoutMs = LOGIN_TIMEOUT_MS)
   }
 }
 
-export async function login(): Promise<void> {
+export interface LoginOptions {
+  /**
+   * Mint a least-privilege agent-scoped key bound to this inbox (bare slugs
+   * expand on the deployment's shared domain), then revoke the account-scoped
+   * bootstrap key from the browser handoff. The machine ends up holding only
+   * a single-inbox credential — the setup harnesses like tether want.
+   */
+  agent?: string;
+  /** Headless mode: validate a pasted/piped/env key instead of the browser. */
+  withKey?: boolean;
+  /** Explicit key value for --with-key (else $E2A_API_KEY, else stdin). */
+  key?: string;
+}
+
+export async function login(opts: LoginOptions = {}): Promise<void> {
   const config = loadConfig();
+
+  if (opts.withKey) {
+    await loginWithKey(config, opts.key);
+    return;
+  }
 
   // Preflight: hit the deployment's public info endpoint before opening
   // the browser. Two wins —
@@ -270,9 +292,15 @@ export async function login(): Promise<void> {
 
   const { apiKey, agentEmail } = await waitForBrowserLogin(config.api_url);
 
+  if (opts.agent) {
+    await exchangeForAgentKey(config, apiKey, opts.agent, discoveredSharedDomain);
+    return;
+  }
+
   saveConfig({
     api_key: apiKey,
     agent_email: agentEmail,
+    key_scope: "account",
     ...(discoveredSharedDomain ? { shared_domain: discoveredSharedDomain } : {}),
   });
 
@@ -286,4 +314,126 @@ export async function login(): Promise<void> {
   } else {
     process.stderr.write(`No agents found yet. Create one at ${config.api_url.replace(/\/+$/, "")}/get-started\n`);
   }
+}
+
+/** Read the key for --with-key: explicit value → $E2A_API_KEY → piped stdin. */
+async function resolveWithKeyInput(explicit?: string): Promise<string> {
+  if (explicit) return explicit;
+  if (process.env.E2A_API_KEY) return process.env.E2A_API_KEY;
+  if (!process.stdin.isTTY) {
+    let data = "";
+    for await (const chunk of process.stdin) data += chunk;
+    const key = data.trim();
+    if (key) return key;
+  }
+  return fail(
+    EXIT.USAGE,
+    "usage: e2a login --with-key <key>  (or pipe the key on stdin / set E2A_API_KEY)",
+  );
+}
+
+/**
+ * Headless login: no browser, no local callback server — validate the key
+ * against GET /v1/account (which also reveals its scope and bound inbox) and
+ * persist it. This is the path for CI boxes and SSH sessions, where the
+ * browser flow's 127.0.0.1 callback can never complete.
+ */
+export async function loginWithKey(config: Config, explicitKey?: string): Promise<void> {
+  const key = await resolveWithKeyInput(explicitKey);
+  const client = new E2AClient({ apiKey: key, baseUrl: config.api_url });
+  const account = await client.account.get(); // throws E2AAuthError → exit 4
+
+  saveConfig({
+    api_key: key,
+    key_scope: account.scope,
+    ...(account.agentAddress ? { agent_email: account.agentAddress } : {}),
+  });
+
+  process.stdout.write(`Logged in to ${hostLabel(config.api_url)} with a ${account.scope}-scoped key.\n`);
+  if (account.agentAddress) {
+    process.stdout.write(`Bound agent: ${account.agentAddress}\n`);
+  }
+  process.stdout.write("Config saved to ~/.e2a/config.json\n");
+}
+
+/**
+ * `login --agent <inbox>`: exchange the account-scoped bootstrap key from the
+ * browser handoff for a least-privilege agent-scoped key, then revoke the
+ * bootstrap so this machine holds only the single-inbox credential.
+ */
+async function exchangeForAgentKey(
+  config: Config,
+  bootstrapKey: string,
+  inbox: string,
+  sharedDomain?: string,
+): Promise<void> {
+  const client = new E2AClient({ apiKey: bootstrapKey, baseUrl: config.api_url });
+
+  // Bare slug → expand on the deployment's shared domain.
+  const domain = sharedDomain || config.shared_domain;
+  const agentEmail = inbox.includes("@") ? inbox : `${inbox}@${domain}`;
+
+  // Verify the inbox before minting: a typo must fail with the owned list,
+  // not mint a key against nothing.
+  try {
+    await client.agents.get(agentEmail);
+  } catch {
+    process.stderr.write(`Agent not found or not owned: ${agentEmail}\nOwned agents:\n`);
+    try {
+      for await (const a of client.agents.list()) {
+        process.stderr.write(`  ${a.email}\n`);
+      }
+    } catch {
+      process.stderr.write("  (could not list agents)\n");
+    }
+    process.exit(EXIT.REQUEST);
+  }
+
+  const created = await client.account.apiKeys.create({
+    name: `cli @${hostname()}`,
+    // Cast: the generated model types scope as a TS enum; "agent" is its wire value.
+    scope: "agent" as CreateAPIKeyRequest["scope"],
+    agent: agentEmail,
+  });
+
+  // Revoke the bootstrap key. The handoff only gave us its plaintext, so
+  // match its visible prefix against the key inventory; refuse to guess if
+  // the match isn't unique — deleting the wrong credential is worse than
+  // leaving one extra "CLI login" key for the dashboard to clean up.
+  let revoked = false;
+  try {
+    const candidates: string[] = [];
+    for await (const k of client.account.apiKeys.list()) {
+      const prefix = k.keyPrefix.replace(/[^A-Za-z0-9_]+$/g, "");
+      if (k.id !== created.id && prefix && bootstrapKey.startsWith(prefix)) {
+        candidates.push(k.id);
+      }
+    }
+    if (candidates.length === 1) {
+      // The agent key can't manage keys, so revoke while we still hold the
+      // account-scoped credential.
+      await client.account.apiKeys.delete(candidates[0]);
+      revoked = true;
+    }
+  } catch {
+    // fall through to the warning below
+  }
+
+  saveConfig({
+    api_key: created.key,
+    agent_email: agentEmail,
+    key_scope: "agent",
+    ...(sharedDomain ? { shared_domain: sharedDomain } : {}),
+  });
+
+  process.stdout.write(`Logged in to ${hostLabel(config.api_url)}.\n`);
+  process.stdout.write(`Agent-scoped key minted for ${agentEmail} (key "cli @${hostname()}").\n`);
+  if (revoked) {
+    process.stdout.write("Bootstrap account key revoked — this machine holds only the agent key.\n");
+  } else {
+    process.stderr.write(
+      'Could not uniquely identify the bootstrap key to revoke it — remove the "CLI login" key at your dashboard\'s API-keys page.\n',
+    );
+  }
+  process.stdout.write("Config saved to ~/.e2a/config.json\n");
 }

--- a/cli/src/commands/messages.ts
+++ b/cli/src/commands/messages.ts
@@ -1,0 +1,84 @@
+import type { ListMessagesParams } from "@e2a/sdk/v1";
+import { createClient, requireAgentEmail } from "../sdk.js";
+import { EXIT, fail } from "../exit.js";
+
+export interface MessagesListOptions {
+  agent?: string;
+  direction?: string;
+  since?: string;
+  conversation?: string;
+  limit?: string;
+  json?: boolean;
+}
+
+export interface MessagesGetOptions {
+  agent?: string;
+  text?: boolean;
+  json?: boolean;
+}
+
+const LIST_USAGE =
+  "usage: e2a messages list [--direction inbound|outbound|all] [--since <ISO>] [--conversation <id>] [--limit <n>] [--agent <inbox>] [--json]";
+const GET_USAGE = "usage: e2a messages get <message-id> [--text] [--agent <inbox>] [--json]";
+
+const DIRECTIONS = ["inbound", "outbound", "all"] as const;
+
+function isoString(d: Date | string): string {
+  return d instanceof Date ? d.toISOString() : String(d);
+}
+
+// Default output is TSV (message_id, from, created_at) in ascending order —
+// the shape a shell poll loop wants (`while IFS=$'\t' read -r id from at`).
+// --json emits one full summary object per line (NDJSON), in the SDK's
+// camelCase model shape like `listen --json`.
+export async function messagesList(opts: MessagesListOptions): Promise<void> {
+  const params: ListMessagesParams = { sort: "asc" };
+
+  if (opts.direction) {
+    if (!(DIRECTIONS as readonly string[]).includes(opts.direction)) fail(EXIT.USAGE, LIST_USAGE);
+    params.direction = opts.direction as (typeof DIRECTIONS)[number];
+  }
+  if (opts.since) params.since = opts.since;
+  if (opts.conversation) params.conversationId = opts.conversation;
+
+  let max: number | undefined;
+  if (opts.limit !== undefined) {
+    max = Number(opts.limit);
+    if (!Number.isInteger(max) || max <= 0) fail(EXIT.USAGE, LIST_USAGE);
+    params.limit = Math.min(max, 100);
+  }
+
+  const client = createClient();
+  const agentEmail = requireAgentEmail(opts.agent);
+
+  let count = 0;
+  for await (const m of client.messages.list(agentEmail, params)) {
+    if (opts.json) {
+      process.stdout.write(JSON.stringify(m) + "\n");
+    } else {
+      process.stdout.write(`${m.messageId}\t${m._from}\t${isoString(m.createdAt)}\n`);
+    }
+    count++;
+    if (max !== undefined && count >= max) break;
+  }
+}
+
+export async function messagesGet(
+  messageId: string | undefined,
+  opts: MessagesGetOptions,
+): Promise<void> {
+  if (!messageId) fail(EXIT.USAGE, GET_USAGE);
+
+  const client = createClient();
+  const agentEmail = requireAgentEmail(opts.agent);
+  const message = await client.messages.get(agentEmail, messageId);
+
+  if (opts.text) {
+    // Parsed text (quoted history stripped) beats the raw body when available;
+    // a just-received message can have neither for a moment (async parse).
+    const text = message.parsed?.text || message.body?.text || "";
+    process.stdout.write(text.trim() + "\n");
+    return;
+  }
+  process.stdout.write(JSON.stringify(message) + "\n");
+}

--- a/cli/src/commands/messages.ts
+++ b/cli/src/commands/messages.ts
@@ -69,11 +69,22 @@ export async function messagesList(opts: MessagesListOptions): Promise<void> {
     if (opts.json) {
       process.stdout.write(JSON.stringify(withWireFrom(m)) + "\n");
     } else {
-      process.stdout.write(`${m.messageId}\t${m._from}\t${m.createdAt.toISOString()}\n`);
+      process.stdout.write(
+        `${m.messageId}\t${sanitizeTsvField(m._from)}\t${m.createdAt.toISOString()}\n`,
+      );
     }
     count++;
     if (max !== undefined && count >= max) break;
   }
+}
+
+/**
+ * TSV fields must never contain the delimiters. The From header is
+ * sender-controlled: a display name with an embedded tab shifts a poll loop's
+ * fields (corrupting its cursor) and a newline injects phantom rows.
+ */
+export function sanitizeTsvField(s: string): string {
+  return s.replace(/[\t\r\n]+/g, " ");
 }
 
 /**

--- a/cli/src/commands/messages.ts
+++ b/cli/src/commands/messages.ts
@@ -23,9 +23,9 @@ const GET_USAGE = "usage: e2a messages get <message-id> [--text] [--agent <inbox
 
 const DIRECTIONS = ["inbound", "outbound", "all"] as const;
 
-function isoString(d: Date | string): string {
-  return d instanceof Date ? d.toISOString() : String(d);
-}
+// The server pages at 50 by default but allows 100; always ask for the max so
+// draining a mailbox costs half the round trips.
+const MAX_PAGE_SIZE = 100;
 
 // Default output is TSV (message_id, from, created_at) in ascending order —
 // the shape a shell poll loop wants (`while IFS=$'\t' read -r id from at`).
@@ -45,8 +45,8 @@ export async function messagesList(opts: MessagesListOptions): Promise<void> {
   if (opts.limit !== undefined) {
     max = Number(opts.limit);
     if (!Number.isInteger(max) || max <= 0) fail(EXIT.USAGE, LIST_USAGE);
-    params.limit = Math.min(max, 100);
   }
+  params.limit = Math.min(max ?? MAX_PAGE_SIZE, MAX_PAGE_SIZE);
 
   const client = createClient();
   const agentEmail = requireAgentEmail(opts.agent);
@@ -56,7 +56,7 @@ export async function messagesList(opts: MessagesListOptions): Promise<void> {
     if (opts.json) {
       process.stdout.write(JSON.stringify(m) + "\n");
     } else {
-      process.stdout.write(`${m.messageId}\t${m._from}\t${isoString(m.createdAt)}\n`);
+      process.stdout.write(`${m.messageId}\t${m._from}\t${m.createdAt.toISOString()}\n`);
     }
     count++;
     if (max !== undefined && count >= max) break;
@@ -68,6 +68,9 @@ export async function messagesGet(
   opts: MessagesGetOptions,
 ): Promise<void> {
   if (!messageId) fail(EXIT.USAGE, GET_USAGE);
+  // JSON is the default output, so --json is accepted as an explicit alias —
+  // but combining it with --text is a contradiction, not a precedence puzzle.
+  if (opts.text && opts.json) fail(EXIT.USAGE, "--text and --json are mutually exclusive");
 
   const client = createClient();
   const agentEmail = requireAgentEmail(opts.agent);

--- a/cli/src/commands/messages.ts
+++ b/cli/src/commands/messages.ts
@@ -8,6 +8,7 @@ export interface MessagesListOptions {
   since?: string;
   conversation?: string;
   limit?: string;
+  readStatus?: string;
   json?: boolean;
 }
 
@@ -18,10 +19,11 @@ export interface MessagesGetOptions {
 }
 
 const LIST_USAGE =
-  "usage: e2a messages list [--direction inbound|outbound|all] [--since <ISO>] [--conversation <id>] [--limit <n>] [--agent <inbox>] [--json]";
+  "usage: e2a messages list [--direction inbound|outbound|all] [--since <ISO>] [--conversation <id>] [--read-status unread|read|all] [--limit <n>] [--agent <inbox>] [--json]";
 const GET_USAGE = "usage: e2a messages get <message-id> [--text] [--agent <inbox>] [--json]";
 
 const DIRECTIONS = ["inbound", "outbound", "all"] as const;
+const READ_STATUSES = ["unread", "read", "all"] as const;
 
 // The server pages at 50 by default but allows 100; always ask for the max so
 // draining a mailbox costs half the round trips.
@@ -32,11 +34,22 @@ const MAX_PAGE_SIZE = 100;
 // --json emits one full summary object per line (NDJSON), in the SDK's
 // camelCase model shape like `listen --json`.
 export async function messagesList(opts: MessagesListOptions): Promise<void> {
-  const params: ListMessagesParams = { sort: "asc" };
+  // readStatus defaults to "all", NOT the server default. The server defaults
+  // inbound lists to unread-only, and `messages get` (and any other consumer)
+  // marks a message read on fetch — so a list→get→list poll loop would
+  // silently lose every message it had already touched. tether's curl layer
+  // learned this the hard way (read_status=all); the CLI must not regress it.
+  const params: ListMessagesParams = { sort: "asc", readStatus: "all" };
 
   if (opts.direction) {
     if (!(DIRECTIONS as readonly string[]).includes(opts.direction)) fail(EXIT.USAGE, LIST_USAGE);
     params.direction = opts.direction as (typeof DIRECTIONS)[number];
+  }
+  if (opts.readStatus) {
+    if (!(READ_STATUSES as readonly string[]).includes(opts.readStatus)) {
+      fail(EXIT.USAGE, LIST_USAGE);
+    }
+    params.readStatus = opts.readStatus as (typeof READ_STATUSES)[number];
   }
   if (opts.since) params.since = opts.since;
   if (opts.conversation) params.conversationId = opts.conversation;
@@ -54,13 +67,28 @@ export async function messagesList(opts: MessagesListOptions): Promise<void> {
   let count = 0;
   for await (const m of client.messages.list(agentEmail, params)) {
     if (opts.json) {
-      process.stdout.write(JSON.stringify(m) + "\n");
+      process.stdout.write(JSON.stringify(withWireFrom(m)) + "\n");
     } else {
       process.stdout.write(`${m.messageId}\t${m._from}\t${m.createdAt.toISOString()}\n`);
     }
     count++;
     if (max !== undefined && count >= max) break;
   }
+}
+
+/**
+ * The generated TS model escapes the reserved-ish `from` property to `_from`
+ * (an OpenAPI Generator artifact that a generator bump could change). Rename
+ * it back before JSON output so scripts read the wire-stable `.from`, not a
+ * codegen implementation detail.
+ */
+function withWireFrom(model: object): Record<string, unknown> {
+  const obj: Record<string, unknown> = { ...model };
+  if ("_from" in obj) {
+    obj.from = obj._from;
+    delete obj._from;
+  }
+  return obj;
 }
 
 export async function messagesGet(
@@ -77,11 +105,15 @@ export async function messagesGet(
   const message = await client.messages.get(agentEmail, messageId);
 
   if (opts.text) {
-    // Parsed text (quoted history stripped) beats the raw body when available;
-    // a just-received message can have neither for a moment (async parse).
-    const text = message.parsed?.text || message.body?.text || "";
+    // Parsed text (quoted history stripped) wins when the parse ran; `??` (not
+    // ||) so a legitimately-empty parsed result ("" = the reply was ALL quoted
+    // history) doesn't fall through to the unstripped raw body. An inbound
+    // message that prints "" truly has no textual content — parsing is
+    // synchronous server-side, there is no async-parse race to retry. Outbound
+    // rows can print "" because rejected/expired drafts are scrubbed.
+    const text = message.parsed?.text ?? message.body?.text ?? "";
     process.stdout.write(text.trim() + "\n");
     return;
   }
-  process.stdout.write(JSON.stringify(message) + "\n");
+  process.stdout.write(JSON.stringify(withWireFrom(message)) + "\n");
 }

--- a/cli/src/commands/protection.ts
+++ b/cli/src/commands/protection.ts
@@ -1,0 +1,79 @@
+import type { ProtectionConfigView, ProtectionDirectionView } from "@e2a/sdk/v1";
+import { createClient } from "../sdk.js";
+import { EXIT, fail } from "../exit.js";
+
+export interface ProtectionGetOptions {
+  json?: boolean;
+}
+
+export interface ProtectionSetOptions {
+  outboundReview?: string;
+  inboundReview?: string;
+  json?: boolean;
+}
+
+const GET_USAGE = "usage: e2a protection get <agent-email> [--json]";
+const SET_USAGE =
+  "usage: e2a protection set <agent-email> [--outbound-review on|off] [--inbound-review on|off] [--json]";
+
+function summarize(config: ProtectionConfigView): string {
+  const dir = (d: ProtectionDirectionView) =>
+    `gate=${d.gate.policy ?? "open"}/${d.gate.action ?? "flag"} scan=${d.scan.sensitivity ?? "off"}`;
+  return (
+    `outbound: ${dir(config.outbound)}\n` +
+    `inbound:  ${dir(config.inbound)}\n` +
+    `holds:    ttl=${config.holds.ttlSeconds ?? 604800}s on_expiry=${config.holds.onExpiry ?? "reject"}\n`
+  );
+}
+
+export async function protectionGet(
+  email: string | undefined,
+  opts: ProtectionGetOptions,
+): Promise<void> {
+  if (!email) fail(EXIT.USAGE, GET_USAGE);
+
+  const client = createClient();
+  const config = await client.agents.getProtection(email);
+  process.stdout.write(opts.json ? JSON.stringify(config) + "\n" : summarize(config));
+}
+
+/**
+ * Flip one direction's review posture, touching ONLY the requested knobs.
+ * "off" = gate non-matches are flagged-through and the content scan is
+ * disabled (a scan can hold too, so review-off must silence both).
+ * "on" = gate non-matches are held for review; scan tuning is left alone.
+ */
+function applyReview(direction: ProtectionDirectionView, mode: "on" | "off"): void {
+  // Casts because the generated models type these as TS enums; the literals
+  // are the enums' wire values (flag/review, off).
+  direction.gate.action = (mode === "on" ? "review" : "flag") as typeof direction.gate.action;
+  if (mode === "off") {
+    direction.scan.sensitivity = "off" as typeof direction.scan.sensitivity;
+  }
+}
+
+export async function protectionSet(
+  email: string | undefined,
+  opts: ProtectionSetOptions,
+): Promise<void> {
+  if (!email) fail(EXIT.USAGE, SET_USAGE);
+  for (const v of [opts.outboundReview, opts.inboundReview]) {
+    if (v !== undefined && v !== "on" && v !== "off") fail(EXIT.USAGE, SET_USAGE);
+  }
+  if (opts.outboundReview === undefined && opts.inboundReview === undefined) {
+    fail(EXIT.USAGE, SET_USAGE);
+  }
+
+  const client = createClient();
+  // GET first, and never PUT unless it succeeded: /protection is full-replace,
+  // so writing a from-scratch doc after a failed read would reset every knob
+  // we weren't asked to touch (the clobber bug in the bash prototype of this
+  // flow). A thrown GET propagates and the PUT below is never reached.
+  const config = await client.agents.getProtection(email);
+
+  if (opts.outboundReview) applyReview(config.outbound, opts.outboundReview as "on" | "off");
+  if (opts.inboundReview) applyReview(config.inbound, opts.inboundReview as "on" | "off");
+
+  const updated = await client.agents.replaceProtection(email, config);
+  process.stdout.write(opts.json ? JSON.stringify(updated) + "\n" : summarize(updated));
+}

--- a/cli/src/commands/protection.ts
+++ b/cli/src/commands/protection.ts
@@ -41,14 +41,20 @@ export async function protectionGet(
  * Flip one direction's review posture, touching ONLY the requested knobs.
  * "off" = gate non-matches are flagged-through and the content scan is
  * disabled (a scan can hold too, so review-off must silence both).
- * "on" = gate non-matches are held for review; scan tuning is left alone.
+ * "on" = gate non-matches are held for review, and a disabled scan is
+ * re-enabled at medium — under the default gate policy "open" every sender
+ * matches (the gate action never fires), so an off→on round-trip that only
+ * touched the gate would LOOK on while holding nothing. A scan already
+ * tuned to low/high is left alone.
  */
 function applyReview(direction: ProtectionDirectionView, mode: "on" | "off"): void {
   // Casts because the generated models type these as TS enums; the literals
-  // are the enums' wire values (flag/review, off).
+  // are the enums' wire values (flag/review, off/medium).
   direction.gate.action = (mode === "on" ? "review" : "flag") as typeof direction.gate.action;
   if (mode === "off") {
     direction.scan.sensitivity = "off" as typeof direction.scan.sensitivity;
+  } else if (!direction.scan.sensitivity || (direction.scan.sensitivity as string) === "off") {
+    direction.scan.sensitivity = "medium" as typeof direction.scan.sensitivity;
   }
 }
 

--- a/cli/src/commands/send.ts
+++ b/cli/src/commands/send.ts
@@ -48,7 +48,10 @@ export function resolveBodies(
   const htmlBody = opts.htmlFile ? readFileOrUsage(opts.htmlFile, "--html-file") : undefined;
   let body = opts.body ?? (opts.bodyFile ? readFileOrUsage(opts.bodyFile, "--body-file") : undefined);
   if (body === undefined && htmlBody !== undefined) body = htmlToText(htmlBody);
-  if (!body) fail(EXIT.USAGE, usage);
+  // Only "no body source at all" is a usage error. An empty string is legal:
+  // markup-only HTML (images/tables, no text nodes) derives "" and must still
+  // send — the HTML part is the real content.
+  if (body === undefined) fail(EXIT.USAGE, usage);
   return { body, htmlBody };
 }
 
@@ -68,7 +71,10 @@ function emitSendResult(result: SendResultView, json?: boolean): void {
       "WARNING: held for review (pending_review) — the message did NOT reach the recipient. " +
         "Disable outbound protection on this agent or approve it in the review queue.\n",
     );
-    process.exit(EXIT.HELD);
+    // exitCode + return, NOT process.exit(): a hard exit can truncate piped
+    // stdout before the message id above flushes, and scripts need that id to
+    // approve the held message.
+    process.exitCode = EXIT.HELD;
   }
 }
 
@@ -78,12 +84,14 @@ export async function send(opts: SendOptions): Promise<void> {
 
   const client = createClient();
   const agentEmail = requireAgentEmail(opts.agent);
+  // Optional fields may be undefined — the generated serializer drops
+  // undefined-valued keys before they reach the wire.
   const result = await client.messages.send(agentEmail, {
     to: opts.to,
     subject: opts.subject,
     body,
-    ...(htmlBody !== undefined ? { htmlBody } : {}),
-    ...(opts.conversationId ? { conversationId: opts.conversationId } : {}),
+    htmlBody,
+    conversationId: opts.conversationId,
   });
   emitSendResult(result, opts.json);
 }
@@ -94,9 +102,6 @@ export async function reply(messageId: string | undefined, opts: ReplyOptions): 
 
   const client = createClient();
   const agentEmail = requireAgentEmail(opts.agent);
-  const result = await client.messages.reply(agentEmail, messageId, {
-    body,
-    ...(htmlBody !== undefined ? { htmlBody } : {}),
-  });
+  const result = await client.messages.reply(agentEmail, messageId, { body, htmlBody });
   emitSendResult(result, opts.json);
 }

--- a/cli/src/commands/send.ts
+++ b/cli/src/commands/send.ts
@@ -13,6 +13,7 @@ export interface SendOptions {
   conversationId?: string;
   agent?: string;
   json?: boolean;
+  idempotencyKey?: string;
 }
 
 export interface ReplyOptions {
@@ -21,6 +22,7 @@ export interface ReplyOptions {
   htmlFile?: string;
   agent?: string;
   json?: boolean;
+  idempotencyKey?: string;
 }
 
 const SEND_USAGE =
@@ -66,10 +68,15 @@ function emitSendResult(result: SendResultView, json?: boolean): void {
   } else {
     process.stdout.write(result.messageId + "\n");
   }
-  if (result.status === "pending_review") {
+  // `status` is an OPEN SET per the spec ("tolerate unknown values") — so the
+  // delivered check is `=== "sent"`, inverted. A future held-variant status
+  // must fail loud (exit HELD), never slip through as exit 0: an unknown
+  // outcome is "not known to be delivered".
+  if (result.status !== "sent") {
     process.stderr.write(
-      "WARNING: held for review (pending_review) — the message did NOT reach the recipient. " +
-        "Disable outbound protection on this agent or approve it in the review queue.\n",
+      `WARNING: send returned status "${result.status}" — the message did NOT go out now. ` +
+        "pending_review means it is held for approval: disable outbound protection on this " +
+        "agent or approve it in the review queue.\n",
     );
     // exitCode + return, NOT process.exit(): a hard exit can truncate piped
     // stdout before the message id above flushes, and scripts need that id to
@@ -85,14 +92,21 @@ export async function send(opts: SendOptions): Promise<void> {
   const client = createClient();
   const agentEmail = requireAgentEmail(opts.agent);
   // Optional fields may be undefined — the generated serializer drops
-  // undefined-valued keys before they reach the wire.
-  const result = await client.messages.send(agentEmail, {
-    to: opts.to,
-    subject: opts.subject,
-    body,
-    htmlBody,
-    conversationId: opts.conversationId,
-  });
+  // undefined-valued keys before they reach the wire. An explicit
+  // --idempotency-key makes a *re-invocation* after an ambiguous failure
+  // dedupe server-side (the SDK's auto-minted key only survives in-process
+  // retries).
+  const result = await client.messages.send(
+    agentEmail,
+    {
+      to: opts.to,
+      subject: opts.subject,
+      body,
+      htmlBody,
+      conversationId: opts.conversationId,
+    },
+    opts.idempotencyKey ? { idempotencyKey: opts.idempotencyKey } : undefined,
+  );
   emitSendResult(result, opts.json);
 }
 
@@ -102,6 +116,11 @@ export async function reply(messageId: string | undefined, opts: ReplyOptions): 
 
   const client = createClient();
   const agentEmail = requireAgentEmail(opts.agent);
-  const result = await client.messages.reply(agentEmail, messageId, { body, htmlBody });
+  const result = await client.messages.reply(
+    agentEmail,
+    messageId,
+    { body, htmlBody },
+    opts.idempotencyKey ? { idempotencyKey: opts.idempotencyKey } : undefined,
+  );
   emitSendResult(result, opts.json);
 }

--- a/cli/src/commands/send.ts
+++ b/cli/src/commands/send.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from "node:fs";
-import type { SendResultView } from "@e2a/sdk/v1";
+import { basename, extname } from "node:path";
+import type { SendResultView, Attachment } from "@e2a/sdk/v1";
 import { createClient, requireAgentEmail } from "../sdk.js";
 import { EXIT, fail } from "../exit.js";
 import { htmlToText } from "../html.js";
@@ -14,6 +15,7 @@ export interface SendOptions {
   agent?: string;
   json?: boolean;
   idempotencyKey?: string;
+  attach?: string[];
 }
 
 export interface ReplyOptions {
@@ -23,6 +25,38 @@ export interface ReplyOptions {
   agent?: string;
   json?: boolean;
   idempotencyKey?: string;
+  attach?: string[];
+}
+
+const MIME_BY_EXT: Record<string, string> = {
+  ".pdf": "application/pdf",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".txt": "text/plain",
+  ".md": "text/markdown",
+  ".html": "text/html",
+  ".json": "application/json",
+  ".csv": "text/csv",
+  ".zip": "application/zip",
+};
+
+function readAttachments(paths: string[] | undefined): Attachment[] | undefined {
+  if (!paths || paths.length === 0) return undefined;
+  return paths.map((p) => {
+    let buf: Buffer;
+    try {
+      buf = readFileSync(p);
+    } catch {
+      return fail(EXIT.USAGE, `--attach file not found or unreadable: ${p}`);
+    }
+    return {
+      filename: basename(p),
+      contentType: MIME_BY_EXT[extname(p).toLowerCase()] ?? "application/octet-stream",
+      data: buf.toString("base64"),
+    };
+  });
 }
 
 const SEND_USAGE =
@@ -104,6 +138,7 @@ export async function send(opts: SendOptions): Promise<void> {
       body,
       htmlBody,
       conversationId: opts.conversationId,
+      attachments: readAttachments(opts.attach),
     },
     opts.idempotencyKey ? { idempotencyKey: opts.idempotencyKey } : undefined,
   );
@@ -119,7 +154,7 @@ export async function reply(messageId: string | undefined, opts: ReplyOptions): 
   const result = await client.messages.reply(
     agentEmail,
     messageId,
-    { body, htmlBody },
+    { body, htmlBody, attachments: readAttachments(opts.attach) },
     opts.idempotencyKey ? { idempotencyKey: opts.idempotencyKey } : undefined,
   );
   emitSendResult(result, opts.json);

--- a/cli/src/commands/send.ts
+++ b/cli/src/commands/send.ts
@@ -1,0 +1,102 @@
+import { readFileSync } from "node:fs";
+import type { SendResultView } from "@e2a/sdk/v1";
+import { createClient, requireAgentEmail } from "../sdk.js";
+import { EXIT, fail } from "../exit.js";
+import { htmlToText } from "../html.js";
+
+export interface SendOptions {
+  to: string[];
+  subject?: string;
+  body?: string;
+  bodyFile?: string;
+  htmlFile?: string;
+  conversationId?: string;
+  agent?: string;
+  json?: boolean;
+}
+
+export interface ReplyOptions {
+  body?: string;
+  bodyFile?: string;
+  htmlFile?: string;
+  agent?: string;
+  json?: boolean;
+}
+
+const SEND_USAGE =
+  "usage: e2a send --to <email> --subject <s> (--body <text> | --body-file <f> | --html-file <f>) [--conversation-id <id>] [--agent <inbox>] [--json]";
+const REPLY_USAGE =
+  "usage: e2a reply <message-id> (--body <text> | --body-file <f> | --html-file <f>) [--agent <inbox>] [--json]";
+
+function readFileOrUsage(path: string, flag: string): string {
+  try {
+    return readFileSync(path, "utf-8");
+  } catch {
+    return fail(EXIT.USAGE, `${flag} file not found or unreadable: ${path}`);
+  }
+}
+
+/**
+ * Resolve the text body + optional HTML body from the flag combination.
+ * `--html-file` without an explicit text body derives a plain-text fallback
+ * from the HTML, so multipart sends never ship an empty text alternative.
+ */
+export function resolveBodies(
+  opts: { body?: string; bodyFile?: string; htmlFile?: string },
+  usage: string,
+): { body: string; htmlBody?: string } {
+  const htmlBody = opts.htmlFile ? readFileOrUsage(opts.htmlFile, "--html-file") : undefined;
+  let body = opts.body ?? (opts.bodyFile ? readFileOrUsage(opts.bodyFile, "--body-file") : undefined);
+  if (body === undefined && htmlBody !== undefined) body = htmlToText(htmlBody);
+  if (!body) fail(EXIT.USAGE, usage);
+  return { body, htmlBody };
+}
+
+/**
+ * Print the send result and enforce the held contract: a held send is an HTTP
+ * success with `status: "pending_review"` — the recipient got NOTHING. Scripts
+ * must be able to branch on that without parsing JSON, hence exit HELD (3).
+ */
+function emitSendResult(result: SendResultView, json?: boolean): void {
+  if (json) {
+    process.stdout.write(JSON.stringify(result) + "\n");
+  } else {
+    process.stdout.write(result.messageId + "\n");
+  }
+  if (result.status === "pending_review") {
+    process.stderr.write(
+      "WARNING: held for review (pending_review) — the message did NOT reach the recipient. " +
+        "Disable outbound protection on this agent or approve it in the review queue.\n",
+    );
+    process.exit(EXIT.HELD);
+  }
+}
+
+export async function send(opts: SendOptions): Promise<void> {
+  if (opts.to.length === 0 || !opts.subject) fail(EXIT.USAGE, SEND_USAGE);
+  const { body, htmlBody } = resolveBodies(opts, SEND_USAGE);
+
+  const client = createClient();
+  const agentEmail = requireAgentEmail(opts.agent);
+  const result = await client.messages.send(agentEmail, {
+    to: opts.to,
+    subject: opts.subject,
+    body,
+    ...(htmlBody !== undefined ? { htmlBody } : {}),
+    ...(opts.conversationId ? { conversationId: opts.conversationId } : {}),
+  });
+  emitSendResult(result, opts.json);
+}
+
+export async function reply(messageId: string | undefined, opts: ReplyOptions): Promise<void> {
+  if (!messageId) fail(EXIT.USAGE, REPLY_USAGE);
+  const { body, htmlBody } = resolveBodies(opts, REPLY_USAGE);
+
+  const client = createClient();
+  const agentEmail = requireAgentEmail(opts.agent);
+  const result = await client.messages.reply(agentEmail, messageId, {
+    body,
+    ...(htmlBody !== undefined ? { htmlBody } : {}),
+  });
+  emitSendResult(result, opts.json);
+}

--- a/cli/src/commands/whoami.ts
+++ b/cli/src/commands/whoami.ts
@@ -1,4 +1,5 @@
 import { createClient } from "../sdk.js";
+import { loadConfig } from "../config.js";
 
 export interface WhoamiOptions {
   json?: boolean;
@@ -20,6 +21,15 @@ export async function whoami(opts: WhoamiOptions): Promise<void> {
   process.stdout.write(`scope: ${account.scope}\n`);
   if (account.agentAddress) {
     process.stdout.write(`agent: ${account.agentAddress}\n`);
+  } else {
+    // Account-scoped keys aren't bound to an inbox — show what send/reply
+    // will actually use, so the preflight answers "which inbox am I?".
+    const agentEmail = loadConfig().agent_email;
+    process.stdout.write(
+      agentEmail
+        ? `agent: ${agentEmail} (default from config/E2A_AGENT_EMAIL)\n`
+        : "agent: (none set — use --agent, E2A_AGENT_EMAIL, or e2a config set agent_email)\n",
+    );
   }
   process.stdout.write(`plan:  ${account.planCode}\n`);
   process.stdout.write(

--- a/cli/src/commands/whoami.ts
+++ b/cli/src/commands/whoami.ts
@@ -1,0 +1,29 @@
+import { createClient } from "../sdk.js";
+
+export interface WhoamiOptions {
+  json?: boolean;
+}
+
+// `whoami` is the preflight for scripts: one call that answers "is this key
+// valid, what scope is it, and which inbox is it bound to". Works for both
+// account- and agent-scoped keys (GET /v1/account is scope-aware).
+export async function whoami(opts: WhoamiOptions): Promise<void> {
+  const client = createClient();
+  const account = await client.account.get();
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(account) + "\n");
+    return;
+  }
+
+  process.stdout.write(`user:  ${account.user.email} (${account.user.id})\n`);
+  process.stdout.write(`scope: ${account.scope}\n`);
+  if (account.agentAddress) {
+    process.stdout.write(`agent: ${account.agentAddress}\n`);
+  }
+  process.stdout.write(`plan:  ${account.planCode}\n`);
+  process.stdout.write(
+    `usage: ${account.usage.agents}/${account.limits.maxAgents} agents, ` +
+      `${account.usage.messagesMonth}/${account.limits.maxMessagesMonth} messages this month\n`,
+  );
+}

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -143,8 +143,11 @@ export function requireApiKey(config: Config): string {
   if (!config.api_key) {
     // Missing credentials are an auth failure per the documented exit-code
     // contract (4) — never 1, which scripts treat as retryable-transient.
-    // Name the headless path too: `login` needs a browser on this machine.
-    process.stderr.write("Not authenticated. Run: e2a login (or set E2A_API_KEY)\n");
+    // Name BOTH acquisition paths: `login` needs a browser on this machine;
+    // headless boxes use --with-key or the env var.
+    process.stderr.write(
+      "Not authenticated. Run: e2a login (browser) or e2a login --with-key (headless), or set E2A_API_KEY\n",
+    );
     process.exit(EXIT.AUTH);
   }
   return config.api_key;

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -15,6 +15,12 @@ export interface Config {
    * works zero-config.
    */
   shared_domain: string;
+  /**
+   * Scope of the stored api_key ("account" or "agent"), recorded at login so
+   * commands that need workspace-admin scope can fail with a precise message
+   * instead of a server 403. Absent for keys saved before this field existed.
+   */
+  key_scope?: string;
 }
 
 const CONFIG_DIR = join(homedir(), ".e2a");
@@ -38,6 +44,7 @@ export function loadConfig(): Config {
     if (file.api_url) config.api_url = file.api_url;
     if (file.agent_email) config.agent_email = file.agent_email;
     if (file.shared_domain) config.shared_domain = file.shared_domain;
+    if (file.key_scope) config.key_scope = file.key_scope;
   } catch {
     // No config file yet
   }
@@ -91,6 +98,14 @@ export function saveConfig(updates: Partial<Config>): void {
     fileConfig.agent_email = merged.agent_email;
   } else {
     delete fileConfig.agent_email;
+  }
+
+  // key_scope mirrors agent_email: persist when set, drop when cleared.
+  if ("key_scope" in updates) {
+    if (updates.key_scope) fileConfig.key_scope = updates.key_scope;
+    else delete fileConfig.key_scope;
+  } else if (merged.key_scope) {
+    fileConfig.key_scope = merged.key_scope;
   }
 
   // Mirror the api_url policy: only persist non-default, non-env-overridden values.

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -16,6 +16,14 @@ export interface Config {
    * works zero-config.
    */
   shared_domain: string;
+  /**
+   * Scope of the stored api_key ("account" or "agent"), recorded by `e2a
+   * login` (which now writes it on every path: browser, --agent exchange,
+   * --with-key). Lets commands that need workspace-admin scope fail with a
+   * precise message instead of a server 403. Absent for keys saved by older
+   * CLIs or set out-of-band.
+   */
+  key_scope?: string;
 }
 
 const CONFIG_DIR = join(homedir(), ".e2a");
@@ -39,6 +47,7 @@ export function loadConfig(): Config {
     if (file.api_url) config.api_url = file.api_url;
     if (file.agent_email) config.agent_email = file.agent_email;
     if (file.shared_domain) config.shared_domain = file.shared_domain;
+    if (file.key_scope) config.key_scope = file.key_scope;
   } catch {
     // No config file yet
   }
@@ -97,6 +106,14 @@ export function saveConfig(updates: Partial<Config>): void {
     fileConfig.agent_email = merged.agent_email;
   } else if (!process.env.E2A_AGENT_EMAIL) {
     delete fileConfig.agent_email;
+  }
+
+  // key_scope has no env override and no default: persist when set, drop when
+  // cleared. Login rewrites it whenever api_key changes, so it can't go stale
+  // through the login path (a hand-edited api_key is on the user).
+  if ("key_scope" in updates) {
+    if (updates.key_scope) fileConfig.key_scope = updates.key_scope;
+    else delete fileConfig.key_scope;
   }
 
   // Mirror the api_url policy: only persist non-default, non-env-overridden values.

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -1,6 +1,7 @@
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
+import { EXIT } from "./exit.js";
 
 export interface Config {
   api_key: string;
@@ -15,12 +16,6 @@ export interface Config {
    * works zero-config.
    */
   shared_domain: string;
-  /**
-   * Scope of the stored api_key ("account" or "agent"), recorded at login so
-   * commands that need workspace-admin scope can fail with a precise message
-   * instead of a server 403. Absent for keys saved before this field existed.
-   */
-  key_scope?: string;
 }
 
 const CONFIG_DIR = join(homedir(), ".e2a");
@@ -44,7 +39,6 @@ export function loadConfig(): Config {
     if (file.api_url) config.api_url = file.api_url;
     if (file.agent_email) config.agent_email = file.agent_email;
     if (file.shared_domain) config.shared_domain = file.shared_domain;
-    if (file.key_scope) config.key_scope = file.key_scope;
   } catch {
     // No config file yet
   }
@@ -100,14 +94,6 @@ export function saveConfig(updates: Partial<Config>): void {
     delete fileConfig.agent_email;
   }
 
-  // key_scope mirrors agent_email: persist when set, drop when cleared.
-  if ("key_scope" in updates) {
-    if (updates.key_scope) fileConfig.key_scope = updates.key_scope;
-    else delete fileConfig.key_scope;
-  } else if (merged.key_scope) {
-    fileConfig.key_scope = merged.key_scope;
-  }
-
   // Mirror the api_url policy: only persist non-default, non-env-overridden values.
   if ("shared_domain" in updates) {
     if (
@@ -133,8 +119,10 @@ export function saveConfig(updates: Partial<Config>): void {
 
 export function requireApiKey(config: Config): string {
   if (!config.api_key) {
+    // Missing credentials are an auth failure per the documented exit-code
+    // contract (4) — never 1, which scripts treat as retryable-transient.
     process.stderr.write("Not authenticated. Run: e2a login\n");
-    process.exit(1);
+    process.exit(EXIT.AUTH);
   }
   return config.api_key;
 }

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -43,9 +43,14 @@ export function loadConfig(): Config {
     // No config file yet
   }
 
-  // Env vars override file
+  // Env vars override file. E2A_BASE_URL is accepted as an alias for E2A_URL
+  // and E2A_AGENT_EMAIL selects the inbox — these are the exact names the
+  // tether harness trains users to export, so ignoring them is a silent trap
+  // for the CLI's primary scripting consumer. E2A_URL wins over the alias.
   if (process.env.E2A_API_KEY) config.api_key = process.env.E2A_API_KEY;
   if (process.env.E2A_URL) config.api_url = process.env.E2A_URL;
+  else if (process.env.E2A_BASE_URL) config.api_url = process.env.E2A_BASE_URL;
+  if (process.env.E2A_AGENT_EMAIL) config.agent_email = process.env.E2A_AGENT_EMAIL;
   if (process.env.E2A_SHARED_DOMAIN) config.shared_domain = process.env.E2A_SHARED_DOMAIN;
 
   return config;
@@ -88,9 +93,9 @@ export function saveConfig(updates: Partial<Config>): void {
   if ("agent_email" in updates) {
     if (updates.agent_email) fileConfig.agent_email = updates.agent_email;
     else delete fileConfig.agent_email;
-  } else if (merged.agent_email) {
+  } else if (!process.env.E2A_AGENT_EMAIL && merged.agent_email) {
     fileConfig.agent_email = merged.agent_email;
-  } else {
+  } else if (!process.env.E2A_AGENT_EMAIL) {
     delete fileConfig.agent_email;
   }
 
@@ -121,7 +126,8 @@ export function requireApiKey(config: Config): string {
   if (!config.api_key) {
     // Missing credentials are an auth failure per the documented exit-code
     // contract (4) — never 1, which scripts treat as retryable-transient.
-    process.stderr.write("Not authenticated. Run: e2a login\n");
+    // Name the headless path too: `login` needs a browser on this machine.
+    process.stderr.write("Not authenticated. Run: e2a login (or set E2A_API_KEY)\n");
     process.exit(EXIT.AUTH);
   }
   return config.api_key;

--- a/cli/src/exit.ts
+++ b/cli/src/exit.ts
@@ -17,8 +17,9 @@ export const EXIT = {
   HELD: 3,
   /** Bad credentials or wrong key scope for the operation. */
   AUTH: 4,
-  /** A bounded wait (e.g. `listen --once --until`) hit its deadline. */
-  TIMEOUT: 5,
+  // 5 is earmarked for deadline-bounded waits (listen --once) and ships with
+  // that feature — a code must never be published in --help before an
+  // invocation can actually produce it.
 } as const;
 
 /** Write a message to stderr and exit with the given code. */

--- a/cli/src/exit.ts
+++ b/cli/src/exit.ts
@@ -17,7 +17,13 @@ export const EXIT = {
   HELD: 3,
   /** Bad credentials or wrong key scope for the operation. */
   AUTH: 4,
-  // 5 is earmarked for deadline-bounded waits (listen --once) and ships with
+  /**
+   * Permanent request error (404 / 409 / 422 …) — retrying the identical
+   * invocation cannot succeed. Distinguished from ERROR so retry-on-1
+   * wrappers don't hammer a typo'd message id or an unverified domain.
+   */
+  REQUEST: 5,
+  // 6 is earmarked for deadline-bounded waits (listen --once) and ships with
   // that feature — a code must never be published in --help before an
   // invocation can actually produce it.
 } as const;

--- a/cli/src/exit.ts
+++ b/cli/src/exit.ts
@@ -23,9 +23,8 @@ export const EXIT = {
    * wrappers don't hammer a typo'd message id or an unverified domain.
    */
   REQUEST: 5,
-  // 6 is earmarked for deadline-bounded waits (listen --once) and ships with
-  // that feature — a code must never be published in --help before an
-  // invocation can actually produce it.
+  /** A deadline-bounded wait (`listen --once --until`) expired unmatched. */
+  TIMEOUT: 6,
 } as const;
 
 /** Write a message to stderr and exit with the given code. */

--- a/cli/src/exit.ts
+++ b/cli/src/exit.ts
@@ -1,0 +1,28 @@
+// Exit codes are the CLI's scripting contract. Harness scripts (tether, hooks,
+// CI lanes) branch on these instead of parsing output, so the values are
+// frozen once published — add new codes, never renumber.
+//
+// HELD exists because a held send is an HTTP 200: the API accepted the message
+// but parked it in the review queue (`status: "pending_review"`), so the
+// recipient got nothing. Scripts that treat "exit 0" as "delivered" would
+// silently report into a queue nobody reads — the exact failure mode that bit
+// the tether harness twice.
+export const EXIT = {
+  OK: 0,
+  /** Network, server, or unexpected error. */
+  ERROR: 1,
+  /** Bad flags or arguments. */
+  USAGE: 2,
+  /** Send accepted but held for review (pending_review) — NOT delivered. */
+  HELD: 3,
+  /** Bad credentials or wrong key scope for the operation. */
+  AUTH: 4,
+  /** A bounded wait (e.g. `listen --once --until`) hit its deadline. */
+  TIMEOUT: 5,
+} as const;
+
+/** Write a message to stderr and exit with the given code. */
+export function fail(code: number, message: string): never {
+  process.stderr.write(message.endsWith("\n") ? message : message + "\n");
+  process.exit(code);
+}

--- a/cli/src/html.ts
+++ b/cli/src/html.ts
@@ -1,0 +1,41 @@
+// Derive a plain-text fallback from an HTML email body, so `send --html-file`
+// without `--body` always produces a text part (multipart emails should never
+// ship an empty text alternative). Crude tag-stripping is fine for this — the
+// HTML part is what mail clients actually render.
+
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+  nbsp: " ",
+};
+
+function decodeEntities(s: string): string {
+  return s.replace(/&(#x?[0-9a-f]+|[a-z]+);/gi, (match, code: string) => {
+    if (code.startsWith("#")) {
+      const n =
+        code[1]?.toLowerCase() === "x"
+          ? parseInt(code.slice(2), 16)
+          : parseInt(code.slice(1), 10);
+      try {
+        return Number.isFinite(n) ? String.fromCodePoint(n) : match;
+      } catch {
+        return match;
+      }
+    }
+    return NAMED_ENTITIES[code.toLowerCase()] ?? match;
+  });
+}
+
+export function htmlToText(html: string): string {
+  let t = html.replace(/<(script|style)\b[\s\S]*?<\/\1\s*>/gi, " ");
+  // Block-level closers and <br> become line breaks so structure survives.
+  t = t.replace(/<(?:br|\/p|\/div|\/li|\/tr|\/h[1-6])\s*\/?>/gi, "\n");
+  t = t.replace(/<[^>]+>/g, " ");
+  t = decodeEntities(t);
+  t = t.replace(/\n\s*\n\s*/g, "\n\n");
+  t = t.replace(/[ \t]+/g, " ");
+  return t.trim();
+}

--- a/cli/src/sdk.ts
+++ b/cli/src/sdk.ts
@@ -1,5 +1,6 @@
 import { E2AClient } from "@e2a/sdk/v1";
 import { loadConfig, requireApiKey } from "./config.js";
+import { EXIT, fail } from "./exit.js";
 
 export function createClient(_opts?: { from?: string }): E2AClient {
   const config = loadConfig();
@@ -11,10 +12,9 @@ export function requireAgentEmail(fromOverride?: string): string {
   const config = loadConfig();
   const email = fromOverride || config.agent_email;
   if (!email) {
-    process.stderr.write(
-      "No agent email. Use --agent or run: e2a config set agent_email <email>\n",
-    );
-    process.exit(1);
+    // A missing inbox selection is a fixable invocation problem → USAGE (2),
+    // per the documented exit-code contract.
+    fail(EXIT.USAGE, "No agent email. Use --agent or run: e2a config set agent_email <email>");
   }
   return email;
 }

--- a/cli/src/sdk.ts
+++ b/cli/src/sdk.ts
@@ -2,7 +2,7 @@ import { E2AClient } from "@e2a/sdk/v1";
 import { loadConfig, requireApiKey } from "./config.js";
 import { EXIT, fail } from "./exit.js";
 
-export function createClient(_opts?: { from?: string }): E2AClient {
+export function createClient(): E2AClient {
   const config = loadConfig();
   const apiKey = requireApiKey(config);
   return new E2AClient({ apiKey, baseUrl: config.api_url });
@@ -14,7 +14,10 @@ export function requireAgentEmail(fromOverride?: string): string {
   if (!email) {
     // A missing inbox selection is a fixable invocation problem → USAGE (2),
     // per the documented exit-code contract.
-    fail(EXIT.USAGE, "No agent email. Use --agent or run: e2a config set agent_email <email>");
+    fail(
+      EXIT.USAGE,
+      "No agent email. Use --agent, set E2A_AGENT_EMAIL, or run: e2a config set agent_email <email>",
+    );
   }
   return email;
 }

--- a/plugins/e2a/skills/tether/SKILL.md
+++ b/plugins/e2a/skills/tether/SKILL.md
@@ -29,10 +29,13 @@ the two directions use different mechanisms:
 - **Send = agent-driven.** The agent calls `tether.sh update "…"` at meaningful
   moments (finished a slice, hit a blocker, needs a decision). Cadence is the
   model's judgment → no per-turn spam, nothing to throttle.
-- **Receive = poll-driven.** The agent runs `tether.sh listen` — a cheap,
-  curl-only poll loop (no LLM tokens per check) that runs for the duration set at
-  `start --for`. It wakes the agent *only* when a reply actually arrives (or the
-  window ends). See **Durability tiers** for keeping it alive across idle/sleep.
+- **Receive = real-time wait.** The agent runs `tether.sh listen` — it blocks
+  on the e2a CLI's WebSocket (`e2a listen --once`; no LLM tokens while waiting)
+  for the duration set at `start --for`, so replies are picked up within
+  seconds; if the WebSocket is unavailable it degrades automatically to
+  interval polling. It wakes the agent *only* when a reply actually arrives (or
+  the window ends). See **Durability tiers** for keeping it alive across
+  idle/sleep.
 - **Questions = ask by email.** When the agent needs a decision or clarification
   from you, it must **not** use a terminal prompt / AskUserQuestion — you're AFK
   and can't see it, which would stall the whole session. It calls
@@ -48,15 +51,36 @@ the two directions use different mechanisms:
 
 ## Setup (once)
 
-Tether needs an **agent-scoped** e2a API key (`e2a_agt_…`) bound to a single
-inbox — least privilege, so a leaked key can't touch the rest of the account.
+> **Prerequisites:** Node (the transport is the `e2a` CLI ≥ the version pinned
+> in `lib.sh` — resolved from `$E2A_CLI`, then PATH, then fetched automatically
+> via `npx -y @e2a/cli@^MIN`, so there is nothing to install by hand) and
+> Python 3 (local state handling only).
 
-1. **Get an agent-scoped API key from the e2a website:**
-   **https://e2a.dev/api-keys** — create or pick an agent and generate a key
-   scoped to it. Note the agent's email address too. If you don't already own a
-   domain, create the agent on the **shared `agents.e2a.dev`** domain (the
-   default — `name@agents.e2a.dev`, live immediately, no DNS). A custom domain is
-   only worth the setup if you own one and want branded addresses.
+### Fast path (recommended): `tether.sh setup`
+
+If the e2a CLI is logged in (`e2a login` in a browser, or `e2a login
+--with-key` on a headless box), one command does the whole bootstrap:
+
+```bash
+"${CLAUDE_PLUGIN_ROOT}/skills/tether/tether.sh" setup
+```
+
+It verifies the credential (`e2a whoami`), ensures a tether inbox (reusing an
+existing `tether-…` agent or creating one on the shared domain — it will
+**not** silently adopt a non-tether inbox), turns outbound review **off** on
+that inbox, mints a **least-privilege agent-scoped key** (`e2a_agt_…`), and
+writes `~/.e2a-tether.env` (previous file kept as `.bak`). Every step fails
+hard — it never stores the broad account key and never reports "ready" with a
+half-working config. Flags: `--email you@yourdomain` to use/create a specific
+inbox, `--new` to force a fresh one.
+
+### Manual setup (fallback)
+
+1. **Get an agent-scoped API key** (`e2a_agt_…` — least privilege, so a leaked
+   key can't touch the rest of the account): from the CLI with
+   `e2a keys create --agent <inbox>`, or from **https://e2a.dev/api-keys**.
+   No domain? Create the agent on the **shared `agents.e2a.dev`** domain
+   (`e2a agents create name@agents.e2a.dev` — live immediately, no DNS).
 2. **Save the credentials:**
    ```bash
    cp "${CLAUDE_PLUGIN_ROOT}/skills/tether/tether.env.example" ~/.e2a-tether.env
@@ -68,9 +92,9 @@ inbox — least privilege, so a leaked key can't touch the rest of the account.
    ```
 
 Credentials resolve in order: explicit env vars → `~/.e2a-tether.env` →
-`~/.e2a/config.json`. (That last one, written by `e2a login`, is an
-**account-scoped** key — broader than tether needs; prefer the agent key above.
-A smoother CLI path is coming.)
+`~/.e2a/config.json` (written by `e2a login`; after `e2a login --agent <inbox>`
+that file already holds a least-privilege agent key, so tether needs no
+tether-specific config at all).
 
 > The tether agent must have send-side protection / HITL **off**, or each update
 > is held for review instead of reaching you. `tether.sh` now detects this on
@@ -85,16 +109,14 @@ Before tethering, confirm the harness can actually send. Run `"$T" status`
 (where `T` is defined below). If it reports **`config: MISSING`**, this is a
 first-time user — **help them get to a working setup instead of just failing**:
 
-1. **Is e2a connected at all?** If they've never used e2a, get them connected
-   first: open **https://e2a.dev** to sign up, and complete the plugin's MCP
-   OAuth (`/plugin` in Claude Code). If the e2a MCP tools (`mcp__e2a__*`) are
-   available, you can then create their first inbox directly with `create_agent`
-   on the shared `agents.e2a.dev` domain — no domain, no DNS. Interactive
-   sign-in/OAuth is theirs to complete: hand them the step, don't drive it.
-2. **Mint the tether key.** tether's poller is a plain-`curl` script, so it needs
-   an **agent-scoped API key** (`e2a_agt_…`), which the MCP OAuth session doesn't
-   provide. Send them to **https://e2a.dev/api-keys** to generate a key scoped to
-   that agent, then save it per **Setup** above (`~/.e2a-tether.env`).
+1. **Is e2a connected at all?** If they've never used e2a, hand them
+   `e2a login` — it opens the browser sign-up/sign-in and saves an
+   account-scoped key to `~/.e2a/config.json`. (Headless box: they mint a key
+   in the dashboard and run `e2a login --with-key`.) Interactive sign-in is
+   theirs to complete: hand them the command, don't drive it.
+2. **Run the bootstrap:** `"$T" setup` — it creates the inbox, disables
+   outbound review, mints the agent-scoped key, and writes
+   `~/.e2a-tether.env`. See **Setup** above for what it refuses to do.
 3. **Re-check.** `"$T" status` should now print `config: OK (agent …)`. Proceed
    to the runtime flow.
 
@@ -148,7 +170,8 @@ Let `T="${CLAUDE_PLUGIN_ROOT}/skills/tether/tether.sh"`.
    terminal prompt; **exit 4** = the question was held for review and never
    reached the user (fix protection).
 5. **Listen for the whole window**: run `"$T" listen` **in the background**. It
-   polls cheaply (curl, no tokens) and exits with either:
+   waits on the CLI's WebSocket (real-time, no tokens while waiting; degrades
+   to polling if the WS is unavailable) and exits with either:
    - `REPLY_RECEIVED:` + the message → act on it (then `update` with the result),
      and **relaunch `listen`** for the remaining window; or
    - `TETHER_EXPIRED` → the window is up; run `"$T" stop`.
@@ -203,21 +226,23 @@ Write for that medium, not for a CLI.
   reach for the e2a MCP `send_message` or start a new subject to reach the user
   mid-session. One session = one thread = one subject.
 
-## Poll interval & knobs
+## Wait behavior & knobs
 
-`listen`/`poll` hit the inbox with a plain `curl` — **no LLM tokens per check** —
-so polling can be frequent. The agent is only woken (a real turn) when a reply
-actually lands.
+`listen`/`ask` block on the e2a CLI's WebSocket wait (**no LLM tokens while
+waiting**), so reply latency is seconds. The poll interval only matters as the
+degraded cadence when the WebSocket is unavailable, and as the backfill check
+between waits. The agent is only woken (a real turn) when a reply actually
+lands.
 
 | env var | default | effect |
 |---|---|---|
-| `E2A_TETHER_POLL_INTERVAL` | `20` (s) | how often `listen`/`ask` check the inbox |
+| `E2A_TETHER_POLL_INTERVAL` | `20` (s) | fallback poll cadence when the WS wait is unavailable |
 | `E2A_TETHER_ASK_TIMEOUT` | `1800` (s) | how long `ask` blocks for an answer before giving up |
 | `E2A_BASE_URL` | `https://api.e2a.dev` | API base (set for self-host) |
+| `E2A_CLI` | (auto) | override the e2a CLI invocation (e.g. `node /repo/cli/dist/bin/e2a.js`) |
 
 The only thing that costs a turn per tick is a `/loop` **heartbeat** (tier 2
-below) — keep that coarse (e.g. 30m). Reply latency ≈ the poll interval, and
-it's cheap, so 20–30s is fine.
+below) — keep that coarse (e.g. 30m).
 
 ## Durability tiers
 
@@ -239,8 +264,8 @@ it's cheap, so 20–30s is fine.
 
 | file | role |
 |---|---|
-| `tether.sh` | runtime CLI: `start [--title] [--for]` / `update [--html] [--attach]` / `ask [--attach]` / `listen` / `poll` / `status` / `stop` |
-| `lib.sh` | config + e2a send/reply/poll helpers |
+| `tether.sh` | runtime CLI: `setup` / `start [--title] [--for]` / `update [--html] [--attach]` / `ask [--attach]` / `listen` / `poll` / `status` / `stop` |
+| `lib.sh` | config + e2a-CLI resolution (`t_cli`) + send/reply/wait helpers |
 | `hooks/tether-notify.sh` | optional Notification hook (blocked-alert) |
 | `install.sh` | wire/unwire the Notification hook; `_selftest` |
 | `tether.env.example` | credentials template |

--- a/plugins/e2a/skills/tether/SKILL.md
+++ b/plugins/e2a/skills/tether/SKILL.md
@@ -110,10 +110,12 @@ Before tethering, confirm the harness can actually send. Run `"$T" status`
 first-time user — **help them get to a working setup instead of just failing**:
 
 1. **Is e2a connected at all?** If they've never used e2a, hand them
-   `e2a login` — it opens the browser sign-up/sign-in and saves an
-   account-scoped key to `~/.e2a/config.json`. (Headless box: they mint a key
-   in the dashboard and run `e2a login --with-key`.) Interactive sign-in is
-   theirs to complete: hand them the command, don't drive it.
+   `e2a login` — or, when `e2a` isn't installed globally, the npx form:
+   `npx -y @e2a/cli login` (same auto-fetch the harness itself uses). It opens
+   the browser sign-up/sign-in and saves an account-scoped key to
+   `~/.e2a/config.json`. (Headless box: they mint a key in the dashboard and
+   run `… login --with-key`.) Interactive sign-in is theirs to complete: hand
+   them the command, don't drive it.
 2. **Run the bootstrap:** `"$T" setup` — it creates the inbox, disables
    outbound review, mints the agent-scoped key, and writes
    `~/.e2a-tether.env`. See **Setup** above for what it refuses to do.
@@ -271,9 +273,12 @@ its thread. To run a second session in the *same* repo, start it with
 `--parallel`: it self-keys a fresh state file and prints a
 `TETHER_STATE="…"` handle — **prefix every subsequent tether call in that
 session with it** (`TETHER_STATE="…" "$T" update …`), and pass a distinct
-`--title` so the inbox threads are tellable apart. (A pre-existing
-machine-global `state.json` from an older tether keeps working until its
-session stops.)
+`--title` so the inbox threads are tellable apart. Forgetting the prefix is
+warned about (commands notice parallel peers exist) and every send echoes its
+thread id, so misdirection is observable. (A pre-existing machine-global
+`state.json` from an older tether keeps working until its session stops —
+note that WHILE it exists it shadows repo keying, so it also blocks `start`
+in other repos; `stop` that session to retire it.)
 
 ## Files
 

--- a/plugins/e2a/skills/tether/SKILL.md
+++ b/plugins/e2a/skills/tether/SKILL.md
@@ -134,12 +134,12 @@ Let `T="${CLAUDE_PLUGIN_ROOT}/skills/tether/tether.sh"`.
    normal question is fine.
 2. **Start**: `"$T" start <email> --title "<work>" --for <duration>` (or
    `--until <ISO>`; omit both for until-stop) — sends the intro, opens the
-   thread, arms, records the window. **Always pass `--title`** with a short
-   description of the work being done (e.g. `"migrate loft → @e2a/ui"`, `"fix
-   webhook retries"`) — it becomes the thread's subject line
-   (`Tether: <repo> — <title>`), which is how the user tells this session apart
-   from others in their inbox. The subject is fixed at start (threading needs it
-   stable), so title the *work*, not the first step. `--for` takes a **single
+   thread, arms, records the window. **`--title` is required** (start refuses
+   without it): a short description of the work being done (e.g. `"migrate
+   loft → @e2a/ui"`, `"fix webhook retries"`) — it becomes the thread's subject
+   line (`Tether: <repo> — <title>`), which is how the user tells this session
+   apart from others in their inbox. The subject is fixed at start (threading
+   needs it stable), so title the *work*, not the first step. `--for` takes a **single
    unit** (`30m`, `2h`, `8h`, `1d`); a compound
    like `1h30m` is rejected rather than silently treated as no-limit. If the intro
    comes back **held for review** (`pending_review`), `start` refuses to arm and
@@ -279,7 +279,7 @@ session stops.)
 
 | file | role |
 |---|---|
-| `tether.sh` | runtime CLI: `setup` / `start [--title] [--for]` / `update [--html] [--attach]` / `ask [--attach]` / `listen` / `poll` / `status` / `stop` |
+| `tether.sh` | runtime CLI: `setup` / `start --title [--for] [--parallel]` / `update [--html] [--attach]` / `ask [--attach]` / `listen` / `poll` / `status` / `stop` |
 | `lib.sh` | config + e2a-CLI resolution (`t_cli`) + send/reply/wait helpers |
 | `hooks/tether-notify.sh` | optional Notification hook (blocked-alert) |
 | `install.sh` | wire/unwire the Notification hook; `_selftest` |

--- a/plugins/e2a/skills/tether/SKILL.md
+++ b/plugins/e2a/skills/tether/SKILL.md
@@ -260,6 +260,18 @@ below) — keep that coarse (e.g. 30m).
    closed terminal, regardless of duration — that needs an **e2a webhook firing
    a cloud Routine** (a *fresh* session per fire, loses live context). Follow-on.
 
+## Multiple sessions
+
+Each `start` opens a **dedicated email thread** (fresh conversation id, its own
+subject; replies anchor by In-Reply-To), and local state is **keyed per repo**
+(git toplevel), so tethered sessions in different repos coexist without
+touching each other's thread, watermark, or ask-lock. Within one repo there is
+one session by design: `start` **refuses to arm over a live session** instead
+of silently hijacking its thread — run `stop` first, or point `TETHER_STATE`
+at a unique path to deliberately run two in parallel. (A pre-existing
+machine-global `state.json` from an older tether keeps working until its
+session stops.)
+
 ## Files
 
 | file | role |

--- a/plugins/e2a/skills/tether/SKILL.md
+++ b/plugins/e2a/skills/tether/SKILL.md
@@ -265,10 +265,13 @@ below) — keep that coarse (e.g. 30m).
 Each `start` opens a **dedicated email thread** (fresh conversation id, its own
 subject; replies anchor by In-Reply-To), and local state is **keyed per repo**
 (git toplevel), so tethered sessions in different repos coexist without
-touching each other's thread, watermark, or ask-lock. Within one repo there is
-one session by design: `start` **refuses to arm over a live session** instead
-of silently hijacking its thread — run `stop` first, or point `TETHER_STATE`
-at a unique path to deliberately run two in parallel. (A pre-existing
+touching each other's thread, watermark, or ask-lock. Within one repo,
+`start` **refuses to arm over a live session** instead of silently hijacking
+its thread. To run a second session in the *same* repo, start it with
+`--parallel`: it self-keys a fresh state file and prints a
+`TETHER_STATE="…"` handle — **prefix every subsequent tether call in that
+session with it** (`TETHER_STATE="…" "$T" update …`), and pass a distinct
+`--title` so the inbox threads are tellable apart. (A pre-existing
 machine-global `state.json` from an older tether keeps working until its
 session stops.)
 

--- a/plugins/e2a/skills/tether/hooks/tether-notify.sh
+++ b/plugins/e2a/skills/tether/hooks/tether-notify.sh
@@ -18,9 +18,11 @@ except Exception:print("")')"
 t_load_config || exit 0
 [ "$(t_state_get armed)" = "1" ] || exit 0
 
-rid="$(t_state_get last_message_id)"
-[ -n "$rid" ] || exit 0
-t_api_reply "$rid" "⏸️ Needs you: ${message}
+# Anchored reply (last message → last inbound → intro), NOT a bare reply to
+# last_message_id: when that anchor is the agent's own reply-created outbound,
+# older hosted APIs 404 it — and this "agent is stuck" alert is the one email
+# that must not silently vanish in exactly that situation.
+t_reply_anchored "⏸️ Needs you: ${message}
 
 Reply to this thread and I'll pick it up at the next check." >/dev/null 2>&1 || true
 exit 0

--- a/plugins/e2a/skills/tether/lib.sh
+++ b/plugins/e2a/skills/tether/lib.sh
@@ -4,6 +4,13 @@
 # Config comes from the environment, falling back to ~/.e2a-tether.env.
 # Required: E2A_API_KEY, E2A_AGENT_EMAIL. The recipient is supplied at
 # `tether.sh start <email>` and kept in the state file.
+#
+# Transport is the e2a CLI (@e2a/cli), NOT raw curl: send/reply/list/get all
+# go through `t_cli`, which resolves $E2A_CLI → `e2a` on PATH (if new enough)
+# → `npx -y @e2a/cli@^MIN`. Node is always present where this skill runs
+# (Claude Code requires it), so existing users need to install nothing and
+# minor CLI upgrades flow automatically through npx. Python 3 is still needed
+# for local state/JSON handling only.
 
 t_load_config() {
   # Explicit env vars win; each fallback source fills only the vars still missing
@@ -41,7 +48,55 @@ except Exception:pass')"
 }
 
 t_now_iso()  { python3 -c 'import datetime;print(datetime.datetime.now(datetime.timezone.utc).isoformat())'; }
-t_urlencode(){ python3 -c 'import sys,urllib.parse;print(urllib.parse.quote(sys.argv[1],safe=""))' "$1"; }
+
+# --- e2a CLI resolution --------------------------------------------------------
+# The minimum CLI this skill's flags require (send --conversation-id, reply
+# --html-file/--attach, messages list TSV, listen --once, exit-code contract).
+# Bump in lockstep with any new flag use; the npx pin below follows it.
+TETHER_MIN_CLI="1.6.0"
+
+# t_ver_ge "<e2a 1.6.2>" "1.6.0" → 0 when the version (last token) >= min.
+t_ver_ge() {
+  python3 -c 'import sys
+def v(s):
+    s = s.strip().split()[-1] if s.strip() else "0"
+    return [int(x) for x in s.lstrip("v").split(".")[:3] if x.isdigit()] or [0]
+sys.exit(0 if v(sys.argv[1]) >= v(sys.argv[2]) else 1)' "$1" "$2" 2>/dev/null
+}
+
+# t_cli <args...> — run the e2a CLI, resolving it once per process:
+#   1. $E2A_CLI override (may be multi-word, e.g. "node /repo/cli/dist/bin/e2a.js")
+#   2. `e2a` on PATH when --version >= TETHER_MIN_CLI (stale → warn, fall through)
+#   3. npx -y @e2a/cli@^MIN  (auto-fetch; nothing for the user to install)
+T_CLI=()
+t_cli() {
+  if [ "${#T_CLI[@]}" -eq 0 ]; then
+    if [ -n "${E2A_CLI:-}" ]; then
+      # shellcheck disable=SC2206  # intentional word-split for multi-word overrides
+      T_CLI=($E2A_CLI)
+    elif command -v e2a >/dev/null 2>&1 && t_ver_ge "$(e2a --version 2>/dev/null)" "$TETHER_MIN_CLI"; then
+      T_CLI=(e2a)
+    elif command -v npx >/dev/null 2>&1; then
+      if command -v e2a >/dev/null 2>&1; then
+        echo "tether: global e2a CLI is older than ${TETHER_MIN_CLI} — using npx for this run (upgrade: npm i -g @e2a/cli@latest)" >&2
+      fi
+      T_CLI=(npx -y "@e2a/cli@^${TETHER_MIN_CLI}")
+    else
+      echo "tether: no e2a CLI available — install Node/npm, or set E2A_CLI" >&2
+      return 127
+    fi
+  fi
+  "${T_CLI[@]}" "$@"
+}
+
+# Human-readable description of what t_cli would run (for status/_selftest).
+t_cli_desc() {
+  if [ -n "${E2A_CLI:-}" ]; then echo "\$E2A_CLI (${E2A_CLI})"
+  elif command -v e2a >/dev/null 2>&1 && t_ver_ge "$(e2a --version 2>/dev/null)" "$TETHER_MIN_CLI"; then
+    echo "e2a on PATH ($(e2a --version 2>/dev/null))"
+  elif command -v npx >/dev/null 2>&1; then echo "npx @e2a/cli@^${TETHER_MIN_CLI}"
+  else echo "MISSING (no e2a, no npx)"; fi
+}
 
 # --- state -------------------------------------------------------------------
 
@@ -107,32 +162,21 @@ try:
 except Exception:print(2147483647)' "$exp"
 }
 
-# --- e2a API -----------------------------------------------------------------
+# --- e2a API (via the CLI) -----------------------------------------------------
+# The CLI's exit-code contract does the heavy lifting: 0 sent / 3 HELD (any
+# non-"sent" status — accepted but NOT delivered) / 5 permanent request error /
+# 4 auth / 1 transient. These wrappers map it onto tether's internal codes
+# (0 ok, 2 held, 3 anchor-not-repliable) so tether.sh stays unchanged above.
+# The CLI reads E2A_API_KEY / E2A_AGENT_EMAIL / E2A_BASE_URL straight from the
+# environment t_load_config resolves — no flag plumbing needed.
 
 # t_api_send <to> <subject> <body> <conversation_id> → prints message_id;
-# returns 2 (and warns on stderr) if the send was HELD (pending_review) so the
-# caller can refuse to arm / not report a phantom "sent".
+# returns 2 if the send was HELD so the caller can refuse to arm.
 t_api_send() {
-  local email resp status mid
-  email="$(t_urlencode "$E2A_AGENT_EMAIL")"
-  local payload
-  payload="$(python3 -c 'import json,sys
-print(json.dumps({"to":[sys.argv[1]],"subject":sys.argv[2],"body":sys.argv[3],"conversation_id":sys.argv[4]}))' \
-    "$1" "$2" "$3" "$4")"
-  resp="$(curl -sS -m 30 -X POST \
-    -H "Authorization: Bearer ${E2A_API_KEY}" -H "Content-Type: application/json" \
-    -d "$payload" "${E2A_BASE_URL}/v1/agents/${email}/messages" 2>/dev/null)" || return 1
-  status="$(printf '%s' "$resp" | python3 -c 'import json,sys
-try:print(json.load(sys.stdin).get("status",""))
-except Exception:print("")')"
-  mid="$(printf '%s' "$resp" | python3 -c 'import json,sys
-try:print(json.load(sys.stdin).get("message_id",""))
-except Exception:print("")')"
+  local mid rc
+  mid="$(t_cli send --to "$1" --subject "$2" --body "$3" --conversation-id "$4")"; rc=$?
   printf '%s' "$mid"
-  if [ "$status" = "pending_review" ]; then
-    echo "tether: WARNING send held (pending_review) — disable protection on ${E2A_AGENT_EMAIL}" >&2
-    return 2
-  fi
+  case "$rc" in 0) return 0;; 3) return 2;; *) return 1;; esac
 }
 
 # Attachment cap: 15 MB of raw bytes total per send. Base64 inflates ~4/3 and
@@ -154,67 +198,26 @@ if total>maxb:
     "$T_ATTACH_MAX_BYTES" "$@"
 }
 
-# t_reply_payload <out_file> <body> <html> [file...] — write the reply JSON
-# payload to <out_file>. Each file becomes {filename, content_type, data(b64)}
-# per the API's attachments[] schema; MIME type is guessed from the filename
-# (fallback application/octet-stream).
-t_reply_payload() {
-  python3 -c 'import json,sys,base64,mimetypes,os
-out,body,html=sys.argv[1],sys.argv[2],sys.argv[3]
-p={"body":body}
-if html: p["html_body"]=html
-atts=[]
-for f in sys.argv[4:]:
-    atts.append({"filename":os.path.basename(f),
-                 "content_type":mimetypes.guess_type(f)[0] or "application/octet-stream",
-                 "data":base64.b64encode(open(f,"rb").read()).decode()})
-if atts: p["attachments"]=atts
-json.dump(p,open(out,"w"))' "$@"
-}
-
-# t_api_reply <in_reply_to_id> <body> [html_body] [attach_file ...] → prints new message_id;
-# returns 2 (and warns on stderr) if the reply was HELD (pending_review). The
-# reply path — every update/ask/stop — used to drop `status`, so a held update
-# printed a phantom "sent" while the user's inbox stayed empty.
-# Optional args past html_body are file paths attached to the reply. The payload
-# goes to curl via a temp file, never argv — a multi-MB base64 attachment would
-# blow past ARG_MAX if passed as a command-line argument.
+# t_api_reply <in_reply_to_id> <body> [html_file] [attach_file ...] → prints
+# new message_id. NOTE the third arg is now an HTML *file path* (the CLI takes
+# --html-file and derives the plain-text fallback itself when body is empty).
+# Returns: 0 sent; 2 HELD (accepted, NOT delivered — CLI exit 3); 3 anchor not
+# repliable here (CLI exit 5, permanent request error) so t_reply_anchored can
+# try the next anchor; 1 anything else (transient).
 t_api_reply() {
-  local email resp status mid rid body html pf
-  rid="$1"; body="$2"; html="${3:-}"
+  local rid="$1" body="${2:-}" htmlfile="${3:-}"
   shift 2; [ $# -gt 0 ] && shift   # remaining args = attachment file paths
-  email="$(t_urlencode "$E2A_AGENT_EMAIL")"
-  pf="$(mktemp "${TMPDIR:-/tmp}/tether-payload.XXXXXX")" || return 1
-  t_reply_payload "$pf" "$body" "$html" "$@" || { rm -f "$pf"; return 1; }
-  resp="$(curl -sS -m 120 -X POST \
-    -H "Authorization: Bearer ${E2A_API_KEY}" -H "Content-Type: application/json" \
-    --data-binary "@${pf}" \
-    "${E2A_BASE_URL}/v1/agents/${email}/messages/${rid}/reply" 2>/dev/null)" || { rm -f "$pf"; return 1; }
-  rm -f "$pf"
-  status="$(printf '%s' "$resp" | python3 -c 'import json,sys
-try:print(json.load(sys.stdin).get("status",""))
-except Exception:print("")')"
-  mid="$(printf '%s' "$resp" | python3 -c 'import json,sys
-try:print(json.load(sys.stdin).get("message_id",""))
-except Exception:print("")')"
+  local args=(reply "$rid")
+  [ -n "$body" ] && args+=(--body "$body")
+  [ -n "$htmlfile" ] && args+=(--html-file "$htmlfile")
+  local f; for f in "$@"; do args+=(--attach "$f"); done
+  local mid rc
+  mid="$(t_cli "${args[@]}")"; rc=$?
   printf '%s' "$mid"
-  if [ -z "$mid" ]; then
-    # Distinguish "this anchor is not repliable" (404) from other failures so
-    # t_reply_anchored can fall back to another anchor instead of giving up.
-    local ecode
-    ecode="$(printf '%s' "$resp" | python3 -c 'import json,sys
-try:print((json.load(sys.stdin).get("error") or {}).get("code",""))
-except Exception:print("")')"
-    [ "$ecode" = "not_found" ] && return 3
-    return 1
-  fi
-  if [ "$status" = "pending_review" ]; then
-    echo "tether: WARNING reply held (pending_review) — disable protection on ${E2A_AGENT_EMAIL}" >&2
-    return 2
-  fi
+  case "$rc" in 0) return 0;; 3) return 2;; 5) return 3;; *) return 1;; esac
 }
 
-# t_reply_anchored <body> <html> [attach_file ...] → send a threaded reply,
+# t_reply_anchored <body> <html_file> [attach_file ...] → send a threaded reply,
 # trying anchors in order: the last message in the thread (best Gmail
 # threading), then the user's last inbound reply, then the intro. Hosted APIs
 # that predate reply-to-own-outbound (#360) 404 when the anchor is a
@@ -222,7 +225,7 @@ except Exception:print("")')"
 # consecutive updates with no user reply in between is silently undeliverable.
 # Prints the new message_id; propagates t_api_reply's return code.
 t_reply_anchored() {
-  local body="$1" html="${2:-}"
+  local body="$1" html="${2:-}"   # html = FILE PATH (passed through to --html-file)
   shift 1; [ $# -gt 0 ] && shift
   local tried="" rid mid rc
   for rid in "$(t_state_get last_message_id)" "$(t_state_get last_inbound_id)" "$(t_state_get intro_id)"; do
@@ -237,47 +240,42 @@ t_reply_anchored() {
   return 3
 }
 
-# strip HTML tags → a plain-text fallback (crude but fine for email body)
-t_html_to_text() {
-  python3 -c 'import sys,re,html
-t=sys.stdin.read()
-t=re.sub(r"(?is)<(script|style).*?</\1>"," ",t)
-t=re.sub(r"(?i)<(br|/p|/div|/li|/tr|/h[1-6])\s*/?>","\n",t)
-t=re.sub(r"<[^>]+>"," ",t)
-t=html.unescape(t)
-print(re.sub(r"[ \t]+"," ",re.sub(r"\n\s*\n\s*","\n\n",t)).strip())'
-}
-
-# t_api_poll <conversation_id> <since_iso> → TSV lines: id<TAB>from<TAB>created_at (inbound, oldest first)
+# t_api_poll <conversation_id> <since_iso> → TSV lines: id<TAB>from<TAB>created_at
+# (inbound, oldest first). The CLI's TSV shape and defaults (read_status=all,
+# sort asc) are this exact contract — that's not a coincidence, it was designed
+# from this function.
 t_api_poll() {
-  local email resp
-  email="$(t_urlencode "$E2A_AGENT_EMAIL")"
-  resp="$(curl -sS -m 30 -G \
-    -H "Authorization: Bearer ${E2A_API_KEY}" \
-    --data-urlencode "direction=inbound" --data-urlencode "read_status=all" \
-    --data-urlencode "sort=asc" --data-urlencode "limit=20" \
-    --data-urlencode "conversation_id=${1}" --data-urlencode "since=${2}" \
-    "${E2A_BASE_URL}/v1/agents/${email}/messages" 2>/dev/null)" || return 1
-  printf '%s' "$resp" | python3 -c 'import json,sys
-try:
-  for m in json.load(sys.stdin).get("items",[]):
-    print("\t".join([m.get("message_id",""),m.get("from",""),m.get("created_at","")]))
-except Exception:pass'
+  t_cli messages list --direction inbound --conversation "$1" --since "$2" --limit 20 2>/dev/null
 }
 
-# t_api_body <message_id> → command text (parsed.text preferred; quoted history stripped)
+# t_api_body <message_id> → command text (parsed.text preferred; quoted history
+# stripped). Empty on transient failure — t_poll_once's age-based retry handles it.
 t_api_body() {
-  local email resp
-  email="$(t_urlencode "$E2A_AGENT_EMAIL")"
-  resp="$(curl -sS -m 30 -H "Authorization: Bearer ${E2A_API_KEY}" \
-    "${E2A_BASE_URL}/v1/agents/${email}/messages/${1}" 2>/dev/null)" || return 1
-  printf '%s' "$resp" | python3 -c 'import json,sys
-try:
-  d=json.load(sys.stdin)
-  p=(d.get("parsed") or {}).get("text") or ""
-  b=(d.get("body") or {}).get("text") or ""
-  print((p or b).strip())
-except Exception:print("")'
+  t_cli messages get "$1" --text 2>/dev/null
+}
+
+# t_ws_wait <seconds> — block until a new inbound arrives in the thread OR the
+# window elapses. A pure WAKE SIGNAL: output is discarded and nothing is marked
+# seen — the caller re-runs the dedup-safe t_poll_once to actually consume.
+# This is what turns the old 20s poll cadence into real-time pickup. Any CLI
+# failure degrades to a plain poll-interval sleep so loops keep their cadence.
+t_ws_wait() {
+  local secs="$1" conv until rc t0
+  conv="$(t_state_get conversation_id)"
+  until="$(python3 -c 'import sys,datetime
+print((datetime.datetime.now(datetime.timezone.utc)+datetime.timedelta(seconds=int(sys.argv[1]))).isoformat())' "$secs")"
+  t0=$SECONDS
+  t_cli listen --conversation "$conv" --once --until "$until" >/dev/null 2>&1
+  rc=$?
+  # 0 = something arrived, 6 = clean window expiry; anything else is a
+  # transient WS problem (e.g. deployments without the WS endpoint). Belt and
+  # braces: if the CLI came back early for ANY non-arrival reason, sleep one
+  # poll interval so the caller's loop degrades to polling cadence instead of
+  # spinning hot.
+  if [ "$rc" != "0" ] && [ $((SECONDS - t0)) -lt "$secs" ]; then
+    sleep "${E2A_TETHER_POLL_INTERVAL:-20}"
+  fi
+  return 0
 }
 
 # --- dedup + poll core -------------------------------------------------------

--- a/plugins/e2a/skills/tether/lib.sh
+++ b/plugins/e2a/skills/tether/lib.sh
@@ -40,10 +40,15 @@ except Exception:pass')"
   # Treat the copied-but-unfilled tether.env.example placeholders as unset, so a
   # user who ran `cp … tether.env.example` without editing gets `config: MISSING`
   # (the new-user signal) instead of a bogus `config: OK` that fails at `start`.
+  # Match ONLY the template's exact defaults — a real corp address that happens
+  # to end in .example must not be silently discarded by a heuristic.
   case "${E2A_API_KEY:-}" in *...*) E2A_API_KEY="";; esac
-  case "${E2A_AGENT_EMAIL:-}" in *@*.example|*.example) E2A_AGENT_EMAIL="";; esac
+  case "${E2A_AGENT_EMAIL:-}" in tether@you.example) E2A_AGENT_EMAIL="";; esac
 
-  E2A_BASE_URL="${E2A_BASE_URL:-https://api.e2a.dev}"
+  # EXPORTED: the transport is a child process (the e2a CLI). An unexported
+  # default here would leave the CLI on its own default host while status
+  # reports this one — a silent split-brain once the hosts diverge.
+  export E2A_BASE_URL="${E2A_BASE_URL:-https://api.e2a.dev}"
   [ -n "${E2A_API_KEY:-}" ] && [ -n "${E2A_AGENT_EMAIL:-}" ]
 }
 
@@ -64,29 +69,59 @@ def v(s):
 sys.exit(0 if v(sys.argv[1]) >= v(sys.argv[2]) else 1)' "$1" "$2" 2>/dev/null
 }
 
-# t_cli <args...> — run the e2a CLI, resolving it once per process:
-#   1. $E2A_CLI override (may be multi-word, e.g. "node /repo/cli/dist/bin/e2a.js")
+# t_cli <args...> — run the e2a CLI, bounded by a hard timeout. Resolution:
+#   1. $E2A_CLI override (multi-word ok, e.g. "node /repo/cli/dist/bin/e2a.js";
+#      paths containing SPACES are unsupported — use a wrapper script)
 #   2. `e2a` on PATH when --version >= TETHER_MIN_CLI (stale → warn, fall through)
 #   3. npx -y @e2a/cli@^MIN  (auto-fetch; nothing for the user to install)
+# The result is exported (T_CLI_RESOLVED) so the many $(t_cli …) subshells
+# don't re-probe versions or re-print the staleness warning on every API call.
 T_CLI=()
-t_cli() {
-  if [ "${#T_CLI[@]}" -eq 0 ]; then
-    if [ -n "${E2A_CLI:-}" ]; then
-      # shellcheck disable=SC2206  # intentional word-split for multi-word overrides
-      T_CLI=($E2A_CLI)
-    elif command -v e2a >/dev/null 2>&1 && t_ver_ge "$(e2a --version 2>/dev/null)" "$TETHER_MIN_CLI"; then
-      T_CLI=(e2a)
-    elif command -v npx >/dev/null 2>&1; then
-      if command -v e2a >/dev/null 2>&1; then
-        echo "tether: global e2a CLI is older than ${TETHER_MIN_CLI} — using npx for this run (upgrade: npm i -g @e2a/cli@latest)" >&2
-      fi
-      T_CLI=(npx -y "@e2a/cli@^${TETHER_MIN_CLI}")
-    else
-      echo "tether: no e2a CLI available — install Node/npm, or set E2A_CLI" >&2
+t_cli_resolve() {
+  [ "${#T_CLI[@]}" -gt 0 ] && return 0
+  if [ -n "${T_CLI_RESOLVED:-}" ]; then
+    # shellcheck disable=SC2206
+    T_CLI=($T_CLI_RESOLVED)
+    return 0
+  fi
+  if [ -n "${E2A_CLI:-}" ]; then
+    # shellcheck disable=SC2206  # intentional word-split for multi-word overrides
+    T_CLI=($E2A_CLI)
+    if [ "${#T_CLI[@]}" -eq 0 ] || ! command -v "${T_CLI[0]}" >/dev/null 2>&1; then
+      echo "tether: E2A_CLI is set but not runnable: '${E2A_CLI}'" >&2
+      T_CLI=()
       return 127
     fi
+  elif command -v e2a >/dev/null 2>&1 && t_ver_ge "$(e2a --version 2>/dev/null)" "$TETHER_MIN_CLI"; then
+    T_CLI=(e2a)
+  elif command -v npx >/dev/null 2>&1; then
+    if command -v e2a >/dev/null 2>&1; then
+      echo "tether: global e2a CLI is older than ${TETHER_MIN_CLI} — using npx for this run (upgrade: npm i -g @e2a/cli@latest)" >&2
+    fi
+    T_CLI=(npx -y "@e2a/cli@^${TETHER_MIN_CLI}")
+  else
+    echo "tether: no e2a CLI available — install Node/npm, or set E2A_CLI" >&2
+    return 127
   fi
-  "${T_CLI[@]}" "$@"
+  export T_CLI_RESOLVED="${T_CLI[*]}"
+}
+
+# Hard deadline on every transport call (default 150s; the old curl layer used
+# -m 30/-m 120). A hung CLI/npx/DNS must never freeze an unattended session —
+# the watchdog TERMs it and the wrappers report "transient". Long-lived waits
+# (t_ws_wait) raise the bound per call to cover their window.
+t_cli() {
+  t_cli_resolve || return 127
+  local tmo="${E2A_TETHER_CLI_TIMEOUT:-150}"
+  "${T_CLI[@]}" "$@" &
+  local pid=$!
+  ( sleep "$tmo"; kill "$pid" 2>/dev/null ) >/dev/null 2>&1 &
+  local wd=$!
+  local rc=0
+  wait "$pid" || rc=$?
+  kill "$wd" 2>/dev/null
+  wait "$wd" 2>/dev/null || true
+  return "$rc"
 }
 
 # Human-readable description of what t_cli would run (for status/_selftest).
@@ -135,19 +170,31 @@ try:print(json.load(open(sys.argv[1])).get(sys.argv[2],"") or "")
 except Exception:pass' "$f" "$1"
 }
 
+# State writes are flocked read-modify-writes with an atomic rename: a
+# background `listen` and a foreground `update` share this file, so an
+# unlocked truncate-then-write would (a) let a concurrent reader see a torn/
+# empty file — whose empty conversation_id then reads as "no filter" — and
+# (b) let last-writer-wins drop the other process's mutation (a lost `seen`
+# entry re-executes an already-handled instruction).
 t_state_set() {  # t_state_set k1 v1 [k2 v2 ...]
   local f; f="$(t_state_path)"; mkdir -p "$(dirname "$f")"
-  python3 -c 'import json,sys,os
+  python3 -c 'import json,sys,os,fcntl
 f=sys.argv[1];kv=sys.argv[2:]
+lock=open(f+".lock","w"); fcntl.flock(lock,fcntl.LOCK_EX)
 d={}
 if os.path.exists(f):
   try:d=json.load(open(f))
   except Exception:d={}
 for i in range(0,len(kv),2):d[kv[i]]=kv[i+1]
-json.dump(d,open(f,"w"),indent=2)' "$f" "$@"
+tmp="%s.tmp.%d"%(f,os.getpid())
+json.dump(d,open(tmp,"w"),indent=2)
+os.replace(tmp,f)' "$f" "$@"
 }
 
-t_state_clear() { rm -f "$(t_state_path)" "$(t_ask_lock_path)"; }
+t_state_clear() {
+  local f; f="$(t_state_path)"
+  rm -f "$f" "${f}.lock" "$(t_ask_lock_path)"
+}
 
 # --- ask/listen mutex --------------------------------------------------------
 # `ask` and `listen` both poll the same inbox and share one dedup cursor, so if
@@ -160,9 +207,20 @@ t_state_clear() { rm -f "$(t_state_path)" "$(t_ask_lock_path)"; }
 # at a fixed name — a fixed name would couple ask/listen across unrelated
 # sessions that share ~/.e2a-tether/.
 t_ask_lock_path() { local f; f="$(t_state_path)"; echo "${f%.json}.ask.lock"; }
-t_ask_begin()  { local f; f="$(t_ask_lock_path)"; mkdir -p "$(dirname "$f")"; : > "$f"; }
+# The lock records the ask's PID so it can't outlive its owner: an EXIT trap
+# can't catch SIGKILL (OOM killer, force-quit), and a lock that survives its
+# process would pause the background listen FOREVER — replies silently ignored
+# in exactly the unattended session tether exists for. A lock whose PID is
+# dead is stale and gets reaped on the next check.
+t_ask_begin()  { local f; f="$(t_ask_lock_path)"; mkdir -p "$(dirname "$f")"; echo "$$" > "$f"; }
 t_ask_end()    { rm -f "$(t_ask_lock_path)"; }
-t_ask_active() { [ -f "$(t_ask_lock_path)" ]; }
+t_ask_active() {
+  local f pid; f="$(t_ask_lock_path)"; [ -f "$f" ] || return 1
+  pid="$(cat "$f" 2>/dev/null)"
+  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then return 0; fi
+  rm -f "$f"   # stale lock from a killed ask — reap so listen resumes
+  return 1
+}
 
 # --- duration / expiry -------------------------------------------------------
 
@@ -200,12 +258,18 @@ except Exception:print(2147483647)' "$exp"
 # environment t_load_config resolves — no flag plumbing needed.
 
 # t_api_send <to> <subject> <body> <conversation_id> → prints message_id;
-# returns 2 if the send was HELD so the caller can refuse to arm.
+# returns 2 if the send was HELD so the caller can refuse to arm; 4 = auth
+# failure (key revoked/invalid — callers must fail loud, not retry).
+# The body travels via --body-file: free text may legitimately start with
+# "--" (which the flag parser rejects) and may exceed argv limits.
 t_api_send() {
-  local mid rc
-  mid="$(t_cli send --to "$1" --subject "$2" --body "$3" --conversation-id "$4")"; rc=$?
+  local mid rc bf
+  bf="$(mktemp "${TMPDIR:-/tmp}/tether-body.XXXXXX")" || return 1
+  printf '%s' "$3" > "$bf"
+  mid="$(t_cli send --to "$1" --subject "$2" --body-file "$bf" --conversation-id "$4")"; rc=$?
+  rm -f "$bf"
   printf '%s' "$mid"
-  case "$rc" in 0) return 0;; 3) return 2;; *) return 1;; esac
+  case "$rc" in 0) return 0;; 3) return 2;; 4) return 4;; *) return 1;; esac
 }
 
 # Attachment cap: 15 MB of raw bytes total per send. Base64 inflates ~4/3 and
@@ -232,18 +296,25 @@ if total>maxb:
 # --html-file and derives the plain-text fallback itself when body is empty).
 # Returns: 0 sent; 2 HELD (accepted, NOT delivered — CLI exit 3); 3 anchor not
 # repliable here (CLI exit 5, permanent request error) so t_reply_anchored can
-# try the next anchor; 1 anything else (transient).
+# try the next anchor; 4 auth failure (fail loud, don't retry); 1 anything
+# else (transient).
 t_api_reply() {
   local rid="$1" body="${2:-}" htmlfile="${3:-}"
   shift 2; [ $# -gt 0 ] && shift   # remaining args = attachment file paths
-  local args=(reply "$rid")
-  [ -n "$body" ] && args+=(--body "$body")
+  local args=(reply "$rid") bf=""
+  if [ -n "$body" ]; then
+    # --body-file, not --body: free text may start with "--" or exceed argv.
+    bf="$(mktemp "${TMPDIR:-/tmp}/tether-body.XXXXXX")" || return 1
+    printf '%s' "$body" > "$bf"
+    args+=(--body-file "$bf")
+  fi
   [ -n "$htmlfile" ] && args+=(--html-file "$htmlfile")
   local f; for f in "$@"; do args+=(--attach "$f"); done
   local mid rc
   mid="$(t_cli "${args[@]}")"; rc=$?
+  [ -n "$bf" ] && rm -f "$bf"
   printf '%s' "$mid"
-  case "$rc" in 0) return 0;; 3) return 2;; 5) return 3;; *) return 1;; esac
+  case "$rc" in 0) return 0;; 3) return 2;; 4) return 4;; 5) return 3;; *) return 1;; esac
 }
 
 # t_reply_anchored <body> <html_file> [attach_file ...] → send a threaded reply,
@@ -278,7 +349,8 @@ t_api_poll() {
 }
 
 # t_api_body <message_id> → command text (parsed.text preferred; quoted history
-# stripped). Empty on transient failure — t_poll_once's age-based retry handles it.
+# stripped). Empty means the message genuinely has no text (or a transient CLI
+# failure) — t_poll_once consumes either case with a placeholder.
 t_api_body() {
   t_cli messages get "$1" --text 2>/dev/null
 }
@@ -291,10 +363,14 @@ t_api_body() {
 t_ws_wait() {
   local secs="$1" conv until rc t0
   conv="$(t_state_get conversation_id)"
+  # No conversation = stopped session or torn state — never wait unfiltered.
+  if [ -z "$conv" ]; then sleep "${E2A_TETHER_POLL_INTERVAL:-20}"; return 0; fi
   until="$(python3 -c 'import sys,datetime
 print((datetime.datetime.now(datetime.timezone.utc)+datetime.timedelta(seconds=int(sys.argv[1]))).isoformat())' "$secs")"
   t0=$SECONDS
-  t_cli listen --conversation "$conv" --once --until "$until" >/dev/null 2>&1
+  # Raise the transport deadline past this wait's own window, else the
+  # watchdog would kill a legitimate long listen.
+  E2A_TETHER_CLI_TIMEOUT=$((secs + 30)) t_cli listen --conversation "$conv" --once --until "$until" >/dev/null 2>&1
   rc=$?
   # 0 = something arrived, 6 = clean window expiry; anything else is a
   # transient WS problem (e.g. deployments without the WS endpoint). Belt and
@@ -309,19 +385,8 @@ print((datetime.datetime.now(datetime.timezone.utc)+datetime.timedelta(seconds=i
 
 # --- dedup + poll core -------------------------------------------------------
 # Replies are deduped by message-id (a `seen` set in state), NOT a bare time
-# cursor. Email parsing is async: a just-arrived reply can have an empty
-# parsed/body for a moment. We therefore do NOT mark such a message seen or
-# advance the watermark past it — we retry it next poll (up to a max age),
-# so a reply can never be silently skipped (the bug that dropped a real reply).
-
-# seconds since an RFC3339 timestamp
-t_age_seconds() {
-  python3 -c 'import sys,datetime
-try:
-  t=datetime.datetime.fromisoformat(sys.argv[1].replace("Z","+00:00"))
-  print(int((datetime.datetime.now(datetime.timezone.utc)-t).total_seconds()))
-except Exception:print(0)' "$1"
-}
+# cursor — the since boundary is inclusive with second-truncated wire
+# timestamps, so the watermark message always reappears and must be deduped.
 
 t_seen_has() {  # <id> → 0 if already processed
   local f; f="$(t_state_path)"; [ -f "$f" ] || return 1
@@ -330,10 +395,11 @@ try:sys.exit(0 if sys.argv[2] in (json.load(open(sys.argv[1])).get("seen") or []
 except Exception:sys.exit(1)' "$f" "$1"
 }
 
-t_seen_add() {  # <id> → record as processed (cap at last 500)
+t_seen_add() {  # <id> → record as processed (cap at last 500); flocked + atomic
   local f; f="$(t_state_path)"; mkdir -p "$(dirname "$f")"
-  python3 -c 'import json,sys,os
+  python3 -c 'import json,sys,os,fcntl
 f,i=sys.argv[1],sys.argv[2]
+lock=open(f+".lock","w"); fcntl.flock(lock,fcntl.LOCK_EX)
 d={}
 if os.path.exists(f):
   try:d=json.load(open(f))
@@ -341,26 +407,33 @@ if os.path.exists(f):
 s=d.get("seen") or []
 if i not in s:s.append(i)
 d["seen"]=s[-500:]
-json.dump(d,open(f,"w"),indent=2)' "$f" "$1"
+tmp="%s.tmp.%d"%(f,os.getpid())
+json.dump(d,open(tmp,"w"),indent=2)
+os.replace(tmp,f)' "$f" "$1"
 }
 
-# t_poll_once → print any new replies (dedup + parse-race safe), else "(no new replies)"
-# Advances the `last_poll` watermark only through the contiguous processed prefix,
-# stopping at the first not-yet-parsed message so it is retried, never lost.
+# t_poll_once → print any new replies (deduped), else "(no new replies)".
+# Returns 1 (transient) without touching anything when the session has no
+# conversation id — cleared state must never widen the poll to the whole
+# mailbox and deliver strangers' emails as "replies".
 t_poll_once() {
-  local conv since rows n advance id from created body age
+  local conv since rows n advance id from created body
   conv="$(t_state_get conversation_id)"; since="$(t_state_get last_poll)"
+  if [ -z "$conv" ]; then
+    echo "tether: no conversation in state (session stopped?)" >&2
+    return 1
+  fi
   rows="$(t_api_poll "$conv" "$since")" || return 1
   n=0; advance="$since"
   while IFS=$'\t' read -r id from created; do
     [ -n "$id" ] || continue
     if t_seen_has "$id"; then advance="$created"; continue; fi
     body="$(t_api_body "$id")"
-    if [ -z "$body" ]; then
-      age="$(t_age_seconds "$created")"
-      if [ "$age" -gt 120 ]; then t_seen_add "$id"; advance="$created"; continue
-      else break; fi   # not parsed yet — retry next poll, don't advance past it
-    fi
+    # Parsing is synchronous server-side (CLI contract), so an empty body is
+    # real content absence — an attachment-only or fully-quoted reply — not a
+    # race to retry. Consume it WITH a placeholder: the old retry-then-drop
+    # window silently lost such replies (and could hot-loop the WS wake).
+    [ -n "$body" ] || body="[no text content — attachment-only or fully-quoted reply; message ${id}]"
     t_seen_add "$id"; advance="$created"; n=$((n+1))
     printf '── reply from %s @ %s ──\n%s\n\n' "$from" "$created" "$body"
     # last_inbound_id is the always-repliable fallback anchor for

--- a/plugins/e2a/skills/tether/lib.sh
+++ b/plugins/e2a/skills/tether/lib.sh
@@ -99,8 +99,34 @@ t_cli_desc() {
 }
 
 # --- state -------------------------------------------------------------------
+# One tether = one session = one state file. The default path is keyed by the
+# repo (git toplevel, else cwd) so concurrent tethered sessions in DIFFERENT
+# repos can't clobber each other's thread pointer, watermark, seen-set, or
+# ask-lock. Two sessions in the SAME repo still resolve to one key — `start`
+# refuses to arm over a live session (loud, instead of silently hijacking its
+# thread); set TETHER_STATE to a unique path to run them in parallel anyway.
+# A legacy machine-global state.json (pre-keying) is honored while it exists,
+# so a live tether isn't orphaned by a plugin update; it disappears at `stop`.
 
-t_state_path() { echo "${TETHER_STATE:-$HOME/.e2a-tether/state.json}"; }
+t_state_key() {
+  local root
+  root="$(git rev-parse --show-toplevel 2>/dev/null)" || root="$PWD"
+  python3 -c 'import hashlib,sys;print(hashlib.sha1(sys.argv[1].encode()).hexdigest()[:12])' "$root"
+}
+
+T_STATE_PATH=""   # memoized: t_state_path runs in every poll tick
+t_state_path() {
+  if [ -z "$T_STATE_PATH" ]; then
+    if [ -n "${TETHER_STATE:-}" ]; then
+      T_STATE_PATH="$TETHER_STATE"
+    elif [ -f "$HOME/.e2a-tether/state.json" ]; then
+      T_STATE_PATH="$HOME/.e2a-tether/state.json"
+    else
+      T_STATE_PATH="$HOME/.e2a-tether/state-$(t_state_key).json"
+    fi
+  fi
+  echo "$T_STATE_PATH"
+}
 
 t_state_get() {
   local f; f="$(t_state_path)"; [ -f "$f" ] || return 0
@@ -130,7 +156,10 @@ t_state_clear() { rm -f "$(t_state_path)" "$(t_ask_lock_path)"; }
 # While an `ask` is in flight it holds this lock; `listen` sees it and pauses
 # polling so the answer flows to the blocked `ask`.
 
-t_ask_lock_path() { echo "$(dirname "$(t_state_path)")/ask.lock"; }
+# The lock lives NEXT TO its session's state file (state-<key>.ask.lock), not
+# at a fixed name — a fixed name would couple ask/listen across unrelated
+# sessions that share ~/.e2a-tether/.
+t_ask_lock_path() { local f; f="$(t_state_path)"; echo "${f%.json}.ask.lock"; }
 t_ask_begin()  { local f; f="$(t_ask_lock_path)"; mkdir -p "$(dirname "$f")"; : > "$f"; }
 t_ask_end()    { rm -f "$(t_ask_lock_path)"; }
 t_ask_active() { [ -f "$(t_ask_lock_path)" ]; }

--- a/plugins/e2a/skills/tether/tether.env.example
+++ b/plugins/e2a/skills/tether/tether.env.example
@@ -8,7 +8,9 @@ export E2A_AGENT_EMAIL="tether@you.example"   # the sending/receiving agent (pro
 
 # Optional
 export E2A_BASE_URL="https://api.e2a.dev"       # self-host: your API base
-export E2A_TETHER_POLL_INTERVAL="20"            # seconds between inbox checks (listen/ask)
+export E2A_TETHER_POLL_INTERVAL="20"            # fallback poll cadence (WS wait is primary)
 export E2A_TETHER_ASK_TIMEOUT="1800"            # seconds `ask` blocks for an answer
+# export E2A_CLI="node /path/to/cli/dist/bin/e2a.js"  # override the e2a CLI (default: PATH, then npx)
 # Fallback: if these are unset, tether reads ~/.e2a/config.json from `e2a login`
-# (an account-scoped key — broader than tether needs; prefer the agent key above).
+# (after `e2a login --agent <inbox>` that's already a least-privilege agent key).
+# Prefer `tether.sh setup` over hand-editing this file.

--- a/plugins/e2a/skills/tether/tether.sh
+++ b/plugins/e2a/skills/tether/tether.sh
@@ -1,20 +1,22 @@
 #!/usr/bin/env bash
 # tether.sh — the runtime CLI the agent calls to stay in touch over email.
 #
+#   tether.sh setup [--email <addr>] [--new]   zero-to-tethered bootstrap (needs `e2a login`)
 #   tether.sh start <email> [--title "<work>"] [--for 2h|8h|30m|1d] [--until <ISO>]  open + arm
 #   tether.sh update "<message>"   send a threaded update ("as you see fit")
 #   tether.sh update --html <file> send an HTML update (+ auto text fallback)
 #   tether.sh update --attach <f>  attach a file (repeatable; 15 MB total cap)
 #   tether.sh ask "<question>" [--attach <f>]...  email a question and BLOCK until the reply
-#   tether.sh listen [--awake]     poll until a reply OR the window ends (bg it)
+#   tether.sh listen [--awake]     wait until a reply OR the window ends (bg it)
 #   tether.sh poll                 print any new replies since last poll (exit 0)
 #   tether.sh status               show tether state
 #   tether.sh stop                 disarm and clear state
 #   tether.sh _selftest            unconfigured dry-run + syntax check
 #
+# Transport is the e2a CLI (see lib.sh t_cli — $E2A_CLI / PATH / npx).
 # Sending is agent-driven: call `update` when there's something worth reporting.
-# Receiving is poll-driven: call `poll` on an interval (keep the session alive
-# with /loop) so replies sent while idle are still picked up.
+# Receiving is real-time: `listen`/`ask` wait on the CLI's WebSocket
+# (`e2a listen --once`) and fall back to interval polling if the WS misbehaves.
 set -uo pipefail
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib.sh
@@ -86,24 +88,22 @@ question or instruction; reply \"stop\" to end early.
         *) msg="$1"; shift;;
       esac
     done
-    html=""
     if [ -n "$htmlfile" ]; then
       [ -f "$htmlfile" ] || { echo "tether: --html file not found: $htmlfile"; exit 2; }
-      html="$(cat "$htmlfile")"
-      # plain-text fallback: explicit --text/positional, else derived from the HTML
+      # plain-text fallback: explicit --text/positional wins; otherwise the CLI
+      # derives one from the HTML file itself (no --body passed).
       [ -n "$msg" ] || msg="$textarg"
-      [ -n "$msg" ] || msg="$(printf '%s' "$html" | t_html_to_text)"
     fi
-    [ -n "$msg" ] || { echo "usage: tether.sh update \"<text>\"  |  update --html <file> [--text \"<fallback>\"]  (either form: [--attach <file>]...)"; exit 2; }
+    { [ -n "$msg" ] || [ -n "$htmlfile" ]; } || { echo "usage: tether.sh update \"<text>\"  |  update --html <file> [--text \"<fallback>\"]  (either form: [--attach <file>]...)"; exit 2; }
     if [ "${#attach[@]}" -gt 0 ]; then t_attach_check "${attach[@]}" || exit $?; fi
-    mid="$(t_reply_anchored "$msg" "$html" ${attach[@]+"${attach[@]}"})"; rc=$?
+    mid="$(t_reply_anchored "$msg" "$htmlfile" ${attach[@]+"${attach[@]}"})"; rc=$?
     if [ -z "$mid" ]; then echo "tether: update send failed"; exit 1; fi
     t_state_set last_message_id "$mid"
     if [ "$rc" = "2" ]; then
       echo "tether: WARNING update HELD for review (pending_review) — it did NOT reach the user. Disable send-side protection on ${E2A_AGENT_EMAIL}."
       exit 2
     fi
-    echo "tether: update sent (${mid})$([ -n "$html" ] && echo ' [html]')$([ "${#attach[@]}" -gt 0 ] && echo " [${#attach[@]} attachment(s)]")"
+    echo "tether: update sent (${mid})$([ -n "$htmlfile" ] && echo ' [html]')$([ "${#attach[@]}" -gt 0 ] && echo " [${#attach[@]} attachment(s)]")"
     ;;
 
   poll)
@@ -112,10 +112,13 @@ question or instruction; reply \"stop\" to end early.
     ;;
 
   listen)
-    # Deadline-bounded poller. Polls until a reply (prints REPLY_RECEIVED + exits)
-    # or until the window (expires_at) ends (prints TETHER_EXPIRED + exits). Run
-    # it in the BACKGROUND: on a reply-exit, act then relaunch for the remaining
-    # window; on TETHER_EXPIRED, run `stop`. Cheap (curl only, no tokens).
+    # Deadline-bounded waiter. Waits until a reply (prints REPLY_RECEIVED +
+    # exits) or until the window (expires_at) ends (prints TETHER_EXPIRED +
+    # exits). Run it in the BACKGROUND: on a reply-exit, act then relaunch for
+    # the remaining window; on TETHER_EXPIRED, run `stop`. Real-time: waits on
+    # the CLI's WebSocket (t_ws_wait) as the wake signal, then consumes via the
+    # dedup-safe poll — so pickup latency is seconds, not the poll interval,
+    # while the seen-set/parse-retry invariants stay intact.
     #   --awake  keep the machine from IDLE-sleeping while listening (macOS
     #            caffeinate; released when listen exits). Does NOT survive the
     #            lid closing.
@@ -134,19 +137,26 @@ question or instruction; reply \"stop\" to end early.
     while :; do
       rem="$(t_remaining_seconds)"
       if [ "$rem" -le 0 ]; then echo "TETHER_EXPIRED"; exit 0; fi
-      # An `ask` is blocking on the same inbox — don't poll, or we'd consume the
+      # An `ask` is blocking on the same inbox — don't consume, or we'd eat the
       # answer it's waiting for. Idle until the ask releases the lock.
       if t_ask_active; then
         s="$interval"; [ "$rem" -lt "$s" ] && s="$rem"; sleep "$s"; continue
       fi
+      # Poll FIRST (catches anything that arrived while we weren't waiting),
+      # then block on the WS wake signal for one poll-interval chunk. Chunking
+      # at the interval means: WS healthy → replies wake us in seconds; WS
+      # unavailable (e.g. deployment without the endpoint — the CLI retries
+      # inside the window and exits 6) → cadence degrades to exactly the old
+      # 20s polling, never worse. Expiry and the ask-lock are re-checked
+      # between chunks.
       out="$(t_poll_once)" || out=""
-      # Empty out = a transient poll failure (curl blip), NOT a reply — without
-      # this guard it exits REPLY_RECEIVED with nothing, killing the listen.
+      # Empty out = a transient failure, NOT a reply — without this guard it
+      # exits REPLY_RECEIVED with nothing, killing the listen.
       if [ -n "$out" ] && [ "$out" != "(no new replies)" ]; then
         echo "REPLY_RECEIVED:"; echo "$out"; exit 0
       fi
-      s="$interval"; [ "$rem" -lt "$s" ] && s="$rem"
-      sleep "$s"
+      w="$interval"; [ "$rem" -lt "$w" ] && w="$rem"
+      t_ws_wait "$w"
     done
     ;;
 
@@ -179,18 +189,93 @@ question or instruction; reply \"stop\" to end early.
       exit 4
     fi
     echo "tether: question sent (${mid}); waiting for your reply…"
-    max="${E2A_TETHER_ASK_TIMEOUT:-1800}"; interval="${E2A_TETHER_POLL_INTERVAL:-20}"; elapsed=0
-    while [ "$elapsed" -lt "$max" ]; do
-      sleep "$interval"; elapsed=$((elapsed + interval))
+    max="${E2A_TETHER_ASK_TIMEOUT:-1800}"; interval="${E2A_TETHER_POLL_INTERVAL:-20}"; start=$SECONDS
+    while [ $((SECONDS - start)) -lt "$max" ]; do
       out="$(t_poll_once)" || out=""
       # Empty out = transient poll failure, not an answer (same guard as listen).
       if [ -n "$out" ] && [ "$out" != "(no new replies)" ]; then echo "$out"; exit 0; fi
+      # Real-time: block on the WS wake signal in poll-interval chunks (same
+      # degradation logic as listen), then re-poll.
+      rem2=$((max - (SECONDS - start))); w="$interval"; [ "$rem2" -lt "$w" ] && w="$rem2"
+      [ "$w" -gt 0 ] && t_ws_wait "$w"
     done
     echo "tether: ask timed out after ${max}s with no answer"; exit 3
     ;;
 
+  setup)
+    # Zero-to-tethered bootstrap on the e2a CLI. Needs an ACCOUNT credential in
+    # the CLI's own config (`e2a login`, or `e2a login --with-key` headless).
+    # Golden path: whoami → ensure inbox (verify/create) → outbound review off
+    # → mint a least-privilege agent key → write ~/.e2a-tether.env. Every step
+    # fails HARD: no protection clobber (the CLI never PUTs after a failed
+    # read), no silent account-key fallback, no "ready" with a broken config.
+    #   --email <addr>  use/create this inbox (bare names expand on the shared domain)
+    #   --new           always create a fresh tether-<rand> inbox
+    force_new=0; want=""
+    while [ $# -gt 0 ]; do case "$1" in --new) force_new=1; shift;; --email) want="${2:-}"; shift 2;; *) shift;; esac; done
+    # Setup deliberately uses the CLI's own stored credential, not whatever a
+    # previous tether run left in the environment.
+    unset E2A_API_KEY E2A_AGENT_EMAIL
+    who="$(t_cli whoami --json 2>/dev/null)" || { echo "tether setup: no usable credential — run 'e2a login' (browser) or 'e2a login --with-key' first, then re-run setup"; exit 1; }
+    scope="$(printf '%s' "$who" | python3 -c 'import json,sys
+try:print(json.load(sys.stdin).get("scope",""))
+except Exception:print("")')"
+    if [ "$scope" = "agent" ]; then
+      bound="$(printf '%s' "$who" | python3 -c 'import json,sys
+try:print(json.load(sys.stdin).get("agentAddress",""))
+except Exception:print("")')"
+      echo "tether setup: the CLI already holds an agent-scoped key (${bound}) — nothing to do."
+      echo "              tether will pick it up from ~/.e2a/config.json; run 'tether.sh status' to confirm."
+      exit 0
+    fi
+    [ "$scope" = "account" ] || { echo "tether setup: could not determine key scope (e2a whoami failed?) — check 'e2a whoami'"; exit 1; }
+    inbox="$want"
+    if [ -z "$inbox" ] && [ "$force_new" = "0" ]; then
+      # Reuse ONLY tether-owned inboxes; never silently adopt (and reconfigure)
+      # someone's production agent just because it's the account's only one.
+      inbox="$(t_cli agents list 2>/dev/null | awk -F'\t' '$1 ~ /^tether-/ {print $1; exit}')"
+      [ -n "$inbox" ] && echo "tether setup: reusing ${inbox}"
+    fi
+    if [ -n "$inbox" ] && [ "${inbox#*@}" = "$inbox" ]; then
+      sd="$(t_cli config get shared_domain 2>/dev/null)"
+      [ -n "$sd" ] || { echo "tether setup: can't expand bare name '${inbox}' — no shared domain known; pass a full address"; exit 1; }
+      inbox="${inbox}@${sd}"
+    fi
+    if [ -z "$inbox" ]; then
+      sd="$(t_cli config get shared_domain 2>/dev/null)"
+      [ -n "$sd" ] || { echo "tether setup: no shared domain on this deployment — pass --email you@yourdomain"; exit 1; }
+      inbox="tether-$(python3 -c 'import secrets;print(secrets.token_hex(3))')@${sd}"
+    fi
+    if ! t_cli agents get "$inbox" >/dev/null 2>&1; then
+      echo "tether setup: creating ${inbox}…"
+      t_cli agents create "$inbox" --name "tether" >/dev/null || { echo "tether setup: agent create failed (slug taken/invalid?)"; exit 1; }
+    fi
+    case "$inbox" in
+      tether-*@*) : ;;
+      *) [ -n "$want" ] || { echo "tether setup: refusing to reconfigure non-tether inbox ${inbox} without an explicit --email"; exit 1; }
+         echo "tether setup: NOTE disabling OUTBOUND review on ${inbox} (explicitly requested via --email)";;
+    esac
+    t_cli protection set "$inbox" --outbound-review off >/dev/null || { echo "tether setup: could not disable outbound review — aborting, nothing written"; exit 1; }
+    echo "tether setup: outbound review off on ${inbox}"
+    agtkey="$(t_cli keys create --agent "$inbox" --name "tether-$(python3 -c 'import secrets;print(secrets.token_hex(2))')" 2>/dev/null)"
+    [ -n "$agtkey" ] || { echo "tether setup: could not mint an agent-scoped key — aborting (NOT storing the broad account key)"; exit 1; }
+    envf="${HOME}/.e2a-tether.env"
+    [ -f "$envf" ] && cp "$envf" "${envf}.bak"
+    { echo "# written by tether.sh setup — $(t_now_iso)"
+      echo "export E2A_API_KEY=\"${agtkey}\""
+      echo "export E2A_AGENT_EMAIL=\"${inbox}\""
+      [ -n "${E2A_BASE_URL:-}" ] && echo "export E2A_BASE_URL=\"${E2A_BASE_URL}\""
+    } > "$envf"
+    chmod 600 "$envf" 2>/dev/null || true
+    echo "tether setup: wrote ${envf} (agent-scoped key, least privilege)$([ -f "${envf}.bak" ] && echo " — previous file kept as .bak")"
+    export E2A_API_KEY="$agtkey" E2A_AGENT_EMAIL="$inbox"
+    bash "${here}/tether.sh" status
+    echo "tether setup: ready → tether.sh start <your-email> --title \"<work>\" --for 30m"
+    ;;
+
   status)
     if t_load_config; then echo "config: OK (agent ${E2A_AGENT_EMAIL}, base ${E2A_BASE_URL})"; else echo "config: MISSING"; fi
+    echo "cli:    $(t_cli_desc)"
     if [ "$(t_state_get armed)" = "1" ]; then
       echo "armed:  yes"
       echo "thread: $(t_state_get conversation_id) → $(t_state_get to)"
@@ -243,25 +328,19 @@ question or instruction; reply \"stop\" to end early.
       echo "ok: ask lock begin/active/end" ) || fail=1
     rm -f /tmp/tether-selftest-lock.json /tmp/ask.lock
 
+    echo "# CLI resolution:"
+    ck "version compare: 1.6.2 >= 1.6.0" "$(t_ver_ge "e2a 1.6.2" "1.6.0" && echo yes)" "yes"
+    ck "version compare: 1.5.9 <  1.6.0" "$(t_ver_ge "e2a 1.5.9" "1.6.0" || echo no)" "no"
+    ck "E2A_CLI override is honored" "$(E2A_CLI="/bin/echo e2a-override" bash -c '. "'"${here}"'/lib.sh"; t_cli ping' 2>/dev/null)" "e2a-override ping"
+
     echo "# attachments:"
     af=/tmp/tether-selftest-att.txt; printf 'hello attachment' > "$af"
-    pj=/tmp/tether-selftest-payload.json
-    t_reply_payload "$pj" "the body" "" "$af" || { echo "FAIL: payload build errored"; fail=1; }
-    ck "payload: body + encoded attachment" "$(python3 -c 'import json,base64
-d=json.load(open("/tmp/tether-selftest-payload.json"));a=d["attachments"][0]
-print(d["body"]=="the body" and "html_body" not in d
-      and a["filename"]=="tether-selftest-att.txt" and a["content_type"]=="text/plain"
-      and base64.b64decode(a["data"]).decode()=="hello attachment")')" "True"
-    t_reply_payload "$pj" "b" "<b>h</b>" || { echo "FAIL: no-attachment payload errored"; fail=1; }
-    ck "payload: no files → no attachments key" "$(python3 -c 'import json
-d=json.load(open("/tmp/tether-selftest-payload.json"))
-print("attachments" not in d and d["html_body"]=="<b>h</b>")')" "True"
     t_attach_check "$af" || { echo "FAIL: attach check on a real file"; fail=1; }
     t_attach_check /nonexistent-tether-file 2>/dev/null; ck "missing file → exit 3" "$?" "3"
     big=/tmp/tether-selftest-big.bin
     python3 -c 'f=open("/tmp/tether-selftest-big.bin","wb");f.seek(16*1024*1024-1);f.write(b"\0")'
     t_attach_check "$big" 2>/dev/null; ck "16 MB → exit 4 (over cap)" "$?" "4"
-    rm -f "$af" "$pj" "$big"
+    rm -f "$af" "$big"
 
     bash -n "${here}/lib.sh" && bash -n "${here}/tether.sh" && echo "# syntax OK"
     [ "$fail" = "0" ] && echo "# selftest PASS" || { echo "# selftest FAIL"; exit 1; }
@@ -271,5 +350,5 @@ print("attachments" not in d and d["html_body"]=="<b>h</b>")')" "True"
     grep '^#' "${here}/tether.sh" | sed 's/^# \{0,1\}//' | sed -n '2,20p'
     ;;
 
-  *) echo "tether: unknown command '$cmd' (try: start|update|poll|status|stop)"; exit 2;;
+  *) echo "tether: unknown command '$cmd' (try: setup|start|update|ask|listen|poll|status|stop)"; exit 2;;
 esac

--- a/plugins/e2a/skills/tether/tether.sh
+++ b/plugins/e2a/skills/tether/tether.sh
@@ -62,6 +62,9 @@ case "$cmd" in
     # make it say what the session is DOING, not just where it's running.
     subject="Tether: ${proj}"
     [ -n "$title" ] && subject="Tether: ${proj} — ${title}"
+    # Untitled sessions all share one subject; several of them in an inbox are
+    # indistinguishable (and read like Gmail split one thread). Nudge, loudly.
+    [ -n "$title" ] || echo "tether: NOTE no --title — every untitled session in this repo shares the subject \"${subject}\"; pass --title \"<work>\" so threads are tellable apart" >&2
     intro="🪢 Tethered — ${proj}${title:+ — ${title}}
 
 This session is now tethered (${window}). I'll send updates to this thread as I

--- a/plugins/e2a/skills/tether/tether.sh
+++ b/plugins/e2a/skills/tether/tether.sh
@@ -25,18 +25,30 @@ here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cmd="${1:-}"; shift || true
 
 need_config() { t_load_config || { echo "tether: not configured (need E2A_API_KEY + E2A_AGENT_EMAIL; see tether.env.example)"; exit 1; }; }
-need_armed()  { [ "$(t_state_get armed)" = "1" ] || { echo "tether: not started — run 'tether.sh start <email>' first"; exit 1; }; }
+need_armed()  { [ "$(t_state_get armed)" = "1" ] || { echo "tether: not started — run 'tether.sh start <email> --title \"<work>\"' first"; exit 1; }; }
+
+# Warn a prefix-less call when this repo has parallel sessions: without the
+# TETHER_STATE handle it resolves to the PRIMARY session's state, and a
+# misdirected update would post into the wrong thread reporting success.
+warn_peers() {
+  if [ -z "${TETHER_STATE:-}" ] && [ "$(t_state_get parallel_peers)" = "1" ]; then
+    echo "tether: NOTE parallel sessions exist in this repo — this call uses the PRIMARY session's state; prefix TETHER_STATE=\"…\" if you meant a parallel session" >&2
+  fi
+}
 
 case "$cmd" in
   start)
     # start <email> [--title "<work>"] [--for 30m|2h|8h|1d] [--until <ISO>]
     need_config
     to=""; forarg=""; untilarg=""; title=""; parallel=0
+    # `shift 2` with only the flag left is a NO-OP in bash (returns 1, shifts
+    # nothing) — without the `|| exit` guard a trailing valueless flag spins
+    # this loop forever, silently hanging an unattended session.
     while [ $# -gt 0 ]; do
       case "$1" in
-        --title) title="${2:-}"; shift 2;;
-        --for) forarg="${2:-}"; shift 2;;
-        --until) untilarg="${2:-}"; shift 2;;
+        --title) title="${2:-}"; shift 2 || { echo "tether: --title requires a value"; exit 2; };;
+        --for) forarg="${2:-}"; shift 2 || { echo "tether: --for requires a value"; exit 2; };;
+        --until) untilarg="${2:-}"; shift 2 || { echo "tether: --until requires a value"; exit 2; };;
         --parallel) parallel=1; shift;;
         *) to="$1"; shift;;
       esac
@@ -50,28 +62,42 @@ case "$cmd" in
       echo "        Title the WORK, not the first step (e.g. --title \"fix webhook retries\")."
       exit 2
     fi
+    # A deliberate parallel session self-keys BEFORE the armed check — it never
+    # competes for the default state file at all ("--parallel = my own state
+    # file", whether or not a primary is armed yet). The session MUST prefix
+    # every subsequent tether call with the printed TETHER_STATE.
+    if [ "$parallel" = "1" ] && [ -z "${TETHER_STATE:-}" ]; then
+      default_state="$(t_state_path)"
+      export TETHER_STATE="$HOME/.e2a-tether/state-$(t_state_key)-$(date +%s)-$$.json"
+      T_STATE_PATH="$TETHER_STATE"
+      echo "tether: parallel session — prefix EVERY subsequent tether.sh call with:"
+      echo "        TETHER_STATE=\"${TETHER_STATE}\""
+      # Mark the primary's state (subshell: the env prefix must not leak into
+      # OUR exported TETHER_STATE) so its prefix-less commands can warn about
+      # the forgotten-handle trap.
+      ( TETHER_STATE="$default_state"; T_STATE_PATH=""; t_state_set parallel_peers 1 ) 2>/dev/null || true
+    fi
     # Never arm over a live session: that would hijack its thread pointer and
     # watermark (each session must keep its own dedicated email thread).
     if [ "$(t_state_get armed)" = "1" ]; then
-      if [ "$parallel" = "1" ] && [ -z "${TETHER_STATE:-}" ]; then
-        # Same-repo parallel session: self-key a fresh state file and hand the
-        # caller its handle. The session MUST prefix every subsequent tether
-        # call with this TETHER_STATE — without it, commands resolve to the
-        # other session's state.
-        export TETHER_STATE="$HOME/.e2a-tether/state-$(t_state_key)-$(date +%s)-$$.json"
-        T_STATE_PATH="$TETHER_STATE"
-        echo "tether: parallel session — prefix EVERY subsequent tether.sh call with:"
-        echo "        TETHER_STATE=\"${TETHER_STATE}\""
-      else
-        echo "tether: already armed — thread $(t_state_get conversation_id) → $(t_state_get to)."
-        echo "        Run 'tether.sh stop' to end it first, or re-run start with --parallel"
-        echo "        to open a second session in this repo (you'll get a TETHER_STATE"
-        echo "        handle to carry on every subsequent call)."
-        exit 1
+      echo "tether: already armed — thread $(t_state_get conversation_id) → $(t_state_get to)."
+      if [ "$(t_state_path)" = "$HOME/.e2a-tether/state.json" ]; then
+        echo "        (state is the legacy machine-global file — the live session may be in ANOTHER repo)"
       fi
+      echo "        Run 'tether.sh stop' to end it first, or re-run start with --parallel"
+      echo "        to open a second session (you'll get a TETHER_STATE handle to carry"
+      echo "        on every subsequent call)."
+      exit 1
     fi
     expires=""
-    if [ -n "$untilarg" ]; then expires="$untilarg"
+    if [ -n "$untilarg" ]; then
+      # Validate like --for: an unparseable expiry reads as the no-expiry
+      # sentinel downstream, silently turning the asked-for window UNBOUNDED.
+      expires="$(python3 -c 'import sys,datetime
+try:
+  datetime.datetime.fromisoformat(sys.argv[1].replace("Z","+00:00")); print(sys.argv[1])
+except Exception: print("INVALID")' "$untilarg")"
+      [ "$expires" = "INVALID" ] && { echo "tether: can't parse --until '$untilarg' — use RFC3339, e.g. 2026-07-02T18:00:00Z"; exit 2; }
     elif [ -n "$forarg" ]; then
       expires="$(t_duration_to_expiry "$forarg")"
       [ "$expires" = "INVALID" ] && { echo "tether: can't parse --for '$forarg' — use a single unit (30m, 2h, 8h, 1d). Omit --for for no time limit."; exit 2; }
@@ -90,10 +116,15 @@ question or instruction; reply \"stop\" to end early.
 
 — your coding agent"
     mid="$(t_api_send "$to" "$subject" "$intro" "$conv")"; rc=$?
+    if [ "$rc" = "4" ]; then
+      echo "tether: intro NOT sent — auth failed (key invalid/revoked). Check 'e2a whoami' / E2A_API_KEY."
+      exit 4
+    fi
     [ -n "$mid" ] || { echo "tether: intro send failed (check creds / base url / agent protection)"; exit 1; }
     if [ "$rc" = "2" ]; then
       echo "tether: intro was HELD for review (pending_review) — the user won't receive it, so NOT arming."
-      echo "        Turn send-side protection/HITL OFF on ${E2A_AGENT_EMAIL}, then run start again."
+      echo "        Fix: e2a protection set ${E2A_AGENT_EMAIL} --outbound-review off"
+      echo "        (needs the account-scoped 'e2a login' credential, or use the dashboard) — then run start again."
       exit 1
     fi
     t_state_set armed 1 to "$to" conversation_id "$conv" last_message_id "$mid" \
@@ -106,13 +137,13 @@ question or instruction; reply \"stop\" to end early.
     # update "<text>"                       plain-text update
     # update --html <file> [--text "<t>"]   HTML update (+ optional text fallback)
     # either form: [--attach <file>]...     attach files (repeatable)
-    need_config; need_armed
+    need_config; need_armed; warn_peers
     htmlfile=""; textarg=""; msg=""; attach=()
     while [ $# -gt 0 ]; do
       case "$1" in
-        --html) htmlfile="${2:-}"; shift 2;;
-        --text) textarg="${2:-}"; shift 2;;
-        --attach) attach+=("${2:-}"); shift 2;;
+        --html) htmlfile="${2:-}"; shift 2 || { echo "tether: --html requires a value"; exit 2; };;
+        --text) textarg="${2:-}"; shift 2 || { echo "tether: --text requires a value"; exit 2; };;
+        --attach) attach+=("${2:-}"); shift 2 || { echo "tether: --attach requires a value"; exit 2; };;
         *) msg="$1"; shift;;
       esac
     done
@@ -125,13 +156,22 @@ question or instruction; reply \"stop\" to end early.
     { [ -n "$msg" ] || [ -n "$htmlfile" ]; } || { echo "usage: tether.sh update \"<text>\"  |  update --html <file> [--text \"<fallback>\"]  (either form: [--attach <file>]...)"; exit 2; }
     if [ "${#attach[@]}" -gt 0 ]; then t_attach_check "${attach[@]}" || exit $?; fi
     mid="$(t_reply_anchored "$msg" "$htmlfile" ${attach[@]+"${attach[@]}"})"; rc=$?
-    if [ -z "$mid" ]; then echo "tether: update send failed"; exit 1; fi
+    if [ "$rc" = "4" ]; then
+      echo "tether: update NOT sent — auth failed (key invalid/revoked). Check 'e2a whoami' / E2A_API_KEY."
+      exit 4
+    fi
+    if [ -z "$mid" ]; then
+      echo "tether: update send failed (if anchors are exhausted, 'tether.sh stop' and start a fresh session)"
+      exit 1
+    fi
     t_state_set last_message_id "$mid"
     if [ "$rc" = "2" ]; then
       echo "tether: WARNING update HELD for review (pending_review) — it did NOT reach the user. Disable send-side protection on ${E2A_AGENT_EMAIL}."
       exit 2
     fi
-    echo "tether: update sent (${mid})$([ -n "$htmlfile" ] && echo ' [html]')$([ "${#attach[@]}" -gt 0 ] && echo " [${#attach[@]} attachment(s)]")"
+    # The thread id in the success line makes cross-session misdirection
+    # OBSERVABLE (a --parallel session that forgot its TETHER_STATE prefix).
+    echo "tether: update sent (${mid}) [thread $(t_state_get conversation_id)]$([ -n "$htmlfile" ] && echo ' [html]')$([ "${#attach[@]}" -gt 0 ] && echo " [${#attach[@]} attachment(s)]")"
     ;;
 
   poll)
@@ -150,7 +190,7 @@ question or instruction; reply \"stop\" to end early.
     #   --awake  keep the machine from IDLE-sleeping while listening (macOS
     #            caffeinate; released when listen exits). Does NOT survive the
     #            lid closing.
-    need_config; need_armed
+    need_config; need_armed; warn_peers
     awake=0
     while [ $# -gt 0 ]; do case "$1" in --awake) awake=1; shift;; *) shift;; esac; done
     if [ "$awake" = "1" ]; then
@@ -163,6 +203,10 @@ question or instruction; reply \"stop\" to end early.
     fi
     interval="${E2A_TETHER_POLL_INTERVAL:-20}"
     while :; do
+      # `stop` (this session's or a takeover) may have cleared the state while
+      # we waited — a disarmed listen must END, never fall through to polling
+      # a cleared state (whose empty conversation would read as "no filter").
+      [ "$(t_state_get armed)" = "1" ] || { echo "TETHER_EXPIRED"; exit 0; }
       rem="$(t_remaining_seconds)"
       if [ "$rem" -le 0 ]; then echo "TETHER_EXPIRED"; exit 0; fi
       # An `ask` is blocking on the same inbox — don't consume, or we'd eat the
@@ -193,11 +237,11 @@ question or instruction; reply \"stop\" to end early.
     # print the answer. This is how a tethered agent asks the user anything —
     # over email, never a terminal prompt the AFK user can't see. Run it in the
     # background and wait for the completion notification.
-    need_config; need_armed
+    need_config; need_armed; warn_peers
     q=""; attach=()
     while [ $# -gt 0 ]; do
       case "$1" in
-        --attach) attach+=("${2:-}"); shift 2;;
+        --attach) attach+=("${2:-}"); shift 2 || { echo "tether: --attach requires a value"; exit 2; };;
         *) q="$1"; shift;;
       esac
     done
@@ -210,6 +254,10 @@ question or instruction; reply \"stop\" to end early.
     mid="$(t_reply_anchored "❓ ${q}
 
 (Reply to this email with your answer — I'll wait for it.)" "" ${attach[@]+"${attach[@]}"})"; rc=$?
+    if [ "$rc" = "4" ]; then
+      echo "tether: ask NOT sent — auth failed (key invalid/revoked). Check 'e2a whoami' / E2A_API_KEY."
+      exit 1
+    fi
     [ -n "$mid" ] || { echo "tether: ask send failed"; exit 1; }
     t_state_set last_message_id "$mid"
     if [ "$rc" = "2" ]; then
@@ -219,6 +267,8 @@ question or instruction; reply \"stop\" to end early.
     echo "tether: question sent (${mid}); waiting for your reply…"
     max="${E2A_TETHER_ASK_TIMEOUT:-1800}"; interval="${E2A_TETHER_POLL_INTERVAL:-20}"; start=$SECONDS
     while [ $((SECONDS - start)) -lt "$max" ]; do
+      # Session stopped while we waited → the question is moot; end cleanly.
+      [ "$(t_state_get armed)" = "1" ] || { echo "tether: session stopped while waiting for the answer"; exit 3; }
       out="$(t_poll_once)" || out=""
       # Empty out = transient poll failure, not an answer (same guard as listen).
       if [ -n "$out" ] && [ "$out" != "(no new replies)" ]; then echo "$out"; exit 0; fi
@@ -240,11 +290,22 @@ question or instruction; reply \"stop\" to end early.
     #   --email <addr>  use/create this inbox (bare names expand on the shared domain)
     #   --new           always create a fresh tether-<rand> inbox
     force_new=0; want=""
-    while [ $# -gt 0 ]; do case "$1" in --new) force_new=1; shift;; --email) want="${2:-}"; shift 2;; *) shift;; esac; done
+    while [ $# -gt 0 ]; do case "$1" in --new) force_new=1; shift;; --email) want="${2:-}"; shift 2 || { echo "tether: --email requires a value"; exit 2; };; *) shift;; esac; done
     # Setup deliberately uses the CLI's own stored credential, not whatever a
     # previous tether run left in the environment.
     unset E2A_API_KEY E2A_AGENT_EMAIL
-    who="$(t_cli whoami --json 2>/dev/null)" || { echo "tether setup: no usable credential — run 'e2a login' (browser) or 'e2a login --with-key' first, then re-run setup"; exit 1; }
+    # Keep the probe's stderr: "npm can't find the CLI" and "not logged in"
+    # need OPPOSITE fixes, and swallowing the error misdiagnosed both as a
+    # credential problem.
+    errf="$(mktemp "${TMPDIR:-/tmp}/tether-setup-err.XXXXXX")"
+    if ! who="$(t_cli whoami --json 2>"$errf")"; then
+      echo "tether setup: the e2a CLI is unavailable or not logged in:"
+      sed 's/^/        /' "$errf" | tail -5
+      rm -f "$errf"
+      echo "        Fix: run 'e2a login' (browser) or 'e2a login --with-key' (headless), then re-run setup."
+      exit 1
+    fi
+    rm -f "$errf"
     scope="$(printf '%s' "$who" | python3 -c 'import json,sys
 try:print(json.load(sys.stdin).get("scope",""))
 except Exception:print("")')"
@@ -252,8 +313,11 @@ except Exception:print("")')"
       bound="$(printf '%s' "$who" | python3 -c 'import json,sys
 try:print(json.load(sys.stdin).get("agentAddress",""))
 except Exception:print("")')"
-      echo "tether setup: the CLI already holds an agent-scoped key (${bound}) — nothing to do."
+      echo "tether setup: the CLI already holds an agent-scoped key (${bound}) — nothing to mint."
       echo "              tether will pick it up from ~/.e2a/config.json; run 'tether.sh status' to confirm."
+      echo "              NOTE this key cannot verify/disable outbound review on ${bound}. If 'start'"
+      echo "              refuses with a HELD intro, run 'e2a protection set ${bound} --outbound-review off'"
+      echo "              with an account-scoped login (or use the dashboard)."
       exit 0
     fi
     [ "$scope" = "account" ] || { echo "tether setup: could not determine key scope (e2a whoami failed?) — check 'e2a whoami'"; exit 1; }
@@ -283,19 +347,40 @@ except Exception:print("")')"
       *) [ -n "$want" ] || { echo "tether setup: refusing to reconfigure non-tether inbox ${inbox} without an explicit --email"; exit 1; }
          echo "tether setup: NOTE disabling OUTBOUND review on ${inbox} (explicitly requested via --email)";;
     esac
-    t_cli protection set "$inbox" --outbound-review off >/dev/null || { echo "tether setup: could not disable outbound review — aborting, nothing written"; exit 1; }
-    echo "tether setup: outbound review off on ${inbox}"
-    agtkey="$(t_cli keys create --agent "$inbox" --name "tether-$(python3 -c 'import secrets;print(secrets.token_hex(2))')" 2>/dev/null)"
+    # Mint FIRST, flip protection SECOND: the mint can fail (quota, 5xx), and
+    # the old order left outbound review disabled on the inbox while claiming
+    # "nothing written". This order is fully rollbackable — a protection
+    # failure revokes the just-minted key and aborts with zero server-side
+    # drift. (--json gives us the key id so the rollback can name it.)
+    kjson="$(t_cli keys create --agent "$inbox" --name "tether-$(python3 -c 'import secrets;print(secrets.token_hex(2))')" --json 2>/dev/null)"
+    agtkey="$(printf '%s' "$kjson" | python3 -c 'import json,sys
+try:print(json.load(sys.stdin).get("key","") or "")
+except Exception:print("")')"
+    keyid="$(printf '%s' "$kjson" | python3 -c 'import json,sys
+try:print(json.load(sys.stdin).get("id","") or "")
+except Exception:print("")')"
     [ -n "$agtkey" ] || { echo "tether setup: could not mint an agent-scoped key — aborting (NOT storing the broad account key)"; exit 1; }
+    if ! t_cli protection set "$inbox" --outbound-review off >/dev/null; then
+      [ -n "$keyid" ] && t_cli keys delete "$keyid" >/dev/null 2>&1
+      echo "tether setup: could not disable outbound review — aborting (minted key revoked, nothing changed)"
+      exit 1
+    fi
+    echo "tether setup: outbound review off on ${inbox}"
     envf="${HOME}/.e2a-tether.env"
-    [ -f "$envf" ] && cp "$envf" "${envf}.bak"
-    { echo "# written by tether.sh setup — $(t_now_iso)"
-      echo "export E2A_API_KEY=\"${agtkey}\""
-      echo "export E2A_AGENT_EMAIL=\"${inbox}\""
-      [ -n "${E2A_BASE_URL:-}" ] && echo "export E2A_BASE_URL=\"${E2A_BASE_URL}\""
-    } > "$envf"
+    if [ -f "$envf" ]; then
+      cp "$envf" "${envf}.bak" && chmod 600 "${envf}.bak" 2>/dev/null
+    fi
+    # umask 077 closes the window where the file briefly exists with default
+    # permissions before a post-hoc chmod — it holds a plaintext key.
+    ( umask 077
+      { echo "# written by tether.sh setup — $(t_now_iso)"
+        echo "export E2A_API_KEY=\"${agtkey}\""
+        echo "export E2A_AGENT_EMAIL=\"${inbox}\""
+        [ -n "${E2A_BASE_URL:-}" ] && echo "export E2A_BASE_URL=\"${E2A_BASE_URL}\""
+      } > "$envf"
+    )
     chmod 600 "$envf" 2>/dev/null || true
-    echo "tether setup: wrote ${envf} (agent-scoped key, least privilege)$([ -f "${envf}.bak" ] && echo " — previous file kept as .bak")"
+    echo "tether setup: wrote ${envf} (agent-scoped key, least privilege)$([ -f "${envf}.bak" ] && echo " — previous file kept as .bak (its key stays valid; revoke unwanted keys via 'e2a keys list' + 'e2a keys delete')")"
     export E2A_API_KEY="$agtkey" E2A_AGENT_EMAIL="$inbox"
     bash "${here}/tether.sh" status
     echo "tether setup: ready → tether.sh start <your-email> --title \"<work>\" --for 30m"
@@ -353,8 +438,14 @@ except Exception:print("")')"
       t_ask_active && { echo "FAIL: lock present before begin"; exit 1; }
       t_ask_begin;  t_ask_active || { echo "FAIL: lock absent after begin"; exit 1; }
       t_ask_end;   ! t_ask_active || { echo "FAIL: lock present after end"; exit 1; }
-      echo "ok: ask lock begin/active/end" ) || fail=1
-    rm -f /tmp/tether-selftest-lock.json /tmp/ask.lock
+      echo "ok: ask lock begin/active/end"
+      # A lock whose PID is dead (SIGKILLed ask) must be treated stale and
+      # reaped, or a background listen pauses forever.
+      echo 99999999 > "$(t_ask_lock_path)"
+      if t_ask_active; then echo "FAIL: stale lock (dead pid) treated as active"; exit 1; fi
+      [ -f "$(t_ask_lock_path)" ] && { echo "FAIL: stale lock not reaped"; exit 1; }
+      echo "ok: stale ask lock (dead pid) is reaped" ) || fail=1
+    rm -f /tmp/tether-selftest-lock.json /tmp/tether-selftest-lock.ask.lock /tmp/ask.lock
 
     echo "# session isolation:"
     k1="$(cd /tmp && TETHER_STATE= bash -c '. "'"${here}"'/lib.sh"; t_state_key')"
@@ -369,6 +460,12 @@ except Exception:print("")')"
       TETHER_STATE=/tmp/tether-selftest-notitle.json bash "${here}/tether.sh" start someone@example.com 2>&1)"; rc=$?
     ck "start without --title is a usage error" "$rc:$(printf '%s' "$out" | grep -c 'title is required')" "2:1"
     rm -f /tmp/tether-selftest-notitle.json
+    # A trailing valueless flag must be a loud usage error, not an infinite
+    # option-parse loop (bash `shift 2` with $#=1 is a no-op).
+    out="$(env E2A_API_KEY='e2a_agt_selftest123' E2A_AGENT_EMAIL='selftest@agents.e2a.dev' \
+      TETHER_STATE=/tmp/tether-selftest-shift.json bash "${here}/tether.sh" start someone@example.com --title 2>&1)"; rc=$?
+    ck "trailing valueless flag → usage error (no hang)" "$rc:$(printf '%s' "$out" | grep -c 'requires a value')" "2:1"
+    rm -f /tmp/tether-selftest-shift.json
     # --parallel: with the DEFAULT path armed (legacy file in a sandbox HOME),
     # start must branch to a fresh self-keyed TETHER_STATE and print the
     # handle. E2A_CLI=/bin/false makes the intro send fail afterwards — the

--- a/plugins/e2a/skills/tether/tether.sh
+++ b/plugins/e2a/skills/tether/tether.sh
@@ -41,6 +41,14 @@ case "$cmd" in
       esac
     done
     [ -n "$to" ] || { echo "usage: tether.sh start <your-email> [--title \"<work>\"] [--for 2h|8h|30m|1d] [--until <ISO>]"; exit 2; }
+    # Never arm over a live session: that would hijack its thread pointer and
+    # watermark (each session must keep its own dedicated email thread).
+    if [ "$(t_state_get armed)" = "1" ]; then
+      echo "tether: already armed — thread $(t_state_get conversation_id) → $(t_state_get to)."
+      echo "        Run 'tether.sh stop' to end it first, or set TETHER_STATE to a unique"
+      echo "        path to run a second session in this repo in parallel."
+      exit 1
+    fi
     expires=""
     if [ -n "$untilarg" ]; then expires="$untilarg"
     elif [ -n "$forarg" ]; then
@@ -327,6 +335,17 @@ except Exception:print("")')"
       t_ask_end;   ! t_ask_active || { echo "FAIL: lock present after end"; exit 1; }
       echo "ok: ask lock begin/active/end" ) || fail=1
     rm -f /tmp/tether-selftest-lock.json /tmp/ask.lock
+
+    echo "# session isolation:"
+    k1="$(cd /tmp && TETHER_STATE= bash -c '. "'"${here}"'/lib.sh"; t_state_key')"
+    k2="$(cd "$HOME" && TETHER_STATE= bash -c '. "'"${here}"'/lib.sh"; t_state_key')"
+    ck "different dirs → different state keys" "$([ -n "$k1" ] && [ -n "$k2" ] && [ "$k1" != "$k2" ] && echo distinct)" "distinct"
+    armf=/tmp/tether-selftest-armed.json
+    printf '{"armed":"1","conversation_id":"tether-old","to":"a@b.c"}' > "$armf"
+    out="$(env E2A_API_KEY='e2a_agt_selftest123' E2A_AGENT_EMAIL='selftest@agents.e2a.dev' \
+      TETHER_STATE="$armf" bash "${here}/tether.sh" start someone@example.com 2>&1)"; rc=$?
+    ck "start refuses to arm over a live session" "$rc:$(printf '%s' "$out" | grep -c 'already armed')" "1:1"
+    rm -f "$armf"
 
     echo "# CLI resolution:"
     ck "version compare: 1.6.2 >= 1.6.0" "$(t_ver_ge "e2a 1.6.2" "1.6.0" && echo yes)" "yes"

--- a/plugins/e2a/skills/tether/tether.sh
+++ b/plugins/e2a/skills/tether/tether.sh
@@ -2,7 +2,7 @@
 # tether.sh — the runtime CLI the agent calls to stay in touch over email.
 #
 #   tether.sh setup [--email <addr>] [--new]   zero-to-tethered bootstrap (needs `e2a login`)
-#   tether.sh start <email> [--title "<work>"] [--for 2h|8h|30m|1d] [--until <ISO>]  open + arm
+#   tether.sh start <email> --title "<work>" [--for 2h|8h|30m|1d] [--until <ISO>]  open + arm
 #   tether.sh update "<message>"   send a threaded update ("as you see fit")
 #   tether.sh update --html <file> send an HTML update (+ auto text fallback)
 #   tether.sh update --attach <f>  attach a file (repeatable; 15 MB total cap)
@@ -41,7 +41,15 @@ case "$cmd" in
         *) to="$1"; shift;;
       esac
     done
-    [ -n "$to" ] || { echo "usage: tether.sh start <your-email> [--title \"<work>\"] [--for 2h|8h|30m|1d] [--until <ISO>] [--parallel]"; exit 2; }
+    [ -n "$to" ] || { echo "usage: tether.sh start <your-email> --title \"<work>\" [--for 2h|8h|30m|1d] [--until <ISO>] [--parallel]"; exit 2; }
+    # The subject is the thread's PERMANENT identity (threading needs it
+    # stable), so a meaningful title is required, not suggested — a bare
+    # "Tether: <repo>" makes every session in this repo indistinguishable.
+    if [ -z "$title" ]; then
+      echo "tether: --title is required — it becomes the thread's subject (\"Tether: ${proj:-$(basename "$PWD")} — <title>\")."
+      echo "        Title the WORK, not the first step (e.g. --title \"fix webhook retries\")."
+      exit 2
+    fi
     # Never arm over a live session: that would hijack its thread pointer and
     # watermark (each session must keep its own dedicated email thread).
     if [ "$(t_state_get armed)" = "1" ]; then
@@ -73,11 +81,7 @@ case "$cmd" in
     conv="tether-$(date +%s)-$$"
     # Subject = the thread's one stable title (threading replies onto it), so
     # make it say what the session is DOING, not just where it's running.
-    subject="Tether: ${proj}"
-    [ -n "$title" ] && subject="Tether: ${proj} — ${title}"
-    # Untitled sessions all share one subject; several of them in an inbox are
-    # indistinguishable (and read like Gmail split one thread). Nudge, loudly.
-    [ -n "$title" ] || echo "tether: NOTE no --title — every untitled session in this repo shares the subject \"${subject}\"; pass --title \"<work>\" so threads are tellable apart" >&2
+    subject="Tether: ${proj} — ${title}"
     intro="🪢 Tethered — ${proj}${title:+ — ${title}}
 
 This session is now tethered (${window}). I'll send updates to this thread as I
@@ -359,8 +363,12 @@ except Exception:print("")')"
     armf=/tmp/tether-selftest-armed.json
     printf '{"armed":"1","conversation_id":"tether-old","to":"a@b.c"}' > "$armf"
     out="$(env E2A_API_KEY='e2a_agt_selftest123' E2A_AGENT_EMAIL='selftest@agents.e2a.dev' \
-      TETHER_STATE="$armf" bash "${here}/tether.sh" start someone@example.com 2>&1)"; rc=$?
+      TETHER_STATE="$armf" bash "${here}/tether.sh" start someone@example.com --title selftest 2>&1)"; rc=$?
     ck "start refuses to arm over a live session" "$rc:$(printf '%s' "$out" | grep -c 'already armed')" "1:1"
+    out="$(env E2A_API_KEY='e2a_agt_selftest123' E2A_AGENT_EMAIL='selftest@agents.e2a.dev' \
+      TETHER_STATE=/tmp/tether-selftest-notitle.json bash "${here}/tether.sh" start someone@example.com 2>&1)"; rc=$?
+    ck "start without --title is a usage error" "$rc:$(printf '%s' "$out" | grep -c 'title is required')" "2:1"
+    rm -f /tmp/tether-selftest-notitle.json
     # --parallel: with the DEFAULT path armed (legacy file in a sandbox HOME),
     # start must branch to a fresh self-keyed TETHER_STATE and print the
     # handle. E2A_CLI=/bin/false makes the intro send fail afterwards — the
@@ -369,7 +377,7 @@ except Exception:print("")')"
     printf '{"armed":"1","conversation_id":"tether-old","to":"a@b.c"}' > "$sb/.e2a-tether/state.json"
     out="$(env HOME="$sb" E2A_CLI=/bin/false E2A_API_KEY='e2a_agt_selftest123' \
       E2A_AGENT_EMAIL='selftest@agents.e2a.dev' \
-      bash "${here}/tether.sh" start someone@example.com --parallel 2>&1)" || true
+      bash "${here}/tether.sh" start someone@example.com --title selftest --parallel 2>&1)" || true
     ck "start --parallel self-keys a fresh TETHER_STATE" \
       "$(printf '%s' "$out" | grep -c 'TETHER_STATE=')" "1"
     rm -rf "$sb" "$armf"

--- a/plugins/e2a/skills/tether/tether.sh
+++ b/plugins/e2a/skills/tether/tether.sh
@@ -31,23 +31,36 @@ case "$cmd" in
   start)
     # start <email> [--title "<work>"] [--for 30m|2h|8h|1d] [--until <ISO>]
     need_config
-    to=""; forarg=""; untilarg=""; title=""
+    to=""; forarg=""; untilarg=""; title=""; parallel=0
     while [ $# -gt 0 ]; do
       case "$1" in
         --title) title="${2:-}"; shift 2;;
         --for) forarg="${2:-}"; shift 2;;
         --until) untilarg="${2:-}"; shift 2;;
+        --parallel) parallel=1; shift;;
         *) to="$1"; shift;;
       esac
     done
-    [ -n "$to" ] || { echo "usage: tether.sh start <your-email> [--title \"<work>\"] [--for 2h|8h|30m|1d] [--until <ISO>]"; exit 2; }
+    [ -n "$to" ] || { echo "usage: tether.sh start <your-email> [--title \"<work>\"] [--for 2h|8h|30m|1d] [--until <ISO>] [--parallel]"; exit 2; }
     # Never arm over a live session: that would hijack its thread pointer and
     # watermark (each session must keep its own dedicated email thread).
     if [ "$(t_state_get armed)" = "1" ]; then
-      echo "tether: already armed — thread $(t_state_get conversation_id) → $(t_state_get to)."
-      echo "        Run 'tether.sh stop' to end it first, or set TETHER_STATE to a unique"
-      echo "        path to run a second session in this repo in parallel."
-      exit 1
+      if [ "$parallel" = "1" ] && [ -z "${TETHER_STATE:-}" ]; then
+        # Same-repo parallel session: self-key a fresh state file and hand the
+        # caller its handle. The session MUST prefix every subsequent tether
+        # call with this TETHER_STATE — without it, commands resolve to the
+        # other session's state.
+        export TETHER_STATE="$HOME/.e2a-tether/state-$(t_state_key)-$(date +%s)-$$.json"
+        T_STATE_PATH="$TETHER_STATE"
+        echo "tether: parallel session — prefix EVERY subsequent tether.sh call with:"
+        echo "        TETHER_STATE=\"${TETHER_STATE}\""
+      else
+        echo "tether: already armed — thread $(t_state_get conversation_id) → $(t_state_get to)."
+        echo "        Run 'tether.sh stop' to end it first, or re-run start with --parallel"
+        echo "        to open a second session in this repo (you'll get a TETHER_STATE"
+        echo "        handle to carry on every subsequent call)."
+        exit 1
+      fi
     fi
     expires=""
     if [ -n "$untilarg" ]; then expires="$untilarg"
@@ -348,7 +361,18 @@ except Exception:print("")')"
     out="$(env E2A_API_KEY='e2a_agt_selftest123' E2A_AGENT_EMAIL='selftest@agents.e2a.dev' \
       TETHER_STATE="$armf" bash "${here}/tether.sh" start someone@example.com 2>&1)"; rc=$?
     ck "start refuses to arm over a live session" "$rc:$(printf '%s' "$out" | grep -c 'already armed')" "1:1"
-    rm -f "$armf"
+    # --parallel: with the DEFAULT path armed (legacy file in a sandbox HOME),
+    # start must branch to a fresh self-keyed TETHER_STATE and print the
+    # handle. E2A_CLI=/bin/false makes the intro send fail afterwards — the
+    # assertion is that the parallel branch ran, not that mail went out.
+    sb=/tmp/tether-selftest-home; mkdir -p "$sb/.e2a-tether"
+    printf '{"armed":"1","conversation_id":"tether-old","to":"a@b.c"}' > "$sb/.e2a-tether/state.json"
+    out="$(env HOME="$sb" E2A_CLI=/bin/false E2A_API_KEY='e2a_agt_selftest123' \
+      E2A_AGENT_EMAIL='selftest@agents.e2a.dev' \
+      bash "${here}/tether.sh" start someone@example.com --parallel 2>&1)" || true
+    ck "start --parallel self-keys a fresh TETHER_STATE" \
+      "$(printf '%s' "$out" | grep -c 'TETHER_STATE=')" "1"
+    rm -rf "$sb" "$armf"
 
     echo "# CLI resolution:"
     ck "version compare: 1.6.2 >= 1.6.0" "$(t_ver_ge "e2a 1.6.2" "1.6.0" && echo yes)" "yes"


### PR DESCRIPTION
## What (consolidated per review discussion)

One reviewable unit: the full CLI scripting surface **plus the tether harness rewritten on top of it** — tether is the integration test for the CLI, per the review plan.

### 1. CLI scripting primitives + exit-code contract
`whoami`, `send`/`reply` (`--html-file` with derived text fallback, `--attach`, `--idempotency-key`, `--conversation-id`), `messages list/get` (TSV/NDJSON, `--read-status` defaulting to `all` so poll loops can't lose read messages), with the stable contract:

| code | meaning |
|---|---|
| 0 | success |
| 1 | transient (network / 5xx / rate limit) — retry may help |
| 2 | usage error (unknown flags and `--flag=value` are rejected loudly) |
| 3 | send HELD (any non-`sent` status — open-set safe) — not delivered |
| 4 | bad credentials / wrong scope |
| 5 | permanent request error (404/409/422) — do NOT retry |
| 6 | bounded wait (`listen --once --until`) expired unmatched |

### 2. Bootstrap surface
- `agents list/create/get` (list closes the discovery gap found by the journey review)
- `protection get/set --outbound-review on|off` — GET-merge-PUT that only touches named knobs and **never writes after a failed read** (kills the config-clobber bug class from #368 by construction)
- `keys create [--agent <inbox>]/list/delete` — non-interactive least-privilege key minting

### 3. Login refinement
- `e2a login --agent <inbox>` — browser bootstrap → mint agent-scoped key → **revoke the account bootstrap** (unique-prefix match; refuses to guess); bare slugs expand on the shared domain; typo → owned-agent list, exit 5
- `e2a login --with-key` — headless (arg / `$E2A_API_KEY` / stdin), validated via `/v1/account`, records `key_scope` (which returns with its writer + enum validation)
- `listen --conversation --once --until --text` — the blocking-wait primitive (clean expiry = 6, terminal close = 1, so wake-loops can't spin hot)

### 4. Golden tether rewrite (`plugins/e2a/skills/tether/`)
- **Requires the CLI**: `lib.sh t_cli` resolves `$E2A_CLI` → `e2a` on PATH (version-gated) → `npx -y @e2a/cli@^1.6.0`. Plugin auto-update delivers the skill; npx delivers the CLI — **existing users upgrade with zero action**.
- The entire curl/python API client is deleted; send/reply/poll/body ride the CLI exit-code contract (all of #363's held-send semantics preserved, #364's attachments, #365's HTML/titles).
- `listen`/`ask` wait on `e2a listen --once` in poll-interval chunks: real-time pickup where the WS works, **byte-identical 20s cadence where it doesn't** (hosted `api.e2a.dev` currently 404s the WS handshake — pre-existing gap, degradation verified live). Dedup/parse-retry/ask-lock invariants unchanged: the WS is only a wake signal; consumption stays in the dedup-safe poll.
- **`tether.sh setup`** — the golden bootstrap (`whoami` → ensure `tether-*` inbox → outbound review off → mint agent key → write env). Fails hard everywhere: no account-key fallback, no protection clobber, no non-tether inbox adopted silently, no "ready" on a broken config.

## Testing
- 105 vitest cases (incl. protection merge semantics + the never-PUT-after-failed-GET guard, login `--with-key`, held open-set, `_from`→`from` NDJSON pinning)
- `tether.sh _selftest` PASS (CLI resolution, version gating, `E2A_CLI` override, mutex, durations, attach caps)
- **Live end-to-end against hosted prod**: a real threaded update delivered to a real inbox through the rewritten harness driving the workspace CLI (`E2A_CLI=node cli/dist/bin/e2a.js`); `listen --once` degradation verified against the prod WS 404.
- Earlier rounds: 8-angle adversarial code review (10 findings fixed) + 3-agent interface review (SDK/API/journey — all highs fixed). Findings and fixes in the PR comments.

## Sequencing
Merging is repo-safe immediately. End users get the new tether via plugin auto-update **after** `@e2a/cli@1.6.0` is published to npm (version bumped in this PR; publish via the standard workflow post-merge). Known follow-up: hosted WS endpoint 404 (pre-existing; tether tolerates it by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)