### PR TITLE
fix!: verifyDomain returns 200 (branch on .verified), not misused 412 (BREAKING)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3608,7 +3608,7 @@ paths:
         - domains
   /v1/domains/{domain}/verify:
     post:
-      description: Probe the domain's published DNS and, when the verification TXT is present, mark it verified. Returns the per-record diagnostic; a missing TXT yields 412.
+      description: Probe the domain's published DNS and, when the verification TXT (and inbound MX) are present, mark it verified. Always returns 200 with the per-record diagnostic — branch on the `verified` boolean in the body, not the HTTP status. A not-yet-published record is the normal `verified:false` outcome, not an error.
       operationId: verifyDomain
       parameters:
         - in: path
@@ -3623,12 +3623,6 @@ paths:
               schema:
                 $ref: "#/components/schemas/VerifyDomainView"
           description: OK
-        "412":
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/VerifyDomainView"
-          description: Precondition Failed — the verification TXT record is not yet published.
         default:
           content:
             application/json:

--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -1979,9 +1979,15 @@ Every fix was **test-first**: a contract/store test was written and confirmed to
   `webhook_deliveries`. (`TestConversationMessagesCarryWebhookStatus`.)
 
 **Contract-honesty fixes (all fixed, TDD via `spec_review_test.go` + handler tests):**
-- **MED-1/2** — declare the runtime `202` (outbound HITL hold) and `412`
-  (domain verify "TXT not published") responses that Huma omitted, so SDK
-  codegen models them.
+- **MED-1** — declare the runtime `202` (outbound HITL hold) response that Huma
+  omitted, so SDK codegen models it.
+- **MED-2** — ~~domain verify "TXT not published" declared a `412`~~ **superseded
+  (pre-GA):** `verifyDomain` now always returns **200** with the `VerifyDomainView`
+  diagnostic; a not-yet-published record is the normal `verified:false` outcome,
+  not an HTTP error. `412` (Precondition Failed) is reserved for conditional-request
+  failures and was being special-cased by SDKs/proxies. Clients branch on the body's
+  `verified` boolean, never the status code. (`TestSpecVerifyDomainNo412` +
+  handler tests.)
 - **MED-3** — duplicate-domain registration now returns **`409 domain_taken`**
   (was `400`) via a typed `identity.ErrDomainTaken` sentinel.
 - **MED-4** — a **recipient-count cap** (≤ 50 total to+cc+bcc) on

--- a/internal/httpapi/domains.go
+++ b/internal/httpapi/domains.go
@@ -238,21 +238,19 @@ func (s *Server) registerDomains() {
 	huma.Register(s.API, huma.Operation{
 		OperationID: "verifyDomain", Method: http.MethodPost, Path: "/v1/domains/{domain}/verify",
 		Summary: "Verify a domain", Tags: []string{"domains"},
-		Description: "Probe the domain's published DNS and, when the verification TXT is present, mark it verified. Returns the per-record diagnostic; a missing TXT yields 412.",
+		Description: "Probe the domain's published DNS and, when the verification TXT (and inbound MX) are present, mark it verified. Always returns 200 with the per-record diagnostic — branch on the `verified` boolean in the body, not the HTTP status. A not-yet-published record is the normal `verified:false` outcome, not an error.",
 		Security:    []map[string][]string{{"bearer": {}}},
 		Responses: map[string]*huma.Response{
-			"412": s.jsonResponse(reflect.TypeOf(VerifyDomainView{}), "VerifyDomainView",
-				"Precondition Failed — the verification TXT record is not yet published."),
 			"default": s.errorEnvelopeResponse(),
 		},
 	}, s.handleVerifyDomain)
 }
 
