### PR TITLE
test(conformance): standard-class quota account + enforcement suite

### DIFF
--- a/cmd/e2a-prober/seed_conformance.go
+++ b/cmd/e2a-prober/seed_conformance.go
@@ -6,45 +6,104 @@ import (
 	"os"
 	"strings"
 
+	"github.com/jackc/pgx/v5/pgxpool"
+
 	"github.com/Mnexa-AI/e2a/internal/identity"
 	"github.com/Mnexa-AI/e2a/internal/limits"
 )
 
-// Conformance test account identity. Fixed values → CreateOrGetUser is
-// idempotent, so re-seeding a staging DB converges on the same account.
+// Conformance test account identities. Fixed values → CreateOrGetUser is
+// idempotent, so re-seeding a staging DB converges on the same accounts.
 const (
 	conformanceUserEmail = "conformance@e2a.test"
 	conformanceUserName  = "e2a conformance"
 	conformanceGoogleSub = "e2a-conformance"
 	conformanceKeyName   = "e2a-conformance"
+
+	// The quota account is a SEPARATE standard-class account with LOW caps, so
+	// the suite can exercise real limit + rate-limit enforcement — which the
+	// main (internal, unmetered, exempt, huge-cap) conformance account cannot.
+	quotaUserEmail  = "conformance-quota@e2a.test"
+	quotaUserName   = "e2a conformance quota"
+	quotaGoogleSub  = "e2a-conformance-quota"
+	quotaKeyName    = "e2a-conformance-quota"
+	quotaMaxAgents  = 5 // low but > the primary agent, so the count-cap is reachable + repeatable
+	quotaMaxDomains = 1
 )
 
