### PR TITLE
fix(sdk)!: uniform from_ property for the reserved-word 'from' field in both SDKs

### DIFF
--- a/cli/src/__tests__/listen.test.ts
+++ b/cli/src/__tests__/listen.test.ts
@@ -161,7 +161,7 @@ describe("listen notification handling", () => {
   it("fetches and prints raw JSON for --json mode", async () => {
     const full = {
       id: "msg_123",
-      _from: "alice@example.com",
+      from_: "alice@example.com",
       delivered_to: "bot@agents.e2a.dev",
       subject: "Hello",
       rawMessage: "U3ViamVjdDogSGVsbG8NCg0KSGkgdGhlcmUh",
@@ -184,7 +184,7 @@ describe("listen notification handling", () => {
   it("forwards exact raw JSON to a generic webhook", async () => {
     const full = {
       id: "msg_123",
-      _from: "alice@example.com",
+      from_: "alice@example.com",
       delivered_to: "bot@agents.e2a.dev",
       subject: "Hello",
       rawMessage: "U3ViamVjdDogSGVsbG8NCg0KSGkgdGhlcmUh",
@@ -231,7 +231,7 @@ describe("listen notification handling", () => {
     const raw = "Subject: Hello\r\n\r\nHi there!";
     const full = {
       id: "msg_123",
-      _from: "alice@example.com",
+      from_: "alice@example.com",
       delivered_to: "bot@agents.e2a.dev",
       subject: "Hello",
       body: { text: "", html: "" },

--- a/cli/src/__tests__/messages.test.ts
+++ b/cli/src/__tests__/messages.test.ts
@@ -16,13 +16,13 @@ function summaries(...items: Array<Record<string, unknown>>) {
 
 const M1 = {
   id: "msg_1",
-  _from: "you@example.com",
+  from_: "you@example.com",
   createdAt: new Date("2026-07-01T10:00:00Z"),
   subject: "re: status",
 };
 const M2 = {
   id: "msg_2",
-  _from: "other@example.com",
+  from_: "other@example.com",
   createdAt: new Date("2026-07-01T10:05:00Z"),
   subject: "re: status",
 };
@@ -73,7 +73,7 @@ describe("messages commands", () => {
     mockList.mockReturnValue(
       summaries({
         id: "msg_evil",
-        _from: 'Evil\tName\n"attacker@x.com"',
+        from_: 'Evil\tName\n"attacker@x.com"',
         createdAt: new Date("2026-07-01T10:00:00Z"),
         subject: "s",
       }),
@@ -88,7 +88,7 @@ describe("messages commands", () => {
     expect(line).toContain('Evil Name "attacker@x.com"');
   });
 
-  it("emits NDJSON with --json, renaming the generated _from to wire-stable from", async () => {
+  it("emits NDJSON with --json, renaming the generated from_ to wire-stable from", async () => {
     mockList.mockReturnValue(summaries(M1));
     const { messagesList } = await import("../commands/messages.js");
     await messagesList({ json: true });
@@ -96,7 +96,7 @@ describe("messages commands", () => {
     const line = mockStdout.mock.calls[0][0] as string;
     const parsed = JSON.parse(line);
     expect(parsed.from).toBe("you@example.com");
-    expect(parsed._from).toBeUndefined();
+    expect(parsed.from_).toBeUndefined();
     expect(parsed.id).toBe("msg_1");
     expect(parsed.createdAt).toBe("2026-07-01T10:00:00.000Z");
   });

--- a/cli/src/commands/messages.ts
+++ b/cli/src/commands/messages.ts
@@ -70,7 +70,7 @@ export async function messagesList(opts: MessagesListOptions): Promise<void> {
       process.stdout.write(JSON.stringify(withWireFrom(m)) + "\n");
     } else {
       process.stdout.write(
-        `${m.id}\t${sanitizeTsvField(m._from)}\t${m.createdAt.toISOString()}\n`,
+        `${m.id}\t${sanitizeTsvField(m.from_)}\t${m.createdAt.toISOString()}\n`,
       );
     }
     count++;
@@ -88,16 +88,16 @@ export function sanitizeTsvField(s: string): string {
 }
 
 /**
- * The generated TS model escapes the reserved-ish `from` property to `_from`
- * (an OpenAPI Generator artifact that a generator bump could change). Rename
- * it back before JSON output so scripts read the wire-stable `.from`, not a
+ * The generated TS model exposes the reserved-word `from` property as `from_`
+ * (name-mapped in generate-oag.sh so both SDKs share one spelling). Rename it
+ * back before JSON output so scripts read the wire-stable `.from`, not a
  * codegen implementation detail.
  */
 function withWireFrom(model: object): Record<string, unknown> {
   const obj: Record<string, unknown> = { ...model };
-  if ("_from" in obj) {
-    obj.from = obj._from;
-    delete obj._from;
+  if ("from_" in obj) {
+    obj.from = obj.from_;
+    delete obj.from_;
   }
   return obj;
 }

--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -1564,7 +1564,9 @@ Break the current `/api/v1` surface directly and move it to
     * **Python: the `python` generator** (pydantic v2 + urllib3) — works as-is:
       typed status-mapped exception hierarchy, safe-by-default retries
       (urllib3 v2 excludes POST, so no duplicate-send on 5xx), `from`→`var_from`
-      alias round-trips correctly.
+      alias round-trips correctly. *(Superseded: the generator is now configured
+      with `--name-mappings from=from_` so both SDKs uniformly expose `from_`;
+      GA review Tier-2 item #33.)*
     * **Pin the image to a released tag** (e.g. `openapitools/openapi-generator-cli:v7.16.0`,
       not `:latest`/SNAPSHOT) and assert the version in the regen-diff gate.
       Output is **deterministic** (regen twice = byte-identical), so

--- a/docs/design/ga-api-review.md
+++ b/docs/design/ga-api-review.md
@@ -177,7 +177,7 @@ warrants a major version bump at publish time.)
 
 **Generated layers — reviewed, strong, no changes:**
 - TS: camelCase, `Date` for `date-time`, typed `ApiException<ErrorEnvelope>` (`error.code`/`requestId` typed), all reshaped models present (`SendResultView`, `AuthVerdict`, `CreateWebhookResponse`; `ApproveResultView` gone).
-- Python: snake_case, `from`→`var_from` alias round-trips, `datetime` for date-time, enum fields are plain `StrictStr` post-strip (forward-compat-tolerant + ergonomic).
+- Python: snake_case, `from`→`from_` alias round-trips (generator name-mapped from the default `var_from` mangle; Tier-2 item #33), `datetime` for date-time, enum fields are plain `StrictStr` post-strip (forward-compat-tolerant + ergonomic).
 
 **Decisions:**
 - **HL-1 ✅** rename hand-layer agent param `address`→`email` (both SDKs) — every email-address param is now `email`. *(Note: BSD `sed` ignores `\b`; used `perl`.)*

--- a/examples/adk-cloud-webhook/webhook.py
+++ b/examples/adk-cloud-webhook/webhook.py
@@ -173,7 +173,7 @@ def _format_email_for_agent(inbound) -> str:
     """
     body = inbound.parsed.text if inbound.parsed else ""
     return (
-        f"From: {inbound.var_from}\n"
+        f"From: {inbound.from_}\n"
         f"Subject: {inbound.subject}\n"
         f"\n"
         f"{body}"

--- a/mcp/src/tools/messages.ts
+++ b/mcp/src/tools/messages.ts
@@ -441,7 +441,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
         return {
           id: email.id,
           conversation_id: email.conversationId,
-          from: email._from,
+          from: email.from_,
           delivered_to: email.deliveredTo,
           to: email.to,
           cc: email.cc,

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -136,7 +136,7 @@ function makeStubClient(
     getMessage: vi.fn(async (id: string, _addr?: string) => ({
       id,
       conversationId: "conv_x",
-      _from: "alice@example.com",
+      from_: "alice@example.com",
       deliveredTo: "bot@example.com",
       to: ["bot@example.com"],
       cc: [],

--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 5.2.0
+
+### Breaking (pre-GA)
+- **The reserved-word wire field `from` is now uniformly exposed as `from_`
+  (PEP 8 trailing underscore) on generated models** (was the generator-mangled
+  `var_from`). Affected models: `Message`, `MessageView`, `MessageSummaryView`,
+  `ReviewView`, `EmailReceivedData`, `EmailSentData`, `EmailFailedData`
+  (generated), plus the generated `list_messages` sender filter parameter. The
+  hand-written layer's `messages.list(from_=...)` already used `from_`, so the
+  SDK now teaches exactly one spelling; the TypeScript SDK exposes the same
+  `from_`. The wire JSON is unchanged — requests and responses still carry
+  `from` (pydantic alias). The webhook/WS `data` payload TypedDicts are
+  wire-true dicts and keep the literal `"from"` key (access as
+  `data["from"]`). Migrate: `message.var_from` → `message.from_`.
+
 ## 5.1.0
 
 ### Breaking (pre-GA)

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "e2a"
-version = "5.1.0"
+version = "5.2.0"
 description = "Python SDK for the e2a protocol — email-to-agent authentication"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdks/python/scripts/generate-oag.sh
+++ b/sdks/python/scripts/generate-oag.sh
@@ -22,9 +22,16 @@ rm -rf "$TMP"
 # on CI's non-root runner. HOME is a writable path for tools that expect it.
 # (Docker Desktop/macOS maps ownership already, so this is a no-op there but
 # required on Linux CI.)
+# --name-mappings / --parameter-name-mappings: the wire field `from` is a
+# Python keyword, which the generator would otherwise escape to the ugly
+# `var_from`. Map it to the PEP-8-standard `from_` (trailing underscore), the
+# same spelling the hand-written layer already uses for request-side params,
+# so the SDK teaches exactly one spelling. Wire JSON stays `from` (the pydantic
+# alias / query-param name are unchanged).
 docker run --rm --user "$(id -u):$(id -g)" -e HOME=/tmp -v "$ROOT:/work" "$IMG" generate \
   -i /work/api/openapi.yaml -g python \
   -o /work/sdks/python/.oag-tmp \
+  --name-mappings from=from_ --parameter-name-mappings from=from_ \
   --additional-properties=packageName=e2a.v1.generated,library=httpx >/dev/null
 
 rm -rf "$DEST"

--- a/sdks/python/src/e2a/v1/client.py
+++ b/sdks/python/src/e2a/v1/client.py
@@ -349,9 +349,10 @@ class MessagesResource:
         until: Optional[str] = None,
         limit: Optional[int] = None,
     ) -> AutoPager[MessageSummaryView]:
-        # `from` is a Python keyword; expose the idiomatic `from_` (PEP 8 trailing
-        # underscore) and translate to the generated base's `var_from` here so the
-        # generator's mangled name never leaks into the public SDK surface.
+        # `from` is a Python keyword; the generator is configured (via
+        # --name-mappings/--parameter-name-mappings in generate-oag.sh) to expose
+        # the idiomatic `from_` (PEP 8 trailing underscore) everywhere, so the
+        # public surface and the generated base share one spelling.
         async def fetch(cursor: Optional[str]) -> Page:
             resp = await self._c._read(
                 lambda h: self._api.list_messages(
@@ -359,7 +360,7 @@ class MessagesResource:
                     direction=direction,
                     read_status=read_status,
                     sort=sort,
-                    var_from=from_,
+                    from_=from_,
                     subject_contains=subject_contains,
                     conversation_id=conversation_id,
                     labels=labels,

--- a/sdks/python/src/e2a/v1/generated/api/messages_api.py
+++ b/sdks/python/src/e2a/v1/generated/api/messages_api.py
@@ -998,7 +998,7 @@ class MessagesApi:
         direction: Annotated[Optional[StrictStr], Field(description="Defaults to inbound.")] = None,
         read_status: Annotated[Optional[StrictStr], Field(description="Inbound only. Filters by inbox read-state (MSG-1). Defaults to unread for inbound, all otherwise.")] = None,
         sort: Annotated[Optional[StrictStr], Field(description="Defaults to desc (newest first).")] = None,
-        var_from: Annotated[Optional[StrictStr], Field(description="Case-insensitive substring match on sender.")] = None,
+        from_: Annotated[Optional[StrictStr], Field(description="Case-insensitive substring match on sender.")] = None,
         subject_contains: Annotated[Optional[StrictStr], Field(description="Case-insensitive substring match on subject.")] = None,
         conversation_id: Optional[StrictStr] = None,
         labels: Annotated[Optional[List[StrictStr]], Field(description="Repeatable; AND-matched.")] = None,
@@ -1031,8 +1031,8 @@ class MessagesApi:
         :type read_status: str
         :param sort: Defaults to desc (newest first).
         :type sort: str
-        :param var_from: Case-insensitive substring match on sender.
-        :type var_from: str
+        :param from_: Case-insensitive substring match on sender.
+        :type from_: str
         :param subject_contains: Case-insensitive substring match on subject.
         :type subject_contains: str
         :param conversation_id:
@@ -1074,7 +1074,7 @@ class MessagesApi:
             direction=direction,
             read_status=read_status,
             sort=sort,
-            var_from=var_from,
+            from_=from_,
             subject_contains=subject_contains,
             conversation_id=conversation_id,
             labels=labels,
@@ -1109,7 +1109,7 @@ class MessagesApi:
         direction: Annotated[Optional[StrictStr], Field(description="Defaults to inbound.")] = None,
         read_status: Annotated[Optional[StrictStr], Field(description="Inbound only. Filters by inbox read-state (MSG-1). Defaults to unread for inbound, all otherwise.")] = None,
         sort: Annotated[Optional[StrictStr], Field(description="Defaults to desc (newest first).")] = None,
-        var_from: Annotated[Optional[StrictStr], Field(description="Case-insensitive substring match on sender.")] = None,
+        from_: Annotated[Optional[StrictStr], Field(description="Case-insensitive substring match on sender.")] = None,
         subject_contains: Annotated[Optional[StrictStr], Field(description="Case-insensitive substring match on subject.")] = None,
         conversation_id: Optional[StrictStr] = None,
         labels: Annotated[Optional[List[StrictStr]], Field(description="Repeatable; AND-matched.")] = None,
@@ -1142,8 +1142,8 @@ class MessagesApi:
         :type read_status: str
         :param sort: Defaults to desc (newest first).
         :type sort: str
-        :param var_from: Case-insensitive substring match on sender.
-        :type var_from: str
+        :param from_: Case-insensitive substring match on sender.
+        :type from_: str
         :param subject_contains: Case-insensitive substring match on subject.
         :type subject_contains: str
         :param conversation_id:
@@ -1185,7 +1185,7 @@ class MessagesApi:
             direction=direction,
             read_status=read_status,
             sort=sort,
-            var_from=var_from,
+            from_=from_,
             subject_contains=subject_contains,
             conversation_id=conversation_id,
             labels=labels,
@@ -1220,7 +1220,7 @@ class MessagesApi:
         direction: Annotated[Optional[StrictStr], Field(description="Defaults to inbound.")] = None,
         read_status: Annotated[Optional[StrictStr], Field(description="Inbound only. Filters by inbox read-state (MSG-1). Defaults to unread for inbound, all otherwise.")] = None,
         sort: Annotated[Optional[StrictStr], Field(description="Defaults to desc (newest first).")] = None,
-        var_from: Annotated[Optional[StrictStr], Field(description="Case-insensitive substring match on sender.")] = None,
+        from_: Annotated[Optional[StrictStr], Field(description="Case-insensitive substring match on sender.")] = None,
         subject_contains: Annotated[Optional[StrictStr], Field(description="Case-insensitive substring match on subject.")] = None,
         conversation_id: Optional[StrictStr] = None,
         labels: Annotated[Optional[List[StrictStr]], Field(description="Repeatable; AND-matched.")] = None,
@@ -1253,8 +1253,8 @@ class MessagesApi:
         :type read_status: str
         :param sort: Defaults to desc (newest first).
         :type sort: str
-        :param var_from: Case-insensitive substring match on sender.
-        :type var_from: str
+        :param from_: Case-insensitive substring match on sender.
+        :type from_: str
         :param subject_contains: Case-insensitive substring match on subject.
         :type subject_contains: str
         :param conversation_id:
@@ -1296,7 +1296,7 @@ class MessagesApi:
             direction=direction,
             read_status=read_status,
             sort=sort,
-            var_from=var_from,
+            from_=from_,
             subject_contains=subject_contains,
             conversation_id=conversation_id,
             labels=labels,
@@ -1326,7 +1326,7 @@ class MessagesApi:
         direction,
         read_status,
         sort,
-        var_from,
+        from_,
         subject_contains,
         conversation_id,
         labels,
@@ -1371,9 +1371,9 @@ class MessagesApi:
             
             _query_params.append(('sort', sort))
             
-        if var_from is not None:
+        if from_ is not None:
             
-            _query_params.append(('from', var_from))
+            _query_params.append(('from', from_))
             
         if subject_contains is not None:
             

--- a/sdks/python/src/e2a/v1/generated/models/email_failed_data.py
+++ b/sdks/python/src/e2a/v1/generated/models/email_failed_data.py
@@ -31,7 +31,7 @@ class EmailFailedData(BaseModel):
     cc: Optional[List[StrictStr]] = None
     conversation_id: Optional[StrictStr] = None
     direction: StrictStr = Field(description="Always \"outbound\" on this event.")
-    var_from: StrictStr = Field(alias="from")
+    from_: StrictStr = Field(alias="from")
     message_id: StrictStr
     message_type: StrictStr = Field(description="Send kind. Open set; tolerate unknown values. Known values: send, reply, forward.")
     method: StrictStr = Field(description="Transport used for the send. Open set; tolerate unknown values. Known values: smtp.")

--- a/sdks/python/src/e2a/v1/generated/models/email_received_data.py
+++ b/sdks/python/src/e2a/v1/generated/models/email_received_data.py
@@ -36,7 +36,7 @@ class EmailReceivedData(BaseModel):
     conversation_id: Optional[StrictStr] = None
     delivered_to: StrictStr = Field(description="The one agent address this per-agent copy was delivered to (scalar by construction — one event per delivery). Fetch key for the message.")
     direction: StrictStr = Field(description="Always \"inbound\" on this event.")
-    var_from: StrictStr = Field(description="Display/reply sender (prefers Reply-To). For the verified identity use authenticated_from.", alias="from")
+    from_: StrictStr = Field(description="Display/reply sender (prefers Reply-To). For the verified identity use authenticated_from.", alias="from")
     message_id: StrictStr
     received_at: datetime
     reply_to: Optional[List[StrictStr]] = None

--- a/sdks/python/src/e2a/v1/generated/models/email_sent_data.py
+++ b/sdks/python/src/e2a/v1/generated/models/email_sent_data.py
@@ -31,7 +31,7 @@ class EmailSentData(BaseModel):
     cc: Optional[List[StrictStr]] = None
     conversation_id: Optional[StrictStr] = None
     direction: StrictStr = Field(description="Always \"outbound\" on this event.")
-    var_from: StrictStr = Field(alias="from")
+    from_: StrictStr = Field(alias="from")
     message_id: StrictStr
     message_type: StrictStr = Field(description="Send kind. Open set; tolerate unknown values. Known values: send, reply, forward.")
     method: StrictStr = Field(description="Transport used for the send. Open set; tolerate unknown values. Known values: smtp.")

--- a/sdks/python/src/e2a/v1/generated/models/message.py
+++ b/sdks/python/src/e2a/v1/generated/models/message.py
@@ -46,7 +46,7 @@ class Message(BaseModel):
     expires_at: datetime
     flag_reason: Optional[StrictStr] = None
     flagged: Optional[StrictBool] = None
-    var_from: StrictStr = Field(alias="from")
+    from_: StrictStr = Field(alias="from")
     html: Optional[StrictStr] = None
     id: StrictStr
     labels: Optional[List[StrictStr]] = None

--- a/sdks/python/src/e2a/v1/generated/models/message_summary_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/message_summary_view.py
@@ -38,7 +38,7 @@ class MessageSummaryView(BaseModel):
     direction: StrictStr
     flag_reason: Optional[StrictStr] = None
     flagged: Optional[StrictBool] = None
-    var_from: StrictStr = Field(alias="from")
+    from_: StrictStr = Field(alias="from")
     id: StrictStr
     labels: List[StrictStr]
     read_status: StrictStr

--- a/sdks/python/src/e2a/v1/generated/models/message_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/message_view.py
@@ -44,7 +44,7 @@ class MessageView(BaseModel):
     direction: StrictStr
     flag_reason: Optional[StrictStr] = None
     flagged: Optional[StrictBool] = None
-    var_from: StrictStr = Field(alias="from")
+    from_: StrictStr = Field(alias="from")
     id: StrictStr
     labels: List[StrictStr]
     parsed: Optional[MessageParsedView] = None

--- a/sdks/python/src/e2a/v1/generated/models/review_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/review_view.py
@@ -33,7 +33,7 @@ class ReviewView(BaseModel):
     direction: StrictStr
     flag_reason: Optional[StrictStr] = None
     flagged: Optional[StrictBool] = None
-    var_from: StrictStr = Field(alias="from")
+    from_: StrictStr = Field(alias="from")
     id: StrictStr = Field(description="The review's id. This is the SAME value as the held message's id (msg_…) — a review IS the held message pending approval, so GET /v1/reviews/{id} and the message id are interchangeable. Intentional and stable.")
     review_status: StrictStr = Field(description="Hold state of this queue item. Open set; tolerate unknown values. Currently always pending_review (the queue lists held items).")
     subject: StrictStr

--- a/sdks/python/tests/test_v1_client.py
+++ b/sdks/python/tests/test_v1_client.py
@@ -62,7 +62,7 @@ _REQUIRED_DEFAULTS = {
     "inbound_policy": "open",
     "name": "n",
     "direction": "inbound",
-    "var_from": "a@x.com",
+    "from_": "a@x.com",
     "labels": [],
     "message_id": "msg_1",
     "delivered_to": "bot@test.dev",

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -374,7 +374,7 @@ wheels = [
 
 [[package]]
 name = "e2a"
-version = "5.1.0"
+version = "5.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 5.2.0
+
+### Breaking (pre-GA)
+- **The reserved-word wire field `from` is now uniformly exposed as `from_` on
+  generated models and the `listMessages` sender filter** (was the
+  private-looking `_from`, an OpenAPI Generator escape artifact). Affected
+  models: `Message`, `MessageView`, `MessageSummaryView`, `ReviewView`,
+  `EmailReceivedData`, `EmailSentData`, `EmailFailedData` (generated). The
+  Python SDK exposes the same `from_` spelling, so both SDKs now teach exactly
+  one name. The wire JSON is unchanged — requests and responses still carry
+  `from`. The hand-written webhook/WS payload interfaces in
+  `webhook-signature.ts` are wire-true and keep the literal `from` property
+  (legal in TS) — those are raw-JSON shapes, not generated models. Migrate:
+  `message._from` → `message.from_`; `list(..., { _from })` → `{ from_ }`.
+
 ## 5.1.0
 
 ### Breaking (pre-GA)

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/sdk",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "description": "TypeScript SDK for e2a — email for AI agents",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/sdks/typescript/scripts/generate-oag.sh
+++ b/sdks/typescript/scripts/generate-oag.sh
@@ -17,9 +17,15 @@ find "$OUT" -name '*.ts' -delete 2>/dev/null || true
 # (Default platform: its fetch call uses a STANDARD RequestInit — no node-fetch
 #  `agent`/`buffer` — so it is native-fetch-compatible once the polyfill import
 #  is stripped below.)
+# --name-mappings / --parameter-name-mappings: the wire field `from` is a
+# reserved word for the generator, which would otherwise escape it to the
+# private-looking `_from`. Map it to `from_` so both SDKs uniformly expose
+# `from_` (matching Python's PEP-8 trailing-underscore convention). Wire JSON
+# stays `from` (baseName / setQueryParam are unchanged).
 docker run --rm --user "$(id -u):$(id -g)" -e HOME=/tmp -v "$ROOT:/work" "$IMG" generate \
   -i /work/api/openapi.yaml -g typescript \
   -o /work/sdks/typescript/src/v1/generated \
+  --name-mappings from=from_ --parameter-name-mappings from=from_ \
   --additional-properties=supportsES6=true,importFileExtension=.js >/dev/null
 
 # Use the runtime's native global fetch (Node 18+, browsers, edge/Workers) — strip

--- a/sdks/typescript/src/v1/generated/apis/MessagesApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/MessagesApi.ts
@@ -216,7 +216,7 @@ export class MessagesApiRequestFactory extends BaseAPIRequestFactory {
      * @param direction Defaults to inbound.
      * @param readStatus Inbound only. Filters by inbox read-state (MSG-1). Defaults to unread for inbound, all otherwise.
      * @param sort Defaults to desc (newest first).
-     * @param _from Case-insensitive substring match on sender.
+     * @param from_ Case-insensitive substring match on sender.
      * @param subjectContains Case-insensitive substring match on subject.
      * @param conversationId 
      * @param labels Repeatable; AND-matched.
@@ -225,7 +225,7 @@ export class MessagesApiRequestFactory extends BaseAPIRequestFactory {
      * @param cursor 
      * @param limit 
      */
-    public async listMessages(email: string, direction?: 'inbound' | 'outbound' | 'all', readStatus?: 'unread' | 'read' | 'all', sort?: 'asc' | 'desc', _from?: string, subjectContains?: string, conversationId?: string, labels?: Array<string>, since?: string, until?: string, cursor?: string, limit?: number, _options?: Configuration): Promise<RequestContext> {
+    public async listMessages(email: string, direction?: 'inbound' | 'outbound' | 'all', readStatus?: 'unread' | 'read' | 'all', sort?: 'asc' | 'desc', from_?: string, subjectContains?: string, conversationId?: string, labels?: Array<string>, since?: string, until?: string, cursor?: string, limit?: number, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
 
         // verify required parameter 'email' is not null or undefined
@@ -269,8 +269,8 @@ export class MessagesApiRequestFactory extends BaseAPIRequestFactory {
         }
 
         // Query Params
-        if (_from !== undefined) {
-            requestContext.setQueryParam("from", ObjectSerializer.serialize(_from, "string", ""));
+        if (from_ !== undefined) {
+            requestContext.setQueryParam("from", ObjectSerializer.serialize(from_, "string", ""));
         }
 
         // Query Params

--- a/sdks/typescript/src/v1/generated/models/EmailFailedData.ts
+++ b/sdks/typescript/src/v1/generated/models/EmailFailedData.ts
@@ -21,7 +21,7 @@ export class EmailFailedData {
     * Always \"outbound\" on this event.
     */
     'direction': string;
-    '_from': string;
+    'from_': string;
     'messageId': string;
     /**
     * Send kind. Open set; tolerate unknown values. Known values: send, reply, forward.
@@ -73,7 +73,7 @@ export class EmailFailedData {
             "format": ""
         },
         {
-            "name": "_from",
+            "name": "from_",
             "baseName": "from",
             "type": "string",
             "format": ""

--- a/sdks/typescript/src/v1/generated/models/EmailReceivedData.ts
+++ b/sdks/typescript/src/v1/generated/models/EmailReceivedData.ts
@@ -37,7 +37,7 @@ export class EmailReceivedData {
     /**
     * Display/reply sender (prefers Reply-To). For the verified identity use authenticated_from.
     */
-    '_from': string;
+    'from_': string;
     'messageId': string;
     'receivedAt': Date;
     'replyTo'?: Array<string>;
@@ -98,7 +98,7 @@ export class EmailReceivedData {
             "format": ""
         },
         {
-            "name": "_from",
+            "name": "from_",
             "baseName": "from",
             "type": "string",
             "format": ""

--- a/sdks/typescript/src/v1/generated/models/EmailSentData.ts
+++ b/sdks/typescript/src/v1/generated/models/EmailSentData.ts
@@ -21,7 +21,7 @@ export class EmailSentData {
     * Always \"outbound\" on this event.
     */
     'direction': string;
-    '_from': string;
+    'from_': string;
     'messageId': string;
     /**
     * Send kind. Open set; tolerate unknown values. Known values: send, reply, forward.
@@ -71,7 +71,7 @@ export class EmailSentData {
             "format": ""
         },
         {
-            "name": "_from",
+            "name": "from_",
             "baseName": "from",
             "type": "string",
             "format": ""

--- a/sdks/typescript/src/v1/generated/models/Message.ts
+++ b/sdks/typescript/src/v1/generated/models/Message.ts
@@ -32,7 +32,7 @@ export class Message {
     'expiresAt': Date;
     'flagReason'?: string;
     'flagged'?: boolean;
-    '_from': string;
+    'from_': string;
     'html'?: string;
     'id': string;
     'labels'?: Array<string> | null;
@@ -173,7 +173,7 @@ export class Message {
             "format": ""
         },
         {
-            "name": "_from",
+            "name": "from_",
             "baseName": "from",
             "type": "string",
             "format": ""

--- a/sdks/typescript/src/v1/generated/models/MessageSummaryView.ts
+++ b/sdks/typescript/src/v1/generated/models/MessageSummaryView.ts
@@ -30,7 +30,7 @@ export class MessageSummaryView {
     'direction': MessageSummaryViewDirectionEnum;
     'flagReason'?: string;
     'flagged'?: boolean;
-    '_from': string;
+    'from_': string;
     'id': string;
     'labels': Array<string>;
     'readStatus': string;
@@ -118,7 +118,7 @@ export class MessageSummaryView {
             "format": ""
         },
         {
-            "name": "_from",
+            "name": "from_",
             "baseName": "from",
             "type": "string",
             "format": ""

--- a/sdks/typescript/src/v1/generated/models/MessageView.ts
+++ b/sdks/typescript/src/v1/generated/models/MessageView.ts
@@ -36,7 +36,7 @@ export class MessageView {
     'direction': MessageViewDirectionEnum;
     'flagReason'?: string;
     'flagged'?: boolean;
-    '_from': string;
+    'from_': string;
     'id': string;
     'labels': Array<string>;
     'parsed'?: MessageParsedView;
@@ -144,7 +144,7 @@ export class MessageView {
             "format": ""
         },
         {
-            "name": "_from",
+            "name": "from_",
             "baseName": "from",
             "type": "string",
             "format": ""

--- a/sdks/typescript/src/v1/generated/models/ReviewView.ts
+++ b/sdks/typescript/src/v1/generated/models/ReviewView.ts
@@ -22,7 +22,7 @@ export class ReviewView {
     'direction': ReviewViewDirectionEnum;
     'flagReason'?: string;
     'flagged'?: boolean;
-    '_from': string;
+    'from_': string;
     /**
     * The review\'s id. This is the SAME value as the held message\'s id (msg_…) — a review IS the held message pending approval, so GET /v1/reviews/{id} and the message id are interchangeable. Intentional and stable.
     */
@@ -76,7 +76,7 @@ export class ReviewView {
             "format": ""
         },
         {
-            "name": "_from",
+            "name": "from_",
             "baseName": "from",
             "type": "string",
             "format": ""

--- a/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
@@ -1186,7 +1186,7 @@ export interface MessagesApiListMessagesRequest {
      * @type string
      * @memberof MessagesApilistMessages
      */
-    _from?: string
+    from_?: string
     /**
      * Case-insensitive substring match on subject.
      * Defaults to: undefined
@@ -1397,7 +1397,7 @@ export class ObjectMessagesApi {
      * @param param the request object
      */
     public listMessagesWithHttpInfo(param: MessagesApiListMessagesRequest, options?: ConfigurationOptions): Promise<HttpInfo<PageMessageSummaryView>> {
-        return this.api.listMessagesWithHttpInfo(param.email, param.direction, param.readStatus, param.sort, param._from, param.subjectContains, param.conversationId, param.labels, param.since, param.until, param.cursor, param.limit,  options).toPromise();
+        return this.api.listMessagesWithHttpInfo(param.email, param.direction, param.readStatus, param.sort, param.from_, param.subjectContains, param.conversationId, param.labels, param.since, param.until, param.cursor, param.limit,  options).toPromise();
     }
 
     /**
@@ -1406,7 +1406,7 @@ export class ObjectMessagesApi {
      * @param param the request object
      */
     public listMessages(param: MessagesApiListMessagesRequest, options?: ConfigurationOptions): Promise<PageMessageSummaryView> {
-        return this.api.listMessages(param.email, param.direction, param.readStatus, param.sort, param._from, param.subjectContains, param.conversationId, param.labels, param.since, param.until, param.cursor, param.limit,  options).toPromise();
+        return this.api.listMessages(param.email, param.direction, param.readStatus, param.sort, param.from_, param.subjectContains, param.conversationId, param.labels, param.since, param.until, param.cursor, param.limit,  options).toPromise();
     }
 
     /**

--- a/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
@@ -1279,7 +1279,7 @@ export class ObservableMessagesApi {
      * @param [direction] Defaults to inbound.
      * @param [readStatus] Inbound only. Filters by inbox read-state (MSG-1). Defaults to unread for inbound, all otherwise.
      * @param [sort] Defaults to desc (newest first).
-     * @param [_from] Case-insensitive substring match on sender.
+     * @param [from_] Case-insensitive substring match on sender.
      * @param [subjectContains] Case-insensitive substring match on subject.
      * @param [conversationId]
      * @param [labels] Repeatable; AND-matched.
@@ -1288,10 +1288,10 @@ export class ObservableMessagesApi {
      * @param [cursor]
      * @param [limit]
      */
-    public listMessagesWithHttpInfo(email: string, direction?: 'inbound' | 'outbound' | 'all', readStatus?: 'unread' | 'read' | 'all', sort?: 'asc' | 'desc', _from?: string, subjectContains?: string, conversationId?: string, labels?: Array<string>, since?: string, until?: string, cursor?: string, limit?: number, _options?: ConfigurationOptions): Observable<HttpInfo<PageMessageSummaryView>> {
+    public listMessagesWithHttpInfo(email: string, direction?: 'inbound' | 'outbound' | 'all', readStatus?: 'unread' | 'read' | 'all', sort?: 'asc' | 'desc', from_?: string, subjectContains?: string, conversationId?: string, labels?: Array<string>, since?: string, until?: string, cursor?: string, limit?: number, _options?: ConfigurationOptions): Observable<HttpInfo<PageMessageSummaryView>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.listMessages(email, direction, readStatus, sort, _from, subjectContains, conversationId, labels, since, until, cursor, limit, _config);
+        const requestContextPromise = this.requestFactory.listMessages(email, direction, readStatus, sort, from_, subjectContains, conversationId, labels, since, until, cursor, limit, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -1315,7 +1315,7 @@ export class ObservableMessagesApi {
      * @param [direction] Defaults to inbound.
      * @param [readStatus] Inbound only. Filters by inbox read-state (MSG-1). Defaults to unread for inbound, all otherwise.
      * @param [sort] Defaults to desc (newest first).
-     * @param [_from] Case-insensitive substring match on sender.
+     * @param [from_] Case-insensitive substring match on sender.
      * @param [subjectContains] Case-insensitive substring match on subject.
      * @param [conversationId]
      * @param [labels] Repeatable; AND-matched.
@@ -1324,8 +1324,8 @@ export class ObservableMessagesApi {
      * @param [cursor]
      * @param [limit]
      */
-    public listMessages(email: string, direction?: 'inbound' | 'outbound' | 'all', readStatus?: 'unread' | 'read' | 'all', sort?: 'asc' | 'desc', _from?: string, subjectContains?: string, conversationId?: string, labels?: Array<string>, since?: string, until?: string, cursor?: string, limit?: number, _options?: ConfigurationOptions): Observable<PageMessageSummaryView> {
-        return this.listMessagesWithHttpInfo(email, direction, readStatus, sort, _from, subjectContains, conversationId, labels, since, until, cursor, limit, _options).pipe(map((apiResponse: HttpInfo<PageMessageSummaryView>) => apiResponse.data));
+    public listMessages(email: string, direction?: 'inbound' | 'outbound' | 'all', readStatus?: 'unread' | 'read' | 'all', sort?: 'asc' | 'desc', from_?: string, subjectContains?: string, conversationId?: string, labels?: Array<string>, since?: string, until?: string, cursor?: string, limit?: number, _options?: ConfigurationOptions): Observable<PageMessageSummaryView> {
+        return this.listMessagesWithHttpInfo(email, direction, readStatus, sort, from_, subjectContains, conversationId, labels, since, until, cursor, limit, _options).pipe(map((apiResponse: HttpInfo<PageMessageSummaryView>) => apiResponse.data));
     }
 
     /**

--- a/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
@@ -932,7 +932,7 @@ export class PromiseMessagesApi {
      * @param [direction] Defaults to inbound.
      * @param [readStatus] Inbound only. Filters by inbox read-state (MSG-1). Defaults to unread for inbound, all otherwise.
      * @param [sort] Defaults to desc (newest first).
-     * @param [_from] Case-insensitive substring match on sender.
+     * @param [from_] Case-insensitive substring match on sender.
      * @param [subjectContains] Case-insensitive substring match on subject.
      * @param [conversationId]
      * @param [labels] Repeatable; AND-matched.
@@ -941,9 +941,9 @@ export class PromiseMessagesApi {
      * @param [cursor]
      * @param [limit]
      */
-    public listMessagesWithHttpInfo(email: string, direction?: 'inbound' | 'outbound' | 'all', readStatus?: 'unread' | 'read' | 'all', sort?: 'asc' | 'desc', _from?: string, subjectContains?: string, conversationId?: string, labels?: Array<string>, since?: string, until?: string, cursor?: string, limit?: number, _options?: PromiseConfigurationOptions): Promise<HttpInfo<PageMessageSummaryView>> {
+    public listMessagesWithHttpInfo(email: string, direction?: 'inbound' | 'outbound' | 'all', readStatus?: 'unread' | 'read' | 'all', sort?: 'asc' | 'desc', from_?: string, subjectContains?: string, conversationId?: string, labels?: Array<string>, since?: string, until?: string, cursor?: string, limit?: number, _options?: PromiseConfigurationOptions): Promise<HttpInfo<PageMessageSummaryView>> {
         const observableOptions = wrapOptions(_options);
-        const result = this.api.listMessagesWithHttpInfo(email, direction, readStatus, sort, _from, subjectContains, conversationId, labels, since, until, cursor, limit, observableOptions);
+        const result = this.api.listMessagesWithHttpInfo(email, direction, readStatus, sort, from_, subjectContains, conversationId, labels, since, until, cursor, limit, observableOptions);
         return result.toPromise();
     }
 
@@ -954,7 +954,7 @@ export class PromiseMessagesApi {
      * @param [direction] Defaults to inbound.
      * @param [readStatus] Inbound only. Filters by inbox read-state (MSG-1). Defaults to unread for inbound, all otherwise.
      * @param [sort] Defaults to desc (newest first).
-     * @param [_from] Case-insensitive substring match on sender.
+     * @param [from_] Case-insensitive substring match on sender.
      * @param [subjectContains] Case-insensitive substring match on subject.
      * @param [conversationId]
      * @param [labels] Repeatable; AND-matched.
@@ -963,9 +963,9 @@ export class PromiseMessagesApi {
      * @param [cursor]
      * @param [limit]
      */
-    public listMessages(email: string, direction?: 'inbound' | 'outbound' | 'all', readStatus?: 'unread' | 'read' | 'all', sort?: 'asc' | 'desc', _from?: string, subjectContains?: string, conversationId?: string, labels?: Array<string>, since?: string, until?: string, cursor?: string, limit?: number, _options?: PromiseConfigurationOptions): Promise<PageMessageSummaryView> {
+    public listMessages(email: string, direction?: 'inbound' | 'outbound' | 'all', readStatus?: 'unread' | 'read' | 'all', sort?: 'asc' | 'desc', from_?: string, subjectContains?: string, conversationId?: string, labels?: Array<string>, since?: string, until?: string, cursor?: string, limit?: number, _options?: PromiseConfigurationOptions): Promise<PageMessageSummaryView> {
         const observableOptions = wrapOptions(_options);
-        const result = this.api.listMessages(email, direction, readStatus, sort, _from, subjectContains, conversationId, labels, since, until, cursor, limit, observableOptions);
+        const result = this.api.listMessages(email, direction, readStatus, sort, from_, subjectContains, conversationId, labels, since, until, cursor, limit, observableOptions);
         return result.toPromise();
     }
 

--- a/web/public/sdk.md
+++ b/web/public/sdk.md
@@ -92,7 +92,7 @@ except E2AWebhookSignatureError:
 if event.type == "email.received":
     data = event.data
     inbound = await client.messages.get(data["delivered_to"], data["message_id"])
-    # inbound.var_from, inbound.subject, inbound.parsed.text
+    # inbound.from_, inbound.subject, inbound.parsed.text
     await client.messages.reply(data["delivered_to"], data["message_id"], {"text": "On it."})
 ```
 


### PR DESCRIPTION
GA-review Tier-2 item #33 (user-approved). The wire field `from` (message sender) is a Python keyword / generator-reserved word, and OpenAPI Generator's default escapes were inconsistent: Python generated models exposed **`var_from`**, TypeScript exposed **`_from`** — two different private-looking manglings — while Python's hand-written request side already used the PEP-8-standard **`from_`**. The SDK taught two spellings; now it teaches one.

## Mechanism (generator configuration, no hand-edits or sed)

Both `sdks/*/scripts/generate-oag.sh` now pass the pinned generator's (`openapi-generator-cli:v7.16.0`) first-class options:

```
--name-mappings from=from_ --parameter-name-mappings from=from_
```

Verified supported by both the `python` and `typescript` generators at v7.16.0. Wire format untouched: the pydantic `alias="from"` / TS `baseName: "from"` / `setQueryParam("from", …)` are all unchanged, and `make spec` produces **zero diff** to `api/openapi.yaml`.

## Before / after

```python
# Python — before                      # after
msg.var_from                           msg.from_
client.messages.list(email, from_=x)   # unchanged (hand layer already from_)
```

```ts
// TypeScript — before                 // after
msg._from                              msg.from_
listMessages(email, …, _from, …)       listMessages(email, …, from_, …)
```

## Affected generated surfaces (both SDKs)

`Message`, `MessageView`, `MessageSummaryView`, `ReviewView`, `EmailReceivedData`, `EmailSentData`, `EmailFailedData`, and the `listMessages`/`list_messages` sender-filter parameter (+ TS `ObjectParamAPI`/`PromiseAPI`/`ObservableAPI` flavors). `latest_from`, `authenticated_from`, `reply_from` etc. are not reserved and are untouched.

## Deliberate reconciliation: hand-written wire-true payload types keep `from`

The #456 hand-written webhook/WS payload types are **raw wire-JSON shapes**, not generated models: TS `webhook-signature.ts` interfaces legally declare the literal `from` property, and Python `webhook_signature.py` TypedDicts carry the `"from"` key (accessed as `data["from"]`). Renaming those would *break* wire-truth for zero gain — the two SDKs are already consistent with each other in that category. So: generated deserialized models uniformly say `from_`; raw-payload typings uniformly say `from`. Docstrings on both already point at the distinction.

## Consumers updated

- Python hand layer `client.py` (`var_from=from_` → `from_=from_`), SDK tests
- CLI `messages.ts` (TSV column + `withWireFrom` JSON normalization — CLI `--json` output still emits wire-stable `from`), CLI tests
- MCP `get_message` tool (`email._from` → `email.from_`), MCP tests
- `examples/adk-cloud-webhook/webhook.py`, `web/public/sdk.md` snippet
- Design docs: `ga-api-review.md` walkthrough line, `api-v1-redesign.md` superseded-note

Noted (pre-existing, not changed here): CLI `listen --json` prints `JSON.stringify` of the SDK model, so its full-message dump emits the generated property name (`from_`, previously `_from`) rather than normalizing to wire `from` like `messages list --json` does — candidate one-line follow-up.

## Version decision

Checked registries: **npm `@e2a/sdk` and PyPI `e2a` both top out at 4.0.1** — the 5.x line has never been published. Pre-release latitude applies: both SDKs bump **5.1.0 → 5.2.0** with a `Breaking (pre-GA)` changelog entry (no major), consistent with how 5.0.0/5.1.0 handled pre-GA breaks.

## Verification

- `make spec`: zero diff (wire untouched)
- `make generate-sdk`: idempotent (second run → `git diff --exit-code` clean)
- TS SDK: `tsc` clean, 143/143 tests pass (contract tests skip without fixtures env, as on main)
- Python SDK: 259 passed, 18 skipped
- CLI: build clean, 108/108
- MCP: build clean, 164/164

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Btj6LswdbWqSgMavGJzBp