### PR TITLE
refactor(jobs): shared River composition root + move senderidentity onto it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ test-integration:
 	E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable" go test -p 1 ./internal/identity/ ./internal/agent/ ./internal/hitlworker/ ./internal/hitlnotify/ ./internal/limits/ ./internal/relay/
 
 test-e2e:
-	E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable" go test -tags integration -p 1 ./internal/e2e/
+	E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable" go test -tags integration -p 1 ./internal/e2e/ ./internal/senderidentity/
 
 # cover writes a coverage profile across the internal packages (needs Postgres
 # on :5433, like `make test`; -p 1 avoids cross-package test-DB contention).

--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -253,6 +253,10 @@ func main() {
 	// domain delete enqueues a teardown job in the delete tx. Without SES the
 	// interface stays a true nil (sending_status never leaves "none").
 	var senderEnqueuer apiserver.SenderIdentityEnqueuer
+	// jobsClient is the shared River client. Hoisted so the shutdown sequence
+	// can drain it under the same bounded deadline as the HTTP server + workers
+	// (nil when SES is off — nothing registers on it yet).
+	var jobsClient *jobs.Client
 	if region := cfg.SenderIdentity.SESRegion; region != "" {
 		provider, perr := senderidentity.NewSESProviderFromConfig(ctx, region)
 		if perr != nil {
@@ -268,15 +272,18 @@ func main() {
 		// only) registrar; as outbound/webhook/HITL move onto River they join
 		// this same jobs.New call. Inject the client back so the manager's
 		// Enqueue* methods can insert.
-		jobsClient, jerr := jobs.New(pool, jobs.Config{}, senderMgr)
+		jc, jerr := jobs.New(pool, jobs.Config{}, senderMgr)
 		if jerr != nil {
 			log.Fatalf("jobs: build shared river client: %v", jerr)
 		}
+		jobsClient = jc
 		senderMgr.SetEnqueuer(jobsClient)
 		if serr := jobsClient.Start(ctx); serr != nil {
 			log.Fatalf("jobs: start shared river client: %v", serr)
 		}
-		defer jobsClient.Stop(context.Background())
+		// Stop is driven from the shutdown sequence under the shared deadline,
+		// not a context.Background() defer (which would drain unbounded, past
+		// the platform grace period).
 		senderEnqueuer = senderMgr
 		log.Printf("[sender-identity] SES provisioning enabled (region=%s)", region)
 	}
@@ -662,6 +669,22 @@ func main() {
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), shutdownBudget)
 	defer shutdownCancel()
 
+	// Drain the shared River client concurrently with HTTP shutdown, under the
+	// SAME deadline. Stop() halts claiming new jobs immediately (so a
+	// terminating replica stops picking up fresh work, like the cancelled
+	// workers above) and drains in-flight jobs; bounding it by shutdownCtx means
+	// a job stuck in an SES/network call is abandoned when the shared budget
+	// expires rather than blocking process exit past the platform grace period.
+	riverDone := make(chan struct{})
+	go func() {
+		if jobsClient != nil {
+			if err := jobsClient.Stop(shutdownCtx); err != nil && shutdownCtx.Err() == nil {
+				log.Printf("River client stop: %v", err)
+			}
+		}
+		close(riverDone)
+	}()
+
 	if err := httpServer.Shutdown(shutdownCtx); err != nil {
 		log.Printf("HTTP server shutdown error: %v", err)
 	}
@@ -681,4 +704,7 @@ func main() {
 	case <-shutdownCtx.Done():
 		log.Println("Background workers did not drain within shutdown budget; exiting anyway.")
 	}
+	// River drain is bounded by the same shutdownCtx, so this returns by the
+	// deadline regardless.
+	<-riverDone
 }

--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/hitlworker"
 	"github.com/Mnexa-AI/e2a/internal/idempotency"
 	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/jobs"
 	"github.com/Mnexa-AI/e2a/internal/limits"
 	"github.com/Mnexa-AI/e2a/internal/oauth"
 	"github.com/Mnexa-AI/e2a/internal/outbound"
@@ -145,10 +146,11 @@ func main() {
 	if err := identity.RunMigrations(ctx, pool, migrations.FS, migrationMode); err != nil {
 		log.Fatalf("Schema migration failed: %v", err)
 	}
-	// River's own schema (job queue) for the sender-identity workers
-	// (decision 4 / Slice 4). Tracked in River's river_migration table,
-	// separate from e2a's schema_migrations; idempotent.
-	if err := senderidentity.Migrate(ctx, pool); err != nil {
+	// River's own schema (the shared job queue, internal/jobs). Tracked in
+	// River's river_migration table, separate from e2a's schema_migrations;
+	// idempotent. Applied unconditionally so river_job exists for every domain
+	// that registers on the shared client.
+	if err := jobs.Migrate(ctx, pool); err != nil {
 		log.Fatalf("River schema migration failed: %v", err)
 	}
 
@@ -256,20 +258,25 @@ func main() {
 		if perr != nil {
 			log.Fatalf("sender identity: build SES provider: %v", perr)
 		}
-		senderMgr, merr := senderidentity.NewManager(
-			pool,
+		senderMgr := senderidentity.NewManager(
 			senderidentity.NewStoreAdapter(store),
 			provider,
 			senderIdentityEventFirer(webhookPublisher),
 			senderidentity.Config{},
 		)
-		if merr != nil {
-			log.Fatalf("sender identity: build manager: %v", merr)
+		// Build the shared River client with senderidentity as its (currently
+		// only) registrar; as outbound/webhook/HITL move onto River they join
+		// this same jobs.New call. Inject the client back so the manager's
+		// Enqueue* methods can insert.
+		jobsClient, jerr := jobs.New(pool, jobs.Config{}, senderMgr)
+		if jerr != nil {
+			log.Fatalf("jobs: build shared river client: %v", jerr)
 		}
-		if serr := senderMgr.Start(ctx); serr != nil {
-			log.Fatalf("sender identity: start manager: %v", serr)
+		senderMgr.SetEnqueuer(jobsClient)
+		if serr := jobsClient.Start(ctx); serr != nil {
+			log.Fatalf("jobs: start shared river client: %v", serr)
 		}
-		defer senderMgr.Stop(context.Background())
+		defer jobsClient.Stop(context.Background())
 		senderEnqueuer = senderMgr
 		log.Printf("[sender-identity] SES provisioning enabled (region=%s)", region)
 	}

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -1,0 +1,110 @@
+// Package jobs is the single River composition root for e2a's background work.
+// All durable background jobs — outbound sends, webhook delivery, HITL hold
+// resolution, sender-identity provisioning, janitors — run on ONE shared
+// river.Client against ONE river_job table, instead of a bespoke Postgres queue
+// per subsystem. Each domain contributes its workers as a Registrar; queues are
+// central (queues.go); business code enqueues through the Enqueuer interface so
+// it stays testable and River lives at the edges.
+//
+// This replaces the hand-rolled claim/lease/retry/sweep machinery: River's
+// SKIP LOCKED claim, per-job MaxAttempts + retry policy, and built-in reaper do
+// the plumbing, so domains only write job args + a Work() handler.
+package jobs
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+	"github.com/riverqueue/river/rivermigrate"
+	"github.com/riverqueue/river/rivertype"
+)
+
+// Enqueuer is the narrow insert surface business code depends on, rather than the
+// whole river.Client — keeps the store/agent layer testable with a fake and River
+// swappable. Insert enqueues immediately; InsertTx enqueues WITHIN the caller's
+// transaction (the outbox pattern: the job commits atomically with the business
+// write and can never be lost). *river.Client[pgx.Tx] satisfies this directly.
+type Enqueuer interface {
+	Insert(ctx context.Context, args river.JobArgs, opts *river.InsertOpts) (*rivertype.JobInsertResult, error)
+	InsertTx(ctx context.Context, tx pgx.Tx, args river.JobArgs, opts *river.InsertOpts) (*rivertype.JobInsertResult, error)
+}
+
+// Registrar is what each domain implements to contribute its jobs to the shared
+// client. RegisterJobs adds the domain's workers to the shared bundle (via
+// river.AddWorker) and returns any periodic jobs it wants scheduled. Called once,
+// at client construction — River requires all workers registered before Start.
+type Registrar interface {
+	RegisterJobs(w *river.Workers) []*river.PeriodicJob
+}
+
+// Config sizes the per-queue worker pools. Zero values get sane defaults.
+type Config struct {
+	OutboundWorkers    int // QueueOutbound concurrency (default 8)
+	WebhookWorkers     int // QueueWebhook concurrency (default 16)
+	MaintenanceWorkers int // QueueMaintenance concurrency (default 2)
+	DefaultWorkers     int // QueueDefault concurrency (default 5)
+}
+
+func (c Config) withDefaults() Config {
+	if c.OutboundWorkers <= 0 {
+		c.OutboundWorkers = 8
+	}
+	if c.WebhookWorkers <= 0 {
+		c.WebhookWorkers = 16
+	}
+	if c.MaintenanceWorkers <= 0 {
+		c.MaintenanceWorkers = 2
+	}
+	if c.DefaultWorkers <= 0 {
+		c.DefaultWorkers = 5
+	}
+	return c
+}
+
+// Client is the shared River client plus e2a's lifecycle helpers. It embeds
+// *river.Client[pgx.Tx], so it IS an Enqueuer and exposes Start/Stop directly.
+type Client struct {
+	*river.Client[pgx.Tx]
+}
+
+// Migrate applies River's own schema (river_job et al.) to the pool. River tracks
+// its migrations in its own river_migration table, separate from e2a's
+// schema_migrations, so this is idempotent and safe alongside identity migrations.
+// Call once at startup, after the e2a migrations. (Generalized from the
+// per-manager Migrate senderidentity used to own.)
+func Migrate(ctx context.Context, pool *pgxpool.Pool) error {
+	migrator, err := rivermigrate.New(riverpgxv5.New(pool), nil)
+	if err != nil {
+		return fmt.Errorf("river migrator: %w", err)
+	}
+	if _, err := migrator.Migrate(ctx, rivermigrate.DirectionUp, nil); err != nil {
+		return fmt.Errorf("river migrate: %w", err)
+	}
+	return nil
+}
+
+// New builds the one shared client from every domain's Registrar. Each registrar
+// adds its workers and periodic jobs; queues are the central set (queues.go). The
+// DB must already have River's schema (call Migrate first).
+func New(pool *pgxpool.Pool, cfg Config, registrars ...Registrar) (*Client, error) {
+	cfg = cfg.withDefaults()
+	workers := river.NewWorkers()
+	var periodic []*river.PeriodicJob
+	for _, r := range registrars {
+		periodic = append(periodic, r.RegisterJobs(workers)...)
+	}
+
+	rc, err := river.NewClient(riverpgxv5.New(pool), &river.Config{
+		Queues:       defaultQueueConfig(cfg.OutboundWorkers, cfg.WebhookWorkers, cfg.MaintenanceWorkers, cfg.DefaultWorkers),
+		Workers:      workers,
+		PeriodicJobs: periodic,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("river client: %w", err)
+	}
+	return &Client{Client: rc}, nil
+}

--- a/internal/jobs/jobs_test.go
+++ b/internal/jobs/jobs_test.go
@@ -1,0 +1,90 @@
+package jobs_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/riverqueue/river"
+
+	"github.com/Mnexa-AI/e2a/internal/jobs"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+)
+
+// Compile-time proof the shared client is an Enqueuer (so business code can
+// depend on the narrow interface and River satisfies it with no adapter).
+var _ jobs.Enqueuer = (*jobs.Client)(nil)
+
+// pingArgs is a trivial job used to prove the composition root assembles a
+// working client end-to-end.
+type pingArgs struct {
+	ID string `json:"id"`
+}
+
+func (pingArgs) Kind() string { return "jobs_test_ping" }
+
+type pingWorker struct {
+	river.WorkerDefaults[pingArgs]
+	got chan string
+}
+
+func (w *pingWorker) Work(_ context.Context, job *river.Job[pingArgs]) error {
+	w.got <- job.Args.ID
+	return nil
+}
+
+// pingRegistrar contributes the ping worker to the shared client.
+type pingRegistrar struct{ w *pingWorker }
+
+func (r pingRegistrar) RegisterJobs(workers *river.Workers) []*river.PeriodicJob {
+	river.AddWorker(workers, r.w)
+	return nil
+}
+
+// TestClient_EndToEnd proves New assembles a client from a Registrar, that the
+// Enqueuer inserts a job, and that a registered worker runs it on its queue.
+func TestClient_EndToEnd(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	if err := jobs.Migrate(ctx, pool); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+
+	got := make(chan string, 1)
+	client, err := jobs.New(pool, jobs.Config{}, pingRegistrar{w: &pingWorker{got: got}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := client.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer client.Stop(ctx)
+
+	// Enqueue through the narrow Enqueuer surface, onto the outbound queue.
+	if _, err := client.Insert(ctx, pingArgs{ID: "hello"}, &river.InsertOpts{Queue: jobs.QueueOutbound}); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+
+	select {
+	case id := <-got:
+		if id != "hello" {
+			t.Errorf("worked job id = %q, want hello", id)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the job to be worked")
+	}
+}
+
+// TestConfig_Defaults confirms the per-queue worker pools fall back to sane
+// non-zero sizes (a zero MaxWorkers would silently never work a queue).
+func TestConfig_Defaults(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	if err := jobs.Migrate(ctx, pool); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	// New with a zero Config must build without error (defaults applied).
+	if _, err := jobs.New(pool, jobs.Config{}); err != nil {
+		t.Fatalf("New with zero config: %v", err)
+	}
+}

--- a/internal/jobs/jobs_test.go
+++ b/internal/jobs/jobs_test.go
@@ -88,3 +88,128 @@ func TestConfig_Defaults(t *testing.T) {
 		t.Fatalf("New with zero config: %v", err)
 	}
 }
+
+// TestClient_DefaultQueue covers the queue senderidentity actually uses in
+// production (nil InsertOpts → QueueDefault) — the jobs foundation's CI-run test
+// otherwise only exercises QueueOutbound.
+func TestClient_DefaultQueue(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	if err := jobs.Migrate(ctx, pool); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	got := make(chan string, 1)
+	client, err := jobs.New(pool, jobs.Config{}, pingRegistrar{w: &pingWorker{got: got}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := client.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer client.Stop(ctx)
+
+	// nil opts → default queue (exactly how senderidentity enqueues).
+	if _, err := client.Insert(ctx, pingArgs{ID: "default"}, nil); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	select {
+	case id := <-got:
+		if id != "default" {
+			t.Errorf("worked id = %q, want default", id)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("default-queue job never ran — is QueueDefault in the client's Queues map?")
+	}
+}
+
+// TestClient_InsertTxCommitRuns proves the outbox path: a job enqueued via
+// InsertTx runs iff its transaction commits.
+func TestClient_InsertTxCommitRuns(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	if err := jobs.Migrate(ctx, pool); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	got := make(chan string, 1)
+	client, err := jobs.New(pool, jobs.Config{}, pingRegistrar{w: &pingWorker{got: got}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := client.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer client.Stop(ctx)
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	if _, err := client.InsertTx(ctx, tx, pingArgs{ID: "committed"}, nil); err != nil {
+		t.Fatalf("InsertTx: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	select {
+	case id := <-got:
+		if id != "committed" {
+			t.Errorf("worked id = %q, want committed", id)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("committed InsertTx job never ran")
+	}
+}
+
+// TestClient_InsertTxRollbackDropsJob proves the other half of the outbox
+// guarantee ("can never be lost" ⇒ also "never enqueued if the tx rolls back"):
+// a rolled-back InsertTx leaves no job. A sentinel enqueued afterward bounds the
+// wait — only the sentinel may ever be worked.
+func TestClient_InsertTxRollbackDropsJob(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	if err := jobs.Migrate(ctx, pool); err != nil {
+		t.Fatalf("Migrate: %v", err)
+	}
+	got := make(chan string, 2)
+	client, err := jobs.New(pool, jobs.Config{}, pingRegistrar{w: &pingWorker{got: got}})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	if err := client.Start(ctx); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	defer client.Stop(ctx)
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("Begin: %v", err)
+	}
+	if _, err := client.InsertTx(ctx, tx, pingArgs{ID: "rolledback"}, nil); err != nil {
+		t.Fatalf("InsertTx: %v", err)
+	}
+	if err := tx.Rollback(ctx); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	// Sentinel via a committed insert — if the rolled-back job were durable it
+	// would race here, but it isn't, so only the sentinel is ever worked.
+	if _, err := client.Insert(ctx, pingArgs{ID: "sentinel"}, nil); err != nil {
+		t.Fatalf("Insert sentinel: %v", err)
+	}
+	select {
+	case id := <-got:
+		if id == "rolledback" {
+			t.Fatal("a rolled-back InsertTx job was worked — the outbox atomicity is broken")
+		}
+		if id != "sentinel" {
+			t.Errorf("worked id = %q, want sentinel", id)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("sentinel job never ran")
+	}
+	// Nothing else should follow the sentinel.
+	select {
+	case id := <-got:
+		t.Fatalf("unexpected second job worked: %q", id)
+	case <-time.After(500 * time.Millisecond):
+	}
+}

--- a/internal/jobs/queues.go
+++ b/internal/jobs/queues.go
@@ -1,0 +1,35 @@
+package jobs
+
+import "github.com/riverqueue/river"
+
+// Named queues. Jobs are assigned a queue at enqueue time (InsertOpts.Queue);
+// the shared client works all of these. Separate queues give INDEPENDENT
+// concurrency per lane, so a backlog in one (e.g. a slow customer webhook
+// endpoint) can never starve another (e.g. outbound sends) — the isolation the
+// hand-rolled queues couldn't express cleanly. Keep these names stable: they are
+// persisted on river_job rows.
+const (
+	// QueueOutbound carries outbound send jobs (API → SES).
+	QueueOutbound = "outbound"
+	// QueueWebhook carries customer webhook-delivery jobs. Isolated from outbound
+	// so a slow/failing endpoint's backlog never delays sends.
+	QueueWebhook = "webhook"
+	// QueueMaintenance carries low-urgency periodic/janitor work (reapers,
+	// hold-TTL resolution, auto-disable sweeps).
+	QueueMaintenance = "maintenance"
+	// QueueDefault is River's built-in default — anything not explicitly routed.
+	QueueDefault = river.QueueDefault
+)
+
+// defaultQueueConfig is the concurrency map the shared client works. Per-lane
+// MaxWorkers is deliberately generous for I/O-bound work (SMTP / HTTP); tune
+// against real throughput. Every queue a domain enqueues into MUST appear here or
+// its jobs sit unworked.
+func defaultQueueConfig(outbound, webhook, maintenance, deflt int) map[string]river.QueueConfig {
+	return map[string]river.QueueConfig{
+		QueueOutbound:    {MaxWorkers: outbound},
+		QueueWebhook:     {MaxWorkers: webhook},
+		QueueMaintenance: {MaxWorkers: maintenance},
+		QueueDefault:     {MaxWorkers: deflt},
+	}
+}

--- a/internal/senderidentity/integration_test.go
+++ b/internal/senderidentity/integration_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/jobs"
 	"github.com/Mnexa-AI/e2a/internal/senderidentity"
 	"github.com/Mnexa-AI/e2a/internal/testutil"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -21,12 +22,28 @@ import (
 func freshRiver(t *testing.T, pool *pgxpool.Pool) {
 	t.Helper()
 	ctx := context.Background()
-	if err := senderidentity.Migrate(ctx, pool); err != nil {
+	if err := jobs.Migrate(ctx, pool); err != nil {
 		t.Fatalf("river migrate: %v", err)
 	}
 	if _, err := pool.Exec(ctx, "TRUNCATE river_job"); err != nil {
 		t.Fatalf("truncate river_job: %v", err)
 	}
+}
+
+// startShared builds the shared jobs client with mgr as its registrar, injects
+// it back, and starts it — the production wiring, so the tests exercise the real
+// shared-client path. Cleanup stops the client.
+func startShared(t *testing.T, pool *pgxpool.Pool, mgr *senderidentity.Manager) {
+	t.Helper()
+	client, err := jobs.New(pool, jobs.Config{}, mgr)
+	if err != nil {
+		t.Fatalf("jobs.New: %v", err)
+	}
+	mgr.SetEnqueuer(client)
+	if err := client.Start(context.Background()); err != nil {
+		t.Fatalf("jobs start: %v", err)
+	}
+	t.Cleanup(func() { client.Stop(context.Background()) })
 }
 
 // recordingFire captures fired sender-identity events.
@@ -109,14 +126,8 @@ func TestProvisionToVerified(t *testing.T) {
 	fake.SetStatus(domain, senderidentity.Result{Status: senderidentity.StatusVerified})
 
 	rec := &recordingFire{}
-	mgr, err := senderidentity.NewManager(pool, senderidentity.NewStoreAdapter(store), fake, rec.firer(), senderidentity.Config{})
-	if err != nil {
-		t.Fatalf("NewManager: %v", err)
-	}
-	if err := mgr.Start(ctx); err != nil {
-		t.Fatalf("Start: %v", err)
-	}
-	defer mgr.Stop(context.Background())
+	mgr := senderidentity.NewManager(senderidentity.NewStoreAdapter(store), fake, rec.firer(), senderidentity.Config{})
+	startShared(t, pool, mgr)
 
 	if err := mgr.EnqueueProvision(ctx, domain); err != nil {
 		t.Fatalf("EnqueueProvision: %v", err)
@@ -146,14 +157,8 @@ func TestProvisionFailsClosed(t *testing.T) {
 	fake := senderidentity.NewFakeProvider()
 	fake.SetStatus(domain, senderidentity.Result{Status: senderidentity.StatusFailed, Error: "dkim mismatch"})
 
-	mgr, err := senderidentity.NewManager(pool, senderidentity.NewStoreAdapter(store), fake, nil, senderidentity.Config{})
-	if err != nil {
-		t.Fatalf("NewManager: %v", err)
-	}
-	if err := mgr.Start(ctx); err != nil {
-		t.Fatalf("Start: %v", err)
-	}
-	defer mgr.Stop(context.Background())
+	mgr := senderidentity.NewManager(senderidentity.NewStoreAdapter(store), fake, nil, senderidentity.Config{})
+	startShared(t, pool, mgr)
 
 	if err := mgr.EnqueueProvision(ctx, domain); err != nil {
 		t.Fatalf("EnqueueProvision: %v", err)
@@ -172,14 +177,8 @@ func TestDeprovisionTeardown(t *testing.T) {
 
 	fake := senderidentity.NewFakeProvider()
 	fake.SeedIdentity("teardown.example.com")
-	mgr, err := senderidentity.NewManager(pool, senderidentity.NewStoreAdapter(store), fake, nil, senderidentity.Config{})
-	if err != nil {
-		t.Fatalf("NewManager: %v", err)
-	}
-	if err := mgr.Start(ctx); err != nil {
-		t.Fatalf("Start: %v", err)
-	}
-	defer mgr.Stop(context.Background())
+	mgr := senderidentity.NewManager(senderidentity.NewStoreAdapter(store), fake, nil, senderidentity.Config{})
+	startShared(t, pool, mgr)
 
 	// EnqueueDeprovisionTx requires a tx; use the pool's own.
 	tx, err := pool.Begin(ctx)
@@ -219,14 +218,8 @@ func TestReprovisionAfterFailed(t *testing.T) {
 
 	fake := senderidentity.NewFakeProvider()
 	fake.SetStatus(domain, senderidentity.Result{Status: senderidentity.StatusFailed, Error: "dns not ready"})
-	mgr, err := senderidentity.NewManager(pool, senderidentity.NewStoreAdapter(store), fake, nil, senderidentity.Config{})
-	if err != nil {
-		t.Fatalf("NewManager: %v", err)
-	}
-	if err := mgr.Start(ctx); err != nil {
-		t.Fatalf("Start: %v", err)
-	}
-	defer mgr.Stop(context.Background())
+	mgr := senderidentity.NewManager(senderidentity.NewStoreAdapter(store), fake, nil, senderidentity.Config{})
+	startShared(t, pool, mgr)
 
 	if err := mgr.EnqueueProvision(ctx, domain); err != nil {
 		t.Fatalf("EnqueueProvision: %v", err)

--- a/internal/senderidentity/manager.go
+++ b/internal/senderidentity/manager.go
@@ -2,14 +2,12 @@ package senderidentity
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
-	"github.com/riverqueue/river/riverdriver/riverpgxv5"
-	"github.com/riverqueue/river/rivermigrate"
+
+	"github.com/Mnexa-AI/e2a/internal/jobs"
 )
 
 // defaultReaperInterval is how often the orphan-identity backstop sweeps.
@@ -17,59 +15,54 @@ import (
 // job; this only catches lost-job edge cases.
 const defaultReaperInterval = time.Hour
 
-// Migrate applies River's own schema (river_job et al.) to the pool. River
-// tracks its migrations in its own river_migration table, separate from e2a's
-// schema_migrations, so this is safe to run alongside identity.RunMigrations
-// and is idempotent. Call once at startup, after the e2a migrations.
-func Migrate(ctx context.Context, pool *pgxpool.Pool) error {
-	migrator, err := rivermigrate.New(riverpgxv5.New(pool), nil)
-	if err != nil {
-		return fmt.Errorf("river migrator: %w", err)
-	}
-	if _, err := migrator.Migrate(ctx, rivermigrate.DirectionUp, nil); err != nil {
-		return fmt.Errorf("river migrate: %w", err)
-	}
-	return nil
-}
-
 // Config tunes the Manager. Zero values get sane defaults.
 type Config struct {
 	// MaxReconcileAttempts bounds the pending→failed TTL. 0 → default.
 	MaxReconcileAttempts int
 	// ReaperInterval overrides the orphan-sweep cadence. 0 → default.
 	ReaperInterval time.Duration
-	// MaxWorkers is the default-queue concurrency. 0 → 5.
-	MaxWorkers int
 }
 
-// Manager owns the River client and the sender-identity job lifecycle. It is
-// the single integration point the rest of the app uses: EnqueueProvision on
-// domain verify, EnqueueDeprovisionTx in the domain-delete tx, Start/Stop on
-// the server lifecycle.
+// Manager owns the sender-identity job lifecycle on the SHARED River client
+// (internal/jobs), instead of a private client. It is a jobs.Registrar — it
+// contributes the provision/reconcile/deprovision workers + the periodic orphan
+// reaper — and the app's enqueue entry point: EnqueueProvision on domain verify,
+// EnqueueDeprovisionTx in the domain-delete tx. The shared client is injected via
+// SetEnqueuer after jobs.New has built it (which needs this Manager as a
+// Registrar first — the standard two-phase wiring).
 type Manager struct {
-	client *river.Client[pgx.Tx]
+	store    Store
+	provider Provider
+	fire     EventFirer
+	cfg      Config
+	enq      jobs.Enqueuer
 }
 
-// NewManager builds the River client with the provision/reconcile/deprovision
-// workers + the periodic orphan reaper. The DB must already have River's
-// schema (call Migrate first). fire may be nil (no events).
-func NewManager(pool *pgxpool.Pool, store Store, provider Provider, fire EventFirer, cfg Config) (*Manager, error) {
-	maxWorkers := cfg.MaxWorkers
-	if maxWorkers <= 0 {
-		maxWorkers = 5
-	}
-	reaperInterval := cfg.ReaperInterval
+// NewManager builds the manager with its dependencies. It does NOT build a River
+// client — call jobs.New with this Manager as a Registrar, then SetEnqueuer with
+// the resulting client. fire may be nil (no events).
+func NewManager(store Store, provider Provider, fire EventFirer, cfg Config) *Manager {
+	return &Manager{store: store, provider: provider, fire: fire, cfg: cfg}
+}
+
+// SetEnqueuer injects the shared client so the Enqueue* methods can insert jobs.
+// Must be called (once, at startup) before EnqueueProvision/EnqueueDeprovisionTx.
+func (m *Manager) SetEnqueuer(e jobs.Enqueuer) { m.enq = e }
+
+// RegisterJobs adds the sender-identity workers to the shared client's bundle and
+// returns the periodic orphan reaper. Implements jobs.Registrar. The workers run
+// on the default queue (nil InsertOpts.Queue), preserving prior behavior.
+func (m *Manager) RegisterJobs(w *river.Workers) []*river.PeriodicJob {
+	river.AddWorker(w, &ProvisionWorker{store: m.store, provider: m.provider, fire: m.fire, maxReconcileAttempt: m.cfg.MaxReconcileAttempts})
+	river.AddWorker(w, &ReconcileWorker{store: m.store, provider: m.provider, fire: m.fire})
+	river.AddWorker(w, &DeprovisionWorker{provider: m.provider})
+	river.AddWorker(w, &ReapWorker{store: m.store, provider: m.provider})
+
+	reaperInterval := m.cfg.ReaperInterval
 	if reaperInterval <= 0 {
 		reaperInterval = defaultReaperInterval
 	}
-
-	workers := river.NewWorkers()
-	river.AddWorker(workers, &ProvisionWorker{store: store, provider: provider, fire: fire, maxReconcileAttempt: cfg.MaxReconcileAttempts})
-	river.AddWorker(workers, &ReconcileWorker{store: store, provider: provider, fire: fire})
-	river.AddWorker(workers, &DeprovisionWorker{provider: provider})
-	river.AddWorker(workers, &ReapWorker{store: store, provider: provider})
-
-	periodic := []*river.PeriodicJob{
+	return []*river.PeriodicJob{
 		river.NewPeriodicJob(
 			river.PeriodicInterval(reaperInterval),
 			func() (river.JobArgs, *river.InsertOpts) {
@@ -82,23 +75,7 @@ func NewManager(pool *pgxpool.Pool, store Store, provider Provider, fire EventFi
 			&river.PeriodicJobOpts{RunOnStart: false},
 		),
 	}
-
-	client, err := river.NewClient(riverpgxv5.New(pool), &river.Config{
-		Queues:       map[string]river.QueueConfig{river.QueueDefault: {MaxWorkers: maxWorkers}},
-		Workers:      workers,
-		PeriodicJobs: periodic,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("river client: %w", err)
-	}
-	return &Manager{client: client}, nil
 }
-
-// Start begins working jobs. Non-blocking.
-func (m *Manager) Start(ctx context.Context) error { return m.client.Start(ctx) }
-
-// Stop drains in-flight jobs and stops the client.
-func (m *Manager) Stop(ctx context.Context) error { return m.client.Stop(ctx) }
 
 // EnqueueProvision schedules sending-identity provisioning for a domain
 // (called when a domain becomes verified, or on a forced re-check via
@@ -112,7 +89,7 @@ func (m *Manager) Stop(ctx context.Context) error { return m.client.Stop(ctx) }
 // the domain is already verified, and SES CreateEmailIdentity treats an
 // existing identity as success. Concurrent duplicate enqueues are harmless.
 func (m *Manager) EnqueueProvision(ctx context.Context, domain string) error {
-	_, err := m.client.Insert(ctx, ProvisionArgs{Domain: domain}, nil)
+	_, err := m.enq.Insert(ctx, ProvisionArgs{Domain: domain}, nil)
 	return err
 }
 
@@ -120,6 +97,6 @@ func (m *Manager) EnqueueProvision(ctx context.Context, domain string) error {
 // delete transaction, so the job is committed atomically with the domain-row
 // delete — it can never be lost if SES is unreachable at delete time.
 func (m *Manager) EnqueueDeprovisionTx(ctx context.Context, tx pgx.Tx, domain string) error {
-	_, err := m.client.InsertTx(ctx, tx, DeprovisionArgs{Domain: domain}, nil)
+	_, err := m.enq.InsertTx(ctx, tx, DeprovisionArgs{Domain: domain}, nil)
 	return err
 }

--- a/internal/senderidentity/manager.go
+++ b/internal/senderidentity/manager.go
@@ -66,11 +66,13 @@ func (m *Manager) RegisterJobs(w *river.Workers) []*river.PeriodicJob {
 		river.NewPeriodicJob(
 			river.PeriodicInterval(reaperInterval),
 			func() (river.JobArgs, *river.InsertOpts) {
-				// No UniqueOpts: River's periodic scheduler already inserts at
-				// most one per interval, and a completed reap must not dedup-
-				// block the next scheduled run (River can't drop `completed`
-				// from a unique state set). The reaper is idempotent anyway.
-				return ReapArgs{}, nil
+				// Route to the maintenance lane (low-urgency janitor work), not
+				// the default queue. No UniqueOpts: River's periodic scheduler
+				// already inserts at most one per interval, and a completed reap
+				// must not dedup-block the next scheduled run (River can't drop
+				// `completed` from a unique state set). The reaper is idempotent
+				// anyway.
+				return ReapArgs{}, &river.InsertOpts{Queue: jobs.QueueMaintenance}
 			},
 			&river.PeriodicJobOpts{RunOnStart: false},
 		),


### PR DESCRIPTION
## What

Stands up **`internal/jobs`** — the single River composition root for all of e2a's background work — and moves `senderidentity` (the one subsystem already on River) onto it. Foundation for consolidating every hand-rolled Postgres queue onto River, one lane at a time.

### `internal/jobs` (new)
- **`Client`** — embeds `*river.Client[pgx.Tx]`, so it exposes `Start`/`Stop` and *is* an `Enqueuer`. One shared client / one `river_job` table for the whole app.
- **`Enqueuer`** — the narrow `Insert`/`InsertTx` surface business code depends on (`InsertTx` = outbox enqueue in the caller's tx), keeping the store/agent layer testable and River at the edges. Compile-time asserted that `*Client` satisfies it.
- **`Registrar`** — each domain contributes its workers + periodic jobs via `RegisterJobs`; `New()` assembles the one client from all registrars. Domains never import `jobs` concretely — composition happens at the root (`main.go`), no cycles.
- **Named queues** (`outbound` / `webhook` / `maintenance` / `default`) with independent concurrency, so one lane's backlog can't starve another.
- **`Migrate()`** generalized from `senderidentity`'s per-manager copy.

### `senderidentity` (moved onto the shared client)
- `Manager` drops its private `river.Client` + `Migrate`/`Start`/`Stop`; it now implements `jobs.Registrar` and holds an injected `jobs.Enqueuer` (`SetEnqueuer`). `NewManager` no longer takes a pool or returns an error; `Config` drops `MaxWorkers` (queue concurrency is central now).
- Workers are unchanged — the provision→reconcile follow-up already uses `river.ClientFromContextSafely`, which resolves to the shared client automatically.
- `main.go`: `jobs.Migrate` (unconditional); the SES block builds the shared `jobs.Client` with `senderMgr` as its registrar, `SetEnqueuer`, and owns Start/Stop. **Behavior-preserving** — senderidentity jobs still run on the default queue.

## Why
`senderidentity` was already on River but with its *own* client. Rather than let outbound/webhook/HITL each spin up another bespoke queue (or another River client), everything shares one client / one `river_job` table with per-lane queue isolation. This PR is the foundation + the first proof of the pattern.

## Testing
- `go build ./...` + `go vet -tags integration ./internal/senderidentity/`.
- `internal/jobs`: end-to-end test — assemble a client from a `Registrar`, enqueue via the `Enqueuer`, worker runs the job on a named queue. Green.
- `senderidentity` unit + integration tests green against a fresh `e2a_test` (the `startShared` helper exercises the real shared-client wiring).

## Next (separate PRs)
Move the hand-rolled queues onto this foundation, per-lane and reviewed: outbound send worker → then webhook delivery → then HITL, retiring `outbound_message_queue` / `webhook_subscriber_deliveries` / `send_attempts` as each lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)