### PR TITLE
feat(mcp): structured error content (code/request_id/retryable) alongside text

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -190,6 +190,42 @@ shapes may change before templates are declared stable.
 | `validate_template` | Dry-run source: parse errors, a rendered preview against `test_data`, and `suggestedData` placeholders. |
 | `list_starter_templates` / `get_starter_template` | Browse the starter catalog; the detail view includes full body sources and per-variable metadata. |
 
+## Errors
+
+Every failed tool call returns an MCP result with `isError: true` and **two
+representations of the error**:
+
+- **`structuredContent`** — the machine-branchable form. Branch on this, not
+  the text:
+
+  ```json
+  {
+    "code": "domain_not_verified",
+    "retryable": false,
+    "status": 403,
+    "request_id": "req_abc123",
+    "retry_after_seconds": 30,
+    "details": { "field": "…" }
+  }
+  ```
+
+  | Field | Presence | Meaning |
+  | --- | --- | --- |
+  | `code` | always | Stable snake_case token from the API error envelope (e.g. `domain_not_verified`, `rate_limited`, `message_not_pending`). Errors raised by the MCP layer itself (bad/missing arguments, `confirm:true` guards) carry `invalid_request`. |
+  | `retryable` | always | `true` when a retry could plausibly succeed (rate limit, 5xx, connection failure). |
+  | `status` | API errors only | HTTP status of the API response (`0` = connection-level failure). Absent when no request was made (MCP-layer validation). |
+  | `request_id` | when available | Server request id — quote it in support requests. |
+  | `retry_after_seconds` | when available | Back-off hint for retryable errors. |
+  | `details` | when available | Structured field-level detail from the envelope (omitted if oversized). |
+
+- **`content` (text)** — the human-readable form, unchanged and stable:
+  `e2a error [<code>] (retryable)?: <message>` for API errors, `e2a error:
+  <message>` for MCP-layer errors. Existing agents that parse this text keep
+  working, but new integrations should read `structuredContent` instead.
+
+Successful results are unaffected (JSON in a text block; list tools return a
+domain-named array plus `next_cursor` while more pages remain).
+
 ## Links
 
 - [e2a docs](https://e2a.dev)

--- a/mcp/src/tools/util.ts
+++ b/mcp/src/tools/util.ts
@@ -3,6 +3,7 @@ import { E2AError } from "@e2a/sdk/v1";
 
 export type ToolResult = {
   content: Array<{ type: "text"; text: string }>;
+  structuredContent?: { [key: string]: unknown };
   isError?: boolean;
 };
 
@@ -62,30 +63,100 @@ export async function runTool<T>(fn: () => Promise<T>): Promise<ToolResult> {
           : JSON.stringify(result, null, 2);
     return { content: [{ type: "text", text }] };
   } catch (err) {
+    // Every tool error carries BOTH representations (GA review Tier-2 #12/#31):
+    //
+    //  * `content` (text) — the human/legacy form. Its wording is a de-facto
+    //    FROZEN contract (`e2a error [code](retryable)?: msg` for API errors,
+    //    `e2a error: msg` for wrapper errors) because deployed agents regex it.
+    //    Do NOT change it.
+    //  * `structuredContent` — the sanctioned machine-branchable form (see
+    //    structuredError below): { code, retryable, status?, request_id?,
+    //    retry_after_seconds?, details? }. New agents should branch on this
+    //    instead of parsing the text.
+    //
+    // The MCP SDK explicitly exempts isError results from outputSchema
+    // validation and allows structuredContent without a declared schema, so
+    // this is additive and non-breaking for every client.
+    const structured = structuredError(err);
     // Surface the API envelope's machine-branchable `code` (§6a #4) so an agent
     // can branch on a stable code (e.g. domain_not_verified, message_not_pending,
     // recipient_suppressed) instead of parsing prose. The retryable hint tells
     // it whether a retry could ever help. Errors thrown by the wrapper itself
     // (plain Error — e.g. "email is required") have no code and fall through to
-    // the prose form.
+    // the prose form (text stays code-less; structuredContent still carries a
+    // stable code).
     if (err instanceof E2AError && err.code) {
       const retry = err.retryable ? " (retryable)" : "";
       // Only the `code` (a trusted snake_case token) goes inside the brackets.
       // The message is free-form and can echo caller/recipient input, so bound +
       // sanitize it: strip control chars/newlines (keep the `[code]` convention
-      // parseable) and cap length (avoid context blowup). We surface code +
-      // message only — never the raw response body, headers, or request_id.
+      // parseable) and cap length (avoid context blowup). The text carries code +
+      // message only; request_id/details ride in structuredContent (details
+      // size-capped there).
       return {
         content: [{ type: "text", text: `e2a error [${err.code}]${retry}: ${sanitizeMessage(err.message)}` }],
+        structuredContent: structured,
         isError: true,
       };
     }
     const message = err instanceof Error ? err.message : String(err);
     return {
       content: [{ type: "text", text: `e2a error: ${sanitizeMessage(message)}` }],
+      structuredContent: structured,
       isError: true,
     };
   }
+}
+
+// structuredError builds the machine-branchable error payload emitted as
+// `structuredContent` on every isError tool result.
+//
+// Shape (stable, additive-only post-GA):
+//   code                 stable snake_case token — ALWAYS present. API errors
+//                        carry the envelope code (domain_not_verified,
+//                        rate_limited, …); wrapper-thrown validation errors
+//                        (missing agent arg, confirm guard) reuse the server's
+//                        canonical validation code `invalid_request`.
+//   retryable            boolean — ALWAYS present; true when a retry could
+//                        plausibly succeed (429 / 5xx / connection).
+//   status               HTTP status of the API response (0 = connection-level
+//                        failure). ABSENT for wrapper errors: no request was
+//                        ever made.
+//   request_id           server X-Request-Id — quote it in support requests.
+//   retry_after_seconds  back-off hint (Retry-After header or the send-path
+//                        429's details.retry_after_seconds).
+//   details              envelope `error.details` (field-level validation
+//                        info). Omitted when it doesn't JSON-serialize or its
+//                        JSON exceeds MAX_DETAILS_JSON_LEN (context-blowup /
+//                        echoed-input guard, mirroring sanitizeMessage).
+const MAX_DETAILS_JSON_LEN = 2000;
+function structuredError(err: unknown): { [key: string]: unknown } {
+  if (err instanceof E2AError) {
+    const out: { [key: string]: unknown } = {
+      // toE2AError always synthesizes a code; "error" only guards a
+      // hand-constructed codeless E2AError (mirrors the SDK's own fallback).
+      code: err.code || "error",
+      retryable: err.retryable,
+      status: err.status,
+    };
+    if (err.requestId) out.request_id = err.requestId;
+    if (err.retryAfterSeconds !== undefined) out.retry_after_seconds = err.retryAfterSeconds;
+    if (err.details !== undefined) {
+      try {
+        const json = JSON.stringify(err.details);
+        if (json !== undefined && json.length <= MAX_DETAILS_JSON_LEN) out.details = err.details;
+      } catch {
+        // Unserializable (cycles, BigInt) — omit rather than fail the result.
+      }
+    }
+    return out;
+  }
+  // Wrapper-thrown validation error (plain Error from the MCP layer itself —
+  // e.g. "delete_agent requires confirm:true", missing agent selection). It is
+  // always a caller-input problem, so reuse the server's canonical validation
+  // code instead of surfacing no code at all. No status/request_id: no HTTP
+  // exchange happened.
+  return { code: "invalid_request", retryable: false };
 }
 
 // sanitizeMessage makes an error message safe to splice into the single-line

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -12,6 +12,7 @@ import { registerReviewTools } from "../src/tools/review.js";
 import { registerWebhookTools } from "../src/tools/webhooks.js";
 import { registerEventTools } from "../src/tools/events.js";
 import { registerTemplateTools } from "../src/tools/templates.js";
