### PR TITLE
feat(ratelimit): exempt system/internal account classes from request limiters

### DIFF
--- a/internal/httpapi/ratelimit.go
+++ b/internal/httpapi/ratelimit.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/usage"
 	"github.com/danielgtaylor/huma/v2"
 )
 
@@ -66,15 +67,34 @@ func (s *Server) rateLimit(ctx huma.Context, next func(huma.Context)) {
 			next(ctx)
 			return
 		}
-		snap, key = s.deps.PollLimit, p.User.ID
 		// Reuse the principal so the handler does not authenticate a second
 		// time on the hot read path.
 		ctx = huma.WithContext(ctx, withPrincipal(ctx.Context(), p))
+		// Trusted internal traffic (system probes, internal dogfooding /
+		// conformance) bypasses the limiter — same policy axis as metering.
+		if !usage.RateLimited(usage.AccountClass(p.User.AccountClass)) {
+			next(ctx)
+			return
+		}
+		snap, key = s.deps.PollLimit, p.User.ID
 	case op.OperationID == "createAgent" && s.deps.RegLimit != nil:
 		r := RequestFromContext(ctx.Context())
 		if r == nil {
 			next(ctx)
 			return
+		}
+		// Exempt trusted internal classes from the per-IP registration limiter
+		// (and reuse the resolved principal downstream). An unauthenticated or
+		// unresolvable create falls through to the limiter; the handler then
+		// emits the canonical 401.
+		if s.deps.Authenticator != nil {
+			if p, err := s.resolvePrincipal(r); err == nil {
+				ctx = huma.WithContext(ctx, withPrincipal(ctx.Context(), p))
+				if !usage.RateLimited(usage.AccountClass(p.User.AccountClass)) {
+					next(ctx)
+					return
+				}
+			}
 		}
 		snap, key = s.deps.RegLimit, clientIP(r)
 	default:

--- a/internal/httpapi/ratelimit.go
+++ b/internal/httpapi/ratelimit.go
@@ -83,17 +83,23 @@ func (s *Server) rateLimit(ctx huma.Context, next func(huma.Context)) {
 			next(ctx)
 			return
 		}