-// verifyDomainOutput uses Huma's special Status field to switch between 200
-// (verified / already-verified) and 412 (TXT not yet published).
+// verifyDomainOutput carries the diagnostic body. Both the verified and the
+// not-yet-verified outcomes are 200 (Huma's default) — callers branch on
+// VerifyDomainView.verified, never on the HTTP status.
 type verifyDomainOutput struct {
-	Status int
-	Body   VerifyDomainView
+	Body VerifyDomainView
 }
 
 func (s *Server) handleVerifyDomain(ctx context.Context, in *DomainParam) (*verifyDomainOutput, error) {
@@ -275,7 +273,7 @@ func (s *Server) handleVerifyDomain(ctx context.Context, in *DomainParam) (*veri
 	// forced sending re-check for a domain whose sending_status is pending/failed.
 	if d.Verified {
 		s.enqueueSenderProvision(ctx, d.Domain)
-		return &verifyDomainOutput{Status: http.StatusOK, Body: VerifyDomainView{
+		return &verifyDomainOutput{Body: VerifyDomainView{
 			Domain: d.Domain, Verified: true, VerifiedAt: d.VerifiedAt,
 			MX: check.MX, SPF: check.SPF, DKIM: check.DKIM,
 		}}, nil
@@ -287,9 +285,12 @@ func (s *Server) handleVerifyDomain(ctx context.Context, in *DomainParam) (*veri
 	// published — otherwise a TXT-only verify would claim a "verified" MX while
 	// inbound mail silently bounces. A domain can't receive mail without the MX,
 	// so requiring it for `verified` is also the correct inbound semantics.
-	// 412 with the diagnostic so callers see exactly which record is missing.
+	// Not-yet-published is the normal `verified:false` outcome — return 200 with
+	// the diagnostic so callers see exactly which record is missing. This is NOT
+	// an HTTP error (a missing TXT/MX is expected while DNS propagates); clients
+	// poll by re-calling and branching on `verified`, never on the status code.
 	if !check.TXTFound || check.MX != "found" {
-		return &verifyDomainOutput{Status: http.StatusPreconditionFailed, Body: VerifyDomainView{
+		return &verifyDomainOutput{Body: VerifyDomainView{
 			Domain: d.Domain, Verified: false, MX: check.MX, SPF: check.SPF, DKIM: check.DKIM,
 		}}, nil
 	}
@@ -302,11 +303,11 @@ func (s *Server) handleVerifyDomain(ctx context.Context, in *DomainParam) (*veri
 	// Re-read for verified_at; fall back to the bare success shape.
 	updated, err := s.deps.LookupDomain(ctx, in.Domain, user.ID)
 	if err != nil || updated == nil {
-		return &verifyDomainOutput{Status: http.StatusOK, Body: VerifyDomainView{
+		return &verifyDomainOutput{Body: VerifyDomainView{
 			Domain: in.Domain, Verified: true, MX: check.MX, SPF: check.SPF, DKIM: check.DKIM,
 		}}, nil
 	}
-	return &verifyDomainOutput{Status: http.StatusOK, Body: VerifyDomainView{
+	return &verifyDomainOutput{Body: VerifyDomainView{
 		Domain: updated.Domain, Verified: true, VerifiedAt: updated.VerifiedAt,
 		MX: check.MX, SPF: check.SPF, DKIM: check.DKIM,
 	}}, nil

--- a/internal/httpapi/domains_test.go
+++ b/internal/httpapi/domains_test.go
@@ -142,25 +142,28 @@ func TestVerifyDomainAlreadyVerified(t *testing.T) {
 func TestVerifyDomainTXTMissing(t *testing.T) {
 	srv := testServer(t)
 	code, body := postJSON(t, srv.URL+"/v1/domains/pending.com/verify", "good", nil)
-	if code != 412 || body["verified"] != false {
-		t.Fatalf("want 412 not-verified, got %d %v", code, body)
+	// Not-yet-published is a normal 200 with verified:false — NOT a 412. Clients
+	// branch on the body's `verified` boolean, not the HTTP status.
+	if code != 200 || body["verified"] != false {
+		t.Fatalf("want 200 not-verified, got %d %v", code, body)
 	}
 	if body["mx"] != "missing" {
-		t.Fatalf("expected diagnostic in 412 body, got %v", body)
+		t.Fatalf("expected diagnostic in 200 body, got %v", body)
 	}
 }
 
 // TestVerifyDomainMXMissing — verification now requires the inbound MX too, not
 // just the ownership TXT, so that inbound_mx.status="verified" (derived from the
-// domain's verified flag) is honest. TXT present but MX missing ⇒ 412, not verified.
+// domain's verified flag) is honest. TXT present but MX missing ⇒ verified:false
+// (returned as a normal 200, not a 412).
 func TestVerifyDomainMXMissing(t *testing.T) {
 	srv := testServer(t)
 	code, body := postJSON(t, srv.URL+"/v1/domains/nomx.com/verify", "good", nil)
-	if code != 412 || body["verified"] != false {
-		t.Fatalf("want 412 not-verified (MX missing), got %d %v", code, body)
+	if code != 200 || body["verified"] != false {
+		t.Fatalf("want 200 not-verified (MX missing), got %d %v", code, body)
 	}
 	if body["mx"] != "missing" {
-		t.Fatalf("expected mx=missing diagnostic in 412 body, got %v", body)
+		t.Fatalf("expected mx=missing diagnostic in 200 body, got %v", body)
 	}
 }
 

--- a/internal/httpapi/spec_review_test.go
+++ b/internal/httpapi/spec_review_test.go
@@ -125,12 +125,18 @@ func TestSpecOutbound202Declared(t *testing.T) {
 	}
 }
 
-// MED-2 — verifyDomain must declare a 412 response (TXT not yet published).
-func TestSpecVerifyDomain412Declared(t *testing.T) {
+// verifyDomain must NOT declare a 412: a not-yet-published record is the normal
+// verified:false outcome, returned as 200. 412 (Precondition Failed) is reserved
+// for conditional-request failures; clients branch on the body's `verified`, not
+// the HTTP status.
+func TestSpecVerifyDomainNo412(t *testing.T) {
 	doc := renderSpec(t)
 	resp := operationResponses(t, doc, "verifyDomain")
-	if _, ok := resp["412"]; !ok {
-		t.Errorf("verifyDomain is missing a 412 response (missing TXT returns 412 at runtime); declared codes: %v", keysOf(resp))
+	if _, ok := resp["412"]; ok {
+		t.Errorf("verifyDomain must not declare a 412 response (not-yet-verified is a normal 200 with verified:false); declared codes: %v", keysOf(resp))
+	}
+	if _, ok := resp["200"]; !ok {
+		t.Errorf("verifyDomain must declare a 200 response (both verified and not-yet-verified return 200); declared codes: %v", keysOf(resp))
 	}
 }
 

--- a/sdks/python/src/e2a/v1/generated/api/domains_api.py
+++ b/sdks/python/src/e2a/v1/generated/api/domains_api.py
@@ -1148,7 +1148,7 @@ class DomainsApi:
     ) -> VerifyDomainView:
         """Verify a domain
 
-        Probe the domain's published DNS and, when the verification TXT is present, mark it verified. Returns the per-record diagnostic; a missing TXT yields 412.
+        Probe the domain's published DNS and, when the verification TXT (and inbound MX) are present, mark it verified. Always returns 200 with the per-record diagnostic — branch on the `verified` boolean in the body, not the HTTP status. A not-yet-published record is the normal `verified:false` outcome, not an error.
 
         :param domain: (required)
         :type domain: str
@@ -1184,7 +1184,6 @@ class DomainsApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "VerifyDomainView",
-            '412': "VerifyDomainView",
         }
         response_data = await self.api_client.call_api(
             *_param,
@@ -1216,7 +1215,7 @@ class DomainsApi:
     ) -> ApiResponse[VerifyDomainView]:
         """Verify a domain
 
-        Probe the domain's published DNS and, when the verification TXT is present, mark it verified. Returns the per-record diagnostic; a missing TXT yields 412.
+        Probe the domain's published DNS and, when the verification TXT (and inbound MX) are present, mark it verified. Always returns 200 with the per-record diagnostic — branch on the `verified` boolean in the body, not the HTTP status. A not-yet-published record is the normal `verified:false` outcome, not an error.
 
         :param domain: (required)
         :type domain: str
@@ -1252,7 +1251,6 @@ class DomainsApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "VerifyDomainView",
-            '412': "VerifyDomainView",
         }
         response_data = await self.api_client.call_api(
             *_param,
@@ -1284,7 +1282,7 @@ class DomainsApi:
     ) -> RESTResponseType:
         """Verify a domain
 
-        Probe the domain's published DNS and, when the verification TXT is present, mark it verified. Returns the per-record diagnostic; a missing TXT yields 412.
+        Probe the domain's published DNS and, when the verification TXT (and inbound MX) are present, mark it verified. Always returns 200 with the per-record diagnostic — branch on the `verified` boolean in the body, not the HTTP status. A not-yet-published record is the normal `verified:false` outcome, not an error.
 
         :param domain: (required)
         :type domain: str
@@ -1320,7 +1318,6 @@ class DomainsApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "VerifyDomainView",
-            '412': "VerifyDomainView",
         }
         response_data = await self.api_client.call_api(
             *_param,

--- a/sdks/typescript/src/v1/generated/apis/DomainsApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/DomainsApi.ts
@@ -192,7 +192,7 @@ export class DomainsApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
-     * Probe the domain\'s published DNS and, when the verification TXT is present, mark it verified. Returns the per-record diagnostic; a missing TXT yields 412.
+     * Probe the domain\'s published DNS and, when the verification TXT (and inbound MX) are present, mark it verified. Always returns 200 with the per-record diagnostic — branch on the `verified` boolean in the body, not the HTTP status. A not-yet-published record is the normal `verified:false` outcome, not an error.
      * Verify a domain
      * @param domain 
      */
@@ -395,13 +395,6 @@ export class DomainsApiResponseProcessor {
                 "VerifyDomainView", ""
             ) as VerifyDomainView;
             return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
-        }
-        if (isCodeInRange("412", response.httpStatusCode)) {
-            const body: VerifyDomainView = ObjectSerializer.deserialize(
-                ObjectSerializer.parse(await response.body.text(), contentType),
-                "VerifyDomainView", ""
-            ) as VerifyDomainView;
-            throw new ApiException<VerifyDomainView>(response.httpStatusCode, "Precondition Failed — the verification TXT record is not yet published.", body, response.headers);
         }
         if (isCodeInRange("0", response.httpStatusCode)) {
             const body: ErrorEnvelope = ObjectSerializer.deserialize(

--- a/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
@@ -845,7 +845,7 @@ export class ObjectDomainsApi {
     }
 
     /**
-     * Probe the domain\'s published DNS and, when the verification TXT is present, mark it verified. Returns the per-record diagnostic; a missing TXT yields 412.
+     * Probe the domain\'s published DNS and, when the verification TXT (and inbound MX) are present, mark it verified. Always returns 200 with the per-record diagnostic — branch on the `verified` boolean in the body, not the HTTP status. A not-yet-published record is the normal `verified:false` outcome, not an error.
      * Verify a domain
      * @param param the request object
      */
@@ -854,7 +854,7 @@ export class ObjectDomainsApi {
     }
 
     /**
-     * Probe the domain\'s published DNS and, when the verification TXT is present, mark it verified. Returns the per-record diagnostic; a missing TXT yields 412.
+     * Probe the domain\'s published DNS and, when the verification TXT (and inbound MX) are present, mark it verified. Always returns 200 with the per-record diagnostic — branch on the `verified` boolean in the body, not the HTTP status. A not-yet-published record is the normal `verified:false` outcome, not an error.
      * Verify a domain
      * @param param the request object
      */

--- a/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
@@ -932,7 +932,7 @@ export class ObservableDomainsApi {
     }
 
     /**
-     * Probe the domain\'s published DNS and, when the verification TXT is present, mark it verified. Returns the per-record diagnostic; a missing TXT yields 412.
+     * Probe the domain\'s published DNS and, when the verification TXT (and inbound MX) are present, mark it verified. Always returns 200 with the per-record diagnostic — branch on the `verified` boolean in the body, not the HTTP status. A not-yet-published record is the normal `verified:false` outcome, not an error.
      * Verify a domain
      * @param domain
      */
@@ -957,7 +957,7 @@ export class ObservableDomainsApi {
     }
 
     /**
-     * Probe the domain\'s published DNS and, when the verification TXT is present, mark it verified. Returns the per-record diagnostic; a missing TXT yields 412.
+     * Probe the domain\'s published DNS and, when the verification TXT (and inbound MX) are present, mark it verified. Always returns 200 with the per-record diagnostic — branch on the `verified` boolean in the body, not the HTTP status. A not-yet-published record is the normal `verified:false` outcome, not an error.
      * Verify a domain
      * @param domain
      */

--- a/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
@@ -667,7 +667,7 @@ export class PromiseDomainsApi {
     }
 
     /**
-     * Probe the domain\'s published DNS and, when the verification TXT is present, mark it verified. Returns the per-record diagnostic; a missing TXT yields 412.
+     * Probe the domain\'s published DNS and, when the verification TXT (and inbound MX) are present, mark it verified. Always returns 200 with the per-record diagnostic — branch on the `verified` boolean in the body, not the HTTP status. A not-yet-published record is the normal `verified:false` outcome, not an error.
      * Verify a domain
      * @param domain
      */
@@ -678,7 +678,7 @@ export class PromiseDomainsApi {
     }
 
     /**
-     * Probe the domain\'s published DNS and, when the verification TXT is present, mark it verified. Returns the per-record diagnostic; a missing TXT yields 412.
+     * Probe the domain\'s published DNS and, when the verification TXT (and inbound MX) are present, mark it verified. Always returns 200 with the per-record diagnostic — branch on the `verified` boolean in the body, not the HTTP status. A not-yet-published record is the normal `verified:false` outcome, not an error.
      * Verify a domain
      * @param domain
      */

--- a/sdks/typescript/test/v1/seed.ts
+++ b/sdks/typescript/test/v1/seed.ts
@@ -141,8 +141,8 @@ interface DnsRecord {
 /**
  * Seeder mints + verifies real domains and injects real inbound mail for one
  * scenario, tracking everything it creates for teardown. One instance per Runner.
- * Uses its OWN non-throwing fetch (the runner's RawApi throws on 4xx, but the
- * verify poll must read the 412 {verified:false} body while records propagate).
+ * Uses its OWN non-throwing fetch (the runner's RawApi throws on 4xx; verify
+ * always returns 200 with a {verified:false} body while records propagate).
  */
 export class Seeder {
   private readonly domains: string[] = [];

--- a/tests/e2e-prod/suites/10-domains.test.ts
+++ b/tests/e2e-prod/suites/10-domains.test.ts
@@ -69,7 +69,7 @@ test("domains: list includes newly-registered domain", async () => {
   assert.ok(found, `freshly-registered ${domain} not in list response`);
 });
 
-test("domains: verify unowned-DNS domain returns 412 (TXT missing) with per-record diagnostic", async () => {
+test("domains: verify unowned-DNS domain returns 200 with verified:false and per-record diagnostic", async () => {
   const domain = fakeDomain("verify");
   const c = await client.post("/v1/domains", { body: { domain } });
   if (c.status !== 201) {
@@ -77,22 +77,22 @@ test("domains: verify unowned-DNS domain returns 412 (TXT missing) with per-reco
     return;
   }
   track("domain", domain);
-  const v = await client.post<{ domain: string; mx?: unknown; spf?: unknown; dkim?: unknown }>(
+  const v = await client.post<{ domain: string; verified?: boolean; mx?: unknown; spf?: unknown; dkim?: unknown }>(
     `/v1/domains/${encodeURIComponent(domain)}/verify`,
     { body: {} },
   );
-  // Spec: 200 if verified, 412 if TXT missing. Real DNS for our fake domain has no
-  // matching TXT, so 412 is the expected path. Anything else (esp. 5xx) is a bug.
+  // Spec: always 200; branch on the body's `verified` boolean, not the status.
+  // Real DNS for our fake domain has no matching TXT, so verified:false is the
+  // expected path. Any non-2xx (esp. 5xx) is a bug.
   if (v.status >= 500) {
     fail(SUITE, "verify-500", `verify on unowned-DNS domain returned ${v.status}: ${v.raw.slice(0, 200)}`);
     return;
   }
-  assert.ok(v.status === 412 || v.status === 200, `verify expected 412 (or 200), got ${v.status}: ${v.raw.slice(0, 200)}`);
-  if (v.status === 200) {
-    info(SUITE, "verify-unexpected-200", `verify succeeded against ${domain} — unexpected (we don't control DNS)`);
-  } else {
-    // 412 should still carry the diagnostic body per spec.
-    assert.equal(v.body?.domain, domain, "412 body still includes domain field");
+  assert.equal(v.status, 200, `verify expected 200 (branch on .verified), got ${v.status}: ${v.raw.slice(0, 200)}`);
+  // The diagnostic body must always identify the domain.
+  assert.equal(v.body?.domain, domain, "200 body still includes domain field");
+  if (v.body?.verified === true) {
+    info(SUITE, "verify-unexpected-verified", `verify reported verified against ${domain} — unexpected (we don't control DNS)`);
   }
 });
 

--- a/tests/e2e-prod/suites/22-domain-lifecycle.test.ts
+++ b/tests/e2e-prod/suites/22-domain-lifecycle.test.ts
@@ -225,7 +225,8 @@ test("domain verify NEGATIVE control: an unpublished domain does NOT verify (gua
     // The discriminating assertion: verified MUST be false. A dev-mode
     // short-circuit would report verified=true here and fail this test.
     assert.equal(v.body?.verified, false, `unpublished domain must report verified=false, got ${v.status} ${v.raw.slice(0, 160)}`);
-    assert.equal(v.status, 412, `unpublished domain verify → 412 not-verified, got ${v.status}`);
+    // Not-yet-verified is a normal 200 (branch on .verified), not a 412.
+    assert.equal(v.status, 200, `unpublished domain verify → 200 with verified:false, got ${v.status}`);
   } finally {
     if (registered) {
       try {


### PR DESCRIPTION
## Pre-GA HTTP-semantics fix (user-approved, BREAKING)

`verifyDomain` (`POST /v1/domains/{domain}/verify`) misused **412 Precondition Failed** for the benign "DNS TXT/MX record not yet published" case. 412 is reserved for conditional-request (`If-Match` / `If-Unmodified-Since`) failures; SDKs, proxies, and caches special-case it. Both branches already return an identical `VerifyDomainView` whose `verified` boolean carries the real outcome, so the status was doing load-bearing work it shouldn't.

**Fix:** both the verified and not-yet-verified cases now return **200** with the `VerifyDomainView` body. Clients branch on `VerifyDomainView.verified` (and the per-record `mx`/`spf`/`dkim` diagnostics), never on the HTTP status. A not-yet-published record is the normal `verified:false` result, not an error.

## Changes
- **Handler** (`internal/httpapi/domains.go`): not-yet-verified branch returns 200; `verifyDomainOutput` drops its `Status` field (Huma defaults 200 for both cases); operation description + `Responses` map updated (412 response removed).
- **Spec** (`api/openapi.yaml`): regenerated via `make spec` — 412 removed, 200 documented for both cases, description says "branch on `verified`, not the HTTP status."
- **SDK codegen** (TS + Python): regenerated via `make generate-sdk`. Removes the generated 412 special-case — TS previously threw `ApiException` on 412; a not-yet-verified result is now a normal 200 body the caller inspects. Hand-written SDK wrappers, MCP tool, and CLI needed no change (MCP tool already documents "if `verified: false` comes back…"; CLI has no verify command).
- **Tests:** httpapi handler tests + `spec_review_test` gate flipped to expect 200 / assert **no** 412 (`TestSpecVerifyDomainNo412`); `tests/e2e-prod` suites 10 + 22 updated; `seed.ts` comment corrected.
- **Docs:** `docs/design/api-v1-redesign.md` MED-2 entry marked superseded.

## Verification
- `go build ./...`, `go vet ./internal/httpapi/` — clean
- `go test ./internal/httpapi/` — pass (fake in-memory Deps, no Postgres)
- `make spec` — golden clean; `make generate-sdk` — TS + Python regenerated
- TS SDK / MCP / CLI `tsc` builds — clean
- Python generated `domains_api.py` parses
- `tests/e2e-prod` `tsc --noEmit` — no new errors in edited files (pre-existing errors in unrelated suites 01/02 only)
- Grep-confirmed no stray 412 remains on the domain-verify path (only explanatory comments)
- **Deferred to CI:** live contract/e2e-prod suites (need a running server + Cloudflare zone); did not touch the shared `e2a_test` DB per concurrency guidance.

> **BREAKING (pre-GA):** clients that branched on the 412 status must now inspect `VerifyDomainView.verified`.

Note: codegen conflicts on the regenerated spec/SDK bases vs. other in-flight pre-GA PRs are expected and reconciled at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Btj6LswdbWqSgMavGJzBp