### PR TITLE
fix: reconcile terminal outbound send failures

### DIFF
--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -255,6 +255,7 @@ func main() {
 		outboundJobs = outboundsend.NewJobs(
 			agent.NewOutboundSendStore(store, webhookOutbox, usageTracker),
 			agent.NewOutboundDeliverer(sender),
+			pool,
 		)
 		registrars = append(registrars, outboundJobs)
 	}

--- a/internal/identity/delivery_store.go
+++ b/internal/identity/delivery_store.go
@@ -343,13 +343,16 @@ func (s *Store) MarkOutboundSentTx(ctx context.Context, tx pgx.Tx, messageID, pr
 
 // MarkOutboundFailedTx records, within the caller's transaction, a terminal
 // outbound send failure: delivery_status='failed' + delivery_detail. Returns the
-// row + owning user for the caller to emit email.failed, or nil if the row is gone.
+// row + owning user for the caller to emit email.failed, or nil if the row is gone
+// or already left accepted/sending. The compare-and-set prevents a late worker or
+// reconciler from overwriting a successful or otherwise terminal delivery state.
 func (s *Store) MarkOutboundFailedTx(ctx context.Context, tx pgx.Tx, messageID, detail string) (*OutboundSentInfo, error) {
 	m := &Message{ID: messageID, Direction: "outbound", DeliveryStatus: "failed", DeliveryDetail: detail}
 	err := tx.QueryRow(ctx,
 		`UPDATE messages
 		    SET delivery_status = 'failed', delivery_detail = $2
 		  WHERE id = $1 AND direction = 'outbound'
+		    AND delivery_status IN ('accepted', 'sending')
 		 RETURNING agent_id, subject, message_type, method, conversation_id, sender, to_recipients, cc, bcc`,
 		messageID, nullIfEmpty(detail),
 	).Scan(&m.AgentID, &m.Subject, &m.Type, &m.Method, &m.ConversationID, &m.Sender, &m.ToRecipients, &m.CC, &m.BCC)

--- a/internal/identity/outbound_async_test.go
+++ b/internal/identity/outbound_async_test.go
@@ -192,4 +192,45 @@ func TestMarkOutboundFailedTx(t *testing.T) {
 	if detail != "550 mailbox unavailable" {
 		t.Errorf("delivery_detail = %q, want the failure detail", detail)
 	}
+
+	var sentMsgID string
+	if err := store.WithTx(ctx, func(tx pgx.Tx) error {
+		m, err := store.CreateOutboundMessageTx(ctx, tx, agentID,
+			[]string{"b@gmail.com"}, nil, nil, "Already sent", "send", "smtp", "", "conv-sent",
+			[]byte("raw"), "accepted", "agent@test.e2a.dev", "relay")
+		if err != nil {
+			return err
+		}
+		sentMsgID = m.ID
+		_, err = store.MarkOutboundSentTx(ctx, tx, sentMsgID, "<provider-sent>")
+		return err
+	}); err != nil {
+		t.Fatalf("create sent message: %v", err)
+	}
+
+	if err := store.WithTx(ctx, func(tx pgx.Tx) error {
+		info, err := store.MarkOutboundFailedTx(ctx, tx, sentMsgID, "late terminal job")
+		if info != nil {
+			t.Errorf("MarkOutboundFailedTx(sent) info = %+v, want nil", info)
+		}
+		return err
+	}); err != nil {
+		t.Fatalf("MarkOutboundFailedTx(sent): %v", err)
+	}
+
+	var providerID string
+	if err := pool.QueryRow(ctx,
+		`SELECT delivery_status, provider_message_id, COALESCE(delivery_detail,'') FROM messages WHERE id=$1`, sentMsgID,
+	).Scan(&deliveryStatus, &providerID, &detail); err != nil {
+		t.Fatalf("read sent row: %v", err)
+	}
+	if deliveryStatus != "sent" {
+		t.Errorf("sent row delivery_status = %q, want sent", deliveryStatus)
+	}
+	if providerID != "<provider-sent>" {
+		t.Errorf("sent row provider_message_id = %q, want unchanged", providerID)
+	}
+	if detail != "" {
+		t.Errorf("sent row delivery_detail = %q, want unchanged empty detail", detail)
+	}
 }

--- a/internal/outboundsend/jobs.go
+++ b/internal/outboundsend/jobs.go
@@ -11,35 +11,38 @@ import (
 )
 
 // Jobs is the outbound-send integration on the shared River client: a
-// jobs.Registrar (contributes SendWorker) plus the transactional enqueue entry
-// point the accept-tx calls. The shared client is injected via SetEnqueuer after
-// jobs.New builds it (two-phase wiring, same as webhookdelivery / senderidentity).
+// jobs.Registrar (contributes SendWorker + the terminal reconciler) plus the
+// transactional enqueue entry point the accept-tx calls. The shared client is
+// injected via SetEnqueuer after jobs.New builds it (two-phase wiring, same as
+// webhookdelivery / senderidentity).
 type Jobs struct {
 	store     Store
 	deliverer Deliverer
+	pool      *pgxpool.Pool
 	enq       jobs.Enqueuer
 }
 
-// NewJobs builds the integration with its dependencies (no client yet).
-func NewJobs(store Store, deliverer Deliverer) *Jobs {
-	return &Jobs{store: store, deliverer: deliverer}
+// NewJobs builds the integration with its dependencies (no client yet). pool
+// backs the periodic terminal-state reconciler's scan.
+func NewJobs(store Store, deliverer Deliverer, pool *pgxpool.Pool) *Jobs {
+	return &Jobs{store: store, deliverer: deliverer, pool: pool}
 }
 
 // SetEnqueuer injects the shared client so EnqueueSendTx can insert jobs.
 func (j *Jobs) SetEnqueuer(e jobs.Enqueuer) { j.enq = e }
 
-// RegisterJobs adds the SendWorker to the shared client's bundle. Implements
-// jobs.Registrar.
-//
-// No live periodic reconciler yet (startup cutover only). The one residual it would close: if a
-// job's terminal write (markFailed) fails on all its retries, the worker still
-// cancels/discards the River job, leaving the row `accepted` with a stamped-but-dead
-// job — which ReconcilePending (keyed on send_job_id IS NULL) does not catch. That
-// needs 3+ consecutive DB failures on the terminal write (very rare); a slice-D
-// periodic keyed on `accepted AND the job is terminal/absent` closes it.
+// RegisterJobs adds the SendWorker and terminal-state safety net to the shared
+// client's bundle. Implements jobs.Registrar.
 func (j *Jobs) RegisterJobs(w *river.Workers) []*river.PeriodicJob {
 	river.AddWorker(w, NewSendWorker(j.store, j.deliverer))
-	return nil
+	river.AddWorker(w, NewTerminalReconcileWorker(j.pool, j.store))
+	return []*river.PeriodicJob{
+		river.NewPeriodicJob(
+			river.PeriodicInterval(terminalReconcileInterval),
+			terminalReconcilePeriodicConstructor,
+			&river.PeriodicJobOpts{RunOnStart: false},
+		),
+	}
 }
 
 // ReconcilePending enqueues an outbound_send job for every accepted message that

--- a/internal/outboundsend/reconcile_test.go
+++ b/internal/outboundsend/reconcile_test.go
@@ -2,14 +2,20 @@ package outboundsend_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
 
+	"github.com/Mnexa-AI/e2a/internal/agent"
 	"github.com/Mnexa-AI/e2a/internal/identity"
 	"github.com/Mnexa-AI/e2a/internal/jobs"
 	"github.com/Mnexa-AI/e2a/internal/outboundsend"
 	"github.com/Mnexa-AI/e2a/internal/testutil"
+	"github.com/Mnexa-AI/e2a/internal/usage"
+	"github.com/Mnexa-AI/e2a/internal/webhookpub"
 )
 
 // TestReconcilePending_EnqueuesStrandedAndStamps stands up a REAL River client and
@@ -55,7 +61,7 @@ func TestReconcilePending_EnqueuesStrandedAndStamps(t *testing.T) {
 
 	// Build the integration on a real shared River client so EnqueueSendTx inserts
 	// an actual river_job row. Store/Deliverer unused by the reconcile path.
-	j := outboundsend.NewJobs(nil, nil)
+	j := outboundsend.NewJobs(nil, nil, pool)
 	client, err := jobs.New(pool, jobs.Config{}, j)
 	if err != nil {
 		t.Fatalf("jobs.New: %v", err)
@@ -98,5 +104,205 @@ func TestReconcilePending_EnqueuesStrandedAndStamps(t *testing.T) {
 	}
 	if jobCount != 1 {
 		t.Errorf("after re-run: river_job for %s = %d, want 1 (idempotent)", msgID, jobCount)
+	}
+}
+
+type terminalFixture struct {
+	pool    *pgxpool.Pool
+	store   *identity.Store
+	agentID string
+	jobs    *outboundsend.Jobs
+}
+
+func newTerminalFixture(t *testing.T, pool *pgxpool.Pool, store *identity.Store, outboundStore outboundsend.Store) *terminalFixture {
+	t.Helper()
+	if pool == nil {
+		pool = testutil.TestDB(t)
+		store = identity.NewStore(pool)
+	}
+	ctx := context.Background()
+	if err := jobs.Migrate(ctx, pool); err != nil {
+		t.Fatalf("jobs.Migrate: %v", err)
+	}
+	user, err := store.CreateOrGetUser(ctx, "owner-terminal@example.com", "Owner", "google-terminal")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	domain := "terminal.example.com"
+	if _, err := store.ClaimOrCreateDomain(ctx, domain, user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+	if err := store.VerifyDomain(ctx, domain, user.ID); err != nil {
+		t.Fatalf("VerifyDomain: %v", err)
+	}
+	ag, err := store.CreateAgent(ctx, "bot@"+domain, domain, "", "", "local", user.ID)
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	j := outboundsend.NewJobs(outboundStore, nil, pool)
+	client, err := jobs.New(pool, jobs.Config{}, j)
+	if err != nil {
+		t.Fatalf("jobs.New: %v", err)
+	}
+	j.SetEnqueuer(client)
+	return &terminalFixture{pool: pool, store: store, agentID: ag.ID, jobs: j}
+}
+
+func (f *terminalFixture) seed(t *testing.T, label, messageStatus, jobState string, missing bool) string {
+	t.Helper()
+	ctx := context.Background()
+	var messageID string
+	var jobID int64
+	if err := f.store.WithTx(ctx, func(tx pgx.Tx) error {
+		m, err := f.store.CreateOutboundMessageTx(ctx, tx, f.agentID,
+			[]string{label + "@gmail.com"}, nil, nil, label, "send", "smtp", "", "conv-"+label,
+			[]byte("raw"), "accepted", "bot@terminal.example.com", "relay")
+		if err != nil {
+			return err
+		}
+		messageID = m.ID
+		jobID, err = f.jobs.EnqueueSendTx(ctx, tx, messageID)
+		if err != nil {
+			return err
+		}
+		if err := f.store.StampSendJobIDTx(ctx, tx, messageID, jobID); err != nil {
+			return err
+		}
+		if messageStatus == "sent" {
+			_, err = f.store.MarkOutboundSentTx(ctx, tx, messageID, "<provider-"+label+">")
+		}
+		return err
+	}); err != nil {
+		t.Fatalf("seed %s: %v", label, err)
+	}
+
+	if missing {
+		if _, err := f.pool.Exec(ctx, `DELETE FROM river_job WHERE id=$1`, jobID); err != nil {
+			t.Fatalf("prune job for %s: %v", label, err)
+		}
+	} else if jobState != "" {
+		query := `UPDATE river_job SET state=$2, finalized_at=NULL WHERE id=$1`
+		if jobState == "cancelled" || jobState == "discarded" || jobState == "completed" {
+			query = `UPDATE river_job SET state=$2, finalized_at=now() WHERE id=$1`
+		}
+		if _, err := f.pool.Exec(ctx, query, jobID, jobState); err != nil {
+			t.Fatalf("set job %s state to %s: %v", label, jobState, err)
+		}
+	}
+	return messageID
+}
+
+func (f *terminalFixture) status(t *testing.T, messageID string) (string, string) {
+	t.Helper()
+	var status, detail string
+	if err := f.pool.QueryRow(context.Background(),
+		`SELECT delivery_status, COALESCE(delivery_detail,'') FROM messages WHERE id=$1`, messageID,
+	).Scan(&status, &detail); err != nil {
+		t.Fatalf("read message %s: %v", messageID, err)
+	}
+	return status, detail
+}
+
+func (f *terminalFixture) failedEventCount(t *testing.T, messageID string) int {
+	t.Helper()
+	var count int
+	if err := f.pool.QueryRow(context.Background(),
+		`SELECT count(*) FROM webhook_events WHERE id=$1`,
+		webhookpub.DeterministicEventID(messageID, webhookpub.EventEmailFailed),
+	).Scan(&count); err != nil {
+		t.Fatalf("count email.failed for %s: %v", messageID, err)
+	}
+	return count
+}
+
+func TestTerminalReconcileWorker_ReconcilesOnlyTerminalJobs(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	adapter := agent.NewOutboundSendStore(store,
+		webhookpub.NewOutbox(pool, webhookpub.StaticFlag(true)), usage.NewNoopUsageTracker())
+
+	f := newTerminalFixture(t, pool, store, adapter)
+	discardedID := f.seed(t, "discarded", "accepted", "discarded", false)
+	cancelledID := f.seed(t, "cancelled", "accepted", "cancelled", false)
+	completedID := f.seed(t, "completed", "accepted", "completed", false)
+	retryableID := f.seed(t, "retryable", "accepted", "retryable", false)
+	sentID := f.seed(t, "sent", "sent", "completed", false)
+	missingID := f.seed(t, "missing", "accepted", "", true)
+
+	worker := outboundsend.NewTerminalReconcileWorker(pool, adapter)
+	if err := worker.Work(context.Background(), &river.Job[outboundsend.TerminalReconcileArgs]{}); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name, id, wantStatus, wantState string
+	}{
+		{"discarded", discardedID, "failed", "discarded"},
+		{"cancelled", cancelledID, "failed", "cancelled"},
+		{"completed", completedID, "failed", "completed"},
+		{"retryable", retryableID, "accepted", ""},
+		{"sent", sentID, "sent", ""},
+		{"missing", missingID, "failed", "missing"},
+	} {
+		status, detail := f.status(t, tc.id)
+		if status != tc.wantStatus {
+			t.Errorf("%s status = %q, want %q", tc.name, status, tc.wantStatus)
+		}
+		if tc.wantState != "" {
+			wantDetail := "outbound send job " + tc.wantState + " before terminal delivery status was recorded"
+			if detail != wantDetail {
+				t.Errorf("%s detail = %q, want %q", tc.name, detail, wantDetail)
+			}
+		}
+	}
+	for _, id := range []string{discardedID, cancelledID, completedID, missingID} {
+		if got := f.failedEventCount(t, id); got != 1 {
+			t.Errorf("email.failed count for %s = %d, want 1", id, got)
+		}
+	}
+	for _, id := range []string{retryableID, sentID} {
+		if got := f.failedEventCount(t, id); got != 0 {
+			t.Errorf("email.failed count for untouched %s = %d, want 0", id, got)
+		}
+	}
+
+	if err := worker.Work(context.Background(), &river.Job[outboundsend.TerminalReconcileArgs]{}); err != nil {
+		t.Fatalf("second Work: %v", err)
+	}
+	for _, id := range []string{discardedID, cancelledID, completedID, missingID} {
+		if got := f.failedEventCount(t, id); got != 1 {
+			t.Errorf("email.failed count after second pass for %s = %d, want 1", id, got)
+		}
+	}
+}
+
+type failingTerminalStore struct{ err error }
+
+func (s failingTerminalStore) LoadForSend(context.Context, string) (*outboundsend.SendJob, error) {
+	return nil, nil
+}
+func (s failingTerminalStore) MarkSent(context.Context, string, string, string) error { return nil }
+func (s failingTerminalStore) MarkFailed(context.Context, string, int, string) error {
+	return s.err
+}
+
+func TestTerminalReconcileWorker_PropagatesStoreFailure(t *testing.T) {
+	sentinel := errors.New("mark failed unavailable")
+	f := newTerminalFixture(t, nil, nil, failingTerminalStore{err: sentinel})
+	f.seed(t, "store-error", "accepted", "discarded", false)
+
+	worker := outboundsend.NewTerminalReconcileWorker(f.pool, failingTerminalStore{err: sentinel})
+	err := worker.Work(context.Background(), &river.Job[outboundsend.TerminalReconcileArgs]{})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("Work error = %v, want %v", err, sentinel)
+	}
+}
+
+func TestRegisterJobs_RegistersTerminalReconcilePeriodic(t *testing.T) {
+	j := outboundsend.NewJobs(nil, nil, nil)
+	periodics := j.RegisterJobs(river.NewWorkers())
+	if len(periodics) != 1 {
+		t.Fatalf("RegisterJobs periodics = %d, want 1", len(periodics))
 	}
 }

--- a/internal/outboundsend/reconcile_test.go
+++ b/internal/outboundsend/reconcile_test.go
@@ -3,6 +3,7 @@ package outboundsend_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
@@ -17,6 +18,44 @@ import (
 	"github.com/Mnexa-AI/e2a/internal/usage"
 	"github.com/Mnexa-AI/e2a/internal/webhookpub"
 )
+
+func TestTerminalReconcileIndex(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+
+	var (
+		valid      bool
+		keyColumns int
+		allColumns int
+		definition string
+		predicate  string
+	)
+	if err := pool.QueryRow(ctx,
+		`SELECT i.indisvalid, i.indnkeyatts, i.indnatts,
+		        pg_get_indexdef(i.indexrelid), pg_get_expr(i.indpred, i.indrelid)
+		   FROM pg_class c
+		   JOIN pg_index i ON i.indexrelid = c.oid
+		  WHERE c.relname = 'idx_messages_outbound_terminal_reconcile'`,
+	).Scan(&valid, &keyColumns, &allColumns, &definition, &predicate); err != nil {
+		t.Fatalf("read terminal reconcile index: %v", err)
+	}
+	if !valid {
+		t.Error("terminal reconcile index is invalid")
+	}
+	if keyColumns != 2 || allColumns != 3 {
+		t.Errorf("terminal reconcile index columns = (%d key, %d total), want (2 key, 3 total)", keyColumns, allColumns)
+	}
+	for _, want := range []string{"(created_at, id)", "INCLUDE (send_job_id)"} {
+		if !strings.Contains(definition, want) {
+			t.Errorf("terminal reconcile index definition %q missing %q", definition, want)
+		}
+	}
+	for _, want := range []string{"direction = 'outbound'", "delivery_status", "'accepted'", "'sending'", "send_job_id IS NOT NULL"} {
+		if !strings.Contains(predicate, want) {
+			t.Errorf("terminal reconcile index predicate %q missing %q", predicate, want)
+		}
+	}
+}
 
 // TestReconcilePending_EnqueuesStrandedAndStamps stands up a REAL River client and
 // asserts the slice-C startup cutover: an accepted message with send_job_id IS NULL

--- a/internal/outboundsend/terminal_reconcile.go
+++ b/internal/outboundsend/terminal_reconcile.go
@@ -1,0 +1,95 @@
+package outboundsend
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+
+	"github.com/Mnexa-AI/e2a/internal/jobs"
+)
+
+const terminalReconcileInterval = time.Minute
+
+// TerminalReconcileArgs drives the periodic safety net for outbound messages
+// whose stamped send job reached a terminal state before recording delivery.
+type TerminalReconcileArgs struct{}
+
+func (TerminalReconcileArgs) Kind() string { return "outbound_terminal_reconcile" }
+
+// TerminalReconcileWorker marks accepted/sending outbound messages failed after
+// their stamped River job is terminal or has already been pruned. SendWorker is
+// still the primary owner; the compare-and-set store transition makes races safe.
+type TerminalReconcileWorker struct {
+	river.WorkerDefaults[TerminalReconcileArgs]
+	pool  *pgxpool.Pool
+	store Store
+}
+
+// NewTerminalReconcileWorker builds the periodic safety-net worker.
+func NewTerminalReconcileWorker(pool *pgxpool.Pool, store Store) *TerminalReconcileWorker {
+	return &TerminalReconcileWorker{pool: pool, store: store}
+}
+
+type terminalCandidate struct {
+	messageID string
+	attempt   int
+	state     string
+}
+
+func (w *TerminalReconcileWorker) Work(ctx context.Context, _ *river.Job[TerminalReconcileArgs]) error {
+	rows, err := w.pool.Query(ctx,
+		`SELECT m.id,
+		        COALESCE(r.attempt, 0),
+		        CASE WHEN r.id IS NULL THEN 'missing' ELSE r.state::text END
+		   FROM messages m
+		   LEFT JOIN river_job r ON r.id = m.send_job_id
+		  WHERE m.direction = 'outbound'
+		    AND m.delivery_status IN ('accepted', 'sending')
+		    AND m.send_job_id IS NOT NULL
+		    AND (r.id IS NULL OR r.state IN ('cancelled', 'discarded', 'completed'))
+		  ORDER BY m.created_at ASC, m.id ASC
+		  LIMIT $1`,
+		jobs.DefaultReconcileBatch,
+	)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	candidates := make([]terminalCandidate, 0)
+	for rows.Next() {
+		var candidate terminalCandidate
+		if err := rows.Scan(&candidate.messageID, &candidate.attempt, &candidate.state); err != nil {
+			return err
+		}
+		candidates = append(candidates, candidate)
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+	rows.Close()
+
+	processed := 0
+	for _, candidate := range candidates {
+		detail := fmt.Sprintf("outbound send job %s before terminal delivery status was recorded", candidate.state)
+		if err := w.store.MarkFailed(ctx, candidate.messageID, candidate.attempt, detail); err != nil {
+			if processed > 0 {
+				log.Printf("[outbound-terminal-reconcile] processed %d candidates", processed)
+			}
+			return err
+		}
+		processed++
+	}
+	if processed > 0 {
+		log.Printf("[outbound-terminal-reconcile] processed %d candidates", processed)
+	}
+	return nil
+}
+
+func terminalReconcilePeriodicConstructor() (river.JobArgs, *river.InsertOpts) {
+	return TerminalReconcileArgs{}, &river.InsertOpts{Queue: jobs.QueueMaintenance}
+}

--- a/internal/outboundsend/terminal_reconcile_internal_test.go
+++ b/internal/outboundsend/terminal_reconcile_internal_test.go
@@ -1,0 +1,27 @@
+package outboundsend
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Mnexa-AI/e2a/internal/jobs"
+)
+
+func TestTerminalReconcilePeriodicConstructor_RoutesToMaintenance(t *testing.T) {
+	if terminalReconcileInterval != time.Minute {
+		t.Errorf("terminalReconcileInterval = %s, want %s", terminalReconcileInterval, time.Minute)
+	}
+	args, opts := terminalReconcilePeriodicConstructor()
+	if opts == nil {
+		t.Fatal("constructor returned nil InsertOpts")
+	}
+	if opts.Queue != jobs.QueueMaintenance {
+		t.Errorf("periodic routed to queue %q, want %q", opts.Queue, jobs.QueueMaintenance)
+	}
+	if _, ok := args.(TerminalReconcileArgs); !ok {
+		t.Errorf("constructor returned args of type %T, want TerminalReconcileArgs", args)
+	}
+	if got := args.Kind(); got != "outbound_terminal_reconcile" {
+		t.Errorf("TerminalReconcileArgs.Kind() = %q, want outbound_terminal_reconcile", got)
+	}
+}

--- a/migrations/062_messages_outbound_terminal_reconcile_idx.sql
+++ b/migrations/062_messages_outbound_terminal_reconcile_idx.sql
@@ -1,0 +1,28 @@
+-- 062_messages_outbound_terminal_reconcile_idx.sql
+-- e2a:no-transaction
+--
+-- Partial covering index backing the one-minute outbound terminal reconciler,
+-- which scans accepted/sending messages with a stamped send_job_id and then joins
+-- those ids to river_job to find terminal or already-pruned jobs. The LIMIT bounds
+-- how many candidates one pass processes, while this index bounds the messages-side
+-- scan and supplies the reconciler's deterministic created_at/id order without a
+-- sort on the traffic-scaled messages table.
+--
+-- CREATE INDEX CONCURRENTLY avoids blocking inbound/outbound message persistence
+-- while the index is built on a production-sized messages table. The
+-- e2a:no-transaction directive (see internal/identity/migrate.go) skips the BeginTx
+-- wrapper because Postgres rejects CONCURRENTLY inside a transaction block. The
+-- no-transaction runner requires this file to contain a single statement.
+--
+-- OPS NOTE — invalid-index recovery: if the CONCURRENTLY build is interrupted,
+-- Postgres leaves an INVALID index of this name. On the next startup this migration
+-- re-runs, but CREATE ... IF NOT EXISTS sees the name and skips the rebuild, marking
+-- the migration applied over a broken index. To recover:
+--     DROP INDEX CONCURRENTLY IF EXISTS idx_messages_outbound_terminal_reconcile;
+-- then re-run this statement. Check validity with:
+--     SELECT indisvalid FROM pg_index WHERE indexrelid = 'idx_messages_outbound_terminal_reconcile'::regclass;
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_messages_outbound_terminal_reconcile
+    ON messages (created_at, id) INCLUDE (send_job_id)
+    WHERE direction = 'outbound'
+      AND delivery_status IN ('accepted', 'sending')
+      AND send_job_id IS NOT NULL;


### PR DESCRIPTION
## Summary

- Add a one-minute River maintenance worker that reconciles outbound messages left in `accepted` or `sending` after their stamped send job becomes terminal or is pruned.
- Make the terminal failure transition compare-and-set so a late worker or reconciler cannot overwrite `sent`, `delivered`, or another terminal state.
- Add a concurrent partial covering index for the bounded reconciliation scan, plus race, idempotency, pruned-job, lifecycle, and event regression coverage.

The normal outbound worker owns the terminal transition. If its final `MarkFailed` database write repeatedly fails, River can discard or prune the job while the message remains non-terminal forever. Startup reconciliation only repairs messages without a stamped job, so it cannot recover this case.

No public API or client surface changes.

## Operational risk

The reconciler scans at most the configured maintenance batch once per minute and only considers outbound messages in `accepted` or `sending` whose River jobs are terminal or missing. The compare-and-set update preserves successful and otherwise terminal states during races.

Migration 062 creates the supporting partial covering index with `CREATE INDEX CONCURRENTLY` so it does not block message persistence on production-sized tables. Rollback is disabling the periodic worker; the index can remain safely in place.

## Test plan

- [x] `go test -count=1 ./internal/relay ./internal/outboundsend ./internal/identity`
- [x] `E2A_TEST_DATABASE_URL=<fresh isolated database> go test -p 1 -count=1 ./...`
- [x] `git diff --check origin/main...HEAD`

The isolated database avoids pre-existing schema pollution in the shared local test database caused by repeatedly running non-idempotent migration tests.