### PR TITLE
feat(oauth): grant account scope to https connectors + default consent to account

### DIFF
--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -658,12 +658,13 @@ func (a *API) authenticatePrincipal(r *http.Request) (*identity.Principal, error
 //
 // The granted OAuth scope is authoritative — it is read, never assumed.
 // (CRITICAL-1 fix: this path previously hardcoded every OAuth token to
-// ScopeAccount, which defeated the public-DCR `scope=agent` cap
+// ScopeAccount, which defeated the public-DCR scope ceiling
 // (oauth_handlers.go) and silently handed agent-tier MCP tokens full
 // account-wide admin.) Resolution:
 //   - granted `account` → account-wide admin. Reachable only when the user
-//     explicitly picks account on the consent screen for an all-loopback
-//     client (the scope-picker); never autonomously by a client.
+//     explicitly picks account on the consent screen for an account-eligible
+//     client (loopback or https — see accountEligibleRedirect); never
+//     autonomously by a client.
 //   - granted `agent`   → confined to the consent-bound agent
 //     (session.AgentEmail), with ownership re-checked, mirroring the REST
 //     resolveOwnedAgent pin and the JWT resolveAgentAccessToken path.

--- a/internal/agent/oauth_bearer_test.go
+++ b/internal/agent/oauth_bearer_test.go
@@ -365,8 +365,8 @@ func getWithBearer(t *testing.T, serverURL, path, bearer string) (int, string) {
 }
 
 // TestBearer_OAuth_AgentScope_RejectedOnAccountOp is THE CRITICAL-1 regression.
-// An OAuth/MCP access token — which public DCR caps to scope=agent, and which
-// the consent fixture now grants as agent — must NOT be able to perform an
+// An OAuth/MCP access token that the consent flow granted as scope=agent
+// must NOT be able to perform an
 // account-admin operation. Before the fix, every ate2a_ token was hardcoded to
 // ScopeAccount, so this returned 200 (full account admin); the granted agent
 // scope was silently elevated. Now the scope is honored and the account-only
@@ -401,10 +401,11 @@ func TestBearer_OAuth_AgentScope_AllowedOnOwnTier(t *testing.T) {
 }
 
 // seedOAuthClient inserts a public PKCE OAuth client registered with the given
-// scopes. Seeding directly bypasses the DCR /register cap (which forces
-// scope=agent on public clients) — this is how we simulate the console/
-// confidential issuance path that the design reserves for account scope, and
-// how we construct a token carrying a retired/unrecognized scope.
+// scopes. Seeding directly lets us pin an arbitrary registered ceiling
+// (e.g. account-only, or a retired/unrecognized scope) without driving the
+// consent UI — this is how we simulate the console/confidential issuance
+// path that the design reserves for account scope, and how we construct a
+// token carrying a retired/unrecognized scope.
 func seedOAuthClient(t *testing.T, f *consentFixture, clientID string, scopes []string) {
 	t.Helper()
 	if _, err := f.pool.Exec(context.Background(), `

--- a/internal/agent/oauth_handlers.go
+++ b/internal/agent/oauth_handlers.go
@@ -227,6 +227,14 @@ func isLoopbackRedirect(raw string) bool {
 // attacker, but the admin token is then held by whatever hosted client the
 // user approved. Consent remains mandatory and grants nothing on its own.
 func accountEligibleRedirect(raw string) bool {
+	// Self-contained fail-closed: never treat a redirect as account-eligible
+	// unless it also passes full redirect_uri validation (rejects userinfo,
+	// empty host, fragments, dangerous schemes). Every caller today
+	// pre-validates, but this keeps the gate correct even if some future
+	// writer to oauth_clients skips validateRedirectURI.
+	if validateRedirectURI(raw) != nil {
+		return false
+	}
 	if isLoopbackRedirect(raw) {
 		return true
 	}
@@ -487,10 +495,12 @@ type OAuthClientPublicMetadata struct {
 	Scopes           []string `json:"scopes"`
 	ClientIDIssuedAt int64    `json:"client_id_issued_at"`
 	// AccountEligible reports whether the consent screen may offer account
-	// (workspace-admin) scope for this client: true iff EVERY registered
-	// redirect_uri is loopback. Drives the consent UI (the Account option is
-	// disabled otherwise); the consent handler re-checks the specific inbound
-	// redirect at grant time, so this is UX, not the security boundary.
+	// (workspace-admin) scope for this client: true iff "account" is on the
+	// client's registered scope ceiling (which DCR writes only when the
+	// redirect is account-eligible AND the client requested it). Drives the
+	// consent UI (the Account option is disabled otherwise); fosite re-checks
+	// granted ⊆ registered at grant time, so this is UX, not the security
+	// boundary.
 	AccountEligible bool `json:"account_eligible"`
 }
 
@@ -1018,8 +1028,9 @@ func (a *API) issueOAuthCode(ctx context.Context, w http.ResponseWriter, r *http
 // runs AFTER this. So appending the consented scope to the requested set is
 // what subjects it to that check, and that check is precisely what enforces
 // granted ⊆ client.scopes: account is granted only if the client row carries
-// it (which DCR writes only for all-loopback clients). Remove the append and
-// account-scope containment silently breaks — keep it.
+// it (which DCR writes only for account-eligible — loopback or https —
+// clients that requested it). Remove the append and account-scope containment
+// silently breaks — keep it.
 func grantConsentedScope(ar fosite.AuthorizeRequester, scope string) {
 	if !ar.GetRequestedScopes().Has(scope) {
 		ar.AppendRequestedScope(scope)

--- a/internal/agent/oauth_handlers.go
+++ b/internal/agent/oauth_handlers.go
@@ -210,6 +210,30 @@ func isLoopbackRedirect(raw string) bool {
 	return isLoopbackHost(u.Hostname())
 }
 
+// accountEligibleRedirect reports whether a redirect_uri may be granted
+// account (workspace-admin) scope.
+//
+// SECURITY DECISION (2026-07-10): account was historically loopback-ONLY —
+// a native tool whose callback lands on the user's own machine — so a
+// hosted/remote client could never be socially-engineered into a
+// workspace-admin grant. That gate is intentionally RELAXED here to also
+// permit any https redirect, so hosted connectors (Claude Chat/Cowork,
+// redirect https://claude.ai/api/mcp/auth_callback) can be granted account.
+//
+// The consequence, accepted deliberately: ANY https MCP connector a user
+// consents to can obtain full e2a workspace admin (create/delete inboxes,
+// manage domains & webhooks, mint API keys, resolve reviews). fosite
+// exact-matches redirect_uris so an auth code still can't be diverted to an
+// attacker, but the admin token is then held by whatever hosted client the
+// user approved. Consent remains mandatory and grants nothing on its own.
+func accountEligibleRedirect(raw string) bool {
+	if isLoopbackRedirect(raw) {
+		return true
+	}
+	u, err := url.Parse(raw)
+	return err == nil && u.Scheme == "https"
+}
+
 func validateRedirectURI(raw string) error {
 	if raw == "" {
 		return errors.New("redirect_uri cannot be empty")
@@ -349,9 +373,6 @@ func (a *API) handleOAuthRegister(w http.ResponseWriter, r *http.Request) {
 	if req.TokenEndpointAuthMethod == "" {
 		req.TokenEndpointAuthMethod = "none"
 	}
-	if req.Scope == "" {
-		req.Scope = "agent"
-	}
 
 	// Capability enforcement — reject anything outside what we
 	// support. Failing here gives a clear error at registration time
@@ -379,31 +400,39 @@ func (a *API) handleOAuthRegister(w http.ResponseWriter, r *http.Request) {
 	// client's REGISTERED scopes are the maximum a user can later approve on
 	// the consent screen — not what the client gets autonomously (consent is
 	// mandatory and grants nothing on its own). "account" (workspace admin) is
-	// offered only to clients whose redirect_uris are ALL loopback: a native
-	// app whose callback lands on the user's own machine. A hosted/remote
-	// client (https redirect) can't receive a localhost callback, so it stays
-	// agent-only and can never be socially-engineered into an account grant.
-	// fosite's ExactScopeStrategy enforces granted ⊆ registered, so account
-	// must be on the client row for the consent screen to grant it.
-	accountEligible := true
+	// eligible only when the client's redirect_uris are ALL account-eligible
+	// (loopback or https — see accountEligibleRedirect). fosite's
+	// ExactScopeStrategy enforces granted ⊆ registered, so account must be on
+	// the client row for the consent screen to grant it.
+	redirectAllowsAccount := true
 	for _, ru := range req.RedirectURIs {
-		if !isLoopbackRedirect(ru) {
-			accountEligible = false
+		if !accountEligibleRedirect(ru) {
+			redirectAllowsAccount = false
 			break
 		}
 	}
-	for _, sc := range strings.Fields(req.Scope) {
-		if sc == identity.ScopeAgent || (sc == identity.ScopeAccount && accountEligible) {
-			continue
+	// Narrow, don't reject (RFC 7591 §3.2.1). A spec-compliant MCP client
+	// requests every scope we advertise in `scopes_supported` (agent AND
+	// account) whenever the 401 challenge carries no `scope` param — so
+	// rejecting a superset would 400 every such client (this was the
+	// "couldn't register with e2a's sign-in service" failure). Instead the
+	// registered ceiling is the requested scopes ∩ what the redirect allows,
+	// with unknown/ineligible scopes dropped and agent as the floor. A client
+	// that OMITS scope gets the full eligible ceiling (Claude's case); a
+	// client that explicitly requests only agent is honored at agent — we
+	// never widen a caller's own least-privilege request. The result is
+	// echoed back via the response's `scope`.
+	wantAccount := redirectAllowsAccount
+	if requested := strings.Fields(req.Scope); len(requested) > 0 {
+		wantAccount = false
+		for _, sc := range requested {
+			if sc == identity.ScopeAccount && redirectAllowsAccount {
+				wantAccount = true
+			}
 		}
-		writeOAuthError(w, http.StatusBadRequest, "invalid_client_metadata",
-			`unsupported scope `+strconv.Quote(sc)+`; public clients may request "agent" (and "account" only when all redirect_uris are loopback)`)
-		return
 	}
-	// Persist the full eligible ceiling, not just what was requested, so the
-	// consent screen can offer account on loopback clients without a re-register.
 	scopeCeiling := []string{identity.ScopeAgent}
-	if accountEligible {
+	if wantAccount {
 		scopeCeiling = append(scopeCeiling, identity.ScopeAccount)
 	}
 
@@ -438,7 +467,11 @@ func (a *API) handleOAuthRegister(w http.ResponseWriter, r *http.Request) {
 		GrantTypes:              req.GrantTypes,
 		ResponseTypes:           req.ResponseTypes,
 		TokenEndpointAuthMethod: req.TokenEndpointAuthMethod,
-		Scope:                   req.Scope,
+		// Echo the granted ceiling, not the raw request: per RFC 7591 the
+		// response reflects the registered metadata, so a client that asked
+		// for a superset (or an ineligible/unknown scope) learns what it
+		// actually got.
+		Scope: strings.Join(scopeCeiling, " "),
 	})
 }
 
@@ -520,10 +553,16 @@ func (a *API) handleOAuthGetClient(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "public, max-age=60")
-	accountEligible := len(redirects) > 0
-	for _, ru := range redirects {
-		if !isLoopbackRedirect(ru) {
-			accountEligible = false
+	// account_eligible drives whether the consent screen offers (and defaults
+	// to) account. It reflects the client's REGISTERED ceiling, not the raw
+	// redirect: DCR only writes account into the ceiling when the redirect
+	// allows it AND the client requested it, so reading the scopes column
+	// keeps the UI consistent with what fosite will actually grant (no
+	// account radio the user can pick only to hit invalid_scope at /authorize).
+	accountEligible := false
+	for _, s := range scopes {
+		if s == identity.ScopeAccount {
+			accountEligible = true
 			break
 		}
 	}
@@ -863,22 +902,20 @@ func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Scope the user consented to. The consent screen is e2a's scope
-	// authority: "agent" (default) binds the grant to one inbox; "account"
-	// is full workspace admin. account is gated to LOOPBACK redirect_uris —
-	// a local tool whose callback lands on the user's own machine — so a
-	// hosted/remote client (which can't receive a localhost callback) can't
-	// be socially-engineered into an account grant. The gate is enforced
-	// here, server-side and fail-closed, independent of the page's UI.
+	// authority: "agent" binds the grant to one inbox; "account" is full
+	// workspace admin. account is granted to loopback OR https redirect_uris
+	// (see accountEligibleRedirect for the deliberate policy). The gate is
+	// enforced here, server-side and fail-closed, independent of the page's UI.
 	scopeChoice := r.PostFormValue("scope_choice")
 	if scopeChoice == "" {
 		scopeChoice = identity.ScopeAgent
 	}
 	switch scopeChoice {
 	case identity.ScopeAccount:
-		if !isLoopbackRedirect(ar.GetRedirectURI().String()) {
+		if !accountEligibleRedirect(ar.GetRedirectURI().String()) {
 			a.oauthProvider.WriteAuthorizeError(ctx, w, ar,
 				fosite.ErrInvalidScope.WithHint(
-					"account scope may only be granted to a client with a loopback (http://localhost) redirect_uri"))
+					"account scope may only be granted to a client with a loopback or https redirect_uri"))
 			return
 		}
 		// account is not inbox-bound: empty AgentEmail, account scope. The

--- a/internal/agent/oauth_loopback_test.go
+++ b/internal/agent/oauth_loopback_test.go
@@ -66,6 +66,13 @@ func TestAccountEligibleRedirect(t *testing.T) {
 		// non-loopback http → not eligible (also rejected at registration)
 		{"http://example.com/callback", false},
 
+		// malformed https that validateRedirectURI rejects → NOT eligible
+		// (defense-in-depth: the gate is self-contained, not trusting an
+		// upstream validator)
+		{"https://user@evil.com/cb", false}, // userinfo
+		{"https:///cb", false},              // empty host
+		{"https://example.com/cb#frag", false}, // fragment
+
 		// junk → not eligible (fail closed)
 		{"", false},
 		{"::::not a uri", false},

--- a/internal/agent/oauth_loopback_test.go
+++ b/internal/agent/oauth_loopback_test.go
@@ -39,3 +39,41 @@ func TestIsLoopbackRedirect(t *testing.T) {
 		}
 	}
 }
+
+// TestAccountEligibleRedirect pins the deliberately-relaxed account gate
+// (2026-07-10): account (workspace admin) is granted to loopback OR https
+// redirects — the latter so hosted connectors (Claude Chat/Cowork) qualify —
+// but NOT to custom-scheme or non-loopback http redirects.
+func TestAccountEligibleRedirect(t *testing.T) {
+	cases := []struct {
+		uri  string
+		want bool
+	}{
+		// loopback http → eligible (unchanged)
+		{"http://localhost:3118/callback", true},
+		{"http://127.0.0.1:8765/cb", true},
+		{"http://[::1]/callback", true},
+
+		// https → now eligible (the relaxation)
+		{"https://claude.ai/api/mcp/auth_callback", true},
+		{"https://app.example.com/callback", true},
+		{"https://localhost/callback", true}, // scheme is what matters, not host
+
+		// reverse-domain custom scheme → NOT eligible (valid redirect, but
+		// the callback doesn't land on the user's machine and isn't https)
+		{"com.example.app:/oauth-callback", false},
+
+		// non-loopback http → not eligible (also rejected at registration)
+		{"http://example.com/callback", false},
+
+		// junk → not eligible (fail closed)
+		{"", false},
+		{"::::not a uri", false},
+		{"javascript:alert(1)", false},
+	}
+	for _, c := range cases {
+		if got := accountEligibleRedirect(c.uri); got != c.want {
+			t.Errorf("accountEligibleRedirect(%q) = %v, want %v", c.uri, got, c.want)
+		}
+	}
+}

--- a/internal/agent/oauth_register_test.go
+++ b/internal/agent/oauth_register_test.go
@@ -108,8 +108,10 @@ func TestHTTP_Register_Happy(t *testing.T) {
 	if got.TokenEndpointAuthMethod != "none" {
 		t.Errorf("token_endpoint_auth_method = %q, want none", got.TokenEndpointAuthMethod)
 	}
-	if got.Scope != "agent" {
-		t.Errorf("scope = %q, want agent", got.Scope)
+	// An https redirect is account-eligible (see accountEligibleRedirect), so
+	// DCR registers the full ceiling and echoes it back in `scope`.
+	if got.Scope != "agent account" {
+		t.Errorf("scope = %q, want %q", got.Scope, "agent account")
 	}
 }
 
@@ -271,8 +273,13 @@ func TestHTTP_Register_RejectsUnsupportedGrant(t *testing.T) {
 	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_client_metadata")
 }
 
-// TestHTTP_Register_RejectsUnsupportedScope.
-func TestHTTP_Register_RejectsUnsupportedScope(t *testing.T) {
+// TestHTTP_Register_DropsUnknownScope: DCR narrows rather than rejects
+// (RFC 7591 §3.2.1). A spec-compliant MCP client requests the whole
+// scopes_supported menu (plus offline_access) whenever the 401 challenge
+// carries no scope param, so a hard 400 on any unrecognized scope would
+// fail every such client ("couldn't register with e2a's sign-in service").
+// Instead the bogus scope is dropped and the eligible ceiling is registered.
+func TestHTTP_Register_DropsUnknownScope(t *testing.T) {
 	srv := newDCRServer(t)
 	resp := postRegister(t, srv, agent.OAuthRegisterRequest{
 		ClientName:   "x",
@@ -280,7 +287,64 @@ func TestHTTP_Register_RejectsUnsupportedScope(t *testing.T) {
 		Scope:        "admin",
 	})
 	defer resp.Body.Close()
-	assertOAuthError(t, resp, http.StatusBadRequest, "invalid_client_metadata")
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 201 (unknown scope dropped, not rejected); body=%s", resp.StatusCode, string(body))
+	}
+	var got agent.OAuthRegisterResponse
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(got.Scope, "admin") {
+		t.Errorf("unknown scope must not be reflected back: got %q", got.Scope)
+	}
+	// The client made an explicit request ("admin") that names no eligible
+	// scope, so it's honored at the agent floor — we don't widen it to account
+	// just because the redirect would allow it.
+	if got.Scope != "agent" {
+		t.Errorf("scope = %q, want %q", got.Scope, "agent")
+	}
+}
+
+// TestHTTP_Register_HonorsExplicitAgentOnly: an account-eligible (https)
+// client that EXPLICITLY requests only agent is registered agent-only — we
+// never widen a caller's own least-privilege request to account just because
+// the redirect would allow it. account_eligible is then reported false so the
+// consent screen won't offer/default account for it.
+func TestHTTP_Register_HonorsExplicitAgentOnly(t *testing.T) {
+	srv := newDCRServer(t)
+	resp := postRegister(t, srv, agent.OAuthRegisterRequest{
+		ClientName:   "least privilege",
+		RedirectURIs: []string{"https://app.example.com/cb"},
+		Scope:        "agent",
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 201; body=%s", resp.StatusCode, string(body))
+	}
+	var got agent.OAuthRegisterResponse
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Scope != "agent" {
+		t.Errorf("scope = %q, want agent (explicit request honored, not widened)", got.Scope)
+	}
+
+	// And the public metadata must report the client account-INELIGIBLE, so
+	// the consent screen won't default a user into account.
+	mResp, err := http.Get(srv.URL + "/oauth2/clients/" + got.ClientID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mResp.Body.Close()
+	var meta agent.OAuthClientPublicMetadata
+	if err := json.NewDecoder(mResp.Body).Decode(&meta); err != nil {
+		t.Fatal(err)
+	}
+	if meta.AccountEligible {
+		t.Error("account_eligible should be false for an agent-only client")
+	}
 }
 
 // TestHTTP_Register_TooManyRedirectURIs.
@@ -435,8 +499,11 @@ func TestHTTP_GetClient_PublicMetadata(t *testing.T) {
 		if !equalStringSlice(got.RedirectURIs, []string{"https://app.example.com/oauth/cb"}) {
 			t.Errorf("redirect_uris = %v", got.RedirectURIs)
 		}
-		if !equalStringSlice(got.Scopes, []string{"agent"}) {
-			t.Errorf("scopes = %v, want [agent]", got.Scopes)
+		if !equalStringSlice(got.Scopes, []string{"agent", "account"}) {
+			t.Errorf("scopes = %v, want [agent account]", got.Scopes)
+		}
+		if !got.AccountEligible {
+			t.Error("account_eligible should be true for an https redirect")
 		}
 		if got.ClientIDIssuedAt == 0 {
 			t.Error("client_id_issued_at must be non-zero")

--- a/internal/agent/oauth_register_test.go
+++ b/internal/agent/oauth_register_test.go
@@ -347,6 +347,50 @@ func TestHTTP_Register_HonorsExplicitAgentOnly(t *testing.T) {
 	}
 }
 
+// TestHTTP_Register_ExplicitMultiScope: the shape a spec-compliant MCP client
+// actually sends — an explicit scope string echoing scopes_supported, possibly
+// with offline_access. account is honored (redirect is https-eligible), and
+// unknown scopes like offline_access are dropped from the persisted ceiling so
+// they never leak into the response `scope` or account_eligible.
+func TestHTTP_Register_ExplicitMultiScope(t *testing.T) {
+	srv := newDCRServer(t)
+	resp := postRegister(t, srv, agent.OAuthRegisterRequest{
+		ClientName:   "Claude",
+		RedirectURIs: []string{"https://claude.ai/api/mcp/auth_callback"},
+		Scope:        "agent account offline_access",
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 201; body=%s", resp.StatusCode, string(body))
+	}
+	var got agent.OAuthRegisterResponse
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Scope != "agent account" {
+		t.Errorf("scope = %q, want %q (account honored, offline_access dropped)", got.Scope, "agent account")
+	}
+
+	mResp, err := http.Get(srv.URL + "/oauth2/clients/" + got.ClientID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer mResp.Body.Close()
+	var meta agent.OAuthClientPublicMetadata
+	if err := json.NewDecoder(mResp.Body).Decode(&meta); err != nil {
+		t.Fatal(err)
+	}
+	if !meta.AccountEligible {
+		t.Error("account_eligible should be true (account is on the ceiling)")
+	}
+	for _, s := range meta.Scopes {
+		if s == "offline_access" {
+			t.Errorf("offline_access must not persist in the registered ceiling: %v", meta.Scopes)
+		}
+	}
+}
+
 // TestHTTP_Register_TooManyRedirectURIs.
 func TestHTTP_Register_TooManyRedirectURIs(t *testing.T) {
 	srv := newDCRServer(t)

--- a/internal/agent/oauth_scope_picker_test.go
+++ b/internal/agent/oauth_scope_picker_test.go
@@ -192,6 +192,47 @@ func TestHTTP_Consent_Account_Https_Allowed(t *testing.T) {
 	}
 }
 
+// TestHTTP_Consent_Account_CustomScheme_RejectedByHandlerGate pins the consent
+// handler's OWN fail-closed gate (accountEligibleRedirect), independent of
+// fosite's ceiling check. The client is seeded WITH account in its ceiling and
+// a reverse-domain custom-scheme redirect — which passes validateRedirectURI
+// but is NOT account-eligible — so the handler gate rejects the account grant
+// before fosite is even reached. (Post-relaxation the renamed https "rejected"
+// test only reaches the fosite layer, so this restores direct coverage of the
+// handler gate's reject branch.)
+func TestHTTP_Consent_Account_CustomScheme_RejectedByHandlerGate(t *testing.T) {
+	f := newConsentFixture(t)
+	ctx := context.Background()
+	clientID := "mcp_customscheme"
+	redirectURI := "com.example.app:/oauth-callback"
+	if _, err := f.pool.Exec(ctx, `
+		INSERT INTO oauth_clients
+		    (client_id, client_name, redirect_uris, grant_types, response_types,
+		     scopes, audiences, token_endpoint_auth_method, public, created_via)
+		VALUES ($1, 'custom scheme client', ARRAY[$2],
+		        ARRAY['authorization_code','refresh_token'], ARRAY['code'],
+		        ARRAY['agent','account'], ARRAY[]::TEXT[], 'none', TRUE, 'dcr')
+		ON CONFLICT (client_id) DO NOTHING`, clientID, redirectURI); err != nil {
+		t.Fatalf("seed custom-scheme client: %v", err)
+	}
+
+	_, challenge := newPKCE(t)
+	form := authorizeParams(challenge, clientID, "s1s1s1s1s1s1s1s1")
+	form.Set("redirect_uri", redirectURI)
+	form.Set("action", "allow")
+	form.Set("scope_choice", "account")
+
+	resp := f.consentPOST(t, form)
+	defer resp.Body.Close()
+	loc, _ := url.Parse(resp.Header.Get("Location"))
+	if loc.Query().Get("code") != "" {
+		t.Fatalf("account must be rejected on a custom-scheme redirect")
+	}
+	if e := loc.Query().Get("error"); e != "invalid_scope" {
+		t.Errorf("error = %q, want invalid_scope", e)
+	}
+}
+
 // TestHTTP_Consent_Account_MixedRedirect_RejectedByScopeCeiling proves the
 // fosite scope-ceiling defense independent of the handler gate: this client is
 // seeded with an agent-only ceiling and its inbound (loopback) redirect passes

--- a/internal/agent/oauth_scope_picker_test.go
+++ b/internal/agent/oauth_scope_picker_test.go
@@ -97,10 +97,12 @@ func TestHTTP_Consent_Account_Loopback(t *testing.T) {
 	}
 }
 
-// TestHTTP_Consent_Account_NonLoopback_Rejected — the loopback gate fails closed
-// for a client whose redirect is https (a hosted/remote client that couldn't
-// receive a localhost callback). No code is issued.
-func TestHTTP_Consent_Account_NonLoopback_Rejected(t *testing.T) {
+// TestHTTP_Consent_Account_CeilingLacksAccount_Rejected — defense-in-depth. An
+// https redirect is now account-ELIGIBLE at the handler gate (see
+// accountEligibleRedirect), but a client whose REGISTERED ceiling is agent-only
+// is still rejected by fosite's ExactScopeStrategy (granted ⊆ registered). No
+// code is issued.
+func TestHTTP_Consent_Account_CeilingLacksAccount_Rejected(t *testing.T) {
 	f := newConsentFixture(t)
 	ctx := context.Background()
 	// Seed a public client registered with an https (non-loopback) redirect.
@@ -135,13 +137,68 @@ func TestHTTP_Consent_Account_NonLoopback_Rejected(t *testing.T) {
 	}
 }
 
+// TestHTTP_Consent_Account_Https_Allowed proves the 2026-07-10 policy: a hosted
+// (https) client whose ceiling includes account can now be granted account
+// scope through consent. The loopback-only gate was intentionally relaxed so
+// Claude Chat/Cowork (redirect https://claude.ai/api/mcp/auth_callback) can hold
+// workspace-admin. The issued token resolves to an account principal.
+func TestHTTP_Consent_Account_Https_Allowed(t *testing.T) {
+	f := newConsentFixture(t)
+	ctx := context.Background()
+	clientID := "mcp_hosted_allowed"
+	redirectURI := "https://claude.ai/api/mcp/auth_callback"
+	if _, err := f.pool.Exec(ctx, `
+		INSERT INTO oauth_clients
+		    (client_id, client_name, redirect_uris, grant_types, response_types,
+		     scopes, audiences, token_endpoint_auth_method, public, created_via)
+		VALUES ($1, 'hosted allowed client', ARRAY[$2],
+		        ARRAY['authorization_code','refresh_token'], ARRAY['code'],
+		        ARRAY['agent','account'], ARRAY[]::TEXT[], 'none', TRUE, 'dcr')
+		ON CONFLICT (client_id) DO NOTHING`, clientID, redirectURI); err != nil {
+		t.Fatalf("seed hosted client: %v", err)
+	}
+	// exchangeCode() presents f.clientID at the token endpoint; the code is
+	// bound to the seeded hosted client, so point the fixture at it.
+	f.clientID = clientID
+
+	verifier, challenge := newPKCE(t)
+	form := authorizeParams(challenge, clientID, "s1s1s1s1s1s1s1s1")
+	form.Set("redirect_uri", redirectURI)
+	form.Set("action", "allow")
+	form.Set("scope_choice", "account")
+
+	resp := f.consentPOST(t, form)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusSeeOther {
+		loc, _ := url.Parse(resp.Header.Get("Location"))
+		t.Fatalf("status = %d, want 303 (account on https is now allowed); error=%q",
+			resp.StatusCode, loc.Query().Get("error"))
+	}
+	loc, _ := url.Parse(resp.Header.Get("Location"))
+	code := loc.Query().Get("code")
+	if code == "" {
+		t.Fatalf("expected code, got error=%q", loc.Query().Get("error"))
+	}
+	access, _, scope := f.exchangeCode(t, code, verifier, redirectURI)
+	if !strings.Contains(scope, "account") {
+		t.Errorf("token scope = %q, want it to contain account", scope)
+	}
+	gotScope, agentAddr := f.whoami(t, access)
+	if gotScope != "account" {
+		t.Errorf("whoami scope = %q, want account", gotScope)
+	}
+	if agentAddr != "" {
+		t.Errorf("account principal must have no bound agent; got agent_address=%q", agentAddr)
+	}
+}
+
 // TestHTTP_Consent_Account_MixedRedirect_RejectedByScopeCeiling proves the
-// second defense layer: a client with BOTH a loopback and an https redirect is
-// NOT account-eligible (DCR writes only [agent]), so even when the inbound
-// redirect is the loopback one — passing the consent handler's own loopback
-// gate — fosite's ExactScopeStrategy rejects the account grant because account
-// is not on the client row. This is the enforcement path the DCR-ceiling
-// deviation rests on; the handler gate alone is insufficient here.
+// fosite scope-ceiling defense independent of the handler gate: this client is
+// seeded with an agent-only ceiling and its inbound (loopback) redirect passes
+// the handler gate, yet fosite's ExactScopeStrategy still rejects the account
+// grant because account is not on the client row. (Under the 2026-07-10 policy a
+// loopback+https client IS account-eligible at DCR, so the agent-only ceiling
+// here is a deliberately seeded fixture, not what fresh DCR would write.)
 func TestHTTP_Consent_Account_MixedRedirect_RejectedByScopeCeiling(t *testing.T) {
 	f := newConsentFixture(t)
 	ctx := context.Background()

--- a/mcp/src/http-server.ts
+++ b/mcp/src/http-server.ts
@@ -140,9 +140,11 @@ export function buildApp(opts: HttpServerOptions): BuiltApp {
       authorization_servers: [opts.authorizationServerUrl ?? opts.baseUrl],
       // Scope vocabulary tracks the AS (Slice 5b): the lone "mcp" scope is
       // retired. MCP clients connect as public DCR clients; the consent screen
-      // grants "agent" (single inbox) by default and "account" (workspace admin)
-      // when the user explicitly opts in on a loopback client — so both are
-      // advertised here so the protected-resource and AS metadata agree.
+      // grants "agent" (single inbox) or "account" (workspace admin) when the
+      // user opts in on an account-eligible client (loopback or https — see the
+      // backend's accountEligibleRedirect). Both are advertised so a
+      // spec-compliant client requests the full menu and the protected-resource
+      // and AS metadata agree.
       scopes_supported: ["agent", "account"],
       bearer_methods_supported: ["header"],
     });

--- a/web/src/app/oauth/consent/page.test.tsx
+++ b/web/src/app/oauth/consent/page.test.tsx
@@ -70,13 +70,17 @@ function mockClientAndAgents(opts: {
   accountEligible?: boolean;
 }) {
   const clientStatus = opts.clientStatus ?? 200;
-  const accountEligible = opts.accountEligible ?? true;
+  // Default to an account-INELIGIBLE client so the agent/inbox-picker path is
+  // the default UX under test. Account-eligible clients now default the scope
+  // picker to "account" (which hides the inbox picker), so tests exercising the
+  // inbox picker opt out of eligibility; the scope-picker tests opt in.
+  // redirect_uris always match VALID_QS's loopback redirect to avoid the
+  // redirect-mismatch banner; the UI honors the account_eligible field directly.
+  const accountEligible = opts.accountEligible ?? false;
   const clientBody = opts.clientBody ?? {
     client_id: "mcp_abc123",
     client_name: "Test MCP Client",
-    redirect_uris: accountEligible
-      ? ["http://localhost:8765/cb"]
-      : ["https://app.example.com/cb"],
+    redirect_uris: ["http://localhost:8765/cb"],
     scopes: accountEligible ? ["agent", "account"] : ["agent"],
     client_id_issued_at: 1700000000,
     account_eligible: accountEligible,
@@ -318,7 +322,7 @@ describe("ConsentPage", () => {
     expect(resource.value).toBe("https://api.e2a.dev");
   });
 
-  test("scope picker offers Agent (default) + Account; Account selectable on a loopback (account_eligible) client", async () => {
+  test("scope picker defaults to Account on an account_eligible client; both radios present; switching to Agent reveals the inbox picker", async () => {
     __setSearchParams(VALID_QS);
     mockClientAndAgents({ agents: [], accountEligible: true });
     render(<ConsentPage />);
@@ -327,11 +331,18 @@ describe("ConsentPage", () => {
     });
     const agentRadio = screen.getByRole("radio", { name: /act as one inbox/i }) as HTMLInputElement;
     const accountRadio = screen.getByRole("radio", { name: /full workspace admin/i }) as HTMLInputElement;
-    expect(agentRadio.checked).toBe(true); // least-privilege default
-    expect(agentRadio.name).toBe("scope_choice");
+    // Account is the default when the client is eligible.
+    expect(accountRadio.checked).toBe(true);
+    expect(agentRadio.checked).toBe(false);
+    expect(agentRadio.disabled).toBe(false);
     expect(accountRadio.disabled).toBe(false);
-    expect(accountRadio.value).toBe("account");
     expect(accountRadio.name).toBe("scope_choice");
+    expect(agentRadio.name).toBe("scope_choice");
+    // Account isn't inbox-bound, so the inbox picker is hidden until the user
+    // switches to Agent.
+    expect(screen.queryByRole("radio", { name: /Create a new inbox/i })).not.toBeInTheDocument();
+    await userEvent.click(agentRadio);
+    expect(screen.getByRole("radio", { name: /Create a new inbox/i })).toBeInTheDocument();
   });
 
   test("Account scope is disabled (with a loopback reason) when account_eligible is false", async () => {
@@ -355,22 +366,27 @@ describe("ConsentPage", () => {
     });
     const accountRadio = screen.getByRole("radio", { name: /full workspace admin/i }) as HTMLInputElement;
     expect(accountRadio.disabled).toBe(true);
-    expect(screen.getByText(/only offered to local tools/i)).toBeInTheDocument();
+    expect(screen.getByText(/isn't registered for account scope/i)).toBeInTheDocument();
   });
 
-  test("selecting Account hides the inbox picker (scope_choice=account is what submits)", async () => {
+  test("scope toggle: Account (default) hides the inbox picker, Agent reveals it, and it round-trips", async () => {
     __setSearchParams(VALID_QS);
     mockClientAndAgents({ agents: [], accountEligible: true });
     render(<ConsentPage />);
     await waitFor(() => {
       expect(screen.getByRole("heading", { name: /Authorize Test MCP Client/i })).toBeInTheDocument();
     });
-    // Agent default → inbox picker present.
-    expect(screen.getByText(/Choose an inbox/i)).toBeInTheDocument();
+    const agentRadio = screen.getByRole("radio", { name: /act as one inbox/i }) as HTMLInputElement;
     const accountRadio = screen.getByRole("radio", { name: /full workspace admin/i }) as HTMLInputElement;
+    // Account is the default → inbox picker hidden (account isn't inbox-bound).
+    expect(accountRadio.checked).toBe(true);
+    expect(screen.queryByText(/Choose an inbox/i)).not.toBeInTheDocument();
+    // Agent → inbox picker appears.
+    await userEvent.click(agentRadio);
+    expect(screen.getByText(/Choose an inbox/i)).toBeInTheDocument();
+    // Back to Account → hidden again.
     await userEvent.click(accountRadio);
     expect(accountRadio.checked).toBe(true);
-    // Account → inbox picker gone (account isn't inbox-bound).
     expect(screen.queryByText(/Choose an inbox/i)).not.toBeInTheDocument();
   });
 });

--- a/web/src/app/oauth/consent/page.tsx
+++ b/web/src/app/oauth/consent/page.tsx
@@ -371,13 +371,8 @@ function ConsentForm({
               </span>
               {!accountEligible && (
                 <span className="block text-xs mt-0.5" style={{ color: "var(--danger-strong)" }}>
-                  Unavailable: this client isn&apos;t registered for account scope.
-                  {inboundRedirect !== "" && (
-                    <>
-                      {" "}This client&apos;s redirect is{" "}
-                      <span className="font-mono break-all">{inboundRedirect}</span>.
-                    </>
-                  )}
+                  Unavailable: this client isn&apos;t registered for account
+                  scope.
                 </span>
               )}
             </span>

--- a/web/src/app/oauth/consent/page.tsx
+++ b/web/src/app/oauth/consent/page.tsx
@@ -256,10 +256,14 @@ function ConsentForm({
   const defaultSlug = useMemo(() => deriveDefaultSlug(client.client_name), [client.client_name]);
   const [slug, setSlug] = useState<string>(defaultSlug);
 
-  // Scope the user is granting. Default to the least-privilege "agent". The
-  // backend re-validates the loopback gate on "account", so this is UX.
-  const [scopeChoice, setScopeChoice] = useState<"agent" | "account">("agent");
+  // Scope the user is granting. Default to "account" (full workspace admin)
+  // whenever this client is account-eligible, else the least-privilege
+  // "agent". The backend re-validates account eligibility server-side, so
+  // this is UX only.
   const accountEligible = client.account_eligible;
+  const [scopeChoice, setScopeChoice] = useState<"agent" | "account">(
+    accountEligible ? "account" : "agent",
+  );
   const pickingAccount = scopeChoice === "account";
 
   const creating = agentChoice === "create_new";
@@ -363,12 +367,11 @@ function ConsentForm({
               <span className="block text-xs text-muted">
                 Everything Agent can do, plus: create/delete inboxes, manage
                 domains &amp; webhooks, mint API keys, resolve reviews, and
-                account settings. Grant only to tools you run yourself.
+                account settings. Grant only to clients you fully trust.
               </span>
               {!accountEligible && (
                 <span className="block text-xs mt-0.5" style={{ color: "var(--danger-strong)" }}>
-                  Unavailable: account scope is only offered to local tools whose
-                  redirect URL is loopback (http://localhost).
+                  Unavailable: this client isn&apos;t registered for account scope.
                   {inboundRedirect !== "" && (
                     <>
                       {" "}This client&apos;s redirect is{" "}


### PR DESCRIPTION
## Summary

Fixes the Claude custom-connector failure **"Couldn't register with e2a's sign-in service"** (`ofid_…`, which is an Anthropic-side reference, not e2a).

**Root cause (confirmed live + against the MCP spec / [Anthropic connector docs](https://claude.com/docs/connectors/building/authentication)):** e2a's `401` `WWW-Authenticate` header carries no `scope` param, so Claude requests the whole `scopes_supported` menu (`agent account`). DCR then hard-`400`'d `account` because Claude's redirect is `https://` (non-loopback) — failing for **every** user regardless of IP. Not rate-limiting.

**Owner decision** (chosen deliberately over a narrower allowlist): allow `account` (full workspace admin) on **any https redirect**, not just loopback, and **default the consent scope picker to account** when the client is account-eligible — so hosted connectors (Claude Chat/Cowork, redirect `https://claude.ai/api/mcp/auth_callback`) can hold admin.

What changed:
- `accountEligibleRedirect()` — the account gate is now loopback **or** https, applied at all three enforcement points (DCR ceiling, `account_eligible` metadata, consent authorize gate).
- **DCR narrows instead of rejecting** (RFC 7591 §3.2.1): registered ceiling = requested ∩ eligible, unknown scopes dropped, `agent` floor. Omitting scope → full eligible ceiling (Claude's case); an explicit `agent`-only request is **honored, not widened**.
- `account_eligible` now reflects the **registered scopes column**, not the raw redirect, so the UI never offers a radio fosite would reject with `invalid_scope`.
- Consent screen defaults to Account when eligible; stale "loopback-only" copy fixed.

## Client surface checklist

This is the `/oauth2/*` + `/.well-known/*` auth surface (internal/agent + web consent + MCP protected-resource metadata), **not** the Huma `/v1` API — so no OpenAPI/SDK/CLI regen applies.

- [x] Go handler + tests (`internal/agent/oauth_handlers.go`, `api.go`)
- [ ] ~~Migration~~ — none (no schema change; uses existing `oauth_clients.scopes`)
- [ ] ~~OpenAPI / TS SDK / Python SDK / CLI~~ — N/A, not a `/v1` surface
- [x] MCP — protected-resource metadata comment only (`scopes_supported` unchanged)
- [x] Web consent screen + tests
- [x] Tests at each surface (positive + negative/regression)

## Operational risk

**Auth / privilege change.** Any https MCP connector a user consents to can now obtain full e2a workspace admin (create/delete inboxes, manage domains & webhooks, mint API keys, resolve reviews), with admin **pre-selected** on the consent screen. Mitigations: fosite exact-matches `redirect_uris` so auth codes can't be diverted; consent remains mandatory and grants nothing autonomously; an explicit least-privilege (`agent`-only) DCR request is honored. No migration, no flag — behavior changes on deploy to `api.e2a.dev`. Rollback = revert.

## Test plan

- [x] `go test ./internal/agent/` (full package green; new `TestHTTP_Consent_Account_Https_Allowed` drives consent→token→whoami=account end-to-end, `TestAccountEligibleRedirect`, `TestHTTP_Register_HonorsExplicitAgentOnly`)
- [x] `npx jest` web consent (11/11), `eslint` clean, MCP `tsc` clean
- [ ] After deploy: reconnect the e2a custom connector in Claude and confirm it registers + grants account

🤖 Generated with [Claude Code](https://claude.com/claude-code)