### PR TITLE
feat(prober): mcp_http_round_trip scenario — gate the deployed HTTP MCP surface

### DIFF
--- a/cmd/e2a-prober/config.go
+++ b/cmd/e2a-prober/config.go
@@ -14,6 +14,7 @@ type config struct {
 	AgentEmail    string
 	APIKey        string
 	WebhookSecret string
+	MCPBaseURL    string        // deployed streamable-HTTP MCP endpoint; empty ⇒ mcp scenario skips
 	SinkURL       string        // what the probe webhook targets (== Listen's public addr + /sink)
 	Listen        string        // serve/run-once bind addr for the sink + status server
 	Interval      time.Duration // serve loop period
@@ -28,6 +29,7 @@ func configFromEnv() config {
 		AgentEmail:    os.Getenv("E2A_PROBE_AGENT_EMAIL"),
 		APIKey:        os.Getenv("E2A_PROBE_API_KEY"),
 		WebhookSecret: os.Getenv("E2A_PROBE_WEBHOOK_SECRET"),
+		MCPBaseURL:    os.Getenv("E2A_PROBE_MCP_URL"),
 		SinkURL:       os.Getenv("E2A_PROBE_SINK_URL"),
 		Listen:        envOr("E2A_PROBE_LISTEN", ":8090"),
 		Interval:      envDuration("E2A_PROBE_INTERVAL", 30*time.Second),

--- a/cmd/e2a-prober/serve.go
+++ b/cmd/e2a-prober/serve.go
@@ -43,6 +43,7 @@ func (p *prober) probe() *selftest.Probe {
 		AgentEmail:    p.cfg.AgentEmail,
 		SMTPAddr:      p.cfg.SMTPAddr,
 		WebhookSecret: p.cfg.WebhookSecret,
+		MCPBaseURL:    p.cfg.MCPBaseURL,
 		Sink:          p.sink,
 		Timeout:       p.cfg.Timeout,
 	}

--- a/docs/design/prober-selftest.md
+++ b/docs/design/prober-selftest.md
@@ -193,9 +193,13 @@ One binary, several modes (mirrors `cmd/e2a-contract-server`):
 (`GET /v1/agents/{probe}`); **inbound round-trip** (`smtp.SendMail` a unique nonce
 to the SMTP listener → await webhook at `/sink` within the round-trip timeout →
 verify nonce correlation + HMAC); self-send loopback (outbound API + compose path,
-method=loopback, no egress); and **agent_lifecycle** (create → get → delete an
+method=loopback, no egress); **agent_lifecycle** (create → get → delete an
 ephemeral agent on the probe's verified domain — the only mutating scenario,
-self-cleaning via a deferred best-effort delete, no email/owner-notify/metering).
+self-cleaning via a deferred best-effort delete, no email/owner-notify/metering);
+and **mcp_http_round_trip** (the deployed streamable-HTTP MCP surface: a stateless
+Bearer-authed `tools/list` then a `whoami` `tools/call` over the real SSE
+transport — both read-only; skips-as-pass when `E2A_PROBE_MCP_URL` is unset, so a
+stack without an MCP endpoint stays green).
 *(fast-follow)* 5xx SLI from `e2a:/metrics`.
 
 ### SLI exposure on `e2a` (phase 2 / fast-follow)

--- a/internal/selftest/scenarios.go
+++ b/internal/selftest/scenarios.go
@@ -44,6 +44,12 @@ var All = []Scenario{
 	// create/delete churn is heavier than the read-only checks; an operator who
 	// wants a purely read-only prod battery can drop it.
 	{Name: "agent_lifecycle", SmokeSafe: true, Run: scenarioAgentLifecycle},
+	// mcp_http_round_trip exercises the DEPLOYED streamable-HTTP MCP surface
+	// (the co-versioned mcp-server image + its Caddy /mcp route), which no other
+	// scenario touches — tools/list then a whoami tool call, both read-only. It
+	// SKIPS (pass) when E2A_PROBE_MCP_URL is unset, so a prober without an MCP
+	// endpoint configured stays green.
+	{Name: "mcp_http_round_trip", SmokeSafe: true, Run: scenarioMCPHTTPRoundTrip},
 }
 
 func pass(detail string) Result { return Result{Status: StatusPass, Detail: detail} }
@@ -296,6 +302,160 @@ func (p *Probe) do(ctx context.Context, method, u string, body []byte) (int, []b
 	defer resp.Body.Close()
 	out, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	return resp.StatusCode, out, nil
+}
+
+// scenarioMCPHTTPRoundTrip exercises the DEPLOYED streamable-HTTP MCP server —
+// the surface that ships to prod but that every other scenario ignores. It is
+// two read-only JSON-RPC calls over the real transport:
+//
+//  1. tools/list — proves the /mcp route, the SSE transport, Bearer auth, and
+//     the tool registry are all live on the candidate mcp-server image;
+//  2. tools/call whoami — a genuine end-to-end MCP dispatch (transport → tool
+//     handler → e2a backend → back), with no mutation and nothing to clean up.
+//
+// The server is stateless (sessionIdGenerator=undefined), so each POST stands
+// alone — no initialize handshake, no Mcp-Session-Id. It authenticates with the
+// probe agent's own Bearer key (the MCP server forwards it to the backend).
+//
+// When E2A_PROBE_MCP_URL is unset the scenario SKIPS (returns pass) so a prober
+// with no MCP endpoint configured — e.g. a stack without the mcp-server — stays
+// green rather than warning.
+func scenarioMCPHTTPRoundTrip(ctx context.Context, p *Probe) Result {
+	if p.MCPBaseURL == "" {
+		return pass("skipped: E2A_PROBE_MCP_URL unset")
+	}
+
+	// 1. tools/list
+	env, st, err := p.mcpCall(ctx, 1, "tools/list", nil)
+	if err != nil {
+		return fail("mcp tools/list: %v", err)
+	}
+	if st != http.StatusOK {
+		return fail("mcp tools/list: HTTP %d, want 200", st)
+	}
+	names := mcpToolNames(env)
+	if len(names) == 0 {
+		return fail("mcp tools/list: no tools returned")
+	}
+	found := false
+	for _, n := range names {
+		if n == "whoami" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fail("mcp tools/list: missing expected tool 'whoami' (got %d tools)", len(names))
+	}
+
+	// 2. tools/call whoami
+	env, st, err = p.mcpCall(ctx, 2, "tools/call", map[string]any{
+		"name":      "whoami",
+		"arguments": map[string]any{},
+	})
+	if err != nil {
+		return fail("mcp whoami call: %v", err)
+	}
+	if st != http.StatusOK {
+		return fail("mcp whoami call: HTTP %d, want 200", st)
+	}
+	if e, ok := env["error"]; ok && e != nil {
+		return fail("mcp whoami call: JSON-RPC error: %v", e)
+	}
+	res, ok := env["result"].(map[string]any)
+	if !ok {
+		return fail("mcp whoami call: response has no result object")
+	}
+	if isErr, _ := res["isError"].(bool); isErr {
+		return fail("mcp whoami call: tool result isError=true")
+	}
+	if content, ok := res["content"].([]any); !ok || len(content) == 0 {
+		return fail("mcp whoami call: empty tool result content")
+	}
+	return pass("mcp http tools/list + whoami round-trip ok")
+}
+
+// mcpCall POSTs one JSON-RPC request to the streamable-HTTP MCP endpoint and
+// returns the decoded response envelope. The MCP SDK answers a POST as an SSE
+// stream (text/event-stream) unless JSON responses are enabled, so the body is
+// parsed accordingly. A non-200 returns (nil, status, nil) — the caller decides.
+func (p *Probe) mcpCall(ctx context.Context, id int, method string, params any) (map[string]any, int, error) {
+	reqBody := map[string]any{"jsonrpc": "2.0", "id": id, "method": method}
+	if params != nil {
+		reqBody["params"] = params
+	}
+	b, _ := json.Marshal(reqBody)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.MCPBaseURL, bytes.NewReader(b))
+	if err != nil {
+		return nil, 0, err
+	}
+	req.Header.Set("Authorization", "Bearer "+p.APIKey)
+	req.Header.Set("Content-Type", "application/json")
+	// Streamable-HTTP requires the client to accept both framings.
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	resp, err := p.httpClient().Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode != http.StatusOK {
+		return nil, resp.StatusCode, nil
+	}
+	env, err := parseJSONRPCEnvelope(raw, resp.Header.Get("Content-Type"))
+	if err != nil {
+		return nil, resp.StatusCode, err
+	}
+	return env, resp.StatusCode, nil
+}
+
+// parseJSONRPCEnvelope decodes a JSON-RPC message from an MCP streamable-HTTP
+// response, accepting either a bare JSON body or an SSE stream. For SSE it walks
+// each event's data: lines and returns the first that decodes to a message
+// carrying a "jsonrpc" key (ignoring pings / other event types).
+func parseJSONRPCEnvelope(raw []byte, contentType string) (map[string]any, error) {
+	if strings.Contains(contentType, "text/event-stream") {
+		body := strings.ReplaceAll(string(raw), "\r\n", "\n")
+		for _, event := range strings.Split(body, "\n\n") {
+			var data strings.Builder
+			for _, line := range strings.Split(event, "\n") {
+				if after, ok := strings.CutPrefix(line, "data:"); ok {
+					data.WriteString(strings.TrimPrefix(after, " "))
+				}
+			}
+			if data.Len() == 0 {
+				continue
+			}
+			var env map[string]any
+			if err := json.Unmarshal([]byte(data.String()), &env); err != nil {
+				continue
+			}
+			if _, ok := env["jsonrpc"]; ok {
+				return env, nil
+			}
+		}
+		return nil, fmt.Errorf("no JSON-RPC message in SSE stream")
+	}
+	var env map[string]any
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return nil, fmt.Errorf("decode JSON-RPC body: %w", err)
+	}
+	return env, nil
+}
+
+// mcpToolNames pulls the tool names out of a tools/list result envelope.
+func mcpToolNames(env map[string]any) []string {
+	res, _ := env["result"].(map[string]any)
+	rawTools, _ := res["tools"].([]any)
+	names := make([]string, 0, len(rawTools))
+	for _, t := range rawTools {
+		if tm, ok := t.(map[string]any); ok {
+			if n, ok := tm["name"].(string); ok {
+				names = append(names, n)
+			}
+		}
+	}
+	return names
 }
 
 // verifyHMAC checks the X-E2A-Signature header against the body using the

