### PR TITLE
feat(web): unread count badge on Inboxes list + live read-state refresh

### DIFF
--- a/web/src/app/(app)/inboxes/_components/AgentCard.test.tsx
+++ b/web/src/app/(app)/inboxes/_components/AgentCard.test.tsx
@@ -1,0 +1,75 @@
+// AgentCard unread badge (Inboxes list, Option A). The card fires a
+// per-inbox probe (getInboxUnread) and renders a red count badge. These
+// pin the count/"99+"/hidden-at-zero rendering and the graceful-degrade
+// on probe failure.
+
+import { render, screen, waitFor } from "../../../../test-utils/swr";
+import { AgentCard } from "./AgentCard";
+import { getInboxUnread } from "../../../components/onboarding/api";
+import type { DashboardAgent } from "../../../components/types";
+
+jest.mock("next/link", () => {
+  return function MockLink({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) {
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    );
+  };
+});
+
+// Mock the probe but keep the real UNREAD_BADGE_CAP the component reads.
+jest.mock("../../../components/onboarding/api", () => ({
+  getInboxUnread: jest.fn(),
+  UNREAD_BADGE_CAP: 99,
+}));
+const mockUnread = getInboxUnread as jest.MockedFunction<typeof getInboxUnread>;
+
+const agent: DashboardAgent = {
+  id: "ag_billing",
+  domain: "acme.dev",
+  email: "billing@acme.dev",
+  name: "billing",
+  domain_verified: true,
+  created_at: "2026-05-10T00:00:00Z",
+};
+
+afterEach(() => mockUnread.mockReset());
+
+it("renders the unread count as a red badge", async () => {
+  mockUnread.mockResolvedValue({ count: 3, more: false });
+  render(<AgentCard agent={agent} />);
+  const badge = await screen.findByTitle("3 unread");
+  expect(badge).toHaveTextContent("3");
+});
+
+it("caps the badge at 99+ when there are more unread than the cap", async () => {
+  mockUnread.mockResolvedValue({ count: 99, more: true });
+  render(<AgentCard agent={agent} />);
+  const badge = await screen.findByTitle("99+ unread");
+  expect(badge).toHaveTextContent("99+");
+});
+
+it("renders no badge when the inbox has zero unread", async () => {
+  mockUnread.mockResolvedValue({ count: 0, more: false });
+  render(<AgentCard agent={agent} />);
+  // The identity still renders...
+  await waitFor(() => expect(screen.getByText("billing@acme.dev")).toBeInTheDocument());
+  // ...but no unread badge.
+  expect(screen.queryByText("unread messages", { exact: false })).not.toBeInTheDocument();
+});
+
+it("degrades to no badge when the probe rejects", async () => {
+  mockUnread.mockRejectedValue(new Error("boom"));
+  render(<AgentCard agent={agent} />);
+  await waitFor(() => expect(screen.getByText("billing@acme.dev")).toBeInTheDocument());
+  expect(screen.queryByText("unread messages", { exact: false })).not.toBeInTheDocument();
+});

--- a/web/src/app/(app)/inboxes/_components/AgentCard.tsx
+++ b/web/src/app/(app)/inboxes/_components/AgentCard.tsx
@@ -1,12 +1,33 @@
+"use client";
+
 import Link from "next/link";
+import useSWR from "swr";
 import type { DashboardAgent } from "../../../components/types";
 import { Chip, Dot } from "@e2a/ui";
