### PR TITLE
feat(hitl): durable approval-notification on River (QueueNotify)

### DIFF
--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -24,11 +24,11 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/hitlworker"
 	"github.com/Mnexa-AI/e2a/internal/idempotency"
 	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/inboundprocess"
 	"github.com/Mnexa-AI/e2a/internal/jobs"
 	"github.com/Mnexa-AI/e2a/internal/limits"
 	"github.com/Mnexa-AI/e2a/internal/oauth"
 	"github.com/Mnexa-AI/e2a/internal/outbound"
-	"github.com/Mnexa-AI/e2a/internal/inboundprocess"
 	"github.com/Mnexa-AI/e2a/internal/outboundsend"
 	"github.com/Mnexa-AI/e2a/internal/relay"
 	"github.com/Mnexa-AI/e2a/internal/senderidentity"
@@ -263,6 +263,20 @@ func main() {
 		registrars = append(registrars, inboundJobs)
 	}
 
+	// Durable HITL approval-notification on River (docs/design/hitl-notify-river.md).
+	// The NotifyWorker registers on the shared client; the hold accept-tx enqueues a
+	// hitl_notify job in the same tx as the pending_review row. The concrete Deliverer
+	// (the Notifier, which needs the relay + signer gating resolved below) is injected
+	// later via SetDeliverer — mirrors inbound's late-bound Processor. Gated on the
+	// same relay+public-URL config as the notifier itself; when unconfigured, no jobs
+	// register and the hold takes the plain path (no notification).
+	var notifyJobs *hitlnotify.Jobs
+	notifierEnabled := cfg.OutboundSMTP.FromDomain != "" && cfg.HTTP.PublicURL != ""
+	if notifierEnabled {
+		notifyJobs = hitlnotify.NewJobs(store)
+		registrars = append(registrars, notifyJobs)
+	}
+
 	var senderMgr *senderidentity.Manager
 	if region := cfg.SenderIdentity.SESRegion; region != "" {
 		provider, perr := senderidentity.NewSESProviderFromConfig(ctx, region)
@@ -326,6 +340,20 @@ func main() {
 			}
 			log.Printf("[outbound-send] engine=river (async accept, E2A_OUTBOUND_MODE=async)")
 		}
