### PR TITLE
test(conformance): P4 — API operationId coverage gate

### DIFF
--- a/tests/e2e-prod/coverage_gate.py
+++ b/tests/e2e-prod/coverage_gate.py
@@ -15,6 +15,17 @@ Maps each exercised concrete path to the most-specific matching operationId, the
 compares the covered set to the full catalog (minus an explicit allowlist of
 operations the black-box suite legitimately must not call).
 
+SCOPE: this gate covers the 56 typed /v1 OpenAPI operations (the operationId
+catalog). Non-/v1 surface (billing, MCP, OAuth machine endpoints, /api/health,
+/webhooks/*) and the webhook EVENT types are NOT operationIds and are out of scope
+here — they have their own dedicated suites (e.g. 21-webhook-events for event
+emission). Exercised paths that don't map to a /v1 operationId are reported (as
+"unmapped") but do not affect the pass/fail verdict.
+
+"Covered" means the suite issued a request to the operation that returned a 2xx
+(the harness only records successes — see harness/coverage.ts), i.e. the operation
+was actually exercised, not merely probed with a rejected request.
+
 Usage: python3 coverage_gate.py [--openapi PATH] [--reports DIR]
 Exit 0 = all covered (or allowlisted); 1 = coverage gap; 2 = usage/IO error.
 """
@@ -31,6 +42,9 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 # knowingly forgoing.
 ALLOWLIST = {
     "deleteAccount": "destructive — the suite must never delete its own account",
+    "deleteSuppression": "no happy path black-box: a suppression is created only by a "
+    "real SES bounce/complaint (no createSuppression API), so there's nothing to delete; "
+    "the 404-unknown-address path is exercised by 19-account",
 }
 
 
@@ -51,8 +65,13 @@ def load_ops(openapi_path):
 
 
 def match_op(method, segments, ops):
-    """Most-specific (most literal segments) operationId matching a concrete path."""
-    best, best_literals = None, -1
+    """Most-specific (most literal segments) operationId matching a concrete path.
+
+    Raises on an ambiguous match (two different operations tie at the same literal
+    count) rather than silently picking one by dict order — that would let a path
+    over-attribute coverage to the wrong op. Doesn't happen with today's spec, but
+    a future literal-sibling of a {param} route would trigger it."""
+    best, best_literals, tied = None, -1, set()
     for m, tsegs, opid in ops:
         if m != method or len(tsegs) != len(segments):
             continue
@@ -67,15 +86,23 @@ def match_op(method, segments, ops):
                 break
             else:
                 literals += 1
-        if ok and literals > best_literals:
-            best, best_literals = opid, literals
+        if not ok:
+            continue
+        if literals > best_literals:
+            best, best_literals, tied = opid, literals, {opid}
+        elif literals == best_literals:
+            tied.add(opid)
+    if len(tied) > 1:
+        raise ValueError(
+            f"ambiguous match for {method} /{'/'.join(segments)}: {sorted(tied)} tie at {best_literals} literal segments"
+        )
     return best
 
 
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--openapi", default=os.path.join(HERE, "../../api/openapi.yaml"))
-    ap.add_argument("--reports", default=os.path.join(HERE, "reports"))
+    ap.add_argument("--reports", default=os.path.join(HERE, "reports", "coverage"))
     args = ap.parse_args()
 
     if not os.path.exists(args.openapi):
@@ -85,7 +112,14 @@ def main():
     ops = load_ops(args.openapi)
     all_ids = {opid for _, _, opid in ops}
 
-    shards = glob.glob(os.path.join(args.reports, "coverage-*.json"))
+    # An allowlist entry that no longer matches a real operationId is a silent hole
+    # (e.g. the op was renamed) — fail loudly so the allowlist can't drift stale.
+    stale = set(ALLOWLIST) - all_ids
+    if stale:
+        print(f"coverage_gate: allowlist entries not in the spec (renamed/removed?): {sorted(stale)}", file=sys.stderr)
+        return 2
+
+    shards = glob.glob(os.path.join(args.reports, "*.json"))
     if not shards:
         print(f"coverage_gate: no coverage shards in {args.reports} — did the suite run?", file=sys.stderr)
         return 2
@@ -107,10 +141,15 @@ def main():
     allowlisted = missing & set(ALLOWLIST)
     uncovered = missing - set(ALLOWLIST)
 
-    print(f"OpenAPI operations : {len(all_ids)}")
-    print(f"Covered            : {len(covered_ids)}")
+    print(f"OpenAPI operations : {len(all_ids)}  (/v1 operationId scope)")
+    print(f"Covered (2xx)      : {len(covered_ids)}")
     print(f"Allowlisted        : {len(allowlisted)} " + (str(sorted(allowlisted)) if allowlisted else ""))
-    print(f"Coverage shards    : {len(shards)}  (exercised pairs: {len(exercised)}, non-/v1: {len(non_v1)})")
+    print(f"Coverage shards    : {len(shards)}  (exercised 2xx pairs: {len(exercised)}, unmapped non-/v1: {len(non_v1)})")
+    if non_v1:
+        # Printed for visibility (a mistyped /v1 path would land here), but out of
+        # scope for the gate — non-/v1 surface has its own suites.
+        for pair in sorted(non_v1)[:20]:
+            print(f"    non-/v1: {pair}")
 
     if uncovered:
         print(f"\nUNCOVERED ({len(uncovered)}):")

--- a/tests/e2e-prod/coverage_gate.py
+++ b/tests/e2e-prod/coverage_gate.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Conformance coverage gate.
+
+Every OpenAPI operation must be exercised by the e2e-prod suite, or the gate
+fails — so if a new operationId is added to api/openapi.yaml (the drift-gated
+SSOT) and no suite calls it, CI catches the coverage regression.
+
+Inputs:
+  - reports/coverage-*.json : shards written by the harness (harness/coverage.ts),
+    each a JSON array of "METHOD /concrete/path" strings the ApiClient issued.
+  - api/openapi.yaml        : the operation catalog (method + path template +
+    operationId).
+
+Maps each exercised concrete path to the most-specific matching operationId, then
+compares the covered set to the full catalog (minus an explicit allowlist of
+operations the black-box suite legitimately must not call).
+
+Usage: python3 coverage_gate.py [--openapi PATH] [--reports DIR]
+Exit 0 = all covered (or allowlisted); 1 = coverage gap; 2 = usage/IO error.
+"""
+import argparse
+import glob
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+# Operations the black-box conformance suite intentionally does NOT exercise, with
+# the reason. Keep this list SHORT and justified — every entry is coverage we're
+# knowingly forgoing.
+ALLOWLIST = {
+    "deleteAccount": "destructive — the suite must never delete its own account",
+}
+
+
+def load_ops(openapi_path):
+    try:
+        import yaml
+    except ImportError:
+        print("coverage_gate: PyYAML required (pip install pyyaml)", file=sys.stderr)
+        sys.exit(2)
+    with open(openapi_path) as f:
+        spec = yaml.safe_load(f)
+    ops = []  # (METHOD, [template segments], operationId)
+    for path, item in (spec.get("paths") or {}).items():
+        for method, op in (item or {}).items():
+            if isinstance(op, dict) and "operationId" in op:
+                ops.append((method.upper(), path.strip("/").split("/"), op["operationId"]))
+    return ops
+
+
+def match_op(method, segments, ops):
+    """Most-specific (most literal segments) operationId matching a concrete path."""
+    best, best_literals = None, -1
+    for m, tsegs, opid in ops:
+        if m != method or len(tsegs) != len(segments):
+            continue
+        literals, ok = 0, True
+        for t, s in zip(tsegs, segments):
+            if t.startswith("{") and t.endswith("}"):
+                if not s:
+                    ok = False
+                    break
+            elif t != s:
+                ok = False
+                break
+            else:
+                literals += 1
+        if ok and literals > best_literals:
+            best, best_literals = opid, literals
+    return best
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--openapi", default=os.path.join(HERE, "../../api/openapi.yaml"))
+    ap.add_argument("--reports", default=os.path.join(HERE, "reports"))
+    args = ap.parse_args()
+
+    if not os.path.exists(args.openapi):
+        print(f"coverage_gate: openapi spec not found: {args.openapi}", file=sys.stderr)
+        return 2
+
+    ops = load_ops(args.openapi)
+    all_ids = {opid for _, _, opid in ops}
+
+    shards = glob.glob(os.path.join(args.reports, "coverage-*.json"))
+    if not shards:
+        print(f"coverage_gate: no coverage shards in {args.reports} — did the suite run?", file=sys.stderr)
+        return 2
+    exercised = set()
+    for shard in shards:
+        with open(shard) as f:
+            exercised.update(json.load(f))
+
+    covered_ids, non_v1 = set(), set()
+    for pair in exercised:
+        method, _, path = pair.partition(" ")
+        opid = match_op(method, path.strip("/").split("/"), ops)
+        if opid:
+            covered_ids.add(opid)
+        else:
+            non_v1.add(pair)
+
+    missing = all_ids - covered_ids
+    allowlisted = missing & set(ALLOWLIST)
+    uncovered = missing - set(ALLOWLIST)
+
+    print(f"OpenAPI operations : {len(all_ids)}")
+    print(f"Covered            : {len(covered_ids)}")
+    print(f"Allowlisted        : {len(allowlisted)} " + (str(sorted(allowlisted)) if allowlisted else ""))
+    print(f"Coverage shards    : {len(shards)}  (exercised pairs: {len(exercised)}, non-/v1: {len(non_v1)})")
+
+    if uncovered:
+        print(f"\nUNCOVERED ({len(uncovered)}):")
+        for opid in sorted(uncovered):
+            m, t, _ = next(o for o in ops if o[2] == opid)
+            print(f"  - {opid:28s} {m} /{'/'.join(t)}")
+        print("\nGATE: FAIL — the above operation(s) are in the spec but no suite exercises them.")
+        return 1
+
+    print("\nGATE: PASS — every OpenAPI operation is exercised (or explicitly allowlisted).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/e2e-prod/harness/client.ts
+++ b/tests/e2e-prod/harness/client.ts
@@ -61,8 +61,6 @@ export class ApiClient {
       body = typeof opts.body === "string" ? opts.body : JSON.stringify(opts.body);
       headers["Content-Type"] = headers["Content-Type"] ?? "application/json";
     }
-    // Record the exercised operation for the coverage gate (best-effort).
-    recordRequest(method, url.pathname);
     const t0 = performance.now();
     // redirect: "manual" stops fetch from transparently following 3xx
     // responses. The default `"follow"` makes tests assert against
@@ -74,6 +72,9 @@ export class ApiClient {
     // a 3xx from any of our routes is a real signal that callers must
     // see, not transparently swallow.
     const res = await fetch(url, { method, headers, body, redirect: "manual" });
+    // Record the exercised operation for the coverage gate — only on a 2xx (see
+    // coverage.ts), so negative/rejected probes don't over-claim coverage.
+    recordRequest(method, url.pathname, res.status);
     const raw = await res.text();
     const latencyMs = performance.now() - t0;
     let parsed: T | null = null;

--- a/tests/e2e-prod/harness/client.ts
+++ b/tests/e2e-prod/harness/client.ts
@@ -1,4 +1,5 @@
 import { loadEnv, type ProdEnv } from "./env.ts";
+import { recordRequest } from "./coverage.ts";
 
 export interface RawResponse<T = unknown> {
   status: number;
@@ -60,6 +61,8 @@ export class ApiClient {
       body = typeof opts.body === "string" ? opts.body : JSON.stringify(opts.body);
       headers["Content-Type"] = headers["Content-Type"] ?? "application/json";
     }
+    // Record the exercised operation for the coverage gate (best-effort).
+    recordRequest(method, url.pathname);
     const t0 = performance.now();
     // redirect: "manual" stops fetch from transparently following 3xx
     // responses. The default `"follow"` makes tests assert against

--- a/tests/e2e-prod/harness/coverage.ts
+++ b/tests/e2e-prod/harness/coverage.ts
@@ -1,0 +1,31 @@
+import { writeFileSync, mkdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// API-coverage recorder. Every request the ApiClient issues is recorded here as a
+// "METHOD /concrete/path" pair. `node --test` runs each suite FILE in its own
+// process, so each process flushes its own coverage shard (coverage-<pid>.json)
+// to reports/ on exit; the Python coverage gate (coverage_gate.py) unions the
+// shards, maps each concrete path to an OpenAPI operationId, and fails if any spec
+// operation went unexercised. Recording is best-effort and never throws.
+const REPORTS_DIR = fileURLToPath(new URL("../reports/", import.meta.url));
+
+const covered = new Set<string>();
+let installed = false;
+
+export function recordRequest(method: string, pathname: string): void {
+  covered.add(`${method.toUpperCase()} ${pathname}`);
+  if (!installed) {
+    installed = true;
+    // Sync flush on process exit — the only hook guaranteed to run once the
+    // suite's tests are done (async handlers can't run during 'exit').
+    process.on("exit", () => {
+      if (covered.size === 0) return;
+      try {
+        mkdirSync(REPORTS_DIR, { recursive: true });
+        writeFileSync(`${REPORTS_DIR}coverage-${process.pid}.json`, JSON.stringify([...covered]));
+      } catch {
+        /* best-effort: coverage is advisory, must never fail a suite */
+      }
+    });
+  }
+}

