### PR TITLE
feat(hitl): route approve sends onto QueueOutbound in async mode

### DIFF
--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -320,7 +320,16 @@ func main() {
 	// publisher as the agent API). Load-bearing for inbound approve: a TTL-released
 	// inbound message has no other push signal.
 	hitlWorker.SetPublisher(outboxPublisher)
-	registrars = append(registrars, hitlworker.NewMaintenanceJobs(hitlWorker))
+	// Async mode: route the sweep's auto-approve send onto QueueOutbound (the
+	// SendWorker does the SMTP submit) instead of a blocking in-process send, so the
+	// sweep is DB-only. Two-phase like the API's SetOutboundEnqueuer: pass the
+	// *outboundsend.Jobs pointer now; its shared client is injected below via
+	// outboundJobs.SetEnqueuer, live well before the first +60s tick. nil ⇒ sync
+	// (blocking) auto-approve, unchanged. asyncSends also bounds the sweep's Timeout.
+	if outboundJobs != nil {
+		hitlWorker.SetOutboundEnqueuer(outboundJobs)
+	}
+	registrars = append(registrars, hitlworker.NewMaintenanceJobs(hitlWorker, outboundJobs != nil))
 
 	// Hourly cleanup janitor (expired messages/sessions/webhook delivery
 	// records/webhook events/OAuth rows/idempotency keys) as a River periodic on

--- a/docs/design/hitl-ttl-async-send.md
+++ b/docs/design/hitl-ttl-async-send.md
@@ -1,0 +1,163 @@
+# HITL approve → QueueOutbound (async send)
+
+Status: approved · Owner: backend · Related: `internal/hitlworker`, `internal/agent`, `internal/outboundsend`, `internal/identity`
+
+## Context / goal
+
+When a HITL outbound hold is approved, e2a sends it. Both approve paths do the
+send **inline, synchronously** today (blocking `Sender.Send`, retrying SMTP,
+`send_attempts` gate):
+
+- **TTL auto-approve** — the `QueueMaintenance` sweep, when `hitl_expiration_action=approve`.
+- **Human approve** — `POST /v1/agents/{email}/messages/{id}/approve` (+ the magic-link
+  `/v1/approve`), via `ApprovePendingCore` → `store.ApproveAndSend`.
+
+This change routes **both** approve sends onto the async outbound River queue
+(`QueueOutbound`) — the same pipeline a normal async send uses — when
+`E2A_OUTBOUND_MODE=async`. The sweep becomes DB-only; the approve endpoint returns
+**`accepted`** (send durably queued) instead of blocking for a synchronous `sent`.
+This is the industry-standard semantic (SendGrid `202 Accepted`, Mailgun "Queued",
+SES accepted-for-sending) and matches every normal e2a async send; the delivery
+outcome follows via `email.sent`/`email.failed`. Sync mode is unchanged.
+
+## Key enabling fact
+
+The async `SendWorker` needs **no changes**. `LoadOutboundForSend` selects by id
+filtered only on `direction='outbound'` (no `status` filter) and `alreadyDone()`
+keys off `delivery_status`. So a hold row transitioned to `delivery_status='accepted'`
+(+ `raw_message`/`envelope_from`/`sent_as` + a stamped `send_job_id`) loads and
+sends like any accepted message, regardless of its hold `status`
+(`review_approved` or `review_expired_approved`). `MarkSent`/`MarkFailed` touch
+only `delivery_status`/`provider_message_id`/`delivery_detail`, leaving the hold
+status intact. The existing outbound reconciler (`delivery_status='accepted' AND
+send_job_id IS NULL`) covers a stranded transition for free.
+
+## Design
+
+Both approve cores (`hitlworker.autoApprove`, `agent.ApprovePendingCore`) gain the
+same three-way branch. The self-send + async decision is made **before** the
+transition, from the reviewed/edited recipients:
+
+```
+approve(msg, [edits], [reviewer]):
+  guards (agent match / domain verified)                 (unchanged)
+  req = build SendRequest from the (edited) draft + attachReferencesChain
+
+  if loopback.IsSelfSend(req, agent):
+      → SYNC loopback (unchanged): ApproveAndSend / ExpireApproveAndSend with the
+        loopback callback. Self-sends never go on QueueOutbound.
+
+  else if async enqueuer wired (E2A_OUTBOUND_MODE=async):
+      → NEW async path:
+          comp = sender.ComposeForAccept(agent, req)        # compose, no submit
+          msg  = store.ApproveAndAccept(msgID, reviewer, targetStatus, edited,
+                       AcceptedSend{To,CC,BCC,Subject,Method,EnvelopeFrom,SentAs,Raw},
+                       enqueue = outboundEnq.EnqueueSendTx)   # one tx (below)
+          publish review_approved (auto_resolved for TTL / reviewer for human;
+                                   provider_message_id empty — send is queued)
+          return msg   # status=review_approved(_expired), delivery_status=accepted
+          # NO blocking send, NO metering, NO send_attempts here — the SendWorker
+          # does the submit + email.sent/failed + metering.
+
+  else (sync mode):
+      → SYNC (unchanged): ApproveAndSend / ExpireApproveAndSend with Sender.Send.
+```
+
+### New store primitive — `ApproveAndAccept`
+
+A pure transactional persist+enqueue (all composition/edit logic stays in the
+agent/hitlworker layer, where the `sender` + edits live). It does NOT re-send or
+use `send_attempts`.
+
+```go
+func (s *Store) ApproveAndAccept(
+    ctx context.Context, messageID string,
+    reviewedByUserID string,   // "" (NULL) for the TTL sweep
+    targetStatus string,       // review_approved | review_expired_approved
+    edited bool,
+    acc AcceptedSend,          // To,CC,BCC []string; Subject,Method,EnvelopeFrom,SentAs string; Raw []byte
+    enqueue func(ctx context.Context, tx pgx.Tx, messageID string) (int64, error),
+) (*Message, error)
+```
+
+One `WithTx`: a compare-and-set UPDATE (the `WHERE status='pending_review'` is the
+atomic guard; `RowsAffected()==0` → `ErrNotPendingApproval`, a no-op) →
+`enqueue(tx)` → `StampSendJobIDTx(tx, jobID)`:
+
+```sql
+UPDATE messages
+   SET status              = $targetStatus,
+       delivery_status     = 'accepted',
+       to_recipients=$, cc=$, bcc=$, subject=$, recipient=$firstTo, method=$,
+       envelope_from=$, sent_as=$, raw_message=$,   -- nullIfEmptyBytes
+       provider_message_id = '',                    -- filled by the SendWorker
+       reviewed_at         = now(),
+       reviewed_by_user_id = $reviewer,             -- NULL for TTL
+       edited              = $edited,
+       body_text=NULL, body_html=NULL, attachments_json=NULL   -- scrub draft
+ WHERE id=$1 AND direction='outbound' AND status='pending_review'
+```
+
+### Events & metering
+
+- **`review_approved`** still fires from the approve core after the transition
+  commits — with **empty `provider_message_id`** (send queued). Keeps `auto_resolved`
+  (TTL) / `reviewed_by_user_id` + `edited` (human). It means "hold resolved to
+  approved", distinct from the delivery outcome.
+- **`email.sent`/`email.failed`** move to the `SendWorker` (real provider id).
+- **Metering** for the async path moves to the `SendWorker`; the approve cores meter
+  only their sync + self-send/loopback paths (unchanged).
+
+### Error handling (async path)
+
+Any tx/enqueue failure is transient (DB/River). The **sweep** logs and leaves the
+row `pending_review` for the next cycle (never `autoReject` — no send happened, so
+no `[hitl-stuck]`). The **endpoint** returns a 500 (same as a normal async accept-tx
+failure); the reviewer retries (idempotency-key-safe).
+
+### Response contract (human approve)
+
+`ApprovePendingCore` returns the transitioned message; the httpapi `SendResultView`
+now reports `status: "accepted"` for the async path (was the synchronous send
+result). The confirmation page / dashboard show the send as `accepted → sent/failed`
+like any async send. `edited` is still surfaced.
+
+### `Timeout()` becomes mode-aware
+
+`MaintenanceJobs`/`MaintenanceWorker` gain `asyncSends bool`. `Timeout()` returns a
+**bounded** value (5 min) when async — the sweep is now DB-only, restoring River's
+slot-occupancy protection — and stays `-1` in sync mode (blocking `Sender.Send`
+remains). Delivers the "return the timeout to bounded" goal for the async prod path.
+
+## Behavior change (blessed)
+
+In async mode a TTL-auto-approved (or human-approved) send whose SMTP submit
+ultimately **fails** ends `status=review_(expired_)approved` + `delivery_status='failed'`
++ an `email.failed` event — it does **not** fall back to `review_(expired_)rejected`.
+Matches the normal async-send model (review decision ≠ delivery outcome).
+
+## Scope / non-goals
+
+- Both approve paths (TTL sweep + human endpoint). Self-sends stay on the sync
+  loopback path. Sync mode (`E2A_OUTBOUND_MODE` unset/`sync`) byte-for-byte unchanged.
+- Inbound review approve/reject and the outbound reject-on-expiry path are untouched.
+
+## Files
+
+- `internal/identity/store.go` — new `ApproveAndAccept` + `AcceptedSend`; reuse `StampSendJobIDTx`.
+- `internal/hitlworker/{worker.go,maintenance.go}` — async branch in `autoApprove`; `outboundEnq` seam + `SetOutboundEnqueuer`; mode-aware `Timeout()`.
+- `internal/agent/hitl_api.go` (+ `hitl_magic_api.go` response mapping) — async branch in `ApprovePendingCore`; reuse the `OutboundEnqueuer` already on `*API`.
+- `internal/httpapi/hitl.go` / `outbound.go` — surface `status: accepted` on the approve view.
+- `cmd/e2a/main.go` — pass `outboundJobs` to the hitl worker + `asyncSends` to the maintenance registrar (already sets `api.SetOutboundEnqueuer`).
+- Tests + live e2e.
+
+## Verification
+
+- Unit: `ApproveAndAccept` CAS (transitions pending_review→accepted, no-op on resolved);
+  sweep + endpoint async branches (enqueue, stamp, review_approved emitted, no meter,
+  no autoReject/500-only on tx error); self-send still loopback; sync unchanged;
+  mode-aware `Timeout()`; approve view reports `accepted`.
+- Live e2e (async instance): human approve → `accepted` returned, `outbound_send`
+  enqueued, `review_approved` fired → SendWorker submits → `delivery_status='sent'` +
+  `email.sent`. Same for TTL auto-approve. Self-send → loopback (no outbound_send job).
+  Failed-submit A/B → `email.failed`, hold stays approved. Sweep does no blocking send.

--- a/docs/design/hitl-ttl-async-send.md
+++ b/docs/design/hitl-ttl-async-send.md
@@ -50,6 +50,10 @@ approve(msg, [edits], [reviewer]):
   else if async enqueuer wired (E2A_OUTBOUND_MODE=async):
       → NEW async path:
           comp = sender.ComposeForAccept(agent, req)        # compose, no submit
+          # targetStatus: 'sent' for a HUMAN approve (outbound's approved terminal,
+          # same as sync ApproveAndSend — the human resolution is recorded via
+          # reviewed_by_user_id + the review_approved event); 'review_expired_approved'
+          # for the TTL sweep (same as sync ExpireApproveAndSend).
           msg  = store.ApproveAndAccept(msgID, reviewer, targetStatus, edited,
                        AcceptedSend{To,CC,BCC,Subject,Method,EnvelopeFrom,SentAs,Raw},
                        enqueue = outboundEnq.EnqueueSendTx)   # one tx (below)
@@ -73,7 +77,7 @@ use `send_attempts`.
 func (s *Store) ApproveAndAccept(
     ctx context.Context, messageID string,
     reviewedByUserID string,   // "" (NULL) for the TTL sweep
-    targetStatus string,       // review_approved | review_expired_approved
+    targetStatus string,       // sent (human approve) | review_expired_approved (TTL)
     edited bool,
     acc AcceptedSend,          // To,CC,BCC []string; Subject,Method,EnvelopeFrom,SentAs string; Raw []byte
     enqueue func(ctx context.Context, tx pgx.Tx, messageID string) (int64, error),
@@ -129,12 +133,28 @@ like any async send. `edited` is still surfaced.
 slot-occupancy protection — and stays `-1` in sync mode (blocking `Sender.Send`
 remains). Delivers the "return the timeout to bounded" goal for the async prod path.
 
-## Behavior change (blessed)
+## Behavior changes (blessed)
 
-In async mode a TTL-auto-approved (or human-approved) send whose SMTP submit
-ultimately **fails** ends `status=review_(expired_)approved` + `delivery_status='failed'`
-+ an `email.failed` event — it does **not** fall back to `review_(expired_)rejected`.
-Matches the normal async-send model (review decision ≠ delivery outcome).
+In async mode:
+
+- **Approve returns `accepted`, not `sent`** — the send is durably queued; the
+  outcome follows via `email.sent`/`email.failed`. Matches every normal async send
+  and the industry (SendGrid `202`, SES accepted-for-sending).
+- **A send that ultimately fails stays approved.** A TTL-auto-approved
+  (`review_expired_approved`) or human-approved (`sent`) hold whose SMTP submit
+  fails ends `delivery_status='failed'` + an `email.failed` event — it does **not**
+  fall back to `review_(expired_)rejected`. Review decision ≠ delivery outcome.
+- **`email.sent` now fires on a HITL-approved send's success.** The sync approve
+  path emitted only `review_approved` (and magic-link nothing); async approve adds
+  `email.sent`/`email.failed` from the SendWorker, consistent with normal async
+  sends. Subscribers keying off `email.sent` will observe it for approved sends once
+  the flag flips.
+
+Known limitation (F2): the SendWorker's 72h outage-tolerance clock (`AcceptedAt`)
+is anchored to the message's `created_at` (hold-creation time), not the approve
+time — so a hold approved >72h after creation, during a provider outage at send
+time, would terminate immediately instead of snoozing. Narrow edge; shared with the
+normal-send anchor, out of scope here.
 
 ## Scope / non-goals
 

--- a/internal/agent/approve_async_test.go
+++ b/internal/agent/approve_async_test.go
@@ -1,0 +1,99 @@
+package agent_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/Mnexa-AI/e2a/internal/agent"
+	"github.com/Mnexa-AI/e2a/internal/identity"
+)
+
+// TestApprovePendingCore_AsyncExternal: with the outbound enqueuer wired (async
+// mode), a dashboard approve of a non-self-send hold transitions it to
+// review_approved + delivery_status='accepted', stamps the enqueued send_job_id, and
+// returns method/sent_as — WITHOUT submitting inline (no provider id yet; the
+// SendWorker submits + emits email.sent later).
+func TestApprovePendingCore_AsyncExternal(t *testing.T) {
+	api, store, _, _ := setupAsyncAPI(t)
+	ctx := context.Background()
+	user, ag := selfAgent(t, store, "apprasyncext")
+
+	msg, err := store.CreatePendingOutboundMessage(ctx, ag.ID,
+		[]string{"alice@external.test"}, nil, nil, "Held", "body", "", nil, "send", "", "", 3600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sent, oerr := api.ApprovePendingCore(ctx, user.ID, msg.ID, ag.Email, agent.ApproveOverrides{})
+	if oerr != nil {
+		t.Fatalf("ApprovePendingCore: status=%d code=%s msg=%s", oerr.Status, oerr.Code, oerr.Msg)
+	}
+	if sent.Status != identity.MessageStatusSent {
+		t.Errorf("status = %q, want %q", sent.Status, identity.MessageStatusSent)
+	}
+	if sent.DeliveryStatus != "accepted" {
+		t.Errorf("DeliveryStatus = %q, want accepted (async)", sent.DeliveryStatus)
+	}
+	if sent.Method != "smtp" {
+		t.Errorf("Method = %q, want smtp (should be populated on the accepted view)", sent.Method)
+	}
+
+	var deliveryStatus, providerID string
+	var sendJobID *int64
+	if err := store.WithTx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT delivery_status, COALESCE(provider_message_id,''), send_job_id FROM messages WHERE id=$1`,
+			msg.ID,
+		).Scan(&deliveryStatus, &providerID, &sendJobID)
+	}); err != nil {
+		t.Fatalf("read row: %v", err)
+	}
+	if deliveryStatus != "accepted" {
+		t.Errorf("db delivery_status = %q, want accepted", deliveryStatus)
+	}
+	if providerID != "" {
+		t.Errorf("provider_message_id = %q, want empty at accept (SendWorker fills it)", providerID)
+	}
+	if sendJobID == nil || *sendJobID != 999 { // fakeOutboundEnqueuer.jobID
+		t.Errorf("send_job_id = %v, want 999 (enqueued)", sendJobID)
+	}
+}
+
+// TestApprovePendingCore_AsyncSelfSendStaysSync: even in async mode, a self-send
+// (single To == the agent's own address) is NOT enqueued onto QueueOutbound — it
+// falls through to the sync loopback path, so no send_job_id is stamped and the row
+// is not delivery_status='accepted'.
+func TestApprovePendingCore_AsyncSelfSendStaysSync(t *testing.T) {
+	api, store, _, _ := setupAsyncAPI(t)
+	ctx := context.Background()
+	user, ag := selfAgent(t, store, "apprasyncself")
+
+	msg, err := store.CreatePendingOutboundMessage(ctx, ag.ID,
+		[]string{ag.EmailAddress()}, nil, nil, "To self", "body", "", nil, "send", "", "", 3600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sent, oerr := api.ApprovePendingCore(ctx, user.ID, msg.ID, ag.Email, agent.ApproveOverrides{})
+	if oerr != nil {
+		t.Fatalf("ApprovePendingCore: status=%d code=%s msg=%s", oerr.Status, oerr.Code, oerr.Msg)
+	}
+	if sent.Status != identity.MessageStatusSent {
+		t.Errorf("status = %q, want %q", sent.Status, identity.MessageStatusSent)
+	}
+	if sent.DeliveryStatus == "accepted" {
+		t.Errorf("self-send must NOT be async-accepted (sync loopback), got DeliveryStatus=%q", sent.DeliveryStatus)
+	}
+
+	var sendJobID *int64
+	if err := store.WithTx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT send_job_id FROM messages WHERE id=$1`, msg.ID).Scan(&sendJobID)
+	}); err != nil {
+		t.Fatalf("read row: %v", err)
+	}
+	if sendJobID != nil {
+		t.Errorf("self-send must NOT be enqueued onto QueueOutbound, send_job_id = %v", *sendJobID)
+	}
+}

