### PR TITLE
fix(httpapi): send-limit 429 now carries the Retry-After header

### DIFF
--- a/internal/httpapi/errors.go
+++ b/internal/httpapi/errors.go
@@ -16,6 +16,7 @@ package httpapi
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/danielgtaylor/huma/v2"
 )
@@ -38,6 +39,13 @@ type ErrorEnvelope struct {
 	// status is the HTTP status; unexported so it never serializes into
 	// the body (the status already rides the status line).
 	status int
+
+	// retryAfter, when > 0, is the seconds value stampRequestID copies into the
+	// Retry-After response header. A StatusError returned from a handler renders
+	// status + body only, so a 429 raised inside a handler (the per-agent send
+	// limiter) carries its Retry-After here; the middleware limiter path sets
+	// the header directly instead. Unexported so it never serializes.
+	retryAfter int
 
 	Err ErrorBody `json:"error"`
 }
@@ -71,6 +79,15 @@ func NewError(status int, code, message string) *ErrorEnvelope {
 // fluent construction.
 func (e *ErrorEnvelope) WithDetails(details any) *ErrorEnvelope {
 	e.Err.Details = details
+	return e
+}
+
+// WithRetryAfter records a Retry-After delay (seconds) for a handler-returned
+// error; stampRequestID copies it into the Retry-After response header. Use it
+// on 429s raised inside a handler (the per-agent send limiter) — the
+// middleware-enforced limiters set the header themselves.
+func (e *ErrorEnvelope) WithRetryAfter(seconds int) *ErrorEnvelope {
+	e.retryAfter = seconds
 	return e
 }
 
@@ -148,8 +165,18 @@ func humaErrorConstructor(status int, message string, errs ...error) huma.Status
 // the X-Request-Id header (api-v1-redesign §4 — "echo the same id in the
 // error envelope"). Success bodies are left untouched.
 func stampRequestID(ctx huma.Context, status string, v any) (any, error) {
-	if env, ok := v.(*ErrorEnvelope); ok && env.Err.RequestID == "" {
+	env, ok := v.(*ErrorEnvelope)
+	if !ok {
+		return v, nil
+	}
+	if env.Err.RequestID == "" {
 		env.Err.RequestID = RequestIDFromContext(ctx.Context())
+	}
+	// A StatusError returned from a handler renders status + body only, so stamp
+	// the Retry-After header here for rate-limit errors that carry a delay —
+	// matching the middleware limiter path, which sets the header itself.
+	if env.retryAfter > 0 {
+		ctx.SetHeader("Retry-After", strconv.Itoa(env.retryAfter))
 	}
 	return v, nil
 }

--- a/internal/httpapi/outbound.go
+++ b/internal/httpapi/outbound.go
@@ -622,8 +622,9 @@ func literalRequest(req outbound.SendRequest) func() (outbound.SendRequest, *Err
 
 // checkSendLimit applies the per-agent outbound rate limit (mirrors the
 // legacy sendLimit). On block it returns a 429 envelope carrying the
-// retry-after seconds; the IETF RateLimit-* response headers are a tracked
-// follow-up (Huma error responses can't set headers directly).
+// retry-after seconds in the body AND — via WithRetryAfter → stampRequestID —
+// the IETF Retry-After response header, so a handler-raised send 429 matches
+// the middleware-enforced registration/poll limiters (which set it directly).
 func (s *Server) checkSendLimit(agentID string) *ErrorEnvelope {
 	if s.deps.SendLimit == nil {
 		return nil
@@ -638,7 +639,8 @@ func (s *Server) checkSendLimit(agentID string) *ErrorEnvelope {
 	}
 	return NewError(http.StatusTooManyRequests, "rate_limited",
 		"rate limit exceeded — max 60 sends per minute per agent").
-		WithDetails(map[string]any{"retry_after_seconds": secs})
+		WithDetails(map[string]any{"retry_after_seconds": secs}).
+		WithRetryAfter(secs)
 }
 
 func (s *Server) handleCreateMessage(ctx context.Context, in *createMessageInput) (*sendOutput, error) {

--- a/internal/httpapi/ratelimit_test.go
+++ b/internal/httpapi/ratelimit_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -259,6 +260,30 @@ func TestSendRateLimited(t *testing.T) {
 	d, _ := e["details"].(map[string]any)
 	if d == nil || d["retry_after_seconds"].(float64) != 7 {
 		t.Fatalf("expected retry_after_seconds=7 in details, got %v", body)
+	}
+}
+
+// TestSendRateLimitSetsRetryAfterHeader pins the fix for the handler-raised
+// send 429: the per-agent send limiter is enforced INSIDE the outbound handler
+// (returns a StatusError), so — unlike the middleware reg/poll limiters — its
+// Retry-After header is stamped via WithRetryAfter → stampRequestID rather than
+// by the middleware. serverWithSendLimit blocks with a 7s retry-after.
+func TestSendRateLimitSetsRetryAfterHeader(t *testing.T) {
+	srv := serverWithSendLimit(t)
+	req, _ := http.NewRequest("POST", srv.URL+"/v1/agents/support%40acme.com/messages",
+		strings.NewReader(`{"to":["a@x.com"],"subject":"Hi","body":"hello"}`))
+	req.Header.Set("Authorization", "Bearer good")
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 429 {
+		t.Fatalf("want 429, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Retry-After"); got != "7" {
+		t.Errorf("Retry-After = %q, want 7 (handler-raised send 429 must carry the header)", got)
 	}
 }
 


### PR DESCRIPTION
## Problem

The three request limiters split into two enforcement styles:
- **Registration + poll** run in the `rateLimit` **middleware**, which has a `huma.Context` → it sets `Retry-After` directly.
- **Send** (60/min per agent) is enforced **inside the outbound handler** (`checkSendLimit`), because its key is the *resolved-owned* agent (post-ownership-check) which the middleware doesn't resolve. It returns an `ErrorEnvelope` (a `huma.StatusError`), which Huma renders as **status + body only** — so the send 429 shipped `retry_after_seconds` in the body but **omitted the `Retry-After` header**.

Result: inconsistent 429 behavior across limiters, and well-behaved clients that back off on `Retry-After` don't get the signal on send throttling. (Surfaced by the conformance suite's quota probe.)

## Fix

Reuse the existing error transformer — no new machinery:
- `ErrorEnvelope` gains an unexported `retryAfter int` + `WithRetryAfter(seconds)`.
- `stampRequestID` (a Huma transformer that already runs on every error with a `huma.Context`, stamping `request_id`) now also stamps `Retry-After` when `retryAfter > 0`. Confirmed `huma.Context.SetHeader` takes effect from a transformer in huma v2.38.
- `checkSendLimit` calls `.WithRetryAfter(secs)` alongside the existing body detail.

## Test

`TestSendRateLimitSetsRetryAfterHeader` — a send 429 must carry `Retry-After: 7` (absent before this change). Full `internal/httpapi` suite green; `gofmt` clean. Server-internal; no `/v1`/SDK surface change.