### PR TITLE
fix(identity): return correct domain_verified from agent create

### DIFF
--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -984,24 +984,25 @@ func createAgent(ctx context.Context, exec agentExecutor, agentEmail, domain, na
 		HITLTTLSeconds:       HITLDefaultTTLSeconds,
 		HITLExpirationAction: HITLDefaultExpirationAct,
 	}
-	_, err := exec.Exec(ctx,
-		`INSERT INTO agent_identities (id, domain, user_id, name, public, created_at)
-		 VALUES ($1, $2, $3, $4, $5, $6)`,
-		a.ID, a.Domain, a.UserID, a.Name, a.Public, a.CreatedAt,
-	)
-	if err != nil {
-		return nil, err
-	}
 	// Report the same domain_verified the read paths (GetAgentByID /
 	// ListAgentsByUser) derive from domains.verified. createAgent builds the
 	// identity in-memory from only the INSERT columns, so DomainVerified would
 	// otherwise be the Go zero value (false) regardless of the domain's real
 	// state — wrong for an agent on a verified domain, and it would flip to the
-	// correct value on the next GET. Read it back in the same executor so it
-	// works for both the pool and an open tx: the just-inserted agent's FK
-	// guarantees the domain row exists and is visible within this transaction.
+	// correct value on the next GET.
+	//
+	// The scalar subquery in RETURNING folds the read back into the INSERT: one
+	// round-trip, and no post-commit window (a separate SELECT after the INSERT
+	// auto-commits on the pool path would, if it errored transiently, surface a
+	// 500 even though the agent row is already committed — a retry then 409s).
+	// The FK on agent_identities.domain guarantees the domains row exists and is
+	// visible here, so the subquery always resolves to a non-NULL bool. Works
+	// identically on the pool and inside a caller-owned tx.
 	if err := exec.QueryRow(ctx,
-		`SELECT verified FROM domains WHERE domain = $1`, a.Domain,
+		`INSERT INTO agent_identities (id, domain, user_id, name, public, created_at)
+		 VALUES ($1, $2, $3, $4, $5, $6)
+		 RETURNING (SELECT verified FROM domains WHERE domain = $2)`,
+		a.ID, a.Domain, a.UserID, a.Name, a.Public, a.CreatedAt,
 	).Scan(&a.DomainVerified); err != nil {
 		return nil, err
 	}

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -970,6 +970,7 @@ func (s *Store) CreateAgentTx(ctx context.Context, tx pgx.Tx, agentEmail, domain
 // in-transaction callers without duplicating the SQL.
 type agentExecutor interface {
 	Exec(ctx context.Context, sql string, arguments ...any) (pgconn.CommandTag, error)
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
 }
 
 func createAgent(ctx context.Context, exec agentExecutor, agentEmail, domain, name, userID string) (*AgentIdentity, error) {
@@ -989,6 +990,19 @@ func createAgent(ctx context.Context, exec agentExecutor, agentEmail, domain, na
 		a.ID, a.Domain, a.UserID, a.Name, a.Public, a.CreatedAt,
 	)
 	if err != nil {
+		return nil, err
+	}
+	// Report the same domain_verified the read paths (GetAgentByID /
+	// ListAgentsByUser) derive from domains.verified. createAgent builds the
+	// identity in-memory from only the INSERT columns, so DomainVerified would
+	// otherwise be the Go zero value (false) regardless of the domain's real
+	// state — wrong for an agent on a verified domain, and it would flip to the
+	// correct value on the next GET. Read it back in the same executor so it
+	// works for both the pool and an open tx: the just-inserted agent's FK
+	// guarantees the domain row exists and is visible within this transaction.
+	if err := exec.QueryRow(ctx,
+		`SELECT verified FROM domains WHERE domain = $1`, a.Domain,
+	).Scan(&a.DomainVerified); err != nil {
 		return nil, err
 	}
 	a.populateEmail()

--- a/internal/identity/store_test.go
+++ b/internal/identity/store_test.go
@@ -40,8 +40,51 @@ func TestCreateAgent(t *testing.T) {
 	if a.Domain != "bot.example.com" {
 		t.Errorf("Domain = %q, want %q", a.Domain, "bot.example.com")
 	}
+	// bot.example.com was claimed but never verified, so the create response
+	// must report DomainVerified=false — matching what GetAgentByID would read
+	// from domains.verified. (This is the meaningful false case: the store
+	// permits agents on unverified domains.)
 	if a.DomainVerified {
-		t.Error("expected DomainVerified=false for new agent")
+		t.Error("expected DomainVerified=false for agent on an unverified domain")
+	}
+}
+
+// TestCreateAgentVerifiedDomain pins the bug fix: when the agent's domain is
+// verified, the create response must report DomainVerified=true immediately —
+// not the Go zero value that createAgent used to leave unset (which flipped to
+// true only on a follow-up GET). Mirrors the value GetAgentByID reads back.
+func TestCreateAgentVerifiedDomain(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, err := store.CreateOrGetUser(ctx, "owner@example.com", "Owner", "google-create-agent-verified")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+
+	if _, err := store.ClaimOrCreateDomain(ctx, "verified.example.com", user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+	if err := store.VerifyDomain(ctx, "verified.example.com", user.ID); err != nil {
+		t.Fatalf("VerifyDomain: %v", err)
+	}
+
+	a, err := store.CreateAgent(ctx, "agent@verified.example.com", "verified.example.com", "", "", "", user.ID)
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	if !a.DomainVerified {
+		t.Error("expected DomainVerified=true for agent on a verified domain (create response must not return a stale zero value)")
+	}
+
+	// And the create response must agree with the authoritative read path.
+	got, err := store.GetAgentByID(ctx, a.ID)
+	if err != nil {
+		t.Fatalf("GetAgentByID: %v", err)
+	}
+	if got.DomainVerified != a.DomainVerified {
+		t.Errorf("create DomainVerified=%v disagrees with GetAgentByID=%v", a.DomainVerified, got.DomainVerified)
 	}
 }
 

--- a/tests/e2e-prod/suites/22-domain-lifecycle.test.ts
+++ b/tests/e2e-prod/suites/22-domain-lifecycle.test.ts
@@ -174,14 +174,15 @@ test("domain lifecycle: register → DNS TXT+MX → verify (happy path) → cust
     assert.equal(got.body?.verified, true, "GET domain reflects verified=true");
 
     agentEmail = `bot@${domain}`;
-    const ag = await client.post<{ email: string }>("/v1/agents", {
+    const ag = await client.post<{ email: string; domain_verified: boolean }>("/v1/agents", {
       body: { email: agentEmail, name: "lifecycle bot" },
     });
     assert.equal(ag.status, 201, `create custom-domain agent: ${ag.raw.slice(0, 200)}`);
-    // NOTE: the CREATE response's domain_verified is a stale zero — createAgent
-    // builds the struct in-memory from the INSERT and never JOINs d.verified
-    // (OSS store.go createAgent). The authoritative value comes from a READ,
-    // which JOINs the live domain.verified. Assert on the read.
+    // The CREATE response must report the authoritative domain_verified up
+    // front — createAgent reads back domains.verified after the INSERT rather
+    // than returning a stale in-memory zero (OSS store.go createAgent). It must
+    // agree with the READ path, which JOINs the live domain.verified.
+    assert.equal(ag.body?.domain_verified, true, "custom-domain agent reports domain_verified=true on create");
     const gotAgent = await client.get<{ domain_verified: boolean }>(`/v1/agents/${encodeURIComponent(agentEmail)}`);
     assert.equal(gotAgent.status, 200, `read custom-domain agent: ${gotAgent.raw.slice(0, 200)}`);
     assert.equal(gotAgent.body?.domain_verified, true, "custom-domain agent reports domain_verified=true on read");


### PR DESCRIPTION
## Problem

`POST /v1/agents` returns `domain_verified: false` unconditionally — even for a **custom-domain** agent, which the create handler *requires* a verified domain to create. The response is simply wrong and flips to the correct value on a follow-up `GET /v1/agents/{email}`.

**Root cause:** `createAgent` in `internal/identity/store.go` builds the `AgentIdentity` in-memory from only the six INSERT columns and never sets `DomainVerified` (Go zero value = `false`). The READ paths `GetAgentByID` and `ListAgentsByUser` instead derive it via `d.verified` from a `JOIN domains`. So create and read disagreed.

## Is the field meaningful, or redundant?

I investigated whether `domain_verified` can ever legitimately be `false` on a readable agent, or whether it's always-true and thus a removal candidate:

- **Shared-domain agents** are always on a `verified=true` row (`EnsureSharedDomain` + the migration-001 seed both stamp `verified=true`).
- **Custom-domain agents via the API** are gated on `dom.Verified` in `handleCreateAgent`.
- Verification is **one-way** — `VerifyDomain` only flips `false→true`; no code path ever sets `verified=false` on an existing row, and a domain with agents can't be deleted (FK-blocked).

That made removal look tempting — **but the invariant lives only in one HTTP handler, not the data model.** The store-level `CreateAgent`/`CreateAgentTx` do **not** check verification, and the existing `TestCreateAgent` creates an agent on an **unverified** domain and asserts `domain_verified=false`. So `false` is a real, reachable, test-exercised value; the field carries genuine signal and the dashboard legitimately models both states. **Conclusion: the field is meaningful — this is a create-path bug, not a redundant field.** Fix the value; don't touch the contract.

## Fix

Read `domains.verified` back within the same executor right after the INSERT, so the create response matches what the read paths return. Works for both the pool and an open transaction (`CreateAgentTx`, the OAuth slug auto-create path), and requires no API-contract change — so no OpenAPI/SDK/CLI/MCP churn.

## Tests

- `TestCreateAgentVerifiedDomain` (new): pins that create on a **verified** domain returns `domain_verified=true` immediately and agrees with `GetAgentByID`.
- `TestCreateAgent`: unchanged assertion (`false` on an unverified domain) — now clarified as the meaningful false case.
- `tests/e2e-prod/suites/22-domain-lifecycle.test.ts`: asserts the create response directly instead of working around the bug.

`go build ./...`, `go vet`, and `go test ./internal/identity/... ./internal/httpapi/...` all pass on a clean test DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)