### PR TITLE
feat(web): agent-prompt cards on Templates, Inboxes, and Domains

### DIFF
--- a/web/src/app/(app)/domains/page.tsx
+++ b/web/src/app/(app)/domains/page.tsx
@@ -8,6 +8,7 @@ import { listDomains, listAgents } from "../../components/onboarding/api";
 import type { DomainInfo } from "../../components/onboarding/types";
 import type { DashboardAgent } from "../../components/types";
 import { PageShell } from "../../components/loft/PageShell";
+import { AgentPromptCard, AGENT_PROMPTS } from "../../components/AgentPromptCard";
 import {
   agentsKey,
   domainsKey,
@@ -113,6 +114,10 @@ export default function DomainsPage() {
             <AddDomainForm onRegistered={handleDomainRegistered} />
           </div>
         )}
+
+        <div className="mt-10">
+          <AgentPromptCard {...AGENT_PROMPTS.domains} />
+        </div>
       </PageShell>
     );
   }
@@ -168,6 +173,10 @@ export default function DomainsPage() {
       ) : (
         <DomainList domains={domains} agents={agents} onRefresh={handleListChanged} />
       )}
+
+      <div className="mt-10">
+        <AgentPromptCard {...AGENT_PROMPTS.domains} />
+      </div>
     </PageShell>
   );
 }

--- a/web/src/app/(app)/domains/page.tsx
+++ b/web/src/app/(app)/domains/page.tsx
@@ -109,15 +109,15 @@ export default function DomainsPage() {
           </div>
         </div>
 
+        <div className="mt-10">
+          <AgentPromptCard {...AGENT_PROMPTS.domains} />
+        </div>
+
         {showAddForm && (
           <div className="mt-6">
             <AddDomainForm onRegistered={handleDomainRegistered} />
           </div>
         )}
-
-        <div className="mt-10">
-          <AgentPromptCard {...AGENT_PROMPTS.domains} />
-        </div>
       </PageShell>
     );
   }
@@ -163,6 +163,10 @@ export default function DomainsPage() {
         </div>
       )}
 
+      <div className="mb-10">
+        <AgentPromptCard {...AGENT_PROMPTS.domains} />
+      </div>
+
       {loading ? (
         <div
           className="text-[13px] py-12 text-center"
@@ -173,10 +177,6 @@ export default function DomainsPage() {
       ) : (
         <DomainList domains={domains} agents={agents} onRefresh={handleListChanged} />
       )}
-
-      <div className="mt-10">
-        <AgentPromptCard {...AGENT_PROMPTS.domains} />
-      </div>
     </PageShell>
   );
 }

--- a/web/src/app/(app)/inboxes/page.tsx
+++ b/web/src/app/(app)/inboxes/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo } from "react";
 import useSWR from "swr";
 import Link from "next/link";
 import { useAuth } from "../../components/AuthProvider";
+import { AgentPromptCard, AGENT_PROMPTS } from "../../components/AgentPromptCard";
 import { listDomains } from "../../components/onboarding/api";
 import { useAgents } from "../../components/hooks/useAgents";
 import { domainsKey } from "../../../lib/swrKeys";
@@ -227,6 +228,10 @@ export default function DashboardPage() {
           </div>
         </>
       )}
+
+      <div className="mt-10">
+        <AgentPromptCard {...AGENT_PROMPTS.inboxes} />
+      </div>
     </PageShell>
   );
 }

--- a/web/src/app/(app)/inboxes/page.tsx
+++ b/web/src/app/(app)/inboxes/page.tsx
@@ -194,6 +194,10 @@ export default function DashboardPage() {
         </div>
       )}
 
+      <div className="mb-10">
+        <AgentPromptCard {...AGENT_PROMPTS.inboxes} />
+      </div>
+
       {loading ? (
         <div
           className="text-[13px] py-12 text-center"
@@ -228,10 +232,6 @@ export default function DashboardPage() {
           </div>
         </>
       )}
-
-      <div className="mt-10">
-        <AgentPromptCard {...AGENT_PROMPTS.inboxes} />
-      </div>
     </PageShell>
   );
 }

--- a/web/src/app/(app)/templates/page.tsx
+++ b/web/src/app/(app)/templates/page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { PageShell } from "../../components/loft/PageShell";
 import { Chip } from "../../components/loft/Chip";
 import { StarterGallery } from "./_components/StarterGallery";
+import { AgentPromptCard, AGENT_PROMPTS } from "../../components/AgentPromptCard";
 import { StarterPreviewModal } from "./_components/StarterPreviewModal";
 import type { StarterTemplateView, TemplateSummaryView } from "./_lib/types";
 
