### PR TITLE
fix(api): return 202 for async review approval

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -4630,7 +4630,7 @@ paths:
         - reviews
   /v1/reviews/{id}/approve:
     post:
-      description: "Approve a hold. Branches on direction: an outbound draft is sent via SES (honoring Idempotency-Key + optional reviewer overrides); an inbound hold is released to the inbox. Account-scoped only — an agent cannot approve its own hold. Approving an outbound draft applies the same per-agent send-rate limit as a direct send: 429 rate_limited when the agent is over its throughput limit (back off Retry-After seconds and retry)."
+      description: "Approve a hold. Branches on direction: an outbound draft is sent via SES (honoring Idempotency-Key + optional reviewer overrides); an inbound hold is released to the inbox. Returns 202 with status=accepted when outbound delivery is durably queued for async submission, and 200 for a synchronous terminal sent result or an inbound release. Account-scoped only — an agent cannot approve its own hold. Approving an outbound draft applies the same per-agent send-rate limit as a direct send: 429 rate_limited when the agent is over its throughput limit (back off Retry-After seconds and retry)."
       operationId: approveReview
       parameters:
         - in: path
@@ -4657,6 +4657,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/SendResultView"
           description: OK
+        "202":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SendResultView"
+          description: Accepted — the approved outbound message was durably queued for async submission (status=accepted); terminal outcome via GET/webhook events.
         "409":
           content:
             application/json:

--- a/docs/api.md
+++ b/docs/api.md
@@ -365,7 +365,10 @@ cannot see or resolve its own holds (self-approval would defeat the gate).
   held message.
 - `POST /v1/reviews/{id}/approve` — branches on direction: an outbound draft is
   sent via SES (honors `Idempotency-Key` + optional reviewer overrides); an
-  inbound hold is released to the inbox.
+  inbound hold is released to the inbox. Returns `202 Accepted` with
+  `status=accepted` when the outbound delivery is durably queued for async
+  submission; synchronous `sent` and inbound `review_approved` outcomes return
+  `200 OK`.
 - `POST /v1/reviews/{id}/reject` — outbound draft discarded (never sent); inbound
   hold dropped (never reaches the agent; payload retained, hidden, for forensics).
 

--- a/internal/agent/approve_async_test.go
+++ b/internal/agent/approve_async_test.go
@@ -26,7 +26,22 @@ func TestApprovePendingCore_AsyncExternal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sent, oerr := api.ApprovePendingCore(ctx, user.ID, msg.ID, ag.Email, agent.ApproveOverrides{})
+	idemCompleted := false
+	complete := func(ctx context.Context, tx pgx.Tx, approved *identity.Message) error {
+		var deliveryStatus string
+		var sendJobID *int64
+		if err := tx.QueryRow(ctx,
+			`SELECT delivery_status, send_job_id FROM messages WHERE id=$1`, approved.ID,
+		).Scan(&deliveryStatus, &sendJobID); err != nil {
+			return err
+		}
+		if deliveryStatus != "accepted" || sendJobID == nil || *sendJobID != 999 {
+			t.Fatalf("idempotency completion ran before async accept was durable in tx: delivery_status=%q send_job_id=%v", deliveryStatus, sendJobID)
+		}
+		idemCompleted = true
+		return nil
+	}
+	sent, oerr := api.ApprovePendingCore(ctx, user.ID, msg.ID, ag.Email, agent.ApproveOverrides{}, complete)
 	if oerr != nil {
 		t.Fatalf("ApprovePendingCore: status=%d code=%s msg=%s", oerr.Status, oerr.Code, oerr.Msg)
 	}
@@ -38,6 +53,9 @@ func TestApprovePendingCore_AsyncExternal(t *testing.T) {
 	}
 	if sent.Method != "smtp" {
 		t.Errorf("Method = %q, want smtp (should be populated on the accepted view)", sent.Method)
+	}
+	if !idemCompleted {
+		t.Error("async approval did not complete idempotency inside the accept transaction")
 	}
 
 	var deliveryStatus, providerID string
