### PR TITLE
fix(api): return 404 not_found for a missing or non-owned agent

### DIFF
--- a/internal/httpapi/agents_write.go
+++ b/internal/httpapi/agents_write.go
@@ -167,7 +167,7 @@ func (s *Server) handleDeleteAgent(ctx context.Context, in *deleteAgentInput) (*
 		return nil, err
 	}
 	// Confirm after ownership: don't prompt to confirm deleting an agent the
-	// caller can't even touch (a not-owned agent is 403/404 first).
+	// caller can't even touch (a not-owned agent is 404 first).
 	if in.Confirm != "DELETE" {
 		return nil, NewError(http.StatusBadRequest, "confirmation_required", "add ?confirm=DELETE to the request to proceed — this is irreversible")
 	}

--- a/internal/httpapi/agents_write_test.go
+++ b/internal/httpapi/agents_write_test.go
@@ -54,8 +54,8 @@ func TestUpdateAgentNotOwned(t *testing.T) {
 	code, _ := sendJSON(t, "PATCH", srv.URL+"/v1/agents/other%40acme.com", "good", map[string]any{
 		"name": "x",
 	})
-	if code != 403 {
-		t.Fatalf("want 403, got %d", code)
+	if code != 404 {
+		t.Fatalf("want 404, got %d", code)
 	}
 }
 
@@ -70,8 +70,8 @@ func TestDeleteAgent(t *testing.T) {
 func TestDeleteAgentNotOwned(t *testing.T) {
 	srv := testServer(t)
 	code, _ := sendJSON(t, "DELETE", srv.URL+"/v1/agents/other%40acme.com", "good", nil)
-	if code != 403 {
-		t.Fatalf("want 403, got %d", code)
+	if code != 404 {
+		t.Fatalf("want 404, got %d", code)
 	}
 }
 

--- a/internal/httpapi/apikeys_test.go
+++ b/internal/httpapi/apikeys_test.go
@@ -70,12 +70,13 @@ func TestCreateAgentScopedAPIKeyRequiresAgent(t *testing.T) {
 
 func TestCreateAgentScopedAPIKeyUnknownAgent(t *testing.T) {
 	srv := testServer(t)
-	// resolveOwnedAgent rejects an agent the caller doesn't own (403).
+	// resolveOwnedAgent reports an agent the caller doesn't own as 404 not_found
+	// (indistinguishable from a nonexistent one — anti-enumeration).
 	code, _ := postJSON(t, srv.URL+"/v1/account/api-keys", "good", map[string]any{
 		"scope": "agent", "agent": "stranger@evil.com",
 	})
-	if code != 403 {
-		t.Fatalf("want 403 for an unowned agent, got %d", code)
+	if code != 404 {
+		t.Fatalf("want 404 for an unowned agent, got %d", code)
 	}
 }
 

--- a/internal/httpapi/hitl_test.go
+++ b/internal/httpapi/hitl_test.go
@@ -42,8 +42,8 @@ func TestApproveNotFound(t *testing.T) {
 func TestApproveNotOwnedAgent(t *testing.T) {
 	srv := testServer(t)
 	code, _ := postJSON(t, srv.URL+"/v1/agents/other%40acme.com/messages/msg_pending/approve", "good", map[string]any{})
-	if code != 403 {
-		t.Fatalf("want 403, got %d", code)
+	if code != 404 {
+		t.Fatalf("want 404, got %d", code)
 	}
 }
 

--- a/internal/httpapi/operations.go
+++ b/internal/httpapi/operations.go
@@ -140,9 +140,13 @@ func (s *Server) registerAgents() {
 
 // resolveOwnedAgent authenticates the caller, loads the agent by address,
 // and verifies ownership — the shared front half of every per-agent
-// operation. It mirrors the legacy resolveAgentForUser behavior: a missing
-// or non-owned agent is reported as 403 (the legacy surface does not
-// distinguish the two, and preserving that is a Slice-1 non-goal to change).
+// operation. A missing OR non-owned agent is reported as 404 not_found,
+// consistent with every other per-resource lookup on the surface (messages,
+// domains, webhooks, templates, events, conversations, reviews). The two
+// cases are deliberately conflated into one indistinguishable 404 so the
+// response never reveals that another account's agent exists (anti-enumeration).
+// A genuine scope-403 — an agent-scoped credential reaching a different agent —
+// is a distinct case handled below and is NOT collapsed into the 404.
 func (s *Server) resolveOwnedAgent(ctx context.Context, address string) (*identity.AgentIdentity, error) {
 	p, err := s.requirePrincipal(ctx)
 	if err != nil {
@@ -153,7 +157,7 @@ func (s *Server) resolveOwnedAgent(ctx context.Context, address string) (*identi
 	}
 	ag, err := s.deps.GetAgent(ctx, identity.NormalizeEmail(address))
 	if err != nil || ag == nil || ag.UserID != p.User.ID {
-		return nil, NewError(http.StatusForbidden, "forbidden", "agent not found")
+		return nil, NewError(http.StatusNotFound, "not_found", "agent not found")
 	}
 	// Hard scope ceiling (Slice 5a): an agent-scoped credential is pinned to a
 	// single agent. Even though the owner owns this agent, a credential bound

--- a/internal/httpapi/operations_test.go
+++ b/internal/httpapi/operations_test.go
@@ -698,7 +698,7 @@ func TestGetAgentOwned(t *testing.T) {
 	}
 }
 
-func TestGetAgentForbiddenWhenUnknown(t *testing.T) {
+func TestGetAgentNotFoundWhenUnknown(t *testing.T) {
 	srv := testServer(t)
 	req, _ := http.NewRequest("GET", srv.URL+"/v1/agents/other%40acme.com", nil)
 	req.Header.Set("Authorization", "Bearer good")
@@ -707,8 +707,10 @@ func TestGetAgentForbiddenWhenUnknown(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer resp.Body.Close()
-	// Mirrors legacy: unknown/non-owned agent -> 403, not 404.
-	if resp.StatusCode != 403 {
+	// An unknown OR non-owned agent is 404 not_found — consistent with every
+	// other per-resource lookup, and the two cases are indistinguishable so the
+	// response never reveals another account's agent (anti-enumeration).
+	if resp.StatusCode != 404 {
 		t.Fatalf("status: %d", resp.StatusCode)
 	}
 	var env struct {
@@ -717,8 +719,8 @@ func TestGetAgentForbiddenWhenUnknown(t *testing.T) {
 		} `json:"error"`
 	}
 	_ = json.NewDecoder(resp.Body).Decode(&env)
-	if env.Error.Code != "forbidden" {
-		t.Fatalf("want code forbidden, got %q", env.Error.Code)
+	if env.Error.Code != "not_found" {
+		t.Fatalf("want code not_found, got %q", env.Error.Code)
 	}
 }
 

--- a/internal/httpapi/outbound_test.go
+++ b/internal/httpapi/outbound_test.go
@@ -131,14 +131,15 @@ func TestSendSetsAgentAsSender(t *testing.T) {
 }
 
 // TestSendNotOwnedAgent: sending through an agent the caller does not own is a
-// 403 (resolveOwnedAgent), never a cross-tenant send.
+// 404 not_found (resolveOwnedAgent — indistinguishable from a nonexistent
+// agent), never a cross-tenant send.
 func TestSendNotOwnedAgent(t *testing.T) {
 	srv := testServer(t)
 	code, _ := postJSON(t, srv.URL+"/v1/agents/other%40nope.com/messages", "good", map[string]any{
 		"to": []string{"alice@x.com"}, "subject": "Hi", "body": "hello",
 	})
-	if code != 403 {
-		t.Fatalf("want 403 for an unowned agent, got %d", code)
+	if code != 404 {
+		t.Fatalf("want 404 for an unowned agent, got %d", code)
 	}
 }
 
@@ -277,8 +278,8 @@ func TestReplyMessageNotFound(t *testing.T) {
 func TestReplyNotOwnedAgent(t *testing.T) {
 	srv := testServer(t)
 	code, _ := postJSON(t, srv.URL+"/v1/agents/other%40acme.com/messages/msg_in1/reply", "good", map[string]any{"body": "x"})
-	if code != 403 {
-		t.Fatalf("want 403, got %d", code)
+	if code != 404 {
+		t.Fatalf("want 404, got %d", code)
 	}
 }
 
@@ -320,7 +321,7 @@ func TestTestSendSent(t *testing.T) {
 func TestTestSendNotOwned(t *testing.T) {
 	srv := testServer(t)
 	code, _ := postJSON(t, srv.URL+"/v1/agents/other%40acme.com/test", "good", nil)
-	if code != 403 {
-		t.Fatalf("want 403, got %d", code)
+	if code != 404 {
+		t.Fatalf("want 404, got %d", code)
 	}
 }

--- a/sdks/typescript/test/v1/errors.test.ts
+++ b/sdks/typescript/test/v1/errors.test.ts
@@ -160,13 +160,13 @@ describe("fromApiException", () => {
     const apiEx = new ApiException(
       403,
       "HTTP 403",
-      { error: { code: "forbidden", message: "agent not yours", details: null } },
+      { error: { code: "forbidden", message: "this agent-scoped credential is bound to a different agent", details: null } },
       { "x-request-id": "req_xyz", "content-type": "application/json" },
     );
     const err = fromApiException(apiEx);
     expect(err).toBeInstanceOf(E2APermissionError);
     expect(err.code).toBe("forbidden");
-    expect(err.message).toBe("agent not yours");
+    expect(err.message).toBe("this agent-scoped credential is bound to a different agent");
     expect(err.requestId).toBe("req_xyz");
   });
 

--- a/tests/e2e-prod/suites/01-basic.test.ts
+++ b/tests/e2e-prod/suites/01-basic.test.ts
@@ -50,9 +50,10 @@ test("agents: get primary agent by email", async () => {
   assert.equal(typeof r.body?.domain_verified, "boolean");
 });
 
-test("agents: get nonexistent agent returns 403 (anti-enumeration; matches spec)", async () => {
+test("agents: get nonexistent agent returns 404 not_found (matches every other resource; anti-enumeration preserved)", async () => {
   const r = await client.get(`/v1/agents/nonexistent-${Date.now()}@agents.e2a.dev`);
-  assert.equal(r.status, 403, `spec only documents 200/401/403 — expected 403 for unknown, got ${r.status}`);
+  assert.equal(r.status, 404, `unknown/non-owned agent → 404, got ${r.status}`);
+  assert.equal(r.body?.error?.code, "not_found", `expected code not_found, got ${r.body?.error?.code}`);
 });
 
 test("agents: get malformed email returns 4xx", async () => {
@@ -82,7 +83,7 @@ test("agents: create + read + delete (slug on shared domain)", async () => {
   assert.ok(del.status === 204 || del.status === 200, `delete expected 200/204, got ${del.status}`);
 
   const after = await client.get(`/v1/agents/${encodeURIComponent(email)}`);
-  assert.equal(after.status, 403, `deleted agent should 403 (anti-enumeration), got ${after.status}`);
+  assert.equal(after.status, 404, `deleted agent should 404 not_found (anti-enumeration), got ${after.status}`);
 });
 
 test("agents: create with missing slug AND email returns 4xx", async () => {

--- a/tests/e2e-prod/suites/02-authz.test.ts
+++ b/tests/e2e-prod/suites/02-authz.test.ts
@@ -83,28 +83,27 @@ test("authz: send as an unowned agent returns 4xx (cannot impersonate)", async (
   assert.ok(r.status >= 400 && r.status < 500, `expected 4xx, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
-test("authz: GET /agents/<email-i-dont-own> returns 403 (no info leak)", async () => {
+test("authz: GET /agents/<email-i-dont-own> returns 404 not_found (no info leak — indistinguishable from nonexistent)", async () => {
   const r = await client.get(`/v1/agents/${encodeURIComponent("nobody@example.com")}`);
-  assert.equal(r.status, 403, `expected 403, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  assert.equal(r.status, 404, `expected 404, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  assert.equal(r.body?.error?.code, "not_found", `expected code not_found, got ${r.body?.error?.code}`);
 });
 
-test("authz: PATCH /agents/<email-i-dont-own> returns 403 or 4xx", async () => {
+test("authz: PATCH /agents/<email-i-dont-own> returns 404 not_found", async () => {
   const r = await client.patch(`/v1/agents/${encodeURIComponent("nobody@example.com")}`, {
     body: { name: "rename attempt" },
   });
-  assert.ok(r.status === 403 || (r.status >= 400 && r.status < 500), `expected 4xx, got ${r.status}`);
+  assert.equal(r.status, 404, `expected 404, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
-test("authz: DELETE /agents/<email-i-dont-own> returns 403 or 4xx (no cross-tenant delete)", async () => {
+test("authz: DELETE /agents/<email-i-dont-own> returns 404 not_found (no cross-tenant delete)", async () => {
   const r = await client.delete(`/v1/agents/${encodeURIComponent("nobody@example.com")}`);
-  // assert.ok throws on a non-4xx response — the explicit 200/204 check
-  // that used to live below was dead code (unreachable past the assert).
-  // The fail-tag is preserved for triage clarity if the assert ever fires.
+  // A cross-tenant delete must never succeed: a 2xx here is a critical breach.
   if (r.status === 200 || r.status === 204) {
     fail(SUITE, "cross-tenant-delete", `CRITICAL: deleted an agent we don't own; got ${r.status}`);
     assert.fail(`cross-tenant DELETE returned ${r.status} — agent we don't own was deleted`);
   }
-  assert.ok(r.status === 403 || (r.status >= 400 && r.status < 500), `expected 4xx, got ${r.status}`);
+  assert.equal(r.status, 404, `expected 404, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
 test("authz: GET /agents/<email>/messages of unowned agent returns 4xx", async () => {

--- a/tests/e2e-prod/suites/14-v030-features.test.ts
+++ b/tests/e2e-prod/suites/14-v030-features.test.ts
@@ -132,14 +132,14 @@ test("conversations: list without auth → 401", async () => {
   assert.equal(r.status, 401, `expected 401, got ${r.status}`);
 });
 
-test("conversations: list under nonexistent agent → 404 or 403", async () => {
-  // The /agents/{id} root uses 403 anti-enumeration but the
-  // sub-resource paths (conversations, messages) return 404 for an
-  // unknown agent. Inconsistency worth tracking, accepted as-shipped.
+test("conversations: list under nonexistent agent → 404 not_found", async () => {
+  // Every per-agent path — the /agents/{id} root and its sub-resources
+  // (conversations, messages) — returns a uniform 404 not_found for an
+  // unknown/non-owned agent (indistinguishable, so no enumeration leak).
   const r = await client.get(
     `/v1/agents/nonexistent-${Date.now()}@agents.e2a.dev/conversations`,
   );
-  assert.ok(r.status === 404 || r.status === 403, `expected 404/403, got ${r.status}`);
+  assert.equal(r.status, 404, `expected 404, got ${r.status}`);
 });
 
 test("conversations: get nonexistent conversation → 404", async () => {

--- a/tests/e2e-prod/suites/20-attachments.test.ts
+++ b/tests/e2e-prod/suites/20-attachments.test.ts
@@ -282,11 +282,11 @@ test("getAttachment: unauthenticated returns 401", async () => {
   assert.equal(r.status, 401, `missing bearer → 401, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
-test("getAttachment: unowned agent returns 403 (anti-enumeration; matches resolveOwnedAgent)", async () => {
+test("getAttachment: unowned agent returns 404 not_found (anti-enumeration; matches resolveOwnedAgent)", async () => {
   const r = await client.get(
     `/v1/agents/${encodeURIComponent(`nobody-${Date.now()}@example.com`)}/messages/msg_x/attachments/0`,
   );
-  assert.equal(r.status, 403, `unowned agent → 403 forbidden, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  assert.equal(r.status, 404, `unowned agent → 404 not_found, got ${r.status}: ${r.raw.slice(0, 200)}`);
 });
 
 test("download: missing token returns 401", async () => {


### PR DESCRIPTION
## Problem

`GET` (and every other per-agent operation) on a **missing OR non-owned agent** returned `403 forbidden "agent not found"`, while every other per-resource lookup on the `/v1` surface (messages, domains, webhooks, templates, events, conversations, reviews) returns `404 not_found` for the same class of miss.

A 403 on a `GET` misleads integrators into debugging their API key / scope when the real cause is a typo'd address — and the anti-enumeration rationale for the 403 didn't even hold uniformly, since the other seven resources 404.

## Change

`resolveOwnedAgent` (`internal/httpapi/operations.go`) — the single choke point at the front of every per-agent operation — now returns **`404 not_found`** for both "doesn't exist" and "exists but not yours". The two cases stay **deliberately indistinguishable**, so the response never reveals that another account's agent exists (anti-enumeration preserved).

What did **not** change (genuine, still-correct 403s):
- The scope ceiling inside `resolveOwnedAgent`: an **agent-scoped credential reaching a different agent** still returns `403 forbidden` ("bound to a different agent").
- `requireAccountScope` / `requireAgentAccess` (`scope.go`): an agent-scoped key on an **account-only op** still returns `403 forbidden`. These are authenticated-but-scope-forbidden, a different failure than not-found, and are untouched.
- Genuine `401` for a missing/invalid credential.

## Symmetric fallout (single batch)

- **OpenAPI:** no drift. The `/v1` operations document a generic `default` `ErrorEnvelope` response (not a per-status 403), so the generated spec is unchanged — `TestSpecGoldenNoDrift` stays green.
- **SDKs:** the TS and Python error hierarchies are **code-first** — `not_found` already maps to `E2ANotFoundError`. Agent-not-found now surfaces as `NotFoundError` instead of `ForbiddenError` with **no SDK source change**. Updated one TS SDK test whose sample `forbidden` envelope used an "agent not yours" message (retargeted to the genuine scope-403 message; the `forbidden → E2APermissionError` mapping assertion is unchanged).
- **Tests:** flipped every test asserting the old 403 for a missing/non-owned agent to assert `404 not_found`, kept **strict** (no weakening):
  - Go: `operations_test.go`, `agents_write_test.go` (update + delete not-owned), `apikeys_test.go`, `hitl_test.go`, `outbound_test.go` (send/reply/test not-owned).
  - Conformance: `01-basic`, `02-authz` (GET/PATCH/DELETE unowned), `14-v030-features` (conversations), `20-attachments`.
  - `scope_test.go` unchanged — every case there is a genuine scope-403 (its `other@acme.com` is *owned*, so it reaches the scope ceiling rather than the ownership check).

Out of scope: the OAuth `POST /agent/identity` bootstrap endpoint (`internal/agent/agent_identity.go`) has its own OAuth-style error surface and a different semantic (the credential is already bound to that one agent) — not part of the `/v1` resource anti-enumeration surface, left as-is.

## Verification

- `go build ./...` — clean.
- `go test ./internal/httpapi/...` — pass (incl. `TestSpecGoldenNoDrift`).
- `npx vitest run test/v1/errors.test.ts` — 26 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)