### PR TITLE
feat(webhookfanout): migrate webhook fan-out onto River (flag-gated)

### DIFF
--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -301,6 +301,21 @@ func main() {
 	webhookDeliveryJobs := webhookdelivery.NewJobs(subscriberStore, subscriberDeliverer, store, pool)
 	registrars = append(registrars, webhookDeliveryJobs)
 
+	// Webhook fan-out (webhook_events → webhook_subscriber_deliveries) on River,
+	// replacing the legacy in-process webhookpub.OutboxWorker drain. Gated by
+	// E2A_WEBHOOK_FANOUT_MODE=river (webhook-fanout-river-migration.md). When enabled:
+	// the FanOutWorker + reconciler are registered, PublishTx/PublishBestEffortTx
+	// enqueue a fan-out job in the event tx (SetFanOutEnqueuer, below), and the legacy
+	// OutboxWorker is NOT started. It reuses webhookDeliveryJobs as its delivery
+	// enqueuer, so the Layer 2→3 delivery path is unchanged. Default (legacy) leaves
+	// everything on the OutboxWorker.
+	fanoutRiver := cfg.WebhookFanout.Mode == "river"
+	var fanoutJobs *webhookpub.FanOutJobs
+	if fanoutRiver {
+		fanoutJobs = webhookpub.NewFanOutJobs(pool, store, webhookDeliveryJobs, metrics)
+		registrars = append(registrars, fanoutJobs)
+	}
+
 	// Webhook janitor (auto-disable failing webhooks + clear expired prev secrets)
 	// as a River periodic on QueueMaintenance — replaces the hand-rolled 5-min
 	// ticker. Reuses AutoDisableWorker.Tick as the sweep body.
@@ -376,6 +391,24 @@ func main() {
 			log.Printf("[webhook-delivery] cutover enqueued %d pending deliveries", n)
 		}
 		log.Printf("[webhook-delivery] engine=river")
+		// Webhook fan-out cutover (E2A_WEBHOOK_FANOUT_MODE=river): wire the shared
+		// client into the fan-out enqueuer, arm the outbox to enqueue a fan-out job in
+		// each event tx (SetFanOutEnqueuer), and re-drive any pending events without a
+		// job — rows the legacy OutboxWorker was mid-draining at cutover, or stranded by
+		// a best-effort-publish enqueue failure. Idempotent (fanout_job_id IS NULL
+		// guard). Order matters: SetFanOutEnqueuer BEFORE the servers start (below) so
+		// no trigger fires an un-enqueued event; ReconcilePending covers the window
+		// before that.
+		if fanoutJobs != nil {
+			fanoutJobs.SetEnqueuer(jobsClient)
+			webhookOutbox.SetFanOutEnqueuer(fanoutJobs)
+			if n, cerr := fanoutJobs.ReconcilePending(ctx, pool); cerr != nil {
+				log.Printf("[webhook-fanout] cutover: %v", cerr)
+			} else if n > 0 {
+				log.Printf("[webhook-fanout] cutover enqueued %d pending events", n)
+			}
+			log.Printf("[webhook-fanout] engine=river")
+		}
 		// Async outbound send cutover (slice C): wire the shared client into the
 		// accept-tx enqueuer and re-drive any accepted-but-unenqueued rows (stranded
 		// by an accept-tx that crashed between message insert and job commit).
@@ -676,12 +709,19 @@ func main() {
 	bgCtx, bgCancel := context.WithCancel(context.Background())
 
 	// Outbox publisher worker: drains webhook_events → subscriber_deliveries and
-	// enqueues River delivery jobs in-tx.
-	workerWG.Add(1)
-	go func() {
-		defer workerWG.Done()
-		outboxWorker.Start(bgCtx)
-	}()
+	// enqueues River delivery jobs in-tx. Skipped when fan-out runs on River
+	// (E2A_WEBHOOK_FANOUT_MODE=river) — the FanOutWorker + in-tx enqueue replace it;
+	// running both would double-fan-out (harmless via the (event_id, webhook_id) dedup,
+	// but wasteful). Default (legacy) starts it as before.
+	if !fanoutRiver {
+		workerWG.Add(1)
+		go func() {
+			defer workerWG.Done()
+			outboxWorker.Start(bgCtx)
+		}()
+	} else {
+		log.Printf("[webhook-fanout] legacy OutboxWorker not started (engine=river)")
+	}
 
 	// (The HITL TTL expiration sweep is now a River periodic on QueueMaintenance,
 	// registered above via hitlworker.NewMaintenanceJobs and drained by the shared

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -42,6 +42,7 @@ type Config struct {
 	OutboundSMTP     OutboundSMTPConfig     `yaml:"outbound_smtp"`
 	Outbound         OutboundConfig         `yaml:"outbound"`
 	Inbound          InboundConfig          `yaml:"inbound"`
+	WebhookFanout    WebhookFanoutConfig    `yaml:"webhook_fanout"`
 	SenderIdentity   SenderIdentityConfig   `yaml:"sender_identity"`
 	DeliveryFeedback DeliveryFeedbackConfig `yaml:"delivery_feedback"`
 	Limits           LimitsConfig           `yaml:"limits"`
@@ -145,6 +146,18 @@ type OutboundConfig struct {
 // Override with E2A_INBOUND_MODE. Any value other than "async" is treated as "sync"
 // (fail-safe to the unchanged path).
 type InboundConfig struct {
+	Mode string `yaml:"mode"`
+}
+
+// WebhookFanoutConfig selects the webhook fan-out execution model (webhook-fanout-
+// river-migration.md). Mode="legacy" (the default) drains webhook_events →
+// webhook_subscriber_deliveries via the in-process webhookpub.OutboxWorker
+// (LISTEN/NOTIFY + poll + SKIP-LOCKED lease). Mode="river" opts into the River
+// pipeline: PublishTx/PublishBestEffortTx enqueue a webhook_fan_out job in the event's
+// tx and the webhookpub.FanOutWorker does the match/insert/enqueue off the drain loop.
+// Override with E2A_WEBHOOK_FANOUT_MODE. Any value other than "river" is treated as
+// "legacy" (fail-safe to the unchanged path). Wired in Slice 2; unused under legacy.
+type WebhookFanoutConfig struct {
 	Mode string `yaml:"mode"`
 }
 
@@ -289,6 +302,9 @@ func Load(path string) (*Config, error) {
 	}
 	if v := os.Getenv("E2A_INBOUND_MODE"); v != "" {
 		cfg.Inbound.Mode = v
+	}
+	if v := os.Getenv("E2A_WEBHOOK_FANOUT_MODE"); v != "" {
+		cfg.WebhookFanout.Mode = v
 	}
 	if v := os.Getenv("E2A_OUTBOUND_SMTP_REQUIRE_TLS"); v != "" {
 		if b, err := strconv.ParseBool(v); err == nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -246,9 +246,10 @@ func Load(path string) (*Config, error) {
 			MaxStorageBytes:  1 << 50, // 1 PiB
 			CacheTTLSeconds:  60,
 		},
-		Outbound: OutboundConfig{Mode: "sync"},
-		Inbound:  InboundConfig{Mode: "sync"},
-		Env:      "development",
+		Outbound:      OutboundConfig{Mode: "sync"},
+		Inbound:       InboundConfig{Mode: "sync"},
+		WebhookFanout: WebhookFanoutConfig{Mode: "legacy"},
+		Env:           "development",
 	}
 
 	if err := yaml.Unmarshal(data, cfg); err != nil {

--- a/internal/relay/server_outbox_test.go
+++ b/internal/relay/server_outbox_test.go
@@ -43,6 +43,8 @@ func (f *fakeOutbox) DeleteExpiredWebhookEvents(ctx context.Context) (int, error
 // whether to suppress the legacy publisher.Publish goroutine.
 func (f *fakeOutbox) Enabled() bool { return f.enabled }
 
+func (f *fakeOutbox) SetFanOutEnqueuer(webhookpub.FanOutEnqueuer) {}
+
 func TestServer_SetOutbox_AcceptsNilForBackwardCompat(t *testing.T) {
 	// A Server constructed without SetOutbox stays in the legacy path.
 	// This is what makes the dual-mode rollout safe: deployments that

--- a/internal/webhookpub/fanout_seam_integration_test.go
+++ b/internal/webhookpub/fanout_seam_integration_test.go
@@ -14,12 +14,20 @@ import (
 // records the event ids it was asked to enqueue and (optionally) fails, to exercise the
 // best-effort savepoint path.
 type fakeFanOutSeamEnq struct {
-	ids []string
-	err error
-	n   int64
+	ids    []string
+	err    error
+	poison bool // if set, run a failing DB statement on the tx (aborting the savepoint subtx) before returning err
+	n      int64
 }
 
-func (f *fakeFanOutSeamEnq) EnqueueFanOutTx(_ context.Context, _ pgx.Tx, eventID string) (int64, error) {
+func (f *fakeFanOutSeamEnq) EnqueueFanOutTx(ctx context.Context, tx pgx.Tx, eventID string) (int64, error) {
+	if f.poison {
+		// Simulate a REAL DB failure inside the fan-out enqueue (e.g. a failed river_job
+		// insert): this aborts the savepoint subtransaction, so the caller MUST issue
+		// ROLLBACK TO SAVEPOINT to recover the parent tx. A fake that only returns an
+		// error (no DB op) would not exercise that recovery.
+		_, _ = tx.Exec(ctx, `SELECT * FROM a_table_that_does_not_exist_xyz`)
+	}
 	if f.err != nil {
 		return 0, f.err
 	}
@@ -112,7 +120,10 @@ func TestOutbox_Integration_PublishBestEffort_SavepointProtectsTx(t *testing.T) 
 	})
 
 	outbox := webhookpub.NewOutbox(pool, webhookpub.StaticFlag(true))
-	outbox.SetFanOutEnqueuer(&fakeFanOutSeamEnq{err: errors.New("river down")})
+	// poison=true makes the enqueue run a failing statement on the savepoint FIRST,
+	// aborting the subtransaction — the realistic river_job-insert-failed case, which
+	// the parent tx must survive via ROLLBACK TO SAVEPOINT.
+	outbox.SetFanOutEnqueuer(&fakeFanOutSeamEnq{poison: true, err: errors.New("river insert failed")})
 
 	event := webhookpub.Event{
 		ID:     webhookpub.DeterministicEventID("msg_seam_be", webhookpub.EventEmailSent),

--- a/internal/webhookpub/fanout_seam_integration_test.go
+++ b/internal/webhookpub/fanout_seam_integration_test.go
@@ -1,0 +1,149 @@
+package webhookpub_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+	"github.com/Mnexa-AI/e2a/internal/webhookpub"
+	"github.com/jackc/pgx/v5"
+)
+
+// fakeFanOutSeamEnq implements webhookpub.FanOutEnqueuer for the outbox seam tests. It
+// records the event ids it was asked to enqueue and (optionally) fails, to exercise the
+// best-effort savepoint path.
+type fakeFanOutSeamEnq struct {
+	ids []string
+	err error
+	n   int64
+}
+
+func (f *fakeFanOutSeamEnq) EnqueueFanOutTx(_ context.Context, _ pgx.Tx, eventID string) (int64, error) {
+	if f.err != nil {
+		return 0, f.err
+	}
+	f.ids = append(f.ids, eventID)
+	f.n++
+	return f.n, nil
+}
+
+// TestOutbox_Integration_PublishTx_EnqueuesFanOut: with a fan-out enqueuer wired
+// (river mode), PublishTx writes the event AND enqueues a fan-out job in the same tx,
+// stamping fanout_job_id. A dedup re-publish (same deterministic id → ON CONFLICT
+// no-op) enqueues nothing more.
+func TestOutbox_Integration_PublishTx_EnqueuesFanOut(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+
+	const userID = "u_fanout_seam_tx"
+	if _, err := pool.Exec(ctx, `INSERT INTO users (id, email, name, google_subject, created_at)
+	                              VALUES ($1, $2, 'Test', $1, now()) ON CONFLICT (id) DO NOTHING`,
+		userID, userID+"@example.com"); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM webhook_events WHERE user_id = $1`, userID)
+		_, _ = pool.Exec(ctx, `DELETE FROM users WHERE id = $1`, userID)
+	})
+
+	outbox := webhookpub.NewOutbox(pool, webhookpub.StaticFlag(true))
+	enq := &fakeFanOutSeamEnq{}
+	outbox.SetFanOutEnqueuer(enq)
+
+	event := webhookpub.Event{
+		ID:     webhookpub.DeterministicEventID("msg_seam_tx", webhookpub.EventEmailReceived),
+		Type:   webhookpub.EventEmailReceived,
+		UserID: userID,
+	}
+
+	// First publish: real insert → enqueue + stamp.
+	tx, _ := pool.Begin(ctx)
+	if err := outbox.PublishTx(ctx, tx, event); err != nil {
+		_ = tx.Rollback(ctx)
+		t.Fatalf("PublishTx: %v", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	if len(enq.ids) != 1 || enq.ids[0] != event.ID {
+		t.Fatalf("enqueued ids = %v, want [%s]", enq.ids, event.ID)
+	}
+	var jobID *int64
+	if err := pool.QueryRow(ctx, `SELECT fanout_job_id FROM webhook_events WHERE id = $1`, event.ID).Scan(&jobID); err != nil {
+		t.Fatalf("read fanout_job_id: %v", err)
+	}
+	if jobID == nil {
+		t.Errorf("fanout_job_id = nil, want stamped")
+	}
+
+	// Second publish of the SAME id: ON CONFLICT no-op → inserted=false → no enqueue.
+	tx2, _ := pool.Begin(ctx)
+	if err := outbox.PublishTx(ctx, tx2, event); err != nil {
+		_ = tx2.Rollback(ctx)
+		t.Fatalf("PublishTx (dedup): %v", err)
+	}
+	if err := tx2.Commit(ctx); err != nil {
+		t.Fatalf("commit (dedup): %v", err)
+	}
+	if len(enq.ids) != 1 {
+		t.Errorf("after dedup re-publish, enqueue calls = %d, want 1", len(enq.ids))
+	}
+}
+
+// TestOutbox_Integration_PublishBestEffort_SavepointProtectsTx pins the load-bearing
+// guarantee: a fan-out enqueue FAILURE on the post-side-effect path must NOT poison the
+// caller's must-commit tx (SES already sent). The event row still commits; fanout_job_id
+// stays NULL for the reconciler to re-drive.
+func TestOutbox_Integration_PublishBestEffort_SavepointProtectsTx(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+
+	const userID = "u_fanout_seam_be"
+	if _, err := pool.Exec(ctx, `INSERT INTO users (id, email, name, google_subject, created_at)
+	                              VALUES ($1, $2, 'Test', $1, now()) ON CONFLICT (id) DO NOTHING`,
+		userID, userID+"@example.com"); err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, `DELETE FROM webhook_events WHERE user_id = $1`, userID)
+		_, _ = pool.Exec(ctx, `DELETE FROM users WHERE id = $1`, userID)
+	})
+
+	outbox := webhookpub.NewOutbox(pool, webhookpub.StaticFlag(true))
+	outbox.SetFanOutEnqueuer(&fakeFanOutSeamEnq{err: errors.New("river down")})
+
+	event := webhookpub.Event{
+		ID:     webhookpub.DeterministicEventID("msg_seam_be", webhookpub.EventEmailSent),
+		Type:   webhookpub.EventEmailSent,
+		UserID: userID,
+	}
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	// The enqueue will fail inside the savepoint; PublishBestEffortTx must swallow it.
+	wrote := outbox.PublishBestEffortTx(ctx, tx, event)
+	if !wrote {
+		t.Fatalf("PublishBestEffortTx wrote=false, want true (row written despite enqueue failure)")
+	}
+	// The caller's tx must still commit cleanly — the savepoint rollback left it usable.
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit after failed fan-out enqueue: %v (tx was poisoned — savepoint failed)", err)
+	}
+
+	// The event row is durably persisted with NO fan-out job — the reconciler's target.
+	var jobID *int64
+	var status string
+	if err := pool.QueryRow(ctx, `SELECT fanout_job_id, status FROM webhook_events WHERE id = $1`, event.ID).Scan(&jobID, &status); err != nil {
+		t.Fatalf("read event: %v (row missing → best-effort lost the event)", err)
+	}
+	if jobID != nil {
+		t.Errorf("fanout_job_id = %v, want nil (enqueue failed)", *jobID)
+	}
+	if status != "pending" {
+		t.Errorf("status = %q, want pending (reconciler re-drives)", status)
+	}
+}

--- a/internal/webhookpub/fanout_worker.go
+++ b/internal/webhookpub/fanout_worker.go
@@ -1,0 +1,248 @@
+package webhookpub
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+
+	"github.com/Mnexa-AI/e2a/internal/jobs"
+	"github.com/Mnexa-AI/e2a/internal/telemetry"
+)
+
+// FanOutArgs drives one webhook fan-out: match the event user's enabled webhooks,
+// insert the matching webhook_subscriber_deliveries rows, and enqueue their delivery
+// jobs. Carries only the event id — the worker re-reads the durable webhook_events row
+// (the three-layer pattern: the job is the trigger, the row is the source of truth),
+// so args stay tiny and a schema change to the event never invalidates enqueued jobs.
+//
+// This is the River replacement for the legacy webhookpub.OutboxWorker drain
+// (LISTEN/NOTIFY + poll + SKIP-LOCKED lease). See docs/design/webhook-fanout-river-migration.md.
+type FanOutArgs struct {
+	EventID string `json:"event_id"`
+}
+
+func (FanOutArgs) Kind() string { return "webhook_fan_out" }
+
+const (
+	// maxFanOutAttempts bounds River's retries of a fan-out job. Fan-out failures are
+	// transient (DB blip, identity read) — a handful of retries rides them out. A
+	// persistent failure (e.g. a matching bug) should surface as a discarded job, not
+	// retry forever the way the legacy pending-row poll did.
+	maxFanOutAttempts = 10
+
+	// fanOutReconcileInterval / fanOutReconcileBatch mirror the delivery reconciler:
+	// frequent + cheap (a partial index backs the status='pending' AND fanout_job_id
+	// IS NULL scan) and bounded per tick so a systemic enqueue failure can't be
+	// amplified by fanning the whole backlog every minute.
+	fanOutReconcileInterval = 1 * time.Minute
+	fanOutReconcileBatch    = 1000
+)
+
+// FanOutJobs is the webhook fan-out integration on the shared River client: a
+// jobs.Registrar (contributes FanOutWorker + the reconcile periodic) plus the
+// transactional enqueue entry point (EnqueueFanOutTx) that PublishTx /
+// PublishBestEffortTx call in the event's own tx. The shared client is injected via
+// SetEnqueuer after jobs.New builds it (two-phase wiring, same as webhookdelivery).
+type FanOutJobs struct {
+	pool          *pgxpool.Pool
+	identityStore identityReader
+	deliveryEnq   DeliveryEnqueuer
+	metrics       telemetry.Metrics
+	enq           jobs.Enqueuer
+}
+
+// NewFanOutJobs builds the integration with its dependencies (no client yet). pool
+// backs the reconciler's scan; deliveryEnq is the SAME delivery enqueuer the legacy
+// OutboxWorker uses — fan-out enqueues Layer-2→3 delivery jobs exactly as before.
+func NewFanOutJobs(pool *pgxpool.Pool, identityStore identityReader, deliveryEnq DeliveryEnqueuer, metrics telemetry.Metrics) *FanOutJobs {
+	if metrics == nil {
+		metrics = telemetry.NoOp{}
+	}
+	return &FanOutJobs{pool: pool, identityStore: identityStore, deliveryEnq: deliveryEnq, metrics: metrics}
+}
+
+// SetEnqueuer injects the shared client so EnqueueFanOutTx can insert fan-out jobs.
+func (j *FanOutJobs) SetEnqueuer(e jobs.Enqueuer) { j.enq = e }
+
+// RegisterJobs adds the FanOutWorker + the reconcile worker and returns the reconcile
+// periodic. Implements jobs.Registrar.
+func (j *FanOutJobs) RegisterJobs(w *river.Workers) []*river.PeriodicJob {
+	river.AddWorker(w, &FanOutWorker{pool: j.pool, identityStore: j.identityStore, deliveryEnq: j.deliveryEnq, metrics: j.metrics})
+	river.AddWorker(w, &FanOutReconcileWorker{jobs: j})
+	return []*river.PeriodicJob{
+		river.NewPeriodicJob(
+			river.PeriodicInterval(fanOutReconcileInterval),
+			func() (river.JobArgs, *river.InsertOpts) {
+				return FanOutReconcileArgs{}, &river.InsertOpts{Queue: jobs.QueueMaintenance}
+			},
+			&river.PeriodicJobOpts{RunOnStart: false},
+		),
+	}
+}
+
+// EnqueueFanOutTx enqueues a fan-out job WITHIN the caller's transaction — the outbox
+// pattern between Layer 1 (webhook_events) and its fan-out: the event-row write and
+// this job commit together, so a pending event can never exist without a job (modulo
+// the best-effort publish path, which the reconciler backstops). Returns the river_job
+// id for the caller to stamp on webhook_events.fanout_job_id. Routed to QueueWebhook.
+func (j *FanOutJobs) EnqueueFanOutTx(ctx context.Context, tx pgx.Tx, eventID string) (int64, error) {
+	res, err := j.enq.InsertTx(ctx, tx, FanOutArgs{EventID: eventID}, &river.InsertOpts{
+		Queue:       jobs.QueueWebhook,
+		MaxAttempts: maxFanOutAttempts,
+	})
+	if err != nil {
+		return 0, err
+	}
+	return res.Job.ID, nil
+}
+
+// FanOutWorker fans out one webhook_events row on River, replacing the legacy
+// OutboxWorker drain. It re-reads the event by id, skips it if it is gone (30d GC) or
+// no longer 'pending' (a duplicate at-least-once job — already fanned out), and
+// otherwise runs the shared fanOutEventCore. Idempotent: the (event_id, webhook_id)
+// unique index dedups delivery-row inserts and the status='pending' guard on the
+// terminal UPDATE makes a re-run a no-op.
+type FanOutWorker struct {
+	river.WorkerDefaults[FanOutArgs]
+	pool          *pgxpool.Pool
+	identityStore identityReader
+	deliveryEnq   DeliveryEnqueuer
+	metrics       telemetry.Metrics
+}
+
+// NewFanOutWorker builds a FanOutWorker. RegisterJobs builds an identical one for the
+// client; this is exported so tests can drive Work directly without a River client.
+func NewFanOutWorker(pool *pgxpool.Pool, identityStore identityReader, deliveryEnq DeliveryEnqueuer, metrics telemetry.Metrics) *FanOutWorker {
+	if metrics == nil {
+		metrics = telemetry.NoOp{}
+	}
+	return &FanOutWorker{pool: pool, identityStore: identityStore, deliveryEnq: deliveryEnq, metrics: metrics}
+}
+
+func (w *FanOutWorker) Work(ctx context.Context, job *river.Job[FanOutArgs]) error {
+	ev, err := loadEventForFanOut(ctx, w.pool, job.Args.EventID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil // event GC'd (30d retention) before fan-out — nothing to do
+		}
+		return err
+	}
+	if ev.status != "pending" {
+		return nil // already fanned out (processed/no_match) — idempotent re-run
+	}
+	return fanOutEventCore(ctx, w.pool, w.identityStore, w.deliveryEnq, w.metrics, ev.leasedEvent)
+}
+
+// Timeout bounds a fan-out job. It is a handful of queries + N inserts — never the long
+// synchronous drain the janitor's 60s-cut hazard came from — but a bounded timeout
+// keeps a pathologically slow DB from pinning a QueueWebhook worker indefinitely.
+func (w *FanOutWorker) Timeout(*river.Job[FanOutArgs]) time.Duration { return 2 * time.Minute }
+
+// loadedEvent is a leasedEvent plus its current status, for the fan-out re-read.
+type loadedEvent struct {
+	leasedEvent
+	status string
+}
+
+// loadEventForFanOut re-reads the columns fanOutEventCore needs from webhook_events by
+// id, plus status for the idempotency guard. Returns pgx.ErrNoRows if the row is gone.
+func loadEventForFanOut(ctx context.Context, pool *pgxpool.Pool, eventID string) (loadedEvent, error) {
+	var ev loadedEvent
+	err := pool.QueryRow(ctx,
+		`SELECT id, user_id, type, envelope, agent_id, conversation_id, message_id, status
+		   FROM webhook_events WHERE id = $1`,
+		eventID,
+	).Scan(&ev.id, &ev.userID, &ev.eventType, &ev.envelope,
+		&ev.agentID, &ev.conversationID, &ev.messageID, &ev.status)
+	if err != nil {
+		return loadedEvent{}, err
+	}
+	return ev, nil
+}
+
+// FanOutReconcileArgs drives the periodic stranded-event reconciler.
+type FanOutReconcileArgs struct{}
+
+func (FanOutReconcileArgs) Kind() string { return "webhook_fanout_reconcile" }
+
+// FanOutReconcileWorker re-enqueues any pending event with no fan-out job. It is the
+// LIVE backstop for the best-effort publish path (PublishBestEffortTx must not fail the
+// caller's tx, so an event can commit with its enqueue lost) and any crash window
+// between the event commit and the job insert — turning "recovered only on restart"
+// into "recovered within fanOutReconcileInterval". Idempotent (fanout_job_id IS NULL
+// guard). Mirrors webhookdelivery.ReconcileWorker.
+type FanOutReconcileWorker struct {
+	river.WorkerDefaults[FanOutReconcileArgs]
+	jobs *FanOutJobs
+}
+
+func (w *FanOutReconcileWorker) Work(ctx context.Context, _ *river.Job[FanOutReconcileArgs]) error {
+	n, err := w.jobs.ReconcilePending(ctx, w.jobs.pool)
+	if err != nil {
+		return err // River retries the reconcile job — a transient DB blip is fine
+	}
+	if n > 0 {
+		log.Printf("[webhook-fanout-reconcile] re-enqueued %d stranded events", n)
+	}
+	return nil
+}
+
+// ReconcilePending enqueues a fan-out job for every pending webhook_events row with no
+// job yet (fanout_job_id IS NULL). Runs at startup (cutover) AND on the live schedule
+// (FanOutReconcileWorker). Idempotent: the per-row FOR UPDATE + fanout_job_id IS NULL
+// guard means a re-run (or a concurrent replica) never double-enqueues. Returns the
+// number of events enqueued.
+func (j *FanOutJobs) ReconcilePending(ctx context.Context, pool *pgxpool.Pool) (int, error) {
+	rows, err := pool.Query(ctx,
+		`SELECT id FROM webhook_events WHERE status='pending' AND fanout_job_id IS NULL LIMIT $1`, fanOutReconcileBatch)
+	if err != nil {
+		return 0, err
+	}
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		ids = append(ids, id)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return 0, err
+	}
+
+	n := 0
+	for _, id := range ids {
+		if err := pgx.BeginFunc(ctx, pool, func(tx pgx.Tx) error {
+			// Re-check under a row lock: another process (or a prior run) may have
+			// enqueued it already. Skip if fanout_job_id is now set.
+			var jobID *int64
+			if err := tx.QueryRow(ctx,
+				`SELECT fanout_job_id FROM webhook_events WHERE id=$1 FOR UPDATE`, id,
+			).Scan(&jobID); err != nil {
+				return err
+			}
+			if jobID != nil {
+				return nil // already enqueued
+			}
+			newJobID, err := j.EnqueueFanOutTx(ctx, tx, id)
+			if err != nil {
+				return err
+			}
+			_, err = tx.Exec(ctx, `UPDATE webhook_events SET fanout_job_id=$2 WHERE id=$1`, id, newJobID)
+			if err == nil {
+				n++
+			}
+			return err
+		}); err != nil {
+			log.Printf("[webhook-fanout-reconcile] enqueue %s: %v", id, err)
+		}
+	}
+	return n, nil
+}

--- a/internal/webhookpub/fanout_worker_integration_test.go
+++ b/internal/webhookpub/fanout_worker_integration_test.go
@@ -1,0 +1,230 @@
+package webhookpub_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+	"github.com/Mnexa-AI/e2a/internal/webhookpub"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
+)
+
+// fakeFanOutEnq is a jobs.Enqueuer that records the FanOutArgs it was asked to enqueue
+// and hands back monotonic job ids — no real River client needed. Mirrors the
+// inboundprocess reconcile fake.
+type fakeFanOutEnq struct {
+	mu   sync.Mutex
+	n    int64
+	args []webhookpub.FanOutArgs
+}
+
+func (f *fakeFanOutEnq) Insert(_ context.Context, args river.JobArgs, _ *river.InsertOpts) (*rivertype.JobInsertResult, error) {
+	return f.record(args)
+}
+
+func (f *fakeFanOutEnq) InsertTx(_ context.Context, _ pgx.Tx, args river.JobArgs, _ *river.InsertOpts) (*rivertype.JobInsertResult, error) {
+	return f.record(args)
+}
+
+func (f *fakeFanOutEnq) record(args river.JobArgs) (*rivertype.JobInsertResult, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.n++
+	if fa, ok := args.(webhookpub.FanOutArgs); ok {
+		f.args = append(f.args, fa)
+	}
+	return &rivertype.JobInsertResult{Job: &rivertype.JobRow{ID: f.n}}, nil
+}
+
+// seedPendingEvent inserts a pending webhook_events row of the given type and returns
+// its id. Mirrors the worker_integration_test seeding.
+func seedPendingEvent(t *testing.T, ctx context.Context, pool *pgxpool.Pool, userID, msgKey, eventType string) string {
+	t.Helper()
+	eventID := webhookpub.DeterministicEventID(msgKey, eventType)
+	env, _ := json.Marshal(webhookpub.Envelope{Type: eventType, ID: eventID, CreatedAt: time.Now().UTC()})
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO webhook_events (id, user_id, type, envelope, status) VALUES ($1, $2, $3, $4, 'pending')`,
+		eventID, userID, eventType, env); err != nil {
+		t.Fatalf("seed event: %v", err)
+	}
+	return eventID
+}
+
+// cleanupWebhookFixture tears down the chain seeded by seedWebhookFixture plus any
+// events/deliveries the fan-out tests created.
+func cleanupWebhookFixture(ctx context.Context, pool *pgxpool.Pool, userID, webhookID string) {
+	_, _ = pool.Exec(ctx, `DELETE FROM webhook_subscriber_deliveries WHERE webhook_id = $1`, webhookID)
+	_, _ = pool.Exec(ctx, `DELETE FROM webhook_events WHERE user_id = $1`, userID)
+	_, _ = pool.Exec(ctx, `DELETE FROM webhooks WHERE id = $1`, webhookID)
+	_, _ = pool.Exec(ctx, `DELETE FROM agent_identities WHERE user_id = $1`, userID)
+	_, _ = pool.Exec(ctx, `DELETE FROM domains WHERE user_id = $1`, userID)
+	_, _ = pool.Exec(ctx, `DELETE FROM users WHERE id = $1`, userID)
+}
+
+// TestFanOutWorker_Integration_FansOutAndEnqueues drives the River FanOutWorker over a
+// pending event: it inserts the Layer 2 delivery row, enqueues its delivery job in the
+// same tx (job_id stamped), and marks the event 'processed'. A second Work on the now-
+// processed event is a no-op (idempotent re-run) — no duplicate enqueue.
+func TestFanOutWorker_Integration_FansOutAndEnqueues(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	userID, _, webhookID := seedWebhookFixture(t, ctx, pool, store, "fo_enq")
+	t.Cleanup(func() { cleanupWebhookFixture(ctx, pool, userID, webhookID) })
+
+	eventID := seedPendingEvent(t, ctx, pool, userID, "msg_fo_1", webhookpub.EventEmailReceived)
+
+	enq := &fakeDeliveryEnqueuer{}
+	w := webhookpub.NewFanOutWorker(pool, store, enq, nil)
+	if err := w.Work(ctx, &river.Job[webhookpub.FanOutArgs]{Args: webhookpub.FanOutArgs{EventID: eventID}}); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+
+	var deliveryID string
+	var jobID *int64
+	if err := pool.QueryRow(ctx,
+		`SELECT id, job_id FROM webhook_subscriber_deliveries WHERE event_id = $1 AND webhook_id = $2`,
+		eventID, webhookID,
+	).Scan(&deliveryID, &jobID); err != nil {
+		t.Fatalf("read delivery: %v", err)
+	}
+	if len(enq.ids) != 1 || enq.ids[0] != deliveryID {
+		t.Fatalf("enqueued ids = %v, want [%s]", enq.ids, deliveryID)
+	}
+	if jobID == nil || *jobID != 1 {
+		t.Errorf("job_id = %v, want 1 (stamped from the enqueue)", jobID)
+	}
+
+	var status string
+	var matched []string
+	if err := pool.QueryRow(ctx,
+		`SELECT status, matched_webhook_ids FROM webhook_events WHERE id = $1`, eventID,
+	).Scan(&status, &matched); err != nil {
+		t.Fatalf("read event: %v", err)
+	}
+	if status != "processed" {
+		t.Errorf("status = %q, want processed", status)
+	}
+	if len(matched) != 1 || matched[0] != webhookID {
+		t.Errorf("matched_webhook_ids = %v, want [%s]", matched, webhookID)
+	}
+
+	// Idempotent re-run: the event is 'processed' now, so Work is a no-op — no second
+	// enqueue, status unchanged.
+	if err := w.Work(ctx, &river.Job[webhookpub.FanOutArgs]{Args: webhookpub.FanOutArgs{EventID: eventID}}); err != nil {
+		t.Fatalf("Work (re-run): %v", err)
+	}
+	if len(enq.ids) != 1 {
+		t.Errorf("after re-run, enqueue calls = %d, want 1 (idempotent)", len(enq.ids))
+	}
+}
+
+// TestFanOutWorker_Integration_NoMatch: an event whose type no enabled webhook
+// subscribes to transitions to 'no_match' with zero deliveries and zero enqueues.
+func TestFanOutWorker_Integration_NoMatch(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	// The fixture's webhook subscribes to email.received only.
+	userID, _, webhookID := seedWebhookFixture(t, ctx, pool, store, "fo_nomatch")
+	t.Cleanup(func() { cleanupWebhookFixture(ctx, pool, userID, webhookID) })
+
+	eventID := seedPendingEvent(t, ctx, pool, userID, "msg_fo_nm", webhookpub.EventEmailSent)
+
+	enq := &fakeDeliveryEnqueuer{}
+	w := webhookpub.NewFanOutWorker(pool, store, enq, nil)
+	if err := w.Work(ctx, &river.Job[webhookpub.FanOutArgs]{Args: webhookpub.FanOutArgs{EventID: eventID}}); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+
+	var status string
+	if err := pool.QueryRow(ctx, `SELECT status FROM webhook_events WHERE id = $1`, eventID).Scan(&status); err != nil {
+		t.Fatalf("read event: %v", err)
+	}
+	if status != "no_match" {
+		t.Errorf("status = %q, want no_match", status)
+	}
+	var n int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM webhook_subscriber_deliveries WHERE event_id = $1`, eventID).Scan(&n); err != nil {
+		t.Fatalf("count deliveries: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("deliveries = %d, want 0", n)
+	}
+	if len(enq.ids) != 0 {
+		t.Errorf("enqueue calls = %d, want 0", len(enq.ids))
+	}
+}
+
+// TestFanOutWorker_Integration_EventGoneReturnsNil: a job for an event that no longer
+// exists (30d GC before fan-out) returns nil — nothing to do, not an error to retry.
+func TestFanOutWorker_Integration_EventGoneReturnsNil(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	w := webhookpub.NewFanOutWorker(pool, store, &fakeDeliveryEnqueuer{}, nil)
+	err := w.Work(ctx, &river.Job[webhookpub.FanOutArgs]{Args: webhookpub.FanOutArgs{EventID: "evt_does_not_exist"}})
+	if err != nil {
+		t.Errorf("Work on missing event = %v, want nil", err)
+	}
+}
+
+// TestFanOutJobs_Integration_ReconcilePending: a pending event with no fan-out job is
+// re-enqueued and its fanout_job_id stamped; a re-run does not double-enqueue it.
+func TestFanOutJobs_Integration_ReconcilePending(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	userID, _, webhookID := seedWebhookFixture(t, ctx, pool, store, "fo_recon")
+	t.Cleanup(func() { cleanupWebhookFixture(ctx, pool, userID, webhookID) })
+
+	eventID := seedPendingEvent(t, ctx, pool, userID, "msg_fo_rc", webhookpub.EventEmailReceived)
+
+	enq := &fakeFanOutEnq{}
+	j := webhookpub.NewFanOutJobs(pool, store, &fakeDeliveryEnqueuer{}, nil)
+	j.SetEnqueuer(enq)
+
+	if _, err := j.ReconcilePending(ctx, pool); err != nil {
+		t.Fatalf("ReconcilePending: %v", err)
+	}
+
+	// Our event got a job stamped and the fake saw its id.
+	var jobID *int64
+	if err := pool.QueryRow(ctx, `SELECT fanout_job_id FROM webhook_events WHERE id = $1`, eventID).Scan(&jobID); err != nil {
+		t.Fatalf("read fanout_job_id: %v", err)
+	}
+	if jobID == nil {
+		t.Fatalf("fanout_job_id = nil, want stamped after reconcile")
+	}
+	var sawOurs bool
+	for _, a := range enq.args {
+		if a.EventID == eventID {
+			sawOurs = true
+		}
+	}
+	if !sawOurs {
+		t.Errorf("reconcile did not enqueue a fan-out job for %s", eventID)
+	}
+
+	// Re-run: our event now has a job, so the fanout_job_id IS NULL guard skips it.
+	before := len(enq.args)
+	if _, err := j.ReconcilePending(ctx, pool); err != nil {
+		t.Fatalf("ReconcilePending (re-run): %v", err)
+	}
+	for _, a := range enq.args[before:] {
+		if a.EventID == eventID {
+			t.Errorf("re-run re-enqueued already-stamped event %s", eventID)
+		}
+	}
+}

--- a/internal/webhookpub/outbox.go
+++ b/internal/webhookpub/outbox.go
@@ -63,6 +63,21 @@ type Outbox interface {
 	// no-ops when false. Retained as a seam; there is no longer a legacy
 	// fan-out path to fall back to.
 	Enabled() bool
+
+	// SetFanOutEnqueuer wires the River fan-out enqueuer (two-phase, called after the
+	// shared client exists). When set (E2A_WEBHOOK_FANOUT_MODE=river), PublishTx /
+	// PublishBestEffortTx enqueue a webhook_fan_out job in the event's own tx and stamp
+	// fanout_job_id — the River FanOutWorker then does the fan-out, replacing the
+	// legacy in-process OutboxWorker drain. nil (default/legacy) ⇒ the event row is
+	// written as before and the OutboxWorker fans it out via LISTEN/NOTIFY + poll.
+	SetFanOutEnqueuer(e FanOutEnqueuer)
+}
+
+// FanOutEnqueuer enqueues a webhook fan-out job within the caller's transaction and
+// returns the river_job id. *FanOutJobs satisfies it. Injected (not imported) so the
+// outbox writer stays decoupled from the River wiring — mirrors DeliveryEnqueuer.
+type FanOutEnqueuer interface {
+	EnqueueFanOutTx(ctx context.Context, tx pgx.Tx, eventID string) (int64, error)
 }
 
 // outboxExecutor is the subset of pgx.Tx and pgxpool.Pool needed by
@@ -75,8 +90,9 @@ type outboxExecutor interface {
 
 // outbox is the production Outbox backed by a pgxpool.
 type outbox struct {
-	pool *pgxpool.Pool
-	flag FeatureFlag
+	pool      *pgxpool.Pool
+	flag      FeatureFlag
+	fanoutEnq FanOutEnqueuer // nil ⇒ legacy OutboxWorker drain; set ⇒ River fan-out
 }
 
 // NewOutbox constructs the Stripe-tier outbox writer. The FeatureFlag
@@ -94,7 +110,60 @@ func (o *outbox) PublishTx(ctx context.Context, tx pgx.Tx, e Event) error {
 	if !o.flag.Enabled() {
 		return nil
 	}
-	return writeOutboxRow(ctx, tx, e)
+	inserted, err := writeOutboxRow(ctx, tx, e)
+	if err != nil {
+		return err
+	}
+	// Pre-side-effect trigger: the fan-out enqueue rides the SAME tx, and an enqueue
+	// failure MUST fail the whole tx so the trigger retries with the (deterministic)
+	// event id — no side effect has happened yet, so a rollback loses nothing. Only on
+	// a real insert: a deduped retry (ON CONFLICT no-op) already has its fan-out job.
+	if inserted {
+		return o.enqueueFanOutTx(ctx, tx, e.ID)
+	}
+	return nil
+}
+
+// SetFanOutEnqueuer implements Outbox — see the interface doc.
+func (o *outbox) SetFanOutEnqueuer(e FanOutEnqueuer) { o.fanoutEnq = e }
+
+// enqueueFanOutTx enqueues the fan-out job in the caller's tx and stamps fanout_job_id.
+// Returns any error to the caller (the pre-side-effect path rolls the tx back on it).
+// No-op when the fan-out enqueuer is unset (legacy mode) — the OutboxWorker drains.
+func (o *outbox) enqueueFanOutTx(ctx context.Context, tx pgx.Tx, eventID string) error {
+	if o.fanoutEnq == nil {
+		return nil
+	}
+	jobID, err := o.fanoutEnq.EnqueueFanOutTx(ctx, tx, eventID)
+	if err != nil {
+		return err
+	}
+	_, err = tx.Exec(ctx, `UPDATE webhook_events SET fanout_job_id = $2 WHERE id = $1`, eventID, jobID)
+	return err
+}
+
+// enqueueFanOutBestEffort does the same inside a SAVEPOINT so a failure can't poison
+// the caller's must-commit tx (the post-side-effect path — SES already sent). On any
+// error it rolls back to the savepoint and logs, leaving the event row committed
+// without a job for the fan-out reconciler (fanout_job_id IS NULL) to re-drive within
+// a minute.
+func (o *outbox) enqueueFanOutBestEffort(ctx context.Context, tx pgx.Tx, eventID string) {
+	if o.fanoutEnq == nil {
+		return
+	}
+	sp, err := tx.Begin(ctx) // pgx nested tx == SAVEPOINT
+	if err != nil {
+		log.Printf("[outbox] fan-out savepoint begin (event=%s): %v — reconciler will re-drive", eventID, err)
+		return
+	}
+	if err := o.enqueueFanOutTx(ctx, sp, eventID); err != nil {
+		_ = sp.Rollback(ctx) // ROLLBACK TO SAVEPOINT — the caller's tx stays intact
+		log.Printf("[outbox] fan-out enqueue (event=%s): %v — reconciler will re-drive", eventID, err)
+		return
+	}
+	if err := sp.Commit(ctx); err != nil { // RELEASE SAVEPOINT
+		log.Printf("[outbox] fan-out savepoint release (event=%s): %v — reconciler will re-drive", eventID, err)
+	}
 }
 
 // Enabled mirrors the flag state. Trigger sites check this to suppress
@@ -156,7 +225,8 @@ func (o *outbox) PublishBestEffortTx(ctx context.Context, tx pgx.Tx, e Event) (w
 	if !o.flag.Enabled() {
 		return false
 	}
-	if err := writeOutboxRow(ctx, tx, e); err != nil {
+	inserted, err := writeOutboxRow(ctx, tx, e)
+	if err != nil {
 		// Best-effort: log and return wrote=false. The caller's tx
 		// commits the business state regardless because the
 		// irreversible action (SES.Send) already happened — rolling
@@ -167,6 +237,12 @@ func (o *outbox) PublishBestEffortTx(ctx context.Context, tx pgx.Tx, e Event) (w
 		log.Printf("[outbox] PublishBestEffortTx err (event=%s type=%s): %v", e.ID, e.Type, err)
 		return false
 	}
+	// Post-side-effect trigger: the fan-out enqueue must NEVER fail the caller's tx (a
+	// rollback would orphan a sent email), so it rides a savepoint — a failure re-drives
+	// via the reconciler, not by losing the send. Only on a real insert.
+	if inserted {
+		o.enqueueFanOutBestEffort(ctx, tx, e.ID)
+	}
 	return true
 }
 
@@ -174,20 +250,20 @@ func (o *outbox) PublishBestEffortTx(ctx context.Context, tx pgx.Tx, e Event) (w
 // PublishBestEffortTx. Idempotent on (id): a retried trigger with the
 // same deterministic id no-ops the second INSERT. Issues pg_notify so
 // the slice-2 worker wakes immediately on commit.
-func writeOutboxRow(ctx context.Context, exec outboxExecutor, e Event) error {
+func writeOutboxRow(ctx context.Context, exec outboxExecutor, e Event) (inserted bool, err error) {
 	if e.ID == "" {
-		return fmt.Errorf("webhookpub: outbox event must have non-empty ID")
+		return false, fmt.Errorf("webhookpub: outbox event must have non-empty ID")
 	}
 	if e.UserID == "" {
-		return fmt.Errorf("webhookpub: outbox event must have non-empty UserID")
+		return false, fmt.Errorf("webhookpub: outbox event must have non-empty UserID")
 	}
 	if e.Type == "" {
-		return fmt.Errorf("webhookpub: outbox event must have non-empty Type")
+		return false, fmt.Errorf("webhookpub: outbox event must have non-empty Type")
 	}
 
 	envelopeJSON, err := json.Marshal(e.AsEnvelope())
 	if err != nil {
-		return fmt.Errorf("webhookpub: marshal envelope: %w", err)
+		return false, fmt.Errorf("webhookpub: marshal envelope: %w", err)
 	}
 
 	var messageID *string
@@ -209,7 +285,7 @@ func writeOutboxRow(ctx context.Context, exec outboxExecutor, e Event) error {
 	// created_at and expires_at use the column DEFAULTs so the
 	// timestamps come from the Postgres server clock (one clock per
 	// primary writer; no application-side skew).
-	_, err = exec.Exec(ctx,
+	tag, err := exec.Exec(ctx,
 		`INSERT INTO webhook_events
 		    (id, user_id, type, aud, envelope, schema_version,
 		     agent_id, conversation_id, message_id, status)
@@ -219,8 +295,12 @@ func writeOutboxRow(ctx context.Context, exec outboxExecutor, e Event) error {
 		agentID, conversationID, messageID,
 	)
 	if err != nil {
-		return fmt.Errorf("webhookpub: insert webhook_events: %w", err)
+		return false, fmt.Errorf("webhookpub: insert webhook_events: %w", err)
 	}
+	// RowsAffected is 1 on a real insert, 0 when ON CONFLICT skipped a duplicate
+	// (deterministic-id retry). The caller enqueues a fan-out job only on a real
+	// insert — a deduped event already has one.
+	inserted = tag.RowsAffected() > 0
 
 	// pg_notify is best-effort: NOTIFY only fires on COMMIT (Postgres
 	// queues it). If COMMIT fails, no notification is emitted. The
@@ -245,7 +325,7 @@ func writeOutboxRow(ctx context.Context, exec outboxExecutor, e Event) error {
 		log.Printf("[outbox] pg_notify webhook_events_new failed (event=%s, type=%s): %v — worker fallback poll will recover",
 			e.ID, e.Type, nerr)
 	}
-	return nil
+	return inserted, nil
 }
 
 // Time helpers — kept here rather than relying on time.Now() in

--- a/internal/webhookpub/outbox_test.go
+++ b/internal/webhookpub/outbox_test.go
@@ -82,7 +82,7 @@ func (f *fakeExec) Exec(ctx context.Context, sql string, args ...any) (pgconn.Co
 
 func TestWriteOutboxRow_RejectsEmptyID(t *testing.T) {
 	fe := &fakeExec{}
-	err := writeOutboxRow(context.Background(), fe, Event{UserID: "u1", Type: "email.received"})
+	_, err := writeOutboxRow(context.Background(), fe, Event{UserID: "u1", Type: "email.received"})
 	if err == nil {
 		t.Fatalf("expected error on empty ID")
 	}
@@ -96,7 +96,7 @@ func TestWriteOutboxRow_RejectsEmptyID(t *testing.T) {
 
 func TestWriteOutboxRow_RejectsEmptyUserID(t *testing.T) {
 	fe := &fakeExec{}
-	err := writeOutboxRow(context.Background(), fe, Event{ID: "evt_abc", Type: "email.received"})
+	_, err := writeOutboxRow(context.Background(), fe, Event{ID: "evt_abc", Type: "email.received"})
 	if err == nil {
 		t.Fatalf("expected error on empty UserID")
 	}
@@ -104,7 +104,7 @@ func TestWriteOutboxRow_RejectsEmptyUserID(t *testing.T) {
 
 func TestWriteOutboxRow_RejectsEmptyType(t *testing.T) {
 	fe := &fakeExec{}
-	err := writeOutboxRow(context.Background(), fe, Event{ID: "evt_abc", UserID: "u1"})
+	_, err := writeOutboxRow(context.Background(), fe, Event{ID: "evt_abc", UserID: "u1"})
 	if err == nil {
 		t.Fatalf("expected error on empty Type")
 	}
@@ -136,7 +136,7 @@ func TestWriteOutboxRow_PgNotifyFailureIsSoft(t *testing.T) {
 		Type:   EventEmailReceived,
 		UserID: "u_42",
 	}
-	if err := writeOutboxRow(context.Background(), fe, e); err != nil {
+	if _, err := writeOutboxRow(context.Background(), fe, e); err != nil {
 		t.Fatalf("writeOutboxRow should swallow pg_notify failure, got: %v", err)
 	}
 	// Both Exec calls must have been attempted — the INSERT first, then
@@ -168,7 +168,7 @@ func TestWriteOutboxRow_InsertFailureStillPropagates(t *testing.T) {
 		Type:   EventEmailReceived,
 		UserID: "u_42",
 	}
-	err := writeOutboxRow(context.Background(), fe, e)
+	_, err := writeOutboxRow(context.Background(), fe, e)
 	if err == nil {
 		t.Fatalf("INSERT failure must propagate to caller; got nil error")
 	}
@@ -194,7 +194,7 @@ func TestWriteOutboxRow_HappyPath_TwoExecCalls(t *testing.T) {
 		MessageID:      "msg_y",
 		Data:           map[string]any{"hello": "world"},
 	}
-	if err := writeOutboxRow(context.Background(), fe, e); err != nil {
+	if _, err := writeOutboxRow(context.Background(), fe, e); err != nil {
 		t.Fatalf("writeOutboxRow err: %v", err)
 	}
 	if len(fe.calls) != 2 {
@@ -221,7 +221,7 @@ func TestWriteOutboxRow_NilsEmptyOptionals(t *testing.T) {
 		UserID: "u_42",
 		// AgentID, ConversationID, MessageID all empty
 	}
-	if err := writeOutboxRow(context.Background(), fe, e); err != nil {
+	if _, err := writeOutboxRow(context.Background(), fe, e); err != nil {
 		t.Fatalf("writeOutboxRow err: %v", err)
 	}
 	if len(fe.args) < 1 || len(fe.args[0]) < 7 {

--- a/internal/webhookpub/worker.go
+++ b/internal/webhookpub/worker.go
@@ -325,14 +325,36 @@ func (w *OutboxWorker) leasePending(ctx context.Context) ([]leasedEvent, error) 
 // apply filter matching, insert delivery rows, mark outbox row
 // processed — all in one transaction so partial fan-out is impossible.
 func (w *OutboxWorker) fanOutOne(ctx context.Context, ev leasedEvent) {
-	webhooks, err := w.identityStore.ListEnabledWebhooksForRouting(ctx, ev.userID, ev.eventType)
+	// The fan-out body is shared with the River FanOutWorker (fanout_worker.go) via
+	// fanOutEventCore. The legacy worker maps a failure to recordFailure — the event
+	// row stays 'pending' and the next lease retries; the River worker returns the
+	// error for River to retry. Behavior here is unchanged from before the extraction:
+	// the failure metrics are emitted inside the core at the same points and with the
+	// same labels, so recordFailure remains the only thing this wrapper adds.
+	if err := fanOutEventCore(ctx, w.pool, w.identityStore, w.enqueuer, w.metrics, ev); err != nil {
+		w.recordFailure(ctx, ev.id, err.Error())
+	}
+}
+
+// fanOutEventCore fans out a single loaded event in ONE transaction: match the user's
+// enabled subscribers, insert one webhook_subscriber_deliveries row per match (ON
+// CONFLICT dedup), enqueue a River delivery job per real insert, and mark the event
+// row terminal (processed/no_match) under a status='pending' guard so a concurrent
+// finisher (an expired-lease replica, or a duplicate at-least-once River job) can't be
+// clobbered. Returns an error instead of recording failure so both the legacy
+// OutboxWorker and the River FanOutWorker share the exact same body.
+//
+// Failure-metric parity with the pre-extraction fanOutOne: a list-subscribers error
+// records NO OutboxFailures label (it only wraps the message, which recordFailure then
+// logs); a tx error emits OutboxFailures("update_status"). Callers add their own
+// recovery on top (recordFailure for the legacy poll, River retry for the worker).
+func fanOutEventCore(ctx context.Context, pool *pgxpool.Pool, identityStore identityReader, enqueuer DeliveryEnqueuer, metrics telemetry.Metrics, ev leasedEvent) error {
+	webhooks, err := identityStore.ListEnabledWebhooksForRouting(ctx, ev.userID, ev.eventType)
 	if err != nil {
-		w.recordFailure(ctx, ev.id, fmt.Sprintf("list subscribers: %v", err))
-		return
+		return fmt.Errorf("list subscribers: %w", err)
 	}
 
-	// Apply filter matching. Need to reconstruct an Event-shaped
-	// struct from the leasedEvent to feed `matches`.
+	// Reconstruct an Event-shaped struct from the leasedEvent to feed `matches`.
 	eventForMatching := Event{
 		Type:           ev.eventType,
 		UserID:         ev.userID,
@@ -342,37 +364,35 @@ func (w *OutboxWorker) fanOutOne(ctx context.Context, ev leasedEvent) {
 		MessageID: derefString(ev.messageID),
 	}
 
-	// matched starts as an empty slice (not nil) so pgx serializes it
-	// as the empty Postgres array '{}', not NULL. The column is
-	// matched_webhook_ids TEXT[] NOT NULL DEFAULT '{}' — a NULL would
-	// fail the NOT NULL constraint and the UPDATE would error.
+	// matched starts as an empty slice (not nil) so pgx serializes it as the empty
+	// Postgres array '{}', not NULL. matched_webhook_ids is TEXT[] NOT NULL DEFAULT
+	// '{}' — a NULL would fail the NOT NULL constraint and the UPDATE would error.
 	matched := make([]string, 0, len(webhooks))
-	for _, w := range webhooks {
-		if matches(eventForMatching, w.Filters) {
-			matched = append(matched, w.ID)
+	for _, wh := range webhooks {
+		if matches(eventForMatching, wh.Filters) {
+			matched = append(matched, wh.ID)
 		}
 	}
 
 	if len(matched) == 0 {
-		w.metrics.OutboxEventsNoMatch(ev.eventType)
+		metrics.OutboxEventsNoMatch(ev.eventType)
 	} else {
-		w.metrics.OutboxEventsFanOut(ev.eventType, len(matched))
+		metrics.OutboxEventsFanOut(ev.eventType, len(matched))
 	}
-	err = poolBeginFunc(ctx, w.pool, func(tx pgx.Tx) error {
+	if err := poolBeginFunc(ctx, pool, func(tx pgx.Tx) error {
 		if len(matched) > 0 {
 			inserted, err := insertPendingBatchTx(ctx, tx, ev.id, matched, ev.eventType, ev.messageID, ev.envelope)
 			if err != nil {
 				return err
 			}
-			// Enqueue a River delivery job for each row that ACTUALLY inserted
-			// (dedup no-ops are absent from `inserted`),
-			// in this same tx — the Layer 2 row and its job commit atomically, so
-			// there is never a record without a job, and a deduped event enqueues
-			// nothing. Stamp the row's job_id for the cutover discriminator +
-			// observability.
-			if w.enqueuer != nil {
+			// Enqueue a River delivery job for each row that ACTUALLY inserted (dedup
+			// no-ops are absent from `inserted`), in this same tx — the Layer 2 row and
+			// its job commit atomically, so there is never a record without a job, and a
+			// deduped event enqueues nothing. Stamp the row's job_id for the cutover
+			// discriminator + observability.
+			if enqueuer != nil {
 				for _, d := range inserted {
-					jobID, err := w.enqueuer.EnqueueDeliveryTx(ctx, tx, d)
+					jobID, err := enqueuer.EnqueueDeliveryTx(ctx, tx, d)
 					if err != nil {
 						return err
 					}
@@ -384,11 +404,10 @@ func (w *OutboxWorker) fanOutOne(ctx context.Context, ev leasedEvent) {
 				}
 			}
 		}
-		// Conditional UPDATE: if another worker already processed
-		// this event row (e.g. our lease expired during a long
-		// fan-out and replica B took over and finished), the
-		// status='pending' predicate matches zero rows and our
-		// UPDATE no-ops. Lease-vs-fanout race fix from §4.4.
+		// Conditional UPDATE: if another worker already processed this event row (our
+		// lease expired during a long fan-out and replica B took over and finished, or
+		// — under River — a duplicate at-least-once job ran), the status='pending'
+		// predicate matches zero rows and this UPDATE no-ops.
 		newStatus := "processed"
 		if len(matched) == 0 {
 			newStatus = "no_match"
@@ -400,11 +419,11 @@ func (w *OutboxWorker) fanOutOne(ctx context.Context, ev leasedEvent) {
 			newStatus, ev.id, matched,
 		)
 		return err
-	})
-	if err != nil {
-		w.recordFailure(ctx, ev.id, err.Error())
-		w.metrics.OutboxFailures("update_status")
+	}); err != nil {
+		metrics.OutboxFailures("update_status")
+		return err
 	}
+	return nil
 }
 
 // insertPendingBatchTx writes one webhook_subscriber_deliveries row

--- a/migrations/060_webhook_events_fanout_job.sql
+++ b/migrations/060_webhook_events_fanout_job.sql
@@ -1,0 +1,25 @@
+-- 060_webhook_events_fanout_job.sql
+--
+-- Webhook fan-out on River (docs/design/webhook-fanout-river-migration.md).
+--
+-- The fan-out step (webhook_events → webhook_subscriber_deliveries) is moving off the
+-- hand-rolled webhookpub.OutboxWorker (LISTEN/NOTIFY + poll + manual SKIP-LOCKED lease)
+-- onto a River job, mirroring the outbound accept-tx (send_job_id, 054) and the HITL
+-- notify accept-tx (notify_job_id, 057): the trigger that writes the webhook_events row
+-- also enqueues a webhook_fan_out job in the SAME transaction and stamps its id here, so
+-- the startup + periodic reconciler can find events stranded without a fan-out job
+-- (status='pending' AND fanout_job_id IS NULL).
+--
+-- Additive + idempotent. Nullable ADD COLUMN with no default is a metadata-only op on
+-- Postgres — safe on the traffic-scaled webhook_events table (same as 054/055/057).
+--
+-- No cutover UPDATE (unlike 057): this ships behind E2A_WEBHOOK_FANOUT_MODE=legacy, so
+-- until the flag flips, NOTHING enqueues fan-out jobs and fanout_job_id stays NULL on
+-- every row — the legacy OutboxWorker still drains them. The reconciler only re-drives
+-- pending rows once mode=river is enqueuing jobs; under legacy mode it is inert (the
+-- worker is not registered). See §Slice 2 of the design.
+--
+-- The reconciler's partial index is built CONCURRENTLY in migration 061 (a plain
+-- CREATE INDEX here would take a write lock on the whole webhook_events table at deploy).
+
+ALTER TABLE webhook_events ADD COLUMN IF NOT EXISTS fanout_job_id BIGINT;

--- a/migrations/061_webhook_events_fanout_job_idx.sql
+++ b/migrations/061_webhook_events_fanout_job_idx.sql
@@ -1,0 +1,29 @@
+-- 061_webhook_events_fanout_job_idx.sql
+-- e2a:no-transaction
+--
+-- Partial index backing the webhook fan-out reconciler
+-- (webhookfanout.ReconcilePending), which scans for pending events that never got a
+-- fan-out job (status='pending' AND fanout_job_id IS NULL). Almost always the empty
+-- set — the trigger's PublishTx/PublishBestEffortTx enqueues the fan-out job in-tx and
+-- stamps fanout_job_id atomically — so the partial index is tiny and the reconciler's
+-- scan is an index lookup instead of a full scan of the traffic-scaled webhook_events
+-- table. Mirrors idx_messages_pending_no_notify_job (058).
+--
+-- CREATE INDEX CONCURRENTLY so the build does not take a write lock on prod-sized
+-- webhook_events (a plain CREATE INDEX would block the outbox fan-out path — every
+-- inbound/outbound event write — for the full build). The e2a:no-transaction directive
+-- (see internal/identity/migrate.go) skips the BeginTx wrapper — required because
+-- Postgres rejects CONCURRENTLY inside a transaction block; the no-transaction runner
+-- requires a single statement. Split from 060 (which adds the column transactionally).
+--
+-- OPS NOTE — invalid-index recovery: if the CONCURRENTLY build is interrupted, Postgres
+-- leaves an INVALID index of this name. On the next startup this migration re-runs, but
+-- CREATE ... IF NOT EXISTS sees the name and SKIPS the rebuild, marking the migration
+-- applied over a broken index — the reconciler then falls back to a seq scan (a
+-- performance, not correctness, regression). To recover:
+--     DROP INDEX CONCURRENTLY IF EXISTS idx_webhook_events_pending_no_fanout_job;
+-- then re-run this statement. Check validity with:
+--     SELECT indisvalid FROM pg_index WHERE indexrelid = 'idx_webhook_events_pending_no_fanout_job'::regclass;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_webhook_events_pending_no_fanout_job
+    ON webhook_events (created_at)
+    WHERE status = 'pending' AND fanout_job_id IS NULL;


### PR DESCRIPTION
Migrates the webhook **fan-out** step (`webhook_events` → `webhook_subscriber_deliveries`) off the hand-rolled `webhookpub.OutboxWorker` (LISTEN/NOTIFY + poll + SKIP-LOCKED lease) onto River — the last bespoke durable background loop. Design: `docs/design/webhook-fanout-river-migration.md` (#398).

**Flag-gated: `E2A_WEBHOOK_FANOUT_MODE` (default `legacy`).** The legacy path is byte-for-byte unchanged until flipped. This is the complete implementation (schema + worker + wiring + reconciler); the cutover is an ops flag-flip and legacy deletion is a post-cutover follow-up.

## Schema (slice 0)
- **060**: `ADD COLUMN webhook_events.fanout_job_id` (additive, nullable).
- **061**: reconciler partial index `WHERE status='pending' AND fanout_job_id IS NULL`, `CONCURRENTLY`. Mirrors notify's 057/058.

## Worker (slice 1)
- `internal/webhookpub/fanout_worker.go`: `FanOutWorker` (re-reads the event by id; skips if gone or already `processed`/`no_match`; runs the shared `fanOutEventCore`), `FanOutJobs` registrar (`RegisterJobs` + `EnqueueFanOutTx` + reconcile periodic), `FanOutReconcileWorker` + `ReconcilePending`. Reuses the **existing** delivery enqueuer — Layer 2→3 delivery is untouched.
- Refactor: extracted `fanOutEventCore` from `OutboxWorker.fanOutOne` so legacy + River share one body. **Byte-for-byte behavior-preserving** (verified by the existing `OutboxWorker` tests).

## Enqueue seam + wiring (slice 2)
- `writeOutboxRow` now reports whether it truly inserted (`RowsAffected > 0` vs an `ON CONFLICT` dedup no-op) → a fan-out job is enqueued only on a real insert.
- **`PublishTx`** (pre-side-effect): enqueue + stamp `fanout_job_id` in the same tx; an enqueue error fails the whole tx (retryable — nothing sent yet).
- **`PublishBestEffortTx`** (post-side-effect, SES already sent): enqueue inside a **SAVEPOINT** so a failure can never poison the caller's must-commit tx — on error it rolls back to the savepoint, the event row commits without a job, and the reconciler re-drives it. Preserves the best-effort contract (a rollback would orphan a sent email).
- `cmd/e2a/main.go` (river mode only): register `FanOutJobs`, `SetEnqueuer` + `SetFanOutEnqueuer` after `jobs.New`, startup `ReconcilePending` cutover, and **do not start** the legacy `OutboxWorker`.

## Idempotency / cutover safety
The `(event_id, webhook_id)` unique index + `WHERE status='pending'` terminal-UPDATE guard (kept verbatim) make an at-least-once re-run a no-op — so a River duplicate, or a legacy/River race across cutover, is safe.

## Tests
- Worker: fan-out+enqueue+`processed`, `no_match`, event-gone → nil, reconcile re-drives + no double-enqueue.
- Seam: `PublishTx` enqueues+stamps and a dedup re-publish does not; **`PublishBestEffortTx` savepoint keeps the caller's tx committable on an enqueue failure** (row persists, `fanout_job_id` NULL).
- Existing `OutboxWorker` fan-out tests still pass (extraction is behavior-preserving). All webhookpub/relay/config green.

## Deliberately deferred (post-cutover)
Deleting the legacy `OutboxWorker` + the `webhook_events_new` NOTIFY trigger + the flag — unsafe to remove the battle-tested path before River runs in prod. That's a follow-up cleanup PR after the flag is flipped and verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)