### PR TITLE
fix(usage): count only active agents so usage.agents matches /v1/agents

### DIFF
--- a/internal/usage/agents_count_test.go
+++ b/internal/usage/agents_count_test.go
@@ -1,0 +1,91 @@
+package usage_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+	"github.com/Mnexa-AI/e2a/internal/usage"
+)
+
+// TestCountAgentsByUser_ExcludesOrphanedAgents is the regression guard for the
+// usage.agents / GET /v1/agents disagreement: CountAgentsByUser (which feeds
+// both usage.Agents in the account view and the max_agents cap) must count only
+// ACTIVE agents — those whose domain row still exists — so the count always
+// equals the length of identity.Store.ListAgentsByUser. An agent orphaned onto
+// a missing domain must NOT be counted; before the JOIN fix it inflated the
+// count above the list length and silently consumed a plan slot.
+func TestCountAgentsByUser_ExcludesOrphanedAgents(t *testing.T) {
+	pool := testutil.TestDB(t)
+	usageStore := usage.NewStore(pool)
+	idStore := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, err := idStore.CreateOrGetUser(ctx, "orphan-count@example.com", "Orphan Count", "google-orphan-count")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+
+	// One agent on a live domain (active) and one on a domain we will delete
+	// out from under it (orphaned).
+	if _, err := idStore.ClaimOrCreateDomain(ctx, "keep.example.com", user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain keep: %v", err)
+	}
+	if _, err := idStore.ClaimOrCreateDomain(ctx, "gone.example.com", user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain gone: %v", err)
+	}
+	if _, err := idStore.CreateAgent(ctx, "bot@keep.example.com", "keep.example.com", "", "", "", user.ID); err != nil {
+		t.Fatalf("CreateAgent keep: %v", err)
+	}
+	if _, err := idStore.CreateAgent(ctx, "bot@gone.example.com", "gone.example.com", "", "", "", user.ID); err != nil {
+		t.Fatalf("CreateAgent gone: %v", err)
+	}
+
+	// Sanity: before orphaning, both agents are active and counted.
+	if n, err := usageStore.CountAgentsByUser(ctx, user.ID); err != nil || n != 2 {
+		t.Fatalf("pre-orphan CountAgentsByUser = %d, err=%v; want 2", n, err)
+	}
+
+	// Orphan the second agent by deleting its domain row. The
+	// agent_identities.domain FK is ON DELETE NO ACTION, so a normal delete is
+	// blocked; disable replication-role triggers on a single pinned connection
+	// to force the orphaned state this test exists to reproduce.
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("pool.Acquire: %v", err)
+	}
+	if _, err := conn.Exec(ctx, `SET session_replication_role = 'replica'`); err != nil {
+		conn.Release()
+		t.Fatalf("disable FK triggers: %v", err)
+	}
+	_, delErr := conn.Exec(ctx, `DELETE FROM domains WHERE domain = 'gone.example.com'`)
+	_, resetErr := conn.Exec(ctx, `SET session_replication_role = 'origin'`)
+	conn.Release()
+	if delErr != nil {
+		t.Fatalf("delete domain row: %v", delErr)
+	}
+	if resetErr != nil {
+		t.Fatalf("reset replication role: %v", resetErr)
+	}
+
+	// The list is the source of truth for "an agent"; the count must match it.
+	agents, err := idStore.ListAgentsByUser(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("ListAgentsByUser: %v", err)
+	}
+	if len(agents) != 1 {
+		t.Fatalf("ListAgentsByUser returned %d agents, want 1 (orphaned agent excluded)", len(agents))
+	}
+
+	count, err := usageStore.CountAgentsByUser(ctx, user.ID)
+	if err != nil {
+		t.Fatalf("CountAgentsByUser: %v", err)
+	}
+	if count != len(agents) {
+		t.Errorf("CountAgentsByUser = %d, but /v1/agents list length = %d; usage.agents must match the list", count, len(agents))
+	}
+	if count != 1 {
+		t.Errorf("CountAgentsByUser = %d, want 1 (orphaned agent must not consume a slot)", count)
+	}
+}