-		// Exempt trusted internal classes from the per-IP registration limiter
-		// (and reuse the resolved principal downstream). An unauthenticated or
-		// unresolvable create falls through to the limiter; the handler then
-		// emits the canonical 401.
-		if s.deps.Authenticator != nil {
-			if p, err := s.resolvePrincipal(r); err == nil {
-				ctx = huma.WithContext(ctx, withPrincipal(ctx.Context(), p))
-				if !usage.RateLimited(usage.AccountClass(p.User.AccountClass)) {
-					next(ctx)
-					return
-				}
+		// Exempt trusted internal classes (system/internal) from the per-IP
+		// registration limiter, reusing the resolved principal downstream.
+		// Resolving here costs a keyed api_keys touch even on an over-cap
+		// attempt (origin/main rejected those IP-only at zero DB cost); accepted
+		// because the exemption must be bucket-independent (behind a proxy the
+		// per-IP bucket is shared), the caller already holds a valid credential,
+		// the write lands only on the caller's OWN key row, and registration is
+		// low-QPS. Branch on the resolve error rather than pre-checking a
+		// specific authenticator field — resolvePrincipal prefers
+		// PrincipalAuthenticator and errors when neither is wired, so an
+		// unauthenticated/unresolvable create simply falls through to the
+		// limiter and the handler emits the canonical 401.
+		if p, err := s.resolvePrincipal(r); err == nil {
+			ctx = huma.WithContext(ctx, withPrincipal(ctx.Context(), p))
+			if !usage.RateLimited(usage.AccountClass(p.User.AccountClass)) {
+				next(ctx)
+				return
 			}
 		}
 		snap, key = s.deps.RegLimit, clientIP(r)

--- a/internal/httpapi/ratelimit_test.go
+++ b/internal/httpapi/ratelimit_test.go
@@ -142,6 +142,64 @@ func TestNonPollLimitedReadNotThrottled(t *testing.T) {
 	}
 }
 
+// TestPollRateLimitExemptInternalClass asserts trusted internal traffic bypasses
+// the poll limiter: an internal-class principal reaches the handler even though
+// PollLimit would block, and the limiter is never consulted (nor its headers set).
+func TestPollRateLimitExemptInternalClass(t *testing.T) {
+	reached := false
+	srv := httptest.NewServer(New(Deps{
+		Authenticator: func(r *http.Request) (*identity.User, error) {
+			return &identity.User{ID: "u_int", AccountClass: "internal"}, nil
+		},
+		ListWebhooks: func(ctx context.Context, userID string) ([]identity.Webhook, error) {
+			reached = true
+			return []identity.Webhook{}, nil
+		},
+		PollLimit: func(key string) (bool, time.Duration, int, int, int) {
+			t.Error("PollLimit must NOT be consulted for an exempt (internal) class")
+			return false, time.Second, 60, 0, 60
+		},
+	}))
+	t.Cleanup(srv.Close)
+
+	resp := getRaw(t, srv.URL+"/v1/webhooks", "good")
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("want 200 (exempt class bypasses poll limit), got %d", resp.StatusCode)
+	}
+	if !reached {
+		t.Error("handler should be reached for an exempt class")
+	}
+	if resp.Header.Get("RateLimit-Limit") != "" {
+		t.Errorf("exempt class should carry no RateLimit-Limit header, got %q", resp.Header.Get("RateLimit-Limit"))
+	}
+}
+
+// TestRegRateLimitExemptSystemClass asserts a system-class principal (the prober)
+// bypasses the per-IP registration limiter even when RegLimit would block.
+func TestRegRateLimitExemptSystemClass(t *testing.T) {
+	srv := httptest.NewServer(New(Deps{
+		Authenticator: func(r *http.Request) (*identity.User, error) {
+			return &identity.User{ID: "u_sys", AccountClass: "system"}, nil
+		},
+		CreateAgent: func(ctx context.Context, email, domain, name, webhookURL, agentMode, userID string) (*identity.AgentIdentity, error) {
+			return &identity.AgentIdentity{ID: email, Email: email, UserID: userID}, nil
+		},
+		RegLimit: func(key string) (bool, time.Duration, int, int, int) {
+			t.Error("RegLimit must NOT be consulted for an exempt (system) class")
+			return false, 30 * time.Second, 200, 0, 3600
+		},
+	}))
+	t.Cleanup(srv.Close)
+
+	// The exemption is proven by RegLimit never being consulted and no 429;
+	// the exact non-429 status depends on handler internals we don't assert.
+	code, body := postJSON(t, srv.URL+"/v1/agents", "good", map[string]any{"slug": "probe"})
+	if code == 429 {
+		t.Fatalf("exempt class must not be reg-limited, got 429 %v", body)
+	}
+}
+
 func TestRegRateLimited(t *testing.T) {
 	srv := httptest.NewServer(New(Deps{
 		Authenticator: func(r *http.Request) (*identity.User, error) {

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -202,6 +202,11 @@ type User struct {
 	Name          string    `json:"name"`
 	GoogleSubject string    `json:"-"`
 	CreatedAt     time.Time `json:"created_at"`
+	// AccountClass (usage.AccountClass) is loaded at auth for metering and
+	// rate-limit decisions. Hidden from API JSON. Empty for principals not
+	// resolved via API key (e.g. session auth), which fail-closes to standard
+	// (metered + limited) in the consuming policies.
+	AccountClass string `json:"-"`
 }
 
 type Message struct {
@@ -3958,9 +3963,9 @@ func (s *Store) GetPrincipalByAPIKey(ctx context.Context, apiKey string) (*Princ
 		     AND (expires_at IS NULL OR expires_at > now())
 		   RETURNING user_id, COALESCE(scope, 'account') AS scope, agent_id
 		 )
-		 SELECT u.id, u.email, u.name, u.google_subject, u.created_at, t.scope, t.agent_id
+		 SELECT u.id, u.email, u.name, u.google_subject, u.created_at, u.account_class, t.scope, t.agent_id
 		 FROM touched t JOIN users u ON u.id = t.user_id`, keyHash,
-	).Scan(&u.ID, &u.Email, &u.Name, &u.GoogleSubject, &u.CreatedAt, &scope, &agentID)
+	).Scan(&u.ID, &u.Email, &u.Name, &u.GoogleSubject, &u.CreatedAt, &u.AccountClass, &scope, &agentID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/usage/policy.go
+++ b/internal/usage/policy.go
@@ -40,8 +40,12 @@ func PolicyFor(c AccountClass) MeteringPolicy {
 	}
 }
 
-// RateLimited reports whether an account class is subject to the in-memory
-// request rate limiters (agent registration, per-user poll, per-agent send).
+// RateLimited reports whether an account class is subject to the two
+// class-exempt request limiters: the per-IP agent-registration limiter and the
+// per-user poll limiter. (The per-agent SEND limiter is intentionally NOT
+// class-exempt — it is keyed on the agent, so the prober/conformance's
+// fresh-agent-per-run pattern never trips it; there is no shared-bucket
+// exhaustion to relieve.)
 // Only trusted first-party traffic bypasses them: ClassSystem (synthetic
 // monitoring probes) and ClassInternal (internal dogfooding + the conformance
 // suite). The limiters exist to bound real-user and anonymous abuse, and those

--- a/internal/usage/policy.go
+++ b/internal/usage/policy.go
@@ -39,3 +39,23 @@ func PolicyFor(c AccountClass) MeteringPolicy {
 		return MeteringPolicy{Meter: true, Bill: true, Analytics: true}
 	}
 }
+
+// RateLimited reports whether an account class is subject to the in-memory
+// request rate limiters (agent registration, per-user poll, per-agent send).
+// Only trusted first-party traffic bypasses them: ClassSystem (synthetic
+// monitoring probes) and ClassInternal (internal dogfooding + the conformance
+// suite). The limiters exist to bound real-user and anonymous abuse, and those
+// two classes are neither. This is deliberately NARROWER than PolicyFor's
+// metering exemption: ClassDemo stays limited (it is user-facing, so a demo
+// account is still an abuse surface), and any unknown/empty value fail-closes
+// to limited — a misclassified account is never silently exempted from the
+// limiters. The exemption follows the account (loaded at auth), so it holds
+// regardless of source IP or whether the request arrives behind a proxy.
+func RateLimited(c AccountClass) bool {
+	switch c {
+	case ClassSystem, ClassInternal:
+		return false
+	default: // ClassStandard, ClassDemo, and any unrecognized value
+		return true
+	}
+}

--- a/internal/usage/policy_test.go
+++ b/internal/usage/policy_test.go
@@ -30,3 +30,24 @@ func TestPolicyFor(t *testing.T) {
 		}
 	}
 }
+
+func TestRateLimited(t *testing.T) {
+	cases := []struct {
+		class usage.AccountClass
+		want  bool
+	}{
+		{usage.ClassStandard, true},
+		{usage.ClassDemo, true}, // user-facing → stays limited (narrower than PolicyFor)
+		{usage.ClassInternal, false},
+		{usage.ClassSystem, false},
+		// Unknown / empty fails closed to limited — a misclassified account must
+		// never be silently exempted from the limiters.
+		{usage.AccountClass(""), true},
+		{usage.AccountClass("bogus"), true},
+	}
+	for _, c := range cases {
+		if got := usage.RateLimited(c.class); got != c.want {
+			t.Errorf("RateLimited(%q) = %v, want %v", c.class, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

The in-memory request limiters (per-IP agent registration = 200/hr, per-user poll = 60/min) are **not account-class-aware**, so trusted first-party traffic — the **system**-class prober and the **internal**-class conformance suite — competes for the same budget as anonymous/real-user traffic.

Worse, `regLimit` keys on the connection IP (`CF-Connecting-IP`, else `RemoteAddr` — never a forgeable XFF). Behind a **non-Cloudflare** proxy (staging is CF **DNS-only**), that's the *proxy's* IP, so **all internal traffic shares one bucket** and the conformance gate exhausts the 200/hr registration budget in a single run.

## Change

- **`usage.RateLimited(class)`** — `system` + `internal` bypass the limiters, mirroring (but deliberately **narrower** than) the metering policy: `demo` stays limited (user-facing), and unknown/empty **fail-closes to limited** (a misclassified account is never silently exempted).
- The account class is **loaded onto the principal at auth** — one extra column on the existing `GetPrincipalByAPIKey` join, hidden from API JSON — so the exemption **follows the account** regardless of source IP/proxy, at zero extra query cost.
- Gated in the httpapi rate-limit middleware for the **poll + reg** limiters (principal reused downstream). The **anonymous per-IP limiters** (OAuth DCR, attachment-download) are **unchanged** — they run pre-auth with no account and are the real abuse surface.

## Why it's safe

- Standard accounts are still limited (existing `TestPollRateLimited`/`TestRegRateLimited` pass unchanged).
- The XFF anti-spoof contract (`TestClientIPIgnoresXForwardedFor`) is untouched.
- Server-internal; **no `/v1` or SDK surface change**.

## Tests

- `usage.RateLimited` table (system/internal exempt; standard/demo/unknown limited).
- httpapi middleware: `TestPollRateLimitExemptInternalClass`, `TestRegRateLimitExemptSystemClass`.
- Full `internal/usage`, `internal/httpapi`, `internal/identity` (auth-path) suites green.

Enables the staging conformance gate + hardens the prober against its own rate limits.