--- a/internal/selftest/scenarios.go
+++ b/internal/selftest/scenarios.go
@@ -317,9 +317,14 @@ func (p *Probe) do(ctx context.Context, method, u string, body []byte) (int, []b
 // alone — no initialize handshake, no Mcp-Session-Id. It authenticates with the
 // probe agent's own Bearer key (the MCP server forwards it to the backend).
 //
-// When E2A_PROBE_MCP_URL is unset the scenario SKIPS (returns pass) so a prober
-// with no MCP endpoint configured — e.g. a stack without the mcp-server — stays
-// green rather than warning.
+// E2A_PROBE_MCP_URL is the in-cluster endpoint (e.g. http://mcp-server:3000/mcp),
+// matching how the other probe vars address containers directly. NOTE: the MCP
+// server enforces a Host allowlist (MCP_ALLOWED_HOSTS) on /mcp and 421s anything
+// else, so that URL's host MUST be in the deployment's allowlist — the staging
+// compose adds the in-cluster service name there. When E2A_PROBE_MCP_URL is unset
+// the scenario SKIPS (returns pass) so a prober with no MCP endpoint configured
+// stays green rather than warning; the release pipeline's prober gate separately
+// asserts the scenario actually ran (didn't skip) on staging.
 func scenarioMCPHTTPRoundTrip(ctx context.Context, p *Probe) Result {
 	if p.MCPBaseURL == "" {
 		return pass("skipped: E2A_PROBE_MCP_URL unset")
@@ -369,8 +374,27 @@ func scenarioMCPHTTPRoundTrip(ctx context.Context, p *Probe) Result {
 	if isErr, _ := res["isError"].(bool); isErr {
 		return fail("mcp whoami call: tool result isError=true")
 	}
-	if content, ok := res["content"].([]any); !ok || len(content) == 0 {
+	content, ok := res["content"].([]any)
+	if !ok || len(content) == 0 {
 		return fail("mcp whoami call: empty tool result content")
+	}
+	// Require an actual non-empty text block — a bare 200 with an empty/typeless
+	// content array (a backend returning nothing useful) must not pass.
+	hasText := false
+	for _, c := range content {
+		cm, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		if t, _ := cm["type"].(string); t == "text" {
+			if s, _ := cm["text"].(string); strings.TrimSpace(s) != "" {
+				hasText = true
+				break
+			}
+		}
+	}
+	if !hasText {
+		return fail("mcp whoami call: result has no non-empty text content")
 	}
 	return pass("mcp http tools/list + whoami round-trip ok")
 }
@@ -420,6 +444,10 @@ func parseJSONRPCEnvelope(raw []byte, contentType string) (map[string]any, error
 			var data strings.Builder
 			for _, line := range strings.Split(event, "\n") {
 				if after, ok := strings.CutPrefix(line, "data:"); ok {
+					// SSE joins successive data: lines within one event with \n.
+					if data.Len() > 0 {
+						data.WriteByte('\n')
+					}
 					data.WriteString(strings.TrimPrefix(after, " "))
 				}
 			}

--- a/internal/selftest/scenarios_internal_test.go
+++ b/internal/selftest/scenarios_internal_test.go
@@ -7,6 +7,9 @@ package selftest
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -115,4 +118,92 @@ func TestRunWorst_WithFailure(t *testing.T) {
 	if Worst(nil) != StatusFail {
 		t.Errorf("Worst(nil) = %s, want fail", Worst(nil))
 	}
+}
+
+// mcpStub is a minimal streamable-HTTP MCP server: it decodes the JSON-RPC
+// method and answers over SSE (the SDK's default framing), so it exercises the
+// scenario's real transport + SSE parsing. tools/list returns the given tool
+// names; tools/call returns a non-error text result.
+func mcpStub(t *testing.T, toolNames []string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		var req struct {
+			ID     int    `json:"id"`
+			Method string `json:"method"`
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &req)
+		var result string
+		switch req.Method {
+		case "tools/list":
+			tools := make([]string, 0, len(toolNames))
+			for _, n := range toolNames {
+				tools = append(tools, fmt.Sprintf(`{"name":%q}`, n))
+			}
+			result = fmt.Sprintf(`{"tools":[%s]}`, joinComma(tools))
+		case "tools/call":
+			result = `{"content":[{"type":"text","text":"agent@probe.test"}],"isError":false}`
+		default:
+			result = `{}`
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":%d,\"result\":%s}\n\n", req.ID, result)
+	}))
+}
+
+func joinComma(ss []string) string {
+	out := ""
+	for i, s := range ss {
+		if i > 0 {
+			out += ","
+		}
+		out += s
+	}
+	return out
+}
+
+func TestScenarioMCPHTTPRoundTrip(t *testing.T) {
+	// Unconfigured (no MCP URL) → skip-as-pass, so a prober without an MCP
+	// endpoint stays green.
+	if r := scenarioMCPHTTPRoundTrip(context.Background(), failProbe("http://127.0.0.1:1", "", nil)); r.Status != StatusPass {
+		t.Errorf("unconfigured MCP: status = %s (%q), want pass (skip)", r.Status, r.Detail)
+	}
+
+	// Happy path over the real SSE transport: tools/list (incl. whoami) then a
+	// whoami tool call.
+	srv := mcpStub(t, []string{"whoami", "create_agent", "list_agents"})
+	defer srv.Close()
+	p := failProbe("http://127.0.0.1:1", "", nil)
+	p.MCPBaseURL = srv.URL
+	if r := scenarioMCPHTTPRoundTrip(context.Background(), p); r.Status != StatusPass {
+		t.Errorf("happy path: status = %s (%q), want pass", r.Status, r.Detail)
+	}
+}
+
+func TestScenarioMCPHTTPRoundTrip_Fail(t *testing.T) {
+	// tools/list succeeds but omits whoami → the registry is wrong.
+	srv := mcpStub(t, []string{"send_message"})
+	defer srv.Close()
+	p := failProbe("http://127.0.0.1:1", "", nil)
+	p.MCPBaseURL = srv.URL
+	mustFail(t, "tools/list missing whoami", scenarioMCPHTTPRoundTrip(context.Background(), p))
+
+	// 500 from the MCP endpoint → fail.
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv2.Close()
+	p2 := failProbe("http://127.0.0.1:1", "", nil)
+	p2.MCPBaseURL = srv2.URL
+	mustFail(t, "mcp 500", scenarioMCPHTTPRoundTrip(context.Background(), p2))
+
+	// Endpoint unreachable → fail.
+	p3 := failProbe("http://127.0.0.1:1", "", nil)
+	p3.MCPBaseURL = "http://127.0.0.1:1/mcp"
+	mustFail(t, "mcp unreachable", scenarioMCPHTTPRoundTrip(context.Background(), p3))
 }

--- a/internal/selftest/scenarios_internal_test.go
+++ b/internal/selftest/scenarios_internal_test.go
@@ -207,3 +207,99 @@ func TestScenarioMCPHTTPRoundTrip_Fail(t *testing.T) {
 	p3.MCPBaseURL = "http://127.0.0.1:1/mcp"
 	mustFail(t, "mcp unreachable", scenarioMCPHTTPRoundTrip(context.Background(), p3))
 }
+
+// sseMsg frames a JSON-RPC result as one SSE message event.
+func sseMsg(id int, result string) string {
+	return fmt.Sprintf("event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":%d,\"result\":%s}\n\n", id, result)
+}
+
+// mcpWhoamiStub answers tools/list with a whoami tool, and tools/call with the
+// caller-supplied result JSON — to drive the whoami-result assertion branches.
+func mcpWhoamiStub(t *testing.T, whoamiResult string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			ID     int    `json:"id"`
+			Method string `json:"method"`
+		}
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &req)
+		w.Header().Set("Content-Type", "text/event-stream")
+		if req.Method == "tools/list" {
+			fmt.Fprint(w, sseMsg(req.ID, `{"tools":[{"name":"whoami"}]}`))
+			return
+		}
+		fmt.Fprint(w, sseMsg(req.ID, whoamiResult))
+	}))
+}
+
+func TestScenarioMCPHTTPRoundTrip_WhoamiBranches(t *testing.T) {
+	cases := []struct {
+		name   string
+		result string
+	}{
+		{"isError true", `{"content":[{"type":"text","text":"boom"}],"isError":true}`},
+		{"empty content", `{"content":[]}`},
+		{"content but no text block", `{"content":[{"type":"image","data":"x"}]}`},
+		{"no result object", `null`},
+	}
+	for _, tc := range cases {
+		srv := mcpWhoamiStub(t, tc.result)
+		p := failProbe("http://127.0.0.1:1", "", nil)
+		p.MCPBaseURL = srv.URL
+		mustFail(t, "whoami "+tc.name, scenarioMCPHTTPRoundTrip(context.Background(), p))
+		srv.Close()
+	}
+
+	// JSON-RPC error envelope on the whoami call → fail.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			ID     int    `json:"id"`
+			Method string `json:"method"`
+		}
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &req)
+		w.Header().Set("Content-Type", "text/event-stream")
+		if req.Method == "tools/list" {
+			fmt.Fprint(w, sseMsg(req.ID, `{"tools":[{"name":"whoami"}]}`))
+			return
+		}
+		fmt.Fprintf(w, "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":%d,\"error\":{\"code\":-32603,\"message\":\"internal\"}}\n\n", req.ID)
+	}))
+	defer srv.Close()
+	p := failProbe("http://127.0.0.1:1", "", nil)
+	p.MCPBaseURL = srv.URL
+	mustFail(t, "whoami json-rpc error", scenarioMCPHTTPRoundTrip(context.Background(), p))
+}
+
+func TestParseJSONRPCEnvelope(t *testing.T) {
+	// application/json body (enableJsonResponse path).
+	env, err := parseJSONRPCEnvelope([]byte(`{"jsonrpc":"2.0","id":1,"result":{"ok":true}}`), "application/json")
+	if err != nil || env["result"] == nil {
+		t.Fatalf("json branch: env=%v err=%v", env, err)
+	}
+
+	// SSE with a ping/comment line, CRLF terminators, and a charset param — all
+	// of which a real proxy/SDK may emit.
+	sse := ":ping\r\nevent: message\r\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{\"ok\":true}}\r\n\r\n"
+	env, err = parseJSONRPCEnvelope([]byte(sse), "text/event-stream; charset=utf-8")
+	if err != nil || env["result"] == nil {
+		t.Fatalf("sse+comment+crlf branch: env=%v err=%v", env, err)
+	}
+
+	// One JSON object split across two data: lines (joined with \n → valid JSON).
+	split := "event: message\ndata: {\"jsonrpc\":\"2.0\",\"id\":1,\ndata: \"result\":{\"ok\":true}}\n\n"
+	env, err = parseJSONRPCEnvelope([]byte(split), "text/event-stream")
+	if err != nil || env["result"] == nil {
+		t.Fatalf("sse multi-data join: env=%v err=%v", env, err)
+	}
+
+	// Non-JSON body (e.g. an HTML error page from a proxy) → error, never a pass.
+	if _, err := parseJSONRPCEnvelope([]byte("<html>bad gateway</html>"), "text/html"); err == nil {
+		t.Error("html body: want decode error")
+	}
+	// SSE stream carrying no JSON-RPC message → error.
+	if _, err := parseJSONRPCEnvelope([]byte(":keep-alive\n\nevent: ping\ndata: {}\n\n"), "text/event-stream"); err == nil {
+		t.Error("sse without jsonrpc message: want error")
+	}
+}

