### PR TITLE
release(plugin/e2a): bump missed .cursor-plugin marketplace to 0.5.0

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -6,7 +6,7 @@
   },
   "metadata": {
     "description": "e2a — authenticated email gateway for AI agents (MCP server + operate-well skill).",
-    "version": "0.4.6"
+    "version": "0.5.0"
   },
   "plugins": [
     {


### PR DESCRIPTION
Completes #371: the fourth manifest (.cursor-plugin/marketplace.json) was missed, failing the Plugin-manifests check on main. One line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)