### PR TITLE
feat: caller-supplied Reply-To on outbound send/reply/forward

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1121,6 +1121,7 @@ components:
         recipient:
           type: string
         reply_to:
+          description: The parsed Reply-To header of an inbound message. Populated for inbound only; always empty for outbound (a Reply-To you SET on a send is a request-side field and is not echoed back here).
           items:
             type: string
           type: array
@@ -1210,6 +1211,7 @@ components:
         recipient:
           type: string
         reply_to:
+          description: The parsed Reply-To header of an inbound message. Populated for inbound only; always empty for outbound (a Reply-To you SET on a send is a request-side field on the send/reply/forward body and is not echoed back here).
           items:
             type: string
           type: array

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -876,6 +876,9 @@ components:
           type: string
         html_body:
           type: string
+        reply_to:
+          description: Sets the Reply-To header — where replies to this message are directed. A single RFC 5322 address, optionally with a display name. Defaults to the sending agent's own address.
+          type: string
         to:
           items:
             type: string
@@ -1675,6 +1678,9 @@ components:
           type: string
         reply_all:
           type: boolean
+        reply_to:
+          description: Sets the Reply-To header — where replies to this message are directed. A single RFC 5322 address, optionally with a display name. Defaults to the sending agent's own address.
+          type: string
       required:
         - body
       type: object
@@ -1769,6 +1775,9 @@ components:
           type: string
         html_body:
           description: Literal HTML body. Mutually exclusive with template_id/template_alias.
+          type: string
+        reply_to:
+          description: Sets the Reply-To header — where replies to this message are directed. A single RFC 5322 address, optionally with a display name (e.g. "Support <support@acme.com>"). Defaults to the sending agent's own address.
           type: string
         subject:
           description: Literal subject. Required unless a template reference is used (mutually exclusive with template_id/template_alias).

--- a/cli/src/bin/e2a.ts
+++ b/cli/src/bin/e2a.ts
@@ -60,6 +60,7 @@ Usage:
         --html-file <f>            HTML body; text fallback derived if no --body
         --attach <file>            Attach a file (repeatable)
         --conversation-id <id>     Thread id (alias: --conversation)
+        --reply-to <email>         Reply-To header (where replies go; default: the agent)
         --idempotency-key <k>      Stable key so a retried invocation can't double-send
         --agent <email>            Sending inbox (or config agent_email / E2A_AGENT_EMAIL)
         --json                     Print the full send result as JSON
