### PR TITLE
feat(janitor): hourly cleanup on River (QueueMaintenance periodic)

### DIFF
--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/idempotency"
 	"github.com/Mnexa-AI/e2a/internal/identity"
 	"github.com/Mnexa-AI/e2a/internal/inboundprocess"
+	"github.com/Mnexa-AI/e2a/internal/janitor"
 	"github.com/Mnexa-AI/e2a/internal/jobs"
 	"github.com/Mnexa-AI/e2a/internal/limits"
 	"github.com/Mnexa-AI/e2a/internal/oauth"
@@ -321,6 +322,29 @@ func main() {
 	hitlWorker.SetPublisher(outboxPublisher)
 	registrars = append(registrars, hitlworker.NewMaintenanceJobs(hitlWorker))
 
+	// Hourly cleanup janitor (expired messages/sessions/webhook delivery
+	// records/webhook events/OAuth rows/idempotency keys) as a River periodic on
+	// QueueMaintenance — replaces the hand-rolled time.Ticker(1h) goroutine that
+	// used to live in the shutdown block. Two of its dependencies (the OAuth
+	// storage and the idempotency store) were previously constructed further
+	// down; they only need `pool`, so they're built here so every janitor dep is
+	// in scope before jobs.New consumes the registrars. Their downstream wiring
+	// (api.SetOAuthProvider / api.SetIdempotencyStore, which need `api`) stays
+	// below. oauthStorage is nil when the OAuth provider is disabled (no
+	// public_url); the janitor skips that pass, preserving the old
+	// `if oauthStorage != nil` guard.
+	var oauthStorage *oauth.Storage
+	if cfg.HTTP.PublicURL != "" {
+		oauthStorage = oauth.NewStorage(pool)
+	}
+	idempotencyStore := idempotency.NewStore(pool)
+	var oauthPruner janitor.OAuthPruner
+	if oauthStorage != nil {
+		oauthPruner = oauthStorage
+	}
+	cleanupJanitor := janitor.New(store, deliveryStore, subscriberStore, webhookOutbox, oauthPruner, idempotencyStore, metrics)
+	registrars = append(registrars, janitor.NewMaintenanceJobs(cleanupJanitor))
+
 	if len(registrars) > 0 {
 		jc, jerr := jobs.New(pool, jobs.Config{}, registrars...)
 		if jerr != nil {
@@ -433,11 +457,12 @@ func main() {
 	// `iss` emission + discovery would emit empty/inconsistent values
 	// — skip wiring so /oauth2/* return 404 and operators get a
 	// loud signal that the deployment needs http.public_url set.
-	var oauthStorage *oauth.Storage
+	// oauthStorage was constructed above (near the janitor wiring) so the cleanup
+	// periodic can prune expired OAuth rows; here we wire the provider on top of
+	// it when a public URL is configured.
 	if cfg.HTTP.PublicURL == "" {
 		log.Printf("[oauth] provider disabled: http.public_url is not set (required for issuer identity)")
 	} else {
-		oauthStorage = oauth.NewStorage(pool)
 		// Issuer = api_url (defaults to public_url). fosite stamps it into
 		// token `iss` and the RFC 9207 response, so it must match what
 		// discovery advertises and what agentAuthIssuer signs/verifies.
@@ -458,7 +483,8 @@ func main() {
 	// model-driven re-invocations). Always wired in production — keeping it optional in
 	// the agent package surfaces a clearer 5xx path for environments that don't run
 	// against this codebase's postgres.
-	idempotencyStore := idempotency.NewStore(pool)
+	// idempotencyStore was constructed above (near the janitor wiring) so the
+	// cleanup periodic can sweep expired keys; here we bind it onto the API.
 	api.SetIdempotencyStore(idempotencyStore)
 
 	// Resource-limits enforcer. The OSS server is plan-agnostic: it
@@ -622,14 +648,14 @@ func main() {
 	// workerWG tracks every background goroutine that needs to drain
 	// before the process exits on SIGTERM. Without it the main
 	// goroutine would return as soon as httpServer.Shutdown returns,
-	// dropping in-flight webhook deliveries mid-iteration. bgCancel/
-	// cleanupCancel signal the remaining workers to stop; wg.Wait() at the
-	// end of shutdown blocks for the current iteration to settle. (The HITL
-	// TTL sweep is now a River periodic drained by jobsClient.Stop.)
+	// dropping in-flight webhook deliveries mid-iteration. bgCancel signals
+	// the remaining background worker(s) to stop; wg.Wait() at the end of
+	// shutdown blocks for the current iteration to settle.
 	//
-	// (The HITL approval-notification email is no longer a detached
-	// goroutine — it's a durable River job on QueueNotify, drained by the
-	// shared jobsClient under the shutdown deadline. See hitl-notify-river.md.)
+	// (The HITL TTL sweep, the hourly cleanup janitor, and the HITL
+	// approval-notification email are all River jobs now — QueueMaintenance
+	// periodics and QueueNotify respectively — drained by the shared
+	// jobsClient under the shutdown deadline, not hand-rolled goroutines.)
 	var workerWG sync.WaitGroup
 
 	// Webhook subscriber delivery now runs entirely on River's DeliverWorker
@@ -652,76 +678,10 @@ func main() {
 	// registered above via hitlworker.NewMaintenanceJobs and drained by the shared
 	// jobsClient under the shutdown deadline — no separate goroutine/cancel needed.)
 
-	// Periodic cleanup of expired messages and sessions. Bound to its
-	// own cancel-context so shutdown stops the loop instead of
-	// orphaning the goroutine.
-	cleanupCtx, cleanupCancel := context.WithCancel(context.Background())
-	workerWG.Add(1)
-	go func() {
-		defer workerWG.Done()
-		ticker := time.NewTicker(1 * time.Hour)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-cleanupCtx.Done():
-				return
-			case <-ticker.C:
-				if deleted, err := store.DeleteExpiredMessages(cleanupCtx); err != nil {
-					log.Printf("Failed to clean up expired messages: %v", err)
-				} else if deleted > 0 {
-					log.Printf("Cleaned up %d expired message(s)", deleted)
-					metrics.JanitorRowsDeleted("messages", int(deleted))
-				}
-
-				if deleted, err := store.DeleteExpiredUserSessions(cleanupCtx); err != nil {
-					log.Printf("Failed to clean up expired user sessions: %v", err)
-				} else if deleted > 0 {
-					log.Printf("Cleaned up %d expired user session(s)", deleted)
-				}
-
-				if deleted, err := deliveryStore.DeleteExpiredDeliveries(cleanupCtx); err != nil {
-					log.Printf("Failed to clean up expired webhook deliveries: %v", err)
-				} else if deleted > 0 {
-					log.Printf("Cleaned up %d expired webhook delivery record(s)", deleted)
-				}
-
-				if deleted, err := subscriberStore.DeleteExpiredSubscriberDeliveries(cleanupCtx); err != nil {
-					log.Printf("Failed to clean up expired webhook subscriber deliveries: %v", err)
-				} else if deleted > 0 {
-					log.Printf("Cleaned up %d expired webhook subscriber delivery record(s)", deleted)
-					metrics.JanitorRowsDeleted("webhook_subscriber_deliveries", deleted)
-				}
-
-				// Slice 1 prerequisite janitor: webhook_events rows
-				// also have a 30-day TTL (migration 026). Without
-				// this, the table grows monotonically once the
-				// outbox path starts writing events.
-				if deleted, err := webhookOutbox.DeleteExpiredWebhookEvents(cleanupCtx); err != nil {
-					log.Printf("Failed to clean up expired webhook events: %v", err)
-				} else if deleted > 0 {
-					log.Printf("Cleaned up %d expired webhook event(s)", deleted)
-					metrics.JanitorRowsDeleted("webhook_events", deleted)
-				}
-
-				if oauthStorage != nil {
-					if res, err := oauthStorage.CleanupExpired(cleanupCtx, time.Now()); err != nil {
-						log.Printf("Failed to clean up expired OAuth rows: %v", err)
-					} else if res.Total() > 0 {
-						log.Printf("Cleaned up OAuth rows: codes=%d pkce=%d access=%d refresh=%d clients=%d",
-							res.AuthCodesDeleted, res.PKCERequestsDeleted,
-							res.AccessTokensDeleted, res.RefreshTokensDeleted,
-							res.ClientsDeleted)
-					}
-				}
-			}
-
-			if deleted, err := idempotencyStore.Sweep(context.Background()); err != nil {
-				log.Printf("Failed to sweep idempotency keys: %v", err)
-			} else if deleted > 0 {
-				log.Printf("Swept %d idempotency key(s) past TTL", deleted)
-			}
-		}
-	}()
+	// The hourly cleanup janitor (expired messages/sessions/webhook records/
+	// OAuth rows/idempotency keys) is now a River periodic on QueueMaintenance
+	// (janitor.MaintenanceJobs, registered above). It drains on shutdown via the
+	// shared jobsClient.Stop below — no separate cancel-context needed.
 
 	<-sigCh
 	log.Println("Shutting down...")
@@ -730,7 +690,6 @@ func main() {
 	// branches return on the next iteration; work already in flight finishes
 	// its current row before the goroutine exits.
 	bgCancel()
-	cleanupCancel()
 
 	// SMTP server: close the listener so no new connections, but
 	// existing connections finish their DATA per the relay's own

--- a/internal/janitor/janitor.go
+++ b/internal/janitor/janitor.go
@@ -219,6 +219,17 @@ func NewMaintenanceJobs(j *Janitor) *MaintenanceJobs { return &MaintenanceJobs{j
 // UniqueOpts (River's periodic scheduler already inserts at most one per
 // interval and a completed run must not dedup-block the next), RunOnStart:false
 // (first sweep after one interval, matching the old ticker's first-tick-after-1h).
+//
+// Two deferred tradeoffs, inherited from the pre-River janitor (not introduced by
+// this migration): (1) each prune is an unbounded single-statement DELETE — on a
+// prod-sized `messages` table the first sweep can hold a long lock / emit a large
+// WAL burst; batching the deletes (a LIMIT-loop) is a separate follow-up. (2) With
+// no UniqueOpts and QueueMaintenance's small worker pool, a sweep that runs longer
+// than the 1h interval can overlap the next tick. That is safe — every prune is an
+// idempotent DELETE on a distinct table and a partial sweep is simply finished by
+// the next interval — but two unbounded `DELETE FROM messages` could briefly
+// contend. Both only bite against a large, long-unpruned table (e.g. the first
+// deploy); steady-state sweeps are near-empty.
 func (m *MaintenanceJobs) RegisterJobs(w *river.Workers) []*river.PeriodicJob {
 	river.AddWorker(w, &MaintenanceWorker{janitor: m.janitor})
 	return []*river.PeriodicJob{

--- a/internal/janitor/janitor.go
+++ b/internal/janitor/janitor.go
@@ -1,0 +1,239 @@
+// Package janitor runs the low-urgency hourly cleanup sweep as a River
+// periodic on QueueMaintenance. It replaces the hand-rolled time.Ticker(1h)
+// goroutine that used to live in cmd/e2a/main.go, mirroring the webhook
+// auto-disable janitor (internal/webhookdelivery.MaintenanceJobs) and the
+// inbound retention sweep (internal/inboundprocess.RetentionWorker).
+//
+// The sweep runs every prune SEQUENTIALLY (not concurrently — a janitor must
+// be gentle on Postgres and there is no latency benefit to parallelism) and
+// CONTINUES PAST any individual prune's error, so one failing DELETE never
+// skips the rest. Sweep accumulates and returns the errors; the worker
+// log-and-swallows them (returning nil) so a transient DB blip doesn't spin
+// River's retry machinery — the next interval picks the work back up.
+package janitor
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/riverqueue/river"
+
+	"github.com/Mnexa-AI/e2a/internal/jobs"
+	"github.com/Mnexa-AI/e2a/internal/oauth"
+)
+
+// janitorInterval is the cleanup cadence — matches the prior time.Ticker(1h).
+const janitorInterval = 1 * time.Hour
+
+// The prune dependencies are narrow interfaces (one per store's prune
+// method(s)) so the sweep is unit-testable with a single fake and never
+// depends on a concrete store. Signatures match the real store methods.
+
+// MessagePruner prunes expired messages and expired user sessions (both live
+// on *identity.Store today).
+type MessagePruner interface {
+	DeleteExpiredMessages(ctx context.Context) (int64, error)
+	DeleteExpiredUserSessions(ctx context.Context) (int64, error)
+}
+
+// DeliveryPruner prunes expired webhook delivery records (*webhook.DeliveryStore).
+type DeliveryPruner interface {
+	DeleteExpiredDeliveries(ctx context.Context) (int64, error)
+}
+
+// SubscriberPruner prunes expired webhook subscriber deliveries (*webhook.SubscriberStore).
+type SubscriberPruner interface {
+	DeleteExpiredSubscriberDeliveries(ctx context.Context) (int, error)
+}
+
+// WebhookEventPruner prunes expired webhook_events rows (webhookpub outbox).
+type WebhookEventPruner interface {
+	DeleteExpiredWebhookEvents(ctx context.Context) (int, error)
+}
+
+// IdempotencyPruner sweeps idempotency keys past their TTL (*idempotency.Store).
+type IdempotencyPruner interface {
+	Sweep(ctx context.Context) (int64, error)
+}
+
+// OAuthPruner cleans up expired OAuth rows (*oauth.Storage). Optional: when the
+// OAuth provider isn't configured the dependency is nil and the pass is skipped
+// (preserving the old `if oauthStorage != nil` guard). Pass a nil interface —
+// NOT a typed nil *oauth.Storage — to skip it.
+type OAuthPruner interface {
+	CleanupExpired(ctx context.Context, now time.Time) (oauth.RetentionResult, error)
+}
+
+// Metrics is the narrow slice of telemetry.Metrics the janitor emits. Injectable
+// so tests don't need a real backend; satisfied by *telemetry.Log / telemetry.NoOp.
+type Metrics interface {
+	JanitorRowsDeleted(table string, count int)
+}
+
+// Janitor holds the prune dependencies and runs the cleanup sweep. All fields
+// are required except oauth, which is nil when the OAuth provider is disabled.
+type Janitor struct {
+	messages     MessagePruner
+	deliveries   DeliveryPruner
+	subscribers  SubscriberPruner
+	webhookEvent WebhookEventPruner
+	oauth        OAuthPruner // optional; nil when OAuth is not configured
+	idempotency  IdempotencyPruner
+	metrics      Metrics
+}
+
+// New builds the Janitor. oauth may be nil (interface, not a typed-nil pointer)
+// to skip the OAuth cleanup pass.
+func New(
+	messages MessagePruner,
+	deliveries DeliveryPruner,
+	subscribers SubscriberPruner,
+	webhookEvent WebhookEventPruner,
+	oauth OAuthPruner,
+	idempotency IdempotencyPruner,
+	metrics Metrics,
+) *Janitor {
+	return &Janitor{
+		messages:     messages,
+		deliveries:   deliveries,
+		subscribers:  subscribers,
+		webhookEvent: webhookEvent,
+		oauth:        oauth,
+		idempotency:  idempotency,
+		metrics:      metrics,
+	}
+}
+
+// Sweep runs every prune once, sequentially, continuing past any individual
+// error. It preserves the exact per-prune logging and metrics emission of the
+// old hand-rolled ticker. Errors are accumulated and returned joined; the
+// caller (the worker) logs-and-swallows so one failing prune never aborts the
+// run or spins River's retry.
+func (j *Janitor) Sweep(ctx context.Context) error {
+	var errs []error
+
+	if deleted, err := j.messages.DeleteExpiredMessages(ctx); err != nil {
+		log.Printf("Failed to clean up expired messages: %v", err)
+		errs = append(errs, err)
+	} else if deleted > 0 {
+		log.Printf("Cleaned up %d expired message(s)", deleted)
+		j.metrics.JanitorRowsDeleted("messages", int(deleted))
+	}
+
+	if deleted, err := j.messages.DeleteExpiredUserSessions(ctx); err != nil {
+		log.Printf("Failed to clean up expired user sessions: %v", err)
+		errs = append(errs, err)
+	} else if deleted > 0 {
+		log.Printf("Cleaned up %d expired user session(s)", deleted)
+	}
+
+	if deleted, err := j.deliveries.DeleteExpiredDeliveries(ctx); err != nil {
+		log.Printf("Failed to clean up expired webhook deliveries: %v", err)
+		errs = append(errs, err)
+	} else if deleted > 0 {
+		log.Printf("Cleaned up %d expired webhook delivery record(s)", deleted)
+	}
+
+	if deleted, err := j.subscribers.DeleteExpiredSubscriberDeliveries(ctx); err != nil {
+		log.Printf("Failed to clean up expired webhook subscriber deliveries: %v", err)
+		errs = append(errs, err)
+	} else if deleted > 0 {
+		log.Printf("Cleaned up %d expired webhook subscriber delivery record(s)", deleted)
+		j.metrics.JanitorRowsDeleted("webhook_subscriber_deliveries", deleted)
+	}
+
+	// webhook_events rows also carry a 30-day TTL (migration 026); without
+	// this the table grows monotonically once the outbox path writes events.
+	if deleted, err := j.webhookEvent.DeleteExpiredWebhookEvents(ctx); err != nil {
+		log.Printf("Failed to clean up expired webhook events: %v", err)
+		errs = append(errs, err)
+	} else if deleted > 0 {
+		log.Printf("Cleaned up %d expired webhook event(s)", deleted)
+		j.metrics.JanitorRowsDeleted("webhook_events", deleted)
+	}
+
+	// OAuth cleanup is skipped when the provider isn't configured (nil dep),
+	// preserving the old `if oauthStorage != nil` guard.
+	if j.oauth != nil {
+		if res, err := j.oauth.CleanupExpired(ctx, time.Now()); err != nil {
+			log.Printf("Failed to clean up expired OAuth rows: %v", err)
+			errs = append(errs, err)
+		} else if res.Total() > 0 {
+			log.Printf("Cleaned up OAuth rows: codes=%d pkce=%d access=%d refresh=%d clients=%d",
+				res.AuthCodesDeleted, res.PKCERequestsDeleted,
+				res.AccessTokensDeleted, res.RefreshTokensDeleted,
+				res.ClientsDeleted)
+		}
+	}
+
+	if deleted, err := j.idempotency.Sweep(ctx); err != nil {
+		log.Printf("Failed to sweep idempotency keys: %v", err)
+		errs = append(errs, err)
+	} else if deleted > 0 {
+		log.Printf("Swept %d idempotency key(s) past TTL", deleted)
+	}
+
+	return errors.Join(errs...)
+}
+
+// JanitorArgs drives the periodic cleanup sweep. No fields — each run prunes
+// the whole expired set.
+type JanitorArgs struct{}
+
+func (JanitorArgs) Kind() string { return "janitor_sweep" }
+
+// MaintenanceWorker runs the cleanup sweep once per scheduled job. Sweep's
+// errors are logged (with a [janitor] prefix) and swallowed — Work returns nil
+// so a transient DB blip never spins River's retry for a best-effort idempotent
+// sweep; the next interval picks it up.
+type MaintenanceWorker struct {
+	river.WorkerDefaults[JanitorArgs]
+	janitor *Janitor
+}
+
+// NewMaintenanceWorker builds the worker around a Janitor. Exported so tests can
+// drive Work directly (RegisterJobs builds an identical one for the client).
+func NewMaintenanceWorker(j *Janitor) *MaintenanceWorker {
+	return &MaintenanceWorker{janitor: j}
+}
+
+func (w *MaintenanceWorker) Work(ctx context.Context, _ *river.Job[JanitorArgs]) error {
+	if err := w.janitor.Sweep(ctx); err != nil {
+		log.Printf("[janitor] sweep completed with error(s): %v", err)
+	}
+	return nil
+}
+
+// MaintenanceJobs is the jobs.Registrar for the cleanup janitor: it contributes
+// the MaintenanceWorker and a periodic that fires it on QueueMaintenance. No
+// enqueuer needed — the schedule is the only trigger.
+type MaintenanceJobs struct{ janitor *Janitor }
+
+// NewMaintenanceJobs builds the registrar around a Janitor.
+func NewMaintenanceJobs(j *Janitor) *MaintenanceJobs { return &MaintenanceJobs{janitor: j} }
+
+// RegisterJobs adds the maintenance worker + its periodic schedule. Mirrors the
+// webhook janitor and senderidentity reaper: routed to QueueMaintenance, no
+// UniqueOpts (River's periodic scheduler already inserts at most one per
+// interval and a completed run must not dedup-block the next), RunOnStart:false
+// (first sweep after one interval, matching the old ticker's first-tick-after-1h).
+func (m *MaintenanceJobs) RegisterJobs(w *river.Workers) []*river.PeriodicJob {
+	river.AddWorker(w, &MaintenanceWorker{janitor: m.janitor})
+	return []*river.PeriodicJob{
+		river.NewPeriodicJob(
+			river.PeriodicInterval(janitorInterval),
+			janitorPeriodicConstructor,
+			&river.PeriodicJobOpts{RunOnStart: false},
+		),
+	}
+}
+
+// janitorPeriodicConstructor is the periodic's per-fire constructor: it routes
+// each scheduled sweep to QueueMaintenance. Extracted (rather than inlined) so a
+// white-box test can assert the queue routing — river.PeriodicJob keeps its
+// constructor unexported, so this is the only way to verify it directly.
+func janitorPeriodicConstructor() (river.JobArgs, *river.InsertOpts) {
+	return JanitorArgs{}, &river.InsertOpts{Queue: jobs.QueueMaintenance}
+}

--- a/internal/janitor/janitor_test.go
+++ b/internal/janitor/janitor_test.go
@@ -37,7 +37,7 @@ type fakePruner struct {
 
 func (f *fakePruner) DeleteExpiredMessages(context.Context) (int64, error) {
 	f.messagesCalled++
-	return 1, f.messagesErr
+	return 3, f.messagesErr // distinct count so the metric test can map count→label
 }
 
 func (f *fakePruner) DeleteExpiredUserSessions(context.Context) (int64, error) {
@@ -52,12 +52,12 @@ func (f *fakePruner) DeleteExpiredDeliveries(context.Context) (int64, error) {
 
 func (f *fakePruner) DeleteExpiredSubscriberDeliveries(context.Context) (int, error) {
 	f.subscribersCalled++
-	return 1, f.subscribersErr
+	return 5, f.subscribersErr // distinct count for the metric test
 }
 
 func (f *fakePruner) DeleteExpiredWebhookEvents(context.Context) (int, error) {
 	f.webhookEventCalled++
-	return 1, f.webhookEventErr
+	return 7, f.webhookEventErr // distinct count for the metric test
 }
 
 func (f *fakePruner) Sweep(context.Context) (int64, error) {
@@ -70,16 +70,29 @@ func (f *fakePruner) CleanupExpired(context.Context, time.Time) (oauth.Retention
 	return oauth.RetentionResult{AuthCodesDeleted: 1}, f.oauthErr
 }
 
-// fakeMetrics records JanitorRowsDeleted calls so the sweep can run without a
-// real telemetry backend.
-type fakeMetrics struct{ calls []string }
+// metricCall captures one JanitorRowsDeleted emission (table + count).
+type metricCall struct {
+	table string
+	count int
+}
 
-func (m *fakeMetrics) JanitorRowsDeleted(table string, _ int) {
-	m.calls = append(m.calls, table)
+// fakeMetrics records every JanitorRowsDeleted call so a test can assert exactly
+// which prunes emit a metric and with what count.
+type fakeMetrics struct{ calls []metricCall }
+
+func (m *fakeMetrics) JanitorRowsDeleted(table string, count int) {
+	m.calls = append(m.calls, metricCall{table, count})
 }
 
 func newJanitor(f *fakePruner, oauth janitor.OAuthPruner) *janitor.Janitor {
 	return janitor.New(f, f, f, f, oauth, f, &fakeMetrics{})
+}
+
+// newJanitorM is newJanitor but also returns the fake metrics sink so a test can
+// assert the emitted (table, count) pairs.
+func newJanitorM(f *fakePruner, oauth janitor.OAuthPruner) (*janitor.Janitor, *fakeMetrics) {
+	m := &fakeMetrics{}
+	return janitor.New(f, f, f, f, oauth, f, m), m
 }
 
 // TestSweep_CallsEveryPruneOnce: one Sweep drives each prune method exactly once
@@ -107,6 +120,32 @@ func TestSweep_CallsEveryPruneOnce(t *testing.T) {
 	for _, c := range checks {
 		if c.got != 1 {
 			t.Errorf("%s called %d times, want 1", c.name, c.got)
+		}
+	}
+}
+
+// TestSweep_EmitsMetricsForCorrectTables: exactly the three metric-emitting prunes
+// (messages, webhook_subscriber_deliveries, webhook_events) fire JanitorRowsDeleted
+// with the count that prune returned — and sessions/deliveries/oauth/idempotency
+// emit NO metric. Guards against a mislabeled, dropped, spurious, or wrong-count
+// metric (incl. the int64→int cast on messages).
+func TestSweep_EmitsMetricsForCorrectTables(t *testing.T) {
+	f := &fakePruner{}
+	j, m := newJanitorM(f, f) // non-nil oauth so every pass runs
+	if err := j.Sweep(context.Background()); err != nil {
+		t.Fatalf("Sweep: unexpected error: %v", err)
+	}
+	want := []metricCall{
+		{"messages", 3},
+		{"webhook_subscriber_deliveries", 5},
+		{"webhook_events", 7},
+	}
+	if len(m.calls) != len(want) {
+		t.Fatalf("emitted %d metrics %+v, want exactly %d %+v", len(m.calls), m.calls, len(want), want)
+	}
+	for i, w := range want {
+		if m.calls[i] != w {
+			t.Errorf("metric[%d] = %+v, want %+v", i, m.calls[i], w)
 		}
 	}
 }

--- a/internal/janitor/janitor_test.go
+++ b/internal/janitor/janitor_test.go
@@ -1,0 +1,182 @@
+package janitor_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/riverqueue/river"
+
+	"github.com/Mnexa-AI/e2a/internal/janitor"
+	"github.com/Mnexa-AI/e2a/internal/oauth"
+)
+
+// fakePruner implements every prune interface (MessagePruner, DeliveryPruner,
+// SubscriberPruner, WebhookEventPruner, IdempotencyPruner, OAuthPruner) so a
+// single fake can stand in for all of the janitor's dependencies. Each method
+// records that it was called and returns a configurable error.
+type fakePruner struct {
+	messagesCalled     int
+	sessionsCalled     int
+	deliveriesCalled   int
+	subscribersCalled  int
+	webhookEventCalled int
+	oauthCalled        int
+	idempotencyCalled  int
+
+	// per-method error injection
+	messagesErr     error
+	sessionsErr     error
+	deliveriesErr   error
+	subscribersErr  error
+	webhookEventErr error
+	oauthErr        error
+	idempotencyErr  error
+}
+
+func (f *fakePruner) DeleteExpiredMessages(context.Context) (int64, error) {
+	f.messagesCalled++
+	return 1, f.messagesErr
+}
+
+func (f *fakePruner) DeleteExpiredUserSessions(context.Context) (int64, error) {
+	f.sessionsCalled++
+	return 1, f.sessionsErr
+}
+
+func (f *fakePruner) DeleteExpiredDeliveries(context.Context) (int64, error) {
+	f.deliveriesCalled++
+	return 1, f.deliveriesErr
+}
+
+func (f *fakePruner) DeleteExpiredSubscriberDeliveries(context.Context) (int, error) {
+	f.subscribersCalled++
+	return 1, f.subscribersErr
+}
+
+func (f *fakePruner) DeleteExpiredWebhookEvents(context.Context) (int, error) {
+	f.webhookEventCalled++
+	return 1, f.webhookEventErr
+}
+
+func (f *fakePruner) Sweep(context.Context) (int64, error) {
+	f.idempotencyCalled++
+	return 1, f.idempotencyErr
+}
+
+func (f *fakePruner) CleanupExpired(context.Context, time.Time) (oauth.RetentionResult, error) {
+	f.oauthCalled++
+	return oauth.RetentionResult{AuthCodesDeleted: 1}, f.oauthErr
+}
+
+// fakeMetrics records JanitorRowsDeleted calls so the sweep can run without a
+// real telemetry backend.
+type fakeMetrics struct{ calls []string }
+
+func (m *fakeMetrics) JanitorRowsDeleted(table string, _ int) {
+	m.calls = append(m.calls, table)
+}
+
+func newJanitor(f *fakePruner, oauth janitor.OAuthPruner) *janitor.Janitor {
+	return janitor.New(f, f, f, f, oauth, f, &fakeMetrics{})
+}
+
+// TestSweep_CallsEveryPruneOnce: one Sweep drives each prune method exactly once
+// (with a non-nil oauth dep, all seven passes run).
+func TestSweep_CallsEveryPruneOnce(t *testing.T) {
+	f := &fakePruner{}
+	j := newJanitor(f, f) // f satisfies OAuthPruner too
+
+	if err := j.Sweep(context.Background()); err != nil {
+		t.Fatalf("Sweep: unexpected error: %v", err)
+	}
+
+	checks := []struct {
+		name string
+		got  int
+	}{
+		{"DeleteExpiredMessages", f.messagesCalled},
+		{"DeleteExpiredUserSessions", f.sessionsCalled},
+		{"DeleteExpiredDeliveries", f.deliveriesCalled},
+		{"DeleteExpiredSubscriberDeliveries", f.subscribersCalled},
+		{"DeleteExpiredWebhookEvents", f.webhookEventCalled},
+		{"CleanupExpired", f.oauthCalled},
+		{"Sweep(idempotency)", f.idempotencyCalled},
+	}
+	for _, c := range checks {
+		if c.got != 1 {
+			t.Errorf("%s called %d times, want 1", c.name, c.got)
+		}
+	}
+}
+
+// TestSweep_ContinuesPastErrors: an early prune failing does NOT prevent the
+// subsequent prunes from running (continue-on-error preserved), and Sweep
+// returns a joined error carrying every failure.
+func TestSweep_ContinuesPastErrors(t *testing.T) {
+	errMsg := errors.New("messages boom")
+	errSub := errors.New("subscribers boom")
+	f := &fakePruner{messagesErr: errMsg, subscribersErr: errSub}
+	j := newJanitor(f, f)
+
+	err := j.Sweep(context.Background())
+	if err == nil {
+		t.Fatal("Sweep: expected an error, got nil")
+	}
+	if !errors.Is(err, errMsg) {
+		t.Errorf("joined error missing messages failure: %v", err)
+	}
+	if !errors.Is(err, errSub) {
+		t.Errorf("joined error missing subscribers failure: %v", err)
+	}
+
+	// Every later prune still ran despite the first prune erroring.
+	if f.sessionsCalled != 1 || f.deliveriesCalled != 1 || f.subscribersCalled != 1 ||
+		f.webhookEventCalled != 1 || f.oauthCalled != 1 || f.idempotencyCalled != 1 {
+		t.Errorf("a prune was skipped after an earlier error: %+v", f)
+	}
+}
+
+// TestSweep_NilOAuthSkipped: a nil OAuth dependency (OAuth provider disabled) is
+// skipped without panicking, and the other prunes still run.
+func TestSweep_NilOAuthSkipped(t *testing.T) {
+	f := &fakePruner{}
+	j := newJanitor(f, nil) // nil OAuthPruner interface
+
+	if err := j.Sweep(context.Background()); err != nil {
+		t.Fatalf("Sweep with nil oauth: unexpected error: %v", err)
+	}
+	if f.oauthCalled != 0 {
+		t.Errorf("CleanupExpired called %d times with nil oauth dep, want 0", f.oauthCalled)
+	}
+	// The remaining prunes still ran.
+	if f.messagesCalled != 1 || f.idempotencyCalled != 1 {
+		t.Errorf("nil oauth dep disturbed the other prunes: %+v", f)
+	}
+}
+
+// TestMaintenanceWorker_WorkSwallowsError: Work returns nil even when Sweep
+// errors, so a transient DB blip never spins River's retry.
+func TestMaintenanceWorker_WorkSwallowsError(t *testing.T) {
+	f := &fakePruner{messagesErr: errors.New("boom")}
+	w := janitor.NewMaintenanceWorker(newJanitor(f, f))
+
+	if err := w.Work(context.Background(), &river.Job[janitor.JanitorArgs]{}); err != nil {
+		t.Fatalf("Work returned %v, want nil (errors are swallowed)", err)
+	}
+	// Sweep still ran to completion.
+	if f.idempotencyCalled != 1 {
+		t.Errorf("Work did not run the full sweep: idempotency called %d times", f.idempotencyCalled)
+	}
+}
+
+// TestMaintenanceJobs_RegistersOnePeriodic: RegisterJobs contributes exactly one
+// periodic (the janitor schedule) and wires its worker.
+func TestMaintenanceJobs_RegistersOnePeriodic(t *testing.T) {
+	m := janitor.NewMaintenanceJobs(newJanitor(&fakePruner{}, nil))
+	periodics := m.RegisterJobs(river.NewWorkers())
+	if len(periodics) != 1 {
+		t.Fatalf("RegisterJobs returned %d periodic jobs, want 1", len(periodics))
+	}
+}

--- a/internal/janitor/periodic_internal_test.go
+++ b/internal/janitor/periodic_internal_test.go
@@ -1,0 +1,28 @@
+package janitor
+
+import (
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/jobs"
+)
+
+// TestPeriodicConstructor_RoutesToMaintenance: the periodic's per-fire
+// constructor routes each sweep to QueueMaintenance with the janitor args.
+// White-box because river.PeriodicJob keeps its constructor unexported, so this
+// is the only way to assert the queue routing directly.
+func TestPeriodicConstructor_RoutesToMaintenance(t *testing.T) {
+	args, opts := janitorPeriodicConstructor()
+
+	if opts == nil {
+		t.Fatal("constructor returned nil InsertOpts")
+	}
+	if opts.Queue != jobs.QueueMaintenance {
+		t.Errorf("periodic routed to queue %q, want %q", opts.Queue, jobs.QueueMaintenance)
+	}
+	if _, ok := args.(JanitorArgs); !ok {
+		t.Errorf("constructor returned args of type %T, want JanitorArgs", args)
+	}
+	if got := args.Kind(); got != "janitor_sweep" {
+		t.Errorf("JanitorArgs.Kind() = %q, want %q", got, "janitor_sweep")
+	}
+}


### PR DESCRIPTION
Migrates the hand-rolled **hourly janitor** from a `time.Ticker(1h)` goroutine in `cmd/e2a/main.go` onto a River **periodic** on `QueueMaintenance` — retiring the last hand-rolled background loop, mirroring the webhook auto-disable / inbound-retention periodics. Behavior-preserving consolidation.

## What & why
The janitor prunes expired rows across seven targets (messages, user sessions, webhook deliveries, subscriber deliveries, webhook_events, OAuth rows, idempotency keys). It ran on a hand-rolled 1h ticker in its own goroutine — the last such loop outside River.

- New `internal/janitor` package: narrow prune interfaces (one per store method), an injectable `Metrics` interface, a `Janitor.Sweep(ctx)` that runs all prunes **sequentially** (deliberately not parallel — a janitor must be gentle on Postgres; there's no latency benefit to parallelism) and **continues past any individual prune's error** (`errors.Join`), preserving the exact `metrics.JanitorRowsDeleted` labels and the `oauthStorage != nil` guard. Plus the River layer: `JanitorArgs` (`janitor_sweep`), `MaintenanceWorker` (Work swallows+logs, returns nil), `MaintenanceJobs` registrar → one periodic on `QueueMaintenance`, `RunOnStart:false`, no `UniqueOpts`.
- `cmd/e2a/main.go`: removed the ticker goroutine + `cleanupCtx`/`cleanupCancel`; the periodic drains on shutdown via the shared `jobsClient.Stop`.

## Notable structural change (reviewed, verified safe)
On `main`, `oauthStorage` and `idempotencyStore` were constructed *after* `jobs.New`. Since the registrar must be appended before `jobs.New`, this **hoists those two constructions earlier**. Verified safe: both are pure pointer-wraps needing only `pool`; the OAuth nil-gate (`cfg.HTTP.PublicURL != ""`) is preserved exactly; downstream `oauth.NewProvider` / `api.SetOAuthProvider` / `api.SetIdempotencyStore` still reference the same vars. The `OAuthPruner` is injected via `var oauthPruner janitor.OAuthPruner` assigned only when non-nil, avoiding the typed-nil-interface trap (a nil-deref when OAuth is disabled) — covered by `TestSweep_NilOAuthSkipped`.

## Scope / non-goals
Behavior-preserving only: same prunes, same order, same continue-on-error, same metrics. **No batching/chunking** of the DELETEs (a separate future concern for prod-sized tables). No parallelism.

## Verification
- `go build ./...`, `gofmt`, `go vet ./internal/janitor/ ./cmd/e2a/` clean.
- `go test ./internal/janitor/ ./internal/jobs/` green. Tests: every prune called once; continue-past-error (injects failures mid-sequence, asserts later prunes still run + joined error); nil-OAuth skipped without panic; `Work` swallows Sweep errors; periodic routes to `QueueMaintenance` with the right args/kind.
- Adversarial review: **clean, no correctness bugs**; the main.go reorder verified safe in detail.

## ⚠️ Merge-order note (vs #393)
#393 (HITL TTL sweep) edits the same `main.go` region. A trial 3-way merge shows two conflicts: (A) the registrar-append anchor — **keep both** blocks (purely additive); (B) the shutdown-cancel block — #393 removes `hitlCancel()`, this removes `cleanupCancel()`, so **whoever merges second must drop BOTH**, leaving only `bgCancel()` (a naive resolution leaves a dangling call → compile error). Recommend merging #393 first, then rebasing this onto the new `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)