### PR TITLE
test(conformance): P2 real-path — webhook-event emission + domain lifecycle

### DIFF
--- a/tests/e2e-prod/suites/21-webhook-events.test.ts
+++ b/tests/e2e-prod/suites/21-webhook-events.test.ts
@@ -9,15 +9,19 @@ import { writeReport, info } from "../harness/report.ts";
 // with the events log ON, prod runs it OFF (list_events → events_log_disabled on
 // prod). So this suite ONLY makes sense against staging.
 //
-// Emission is proved two independent ways for every event type:
-//   1. listEvents  (GET /v1/events, filtered type + agent_id + since) — the event
-//      row landed in the outbox/log.
-//   2. listWebhookDeliveries (GET /v1/webhooks/{id}/deliveries) — the event was
-//      fanned out to a subscriber and an HTTP delivery was ATTEMPTED for that
-//      event_type. We assert attempts>=1, NOT delivery success: staging has no
-//      real webhook sink, so the dummy target (example.com) 405s the POST. A 405
-//      (or any last_status_code) still proves the delivery leg ran — which is the
-//      emission signal. Requiring a 2xx would test the sink, not e2a.
+// Emission is proved for every event type across THREE correlated signals:
+//   1. listEvents (GET /v1/events, filtered type + agent_id + since) — THIS
+//      message's event row landed in the outbox/log (correlated by message_id).
+//   2. the event's OWN delivery_status.matched_webhooks (GET /v1/events/{id}) —
+//      EVENT-scoped proof THIS event fanned out to >=1 subscriber.
+//   3. listWebhookDeliveries (GET /v1/webhooks/{id}/deliveries) — WEBHOOK-scoped
+//      proof that OUR fresh webhook's HTTP delivery leg was ATTEMPTED. We assert
+//      attempts>=1, NOT delivery success: staging has no real webhook sink, so the
+//      dummy target (example.com) 405s the POST. A 405 (or any last_status_code)
+//      still proves the delivery leg ran; requiring a 2xx would test the sink, not
+//      e2a. (2) and (3) are complementary — (2) is event-scoped but counts every
+//      matching webhook; (3) is webhook-scoped but attempt-level — together they
+//      close both the cross-suite and the "did the delivery worker run" gaps.
 //
 // Shapes/status verified against api/openapi.yaml (the drift-gated SSOT) AND
 // curl-probed on live staging before these assertions were written (2026-07-10):
@@ -220,11 +224,17 @@ async function pollDelivery(
 }
 
 // pollEventFanout: GET the specific event and poll until its OWN delivery_status
