### PR TITLE
fix(sdk): webhook-verify (py) + WS listener (ts) no longer crash on crafted/transient input

### DIFF
--- a/sdks/python/src/e2a/v1/webhook_signature.py
+++ b/sdks/python/src/e2a/v1/webhook_signature.py
@@ -95,6 +95,12 @@ def verify_webhook_signature(
     # silently disable the replay guard for a t=nan delivery.
     if not math.isfinite(ts):
         return False
+    # float() accepts non-ASCII Unicode digits (e.g. fullwidth "１７５０"), which
+    # clear the checks above but blow up on t.encode("ascii") below. A legitimate
+    # signed timestamp is always ASCII, so a non-ASCII t can never match — reject
+    # it cleanly rather than raising (WH-SIG "never raises" contract).
+    if not t.isascii():
+        return False
     if now is None:
         now = time.time()
     if abs(now - ts) > tolerance_seconds:
@@ -108,6 +114,11 @@ def verify_webhook_signature(
         expected = hmac.new(sec.encode("utf-8"), signed_payload, hashlib.sha256).hexdigest()
         for candidate in v1s:
             if len(candidate) != len(expected):
+                continue
+            # hmac.compare_digest raises TypeError on non-ASCII str; a real
+            # signature is lowercase hex, so a non-ASCII candidate can never
+            # match — skip it instead of raising (never-raises contract).
+            if not candidate.isascii():
                 continue
             if hmac.compare_digest(candidate, expected):
                 return True

--- a/sdks/python/tests/test_webhook_signature.py
+++ b/sdks/python/tests/test_webhook_signature.py
@@ -90,6 +90,29 @@ def test_rejects_malformed_header() -> None:
     assert not verify_webhook_signature("{}", "v1=abc", SECRET)
 
 
+def test_rejects_non_ascii_signature_without_raising() -> None:
+    # Regression: a v1= of exactly 64 non-ASCII chars passes the length gate and
+    # reaches hmac.compare_digest, which raises TypeError on non-ASCII str
+    # ("comparing strings with non-ASCII characters is not supported"). The
+    # documented contract is "never raises" — a malformed signature must be a
+    # clean False, not an unhandled 500 in the caller's webhook handler.
+    body = "{}"
+    t = str(int(time.time()))
+    header = f"t={t},v1={'é' * 64}"  # 64 chars, same length as a real hexdigest
+    assert verify_webhook_signature(body, header, SECRET) is False
+
+
+def test_rejects_unicode_digit_timestamp_without_raising() -> None:
+    # Regression: float() accepts Unicode digits (e.g. fullwidth "１７５０"), so a
+    # non-ASCII t within tolerance cleared the isfinite/replay checks and hit
+    # t.encode("ascii"), raising UnicodeEncodeError. Must be a clean False.
+    now = 1_700_000_000.0
+    fullwidth_t = "".join(chr(ord(c) + 0xFEE0) for c in str(int(now)))
+    assert not fullwidth_t.isascii()  # sanity: the input really is non-ASCII
+    header = f"t={fullwidth_t},v1={_sign(SECRET, fullwidth_t, body='{}')}"
+    assert verify_webhook_signature("{}", header, SECRET, now=now) is False
+
+
 def test_accepts_any_secret_in_a_list() -> None:
     body = "{}"
     t = str(int(time.time()))

--- a/sdks/typescript/src/v1/ws.ts
+++ b/sdks/typescript/src/v1/ws.ts
@@ -289,13 +289,26 @@ export class WSStream extends EventEmitter<WSListenerEvents>
     this.listener.on("open", () => this.emit("open"));
     this.listener.on("close", (code, reason) => this.emit("close", code, reason));
     this.listener.on("error", (err) => {
-      this.emit("error", err);
-      // A typed (fatal) error — e.g. an auth/4xx handshake rejection — ends the
-      // stream: the listener has stopped reconnecting, so mark closed too, then
-      // reject in-flight awaits so the for-await throws the typed error rather
-      // than hanging on a stream that will never deliver again (F6).
-      if (err instanceof E2AError) this.closed = true;
-      this.drainWaitersWithError(err);
+      // Node's EventEmitter THROWS when "error" is emitted with no registered
+      // "error" listener. The documented usage is `for await (const e of
+      // stream)`, which registers async-iterator *waiters*, not an EventEmitter
+      // listener — so emitting unconditionally would crash the whole process on
+      // a routine transient disconnect. Only emit when someone is listening.
+      if (this.listenerCount("error") > 0) this.emit("error", err);
+      // Only a typed (fatal) error ends the stream — e.g. an auth/4xx handshake
+      // rejection or a terminal server close code. The listener has stopped
+      // reconnecting, so mark closed and reject in-flight awaits so the
+      // for-await throws the typed error rather than hanging (F6).
+      //
+      // Transient errors (network blips, a single malformed frame) ride
+      // alongside an automatic reconnect in WSListener — swallow them here so
+      // the async iterator keeps waiting for the reconnected stream, matching
+      // the Python SDK, which logs-and-reconnects and never surfaces transient
+      // failures to `async for`.
+      if (err instanceof E2AError) {
+        this.closed = true;
+        this.drainWaitersWithError(err);
+      }
     });
 
     this.listener.on("event", (notif) => {

--- a/sdks/typescript/src/v1/ws.ts
+++ b/sdks/typescript/src/v1/ws.ts
@@ -279,15 +279,35 @@ export class WSStream extends EventEmitter<WSListenerEvents>
     reject: (err: Error) => void;
   }> = [];
   private closed = false;
+  // A terminal typed error waiting to be observed by iteration. Set when a
+  // fatal error arrives with no waiter in flight (the `for await` body is busy
+  // between pulls); the next `next()` drains any buffered events, then rejects
+  // with this — so the typed error is never silently dropped. Delivered once.
+  private pendingError: E2AError | null = null;
+  // Whether the underlying listener will auto-reconnect on a transient close.
+  // When false, a transient disconnect is terminal for iteration (there is no
+  // redial coming), so the stream must end rather than leave a pull hanging.
+  private readonly reconnectEnabled: boolean;
 
   constructor(opts: WSListenerOptions) {
     super();
+    this.reconnectEnabled = opts.reconnect ?? true;
     this.listener = new WSListener(opts);
 
     // Forward connection-level events to consumers who prefer the
     // EventEmitter interface (or want both).
     this.listener.on("open", () => this.emit("open"));
-    this.listener.on("close", (code, reason) => this.emit("close", code, reason));
+    this.listener.on("close", (code, reason) => {
+      this.emit("close", code, reason);
+      // A transient close with reconnect disabled emits no "error" (nothing is
+      // fatally wrong) yet the listener schedules no redial — so a pending
+      // next() would hang forever. End iteration cleanly. This is deferred to a
+      // microtask because a fatal close emits its typed "error" synchronously
+      // right after this "close"; letting that run first lets the error path
+      // (finishWithError) win, and finish() then no-ops on the already-closed
+      // stream. Mirrors the Python SDK's reconnect=False behavior.
+      if (!this.reconnectEnabled) queueMicrotask(() => this.finish());
+    });
     this.listener.on("error", (err) => {
       // Node's EventEmitter THROWS when "error" is emitted with no registered
       // "error" listener. The documented usage is `for await (const e of
@@ -297,17 +317,20 @@ export class WSStream extends EventEmitter<WSListenerEvents>
       if (this.listenerCount("error") > 0) this.emit("error", err);
       // Only a typed (fatal) error ends the stream — e.g. an auth/4xx handshake
       // rejection or a terminal server close code. The listener has stopped
-      // reconnecting, so mark closed and reject in-flight awaits so the
-      // for-await throws the typed error rather than hanging (F6).
+      // reconnecting, so end iteration and surface the typed error rather than
+      // hang (F6). If a waiter is in flight it rejects immediately; otherwise
+      // the error is held in `pendingError` until the next pull observes it, so
+      // a terminal close that lands while the for-await body is busy is never
+      // silently swallowed.
       //
       // Transient errors (network blips, a single malformed frame) ride
       // alongside an automatic reconnect in WSListener — swallow them here so
       // the async iterator keeps waiting for the reconnected stream, matching
       // the Python SDK, which logs-and-reconnects and never surfaces transient
-      // failures to `async for`.
+      // failures to `async for`. (When reconnect is disabled, the "close"
+      // handler above ends iteration cleanly instead.)
       if (err instanceof E2AError) {
-        this.closed = true;
-        this.drainWaitersWithError(err);
+        this.finishWithError(err);
       }
     });
 
@@ -322,6 +345,9 @@ export class WSStream extends EventEmitter<WSListenerEvents>
   /** Close the connection and end iteration. */
   close(): void {
     this.closed = true;
+    // Explicit close is a clean stop — drop any pending terminal error so the
+    // loop exits with done=true rather than throwing after the caller asked out.
+    this.pendingError = null;
     this.listener.close();
     // Resolve any in-flight awaits with done=true so the loop exits.
     while (this.waiters.length > 0) {
@@ -332,8 +358,17 @@ export class WSStream extends EventEmitter<WSListenerEvents>
   [Symbol.asyncIterator](): AsyncIterator<WSEvent> {
     return {
       next: (): Promise<IteratorResult<WSEvent>> => {
+        // Buffered events drain first — even after a terminal error — so events
+        // that arrived before the close are delivered in order before the error.
         if (this.buffer.length > 0) {
           return Promise.resolve({ value: this.buffer.shift()!, done: false });
+        }
+        // A terminal error that landed with no waiter in flight surfaces here,
+        // exactly once, then the stream reads as a clean terminal done.
+        if (this.pendingError) {
+          const err = this.pendingError;
+          this.pendingError = null;
+          return Promise.reject(err);
         }
         if (this.closed) {
           return Promise.resolve({ value: undefined, done: true });
@@ -357,9 +392,30 @@ export class WSStream extends EventEmitter<WSListenerEvents>
     }
   }
 
-  private drainWaitersWithError(err: Error): void {
+  // End iteration cleanly (done=true). Idempotent — no-ops once the stream has
+  // already terminated (e.g. a fatal "error" beat this "close"-driven finish).
+  private finish(): void {
+    if (this.closed) return;
+    this.closed = true;
     while (this.waiters.length > 0) {
-      this.waiters.shift()!.reject(err);
+      this.waiters.shift()!.resolve({ value: undefined, done: true });
+    }
+  }
+
+  // End iteration with a terminal typed error. A waiter in flight rejects
+  // immediately; with none, the error is parked in `pendingError` for the next
+  // pull to observe (buffered events drain first — see next()). Idempotent.
+  private finishWithError(err: E2AError): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.pendingError = err;
+    if (this.waiters.length > 0) {
+      // A waiter exists ⇒ the buffer is empty (deliver()/next() invariant), so
+      // reject now and mark the error observed.
+      this.pendingError = null;
+      while (this.waiters.length > 0) {
+        this.waiters.shift()!.reject(err);
+      }
     }
   }
 }

--- a/sdks/typescript/test/v1/ws.test.ts
+++ b/sdks/typescript/test/v1/ws.test.ts
@@ -217,3 +217,107 @@ describe("E2AClient.listen()", () => {
     expect(() => c.listen("")).toThrow(/email is required/);
   });
 });
+
+describe("WSStream error handling (async-iterator consumers)", () => {
+  // The documented usage is `for await (const e of client.listen(addr))` with
+  // NO `.on("error")` listener. Node's EventEmitter throws if "error" is emitted
+  // with no registered listener, so the stream must not emit unconditionally,
+  // and transient failures must not end iteration (the socket reconnects).
+  type Handler = (...args: unknown[]) => void;
+  class FakeWS {
+    static instances: FakeWS[] = [];
+    handlers = new Map<string, Handler>();
+    constructor(
+      public url: string,
+      public opts: unknown,
+    ) {
+      FakeWS.instances.push(this);
+    }
+    on(event: string, fn: Handler) {
+      this.handlers.set(event, fn);
+      return this;
+    }
+    close() {}
+    serverOpen() {
+      this.handlers.get("open")?.();
+    }
+    serverError(err: Error) {
+      this.handlers.get("error")?.(err);
+    }
+    serverMessage(obj: unknown) {
+      this.handlers.get("message")?.(Buffer.from(JSON.stringify(obj)));
+    }
+    serverClose(code: number, reason: string) {
+      this.handlers.get("close")?.(code, Buffer.from(reason));
+    }
+  }
+
+  async function makeStream(reconnectDelay = 10) {
+    FakeWS.instances = [];
+    vi.resetModules();
+    vi.doMock("ws", () => ({ default: FakeWS }));
+    const ws = await import("../../src/v1/ws.js");
+    const errors = await import("../../src/v1/errors.js");
+    const stream = new ws.WSStream({
+      apiKey: "k",
+      agentEmail: "bot@x.dev",
+      reconnect: true,
+      reconnectDelay,
+    });
+    return { stream, errors };
+  }
+
+  it("does not crash on a transient transport error under for-await (no error listener) and keeps streaming after reconnect", async () => {
+    vi.useFakeTimers();
+    const { stream } = await makeStream(10);
+
+    // Iterate, register NO EventEmitter "error" listener (the documented path).
+    const iterator = stream[Symbol.asyncIterator]();
+    const nextP = iterator.next(); // registers a waiter
+    const first = FakeWS.instances[0];
+    first.serverOpen();
+
+    // Pre-fix: emit("error") with no listener throws out of the `ws` callback and
+    // crashes the process. Post-fix: a transient error is swallowed — no throw.
+    expect(() => first.serverError(new Error("ECONNREFUSED"))).not.toThrow();
+
+    // ...and a transient error must NOT end iteration; the socket reconnects.
+    first.serverClose(1006, ""); // abnormal close → schedule redial
+    await vi.advanceTimersByTimeAsync(50);
+    expect(FakeWS.instances.length).toBeGreaterThan(1); // redialed
+
+    // The reconnected socket delivers an event → the pending waiter resolves.
+    const latest = FakeWS.instances[FakeWS.instances.length - 1];
+    latest.serverMessage({
+      type: "email.received",
+      id: "evt_1",
+      schema_version: "1",
+      created_at: "2026-07-01T10:30:00Z",
+      data: {},
+    });
+    const res = await nextP;
+    expect(res.done).toBe(false);
+    expect((res.value as { id: string }).id).toBe("evt_1");
+
+    stream.close();
+    vi.useRealTimers();
+    vi.doUnmock("ws");
+    vi.resetModules();
+  });
+
+  it("rejects the for-await iterator with the typed error on a fatal close (4000 replaced) and does not reconnect", async () => {
+    const { stream, errors } = await makeStream();
+    const iterator = stream[Symbol.asyncIterator]();
+    const nextP = iterator.next();
+
+    // Fatal terminal close with no `.on("error")` listener registered. Pre-fix
+    // this crashed the process; post-fix the typed error surfaces to `for await`.
+    FakeWS.instances[0].serverClose(4000, "replaced");
+
+    await expect(nextP).rejects.toBeInstanceOf(errors.E2AConnectionReplacedError);
+    expect(FakeWS.instances).toHaveLength(1); // never redialed
+
+    vi.doUnmock("ws");
+    vi.resetModules();
+  });
+});

--- a/sdks/typescript/test/v1/ws.test.ts
+++ b/sdks/typescript/test/v1/ws.test.ts
@@ -252,7 +252,7 @@ describe("WSStream error handling (async-iterator consumers)", () => {
     }
   }
 
-  async function makeStream(reconnectDelay = 10) {
+  async function makeStream(reconnectDelay = 10, reconnect = true) {
     FakeWS.instances = [];
     vi.resetModules();
     vi.doMock("ws", () => ({ default: FakeWS }));
@@ -261,7 +261,7 @@ describe("WSStream error handling (async-iterator consumers)", () => {
     const stream = new ws.WSStream({
       apiKey: "k",
       agentEmail: "bot@x.dev",
-      reconnect: true,
+      reconnect,
       reconnectDelay,
     });
     return { stream, errors };
@@ -315,6 +315,72 @@ describe("WSStream error handling (async-iterator consumers)", () => {
     FakeWS.instances[0].serverClose(4000, "replaced");
 
     await expect(nextP).rejects.toBeInstanceOf(errors.E2AConnectionReplacedError);
+    expect(FakeWS.instances).toHaveLength(1); // never redialed
+
+    vi.doUnmock("ws");
+    vi.resetModules();
+  });
+
+  it("preserves a fatal error that arrives with no waiter in flight until the next() observes it (P1)", async () => {
+    const { stream, errors } = await makeStream();
+    const iterator = stream[Symbol.asyncIterator]();
+
+    // Simulate the real `for await` window: the loop body is processing an
+    // event, so there is NO pending waiter at the instant the terminal close
+    // lands. Pre-fix, this set `closed` and the typed error was silently lost —
+    // the next `next()` returned a clean `{ done: true }`.
+    FakeWS.instances[0].serverOpen();
+    FakeWS.instances[0].serverClose(4000, "replaced");
+
+    // The next iteration must still surface the typed error, not done:true.
+    await expect(iterator.next()).rejects.toBeInstanceOf(errors.E2AConnectionReplacedError);
+    // Delivered exactly once — a subsequent pull is a clean terminal done.
+    await expect(iterator.next()).resolves.toEqual({ value: undefined, done: true });
+    expect(FakeWS.instances).toHaveLength(1); // never redialed
+
+    vi.doUnmock("ws");
+    vi.resetModules();
+  });
+
+  it("drains buffered events before surfacing a fatal error that arrived with no waiter (P1 ordering)", async () => {
+    const { stream, errors } = await makeStream();
+    const iterator = stream[Symbol.asyncIterator]();
+
+    FakeWS.instances[0].serverOpen();
+    // An event is buffered (no waiter), then the terminal close lands.
+    FakeWS.instances[0].serverMessage({
+      type: "email.received",
+      id: "evt_buffered",
+      schema_version: "1",
+      created_at: "2026-07-01T10:30:00Z",
+      data: {},
+    });
+    FakeWS.instances[0].serverClose(4000, "replaced");
+
+    // Buffered event drains first...
+    const first = await iterator.next();
+    expect(first.done).toBe(false);
+    expect((first.value as { id: string }).id).toBe("evt_buffered");
+    // ...then the typed error surfaces.
+    await expect(iterator.next()).rejects.toBeInstanceOf(errors.E2AConnectionReplacedError);
+
+    vi.doUnmock("ws");
+    vi.resetModules();
+  });
+
+  it("ends iteration on a transient disconnect when reconnect is disabled instead of hanging (P2)", async () => {
+    const { stream } = await makeStream(10, /* reconnect */ false);
+    const iterator = stream[Symbol.asyncIterator]();
+    const nextP = iterator.next(); // registers a waiter
+
+    FakeWS.instances[0].serverOpen();
+    // Transient close (network drop). With reconnect disabled the listener
+    // schedules no redial; pre-fix the stream was never marked closed and this
+    // waiter hung forever. Post-fix iteration ends cleanly (matches Python's
+    // reconnect=False, which returns from iteration after the first disconnect).
+    FakeWS.instances[0].serverClose(1006, "");
+
+    await expect(nextP).resolves.toEqual({ value: undefined, done: true });
     expect(FakeWS.instances).toHaveLength(1); // never redialed
 
     vi.doUnmock("ws");


### PR DESCRIPTION
## Summary

Two verified, low-risk robustness fixes on the client SDK edges, each written test-first with a regression test. **No behavior change for well-formed input; no Go changes.** Both came out of a broader quality/security audit of the API, SDK, and MCP surfaces (see *Follow-ups* below).

## 1. Python SDK — `verify_webhook_signature` no longer raises on crafted input

`verify_webhook_signature` documents a **"never raises"** contract (returns `True`/`False` only), but two attacker-reachable inputs broke it — turning a receiver's clean 401 into an *unhandled 500* (nuisance DoS), and diverging from the TS SDK:

- A `t=` of non-ASCII Unicode digits (e.g. fullwidth `１７５０…`) passes `float()` / `isfinite()` / the replay-window check, then raises `UnicodeEncodeError` at `t.encode("ascii")`.
- A `v1=` of exactly 64 non-ASCII characters clears the `len()` gate, then raises `TypeError` in `hmac.compare_digest` (*"comparing strings with non-ASCII characters is not supported"*).

A legitimate timestamp is ASCII and a legitimate signature is lowercase hex, so both malformed inputs can only ever be non-matching. Two precise guards (`t.isascii()` → `False`, `candidate.isascii()` → skip) return the clean `False` the contract promises. The TS SDK already rejected both, so this is also a parity fix.

## 2. TypeScript SDK — `WSStream` no longer crashes the process on a transient WS error

`WSStream` re-emitted `"error"` unconditionally. Node's `EventEmitter` **throws** when `"error"` is emitted with no registered listener, and the documented usage —

```ts
for await (const event of client.listen("bot@acme.dev")) { … }
```

— registers async-iterator *waiters*, not an EventEmitter `"error"` listener. So a routine transient disconnect (ECONNREFUSED, etc.) crashed the **whole process**, and because the throw fired *before* `drainWaitersWithError`, the iterator never even saw the error.

The fix aligns TS with the Python SDK's contract:

- emit `"error"` only when a listener is registered (`this.listenerCount("error") > 0`) — no crash;
- drain waiters / end the stream **only for typed (fatal) `E2AError`s**. Transient errors ride alongside `WSListener`'s automatic reconnect, so they're swallowed and the async iterator keeps waiting for the reconnected stream instead of throwing on every network blip.

### Behavior-change note

Async-iterator (`for await`) consumers now receive **only fatal errors** (thrown); transient blips are handled transparently by reconnect — matching the Python SDK's async-generator behavior. EventEmitter consumers that register `.on("error")` still receive both transient and fatal errors. A single malformed frame no longer ends the stream.

## Testing

- **Python:** `pytest` — **269 unit tests pass** (2 new regression tests: non-ASCII `v1=`, fullwidth-digit `t=`).
- **TypeScript:** `vitest` — **152 unit tests pass** (2 new `WSStream` regression tests), `tsc` build clean.
- Each fix was written **test-first** (confirmed red reproducing the crash/raise → green after the fix).

## Follow-ups (intentionally out of scope here to keep this minimal)

The audit surfaced further verified items, triaged out of this PR:

- **MCP:** `express.json({ limit: "1mb" })` breaks the advertised 10/25 MB attachment contract (the only transport); no Express error-middleware → stack-trace leak + non-JSON-RPC errors.
- **TS SDK WS:** `close()` doesn't cancel a pending reconnect (zombie connection); unbounded event buffer; no ping/keepalive (half-open sockets undetected).
- **Python SDK:** retry ignores HTTP-date `Retry-After` (TS honors it).
- **Go:** cheap high-value test gaps — SSRF blocklist has no IPv6 / v4-mapped coverage; JWT `alg` not pinned/tested; custom-domain agent-create doesn't validate the email local-part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
