### PR TITLE
fix(python-sdk): thread cursors through all list methods + manual page primitive (pagination parity)

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 4.2.0
+
+Additive, no breaking changes.
+
+### Fixed
+- **`templates.list()` / `templates.list_starters()` silently truncated to the
+  first page.** Both ignored the server's `next_cursor` and stopped after one
+  request, dropping every template/starter past page one. They now thread the
+  cursor and auto-page to completion like every other `.list()` (TS SDK
+  parity), and accept a `limit=` per-page size.
+
+### Added
+- **`AutoPager.page(cursor=None)`** — the manual, caller-driven pagination
+  primitive (parity with the TS SDK's `pager.page()`): fetch a SINGLE page and
+  get back a `Page` of `items` + `next_cursor`. Pass the previous page's
+  `next_cursor` to resume (e.g. checkpoint/restart from a queue); a `None`
+  `next_cursor` in the result means there are no more pages. The page size is
+  the `limit` baked into the list call that produced the pager.
+
 ## 4.1.0
 
 Additive, no breaking changes.

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -146,6 +146,18 @@ List methods return an `AutoPager` — async-iterate it, or use
 `await pager.to_list(limit=N)` (the limit is required, to bound memory) or
 `await pager.for_each(fn)` (return `False` to stop early).
 
+For manual, caller-driven pagination (e.g. checkpoint/resume from a queue), use
+`await pager.page(cursor)`: it fetches a SINGLE page and returns a `Page` of
+`items` + `next_cursor`. Omit the cursor for the first page and pass the
+previous page's `next_cursor` to resume; a `None` `next_cursor` means there are
+no more pages.
+
+```python
+page = await client.messages.list("bot@agents.e2a.dev", limit=100).page()
+process(page.items)
+checkpoint(page.next_cursor)  # resume later with .page(saved_cursor)
+```
+
 ## WebSocket (real-time delivery for local agents)
 
 ```python

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "e2a"
-version = "4.1.0"
+version = "4.2.0"
 description = "Python SDK for the e2a protocol — email-to-agent authentication"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdks/python/src/e2a/v1/client.py
+++ b/sdks/python/src/e2a/v1/client.py
@@ -446,14 +446,16 @@ class TemplatesResource:
         self._api = api
         self._c = client
 
-    def list(self) -> AutoPager[TemplateSummaryView]:
+    def list(self, *, limit: Optional[int] = None) -> AutoPager[TemplateSummaryView]:
         """List the account's stored templates, newest first. Summary rows only
         (no text/html sources) — ``get(id)`` returns the full sources."""
 
-        async def fetch(_cursor: Optional[str]) -> Page:
-            resp = await self._c._read(lambda h: self._api.list_templates(_headers=h))
-            # No cursor param: single-page at GA — see AgentsResource.list.
-            return _page(resp.items)
+        # Cursor-paginated: the AutoPager walks next_cursor to completion.
+        async def fetch(cursor: Optional[str]) -> Page:
+            resp = await self._c._read(
+                lambda h: self._api.list_templates(cursor=cursor, limit=limit, _headers=h)
+            )
+            return _page(resp.items, resp.next_cursor)
 
         return AutoPager(fetch)
 
@@ -492,15 +494,17 @@ class TemplatesResource:
         req = _coerce(ValidateTemplateRequest, body)
         return await self._c._read(lambda h: self._api.validate_template(req, _headers=h))
 
-    def list_starters(self) -> AutoPager[StarterTemplateView]:
+    def list_starters(self, *, limit: Optional[int] = None) -> AutoPager[StarterTemplateView]:
         """List the pre-built starter templates shipped with the deployment
         (catalog metadata + variables; ``get_starter(alias)`` adds the full body
         sources)."""
 
-        async def fetch(_cursor: Optional[str]) -> Page:
-            resp = await self._c._read(lambda h: self._api.list_starter_templates(_headers=h))
-            # No cursor param: single-page at GA — see AgentsResource.list.
-            return _page(resp.items)
+        # Cursor-paginated: the AutoPager walks next_cursor to completion.
+        async def fetch(cursor: Optional[str]) -> Page:
+            resp = await self._c._read(
+                lambda h: self._api.list_starter_templates(cursor=cursor, limit=limit, _headers=h)
+            )
+            return _page(resp.items, resp.next_cursor)
 
         return AutoPager(fetch)
 

--- a/sdks/python/src/e2a/v1/pagination.py
+++ b/sdks/python/src/e2a/v1/pagination.py
@@ -75,6 +75,22 @@ class AutoPager(Generic[T]):
                 seen.add(cursor)
             cursor = nxt
 
+    async def page(self, cursor: Optional[str] = None) -> "Page[T]":
+        """Fetch a SINGLE page for caller-driven pagination: pass the previous
+        page's ``next_cursor`` (omit for the first page) and get back a
+        :class:`Page` of ``items`` + ``next_cursor``. A ``None`` ``next_cursor``
+        in the result means there are no more pages. This is the primitive
+        behind the cursor+limit shape the MCP tools expose and is available to
+        SDK users who want manual paging (e.g. checkpoint/resume from a queue)
+        instead of ``async for`` / ``to_list``. The page size is governed by the
+        ``limit`` baked into the list call that produced this pager."""
+        p = await self._fetch_page(cursor or None)
+        # Normalize a null/empty next_cursor to None (= no more pages), matching
+        # the iterator's own `not nxt` termination. A bare passthrough would leak
+        # an empty-string cursor as a truthy "more pages".
+        nxt = p.next_cursor
+        return Page(items=p.items or [], next_cursor=nxt if nxt else None)
+
     async def to_list(self, *, limit: int) -> List[T]:
         """Collect up to ``limit`` items. The limit is required — it caps memory
         for an inbox that could page indefinitely."""

--- a/sdks/python/tests/test_v1_client.py
+++ b/sdks/python/tests/test_v1_client.py
@@ -419,8 +419,8 @@ async def test_suppressions_list_threads_cursor(httpx_mock):
 
 
 # ── pagination: keyset-cursor list endpoints ────────────────────────
-# agents/domains/webhooks/deliveries/api-keys are all keyset-paginated on
-# (created_at, id) now — the AutoPager must thread next_cursor to completion,
+# agents/domains/webhooks/deliveries/api-keys/templates/starters are all
+# keyset-paginated — the AutoPager must thread next_cursor to completion,
 # exactly like messages/events/suppressions. This locks in the
 # consistent-pagination contract (no more silent single-page cap).
 
@@ -459,8 +459,20 @@ async def test_suppressions_list_threads_cursor(httpx_mock):
             lambda c: c.account.api_keys.list(),
             lambda r: r.id,
         ),
+        (
+            {"items": [_valid(TemplateSummaryView, id="tmpl_1")], "next_cursor": "cur_2"},
+            {"items": [_valid(TemplateSummaryView, id="tmpl_2")], "next_cursor": None},
+            lambda c: c.templates.list(),
+            lambda r: r.id,
+        ),
+        (
+            {"items": [_valid(StarterTemplateView, alias="welcome")], "next_cursor": "cur_2"},
+            {"items": [_valid(StarterTemplateView, alias="digest")], "next_cursor": None},
+            lambda c: c.templates.list_starters(),
+            lambda r: r.alias,
+        ),
     ],
-    ids=["agents", "domains", "webhooks", "deliveries", "api_keys"],
+    ids=["agents", "domains", "webhooks", "deliveries", "api_keys", "templates", "starters"],
 )
 async def test_keyset_lists_thread_cursor(httpx_mock, page1, page2, lister, key):
     httpx_mock.add_response(json=page1)
@@ -473,34 +485,57 @@ async def test_keyset_lists_thread_cursor(httpx_mock, page1, page2, lister, key)
     assert "cursor=cur_2" in str(reqs[1].url)
 
 
-# ── pagination: cursorless (single-page) list endpoints ─────────────
-# templates + the starter catalog stay single-page at GA (beta shapes): the
-# AutoPager must NOT thread a next_cursor even if the server echoes one, so it
-# stops after exactly one request. Guards against templates accidentally
-# picking up keyset threading like the endpoints above.
+# ── pagination: multi-page walk + manual page() resume ──────────────
+# End-to-end guard on the two properties auto-pagination must hold: a full
+# multi-page walk yields every item exactly once (no loss, no dupes), and the
+# manual `page(cursor)` primitive lets a caller checkpoint on next_cursor and
+# resume mid-listing (parity with the TS SDK's `pager.page()`).
 
 
 @pytest.mark.anyio
-@pytest.mark.parametrize(
-    "fixture, lister",
-    [
-        (
-            {"items": [_valid(TemplateSummaryView, id="tmpl_1")], "next_cursor": "IGNORE_ME"},
-            lambda c: c.templates.list(),
-        ),
-        (
-            {"items": [_valid(StarterTemplateView, alias="welcome")], "next_cursor": "IGNORE_ME"},
-            lambda c: c.templates.list_starters(),
-        ),
-    ],
-    ids=["templates", "starters"],
-)
-async def test_cursorless_lists_stop_after_one_page(httpx_mock, fixture, lister):
-    httpx_mock.add_response(json=fixture)
+async def test_templates_list_walks_all_pages_no_loss_no_dupes(httpx_mock):
+    httpx_mock.add_response(
+        json={"items": [_valid(TemplateSummaryView, id="tmpl_1"), _valid(TemplateSummaryView, id="tmpl_2")], "next_cursor": "cur_2"}
+    )
+    httpx_mock.add_response(
+        json={"items": [_valid(TemplateSummaryView, id="tmpl_3")], "next_cursor": "cur_3"}
+    )
+    httpx_mock.add_response(
+        json={"items": [_valid(TemplateSummaryView, id="tmpl_4")], "next_cursor": None}
+    )
     async with _client() as c:
-        items = await lister(c).to_list(limit=100)
-    assert len(items) == 1
-    assert len(httpx_mock.get_requests()) == 1
+        items = await c.templates.list(limit=2).to_list(limit=100)
+    ids = [t.id for t in items]
+    assert ids == ["tmpl_1", "tmpl_2", "tmpl_3", "tmpl_4"]  # ordered, no loss
+    assert len(set(ids)) == len(ids)  # no dupes
+    reqs = httpx_mock.get_requests()
+    assert len(reqs) == 3
+    assert "cursor" not in str(reqs[0].url)
+    assert "cursor=cur_2" in str(reqs[1].url) and "limit=2" in str(reqs[1].url)
+    assert "cursor=cur_3" in str(reqs[2].url)
+
+
+@pytest.mark.anyio
+async def test_manual_page_resumes_from_cursor(httpx_mock):
+    # A queue-driven consumer checkpoints next_cursor and resumes later — the
+    # second fetch must carry the stored cursor, and the last page must
+    # normalize its next_cursor to None.
+    httpx_mock.add_response(
+        json={"items": [_valid(AgentView, email="a@test.dev")], "next_cursor": "cur_2"}
+    )
+    async with _client() as c:
+        p1 = await c.agents.list(limit=1).page()
+    assert [a.email for a in p1.items] == ["a@test.dev"]
+    assert p1.next_cursor == "cur_2"  # checkpoint this
+
+    httpx_mock.add_response(
+        json={"items": [_valid(AgentView, email="b@test.dev")], "next_cursor": ""}
+    )
+    async with _client() as c:
+        p2 = await c.agents.list(limit=1).page(p1.next_cursor)  # resume
+    assert [a.email for a in p2.items] == ["b@test.dev"]
+    assert p2.next_cursor is None  # ""/null both normalize to None = done
+    assert "cursor=cur_2" in str(httpx_mock.get_requests()[-1].url)
 
 
 # ── templates (beta) ────────────────────────────────────────────────

--- a/sdks/python/tests/test_v1_pagination.py
+++ b/sdks/python/tests/test_v1_pagination.py
@@ -27,6 +27,40 @@ async def test_iterates_all_items_until_null_cursor():
 
 
 @pytest.mark.anyio
+async def test_page_fetches_one_page_and_surfaces_next_cursor():
+    # Caller-driven pagination: fetch a single page, checkpoint next_cursor,
+    # resume from it (parity with the TS SDK's `pager.page()`).
+    pager = AutoPager(make_pages(THREE_PAGES))
+    p1 = await pager.page()  # first page (no cursor)
+    assert list(p1.items) == [1, 2]
+    assert p1.next_cursor == "c2"
+    p2 = await pager.page(p1.next_cursor)  # follow the cursor
+    assert list(p2.items) == [3, 4]
+    assert p2.next_cursor == "c3"
+    p3 = await pager.page(p2.next_cursor)
+    assert list(p3.items) == [5]
+    assert p3.next_cursor is None  # null → last page
+
+
+@pytest.mark.anyio
+async def test_page_treats_empty_string_cursor_as_first_page():
+    pager = AutoPager(make_pages(THREE_PAGES))
+    assert list((await pager.page("")).items) == [1, 2]
+
+
+@pytest.mark.anyio
+async def test_page_normalizes_empty_next_cursor_to_none():
+    # A non-conforming server could return "" instead of null; page() must
+    # treat it as "no more pages" so `if page.next_cursor:` works.
+    async def fetch(_cursor):
+        return Page(items=[9], next_cursor="")
+
+    pager = AutoPager(fetch)
+    p = await pager.page()
+    assert p.next_cursor is None
+
+
+@pytest.mark.anyio
 async def test_to_list_respects_limit():
     pager = AutoPager(make_pages(THREE_PAGES))
     assert await pager.to_list(limit=3) == [1, 2, 3]

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -374,7 +374,7 @@ wheels = [
 
 [[package]]
 name = "e2a"
-version = "3.0.0"
+version = "4.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
@@ -414,7 +414,7 @@ requires-dist = [
     { name = "twine", marker = "extra == 'dev'" },
     { name = "typing-extensions", specifier = ">=4.7" },
     { name = "urllib3", specifier = ">=1.25" },
-    { name = "websockets", marker = "extra == 'ws'", specifier = ">=12" },
+    { name = "websockets", marker = "extra == 'ws'", specifier = ">=14" },
 ]
 provides-extras = ["dev", "ws"]
 


### PR DESCRIPTION
GA-review Tier-2 items **#15/#36** (silent truncation) + **#35** (no manual page primitive). Python-SDK-only — no Go/spec/TS/codegen changes.

## Data-loss bug (#15/#36)

`templates.list()` and `templates.list_starters()` ignored the server's `next_cursor` and stopped after exactly one request — **silently dropping every template/starter past page one**. The server and the generated Python base (`list_templates` / `list_starter_templates`) already accepted `cursor`+`limit`; only the hand-written wrappers lagged, behind a stale "single-page at GA" comment. The TS SDK has auto-paged these since the keyset-pagination batch, so this was an SDK-symmetry violation.

Both now thread the cursor, accept `limit=`, and auto-page to completion like every other `.list()`.

### Audit — every hand-written Python `.list*()` vs `sdks/typescript/src/v1/client.ts`

| Resource | Verdict |
|---|---|
| `agents.list` | ok (cursor+limit) |
| `messages.list` | ok |
| `reviews.list` | ok |
| `templates.list` | **fixed** — dropped cursor, no limit |
| `templates.list_starters` | **fixed** — dropped cursor, no limit |
| `conversations.list` | ok |
| `domains.list` | ok |
| `events.list` | ok |
| `webhooks.list` | ok |
| `webhooks.deliveries` | ok |
| `account.suppressions.list` | ok — threads cursor; no-limit signature matches TS |
| `account.api_keys.list` | ok |

## Manual page primitive (#35)

`AutoPager.page(cursor=None)` — parity with the TS pager's `page()`: fetches a **single** page and returns `Page(items, next_cursor)` so queue-driven consumers can checkpoint on `next_cursor` and resume later instead of `async for`/`to_list`. Same normalization as TS: `""` in → first page; `""`/null out → `None` (= no more pages). Page size = the `limit` baked into the list call that produced the pager.

## Tests

- `tests/test_v1_pagination.py`: three new `page()` unit tests mirroring the TS `pagination.test.ts` trio (single-page fetch + cursor follow, empty-string cursor = first page, empty next_cursor → `None`).
- `tests/test_v1_client.py`: deleted the `test_cursorless_lists_stop_after_one_page` lock-in of the buggy behavior; templates/starters join the keyset cursor-threading matrix; new 3-page templates walk (ordered, no loss, no dupes, `cursor`+`limit` asserted on the wire) and a `page()` checkpoint/resume test through a real resource.
- `uv run pytest`: **206 passed, 18 skipped** (skips pre-existing).

## Version

Bumped to **4.2.0** (additive) with CHANGELOG entry + README manual-paging section. `uv.lock` refreshed (was stale at 3.0.0 / `websockets>=12` vs pyproject's `>=14`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Btj6LswdbWqSgMavGJzBp