### PR TITLE
feat(v1): async-send contract — accepted status, wait param, terminal events + honesty fixes

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -533,6 +533,8 @@ components:
             enum:
               - email.received
               - email.sent
+              - email.failed
+              - email.deferred
               - email.review_approved
               - email.review_rejected
               - domain.sending_verified
@@ -568,7 +570,7 @@ components:
         enabled:
           type: boolean
         events:
-          description: "The event types this webhook matches. Open set: new event types may be added over time, so treat these as strings and tolerate unknown values. Known values: email.received, email.sent, email.delivered, email.bounced, email.complained, email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected, domain.sending_verified, domain.sending_failed, domain.suppression_added. Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable."
+          description: "The event types this webhook matches. Open set: new event types may be added over time, so treat these as strings and tolerate unknown values. Known values: email.received, email.sent, email.failed, email.deferred, email.delivered, email.bounced, email.complained, email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected, domain.sending_verified, domain.sending_failed, domain.suppression_added. Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable."
           items:
             type: string
           type: array
@@ -1092,7 +1094,7 @@ components:
         delivery_detail:
           type: string
         delivery_status:
-          description: "Outbound delivery rollup (worst recipient status by precedence; outbound only). Open set; tolerate unknown values. Known values: queued, sent, delivered, bounced, complained, deferred, failed."
+          description: "Outbound delivery rollup (worst recipient status by precedence; outbound only). Open set; tolerate unknown values. Known values: accepted, sending, sent, delivered, deferred, bounced, complained, failed. Lifecycle: accepted → sending → sent → delivered | deferred | bounced | complained | failed. (Legacy 'queued' is superseded by 'accepted'.)"
           type: string
         direction:
           enum:
@@ -1176,7 +1178,7 @@ components:
         delivery_detail:
           type: string
         delivery_status:
-          description: "Outbound delivery rollup (worst recipient status by precedence; outbound only). Open set; tolerate unknown values. Known values: queued, sent, delivered, bounced, complained, deferred, failed."
+          description: "Outbound delivery rollup (worst recipient status by precedence; outbound only). Open set; tolerate unknown values. Known values: accepted, sending, sent, delivered, deferred, bounced, complained, failed. Lifecycle: accepted → sending → sent → delivered | deferred | bounced | complained | failed. (Legacy 'queued' is superseded by 'accepted'.)"
           type: string
         direction:
           enum:
@@ -1802,12 +1804,13 @@ components:
           description: "Send transport. Open set; tolerate unknown values. Known values: smtp, loopback."
           type: string
         provider_message_id:
+          description: Upstream provider (SES) id. Optional/absent until the message is actually sent — an accepted-but-not-yet-sent message has no provider id.
           type: string
         sent_as:
           description: "From identity used. Open set; tolerate unknown values. Known values: own_address, relay."
           type: string
         status:
-          description: "Outcome. Open set; tolerate unknown values. Known values: sent, pending_review, review_approved."
+          description: "Outcome. Open set; tolerate unknown values. Known values: accepted, sent, pending_review, review_approved, failed. accepted = durably persisted and queued for submission (async pipeline); the terminal outcome arrives via webhook events (email.sent / email.failed) or GET /v1/messages/{id}. failed = terminal failure. Always branch on this field, not the HTTP status code."
           type: string
       required:
         - status
@@ -2017,6 +2020,8 @@ components:
           enum:
             - email.received
             - email.sent
+            - email.failed
+            - email.deferred
             - email.review_approved
             - email.review_rejected
             - domain.sending_verified
@@ -2100,6 +2105,8 @@ components:
             enum:
               - email.received
               - email.sent
+              - email.failed
+              - email.deferred
               - email.review_approved
               - email.review_rejected
               - domain.sending_verified
@@ -2278,7 +2285,7 @@ components:
           format: date-time
           type: string
         event_type:
-          description: "The event type that triggered this delivery. Open set: new event types may be added, so treat as a string and tolerate unknown values. Known values are the webhook event catalog (email.received, email.sent, email.delivered, …, domain.*)."
+          description: "The event type that triggered this delivery. Open set: new event types may be added, so treat as a string and tolerate unknown values. Known values are the webhook event catalog (email.received, email.sent, email.failed, email.deferred, email.delivered, …, domain.*)."
           type: string
         id:
           type: string
@@ -2334,7 +2341,7 @@ components:
         enabled:
           type: boolean
         events:
-          description: "The event types this webhook matches. Open set: new event types may be added over time, so treat these as strings and tolerate unknown values. Known values: email.received, email.sent, email.delivered, email.bounced, email.complained, email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected, domain.sending_verified, domain.sending_failed, domain.suppression_added. Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable."
+          description: "The event types this webhook matches. Open set: new event types may be added over time, so treat these as strings and tolerate unknown values. Known values: email.received, email.sent, email.failed, email.deferred, email.delivered, email.bounced, email.complained, email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected, domain.sending_verified, domain.sending_failed, domain.suppression_added. Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable."
           items:
             type: string
           type: array
@@ -2946,6 +2953,13 @@ paths:
           name: Idempotency-Key
           schema:
             type: string
+        - description: "Sync-compat valve. wait=sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status=accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome."
+          explode: false
+          in: query
+          name: wait
+          schema:
+            description: "Sync-compat valve. wait=sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status=accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome."
+            type: string
       requestBody:
         content:
           application/json:
@@ -3171,6 +3185,13 @@ paths:
           name: Idempotency-Key
           schema:
             type: string
+        - description: "Sync-compat valve. wait=sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status=accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome."
+          explode: false
+          in: query
+          name: wait
+          schema:
+            description: "Sync-compat valve. wait=sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status=accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome."
+            type: string
       requestBody:
         content:
           application/json:
@@ -3264,6 +3285,13 @@ paths:
         - in: header
           name: Idempotency-Key
           schema:
+            type: string
+        - description: "Sync-compat valve. wait=sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status=accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome."
+          explode: false
+          in: query
+          name: wait
+          schema:
+            description: "Sync-compat valve. wait=sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status=accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome."
             type: string
       requestBody:
         content:

--- a/docs/api.md
+++ b/docs/api.md
@@ -136,7 +136,20 @@ single message.
   `since`, `until`) and cursor pagination. Held outbound drafts appear with
   `status=pending_review`.
 - `POST …/messages` — send a new email (a new thread). `202` + `pending_review`
-  when the agent's protection policy holds it for review.
+  when the agent's protection policy holds it for review. The send result
+  `status` is an open set — known values `accepted | sent | pending_review |
+  review_approved | failed`. **Always branch on `status`, not the HTTP code.**
+  `accepted` (async pipeline) means the message is durably persisted and queued;
+  the terminal outcome then arrives via the `email.sent` / `email.failed` webhook
+  events or `GET …/messages/{id}`. `provider_message_id` is absent until the
+  message is actually sent. Optional `?wait=sent` holds the request until the
+  message reaches a terminal-or-held state or a bounded timeout (a synchronous
+  server treats it as a no-op).
+- **`delivery_status`** on a message follows `accepted → sending → sent →
+  delivered | deferred | bounced | complained | failed`. Note **`sent` ≠
+  `delivered`**: `sent` means the upstream provider (SES) accepted the message,
+  not that the recipient's server did. Delivery/bounce/complaint are per-recipient
+  async outcomes reported later via SNS and the corresponding webhook events.
 - `GET …/messages/{id}` — fetch one message (inbound or outbound), including the
   raw message and inbound auth headers. Reading an unread inbound message flips it
   to `read`.

--- a/docs/events.md
+++ b/docs/events.md
@@ -58,6 +58,8 @@ for e in client.events.list(type="email.received", limit=20):
 | `email.received` | Inbound SMTP message accepted | **At-least-once** end-to-end |
 | `email.flagged` | Inbound message accepted but did not match the agent's `inbound_policy` (delivered + flagged, never dropped) | **At-least-once** end-to-end |
 | `email.sent` | Outbound `/send` accepted by SES | Best-effort |
+| `email.failed` | Outbound send terminally failed (retries exhausted / permanent reject) — carries `reason`, `retryable: false` | **At-least-once** |
+| `email.deferred` | Outbound send transiently delayed and still retrying (SES 4xx / ramp deferral) — non-terminal; a later `email.sent`/`email.failed` follows | Best-effort |
 | `email.pending_review` | Message held for human review (outbound HITL or inbound screening) — carries `direction` | **At-least-once** |
 | `email.review_approved` | Review approved (outbound: sent; inbound: released to the inbox) | Best-effort |
 | `email.review_rejected` | Review rejected (outbound: discarded; inbound: dropped) | **At-least-once** |

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -1204,17 +1204,19 @@ func (a *API) DeliverOutbound(ctx context.Context, user *identity.User, agent *i
 		return &OutboundResult{Held: true, PendingMessageID: msg.ID, ApprovalExpiresAt: msg.ApprovalExpiresAt}, nil
 	}
 