@@ -322,7 +323,7 @@ async function main() {
     case "send":
       checkFlags(args, [
         "--to", "--subject", "--body", "--body-file", "--html-file", "--attach",
-        "--conversation-id", "--conversation", "--agent", "--idempotency-key", "--json",
+        "--conversation-id", "--conversation", "--reply-to", "--agent", "--idempotency-key", "--json",
       ]);
       await send({
         to: getFlagsChecked(args, "--to"),
@@ -335,6 +336,7 @@ async function main() {
         // trip each other's spelling.
         conversationId:
           getFlagChecked(args, "--conversation-id") ?? getFlagChecked(args, "--conversation"),
+        replyTo: getFlagChecked(args, "--reply-to"),
         agent: getFlagChecked(args, "--agent"),
         idempotencyKey: getFlagChecked(args, "--idempotency-key"),
         json: hasFlag(args, "--json"),
@@ -342,13 +344,14 @@ async function main() {
       break;
     case "reply":
       checkFlags(args, [
-        "--body", "--body-file", "--html-file", "--attach", "--agent", "--idempotency-key", "--json",
+        "--body", "--body-file", "--html-file", "--attach", "--reply-to", "--agent", "--idempotency-key", "--json",
       ]);
       await reply(getPositionals(args)[0], {
         attach: getFlagsChecked(args, "--attach"),
         body: getFlagChecked(args, "--body"),
         bodyFile: getFlagChecked(args, "--body-file"),
         htmlFile: getFlagChecked(args, "--html-file"),
+        replyTo: getFlagChecked(args, "--reply-to"),
         agent: getFlagChecked(args, "--agent"),
         idempotencyKey: getFlagChecked(args, "--idempotency-key"),
         json: hasFlag(args, "--json"),

--- a/cli/src/commands/send.ts
+++ b/cli/src/commands/send.ts
@@ -12,6 +12,7 @@ export interface SendOptions {
   bodyFile?: string;
   htmlFile?: string;
   conversationId?: string;
+  replyTo?: string;
   agent?: string;
   json?: boolean;
   idempotencyKey?: string;
@@ -22,6 +23,7 @@ export interface ReplyOptions {
   body?: string;
   bodyFile?: string;
   htmlFile?: string;
+  replyTo?: string;
   agent?: string;
   json?: boolean;
   idempotencyKey?: string;
@@ -60,9 +62,9 @@ function readAttachments(paths: string[] | undefined): Attachment[] | undefined 
 }
 
 const SEND_USAGE =
-  "usage: e2a send --to <email> --subject <s> (--body <text> | --body-file <f> | --html-file <f>) [--conversation-id <id>] [--agent <inbox>] [--json]";
+  "usage: e2a send --to <email> --subject <s> (--body <text> | --body-file <f> | --html-file <f>) [--conversation-id <id>] [--reply-to <email>] [--agent <inbox>] [--json]";
 const REPLY_USAGE =
-  "usage: e2a reply <message-id> (--body <text> | --body-file <f> | --html-file <f>) [--agent <inbox>] [--json]";
+  "usage: e2a reply <message-id> (--body <text> | --body-file <f> | --html-file <f>) [--reply-to <email>] [--agent <inbox>] [--json]";
 
 function readFileOrUsage(path: string, flag: string): string {
   try {
@@ -138,6 +140,7 @@ export async function send(opts: SendOptions): Promise<void> {
       body,
       htmlBody,
       conversationId: opts.conversationId,
+      replyTo: opts.replyTo,
       attachments: readAttachments(opts.attach),
     },
     opts.idempotencyKey ? { idempotencyKey: opts.idempotencyKey } : undefined,
@@ -154,7 +157,7 @@ export async function reply(messageId: string | undefined, opts: ReplyOptions): 
   const result = await client.messages.reply(
     agentEmail,
     messageId,
-    { body, htmlBody, attachments: readAttachments(opts.attach) },
+    { body, htmlBody, replyTo: opts.replyTo, attachments: readAttachments(opts.attach) },
     opts.idempotencyKey ? { idempotencyKey: opts.idempotencyKey } : undefined,
   );
   emitSendResult(result, opts.json);

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -980,7 +980,7 @@ func (a *API) HoldForApprovalCore(ctx context.Context, agent *identity.AgentIden
 				req.To, req.CC, req.BCC,
 				req.Subject, req.Body, req.HTMLBody,
 				attachmentsJSON,
-				msgType, req.ConversationID, replyToEmailMessageID,
+				msgType, req.ConversationID, replyToEmailMessageID, req.ReplyTo,
 				agent.HITLTTLSeconds,
 			)
 			if err != nil {
@@ -1006,7 +1006,7 @@ func (a *API) HoldForApprovalCore(ctx context.Context, agent *identity.AgentIden
 			req.To, req.CC, req.BCC,
 			req.Subject, req.Body, req.HTMLBody,
 			attachmentsJSON,
-			msgType, req.ConversationID, replyToEmailMessageID,
+			msgType, req.ConversationID, replyToEmailMessageID, req.ReplyTo,
 			agent.HITLTTLSeconds,
 		)
 		if err != nil {

--- a/internal/agent/approve_async_test.go
+++ b/internal/agent/approve_async_test.go
@@ -21,7 +21,7 @@ func TestApprovePendingCore_AsyncExternal(t *testing.T) {
 	user, ag := selfAgent(t, store, "apprasyncext")
 
 	msg, err := store.CreatePendingOutboundMessage(ctx, ag.ID,
-		[]string{"alice@external.test"}, nil, nil, "Held", "body", "", nil, "send", "", "", 3600)
+		[]string{"alice@external.test"}, nil, nil, "Held", "body", "", nil, "send", "", "", "", 3600)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -71,7 +71,7 @@ func TestApprovePendingCore_AsyncSelfSendStaysSync(t *testing.T) {
 	user, ag := selfAgent(t, store, "apprasyncself")
 
 	msg, err := store.CreatePendingOutboundMessage(ctx, ag.ID,
-		[]string{ag.EmailAddress()}, nil, nil, "To self", "body", "", nil, "send", "", "", 3600)
+		[]string{ag.EmailAddress()}, nil, nil, "To self", "body", "", nil, "send", "", "", "", 3600)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/agent/hitl_api.go
+++ b/internal/agent/hitl_api.go
@@ -268,6 +268,13 @@ func buildSendRequestFromMessage(m *identity.Message) (outbound.SendRequest, err
 	if m.Type == "reply" {
 		replyToMessageID = m.EmailMessageID
 	}
+	// A caller-supplied Reply-To override is persisted on the held row's reply_to
+	// column (single element) so it survives the recompose at approval time —
+	// without this the override would silently vanish on every reviewed send.
+	var replyTo string
+	if len(m.ReplyTo) > 0 {
+		replyTo = m.ReplyTo[0]
+	}
 	return outbound.SendRequest{
 		To:               m.ToRecipients,
 		CC:               m.CC,
@@ -275,6 +282,7 @@ func buildSendRequestFromMessage(m *identity.Message) (outbound.SendRequest, err
 		Subject:          m.Subject,
 		Body:             m.BodyText,
 		HTMLBody:         m.BodyHTML,
+		ReplyTo:          replyTo,
 		ReplyToMessageID: replyToMessageID,
 		ConversationID:   m.ConversationID,
 		Attachments:      attachments,

--- a/internal/agent/hitl_magic_api_test.go
+++ b/internal/agent/hitl_magic_api_test.go
@@ -79,7 +79,7 @@ func issuePending(t *testing.T, store *identity.Store, agentID string) *identity
 	msg, err := store.CreatePendingOutboundMessage(context.Background(), agentID,
 		[]string{"alice@example.com"}, nil, nil,
 		"Held", "plain body", "<p>html</p>", nil,
-		"send", "", "", 3600)
+		"send", "", "", "", 3600)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -249,7 +249,7 @@ func TestMagicApprovePOSTSelfSendDeliversViaLoopback(t *testing.T) {
 	held, err := store.CreatePendingOutboundMessage(ctx, a.ID,
 		[]string{a.EmailAddress()}, nil, nil,
 		"self-magic", "note to self via magic link", "", nil,
-		"send", "", "", 3600)
+		"send", "", "", "", 3600)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/hitlnotify/e2e_test.go
+++ b/internal/hitlnotify/e2e_test.go
@@ -77,7 +77,7 @@ func TestEndToEnd_AcceptTxThroughRiverToSMTP(t *testing.T) {
 	if err := store.WithTx(ctx, func(tx pgx.Tx) error {
 		m, err := store.CreatePendingOutboundMessageTx(ctx, tx, ag.ID,
 			[]string{"alice@example.com"}, nil, nil, "E2E subject", "body", "", nil,
-			"send", "conv-e2e", "", 3600)
+			"send", "conv-e2e", "", "", 3600)
 		if err != nil {
 			return err
 		}

--- a/internal/hitlnotify/notifier_test.go
+++ b/internal/hitlnotify/notifier_test.go
@@ -71,8 +71,7 @@ func setupPendingMessage(t *testing.T, store *identity.Store, slug string) (*ide
 	msg, err := store.CreatePendingOutboundMessage(ctx, a.ID,
 		[]string{"alice@example.com"}, []string{"carol@example.com"}, nil,
 		"Important draft", "This is the body that will be reviewed.", "<p>html body</p>",
-		nil, "send", "conv_1", "", 3600,
-	)
+		nil, "send", "conv_1", "", "", 3600)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/hitlnotify/reconcile_test.go
+++ b/internal/hitlnotify/reconcile_test.go
@@ -43,7 +43,7 @@ func TestReconcilePending_EnqueuesStrandedAndStamps(t *testing.T) {
 	}
 	msg, err := store.CreatePendingOutboundMessage(ctx, ag.ID,
 		[]string{"a@gmail.com"}, nil, nil, "Subject", "body", "", nil,
-		"send", "conv-notify-recon", "", 3600)
+		"send", "conv-notify-recon", "", "", 3600)
 	if err != nil {
 		t.Fatalf("CreatePendingOutboundMessage: %v", err)
 	}
@@ -93,7 +93,7 @@ func TestReconcilePending_EnqueuesStrandedAndStamps(t *testing.T) {
 	// SKIPPED — never re-notified. Seed one and assert the reconciler ignores it.
 	already, err := store.CreatePendingOutboundMessage(ctx, ag.ID,
 		[]string{"b@gmail.com"}, nil, nil, "Already", "body", "", nil,
-		"send", "conv-already", "", 3600)
+		"send", "conv-already", "", "", 3600)
 	if err != nil {
 		t.Fatalf("CreatePendingOutboundMessage(already): %v", err)
 	}

--- a/internal/hitlworker/async_approve_test.go
+++ b/internal/hitlworker/async_approve_test.go
@@ -33,7 +33,7 @@ func TestWorkerAutoApproveAsync(t *testing.T) {
 
 	msg, err := store.CreatePendingOutboundMessage(ctx, agent.ID,
 		[]string{"alice@external.test"}, nil, nil,
-		"Held", "body", "<p>html</p>", nil, "send", "", "", 60)
+		"Held", "body", "<p>html</p>", nil, "send", "", "", "", 60)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -80,7 +80,7 @@ func TestWorkerAutoApproveAsync_SelfSendStaysLoopback(t *testing.T) {
 
 	msg, err := store.CreatePendingOutboundMessage(ctx, agent.ID,
 		[]string{agent.EmailAddress()}, nil, nil,
-		"To myself", "body", "", nil, "send", "", "", 60)
+		"To myself", "body", "", nil, "send", "", "", "", 60)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/hitlworker/events_test.go
+++ b/internal/hitlworker/events_test.go
@@ -130,7 +130,7 @@ func TestWorkerEmitsOutboundReviewRejectedOnExpiry(t *testing.T) {
 
 	agent := prepareAgent(t, store, "emit-outreject", identity.HITLExpirationReject)
 	msg, err := store.CreatePendingOutboundMessage(ctx, agent.ID,
-		[]string{"alice@example.com"}, nil, nil, "Held", "body", "<p>html</p>", nil, "send", "", "", 60)
+		[]string{"alice@example.com"}, nil, nil, "Held", "body", "<p>html</p>", nil, "send", "", "", "", 60)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -158,7 +158,7 @@ func TestWorkerEmitsOutboundReviewApprovedOnExpiry(t *testing.T) {
 
 	agent := prepareAgent(t, store, "emit-outapprove", identity.HITLExpirationApprove)
 	msg, err := store.CreatePendingOutboundMessage(ctx, agent.ID,
-		[]string{"alice@example.com"}, nil, nil, "Held", "body", "<p>html</p>", nil, "send", "", "", 60)
+		[]string{"alice@example.com"}, nil, nil, "Held", "body", "<p>html</p>", nil, "send", "", "", "", 60)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/hitlworker/worker.go
+++ b/internal/hitlworker/worker.go
@@ -356,6 +356,13 @@ func sendRequestFromStoredMessage(m *identity.Message) (outbound.SendRequest, er
 			return outbound.SendRequest{}, err
 		}
 	}
+	// Carry a caller-supplied Reply-To override (persisted single-element on the
+	// held row's reply_to column) through the TTL auto-approve recompose, so an
+	// expired-but-approved send keeps the same Reply-To a human approval would.
+	var replyTo string
+	if len(m.ReplyTo) > 0 {
+		replyTo = m.ReplyTo[0]
+	}
 	return outbound.SendRequest{
 		To:               m.ToRecipients,
 		CC:               m.CC,
@@ -363,6 +370,7 @@ func sendRequestFromStoredMessage(m *identity.Message) (outbound.SendRequest, er
 		Subject:          m.Subject,
 		Body:             m.BodyText,
 		HTMLBody:         m.BodyHTML,
+		ReplyTo:          replyTo,
 		ReplyToMessageID: m.EmailMessageID,
 		ConversationID:   m.ConversationID,
 		Attachments:      attachments,

--- a/internal/hitlworker/worker_test.go
+++ b/internal/hitlworker/worker_test.go
@@ -161,6 +161,37 @@ func TestWorkerAutoApprovesExpiredPending(t *testing.T) {
 	}
 }
 
+// TestWorkerAutoApproveCarriesReplyTo pins the Reply-To override through the
+// SYNC TTL auto-approve path end-to-end: pending row with a caller override →
+// TTL expiry → ExpireApproveAndSend recompose → composed SMTP bytes carry the
+// override, not the agent's own address. This is the exact seam where a missing
+// reply_to in ExpireApproveAndSend's locked SELECT silently dropped the override.
+func TestWorkerAutoApproveCarriesReplyTo(t *testing.T) {
+	w, store, pool, smtpDone := setupWorker(t)
+	ctx := context.Background()
+
+	agent := prepareAgent(t, store, "auto-approve-rt", identity.HITLExpirationApprove)
+	const override = "Support <support@acme.com>"
+	msg, _ := store.CreatePendingOutboundMessage(ctx, agent.ID,
+		[]string{"alice@example.com"}, nil, nil,
+		"RT subject", "plain body", "", nil,
+		"send", "", "", override, 60)
+	backdateExpiry(t, pool, msg.ID)
+
+	w.RunOnce(ctx)
+
+	msgs := smtpDone()
+	if len(msgs) != 1 {
+		t.Fatalf("expected 1 SMTP message, got %d", len(msgs))
+	}
+	if !strings.Contains(msgs[0].Data, "Reply-To: "+override) {
+		t.Errorf("SMTP body missing overridden Reply-To %q:\n%s", override, msgs[0].Data)
+	}
+	if strings.Contains(msgs[0].Data, "Reply-To: "+agent.EmailAddress()) {
+		t.Errorf("SMTP body fell back to agent-address Reply-To — override was dropped:\n%s", msgs[0].Data)
+	}
+}
+
 // TestWorkerAutoApproveSelfSendDeliversViaLoopback: a held self-send
 // whose TTL expires with the agent's hitl_expiration_action="approve"
 // must be auto-approved via the loopback path — outbound.Sender.Send

--- a/internal/hitlworker/worker_test.go
+++ b/internal/hitlworker/worker_test.go
@@ -82,7 +82,7 @@ func TestWorkerAutoRejectsExpiredPending(t *testing.T) {
 	msg, err := store.CreatePendingOutboundMessage(ctx, agent.ID,
 		[]string{"alice@example.com"}, nil, nil,
 		"Held", "body", "<p>html</p>", nil,
-		"send", "", "", 60)
+		"send", "", "", "", 60)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -122,7 +122,7 @@ func TestWorkerAutoApprovesExpiredPending(t *testing.T) {
 	msg, _ := store.CreatePendingOutboundMessage(ctx, agent.ID,
 		[]string{"alice@example.com"}, nil, nil,
 		"Auto-send subject", "plain body", "<p>html body</p>", nil,
-		"send", "", "", 60)
+		"send", "", "", "", 60)
 	backdateExpiry(t, pool, msg.ID)
 
 	w.RunOnce(ctx)
@@ -178,7 +178,7 @@ func TestWorkerAutoApproveSelfSendDeliversViaLoopback(t *testing.T) {
 	msg, err := store.CreatePendingOutboundMessage(ctx, agent.ID,
 		[]string{agent.EmailAddress()}, nil, nil,
 		"self auto-approve", "note to self body", "", nil,
-		"send", "", "", 60)
+		"send", "", "", "", 60)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -239,7 +239,7 @@ func TestWorkerAutoApproveSendFailureFallsBackToRejected(t *testing.T) {
 	agent := prepareAgent(t, store, "auto-approve-fail", identity.HITLExpirationApprove)
 	msg, _ := store.CreatePendingOutboundMessage(ctx, agent.ID,
 		[]string{"alice@example.com"}, nil, nil,
-		"x", "body", "", nil, "send", "", "", 60)
+		"x", "body", "", nil, "send", "", "", "", 60)
 	backdateExpiry(t, pool, msg.ID)
 
 	w.RunOnce(ctx)
@@ -279,7 +279,7 @@ func TestWorkerAutoApproveUnverifiedAgentRejects(t *testing.T) {
 
 	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
 		[]string{"alice@example.com"}, nil, nil,
-		"x", "body", "", nil, "send", "", "", 60)
+		"x", "body", "", nil, "send", "", "", "", 60)
 	backdateExpiry(t, pool, msg.ID)
 
 	w.RunOnce(ctx)
@@ -307,7 +307,7 @@ func TestWorkerSkipsFreshPending(t *testing.T) {
 	agent := prepareAgent(t, store, "skip-fresh", identity.HITLExpirationReject)
 	msg, _ := store.CreatePendingOutboundMessage(ctx, agent.ID,
 		[]string{"alice@example.com"}, nil, nil,
-		"fresh", "b", "", nil, "send", "", "", 3600)
+		"fresh", "b", "", nil, "send", "", "", "", 3600)
 
 	w.RunOnce(ctx)
 

--- a/internal/httpapi/messages.go
+++ b/internal/httpapi/messages.go
@@ -24,7 +24,7 @@ type MessageView struct {
 	From           string   `json:"from"`
 	To             []string `json:"to" nullable:"false"`
 	CC             []string `json:"cc" nullable:"false"`
-	ReplyTo        []string `json:"reply_to" nullable:"false"`
+	ReplyTo        []string `json:"reply_to" nullable:"false" doc:"The parsed Reply-To header of an inbound message. Populated for inbound only; always empty for outbound (a Reply-To you SET on a send is a request-side field on the send/reply/forward body and is not echoed back here)."`
 	Recipient      string   `json:"recipient"`
 	Subject        string   `json:"subject"`
 	ConversationID string   `json:"conversation_id"`
@@ -222,7 +222,7 @@ type MessageSummaryView struct {
 	From           string   `json:"from"`
 	To             []string `json:"to" nullable:"false"`
 	CC             []string `json:"cc,omitempty" nullable:"false"`
-	ReplyTo        []string `json:"reply_to,omitempty" nullable:"false"`
+	ReplyTo        []string `json:"reply_to,omitempty" nullable:"false" doc:"The parsed Reply-To header of an inbound message. Populated for inbound only; always empty for outbound (a Reply-To you SET on a send is a request-side field and is not echoed back here)."`
 	Recipient      string   `json:"recipient"`
 	Subject        string   `json:"subject"`
 	ConversationID string   `json:"conversation_id,omitempty"`

--- a/internal/httpapi/messages.go
+++ b/internal/httpapi/messages.go
@@ -132,7 +132,7 @@ func messageViewFromIdentity(m *identity.Message) MessageView {
 		From:           m.Sender,
 		To:             orEmptyStrings(m.ToRecipients),
 		CC:             orEmptyStrings(m.CC),
-		ReplyTo:        orEmptyStrings(m.ReplyTo),
+		ReplyTo:        inboundReplyToView(m),
 		Recipient:      m.Recipient,
 		Subject:        m.Subject,
 		ConversationID: m.ConversationID,
@@ -263,6 +263,19 @@ func authVerdict(r *emailauth.Result) *AuthVerdict {
 	return &v
 }
 
+// inboundReplyToView returns the parsed inbound Reply-To for the wire view. The
+// reply_to field is defined as the Reply-To header PARSED off an inbound message;
+// on outbound rows the same column now doubles as internal storage for a caller's
+// Reply-To OVERRIDE (so a held send survives the approval recompose), which is a
+// different concept and must not leak into the message view. Gate on direction so
+// the field keeps its single documented meaning.
+func inboundReplyToView(m *identity.Message) []string {
+	if m.Direction != "inbound" {
+		return []string{}
+	}
+	return orEmptyStrings(m.ReplyTo)
+}
+
 func messageSummaryFromIdentity(m identity.Message) MessageSummaryView {
 	s := MessageSummaryView{
 		ID:             m.ID,
@@ -270,7 +283,7 @@ func messageSummaryFromIdentity(m identity.Message) MessageSummaryView {
 		From:           m.Sender,
 		To:             orEmptyStrings(m.ToRecipients),
 		CC:             orEmptyStrings(m.CC),
-		ReplyTo:        orEmptyStrings(m.ReplyTo),
+		ReplyTo:        inboundReplyToView(&m),
 		Recipient:      m.Recipient,
 		Subject:        m.Subject,
 		ConversationID: m.ConversationID,

--- a/internal/httpapi/messages_parsed_test.go
+++ b/internal/httpapi/messages_parsed_test.go
@@ -6,6 +6,34 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/identity"
 )
 
+// TestMessageViewReplyToDirectionGated: the wire `reply_to` field means the
+// PARSED INBOUND Reply-To header. The same identity column now doubles as
+// storage for an outbound override (so held sends survive the approval
+// recompose), which must NOT leak into the view. Inbound preserves it; outbound
+// is always [] regardless of the stored override.
+func TestMessageViewReplyToDirectionGated(t *testing.T) {
+	inbound := messageViewFromIdentity(&identity.Message{
+		ID: "msg_in", Direction: "inbound", ReplyTo: []string{"real-reply@x.com"},
+	})
+	if len(inbound.ReplyTo) != 1 || inbound.ReplyTo[0] != "real-reply@x.com" {
+		t.Errorf("inbound view ReplyTo = %v, want [real-reply@x.com]", inbound.ReplyTo)
+	}
+
+	outbound := messageViewFromIdentity(&identity.Message{
+		ID: "msg_out", Direction: "outbound", ReplyTo: []string{"override@acme.com"},
+	})
+	if len(outbound.ReplyTo) != 0 {
+		t.Errorf("outbound view ReplyTo = %v, want [] (override must not leak)", outbound.ReplyTo)
+	}
+
+	summary := messageSummaryFromIdentity(identity.Message{
+		ID: "msg_out", Direction: "outbound", ReplyTo: []string{"override@acme.com"},
+	})
+	if len(summary.ReplyTo) != 0 {
+		t.Errorf("outbound summary ReplyTo = %v, want []", summary.ReplyTo)
+	}
+}
+
 // Any message carrying raw MIME gets a parsed view (quoted reply stripped) —
 // inbound and sent outbound alike. Held drafts (no raw) don't.
 func TestMessageViewParsed(t *testing.T) {

--- a/internal/httpapi/outbound.go
+++ b/internal/httpapi/outbound.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/mail"
 	"reflect"
 	"strings"
 	"time"
@@ -114,6 +115,7 @@ type SendEmailRequest struct {
 	TemplateAlias  string                `json:"template_alias,omitempty" doc:"Send using a stored template resolved by its per-user alias. Mutually exclusive with template_id and with literal subject/body/html_body. Beta: templates are unstable — their shape may change before they are declared stable."`
 	TemplateData   TemplateData          `json:"template_data,omitempty" doc:"Variables for the referenced template ({{name}}, dot paths into nested objects). Missing variables render as empty strings. Beta: templates are unstable — their shape may change before they are declared stable."`
 	ConversationID string                `json:"conversation_id,omitempty"`
+	ReplyTo        string                `json:"reply_to,omitempty" doc:"Sets the Reply-To header — where replies to this message are directed. A single RFC 5322 address, optionally with a display name (e.g. \"Support <support@acme.com>\"). Defaults to the sending agent's own address."`
 	Attachments    []outbound.Attachment `json:"attachments,omitempty" nullable:"false"`
 }
 
@@ -219,6 +221,7 @@ type ReplyRequest struct {
 	CC             []string              `json:"cc,omitempty" nullable:"false"`
 	BCC            []string              `json:"bcc,omitempty" nullable:"false"`
 	ConversationID string                `json:"conversation_id,omitempty"`
+	ReplyTo        string                `json:"reply_to,omitempty" doc:"Sets the Reply-To header — where replies to this message are directed. A single RFC 5322 address, optionally with a display name. Defaults to the sending agent's own address."`
 	Attachments    []outbound.Attachment `json:"attachments,omitempty" nullable:"false"`
 }
 
@@ -273,6 +276,9 @@ func (s *Server) handleReply(ctx context.Context, in *replyInput) (*sendOutput, 
 	if e := validateConversationID(b.ConversationID); e != nil {
 		return nil, NewError(http.StatusBadRequest, "invalid_request", e.Error())
 	}
+	if env := validateReplyTo(b.ReplyTo); env != nil {
+		return nil, env
+	}
 	// Build the reply request via the same outbound helpers the legacy
 	// handler uses (subject normalization, recipient parsing, References).
 	subject := msg.Subject
@@ -303,7 +309,7 @@ func (s *Server) handleReply(ctx context.Context, in *replyInput) (*sendOutput, 
 		// conversation_id resolution (caller id > inherit-from-referenced > mint)
 		// is centralized in DeliverOutbound, which receives this message as the
 		// referenced message — so the reply inherits its thread there (#328).
-		ConversationID: b.ConversationID, Attachments: b.Attachments,
+		ConversationID: b.ConversationID, ReplyTo: b.ReplyTo, Attachments: b.Attachments,
 	}
 	req.CC = agent.StripAgentSelfAliases(req.CC, ag.EmailAddress())
 	req.BCC = agent.StripAgentSelfAliases(req.BCC, ag.EmailAddress())
@@ -351,6 +357,7 @@ type ForwardRequest struct {
 	Body           string                `json:"body"` // required (MSG-3); subject derived as "Fwd:"
 	HTMLBody       string                `json:"html_body,omitempty"`
 	ConversationID string                `json:"conversation_id,omitempty"`
+	ReplyTo        string                `json:"reply_to,omitempty" doc:"Sets the Reply-To header — where replies to this message are directed. A single RFC 5322 address, optionally with a display name. Defaults to the sending agent's own address."`
 	Attachments    []outbound.Attachment `json:"attachments,omitempty" nullable:"false" doc:"Additional attachments to include alongside the forwarded message's original attachments, which are carried over automatically."`
 }
 
@@ -381,6 +388,9 @@ func (s *Server) handleForward(ctx context.Context, in *forwardInput) (*sendOutp
 	if e := validateConversationID(b.ConversationID); e != nil {
 		return nil, NewError(http.StatusBadRequest, "invalid_request", e.Error())
 	}
+	if env := validateReplyTo(b.ReplyTo); env != nil {
+		return nil, env
+	}
 	subject := outbound.BuildForwardSubject(msg.Subject)
 	fwdCtx := outbound.ExtractForwardContext(msg.RawMessage)
 	composedBody := outbound.BuildForwardBody(b.Body, fwdCtx)
@@ -396,7 +406,7 @@ func (s *Server) handleForward(ctx context.Context, in *forwardInput) (*sendOutp
 	attachments = append(attachments, b.Attachments...)
 	req := outbound.SendRequest{
 		To: b.To, CC: b.CC, BCC: b.BCC, Subject: subject, Body: composedBody, HTMLBody: composedHTML,
-		ConversationID: b.ConversationID, Attachments: attachments,
+		ConversationID: b.ConversationID, ReplyTo: b.ReplyTo, Attachments: attachments,
 	}
 	req.CC = agent.StripAgentSelfAliases(req.CC, ag.EmailAddress())
 	req.BCC = agent.StripAgentSelfAliases(req.BCC, ag.EmailAddress())
@@ -422,6 +432,28 @@ func (s *Server) validateOutboundBody(subject, body string, to, cc, bcc []string
 	}
 	if err := validateConversationID(conversationID); err != nil {
 		return NewError(http.StatusBadRequest, "invalid_request", err.Error())
+	}
+	return nil
+}
+
+// validateReplyTo checks a caller-supplied Reply-To override. Empty is valid
+// (the compose layer defaults it to the agent's own address). A non-empty value
+// must be exactly one RFC 5322 address, optionally with a display name; multiple
+// addresses and unparseable input are rejected at the edge so a bad Reply-To
+// never reaches the composer (where sanitizeHeaderValue would silently mangle
+// it) or the SMTP relay (a generic 500).
+func validateReplyTo(replyTo string) *ErrorEnvelope {
+	if replyTo == "" {
+		return nil
+	}
+	addrs, err := mail.ParseAddressList(replyTo)
+	if err != nil {
+		return NewError(http.StatusBadRequest, "invalid_request",
+			fmt.Sprintf("reply_to is not a valid email address: %v", err))
+	}
+	if len(addrs) != 1 {
+		return NewError(http.StatusBadRequest, "invalid_request",
+			"reply_to must be a single email address")
 	}
 	return nil
 }
@@ -643,12 +675,16 @@ func (s *Server) handleCreateMessage(ctx context.Context, in *createMessageInput
 		if env := s.validateOutboundBody(b.Subject, b.Body, b.To, b.CC, b.BCC, b.ConversationID); env != nil {
 			return outbound.SendRequest{}, env
 		}
+		if env := validateReplyTo(b.ReplyTo); env != nil {
+			return outbound.SendRequest{}, env
+		}
 		// The sender is the path agent (decision 3) — there is no body `from`;
 		// the agent is the path and auth scopes the sender, so no spoofing is
 		// possible.
 		return outbound.SendRequest{
 			From: ag.EmailAddress(), To: b.To, CC: b.CC, BCC: b.BCC, Subject: b.Subject,
-			Body: b.Body, HTMLBody: b.HTMLBody, ConversationID: b.ConversationID, Attachments: b.Attachments,
+			Body: b.Body, HTMLBody: b.HTMLBody, ConversationID: b.ConversationID,
+			ReplyTo: b.ReplyTo, Attachments: b.Attachments,
 		}, nil
 	}
 	// A cold send has no referenced inbound (nil) — it's not a reply/forward.

--- a/internal/httpapi/outbound_test.go
+++ b/internal/httpapi/outbound_test.go
@@ -76,6 +76,48 @@ func TestSendInvalidRecipient(t *testing.T) {
 	}
 }
 
+// TestSendReplyToPropagates: a valid reply_to reaches the delivery layer verbatim
+// (display name preserved), so the composer can set the Reply-To header.
+func TestSendReplyToPropagates(t *testing.T) {
+	srv := testServer(t)
+	code, body := postJSON(t, srv.URL+sendURL, "good", map[string]any{
+		"to": []string{"alice@x.com"}, "subject": "Hi", "body": "hello",
+		"reply_to": "Support <support@acme.com>",
+	})
+	if code != 200 || body["status"] != "sent" {
+		t.Fatalf("want 200 sent, got %d %v", code, body)
+	}
+	if got := lastDeliveredReq().ReplyTo; got != "Support <support@acme.com>" {
+		t.Fatalf("delivered ReplyTo = %q, want %q", got, "Support <support@acme.com>")
+	}
+}
+
+// TestSendInvalidReplyTo: a non-address reply_to is rejected at the edge (400)
+// rather than silently mangled by the composer or bounced by the relay.
+func TestSendInvalidReplyTo(t *testing.T) {
+	srv := testServer(t)
+	code, body := postJSON(t, srv.URL+sendURL, "good", map[string]any{
+		"to": []string{"alice@x.com"}, "subject": "Hi", "body": "hello",
+		"reply_to": "not an address",
+	})
+	if code != 400 || errCode(body) != "invalid_request" {
+		t.Fatalf("want 400 invalid_request for bad reply_to, got %d %v", code, body)
+	}
+}
+
+// TestSendMultiReplyToRejected: Reply-To carries a single mailbox in our contract;
+// a comma list is rejected so callers don't rely on unspecified multi-address behavior.
+func TestSendMultiReplyToRejected(t *testing.T) {
+	srv := testServer(t)
+	code, body := postJSON(t, srv.URL+sendURL, "good", map[string]any{
+		"to": []string{"alice@x.com"}, "subject": "Hi", "body": "hello",
+		"reply_to": "a@x.com, b@x.com",
+	})
+	if code != 400 || errCode(body) != "invalid_request" {
+		t.Fatalf("want 400 invalid_request for multi reply_to, got %d %v", code, body)
+	}
+}
+
 // TestSendSetsAgentAsSender: there is no body `from` — the sender is the path
 // agent and auth scopes it. A plain send (no `from`) succeeds.
 func TestSendSetsAgentAsSender(t *testing.T) {

--- a/internal/httpapi/outbound_test.go
+++ b/internal/httpapi/outbound_test.go
@@ -190,6 +190,52 @@ func TestReplySent(t *testing.T) {
 	}
 }
 
+// TestReplyReplyToPropagates / TestForwardReplyToPropagates: reply and forward
+// each build their own outbound.SendRequest literal, so a dropped ReplyTo mapping
+// there wouldn't be caught by the send-path test. Assert the override reaches the
+// delivery layer on both.
+func TestReplyReplyToPropagates(t *testing.T) {
+	srv := testServer(t)
+	code, _ := postJSON(t, srv.URL+"/v1/agents/support%40acme.com/messages/msg_in1/reply", "good",
+		map[string]any{"body": "thanks", "reply_to": "Support <support@acme.com>"})
+	if code != 200 {
+		t.Fatalf("want 200, got %d", code)
+	}
+	if got := lastDeliveredReq().ReplyTo; got != "Support <support@acme.com>" {
+		t.Fatalf("reply delivered ReplyTo = %q, want override", got)
+	}
+}
+
+func TestReplyInvalidReplyTo(t *testing.T) {
+	srv := testServer(t)
+	code, body := postJSON(t, srv.URL+"/v1/agents/support%40acme.com/messages/msg_in1/reply", "good",
+		map[string]any{"body": "thanks", "reply_to": "not an address"})
+	if code != 400 || errCode(body) != "invalid_request" {
+		t.Fatalf("want 400 invalid_request, got %d %v", code, body)
+	}
+}
+
+func TestForwardReplyToPropagates(t *testing.T) {
+	srv := testServer(t)
+	code, _ := postJSON(t, srv.URL+"/v1/agents/support%40acme.com/messages/msg_in1/forward", "good",
+		map[string]any{"to": []string{"newperson@x.com"}, "body": "fyi", "reply_to": "Support <support@acme.com>"})
+	if code != 200 {
+		t.Fatalf("want 200, got %d", code)
+	}
+	if got := lastDeliveredReq().ReplyTo; got != "Support <support@acme.com>" {
+		t.Fatalf("forward delivered ReplyTo = %q, want override", got)
+	}
+}
+
+func TestForwardInvalidReplyTo(t *testing.T) {
+	srv := testServer(t)
+	code, body := postJSON(t, srv.URL+"/v1/agents/support%40acme.com/messages/msg_in1/forward", "good",
+		map[string]any{"to": []string{"newperson@x.com"}, "body": "fyi", "reply_to": "a@x.com, b@x.com"})
+	if code != 400 || errCode(body) != "invalid_request" {
+		t.Fatalf("want 400 invalid_request for multi reply_to, got %d %v", code, body)
+	}
+}
+
 // TestReplyAllRespectsRecipientCap: reply_all expands the thread's recipients
 // into the outbound set, so the cap must be enforced on the FINAL set — not just
 // the caller-supplied cc/bcc (which is empty here).

--- a/internal/identity/approve_accept_test.go
+++ b/internal/identity/approve_accept_test.go
@@ -35,7 +35,7 @@ func TestApproveAndAccept(t *testing.T) {
 	}
 	msg, err := store.CreatePendingOutboundMessage(ctx, ag.ID,
 		[]string{"a@gmail.com"}, nil, nil, "Subj", "body", "", nil,
-		"send", "conv-aa", "", 3600)
+		"send", "conv-aa", "", "", 3600)
 	if err != nil {
 		t.Fatalf("CreatePendingOutboundMessage: %v", err)
 	}

--- a/internal/identity/hitl_approve_test.go
+++ b/internal/identity/hitl_approve_test.go
@@ -183,6 +183,37 @@ func TestListPendingOutboundForUserScoping(t *testing.T) {
 	}
 }
 
+// TestApproveAndSendCarriesReplyTo pins that a caller Reply-To override survives
+// ApproveAndSend's own locked SELECT/scan (a third hand-maintained query, distinct
+// from GetOutboundMessageForUser and LoadOutboundDraft) and reaches the send
+// callback's message. A dropped reply_to column here silently strips the override
+// on every human-approved send.
+func TestApproveAndSendCarriesReplyTo(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, a := setupPendingAgent(t, store, "approve-rt")
+	const override = "Support <support@acme.com>"
+	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
+		[]string{"alice@example.com"}, nil, nil,
+		"Draft", "body", "", nil,
+		"send", "", "", override, 3600)
+
+	var got []string
+	_, err := store.ApproveAndSend(ctx, msg.ID, user.ID, identity.PendingApprovalEdit{},
+		func(m *identity.Message) (identity.SendResult, error) {
+			got = m.ReplyTo
+			return identity.SendResult{ProviderMessageID: "<x@ses>", Method: "smtp", To: m.ToRecipients}, nil
+		})
+	if err != nil {
+		t.Fatalf("ApproveAndSend: %v", err)
+	}
+	if len(got) != 1 || got[0] != override {
+		t.Errorf("send callback ReplyTo = %v, want [%q]", got, override)
+	}
+}
+
 func TestApproveAndSendHappyPath(t *testing.T) {
 	pool := testutil.TestDB(t)
 	store := identity.NewStore(pool)

--- a/internal/identity/hitl_approve_test.go
+++ b/internal/identity/hitl_approve_test.go
@@ -52,8 +52,7 @@ func TestGetOutboundMessageForUser(t *testing.T) {
 		"Draft", "plain", "<p>html</p>",
 		atts,
 		"send", "conv_1", "",
-		3600,
-	)
+		"", 3600)
 	if err != nil {
 		t.Fatalf("CreatePendingOutboundMessage: %v", err)
 	}
@@ -100,8 +99,7 @@ func TestGetOutboundMessageForUserCrossUserIsNotFound(t *testing.T) {
 		ctx, a.ID,
 		[]string{"alice@example.com"}, nil, nil,
 		"Draft", "b", "", nil,
-		"send", "", "", 3600,
-	)
+		"send", "", "", "", 3600)
 
 	_, err = store.GetOutboundMessageForUser(ctx, msg.ID, otherUser.ID)
 	if !errors.Is(err, identity.ErrMessageNotFound) {
@@ -118,17 +116,17 @@ func TestListPendingOutboundForUser(t *testing.T) {
 
 	// Three pending messages with different expiries
 	_, err := store.CreatePendingOutboundMessage(ctx, a.ID,
-		[]string{"c@example.com"}, nil, nil, "C", "x", "", nil, "send", "", "", 7200)
+		[]string{"c@example.com"}, nil, nil, "C", "x", "", nil, "send", "", "", "", 7200)
 	if err != nil {
 		t.Fatal(err)
 	}
 	_, err = store.CreatePendingOutboundMessage(ctx, a.ID,
-		[]string{"a@example.com"}, nil, nil, "A", "x", "", nil, "send", "", "", 600)
+		[]string{"a@example.com"}, nil, nil, "A", "x", "", nil, "send", "", "", "", 600)
 	if err != nil {
 		t.Fatal(err)
 	}
 	_, err = store.CreatePendingOutboundMessage(ctx, a.ID,
-		[]string{"b@example.com"}, nil, nil, "B", "x", "", nil, "send", "", "", 3600)
+		[]string{"b@example.com"}, nil, nil, "B", "x", "", nil, "send", "", "", "", 3600)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -172,9 +170,9 @@ func TestListPendingOutboundForUserScoping(t *testing.T) {
 	_, agentB := setupPendingAgent(t, store, "scope-b")
 
 	_, _ = store.CreatePendingOutboundMessage(ctx, agentA.ID,
-		[]string{"x@example.com"}, nil, nil, "A-msg", "b", "", nil, "send", "", "", 3600)
+		[]string{"x@example.com"}, nil, nil, "A-msg", "b", "", nil, "send", "", "", "", 3600)
 	_, _ = store.CreatePendingOutboundMessage(ctx, agentB.ID,
-		[]string{"x@example.com"}, nil, nil, "B-msg", "b", "", nil, "send", "", "", 3600)
+		[]string{"x@example.com"}, nil, nil, "B-msg", "b", "", nil, "send", "", "", "", 3600)
 
 	got, err := store.ListPendingOutboundForUser(ctx, userA.ID, 50)
 	if err != nil {
@@ -196,7 +194,7 @@ func TestApproveAndSendHappyPath(t *testing.T) {
 		[]string{"alice@example.com"}, []string{"carol@example.com"}, nil,
 		"Draft", "body", "<p>body</p>",
 		[]byte(`[{"filename":"x.txt","content_type":"text/plain","data":"aGk="}]`),
-		"send", "conv_h", "", 3600)
+		"send", "conv_h", "", "", 3600)
 
 	var receivedSubject string
 	var receivedBody string
@@ -277,7 +275,7 @@ func TestApproveAndSend_RecordsReviewedBy(t *testing.T) {
 
 	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
 		[]string{"alice@example.com"}, nil, nil,
-		"With reviewer", "body", "", nil, "send", "", "", 3600)
+		"With reviewer", "body", "", nil, "send", "", "", "", 3600)
 
 	sent, err := store.ApproveAndSend(ctx, msg.ID, user.ID, identity.PendingApprovalEdit{},
 		func(m *identity.Message) (identity.SendResult, error) {
@@ -313,7 +311,7 @@ func TestRejectPending_RecordsReviewedBy(t *testing.T) {
 	user, a := setupPendingAgent(t, store, "reject-reviewer")
 	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
 		[]string{"alice@example.com"}, nil, nil,
-		"to-reject", "body", "", nil, "send", "", "", 3600)
+		"to-reject", "body", "", nil, "send", "", "", "", 3600)
 
 	rejected, err := store.RejectPending(ctx, msg.ID, user.ID, "wrong tone")
 	if err != nil {
@@ -339,7 +337,7 @@ func TestExpireApprove_ReviewedByNil(t *testing.T) {
 	user, a := setupPendingAgent(t, store, "expire-no-reviewer")
 	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
 		[]string{"alice@example.com"}, nil, nil,
-		"to-expire", "body", "", nil, "send", "", "", 3600)
+		"to-expire", "body", "", nil, "send", "", "", "", 3600)
 	// Backdate so ExpireApproveAndSend's pending+expired predicate fires.
 	pool.Exec(ctx, `UPDATE messages SET approval_expires_at = $1 WHERE id = $2`,
 		time.Now().Add(-5*time.Minute), msg.ID)
@@ -373,7 +371,7 @@ func TestApproveAndSendWithEdits(t *testing.T) {
 	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
 		[]string{"alice@example.com"}, nil, nil,
 		"Draft", "orig body", "", nil,
-		"send", "", "", 3600)
+		"send", "", "", "", 3600)
 
 	newSubject := "Edited subject"
 	newBody := "Edited body"
@@ -442,7 +440,7 @@ func TestApproveAndSendSendFailureRollsBack(t *testing.T) {
 	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
 		[]string{"alice@example.com"}, nil, nil,
 		"Draft", "body", "", nil,
-		"send", "", "", 3600)
+		"send", "", "", "", 3600)
 
 	sendErr := errors.New("smtp unavailable")
 	_, err := store.ApproveAndSend(ctx, msg.ID, user.ID, identity.PendingApprovalEdit{},
@@ -506,7 +504,7 @@ func TestApproveAndSendConcurrentApprovers(t *testing.T) {
 	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
 		[]string{"alice@example.com"}, nil, nil,
 		"Draft", "body", "", nil,
-		"send", "", "", 3600)
+		"send", "", "", "", 3600)
 
 	// Barrier: both goroutines enter ApproveAndSend, then their send
 	// callbacks wait on `release` before returning. The DB row lock makes
@@ -588,7 +586,7 @@ func TestApproveAndSendClearsAttachmentsWhenEditsSetEmpty(t *testing.T) {
 	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
 		[]string{"alice@example.com"}, nil, nil,
 		"Draft", "body", "", []byte(`[{"filename":"x","content_type":"text/plain","data":"aA=="}]`),
-		"send", "", "", 3600)
+		"send", "", "", "", 3600)
 
 	var sawAttachments int
 	clearEdit := identity.PendingApprovalEdit{
@@ -632,7 +630,7 @@ func TestApproveAndSendPreservesPriorEditedFlag(t *testing.T) {
 	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
 		[]string{"alice@example.com"}, nil, nil,
 		"Draft", "body", "", nil,
-		"send", "", "", 3600)
+		"send", "", "", "", 3600)
 
 	// Simulate a prior edit flag on the stored row.
 	if _, err := pool.Exec(ctx,
@@ -676,7 +674,7 @@ func TestApproveAndSendCrossUser(t *testing.T) {
 
 	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
 		[]string{"alice@example.com"}, nil, nil,
-		"Draft", "b", "", nil, "send", "", "", 3600)
+		"Draft", "b", "", nil, "send", "", "", "", 3600)
 
 	_, err := store.ApproveAndSend(ctx, msg.ID, otherUser.ID, identity.PendingApprovalEdit{},
 		func(m *identity.Message) (identity.SendResult, error) {
@@ -699,7 +697,7 @@ func TestRejectPendingHappyPath(t *testing.T) {
 		[]string{"alice@example.com"}, nil, nil,
 		"Draft", "bodyX", "<p>htmlX</p>",
 		[]byte(`[{"filename":"x.txt","content_type":"text/plain","data":"aA=="}]`),
-		"send", "", "", 3600)
+		"send", "", "", "", 3600)
 
 	got, err := store.RejectPending(ctx, msg.ID, user.ID, "inappropriate tone")
 	if err != nil {
@@ -746,7 +744,7 @@ func TestRejectPendingAlreadyRejected(t *testing.T) {
 
 	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
 		[]string{"alice@example.com"}, nil, nil,
-		"Draft", "b", "", nil, "send", "", "", 3600)
+		"Draft", "b", "", nil, "send", "", "", "", 3600)
 
 	if _, err := store.RejectPending(ctx, msg.ID, user.ID, "first time"); err != nil {
 		t.Fatalf("first reject: %v", err)
@@ -767,7 +765,7 @@ func TestRejectPendingCrossUser(t *testing.T) {
 
 	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
 		[]string{"alice@example.com"}, nil, nil,
-		"Draft", "b", "", nil, "send", "", "", 3600)
+		"Draft", "b", "", nil, "send", "", "", "", 3600)
 
 	_, err := store.RejectPending(ctx, msg.ID, otherUser.ID, "nope")
 	if !errors.Is(err, identity.ErrMessageNotFound) {

--- a/internal/identity/hitl_expire_test.go
+++ b/internal/identity/hitl_expire_test.go
@@ -20,14 +20,14 @@ func TestListExpiredPending(t *testing.T) {
 	// Pending but not yet expired
 	fresh, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
 		[]string{"a@example.com"}, nil, nil, "fresh", "b", "", nil,
-		"send", "", "", 3600)
+		"send", "", "", "", 3600)
 	// Pending and expired (backdate approval_expires_at)
 	stale1, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
 		[]string{"b@example.com"}, nil, nil, "stale1", "b", "", nil,
-		"send", "", "", 60)
+		"send", "", "", "", 60)
 	stale2, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
 		[]string{"c@example.com"}, nil, nil, "stale2", "b", "", nil,
-		"send", "", "", 60)
+		"send", "", "", "", 60)
 	pool.Exec(ctx, `UPDATE messages SET approval_expires_at = $1 WHERE id = ANY($2)`,
 		time.Now().Add(-10*time.Minute), []string{stale1.ID, stale2.ID})
 
@@ -80,11 +80,11 @@ func TestListExpiredPendingOrdering(t *testing.T) {
 	// distinct points in the past. Insertion order deliberately differs
 	// from expected return order.
 	msgNewest, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
-		[]string{"n@example.com"}, nil, nil, "newest", "b", "", nil, "send", "", "", 60)
+		[]string{"n@example.com"}, nil, nil, "newest", "b", "", nil, "send", "", "", "", 60)
 	msgMiddle, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
-		[]string{"m@example.com"}, nil, nil, "middle", "b", "", nil, "send", "", "", 60)
+		[]string{"m@example.com"}, nil, nil, "middle", "b", "", nil, "send", "", "", "", 60)
 	msgOldest, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
-		[]string{"o@example.com"}, nil, nil, "oldest", "b", "", nil, "send", "", "", 60)
+		[]string{"o@example.com"}, nil, nil, "oldest", "b", "", nil, "send", "", "", "", 60)
 
 	base := time.Now()
 	pool.Exec(ctx, `UPDATE messages SET approval_expires_at = $1 WHERE id = $2`,
@@ -119,7 +119,7 @@ func TestExpireApproveAndSendHappyPath(t *testing.T) {
 	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
 		[]string{"alice@example.com"}, nil, nil,
 		"Held", "body", "<p>body</p>", nil,
-		"send", "conv_exp", "", 60)
+		"send", "conv_exp", "", "", 60)
 	pool.Exec(ctx, `UPDATE messages SET approval_expires_at = $1 WHERE id = $2`,
 		time.Now().Add(-1*time.Minute), msg.ID)
 
@@ -168,7 +168,7 @@ func TestExpireApproveAndSendSkipsFreshPending(t *testing.T) {
 
 	fresh, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
 		[]string{"a@example.com"}, nil, nil, "fresh", "b", "", nil,
-		"send", "", "", 3600)
+		"send", "", "", "", 3600)
 
 	_, err := store.ExpireApproveAndSend(ctx, fresh.ID,
 		func(m *identity.Message) (identity.SendResult, error) {
@@ -210,7 +210,7 @@ func TestExpireApproveAndSendSendFailureRollsBack(t *testing.T) {
 
 	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
 		[]string{"a@example.com"}, nil, nil, "held", "body", "", nil,
-		"send", "", "", 60)
+		"send", "", "", "", 60)
 	pool.Exec(ctx, `UPDATE messages SET approval_expires_at = $1 WHERE id = $2`,
 		time.Now().Add(-1*time.Minute), msg.ID)
 
@@ -250,7 +250,7 @@ func TestExpireRejectHappyPath(t *testing.T) {
 	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
 		[]string{"x@example.com"}, nil, nil, "x", "body", "<p>html</p>",
 		[]byte(`[{"filename":"x","content_type":"text/plain","data":"aA=="}]`),
-		"send", "", "", 60)
+		"send", "", "", "", 60)
 	pool.Exec(ctx, `UPDATE messages SET approval_expires_at = $1 WHERE id = $2`,
 		time.Now().Add(-1*time.Minute), msg.ID)
 
@@ -287,7 +287,7 @@ func TestExpireRejectRaceReturnsErrNotPending(t *testing.T) {
 
 	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
 		[]string{"x@example.com"}, nil, nil, "x", "b", "", nil,
-		"send", "", "", 60)
+		"send", "", "", "", 60)
 
 	// Simulate: human rejected through the user-scoped API before the
 	// worker got to it.

--- a/internal/identity/hitl_test.go
+++ b/internal/identity/hitl_test.go
@@ -229,6 +229,75 @@ func TestCreateOutboundMessageStatusSent(t *testing.T) {
 
 // --- CreatePendingOutboundMessage ---
 
+// TestPendingOutboundReplyToRoundTrip pins the held-send Reply-To plumbing: a
+// caller override persists on the reply_to column and is returned by BOTH
+// approve-path loads (GetOutboundMessageForUser drives the dashboard/magic
+// async approve; LoadOutboundDraft drives the TTL auto-approve). Without this
+// round-trip the override would silently vanish on every reviewed send, since
+// approval recomposes the MIME from these columns rather than a stored raw body.
+func TestPendingOutboundReplyToRoundTrip(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "rt-owner@example.com", "Owner", "google-rt")
+	store.ClaimOrCreateDomain(ctx, "rt.example.com", user.ID)
+	a, _ := store.CreateAgent(ctx, "bot@rt.example.com", "rt.example.com", "", "https://example.com/webhook", "", user.ID)
+
+	const override = "Support <support@acme.com>"
+	msg, err := store.CreatePendingOutboundMessage(
+		ctx, a.ID,
+		[]string{"alice@example.com"}, nil, nil,
+		"Draft", "body", "",
+		nil,
+		"send", "", "", override, 3600)
+	if err != nil {
+		t.Fatalf("CreatePendingOutboundMessage: %v", err)
+	}
+	if len(msg.ReplyTo) != 1 || msg.ReplyTo[0] != override {
+		t.Fatalf("in-memory ReplyTo = %v, want [%q]", msg.ReplyTo, override)
+	}
+
+	// GetOutboundMessageForUser (async approve draft).
+	got, err := store.GetOutboundMessageForUser(ctx, msg.ID, user.ID)
+	if err != nil {
+		t.Fatalf("GetOutboundMessageForUser: %v", err)
+	}
+	if len(got.ReplyTo) != 1 || got.ReplyTo[0] != override {
+		t.Errorf("GetOutboundMessageForUser ReplyTo = %v, want [%q]", got.ReplyTo, override)
+	}
+
+	// LoadOutboundDraft (TTL auto-approve recompose).
+	draft, err := store.LoadOutboundDraft(ctx, msg.ID)
+	if err != nil {
+		t.Fatalf("LoadOutboundDraft: %v", err)
+	}
+	if len(draft.ReplyTo) != 1 || draft.ReplyTo[0] != override {
+		t.Errorf("LoadOutboundDraft ReplyTo = %v, want [%q]", draft.ReplyTo, override)
+	}
+
+	// No override ⇒ empty (NULL column), never a phantom Reply-To.
+	plain, err := store.CreatePendingOutboundMessage(
+		ctx, a.ID,
+		[]string{"alice@example.com"}, nil, nil,
+		"Draft", "body", "",
+		nil,
+		"send", "", "", "", 3600)
+	if err != nil {
+		t.Fatalf("CreatePendingOutboundMessage (plain): %v", err)
+	}
+	if plain.ReplyTo != nil {
+		t.Errorf("plain in-memory ReplyTo = %v, want nil", plain.ReplyTo)
+	}
+	plainDraft, err := store.LoadOutboundDraft(ctx, plain.ID)
+	if err != nil {
+		t.Fatalf("LoadOutboundDraft (plain): %v", err)
+	}
+	if len(plainDraft.ReplyTo) != 0 {
+		t.Errorf("plain LoadOutboundDraft ReplyTo = %v, want empty", plainDraft.ReplyTo)
+	}
+}
+
 func TestCreatePendingOutboundMessage(t *testing.T) {
 	pool := testutil.TestDB(t)
 	store := identity.NewStore(pool)
@@ -252,8 +321,7 @@ func TestCreatePendingOutboundMessage(t *testing.T) {
 		"Draft subject", "Plain body", "<p>HTML body</p>",
 		attachmentsJSON,
 		"reply", "conv_123", "<inbound-msgid@gmail.com>",
-		3600,
-	)
+		"", 3600)
 	if err != nil {
 		t.Fatalf("CreatePendingOutboundMessage: %v", err)
 	}
@@ -384,8 +452,7 @@ func TestCreatePendingOutboundMessageEmptyBodyAsNull(t *testing.T) {
 		"No body", "", "",
 		nil,
 		"send", "", "",
-		600,
-	)
+		"", 600)
 	if err != nil {
 		t.Fatalf("CreatePendingOutboundMessage: %v", err)
 	}
@@ -423,8 +490,7 @@ func TestCreatePendingOutboundMessageInvalidTTL(t *testing.T) {
 			ctx, a.ID,
 			[]string{"alice@example.com"}, nil, nil,
 			"x", "body", "", nil,
-			"send", "", "", ttl,
-		)
+			"send", "", "", "", ttl)
 		if err == nil {
 			t.Errorf("ttl=%d: expected error, got nil", ttl)
 		}