+import { runTool } from "../src/tools/util.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 // Build a small RFC822 blob with one attachment so the MessageView's
@@ -1205,6 +1206,130 @@ describe("e2a MCP server", () => {
     const text = (res.content as Array<{ text: string }>)[0]?.text ?? "";
     expect(text.length).toBeLessThan(600); // bounded, not 5000+
     expect(text).toContain("…");
+  });
+
+  // ── structuredContent on tool errors (GA review Tier-2 #12/#31) ─────────
+  //
+  // Every isError result now ALSO carries a machine-branchable
+  // `structuredContent` payload — the sanctioned alternative to regex-parsing
+  // the (frozen) `e2a error [code]: msg` text. The text stays byte-for-byte
+  // stable; structuredContent is additive.
+
+  it("a typed API error surfaces code/status/request_id/retryable/details in structuredContent", async () => {
+    (stub.send as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new E2AError({
+        code: "domain_not_verified",
+        message: "the sending domain is not verified",
+        status: 403,
+        requestId: "req_abc123",
+        details: { domain: "example.com", hint: "verify DNS" },
+        retryable: false,
+      }),
+    );
+    const res = await client.callTool({
+      name: "send_message",
+      arguments: { to: ["x@example.com"], subject: "s", text: "b" },
+    });
+    expect(res.isError).toBe(true);
+    expect(res.structuredContent).toEqual({
+      code: "domain_not_verified",
+      status: 403,
+      request_id: "req_abc123",
+      retryable: false,
+      details: { domain: "example.com", hint: "verify DNS" },
+    });
+    // The legacy text form is untouched — agents parsing it keep working.
+    const text = (res.content as Array<{ text: string }>)[0]?.text ?? "";
+    expect(text).toBe("e2a error [domain_not_verified]: the sending domain is not verified");
+  });
+
+  it("a retryable API error carries retryable + retry_after_seconds in structuredContent", async () => {
+    (stub.send as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new E2AError({
+        code: "rate_limited",
+        message: "slow down",
+        status: 429,
+        retryable: true,
+        retryAfterSeconds: 30,
+      }),
+    );
+    const res = await client.callTool({
+      name: "send_message",
+      arguments: { to: ["x@example.com"], subject: "s", text: "b" },
+    });
+    expect(res.isError).toBe(true);
+    expect(res.structuredContent).toEqual({
+      code: "rate_limited",
+      status: 429,
+      retryable: true,
+      retry_after_seconds: 30,
+    });
+  });
+
+  it("a wrapper-thrown error carries the stable invalid_request code (no status/request_id)", async () => {
+    // Plain Error from the MCP layer itself — no HTTP exchange happened, so
+    // structuredContent has no status/request_id, but it still carries a
+    // stable code (the server's canonical validation code) instead of none.
+    (stub.send as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("email is required"));
+    const res = await client.callTool({
+      name: "send_message",
+      arguments: { to: ["x@example.com"], subject: "s", text: "b" },
+    });
+    expect(res.isError).toBe(true);
+    expect(res.structuredContent).toEqual({ code: "invalid_request", retryable: false });
+    // Text form unchanged: prose, no fabricated code bracket.
+    const text = (res.content as Array<{ text: string }>)[0]?.text ?? "";
+    expect(text).toBe("e2a error: email is required");
+  });
+
+  it("the confirm-guard throw carries invalid_request in structuredContent", async () => {
+    // The tools' confirm guards (`throw new Error("delete_agent requires
+    // confirm:true …")`) sit behind a z.literal(true) schema, so drive runTool
+    // directly with the guard-style throw to pin its structured shape.
+    const res = await runTool(async () => {
+      throw new Error(
+        "delete_agent requires confirm:true — refusing to proceed without explicit confirmation.",
+      );
+    });
+    expect(res.isError).toBe(true);
+    expect(res.structuredContent).toEqual({ code: "invalid_request", retryable: false });
+    expect(res.content[0]?.text).toBe(
+      "e2a error: delete_agent requires confirm:true — refusing to proceed without explicit confirmation.",
+    );
+  });
+
+  it("oversized details are omitted from structuredContent (context-blowup guard)", async () => {
+    (stub.send as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new E2AError({
+        code: "invalid_request",
+        message: "bad input",
+        status: 422,
+        details: { blob: "a".repeat(5000) },
+        retryable: false,
+      }),
+    );
+    const res = await client.callTool({
+      name: "send_message",
+      arguments: { to: ["x@example.com"], subject: "s", text: "b" },
+    });
+    expect(res.isError).toBe(true);
+    expect(res.structuredContent).toEqual({
+      code: "invalid_request",
+      status: 422,
+      retryable: false,
+      // no `details` key — its JSON exceeded the cap
+    });
+  });
+
+  it("success results are unchanged: no structuredContent", async () => {
+    const res = await client.callTool({
+      name: "send_message",
+      arguments: { to: ["x@example.com"], subject: "s", text: "b" },
+    });
+    expect(res.isError).toBeFalsy();
+    expect(res.structuredContent).toBeUndefined();
+    const text = (res.content as Array<{ text: string }>)[0]?.text ?? "";
+    expect(JSON.parse(text)).toMatchObject({ messageId: "msg_sent" });
   });
 
   // ── Templates (beta) ────────────────────────────────────────────