-	// Record usage (side-effect only — never block on quota; the cap
-	// pre-check is the gate).
-	if _, err := a.usage.RecordAndCheck(ctx, user.ID, agent.ID, agent.Domain, "outbound"); err != nil {
-		log.Printf("[api] usage recording error: %v", err)
-	}
-
+	// Usage is metered AFTER the side effect + persist, never before (slice 1
+	// §7.2 / async-send-contract.md): billing must not run ahead of a durable
+	// message row, or a crash between meter and persist bills an invisible send.
 	if isSelfSend(req, agent.EmailAddress()) {
 		providerID, err := a.performSelfSend(ctx, agent, req, msgType)
 		if err != nil {
 			log.Printf("[api] self-send failed: agent=%s error=%v", agent.EmailAddress(), err)
 			return nil, &OutboundError{http.StatusInternalServerError, "internal_error", "self-send failed"}
+		}
+		// Meter after the loopback delivery succeeds (side-effect only — never
+		// block on quota; the cap pre-check is the gate).
+		if _, err := a.usage.RecordAndCheck(ctx, user.ID, agent.ID, agent.Domain, "outbound"); err != nil {
+			log.Printf("[api] usage recording error: %v", err)
 		}
 		slug, _, _ := strings.Cut(agent.EmailAddress(), "@")
 		log.Printf("[mail] dir=outbound type=%s method=loopback from=%s to=%s slug=%s conv_id=%s subject=%q provider_id=%s", msgType, agent.EmailAddress(), agent.EmailAddress(), slug, req.ConversationID, req.Subject, providerID)
@@ -1231,31 +1233,34 @@ func (a *API) DeliverOutbound(ctx context.Context, user *identity.User, agent *i
 	}
 	outMsg, err := a.store.CreateOutboundMessage(ctx, agent.ID, result.To, result.CC, result.BCC, req.Subject, msgType, result.Method, result.MessageID, req.ConversationID, result.Raw)
 	if err != nil {
-		log.Printf("[api] failed to record outbound message: %v", err)
+		// Slice 1 §7.1 (async-send-contract.md): the SES send already happened but
+		// we could not record it. Do NOT return a clean 2xx — a send that isn't in
+		// the DB is invisible and unrecoverable, so surface a 500 rather than
+		// claiming success. (Persist-first, slice 2, removes this window entirely.)
+		log.Printf("[api] failed to record outbound message (send already submitted): %v", err)
+		return nil, &OutboundError{http.StatusInternalServerError, "internal_error", "message was sent but could not be recorded; do not retry blindly"}
+	}
+	// Slice 1 §7.2: meter only after the message row is durable, so a crash or a
+	// failed insert above can never bill a message that has no row.
+	if _, err := a.usage.RecordAndCheck(ctx, user.ID, agent.ID, agent.Domain, "outbound"); err != nil {
+		log.Printf("[api] usage recording error: %v", err)
 	}
 	slug, _, _ := strings.Cut(agent.EmailAddress(), "@")
-	if outMsg != nil {
-		// Record the delivery lifecycle (decision 9): delivery_status='sent',
-		// which From identity was used, and the per-recipient breakdown the SES
-		// notifications consumer transitions as feedback arrives.
-		if err := a.store.MarkMessageSent(ctx, outMsg.ID, result.SentAs, result.To, result.CC, result.BCC); err != nil {
-			log.Printf("[api] mark sent (delivery_status): %v", err)
-		}
-		// flag verdict: delivered + annotated (denorm + protection_events + event).
-		if verdict.Annotate() {
-			a.annotateAndAudit(ctx, agent, outMsg.ID, req, verdict)
-		}
-		log.Printf("[mail:%s] dir=outbound type=%s from=%s to=%v slug=%s conv_id=%s subject=%q", outMsg.ID, msgType, agent.EmailAddress(), result.To, slug, req.ConversationID, req.Subject)
+	// Record the delivery lifecycle (decision 9): delivery_status='sent', which
+	// From identity was used, and the per-recipient breakdown the SES
+	// notifications consumer transitions as feedback arrives.
+	if err := a.store.MarkMessageSent(ctx, outMsg.ID, result.SentAs, result.To, result.CC, result.BCC); err != nil {
+		log.Printf("[api] mark sent (delivery_status): %v", err)
 	}
+	// flag verdict: delivered + annotated (denorm + protection_events + event).
+	if verdict.Annotate() {
+		a.annotateAndAudit(ctx, agent, outMsg.ID, req, verdict)
+	}
+	log.Printf("[mail:%s] dir=outbound type=%s from=%s to=%v slug=%s conv_id=%s subject=%q", outMsg.ID, msgType, agent.EmailAddress(), result.To, slug, req.ConversationID, req.Subject)
 	a.publishSent(ctx, a.buildSentEvent(agent, outMsg, result, req, msgType), outMsg)
-	// message_id is the e2a msg_ id (GET-able); the SES id is provider_message_id
-	// (MSG-9). Fall back to the provider id only if the row write failed.
-	e2aID := result.MessageID
-	if outMsg != nil {
-		e2aID = outMsg.ID
-	}
+	// message_id is the e2a msg_ id (GET-able); the SES id is provider_message_id (MSG-9).
 	return &OutboundResult{
-		MessageID:         e2aID,
+		MessageID:         outMsg.ID,
 		ProviderMessageID: result.MessageID,
 		SentAs:            result.SentAs,
 		Method:            result.Method,

--- a/internal/delivery/status.go
+++ b/internal/delivery/status.go
@@ -11,30 +11,40 @@ package delivery
 type Status string
 
 const (
-	StatusQueued     Status = "queued"     // accepted into the outbound path, not yet relayed
+	// StatusAccepted is the async-pipeline entry state (async-send-contract.md
+	// §3.1): durably persisted + queued for submission, no network I/O yet.
+	// Replaces the legacy StatusQueued, which was never emitted in production.
+	StatusAccepted Status = "accepted"
+	// StatusSending means a worker holds the lease and is submitting to SES.
+	StatusSending    Status = "sending"
+	StatusQueued     Status = "queued"     // DEPRECATED legacy alias for accepted; kept so any historical row stays Valid()
 	StatusSent       Status = "sent"       // accepted by the relay (SES) — NON-terminal
 	StatusDeferred   Status = "deferred"   // transient delay (SES deliveryDelay); poll, no event
 	StatusDelivered  Status = "delivered"  // SES confirmed delivery to the recipient MTA
 	StatusBounced    Status = "bounced"    // hard/soft bounce
 	StatusComplained Status = "complained" // recipient marked spam (FBL complaint)
-	StatusFailed     Status = "failed"     // local send failure (never reached the relay)
+	StatusFailed     Status = "failed"     // terminal send failure (retries exhausted / permanent reject)
 )
 
 // rank orders statuses by the decision-9 monotonic precedence
 //
-//	complained > bounced > delivered > deferred > sent > queued
+//	complained > bounced > delivered > deferred > sent > sending > accepted
 //
 // plus `failed` as a terminal local outcome above all SES feedback. Higher
 // rank wins a merge, so out-of-order or duplicate SNS events can never regress
 // a terminal status (a late `delivered` never clobbers a `complained`).
+// `accepted`/`sending` sit below `sent` so the async pre-send states never win
+// over provider feedback. (async-send-contract.md §3.1.)
 var rank = map[Status]int{
-	StatusQueued:     0,
-	StatusSent:       1,
-	StatusDeferred:   2,
-	StatusDelivered:  3,
-	StatusBounced:    4,
-	StatusComplained: 5,
-	StatusFailed:     6,
+	StatusAccepted:   0,
+	StatusQueued:     0, // legacy alias, equal rank to accepted
+	StatusSending:    1,
+	StatusSent:       2,
+	StatusDeferred:   3,
+	StatusDelivered:  4,
+	StatusBounced:    5,
+	StatusComplained: 6,
+	StatusFailed:     7,
 }
 
 // Valid reports whether s is a known status.

--- a/internal/httpapi/messages.go
+++ b/internal/httpapi/messages.go
@@ -52,7 +52,7 @@ type MessageView struct {
 	// DeliveryStatus is the outbound delivery rollup (migration 031:
 	// 'sent', 'delivered', 'bounced', …) — the worst recipient status by
 	// precedence. Outbound-only; omitted on inbound messages.
-	DeliveryStatus string `json:"delivery_status,omitempty" doc:"Outbound delivery rollup (worst recipient status by precedence; outbound only). Open set; tolerate unknown values. Known values: queued, sent, delivered, bounced, complained, deferred, failed."`
+	DeliveryStatus string `json:"delivery_status,omitempty" doc:"Outbound delivery rollup (worst recipient status by precedence; outbound only). Open set; tolerate unknown values. Known values: accepted, sending, sent, delivered, deferred, bounced, complained, failed. Lifecycle: accepted → sending → sent → delivered | deferred | bounced | complained | failed. (Legacy 'queued' is superseded by 'accepted'.)"`
 	// DeliveryDetail is the human-readable diagnostic for the delivery
 	// rollup (e.g. bounce sub-type / SMTP response). Outbound-only.
 	DeliveryDetail string `json:"delivery_detail,omitempty"`
@@ -233,7 +233,7 @@ type MessageSummaryView struct {
 	WebhookError   string   `json:"webhook_error,omitempty"`
 	// DeliveryStatus / DeliveryDetail / SentAs are the outbound delivery
 	// rollup (migration 031). Outbound-only; omitted on inbound rows.
-	DeliveryStatus string `json:"delivery_status,omitempty" doc:"Outbound delivery rollup (worst recipient status by precedence; outbound only). Open set; tolerate unknown values. Known values: queued, sent, delivered, bounced, complained, deferred, failed."`
+	DeliveryStatus string `json:"delivery_status,omitempty" doc:"Outbound delivery rollup (worst recipient status by precedence; outbound only). Open set; tolerate unknown values. Known values: accepted, sending, sent, delivered, deferred, bounced, complained, failed. Lifecycle: accepted → sending → sent → delivered | deferred | bounced | complained | failed. (Legacy 'queued' is superseded by 'accepted'.)"`
 	DeliveryDetail string `json:"delivery_detail,omitempty"`
 	SentAs         string `json:"sent_as,omitempty" doc:"From identity used at relay accept time (outbound only). Open set; tolerate unknown values. Known values: own_address, relay."`
 	// Flagged + FlagReason are the inbound ingestion verdict (migration 033 /

--- a/internal/httpapi/outbound.go
+++ b/internal/httpapi/outbound.go
@@ -55,9 +55,9 @@ type SendResultView struct {
 	// review_approved is the inbound-release outcome of POST .../approve (an
 	// inbound hold released to the agent's inbox — no send). sent/pending_review
 	// are the send/outbound-approve outcomes.
-	Status            string     `json:"status" doc:"Outcome. Open set; tolerate unknown values. Known values: sent, pending_review, review_approved."`
+	Status            string     `json:"status" doc:"Outcome. Open set; tolerate unknown values. Known values: accepted, sent, pending_review, review_approved, failed. accepted = durably persisted and queued for submission (async pipeline); the terminal outcome arrives via webhook events (email.sent / email.failed) or GET /v1/messages/{id}. failed = terminal failure. Always branch on this field, not the HTTP status code."`
 	MessageID         string     `json:"message_id"`
-	ProviderMessageID string     `json:"provider_message_id,omitempty"`
+	ProviderMessageID string     `json:"provider_message_id,omitempty" doc:"Upstream provider (SES) id. Optional/absent until the message is actually sent — an accepted-but-not-yet-sent message has no provider id."`
 	SentAs            string     `json:"sent_as,omitempty" doc:"From identity used. Open set; tolerate unknown values. Known values: own_address, relay."`
 	Method            string     `json:"method,omitempty" doc:"Send transport. Open set; tolerate unknown values. Known values: smtp, loopback."`
 	ApprovalExpiresAt *time.Time `json:"approval_expires_at,omitempty"`
@@ -118,6 +118,7 @@ type createMessageInput struct {
 	Address        string `path:"email"`
 	RawBody        []byte
 	IdempotencyKey string `header:"Idempotency-Key"`
+	Wait           string `query:"wait" doc:"Sync-compat valve. wait=sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status=accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome."`
 	Body           SendEmailRequest
 }
 
@@ -223,6 +224,7 @@ type replyInput struct {
 	ID             string `path:"id"`
 	RawBody        []byte
 	IdempotencyKey string `header:"Idempotency-Key"`
+	Wait           string `query:"wait" doc:"Sync-compat valve. wait=sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status=accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome."`
 	Body           ReplyRequest
 }
 
@@ -354,6 +356,7 @@ type forwardInput struct {
 	ID             string `path:"id"`
 	RawBody        []byte
 	IdempotencyKey string `header:"Idempotency-Key"`
+	Wait           string `query:"wait" doc:"Sync-compat valve. wait=sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status=accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome."`
 	Body           ForwardRequest
 }
 

--- a/internal/httpapi/webhooks.go
+++ b/internal/httpapi/webhooks.go
@@ -38,7 +38,7 @@ type WebhookView struct {
 	ID              string             `json:"id"`
 	URL             string             `json:"url"`
 	Description     string             `json:"description"`
-	Events          []string           `json:"events" nullable:"false" doc:"The event types this webhook matches. Open set: new event types may be added over time, so treat these as strings and tolerate unknown values. Known values: email.received, email.sent, email.delivered, email.bounced, email.complained, email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected, domain.sending_verified, domain.sending_failed, domain.suppression_added. Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable."`
+	Events          []string           `json:"events" nullable:"false" doc:"The event types this webhook matches. Open set: new event types may be added over time, so treat these as strings and tolerate unknown values. Known values: email.received, email.sent, email.failed, email.deferred, email.delivered, email.bounced, email.complained, email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected, domain.sending_verified, domain.sending_failed, domain.suppression_added. Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable."`
 	Filters         WebhookFiltersView `json:"filters"`
 	Enabled         bool               `json:"enabled"`
 	AutoDisabledAt  string             `json:"auto_disabled_at,omitempty" format:"date-time"`
@@ -182,7 +182,7 @@ type listWebhooksOutput struct {
 // webhookpub.AllEventTypes).
 type CreateWebhookRequest struct {
 	URL         string              `json:"url"`
-	Events      []string            `json:"events" nullable:"false" enum:"email.received,email.sent,email.review_approved,email.review_rejected,domain.sending_verified,domain.sending_failed,email.delivered,email.bounced,email.complained,domain.suppression_added,email.flagged,email.blocked,email.pending_review" doc:"Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable. All other events are stable."`
+	Events      []string            `json:"events" nullable:"false" enum:"email.received,email.sent,email.failed,email.deferred,email.review_approved,email.review_rejected,domain.sending_verified,domain.sending_failed,email.delivered,email.bounced,email.complained,domain.suppression_added,email.flagged,email.blocked,email.pending_review" doc:"Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable. All other events are stable."`
 	Filters     *WebhookFiltersView `json:"filters,omitempty"`
 	Description string              `json:"description,omitempty"`
 }
@@ -249,7 +249,7 @@ func (s *Server) registerWebhooks() {
 
 // TestWebhookRequest mirrors the legacy body.
 type TestWebhookRequest struct {
-	Event string         `json:"event,omitempty" enum:"email.received,email.sent,email.review_approved,email.review_rejected,domain.sending_verified,domain.sending_failed,email.delivered,email.bounced,email.complained,domain.suppression_added,email.flagged,email.blocked,email.pending_review"`
+	Event string         `json:"event,omitempty" enum:"email.received,email.sent,email.failed,email.deferred,email.review_approved,email.review_rejected,domain.sending_verified,domain.sending_failed,email.delivered,email.bounced,email.complained,domain.suppression_added,email.flagged,email.blocked,email.pending_review"`
 	Data  map[string]any `json:"data,omitempty"`
 }
 type testWebhookInput struct {
@@ -306,7 +306,7 @@ func (s *Server) handleTestWebhook(ctx context.Context, in *testWebhookInput) (*
 // WebhookDeliveryView mirrors the legacy per-delivery wire shape.
 type WebhookDeliveryView struct {
 	ID             string `json:"id"`
-	EventType      string `json:"event_type" doc:"The event type that triggered this delivery. Open set: new event types may be added, so treat as a string and tolerate unknown values. Known values are the webhook event catalog (email.received, email.sent, email.delivered, …, domain.*)."`
+	EventType      string `json:"event_type" doc:"The event type that triggered this delivery. Open set: new event types may be added, so treat as a string and tolerate unknown values. Known values are the webhook event catalog (email.received, email.sent, email.failed, email.deferred, email.delivered, …, domain.*)."`
 	Status         string `json:"status" doc:"Delivery state. Open set; tolerate unknown values. Known values: pending, delivered, failed."`
 	Attempts       int    `json:"attempts"`
 	LastError      string `json:"last_error,omitempty"`
@@ -369,7 +369,7 @@ func (s *Server) handleListWebhookDeliveries(ctx context.Context, in *ListDelive
 // absent != zero; url/events/filters are full-replace when present.
 type UpdateWebhookRequest struct {
 	URL         *string             `json:"url,omitempty"`
-	Events      *[]string           `json:"events,omitempty" enum:"email.received,email.sent,email.review_approved,email.review_rejected,domain.sending_verified,domain.sending_failed,email.delivered,email.bounced,email.complained,domain.suppression_added,email.flagged,email.blocked,email.pending_review" doc:"Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable. All other events are stable."`
+	Events      *[]string           `json:"events,omitempty" enum:"email.received,email.sent,email.failed,email.deferred,email.review_approved,email.review_rejected,domain.sending_verified,domain.sending_failed,email.delivered,email.bounced,email.complained,domain.suppression_added,email.flagged,email.blocked,email.pending_review" doc:"Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable. All other events are stable."`
 	Filters     *WebhookFiltersView `json:"filters,omitempty"`
 	Description *string             `json:"description,omitempty"`
 	Enabled     *bool               `json:"enabled,omitempty"`

--- a/internal/webhookpub/event.go
+++ b/internal/webhookpub/event.go
@@ -31,6 +31,18 @@ import (
 const (
 	EventEmailReceived = "email.received"
 	EventEmailSent     = "email.sent"
+	// Async-send terminal outcomes (async-send-contract.md §4). With the
+	// persist-first pipeline the API returns 200 `accepted` before the send
+	// completes, so these events are the push signal that a send finished:
+	//   - email.failed: terminal failure (retries exhausted / permanent reject /
+	//     block / review-reject-or-expiry). Carries retryable:false + reason.
+	//   - email.deferred: a transient delay the worker is still retrying (SES 4xx
+	//     / ramp deferral) — not terminal; a later email.sent or email.failed
+	//     follows. Peers (Resend/SendGrid) push the same delayed/deferred signal.
+	// Emitted synchronously today (the sync server already knows the outcome);
+	// they become the primary async signal once the worker pool ships (slice 3).
+	EventEmailFailed   = "email.failed"
+	EventEmailDeferred = "email.deferred"
 	// Review-hold lifecycle (unified, direction-aware — design 2026-06-22). A held
 	// message fires email.pending_review (defined below); on resolution it fires
 	// email.review_approved (outbound: sent; inbound: released to the agent) or
@@ -78,6 +90,8 @@ const (
 var AllEventTypes = []string{
 	EventEmailReceived,
 	EventEmailSent,
+	EventEmailFailed,
+	EventEmailDeferred,
 	EventEmailReviewApproved,
 	EventEmailReviewRejected,
 	EventDomainSendingVerified,

--- a/sdks/python/src/e2a/v1/generated/api/messages_api.py
+++ b/sdks/python/src/e2a/v1/generated/api/messages_api.py
@@ -380,6 +380,7 @@ class MessagesApi:
         id: StrictStr,
         forward_request: ForwardRequest,
         idempotency_key: Optional[StrictStr] = None,
+        wait: Annotated[Optional[StrictStr], Field(description="Sync-compat valve. wait=sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status=accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -405,6 +406,8 @@ class MessagesApi:
         :type forward_request: ForwardRequest
         :param idempotency_key:
         :type idempotency_key: str
+        :param wait: Sync-compat valve. wait=sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status=accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.
+        :type wait: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -432,6 +435,7 @@ class MessagesApi:
             id=id,
             forward_request=forward_request,
             idempotency_key=idempotency_key,
+            wait=wait,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -460,6 +464,7 @@ class MessagesApi:
         id: StrictStr,
         forward_request: ForwardRequest,
         idempotency_key: Optional[StrictStr] = None,
+        wait: Annotated[Optional[StrictStr], Field(description="Sync-compat valve. wait=sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status=accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -485,6 +490,8 @@ class MessagesApi:
         :type forward_request: ForwardRequest
         :param idempotency_key:
         :type idempotency_key: str
+        :param wait: Sync-compat valve. wait=sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status=accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.
+        :type wait: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -512,6 +519,7 @@ class MessagesApi:
             id=id,
             forward_request=forward_request,
             idempotency_key=idempotency_key,
+            wait=wait,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -540,6 +548,7 @@ class MessagesApi:
         id: StrictStr,
         forward_request: ForwardRequest,
         idempotency_key: Optional[StrictStr] = None,
+        wait: Annotated[Optional[StrictStr], Field(description="Sync-compat valve. wait=sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status=accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -565,6 +574,8 @@ class MessagesApi:
         :type forward_request: ForwardRequest
         :param idempotency_key:
         :type idempotency_key: str
+        :param wait: Sync-compat valve. wait=sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status=accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.
+        :type wait: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -592,6 +603,7 @@ class MessagesApi:
             id=id,
             forward_request=forward_request,
             idempotency_key=idempotency_key,
+            wait=wait,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -615,6 +627,7 @@ class MessagesApi:
         id,
         forward_request,
         idempotency_key,
+        wait,
         _request_auth,
         _content_type,
         _headers,
@@ -641,6 +654,10 @@ class MessagesApi:
         if id is not None:
             _path_params['id'] = id
         # process the query parameters
+        if wait is not None:
+            
+            _query_params.append(('wait', wait))
+            
         # process the header parameters
         if idempotency_key is not None:
             _header_params['Idempotency-Key'] = idempotency_key
@@ -2043,6 +2060,7 @@ class MessagesApi:
         id: StrictStr,
         reply_request: ReplyRequest,
         idempotency_key: Optional[StrictStr] = None,
+        wait: Annotated[Optional[StrictStr], Field(description="Sync-compat valve. wait=sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status=accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -2068,6 +2086,8 @@ class MessagesApi:
         :type reply_request: ReplyRequest
         :param idempotency_key:
         :type idempotency_key: str
+        :param wait: Sync-compat valve. wait=sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status=accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.
+        :type wait: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -2095,6 +2115,7 @@ class MessagesApi:
             id=id,
             reply_request=reply_request,
             idempotency_key=idempotency_key,
+            wait=wait,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -2123,6 +2144,7 @@ class MessagesApi:
         id: StrictStr,
         reply_request: ReplyRequest,
         idempotency_key: Optional[StrictStr] = None,
+        wait: Annotated[Optional[StrictStr], Field(description="Sync-compat valve. wait=sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status=accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -2148,6 +2170,8 @@ class MessagesApi:
         :type reply_request: ReplyRequest
         :param idempotency_key:
         :type idempotency_key: str
+        :param wait: Sync-compat valve. wait=sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status=accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.
+        :type wait: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -2175,6 +2199,7 @@ class MessagesApi:
             id=id,
             reply_request=reply_request,
             idempotency_key=idempotency_key,
+            wait=wait,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -2203,6 +2228,7 @@ class MessagesApi:
         id: StrictStr,
         reply_request: ReplyRequest,
         idempotency_key: Optional[StrictStr] = None,
+        wait: Annotated[Optional[StrictStr], Field(description="Sync-compat valve. wait=sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status=accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -2228,6 +2254,8 @@ class MessagesApi:
         :type reply_request: ReplyRequest
         :param idempotency_key:
         :type idempotency_key: str
+        :param wait: Sync-compat valve. wait=sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status=accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.
+        :type wait: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -2255,6 +2283,7 @@ class MessagesApi:
             id=id,
             reply_request=reply_request,
             idempotency_key=idempotency_key,
+            wait=wait,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -2278,6 +2307,7 @@ class MessagesApi:
         id,
         reply_request,
         idempotency_key,
+        wait,
         _request_auth,
         _content_type,
         _headers,
@@ -2304,6 +2334,10 @@ class MessagesApi:
         if id is not None:
             _path_params['id'] = id
         # process the query parameters
+        if wait is not None:
+            
+            _query_params.append(('wait', wait))
+            
         # process the header parameters
         if idempotency_key is not None:
             _header_params['Idempotency-Key'] = idempotency_key
@@ -2365,6 +2399,7 @@ class MessagesApi:
         email: StrictStr,
         send_email_request: SendEmailRequest,
         idempotency_key: Optional[StrictStr] = None,
+        wait: Annotated[Optional[StrictStr], Field(description="Sync-compat valve. wait=sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status=accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -2388,6 +2423,8 @@ class MessagesApi:
         :type send_email_request: SendEmailRequest
         :param idempotency_key:
         :type idempotency_key: str
+        :param wait: Sync-compat valve. wait=sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status=accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.
+        :type wait: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -2414,6 +2451,7 @@ class MessagesApi:
             email=email,
             send_email_request=send_email_request,
             idempotency_key=idempotency_key,
+            wait=wait,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -2441,6 +2479,7 @@ class MessagesApi:
         email: StrictStr,
         send_email_request: SendEmailRequest,
         idempotency_key: Optional[StrictStr] = None,
+        wait: Annotated[Optional[StrictStr], Field(description="Sync-compat valve. wait=sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status=accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -2464,6 +2503,8 @@ class MessagesApi:
         :type send_email_request: SendEmailRequest
         :param idempotency_key:
         :type idempotency_key: str
+        :param wait: Sync-compat valve. wait=sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status=accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.
+        :type wait: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -2490,6 +2531,7 @@ class MessagesApi:
             email=email,
             send_email_request=send_email_request,
             idempotency_key=idempotency_key,
+            wait=wait,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -2517,6 +2559,7 @@ class MessagesApi:
         email: StrictStr,
         send_email_request: SendEmailRequest,
         idempotency_key: Optional[StrictStr] = None,
+        wait: Annotated[Optional[StrictStr], Field(description="Sync-compat valve. wait=sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status=accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -2540,6 +2583,8 @@ class MessagesApi:
         :type send_email_request: SendEmailRequest
         :param idempotency_key:
         :type idempotency_key: str
+        :param wait: Sync-compat valve. wait=sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status=accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.
+        :type wait: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -2566,6 +2611,7 @@ class MessagesApi:
             email=email,
             send_email_request=send_email_request,
             idempotency_key=idempotency_key,
+            wait=wait,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -2588,6 +2634,7 @@ class MessagesApi:
         email,
         send_email_request,
         idempotency_key,
+        wait,
         _request_auth,
         _content_type,
         _headers,
@@ -2612,6 +2659,10 @@ class MessagesApi:
         if email is not None:
             _path_params['email'] = email
         # process the query parameters
+        if wait is not None:
+            
+            _query_params.append(('wait', wait))
+            
         # process the header parameters
         if idempotency_key is not None:
             _header_params['Idempotency-Key'] = idempotency_key

--- a/sdks/python/src/e2a/v1/generated/models/create_webhook_response.py
+++ b/sdks/python/src/e2a/v1/generated/models/create_webhook_response.py
@@ -32,7 +32,7 @@ class CreateWebhookResponse(BaseModel):
     created_at: datetime
     description: StrictStr
     enabled: StrictBool
-    events: List[StrictStr] = Field(description="The event types this webhook matches. Open set: new event types may be added over time, so treat these as strings and tolerate unknown values. Known values: email.received, email.sent, email.delivered, email.bounced, email.complained, email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected, domain.sending_verified, domain.sending_failed, domain.suppression_added. Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable.")
+    events: List[StrictStr] = Field(description="The event types this webhook matches. Open set: new event types may be added over time, so treat these as strings and tolerate unknown values. Known values: email.received, email.sent, email.failed, email.deferred, email.delivered, email.bounced, email.complained, email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected, domain.sending_verified, domain.sending_failed, domain.suppression_added. Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable.")
     filters: WebhookFiltersView
     id: StrictStr
     last_delivered_at: Optional[datetime] = None

--- a/sdks/python/src/e2a/v1/generated/models/message_summary_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/message_summary_view.py
@@ -33,7 +33,7 @@ class MessageSummaryView(BaseModel):
     conversation_id: Optional[StrictStr] = None
     created_at: datetime
     delivery_detail: Optional[StrictStr] = None
-    delivery_status: Optional[StrictStr] = Field(default=None, description="Outbound delivery rollup (worst recipient status by precedence; outbound only). Open set; tolerate unknown values. Known values: queued, sent, delivered, bounced, complained, deferred, failed.")
+    delivery_status: Optional[StrictStr] = Field(default=None, description="Outbound delivery rollup (worst recipient status by precedence; outbound only). Open set; tolerate unknown values. Known values: accepted, sending, sent, delivered, deferred, bounced, complained, failed. Lifecycle: accepted → sending → sent → delivered | deferred | bounced | complained | failed. (Legacy 'queued' is superseded by 'accepted'.)")
     direction: StrictStr
     flag_reason: Optional[StrictStr] = None
     flagged: Optional[StrictBool] = None

--- a/sdks/python/src/e2a/v1/generated/models/message_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/message_view.py
@@ -39,7 +39,7 @@ class MessageView(BaseModel):
     conversation_id: StrictStr
     created_at: datetime
     delivery_detail: Optional[StrictStr] = None
-    delivery_status: Optional[StrictStr] = Field(default=None, description="Outbound delivery rollup (worst recipient status by precedence; outbound only). Open set; tolerate unknown values. Known values: queued, sent, delivered, bounced, complained, deferred, failed.")
+    delivery_status: Optional[StrictStr] = Field(default=None, description="Outbound delivery rollup (worst recipient status by precedence; outbound only). Open set; tolerate unknown values. Known values: accepted, sending, sent, delivered, deferred, bounced, complained, failed. Lifecycle: accepted → sending → sent → delivered | deferred | bounced | complained | failed. (Legacy 'queued' is superseded by 'accepted'.)")
     direction: StrictStr
     flag_reason: Optional[StrictStr] = None
     flagged: Optional[StrictBool] = None

--- a/sdks/python/src/e2a/v1/generated/models/send_result_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/send_result_view.py
@@ -31,9 +31,9 @@ class SendResultView(BaseModel):
     edited: Optional[StrictBool] = None
     message_id: StrictStr
     method: Optional[StrictStr] = Field(default=None, description="Send transport. Open set; tolerate unknown values. Known values: smtp, loopback.")
-    provider_message_id: Optional[StrictStr] = None
+    provider_message_id: Optional[StrictStr] = Field(default=None, description="Upstream provider (SES) id. Optional/absent until the message is actually sent — an accepted-but-not-yet-sent message has no provider id.")
     sent_as: Optional[StrictStr] = Field(default=None, description="From identity used. Open set; tolerate unknown values. Known values: own_address, relay.")
-    status: StrictStr = Field(description="Outcome. Open set; tolerate unknown values. Known values: sent, pending_review, review_approved.")
+    status: StrictStr = Field(description="Outcome. Open set; tolerate unknown values. Known values: accepted, sent, pending_review, review_approved, failed. accepted = durably persisted and queued for submission (async pipeline); the terminal outcome arrives via webhook events (email.sent / email.failed) or GET /v1/messages/{id}. failed = terminal failure. Always branch on this field, not the HTTP status code.")
     __properties: ClassVar[List[str]] = ["approval_expires_at", "edited", "message_id", "method", "provider_message_id", "sent_as", "status"]
 
     model_config = ConfigDict(

--- a/sdks/python/src/e2a/v1/generated/models/webhook_delivery_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/webhook_delivery_view.py
@@ -29,7 +29,7 @@ class WebhookDeliveryView(BaseModel):
     """ # noqa: E501
     attempts: StrictInt
     created_at: datetime
-    event_type: StrictStr = Field(description="The event type that triggered this delivery. Open set: new event types may be added, so treat as a string and tolerate unknown values. Known values are the webhook event catalog (email.received, email.sent, email.delivered, …, domain.*).")
+    event_type: StrictStr = Field(description="The event type that triggered this delivery. Open set: new event types may be added, so treat as a string and tolerate unknown values. Known values are the webhook event catalog (email.received, email.sent, email.failed, email.deferred, email.delivered, …, domain.*).")
     id: StrictStr
     last_attempt_at: Optional[datetime] = None
     last_error: Optional[StrictStr] = None

--- a/sdks/python/src/e2a/v1/generated/models/webhook_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/webhook_view.py
@@ -32,7 +32,7 @@ class WebhookView(BaseModel):
     created_at: datetime
     description: StrictStr
     enabled: StrictBool
-    events: List[StrictStr] = Field(description="The event types this webhook matches. Open set: new event types may be added over time, so treat these as strings and tolerate unknown values. Known values: email.received, email.sent, email.delivered, email.bounced, email.complained, email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected, domain.sending_verified, domain.sending_failed, domain.suppression_added. Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable.")
+    events: List[StrictStr] = Field(description="The event types this webhook matches. Open set: new event types may be added over time, so treat these as strings and tolerate unknown values. Known values: email.received, email.sent, email.failed, email.deferred, email.delivered, email.bounced, email.complained, email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected, domain.sending_verified, domain.sending_failed, domain.suppression_added. Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable.")
     filters: WebhookFiltersView
     id: StrictStr
     last_delivered_at: Optional[datetime] = None

--- a/sdks/typescript/src/v1/generated/apis/MessagesApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/MessagesApi.ts
@@ -107,8 +107,9 @@ export class MessagesApiRequestFactory extends BaseAPIRequestFactory {
      * @param id 
      * @param forwardRequest 
      * @param idempotencyKey 
+     * @param wait Sync-compat valve. wait&#x3D;sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status&#x3D;accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.
      */
-    public async forwardMessage(email: string, id: string, forwardRequest: ForwardRequest, idempotencyKey?: string, _options?: Configuration): Promise<RequestContext> {
+    public async forwardMessage(email: string, id: string, forwardRequest: ForwardRequest, idempotencyKey?: string, wait?: string, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
 
         // verify required parameter 'email' is not null or undefined
@@ -130,6 +131,7 @@ export class MessagesApiRequestFactory extends BaseAPIRequestFactory {
 
 
 
+
         // Path Params
         const localVarPath = '/v1/agents/{email}/messages/{id}/forward'
             .replace('{' + 'email' + '}', encodeURIComponent(String(email)))
@@ -138,6 +140,11 @@ export class MessagesApiRequestFactory extends BaseAPIRequestFactory {
         // Make Request Context
         const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
+
+        // Query Params
+        if (wait !== undefined) {
+            requestContext.setQueryParam("wait", ObjectSerializer.serialize(wait, "string", ""));
+        }
 
         // Header Params
         requestContext.setHeaderParam("Idempotency-Key", ObjectSerializer.serialize(idempotencyKey, "string", ""));
@@ -466,8 +473,9 @@ export class MessagesApiRequestFactory extends BaseAPIRequestFactory {
      * @param id 
      * @param replyRequest 
      * @param idempotencyKey 
+     * @param wait Sync-compat valve. wait&#x3D;sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status&#x3D;accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.
      */
-    public async replyToMessage(email: string, id: string, replyRequest: ReplyRequest, idempotencyKey?: string, _options?: Configuration): Promise<RequestContext> {
+    public async replyToMessage(email: string, id: string, replyRequest: ReplyRequest, idempotencyKey?: string, wait?: string, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
 
         // verify required parameter 'email' is not null or undefined
@@ -489,6 +497,7 @@ export class MessagesApiRequestFactory extends BaseAPIRequestFactory {
 
 
 
+
         // Path Params
         const localVarPath = '/v1/agents/{email}/messages/{id}/reply'
             .replace('{' + 'email' + '}', encodeURIComponent(String(email)))
@@ -497,6 +506,11 @@ export class MessagesApiRequestFactory extends BaseAPIRequestFactory {
         // Make Request Context
         const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
+
+        // Query Params
+        if (wait !== undefined) {
+            requestContext.setQueryParam("wait", ObjectSerializer.serialize(wait, "string", ""));
+        }
 
         // Header Params
         requestContext.setHeaderParam("Idempotency-Key", ObjectSerializer.serialize(idempotencyKey, "string", ""));
@@ -536,8 +550,9 @@ export class MessagesApiRequestFactory extends BaseAPIRequestFactory {
      * @param email 
      * @param sendEmailRequest 
      * @param idempotencyKey 
+     * @param wait Sync-compat valve. wait&#x3D;sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status&#x3D;accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.
      */
-    public async sendMessage(email: string, sendEmailRequest: SendEmailRequest, idempotencyKey?: string, _options?: Configuration): Promise<RequestContext> {
+    public async sendMessage(email: string, sendEmailRequest: SendEmailRequest, idempotencyKey?: string, wait?: string, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
 
         // verify required parameter 'email' is not null or undefined
@@ -553,6 +568,7 @@ export class MessagesApiRequestFactory extends BaseAPIRequestFactory {
 
 
 
+
         // Path Params
         const localVarPath = '/v1/agents/{email}/messages'
             .replace('{' + 'email' + '}', encodeURIComponent(String(email)));
@@ -560,6 +576,11 @@ export class MessagesApiRequestFactory extends BaseAPIRequestFactory {
         // Make Request Context
         const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
+
+        // Query Params
+        if (wait !== undefined) {
+            requestContext.setQueryParam("wait", ObjectSerializer.serialize(wait, "string", ""));
+        }
 
         // Header Params
         requestContext.setHeaderParam("Idempotency-Key", ObjectSerializer.serialize(idempotencyKey, "string", ""));

--- a/sdks/typescript/src/v1/generated/models/CreateWebhookRequest.ts
+++ b/sdks/typescript/src/v1/generated/models/CreateWebhookRequest.ts
@@ -63,6 +63,8 @@ export class CreateWebhookRequest {
 export enum CreateWebhookRequestEventsEnum {
     EmailReceived = 'email.received',
     EmailSent = 'email.sent',
+    EmailFailed = 'email.failed',
+    EmailDeferred = 'email.deferred',
     EmailReviewApproved = 'email.review_approved',
     EmailReviewRejected = 'email.review_rejected',
     DomainSendingVerified = 'domain.sending_verified',

--- a/sdks/typescript/src/v1/generated/models/CreateWebhookResponse.ts
+++ b/sdks/typescript/src/v1/generated/models/CreateWebhookResponse.ts
@@ -19,7 +19,7 @@ export class CreateWebhookResponse {
     'description': string;
     'enabled': boolean;
     /**
-    * The event types this webhook matches. Open set: new event types may be added over time, so treat these as strings and tolerate unknown values. Known values: email.received, email.sent, email.delivered, email.bounced, email.complained, email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected, domain.sending_verified, domain.sending_failed, domain.suppression_added. Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable.
+    * The event types this webhook matches. Open set: new event types may be added over time, so treat these as strings and tolerate unknown values. Known values: email.received, email.sent, email.failed, email.deferred, email.delivered, email.bounced, email.complained, email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected, domain.sending_verified, domain.sending_failed, domain.suppression_added. Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable.
     */
     'events': Array<string>;
     'filters': WebhookFiltersView;

--- a/sdks/typescript/src/v1/generated/models/MessageSummaryView.ts
+++ b/sdks/typescript/src/v1/generated/models/MessageSummaryView.ts
@@ -20,7 +20,7 @@ export class MessageSummaryView {
     'createdAt': Date;
     'deliveryDetail'?: string;
     /**
-    * Outbound delivery rollup (worst recipient status by precedence; outbound only). Open set; tolerate unknown values. Known values: queued, sent, delivered, bounced, complained, deferred, failed.
+    * Outbound delivery rollup (worst recipient status by precedence; outbound only). Open set; tolerate unknown values. Known values: accepted, sending, sent, delivered, deferred, bounced, complained, failed. Lifecycle: accepted → sending → sent → delivered | deferred | bounced | complained | failed. (Legacy \'queued\' is superseded by \'accepted\'.)
     */
     'deliveryStatus'?: string;
     'direction': MessageSummaryViewDirectionEnum;

--- a/sdks/typescript/src/v1/generated/models/MessageView.ts
+++ b/sdks/typescript/src/v1/generated/models/MessageView.ts
@@ -26,7 +26,7 @@ export class MessageView {
     'createdAt': Date;
     'deliveryDetail'?: string;
     /**
-    * Outbound delivery rollup (worst recipient status by precedence; outbound only). Open set; tolerate unknown values. Known values: queued, sent, delivered, bounced, complained, deferred, failed.
+    * Outbound delivery rollup (worst recipient status by precedence; outbound only). Open set; tolerate unknown values. Known values: accepted, sending, sent, delivered, deferred, bounced, complained, failed. Lifecycle: accepted → sending → sent → delivered | deferred | bounced | complained | failed. (Legacy \'queued\' is superseded by \'accepted\'.)
     */
     'deliveryStatus'?: string;
     'direction': MessageViewDirectionEnum;

--- a/sdks/typescript/src/v1/generated/models/SendResultView.ts
+++ b/sdks/typescript/src/v1/generated/models/SendResultView.ts
@@ -20,13 +20,16 @@ export class SendResultView {
     * Send transport. Open set; tolerate unknown values. Known values: smtp, loopback.
     */
     'method'?: string;
+    /**
+    * Upstream provider (SES) id. Optional/absent until the message is actually sent — an accepted-but-not-yet-sent message has no provider id.
+    */
     'providerMessageId'?: string;
     /**
     * From identity used. Open set; tolerate unknown values. Known values: own_address, relay.
     */
     'sentAs'?: string;
     /**
-    * Outcome. Open set; tolerate unknown values. Known values: sent, pending_review, review_approved.
+    * Outcome. Open set; tolerate unknown values. Known values: accepted, sent, pending_review, review_approved, failed. accepted = durably persisted and queued for submission (async pipeline); the terminal outcome arrives via webhook events (email.sent / email.failed) or GET /v1/messages/{id}. failed = terminal failure. Always branch on this field, not the HTTP status code.
     */
     'status': string;
 

--- a/sdks/typescript/src/v1/generated/models/TestWebhookRequest.ts
+++ b/sdks/typescript/src/v1/generated/models/TestWebhookRequest.ts
@@ -45,6 +45,8 @@ export class TestWebhookRequest {
 export enum TestWebhookRequestEventEnum {
     EmailReceived = 'email.received',
     EmailSent = 'email.sent',
+    EmailFailed = 'email.failed',
+    EmailDeferred = 'email.deferred',
     EmailReviewApproved = 'email.review_approved',
     EmailReviewRejected = 'email.review_rejected',
     DomainSendingVerified = 'domain.sending_verified',

--- a/sdks/typescript/src/v1/generated/models/UpdateWebhookRequest.ts
+++ b/sdks/typescript/src/v1/generated/models/UpdateWebhookRequest.ts
@@ -70,6 +70,8 @@ export class UpdateWebhookRequest {
 export enum UpdateWebhookRequestEventsEnum {
     EmailReceived = 'email.received',
     EmailSent = 'email.sent',
+    EmailFailed = 'email.failed',
+    EmailDeferred = 'email.deferred',
     EmailReviewApproved = 'email.review_approved',
     EmailReviewRejected = 'email.review_rejected',
     DomainSendingVerified = 'domain.sending_verified',

--- a/sdks/typescript/src/v1/generated/models/WebhookDeliveryView.ts
+++ b/sdks/typescript/src/v1/generated/models/WebhookDeliveryView.ts
@@ -16,7 +16,7 @@ export class WebhookDeliveryView {
     'attempts': number;
     'createdAt': Date;
     /**
-    * The event type that triggered this delivery. Open set: new event types may be added, so treat as a string and tolerate unknown values. Known values are the webhook event catalog (email.received, email.sent, email.delivered, …, domain.*).
+    * The event type that triggered this delivery. Open set: new event types may be added, so treat as a string and tolerate unknown values. Known values are the webhook event catalog (email.received, email.sent, email.failed, email.deferred, email.delivered, …, domain.*).
     */
     'eventType': string;
     'id': string;

--- a/sdks/typescript/src/v1/generated/models/WebhookView.ts
+++ b/sdks/typescript/src/v1/generated/models/WebhookView.ts
@@ -19,7 +19,7 @@ export class WebhookView {
     'description': string;
     'enabled': boolean;
     /**
-    * The event types this webhook matches. Open set: new event types may be added over time, so treat these as strings and tolerate unknown values. Known values: email.received, email.sent, email.delivered, email.bounced, email.complained, email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected, domain.sending_verified, domain.sending_failed, domain.suppression_added. Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable.
+    * The event types this webhook matches. Open set: new event types may be added over time, so treat these as strings and tolerate unknown values. Known values: email.received, email.sent, email.failed, email.deferred, email.delivered, email.bounced, email.complained, email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected, domain.sending_verified, domain.sending_failed, domain.suppression_added. Beta: the screening + review-hold events (email.flagged, email.blocked, email.pending_review, email.review_approved, email.review_rejected) are unstable — their payload may change before they are declared stable.
     */
     'events': Array<string>;
     'filters': WebhookFiltersView;

--- a/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
@@ -1026,6 +1026,13 @@ export interface MessagesApiForwardMessageRequest {
      * @memberof MessagesApiforwardMessage
      */
     idempotencyKey?: string
+    /**
+     * Sync-compat valve. wait&#x3D;sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status&#x3D;accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.
+     * Defaults to: undefined
+     * @type string
+     * @memberof MessagesApiforwardMessage
+     */
+    wait?: string
 }
 
 export interface MessagesApiGetAttachmentRequest {
@@ -1217,6 +1224,13 @@ export interface MessagesApiReplyToMessageRequest {
      * @memberof MessagesApireplyToMessage
      */
     idempotencyKey?: string
+    /**
+     * Sync-compat valve. wait&#x3D;sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status&#x3D;accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.
+     * Defaults to: undefined
+     * @type string
+     * @memberof MessagesApireplyToMessage
+     */
+    wait?: string
 }
 
 export interface MessagesApiSendMessageRequest {
@@ -1240,6 +1254,13 @@ export interface MessagesApiSendMessageRequest {
      * @memberof MessagesApisendMessage
      */
     idempotencyKey?: string
+    /**
+     * Sync-compat valve. wait&#x3D;sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status&#x3D;accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.
+     * Defaults to: undefined
+     * @type string
+     * @memberof MessagesApisendMessage
+     */
+    wait?: string
 }
 
 export interface MessagesApiUpdateMessageRequest {
@@ -1296,7 +1317,7 @@ export class ObjectMessagesApi {
      * @param param the request object
      */
     public forwardMessageWithHttpInfo(param: MessagesApiForwardMessageRequest, options?: ConfigurationOptions): Promise<HttpInfo<SendResultView>> {
-        return this.api.forwardMessageWithHttpInfo(param.email, param.id, param.forwardRequest, param.idempotencyKey,  options).toPromise();
+        return this.api.forwardMessageWithHttpInfo(param.email, param.id, param.forwardRequest, param.idempotencyKey, param.wait,  options).toPromise();
     }
 
     /**
@@ -1305,7 +1326,7 @@ export class ObjectMessagesApi {
      * @param param the request object
      */
     public forwardMessage(param: MessagesApiForwardMessageRequest, options?: ConfigurationOptions): Promise<SendResultView> {
-        return this.api.forwardMessage(param.email, param.id, param.forwardRequest, param.idempotencyKey,  options).toPromise();
+        return this.api.forwardMessage(param.email, param.id, param.forwardRequest, param.idempotencyKey, param.wait,  options).toPromise();
     }
 
     /**
@@ -1386,7 +1407,7 @@ export class ObjectMessagesApi {
      * @param param the request object
      */
     public replyToMessageWithHttpInfo(param: MessagesApiReplyToMessageRequest, options?: ConfigurationOptions): Promise<HttpInfo<SendResultView>> {
-        return this.api.replyToMessageWithHttpInfo(param.email, param.id, param.replyRequest, param.idempotencyKey,  options).toPromise();
+        return this.api.replyToMessageWithHttpInfo(param.email, param.id, param.replyRequest, param.idempotencyKey, param.wait,  options).toPromise();
     }
 
     /**
@@ -1395,7 +1416,7 @@ export class ObjectMessagesApi {
      * @param param the request object
      */
     public replyToMessage(param: MessagesApiReplyToMessageRequest, options?: ConfigurationOptions): Promise<SendResultView> {
-        return this.api.replyToMessage(param.email, param.id, param.replyRequest, param.idempotencyKey,  options).toPromise();
+        return this.api.replyToMessage(param.email, param.id, param.replyRequest, param.idempotencyKey, param.wait,  options).toPromise();
     }
 
     /**
@@ -1404,7 +1425,7 @@ export class ObjectMessagesApi {
      * @param param the request object
      */
     public sendMessageWithHttpInfo(param: MessagesApiSendMessageRequest, options?: ConfigurationOptions): Promise<HttpInfo<SendResultView>> {
-        return this.api.sendMessageWithHttpInfo(param.email, param.sendEmailRequest, param.idempotencyKey,  options).toPromise();
+        return this.api.sendMessageWithHttpInfo(param.email, param.sendEmailRequest, param.idempotencyKey, param.wait,  options).toPromise();
     }
 
     /**
@@ -1413,7 +1434,7 @@ export class ObjectMessagesApi {
      * @param param the request object
      */
     public sendMessage(param: MessagesApiSendMessageRequest, options?: ConfigurationOptions): Promise<SendResultView> {
-        return this.api.sendMessage(param.email, param.sendEmailRequest, param.idempotencyKey,  options).toPromise();
+        return this.api.sendMessage(param.email, param.sendEmailRequest, param.idempotencyKey, param.wait,  options).toPromise();
     }
 
     /**

--- a/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
@@ -1150,11 +1150,12 @@ export class ObservableMessagesApi {
      * @param id
      * @param forwardRequest
      * @param [idempotencyKey]
+     * @param [wait] Sync-compat valve. wait&#x3D;sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status&#x3D;accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.
      */
-    public forwardMessageWithHttpInfo(email: string, id: string, forwardRequest: ForwardRequest, idempotencyKey?: string, _options?: ConfigurationOptions): Observable<HttpInfo<SendResultView>> {
+    public forwardMessageWithHttpInfo(email: string, id: string, forwardRequest: ForwardRequest, idempotencyKey?: string, wait?: string, _options?: ConfigurationOptions): Observable<HttpInfo<SendResultView>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.forwardMessage(email, id, forwardRequest, idempotencyKey, _config);
+        const requestContextPromise = this.requestFactory.forwardMessage(email, id, forwardRequest, idempotencyKey, wait, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -1178,9 +1179,10 @@ export class ObservableMessagesApi {
      * @param id
      * @param forwardRequest
      * @param [idempotencyKey]
+     * @param [wait] Sync-compat valve. wait&#x3D;sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status&#x3D;accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.
      */
-    public forwardMessage(email: string, id: string, forwardRequest: ForwardRequest, idempotencyKey?: string, _options?: ConfigurationOptions): Observable<SendResultView> {
-        return this.forwardMessageWithHttpInfo(email, id, forwardRequest, idempotencyKey, _options).pipe(map((apiResponse: HttpInfo<SendResultView>) => apiResponse.data));
+    public forwardMessage(email: string, id: string, forwardRequest: ForwardRequest, idempotencyKey?: string, wait?: string, _options?: ConfigurationOptions): Observable<SendResultView> {
+        return this.forwardMessageWithHttpInfo(email, id, forwardRequest, idempotencyKey, wait, _options).pipe(map((apiResponse: HttpInfo<SendResultView>) => apiResponse.data));
     }
 
     /**
@@ -1360,11 +1362,12 @@ export class ObservableMessagesApi {
      * @param id
      * @param replyRequest
      * @param [idempotencyKey]
+     * @param [wait] Sync-compat valve. wait&#x3D;sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status&#x3D;accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.
      */
-    public replyToMessageWithHttpInfo(email: string, id: string, replyRequest: ReplyRequest, idempotencyKey?: string, _options?: ConfigurationOptions): Observable<HttpInfo<SendResultView>> {
+    public replyToMessageWithHttpInfo(email: string, id: string, replyRequest: ReplyRequest, idempotencyKey?: string, wait?: string, _options?: ConfigurationOptions): Observable<HttpInfo<SendResultView>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.replyToMessage(email, id, replyRequest, idempotencyKey, _config);
+        const requestContextPromise = this.requestFactory.replyToMessage(email, id, replyRequest, idempotencyKey, wait, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -1388,9 +1391,10 @@ export class ObservableMessagesApi {
      * @param id
      * @param replyRequest
      * @param [idempotencyKey]
+     * @param [wait] Sync-compat valve. wait&#x3D;sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status&#x3D;accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.
      */
-    public replyToMessage(email: string, id: string, replyRequest: ReplyRequest, idempotencyKey?: string, _options?: ConfigurationOptions): Observable<SendResultView> {
-        return this.replyToMessageWithHttpInfo(email, id, replyRequest, idempotencyKey, _options).pipe(map((apiResponse: HttpInfo<SendResultView>) => apiResponse.data));
+    public replyToMessage(email: string, id: string, replyRequest: ReplyRequest, idempotencyKey?: string, wait?: string, _options?: ConfigurationOptions): Observable<SendResultView> {
+        return this.replyToMessageWithHttpInfo(email, id, replyRequest, idempotencyKey, wait, _options).pipe(map((apiResponse: HttpInfo<SendResultView>) => apiResponse.data));
     }
 
     /**
@@ -1399,11 +1403,12 @@ export class ObservableMessagesApi {
      * @param email
      * @param sendEmailRequest
      * @param [idempotencyKey]
+     * @param [wait] Sync-compat valve. wait&#x3D;sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status&#x3D;accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.
      */
-    public sendMessageWithHttpInfo(email: string, sendEmailRequest: SendEmailRequest, idempotencyKey?: string, _options?: ConfigurationOptions): Observable<HttpInfo<SendResultView>> {
+    public sendMessageWithHttpInfo(email: string, sendEmailRequest: SendEmailRequest, idempotencyKey?: string, wait?: string, _options?: ConfigurationOptions): Observable<HttpInfo<SendResultView>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.sendMessage(email, sendEmailRequest, idempotencyKey, _config);
+        const requestContextPromise = this.requestFactory.sendMessage(email, sendEmailRequest, idempotencyKey, wait, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -1426,9 +1431,10 @@ export class ObservableMessagesApi {
      * @param email
      * @param sendEmailRequest
      * @param [idempotencyKey]
+     * @param [wait] Sync-compat valve. wait&#x3D;sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status&#x3D;accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.
      */
-    public sendMessage(email: string, sendEmailRequest: SendEmailRequest, idempotencyKey?: string, _options?: ConfigurationOptions): Observable<SendResultView> {
-        return this.sendMessageWithHttpInfo(email, sendEmailRequest, idempotencyKey, _options).pipe(map((apiResponse: HttpInfo<SendResultView>) => apiResponse.data));
+    public sendMessage(email: string, sendEmailRequest: SendEmailRequest, idempotencyKey?: string, wait?: string, _options?: ConfigurationOptions): Observable<SendResultView> {
+        return this.sendMessageWithHttpInfo(email, sendEmailRequest, idempotencyKey, wait, _options).pipe(map((apiResponse: HttpInfo<SendResultView>) => apiResponse.data));
     }
 
     /**

--- a/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
@@ -827,10 +827,11 @@ export class PromiseMessagesApi {
      * @param id
      * @param forwardRequest
      * @param [idempotencyKey]
+     * @param [wait] Sync-compat valve. wait&#x3D;sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status&#x3D;accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.
      */
-    public forwardMessageWithHttpInfo(email: string, id: string, forwardRequest: ForwardRequest, idempotencyKey?: string, _options?: PromiseConfigurationOptions): Promise<HttpInfo<SendResultView>> {
+    public forwardMessageWithHttpInfo(email: string, id: string, forwardRequest: ForwardRequest, idempotencyKey?: string, wait?: string, _options?: PromiseConfigurationOptions): Promise<HttpInfo<SendResultView>> {
         const observableOptions = wrapOptions(_options);
-        const result = this.api.forwardMessageWithHttpInfo(email, id, forwardRequest, idempotencyKey, observableOptions);
+        const result = this.api.forwardMessageWithHttpInfo(email, id, forwardRequest, idempotencyKey, wait, observableOptions);
         return result.toPromise();
     }
 
@@ -841,10 +842,11 @@ export class PromiseMessagesApi {
      * @param id
      * @param forwardRequest
      * @param [idempotencyKey]
+     * @param [wait] Sync-compat valve. wait&#x3D;sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status&#x3D;accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.
      */
-    public forwardMessage(email: string, id: string, forwardRequest: ForwardRequest, idempotencyKey?: string, _options?: PromiseConfigurationOptions): Promise<SendResultView> {
+    public forwardMessage(email: string, id: string, forwardRequest: ForwardRequest, idempotencyKey?: string, wait?: string, _options?: PromiseConfigurationOptions): Promise<SendResultView> {
         const observableOptions = wrapOptions(_options);
-        const result = this.api.forwardMessage(email, id, forwardRequest, idempotencyKey, observableOptions);
+        const result = this.api.forwardMessage(email, id, forwardRequest, idempotencyKey, wait, observableOptions);
         return result.toPromise();
     }
 
@@ -977,10 +979,11 @@ export class PromiseMessagesApi {
      * @param id
      * @param replyRequest
      * @param [idempotencyKey]
+     * @param [wait] Sync-compat valve. wait&#x3D;sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status&#x3D;accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.
      */
-    public replyToMessageWithHttpInfo(email: string, id: string, replyRequest: ReplyRequest, idempotencyKey?: string, _options?: PromiseConfigurationOptions): Promise<HttpInfo<SendResultView>> {
+    public replyToMessageWithHttpInfo(email: string, id: string, replyRequest: ReplyRequest, idempotencyKey?: string, wait?: string, _options?: PromiseConfigurationOptions): Promise<HttpInfo<SendResultView>> {
         const observableOptions = wrapOptions(_options);
-        const result = this.api.replyToMessageWithHttpInfo(email, id, replyRequest, idempotencyKey, observableOptions);
+        const result = this.api.replyToMessageWithHttpInfo(email, id, replyRequest, idempotencyKey, wait, observableOptions);
         return result.toPromise();
     }
 
@@ -991,10 +994,11 @@ export class PromiseMessagesApi {
      * @param id
      * @param replyRequest
      * @param [idempotencyKey]
+     * @param [wait] Sync-compat valve. wait&#x3D;sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status&#x3D;accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.
      */
-    public replyToMessage(email: string, id: string, replyRequest: ReplyRequest, idempotencyKey?: string, _options?: PromiseConfigurationOptions): Promise<SendResultView> {
+    public replyToMessage(email: string, id: string, replyRequest: ReplyRequest, idempotencyKey?: string, wait?: string, _options?: PromiseConfigurationOptions): Promise<SendResultView> {
         const observableOptions = wrapOptions(_options);
-        const result = this.api.replyToMessage(email, id, replyRequest, idempotencyKey, observableOptions);
+        const result = this.api.replyToMessage(email, id, replyRequest, idempotencyKey, wait, observableOptions);
         return result.toPromise();
     }
 
@@ -1004,10 +1008,11 @@ export class PromiseMessagesApi {
      * @param email
      * @param sendEmailRequest
      * @param [idempotencyKey]
+     * @param [wait] Sync-compat valve. wait&#x3D;sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status&#x3D;accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.
      */
-    public sendMessageWithHttpInfo(email: string, sendEmailRequest: SendEmailRequest, idempotencyKey?: string, _options?: PromiseConfigurationOptions): Promise<HttpInfo<SendResultView>> {
+    public sendMessageWithHttpInfo(email: string, sendEmailRequest: SendEmailRequest, idempotencyKey?: string, wait?: string, _options?: PromiseConfigurationOptions): Promise<HttpInfo<SendResultView>> {
         const observableOptions = wrapOptions(_options);
-        const result = this.api.sendMessageWithHttpInfo(email, sendEmailRequest, idempotencyKey, observableOptions);
+        const result = this.api.sendMessageWithHttpInfo(email, sendEmailRequest, idempotencyKey, wait, observableOptions);
         return result.toPromise();
     }
 
@@ -1017,10 +1022,11 @@ export class PromiseMessagesApi {
      * @param email
      * @param sendEmailRequest
      * @param [idempotencyKey]
+     * @param [wait] Sync-compat valve. wait&#x3D;sent holds the request until the message reaches a terminal-or-held state or a bounded timeout (≤20s), then returns that state; on timeout returns status&#x3D;accepted. Default: no wait. Always branch on body.status, not the HTTP code. No-op until the async pipeline ships — a synchronous server already has the outcome.
      */
-    public sendMessage(email: string, sendEmailRequest: SendEmailRequest, idempotencyKey?: string, _options?: PromiseConfigurationOptions): Promise<SendResultView> {
+    public sendMessage(email: string, sendEmailRequest: SendEmailRequest, idempotencyKey?: string, wait?: string, _options?: PromiseConfigurationOptions): Promise<SendResultView> {
         const observableOptions = wrapOptions(_options);
-        const result = this.api.sendMessage(email, sendEmailRequest, idempotencyKey, observableOptions);
+        const result = this.api.sendMessage(email, sendEmailRequest, idempotencyKey, wait, observableOptions);
         return result.toPromise();
     }
 


### PR DESCRIPTION
## What

The **engine-agnostic** contract/spec changes that make the frozen `/v1` send surface forward-compatible with the async send pipeline, plus two server honesty fixes. A synchronous server fully satisfies this contract — it does not depend on how (or whether) the queue is built, so it can merge independently of the queue-engine work (River consolidation).

### Contract / spec
- Send-result `status` known-values gain **`accepted`** and **`failed`** (open set); `provider_message_id` documented **optional/absent until sent**.
- `delivery_status` vocabulary: add **`accepted`** / **`sending`** (below `sent` in `delivery.Merge` precedence); `queued` kept as a deprecated legacy alias.
- New webhook events **`email.failed`** + **`email.deferred`** (catalog + the three request-side enums + docs).
- New **`wait=sent`** query param on send/reply/forward — documented, and a **no-op on today's synchronous server** (it already has the outcome), so this changes no runtime behavior.
- Regenerated `api/openapi.yaml` + TS/Python SDK bases; updated `docs/api.md` + `docs/events.md`.

### Server honesty fixes (`internal/agent/api.go` `DeliverOutbound`)
- **§7.1** — a failed `CreateOutboundMessage` no longer returns a clean 2xx: a send we can't record now returns **500** (do not claim success for an invisible send).
- **§7.2** — usage metering moved **after** the message-row persist, so a crash/failed insert can't bill a message that has no row.

## Why now
These land the pre-GA contract regardless of the queue-engine decision, so they're split out from the (larger, separate) River queue-consolidation work to merge on their own timeline.

## Testing
- `make test-unit` green; agent DB-backed send suite green (real Postgres).
- `spec-check` (`TestSpecGoldenNoDrift`) + `generate-sdk-check` drift gates green.
- `TestWebhookEventEnumMatchesCatalog` green (new events added to all request-side enums).

## Not in this PR
The async pipeline implementation (queue + worker) — that's the River-based consolidation, on a separate branch. The `wait=sent` behavior, the 202→200 held-send flip, and async scan land with that work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)