### PR TITLE
fix(prober): adopt the server-seeded shared domain in `seed`

### DIFF
--- a/cmd/e2a-prober/prober_test.go
+++ b/cmd/e2a-prober/prober_test.go
@@ -80,6 +80,57 @@ func TestSeedProbe_ProvisionsSystemAccountIdempotently(t *testing.T) {
 	}
 }
 
+// Regression: the server seeds the configured shared domain as a verified,
+// ownerless row on every boot (EnsureSharedDomain). ClaimOrCreateDomain cannot
+// claim that row, so seed must adopt it. Before the AdoptSharedDomain fallback,
+// seeding the probe on the shared domain failed with "already claimed by another
+// account" — which meant the prober gate could never come up against a real
+// server (this was never exercised because the prober had never been deployed).
+func TestSeedProbe_AdoptsPreSeededSharedDomain(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	const shared = "agents.shared.prober-test"
+	const agentEmail = "probe@" + shared
+	const sinkURL = "http://prober:8090/sink"
+
+	// Simulate the server's boot-time EnsureSharedDomain (verified, user_id NULL).
+	if err := store.EnsureSharedDomain(ctx, shared); err != nil {
+		t.Fatalf("EnsureSharedDomain: %v", err)
+	}
+
+	res, err := seedProbe(ctx, store, agentEmail, sinkURL)
+	if err != nil {
+		t.Fatalf("seedProbe against pre-seeded shared domain: %v", err)
+	}
+	if res.APIKey == "" || res.WebhookSecret == "" {
+		t.Error("expected API key + webhook secret on first seed")
+	}
+
+	// The probe user now owns the shared-domain row, and it stays verified.
+	agent, err := store.GetAgentByID(ctx, agentEmail)
+	if err != nil {
+		t.Fatalf("GetAgentByID: %v", err)
+	}
+	var owner *string
+	var verified bool
+	if err := pool.QueryRow(ctx, `SELECT user_id, verified FROM domains WHERE domain = $1`, shared).Scan(&owner, &verified); err != nil {
+		t.Fatalf("read domain row: %v", err)
+	}
+	if owner == nil || *owner != agent.UserID {
+		t.Errorf("domain owner = %v, want probe user %s", owner, agent.UserID)
+	}
+	if !verified {
+		t.Error("shared domain should remain verified after adopt")
+	}
+
+	// Idempotent: re-seeding succeeds (adopt returns the already-owned row).
+	if _, err := seedProbe(ctx, store, agentEmail, sinkURL); err != nil {
+		t.Fatalf("re-seed against adopted shared domain: %v", err)
+	}
+}
+
 func TestHandleStatus_ConsecutiveGreen(t *testing.T) {
 	p := newProber(config{})
 	base := time.Unix(1_700_000_000, 0)

--- a/cmd/e2a-prober/seed.go
+++ b/cmd/e2a-prober/seed.go
@@ -52,8 +52,9 @@ func seedProbe(ctx context.Context, store *identity.Store, agentEmail, sinkURL s
 		// ON CONFLICT DO NOTHING), which ClaimOrCreateDomain can't claim — it only
 		// upserts an unverified, same-user row. The probe identity lives on that
 		// shared domain by design (slug agents need no DNS verification), so adopt
-		// the ownerless row under the probe user instead of failing. Idempotent:
-		// AdoptSharedDomain also returns a row already owned by the probe user.
+		// the ownerless row under the probe user instead of failing. (On re-seed
+		// the row is already probe-owned and verified, so ClaimOrCreateDomain
+		// returns it directly and this fallback isn't reached.)
 		dom, err = store.AdoptSharedDomain(ctx, domain, user.ID)
 	}
 	if err != nil {

--- a/cmd/e2a-prober/seed.go
+++ b/cmd/e2a-prober/seed.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -45,11 +46,22 @@ func seedProbe(ctx context.Context, store *identity.Store, agentEmail, sinkURL s
 	}
 
 	dom, err := store.ClaimOrCreateDomain(ctx, domain, user.ID)
+	if errors.Is(err, identity.ErrDomainTaken) {
+		// The server seeds the configured shared domain as a verified, ownerless
+		// row on every boot (EnsureSharedDomain: user_id NULL, verified true,
+		// ON CONFLICT DO NOTHING), which ClaimOrCreateDomain can't claim — it only
+		// upserts an unverified, same-user row. The probe identity lives on that
+		// shared domain by design (slug agents need no DNS verification), so adopt
+		// the ownerless row under the probe user instead of failing. Idempotent:
+		// AdoptSharedDomain also returns a row already owned by the probe user.
+		dom, err = store.AdoptSharedDomain(ctx, domain, user.ID)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("claim domain %s: %w", domain, err)
 	}
 	// VerifyDomain is not idempotent (it errors on an already-verified domain),
-	// so only verify when needed — keeps re-seeding safe.
+	// so only verify when needed — keeps re-seeding safe. The adopted shared
+	// domain is already verified, so this is skipped for it.
 	if !dom.Verified {
 		if err := store.VerifyDomain(ctx, domain, user.ID); err != nil {
 			return nil, fmt.Errorf("verify domain %s: %w", domain, err)

--- a/internal/identity/shared_domain_test.go
+++ b/internal/identity/shared_domain_test.go
@@ -53,6 +53,17 @@ func TestAdoptSharedDomain(t *testing.T) {
 	if _, err := store.AdoptSharedDomain(ctx, "nope.example.com", u1.ID); !errors.Is(err, identity.ErrDomainTaken) {
 		t.Fatalf("AdoptSharedDomain (missing): err = %v, want ErrDomainTaken", err)
 	}
+
+	// An ownerless but UNVERIFIED row is not adoptable: the verified=true guard
+	// scopes the method to the server-seeded shared-domain shape, so it can never
+	// hand out some other NULL-owner row even if one existed.
+	const unverified = "ownerless.unverified.example.com"
+	if _, err := pool.Exec(ctx, `INSERT INTO domains (domain, user_id, verified) VALUES ($1, NULL, false)`, unverified); err != nil {
+		t.Fatalf("seed unverified ownerless row: %v", err)
+	}
+	if _, err := store.AdoptSharedDomain(ctx, unverified, u1.ID); !errors.Is(err, identity.ErrDomainTaken) {
+		t.Fatalf("AdoptSharedDomain (unverified ownerless): err = %v, want ErrDomainTaken", err)
+	}
 }
 
 func TestEnsureSharedDomain_EmptyIsNoop(t *testing.T) {

--- a/internal/identity/shared_domain_test.go
+++ b/internal/identity/shared_domain_test.go
@@ -2,11 +2,58 @@ package identity_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/Mnexa-AI/e2a/internal/identity"
 	"github.com/Mnexa-AI/e2a/internal/testutil"
 )
+
+func TestAdoptSharedDomain(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	const dom = "agents.adopt.example.com"
+	if err := store.EnsureSharedDomain(ctx, dom); err != nil {
+		t.Fatalf("EnsureSharedDomain: %v", err)
+	}
+	u1, err := store.CreateOrGetUser(ctx, "probe@adopt.test", "probe", "google-adopt-1")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+
+	// Adopt the ownerless, server-seeded row.
+	d, err := store.AdoptSharedDomain(ctx, dom, u1.ID)
+	if err != nil {
+		t.Fatalf("AdoptSharedDomain (ownerless): %v", err)
+	}
+	if d.UserID == nil || *d.UserID != u1.ID {
+		t.Fatalf("owner = %v, want %s", d.UserID, u1.ID)
+	}
+	if !d.Verified {
+		t.Error("adopted shared domain should stay verified")
+	}
+
+	// Idempotent: the same user re-adopts without error.
+	if _, err := store.AdoptSharedDomain(ctx, dom, u1.ID); err != nil {
+		t.Fatalf("AdoptSharedDomain (idempotent re-adopt): %v", err)
+	}
+
+	// A different account cannot steal an already-owned domain.
+	u2, err := store.CreateOrGetUser(ctx, "other@adopt.test", "other", "google-adopt-2")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser u2: %v", err)
+	}
+	if _, err := store.AdoptSharedDomain(ctx, dom, u2.ID); !errors.Is(err, identity.ErrDomainTaken) {
+		t.Fatalf("AdoptSharedDomain by another user: err = %v, want ErrDomainTaken", err)
+	}
+
+	// AdoptSharedDomain on a nonexistent domain is ErrDomainTaken, not a panic.
+	if _, err := store.AdoptSharedDomain(ctx, "nope.example.com", u1.ID); !errors.Is(err, identity.ErrDomainTaken) {
+		t.Fatalf("AdoptSharedDomain (missing): err = %v, want ErrDomainTaken", err)
+	}
+}
 
 func TestEnsureSharedDomain_EmptyIsNoop(t *testing.T) {
 	pool := testutil.TestDB(t)

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -553,6 +553,34 @@ func (s *Store) ClaimOrCreateDomain(ctx context.Context, domain, userID string) 
 	return nil, ErrDomainTaken
 }
 
+// AdoptSharedDomain assigns ownership of an existing domain row to userID,
+// used to claim the configured shared domain that the server seeds on every
+// boot via EnsureSharedDomain (user_id NULL, verified true). ClaimOrCreateDomain
+// cannot claim that row — it only upserts an unverified, same-user row — yet the
+// probe/system identity that seeds itself lives on the shared domain by design.
+// Adoption is scoped to a currently-unowned row (or one already owned by userID,
+// so re-seeding is idempotent); a row owned by a different account is left
+// untouched and ErrDomainTaken is returned. The verified flag and DKIM columns
+// are not modified.
+func (s *Store) AdoptSharedDomain(ctx context.Context, domain, userID string) (*Domain, error) {
+	domain = normalizeDomain(domain)
+	d := &Domain{}
+	err := s.pool.QueryRow(ctx,
+		`UPDATE domains SET user_id = $2
+		 WHERE domain = $1 AND (user_id IS NULL OR user_id = $2)
+		 RETURNING domain, user_id, verified, verification_token, created_at, verified_at, is_primary, last_checked_at, COALESCE(dkim_selector, ''), COALESCE(dkim_public_key, ''), sending_status, COALESCE(sending_error, ''), sending_dns_records, sending_last_checked_at, COALESCE(sending_dkim_status, ''), COALESCE(sending_mail_from_status, '')`,
+		domain, userID,
+	).Scan(&d.Domain, &d.UserID, &d.Verified, &d.VerificationToken, &d.CreatedAt, &d.VerifiedAt, &d.IsPrimary, &d.LastCheckedAt, &d.DKIMSelector, &d.DKIMPublicKey, &d.SendingStatus, &d.SendingError, &d.SendingDNSRecordsJSON, &d.SendingLastCheckedAt, &d.SendingDkimStatus, &d.SendingMailFromStatus)
+	if err == nil {
+		return d, nil
+	}
+	if errors.Is(err, pgx.ErrNoRows) {
+		// No adoptable row: it doesn't exist, or a different account owns it.
+		return nil, ErrDomainTaken
+	}
+	return nil, fmt.Errorf("adopt shared domain %q: %w", domain, err)
+}
+
 // nullIfEmpty returns nil for empty strings so we can write SQL NULL
 // (rather than empty-string) for nullable text columns. Pgx treats an
 // untyped nil interface{} as NULL.

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -553,21 +553,26 @@ func (s *Store) ClaimOrCreateDomain(ctx context.Context, domain, userID string) 
 	return nil, ErrDomainTaken
 }
 
-// AdoptSharedDomain assigns ownership of an existing domain row to userID,
-// used to claim the configured shared domain that the server seeds on every
-// boot via EnsureSharedDomain (user_id NULL, verified true). ClaimOrCreateDomain
-// cannot claim that row — it only upserts an unverified, same-user row — yet the
+// AdoptSharedDomain assigns ownership of the server-seeded shared-domain row to
+// userID. The server seeds that row on every boot via EnsureSharedDomain
+// (user_id NULL, verified true, ON CONFLICT DO NOTHING); ClaimOrCreateDomain
+// cannot claim it — it only upserts an unverified, same-user row — yet the
 // probe/system identity that seeds itself lives on the shared domain by design.
-// Adoption is scoped to a currently-unowned row (or one already owned by userID,
-// so re-seeding is idempotent); a row owned by a different account is left
-// untouched and ErrDomainTaken is returned. The verified flag and DKIM columns
-// are not modified.
+//
+// The UPDATE is guarded to a VERIFIED, currently-unowned row (or one already
+// owned by userID, so re-seeding is idempotent). Requiring verified=true — the
+// signature EnsureSharedDomain stamps — keeps this method from ever adopting
+// some other ownerless row, so its safety does not rely on the domains schema
+// never producing another NULL-owner row nor on the caller passing only a
+// trusted domain. A row owned by a different account, a nonexistent row, or an
+// ownerless-but-unverified row all match nothing and return ErrDomainTaken. The
+// verified flag and DKIM columns are not modified.
 func (s *Store) AdoptSharedDomain(ctx context.Context, domain, userID string) (*Domain, error) {
 	domain = normalizeDomain(domain)
 	d := &Domain{}
 	err := s.pool.QueryRow(ctx,
 		`UPDATE domains SET user_id = $2
-		 WHERE domain = $1 AND (user_id IS NULL OR user_id = $2)
+		 WHERE domain = $1 AND verified = true AND (user_id IS NULL OR user_id = $2)
 		 RETURNING domain, user_id, verified, verification_token, created_at, verified_at, is_primary, last_checked_at, COALESCE(dkim_selector, ''), COALESCE(dkim_public_key, ''), sending_status, COALESCE(sending_error, ''), sending_dns_records, sending_last_checked_at, COALESCE(sending_dkim_status, ''), COALESCE(sending_mail_from_status, '')`,
 		domain, userID,
 	).Scan(&d.Domain, &d.UserID, &d.Verified, &d.VerificationToken, &d.CreatedAt, &d.VerifiedAt, &d.IsPrimary, &d.LastCheckedAt, &d.DKIMSelector, &d.DKIMPublicKey, &d.SendingStatus, &d.SendingError, &d.SendingDNSRecordsJSON, &d.SendingLastCheckedAt, &d.SendingDkimStatus, &d.SendingMailFromStatus)


### PR DESCRIPTION
## Problem

`e2a-prober seed` cannot provision the probe identity on the **shared domain**, so the prober gate can never come up against a real server.

The server seeds the configured shared domain as a **verified, ownerless** row on every boot:

```go
// cmd/e2a/main.go
store.EnsureSharedDomain(ctx, cfg.SharedDomain)
// INSERT INTO domains (domain, user_id, verified, verified_at)
// VALUES ($1, NULL, true, now()) ON CONFLICT (domain) DO NOTHING
```

`seed` then calls `ClaimOrCreateDomain(sharedDomain, probeUser)`, which only upserts an **unverified, same-user** row. Against the pre-seeded verified/NULL-owner row it returns `ErrDomainTaken` ("already claimed by another account") and **seed exits 1**.

The prober lives only on `main` and had never been deployed, so this path was never exercised. It surfaced while bringing up the **staging** prober gate — seed failed on `agents-staging.e2a.dev` — and the **prod** prober gate (P2) would fail identically.

## Fix

- **`Store.AdoptSharedDomain(domain, userID)`** — assigns ownership of an existing **unowned** row (or one already owned by `userID`, so re-seeding is idempotent) to the probe user via `UPDATE … WHERE user_id IS NULL OR user_id = $2 RETURNING …`. `verified`/DKIM columns are untouched; a row owned by a different account (or a missing row) returns `ErrDomainTaken`.
- **`seed`** falls back to `AdoptSharedDomain` when `ClaimOrCreateDomain` reports `ErrDomainTaken`, then skips verification (the adopted shared row is already verified). `createAgent` does not require domain ownership, so probe agent creation is unaffected.

`EnsureSharedDomain` is `ON CONFLICT DO NOTHING`, so the probe's ownership persists across server reboots.

## Testing

- `TestSeedProbe_AdoptsPreSeededSharedDomain` — pre-seeds the shared domain (as the server does), seeds the probe, asserts probe ownership + still verified + idempotent re-seed. **This is the regression** (fails before the fix with `ErrDomainTaken`).
- `TestAdoptSharedDomain` — ownerless adopt, idempotent re-adopt, reject cross-user steal, missing domain → `ErrDomainTaken`.
- Existing `TestSeedProbe_ProvisionsSystemAccountIdempotently` (fresh-domain path) still passes.
- **End-to-end:** with this change the **staging prober gate goes green across all six scenarios** (liveness, auth_read, inbound_round_trip, outbound_send, self_send_loopback, agent_lifecycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Btj6LswdbWqSgMavGJzBp