### PR TITLE
chore(github): PR template — Python SDK rows reflect the async-only /v1 layout

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,9 +24,8 @@ to be in the Python SDK).
 - [ ] Go handler + integration tests
 - [ ] Migration written + idempotent + safe on prod-sized tables (see [CLAUDE.md](../CLAUDE.md))
 - [ ] OpenAPI spec + generated types refreshed (`make generate` is clean)
-- [ ] TypeScript SDK — `api.ts` (raw) **and** `client.ts` (high-level)
-- [ ] Python SDK sync — `api.py` (raw) **and** `client.py` (high-level)
-- [ ] Python SDK async — `async_client.py` (both raw and high-level methods)
+- [ ] TypeScript SDK — generated base regenerated (`make generate-sdk`) **and** resource added to the hand-written `E2AClient` (`sdks/typescript/src/v1/client.ts`)
+- [ ] Python SDK — generated base regenerated (`make generate-sdk`) **and** resource added to the hand-written async `E2AClient` (`sdks/python/src/e2a/v1/client.py`)
 - [ ] CLI command or flag in `cli/src/commands/` + wired into `cli/src/bin/e2a.ts`
 - [ ] MCP tool in `mcp/src/tools/` + registry assertion in `mcp/tests/{tools,http}.test.ts`
 - [ ] Tests at each surface above (positive + at least one negative-path / regression case)


### PR DESCRIPTION
The client-surface checklist still described the pre-/v1-cutover Python SDK layout: a sync `api.py`/`client.py` pair plus an `async_client.py` — none of which exist anymore. The /v1 Python SDK is async-only (per its README, the sync client and flat methods are gone): an OpenAPI-Generator base at `sdks/python/src/e2a/v1/generated/` plus one hand-written async `E2AClient` in `sdks/python/src/e2a/v1/client.py`. The TypeScript row had the same staleness — `api.ts` was retired in the cutover too, so it now points at the generated base + `sdks/typescript/src/v1/client.ts`. Discovered while filling out the checklist in #375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)