-// cmdSeedConformance provisions the persistent account that the black-box
-// tests/e2e-prod conformance suite runs against on staging. Unlike the
-// system-class probe (cmdSeed), this account is INTERNAL class so it is
-// unmetered (usage.PolicyFor: only "standard" is metered) — the suite's
-// heavy message churn never trips the monthly send quota — while a high
-// account_limits row gives the count-based caps (max_agents/max_domains,
-// which are enforced regardless of class) enough headroom for the suite's
-// create/delete churn (staging's default caps are 3 agents / 1 domain).
-//
-// It seeds: the internal-class user, its high limits row, the shared domain
-// (find-or-create — the server already seeds it on boot), a primary agent
-// (the pre-existing inbox the suite reads against but never deletes), and an
-// API key. It prints E2A_AGENT_EMAIL / E2A_SHARED_DOMAIN / E2A_API_KEY for the
-// pipeline to capture. Idempotent: user/domain/agent are find-or-create and
-// the API key is (re)created only when the account has none (its plaintext is
-// unrecoverable, so an existing key can't be re-printed — reuse the first).
-func cmdSeedConformance(ctx context.Context, cfg config) error {
-	agentEmail := os.Getenv("E2A_CONFORMANCE_AGENT_EMAIL")
-	if agentEmail == "" {
-		return fmt.Errorf("E2A_CONFORMANCE_AGENT_EMAIL is required (primary agent, e.g. conformance@agents-staging.e2a.dev)")
-	}
+// seededAccount is the credential + identity a freshly-seeded test account
+// exposes. APIKey is empty when the account already had one (its plaintext is
+// unrecoverable, so an existing key can't be re-printed).
+type seededAccount struct {
+	AgentEmail string
+	Domain     string
+	APIKey     string
+}
+
+// seedAccount provisions one test account: a user of the given class, its
+// account_limits row, the shared domain (find-or-create — the server seeds it
+// on boot), a primary agent (the pre-existing inbox the suite reads against but
+// never deletes), and an API key (created only when the account has none).
+// Idempotent across re-seeds.
+func seedAccount(ctx context.Context, store *identity.Store, pool *pgxpool.Pool, email, name, googleSub, class, keyName, agentEmail string, lim limits.Limits) (*seededAccount, error) {
 	parts := strings.SplitN(agentEmail, "@", 2)
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-		return fmt.Errorf("invalid agent email %q", agentEmail)
+		return nil, fmt.Errorf("invalid agent email %q", agentEmail)
 	}
 	domain := parts[1]
+
+	user, err := store.CreateOrGetUser(ctx, email, name, googleSub)
+	if err != nil {
+		return nil, fmt.Errorf("create user %s: %w", email, err)
+	}
+	if err := store.SetAccountClass(ctx, user.ID, class); err != nil {
+		return nil, fmt.Errorf("set %s class on %s: %w", class, email, err)
+	}
+	if err := limits.NewStore(pool).Upsert(ctx, user.ID, lim); err != nil {
+		return nil, fmt.Errorf("set limits on %s: %w", email, err)
+	}
+	if err := store.EnsureSharedDomain(ctx, domain); err != nil {
+		return nil, fmt.Errorf("ensure shared domain %s: %w", domain, err)
+	}
+	if _, err := store.GetAgentByID(ctx, agentEmail); err != nil {
+		// Not found → create the primary agent on the shared domain.
+		if _, cerr := store.CreateAgent(ctx, agentEmail, domain, name, "", "cloud", user.ID); cerr != nil {
+			return nil, fmt.Errorf("create primary agent %s: %w", agentEmail, cerr)
+		}
+	}
+	res := &seededAccount{AgentEmail: agentEmail, Domain: domain}
+	keys, err := store.ListAPIKeys(ctx, user.ID)
+	if err != nil {
+		return nil, fmt.Errorf("list api keys for %s: %w", email, err)
+	}
+	if len(keys) == 0 {
+		key, err := store.CreateAPIKey(ctx, user.ID, keyName, nil)
+		if err != nil {
+			return nil, fmt.Errorf("create api key for %s: %w", email, err)
+		}
+		res.APIKey = key.PlaintextKey
+	}
+	return res, nil
+}
+
+// cmdSeedConformance provisions the persistent account(s) the black-box
+// tests/e2e-prod conformance suite runs against on staging:
+//
+//   - the CONFORMANCE account (internal class, unmetered, rate-limit-exempt, huge
+//     caps) — the main account the suite churns against without tripping quota,
+//     rate limits, or the staging default 3-agent/1-domain caps.
+//   - the QUOTA account (standard class, low caps) — a SEPARATE account so the
+//     suite can assert real limit + rate-limit enforcement, which the internal
+//     account is by construction blind to. Seeded only when E2A_QUOTA_AGENT_EMAIL
+//     is set (opt-in).
+//
+// Prints E2A_AGENT_EMAIL / E2A_SHARED_DOMAIN / E2A_API_KEY (conformance) and, when
+// seeded, E2A_QUOTA_AGENT_EMAIL / E2A_QUOTA_API_KEY for the pipeline to capture.
+func cmdSeedConformance(ctx context.Context, cfg config) error {
+	confAgent := os.Getenv("E2A_CONFORMANCE_AGENT_EMAIL")
+	if confAgent == "" {
+		return fmt.Errorf("E2A_CONFORMANCE_AGENT_EMAIL is required (primary agent, e.g. conformance@agents-staging.e2a.dev)")
+	}
 
 	pool, err := openPool(ctx, cfg)
 	if err != nil {
@@ -53,54 +112,42 @@ func cmdSeedConformance(ctx context.Context, cfg config) error {
 	defer pool.Close()
 	store := identity.NewStore(pool)
 
-	user, err := store.CreateOrGetUser(ctx, conformanceUserEmail, conformanceUserName, conformanceGoogleSub)
-	if err != nil {
-		return fmt.Errorf("create conformance user: %w", err)
-	}
-	if err := store.SetAccountClass(ctx, user.ID, "internal"); err != nil {
-		return fmt.Errorf("set internal class: %w", err)
-	}
-
-	if err := limits.NewStore(pool).Upsert(ctx, user.ID, limits.Limits{
+	conf, err := seedAccount(ctx, store, pool, conformanceUserEmail, conformanceUserName, conformanceGoogleSub, "internal", conformanceKeyName, confAgent, limits.Limits{
 		PlanCode:         "conformance",
 		MaxAgents:        100000,
 		MaxDomains:       100000,
 		MaxMessagesMonth: 100000000,
 		MaxStorageBytes:  1 << 40, // 1 TiB
-	}); err != nil {
-		return fmt.Errorf("set conformance limits: %w", err)
-	}
-
-	if err := store.EnsureSharedDomain(ctx, domain); err != nil {
-		return fmt.Errorf("ensure shared domain %s: %w", domain, err)
-	}
-
-	if _, err := store.GetAgentByID(ctx, agentEmail); err != nil {
-		// Not found → create the primary agent on the shared domain.
-		if _, cerr := store.CreateAgent(ctx, agentEmail, domain, "e2a conformance", "", "cloud", user.ID); cerr != nil {
-			return fmt.Errorf("create primary agent: %w", cerr)
-		}
-	}
-
-	var apiKey string
-	keys, err := store.ListAPIKeys(ctx, user.ID)
+	})
 	if err != nil {
-		return fmt.Errorf("list api keys: %w", err)
+		return err
 	}
-	if len(keys) == 0 {
-		key, err := store.CreateAPIKey(ctx, user.ID, conformanceKeyName, nil)
-		if err != nil {
-			return fmt.Errorf("create api key: %w", err)
-		}
-		apiKey = key.PlaintextKey
-	}
-
-	fmt.Printf("E2A_AGENT_EMAIL=%s\n", agentEmail)
-	fmt.Printf("E2A_SHARED_DOMAIN=%s\n", domain)
-	if apiKey != "" {
-		fmt.Printf("E2A_API_KEY=%s\n", apiKey)
+	fmt.Printf("E2A_AGENT_EMAIL=%s\n", conf.AgentEmail)
+	fmt.Printf("E2A_SHARED_DOMAIN=%s\n", conf.Domain)
+	if conf.APIKey != "" {
+		fmt.Printf("E2A_API_KEY=%s\n", conf.APIKey)
 	} else {
 		fmt.Printf("# conformance account already has an API key; reuse the one captured at first seed\n")
+	}
+
+	// Opt-in standard-class quota account for enforcement coverage.
+	if quotaAgent := os.Getenv("E2A_QUOTA_AGENT_EMAIL"); quotaAgent != "" {
+		quota, err := seedAccount(ctx, store, pool, quotaUserEmail, quotaUserName, quotaGoogleSub, "standard", quotaKeyName, quotaAgent, limits.Limits{
+			PlanCode:         "conformance-quota",
+			MaxAgents:        quotaMaxAgents,
+			MaxDomains:       quotaMaxDomains,
+			MaxMessagesMonth: 100000000, // monthly quota accumulates across runs; not asserted — kept high
+			MaxStorageBytes:  1 << 40,
+		})
+		if err != nil {
+			return err
+		}
+		fmt.Printf("E2A_QUOTA_AGENT_EMAIL=%s\n", quota.AgentEmail)
+		if quota.APIKey != "" {
+			fmt.Printf("E2A_QUOTA_API_KEY=%s\n", quota.APIKey)
+		} else {
+			fmt.Printf("# quota account already has an API key; reuse the one captured at first seed\n")
+		}
 	}
 	return nil
 }

--- a/tests/e2e-prod/harness/env.ts
+++ b/tests/e2e-prod/harness/env.ts
@@ -7,6 +7,11 @@ export interface ProdEnv {
   apiKey: string;
   primaryAgentEmail: string;
   sharedDomain: string;
+  // Optional separate STANDARD-class, low-cap account for enforcement tests
+  // (limit + rate-limit). Absent → the enforcement suite skips, since the main
+  // conformance account is internal-class and by construction exempt.
+  quotaApiKey?: string;
+  quotaAgentEmail?: string;
   allowStress: boolean;
   cleanupMode: "always" | "on_success" | "never";
   rateLimitRps: number;
@@ -51,6 +56,8 @@ export function loadEnv(): ProdEnv {
     apiKey: process.env.E2A_API_KEY ?? local.api_key ?? "",
     primaryAgentEmail: pickEnv("E2A_AGENT_EMAIL", "E2A_PRIMARY_AGENT") ?? local.agent_email ?? "",
     sharedDomain: process.env.E2A_SHARED_DOMAIN ?? local.shared_domain ?? "agents.e2a.dev",
+    quotaApiKey: process.env.E2A_QUOTA_API_KEY || undefined,
+    quotaAgentEmail: process.env.E2A_QUOTA_AGENT_EMAIL || undefined,
     allowStress: process.env.E2E_PROD_STRESS === "1",
     cleanupMode: (process.env.E2E_CLEANUP as ProdEnv["cleanupMode"]) ?? "always",
     rateLimitRps: Number(process.env.E2E_RPS ?? "1"),

--- a/tests/e2e-prod/suites/15-quota-enforcement.test.ts
+++ b/tests/e2e-prod/suites/15-quota-enforcement.test.ts
@@ -1,0 +1,92 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { uniqueSlug } from "../harness/fixtures.ts";
+import { writeReport } from "../harness/report.ts";
+
+// Limit/quota ENFORCEMENT can only be exercised against a STANDARD-class,
+// low-cap account. The main conformance account is internal-class → unmetered,
+// rate-limit-exempt, and huge caps by construction, so a green conformance run
+// does NOT attest that enforcement works. This suite uses a SEPARATE opt-in
+// account (E2A_QUOTA_API_KEY / E2A_QUOTA_AGENT_EMAIL, provisioned by
+// `e2a-prober seed-conformance`) to close that gap. It skips cleanly when the
+// quota account isn't provisioned. Cleanup is inline (per-account, via q) rather
+// than the shared cleanup harness, which is single-client.
+const SUITE = "15-quota-enforcement";
+const base = new ApiClient();
+const q = base.env.quotaApiKey
+  ? new ApiClient({
+      ...base.env,
+      apiKey: base.env.quotaApiKey,
+      primaryAgentEmail: base.env.quotaAgentEmail ?? base.env.primaryAgentEmail,
+    })
+  : null;
+const skip = q ? false : "E2A_QUOTA_API_KEY not set (standard-class quota account not provisioned)";
+
+interface LimitErr {
+  error?: { code?: string; details?: { resource?: string; limit?: number; current?: number } };
+}
+
+test("quota: agent-count cap is enforced (402 limit_exceeded)", { skip }, async () => {
+  // Create slug agents until the account's max_agents cap trips. The cap is a
+  // 402 limit_exceeded carrying resource + current/limit in details.
+  const created: string[] = [];
+  let capped: { status: number; body: LimitErr | null; raw: string } | null = null;
+  try {
+    for (let i = 0; i < 20; i++) {
+      const slug = uniqueSlug("quota");
+      const r = await q!.post<{ email: string }>("/v1/agents", {
+        body: { email: `${slug}@${q!.env.sharedDomain}`, name: "quota-cap" },
+      });
+      if (r.status === 201) {
+        created.push(r.body!.email);
+        continue;
+      }
+      capped = r as { status: number; body: LimitErr | null; raw: string };
+      break;
+    }
+    assert.ok(capped, `expected the agent cap to trip within 20 creates (created ${created.length})`);
+    assert.equal(capped.status, 402, `agent cap → 402 limit_exceeded, got ${capped.status}: ${capped.raw.slice(0, 200)}`);
+    assert.equal(capped.body?.error?.code, "limit_exceeded");
+    assert.equal(capped.body?.error?.details?.resource, "agents");
+    assert.equal(typeof capped.body?.error?.details?.limit, "number", "limit_exceeded carries the numeric cap");
+    assert.ok(created.length >= 1, "at least one create succeeded before the cap");
+  } finally {
+    for (const email of created) {
+      await q!.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE`);
+    }
+  }
+});
+
+test("quota: domain-count cap is enforced (402 limit_exceeded)", { skip }, async () => {
+  // The quota account owns no domain initially (agents live on the shared
+  // domain), so max_domains=1 → the 2nd register trips the cap. RFC-2606
+  // .example.com names can never verify against real DNS — fine, we only test
+  // the register-count cap.
+  const created: string[] = [];
+  let capped: { status: number; body: LimitErr | null; raw: string } | null = null;
+  try {
+    for (let i = 0; i < 5; i++) {
+      const domain = `q-${uniqueSlug("d").replace(/[^a-z0-9-]/g, "")}.example.com`;
+      const r = await q!.post<{ domain: string }>("/v1/domains", { body: { domain } });
+      if (r.status === 201) {
+        created.push(r.body!.domain);
+        continue;
+      }
+      capped = r as { status: number; body: LimitErr | null; raw: string };
+      break;
+    }
+    assert.ok(capped, `expected the domain cap to trip (created ${created.length})`);
+    assert.equal(capped.status, 402, `domain cap → 402, got ${capped.status}: ${capped.raw.slice(0, 200)}`);
+    assert.equal(capped.body?.error?.code, "limit_exceeded");
+    assert.equal(capped.body?.error?.details?.resource, "domains");
+  } finally {
+    for (const domain of created) {
+      await q!.delete(`/v1/domains/${encodeURIComponent(domain)}?confirm=DELETE`);
+    }
+  }
+});
+
+after(async () => {
+  await writeReport(`./reports/${SUITE}.json`);
+});


### PR DESCRIPTION
Closes the gap both #409 reviewers flagged: the main conformance account is **internal**-class → unmetered, rate-limit-exempt, and huge-capped, so a green conformance run does **not** attest that limit/quota enforcement works.

## Change
- **`seed-conformance`** now also provisions a **separate `standard`-class, low-cap** quota account (`max_agents=5`, `max_domains=1`) when `E2A_QUOTA_AGENT_EMAIL` is set (opt-in). Refactored per-account provisioning into a shared `seedAccount` helper. Prints `E2A_QUOTA_AGENT_EMAIL` / `E2A_QUOTA_API_KEY`.
- **e2e-prod harness** loads the optional `E2A_QUOTA_*` creds (`env.ts`).
- **New suite `15-quota-enforcement`** builds a second client from those creds and asserts real enforcement: the **agent-count** and **domain-count** caps trip with `402 limit_exceeded` (resource + numeric cap in `details`). Self-cleaning (inline per-account deletes — the shared cleanup harness is single-client); **skips** when the quota account isn't provisioned.

## Verified against live staging
Both caps enforced — `402 "limits: agents cap reached (5/5)"` / domains — suite green; `tsc` clean.

## Follow-up (tracked separately)
Send-rate-limit `429` + `Retry-After` against the quota account (validates the send-limit header fix end-to-end) — expensive (~60 sends) and needs staging on the current candidate.