### PR TITLE
feat(outbound): enforce composed-message cap on the HITL approve-override path

### DIFF
--- a/internal/agent/approve_composed_cap_test.go
+++ b/internal/agent/approve_composed_cap_test.go
@@ -1,0 +1,110 @@
+package agent_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/Mnexa-AI/e2a/internal/agent"
+	"github.com/Mnexa-AI/e2a/internal/identity"
+)
+
+// bigAttachmentJSON builds the attachments_json for a single attachment whose
+// DECODED size is decodedBytes (base64 on the wire). Shape matches
+// outbound.Attachment's JSON tags (filename/content_type/data).
+func bigAttachmentJSON(t *testing.T, decodedBytes int) []byte {
+	t.Helper()
+	att := []map[string]string{{
+		"filename":     "big.bin",
+		"content_type": "application/octet-stream",
+		"data":         base64.StdEncoding.EncodeToString(make([]byte, decodedBytes)),
+	}}
+	b, err := json.Marshal(att)
+	if err != nil {
+		t.Fatalf("marshal attachment: %v", err)
+	}
+	return b
+}
+
+// TestApprovePendingCore_ComposedCapOnMergedMessage closes the approve-override
+// gap: the composed-message ceiling must be enforced on the MERGED message
+// (reviewer edits applied on top of the stored draft), not just on the override
+// fields in isolation. Here the draft carries a ~9.5 MiB attachment (under the
+// 10 MiB per-attachment cap) and the reviewer overrides the body with ~1 MiB of
+// text (under the 1 MiB field cap). Each field is individually legal, but the
+// composed total (attachment + body) exceeds the 10 MiB SES stored-message
+// ceiling, so the approve must be rejected with 413 payload_too_large and the
+// hold must stay pending for the reviewer to trim.
+func TestApprovePendingCore_ComposedCapOnMergedMessage(t *testing.T) {
+	api, store, _, _ := setupAsyncAPI(t)
+	ctx := context.Background()
+	user, ag := selfAgent(t, store, "apprcompcap")
+
+	attJSON := bigAttachmentJSON(t, 9_500_000) // ~9.5 MiB decoded, < 10 MiB per-attachment cap
+	msg, err := store.CreatePendingOutboundMessage(ctx, ag.ID,
+		[]string{"alice@external.test"}, nil, nil, "Held", "small body", "", attJSON, "send", "", "", "", 3600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bigBody := strings.Repeat("x", 1_000_000) // ~1 MiB, within the per-field cap
+	ovr := agent.ApproveOverrides{BodyText: &bigBody}
+
+	_, oerr := api.ApprovePendingCore(ctx, user.ID, msg.ID, ag.Email, ovr, nil)
+	if oerr == nil {
+		t.Fatal("expected 413 payload_too_large for an over-cap merged message, got nil")
+	}
+	if oerr.Status != http.StatusRequestEntityTooLarge || oerr.Code != "payload_too_large" {
+		t.Fatalf("want 413 payload_too_large, got status=%d code=%s msg=%q", oerr.Status, oerr.Code, oerr.Msg)
+	}
+
+	// The over-cap approve must be a no-op on the hold — never sent/accepted.
+	var status, deliveryStatus string
+	if err := store.WithTx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT status, COALESCE(delivery_status,'') FROM messages WHERE id=$1`, msg.ID,
+		).Scan(&status, &deliveryStatus)
+	}); err != nil {
+		t.Fatalf("read row: %v", err)
+	}
+	if status != identity.MessageStatusPendingReview {
+		t.Errorf("status = %q, want it to remain %q after a rejected over-cap approve", status, identity.MessageStatusPendingReview)
+	}
+	if deliveryStatus == "accepted" {
+		t.Errorf("delivery_status = accepted, want the over-cap approve to NOT enqueue delivery")
+	}
+}
+
+// TestApprovePendingCore_MergedUnderCapSends guards against a false rejection:
+// an edited approve whose merged composed size stays under the ceiling still
+// goes through (async-accepted). Draft carries a ~5 MiB attachment; the reviewer
+// overrides the body with ~1 MiB of text — merged ~6 MiB, comfortably under the
+// 10 MiB cap.
+func TestApprovePendingCore_MergedUnderCapSends(t *testing.T) {
+	api, store, _, _ := setupAsyncAPI(t)
+	ctx := context.Background()
+	user, ag := selfAgent(t, store, "apprundercap")
+
+	attJSON := bigAttachmentJSON(t, 5_000_000) // ~5 MiB decoded
+	msg, err := store.CreatePendingOutboundMessage(ctx, ag.ID,
+		[]string{"alice@external.test"}, nil, nil, "Held", "small body", "", attJSON, "send", "", "", "", 3600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bigBody := strings.Repeat("x", 1_000_000) // ~1 MiB; merged ~6 MiB < 10 MiB
+	ovr := agent.ApproveOverrides{BodyText: &bigBody}
+
+	sent, oerr := api.ApprovePendingCore(ctx, user.ID, msg.ID, ag.Email, ovr, nil)
+	if oerr != nil {
+		t.Fatalf("under-cap edited approve must succeed, got status=%d code=%s msg=%q", oerr.Status, oerr.Code, oerr.Msg)
+	}
+	if sent.Status != identity.MessageStatusSent {
+		t.Errorf("status = %q, want %q", sent.Status, identity.MessageStatusSent)
+	}
+}

--- a/internal/agent/hitl_api.go
+++ b/internal/agent/hitl_api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"log"
 	"net/http"
 	"strings"
@@ -91,6 +92,28 @@ func (a *API) ApprovePendingCore(ctx context.Context, userID, messageID, expecte
 	}
 	if !agent.DomainVerified {
 		return nil, &OutboundError{http.StatusForbidden, "domain_not_verified", "agent domain must be verified before sending"}
+	}
+
+	// Composed-message hard cap. A reviewer's edits (new subject/body/attachments)
+	// are merged onto the stored draft, so the true composed size must be checked
+	// on the MERGED message — not just the override fields. The per-field maxLength
+	// (schema layer) and validateAttachments (httpapi) already bound each field and
+	// each attachment individually, but a reviewer can still push a previously-valid
+	// draft over the SES stored-message ceiling by editing the body on top of the
+	// original attachments (or replacing attachments while the original body stays).
+	// Mirror the send/reply/forward composed-cap check (httpapi.deliver) here so the
+	// approve-override path can't bypass it. Applied on a copy so preview is
+	// untouched (both async and sync dispatch below re-derive from it).
+	merged := *preview
+	edits.Apply(&merged)
+	mergedReq, err := buildSendRequestFromMessage(&merged)
+	if err != nil {
+		return nil, &OutboundError{http.StatusBadRequest, "invalid_request", "invalid attachments"}
+	}
+	if total := outbound.ComposedSize(mergedReq.Subject, mergedReq.Body, mergedReq.HTMLBody, mergedReq.Attachments); total > outbound.MaxComposedMessageBytes {
+		return nil, &OutboundError{http.StatusRequestEntityTooLarge, "payload_too_large",
+			fmt.Sprintf("composed message too large — %d bytes (subject + text + html + decoded attachments), limit is %d (%d MB)",
+				total, outbound.MaxComposedMessageBytes, outbound.MaxComposedMessageBytes/(1024*1024))}
 	}
 
 	// Async mode: transition the hold to review_approved + delivery_status='accepted'

--- a/internal/httpapi/outbound.go
+++ b/internal/httpapi/outbound.go
@@ -157,8 +157,10 @@ const (
 	// maxComposedMessageBytes is the hard cap on a composed outbound message —
 	// subject + text + html + DECODED attachments. The SES v1 stored-message
 	// ceiling (the real upstream limit). Enforced at runtime by
-	// composedMessageSizeError; over → 413 payload_too_large.
-	maxComposedMessageBytes = 10 * 1024 * 1024
+	// composedMessageSizeError; over → 413 payload_too_large. Aliased to the
+	// canonical outbound.MaxComposedMessageBytes so this and the HITL approve-
+	// override path (internal/agent) share one source of truth.
+	maxComposedMessageBytes = outbound.MaxComposedMessageBytes
 )
 
 // maxRecipients caps the combined to+cc+bcc fan-out of a single outbound
@@ -545,26 +547,11 @@ func (s *Server) validateOutboundBody(subject, body string, to, cc, bcc []string
 // can stay under each individual limit while the composed MIME exceeds what the
 // upstream provider will accept, so the real ceiling is checked here on the
 // fully-composed content. Over → 413 payload_too_large (reuses the existing 413
-// path/error code — no new status). Sizes are computed on DECODED attachment
-// bytes (not the base64-inflated wire size). validateAttachments runs before
-// this, so base64 is known-decodable; a decode failure here falls back to the
-// raw wire length so we never under-count.
+// path/error code — no new status). The byte total (DECODED attachment bytes,
+// not the base64-inflated wire size) is computed by the shared
+// outbound.ComposedSize so this and the HITL approve-override path agree exactly.
 func composedMessageSizeError(subject, text, html string, atts []outbound.Attachment) *ErrorEnvelope {
-	total := len(subject) + len(text) + len(html)
-	for _, att := range atts {
-		clean := strings.Map(func(r rune) rune {
-			if r == '\r' || r == '\n' || r == ' ' || r == '\t' {
-				return -1
-			}
-			return r
-		}, att.Data)
-		decoded, err := base64.StdEncoding.DecodeString(clean)
-		if err != nil {
-			total += len(att.Data) // never under-count on a decode miss
-			continue
-		}
-		total += len(decoded)
-	}
+	total := outbound.ComposedSize(subject, text, html, atts)
 	if total > maxComposedMessageBytes {
 		return NewError(http.StatusRequestEntityTooLarge, "payload_too_large",
 			fmt.Sprintf("composed message too large — %d bytes (subject + text + html + decoded attachments), limit is %d (%d MB)",

--- a/internal/outbound/limits.go
+++ b/internal/outbound/limits.go
@@ -1,0 +1,43 @@
+package outbound
+
+import (
+	"encoding/base64"
+	"strings"
+)
+
+// MaxComposedMessageBytes is the hard cap on a composed outbound message — the
+// sum of subject + text + html + DECODED attachment bytes. It is the SES v1
+// stored-message ceiling (the real upstream limit), distinct from the per-field
+// (subject/body) and per-attachment caps: a caller can stay under every
+// individual limit while the composed MIME still exceeds what the upstream
+// provider accepts, so the true ceiling is checked on the fully-composed
+// content. Over → 413 payload_too_large at the API edge.
+const MaxComposedMessageBytes = 10 * 1024 * 1024
+
+// ComposedSize returns the composed byte total of an outbound message: the sum
+// of subject + text + html + DECODED attachment bytes. Attachment Data is
+// base64; embedded whitespace (CR/LF, spaces, tabs) is stripped before decoding
+// and a decode failure falls back to the raw wire length so the total is never
+// under-counted.
+//
+// This is the single source of truth for the composed-message ceiling, shared
+// by the direct send path (httpapi send/reply/forward) and the HITL approve-
+// override path (agent) so neither entry point can bypass the cap.
+func ComposedSize(subject, text, html string, atts []Attachment) int {
+	total := len(subject) + len(text) + len(html)
+	for _, att := range atts {
+		clean := strings.Map(func(r rune) rune {
+			if r == '\r' || r == '\n' || r == ' ' || r == '\t' {
+				return -1
+			}
+			return r
+		}, att.Data)
+		decoded, err := base64.StdEncoding.DecodeString(clean)
+		if err != nil {
+			total += len(att.Data) // never under-count on a decode miss
+			continue
+		}
+		total += len(decoded)
+	}
+	return total
+}

--- a/internal/outbound/limits_test.go
+++ b/internal/outbound/limits_test.go
@@ -1,0 +1,69 @@
+package outbound
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+// ComposedSize is the single source of truth for the composed-message ceiling,
+// shared by the httpapi send path and the agent HITL approve-override path.
+
+// The total is subject + text + html + DECODED attachment bytes.
+func TestComposedSize_SumsAllParts(t *testing.T) {
+	att := Attachment{
+		Filename:    "a.bin",
+		ContentType: "application/octet-stream",
+		Data:        base64.StdEncoding.EncodeToString(make([]byte, 1000)),
+	}
+	got := ComposedSize("subj", "text", "html", []Attachment{att})
+	want := len("subj") + len("text") + len("html") + 1000
+	if got != want {
+		t.Fatalf("ComposedSize = %d, want %d", got, want)
+	}
+}
+
+// Attachment size is counted on DECODED bytes, not the larger base64 wire size:
+// N decoded bytes base64-encode to ~4/3·N on the wire, but only N must count.
+func TestComposedSize_CountsDecodedNotWire(t *testing.T) {
+	decoded := 3000
+	att := Attachment{Data: base64.StdEncoding.EncodeToString(make([]byte, decoded))}
+	got := ComposedSize("", "", "", []Attachment{att})
+	if got != decoded {
+		t.Fatalf("ComposedSize = %d, want %d (decoded, not wire)", got, decoded)
+	}
+	if wire := len(att.Data); got >= wire {
+		t.Fatalf("expected decoded (%d) < wire (%d)", got, wire)
+	}
+}
+
+// Embedded whitespace in the base64 payload is stripped before decoding, so a
+// line-wrapped attachment still counts its true decoded size.
+func TestComposedSize_StripsWhitespaceBeforeDecode(t *testing.T) {
+	decoded := 900
+	b64 := base64.StdEncoding.EncodeToString(make([]byte, decoded))
+	wrapped := strings.Join(chunk(b64, 76), "\r\n") // MIME-style 76-col wrap
+	att := Attachment{Data: wrapped}
+	if got := ComposedSize("", "", "", []Attachment{att}); got != decoded {
+		t.Fatalf("ComposedSize (wrapped) = %d, want %d", got, decoded)
+	}
+}
+
+// A non-decodable payload falls back to the raw wire length so the total is
+// never under-counted (fail-safe toward rejecting, not admitting).
+func TestComposedSize_UndecodableFallsBackToWireLength(t *testing.T) {
+	junk := "!!!not-base64!!!"
+	att := Attachment{Data: junk}
+	if got := ComposedSize("", "", "", []Attachment{att}); got != len(junk) {
+		t.Fatalf("ComposedSize (junk) = %d, want fallback %d", got, len(junk))
+	}
+}
+
+func chunk(s string, n int) []string {
+	var out []string
+	for len(s) > n {
+		out = append(out, s[:n])
+		s = s[n:]
+	}
+	return append(out, s)
+}


### PR DESCRIPTION
## Summary

Follow-up to #472. That PR added the composed-message ceiling (10 MB — `subject + text + html + DECODED attachments`, the SES v1 stored-message limit) but enforced it **only on the direct send/reply/forward paths** (`httpapi.deliver`). This closes the gap on the reviewer **approve-override** path (`POST /v1/reviews/{id}/approve`).

## The gap

A reviewer's edits are merged onto the stored draft before sending. Each field is individually bounded (per-field `maxLength` schema caps + `validateAttachments`), but the **merged** message wasn't size-checked — so a reviewer could push a previously-valid draft over the ceiling:

- editing the `text`/`html` body (up to 1 MiB each) on top of a draft that already carries ~9.9 MB of attachments, or
- swapping in new attachments while the original body stays.

Each individual field passes its cap; the composed MIME exceeds what SES will accept.

## The fix

Enforce the cap on the **merged** message in `ApprovePendingCore`, positioned before both the async and sync dispatch so a single check covers every approve route. Over → **413 `payload_too_large`**, and the hold stays `pending_review` for the reviewer to trim.

Extracted the size computation into a shared **`outbound.ComposedSize`** + **`outbound.MaxComposedMessageBytes`** so the httpapi send path and the agent approve path share ONE source of truth — `httpapi.composedMessageSizeError` now delegates to it, and the `maxComposedMessageBytes` const aliases the canonical value (existing httpapi tests/error text unchanged).

**No schema change** — this is a runtime check, so `api/openapi.yaml` and the SDK bases are untouched (verified: the check adds nothing to the emitted spec).

## Tests

- `internal/outbound/limits_test.go` — `ComposedSize`: sum-of-parts, decoded-not-wire, MIME-whitespace strip, undecodable→wire-length fallback.
- `internal/agent/approve_composed_cap_test.go` — merged over-cap (draft attachment + body override) → 413 **and the hold stays pending**; merged under-cap edited approve still sends.
- Verified: `go build ./...`, full `internal/outbound` + `internal/agent` packages green, and all `httpapi` composed/field-limit tests green.

## Note

The merged-size check lives in the agent core (where the draft is loaded and edits are merged), which runs after the rate-limit/idempotency gate in `hitl.go`. A rejected over-cap approve therefore consumes one rate-limit token — consistent with the other permanent errors already raised in `ApprovePendingCore` (e.g. `domain_not_verified`). Acceptable; noted for visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)