--- a/internal/identity/outbound_retention_test.go
+++ b/internal/identity/outbound_retention_test.go
@@ -69,7 +69,7 @@ func TestOutboundRetention_HITLApprove(t *testing.T) {
 	userID, agentID := seedRetentionAgent(t, store, ctx, "rethitl.example.com")
 
 	pending, err := store.CreatePendingOutboundMessage(ctx, agentID, []string{"a@b.com"}, nil, nil,
-		"subj", "body text", "", nil, "send", "", "", 3600)
+		"subj", "body text", "", nil, "send", "", "", "", 3600)
 	if err != nil {
 		t.Fatalf("CreatePendingOutboundMessage: %v", err)
 	}
@@ -118,7 +118,7 @@ func TestOutboundRetention_MetersStorage(t *testing.T) {
 	}
 
 	pending, err := store.CreatePendingOutboundMessage(ctx, agentID, []string{"a@b.com"}, nil, nil,
-		"subj", "tiny", "", nil, "send", "", "", 3600)
+		"subj", "tiny", "", nil, "send", "", "", "", 3600)
 	if err != nil {
 		t.Fatalf("CreatePendingOutboundMessage: %v", err)
 	}

--- a/internal/identity/send_attempts_test.go
+++ b/internal/identity/send_attempts_test.go
@@ -20,7 +20,7 @@ func TestClaimSendAttempt_FreshAcquires(t *testing.T) {
 	store := identity.NewStore(pool)
 	_, a := setupPendingAgent(t, store, "claim-fresh")
 	msg, _ := store.CreatePendingOutboundMessage(context.Background(), a.ID,
-		[]string{"x@example.com"}, nil, nil, "x", "b", "", nil, "send", "", "", 3600)
+		[]string{"x@example.com"}, nil, nil, "x", "b", "", nil, "send", "", "", "", 3600)
 
 	res, err := store.ClaimSendAttempt(context.Background(), msg.ID)
 	if err != nil {
@@ -36,7 +36,7 @@ func TestClaimSendAttempt_InFlightOnSecondCall(t *testing.T) {
 	store := identity.NewStore(pool)
 	_, a := setupPendingAgent(t, store, "claim-inflight")
 	msg, _ := store.CreatePendingOutboundMessage(context.Background(), a.ID,
-		[]string{"x@example.com"}, nil, nil, "x", "b", "", nil, "send", "", "", 3600)
+		[]string{"x@example.com"}, nil, nil, "x", "b", "", nil, "send", "", "", "", 3600)
 
 	first, _ := store.ClaimSendAttempt(context.Background(), msg.ID)
 	if first.Outcome != identity.SendAttemptAcquired {
@@ -58,7 +58,7 @@ func TestClaimSendAttempt_AlreadySentReplaysCachedResult(t *testing.T) {
 	_, a := setupPendingAgent(t, store, "claim-sent")
 	msg, _ := store.CreatePendingOutboundMessage(context.Background(), a.ID,
 		[]string{"alice@example.com"}, []string{"bob@example.com"}, nil,
-		"x", "b", "", nil, "send", "", "", 3600)
+		"x", "b", "", nil, "send", "", "", "", 3600)
 
 	first, _ := store.ClaimSendAttempt(context.Background(), msg.ID)
 	if first.Outcome != identity.SendAttemptAcquired {
@@ -98,7 +98,7 @@ func TestClaimSendAttempt_FailedAllowsRetry(t *testing.T) {
 	store := identity.NewStore(pool)
 	_, a := setupPendingAgent(t, store, "claim-failed")
 	msg, _ := store.CreatePendingOutboundMessage(context.Background(), a.ID,
-		[]string{"x@example.com"}, nil, nil, "x", "b", "", nil, "send", "", "", 3600)
+		[]string{"x@example.com"}, nil, nil, "x", "b", "", nil, "send", "", "", "", 3600)
 
 	first, _ := store.ClaimSendAttempt(context.Background(), msg.ID)
 	if first.Outcome != identity.SendAttemptAcquired {
@@ -123,7 +123,7 @@ func TestClaimSendAttempt_ConcurrentOnlyOneAcquires(t *testing.T) {
 	store := identity.NewStore(pool)
 	_, a := setupPendingAgent(t, store, "claim-conc")
 	msg, _ := store.CreatePendingOutboundMessage(context.Background(), a.ID,
-		[]string{"x@example.com"}, nil, nil, "x", "b", "", nil, "send", "", "", 3600)
+		[]string{"x@example.com"}, nil, nil, "x", "b", "", nil, "send", "", "", "", 3600)
 
 	const N = 20
 	var (
@@ -182,7 +182,7 @@ func TestApproveAndSend_TxRollbackRetry_DoesNotCallSendTwice(t *testing.T) {
 	ctx := context.Background()
 	user, a := setupPendingAgent(t, store, "approve-rollback")
 	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
-		[]string{"alice@example.com"}, nil, nil, "x", "body", "", nil, "send", "", "", 3600)
+		[]string{"alice@example.com"}, nil, nil, "x", "body", "", nil, "send", "", "", "", 3600)
 
 	var sendCalls int32
 
@@ -243,7 +243,7 @@ func TestApproveAndSend_SendErrorMarksFailedAndAllowsRetry(t *testing.T) {
 	ctx := context.Background()
 	user, a := setupPendingAgent(t, store, "approve-failed")
 	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
-		[]string{"alice@example.com"}, nil, nil, "x", "body", "", nil, "send", "", "", 3600)
+		[]string{"alice@example.com"}, nil, nil, "x", "body", "", nil, "send", "", "", "", 3600)
 
 	var sendCalls int32
 
@@ -307,7 +307,7 @@ func TestExpireApproveAndSend_TxRollbackRetry_DoesNotCallSendTwice(t *testing.T)
 	ctx := context.Background()
 	_, a := setupPendingAgent(t, store, "expire-rollback")
 	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
-		[]string{"alice@example.com"}, nil, nil, "x", "body", "", nil, "send", "", "", 60)
+		[]string{"alice@example.com"}, nil, nil, "x", "body", "", nil, "send", "", "", "", 60)
 	// ExpireApproveAndSend only picks up rows whose approval_expires_at
 	// is in the past — push the expiry back so the WHERE matches.
 	if _, err := pool.Exec(ctx, `UPDATE messages SET approval_expires_at = now() - interval '1 minute' WHERE id = $1`, msg.ID); err != nil {
@@ -376,7 +376,7 @@ func TestExpireApproveAndSend_InFlightReturnsErrSendInProgress(t *testing.T) {
 	ctx := context.Background()
 	_, a := setupPendingAgent(t, store, "expire-inflight")
 	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
-		[]string{"alice@example.com"}, nil, nil, "x", "body", "", nil, "send", "", "", 60)
+		[]string{"alice@example.com"}, nil, nil, "x", "body", "", nil, "send", "", "", "", 60)
 	if _, err := pool.Exec(ctx, `UPDATE messages SET approval_expires_at = now() - interval '1 minute' WHERE id = $1`, msg.ID); err != nil {
 		t.Fatalf("age approval_expires_at: %v", err)
 	}
@@ -411,7 +411,7 @@ func TestApproveAndSend_InFlightReturnsErrSendInProgress(t *testing.T) {
 	ctx := context.Background()
 	user, a := setupPendingAgent(t, store, "approve-inflight")
 	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
-		[]string{"alice@example.com"}, nil, nil, "x", "body", "", nil, "send", "", "", 3600)
+		[]string{"alice@example.com"}, nil, nil, "x", "body", "", nil, "send", "", "", "", 3600)
 
 	// Plant a recent 'attempting' row directly so the next
 	// ClaimSendAttempt observes InFlight.