@@ -176,12 +177,15 @@ export default function TemplatesPage() {
         <div className="space-y-10">
           {list}
           {gallery}
+          <AgentPromptCard {...AGENT_PROMPTS.templates} />
         </div>
       ) : (
         // No templates yet — lead with the starter gallery so the first
-        // action is one click away, and keep the (empty) list below it.
+        // action is one click away, then the agent prompt (the other
+        // zero-to-one path), and keep the (empty) list below.
         <div className="space-y-10">
           {gallery}
+          <AgentPromptCard {...AGENT_PROMPTS.templates} />
           {list}
         </div>
       )}

--- a/web/src/app/(app)/templates/page.tsx
+++ b/web/src/app/(app)/templates/page.tsx
@@ -175,17 +175,17 @@ export default function TemplatesPage() {
         </p>
       ) : hasTemplates ? (
         <div className="space-y-10">
+          <AgentPromptCard {...AGENT_PROMPTS.templates} />
           {list}
           {gallery}
-          <AgentPromptCard {...AGENT_PROMPTS.templates} />
         </div>
       ) : (
-        // No templates yet — lead with the starter gallery so the first
-        // action is one click away, then the agent prompt (the other
-        // zero-to-one path), and keep the (empty) list below.
+        // No templates yet — the agent prompt leads (hand the whole setup
+        // to a coding agent), then the starter gallery for the one-click
+        // path, with the (empty) list below.
         <div className="space-y-10">
-          {gallery}
           <AgentPromptCard {...AGENT_PROMPTS.templates} />
+          {gallery}
           {list}
         </div>
       )}

--- a/web/src/app/components/AgentPromptCard.test.tsx
+++ b/web/src/app/components/AgentPromptCard.test.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { AgentPromptCard, AGENT_PROMPTS } from "./AgentPromptCard";
+
+// jsdom doesn't provide navigator.clipboard. The Copy-prompt button calls
+// writeText, so we install a jest mock once at module level (same pattern
+// as the settings page tests).
+const writeText = jest.fn(async () => {});
+Object.assign(navigator, { clipboard: { writeText } });
+beforeEach(() => writeText.mockClear());
+
+test("renders the blurb and prompt verbatim", () => {
+  render(<AgentPromptCard {...AGENT_PROMPTS.templates} />);
+  expect(
+    screen.getByRole("heading", { name: "Set up with a coding agent" }),
+  ).toBeInTheDocument();
+  expect(screen.getByText(AGENT_PROMPTS.templates.blurb)).toBeInTheDocument();
+  expect(screen.getByText(AGENT_PROMPTS.templates.prompt)).toBeInTheDocument();
+});
+
+test("every prompt anchors on a published e2a.dev doc, not a GitHub path", () => {
+  for (const { prompt } of Object.values(AGENT_PROMPTS)) {
+    expect(prompt).toMatch(/https:\/\/e2a\.dev\/(templates|e2a)\.md/);
+    expect(prompt).not.toContain("github.com");
+  }
+});
+
+test("copy button writes the card's prompt to the clipboard and flips its label", async () => {
+  render(<AgentPromptCard {...AGENT_PROMPTS.domains} />);
+  fireEvent.click(screen.getByRole("button", { name: "Copy prompt" }));
+  await waitFor(() =>
+    expect(writeText).toHaveBeenCalledWith(AGENT_PROMPTS.domains.prompt),
+  );
+  await waitFor(() =>
+    expect(
+      screen.getByRole("button", { name: "Copy prompt" }),
+    ).toHaveTextContent("Copied"),
+  );
+});

