### PR TITLE
fix(export)!: replace webhook_healthy bool with webhook_status enum (BREAKING)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -173,8 +173,9 @@ components:
           type: integer
         user_id:
           type: string
-        webhook_healthy:
-          type: boolean
+        webhook_status:
+          description: "Webhook posture for this agent, derived from the account's webhook subscribers that match it (a webhook with no agent filter matches every agent). Open set; tolerate unknown values. Known values: none (no webhook matches this agent), healthy (an enabled webhook matches and none serving this agent has a terminally-failed delivery in the last 24h), failing (an enabled webhook matches but at least one delivery on a matching enabled webhook terminally failed in the last 24h), disabled (webhooks match but every one is disabled, turned off manually), auto_disabled (webhooks match, every one is disabled, and at least one was auto-disabled by the chronic-failure sweep). Present on enriched surfaces (account export, dashboard agent list); absent where not computed."
+          type: string
       required:
         - domain
         - email
@@ -188,7 +189,6 @@ components:
         - inbound_7d
         - outbound_7d
         - pending_count
-        - webhook_healthy
         - inbound_policy
         - inbound_policy_action
         - outbound_policy

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -117,10 +117,16 @@ type AgentIdentity struct {
 	Outbound7d     int        `json:"outbound_7d"`
 	PendingCount   int        `json:"pending_count"`
 	LastDeliveryAt *time.Time `json:"last_delivery_at,omitempty"`
-	// WebhookHealthy is false iff there's been a failed webhook delivery
-	// in the last 24h. Defaults to true for agents with no deliveries
-	// yet — avoids painting fresh agents red.
-	WebhookHealthy bool `json:"webhook_healthy"`
+	// WebhookStatus summarizes the webhook posture serving this agent,
+	// derived from the /v1/webhooks subscriber resource: which of the
+	// account's webhooks match this agent (an empty agent filter matches
+	// every agent) and how their recent deliveries have fared. One of the
+	// WebhookStatus* constants below; open set. Computed only on enriched
+	// read paths (ListAgentsByUser, the account export) — other load paths
+	// leave it empty, and omitempty keeps the un-computed zero value off
+	// the wire. Replaces the pre-GA webhook_healthy bool, which could not
+	// distinguish "no webhook configured" from "healthy".
+	WebhookStatus string `json:"webhook_status,omitempty" doc:"Webhook posture for this agent, derived from the account's webhook subscribers that match it (a webhook with no agent filter matches every agent). Open set; tolerate unknown values. Known values: none (no webhook matches this agent), healthy (an enabled webhook matches and none serving this agent has a terminally-failed delivery in the last 24h), failing (an enabled webhook matches but at least one delivery on a matching enabled webhook terminally failed in the last 24h), disabled (webhooks match but every one is disabled, turned off manually), auto_disabled (webhooks match, every one is disabled, and at least one was auto-disabled by the chronic-failure sweep). Present on enriched surfaces (account export, dashboard agent list); absent where not computed."`
 	// InboundPolicy is the per-agent inbound ingestion gate (migration 033 /
 	// Slice 7): one of inboundpolicy.{Open,Allowlist,Domain}.
 	// Defaults to 'open' (the column default). InboundAllowlist holds the
@@ -154,6 +160,72 @@ type AgentIdentity struct {
 	// re-checked at the token endpoint; a bump invalidates prior tokens.
 	AssertionVersion int `json:"-"`
 }
+
+// WebhookStatus* are the known AgentIdentity.WebhookStatus values. The set is
+// open — API consumers must tolerate unknown values — but the server only
+// emits these five today. Precedence when several webhooks match one agent:
+// any enabled webhook wins (healthy/failing per recent deliveries); among
+// all-disabled matches, an auto-disabled one wins over a manual disable.
+const (
+	// WebhookStatusNone: no webhook subscriber matches this agent.
+	WebhookStatusNone = "none"
+	// WebhookStatusHealthy: at least one enabled webhook matches, and no
+	// matching enabled webhook has a terminally-failed delivery in the
+	// last 24h.
+	WebhookStatusHealthy = "healthy"
+	// WebhookStatusFailing: at least one enabled webhook matches, but a
+	// matching enabled webhook had a terminally-failed delivery (retries
+	// exhausted) in the last 24h.
+	WebhookStatusFailing = "failing"
+	// WebhookStatusDisabled: webhooks match this agent but every one is
+	// disabled, all by hand (no auto_disabled_at).
+	WebhookStatusDisabled = "disabled"
+	// WebhookStatusAutoDisabled: webhooks match this agent, every one is
+	// disabled, and at least one was tripped by the chronic-failure sweep
+	// (AutoDisableFailingWebhooks).
+	WebhookStatusAutoDisabled = "auto_disabled"
+)
+
+// webhookMatchesAgentSQL is the SQL twin of webhookpub's matches() agent rule:
+// a webhook scopes to an agent when its filters.agent_ids is absent/empty (no
+// constraint) or contains the agent id. Expects `w` (webhooks) and `a`
+// (agent_identities) aliases in scope. Conversation/label filters are event
+// dimensions, not agent dimensions, so they don't participate here.
+const webhookMatchesAgentSQL = `(COALESCE(jsonb_array_length(w.filters->'agent_ids'), 0) = 0
+	             OR w.filters->'agent_ids' ? a.id)`
+
+// webhookStatusSQL derives AgentIdentity.WebhookStatus for the agent row
+// aliased `a`. Health reads webhook_subscriber_deliveries (the live
+// /v1/webhooks pipeline), NOT the legacy webhook_deliveries table, which is
+// retained only for janitor draining and no longer receives rows. Failure
+// attribution is per matching webhook (endpoint), not per event: if an
+// endpoint serving this agent is failing, the agent's events are at risk
+// regardless of which agent's event tripped the failure.
+const webhookStatusSQL = `CASE
+	 WHEN EXISTS (
+	     SELECT 1 FROM webhooks w
+	     WHERE w.user_id = a.user_id AND w.enabled
+	       AND ` + webhookMatchesAgentSQL + `
+	 ) THEN CASE WHEN EXISTS (
+	     SELECT 1 FROM webhook_subscriber_deliveries wsd
+	     JOIN webhooks w ON w.id = wsd.webhook_id
+	     WHERE w.user_id = a.user_id AND w.enabled
+	       AND ` + webhookMatchesAgentSQL + `
+	       AND wsd.status = 'failed'
+	       AND wsd.last_attempt_at > now() - interval '24 hours'
+	 ) THEN '` + WebhookStatusFailing + `' ELSE '` + WebhookStatusHealthy + `' END
+	 WHEN EXISTS (
+	     SELECT 1 FROM webhooks w
+	     WHERE w.user_id = a.user_id AND w.auto_disabled_at IS NOT NULL
+	       AND ` + webhookMatchesAgentSQL + `
+	 ) THEN '` + WebhookStatusAutoDisabled + `'
+	 WHEN EXISTS (
+	     SELECT 1 FROM webhooks w
+	     WHERE w.user_id = a.user_id
+	       AND ` + webhookMatchesAgentSQL + `
+	 ) THEN '` + WebhookStatusDisabled + `'
+	 ELSE '` + WebhookStatusNone + `'
+	END`
 
 // HITL constants mirror the CHECK constraints in migration 003_hitl.sql.
 const (
@@ -1110,10 +1182,10 @@ func (s *Store) UpdateAgentName(ctx context.Context, agentID, userID, name strin
 }
 
 // Agents are joined with domain verification AND enriched with per-agent stats
-// for the dashboard. Five correlated subqueries compute inbound/outbound 7-day
-// counts, pending approvals, last delivery, and webhook health in a single
+// for the dashboard. Correlated subqueries compute inbound/outbound 7-day
+// counts, pending approvals, last delivery, and webhook status in a single
 // round-trip. Other load paths (GetAgentByID, GetAgentByEmail) intentionally
-// don't compute these — only the dashboard needs them.
+// don't compute these — only the dashboard and the account export need them.
 //
 // ListAgentsByUser returns one page of the user's agents, newest-first,
 // keyset-paginated on (created_at, id). limit<=0 returns every agent
@@ -1142,13 +1214,7 @@ func (s *Store) ListAgentsByUser(ctx context.Context, userID string, limit int, 
 		        (SELECT max(m.created_at) FROM messages m
 		           WHERE m.agent_id = a.id AND m.direction = 'outbound'
 		             AND m.status = 'sent') AS last_delivery_at,
-		        NOT EXISTS (
-		           SELECT 1 FROM webhook_deliveries wd
-		           JOIN messages m ON m.id = wd.message_id
-		           WHERE m.agent_id = a.id
-		             AND wd.status = 'failed'
-		             AND wd.last_attempt_at > now() - interval '24 hours'
-		        ) AS webhook_healthy
+		        ` + webhookStatusSQL + ` AS webhook_status
 		 FROM agent_identities a
 		 JOIN domains d ON a.domain = d.domain
 		 WHERE a.user_id = $1`
@@ -1183,7 +1249,7 @@ func (s *Store) ListAgentsByUser(ctx context.Context, userID string, limit int, 
 			&a.InboundScanSensitivity, &a.OutboundScanSensitivity,
 			&a.DomainVerified,
 			&a.Inbound7d, &a.Outbound7d, &a.PendingCount,
-			&lastDeliveryAt, &a.WebhookHealthy); err != nil {
+			&lastDeliveryAt, &a.WebhookStatus); err != nil {
 			return nil, err
 		}
 		a.LastDeliveryAt = lastDeliveryAt

--- a/internal/identity/store_test.go
+++ b/internal/identity/store_test.go
@@ -1277,8 +1277,8 @@ func TestGetDashboardStats_DeliverySuccess(t *testing.T) {
 
 // TestListAgentsByUser_EnrichedFields: the dashboard's GET /api/dashboard/agents
 // must surface per-agent stats (Inbound7d, Outbound7d, PendingCount,
-// LastDeliveryAt, WebhookHealthy) so the cards can render without
-// extra round-trips. Asserts the five subqueries produce the right
+// LastDeliveryAt, WebhookStatus) so the cards can render without
+// extra round-trips. Asserts the subqueries produce the right
 // counts for a representative mix of activity.
 func TestListAgentsByUser_EnrichedFields(t *testing.T) {
 	pool := testutil.TestDB(t)
@@ -1293,7 +1293,7 @@ func TestListAgentsByUser_EnrichedFields(t *testing.T) {
 	// Seed:
 	//   2 inbound in last 7d, 1 inbound > 7d old
 	//   3 outbound (sent) in last 7d, 1 pending_approval
-	//   1 webhook delivery: delivered (healthy)
+	//   1 enabled webhook + 1 delivered subscriber delivery (healthy)
 	for i := 0; i < 2; i++ {
 		store.CreateInboundMessage(ctx, "", agent.ID, "alice@gmail.com", agent.EmailAddress(), "", "in fresh", "", "", nil, nil, nil, false, "", nil, nil, nil, identity.InboundScreening{})
 	}
@@ -1308,12 +1308,19 @@ func TestListAgentsByUser_EnrichedFields(t *testing.T) {
 		"send", "", "", "", 3600)
 	_ = pending
 
-	// One delivered webhook (healthy state)
-	m, _ := store.CreateOutboundMessage(ctx, agent.ID, []string{"alice@example.com"}, nil, nil, "delivered-msg", "send", "webhook", "", "", nil)
-	pool.Exec(ctx,
-		`INSERT INTO webhook_deliveries (message_id, status, attempts, last_error, created_at, last_attempt_at)
-		 VALUES ($1, 'delivered', 1, '', now(), now())`,
-		m.ID)
+	// An enabled account-wide webhook subscriber with one delivered
+	// delivery — the healthy state.
+	wh, err := store.CreateWebhook(ctx, user.ID, "https://example.com/wh", "", []string{"email.received"}, identity.WebhookFilters{})
+	if err != nil {
+		t.Fatalf("CreateWebhook: %v", err)
+	}
+	store.CreateOutboundMessage(ctx, agent.ID, []string{"alice@example.com"}, nil, nil, "delivered-msg", "send", "webhook", "", "", nil)
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO webhook_subscriber_deliveries (id, webhook_id, event_type, event_payload, status, attempts, last_attempt_at)
+		 VALUES ($1, $2, 'email.sent', '{}'::jsonb, 'delivered', 1, now())`,
+		"whd_enriched_ok", wh.ID); err != nil {
+		t.Fatalf("seed webhook_subscriber_deliveries: %v", err)
+	}
 
 	agents, err := store.ListAgentsByUser(ctx, user.ID, 0, time.Time{}, "")
 	if err != nil {
@@ -1339,15 +1346,17 @@ func TestListAgentsByUser_EnrichedFields(t *testing.T) {
 	if a.LastDeliveryAt == nil {
 		t.Errorf("LastDeliveryAt should be set (we created 4 sent outbound messages)")
 	}
-	if !a.WebhookHealthy {
-		t.Errorf("WebhookHealthy = false, want true (only delivery is status=delivered)")
+	if a.WebhookStatus != identity.WebhookStatusHealthy {
+		t.Errorf("WebhookStatus = %q, want %q (enabled webhook, only delivery is status=delivered)",
+			a.WebhookStatus, identity.WebhookStatusHealthy)
 	}
 }
 
-// TestListAgentsByUser_WebhookUnhealthyOnRecentFailure: a failed delivery
-// in the last 24h flips WebhookHealthy to false. Operator-visible signal
-// so the dashboard can paint the badge red.
-func TestListAgentsByUser_WebhookUnhealthyOnRecentFailure(t *testing.T) {
+// TestListAgentsByUser_WebhookFailingOnRecentFailure: a terminally-failed
+// subscriber delivery in the last 24h on a webhook serving the agent
+// surfaces as webhook_status=failing. Operator-visible signal so the
+// dashboard can paint the badge red.
+func TestListAgentsByUser_WebhookFailingOnRecentFailure(t *testing.T) {
 	pool := testutil.TestDB(t)
 	store := identity.NewStore(pool)
 	ctx := context.Background()
@@ -1355,23 +1364,29 @@ func TestListAgentsByUser_WebhookUnhealthyOnRecentFailure(t *testing.T) {
 	user, _ := store.CreateOrGetUser(ctx, "wh-fail@example.com", "Owner", "google-wh-fail")
 	store.ClaimOrCreateDomain(ctx, "whfail.example.com", user.ID)
 	store.VerifyDomain(ctx, "whfail.example.com", user.ID)
-	agent, _ := store.CreateAgent(ctx, "bot@whfail.example.com", "whfail.example.com", "", "https://example.com/wh", "cloud", user.ID)
+	store.CreateAgent(ctx, "bot@whfail.example.com", "whfail.example.com", "", "", "cloud", user.ID)
 
-	m, _ := store.CreateOutboundMessage(ctx, agent.ID, []string{"alice@example.com"}, nil, nil, "failed-msg", "send", "webhook", "", "", nil)
-	pool.Exec(ctx,
-		`INSERT INTO webhook_deliveries (message_id, status, attempts, last_error, created_at, last_attempt_at)
-		 VALUES ($1, 'failed', 3, '500 internal', now(), now() - interval '5 minutes')`,
-		m.ID)
+	wh, err := store.CreateWebhook(ctx, user.ID, "https://example.com/wh", "", []string{"email.received"}, identity.WebhookFilters{})
+	if err != nil {
+		t.Fatalf("CreateWebhook: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO webhook_subscriber_deliveries (id, webhook_id, event_type, event_payload, status, attempts, last_error, last_attempt_at)
+		 VALUES ($1, $2, 'email.received', '{}'::jsonb, 'failed', 5, '500 internal', now() - interval '5 minutes')`,
+		"whd_recent_fail", wh.ID); err != nil {
+		t.Fatalf("seed webhook_subscriber_deliveries: %v", err)
+	}
 
 	agents, _ := store.ListAgentsByUser(ctx, user.ID, 0, time.Time{}, "")
-	if agents[0].WebhookHealthy {
-		t.Error("WebhookHealthy = true, want false on recent failed delivery")
+	if agents[0].WebhookStatus != identity.WebhookStatusFailing {
+		t.Errorf("WebhookStatus = %q, want %q on recent failed delivery",
+			agents[0].WebhookStatus, identity.WebhookStatusFailing)
 	}
 }
 
 // TestListAgentsByUser_OldFailureDoesNotPoisonHealth: failures older
-// than 24h don't flip WebhookHealthy. Otherwise a one-off blip from
-// last week would forever paint the agent red.
+// than 24h don't flip webhook_status to failing. Otherwise a one-off
+// blip from last week would forever paint the agent red.
 func TestListAgentsByUser_OldFailureDoesNotPoisonHealth(t *testing.T) {
 	pool := testutil.TestDB(t)
 	store := identity.NewStore(pool)
@@ -1380,17 +1395,112 @@ func TestListAgentsByUser_OldFailureDoesNotPoisonHealth(t *testing.T) {
 	user, _ := store.CreateOrGetUser(ctx, "wh-old-fail@example.com", "Owner", "google-wh-of")
 	store.ClaimOrCreateDomain(ctx, "wholdfail.example.com", user.ID)
 	store.VerifyDomain(ctx, "wholdfail.example.com", user.ID)
-	agent, _ := store.CreateAgent(ctx, "bot@wholdfail.example.com", "wholdfail.example.com", "", "https://example.com/wh", "cloud", user.ID)
+	store.CreateAgent(ctx, "bot@wholdfail.example.com", "wholdfail.example.com", "", "", "cloud", user.ID)
 
-	m, _ := store.CreateOutboundMessage(ctx, agent.ID, []string{"alice@example.com"}, nil, nil, "stale-fail", "send", "webhook", "", "", nil)
-	pool.Exec(ctx,
-		`INSERT INTO webhook_deliveries (message_id, status, attempts, last_error, created_at, last_attempt_at)
-		 VALUES ($1, 'failed', 5, 'stale', now() - interval '3 days', now() - interval '3 days')`,
-		m.ID)
+	wh, err := store.CreateWebhook(ctx, user.ID, "https://example.com/wh", "", []string{"email.received"}, identity.WebhookFilters{})
+	if err != nil {
+		t.Fatalf("CreateWebhook: %v", err)
+	}
+	if _, err := pool.Exec(ctx,
+		`INSERT INTO webhook_subscriber_deliveries (id, webhook_id, event_type, event_payload, status, attempts, last_error, created_at, last_attempt_at)
+		 VALUES ($1, $2, 'email.received', '{}'::jsonb, 'failed', 5, 'stale', now() - interval '3 days', now() - interval '3 days')`,
+		"whd_stale_fail", wh.ID); err != nil {
+		t.Fatalf("seed webhook_subscriber_deliveries: %v", err)
+	}
 
 	agents, _ := store.ListAgentsByUser(ctx, user.ID, 0, time.Time{}, "")
-	if !agents[0].WebhookHealthy {
-		t.Error("WebhookHealthy = false, want true (3-day-old failure shouldn't poison health)")
+	if agents[0].WebhookStatus != identity.WebhookStatusHealthy {
+		t.Errorf("WebhookStatus = %q, want %q (3-day-old failure shouldn't poison health)",
+			agents[0].WebhookStatus, identity.WebhookStatusHealthy)
+	}
+}
+
+// TestListAgentsByUser_WebhookStatusNoneWithoutSubscriber: an agent with
+// no matching webhook subscriber reports webhook_status=none — the state
+// the old webhook_healthy bool could not express (it read as "healthy").
+// Also covers agent-filter scoping: a webhook pinned to a different agent
+// must not count as "configured" for this one.
+func TestListAgentsByUser_WebhookStatusNoneWithoutSubscriber(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "wh-none@example.com", "Owner", "google-wh-none")
+	store.ClaimOrCreateDomain(ctx, "whnone.example.com", user.ID)
+	store.VerifyDomain(ctx, "whnone.example.com", user.ID)
+	covered, _ := store.CreateAgent(ctx, "covered@whnone.example.com", "whnone.example.com", "", "", "cloud", user.ID)
+	store.CreateAgent(ctx, "bare@whnone.example.com", "whnone.example.com", "", "", "cloud", user.ID)
+
+	// One webhook, filtered to `covered` only.
+	if _, err := store.CreateWebhook(ctx, user.ID, "https://example.com/wh", "", []string{"email.received"},
+		identity.WebhookFilters{AgentIDs: []string{covered.ID}}); err != nil {
+		t.Fatalf("CreateWebhook: %v", err)
+	}
+
+	agents, err := store.ListAgentsByUser(ctx, user.ID, 0, time.Time{}, "")
+	if err != nil {
+		t.Fatalf("ListAgentsByUser: %v", err)
+	}
+	byEmail := map[string]string{}
+	for _, a := range agents {
+		byEmail[a.Email] = a.WebhookStatus
+	}
+	if got := byEmail["covered@whnone.example.com"]; got != identity.WebhookStatusHealthy {
+		t.Errorf("covered agent WebhookStatus = %q, want %q (agent-filtered webhook matches it)",
+			got, identity.WebhookStatusHealthy)
+	}
+	if got := byEmail["bare@whnone.example.com"]; got != identity.WebhookStatusNone {
+		t.Errorf("bare agent WebhookStatus = %q, want %q (no webhook matches it)",
+			got, identity.WebhookStatusNone)
+	}
+}
+
+// TestListAgentsByUser_WebhookStatusDisabledStates: a matching webhook that
+// is disabled reports `disabled` when turned off by hand and `auto_disabled`
+// when the chronic-failure sweep tripped it (auto_disabled_at set) — and an
+// enabled matching webhook takes precedence over a disabled one.
+func TestListAgentsByUser_WebhookStatusDisabledStates(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, _ := store.CreateOrGetUser(ctx, "wh-disabled@example.com", "Owner", "google-wh-disabled")
+	store.ClaimOrCreateDomain(ctx, "whdis.example.com", user.ID)
+	store.VerifyDomain(ctx, "whdis.example.com", user.ID)
+	store.CreateAgent(ctx, "bot@whdis.example.com", "whdis.example.com", "", "", "cloud", user.ID)
+
+	wh, err := store.CreateWebhook(ctx, user.ID, "https://example.com/wh", "", []string{"email.received"}, identity.WebhookFilters{})
+	if err != nil {
+		t.Fatalf("CreateWebhook: %v", err)
+	}
+
+	status := func() string {
+		t.Helper()
+		agents, err := store.ListAgentsByUser(ctx, user.ID, 0, time.Time{}, "")
+		if err != nil {
+			t.Fatalf("ListAgentsByUser: %v", err)
+		}
+		return agents[0].WebhookStatus
+	}
+
+	// Manually disabled: enabled=false, no auto_disabled_at.
+	pool.Exec(ctx, `UPDATE webhooks SET enabled = false, auto_disabled_at = NULL WHERE id = $1`, wh.ID)
+	if got := status(); got != identity.WebhookStatusDisabled {
+		t.Errorf("WebhookStatus = %q, want %q (manually disabled webhook)", got, identity.WebhookStatusDisabled)
+	}
+
+	// Auto-disabled by the failure sweep: auto_disabled_at set.
+	pool.Exec(ctx, `UPDATE webhooks SET enabled = false, auto_disabled_at = now() WHERE id = $1`, wh.ID)
+	if got := status(); got != identity.WebhookStatusAutoDisabled {
+		t.Errorf("WebhookStatus = %q, want %q (auto-disabled webhook)", got, identity.WebhookStatusAutoDisabled)
+	}
+
+	// A second, enabled webhook outranks the disabled one.
+	if _, err := store.CreateWebhook(ctx, user.ID, "https://example.com/wh2", "", []string{"email.received"}, identity.WebhookFilters{}); err != nil {
+		t.Fatalf("CreateWebhook 2: %v", err)
+	}
+	if got := status(); got != identity.WebhookStatusHealthy {
+		t.Errorf("WebhookStatus = %q, want %q (enabled webhook outranks disabled)", got, identity.WebhookStatusHealthy)
 	}
 }
 

--- a/internal/identity/user_data_rights.go
+++ b/internal/identity/user_data_rights.go
@@ -363,11 +363,16 @@ func scanDomainsForUser(ctx context.Context, tx pgx.Tx, userID string) ([]Domain
 }
 
 func scanAgentsForUser(ctx context.Context, tx pgx.Tx, userID string) ([]AgentIdentity, error) {
+	// webhook_status is computed here (same derivation as ListAgentsByUser)
+	// so the export never emits the un-computed zero value: an export that
+	// said "unhealthy" for agents whose status was simply never calculated
+	// is exactly the bug the enum replaced webhook_healthy to fix.
 	rows, err := tx.Query(ctx,
-		`SELECT id, domain, name,
-		        hitl_ttl_seconds, hitl_expiration_action,
-		        public, created_at, user_id
-		   FROM agent_identities WHERE user_id = $1 ORDER BY created_at`, userID)
+		`SELECT a.id, a.domain, a.name,
+		        a.hitl_ttl_seconds, a.hitl_expiration_action,
+		        a.public, a.created_at, a.user_id,
+		        `+webhookStatusSQL+` AS webhook_status
+		   FROM agent_identities a WHERE a.user_id = $1 ORDER BY a.created_at`, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -377,7 +382,7 @@ func scanAgentsForUser(ctx context.Context, tx pgx.Tx, userID string) ([]AgentId
 		var a AgentIdentity
 		if err := rows.Scan(&a.ID, &a.Domain, &a.Name,
 			&a.HITLTTLSeconds, &a.HITLExpirationAction,
-			&a.Public, &a.CreatedAt, &a.UserID); err != nil {
+			&a.Public, &a.CreatedAt, &a.UserID, &a.WebhookStatus); err != nil {
 			return nil, err
 		}
 		// Domain verification flag is on the joined domain row; for

--- a/internal/identity/user_data_rights_test.go
+++ b/internal/identity/user_data_rights_test.go
@@ -126,6 +126,17 @@ func TestExportUserData(t *testing.T) {
 		if !jsonContains(agentJSON, "email") {
 			t.Error("exported agent is missing `email` — the agent's identifier")
 		}
+		// webhook_status must be computed (not the zero value) in the
+		// export: the fixture has no webhook subscriber, so the agent
+		// reports `none` — the state the old webhook_healthy bool could
+		// not express. The dropped bool must not resurface on the wire.
+		if got := dump.Agents[0].WebhookStatus; got != identity.WebhookStatusNone {
+			t.Errorf("exported agent WebhookStatus = %q, want %q (no webhook subscriber seeded)",
+				got, identity.WebhookStatusNone)
+		}
+		if jsonContains(agentJSON, "webhook_healthy") {
+			t.Error("exported agent leaks `webhook_healthy` — replaced by the webhook_status enum pre-GA")
+		}
 	}
 	if len(dump.APIKeys) != 2 {
 		t.Errorf("api_keys: got %d, want 2", len(dump.APIKeys))

--- a/package-lock.json
+++ b/package-lock.json
@@ -6193,7 +6193,7 @@
     },
     "sdks/typescript": {
       "name": "@e2a/sdk",
-      "version": "4.1.0",
+      "version": "4.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "ws": "^8.21.0"

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 4.3.0
+
+### Breaking (pre-GA)
+- **`AgentIdentity.webhook_healthy` (bool) replaced by `AgentIdentity.webhook_status`
+  (optional string enum).** The bool could not distinguish "no webhook
+  configured" from "healthy". The new field is an open set — tolerate unknown
+  values. Known values: `none` (no webhook matches the agent), `healthy` (an
+  enabled matching webhook, no terminally-failed delivery in the last 24h),
+  `failing` (an enabled matching webhook had a terminally-failed delivery in
+  the last 24h), `disabled` (matching webhooks exist but all are manually
+  disabled), `auto_disabled` (all matching webhooks disabled, at least one by
+  the chronic-failure sweep). `AgentIdentity` only appears in the account
+  export (`account.export()`), so most integrations are unaffected.
+
 ## 4.2.0
 
 Additive, no breaking changes.

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "e2a"
-version = "4.2.0"
+version = "4.3.0"
 description = "Python SDK for the e2a protocol — email-to-agent authentication"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdks/python/src/e2a/v1/generated/models/agent_identity.py
+++ b/sdks/python/src/e2a/v1/generated/models/agent_identity.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 from datetime import datetime
-from pydantic import BaseModel, ConfigDict, StrictBool, StrictFloat, StrictInt, StrictStr
+from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictFloat, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional, Union
 from typing import Optional, Set
 from typing_extensions import Self
@@ -54,9 +54,9 @@ class AgentIdentity(BaseModel):
     public: StrictBool
     ttl_seconds: StrictInt
     user_id: StrictStr
-    webhook_healthy: StrictBool
+    webhook_status: Optional[StrictStr] = Field(default=None, description="Webhook posture for this agent, derived from the account's webhook subscribers that match it (a webhook with no agent filter matches every agent). Open set; tolerate unknown values. Known values: none (no webhook matches this agent), healthy (an enabled webhook matches and none serving this agent has a terminally-failed delivery in the last 24h), failing (an enabled webhook matches but at least one delivery on a matching enabled webhook terminally failed in the last 24h), disabled (webhooks match but every one is disabled, turned off manually), auto_disabled (webhooks match, every one is disabled, and at least one was auto-disabled by the chronic-failure sweep). Present on enriched surfaces (account export, dashboard agent list); absent where not computed.")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["created_at", "domain", "domain_verified", "email", "inbound_7d", "inbound_allowlist", "inbound_policy", "inbound_policy_action", "inbound_scan", "inbound_scan_block_threshold", "inbound_scan_review_threshold", "inbound_scan_sensitivity", "last_delivery_at", "name", "on_expiry", "outbound_7d", "outbound_allowlist", "outbound_policy", "outbound_policy_action", "outbound_scan", "outbound_scan_block_threshold", "outbound_scan_review_threshold", "outbound_scan_sensitivity", "pending_count", "public", "ttl_seconds", "user_id", "webhook_healthy"]
+    __properties: ClassVar[List[str]] = ["created_at", "domain", "domain_verified", "email", "inbound_7d", "inbound_allowlist", "inbound_policy", "inbound_policy_action", "inbound_scan", "inbound_scan_block_threshold", "inbound_scan_review_threshold", "inbound_scan_sensitivity", "last_delivery_at", "name", "on_expiry", "outbound_7d", "outbound_allowlist", "outbound_policy", "outbound_policy_action", "outbound_scan", "outbound_scan_block_threshold", "outbound_scan_review_threshold", "outbound_scan_sensitivity", "pending_count", "public", "ttl_seconds", "user_id", "webhook_status"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -153,7 +153,7 @@ class AgentIdentity(BaseModel):
             "public": obj.get("public"),
             "ttl_seconds": obj.get("ttl_seconds"),
             "user_id": obj.get("user_id"),
-            "webhook_healthy": obj.get("webhook_healthy")
+            "webhook_status": obj.get("webhook_status")
         })
         # store additional fields in additional_properties
         for _key in obj.keys():

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -374,7 +374,7 @@ wheels = [
 
 [[package]]
 name = "e2a"
-version = "4.2.0"
+version = "4.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 4.2.0
+
+### Breaking (pre-GA)
+- **`AgentIdentity.webhookHealthy` (boolean) replaced by `AgentIdentity.webhookStatus`
+  (optional string enum).** The bool could not distinguish "no webhook
+  configured" from "healthy". The new field is an open set — tolerate unknown
+  values. Known values: `none` (no webhook matches the agent), `healthy` (an
+  enabled matching webhook, no terminally-failed delivery in the last 24h),
+  `failing` (an enabled matching webhook had a terminally-failed delivery in
+  the last 24h), `disabled` (matching webhooks exist but all are manually
+  disabled), `auto_disabled` (all matching webhooks disabled, at least one by
+  the chronic-failure sweep). `AgentIdentity` only appears in the account
+  export (`account.export()`), so most integrations are unaffected.
+
 ## 4.1.0
 
 Additive, no breaking changes.

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/sdk",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "TypeScript SDK for e2a — email for AI agents",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/sdks/typescript/src/v1/generated/models/AgentIdentity.ts
+++ b/sdks/typescript/src/v1/generated/models/AgentIdentity.ts
@@ -40,7 +40,10 @@ export class AgentIdentity {
     '_public': boolean;
     'ttlSeconds': number;
     'userId': string;
-    'webhookHealthy': boolean;
+    /**
+    * Webhook posture for this agent, derived from the account\'s webhook subscribers that match it (a webhook with no agent filter matches every agent). Open set; tolerate unknown values. Known values: none (no webhook matches this agent), healthy (an enabled webhook matches and none serving this agent has a terminally-failed delivery in the last 24h), failing (an enabled webhook matches but at least one delivery on a matching enabled webhook terminally failed in the last 24h), disabled (webhooks match but every one is disabled, turned off manually), auto_disabled (webhooks match, every one is disabled, and at least one was auto-disabled by the chronic-failure sweep). Present on enriched surfaces (account export, dashboard agent list); absent where not computed.
+    */
+    'webhookStatus'?: string;
 
     static readonly discriminator: string | undefined = undefined;
 
@@ -210,9 +213,9 @@ export class AgentIdentity {
             "format": ""
         },
         {
-            "name": "webhookHealthy",
-            "baseName": "webhook_healthy",
-            "type": "boolean",
+            "name": "webhookStatus",
+            "baseName": "webhook_status",
+            "type": "string",
             "format": ""
         }    ];
 


### PR DESCRIPTION
GA-review Tier-2 #44 (user-approved pre-GA break).

## Why

The user-data export's `AgentIdentity` carried a `webhook_healthy` BOOLEAN that cannot distinguish "no webhook configured" from "healthy" — and both surfaces that emitted it were lying, each in a different way:

- **Export** (`GET /v1/account/export`): `scanAgentsForUser` never computed the field, so every exported agent read `webhook_healthy: false` ("unhealthy") regardless of reality.
- **Dashboard agent list** (`ListAgentsByUser`): derived from the **legacy `webhook_deliveries` table**, which stopped receiving rows when push moved to the `/v1/webhooks` subscriber resource (the table is only janitor-drained now) — so the flag was pinned `true`, and "no webhook at all" was indistinguishable from "healthy".

A bool→enum change post-GA is breaking, so it's fixed now, before the freeze.

## What

`webhook_healthy` is **dropped** and replaced by `webhook_status`, a string enum derived from the live subscriber pipeline (`webhooks` + `webhook_subscriber_deliveries`). A webhook *matches* an agent when its `filters.agent_ids` is absent/empty (account-wide subscriber) or contains the agent id — the SQL twin of `webhookpub.matches()`.

| value | meaning | derivation |
|---|---|---|
| `none` | no webhook configured for this agent | no `webhooks` row matches the agent |
| `healthy` | configured, delivering | an **enabled** matching webhook exists and no matching enabled webhook has a `webhook_subscriber_deliveries` row with `status='failed'` in the last 24h |
| `failing` | configured, but deliveries are terminally failing | an enabled matching webhook exists **and** one had a `failed` (retries-exhausted) delivery in the last 24h |
| `disabled` | configured but switched off by hand | matching webhooks exist, all `enabled=false`, none auto-disabled |
| `auto_disabled` | disabled by the chronic-failure sweep | all matching webhooks disabled and at least one has `auto_disabled_at` set (`AutoDisableFailingWebhooks`, 10 failures/72h) |

Precedence: any enabled match wins (healthy/failing); among all-disabled matches, `auto_disabled` outranks manual `disabled`.

**Open set** — documented per the repo's enum convention ("Open set; tolerate unknown values. Known values: …") in the field's `doc` tag → spec → SDK docstrings.

`failing` goes beyond the minimal none/healthy/disabled shape deliberately: a recent terminal delivery failure is the one signal the old bool actually measured, and it is *not* the same state as disabled (the sweep only trips after 10 consecutive failures with zero successes over 72h). Collapsing it into `healthy` would reproduce the exact class of lie this change removes.

The field is `omitempty` (now optional in the spec) and computed on the enriched read paths only: the account export — **computed there for the first time** — and the dashboard agent list. Non-enriched loads omit it rather than emitting a zero value. Both queries share one SQL fragment (`webhookStatusSQL` in `internal/identity/store.go`).

## Blast radius

- `AgentIdentity` appears on the wire only in the `UserExport` schema and the internal dashboard `GET /api/dashboard/agents`; `/v1/agents*` uses `AgentView` (untouched).
- No hand-written SDK/MCP/CLI/web code read `webhook_healthy` — only the generated model types change. TS SDK → 4.2.0, Python SDK → 4.3.0, changelogs updated.
- Grep-confirmed `webhook_healthy` is gone from every wire surface (spec, generated SDKs, web, mcp, cli); remaining mentions are comments/changelog history.

## Tests

- Store tests rewritten against the live subscriber tables (they previously seeded the dead legacy table, which is why they kept passing) + new coverage: `none` + agent-filter scoping, `disabled`, `auto_disabled`, enabled-outranks-disabled, failing-on-recent-failure, old-failure-doesn't-poison.
- Export test pins `webhook_status=none` for the webhook-less fixture and guards against `webhook_healthy` resurfacing in the JSON.
- Green: `go build ./...`; identity/httpapi/agent/webhook/webhookpub/auth suites (`-p 1`, scratch DB `e2a_test_webhookstatus`, created+dropped); spec golden (`make spec`) clean; `make generate-sdk` clean; TS 123/123; Python 208 passed/18 skipped; MCP 161/161; CLI 108/108.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Btj6LswdbWqSgMavGJzBp