### PR TITLE
feat(python-sdk): add templates resource at parity with the TS SDK

### DIFF
--- a/sdks/python/src/e2a/v1/client.py
+++ b/sdks/python/src/e2a/v1/client.py
@@ -25,6 +25,7 @@ from .generated.api.events_api import EventsApi
 from .generated.api.messages_api import MessagesApi
 from .generated.api.meta_api import MetaApi
 from .generated.api.reviews_api import ReviewsApi
+from .generated.api.templates_api import TemplatesApi
 from .generated.api.webhooks_api import WebhooksApi
 from .generated.api_client import ApiClient
 from .generated.configuration import Configuration
@@ -58,14 +59,22 @@ from .generated.models import (
     RotateSecretResponse,
     SendEmailRequest,
     SendResultView,
+    StarterTemplateDetailView,
+    StarterTemplateView,
     Suppression,
+    TemplateSummaryView,
+    TemplateView,
     TestWebhookResponse,
     TestWebhookRequest,
     ProtectionConfigView,
+    CreateTemplateRequest,
     UpdateAgentRequest,
     UpdateMessageRequest,
     UpdateMessageResultView,
+    UpdateTemplateRequest,
     UpdateWebhookRequest,
+    ValidateTemplateRequest,
+    ValidateTemplateResponse,
     UserExport,
     VerifyDomainView,
     WebhookDeliveryView,
@@ -176,6 +185,7 @@ class E2AClient:
         self.webhooks = WebhooksResource(WebhooksApi(self._api_client), self)
         self.account = AccountResource(AccountApi(self._api_client), self)
         self.reviews = ReviewsResource(ReviewsApi(self._api_client), self)
+        self.templates = TemplatesResource(TemplatesApi(self._api_client), self)
         self._meta = MetaApi(self._api_client)
 
     # ── lifecycle ───────────────────────────────────────────────────
@@ -444,6 +454,81 @@ class ReviewsResource:
         return await self._c._write_unsafe(
             lambda h: self._api.reject_review(message_id, req, _headers=h)
         )
+
+
+class TemplatesResource:
+    """Reusable email templates + the read-only starter catalog (beta — shapes
+    may change before templates are declared stable). Account scope only; the
+    send-side reference lives on ``messages.send`` (``template_id`` /
+    ``template_alias`` / ``template_data``, mutually exclusive with a literal
+    subject/body)."""
+
+    def __init__(self, api: TemplatesApi, client: E2AClient) -> None:
+        self._api = api
+        self._c = client
+
+    def list(self) -> AutoPager[TemplateSummaryView]:
+        """List the account's stored templates, newest first. Summary rows only
+        (no body/html_body sources) — ``get(id)`` returns the full sources."""
+
+        async def fetch(_cursor: Optional[str]) -> Page:
+            resp = await self._c._read(lambda h: self._api.list_templates(_headers=h))
+            # No cursor param: single-page at GA — see AgentsResource.list.
+            return _page(resp.items)
+
+        return AutoPager(fetch)
+
+    async def get(self, template_id: str) -> TemplateView:
+        """Fetch one stored template by id (tmpl_…), including its sources."""
+        return await self._c._read(lambda h: self._api.get_template(template_id, _headers=h))
+
+    async def create(self, body: Body) -> TemplateView:
+        """Create a template from literal source (name + subject + body), or copy
+        a starter verbatim via ``from_starter`` (mutually exclusive with the
+        source fields — edit the created copy afterwards with ``update``). Bare
+        POST: not retried (mirrors agents/domains/webhooks create), since the
+        create has no server-side idempotency dedup."""
+        req = _coerce(CreateTemplateRequest, body)
+        return await self._c._write_unsafe(lambda h: self._api.create_template(req, _headers=h))
+
+    async def update(self, template_id: str, patch: Body) -> TemplateView:
+        """Partial update; omitted fields are left unchanged. Changed parts are
+        re-parsed. Set alias or html_body to "" to clear them. PATCH is
+        idempotent → safe to retry."""
+        req = _coerce(UpdateTemplateRequest, patch)
+        return await self._c._write_idempotent(
+            lambda h: self._api.update_template(template_id, req, _headers=h)
+        )
+
+    async def delete(self, template_id: str) -> None:
+        # In-flight sends are unaffected (rendering happens at send time). DELETE
+        # is idempotent → safe to retry.
+        await self._c._write_idempotent(lambda h: self._api.delete_template(template_id, _headers=h))
+
+    async def validate(self, body: Body) -> ValidateTemplateResponse:
+        """Dry-run template source without persisting: per-part parse errors, a
+        rendered preview against test_data (present only when valid), and
+        suggested_data — a nested placeholder object covering every variable the
+        source references. Side-effect-free → treated as a retryable read."""
+        req = _coerce(ValidateTemplateRequest, body)
+        return await self._c._read(lambda h: self._api.validate_template(req, _headers=h))
+
+    def list_starters(self) -> AutoPager[StarterTemplateView]:
+        """List the pre-built starter templates shipped with the deployment
+        (catalog metadata + variables; ``get_starter(alias)`` adds the full body
+        sources)."""
+
+        async def fetch(_cursor: Optional[str]) -> Page:
+            resp = await self._c._read(lambda h: self._api.list_starter_templates(_headers=h))
+            # No cursor param: single-page at GA — see AgentsResource.list.
+            return _page(resp.items)
+
+        return AutoPager(fetch)
+
+    async def get_starter(self, alias: str) -> StarterTemplateDetailView:
+        """Fetch one starter by alias, including its full body sources. Starters
+        are read-only masters — copy one with ``create({"from_starter": alias})``."""
+        return await self._c._read(lambda h: self._api.get_starter_template(alias, _headers=h))
 
 
 class ConversationsResource:

--- a/sdks/python/tests/test_v1_client.py
+++ b/sdks/python/tests/test_v1_client.py
@@ -28,7 +28,10 @@ from e2a.v1.generated.models import (
     MessageSummaryView,
     MessageView,
     ReviewView,
+    StarterTemplateView,
     Suppression,
+    TemplateSummaryView,
+    TemplateView,
     WebhookDeliveryView,
     WebhookView,
 )
@@ -46,6 +49,7 @@ _REQUIRED_DEFAULTS = {
     "first_message_at": _DT,
     "last_message_at": _DT,
     "next_retry_at": _DT,
+    "updated_at": _DT,
     "domain": "test.dev",
     "domain_verified": True,
     "email": "x@test.dev",
@@ -125,7 +129,7 @@ def test_requires_api_key():
 
 def test_resources_exposed():
     c = _client()
-    for name in ("agents", "messages", "conversations", "domains", "events", "webhooks", "account", "reviews"):
+    for name in ("agents", "messages", "conversations", "domains", "events", "webhooks", "account", "reviews", "templates"):
         assert getattr(c, name) is not None
     assert c.account.suppressions is not None
 
@@ -440,8 +444,16 @@ async def test_suppressions_list_threads_cursor(httpx_mock):
             {"items": [_valid(WebhookDeliveryView, id="del_1")], "next_cursor": "IGNORE_ME"},
             lambda c: c.webhooks.deliveries("wh_1"),
         ),
+        (
+            {"items": [_valid(TemplateSummaryView, id="tmpl_1")], "next_cursor": "IGNORE_ME"},
+            lambda c: c.templates.list(),
+        ),
+        (
+            {"items": [_valid(StarterTemplateView, alias="welcome")], "next_cursor": "IGNORE_ME"},
+            lambda c: c.templates.list_starters(),
+        ),
     ],