--- a/internal/agent/hitl_api.go
+++ b/internal/agent/hitl_api.go
@@ -161,12 +161,18 @@ func (a *API) ApprovePendingCore(ctx context.Context, userID, messageID, expecte
 }
 
 // approveOutboundAsync composes the (edited) draft and, for a non-self-send,
-// transitions the hold to review_approved + delivery_status='accepted' and enqueues
-// an outbound_send job in one tx (via store.ApproveAndAccept). Returns
-// (sent, true, nil) when queued; (nil, false, nil) when the message is a self-send
-// (the caller uses the sync loopback path); (nil, false, err) on failure. Shared by
-// the dashboard-approve (ApprovePendingCore) and magic-link (magicApprove) paths.
-// draft is the loaded pending_review row; edits is empty for the magic-link path.
+// transitions the hold to status='sent' + delivery_status='accepted' and enqueues an
+// outbound_send job in one tx (via store.ApproveAndAccept). Returns (sent, true, nil)
+// when queued; (nil, false, nil) when the message is a self-send (the caller uses the
+// sync loopback path); (nil, false, err) on failure. Shared by the dashboard-approve
+// (ApprovePendingCore) and magic-link (magicApprove) paths. draft is the loaded
+// pending_review row; edits is empty for the magic-link path.
+//
+// The hold status becomes 'sent' — the same terminal the SYNC human approve
+// (ApproveAndSend) uses: outbound has no separate "approved" hold status; the human
+// resolution is recorded via reviewed_by_user_id + the review_approved event, and
+// delivery_status ('accepted' → 'sent'/'failed') tracks the async send. (The TTL
+// sweep uses review_expired_approved instead — see hitlworker.autoApproveAsync.)
 func (a *API) approveOutboundAsync(ctx context.Context, agent *identity.AgentIdentity, messageID, userID string, draft *identity.Message, edits identity.PendingApprovalEdit) (*identity.Message, bool, error) {
 	editedByReviewer := edits.Apply(draft)
 	sendReq, err := buildSendRequestFromMessage(draft)
@@ -185,7 +191,7 @@ func (a *API) approveOutboundAsync(ctx context.Context, agent *identity.AgentIde
 		To: comp.To, CC: comp.CC, BCC: comp.BCC, Subject: sendReq.Subject,
 		Method: comp.Method, EnvelopeFrom: comp.EnvelopeFrom, SentAs: comp.SentAs, Raw: comp.Raw,
 	}
-	sent, err := a.store.ApproveAndAccept(ctx, messageID, userID, identity.MessageStatusReviewApproved, editedByReviewer, acc, a.outboundEnq.EnqueueSendTx)
+	sent, err := a.store.ApproveAndAccept(ctx, messageID, userID, identity.MessageStatusSent, editedByReviewer, acc, a.outboundEnq.EnqueueSendTx)
 	if err != nil {
 		return nil, false, err
 	}

--- a/internal/agent/hitl_api.go
+++ b/internal/agent/hitl_api.go
@@ -92,6 +92,25 @@ func (a *API) ApprovePendingCore(ctx context.Context, userID, messageID, expecte
 		return nil, &OutboundError{http.StatusForbidden, "domain_not_verified", "agent domain must be verified before sending"}
 	}
 
+	// Async mode: transition the hold to review_approved + delivery_status='accepted'
+	// and enqueue an outbound_send job; the SendWorker performs the SMTP submit +
+	// email.sent/failed + metering. The reviewer gets "accepted" back (the send is
+	// durably queued). Self-sends fall through to the sync loopback path below.
+	if a.outboundEnq != nil {
+		sent, handled, aerr := a.approveOutboundAsync(ctx, agent, messageID, userID, preview, edits)
+		if aerr != nil {
+			return nil, approveAsyncError(agent.ID, messageID, aerr)
+		}
+		if handled {
+			slug, _, _ := strings.Cut(agent.EmailAddress(), "@")
+			log.Printf("[mail:%s] dir=outbound type=%s status=%s from=%s to=%v slug=%s subject=%q edited=%v approved=user:%s delivery=async",
+				sent.ID, sent.Type, sent.Status, agent.EmailAddress(), sent.ToRecipients, slug, sent.Subject, sent.Edited, userID)
+			a.publishApproved(ctx, a.buildApprovedEvent(agent, sent, userID), sent)
+			// No metering here — the SendWorker meters on MarkSent.
+			return sent, nil
+		}
+	}
+
 	sent, err := a.store.ApproveAndSend(ctx, messageID, userID, edits,
 		func(locked *identity.Message) (identity.SendResult, error) {
 			sendReq, err := buildSendRequestFromMessage(locked)
@@ -139,6 +158,56 @@ func (a *API) ApprovePendingCore(ctx context.Context, userID, messageID, expecte
 		sent.ID, sent.Type, sent.Status, agent.EmailAddress(), sent.ToRecipients, slug, sent.Subject, sent.Edited, userID)
 	a.publishApproved(ctx, a.buildApprovedEvent(agent, sent, userID), sent)
 	return sent, nil
+}
+
+// approveOutboundAsync composes the (edited) draft and, for a non-self-send,
+// transitions the hold to review_approved + delivery_status='accepted' and enqueues
+// an outbound_send job in one tx (via store.ApproveAndAccept). Returns
+// (sent, true, nil) when queued; (nil, false, nil) when the message is a self-send
+// (the caller uses the sync loopback path); (nil, false, err) on failure. Shared by
+// the dashboard-approve (ApprovePendingCore) and magic-link (magicApprove) paths.
+// draft is the loaded pending_review row; edits is empty for the magic-link path.
+func (a *API) approveOutboundAsync(ctx context.Context, agent *identity.AgentIdentity, messageID, userID string, draft *identity.Message, edits identity.PendingApprovalEdit) (*identity.Message, bool, error) {
+	editedByReviewer := edits.Apply(draft)
+	sendReq, err := buildSendRequestFromMessage(draft)
+	if err != nil {
+		return nil, false, err
+	}
+	attachReferencesChain(ctx, a.store, agent.ID, &sendReq)
+	if isSelfSend(sendReq, agent.EmailAddress()) {
+		return nil, false, nil // self-send — caller uses the sync loopback path
+	}
+	comp, err := a.sender.ComposeForAccept(agent, sendReq)
+	if err != nil {
+		return nil, false, err
+	}
+	acc := identity.AcceptedSend{
+		To: comp.To, CC: comp.CC, BCC: comp.BCC, Subject: sendReq.Subject,
+		Method: comp.Method, EnvelopeFrom: comp.EnvelopeFrom, SentAs: comp.SentAs, Raw: comp.Raw,
+	}
+	sent, err := a.store.ApproveAndAccept(ctx, messageID, userID, identity.MessageStatusReviewApproved, editedByReviewer, acc, a.outboundEnq.EnqueueSendTx)
+	if err != nil {
+		return nil, false, err
+	}
+	return sent, true, nil
+}
+
+// approveAsyncError maps an approveOutboundAsync failure to an OutboundError,
+// matching the sync approve path's status codes.
+func approveAsyncError(agentID, messageID string, err error) *OutboundError {
+	switch {
+	case errors.Is(err, identity.ErrNotPendingApproval):
+		return &OutboundError{http.StatusConflict, "message_not_pending", "message is not pending approval"}
+	case errors.Is(err, identity.ErrMessageNotFound):
+		return &OutboundError{http.StatusNotFound, "not_found", "message not found"}
+	default:
+		var ve *outbound.ValidationError
+		if errors.As(err, &ve) {
+			return &OutboundError{http.StatusBadRequest, "invalid_request", ve.Error()}
+		}
+		log.Printf("[api] approve-accept failed: agent=%s msg=%s err=%v", agentID, messageID, err)
+		return &OutboundError{http.StatusInternalServerError, "internal_error", "send failed"}
+	}
 }
 
 // attachReferencesChain rebuilds the References chain on a HITL-approved

--- a/internal/agent/hitl_magic_api.go
+++ b/internal/agent/hitl_magic_api.go
@@ -183,6 +183,30 @@ func (a *API) magicApprove(w http.ResponseWriter, r *http.Request, messageID, us
 		return
 	}
 
+	// Async mode: transition + enqueue onto QueueOutbound (the SendWorker submits).
+	// Self-sends fall through to the sync loopback path below. Mirrors the sync magic
+	// path's events (no review_approved) — only the send routing changes.
+	if a.outboundEnq != nil {
+		draft, derr := a.store.GetOutboundMessageForUser(r.Context(), messageID, userID)
+		if derr != nil {
+			writeMagicMessage(w, http.StatusNotFound, "Message not found", "This message no longer exists.")
+			return
+		}
+		sent, handled, aerr := a.approveOutboundAsync(r.Context(), agent, messageID, userID, draft, identity.PendingApprovalEdit{})
+		if aerr != nil {
+			writeMagicApproveError(w, messageID, aerr)
+			return
+		}
+		if handled {
+			log.Printf("[mail:%s] dir=outbound type=%s status=%s agent=%s to=%v approved=magic-link:user:%s delivery=async",
+				sent.ID, sent.Type, sent.Status, agent.EmailAddress(), sent.ToRecipients, userID)
+			writeMagicMessage(w, http.StatusOK, "Approved",
+				fmt.Sprintf("Your message to %s has been queued for delivery.", html.EscapeString(firstRecipient(sent.ToRecipients))))
+			return
+		}
+		// self-send → fall through to the sync ApproveAndSend loopback path below
+	}
+
 	sent, err := a.store.ApproveAndSend(r.Context(), messageID, userID, identity.PendingApprovalEdit{},
 		func(locked *identity.Message) (identity.SendResult, error) {
 			sendReq, err := buildSendRequestFromMessage(locked)
@@ -243,6 +267,27 @@ func (a *API) magicApprove(w http.ResponseWriter, r *http.Request, messageID, us
 	writeMagicMessage(w, http.StatusOK,
 		"Approved",
 		fmt.Sprintf("Your message to %s has been sent.", html.EscapeString(firstRecipient(sent.ToRecipients))))
+}
+
+// writeMagicApproveError renders the magic-link HTML error page for an async
+// approve failure, matching the sync approve path's status mapping.
+func writeMagicApproveError(w http.ResponseWriter, messageID string, err error) {
+	switch {
+	case errors.Is(err, identity.ErrMessageNotFound):
+		writeMagicMessage(w, http.StatusNotFound, "Message not found", "This message no longer exists.")
+	case errors.Is(err, identity.ErrNotPendingApproval):
+		writeMagicMessage(w, http.StatusConflict, "Already resolved",
+			"This message has already been approved, rejected, or expired.")
+	default:
+		var ve *outbound.ValidationError
+		if errors.As(err, &ve) {
+			writeMagicMessage(w, http.StatusBadRequest, "Cannot send", html.EscapeString(ve.Error()))
+			return
+		}
+		log.Printf("[api] magic-approve accept failed: msg=%s err=%v", messageID, err)
+		writeMagicMessage(w, http.StatusInternalServerError, "Send failed",
+			"The message couldn't be sent. Try again from the dashboard.")
+	}
 }
 
 func (a *API) magicReject(w http.ResponseWriter, r *http.Request, messageID, userID, reason string) {

--- a/internal/hitlworker/async_approve_test.go
+++ b/internal/hitlworker/async_approve_test.go
@@ -1,0 +1,104 @@
+package hitlworker_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+)
+
+// fakeEnq records EnqueueSendTx calls (the outbound_send enqueue) so the async
+// branch can be asserted without a real River client.
+type fakeEnq struct{ calls []string }
+
+func (f *fakeEnq) EnqueueSendTx(_ context.Context, _ pgx.Tx, messageID string) (int64, error) {
+	f.calls = append(f.calls, messageID)
+	return 7777, nil
+}
+
+// TestWorkerAutoApproveAsync: with an outbound enqueuer wired (async mode), an
+// expired approve-hold to an EXTERNAL recipient is transitioned to
+// review_expired_approved + delivery_status='accepted', an outbound_send job is
+// enqueued (+ send_job_id stamped), and NO inline SMTP send happens — the
+// SendWorker owns the submit.
+func TestWorkerAutoApproveAsync(t *testing.T) {
+	w, store, pool, smtpDone := setupWorker(t)
+	ctx := context.Background()
+
+	agent := prepareAgent(t, store, "approve-async", identity.HITLExpirationApprove)
+	enq := &fakeEnq{}
+	w.SetOutboundEnqueuer(enq)
+
+	msg, err := store.CreatePendingOutboundMessage(ctx, agent.ID,
+		[]string{"alice@external.test"}, nil, nil,
+		"Held", "body", "<p>html</p>", nil, "send", "", "", 60)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backdateExpiry(t, pool, msg.ID)
+
+	w.RunOnce(ctx)
+
+	if msgs := smtpDone(); len(msgs) != 0 {
+		t.Fatalf("async approve must NOT send inline, got %d SMTP messages", len(msgs))
+	}
+	if len(enq.calls) != 1 || enq.calls[0] != msg.ID {
+		t.Fatalf("EnqueueSendTx calls = %v, want [%s]", enq.calls, msg.ID)
+	}
+
+	var status, deliveryStatus string
+	var sendJobID *int64
+	if err := pool.QueryRow(ctx,
+		`SELECT status, COALESCE(delivery_status,''), send_job_id FROM messages WHERE id=$1`, msg.ID,
+	).Scan(&status, &deliveryStatus, &sendJobID); err != nil {
+		t.Fatal(err)
+	}
+	if status != identity.MessageStatusReviewExpiredApproved {
+		t.Errorf("status = %q, want %q", status, identity.MessageStatusReviewExpiredApproved)
+	}
+	if deliveryStatus != "accepted" {
+		t.Errorf("delivery_status = %q, want accepted", deliveryStatus)
+	}
+	if sendJobID == nil || *sendJobID != 7777 {
+		t.Errorf("send_job_id = %v, want 7777", sendJobID)
+	}
+}
+
+// TestWorkerAutoApproveAsync_SelfSendStaysLoopback: even with the enqueuer wired,
+// a self-send (single To == the agent's own address) must NOT be enqueued onto
+// QueueOutbound (the relay would strip the address). It falls through to the sync
+// loopback path and resolves to review_expired_approved.
+func TestWorkerAutoApproveAsync_SelfSendStaysLoopback(t *testing.T) {
+	w, store, pool, smtpDone := setupWorker(t)
+	ctx := context.Background()
+
+	agent := prepareAgent(t, store, "selfsend-async", identity.HITLExpirationApprove)
+	enq := &fakeEnq{}
+	w.SetOutboundEnqueuer(enq)
+
+	msg, err := store.CreatePendingOutboundMessage(ctx, agent.ID,
+		[]string{agent.EmailAddress()}, nil, nil,
+		"To myself", "body", "", nil, "send", "", "", 60)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backdateExpiry(t, pool, msg.ID)
+
+	w.RunOnce(ctx)
+
+	if len(enq.calls) != 0 {
+		t.Errorf("self-send must NOT enqueue onto QueueOutbound, got calls %v", enq.calls)
+	}
+	if msgs := smtpDone(); len(msgs) != 0 {
+		t.Errorf("self-send delivers via loopback, not SMTP, got %d messages", len(msgs))
+	}
+	var status string
+	if err := pool.QueryRow(ctx, `SELECT status FROM messages WHERE id=$1`, msg.ID).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != identity.MessageStatusReviewExpiredApproved {
+		t.Errorf("self-send status = %q, want %q (resolved via loopback)", status, identity.MessageStatusReviewExpiredApproved)
+	}
+}

--- a/internal/hitlworker/maintenance.go
+++ b/internal/hitlworker/maintenance.go
@@ -15,6 +15,13 @@ import (
 // within a minute, long enough to avoid hot-looping the DB when there's nothing to do.
 const maintenanceInterval = 60 * time.Second
 
+// asyncSweepTimeout bounds a sweep when outbound sends are routed to QueueOutbound
+// (async mode): the sweep is then DB-only (self-sends are fast loopback DB writes;
+// auto-reject and the approve→accepted transition are single statements), so River's
+// per-job timeout can safely bound slot occupancy again. Generous enough for a
+// 100-row DB-only batch even under load.
+const asyncSweepTimeout = 5 * time.Minute
+
 // Sweeper runs one TTL-expiration sweep of both hold queues (outbound holds +
 // inbound review holds). Satisfied by *Worker — the River worker just drives its
 // RunOnce on a schedule instead of a hand-rolled time.Ticker.
@@ -35,28 +42,35 @@ func (HITLMaintenanceArgs) Kind() string { return "hitl_ttl_sweep" }
 type MaintenanceWorker struct {
 	river.WorkerDefaults[HITLMaintenanceArgs]
 	sweeper Sweeper
+	// asyncSends is true when auto-approve routes outbound sends onto QueueOutbound
+	// (E2A_OUTBOUND_MODE=async). It makes the sweep DB-only, which lets Timeout
+	// return a bounded value instead of disabling the cap.
+	asyncSends bool
 }
 
-// NewMaintenanceWorker builds the worker around a Sweeper. Exported so tests can
-// drive Work directly (RegisterJobs builds an identical one for the client).
-func NewMaintenanceWorker(sweeper Sweeper) *MaintenanceWorker {
-	return &MaintenanceWorker{sweeper: sweeper}
+// NewMaintenanceWorker builds the worker around a Sweeper. asyncSends reflects
+// whether outbound auto-approve sends are routed to QueueOutbound (async mode).
+// Exported so tests can drive Work directly (RegisterJobs builds an identical one).
+func NewMaintenanceWorker(sweeper Sweeper, asyncSends bool) *MaintenanceWorker {
+	return &MaintenanceWorker{sweeper: sweeper, asyncSends: asyncSends}
 }
 
-// Timeout disables River's per-job timeout for the sweep (River's client default is
-// 1 minute). Unlike a typical maintenance job — a quick handful of DELETEs — one
-// sweep can legitimately run for many minutes: it performs up to DefaultBatchSize
-// (100) SYNCHRONOUS, retrying SMTP sends for expired auto-approve holds, and the
-// relay send is not context-cancellable (its own per-send network deadline bounds
-// it). Under the 60s default a backlogged sweep is cancelled mid-iteration; the
-// store's ctx-derived hold transitions then fail and surface as FALSE
-// "[hitl-stuck] needs_manual_intervention" alarms on the auto-send path — every
-// cycle, precisely during SMTP/SES degradation. The old hand-rolled ticker ran
-// under an unbounded context; returning a negative duration restores that (River
-// treats <0 as "no timeout"). The structural fix that would let this return to a
-// bounded timeout is moving each auto-send onto its own QueueOutbound job (tracked
-// follow-up) so a sweep does DB-only work again.
+// Timeout caps the sweep's runtime. River's client default is 1 minute.
+//
+//   - **Sync mode** (asyncSends=false): the sweep performs up to DefaultBatchSize
+//     (100) SYNCHRONOUS, retrying SMTP sends for expired auto-approve holds, each up
+//     to ~21s and not context-cancellable. Under the 60s default a backlogged sweep
+//     is cancelled mid-iteration, and the store's ctx-derived transitions then fail
+//     and surface as FALSE "[hitl-stuck] needs_manual_intervention" alarms every
+//     cycle. So we disable the timeout (River treats <0 as "no timeout"), matching
+//     the old hand-rolled ticker's unbounded context.
+//   - **Async mode** (asyncSends=true): auto-approve enqueues onto QueueOutbound
+//     instead of blocking, so the sweep is DB-only and a bounded timeout is safe —
+//     it restores River's slot-occupancy protection on the shared maintenance pool.
 func (w *MaintenanceWorker) Timeout(*river.Job[HITLMaintenanceArgs]) time.Duration {
+	if w.asyncSends {
+		return asyncSweepTimeout
+	}
 	return -1
 }
 
@@ -70,10 +84,17 @@ func (w *MaintenanceWorker) Work(ctx context.Context, _ *river.Job[HITLMaintenan
 // MaintenanceJobs is the jobs.Registrar for the HITL TTL sweep: it contributes the
 // MaintenanceWorker and a periodic that fires it on QueueMaintenance. No enqueuer
 // needed — the schedule is the only trigger.
-type MaintenanceJobs struct{ sweeper Sweeper }
+type MaintenanceJobs struct {
+	sweeper    Sweeper
+	asyncSends bool
+}
 
 // NewMaintenanceJobs builds the registrar around a Sweeper (the *Worker).
-func NewMaintenanceJobs(sweeper Sweeper) *MaintenanceJobs { return &MaintenanceJobs{sweeper: sweeper} }
+// asyncSends is true when outbound auto-approve sends go to QueueOutbound (async
+// mode) — it makes the sweep DB-only and its Timeout bounded.
+func NewMaintenanceJobs(sweeper Sweeper, asyncSends bool) *MaintenanceJobs {
+	return &MaintenanceJobs{sweeper: sweeper, asyncSends: asyncSends}
+}
 
 // RegisterJobs adds the maintenance worker + its periodic schedule. Mirrors the
 // webhook janitor + inbound retention periodics: routed to QueueMaintenance, no
@@ -84,7 +105,7 @@ func NewMaintenanceJobs(sweeper Sweeper) *MaintenanceJobs { return &MaintenanceJ
 // idempotent + cross-replica-safe so scheduling is the only concern). Implements
 // jobs.Registrar.
 func (m *MaintenanceJobs) RegisterJobs(w *river.Workers) []*river.PeriodicJob {
-	river.AddWorker(w, &MaintenanceWorker{sweeper: m.sweeper})
+	river.AddWorker(w, &MaintenanceWorker{sweeper: m.sweeper, asyncSends: m.asyncSends})
 	return []*river.PeriodicJob{
 		river.NewPeriodicJob(
 			river.PeriodicInterval(maintenanceInterval),

--- a/internal/hitlworker/maintenance_test.go
+++ b/internal/hitlworker/maintenance_test.go
@@ -28,7 +28,7 @@ func (f *fakeSweeper) RunOnce(_ context.Context) error {
 // idempotent sweep; the next interval picks it up.
 func TestMaintenanceWorker_WorkSwallowsSweepError(t *testing.T) {
 	sw := &fakeSweeper{err: errors.New("boom")}
-	w := NewMaintenanceWorker(sw)
+	w := NewMaintenanceWorker(sw, false)
 	if err := w.Work(context.Background(), &river.Job[HITLMaintenanceArgs]{}); err != nil {
 		t.Fatalf("Work returned %v, want nil (error must be swallowed)", err)
 	}
@@ -41,7 +41,7 @@ func TestMaintenanceWorker_WorkSwallowsSweepError(t *testing.T) {
 // and returns nil.
 func TestMaintenanceWorker_WorkRunsSweep(t *testing.T) {
 	sw := &fakeSweeper{}
-	w := NewMaintenanceWorker(sw)
+	w := NewMaintenanceWorker(sw, false)
 	if err := w.Work(context.Background(), &river.Job[HITLMaintenanceArgs]{}); err != nil {
 		t.Fatalf("Work: %v", err)
 	}
@@ -50,21 +50,23 @@ func TestMaintenanceWorker_WorkRunsSweep(t *testing.T) {
 	}
 }
 
-// TestMaintenanceWorker_TimeoutDisabled: the sweep must NOT run under River's 60s
-// default job timeout — it does up to 100 synchronous, non-ctx-aware SMTP sends and
-// would otherwise be cancelled mid-drain, firing false [hitl-stuck] alarms. A
-// negative return tells River "no timeout" (restores the old ticker's unbounded run).
-func TestMaintenanceWorker_TimeoutDisabled(t *testing.T) {
-	w := NewMaintenanceWorker(&fakeSweeper{})
-	if got := w.Timeout(&river.Job[HITLMaintenanceArgs]{}); got >= 0 {
-		t.Errorf("Timeout() = %v, want a negative duration (River default 60s cap disabled)", got)
+// TestMaintenanceWorker_Timeout: in SYNC mode the sweep does up to 100 synchronous,
+// non-ctx-aware SMTP sends, so its Timeout is disabled (<0) to avoid a mid-drain cut
+// + false [hitl-stuck] alarms. In ASYNC mode auto-approve enqueues onto QueueOutbound
+// so the sweep is DB-only and Timeout is bounded (restores slot-occupancy protection).
+func TestMaintenanceWorker_Timeout(t *testing.T) {
+	if got := NewMaintenanceWorker(&fakeSweeper{}, false).Timeout(&river.Job[HITLMaintenanceArgs]{}); got >= 0 {
+		t.Errorf("sync Timeout() = %v, want a negative duration (cap disabled)", got)
+	}
+	if got := NewMaintenanceWorker(&fakeSweeper{}, true).Timeout(&river.Job[HITLMaintenanceArgs]{}); got != asyncSweepTimeout {
+		t.Errorf("async Timeout() = %v, want %v (bounded)", got, asyncSweepTimeout)
 	}
 }
 
 // TestMaintenanceJobs_RegistersOnePeriodic: RegisterJobs contributes exactly one
 // periodic (the TTL sweep schedule) and wires its worker.
 func TestMaintenanceJobs_RegistersOnePeriodic(t *testing.T) {
-	m := NewMaintenanceJobs(&fakeSweeper{})
+	m := NewMaintenanceJobs(&fakeSweeper{}, false)
 	periodics := m.RegisterJobs(river.NewWorkers())
 	if len(periodics) != 1 {
 		t.Fatalf("RegisterJobs returned %d periodic jobs, want 1", len(periodics))

--- a/internal/hitlworker/worker.go
+++ b/internal/hitlworker/worker.go
@@ -8,8 +8,11 @@ package hitlworker
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
+
+	"github.com/jackc/pgx/v5"
 
 	"github.com/Mnexa-AI/e2a/internal/identity"
 	"github.com/Mnexa-AI/e2a/internal/loopback"
@@ -17,6 +20,15 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/usage"
 	"github.com/Mnexa-AI/e2a/internal/webhookpub"
 )
+
+// OutboundEnqueuer inserts an outbound_send job (QueueOutbound) in the caller's
+// transaction. Satisfied by *outboundsend.Jobs. When wired (E2A_OUTBOUND_MODE=async)
+// the sweep hands an approved outbound send to the async pipeline — transitioning
+// the hold to review_expired_approved + delivery_status='accepted' and enqueuing —
+// instead of blocking on Sender.Send. Self-sends never use it (they loopback).
+type OutboundEnqueuer interface {
+	EnqueueSendTx(ctx context.Context, tx pgx.Tx, messageID string) (int64, error)
+}
 
 // DefaultBatchSize caps how many rows one sweep will try to finalize. The
 // partial index on (approval_expires_at) WHERE status='pending_review'
@@ -37,11 +49,22 @@ type Worker struct {
 	// from internal/agent). Optional — nil leaves the sweep silent (legacy
 	// behavior). Wired via SetPublisher.
 	publisher webhookpub.Publisher
+	// outboundEnq, when non-nil (E2A_OUTBOUND_MODE=async), routes an approved
+	// outbound send onto QueueOutbound instead of a blocking Sender.Send — the
+	// sweep becomes DB-only. Wired via SetOutboundEnqueuer. Self-sends ignore it.
+	outboundEnq OutboundEnqueuer
 }
 
 // SetPublisher wires the webhook publisher used to emit review-resolution events
 // on TTL auto-resolution. Without it the sweep transitions rows silently.
 func (w *Worker) SetPublisher(p webhookpub.Publisher) { w.publisher = p }
+
+// SetOutboundEnqueuer wires the async outbound send enqueuer. When set (async
+// mode), auto-approve transitions the hold + enqueues an outbound_send job and the
+// SendWorker performs the SMTP submit; when nil (sync mode), auto-approve keeps the
+// blocking in-process send. Two-phase wiring: pass the *outboundsend.Jobs pointer;
+// its shared River client is injected later via the jobs client's SetEnqueuer.
+func (w *Worker) SetOutboundEnqueuer(e OutboundEnqueuer) { w.outboundEnq = e }
 
 // New constructs a Worker. fromDomain is the deployment's outbound
 // from-domain (cfg.OutboundSMTP.FromDomain) — used by the self-send
@@ -152,6 +175,72 @@ func (w *Worker) autoApprove(ctx context.Context, c identity.ExpirationCandidate
 		return
 	}
 
+	// Async mode: hand the send to QueueOutbound (DB-only sweep). Returns false
+	// only for self-sends, which fall through to the sync loopback path below.
+	if w.outboundEnq != nil && w.autoApproveAsync(ctx, agent, c) {
+		return
+	}
+	w.autoApproveSync(ctx, agent, c)
+}
+
+// autoApproveAsync transitions the hold to review_expired_approved +
+// delivery_status='accepted' and enqueues an outbound_send job; the SendWorker does
+// the actual submit + email.sent/failed + metering. Returns false (handled nothing)
+// ONLY when the message is a self-send — the caller then uses the sync loopback
+// path. Any other outcome (queued, already-resolved, transient failure left for the
+// next cycle, or a permanent-draft reject) returns true.
+func (w *Worker) autoApproveAsync(ctx context.Context, agent *identity.AgentIdentity, c identity.ExpirationCandidate) bool {
+	msg, err := w.store.LoadOutboundDraft(ctx, c.MessageID)
+	if err != nil {
+		if errors.Is(err, identity.ErrMessageNotFound) {
+			return true // gone — no-op
+		}
+		log.Printf("[hitl-worker] auto-approve %s: load draft: %v", c.MessageID, err)
+		return true // transient — leave pending_review for the next cycle
+	}
+	if msg.Status != identity.MessageStatusPendingReview {
+		return true // resolved by a human/other worker
+	}
+	req, err := sendRequestFromStoredMessage(msg)
+	if err != nil {
+		w.autoReject(ctx, c.MessageID, fmt.Sprintf("auto-approve failed: rebuild request: %v", err))
+		return true
+	}
+	w.attachReferencesChain(ctx, agent.ID, &req)
+	if loopback.IsSelfSend(req, agent.EmailAddress()) {
+		return false // self-send — fall through to the sync loopback path
+	}
+	comp, err := w.sender.ComposeForAccept(agent, req)
+	if err != nil {
+		// Compose failures are deterministic (bad addresses / no visible
+		// recipients) — a retry can't fix them, so reject like the sync path would.
+		w.autoReject(ctx, c.MessageID, fmt.Sprintf("auto-approve failed: compose: %v", err))
+		return true
+	}
+	acc := identity.AcceptedSend{
+		To: comp.To, CC: comp.CC, BCC: comp.BCC, Subject: req.Subject,
+		Method: comp.Method, EnvelopeFrom: comp.EnvelopeFrom, SentAs: comp.SentAs, Raw: comp.Raw,
+	}
+	sent, err := w.store.ApproveAndAccept(ctx, c.MessageID, "", identity.MessageStatusReviewExpiredApproved, false, acc, w.outboundEnq.EnqueueSendTx)
+	if err != nil {
+		if errors.Is(err, identity.ErrNotPendingApproval) {
+			return true // resolved between load and transition
+		}
+		// Transient tx/enqueue failure: leave the row pending_review for the next
+		// cycle. Do NOT autoReject — no send happened, so this is not a "stuck" send.
+		log.Printf("[hitl-worker] auto-approve %s: accept+enqueue: %v", c.MessageID, err)
+		return true
+	}
+	log.Printf("[mail:%s] dir=outbound type=%s status=%s agent=%s to=%v auto_approved=true delivery=async",
+		sent.ID, sent.Type, sent.Status, agent.ID, sent.ToRecipients)
+	// review_approved fires now (hold resolved to approved); the delivery outcome
+	// arrives later via email.sent/email.failed from the SendWorker. No metering
+	// here — the SendWorker meters on MarkSent.
+	w.emitOutboundApproved(agent, sent)
+	return true
+}
+
+func (w *Worker) autoApproveSync(ctx context.Context, agent *identity.AgentIdentity, c identity.ExpirationCandidate) {
 	sent, err := w.store.ExpireApproveAndSend(ctx, c.MessageID,
 		func(msg *identity.Message) (identity.SendResult, error) {
 			req, err := sendRequestFromStoredMessage(msg)

--- a/internal/httpapi/hitl.go
+++ b/internal/httpapi/hitl.go
@@ -133,8 +133,15 @@ func (s *Server) approveHeld(ctx context.Context, userID, msgID, agentEmail stri
 			return 0, SendResultView{}, NewError(derr.Status, derr.Code, derr.Msg)
 		}
 		edited := sent.Edited
+		// Async mode returns the hold resolved to approved with delivery_status
+		// 'accepted' (the SendWorker submits later, emitting email.sent/failed) —
+		// surface "accepted" like any async send. Sync mode sent inline → "sent".
+		status := "sent"
+		if sent.DeliveryStatus == "accepted" {
+			status = "accepted"
+		}
 		return http.StatusOK, SendResultView{
-			Status: "sent", MessageID: sent.ID, ProviderMessageID: sent.ProviderMessageID,
+			Status: status, MessageID: sent.ID, ProviderMessageID: sent.ProviderMessageID,
 			SentAs: sent.SentAs, Method: sent.Method, Edited: &edited,
 		}, nil
 	})

--- a/internal/identity/approve_accept_test.go
+++ b/internal/identity/approve_accept_test.go
@@ -1,0 +1,95 @@
+package identity_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+)
+
+// TestApproveAndAccept transitions a pending_review outbound hold to
+// approved+accepted, enqueues via the callback, stamps the returned job id, and is
+// a no-op (ErrNotPendingApproval) once the hold is already resolved.
+func TestApproveAndAccept(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	store := identity.NewStore(pool)
+
+	user, err := store.CreateOrGetUser(ctx, "owner-aa@example.com", "Owner", "google-aa")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	domain := "aa.example.com"
+	if _, err := store.ClaimOrCreateDomain(ctx, domain, user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+	if err := store.VerifyDomain(ctx, domain, user.ID); err != nil {
+		t.Fatalf("VerifyDomain: %v", err)
+	}
+	ag, err := store.CreateAgent(ctx, "bot@"+domain, domain, "", "", "local", user.ID)
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	msg, err := store.CreatePendingOutboundMessage(ctx, ag.ID,
+		[]string{"a@gmail.com"}, nil, nil, "Subj", "body", "", nil,
+		"send", "conv-aa", "", 3600)
+	if err != nil {
+		t.Fatalf("CreatePendingOutboundMessage: %v", err)
+	}
+
+	var enqueued int
+	enqueue := func(_ context.Context, _ pgx.Tx, _ string) (int64, error) {
+		enqueued++
+		return 4242, nil
+	}
+	acc := identity.AcceptedSend{
+		To: []string{"a@gmail.com"}, Subject: "Subj", Method: "smtp",
+		EnvelopeFrom: "bot@aa.example.com", SentAs: "relay", Raw: []byte("raw-mime"),
+	}
+
+	out, err := store.ApproveAndAccept(ctx, msg.ID, user.ID, identity.MessageStatusReviewApproved, false, acc, enqueue)
+	if err != nil {
+		t.Fatalf("ApproveAndAccept: %v", err)
+	}
+	if out.Status != identity.MessageStatusReviewApproved {
+		t.Errorf("status = %q, want %q", out.Status, identity.MessageStatusReviewApproved)
+	}
+	if out.DeliveryStatus != "accepted" {
+		t.Errorf("delivery_status = %q, want accepted", out.DeliveryStatus)
+	}
+	if enqueued != 1 {
+		t.Errorf("enqueue called %d times, want 1", enqueued)
+	}
+
+	// DB reflects the transition + stamped send_job_id + accepted delivery + scrubbed body.
+	var (
+		status, deliveryStatus string
+		sendJobID              *int64
+		bodyText               *string
+	)
+	if err := pool.QueryRow(ctx,
+		`SELECT status, delivery_status, send_job_id, body_text FROM messages WHERE id=$1`, msg.ID,
+	).Scan(&status, &deliveryStatus, &sendJobID, &bodyText); err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if status != identity.MessageStatusReviewApproved || deliveryStatus != "accepted" {
+		t.Errorf("db status/delivery = %q/%q", status, deliveryStatus)
+	}
+	if sendJobID == nil || *sendJobID != 4242 {
+		t.Errorf("send_job_id = %v, want 4242", sendJobID)
+	}
+	if bodyText != nil {
+		t.Errorf("body_text not scrubbed: %v", *bodyText)
+	}
+
+	// Idempotent: a second attempt (row no longer pending_review) is a no-op.
+	if _, err := store.ApproveAndAccept(ctx, msg.ID, user.ID, identity.MessageStatusReviewApproved, false, acc, enqueue); err != identity.ErrNotPendingApproval {
+		t.Errorf("second ApproveAndAccept err = %v, want ErrNotPendingApproval", err)
+	}
+	if enqueued != 1 {
+		t.Errorf("enqueue called %d times after no-op attempt, want still 1", enqueued)
+	}
+}

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -2508,6 +2508,11 @@ func (s *Store) ApproveAndAccept(
 		}
 		m.Direction = "outbound"
 		m.DeliveryStatus = "accepted"
+		// Surface the composed envelope on the returned row so the approve view +
+		// review_approved event report method/sent_as (like the sync path). The
+		// provider_message_id stays empty — the SendWorker fills it on email.sent.
+		m.Method = acc.Method
+		m.SentAs = acc.SentAs
 		out = &m
 		return nil
 	})

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -2421,6 +2421,102 @@ func (s *Store) ExpireApproveAndSend(
 	return &m, nil
 }
 
+// AcceptedSend carries the composed, ready-to-submit values for an approved HITL
+// message being handed to the async outbound queue (QueueOutbound) instead of being
+// sent inline. Populated by the caller from outbound.ComposeResult.
+type AcceptedSend struct {
+	To, CC, BCC  []string
+	Subject      string
+	Method       string
+	EnvelopeFrom string
+	SentAs       string
+	Raw          []byte
+}
+
+// ApproveAndAccept resolves a pending_review outbound hold to an APPROVED,
+// ASYNC-QUEUED state in one transaction, mirroring the API's async accept-tx: it
+// flips status to targetStatus (review_approved for a human approve,
+// review_expired_approved for the TTL sweep) AND delivery_status to 'accepted',
+// persists the composed bytes + envelope, then enqueues the outbound_send job and
+// stamps its id. The existing SendWorker picks the row up by id and performs the
+// actual SMTP submit + email.sent/failed + metering; this method does NOT send and
+// does NOT use the send_attempts gate (async idempotency is the accept-tx atomicity
+// + the worker's delivery_status/alreadyDone guard). reviewedByUserID is "" (→ NULL)
+// for the sweep.
+//
+// The WHERE status='pending_review' is the compare-and-set guard: RETURNING no row
+// means a human/other worker already resolved the hold → ErrNotPendingApproval (a
+// no-op for the caller). Body columns are scrubbed exactly like ApproveAndSend.
+func (s *Store) ApproveAndAccept(
+	ctx context.Context,
+	messageID, reviewedByUserID, targetStatus string,
+	edited bool,
+	acc AcceptedSend,
+	enqueue func(ctx context.Context, tx pgx.Tx, messageID string) (int64, error),
+) (*Message, error) {
+	var out *Message
+	err := s.WithTx(ctx, func(tx pgx.Tx) error {
+		var m Message
+		var msgType *string
+		err := tx.QueryRow(ctx,
+			`UPDATE messages
+			    SET status              = $2,
+			        delivery_status     = 'accepted',
+			        to_recipients       = $3,
+			        cc                  = $4,
+			        bcc                 = $5,
+			        subject             = $6,
+			        recipient           = $7,
+			        method              = $8,
+			        envelope_from       = $9,
+			        sent_as             = $10,
+			        raw_message         = $11::bytea,
+			        provider_message_id = '',
+			        reviewed_at         = now(),
+			        reviewed_by_user_id = $12,
+			        edited              = $13,
+			        body_text = NULL, body_html = NULL, attachments_json = NULL
+			  WHERE id = $1 AND direction = 'outbound' AND status = 'pending_review'
+			  RETURNING id, agent_id, message_type, subject, to_recipients, cc, bcc, status, edited`,
+			messageID,
+			targetStatus,
+			acc.To, acc.CC, acc.BCC,
+			acc.Subject,
+			firstOr(acc.To, ""),
+			acc.Method,
+			acc.EnvelopeFrom,
+			acc.SentAs,
+			nullIfEmptyBytes(acc.Raw),
+			nullIfEmptyString(reviewedByUserID),
+			edited,
+		).Scan(&m.ID, &m.AgentID, &msgType, &m.Subject, &m.ToRecipients, &m.CC, &m.BCC, &m.Status, &m.Edited)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return ErrNotPendingApproval
+		}
+		if err != nil {
+			return err
+		}
+		if msgType != nil {
+			m.Type = *msgType
+		}
+		jobID, err := enqueue(ctx, tx, m.ID)
+		if err != nil {
+			return err
+		}
+		if err := s.StampSendJobIDTx(ctx, tx, m.ID, jobID); err != nil {
+			return err
+		}
+		m.Direction = "outbound"
+		m.DeliveryStatus = "accepted"
+		out = &m
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // ExpireReject transitions a pending_review message to review_expired_rejected
 // and scrubs body columns. No user ownership check — this is the worker
 // path. If the row is no longer pending (racing worker, already handled)

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -2517,6 +2517,45 @@ func (s *Store) ApproveAndAccept(
 	return out, nil
 }
 
+// LoadOutboundDraft loads a pending_review outbound message's full draft content
+// (recipients, subject, body, attachments, reply-to) by id, system-scoped (no user
+// filter, no side effects) — the TTL sweep uses it to reconstruct the SendRequest
+// and compose before ApproveAndAccept. Returns ErrMessageNotFound if the row is
+// gone or not an outbound message. The caller must still handle the pending_review
+// CAS in ApproveAndAccept (a human may resolve the hold before the transition).
+func (s *Store) LoadOutboundDraft(ctx context.Context, messageID string) (*Message, error) {
+	m := &Message{ID: messageID, Direction: "outbound"}
+	var bodyText, bodyHTML *string
+	var attachments []byte
+	var msgType *string
+	err := s.pool.QueryRow(ctx,
+		`SELECT agent_id, sender, subject, email_message_id, message_type, conversation_id,
+		        to_recipients, cc, bcc, status, body_text, body_html, attachments_json
+		   FROM messages WHERE id=$1 AND direction='outbound'`,
+		messageID,
+	).Scan(&m.AgentID, &m.Sender, &m.Subject, &m.EmailMessageID, &msgType, &m.ConversationID,
+		&m.ToRecipients, &m.CC, &m.BCC, &m.Status, &bodyText, &bodyHTML, &attachments)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, ErrMessageNotFound
+		}
+		return nil, err
+	}
+	if msgType != nil {
+		m.Type = *msgType
+	}
+	if bodyText != nil {
+		m.BodyText = *bodyText
+	}
+	if bodyHTML != nil {
+		m.BodyHTML = *bodyHTML
+	}
+	if len(attachments) > 0 {
+		m.AttachmentsJSON = json.RawMessage(attachments)
+	}
+	return m, nil
+}
+
 // ExpireReject transitions a pending_review message to review_expired_rejected
 // and scrubs body columns. No user ownership check — this is the worker
 // path. If the row is no longer pending (racing worker, already handled)


### PR DESCRIPTION
Routes **HITL approve sends** onto the async outbound River queue (`QueueOutbound`) when `E2A_OUTBOUND_MODE=async`, instead of a blocking in-process `Sender.Send`. Covers all three approve paths: the TTL sweep, the dashboard endpoint, and the magic-link. The structural follow-up to the HITL-on-River work — it retires the sweep's blocking send and lets the sweep's `Timeout()` return to a bounded value. Design: `docs/design/hitl-ttl-async-send.md`.

## What & why
Before, every approve blocked on a retrying SMTP submit inside the request (or the maintenance sweep). Now, in async mode, an approve **transitions the existing hold row** to `delivery_status='accepted'` + composed raw bytes, enqueues an `outbound_send` job, and stamps `send_job_id` — all in one tx. The existing `SendWorker` (unchanged) does the SMTP submit + `email.sent`/`email.failed` + metering.

- **New store primitive** `identity.ApproveAndAccept` — a compare-and-set `UPDATE ... WHERE status='pending_review' RETURNING` (0 rows → `ErrNotPendingApproval`) + `EnqueueSendTx` + `StampSendJobIDTx`. No `send_attempts` gate (async idempotency = accept-tx atomicity + the worker's `alreadyDone`).
- **Key enabler:** the `SendWorker` needs no changes — `LoadOutboundForSend` filters only on `direction='outbound'` and keys idempotency off `delivery_status`, so a transitioned hold row flows through untouched; `MarkSent`/`MarkFailed` never clobber the hold status.
- **Three paths:** TTL sweep (`hitlworker.autoApproveAsync` → `review_expired_approved`), dashboard `ApprovePendingCore` + magic-link `magicApprove` (→ `sent`, matching sync — outbound's approved terminal — via a shared `approveOutboundAsync` helper). Self-sends stay on the sync loopback path (the relay strips the agent's own address). Sync mode is **byte-for-byte unchanged**.
- **Mode-aware `Timeout()`**: bounded (5 min) in async — the sweep is now DB-only — and `-1` in sync (blocking send remains).
- **Response contract:** approve now returns `accepted` (send queued), not `sent`; the outcome follows via `email.sent`/`email.failed`. This is the industry norm (SendGrid `202`, SES accepted-for-sending) and matches every normal e2a async send.

## Behavior changes (async mode)
- Approve returns `accepted`, not `sent`.
- A send that ultimately **fails** stays approved (`delivery_status='failed'` + `email.failed`) — it does not revert to `rejected`. Review decision ≠ delivery outcome.
- `email.sent` now fires on an approved send's success (sync approve emitted only `review_approved`).

## Scope
TTL sweep + both human approve endpoints. Self-sends stay loopback. Sync mode unchanged. Inbound review + outbound reject-on-expiry untouched.

## Verification
- `go build ./...`, `gofmt`, `go vet` clean; **no OpenAPI drift** (`accepted` is a value, not a schema change). Affected sync suites (`identity`, `agent`, `httpapi`, `hitlworker`) all green — sync approve paths intact.
- New tests: `ApproveAndAccept` CAS + idempotent no-op; worker async (enqueue) + self-send→loopback; `ApprovePendingCore` async external + self-send-stays-sync.
- **Two adversarial reviews — both no blocking bugs.** Correctness review verified the CAS atomicity, SendWorker pickup, reconciler can't wrongly re-drive, no double-send/double-meter, mixed-mode safety. Behavior review verified the response contract, events split, metering, the approved-even-if-fails semantics, and mode-aware Timeout. A new API-layer test caught (and this PR fixes) that human approve must resolve to `status='sent'` to match the sync path.
- **Live e2e (async instance) — PASS**: TTL + dashboard approve both → `accepted` → SendWorker → `sent` + Mailpit + `email.sent`; dashboard HTTP body `{"status":"accepted"}`; self-send → loopback (no `outbound_send` job, no `send_attempts` row, inbound twin created). `webhook_events`: `review_approved`×3, `email.sent`×2 (loopback none). No errors/panics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)