### PR TITLE
feat(hitl): TTL expiration sweep on River (QueueMaintenance periodic)

### DIFF
--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -306,6 +306,21 @@ func main() {
 	webhookMaint := webhookdelivery.NewMaintenanceJobs(webhook.NewAutoDisableWorker(store))
 	registrars = append(registrars, webhookMaint)
 
+	// HITL TTL expiration sweep as a River periodic on QueueMaintenance — replaces
+	// the hand-rolled 60s ticker. Transitions pending_review messages past their TTL
+	// into review_expired_approved (auto-send/release) or review_expired_rejected per
+	// the owning agent's hitl_expiration_action. Reuses RunOnce as the sweep body.
+	// SetPublisher is called immediately below (before jobs.New, and the registrar
+	// holds this same *Worker pointer), so the publisher is wired well before the
+	// first tick (RunOnStart:false ⇒ first sweep at +60s).
+	hitlWorker := hitlworker.New(store, sender, usageTracker, cfg.OutboundSMTP.FromDomain)
+	// Fire review_approved/review_rejected on TTL auto-resolution, so a hold resolved
+	// by timeout notifies subscribers exactly like a human-resolved one (same legacy
+	// publisher as the agent API). Load-bearing for inbound approve: a TTL-released
+	// inbound message has no other push signal.
+	hitlWorker.SetPublisher(outboxPublisher)
+	registrars = append(registrars, hitlworker.NewMaintenanceJobs(hitlWorker))
+
 	if len(registrars) > 0 {
 		jc, jerr := jobs.New(pool, jobs.Config{}, registrars...)
 		if jerr != nil {
@@ -607,10 +622,10 @@ func main() {
 	// workerWG tracks every background goroutine that needs to drain
 	// before the process exits on SIGTERM. Without it the main
 	// goroutine would return as soon as httpServer.Shutdown returns,
-	// dropping in-flight webhook deliveries and HITL TTL transitions
-	// mid-iteration. retryCancel/hitlCancel signal the workers to
-	// stop; wg.Wait() at the end of shutdown blocks for the current
-	// iteration to settle.
+	// dropping in-flight webhook deliveries mid-iteration. bgCancel/
+	// cleanupCancel signal the remaining workers to stop; wg.Wait() at the
+	// end of shutdown blocks for the current iteration to settle. (The HITL
+	// TTL sweep is now a River periodic drained by jobsClient.Stop.)
 	//
 	// (The HITL approval-notification email is no longer a detached
 	// goroutine — it's a durable River job on QueueNotify, drained by the
@@ -633,23 +648,9 @@ func main() {
 		outboxWorker.Start(bgCtx)
 	}()
 
-	// HITL expiration worker: transitions pending_review messages that
-	// blew past their TTL into review_expired_approved (auto-send/release) or
-	// review_expired_rejected based on the owning agent's hitl_expiration_action.
-	hitlWorker := hitlworker.New(store, sender, usageTracker, cfg.OutboundSMTP.FromDomain)
-	// Fire review_approved/review_rejected on TTL auto-resolution, so a hold
-	// resolved by timeout notifies subscribers exactly like a human-resolved one
-	// (same legacy publisher as the agent API). Load-bearing for inbound approve:
-	// a TTL-released inbound message has no other push signal.
-	hitlWorker.SetPublisher(outboxPublisher)
-	hitlCtx, hitlCancel := context.WithCancel(context.Background())
-	workerWG.Add(1)
-	go func() {
-		defer workerWG.Done()
-		if err := hitlWorker.Run(hitlCtx); err != nil && err != context.Canceled {
-			log.Printf("[hitl-worker] stopped: %v", err)
-		}
-	}()
+	// (The HITL TTL expiration sweep is now a River periodic on QueueMaintenance,
+	// registered above via hitlworker.NewMaintenanceJobs and drained by the shared
+	// jobsClient under the shutdown deadline — no separate goroutine/cancel needed.)
 
 	// Periodic cleanup of expired messages and sessions. Bound to its
 	// own cancel-context so shutdown stops the loop instead of
@@ -725,12 +726,10 @@ func main() {
 	<-sigCh
 	log.Println("Shutting down...")
 
-	// Signal every background worker to stop. Their inner ctx-select
-	// branches return on the next iteration; processBatch / RunOnce
-	// calls already in flight finish their current row before the
-	// goroutine exits.
+	// Signal the remaining background workers to stop. Their inner ctx-select
+	// branches return on the next iteration; work already in flight finishes
+	// its current row before the goroutine exits.
 	bgCancel()
-	hitlCancel()
 	cleanupCancel()
 
 	// SMTP server: close the listener so no new connections, but

--- a/internal/hitlworker/maintenance.go
+++ b/internal/hitlworker/maintenance.go
@@ -43,6 +43,23 @@ func NewMaintenanceWorker(sweeper Sweeper) *MaintenanceWorker {
 	return &MaintenanceWorker{sweeper: sweeper}
 }
 
+// Timeout disables River's per-job timeout for the sweep (River's client default is
+// 1 minute). Unlike a typical maintenance job — a quick handful of DELETEs — one
+// sweep can legitimately run for many minutes: it performs up to DefaultBatchSize
+// (100) SYNCHRONOUS, retrying SMTP sends for expired auto-approve holds, and the
+// relay send is not context-cancellable (its own per-send network deadline bounds
+// it). Under the 60s default a backlogged sweep is cancelled mid-iteration; the
+// store's ctx-derived hold transitions then fail and surface as FALSE
+// "[hitl-stuck] needs_manual_intervention" alarms on the auto-send path — every
+// cycle, precisely during SMTP/SES degradation. The old hand-rolled ticker ran
+// under an unbounded context; returning a negative duration restores that (River
+// treats <0 as "no timeout"). The structural fix that would let this return to a
+// bounded timeout is moving each auto-send onto its own QueueOutbound job (tracked
+// follow-up) so a sweep does DB-only work again.
+func (w *MaintenanceWorker) Timeout(*river.Job[HITLMaintenanceArgs]) time.Duration {
+	return -1
+}
+
 func (w *MaintenanceWorker) Work(ctx context.Context, _ *river.Job[HITLMaintenanceArgs]) error {
 	if err := w.sweeper.RunOnce(ctx); err != nil {
 		log.Printf("[hitl-sweep] TTL sweep error (swallowed; next tick retries): %v", err)

--- a/internal/hitlworker/maintenance.go
+++ b/internal/hitlworker/maintenance.go
@@ -1,0 +1,85 @@
+package hitlworker
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/riverqueue/river"
+
+	"github.com/Mnexa-AI/e2a/internal/jobs"
+)
+
+// maintenanceInterval is the TTL-sweep cadence — preserves the prior hand-rolled
+// ticker's 60s (was DefaultInterval). Short enough that TTL boundaries are honored
+// within a minute, long enough to avoid hot-looping the DB when there's nothing to do.
+const maintenanceInterval = 60 * time.Second
+
+// Sweeper runs one TTL-expiration sweep of both hold queues (outbound holds +
+// inbound review holds). Satisfied by *Worker — the River worker just drives its
+// RunOnce on a schedule instead of a hand-rolled time.Ticker.
+type Sweeper interface {
+	RunOnce(ctx context.Context) error
+}
+
+// HITLMaintenanceArgs drives the periodic HITL TTL sweep. No fields — the worker
+// sweeps every expired hold each run.
+type HITLMaintenanceArgs struct{}
+
+func (HITLMaintenanceArgs) Kind() string { return "hitl_ttl_sweep" }
+
+// MaintenanceWorker runs the TTL sweep once per scheduled job. Any sweep error is
+// logged and swallowed (Work returns nil) so a transient DB blip never spins
+// River's retry machinery for a best-effort idempotent sweep — the next interval
+// picks it up. Mirrors webhookdelivery.MaintenanceWorker.
+type MaintenanceWorker struct {
+	river.WorkerDefaults[HITLMaintenanceArgs]
+	sweeper Sweeper
+}
+
+// NewMaintenanceWorker builds the worker around a Sweeper. Exported so tests can
+// drive Work directly (RegisterJobs builds an identical one for the client).
+func NewMaintenanceWorker(sweeper Sweeper) *MaintenanceWorker {
+	return &MaintenanceWorker{sweeper: sweeper}
+}
+
+func (w *MaintenanceWorker) Work(ctx context.Context, _ *river.Job[HITLMaintenanceArgs]) error {
+	if err := w.sweeper.RunOnce(ctx); err != nil {
+		log.Printf("[hitl-sweep] TTL sweep error (swallowed; next tick retries): %v", err)
+	}
+	return nil
+}
+
+// MaintenanceJobs is the jobs.Registrar for the HITL TTL sweep: it contributes the
+// MaintenanceWorker and a periodic that fires it on QueueMaintenance. No enqueuer
+// needed — the schedule is the only trigger.
+type MaintenanceJobs struct{ sweeper Sweeper }
+
+// NewMaintenanceJobs builds the registrar around a Sweeper (the *Worker).
+func NewMaintenanceJobs(sweeper Sweeper) *MaintenanceJobs { return &MaintenanceJobs{sweeper: sweeper} }
+
+// RegisterJobs adds the maintenance worker + its periodic schedule. Mirrors the
+// webhook janitor + inbound retention periodics: routed to QueueMaintenance, no
+// UniqueOpts (River's periodic scheduler already inserts at most one per interval
+// and a completed run must not dedup-block the next), RunOnStart:false (first sweep
+// after one interval — a conscious minor change from the old ticker's immediate
+// first sweep, consistent with the other periodics; the per-row store operations are
+// idempotent + cross-replica-safe so scheduling is the only concern). Implements
+// jobs.Registrar.
+func (m *MaintenanceJobs) RegisterJobs(w *river.Workers) []*river.PeriodicJob {
+	river.AddWorker(w, &MaintenanceWorker{sweeper: m.sweeper})
+	return []*river.PeriodicJob{
+		river.NewPeriodicJob(
+			river.PeriodicInterval(maintenanceInterval),
+			maintenanceJobConstructor,
+			&river.PeriodicJobOpts{RunOnStart: false},
+		),
+	}
+}
+
+// maintenanceJobConstructor builds each tick's insert: a HITLMaintenanceArgs
+// routed to QueueMaintenance. Factored out (vs. an inline closure) so a test can
+// assert the queue routing, which River's *PeriodicJob doesn't expose.
+func maintenanceJobConstructor() (river.JobArgs, *river.InsertOpts) {
+	return HITLMaintenanceArgs{}, &river.InsertOpts{Queue: jobs.QueueMaintenance}
+}

--- a/internal/hitlworker/maintenance_test.go
+++ b/internal/hitlworker/maintenance_test.go
@@ -1,0 +1,81 @@
+package hitlworker
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/riverqueue/river"
+
+	"github.com/Mnexa-AI/e2a/internal/jobs"
+)
+
+// fakeSweeper records how many times RunOnce ran and returns a canned error, so
+// the worker's swallow behavior can be exercised without a database.
+type fakeSweeper struct {
+	runs int
+	err  error
+}
+
+func (f *fakeSweeper) RunOnce(_ context.Context) error {
+	f.runs++
+	return f.err
+}
+
+// TestMaintenanceWorker_WorkSwallowsSweepError: the periodic worker drives the
+// sweeper's RunOnce once per job and returns nil even when RunOnce errors — a
+// transient DB blip must not spin River's retry machinery for a best-effort
+// idempotent sweep; the next interval picks it up.
+func TestMaintenanceWorker_WorkSwallowsSweepError(t *testing.T) {
+	sw := &fakeSweeper{err: errors.New("boom")}
+	w := NewMaintenanceWorker(sw)
+	if err := w.Work(context.Background(), &river.Job[HITLMaintenanceArgs]{}); err != nil {
+		t.Fatalf("Work returned %v, want nil (error must be swallowed)", err)
+	}
+	if sw.runs != 1 {
+		t.Errorf("sweeper ran %d times, want 1", sw.runs)
+	}
+}
+
+// TestMaintenanceWorker_WorkRunsSweep: the happy path also drives RunOnce once
+// and returns nil.
+func TestMaintenanceWorker_WorkRunsSweep(t *testing.T) {
+	sw := &fakeSweeper{}
+	w := NewMaintenanceWorker(sw)
+	if err := w.Work(context.Background(), &river.Job[HITLMaintenanceArgs]{}); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	if sw.runs != 1 {
+		t.Errorf("sweeper ran %d times, want 1", sw.runs)
+	}
+}
+
+// TestMaintenanceJobs_RegistersOnePeriodic: RegisterJobs contributes exactly one
+// periodic (the TTL sweep schedule) and wires its worker.
+func TestMaintenanceJobs_RegistersOnePeriodic(t *testing.T) {
+	m := NewMaintenanceJobs(&fakeSweeper{})
+	periodics := m.RegisterJobs(river.NewWorkers())
+	if len(periodics) != 1 {
+		t.Fatalf("RegisterJobs returned %d periodic jobs, want 1", len(periodics))
+	}
+}
+
+// TestMaintenanceJobConstructor_RoutesToMaintenanceQueue: each scheduled tick
+// inserts a hitl_ttl_sweep job onto QueueMaintenance. River's *PeriodicJob keeps
+// its constructor unexported, so this asserts the factored constructor directly.
+func TestMaintenanceJobConstructor_RoutesToMaintenanceQueue(t *testing.T) {
+	args, opts := maintenanceJobConstructor()
+	if got := args.Kind(); got != "hitl_ttl_sweep" {
+		t.Errorf("args.Kind() = %q, want %q", got, "hitl_ttl_sweep")
+	}
+	if opts == nil || opts.Queue != jobs.QueueMaintenance {
+		t.Errorf("insert queue = %q, want %q", queueOf(opts), jobs.QueueMaintenance)
+	}
+}
+
+func queueOf(o *river.InsertOpts) string {
+	if o == nil {
+		return "<nil>"
+	}
+	return o.Queue
+}

--- a/internal/hitlworker/maintenance_test.go
+++ b/internal/hitlworker/maintenance_test.go
@@ -50,6 +50,17 @@ func TestMaintenanceWorker_WorkRunsSweep(t *testing.T) {
 	}
 }
 
+// TestMaintenanceWorker_TimeoutDisabled: the sweep must NOT run under River's 60s
+// default job timeout — it does up to 100 synchronous, non-ctx-aware SMTP sends and
+// would otherwise be cancelled mid-drain, firing false [hitl-stuck] alarms. A
+// negative return tells River "no timeout" (restores the old ticker's unbounded run).
+func TestMaintenanceWorker_TimeoutDisabled(t *testing.T) {
+	w := NewMaintenanceWorker(&fakeSweeper{})
+	if got := w.Timeout(&river.Job[HITLMaintenanceArgs]{}); got >= 0 {
+		t.Errorf("Timeout() = %v, want a negative duration (River default 60s cap disabled)", got)
+	}
+}
+
 // TestMaintenanceJobs_RegistersOnePeriodic: RegisterJobs contributes exactly one
 // periodic (the TTL sweep schedule) and wires its worker.
 func TestMaintenanceJobs_RegistersOnePeriodic(t *testing.T) {

--- a/internal/hitlworker/worker.go
+++ b/internal/hitlworker/worker.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/Mnexa-AI/e2a/internal/identity"
 	"github.com/Mnexa-AI/e2a/internal/loopback"
@@ -19,23 +18,18 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/webhookpub"
 )
 
-// DefaultInterval is the sweep cadence. One minute matches the design doc
-// target; short enough that TTL boundaries are honored within a minute,
-// long enough to avoid hot-looping the DB when there's nothing to do.
-const DefaultInterval = 60 * time.Second
-
 // DefaultBatchSize caps how many rows one sweep will try to finalize. The
 // partial index on (approval_expires_at) WHERE status='pending_review'
 // keeps the list query cheap regardless of total table size.
 const DefaultBatchSize = 100
 
-// Worker runs the TTL sweep. Construct with New, start with Run.
+// Worker runs the TTL sweep. Construct with New; its RunOnce is driven on a
+// schedule by the River maintenance periodic (see maintenance.go).
 type Worker struct {
 	store      *identity.Store
 	sender     *outbound.Sender
 	usage      usage.UsageTracker
 	fromDomain string
-	interval   time.Duration
 	batchSize  int
 	// publisher fires the review-resolution webhook when the sweep auto-resolves
 	// a hold, so a TTL-resolved hold notifies subscribers exactly like a
@@ -61,39 +55,20 @@ func New(store *identity.Store, sender *outbound.Sender, usage usage.UsageTracke
 		sender:     sender,
 		usage:      usage,
 		fromDomain: fromDomain,
-		interval:   DefaultInterval,
 		batchSize:  DefaultBatchSize,
 	}
 }
 
-// Run drives the periodic sweep until ctx is cancelled. Returns ctx.Err()
-// on shutdown. Safe to run from its own goroutine; multiple instances
-// across processes are fine because the per-row store operations use
-// row-level locking + status guards.
-func (w *Worker) Run(ctx context.Context) error {
-	// One immediate sweep so a process restart doesn't leave a full
-	// interval's worth of already-expired rows sitting.
+// RunOnce performs a single sweep of both queues (outbound holds, then inbound
+// review holds). This is the sweep body the River maintenance periodic drives on
+// a schedule (see maintenance.go); it's also called directly by tests for
+// deterministic behavior. Returns nil — both sweeps log and swallow their own
+// per-row/query errors internally (a transient DB blip should not spin River's
+// retry machinery); the error return satisfies the Sweeper interface.
+func (w *Worker) RunOnce(ctx context.Context) error {
 	w.sweep(ctx)
 	w.sweepReviews(ctx)
-
-	ticker := time.NewTicker(w.interval)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-ticker.C:
-			w.sweep(ctx)
-			w.sweepReviews(ctx)
-		}
-	}
-}
-
-// RunOnce performs a single sweep of both queues. Exposed for tests that want
-// deterministic behavior without setting up a ticker.
-func (w *Worker) RunOnce(ctx context.Context) {
-	w.sweep(ctx)
-	w.sweepReviews(ctx)
+	return nil
 }
 
 // sweepReviews auto-resolves expired INBOUND review holds. Both directions share

--- a/internal/hitlworker/worker_test.go
+++ b/internal/hitlworker/worker_test.go
@@ -6,13 +6,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jackc/pgx/v5/pgxpool"
-	"github.com/Mnexa-AI/e2a/internal/usage"
 	"github.com/Mnexa-AI/e2a/internal/config"
 	"github.com/Mnexa-AI/e2a/internal/hitlworker"
 	"github.com/Mnexa-AI/e2a/internal/identity"
 	"github.com/Mnexa-AI/e2a/internal/outbound"
 	"github.com/Mnexa-AI/e2a/internal/testutil"
+	"github.com/Mnexa-AI/e2a/internal/usage"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // setupWorker wires a worker + fake SMTP on a fresh test database. Returns
@@ -335,26 +335,5 @@ func TestWorkerRunOnceIsSafeWhenNoExpiredRows(t *testing.T) {
 	w.RunOnce(context.Background())
 	if msgs := smtpDone(); len(msgs) != 0 {
 		t.Fatalf("expected 0 SMTP messages from an empty sweep, got %d", len(msgs))
-	}
-}
-
-func TestWorkerRunStopsOnContextCancel(t *testing.T) {
-	w, _, _, _ := setupWorker(t)
-	ctx, cancel := context.WithCancel(context.Background())
-
-	done := make(chan error, 1)
-	go func() { done <- w.Run(ctx) }()
-
-	// Give Run a moment to enter its ticker loop.
-	time.Sleep(50 * time.Millisecond)
-	cancel()
-
-	select {
-	case err := <-done:
-		if err != context.Canceled {
-			t.Errorf("Run returned %v, want context.Canceled", err)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("Run did not return after cancel")
 	}
 }


### PR DESCRIPTION
Migrates the hand-rolled **HITL TTL expiration sweep** from a `time.Ticker(60s)` goroutine onto a River **periodic** on `QueueMaintenance` — retiring the last hand-rolled ticker in the HITL path, mirroring the already-shipped webhook janitor. Pure **consolidation**: the sweep *body* is unchanged; only the *scheduling* moves.

## What & why
`internal/hitlworker` swept `pending_review` messages past their TTL (outbound → auto-send/reject, inbound → release/drop, + `review_approved`/`review_rejected` webhooks) on a hand-rolled 60s ticker in its own goroutine. This moves the schedule to River:
- New `internal/hitlworker/maintenance.go` — `HITLMaintenanceArgs` (`hitl_ttl_sweep`), a `Sweeper` interface, a `MaintenanceWorker` whose `Work` runs the sweep and returns nil (errors logged+swallowed so a DB blip doesn't spin River's retry), and a `jobs.Registrar` scheduling one periodic on `QueueMaintenance` (`RunOnStart:false`, no `UniqueOpts` — same as the sibling periodics).
- `worker.go` — deleted `Run` (the ticker loop), the `interval` field, and `DefaultInterval`; `RunOnce` (the existing single-pass sweep body, already what tests drive) now returns `error`. `New`, `SetPublisher`, both sweep functions, and all auto-send/reject/release + event logic are **byte-for-byte unchanged**.
- `cmd/e2a/main.go` — removed the hitl ticker goroutine + its `hitlCtx`/`hitlCancel`/`workerWG`; the periodic now drains on shutdown via the shared `jobsClient.Stop`. Registrar appended before `jobs.New`.

Cross-replica safe with no `UniqueOpts` (the store transitions are status-guarded compare-and-set / `FOR UPDATE SKIP LOCKED` + a `send_attempts` exactly-once gate), exactly as when the ticker could already run on every replica.

## Scope
**Out of scope (deferred):** routing the TTL auto-approve send onto `QueueOutbound`. The auto-approve still uses the in-process `Sender.Send` — unchanged here.

## Behavior note
`RunOnStart:false` (consistent with every sibling `QueueMaintenance` periodic) means the first sweep is ≤60s after boot instead of immediate — negligible against hour-scale TTLs.

## Verification
- `go build ./...`, `gofmt`, `go vet ./internal/hitlworker/ ./cmd/e2a/` clean.
- `go test ./internal/hitlworker/ ./internal/jobs/` green. New `maintenance_test.go`: error-swallow, happy-path, single-periodic, and QueueMaintenance/args-kind routing. Deleted the obsolete `TestWorkerRunStopsOnContextCancel` (ticker-only).

## Review
Two adversarial review passes (wiring/shutdown + body-preservation/tests) — **both: faithful, safe, ship-able.** Confirmed the sweep body is unchanged, no dangling refs, drain flows correctly through `jobsClient.Stop`, and `outboxPublisher` is wired before the first tick. A stale wiring comment they flagged is fixed in this commit.

**Tracked follow-up (not a blocker):** the old ticker *coalesced* ticks; a River periodic enqueues every 60s regardless, and this sweep is the only `QueueMaintenance` job doing synchronous SES sends (≤100 × up to ~21s under a backlog), so sweeps could briefly pile up on the 2-worker maintenance pool. Bounded and self-healing (each sweep resolves holds, so later ones get cheaper). The clean fix is the **deferred `QueueOutbound` send-routing** — folding it there removes the synchronous send from the sweep entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)