-    ids=["agents", "domains", "webhooks", "deliveries"],
+    ids=["agents", "domains", "webhooks", "deliveries", "templates", "starters"],
 )
 async def test_cursorless_lists_stop_after_one_page(httpx_mock, fixture, lister):
     httpx_mock.add_response(json=fixture)
@@ -449,6 +461,201 @@ async def test_cursorless_lists_stop_after_one_page(httpx_mock, fixture, lister)
         items = await lister(c).to_list(limit=100)
     assert len(items) == 1
     assert len(httpx_mock.get_requests()) == 1
+
+
+# ── templates (beta) ────────────────────────────────────────────────
+# Full parity with the TS SDK's TemplatesResource: the stored-template CRUD +
+# validate dry-run + the read-only starter catalog. Python models are snake_case
+# on both sides (no camel↔snake mapping), so wire keys equal field names.
+
+
+@pytest.mark.anyio
+async def test_templates_list_reads_templates_endpoint(httpx_mock):
+    httpx_mock.add_response(
+        json={"items": [_valid(TemplateSummaryView, id="tmpl_1", name="Welcome")], "next_cursor": None}
+    )
+    async with _client() as c:
+        items = await c.templates.list().to_list(limit=50)
+    assert [t.id for t in items] == ["tmpl_1"]
+    req = httpx_mock.get_requests()[-1]
+    assert req.method == "GET"
+    assert str(req.url).endswith("/v1/templates")
+
+
+@pytest.mark.anyio
+async def test_templates_get_maps_wire_fields(httpx_mock):
+    httpx_mock.add_response(
+        json=_valid(
+            TemplateView,
+            id="tmpl_1",
+            name="Welcome",
+            subject="Welcome, {{name}}!",
+            body="Hi {{name}}",
+            html_body="<p>Hi {{name}}</p>",
+            from_starter_alias="welcome",
+            from_starter_version="1",
+        )
+    )
+    async with _client() as c:
+        tmpl = await c.templates.get("tmpl_1")
+    assert tmpl.html_body == "<p>Hi {{name}}</p>"
+    assert tmpl.from_starter_alias == "welcome"
+    assert tmpl.from_starter_version == "1"
+    req = httpx_mock.get_requests()[-1]
+    assert req.method == "GET"
+    assert "/v1/templates/tmpl_1" in str(req.url)
+
+
+@pytest.mark.anyio
+async def test_templates_create_posts_from_starter_body(httpx_mock):
+    # Exactly the caller's fields reach the wire — no fabricated subject/body keys
+    # that would trip the server's from_starter exclusivity.
+    httpx_mock.add_response(
+        status_code=201,
+        json=_valid(TemplateView, id="tmpl_new", name="Approvals", subject="s", body="b"),
+    )
+    async with _client() as c:
+        res = await c.templates.create({"from_starter": "approval-request", "alias": "my-approvals"})
+    assert res.id == "tmpl_new"
+    req = httpx_mock.get_requests()[-1]
+    assert req.method == "POST"
+    assert str(req.url).endswith("/v1/templates")
+    import json as _json
+
+    assert _json.loads(req.content) == {"from_starter": "approval-request", "alias": "my-approvals"}
+
+
+@pytest.mark.anyio
+async def test_templates_update_patches_and_keeps_explicit_html_clear(httpx_mock):
+    httpx_mock.add_response(
+        json=_valid(TemplateView, id="tmpl_1", name="Welcome", subject="New {{x}}", body="b")
+    )
+    async with _client() as c:
+        await c.templates.update("tmpl_1", {"subject": "New {{x}}", "html_body": ""})
+    req = httpx_mock.get_requests()[-1]
+    assert req.method == "PATCH"
+    assert "/v1/templates/tmpl_1" in str(req.url)
+    import json as _json
+
+    # An explicit html_body:"" is a deliberate clear — it must survive to the wire.
+    assert _json.loads(req.content) == {"subject": "New {{x}}", "html_body": ""}
+
+
+@pytest.mark.anyio
+async def test_templates_delete_issues_delete(httpx_mock):
+    httpx_mock.add_response(status_code=204)
+    async with _client() as c:
+        await c.templates.delete("tmpl_1")
+    req = httpx_mock.get_requests()[-1]
+    assert req.method == "DELETE"
+    assert "/v1/templates/tmpl_1" in str(req.url)
+
+
+@pytest.mark.anyio
+async def test_templates_validate_posts_and_maps_response(httpx_mock):
+    httpx_mock.add_response(
+        json={
+            "valid": True,
+            "errors": [],
+            "rendered": {"subject": "Welcome, Ada!", "body": "Hi Ada", "html_body": "<p>Hi Ada</p>"},
+            "suggested_data": {"user": {"name": "example"}},
+        }
+    )
+    async with _client() as c:
+        res = await c.templates.validate(
+            {"subject": "Welcome, {{user.name}}!", "body": "Hi {{user.name}}", "test_data": {"user": {"name": "Ada"}}}
+        )
+    assert res.valid is True
+    assert res.rendered is not None and res.rendered.html_body == "<p>Hi Ada</p>"
+    assert res.suggested_data == {"user": {"name": "example"}}
+    req = httpx_mock.get_requests()[-1]
+    assert req.method == "POST"
+    assert "/v1/templates/validate" in str(req.url)
+    import json as _json
+
+    assert _json.loads(req.content) == {
+        "subject": "Welcome, {{user.name}}!",
+        "body": "Hi {{user.name}}",
+        "test_data": {"user": {"name": "Ada"}},
+    }
+
+
+@pytest.mark.anyio
+async def test_templates_get_starter_reads_starter_catalog(httpx_mock):
+    httpx_mock.add_response(
+        json={
+            "alias": "approval-request",
+            "name": "Approval request",
+            "description": "Ask a human to approve an action.",
+            "version": "1",
+            "subject": "Approval needed: {{action}}",
+            "body": "Approve: {{approve_url}}",
+            "html_body": '<a href="{{approve_url}}">Approve</a>',
+            "variables": [
+                {"name": "approve_url", "required": True, "raw": False, "description": "d", "example": "https://x/approve"}
+            ],
+        }
+    )
+    async with _client() as c:
+        starter = await c.templates.get_starter("approval-request")
+    assert "{{approve_url}}" in starter.html_body
+    assert starter.variables[0].name == "approve_url"
+    req = httpx_mock.get_requests()[-1]
+    assert req.method == "GET"
+    assert "/v1/starter-templates/approval-request" in str(req.url)
+
+
+@pytest.mark.anyio
+async def test_templates_create_maps_parse_failure_to_validation_error(httpx_mock):
+    # A template-part parse failure (400 invalid_template) must surface as a typed,
+    # non-retryable E2AValidationError carrying the machine code.
+    httpx_mock.add_response(
+        status_code=400,
+        json={"error": {"code": "invalid_template", "message": "template part body failed to parse"}},
+    )
+    async with _client() as c:
+        with pytest.raises(E2AValidationError) as ei:
+            await c.templates.create({"name": "x", "subject": "s", "body": "{{#bad}}"})
+    assert ei.value.code == "invalid_template"
+    assert ei.value.retryable is False
+
+
+@pytest.mark.anyio
+async def test_templates_round_trip_create_update_delete(httpx_mock):
+    # A create→update→delete round-trip against the mocked generated layer,
+    # asserting each hits the right method+path.
+    httpx_mock.add_response(status_code=201, json=_valid(TemplateView, id="tmpl_rt", name="RT", subject="s", body="b"))
+    httpx_mock.add_response(json=_valid(TemplateView, id="tmpl_rt", name="RT", subject="s2", body="b"))
+    httpx_mock.add_response(status_code=204)
+    async with _client() as c:
+        created = await c.templates.create({"name": "RT", "subject": "s", "body": "b"})
+        assert created.id == "tmpl_rt"
+        updated = await c.templates.update("tmpl_rt", {"subject": "s2"})
+        assert updated.subject == "s2"
+        await c.templates.delete("tmpl_rt")
+    methods = [(r.method, str(r.url)) for r in httpx_mock.get_requests()]
+    assert methods[0][0] == "POST" and methods[0][1].endswith("/v1/templates")
+    assert methods[1][0] == "PATCH" and "/v1/templates/tmpl_rt" in methods[1][1]
+    assert methods[2][0] == "DELETE" and "/v1/templates/tmpl_rt" in methods[2][1]
+
+
+def test_templates_view_types_exported_from_v1():
+    # Parity with the TS SDK, which re-exports TemplateView et al. from its public
+    # index. In Python these ride the `from generated.models import *` wildcard —
+    # the same mechanism as AgentView/DomainView — so they must import from e2a.v1.
+    from e2a.v1 import (  # noqa: F401
+        CreateTemplateRequest,
+        StarterTemplateDetailView,
+        StarterTemplateView,
+        TemplateSummaryView,
+        TemplateView,
+        UpdateTemplateRequest,
+        ValidateTemplateRequest,
+        ValidateTemplateResponse,
+    )
+
+    assert TemplateView is not None
+    assert ValidateTemplateResponse is not None
 
 
 # ── error mapping ───────────────────────────────────────────────────