+		// HITL approval-notification cutover: wire the shared client into the hold
+		// accept-tx enqueuer and re-drive any pending_review rows without a
+		// notification job (rows held before this shipped, or stranded by a crash
+		// between message insert and job commit). Idempotent (notify_job_id IS NULL
+		// guard). The concrete Deliverer is bound just below at the notifier gating.
+		if notifyJobs != nil {
+			notifyJobs.SetEnqueuer(jobsClient)
+			if n, cerr := notifyJobs.ReconcilePending(ctx, pool); cerr != nil {
+				log.Printf("[hitl-notify] cutover: %v", cerr)
+			} else if n > 0 {
+				log.Printf("[hitl-notify] cutover enqueued %d un-notified holds", n)
+			}
+			log.Printf("[hitl-notify] engine=river")
+		}
 		// Stop is driven from the shutdown sequence under the shared deadline.
 		if serr := jobsClient.Start(ctx); serr != nil {
 			log.Fatalf("jobs: start shared river client: %v", serr)
@@ -370,8 +398,18 @@ func main() {
 		log.Printf("[hitl] notifier disabled: outbound_smtp.from_domain is not set")
 	} else if cfg.HTTP.PublicURL == "" {
 		log.Printf("[hitl] notifier disabled: http.public_url is not set (magic links require an absolute base URL)")
+	} else if notifyJobs == nil {
+		// notifierEnabled matches these same two config checks, so this is
+		// unreachable in practice — kept as a defensive guard against future drift.
+		log.Printf("[hitl] notifier disabled: notification job pipeline not registered")
 	} else {
-		api.SetNotifier(hitlnotify.New(store, smtpRelay, approvalSigner, cfg.OutboundSMTP.FromDomain, cfg.HTTP.PublicURL))
+		notifier := hitlnotify.New(store, smtpRelay, approvalSigner, cfg.OutboundSMTP.FromDomain, cfg.HTTP.PublicURL)
+		// Late-bind the concrete Deliverer onto the registered NotifyWorker (which
+		// has been running since jobsClient.Start; jobs enqueued before this bind
+		// simply retry) and give the hold path its accept-tx enqueuer. The HTTP
+		// server isn't accepting requests yet, so no hold can miss the enqueuer.
+		notifyJobs.SetDeliverer(notifier)
+		api.SetNotifyEnqueuer(notifyJobs)
 	}
 
 	// OAuth 2.1 / fosite-backed authorization server. Needs the same
@@ -574,12 +612,9 @@ func main() {
 	// stop; wg.Wait() at the end of shutdown blocks for the current
 	// iteration to settle.
 	//
-	// Known gap: NotifyPendingApprovalAsync goroutines are detached
-	// (context.Background, no handle) and remain at risk. Operators
-	// running rolling deploys should ensure SMTP is reachable from
-	// the new replica before reaping the old one so notifications
-	// have somewhere to land. Threading the wg through the notifier
-	// is a follow-up.
+	// (The HITL approval-notification email is no longer a detached
+	// goroutine — it's a durable River job on QueueNotify, drained by the
+	// shared jobsClient under the shutdown deadline. See hitl-notify-river.md.)
 	var workerWG sync.WaitGroup
 
 	// Webhook subscriber delivery now runs entirely on River's DeliverWorker

--- a/docs/design/hitl-notify-river.md
+++ b/docs/design/hitl-notify-river.md
@@ -1,0 +1,127 @@
+# Durable HITL approval-notification on River
+
+Status: implementing · Owner: backend · Related: `internal/hitlnotify`, `internal/agent/api.go`, migration 057
+
+## Context / the gap
+
+When an outbound message enters `pending_review` (HITL hold), the account
+owner gets an email with a preview + one-click approve/reject magic links. It
+is the reviewer's primary — sometimes only — signal that a message is waiting.
+
+Today that email is **fire-and-forget**: `HoldForApprovalCore`
+(`internal/agent/api.go`) calls `Notifier.NotifyPendingApprovalAsync`, which
+spawns a detached `go func()` (background ctx, 2-min timeout) that composes and
+SMTP-sends inline. Nothing persists the intent to notify. If the process
+crashes or SMTP is unreachable between the `202 pending_review` response and the
+send, **the notification is lost forever** and the reviewer is never told.
+`cmd/e2a/main.go` flags this in-code as a known gap.
+
+This is the last real at-least-once hole after the inbound (#391) and outbound
+(#388) River migrations. This change closes it by putting the notification on
+River — same three-layer pattern as `internal/outboundsend`.
+
+## Design
+
+Three layers, mirroring `outboundsend`:
+
+```
+HoldForApprovalCore (one tx):  INSERT messages (pending_review)
+                               + InsertTx hitl_notify job
+                               + stamp notify_job_id            → commit → 202
+River QueueNotify worker:      re-read msg+agent+owner → compose → SendOnce
+                               → set notified_at
+```
+
+- **Layer 1 (fact):** the `messages` row entering `pending_review` — it already
+  exists, so no new table. We add two nullable columns to `messages`:
+  `notify_job_id BIGINT` (reconciler bookkeeping) and `notified_at TIMESTAMPTZ`
+  (send-dedup marker).
+- **Layer 2 (state / outbox):** in the **same tx** as the pending-message
+  insert, `EnqueueNotifyTx` inserts the `hitl_notify` River job and stamps its
+  id onto `notify_job_id`. The row and its job commit atomically — neither can
+  exist without the other. (This matches the outbound accept-tx; if the enqueue
+  fails the whole hold fails with a 500, which is a same-DB failure that would
+  fail the message insert anyway.)
+- **Layer 3 (execution):** a `river.Worker` on a new `notify` queue re-reads the
+  message + agent + owner, composes the email (existing render code, deterministic
+  magic-link tokens), and submits **once** via `SMTPRelay.SendOnce` — River owns
+  the retry envelope, replacing the notifier's old inline behavior.
+
+### Worker guards (idempotency / pointlessness)
+
+`Work` loads the row and no-ops (returns nil) when:
+1. message is gone (deleted/pruned) — `LoadPendingNotify` returns nil;
+2. `status != pending_review` — already approved/rejected/expired, nothing to review;
+3. `approval_expires_at` is in the past — the hold is dead; the TTL worker
+   handles it, a "please review" email is now useless;
+4. `notified_at` is already set — a prior attempt sent it (crash-after-send
+   re-drive).
+
+On deliver:
+- **success** → `MarkNotified` (sets `notified_at`), return nil;
+- **permanent** (`IsPermanentSMTPError`, e.g. bad owner address) → log + `river.JobCancel`
+  (no retry; unavoidable, the hold still finalizes on TTL);
+- **connection/outage** (`IsConnectionError`) → `river.JobSnooze` while the hold is
+  still live, else give up;
+- **transient** → wrapped error → River reschedules per `NextRetry` until
+  `MaxNotifyAttempts`, then cancel + log.
+
+At-least-once holds because loss is impossible: `notified_at` is only ever set
+**after** a successful send. A duplicate "please review" email (rare crash
+window) is benign — the accepted at-least-once trade.
+
+### Reconciler (cutover)
+
+`ReconcilePending`, run once at startup like the inbound/outbound reconcilers:
+`SELECT id FROM messages WHERE status='pending_review' AND notify_job_id IS NULL
+AND notified_at IS NULL`, per-row `FOR UPDATE` re-check + `EnqueueNotifyTx` +
+stamp. Backed by a partial index `idx_messages_pending_no_notify_job` (built
+`CONCURRENTLY` in migration 058 so the deploy doesn't write-lock `messages`).
+
+**Cutover double-notify — the `notified_at IS NULL` guard.** Unlike the outbound
+cutover (where the sync path had already moved rows off `accepted`), every hold
+still `pending_review` when this ships was *already* emailed by the old
+goroutine. Without a guard the reconciler would email each owner a second time.
+Migration 057 stamps `notified_at = now()` on exactly those pre-existing
+`pending_review` rows, and the reconciler skips any row with `notified_at` set —
+so the first deploy notifies no one twice. A hold created on the no-notifier
+plain path keeps `notified_at` NULL and is correctly picked up if a relay is
+later configured.
+
+### Queue
+
+New `QueueNotify = "notify"` (small pool, ~4 workers) so a burst of held sends
+notifying can't starve customer outbound delivery, and a stuck notification
+(bad owner address retrying) doesn't consume outbound worker slots. Adding a
+queue is a `queues.go` map + `jobs.Config` entry — no SQL (River owns its own
+schema).
+
+## Files
+
+- `migrations/057_messages_notify_job.sql` — `ADD COLUMN IF NOT EXISTS notify_job_id
+  BIGINT`, `notified_at TIMESTAMPTZ` (metadata-only), + a cutover `UPDATE` stamping
+  `notified_at` on pre-existing `pending_review` rows.
+- `migrations/058_messages_notify_job_idx.sql` — the partial reconciler index, built
+  `CREATE INDEX CONCURRENTLY` under `-- e2a:no-transaction` (split out so the build
+  doesn't write-lock `messages`).
+- `internal/jobs/queues.go` — add `QueueNotify` + config wiring.
+- `internal/hitlnotify/` — new `HITLNotifyArgs`, `NotifyWorker`, `Store`/`Deliverer`
+  interfaces, `Jobs` (Registrar + `EnqueueNotifyTx` + `ReconcilePending`); refactor
+  `Notifier` to implement `Deliverer` via `SendOnce`; drop `NotifyPendingApprovalAsync`.
+- `internal/identity/store.go` — extract shared `createPendingOutboundMessage(exec, …)`,
+  add `CreatePendingOutboundMessageTx`, `StampNotifyJobIDTx`, `MarkMessageNotified`,
+  `LoadPendingNotify` (+ `PendingNotify` type).
+- `internal/agent/api.go` — `NotifyEnqueuer` seam + `SetNotifyEnqueuer`; rewrite
+  `HoldForApprovalCore` to the same-tx path (falls back to the plain insert when
+  no enqueuer is wired, i.e. notifier unconfigured).
+- `cmd/e2a/main.go` — build + register the notify Jobs, `SetEnqueuer`,
+  `ReconcilePending`, `SetNotifyEnqueuer(api)`; delete the known-gap comment.
+
+## Verification
+
+- `go build ./...`, unit tests for the worker (success, gone, resolved, expired,
+  already-notified, permanent-cancel, outage-snooze, last-attempt) + reconciler
+  integration test (mirrors `outboundsend/reconcile_test.go`).
+- Live smoke against Mailpit: hold a send → `202` → notification email lands
+  **off** the request path → re-drive/duplicate is suppressed by `notified_at`;
+  unconfigured notifier → plain hold, no enqueue, no notification (unchanged).

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -20,7 +20,6 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/approvaltoken"
 	"github.com/Mnexa-AI/e2a/internal/auth"
 	"github.com/Mnexa-AI/e2a/internal/dkim"
-	"github.com/Mnexa-AI/e2a/internal/hitlnotify"
 	"github.com/Mnexa-AI/e2a/internal/idempotency"
 	"github.com/Mnexa-AI/e2a/internal/identity"
 	"github.com/Mnexa-AI/e2a/internal/limits"
@@ -187,7 +186,7 @@ type API struct {
 	dcrLimit          *ratelimit.Limiter    // OAuth Dynamic Client Registration — anonymous endpoint, per-IP
 	downloadLimit     *ratelimit.Limiter    // attachment byte-download — capability-token route (no bearer), per-IP
 	approvalSigner    *approvaltoken.Signer // optional; if nil, magic-link endpoints return 404
-	notifier          *hitlnotify.Notifier  // optional; if nil, holdForApproval doesn't send notification email
+	notifyEnq         NotifyEnqueuer        // optional; if nil, holdForApproval persists the hold but sends no notification
 	oauthProvider     fosite.OAuth2Provider // optional; if nil, /oauth2/* endpoints return 404
 	oauthStorage      *oauth.Storage        // optional; consent handler needs Pool() for cross-package tx
 	signer            *agentauth.Signer     // optional; nil ⇒ JWKS serves an empty set (agent-auth disabled)
@@ -330,14 +329,24 @@ func (a *API) publishRejected(ctx context.Context, e webhookpub.Event, rejectedM
 // handleRejectMagicLink respond with 404.
 func (a *API) SetApprovalSigner(s *approvaltoken.Signer) { a.approvalSigner = s }
 
-// SetNotifier wires in the HITL notifier. When nil, holdForApproval
-// still persists the pending message but doesn't fire the email — useful
-// for tests that don't want the async SMTP traffic.
-func (a *API) SetNotifier(n *hitlnotify.Notifier) { a.notifier = n }
+// NotifyEnqueuer inserts the HITL approval-notification job (QueueNotify) in the
+// hold accept-tx, so the reviewer's email is enqueued atomically with the
+// pending_review row (docs/design/hitl-notify-river.md). Satisfied by
+// *hitlnotify.Jobs. When nil (notifier unconfigured), HoldForApprovalCore persists
+// the hold on the plain path and sends no notification.
+type NotifyEnqueuer interface {
+	EnqueueNotifyTx(ctx context.Context, tx pgx.Tx, messageID string) (int64, error)
+}
+
+// SetNotifyEnqueuer wires the HITL-notification accept-tx enqueuer. When nil,
+// holdForApproval still persists the pending message but enqueues no notification —
+// useful for tests that don't want the SMTP traffic, and for deployments without a
+// configured relay / public URL.
+func (a *API) SetNotifyEnqueuer(e NotifyEnqueuer) { a.notifyEnq = e }
 
 // SetOAuthProvider wires in the fosite-backed OAuth provider. When
 // nil, /oauth2/* endpoints return 404 (matches the
-// SetApprovalSigner / SetNotifier pattern of "optional capability,
+// SetApprovalSigner / SetNotifyEnqueuer pattern of "optional capability,
 // silently absent when not wired"). Operators who don't want OAuth
 // enabled simply don't call this.
 func (a *API) SetOAuthProvider(p fosite.OAuth2Provider) { a.oauthProvider = p }
@@ -957,30 +966,59 @@ func (a *API) HoldForApprovalCore(ctx context.Context, agent *identity.AgentIden
 		attachmentsJSON = b
 	}
 
-	msg, err := a.store.CreatePendingOutboundMessage(
-		ctx, agent.ID,
-		req.To, req.CC, req.BCC,
-		req.Subject, req.Body, req.HTMLBody,
-		attachmentsJSON,
-		msgType, req.ConversationID, replyToEmailMessageID,
-		agent.HITLTTLSeconds,
-	)
-	if err != nil {
-		log.Printf("[api] hitl: create pending message: agent=%s err=%v", agent.ID, err)
-		return nil, err
+	var msg *identity.Message
+	if a.notifyEnq != nil {
+		// Durable notification path: persist the pending_review row AND enqueue its
+		// approval-notification job (QueueNotify) in ONE transaction, then stamp the
+		// job id, so the reviewer's email is never lost on a crash between the 202
+		// and the send (docs/design/hitl-notify-river.md). Mirrors the outbound
+		// accept-tx. A same-tx enqueue failure fails the whole hold (500) — the same
+		// DB fault would have failed the message insert anyway.
+		if txErr := a.store.WithTx(ctx, func(tx pgx.Tx) error {
+			m, err := a.store.CreatePendingOutboundMessageTx(
+				ctx, tx, agent.ID,
+				req.To, req.CC, req.BCC,
+				req.Subject, req.Body, req.HTMLBody,
+				attachmentsJSON,
+				msgType, req.ConversationID, replyToEmailMessageID,
+				agent.HITLTTLSeconds,
+			)
+			if err != nil {
+				return err
+			}
+			jobID, err := a.notifyEnq.EnqueueNotifyTx(ctx, tx, m.ID)
+			if err != nil {
+				return err
+			}
+			if err := a.store.StampNotifyJobIDTx(ctx, tx, m.ID, jobID); err != nil {
+				return err
+			}
+			msg = m
+			return nil
+		}); txErr != nil {
+			log.Printf("[api] hitl: create+enqueue pending message: agent=%s err=%v", agent.ID, txErr)
+			return nil, txErr
+		}
+	} else {
+		// No notifier configured: plain hold, no notification (behavior unchanged).
+		m, err := a.store.CreatePendingOutboundMessage(
+			ctx, agent.ID,
+			req.To, req.CC, req.BCC,
+			req.Subject, req.Body, req.HTMLBody,
+			attachmentsJSON,
+			msgType, req.ConversationID, replyToEmailMessageID,
+			agent.HITLTTLSeconds,
+		)
+		if err != nil {
+			log.Printf("[api] hitl: create pending message: agent=%s err=%v", agent.ID, err)
+			return nil, err
+		}
+		msg = m
 	}
 
 	slug, _, _ := strings.Cut(agent.EmailAddress(), "@")
 	log.Printf("[mail:%s] dir=outbound type=%s status=%s from=%s to=%v slug=%s conv_id=%s subject=%q approval_expires_at=%s",
 		msg.ID, msgType, msg.Status, agent.EmailAddress(), req.To, slug, req.ConversationID, req.Subject, msg.ApprovalExpiresAt.Format(time.RFC3339))
-
-	// Fire the reviewer notification asynchronously. Failures are logged
-	// inside the notifier and must never block the response — the pending
-	// row is already persisted and the expiration worker will finalize it
-	// even if every notification email bounces.
-	if a.notifier != nil {
-		a.notifier.NotifyPendingApprovalAsync(msg, agent)
-	}
 
 	a.publishPendingApproval(ctx, a.buildPendingApprovalEvent(agent, msg, req, msgType), msg.ID)
 	return msg, nil

--- a/internal/hitlnotify/e2e_test.go
+++ b/internal/hitlnotify/e2e_test.go
@@ -1,0 +1,118 @@
+package hitlnotify_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/Mnexa-AI/e2a/internal/approvaltoken"
+	"github.com/Mnexa-AI/e2a/internal/config"
+	"github.com/Mnexa-AI/e2a/internal/hitlnotify"
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/jobs"
+	"github.com/Mnexa-AI/e2a/internal/outbound"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+)
+
+// TestEndToEnd_AcceptTxThroughRiverToSMTP drives the whole durable path with a REAL
+// River client and a real Notifier (talking to a fake SMTP): the accept-tx enqueues
+// a hitl_notify job in the same tx as the pending_review row, River works it, the
+// NotifyWorker composes + SendOnce's the email, and notified_at is stamped. Proves
+// the seams (tx enqueue → worker → deliver → mark) compose end to end.
+func TestEndToEnd_AcceptTxThroughRiverToSMTP(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	if err := jobs.Migrate(ctx, pool); err != nil {
+		t.Fatalf("jobs.Migrate: %v", err)
+	}
+	store := identity.NewStore(pool)
+
+	smtpAddr, smtpDone := testutil.FakeSMTPServer(t)
+	relay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{
+		Host: smtpAddr.Host, Port: smtpAddr.Port, FromDomain: "notify.test",
+	})
+	signer := approvaltoken.NewSigner("hitl-notify-e2e-secret")
+	notifier := hitlnotify.New(store, relay, signer, "notify.test", "https://app.example.test")
+
+	// Seed a verified HITL agent + owner.
+	user, err := store.CreateOrGetUser(ctx, "owner-e2e@reviewer.test", "Owner", "google-notify-e2e")
+	if err != nil {
+		t.Fatal(err)
+	}
+	domain := "e2e.bot.test"
+	if _, err := store.ClaimOrCreateDomain(ctx, domain, user.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.VerifyDomain(ctx, domain, user.ID); err != nil {
+		t.Fatal(err)
+	}
+	ag, err := store.CreateAgent(ctx, "bot@"+domain, domain, "", "https://example.com/webhook", "", user.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Build the integration on a real client and bind the concrete Notifier.
+	j := hitlnotify.NewJobs(store)
+	client, err := jobs.New(pool, jobs.Config{}, j)
+	if err != nil {
+		t.Fatalf("jobs.New: %v", err)
+	}
+	j.SetEnqueuer(client)
+	j.SetDeliverer(notifier)
+
+	if err := client.Start(ctx); err != nil {
+		t.Fatalf("client.Start: %v", err)
+	}
+	t.Cleanup(func() {
+		stopCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		_ = client.Stop(stopCtx)
+	})
+
+	// The accept-tx: create the pending_review row + enqueue the notify job + stamp,
+	// all in one tx — exactly what HoldForApprovalCore does.
+	var msgID string
+	if err := store.WithTx(ctx, func(tx pgx.Tx) error {
+		m, err := store.CreatePendingOutboundMessageTx(ctx, tx, ag.ID,
+			[]string{"alice@example.com"}, nil, nil, "E2E subject", "body", "", nil,
+			"send", "conv-e2e", "", 3600)
+		if err != nil {
+			return err
+		}
+		msgID = m.ID
+		jobID, err := j.EnqueueNotifyTx(ctx, tx, m.ID)
+		if err != nil {
+			return err
+		}
+		return store.StampNotifyJobIDTx(ctx, tx, m.ID, jobID)
+	}); err != nil {
+		t.Fatalf("accept tx: %v", err)
+	}
+
+	// Wait for the worker to run the full path: notified_at is stamped only after a
+	// successful SendOnce.
+	deadline := time.Now().Add(15 * time.Second)
+	var notifiedAt *time.Time
+	for time.Now().Before(deadline) {
+		if err := pool.QueryRow(ctx, `SELECT notified_at FROM messages WHERE id=$1`, msgID).Scan(&notifiedAt); err != nil {
+			t.Fatalf("poll notified_at: %v", err)
+		}
+		if notifiedAt != nil {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if notifiedAt == nil {
+		t.Fatal("notified_at never stamped — worker did not complete the send path")
+	}
+
+	msgs := smtpDone()
+	if len(msgs) != 1 {
+		t.Fatalf("fake SMTP got %d messages, want 1", len(msgs))
+	}
+	if msgs[0].To != "owner-e2e@reviewer.test" {
+		t.Errorf("notification went to %q, want the owner", msgs[0].To)
+	}
+}

--- a/internal/hitlnotify/jobs.go
+++ b/internal/hitlnotify/jobs.go
@@ -1,0 +1,155 @@
+package hitlnotify
+
+import (
+	"context"
+	"errors"
+	"log"
+	"sync"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/jobs"
+)
+
+// reconcileBatch bounds one cutover scan of pending_review rows without a
+// notification job — mirrors outboundsend/inboundprocess. In steady state the set
+// is ~empty (the accept-tx stamps notify_job_id atomically); this caps how many
+// rows one pass re-drives if the feature was just enabled or a crash left a backlog.
+const reconcileBatch = 1000
+
+// Jobs is the HITL-notification integration on the shared River client: a
+// jobs.Registrar (contributes NotifyWorker) plus the transactional enqueue entry
+// point the hold accept-tx calls. Both the shared client and the concrete Deliverer
+// are injected AFTER construction (two-phase wiring) — the client via SetEnqueuer,
+// the Deliverer (the Notifier, which needs the relay + signer resolved) via
+// SetDeliverer. Jobs itself is the worker's Deliverer, late-binding to the concrete
+// one, mirroring inboundprocess's late-bound Processor.
+type Jobs struct {
+	store Store
+	enq   jobs.Enqueuer
+
+	mu        sync.RWMutex
+	deliverer Deliverer
+}
+
+// NewJobs builds the integration with just its store (no client, no deliverer yet).
+func NewJobs(store Store) *Jobs { return &Jobs{store: store} }
+
+// SetEnqueuer injects the shared client so EnqueueNotifyTx can insert jobs.
+func (j *Jobs) SetEnqueuer(e jobs.Enqueuer) { j.enq = e }
+
+// SetDeliverer injects the concrete Deliverer (the Notifier), built after the
+// relay/signer gating resolves. Guarded so the River worker goroutines read it
+// race-free.
+func (j *Jobs) SetDeliverer(d Deliverer) {
+	j.mu.Lock()
+	j.deliverer = d
+	j.mu.Unlock()
+}
+
+// Deliver makes Jobs itself the worker's Deliverer, delegating to the concrete one
+// set via SetDeliverer. Until that is wired (the brief startup window before the
+// notifier is built) it returns a retryable outcome, so a pending job simply
+// retries rather than dropping on a nil deliverer.
+func (j *Jobs) Deliver(ctx context.Context, pn *identity.PendingNotify) DeliverOutcome {
+	j.mu.RLock()
+	d := j.deliverer
+	j.mu.RUnlock()
+	if d == nil {
+		return DeliverOutcome{Err: errors.New("hitl notifier not wired yet — retrying")}
+	}
+	return d.Deliver(ctx, pn)
+}
+
+// RegisterJobs adds the NotifyWorker (with Jobs as the late-binding Deliverer).
+// No periodics — the reconciler is a one-shot startup cutover. Implements
+// jobs.Registrar.
+func (j *Jobs) RegisterJobs(w *river.Workers) []*river.PeriodicJob {
+	river.AddWorker(w, NewNotifyWorker(j.store, j))
+	return nil
+}
+
+// EnqueueNotifyTx inserts the hitl_notify job in the caller's hold accept-tx (the
+// same tx as the pending_review insert), returning the River job id to stamp on the
+// message so a committed pending_review row always has its notification job.
+func (j *Jobs) EnqueueNotifyTx(ctx context.Context, tx pgx.Tx, messageID string) (int64, error) {
+	res, err := j.enq.InsertTx(ctx, tx, HITLNotifyArgs{MessageID: messageID}, &river.InsertOpts{
+		Queue:       jobs.QueueNotify,
+		MaxAttempts: MaxNotifyAttempts,
+	})
+	if err != nil {
+		return 0, err
+	}
+	return res.Job.ID, nil
+}
+
+// ReconcilePending enqueues a hitl_notify job for every pending_review message that
+// has no job yet AND was never notified (notify_job_id IS NULL AND notified_at IS
+// NULL). Run ONCE at startup as the cutover.
+//
+// Because the accept-tx is a single transaction (message insert + job enqueue +
+// job-id stamp commit together), a committed pending_review row in steady state
+// ALWAYS has its job — so this set is normally empty. It exists to enqueue holds
+// created on the no-notifier plain path (notified_at NULL) if a relay is later
+// configured, plus any row stranded by a crash between insert and enqueue.
+//
+// The `notified_at IS NULL` guard is what makes the feature's very first deploy
+// safe: every hold already pending_review at cutover was notified by the old code
+// path, and migration 057 stamps notified_at on exactly those rows, so this scan
+// skips them — no owner is emailed twice. Idempotent: the per-row FOR UPDATE +
+// notify_job_id IS NULL re-check means a re-run (or a concurrent replica) never
+// double-enqueues.
+func (j *Jobs) ReconcilePending(ctx context.Context, pool *pgxpool.Pool) (int, error) {
+	rows, err := pool.Query(ctx,
+		`SELECT id FROM messages
+		  WHERE status='pending_review' AND notify_job_id IS NULL AND notified_at IS NULL
+		  LIMIT $1`, reconcileBatch)
+	if err != nil {
+		return 0, err
+	}
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		ids = append(ids, id)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+
+	n := 0
+	for _, id := range ids {
+		if err := pgx.BeginFunc(ctx, pool, func(tx pgx.Tx) error {
+			// Re-check under a row lock: another process (or a prior run) may have
+			// enqueued it already. Skip if notify_job_id is now set.
+			var jobID *int64
+			if err := tx.QueryRow(ctx,
+				`SELECT notify_job_id FROM messages WHERE id=$1 FOR UPDATE`, id,
+			).Scan(&jobID); err != nil {
+				return err
+			}
+			if jobID != nil {
+				return nil // already enqueued
+			}
+			newJobID, err := j.EnqueueNotifyTx(ctx, tx, id)
+			if err != nil {
+				return err
+			}
+			if err := j.store.StampNotifyJobIDTx(ctx, tx, id, newJobID); err != nil {
+				return err
+			}
+			n++
+			return nil
+		}); err != nil {
+			log.Printf("[hitl-notify] reconcile enqueue %s: %v", id, err)
+		}
+	}
+	return n, nil
+}

--- a/internal/hitlnotify/notifier.go
+++ b/internal/hitlnotify/notifier.go
@@ -6,9 +6,12 @@
 // message and one-click approve / reject magic links, plus a link back
 // to the dashboard for edit-before-approve.
 //
-// The notifier is intentionally best-effort: delivery failures are
-// logged but never surfaced as HTTP errors, so a broken relay cannot
-// block the send-hold contract the API promises to its SDK/CLI users.
+// Delivery is durable, on River: the hold accept-tx enqueues a hitl_notify
+// job (QueueNotify) in the same transaction as the pending_review row, and
+// the NotifyWorker (worker.go) recomposes and submits the email ONCE off the
+// request path — River owns the retry envelope (docs/design/hitl-notify-river.md).
+// This replaced the earlier detached, best-effort goroutine, which lost the
+// notification on a crash or SMTP outage between the 202 response and the send.
 package hitlnotify
 
 import (
@@ -60,10 +63,10 @@ func New(store *identity.Store, relay *outbound.SMTPRelay, signer *approvaltoken
 	}
 }
 
-// NotifyPendingApproval composes and sends the notification email for a
-// newly held message. Designed to be called in a goroutine from the HTTP
-// handler — any returned error is only for tests; production callers
-// should ignore it and rely on the notifier's own logging.
+// NotifyPendingApproval composes and sends the notification email for a held
+// message, submitting once (SendOnce). It is the compose+send core the River
+// NotifyWorker drives via Deliver; the returned error is classified there into
+// retry/permanent/outage.
 func (n *Notifier) NotifyPendingApproval(ctx context.Context, msg *identity.Message, agent *identity.AgentIdentity) error {
 	if n == nil {
 		return nil
@@ -126,7 +129,10 @@ func (n *Notifier) NotifyPendingApproval(ctx context.Context, msg *identity.Mess
 		return fmt.Errorf("notify: compose: %w", err)
 	}
 
-	if _, err := n.relay.Send(fromAddr, []string{owner.Email}, message); err != nil {
+	// SendOnce, not Send: this runs inside a River job, so River (not the relay's
+	// in-process loop) owns retries. The %w keeps the SMTP error classifiable by
+	// Deliver via internal/outbound's IsPermanentSMTPError / IsConnectionError.
+	if _, err := n.relay.SendOnce(fromAddr, []string{owner.Email}, message); err != nil {
 		return fmt.Errorf("notify: smtp send: %w", err)
 	}
 
@@ -135,33 +141,20 @@ func (n *Notifier) NotifyPendingApproval(ctx context.Context, msg *identity.Mess
 	return nil
 }
 
-// NotifyPendingApprovalAsync is a thin fire-and-forget wrapper suitable
-// for goroutine launches from HTTP handlers. It swallows the error
-// after logging so callers don't need to.
-func (n *Notifier) NotifyPendingApprovalAsync(msg *identity.Message, agent *identity.AgentIdentity) {
-	if n == nil {
-		// Operator-side misconfiguration: notifier wasn't wired (most
-		// likely because OutboundSMTP.FromDomain or HTTP.PublicURL is
-		// unset; the wiring in cmd/e2a/main.go gates on both). The API
-		// still returns 202 pending_review to the caller, but the
-		// reviewer never gets an email — silent and confusing without
-		// a log line.
-		msgID := ""
-		if msg != nil {
-			msgID = msg.ID
+// Deliver composes and sends the approval email for one held message, classifying
+// the result for the River NotifyWorker: a 5xx / validation reject is Permanent
+// (no retry), an unreachable relay is an Outage (snooze), everything else retries.
+// Implements hitlnotify.Deliverer. The classifiers key on the SMTP code / net
+// error preserved through NotifyPendingApproval's %w wrapping.
+func (n *Notifier) Deliver(ctx context.Context, pn *identity.PendingNotify) DeliverOutcome {
+	if err := n.NotifyPendingApproval(ctx, pn.Message, pn.Agent); err != nil {
+		return DeliverOutcome{
+			Err:       err,
+			Permanent: outbound.IsPermanentSMTPError(err),
+			Outage:    outbound.IsConnectionError(err),
 		}
-		log.Printf("[hitl-notify] suppressed (notifier not configured): msg=%s", msgID)
-		return
 	}
-	go func() {
-		// Detach from the request context so shutting down mid-notification
-		// doesn't drop the email. Cap the total send time generously.
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-		defer cancel()
-		if err := n.NotifyPendingApproval(ctx, msg, agent); err != nil {
-			log.Printf("[hitl-notify] send failed: msg=%s err=%v", msg.ID, err)
-		}
-	}()
+	return DeliverOutcome{}
 }
 
 func (n *Notifier) magicURL(path, token string) string {

--- a/internal/hitlnotify/notifier_test.go
+++ b/internal/hitlnotify/notifier_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/Mnexa-AI/e2a/internal/approvaltoken"
 	"github.com/Mnexa-AI/e2a/internal/config"
@@ -111,8 +110,8 @@ func TestNotifierSendsEmailToOwner(t *testing.T) {
 		"alice@example.com",            // recipient
 		"carol@example.com",            // cc
 		"Important draft",              // subject
-		"/v1/approve?t=",           // magic approve link
-		"/v1/reject?t=",            // magic reject link
+		"/v1/approve?t=",               // magic approve link
+		"/v1/reject?t=",                // magic reject link
 		"/dashboard/pending/" + msg.ID, // dashboard link
 	} {
 		if !strings.Contains(data, needle) {
@@ -209,30 +208,32 @@ func TestNotifierRejectsMessageWithNilApprovalExpiresAt(t *testing.T) {
 	}
 }
 
-func TestNotifierAsyncFireAndForget(t *testing.T) {
+func TestNotifierDeliver(t *testing.T) {
 	n, store, _, smtpDone := newNotifier(t)
-	agent, msg := setupPendingMessage(t, store, "async")
+	agent, msg := setupPendingMessage(t, store, "deliver")
 
-	n.NotifyPendingApprovalAsync(msg, agent)
-
-	// Fakesmtp closes the listener on the first smtpDone() call, so
-	// sleep once and then read the result in a single shot.
-	time.Sleep(500 * time.Millisecond)
+	// Deliver is what the River NotifyWorker calls: it composes + sends once and
+	// classifies the result. A healthy send returns a zero-value outcome.
+	out := n.Deliver(context.Background(), &identity.PendingNotify{Message: msg, Agent: agent})
+	if out.Err != nil {
+		t.Fatalf("Deliver: unexpected err = %v", out.Err)
+	}
+	if out.Permanent || out.Outage {
+		t.Errorf("Deliver: healthy send classified Permanent=%v Outage=%v", out.Permanent, out.Outage)
+	}
 	msgs := smtpDone()
 	if len(msgs) != 1 {
-		t.Fatalf("async notification: got %d messages, want 1", len(msgs))
+		t.Fatalf("Deliver: got %d messages, want 1", len(msgs))
 	}
 }
 
 func TestNotifierNilSafe(t *testing.T) {
 	var n *hitlnotify.Notifier
-	// Both sync and async paths must tolerate a nil receiver so wiring
-	// can omit the notifier in tests / partial deployments without
-	// having to guard every call site.
+	// The sync compose+send tolerates a nil receiver so wiring can omit the
+	// notifier in tests / partial deployments without guarding every call site.
 	if err := n.NotifyPendingApproval(context.Background(), nil, nil); err != nil {
 		t.Errorf("nil receiver sync: err = %v, want nil", err)
 	}
-	n.NotifyPendingApprovalAsync(nil, nil) // must not panic
 }
 
 // extractToken pulls the ?t=... token out of the first occurrence of the

--- a/internal/hitlnotify/reconcile_test.go
+++ b/internal/hitlnotify/reconcile_test.go
@@ -1,0 +1,123 @@
+package hitlnotify_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/hitlnotify"
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/jobs"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+)
+
+// TestReconcilePending_EnqueuesStrandedAndStamps stands up a REAL River client and
+// asserts the startup cutover: a pending_review message with notify_job_id IS NULL
+// (held before the feature shipped, or stranded by an accept-tx that crashed before
+// the job committed) gets a hitl_notify river_job carrying its message id, its
+// notify_job_id stamped, and a re-run is idempotent. The Deliverer is nil — the
+// reconciler only exercises the enqueue path, never the worker.
+func TestReconcilePending_EnqueuesStrandedAndStamps(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	if err := jobs.Migrate(ctx, pool); err != nil {
+		t.Fatalf("jobs.Migrate: %v", err)
+	}
+	store := identity.NewStore(pool)
+
+	// Seed a verified agent + one pending_review message with NO notify job (the
+	// plain CreatePendingOutboundMessage path leaves notify_job_id NULL).
+	user, err := store.CreateOrGetUser(ctx, "owner-notify-recon@example.com", "Owner", "google-notify-recon")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	domain := "notify-recon.example.com"
+	if _, err := store.ClaimOrCreateDomain(ctx, domain, user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+	if err := store.VerifyDomain(ctx, domain, user.ID); err != nil {
+		t.Fatalf("VerifyDomain: %v", err)
+	}
+	ag, err := store.CreateAgent(ctx, "bot@"+domain, domain, "", "", "local", user.ID)
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	msg, err := store.CreatePendingOutboundMessage(ctx, ag.ID,
+		[]string{"a@gmail.com"}, nil, nil, "Subject", "body", "", nil,
+		"send", "conv-notify-recon", "", 3600)
+	if err != nil {
+		t.Fatalf("CreatePendingOutboundMessage: %v", err)
+	}
+	msgID := msg.ID
+
+	// Build the integration on a real shared River client so EnqueueNotifyTx inserts
+	// an actual river_job row. Deliverer unused by the reconcile path.
+	j := hitlnotify.NewJobs(store)
+	client, err := jobs.New(pool, jobs.Config{}, j)
+	if err != nil {
+		t.Fatalf("jobs.New: %v", err)
+	}
+	j.SetEnqueuer(client)
+
+	n, err := j.ReconcilePending(ctx, pool)
+	if err != nil {
+		t.Fatalf("ReconcilePending: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("ReconcilePending enqueued %d, want 1", n)
+	}
+
+	var jobCount int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM river_job WHERE kind='hitl_notify' AND args->>'message_id' = $1`,
+		msgID).Scan(&jobCount); err != nil {
+		t.Fatalf("count river_job: %v", err)
+	}
+	if jobCount != 1 {
+		t.Errorf("hitl_notify river_job for %s = %d, want 1", msgID, jobCount)
+	}
+	var notifyJobID *int64
+	if err := pool.QueryRow(ctx, `SELECT notify_job_id FROM messages WHERE id=$1`, msgID).Scan(&notifyJobID); err != nil {
+		t.Fatalf("read notify_job_id: %v", err)
+	}
+	if notifyJobID == nil {
+		t.Errorf("notify_job_id not stamped after ReconcilePending")
+	}
+
+	// Idempotent: a second cutover pass enqueues nothing more.
+	if n2, err := j.ReconcilePending(ctx, pool); err != nil || n2 != 0 {
+		t.Errorf("second ReconcilePending = (%d, %v), want (0, nil)", n2, err)
+	}
+
+	// Cutover safety: a pending_review hold already stamped notified_at (either by
+	// the old code path at deploy, seeded in migration 057, or a prior send) must be
+	// SKIPPED — never re-notified. Seed one and assert the reconciler ignores it.
+	already, err := store.CreatePendingOutboundMessage(ctx, ag.ID,
+		[]string{"b@gmail.com"}, nil, nil, "Already", "body", "", nil,
+		"send", "conv-already", "", 3600)
+	if err != nil {
+		t.Fatalf("CreatePendingOutboundMessage(already): %v", err)
+	}
+	if err := store.MarkMessageNotified(ctx, already.ID); err != nil {
+		t.Fatalf("MarkMessageNotified: %v", err)
+	}
+	if n3, err := j.ReconcilePending(ctx, pool); err != nil || n3 != 0 {
+		t.Errorf("ReconcilePending over an already-notified hold = (%d, %v), want (0, nil)", n3, err)
+	}
+	var strayJobs int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM river_job WHERE kind='hitl_notify' AND args->>'message_id' = $1`,
+		already.ID).Scan(&strayJobs); err != nil {
+		t.Fatalf("count river_job(already): %v", err)
+	}
+	if strayJobs != 0 {
+		t.Errorf("an already-notified hold must not be enqueued, got %d job(s)", strayJobs)
+	}
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM river_job WHERE kind='hitl_notify' AND args->>'message_id' = $1`,
+		msgID).Scan(&jobCount); err != nil {
+		t.Fatalf("recount river_job: %v", err)
+	}
+	if jobCount != 1 {
+		t.Errorf("after re-run: river_job for %s = %d, want 1 (idempotent)", msgID, jobCount)
+	}
+}

--- a/internal/hitlnotify/worker.go
+++ b/internal/hitlnotify/worker.go
@@ -1,0 +1,148 @@
+// worker.go is Layer 3 of the durable HITL approval-notification pipeline
+// (docs/design/hitl-notify-river.md): the River execution stage that takes a
+// pending_review message, recomposes the reviewer's approve/reject email, and
+// submits it ONCE off the request path. It mirrors internal/outboundsend — a
+// River Worker on the shared `notify` queue, with River owning claim/retry/rescue.
+//
+// At-least-once from the 202 response: the hitl_notify job is enqueued in the same
+// tx as the pending_review row (the hold accept-tx) before the API answers, so an
+// accepted hold's notification is never lost. The worker's notified_at stamp
+// (written only AFTER a successful send) makes a crash-after-send re-drive a no-op;
+// loss is impossible, a rare duplicate "please review" email is benign.
+package hitlnotify
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+)
+
+// notifyRetryBackoffs is the per-attempt delay for a failed notification send.
+// Shorter than the outbound sender's: a review email is worthless once the hold
+// passes its TTL (the worker short-circuits on approval_expires_at), so there is
+// no point in the multi-hour tail an at-least-once customer send needs.
+var notifyRetryBackoffs = []time.Duration{
+	15 * time.Second,
+	1 * time.Minute,
+	5 * time.Minute,
+	15 * time.Minute,
+	1 * time.Hour,
+}
+
+// MaxNotifyAttempts caps the retry tail before River discards the job.
+const MaxNotifyAttempts = 6
+
+// notifyOutageSnooze defers a job when the relay is unreachable, without burning
+// an attempt (mirrors the outbound outage snooze).
+const notifyOutageSnooze = 5 * time.Minute
+
+// HITLNotifyArgs drives one approval-notification job. Args carry only the message
+// id; the worker re-reads the message + agent (the source of truth) each attempt,
+// so the job row stays tiny and always reflects the current hold state.
+type HITLNotifyArgs struct {
+	MessageID string `json:"message_id"`
+}
+
+func (HITLNotifyArgs) Kind() string { return "hitl_notify" }
+
+// DeliverOutcome is the classified result of one notification send. Permanent and
+// Outage split the retry decision exactly as the outbound worker's does, using the
+// shared internal/outbound SMTP classifiers.
+type DeliverOutcome struct {
+	Err       error
+	Permanent bool // 5xx / validation — no retry
+	Outage    bool // relay unreachable — snooze without spending an attempt
+}
+
+// Deliverer composes and sends the approval email for one held message. Implemented
+// by *Notifier (compose + SMTPRelay.SendOnce + classify).
+type Deliverer interface {
+	Deliver(ctx context.Context, pn *identity.PendingNotify) DeliverOutcome
+}
+
+// Store is the message surface the worker + reconciler need. Implemented over
+// internal/identity (*identity.Store).
+type Store interface {
+	// LoadPendingNotify returns the held message + owning agent, or (nil, nil) when
+	// there is nothing to notify about (message or agent gone) — a no-op.
+	LoadPendingNotify(ctx context.Context, messageID string) (*identity.PendingNotify, error)
+	// MarkMessageNotified stamps notified_at after a successful send (the dedup marker).
+	MarkMessageNotified(ctx context.Context, messageID string) error
+	// StampNotifyJobIDTx records the job id on a reconciled row (accept-tx + reconciler).
+	StampNotifyJobIDTx(ctx context.Context, tx pgx.Tx, messageID string, jobID int64) error
+}
+
+// NotifyWorker sends the approval notification for one pending_review message.
+// Mirrors outboundsend.SendWorker.
+type NotifyWorker struct {
+	river.WorkerDefaults[HITLNotifyArgs]
+	store     Store
+	deliverer Deliverer
+}
+
+func NewNotifyWorker(store Store, deliverer Deliverer) *NotifyWorker {
+	return &NotifyWorker{store: store, deliverer: deliverer}
+}
+
+// NextRetry overrides River's default backoff with the decided notify envelope.
+func (w *NotifyWorker) NextRetry(job *river.Job[HITLNotifyArgs]) time.Time {
+	i := job.Attempt
+	if i < 0 || i >= len(notifyRetryBackoffs) {
+		return time.Time{} // fall back to River's default at the tail
+	}
+	return time.Now().Add(notifyRetryBackoffs[i])
+}
+
+func (w *NotifyWorker) Work(ctx context.Context, job *river.Job[HITLNotifyArgs]) error {
+	pn, err := w.store.LoadPendingNotify(ctx, job.Args.MessageID)
+	if err != nil {
+		return err // DB error — retryable
+	}
+	if pn == nil {
+		return nil // message or owning agent gone — nothing to notify
+	}
+	msg := pn.Message
+
+	// Pointlessness / idempotency guards — each a no-op (return nil):
+	if msg.Status != identity.MessageStatusPendingReview {
+		return nil // resolved (approved/rejected/expired) before we notified
+	}
+	if msg.ApprovalExpiresAt != nil && msg.ApprovalExpiresAt.Before(time.Now()) {
+		return nil // hold already past TTL — a review email is now useless
+	}
+	if pn.Notified {
+		return nil // a prior attempt already sent it (crash-after-send re-drive)
+	}
+
+	out := w.deliverer.Deliver(ctx, pn)
+	if out.Err == nil {
+		if merr := w.store.MarkMessageNotified(ctx, msg.ID); merr != nil {
+			// The email is already out; only the dedup marker failed to persist. Do
+			// NOT return an error — a retry would re-send. Completing the job leaves
+			// notify_job_id set, so the reconciler won't re-enqueue it either.
+			log.Printf("[hitl-notify] sent %s but mark-notified failed: %v", msg.ID, merr)
+		}
+		return nil
+	}
+	if out.Permanent {
+		// e.g. the owner address is rejected 5xx. Unavoidable — the hold still
+		// finalizes on its TTL. Cancel (no retry) rather than churn the tail.
+		log.Printf("[hitl-notify] permanent send failure for %s (no retry): %v", msg.ID, out.Err)
+		return river.JobCancel(out.Err)
+	}
+	if out.Outage {
+		// Relay unreachable. Snooze without burning an attempt. If the hold has
+		// since passed its TTL, the next attempt's expiry guard above short-circuits
+		// to a no-op — no need to special-case it here.
+		return river.JobSnooze(notifyOutageSnooze)
+	}
+	// Transient (relay throttle, owner lookup blip, compose error): let River
+	// reschedule per NextRetry until MaxNotifyAttempts, then discard.
+	return fmt.Errorf("hitl notify attempt %d failed: %w", job.Attempt, out.Err)
+}

--- a/internal/hitlnotify/worker_test.go
+++ b/internal/hitlnotify/worker_test.go
@@ -1,0 +1,200 @@
+package hitlnotify_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
+
+	"github.com/Mnexa-AI/e2a/internal/hitlnotify"
+	"github.com/Mnexa-AI/e2a/internal/identity"
+)
+
+type fakeStore struct {
+	pn      *identity.PendingNotify
+	loadErr error
+	markErr error
+
+	notified []string
+}
+
+func (f *fakeStore) LoadPendingNotify(_ context.Context, _ string) (*identity.PendingNotify, error) {
+	return f.pn, f.loadErr
+}
+func (f *fakeStore) MarkMessageNotified(_ context.Context, id string) error {
+	f.notified = append(f.notified, id)
+	return f.markErr
+}
+func (f *fakeStore) StampNotifyJobIDTx(_ context.Context, _ pgx.Tx, _ string, _ int64) error {
+	return nil
+}
+
+type fakeDeliverer struct {
+	out    hitlnotify.DeliverOutcome
+	called int
+}
+
+func (f *fakeDeliverer) Deliver(_ context.Context, _ *identity.PendingNotify) hitlnotify.DeliverOutcome {
+	f.called++
+	return f.out
+}
+
+func job(id string, attempt int) *river.Job[hitlnotify.HITLNotifyArgs] {
+	return &river.Job[hitlnotify.HITLNotifyArgs]{
+		JobRow: &rivertype.JobRow{Attempt: attempt, MaxAttempts: hitlnotify.MaxNotifyAttempts, Kind: hitlnotify.HITLNotifyArgs{}.Kind()},
+		Args:   hitlnotify.HITLNotifyArgs{MessageID: id},
+	}
+}
+
+// pending builds a live pending_review PendingNotify (TTL in the future).
+func pending(id string) *identity.PendingNotify {
+	exp := time.Now().Add(1 * time.Hour)
+	return &identity.PendingNotify{
+		Message: &identity.Message{ID: id, Status: identity.MessageStatusPendingReview, ApprovalExpiresAt: &exp},
+		Agent:   &identity.AgentIdentity{ID: "agent@x.test"},
+	}
+}
+
+func TestNotifyWorker_Success(t *testing.T) {
+	st := &fakeStore{pn: pending("msg_1")}
+	dl := &fakeDeliverer{}
+	w := hitlnotify.NewNotifyWorker(st, dl)
+	if err := w.Work(context.Background(), job("msg_1", 1)); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	if dl.called != 1 {
+		t.Errorf("Deliver called %d times, want 1", dl.called)
+	}
+	if len(st.notified) != 1 || st.notified[0] != "msg_1" {
+		t.Errorf("MarkMessageNotified = %v, want [msg_1]", st.notified)
+	}
+}
+
+func TestNotifyWorker_MessageGoneIsNoOp(t *testing.T) {
+	st := &fakeStore{pn: nil} // LoadPendingNotify returns (nil, nil) → gone
+	dl := &fakeDeliverer{}
+	w := hitlnotify.NewNotifyWorker(st, dl)
+	if err := w.Work(context.Background(), job("msg_gone", 1)); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	if dl.called != 0 || len(st.notified) != 0 {
+		t.Errorf("gone message must be a no-op (deliver=%d notified=%v)", dl.called, st.notified)
+	}
+}
+
+func TestNotifyWorker_ResolvedIsNoOp(t *testing.T) {
+	pn := pending("msg_1")
+	pn.Message.Status = identity.MessageStatusSent // approved/resolved before we notified
+	st := &fakeStore{pn: pn}
+	dl := &fakeDeliverer{}
+	w := hitlnotify.NewNotifyWorker(st, dl)
+	if err := w.Work(context.Background(), job("msg_1", 1)); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	if dl.called != 0 {
+		t.Errorf("a resolved hold must not send, Deliver called %d", dl.called)
+	}
+}
+
+func TestNotifyWorker_ExpiredHoldIsNoOp(t *testing.T) {
+	pn := pending("msg_1")
+	past := time.Now().Add(-1 * time.Minute)
+	pn.Message.ApprovalExpiresAt = &past
+	st := &fakeStore{pn: pn}
+	dl := &fakeDeliverer{}
+	w := hitlnotify.NewNotifyWorker(st, dl)
+	if err := w.Work(context.Background(), job("msg_1", 1)); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	if dl.called != 0 {
+		t.Errorf("an expired hold must not send, Deliver called %d", dl.called)
+	}
+}
+
+func TestNotifyWorker_AlreadyNotifiedIsNoOp(t *testing.T) {
+	pn := pending("msg_1")
+	pn.Notified = true // notified_at already set (crash-after-send re-drive)
+	st := &fakeStore{pn: pn}
+	dl := &fakeDeliverer{}
+	w := hitlnotify.NewNotifyWorker(st, dl)
+	if err := w.Work(context.Background(), job("msg_1", 1)); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	if dl.called != 0 {
+		t.Errorf("an already-notified hold must not re-send, Deliver called %d", dl.called)
+	}
+}
+
+func TestNotifyWorker_MarkFailedAfterSendDoesNotRetry(t *testing.T) {
+	// The email is already out; only the dedup marker failed. Returning an error
+	// would re-send on retry, so Work must swallow it and complete.
+	st := &fakeStore{pn: pending("msg_1"), markErr: errors.New("db blip")}
+	dl := &fakeDeliverer{}
+	w := hitlnotify.NewNotifyWorker(st, dl)
+	if err := w.Work(context.Background(), job("msg_1", 1)); err != nil {
+		t.Fatalf("mark-notified failure after a successful send must not error, got %v", err)
+	}
+}
+
+func TestNotifyWorker_PermanentCancels(t *testing.T) {
+	st := &fakeStore{pn: pending("msg_1")}
+	dl := &fakeDeliverer{out: hitlnotify.DeliverOutcome{Err: errors.New("550 user unknown"), Permanent: true}}
+	w := hitlnotify.NewNotifyWorker(st, dl)
+	err := w.Work(context.Background(), job("msg_1", 1))
+	if err == nil {
+		t.Fatal("a permanent failure should return a (cancel) error")
+	}
+	if len(st.notified) != 0 {
+		t.Errorf("a failed send must not mark notified, got %v", st.notified)
+	}
+}
+
+func TestNotifyWorker_OutageSnoozes(t *testing.T) {
+	st := &fakeStore{pn: pending("msg_1")}
+	dl := &fakeDeliverer{out: hitlnotify.DeliverOutcome{Err: errors.New("connection refused"), Outage: true}}
+	w := hitlnotify.NewNotifyWorker(st, dl)
+	// Even at a high attempt number an outage must snooze (JobSnooze doesn't burn
+	// an attempt), never terminal-fail.
+	err := w.Work(context.Background(), job("msg_1", hitlnotify.MaxNotifyAttempts))
+	if err == nil {
+		t.Fatal("a relay outage should snooze (non-nil JobSnooze error)")
+	}
+	if len(st.notified) != 0 {
+		t.Errorf("an outage must not mark notified, got %v", st.notified)
+	}
+}
+
+func TestNotifyWorker_TransientRetries(t *testing.T) {
+	st := &fakeStore{pn: pending("msg_1")}
+	dl := &fakeDeliverer{out: hitlnotify.DeliverOutcome{Err: errors.New("owner lookup blip")}}
+	w := hitlnotify.NewNotifyWorker(st, dl)
+	if err := w.Work(context.Background(), job("msg_1", 1)); err == nil {
+		t.Fatal("a transient failure must return an error so River retries")
+	}
+	if len(st.notified) != 0 {
+		t.Errorf("a failed send must not mark notified, got %v", st.notified)
+	}
+}
+
+func TestNotifyWorker_LoadErrorRetries(t *testing.T) {
+	st := &fakeStore{loadErr: errors.New("db down")}
+	w := hitlnotify.NewNotifyWorker(st, &fakeDeliverer{})
+	if err := w.Work(context.Background(), job("msg_1", 1)); err == nil {
+		t.Fatal("a load error must propagate so River retries")
+	}
+}
+
+func TestNotifyWorker_NextRetryMatchesEnvelope(t *testing.T) {
+	w := hitlnotify.NewNotifyWorker(nil, nil)
+	want := []time.Duration{15 * time.Second, 1 * time.Minute, 5 * time.Minute, 15 * time.Minute, 1 * time.Hour}
+	for i, d := range want {
+		got := time.Until(w.NextRetry(job("x", i))).Round(time.Second)
+		if diff := got - d; diff < -2*time.Second || diff > 2*time.Second {
+			t.Errorf("attempt %d: next retry in %v, want ~%v", i, got, d)
+		}
+	}
+}

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -1555,6 +1555,21 @@ func (s *Store) StampSendJobIDTx(ctx context.Context, tx pgx.Tx, messageID strin
 // ([{filename, content_type, data}, ...]) or nil. Callers that already have
 // an []outbound.Attachment slice should json.Marshal it before passing in.
 func (s *Store) CreatePendingOutboundMessage(ctx context.Context, agentID string, toRecipients, cc, bcc []string, subject, bodyText, bodyHTML string, attachmentsJSON []byte, msgType, conversationID, replyToEmailMessageID string, ttlSeconds int) (*Message, error) {
+	return createPendingOutboundMessage(ctx, s.pool, agentID, toRecipients, cc, bcc, subject, bodyText, bodyHTML, attachmentsJSON, msgType, conversationID, replyToEmailMessageID, ttlSeconds)
+}
+
+// CreatePendingOutboundMessageTx is the in-tx sibling of
+// CreatePendingOutboundMessage, letting the HITL hold write the pending_review
+// row and enqueue its approval-notification job (QueueNotify) in ONE transaction
+// so neither can exist without the other (docs/design/hitl-notify-river.md).
+// Mirrors CreateOutboundMessageTx / the send accept-tx.
+func (s *Store) CreatePendingOutboundMessageTx(ctx context.Context, tx pgx.Tx, agentID string, toRecipients, cc, bcc []string, subject, bodyText, bodyHTML string, attachmentsJSON []byte, msgType, conversationID, replyToEmailMessageID string, ttlSeconds int) (*Message, error) {
+	return createPendingOutboundMessage(ctx, tx, agentID, toRecipients, cc, bcc, subject, bodyText, bodyHTML, attachmentsJSON, msgType, conversationID, replyToEmailMessageID, ttlSeconds)
+}
+
+// createPendingOutboundMessage is the shared body of the pool and in-tx pending
+// creators; exec is satisfied by both *pgxpool.Pool and pgx.Tx (messageExecutor).
+func createPendingOutboundMessage(ctx context.Context, exec messageExecutor, agentID string, toRecipients, cc, bcc []string, subject, bodyText, bodyHTML string, attachmentsJSON []byte, msgType, conversationID, replyToEmailMessageID string, ttlSeconds int) (*Message, error) {
 	if ttlSeconds <= 0 || ttlSeconds > HITLMaxTTLSeconds {
 		return nil, fmt.Errorf("ttl_seconds must be between 1 and %d", HITLMaxTTLSeconds)
 	}
@@ -1596,7 +1611,7 @@ func (s *Store) CreatePendingOutboundMessage(ctx context.Context, agentID string
 		// on a held draft's detail/list view (B1).
 		Sender: agentID,
 	}
-	_, err := s.pool.Exec(ctx,
+	_, err := exec.Exec(ctx,
 		`INSERT INTO messages (
 		    id, agent_id, direction, recipient, subject, email_message_id, message_type,
 		    conversation_id, created_at, expires_at,
@@ -1618,6 +1633,63 @@ func (s *Store) CreatePendingOutboundMessage(ctx context.Context, agentID string
 		return nil, err
 	}
 	return m, nil
+}
+
+// StampNotifyJobIDTx records the River QueueNotify job id on the pending_review
+// message, within the hold accept-tx, so the notification reconciler can find
+// rows stranded without a job (pending_review AND notify_job_id IS NULL).
+// Mirrors StampSendJobIDTx.
+func (s *Store) StampNotifyJobIDTx(ctx context.Context, tx pgx.Tx, messageID string, jobID int64) error {
+	_, err := tx.Exec(ctx, `UPDATE messages SET notify_job_id = $2 WHERE id = $1`, messageID, jobID)
+	return err
+}
+
+// MarkMessageNotified stamps notified_at after the approval-notification email is
+// sent. Set only AFTER a successful send, so it is the send-dedup marker that makes
+// a crash-after-send River re-drive a no-op without ever risking a lost
+// notification (loss would require setting it before the send).
+func (s *Store) MarkMessageNotified(ctx context.Context, messageID string) error {
+	_, err := s.pool.Exec(ctx, `UPDATE messages SET notified_at = now() WHERE id = $1`, messageID)
+	return err
+}
+
+// PendingNotify is what the HITL approval-notification worker re-reads for one
+// message: the held message (the fields the notifier composes from), its owning
+// agent, and whether it was already notified.
+type PendingNotify struct {
+	Message  *Message
+	Agent    *AgentIdentity
+	Notified bool
+}
+
+// LoadPendingNotify returns the row the notification worker needs, or (nil, nil)
+// when there is nothing to notify about — the message was deleted/pruned, or its
+// owning agent no longer exists (an orphaned hold; other paths finalize it). The
+// worker treats a nil return as a no-op.
+func (s *Store) LoadPendingNotify(ctx context.Context, messageID string) (*PendingNotify, error) {
+	m := &Message{ID: messageID}
+	var agentID string
+	var notifiedAt *time.Time
+	err := s.pool.QueryRow(ctx,
+		`SELECT status, subject, to_recipients, cc, bcc, approval_expires_at, agent_id, notified_at
+		   FROM messages WHERE id = $1`, messageID,
+	).Scan(&m.Status, &m.Subject, &m.ToRecipients, &m.CC, &m.BCC, &m.ApprovalExpiresAt, &agentID, &notifiedAt)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil // message gone
+		}
+		return nil, err
+	}
+	m.AgentID = agentID
+
+	agent, err := s.GetAgentByID(ctx, agentID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil // owning agent deleted — orphaned hold, nothing to notify
+		}
+		return nil, err
+	}
+	return &PendingNotify{Message: m, Agent: agent, Notified: notifiedAt != nil}, nil
 }
 
 // nullIfEmptyString returns nil interface when s is empty so the column is

--- a/internal/jobs/jobs.go
+++ b/internal/jobs/jobs.go
@@ -47,6 +47,7 @@ type Config struct {
 	InboundWorkers     int // QueueInbound concurrency (default 8)
 	WebhookWorkers     int // QueueWebhook concurrency (default 16)
 	MaintenanceWorkers int // QueueMaintenance concurrency (default 2)
+	NotifyWorkers      int // QueueNotify concurrency (default 4)
 	DefaultWorkers     int // QueueDefault concurrency (default 5)
 }
 
@@ -62,6 +63,9 @@ func (c Config) withDefaults() Config {
 	}
 	if c.MaintenanceWorkers <= 0 {
 		c.MaintenanceWorkers = 2
+	}
+	if c.NotifyWorkers <= 0 {
+		c.NotifyWorkers = 4
 	}
 	if c.DefaultWorkers <= 0 {
 		c.DefaultWorkers = 5
@@ -103,7 +107,7 @@ func New(pool *pgxpool.Pool, cfg Config, registrars ...Registrar) (*Client, erro
 	}
 
 	rc, err := river.NewClient(riverpgxv5.New(pool), &river.Config{
-		Queues:       defaultQueueConfig(cfg.OutboundWorkers, cfg.InboundWorkers, cfg.WebhookWorkers, cfg.MaintenanceWorkers, cfg.DefaultWorkers),
+		Queues:       defaultQueueConfig(cfg.OutboundWorkers, cfg.InboundWorkers, cfg.WebhookWorkers, cfg.MaintenanceWorkers, cfg.NotifyWorkers, cfg.DefaultWorkers),
 		Workers:      workers,
 		PeriodicJobs: periodic,
 	})

--- a/internal/jobs/queues.go
+++ b/internal/jobs/queues.go
@@ -21,6 +21,11 @@ const (
 	// QueueMaintenance carries low-urgency periodic/janitor work (reapers,
 	// hold-TTL resolution, auto-disable sweeps).
 	QueueMaintenance = "maintenance"
+	// QueueNotify carries HITL approval-notification emails (the owner's review
+	// alert when an outbound message enters pending_review). Small, isolated pool
+	// so a burst of held sends notifying — or a stuck notification to a bad owner
+	// address retrying — never competes with customer outbound delivery.
+	QueueNotify = "notify"
 	// QueueDefault is River's built-in default — anything not explicitly routed.
 	QueueDefault = river.QueueDefault
 )
@@ -29,12 +34,13 @@ const (
 // MaxWorkers is deliberately generous for I/O-bound work (SMTP / HTTP); tune
 // against real throughput. Every queue a domain enqueues into MUST appear here or
 // its jobs sit unworked.
-func defaultQueueConfig(outbound, inbound, webhook, maintenance, deflt int) map[string]river.QueueConfig {
+func defaultQueueConfig(outbound, inbound, webhook, maintenance, notify, deflt int) map[string]river.QueueConfig {
 	return map[string]river.QueueConfig{
 		QueueOutbound:    {MaxWorkers: outbound},
 		QueueInbound:     {MaxWorkers: inbound},
 		QueueWebhook:     {MaxWorkers: webhook},
 		QueueMaintenance: {MaxWorkers: maintenance},
+		QueueNotify:      {MaxWorkers: notify},
 		QueueDefault:     {MaxWorkers: deflt},
 	}
 }

--- a/migrations/057_messages_notify_job.sql
+++ b/migrations/057_messages_notify_job.sql
@@ -1,0 +1,36 @@
+-- 057_messages_notify_job.sql
+--
+-- Durable HITL approval-notification on River (docs/design/hitl-notify-river.md).
+--
+-- The approve/reject notification email that fires when an outbound message enters
+-- pending_review used to be a detached, best-effort goroutine — lost on a crash or
+-- an SMTP outage between the 202 response and the send. It now rides a River job
+-- (QueueNotify) enqueued in the SAME transaction as the pending_review row, mirroring
+-- the outbound accept-tx (send_job_id, migration 054).
+--
+-- Two additive columns on messages:
+--   notify_job_id — the River QueueNotify job id, stamped in the accept-tx so the
+--                   startup reconciler can find rows stranded without a job
+--                   (pending_review AND notify_job_id IS NULL AND notified_at IS NULL).
+--   notified_at   — set by the worker AFTER a successful send; the send-dedup marker
+--                   that makes a crash-after-send re-drive a no-op. Loss is
+--                   impossible (only set post-send); a rare duplicate is benign.
+--
+-- Additive + idempotent. Nullable ADD COLUMN with no default is a metadata-only op
+-- on Postgres — safe on the prod-sized messages table (same as 054/055).
+--
+-- The reconciler's partial index is built CONCURRENTLY in migration 058 (a plain
+-- CREATE INDEX here would take a write lock on the whole messages table at deploy).
+
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS notify_job_id BIGINT;
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS notified_at   TIMESTAMPTZ;
+
+-- Cutover: every message already in pending_review at the moment this ships was
+-- created under the old code path, which ALREADY sent its notification (the detached
+-- goroutine). Mark those rows notified so the startup reconciler does not re-notify
+-- their owners a second time. (New holds get notify_job_id atomically and never
+-- match the reconciler; a hold created on the no-notifier plain path keeps
+-- notified_at NULL and is correctly picked up.) Touches only the tiny pending_review
+-- set (bounded by TTL, served by idx_messages_pending_review) — cheap + idempotent.
+UPDATE messages SET notified_at = now()
+    WHERE status = 'pending_review' AND notified_at IS NULL;

--- a/migrations/058_messages_notify_job_idx.sql
+++ b/migrations/058_messages_notify_job_idx.sql
@@ -1,0 +1,29 @@
+-- 058_messages_notify_job_idx.sql
+-- e2a:no-transaction
+--
+-- Partial index backing the HITL-notification startup reconciler
+-- (hitlnotify.ReconcilePending), which scans for pending_review holds that never
+-- got a notification job (status='pending_review' AND notify_job_id IS NULL).
+-- Almost always the empty set — the hold accept-tx enqueues in-tx and stamps
+-- notify_job_id atomically — so the partial index is tiny and the reconciler's scan
+-- is an index lookup instead of a full scan of the multi-million-row messages table.
+--
+-- CREATE INDEX CONCURRENTLY so the build does not take a write lock on prod-sized
+-- messages (a plain CREATE INDEX would block all inbound/outbound mail persistence
+-- for the full build). The e2a:no-transaction directive (see
+-- internal/identity/migrate.go) skips the BeginTx wrapper — required because
+-- Postgres rejects CONCURRENTLY inside a transaction block. Split from 057 (which
+-- adds the columns transactionally) because the no-transaction runner requires a
+-- single statement.
+--
+-- OPS NOTE — invalid-index recovery: if the CONCURRENTLY build is interrupted,
+-- Postgres leaves an INVALID index of this name. On the next startup this migration
+-- re-runs, but CREATE ... IF NOT EXISTS sees the name and SKIPS the rebuild, marking
+-- the migration applied over a broken index — the reconciler then falls back to a
+-- seq scan at startup (a performance, not correctness, regression). To recover:
+--     DROP INDEX CONCURRENTLY IF EXISTS idx_messages_pending_no_notify_job;
+-- then re-run this statement. Check validity with:
+--     SELECT indisvalid FROM pg_index WHERE indexrelid = 'idx_messages_pending_no_notify_job'::regclass;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_messages_pending_no_notify_job
+    ON messages (created_at)
+    WHERE status = 'pending_review' AND notify_job_id IS NULL;


### PR DESCRIPTION
Makes the **HITL approval-notification email** durable by moving it onto River — the symmetric follow-up to inbound (#391) and outbound (#388), closing the last at-least-once hole. Design: `docs/design/hitl-notify-river.md`.

## The gap (today)
When an outbound message enters `pending_review`, the account owner gets an email with a preview + one-click approve/reject magic links — the reviewer's primary (sometimes only) signal a message is held. Today `HoldForApprovalCore` fires it via `NotifyPendingApprovalAsync`: a detached `go func()` (`context.Background`, in-process SMTP retries). A crash or unreachable SMTP **between the `202 pending_review` and the send drops it silently** — the reviewer is never told. `cmd/e2a/main.go` flagged this in-code as a known gap.

## The pipeline (three layers, same as inbound/outbound)
```
HoldForApprovalCore (one tx):  INSERT messages (pending_review)
                               + InsertTx hitl_notify job (QueueNotify)
                               + stamp notify_job_id            → commit → 202
River QueueNotify worker:      re-read msg → guard → SendOnce → stamp notified_at
```
- **Accept-tx** persists the hold **and** enqueues the notification job in ONE transaction, so the notification is durably queued before the `202` — a crash can't lose it. A same-tx enqueue failure fails the hold (500), consistent with the outbound accept-tx.
- **Worker** re-reads the message and no-ops on gone / resolved / expired / already-notified; sends via the no-loop `SMTPRelay.SendOnce` (River owns the retry envelope, replacing the relay's in-process loop); stamps `notified_at` **only after a successful send**.
- **At-least-once:** loss is impossible (`notified_at` is only ever set post-send); a rare crash-window duplicate "please review" email is the accepted trade.
- **Isolation:** a dedicated `QueueNotify` (4 workers) so a burst of held sends — or a stuck notification to a bad owner address — never competes with customer outbound delivery.
- `ReconcilePending` re-drives holds stranded without a job at startup.

## Migrations
- **057** — `notify_job_id BIGINT` + `notified_at TIMESTAMPTZ` (metadata-only), **plus a cutover `UPDATE`** stamping `notified_at` on pre-existing `pending_review` rows: every hold live at deploy was *already* emailed by the old code, so this stops the reconciler re-notifying those owners.
- **058** — the reconciler's partial index, `CREATE INDEX CONCURRENTLY` under `-- e2a:no-transaction` so the deploy doesn't write-lock the prod-sized `messages` table.

## Gating
Wired on the same relay + public-URL config as the notifier. Unconfigured deployments keep the plain hold path (no notification) **byte-for-byte unchanged**.

## Verification
- `go build ./...`, `gofmt`, and `go vet` clean; affected suite (`hitlnotify`, `identity`, `agent`, `jobs`) green; migrations apply idempotently through the real migrator (incl. 058's CONCURRENTLY/no-transaction path).
- Tests: 11 worker unit tests (success/gone/resolved/expired/already-notified/permanent-cancel/outage-snooze/transient/load-error), reconciler + **cutover-skip** integration, and a **driven end-to-end** (accept-tx → real River → fake SMTP → `notified_at` stamped).

## Review
An adversarial review pass on the pre-fix diff caught two issues, both fixed here: the migration index write-lock (→ split to 058 `CONCURRENTLY`) and the cutover double-notify (→ `notified_at` seed + reconciler `notified_at IS NULL` guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)