### PR TITLE
fix(api): allow null raw message before review approval

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1733,7 +1733,10 @@ components:
           $ref: "#/components/schemas/MessageParsedView"
         raw_message:
           contentEncoding: base64
-          type: string
+          description: Base64-encoded canonical RAW MIME. Required but null while an outbound message is pending review because reviewer-editable content lives in body until approval composes the final MIME; non-null for inbound and composed outbound messages.
+          type:
+            - string
+            - "null"
         read_status:
           type: string
         reply_to:

--- a/internal/httpapi/messages.go
+++ b/internal/httpapi/messages.go
@@ -90,13 +90,14 @@ type MessageView struct {
 	// each with status + detail) from migration 032. Inbound-only; omitted on
 	// outbound messages, which carry no verdict.
 	Auth       *AuthVerdict `json:"auth,omitempty"`
-	RawMessage []byte       `json:"raw_message"`
+	RawMessage []byte       `json:"raw_message" nullable:"true" doc:"Base64-encoded canonical RAW MIME. Required but null while an outbound message is pending review because reviewer-editable content lives in body until approval composes the final MIME; non-null for inbound and composed outbound messages."`
 	// Parsed is the derived view (decision 9 / Slice 4b-3): the raw message
 	// rendered to text (`text`, quoted chains stripped + length-capped, for the
 	// agent to feed a model by default) plus the decoded HTML part (`html`, for
 	// display). Present on any message carrying raw MIME — inbound and sent
-	// outbound. A CONVENIENCE — `raw_message` is always present and the security
-	// decision is made on `auth` + provenance, never on this derived body.
+	// outbound. A CONVENIENCE — when raw_message is non-null, it is canonical;
+	// the security decision is made on `auth` + provenance, never on this derived
+	// body. Held outbound drafts have raw_message=null and use Body below.
 	Parsed *MessageParsedView `json:"parsed,omitempty"`
 	// Body is the mutable draft body for a held outbound message
 	// (status=pending_review), which has no raw_message yet. This is the

--- a/internal/httpapi/messages_parsed_test.go
+++ b/internal/httpapi/messages_parsed_test.go
@@ -1,6 +1,7 @@
 package httpapi
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/Mnexa-AI/e2a/internal/identity"
@@ -125,5 +126,50 @@ func TestMessageViewHeldDraftBody(t *testing.T) {
 	sent := messageViewFromIdentity(&identity.Message{ID: "msg_s", Direction: "inbound", RawMessage: []byte("From: a@x\r\n\r\nhi")})
 	if sent.Body != nil {
 		t.Fatalf("inbound/sent must not carry a draft Body, got %+v", sent.Body)
+	}
+}
+
+// The shared message-detail shape always carries raw_message. Before an
+// outbound review draft is approved there is no canonical MIME yet, so the
+// required field is null; once composed, []byte uses the documented base64
+// JSON representation.
+func TestMessageViewRawMessageWireLifecycle(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		msg  *identity.Message
+		want any
+	}{
+		{
+			name: "held outbound draft",
+			msg: &identity.Message{
+				ID: "msg_held", Direction: "outbound", Status: "pending_review", BodyText: "review me",
+			},
+			want: nil,
+		},
+		{
+			name: "composed outbound message",
+			msg: &identity.Message{
+				ID: "msg_sent", Direction: "outbound", Status: "sent", RawMessage: []byte("raw MIME"),
+			},
+			want: "cmF3IE1JTUU=",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := json.Marshal(messageViewFromIdentity(tc.msg))
+			if err != nil {
+				t.Fatalf("marshal MessageView: %v", err)
+			}
+			var wire map[string]any
+			if err := json.Unmarshal(raw, &wire); err != nil {
+				t.Fatalf("unmarshal MessageView: %v", err)
+			}
+			got, present := wire["raw_message"]
+			if !present {
+				t.Fatal("raw_message must remain present in every message detail")
+			}
+			if got != tc.want {
+				t.Fatalf("raw_message = %#v, want %#v", got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/httpapi/spec_review_test.go
+++ b/internal/httpapi/spec_review_test.go
@@ -98,6 +98,35 @@ func typeIsNullable(props map[string]any, field string) bool {
 	return false
 }
 
+// Held outbound drafts have not been composed into MIME yet: reviewers read
+// their editable content from `body`, while `raw_message` is explicitly null.
+// Keep the field required so every detail response has a stable shape, but make
+// its value nullable until approval composes the canonical sent copy.
+func TestSpecMessageViewRawMessageRequiredNullable(t *testing.T) {
+	doc := renderSpec(t)
+	comps, _ := doc["components"].(map[string]any)
+	schemas, _ := comps["schemas"].(map[string]any)
+	messageView, ok := schemas["MessageView"].(map[string]any)
+	if !ok {
+		t.Fatal("MessageView schema not found")
+	}
+
+	required, _ := messageView["required"].([]any)
+	var rawRequired bool
+	for _, field := range required {
+		if field == "raw_message" {
+			rawRequired = true
+			break
+		}
+	}
+	if !rawRequired {
+		t.Fatal("MessageView.raw_message must remain required")
+	}
+	if !typeIsNullable(schemaProps(t, doc, "MessageView"), "raw_message") {
+		t.Fatal("MessageView.raw_message must allow null for uncomposed outbound review drafts")
+	}
+}
+
 func setEqual(a []string, b ...string) bool {
 	if len(a) != len(b) {
 		return false

--- a/sdks/python/src/e2a/v1/generated/models/message_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/message_view.py
@@ -49,7 +49,7 @@ class MessageView(BaseModel):
     id: StrictStr
     labels: List[StrictStr]
     parsed: Optional[MessageParsedView] = None
-    raw_message: StrictStr
+    raw_message: Optional[StrictStr] = Field(description="Base64-encoded canonical RAW MIME. Required but null while an outbound message is pending review because reviewer-editable content lives in body until approval composes the final MIME; non-null for inbound and composed outbound messages.")
     read_status: StrictStr
     reply_to: List[StrictStr] = Field(description="The parsed Reply-To header of an inbound message. Populated for inbound only; always empty for outbound (a Reply-To you SET on a send is a request-side field on the send/reply/forward body and is not echoed back here).")
     review_status: Optional[StrictStr] = Field(default=None, description="Review-hold lifecycle (outbound only). Open set; tolerate unknown values. Known values: pending_review, sent, review_rejected, review_expired_approved, review_expired_rejected. Note: an APPROVED outbound hold reads as sent here — the message view intentionally collapses the approved outcome into the delivery lifecycle. The distinct review_approved spelling appears only in the approve result (SendResultView.status, for inbound release) and the email.review_approved webhook event, not in this field.")
@@ -123,6 +123,11 @@ class MessageView(BaseModel):
         if self.additional_properties is not None:
             for _key, _value in self.additional_properties.items():
                 _dict[_key] = _value
+
+        # set to None if raw_message (nullable) is None
+        # and model_fields_set contains the field
+        if self.raw_message is None and "raw_message" in self.model_fields_set:
+            _dict['raw_message'] = None
 
         return _dict
 

--- a/sdks/python/tests/test_v1_client.py
+++ b/sdks/python/tests/test_v1_client.py
@@ -233,8 +233,10 @@ async def test_get_attachment_hits_endpoint_and_maps_view(httpx_mock):
 @pytest.mark.anyio
 async def test_webhooks_fetch_message_resolves_keys(httpx_mock):
     # email.received is metadata-only; fetch_message resolves (delivered_to,
-    # message_id) into the full-message GET.
-    httpx_mock.add_response(json=_valid(MessageView, id="msg_9", subject="Hi"))
+    # message_id) into the full-message GET. A held outbound draft has no
+    # canonical MIME until approval, so the generated model must accept the
+    # required raw_message field with a null value.
+    httpx_mock.add_response(json=_valid(MessageView, id="msg_9", subject="Hi", raw_message=None))
     event = WebhookEvent(
         type="email.received",
         data={"message_id": "msg_9", "delivered_to": "bot@test.dev"},
@@ -243,6 +245,7 @@ async def test_webhooks_fetch_message_resolves_keys(httpx_mock):
     async with _client() as c:
         msg = await c.webhooks.fetch_message(event)
     assert msg.id == "msg_9"
+    assert msg.raw_message is None
     req = httpx_mock.get_requests()[-1]
     assert req.method == "GET"
     assert "/messages/msg_9" in str(req.url)

--- a/sdks/typescript/src/v1/generated/models/MessageView.ts
+++ b/sdks/typescript/src/v1/generated/models/MessageView.ts
@@ -44,7 +44,10 @@ export class MessageView {
     'id': string;
     'labels': Array<string>;
     'parsed'?: MessageParsedView;
-    'rawMessage': string;
+    /**
+    * Base64-encoded canonical RAW MIME. Required but null while an outbound message is pending review because reviewer-editable content lives in body until approval composes the final MIME; non-null for inbound and composed outbound messages.
+    */
+    'rawMessage': string | null;
     'readStatus': string;
     /**
     * The parsed Reply-To header of an inbound message. Populated for inbound only; always empty for outbound (a Reply-To you SET on a send is a request-side field on the send/reply/forward body and is not echoed back here).

--- a/sdks/typescript/test/v1/client.test.ts
+++ b/sdks/typescript/test/v1/client.test.ts
@@ -228,7 +228,9 @@ describe("E2AClient", () => {
 
   // ── webhooks.fetchMessage: email.received is metadata-only ──────
   it("webhooks.fetchMessage resolves (delivered_to, message_id) → GET the full message", async () => {
-    globalThis.fetch = mockFetch(200, { id: "msg_9", subject: "Hi", raw_message: "..." });
+    // Held outbound drafts have no canonical MIME until approval. The field is
+    // required but explicitly null in that lifecycle state.
+    globalThis.fetch = mockFetch(200, { id: "msg_9", subject: "Hi", raw_message: null });
     const event = {
       id: "evt_1",
       type: "email.received",
@@ -241,6 +243,7 @@ describe("E2AClient", () => {
     expect(url).toContain("/messages/msg_9");
     expect(url).toContain("bot%40test.dev");
     expect(msg.id).toBe("msg_9");
+    expect(msg.rawMessage).toBeNull();
   });
 
   it("webhooks.fetchMessage rejects a non-received event or missing fetch keys", async () => {


### PR DESCRIPTION
## Summary

Correct the shared message-detail contract for outbound review drafts: `raw_message` remains required but is nullable until approval composes canonical MIME. Regenerate both SDK models and add server/SDK regressions for the lifecycle.

## Client surface checklist

- [x] Go handler + integration tests
- [x] OpenAPI spec + generated types refreshed (`make generate-sdk-check` is clean)
- [x] TypeScript SDK generated base regenerated
- [x] Python SDK generated base regenerated
- [x] Tests at each affected surface

No migration, CLI, or MCP behavior changes are required: storage already intentionally keeps review drafts in `body_text`/`body_html`, and all clients consume the shared generated message model.

## Operational risk

Contract-only correction. No delivery, persistence, billing, authentication, or notification behavior changes. Generated clients now accept the value the server already emits.

## Test plan

- [x] `go test ./internal/httpapi -count=1`
- [x] `make spec-check`
- [x] `make generate-sdk-check`
- [x] `npm run build --workspace @e2a/sdk`
- [x] `npm test --workspace @e2a/sdk` — 155 passed
- [x] `sdks/python/.venv/bin/pytest sdks/python/tests/ -q` — 277 passed, 18 skipped