--- a/web/src/app/components/AgentPromptCard.tsx
+++ b/web/src/app/components/AgentPromptCard.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Button } from "./loft/Button";
+
+// Copy-paste prompts for driving each workspace surface from a coding
+// agent (Claude Code, Cursor, …) instead of the dashboard. The templates
+// prompt is kept in sync with docs/templates.md ("Using a coding
+// agent?"); the others anchor on the agent-facing doc at e2a.dev/e2a.md.
+export const AGENT_PROMPTS = {
+  templates: {
+    blurb:
+      "Templates are a one-time setup your coding agent can do headlessly — paste this into Claude Code, Cursor, or any agent connected to e2a.",
+    prompt: `Read https://e2a.dev/templates.md and set up e2a email templates for this project: browse the starter templates, copy the ones we need via from_starter, brand them (accent color is marked <!-- BRAND: accent -->), and wire our transactional sends using template_alias + template_data. Use the e2a MCP tools if connected (otherwise the REST API with $E2A_API_KEY), validate each template before wiring it in, and finish by listing the templates you created plus the send code you added.`,
+  },
+  inboxes: {
+    blurb:
+      "Creating and wiring an inbox is a one-time setup your coding agent can do headlessly — paste this into Claude Code, Cursor, or any agent connected to e2a.",
+    prompt: `Read https://e2a.dev/e2a.md and set up e2a email for this project's agent: connect over MCP (https://api.e2a.dev/mcp) or the REST API with $E2A_API_KEY, create an agent inbox, and wire inbound delivery into this project (webhook, or WebSocket listen for local dev). Finish by sending a test email to the new inbox and replying to it in-thread to prove the send/receive loop works.`,
+  },
+  domains: {
+    blurb:
+      "Domain setup is a one-time task your coding agent can drive end to end — paste this into Claude Code, Cursor, or any agent connected to e2a.",
+    prompt: `Read https://e2a.dev/e2a.md and connect our custom domain to e2a: register it, show me the DNS records to add (or add them yourself if you have access to our DNS provider), poll verification until it passes, then create the agent inboxes we need on the domain. Use the e2a MCP tools if connected, otherwise the REST API with $E2A_API_KEY.`,
+  },
+} as const;
+
+export type AgentPromptCardProps = {
+  blurb: string;
+  prompt: string;
+};
+
+// A copy-paste prompt card: these surfaces are one-time-setup shaped, so
+// the card hands the developer's coding agent the whole job instead of
+// walking the human through clicks.
+export function AgentPromptCard({ blurb, prompt }: AgentPromptCardProps) {
+  const [copied, setCopied] = useState(false);
+  const copyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (copyTimer.current !== null) clearTimeout(copyTimer.current);
+    };
+  }, []);
+
+  const onCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(prompt);
+      setCopied(true);
+      if (copyTimer.current !== null) clearTimeout(copyTimer.current);
+      copyTimer.current = setTimeout(() => {
+        setCopied(false);
+        copyTimer.current = null;
+      }, 1200);
+    } catch {
+      // clipboard unavailable — silently ignore
+    }
+  }, [prompt]);
+
+  return (
+    <section
+      aria-label="Set up with a coding agent"
+      className="rounded-[var(--r-lg)] border p-5"
+      style={{ background: "var(--bg-panel)", borderColor: "var(--border)" }}
+    >
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2
+            className="text-[16px] font-semibold"
+            style={{ color: "var(--fg)", margin: 0 }}
+          >
+            Set up with a coding agent
+          </h2>
+          <p
+            className="text-[13px] mt-1 mb-0 leading-[1.6]"
+            style={{ color: "var(--fg-muted)", maxWidth: 640 }}
+          >
+            {blurb}
+          </p>
+        </div>
+        <Button variant="ghost" onClick={onCopy} aria-label="Copy prompt">
+          {copied ? "Copied" : "Copy prompt"}
+        </Button>
+      </div>
+      <pre
+        className="mt-4 mb-0 whitespace-pre-wrap rounded-[var(--r-md)] border p-3.5 text-[12px] leading-[1.7]"
+        style={{
+          fontFamily: "var(--f-mono)",
+          color: "var(--fg-muted)",
+          background: "var(--bg)",
+          borderColor: "var(--border)",
+        }}
+      >
+        {prompt}
+      </pre>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a "Set up with a coding agent" card to the Templates, Inboxes, and Domains pages: a per-surface copy-paste prompt (with copy button) that hands the whole setup task to the user's coding agent — templates setup/branding/send wiring, inbox creation + delivery wiring, and domain registration/DNS/verification. One shared `AgentPromptCard` component owns all three prompts; the templates prompt matches `docs/templates.md` verbatim, the other two anchor on `e2a.dev/e2a.md`. Follows up on the docs-side prompt shipped in #375.

## Client surface checklist

Web-only (no API change) — checklist rows deleted per template guidance.

## Operational risk

None — static dashboard UI addition, no data or backend interaction beyond `navigator.clipboard`.

## Test plan

- [x] `npm test` — 299 tests (3 new: render, prompt-content invariants incl. no-GitHub-URL rule, copy-to-clipboard behavior)
- [x] `npm run lint` (0 errors), `npm run build` (static export)
- [x] Viewed live on the local dev server against the branch backend (all three pages, populated + empty states)

🤖 Generated with [Claude Code](https://claude.com/claude-code)