### PR TITLE
fix!: return 202 Accepted for enqueued async work (redeliver, outbound accepted) (BREAKING)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3031,7 +3031,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SendResultView"
-          description: Accepted — held for human approval (status=pending_review).
+          description: "Accepted — durably accepted but not yet delivered: status=accepted (queued for async submission; terminal outcome via GET/webhook events) or status=pending_review (held for human approval)."
         default:
           content:
             application/json:
@@ -3263,7 +3263,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SendResultView"
-          description: Accepted — held for human approval (status=pending_review).
+          description: "Accepted — durably accepted but not yet delivered: status=accepted (queued for async submission; terminal outcome via GET/webhook events) or status=pending_review (held for human approval)."
         default:
           content:
             application/json:
@@ -3364,7 +3364,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SendResultView"
-          description: Accepted — held for human approval (status=pending_review).
+          description: "Accepted — durably accepted but not yet delivered: status=accepted (queued for async submission; terminal outcome via GET/webhook events) or status=pending_review (held for human approval)."
         default:
           content:
             application/json:
@@ -3465,7 +3465,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/SendResultView"
-          description: Accepted — held for human approval (status=pending_review).
+          description: "Accepted — durably accepted but not yet delivered: status=accepted (queued for async submission; terminal outcome via GET/webhook events) or status=pending_review (held for human approval)."
         default:
           content:
             application/json:
@@ -3740,7 +3740,7 @@ paths:
         - events
   /v1/events/{id}/redeliver:
     post:
-      description: Re-enqueue webhook delivery for an event. With a webhook_id, replays to that subscriber; without, fans out to every originally-matched subscriber. Auto-deduplicated within a short window — receivers must dedup on event id.
+      description: "Re-enqueue webhook delivery for an event. With a webhook_id, replays to that subscriber; without, fans out to every originally-matched subscriber. Auto-deduplicated within a short window — receivers must dedup on event id. Returns 202 Accepted: the redelivery is durably enqueued for async submission, not delivered synchronously — the per-subscriber outcome surfaces via the delivery log, and each delivery's status is 'pending' (or 'scheduled' for the fan-out)."
       operationId: redeliverEvent
       parameters:
         - in: path
@@ -3755,12 +3755,12 @@ paths:
               $ref: "#/components/schemas/RedeliverEventRequest"
         required: true
       responses:
-        "200":
+        "202":
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/RedeliverView"
-          description: OK
+          description: Accepted
         default:
           content:
             application/json:

--- a/cli/src/exit.ts
+++ b/cli/src/exit.ts
@@ -2,11 +2,13 @@
 // CI lanes) branch on these instead of parsing output, so the values are
 // frozen once published — add new codes, never renumber.
 //
-// HELD exists because a held send is an HTTP 200: the API accepted the message
-// but parked it in the review queue (`status: "pending_review"`), so the
-// recipient got nothing. Scripts that treat "exit 0" as "delivered" would
-// silently report into a queue nobody reads — the exact failure mode that bit
-// the tether harness twice.
+// HELD exists because a held send is an HTTP 2xx success (202 Accepted): the API
+// accepted the message but parked it in the review queue (`status:
+// "pending_review"`), so the recipient got nothing. Scripts that treat "exit 0"
+// as "delivered" would silently report into a queue nobody reads — the exact
+// failure mode that bit the tether harness twice. The CLI branches on the
+// response body's `status`, not the HTTP code, so this holds regardless of
+// whether the outcome came back 200 (sent) or 202 (accepted/pending_review).
 export const EXIT = {
   OK: 0,
   /** Network, server, or unexpected error. */

--- a/docs/api.md
+++ b/docs/api.md
@@ -135,8 +135,10 @@ single message.
   `read_status`, `sort`, `from`, `subject_contains`, `conversation_id`, `labels`,
   `since`, `until`) and cursor pagination. Held outbound drafts appear with
   `status=pending_review`.
-- `POST …/messages` — send a new email (a new thread). `202` + `pending_review`
-  when the agent's protection policy holds it for review. The send result
+- `POST …/messages` — send a new email (a new thread). Returns `202 Accepted` for
+  every non-terminal outcome — `pending_review` when the agent's protection policy
+  holds it for review, or `accepted` when the async pipeline durably queues it —
+  and `200 OK` for the terminal-synchronous `sent`. The send result
   `status` is an open set — known values `accepted | sent | pending_review |
   review_approved | failed`. **Always branch on `status`, not the HTTP code.**
   `accepted` (async pipeline) means the message is durably persisted and queued;
