### PR TITLE
chore(ws): remove dead gorilla-mux Handle; test the WS handler on prod's router semantics

### DIFF
--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/Mnexa-AI/e2a/internal/identity"
-	"github.com/gorilla/mux"
 	"nhooyr.io/websocket"
 )
 
@@ -34,16 +33,11 @@ func NewHandler(hub *Hub, store HandlerStore) *Handler {
 	return &Handler{hub: hub, store: store}
 }
 
-// Handle is the HTTP handler for WebSocket upgrade requests.
-// Route: GET /v1/agents/{email}/ws — authenticated by `Authorization: Bearer <api_key>`.
-// Handle reads the agent email from the gorilla/mux route var.
-func (h *Handler) Handle(w http.ResponseWriter, r *http.Request) {
-	h.serve(w, r, mux.Vars(r)["email"])
-}
-
 // ServeWithEmail handles the WebSocket upgrade for an explicitly-provided
-// agent email, so non-mux routers (chi at /v1/agents/{address}/ws) can host
-// the same transport.
+// agent email — the router owns path extraction (and, for routers like chi
+// that return params still percent-encoded, DECODING; see the /v1 mount in
+// internal/httpapi). The old gorilla/mux `Handle` variant was removed with
+// the retired /api/v1 surface: this is the transport's only entry point.
 func (h *Handler) ServeWithEmail(w http.ResponseWriter, r *http.Request, rawEmail string) {
 	h.serve(w, r, rawEmail)
 }

--- a/internal/ws/handler_test.go
+++ b/internal/ws/handler_test.go
@@ -7,12 +7,13 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/Mnexa-AI/e2a/internal/identity"
-	"github.com/gorilla/mux"
+	"github.com/go-chi/chi/v5"
 	"nhooyr.io/websocket"
 )
 
@@ -61,11 +62,21 @@ func newTestUser() *identity.User {
 	return &identity.User{ID: "user_1", Email: "alice@example.com"}
 }
 
-// startServer creates an httptest server with the WS handler mounted on a mux router.
+// startServer mounts the WS handler EXACTLY the way production does
+// (internal/httpapi: chi + PathUnescape + ServeWithEmail). The old test mount
+// used gorilla/mux, which decodes route vars — the opposite of chi — and that
+// mismatch masked the percent-encoded-address 404 (#372): the handler passed
+// its tests on a router with different semantics than the one serving it.
 func startServer(t *testing.T, handler *Handler) *httptest.Server {
 	t.Helper()
-	r := mux.NewRouter()
-	r.HandleFunc("/api/v1/agents/{email}/ws", handler.Handle)
+	r := chi.NewRouter()
+	r.Get("/api/v1/agents/{email}/ws", func(w http.ResponseWriter, req *http.Request) {
+		address := chi.URLParam(req, "email")
+		if decoded, err := url.PathUnescape(address); err == nil {
+			address = decoded
+		}
+		handler.ServeWithEmail(w, req, address)
+	})
 	srv := httptest.NewServer(r)
 	t.Cleanup(srv.Close)
 	return srv
@@ -93,7 +104,10 @@ func dialWSPath(t *testing.T, srv *httptest.Server, path, token string) (*websoc
 // dialWS connects to the versioned WS endpoint.
 func dialWS(t *testing.T, srv *httptest.Server, email, token string) (*websocket.Conn, *http.Response) {
 	t.Helper()
-	return dialWSPath(t, srv, fmt.Sprintf("/api/v1/agents/%s/ws", email), token)
+	// Percent-encode the address like every real client does
+	// (encodeURIComponent in ws.ts, quote() in the Python SDK) — realistic
+	// input is the whole point of mounting the test router like production.
+	return dialWSPath(t, srv, fmt.Sprintf("/api/v1/agents/%s/ws", url.PathEscape(email)), token)
 }
 
 // waitConnected polls the hub until the agent is registered or timeout.


### PR DESCRIPTION
Follow-up to #372, answering "can we remove the legacy WS path?" — investigation showed there is **no live legacy route**: `/api/v1` was fully retired, and `Handler.Handle` (the gorilla-mux variant) had no production registration — dead code kept alive by its own tests.

The removal's real value is the test harness it forces: the handler tests mounted on gorilla/mux, which **decodes** route vars — opposite semantics to the chi router that actually serves the handler — which is precisely how the encoded-address 404 stayed invisible (post-mortem gap #1). Tests now mount exactly like production (chi + `PathUnescape` + `ServeWithEmail`) and dial with percent-encoded addresses like every real client.

- `internal/ws` no longer imports gorilla/mux
- Full upgrade-path test suite passes on the prod-shaped mount (30s of real WS dials)
- `internal/httpapi` suite green
- No behavior change to any served route

🤖 Generated with [Claude Code](https://claude.com/claude-code)