### PR TITLE
fix(export): typed attachments (AttachmentMeta) + documented byte semantics for size_bytes

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -282,6 +282,7 @@ components:
           format: int64
           type: integer
         size_bytes:
+          description: DECODED attachment payload size in bytes (Content-Transfer-Encoding undone) — the size of the file a download yields, not its encoded size inside the raw MIME.
           format: int64
           type: integer
       required:
@@ -299,6 +300,7 @@ components:
           format: int64
           type: integer
         size_bytes:
+          description: DECODED attachment payload size in bytes (Content-Transfer-Encoding undone) — the size of the file a download yields, not its encoded size inside the raw MIME.
           format: int64
           type: integer
       required:
@@ -323,6 +325,7 @@ components:
           format: int64
           type: integer
         size_bytes:
+          description: DECODED attachment payload size in bytes (Content-Transfer-Encoding undone) — exactly what download_url serves and what the 256 KB inline cap is checked against; not the encoded size inside the raw MIME.
           format: int64
           type: integer
       required:
@@ -1369,6 +1372,7 @@ components:
           format: int64
           type: integer
         max_storage_bytes:
+          description: Storage-quota cap in bytes, checked against usage.storage_bytes (see its doc for what is counted).
           format: int64
           type: integer
       required:
@@ -1390,6 +1394,7 @@ components:
           format: int64
           type: integer
         storage_bytes:
+          description: "Bytes of stored message content counted against the storage quota: per message, the RAW MIME length (its size_bytes) plus any retained held-draft body/attachment columns (pending_review only; scrubbed on terminal transitions)."
           format: int64
           type: integer
       required:
@@ -1406,7 +1411,12 @@ components:
         approval_expires_at:
           format: date-time
           type: string
-        attachments: {}
+        attachments:
+          items:
+            $ref: "#/components/schemas/AttachmentMeta"
+          type:
+            - array
+            - "null"
         auth:
           $ref: "#/components/schemas/Result"
         auth_headers:
@@ -1495,6 +1505,7 @@ components:
         sent_as:
           type: string
         size_bytes:
+          description: RAW MIME byte length of the whole stored message (octet length of raw_message). Distinct from an attachment's size_bytes (DECODED payload size). Dominant term of storage-quota accounting (usage.storage_bytes).
           format: int64
           type: integer
         status:
@@ -1602,6 +1613,7 @@ components:
           description: "From identity used at relay accept time (outbound only). Open set; tolerate unknown values. Known values: own_address, relay."
           type: string
         size_bytes:
+          description: RAW MIME byte length of the whole stored message (headers + bodies + encoded attachments as transported). Distinct from an attachment's size_bytes, which is its DECODED payload size. This value is the dominant term of the account's storage-quota accounting (usage.storage_bytes).
           format: int64
           type: integer
         subject:
@@ -1693,6 +1705,7 @@ components:
           description: "From identity used at relay accept time (outbound only). Open set; tolerate unknown values. Known values: own_address, relay."
           type: string
         size_bytes:
+          description: RAW MIME byte length of the whole stored message (headers + bodies + encoded attachments as transported). Distinct from attachments[].size_bytes, which is one attachment's DECODED payload size. This value is the dominant term of the account's storage-quota accounting (usage.storage_bytes).
           format: int64
           type: integer
         subject:

--- a/docs/api.md
+++ b/docs/api.md
@@ -217,6 +217,12 @@ Workspace identity, plan limits, keys, suppressions, and data rights.
   all owned data; returns per-table row counts (GDPR Art. 17). Irreversible.
 - `GET /v1/account/export` — JSON dump of every record the account owns (GDPR
   Art. 15). Omits internal identifiers; see [data-handling.md](data-handling.md).
+  Each exported message carries `attachments` as the same typed
+  `AttachmentMeta` metadata (`{filename, content_type, size_bytes, index}`,
+  `size_bytes` = decoded payload) the live API uses; the attachment **bytes**
+  of sent/inbound messages are inside the exported `raw_message`. A held
+  draft's (`pending_review`) staged attachment bytes are internal transient
+  storage and are not inlined.
 - `GET/POST /v1/account/api-keys`, `DELETE /v1/account/api-keys/{id}?confirm=DELETE`
   — mint (plaintext shown once), list (metadata only), and revoke API keys.
   Account scope only.
@@ -310,6 +316,29 @@ an attachment or combined total over its size limit → `413 payload_too_large` 
 limit and offending size are in `error.details`). On `forward`, the limits apply to
 the **combined** set — the original message's carried-over attachments plus any you
 supply. These are conservative starting limits and may be raised over time.
