### PR TITLE
fix(mcp): not-found code for resolved/missing pending message + connection-failure test

### DIFF
--- a/mcp/src/client.ts
+++ b/mcp/src/client.ts
@@ -38,6 +38,7 @@ import type {
 } from "@e2a/sdk/v1";
 import type { McpConfig } from "./config.js";
 import type { Scope } from "./tools/tiers.js";
+import { CodedError } from "./tools/util.js";
 
 // Outbound drafts held for human review surface in the message list with
 // this status (the hold vocabulary was unified on `pending_review` across
@@ -335,7 +336,11 @@ export class McpClient {
         .toArray({ limit: DEFAULT_LIST_LIMIT });
       if (rows.some((r) => r.id === messageId)) return address;
     }
-    throw new Error(
+    // Not-found/already-resolved, NOT malformed input — carry the server's
+    // canonical `not_found` code so an agent branching on structuredContent
+    // doesn't wrongly re-validate its arguments (PR #453 review).
+    throw new CodedError(
+      "not_found",
       `pending message ${messageId} not found on any owned agent (it may have already been approved, rejected, or expired).`,
     );
   }

--- a/mcp/src/tools/util.ts
+++ b/mcp/src/tools/util.ts
@@ -52,6 +52,24 @@ export const paginationInput = {
     .describe("Max items in this page (1–100). Defaults to a server-chosen page size (100)."),
 } as const;
 
+// CodedError: a wrapper-thrown error that carries a stable machine `code`
+// from the SERVER'S canonical vocabulary (e.g. "not_found") instead of the
+// blanket `invalid_request` that plain wrapper Errors map to. Use it when the
+// wrapper synthesizes a failure that is semantically NOT a caller-input
+// problem — e.g. ownerOfPending's "pending message not found / already
+// resolved", where an agent branching on `invalid_request` would wrongly
+// re-validate its arguments. No status/request_id ride along: the failure was
+// synthesized by the wrapper, not read off a specific HTTP response. The text
+// form stays the code-less `e2a error: msg` prose (frozen wrapper shape).
+export class CodedError extends Error {
+  readonly code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = "CodedError";
+    this.code = code;
+  }
+}
+
 export async function runTool<T>(fn: () => Promise<T>): Promise<ToolResult> {
   try {
     const result = await fn();
@@ -74,9 +92,10 @@ export async function runTool<T>(fn: () => Promise<T>): Promise<ToolResult> {
     //    retry_after_seconds?, details? }. New agents should branch on this
     //    instead of parsing the text.
     //
-    // The MCP SDK explicitly exempts isError results from outputSchema
-    // validation and allows structuredContent without a declared schema, so
-    // this is additive and non-breaking for every client.
+    // The MCP TS SDK skips outputSchema validation for isError results
+    // server-side and allows structuredContent without a declared schema.
+    // (A client MAY still validate against a declared outputSchema — but no
+    // e2a tool declares one, so this is additive and non-breaking.)
     const structured = structuredError(err);
     // Surface the API envelope's machine-branchable `code` (§6a #4) so an agent
     // can branch on a stable code (e.g. domain_not_verified, message_not_pending,
@@ -116,7 +135,9 @@ export async function runTool<T>(fn: () => Promise<T>): Promise<ToolResult> {
 //                        carry the envelope code (domain_not_verified,
 //                        rate_limited, …); wrapper-thrown validation errors
 //                        (missing agent arg, confirm guard) reuse the server's
-//                        canonical validation code `invalid_request`.
+//                        canonical validation code `invalid_request`; a
+//                        CodedError carries its own server-vocabulary code
+//                        (e.g. `not_found`).
 //   retryable            boolean — ALWAYS present; true when a retry could
 //                        plausibly succeed (429 / 5xx / connection).
 //   status               HTTP status of the API response (0 = connection-level
@@ -150,6 +171,13 @@ function structuredError(err: unknown): { [key: string]: unknown } {
       }
     }
     return out;
+  }
+  // Wrapper-thrown error with an explicit server-vocabulary code (e.g.
+  // ownerOfPending's "not_found" for a pending draft that was already
+  // approved/rejected/expired). Not retryable, and no status/request_id —
+  // the wrapper synthesized it rather than reading it off a response.
+  if (err instanceof CodedError) {
+    return { code: err.code, retryable: false };
   }
   // Wrapper-thrown validation error (plain Error from the MCP layer itself —
   // e.g. "delete_agent requires confirm:true", missing agent selection). It is

--- a/mcp/tests/client.test.ts
+++ b/mcp/tests/client.test.ts
@@ -51,6 +51,19 @@ describe("McpClient review routing (tier-correct endpoints)", () => {
     expect(sdk.messages.get).toHaveBeenCalledWith("bot@test.dev", "msg_p");
     expect(sdk.reviews.get).not.toHaveBeenCalled();
   });
+
+  it("getReview on a missing/resolved pending draft throws not_found, not invalid_request", async () => {
+    // PR #453 review: an already-approved/rejected/expired draft is a
+    // not-found condition — a CodedError with the server's canonical
+    // `not_found` code, so structuredError doesn't mislabel it as a
+    // caller-input problem.
+    const sdk = mockSdk();
+    const c = new McpClient(sdk as never, "bot@test.dev", "agent");
+    await expect(c.getReview("msg_gone")).rejects.toMatchObject({
+      code: "not_found",
+      message: expect.stringContaining("already been approved, rejected, or expired"),
+    });
+  });
 });
 
 // Templates (beta) ride the SDK's `templates` resource through the shared

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach, vi } from "vitest";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { E2AError } from "@e2a/sdk/v1";
+import { E2AConnectionError, E2AError } from "@e2a/sdk/v1";
 import type { McpClient } from "../src/client.js";
 import { buildServer } from "../src/server.js";
 import { assertToolTiersComplete, toolNamesForScope, RUNTIME_TOOLS } from "../src/tools/tiers.js";
