### PR TITLE
test(conformance): P3b — API-driven seeding runs contract scenarios on staging

### DIFF
--- a/sdks/typescript/test/v1/contract.test.ts
+++ b/sdks/typescript/test/v1/contract.test.ts
@@ -15,11 +15,16 @@
  * cross-language scenarios.yaml migration (tracked separately); this runner is
  * gated behind live-server env vars and is not part of the unit build.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterAll } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve as pathResolve } from "node:path";
 import { parse as yamlParse } from "yaml";
 import { WSListener } from "../../src/v1/ws.js";
+import { Seeder, seedEnabled, sweepLeaks } from "./seed.js";
+
+// When the isolated CF zone + SMTP port are configured, store-dependent scenarios
+// are SEEDED over the API (verified domains + real inbound) instead of skipped.
+const SEED = seedEnabled();
 
 // Minimal raw-HTTP driver — the scenario runner needs a generic
 // request(method, path, body) shim, not the ergonomic client surface.
@@ -86,6 +91,9 @@ interface Step {
   subject?: string;
   verify_domain?: string;
   expect?: Expectation;
+  /** After assertions, extract response json-paths into vars (Go-runner parity):
+   *  { var_name: "json.path" } → resolvable later as {var_name}. */
+  capture?: Record<string, string>;
 }
 
 interface Expectation {
@@ -163,6 +171,9 @@ class Runner {
   private wsListener: WSListener | null = null;
   /** Buffer of notifications received from WSListener. */
   private wsMessages: string[] = [];
+  private seeder: Seeder | null;
+  /** Placeholder test domain → real minted+verified domain (seed mode only). */
+  private domainSubs: Record<string, string> = {};
 
   constructor(
     private readonly baseUrl: string,
@@ -170,6 +181,7 @@ class Runner {
     private readonly scenario: Scenario,
   ) {
     this.api = new RawApi(apiKey, baseUrl);
+    this.seeder = SEED ? new Seeder(baseUrl, apiKey) : null;
   }
 
   resolve(s: string): string {
@@ -177,6 +189,14 @@ class Runner {
     s = s.replaceAll("{api_key}", this.apiKey);
     for (const [k, v] of Object.entries(this.vars)) {
       s = s.replaceAll(`{${k}}`, v);
+    }
+    // In seed mode, scenarios' hardcoded placeholder domains (crud.test.dev, …)
+    // are rewritten to the real minted+verified domains everywhere they appear
+    // (bodies, paths, body_match expectations). Longest placeholder first so a
+    // shorter one can't corrupt a prefix-sharing longer one (ws.test.dev vs
+    // wsauth.test.dev) — latent today (one domain per scenario), cheap to anchor.
+    for (const placeholder of Object.keys(this.domainSubs).sort((a, b) => b.length - a.length)) {
+      s = s.replaceAll(placeholder, this.domainSubs[placeholder]);
     }
     return s;
   }
@@ -204,38 +224,60 @@ class Runner {
     return this.authOverride(step) !== undefined;
   }
 
-  /** Returns true if setup requires store access (scenario should be skipped). */
+  /** Runs setup. Returns true if setup needs store access we DON'T have (→ skip).
+   *  In seed mode, store-dependent setup (verify_domain, inject_message) is
+   *  satisfied over the API instead, and this always returns false. */
   async executeSetup(): Promise<boolean> {
     if (!this.scenario.setup) return false;
 
     for (const s of this.scenario.setup) {
-      if (s.inject_message) return true;
-      if (s.verify_domain) return true;
-
       if (s.register_domain) {
-        try {
-          await this.api.registerDomain({ domain: this.resolve(s.register_domain) });
-        } catch (err) {
-          if (err instanceof RawApiError && err.statusCode === 409) {
-            /* already exists */
-          } else {
-            throw err;
+        const placeholder = s.register_domain;
+        if (this.seeder) {
+          // Mint + register a real domain (not verified yet); rewrite the placeholder.
+          this.domainSubs[placeholder] = await this.seeder.registerDomain(placeholder.split(".")[0]);
+        } else {
+          try {
+            await this.api.registerDomain({ domain: this.resolve(placeholder) });
+          } catch (err) {
+            if (!(err instanceof RawApiError && err.statusCode === 409)) throw err;
           }
         }
+        continue;
+      }
+
+      if (s.verify_domain) {
+        if (!this.seeder) return true; // no store access → skip the scenario
+        const placeholder = s.verify_domain;
+        let real = this.domainSubs[placeholder];
+        if (!real) {
+          real = await this.seeder.registerDomain(placeholder.split(".")[0]);
+          this.domainSubs[placeholder] = real;
+        }
+        await this.seeder.verifyDomain(real);
+        continue;
       }
 
       if (s.register_agent) {
-        const email = this.resolve(s.register_agent.email);
+        const email = this.resolve(s.register_agent.email); // domainSubs applied
         try {
           await this.api.registerAgent({ email });
         } catch (err) {
-          if (err instanceof RawApiError && err.statusCode === 409) {
-            /* already exists */
-          } else {
-            throw err;
-          }
+          if (!(err instanceof RawApiError && err.statusCode === 409)) throw err;
         }
         this.vars["agent_email"] = email;
+        continue;
+      }
+
+      if (s.inject_message) {
+        if (!this.seeder) return true; // no store access → skip the scenario
+        const im = s.inject_message;
+        this.vars["injected_message_id"] = await this.seeder.injectMessage(
+          this.resolve(im.agent_email),
+          this.resolve(im.from),
+          this.resolve(im.subject),
+        );
+        continue;
       }
     }
     return false;
@@ -248,7 +290,13 @@ class Runner {
           await this.execRequest(step);
           break;
         case "inject_message":
-          throw new Error(`step ${step.id}: inject_message not supported in TS runner`);
+          if (!this.seeder) throw new Error(`step ${step.id}: inject_message needs seeding (set the CF zone + SMTP env)`);
+          this.vars["injected_message_id"] = await this.seeder.injectMessage(
+            this.resolve(step.agent_email!),
+            this.resolve(step.from!),
+            this.resolve(step.subject!),
+          );
+          break;
         case "ws_connect":
           await this.execWSConnect(step);
           break;
@@ -259,18 +307,30 @@ class Runner {
           await this.execWSRead(step);
           break;
         case "verify_and_retry":
-          throw new Error(`step ${step.id}: verify_and_retry not supported in TS runner`);
+          if (!this.seeder) throw new Error(`step ${step.id}: verify_and_retry needs seeding (set the CF zone env)`);
+          await this.execVerifyAndRetry(step);
+          break;
         default:
           throw new Error(`step ${step.id}: unknown action ${step.action}`);
       }
     }
   }
 
-  cleanup(): void {
+  async cleanup(): Promise<void> {
     if (this.wsListener) {
       this.wsListener.close();
       this.wsListener = null;
     }
+    if (this.seeder) await this.seeder.cleanup();
+  }
+
+  /** verify_and_retry: verify the (registered) domain, then run the request. */
+  private async execVerifyAndRetry(step: Step): Promise<void> {
+    const placeholder = step.verify_domain!;
+    const real = this.domainSubs[placeholder];
+    if (!real) throw new Error(`step ${step.id}: ${placeholder} was not registered in setup`);
+    await this.seeder!.verifyDomain(real);
+    await this.execRequest(step);
   }
 
   // ── Step executors ──────────────────────────────────────────
@@ -315,25 +375,25 @@ class Runner {
       }
     }
 
-    if (!ex) return;
-
-    if (ex.status) {
+    if (ex?.status) {
       expect(status, `step ${step.id}: status`).toBe(ex.status);
     }
 
-    if (!ex.body_contains?.length && !ex.body_match && !ex.body_excludes?.length) return;
+    const hasBodyChecks = Boolean(ex?.body_contains?.length || ex?.body_match || ex?.body_excludes?.length);
+    const hasCapture = Boolean(step.capture && Object.keys(step.capture).length);
+    if (!hasBodyChecks && !hasCapture) return;
 
     const json = JSON.parse(rawBody) as Record<string, unknown>;
 
-    for (const key of ex.body_contains ?? []) {
+    for (const key of ex?.body_contains ?? []) {
       const resolved = this.resolve(key);
       expect(json, `step ${step.id}: body_contains ${resolved}`).toHaveProperty(resolved);
     }
-    for (const key of ex.body_excludes ?? []) {
+    for (const key of ex?.body_excludes ?? []) {
       const resolved = this.resolve(key);
       expect(json, `step ${step.id}: body_excludes ${resolved}`).not.toHaveProperty(resolved);
     }
-    if (ex.body_match) {
+    if (ex?.body_match) {
       for (const [jsonPath, expected] of Object.entries(ex.body_match)) {
         const resolvedPath = this.resolve(jsonPath);
         const actual = jsonPathGet(json, resolvedPath);
@@ -343,6 +403,14 @@ class Runner {
           `step ${step.id}: body_match ${resolvedPath} = ${JSON.stringify(actual)}, want ${JSON.stringify(resolvedExpected)}`,
         ).toBe(true);
       }
+    }
+
+    // Capture phase — AFTER assertions (Go-runner parity): extract a response
+    // json-path into a var so later steps can reference it as {name}.
+    for (const [name, srcPath] of Object.entries(step.capture ?? {})) {
+      const val = jsonPathGet(json, this.resolve(srcPath));
+      if (val === undefined) throw new Error(`step ${step.id}: capture path ${srcPath} not found in response`);
+      this.vars[name] = String(val);
     }
   }
 
@@ -442,21 +510,48 @@ function scenarioNeedsStore(sc: Scenario): boolean {
 const baseUrl = process.env.E2A_TEST_BASE_URL;
 const apiKey = process.env.E2A_TEST_API_KEY;
 
+// These scenarios assert account-GLOBAL collection state, which assumes an
+// isolated/empty account — not the shared staging conformance account (it holds
+// the shared domain + concurrent seeded domains + other suites' fresh agents):
+//   agent_crud            — items.length:0 after delete
+//   domain_crud           — items.length:1 on /v1/domains
+//   placeholder_resolution — items[0].email == {agent_email} (i.e. "my agent is
+//                            the account-newest"; races with concurrent suites)
+// Their behavior is covered by the resource-scoped e2e-prod suites; the Go/local
+// runner still covers them against a fresh DB. Skip regardless of seeding.
+const ACCOUNT_GLOBAL = new Set(["agent_crud", "domain_crud", "placeholder_resolution"]);
+
 describe.skipIf(!baseUrl || !apiKey)("Contract scenarios", () => {
   const scenarios = loadScenarios();
 
   for (const sc of scenarios) {
-    const needsStore = scenarioNeedsStore(sc);
+    // Store-dependent scenarios run when SEED supplies their preconditions over
+    // the API; otherwise they skip. Account-global scenarios skip regardless.
+    const skip = ACCOUNT_GLOBAL.has(sc.name) || (scenarioNeedsStore(sc) && !SEED);
 
-    (needsStore ? it.skip : it)(sc.name, async () => {
-      const runner = new Runner(baseUrl!, apiKey!, sc);
-      try {
-        const skipped = await runner.executeSetup();
-        if (skipped) return;
-        await runner.executeSteps();
-      } finally {
-        runner.cleanup();
-      }
-    });
+    (skip ? it.skip : it)(
+      sc.name,
+      async () => {
+        const runner = new Runner(baseUrl!, apiKey!, sc);
+        try {
+          const skipped = await runner.executeSetup();
+          if (skipped) return;
+          await runner.executeSteps();
+        } finally {
+          await runner.cleanup();
+        }
+      },
+      // Seeding mints + CF-verifies a real domain (variable DNS propagation), so
+      // seeded scenarios need a generous budget with headroom over the worst-case
+      // ~270s (register + propagate + verify); non-seeded stay snappy.
+      SEED ? 420_000 : 20_000,
+    );
   }
+
+  // Safety-net teardown: if any seeded scenario timed out (skipping its own
+  // finally), sweep leftover seeded domains + CF records so nothing leaks into the
+  // shared zone/account. No-op when seeding is off.
+  afterAll(async () => {
+    if (SEED) await sweepLeaks(baseUrl!, apiKey!);
+  }, 120_000);
 });

--- a/sdks/typescript/test/v1/seed.ts
+++ b/sdks/typescript/test/v1/seed.ts
@@ -1,0 +1,304 @@
+/**
+ * Staging API-driven seeding for the contract runner.
+ *
+ * The contract scenarios' store-dependent setup (verify_domain, inject_message)
+ * assumes direct DB access. Against a REMOTE staging server there is no store, so
+ * those scenarios normally skip. This module provides the same preconditions
+ * over the public surface instead:
+ *
+ *   - verify_domain → mint a real <slug>.<zone> domain, publish its ownership TXT
+ *     + inbound MX to an ISOLATED Cloudflare zone (never prod), wait for public
+ *     propagation, then drive POST /v1/domains/{d}/verify. (Mirrors P2 suite 22.)
+ *   - inject_message → deliver a real inbound email over the staging SMTP listener
+ *     (raw SMTP, no auth/TLS — the plaintext inbound port).
+ *
+ * All opt-in via env; when unset, seedEnabled() is false and the runner keeps its
+ * store-skip behavior (so local/CI Go-server runs are unaffected):
+ *   CLOUDFLARE_API_TOKEN / CLOUDFLARE_ZONE_ID / CLOUDFLARE_ZONE_NAME  (verify)
+ *   E2A_TEST_SMTP_HOST (default 127.0.0.1) / E2A_TEST_SMTP_PORT       (inject)
+ */
+import net from "node:net";
+import { Resolver } from "node:dns/promises";
+
+const CF_TOKEN = process.env.CLOUDFLARE_API_TOKEN;
+const CF_ZONE = process.env.CLOUDFLARE_ZONE_ID;
+const CF_ZONE_NAME = process.env.CLOUDFLARE_ZONE_NAME;
+const SMTP_HOST = process.env.E2A_TEST_SMTP_HOST || "127.0.0.1";
+const SMTP_PORT = Number(process.env.E2A_TEST_SMTP_PORT || "0");
+
+const CF_API = "https://api.cloudflare.com/client/v4";
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Seeding is available only when the isolated CF zone AND the SMTP port are set. */
+export function seedEnabled(): boolean {
+  return Boolean(CF_TOKEN && CF_ZONE && CF_ZONE_NAME && SMTP_PORT > 0);
+}
+
+/**
+ * afterAll safety-net: independent of per-test cleanup, delete any leftover seeded
+ * domains (+ their agents) on the account and any CF records tagged with our seed
+ * comment. So a test that times out mid-run (skipping its finally) still can't
+ * permanently leak into the SHARED zone/account. Best-effort; never throws.
+ */
+export async function sweepLeaks(baseUrl: string, apiKey: string): Promise<void> {
+  if (!seedEnabled()) return;
+  const raw = (method: string, path: string) =>
+    fetch(`${baseUrl}${path}`, { method, headers: { Authorization: `Bearer ${apiKey}` } });
+  try {
+    const domains =
+      ((await (await raw("GET", "/v1/domains")).json()) as { items?: Array<{ domain: string }> }).items ?? [];
+    const seeded = new Set(domains.map((d) => d.domain).filter((d) => d.endsWith(`.${CF_ZONE_NAME}`)));
+    if (seeded.size) {
+      const agents =
+        ((await (await raw("GET", "/v1/agents")).json()) as { items?: Array<{ email: string }> }).items ?? [];
+      for (const a of agents) {
+        if (seeded.has(a.email.split("@")[1])) {
+          await raw("DELETE", `/v1/agents/${encodeURIComponent(a.email)}?confirm=DELETE`).catch(() => {});
+        }
+      }
+      for (const d of seeded) await raw("DELETE", `/v1/domains/${d}?confirm=DELETE`).catch(() => {});
+    }
+  } catch {
+    /* best-effort */
+  }
+  try {
+    const res = await fetch(`${CF_API}/zones/${CF_ZONE}/dns_records?per_page=100`, {
+      headers: { Authorization: `Bearer ${CF_TOKEN}` },
+    });
+    const j = (await res.json()) as { result?: Array<{ id: string; comment?: string }> };
+    for (const rec of j.result ?? []) {
+      if (rec.comment?.includes("e2a contract-seed")) await cfDelete(rec.id);
+    }
+  } catch {
+    /* best-effort */
+  }
+}
+
+function slug(prefix: string): string {
+  // Unique-enough per scenario; the runner also namespaces by scenario name.
+  return `${prefix}-${Math.random().toString(36).slice(2, 8)}${Date.now().toString(36).slice(-4)}`;
+}
+
+async function cfCreate(rec: { type: string; name: string; content: string; priority?: number }): Promise<string> {
+  const res = await fetch(`${CF_API}/zones/${CF_ZONE}/dns_records`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${CF_TOKEN}`, "Content-Type": "application/json" },
+    body: JSON.stringify({ ...rec, ttl: 60, comment: "e2a contract-seed (temporary)" }),
+  });
+  const j = (await res.json()) as { success: boolean; result?: { id: string }; errors?: unknown };
+  if (!j.success || !j.result?.id) throw new Error(`CF ${rec.type} create failed: ${JSON.stringify(j.errors)}`);
+  return j.result.id;
+}
+
+async function cfDelete(id: string): Promise<void> {
+  const res = await fetch(`${CF_API}/zones/${CF_ZONE}/dns_records/${id}`, {
+    method: "DELETE",
+    headers: { Authorization: `Bearer ${CF_TOKEN}` },
+  }).catch(() => null);
+  if (res && !res.ok) console.warn(`[seed] CF record ${id} delete failed HTTP ${res.status} — manual cleanup`);
+}
+
+// Wait until BOTH records resolve on Google Public DNS (the resolver family the
+// GCP VM forwards to) before the first verify, so the server's live lookup can't
+// negative-cache the miss for the zone SOA minimum. Generous budget: fresh-record
+// propagation is variable (see P2).
+async function waitForPublicDns(domain: string, txtValue: string, mxHost: string): Promise<boolean> {
+  const r = new Resolver();
+  r.setServers(["8.8.8.8"]);
+  // Initial delay BEFORE the first query: if we query 8.8.8.8 the instant after
+  // cfCreate — before the record propagates to CF's edge — 8.8.8.8 negative-caches
+  // the miss (up to the zone SOA minimum), and that cached NXDOMAIN can outlast the
+  // whole poll budget. Waiting for CF's edge first makes the first lookup positive.
+  await sleep(12000);
+  for (let i = 0; i < 60; i++) {
+    let txtOk = false;
+    let mxOk = false;
+    try {
+      txtOk = (await r.resolveTxt(domain)).some((c) => c.join("").includes(txtValue));
+    } catch {
+      /* propagating */
+    }
+    try {
+      const wantMx = mxHost.replace(/\.$/, "").toLowerCase();
+      mxOk = (await r.resolveMx(domain)).some((m) => m.exchange.replace(/\.$/, "").toLowerCase() === wantMx);
+    } catch {
+      /* propagating */
+    }
+    if (txtOk && mxOk) return true;
+    await sleep(3000);
+  }
+  return false;
+}
+
+interface DnsRecord {
+  type: string;
+  name: string;
+  value: string;
+  purpose: string;
+  priority?: number | null;
+}
+
+/**
+ * Seeder mints + verifies real domains and injects real inbound mail for one
+ * scenario, tracking everything it creates for teardown. One instance per Runner.
+ * Uses its OWN non-throwing fetch (the runner's RawApi throws on 4xx, but the
+ * verify poll must read the 412 {verified:false} body while records propagate).
+ */
+export class Seeder {
+  private readonly domains: string[] = [];
+  private readonly dnsIds: string[] = [];
+  // Ownership TXT value + inbound MX host per registered domain, so verifyDomain()
+  // (which may run later, e.g. a verify_and_retry step) can wait for propagation.
+  private readonly pending: Record<string, { txt: string; mx: string }> = {};
+
+  constructor(
+    private readonly baseUrl: string,
+    private readonly apiKey: string,
+  ) {}
+
+  private async raw(method: string, path: string, body?: unknown): Promise<Response> {
+    const headers: Record<string, string> = { Authorization: `Bearer ${this.apiKey}` };
+    if (body !== undefined) headers["Content-Type"] = "application/json";
+    return fetch(`${this.baseUrl}${path}`, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+  }
+
+  /** Mint <slug>.<zone>, register it, and publish TXT+MX — but do NOT verify yet
+   *  (domain_verification_enforced needs an unverified-then-verified domain). */
+  async registerDomain(prefix: string): Promise<string> {
+    const domain = `${slug(prefix)}.${CF_ZONE_NAME}`;
+    const reg = (await (await this.raw("POST", "/v1/domains", { domain })).json()) as { dns_records: DnsRecord[] };
+    this.domains.push(domain);
+    const txt = reg.dns_records.find((r) => r.purpose === "ownership" && r.type === "TXT");
+    const mx = reg.dns_records.find((r) => r.purpose === "inbound_mx" && r.type === "MX");
+    if (!txt || !mx) throw new Error(`register ${domain} missing TXT/MX records`);
+    this.dnsIds.push(await cfCreate({ type: "TXT", name: txt.name, content: txt.value }));
+    this.dnsIds.push(await cfCreate({ type: "MX", name: mx.name, content: mx.value, priority: mx.priority ?? 10 }));
+    this.pending[domain] = { txt: txt.value, mx: mx.value };
+    return domain;
+  }
+
+  /** Wait for the (already-published) records to propagate, then verify. */
+  async verifyDomain(domain: string): Promise<void> {
+    const p = this.pending[domain];
+    if (!p) throw new Error(`seed: verifyDomain(${domain}) before registerDomain`);
+    if (!(await waitForPublicDns(domain, p.txt, p.mx))) {
+      throw new Error(`seed: DNS for ${domain} did not become public within budget`);
+    }
+    await sleep(5000); // margin so the VM's resolver PoP catches up before the first verify
+    let verified = false;
+    for (let i = 0; i < 20 && !verified; i++) {
+      const v = (await (await this.raw("POST", `/v1/domains/${domain}/verify`)).json()) as { verified?: boolean };
+      verified = v.verified === true;
+      if (!verified) await sleep(3000);
+    }
+    if (!verified) throw new Error(`seed: ${domain} did not verify after propagation`);
+  }
+
+  /**
+   * Deliver a real inbound email over the staging SMTP listener, then poll the
+   * agent's inbox until it lands and return its message id.
+   */
+  async injectMessage(agentEmail: string, from: string, subject: string): Promise<string> {
+    await smtpInject({ from, to: agentEmail, subject, body: "contract-seed injected inbound body" });
+    for (let i = 0; i < 15; i++) {
+      const page = (await (await this.raw("GET", `/v1/agents/${encodeURIComponent(agentEmail)}/messages?limit=20`)).json()) as {
+        items: Array<{ message_id: string; subject: string }>;
+      };
+      const hit = page.items.find((m) => m.subject === subject);
+      if (hit) return hit.message_id;
+      await sleep(2000);
+    }
+    throw new Error(`seed: injected message (subject "${subject}") never appeared in ${agentEmail}`);
+  }
+
+  /** Delete every agent, domain, and CF record this seeder created. Agents MUST go
+   *  first: domain delete returns 400 domain_has_agents while any agent remains, so
+   *  skipping them silently leaks the domain (accumulates in the shared account). */
+  async cleanup(): Promise<void> {
+    if (this.domains.length) {
+      const mine = new Set(this.domains);
+      try {
+        const page = (await (await this.raw("GET", "/v1/agents?limit=200")).json()) as {
+          items?: Array<{ email: string }>;
+        };
+        for (const a of page.items ?? []) {
+          if (mine.has(a.email.split("@")[1])) {
+            await this.raw("DELETE", `/v1/agents/${encodeURIComponent(a.email)}?confirm=DELETE`).catch(() => {});
+          }
+        }
+      } catch {
+        /* best-effort: fall through to domain/record deletes */
+      }
+    }
+    for (const d of this.domains) {
+      await this.raw("DELETE", `/v1/domains/${d}?confirm=DELETE`).catch(() => {});
+    }
+    for (const id of this.dnsIds) await cfDelete(id);
+  }
+}
+
+/**
+ * Minimal plaintext SMTP client — enough to hand a message to the inbound
+ * listener (no AUTH, no STARTTLS; the inbound port is plaintext). Lock-steps
+ * through the exchange, sending the next command after each positive final reply.
+ *
+ * Resolves as soon as the message is ACCEPTED (the 250 after the DATA payload) —
+ * QUIT is fire-and-forget, so a server that closes without a 221 doesn't cause a
+ * spurious timeout. Multiline replies (`NNN-…` continuation lines) are ignored;
+ * final lines are `NNN ` (space). Tolerates bare-LF as well as CRLF framing.
+ * Only ever fails on a >=400 reply, an error, or a timeout — never false-positive.
+ */
+export function smtpInject(m: { from: string; to: string; subject: string; body: string }): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const sock = net.createConnection({ host: SMTP_HOST, port: SMTP_PORT });
+    sock.setEncoding("utf8");
+    let done = false;
+    const fail = (e: Error) => {
+      if (done) return;
+      done = true;
+      sock.destroy();
+      reject(e);
+    };
+    sock.setTimeout(20000, () => fail(new Error("smtp: timeout")));
+    sock.on("error", fail);
+
+    const payload =
+      `From: ${m.from}\r\nTo: ${m.to}\r\nSubject: ${m.subject}\r\n` +
+      `Message-ID: <${slug("seed")}@conformance.local>\r\n\r\n${m.body}\r\n.`;
+    // The reply to the LAST step (the payload) is the queue-ack → accepted.
+    const steps = [`EHLO conformance.local`, `MAIL FROM:<${m.from}>`, `RCPT TO:<${m.to}>`, `DATA`, payload];
+
+    let i = 0;
+    let buf = "";
+    sock.on("data", (chunk: string) => {
+      if (done) return;
+      buf += chunk;
+      let nl: number;
+      while ((nl = buf.search(/\r?\n/)) !== -1) {
+        const line = buf.slice(0, nl);
+        buf = buf.slice(buf[nl] === "\r" ? nl + 2 : nl + 1);
+        if (!/^\d{3} /.test(line)) continue; // multiline continuation line
+        const code = Number(line.slice(0, 3));
+        if (code >= 400) return fail(new Error(`smtp: ${line}`));
+        if (i < steps.length) {
+          sock.write(steps[i++] + "\r\n"); // reply to greeting/prev step → send next
+        } else {
+          // Positive reply to the payload = message queued. Done.
+          done = true;
+          try {
+            sock.write("QUIT\r\n"); // best-effort; we don't wait for the 221
+            sock.end();
+          } catch {
+            /* socket may already be closing */
+          }
+          resolve();
+          return;
+        }
+      }
+    });
+  });
+}


### PR DESCRIPTION
Supersedes #418 (auto-closed when its stacked base #417 merged + deleted the base branch). Same content — the two self-contained 3b files (`seed.ts` + `contract.test.ts` seed mode), rebased onto main. Review + adversarial review already applied; validated on staging: **11 pass / 3 skip / 0 fail / 0 leaks**.

Staging SEED mode so store-dependent contract scenarios run against remote staging (verify_domain via CF-verified `<slug>.trymnexa.com`; inject_message via the staging SMTP listener) instead of skipping. Backward-compatible — no-op without CF/SMTP env, so the local/CI Go-server path is untouched. Excludes account-global scenarios (agent_crud/domain_crud/placeholder_resolution) that assume an empty account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Btj6LswdbWqSgMavGJzBp