### PR TITLE
fix(ws): standard v1 error envelope + close the agent-existence enumeration oracle (not-owned 403→404)

### DIFF
--- a/internal/httpapi/attachments.go
+++ b/internal/httpapi/attachments.go
@@ -5,7 +5,6 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -300,8 +299,5 @@ func writeRawError(w http.ResponseWriter, r *http.Request, status int, code, msg
 	if details != nil {
 		env = env.WithDetails(details)
 	}
-	env.Err.RequestID = RequestIDFromContext(r.Context())
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(env)
+	writeRawEnvelope(w, r, env)
 }

--- a/internal/httpapi/errors.go
+++ b/internal/httpapi/errors.go
@@ -15,6 +15,7 @@
 package httpapi
 
 import (
+	"encoding/json"
 	"net/http"
 	"strconv"
 
@@ -179,6 +180,40 @@ func stampRequestID(ctx huma.Context, status string, v any) (any, error) {
 		ctx.SetHeader("Retry-After", strconv.Itoa(env.retryAfter))
 	}
 	return v, nil
+}
+
+// writeRawEnvelope serializes an ErrorEnvelope to a raw (non-Huma)
+// ResponseWriter, giving handlers that bypass Huma the SAME error contract every
+// operation emits. It reuses the request id the requestID middleware already
+// stamped (the production chi root always sets one, so header == body == what
+// REST would return) and mints one only when absent (a direct call in a test),
+// then mirrors it onto the X-Request-Id header and sets Content-Type:
+// application/json before writing the status + body. This is the one place raw
+// chi routes stay in lockstep with the Huma surface on the envelope shape.
+// (The middleware path uses the huma.Context-based writeEnvelope in ratelimit.go.)
+func writeRawEnvelope(w http.ResponseWriter, r *http.Request, env *ErrorEnvelope) {
+	id := RequestIDFromContext(r.Context())
+	if id == "" {
+		id = newRequestID()
+	}
+	env.Err.RequestID = id
+	w.Header().Set(requestIDHeader, id)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(env.status)
+	_ = json.NewEncoder(w).Encode(env)
+}
+
+// WriteError writes the canonical v1 error envelope to a raw ResponseWriter for
+// handlers OUTSIDE this package that bypass Huma — specifically the WebSocket
+// upgrade handshake (internal/ws), which authenticates and authorizes BEFORE the
+// upgrade and so rejects a bad handshake with a normal HTTP response. Routing
+// those rejections through here makes the WS handshake body byte-for-byte
+// consistent with every /v1 REST endpoint: {error:{code,message,request_id}} +
+// X-Request-Id. The caller supplies the status and a code from the REST
+// vocabulary (unauthorized / forbidden / not_found / bad_request); status codes
+// are the caller's to choose so this never rewrites them.
+func WriteError(w http.ResponseWriter, r *http.Request, status int, code, message string) {
+	writeRawEnvelope(w, r, NewError(status, code, message))
 }
 
 // installErrorEnvelope wires the envelope constructor globally. It is called

--- a/internal/httpapi/ws_route_test.go
+++ b/internal/httpapi/ws_route_test.go
@@ -1,6 +1,8 @@
 package httpapi
 
 import (
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -42,5 +44,61 @@ func TestWSRouteDecodesPercentEncodedAddress(t *testing.T) {
 				t.Fatalf("WSHandle received address %q, want %q", got, "tether@agents.e2a.dev")
 			}
 		})