@@ -76,7 +94,7 @@ func TestApprovePendingCore_AsyncSelfSendStaysSync(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sent, oerr := api.ApprovePendingCore(ctx, user.ID, msg.ID, ag.Email, agent.ApproveOverrides{})
+	sent, oerr := api.ApprovePendingCore(ctx, user.ID, msg.ID, ag.Email, agent.ApproveOverrides{}, nil)
 	if oerr != nil {
 		t.Fatalf("ApprovePendingCore: status=%d code=%s msg=%s", oerr.Status, oerr.Code, oerr.Msg)
 	}

--- a/internal/agent/hitl_api.go
+++ b/internal/agent/hitl_api.go
@@ -66,9 +66,10 @@ type ApproveOverrides = approveRequest
 // and publishes the approved event. Both the legacy handler and the v1 layer
 // call it. expectedAgentEmail (when non-empty) must equal the message's
 // agent's email — mirrors the legacy verifyURLAgentEmail URL guard.
-// On a nil-error return the SES send has committed; the idempotency key must
-// be Completed (cached), never Released.
-func (a *API) ApprovePendingCore(ctx context.Context, userID, messageID, expectedAgentEmail string, ovr ApproveOverrides) (*identity.Message, *OutboundError) {
+// On a nil-error return the synchronous send or async enqueue has committed;
+// the idempotency key must be Completed (cached), never Released. In async mode
+// idemCompleteTx is invoked inside the approve-and-enqueue transaction.
+func (a *API) ApprovePendingCore(ctx context.Context, userID, messageID, expectedAgentEmail string, ovr ApproveOverrides, idemCompleteTx ApproveIdemCompleter) (*identity.Message, *OutboundError) {
 	edits, err := ovr.toEdit()
 	if err != nil {
 		return nil, &OutboundError{http.StatusBadRequest, "invalid_request", "invalid attachments"}
@@ -97,7 +98,7 @@ func (a *API) ApprovePendingCore(ctx context.Context, userID, messageID, expecte
 	// email.sent/failed + metering. The reviewer gets "accepted" back (the send is
 	// durably queued). Self-sends fall through to the sync loopback path below.
 	if a.outboundEnq != nil {
-		sent, handled, aerr := a.approveOutboundAsync(ctx, agent, messageID, userID, preview, edits)
+		sent, handled, aerr := a.approveOutboundAsync(ctx, agent, messageID, userID, preview, edits, idemCompleteTx)
 		if aerr != nil {
 			return nil, approveAsyncError(agent.ID, messageID, aerr)
 		}
@@ -173,7 +174,7 @@ func (a *API) ApprovePendingCore(ctx context.Context, userID, messageID, expecte
 // resolution is recorded via reviewed_by_user_id + the review_approved event, and
 // delivery_status ('accepted' → 'sent'/'failed') tracks the async send. (The TTL
 // sweep uses review_expired_approved instead — see hitlworker.autoApproveAsync.)
-func (a *API) approveOutboundAsync(ctx context.Context, agent *identity.AgentIdentity, messageID, userID string, draft *identity.Message, edits identity.PendingApprovalEdit) (*identity.Message, bool, error) {
+func (a *API) approveOutboundAsync(ctx context.Context, agent *identity.AgentIdentity, messageID, userID string, draft *identity.Message, edits identity.PendingApprovalEdit, idemCompleteTx ApproveIdemCompleter) (*identity.Message, bool, error) {
 	editedByReviewer := edits.Apply(draft)
 	sendReq, err := buildSendRequestFromMessage(draft)
 	if err != nil {
@@ -191,7 +192,7 @@ func (a *API) approveOutboundAsync(ctx context.Context, agent *identity.AgentIde
 		To: comp.To, CC: comp.CC, BCC: comp.BCC, Subject: sendReq.Subject,
 		Method: comp.Method, EnvelopeFrom: comp.EnvelopeFrom, SentAs: comp.SentAs, Raw: comp.Raw,
 	}
-	sent, err := a.store.ApproveAndAccept(ctx, messageID, userID, identity.MessageStatusSent, editedByReviewer, acc, a.outboundEnq.EnqueueSendTx)
+	sent, err := a.store.ApproveAndAccept(ctx, messageID, userID, identity.MessageStatusSent, editedByReviewer, acc, a.outboundEnq.EnqueueSendTx, idemCompleteTx)
 	if err != nil {
 		return nil, false, err
 	}

--- a/internal/agent/hitl_magic_api.go
+++ b/internal/agent/hitl_magic_api.go
@@ -192,7 +192,7 @@ func (a *API) magicApprove(w http.ResponseWriter, r *http.Request, messageID, us
 			writeMagicMessage(w, http.StatusNotFound, "Message not found", "This message no longer exists.")
 			return
 		}
-		sent, handled, aerr := a.approveOutboundAsync(r.Context(), agent, messageID, userID, draft, identity.PendingApprovalEdit{})
+		sent, handled, aerr := a.approveOutboundAsync(r.Context(), agent, messageID, userID, draft, identity.PendingApprovalEdit{}, nil)
 		if aerr != nil {
 			writeMagicApproveError(w, messageID, aerr)
 			return

--- a/internal/agent/outbound_async.go
+++ b/internal/agent/outbound_async.go
@@ -29,6 +29,12 @@ import (
 // no Idempotency-Key (or no idempotency store is wired).
 type AcceptIdemCompleter func(ctx context.Context, tx pgx.Tx, messageID string) error
 
+// ApproveIdemCompleter completes an approval's idempotency key inside the
+// async approve-and-enqueue transaction. It receives the resolved message so
+// the httpapi layer can cache the exact SendResultView (including edited,
+// method, and sent_as) that the live request returns.
+type ApproveIdemCompleter func(ctx context.Context, tx pgx.Tx, approved *identity.Message) error
+
 // OutboundEnqueuer is the accept-tx's handle on the shared River client — it
 // inserts the outbound_send job in the same transaction as the message row.
 // *outboundsend.Jobs satisfies it. Injected via SetOutboundEnqueuer; nil keeps

--- a/internal/hitlworker/worker.go
+++ b/internal/hitlworker/worker.go
@@ -221,7 +221,7 @@ func (w *Worker) autoApproveAsync(ctx context.Context, agent *identity.AgentIden
 		To: comp.To, CC: comp.CC, BCC: comp.BCC, Subject: req.Subject,
 		Method: comp.Method, EnvelopeFrom: comp.EnvelopeFrom, SentAs: comp.SentAs, Raw: comp.Raw,
 	}
-	sent, err := w.store.ApproveAndAccept(ctx, c.MessageID, "", identity.MessageStatusReviewExpiredApproved, false, acc, w.outboundEnq.EnqueueSendTx)
+	sent, err := w.store.ApproveAndAccept(ctx, c.MessageID, "", identity.MessageStatusReviewExpiredApproved, false, acc, w.outboundEnq.EnqueueSendTx, nil)
 	if err != nil {
 		if errors.Is(err, identity.ErrNotPendingApproval) {
 			return true // resolved between load and transition

--- a/internal/httpapi/hitl.go
+++ b/internal/httpapi/hitl.go
@@ -2,9 +2,13 @@ package httpapi
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 
+	"github.com/jackc/pgx/v5"
+
 	"github.com/Mnexa-AI/e2a/internal/agent"
+	"github.com/Mnexa-AI/e2a/internal/idempotency"
 	"github.com/Mnexa-AI/e2a/internal/identity"
 )
 
@@ -17,7 +21,8 @@ import (
 // approveOutput returns the unified SendResultView (MSG-9) — approve is a send,
 // so it shares send/reply/forward's result shape (with edited set).
 type approveOutput struct {
-	Body SendResultView
+	Status int
+	Body   SendResultView
 }
 
 // RejectResultView is the reject response. Reject is not a send, so it keeps
@@ -58,56 +63,83 @@ func (s *Server) resolveHeldDirection(ctx context.Context, messageID, agentID st
 // caller MUST have proven account scope + ownership of agentEmail. Branches on
 // direction: inbound holds release to the inbox; outbound holds send via SES
 // (with send-limit + idempotency).
-func (s *Server) approveHeld(ctx context.Context, userID, msgID, agentEmail string, body agent.ApproveOverrides, idemKey string, rawBody []byte) (SendResultView, error) {
+func (s *Server) approveHeld(ctx context.Context, userID, msgID, agentEmail string, body agent.ApproveOverrides, idemKey string, rawBody []byte) (int, SendResultView, error) {
 	meta, inbound, err := s.resolveHeldDirection(ctx, msgID, agentEmail)
 	if err != nil {
-		return SendResultView{}, err
+		return 0, SendResultView{}, err
 	}
 	if inbound {
 		if s.deps.ApproveInboundReview == nil {
-			return SendResultView{}, NewError(http.StatusInternalServerError, "internal_error", "approve unavailable")
+			return 0, SendResultView{}, NewError(http.StatusInternalServerError, "internal_error", "approve unavailable")
 		}
 		if derr := s.deps.ApproveInboundReview(ctx, userID, meta); derr != nil {
-			return SendResultView{}, NewError(derr.Status, derr.Code, derr.Msg)
+			return 0, SendResultView{}, NewError(derr.Status, derr.Code, derr.Msg)
 		}
-		return SendResultView{Status: identity.MessageStatusReviewApproved, MessageID: meta.ID}, nil
+		return http.StatusOK, SendResultView{Status: identity.MessageStatusReviewApproved, MessageID: meta.ID}, nil
 	}
 	// An approve that edits the held draft can replace its attachments; enforce the
 	// same per-attachment / count / total limits here so this outbound path can't
 	// bypass what send/reply/forward enforce at compose time.
 	if body.Attachments != nil {
 		if env := validateAttachments(*body.Attachments); env != nil {
-			return SendResultView{}, env
+			return 0, SendResultView{}, env
 		}
 	}
-	if env := s.checkSendLimit(agentEmail); env != nil {
-		return SendResultView{}, env
-	}
 	if s.deps.ApprovePending == nil {
-		return SendResultView{}, NewError(http.StatusInternalServerError, "internal_error", "approve unavailable")
+		return 0, SendResultView{}, NewError(http.StatusInternalServerError, "internal_error", "approve unavailable")
 	}
-	_, view, err := runIdempotent(s, ctx, userID, idemKey, "/v1/approve/"+msgID, rawBody, func() (int, SendResultView, error) {
-		sent, derr := s.deps.ApprovePending(ctx, userID, msgID, agentEmail, body)
+	// Async approval resolves the hold and enqueues delivery in one transaction.
+	// Complete a keyed request in that SAME transaction so a crash after commit
+	// still replays the exact accepted response instead of re-running approval.
+	var idemCompleteTx agent.ApproveIdemCompleter
+	if idemKey != "" && s.deps.Idempotency != nil {
+		nsKey := idemUserNS + idemKey
+		uid := userID
+		idemCompleteTx = func(ctx context.Context, tx pgx.Tx, sent *identity.Message) error {
+			status, view := approveResult(sent)
+			raw, marshalErr := json.Marshal(view)
+			if marshalErr != nil {
+				raw = []byte("{}")
+			}
+			return s.deps.Idempotency.CompleteTx(ctx, tx, uid, nsKey, idempotency.CachedResponse{
+				StatusCode: status, ContentType: "application/json", Body: raw,
+			})
+		}
+	}
+	status, view, err := runIdempotent(s, ctx, userID, idemKey, "/v1/approve/"+msgID, rawBody, func() (int, SendResultView, error) {
+		// Mutable rate-limit state is evaluated only after the idempotency claim,
+		// so a completed keyed retry replays its cached response without consuming
+		// another token or being replaced by a later 429.
+		if env := s.checkSendLimit(agentEmail); env != nil {
+			return 0, SendResultView{}, env
+		}
+		sent, derr := s.deps.ApprovePending(ctx, userID, msgID, agentEmail, body, idemCompleteTx)
 		if derr != nil {
 			return 0, SendResultView{}, NewError(derr.Status, derr.Code, derr.Msg)
 		}
-		edited := sent.Edited
-		// Async mode returns the hold resolved to approved with delivery_status
-		// 'accepted' (the SendWorker submits later, emitting email.sent/failed) —
-		// surface "accepted" like any async send. Sync mode sent inline → "sent".
-		status := "sent"
-		if sent.DeliveryStatus == "accepted" {
-			status = "accepted"
-		}
-		return http.StatusOK, SendResultView{
-			Status: status, MessageID: sent.ID, ProviderMessageID: sent.ProviderMessageID,
-			SentAs: sent.SentAs, Method: sent.Method, Edited: &edited,
-		}, nil
+		status, view := approveResult(sent)
+		return status, view, nil
 	})
 	if err != nil {
-		return SendResultView{}, err
+		return 0, SendResultView{}, err
 	}
-	return view, nil
+	return status, view, nil
+}
+
+// approveResult is the single source of the approval response's status + body,
+// shared by the live response and the in-transaction idempotency cache.
+func approveResult(sent *identity.Message) (int, SendResultView) {
+	statusCode := http.StatusOK
+	status := "sent"
+	if sent.DeliveryStatus == "accepted" {
+		statusCode = http.StatusAccepted
+		status = "accepted"
+	}
+	edited := sent.Edited
+	return statusCode, SendResultView{
+		Status: status, MessageID: sent.ID, ProviderMessageID: sent.ProviderMessageID,
+		SentAs: sent.SentAs, Method: sent.Method, Edited: &edited,
+	}
 }
 
 // rejectHeld is the shared reject dispatch behind /reviews/{id}/reject. Caller

--- a/internal/httpapi/hitl_test.go
+++ b/internal/httpapi/hitl_test.go
@@ -1,6 +1,19 @@
 package httpapi
 
-import "testing"
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/Mnexa-AI/e2a/internal/agent"
+	"github.com/Mnexa-AI/e2a/internal/idempotency"
+	"github.com/Mnexa-AI/e2a/internal/identity"
+)
 
 // These exercise the account-scoped review queue approve/reject dispatch
 // (/v1/reviews/{id}/approve|reject) — the only approve/reject path since the
@@ -15,6 +28,75 @@ func TestApproveSent(t *testing.T) {
 	}
 	if body["provider_message_id"] != "<prov@ses>" {
 		t.Fatalf("expected provider_message_id, got %v", body)
+	}
+}
+
+// txOnlyIdem records only transaction-level completion, simulating the crash
+// window where post-transaction runIdempotent completion never lands.
+type txOnlyIdem struct{ *memIdem }
+
+func (m *txOnlyIdem) Complete(context.Context, string, string, idempotency.CachedResponse) error {
+	return nil // simulate a crash window where post-transaction completion never lands
+}
+
+func (m *txOnlyIdem) CompleteTx(ctx context.Context, _ pgx.Tx, userID, key string, resp idempotency.CachedResponse) error {
+	return m.memIdem.Complete(ctx, userID, key, resp)
+}
+
+// TestApproveAccepted202AndIdempotentReplay pins the async-accept convention
+// for review approval: enqueued delivery returns 202 Accepted, and a
+// byte-identical keyed retry replays the transaction-cached 202 without
+// approving twice or consuming another rate-limit token. Synchronous sent and
+// inbound released outcomes remain terminal 200s.
+func TestApproveAccepted202AndIdempotentReplay(t *testing.T) {
+	approvals := 0
+	rateChecks := 0
+	srv := testServer(t, func(d *Deps) {
+		d.Idempotency = &txOnlyIdem{memIdem: newMemIdem()}
+		d.SendLimit = func(key string) (bool, time.Duration) {
+			rateChecks++
+			return rateChecks == 1, 7 * time.Second
+		}
+		d.ApprovePending = func(ctx context.Context, userID, messageID, expectedAgentEmail string, ovr agent.ApproveOverrides, complete agent.ApproveIdemCompleter) (*identity.Message, *agent.OutboundError) {
+			approvals++
+			sent := &identity.Message{ID: messageID, DeliveryStatus: "accepted", Method: "smtp"}
+			if complete == nil {
+				t.Fatal("async approval must receive an in-transaction idempotency completer")
+			}
+			if err := complete(ctx, nil, sent); err != nil {
+				t.Fatalf("complete approval idempotency in tx: %v", err)
+			}
+			return sent, nil
+		}
+	})
+
+	rawBody := []byte(`{}`)
+	approve := func() (int, map[string]any) {
+		req, _ := http.NewRequest(http.MethodPost, srv.URL+"/v1/reviews/msg_pending/approve", bytes.NewReader(rawBody))
+		req.Header.Set("Authorization", "Bearer good")
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Idempotency-Key", "approve-accepted-1")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		var body map[string]any
+		_ = json.NewDecoder(resp.Body).Decode(&body)
+		return resp.StatusCode, body
+	}
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		code, body := approve()
+		if code != http.StatusAccepted || body["status"] != "accepted" || body["message_id"] != "msg_pending" {
+			t.Fatalf("attempt %d: want 202 accepted msg_pending, got %d %v", attempt, code, body)
+		}
+	}
+	if approvals != 1 {
+		t.Fatalf("ApprovePending ran %d times, want exactly 1 (retry must replay, not re-enqueue)", approvals)
+	}
+	if rateChecks != 1 {
+		t.Fatalf("send rate limit checked %d times, want exactly 1 (cached retry must not consume or require another token)", rateChecks)
 	}
 }
 

--- a/internal/httpapi/httpapi.go
+++ b/internal/httpapi/httpapi.go
@@ -155,7 +155,7 @@ type Deps struct {
 	// Optional — nil disables the wait valve (accepted is returned immediately).
 	PollSendOutcome func(ctx context.Context, messageID string) (identity.SendOutcome, error)
 	// HITL approve/reject (the held-draft decision)
-	ApprovePending     func(ctx context.Context, userID, messageID, expectedAgentEmail string, ovr agent.ApproveOverrides) (*identity.Message, *agent.OutboundError)
+	ApprovePending     func(ctx context.Context, userID, messageID, expectedAgentEmail string, ovr agent.ApproveOverrides, idemCompleteTx agent.ApproveIdemCompleter) (*identity.Message, *agent.OutboundError)
 	RejectPending      func(ctx context.Context, userID, messageID, expectedAgentEmail, reason string) (*identity.Message, *agent.OutboundError)
 	EnforceMessageSend func(ctx context.Context, userID string) error
 	// Inbound review release — the held-screening decision (design 2026-06-22 §5).

--- a/internal/httpapi/operations_test.go
+++ b/internal/httpapi/operations_test.go
@@ -486,7 +486,7 @@ func testServer(t *testing.T, opts ...func(*Deps)) *httptest.Server {
 		SendTest: func(ctx context.Context, ag *identity.AgentIdentity) (*agent.OutboundResult, *agent.OutboundError) {
 			return &agent.OutboundResult{MessageID: "msg_test_1", Method: "smtp"}, nil
 		},
-		ApprovePending: func(ctx context.Context, userID, messageID, expectedAgentEmail string, ovr agent.ApproveOverrides) (*identity.Message, *agent.OutboundError) {
+		ApprovePending: func(ctx context.Context, userID, messageID, expectedAgentEmail string, ovr agent.ApproveOverrides, _ agent.ApproveIdemCompleter) (*identity.Message, *agent.OutboundError) {
 			switch messageID {
 			case "msg_pending":
 				return &identity.Message{ID: "msg_pending", Status: "sent", ProviderMessageID: "<prov@ses>", Method: "smtp"}, nil

--- a/internal/httpapi/reviews.go
+++ b/internal/httpapi/reviews.go
@@ -98,9 +98,11 @@ func (s *Server) registerReviews() {
 	huma.Register(s.API, huma.Operation{
 		OperationID: "approveReview", Method: http.MethodPost, Path: "/v1/reviews/{id}/approve",
 		Summary: "Approve a held message", Tags: []string{"reviews"},
-		Description: "Approve a hold. Branches on direction: an outbound draft is sent via SES (honoring Idempotency-Key + optional reviewer overrides); an inbound hold is released to the inbox. Account-scoped only — an agent cannot approve its own hold. Approving an outbound draft applies the same per-agent send-rate limit as a direct send: 429 rate_limited when the agent is over its throughput limit (back off Retry-After seconds and retry).",
+		Description: "Approve a hold. Branches on direction: an outbound draft is sent via SES (honoring Idempotency-Key + optional reviewer overrides); an inbound hold is released to the inbox. Returns 202 with status=accepted when outbound delivery is durably queued for async submission, and 200 for a synchronous terminal sent result or an inbound release. Account-scoped only — an agent cannot approve its own hold. Approving an outbound draft applies the same per-agent send-rate limit as a direct send: 429 rate_limited when the agent is over its throughput limit (back off Retry-After seconds and retry).",
 		Security:    []map[string][]string{{"bearer": {}}},
 		Responses: map[string]*huma.Response{
+			"202": s.jsonResponse(reflect.TypeOf(SendResultView{}), "SendResultView",
+				"Accepted — the approved outbound message was durably queued for async submission (status=accepted); terminal outcome via GET/webhook events."),
 			// approve's 409 is shared by two codes, so it gets a merged description
 			// instead of the stock idempotencyInFlightResponse.
 			"409": s.jsonResponse(reflect.TypeOf(ErrorEnvelope{}), "ErrorEnvelope",
@@ -198,11 +200,11 @@ func (s *Server) handleApproveReview(ctx context.Context, in *approveReviewInput
 	if err != nil {
 		return nil, err
 	}
-	view, err := s.approveHeld(ctx, p.User.ID, in.ID, msg.AgentID, in.Body, in.IdempotencyKey, in.RawBody)
+	status, view, err := s.approveHeld(ctx, p.User.ID, in.ID, msg.AgentID, in.Body, in.IdempotencyKey, in.RawBody)
 	if err != nil {
 		return nil, err
 	}
-	return &approveOutput{Body: view}, nil
+	return &approveOutput{Status: status, Body: view}, nil
 }
 
 func (s *Server) handleRejectReview(ctx context.Context, in *rejectReviewInput) (*rejectOutput, error) {

--- a/internal/httpapi/spec_review_test.go
+++ b/internal/httpapi/spec_review_test.go
@@ -125,6 +125,20 @@ func TestSpecOutbound202Declared(t *testing.T) {
 	}
 }
 
+// Async outbound approval is another non-terminal enqueue and follows the same
+// 202 Accepted convention as send/reply/forward. Terminal sent/released
+// approval outcomes remain represented by the operation's inferred 200.
+func TestSpecApprove202Declared(t *testing.T) {
+	doc := renderSpec(t)
+	resp := operationResponses(t, doc, "approveReview")
+	if ref := responseSchemaRef(resp, "202"); ref != "#/components/schemas/SendResultView" {
+		t.Errorf("approveReview: 202 must be declared with SendResultView, got %q; codes=%v", ref, keysOf(resp))
+	}
+	if ref := responseSchemaRef(resp, "200"); ref != "#/components/schemas/SendResultView" {
+		t.Errorf("approveReview: terminal 200 must remain declared with SendResultView, got %q; codes=%v", ref, keysOf(resp))
+	}
+}
+
 // verifyDomain must NOT declare a 412: a not-yet-published record is the normal
 // verified:false outcome, returned as 200. 412 (Precondition Failed) is reserved
 // for conditional-request failures; clients branch on the body's `verified`, not
@@ -202,6 +216,7 @@ func TestSpec402_429Split(t *testing.T) {
 //   - A field whose value set the server may grow (delivery/review/send/event
 //     status, sending_status, sent_as, method, event types) is an OPEN string with
 //     no enum, so adding a value later doesn't break strict spec-generated clients.
+//
 // This test pins both halves so neither regresses: an open field must not silently
 // re-acquire a closed enum, and direction must not lose its enum.
 func TestSpecStatusEnums(t *testing.T) {

--- a/internal/identity/approve_accept_test.go
+++ b/internal/identity/approve_accept_test.go
@@ -50,7 +50,7 @@ func TestApproveAndAccept(t *testing.T) {
 		EnvelopeFrom: "bot@aa.example.com", SentAs: "relay", Raw: []byte("raw-mime"),
 	}
 
-	out, err := store.ApproveAndAccept(ctx, msg.ID, user.ID, identity.MessageStatusReviewApproved, false, acc, enqueue)
+	out, err := store.ApproveAndAccept(ctx, msg.ID, user.ID, identity.MessageStatusReviewApproved, false, acc, enqueue, nil)
 	if err != nil {
 		t.Fatalf("ApproveAndAccept: %v", err)
 	}
@@ -86,7 +86,7 @@ func TestApproveAndAccept(t *testing.T) {
 	}
 
 	// Idempotent: a second attempt (row no longer pending_review) is a no-op.
-	if _, err := store.ApproveAndAccept(ctx, msg.ID, user.ID, identity.MessageStatusReviewApproved, false, acc, enqueue); err != identity.ErrNotPendingApproval {
+	if _, err := store.ApproveAndAccept(ctx, msg.ID, user.ID, identity.MessageStatusReviewApproved, false, acc, enqueue, nil); err != identity.ErrNotPendingApproval {
 		t.Errorf("second ApproveAndAccept err = %v, want ErrNotPendingApproval", err)
 	}
 	if enqueued != 1 {

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -383,11 +383,11 @@ type Message struct {
 	// users row, populated only by GetOutboundMessageForUser. List
 	// endpoints leave this empty to avoid a join-per-row cost — the
 	// pending-detail page is where reviewer attribution matters.
-	ReviewedByName  *string         `json:"reviewed_by_name,omitempty"`
-	RejectionReason string `json:"rejection_reason,omitempty"`
-	Edited          bool   `json:"edited,omitempty"`
-	BodyText        string `json:"text,omitempty"`
-	BodyHTML        string `json:"html,omitempty"`
+	ReviewedByName  *string `json:"reviewed_by_name,omitempty"`
+	RejectionReason string  `json:"rejection_reason,omitempty"`
+	Edited          bool    `json:"edited,omitempty"`
+	BodyText        string  `json:"text,omitempty"`
+	BodyHTML        string  `json:"html,omitempty"`
 	// AttachmentsJSON is the INTERNAL storage blob for a held draft's
 	// attachments (messages.attachments_json): the []outbound.Attachment
 	// shape {filename, content_type, data} with data as base64 bytes. It
@@ -2653,7 +2653,8 @@ type AcceptedSend struct {
 // actual SMTP submit + email.sent/failed + metering; this method does NOT send and
 // does NOT use the send_attempts gate (async idempotency is the accept-tx atomicity
 // + the worker's delivery_status/alreadyDone guard). reviewedByUserID is "" (→ NULL)
-// for the sweep.
+// for the sweep. When completeIdempotency is non-nil, it runs after the send job
+// is stamped but before commit; an error rolls back the approval, job, and key.
 //
 // The WHERE status='pending_review' is the compare-and-set guard: RETURNING no row
 // means a human/other worker already resolved the hold → ErrNotPendingApproval (a
@@ -2664,6 +2665,7 @@ func (s *Store) ApproveAndAccept(
 	edited bool,
 	acc AcceptedSend,
 	enqueue func(ctx context.Context, tx pgx.Tx, messageID string) (int64, error),
+	completeIdempotency func(ctx context.Context, tx pgx.Tx, approved *Message) error,
 ) (*Message, error) {
 	var out *Message
 	err := s.WithTx(ctx, func(tx pgx.Tx) error {
@@ -2724,6 +2726,11 @@ func (s *Store) ApproveAndAccept(
 		// provider_message_id stays empty — the SendWorker fills it on email.sent.
 		m.Method = acc.Method
 		m.SentAs = acc.SentAs
+		if completeIdempotency != nil {
+			if err := completeIdempotency(ctx, tx, &m); err != nil {
+				return err
+			}
+		}
 		out = &m
 		return nil
 	})

--- a/sdks/python/src/e2a/v1/generated/api/reviews_api.py
+++ b/sdks/python/src/e2a/v1/generated/api/reviews_api.py
@@ -65,7 +65,7 @@ class ReviewsApi:
     ) -> SendResultView:
         """Approve a held message
 
-        Approve a hold. Branches on direction: an outbound draft is sent via SES (honoring Idempotency-Key + optional reviewer overrides); an inbound hold is released to the inbox. Account-scoped only — an agent cannot approve its own hold. Approving an outbound draft applies the same per-agent send-rate limit as a direct send: 429 rate_limited when the agent is over its throughput limit (back off Retry-After seconds and retry).
+        Approve a hold. Branches on direction: an outbound draft is sent via SES (honoring Idempotency-Key + optional reviewer overrides); an inbound hold is released to the inbox. Returns 202 with status=accepted when outbound delivery is durably queued for async submission, and 200 for a synchronous terminal sent result or an inbound release. Account-scoped only — an agent cannot approve its own hold. Approving an outbound draft applies the same per-agent send-rate limit as a direct send: 429 rate_limited when the agent is over its throughput limit (back off Retry-After seconds and retry).
 
         :param id: (required)
         :type id: str
@@ -107,6 +107,7 @@ class ReviewsApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "SendResultView",
+            '202': "SendResultView",
             '409': "ErrorEnvelope",
             '422': "ErrorEnvelope",
             '429': "RateLimitedEnvelope",
@@ -143,7 +144,7 @@ class ReviewsApi:
     ) -> ApiResponse[SendResultView]:
         """Approve a held message
 
-        Approve a hold. Branches on direction: an outbound draft is sent via SES (honoring Idempotency-Key + optional reviewer overrides); an inbound hold is released to the inbox. Account-scoped only — an agent cannot approve its own hold. Approving an outbound draft applies the same per-agent send-rate limit as a direct send: 429 rate_limited when the agent is over its throughput limit (back off Retry-After seconds and retry).
+        Approve a hold. Branches on direction: an outbound draft is sent via SES (honoring Idempotency-Key + optional reviewer overrides); an inbound hold is released to the inbox. Returns 202 with status=accepted when outbound delivery is durably queued for async submission, and 200 for a synchronous terminal sent result or an inbound release. Account-scoped only — an agent cannot approve its own hold. Approving an outbound draft applies the same per-agent send-rate limit as a direct send: 429 rate_limited when the agent is over its throughput limit (back off Retry-After seconds and retry).
 
         :param id: (required)
         :type id: str
@@ -185,6 +186,7 @@ class ReviewsApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "SendResultView",
+            '202': "SendResultView",
             '409': "ErrorEnvelope",
             '422': "ErrorEnvelope",
             '429': "RateLimitedEnvelope",
@@ -221,7 +223,7 @@ class ReviewsApi:
     ) -> RESTResponseType:
         """Approve a held message
 
-        Approve a hold. Branches on direction: an outbound draft is sent via SES (honoring Idempotency-Key + optional reviewer overrides); an inbound hold is released to the inbox. Account-scoped only — an agent cannot approve its own hold. Approving an outbound draft applies the same per-agent send-rate limit as a direct send: 429 rate_limited when the agent is over its throughput limit (back off Retry-After seconds and retry).
+        Approve a hold. Branches on direction: an outbound draft is sent via SES (honoring Idempotency-Key + optional reviewer overrides); an inbound hold is released to the inbox. Returns 202 with status=accepted when outbound delivery is durably queued for async submission, and 200 for a synchronous terminal sent result or an inbound release. Account-scoped only — an agent cannot approve its own hold. Approving an outbound draft applies the same per-agent send-rate limit as a direct send: 429 rate_limited when the agent is over its throughput limit (back off Retry-After seconds and retry).
 
         :param id: (required)
         :type id: str
@@ -263,6 +265,7 @@ class ReviewsApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "SendResultView",
+            '202': "SendResultView",
             '409': "ErrorEnvelope",
             '422': "ErrorEnvelope",
             '429': "RateLimitedEnvelope",

--- a/sdks/typescript/src/v1/generated/apis/ReviewsApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/ReviewsApi.ts
@@ -23,7 +23,7 @@ import { SendResultView } from '../models/SendResultView.js';
 export class ReviewsApiRequestFactory extends BaseAPIRequestFactory {
 
     /**
-     * Approve a hold. Branches on direction: an outbound draft is sent via SES (honoring Idempotency-Key + optional reviewer overrides); an inbound hold is released to the inbox. Account-scoped only — an agent cannot approve its own hold. Approving an outbound draft applies the same per-agent send-rate limit as a direct send: 429 rate_limited when the agent is over its throughput limit (back off Retry-After seconds and retry).
+     * Approve a hold. Branches on direction: an outbound draft is sent via SES (honoring Idempotency-Key + optional reviewer overrides); an inbound hold is released to the inbox. Returns 202 with status=accepted when outbound delivery is durably queued for async submission, and 200 for a synchronous terminal sent result or an inbound release. Account-scoped only — an agent cannot approve its own hold. Approving an outbound draft applies the same per-agent send-rate limit as a direct send: 429 rate_limited when the agent is over its throughput limit (back off Retry-After seconds and retry).
      * Approve a held message
      * @param id 
      * @param approveRequest 
@@ -235,6 +235,13 @@ export class ReviewsApiResponseProcessor {
      public async approveReviewWithHttpInfo(response: ResponseContext): Promise<HttpInfo<SendResultView >> {
         const contentType = ObjectSerializer.normalizeMediaType(response.headers["content-type"]);
         if (isCodeInRange("200", response.httpStatusCode)) {
+            const body: SendResultView = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "SendResultView", ""
+            ) as SendResultView;
+            return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
+        }
+        if (isCodeInRange("202", response.httpStatusCode)) {
             const body: SendResultView = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "SendResultView", ""

--- a/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
@@ -1577,7 +1577,7 @@ export class ObjectReviewsApi {
     }
 
     /**
-     * Approve a hold. Branches on direction: an outbound draft is sent via SES (honoring Idempotency-Key + optional reviewer overrides); an inbound hold is released to the inbox. Account-scoped only — an agent cannot approve its own hold. Approving an outbound draft applies the same per-agent send-rate limit as a direct send: 429 rate_limited when the agent is over its throughput limit (back off Retry-After seconds and retry).
+     * Approve a hold. Branches on direction: an outbound draft is sent via SES (honoring Idempotency-Key + optional reviewer overrides); an inbound hold is released to the inbox. Returns 202 with status=accepted when outbound delivery is durably queued for async submission, and 200 for a synchronous terminal sent result or an inbound release. Account-scoped only — an agent cannot approve its own hold. Approving an outbound draft applies the same per-agent send-rate limit as a direct send: 429 rate_limited when the agent is over its throughput limit (back off Retry-After seconds and retry).
      * Approve a held message
      * @param param the request object
      */
@@ -1586,7 +1586,7 @@ export class ObjectReviewsApi {
     }
 
     /**
-     * Approve a hold. Branches on direction: an outbound draft is sent via SES (honoring Idempotency-Key + optional reviewer overrides); an inbound hold is released to the inbox. Account-scoped only — an agent cannot approve its own hold. Approving an outbound draft applies the same per-agent send-rate limit as a direct send: 429 rate_limited when the agent is over its throughput limit (back off Retry-After seconds and retry).
+     * Approve a hold. Branches on direction: an outbound draft is sent via SES (honoring Idempotency-Key + optional reviewer overrides); an inbound hold is released to the inbox. Returns 202 with status=accepted when outbound delivery is durably queued for async submission, and 200 for a synchronous terminal sent result or an inbound release. Account-scoped only — an agent cannot approve its own hold. Approving an outbound draft applies the same per-agent send-rate limit as a direct send: 429 rate_limited when the agent is over its throughput limit (back off Retry-After seconds and retry).
      * Approve a held message
      * @param param the request object
      */

--- a/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
@@ -1517,7 +1517,7 @@ export class ObservableReviewsApi {
     }
 
     /**
-     * Approve a hold. Branches on direction: an outbound draft is sent via SES (honoring Idempotency-Key + optional reviewer overrides); an inbound hold is released to the inbox. Account-scoped only — an agent cannot approve its own hold. Approving an outbound draft applies the same per-agent send-rate limit as a direct send: 429 rate_limited when the agent is over its throughput limit (back off Retry-After seconds and retry).
+     * Approve a hold. Branches on direction: an outbound draft is sent via SES (honoring Idempotency-Key + optional reviewer overrides); an inbound hold is released to the inbox. Returns 202 with status=accepted when outbound delivery is durably queued for async submission, and 200 for a synchronous terminal sent result or an inbound release. Account-scoped only — an agent cannot approve its own hold. Approving an outbound draft applies the same per-agent send-rate limit as a direct send: 429 rate_limited when the agent is over its throughput limit (back off Retry-After seconds and retry).
      * Approve a held message
      * @param id
      * @param approveRequest
@@ -1544,7 +1544,7 @@ export class ObservableReviewsApi {
     }
 
     /**
-     * Approve a hold. Branches on direction: an outbound draft is sent via SES (honoring Idempotency-Key + optional reviewer overrides); an inbound hold is released to the inbox. Account-scoped only — an agent cannot approve its own hold. Approving an outbound draft applies the same per-agent send-rate limit as a direct send: 429 rate_limited when the agent is over its throughput limit (back off Retry-After seconds and retry).
+     * Approve a hold. Branches on direction: an outbound draft is sent via SES (honoring Idempotency-Key + optional reviewer overrides); an inbound hold is released to the inbox. Returns 202 with status=accepted when outbound delivery is durably queued for async submission, and 200 for a synchronous terminal sent result or an inbound release. Account-scoped only — an agent cannot approve its own hold. Approving an outbound draft applies the same per-agent send-rate limit as a direct send: 429 rate_limited when the agent is over its throughput limit (back off Retry-After seconds and retry).
      * Approve a held message
      * @param id
      * @param approveRequest

--- a/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
@@ -1112,7 +1112,7 @@ export class PromiseReviewsApi {
     }
 
     /**
-     * Approve a hold. Branches on direction: an outbound draft is sent via SES (honoring Idempotency-Key + optional reviewer overrides); an inbound hold is released to the inbox. Account-scoped only — an agent cannot approve its own hold. Approving an outbound draft applies the same per-agent send-rate limit as a direct send: 429 rate_limited when the agent is over its throughput limit (back off Retry-After seconds and retry).
+     * Approve a hold. Branches on direction: an outbound draft is sent via SES (honoring Idempotency-Key + optional reviewer overrides); an inbound hold is released to the inbox. Returns 202 with status=accepted when outbound delivery is durably queued for async submission, and 200 for a synchronous terminal sent result or an inbound release. Account-scoped only — an agent cannot approve its own hold. Approving an outbound draft applies the same per-agent send-rate limit as a direct send: 429 rate_limited when the agent is over its throughput limit (back off Retry-After seconds and retry).
      * Approve a held message
      * @param id
      * @param approveRequest
@@ -1125,7 +1125,7 @@ export class PromiseReviewsApi {
     }
 
     /**
-     * Approve a hold. Branches on direction: an outbound draft is sent via SES (honoring Idempotency-Key + optional reviewer overrides); an inbound hold is released to the inbox. Account-scoped only — an agent cannot approve its own hold. Approving an outbound draft applies the same per-agent send-rate limit as a direct send: 429 rate_limited when the agent is over its throughput limit (back off Retry-After seconds and retry).
+     * Approve a hold. Branches on direction: an outbound draft is sent via SES (honoring Idempotency-Key + optional reviewer overrides); an inbound hold is released to the inbox. Returns 202 with status=accepted when outbound delivery is durably queued for async submission, and 200 for a synchronous terminal sent result or an inbound release. Account-scoped only — an agent cannot approve its own hold. Approving an outbound draft applies the same per-agent send-rate limit as a direct send: 429 rate_limited when the agent is over its throughput limit (back off Retry-After seconds and retry).
      * Approve a held message
      * @param id
      * @param approveRequest

--- a/tests/e2e-prod/suites/11-messaging.test.ts
+++ b/tests/e2e-prod/suites/11-messaging.test.ts
@@ -144,7 +144,7 @@ test("messaging: /agents/{email}/test on HITL agent returns 202 with message_id 
   }
 });
 
-test("messaging: HITL approve flow — send queues, approve sends, status→sent", async () => {
+test("messaging: HITL approve flow — send queues, approve sends or enqueues", async () => {
   const email = await createHitlAgent("appr");
   const s = await client.post<{ message_id: string; status: string }>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
     body: { to: [SINK_EMAIL], subject: uniqueSubject("approve"), text: "approve me" },
@@ -158,16 +158,18 @@ test("messaging: HITL approve flow — send queues, approve sends, status→sent
 
   // Approve — empty body approves as-is. Goes out via SMTP to blackhole sink.
   const ap = await client.post<{ message_id: string; status: string }>(`/v1/reviews/${id}/approve`, { body: {} });
-  if (ap.status !== 200) {
-    fail(SUITE, "approve-non-200", `approve returned ${ap.status}: ${ap.raw.slice(0, 200)}`);
+  const validApprove = (ap.status === 200 && ap.body?.status === "sent") ||
+    (ap.status === 202 && ap.body?.status === "accepted");
+  if (!validApprove) {
+    fail(SUITE, "approve-status-mismatch", `approve returned ${ap.status} status=${ap.body?.status}: ${ap.raw.slice(0, 200)}`);
     return;
   }
   assert.equal(ap.body?.message_id, id);
-  // Status should be "sent" or whatever the post-approve canonical is.
+  // Synchronous delivery is terminal sent/200; async enqueue is accepted/202.
   const finalStatus = ap.body?.status;
   info(SUITE, "approve-final-status", `approve returned status="${finalStatus}"`);
 
-  // Re-approve must fail with 409 (already sent).
+  // Re-approve must fail with 409 (the hold was resolved before sync send/async enqueue).
   const ap2 = await client.post(`/v1/reviews/${id}/approve`, { body: {} });
   if (ap2.status !== 409) {
     info(SUITE, "double-approve-non-409", `re-approve of sent message returned ${ap2.status} instead of 409: ${ap2.raw.slice(0, 200)}`);
@@ -184,9 +186,9 @@ test("messaging: reject of a sent message returns 409 (state guard)", async () =
     return;
   }
   const id = s.body.message_id;
-  // First approve so it transitions to sent.
+  // First approve so the hold resolves (sent synchronously or accepted async).
   const ap = await client.post(`/v1/reviews/${id}/approve`, { body: {} });
-  if (ap.status !== 200) {
+  if (ap.status !== 200 && ap.status !== 202) {
     info(SUITE, "rej-after-send-approve-failed", `approve returned ${ap.status}, can't test reject-after-send`);
     return;
   }
@@ -214,8 +216,8 @@ test("messaging: approve with field overrides applies them before send", async (
     `/v1/reviews/${id}/approve`,
     { body: { subject: "overridden subject (approve-time)", text: "overridden body" } },
   );
-  if (ap.status !== 200) {
-    info(SUITE, "approve-override-non-200", `override approve returned ${ap.status}: ${ap.raw.slice(0, 200)}`);
+  if (ap.status !== 200 && ap.status !== 202) {
+    info(SUITE, "approve-override-non-2xx", `override approve returned ${ap.status}: ${ap.raw.slice(0, 200)}`);
     return;
   }
   // Fetch the message to see whether the override was actually persisted to the

--- a/tests/e2e-prod/suites/18-reviews.test.ts
+++ b/tests/e2e-prod/suites/18-reviews.test.ts
@@ -200,7 +200,7 @@ test("reviews: rejectReview discards the hold; re-reject → 409; nonexistent �
   }
 });
 
-test("reviews: approveReview resolves the outbound hold (200 SendResultView; staging SES send-fail tolerated)", async () => {
+test("reviews: approveReview resolves the outbound hold (200 terminal or 202 enqueued; staging send-fail tolerated)", async () => {
   const { email, id } = await createHeldReview("approve");
   let resolved = false;
   try {
@@ -208,9 +208,10 @@ test("reviews: approveReview resolves the outbound hold (200 SendResultView; sta
       `/v1/reviews/${id}/approve`,
       { body: {} },
     );
-    if (r.status === 200) {
-      // Happy path: SendResultView. approveReview sends the outbound draft via SES.
+    if (r.status === 200 || r.status === 202) {
+      // Happy path: synchronous delivery is sent/200; async enqueue is accepted/202.
       assert.equal(r.body?.message_id, id, "SendResultView echoes the approved message id");
+      assert.equal(r.body?.status, r.status === 202 ? "accepted" : "sent", "HTTP status matches the approval outcome");
       resolved = true;
       // Re-approving a sent hold must 409.
       const again = await client.post(`/v1/reviews/${id}/approve`, { body: {} });
@@ -221,7 +222,7 @@ test("reviews: approveReview resolves the outbound hold (200 SendResultView; sta
       // send leg 500s ("send failed"). Verified during authoring that the fault
       // is the send transport on staging, not the /v1/reviews routing/authz. The hold
       // stays pending_review after the failed send, so we reject it below to
-      // clean up. If prod ever runs this against a deliverable sink, the 200
+      // clean up. If prod ever runs this against a deliverable sink, the 2xx
       // branch above is the real assertion.
       info(SUITE, "approve-send-failed-staging", `approveReview reached the send leg but SES failed on staging (500 "send failed") — endpoint routing/authz OK; hold left pending and cleaned via reject. request handled id=${id}`);
     } else {

--- a/tests/e2e-prod/suites/21-webhook-events.test.ts
+++ b/tests/e2e-prod/suites/21-webhook-events.test.ts
@@ -400,8 +400,8 @@ test("emit: email.review_approved — approving a hold (to the simulator) emits 
     heldId = send.body!.message_id!;
 
     const ap = await client.post<SendResult>(`/v1/reviews/${heldId}/approve`, { body: {} });
-    assert.equal(ap.status, 200, `approve→send (to simulator) expected 200, got ${ap.status}: ${ap.raw.slice(0, 200)}`);
-    assert.equal(ap.body?.status, "sent", "approved hold to the simulator sends successfully");
+    assert.ok(ap.status === 200 || ap.status === 202, `approve→send expected 200 terminal or 202 enqueued, got ${ap.status}: ${ap.raw.slice(0, 200)}`);
+    assert.equal(ap.body?.status, ap.status === 202 ? "accepted" : "sent", "HTTP status matches the approval outcome");
     resolved = true;
 
     const ev = await pollEvent({ type: "email.review_approved", agentId: email, since }, (e) =>

--- a/tests/e2e-prod/suites/23-coverage-happy-path.test.ts
+++ b/tests/e2e-prod/suites/23-coverage-happy-path.test.ts
@@ -98,7 +98,7 @@ test("forwardMessage: forward an inbound message to the simulator (200)", async 
   assert.ok(r.body?.message_id, "forward returned a message id");
 });
 
-test("approveReview: approve a HITL-held outbound (200)", async () => {
+test("approveReview: approve a HITL-held outbound (200 terminal or 202 enqueued)", async () => {
   const email = await freshAgent("covap", true); // holds all outbound for review
   const send = await client.post<{ status: string; message_id: string }>(
     `/v1/agents/${encodeURIComponent(email)}/messages`,
@@ -108,9 +108,10 @@ test("approveReview: approve a HITL-held outbound (200)", async () => {
   const id = send.body!.message_id;
   const ap = await client.post<{ message_id: string; status: string }>(
     `/v1/reviews/${id}/approve`,
-    { body: {}, expect: 200 },
+    { body: {}, expect: [200, 202] },
   );
   assert.equal(ap.body?.message_id, id);
+  assert.equal(ap.body?.status, ap.status === 202 ? "accepted" : "sent");
 });
 
 after(async () => {


### PR DESCRIPTION
## Summary

Return HTTP 202 for asynchronous review approvals that enqueue non-terminal work, matching the PR #442 convention already used by async send/reply/forward. Preserve HTTP 200 for synchronous terminal/released approvals, and update the API contract, generated SDKs, docs, and tests accordingly.

The root cause was that the review approval handler discarded the idempotent operation's HTTP status even when the response body was `{status: "accepted"}`.

## Client surface checklist

- [x] Go handler + integration tests
- [x] OpenAPI spec + generated types refreshed (`make spec-check` is clean)
- [x] TypeScript SDK generated base regenerated
- [x] Python SDK generated base regenerated
- [x] Tests at each affected surface (positive + regression coverage)

Intentionally skipped:

- Migration: no schema change.
- Hand-written TypeScript/Python client changes: generated response handling only; no new resource or method.
- CLI and MCP: no command or tool surface changes.

## Operational risk

Low-to-moderate API behavior change: async approval now reports the semantically correct 202 status. Synchronous sent and inbound review-approved outcomes remain 200. Async idempotency completion now occurs in the same transaction as hold resolution and job enqueue, and completed keyed replays do not consume a rate-limit token or become a later 429.

Rollback is a normal code revert; no data migration or feature flag is involved.

## Test plan

- [x] `go test ./internal/httpapi -count=1`
- [x] `go test ./internal/agent -run 'TestApprovePendingCore_AsyncExternal|TestApprovePendingCore_AsyncSelfSendStaysSync' -count=1`
- [x] `make spec-check`
- [x] TypeScript SDK: `npm run build && npm test` (150 tests)
- [x] Changed E2E suites: standalone TypeScript compile
- [x] Python generated client: `python3 -m compileall`
- [x] `git diff --check`
