### PR TITLE
feat(prober): real outbound-send scenario + agent PATCH + internal-sink deliverer exemption

### DIFF
--- a/cmd/e2a-prober/seed.go
+++ b/cmd/e2a-prober/seed.go
@@ -93,7 +93,7 @@ func seedProbe(ctx context.Context, store *identity.Store, agentEmail, sinkURL s
 	}
 	if !found {
 		wh, err := store.CreateWebhook(ctx, user.ID, sinkURL, probeWebhookDsc,
-			[]string{"email.received"}, identity.WebhookFilters{})
+			[]string{"email.received", "email.sent"}, identity.WebhookFilters{})
 		if err != nil {
 			return nil, fmt.Errorf("create webhook: %w", err)
 		}

--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -177,7 +177,7 @@ func main() {
 	// (webhook_events) → drain → River delivery; the legacy in-process
 	// publisher is retired.
 	subscriberStore := webhook.NewSubscriberStore(pool)
-	subscriberDeliverer := webhook.NewSubscriberDeliverer(cfg.IsProduction())
+	subscriberDeliverer := webhook.NewSubscriberDeliverer(cfg.IsProduction(), cfg.Webhook.InternalSinkURL)
 
 	// The transactional outbox is now UNCONDITIONAL (webhook-delivery→River
 	// migration): every event commits to webhook_events in the message tx, so

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,6 +43,7 @@ type Config struct {
 	Outbound         OutboundConfig         `yaml:"outbound"`
 	Inbound          InboundConfig          `yaml:"inbound"`
 	WebhookFanout    WebhookFanoutConfig    `yaml:"webhook_fanout"`
+	Webhook          WebhookConfig          `yaml:"webhook"`
 	SenderIdentity   SenderIdentityConfig   `yaml:"sender_identity"`
 	DeliveryFeedback DeliveryFeedbackConfig `yaml:"delivery_feedback"`
 	Limits           LimitsConfig           `yaml:"limits"`
@@ -159,6 +160,19 @@ type InboundConfig struct {
 // "legacy" (fail-safe to the unchanged path). Wired in Slice 2; unused under legacy.
 type WebhookFanoutConfig struct {
 	Mode string `yaml:"mode"`
+}
+
+// WebhookConfig carries webhook-delivery settings other than the fan-out engine
+// choice. InternalSinkURL, when set, names a single trusted internal sink URL
+// (the e2a-prober's /sink) that is EXEMPT from the production HTTPS-required +
+// SSRF private-IP delivery guards. It must exactly match the probe webhook's
+// registered URL. Safe: it is a server-operator config value (never attacker
+// input), matched by exact string equality, and the probe webhook is created by
+// the privileged prober `seed`, not the public registration API (which rejects
+// http:// + private hosts). Override with E2A_WEBHOOK_INTERNAL_SINK_URL. Empty
+// (the default) disables the exemption.
+type WebhookConfig struct {
+	InternalSinkURL string `yaml:"internal_sink_url"`
 }
 
 // DeliveryFeedbackConfig controls outbound delivery feedback (decision 9 /
@@ -306,6 +320,9 @@ func Load(path string) (*Config, error) {
 	}
 	if v := os.Getenv("E2A_WEBHOOK_FANOUT_MODE"); v != "" {
 		cfg.WebhookFanout.Mode = v
+	}
+	if v := os.Getenv("E2A_WEBHOOK_INTERNAL_SINK_URL"); v != "" {
+		cfg.Webhook.InternalSinkURL = v
 	}
 	if v := os.Getenv("E2A_OUTBOUND_SMTP_REQUIRE_TLS"); v != "" {
 		if b, err := strconv.ParseBool(v); err == nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -84,6 +84,7 @@ signing:
 	// KEY" armor so secret scanners don't false-positive on a test fixture.
 	t.Setenv("E2A_OAUTH_SIGNING_KEY", "signing-key-sentinel-not-a-real-pem")
 	t.Setenv("E2A_OAUTH_SIGNING_KID", "k7")
+	t.Setenv("E2A_WEBHOOK_INTERNAL_SINK_URL", "http://prober:8090/sink")
 
 	cfg, err := Load(cfgPath)
 	if err != nil {
@@ -105,6 +106,9 @@ signing:
 	}
 	if cfg.OutboundSMTP.Password != "smtp-pass" {
 		t.Errorf("expected env override for OutboundSMTP.Password, got %q", cfg.OutboundSMTP.Password)
+	}
+	if cfg.Webhook.InternalSinkURL != "http://prober:8090/sink" {
+		t.Errorf("expected env override for Webhook.InternalSinkURL, got %q", cfg.Webhook.InternalSinkURL)
 	}
 }
 

--- a/internal/e2e/events_api_e2e_test.go
+++ b/internal/e2e/events_api_e2e_test.go
@@ -98,7 +98,7 @@ func newEventsFixture(t *testing.T) *eventsE2EFixture {
 	outbox := webhookpub.NewOutbox(pool, webhookpub.StaticFlag(true))
 	worker := webhookpub.NewOutboxWorker(pool, store)
 	subStore := webhook.NewSubscriberStore(pool)
-	subDeliverer := webhook.NewSubscriberDeliverer(false)
+	subDeliverer := webhook.NewSubscriberDeliverer(false, "")
 	deliverWorker := webhookdelivery.NewDeliverWorker(subStore, subDeliverer, store)
 
 	// HTTP server wired with the agent API for the events endpoints.

--- a/internal/selftest/scenarios.go
+++ b/internal/selftest/scenarios.go
@@ -25,13 +25,18 @@ import (
 const defaultRoundTripTimeout = 30 * time.Second
 
 // All is the critical-path battery. Every scenario here is SmokeSafe: read-only,
-// a loopback (no egress), or the inbound round-trip (synthetic mail to the probe
-// agent, no real recipient). None meters (the probe runs under a system-class
-// account) and none emails an owner.
+// a loopback (no egress), the inbound round-trip (synthetic mail to the probe
+// agent), or a real outbound send to the AWS mailbox simulator (no real
+// recipient). None meters (the probe runs under a system-class account) and none
+// emails an owner.
 var All = []Scenario{
 	{Name: "liveness", SmokeSafe: true, Run: scenarioLiveness},
 	{Name: "auth_read", SmokeSafe: true, Run: scenarioAuthRead},
 	{Name: "inbound_round_trip", SmokeSafe: true, Run: scenarioInboundRoundTrip},
+	// outbound_send does a REAL SES submit, but only to the mailbox simulator
+	// (no real recipient, no cost, no owner notification, system-class = no
+	// metering), then confirms the email.sent event is delivered + HMAC-signed.
+	{Name: "outbound_send", SmokeSafe: true, Run: scenarioOutboundSend},
 	{Name: "self_send_loopback", SmokeSafe: true, Run: scenarioSelfSendLoopback},
 	// agent_lifecycle MUTATES prod (creates then deletes an ephemeral agent on
 	// the probe's verified domain) but is self-cleaning — no email, no owner
@@ -119,6 +124,59 @@ func scenarioInboundRoundTrip(ctx context.Context, p *Probe) Result {
 	return pass("inbound round-trip + HMAC ok")
 }
 
+// scenarioOutboundSend is the real-egress counterpart to the inbound round-trip:
+// the probe agent sends a unique message to the AWS SES mailbox simulator
+// (success@simulator.amazonses.com — accepted + blackholed, no real recipient,
+// no cost, no reputation impact), then confirms the resulting email.sent event
+// is delivered out the webhook with a valid HMAC. Covers the outbound API +
+// screening + compose + real SES submit + the outbound event → outbox →
+// subscriber worker → webhook delivery → signing path. Correlated by the
+// returned message_id (sync mode emits email.sent inline; async mode's worker
+// emits it after the SES submit — both land at the sink). Requires the probe
+// webhook to subscribe to email.sent (see cmd/e2a-prober seed).
+func scenarioOutboundSend(ctx context.Context, p *Probe) Result {
+	if p.Sink == nil {
+		return fail("no sink configured")
+	}
+	nonce, err := randHex(16)
+	if err != nil {
+		return fail("nonce: %v", err)
+	}
+	u := p.HTTPBaseURL + "/v1/agents/" + url.PathEscape(p.AgentEmail) + "/messages"
+	payload := map[string]any{
+		"to":      []string{"success@simulator.amazonses.com"},
+		"subject": "e2a-selftest outbound " + nonce,
+		"body":    "e2a selftest outbound " + nonce,
+	}
+	b, _ := json.Marshal(payload)
+	st, respBody, err := p.do(ctx, http.MethodPost, u, b)
+	if err != nil {
+		return fail("send: %v", err)
+	}
+	if st != http.StatusOK {
+		return fail("send: HTTP %d", st)
+	}
+	var out struct {
+		MessageID string `json:"message_id"`
+		Status    string `json:"status"`
+	}
+	if jerr := json.Unmarshal(respBody, &out); jerr != nil || out.MessageID == "" {
+		return fail("send: could not parse message_id from response (status=%q)", out.Status)
+	}
+
+	d, err := p.Sink.Await(ctx, func(d Delivery) bool {
+		return bytes.Contains(d.Body, []byte(out.MessageID)) &&
+			bytes.Contains(d.Body, []byte("email.sent"))
+	}, p.roundTripTimeout())
+	if err != nil {
+		return fail("await email.sent for message %s: %v", out.MessageID, err)
+	}
+	if !verifyHMAC(d.Headers.Get("X-E2A-Signature"), d.Body, p.WebhookSecret) {
+		return fail("email.sent webhook HMAC verification failed")
+	}
+	return pass("outbound send → email.sent + HMAC ok")
+}
+
 // scenarioSelfSendLoopback: the probe agent sends to itself. Self-send routes
 // through the loopback path (method=loopback) — no SMTP egress, no HITL owner
 // notification — exercising the outbound API + compose path safely.
@@ -191,6 +249,14 @@ func scenarioAgentLifecycle(ctx context.Context, p *Probe) Result {
 		return fail("get created agent: %v", err)
 	} else if st != http.StatusOK {
 		return fail("get created agent: HTTP %d, want 200", st)
+	}
+
+	// PATCH (update display name) → 200.
+	patchBody, _ := json.Marshal(map[string]string{"name": "e2a selftest lifecycle (updated)"})
+	if st, _, err := p.do(ctx, http.MethodPatch, agentURL, patchBody); err != nil {
+		return fail("update agent: %v", err)
+	} else if st != http.StatusOK {
+		return fail("update agent: HTTP %d, want 200", st)
 	}
 
 	// DELETE (confirmed) → 204.

--- a/internal/selftest/selftest_test.go
+++ b/internal/selftest/selftest_test.go
@@ -54,8 +54,11 @@ func TestSelftestAll_AgainstRealServer(t *testing.T) {
 	sink := selftest.NewHTTPSink()
 	sinkSrv := httptest.NewServer(sink)
 	defer sinkSrv.Close()
+	// Subscribe to both event types the battery asserts on — email.received for
+	// the inbound round-trip and email.sent for the outbound-send scenario —
+	// mirroring what cmd/e2a-prober seed provisions.
 	wh, err := ts.Store.CreateWebhook(ctx, user.ID, sinkSrv.URL+"/sink", "selftest",
-		[]string{"email.received"}, identity.WebhookFilters{})
+		[]string{"email.received", "email.sent"}, identity.WebhookFilters{})
 	if err != nil {
 		t.Fatalf("CreateWebhook: %v", err)
 	}

--- a/internal/selftest/selftest_test.go
+++ b/internal/selftest/selftest_test.go
@@ -22,7 +22,12 @@ import (
 // River delivery workers.
 func TestSelftestAll_AgainstRealServer(t *testing.T) {
 	pool := testutil.TestDB(t)
-	ts := testutil.TestServer(t, pool, testutil.WithOutboundSMTP("127.0.0.1", 1025, "test.e2a.dev"))
+	// In-process fake SMTP so the outbound_send scenario has a reachable relay
+	// without depending on an external Mailpit — the unit/coverage jobs run this
+	// test (no `integration` tag) but don't start Mailpit. The fake accepts the
+	// message and returns a Message-ID, so the real outbound path + email.sent fire.
+	fakeSMTP, _ := testutil.FakeSMTPServer(t)
+	ts := testutil.TestServer(t, pool, testutil.WithOutboundSMTP(fakeSMTP.Host, fakeSMTP.Port, "test.e2a.dev"))
 	ctx := context.Background()
 
 	// --- seed a system-class probe account + agent ---

--- a/internal/testutil/server.go
+++ b/internal/testutil/server.go
@@ -144,7 +144,7 @@ func TestServer(t *testing.T, pool *pgxpool.Pool, opts ...TestServerOption) *E2A
 	// events. Neither worker is started as a goroutine — tests call
 	// DrainAndDeliver(ctx) directly for deterministic delivery without any tick.
 	subscriberStore := webhook.NewSubscriberStore(pool)
-	subscriberDeliverer := webhook.NewSubscriberDeliverer(false)
+	subscriberDeliverer := webhook.NewSubscriberDeliverer(false, "")
 	outbox := webhookpub.NewOutbox(pool, webhookpub.StaticFlag(true))
 	outboxWorker := webhookpub.NewOutboxWorker(pool, store)
 	deliverWorker := webhookdelivery.NewDeliverWorker(subscriberStore, subscriberDeliverer, store)

--- a/internal/webhook/ssrf_test.go
+++ b/internal/webhook/ssrf_test.go
@@ -61,7 +61,7 @@ func TestGuardedDialControl(t *testing.T) {
 // webhook URL that resolves to an internal IP — the DNS-rebinding payload — is
 // refused at connect time even though it passed registration validation.
 func TestSubscriberDeliverer_ProdBlocksInternalIP(t *testing.T) {
-	d := NewSubscriberDeliverer(true)
+	d := NewSubscriberDeliverer(true, "")
 	// A literal-IP HTTPS URL clears the scheme check, then the dial guard
 	// rejects the resolved loopback address before any connection is made.
 	out := d.Deliver(context.Background(), "https://127.0.0.1:9/hook", []byte(`{}`), "whsec_x", "")
@@ -76,7 +76,7 @@ func TestSubscriberDeliverer_ProdBlocksInternalIP(t *testing.T) {
 // The non-production deliverer keeps the default transport (no guard) so local
 // and CI deliveries to 127.0.0.1 still work.
 func TestSubscriberDeliverer_DevAllowsLoopbackTransport(t *testing.T) {
-	d := NewSubscriberDeliverer(false)
+	d := NewSubscriberDeliverer(false, "")
 	if d.client.Transport != nil {
 		t.Error("dev deliverer installed a custom transport; want default (no IP guard)")
 	}

--- a/internal/webhook/subscriber_deliverer.go
+++ b/internal/webhook/subscriber_deliverer.go
@@ -25,6 +25,13 @@ import (
 type SubscriberDeliverer struct {
 	client       *http.Client
 	requireHTTPS bool
+
+	// internalSinkURL, when non-empty, is a single trusted internal sink URL
+	// (the e2a-prober's /sink) that is EXEMPT from the production HTTPS +
+	// SSRF-dial guards; exemptClient serves only that URL. See
+	// NewSubscriberDeliverer for the safety argument.
+	internalSinkURL string
+	exemptClient    *http.Client
 }
 
 // NewSubscriberDeliverer constructs the deliverer with the 15s
@@ -36,16 +43,25 @@ type SubscriberDeliverer struct {
 // internal IP before delivery (DNS rebinding). The guard re-checks the actual
 // resolved IP at connect time, closing that window. It is gated to production
 // so local/CI deliveries to 127.0.0.1 still work.
-func NewSubscriberDeliverer(requireHTTPS bool) *SubscriberDeliverer {
+//
+// internalSinkURL (usually empty) names ONE trusted internal sink — the
+// e2a-prober's /sink — reached over plain HTTP on an internal host. Deliveries
+// to that EXACT URL bypass the HTTPS + SSRF guards via a separate exemptClient.
+// This is safe because: (1) the value is server-operator config, never attacker
+// input; (2) it is matched by exact string equality, so it grants access to no
+// other internal address; and (3) the probe webhook that targets it is created
+// by the privileged prober `seed`, not the public registration API (which
+// rejects http:// + private hosts). Empty disables the exemption entirely.
+func NewSubscriberDeliverer(requireHTTPS bool, internalSinkURL string) *SubscriberDeliverer {
+	// Refuse redirects to prevent SSRF — same defense the legacy Deliverer
+	// uses. A registered HTTPS URL that 301s to 127.0.0.1 would otherwise let
+	// an attacker reach internal services. Applied to BOTH clients.
+	noRedirect := func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
 	client := &http.Client{
-		Timeout: 15 * time.Second,
-		// Refuse redirects to prevent SSRF — same defense the
-		// legacy Deliverer uses. A registered HTTPS URL that
-		// 301s to 127.0.0.1 would otherwise let an attacker
-		// reach internal services.
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
+		Timeout:       15 * time.Second,
+		CheckRedirect: noRedirect,
 	}
 	if requireHTTPS {
 		client.Transport = &http.Transport{
@@ -62,10 +78,22 @@ func NewSubscriberDeliverer(requireHTTPS bool) *SubscriberDeliverer {
 			ExpectContinueTimeout: 1 * time.Second,
 		}
 	}
-	return &SubscriberDeliverer{
-		client:       client,
-		requireHTTPS: requireHTTPS,
+	d := &SubscriberDeliverer{
+		client:          client,
+		requireHTTPS:    requireHTTPS,
+		internalSinkURL: internalSinkURL,
 	}
+	// The exempt client keeps the no-redirect defense but uses the default
+	// transport (no guardedDialControl), so it can reach the internal sink's
+	// private IP. It is used ONLY for deliveries whose URL exactly equals
+	// internalSinkURL.
+	if internalSinkURL != "" {
+		d.exemptClient = &http.Client{
+			Timeout:       15 * time.Second,
+			CheckRedirect: noRedirect,
+		}
+	}
+	return d
 }
 
 // DeliveryOutcome is what the deliverer returns to the caller for
@@ -91,7 +119,13 @@ type DeliveryOutcome struct {
 // redirects are blocked) is a failure with the HTTP status code
 // reported back. Connection errors return Success=false and StatusCode=0.
 func (d *SubscriberDeliverer) Deliver(ctx context.Context, url string, body []byte, secret, secretPrev string) DeliveryOutcome {
-	if d.requireHTTPS && !strings.HasPrefix(url, "https://") {
+	client := d.client
+	if d.internalSinkURL != "" && url == d.internalSinkURL {
+		// Trusted internal sink (see NewSubscriberDeliverer): exempt from the
+		// HTTPS + SSRF guards. exemptClient is always non-nil when
+		// internalSinkURL is set.
+		client = d.exemptClient
+	} else if d.requireHTTPS && !strings.HasPrefix(url, "https://") {
 		return DeliveryOutcome{Success: false, Error: "webhook URL must use HTTPS in production"}
 	}
 
@@ -106,7 +140,7 @@ func (d *SubscriberDeliverer) Deliver(ctx context.Context, url string, body []by
 	req.Header.Set("X-E2A-Signature", signatureValue)
 	req.Header.Set("User-Agent", "e2a-webhooks/1")
 
-	resp, err := d.client.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return DeliveryOutcome{Success: false, Error: err.Error()}
 	}

--- a/internal/webhook/subscriber_deliverer_test.go
+++ b/internal/webhook/subscriber_deliverer_test.go
@@ -25,7 +25,7 @@ func TestSubscriberDeliverer_SignsRequest(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	d := NewSubscriberDeliverer(false)
+	d := NewSubscriberDeliverer(false, "")
 	body := []byte(`{"event":"email.received","id":"evt_x"}`)
 	out := d.Deliver(context.Background(), srv.URL, body, "whsec_secret", "")
 	if !out.Success {
@@ -70,7 +70,7 @@ func TestSubscriberDeliverer_DualSigDuringRotationGrace(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	d := NewSubscriberDeliverer(false)
+	d := NewSubscriberDeliverer(false, "")
 	body := []byte(`{"event":"email.received"}`)
 	out := d.Deliver(context.Background(), srv.URL, body, "whsec_new", "whsec_old")
 	if !out.Success {
@@ -90,7 +90,7 @@ func TestSubscriberDeliverer_4xxIsFailure(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	d := NewSubscriberDeliverer(false)
+	d := NewSubscriberDeliverer(false, "")
 	out := d.Deliver(context.Background(), srv.URL, []byte(`{}`), "whsec_x", "")
 	if out.Success {
 		t.Error("4xx response reported as success")
@@ -106,7 +106,7 @@ func TestSubscriberDeliverer_5xxIsFailure(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	d := NewSubscriberDeliverer(false)
+	d := NewSubscriberDeliverer(false, "")
 	out := d.Deliver(context.Background(), srv.URL, []byte(`{}`), "whsec_x", "")
 	if out.Success {
 		t.Error("5xx response reported as success")
@@ -120,7 +120,7 @@ func TestSubscriberDeliverer_ConnectionErrorReportsZeroStatus(t *testing.T) {
 	// 192.0.2.0/24 is reserved for documentation per RFC 5737;
 	// connection attempts to it should fail without ever reaching a
 	// real service.
-	d := NewSubscriberDeliverer(false)
+	d := NewSubscriberDeliverer(false, "")
 	d.client.Timeout = 100 * time.Millisecond // speed up the test
 	out := d.Deliver(context.Background(), "http://192.0.2.1:8080/", []byte(`{}`), "whsec_x", "")
 	if out.Success {
@@ -132,13 +132,48 @@ func TestSubscriberDeliverer_ConnectionErrorReportsZeroStatus(t *testing.T) {
 }
 
 func TestSubscriberDeliverer_RefusesPlaintextInProd(t *testing.T) {
-	d := NewSubscriberDeliverer(true) // requireHTTPS=true
+	d := NewSubscriberDeliverer(true, "") // requireHTTPS=true
 	out := d.Deliver(context.Background(), "http://example.com/hook", []byte(`{}`), "whsec_x", "")
 	if out.Success {
 		t.Error("plaintext URL allowed in HTTPS-required mode")
 	}
 	if !strings.Contains(out.Error, "HTTPS") {
 		t.Errorf("error message doesn't mention HTTPS: %q", out.Error)
+	}
+}
+
+func TestSubscriberDeliverer_ExemptsConfiguredInternalSink(t *testing.T) {
+	// A plaintext, loopback sink — exactly what the e2a-prober exposes. Under
+	// requireHTTPS=true this would normally be refused (http://) and, if it got
+	// that far, dial-blocked (127.0.0.1). Configured as the internal sink, an
+	// exact-URL-match delivery must bypass both guards.
+	var hit bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	d := NewSubscriberDeliverer(true /* requireHTTPS */, srv.URL /* internalSinkURL */)
+
+	// Exact match → exempt → delivered over plain HTTP to loopback.
+	out := d.Deliver(context.Background(), srv.URL, []byte(`{"event":"email.received"}`), "whsec_x", "")
+	if !out.Success {
+		t.Fatalf("delivery to the configured internal sink failed: %+v", out)
+	}
+	if !hit {
+		t.Error("sink handler was never called")
+	}
+
+	// A DIFFERENT plaintext URL is NOT exempt — exact-match only, so the HTTPS
+	// guard still applies. This is the security property that keeps the
+	// exemption from widening into an arbitrary-internal-host SSRF.
+	out = d.Deliver(context.Background(), "http://example.com/other", []byte(`{}`), "whsec_x", "")
+	if out.Success {
+		t.Error("a non-sink plaintext URL was allowed — exemption must be exact-match only")
+	}
+	if !strings.Contains(out.Error, "HTTPS") {
+		t.Errorf("non-sink plaintext error should mention HTTPS, got %q", out.Error)
 	}
 }
 
@@ -151,7 +186,7 @@ func TestSubscriberDeliverer_RefusesRedirects(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	d := NewSubscriberDeliverer(false)
+	d := NewSubscriberDeliverer(false, "")
 	out := d.Deliver(context.Background(), srv.URL, []byte(`{}`), "whsec_x", "")
 	if out.Success {
 		t.Error("3xx response reported as success — redirects must be refused")


### PR DESCRIPTION
Completes the **server-side** pieces needed to run the `e2a-prober` real-path battery against a deployment as a release gate (finishing the never-landed part of `docs/design/prober-selftest.md`). **Server-internal only — no `/v1` contract or SDK change** (the prober is just a *client* of existing endpoints; `make spec-check` / SDK codegen stay green).

### 1. Internal-sink deliverer exemption (the documented blocker)
The prober's inbound round-trip needs the webhook deliverer to POST to its internal sink (`http://prober:8090/sink`), but in production the deliverer requires `https://` and dial-blocks private/loopback IPs (SSRF guard) — so the round-trip couldn't work against prod.

- New `config.Webhook.InternalSinkURL` (`E2A_WEBHOOK_INTERNAL_SINK_URL`, default empty). When set, `SubscriberDeliverer` routes deliveries whose URL **exactly equals** that value through a separate client without the HTTPS check or dial guard; every other delivery is unchanged.
- **Safe by construction:** operator config (never attacker input), exact-match only (grants access to no other internal address), and the probe webhook is created via the privileged `seed`, not the public registration API (which rejects `http://`+private). Tests cover the exemption *and* that a non-matching plaintext URL is still refused.

### 2. Real outbound-send scenario (real egress)
`scenarioOutboundSend`: the probe agent sends to the **AWS SES mailbox simulator** (`success@simulator.amazonses.com` — accepted + blackholed, no real recipient, no cost, no reputation impact), then confirms the `email.sent` event is delivered out the webhook with a valid HMAC. Correlated by `message_id` (fires in both sync and async outbound modes). `SmokeSafe`; added to the `All` battery. The `seed` webhook now subscribes to `email.sent` too.

### 3. Agent PATCH in `agent_lifecycle`
The lifecycle scenario now exercises create → get → **update (PATCH)** → delete.

### Verification
- `go build ./...`, `go vet` clean.
- `internal/webhook` + `internal/config` tests green (exemption).
- `internal/selftest` full battery passes against a real in-process server (inbound round-trip + **real outbound → email.sent → HMAC** + agent CRUD incl. PATCH).

Ops-side wiring (prober compose service + `deploy.yml` bake-gate) lands in `e2a-ops` next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)