@@ -225,7 +227,10 @@ semantics.
   and time range; cursor pagination.
 - `GET /v1/events/{id}` — one event (returns `410 Gone` past retention).
 - `POST /v1/events/{id}/redeliver` — re-enqueue delivery for an event (to one
-  webhook or all originally-matched). Receivers must dedup on event id.
+  webhook or all originally-matched). Returns `202 Accepted`: the redelivery is
+  durably enqueued for async submission (per-delivery `status: pending`, or
+  `scheduled` for the fan-out), not delivered synchronously. Receivers must dedup
+  on event id.
 
 ## Real-time delivery (WebSocket)
 

--- a/internal/e2e/edge_cases_e2e_test.go
+++ b/internal/e2e/edge_cases_e2e_test.go
@@ -43,9 +43,9 @@ func TestEdge_RedeliverEmptyMatched_NoCrash(t *testing.T) {
 	// length 0 without crashing.
 	resp := fix.httpPost("/v1/events/"+eventID+"/redeliver", apiKey, []byte(`{}`))
 	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != 202 {
 		b, _ := io.ReadAll(resp.Body)
-		t.Fatalf("empty-matched replay → %d (%s); want 200", resp.StatusCode, b)
+		t.Fatalf("empty-matched replay → %d (%s); want 202", resp.StatusCode, b)
 	}
 	var r struct {
 		Deliveries []map[string]any `json:"deliveries"`
@@ -142,7 +142,7 @@ func TestEdge_RedeliverIdempotency_FiveMinWindow(t *testing.T) {
 	// First replay.
 	body := fmt.Sprintf(`{"webhook_id":"%s"}`, webhookID)
 	resp1 := fix.httpPost("/v1/events/"+eventID+"/redeliver", apiKey, []byte(body))
-	if resp1.StatusCode != 200 {
+	if resp1.StatusCode != 202 {
 		raw, _ := io.ReadAll(resp1.Body)
 		t.Fatalf("first replay → %d (%s)", resp1.StatusCode, raw)
 	}
@@ -158,7 +158,7 @@ func TestEdge_RedeliverIdempotency_FiveMinWindow(t *testing.T) {
 
 	// Second replay within the window.
 	resp2 := fix.httpPost("/v1/events/"+eventID+"/redeliver", apiKey, []byte(body))
-	if resp2.StatusCode != 200 {
+	if resp2.StatusCode != 202 {
 		raw, _ := io.ReadAll(resp2.Body)
 		t.Fatalf("second replay → %d (%s)", resp2.StatusCode, raw)
 	}

--- a/internal/e2e/events_api_e2e_test.go
+++ b/internal/e2e/events_api_e2e_test.go
@@ -509,7 +509,7 @@ func TestEventsE2E_RedeliverFanOut(t *testing.T) {
 	}
 
 	resp := fix.httpPost("/v1/events/"+eventID+"/redeliver", apiKey, []byte(`{}`))
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != 202 {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("redeliver status %d: %s", resp.StatusCode, body)
 	}

--- a/internal/httpapi/events.go
+++ b/internal/httpapi/events.go
@@ -77,8 +77,9 @@ func (s *Server) registerEvents() {
 	huma.Register(s.API, huma.Operation{
 		OperationID: "redeliverEvent", Method: http.MethodPost, Path: "/v1/events/{id}/redeliver",
 		Summary: "Redeliver an event", Tags: []string{"events"},
-		Description: "Re-enqueue webhook delivery for an event. With a webhook_id, replays to that subscriber; without, fans out to every originally-matched subscriber. Auto-deduplicated within a short window — receivers must dedup on event id.",
-		Security:    []map[string][]string{{"bearer": {}}},
+		Description: "Re-enqueue webhook delivery for an event. With a webhook_id, replays to that subscriber; without, fans out to every originally-matched subscriber. Auto-deduplicated within a short window — receivers must dedup on event id. Returns 202 Accepted: the redelivery is durably enqueued for async submission, not delivered synchronously — the per-subscriber outcome surfaces via the delivery log, and each delivery's status is 'pending' (or 'scheduled' for the fan-out).",
+		Security:      []map[string][]string{{"bearer": {}}},
+		DefaultStatus: http.StatusAccepted,
 	}, s.handleRedeliverEvent)
 }
 
@@ -171,7 +172,7 @@ func (s *Server) handleRedeliverEvent(ctx context.Context, in *RedeliverEventInp
 					log.Printf("[events] replay %s enqueue failed (reconciler will retry): %v", dl, err)
 				}
 			}
-			return http.StatusOK, RedeliverView{DeliveryID: dl, EventID: in.ID, WebhookID: webhookID, Status: "pending"}, nil
+			return http.StatusAccepted, RedeliverView{DeliveryID: dl, EventID: in.ID, WebhookID: webhookID, Status: "pending"}, nil
 		}
 		// Bulk fan-out to every originally-matched subscriber.
 		deliveries := make([]RedeliverDelivery, 0, len(row.MatchedWebhookIDs))
@@ -190,7 +191,7 @@ func (s *Server) handleRedeliverEvent(ctx context.Context, in *RedeliverEventInp
 			}
 			deliveries = append(deliveries, RedeliverDelivery{WebhookID: whID, DeliveryID: dl, Status: "pending"})
 		}
-		return http.StatusOK, RedeliverView{EventID: in.ID, Status: "scheduled", Deliveries: deliveries}, nil
+		return http.StatusAccepted, RedeliverView{EventID: in.ID, Status: "scheduled", Deliveries: deliveries}, nil
 	})
 	if err != nil {
 		return nil, err

--- a/internal/httpapi/events_test.go
+++ b/internal/httpapi/events_test.go
@@ -90,7 +90,7 @@ func TestGetEventExpiredGone(t *testing.T) {
 func TestRedeliverEventTargeted(t *testing.T) {
 	srv := testServer(t)
 	code, body := postJSON(t, srv.URL+"/v1/events/evt_a/redeliver", "good", map[string]any{"webhook_id": "wh_1"})
-	if code != 200 || body["delivery_id"] != "whd_wh_1" || body["status"] != "pending" {
+	if code != 202 || body["delivery_id"] != "whd_wh_1" || body["status"] != "pending" {
 		t.Fatalf("targeted redeliver: %d %v", code, body)
 	}
 }
@@ -98,7 +98,7 @@ func TestRedeliverEventTargeted(t *testing.T) {
 func TestRedeliverEventFanout(t *testing.T) {
 	srv := testServer(t)
 	code, body := postJSON(t, srv.URL+"/v1/events/evt_a/redeliver", "good", map[string]any{})
-	if code != 200 || body["status"] != "scheduled" {
+	if code != 202 || body["status"] != "scheduled" {
 		t.Fatalf("fanout redeliver: %d %v", code, body)
 	}
 	dels, _ := body["deliveries"].([]any)
@@ -121,16 +121,16 @@ func TestEnqueueError_ReportsPendingNotFailure(t *testing.T) {
 		t.Fatalf("/test on enqueue error: want 200 + delivery_id, got %d %v", code, body)
 	}
 
-	// Targeted redeliver → 200 pending (not 500).
+	// Targeted redeliver → 202 pending (not 500).
 	code, body = postJSON(t, srv.URL+"/v1/events/evt_a/redeliver", "good", map[string]any{"webhook_id": "wh_1"})
-	if code != 200 || body["status"] != "pending" {
-		t.Fatalf("targeted redeliver on enqueue error: want 200 pending, got %d %v", code, body)
+	if code != 202 || body["status"] != "pending" {
+		t.Fatalf("targeted redeliver on enqueue error: want 202 pending, got %d %v", code, body)
 	}
 
-	// Fanout redeliver → 200, every delivery 'pending' (not 'skipped').
+	// Fanout redeliver → 202, every delivery 'pending' (not 'skipped').
 	code, body = postJSON(t, srv.URL+"/v1/events/evt_a/redeliver", "good", map[string]any{})
-	if code != 200 {
-		t.Fatalf("fanout redeliver on enqueue error: want 200, got %d %v", code, body)
+	if code != 202 {
+		t.Fatalf("fanout redeliver on enqueue error: want 202, got %d %v", code, body)
 	}
 	dels, _ := body["deliveries"].([]any)
 	if len(dels) == 0 {

--- a/internal/httpapi/outbound.go
+++ b/internal/httpapi/outbound.go
@@ -133,12 +133,15 @@ type sendOutput struct {
 }
 
 func (s *Server) registerOutbound() {
-	// 202 Accepted is the HITL-hold outcome of every outbound op: the message
-	// is queued as a pending_review draft rather than sent. Declared
-	// explicitly because Huma infers only the single DefaultStatus (200).
-	held202 := func() *huma.Response {
+	// 202 Accepted covers every non-terminal outbound outcome: the message was
+	// durably accepted but not yet delivered — either queued for async
+	// submission (status=accepted; the terminal sent/failed arrives via GET /
+	// webhook events) or held for human approval (status=pending_review).
+	// Declared explicitly because Huma infers only the single DefaultStatus
+	// (200, kept for the terminal-synchronous status=sent result).
+	accepted202 := func() *huma.Response {
 		return s.jsonResponse(reflect.TypeOf(SendResultView{}), "SendResultView",
-			"Accepted — held for human approval (status=pending_review).")
+			"Accepted — durably accepted but not yet delivered: status=accepted (queued for async submission; terminal outcome via GET/webhook events) or status=pending_review (held for human approval).")
 	}
 
 	huma.Register(s.API, huma.Operation{
@@ -147,7 +150,7 @@ func (s *Server) registerOutbound() {
 		Description:  "Send a new email from the agent named in the path (a new thread). The sender is the path agent — `reply`/`forward` are their own sub-resources. 202 + pending_review when the agent has HITL enabled. Honors Idempotency-Key.",
 		Security:     []map[string][]string{{"bearer": {}}},
 		MaxBodyBytes: maxOutboundBytes,
-		Responses:    map[string]*huma.Response{"202": held202(), "default": s.errorEnvelopeResponse()},
+		Responses:    map[string]*huma.Response{"202": accepted202(), "default": s.errorEnvelopeResponse()},
 	}, s.handleCreateMessage)
 
 	huma.Register(s.API, huma.Operation{
@@ -156,7 +159,7 @@ func (s *Server) registerOutbound() {
 		Description:  "Reply to a message (inbound or outbound); recipients and threading are derived from the original. Replying to a message the agent received targets its sender; replying to a message the agent sent continues the thread to its original recipients (`reply_all` also re-includes the original Cc). 202 when held for HITL.",
 		Security:     []map[string][]string{{"bearer": {}}},
 		MaxBodyBytes: maxOutboundBytes,
-		Responses:    map[string]*huma.Response{"202": held202(), "default": s.errorEnvelopeResponse()},
+		Responses:    map[string]*huma.Response{"202": accepted202(), "default": s.errorEnvelopeResponse()},
 	}, s.handleReply)
 
 	huma.Register(s.API, huma.Operation{
@@ -165,7 +168,7 @@ func (s *Server) registerOutbound() {
 		Description:  "Forward a message (inbound or outbound) to new recipients; the original is quoted and its attachments are carried over by default. Any attachments[] you supply are added on top of the originals. 202 when held for HITL.",
 		Security:     []map[string][]string{{"bearer": {}}},
 		MaxBodyBytes: maxOutboundBytes,
-		Responses:    map[string]*huma.Response{"202": held202(), "default": s.errorEnvelopeResponse()},
+		Responses:    map[string]*huma.Response{"202": accepted202(), "default": s.errorEnvelopeResponse()},
 	}, s.handleForward)
 
 	huma.Register(s.API, huma.Operation{
@@ -173,7 +176,7 @@ func (s *Server) registerOutbound() {
 		Summary: "Send a test email to the agent's own address", Tags: []string{"agents"},
 		Description: "Send a platform test email to the agent's own address to confirm inbound delivery. 202 when held for HITL.",
 		Security:    []map[string][]string{{"bearer": {}}},
-		Responses:   map[string]*huma.Response{"202": held202(), "default": s.errorEnvelopeResponse()},
+		Responses:   map[string]*huma.Response{"202": accepted202(), "default": s.errorEnvelopeResponse()},
 	}, s.handleTestSend)
 }
 
@@ -521,7 +524,7 @@ func (s *Server) deliver(ctx context.Context, user *identity.User, ag *identity.
 				raw = []byte("{}")
 			}
 			return s.deps.Idempotency.CompleteTx(ctx, tx, uid, nsKey, idempotency.CachedResponse{
-				StatusCode: http.StatusOK, ContentType: "application/json", Body: raw,
+				StatusCode: http.StatusAccepted, ContentType: "application/json", Body: raw,
 			})
 		}
 	}
@@ -554,11 +557,15 @@ func (s *Server) deliver(ctx context.Context, user *identity.User, ag *identity.
 		if res.Held {
 			return http.StatusAccepted, SendResultView{Status: "pending_review", MessageID: res.PendingMessageID, ApprovalExpiresAt: res.ApprovalExpiresAt}, nil
 		}
-		// Async accept (slice C): 200 with status=accepted. The body MUST match
-		// acceptedView (the idempotency cache is keyed to it) — no provider id /
-		// sent_as yet (the send hasn't happened; they surface via GET / webhooks).
+		// Async accept (slice C): 202 Accepted with status=accepted — the message
+		// is durably persisted and queued for async submission; the terminal
+		// outcome (sent/failed) arrives later via GET / webhooks, not this
+		// response. The body MUST match acceptedView (the idempotency cache is
+		// keyed to it) — no provider id / sent_as yet (the send hasn't happened).
+		// The cached StatusCode (idemCompleteTx, above) is likewise 202 so a
+		// replayed idempotent request returns the same 202, never a stale 200.
 		if res.Status == "accepted" {
-			return http.StatusOK, acceptedView(res.MessageID), nil
+			return http.StatusAccepted, acceptedView(res.MessageID), nil
 		}
 		return http.StatusOK, SendResultView{Status: "sent", MessageID: res.MessageID, ProviderMessageID: res.ProviderMessageID, SentAs: res.SentAs, Method: res.Method}, nil
 	})

--- a/internal/httpapi/outbound_idem_test.go
+++ b/internal/httpapi/outbound_idem_test.go
@@ -214,3 +214,55 @@ func TestSendTemplateIdempotentRetryAfterTemplateDelete(t *testing.T) {
 		t.Fatalf("DeliverOutbound ran %d times, want exactly 1 (retry must replay, not re-send)", deliveries)
 	}
 }
+
+// TestSendAccepted202AndIdempotentReplay pins the async-accept convention: an
+// enqueued (status=accepted) send returns 202 Accepted — not 200 — and a
+// byte-identical keyed retry REPLAYS the cached 202 (never a stale 200). The
+// 200-for-accepted status was baked into the idempotency cache, so this guards
+// both the live response and the cached-status replay.
+func TestSendAccepted202AndIdempotentReplay(t *testing.T) {
+	deliveries := 0
+	srv := httptest.NewServer(New(Deps{
+		Authenticator: func(r *http.Request) (*identity.User, error) { return &identity.User{ID: "u_1"}, nil },
+		GetAgent: func(ctx context.Context, address string) (*identity.AgentIdentity, error) {
+			return &identity.AgentIdentity{ID: address, Email: address, UserID: "u_1", DomainVerified: true}, nil
+		},
+		Idempotency: newMemIdem(),
+		DeliverOutbound: func(ctx context.Context, u *identity.User, ag *identity.AgentIdentity, req outbound.SendRequest, mt, rt string, ref *identity.Message, ic agent.AcceptIdemCompleter) (*agent.OutboundResult, *agent.OutboundError) {
+			deliveries++
+			// Async pipeline: durably persisted + queued, terminal outcome later.
+			return &agent.OutboundResult{MessageID: "msg_acc", Status: "accepted", Method: "smtp"}, nil
+		},
+	}))
+	t.Cleanup(srv.Close)
+
+	rawBody := []byte(`{"to":["alice@x.com"],"subject":"Hi","text":"hello"}`)
+	send := func() (int, map[string]any) {
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/agents/a%40acme.com/messages", bytes.NewReader(rawBody))
+		req.Header.Set("Authorization", "Bearer good")
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Idempotency-Key", "acc-key-1")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		var body map[string]any
+		_ = json.NewDecoder(resp.Body).Decode(&body)
+		return resp.StatusCode, body
+	}
+
+	code, body := send()
+	if code != http.StatusAccepted || body["status"] != "accepted" || body["message_id"] != "msg_acc" {
+		t.Fatalf("first send: want 202 accepted msg_acc, got %d %v", code, body)
+	}
+
+	// Byte-identical retry must replay the cached 202 — not a stale 200.
+	code, body = send()
+	if code != http.StatusAccepted || body["status"] != "accepted" || body["message_id"] != "msg_acc" {
+		t.Fatalf("keyed retry: want replayed 202 accepted, got %d %v", code, body)
+	}
+	if deliveries != 1 {
+		t.Fatalf("DeliverOutbound ran %d times, want exactly 1 (retry must replay, not re-enqueue)", deliveries)
+	}
+}

--- a/sdks/python/src/e2a/v1/generated/api/events_api.py
+++ b/sdks/python/src/e2a/v1/generated/api/events_api.py
@@ -702,7 +702,7 @@ class EventsApi:
     ) -> RedeliverView:
         """Redeliver an event
 
-        Re-enqueue webhook delivery for an event. With a webhook_id, replays to that subscriber; without, fans out to every originally-matched subscriber. Auto-deduplicated within a short window — receivers must dedup on event id.
+        Re-enqueue webhook delivery for an event. With a webhook_id, replays to that subscriber; without, fans out to every originally-matched subscriber. Auto-deduplicated within a short window — receivers must dedup on event id. Returns 202 Accepted: the redelivery is durably enqueued for async submission, not delivered synchronously — the per-subscriber outcome surfaces via the delivery log, and each delivery's status is 'pending' (or 'scheduled' for the fan-out).
 
         :param id: (required)
         :type id: str
@@ -740,7 +740,7 @@ class EventsApi:
         )
 
         _response_types_map: Dict[str, Optional[str]] = {
-            '200': "RedeliverView",
+            '202': "RedeliverView",
         }
         response_data = await self.api_client.call_api(
             *_param,
@@ -773,7 +773,7 @@ class EventsApi:
     ) -> ApiResponse[RedeliverView]:
         """Redeliver an event
 
-        Re-enqueue webhook delivery for an event. With a webhook_id, replays to that subscriber; without, fans out to every originally-matched subscriber. Auto-deduplicated within a short window — receivers must dedup on event id.
+        Re-enqueue webhook delivery for an event. With a webhook_id, replays to that subscriber; without, fans out to every originally-matched subscriber. Auto-deduplicated within a short window — receivers must dedup on event id. Returns 202 Accepted: the redelivery is durably enqueued for async submission, not delivered synchronously — the per-subscriber outcome surfaces via the delivery log, and each delivery's status is 'pending' (or 'scheduled' for the fan-out).
 
         :param id: (required)
         :type id: str
@@ -811,7 +811,7 @@ class EventsApi:
         )
 
         _response_types_map: Dict[str, Optional[str]] = {
-            '200': "RedeliverView",
+            '202': "RedeliverView",
         }
         response_data = await self.api_client.call_api(
             *_param,
@@ -844,7 +844,7 @@ class EventsApi:
     ) -> RESTResponseType:
         """Redeliver an event
 
-        Re-enqueue webhook delivery for an event. With a webhook_id, replays to that subscriber; without, fans out to every originally-matched subscriber. Auto-deduplicated within a short window — receivers must dedup on event id.
+        Re-enqueue webhook delivery for an event. With a webhook_id, replays to that subscriber; without, fans out to every originally-matched subscriber. Auto-deduplicated within a short window — receivers must dedup on event id. Returns 202 Accepted: the redelivery is durably enqueued for async submission, not delivered synchronously — the per-subscriber outcome surfaces via the delivery log, and each delivery's status is 'pending' (or 'scheduled' for the fan-out).
 
         :param id: (required)
         :type id: str
@@ -882,7 +882,7 @@ class EventsApi:
         )
 
         _response_types_map: Dict[str, Optional[str]] = {
-            '200': "RedeliverView",
+            '202': "RedeliverView",
         }
         response_data = await self.api_client.call_api(
             *_param,

--- a/sdks/typescript/src/v1/generated/apis/EventsApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/EventsApi.ts
@@ -143,7 +143,7 @@ export class EventsApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
-     * Re-enqueue webhook delivery for an event. With a webhook_id, replays to that subscriber; without, fans out to every originally-matched subscriber. Auto-deduplicated within a short window — receivers must dedup on event id.
+     * Re-enqueue webhook delivery for an event. With a webhook_id, replays to that subscriber; without, fans out to every originally-matched subscriber. Auto-deduplicated within a short window — receivers must dedup on event id. Returns 202 Accepted: the redelivery is durably enqueued for async submission, not delivered synchronously — the per-subscriber outcome surfaces via the delivery log, and each delivery\'s status is \'pending\' (or \'scheduled\' for the fan-out).
      * Redeliver an event
      * @param id 
      * @param redeliverEventRequest 
@@ -283,7 +283,7 @@ export class EventsApiResponseProcessor {
      */
      public async redeliverEventWithHttpInfo(response: ResponseContext): Promise<HttpInfo<RedeliverView >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
-        if (isCodeInRange("200", response.httpStatusCode)) {
+        if (isCodeInRange("202", response.httpStatusCode)) {
             const body: RedeliverView = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "RedeliverView", ""

--- a/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
@@ -996,7 +996,7 @@ export class ObjectEventsApi {
     }
 
     /**
-     * Re-enqueue webhook delivery for an event. With a webhook_id, replays to that subscriber; without, fans out to every originally-matched subscriber. Auto-deduplicated within a short window — receivers must dedup on event id.
+     * Re-enqueue webhook delivery for an event. With a webhook_id, replays to that subscriber; without, fans out to every originally-matched subscriber. Auto-deduplicated within a short window — receivers must dedup on event id. Returns 202 Accepted: the redelivery is durably enqueued for async submission, not delivered synchronously — the per-subscriber outcome surfaces via the delivery log, and each delivery\'s status is \'pending\' (or \'scheduled\' for the fan-out).
      * Redeliver an event
      * @param param the request object
      */
@@ -1005,7 +1005,7 @@ export class ObjectEventsApi {
     }
 
     /**
-     * Re-enqueue webhook delivery for an event. With a webhook_id, replays to that subscriber; without, fans out to every originally-matched subscriber. Auto-deduplicated within a short window — receivers must dedup on event id.
+     * Re-enqueue webhook delivery for an event. With a webhook_id, replays to that subscriber; without, fans out to every originally-matched subscriber. Auto-deduplicated within a short window — receivers must dedup on event id. Returns 202 Accepted: the redelivery is durably enqueued for async submission, not delivered synchronously — the per-subscriber outcome surfaces via the delivery log, and each delivery\'s status is \'pending\' (or \'scheduled\' for the fan-out).
      * Redeliver an event
      * @param param the request object
      */

--- a/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
@@ -1064,7 +1064,7 @@ export class ObservableEventsApi {
     }
 
     /**
-     * Re-enqueue webhook delivery for an event. With a webhook_id, replays to that subscriber; without, fans out to every originally-matched subscriber. Auto-deduplicated within a short window — receivers must dedup on event id.
+     * Re-enqueue webhook delivery for an event. With a webhook_id, replays to that subscriber; without, fans out to every originally-matched subscriber. Auto-deduplicated within a short window — receivers must dedup on event id. Returns 202 Accepted: the redelivery is durably enqueued for async submission, not delivered synchronously — the per-subscriber outcome surfaces via the delivery log, and each delivery\'s status is \'pending\' (or \'scheduled\' for the fan-out).
      * Redeliver an event
      * @param id
      * @param redeliverEventRequest
@@ -1090,7 +1090,7 @@ export class ObservableEventsApi {
     }
 
     /**
-     * Re-enqueue webhook delivery for an event. With a webhook_id, replays to that subscriber; without, fans out to every originally-matched subscriber. Auto-deduplicated within a short window — receivers must dedup on event id.
+     * Re-enqueue webhook delivery for an event. With a webhook_id, replays to that subscriber; without, fans out to every originally-matched subscriber. Auto-deduplicated within a short window — receivers must dedup on event id. Returns 202 Accepted: the redelivery is durably enqueued for async submission, not delivered synchronously — the per-subscriber outcome surfaces via the delivery log, and each delivery\'s status is \'pending\' (or \'scheduled\' for the fan-out).
      * Redeliver an event
      * @param id
      * @param redeliverEventRequest

--- a/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
@@ -764,7 +764,7 @@ export class PromiseEventsApi {
     }
 
     /**
-     * Re-enqueue webhook delivery for an event. With a webhook_id, replays to that subscriber; without, fans out to every originally-matched subscriber. Auto-deduplicated within a short window — receivers must dedup on event id.
+     * Re-enqueue webhook delivery for an event. With a webhook_id, replays to that subscriber; without, fans out to every originally-matched subscriber. Auto-deduplicated within a short window — receivers must dedup on event id. Returns 202 Accepted: the redelivery is durably enqueued for async submission, not delivered synchronously — the per-subscriber outcome surfaces via the delivery log, and each delivery\'s status is \'pending\' (or \'scheduled\' for the fan-out).
      * Redeliver an event
      * @param id
      * @param redeliverEventRequest
@@ -776,7 +776,7 @@ export class PromiseEventsApi {
     }
 
     /**
-     * Re-enqueue webhook delivery for an event. With a webhook_id, replays to that subscriber; without, fans out to every originally-matched subscriber. Auto-deduplicated within a short window — receivers must dedup on event id.
+     * Re-enqueue webhook delivery for an event. With a webhook_id, replays to that subscriber; without, fans out to every originally-matched subscriber. Auto-deduplicated within a short window — receivers must dedup on event id. Returns 202 Accepted: the redelivery is durably enqueued for async submission, not delivered synchronously — the per-subscriber outcome surfaces via the delivery log, and each delivery\'s status is \'pending\' (or \'scheduled\' for the fan-out).
      * Redeliver an event
      * @param id
      * @param redeliverEventRequest


### PR DESCRIPTION
## What

Adopt a consistent pre-GA convention across the `/v1` surface: **an operation that durably enqueues async work and returns a non-terminal `accepted` outcome responds `202 Accepted`, not `200`.** Terminal-synchronous outcomes keep `200`. `pending_review` already returned `202`; this aligns the two remaining violators. Deliberate, user-approved pre-GA fix.

## Breaking wire changes

- **`POST /v1/events/{id}/redeliver`: `200` → `202`.** The redelivery is durably enqueued for async submission (per-delivery `status: pending`, or `scheduled` for the fan-out), not delivered synchronously. Both branches are enqueues, so this is the operation's `DefaultStatus`.
- **`POST /v1/agents/{email}/messages` (+ `/reply`, `/forward`, `/test`): the `accepted` outcome → `202`** (was `200`). `accepted` = async pipeline durably persisted the message and queued it; the terminal `sent`/`failed` arrives later via `GET /v1/messages/{id}` or the `email.sent` / `email.failed` webhook events. **The terminal-synchronous `sent` result stays `200`.** `pending_review` unchanged (already `202`).

Clients should already branch on `body.status`, never the HTTP code (documented as an open set) — so this is a status-code alignment, not a semantic shift.

## Idempotency-cache subtlety

The `200` for `accepted` was baked into the Idempotency-Key cache — `deliver()`'s `idemCompleteTx` (`CompleteTx`) records the accept-time status atomically with the message insert + send-job enqueue. Both the live `fn` return **and** the cached `StatusCode` are now `http.StatusAccepted`, so a replayed idempotent send returns the same `202`, never a stale `200`. New `TestSendAccepted202AndIdempotentReplay` pins both the live response and the cached replay. (Latent until the async pipeline is enabled, but fixed now so it's correct pre-freeze.) The redeliver auto-idempotency cache likewise records `202`.

## Coordinated across every surface

- Server handlers (`internal/httpapi/events.go`, `outbound.go`).
- `api/openapi.yaml` regenerated (`make spec`): redeliver success is `202`; send/reply/forward/test `202` response documents both `accepted` and `pending_review`, `200` kept for `sent`.
- TS + Python SDK generated bases regenerated (`make generate-sdk`): redeliver now maps `202` → `RedeliverView`. Hand-written SDK error layers already treat any non-2xx as the error boundary, so `202` is success — no `200`-special-casing to fix.
- CLI branches on `body.status` (not the HTTP code); corrected the stale "held send is HTTP 200" comment in `cli/src/exit.ts` to 2xx/202.
- MCP delegates to the SDK; no change needed.
- `docs/api.md` updated for both endpoints.

## Tests

- `go build ./...` clean; `make spec` clean (no drift); `make generate-sdk` clean.
- Go unit + e2e tests asserting `200` on the redeliver / accepted paths flipped to `202`; added the accepted-202 + idempotent-replay test.
- TS SDK (119), CLI (108), MCP (155) and Python SDK (195) unit suites pass.
- Postgres-backed e2e (`//go:build integration`) tests compile; execution deferred to CI (shared test DB not touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Btj6LswdbWqSgMavGJzBp