+	}
+}
+
+// TestWSHandshakeError_HonorsClientRequestID exercises the PRODUCTION request-id
+// path (not the WriteError fallback that mints its own id). Mounted on the real
+// New(deps).Router, the chi-root requestID middleware honors a caller-supplied
+// X-Request-Id and stashes it in context; a WS handshake rejection routed
+// through WriteError must then echo THAT id in both the JSON envelope's
+// request_id and the X-Request-Id response header — so a client's trace id flows
+// end-to-end through a failed WS handshake exactly as it does through REST.
+func TestWSHandshakeError_HonorsClientRequestID(t *testing.T) {
+	const clientReqID = "req_client_supplied_123"
+
+	deps := Deps{
+		WSHandle: func(w http.ResponseWriter, r *http.Request, _ string) {
+			// A handshake rejection (before the WebSocket upgrade) uses the same
+			// raw error envelope every /v1 endpoint does.
+			WriteError(w, r, http.StatusNotFound, "not_found", "agent not found")
+		},
+	}
+	srv := httptest.NewServer(New(deps).Router)
+	t.Cleanup(srv.Close)
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/v1/agents/bot%40agents.e2a.dev/ws", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("X-Request-Id", clientReqID)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status: got %d, want 404", resp.StatusCode)
+	}
+	if h := resp.Header.Get("X-Request-Id"); h != clientReqID {
+		t.Fatalf("X-Request-Id header: got %q, want the client-supplied %q", h, clientReqID)
+	}
+
+	body, _ := io.ReadAll(resp.Body)
+	var env struct {
+		Error struct {
+			Code      string `json:"code"`
+			RequestID string `json:"request_id"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		t.Fatalf("body is not the JSON envelope: %v (body=%s)", err, body)
+	}
+	if env.Error.Code != "not_found" {
+		t.Fatalf("code: got %q, want not_found", env.Error.Code)
+	}
+	if env.Error.RequestID != clientReqID {
+		t.Fatalf("envelope request_id: got %q, want the client-supplied %q", env.Error.RequestID, clientReqID)
 	}
 }

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Mnexa-AI/e2a/internal/httpapi"
 	"github.com/Mnexa-AI/e2a/internal/identity"
 	"nhooyr.io/websocket"
 )
@@ -51,16 +52,28 @@ func (h *Handler) serve(w http.ResponseWriter, r *http.Request, rawEmail string)
 	// Python SDKs and the CLI) are non-browser and set the header on the
 	// handshake. (A short-lived connect ticket is the path to add later if an
 	// in-browser client ever needs to connect — browsers can't set headers.)
+	// Handshake rejections happen BEFORE the WebSocket upgrade (the connection
+	// is still a plain HTTP request, not yet hijacked), so they return the same
+	// canonical error envelope every /v1 REST endpoint does — httpapi.WriteError
+	// emits {error:{code,message,request_id}} + the X-Request-Id header, reusing
+	// the request id the chi-root middleware already stamped. A client's shared
+	// envelope-based error handling then works identically on a failed WS
+	// handshake and a failed REST call. Status codes are UNCHANGED from the prior
+	// behavior. WWW-Authenticate (RFC 6750 §3) is set before WriteError writes the
+	// status line, since headers can't be added once the status is flushed; on the
+	// prod stack the authChallenge middleware also (re)asserts it on any 401.
 	token := bearerToken(r)
 	if token == "" {
 		w.Header().Set("WWW-Authenticate", `Bearer realm="e2a"`)
-		http.Error(w, "missing credential — send Authorization: Bearer <api_key>", http.StatusUnauthorized)
+		httpapi.WriteError(w, r, http.StatusUnauthorized, "unauthorized",
+			"missing credential — send Authorization: Bearer <api_key>")
 		return
 	}
 
 	principal, err := h.store.GetPrincipalByAPIKey(r.Context(), token)
 	if err != nil || principal == nil || principal.User == nil {
-		http.Error(w, "invalid token", http.StatusUnauthorized)
+		w.Header().Set("WWW-Authenticate", `Bearer realm="e2a"`)
+		httpapi.WriteError(w, r, http.StatusUnauthorized, "unauthorized", "invalid token")
 		return
 	}
 
@@ -70,19 +83,19 @@ func (h *Handler) serve(w http.ResponseWriter, r *http.Request, rawEmail string)
 	email := identity.NormalizeEmail(rawEmail)
 	agent, err := h.store.GetAgentByEmail(r.Context(), email)
 	if err != nil {
-		http.Error(w, "agent not found", http.StatusNotFound)
+		httpapi.WriteError(w, r, http.StatusNotFound, "not_found", "agent not found")
 		return
 	}
 	// Tenant ownership: the agent must belong to the credential's user.
 	if agent.UserID != principal.User.ID {
-		http.Error(w, "not authorized for this agent", http.StatusForbidden)
+		httpapi.WriteError(w, r, http.StatusForbidden, "forbidden", "not authorized for this agent")
 		return
 	}
 	// Agent-scope confinement (HIGH-1): an agent-scoped credential is pinned to
 	// its one bound agent — it may not open a different agent's stream even
 	// within the same account. Mirrors the REST resolveOwnedAgent pin.
 	if principal.Scope == identity.ScopeAgent && principal.AgentID != agent.ID {
-		http.Error(w, "not authorized for this agent", http.StatusForbidden)
+		httpapi.WriteError(w, r, http.StatusForbidden, "forbidden", "not authorized for this agent")
 		return
 	}
 

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -86,9 +86,15 @@ func (h *Handler) serve(w http.ResponseWriter, r *http.Request, rawEmail string)
 		httpapi.WriteError(w, r, http.StatusNotFound, "not_found", "agent not found")
 		return
 	}
-	// Tenant ownership: the agent must belong to the credential's user.
+	// Tenant ownership: the agent must belong to the credential's user. A
+	// cross-tenant miss returns 404 not_found — the SAME response as a
+	// nonexistent agent above — so an authenticated caller can't tell "this
+	// address doesn't exist" from "it exists but isn't yours". Emitting 403
+	// here would make the WS handshake an agent-existence enumeration oracle
+	// across tenants; collapsing both into 404 closes it (mirrors the REST
+	// resolveOwnedAgent, which likewise refuses to distinguish the two).
 	if agent.UserID != principal.User.ID {
-		httpapi.WriteError(w, r, http.StatusForbidden, "forbidden", "not authorized for this agent")
+		httpapi.WriteError(w, r, http.StatusNotFound, "not_found", "agent not found")
 		return
 	}
 	// Agent-scope confinement (HIGH-1): an agent-scoped credential is pinned to

--- a/internal/ws/handler_test.go
+++ b/internal/ws/handler_test.go
@@ -184,6 +184,106 @@ func TestHandler_QueryTokenRejected(t *testing.T) {
 	}
 }
 
+// TestHandler_HandshakeError_JSONEnvelope pins the fix: a handshake rejection
+// (before the WebSocket upgrade) returns the SAME canonical error envelope the
+// REST /v1 surface does — Content-Type: application/json, a body that unmarshals
+// to {error:{code,message,request_id}} with non-empty fields, and an
+// X-Request-Id header that matches the body's request_id — so a client's shared
+// envelope-based error handling works identically on a failed WS handshake.
+func TestHandler_HandshakeError_JSONEnvelope(t *testing.T) {
+	type envelope struct {
+		Error struct {
+			Code      string `json:"code"`
+			Message   string `json:"message"`
+			RequestID string `json:"request_id"`
+		} `json:"error"`
+	}
+
+	cases := []struct {
+		name        string
+		store       *mockStore
+		token       string
+		wantStatus  int
+		wantCode    string
+		wantWWWAuth bool // 401s must advertise the RFC 6750 Bearer challenge
+	}{
+		{
+			name:        "missing bearer",
+			store:       &mockStore{},
+			token:       "",
+			wantStatus:  http.StatusUnauthorized,
+			wantCode:    "unauthorized",
+			wantWWWAuth: true,
+		},
+		{
+			name:        "invalid token",
+			store:       &mockStore{user: nil, userErr: fmt.Errorf("not found")},
+			token:       "bad_key",
+			wantStatus:  http.StatusUnauthorized,
+			wantCode:    "unauthorized",
+			wantWWWAuth: true,
+		},
+		{
+			name:       "not owner",
+			store:      &mockStore{user: newTestUser(), agent: newTestAgent("other_user")},
+			token:      "valid_key",
+			wantStatus: http.StatusForbidden,
+			wantCode:   "forbidden",
+		},
+		{
+			name:       "agent not found",
+			store:      &mockStore{user: newTestUser(), agentErr: fmt.Errorf("not found")},
+			token:      "valid_key",
+			wantStatus: http.StatusNotFound,
+			wantCode:   "not_found",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			hub := NewHub()
+			defer hub.Close()
+			srv := startServer(t, NewHandler(hub, tc.store))
+
+			resp := doHTTP(t, srv, "bot@agents.e2a.dev", tc.token)
+			defer resp.Body.Close()
+
+			if resp.StatusCode != tc.wantStatus {
+				t.Fatalf("status: got %d, want %d", resp.StatusCode, tc.wantStatus)
+			}
+			if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+				t.Fatalf("Content-Type: got %q, want application/json", ct)
+			}
+
+			body, _ := io.ReadAll(resp.Body)
+			var env envelope
+			if err := json.Unmarshal(body, &env); err != nil {
+				t.Fatalf("body is not the JSON envelope: %v (body=%s)", err, body)
+			}
+			if env.Error.Code != tc.wantCode {
+				t.Fatalf("code: got %q, want %q", env.Error.Code, tc.wantCode)
+			}
+			if env.Error.Message == "" {
+				t.Fatal("envelope message is empty")
+			}
+			if env.Error.RequestID == "" {
+				t.Fatal("envelope request_id is empty")
+			}
+
+			// Header must echo the same request id that's in the body.
+			if h := resp.Header.Get("X-Request-Id"); h != env.Error.RequestID {
+				t.Fatalf("X-Request-Id header %q != body request_id %q", h, env.Error.RequestID)
+			}
+
+			if tc.wantWWWAuth {
+				if wa := resp.Header.Get("WWW-Authenticate"); wa != `Bearer realm="e2a"` {
+					t.Fatalf("401 must carry WWW-Authenticate Bearer challenge, got %q", wa)
+				}
+			}
+		})
+	}
+}
+
 func TestHandler_InvalidToken(t *testing.T) {
 	hub := NewHub()
 	defer hub.Close()

--- a/internal/ws/handler_test.go
+++ b/internal/ws/handler_test.go
@@ -224,11 +224,14 @@ func TestHandler_HandshakeError_JSONEnvelope(t *testing.T) {
 			wantWWWAuth: true,
 		},
 		{
-			name:       "not owner",
+			// Cross-tenant: the agent exists but belongs to another account.
+			// Must be INDISTINGUISHABLE from a nonexistent agent (both 404
+			// not_found) so the handshake isn't an existence-enumeration oracle.
+			name:       "not owner (cross-tenant)",
 			store:      &mockStore{user: newTestUser(), agent: newTestAgent("other_user")},
 			token:      "valid_key",
-			wantStatus: http.StatusForbidden,
-			wantCode:   "forbidden",
+			wantStatus: http.StatusNotFound,
+			wantCode:   "not_found",
 		},
 		{
 			name:       "agent not found",
@@ -315,6 +318,13 @@ func TestHandler_AgentNotFound(t *testing.T) {
 	}
 }
 
+// TestHandler_NotOwner pins the anti-enumeration behavior: an agent that exists
+// but belongs to a DIFFERENT account returns 404 not_found — the same response
+// as a nonexistent agent (TestHandler_AgentNotFound) — so an authenticated
+// caller can't probe which agent addresses exist across tenants. This mirrors
+// the REST resolveOwnedAgent, which refuses to distinguish the two. The
+// same-account agent-scope ceiling is a genuine authorization error and stays
+// 403 (TestHandler_AgentScoped_WrongAgent_Forbidden).
 func TestHandler_NotOwner(t *testing.T) {
 	hub := NewHub()
 	defer hub.Close()
@@ -327,8 +337,8 @@ func TestHandler_NotOwner(t *testing.T) {
 
 	resp := doHTTP(t, srv, "bot@agents.e2a.dev", "valid_key")
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusForbidden {
-		t.Fatalf("expected 403, got %d", resp.StatusCode)
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("cross-tenant not-owned must be 404 (anti-enumeration), got %d", resp.StatusCode)
 	}
 }
 

--- a/sdks/python/src/e2a/v1/websocket.py
+++ b/sdks/python/src/e2a/v1/websocket.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 from typing import AsyncIterator, Optional
 from urllib.parse import quote, urlparse, urlunparse
 
-from .errors import E2AAuthError, E2AError, E2APermissionError
+from .errors import E2AAuthError, E2AError, E2ANotFoundError, E2APermissionError
 
 __all__ = ["WSNotification", "WSStream"]
 
@@ -64,6 +64,16 @@ def _fatal_error_for_status(status: int, exc: BaseException) -> Optional[E2AErro
     if status == 403:
         return E2APermissionError(
             code="forbidden",
+            message=f"WebSocket handshake rejected: HTTP {status}",
+            status=status,
+            retryable=False,
+        )
+    if status == 404:
+        # The agent doesn't exist OR isn't yours — the server collapses the
+        # cross-tenant case into not_found so the handshake can't be used to
+        # enumerate which agent addresses exist across accounts.
+        return E2ANotFoundError(
+            code="not_found",
             message=f"WebSocket handshake rejected: HTTP {status}",
             status=status,
             retryable=False,

--- a/sdks/python/tests/test_v1_websocket.py
+++ b/sdks/python/tests/test_v1_websocket.py
@@ -304,13 +304,23 @@ def test_handshake_status_extracts_from_both_shapes():
 
 
 def test_fatal_error_for_status_maps_typed():
-    from e2a.v1.errors import E2AAuthError, E2AError, E2APermissionError
+    from e2a.v1.errors import (
+        E2AAuthError,
+        E2AError,
+        E2ANotFoundError,
+        E2APermissionError,
+    )
     from e2a.v1.websocket import _fatal_error_for_status
 
     assert isinstance(_fatal_error_for_status(401, ValueError()), E2AAuthError)
     assert isinstance(_fatal_error_for_status(403, ValueError()), E2APermissionError)
+    # 404 -> typed not-found. The server returns 404 both when the agent doesn't
+    # exist AND when it exists but isn't yours (cross-tenant), collapsing the two
+    # so the handshake can't enumerate agents; the SDK surfaces one typed error.
+    not_found = _fatal_error_for_status(404, ValueError())
+    assert isinstance(not_found, E2ANotFoundError) and not_found.retryable is False
     # Other 4xx -> generic but still fatal E2AError.
-    other = _fatal_error_for_status(404, ValueError())
+    other = _fatal_error_for_status(422, ValueError())
     assert isinstance(other, E2AError) and other.retryable is False
     # 5xx is transient -> no fatal error (reconnect).
     assert _fatal_error_for_status(503, ValueError()) is None

--- a/sdks/typescript/src/v1/ws.ts
+++ b/sdks/typescript/src/v1/ws.ts
@@ -1,6 +1,6 @@
 import WebSocket from "ws";
 import { EventEmitter } from "node:events";
-import { E2AError, E2AAuthError, E2APermissionError } from "./errors.js";
+import { E2AError, E2AAuthError, E2APermissionError, E2ANotFoundError } from "./errors.js";
 
 // Map a fatal (non-retryable) WebSocket handshake rejection status to a typed
 // error — mirrors the Python SDK's _fatal_error_for_status (F6). A 4xx means the
@@ -10,6 +10,9 @@ function fatalErrorForStatus(status: number): E2AError {
   const message = `WebSocket handshake rejected: HTTP ${status}`;
   if (status === 401) return new E2AAuthError({ code: "unauthorized", message, status, retryable: false });
   if (status === 403) return new E2APermissionError({ code: "forbidden", message, status, retryable: false });
+  // 404 — the agent doesn't exist OR isn't yours (the server collapses the
+  // cross-tenant case into not_found so the handshake can't enumerate agents).
+  if (status === 404) return new E2ANotFoundError({ code: "not_found", message, status, retryable: false });
   return new E2AError({ code: "websocket_rejected", message, status, retryable: false });
 }
 


### PR DESCRIPTION
## Problem

Two related defects on the realtime endpoint `/v1/agents/{email}/ws`:

1. **Error shape (original scope).** The handshake rejected a bad request with **plain-text** `http.Error` bodies, while every `/v1` REST endpoint returns the uniform JSON envelope `{error:{code,message,request_id}}` (+ an `X-Request-Id` header). A client's shared, envelope-based error handling broke on WS auth failures because the body shape and `Content-Type` differed.

2. **Agent-existence enumeration oracle (added scope).** The handshake returned `404 not_found` for a **nonexistent** agent but `403 forbidden` for an agent that **exists in another account**. That 403-vs-404 split let any authenticated caller probe which agent addresses exist across tenants — the exact leak the REST `resolveOwnedAgent` refuses to expose.

These rejections fire **before** the WebSocket upgrade — the connection is still a plain HTTP request, not yet hijacked — so a normal JSON HTTP response is valid and correct.

## Change

### 1. Route all handshake rejections through the REST error envelope

| Case | Status | code |
|------|--------|------|
| missing bearer | 401 | `unauthorized` |
| invalid/expired key | 401 | `unauthorized` |
| agent not found **or not owned (cross-tenant)** | 404 | `not_found` |
| same-account agent-scope ceiling mismatch | 403 | `forbidden` |

- New exported `httpapi.WriteError`, backed by a shared `writeRawEnvelope` that the existing raw attachment-download route's `writeRawError` now also uses (one code path for all non-Huma routes).
- Reuses the request id the chi-root `requestID` middleware already stamped, so **header == body == what REST would emit**, and mirrors it onto `X-Request-Id` (minting a fallback only for a direct call with no middleware, e.g. a unit test).
- `WWW-Authenticate: Bearer realm="e2a"` (RFC 6750 §3) preserved on the missing-bearer 401 and added to the invalid-token 401.

### 2. Close the cross-tenant enumeration oracle (403→404 on not-owned)

The **cross-tenant not-owned** case (`agent.UserID != principal.User.ID`) now returns the **same `404 not_found "agent not found"`** as a nonexistent agent, so an authenticated caller can't distinguish "this address doesn't exist" from "it exists but isn't yours". This mirrors REST `resolveOwnedAgent`, which likewise refuses to distinguish the two.

The **same-account agent-scope ceiling** (`principal.Scope == ScopeAgent && principal.AgentID != agent.ID` — an agent-scoped credential targeting a *different agent the owner owns*) **stays `403 forbidden`**: that's a genuine authorization/scope error, not an existence probe. It sits below the not-found check exactly as it does in REST.

### Not in scope
- The WS endpoint stays **out of the OpenAPI spec** (raw chi upgrade, not a Huma op — OpenAPI can't model WebSockets).

## SDKs (symmetric — API behavior lands across SDKs)

Both WS clients map handshake failures **by HTTP status**. Adds a `404 → typed not-found` branch mirroring 401/403:
- `sdks/typescript/src/v1/ws.ts` → `E2ANotFoundError`
- `sdks/python/src/e2a/v1/websocket.py` → `E2ANotFoundError`

With this, a cross-tenant/nonexistent WS handshake now surfaces the same typed error the REST 404 does. (The envelope codes `unauthorized`/`forbidden`/`not_found` also now match the server byte-for-byte.)

## Tests

`go build ./... && go test ./internal/ws/... ./internal/httpapi/...` green.

- `internal/ws`: table-driven handshake-envelope test asserts `Content-Type: application/json`, an unmarshalable `{error:{code,message,request_id}}` with non-empty fields, a matching `X-Request-Id` header, and the preserved `WWW-Authenticate` on 401. The **not-owner (cross-tenant)** case now asserts **`404 not_found`**; the **agent-scope-ceiling** case still asserts **`403`**.
- `internal/httpapi`: new `ws_route` test wraps a `WriteError` handshake rejection in the **real `requestID` middleware** and asserts a client-supplied `X-Request-Id` is echoed in both the envelope `request_id` and the response header — covering the production request-id path, not just the mint-a-fallback path.
- `sdks/python`: `_fatal_error_for_status(404)` now asserts `E2ANotFoundError` (28 WS tests pass). TS WS/errors tests pass; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
