### PR TITLE
ci: build & publish the e2a-prober image (co-versioned)

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -58,6 +58,12 @@ jobs:
             # context. See web/Dockerfile.
             context: .
             dockerfile: web/Dockerfile
+          - image: e2a-prober
+            display_name: prober image
+            # The critical-path self-test runner (cmd/e2a-prober), co-versioned
+            # with the server so the hosted deploy pins it to the same tag.
+            context: .
+            dockerfile: Dockerfile.prober
     steps:
       - uses: actions/checkout@v7
 

--- a/Dockerfile.prober
+++ b/Dockerfile.prober
@@ -1,0 +1,32 @@
+# e2a-prober image — the critical-path self-test runner (cmd/e2a-prober).
+#
+# Co-versioned with the server: the hosted deploy pins e2a-prober to the same
+# release tag as ghcr.io/mnexa-ai/e2a. Env-driven (E2A_PROBE_*), no config file.
+# See docs/design/prober-selftest.md. Modes: seed | validate | run-once | serve
+# (serve is the default — the continuous monitor + deploy bake-gate signal).
+#
+# Mirrors ./Dockerfile: native-arch builder + CGO-free cross-compile, alpine
+# runtime, non-root user.
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
+ARG TARGETOS TARGETARCH
+
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /e2a-prober ./cmd/e2a-prober
+
+FROM alpine:3.24
+RUN apk add --no-cache ca-certificates wget \
+    && adduser -D -u 1001 -h /home/e2a e2a
+COPY --from=builder /e2a-prober /usr/local/bin/e2a-prober
+USER e2a
+# serve hosts /sink /healthz /metrics /status on :8090 (bound to loopback by the
+# deployment; never published publicly).
+EXPOSE 8090
+HEALTHCHECK --interval=10s --timeout=3s --start-period=10s --retries=5 \
+    CMD wget -qO- http://127.0.0.1:8090/healthz || exit 1
+# Default to the continuous monitor. seed/validate/run-once are invoked by
+# overriding the command (e.g. `docker run ... e2a-prober seed`).
+ENTRYPOINT ["e2a-prober"]
+CMD ["serve"]


### PR DESCRIPTION
The prober (`cmd/e2a-prober`) is the critical-path self-test runner + deploy bake-gate (`docs/design/prober-selftest.md`), but **no image was ever published** — `Dockerfile` builds only `./cmd/e2a`, and `build-image.yml` publishes just `e2a` + `e2a-web`. This blocks wiring the prober into the hosted deploy.

Adds `Dockerfile.prober` (builds `./cmd/e2a-prober`, alpine, non-root, `serve` as the default CMD, healthcheck on `:8090/healthz`) + a `build-image.yml` matrix entry, so a `v*` release publishes **`ghcr.io/mnexa-ai/e2a-prober:<tag>`**, co-versioned with the server. The hosted deploy (`e2a-ops`) then pins the prober to the same release tag as the server/MCP images.

Independent of the prober-scenario PR (#403); this just packages the existing binary. Dockerfile verified to build locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)