### PR DESCRIPTION
## Why

The TypeScript SDK exposes a full `templates` resource (reusable message templates + a starter catalog, referenced by `messages.send`'s `template_id`/`template_alias`), but the **Python SDK did not** — a whole documented product surface was callable from TS and not Python. The generated `TemplatesApi` already existed in the Python SDK; it was just never surfaced on the ergonomic `E2AClient`.

This is a **client-only addition**: no API-contract/OpenAPI change, no server change. The generated layer already exists.

## What

Adds `client.templates` with 8 methods mirroring the TS `TemplatesResource` exactly:

| method | returns | executor |
|---|---|---|
| `list()` | `AutoPager[TemplateSummaryView]` | `_read` (single-page, no cursor param) |
| `get(id)` | `TemplateView` | `_read` |
| `create(body)` | `TemplateView` | `_write_unsafe` (bare POST, not retried) |
| `update(id, patch)` | `TemplateView` | `_write_idempotent` (PATCH) |
| `delete(id)` | `None` | `_write_idempotent` (DELETE) |
| `validate(body)` | `ValidateTemplateResponse` | `_read` (side-effect-free dry-run) |
| `list_starters()` | `AutoPager[StarterTemplateView]` | `_read` (single-page) |
| `get_starter(alias)` | `StarterTemplateDetailView` | `_read` |

### Conventions mirrored (no new style invented)
- Composition over the generated `TemplatesApi` (never inheritance), wired in the `E2AClient` constructor alongside the other resources.
- `_read` / `_write_unsafe` / `_write_idempotent` executors for error mapping + retry semantics — `create` is a bare, not-retried POST (matches `agents`/`domains`/`webhooks` create; the template POST has no server-side idempotency dedup), `update`/`delete` are HTTP-idempotent and retried, `validate` is side-effect-free so it's a retryable read.
- `_coerce` for typed-model-or-dict request bodies; `AutoPager` for `list`/`list_starters` so they stay consistent with the other Python list methods (and compose cleanly if keyset pagination lands on these endpoints later).

### Public type exports
Template view/request types (`TemplateView`, `TemplateSummaryView`, `StarterTemplateView`, `StarterTemplateDetailView`, `CreateTemplateRequest`, `UpdateTemplateRequest`, `ValidateTemplateRequest`, `ValidateTemplateResponse`) are **already public** via the `from generated.models import *` re-export in `e2a.v1.__init__` — the same mechanism that exports `AgentView`/`DomainView`. No `__init__.py` change was needed; a test locks in that they import from `e2a.v1`.

## Tests

Added a Templates section to `tests/test_v1_client.py` mirroring the TS SDK's template tests (`sdks/typescript/test/v1/client.test.ts`): list (paging + single-page cursor-drop), get (field mapping), create/update/delete round-trip, `from_starter` create body fidelity, explicit `html_body:""` clear survives to the wire, validate request/response mapping, `get_starter`, a `400 invalid_template` → `E2AValidationError` mapping, and the public-export assertion.

- `uv run --extra dev pytest` → **193 passed, 18 skipped** (skips are the DB-backed store tests, unrelated).
- `mypy` on the client module → clean. (No mypy is wired into the SDK's dev deps / CI type-check; the sibling resource code is the type contract, exercised by the tests.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)