### PR TITLE
release(plugin/e2a): 0.5.0 — tether on the CLI transport

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   },
   "metadata": {
     "description": "e2a plugins for Claude Code — authenticated email for AI agents",
-    "version": "0.4.6"
+    "version": "0.5.0"
   },
   "plugins": [
     {

--- a/plugins/e2a/.claude-plugin/plugin.json
+++ b/plugins/e2a/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.4.6",
+  "version": "0.5.0",
   "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 37 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "Mnexa AI",

--- a/plugins/e2a/.codex-plugin/plugin.json
+++ b/plugins/e2a/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.4.6",
+  "version": "0.5.0",
   "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 37 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "Mnexa AI"

--- a/plugins/e2a/.cursor-plugin/plugin.json
+++ b/plugins/e2a/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "e2a",
   "displayName": "e2a",
-  "version": "0.4.6",
+  "version": "0.5.0",
   "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 37 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "Mnexa AI",


### PR DESCRIPTION
Releases plugin 0.5.0 to deliver the tether-on-CLI rewrite (#369) to users via plugin auto-update.

**Ordering satisfied:** `@e2a/cli@1.6.0` is published and verified on npm (the harness's npx pin `^1.6.0` resolves), so a fresh user's first `t_cli` call works. Bumps the three plugin manifests + the marketplace index from 0.4.6 → 0.5.0.

What users get: `tether.sh setup` one-command onboarding, real-time replies (WS wait with automatic polling degradation), per-repo session isolation + `--parallel`, required `--title`, and the six-agent-review hardening batch (transport timeouts, atomic state writes, stale-lock reaping, empty-filter/injection guards, credential-flow fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)