### PR TITLE
test(conformance): P1 suites — webhooks/templates/reviews/account/attachments

### DIFF
--- a/tests/e2e-prod/suites/16-webhooks.test.ts
+++ b/tests/e2e-prod/suites/16-webhooks.test.ts
@@ -1,0 +1,266 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { uniqueSlug } from "../harness/fixtures.ts";
+import { fail, info, writeReport } from "../harness/report.ts";
+
+// Black-box conformance for the webhooks API (8 ops) against LIVE staging.
+// Shapes/status codes verified against api/openapi.yaml (the drift-gated SSOT)
+// AND curl-probed on the live server before these assertions were written.
+//
+// The shared cleanup harness only tracks agents/domains, so every webhook this
+// suite creates is deleted inline in a `finally`. deleteWebhook takes NO
+// `?confirm=DELETE` (unlike agents/domains) — a plain DELETE returns 204
+// (probed 2026-07-10; openapi documents no confirm param for this op).
+const SUITE = "16-webhooks";
+const client = new ApiClient();
+
+const HOOK_URL = "https://example.com/e2e-webhook";
+
+interface WebhookView {
+  id: string;
+  url: string;
+  description: string;
+  events: string[];
+  filters: Record<string, unknown>;
+  enabled: boolean;
+  created_at: string;
+  last_delivered_at?: string;
+  auto_disabled_at?: string;
+}
+interface CreateWebhookResponse extends WebhookView {
+  signing_secret: string;
+}
+interface PageWebhookView {
+  items: WebhookView[];
+  next_cursor: string | null;
+}
+interface WebhookDeliveryView {
+  id: string;
+  event_type: string;
+  status: string;
+  attempts: number;
+  next_retry_at: string;
+  created_at: string;
+}
+interface PageWebhookDeliveryView {
+  items: WebhookDeliveryView[];
+  next_cursor: string | null;
+}
+interface RotateSecretResponse {
+  signing_secret: string;
+  previous_secret_expires_at: string;
+}
+interface ErrEnvelope {
+  error?: { code?: string; message?: string; request_id?: string };
+}
+
+async function createHook(events: string[] = ["email.received", "email.sent"]): Promise<CreateWebhookResponse> {
+  const r = await client.post<CreateWebhookResponse>("/v1/webhooks", {
+    body: { url: HOOK_URL, events, description: `e2e ${uniqueSlug("wh")}` },
+  });
+  assert.equal(r.status, 201, `create expected 201, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  assert.ok(r.body, "create returns a body");
+  return r.body!;
+}
+
+async function deleteHook(id: string): Promise<void> {
+  // No ?confirm=DELETE for webhooks (unlike agents/domains). Idempotent-ish:
+  // a second delete 404s, which is fine for best-effort cleanup.
+  await client.delete(`/v1/webhooks/${encodeURIComponent(id)}`);
+}
+
+// createWebhook + getWebhook + listWebhooks + updateWebhook + rotateWebhookSecret
+// + listWebhookDeliveries + deleteWebhook — the full CRUD round-trip.
+test("webhooks: full CRUD round-trip (create/list/get/patch/rotate/deliveries/delete)", async () => {
+  const created = await createHook();
+  const id = created.id;
+  try {
+    // createWebhook response shape (CreateWebhookResponse — signing_secret only here + on rotate)
+    assert.ok(id.startsWith("wh_"), `id has wh_ prefix: ${id}`);
+    assert.equal(created.url, HOOK_URL);
+    assert.deepEqual(created.events, ["email.received", "email.sent"]);
+    assert.equal(created.enabled, true, "new webhook defaults to enabled");
+    assert.equal(typeof created.filters, "object", "filters present (defaults to {})");
+    assert.ok(typeof created.created_at === "string" && created.created_at.length > 0);
+    assert.ok(
+      typeof created.signing_secret === "string" && created.signing_secret.startsWith("whsec_"),
+      `create returns signing_secret with whsec_ prefix: ${created.signing_secret}`,
+    );
+
+    // listWebhooks — envelope {items,next_cursor}; the created hook must be present.
+    const list = await client.get<PageWebhookView>("/v1/webhooks");
+    assert.equal(list.status, 200);
+    assert.ok(Array.isArray(list.body?.items), "list.items is an array");
+    assert.ok(
+      list.body!.next_cursor === null || typeof list.body!.next_cursor === "string",
+      "next_cursor is string|null",
+    );
+    const inList = list.body!.items.find((w) => w.id === id);
+    assert.ok(inList, `created webhook ${id} is present in list`);
+    // list items are WebhookView — no signing_secret leaked in the list.
+    assert.ok(!("signing_secret" in (inList as object)), "list item must NOT carry signing_secret");
+
+    // getWebhook — WebhookView (no signing_secret).
+    const got = await client.get<WebhookView & { signing_secret?: string }>(`/v1/webhooks/${id}`);
+    assert.equal(got.status, 200);
+    assert.equal(got.body?.id, id);
+    assert.equal(got.body?.url, HOOK_URL);
+    assert.equal(got.body?.enabled, true);
+    assert.equal(got.body?.signing_secret, undefined, "getWebhook must NOT return signing_secret");
+
+    // updateWebhook (PATCH) — partial; events is full-replace when present.
+    const patch = await client.patch<WebhookView>(`/v1/webhooks/${id}`, {
+      body: { enabled: false, events: ["email.failed"], description: "e2e patched" },
+    });
+    assert.equal(patch.status, 200, `patch expected 200, got ${patch.status}: ${patch.raw.slice(0, 200)}`);
+    assert.equal(patch.body?.enabled, false, "PATCH enabled=false took effect");
+    assert.deepEqual(patch.body?.events, ["email.failed"], "PATCH events is a full replace");
+    assert.equal(patch.body?.description, "e2e patched");
+
+    // rotateWebhookSecret — new signing_secret + a grace-window expiry (~24h).
+    const rot = await client.post<RotateSecretResponse>(`/v1/webhooks/${id}/rotate-secret`);
+    assert.equal(rot.status, 200, `rotate expected 200, got ${rot.status}: ${rot.raw.slice(0, 200)}`);
+    assert.ok(
+      rot.body?.signing_secret?.startsWith("whsec_"),
+      `rotate returns a whsec_ secret: ${rot.body?.signing_secret}`,
+    );
+    assert.notEqual(rot.body!.signing_secret, created.signing_secret, "rotate yields a DIFFERENT secret");
+    assert.ok(
+      typeof rot.body?.previous_secret_expires_at === "string",
+      "rotate returns previous_secret_expires_at (grace window)",
+    );
+
+    // listWebhookDeliveries — PageWebhookDeliveryView {items,next_cursor}.
+    // Likely empty (no real events fired at this hook); assert the shape either way.
+    const del = await client.get<PageWebhookDeliveryView>(`/v1/webhooks/${id}/deliveries`);
+    assert.equal(del.status, 200);
+    assert.ok(Array.isArray(del.body?.items), "deliveries.items is an array");
+    assert.ok(
+      del.body!.next_cursor === null || typeof del.body!.next_cursor === "string",
+      "deliveries.next_cursor is string|null",
+    );
+    for (const d of del.body!.items) {
+      assert.ok(d.id && d.event_type && d.status, "delivery view has id/event_type/status");
+      assert.equal(typeof d.attempts, "number", "delivery.attempts is a number");
+    }
+
+    // deleteWebhook — 204, then the hook 404s.
+    const rm = await client.delete(`/v1/webhooks/${id}`);
+    assert.equal(rm.status, 204, `delete expected 204, got ${rm.status}: ${rm.raw.slice(0, 200)}`);
+    const gone = await client.get<ErrEnvelope>(`/v1/webhooks/${id}`);
+    assert.equal(gone.status, 404, `deleted webhook should 404, got ${gone.status}`);
+    assert.equal(gone.body?.error?.code, "not_found");
+  } finally {
+    await deleteHook(id);
+  }
+});
+
+// testWebhook — on an ENABLED hook it schedules a synthetic delivery and returns
+// 200 { delivery_id }. It does NOT block on the real HTTP POST to the target, so
+// an unreachable/erroring target URL does NOT surface as a 5xx here.
+test("webhooks: testWebhook on enabled hook returns 200 with delivery_id (async, no 5xx)", async () => {
+  const hook = await createHook();
+  try {
+    const r = await client.post<{ delivery_id: string }>(`/v1/webhooks/${hook.id}/test`, {
+      body: { event: "email.received" },
+    });
+    assert.ok(
+      r.status < 500,
+      `testWebhook must not 5xx even with an unreachable target, got ${r.status}: ${r.raw.slice(0, 200)}`,
+    );
+    assert.equal(r.status, 200, `testWebhook (enabled) expected 200, got ${r.status}: ${r.raw.slice(0, 200)}`);
+    assert.ok(
+      typeof r.body?.delivery_id === "string" && r.body.delivery_id.length > 0,
+      `testWebhook returns a delivery_id: ${r.body?.delivery_id}`,
+    );
+
+    // TestWebhookRequest has no required fields — an empty body is accepted (200).
+    const empty = await client.post<{ delivery_id: string }>(`/v1/webhooks/${hook.id}/test`, { body: {} });
+    assert.equal(empty.status, 200, `testWebhook with empty body expected 200, got ${empty.status}`);
+    assert.ok(typeof empty.body?.delivery_id === "string", "empty-body test still returns a delivery_id");
+  } finally {
+    await deleteHook(hook.id);
+  }
+});
+
+// testWebhook on a DISABLED hook. openapi documents only 200 + a `default` error
+// for this op; the server pins a specific, sensible 409 webhook_disabled. Not a
+// violation (default covers it) but worth asserting so a silent change (e.g. a
+// 5xx, or accepting the test on a disabled hook) is caught.
+test("webhooks: testWebhook on disabled hook returns 409 webhook_disabled", async () => {
+  const hook = await createHook();
+  try {
+    const patch = await client.patch<WebhookView>(`/v1/webhooks/${hook.id}`, { body: { enabled: false } });
+    assert.equal(patch.status, 200);
+    assert.equal(patch.body?.enabled, false);
+
+    const r = await client.post<ErrEnvelope>(`/v1/webhooks/${hook.id}/test`, {
+      body: { event: "email.received" },
+    });
+    assert.ok(r.status >= 400 && r.status < 500, `disabled-hook test should be 4xx, got ${r.status}`);
+    if (r.status !== 409) {
+      info(SUITE, "test-disabled-code", `probed 409 webhook_disabled; server now returns ${r.status}: ${r.raw.slice(0, 160)}`);
+    } else {
+      assert.equal(r.body?.error?.code, "webhook_disabled", "409 carries webhook_disabled code");
+    }
+  } finally {
+    await deleteHook(hook.id);
+  }
+});
+
+// ---- Negatives ----
+
+test("webhooks: unauthenticated list returns 401", async () => {
+  const r = await client.get<ErrEnvelope>("/v1/webhooks", { apiKey: null });
+  assert.equal(r.status, 401, `unauth list expected 401, got ${r.status}`);
+  assert.equal(r.body?.error?.code, "unauthorized");
+});
+
+test("webhooks: get nonexistent returns 404 not_found", async () => {
+  const r = await client.get<ErrEnvelope>(`/v1/webhooks/wh_${uniqueSlug("missing").replace(/-/g, "")}`);
+  assert.equal(r.status, 404, `get nonexistent expected 404, got ${r.status}`);
+  assert.equal(r.body?.error?.code, "not_found");
+});
+
+test("webhooks: delete nonexistent returns 404 not_found", async () => {
+  const r = await client.delete<ErrEnvelope>(`/v1/webhooks/wh_${uniqueSlug("missing").replace(/-/g, "")}`);
+  assert.equal(r.status, 404, `delete nonexistent expected 404, got ${r.status}`);
+  assert.equal(r.body?.error?.code, "not_found");
+});
+
+test("webhooks: create missing required fields returns 422", async () => {
+  const noUrl = await client.post<ErrEnvelope>("/v1/webhooks", { body: { events: ["email.sent"] } });
+  assert.equal(noUrl.status, 422, `create missing url expected 422, got ${noUrl.status}: ${noUrl.raw.slice(0, 160)}`);
+  assert.equal(noUrl.body?.error?.code, "unprocessable_entity");
+
+  const noEvents = await client.post<ErrEnvelope>("/v1/webhooks", { body: { url: HOOK_URL } });
+  assert.equal(noEvents.status, 422, `create missing events expected 422, got ${noEvents.status}`);
+  assert.equal(noEvents.body?.error?.code, "unprocessable_entity");
+});
+
+test("webhooks: create with unknown event enum returns 422", async () => {
+  const r = await client.post<ErrEnvelope>("/v1/webhooks", {
+    body: { url: HOOK_URL, events: ["not.a.real.event"] },
+  });
+  assert.equal(r.status, 422, `bad enum expected 422, got ${r.status}: ${r.raw.slice(0, 160)}`);
+  assert.equal(r.body?.error?.code, "unprocessable_entity");
+});
+
+// URL must be HTTPS — enforced with a distinct 400 invalid_webhook_url (SSRF/plaintext
+// guard). openapi is silent on the code; pinned here from the live probe.
+test("webhooks: create with non-HTTPS url returns 400 invalid_webhook_url", async () => {
+  const r = await client.post<ErrEnvelope>("/v1/webhooks", {
+    body: { url: "http://example.com/e2e-webhook", events: ["email.sent"] },
+  });
+  assert.ok(r.status >= 400 && r.status < 500, `non-https url expected 4xx, got ${r.status}`);
+  if (r.status === 400) {
+    assert.equal(r.body?.error?.code, "invalid_webhook_url", "400 carries invalid_webhook_url code");
+  } else {
+    info(SUITE, "non-https-code", `probed 400 invalid_webhook_url; server now returns ${r.status}: ${r.raw.slice(0, 160)}`);
+  }
+});
+
+after(async () => {
+  await writeReport(`./reports/${SUITE}.json`);
+});

--- a/tests/e2e-prod/suites/16-webhooks.test.ts
+++ b/tests/e2e-prod/suites/16-webhooks.test.ts
@@ -2,7 +2,7 @@ import { test, after } from "node:test";
 import assert from "node:assert/strict";
 import { ApiClient } from "../harness/client.ts";
 import { uniqueSlug } from "../harness/fixtures.ts";
-import { fail, info, writeReport } from "../harness/report.ts";
+import { info, writeReport } from "../harness/report.ts";
 
 // Black-box conformance for the webhooks API (8 ops) against LIVE staging.
 // Shapes/status codes verified against api/openapi.yaml (the drift-gated SSOT)

--- a/tests/e2e-prod/suites/17-templates.test.ts
+++ b/tests/e2e-prod/suites/17-templates.test.ts
@@ -1,0 +1,305 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { uniqueSlug } from "../harness/fixtures.ts";
+import { writeReport } from "../harness/report.ts";
+
+// Black-box conformance for the templates API (beta/unstable per api/openapi.yaml,
+// tag: templates). Covers all 8 ops: listStarterTemplates, getStarterTemplate,
+// listTemplates, createTemplate, validateTemplate, deleteTemplate, getTemplate,
+// updateTemplate (PATCH). Shapes/status pinned against openapi.yaml and verified
+// by curl-probing the live staging server. Every created template is deleted
+// inline in a finally. Cleanup is self-contained (not the shared cleanup harness,
+// which only tracks agents/domains). The conformance account is internal-class
+// (rate-limit-exempt, high-cap) so churn is free.
+const SUITE = "17-templates";
+const client = new ApiClient();
+
+interface StarterTemplateVariable {
+  name: string;
+  required: boolean;
+  raw: boolean;
+  description: string;
+  example: string;
+}
+interface StarterTemplateView {
+  alias: string;
+  name: string;
+  description: string;
+  version: string;
+  subject: string;
+  variables: StarterTemplateVariable[];
+}
+interface StarterTemplateDetailView extends StarterTemplateView {
+  body: string;
+  html_body: string;
+}
+interface Page<T> {
+  items: T[];
+  next_cursor: string | null;
+}
+interface TemplateSummaryView {
+  id: string;
+  name: string;
+  subject: string;
+  alias?: string;
+  created_at: string;
+  updated_at: string;
+}
+interface TemplateView extends TemplateSummaryView {
+  body: string;
+  html_body?: string;
+  from_starter_alias?: string;
+  from_starter_version?: string;
+}
+interface ValidateTemplateResponse {
+  valid: boolean;
+  errors: Array<{ part: string; message: string }>;
+  rendered?: { subject: string; body: string; html_body?: string };
+  suggested_data?: Record<string, unknown>;
+}
+interface ErrEnv {
+  error?: { code?: string; message?: string; request_id?: string };
+}
+
+function delTemplate(id: string) {
+  // deleteTemplate takes no ?confirm — openapi documents only the {id} path
+  // param, and the live server returns 204 for a plain DELETE (verified).
+  return client.delete(`/v1/templates/${encodeURIComponent(id)}`);
+}
+
+// ---------- starter templates ----------
+
+test("listStarterTemplates: 200 with {items, next_cursor} envelope", async () => {
+  const r = await client.get<Page<StarterTemplateView>>("/v1/starter-templates");
+  assert.equal(r.status, 200, `expected 200, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  assert.ok(Array.isArray(r.body?.items), "items is an array");
+  assert.ok("next_cursor" in (r.body as object), "next_cursor key present (required)");
+  assert.ok(
+    r.body!.next_cursor === null || typeof r.body!.next_cursor === "string",
+    "next_cursor is string|null",
+  );
+  assert.ok(r.body!.items.length >= 1, "deployment ships at least one starter template");
+  for (const s of r.body!.items) {
+    assert.ok(s.alias, "starter has alias");
+    assert.ok(s.name, "starter has name");
+    assert.equal(typeof s.description, "string", "starter has description");
+    assert.ok(s.version, "starter has version");
+    assert.equal(typeof s.subject, "string", "starter has subject source");
+    assert.ok(Array.isArray(s.variables), "starter has variables[]");
+  }
+});
+
+test("getStarterTemplate: 200 detail view (body + html_body) for an alias from the list", async () => {
+  const list = await client.get<Page<StarterTemplateView>>("/v1/starter-templates");
+  assert.equal(list.status, 200);
+  const alias = list.body!.items[0]?.alias;
+  assert.ok(alias, "picked a starter alias from the list");
+
+  const r = await client.get<StarterTemplateDetailView>(
+    `/v1/starter-templates/${encodeURIComponent(alias)}`,
+  );
+  assert.equal(r.status, 200, `expected 200, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  assert.equal(r.body?.alias, alias, "detail alias matches request");
+  // The detail view adds the full body sources over the list (summary) view.
+  assert.equal(typeof r.body?.body, "string", "detail carries plain-text body source");
+  assert.equal(typeof r.body?.html_body, "string", "detail carries html_body source");
+  assert.equal(typeof r.body?.subject, "string", "detail carries subject source");
+  assert.ok(Array.isArray(r.body?.variables), "detail carries variables[]");
+  for (const v of r.body!.variables) {
+    assert.ok(v.name, "variable has name");
+    assert.equal(typeof v.required, "boolean", "variable.required is boolean");
+    assert.equal(typeof v.raw, "boolean", "variable.raw is boolean");
+  }
+});
+
+test("getStarterTemplate: nonexistent alias returns 404", async () => {
+  const r = await client.get<ErrEnv>(`/v1/starter-templates/nope-${uniqueSlug("s")}`);
+  assert.equal(r.status, 404, `nonexistent starter → 404, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  assert.equal(r.body?.error?.code, "starter_template_not_found");
+});
+
+// ---------- user templates: lifecycle ----------
+
+test("createTemplate + getTemplate + listTemplates + deleteTemplate lifecycle", async () => {
+  const alias = uniqueSlug("tmpl");
+  let id: string | null = null;
+  try {
+    const create = await client.post<TemplateView>("/v1/templates", {
+      body: {
+        name: `e2e ${alias}`,
+        subject: "Hi {{name}}",
+        body: "Hello {{name}}, welcome to {{company}}.",
+        alias,
+      },
+    });
+    assert.equal(create.status, 201, `create → 201, got ${create.status}: ${create.raw.slice(0, 200)}`);
+    id = create.body!.id;
+    assert.ok(id?.startsWith("tmpl_"), `id has tmpl_ prefix: ${id}`);
+    assert.equal(create.body?.name, `e2e ${alias}`);
+    assert.equal(create.body?.subject, "Hi {{name}}");
+    assert.equal(create.body?.body, "Hello {{name}}, welcome to {{company}}.");
+    assert.equal(create.body?.alias, alias, "alias echoed back");
+    assert.ok(create.body?.created_at, "created_at present");
+    assert.ok(create.body?.updated_at, "updated_at present");
+
+    const got = await client.get<TemplateView>(`/v1/templates/${id}`);
+    assert.equal(got.status, 200, `getTemplate → 200, got ${got.status}`);
+    assert.equal(got.body?.id, id);
+    assert.equal(got.body?.body, "Hello {{name}}, welcome to {{company}}.", "get returns full body source");
+
+    const list = await client.get<Page<TemplateSummaryView>>("/v1/templates");
+    assert.equal(list.status, 200);
+    assert.ok("next_cursor" in (list.body as object), "next_cursor present in page");
+    assert.ok(
+      list.body!.items.some((t) => t.id === id),
+      "created template appears in listTemplates",
+    );
+
+    const del = await delTemplate(id);
+    assert.equal(del.status, 204, `deleteTemplate → 204, got ${del.status}: ${del.raw.slice(0, 200)}`);
+    id = null;
+
+    const after = await client.get<ErrEnv>(`/v1/templates/${create.body!.id}`);
+    assert.equal(after.status, 404, `deleted template → 404, got ${after.status}`);
+    assert.equal(after.body?.error?.code, "not_found");
+  } finally {
+    if (id) await delTemplate(id);
+  }
+});
+
+test("updateTemplate (PATCH): partial update mutates name and bumps updated_at", async () => {
+  const alias = uniqueSlug("tmpl");
+  let id: string | null = null;
+  try {
+    const create = await client.post<TemplateView>("/v1/templates", {
+      body: { name: "before", subject: "S {{x}}", body: "B {{x}}", alias },
+    });
+    assert.equal(create.status, 201, `create → 201, got ${create.status}: ${create.raw.slice(0, 200)}`);
+    id = create.body!.id;
+
+    const patch = await client.patch<TemplateView>(`/v1/templates/${id}`, {
+      body: { name: "after", subject: "S2 {{x}}" },
+    });
+    assert.equal(patch.status, 200, `PATCH → 200, got ${patch.status}: ${patch.raw.slice(0, 200)}`);
+    assert.equal(patch.body?.name, "after", "name updated");
+    assert.equal(patch.body?.subject, "S2 {{x}}", "subject updated");
+    assert.equal(patch.body?.body, "B {{x}}", "unchanged part preserved");
+    assert.equal(patch.body?.alias, alias, "alias preserved when not in patch");
+
+    const got = await client.get<TemplateView>(`/v1/templates/${id}`);
+    assert.equal(got.body?.name, "after", "PATCH persisted");
+  } finally {
+    if (id) await delTemplate(id);
+  }
+});
+
+test("createTemplate: from_starter copies a starter verbatim (201, carries provenance fields)", async () => {
+  const list = await client.get<Page<StarterTemplateView>>("/v1/starter-templates");
+  const starterAlias = list.body!.items[0]?.alias;
+  assert.ok(starterAlias, "have a starter alias to copy");
+  const alias = uniqueSlug("fromst");
+  let id: string | null = null;
+  try {
+    const create = await client.post<TemplateView>("/v1/templates", {
+      body: { from_starter: starterAlias, alias },
+    });
+    assert.equal(create.status, 201, `from_starter create → 201, got ${create.status}: ${create.raw.slice(0, 200)}`);
+    id = create.body!.id;
+    assert.ok(id?.startsWith("tmpl_"));
+    assert.equal(create.body?.from_starter_alias, starterAlias, "from_starter_alias records provenance");
+    assert.ok(create.body?.from_starter_version, "from_starter_version records catalog version at copy time");
+    assert.ok(create.body?.body, "copied body source is populated");
+  } finally {
+    if (id) await delTemplate(id);
+  }
+});
+
+// ---------- validateTemplate ----------
+
+test("validateTemplate: valid source → 200 valid:true with rendered preview + suggested_data", async () => {
+  const r = await client.post<ValidateTemplateResponse>("/v1/templates/validate", {
+    body: {
+      subject: "Hi {{name}}",
+      body: "Welcome {{name}} to {{company}}",
+      test_data: { name: "Ada", company: "Acme" },
+    },
+  });
+  assert.equal(r.status, 200, `validate → 200, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  assert.equal(r.body?.valid, true, "valid source reports valid:true");
+  assert.deepEqual(r.body?.errors, [], "no errors for valid source");
+  assert.equal(r.body?.rendered?.subject, "Hi Ada", "subject rendered against test_data");
+  assert.equal(r.body?.rendered?.body, "Welcome Ada to Acme", "body rendered against test_data");
+  assert.ok(r.body?.suggested_data, "suggested_data present (placeholder per referenced variable)");
+  assert.ok(
+    "name" in (r.body!.suggested_data as object) && "company" in (r.body!.suggested_data as object),
+    "suggested_data covers every referenced variable",
+  );
+});
+
+test("validateTemplate: invalid source → HTTP 200 with valid:false + per-part errors", async () => {
+  // Pinned behavior: a parse error is a 200 payload (valid:false + errors[]),
+  // NOT a 4xx. openapi documents only 200/ValidateTemplateResponse for this op
+  // and ValidateTemplateResponse.valid is a boolean, so the parse verdict rides
+  // in the body. (Verified against live server.)
+  const r = await client.post<ValidateTemplateResponse>("/v1/templates/validate", {
+    body: { subject: "Hi {{name", body: "ok" },
+  });
+  assert.equal(r.status, 200, `invalid template still returns 200, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  assert.equal(r.body?.valid, false, "unparseable source reports valid:false");
+  assert.ok(Array.isArray(r.body?.errors) && r.body!.errors.length >= 1, "errors[] is populated");
+  const subjErr = r.body!.errors.find((e) => e.part === "subject");
+  assert.ok(subjErr, "error is attributed to the offending part (subject)");
+  assert.ok(subjErr!.message, "error carries a message");
+});
+
+// ---------- negatives ----------
+
+test("templates: unauthenticated list returns 401", async () => {
+  const r = await client.get("/v1/templates", { apiKey: null });
+  assert.equal(r.status, 401, `unauth → 401, got ${r.status}: ${r.raw.slice(0, 200)}`);
+});
+
+test("getTemplate: nonexistent id returns 404", async () => {
+  const r = await client.get<ErrEnv>(`/v1/templates/tmpl_${"0".repeat(32)}`);
+  assert.equal(r.status, 404, `nonexistent get → 404, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  assert.equal(r.body?.error?.code, "not_found");
+});
+
+test("deleteTemplate: nonexistent id returns 404", async () => {
+  const r = await client.delete<ErrEnv>(`/v1/templates/tmpl_${"0".repeat(32)}`);
+  assert.equal(r.status, 404, `nonexistent delete → 404, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  assert.equal(r.body?.error?.code, "not_found");
+});
+
+test("createTemplate: missing required fields returns 4xx", async () => {
+  // CreateTemplateRequest requires name + subject + body (unless from_starter).
+  const r = await client.post<ErrEnv>("/v1/templates", { body: {} });
+  assert.ok(r.status >= 400 && r.status < 500, `bad create → 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  assert.equal(r.status, 400, `documented invalid_request → 400, got ${r.status}`);
+  assert.equal(r.body?.error?.code, "invalid_request");
+});
+
+test("createTemplate: duplicate alias returns 409 alias_taken", async () => {
+  const alias = uniqueSlug("dup");
+  let id: string | null = null;
+  try {
+    const first = await client.post<TemplateView>("/v1/templates", {
+      body: { name: "first", subject: "S {{x}}", body: "B {{x}}", alias },
+    });
+    assert.equal(first.status, 201, `first create → 201, got ${first.status}: ${first.raw.slice(0, 200)}`);
+    id = first.body!.id;
+
+    const second = await client.post<ErrEnv>("/v1/templates", {
+      body: { name: "second", subject: "S {{x}}", body: "B {{x}}", alias },
+    });
+    assert.equal(second.status, 409, `dup alias → 409, got ${second.status}: ${second.raw.slice(0, 200)}`);
+    assert.equal(second.body?.error?.code, "alias_taken");
+  } finally {
+    if (id) await delTemplate(id);
+  }
+});
+
+after(async () => {
+  await writeReport(`./reports/${SUITE}.json`);
+});

--- a/tests/e2e-prod/suites/18-reviews.test.ts
+++ b/tests/e2e-prod/suites/18-reviews.test.ts
@@ -1,0 +1,266 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { uniqueSlug, uniqueSubject, holdAllOutbound } from "../harness/fixtures.ts";
+import { fail, info, writeReport } from "../harness/report.ts";
+
+// /v1/reviews is the ACCOUNT-level human-review queue: every message held in
+// pending_review across the account's inboxes. Account-scoped credentials only
+// (an agent cannot see/resolve its own holds). This suite drives all four ops
+// against LIVE staging (api/openapi.yaml is the drift-gated SSOT):
+//   listReviews  GET  /v1/reviews          -> PageReviewView {items,next_cursor}
+//   getReview    GET  /v1/reviews/{id}      -> MessageView (id == msg_ id)
+//   approveReview POST /v1/reviews/{id}/approve -> SendResultView
+//   rejectReview POST /v1/reviews/{id}/reject   -> RejectResultView
+//
+// To have a review to act on we must CREATE one: put a throwaway agent into
+// hold-all-outbound (an outbound review gate) and send — the send is held as
+// pending_review and surfaces in the queue. Every test provisions its own
+// agent and deletes it in a finally (agent delete cascades to its held
+// messages, clearing them from the account queue — verified during authoring).
+const SUITE = "18-reviews";
+const client = new ApiClient();
+
+const SINK = "blackhole+e2e@e2a.dev";
+
+interface Review {
+  id: string;
+  agent: string;
+  direction: string;
+  from: string;
+  to: string[];
+  subject: string;
+  conversation_id?: string;
+  review_status: string;
+  created_at: string;
+}
+interface Page {
+  items: Review[];
+  next_cursor: string | null;
+}
+
+async function del(email: string): Promise<void> {
+  await client.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE`);
+}
+
+// createHeldReview: throwaway agent -> hold-all-outbound -> send. Returns the
+// agent email + the held message id (== the review id). Caller MUST del(email)
+// in a finally.
+async function createHeldReview(label: string): Promise<{ email: string; id: string; subject: string }> {
+  const slug = uniqueSlug(label);
+  const c = await client.post<{ email: string }>("/v1/agents", {
+    body: { email: `${slug}@${client.env.sharedDomain}`, name: `reviews ${label}` },
+  });
+  if (c.status !== 201) throw new Error(`create agent failed: ${c.status} ${c.raw.slice(0, 200)}`);
+  const email = c.body!.email;
+  const u = await holdAllOutbound(client, email);
+  if (u.status !== 200) {
+    await del(email);
+    throw new Error(`hold-all-outbound failed: ${u.status} ${u.raw.slice(0, 200)}`);
+  }
+  const subject = uniqueSubject(`review ${label}`);
+  const s = await client.post<{ message_id: string; status: string }>(
+    `/v1/agents/${encodeURIComponent(email)}/messages`,
+    { body: { to: [SINK], subject, body: "held for review — must never actually go out" } },
+  );
+  if (s.status !== 202 || !s.body?.message_id) {
+    await del(email);
+    throw new Error(`held send expected 202 pending_review, got ${s.status}: ${s.raw.slice(0, 200)}`);
+  }
+  assert.equal(s.body.status, "pending_review", "held send status is pending_review");
+  return { email, id: s.body.message_id, subject };
+}
+
+test("reviews: listReviews returns PageReviewView envelope with the new held review present", async () => {
+  const { email, id, subject } = await createHeldReview("list");
+  try {
+    const r = await client.get<Page>("/v1/reviews");
+    assert.equal(r.status, 200, `listReviews expected 200, got ${r.status}: ${r.raw.slice(0, 200)}`);
+    assert.ok(Array.isArray(r.body?.items), "items is an array");
+    // next_cursor is REQUIRED and nullable in PageReviewView (string | null).
+    assert.ok(
+      r.body!.next_cursor === null || typeof r.body!.next_cursor === "string",
+      `next_cursor must be present as string|null, got ${JSON.stringify(r.body!.next_cursor)}`,
+    );
+    const mine = r.body!.items.find((v) => v.id === id);
+    assert.ok(mine, `the just-created held review ${id} should appear in the account queue`);
+    // ReviewView required fields: id, agent, direction, from, to, subject, review_status, created_at.
+    assert.equal(mine!.agent, email, "review.agent is the sending inbox");
+    assert.equal(mine!.direction, "outbound", "held outbound draft");
+    assert.equal(mine!.from, email, "review.from is the sending agent");
+    assert.ok(Array.isArray(mine!.to) && mine!.to.includes(SINK), "review.to carries the recipient");
+    assert.equal(mine!.subject, subject, "review.subject matches the sent subject");
+    assert.equal(mine!.review_status, "pending_review", "queued item is pending_review");
+    assert.ok(typeof mine!.created_at === "string" && mine!.created_at.length > 0, "created_at present");
+  } finally {
+    await del(email);
+  }
+});
+
+test("reviews: listReviews surfaces every held item; ?limit pagination is undocumented + not honored (FLAG)", async () => {
+  // Queue two held reviews under one throwaway agent, then confirm BOTH appear
+  // in the queue. Separately probe ?limit — the listReviews operation in
+  // openapi.yaml documents NO query parameters, yet PageReviewView carries a
+  // required next_cursor (a paginated envelope with no documented inputs). We
+  // record what the server actually does with ?limit rather than assert on
+  // undocumented behavior.
+  const slug = uniqueSlug("page");
+  const c = await client.post<{ email: string }>("/v1/agents", {
+    body: { email: `${slug}@${client.env.sharedDomain}`, name: "reviews page" },
+  });
+  assert.equal(c.status, 201, `create agent expected 201, got ${c.status}: ${c.raw.slice(0, 200)}`);
+  const email = c.body!.email;
+  try {
+    const u = await holdAllOutbound(client, email);
+    assert.equal(u.status, 200);
+    const mine: string[] = [];
+    for (let i = 0; i < 2; i++) {
+      const s = await client.post<{ message_id: string }>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
+        body: { to: [SINK], subject: uniqueSubject(`page ${i}`), body: "x" },
+      });
+      assert.equal(s.status, 202, `held send ${i} expected 202, got ${s.status}`);
+      mine.push(s.body!.message_id);
+    }
+    const all = await client.get<Page>("/v1/reviews");
+    assert.equal(all.status, 200);
+    const ids = new Set(all.body!.items.map((v) => v.id));
+    for (const id of mine) {
+      assert.ok(ids.has(id), `held review ${id} must appear in the account queue`);
+    }
+
+    // Probe ?limit: the spec documents no params, so this is a conformance
+    // observation, not an assertion. Confirmed during authoring that ?limit is
+    // ignored (limit=1 returned the full unclamped page).
+    const limited = await client.get<Page>("/v1/reviews", { query: { limit: 1 } });
+    assert.equal(limited.status, 200, "?limit must not error even though it is undocumented");
+    if (limited.body!.items.length > 1) {
+      info(
+        SUITE,
+        "list-limit-undocumented",
+        `listReviews returns a paginated PageReviewView (required next_cursor) but documents NO limit/cursor query params, and the server IGNORES ?limit (limit=1 returned ${limited.body!.items.length} items). Either document + honor pagination or drop next_cursor from the envelope.`,
+      );
+    }
+  } finally {
+    await del(email);
+  }
+});
+
+test("reviews: getReview returns full MessageView; nonexistent id → 404", async () => {
+  const { email, id, subject } = await createHeldReview("get");
+  try {
+    const r = await client.get<{
+      message_id: string;
+      direction: string;
+      review_status: string;
+      subject: string;
+      body?: { text?: string };
+      to?: string[];
+    }>(`/v1/reviews/${id}`);
+    assert.equal(r.status, 200, `getReview expected 200, got ${r.status}: ${r.raw.slice(0, 200)}`);
+    // getReview returns a MessageView (id-addressed by the msg_ id). The list
+    // exposes the same id as `id`; the detail view keys it `message_id`.
+    assert.equal(r.body?.message_id, id, "MessageView.message_id equals the review id");
+    assert.equal(r.body?.direction, "outbound");
+    assert.equal(r.body?.review_status, "pending_review");
+    assert.equal(r.body?.subject, subject);
+    assert.ok(Array.isArray(r.body?.to) && r.body!.to!.includes(SINK), "recipients present");
+    assert.ok(r.body?.body?.text, "full detail carries the message body");
+
+    const miss = await client.get(`/v1/reviews/msg_nonexistent_${Date.now()}`);
+    assert.equal(miss.status, 404, `getReview nonexistent expected 404, got ${miss.status}: ${miss.raw.slice(0, 200)}`);
+  } finally {
+    await del(email);
+  }
+});
+
+test("reviews: rejectReview discards the hold; re-reject → 409; nonexistent → 404", async () => {
+  const { email, id } = await createHeldReview("reject");
+  try {
+    const reason = "e2e reviews-suite rejection";
+    const r = await client.post<{ status: string; message_id: string; rejection_reason?: string }>(
+      `/v1/reviews/${id}/reject`,
+      { body: { reason } },
+    );
+    assert.equal(r.status, 200, `rejectReview expected 200, got ${r.status}: ${r.raw.slice(0, 200)}`);
+    // RejectResultView requires {status, message_id}.
+    assert.equal(r.body?.message_id, id, "reject result echoes the message id");
+    assert.equal(r.body?.status, "review_rejected", "reject transitions to review_rejected");
+    if (r.body?.rejection_reason !== undefined) {
+      assert.equal(r.body.rejection_reason, reason, "rejection_reason echoes the supplied reason");
+    }
+
+    // Re-resolving a no-longer-pending hold must 409 (state guard).
+    const again = await client.post(`/v1/reviews/${id}/reject`, { body: { reason: "again" } });
+    assert.equal(again.status, 409, `re-reject of resolved hold expected 409, got ${again.status}: ${again.raw.slice(0, 200)}`);
+
+    const miss = await client.post(`/v1/reviews/msg_nonexistent_${Date.now()}/reject`, { body: { reason: "x" } });
+    assert.equal(miss.status, 404, `reject nonexistent expected 404, got ${miss.status}: ${miss.raw.slice(0, 200)}`);
+  } finally {
+    await del(email);
+  }
+});
+
+test("reviews: approveReview resolves the outbound hold (200 SendResultView; staging SES send-fail tolerated)", async () => {
+  const { email, id } = await createHeldReview("approve");
+  let resolved = false;
+  try {
+    const r = await client.post<{ message_id?: string; status?: string; method?: string }>(
+      `/v1/reviews/${id}/approve`,
+      { body: {} },
+    );
+    if (r.status === 200) {
+      // Happy path: SendResultView. approveReview sends the outbound draft via SES.
+      assert.equal(r.body?.message_id, id, "SendResultView echoes the approved message id");
+      resolved = true;
+      // Re-approving a sent hold must 409.
+      const again = await client.post(`/v1/reviews/${id}/approve`, { body: {} });
+      assert.equal(again.status, 409, `re-approve of sent hold expected 409, got ${again.status}: ${again.raw.slice(0, 200)}`);
+    } else if (r.status === 500 && r.body && (r.body as { error?: { message?: string } }).error?.message === "send failed") {
+      // KNOWN STAGING LIMITATION, not a reviews-endpoint bug: approve attempts a
+      // real SES send and staging can't deliver to the blackhole sink, so the
+      // send leg 500s ("send failed"). Verified during authoring that the SAME
+      // 500 reproduces on the deprecated agent-path approve
+      // (POST /v1/agents/{email}/messages/{id}/approve) — so the fault is the
+      // send transport on staging, not the /v1/reviews routing/authz. The hold
+      // stays pending_review after the failed send, so we reject it below to
+      // clean up. If prod ever runs this against a deliverable sink, the 200
+      // branch above is the real assertion.
+      info(SUITE, "approve-send-failed-staging", `approveReview reached the send leg but SES failed on staging (500 "send failed") — endpoint routing/authz OK; hold left pending and cleaned via reject. request handled id=${id}`);
+    } else {
+      fail(SUITE, "approve-unexpected", `approveReview returned unexpected ${r.status}: ${r.raw.slice(0, 200)}`);
+    }
+
+    // Nonexistent id → 404 regardless of the send outcome above.
+    const miss = await client.post(`/v1/reviews/msg_nonexistent_${Date.now()}/approve`, { body: {} });
+    assert.equal(miss.status, 404, `approve nonexistent expected 404, got ${miss.status}: ${miss.raw.slice(0, 200)}`);
+  } finally {
+    if (!resolved) {
+      // Hold is still pending (approve either 500'd or we bailed) — reject so
+      // nothing lingers in the queue. Agent delete would cascade anyway, but be explicit.
+      await client.post(`/v1/reviews/${id}/reject`, { body: { reason: "e2e approve-suite cleanup" } });
+    }
+    await del(email);
+  }
+});
+
+test("reviews: unauthenticated access to every op → 401", async () => {
+  // A real held review to address, so a 401 proves the auth gate (not a 404
+  // masking it). apiKey:null strips the Authorization header.
+  const { email, id } = await createHeldReview("unauth");
+  try {
+    const list = await client.get("/v1/reviews", { apiKey: null });
+    assert.equal(list.status, 401, `unauth listReviews expected 401, got ${list.status}`);
+    const get = await client.get(`/v1/reviews/${id}`, { apiKey: null });
+    assert.equal(get.status, 401, `unauth getReview expected 401, got ${get.status}`);
+    const ap = await client.post(`/v1/reviews/${id}/approve`, { apiKey: null, body: {} });
+    assert.equal(ap.status, 401, `unauth approveReview expected 401, got ${ap.status}`);
+    const rj = await client.post(`/v1/reviews/${id}/reject`, { apiKey: null, body: { reason: "x" } });
+    assert.equal(rj.status, 401, `unauth rejectReview expected 401, got ${rj.status}`);
+  } finally {
+    await del(email);
+  }
+});
+
+after(async () => {
+  await writeReport(`./reports/${SUITE}.json`);
+});

--- a/tests/e2e-prod/suites/19-account.test.ts
+++ b/tests/e2e-prod/suites/19-account.test.ts
@@ -1,0 +1,290 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { info, writeReport } from "../harness/report.ts";
+
+// Black-box conformance for the /v1/account surface (account ops in the
+// drift-gated api/openapi.yaml SSOT): getAccount, listApiKeys, createApiKey,
+// deleteApiKey, exportAccount, listSuppressions, deleteSuppression, and a
+// documented-skip placeholder for deleteAccount.
+//
+// SAFETY (see the deleteAccount placeholder + the createApiKey test):
+//  - deleteAccount is NEVER invoked — it would nuke the account the whole
+//    conformance run depends on, and there is no black-box way to mint a
+//    throwaway account to test it against.
+//  - createApiKey mints a NEW key; only that new key is ever deleted. The
+//    authenticating key (E2A_API_KEY) is never touched.
+const SUITE = "19-account";
+const client = new ApiClient();
+
+interface AccountView {
+  user: { id: string; email: string };
+  scope: "account" | "agent";
+  plan_code: string;
+  agent_address?: string;
+  upgrade_url: string;
+  limits: { max_agents: number; max_domains: number; max_messages_month: number; max_storage_bytes: number };
+  usage: { agents: number; domains: number; messages_month: number; storage_bytes: number };
+}
+interface ApiKeyView {
+  id: string;
+  name: string;
+  key_prefix: string;
+  scope: "account" | "agent";
+  created_at: string;
+  agent?: string;
+  last_used_at?: string;
+  expires_at?: string;
+}
+interface PageApiKeyView {
+  items: ApiKeyView[];
+  next_cursor: string | null;
+}
+interface CreateApiKeyResponse extends ApiKeyView {
+  key: string;
+}
+interface Suppression {
+  address: string;
+  source: string;
+  created_at: string;
+  reason?: string;
+  source_message_id?: string;
+}
+interface PageSuppression {
+  items: Suppression[];
+  next_cursor: string | null;
+}
+interface ErrorEnvelope {
+  error?: { code?: string; message?: string; request_id?: string };
+}
+
+// ---------------------------------------------------------------------------
+// getAccount — AccountView (whoami): identity + plan caps + usage.
+// ---------------------------------------------------------------------------
+test("getAccount: returns AccountView (user, scope, plan_code, limits, usage, upgrade_url)", async () => {
+  const r = await client.get<AccountView>("/v1/account");
+  assert.equal(r.status, 200, `getAccount expected 200, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  const b = r.body!;
+  // user{id,email} required
+  assert.ok(b.user?.id, "user.id present");
+  assert.ok(b.user?.email?.includes("@"), `user.email valid: ${b.user?.email}`);
+  // scope enum
+  assert.ok(b.scope === "account" || b.scope === "agent", `scope in {account,agent}: ${b.scope}`);
+  assert.equal(typeof b.plan_code, "string", "plan_code is a string");
+  assert.ok(b.plan_code.length > 0, "plan_code non-empty");
+  assert.equal(typeof b.upgrade_url, "string", "upgrade_url present (may be empty)");
+  // limits: all four max_* caps required + integer
+  for (const k of ["max_agents", "max_domains", "max_messages_month", "max_storage_bytes"] as const) {
+    assert.equal(typeof b.limits?.[k], "number", `limits.${k} is a number`);
+    assert.ok(Number.isInteger(b.limits[k]), `limits.${k} is an integer`);
+  }
+  // usage: all four counters required + integer + non-negative
+  for (const k of ["agents", "domains", "messages_month", "storage_bytes"] as const) {
+    assert.equal(typeof b.usage?.[k], "number", `usage.${k} is a number`);
+    assert.ok(b.usage[k] >= 0, `usage.${k} non-negative`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// listApiKeys — PageAPIKeyView envelope + the authenticating key is present.
+// ---------------------------------------------------------------------------
+test("listApiKeys: PageAPIKeyView envelope; the authenticating key is present", async () => {
+  const r = await client.get<PageApiKeyView>("/v1/account/api-keys");
+  assert.equal(r.status, 200, `listApiKeys expected 200, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  assert.ok(Array.isArray(r.body?.items), "items is an array");
+  assert.ok(
+    r.body!.next_cursor === null || typeof r.body!.next_cursor === "string",
+    "next_cursor is string|null (required by PageAPIKeyView)",
+  );
+  for (const k of r.body!.items) {
+    // APIKeyView required: id, name, key_prefix, scope, created_at — and NO secret.
+    assert.ok(k.id, "key.id present");
+    assert.equal(typeof k.name, "string", "key.name is a string");
+    assert.ok(k.key_prefix, "key.key_prefix present");
+    assert.ok(k.scope === "account" || k.scope === "agent", `key.scope in {account,agent}: ${k.scope}`);
+    assert.ok(k.created_at, "key.created_at present");
+    assert.ok(!("key" in (k as object)), "list must NOT leak the secret key (metadata only)");
+  }
+  // The authenticating key must appear in its own list. key_prefix is a
+  // non-secret leading slice of the full secret (e.g. e2a_acct_<hex7>), so the
+  // env key must start with exactly one listed key's prefix.
+  const mine = r.body!.items.find((k) => client.env.apiKey.startsWith(k.key_prefix));
+  assert.ok(mine, "the E2A_API_KEY the suite authenticates with is present in listApiKeys");
+});
+
+// ---------------------------------------------------------------------------
+// createApiKey → plaintext once → appears in list → deleteApiKey (NEW key
+// only) → gone. NEVER deletes the authenticating key.
+// ---------------------------------------------------------------------------
+test("createApiKey → list shows it → deleteApiKey (new key only) → gone", async () => {
+  const name = `conf-19-${Date.now()}`;
+  const create = await client.post<CreateApiKeyResponse>("/v1/account/api-keys", {
+    body: { name, scope: "account" },
+  });
+  assert.equal(create.status, 201, `createApiKey expected 201, got ${create.status}: ${create.raw.slice(0, 200)}`);
+  const created = create.body!;
+  // CreateAPIKeyResponse required: key (plaintext, once), id, name, key_prefix, scope, created_at.
+  assert.ok(created.key, "plaintext key returned exactly once at creation");
+  assert.ok(created.key.startsWith(created.key_prefix), "returned key begins with its key_prefix");
+  assert.ok(created.id, "created.id present");
+  assert.equal(created.name, name, "created.name echoes the request");
+  assert.equal(created.scope, "account", "created.scope is account");
+
+  // Guard: we must never delete the key we authenticate with.
+  assert.notEqual(created.key, client.env.apiKey, "new key is distinct from the auth key");
+
+  let deleted = false;
+  try {
+    // Present in the list now.
+    const list = await client.get<PageApiKeyView>("/v1/account/api-keys");
+    assert.equal(list.status, 200);
+    assert.ok(list.body!.items.some((k) => k.id === created.id), "new key appears in listApiKeys");
+
+    // Delete the NEW key (never the auth key).
+    assert.ok(
+      !client.env.apiKey.startsWith(created.key_prefix),
+      "sanity: new key_prefix does not match the auth key before delete",
+    );
+    const del = await client.delete(`/v1/account/api-keys/${encodeURIComponent(created.id)}`);
+    assert.equal(del.status, 204, `deleteApiKey expected 204 No Content, got ${del.status}: ${del.raw.slice(0, 200)}`);
+    deleted = true;
+
+    // Gone from the list.
+    const after = await client.get<PageApiKeyView>("/v1/account/api-keys");
+    assert.equal(after.status, 200);
+    assert.ok(!after.body!.items.some((k) => k.id === created.id), "deleted key is gone from listApiKeys");
+  } finally {
+    // Self-clean: if an assertion aborted before the delete, revoke the throwaway.
+    if (!deleted) await client.delete(`/v1/account/api-keys/${encodeURIComponent(created.id)}`);
+  }
+});
+
+test("deleteApiKey: unknown id returns 404 not_found", async () => {
+  const r = await client.delete<ErrorEnvelope>("/v1/account/api-keys/apk_conf19doesnotexist000000000000");
+  assert.equal(r.status, 404, `unknown key delete → 404, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  assert.equal(r.body?.error?.code, "not_found", "error envelope code=not_found");
+});
+
+// ---------------------------------------------------------------------------
+// exportAccount — UserExport (GDPR right-of-access).
+// ---------------------------------------------------------------------------
+test("exportAccount: 200 UserExport with required sections + attachment header", async () => {
+  const r = await client.get<Record<string, unknown>>("/v1/account/export");
+  assert.equal(r.status, 200, `exportAccount expected 200, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  const b = r.body!;
+  // UserExport required: generated_at, schema_version, user, domains, agents,
+  // api_keys, messages, suppressions, protection_events.
+  for (const k of [
+    "generated_at",
+    "schema_version",
+    "user",
+    "domains",
+    "agents",
+    "api_keys",
+    "messages",
+    "suppressions",
+    "protection_events",
+  ]) {
+    assert.ok(k in b, `export has required section '${k}'`);
+  }
+  // user is UserExportUser{id,email,name,created_at}.
+  const user = b.user as { id?: string; email?: string; name?: string; created_at?: string };
+  assert.ok(user?.id && user?.email, "export.user has id + email");
+  // Array-typed sections must be arrays.
+  for (const k of ["domains", "agents", "api_keys", "messages", "suppressions", "protection_events"]) {
+    assert.ok(Array.isArray(b[k]), `export.${k} is an array`);
+  }
+  // Exported api_keys are metadata only — never the plaintext secret.
+  for (const k of b.api_keys as Array<Record<string, unknown>>) {
+    assert.ok(!("key" in k), "export.api_keys entries carry no plaintext secret");
+  }
+  // Downloadable dump: Content-Disposition attachment (spec documents the header).
+  const cd = r.headers["content-disposition"];
+  assert.ok(cd && /attachment/i.test(cd), `export sets Content-Disposition: attachment (got: ${cd ?? "absent"})`);
+});
+
+// ---------------------------------------------------------------------------
+// listSuppressions — PageSuppression envelope (typically empty for a fresh acct).
+// ---------------------------------------------------------------------------
+test("listSuppressions: PageSuppression envelope {items, next_cursor}", async () => {
+  const r = await client.get<PageSuppression>("/v1/account/suppressions", { query: { limit: 100 } });
+  assert.equal(r.status, 200, `listSuppressions expected 200, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  assert.ok(Array.isArray(r.body?.items), "items is an array");
+  assert.ok(
+    r.body!.next_cursor === null || typeof r.body!.next_cursor === "string",
+    "next_cursor is string|null (required by PageSuppression)",
+  );
+  for (const s of r.body!.items) {
+    // Suppression required: address, source, created_at.
+    assert.ok(s.address?.includes("@"), `suppression.address valid: ${s.address}`);
+    assert.ok(s.source, "suppression.source present");
+    assert.ok(s.created_at, "suppression.created_at present");
+  }
+  if (r.body!.items.length === 0) {
+    info(SUITE, "listSuppressions", "suppression list is empty (expected for the conformance account)");
+  }
+});
+
+test("deleteSuppression: unknown address returns 404 not_found", async () => {
+  const addr = `conf19-nonexistent-${Date.now()}@example.com`;
+  const r = await client.delete<ErrorEnvelope>(`/v1/account/suppressions/${encodeURIComponent(addr)}`);
+  assert.equal(r.status, 404, `un-suppressing an unknown address → 404, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  assert.equal(r.body?.error?.code, "not_found", "error envelope code=not_found");
+});
+
+// ---------------------------------------------------------------------------
+// Unauthenticated access — every account op must reject with 401.
+// ---------------------------------------------------------------------------
+test("unauth: every account op rejects an unauthenticated caller with 401", async () => {
+  // apiKey: null strips the Authorization header entirely.
+  const noAuth = { apiKey: null as null };
+
+  const cases: Array<{ label: string; run: () => Promise<{ status: number; raw: string }> }> = [
+    { label: "GET /v1/account", run: () => client.get("/v1/account", noAuth) },
+    { label: "GET /v1/account/api-keys", run: () => client.get("/v1/account/api-keys", noAuth) },
+    {
+      // NOTE: the server parses/validates the request body BEFORE the auth
+      // check, so a POST with a MISSING/MALFORMED body 400s (validation) even
+      // unauthenticated. To actually exercise the auth gate we send a
+      // well-formed body — then the response is a clean 401. (Pinned quirk:
+      // body-before-auth ordering; the 400 leaks no data, but the auth-first
+      // contract is only observable with a valid body.)
+      label: "POST /v1/account/api-keys",
+      run: () => client.post("/v1/account/api-keys", { ...noAuth, body: { name: "unauth-probe", scope: "account" } }),
+    },
+    { label: "GET /v1/account/export", run: () => client.get("/v1/account/export", noAuth) },
+    { label: "GET /v1/account/suppressions", run: () => client.get("/v1/account/suppressions", noAuth) },
+    {
+      label: "DELETE /v1/account/api-keys/{id}",
+      run: () => client.delete("/v1/account/api-keys/apk_unauth", noAuth),
+    },
+    {
+      label: "DELETE /v1/account/suppressions/{address}",
+      run: () => client.delete("/v1/account/suppressions/unauth%40example.com", noAuth),
+    },
+  ];
+
+  for (const c of cases) {
+    const r = await c.run();
+    assert.equal(r.status, 401, `${c.label} unauthenticated → 401, got ${r.status}: ${r.raw.slice(0, 160)}`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// deleteAccount — DELIBERATELY NOT EXERCISED. It permanently deletes the
+// account (and cascades all owned data) that the entire conformance suite
+// authenticates as. There is no black-box API to mint a throwaway account, so
+// there is no safe target. A dedicated disposable-account fixture is a
+// follow-up. This test never invokes DELETE /v1/account.
+// ---------------------------------------------------------------------------
+test(
+  "deleteAccount: DELETE /v1/account",
+  { skip: "destructive — needs a dedicated throwaway account (follow-up); never run against the conformance account" },
+  () => {
+    assert.fail("unreachable — deleteAccount is intentionally skipped and must never execute here");
+  },
+);
+
+after(async () => {
+  await writeReport(`./reports/${SUITE}.json`);
+});

--- a/tests/e2e-prod/suites/20-attachments.test.ts
+++ b/tests/e2e-prod/suites/20-attachments.test.ts
@@ -106,11 +106,16 @@ async function doSetup(): Promise<SentAttachment | null> {
   return null;
 }
 
+// Build the fixture ONCE up front. When staging can't produce a retrievable
+// attachment, the real-retrieval + capability-token tests SKIP (not silently
+// pass) — so a broken fixture can never hide a regression in the authz coverage.
+const fixture = await ensureSentAttachment();
+const fxSkip = fixture ? false : "staging could not produce a retrievable attachment fixture";
+
 // ── Happy path (real attachment retrieval) ───────────────────────────────────
 
-test("getAttachment: returns AttachmentView (metadata + short-lived download_url)", async () => {
-  const s = await ensureSentAttachment();
-  if (!s) return; // limitation already flagged in setup
+test("getAttachment: returns AttachmentView (metadata + short-lived download_url)", { skip: fxSkip }, async () => {
+  const s = fixture!;
   const r = await client.get<{
     index: number;
     filename?: string;
@@ -139,9 +144,8 @@ test("getAttachment: returns AttachmentView (metadata + short-lived download_url
   assert.ok(r.body?.data === undefined, "no inline `data` unless inline=true");
 });
 
-test("getAttachment: ?inline=true returns base64 data that round-trips", async () => {
-  const s = await ensureSentAttachment();
-  if (!s) return;
+test("getAttachment: ?inline=true returns base64 data that round-trips", { skip: fxSkip }, async () => {
+  const s = fixture!;
   const r = await client.get<{ data?: string; size_bytes: number }>(
     `/v1/agents/${encodeURIComponent(s.agentEmail)}/messages/${s.messageId}/attachments/0`,
     { query: { inline: "true" } },
@@ -152,9 +156,8 @@ test("getAttachment: ?inline=true returns base64 data that round-trips", async (
   assert.equal(decoded, ATTACH_TEXT, "inline data decodes back to the sent bytes");
 });
 
-test("getAttachment: out-of-range index returns 404 attachment_not_found", async () => {
-  const s = await ensureSentAttachment();
-  if (!s) return;
+test("getAttachment: out-of-range index returns 404 attachment_not_found", { skip: fxSkip }, async () => {
+  const s = fixture!;
   const r = await client.get<{ error?: { code?: string } }>(
     `/v1/agents/${encodeURIComponent(s.agentEmail)}/messages/${s.messageId}/attachments/9`,
   );
@@ -162,9 +165,8 @@ test("getAttachment: out-of-range index returns 404 attachment_not_found", async
   assert.equal(r.body?.error?.code, "attachment_not_found", "error envelope carries attachment_not_found");
 });
 
-test("download: valid capability token streams the exact bytes", async () => {
-  const s = await ensureSentAttachment();
-  if (!s) return;
+test("download: valid capability token streams the exact bytes", { skip: fxSkip }, async () => {
+  const s = fixture!;
   const meta = await client.get<{ download_url: string }>(
     `/v1/agents/${encodeURIComponent(s.agentEmail)}/messages/${s.messageId}/attachments/0`,
   );
@@ -183,9 +185,8 @@ test("download: valid capability token streams the exact bytes", async () => {
   assert.equal(dl.headers["x-content-type-options"], "nosniff", "download is served nosniff");
 });
 
-test("download: token bound to index 0 is rejected for index 1 (capability scoping)", async () => {
-  const s = await ensureSentAttachment();
-  if (!s) return;
+test("download: token bound to index 0 is rejected for index 1 (capability scoping)", { skip: fxSkip }, async () => {
+  const s = fixture!;
   const meta = await client.get<{ download_url: string }>(
     `/v1/agents/${encodeURIComponent(s.agentEmail)}/messages/${s.messageId}/attachments/0`,
   );
@@ -195,9 +196,8 @@ test("download: token bound to index 0 is rejected for index 1 (capability scopi
   assert.equal(dl.status, 403, `index-swapped token → 403, got ${dl.status}: ${dl.raw.slice(0, 200)}`);
 });
 
-test("download: valid token is rejected when the {email} path names a different agent (path-agent binding)", async () => {
-  const s = await ensureSentAttachment();
-  if (!s) return;
+test("download: valid token is rejected when the {email} path names a different agent (path-agent binding)", { skip: fxSkip }, async () => {
+  const s = fixture!;
   const meta = await client.get<{ download_url: string }>(
     `/v1/agents/${encodeURIComponent(s.agentEmail)}/messages/${s.messageId}/attachments/0`,
   );

--- a/tests/e2e-prod/suites/20-attachments.test.ts
+++ b/tests/e2e-prod/suites/20-attachments.test.ts
@@ -1,0 +1,343 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { uniqueSlug, uniqueSubject, holdAllOutbound } from "../harness/fixtures.ts";
+import { fail, info, warn, writeReport } from "../harness/report.ts";
+
+// Black-box conformance for the attachments surface (SSOT: api/openapi.yaml +
+// the non-openapi raw download route). Two endpoints under test:
+//   1. getAttachment  — GET /v1/agents/{email}/messages/{id}/attachments/{index}
+//        (Huma/bearer; returns AttachmentView = metadata + short-lived
+//         download_url + expires_at; ?inline=true adds base64 `data` for
+//         attachments <= 256 KB, else 413). Verified against openapi shapes.
+//   2. the raw DOWNLOAD route — GET .../attachments/{index}/download?token=...
+//        (NOT in openapi; a chi route outside Huma. The capability TOKEN in the
+//         URL authorizes the stream — no bearer. Errors are PLAIN TEXT via
+//         http.Error, NOT the JSON error envelope — this is by design for the
+//         raw route, pinned below, not a spec violation since it's off-contract.)
+//
+// Producing a message WITH a retrievable attachment on staging:
+//   - Inbound-with-attachments is unavailable (no MX on staging).
+//   - HELD outbound (holdAllOutbound) does NOT work: a pending_review draft has
+//     NO raw_message, so `attachments` is [] and getAttachment 404s. This is a
+//     deliberate server property (internal/httpapi/messages.go: "held drafts
+//     (no raw_message) carry []"). We assert it below rather than assume it.
+//   - REAL outbound to the SES simulator (success@simulator.amazonses.com)
+//     WITHOUT holding DOES work: staging sends via relay, persists the sent
+//     MIME, and getAttachment/download then operate on real bytes. This is the
+//     happy path this suite uses. If a real send ever stops yielding a
+//     retrievable attachment, the happy-path tests self-downgrade to a flagged
+//     staging limitation (see ensureSentAttachment) rather than fail.
+
+const SUITE = "20-attachments";
+const client = new ApiClient();
+
+// Bytes we send as the attachment; the download must round-trip these exactly.
+const ATTACH_TEXT = "hello attachment world";
+const ATTACH_B64 = Buffer.from(ATTACH_TEXT, "utf8").toString("base64");
+const ATTACH_FILENAME = "hello.txt";
+const ATTACH_CTYPE = "text/plain";
+
+// Throwaway agents to delete in `after` (delete cascades to messages).
+const createdAgents: string[] = [];
+
+interface SentAttachment {
+  agentEmail: string;
+  messageId: string;
+}
+
+// ensureSentAttachment lazily provisions ONE throwaway agent, does a REAL send
+// with an attachment to the SES simulator (no hold), and polls the sent message
+// until its parsed `attachments[]` is populated. Memoized so every happy-path
+// test shares the single fixture regardless of run order. Returns null (after
+// recording a warn) if staging can't produce a retrievable attachment — the
+// happy-path tests then self-skip and the limitation is flagged, per the brief.
+let setupPromise: Promise<SentAttachment | null> | undefined;
+function ensureSentAttachment(): Promise<SentAttachment | null> {
+  if (!setupPromise) setupPromise = doSetup();
+  return setupPromise;
+}
+
+async function doSetup(): Promise<SentAttachment | null> {
+  const slug = uniqueSlug("attach");
+  const agentEmail = `${slug}@${client.env.sharedDomain}`;
+  const create = await client.post<{ email: string }>("/v1/agents", {
+    body: { email: agentEmail, name: "attach fixture" },
+  });
+  if (create.status !== 201) {
+    warn(SUITE, "setup", `could not create fixture agent (got ${create.status}); happy-path flagged`, create.raw.slice(0, 200));
+    return null;
+  }
+  createdAgents.push(agentEmail);
+
+  const send = await client.post<{ status: string; message_id: string }>(
+    `/v1/agents/${encodeURIComponent(agentEmail)}/messages`,
+    {
+      body: {
+        to: ["success@simulator.amazonses.com"],
+        subject: uniqueSubject("attach"),
+        body: "see attached",
+        attachments: [{ filename: ATTACH_FILENAME, content_type: ATTACH_CTYPE, data: ATTACH_B64 }],
+      },
+    },
+  );
+  if (send.status !== 200 || !send.body?.message_id) {
+    warn(SUITE, "setup", `real send with attachment did not return 200+message_id (got ${send.status}); happy-path flagged`, send.raw.slice(0, 200));
+    return null;
+  }
+  const messageId = send.body.message_id;
+
+  // The sent MIME is normally persisted synchronously, but poll a few times to
+  // tolerate an async delivery worker before flagging a limitation.
+  for (let attempt = 0; attempt < 8; attempt++) {
+    const msg = await client.get<{ attachments?: Array<{ index: number }> }>(
+      `/v1/agents/${encodeURIComponent(agentEmail)}/messages/${messageId}`,
+    );
+    if (msg.status === 200 && Array.isArray(msg.body?.attachments) && msg.body!.attachments.length > 0) {
+      return { agentEmail, messageId };
+    }
+    await new Promise((r) => setTimeout(r, 750));
+  }
+  warn(
+    SUITE,
+    "setup",
+    "STAGING LIMITATION: a real send accepted the attachment but the sent message never exposed a retrievable attachments[] within the poll window; happy-path (real retrieval) flagged, negatives still run",
+  );
+  return null;
+}
+
+// ── Happy path (real attachment retrieval) ───────────────────────────────────
+
+test("getAttachment: returns AttachmentView (metadata + short-lived download_url)", async () => {
+  const s = await ensureSentAttachment();
+  if (!s) return; // limitation already flagged in setup
+  const r = await client.get<{
+    index: number;
+    filename?: string;
+    content_type?: string;
+    size_bytes: number;
+    download_url: string;
+    expires_at: string;
+    data?: string;
+  }>(`/v1/agents/${encodeURIComponent(s.agentEmail)}/messages/${s.messageId}/attachments/0`);
+
+  assert.equal(r.status, 200, `expected 200, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  // openapi AttachmentView required: index, size_bytes, download_url, expires_at.
+  assert.equal(r.body?.index, 0, "index is the 0-based attachment index");
+  assert.equal(typeof r.body?.size_bytes, "number", "size_bytes is int");
+  assert.equal(r.body?.size_bytes, ATTACH_TEXT.length, "size_bytes matches sent bytes");
+  assert.ok(typeof r.body?.download_url === "string" && r.body!.download_url.length > 0, "download_url present");
+  assert.ok(r.body?.download_url?.includes("/attachments/0/download?token="), "download_url is the capability-token route");
+  // expires_at is an RFC3339 date-time in the future (15-min TTL server-side).
+  const exp = Date.parse(r.body!.expires_at);
+  assert.ok(!Number.isNaN(exp), "expires_at is a parseable date-time");
+  assert.ok(exp > Date.now(), "download_url has not already expired");
+  // Optional metadata the server does populate for this send.
+  assert.equal(r.body?.filename, ATTACH_FILENAME, "filename echoed");
+  assert.equal(r.body?.content_type, ATTACH_CTYPE, "content_type echoed");
+  // Without inline, bytes must NOT be present (the whole point of §6a #5).
+  assert.ok(r.body?.data === undefined, "no inline `data` unless inline=true");
+});
+
+test("getAttachment: ?inline=true returns base64 data that round-trips", async () => {
+  const s = await ensureSentAttachment();
+  if (!s) return;
+  const r = await client.get<{ data?: string; size_bytes: number }>(
+    `/v1/agents/${encodeURIComponent(s.agentEmail)}/messages/${s.messageId}/attachments/0`,
+    { query: { inline: "true" } },
+  );
+  assert.equal(r.status, 200, `expected 200, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  assert.ok(typeof r.body?.data === "string", "inline=true adds base64 `data` for a small attachment");
+  const decoded = Buffer.from(r.body!.data!, "base64").toString("utf8");
+  assert.equal(decoded, ATTACH_TEXT, "inline data decodes back to the sent bytes");
+});
+
+test("getAttachment: out-of-range index returns 404 attachment_not_found", async () => {
+  const s = await ensureSentAttachment();
+  if (!s) return;
+  const r = await client.get<{ error?: { code?: string } }>(
+    `/v1/agents/${encodeURIComponent(s.agentEmail)}/messages/${s.messageId}/attachments/9`,
+  );
+  assert.equal(r.status, 404, `out-of-range index → 404, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  assert.equal(r.body?.error?.code, "attachment_not_found", "error envelope carries attachment_not_found");
+});
+
+test("download: valid capability token streams the exact bytes", async () => {
+  const s = await ensureSentAttachment();
+  if (!s) return;
+  const meta = await client.get<{ download_url: string }>(
+    `/v1/agents/${encodeURIComponent(s.agentEmail)}/messages/${s.messageId}/attachments/0`,
+  );
+  assert.equal(meta.status, 200);
+  // download_url is minted against the deployment's public base (staging.e2a.dev);
+  // re-target it at the client's apiUrl (the local proxy). The token is an
+  // HMAC over message|index|exp — host-independent — so this is faithful.
+  const path = pathAndQuery(meta.body!.download_url);
+  const dl = await client.get<never>(path, { apiKey: null });
+  assert.equal(dl.status, 200, `valid-token download → 200, got ${dl.status}: ${dl.raw.slice(0, 200)}`);
+  assert.equal(dl.raw, ATTACH_TEXT, "streamed body equals the sent attachment bytes");
+  assert.ok(
+    (dl.headers["content-type"] ?? "").startsWith(ATTACH_CTYPE),
+    `content-type is the attachment's, got ${dl.headers["content-type"]}`,
+  );
+  assert.equal(dl.headers["x-content-type-options"], "nosniff", "download is served nosniff");
+});
+
+test("download: token bound to index 0 is rejected for index 1 (capability scoping)", async () => {
+  const s = await ensureSentAttachment();
+  if (!s) return;
+  const meta = await client.get<{ download_url: string }>(
+    `/v1/agents/${encodeURIComponent(s.agentEmail)}/messages/${s.messageId}/attachments/0`,
+  );
+  assert.equal(meta.status, 200);
+  const path = pathAndQuery(meta.body!.download_url).replace("/attachments/0/download", "/attachments/1/download");
+  const dl = await client.get(path, { apiKey: null });
+  assert.equal(dl.status, 403, `index-swapped token → 403, got ${dl.status}: ${dl.raw.slice(0, 200)}`);
+});
+
+test("download: valid token is rejected when the {email} path names a different agent (path-agent binding)", async () => {
+  const s = await ensureSentAttachment();
+  if (!s) return;
+  const meta = await client.get<{ download_url: string }>(
+    `/v1/agents/${encodeURIComponent(s.agentEmail)}/messages/${s.messageId}/attachments/0`,
+  );
+  assert.equal(meta.status, 200);
+  // The token binds message+index but NOT identity; the handler additionally
+  // keys GetMessage by the path agent. Swap the path agent to a DIFFERENT owned
+  // agent (the primary) — the message doesn't belong to it → 404 not-found.
+  // NB: the minted path keeps the RAW email (Go url.PathEscape leaves `@`
+  // unescaped), so swap on the raw address, not an encodeURIComponent form.
+  const path = pathAndQuery(meta.body!.download_url).replace(
+    `/agents/${s.agentEmail}/`,
+    `/agents/${client.env.primaryAgentEmail}/`,
+  );
+  assert.ok(path.includes(`/agents/${client.env.primaryAgentEmail}/`), "path-agent swap applied");
+  const dl = await client.get(path, { apiKey: null });
+  assert.equal(dl.status, 404, `token replayed under a different agent path → 404, got ${dl.status}: ${dl.raw.slice(0, 200)}`);
+});
+
+// ── Held-draft has no retrievable attachment (documents WHY we real-send) ─────
+
+test("getAttachment: a HELD (pending_review) draft carrying an attachment exposes NO attachment (404)", async () => {
+  const slug = uniqueSlug("attach-held");
+  const email = `${slug}@${client.env.sharedDomain}`;
+  const create = await client.post<{ email: string }>("/v1/agents", {
+    body: { email, name: "attach held" },
+  });
+  assert.equal(create.status, 201, `create expected 201, got ${create.status}: ${create.raw.slice(0, 200)}`);
+  createdAgents.push(email);
+
+  const hold = await holdAllOutbound(client, email);
+  assert.equal(hold.status, 200, `hold-all-outbound expected 200, got ${hold.status}`);
+
+  const send = await client.post<{ status: string; message_id: string }>(
+    `/v1/agents/${encodeURIComponent(email)}/messages`,
+    {
+      body: {
+        to: ["success@simulator.amazonses.com"],
+        subject: uniqueSubject("held attach"),
+        body: "held with attachment",
+        attachments: [{ filename: ATTACH_FILENAME, content_type: ATTACH_CTYPE, data: ATTACH_B64 }],
+      },
+    },
+  );
+  assert.equal(send.status, 202, `held send expected 202 pending_review, got ${send.status}: ${send.raw.slice(0, 200)}`);
+  const messageId = send.body!.message_id;
+
+  // The draft carries no raw_message, so `attachments` is [] and index 0 404s.
+  const msg = await client.get<{ attachments?: unknown[] }>(
+    `/v1/agents/${encodeURIComponent(email)}/messages/${messageId}`,
+  );
+  assert.equal(msg.status, 200);
+  assert.deepEqual(msg.body?.attachments, [], "held draft exposes an EMPTY attachments[] (no raw_message)");
+
+  const att = await client.get<{ error?: { code?: string } }>(
+    `/v1/agents/${encodeURIComponent(email)}/messages/${messageId}/attachments/0`,
+  );
+  assert.equal(att.status, 404, `getAttachment on a held draft → 404, got ${att.status}: ${att.raw.slice(0, 200)}`);
+
+  // Resolve the hold so we don't leave a dangling pending_review item.
+  const reject = await client.post(
+    `/v1/agents/${encodeURIComponent(email)}/messages/${messageId}/reject`,
+    { body: { reason: "e2e attachments suite cleanup" } },
+  );
+  assert.ok(reject.status === 200, `reject expected 200, got ${reject.status}: ${reject.raw.slice(0, 200)}`);
+});
+
+// ── Negative paths (no attachment fixture required) ──────────────────────────
+
+test("getAttachment: nonexistent message returns 404 not_found", async () => {
+  const r = await client.get<{ error?: { code?: string } }>(
+    `/v1/agents/${encodeURIComponent(client.env.primaryAgentEmail)}/messages/msg_doesnotexist_${Date.now()}/attachments/0`,
+  );
+  assert.equal(r.status, 404, `nonexistent message → 404, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  assert.equal(r.body?.error?.code, "not_found", "error envelope carries not_found");
+});
+
+test("getAttachment: unauthenticated returns 401", async () => {
+  const r = await client.get(
+    `/v1/agents/${encodeURIComponent(client.env.primaryAgentEmail)}/messages/msg_x/attachments/0`,
+    { apiKey: null },
+  );
+  assert.equal(r.status, 401, `missing bearer → 401, got ${r.status}: ${r.raw.slice(0, 200)}`);
+});
+
+test("getAttachment: unowned agent returns 403 (anti-enumeration; matches resolveOwnedAgent)", async () => {
+  const r = await client.get(
+    `/v1/agents/${encodeURIComponent(`nobody-${Date.now()}@example.com`)}/messages/msg_x/attachments/0`,
+  );
+  assert.equal(r.status, 403, `unowned agent → 403 forbidden, got ${r.status}: ${r.raw.slice(0, 200)}`);
+});
+
+test("download: missing token returns 401", async () => {
+  const r = await client.get(
+    `/v1/agents/${encodeURIComponent(client.env.primaryAgentEmail)}/messages/msg_x/attachments/0/download`,
+    { apiKey: null },
+  );
+  assert.equal(r.status, 401, `download with no token → 401, got ${r.status}: ${r.raw.slice(0, 200)}`);
+});
+
+test("download: malformed token returns 403", async () => {
+  const r = await client.get(
+    `/v1/agents/${encodeURIComponent(client.env.primaryAgentEmail)}/messages/msg_x/attachments/0/download?token=garbage.abc`,
+    { apiKey: null },
+  );
+  assert.equal(r.status, 403, `bad token → 403, got ${r.status}: ${r.raw.slice(0, 200)}`);
+});
+
+test("download: non-numeric / negative index returns 400", async () => {
+  const email = encodeURIComponent(client.env.primaryAgentEmail);
+  const bad = await client.get(
+    `/v1/agents/${email}/messages/msg_x/attachments/abc/download?token=garbage.abc`,
+    { apiKey: null },
+  );
+  assert.equal(bad.status, 400, `non-numeric index → 400, got ${bad.status}: ${bad.raw.slice(0, 200)}`);
+  const neg = await client.get(
+    `/v1/agents/${email}/messages/msg_x/attachments/-1/download?token=garbage.abc`,
+    { apiKey: null },
+  );
+  assert.equal(neg.status, 400, `negative index → 400, got ${neg.status}: ${neg.raw.slice(0, 200)}`);
+});
+
+// pathAndQuery extracts a minted absolute download_url's path+query so it can be
+// re-issued through the ApiClient (which resolves relative paths against apiUrl,
+// i.e. the local proxy). The capability token is host-independent.
+function pathAndQuery(absoluteUrl: string): string {
+  const u = new URL(absoluteUrl);
+  return u.pathname + u.search;
+}
+
+after(async () => {
+  for (const email of createdAgents) {
+    const del = await client.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE`);
+    if (!(del.status === 204 || del.status === 200)) {
+      fail(SUITE, "cleanup", `failed to delete throwaway agent ${email} (got ${del.status})`, del.raw.slice(0, 200));
+    }
+  }
+  info(SUITE, "cleanup", `deleted ${createdAgents.length} throwaway agent(s)`);
+  // The raw download route returns PLAIN-TEXT errors (http.Error), not the JSON
+  // error envelope the Huma surface uses — intentional for this off-openapi
+  // capability route; recorded so a future contract sweep doesn't mis-flag it.
+  info(SUITE, "download-route", "raw download route errors are plain-text (non-enveloped) by design; it is not part of openapi.yaml");
+  await writeReport(`./reports/${SUITE}.json`);
+});


### PR DESCRIPTION
Five new black-box conformance suites, each covering an API group the existing suite didn't — closing the 56-op matrix. All written + verified **green against live staging**.

| Suite | Ops | Tests | Notes |
|---|---|---|---|
| `16-webhooks` | 8 | 9 | CRUD, deliveries, rotate-secret, test |
| `17-templates` | 8 | 13 | user + starter, `from_starter` copy, validate |
| `18-reviews` | 4 | 6 | account review queue (drives a real HITL hold) |
| `19-account` | 8 | 8 + 1 skip | api-keys CRUD (throwaway only), export, suppressions; **`deleteAccount` skipped — never invoked** |
| `20-attachments` | — | 13 | `getAttachment` + raw capability-token download, **real attachment bytes** |

**50 tests, 49 pass, 0 fail, 1 intentional skip; `tsc` clean.** All self-cleaning (inline — the shared cleanup harness is agent/domain-only). Each expectation verified against `api/openapi.yaml` **and** the live server; no de-drift masking a bug.

## Server/spec findings (flagged, pinned in-suite — for OSS tickets)
- **`deleteWebhook` + `deleteTemplate` take no `?confirm=DELETE`** — inconsistent with agents/domains (which require it).
- **`listReviews`** returns a paginated `{items,next_cursor}` envelope but documents no `limit`/`cursor` params and **ignores `?limit`**.
- **`POST /v1/account/api-keys`** parses the body before the auth gate → an unauth request with a bad body is `400`, not `401` (no data leak).
- `validateTemplate` → `200 {valid:false}` (verdict in body); `testWebhook` async (`200` on unreachable, `409` on disabled); non-HTTPS webhook URL → `400`; the attachment download route returns plaintext errors (off-openapi by design).
- **Gate config:** `approve`/send hits `500` on staging's SES-sandbox sink — the gate should set `E2E_SINK_EMAIL` to the **SES simulator** rather than `blackhole+e2e@e2a.dev`.