@@ -449,7 +449,7 @@ func TestMarkSendSucceededWithRetry_HappyPath_TransitionsRowToSent(t *testing.T)
 	ctx := context.Background()
 	_, a := setupPendingAgent(t, store, "mark-success-retry")
 	msg, _ := store.CreatePendingOutboundMessage(ctx, a.ID,
-		[]string{"alice@example.com"}, nil, nil, "x", "b", "", nil, "send", "", "", 3600)
+		[]string{"alice@example.com"}, nil, nil, "x", "b", "", nil, "send", "", "", "", 3600)
 
 	// Acquire the slot via the normal claim path so the row exists
 	// with status='attempting' — same shape as the real ApproveAndSend

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -1554,8 +1554,8 @@ func (s *Store) StampSendJobIDTx(ctx context.Context, tx pgx.Tx, messageID strin
 // attachmentsJSON must be a JSON array matching the public Attachment shape
 // ([{filename, content_type, data}, ...]) or nil. Callers that already have
 // an []outbound.Attachment slice should json.Marshal it before passing in.
-func (s *Store) CreatePendingOutboundMessage(ctx context.Context, agentID string, toRecipients, cc, bcc []string, subject, bodyText, bodyHTML string, attachmentsJSON []byte, msgType, conversationID, replyToEmailMessageID string, ttlSeconds int) (*Message, error) {
-	return createPendingOutboundMessage(ctx, s.pool, agentID, toRecipients, cc, bcc, subject, bodyText, bodyHTML, attachmentsJSON, msgType, conversationID, replyToEmailMessageID, ttlSeconds)
+func (s *Store) CreatePendingOutboundMessage(ctx context.Context, agentID string, toRecipients, cc, bcc []string, subject, bodyText, bodyHTML string, attachmentsJSON []byte, msgType, conversationID, replyToEmailMessageID, replyTo string, ttlSeconds int) (*Message, error) {
+	return createPendingOutboundMessage(ctx, s.pool, agentID, toRecipients, cc, bcc, subject, bodyText, bodyHTML, attachmentsJSON, msgType, conversationID, replyToEmailMessageID, replyTo, ttlSeconds)
 }
 
 // CreatePendingOutboundMessageTx is the in-tx sibling of
@@ -1563,13 +1563,15 @@ func (s *Store) CreatePendingOutboundMessage(ctx context.Context, agentID string
 // row and enqueue its approval-notification job (QueueNotify) in ONE transaction
 // so neither can exist without the other (docs/design/hitl-notify-river.md).
 // Mirrors CreateOutboundMessageTx / the send accept-tx.
-func (s *Store) CreatePendingOutboundMessageTx(ctx context.Context, tx pgx.Tx, agentID string, toRecipients, cc, bcc []string, subject, bodyText, bodyHTML string, attachmentsJSON []byte, msgType, conversationID, replyToEmailMessageID string, ttlSeconds int) (*Message, error) {
-	return createPendingOutboundMessage(ctx, tx, agentID, toRecipients, cc, bcc, subject, bodyText, bodyHTML, attachmentsJSON, msgType, conversationID, replyToEmailMessageID, ttlSeconds)
+func (s *Store) CreatePendingOutboundMessageTx(ctx context.Context, tx pgx.Tx, agentID string, toRecipients, cc, bcc []string, subject, bodyText, bodyHTML string, attachmentsJSON []byte, msgType, conversationID, replyToEmailMessageID, replyTo string, ttlSeconds int) (*Message, error) {
+	return createPendingOutboundMessage(ctx, tx, agentID, toRecipients, cc, bcc, subject, bodyText, bodyHTML, attachmentsJSON, msgType, conversationID, replyToEmailMessageID, replyTo, ttlSeconds)
 }
 
 // createPendingOutboundMessage is the shared body of the pool and in-tx pending
 // creators; exec is satisfied by both *pgxpool.Pool and pgx.Tx (messageExecutor).
-func createPendingOutboundMessage(ctx context.Context, exec messageExecutor, agentID string, toRecipients, cc, bcc []string, subject, bodyText, bodyHTML string, attachmentsJSON []byte, msgType, conversationID, replyToEmailMessageID string, ttlSeconds int) (*Message, error) {
+// replyTo, when non-empty, is a caller-supplied Reply-To override persisted on
+// the reply_to column (single element) so it survives the recompose at approval.
+func createPendingOutboundMessage(ctx context.Context, exec messageExecutor, agentID string, toRecipients, cc, bcc []string, subject, bodyText, bodyHTML string, attachmentsJSON []byte, msgType, conversationID, replyToEmailMessageID, replyTo string, ttlSeconds int) (*Message, error) {
 	if ttlSeconds <= 0 || ttlSeconds > HITLMaxTTLSeconds {
 		return nil, fmt.Errorf("ttl_seconds must be between 1 and %d", HITLMaxTTLSeconds)
 	}
@@ -1588,6 +1590,13 @@ func createPendingOutboundMessage(ctx context.Context, exec messageExecutor, age
 		attachmentsArg = attachmentsJSON
 	}
 
+	// Persist a caller Reply-To override as a single-element array (matching how
+	// the reply_to column stores the parsed header on inbound rows). Empty ⇒ NULL.
+	var replyToArg []string
+	if replyTo != "" {
+		replyToArg = []string{replyTo}
+	}
+
 	m := &Message{
 		ID:                id,
 		AgentID:           agentID,
@@ -1602,6 +1611,7 @@ func createPendingOutboundMessage(ctx context.Context, exec messageExecutor, age
 		ToRecipients:      toRecipients,
 		CC:                cc,
 		BCC:               bcc,
+		ReplyTo:           replyToArg,
 		Status:            MessageStatusPendingReview,
 		ApprovalExpiresAt: &approvalExpiresAt,
 		BodyText:          bodyText,
@@ -1615,17 +1625,17 @@ func createPendingOutboundMessage(ctx context.Context, exec messageExecutor, age
 		`INSERT INTO messages (
 		    id, agent_id, direction, recipient, subject, email_message_id, message_type,
 		    conversation_id, created_at, expires_at,
-		    to_recipients, cc, bcc,
+		    to_recipients, cc, bcc, reply_to,
 		    status, approval_expires_at,
 		    body_text, body_html, attachments_json, sender)
 		 VALUES ($1, $2, $3, $4, $5, $6, $7,
 		         $8, $9, $10,
-		         $11, $12, $13,
-		         $14, $15,
-		         $16, $17, $18, $19)`,
+		         $11, $12, $13, $14,
+		         $15, $16,
+		         $17, $18, $19, $20)`,
 		m.ID, m.AgentID, m.Direction, m.Recipient, m.Subject, m.EmailMessageID, m.Type,
 		m.ConversationID, m.CreatedAt, m.ExpiresAt,
-		m.ToRecipients, m.CC, m.BCC,
+		m.ToRecipients, m.CC, m.BCC, replyToArg,
 		m.Status, m.ApprovalExpiresAt,
 		nullIfEmptyString(m.BodyText), nullIfEmptyString(m.BodyHTML), attachmentsArg, m.Sender,
 	)
@@ -1809,7 +1819,7 @@ func (s *Store) GetOutboundMessageForUser(ctx context.Context, messageID, userID
 		        m.email_message_id, COALESCE(m.provider_message_id, ''),
 		        m.method, m.message_type,
 		        m.conversation_id, m.created_at, m.expires_at,
-		        m.to_recipients, m.cc, m.bcc,
+		        m.to_recipients, m.cc, m.bcc, m.reply_to,
 		        m.status, m.approval_expires_at, m.reviewed_at,
 		        m.rejection_reason, m.edited,
 		        m.body_text, m.body_html, m.attachments_json,
@@ -1825,7 +1835,7 @@ func (s *Store) GetOutboundMessageForUser(ctx context.Context, messageID, userID
 		&m.EmailMessageID, &m.ProviderMessageID,
 		&method, &msgType,
 		&m.ConversationID, &m.CreatedAt, &m.ExpiresAt,
-		&m.ToRecipients, &m.CC, &m.BCC,
+		&m.ToRecipients, &m.CC, &m.BCC, &m.ReplyTo,
 		&m.Status, &approvalExpires, &reviewedAt,
 		&rejectionReason, &m.Edited,
 		&bodyText, &bodyHTML, &attachments,
@@ -2010,7 +2020,7 @@ func (s *Store) ApproveAndSend(
 		        m.email_message_id,
 		        m.method, m.message_type,
 		        m.conversation_id, m.created_at, m.expires_at,
-		        m.to_recipients, m.cc, m.bcc,
+		        m.to_recipients, m.cc, m.bcc, m.reply_to,
 		        m.status, m.approval_expires_at, m.edited,
 		        m.body_text, m.body_html, m.attachments_json,
 		        a.user_id
@@ -2024,7 +2034,7 @@ func (s *Store) ApproveAndSend(
 		&m.EmailMessageID,
 		&method, &msgType,
 		&m.ConversationID, &m.CreatedAt, &m.ExpiresAt,
-		&m.ToRecipients, &m.CC, &m.BCC,
+		&m.ToRecipients, &m.CC, &m.BCC, &m.ReplyTo,
 		&m.Status, &approvalExpires, &m.Edited,
 		&bodyText, &bodyHTML, &attachments,
 		&ownerUserID,
@@ -2535,11 +2545,11 @@ func (s *Store) LoadOutboundDraft(ctx context.Context, messageID string) (*Messa
 	var msgType *string
 	err := s.pool.QueryRow(ctx,
 		`SELECT agent_id, sender, subject, email_message_id, message_type, conversation_id,
-		        to_recipients, cc, bcc, status, body_text, body_html, attachments_json
+		        to_recipients, cc, bcc, reply_to, status, body_text, body_html, attachments_json
 		   FROM messages WHERE id=$1 AND direction='outbound'`,
 		messageID,
 	).Scan(&m.AgentID, &m.Sender, &m.Subject, &m.EmailMessageID, &msgType, &m.ConversationID,
-		&m.ToRecipients, &m.CC, &m.BCC, &m.Status, &bodyText, &bodyHTML, &attachments)
+		&m.ToRecipients, &m.CC, &m.BCC, &m.ReplyTo, &m.Status, &bodyText, &bodyHTML, &attachments)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return nil, ErrMessageNotFound

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -2306,7 +2306,7 @@ func (s *Store) ExpireApproveAndSend(
 		        email_message_id,
 		        method, message_type,
 		        conversation_id, created_at, expires_at,
-		        to_recipients, cc, bcc,
+		        to_recipients, cc, bcc, reply_to,
 		        status, approval_expires_at, edited,
 		        body_text, body_html, attachments_json
 		 FROM messages
@@ -2321,7 +2321,7 @@ func (s *Store) ExpireApproveAndSend(
 		&m.EmailMessageID,
 		&method, &msgType,
 		&m.ConversationID, &m.CreatedAt, &m.ExpiresAt,
-		&m.ToRecipients, &m.CC, &m.BCC,
+		&m.ToRecipients, &m.CC, &m.BCC, &m.ReplyTo,
 		&m.Status, &approvalExpires, &m.Edited,
 		&bodyText, &bodyHTML, &attachments,
 	)

--- a/internal/identity/store_test.go
+++ b/internal/identity/store_test.go
@@ -1158,7 +1158,7 @@ func TestGetDashboardStats_Pending(t *testing.T) {
 		store.CreatePendingOutboundMessage(ctx, agent.ID,
 			[]string{"alice@example.com"}, nil, nil,
 			fmt.Sprintf("subject-%d", i), "body", "", nil,
-			"send", "", "", 3600)
+			"send", "", "", "", 3600)
 	}
 	// Backdate the second one to ~2 hours old. created_at and
 	// approval_expires_at are both moved so the partial index still
@@ -1262,7 +1262,7 @@ func TestListAgentsByUser_EnrichedFields(t *testing.T) {
 	}
 	pending, _ := store.CreatePendingOutboundMessage(ctx, agent.ID,
 		[]string{"bob@example.com"}, nil, nil, "held", "body", "", nil,
-		"send", "", "", 3600)
+		"send", "", "", "", 3600)
 	_ = pending
 
 	// One delivered webhook (healthy state)

--- a/internal/limits/integration_test.go
+++ b/internal/limits/integration_test.go
@@ -53,8 +53,7 @@ func TestStorageTrigger_IncrementsOnInsert(t *testing.T) {
 	_, err := idStore.CreatePendingOutboundMessage(ctx, agent.ID,
 		[]string{"alice@example.com"}, nil, nil,
 		"hi", "body text here", "<p>body html here</p>", attachJSON,
-		"send", "", "", 60,
-	)
+		"send", "", "", "", 60)
 	if err != nil {
 		t.Fatalf("CreatePendingOutboundMessage: %v", err)
 	}
@@ -76,8 +75,7 @@ func TestStorageTrigger_DecrementsOnDelete(t *testing.T) {
 	msg, err := idStore.CreatePendingOutboundMessage(ctx, agent.ID,
 		[]string{"alice@example.com"}, nil, nil,
 		"hi", "some body text", "", nil,
-		"send", "", "", 60,
-	)
+		"send", "", "", "", 60)
 	if err != nil {
 		t.Fatalf("CreatePendingOutboundMessage: %v", err)
 	}

--- a/internal/loopback/loopback.go
+++ b/internal/loopback/loopback.go
@@ -120,6 +120,12 @@ func ComposeMIME(agent *identity.AgentIdentity, req outbound.SendRequest, provid
 		headerFrom = email
 	}
 
+	// A caller-supplied Reply-To override is honored on the loopback path too, so
+	// a self-send's stored raw_message matches what the SMTP path would compose.
+	// Default stays "" (no Reply-To header) to preserve existing note-to-self
+	// behavior; only an explicit req.ReplyTo sets one.
+	replyTo := req.ReplyTo
+
 	var msg []byte
 	var err error
 	if len(req.Attachments) > 0 {
@@ -133,7 +139,7 @@ func ComposeMIME(agent *identity.AgentIdentity, req outbound.SendRequest, provid
 			req.ReplyToMessageID,
 			req.References,
 			fromDomain,
-			"", // reply_to header
+			replyTo,
 			req.ConversationID,
 			req.Attachments,
 		)
@@ -157,7 +163,7 @@ func ComposeMIME(agent *identity.AgentIdentity, req outbound.SendRequest, provid
 			req.ReplyToMessageID,
 			req.References,
 			fromDomain,
-			"", // reply_to header
+			replyTo,
 			req.ConversationID,
 		)
 	}

--- a/internal/loopback/loopback_test.go
+++ b/internal/loopback/loopback_test.go
@@ -1,0 +1,64 @@
+package loopback
+
+import (
+	"net/mail"
+	"strings"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/outbound"
+)
+
+// TestComposeMIMEReplyToOverride pins that a caller-supplied Reply-To override is
+// honored on the loopback (self-send) path, matching the SMTP path. Without the
+// override the loopback message carries NO Reply-To (unchanged note-to-self
+// default); with it, the header is present verbatim in both the single-part and
+// attachment branches.
+func TestComposeMIMEReplyToOverride(t *testing.T) {
+	agent := &identity.AgentIdentity{ID: "bot@example.com", Domain: "example.com"}
+	const override = "Support <support@acme.com>"
+
+	replyToHeader := func(t *testing.T, raw []byte) string {
+		t.Helper()
+		// Strip the synthetic leading Received: line the loopback prepends so
+		// mail.ReadMessage sees a clean header block.
+		s := string(raw)
+		if i := strings.Index(s, "\r\nFrom:"); i >= 0 {
+			s = s[i+2:]
+		}
+		m, err := mail.ReadMessage(strings.NewReader(s))
+		if err != nil {
+			t.Fatalf("parse loopback MIME: %v\n%s", err, string(raw))
+		}
+		return m.Header.Get("Reply-To")
+	}
+
+	cases := []struct {
+		name string
+		req  outbound.SendRequest
+	}{
+		{"single-part", outbound.SendRequest{To: []string{"bot@example.com"}, Subject: "hi", Body: "note", ReplyTo: override}},
+		{"attachments", outbound.SendRequest{To: []string{"bot@example.com"}, Subject: "hi", Body: "note", ReplyTo: override,
+			Attachments: []outbound.Attachment{{Filename: "a.txt", ContentType: "text/plain", Data: "aGVsbG8="}}}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := ComposeMIME(agent, tc.req, ProviderID("example.com"), "example.com")
+			if err != nil {
+				t.Fatalf("ComposeMIME: %v", err)
+			}
+			if got := replyToHeader(t, raw); got != override {
+				t.Errorf("Reply-To = %q, want %q", got, override)
+			}
+		})
+	}
+
+	// No override → no Reply-To header (preserve existing loopback behavior).
+	raw, err := ComposeMIME(agent, outbound.SendRequest{To: []string{"bot@example.com"}, Subject: "hi", Body: "note"}, ProviderID("example.com"), "example.com")
+	if err != nil {
+		t.Fatalf("ComposeMIME (plain): %v", err)
+	}
+	if got := replyToHeader(t, raw); got != "" {
+		t.Errorf("plain self-send Reply-To = %q, want empty", got)
+	}
+}

--- a/internal/outbound/sender.go
+++ b/internal/outbound/sender.go
@@ -46,13 +46,18 @@ type Attachment struct {
 // participant's mailbox. When empty but ReplyToMessageID is set, the
 // References header falls back to a single id (legacy behavior).
 type SendRequest struct {
-	From             string       `json:"from,omitempty"`
-	To               []string     `json:"to"`
-	CC               []string     `json:"cc,omitempty"`
-	BCC              []string     `json:"bcc,omitempty"`
-	Subject          string       `json:"subject"`
-	Body             string       `json:"body"`
-	HTMLBody         string       `json:"html_body,omitempty"`
+	From     string   `json:"from,omitempty"`
+	To       []string `json:"to"`
+	CC       []string `json:"cc,omitempty"`
+	BCC      []string `json:"bcc,omitempty"`
+	Subject  string   `json:"subject"`
+	Body     string   `json:"body"`
+	HTMLBody string   `json:"html_body,omitempty"`
+	// ReplyTo, when set, overrides the Reply-To header (which otherwise
+	// defaults to the agent's own address). Replies land here instead of at the
+	// From address. Must be a single RFC 5322 address, optionally with a display
+	// name; validated at the API edge.
+	ReplyTo          string       `json:"reply_to,omitempty"`
 	ReplyToMessageID string       `json:"reply_to_message_id"`
 	References       []string     `json:"references,omitempty"`
 	ConversationID   string       `json:"conversation_id,omitempty"`
@@ -356,7 +361,15 @@ func (s *Sender) compose(agent *identity.AgentIdentity, req SendRequest) (*compo
 	} else {
 		headerFrom = fmt.Sprintf("%q <%s>", displayName+" via e2a", envelopeFrom)
 	}
+	// Reply-To defaults to the agent's own address so replies reach it directly;
+	// a caller-supplied req.ReplyTo overrides that (e.g. routing replies to a
+	// shared inbox or a different agent). Header-injection is neutralized by
+	// sanitizeHeaderValue in the compose layer; address validity is enforced at
+	// the API edge.
 	replyTo := agent.EmailAddress()
+	if req.ReplyTo != "" {
+		replyTo = req.ReplyTo
+	}
 
 	var message []byte
 	if len(req.Attachments) > 0 {

--- a/internal/outbound/sender_test.go
+++ b/internal/outbound/sender_test.go
@@ -4,12 +4,47 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"net/mail"
 	"reflect"
 	"testing"
 
 	"github.com/Mnexa-AI/e2a/internal/dkim"
 	"github.com/Mnexa-AI/e2a/internal/identity"
 )
+
+// TestComposeReplyToOverride pins the Reply-To behavior: absent a caller value the
+// header defaults to the agent's own address; a req.ReplyTo overrides it verbatim
+// (display name preserved). This is the seam the whole feature rides on — a
+// regression here silently misroutes every recipient's replies.
+func TestComposeReplyToOverride(t *testing.T) {
+	s := NewSender(nil, "example.com")
+	agent := &identity.AgentIdentity{ID: "bot@example.com", Domain: "example.com"}
+
+	replyToHeader := func(t *testing.T, req SendRequest) string {
+		t.Helper()
+		c, err := s.compose(agent, req)
+		if err != nil {
+			t.Fatalf("compose: %v", err)
+		}
+		m, err := mail.ReadMessage(bytes.NewReader(c.sentBody))
+		if err != nil {
+			t.Fatalf("parse composed message: %v", err)
+		}
+		return m.Header.Get("Reply-To")
+	}
+
+	base := SendRequest{To: []string{"x@y.com"}, Subject: "hi", Body: "body text"}
+
+	if got := replyToHeader(t, base); got != agent.EmailAddress() {
+		t.Errorf("default Reply-To = %q, want agent address %q", got, agent.EmailAddress())
+	}
+
+	withOverride := base
+	withOverride.ReplyTo = "Support <support@acme.com>"
+	if got := replyToHeader(t, withOverride); got != "Support <support@acme.com>" {
+		t.Errorf("overridden Reply-To = %q, want %q", got, "Support <support@acme.com>")
+	}
+}
 
 // TestComposeForAccept_MatchesSyncComposeBytes pins the load-bearing async/sync
 // invariant: the accept path (ComposeForAccept) stores the SAME Sent-folder bytes

--- a/mcp/src/client.ts
+++ b/mcp/src/client.ts
@@ -165,6 +165,7 @@ export class McpClient {
       bcc?: Array<string>;
       attachments?: Array<Attachment>;
       conversationId?: string;
+      replyTo?: string;
     },
     opts: SendOpts = {},
     explicitAddress?: string,
@@ -182,6 +183,7 @@ export class McpClient {
       bcc?: Array<string>;
       attachments?: Array<Attachment>;
       conversationId?: string;
+      replyTo?: string;
     },
     opts: SendOpts = {},
     explicitAddress?: string,
@@ -204,6 +206,7 @@ export class McpClient {
       bcc?: Array<string>;
       attachments?: Array<Attachment>;
       conversationId?: string;
+      replyTo?: string;
     },
     opts: SendOpts = {},
     explicitAddress?: string,

--- a/mcp/src/tools/messages.ts
+++ b/mcp/src/tools/messages.ts
@@ -59,7 +59,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
           .string()
           .optional()
           .describe(
-            "Sets the Reply-To header — where the recipient's replies are directed. A single address, optionally with a display name (e.g. \"Support <support@acme.com>\"). Defaults to the sending agent's own address.",
+            "Sets the Reply-To header — where replies to this message are directed. A single address, optionally with a display name (e.g. \"Support <support@acme.com>\"). Defaults to the sending agent's own address.",
           ),
         idempotency_key: z
           .string()

--- a/mcp/src/tools/messages.ts
+++ b/mcp/src/tools/messages.ts
@@ -55,6 +55,12 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
           .string()
           .optional()
           .describe("Optional conversation grouping ID. Server generates one if omitted."),
+        reply_to: z
+          .string()
+          .optional()
+          .describe(
+            "Sets the Reply-To header — where the recipient's replies are directed. A single address, optionally with a display name (e.g. \"Support <support@acme.com>\"). Defaults to the sending agent's own address.",
+          ),
         idempotency_key: z
           .string()
           .optional()
@@ -95,6 +101,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
             ...(args.conversation_id !== undefined
               ? { conversationId: args.conversation_id }
               : {}),
+            ...(args.reply_to !== undefined ? { replyTo: args.reply_to } : {}),
           },
           opts,
           args.email,
@@ -121,6 +128,12 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
         bcc: z.array(z.string()).optional(),
         attachments: attachmentsArraySchema,
         conversation_id: z.string().optional(),
+        reply_to: z
+          .string()
+          .optional()
+          .describe(
+            "Sets the Reply-To header — where replies to this message are directed. A single address, optionally with a display name. Defaults to the sending agent's own address.",
+          ),
         idempotency_key: z
           .string()
           .optional()
@@ -150,6 +163,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
             ...(args.conversation_id !== undefined
               ? { conversationId: args.conversation_id }
               : {}),
+            ...(args.reply_to !== undefined ? { replyTo: args.reply_to } : {}),
           },
           opts,
           args.email,
@@ -183,6 +197,12 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
           .describe(
             "Optional conversation grouping ID. A forward is a new thread by default — set this only to bind it to an existing thread explicitly.",
           ),
+        reply_to: z
+          .string()
+          .optional()
+          .describe(
+            "Sets the Reply-To header — where replies to the forward are directed. A single address, optionally with a display name. Defaults to the sending agent's own address.",
+          ),
         idempotency_key: z
           .string()
           .optional()
@@ -214,6 +234,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
             ...(args.conversation_id !== undefined
               ? { conversationId: args.conversation_id }
               : {}),
+            ...(args.reply_to !== undefined ? { replyTo: args.reply_to } : {}),
           },
           opts,
           args.email,

--- a/sdks/python/src/e2a/v1/generated/models/forward_request.py
+++ b/sdks/python/src/e2a/v1/generated/models/forward_request.py
@@ -33,8 +33,9 @@ class ForwardRequest(BaseModel):
     cc: Optional[List[StrictStr]] = None
     conversation_id: Optional[StrictStr] = None
     html_body: Optional[StrictStr] = None
+    reply_to: Optional[StrictStr] = Field(default=None, description="Sets the Reply-To header — where replies to this message are directed. A single RFC 5322 address, optionally with a display name. Defaults to the sending agent's own address.")
     to: List[StrictStr]
-    __properties: ClassVar[List[str]] = ["attachments", "bcc", "body", "cc", "conversation_id", "html_body", "to"]
+    __properties: ClassVar[List[str]] = ["attachments", "bcc", "body", "cc", "conversation_id", "html_body", "reply_to", "to"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -100,6 +101,7 @@ class ForwardRequest(BaseModel):
             "cc": obj.get("cc"),
             "conversation_id": obj.get("conversation_id"),
             "html_body": obj.get("html_body"),
+            "reply_to": obj.get("reply_to"),
             "to": obj.get("to")
         })
         return _obj

--- a/sdks/python/src/e2a/v1/generated/models/message_summary_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/message_summary_view.py
@@ -42,7 +42,7 @@ class MessageSummaryView(BaseModel):
     message_id: StrictStr
     read_status: StrictStr
     recipient: StrictStr
-    reply_to: Optional[List[StrictStr]] = None
+    reply_to: Optional[List[StrictStr]] = Field(default=None, description="The parsed Reply-To header of an inbound message. Populated for inbound only; always empty for outbound (a Reply-To you SET on a send is a request-side field and is not echoed back here).")
     review_status: Optional[StrictStr] = Field(default=None, description="Review-hold lifecycle (outbound only). Open set; tolerate unknown values. Known values: pending_review, sent, review_rejected, review_expired_approved, review_expired_rejected.")
     sent_as: Optional[StrictStr] = Field(default=None, description="From identity used at relay accept time (outbound only). Open set; tolerate unknown values. Known values: own_address, relay.")
     size_bytes: Optional[StrictInt] = None

--- a/sdks/python/src/e2a/v1/generated/models/message_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/message_view.py
@@ -50,7 +50,7 @@ class MessageView(BaseModel):
     raw_message: StrictStr
     read_status: StrictStr
     recipient: StrictStr
-    reply_to: List[StrictStr]
+    reply_to: List[StrictStr] = Field(description="The parsed Reply-To header of an inbound message. Populated for inbound only; always empty for outbound (a Reply-To you SET on a send is a request-side field on the send/reply/forward body and is not echoed back here).")
     review_status: Optional[StrictStr] = Field(default=None, description="Review-hold lifecycle (outbound only). Open set; tolerate unknown values. Known values: pending_review, sent, review_rejected, review_expired_approved, review_expired_rejected.")
     sent_as: Optional[StrictStr] = Field(default=None, description="From identity used at relay accept time (outbound only). Open set; tolerate unknown values. Known values: own_address, relay.")
     size_bytes: Optional[StrictInt] = None

--- a/sdks/python/src/e2a/v1/generated/models/reply_request.py
+++ b/sdks/python/src/e2a/v1/generated/models/reply_request.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, StrictBool, StrictStr
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from e2a.v1.generated.models.attachment import Attachment
 from typing import Optional, Set
@@ -34,7 +34,8 @@ class ReplyRequest(BaseModel):
     conversation_id: Optional[StrictStr] = None
     html_body: Optional[StrictStr] = None
     reply_all: Optional[StrictBool] = None
-    __properties: ClassVar[List[str]] = ["attachments", "bcc", "body", "cc", "conversation_id", "html_body", "reply_all"]
+    reply_to: Optional[StrictStr] = Field(default=None, description="Sets the Reply-To header — where replies to this message are directed. A single RFC 5322 address, optionally with a display name. Defaults to the sending agent's own address.")
+    __properties: ClassVar[List[str]] = ["attachments", "bcc", "body", "cc", "conversation_id", "html_body", "reply_all", "reply_to"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -100,7 +101,8 @@ class ReplyRequest(BaseModel):
             "cc": obj.get("cc"),
             "conversation_id": obj.get("conversation_id"),
             "html_body": obj.get("html_body"),
-            "reply_all": obj.get("reply_all")
+            "reply_all": obj.get("reply_all"),
+            "reply_to": obj.get("reply_to")
         })
         return _obj
 

--- a/sdks/python/src/e2a/v1/generated/models/send_email_request.py
+++ b/sdks/python/src/e2a/v1/generated/models/send_email_request.py
@@ -33,13 +33,14 @@ class SendEmailRequest(BaseModel):
     cc: Optional[List[StrictStr]] = None
     conversation_id: Optional[StrictStr] = None
     html_body: Optional[StrictStr] = Field(default=None, description="Literal HTML body. Mutually exclusive with template_id/template_alias.")
+    reply_to: Optional[StrictStr] = Field(default=None, description="Sets the Reply-To header — where replies to this message are directed. A single RFC 5322 address, optionally with a display name (e.g. \"Support <support@acme.com>\"). Defaults to the sending agent's own address.")
     subject: Optional[StrictStr] = Field(default=None, description="Literal subject. Required unless a template reference is used (mutually exclusive with template_id/template_alias).")
     template_alias: Optional[StrictStr] = Field(default=None, description="Send using a stored template resolved by its per-user alias. Mutually exclusive with template_id and with literal subject/body/html_body. Beta: templates are unstable — their shape may change before they are declared stable.")
     template_data: Optional[Dict[str, Any]] = Field(default=None, description="Variables for the referenced template ({{name}}, dot paths into nested objects). Missing variables render as empty strings. Beta: templates are unstable — their shape may change before they are declared stable.")
     template_id: Optional[StrictStr] = Field(default=None, description="Send using a stored template (rendered server-side, before any review hold). Mutually exclusive with template_alias and with literal subject/body/html_body. Beta: templates are unstable — their shape may change before they are declared stable.")
     to: List[StrictStr]
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["attachments", "bcc", "body", "cc", "conversation_id", "html_body", "subject", "template_alias", "template_data", "template_id", "to"]
+    __properties: ClassVar[List[str]] = ["attachments", "bcc", "body", "cc", "conversation_id", "html_body", "reply_to", "subject", "template_alias", "template_data", "template_id", "to"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -112,6 +113,7 @@ class SendEmailRequest(BaseModel):
             "cc": obj.get("cc"),
             "conversation_id": obj.get("conversation_id"),
             "html_body": obj.get("html_body"),
+            "reply_to": obj.get("reply_to"),
             "subject": obj.get("subject"),
             "template_alias": obj.get("template_alias"),
             "template_data": obj.get("template_data"),

--- a/sdks/typescript/src/v1/generated/models/ForwardRequest.ts
+++ b/sdks/typescript/src/v1/generated/models/ForwardRequest.ts
@@ -23,6 +23,10 @@ export class ForwardRequest {
     'cc'?: Array<string>;
     'conversationId'?: string;
     'htmlBody'?: string;
+    /**
+    * Sets the Reply-To header — where replies to this message are directed. A single RFC 5322 address, optionally with a display name. Defaults to the sending agent\'s own address.
+    */
+    'replyTo'?: string;
     'to': Array<string>;
 
     static readonly discriminator: string | undefined = undefined;
@@ -63,6 +67,12 @@ export class ForwardRequest {
         {
             "name": "htmlBody",
             "baseName": "html_body",
+            "type": "string",
+            "format": ""
+        },
+        {
+            "name": "replyTo",
+            "baseName": "reply_to",
             "type": "string",
             "format": ""
         },

--- a/sdks/typescript/src/v1/generated/models/MessageSummaryView.ts
+++ b/sdks/typescript/src/v1/generated/models/MessageSummaryView.ts
@@ -31,6 +31,9 @@ export class MessageSummaryView {
     'messageId': string;
     'readStatus': string;
     'recipient': string;
+    /**
+    * The parsed Reply-To header of an inbound message. Populated for inbound only; always empty for outbound (a Reply-To you SET on a send is a request-side field and is not echoed back here).
+    */
     'replyTo'?: Array<string>;
     /**
     * Review-hold lifecycle (outbound only). Open set; tolerate unknown values. Known values: pending_review, sent, review_rejected, review_expired_approved, review_expired_rejected.

--- a/sdks/typescript/src/v1/generated/models/MessageView.ts
+++ b/sdks/typescript/src/v1/generated/models/MessageView.ts
@@ -39,6 +39,9 @@ export class MessageView {
     'rawMessage': string;
     'readStatus': string;
     'recipient': string;
+    /**
+    * The parsed Reply-To header of an inbound message. Populated for inbound only; always empty for outbound (a Reply-To you SET on a send is a request-side field on the send/reply/forward body and is not echoed back here).
+    */
     'replyTo': Array<string>;
     /**
     * Review-hold lifecycle (outbound only). Open set; tolerate unknown values. Known values: pending_review, sent, review_rejected, review_expired_approved, review_expired_rejected.

--- a/sdks/typescript/src/v1/generated/models/ReplyRequest.ts
+++ b/sdks/typescript/src/v1/generated/models/ReplyRequest.ts
@@ -21,6 +21,10 @@ export class ReplyRequest {
     'conversationId'?: string;
     'htmlBody'?: string;
     'replyAll'?: boolean;
+    /**
+    * Sets the Reply-To header — where replies to this message are directed. A single RFC 5322 address, optionally with a display name. Defaults to the sending agent\'s own address.
+    */
+    'replyTo'?: string;
 
     static readonly discriminator: string | undefined = undefined;
 
@@ -67,6 +71,12 @@ export class ReplyRequest {
             "name": "replyAll",
             "baseName": "reply_all",
             "type": "boolean",
+            "format": ""
+        },
+        {
+            "name": "replyTo",
+            "baseName": "reply_to",
+            "type": "string",
             "format": ""
         }    ];
 

--- a/sdks/typescript/src/v1/generated/models/SendEmailRequest.ts
+++ b/sdks/typescript/src/v1/generated/models/SendEmailRequest.ts
@@ -27,6 +27,10 @@ export class SendEmailRequest {
     */
     'htmlBody'?: string;
     /**
+    * Sets the Reply-To header — where replies to this message are directed. A single RFC 5322 address, optionally with a display name (e.g. \"Support <support@acme.com>\"). Defaults to the sending agent\'s own address.
+    */
+    'replyTo'?: string;
+    /**
     * Literal subject. Required unless a template reference is used (mutually exclusive with template_id/template_alias).
     */
     'subject'?: string;
@@ -82,6 +86,12 @@ export class SendEmailRequest {
         {
             "name": "htmlBody",
             "baseName": "html_body",
+            "type": "string",
+            "format": ""
+        },
+        {
+            "name": "replyTo",
+            "baseName": "reply_to",
             "type": "string",
             "format": ""
         },


### PR DESCRIPTION
## What

Adds an optional **`reply_to`** field so callers can set the `Reply-To` header when **sending, replying, or forwarding** — controlling where a recipient's replies land. Defaults to the sending agent's own address (unchanged behavior).

The compose layer already wrote `Reply-To` hardcoded to the agent address (`sender.go:359`); this makes a caller value override it, threaded through every delivery path.

## Layers touched

- **Go core** — `outbound.SendRequest.ReplyTo` + override in `compose()`.
- **`/v1` API** — `reply_to` on the send/reply/forward request bodies, validated at the edge (`validateReplyTo`: exactly one RFC 5322 address; garbage and comma-lists → `400 invalid_request` rather than letting the composer mangle a bad value or the relay bounce it).
- **HITL review-hold** (the subtle part) — held sends are **recomposed from DB columns at approval**, so a value only living in the request would silently vanish on any reviewed send. It's persisted through the hold (reusing the existing `reply_to` column — **no migration**) and restored across every recompose path: `CreatePendingOutboundMessage`, the three approve-path loads (`GetOutboundMessageForUser`, `ApproveAndSend` lock, `LoadOutboundDraft`), and both rebuild helpers (`buildSendRequestFromMessage`, `sendRequestFromStoredMessage` for TTL auto-approve).
- **Message view** — gated `reply_to` to **inbound only**, keeping the outbound override column as internal recompose plumbing so the field keeps its one documented meaning (parsed inbound Reply-To).
- **Spec + SDKs** — regenerated `api/openapi.yaml` and the TS/Python generated bases (`make spec` / `make generate-sdk`, deterministic; hand-written SDK layers pass the body through).
- **CLI** — `--reply-to` on `e2a send` / `e2a reply`.
- **MCP** — `reply_to` on `send_message`, `reply_to_message`, `forward_message`.

## Correctness

Delivery is correct on **all** paths — direct sync, async/River (`ReplyTo` baked into `raw_message` at accept), and reviewed (persist → restore at approval). Header-injection is neutralized twice: `mail.ParseAddressList` at the edge + `sanitizeHeaderValue` in compose.

### Deliberate scoping call
The message **view** intentionally does **not** echo `reply_to` back for outbound messages. That field means "parsed inbound Reply-To"; surfacing the outbound override there would require threading it through every direct-send persist path (~16 more test files) for a cosmetic gain. The header is set and delivered regardless.

## Tests

- Compose override — default vs. override, display name preserved (`internal/outbound`).
- Handler propagation + invalid/multi-address rejection (`internal/httpapi`).
- Held-path DB round-trip proving the override survives the approval recompose (`internal/identity`).

All affected Go packages pass serially; TS SDK/CLI/MCP build + test pass; `make spec-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DfAXBRMJ3KPuU3UEgwqjhS