### PR TITLE
feat(api): make list pagination consistent + real across the v1 surface

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -2440,6 +2440,25 @@ paths:
     get:
       description: "API keys for the account (metadata only — secrets are shown once, at creation). Account scope only: an agent-scoped credential cannot manage keys."
       operationId: listApiKeys
+      parameters:
+        - description: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+          explode: false
+          in: query
+          name: cursor
+          schema:
+            description: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+            type: string
+        - description: Maximum number of items to return (1-100).
+          explode: false
+          in: query
+          name: limit
+          schema:
+            default: 50
+            description: Maximum number of items to return (1-100).
+            format: int64
+            maximum: 100
+            minimum: 1
+            type: integer
       responses:
         "200":
           content:
@@ -2602,8 +2621,27 @@ paths:
         - account
   /v1/agents:
     get:
-      description: List the agents owned by the authenticated account.
+      description: List the agents owned by the authenticated account, newest first, with cursor pagination.
       operationId: listAgents
+      parameters:
+        - description: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+          explode: false
+          in: query
+          name: cursor
+          schema:
+            description: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+            type: string
+        - description: Maximum number of items to return (1-100).
+          explode: false
+          in: query
+          name: limit
+          schema:
+            default: 50
+            description: Maximum number of items to return (1-100).
+            format: int64
+            maximum: 100
+            minimum: 1
+            type: integer
       responses:
         "200":
           content:
@@ -3442,7 +3480,27 @@ paths:
         - agents
   /v1/domains:
     get:
+      description: List the domains owned by the authenticated account, newest first, with cursor pagination.
       operationId: listDomains
+      parameters:
+        - description: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+          explode: false
+          in: query
+          name: cursor
+          schema:
+            description: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+            type: string
+        - description: Maximum number of items to return (1-100).
+          explode: false
+          in: query
+          name: limit
+          schema:
+            default: 50
+            description: Maximum number of items to return (1-100).
+            format: int64
+            maximum: 100
+            minimum: 1
+            type: integer
       responses:
         "200":
           content:
@@ -3739,6 +3797,25 @@ paths:
     get:
       description: "The review queue: every message held in pending_review across the account's inboxes — outbound drafts awaiting send approval AND inbound messages held by a screening gate. Account-scoped credentials only; agents cannot see (or resolve) holds."
       operationId: listReviews
+      parameters:
+        - description: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+          explode: false
+          in: query
+          name: cursor
+          schema:
+            description: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+            type: string
+        - description: Maximum number of items to return (1-100).
+          explode: false
+          in: query
+          name: limit
+          schema:
+            default: 50
+            description: Maximum number of items to return (1-100).
+            format: int64
+            maximum: 100
+            minimum: 1
+            type: integer
       responses:
         "200":
           content:
@@ -3866,6 +3943,25 @@ paths:
     get:
       description: "List the pre-built starter templates shipped with the deployment, sorted by alias. Returns catalog metadata only; fetch one by alias for the full body sources, or copy one into your library with from_starter on POST /v1/templates. Beta: templates are unstable — their shape may change before they are declared stable."
       operationId: listStarterTemplates
+      parameters:
+        - description: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+          explode: false
+          in: query
+          name: cursor
+          schema:
+            description: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+            type: string
+        - description: Maximum number of items to return (1-100).
+          explode: false
+          in: query
+          name: limit
+          schema:
+            default: 50
+            description: Maximum number of items to return (1-100).
+            format: int64
+            maximum: 100
+            minimum: 1
+            type: integer
       responses:
         "200":
           content:
@@ -3918,6 +4014,25 @@ paths:
     get:
       description: "List the account's templates, newest first. Returns metadata only (no body/html_body); fetch one by id for the full sources. Beta: templates are unstable — their shape may change before they are declared stable."
       operationId: listTemplates
+      parameters:
+        - description: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+          explode: false
+          in: query
+          name: cursor
+          schema:
+            description: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+            type: string
+        - description: Maximum number of items to return (1-100).
+          explode: false
+          in: query
+          name: limit
+          schema:
+            default: 50
+            description: Maximum number of items to return (1-100).
+            format: int64
+            maximum: 100
+            minimum: 1
+            type: integer
       responses:
         "200":
           content:
@@ -4077,7 +4192,27 @@ paths:
         - templates
   /v1/webhooks:
     get:
+      description: List the webhooks owned by the authenticated account, newest first, with cursor pagination.
       operationId: listWebhooks
+      parameters:
+        - description: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+          explode: false
+          in: query
+          name: cursor
+          schema:
+            description: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+            type: string
+        - description: Maximum number of items to return (1-100).
+          explode: false
+          in: query
+          name: limit
+          schema:
+            default: 50
+            description: Maximum number of items to return (1-100).
+            format: int64
+            maximum: 100
+            minimum: 1
+            type: integer
       responses:
         "200":
           content:
@@ -4222,6 +4357,13 @@ paths:
               - pending
               - delivered
               - failed
+            type: string
+        - description: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the status filter.
+          explode: false
+          in: query
+          name: cursor
+          schema:
+            description: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the status filter.
             type: string
         - explode: false
           in: query

--- a/cmd/e2a-prober/prober_test.go
+++ b/cmd/e2a-prober/prober_test.go
@@ -58,7 +58,7 @@ func TestSeedProbe_ProvisionsSystemAccountIdempotently(t *testing.T) {
 	if res2.APIKey != "" {
 		t.Error("re-seed should not mint a new API key when one exists (empty key)")
 	}
-	whs, err := store.ListWebhooksByUser(ctx, agent.UserID)
+	whs, err := store.ListWebhooksByUser(ctx, agent.UserID, 0, time.Time{}, "")
 	if err != nil {
 		t.Fatalf("ListWebhooksByUser: %v", err)
 	}

--- a/cmd/e2a-prober/seed.go
+++ b/cmd/e2a-prober/seed.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/Mnexa-AI/e2a/internal/identity"
 )
@@ -81,7 +82,7 @@ func seedProbe(ctx context.Context, store *identity.Store, agentEmail, sinkURL s
 	// Create an API key only if the probe user has none — re-seeding otherwise
 	// accumulates orphan keys (the plaintext is unrecoverable, so an existing
 	// key can't be re-displayed; the operator reuses the one captured first).
-	keys, err := store.ListAPIKeys(ctx, user.ID)
+	keys, err := store.ListAPIKeys(ctx, user.ID, 0, time.Time{}, "")
 	if err != nil {
 		return nil, fmt.Errorf("list api keys: %w", err)
 	}
@@ -93,7 +94,7 @@ func seedProbe(ctx context.Context, store *identity.Store, agentEmail, sinkURL s
 		res.APIKey = key.PlaintextKey
 	}
 
-	existing, err := store.ListWebhooksByUser(ctx, user.ID)
+	existing, err := store.ListWebhooksByUser(ctx, user.ID, 0, time.Time{}, "")
 	if err != nil {
 		return nil, fmt.Errorf("list webhooks: %w", err)
 	}

--- a/cmd/e2a-prober/seed_conformance.go
+++ b/cmd/e2a-prober/seed_conformance.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 
@@ -72,7 +73,7 @@ func seedAccount(ctx context.Context, store *identity.Store, pool *pgxpool.Pool,
 		}
 	}
 	res := &seededAccount{AgentEmail: agentEmail, Domain: domain}