--- a/internal/selftest/selftest.go
+++ b/internal/selftest/selftest.go
@@ -57,6 +57,7 @@ type Probe struct {
 	AgentEmail    string        // the synthetic probe agent address
 	SMTPAddr      string        // host:port of the inbound SMTP listener
 	WebhookSecret string        // signing secret of the probe webhook (HMAC verify)
+	MCPBaseURL    string        // deployed streamable-HTTP MCP endpoint, e.g. http://mcp-server:3000/mcp; empty ⇒ mcp scenario skips
 	Sink          *HTTPSink     // receives the webhook callback for the round-trip
 	HTTP          *http.Client  // nil → defaultHTTPClient
 	Timeout       time.Duration // round-trip await timeout; 0 → defaultRoundTripTimeout


### PR DESCRIPTION
## Why

The prober battery (`internal/selftest.All`) covers liveness, auth, inbound round-trip, outbound send, loopback, and agent CRUD — but **nothing exercises the deployed streamable-HTTP MCP server** (`e2a-mcp-http`, co-versioned with the server, behind Caddy's `/mcp` route). Today it ships to prod validated only by "the container started." The e2e MCP suites (`tests/e2e-prod/suites/08-mcp`, `12-mcp-extended`) spawn a **local stdio** MCP server — they test the tool logic, not the deployed HTTP transport/auth.

## What

A SmokeSafe `mcp_http_round_trip` scenario making two **read-only** JSON-RPC calls against the real MCP endpoint:

1. **`tools/list`** — proves the `/mcp` route, SSE transport, Bearer auth, and tool registry are live on the candidate image.
2. **`tools/call whoami`** — a genuine end-to-end MCP dispatch (transport → tool handler → e2a backend → back). No mutation, nothing to clean up.

The server is **stateless** (`sessionIdGenerator=undefined`), so each POST stands alone — no `initialize` handshake, no `Mcp-Session-Id`. It authenticates with the probe agent's own Bearer key (the MCP server forwards it to the backend). The response parser accepts either SSE (SDK default) or plain JSON.

## Config

`E2A_PROBE_MCP_URL` (e.g. `http://mcp-server:3000/mcp`). **Unset ⇒ the scenario skips-as-pass**, so a prober on a stack without an MCP endpoint stays green rather than warning (`StatusWarn` would break the deploy bake-gate's `consecutive_green`). The staging deploy sets it; prod need not until we wire it.

## Tests

Skip path, a happy round-trip over a real SSE `httptest` stub, and three failure modes (registry missing `whoami`, 5xx, unreachable). `gofmt`/`vet` clean; `internal/selftest` fully green.

> Note: `cmd/e2a-prober` `TestCmdValidate_Failures` fails on my **local** dirty test DB ("1600 columns" from repeated migration runs) — pre-existing, references none of these changes; CI's fresh DB is the real signal.

## Follow-on (e2a-ops)

Set `E2A_PROBE_MCP_URL=http://mcp-server:3000/mcp` on the staging `prober` service so the release pipeline's prober gate covers real MCP once a release carrying this lands.