### PR DESCRIPTION
## What

GA-review Tier-2 items #12/#31. MCP tool errors previously surfaced only the prose text block — the machine-branchable `code` was recoverable only by regex-parsing `e2a error [code]: msg`, `details`/`request_id` were dropped entirely, and wrapper-thrown errors (missing agent selection, `confirm:true` guards) carried no code at all. That text format was becoming a de-facto frozen contract as agents parse it.

Every `isError: true` tool result now **also** carries `structuredContent`:

```json
{
  "code": "domain_not_verified",
  "retryable": false,
  "status": 403,
  "request_id": "req_abc123",
  "retry_after_seconds": 30,
  "details": { "field": "…" }
}
```

- `code` / `retryable` — always present. API errors source them from the typed `E2AError` (SDK envelope mapping, code-first).
- `status` — API errors only (`0` = connection-level failure); **absent** for MCP-layer errors, where no HTTP exchange happened.
- `request_id` / `retry_after_seconds` / `details` — when available; `details` is size-capped (2000 chars of JSON, mirroring the existing `sanitizeMessage` context-blowup guard) and omitted when oversized or unserializable.

## Wrapper-error code decision

Wrapper-thrown plain Errors (missing agent arg, confirm guards, resolution failures) reuse the server's **canonical validation code `invalid_request`** rather than a new MCP-only code: they are always caller-input problems, and reusing the code the server already emits for 400/422 keeps the branchable vocabulary to one set. They carry `retryable: false` and no `status`/`request_id`.

## SDK mechanism

`@modelcontextprotocol/sdk` 1.29: `structuredContent` without a declared `outputSchema` is explicitly allowed, and the SDK exempts `isError` results from output-schema validation — so an *error-side* `outputSchema` is not expressible in this SDK version (declaring one would instead bind **success** results to it, breaking the frozen success envelope). The sanctioned equivalent is emitting schema-less `structuredContent` on error results and documenting the shape, which this PR does (new "Errors" section in `mcp/README.md`).

## Frozen contracts untouched

- The error **text** block is byte-for-byte unchanged (`e2a error [code](retryable)?: msg` / `e2a error: msg`) — deployed agents that regex it keep working; `structuredContent` is the sanctioned path forward.
- Success results unchanged: no `structuredContent`, list envelope (domain-named arrays, `next_cursor` omitted when done) and `paginationInput` untouched.

## Tests

`cd mcp && npm run build && npm test` — 161 passed (155 existing + 6 new): typed API error surfaces code/status/request_id/details in `structuredContent`; retryable + `retry_after_seconds` passthrough; wrapper and confirm-guard errors carry `invalid_request`; oversized `details` omitted; success results have no `structuredContent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Btj6LswdbWqSgMavGJzBp