### PR TITLE
docs(security): fix security contact email + enable private vuln reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@ For what e2a stores, how long it lives, log handling, and the user/operator data
 
 ## Reporting a vulnerability
 
-Email **security@mnexa.ai** with:
+Email **josh@mnexa.ai** with:
 
 - A description of the issue
 - Steps to reproduce (or a proof-of-concept)


### PR DESCRIPTION
## What

- Change the security contact in `SECURITY.md` from `security@mnexa.ai` (bouncing) to `josh@mnexa.ai`.
- Enabled GitHub **private vulnerability reporting** on the repo (already done via API), so the `security/advisories/new` link in `SECURITY.md` resolves instead of 404ing.

## Why

An external reporter (Rajnish Tiwari) attempted to privately disclose a security issue but both channels were broken: the listed email bounced and the advisory link 404'd. This restores both reporting paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)