### PR TITLE
fix(httpapi): decode percent-encoded address on the /v1 WS route (404 for every SDK client)

### DIFF
--- a/internal/httpapi/httpapi.go
+++ b/internal/httpapi/httpapi.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/Mnexa-AI/e2a/internal/agent"
@@ -330,7 +331,17 @@ func New(deps Deps) *Server {
 	// upgrade, not a JSON operation). First-class /v1 inbound transport.
 	if deps.WSHandle != nil {
 		root.Get("/v1/agents/{email}/ws", func(w http.ResponseWriter, r *http.Request) {
-			deps.WSHandle(w, r, chi.URLParam(r, "email"))
+			// chi routes on RawPath when the request URI is percent-encoded and
+			// returns URL params STILL ENCODED — and every SDK client encodes the
+			// address (encodeURIComponent), so without this decode the handler
+			// looked up an agent literally named "x%40y" and 404'd every real
+			// WebSocket client. Huma decodes its own params; this bypass route
+			// must do it explicitly.
+			address := chi.URLParam(r, "email")
+			if decoded, err := url.PathUnescape(address); err == nil {
+				address = decoded
+			}
+			deps.WSHandle(w, r, address)
 		})
 	}
 

--- a/internal/httpapi/ws_route_test.go
+++ b/internal/httpapi/ws_route_test.go
@@ -1,0 +1,46 @@
+package httpapi
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// The WS route is the one /v1 route hand-mounted on chi (not Huma), and chi
+// returns URL params STILL PERCENT-ENCODED when the request URI was encoded
+// (RawPath routing). Every SDK client encodeURIComponent()s the address, so
+// without an explicit PathUnescape at the mount the handler received
+// "x%40y" and 404'd every real WebSocket client — while the raw-@ form (and
+// every Huma REST route, which decodes its own params) worked. Regression:
+// both spellings must reach WSHandle as the decoded address.
+func TestWSRouteDecodesPercentEncodedAddress(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		path string
+	}{
+		{"percent-encoded (what SDKs send)", "/v1/agents/tether%40agents.e2a.dev/ws"},
+		{"raw @", "/v1/agents/tether@agents.e2a.dev/ws"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var got string
+			deps := Deps{
+				WSHandle: func(w http.ResponseWriter, r *http.Request, address string) {
+					got = address
+					w.WriteHeader(http.StatusSwitchingProtocols)
+				},
+			}
+			srv := httptest.NewServer(New(deps).Router)
+			t.Cleanup(srv.Close)
+
+			resp, err := http.Get(srv.URL + tc.path)
+			if err != nil {
+				t.Fatalf("request failed: %v", err)
+			}
+			resp.Body.Close()
+
+			if got != "tether@agents.e2a.dev" {
+				t.Fatalf("WSHandle received address %q, want %q", got, "tether@agents.e2a.dev")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What / why

`e2a listen` (and both SDKs' WS clients) against hosted `api.e2a.dev` failed with `handshake rejected: HTTP 404`. Wire evidence with the same valid agent key:

- `/v1/agents/josh-cc%40agents.e2a.dev/ws` → **404** ("agent not found", `ws/handler.go:79`)
- `/v1/agents/josh-cc@agents.e2a.dev/ws` → **426** (route + auth + agent lookup all fine; reaches the upgrade)

Root cause: the WS route is the one `/v1` route mounted directly on chi (raw upgrade, not a Huma op). chi routes on `RawPath` when the URI is percent-encoded and **returns the param still encoded** — and every SDK client `encodeURIComponent()`s the address (`ws.ts:87`), so the handler looked up an agent literally named `x%40y`. Huma decodes its own path params, which is why every REST route with the same address shape works.

Fix: `url.PathUnescape` at the mount point; regression test pins both spellings reaching `WSHandle` decoded.

## Impact

Unblocks real-time tether reply delivery on the next prod deploy — the 0.5.0 harness's WS wait currently degrades to 20s polling against hosted (by design), and will pick up seconds-latency automatically once this ships. No `/v1` spec change (the WS route isn't an OpenAPI operation).

## Testing

- New `TestWSRouteDecodesPercentEncodedAddress` (fails on main, passes here)
- `make test-unit` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)