--- a/tests/e2e-prod/harness/coverage.ts
+++ b/tests/e2e-prod/harness/coverage.ts
@@ -1,28 +1,39 @@
 import { writeFileSync, mkdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-// API-coverage recorder. Every request the ApiClient issues is recorded here as a
-// "METHOD /concrete/path" pair. `node --test` runs each suite FILE in its own
-// process, so each process flushes its own coverage shard (coverage-<pid>.json)
-// to reports/ on exit; the Python coverage gate (coverage_gate.py) unions the
-// shards, maps each concrete path to an OpenAPI operationId, and fails if any spec
-// operation went unexercised. Recording is best-effort and never throws.
-const REPORTS_DIR = fileURLToPath(new URL("../reports/", import.meta.url));
+// API-coverage recorder. The ApiClient calls record(method, path, status) AFTER
+// each response; an operation is marked covered only on a 2xx — a 401 auth-probe,
+// a 404 unknown-id test, or a 422 validation-rejection issues a request at the
+// route WITHOUT the operation's handler running to success, so counting it would
+// over-claim coverage. Recording after the response also means a network failure
+// (fetch throws) never counts.
+//
+// Shards live in reports/coverage/ (a SUBDIR) so they don't collide with the
+// per-suite report JSONs in reports/ (consolidate.ts reads those as {findings}
+// objects and would choke on a bare array). `node --test` runs each suite FILE in
+// its own process, so each flushes reports/coverage/<pid>.json on exit; the gate
+// (coverage_gate.py) unions the shards. A `pretest` step clears the dir before
+// each run so a PRIOR run's shards can't inflate coverage into a false PASS.
+const COVERAGE_DIR = fileURLToPath(new URL("../reports/coverage/", import.meta.url));
 
 const covered = new Set<string>();
 let installed = false;
 
-export function recordRequest(method: string, pathname: string): void {
+export function recordRequest(method: string, pathname: string, status: number): void {
+  if (status < 200 || status >= 300) return; // only a success proves the op ran
   covered.add(`${method.toUpperCase()} ${pathname}`);
   if (!installed) {
     installed = true;
-    // Sync flush on process exit — the only hook guaranteed to run once the
-    // suite's tests are done (async handlers can't run during 'exit').
+    // Sync flush on 'exit' — the only hook guaranteed to run once the suite's
+    // tests are done. NOTE: 'exit' does NOT fire on SIGTERM/SIGKILL, so a suite the
+    // runner force-kills contributes no shard → its unique ops read UNCOVERED. That
+    // is a safe false-FAIL (never a false-PASS), because the pretest clean removes
+    // any stale shard that could otherwise mask the loss.
     process.on("exit", () => {
       if (covered.size === 0) return;
       try {
-        mkdirSync(REPORTS_DIR, { recursive: true });
-        writeFileSync(`${REPORTS_DIR}coverage-${process.pid}.json`, JSON.stringify([...covered]));
+        mkdirSync(COVERAGE_DIR, { recursive: true });
+        writeFileSync(`${COVERAGE_DIR}${process.pid}.json`, JSON.stringify([...covered]));
       } catch {
         /* best-effort: coverage is advisory, must never fail a suite */
       }

--- a/tests/e2e-prod/package.json
+++ b/tests/e2e-prod/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "smoke": "node smoke.ts",
     "test": "node --test --test-reporter=spec suites/*.test.ts",
+    "coverage:gate": "python3 coverage_gate.py",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/tests/e2e-prod/package.json
+++ b/tests/e2e-prod/package.json
@@ -4,8 +4,10 @@
   "type": "module",
   "scripts": {
     "smoke": "node smoke.ts",
+    "pretest": "rm -rf reports/coverage",
     "test": "node --test --test-reporter=spec suites/*.test.ts",
     "coverage:gate": "python3 coverage_gate.py",
+    "coverage": "npm test; npm run coverage:gate",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/tests/e2e-prod/suites/23-coverage-happy-path.test.ts
+++ b/tests/e2e-prod/suites/23-coverage-happy-path.test.ts
@@ -1,0 +1,119 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { uniqueSlug, uniqueSubject, holdAllOutbound } from "../harness/fixtures.ts";
+import { track, cleanup } from "../harness/cleanup.ts";
+import { writeReport } from "../harness/report.ts";
+
+// Happy-path coverage for operations the rest of the suite only PROBES negatively
+// (updateAgent, updateMessage, forwardMessage, getConversation, replyToMessage,
+// approveMessage). The operationId coverage gate records an op as covered only on
+// a 2xx, so an op that elsewhere gets nothing but a 404/400 probe reads as
+// UNCOVERED. These tests close that gap by INVOKING each op successfully on fresh,
+// isolated agents — no dependency on shared-account state (which made the messaging
+// suite's approve/reply flaky under the full concurrent run).
+const SUITE = "23-coverage-happy-path";
+const client = new ApiClient();
+
+// A real, deliverable recipient: SES accepts + 200s it (a non-simulator recipient
+// 500s on staging's SES sandbox), so outbound-carrying ops actually reach "sent".
+const SIMULATOR = "success@simulator.amazonses.com";
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+async function freshAgent(label: string, hold = false): Promise<string> {
+  const email = `${uniqueSlug(label)}@${client.env.sharedDomain}`;
+  const r = await client.post<{ email: string }>("/v1/agents", {
+    body: { email, name: `cov ${label}` },
+    expect: 201,
+  });
+  track("agent", email);
+  if (hold) {
+    const u = await holdAllOutbound(client, email);
+    assert.equal(u.status, 200, `hold-all-outbound ${email}: ${u.raw.slice(0, 200)}`);
+  }
+  return email;
+}
+
+// Self-send loopback → poll the inbox for the inbound copy (with its conversation id).
+async function loopbackMessage(email: string, subject: string): Promise<{ id: string; conversationId: string }> {
+  await client.post(`/v1/agents/${encodeURIComponent(email)}/messages`, {
+    body: { to: [email], subject, body: "coverage happy-path body" },
+    expect: 200,
+  });
+  for (let i = 0; i < 12; i++) {
+    const list = await client.get<{
+      items: Array<{ message_id: string; subject: string; conversation_id: string }>;
+    }>(`/v1/agents/${encodeURIComponent(email)}/messages`, { query: { direction: "inbound", limit: 20 } });
+    const m = list.body?.items?.find((x) => x.subject === subject);
+    if (m) return { id: m.message_id, conversationId: m.conversation_id };
+    await sleep(1500);
+  }
+  throw new Error(`loopback message "${subject}" never appeared for ${email}`);
+}
+
+test("updateAgent: PATCH an agent's name (200)", async () => {
+  const email = await freshAgent("covua");
+  const r = await client.patch<{ name: string }>(`/v1/agents/${encodeURIComponent(email)}`, {
+    body: { name: "renamed-by-coverage" },
+    expect: 200,
+  });
+  assert.equal(r.body?.name, "renamed-by-coverage");
+});
+
+test("updateMessage + getConversation: label an inbound message, fetch its conversation (200)", async () => {
+  const email = await freshAgent("covum");
+  const { id, conversationId } = await loopbackMessage(email, uniqueSubject("cov um"));
+
+  const upd = await client.patch<{ labels?: string[] }>(`/v1/agents/${encodeURIComponent(email)}/messages/${id}`, {
+    body: { add_labels: ["coverage"] },
+    expect: 200,
+  });
+  assert.ok((upd.body?.labels ?? ["coverage"]).includes("coverage"), "label was added");
+
+  const conv = await client.get<{ conversation_id?: string }>(
+    `/v1/agents/${encodeURIComponent(email)}/conversations/${encodeURIComponent(conversationId)}`,
+    { expect: 200 },
+  );
+  assert.ok(conv.body, "conversation fetched");
+});
+
+test("replyToMessage: reply to an inbound message (self-loopback → 200)", async () => {
+  const email = await freshAgent("covrp");
+  const { id } = await loopbackMessage(email, uniqueSubject("cov rp"));
+  // The loopback message's sender is the agent itself → the reply loops back too.
+  const r = await client.post<{ message_id: string }>(`/v1/agents/${encodeURIComponent(email)}/messages/${id}/reply`, {
+    body: { body: "replying for coverage" },
+    expect: [200, 202],
+  });
+  assert.ok(r.body?.message_id, "reply returned a message id");
+});
+
+test("forwardMessage: forward an inbound message to the simulator (200)", async () => {
+  const email = await freshAgent("covfw");
+  const { id } = await loopbackMessage(email, uniqueSubject("cov fw"));
+  const r = await client.post<{ message_id: string }>(`/v1/agents/${encodeURIComponent(email)}/messages/${id}/forward`, {
+    body: { to: [SIMULATOR], body: "fyi — forwarded for coverage" },
+    expect: [200, 202],
+  });
+  assert.ok(r.body?.message_id, "forward returned a message id");
+});
+
+test("approveMessage: approve a HITL-held outbound (200)", async () => {
+  const email = await freshAgent("covap", true); // holds all outbound for review
+  const send = await client.post<{ status: string; message_id: string }>(
+    `/v1/agents/${encodeURIComponent(email)}/messages`,
+    { body: { to: [SIMULATOR], subject: uniqueSubject("cov ap"), body: "to approve" }, expect: 202 },
+  );
+  assert.equal(send.body?.status, "pending_review");
+  const id = send.body!.message_id;
+  const ap = await client.post<{ message_id: string; status: string }>(
+    `/v1/agents/${encodeURIComponent(email)}/messages/${id}/approve`,
+    { body: {}, expect: 200 },
+  );
+  assert.equal(ap.body?.message_id, id);
+});
+
+after(async () => {
+  await cleanup(client);
+  await writeReport(`./reports/${SUITE}.json`);
+});


### PR DESCRIPTION
## P4 — API operationId coverage gate

Fails CI if any OpenAPI operation is in the spec but no e2e-prod suite **successfully exercises** it. **Validated on staging: 54 covered + 2 allowlisted = all 56 → GATE PASS** (reviewed + adversarially reviewed; the fixes below made the gate honest, which then surfaced — and closed — real coverage gaps).

### How it works
- **`harness/coverage.ts`** + a hook in `client.ts`: each request is recorded **after the response, only on a 2xx** — so "covered" means the operation ran successfully, not merely that a request was shaped at the route (a 401 auth-probe / 404 unknown-id test does not count). Each `node --test` suite process flushes a shard to **`reports/coverage/`** (a subdir, invisible to `consolidate.ts`); a **`pretest` clean** guarantees fresh shards so a prior run can't inflate coverage.
- **`coverage_gate.py`**: unions the shards, maps each concrete path to the most-specific operationId in `api/openapi.yaml`, compares to the 56-op catalog. Exits 1 on any uncovered non-allowlisted op. Allowlist keys are validated against the spec; `match_op` errors on an ambiguous tie. Run via `npm run coverage:gate` (or `npm run coverage` = clean → suite → gate).

### The strict semantic found real gaps — now filled
The old "record any request" version *hid* that 7 operations were only probed negatively, never successfully exercised. Closed:
- **`suites/23-coverage-happy-path.test.ts`** (new): reliable happy paths for `updateAgent` / `updateMessage` / `getConversation` / `replyToMessage` / `forwardMessage` / `approveMessage` on **fresh isolated agents** (loopback + SES simulator) — no dependency on shared-account state.
- **`deleteSuppression`** allowlisted: no `createSuppression` API (a suppression only exists after a real SES bounce), so nothing to delete black-box; the 404 path stays covered by `19-account`.

### Scope
The 56 typed **`/v1` operationIds**. Non-`/v1` surface (billing, MCP, OAuth, health, webhooks) + webhook **event types** are out of scope here — covered by their own suites (e.g. `21-webhook-events`).

### Pipeline note (task 6)
A full staging run still has ~21 env/flaky failures (MCP + billing suites — those services aren't in the tunnel'd staging stack; a few shared-account messaging/WS flakes). **Coverage is unaffected** (satisfied by reliable tests), but the pipeline must run the gate on a suite it keeps green — bring MCP + billing up in staging or scope the gate's suite set.

Completes the P0–P4 conformance suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Btj6LswdbWqSgMavGJzBp