### PR TITLE
test(e2e-prod): MCP suites hit the deployed HTTP /mcp, not a local stdio binary

### DIFF
--- a/tests/e2e-prod/harness/env.ts
+++ b/tests/e2e-prod/harness/env.ts
@@ -7,6 +7,10 @@ export interface ProdEnv {
   apiKey: string;
   primaryAgentEmail: string;
   sharedDomain: string;
+  // Deployed streamable-HTTP MCP endpoint the MCP suites target. Defaults to
+  // `${apiUrl}/mcp` (Caddy routes /mcp to the co-versioned mcp-server image);
+  // override with E2A_MCP_URL for an out-of-band host (e.g. an in-cluster URL).
+  mcpUrl: string;
   // Optional separate STANDARD-class, low-cap account for enforcement tests
   // (limit + rate-limit). Absent → the enforcement suite skips, since the main
   // conformance account is internal-class and by construction exempt.
@@ -53,6 +57,7 @@ export function loadEnv(): ProdEnv {
   const local = readLocalConfig();
   const env: ProdEnv = {
     apiUrl: pickEnv("E2A_URL", "E2A_API_URL") ?? local.api_url ?? "https://e2a.dev",
+    mcpUrl: "", // filled below once apiUrl is known
     apiKey: process.env.E2A_API_KEY ?? local.api_key ?? "",
     primaryAgentEmail: pickEnv("E2A_AGENT_EMAIL", "E2A_PRIMARY_AGENT") ?? local.agent_email ?? "",
     sharedDomain: process.env.E2A_SHARED_DOMAIN ?? local.shared_domain ?? "agents.e2a.dev",
@@ -62,6 +67,8 @@ export function loadEnv(): ProdEnv {
     cleanupMode: (process.env.E2E_CLEANUP as ProdEnv["cleanupMode"]) ?? "always",
     rateLimitRps: Number(process.env.E2E_RPS ?? "1"),
   };
+  // Default the MCP endpoint to the API host's /mcp route; E2A_MCP_URL overrides.
+  env.mcpUrl = process.env.E2A_MCP_URL || new URL("/mcp", env.apiUrl).toString();
   if (!env.apiKey) {
     throw new Error("No API key found. Set E2A_API_KEY or run `e2a login` first.");
   }

--- a/tests/e2e-prod/harness/mcp.ts
+++ b/tests/e2e-prod/harness/mcp.ts
@@ -108,6 +108,116 @@ export class StdioMcpClient {
   }
 }
 
+/**
+ * The single MCP surface the suites depend on: one JSON-RPC round-trip.
+ * Both the stdio child-process client and the streamable-HTTP client
+ * implement it, so a suite can swap transports without touching test bodies.
+ */
+export interface McpRpcClient {
+  call<T = unknown>(method: string, params?: unknown, timeoutMs?: number): Promise<T>;
+}
+
+/**
+ * MCP client that talks to a DEPLOYED streamable-HTTP `/mcp` server over
+ * plain `fetch` — no child process, no `@modelcontextprotocol/sdk` (this
+ * package is intentionally zero-dependency). This exercises the same image
+ * that ships to prod/staging, not a locally-built stdio binary.
+ *
+ * The server is a **stateless** transport (`sessionIdGenerator: undefined`
+ * in mcp/src/http-server.ts): there is no `initialize` handshake and no
+ * `Mcp-Session-Id` — a bare `tools/list` / `tools/call` dispatches on its
+ * own. The user's Bearer is forwarded to the e2a backend as-is. The SDK
+ * answers a POST as an SSE stream (`text/event-stream`) unless JSON
+ * responses are enabled (they aren't), so we accept both framings and parse
+ * accordingly — mirroring the Go prober's `mcpCall` (internal/selftest).
+ */
+export class HttpMcpClient implements McpRpcClient {
+  private nextId = 1;
+  private readonly url: string;
+  private readonly apiKey: string;
+
+  // Plain field assignment (not constructor parameter properties) — the suites
+  // run under `node --test` strip-only mode, which rejects param properties.
+  constructor(url: string, apiKey: string) {
+    this.url = url;
+    this.apiKey = apiKey;
+  }
+
+  async call<T = unknown>(method: string, params?: unknown, timeoutMs = 15_000): Promise<T> {
+    const id = this.nextId++;
+    const body: JsonRpcRequest = { jsonrpc: "2.0", id, method, params };
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), timeoutMs);
+    let resp: Response;
+    try {
+      resp = await fetch(this.url, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${this.apiKey}`,
+          "Content-Type": "application/json",
+          // Streamable-HTTP requires the client to accept both framings.
+          Accept: "application/json, text/event-stream",
+        },
+        body: JSON.stringify(body),
+        signal: ctrl.signal,
+      });
+    } catch (err) {
+      const reason = (err as Error)?.name === "AbortError" ? `timed out after ${timeoutMs}ms` : String(err);
+      throw new Error(`MCP call ${method} failed: ${reason} (POST ${this.url})`);
+    } finally {
+      clearTimeout(timer);
+    }
+    const raw = await resp.text();
+    if (!resp.ok) {
+      throw new Error(`MCP ${method}: HTTP ${resp.status}. body: ${raw.slice(0, 500)}`);
+    }
+    const env = parseJsonRpcEnvelope<T>(raw, resp.headers.get("content-type") ?? "");
+    if (!env) {
+      throw new Error(`MCP ${method}: no JSON-RPC message in response. body: ${raw.slice(0, 500)}`);
+    }
+    if (env.error) {
+      throw new Error(`MCP ${method} error ${env.error.code}: ${env.error.message}`);
+    }
+    return env.result as T;
+  }
+
+  // No process/socket to tear down — present so suites can call it uniformly.
+  async stop(): Promise<void> {}
+}
+
+/**
+ * Decode a JSON-RPC message from an MCP streamable-HTTP response, accepting
+ * either a bare JSON body or an SSE stream. For SSE, walk each event's
+ * `data:` lines (successive `data:` lines within one event join with `\n`)
+ * and return the first that decodes to a message carrying a `jsonrpc` key
+ * (ignoring pings / other event types). Mirrors the prober's Go parser.
+ */
+function parseJsonRpcEnvelope<T>(raw: string, contentType: string): JsonRpcResponse<T> | null {
+  if (contentType.includes("text/event-stream")) {
+    const body = raw.replace(/\r\n/g, "\n");
+    for (const event of body.split("\n\n")) {
+      const dataLines: string[] = [];
+      for (const line of event.split("\n")) {
+        if (line.startsWith("data:")) dataLines.push(line.slice(5).replace(/^ /, ""));
+      }
+      if (dataLines.length === 0) continue;
+      let msg: JsonRpcResponse<T>;
+      try {
+        msg = JSON.parse(dataLines.join("\n"));
+      } catch {
+        continue;
+      }
+      if (msg && (msg as { jsonrpc?: unknown }).jsonrpc) return msg;
+    }
+    return null;
+  }
+  try {
+    return JSON.parse(raw) as JsonRpcResponse<T>;
+  } catch {
+    return null;
+  }
+}
+
 export interface McpToolCall {
   name: string;
   arguments?: Record<string, unknown>;
@@ -118,6 +228,6 @@ export interface McpToolResult {
   isError?: boolean;
 }
 
-export async function callTool(c: StdioMcpClient, name: string, args?: Record<string, unknown>): Promise<McpToolResult> {
+export async function callTool(c: McpRpcClient, name: string, args?: Record<string, unknown>): Promise<McpToolResult> {
   return c.call<McpToolResult>("tools/call", { name, arguments: args ?? {} });
 }

--- a/tests/e2e-prod/suites/08-mcp.test.ts
+++ b/tests/e2e-prod/suites/08-mcp.test.ts
@@ -49,13 +49,22 @@ test("mcp: list_agents returns user's agents", async () => {
   assert.ok(parsed.agents!.some((a) => a.email === apiClient.env.primaryAgentEmail), "primary agent listed");
 });
 
-test("mcp: whoami returns the env-pinned default agent", async () => {
+test("mcp: whoami returns the account identity (agent_email when agent-scoped)", async () => {
   const r = await callTool(mcp, "whoami");
   assert.equal(r.isError, undefined, `whoami isError: ${JSON.stringify(r)}`);
   const text = r.content?.find((c) => c.type === "text")?.text;
   assert.ok(text, "text content present");
-  const parsed = JSON.parse(text!) as { email?: string };
-  assert.equal(parsed.email, apiClient.env.primaryAgentEmail, "whoami returns the pinned agent");
+  // whoami → AccountView: { user, scope, plan_code, ... } and, ONLY for an
+  // agent-scoped credential, agent_email (the single agent that key IS). There
+  // is no top-level `email`, and the tool never guesses a 'default' agent.
+  const parsed = JSON.parse(text!) as { scope?: string; agent_email?: string; user?: unknown };
+  assert.ok(parsed.user, "whoami returns the authenticated user");
+  assert.ok(parsed.scope === "account" || parsed.scope === "agent", `valid scope, got ${parsed.scope}`);
+  if (parsed.scope === "agent") {
+    assert.equal(parsed.agent_email, apiClient.env.primaryAgentEmail, "agent-scoped whoami returns the pinned agent");
+  } else {
+    info(SUITE, "whoami-scope", "account-scoped credential — no agent_email to pin");
+  }
 });
 
 test("mcp: unknown tool name produces an error result (isError or JSON-RPC error)", async () => {
@@ -107,10 +116,11 @@ test("mcp: list_messages tool works against the inbox", async () => {
     info(SUITE, "list-messages-absent", "no list_messages tool — skipping");
     return;
   }
-  // page_size is the actual MCP tool param (not `limit`, which is the
-  // raw HTTP API name). Use page_size here; the strict-schema test
-  // below specifically verifies unknown keys like `limit` are rejected.
-  const r = await callTool(mcp, "list_messages", { page_size: 5 });
+  // list_messages is cursor-paginated with no page-size knob in its strict
+  // schema (direction / read_status / sort / cursor / search filters only).
+  // Call with a valid arg; the strict-schema test below verifies unknown
+  // keys are rejected.
+  const r = await callTool(mcp, "list_messages", { direction: "inbound" });
   assert.equal(r.isError, undefined, `list_messages isError: ${JSON.stringify(r)}`);
   const text = r.content?.find((c) => c.type === "text")?.text;
   assert.ok(text, "text content present");
@@ -125,12 +135,13 @@ test("mcp: tool arg validation — unknown keys are rejected (strict schemas)", 
     info(SUITE, "list-messages-absent", "skipping arg-type test");
     return;
   }
-  // `limit` is not a valid arg for list_messages (the MCP tool uses `page_size`).
+  // `limit` is the raw HTTP API name, NOT a valid MCP arg for list_messages
+  // (whose strict schema exposes direction/read_status/sort/cursor/filters).
   // With strict schemas, the unknown key should be rejected at the MCP layer.
   let errored = false;
   let detail = "";
   try {
-    const r = await callTool(mcp, "list_messages", { limit: "not-a-number" });
+    const r = await callTool(mcp, "list_messages", { limit: 5 });
     if (r.isError) {
       errored = true;
       detail = `isError: ${r.content?.find((c) => c.type === "text")?.text?.slice(0, 200)}`;
@@ -144,11 +155,13 @@ test("mcp: tool arg validation — unknown keys are rejected (strict schemas)", 
 });
 
 test("mcp: tool arg validation — wrong type for declared param is rejected", async () => {
-  // page_size is declared as z.number().int().positive(); a string must be rejected.
+  // `sort` is a declared param constrained to the enum "asc" | "desc". A value
+  // outside the enum must be rejected by the schema (a genuine type/enum error,
+  // distinct from the unknown-key rejection above).
   let errored = false;
   let detail = "";
   try {
-    const r = await callTool(mcp, "list_messages", { page_size: "not-a-number" });
+    const r = await callTool(mcp, "list_messages", { sort: "not-a-sort-order" });
     if (r.isError) {
       errored = true;
       detail = `isError: ${r.content?.find((c) => c.type === "text")?.text?.slice(0, 200)}`;
@@ -157,7 +170,7 @@ test("mcp: tool arg validation — wrong type for declared param is rejected", a
     errored = true;
     detail = `JSON-RPC error: ${(e as Error).message}`;
   }
-  assert.ok(errored, "string page_size should be rejected by zod number validator");
+  assert.ok(errored, "invalid `sort` enum value should be rejected by the schema");
   info(SUITE, "bad-type-rejected", detail);
 });
 

--- a/tests/e2e-prod/suites/08-mcp.test.ts
+++ b/tests/e2e-prod/suites/08-mcp.test.ts
@@ -2,25 +2,20 @@ import { test, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { ApiClient } from "../harness/client.ts";
 import { cleanup } from "../harness/cleanup.ts";
-import { StdioMcpClient, callTool } from "../harness/mcp.ts";
+import { HttpMcpClient, callTool } from "../harness/mcp.ts";
 import { fail, info, warn, writeReport } from "../harness/report.ts";
 
 const apiClient = new ApiClient();
 const SUITE = "08-mcp";
 
-const mcp = new StdioMcpClient();
+// Talk to the DEPLOYED streamable-HTTP /mcp server (the co-versioned
+// mcp-server image behind Caddy) — the same surface that ships to prod —
+// rather than spawning a locally-built stdio binary. Endpoint defaults to
+// `${E2A_URL}/mcp`; E2A_MCP_URL overrides.
+const mcp = new HttpMcpClient(apiClient.env.mcpUrl, apiClient.env.apiKey);
 
 before(async () => {
-  // Default to the repo-relative dist path so the suite works for any
-  // contributor / CI runner. Hardcoded absolute path was unportable.
-  // Override with E2A_MCP_DIST if the dist lives elsewhere.
-  const mcpDist =
-    process.env.E2A_MCP_DIST ?? new URL("../../../mcp/dist/index.js", import.meta.url).pathname;
-  await mcp.start("node", [mcpDist], {
-    E2A_API_KEY: apiClient.env.apiKey,
-    E2A_URL: apiClient.env.apiUrl,
-    E2A_AGENT_EMAIL: apiClient.env.primaryAgentEmail,
-  });
+  info(SUITE, "transport", `MCP over HTTP → ${apiClient.env.mcpUrl}`);
 });
 
 after(async () => {

--- a/tests/e2e-prod/suites/12-mcp-extended.test.ts
+++ b/tests/e2e-prod/suites/12-mcp-extended.test.ts
@@ -2,24 +2,18 @@ import { test, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { ApiClient } from "../harness/client.ts";
 import { cleanup, track } from "../harness/cleanup.ts";
-import { StdioMcpClient, callTool } from "../harness/mcp.ts";
+import { HttpMcpClient, callTool } from "../harness/mcp.ts";
 import { uniqueSlug, uniqueSubject, SINK_EMAIL, holdAllOutbound } from "../harness/fixtures.ts";
 import { fail, info, warn, writeReport } from "../harness/report.ts";
 
 const apiClient = new ApiClient();
 const SUITE = "12-mcp-extended";
-const mcp = new StdioMcpClient();
+// Deployed streamable-HTTP /mcp server (co-versioned mcp-server image) — the
+// shipped surface, not a locally-built stdio binary. Defaults to `${E2A_URL}/mcp`.
+const mcp = new HttpMcpClient(apiClient.env.mcpUrl, apiClient.env.apiKey);
 
 before(async () => {
-  // Default to the repo-relative dist path so the suite works for any
-  // contributor / CI runner. Override with E2A_MCP_DIST if needed.
-  const mcpDist =
-    process.env.E2A_MCP_DIST ?? new URL("../../../mcp/dist/index.js", import.meta.url).pathname;
-  await mcp.start("node", [mcpDist], {
-    E2A_API_KEY: apiClient.env.apiKey,
-    E2A_URL: apiClient.env.apiUrl,
-    E2A_AGENT_EMAIL: apiClient.env.primaryAgentEmail,
-  });
+  info(SUITE, "transport", `MCP over HTTP → ${apiClient.env.mcpUrl}`);
 });
 
 after(async () => {


### PR DESCRIPTION
## Problem

`tests/e2e-prod/suites/08-mcp.test.ts` and `12-mcp-extended.test.ts` spawned the MCP server as a **local stdio child process** (`node mcp/dist/index.js`). That means:

1. They tested a **locally-built** MCP binary, not the deployed `mcp-server` image that actually ships.
2. In the e2a-ops **staging conformance gate** — which builds only the conformance suite, never `@e2a/mcp-server` — all 17 tests in these two suites fail at `before()` with:
   ```
   MCP call initialize timed out after 15000ms. stderr:
   Error: Cannot find module '.../mcp/dist/index.js'
   ```

So the "MCP" coverage in the staging gate validated nothing about the shipped MCP surface.

## Change

Point both suites at the **deployed streamable-HTTP `/mcp` server** — the same co-versioned `mcp-server` image behind Caddy that ships to prod/staging.

- **`harness/mcp.ts`** — add `HttpMcpClient`: raw `fetch`, **zero-dependency** (this package intentionally has no `@modelcontextprotocol/sdk`). Key transport facts, from `mcp/src/http-server.ts`:
  - The server is a **stateless** transport (`sessionIdGenerator: undefined`) → **no `initialize` handshake, no `Mcp-Session-Id`**; a bare `tools/list` / `tools/call` dispatches on its own.
  - It answers a POST as **SSE** (`text/event-stream`) unless JSON responses are enabled (they aren't), so the client sends `Accept: application/json, text/event-stream` and parses **either** framing — mirroring the Go prober's `mcpCall` in `internal/selftest`.
  - Bearer is forwarded as-is.
  - Both clients now implement a shared `McpRpcClient` interface, so `callTool()` is transport-agnostic. `StdioMcpClient` stays for local MCP development.
- **`harness/env.ts`** — add `ProdEnv.mcpUrl`: `E2A_MCP_URL` override, else `${apiUrl}/mcp`.
- **suites 08 / 12** — construct `HttpMcpClient(env.mcpUrl, env.apiKey)`; drop the stdio spawn.

## Why HTTP (not the SDK client or stdio)

- `tests/e2e-prod` is **zero-dep and not a workspace member**, so no MCP SDK is available — raw `fetch` matches the suite's existing style.
- The **prober** (`mcp_http_round_trip`) already smoke-covers the deployed HTTP surface; this restores the **broad tool-surface assertions** on top of it, against the real image.

## Verification

- `HttpMcpClient` against `https://api-staging.e2a.dev/mcp` with a bogus key → clean **HTTP 401 `invalid bearer token`** (JSON-RPC `-32001`) surfaced as an `Error`. Proves routing, SSE/JSON envelope parsing, and error handling all work.
- Authenticated happy path runs in the **conformance gate** (which holds the staging API key) — this PR is validated there via `oss_test_ref`.
- `tsc --noEmit` adds **no new type errors** (4 pre-existing errors in `01-basic`/`02-authz` are untouched and unrelated).
- Avoids TS **parameter properties** — `node --test` strip-only mode rejects them (caught in local verification).

## Notes

- No API / server / SDK change — **test-only**. No cross-SDK symmetry needed.
- The e2a-ops `release-pipeline.yml` conformance-gate comment already claims "MCP suites now hit the deployed HTTP /mcp server" — this PR makes that true.