-	keys, err := store.ListAPIKeys(ctx, user.ID)
+	keys, err := store.ListAPIKeys(ctx, user.ID, 0, time.Time{}, "")
 	if err != nil {
 		return nil, fmt.Errorf("list api keys for %s: %w", email, err)
 	}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -236,7 +236,7 @@ func (ua *UserAuth) setCookie(w http.ResponseWriter, name, value string, maxAge 
 }
 
 func (ua *UserAuth) defaultAgentEmail(ctx context.Context, userID string) string {
-	agents, err := ua.store.ListAgentsByUser(ctx, userID)
+	agents, err := ua.store.ListAgentsByUser(ctx, userID, 0, time.Time{}, "")
 	if err != nil || len(agents) == 0 {
 		return ""
 	}
@@ -594,7 +594,7 @@ func (ua *UserAuth) HandleDashboardAgents(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	agents, err := ua.store.ListAgentsByUser(r.Context(), user.ID)
+	agents, err := ua.store.ListAgentsByUser(r.Context(), user.ID, 0, time.Time{}, "")
 	if err != nil {
 		http.Error(w, "failed to list agents", http.StatusInternalServerError)
 		return
@@ -827,7 +827,7 @@ func (ua *UserAuth) HandleListAPIKeys(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	keys, err := ua.store.ListAPIKeys(r.Context(), user.ID)
+	keys, err := ua.store.ListAPIKeys(r.Context(), user.ID, 0, time.Time{}, "")
 	if err != nil {
 		http.Error(w, "failed to list API keys", http.StatusInternalServerError)
 		return

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -232,7 +232,7 @@ func TestHandleCreateAPIKey_AcceptsExpiresAt(t *testing.T) {
 	}
 
 	// Round-trip through the DB to confirm it was actually persisted.
-	keys, _ := store.ListAPIKeys(ctx, user.ID)
+	keys, _ := store.ListAPIKeys(ctx, user.ID, 0, time.Time{}, "")
 	if len(keys) != 1 || keys[0].ExpiresAt == nil || !keys[0].ExpiresAt.Equal(expiresAt) {
 		t.Errorf("persisted ExpiresAt mismatch: %+v", keys)
 	}

--- a/internal/httpapi/apikeys.go
+++ b/internal/httpapi/apikeys.go
@@ -90,7 +90,12 @@ func (s *Server) registerAPIKeys() {
 	}, s.handleDeleteAPIKey)
 }
 
-func (s *Server) handleListAPIKeys(ctx context.Context, _ *struct{}) (*listAPIKeysOutput, error) {
+// listAPIKeysInput carries the standard cursor/limit (PageParams).
+type listAPIKeysInput struct {
+	PageParams
+}
+
+func (s *Server) handleListAPIKeys(ctx context.Context, in *listAPIKeysInput) (*listAPIKeysOutput, error) {
 	user, err := s.requireAccountUser(ctx)
 	if err != nil {
 		return nil, err
@@ -98,15 +103,32 @@ func (s *Server) handleListAPIKeys(ctx context.Context, _ *struct{}) (*listAPIKe
 	if s.deps.ListAPIKeys == nil {
 		return nil, NewError(http.StatusNotImplemented, "not_implemented", "API keys are not available on this deployment")
 	}
-	keys, err := s.deps.ListAPIKeys(ctx, user.ID)
+	afterCreatedAt, afterID, err := s.decodeKeyset(in.Cursor)
+	if err != nil {
+		return nil, err
+	}
+	limit := effectiveLimit(in.Limit)
+	// Fetch limit+1 to detect a further page.
+	keys, err := s.deps.ListAPIKeys(ctx, user.ID, limit+1, afterCreatedAt, afterID)
 	if err != nil {
 		return nil, NewError(http.StatusInternalServerError, "internal_error", "failed to list API keys")
+	}
+	hasMore := len(keys) > limit
+	if hasMore {
+		keys = keys[:limit]
 	}
 	views := make([]APIKeyView, 0, len(keys))
 	for _, k := range keys {
 		views = append(views, apiKeyView(k))
 	}
-	return &listAPIKeysOutput{Body: NewPage(views, "")}, nil
+	var nextCursor string
+	if hasMore {
+		last := keys[len(keys)-1]
+		if nextCursor, err = s.encodeKeyset(last.CreatedAt, last.ID); err != nil {
+			return nil, err
+		}
+	}
+	return &listAPIKeysOutput{Body: NewPage(views, nextCursor)}, nil
 }
 
 func (s *Server) handleCreateAPIKey(ctx context.Context, in *createAPIKeyInput) (*createAPIKeyOutput, error) {

--- a/internal/httpapi/domains.go
+++ b/internal/httpapi/domains.go
@@ -184,10 +184,16 @@ type VerifyDomainView struct {
 	DKIM       string     `json:"dkim,omitempty" doc:"Live DKIM probe state. Known values: found, missing, deferred, mismatch. 'mismatch' means a DKIM record IS published at the selector but its key doesn't match the issued one — almost always a truncated/clipped TXT (the value is ~400 chars and must be published in full, ending in 'AQAB'). On 'mismatch', re-publish the complete DKIM record; do not just wait."`
 }
 
-// listDomainsOutput uses the shared Page[T] envelope (items + next_cursor);
-// next_cursor is null at launch. See listAgentsOutput. (GA blocker #3.)
+// listDomainsOutput uses the shared Page[T] envelope (items + next_cursor). The
+// list is keyset-paginated on (created_at, domain) — domain is the unique
+// tiebreak. See listAgentsOutput.
 type listDomainsOutput struct {
 	Body Page[DomainView]
+}
+
+// listDomainsInput carries the standard cursor/limit (PageParams).
+type listDomainsInput struct {
+	PageParams
 }
 type domainOutput struct{ Body DomainView }
 type domainCreateOutput struct{ Body DomainView }
@@ -202,7 +208,8 @@ func (s *Server) registerDomains() {
 	huma.Register(s.API, huma.Operation{
 		OperationID: "listDomains", Method: http.MethodGet, Path: "/v1/domains",
 		Summary: "List domains", Tags: []string{"domains"},
-		Security: []map[string][]string{{"bearer": {}}},
+		Description: "List the domains owned by the authenticated account, newest first, with cursor pagination.",
+		Security:    []map[string][]string{{"bearer": {}}},
 	}, s.handleListDomains)
 
 	huma.Register(s.API, huma.Operation{
@@ -305,20 +312,39 @@ func (s *Server) handleVerifyDomain(ctx context.Context, in *DomainParam) (*veri
 	}}, nil
 }
 
-func (s *Server) handleListDomains(ctx context.Context, _ *struct{}) (*listDomainsOutput, error) {
+func (s *Server) handleListDomains(ctx context.Context, in *listDomainsInput) (*listDomainsOutput, error) {
 	user, err := s.requireAccountUser(ctx)
 	if err != nil {
 		return nil, err
 	}
-	domains, err := s.deps.ListDomains(ctx, user.ID)
+	// The keyset tiebreak for domains is the domain string (its unique key), so
+	// the cursor's `id` slot carries the after-domain.
+	afterCreatedAt, afterDomain, err := s.decodeKeyset(in.Cursor)
+	if err != nil {
+		return nil, err
+	}
+	limit := effectiveLimit(in.Limit)
+	// Fetch limit+1 to detect a further page.
+	domains, err := s.deps.ListDomains(ctx, user.ID, limit+1, afterCreatedAt, afterDomain)
 	if err != nil {
 		return nil, NewError(http.StatusInternalServerError, "internal_error", "failed to list domains")
+	}
+	hasMore := len(domains) > limit
+	if hasMore {
+		domains = domains[:limit]
 	}
 	items := make([]DomainView, 0, len(domains))
 	for i := range domains {
 		items = append(items, s.domainView(&domains[i]))
 	}
-	return &listDomainsOutput{Body: NewPage(items, "")}, nil
+	var nextCursor string
+	if hasMore {
+		last := domains[len(domains)-1]
+		if nextCursor, err = s.encodeKeyset(last.CreatedAt, last.Domain); err != nil {
+			return nil, err
+		}
+	}
+	return &listDomainsOutput{Body: NewPage(items, nextCursor)}, nil
 }
 
 func (s *Server) handleGetDomain(ctx context.Context, in *DomainParam) (*domainOutput, error) {

--- a/internal/httpapi/httpapi.go
+++ b/internal/httpapi/httpapi.go
@@ -30,10 +30,14 @@ type Authenticator func(r *http.Request) (*identity.User, error)
 // and treats every caller as account-scoped (pre-Slice-5a behavior).
 type PrincipalAuthenticator func(r *http.Request) (*identity.Principal, error)
 
-// AgentLister returns the agents owned by a user. Injected as a narrow
-// function so the foundation slice doesn't depend on the whole store; the
-// remaining ports will widen this into a resource-scoped store interface.
-type AgentLister func(ctx context.Context, userID string) ([]identity.AgentIdentity, error)
+// AgentLister returns one page of the agents owned by a user, keyset-paginated
+// on (created_at, id): limit is the page size (the handler passes limit+1 to
+// detect a further page; limit<=0 returns every agent, which the webhook
+// filter-ownership validation relies on), and afterCreatedAt/afterID is the
+// position from the previous page's last row (zero afterCreatedAt = first page).
+// Injected as a narrow function so the foundation slice doesn't depend on the
+// whole store.
+type AgentLister func(ctx context.Context, userID string, limit int, afterCreatedAt time.Time, afterID string) ([]identity.AgentIdentity, error)
 
 // AgentGetter loads a single agent by its full email address (the
 // identifier). Ownership is checked by the caller against the resolved
@@ -109,8 +113,11 @@ type Deps struct {
 	UpdateAgentProtection func(ctx context.Context, agentID, userID string, cfg identity.ProtectionConfig) error
 	DeleteAgent           AgentDeleter
 
-	// domains
-	ListDomains         func(ctx context.Context, userID string) ([]identity.Domain, error)
+	// domains. ListDomains is keyset-paginated on (created_at, domain): the
+	// handler passes limit+1 to detect a further page (limit<=0 = all), and the
+	// after-key from the previous page's last row (zero afterCreatedAt = first
+	// page).
+	ListDomains         func(ctx context.Context, userID string, limit int, afterCreatedAt time.Time, afterDomain string) ([]identity.Domain, error)
 	ClaimDomain         func(ctx context.Context, domain, userID string) (*identity.Domain, error)
 	EnforceDomainCreate func(ctx context.Context, userID string) error
 	DeleteDomain        func(ctx context.Context, domain, userID string) error
@@ -164,7 +171,10 @@ type Deps struct {
 	// (both directions) across the user's agents; GetReviewWithContent loads one
 	// held message (ownership-scoped) for the detail view + approve/reject
 	// resolution. Both intentionally include held inbound — operator surface only.
-	ListReviews          func(ctx context.Context, userID string) ([]identity.ReviewListItem, error)
+	// ListReviews is keyset-paginated on (created_at, id): the handler passes
+	// limit+1 to detect a further page and the after-key from the previous page's
+	// last row (zero afterCreatedAt = first page).
+	ListReviews          func(ctx context.Context, userID string, limit int, afterCreatedAt time.Time, afterID string) ([]identity.ReviewListItem, error)
 	GetReviewWithContent func(ctx context.Context, userID, messageID string) (*identity.Message, error)
 	// SendLimit is the per-agent outbound rate limiter (mirrors
 	// sendLimit.AllowWithRetryAfter; key = agent id). Optional.
@@ -219,7 +229,10 @@ type Deps struct {
 
 	// webhooks
 	CreateWebhook func(ctx context.Context, userID, url, description string, events []string, filters identity.WebhookFilters) (*identity.Webhook, error)
-	ListWebhooks  func(ctx context.Context, userID string) ([]identity.Webhook, error)
+	// ListWebhooks is keyset-paginated on (created_at, id): the handler passes
+	// limit+1 to detect a further page (limit<=0 = all) and the after-key from the
+	// previous page's last row (zero afterCreatedAt = first page).
+	ListWebhooks  func(ctx context.Context, userID string, limit int, afterCreatedAt time.Time, afterID string) ([]identity.Webhook, error)
 	GetWebhook    func(ctx context.Context, webhookID, userID string) (*identity.Webhook, error)
 	UpdateWebhook func(ctx context.Context, webhookID, userID string, u identity.WebhookUpdate) (*identity.Webhook, error)
 	DeleteWebhook func(ctx context.Context, webhookID, userID string) error
@@ -228,7 +241,11 @@ type Deps struct {
 	// InsertPendingForTest). ListDeliveries reads the per-webhook delivery
 	// log (subscriberStore.ListDeliveriesByWebhook).
 	TestWebhookInsert func(ctx context.Context, webhookID, eventType string, envelope []byte) (string, error)
-	ListDeliveries    func(ctx context.Context, webhookID, status string, limit int) ([]webhook.SubscriberDelivery, error)
+	// ListDeliveries is keyset-paginated on (created_at, id): the handler passes
+	// limit+1 to detect a further page and the after-key from the previous page's
+	// last row (zero afterCreatedAt = first page). status optionally restricts to
+	// pending|delivered|failed.
+	ListDeliveries func(ctx context.Context, webhookID, status string, limit int, afterCreatedAt time.Time, afterID string) ([]webhook.SubscriberDelivery, error)
 	// EnqueueDelivery enqueues a River webhook_deliver job for a
 	// webhook_subscriber_deliveries row that was inserted directly — the /test
 	// endpoint and the event-redelivery API. Those two surfaces bypass the outbox
@@ -243,7 +260,7 @@ type Deps struct {
 	// not-found). GetTemplate/GetTemplateByAlias also serve the send path's
 	// template_id/template_alias resolution.
 	CreateTemplate     func(ctx context.Context, userID string, in identity.TemplateCreate) (*identity.Template, error)
-	ListTemplates      func(ctx context.Context, userID string) ([]identity.TemplateSummary, error)
+	ListTemplates      func(ctx context.Context, userID string, limit int, afterCreatedAt time.Time, afterID string) ([]identity.TemplateSummary, error)
 	GetTemplate        func(ctx context.Context, templateID, userID string) (*identity.Template, error)
 	GetTemplateByAlias func(ctx context.Context, alias, userID string) (*identity.Template, error)
 	UpdateTemplate     func(ctx context.Context, templateID, userID string, u identity.TemplateUpdate) (*identity.Template, error)
@@ -253,7 +270,7 @@ type Deps struct {
 	// minted key including its one-time plaintext; agentID is "" for account
 	// scope and a resolved agent id for agent scope.
 	CreateScopedAPIKey func(ctx context.Context, userID, name, scope, agentID string, expiresAt *time.Time) (*identity.APIKey, error)
-	ListAPIKeys        func(ctx context.Context, userID string) ([]identity.APIKey, error)
+	ListAPIKeys        func(ctx context.Context, userID string, limit int, afterCreatedAt time.Time, afterID string) ([]identity.APIKey, error)
 	DeleteAPIKey       func(ctx context.Context, keyID, userID string) error
 
 	// domain verification

--- a/internal/httpapi/operations.go
+++ b/internal/httpapi/operations.go
@@ -77,12 +77,16 @@ func agentViewFromIdentity(ag *identity.AgentIdentity) AgentView {
 	}
 }
 
-// listAgentsOutput uses the shared Page[T] envelope (items + next_cursor) so
-// the list has a pagination slot from GA day one. next_cursor is null at launch
-// (all agents are returned in one page); wiring real cursoring + a server-side
-// limit later is additive — no response-shape change. (GA blocker #3.)
+// listAgentsOutput uses the shared Page[T] envelope (items + next_cursor). The
+// list is keyset-paginated on (created_at, id) — same cursor scheme as every
+// other v1 collection.
 type listAgentsOutput struct {
 	Body Page[AgentView]
+}
+
+// listAgentsInput carries the standard cursor/limit (PageParams).
+type listAgentsInput struct {
+	PageParams
 }
 
 // AddressParam is the shared path input for per-agent operations. The
@@ -102,24 +106,10 @@ func (s *Server) registerAgents() {
 		Method:      http.MethodGet,
 		Path:        "/v1/agents",
 		Summary:     "List agents",
-		Description: "List the agents owned by the authenticated account.",
+		Description: "List the agents owned by the authenticated account, newest first, with cursor pagination.",
 		Tags:        []string{"agents"},
 		Security:    []map[string][]string{{"bearer": {}}},
-	}, func(ctx context.Context, _ *struct{}) (*listAgentsOutput, error) {
-		user, err := s.requireAccountUser(ctx)
-		if err != nil {
-			return nil, err
-		}
-		agents, err := s.deps.ListAgents(ctx, user.ID)
-		if err != nil {
-			return nil, NewError(http.StatusInternalServerError, "internal_error", "failed to list agents")
-		}
-		items := make([]AgentView, 0, len(agents))
-		for i := range agents {
-			items = append(items, agentViewFromIdentity(&agents[i]))
-		}
-		return &listAgentsOutput{Body: NewPage(items, "")}, nil
-	})
+	}, s.handleListAgents)
 
 	huma.Register(s.API, huma.Operation{
 		OperationID: "getAgent",
@@ -136,6 +126,39 @@ func (s *Server) registerAgents() {
 		}
 		return &agentOutput{Body: agentViewFromIdentity(ag)}, nil
 	})
+}
+
+func (s *Server) handleListAgents(ctx context.Context, in *listAgentsInput) (*listAgentsOutput, error) {
+	user, err := s.requireAccountUser(ctx)
+	if err != nil {
+		return nil, err
+	}
+	afterCreatedAt, afterID, err := s.decodeKeyset(in.Cursor)
+	if err != nil {
+		return nil, err
+	}
+	limit := effectiveLimit(in.Limit)
+	// Fetch limit+1 to detect a further page.
+	agents, err := s.deps.ListAgents(ctx, user.ID, limit+1, afterCreatedAt, afterID)
+	if err != nil {
+		return nil, NewError(http.StatusInternalServerError, "internal_error", "failed to list agents")
+	}
+	hasMore := len(agents) > limit
+	if hasMore {
+		agents = agents[:limit]
+	}
+	items := make([]AgentView, 0, len(agents))
+	for i := range agents {
+		items = append(items, agentViewFromIdentity(&agents[i]))
+	}
+	var nextCursor string
+	if hasMore {
+		last := agents[len(agents)-1]
+		if nextCursor, err = s.encodeKeyset(last.CreatedAt, last.ID); err != nil {
+			return nil, err
+		}
+	}
+	return &listAgentsOutput{Body: NewPage(items, nextCursor)}, nil
 }
 
 // resolveOwnedAgent authenticates the caller, loads the agent by address,

--- a/internal/httpapi/operations_test.go
+++ b/internal/httpapi/operations_test.go
@@ -86,7 +86,7 @@ func testServer(t *testing.T, opts ...func(*Deps)) *httptest.Server {
 				return nil, errors.New("unauthorized")
 			}
 		},
-		ListAgents: func(ctx context.Context, userID string) ([]identity.AgentIdentity, error) {
+		ListAgents: func(ctx context.Context, userID string, limit int, afterCreatedAt time.Time, afterID string) ([]identity.AgentIdentity, error) {
 			if userID != "u_1" {
 				return nil, errors.New("unexpected user")
 			}
@@ -115,7 +115,7 @@ func testServer(t *testing.T, opts ...func(*Deps)) *httptest.Server {
 				CreatedAt: time.Unix(1700000000, 0).UTC(), UpdatedAt: time.Unix(1700000000, 0).UTC(),
 			}, nil
 		},
-		ListTemplates: func(ctx context.Context, userID string) ([]identity.TemplateSummary, error) {
+		ListTemplates: func(ctx context.Context, userID string, limit int, afterCreatedAt time.Time, afterID string) ([]identity.TemplateSummary, error) {
 			tp := sampleTemplate()
 			return []identity.TemplateSummary{{
 				ID: tp.ID, UserID: tp.UserID, Name: tp.Name, Alias: tp.Alias,
@@ -225,7 +225,7 @@ func testServer(t *testing.T, opts ...func(*Deps)) *httptest.Server {
 				CreatedAt: time.Unix(1700000400, 0).UTC(), ExpiresAt: expiresAt,
 			}, nil
 		},
-		ListAPIKeys: func(ctx context.Context, userID string) ([]identity.APIKey, error) {
+		ListAPIKeys: func(ctx context.Context, userID string, limit int, afterCreatedAt time.Time, afterID string) ([]identity.APIKey, error) {
 			if userID != "u_1" {
 				return nil, errors.New("unexpected user")
 			}
@@ -352,7 +352,7 @@ func testServer(t *testing.T, opts ...func(*Deps)) *httptest.Server {
 				return nil, errors.New("not registered")
 			}
 		},
-		ListDomains: func(ctx context.Context, userID string) ([]identity.Domain, error) {
+		ListDomains: func(ctx context.Context, userID string, limit int, afterCreatedAt time.Time, afterDomain string) ([]identity.Domain, error) {
 			return []identity.Domain{{Domain: "acme.com", Verified: true, VerificationToken: "e2a-verify=tok", IsPrimary: true, AgentCount: 2}}, nil
 		},
 		ClaimDomain: func(ctx context.Context, domain, userID string) (*identity.Domain, error) {
@@ -434,7 +434,7 @@ func testServer(t *testing.T, opts ...func(*Deps)) *httptest.Server {
 			}
 			return &identity.Webhook{ID: "wh_1", URL: url, Description: description, Events: events, Filters: filters, SigningSecret: "whsec_xyz", Enabled: true, CreatedAt: time.Unix(1700000000, 0).UTC()}, nil
 		},
-		ListWebhooks: func(ctx context.Context, userID string) ([]identity.Webhook, error) {
+		ListWebhooks: func(ctx context.Context, userID string, limit int, afterCreatedAt time.Time, afterID string) ([]identity.Webhook, error) {
 			return []identity.Webhook{{ID: "wh_1", URL: "https://x.com/h", Events: []string{"email.received"}, Enabled: true, SigningSecret: "whsec_should_be_hidden", CreatedAt: time.Unix(1700000000, 0).UTC()}}, nil
 		},
 		GetWebhook: func(ctx context.Context, webhookID, userID string) (*identity.Webhook, error) {
@@ -472,7 +472,7 @@ func testServer(t *testing.T, opts ...func(*Deps)) *httptest.Server {
 		TestWebhookInsert: func(ctx context.Context, webhookID, eventType string, envelope []byte) (string, error) {
 			return "whd_test_1", nil
 		},
-		ListDeliveries: func(ctx context.Context, webhookID, status string, limit int) ([]webhook.SubscriberDelivery, error) {
+		ListDeliveries: func(ctx context.Context, webhookID, status string, limit int, afterCreatedAt time.Time, afterID string) ([]webhook.SubscriberDelivery, error) {
 			return []webhook.SubscriberDelivery{
 				{ID: "whd_1", EventType: "email.received", Status: "delivered", Attempts: 1, NextRetryAt: time.Unix(1700000000, 0).UTC(), CreatedAt: time.Unix(1700000000, 0).UTC()},
 			}, nil

--- a/internal/httpapi/pagination.go
+++ b/internal/httpapi/pagination.go
@@ -6,7 +6,9 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"strings"
+	"time"
 )
 
 // Page is the one list-response shape across every v1 collection
@@ -47,6 +49,57 @@ type PageParams struct {
 // ErrInvalidCursor is returned when a cursor fails to decode. Handlers map
 // it to a 400 with code "invalid_cursor".
 var ErrInvalidCursor = errors.New("invalid pagination cursor")
+
+// keysetCursor is the standard opaque continuation for a collection
+// keyset-paginated on (created_at, id) with no cursor-pinned filters — the
+// common case across the account-scoped lists (agents, domains, webhooks,
+// webhook deliveries, templates, api keys, reviews). The compact json keys keep
+// the encoded cursor short. Resources that must pin extra filters across a
+// continuation (messages, events) define their own richer cursor instead.
+//
+// `id` holds whatever unique tiebreak the resource's ORDER BY uses — the row id
+// for most, the domain string for the domains list (its unique key).
+type keysetCursor struct {
+	CreatedAt time.Time `json:"c"`
+	ID        string    `json:"i"`
+}
+
+// decodeKeyset resolves a (created_at, id) continuation cursor into its keyset
+// position. An empty cursor is the first page (zero time, empty id). A malformed
+// or tampered cursor yields a 400 invalid_cursor envelope.
+func (s *Server) decodeKeyset(cursor string) (time.Time, string, error) {
+	if cursor == "" {
+		return time.Time{}, "", nil
+	}
+	var cur keysetCursor
+	if err := DecodeCursor([]string{s.deps.CursorSecret}, cursor, &cur); err != nil {
+		return time.Time{}, "", NewError(http.StatusBadRequest, "invalid_cursor", "invalid pagination cursor")
+	}
+	return cur.CreatedAt, cur.ID, nil
+}
+
+// encodeKeyset mints the next-page cursor from the last row's (created_at, id).
+// A marshal failure maps to a 500 envelope (matches the other list handlers).
+func (s *Server) encodeKeyset(createdAt time.Time, id string) (string, error) {
+	c, err := EncodeCursor(s.deps.CursorSecret, keysetCursor{CreatedAt: createdAt, ID: id})
+	if err != nil {
+		return "", NewError(http.StatusInternalServerError, "internal_error", "failed to build pagination cursor")
+	}
+	return c, nil
+}
+
+// effectiveLimit normalizes a request limit to the default when unset (<=0).
+// Mirrors the inline `if limit <= 0 { limit = 50 }` the list handlers share.
+func effectiveLimit(limit int) int {
+	if limit <= 0 {
+		return defaultPageLimit
+	}
+	return limit
+}
+
+// defaultPageLimit is the page size when a list request omits limit — the same
+// default PageParams declares (50).
+const defaultPageLimit = 50
 
 // EncodeCursor serializes an arbitrary cursor payload (the position +
 // filter snapshot a resource needs to resume) into the opaque, URL-safe,

--- a/internal/httpapi/pagination_endpoints_test.go
+++ b/internal/httpapi/pagination_endpoints_test.go
@@ -1,0 +1,287 @@
+package httpapi
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/webhook"
+)
+
+// These tests verify the newly-standardized keyset pagination on the list
+// endpoints that previously stubbed next_cursor: seed >1 page, walk the cursor,
+// and assert the concatenated pages equal the full set with no dupes/gaps and a
+// stable order — plus that a full final page does NOT emit a spurious cursor and
+// that a tampered cursor is rejected.
+
+// afterKey is the generic keyset predicate shared by the fakes: newest-first on
+// (createdAt, id), returning true when row (c,id) sorts strictly AFTER the
+// cursor position — i.e. should appear on a later page.
+func afterKey(c time.Time, id string, afterC time.Time, afterID string) bool {
+	if afterC.IsZero() {
+		return true // first page
+	}
+	if c.Before(afterC) {
+		return true
+	}
+	if c.Equal(afterC) && id < afterID {
+		return true
+	}
+	return false
+}
+
+// walkPages drives a paginated endpoint from the first page to the last,
+// following next_cursor, and returns the concatenated item ids in order. It
+// fails if a cursor loops, if more than maxPages are needed, or on a non-200.
+func walkPages(t *testing.T, srv *httptest.Server, path, idField string) []string {
+	t.Helper()
+	var ids []string
+	cursor := ""
+	seenCursors := map[string]bool{}
+	for page := 0; page < 50; page++ {
+		u := srv.URL + path
+		if cursor != "" {
+			sep := "&"
+			u += sep + "cursor=" + cursor
+		}
+		code, body := getJSON(t, u, "good")
+		if code != 200 {
+			t.Fatalf("page %d: status %d body %v", page, code, body)
+		}
+		items, _ := body["items"].([]any)
+		for _, it := range items {
+			m := it.(map[string]any)
+			ids = append(ids, m[idField].(string))
+		}
+		next, ok := body["next_cursor"].(string)
+		if !ok || next == "" {
+			return ids // last page
+		}
+		if seenCursors[next] {
+			t.Fatalf("cursor loop detected at page %d", page)
+		}
+		seenCursors[next] = true
+		cursor = next
+	}
+	t.Fatalf("did not terminate within 50 pages")
+	return ids
+}
+
+func assertNoDupes(t *testing.T, ids []string, want int) {
+	t.Helper()
+	if len(ids) != want {
+		t.Fatalf("want %d items across all pages, got %d: %v", want, len(ids), ids)
+	}
+	seen := map[string]bool{}
+	for _, id := range ids {
+		if seen[id] {
+			t.Fatalf("duplicate id %q across pages: %v", id, ids)
+		}
+		seen[id] = true
+	}
+}
+
+// --- reviews (PRIORITY 1: unbounded review backlog) ---
+
+func paginatedReviewsServer(t *testing.T, n int) *httptest.Server {
+	t.Helper()
+	// Newest-first canonical order: r0 (newest) .. r{n-1} (oldest).
+	all := make([]identity.ReviewListItem, n)
+	base := time.Unix(1700000000, 0).UTC()
+	for i := 0; i < n; i++ {
+		all[i] = identity.ReviewListItem{
+			ID:        idFor(i),
+			AgentID:   "support@acme.dev",
+			Direction: "inbound",
+			Sender:    "s@x.com",
+			To:        []string{"support@acme.dev"},
+			Subject:   "held",
+			Status:    "pending_review",
+			CreatedAt: base.Add(-time.Duration(i) * time.Minute),
+		}
+	}
+	srv := httptest.NewServer(New(Deps{
+		Authenticator: bearerGood,
+		ListReviews: func(_ context.Context, userID string, limit int, afterC time.Time, afterID string) ([]identity.ReviewListItem, error) {
+			out := []identity.ReviewListItem{}
+			for _, r := range all {
+				if !afterKey(r.CreatedAt, r.ID, afterC, afterID) {
+					continue
+				}
+				out = append(out, r)
+				if limit > 0 && len(out) == limit {
+					break
+				}
+			}
+			return out, nil
+		},
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestReviews_KeysetPaginationWalksFullSet(t *testing.T) {
+	srv := paginatedReviewsServer(t, 5)
+	ids := walkPages(t, srv, "/v1/reviews?limit=2", "id")
+	assertNoDupes(t, ids, 5)
+	// Stable newest-first order across pages.
+	want := []string{idFor(0), idFor(1), idFor(2), idFor(3), idFor(4)}
+	for i := range want {
+		if ids[i] != want[i] {
+			t.Fatalf("order mismatch at %d: want %v got %v", i, want, ids)
+		}
+	}
+}
+
+func TestReviews_FullFinalPageNoSpuriousCursor(t *testing.T) {
+	srv := paginatedReviewsServer(t, 4)
+	// limit=2 over exactly 4 => page1 (2 + cursor), page2 (2, NO cursor).
+	code, body := getJSON(t, srv.URL+"/v1/reviews?limit=2", "good")
+	if code != 200 {
+		t.Fatalf("status %d", code)
+	}
+	cursor := body["next_cursor"].(string)
+	code, body2 := getJSON(t, srv.URL+"/v1/reviews?limit=2&cursor="+cursor, "good")
+	if code != 200 {
+		t.Fatalf("status %d", code)
+	}
+	if nc, ok := body2["next_cursor"]; ok && nc != nil {
+		t.Fatalf("full final page must not emit a cursor, got %v", nc)
+	}
+}
+
+func TestReviews_TamperedCursorRejected(t *testing.T) {
+	srv := paginatedReviewsServer(t, 3)
+	code, body := getJSON(t, srv.URL+"/v1/reviews?limit=1&cursor=not-a-valid-cursor", "good")
+	if code != http.StatusBadRequest {
+		t.Fatalf("want 400 for bad cursor, got %d body %v", code, body)
+	}
+	if errCode(body) != "invalid_cursor" {
+		t.Fatalf("want code invalid_cursor, got %v", body)
+	}
+}
+
+// --- webhook deliveries (PRIORITY 1: unbounded delivery log) ---
+
+func paginatedDeliveriesServer(t *testing.T, n int) *httptest.Server {
+	t.Helper()
+	all := make([]webhook.SubscriberDelivery, n)
+	base := time.Unix(1700000000, 0).UTC()
+	for i := 0; i < n; i++ {
+		all[i] = webhook.SubscriberDelivery{
+			ID:          idFor(i),
+			WebhookID:   "wh_1",
+			EventType:   "email.received",
+			Status:      "delivered",
+			NextRetryAt: base,
+			CreatedAt:   base.Add(-time.Duration(i) * time.Minute),
+		}
+	}
+	srv := httptest.NewServer(New(Deps{
+		Authenticator: bearerGood,
+		GetWebhook: func(_ context.Context, id, userID string) (*identity.Webhook, error) {
+			return &identity.Webhook{ID: id, UserID: userID}, nil
+		},
+		ListDeliveries: func(_ context.Context, webhookID, status string, limit int, afterC time.Time, afterID string) ([]webhook.SubscriberDelivery, error) {
+			out := []webhook.SubscriberDelivery{}
+			for _, d := range all {
+				if status != "" && d.Status != status {
+					continue
+				}
+				if !afterKey(d.CreatedAt, d.ID, afterC, afterID) {
+					continue
+				}
+				out = append(out, d)
+				if limit > 0 && len(out) == limit {
+					break
+				}
+			}
+			return out, nil
+		},
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestWebhookDeliveries_KeysetPaginationWalksFullSet(t *testing.T) {
+	srv := paginatedDeliveriesServer(t, 7)
+	ids := walkPages(t, srv, "/v1/webhooks/wh_1/deliveries?limit=3", "id")
+	assertNoDupes(t, ids, 7)
+	for i := 0; i < 7; i++ {
+		if ids[i] != idFor(i) {
+			t.Fatalf("order mismatch: want %s at %d, got %v", idFor(i), i, ids)
+		}
+	}
+}
+
+func TestWebhookDeliveries_CursorPinsStatusFilter(t *testing.T) {
+	srv := paginatedDeliveriesServer(t, 5)
+	// Mint a cursor with no status filter, then replay it WITH a status filter.
+	code, body := getJSON(t, srv.URL+"/v1/webhooks/wh_1/deliveries?limit=2", "good")
+	if code != 200 {
+		t.Fatalf("status %d", code)
+	}
+	cursor := body["next_cursor"].(string)
+	code, body = getJSON(t, srv.URL+"/v1/webhooks/wh_1/deliveries?limit=2&status=failed&cursor="+cursor, "good")
+	if code != http.StatusBadRequest || errCode(body) != "invalid_cursor" {
+		t.Fatalf("want 400 invalid_cursor for status change under a cursor, got %d %v", code, body)
+	}
+}
+
+// --- agents (PRIORITY 2: bulk list previously capped) ---
+
+func paginatedAgentsServer(t *testing.T, n int) *httptest.Server {
+	t.Helper()
+	all := make([]identity.AgentIdentity, n)
+	base := time.Unix(1700000000, 0).UTC()
+	for i := 0; i < n; i++ {
+		all[i] = identity.AgentIdentity{
+			ID:        idFor(i),
+			Domain:    "acme.com",
+			UserID:    "u_1",
+			Name:      "agent",
+			CreatedAt: base.Add(-time.Duration(i) * time.Minute),
+		}
+	}
+	srv := httptest.NewServer(New(Deps{
+		Authenticator: bearerGood,
+		ListAgents: func(_ context.Context, userID string, limit int, afterC time.Time, afterID string) ([]identity.AgentIdentity, error) {
+			out := []identity.AgentIdentity{}
+			for _, a := range all {
+				if !afterKey(a.CreatedAt, a.ID, afterC, afterID) {
+					continue
+				}
+				out = append(out, a)
+				if limit > 0 && len(out) == limit {
+					break
+				}
+			}
+			return out, nil
+		},
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func TestAgents_KeysetPaginationWalksFullSet(t *testing.T) {
+	srv := paginatedAgentsServer(t, 6)
+	ids := walkPages(t, srv, "/v1/agents?limit=2", "id")
+	assertNoDupes(t, ids, 6)
+}
+
+// idFor builds a lexically-descending id so the (created_at DESC, id DESC)
+// tiebreak is exercised: newer rows (i smaller) get lexically-larger ids.
+func idFor(i int) string {
+	return string(rune('a'+(20-i))) + "_id"
+}
+
+func bearerGood(r *http.Request) (*identity.User, error) {
+	if r.Header.Get("Authorization") == "Bearer good" {
+		return &identity.User{ID: "u_1", Email: "owner@acme.com"}, nil
+	}
+	return nil, errors.New("unauthorized")
+}

--- a/internal/httpapi/pagination_endpoints_test.go
+++ b/internal/httpapi/pagination_endpoints_test.go
@@ -90,9 +90,24 @@ func assertNoDupes(t *testing.T, ids []string, want int) {
 func paginatedReviewsServer(t *testing.T, n int) *httptest.Server {
 	t.Helper()
 	// Newest-first canonical order: r0 (newest) .. r{n-1} (oldest).
+	//
+	// Rows 1..3 (when present) deliberately SHARE one created_at so the fake's
+	// afterKey tiebreak branch (Equal && id < afterID) actually executes as the
+	// walk crosses the tie — otherwise, with strictly-distinct timestamps, that
+	// branch is dead code and the handler test would only cover cursor plumbing.
+	// Because idFor is lexically descending in step with recency (idFor(1) >
+	// idFor(2) > idFor(3)), the id-DESC tiebreak reproduces the same order the
+	// distinct-timestamp seed had, so the order assertions below are unchanged.
+	// The real SQL keyset predicate under a tie is covered separately by the
+	// DB-backed store tests (internal/identity, internal/webhook).
 	all := make([]identity.ReviewListItem, n)
 	base := time.Unix(1700000000, 0).UTC()
+	tieAt := base.Add(-2 * time.Minute)
 	for i := 0; i < n; i++ {
+		at := base.Add(-time.Duration(i) * time.Minute)
+		if i >= 1 && i <= 3 {
+			at = tieAt
+		}
 		all[i] = identity.ReviewListItem{
 			ID:        idFor(i),
 			AgentID:   "support@acme.dev",
@@ -101,7 +116,7 @@ func paginatedReviewsServer(t *testing.T, n int) *httptest.Server {
 			To:        []string{"support@acme.dev"},
 			Subject:   "held",
 			Status:    "pending_review",
-			CreatedAt: base.Add(-time.Duration(i) * time.Minute),
+			CreatedAt: at,
 		}
 	}
 	srv := httptest.NewServer(New(Deps{
@@ -273,8 +288,13 @@ func TestAgents_KeysetPaginationWalksFullSet(t *testing.T) {
 	assertNoDupes(t, ids, 6)
 }
 
-// idFor builds a lexically-descending id so the (created_at DESC, id DESC)
-// tiebreak is exercised: newer rows (i smaller) get lexically-larger ids.
+// idFor builds a lexically-descending id: newer rows (smaller i) get
+// lexically-larger ids. Combined with the equal-created_at subset that
+// paginatedReviewsServer seeds, this drives the fake's id-DESC tiebreak so the
+// order is stable across a tie. NOTE: this handler-level fake only exercises the
+// cursor plumbing and the fake's own afterKey tiebreak — the real store SQL
+// predicate under a created_at tie is covered by the DB-backed store tests in
+// internal/identity (reviews, agents) and internal/webhook (deliveries).
 func idFor(i int) string {
 	return string(rune('a'+(20-i))) + "_id"
 }

--- a/internal/httpapi/ratelimit_test.go
+++ b/internal/httpapi/ratelimit_test.go
@@ -38,7 +38,7 @@ func TestPollRateLimited(t *testing.T) {
 			}
 			return nil, errors.New("no")
 		},
-		ListWebhooks: func(ctx context.Context, userID string) ([]identity.Webhook, error) {
+		ListWebhooks: func(ctx context.Context, userID string, limit int, afterCreatedAt time.Time, afterID string) ([]identity.Webhook, error) {
 			t.Error("ListWebhooks must NOT be reached when poll-limited")
 			return nil, nil
 		},
@@ -78,7 +78,7 @@ func TestPollRateHeadersOnAllowed(t *testing.T) {
 		Authenticator: func(r *http.Request) (*identity.User, error) {
 			return &identity.User{ID: "u_1"}, nil
 		},
-		ListWebhooks: func(ctx context.Context, userID string) ([]identity.Webhook, error) {
+		ListWebhooks: func(ctx context.Context, userID string, limit int, afterCreatedAt time.Time, afterID string) ([]identity.Webhook, error) {
 			reached = true
 			return []identity.Webhook{}, nil
 		},
@@ -118,7 +118,7 @@ func TestNonPollLimitedReadNotThrottled(t *testing.T) {
 		Authenticator: func(r *http.Request) (*identity.User, error) {
 			return &identity.User{ID: "u_1"}, nil
 		},
-		ListAgents: func(ctx context.Context, userID string) ([]identity.AgentIdentity, error) {
+		ListAgents: func(ctx context.Context, userID string, limit int, afterCreatedAt time.Time, afterID string) ([]identity.AgentIdentity, error) {
 			reached = true
 			return []identity.AgentIdentity{}, nil
 		},
@@ -152,7 +152,7 @@ func TestPollRateLimitExemptInternalClass(t *testing.T) {
 		Authenticator: func(r *http.Request) (*identity.User, error) {
 			return &identity.User{ID: "u_int", AccountClass: "internal"}, nil
 		},
-		ListWebhooks: func(ctx context.Context, userID string) ([]identity.Webhook, error) {
+		ListWebhooks: func(ctx context.Context, userID string, limit int, afterCreatedAt time.Time, afterID string) ([]identity.Webhook, error) {
 			reached = true
 			return []identity.Webhook{}, nil
 		},

--- a/internal/httpapi/reviews.go
+++ b/internal/httpapi/reviews.go
@@ -56,6 +56,13 @@ func reviewView(it identity.ReviewListItem) ReviewView {
 type listReviewsOutput struct{ Body Page[ReviewView] }
 type reviewDetailOutput struct{ Body MessageView }
 
+// listReviewsInput carries the standard cursor/limit (PageParams). The review
+// queue is keyset-paginated on (created_at, id); it grows with the
+// pending-review backlog, so it must not return the whole set in one page.
+type listReviewsInput struct {
+	PageParams
+}
+
 type getReviewInput struct {
 	ID string `path:"id"`
 }
@@ -102,7 +109,7 @@ func (s *Server) registerReviews() {
 	}, s.handleRejectReview)
 }
 
-func (s *Server) handleListReviews(ctx context.Context, _ *struct{}) (*listReviewsOutput, error) {
+func (s *Server) handleListReviews(ctx context.Context, in *listReviewsInput) (*listReviewsOutput, error) {
 	p, err := s.requireAccountScope(ctx)
 	if err != nil {
 		return nil, err
@@ -110,15 +117,32 @@ func (s *Server) handleListReviews(ctx context.Context, _ *struct{}) (*listRevie
 	if s.deps.ListReviews == nil {
 		return nil, NewError(http.StatusNotImplemented, "not_implemented", "reviews are not available on this deployment")
 	}
-	items, err := s.deps.ListReviews(ctx, p.User.ID)
+	afterCreatedAt, afterID, err := s.decodeKeyset(in.Cursor)
+	if err != nil {
+		return nil, err
+	}
+	limit := effectiveLimit(in.Limit)
+	// Fetch limit+1 to detect a further page.
+	items, err := s.deps.ListReviews(ctx, p.User.ID, limit+1, afterCreatedAt, afterID)
 	if err != nil {
 		return nil, NewError(http.StatusInternalServerError, "internal_error", "failed to list reviews")
+	}
+	hasMore := len(items) > limit
+	if hasMore {
+		items = items[:limit]
 	}
 	views := make([]ReviewView, 0, len(items))
 	for _, it := range items {
 		views = append(views, reviewView(it))
 	}
-	return &listReviewsOutput{Body: NewPage(views, "")}, nil
+	var nextCursor string
+	if hasMore {
+		last := items[len(items)-1]
+		if nextCursor, err = s.encodeKeyset(last.CreatedAt, last.ID); err != nil {
+			return nil, err
+		}
+	}
+	return &listReviewsOutput{Body: NewPage(views, nextCursor)}, nil
 }
 
 // requireOwnedReview resolves a held message by id, scoped to the account, and

--- a/internal/httpapi/reviews_test.go
+++ b/internal/httpapi/reviews_test.go
@@ -20,7 +20,7 @@ func reviewsServer(t *testing.T) *httptest.Server {
 			}
 			return nil, errors.New("unauthorized")
 		},
-		ListReviews: func(ctx context.Context, userID string) ([]identity.ReviewListItem, error) {
+		ListReviews: func(ctx context.Context, userID string, limit int, afterCreatedAt time.Time, afterID string) ([]identity.ReviewListItem, error) {
 			if userID != "u_1" {
 				return nil, errors.New("unexpected user")
 			}

--- a/internal/httpapi/scope_test.go
+++ b/internal/httpapi/scope_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/Mnexa-AI/e2a/internal/identity"
 )
@@ -34,7 +35,7 @@ func scopeTestServer(t *testing.T) *httptest.Server {
 			}
 			return nil, errors.New("unauthorized")
 		},
-		ListAgents: func(ctx context.Context, userID string) ([]identity.AgentIdentity, error) {
+		ListAgents: func(ctx context.Context, userID string, limit int, afterCreatedAt time.Time, afterID string) ([]identity.AgentIdentity, error) {
 			return []identity.AgentIdentity{sampleAgent()}, nil
 		},
 		GetAgent: func(ctx context.Context, address string) (*identity.AgentIdentity, error) {
@@ -197,7 +198,7 @@ func TestScope_LegacyAuthenticatorIsAccount(t *testing.T) {
 			}
 			return nil, errors.New("unauthorized")
 		},
-		ListAgents: func(ctx context.Context, userID string) ([]identity.AgentIdentity, error) {
+		ListAgents: func(ctx context.Context, userID string, limit int, afterCreatedAt time.Time, afterID string) ([]identity.AgentIdentity, error) {
 			return []identity.AgentIdentity{sampleAgent()}, nil
 		},
 		Legacy: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusTeapot) }),

--- a/internal/httpapi/startertemplates.go
+++ b/internal/httpapi/startertemplates.go
@@ -8,6 +8,18 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 )
 
+// starterTemplatesCursor is the opaque keyset position over the alias-sorted
+// starter catalog: the last returned alias. The catalog is a small embedded set
+// with no created_at, so alias (its unique, stable sort key) is the whole key.
+type starterTemplatesCursor struct {
+	Alias string `json:"a"`
+}
+
+// listStarterTemplatesInput carries the standard cursor/limit (PageParams).
+type listStarterTemplatesInput struct {
+	PageParams
+}
+
 // Starter templates sub-resource (beta, read-only).
 //
 // Starter templates are the pre-built masters shipped in
@@ -89,18 +101,44 @@ func (s *Server) registerStarterTemplates() {
 	}, s.handleGetStarterTemplate)
 }
 
-func (s *Server) handleListStarterTemplates(ctx context.Context, _ *struct{}) (*listStarterTemplatesOutput, error) {
+func (s *Server) handleListStarterTemplates(ctx context.Context, in *listStarterTemplatesInput) (*listStarterTemplatesOutput, error) {
 	if _, err := s.requireAccountUser(ctx); err != nil {
 		return nil, err
 	}
-	cat := startertemplates.Catalog() // already alias-sorted
-	items := make([]StarterTemplateView, 0, len(cat))
-	for _, m := range cat {
-		items = append(items, starterTemplateView(m))
+	cat := startertemplates.Catalog() // already alias-sorted (ascending)
+	// Keyset over the alias sort key: skip everything up to and including the
+	// cursor's alias, then return the next `limit`.
+	var afterAlias string
+	if in.Cursor != "" {
+		var cur starterTemplatesCursor
+		if err := DecodeCursor([]string{s.deps.CursorSecret}, in.Cursor, &cur); err != nil {
+			return nil, NewError(http.StatusBadRequest, "invalid_cursor", "invalid pagination cursor")
+		}
+		afterAlias = cur.Alias
 	}
-	// The embedded catalog is a handful of masters — always one page
-	// (next_cursor null, webhooks precedent).
-	return &listStarterTemplatesOutput{Body: NewPage(items, "")}, nil
+	limit := effectiveLimit(in.Limit)
+	items := make([]StarterTemplateView, 0, limit)
+	var lastAlias string
+	hasMore := false
+	for _, m := range cat {
+		if afterAlias != "" && m.Alias <= afterAlias {
+			continue
+		}
+		if len(items) == limit {
+			hasMore = true
+			break
+		}
+		items = append(items, starterTemplateView(m))
+		lastAlias = m.Alias
+	}
+	var nextCursor string
+	if hasMore {
+		var err error
+		if nextCursor, err = EncodeCursor(s.deps.CursorSecret, starterTemplatesCursor{Alias: lastAlias}); err != nil {
+			return nil, NewError(http.StatusInternalServerError, "internal_error", "failed to build pagination cursor")
+		}
+	}
+	return &listStarterTemplatesOutput{Body: NewPage(items, nextCursor)}, nil
 }
 
 func (s *Server) handleGetStarterTemplate(ctx context.Context, in *StarterTemplateAliasParam) (*starterTemplateOutput, error) {

--- a/internal/httpapi/templates.go
+++ b/internal/httpapi/templates.go
@@ -295,7 +295,12 @@ func (s *Server) handleCreateTemplate(ctx context.Context, in *createTemplateInp
 	return &templateOutput{Body: templateView(tp)}, nil
 }
 
-func (s *Server) handleListTemplates(ctx context.Context, _ *struct{}) (*listTemplatesOutput, error) {
+// listTemplatesInput carries the standard cursor/limit (PageParams).
+type listTemplatesInput struct {
+	PageParams
+}
+
+func (s *Server) handleListTemplates(ctx context.Context, in *listTemplatesInput) (*listTemplatesOutput, error) {
 	user, err := s.requireAccountUser(ctx)
 	if err != nil {
 		return nil, err
@@ -303,17 +308,32 @@ func (s *Server) handleListTemplates(ctx context.Context, _ *struct{}) (*listTem
 	if s.deps.ListTemplates == nil {
 		return nil, NewError(http.StatusInternalServerError, "internal_error", "templates unavailable")
 	}
-	tps, err := s.deps.ListTemplates(ctx, user.ID)
+	afterCreatedAt, afterID, err := s.decodeKeyset(in.Cursor)
+	if err != nil {
+		return nil, err
+	}
+	limit := effectiveLimit(in.Limit)
+	// Fetch limit+1 to detect a further page.
+	tps, err := s.deps.ListTemplates(ctx, user.ID, limit+1, afterCreatedAt, afterID)
 	if err != nil {
 		return nil, NewError(http.StatusInternalServerError, "internal_error", "failed to list templates")
+	}
+	hasMore := len(tps) > limit
+	if hasMore {
+		tps = tps[:limit]
 	}
 	items := make([]TemplateSummaryView, 0, len(tps))
 	for i := range tps {
 		items = append(items, templateSummaryView(&tps[i]))
 	}
-	// Single-page at launch (no server-side cursoring): next_cursor null,
-	// same as webhooks/agents.
-	return &listTemplatesOutput{Body: NewPage(items, "")}, nil
+	var nextCursor string
+	if hasMore {
+		last := tps[len(tps)-1]
+		if nextCursor, err = s.encodeKeyset(last.CreatedAt, last.ID); err != nil {
+			return nil, err
+		}
+	}
+	return &listTemplatesOutput{Body: NewPage(items, nextCursor)}, nil
 }
 
 func (s *Server) handleGetTemplate(ctx context.Context, in *TemplateIDParam) (*templateOutput, error) {

--- a/internal/httpapi/webhooks.go
+++ b/internal/httpapi/webhooks.go
@@ -154,7 +154,9 @@ func (s *Server) assertAgentsOwned(ctx context.Context, userID string, agentIDs 
 	if len(agentIDs) == 0 {
 		return nil
 	}
-	agents, err := s.deps.ListAgents(ctx, userID)
+	// limit<=0 = every agent: ownership validation must see the caller's whole
+	// agent set, not one page.
+	agents, err := s.deps.ListAgents(ctx, userID, 0, time.Time{}, "")
 	if err != nil {
 		return NewError(http.StatusInternalServerError, "internal_error", "failed to validate agent filters")
 	}
@@ -204,7 +206,8 @@ func (s *Server) registerWebhooks() {
 	huma.Register(s.API, huma.Operation{
 		OperationID: "listWebhooks", Method: http.MethodGet, Path: "/v1/webhooks",
 		Summary: "List webhooks", Tags: []string{"webhooks"},
-		Security: []map[string][]string{{"bearer": {}}},
+		Description: "List the webhooks owned by the authenticated account, newest first, with cursor pagination.",
+		Security:    []map[string][]string{{"bearer": {}}},
 	}, s.handleListWebhooks)
 
 	huma.Register(s.API, huma.Operation{
@@ -327,13 +330,27 @@ type WebhookDeliveryView struct {
 	CreatedAt      string `json:"created_at" format:"date-time"`
 }
 
-// ListDeliveriesInput — this debug log is intentionally single-page (no cursor,
-// WH-7); the limit is generous (default 100, up to 500) so a recent-deliveries
-// view isn't truncated on a busy webhook.
+// ListDeliveriesInput — the per-webhook delivery log, keyset-paginated on
+// (created_at, id) like every other v1 list. The delivery log grows unbounded on
+// a busy webhook, so a cursor (not a fixed cap) is what keeps the whole log
+// reachable; the limit is generous (default 100, up to 500) so a recent view is
+// rarely more than one page. `status` restricts to pending|delivered|failed and
+// is pinned into the cursor (a continuation must not change it).
 type ListDeliveriesInput struct {
 	ID     string `path:"id"`
 	Status string `query:"status" enum:"pending,delivered,failed"`
+	Cursor string `query:"cursor" doc:"Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the status filter."`
 	Limit  int    `query:"limit" minimum:"1" maximum:"500" default:"100"`
+}
+
+// deliveriesCursor is the opaque keyset position for the delivery log: the last
+// row's (created_at, id) plus the status filter it was minted under, so a
+// continuation that changes status is rejected rather than silently returning a
+// wrong page (mirrors the messages/events filter-binding).
+type deliveriesCursor struct {
+	CreatedAt time.Time `json:"c"`
+	ID        string    `json:"i"`
+	Status    string    `json:"s,omitempty"`
 }
 type listDeliveriesOutput struct {
 	Body Page[WebhookDeliveryView]
@@ -351,13 +368,25 @@ func (s *Server) handleListWebhookDeliveries(ctx context.Context, in *ListDelive
 	if wh, err := s.deps.GetWebhook(ctx, in.ID, user.ID); err != nil || wh == nil {
 		return nil, NewError(http.StatusNotFound, "not_found", "webhook not found")
 	}
-	limit := in.Limit
-	if limit <= 0 {
-		limit = 50
+	var cur deliveriesCursor
+	if in.Cursor != "" {
+		if err := DecodeCursor([]string{s.deps.CursorSecret}, in.Cursor, &cur); err != nil {
+			return nil, NewError(http.StatusBadRequest, "invalid_cursor", "invalid pagination cursor")
+		}
+		if cur.Status != in.Status {
+			return nil, NewError(http.StatusBadRequest, "invalid_cursor",
+				"cursor was created with a different status filter — start a new query without a cursor")
+		}
 	}
-	rows, err := s.deps.ListDeliveries(ctx, in.ID, in.Status, limit)
+	limit := effectiveLimit(in.Limit)
+	// Fetch limit+1 to detect a further page.
+	rows, err := s.deps.ListDeliveries(ctx, in.ID, in.Status, limit+1, cur.CreatedAt, cur.ID)
 	if err != nil {
 		return nil, NewError(http.StatusInternalServerError, "internal_error", "failed to list deliveries")
+	}
+	hasMore := len(rows) > limit
+	if hasMore {
+		rows = rows[:limit]
 	}
 	items := make([]WebhookDeliveryView, 0, len(rows))
 	for _, d := range rows {
@@ -372,8 +401,17 @@ func (s *Server) handleListWebhookDeliveries(ctx context.Context, in *ListDelive
 		}
 		items = append(items, v)
 	}
-	// No cursor continuation in the store (limit only) — next_cursor null.
-	return &listDeliveriesOutput{Body: NewPage(items, "")}, nil
+	var nextCursor string
+	if hasMore {
+		last := rows[len(rows)-1]
+		nextCursor, err = EncodeCursor(s.deps.CursorSecret, deliveriesCursor{
+			CreatedAt: last.CreatedAt, ID: last.ID, Status: in.Status,
+		})
+		if err != nil {
+			return nil, NewError(http.StatusInternalServerError, "internal_error", "failed to build pagination cursor")
+		}
+	}
+	return &listDeliveriesOutput{Body: NewPage(items, nextCursor)}, nil
 }
 
 // UpdateWebhookRequest mirrors the legacy PATCH body — pointer fields so
@@ -522,20 +560,42 @@ func (s *Server) handleCreateWebhook(ctx context.Context, in *createWebhookInput
 	}}, nil
 }
 
-func (s *Server) handleListWebhooks(ctx context.Context, _ *struct{}) (*listWebhooksOutput, error) {
+// listWebhooksInput carries the standard cursor/limit (PageParams).
+type listWebhooksInput struct {
+	PageParams
+}
+
+func (s *Server) handleListWebhooks(ctx context.Context, in *listWebhooksInput) (*listWebhooksOutput, error) {
 	user, err := s.requireAccountUser(ctx)
 	if err != nil {
 		return nil, err
 	}
-	hooks, err := s.deps.ListWebhooks(ctx, user.ID)
+	afterCreatedAt, afterID, err := s.decodeKeyset(in.Cursor)
+	if err != nil {
+		return nil, err
+	}
+	limit := effectiveLimit(in.Limit)
+	// Fetch limit+1 to detect a further page.
+	hooks, err := s.deps.ListWebhooks(ctx, user.ID, limit+1, afterCreatedAt, afterID)
 	if err != nil {
 		return nil, NewError(http.StatusInternalServerError, "internal_error", "failed to list webhooks")
+	}
+	hasMore := len(hooks) > limit
+	if hasMore {
+		hooks = hooks[:limit]
 	}
 	items := make([]WebhookView, 0, len(hooks))
 	for i := range hooks {
 		items = append(items, webhookView(&hooks[i]))
 	}
-	return &listWebhooksOutput{Body: NewPage(items, "")}, nil
+	var nextCursor string
+	if hasMore {
+		last := hooks[len(hooks)-1]
+		if nextCursor, err = s.encodeKeyset(last.CreatedAt, last.ID); err != nil {
+			return nil, err
+		}
+	}
+	return &listWebhooksOutput{Body: NewPage(items, nextCursor)}, nil
 }
 
 func (s *Server) handleGetWebhook(ctx context.Context, in *WebhookIDParam) (*webhookOutput, error) {

--- a/internal/identity/hitl_test.go
+++ b/internal/identity/hitl_test.go
@@ -186,7 +186,7 @@ func TestListAgentsByUserIncludesHITL(t *testing.T) {
 		t.Fatalf("UpdateAgentHITL: %v", err)
 	}
 
-	agents, err := store.ListAgentsByUser(ctx, user.ID)
+	agents, err := store.ListAgentsByUser(ctx, user.ID, 0, time.Time{}, "")
 	if err != nil {
 		t.Fatalf("ListAgentsByUser: %v", err)
 	}

--- a/internal/identity/pagination_tie_test.go
+++ b/internal/identity/pagination_tie_test.go
@@ -1,0 +1,211 @@
+package identity_test
+
+import (
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+)
+
+// These DB-backed tests are the regression coverage for the whole reason keyset
+// pagination exists: the tiebreak when several rows share a created_at. The
+// handler-level fakes in internal/httpapi drive the cursor plumbing, but only a
+// real Postgres round-trip exercises the SQL predicate
+//
+//	(created_at < $1 OR (created_at = $1 AND id < $2))
+//
+// A refactor to the naive `created_at < $1 AND id < $2` form would silently skip
+// every tied row after the first on each page boundary; these walks catch that
+// by asserting the concatenation of every page is EXACTLY the full set — no
+// duplicates, no gaps — in the canonical (created_at DESC, id DESC) order, with
+// the tie group deliberately straddling page boundaries (limit < tie size).
+
+// keyRow is the minimal (id, created_at) projection the generic walk needs; each
+// store test maps its own row type onto it.
+type keyRow struct {
+	id        string
+	createdAt time.Time
+}
+
+// walkKeyset drives a store list method from the first page to exhaustion using
+// ONLY the (created_at, id) after-key from the previous page's last row — i.e.
+// the raw keyset predicate, with no HMAC cursor in the loop, so the SQL is what
+// is under test. It returns the concatenated ids in walked order and fails on a
+// page larger than the limit or a walk that never terminates.
+func walkKeyset(t *testing.T, limit int, fetch func(limit int, afterC time.Time, afterID string) ([]keyRow, error)) []string {
+	t.Helper()
+	var got []string
+	var afterC time.Time
+	var afterID string
+	for page := 0; page < 200; page++ {
+		rows, err := fetch(limit, afterC, afterID)
+		if err != nil {
+			t.Fatalf("fetch page %d: %v", page, err)
+		}
+		if len(rows) == 0 {
+			return got
+		}
+		if len(rows) > limit {
+			t.Fatalf("page %d returned %d rows, want <= limit %d", page, len(rows), limit)
+		}
+		for _, r := range rows {
+			got = append(got, r.id)
+		}
+		last := rows[len(rows)-1]
+		afterC, afterID = last.createdAt, last.id
+		if len(rows) < limit {
+			return got
+		}
+	}
+	t.Fatalf("walk did not terminate within page cap")
+	return nil
+}
+
+// assertExactSet fails unless got equals want element-for-element (order,
+// membership, and no duplicates).
+func assertExactSet(t *testing.T, limit int, got, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("limit=%d: walked %d ids, want %d\n got=%v\nwant=%v", limit, len(got), len(want), got, want)
+	}
+	seen := map[string]bool{}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("limit=%d: order mismatch at index %d\n got=%v\nwant=%v", limit, i, got, want)
+		}
+		if seen[got[i]] {
+			t.Fatalf("limit=%d: duplicate id %q across pages: %v", limit, got[i], got)
+		}
+		seen[got[i]] = true
+	}
+}
+
+// descByID returns a copy of ids sorted descending — the intra-tie order the
+// ORDER BY ... id DESC clause produces among rows sharing a created_at.
+func descByID(ids []string) []string {
+	out := append([]string(nil), ids...)
+	sort.Sort(sort.Reverse(sort.StringSlice(out)))
+	return out
+}
+
+// TestListReviews_KeysetTieOnCreatedAtWalksFullSet seeds a THREE-row group with
+// an identical created_at (distinct message ids), flanked by a newer singleton
+// and two older singletons, then walks the review queue one/two rows per page.
+// The tie sits mid-list so it straddles page boundaries under limit<3.
+func TestListReviews_KeysetTieOnCreatedAtWalksFullSet(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	userID, agentID := seedReviewAgent(t, store, ctx, "reviewtie.example.com")
+	exp := time.Now().Add(time.Hour)
+
+	// Fixed, microsecond-clean instants (Postgres timestamps are µs precision).
+	base := time.Unix(1700000000, 0).UTC()
+	newer := base.Add(2 * time.Minute)
+	older1 := base.Add(-1 * time.Minute)
+	older2 := base.Add(-2 * time.Minute)
+
+	// CreateInboundMessage stamps created_at = now(); pin it explicitly so the
+	// tie is real rather than three near-but-not-equal timestamps.
+	seed := func(subj string, at time.Time) string {
+		id := createInbound(t, store, ctx, agentID, "evil@x.com", subj, identity.InboundScreening{
+			Status:            identity.MessageStatusPendingReview,
+			ScanAction:        "review",
+			ReviewReason:      identity.ReviewReasonInboundScan,
+			ApprovalExpiresAt: &exp,
+		})
+		if _, err := pool.Exec(ctx, `UPDATE messages SET created_at=$1 WHERE id=$2`, at, id); err != nil {
+			t.Fatalf("pin created_at for %s: %v", subj, err)
+		}
+		return id
+	}
+
+	newerID := seed("newer", newer)
+	tie := []string{seed("tie-a", base), seed("tie-b", base), seed("tie-c", base)}
+	older1ID := seed("older1", older1)
+	older2ID := seed("older2", older2)
+
+	// Canonical order: created_at DESC, then id DESC within the tie group.
+	want := append([]string{newerID}, descByID(tie)...)
+	want = append(want, older1ID, older2ID)
+
+	fetch := func(limit int, afterC time.Time, afterID string) ([]keyRow, error) {
+		rows, err := store.ListReviews(ctx, userID, limit, afterC, afterID)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]keyRow, len(rows))
+		for i, r := range rows {
+			out[i] = keyRow{id: r.ID, createdAt: r.CreatedAt}
+		}
+		return out, nil
+	}
+
+	// limit=1 puts every tie member on its own page (maximal straddle);
+	// limit=2 lands a page boundary in the MIDDLE of the tie group.
+	for _, limit := range []int{1, 2} {
+		got := walkKeyset(t, limit, fetch)
+		assertExactSet(t, limit, got, want)
+	}
+}
+
+// TestListAgentsByUser_KeysetTieOnCreatedAtWalksFullSet is the same tiebreak
+// regression for the agents list (the other primary generic-keyset store).
+func TestListAgentsByUser_KeysetTieOnCreatedAtWalksFullSet(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, err := store.CreateOrGetUser(ctx, "o@agenttie.example.com", "O", "g-agenttie")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	if _, err := store.ClaimOrCreateDomain(ctx, "agenttie.example.com", user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+
+	base := time.Unix(1700000000, 0).UTC()
+	newer := base.Add(2 * time.Minute)
+	older1 := base.Add(-1 * time.Minute)
+	older2 := base.Add(-2 * time.Minute)
+
+	// CreateAgent stamps created_at = time.Now(); pin it so the tie is exact.
+	seed := func(local string, at time.Time) string {
+		email := local + "@agenttie.example.com"
+		if _, err := store.CreateAgent(ctx, email, "agenttie.example.com", "", "", "", user.ID); err != nil {
+			t.Fatalf("CreateAgent(%s): %v", email, err)
+		}
+		if _, err := pool.Exec(ctx, `UPDATE agent_identities SET created_at=$1 WHERE id=$2`, at, email); err != nil {
+			t.Fatalf("pin created_at for %s: %v", email, err)
+		}
+		return email
+	}
+
+	newerID := seed("z-newer", newer)
+	tie := []string{seed("tie-c", base), seed("tie-b", base), seed("tie-a", base)}
+	older1ID := seed("m-older1", older1)
+	older2ID := seed("n-older2", older2)
+
+	want := append([]string{newerID}, descByID(tie)...)
+	want = append(want, older1ID, older2ID)
+
+	fetch := func(limit int, afterC time.Time, afterID string) ([]keyRow, error) {
+		rows, err := store.ListAgentsByUser(ctx, user.ID, limit, afterC, afterID)
+		if err != nil {
+			return nil, err
+		}
+		out := make([]keyRow, len(rows))
+		for i, a := range rows {
+			out[i] = keyRow{id: a.ID, createdAt: a.CreatedAt}
+		}
+		return out, nil
+	}
+
+	for _, limit := range []int{1, 2} {
+		got := walkKeyset(t, limit, fetch)
+		assertExactSet(t, limit, got, want)
+	}
+}

--- a/internal/identity/review.go
+++ b/internal/identity/review.go
@@ -24,23 +24,36 @@ type ReviewListItem struct {
 	FlagReason     string
 }
 
-// ListReviews returns every held (pending_review) message — BOTH directions —
-// across all of userID's agents, newest-first. This is the operator review
-// queue: it intentionally includes held inbound (which every agent-facing read
-// path excludes). SECURITY: account-scoped reviewer flow only; the user join is
-// the tenant-isolation guard.
-func (s *Store) ListReviews(ctx context.Context, userID string) ([]ReviewListItem, error) {
-	rows, err := s.pool.Query(ctx,
-		`SELECT m.id, m.agent_id, m.direction, m.sender, m.to_recipients,
-		        COALESCE(m.subject, ''), COALESCE(m.conversation_id, ''),
-		        COALESCE(m.status, ''), m.created_at,
-		        COALESCE(m.flagged, false), COALESCE(m.flag_reason, '')
-		   FROM messages m
-		   JOIN agent_identities a ON a.id = m.agent_id
-		  WHERE a.user_id = $1 AND m.status = 'pending_review' AND m.expires_at > now()
-		  ORDER BY m.created_at DESC`,
-		userID,
-	)
+// ListReviews returns one page of held (pending_review) messages — BOTH
+// directions — across all of userID's agents, newest-first, keyset-paginated on
+// (created_at, id). The caller passes limit (fetch limit+1 to detect a further
+// page; limit<=0 returns every row unpaginated) and the after-key from the
+// previous page's last row (zero afterCreatedAt = first page). The review queue
+// grows unbounded with the pending-review backlog, so it needs real pagination
+// rather than returning the whole set. This is the operator review queue: it
+// intentionally includes held inbound (which every agent-facing read path
+// excludes). SECURITY: account-scoped reviewer flow only; the user join is the
+// tenant-isolation guard.
+func (s *Store) ListReviews(ctx context.Context, userID string, limit int, afterCreatedAt time.Time, afterID string) ([]ReviewListItem, error) {
+	q := `SELECT m.id, m.agent_id, m.direction, m.sender, m.to_recipients,
+	        COALESCE(m.subject, ''), COALESCE(m.conversation_id, ''),
+	        COALESCE(m.status, ''), m.created_at,
+	        COALESCE(m.flagged, false), COALESCE(m.flag_reason, '')
+	   FROM messages m
+	   JOIN agent_identities a ON a.id = m.agent_id
+	  WHERE a.user_id = $1 AND m.status = 'pending_review' AND m.expires_at > now()`
+	args := []interface{}{userID}
+	if !afterCreatedAt.IsZero() {
+		i := len(args) + 1
+		q += fmt.Sprintf(` AND (m.created_at < $%d OR (m.created_at = $%d AND m.id < $%d))`, i, i, i+1)
+		args = append(args, afterCreatedAt, afterID)
+	}
+	q += ` ORDER BY m.created_at DESC, m.id DESC`
+	if limit > 0 {
+		q += fmt.Sprintf(` LIMIT $%d`, len(args)+1)
+		args = append(args, limit)
+	}
+	rows, err := s.pool.Query(ctx, q, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -784,23 +784,38 @@ func (s *Store) VerifyDomain(ctx context.Context, domain, userID string) error {
 	return nil
 }
 
-// ListDomainsByUser returns all domains owned by the user (excludes system rows).
 // AgentCount is computed inline via a correlated subquery — one round-trip
-// regardless of how many domains the user has, and the per-row count is
+// regardless of how many domains the page has, and the per-row count is
 // cheap because (agent_identities.user_id, agent_identities.domain) is
-// indexed via the existing idx_agent_identities_user.
-func (s *Store) ListDomainsByUser(ctx context.Context, userID string) ([]Domain, error) {
-	rows, err := s.pool.Query(ctx,
-		`SELECT d.domain, d.user_id, d.verified, d.verification_token, d.created_at, d.verified_at,
-		        d.is_primary, d.last_checked_at,
-		        COALESCE(d.dkim_selector, ''), COALESCE(d.dkim_public_key, ''),
-		        d.sending_status, COALESCE(d.sending_error, ''), d.sending_dns_records, d.sending_last_checked_at,
-		        COALESCE(d.sending_dkim_status, ''), COALESCE(d.sending_mail_from_status, ''),
-		        (SELECT count(*) FROM agent_identities a WHERE a.domain = d.domain AND a.user_id = d.user_id) AS agent_count
-		 FROM domains d
-		 WHERE d.user_id = $1
-		 ORDER BY d.created_at DESC`, userID,
-	)
+// indexed via the existing idx_agent_identities_user. Excludes system rows.
+//
+// ListDomainsByUser returns one page of the user's domains, newest-first,
+// keyset-paginated on (created_at, domain) — domain is the table's unique key,
+// so it is the deterministic tiebreak. limit<=0 returns every domain
+// unpaginated; a positive limit fetches that many (pass limit+1 to detect a
+// further page) starting after the (afterCreatedAt, afterDomain) key from the
+// previous page's last row (zero afterCreatedAt = first page).
+func (s *Store) ListDomainsByUser(ctx context.Context, userID string, limit int, afterCreatedAt time.Time, afterDomain string) ([]Domain, error) {
+	q := `SELECT d.domain, d.user_id, d.verified, d.verification_token, d.created_at, d.verified_at,
+	        d.is_primary, d.last_checked_at,
+	        COALESCE(d.dkim_selector, ''), COALESCE(d.dkim_public_key, ''),
+	        d.sending_status, COALESCE(d.sending_error, ''), d.sending_dns_records, d.sending_last_checked_at,
+	        COALESCE(d.sending_dkim_status, ''), COALESCE(d.sending_mail_from_status, ''),
+	        (SELECT count(*) FROM agent_identities a WHERE a.domain = d.domain AND a.user_id = d.user_id) AS agent_count
+	 FROM domains d
+	 WHERE d.user_id = $1`
+	args := []interface{}{userID}
+	if !afterCreatedAt.IsZero() {
+		i := len(args) + 1
+		q += fmt.Sprintf(` AND (d.created_at < $%d OR (d.created_at = $%d AND d.domain < $%d))`, i, i, i+1)
+		args = append(args, afterCreatedAt, afterDomain)
+	}
+	q += ` ORDER BY d.created_at DESC, d.domain DESC`
+	if limit > 0 {
+		q += fmt.Sprintf(` LIMIT $%d`, len(args)+1)
+		args = append(args, limit)
+	}
+	rows, err := s.pool.Query(ctx, q, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -1075,16 +1090,20 @@ func (s *Store) UpdateAgentName(ctx context.Context, agentID, userID, name strin
 	return nil
 }
 
-// ListAgentsByUser returns all agents owned by the user, joined with
-// domain verification AND enriched with per-agent stats for the
-// dashboard. Five correlated subqueries compute
-// inbound/outbound 7-day counts, pending approvals, last delivery, and
-// webhook health in a single round-trip. Other load paths
-// (GetAgentByID, GetAgentByEmail) intentionally don't compute these —
-// only the dashboard needs them.
-func (s *Store) ListAgentsByUser(ctx context.Context, userID string) ([]AgentIdentity, error) {
-	rows, err := s.pool.Query(ctx,
-		`SELECT a.id, a.domain, a.user_id, a.name, a.public, a.created_at,
+// Agents are joined with domain verification AND enriched with per-agent stats
+// for the dashboard. Five correlated subqueries compute inbound/outbound 7-day
+// counts, pending approvals, last delivery, and webhook health in a single
+// round-trip. Other load paths (GetAgentByID, GetAgentByEmail) intentionally
+// don't compute these — only the dashboard needs them.
+//
+// ListAgentsByUser returns one page of the user's agents, newest-first,
+// keyset-paginated on (created_at, id). limit<=0 returns every agent
+// unpaginated (the all-consumers: auth dashboard views + webhook filter
+// ownership validation); a positive limit fetches that many (pass limit+1 to
+// detect a further page) starting after the (afterCreatedAt, afterID) key from
+// the previous page's last row (zero afterCreatedAt = first page).
+func (s *Store) ListAgentsByUser(ctx context.Context, userID string, limit int, afterCreatedAt time.Time, afterID string) ([]AgentIdentity, error) {
+	q := `SELECT a.id, a.domain, a.user_id, a.name, a.public, a.created_at,
 		        a.hitl_ttl_seconds, a.hitl_expiration_action,
 		        COALESCE(a.inbound_policy, 'open'), a.inbound_allowlist,
 		        a.inbound_policy_action,
@@ -1113,9 +1132,19 @@ func (s *Store) ListAgentsByUser(ctx context.Context, userID string) ([]AgentIde
 		        ) AS webhook_healthy
 		 FROM agent_identities a
 		 JOIN domains d ON a.domain = d.domain
-		 WHERE a.user_id = $1
-		 ORDER BY a.created_at DESC`, userID,
-	)
+		 WHERE a.user_id = $1`
+	args := []interface{}{userID}
+	if !afterCreatedAt.IsZero() {
+		i := len(args) + 1
+		q += fmt.Sprintf(` AND (a.created_at < $%d OR (a.created_at = $%d AND a.id < $%d))`, i, i, i+1)
+		args = append(args, afterCreatedAt, afterID)
+	}
+	q += ` ORDER BY a.created_at DESC, a.id DESC`
+	if limit > 0 {
+		q += fmt.Sprintf(` LIMIT $%d`, len(args)+1)
+		args = append(args, limit)
+	}
+	rows, err := s.pool.Query(ctx, q, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -3887,12 +3916,27 @@ func (s *Store) userOwnsAgent(ctx context.Context, agentID, userID string) (bool
 	return exists, err
 }
 
-func (s *Store) ListAPIKeys(ctx context.Context, userID string) ([]APIKey, error) {
-	rows, err := s.pool.Query(ctx,
-		`SELECT id, user_id, name, key_prefix, COALESCE(scope, 'account'), agent_id, created_at, last_used_at, expires_at
-		   FROM api_keys WHERE user_id = $1 AND revoked_at IS NULL ORDER BY created_at DESC`,
-		userID,
-	)
+// ListAPIKeys returns one page of the user's live (non-revoked) API keys,
+// newest-first, keyset-paginated on (created_at, id). limit<=0 returns every
+// key unpaginated (the all-consumers: auth dashboard + prober seed); a positive
+// limit fetches that many (pass limit+1 to detect a further page) starting after
+// the (afterCreatedAt, afterID) key from the previous page's last row (zero
+// afterCreatedAt = first page).
+func (s *Store) ListAPIKeys(ctx context.Context, userID string, limit int, afterCreatedAt time.Time, afterID string) ([]APIKey, error) {
+	q := `SELECT id, user_id, name, key_prefix, COALESCE(scope, 'account'), agent_id, created_at, last_used_at, expires_at
+	   FROM api_keys WHERE user_id = $1 AND revoked_at IS NULL`
+	args := []interface{}{userID}
+	if !afterCreatedAt.IsZero() {
+		i := len(args) + 1
+		q += fmt.Sprintf(` AND (created_at < $%d OR (created_at = $%d AND id < $%d))`, i, i, i+1)
+		args = append(args, afterCreatedAt, afterID)
+	}
+	q += ` ORDER BY created_at DESC, id DESC`
+	if limit > 0 {
+		q += fmt.Sprintf(` LIMIT $%d`, len(args)+1)
+		args = append(args, limit)
+	}
+	rows, err := s.pool.Query(ctx, q, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/identity/store_test.go
+++ b/internal/identity/store_test.go
@@ -209,7 +209,7 @@ func TestListAPIKeys(t *testing.T) {
 	store.CreateAPIKey(ctx, user.ID, "key-1", nil)
 	store.CreateAPIKey(ctx, user.ID, "key-2", nil)
 
-	keys, err := store.ListAPIKeys(ctx, user.ID)
+	keys, err := store.ListAPIKeys(ctx, user.ID, 0, time.Time{}, "")
 	if err != nil {
 		t.Fatalf("ListAPIKeys: %v", err)
 	}
@@ -231,7 +231,7 @@ func TestDeleteAPIKey(t *testing.T) {
 		t.Fatalf("DeleteAPIKey: %v", err)
 	}
 
-	keys, _ := store.ListAPIKeys(ctx, user.ID)
+	keys, _ := store.ListAPIKeys(ctx, user.ID, 0, time.Time{}, "")
 	if len(keys) != 0 {
 		t.Errorf("expected 0 keys after delete, got %d", len(keys))
 	}
@@ -274,7 +274,7 @@ func TestAPIKey_ListReturnsLastUsedAtAndExpiresAt(t *testing.T) {
 	neverExpires, _ := store.CreateAPIKey(ctx, user.ID, "never-expires", nil)
 
 	// Before any use, last_used_at is NULL on both rows.
-	keys, err := store.ListAPIKeys(ctx, user.ID)
+	keys, err := store.ListAPIKeys(ctx, user.ID, 0, time.Time{}, "")
 	if err != nil {
 		t.Fatalf("ListAPIKeys: %v", err)
 	}
@@ -296,7 +296,7 @@ func TestAPIKey_ListReturnsLastUsedAtAndExpiresAt(t *testing.T) {
 	if _, err := store.GetUserByAPIKey(ctx, withExpiry.PlaintextKey); err != nil {
 		t.Fatalf("GetUserByAPIKey: %v", err)
 	}
-	keys, _ = store.ListAPIKeys(ctx, user.ID)
+	keys, _ = store.ListAPIKeys(ctx, user.ID, 0, time.Time{}, "")
 	for _, k := range keys {
 		if k.ID == withExpiry.ID {
 			if k.LastUsedAt == nil {
@@ -981,7 +981,7 @@ func TestListDomainsByUser_ReturnsEnrichmentColumns(t *testing.T) {
 
 	store.ClaimOrCreateDomain(ctx, "no-agent.example.com", user.ID)
 
-	domains, err := store.ListDomainsByUser(ctx, user.ID)
+	domains, err := store.ListDomainsByUser(ctx, user.ID, 0, time.Time{}, "")
 	if err != nil {
 		t.Fatalf("ListDomainsByUser: %v", err)
 	}
@@ -1272,7 +1272,7 @@ func TestListAgentsByUser_EnrichedFields(t *testing.T) {
 		 VALUES ($1, 'delivered', 1, '', now(), now())`,
 		m.ID)
 
-	agents, err := store.ListAgentsByUser(ctx, user.ID)
+	agents, err := store.ListAgentsByUser(ctx, user.ID, 0, time.Time{}, "")
 	if err != nil {
 		t.Fatalf("ListAgentsByUser: %v", err)
 	}
@@ -1320,7 +1320,7 @@ func TestListAgentsByUser_WebhookUnhealthyOnRecentFailure(t *testing.T) {
 		 VALUES ($1, 'failed', 3, '500 internal', now(), now() - interval '5 minutes')`,
 		m.ID)
 
-	agents, _ := store.ListAgentsByUser(ctx, user.ID)
+	agents, _ := store.ListAgentsByUser(ctx, user.ID, 0, time.Time{}, "")
 	if agents[0].WebhookHealthy {
 		t.Error("WebhookHealthy = true, want false on recent failed delivery")
 	}
@@ -1345,7 +1345,7 @@ func TestListAgentsByUser_OldFailureDoesNotPoisonHealth(t *testing.T) {
 		 VALUES ($1, 'failed', 5, 'stale', now() - interval '3 days', now() - interval '3 days')`,
 		m.ID)
 
-	agents, _ := store.ListAgentsByUser(ctx, user.ID)
+	agents, _ := store.ListAgentsByUser(ctx, user.ID, 0, time.Time{}, "")
 	if !agents[0].WebhookHealthy {
 		t.Error("WebhookHealthy = false, want true (3-day-old failure shouldn't poison health)")
 	}

--- a/internal/identity/templates.go
+++ b/internal/identity/templates.go
@@ -176,14 +176,28 @@ type TemplateSummary struct {
 	UpdatedAt time.Time `json:"updated_at"`
 }
 
-// ListTemplatesByUser returns every template owned by the user, newest
-// first — summaries only (no body/html_body).
-func (s *Store) ListTemplatesByUser(ctx context.Context, userID string) ([]TemplateSummary, error) {
-	rows, err := s.pool.Query(ctx,
-		`SELECT id, user_id, name, COALESCE(alias, ''), subject, created_at, updated_at
-		 FROM templates WHERE user_id = $1 ORDER BY created_at DESC, id`,
-		userID,
-	)
+// Summaries only (no body/html_body).
+//
+// ListTemplatesByUser returns one page of the user's templates, newest-first,
+// keyset-paginated on (created_at, id). limit<=0 returns every template
+// unpaginated; a positive limit fetches that many (pass limit+1 to detect a
+// further page) starting after the (afterCreatedAt, afterID) key from the
+// previous page's last row (zero afterCreatedAt = first page).
+func (s *Store) ListTemplatesByUser(ctx context.Context, userID string, limit int, afterCreatedAt time.Time, afterID string) ([]TemplateSummary, error) {
+	q := `SELECT id, user_id, name, COALESCE(alias, ''), subject, created_at, updated_at
+	 FROM templates WHERE user_id = $1`
+	args := []interface{}{userID}
+	if !afterCreatedAt.IsZero() {
+		i := len(args) + 1
+		q += fmt.Sprintf(` AND (created_at < $%d OR (created_at = $%d AND id < $%d))`, i, i, i+1)
+		args = append(args, afterCreatedAt, afterID)
+	}
+	q += ` ORDER BY created_at DESC, id DESC`
+	if limit > 0 {
+		q += fmt.Sprintf(` LIMIT $%d`, len(args)+1)
+		args = append(args, limit)
+	}
+	rows, err := s.pool.Query(ctx, q, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/identity/templates_test.go
+++ b/internal/identity/templates_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/Mnexa-AI/e2a/internal/identity"
 	"github.com/Mnexa-AI/e2a/internal/testutil"
@@ -188,14 +189,14 @@ func TestListTemplatesByUser_ScopesByOwner(t *testing.T) {
 	store.CreateTemplate(ctx, userA, identity.TemplateCreate{Name: "A2", Subject: "S", Body: "B"})
 	store.CreateTemplate(ctx, userB, identity.TemplateCreate{Name: "B1", Subject: "S", Body: "B"})
 
-	listA, err := store.ListTemplatesByUser(ctx, userA)
+	listA, err := store.ListTemplatesByUser(ctx, userA, 0, time.Time{}, "")
 	if err != nil {
 		t.Fatalf("ListTemplatesByUser A: %v", err)
 	}
 	if len(listA) != 2 {
 		t.Errorf("user A sees %d templates, want 2", len(listA))
 	}
-	listB, _ := store.ListTemplatesByUser(ctx, userB)
+	listB, _ := store.ListTemplatesByUser(ctx, userB, 0, time.Time{}, "")
 	if len(listB) != 1 {
 		t.Errorf("user B sees %d templates, want 1", len(listB))
 	}
@@ -212,7 +213,7 @@ func TestListTemplatesByUser_SummaryShape(t *testing.T) {
 		t.Fatalf("CreateTemplate: %v", err)
 	}
 
-	list, err := store.ListTemplatesByUser(ctx, userID)
+	list, err := store.ListTemplatesByUser(ctx, userID, 0, time.Time{}, "")
 	if err != nil {
 		t.Fatalf("ListTemplatesByUser: %v", err)
 	}

--- a/internal/identity/webhooks.go
+++ b/internal/identity/webhooks.go
@@ -219,18 +219,33 @@ func (s *Store) GetWebhookByIDInternal(ctx context.Context, webhookID string) (*
 	return w, nil
 }
 
-// ListWebhooksByUser returns every webhook owned by the user — used
-// by the slice-2 GET /v1/webhooks endpoint. Storage layer surfaces
-// enabled and disabled rows alike; filter at the handler if needed.
-func (s *Store) ListWebhooksByUser(ctx context.Context, userID string) ([]Webhook, error) {
-	rows, err := s.pool.Query(ctx,
-		`SELECT id, user_id, url, description, events, filters,
-		        signing_secret, COALESCE(signing_secret_prev, ''),
-		        signing_secret_prev_expires_at,
-		        enabled, auto_disabled_at, created_at, last_delivered_at
-		 FROM webhooks WHERE user_id = $1 ORDER BY created_at DESC`,
-		userID,
-	)
+// Storage layer surfaces enabled and disabled rows alike; filter at the handler
+// if needed.
+//
+// ListWebhooksByUser returns one page of the user's webhooks, newest-first,
+// keyset-paginated on (created_at, id). limit<=0 returns every webhook
+// unpaginated (the all-consumers: prober seed); a positive limit fetches that
+// many (pass limit+1 to detect a further page) starting after the
+// (afterCreatedAt, afterID) key from the previous page's last row (zero
+// afterCreatedAt = first page).
+func (s *Store) ListWebhooksByUser(ctx context.Context, userID string, limit int, afterCreatedAt time.Time, afterID string) ([]Webhook, error) {
+	q := `SELECT id, user_id, url, description, events, filters,
+	        signing_secret, COALESCE(signing_secret_prev, ''),
+	        signing_secret_prev_expires_at,
+	        enabled, auto_disabled_at, created_at, last_delivered_at
+	 FROM webhooks WHERE user_id = $1`
+	args := []interface{}{userID}
+	if !afterCreatedAt.IsZero() {
+		i := len(args) + 1
+		q += fmt.Sprintf(` AND (created_at < $%d OR (created_at = $%d AND id < $%d))`, i, i, i+1)
+		args = append(args, afterCreatedAt, afterID)
+	}
+	q += ` ORDER BY created_at DESC, id DESC`
+	if limit > 0 {
+		q += fmt.Sprintf(` LIMIT $%d`, len(args)+1)
+		args = append(args, limit)
+	}
+	rows, err := s.pool.Query(ctx, q, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/identity/webhooks_test.go
+++ b/internal/identity/webhooks_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/Mnexa-AI/e2a/internal/identity"
 	"github.com/Mnexa-AI/e2a/internal/testutil"
@@ -92,14 +93,14 @@ func TestListWebhooksByUser_ScopesByOwner(t *testing.T) {
 	store.CreateWebhook(ctx, userA, "https://a2.example.com", "", []string{"email.received"}, identity.WebhookFilters{})
 	store.CreateWebhook(ctx, userB, "https://b1.example.com", "", []string{"email.received"}, identity.WebhookFilters{})
 
-	listA, err := store.ListWebhooksByUser(ctx, userA)
+	listA, err := store.ListWebhooksByUser(ctx, userA, 0, time.Time{}, "")
 	if err != nil {
 		t.Fatalf("ListWebhooksByUser A: %v", err)
 	}
 	if len(listA) != 2 {
 		t.Errorf("user A sees %d webhooks, want 2", len(listA))
 	}
-	listB, _ := store.ListWebhooksByUser(ctx, userB)
+	listB, _ := store.ListWebhooksByUser(ctx, userB, 0, time.Time{}, "")
 	if len(listB) != 1 {
 		t.Errorf("user B sees %d webhooks, want 1", len(listB))
 	}

--- a/internal/webhook/pagination_tie_test.go
+++ b/internal/webhook/pagination_tie_test.go
@@ -1,0 +1,116 @@
+package webhook_test
+
+import (
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
+	"github.com/Mnexa-AI/e2a/internal/testutil"
+	"github.com/Mnexa-AI/e2a/internal/webhook"
+)
+
+// TestListDeliveriesByWebhook_KeysetTieOnCreatedAtWalksFullSet is the DB-backed
+// tiebreak regression for the webhook delivery log — the third generic-keyset
+// store, and one of the two lists that grew unbounded in production. It seeds a
+// THREE-row group sharing an identical created_at (distinct delivery ids),
+// flanked by a newer and two older singletons, then walks the log one/two rows
+// per page following ONLY the (created_at, id) after-key — so the real SQL
+// predicate `(created_at < $1 OR (created_at = $1 AND id < $2))` is what runs.
+//
+// The naive `created_at < $1 AND id < $2` form would drop every tied row after
+// the first at a page boundary; the exact-set assertion catches that.
+func TestListDeliveriesByWebhook_KeysetTieOnCreatedAtWalksFullSet(t *testing.T) {
+	pool := testutil.TestDB(t)
+	istore := identity.NewStore(pool)
+	ss := webhook.NewSubscriberStore(pool)
+	ctx := context.Background()
+
+	user, err := istore.CreateOrGetUser(ctx, "whd-tie@example.com", "Owner", "google-whd-tie")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	wh, err := istore.CreateWebhook(ctx, user.ID, "https://example.com/hook", "", []string{"email.received"}, identity.WebhookFilters{})
+	if err != nil {
+		t.Fatalf("CreateWebhook: %v", err)
+	}
+	env := []byte(`{"type":"email.received"}`)
+
+	// Fixed, microsecond-clean instants (Postgres timestamps are µs precision).
+	base := time.Unix(1700000000, 0).UTC()
+	newer := base.Add(2 * time.Minute)
+	older1 := base.Add(-1 * time.Minute)
+	older2 := base.Add(-2 * time.Minute)
+
+	// InsertPendingForTest lets created_at default to now(); pin it explicitly
+	// so the three-row tie is exact rather than near-equal.
+	seed := func(at time.Time) string {
+		id, err := ss.InsertPendingForTest(ctx, wh.ID, "email.received", env)
+		if err != nil {
+			t.Fatalf("InsertPendingForTest: %v", err)
+		}
+		if _, err := pool.Exec(ctx, `UPDATE webhook_subscriber_deliveries SET created_at=$1 WHERE id=$2`, at, id); err != nil {
+			t.Fatalf("pin created_at: %v", err)
+		}
+		return id
+	}
+
+	newerID := seed(newer)
+	tie := []string{seed(base), seed(base), seed(base)}
+	older1ID := seed(older1)
+	older2ID := seed(older2)
+
+	// Canonical order: created_at DESC, then id DESC within the tie group.
+	sortedTie := append([]string(nil), tie...)
+	sort.Sort(sort.Reverse(sort.StringSlice(sortedTie)))
+	want := append([]string{newerID}, sortedTie...)
+	want = append(want, older1ID, older2ID)
+
+	walk := func(limit int) []string {
+		var got []string
+		var afterC time.Time
+		var afterID string
+		for page := 0; page < 200; page++ {
+			rows, err := ss.ListDeliveriesByWebhook(ctx, wh.ID, "", limit, afterC, afterID)
+			if err != nil {
+				t.Fatalf("ListDeliveriesByWebhook page %d: %v", page, err)
+			}
+			if len(rows) == 0 {
+				return got
+			}
+			if len(rows) > limit {
+				t.Fatalf("page %d returned %d rows, want <= limit %d", page, len(rows), limit)
+			}
+			for _, d := range rows {
+				got = append(got, d.ID)
+			}
+			last := rows[len(rows)-1]
+			afterC, afterID = last.CreatedAt, last.ID
+			if len(rows) < limit {
+				return got
+			}
+		}
+		t.Fatalf("walk did not terminate within page cap")
+		return nil
+	}
+
+	// limit=1 puts every tie member on its own page (maximal straddle);
+	// limit=2 lands a page boundary in the MIDDLE of the tie group.
+	for _, limit := range []int{1, 2} {
+		got := walk(limit)
+		if len(got) != len(want) {
+			t.Fatalf("limit=%d: walked %d ids, want %d\n got=%v\nwant=%v", limit, len(got), len(want), got, want)
+		}
+		seen := map[string]bool{}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("limit=%d: order mismatch at index %d\n got=%v\nwant=%v", limit, i, got, want)
+			}
+			if seen[got[i]] {
+				t.Fatalf("limit=%d: duplicate id %q across pages: %v", limit, got[i], got)
+			}
+			seen[got[i]] = true
+		}
+	}
+}

--- a/internal/webhook/subscriber_store.go
+++ b/internal/webhook/subscriber_store.go
@@ -187,11 +187,15 @@ func (s *SubscriberStore) DeleteExpiredSubscriberDeliveries(ctx context.Context)
 	}
 }
 
-// ListDeliveriesByWebhook returns up to `limit` delivery rows for the
-// webhook, most-recent first. When status is non-empty, restricts to
-// that status (pending|delivered|failed). Limit is bounded by the
-// caller; this method does not enforce a cap.
-func (s *SubscriberStore) ListDeliveriesByWebhook(ctx context.Context, webhookID, status string, limit int) ([]SubscriberDelivery, error) {
+// ListDeliveriesByWebhook returns one page of delivery rows for the webhook,
+// most-recent first, keyset-paginated on (created_at, id). When status is
+// non-empty, restricts to that status (pending|delivered|failed). The caller
+// passes limit (fetch limit+1 to detect a further page) and the after-key from
+// the previous page's last row (zero afterCreatedAt = first page). The delivery
+// log grows unbounded on a busy webhook, so it needs real pagination rather than
+// silently truncating at a fixed cap. Limit is bounded by the caller; this
+// method does not enforce a cap.
+func (s *SubscriberStore) ListDeliveriesByWebhook(ctx context.Context, webhookID, status string, limit int, afterCreatedAt time.Time, afterID string) ([]SubscriberDelivery, error) {
 	var (
 		rowsErr error
 		out     []SubscriberDelivery
@@ -204,10 +208,15 @@ func (s *SubscriberStore) ListDeliveriesByWebhook(ctx context.Context, webhookID
 	      WHERE webhook_id = $1`
 	args := []interface{}{webhookID}
 	if status != "" {
-		q += ` AND status = $2`
+		q += fmt.Sprintf(` AND status = $%d`, len(args)+1)
 		args = append(args, status)
 	}
-	q += ` ORDER BY created_at DESC LIMIT $` + fmt.Sprintf("%d", len(args)+1)
+	if !afterCreatedAt.IsZero() {
+		i := len(args) + 1
+		q += fmt.Sprintf(` AND (created_at < $%d OR (created_at = $%d AND id < $%d))`, i, i, i+1)
+		args = append(args, afterCreatedAt, afterID)
+	}
+	q += fmt.Sprintf(` ORDER BY created_at DESC, id DESC LIMIT $%d`, len(args)+1)
 	args = append(args, limit)
 
 	rows, err := s.pool.Query(ctx, q, args...)

--- a/internal/webhook/subscriber_store_test.go
+++ b/internal/webhook/subscriber_store_test.go
@@ -63,14 +63,14 @@ func TestSubscriberStore_DeliveryLifecycle(t *testing.T) {
 	}
 
 	// ListDeliveriesByWebhook — all, then filtered by status.
-	all, err := ss.ListDeliveriesByWebhook(ctx, wh.ID, "", 100)
+	all, err := ss.ListDeliveriesByWebhook(ctx, wh.ID, "", 100, time.Time{}, "")
 	if err != nil {
 		t.Fatalf("ListDeliveriesByWebhook: %v", err)
 	}
 	if len(all) < 2 {
 		t.Errorf("list all: got %d, want >=2", len(all))
 	}
-	if failed, _ := ss.ListDeliveriesByWebhook(ctx, wh.ID, "failed", 100); len(failed) != 1 {
+	if failed, _ := ss.ListDeliveriesByWebhook(ctx, wh.ID, "failed", 100, time.Time{}, ""); len(failed) != 1 {
 		t.Errorf("list failed: got %d, want 1", len(failed))
 	}
 

--- a/mcp/src/client.ts
+++ b/mcp/src/client.ts
@@ -107,7 +107,16 @@ export class McpClient {
 
   // ── Agents ──────────────────────────────────────────────────────
 
-  async listAgents(): Promise<AgentView[]> {
+  // Cursor-paginated (GET /v1/agents). One page in `agents` + a next_cursor
+  // when more remain; pass it back as `cursor`.
+  listAgents(params: { cursor?: string; limit?: number } = {}): Promise<Page<AgentView>> {
+    const { cursor, limit } = params;
+    return this.sdk.agents.list(limit !== undefined ? { limit } : {}).page(cursor);
+  }
+
+  // listAllAgents collapses the pager to a flat array for internal aggregations
+  // (list_pending_messages fan-out) that need every agent, not one page.
+  listAllAgents(): Promise<AgentView[]> {
     return this.sdk.agents.list().toArray({ limit: DEFAULT_LIST_LIMIT });
   }
 
@@ -295,7 +304,7 @@ export class McpClient {
   async listPendingMessages(): Promise<MessageSummaryView[]> {
     const addresses = this.agentEmail
       ? [this.agentEmail]
-      : (await this.listAgents()).map((a) => a.email);
+      : (await this.listAllAgents()).map((a) => a.email);
     const out: MessageSummaryView[] = [];
     for (const address of addresses) {
       const rows = await this.sdk.messages
@@ -318,7 +327,7 @@ export class McpClient {
   private async ownerOfPending(messageId: string): Promise<string> {
     const addresses = this.agentEmail
       ? [this.agentEmail]
-      : (await this.listAgents()).map((a) => a.email);
+      : (await this.listAllAgents()).map((a) => a.email);
     for (const address of addresses) {
       const rows = await this.sdk.messages
         .list(address, { direction: "outbound" })
@@ -364,8 +373,10 @@ export class McpClient {
 
   // ── Domains ─────────────────────────────────────────────────────
 
-  listDomains(): Promise<DomainView[]> {
-    return this.sdk.domains.list().toArray({ limit: DEFAULT_LIST_LIMIT });
+  // Cursor-paginated (GET /v1/domains). One page + a next_cursor when more remain.
+  listDomains(params: { cursor?: string; limit?: number } = {}): Promise<Page<DomainView>> {
+    const { cursor, limit } = params;
+    return this.sdk.domains.list(limit !== undefined ? { limit } : {}).page(cursor);
   }
 
   getDomain(domain: string): Promise<DomainView> {
@@ -386,8 +397,10 @@ export class McpClient {
 
   // ── Webhooks ────────────────────────────────────────────────────
 
-  listWebhooks(): Promise<WebhookView[]> {
-    return this.sdk.webhooks.list().toArray({ limit: DEFAULT_LIST_LIMIT });
+  // Cursor-paginated (GET /v1/webhooks). One page + a next_cursor when more remain.
+  listWebhooks(params: { cursor?: string; limit?: number } = {}): Promise<Page<WebhookView>> {
+    const { cursor, limit } = params;
+    return this.sdk.webhooks.list(limit !== undefined ? { limit } : {}).page(cursor);
   }
 
   getWebhook(id: string): Promise<WebhookView> {
@@ -429,25 +442,25 @@ export class McpClient {
   }
 
   // Per-delivery debugging (status/attempts/last_error/last_status_code) for one
-  // webhook. Single page by contract (no cursor); GET /v1/webhooks/{id}/deliveries.
+  // webhook. Cursor-paginated (GET /v1/webhooks/{id}/deliveries): one page + a
+  // next_cursor when more remain. The status filter is pinned into the cursor.
   listWebhookDeliveries(
     id: string,
-    params: { status?: "pending" | "delivered" | "failed"; limit?: number },
-  ): Promise<WebhookDeliveryView[]> {
-    return this.sdk.webhooks
-      .deliveries(id, params)
-      .toArray({ limit: params.limit ?? DEFAULT_LIST_LIMIT });
+    params: { status?: "pending" | "delivered" | "failed"; cursor?: string; limit?: number },
+  ): Promise<Page<WebhookDeliveryView>> {
+    const { cursor, ...rest } = params;
+    return this.sdk.webhooks.deliveries(id, rest).page(cursor);
   }
 
   // ── Templates (beta) ────────────────────────────────────────────
   //
   // SDK-backed (sdk.templates): same retry layer, typed E2AError mapping,
   // and camelCase views as every other tool. Both list endpoints are
-  // single-page by contract (no cursor param), so the wrapper collapses
-  // the pager to a flat array like listAgents/listWebhooks.
+  // cursor-paginated (GET /v1/templates and /v1/starter-templates).
 
-  listTemplates(): Promise<TemplateSummaryView[]> {
-    return this.sdk.templates.list().toArray({ limit: DEFAULT_LIST_LIMIT });
+  listTemplates(params: { cursor?: string; limit?: number } = {}): Promise<Page<TemplateSummaryView>> {
+    const { cursor, limit } = params;
+    return this.sdk.templates.list(limit !== undefined ? { limit } : {}).page(cursor);
   }
 
   getTemplate(id: string): Promise<TemplateView> {
@@ -470,8 +483,9 @@ export class McpClient {
     return this.sdk.templates.validate(body);
   }
 
-  listStarterTemplates(): Promise<StarterTemplateView[]> {
-    return this.sdk.templates.listStarters().toArray({ limit: DEFAULT_LIST_LIMIT });
+  listStarterTemplates(params: { cursor?: string; limit?: number } = {}): Promise<Page<StarterTemplateView>> {
+    const { cursor, limit } = params;
+    return this.sdk.templates.listStarters(limit !== undefined ? { limit } : {}).page(cursor);
   }
 
   getStarterTemplate(alias: string): Promise<StarterTemplateDetailView> {

--- a/mcp/src/tools/agents.ts
+++ b/mcp/src/tools/agents.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { McpClient } from "../client.js";
 import { z } from "zod";
-import { runTool, strictInputSchema } from "./util.js";
+import { runTool, strictInputSchema, paginationInput } from "./util.js";
 
 export function registerAgentTools(server: McpServer, client: McpClient): void {
   server.registerTool(
@@ -10,10 +10,17 @@ export function registerAgentTools(server: McpServer, client: McpClient): void {
       title: "List agents",
       annotations: { readOnlyHint: true },
       description:
-        "List every agent inbox owned by the authenticated user. Useful for orientation — which inbox to send `from` or query messages against. Read-only.",
-      inputSchema: strictInputSchema({}),
+        "List the agent inboxes owned by the authenticated user, newest first. Useful for orientation — which inbox to send `from` or query messages against. **Cursor-paginated:** returns one page in `agents` plus a `next_cursor` when more remain — pass it back as `cursor` for the next page. Read-only.",
+      inputSchema: strictInputSchema({ ...paginationInput }),
     },
-    async () => runTool(async () => ({ agents: await client.listAgents() })),
+    async (args) =>
+      runTool(async () => {
+        const page = await client.listAgents({
+          ...(args.cursor !== undefined ? { cursor: args.cursor } : {}),
+          ...(args.limit !== undefined ? { limit: args.limit } : {}),
+        });
+        return { agents: page.items, ...(page.next_cursor ? { next_cursor: page.next_cursor } : {}) };
+      }),
   );
 
   server.registerTool(

--- a/mcp/src/tools/domains.ts
+++ b/mcp/src/tools/domains.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { McpClient } from "../client.js";
 import { z } from "zod";
-import { runTool, strictInputSchema } from "./util.js";
+import { runTool, strictInputSchema, paginationInput } from "./util.js";
 
 /**
  * Domain-management tools. Mirrors the four domain endpoints the
@@ -22,10 +22,17 @@ export function registerDomainTools(server: McpServer, client: McpClient): void 
       title: "List domains",
       annotations: { readOnlyHint: true },
       description:
-        "List every custom mail domain registered under the authenticated user, with verification status (verified / pending DNS / failed) and the verification token for each. Useful to discover which domains can already send/receive mail and which still need DNS records to be added. Read-only; cheap to call.",
-      inputSchema: strictInputSchema({}),
+        "List the custom mail domains registered under the authenticated user, newest first, with verification status (verified / pending DNS / failed) and the verification token for each. Useful to discover which domains can already send/receive mail and which still need DNS records to be added. **Cursor-paginated:** returns one page in `domains` plus a `next_cursor` when more remain — pass it back as `cursor` for the next page. Read-only; cheap to call.",
+      inputSchema: strictInputSchema({ ...paginationInput }),
     },
-    async () => runTool(async () => ({ domains: await client.listDomains() })),
+    async (args) =>
+      runTool(async () => {
+        const page = await client.listDomains({
+          ...(args.cursor !== undefined ? { cursor: args.cursor } : {}),
+          ...(args.limit !== undefined ? { limit: args.limit } : {}),
+        });
+        return { domains: page.items, ...(page.next_cursor ? { next_cursor: page.next_cursor } : {}) };
+      }),
   );
 
   server.registerTool(

--- a/mcp/src/tools/templates.ts
+++ b/mcp/src/tools/templates.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { McpClient } from "../client.js";
 import { z } from "zod";
-import { runTool, strictInputSchema } from "./util.js";
+import { runTool, strictInputSchema, paginationInput } from "./util.js";
 
 /**
  * Template tools (beta) — reusable email templates + the read-only starter
@@ -44,11 +44,19 @@ export function registerTemplateTools(server: McpServer, client: McpClient): voi
       description:
         "List the account's stored email templates, newest first — summary rows (id, name, alias, subject, timestamps); " +
         "`get_template` returns the full body sources. Use a template on send via `send_message`'s template_id or " +
-        "template_alias. Read-only; cheap. " +
+        "template_alias. **Cursor-paginated:** returns one page in `templates` plus a `next_cursor` when more remain — " +
+        "pass it back as `cursor` for the next page. Read-only; cheap. " +
         BETA,
-      inputSchema: strictInputSchema({}),
+      inputSchema: strictInputSchema({ ...paginationInput }),
     },
-    async () => runTool(async () => ({ templates: await client.listTemplates() })),
+    async (args) =>
+      runTool(async () => {
+        const page = await client.listTemplates({
+          ...(args.cursor !== undefined ? { cursor: args.cursor } : {}),
+          ...(args.limit !== undefined ? { limit: args.limit } : {}),
+        });
+        return { templates: page.items, ...(page.next_cursor ? { next_cursor: page.next_cursor } : {}) };
+      }),
   );
 
   server.registerTool(
@@ -224,10 +232,22 @@ export function registerTemplateTools(server: McpServer, client: McpClient): voi
         "description, example. Catalog metadata only; `get_starter_template` adds the full body sources. Copy one into " +
         "the account's library with `create_template`'s from_starter, then send with template_alias. Variables marked " +
         "raw:true are {{{…_html}}} fragment slots — HTML-escape any user content you splice into them. " +
+        "**Cursor-paginated:** returns one page in `starter_templates` plus a `next_cursor` when more remain — " +
+        "pass it back as `cursor` for the next page. " +
         APPROVAL_LINK_WARNING + " " + BETA,
-      inputSchema: strictInputSchema({}),
+      inputSchema: strictInputSchema({ ...paginationInput }),
     },
-    async () => runTool(async () => ({ starter_templates: await client.listStarterTemplates() })),
+    async (args) =>
+      runTool(async () => {
+        const page = await client.listStarterTemplates({
+          ...(args.cursor !== undefined ? { cursor: args.cursor } : {}),
+          ...(args.limit !== undefined ? { limit: args.limit } : {}),
+        });
+        return {
+          starter_templates: page.items,
+          ...(page.next_cursor ? { next_cursor: page.next_cursor } : {}),
+        };
+      }),
   );
 
   server.registerTool(

--- a/mcp/src/tools/webhooks.ts
+++ b/mcp/src/tools/webhooks.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { McpClient } from "../client.js";
 import { z } from "zod";
-import { runTool, strictInputSchema } from "./util.js";
+import { runTool, strictInputSchema, paginationInput } from "./util.js";
 
 /**
  * Webhook-subscriber tools (top-level webhooks-as-a-resource).
@@ -49,10 +49,17 @@ export function registerWebhookTools(server: McpServer, client: McpClient): void
       title: "List webhook subscribers",
       annotations: { readOnlyHint: true },
       description:
-        "Returns every webhook subscriber owned by the authenticated user, enabled + disabled, with their event subscriptions, filters, and last-delivered timestamp. signing_secret is omitted (it is only ever returned on create + rotate). Read-only; cheap.",
-      inputSchema: strictInputSchema({}),
+        "Returns the webhook subscribers owned by the authenticated user, newest first, enabled + disabled, with their event subscriptions, filters, and last-delivered timestamp. signing_secret is omitted (it is only ever returned on create + rotate). **Cursor-paginated:** returns one page in `webhooks` plus a `next_cursor` when more remain — pass it back as `cursor` for the next page. Read-only; cheap.",
+      inputSchema: strictInputSchema({ ...paginationInput }),
     },
-    async () => runTool(async () => ({ webhooks: await client.listWebhooks() })),
+    async (args) =>
+      runTool(async () => {
+        const page = await client.listWebhooks({
+          ...(args.cursor !== undefined ? { cursor: args.cursor } : {}),
+          ...(args.limit !== undefined ? { limit: args.limit } : {}),
+        });
+        return { webhooks: page.items, ...(page.next_cursor ? { next_cursor: page.next_cursor } : {}) };
+      }),
   );
 
   server.registerTool(
@@ -190,28 +197,24 @@ export function registerWebhookTools(server: McpServer, client: McpClient): void
       title: "List recent delivery attempts for a webhook",
       annotations: { readOnlyHint: true },
       description:
-        "Returns the most recent delivery rows for one webhook. Each row includes status (pending|delivered|failed), attempts, last_error, last_status_code, and timestamps. The way to debug why a subscriber is missing events, or to check the outcome of a `test_webhook` call. Read-only. Distinct from `list_events` (the account-wide event log); this is the per-webhook delivery ledger.",
+        "Returns the delivery rows for one webhook, newest first. Each row includes status (pending|delivered|failed), attempts, last_error, last_status_code, and timestamps. The way to debug why a subscriber is missing events, or to check the outcome of a `test_webhook` call. **Cursor-paginated:** returns one page in `deliveries` plus a `next_cursor` when more remain — pass it back as `cursor` (keep the same `status` filter). Read-only. Distinct from `list_events` (the account-wide event log); this is the per-webhook delivery ledger.",
       inputSchema: strictInputSchema({
         id: z.string().min(1).describe("Webhook id (wh_…)."),
         status: z
           .enum(["pending", "delivered", "failed"])
           .optional()
           .describe("Optionally restrict to one delivery status."),
-        limit: z
-          .number()
-          .int()
-          .min(1)
-          .max(100)
-          .optional()
-          .describe("Max rows to return."),
+        ...paginationInput,
       }),
     },
     async (args) =>
-      runTool(async () => ({
-        deliveries: await client.listWebhookDeliveries(args.id, {
+      runTool(async () => {
+        const page = await client.listWebhookDeliveries(args.id, {
           ...(args.status !== undefined ? { status: args.status } : {}),
+          ...(args.cursor !== undefined ? { cursor: args.cursor } : {}),
           ...(args.limit !== undefined ? { limit: args.limit } : {}),
-        }),
-      })),
+        });
+        return { deliveries: page.items, ...(page.next_cursor ? { next_cursor: page.next_cursor } : {}) };
+      }),
   );
 }

--- a/mcp/tests/client.test.ts
+++ b/mcp/tests/client.test.ts
@@ -62,13 +62,13 @@ describe("McpClient templates (SDK-backed)", () => {
   function mockTemplatesSdk() {
     return {
       templates: {
-        list: vi.fn(() => ({ toArray: async () => [{ id: "tmpl_1", name: "Welcome" }] })),
+        list: vi.fn(() => ({ page: async () => ({ items: [{ id: "tmpl_1", name: "Welcome" }], next_cursor: undefined }) })),
         get: vi.fn(async (id: string) => ({ id, name: "Welcome", htmlBody: "<p>Hi</p>" })),
         create: vi.fn(async () => ({ id: "tmpl_new", name: "Approvals" })),
         update: vi.fn(async (id: string) => ({ id, name: "Welcome" })),
         delete: vi.fn(async () => undefined),
         validate: vi.fn(async () => ({ valid: true, errors: [], suggestedData: { name: "example" } })),
-        listStarters: vi.fn(() => ({ toArray: async () => [{ alias: "welcome" }] })),
+        listStarters: vi.fn(() => ({ page: async () => ({ items: [{ alias: "welcome" }], next_cursor: undefined }) })),
         getStarter: vi.fn(async (alias: string) => ({ alias, body: "Hi {{name}}" })),
       },
     };
@@ -78,7 +78,7 @@ describe("McpClient templates (SDK-backed)", () => {
     const sdk = mockTemplatesSdk();
     const c = new McpClient(sdk as never, "", "account");
 
-    expect(await c.listTemplates()).toEqual([{ id: "tmpl_1", name: "Welcome" }]);
+    expect(await c.listTemplates()).toEqual({ items: [{ id: "tmpl_1", name: "Welcome" }], next_cursor: undefined });
     expect(sdk.templates.list).toHaveBeenCalledOnce();
 
     await c.getTemplate("tmpl_1");
@@ -96,7 +96,7 @@ describe("McpClient templates (SDK-backed)", () => {
     await c.validateTemplate({ subject: "Hi {{name}}", testData: { name: "Ada" } });
     expect(sdk.templates.validate).toHaveBeenCalledWith({ subject: "Hi {{name}}", testData: { name: "Ada" } });
 
-    expect(await c.listStarterTemplates()).toEqual([{ alias: "welcome" }]);
+    expect(await c.listStarterTemplates()).toEqual({ items: [{ alias: "welcome" }], next_cursor: undefined });
     expect(sdk.templates.listStarters).toHaveBeenCalledOnce();
 
     await c.getStarterTemplate("welcome");

--- a/mcp/tests/http.test.ts
+++ b/mcp/tests/http.test.ts
@@ -27,9 +27,10 @@ function makeStubClient(): McpClient {
     rejectMessage: vi.fn(async () => ({ messageId: "x", status: "rejected" })),
     // Templates (beta) — SDK-backed via the shared E2AClient, so a
     // factory-built session supports them like any other tool.
-    listTemplates: vi.fn(async () => [
-      { id: "tmpl_1", name: "Welcome", alias: "welcome", subject: "Welcome, {{name}}!" },
-    ]),
+    listTemplates: vi.fn(async () => ({
+      items: [{ id: "tmpl_1", name: "Welcome", alias: "welcome", subject: "Welcome, {{name}}!" }],
+      next_cursor: undefined,
+    })),
   };
   return stub as unknown as McpClient;
 }

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -64,7 +64,8 @@ function makeStubClient(
     listConversations: vi.fn(async () => ({ items: [{ conversationId: "conv_1" }], next_cursor: undefined })),
     getConversation: vi.fn(async () => ({ conversationId: "conv_1", messages: [] })),
     listMessages: vi.fn(async () => ({ items: [], next_cursor: undefined })),
-    listAgents: vi.fn(async () => [{ email: "bot@example.com" }]),
+    listAgents: vi.fn(async () => ({ items: [{ email: "bot@example.com" }], next_cursor: undefined })),
+    listAllAgents: vi.fn(async () => [{ email: "bot@example.com" }]),
     // whoami → client.whoami() returns an AccountView (the authenticated
     // account identity), NOT an agent record. No default-agent resolution.
     whoami: vi.fn(async () => ({
@@ -98,9 +99,10 @@ function makeStubClient(
     })),
     updateProtection: vi.fn(async (config: unknown, _addr?: string) => config),
     deleteAgent: vi.fn(async (addr?: string) => addr ?? "bot@example.com"),
-    listDomains: vi.fn(async () => [
-      { domain: "mail.acme.com", verified: true, verificationToken: "tok1" },
-    ]),
+    listDomains: vi.fn(async () => ({
+      items: [{ domain: "mail.acme.com", verified: true, verificationToken: "tok1" }],
+      next_cursor: undefined,
+    })),
     registerDomain: vi.fn(async (domain: string) => ({
       domain,
       verified: false,
@@ -122,9 +124,10 @@ function makeStubClient(
     })),
     deleteDomain: vi.fn(async () => undefined),
     listWebhookDeliveries: vi.fn(
-      async (id: string, _params: { status?: string; limit?: number }) => [
-        { id: "whd_1", webhookId: id, status: "delivered", attempts: 1 },
-      ],
+      async (id: string, _params: { status?: string; cursor?: string; limit?: number }) => ({
+        items: [{ id: "whd_1", webhookId: id, status: "delivered", attempts: 1 }],
+        next_cursor: undefined,
+      }),
     ),
     // Stand-in for McpClient.getMessage() which returns a v1
     // MessageView. Attachments are decoded by the tool from
@@ -166,19 +169,22 @@ function makeStubClient(
     })),
     approveMessage: vi.fn(async () => ({ messageId: "msg_x", status: "sent" })),
     rejectMessage: vi.fn(async () => ({ messageId: "msg_x", status: "rejected" })),
-    // Templates (beta) — SDK-backed: list methods return flat arrays (the
-    // wrapper collapses the single-page pager) and rows are camelCase SDK
-    // views, like every other tool.
-    listTemplates: vi.fn(async () => [
-      {
-        id: "tmpl_1",
-        name: "Welcome",
-        alias: "welcome",
-        subject: "Welcome, {{name}}!",
-        createdAt: "2026-06-01T00:00:00Z",
-        updatedAt: "2026-06-01T00:00:00Z",
-      },
-    ]),
+    // Templates (beta) — SDK-backed: list methods return a Page { items,
+    // next_cursor } (cursor-paginated) and rows are camelCase SDK views, like
+    // every other tool.
+    listTemplates: vi.fn(async () => ({
+      items: [
+        {
+          id: "tmpl_1",
+          name: "Welcome",
+          alias: "welcome",
+          subject: "Welcome, {{name}}!",
+          createdAt: "2026-06-01T00:00:00Z",
+          updatedAt: "2026-06-01T00:00:00Z",
+        },
+      ],
+      next_cursor: undefined,
+    })),
     getTemplate: vi.fn(async (id: string) => ({
       id,
       name: "Welcome",
@@ -210,18 +216,21 @@ function makeStubClient(
       rendered: { subject: "Welcome, Ada!", body: "Hi Ada" },
       suggestedData: { name: "Ada" },
     })),
-    listStarterTemplates: vi.fn(async () => [
-      {
-        alias: "approval-request",
-        name: "Approval request",
-        description: "Ask a human to approve an action.",
-        version: "1",
-        subject: "Approval needed: {{action}}",
-        variables: [
-          { name: "approve_url", required: true, raw: false, description: "Confirmation-page URL", example: "https://x/approve" },
-        ],
-      },
-    ]),
+    listStarterTemplates: vi.fn(async () => ({
+      items: [
+        {
+          alias: "approval-request",
+          name: "Approval request",
+          description: "Ask a human to approve an action.",
+          version: "1",
+          subject: "Approval needed: {{action}}",
+          variables: [
+            { name: "approve_url", required: true, raw: false, description: "Confirmation-page URL", example: "https://x/approve" },
+          ],
+        },
+      ],
+      next_cursor: undefined,
+    })),
     getStarterTemplate: vi.fn(async (alias: string) => ({
       alias,
       name: "Approval request",

--- a/sdks/python/src/e2a/v1/client.py
+++ b/sdks/python/src/e2a/v1/client.py
@@ -238,12 +238,11 @@ class AgentsResource:
         self._api = api
         self._c = client
 
-    def list(self) -> AutoPager[AgentView]:
-        async def fetch(_cursor: Optional[str]) -> Page:
-            resp = await self._c._read(lambda h: self._api.list_agents(_headers=h))
-            # No cursor param: drop next_cursor so the pager stops after one page.
-            # (Single-page at GA — see webhooks.deliveries.)
-            return _page(resp.items)
+    def list(self, *, limit: Optional[int] = None) -> AutoPager[AgentView]:
+        # Cursor-paginated: the AutoPager walks next_cursor to completion.
+        async def fetch(cursor: Optional[str]) -> Page:
+            resp = await self._c._read(lambda h: self._api.list_agents(cursor=cursor, limit=limit, _headers=h))
+            return _page(resp.items, resp.next_cursor)
 
         return AutoPager(fetch)
 
@@ -413,11 +412,11 @@ class ReviewsResource:
         self._api = api
         self._c = client
 
-    def list(self) -> AutoPager[ReviewView]:
-        async def fetch(_cursor: Optional[str]) -> Page:
-            resp = await self._c._read(lambda h: self._api.list_reviews(_headers=h))
-            # No cursor param: single-page at GA — see AgentsResource.list.
-            return _page(resp.items)
+    def list(self, *, limit: Optional[int] = None) -> AutoPager[ReviewView]:
+        # Cursor-paginated: the AutoPager walks next_cursor to completion.
+        async def fetch(cursor: Optional[str]) -> Page:
+            resp = await self._c._read(lambda h: self._api.list_reviews(cursor=cursor, limit=limit, _headers=h))
+            return _page(resp.items, resp.next_cursor)
 
         return AutoPager(fetch)
 
@@ -481,12 +480,11 @@ class DomainsResource:
         self._api = api
         self._c = client
 
-    def list(self) -> AutoPager[DomainView]:
-        async def fetch(_cursor: Optional[str]) -> Page:
-            resp = await self._c._read(lambda h: self._api.list_domains(_headers=h))
-            # No cursor param: drop next_cursor so the pager stops after one page.
-            # (Single-page at GA — see webhooks.deliveries.)
-            return _page(resp.items)
+    def list(self, *, limit: Optional[int] = None) -> AutoPager[DomainView]:
+        # Cursor-paginated: the AutoPager walks next_cursor to completion.
+        async def fetch(cursor: Optional[str]) -> Page:
+            resp = await self._c._read(lambda h: self._api.list_domains(cursor=cursor, limit=limit, _headers=h))
+            return _page(resp.items, resp.next_cursor)
 
         return AutoPager(fetch)
 
@@ -571,12 +569,11 @@ class WebhooksResource:
             )
         return await self._c.messages.get(recipient, message_id)
 
-    def list(self) -> AutoPager[WebhookView]:
-        async def fetch(_cursor: Optional[str]) -> Page:
-            resp = await self._c._read(lambda h: self._api.list_webhooks(_headers=h))
-            # No cursor param: drop next_cursor so the pager stops after one page.
-            # (Single-page at GA — see webhooks.deliveries.)
-            return _page(resp.items)
+    def list(self, *, limit: Optional[int] = None) -> AutoPager[WebhookView]:
+        # Cursor-paginated: the AutoPager walks next_cursor to completion.
+        async def fetch(cursor: Optional[str]) -> Page:
+            resp = await self._c._read(lambda h: self._api.list_webhooks(cursor=cursor, limit=limit, _headers=h))
+            return _page(resp.items, resp.next_cursor)
 
         return AutoPager(fetch)
 
@@ -613,14 +610,16 @@ class WebhooksResource:
     def deliveries(
         self, webhook_id: str, *, status: Optional[str] = None, limit: Optional[int] = None
     ) -> AutoPager[WebhookDeliveryView]:
-        async def fetch(_cursor: Optional[str]) -> Page:
+        # Cursor-paginated: the AutoPager walks next_cursor to completion. The
+        # status filter is pinned into the cursor server-side, which the pager
+        # honors by keeping status constant across follow-up requests.
+        async def fetch(cursor: Optional[str]) -> Page:
             resp = await self._c._read(
                 lambda h: self._api.list_webhook_deliveries(
-                    webhook_id, status=status, limit=limit, _headers=h
+                    webhook_id, status=status, cursor=cursor, limit=limit, _headers=h
                 )
             )
-            # No cursor param: drop next_cursor so the pager stops after one page.
-            return _page(resp.items, None)
+            return _page(resp.items, resp.next_cursor)
 
         return AutoPager(fetch)
 
@@ -647,11 +646,11 @@ class APIKeysResource:
         self._api = api
         self._c = client
 
-    def list(self) -> AutoPager[APIKeyView]:
-        # No cursor param: single page by contract (see webhooks list).
+    def list(self, *, limit: Optional[int] = None) -> AutoPager[APIKeyView]:
+        # Cursor-paginated: the AutoPager walks next_cursor to completion.
         async def fetch(cursor: Optional[str]) -> Page:
-            resp = await self._c._read(lambda h: self._api.list_api_keys(_headers=h))
-            return _page(resp.items, None)
+            resp = await self._c._read(lambda h: self._api.list_api_keys(cursor=cursor, limit=limit, _headers=h))
+            return _page(resp.items, resp.next_cursor)
 
         return AutoPager(fetch)
 

--- a/sdks/python/src/e2a/v1/generated/api/account_api.py
+++ b/sdks/python/src/e2a/v1/generated/api/account_api.py
@@ -1599,6 +1599,8 @@ class AccountApi:
     @validate_call
     async def list_api_keys(
         self,
+        cursor: Annotated[Optional[StrictStr], Field(description="Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.")] = None,
+        limit: Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=1)]], Field(description="Maximum number of items to return (1-100).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1616,6 +1618,10 @@ class AccountApi:
 
         API keys for the account (metadata only — secrets are shown once, at creation). Account scope only: an agent-scoped credential cannot manage keys.
 
+        :param cursor: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+        :type cursor: str
+        :param limit: Maximum number of items to return (1-100).
+        :type limit: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1639,6 +1645,8 @@ class AccountApi:
         """ # noqa: E501
 
         _param = self._list_api_keys_serialize(
+            cursor=cursor,
+            limit=limit,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1662,6 +1670,8 @@ class AccountApi:
     @validate_call
     async def list_api_keys_with_http_info(
         self,
+        cursor: Annotated[Optional[StrictStr], Field(description="Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.")] = None,
+        limit: Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=1)]], Field(description="Maximum number of items to return (1-100).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1679,6 +1689,10 @@ class AccountApi:
 
         API keys for the account (metadata only — secrets are shown once, at creation). Account scope only: an agent-scoped credential cannot manage keys.
 
+        :param cursor: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+        :type cursor: str
+        :param limit: Maximum number of items to return (1-100).
+        :type limit: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1702,6 +1716,8 @@ class AccountApi:
         """ # noqa: E501
 
         _param = self._list_api_keys_serialize(
+            cursor=cursor,
+            limit=limit,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1725,6 +1741,8 @@ class AccountApi:
     @validate_call
     async def list_api_keys_without_preload_content(
         self,
+        cursor: Annotated[Optional[StrictStr], Field(description="Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.")] = None,
+        limit: Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=1)]], Field(description="Maximum number of items to return (1-100).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1742,6 +1760,10 @@ class AccountApi:
 
         API keys for the account (metadata only — secrets are shown once, at creation). Account scope only: an agent-scoped credential cannot manage keys.
 
+        :param cursor: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+        :type cursor: str
+        :param limit: Maximum number of items to return (1-100).
+        :type limit: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1765,6 +1787,8 @@ class AccountApi:
         """ # noqa: E501
 
         _param = self._list_api_keys_serialize(
+            cursor=cursor,
+            limit=limit,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1783,6 +1807,8 @@ class AccountApi:
 
     def _list_api_keys_serialize(
         self,
+        cursor,
+        limit,
         _request_auth,
         _content_type,
         _headers,
@@ -1805,6 +1831,14 @@ class AccountApi:
 
         # process the path parameters
         # process the query parameters
+        if cursor is not None:
+            
+            _query_params.append(('cursor', cursor))
+            
+        if limit is not None:
+            
+            _query_params.append(('limit', limit))
+            
         # process the header parameters
         # process the form parameters
         # process the body parameter

--- a/sdks/python/src/e2a/v1/generated/api/agents_api.py
+++ b/sdks/python/src/e2a/v1/generated/api/agents_api.py
@@ -1121,6 +1121,8 @@ class AgentsApi:
     @validate_call
     async def list_agents(
         self,
+        cursor: Annotated[Optional[StrictStr], Field(description="Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.")] = None,
+        limit: Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=1)]], Field(description="Maximum number of items to return (1-100).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1136,8 +1138,12 @@ class AgentsApi:
     ) -> PageAgentView:
         """List agents
 
-        List the agents owned by the authenticated account.
+        List the agents owned by the authenticated account, newest first, with cursor pagination.
 
+        :param cursor: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+        :type cursor: str
+        :param limit: Maximum number of items to return (1-100).
+        :type limit: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1161,6 +1167,8 @@ class AgentsApi:
         """ # noqa: E501
 
         _param = self._list_agents_serialize(
+            cursor=cursor,
+            limit=limit,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1184,6 +1192,8 @@ class AgentsApi:
     @validate_call
     async def list_agents_with_http_info(
         self,
+        cursor: Annotated[Optional[StrictStr], Field(description="Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.")] = None,
+        limit: Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=1)]], Field(description="Maximum number of items to return (1-100).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1199,8 +1209,12 @@ class AgentsApi:
     ) -> ApiResponse[PageAgentView]:
         """List agents
 
-        List the agents owned by the authenticated account.
+        List the agents owned by the authenticated account, newest first, with cursor pagination.
 
+        :param cursor: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+        :type cursor: str
+        :param limit: Maximum number of items to return (1-100).
+        :type limit: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1224,6 +1238,8 @@ class AgentsApi:
         """ # noqa: E501
 
         _param = self._list_agents_serialize(
+            cursor=cursor,
+            limit=limit,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1247,6 +1263,8 @@ class AgentsApi:
     @validate_call
     async def list_agents_without_preload_content(
         self,
+        cursor: Annotated[Optional[StrictStr], Field(description="Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.")] = None,
+        limit: Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=1)]], Field(description="Maximum number of items to return (1-100).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1262,8 +1280,12 @@ class AgentsApi:
     ) -> RESTResponseType:
         """List agents
 
-        List the agents owned by the authenticated account.
+        List the agents owned by the authenticated account, newest first, with cursor pagination.
 
+        :param cursor: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+        :type cursor: str
+        :param limit: Maximum number of items to return (1-100).
+        :type limit: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1287,6 +1309,8 @@ class AgentsApi:
         """ # noqa: E501
 
         _param = self._list_agents_serialize(
+            cursor=cursor,
+            limit=limit,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1305,6 +1329,8 @@ class AgentsApi:
 
     def _list_agents_serialize(
         self,
+        cursor,
+        limit,
         _request_auth,
         _content_type,
         _headers,
@@ -1327,6 +1353,14 @@ class AgentsApi:
 
         # process the path parameters
         # process the query parameters
+        if cursor is not None:
+            
+            _query_params.append(('cursor', cursor))
+            
+        if limit is not None:
+            
+            _query_params.append(('limit', limit))
+            
         # process the header parameters
         # process the form parameters
         # process the body parameter

--- a/sdks/python/src/e2a/v1/generated/api/domains_api.py
+++ b/sdks/python/src/e2a/v1/generated/api/domains_api.py
@@ -578,6 +578,8 @@ class DomainsApi:
     @validate_call
     async def list_domains(
         self,
+        cursor: Annotated[Optional[StrictStr], Field(description="Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.")] = None,
+        limit: Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=1)]], Field(description="Maximum number of items to return (1-100).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -593,7 +595,12 @@ class DomainsApi:
     ) -> PageDomainView:
         """List domains
 
+        List the domains owned by the authenticated account, newest first, with cursor pagination.
 
+        :param cursor: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+        :type cursor: str
+        :param limit: Maximum number of items to return (1-100).
+        :type limit: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -617,6 +624,8 @@ class DomainsApi:
         """ # noqa: E501
 
         _param = self._list_domains_serialize(
+            cursor=cursor,
+            limit=limit,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -640,6 +649,8 @@ class DomainsApi:
     @validate_call
     async def list_domains_with_http_info(
         self,
+        cursor: Annotated[Optional[StrictStr], Field(description="Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.")] = None,
+        limit: Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=1)]], Field(description="Maximum number of items to return (1-100).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -655,7 +666,12 @@ class DomainsApi:
     ) -> ApiResponse[PageDomainView]:
         """List domains
 
+        List the domains owned by the authenticated account, newest first, with cursor pagination.
 
+        :param cursor: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+        :type cursor: str
+        :param limit: Maximum number of items to return (1-100).
+        :type limit: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -679,6 +695,8 @@ class DomainsApi:
         """ # noqa: E501
 
         _param = self._list_domains_serialize(
+            cursor=cursor,
+            limit=limit,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -702,6 +720,8 @@ class DomainsApi:
     @validate_call
     async def list_domains_without_preload_content(
         self,
+        cursor: Annotated[Optional[StrictStr], Field(description="Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.")] = None,
+        limit: Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=1)]], Field(description="Maximum number of items to return (1-100).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -717,7 +737,12 @@ class DomainsApi:
     ) -> RESTResponseType:
         """List domains
 
+        List the domains owned by the authenticated account, newest first, with cursor pagination.
 
+        :param cursor: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+        :type cursor: str
+        :param limit: Maximum number of items to return (1-100).
+        :type limit: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -741,6 +766,8 @@ class DomainsApi:
         """ # noqa: E501
 
         _param = self._list_domains_serialize(
+            cursor=cursor,
+            limit=limit,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -759,6 +786,8 @@ class DomainsApi:
 
     def _list_domains_serialize(
         self,
+        cursor,
+        limit,
         _request_auth,
         _content_type,
         _headers,
@@ -781,6 +810,14 @@ class DomainsApi:
 
         # process the path parameters
         # process the query parameters
+        if cursor is not None:
+            
+            _query_params.append(('cursor', cursor))
+            
+        if limit is not None:
+            
+            _query_params.append(('limit', limit))
+            
         # process the header parameters
         # process the form parameters
         # process the body parameter

--- a/sdks/python/src/e2a/v1/generated/api/reviews_api.py
+++ b/sdks/python/src/e2a/v1/generated/api/reviews_api.py
@@ -16,8 +16,9 @@ from pydantic import validate_call, Field, StrictFloat, StrictStr, StrictInt
 from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 
-from pydantic import StrictStr
+from pydantic import Field, StrictStr
 from typing import Optional
+from typing_extensions import Annotated
 from e2a.v1.generated.models.approve_request import ApproveRequest
 from e2a.v1.generated.models.message_view import MessageView
 from e2a.v1.generated.models.page_review_view import PageReviewView
@@ -612,6 +613,8 @@ class ReviewsApi:
     @validate_call
     async def list_reviews(
         self,
+        cursor: Annotated[Optional[StrictStr], Field(description="Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.")] = None,
+        limit: Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=1)]], Field(description="Maximum number of items to return (1-100).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -629,6 +632,10 @@ class ReviewsApi:
 
         The review queue: every message held in pending_review across the account's inboxes — outbound drafts awaiting send approval AND inbound messages held by a screening gate. Account-scoped credentials only; agents cannot see (or resolve) holds.
 
+        :param cursor: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+        :type cursor: str
+        :param limit: Maximum number of items to return (1-100).
+        :type limit: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -652,6 +659,8 @@ class ReviewsApi:
         """ # noqa: E501
 
         _param = self._list_reviews_serialize(
+            cursor=cursor,
+            limit=limit,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -675,6 +684,8 @@ class ReviewsApi:
     @validate_call
     async def list_reviews_with_http_info(
         self,
+        cursor: Annotated[Optional[StrictStr], Field(description="Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.")] = None,
+        limit: Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=1)]], Field(description="Maximum number of items to return (1-100).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -692,6 +703,10 @@ class ReviewsApi:
 
         The review queue: every message held in pending_review across the account's inboxes — outbound drafts awaiting send approval AND inbound messages held by a screening gate. Account-scoped credentials only; agents cannot see (or resolve) holds.
 
+        :param cursor: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+        :type cursor: str
+        :param limit: Maximum number of items to return (1-100).
+        :type limit: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -715,6 +730,8 @@ class ReviewsApi:
         """ # noqa: E501
 
         _param = self._list_reviews_serialize(
+            cursor=cursor,
+            limit=limit,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -738,6 +755,8 @@ class ReviewsApi:
     @validate_call
     async def list_reviews_without_preload_content(
         self,
+        cursor: Annotated[Optional[StrictStr], Field(description="Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.")] = None,
+        limit: Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=1)]], Field(description="Maximum number of items to return (1-100).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -755,6 +774,10 @@ class ReviewsApi:
 
         The review queue: every message held in pending_review across the account's inboxes — outbound drafts awaiting send approval AND inbound messages held by a screening gate. Account-scoped credentials only; agents cannot see (or resolve) holds.
 
+        :param cursor: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+        :type cursor: str
+        :param limit: Maximum number of items to return (1-100).
+        :type limit: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -778,6 +801,8 @@ class ReviewsApi:
         """ # noqa: E501
 
         _param = self._list_reviews_serialize(
+            cursor=cursor,
+            limit=limit,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -796,6 +821,8 @@ class ReviewsApi:
 
     def _list_reviews_serialize(
         self,
+        cursor,
+        limit,
         _request_auth,
         _content_type,
         _headers,
@@ -818,6 +845,14 @@ class ReviewsApi:
 
         # process the path parameters
         # process the query parameters
+        if cursor is not None:
+            
+            _query_params.append(('cursor', cursor))
+            
+        if limit is not None:
+            
+            _query_params.append(('limit', limit))
+            
         # process the header parameters
         # process the form parameters
         # process the body parameter

--- a/sdks/python/src/e2a/v1/generated/api/templates_api.py
+++ b/sdks/python/src/e2a/v1/generated/api/templates_api.py
@@ -17,6 +17,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 
 from pydantic import Field, StrictStr
+from typing import Optional
 from typing_extensions import Annotated
 from e2a.v1.generated.models.create_template_request import CreateTemplateRequest
 from e2a.v1.generated.models.page_starter_template_view import PageStarterTemplateView
@@ -1105,6 +1106,8 @@ class TemplatesApi:
     @validate_call
     async def list_starter_templates(
         self,
+        cursor: Annotated[Optional[StrictStr], Field(description="Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.")] = None,
+        limit: Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=1)]], Field(description="Maximum number of items to return (1-100).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1122,6 +1125,10 @@ class TemplatesApi:
 
         List the pre-built starter templates shipped with the deployment, sorted by alias. Returns catalog metadata only; fetch one by alias for the full body sources, or copy one into your library with from_starter on POST /v1/templates. Beta: templates are unstable — their shape may change before they are declared stable.
 
+        :param cursor: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+        :type cursor: str
+        :param limit: Maximum number of items to return (1-100).
+        :type limit: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1145,6 +1152,8 @@ class TemplatesApi:
         """ # noqa: E501
 
         _param = self._list_starter_templates_serialize(
+            cursor=cursor,
+            limit=limit,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1168,6 +1177,8 @@ class TemplatesApi:
     @validate_call
     async def list_starter_templates_with_http_info(
         self,
+        cursor: Annotated[Optional[StrictStr], Field(description="Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.")] = None,
+        limit: Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=1)]], Field(description="Maximum number of items to return (1-100).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1185,6 +1196,10 @@ class TemplatesApi:
 
         List the pre-built starter templates shipped with the deployment, sorted by alias. Returns catalog metadata only; fetch one by alias for the full body sources, or copy one into your library with from_starter on POST /v1/templates. Beta: templates are unstable — their shape may change before they are declared stable.
 
+        :param cursor: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+        :type cursor: str
+        :param limit: Maximum number of items to return (1-100).
+        :type limit: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1208,6 +1223,8 @@ class TemplatesApi:
         """ # noqa: E501
 
         _param = self._list_starter_templates_serialize(
+            cursor=cursor,
+            limit=limit,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1231,6 +1248,8 @@ class TemplatesApi:
     @validate_call
     async def list_starter_templates_without_preload_content(
         self,
+        cursor: Annotated[Optional[StrictStr], Field(description="Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.")] = None,
+        limit: Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=1)]], Field(description="Maximum number of items to return (1-100).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1248,6 +1267,10 @@ class TemplatesApi:
 
         List the pre-built starter templates shipped with the deployment, sorted by alias. Returns catalog metadata only; fetch one by alias for the full body sources, or copy one into your library with from_starter on POST /v1/templates. Beta: templates are unstable — their shape may change before they are declared stable.
 
+        :param cursor: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+        :type cursor: str
+        :param limit: Maximum number of items to return (1-100).
+        :type limit: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1271,6 +1294,8 @@ class TemplatesApi:
         """ # noqa: E501
 
         _param = self._list_starter_templates_serialize(
+            cursor=cursor,
+            limit=limit,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1289,6 +1314,8 @@ class TemplatesApi:
 
     def _list_starter_templates_serialize(
         self,
+        cursor,
+        limit,
         _request_auth,
         _content_type,
         _headers,
@@ -1311,6 +1338,14 @@ class TemplatesApi:
 
         # process the path parameters
         # process the query parameters
+        if cursor is not None:
+            
+            _query_params.append(('cursor', cursor))
+            
+        if limit is not None:
+            
+            _query_params.append(('limit', limit))
+            
         # process the header parameters
         # process the form parameters
         # process the body parameter
@@ -1351,6 +1386,8 @@ class TemplatesApi:
     @validate_call
     async def list_templates(
         self,
+        cursor: Annotated[Optional[StrictStr], Field(description="Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.")] = None,
+        limit: Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=1)]], Field(description="Maximum number of items to return (1-100).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1368,6 +1405,10 @@ class TemplatesApi:
 
         List the account's templates, newest first. Returns metadata only (no body/html_body); fetch one by id for the full sources. Beta: templates are unstable — their shape may change before they are declared stable.
 
+        :param cursor: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+        :type cursor: str
+        :param limit: Maximum number of items to return (1-100).
+        :type limit: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1391,6 +1432,8 @@ class TemplatesApi:
         """ # noqa: E501
 
         _param = self._list_templates_serialize(
+            cursor=cursor,
+            limit=limit,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1414,6 +1457,8 @@ class TemplatesApi:
     @validate_call
     async def list_templates_with_http_info(
         self,
+        cursor: Annotated[Optional[StrictStr], Field(description="Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.")] = None,
+        limit: Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=1)]], Field(description="Maximum number of items to return (1-100).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1431,6 +1476,10 @@ class TemplatesApi:
 
         List the account's templates, newest first. Returns metadata only (no body/html_body); fetch one by id for the full sources. Beta: templates are unstable — their shape may change before they are declared stable.
 
+        :param cursor: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+        :type cursor: str
+        :param limit: Maximum number of items to return (1-100).
+        :type limit: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1454,6 +1503,8 @@ class TemplatesApi:
         """ # noqa: E501
 
         _param = self._list_templates_serialize(
+            cursor=cursor,
+            limit=limit,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1477,6 +1528,8 @@ class TemplatesApi:
     @validate_call
     async def list_templates_without_preload_content(
         self,
+        cursor: Annotated[Optional[StrictStr], Field(description="Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.")] = None,
+        limit: Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=1)]], Field(description="Maximum number of items to return (1-100).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1494,6 +1547,10 @@ class TemplatesApi:
 
         List the account's templates, newest first. Returns metadata only (no body/html_body); fetch one by id for the full sources. Beta: templates are unstable — their shape may change before they are declared stable.
 
+        :param cursor: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+        :type cursor: str
+        :param limit: Maximum number of items to return (1-100).
+        :type limit: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1517,6 +1574,8 @@ class TemplatesApi:
         """ # noqa: E501
 
         _param = self._list_templates_serialize(
+            cursor=cursor,
+            limit=limit,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1535,6 +1594,8 @@ class TemplatesApi:
 
     def _list_templates_serialize(
         self,
+        cursor,
+        limit,
         _request_auth,
         _content_type,
         _headers,
@@ -1557,6 +1618,14 @@ class TemplatesApi:
 
         # process the path parameters
         # process the query parameters
+        if cursor is not None:
+            
+            _query_params.append(('cursor', cursor))
+            
+        if limit is not None:
+            
+            _query_params.append(('limit', limit))
+            
         # process the header parameters
         # process the form parameters
         # process the body parameter

--- a/sdks/python/src/e2a/v1/generated/api/webhooks_api.py
+++ b/sdks/python/src/e2a/v1/generated/api/webhooks_api.py
@@ -839,6 +839,7 @@ class WebhooksApi:
         self,
         id: StrictStr,
         status: Optional[StrictStr] = None,
+        cursor: Annotated[Optional[StrictStr], Field(description="Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the status filter.")] = None,
         limit: Optional[Annotated[int, Field(le=500, strict=True, ge=1)]] = None,
         _request_timeout: Union[
             None,
@@ -861,6 +862,8 @@ class WebhooksApi:
         :type id: str
         :param status:
         :type status: str
+        :param cursor: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the status filter.
+        :type cursor: str
         :param limit:
         :type limit: int
         :param _request_timeout: timeout setting for this request. If one
@@ -888,6 +891,7 @@ class WebhooksApi:
         _param = self._list_webhook_deliveries_serialize(
             id=id,
             status=status,
+            cursor=cursor,
             limit=limit,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -914,6 +918,7 @@ class WebhooksApi:
         self,
         id: StrictStr,
         status: Optional[StrictStr] = None,
+        cursor: Annotated[Optional[StrictStr], Field(description="Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the status filter.")] = None,
         limit: Optional[Annotated[int, Field(le=500, strict=True, ge=1)]] = None,
         _request_timeout: Union[
             None,
@@ -936,6 +941,8 @@ class WebhooksApi:
         :type id: str
         :param status:
         :type status: str
+        :param cursor: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the status filter.
+        :type cursor: str
         :param limit:
         :type limit: int
         :param _request_timeout: timeout setting for this request. If one
@@ -963,6 +970,7 @@ class WebhooksApi:
         _param = self._list_webhook_deliveries_serialize(
             id=id,
             status=status,
+            cursor=cursor,
             limit=limit,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -989,6 +997,7 @@ class WebhooksApi:
         self,
         id: StrictStr,
         status: Optional[StrictStr] = None,
+        cursor: Annotated[Optional[StrictStr], Field(description="Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the status filter.")] = None,
         limit: Optional[Annotated[int, Field(le=500, strict=True, ge=1)]] = None,
         _request_timeout: Union[
             None,
@@ -1011,6 +1020,8 @@ class WebhooksApi:
         :type id: str
         :param status:
         :type status: str
+        :param cursor: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the status filter.
+        :type cursor: str
         :param limit:
         :type limit: int
         :param _request_timeout: timeout setting for this request. If one
@@ -1038,6 +1049,7 @@ class WebhooksApi:
         _param = self._list_webhook_deliveries_serialize(
             id=id,
             status=status,
+            cursor=cursor,
             limit=limit,
             _request_auth=_request_auth,
             _content_type=_content_type,
@@ -1059,6 +1071,7 @@ class WebhooksApi:
         self,
         id,
         status,
+        cursor,
         limit,
         _request_auth,
         _content_type,
@@ -1087,6 +1100,10 @@ class WebhooksApi:
         if status is not None:
             
             _query_params.append(('status', status))
+            
+        if cursor is not None:
+            
+            _query_params.append(('cursor', cursor))
             
         if limit is not None:
             
@@ -1132,6 +1149,8 @@ class WebhooksApi:
     @validate_call
     async def list_webhooks(
         self,
+        cursor: Annotated[Optional[StrictStr], Field(description="Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.")] = None,
+        limit: Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=1)]], Field(description="Maximum number of items to return (1-100).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1147,7 +1166,12 @@ class WebhooksApi:
     ) -> PageWebhookView:
         """List webhooks
 
+        List the webhooks owned by the authenticated account, newest first, with cursor pagination.
 
+        :param cursor: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+        :type cursor: str
+        :param limit: Maximum number of items to return (1-100).
+        :type limit: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1171,6 +1195,8 @@ class WebhooksApi:
         """ # noqa: E501
 
         _param = self._list_webhooks_serialize(
+            cursor=cursor,
+            limit=limit,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1194,6 +1220,8 @@ class WebhooksApi:
     @validate_call
     async def list_webhooks_with_http_info(
         self,
+        cursor: Annotated[Optional[StrictStr], Field(description="Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.")] = None,
+        limit: Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=1)]], Field(description="Maximum number of items to return (1-100).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1209,7 +1237,12 @@ class WebhooksApi:
     ) -> ApiResponse[PageWebhookView]:
         """List webhooks
 
+        List the webhooks owned by the authenticated account, newest first, with cursor pagination.
 
+        :param cursor: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+        :type cursor: str
+        :param limit: Maximum number of items to return (1-100).
+        :type limit: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1233,6 +1266,8 @@ class WebhooksApi:
         """ # noqa: E501
 
         _param = self._list_webhooks_serialize(
+            cursor=cursor,
+            limit=limit,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1256,6 +1291,8 @@ class WebhooksApi:
     @validate_call
     async def list_webhooks_without_preload_content(
         self,
+        cursor: Annotated[Optional[StrictStr], Field(description="Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.")] = None,
+        limit: Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=1)]], Field(description="Maximum number of items to return (1-100).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1271,7 +1308,12 @@ class WebhooksApi:
     ) -> RESTResponseType:
         """List webhooks
 
+        List the webhooks owned by the authenticated account, newest first, with cursor pagination.
 
+        :param cursor: Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.
+        :type cursor: str
+        :param limit: Maximum number of items to return (1-100).
+        :type limit: int
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -1295,6 +1337,8 @@ class WebhooksApi:
         """ # noqa: E501
 
         _param = self._list_webhooks_serialize(
+            cursor=cursor,
+            limit=limit,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -1313,6 +1357,8 @@ class WebhooksApi:
 
     def _list_webhooks_serialize(
         self,
+        cursor,
+        limit,
         _request_auth,
         _content_type,
         _headers,
@@ -1335,6 +1381,14 @@ class WebhooksApi:
 
         # process the path parameters
         # process the query parameters
+        if cursor is not None:
+            
+            _query_params.append(('cursor', cursor))
+            
+        if limit is not None:
+            
+            _query_params.append(('limit', limit))
+            
         # process the header parameters
         # process the form parameters
         # process the body parameter

--- a/sdks/python/tests/test_v1_client.py
+++ b/sdks/python/tests/test_v1_client.py
@@ -21,6 +21,7 @@ from e2a.v1.errors import (
 from e2a.v1.webhook_signature import WebhookEvent
 from e2a.v1.generated.models import (
     AgentView,
+    APIKeyView,
     AttachmentView,
     ConversationSummaryView,
     DomainView,
@@ -412,43 +413,59 @@ async def test_suppressions_list_threads_cursor(httpx_mock):
     assert "cursor=cur_2" in str(reqs[1].url)
 
 
-# ── pagination: cursorless (single-page) endpoints ──────────────────
-# agents/domains/webhooks/deliveries have NO cursor query param. Even if the
-# server hands back a non-null next_cursor, the pager must stop after exactly one
-# page: it can't forward a cursor, and following it would re-fetch page 1 and
-# trip the AutoPager cycle guard. This locks the intentional cursor-drop so a
-# future "fix" that surfaces next_cursor (without a cursor param) is caught.
+# ── pagination: keyset-cursor list endpoints ────────────────────────
+# agents/domains/webhooks/deliveries/api-keys are all keyset-paginated on
+# (created_at, id) now — the AutoPager must thread next_cursor to completion,
+# exactly like messages/events/suppressions. This locks in the
+# consistent-pagination contract (no more silent single-page cap).
 
 
 @pytest.mark.anyio
 @pytest.mark.parametrize(
-    "fixture, lister",
+    "page1, page2, lister, key",
     [
         (
-            {"items": [_valid(AgentView, id="ag_1", email="bot@test.dev")], "next_cursor": "IGNORE_ME"},
+            {"items": [_valid(AgentView, id="ag_1", email="a@test.dev")], "next_cursor": "cur_2"},
+            {"items": [_valid(AgentView, id="ag_2", email="b@test.dev")], "next_cursor": None},
             lambda c: c.agents.list(),
+            lambda r: r.id,
         ),
         (
-            {"items": [_valid(DomainView, domain="test.dev")], "next_cursor": "IGNORE_ME"},
+            {"items": [_valid(DomainView, domain="a.dev")], "next_cursor": "cur_2"},
+            {"items": [_valid(DomainView, domain="b.dev")], "next_cursor": None},
             lambda c: c.domains.list(),
+            lambda r: r.domain,
         ),
         (
-            {"items": [_valid(WebhookView, id="wh_1")], "next_cursor": "IGNORE_ME"},
+            {"items": [_valid(WebhookView, id="wh_1")], "next_cursor": "cur_2"},
+            {"items": [_valid(WebhookView, id="wh_2")], "next_cursor": None},
             lambda c: c.webhooks.list(),
+            lambda r: r.id,
         ),
         (
-            {"items": [_valid(WebhookDeliveryView, id="del_1")], "next_cursor": "IGNORE_ME"},
+            {"items": [_valid(WebhookDeliveryView, id="del_1")], "next_cursor": "cur_2"},
+            {"items": [_valid(WebhookDeliveryView, id="del_2")], "next_cursor": None},
             lambda c: c.webhooks.deliveries("wh_1"),
+            lambda r: r.id,
+        ),
+        (
+            {"items": [_valid(APIKeyView, id="key_1")], "next_cursor": "cur_2"},
+            {"items": [_valid(APIKeyView, id="key_2")], "next_cursor": None},
+            lambda c: c.account.api_keys.list(),
+            lambda r: r.id,
         ),
     ],
-    ids=["agents", "domains", "webhooks", "deliveries"],
+    ids=["agents", "domains", "webhooks", "deliveries", "api_keys"],
 )
-async def test_cursorless_lists_stop_after_one_page(httpx_mock, fixture, lister):
-    httpx_mock.add_response(json=fixture)
+async def test_keyset_lists_thread_cursor(httpx_mock, page1, page2, lister, key):
+    httpx_mock.add_response(json=page1)
+    httpx_mock.add_response(json=page2)
     async with _client() as c:
         items = await lister(c).to_list(limit=100)
-    assert len(items) == 1
-    assert len(httpx_mock.get_requests()) == 1
+    assert len(items) == 2
+    reqs = httpx_mock.get_requests()
+    assert len(reqs) == 2
+    assert "cursor=cur_2" in str(reqs[1].url)
 
 
 # ── error mapping ───────────────────────────────────────────────────

--- a/sdks/typescript/src/v1/client.ts
+++ b/sdks/typescript/src/v1/client.ts
@@ -199,11 +199,12 @@ export class E2AClient {
 
 class AgentsResource {
   constructor(private readonly api: PromiseAgentsApi) {}
-  list(): AutoPager<AgentView> {
-    // No cursor param: omit next_cursor so the pager stops after one page — it
-    // can't forward a cursor, and surfacing one would re-fetch page 1 and trip
-    // the cycle guard. Single-page at GA; see webhooks.deliveries.
-    return new AutoPager(async () => ({ items: (await call(() => this.api.listAgents())).items ?? [] }));
+  list(params: { limit?: number } = {}): AutoPager<AgentView> {
+    // Cursor-paginated: the AutoPager walks next_cursor to completion.
+    return new AutoPager(async (cursor) => {
+      const page = await call(() => this.api.listAgents(cursor, params.limit));
+      return { items: page.items ?? [], next_cursor: page.nextCursor };
+    });
   }
   get(email: string): Promise<AgentView> {
     return call(() => this.api.getAgent(email));
@@ -306,9 +307,12 @@ class MessagesResource {
 class ReviewsResource {
   constructor(private readonly api: PromiseReviewsApi) {}
   /** List every held message across the account's inboxes. */
-  list(): AutoPager<ReviewView> {
-    // No cursor param: single-page at GA — see AgentsResource.list / domains.
-    return new AutoPager(async () => ({ items: (await call(() => this.api.listReviews())).items ?? [] }));
+  list(params: { limit?: number } = {}): AutoPager<ReviewView> {
+    // Cursor-paginated: the AutoPager walks next_cursor to completion.
+    return new AutoPager(async (cursor) => {
+      const page = await call(() => this.api.listReviews(cursor, params.limit));
+      return { items: page.items ?? [], next_cursor: page.nextCursor };
+    });
   }
   /** Full detail of one held message (body + recipients + screening context). */
   get(id: string): Promise<MessageView> {
@@ -333,9 +337,12 @@ class TemplatesResource {
   constructor(private readonly api: PromiseTemplatesApi) {}
   /** List the account's stored templates, newest first. Summary rows only (no
    *  body/html_body sources) — `get(id)` returns the full sources. */
-  list(): AutoPager<TemplateSummaryView> {
-    // No cursor param: single-page at GA — see AgentsResource.list / domains.
-    return new AutoPager(async () => ({ items: (await call(() => this.api.listTemplates())).items ?? [] }));
+  list(params: { limit?: number } = {}): AutoPager<TemplateSummaryView> {
+    // Cursor-paginated: the AutoPager walks next_cursor to completion.
+    return new AutoPager(async (cursor) => {
+      const page = await call(() => this.api.listTemplates(cursor, params.limit));
+      return { items: page.items ?? [], next_cursor: page.nextCursor };
+    });
   }
   /** Fetch one stored template by id (tmpl_…), including its sources. */
   get(id: string): Promise<TemplateView> {
@@ -364,9 +371,12 @@ class TemplatesResource {
   }
   /** List the pre-built starter templates shipped with the deployment (catalog
    *  metadata + variables; `getStarter(alias)` adds the full body sources). */
-  listStarters(): AutoPager<StarterTemplateView> {
-    // No cursor param: single-page at GA — see AgentsResource.list / domains.
-    return new AutoPager(async () => ({ items: (await call(() => this.api.listStarterTemplates())).items ?? [] }));
+  listStarters(params: { limit?: number } = {}): AutoPager<StarterTemplateView> {
+    // Cursor-paginated: the AutoPager walks next_cursor to completion.
+    return new AutoPager(async (cursor) => {
+      const page = await call(() => this.api.listStarterTemplates(cursor, params.limit));
+      return { items: page.items ?? [], next_cursor: page.nextCursor };
+    });
   }
   /** Fetch one starter by alias, including its full body sources. Starters are
    *  read-only masters — copy one with `create({ fromStarter: alias })`. */
@@ -392,9 +402,12 @@ class ConversationsResource {
 
 class DomainsResource {
   constructor(private readonly api: PromiseDomainsApi) {}
-  list(): AutoPager<DomainView> {
-    // No cursor param: single-page at GA — see AgentsResource.list / deliveries.
-    return new AutoPager(async () => ({ items: (await call(() => this.api.listDomains())).items ?? [] }));
+  list(params: { limit?: number } = {}): AutoPager<DomainView> {
+    // Cursor-paginated: the AutoPager walks next_cursor to completion.
+    return new AutoPager(async (cursor) => {
+      const page = await call(() => this.api.listDomains(cursor, params.limit));
+      return { items: page.items ?? [], next_cursor: page.nextCursor };
+    });
   }
   get(domain: string): Promise<DomainView> {
     return call(() => this.api.getDomain(domain));
@@ -462,9 +475,12 @@ class WebhooksResource {
     return this.messages.get(d.recipient, d.message_id);
   }
 
-  list(): AutoPager<WebhookView> {
-    // No cursor param: single-page at GA — see AgentsResource.list / deliveries.
-    return new AutoPager(async () => ({ items: (await call(() => this.api.listWebhooks())).items ?? [] }));
+  list(params: { limit?: number } = {}): AutoPager<WebhookView> {
+    // Cursor-paginated: the AutoPager walks next_cursor to completion.
+    return new AutoPager(async (cursor) => {
+      const page = await call(() => this.api.listWebhooks(cursor, params.limit));
+      return { items: page.items ?? [], next_cursor: page.nextCursor };
+    });
   }
   get(id: string): Promise<WebhookView> {
     return call(() => this.api.getWebhook(id));
@@ -485,12 +501,12 @@ class WebhooksResource {
     return call(() => this.api.testWebhook(id, body));
   }
   deliveries(id: string, params: { status?: "pending" | "delivered" | "failed"; limit?: number } = {}): AutoPager<WebhookDeliveryView> {
+    // Cursor-paginated: the AutoPager walks next_cursor to completion. The status
+    // filter is pinned into the cursor server-side (a continuation must not
+    // change it), which the AutoPager honors by keeping status constant.
     return new AutoPager(async (cursor) => {
-      void cursor; // listWebhookDeliveries has no cursor param — single page by contract.
-      const page = await call(() => this.api.listWebhookDeliveries(id, params.status, params.limit));
-      // Drop next_cursor: we can't pass it back (no cursor param), so surfacing
-      // it would make the pager re-fetch the same page and trip the cycle guard.
-      return { items: page.items ?? [], next_cursor: undefined };
+      const page = await call(() => this.api.listWebhookDeliveries(id, params.status, cursor, params.limit));
+      return { items: page.items ?? [], next_cursor: page.nextCursor };
     });
   }
 }
@@ -510,11 +526,11 @@ class SuppressionsResource {
 
 class APIKeysResource {
   constructor(private readonly api: PromiseAccountApi) {}
-  list(): AutoPager<APIKeyView> {
+  list(params: { limit?: number } = {}): AutoPager<APIKeyView> {
+    // Cursor-paginated: the AutoPager walks next_cursor to completion.
     return new AutoPager(async (cursor) => {
-      void cursor; // listApiKeys has no cursor param — single page by contract.
-      const page = await call(() => this.api.listApiKeys());
-      return { items: page.items ?? [], next_cursor: undefined };
+      const page = await call(() => this.api.listApiKeys(cursor, params.limit));
+      return { items: page.items ?? [], next_cursor: page.nextCursor };
     });
   }
   // create returns the one-time plaintext key in `.key` — store it now.

--- a/sdks/typescript/src/v1/generated/apis/AccountApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/AccountApi.ts
@@ -246,9 +246,13 @@ export class AccountApiRequestFactory extends BaseAPIRequestFactory {
     /**
      * API keys for the account (metadata only — secrets are shown once, at creation). Account scope only: an agent-scoped credential cannot manage keys.
      * List API keys
+     * @param cursor Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param limit Maximum number of items to return (1-100).
      */
-    public async listApiKeys(_options?: Configuration): Promise<RequestContext> {
+    public async listApiKeys(cursor?: string, limit?: number, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
+
+
 
         // Path Params
         const localVarPath = '/v1/account/api-keys';
@@ -256,6 +260,16 @@ export class AccountApiRequestFactory extends BaseAPIRequestFactory {
         // Make Request Context
         const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
+
+        // Query Params
+        if (cursor !== undefined) {
+            requestContext.setQueryParam("cursor", ObjectSerializer.serialize(cursor, "string", ""));
+        }
+
+        // Query Params
+        if (limit !== undefined) {
+            requestContext.setQueryParam("limit", ObjectSerializer.serialize(limit, "number", "int64"));
+        }
 
 
         let authMethod: SecurityAuthentication | undefined;

--- a/sdks/typescript/src/v1/generated/apis/AgentsApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/AgentsApi.ts
@@ -191,11 +191,15 @@ export class AgentsApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
-     * List the agents owned by the authenticated account.
+     * List the agents owned by the authenticated account, newest first, with cursor pagination.
      * List agents
+     * @param cursor Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param limit Maximum number of items to return (1-100).
      */
-    public async listAgents(_options?: Configuration): Promise<RequestContext> {
+    public async listAgents(cursor?: string, limit?: number, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
+
+
 
         // Path Params
         const localVarPath = '/v1/agents';
@@ -203,6 +207,16 @@ export class AgentsApiRequestFactory extends BaseAPIRequestFactory {
         // Make Request Context
         const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
+
+        // Query Params
+        if (cursor !== undefined) {
+            requestContext.setQueryParam("cursor", ObjectSerializer.serialize(cursor, "string", ""));
+        }
+
+        // Query Params
+        if (limit !== undefined) {
+            requestContext.setQueryParam("limit", ObjectSerializer.serialize(limit, "number", "int64"));
+        }
 
 
         let authMethod: SecurityAuthentication | undefined;

--- a/sdks/typescript/src/v1/generated/apis/DomainsApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/DomainsApi.ts
@@ -101,10 +101,15 @@ export class DomainsApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
+     * List the domains owned by the authenticated account, newest first, with cursor pagination.
      * List domains
+     * @param cursor Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param limit Maximum number of items to return (1-100).
      */
-    public async listDomains(_options?: Configuration): Promise<RequestContext> {
+    public async listDomains(cursor?: string, limit?: number, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
+
+
 
         // Path Params
         const localVarPath = '/v1/domains';
@@ -112,6 +117,16 @@ export class DomainsApiRequestFactory extends BaseAPIRequestFactory {
         // Make Request Context
         const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
+
+        // Query Params
+        if (cursor !== undefined) {
+            requestContext.setQueryParam("cursor", ObjectSerializer.serialize(cursor, "string", ""));
+        }
+
+        // Query Params
+        if (limit !== undefined) {
+            requestContext.setQueryParam("limit", ObjectSerializer.serialize(limit, "number", "int64"));
+        }
 
 
         let authMethod: SecurityAuthentication | undefined;

--- a/sdks/typescript/src/v1/generated/apis/ReviewsApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/ReviewsApi.ts
@@ -125,9 +125,13 @@ export class ReviewsApiRequestFactory extends BaseAPIRequestFactory {
     /**
      * The review queue: every message held in pending_review across the account\'s inboxes — outbound drafts awaiting send approval AND inbound messages held by a screening gate. Account-scoped credentials only; agents cannot see (or resolve) holds.
      * List messages awaiting review
+     * @param cursor Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param limit Maximum number of items to return (1-100).
      */
-    public async listReviews(_options?: Configuration): Promise<RequestContext> {
+    public async listReviews(cursor?: string, limit?: number, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
+
+
 
         // Path Params
         const localVarPath = '/v1/reviews';
@@ -135,6 +139,16 @@ export class ReviewsApiRequestFactory extends BaseAPIRequestFactory {
         // Make Request Context
         const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
+
+        // Query Params
+        if (cursor !== undefined) {
+            requestContext.setQueryParam("cursor", ObjectSerializer.serialize(cursor, "string", ""));
+        }
+
+        // Query Params
+        if (limit !== undefined) {
+            requestContext.setQueryParam("limit", ObjectSerializer.serialize(limit, "number", "int64"));
+        }
 
 
         let authMethod: SecurityAuthentication | undefined;

--- a/sdks/typescript/src/v1/generated/apis/TemplatesApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/TemplatesApi.ts
@@ -188,9 +188,13 @@ export class TemplatesApiRequestFactory extends BaseAPIRequestFactory {
     /**
      * List the pre-built starter templates shipped with the deployment, sorted by alias. Returns catalog metadata only; fetch one by alias for the full body sources, or copy one into your library with from_starter on POST /v1/templates. Beta: templates are unstable — their shape may change before they are declared stable.
      * List starter templates (beta)
+     * @param cursor Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param limit Maximum number of items to return (1-100).
      */
-    public async listStarterTemplates(_options?: Configuration): Promise<RequestContext> {
+    public async listStarterTemplates(cursor?: string, limit?: number, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
+
+
 
         // Path Params
         const localVarPath = '/v1/starter-templates';
@@ -198,6 +202,16 @@ export class TemplatesApiRequestFactory extends BaseAPIRequestFactory {
         // Make Request Context
         const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
+
+        // Query Params
+        if (cursor !== undefined) {
+            requestContext.setQueryParam("cursor", ObjectSerializer.serialize(cursor, "string", ""));
+        }
+
+        // Query Params
+        if (limit !== undefined) {
+            requestContext.setQueryParam("limit", ObjectSerializer.serialize(limit, "number", "int64"));
+        }
 
 
         let authMethod: SecurityAuthentication | undefined;
@@ -218,9 +232,13 @@ export class TemplatesApiRequestFactory extends BaseAPIRequestFactory {
     /**
      * List the account\'s templates, newest first. Returns metadata only (no body/html_body); fetch one by id for the full sources. Beta: templates are unstable — their shape may change before they are declared stable.
      * List templates (beta)
+     * @param cursor Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param limit Maximum number of items to return (1-100).
      */
-    public async listTemplates(_options?: Configuration): Promise<RequestContext> {
+    public async listTemplates(cursor?: string, limit?: number, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
+
+
 
         // Path Params
         const localVarPath = '/v1/templates';
@@ -228,6 +246,16 @@ export class TemplatesApiRequestFactory extends BaseAPIRequestFactory {
         // Make Request Context
         const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
+
+        // Query Params
+        if (cursor !== undefined) {
+            requestContext.setQueryParam("cursor", ObjectSerializer.serialize(cursor, "string", ""));
+        }
+
+        // Query Params
+        if (limit !== undefined) {
+            requestContext.setQueryParam("limit", ObjectSerializer.serialize(limit, "number", "int64"));
+        }
 
 
         let authMethod: SecurityAuthentication | undefined;

--- a/sdks/typescript/src/v1/generated/apis/WebhooksApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/WebhooksApi.ts
@@ -150,15 +150,17 @@ export class WebhooksApiRequestFactory extends BaseAPIRequestFactory {
      * List webhook deliveries
      * @param id 
      * @param status 
+     * @param cursor Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the status filter.
      * @param limit 
      */
-    public async listWebhookDeliveries(id: string, status?: 'pending' | 'delivered' | 'failed', limit?: number, _options?: Configuration): Promise<RequestContext> {
+    public async listWebhookDeliveries(id: string, status?: 'pending' | 'delivered' | 'failed', cursor?: string, limit?: number, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
 
         // verify required parameter 'id' is not null or undefined
         if (id === null || id === undefined) {
             throw new RequiredError("WebhooksApi", "listWebhookDeliveries", "id");
         }
+
 
 
 
@@ -174,6 +176,11 @@ export class WebhooksApiRequestFactory extends BaseAPIRequestFactory {
         // Query Params
         if (status !== undefined) {
             requestContext.setQueryParam("status", ObjectSerializer.serialize(status, "'pending' | 'delivered' | 'failed'", ""));
+        }
+
+        // Query Params
+        if (cursor !== undefined) {
+            requestContext.setQueryParam("cursor", ObjectSerializer.serialize(cursor, "string", ""));
         }
 
         // Query Params
@@ -198,10 +205,15 @@ export class WebhooksApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
+     * List the webhooks owned by the authenticated account, newest first, with cursor pagination.
      * List webhooks
+     * @param cursor Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param limit Maximum number of items to return (1-100).
      */
-    public async listWebhooks(_options?: Configuration): Promise<RequestContext> {
+    public async listWebhooks(cursor?: string, limit?: number, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
+
+
 
         // Path Params
         const localVarPath = '/v1/webhooks';
@@ -209,6 +221,16 @@ export class WebhooksApiRequestFactory extends BaseAPIRequestFactory {
         // Make Request Context
         const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.GET);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
+
+        // Query Params
+        if (cursor !== undefined) {
+            requestContext.setQueryParam("cursor", ObjectSerializer.serialize(cursor, "string", ""));
+        }
+
+        // Query Params
+        if (limit !== undefined) {
+            requestContext.setQueryParam("limit", ObjectSerializer.serialize(limit, "number", "int64"));
+        }
 
 
         let authMethod: SecurityAuthentication | undefined;

--- a/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
@@ -145,6 +145,22 @@ export interface AccountApiGetAccountRequest {
 }
 
 export interface AccountApiListApiKeysRequest {
+    /**
+     * Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * Defaults to: undefined
+     * @type string
+     * @memberof AccountApilistApiKeys
+     */
+    cursor?: string
+    /**
+     * Maximum number of items to return (1-100).
+     * Minimum: 1
+     * Maximum: 100
+     * Defaults to: 50
+     * @type number
+     * @memberof AccountApilistApiKeys
+     */
+    limit?: number
 }
 
 export interface AccountApiListSuppressionsRequest {
@@ -287,7 +303,7 @@ export class ObjectAccountApi {
      * @param param the request object
      */
     public listApiKeysWithHttpInfo(param: AccountApiListApiKeysRequest = {}, options?: ConfigurationOptions): Promise<HttpInfo<PageAPIKeyView>> {
-        return this.api.listApiKeysWithHttpInfo( options).toPromise();
+        return this.api.listApiKeysWithHttpInfo(param.cursor, param.limit,  options).toPromise();
     }
 
     /**
@@ -296,7 +312,7 @@ export class ObjectAccountApi {
      * @param param the request object
      */
     public listApiKeys(param: AccountApiListApiKeysRequest = {}, options?: ConfigurationOptions): Promise<PageAPIKeyView> {
-        return this.api.listApiKeys( options).toPromise();
+        return this.api.listApiKeys(param.cursor, param.limit,  options).toPromise();
     }
 
     /**
@@ -369,6 +385,22 @@ export interface AgentsApiGetAgentProtectionRequest {
 }
 
 export interface AgentsApiListAgentsRequest {
+    /**
+     * Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * Defaults to: undefined
+     * @type string
+     * @memberof AgentsApilistAgents
+     */
+    cursor?: string
+    /**
+     * Maximum number of items to return (1-100).
+     * Minimum: 1
+     * Maximum: 100
+     * Defaults to: 50
+     * @type number
+     * @memberof AgentsApilistAgents
+     */
+    limit?: number
 }
 
 export interface AgentsApiPutAgentProtectionRequest {
@@ -493,21 +525,21 @@ export class ObjectAgentsApi {
     }
 
     /**
-     * List the agents owned by the authenticated account.
+     * List the agents owned by the authenticated account, newest first, with cursor pagination.
      * List agents
      * @param param the request object
      */
     public listAgentsWithHttpInfo(param: AgentsApiListAgentsRequest = {}, options?: ConfigurationOptions): Promise<HttpInfo<PageAgentView>> {
-        return this.api.listAgentsWithHttpInfo( options).toPromise();
+        return this.api.listAgentsWithHttpInfo(param.cursor, param.limit,  options).toPromise();
     }
 
     /**
-     * List the agents owned by the authenticated account.
+     * List the agents owned by the authenticated account, newest first, with cursor pagination.
      * List agents
      * @param param the request object
      */
     public listAgents(param: AgentsApiListAgentsRequest = {}, options?: ConfigurationOptions): Promise<PageAgentView> {
-        return this.api.listAgents( options).toPromise();
+        return this.api.listAgents(param.cursor, param.limit,  options).toPromise();
     }
 
     /**
@@ -702,6 +734,22 @@ export interface DomainsApiGetDomainRequest {
 }
 
 export interface DomainsApiListDomainsRequest {
+    /**
+     * Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * Defaults to: undefined
+     * @type string
+     * @memberof DomainsApilistDomains
+     */
+    cursor?: string
+    /**
+     * Maximum number of items to return (1-100).
+     * Minimum: 1
+     * Maximum: 100
+     * Defaults to: 50
+     * @type number
+     * @memberof DomainsApilistDomains
+     */
+    limit?: number
 }
 
 export interface DomainsApiRegisterDomainRequest {
@@ -763,19 +811,21 @@ export class ObjectDomainsApi {
     }
 
     /**
+     * List the domains owned by the authenticated account, newest first, with cursor pagination.
      * List domains
      * @param param the request object
      */
     public listDomainsWithHttpInfo(param: DomainsApiListDomainsRequest = {}, options?: ConfigurationOptions): Promise<HttpInfo<PageDomainView>> {
-        return this.api.listDomainsWithHttpInfo( options).toPromise();
+        return this.api.listDomainsWithHttpInfo(param.cursor, param.limit,  options).toPromise();
     }
 
     /**
+     * List the domains owned by the authenticated account, newest first, with cursor pagination.
      * List domains
      * @param param the request object
      */
     public listDomains(param: DomainsApiListDomainsRequest = {}, options?: ConfigurationOptions): Promise<PageDomainView> {
-        return this.api.listDomains( options).toPromise();
+        return this.api.listDomains(param.cursor, param.limit,  options).toPromise();
     }
 
     /**
@@ -1527,6 +1577,22 @@ export interface ReviewsApiGetReviewRequest {
 }
 
 export interface ReviewsApiListReviewsRequest {
+    /**
+     * Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * Defaults to: undefined
+     * @type string
+     * @memberof ReviewsApilistReviews
+     */
+    cursor?: string
+    /**
+     * Maximum number of items to return (1-100).
+     * Minimum: 1
+     * Maximum: 100
+     * Defaults to: 50
+     * @type number
+     * @memberof ReviewsApilistReviews
+     */
+    limit?: number
 }
 
 export interface ReviewsApiRejectReviewRequest {
@@ -1594,7 +1660,7 @@ export class ObjectReviewsApi {
      * @param param the request object
      */
     public listReviewsWithHttpInfo(param: ReviewsApiListReviewsRequest = {}, options?: ConfigurationOptions): Promise<HttpInfo<PageReviewView>> {
-        return this.api.listReviewsWithHttpInfo( options).toPromise();
+        return this.api.listReviewsWithHttpInfo(param.cursor, param.limit,  options).toPromise();
     }
 
     /**
@@ -1603,7 +1669,7 @@ export class ObjectReviewsApi {
      * @param param the request object
      */
     public listReviews(param: ReviewsApiListReviewsRequest = {}, options?: ConfigurationOptions): Promise<PageReviewView> {
-        return this.api.listReviews( options).toPromise();
+        return this.api.listReviews(param.cursor, param.limit,  options).toPromise();
     }
 
     /**
@@ -1669,9 +1735,41 @@ export interface TemplatesApiGetTemplateRequest {
 }
 
 export interface TemplatesApiListStarterTemplatesRequest {
+    /**
+     * Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * Defaults to: undefined
+     * @type string
+     * @memberof TemplatesApilistStarterTemplates
+     */
+    cursor?: string
+    /**
+     * Maximum number of items to return (1-100).
+     * Minimum: 1
+     * Maximum: 100
+     * Defaults to: 50
+     * @type number
+     * @memberof TemplatesApilistStarterTemplates
+     */
+    limit?: number
 }
 
 export interface TemplatesApiListTemplatesRequest {
+    /**
+     * Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * Defaults to: undefined
+     * @type string
+     * @memberof TemplatesApilistTemplates
+     */
+    cursor?: string
+    /**
+     * Maximum number of items to return (1-100).
+     * Minimum: 1
+     * Maximum: 100
+     * Defaults to: 50
+     * @type number
+     * @memberof TemplatesApilistTemplates
+     */
+    limit?: number
 }
 
 export interface TemplatesApiUpdateTemplateRequest {
@@ -1784,7 +1882,7 @@ export class ObjectTemplatesApi {
      * @param param the request object
      */
     public listStarterTemplatesWithHttpInfo(param: TemplatesApiListStarterTemplatesRequest = {}, options?: ConfigurationOptions): Promise<HttpInfo<PageStarterTemplateView>> {
-        return this.api.listStarterTemplatesWithHttpInfo( options).toPromise();
+        return this.api.listStarterTemplatesWithHttpInfo(param.cursor, param.limit,  options).toPromise();
     }
 
     /**
@@ -1793,7 +1891,7 @@ export class ObjectTemplatesApi {
      * @param param the request object
      */
     public listStarterTemplates(param: TemplatesApiListStarterTemplatesRequest = {}, options?: ConfigurationOptions): Promise<PageStarterTemplateView> {
-        return this.api.listStarterTemplates( options).toPromise();
+        return this.api.listStarterTemplates(param.cursor, param.limit,  options).toPromise();
     }
 
     /**
@@ -1802,7 +1900,7 @@ export class ObjectTemplatesApi {
      * @param param the request object
      */
     public listTemplatesWithHttpInfo(param: TemplatesApiListTemplatesRequest = {}, options?: ConfigurationOptions): Promise<HttpInfo<PageTemplateSummaryView>> {
-        return this.api.listTemplatesWithHttpInfo( options).toPromise();
+        return this.api.listTemplatesWithHttpInfo(param.cursor, param.limit,  options).toPromise();
     }
 
     /**
@@ -1811,7 +1909,7 @@ export class ObjectTemplatesApi {
      * @param param the request object
      */
     public listTemplates(param: TemplatesApiListTemplatesRequest = {}, options?: ConfigurationOptions): Promise<PageTemplateSummaryView> {
-        return this.api.listTemplates( options).toPromise();
+        return this.api.listTemplates(param.cursor, param.limit,  options).toPromise();
     }
 
     /**
@@ -1900,6 +1998,13 @@ export interface WebhooksApiListWebhookDeliveriesRequest {
      */
     status?: 'pending' | 'delivered' | 'failed'
     /**
+     * Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the status filter.
+     * Defaults to: undefined
+     * @type string
+     * @memberof WebhooksApilistWebhookDeliveries
+     */
+    cursor?: string
+    /**
      * 
      * Minimum: 1
      * Maximum: 500
@@ -1911,6 +2016,22 @@ export interface WebhooksApiListWebhookDeliveriesRequest {
 }
 
 export interface WebhooksApiListWebhooksRequest {
+    /**
+     * Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * Defaults to: undefined
+     * @type string
+     * @memberof WebhooksApilistWebhooks
+     */
+    cursor?: string
+    /**
+     * Maximum number of items to return (1-100).
+     * Minimum: 1
+     * Maximum: 100
+     * Defaults to: 50
+     * @type number
+     * @memberof WebhooksApilistWebhooks
+     */
+    limit?: number
 }
 
 export interface WebhooksApiRotateWebhookSecretRequest {
@@ -2023,7 +2144,7 @@ export class ObjectWebhooksApi {
      * @param param the request object
      */
     public listWebhookDeliveriesWithHttpInfo(param: WebhooksApiListWebhookDeliveriesRequest, options?: ConfigurationOptions): Promise<HttpInfo<PageWebhookDeliveryView>> {
-        return this.api.listWebhookDeliveriesWithHttpInfo(param.id, param.status, param.limit,  options).toPromise();
+        return this.api.listWebhookDeliveriesWithHttpInfo(param.id, param.status, param.cursor, param.limit,  options).toPromise();
     }
 
     /**
@@ -2032,23 +2153,25 @@ export class ObjectWebhooksApi {
      * @param param the request object
      */
     public listWebhookDeliveries(param: WebhooksApiListWebhookDeliveriesRequest, options?: ConfigurationOptions): Promise<PageWebhookDeliveryView> {
-        return this.api.listWebhookDeliveries(param.id, param.status, param.limit,  options).toPromise();
+        return this.api.listWebhookDeliveries(param.id, param.status, param.cursor, param.limit,  options).toPromise();
     }
 
     /**
+     * List the webhooks owned by the authenticated account, newest first, with cursor pagination.
      * List webhooks
      * @param param the request object
      */
     public listWebhooksWithHttpInfo(param: WebhooksApiListWebhooksRequest = {}, options?: ConfigurationOptions): Promise<HttpInfo<PageWebhookView>> {
-        return this.api.listWebhooksWithHttpInfo( options).toPromise();
+        return this.api.listWebhooksWithHttpInfo(param.cursor, param.limit,  options).toPromise();
     }
 
     /**
+     * List the webhooks owned by the authenticated account, newest first, with cursor pagination.
      * List webhooks
      * @param param the request object
      */
     public listWebhooks(param: WebhooksApiListWebhooksRequest = {}, options?: ConfigurationOptions): Promise<PageWebhookView> {
-        return this.api.listWebhooks( options).toPromise();
+        return this.api.listWebhooks(param.cursor, param.limit,  options).toPromise();
     }
 
     /**

--- a/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
@@ -316,11 +316,13 @@ export class ObservableAccountApi {
     /**
      * API keys for the account (metadata only — secrets are shown once, at creation). Account scope only: an agent-scoped credential cannot manage keys.
      * List API keys
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param [limit] Maximum number of items to return (1-100).
      */
-    public listApiKeysWithHttpInfo(_options?: ConfigurationOptions): Observable<HttpInfo<PageAPIKeyView>> {
+    public listApiKeysWithHttpInfo(cursor?: string, limit?: number, _options?: ConfigurationOptions): Observable<HttpInfo<PageAPIKeyView>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.listApiKeys(_config);
+        const requestContextPromise = this.requestFactory.listApiKeys(cursor, limit, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -340,9 +342,11 @@ export class ObservableAccountApi {
     /**
      * API keys for the account (metadata only — secrets are shown once, at creation). Account scope only: an agent-scoped credential cannot manage keys.
      * List API keys
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param [limit] Maximum number of items to return (1-100).
      */
-    public listApiKeys(_options?: ConfigurationOptions): Observable<PageAPIKeyView> {
-        return this.listApiKeysWithHttpInfo(_options).pipe(map((apiResponse: HttpInfo<PageAPIKeyView>) => apiResponse.data));
+    public listApiKeys(cursor?: string, limit?: number, _options?: ConfigurationOptions): Observable<PageAPIKeyView> {
+        return this.listApiKeysWithHttpInfo(cursor, limit, _options).pipe(map((apiResponse: HttpInfo<PageAPIKeyView>) => apiResponse.data));
     }
 
     /**
@@ -538,13 +542,15 @@ export class ObservableAgentsApi {
     }
 
     /**
-     * List the agents owned by the authenticated account.
+     * List the agents owned by the authenticated account, newest first, with cursor pagination.
      * List agents
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param [limit] Maximum number of items to return (1-100).
      */
-    public listAgentsWithHttpInfo(_options?: ConfigurationOptions): Observable<HttpInfo<PageAgentView>> {
+    public listAgentsWithHttpInfo(cursor?: string, limit?: number, _options?: ConfigurationOptions): Observable<HttpInfo<PageAgentView>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.listAgents(_config);
+        const requestContextPromise = this.requestFactory.listAgents(cursor, limit, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -562,11 +568,13 @@ export class ObservableAgentsApi {
     }
 
     /**
-     * List the agents owned by the authenticated account.
+     * List the agents owned by the authenticated account, newest first, with cursor pagination.
      * List agents
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param [limit] Maximum number of items to return (1-100).
      */
-    public listAgents(_options?: ConfigurationOptions): Observable<PageAgentView> {
-        return this.listAgentsWithHttpInfo(_options).pipe(map((apiResponse: HttpInfo<PageAgentView>) => apiResponse.data));
+    public listAgents(cursor?: string, limit?: number, _options?: ConfigurationOptions): Observable<PageAgentView> {
+        return this.listAgentsWithHttpInfo(cursor, limit, _options).pipe(map((apiResponse: HttpInfo<PageAgentView>) => apiResponse.data));
     }
 
     /**
@@ -856,12 +864,15 @@ export class ObservableDomainsApi {
     }
 
     /**
+     * List the domains owned by the authenticated account, newest first, with cursor pagination.
      * List domains
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param [limit] Maximum number of items to return (1-100).
      */
-    public listDomainsWithHttpInfo(_options?: ConfigurationOptions): Observable<HttpInfo<PageDomainView>> {
+    public listDomainsWithHttpInfo(cursor?: string, limit?: number, _options?: ConfigurationOptions): Observable<HttpInfo<PageDomainView>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.listDomains(_config);
+        const requestContextPromise = this.requestFactory.listDomains(cursor, limit, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -879,10 +890,13 @@ export class ObservableDomainsApi {
     }
 
     /**
+     * List the domains owned by the authenticated account, newest first, with cursor pagination.
      * List domains
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param [limit] Maximum number of items to return (1-100).
      */
-    public listDomains(_options?: ConfigurationOptions): Observable<PageDomainView> {
-        return this.listDomainsWithHttpInfo(_options).pipe(map((apiResponse: HttpInfo<PageDomainView>) => apiResponse.data));
+    public listDomains(cursor?: string, limit?: number, _options?: ConfigurationOptions): Observable<PageDomainView> {
+        return this.listDomainsWithHttpInfo(cursor, limit, _options).pipe(map((apiResponse: HttpInfo<PageDomainView>) => apiResponse.data));
     }
 
     /**
@@ -1618,11 +1632,13 @@ export class ObservableReviewsApi {
     /**
      * The review queue: every message held in pending_review across the account\'s inboxes — outbound drafts awaiting send approval AND inbound messages held by a screening gate. Account-scoped credentials only; agents cannot see (or resolve) holds.
      * List messages awaiting review
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param [limit] Maximum number of items to return (1-100).
      */
-    public listReviewsWithHttpInfo(_options?: ConfigurationOptions): Observable<HttpInfo<PageReviewView>> {
+    public listReviewsWithHttpInfo(cursor?: string, limit?: number, _options?: ConfigurationOptions): Observable<HttpInfo<PageReviewView>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.listReviews(_config);
+        const requestContextPromise = this.requestFactory.listReviews(cursor, limit, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -1642,9 +1658,11 @@ export class ObservableReviewsApi {
     /**
      * The review queue: every message held in pending_review across the account\'s inboxes — outbound drafts awaiting send approval AND inbound messages held by a screening gate. Account-scoped credentials only; agents cannot see (or resolve) holds.
      * List messages awaiting review
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param [limit] Maximum number of items to return (1-100).
      */
-    public listReviews(_options?: ConfigurationOptions): Observable<PageReviewView> {
-        return this.listReviewsWithHttpInfo(_options).pipe(map((apiResponse: HttpInfo<PageReviewView>) => apiResponse.data));
+    public listReviews(cursor?: string, limit?: number, _options?: ConfigurationOptions): Observable<PageReviewView> {
+        return this.listReviewsWithHttpInfo(cursor, limit, _options).pipe(map((apiResponse: HttpInfo<PageReviewView>) => apiResponse.data));
     }
 
     /**
@@ -1840,11 +1858,13 @@ export class ObservableTemplatesApi {
     /**
      * List the pre-built starter templates shipped with the deployment, sorted by alias. Returns catalog metadata only; fetch one by alias for the full body sources, or copy one into your library with from_starter on POST /v1/templates. Beta: templates are unstable — their shape may change before they are declared stable.
      * List starter templates (beta)
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param [limit] Maximum number of items to return (1-100).
      */
-    public listStarterTemplatesWithHttpInfo(_options?: ConfigurationOptions): Observable<HttpInfo<PageStarterTemplateView>> {
+    public listStarterTemplatesWithHttpInfo(cursor?: string, limit?: number, _options?: ConfigurationOptions): Observable<HttpInfo<PageStarterTemplateView>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.listStarterTemplates(_config);
+        const requestContextPromise = this.requestFactory.listStarterTemplates(cursor, limit, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -1864,19 +1884,23 @@ export class ObservableTemplatesApi {
     /**
      * List the pre-built starter templates shipped with the deployment, sorted by alias. Returns catalog metadata only; fetch one by alias for the full body sources, or copy one into your library with from_starter on POST /v1/templates. Beta: templates are unstable — their shape may change before they are declared stable.
      * List starter templates (beta)
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param [limit] Maximum number of items to return (1-100).
      */
-    public listStarterTemplates(_options?: ConfigurationOptions): Observable<PageStarterTemplateView> {
-        return this.listStarterTemplatesWithHttpInfo(_options).pipe(map((apiResponse: HttpInfo<PageStarterTemplateView>) => apiResponse.data));
+    public listStarterTemplates(cursor?: string, limit?: number, _options?: ConfigurationOptions): Observable<PageStarterTemplateView> {
+        return this.listStarterTemplatesWithHttpInfo(cursor, limit, _options).pipe(map((apiResponse: HttpInfo<PageStarterTemplateView>) => apiResponse.data));
     }
 
     /**
      * List the account\'s templates, newest first. Returns metadata only (no body/html_body); fetch one by id for the full sources. Beta: templates are unstable — their shape may change before they are declared stable.
      * List templates (beta)
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param [limit] Maximum number of items to return (1-100).
      */
-    public listTemplatesWithHttpInfo(_options?: ConfigurationOptions): Observable<HttpInfo<PageTemplateSummaryView>> {
+    public listTemplatesWithHttpInfo(cursor?: string, limit?: number, _options?: ConfigurationOptions): Observable<HttpInfo<PageTemplateSummaryView>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.listTemplates(_config);
+        const requestContextPromise = this.requestFactory.listTemplates(cursor, limit, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -1896,9 +1920,11 @@ export class ObservableTemplatesApi {
     /**
      * List the account\'s templates, newest first. Returns metadata only (no body/html_body); fetch one by id for the full sources. Beta: templates are unstable — their shape may change before they are declared stable.
      * List templates (beta)
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param [limit] Maximum number of items to return (1-100).
      */
-    public listTemplates(_options?: ConfigurationOptions): Observable<PageTemplateSummaryView> {
-        return this.listTemplatesWithHttpInfo(_options).pipe(map((apiResponse: HttpInfo<PageTemplateSummaryView>) => apiResponse.data));
+    public listTemplates(cursor?: string, limit?: number, _options?: ConfigurationOptions): Observable<PageTemplateSummaryView> {
+        return this.listTemplatesWithHttpInfo(cursor, limit, _options).pipe(map((apiResponse: HttpInfo<PageTemplateSummaryView>) => apiResponse.data));
     }
 
     /**
@@ -2090,12 +2116,13 @@ export class ObservableWebhooksApi {
      * List webhook deliveries
      * @param id
      * @param [status]
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the status filter.
      * @param [limit]
      */
-    public listWebhookDeliveriesWithHttpInfo(id: string, status?: 'pending' | 'delivered' | 'failed', limit?: number, _options?: ConfigurationOptions): Observable<HttpInfo<PageWebhookDeliveryView>> {
+    public listWebhookDeliveriesWithHttpInfo(id: string, status?: 'pending' | 'delivered' | 'failed', cursor?: string, limit?: number, _options?: ConfigurationOptions): Observable<HttpInfo<PageWebhookDeliveryView>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.listWebhookDeliveries(id, status, limit, _config);
+        const requestContextPromise = this.requestFactory.listWebhookDeliveries(id, status, cursor, limit, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -2117,19 +2144,23 @@ export class ObservableWebhooksApi {
      * List webhook deliveries
      * @param id
      * @param [status]
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the status filter.
      * @param [limit]
      */
-    public listWebhookDeliveries(id: string, status?: 'pending' | 'delivered' | 'failed', limit?: number, _options?: ConfigurationOptions): Observable<PageWebhookDeliveryView> {
-        return this.listWebhookDeliveriesWithHttpInfo(id, status, limit, _options).pipe(map((apiResponse: HttpInfo<PageWebhookDeliveryView>) => apiResponse.data));
+    public listWebhookDeliveries(id: string, status?: 'pending' | 'delivered' | 'failed', cursor?: string, limit?: number, _options?: ConfigurationOptions): Observable<PageWebhookDeliveryView> {
+        return this.listWebhookDeliveriesWithHttpInfo(id, status, cursor, limit, _options).pipe(map((apiResponse: HttpInfo<PageWebhookDeliveryView>) => apiResponse.data));
     }
 
     /**
+     * List the webhooks owned by the authenticated account, newest first, with cursor pagination.
      * List webhooks
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param [limit] Maximum number of items to return (1-100).
      */
-    public listWebhooksWithHttpInfo(_options?: ConfigurationOptions): Observable<HttpInfo<PageWebhookView>> {
+    public listWebhooksWithHttpInfo(cursor?: string, limit?: number, _options?: ConfigurationOptions): Observable<HttpInfo<PageWebhookView>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.listWebhooks(_config);
+        const requestContextPromise = this.requestFactory.listWebhooks(cursor, limit, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -2147,10 +2178,13 @@ export class ObservableWebhooksApi {
     }
 
     /**
+     * List the webhooks owned by the authenticated account, newest first, with cursor pagination.
      * List webhooks
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param [limit] Maximum number of items to return (1-100).
      */
-    public listWebhooks(_options?: ConfigurationOptions): Observable<PageWebhookView> {
-        return this.listWebhooksWithHttpInfo(_options).pipe(map((apiResponse: HttpInfo<PageWebhookView>) => apiResponse.data));
+    public listWebhooks(cursor?: string, limit?: number, _options?: ConfigurationOptions): Observable<PageWebhookView> {
+        return this.listWebhooksWithHttpInfo(cursor, limit, _options).pipe(map((apiResponse: HttpInfo<PageWebhookView>) => apiResponse.data));
     }
 
     /**

--- a/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
@@ -240,20 +240,24 @@ export class PromiseAccountApi {
     /**
      * API keys for the account (metadata only — secrets are shown once, at creation). Account scope only: an agent-scoped credential cannot manage keys.
      * List API keys
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param [limit] Maximum number of items to return (1-100).
      */
-    public listApiKeysWithHttpInfo(_options?: PromiseConfigurationOptions): Promise<HttpInfo<PageAPIKeyView>> {
+    public listApiKeysWithHttpInfo(cursor?: string, limit?: number, _options?: PromiseConfigurationOptions): Promise<HttpInfo<PageAPIKeyView>> {
         const observableOptions = wrapOptions(_options);
-        const result = this.api.listApiKeysWithHttpInfo(observableOptions);
+        const result = this.api.listApiKeysWithHttpInfo(cursor, limit, observableOptions);
         return result.toPromise();
     }
 
     /**
      * API keys for the account (metadata only — secrets are shown once, at creation). Account scope only: an agent-scoped credential cannot manage keys.
      * List API keys
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param [limit] Maximum number of items to return (1-100).
      */
-    public listApiKeys(_options?: PromiseConfigurationOptions): Promise<PageAPIKeyView> {
+    public listApiKeys(cursor?: string, limit?: number, _options?: PromiseConfigurationOptions): Promise<PageAPIKeyView> {
         const observableOptions = wrapOptions(_options);
-        const result = this.api.listApiKeys(observableOptions);
+        const result = this.api.listApiKeys(cursor, limit, observableOptions);
         return result.toPromise();
     }
 
@@ -391,22 +395,26 @@ export class PromiseAgentsApi {
     }
 
     /**
-     * List the agents owned by the authenticated account.
+     * List the agents owned by the authenticated account, newest first, with cursor pagination.
      * List agents
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param [limit] Maximum number of items to return (1-100).
      */
-    public listAgentsWithHttpInfo(_options?: PromiseConfigurationOptions): Promise<HttpInfo<PageAgentView>> {
+    public listAgentsWithHttpInfo(cursor?: string, limit?: number, _options?: PromiseConfigurationOptions): Promise<HttpInfo<PageAgentView>> {
         const observableOptions = wrapOptions(_options);
-        const result = this.api.listAgentsWithHttpInfo(observableOptions);
+        const result = this.api.listAgentsWithHttpInfo(cursor, limit, observableOptions);
         return result.toPromise();
     }
 
     /**
-     * List the agents owned by the authenticated account.
+     * List the agents owned by the authenticated account, newest first, with cursor pagination.
      * List agents
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param [limit] Maximum number of items to return (1-100).
      */
-    public listAgents(_options?: PromiseConfigurationOptions): Promise<PageAgentView> {
+    public listAgents(cursor?: string, limit?: number, _options?: PromiseConfigurationOptions): Promise<PageAgentView> {
         const observableOptions = wrapOptions(_options);
-        const result = this.api.listAgents(observableOptions);
+        const result = this.api.listAgents(cursor, limit, observableOptions);
         return result.toPromise();
     }
 
@@ -615,20 +623,26 @@ export class PromiseDomainsApi {
     }
 
     /**
+     * List the domains owned by the authenticated account, newest first, with cursor pagination.
      * List domains
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param [limit] Maximum number of items to return (1-100).
      */
-    public listDomainsWithHttpInfo(_options?: PromiseConfigurationOptions): Promise<HttpInfo<PageDomainView>> {
+    public listDomainsWithHttpInfo(cursor?: string, limit?: number, _options?: PromiseConfigurationOptions): Promise<HttpInfo<PageDomainView>> {
         const observableOptions = wrapOptions(_options);
-        const result = this.api.listDomainsWithHttpInfo(observableOptions);
+        const result = this.api.listDomainsWithHttpInfo(cursor, limit, observableOptions);
         return result.toPromise();
     }
 
     /**
+     * List the domains owned by the authenticated account, newest first, with cursor pagination.
      * List domains
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param [limit] Maximum number of items to return (1-100).
      */
-    public listDomains(_options?: PromiseConfigurationOptions): Promise<PageDomainView> {
+    public listDomains(cursor?: string, limit?: number, _options?: PromiseConfigurationOptions): Promise<PageDomainView> {
         const observableOptions = wrapOptions(_options);
-        const result = this.api.listDomains(observableOptions);
+        const result = this.api.listDomains(cursor, limit, observableOptions);
         return result.toPromise();
     }
 
@@ -1165,20 +1179,24 @@ export class PromiseReviewsApi {
     /**
      * The review queue: every message held in pending_review across the account\'s inboxes — outbound drafts awaiting send approval AND inbound messages held by a screening gate. Account-scoped credentials only; agents cannot see (or resolve) holds.
      * List messages awaiting review
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param [limit] Maximum number of items to return (1-100).
      */
-    public listReviewsWithHttpInfo(_options?: PromiseConfigurationOptions): Promise<HttpInfo<PageReviewView>> {
+    public listReviewsWithHttpInfo(cursor?: string, limit?: number, _options?: PromiseConfigurationOptions): Promise<HttpInfo<PageReviewView>> {
         const observableOptions = wrapOptions(_options);
-        const result = this.api.listReviewsWithHttpInfo(observableOptions);
+        const result = this.api.listReviewsWithHttpInfo(cursor, limit, observableOptions);
         return result.toPromise();
     }
 
     /**
      * The review queue: every message held in pending_review across the account\'s inboxes — outbound drafts awaiting send approval AND inbound messages held by a screening gate. Account-scoped credentials only; agents cannot see (or resolve) holds.
      * List messages awaiting review
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param [limit] Maximum number of items to return (1-100).
      */
-    public listReviews(_options?: PromiseConfigurationOptions): Promise<PageReviewView> {
+    public listReviews(cursor?: string, limit?: number, _options?: PromiseConfigurationOptions): Promise<PageReviewView> {
         const observableOptions = wrapOptions(_options);
-        const result = this.api.listReviews(observableOptions);
+        const result = this.api.listReviews(cursor, limit, observableOptions);
         return result.toPromise();
     }
 
@@ -1316,40 +1334,48 @@ export class PromiseTemplatesApi {
     /**
      * List the pre-built starter templates shipped with the deployment, sorted by alias. Returns catalog metadata only; fetch one by alias for the full body sources, or copy one into your library with from_starter on POST /v1/templates. Beta: templates are unstable — their shape may change before they are declared stable.
      * List starter templates (beta)
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param [limit] Maximum number of items to return (1-100).
      */
-    public listStarterTemplatesWithHttpInfo(_options?: PromiseConfigurationOptions): Promise<HttpInfo<PageStarterTemplateView>> {
+    public listStarterTemplatesWithHttpInfo(cursor?: string, limit?: number, _options?: PromiseConfigurationOptions): Promise<HttpInfo<PageStarterTemplateView>> {
         const observableOptions = wrapOptions(_options);
-        const result = this.api.listStarterTemplatesWithHttpInfo(observableOptions);
+        const result = this.api.listStarterTemplatesWithHttpInfo(cursor, limit, observableOptions);
         return result.toPromise();
     }
 
     /**
      * List the pre-built starter templates shipped with the deployment, sorted by alias. Returns catalog metadata only; fetch one by alias for the full body sources, or copy one into your library with from_starter on POST /v1/templates. Beta: templates are unstable — their shape may change before they are declared stable.
      * List starter templates (beta)
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param [limit] Maximum number of items to return (1-100).
      */
-    public listStarterTemplates(_options?: PromiseConfigurationOptions): Promise<PageStarterTemplateView> {
+    public listStarterTemplates(cursor?: string, limit?: number, _options?: PromiseConfigurationOptions): Promise<PageStarterTemplateView> {
         const observableOptions = wrapOptions(_options);
-        const result = this.api.listStarterTemplates(observableOptions);
+        const result = this.api.listStarterTemplates(cursor, limit, observableOptions);
         return result.toPromise();
     }
 
     /**
      * List the account\'s templates, newest first. Returns metadata only (no body/html_body); fetch one by id for the full sources. Beta: templates are unstable — their shape may change before they are declared stable.
      * List templates (beta)
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param [limit] Maximum number of items to return (1-100).
      */
-    public listTemplatesWithHttpInfo(_options?: PromiseConfigurationOptions): Promise<HttpInfo<PageTemplateSummaryView>> {
+    public listTemplatesWithHttpInfo(cursor?: string, limit?: number, _options?: PromiseConfigurationOptions): Promise<HttpInfo<PageTemplateSummaryView>> {
         const observableOptions = wrapOptions(_options);
-        const result = this.api.listTemplatesWithHttpInfo(observableOptions);
+        const result = this.api.listTemplatesWithHttpInfo(cursor, limit, observableOptions);
         return result.toPromise();
     }
 
     /**
      * List the account\'s templates, newest first. Returns metadata only (no body/html_body); fetch one by id for the full sources. Beta: templates are unstable — their shape may change before they are declared stable.
      * List templates (beta)
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param [limit] Maximum number of items to return (1-100).
      */
-    public listTemplates(_options?: PromiseConfigurationOptions): Promise<PageTemplateSummaryView> {
+    public listTemplates(cursor?: string, limit?: number, _options?: PromiseConfigurationOptions): Promise<PageTemplateSummaryView> {
         const observableOptions = wrapOptions(_options);
-        const result = this.api.listTemplates(observableOptions);
+        const result = this.api.listTemplates(cursor, limit, observableOptions);
         return result.toPromise();
     }
 
@@ -1483,11 +1509,12 @@ export class PromiseWebhooksApi {
      * List webhook deliveries
      * @param id
      * @param [status]
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the status filter.
      * @param [limit]
      */
-    public listWebhookDeliveriesWithHttpInfo(id: string, status?: 'pending' | 'delivered' | 'failed', limit?: number, _options?: PromiseConfigurationOptions): Promise<HttpInfo<PageWebhookDeliveryView>> {
+    public listWebhookDeliveriesWithHttpInfo(id: string, status?: 'pending' | 'delivered' | 'failed', cursor?: string, limit?: number, _options?: PromiseConfigurationOptions): Promise<HttpInfo<PageWebhookDeliveryView>> {
         const observableOptions = wrapOptions(_options);
-        const result = this.api.listWebhookDeliveriesWithHttpInfo(id, status, limit, observableOptions);
+        const result = this.api.listWebhookDeliveriesWithHttpInfo(id, status, cursor, limit, observableOptions);
         return result.toPromise();
     }
 
@@ -1496,29 +1523,36 @@ export class PromiseWebhooksApi {
      * List webhook deliveries
      * @param id
      * @param [status]
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the status filter.
      * @param [limit]
      */
-    public listWebhookDeliveries(id: string, status?: 'pending' | 'delivered' | 'failed', limit?: number, _options?: PromiseConfigurationOptions): Promise<PageWebhookDeliveryView> {
+    public listWebhookDeliveries(id: string, status?: 'pending' | 'delivered' | 'failed', cursor?: string, limit?: number, _options?: PromiseConfigurationOptions): Promise<PageWebhookDeliveryView> {
         const observableOptions = wrapOptions(_options);
-        const result = this.api.listWebhookDeliveries(id, status, limit, observableOptions);
+        const result = this.api.listWebhookDeliveries(id, status, cursor, limit, observableOptions);
         return result.toPromise();
     }
 
     /**
+     * List the webhooks owned by the authenticated account, newest first, with cursor pagination.
      * List webhooks
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param [limit] Maximum number of items to return (1-100).
      */
-    public listWebhooksWithHttpInfo(_options?: PromiseConfigurationOptions): Promise<HttpInfo<PageWebhookView>> {
+    public listWebhooksWithHttpInfo(cursor?: string, limit?: number, _options?: PromiseConfigurationOptions): Promise<HttpInfo<PageWebhookView>> {
         const observableOptions = wrapOptions(_options);
-        const result = this.api.listWebhooksWithHttpInfo(observableOptions);
+        const result = this.api.listWebhooksWithHttpInfo(cursor, limit, observableOptions);
         return result.toPromise();
     }
 
     /**
+     * List the webhooks owned by the authenticated account, newest first, with cursor pagination.
      * List webhooks
+     * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
+     * @param [limit] Maximum number of items to return (1-100).
      */
-    public listWebhooks(_options?: PromiseConfigurationOptions): Promise<PageWebhookView> {
+    public listWebhooks(cursor?: string, limit?: number, _options?: PromiseConfigurationOptions): Promise<PageWebhookView> {
         const observableOptions = wrapOptions(_options);
-        const result = this.api.listWebhooks(observableOptions);
+        const result = this.api.listWebhooks(cursor, limit, observableOptions);
         return result.toPromise();
     }
 

--- a/sdks/typescript/test/v1/client.test.ts
+++ b/sdks/typescript/test/v1/client.test.ts
@@ -310,33 +310,29 @@ describe("E2AClient", () => {
     expect(calls[1]).toContain("cursor=cur_2");
   });
 
-  // ── Pagination: cursorless (single-page) endpoints ──────────────
-  // agents/domains/webhooks have no cursor param. Even if the server returns a
-  // non-null next_cursor, the pager must stop after one page (it can't forward a
-  // cursor; surfacing one would loop page 1 and trip the cycle guard). This locks
-  // the intentional cursor-drop. (webhooks.deliveries is covered below.)
+  // ── Pagination: keyset-cursor list endpoints ────────────────────
+  // agents/domains/webhooks/templates/starter-templates/api-keys are all
+  // keyset-paginated on (created_at, id) now — the AutoPager must thread
+  // next_cursor to completion, exactly like messages/events/suppressions. This
+  // locks in the consistent-pagination contract (no more silent single-page cap).
 
   it.each([
-    ["agents", () => client.agents.list(), { id: "ag_1", email: "bot@test.dev" }],
-    ["domains", () => client.domains.list(), { domain: "test.dev" }],
-    ["webhooks", () => client.webhooks.list(), { id: "wh_1" }],
-    ["templates", () => client.templates.list(), { id: "tmpl_1", name: "Welcome" }],
-    ["templates.listStarters", () => client.templates.listStarters(), { alias: "welcome" }],
-  ] as const)("%s.list stops after one page even if the server returns a next_cursor", async (_name, lister, item) => {
-    let calls = 0;
-    globalThis.fetch = vi.fn(async () => {
-      calls++;
-      const text = JSON.stringify({ items: [item], next_cursor: "should_be_ignored" });
-      return {
-        status: 200,
-        headers: new Headers({ "content-type": "application/json" }),
-        text: async () => text,
-        blob: async () => new Blob([text]),
-      } as unknown as Response;
-    }) as unknown as typeof fetch;
-    const items = await lister().toArray({ limit: 100 });
-    expect(items).toHaveLength(1);
-    expect(calls).toBe(1);
+    ["agents", () => client.agents.list(), [{ id: "ag_1" }, { id: "ag_2" }], (r: { id: string }) => r.id],
+    ["domains", () => client.domains.list(), [{ domain: "a.dev" }, { domain: "b.dev" }], (r: { domain: string }) => r.domain],
+    ["webhooks", () => client.webhooks.list(), [{ id: "wh_1" }, { id: "wh_2" }], (r: { id: string }) => r.id],
+    ["templates", () => client.templates.list(), [{ id: "t_1", name: "A" }, { id: "t_2", name: "B" }], (r: { id: string }) => r.id],
+    ["templates.listStarters", () => client.templates.listStarters(), [{ alias: "welcome" }, { alias: "receipt" }], (r: { alias: string }) => r.alias],
+    ["account.apiKeys", () => client.account.apiKeys.list(), [{ id: "key_1" }, { id: "key_2" }], (r: { id: string }) => r.id],
+  ] as const)("%s.list threads next_cursor across pages", async (_name, lister, rows, keyOf) => {
+    const { fn, calls } = pagingFetch({
+      "": { items: [rows[0]], next_cursor: "cur_2" },
+      cur_2: { items: [rows[1]], next_cursor: null },
+    });
+    globalThis.fetch = fn as unknown as typeof fetch;
+    const items = await (lister() as { toArray: (o: { limit: number }) => Promise<unknown[]> }).toArray({ limit: 50 });
+    expect(items.map((it) => keyOf(it as never))).toEqual([keyOf(rows[0] as never), keyOf(rows[1] as never)]);
+    expect(calls).toHaveLength(2);
+    expect(calls[1]).toContain("cursor=cur_2");
   });
 
   // ── Templates (beta) ────────────────────────────────────────────
@@ -500,26 +496,20 @@ describe("E2AClient", () => {
     }
   });
 
-  // ── webhooks.deliveries pager termination (review finding) ──────
+  // ── webhooks.deliveries pagination ──────────────────────────────
 
-  it("webhooks.deliveries terminates even if the page carries a next_cursor", async () => {
-    // The endpoint has no cursor param; surfacing next_cursor would make the
-    // pager re-fetch the same page and trip the cycle guard. It must stop after
-    // one page regardless.
-    let calls = 0;
-    globalThis.fetch = vi.fn(async () => {
-      calls++;
-      const text = JSON.stringify({ items: [{ id: "del_1" }], next_cursor: "should_be_ignored" });
-      return {
-        status: 200,
-        headers: new Headers({ "content-type": "application/json" }),
-        text: async () => text,
-        blob: async () => new Blob([text]),
-      } as unknown as Response;
-    }) as unknown as typeof fetch;
+  it("webhooks.deliveries threads next_cursor across pages", async () => {
+    // The delivery log is keyset-paginated now — the AutoPager walks the cursor
+    // to completion instead of silently capping at one page.
+    const { fn, calls } = pagingFetch({
+      "": { items: [{ id: "del_1" }], next_cursor: "cur_2" },
+      cur_2: { items: [{ id: "del_2" }], next_cursor: null },
+    });
+    globalThis.fetch = fn as unknown as typeof fetch;
     const items = await client.webhooks.deliveries("wh_1").toArray({ limit: 100 });
-    expect(items).toHaveLength(1);
-    expect(calls).toBe(1); // single page, no loop
+    expect(items.map((d) => d.id)).toEqual(["del_1", "del_2"]);
+    expect(calls).toHaveLength(2);
+    expect(calls[1]).toContain("cursor=cur_2");
   });
 
   // ── account + suppressions smoke (thin passthroughs) ────────────


### PR DESCRIPTION
## Problem

The `/v1` API advertises **one** list envelope — `Page[T]` = `{items, next_cursor}` with `cursor`+`limit` request params — and a few endpoints implement it for real with opaque HMAC-signed keyset cursors (`listMessages`, `listEvents`, `listSuppressions`, `listConversations`). But **many** list endpoints stubbed it: they took no `cursor`/`limit`, returned the full set (or silently capped ~1000 via `toArray`), and hardwired `next_cursor: null` — so the envelope promised paging that never happened. Two grew **unbounded** in production:

- **`listReviews`** — returned the entire review backlog.
- **`listWebhookDeliveries`** — took `limit` (max 500) but no cursor, silently truncating a busy webhook's delivery log.

## What this does

Converts every stubbed list to **real HMAC-signed keyset pagination**, mirroring the existing scheme exactly (opaque cursor over `(created_at, id)` with a unique tiebreak; `EncodeCursor`/`DecodeCursor`; fetch `limit+1` to detect a further page; `next_cursor` only when a full page was returned). No new cursor scheme was invented.

**Endpoints paginated (server + store):**

| Priority | Endpoint | Notes |
|---|---|---|
| 1 (unbounded) | `listReviews` | keyset on `(created_at, id)` |
| 1 (unbounded) | `listWebhookDeliveries` | `status` filter pinned into the cursor |
| 2 (bulk) | `listAgents`, `listDomains`, `listWebhooks`, `listTemplates`, `listApiKeys`, `listStarterTemplates` | `domains` tiebreaks on the unique `domain`; starter catalog keysets on `alias` |

Store methods now take `(limit, afterCreatedAt, afterID)`; `limit<=0` returns the whole set unpaginated, so internal all-consumers (auth dashboard views, webhook filter-ownership validation, prober seed) keep their semantics. A shared `keysetCursor` + `decodeKeyset`/`encodeKeyset` helper in `pagination.go` removes the per-handler boilerplate for the common `(created_at, id)` case.

## Symmetry (server / OpenAPI / SDK / MCP / CLI / tests — one batch)

- **OpenAPI** regenerated from the handlers (`cursor`+`limit` params added; `TestSpecGoldenNoDrift` green).
- **SDKs** — generated bases regenerated via OpenAPI Generator; the hand-written **AutoPager** layers (TS `client.ts`, Python `client.py`) now thread the cursor for these endpoints instead of dropping it. SDK pagination tests updated to walk multiple pages.
- **MCP** — the list tools whose backing endpoints are now paginated adopt the standard `paginationInput` (cursor+limit) shape and return `{<items>, next_cursor}`; strict schemas kept. (`list_pending_messages` is an aggregation across agents, not a single endpoint — left as-is.)
- **CLI** — `for await` over the AutoPager now walks all pages transparently; no code change needed.

## Tests

- **Server:** seed >1 page, walk `next_cursor` to completion, assert concatenated pages equal the full set with no dupes/gaps and stable order; a full final page emits no spurious cursor; tampered / status-mismatch cursors are rejected `400 invalid_cursor`.
- **SDK/MCP:** TS (`119 unit`), Python (`172`), MCP (`155`), CLI (`108`) all green; the old "single-page / cursor-dropped" assertions replaced with cursor-threading ones.

## Not in scope

Python AutoPager still lacks TS's manual `.page()` — untouched (not needed for these endpoints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)