-// shows it fanned out to >=1 subscriber. Message-scoped — the server counts
-// webhook_subscriber_deliveries WHERE event_id = THIS event — so, unlike the
-// account-wide deliveries list (pollDelivery), it CANNOT be satisfied by another
-// concurrently-running suite's same-typed delivery under `node --test` file
-// parallelism. This is the correlated proof that THIS event was fanned out.
+// shows it fanned out to >=1 subscriber. EVENT-scoped — the server counts
+// webhook_subscriber_deliveries WHERE event_id = THIS (globally unique) event, so
+// it proves THIS message's event fanned out and can't be satisfied by another
+// suite's same-typed event. Caveat: it counts ALL matching webhooks in the account,
+// not just ours, and the rows are inserted as status=pending (attempts=0) at
+// ENQUEUE — so this alone proves neither "our webhook was matched" nor "a delivery
+// attempt ran". Each emit test therefore ALSO asserts pollDelivery(hook.id) with
+// attempts>=1: that endpoint is scoped to our fresh per-test webhook (ownership-
+// checked, webhook-id path param) and only advances attempts once the HTTP leg
+// fires. The pair — event-scoped fanout + webhook-scoped attempt — is what closes
+// both the cross-suite and the "did the delivery worker actually run" gaps.
 async function pollEventFanout(
   eventId: string,
   timeoutMs = 15000,
@@ -282,9 +292,16 @@ test("emit: email.sent — real send emits the event and attempts a delivery", {
     assert.ok(ev, `email.sent event for ${messageId} must appear in listEvents within 15s`);
     assertEventShape(ev!, { type: "email.sent", agentId: email, messageId });
 
+    // Event-scoped: THIS event fanned out to >=1 subscriber (matched_webhooks
+    // counts webhook_subscriber_deliveries WHERE event_id = this unique event).
     const fanout = await pollEventFanout(ev!.id);
-    assert.ok(fanout, `event ${ev!.id} must fan out to the subscribed webhook (matched_webhooks>=1) within 15s`);
-    info(SUITE, "email.sent", `emitted evt=${ev!.id} fanned to ${fanout!.matched_webhooks} webhook(s) (delivered=${fanout!.delivered ?? 0} pending=${fanout!.pending ?? 0} failed=${fanout!.failed ?? 0})`);
+    assert.ok(fanout, `event ${ev!.id} must fan out (matched_webhooks>=1) within 15s`);
+    // Webhook-scoped: OUR fresh webhook's delivery leg actually RAN. The example.com
+    // sink 405s the POST — attempts>=1 proves the leg fired (not delivery success).
+    const del = await pollDelivery(hook.id, "email.sent");
+    assert.ok(del, `a delivery ATTEMPT for email.sent must appear on webhook ${hook.id}`);
+    assert.ok(del!.attempts >= 1, `delivery attempted (attempts=${del!.attempts})`);
+    info(SUITE, "email.sent", `emitted evt=${ev!.id} fanned to ${fanout!.matched_webhooks} webhook(s); our webhook whd=${del!.id} attempts=${del!.attempts} last_status=${del!.last_status_code}`);
   } finally {
     await delHook(hook.id);
     await delAgent(email);
@@ -315,8 +332,11 @@ test("emit: email.pending_review — held send emits the event and attempts a de
     assert.equal(ev!.data.direction, "outbound", "pending_review payload carries direction=outbound");
 
     const fanout = await pollEventFanout(ev!.id);
-    assert.ok(fanout, `event ${ev!.id} must fan out to the subscribed webhook (matched_webhooks>=1) within 15s`);
-    info(SUITE, "email.pending_review", `emitted evt=${ev!.id} fanned to ${fanout!.matched_webhooks} webhook(s) (pending=${fanout!.pending ?? 0} failed=${fanout!.failed ?? 0})`);
+    assert.ok(fanout, `event ${ev!.id} must fan out (matched_webhooks>=1) within 15s`);
+    const del = await pollDelivery(hook.id, "email.pending_review");
+    assert.ok(del, `a delivery ATTEMPT for email.pending_review must appear on webhook ${hook.id}`);
+    assert.ok(del!.attempts >= 1, `delivery attempted (attempts=${del!.attempts})`);
+    info(SUITE, "email.pending_review", `emitted evt=${ev!.id} fanned to ${fanout!.matched_webhooks} webhook(s); our webhook whd=${del!.id} attempts=${del!.attempts}`);
   } finally {
     // Resolve the hold explicitly (reject), then delete (delete cascades anyway).
     if (heldId) await client.post(`/v1/reviews/${heldId}/reject`, { body: { reason: "e2e pending-emit cleanup" } });
@@ -352,8 +372,11 @@ test("emit: email.review_rejected — rejecting a hold emits the event and attem
     assert.equal(ev!.data.rejection_reason, reason, "payload echoes the rejection reason");
 
     const fanout = await pollEventFanout(ev!.id);
-    assert.ok(fanout, `event ${ev!.id} must fan out to the subscribed webhook (matched_webhooks>=1) within 15s`);
-    info(SUITE, "email.review_rejected", `emitted evt=${ev!.id} fanned to ${fanout!.matched_webhooks} webhook(s) (pending=${fanout!.pending ?? 0} failed=${fanout!.failed ?? 0})`);
+    assert.ok(fanout, `event ${ev!.id} must fan out (matched_webhooks>=1) within 15s`);
+    const del = await pollDelivery(hook.id, "email.review_rejected");
+    assert.ok(del, `a delivery ATTEMPT for email.review_rejected must appear on webhook ${hook.id}`);
+    assert.ok(del!.attempts >= 1, `delivery attempted (attempts=${del!.attempts})`);
+    info(SUITE, "email.review_rejected", `emitted evt=${ev!.id} fanned to ${fanout!.matched_webhooks} webhook(s); our webhook whd=${del!.id} attempts=${del!.attempts}`);
   } finally {
     await delHook(hook.id);
     await delAgent(email);
@@ -389,8 +412,11 @@ test("emit: email.review_approved — approving a hold (to the simulator) emits 
     assert.equal(ev!.data.direction, "outbound", "review_approved payload carries direction=outbound");
 
     const fanout = await pollEventFanout(ev!.id);
-    assert.ok(fanout, `event ${ev!.id} must fan out to the subscribed webhook (matched_webhooks>=1) within 15s`);
-    info(SUITE, "email.review_approved", `emitted evt=${ev!.id} fanned to ${fanout!.matched_webhooks} webhook(s) (delivered=${fanout!.delivered ?? 0} pending=${fanout!.pending ?? 0} failed=${fanout!.failed ?? 0})`);
+    assert.ok(fanout, `event ${ev!.id} must fan out (matched_webhooks>=1) within 15s`);
+    const del = await pollDelivery(hook.id, "email.review_approved");
+    assert.ok(del, `a delivery ATTEMPT for email.review_approved must appear on webhook ${hook.id}`);
+    assert.ok(del!.attempts >= 1, `delivery attempted (attempts=${del!.attempts})`);
+    info(SUITE, "email.review_approved", `emitted evt=${ev!.id} fanned to ${fanout!.matched_webhooks} webhook(s); our webhook whd=${del!.id} attempts=${del!.attempts}`);
   } finally {
     // If approve didn't resolve the hold, reject it so nothing lingers.
     if (heldId && !resolved) {

--- a/tests/e2e-prod/suites/21-webhook-events.test.ts
+++ b/tests/e2e-prod/suites/21-webhook-events.test.ts
@@ -1,0 +1,515 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { uniqueSlug, uniqueSubject, holdAllOutbound } from "../harness/fixtures.ts";
+import { writeReport, info } from "../harness/report.ts";
+
+// Black-box conformance for REAL webhook-event EMISSION against LIVE staging.
+// This is the P2 gap the prod e2e suite structurally cannot cover: staging runs
+// with the events log ON, prod runs it OFF (list_events → events_log_disabled on
+// prod). So this suite ONLY makes sense against staging.
+//
+// Emission is proved two independent ways for every event type:
+//   1. listEvents  (GET /v1/events, filtered type + agent_id + since) — the event
+//      row landed in the outbox/log.
+//   2. listWebhookDeliveries (GET /v1/webhooks/{id}/deliveries) — the event was
+//      fanned out to a subscriber and an HTTP delivery was ATTEMPTED for that
+//      event_type. We assert attempts>=1, NOT delivery success: staging has no
+//      real webhook sink, so the dummy target (example.com) 405s the POST. A 405
+//      (or any last_status_code) still proves the delivery leg ran — which is the
+//      emission signal. Requiring a 2xx would test the sink, not e2a.
+//
+// Shapes/status verified against api/openapi.yaml (the drift-gated SSOT) AND
+// curl-probed on live staging before these assertions were written (2026-07-10):
+//   EventJSON     required {id,type,schema_version,created_at,status,data};
+//                 optional agent_id, conversation_id, message_id, delivery_status.
+//   PageEventJSON {items, next_cursor:string|null}.
+//   RedeliverView required {event_id,status}; single-webhook replay also carries
+//                 top-level delivery_id + webhook_id (status "pending"); bulk
+//                 fan-out carries deliveries[] (status "scheduled").
+//   WebhookDeliveryView required {id,event_type,status,attempts,next_retry_at,created_at}.
+//
+// Event types covered (HTTP-triggerable, per internal/webhookpub/event.go):
+//   email.sent            — real send (no hold) to the SES simulator (SES 200).
+//   email.pending_review  — hold-all-outbound BEFORE send → 202 pending_review.
+//   email.review_rejected — reject a held message (clean; no send).
+//   email.review_approved — approve a held message addressed to the simulator
+//                           (approve→send succeeds; a non-simulator recipient
+//                           500s on staging's SES sandbox).
+//
+// Event types SKIPPED with reasons (not HTTP-triggerable on staging here):
+//   email.received  — needs a real inbound SMTP delivery; that is the prober's
+//                     dedicated round-trip, not an API-driven trigger.
+//   email.blocked   — needs a screening `block` gate/scan config to refuse a
+//                     message; out of scope for the emission battery.
+//   email.delivered/bounced/complained — async SES delivery-feedback, arrives via
+//                     SNS on an unbounded timeline (and the simulator's feedback
+//                     is not deterministic within a test window).
+//   email.failed/deferred — terminal/transient async-send outcomes; only the
+//                     primary signal under E2A_OUTBOUND_MODE=async.
+//   domain.sending_verified/failed, domain.suppression_added — need real
+//                     sending-identity provisioning against a custom domain.
+//
+// Ops exercised: listEvents (envelope + filters), getEvent (+404), redeliverEvent
+// (re-queues a delivery; a new attempt appears). Every agent + webhook created is
+// deleted inline in a finally (agent delete cascades to held messages; we also
+// resolve holds explicitly). The shared cleanup harness is not used (it only
+// tracks agents), and per the task the harness/ is never edited.
+const SUITE = "21-webhook-events";
+const client = new ApiClient();
+
+// Real, deliverable recipient: SES accepts + 200s it and drops it (no real
+// mailbox), so email.sent / review_approved actually reach the "sent" state.
+const SIMULATOR = "success@simulator.amazonses.com";
+
+interface EventJSON {
+  id: string;
+  type: string;
+  schema_version: number;
+  created_at: string;
+  status: string;
+  data: Record<string, unknown>;
+  agent_id?: string;
+  conversation_id?: string;
+  message_id?: string;
+  delivery_status?: { matched_webhooks?: number; delivered?: number; pending?: number; failed?: number };
+}
+interface PageEventJSON {
+  items: EventJSON[];
+  next_cursor: string | null;
+}
+interface WebhookDeliveryView {
+  id: string;
+  event_type: string;
+  status: string;
+  attempts: number;
+  next_retry_at: string;
+  created_at: string;
+  last_status_code?: number;
+  last_error?: string;
+  last_attempt_at?: string;
+}
+interface PageWebhookDeliveryView {
+  items: WebhookDeliveryView[];
+  next_cursor: string | null;
+}
+interface CreateWebhookResponse {
+  id: string;
+  url: string;
+  events: string[];
+  enabled: boolean;
+  signing_secret: string;
+}
+interface RedeliverView {
+  event_id: string;
+  status: string;
+  delivery_id?: string;
+  webhook_id?: string;
+  deliveries?: Array<{ webhook_id?: string; delivery_id?: string; status?: string }>;
+}
+interface SendResult {
+  status?: string;
+  message_id?: string;
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function createAgent(label: string, hold = false): Promise<string> {
+  const slug = uniqueSlug(label);
+  const c = await client.post<{ email: string }>("/v1/agents", {
+    body: { email: `${slug}@${client.env.sharedDomain}`, name: `events ${label}` },
+  });
+  if (c.status !== 201 || !c.body?.email) {
+    throw new Error(`create agent failed: ${c.status} ${c.raw.slice(0, 200)}`);
+  }
+  const email = c.body.email;
+  if (hold) {
+    const u = await holdAllOutbound(client, email);
+    if (u.status !== 200) {
+      await delAgent(email);
+      throw new Error(`hold-all-outbound failed: ${u.status} ${u.raw.slice(0, 200)}`);
+    }
+  }
+  return email;
+}
+
+async function createHook(events: string[]): Promise<CreateWebhookResponse> {
+  const r = await client.post<CreateWebhookResponse>("/v1/webhooks", {
+    // Dummy HTTPS target: passes the create-time HTTPS/SSRF guard, then 405s the
+    // POST at delivery time — proving the delivery ATTEMPT without a real sink.
+    body: { url: "https://example.com/e2e-webhook-events", events, description: `e2e ${uniqueSlug("whev")}` },
+  });
+  assert.equal(r.status, 201, `create webhook expected 201, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  assert.ok(r.body?.id?.startsWith("wh_"), `webhook id has wh_ prefix: ${r.body?.id}`);
+  return r.body!;
+}
+
+async function delAgent(email: string): Promise<void> {
+  await client.delete(`/v1/agents/${encodeURIComponent(email)}?confirm=DELETE`);
+}
+async function delHook(id: string): Promise<void> {
+  await client.delete(`/v1/webhooks/${encodeURIComponent(id)}`);
+}
+
+// pollEvent: poll listEvents (filtered type+agent_id+since) until an event
+// matching `match` appears, or the bounded window elapses. Backoff 500ms→3s.
+async function pollEvent(
+  params: { type: string; agentId: string; since: string },
+  match: (e: EventJSON) => boolean,
+  timeoutMs = 15000,
+): Promise<EventJSON | null> {
+  const deadline = Date.now() + timeoutMs;
+  let delay = 500;
+  while (Date.now() < deadline) {
+    const r = await client.get<PageEventJSON>("/v1/events", {
+      query: { type: params.type, agent_id: params.agentId, since: params.since, limit: 50 },
+    });
+    if (r.status === 200 && r.body?.items) {
+      const found = r.body.items.find(match);
+      if (found) return found;
+    }
+    await sleep(delay);
+    delay = Math.min(Math.floor(delay * 1.5), 3000);
+  }
+  return null;
+}
+
+// pollDelivery: poll a webhook's deliveries until one for `eventType` with
+// attempts>=1 appears (proving a delivery leg ran for that event). Optionally
+// require a specific delivery id (used by the redeliver test).
+async function pollDelivery(
+  webhookId: string,
+  eventType: string,
+  opts: { deliveryId?: string } = {},
+  timeoutMs = 15000,
+): Promise<WebhookDeliveryView | null> {
+  const deadline = Date.now() + timeoutMs;
+  let delay = 500;
+  while (Date.now() < deadline) {
+    const r = await client.get<PageWebhookDeliveryView>(`/v1/webhooks/${webhookId}/deliveries`);
+    if (r.status === 200 && r.body?.items) {
+      const found = r.body.items.find(
+        (d) => d.event_type === eventType && d.attempts >= 1 && (!opts.deliveryId || d.id === opts.deliveryId),
+      );
+      if (found) return found;
+    }
+    await sleep(delay);
+    delay = Math.min(Math.floor(delay * 1.5), 3000);
+  }
+  return null;
+}
+
+function assertEventShape(e: EventJSON, expect: { type: string; agentId: string; messageId?: string }): void {
+  // EventJSON required fields (openapi): id,type,schema_version,created_at,status,data.
+  assert.ok(typeof e.id === "string" && e.id.startsWith("evt_"), `event id has evt_ prefix: ${e.id}`);
+  assert.equal(e.type, expect.type, "event.type matches the triggered type");
+  assert.ok(typeof e.schema_version === "number" && e.schema_version >= 1, "schema_version is a positive integer");
+  assert.ok(typeof e.created_at === "string" && e.created_at.length > 0, "created_at present");
+  assert.ok(typeof e.status === "string" && e.status.length > 0, "status present");
+  assert.ok(e.data && typeof e.data === "object", "data object present");
+  // agent_id is optional in the schema but populated for these agent-scoped events.
+  assert.equal(e.agent_id, expect.agentId, "event.agent_id is the triggering inbox");
+  if (expect.messageId) {
+    // Correlate to the triggering message: top-level message_id (populated on
+    // staging) OR data.message_id (always present in the payload).
+    const dataMsg = e.data.message_id;
+    assert.ok(
+      e.message_id === expect.messageId || dataMsg === expect.messageId,
+      `event correlates to message ${expect.messageId} (top-level=${e.message_id} data=${String(dataMsg)})`,
+    );
+  }
+}
+
+// ---- email.sent: a REAL send (no hold) to the SES simulator ----
+test("emit: email.sent — real send emits the event and attempts a delivery", async () => {
+  const email = await createAgent("sent");
+  const hook = await createHook(["email.sent"]);
+  const since = new Date().toISOString();
+  try {
+    const send = await client.post<SendResult>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
+      body: { to: [SIMULATOR], subject: uniqueSubject("emit sent"), body: "real send to SES simulator" },
+    });
+    assert.equal(send.status, 200, `real send expected 200 sent, got ${send.status}: ${send.raw.slice(0, 200)}`);
+    assert.equal(send.body?.status, "sent", "no-hold agent sends immediately");
+    const messageId = send.body!.message_id!;
+    assert.ok(messageId?.startsWith("msg_"), "send returns a msg_ id");
+
+    const ev = await pollEvent({ type: "email.sent", agentId: email, since }, (e) =>
+      e.message_id === messageId || e.data.message_id === messageId,
+    );
+    assert.ok(ev, `email.sent event for ${messageId} must appear in listEvents within 15s`);
+    assertEventShape(ev!, { type: "email.sent", agentId: email, messageId });
+
+    const del = await pollDelivery(hook.id, "email.sent");
+    assert.ok(del, `a delivery ATTEMPT (attempts>=1) for email.sent must appear on webhook ${hook.id}`);
+    assert.ok(del!.attempts >= 1, `delivery attempted (attempts=${del!.attempts})`);
+    info(SUITE, "email.sent", `emitted evt=${ev!.id}, delivery whd=${del!.id} attempts=${del!.attempts} last_status=${del!.last_status_code} (405 = no real sink, delivery leg ran)`);
+  } finally {
+    await delHook(hook.id);
+    await delAgent(email);
+  }
+});
+
+// ---- email.pending_review: hold-all-outbound BEFORE send → 202 ----
+test("emit: email.pending_review — held send emits the event and attempts a delivery", async () => {
+  const email = await createAgent("pending", true);
+  const hook = await createHook(["email.pending_review"]);
+  const since = new Date().toISOString();
+  let heldId: string | null = null;
+  try {
+    const send = await client.post<SendResult>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
+      body: { to: [SIMULATOR], subject: uniqueSubject("emit pending"), body: "held for review" },
+    });
+    assert.equal(send.status, 202, `held send expected 202 pending_review, got ${send.status}: ${send.raw.slice(0, 200)}`);
+    assert.equal(send.body?.status, "pending_review", "gated send is held");
+    heldId = send.body!.message_id!;
+    assert.ok(heldId?.startsWith("msg_"), "held send returns a msg_ id");
+
+    const ev = await pollEvent({ type: "email.pending_review", agentId: email, since }, (e) =>
+      e.message_id === heldId || e.data.message_id === heldId,
+    );
+    assert.ok(ev, `email.pending_review event for ${heldId} must appear within 15s`);
+    assertEventShape(ev!, { type: "email.pending_review", agentId: email, messageId: heldId! });
+    // Payload is direction-aware (outbound HITL hold).
+    assert.equal(ev!.data.direction, "outbound", "pending_review payload carries direction=outbound");
+
+    const del = await pollDelivery(hook.id, "email.pending_review");
+    assert.ok(del, `a delivery ATTEMPT for email.pending_review must appear on webhook ${hook.id}`);
+    assert.ok(del!.attempts >= 1, `delivery attempted (attempts=${del!.attempts})`);
+    info(SUITE, "email.pending_review", `emitted evt=${ev!.id}, delivery whd=${del!.id} attempts=${del!.attempts}`);
+  } finally {
+    // Resolve the hold explicitly (reject), then delete (delete cascades anyway).
+    if (heldId) await client.post(`/v1/reviews/${heldId}/reject`, { body: { reason: "e2e pending-emit cleanup" } });
+    await delHook(hook.id);
+    await delAgent(email);
+  }
+});
+
+// ---- email.review_rejected: reject a held message (no send) ----
+test("emit: email.review_rejected — rejecting a hold emits the event and attempts a delivery", async () => {
+  const email = await createAgent("reject", true);
+  const hook = await createHook(["email.review_rejected"]);
+  const since = new Date().toISOString();
+  try {
+    const send = await client.post<SendResult>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
+      body: { to: [SIMULATOR], subject: uniqueSubject("emit reject"), body: "will be rejected" },
+    });
+    assert.equal(send.status, 202, `held send expected 202, got ${send.status}: ${send.raw.slice(0, 200)}`);
+    const heldId = send.body!.message_id!;
+
+    const reason = "e2e review_rejected emission";
+    const rej = await client.post<{ status?: string; message_id?: string }>(`/v1/reviews/${heldId}/reject`, {
+      body: { reason },
+    });
+    assert.equal(rej.status, 200, `reject expected 200, got ${rej.status}: ${rej.raw.slice(0, 200)}`);
+    assert.equal(rej.body?.status, "review_rejected", "reject transitions to review_rejected");
+
+    const ev = await pollEvent({ type: "email.review_rejected", agentId: email, since }, (e) =>
+      e.message_id === heldId || e.data.message_id === heldId,
+    );
+    assert.ok(ev, `email.review_rejected event for ${heldId} must appear within 15s`);
+    assertEventShape(ev!, { type: "email.review_rejected", agentId: email, messageId: heldId });
+    assert.equal(ev!.data.rejection_reason, reason, "payload echoes the rejection reason");
+
+    const del = await pollDelivery(hook.id, "email.review_rejected");
+    assert.ok(del, `a delivery ATTEMPT for email.review_rejected must appear on webhook ${hook.id}`);
+    assert.ok(del!.attempts >= 1, `delivery attempted (attempts=${del!.attempts})`);
+    info(SUITE, "email.review_rejected", `emitted evt=${ev!.id}, delivery whd=${del!.id} attempts=${del!.attempts}`);
+  } finally {
+    await delHook(hook.id);
+    await delAgent(email);
+  }
+});
+
+// ---- email.review_approved: approve a held message addressed to the simulator ----
+test("emit: email.review_approved — approving a hold (to the simulator) emits the event and attempts a delivery", async () => {
+  const email = await createAgent("approve", true);
+  const hook = await createHook(["email.review_approved"]);
+  const since = new Date().toISOString();
+  let heldId: string | null = null;
+  let resolved = false;
+  try {
+    const send = await client.post<SendResult>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
+      // Addressed to the simulator so approve→send actually succeeds on staging's
+      // SES sandbox (a non-simulator/blackhole recipient 500s the send leg).
+      body: { to: [SIMULATOR], subject: uniqueSubject("emit approve"), body: "will be approved + sent" },
+    });
+    assert.equal(send.status, 202, `held send expected 202, got ${send.status}: ${send.raw.slice(0, 200)}`);
+    heldId = send.body!.message_id!;
+
+    const ap = await client.post<SendResult>(`/v1/reviews/${heldId}/approve`, { body: {} });
+    assert.equal(ap.status, 200, `approve→send (to simulator) expected 200, got ${ap.status}: ${ap.raw.slice(0, 200)}`);
+    assert.equal(ap.body?.status, "sent", "approved hold to the simulator sends successfully");
+    resolved = true;
+
+    const ev = await pollEvent({ type: "email.review_approved", agentId: email, since }, (e) =>
+      e.message_id === heldId || e.data.message_id === heldId,
+    );
+    assert.ok(ev, `email.review_approved event for ${heldId} must appear within 15s`);
+    assertEventShape(ev!, { type: "email.review_approved", agentId: email, messageId: heldId! });
+    assert.equal(ev!.data.direction, "outbound", "review_approved payload carries direction=outbound");
+
+    const del = await pollDelivery(hook.id, "email.review_approved");
+    assert.ok(del, `a delivery ATTEMPT for email.review_approved must appear on webhook ${hook.id}`);
+    assert.ok(del!.attempts >= 1, `delivery attempted (attempts=${del!.attempts})`);
+    info(SUITE, "email.review_approved", `emitted evt=${ev!.id}, delivery whd=${del!.id} attempts=${del!.attempts}`);
+  } finally {
+    // If approve didn't resolve the hold, reject it so nothing lingers.
+    if (heldId && !resolved) {
+      await client.post(`/v1/reviews/${heldId}/reject`, { body: { reason: "e2e approve-emit cleanup" } });
+    }
+    await delHook(hook.id);
+    await delAgent(email);
+  }
+});
+
+// ---- Events read API: listEvents envelope + filters ----
+test("events: listEvents returns PageEventJSON envelope and honors type/agent_id/since/limit filters", async () => {
+  const email = await createAgent("list");
+  const hook = await createHook(["email.sent"]);
+  const since = new Date().toISOString();
+  try {
+    const send = await client.post<SendResult>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
+      body: { to: [SIMULATOR], subject: uniqueSubject("emit list"), body: "for listEvents" },
+    });
+    assert.equal(send.status, 200, `real send expected 200, got ${send.status}: ${send.raw.slice(0, 200)}`);
+    const messageId = send.body!.message_id!;
+    // Ensure the event exists before asserting on the filtered list.
+    const seed = await pollEvent({ type: "email.sent", agentId: email, since }, (e) =>
+      e.message_id === messageId || e.data.message_id === messageId,
+    );
+    assert.ok(seed, "seed email.sent event present");
+
+    // Full envelope shape (PageEventJSON: items + next_cursor:string|null, both required).
+    const page = await client.get<PageEventJSON>("/v1/events", { query: { limit: 5 } });
+    assert.equal(page.status, 200, `listEvents expected 200, got ${page.status}`);
+    assert.ok(Array.isArray(page.body?.items), "items is an array");
+    assert.ok(
+      page.body!.next_cursor === null || typeof page.body!.next_cursor === "string",
+      `next_cursor must be present as string|null, got ${JSON.stringify(page.body!.next_cursor)}`,
+    );
+    assert.ok(page.body!.items.length <= 5, "limit=5 clamps the page size");
+
+    // type filter: every returned item is the requested type.
+    const typed = await client.get<PageEventJSON>("/v1/events", {
+      query: { type: "email.sent", agent_id: email, since },
+    });
+    assert.equal(typed.status, 200);
+    assert.ok(typed.body!.items.length >= 1, "type+agent_id+since filter returns the seeded event");
+    for (const e of typed.body!.items) {
+      assert.equal(e.type, "email.sent", "type filter is honored");
+      assert.equal(e.agent_id, email, "agent_id filter is honored");
+    }
+
+    // agent_id filter isolation: a bogus agent_id returns an empty page (not an error).
+    const other = await client.get<PageEventJSON>("/v1/events", {
+      query: { agent_id: `nonexistent-${Date.now()}@${client.env.sharedDomain}`, since },
+    });
+    assert.equal(other.status, 200, "agent_id filter with no matches returns 200");
+    assert.equal(other.body!.items.length, 0, "unknown agent_id yields an empty page");
+
+    // since filter: a future timestamp excludes everything.
+    const future = new Date(Date.now() + 3_600_000).toISOString();
+    const none = await client.get<PageEventJSON>("/v1/events", { query: { agent_id: email, since: future } });
+    assert.equal(none.status, 200);
+    assert.equal(none.body!.items.length, 0, "since=future excludes all events");
+  } finally {
+    await delHook(hook.id);
+    await delAgent(email);
+  }
+});
+
+// ---- Events read API: getEvent (+ 404) ----
+test("events: getEvent returns the EventJSON by evt_ id; nonexistent → 404", async () => {
+  const email = await createAgent("get");
+  const hook = await createHook(["email.sent"]);
+  const since = new Date().toISOString();
+  try {
+    const send = await client.post<SendResult>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
+      body: { to: [SIMULATOR], subject: uniqueSubject("emit get"), body: "for getEvent" },
+    });
+    assert.equal(send.status, 200);
+    const messageId = send.body!.message_id!;
+    const ev = await pollEvent({ type: "email.sent", agentId: email, since }, (e) =>
+      e.message_id === messageId || e.data.message_id === messageId,
+    );
+    assert.ok(ev, "seeded email.sent event present");
+
+    const got = await client.get<EventJSON>(`/v1/events/${ev!.id}`);
+    assert.equal(got.status, 200, `getEvent expected 200, got ${got.status}: ${got.raw.slice(0, 200)}`);
+    assert.equal(got.body?.id, ev!.id, "getEvent echoes the requested id");
+    assertEventShape(got.body!, { type: "email.sent", agentId: email, messageId });
+
+    const miss = await client.get(`/v1/events/evt_nonexistent_${Date.now()}`);
+    assert.equal(miss.status, 404, `getEvent nonexistent expected 404, got ${miss.status}: ${miss.raw.slice(0, 200)}`);
+  } finally {
+    await delHook(hook.id);
+    await delAgent(email);
+  }
+});
+
+// ---- Events read API: redeliverEvent (re-queues a delivery) ----
+test("events: redeliverEvent re-queues a delivery for the event; a new attempt appears", async () => {
+  const email = await createAgent("redeliver");
+  const hook = await createHook(["email.sent"]);
+  const since = new Date().toISOString();
+  try {
+    const send = await client.post<SendResult>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
+      body: { to: [SIMULATOR], subject: uniqueSubject("emit redeliver"), body: "for redeliver" },
+    });
+    assert.equal(send.status, 200);
+    const messageId = send.body!.message_id!;
+    const ev = await pollEvent({ type: "email.sent", agentId: email, since }, (e) =>
+      e.message_id === messageId || e.data.message_id === messageId,
+    );
+    assert.ok(ev, "seeded email.sent event present");
+    // Wait for the original delivery so we can prove redeliver ADDS one.
+    const first = await pollDelivery(hook.id, "email.sent");
+    assert.ok(first, "original email.sent delivery attempt present before redeliver");
+
+    // Single-webhook replay: RedeliverView carries event_id + status + top-level
+    // delivery_id + webhook_id (probed status "pending"). requestBody is required.
+    const rd = await client.post<RedeliverView>(`/v1/events/${ev!.id}/redeliver`, { body: { webhook_id: hook.id } });
+    assert.equal(rd.status, 200, `redeliver expected 200, got ${rd.status}: ${rd.raw.slice(0, 200)}`);
+    assert.equal(rd.body?.event_id, ev!.id, "RedeliverView echoes the event id");
+    assert.ok(typeof rd.body?.status === "string" && rd.body.status.length > 0, "RedeliverView has a status");
+    // Collect the new delivery id(s) from either the single or bulk shape.
+    const newIds = [
+      rd.body?.delivery_id,
+      ...(rd.body?.deliveries ?? []).map((d) => d.delivery_id),
+    ].filter((x): x is string => typeof x === "string" && x.length > 0);
+    assert.ok(newIds.length >= 1, `redeliver returns at least one new delivery id: ${JSON.stringify(rd.body)}`);
+    assert.ok(newIds.includes(first!.id) === false, "redeliver id is distinct from the original delivery");
+
+    // The re-queued delivery must surface in the webhook's deliveries.
+    const requeued = await pollDelivery(hook.id, "email.sent", { deliveryId: newIds[0] });
+    assert.ok(requeued, `re-queued delivery ${newIds[0]} must appear on webhook ${hook.id}`);
+    assert.ok(requeued!.attempts >= 1, `re-queued delivery attempted (attempts=${requeued!.attempts})`);
+    info(SUITE, "redeliverEvent", `event=${ev!.id} original whd=${first!.id} → redelivered whd=${newIds[0]} status=${rd.body?.status}`);
+
+    // Redeliver of a nonexistent event → 404.
+    const miss = await client.post(`/v1/events/evt_nonexistent_${Date.now()}/redeliver`, { body: {} });
+    assert.equal(miss.status, 404, `redeliver nonexistent expected 404, got ${miss.status}: ${miss.raw.slice(0, 200)}`);
+  } finally {
+    await delHook(hook.id);
+    await delAgent(email);
+  }
+});
+
+// ---- Negatives ----
+test("events: unauthenticated listEvents / getEvent → 401", async () => {
+  const list = await client.get("/v1/events", { apiKey: null });
+  assert.equal(list.status, 401, `unauth listEvents expected 401, got ${list.status}`);
+  const get = await client.get(`/v1/events/evt_whatever`, { apiKey: null });
+  assert.equal(get.status, 401, `unauth getEvent expected 401, got ${get.status}`);
+});
+
+// ---- Documented skips for events that can't be HTTP-triggered on staging here ----
+test("emit: email.received — needs real inbound SMTP (prober's round-trip)", { skip: "email.received requires a real inbound SMTP delivery; that is the prober's dedicated job, not an API-driven trigger from this suite" }, () => {});
+test("emit: email.blocked — needs a screening block config", { skip: "email.blocked requires a screening gate/scan `block` action to refuse a message; out of scope for the HTTP emission battery" }, () => {});
+test("emit: email.delivered/bounced/complained — async SES delivery feedback", { skip: "delivery-feedback events arrive async via SES→SNS on an unbounded timeline and are not deterministic within a test window" }, () => {});
+test("emit: domain.sending_verified/failed, domain.suppression_added — need sending-identity provisioning", { skip: "domain.* events require real SES sending-identity provisioning against a custom domain, not available to a throwaway shared-domain agent" }, () => {});
+
+after(async () => {
+  await writeReport(`./reports/${SUITE}.json`);
+});

--- a/tests/e2e-prod/suites/21-webhook-events.test.ts
+++ b/tests/e2e-prod/suites/21-webhook-events.test.ts
@@ -58,6 +58,26 @@ import { writeReport, info } from "../harness/report.ts";
 const SUITE = "21-webhook-events";
 const client = new ApiClient();
 
+// Staging-only: prod runs the events log OFF (list/get/redeliver → 501
+// events_log_disabled), so against a non-staging target we skip the whole suite
+// cleanly rather than hard-fail every test — mirroring siblings 15/22. Probe once
+// at module load (top-level await; the runner waits for module eval to finish).
+let skip: string | false = false;
+try {
+  const eventsProbe = await client.get("/v1/events", { query: { limit: 1 } });
+  if (eventsProbe.status === 501) {
+    skip = "events log disabled on this target (prod); this suite is staging-only";
+  }
+} catch {
+  // Probe couldn't reach the target — do NOT skip. Let the tests run and surface
+  // the real connectivity error rather than masking an outage as a clean skip.
+}
+
+// sinceNow returns a `since` filter with a few seconds of slack, so host/server
+// clock skew (host clock ahead of the server's) can't place `since` after a
+// just-emitted event's server-side created_at and hide it → false RED.
+const sinceNow = () => new Date(Date.now() - 5000).toISOString();
+
 // Real, deliverable recipient: SES accepts + 200s it and drops it (no real
 // mailbox), so email.sent / review_approved actually reach the "sent" state.
 const SIMULATOR = "success@simulator.amazonses.com";
@@ -199,6 +219,28 @@ async function pollDelivery(
   return null;
 }
 
+// pollEventFanout: GET the specific event and poll until its OWN delivery_status
+// shows it fanned out to >=1 subscriber. Message-scoped — the server counts
+// webhook_subscriber_deliveries WHERE event_id = THIS event — so, unlike the
+// account-wide deliveries list (pollDelivery), it CANNOT be satisfied by another
+// concurrently-running suite's same-typed delivery under `node --test` file
+// parallelism. This is the correlated proof that THIS event was fanned out.
+async function pollEventFanout(
+  eventId: string,
+  timeoutMs = 15000,
+): Promise<NonNullable<EventJSON["delivery_status"]> | null> {
+  const deadline = Date.now() + timeoutMs;
+  let delay = 500;
+  while (Date.now() < deadline) {
+    const r = await client.get<EventJSON>(`/v1/events/${eventId}`);
+    const ds = r.body?.delivery_status;
+    if (r.status === 200 && ds && (ds.matched_webhooks ?? 0) >= 1) return ds;
+    await sleep(delay);
+    delay = Math.min(Math.floor(delay * 1.5), 3000);
+  }
+  return null;
+}
+
 function assertEventShape(e: EventJSON, expect: { type: string; agentId: string; messageId?: string }): void {
   // EventJSON required fields (openapi): id,type,schema_version,created_at,status,data.
   assert.ok(typeof e.id === "string" && e.id.startsWith("evt_"), `event id has evt_ prefix: ${e.id}`);
@@ -221,10 +263,10 @@ function assertEventShape(e: EventJSON, expect: { type: string; agentId: string;
 }
 
 // ---- email.sent: a REAL send (no hold) to the SES simulator ----
-test("emit: email.sent — real send emits the event and attempts a delivery", async () => {
+test("emit: email.sent — real send emits the event and attempts a delivery", { skip }, async () => {
   const email = await createAgent("sent");
   const hook = await createHook(["email.sent"]);
-  const since = new Date().toISOString();
+  const since = sinceNow();
   try {
     const send = await client.post<SendResult>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
       body: { to: [SIMULATOR], subject: uniqueSubject("emit sent"), body: "real send to SES simulator" },
@@ -240,10 +282,9 @@ test("emit: email.sent — real send emits the event and attempts a delivery", a
     assert.ok(ev, `email.sent event for ${messageId} must appear in listEvents within 15s`);
     assertEventShape(ev!, { type: "email.sent", agentId: email, messageId });
 
-    const del = await pollDelivery(hook.id, "email.sent");
-    assert.ok(del, `a delivery ATTEMPT (attempts>=1) for email.sent must appear on webhook ${hook.id}`);
-    assert.ok(del!.attempts >= 1, `delivery attempted (attempts=${del!.attempts})`);
-    info(SUITE, "email.sent", `emitted evt=${ev!.id}, delivery whd=${del!.id} attempts=${del!.attempts} last_status=${del!.last_status_code} (405 = no real sink, delivery leg ran)`);
+    const fanout = await pollEventFanout(ev!.id);
+    assert.ok(fanout, `event ${ev!.id} must fan out to the subscribed webhook (matched_webhooks>=1) within 15s`);
+    info(SUITE, "email.sent", `emitted evt=${ev!.id} fanned to ${fanout!.matched_webhooks} webhook(s) (delivered=${fanout!.delivered ?? 0} pending=${fanout!.pending ?? 0} failed=${fanout!.failed ?? 0})`);
   } finally {
     await delHook(hook.id);
     await delAgent(email);
@@ -251,10 +292,10 @@ test("emit: email.sent — real send emits the event and attempts a delivery", a
 });
 
 // ---- email.pending_review: hold-all-outbound BEFORE send → 202 ----
-test("emit: email.pending_review — held send emits the event and attempts a delivery", async () => {
+test("emit: email.pending_review — held send emits the event and attempts a delivery", { skip }, async () => {
   const email = await createAgent("pending", true);
   const hook = await createHook(["email.pending_review"]);
-  const since = new Date().toISOString();
+  const since = sinceNow();
   let heldId: string | null = null;
   try {
     const send = await client.post<SendResult>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
@@ -273,10 +314,9 @@ test("emit: email.pending_review — held send emits the event and attempts a de
     // Payload is direction-aware (outbound HITL hold).
     assert.equal(ev!.data.direction, "outbound", "pending_review payload carries direction=outbound");
 
-    const del = await pollDelivery(hook.id, "email.pending_review");
-    assert.ok(del, `a delivery ATTEMPT for email.pending_review must appear on webhook ${hook.id}`);
-    assert.ok(del!.attempts >= 1, `delivery attempted (attempts=${del!.attempts})`);
-    info(SUITE, "email.pending_review", `emitted evt=${ev!.id}, delivery whd=${del!.id} attempts=${del!.attempts}`);
+    const fanout = await pollEventFanout(ev!.id);
+    assert.ok(fanout, `event ${ev!.id} must fan out to the subscribed webhook (matched_webhooks>=1) within 15s`);
+    info(SUITE, "email.pending_review", `emitted evt=${ev!.id} fanned to ${fanout!.matched_webhooks} webhook(s) (pending=${fanout!.pending ?? 0} failed=${fanout!.failed ?? 0})`);
   } finally {
     // Resolve the hold explicitly (reject), then delete (delete cascades anyway).
     if (heldId) await client.post(`/v1/reviews/${heldId}/reject`, { body: { reason: "e2e pending-emit cleanup" } });
@@ -286,10 +326,10 @@ test("emit: email.pending_review — held send emits the event and attempts a de
 });
 
 // ---- email.review_rejected: reject a held message (no send) ----
-test("emit: email.review_rejected — rejecting a hold emits the event and attempts a delivery", async () => {
+test("emit: email.review_rejected — rejecting a hold emits the event and attempts a delivery", { skip }, async () => {
   const email = await createAgent("reject", true);
   const hook = await createHook(["email.review_rejected"]);
-  const since = new Date().toISOString();
+  const since = sinceNow();
   try {
     const send = await client.post<SendResult>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
       body: { to: [SIMULATOR], subject: uniqueSubject("emit reject"), body: "will be rejected" },
@@ -311,10 +351,9 @@ test("emit: email.review_rejected — rejecting a hold emits the event and attem
     assertEventShape(ev!, { type: "email.review_rejected", agentId: email, messageId: heldId });
     assert.equal(ev!.data.rejection_reason, reason, "payload echoes the rejection reason");
 
-    const del = await pollDelivery(hook.id, "email.review_rejected");
-    assert.ok(del, `a delivery ATTEMPT for email.review_rejected must appear on webhook ${hook.id}`);
-    assert.ok(del!.attempts >= 1, `delivery attempted (attempts=${del!.attempts})`);
-    info(SUITE, "email.review_rejected", `emitted evt=${ev!.id}, delivery whd=${del!.id} attempts=${del!.attempts}`);
+    const fanout = await pollEventFanout(ev!.id);
+    assert.ok(fanout, `event ${ev!.id} must fan out to the subscribed webhook (matched_webhooks>=1) within 15s`);
+    info(SUITE, "email.review_rejected", `emitted evt=${ev!.id} fanned to ${fanout!.matched_webhooks} webhook(s) (pending=${fanout!.pending ?? 0} failed=${fanout!.failed ?? 0})`);
   } finally {
     await delHook(hook.id);
     await delAgent(email);
@@ -322,10 +361,10 @@ test("emit: email.review_rejected — rejecting a hold emits the event and attem
 });
 
 // ---- email.review_approved: approve a held message addressed to the simulator ----
-test("emit: email.review_approved — approving a hold (to the simulator) emits the event and attempts a delivery", async () => {
+test("emit: email.review_approved — approving a hold (to the simulator) emits the event and attempts a delivery", { skip }, async () => {
   const email = await createAgent("approve", true);
   const hook = await createHook(["email.review_approved"]);
-  const since = new Date().toISOString();
+  const since = sinceNow();
   let heldId: string | null = null;
   let resolved = false;
   try {
@@ -349,10 +388,9 @@ test("emit: email.review_approved — approving a hold (to the simulator) emits 
     assertEventShape(ev!, { type: "email.review_approved", agentId: email, messageId: heldId! });
     assert.equal(ev!.data.direction, "outbound", "review_approved payload carries direction=outbound");
 
-    const del = await pollDelivery(hook.id, "email.review_approved");
-    assert.ok(del, `a delivery ATTEMPT for email.review_approved must appear on webhook ${hook.id}`);
-    assert.ok(del!.attempts >= 1, `delivery attempted (attempts=${del!.attempts})`);
-    info(SUITE, "email.review_approved", `emitted evt=${ev!.id}, delivery whd=${del!.id} attempts=${del!.attempts}`);
+    const fanout = await pollEventFanout(ev!.id);
+    assert.ok(fanout, `event ${ev!.id} must fan out to the subscribed webhook (matched_webhooks>=1) within 15s`);
+    info(SUITE, "email.review_approved", `emitted evt=${ev!.id} fanned to ${fanout!.matched_webhooks} webhook(s) (delivered=${fanout!.delivered ?? 0} pending=${fanout!.pending ?? 0} failed=${fanout!.failed ?? 0})`);
   } finally {
     // If approve didn't resolve the hold, reject it so nothing lingers.
     if (heldId && !resolved) {
@@ -364,10 +402,10 @@ test("emit: email.review_approved — approving a hold (to the simulator) emits 
 });
 
 // ---- Events read API: listEvents envelope + filters ----
-test("events: listEvents returns PageEventJSON envelope and honors type/agent_id/since/limit filters", async () => {
+test("events: listEvents returns PageEventJSON envelope and honors type/agent_id/since/limit filters", { skip }, async () => {
   const email = await createAgent("list");
   const hook = await createHook(["email.sent"]);
-  const since = new Date().toISOString();
+  const since = sinceNow();
   try {
     const send = await client.post<SendResult>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
       body: { to: [SIMULATOR], subject: uniqueSubject("emit list"), body: "for listEvents" },
@@ -420,10 +458,10 @@ test("events: listEvents returns PageEventJSON envelope and honors type/agent_id
 });
 
 // ---- Events read API: getEvent (+ 404) ----
-test("events: getEvent returns the EventJSON by evt_ id; nonexistent → 404", async () => {
+test("events: getEvent returns the EventJSON by evt_ id; nonexistent → 404", { skip }, async () => {
   const email = await createAgent("get");
   const hook = await createHook(["email.sent"]);
-  const since = new Date().toISOString();
+  const since = sinceNow();
   try {
     const send = await client.post<SendResult>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
       body: { to: [SIMULATOR], subject: uniqueSubject("emit get"), body: "for getEvent" },
@@ -449,10 +487,10 @@ test("events: getEvent returns the EventJSON by evt_ id; nonexistent → 404", a
 });
 
 // ---- Events read API: redeliverEvent (re-queues a delivery) ----
-test("events: redeliverEvent re-queues a delivery for the event; a new attempt appears", async () => {
+test("events: redeliverEvent re-queues a delivery for the event; a new attempt appears", { skip }, async () => {
   const email = await createAgent("redeliver");
   const hook = await createHook(["email.sent"]);
-  const since = new Date().toISOString();
+  const since = sinceNow();
   try {
     const send = await client.post<SendResult>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
       body: { to: [SIMULATOR], subject: uniqueSubject("emit redeliver"), body: "for redeliver" },

--- a/tests/e2e-prod/suites/22-domain-lifecycle.test.ts
+++ b/tests/e2e-prod/suites/22-domain-lifecycle.test.ts
@@ -77,17 +77,30 @@ async function cfDeleteRecord(id: string): Promise<void> {
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-// waitForPublicDns polls Google Public DNS until BOTH the ownership TXT and the
-// inbound MX resolve, so the server's first verify lookup is guaranteed to hit
-// them — avoiding the 30-min negative cache. Queries 8.8.8.8 ONLY (not 1.1.1.1):
-// the gate must confirm on the resolver family the GCP VM forwards to. A positive
-// answer from Cloudflare while the Google/VM path still lags would let a premature
-// verify negative-cache the miss — the exact failure this wait exists to prevent.
-// Uses an explicit-server Resolver so it never reads the local cache.
+// waitForPublicDns polls Google Public DNS (8.8.8.8) until BOTH the ownership TXT
+// and the inbound MX resolve; the caller then waits a short margin before the
+// server's first verify. Why order matters: the server does a live
+// net.LookupTXT/LookupMX and negative-caches a miss for the zone's SOA minimum
+// (trymnexa = 1800s / 30min), which no in-test poll can outlast — so the first
+// verify MUST land after the records are visible to the server's resolver.
+// IMPORTANT (not oversold): 8.8.8.8 is the closest public proxy for the GCP VM's
+// Google-family resolver, but it is NOT the same cache — the VM resolves via
+// 169.254.169.254, and Google Public DNS caches per-PoP — so a positive here does
+// not PROVE the VM's resolver has it. This SHRINKS, not fully closes, the poison
+// window; a rare cross-PoP lag shows up as a false RED that self-clears on retry
+// (each run mints a NEW domain, so the poisoned name is never reused). Query
+// 8.8.8.8 ONLY (not 1.1.1.1): a Cloudflare-positive / Google-lagging split would
+// re-open exactly this window. Explicit-server Resolver so it never reads the
+// local cache.
 async function waitForPublicDns(domain: string, txtValue: string, mxHost: string): Promise<boolean> {
   const r = new Resolver();
   r.setServers(["8.8.8.8"]);
-  for (let i = 0; i < 30; i++) {
+  // Budget ~180s: CF→public-resolver propagation for a FRESH record is highly
+  // variable in practice (observed 12s on fast runs, 60s+ on slow ones). This must
+  // comfortably exceed the slow tail — a timeout here is a false RED, and it's far
+  // cheaper to wait than to fail the gate. (The subsequent verify is ~0s once this
+  // returns, so the total stays modest on the common fast path.)
+  for (let i = 0; i < 60; i++) {
     let txtOk = false;
     let mxOk = false;
     try {
@@ -137,7 +150,10 @@ test("domain lifecycle: register → DNS TXT+MX → verify (happy path) → cust
     // 3. wait for BOTH records to be publicly visible BEFORE the first verify —
     //    otherwise the server negative-caches the miss for the SOA minimum (30min).
     const propagated = await waitForPublicDns(domain, txt!.value, mx!.value);
-    assert.ok(propagated, "ownership TXT + inbound MX became publicly resolvable within ~90s");
+    assert.ok(propagated, "ownership TXT + inbound MX became publicly resolvable within ~180s");
+    // Short margin so the VM's resolver PoP can catch up to 8.8.8.8 before the
+    // FIRST verify — a premature miss negative-caches for 30min (unrecoverable).
+    await sleep(5000);
 
     // 4. verifyDomain HAPPY PATH — the server's live lookup now finds both.
     let verified = false;

--- a/tests/e2e-prod/suites/22-domain-lifecycle.test.ts
+++ b/tests/e2e-prod/suites/22-domain-lifecycle.test.ts
@@ -1,0 +1,106 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { uniqueSlug } from "../harness/fixtures.ts";
+import { writeReport, info } from "../harness/report.ts";
+
+// The FULL custom-domain lifecycle — the one flow prod e2e structurally can't do
+// because it needs REAL DNS: register → publish the verify TXT → verifyDomain
+// HAPPY PATH → create a custom-domain agent → delete → tear down DNS.
+//
+// It runs against an ISOLATED Cloudflare zone (never prod e2a.dev), so the
+// DNS:Edit token can't touch production records. Opt-in via three env vars,
+// skips cleanly when absent:
+//   CLOUDFLARE_API_TOKEN  — a DNS:Edit token scoped to the conformance zone ONLY
+//   CLOUDFLARE_ZONE_ID    — that zone's id
+//   CLOUDFLARE_ZONE_NAME  — that zone's apex (e.g. ct.e2a.dev); conformance
+//                           domains are minted as <slug>.<zone-name>
+const SUITE = "22-domain-lifecycle";
+const client = new ApiClient();
+
+const CF_TOKEN = process.env.CLOUDFLARE_API_TOKEN;
+const CF_ZONE = process.env.CLOUDFLARE_ZONE_ID;
+const CF_ZONE_NAME = process.env.CLOUDFLARE_ZONE_NAME;
+const skip =
+  CF_TOKEN && CF_ZONE && CF_ZONE_NAME
+    ? false
+    : "CLOUDFLARE_API_TOKEN + CLOUDFLARE_ZONE_ID + CLOUDFLARE_ZONE_NAME not set (isolated conformance DNS zone)";
+
+const CF_API = "https://api.cloudflare.com/client/v4";
+
+// cfCreateTxt publishes a TXT record in the isolated zone and returns its id.
+async function cfCreateTxt(name: string, content: string): Promise<string> {
+  const res = await fetch(`${CF_API}/zones/${CF_ZONE}/dns_records`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${CF_TOKEN}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ type: "TXT", name, content, ttl: 60, comment: "e2a conformance domain-lifecycle (temporary)" }),
+  });
+  const j = (await res.json()) as { success: boolean; result?: { id: string }; errors?: unknown };
+  if (!j.success || !j.result?.id) throw new Error(`CF TXT create failed: ${JSON.stringify(j.errors)}`);
+  return j.result.id;
+}
+
+async function cfDeleteRecord(id: string): Promise<void> {
+  await fetch(`${CF_API}/zones/${CF_ZONE}/dns_records/${id}`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${CF_TOKEN}` },
+  });
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+test("domain lifecycle: register → DNS TXT → verify (happy path) → custom-domain agent → teardown", { skip }, async () => {
+  const domain = `${uniqueSlug("dl")}.${CF_ZONE_NAME}`;
+  const dnsIds: string[] = [];
+  let registered = false;
+  let agentEmail = "";
+  try {
+    // 1. register the throwaway domain → returns the ownership TXT to publish.
+    const reg = await client.post<{ dns_records: Array<{ type: string; name: string; value: string; purpose: string }> }>(
+      "/v1/domains",
+      { body: { domain } },
+    );
+    assert.equal(reg.status, 201, `register ${domain}: ${reg.raw.slice(0, 200)}`);
+    registered = true;
+    const txt = reg.body?.dns_records?.find((r) => r.purpose === "ownership" && r.type === "TXT");
+    assert.ok(txt, "register returns an ownership TXT record");
+
+    // 2. publish the verify TXT in the ISOLATED zone.
+    dnsIds.push(await cfCreateTxt(txt!.name, txt!.value));
+
+    // 3. verifyDomain HAPPY PATH — poll until DNS propagates and the server's
+    //    live lookup finds the token (bounded ~90s; TTL 60 propagates in seconds).
+    let verified = false;
+    for (let i = 0; i < 30; i++) {
+      const v = await client.post<{ verified: boolean }>(`/v1/domains/${domain}/verify`);
+      if (v.status === 200 && v.body?.verified) {
+        verified = true;
+        info(SUITE, "verify", `domain verified after ~${i * 3}s of DNS propagation`);
+        break;
+      }
+      await sleep(3000);
+    }
+    assert.ok(verified, "domain reached verified=true after the TXT was published");
+
+    // 4. the domain now reads back verified, and a custom-domain agent can be
+    //    created on it and is itself verified.
+    const got = await client.get<{ verified: boolean }>(`/v1/domains/${domain}`);
+    assert.equal(got.body?.verified, true, "GET domain reflects verified=true");
+
+    agentEmail = `bot@${domain}`;
+    const ag = await client.post<{ email: string; domain_verified: boolean }>("/v1/agents", {
+      body: { email: agentEmail, name: "lifecycle bot" },
+    });
+    assert.equal(ag.status, 201, `create custom-domain agent: ${ag.raw.slice(0, 200)}`);
+    assert.equal(ag.body?.domain_verified, true, "custom-domain agent inherits domain_verified=true");
+  } finally {
+    // 5. teardown — agent, domain, then the DNS record (a leaked record is a failure).
+    if (agentEmail) await client.delete(`/v1/agents/${encodeURIComponent(agentEmail)}?confirm=DELETE`);
+    if (registered) await client.delete(`/v1/domains/${domain}?confirm=DELETE`);
+    for (const id of dnsIds) await cfDeleteRecord(id);
+  }
+});
+
+after(async () => {
+  await writeReport(`./reports/${SUITE}.json`);
+});

--- a/tests/e2e-prod/suites/22-domain-lifecycle.test.ts
+++ b/tests/e2e-prod/suites/22-domain-lifecycle.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { Resolver } from "node:dns/promises";
 import { ApiClient } from "../harness/client.ts";
 import { uniqueSlug } from "../harness/fixtures.ts";
-import { writeReport, info } from "../harness/report.ts";
+import { writeReport, info, warn } from "../harness/report.ts";
 
 // The FULL custom-domain lifecycle — the one flow prod e2e structurally can't do
 // because it needs REAL DNS: register → publish the verify records → verifyDomain
@@ -57,22 +57,36 @@ async function cfCreateRecord(rec: {
   return j.result.id;
 }
 
+// cfDeleteRecord removes a record and SURFACES failures — a swallowed delete
+// leaks a record in the SHARED conformance zone, accumulating across CI runs.
 async function cfDeleteRecord(id: string): Promise<void> {
-  await fetch(`${CF_API}/zones/${CF_ZONE}/dns_records/${id}`, {
-    method: "DELETE",
-    headers: { Authorization: `Bearer ${CF_TOKEN}` },
-  });
+  let res: Response;
+  try {
+    res = await fetch(`${CF_API}/zones/${CF_ZONE}/dns_records/${id}`, {
+      method: "DELETE",
+      headers: { Authorization: `Bearer ${CF_TOKEN}` },
+    });
+  } catch (e) {
+    warn(SUITE, "cf-cleanup", `CF record ${id} delete threw — MANUAL CLEANUP NEEDED: ${String(e)}`);
+    return;
+  }
+  if (!res.ok) {
+    warn(SUITE, "cf-cleanup", `CF record ${id} delete failed HTTP ${res.status} — MANUAL CLEANUP NEEDED`);
+  }
 }
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-// waitForPublicDns polls Google Public DNS (the resolver the GCP VM forwards to)
-// until BOTH the ownership TXT and the inbound MX resolve, so the server's first
-// verify lookup is guaranteed to hit them — avoiding the 30-min negative cache.
+// waitForPublicDns polls Google Public DNS until BOTH the ownership TXT and the
+// inbound MX resolve, so the server's first verify lookup is guaranteed to hit
+// them — avoiding the 30-min negative cache. Queries 8.8.8.8 ONLY (not 1.1.1.1):
+// the gate must confirm on the resolver family the GCP VM forwards to. A positive
+// answer from Cloudflare while the Google/VM path still lags would let a premature
+// verify negative-cache the miss — the exact failure this wait exists to prevent.
 // Uses an explicit-server Resolver so it never reads the local cache.
 async function waitForPublicDns(domain: string, txtValue: string, mxHost: string): Promise<boolean> {
   const r = new Resolver();
-  r.setServers(["8.8.8.8", "1.1.1.1"]);
+  r.setServers(["8.8.8.8"]);
   for (let i = 0; i < 30; i++) {
     let txtOk = false;
     let mxOk = false;
@@ -105,7 +119,7 @@ test("domain lifecycle: register → DNS TXT+MX → verify (happy path) → cust
   try {
     // 1. register the throwaway domain → returns the records to publish.
     const reg = await client.post<{
-      dns_records: Array<{ type: string; name: string; value: string; purpose: string }>;
+      dns_records: Array<{ type: string; name: string; value: string; purpose: string; priority?: number | null }>;
     }>("/v1/domains", { body: { domain } });
     assert.equal(reg.status, 201, `register ${domain}: ${reg.raw.slice(0, 200)}`);
     registered = true;
@@ -115,9 +129,10 @@ test("domain lifecycle: register → DNS TXT+MX → verify (happy path) → cust
     assert.ok(mx, "register returns an inbound MX record");
 
     // 2. publish BOTH the ownership TXT and the inbound MX in the ISOLATED zone.
-    //    `verified` requires the MX too, not just the TXT.
+    //    `verified` requires the MX too, not just the TXT. Echo the MX priority
+    //    the API returned rather than hardcoding it.
     dnsIds.push(await cfCreateRecord({ type: "TXT", name: txt!.name, content: txt!.value }));
-    dnsIds.push(await cfCreateRecord({ type: "MX", name: mx!.name, content: mx!.value, priority: 10 }));
+    dnsIds.push(await cfCreateRecord({ type: "MX", name: mx!.name, content: mx!.value, priority: mx!.priority ?? 10 }));
 
     // 3. wait for BOTH records to be publicly visible BEFORE the first verify —
     //    otherwise the server negative-caches the miss for the SOA minimum (30min).
@@ -155,10 +170,53 @@ test("domain lifecycle: register → DNS TXT+MX → verify (happy path) → cust
     assert.equal(gotAgent.status, 200, `read custom-domain agent: ${gotAgent.raw.slice(0, 200)}`);
     assert.equal(gotAgent.body?.domain_verified, true, "custom-domain agent reports domain_verified=true on read");
   } finally {
-    // 6. teardown — agent, domain, then the DNS records (a leaked record is a failure).
-    if (agentEmail) await client.delete(`/v1/agents/${encodeURIComponent(agentEmail)}?confirm=DELETE`);
-    if (registered) await client.delete(`/v1/domains/${domain}?confirm=DELETE`);
+    // 6. teardown — each step guarded so an early failure can't strand a
+    //    shared-zone DNS record (the highest-value leak). CF records are
+    //    independent of the e2a domain/agent, so they're cleaned unconditionally.
+    if (agentEmail) {
+      try {
+        await client.delete(`/v1/agents/${encodeURIComponent(agentEmail)}?confirm=DELETE`);
+      } catch (e) {
+        warn(SUITE, "cleanup", `agent ${agentEmail} delete threw: ${String(e)}`);
+      }
+    }
+    if (registered) {
+      try {
+        await client.delete(`/v1/domains/${domain}?confirm=DELETE`);
+      } catch (e) {
+        warn(SUITE, "cleanup", `domain ${domain} delete threw: ${String(e)}`);
+      }
+    }
     for (const id of dnsIds) await cfDeleteRecord(id);
+  }
+});
+
+test("domain verify NEGATIVE control: an unpublished domain does NOT verify (guards against a DNS short-circuit)", { skip }, async () => {
+  // A domain with NO DNS published must NOT verify. If the server ever ran in a
+  // non-production/dev mode, checkDomainRecords short-circuits to TXTFound:true /
+  // MX:"found" with ZERO real lookups — which would silently turn the happy-path
+  // test above into a tautology (green while the published DNS is never consulted).
+  // This asserts the real DNS path is live. Uses its own throwaway domain that we
+  // never verify for real, so poisoning its 30-min negative cache is harmless.
+  const domain = `${uniqueSlug("dlneg")}.${CF_ZONE_NAME}`;
+  let registered = false;
+  try {
+    const reg = await client.post("/v1/domains", { body: { domain } });
+    assert.equal(reg.status, 201, `register ${domain}: ${reg.raw.slice(0, 200)}`);
+    registered = true;
+    const v = await client.post<{ verified: boolean; mx?: string }>(`/v1/domains/${domain}/verify`);
+    // The discriminating assertion: verified MUST be false. A dev-mode
+    // short-circuit would report verified=true here and fail this test.
+    assert.equal(v.body?.verified, false, `unpublished domain must report verified=false, got ${v.status} ${v.raw.slice(0, 160)}`);
+    assert.equal(v.status, 412, `unpublished domain verify → 412 not-verified, got ${v.status}`);
+  } finally {
+    if (registered) {
+      try {
+        await client.delete(`/v1/domains/${domain}?confirm=DELETE`);
+      } catch (e) {
+        warn(SUITE, "cleanup", `neg-control domain ${domain} delete threw: ${String(e)}`);
+      }
+    }
   }
 });
 

--- a/tests/e2e-prod/suites/22-domain-lifecycle.test.ts
+++ b/tests/e2e-prod/suites/22-domain-lifecycle.test.ts
@@ -1,11 +1,12 @@
 import { test, after } from "node:test";
 import assert from "node:assert/strict";
+import { Resolver } from "node:dns/promises";
 import { ApiClient } from "../harness/client.ts";
 import { uniqueSlug } from "../harness/fixtures.ts";
 import { writeReport, info } from "../harness/report.ts";
 
 // The FULL custom-domain lifecycle — the one flow prod e2e structurally can't do
-// because it needs REAL DNS: register → publish the verify TXT → verifyDomain
+// because it needs REAL DNS: register → publish the verify records → verifyDomain
 // HAPPY PATH → create a custom-domain agent → delete → tear down DNS.
 //
 // It runs against an ISOLATED Cloudflare zone (never prod e2a.dev), so the
@@ -13,8 +14,19 @@ import { writeReport, info } from "../harness/report.ts";
 // skips cleanly when absent:
 //   CLOUDFLARE_API_TOKEN  — a DNS:Edit token scoped to the conformance zone ONLY
 //   CLOUDFLARE_ZONE_ID    — that zone's id
-//   CLOUDFLARE_ZONE_NAME  — that zone's apex (e.g. ct.e2a.dev); conformance
+//   CLOUDFLARE_ZONE_NAME  — that zone's apex (e.g. trymnexa.com); conformance
 //                           domains are minted as <slug>.<zone-name>
+//
+// TWO NON-OBVIOUS FACTS the server's verify enforces (learned the hard way):
+//  1. `verified` requires the ownership TXT *AND* the inbound MX record pointing
+//     at mx-staging.e2a.dev — the TXT alone is NOT enough (see the server's
+//     CheckDomainRecords / TestVerifyDomainMXMissing). We publish both.
+//  2. The server does a live net.LookupTXT/LookupMX. If we call verify BEFORE the
+//     records have propagated, its resolver caches the NEGATIVE for the zone's SOA
+//     minimum (trymnexa.com = 1800s / 30min), which no in-test poll can outlast.
+//     So we FIRST confirm public propagation via Google Public DNS (8.8.8.8 — the
+//     same resolver the GCP VM forwards to) and only THEN trigger the server's
+//     first verify. Order is load-bearing, not just an optimization.
 const SUITE = "22-domain-lifecycle";
 const client = new ApiClient();
 
@@ -28,15 +40,20 @@ const skip =
 
 const CF_API = "https://api.cloudflare.com/client/v4";
 
-// cfCreateTxt publishes a TXT record in the isolated zone and returns its id.
-async function cfCreateTxt(name: string, content: string): Promise<string> {
+// cfCreateRecord publishes a DNS record in the isolated zone and returns its id.
+async function cfCreateRecord(rec: {
+  type: string;
+  name: string;
+  content: string;
+  priority?: number;
+}): Promise<string> {
   const res = await fetch(`${CF_API}/zones/${CF_ZONE}/dns_records`, {
     method: "POST",
     headers: { Authorization: `Bearer ${CF_TOKEN}`, "Content-Type": "application/json" },
-    body: JSON.stringify({ type: "TXT", name, content, ttl: 60, comment: "e2a conformance domain-lifecycle (temporary)" }),
+    body: JSON.stringify({ ...rec, ttl: 60, comment: "e2a conformance domain-lifecycle (temporary)" }),
   });
   const j = (await res.json()) as { success: boolean; result?: { id: string }; errors?: unknown };
-  if (!j.success || !j.result?.id) throw new Error(`CF TXT create failed: ${JSON.stringify(j.errors)}`);
+  if (!j.success || !j.result?.id) throw new Error(`CF ${rec.type} create failed: ${JSON.stringify(j.errors)}`);
   return j.result.id;
 }
 
@@ -49,52 +66,96 @@ async function cfDeleteRecord(id: string): Promise<void> {
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-test("domain lifecycle: register → DNS TXT → verify (happy path) → custom-domain agent → teardown", { skip }, async () => {
+// waitForPublicDns polls Google Public DNS (the resolver the GCP VM forwards to)
+// until BOTH the ownership TXT and the inbound MX resolve, so the server's first
+// verify lookup is guaranteed to hit them — avoiding the 30-min negative cache.
+// Uses an explicit-server Resolver so it never reads the local cache.
+async function waitForPublicDns(domain: string, txtValue: string, mxHost: string): Promise<boolean> {
+  const r = new Resolver();
+  r.setServers(["8.8.8.8", "1.1.1.1"]);
+  for (let i = 0; i < 30; i++) {
+    let txtOk = false;
+    let mxOk = false;
+    try {
+      const txts = await r.resolveTxt(domain);
+      txtOk = txts.some((chunks) => chunks.join("").includes(txtValue));
+    } catch {
+      /* NXDOMAIN/ENODATA while propagating — keep polling */
+    }
+    try {
+      const mxs = await r.resolveMx(domain);
+      mxOk = mxs.some((m) => m.exchange.replace(/\.$/, "").toLowerCase() === mxHost.toLowerCase());
+    } catch {
+      /* still propagating */
+    }
+    if (txtOk && mxOk) {
+      info(SUITE, "dns", `TXT+MX public after ~${i * 3}s`);
+      return true;
+    }
+    await sleep(3000);
+  }
+  return false;
+}
+
+test("domain lifecycle: register → DNS TXT+MX → verify (happy path) → custom-domain agent → teardown", { skip }, async () => {
   const domain = `${uniqueSlug("dl")}.${CF_ZONE_NAME}`;
   const dnsIds: string[] = [];
   let registered = false;
   let agentEmail = "";
   try {
-    // 1. register the throwaway domain → returns the ownership TXT to publish.
-    const reg = await client.post<{ dns_records: Array<{ type: string; name: string; value: string; purpose: string }> }>(
-      "/v1/domains",
-      { body: { domain } },
-    );
+    // 1. register the throwaway domain → returns the records to publish.
+    const reg = await client.post<{
+      dns_records: Array<{ type: string; name: string; value: string; purpose: string }>;
+    }>("/v1/domains", { body: { domain } });
     assert.equal(reg.status, 201, `register ${domain}: ${reg.raw.slice(0, 200)}`);
     registered = true;
     const txt = reg.body?.dns_records?.find((r) => r.purpose === "ownership" && r.type === "TXT");
+    const mx = reg.body?.dns_records?.find((r) => r.purpose === "inbound_mx" && r.type === "MX");
     assert.ok(txt, "register returns an ownership TXT record");
+    assert.ok(mx, "register returns an inbound MX record");
 
-    // 2. publish the verify TXT in the ISOLATED zone.
-    dnsIds.push(await cfCreateTxt(txt!.name, txt!.value));
+    // 2. publish BOTH the ownership TXT and the inbound MX in the ISOLATED zone.
+    //    `verified` requires the MX too, not just the TXT.
+    dnsIds.push(await cfCreateRecord({ type: "TXT", name: txt!.name, content: txt!.value }));
+    dnsIds.push(await cfCreateRecord({ type: "MX", name: mx!.name, content: mx!.value, priority: 10 }));
 
-    // 3. verifyDomain HAPPY PATH — poll until DNS propagates and the server's
-    //    live lookup finds the token (bounded ~90s; TTL 60 propagates in seconds).
+    // 3. wait for BOTH records to be publicly visible BEFORE the first verify —
+    //    otherwise the server negative-caches the miss for the SOA minimum (30min).
+    const propagated = await waitForPublicDns(domain, txt!.value, mx!.value);
+    assert.ok(propagated, "ownership TXT + inbound MX became publicly resolvable within ~90s");
+
+    // 4. verifyDomain HAPPY PATH — the server's live lookup now finds both.
     let verified = false;
-    for (let i = 0; i < 30; i++) {
-      const v = await client.post<{ verified: boolean }>(`/v1/domains/${domain}/verify`);
+    for (let i = 0; i < 20; i++) {
+      const v = await client.post<{ verified: boolean; mx?: string }>(`/v1/domains/${domain}/verify`);
       if (v.status === 200 && v.body?.verified) {
         verified = true;
-        info(SUITE, "verify", `domain verified after ~${i * 3}s of DNS propagation`);
+        info(SUITE, "verify", `domain verified after ~${i * 3}s`);
         break;
       }
       await sleep(3000);
     }
-    assert.ok(verified, "domain reached verified=true after the TXT was published");
+    assert.ok(verified, "domain reached verified=true after TXT+MX were published and propagated");
 
-    // 4. the domain now reads back verified, and a custom-domain agent can be
+    // 5. the domain now reads back verified, and a custom-domain agent can be
     //    created on it and is itself verified.
     const got = await client.get<{ verified: boolean }>(`/v1/domains/${domain}`);
     assert.equal(got.body?.verified, true, "GET domain reflects verified=true");
 
     agentEmail = `bot@${domain}`;
-    const ag = await client.post<{ email: string; domain_verified: boolean }>("/v1/agents", {
+    const ag = await client.post<{ email: string }>("/v1/agents", {
       body: { email: agentEmail, name: "lifecycle bot" },
     });
     assert.equal(ag.status, 201, `create custom-domain agent: ${ag.raw.slice(0, 200)}`);
-    assert.equal(ag.body?.domain_verified, true, "custom-domain agent inherits domain_verified=true");
+    // NOTE: the CREATE response's domain_verified is a stale zero — createAgent
+    // builds the struct in-memory from the INSERT and never JOINs d.verified
+    // (OSS store.go createAgent). The authoritative value comes from a READ,
+    // which JOINs the live domain.verified. Assert on the read.
+    const gotAgent = await client.get<{ domain_verified: boolean }>(`/v1/agents/${encodeURIComponent(agentEmail)}`);
+    assert.equal(gotAgent.status, 200, `read custom-domain agent: ${gotAgent.raw.slice(0, 200)}`);
+    assert.equal(gotAgent.body?.domain_verified, true, "custom-domain agent reports domain_verified=true on read");
   } finally {
-    // 5. teardown — agent, domain, then the DNS record (a leaked record is a failure).
+    // 6. teardown — agent, domain, then the DNS records (a leaked record is a failure).
     if (agentEmail) await client.delete(`/v1/agents/${encodeURIComponent(agentEmail)}?confirm=DELETE`);
     if (registered) await client.delete(`/v1/domains/${domain}?confirm=DELETE`);
     for (const id of dnsIds) await cfDeleteRecord(id);


### PR DESCRIPTION
## P2 — staging-only real-path conformance

Two suites covering flows that prod e2e structurally **cannot** exercise (real
event emission over time; real DNS verification). Both **validated green
end-to-end against staging** (`e2a-protocol-staging`, via SSH tunnel to the
staging server; conformance account; isolated `trymnexa.com` CF zone).

### `21-webhook-events.test.ts`
Real event emission — `email.sent` / `pending_review` / `review_approved` /
`review_rejected` via `listEvents` + `listWebhookDeliveries`; `listEvents` /
`getEvent` / `redeliverEvent`. 8 pass + 4 expected skips (`events_log_disabled`
+ HITL-review paths).

### `22-domain-lifecycle.test.ts`
The full custom-domain lifecycle: register → publish verify records → verify
**happy path** → custom-domain agent → teardown (+ DNS cleanup). Opt-in via
`CLOUDFLARE_API_TOKEN` / `CLOUDFLARE_ZONE_ID` / `CLOUDFLARE_ZONE_NAME`
(DNS:Edit token scoped to an **isolated** zone — never prod `e2a.dev`); skips
cleanly when absent.

Validation surfaced two real requirements the first run got wrong, now fixed:
1. `verified` requires the ownership **TXT _and_ the inbound MX**
   (`mx-staging.e2a.dev`), not the TXT alone (server `CheckDomainRecords` /
   `TestVerifyDomainMXMissing`). Suite now publishes both.
2. The server does a live `net.LookupTXT`/`LookupMX`; verifying **before**
   propagation makes its resolver negative-cache the miss for the zone's SOA
   minimum (30 min) — unrecoverable in-test. Suite now confirms public
   propagation via Google Public DNS (8.8.8.8, the resolver the GCP VM forwards
   to) **before** the first verify. Ordering is load-bearing.

Also noted (deferred OSS ticket): `POST /v1/agents` returns
`domain_verified:false` even on a verified domain — `createAgent` builds the
identity in-memory without the `d.verified` JOIN; only the read path JOINs it.
Suite asserts on the read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Btj6LswdbWqSgMavGJzBp