+
+**Byte semantics** — the field name `size_bytes` appears at two levels with two
+different meanings:
+
+- **On a message** (`MessageView` / `MessageSummaryView` / the export's
+  `Message`): the **raw MIME byte length** of the whole stored message —
+  headers + bodies + attachments *as transported* (i.e. base64-encoded
+  attachment parts count at their encoded size). It is the octet length of
+  `raw_message`.
+- **On an attachment** (`attachments[]` on a message, the attachment endpoint,
+  and the `email.received` event's attachment metadata): the **decoded payload
+  size** — the byte count of the file after the Content-Transfer-Encoding is
+  undone; exactly what `download_url` serves, what the 256 KB `?inline` cap is
+  checked against, and what the outbound attachment limits above are enforced
+  on. Because base64 inflates by ~4/3, a message's `size_bytes` is expected to
+  exceed the sum of its attachments' `size_bytes` plus body text.
+- **Storage-quota accounting** (`usage.storage_bytes` vs
+  `limits.max_storage_bytes` on `GET /v1/account`): per stored message, the
+  raw MIME length (the message-level `size_bytes`) **plus** any retained
+  held-draft body/attachment columns (these exist only while a message is
+  `pending_review` and are scrubbed on terminal transitions) — so for
+  sent/inbound messages, storage usage is exactly the sum of their
+  `size_bytes`.
 
 > **Note:** approve/reject a held message via the account-scoped **Reviews**
 > queue below (`POST /v1/reviews/{id}/approve|reject`), which addresses holds by

--- a/docs/events.md
+++ b/docs/events.md
@@ -90,7 +90,7 @@ Every event — on the webhook channel, in this event log, and on the WebSocket 
 
 | Event type | `data` schema | Required fields | Optional fields |
 |---|---|---|---|
-| `email.received` | `EmailReceivedData` | `message_id`, `agent_email`, `direction` (`inbound`), `from` (display/Reply-To sender), `authenticated_from` (the SPF/DKIM/DMARC-verified identity — gate on THIS), `to[]`, `delivered_to` (scalar — the one per-agent copy; the fetch key), `subject`, `auth_headers{}`, `received_at` | `conversation_id`, `cc[]`, `reply_to[]`, `attachments[]` (metadata only: `filename`, `content_type`, `size_bytes`, `index`) |
+| `email.received` | `EmailReceivedData` | `message_id`, `agent_email`, `direction` (`inbound`), `from` (display/Reply-To sender), `authenticated_from` (the SPF/DKIM/DMARC-verified identity — gate on THIS), `to[]`, `delivered_to` (scalar — the one per-agent copy; the fetch key), `subject`, `auth_headers{}`, `received_at` | `conversation_id`, `cc[]`, `reply_to[]`, `attachments[]` (metadata only: `filename`, `content_type`, `size_bytes` — the DECODED payload size, `index`) |
 | `email.sent` | `EmailSentData` | `message_id`, `agent_email`, `direction` (`outbound`), `provider_message_id`, `method`, `from`, `to[]`, `subject`, `message_type` | `conversation_id`, `cc[]`, `bcc[]` |
 | `email.failed` | `EmailFailedData` | `message_id`, `agent_email`, `direction`, `method`, `from`, `to[]`, `subject`, `message_type`, `reason` | `conversation_id`, `cc[]`, `bcc[]`, `reason_code`, `retryable` (present only when genuinely known) |
 | `email.delivered` | `EmailDeliveredData` | `message_id`, `agent_email`, `direction`, `delivered_to` (the one recipient this outcome is about) | `subject`, `smtp_detail` |

--- a/internal/eventpayload/payloads.go
+++ b/internal/eventpayload/payloads.go
@@ -40,8 +40,13 @@ import (
 type AttachmentMeta struct {
 	Filename    string `json:"filename,omitempty"`
 	ContentType string `json:"content_type,omitempty"`
-	SizeBytes   int    `json:"size_bytes"`
-	Index       int    `json:"index" doc:"Stable 0-based attachment index (document order) — the fetch key for the attachment-bytes endpoint."`
+	// SizeBytes is the DECODED attachment payload size — the byte count of the
+	// file after the MIME Content-Transfer-Encoding (base64 / quoted-printable)
+	// is undone: the size of the file a download yields. NOT the encoded
+	// on-the-wire size inside the raw MIME, and NOT the message-level
+	// size_bytes (which is the raw MIME length of the whole message).
+	SizeBytes int `json:"size_bytes" doc:"DECODED attachment payload size in bytes (Content-Transfer-Encoding undone) — the size of the file a download yields, not its encoded size inside the raw MIME."`
+	Index     int `json:"index" doc:"Stable 0-based attachment index (document order) — the fetch key for the attachment-bytes endpoint."`
 }
 
 // EmailReceivedData is the `data` payload of an email.received event. The

--- a/internal/httpapi/account.go
+++ b/internal/httpapi/account.go
@@ -36,15 +36,23 @@ type LimitsCapsView struct {
 	MaxAgents        int   `json:"max_agents"`
 	MaxDomains       int   `json:"max_domains"`
 	MaxMessagesMonth int   `json:"max_messages_month"`
-	MaxStorageBytes  int64 `json:"max_storage_bytes"`
+	MaxStorageBytes  int64 `json:"max_storage_bytes" doc:"Storage-quota cap in bytes, checked against usage.storage_bytes (see its doc for what is counted)."`
 }
 
 // LimitsUsageView is the current consumption snapshot.
+//
+// StorageBytes is the storage-quota accounting basis: per stored message it
+// sums the RAW MIME byte length (raw_message — the message-level size_bytes)
+// PLUS any retained held-draft body columns (body_text, body_html, and the
+// draft attachments blob, which exist only while a message is pending_review
+// and are scrubbed on terminal transitions). Maintained transactionally by a
+// DB trigger on the messages table (migrations 016/039), so for sent/inbound
+// messages it is exactly the sum of their size_bytes values.
 type LimitsUsageView struct {
 	Agents        int   `json:"agents"`
 	Domains       int   `json:"domains"`
 	MessagesMonth int   `json:"messages_month"`
-	StorageBytes  int64 `json:"storage_bytes"`
+	StorageBytes  int64 `json:"storage_bytes" doc:"Bytes of stored message content counted against the storage quota: per message, the RAW MIME length (its size_bytes) plus any retained held-draft body/attachment columns (pending_review only; scrubbed on terminal transitions)."`
 }
 
 type accountOutput struct{ Body AccountView }

--- a/internal/httpapi/attachments.go
+++ b/internal/httpapi/attachments.go
@@ -141,11 +141,15 @@ type attachmentParam struct {
 
 // AttachmentView is the metadata + short-lived download for one attachment.
 // Bytes are NOT included unless inline was requested for a small file.
+// SizeBytes is the DECODED payload size (Content-Transfer-Encoding undone) —
+// exactly the byte count download_url serves and the count the inline cap is
+// checked against. NOT the encoded size inside the raw MIME, and NOT the
+// message-level size_bytes (raw MIME length of the whole message).
 type AttachmentView struct {
 	Index       int       `json:"index"`
 	Filename    string    `json:"filename,omitempty"`
 	ContentType string    `json:"content_type,omitempty"`
-	SizeBytes   int       `json:"size_bytes"`
+	SizeBytes   int       `json:"size_bytes" doc:"DECODED attachment payload size in bytes (Content-Transfer-Encoding undone) — exactly what download_url serves and what the 256 KB inline cap is checked against; not the encoded size inside the raw MIME."`
 	DownloadURL string    `json:"download_url"`
 	ExpiresAt   time.Time `json:"expires_at" format:"date-time"`
 	// Data is the base64 bytes, present ONLY when inline=true and the attachment

--- a/internal/httpapi/messages.go
+++ b/internal/httpapi/messages.go
@@ -47,8 +47,14 @@ type MessageView struct {
 	// the empty case.
 	WebhookStatus string `json:"webhook_status,omitempty"`
 	WebhookError  string `json:"webhook_error,omitempty"`
-	// SizeBytes is the raw_message byte length, mirroring MessageSummaryView.
-	SizeBytes int `json:"size_bytes,omitempty"`
+	// SizeBytes is the RAW MIME byte length of the whole stored message
+	// (octet length of raw_message) — headers + bodies + encoded attachments as
+	// transported. Mirrors MessageSummaryView. Distinct from the per-attachment
+	// size_bytes in attachments[], which is the DECODED payload size of one
+	// attachment. This raw length is also the dominant term of storage-quota
+	// accounting: usage.storage_bytes sums raw_message plus any retained
+	// held-draft body columns per message (see AccountView).
+	SizeBytes int `json:"size_bytes,omitempty" doc:"RAW MIME byte length of the whole stored message (headers + bodies + encoded attachments as transported). Distinct from attachments[].size_bytes, which is one attachment's DECODED payload size. This value is the dominant term of the account's storage-quota accounting (usage.storage_bytes)."`
 	// DeliveryStatus is the outbound delivery rollup (migration 031:
 	// 'sent', 'delivered', 'bounced', …) — the worst recipient status by
 	// precedence. Outbound-only; omitted on inbound messages.
@@ -102,12 +108,15 @@ type MessageView struct {
 
 // AttachmentMetaView is metadata for one attachment of a message — never the
 // bytes. `index` is the stable 0-based attachment index (document order) used to
-// fetch the bytes via the attachment endpoint.
+// fetch the bytes via the attachment endpoint. SizeBytes is the DECODED
+// payload size (Content-Transfer-Encoding undone) — the size of the file a
+// download yields, NOT the encoded size inside the raw MIME and NOT the
+// message-level size_bytes (raw MIME length of the whole message).
 type AttachmentMetaView struct {
 	Index       int    `json:"index"`
 	Filename    string `json:"filename,omitempty"`
 	ContentType string `json:"content_type,omitempty"`
-	SizeBytes   int    `json:"size_bytes"`
+	SizeBytes   int    `json:"size_bytes" doc:"DECODED attachment payload size in bytes (Content-Transfer-Encoding undone) — the size of the file a download yields, not its encoded size inside the raw MIME."`
 }
 
 // MessageParsedView is the parsed-body payload (see MessageView.Parsed).
@@ -244,10 +253,13 @@ type MessageSummaryView struct {
 	// Flagged + FlagReason are the inbound ingestion verdict (migration 033 /
 	// Slice 7). Surfaced in list views so flagged mail is visible without a
 	// per-message drill-down. Inbound-relevant; omitted on unflagged rows.
-	Flagged    bool     `json:"flagged,omitempty"`
-	FlagReason string   `json:"flag_reason,omitempty"`
-	SizeBytes  int      `json:"size_bytes,omitempty"`
-	Labels     []string `json:"labels" nullable:"false"`
+	Flagged    bool   `json:"flagged,omitempty"`
+	FlagReason string `json:"flag_reason,omitempty"`
+	// SizeBytes is the RAW MIME byte length of the whole stored message —
+	// same semantics as MessageView.SizeBytes (see there for the full note,
+	// including its role as the dominant term of storage-quota accounting).
+	SizeBytes int      `json:"size_bytes,omitempty" doc:"RAW MIME byte length of the whole stored message (headers + bodies + encoded attachments as transported). Distinct from an attachment's size_bytes, which is its DECODED payload size. This value is the dominant term of the account's storage-quota accounting (usage.storage_bytes)."`
+	Labels    []string `json:"labels" nullable:"false"`
 	// CreatedAt is the keyset pagination ordering key, emitted at full RFC3339Nano
 	// precision (time.Time) so sub-second ordering is visible on the wire.
 	CreatedAt time.Time `json:"created_at" format:"date-time"`

--- a/internal/httpapi/stability_test.go
+++ b/internal/httpapi/stability_test.go
@@ -197,6 +197,12 @@ func TestSpecEvolutionStanceCoversUnreachableComponents(t *testing.T) {
 	// (they are documentation/codegen components, not operation bodies), and
 	// therefore be covered by the loop above — a rename or a future "attach
 	// them to an operation" refactor must consciously revisit this test.
+	//
+	// Conscious exception: AttachmentMeta. Since the user-data export's Message
+	// schema typed its `attachments` as []AttachmentMeta (one shape everywhere),
+	// AttachmentMeta IS response-reachable (GET /v1/account/export → UserExport
+	// → Message → AttachmentMeta) and is opened by the normal response pass in
+	// applyEvolutionStance. It must still never become request-reachable.
 	for _, name := range eventPayloadComponentNames {
 		if _, ok := schemas[name]; !ok {
 			t.Errorf("event payload component %s missing from the rendered spec", name)
@@ -204,6 +210,12 @@ func TestSpecEvolutionStanceCoversUnreachableComponents(t *testing.T) {
 		}
 		if request[name] {
 			t.Errorf("event payload component %s became request-reachable — it would now be forced strict, breaking additive payload evolution", name)
+		}
+		if name == "AttachmentMeta" {
+			if !response[name] {
+				t.Error("AttachmentMeta expected response-reachable via the export's Message.attachments — if that changed, revisit this exception")
+			}
+			continue
 		}
 		if !unreachable[name] {
 			t.Errorf("event payload component %s expected to be operation-unreachable (got reachable) — update this test's assumptions consciously", name)

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/Mnexa-AI/e2a/internal/dkim"
 	"github.com/Mnexa-AI/e2a/internal/emailauth"
+	"github.com/Mnexa-AI/e2a/internal/eventpayload"
 	"github.com/Mnexa-AI/e2a/internal/inboundpolicy"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -324,10 +325,18 @@ type Message struct {
 	WebhookStatus   string    `json:"webhook_status,omitempty"`
 	WebhookError    string    `json:"webhook_error,omitempty"`
 	WebhookAttempts int       `json:"webhook_attempts,omitempty"`
-	// SizeBytes is the byte length of raw_message. Populated by load paths
-	// that compute it (e.g. GetMessagesByAgent for the dashboard inbox).
-	// Zero on load paths that don't — the inbox renders "—" in that case.
-	SizeBytes int `json:"size_bytes,omitempty"`
+	// SizeBytes is the RAW MIME byte length of the whole stored message —
+	// the octet length of raw_message (headers + bodies + encoded attachments
+	// as transported). NOT a decoded-attachment size: the per-attachment
+	// size_bytes (eventpayload.AttachmentMeta / httpapi.AttachmentMetaView)
+	// is the DECODED payload of one attachment. This raw length is also the
+	// dominant term of storage-quota accounting — the messages storage
+	// trigger (migrations 016/039) sums octet_length(raw_message) plus the
+	// held-draft body columns into account_usage.storage_bytes.
+	// Populated by load paths that compute it (e.g. GetMessagesByAgent for
+	// the dashboard inbox). Zero on load paths that don't — the inbox
+	// renders "—" in that case.
+	SizeBytes int `json:"size_bytes,omitempty" doc:"RAW MIME byte length of the whole stored message (octet length of raw_message). Distinct from an attachment's size_bytes (DECODED payload size). Dominant term of storage-quota accounting (usage.storage_bytes)."`
 	// InboxStatus mirrors messages.inbox_status ('unread' | 'read') for
 	// inbound rows. Kept separate from DeliveryStatus (which currently
 	// carries the same value under a confusing JSON key — see line 161)
@@ -375,11 +384,26 @@ type Message struct {
 	// endpoints leave this empty to avoid a join-per-row cost — the
 	// pending-detail page is where reviewer attribution matters.
 	ReviewedByName  *string         `json:"reviewed_by_name,omitempty"`
-	RejectionReason string          `json:"rejection_reason,omitempty"`
-	Edited          bool            `json:"edited,omitempty"`
-	BodyText        string          `json:"text,omitempty"`
-	BodyHTML        string          `json:"html,omitempty"`
-	AttachmentsJSON json.RawMessage `json:"attachments,omitempty"`
+	RejectionReason string `json:"rejection_reason,omitempty"`
+	Edited          bool   `json:"edited,omitempty"`
+	BodyText        string `json:"text,omitempty"`
+	BodyHTML        string `json:"html,omitempty"`
+	// AttachmentsJSON is the INTERNAL storage blob for a held draft's
+	// attachments (messages.attachments_json): the []outbound.Attachment
+	// shape {filename, content_type, data} with data as base64 bytes. It
+	// exists only while status=pending_review (scrubbed on terminal
+	// transitions) and is what the approve path recomposes the send from.
+	// Never serialized — the wire representation is Attachments below.
+	AttachmentsJSON json.RawMessage `json:"-"`
+	// Attachments is the typed per-attachment METADATA for the wire (the
+	// user-data export's Message schema) — the same AttachmentMeta shape
+	// {filename, content_type, size_bytes (DECODED), index} the live API
+	// (MessageView.attachments, email.received) uses. Populated at export
+	// time: parsed from raw_message when present (inbound + sent outbound),
+	// else mapped from the held-draft AttachmentsJSON blob. Bytes are never
+	// inlined — for sent/inbound messages they are inside the exported
+	// raw_message.
+	Attachments []eventpayload.AttachmentMeta `json:"attachments,omitempty"`
 
 	// Flagged + FlagReason carry the inbound ingestion verdict (migration 033 /
 	// Slice 7): true when the agent's inbound_policy gate flagged this message

--- a/internal/identity/user_data_rights.go
+++ b/internal/identity/user_data_rights.go
@@ -2,10 +2,13 @@ package identity
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
+	"github.com/Mnexa-AI/e2a/internal/eventpayload"
 	"github.com/jackc/pgx/v5"
 )
 
@@ -460,12 +463,75 @@ func scanMessagesForUser(ctx context.Context, tx pgx.Tx, userID string) ([]Messa
 		if len(authHeadersJSON) > 0 {
 			_ = json.Unmarshal(authHeadersJSON, &m.AuthHeaders)
 		}
-		if len(attachmentsJSON) > 0 {
-			m.AttachmentsJSON = json.RawMessage(attachmentsJSON)
-		}
+		// size_bytes: the RAW MIME length of the stored message (same value
+		// the message list/detail views carry, and the dominant term of
+		// storage-quota accounting). Cheap to compute here; a held draft has
+		// no raw_message yet, so the field is omitted (0/omitempty) there.
+		m.SizeBytes = len(m.RawMessage)
+		// attachments: ONE shape everywhere — the export emits the same
+		// AttachmentMeta metadata {filename, content_type, size_bytes
+		// (DECODED), index} the live API uses, mapped at export time. For
+		// sent/inbound messages it is parsed from raw_message (whose exported
+		// bytes still contain the full attachment content); for held drafts
+		// (pending_review, no raw_message yet) it is mapped from the internal
+		// attachments_json blob ([]outbound.Attachment with base64 data),
+		// whose inline base64 bytes are deliberately NOT exported — the blob
+		// is transient internal storage, scrubbed on any terminal transition.
+		m.Attachments = exportAttachmentMeta(m.RawMessage, attachmentsJSON)
 		out = append(out, m)
 	}
 	return out, rows.Err()
+}
+
+// exportAttachmentMeta maps a message's attachments to the wire AttachmentMeta
+// shape for the export. Precedence: raw MIME when present (the authoritative
+// copy, same extraction as the live API), else the held-draft blob. A blob
+// that fails to parse yields nil rather than failing the whole export.
+func exportAttachmentMeta(raw, draftJSON []byte) []eventpayload.AttachmentMeta {
+	if len(raw) > 0 {
+		return eventpayload.AttachmentMetadata(raw)
+	}
+	if len(draftJSON) == 0 {
+		return nil
+	}
+	// The stored draft shape is []outbound.Attachment; decode structurally
+	// here to keep identity free of an outbound dependency.
+	var drafts []struct {
+		Filename    string `json:"filename"`
+		ContentType string `json:"content_type"`
+		Data        string `json:"data"`
+	}
+	if err := json.Unmarshal(draftJSON, &drafts); err != nil {
+		return nil
+	}
+	out := make([]eventpayload.AttachmentMeta, 0, len(drafts))
+	for i, d := range drafts {
+		out = append(out, eventpayload.AttachmentMeta{
+			Filename:    d.Filename,
+			ContentType: d.ContentType,
+			SizeBytes:   decodedBase64Len(d.Data),
+			Index:       i,
+		})
+	}
+	return out
+}
+
+// decodedBase64Len returns the DECODED byte length of a base64 string,
+// tolerating the line-wrapping whitespace mail tooling inserts (mirroring
+// validateAttachments on the accept path). Invalid base64 — which the accept
+// path rejects, so it shouldn't occur — reads as 0 rather than erroring.
+func decodedBase64Len(data string) int {
+	clean := strings.Map(func(r rune) rune {
+		if r == '\r' || r == '\n' || r == ' ' || r == '\t' {
+			return -1
+		}
+		return r
+	}, data)
+	decoded, err := base64.StdEncoding.DecodeString(clean)
+	if err != nil {
+		return 0
+	}
+	return len(decoded)
 }
 
 func scanUsageEventsForUser(ctx context.Context, tx pgx.Tx, userID string) ([]UsageEventEntry, error) {

--- a/internal/identity/user_data_rights_test.go
+++ b/internal/identity/user_data_rights_test.go
@@ -11,10 +11,32 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/testutil"
 )
 
+// seedRawWithAttachment is a raw RFC 5322 multipart message carrying ONE
+// base64 attachment whose DECODED payload is "hello world" (11 bytes). The
+// export must surface it as typed AttachmentMeta with size_bytes = 11 (the
+// decoded size — not the 16-byte base64 wire size inside the MIME).
+const seedRawWithAttachment = "From: alice@gmail.com\r\n" +
+	"Subject: Hi\r\n" +
+	"MIME-Version: 1.0\r\n" +
+	"Content-Type: multipart/mixed; boundary=\"b\"\r\n" +
+	"\r\n" +
+	"--b\r\n" +
+	"Content-Type: text/plain\r\n" +
+	"\r\n" +
+	"body\r\n" +
+	"--b\r\n" +
+	"Content-Type: application/pdf; name=\"report.pdf\"\r\n" +
+	"Content-Disposition: attachment; filename=\"report.pdf\"\r\n" +
+	"Content-Transfer-Encoding: base64\r\n" +
+	"\r\n" +
+	"aGVsbG8gd29ybGQ=\r\n" + // "hello world"
+	"--b--\r\n"
+
 // seedUserData creates one user with: 1 verified domain, 2 agents (one
-// custom-domain, one shared-domain), 1 inbound + 1 outbound message,
-// 2 API keys, 1 user_session, and 2 usage_events. Returns the user so
-// the caller can drive Export/Delete against a known fixture.
+// custom-domain, one shared-domain), 1 inbound (with one MIME attachment) +
+// 1 outbound message + 1 held pending_review draft (with one staged
+// attachment), 2 API keys, 1 user_session, and 2 usage_events. Returns the
+// user so the caller can drive Export/Delete against a known fixture.
 func seedUserData(t *testing.T, store *identity.Store, ctx context.Context, label string) *identity.User {
 	t.Helper()
 
@@ -44,7 +66,7 @@ func seedUserData(t *testing.T, store *identity.Store, ctx context.Context, labe
 		"msg_in_"+label, customAgent.ID,
 		"alice@gmail.com", customAgent.EmailAddress(),
 		"<orig@gmail.com>", "Hi there", "", "delivered",
-		[]byte("From: alice@gmail.com\r\nSubject: Hi\r\n\r\nbody"),
+		[]byte(seedRawWithAttachment),
 		map[string]string{"X-E2A-Auth-Verified": "true"},
 		nil,
 		false, "",
@@ -58,6 +80,17 @@ func seedUserData(t *testing.T, store *identity.Store, ctx context.Context, labe
 		[]string{"alice@gmail.com"}, nil, nil,
 		"Re: Hi", "reply", "smtp", "<sent@e2a.example>", "", nil); err != nil {
 		t.Fatalf("seed: CreateOutboundMessage: %v", err)
+	}
+
+	// Held pending_review draft with one staged attachment ("hello", 5 bytes
+	// decoded). Its internal storage blob carries inline base64 `data`; the
+	// export must surface typed AttachmentMeta and never that blob.
+	draftAtts := []byte(`[{"filename":"notes.txt","content_type":"text/plain","data":"aGVsbG8="}]`)
+	if _, err := store.CreatePendingOutboundMessage(ctx, customAgent.ID,
+		[]string{"alice@gmail.com"}, nil, nil,
+		"Draft subject", "draft body", "", draftAtts,
+		"send", "", "", "", 3600); err != nil {
+		t.Fatalf("seed: CreatePendingOutboundMessage: %v", err)
 	}
 
 	if _, err := store.CreateAPIKey(ctx, user.ID, "primary", nil); err != nil {
@@ -141,8 +174,8 @@ func TestExportUserData(t *testing.T) {
 	if len(dump.APIKeys) != 2 {
 		t.Errorf("api_keys: got %d, want 2", len(dump.APIKeys))
 	}
-	if len(dump.Messages) != 2 {
-		t.Errorf("messages: got %d, want 2 (1 inbound + 1 outbound)", len(dump.Messages))
+	if len(dump.Messages) != 3 {
+		t.Errorf("messages: got %d, want 3 (1 inbound + 1 outbound + 1 held draft)", len(dump.Messages))
 	}
 	if len(dump.Suppressions) != 1 || dump.Suppressions[0].Address != "blocked@spam.com" {
 		t.Errorf("suppressions: got %+v, want 1 (blocked@spam.com)", dump.Suppressions)
@@ -170,6 +203,46 @@ func TestExportUserData(t *testing.T) {
 		t.Errorf("inbound ReplyTo in export = %v, want %v", inbound.ReplyTo, wantReplyTo)
 	}
 
+	// size_bytes on an exported message is the RAW MIME length of the whole
+	// stored message (the storage-accounting basis), not an attachment size.
+	if inbound.SizeBytes != len(seedRawWithAttachment) {
+		t.Errorf("inbound SizeBytes = %d, want %d (raw MIME length)",
+			inbound.SizeBytes, len(seedRawWithAttachment))
+	}
+
+	// Typed attachments (one shape everywhere): the inbound message's
+	// attachments come parsed from raw_message as AttachmentMeta, with
+	// size_bytes = the DECODED payload (11, "hello world") — not the 16-byte
+	// base64 wire size.
+	if len(inbound.Attachments) != 1 {
+		t.Fatalf("inbound attachments in export = %d, want 1", len(inbound.Attachments))
+	}
+	if a := inbound.Attachments[0]; a.Filename != "report.pdf" ||
+		a.ContentType != "application/pdf" || a.SizeBytes != 11 || a.Index != 0 {
+		t.Errorf("inbound attachment meta = %+v, want {report.pdf application/pdf 11 0}", a)
+	}
+
+	// The held draft maps its internal attachments_json blob to the same
+	// AttachmentMeta shape (size_bytes = decoded base64 length, 5 for
+	// "hello") — the inline base64 bytes must NOT be exported.
+	var draft *identity.Message
+	for i := range dump.Messages {
+		if dump.Messages[i].Status == identity.MessageStatusPendingReview {
+			draft = &dump.Messages[i]
+			break
+		}
+	}
+	if draft == nil {
+		t.Fatal("no pending_review draft in export")
+	}
+	if len(draft.Attachments) != 1 {
+		t.Fatalf("draft attachments in export = %d, want 1", len(draft.Attachments))
+	}
+	if a := draft.Attachments[0]; a.Filename != "notes.txt" ||
+		a.ContentType != "text/plain" || a.SizeBytes != 5 || a.Index != 0 {
+		t.Errorf("draft attachment meta = %+v, want {notes.txt text/plain 5 0}", a)
+	}
+
 	// Confirm the export doesn't leak internal identifiers. We marshal
 	// to JSON because the most likely accidental leak path is a struct
 	// field with a `json:` tag we forgot.
@@ -182,6 +255,12 @@ func TestExportUserData(t *testing.T) {
 	}
 	if jsonContains(raw, "key_hash") {
 		t.Error("export leaks key_hash — that's a credential equivalent")
+	}
+	// The held draft's internal attachments_json blob carries inline base64
+	// under a `data` key; the export types attachments as AttachmentMeta and
+	// must not emit that internal storage shape.
+	if jsonContains(raw, "data") {
+		t.Error("export leaks `data` — the held-draft attachment blob's inline base64 must not be exported")
 	}
 	// Schema metadata should be present so consumers can detect format
 	// changes across versions.
@@ -218,8 +297,8 @@ func TestDeleteUserData(t *testing.T) {
 	if res.AgentsDeleted != 1 {
 		t.Errorf("AgentsDeleted = %d, want 1", res.AgentsDeleted)
 	}
-	if res.MessagesDeleted != 2 {
-		t.Errorf("MessagesDeleted = %d, want 2", res.MessagesDeleted)
+	if res.MessagesDeleted != 3 {
+		t.Errorf("MessagesDeleted = %d, want 3", res.MessagesDeleted)
 	}
 	if res.APIKeysDeleted != 2 {
 		t.Errorf("APIKeysDeleted = %d, want 2", res.APIKeysDeleted)
@@ -290,8 +369,8 @@ func TestDeleteUserData_DoesNotAffectOtherUsers(t *testing.T) {
 	if len(dump.Agents) != 1 {
 		t.Errorf("bystander agents: got %d, want 1 — cross-tenant cascade leaked", len(dump.Agents))
 	}
-	if len(dump.Messages) != 2 {
-		t.Errorf("bystander messages: got %d, want 2 — cross-tenant cascade leaked", len(dump.Messages))
+	if len(dump.Messages) != 3 {
+		t.Errorf("bystander messages: got %d, want 3 — cross-tenant cascade leaked", len(dump.Messages))
 	}
 }
 

--- a/sdks/python/src/e2a/v1/generated/models/attachment_meta.py
+++ b/sdks/python/src/e2a/v1/generated/models/attachment_meta.py
@@ -29,7 +29,7 @@ class AttachmentMeta(BaseModel):
     content_type: Optional[StrictStr] = None
     filename: Optional[StrictStr] = None
     index: StrictInt = Field(description="Stable 0-based attachment index (document order) — the fetch key for the attachment-bytes endpoint.")
-    size_bytes: StrictInt
+    size_bytes: StrictInt = Field(description="DECODED attachment payload size in bytes (Content-Transfer-Encoding undone) — the size of the file a download yields, not its encoded size inside the raw MIME.")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["content_type", "filename", "index", "size_bytes"]
 

--- a/sdks/python/src/e2a/v1/generated/models/attachment_meta_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/attachment_meta_view.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, StrictInt, StrictStr
+from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from typing import Optional, Set
 from typing_extensions import Self
@@ -29,7 +29,7 @@ class AttachmentMetaView(BaseModel):
     content_type: Optional[StrictStr] = None
     filename: Optional[StrictStr] = None
     index: StrictInt
-    size_bytes: StrictInt
+    size_bytes: StrictInt = Field(description="DECODED attachment payload size in bytes (Content-Transfer-Encoding undone) — the size of the file a download yields, not its encoded size inside the raw MIME.")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["content_type", "filename", "index", "size_bytes"]
 

--- a/sdks/python/src/e2a/v1/generated/models/attachment_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/attachment_view.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 from datetime import datetime
-from pydantic import BaseModel, ConfigDict, StrictInt, StrictStr
+from pydantic import BaseModel, ConfigDict, Field, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from typing import Optional, Set
 from typing_extensions import Self
@@ -33,7 +33,7 @@ class AttachmentView(BaseModel):
     expires_at: datetime
     filename: Optional[StrictStr] = None
     index: StrictInt
-    size_bytes: StrictInt
+    size_bytes: StrictInt = Field(description="DECODED attachment payload size in bytes (Content-Transfer-Encoding undone) — exactly what download_url serves and what the 256 KB inline cap is checked against; not the encoded size inside the raw MIME.")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["content_type", "data", "download_url", "expires_at", "filename", "index", "size_bytes"]
 

--- a/sdks/python/src/e2a/v1/generated/models/limits_caps_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/limits_caps_view.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, StrictInt
+from pydantic import BaseModel, ConfigDict, Field, StrictInt
 from typing import Any, ClassVar, Dict, List
 from typing import Optional, Set
 from typing_extensions import Self
@@ -29,7 +29,7 @@ class LimitsCapsView(BaseModel):
     max_agents: StrictInt
     max_domains: StrictInt
     max_messages_month: StrictInt
-    max_storage_bytes: StrictInt
+    max_storage_bytes: StrictInt = Field(description="Storage-quota cap in bytes, checked against usage.storage_bytes (see its doc for what is counted).")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["max_agents", "max_domains", "max_messages_month", "max_storage_bytes"]
 

--- a/sdks/python/src/e2a/v1/generated/models/limits_usage_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/limits_usage_view.py
@@ -17,7 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
-from pydantic import BaseModel, ConfigDict, StrictInt
+from pydantic import BaseModel, ConfigDict, Field, StrictInt
 from typing import Any, ClassVar, Dict, List
 from typing import Optional, Set
 from typing_extensions import Self
@@ -29,7 +29,7 @@ class LimitsUsageView(BaseModel):
     agents: StrictInt
     domains: StrictInt
     messages_month: StrictInt
-    storage_bytes: StrictInt
+    storage_bytes: StrictInt = Field(description="Bytes of stored message content counted against the storage quota: per message, the RAW MIME length (its size_bytes) plus any retained held-draft body/attachment columns (pending_review only; scrubbed on terminal transitions).")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["agents", "domains", "messages_month", "storage_bytes"]
 

--- a/sdks/python/src/e2a/v1/generated/models/message.py
+++ b/sdks/python/src/e2a/v1/generated/models/message.py
@@ -20,6 +20,7 @@ import json
 from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictBool, StrictFloat, StrictInt, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional, Union
+from e2a.v1.generated.models.attachment_meta import AttachmentMeta
 from e2a.v1.generated.models.result import Result
 from typing import Optional, Set
 from typing_extensions import Self
@@ -30,7 +31,7 @@ class Message(BaseModel):
     """ # noqa: E501
     agent_email: StrictStr
     approval_expires_at: Optional[datetime] = None
-    attachments: Optional[Any] = None
+    attachments: Optional[List[AttachmentMeta]] = None
     auth: Optional[Result] = None
     auth_headers: Optional[Dict[str, StrictStr]] = None
     bcc: Optional[List[StrictStr]] = None
@@ -63,7 +64,7 @@ class Message(BaseModel):
     scan_action: Optional[StrictStr] = None
     scan_score: Optional[Union[StrictFloat, StrictInt]] = None
     sent_as: Optional[StrictStr] = None
-    size_bytes: Optional[StrictInt] = None
+    size_bytes: Optional[StrictInt] = Field(default=None, description="RAW MIME byte length of the whole stored message (octet length of raw_message). Distinct from an attachment's size_bytes (DECODED payload size). Dominant term of storage-quota accounting (usage.storage_bytes).")
     status: Optional[StrictStr] = None
     subject: StrictStr
     text: Optional[StrictStr] = None
@@ -116,6 +117,13 @@ class Message(BaseModel):
             exclude=excluded_fields,
             exclude_none=True,
         )
+        # override the default output from pydantic by calling `to_dict()` of each item in attachments (list)
+        _items = []
+        if self.attachments:
+            for _item_attachments in self.attachments:
+                if _item_attachments:
+                    _items.append(_item_attachments.to_dict())
+            _dict['attachments'] = _items
         # override the default output from pydantic by calling `to_dict()` of auth
         if self.auth:
             _dict['auth'] = self.auth.to_dict()
@@ -168,7 +176,7 @@ class Message(BaseModel):
         _obj = cls.model_validate({
             "agent_email": obj.get("agent_email"),
             "approval_expires_at": obj.get("approval_expires_at"),
-            "attachments": obj.get("attachments"),
+            "attachments": [AttachmentMeta.from_dict(_item) for _item in obj["attachments"]] if obj.get("attachments") is not None else None,
             "auth": Result.from_dict(obj["auth"]) if obj.get("auth") is not None else None,
             "auth_headers": obj.get("auth_headers"),
             "bcc": obj.get("bcc"),

--- a/sdks/python/src/e2a/v1/generated/models/message_summary_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/message_summary_view.py
@@ -45,7 +45,7 @@ class MessageSummaryView(BaseModel):
     reply_to: Optional[List[StrictStr]] = Field(default=None, description="The parsed Reply-To header of an inbound message. Populated for inbound only; always empty for outbound (a Reply-To you SET on a send is a request-side field and is not echoed back here).")
     review_status: Optional[StrictStr] = Field(default=None, description="Review-hold lifecycle (outbound only). Open set; tolerate unknown values. Known values: pending_review, sent, review_rejected, review_expired_approved, review_expired_rejected. Note: an APPROVED outbound hold reads as sent here — the message view intentionally collapses the approved outcome into the delivery lifecycle. The distinct review_approved spelling appears only in the approve result (SendResultView.status, for inbound release) and the email.review_approved webhook event, not in this field.")
     sent_as: Optional[StrictStr] = Field(default=None, description="From identity used at relay accept time (outbound only). Open set; tolerate unknown values. Known values: own_address, relay.")
-    size_bytes: Optional[StrictInt] = None
+    size_bytes: Optional[StrictInt] = Field(default=None, description="RAW MIME byte length of the whole stored message (headers + bodies + encoded attachments as transported). Distinct from an attachment's size_bytes, which is its DECODED payload size. This value is the dominant term of the account's storage-quota accounting (usage.storage_bytes).")
     subject: StrictStr
     to: List[StrictStr]
     webhook_error: Optional[StrictStr] = None

--- a/sdks/python/src/e2a/v1/generated/models/message_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/message_view.py
@@ -53,7 +53,7 @@ class MessageView(BaseModel):
     reply_to: List[StrictStr] = Field(description="The parsed Reply-To header of an inbound message. Populated for inbound only; always empty for outbound (a Reply-To you SET on a send is a request-side field on the send/reply/forward body and is not echoed back here).")
     review_status: Optional[StrictStr] = Field(default=None, description="Review-hold lifecycle (outbound only). Open set; tolerate unknown values. Known values: pending_review, sent, review_rejected, review_expired_approved, review_expired_rejected. Note: an APPROVED outbound hold reads as sent here — the message view intentionally collapses the approved outcome into the delivery lifecycle. The distinct review_approved spelling appears only in the approve result (SendResultView.status, for inbound release) and the email.review_approved webhook event, not in this field.")
     sent_as: Optional[StrictStr] = Field(default=None, description="From identity used at relay accept time (outbound only). Open set; tolerate unknown values. Known values: own_address, relay.")
-    size_bytes: Optional[StrictInt] = None
+    size_bytes: Optional[StrictInt] = Field(default=None, description="RAW MIME byte length of the whole stored message (headers + bodies + encoded attachments as transported). Distinct from attachments[].size_bytes, which is one attachment's DECODED payload size. This value is the dominant term of the account's storage-quota accounting (usage.storage_bytes).")
     subject: StrictStr
     to: List[StrictStr]
     webhook_error: Optional[StrictStr] = None

--- a/sdks/typescript/src/v1/generated/models/AttachmentMeta.ts
+++ b/sdks/typescript/src/v1/generated/models/AttachmentMeta.ts
@@ -19,6 +19,9 @@ export class AttachmentMeta {
     * Stable 0-based attachment index (document order) — the fetch key for the attachment-bytes endpoint.
     */
     'index': number;
+    /**
+    * DECODED attachment payload size in bytes (Content-Transfer-Encoding undone) — the size of the file a download yields, not its encoded size inside the raw MIME.
+    */
     'sizeBytes': number;
 
     static readonly discriminator: string | undefined = undefined;

--- a/sdks/typescript/src/v1/generated/models/AttachmentMetaView.ts
+++ b/sdks/typescript/src/v1/generated/models/AttachmentMetaView.ts
@@ -16,6 +16,9 @@ export class AttachmentMetaView {
     'contentType'?: string;
     'filename'?: string;
     'index': number;
+    /**
+    * DECODED attachment payload size in bytes (Content-Transfer-Encoding undone) — the size of the file a download yields, not its encoded size inside the raw MIME.
+    */
     'sizeBytes': number;
 
     static readonly discriminator: string | undefined = undefined;

--- a/sdks/typescript/src/v1/generated/models/AttachmentView.ts
+++ b/sdks/typescript/src/v1/generated/models/AttachmentView.ts
@@ -19,6 +19,9 @@ export class AttachmentView {
     'expiresAt': Date;
     'filename'?: string;
     'index': number;
+    /**
+    * DECODED attachment payload size in bytes (Content-Transfer-Encoding undone) — exactly what download_url serves and what the 256 KB inline cap is checked against; not the encoded size inside the raw MIME.
+    */
     'sizeBytes': number;
 
     static readonly discriminator: string | undefined = undefined;

--- a/sdks/typescript/src/v1/generated/models/LimitsCapsView.ts
+++ b/sdks/typescript/src/v1/generated/models/LimitsCapsView.ts
@@ -16,6 +16,9 @@ export class LimitsCapsView {
     'maxAgents': number;
     'maxDomains': number;
     'maxMessagesMonth': number;
+    /**
+    * Storage-quota cap in bytes, checked against usage.storage_bytes (see its doc for what is counted).
+    */
     'maxStorageBytes': number;
 
     static readonly discriminator: string | undefined = undefined;

--- a/sdks/typescript/src/v1/generated/models/LimitsUsageView.ts
+++ b/sdks/typescript/src/v1/generated/models/LimitsUsageView.ts
@@ -16,6 +16,9 @@ export class LimitsUsageView {
     'agents': number;
     'domains': number;
     'messagesMonth': number;
+    /**
+    * Bytes of stored message content counted against the storage quota: per message, the RAW MIME length (its size_bytes) plus any retained held-draft body/attachment columns (pending_review only; scrubbed on terminal transitions).
+    */
     'storageBytes': number;
 
     static readonly discriminator: string | undefined = undefined;

--- a/sdks/typescript/src/v1/generated/models/Message.ts
+++ b/sdks/typescript/src/v1/generated/models/Message.ts
@@ -10,13 +10,14 @@
  * Do not edit the class manually.
  */
 
+import { AttachmentMeta } from '../models/AttachmentMeta.js';
 import { Result } from '../models/Result.js';
 import { HttpFile } from '../http/http.js';
 
 export class Message {
     'agentEmail': string;
     'approvalExpiresAt'?: Date;
-    'attachments'?: any | null;
+    'attachments'?: Array<AttachmentMeta> | null;
     'auth'?: Result;
     'authHeaders'?: { [key: string]: string; };
     'bcc'?: Array<string> | null;
@@ -49,6 +50,9 @@ export class Message {
     'scanAction'?: string;
     'scanScore'?: number;
     'sentAs'?: string;
+    /**
+    * RAW MIME byte length of the whole stored message (octet length of raw_message). Distinct from an attachment\'s size_bytes (DECODED payload size). Dominant term of storage-quota accounting (usage.storage_bytes).
+    */
     'sizeBytes'?: number;
     'status'?: string;
     'subject': string;
@@ -79,7 +83,7 @@ export class Message {
         {
             "name": "attachments",
             "baseName": "attachments",
-            "type": "any",
+            "type": "Array<AttachmentMeta>",
             "format": ""
         },
         {

--- a/sdks/typescript/src/v1/generated/models/MessageSummaryView.ts
+++ b/sdks/typescript/src/v1/generated/models/MessageSummaryView.ts
@@ -46,6 +46,9 @@ export class MessageSummaryView {
     * From identity used at relay accept time (outbound only). Open set; tolerate unknown values. Known values: own_address, relay.
     */
     'sentAs'?: string;
+    /**
+    * RAW MIME byte length of the whole stored message (headers + bodies + encoded attachments as transported). Distinct from an attachment\'s size_bytes, which is its DECODED payload size. This value is the dominant term of the account\'s storage-quota accounting (usage.storage_bytes).
+    */
     'sizeBytes'?: number;
     'subject': string;
     'to': Array<string>;

--- a/sdks/typescript/src/v1/generated/models/MessageView.ts
+++ b/sdks/typescript/src/v1/generated/models/MessageView.ts
@@ -54,6 +54,9 @@ export class MessageView {
     * From identity used at relay accept time (outbound only). Open set; tolerate unknown values. Known values: own_address, relay.
     */
     'sentAs'?: string;
+    /**
+    * RAW MIME byte length of the whole stored message (headers + bodies + encoded attachments as transported). Distinct from attachments[].size_bytes, which is one attachment\'s DECODED payload size. This value is the dominant term of the account\'s storage-quota accounting (usage.storage_bytes).
+    */
     'sizeBytes'?: number;
     'subject': string;
     'to': Array<string>;


### PR DESCRIPTION
Pre-GA data-model documentation + typing fix (GA-review Tier-2 #65). Two related gaps: the field name `size_bytes` carried two different, undocumented meanings, and the user-data export's `Message` schema declared `attachments` as an untyped `{}` while the live API has the concrete `AttachmentMeta` shape (#456).

## `size_bytes` catalog (every wire occurrence, now with a meaning-specific doc in the spec + SDKs)

| Where | Meaning |
|---|---|
| `MessageView.size_bytes`, `MessageSummaryView.size_bytes`, export `Message.size_bytes` | **RAW MIME byte length** of the whole stored message — octet length of `raw_message` (headers + bodies + attachments *as transported*, i.e. base64 parts at encoded size) |
| `AttachmentMetaView.size_bytes` (message `attachments[]`), `AttachmentView.size_bytes` (attachment endpoint), `AttachmentMeta.size_bytes` (`email.received` event) | **DECODED attachment payload size** (Content-Transfer-Encoding undone) — the size of the file a download yields; exactly what `download_url` serves and what the 256 KB inline cap + outbound attachment limits are checked against |
| `usage.storage_bytes` / `limits.max_storage_bytes` (`GET /v1/account`) | storage-quota accounting — see below |

Non-wire `SizeBytes` (piguard scan-request internals, screening request) left undocumented on purpose; the legacy dead `agent.LimitsInfo` type is not on any route.

## Storage-quota basis (verified in code, not assumed)

The claim "`usage.storage_bytes` sums message `size_bytes`" is **almost but not exactly true**: the meter is a DB trigger (migrations `016_account_limits.sql` / `039_messages_storage_update_meter.sql`) that per message row sums `octet_length(raw_message) + octet_length(body_text) + octet_length(body_html) + octet_length(attachments_json::text)` into `account_usage.storage_bytes` (INSERT/UPDATE/DELETE deltas). The draft body columns exist only while a message is `pending_review` and are scrubbed on terminal transitions — so for sent/inbound messages storage usage IS exactly the sum of their `size_bytes`, with held drafts adding their staged body/attachment columns on top. Documented exactly that way (AccountView docs + `docs/api.md` "Byte semantics" note).

## Export attachments: mapped to `AttachmentMeta` (one shape everywhere)

What the export actually emitted today: the raw `messages.attachments_json` blob verbatim — which is the **internal held-draft storage shape** `[]outbound.Attachment` = `{filename, content_type, data}` with `data` as inline base64 bytes; it exists only for `pending_review` drafts (scrubbed on approve/reject/expire), so sent/inbound messages exported **no attachment info at all**.

**The call: map to `AttachmentMeta` at export time** (the task-preferred option):
- messages with `raw_message` (inbound + sent outbound): parsed via the same `eventpayload.AttachmentMetadata`/`mailparse` extraction the live API uses — indexes and sizes agree with `GET .../attachments/{index}`. New information the export previously lacked.
- held drafts (no `raw_message` yet): mapped from the blob, `size_bytes` = decoded base64 length (whitespace-tolerant, mirroring `validateAttachments`).
- Trade-off, made deliberately: a held draft's staged **bytes** no longer appear in the export. They are transient internal storage (`pending_review` only, ≤ 7 days, scrubbed on any terminal transition; once approved-and-sent the full bytes are inside the exported `raw_message`). The export also now populates message-level `size_bytes`. `identity.Message.AttachmentsJSON` stays as the internal field (`json:"-"`) the HITL recompose path reads.

## Other untyped `{}` fields (audited, left as is)

`GET /v1/events` envelope `data`, `template_data` / `test_data` / `suggested_data`, and `TestWebhookRequest.data` are all deliberately-open maps with docs saying so — nothing else in the webhook/export schemas has a concrete-but-untyped shape.

## Spec / SDK / tests

- `make spec` + `make generate-sdk` regenerated; `make generate-check` clean on the committed tree. Export `Message.attachments` is now `$ref AttachmentMeta` array in the spec; all 6 `size_bytes` schema fields carry descriptions.
- Stance test updated **consciously**: `AttachmentMeta` is now response-reachable (export → `Message.attachments`); the anchor still forbids it ever becoming request-reachable.
- Export tests extended: seed now includes a MIME attachment on the inbound message + a held draft with a staged attachment; asserts typed meta (decoded sizes 11/5), raw-MIME `size_bytes`, and that the export never emits a `"data"` key (the old blob leak).
- Green (scratch DB `e2a_test_sizeb`, never shared `e2a_test`): `go build ./...`, `internal/identity`, `internal/httpapi`, `internal/eventpayload`, `internal/agent`, `internal/usage`, `internal/limits`; TS SDK 143/143, Python SDK 259 passed, MCP 164/164.
- Docs: `docs/api.md` gains a "Byte semantics" note (message vs attachment vs storage accounting) + export-attachments note; `docs/events.md` clarifies the event metadata size is decoded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016Btj6LswdbWqSgMavGJzBp