+import {
+  getInboxUnread,
+  UNREAD_BADGE_CAP,
+} from "../../../components/onboarding/api";
+import { agentUnreadKey } from "../../../../lib/swrKeys";
 
 export function AgentCard({
   agent,
 }: {
   agent: DashboardAgent;
 }) {
+  // Option A unread affordance: one lightweight per-card probe against the
+  // messages endpoint (read_status=unread). SWR shares/dedupes the call and
+  // revalidates on focus, so returning to this tab after reading an inbox
+  // updates the count. Failures degrade silently to "no badge".
+  const { data: unread } = useSWR(agentUnreadKey(agent.email), () =>
+    getInboxUnread(agent.email).catch(() => ({ count: 0, more: false })),
+  );
+  const unreadCount = unread?.count ?? 0;
+  const unreadLabel =
+    unread?.more || unreadCount > UNREAD_BADGE_CAP
+      ? `${UNREAD_BADGE_CAP}+`
+      : String(unreadCount);
+
   return (
     <div
       style={{
@@ -27,6 +48,28 @@ export function AgentCard({
               (Activity log) so clicking the agent's address from the
               dashboard lands on the debug surface for that agent. */}
           <div className="flex items-center gap-2 mb-2 flex-wrap">
+            {unreadCount > 0 && (
+              // Red unread count badge. Solid --danger with white text
+              // reads in both themes; sr-only text spells it out for
+              // screen readers since the number alone lacks context.
+              <span
+                className="inline-flex items-center justify-center shrink-0 font-mono font-semibold tabular-nums"
+                title={`${unreadLabel} unread`}
+                style={{
+                  minWidth: 18,
+                  height: 18,
+                  padding: "0 5px",
+                  fontSize: 11,
+                  lineHeight: 1,
+                  color: "#fff",
+                  background: "var(--danger)",
+                  borderRadius: 999,
+                }}
+              >
+                {unreadLabel}
+                <span className="sr-only"> unread messages</span>
+              </span>
+            )}
             {agent.name && (
               <Link
                 href={`/inboxes/messages?email=${encodeURIComponent(agent.email)}`}

--- a/web/src/app/components/messages/ThreadBubble.test.tsx
+++ b/web/src/app/components/messages/ThreadBubble.test.tsx
@@ -6,12 +6,24 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import { ThreadBubble } from "./ThreadBubble";
 import { getMessageDetail } from "../onboarding/api";
+import {
+  invalidateAgentMessages,
+  invalidateAgentUnread,
+} from "../../../lib/swrKeys";
 import type { MessageSummary } from "../types";
 
 jest.mock("../onboarding/api", () => ({
   getMessageDetail: jest.fn(),
 }));
+jest.mock("../../../lib/swrKeys", () => ({
+  invalidateAgentMessages: jest.fn(),
+  invalidateAgentUnread: jest.fn(),
+}));
 const mockGet = getMessageDetail as jest.MockedFunction<typeof getMessageDetail>;
+const mockInvalidateMessages =
+  invalidateAgentMessages as jest.MockedFunction<typeof invalidateAgentMessages>;
+const mockInvalidateUnread =
+  invalidateAgentUnread as jest.MockedFunction<typeof invalidateAgentUnread>;
 
 // Each test uses a distinct message_id: useSWR keys the body cache by id and
 // that cache is process-global, so reusing an id would leak one test's body
@@ -34,7 +46,11 @@ function inbound(data: Record<string, unknown>) {
   mockGet.mockResolvedValue({ direction: "inbound", data } as never);
 }
 
-afterEach(() => mockGet.mockReset());
+afterEach(() => {
+  mockGet.mockReset();
+  mockInvalidateMessages.mockReset();
+  mockInvalidateUnread.mockReset();
+});
 
 describe("ThreadBubble body precedence", () => {
   it("renders parsed.html in the sandboxed iframe when present", async () => {
@@ -55,5 +71,42 @@ describe("ThreadBubble body precedence", () => {
       expect(screen.getByText("just the plain body")).toBeInTheDocument();
     });
     expect(screen.queryByTitle("Email body")).not.toBeInTheDocument();
+  });
+});
+
+describe("ThreadBubble marks-read cache refresh", () => {
+  // Opening a message body flips inbox_status unread → read on the backend.
+  // The thread list (bold rows) and the Inboxes unread badge both cache the
+  // stale state, so the bubble must revalidate them once the body loads.
+  it("invalidates the thread list + unread badge after reading an unread inbound message", async () => {
+    inbound({ parsed: { text: "body" }, raw_message: "" });
+    const m = { ...msg("msg_unread_inbound"), read_status: "unread" };
+    render(<ThreadBubble message={m} counterparty={CP} agentEmail="support@acme.dev" />);
+    await waitFor(() => {
+      expect(mockInvalidateMessages).toHaveBeenCalledWith("support@acme.dev");
+      expect(mockInvalidateUnread).toHaveBeenCalledWith("support@acme.dev");
+    });
+  });
+
+  it("does not invalidate when the inbound message was already read", async () => {
+    inbound({ parsed: { text: "body" }, raw_message: "" });
+    const m = { ...msg("msg_read_inbound"), read_status: "read" };
+    render(<ThreadBubble message={m} counterparty={CP} agentEmail="support@acme.dev" />);
+    // Wait for the body fetch to resolve so onSuccess has had its chance.
+    await waitFor(() => expect(screen.getByText("body")).toBeInTheDocument());
+    expect(mockInvalidateMessages).not.toHaveBeenCalled();
+    expect(mockInvalidateUnread).not.toHaveBeenCalled();
+  });
+
+  it("does not invalidate for outbound messages", async () => {
+    mockGet.mockResolvedValue({
+      direction: "outbound",
+      data: { body_text: "sent body", body_html: "" },
+    } as never);
+    const m: MessageSummary = { ...msg("msg_outbound"), direction: "outbound", read_status: "" };
+    render(<ThreadBubble message={m} counterparty={CP} agentEmail="support@acme.dev" />);
+    await waitFor(() => expect(screen.getByText("sent body")).toBeInTheDocument());
+    expect(mockInvalidateMessages).not.toHaveBeenCalled();
+    expect(mockInvalidateUnread).not.toHaveBeenCalled();
   });
 });

--- a/web/src/app/components/messages/ThreadBubble.tsx
+++ b/web/src/app/components/messages/ThreadBubble.tsx
@@ -13,6 +13,10 @@ import { Chip, Dot } from "@e2a/ui";
 import { CounterpartyAvatar } from "./CounterpartyAvatar";
 import { EmailHtmlBody } from "./EmailHtmlBody";
 import { getMessageDetail } from "../onboarding/api";
+import {
+  invalidateAgentMessages,
+  invalidateAgentUnread,
+} from "../../../lib/swrKeys";
 import type { MessageSummary } from "../types";
 import type { Counterparty } from "./threading";
 
@@ -68,11 +72,28 @@ export function ThreadBubble({
   const pending = message.review_status === "pending_review";
   const [showDetails, setShowDetails] = useState(false);
 
+  // Opening a message body fetches its detail, which flips inbox_status
+  // unread → read on the backend (GetMessageWithContent). Capture whether
+  // THIS row was an unread inbound message at fetch time so we can refresh
+  // the stale caches once the read-flip has happened.
+  const wasUnreadInbound = isInbound && message.read_status === "unread";
+
   // Fetch this message's body. Keyed per (agent, id, direction) so each
   // message caches independently and shares with the focus page's cache.
   const { data: detail, isLoading } = useSWR(
     ["thread-msg-body", agentEmail, message.message_id, message.direction] as const,
     () => getMessageDetail(agentEmail, message.message_id, message.direction),
+    {
+      // After the read-flip, the thread list (bold rows) and the Inboxes
+      // unread badge both hold stale unread state. Revalidate them so the
+      // row un-bolds and the badge count drops without a hard refresh.
+      onSuccess: () => {
+        if (wasUnreadInbound) {
+          invalidateAgentMessages(agentEmail);
+          invalidateAgentUnread(agentEmail);
+        }
+      },
+    },
   );
 
   // Resolve both representations: a rich HTML body (rendered sanitized in a

--- a/web/src/app/components/onboarding/api.test.ts
+++ b/web/src/app/components/onboarding/api.test.ts
@@ -5,7 +5,12 @@
 // shape, which silently disabled the whole pending queue. These tests
 // pin the projection to the v1 field names so that can't recur.
 
-import { listAgentMessages, listPendingMessages } from "./api";
+import {
+  listAgentMessages,
+  listPendingMessages,
+  getInboxUnread,
+  UNREAD_BADGE_CAP,
+} from "./api";
 
 const mockFetch = jest.fn();
 beforeEach(() => {
@@ -122,5 +127,57 @@ describe("message projection (v1 contract)", () => {
     await listPendingMessages();
     const urls = mockFetch.mock.calls.map((c) => c[0] as string);
     expect(urls).toEqual(["/v1/reviews"]);
+  });
+});
+
+describe("getInboxUnread (Inboxes list badge probe)", () => {
+  it("queries inbound unread with the capped limit and reports the count", async () => {
+    mockFetch.mockImplementation((url: string) =>
+      url.includes("/messages")
+        ? okJson({
+            items: [
+              { message_id: "m1" },
+              { message_id: "m2" },
+              { message_id: "m3" },
+            ],
+            next_cursor: null,
+          })
+        : notFound(),
+    );
+    const res = await getInboxUnread("billing@acme.dev");
+    expect(res).toEqual({ count: 3, more: false });
+
+    // Must filter on the backend's inbound read-state param (read_status),
+    // not the ignored `status` param, and only pull one capped page.
+    const url = mockFetch.mock.calls[0][0] as string;
+    expect(url).toContain("/v1/agents/billing%40acme.dev/messages");
+    expect(url).toContain("direction=inbound");
+    expect(url).toContain("read_status=unread");
+    expect(url).toContain(`limit=${UNREAD_BADGE_CAP}`);
+  });
+
+  it("flags more=true when the capped page is full (cursor present)", async () => {
+    // A returned cursor means there are more unread than the cap — the card
+    // renders "N+" off this flag.
+    mockFetch.mockImplementation((url: string) =>
+      url.includes("/messages")
+        ? okJson({
+            items: Array.from({ length: UNREAD_BADGE_CAP }, (_, i) => ({
+              message_id: `m${i}`,
+            })),
+            next_cursor: "cursor-abc",
+          })
+        : notFound(),
+    );
+    const res = await getInboxUnread("billing@acme.dev");
+    expect(res.count).toBe(UNREAD_BADGE_CAP);
+    expect(res.more).toBe(true);
+  });
+
+  it("reports zero unread on an empty page", async () => {
+    mockFetch.mockImplementation((url: string) =>
+      url.includes("/messages") ? okJson({ items: [], next_cursor: null }) : notFound(),
+    );
+    expect(await getInboxUnread("billing@acme.dev")).toEqual({ count: 0, more: false });
   });
 });

--- a/web/src/app/components/onboarding/api.ts
+++ b/web/src/app/components/onboarding/api.ts
@@ -214,6 +214,30 @@ export async function listAgentMessages(
   };
 }
 
+// Max unread we count before showing "N+" — keeps the per-card probe a
+// small fixed page instead of walking the whole unread backlog.
+export const UNREAD_BADGE_CAP = 99;
+
+// Inbox-level unread rollup for the Inboxes list. Asks the messages
+// endpoint for unread inbound rows (read_status=unread is the backend's
+// inbound read-state filter — MSG-1) and reports how many there are. We
+// pull one capped page (limit=CAP) and treat a returned cursor as "more
+// than CAP" so the card can render "99+". One call per inbox card
+// (Option A); a native per-agent unread count on GET /v1/agents would
+// replace this later.
+export async function getInboxUnread(
+  email: string,
+): Promise<{ count: number; more: boolean }> {
+  const page = await request<PageMessageSummaryWire>(
+    "/v1/agents/" +
+      encodeURIComponent(email) +
+      "/messages?direction=inbound&read_status=unread&limit=" +
+      UNREAD_BADGE_CAP,
+  );
+  const count = (page.items ?? []).length;
+  return { count, more: Boolean(page.next_cursor) };
+}
+
 // Wire shape of MessageView (GET /v1/agents/{address}/messages/{id}).
 type MessageViewWire = {
   message_id: string;

--- a/web/src/lib/swrKeys.ts
+++ b/web/src/lib/swrKeys.ts
@@ -37,6 +37,12 @@ export const agentMessagesKey = (
 ) =>
   ["agent-messages", email, direction, status, token ?? null] as const;
 
+// Per-inbox unread flag for the Inboxes list (getInboxHasUnread →
+// GET /v1/agents/{address}/messages?read_status=unread&limit=1), keyed
+// by the owning agent's email so each card caches independently.
+export const agentUnreadKey = (email: string) =>
+  ["agent-unread", email] as const;
+
 // Agent-scoped in /v1: the detail fetch is GET /v1/agents/{address}/
 // messages/{id}, so the cache key carries the owning agent's email.
 export const pendingMessageKey = (email: string, id: string) =>
@@ -96,6 +102,13 @@ export function invalidateAllAgentMessages() {
   return mutate(
     (key) => Array.isArray(key) && key[0] === "agent-messages",
   );
+}
+
+// After a message is read (its detail fetch flips inbox_status → read on
+// the backend), the Inboxes list unread badge for that agent is stale.
+// Revalidate its per-agent probe so the count drops without a hard refresh.
+export function invalidateAgentUnread(email: string) {
+  return mutate(agentUnreadKey(email));
 }
 
 export function invalidateDomains() {


### PR DESCRIPTION
## What

Adds a red **unread-count badge** to each inbox card on the **Inboxes** list so you can see at a glance which inboxes have new mail, and fixes a stale read-state bug where reading an email didn't clear the unread indicators without a hard refresh.

![before: no unread signal on the Inboxes list]

### Unread badge (Option A — frontend-only)
- `getInboxUnread(email)` probes `GET /v1/agents/{email}/messages?direction=inbound&read_status=unread&limit=99` (the backend's inbound read-state filter, MSG-1) and returns `{ count, more }`. A returned cursor means "more than the cap" → the card renders `99+`.
- `AgentCard` renders the count in a small red badge (solid `--danger`, white text, readable in light + dark) with an sr-only "unread messages" label. Hidden at zero; degrades to no badge if the probe fails.
- One request per card. A native per-agent unread rollup on `GET /v1/agents` (Option B) would replace this later — left as a follow-up.

### Live read-state refresh (bug fix)
Opening a thread already marks its messages read on the backend — `ThreadBubble`'s per-message detail fetch (`GET .../messages/{id}`) flips `inbox_status` unread → read. But nothing revalidated the **thread list** (which bolds rows from cached `read_status`) or the **new badge**, so both showed stale `unread` until a hard refresh. `ThreadBubble` now invalidates both caches (`invalidateAgentMessages` + `invalidateAgentUnread`) once an unread inbound message's body loads. Gated so already-read and outbound messages don't trigger needless refetches (no revalidation loop).

## Tests
- `api.test.ts` — `getInboxUnread` count, `99+` cap via cursor, empty page.
- `AgentCard.test.tsx` (new) — badge renders count, caps at `99+`, hidden at zero, degrades on probe failure.
- `ThreadBubble.test.tsx` — invalidates list + badge after reading an unread inbound message; does **not** for already-read or outbound.

Full web suite: **309 passed / 36 suites**. Lint clean (the single warning is pre-existing in `messages/page.tsx`).

## Scope
`web/` only — no backend, API, or SDK changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)