@@ -12,7 +12,7 @@ import { registerReviewTools } from "../src/tools/review.js";
 import { registerWebhookTools } from "../src/tools/webhooks.js";
 import { registerEventTools } from "../src/tools/events.js";
 import { registerTemplateTools } from "../src/tools/templates.js";
-import { runTool } from "../src/tools/util.js";
+import { CodedError, runTool } from "../src/tools/util.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 // Build a small RFC822 blob with one attachment so the MessageView's
@@ -1280,6 +1280,40 @@ describe("e2a MCP server", () => {
     // Text form unchanged: prose, no fabricated code bracket.
     const text = (res.content as Array<{ text: string }>)[0]?.text ?? "";
     expect(text).toBe("e2a error: email is required");
+  });
+
+  it("a connection-level failure carries connection_error/retryable/status 0 in structuredContent", async () => {
+    // The SDK's connectionError(...) shape: code connection_error, status 0
+    // (no HTTP response), retryable true — the documented structured form for
+    // "the API was never reached".
+    (stub.send as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new E2AConnectionError({
+        code: "connection_error",
+        message: "connection to https://api.e2a.dev failed: fetch failed",
+        status: 0,
+        retryable: true,
+      }),
+    );
+    const res = await client.callTool({
+      name: "send_message",
+      arguments: { to: ["x@example.com"], subject: "s", text: "b" },
+    });
+    expect(res.isError).toBe(true);
+    expect(res.structuredContent).toEqual({ code: "connection_error", retryable: true, status: 0 });
+  });
+
+  it("a CodedError carries its server-vocabulary code (no status); text stays prose", async () => {
+    // ownerOfPending's "pending draft already approved/rejected/expired" is a
+    // not-found condition, not malformed input — it must NOT surface as
+    // invalid_request (PR #453 review).
+    const res = await runTool(async () => {
+      throw new CodedError("not_found", "pending message msg_p not found on any owned agent");
+    });
+    expect(res.isError).toBe(true);
+    expect(res.structuredContent).toEqual({ code: "not_found", retryable: false });
+    expect(res.content[0]?.text).toBe(
+      "e2a error: pending message msg_p not found on any owned agent",
+    );
   });
 
   it("the confirm-guard throw carries invalid_request in structuredContent", async () => {


### PR DESCRIPTION
Follow-up applying the two non-blocking findings from the PR #453 review (MCP structured errors), plus one comment nit. `mcp/` only.

## 1. `ownerOfPending` semantic relabel (`mcp/src/client.ts`)

The "pending message … not found on any owned agent (may have already been approved, rejected, or expired)" throw was a plain `Error`, so `runTool`'s catch-all surfaced it in `structuredContent` as `invalid_request` / `retryable:false` — semantically it's a **not-found / already-resolved** condition, not malformed input; an agent branching on the code would wrongly re-validate its arguments.

- New minimal `CodedError` in `mcp/src/tools/util.ts`: a wrapper-thrown error carrying a stable code from the **server's** vocabulary. The Go handlers use a single canonical `not_found` for every missing resource (reviews.go: `NewError(http.StatusNotFound, "not_found", "review not found")`; no `review_not_found`/`message_not_found` variants exist) — so that's the code reused, not an invented one.
- `structuredError` recognizes it → `{ code: "not_found", retryable: false }`; still no `status`/`request_id` (wrapper-synthesized, not read off an HTTP response).
- **Frozen text format: untouched.** The text stays the code-less `e2a error: msg` wrapper prose, byte-for-byte — no switch to the `[code]` variant.

## 2. Connection-failure `structuredContent` test (`mcp/tests/tools.test.ts`)

Pins the documented shape for "the API was never reached": an `E2AConnectionError` (the SDK `connectionError(...)` shape — the factory itself isn't exported from `@e2a/sdk/v1`, only the class) surfaces `structuredContent` `{ code: "connection_error", retryable: true, status: 0 }`.

## 3. Comment nit (`mcp/src/tools/util.ts`)

Softened the overstated "the MCP SDK explicitly exempts isError results from outputSchema validation" — server-side skip; a client MAY validate when a schema is declared (none of our tools declare one).

## Tests

`npm run build --workspace @e2a/sdk && npm test --workspace @e2a/mcp-server && npm run build --workspace @e2a/mcp-server` — **164/164** (was 161): +1 connection-failure case, +1 `CodedError` structured-shape case, +1 client-routing case pinning the `not_found` throw on a missing/resolved pending draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Btj6LswdbWqSgMavGJzBp