### PR TITLE
fix!: drop redundant agent id from the user-data export (id == email) (BREAKING)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -110,8 +110,6 @@ components:
           type: boolean
         email:
           type: string
-        id:
-          type: string
         inbound_7d:
           format: int64
           type: integer
@@ -178,7 +176,6 @@ components:
         webhook_healthy:
           type: boolean
       required:
-        - id
         - domain
         - email
         - name

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -90,7 +90,11 @@ type Domain struct {
 }
 
 type AgentIdentity struct {
-	ID             string    `json:"id"`
+	// ID is the agent's full email address and its identifier (id == email;
+	// EmailAddress() returns it). It is never serialized: every API surface
+	// keys an agent on `email`, and the #436 rename dropped the redundant
+	// `id` from the public contract. Kept as a field for internal use only.
+	ID             string    `json:"-"`
 	Domain         string    `json:"domain"`
 	Email          string    `json:"email"`
 	Name           string    `json:"name"`

--- a/internal/identity/user_data_rights_test.go
+++ b/internal/identity/user_data_rights_test.go
@@ -112,6 +112,21 @@ func TestExportUserData(t *testing.T) {
 	if len(dump.Agents) != 1 {
 		t.Errorf("agents: got %d, want 1", len(dump.Agents))
 	}
+	// The export keys an agent on `email` only. The #436 rename dropped the
+	// redundant `id` (id == email) from every other surface; guard that the
+	// export doesn't reintroduce it as a re-exposed identifier.
+	if len(dump.Agents) == 1 {
+		agentJSON, err := json.Marshal(dump.Agents[0])
+		if err != nil {
+			t.Fatalf("marshal exported agent: %v", err)
+		}
+		if jsonContains(agentJSON, "id") {
+			t.Error("exported agent leaks `id` — it's redundant with `email` (id == email)")
+		}
+		if !jsonContains(agentJSON, "email") {
+			t.Error("exported agent is missing `email` — the agent's identifier")
+		}
+	}
 	if len(dump.APIKeys) != 2 {
 		t.Errorf("api_keys: got %d, want 2", len(dump.APIKeys))
 	}

--- a/sdks/python/src/e2a/v1/generated/models/agent_identity.py
+++ b/sdks/python/src/e2a/v1/generated/models/agent_identity.py
@@ -31,7 +31,6 @@ class AgentIdentity(BaseModel):
     domain: StrictStr
     domain_verified: StrictBool
     email: StrictStr
-    id: StrictStr
     inbound_7d: StrictInt
     inbound_allowlist: Optional[List[StrictStr]] = None
     inbound_policy: StrictStr
@@ -56,7 +55,7 @@ class AgentIdentity(BaseModel):
     ttl_seconds: StrictInt
     user_id: StrictStr
     webhook_healthy: StrictBool
-    __properties: ClassVar[List[str]] = ["created_at", "domain", "domain_verified", "email", "id", "inbound_7d", "inbound_allowlist", "inbound_policy", "inbound_policy_action", "inbound_scan", "inbound_scan_block_threshold", "inbound_scan_review_threshold", "inbound_scan_sensitivity", "last_delivery_at", "name", "on_expiry", "outbound_7d", "outbound_allowlist", "outbound_policy", "outbound_policy_action", "outbound_scan", "outbound_scan_block_threshold", "outbound_scan_review_threshold", "outbound_scan_sensitivity", "pending_count", "public", "ttl_seconds", "user_id", "webhook_healthy"]
+    __properties: ClassVar[List[str]] = ["created_at", "domain", "domain_verified", "email", "inbound_7d", "inbound_allowlist", "inbound_policy", "inbound_policy_action", "inbound_scan", "inbound_scan_block_threshold", "inbound_scan_review_threshold", "inbound_scan_sensitivity", "last_delivery_at", "name", "on_expiry", "outbound_7d", "outbound_allowlist", "outbound_policy", "outbound_policy_action", "outbound_scan", "outbound_scan_block_threshold", "outbound_scan_review_threshold", "outbound_scan_sensitivity", "pending_count", "public", "ttl_seconds", "user_id", "webhook_healthy"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -123,7 +122,6 @@ class AgentIdentity(BaseModel):
             "domain": obj.get("domain"),
             "domain_verified": obj.get("domain_verified"),
             "email": obj.get("email"),
-            "id": obj.get("id"),
             "inbound_7d": obj.get("inbound_7d"),
             "inbound_allowlist": obj.get("inbound_allowlist"),
             "inbound_policy": obj.get("inbound_policy"),

--- a/sdks/typescript/src/v1/generated/models/AgentIdentity.ts
+++ b/sdks/typescript/src/v1/generated/models/AgentIdentity.ts
@@ -17,7 +17,6 @@ export class AgentIdentity {
     'domain': string;
     'domainVerified': boolean;
     'email': string;
-    'id': string;
     'inbound7d': number;
     'inboundAllowlist'?: Array<string> | null;
     'inboundPolicy': string;
@@ -69,12 +68,6 @@ export class AgentIdentity {
         {
             "name": "email",
             "baseName": "email",
-            "type": "string",
-            "format": ""
-        },
-        {
-            "name": "id",
-            "baseName": "id",
             "type": "string",
             "format": ""
         },


### PR DESCRIPTION
## What

The GDPR / right-of-access **user-data export** (`UserExport.agents`, the `AgentIdentity` schema) still exposed an opaque `id` field on each agent. Since an agent's id **is** its email — `internal/identity/store.go`'s `populateEmail()` sets `a.Email = a.ID` and `EmailAddress()` returns `a.ID` — that `id` is a redundant re-exposure of the identifier the #436 rename already dropped from every other surface.

This drops it so the export matches the rest of the frozen pre-GA contract.

## Why

Pre-GA freeze consistency fix (**user-approved**). Deliberate **BREAKING** change made now, before GA freezes the contract.

## Change

- **`internal/identity/store.go`** — `AgentIdentity.ID` json tag `"id"` → `"-"`. The field stays for internal use (it's referenced pervasively as `a.ID`); it is simply never serialized. This also drops `id` from the internal `/api/dashboard/agents` response — not part of the OpenAPI contract, and its consumer (the web dashboard) already keys agents on `email`.
- **`api/openapi.yaml` + both SDK bases** — regenerated via `make spec` + `make generate-sdk`. The `id` property and its `required` entry are gone from `AgentIdentity`; the TS and Python generated models are updated. Regeneration is idempotent and no hand-written SDK/CLI code referenced the field.
- **Export test** — added a regression guard: the marshaled exported agent must not contain `id` and must contain `email`.

Consumers switch `agent.id` → `agent.email`; the value is byte-identical.

## `user_id` disposition (flagged, not changed)

`user_id` is **deliberately kept**. Dropping it is a separate, broader decision than the committed `id` removal, and `AgentIdentity` is a shared struct. Within a single-user export it is arguably redundant with the top-level `user.id`, but that's a judgment call worth a second look — flagging rather than forcing it here.

## Verification

- `go build ./...` clean.
- `make spec` regenerated the golden with no drift; `id` property + required entry dropped.
- `make generate-sdk` idempotent — only `AgentIdentity` (TS + Py) changed; `grep` confirms `id` gone from both generated models and the spec.
- Export test (`TestExportUserData`) passes with the new assertion, against an isolated throwaway DB (`e2a_test_exportid`, dropped afterwards — the shared test DB was untouched).
- `internal/httpapi` and `internal/auth` packages pass. (Two pre-existing `TestInboundIntake_*` failures are environmental to the freshly-seeded local DB and reproduce without this change; unrelated to `AgentIdentity`.)
- TS/Python SDK compile deferred to CI (sandbox has no npm network); change is generated-only with no hand-written references.

Note: concurrent naming PRs exist — any codegen conflict is a mechanical re-run of `make spec`/`make generate-sdk` at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)