--- a/internal/usage/store.go
+++ b/internal/usage/store.go
@@ -108,10 +108,25 @@ func (s *Store) GetAccountClass(ctx context.Context, userID string) (AccountClas
 	return AccountClass(class), nil
 }
 
+// CountAgentsByUser returns the number of ACTIVE agents owned by the user —
+// active meaning the agent's domain row still exists. The INNER JOIN on
+// domains mirrors identity.Store.ListAgentsByUser EXACTLY (same
+// `agent_identities a JOIN domains d ON a.domain = d.domain WHERE a.user_id`
+// predicate), so this count is guaranteed to equal the length of the
+// /v1/agents list. Without the join an orphaned agent (one whose domain row
+// is gone) would inflate the count above the list length, silently consuming
+// a plan slot and letting usage.agents exceed max_agents while the agent is
+// invisible to the user. Both consumers — the account usage view
+// (usage.Agents) and the max_agents cap in limits.DBEnforcer.CheckAgentCreate
+// — therefore count only agents the user can actually see and manage, so an
+// orphaned agent neither shows up as usage nor blocks creating a new one.
 func (s *Store) CountAgentsByUser(ctx context.Context, userID string) (int, error) {
 	var count int
 	err := s.pool.QueryRow(ctx,
-		`SELECT COUNT(*) FROM agent_identities WHERE user_id = $1`, userID,
+		`SELECT COUNT(*)
+		   FROM agent_identities a
+		   JOIN domains d ON a.domain = d.domain
+		  WHERE a.user_id = $1`, userID,
 	).Scan(&count)
 	return count, err
 }


### PR DESCRIPTION
## Problem

`usage.agents` (in `GET /v1/account`) and `GET /v1/agents` disagreed on what counts as "an agent":

- `internal/usage/store.go` `CountAgentsByUser` = `SELECT COUNT(*) FROM agent_identities WHERE user_id = $1` — **no join**. Wired to `usage.Agents` in `internal/apiserver/apiserver.go`.
- `internal/identity/store.go` `ListAgentsByUser` (backing `GET /v1/agents`) lists via `FROM agent_identities a JOIN domains d ON a.domain = d.domain WHERE a.user_id = $1` — so an agent whose `domains` row is gone (orphaned) is **not** listed.

Result: `usage.agents` could exceed the list length; an orphaned agent invisibly consumed a plan slot. The same counter also enforces the `max_agents` cap via `internal/limits/enforcer.go` (`CheckAgentCreate`), so an invisible agent could also block creating a new one.

## Fix

Make `CountAgentsByUser` count only **active** agents by mirroring the list predicate **exactly** — adding the same `JOIN domains d ON a.domain = d.domain`. This guarantees `count == len(ListAgentsByUser)`.

### Consumer behavior after the fix

1. **`usage.Agents`** (the account view) — now reports the same number the user sees in `GET /v1/agents`.
2. **`max_agents` enforcement** (`limits.DBEnforcer.CheckAgentCreate`) — now counts only active agents, so an orphaned agent no longer blocks creating a new one against the cap.

Both are the intended, consistent behavior: an orphaned agent should neither show up as usage nor consume a cap slot.

### `CountDomainsByUser` — no change

`domains` is the parent table; its count predicate (`WHERE user_id = $1`) already matches `ListDomainsByUser` exactly (no join). Left as-is intentionally.

## Contract impact

Server-internal value fix only. `AccountView` shape is unchanged, so **no SDK / OpenAPI / CLI / MCP changes** are needed.

## Tests

- `go build ./...` clean.
- `go test ./internal/usage/... ./internal/limits/... ./internal/httpapi/...` — all pass.
- Adds a DB-backed regression test (`TestCountAgentsByUser_ExcludesOrphanedAgents`) that creates a user with one active agent and one agent orphaned onto a deleted domain, then asserts `CountAgentsByUser` == the `/v1/agents` list length (both == 1). Verified load-bearing: it fails (`count = 2`) against the old bare-COUNT query and passes with the JOIN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)