### PR TITLE
feat(sdk,mcp): expose trash restore lifecycle

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -118,11 +118,11 @@ The server exposes up to **48** tools spanning agents, messages, human-in-the-lo
 approval, attachments, domains, events, webhooks, API keys, and email templates
 (beta).
 **The visible set depends on your credential's scope:** an **agent**-scoped
-credential sees the 14 runtime/inbox tools (read, send, reply, and view its
+credential sees the 15 runtime/inbox tools (read, send, reply, restore messages, and view its
 pending queue); an **account**-scoped credential also sees the 34 admin/setup
 tools (agent/domain/webhook/event/template/API-key management — **and HITL
 approve/reject, which is an account-owner action, never agent self-approval**)
-— all 48.
+— all 50.
 Every tool carries MCP annotations (`readOnlyHint`/`destructiveHint`/
 `idempotentHint`) so hosts can auto-approve reads and flag destructive actions.
 The tables below highlight the most commonly used ones — your MCP host's tool list
@@ -133,9 +133,10 @@ shows the set your scope allows, with per-tool descriptions.
 | Tool | Description |
 | --- | --- |
 | `whoami` | Get the authenticated account's identity — user, scope, plan/limits; for an agent-scoped credential, also the bound agent address. |
-| `list_agents` | List every agent inbox owned by the authenticated user. |
+| `list_agents` | List agent inboxes; pass `deleted:true` to list the 30-day trash. |
 | `get_agent` | Get one agent inbox by its full email address. |
 | `create_agent` | Register a new agent by its full email address — on a verified domain you own, or the deployment's shared domain. No delivery "mode": inbound is always available via `list_messages` (poll) or a `create_webhook` subscription. (Admin/account-scoped.) |
+| `restore_agent` | Restore a soft-deleted agent and its configuration. (Admin/account-scoped.) |
 
 > **Webhook deliveries are signed — verify them.** Push delivery is a top-level
 > resource (`create_webhook`), not a per-agent mode. e2a HMAC-signs every webhook
@@ -152,7 +153,8 @@ shows the set your scope allows, with per-tool descriptions.
 | --- | --- |
 | `send_message` | Send a new email. When the agent's outbound policy or content scan holds it for review, the message is held and returns `status: pending_review` instead of `sent`. |
 | `reply_to_message` | Reply to a message — one the agent received (replies to its sender) or one it sent (continues the thread to the original recipients). Preserves In-Reply-To / References for thread continuity. |
-| `list_messages` | List inbound mail. Filter by `read_status` (unread / read / all); cursor-paginated (`cursor` + `limit` in, `next_cursor` out). |
+| `list_messages` | List mail; pass `deleted:true` to list trash. Filter by `read_status`; cursor-paginated (`cursor` + `limit` in, `next_cursor` out). |
+| `restore_message` | Restore a soft-deleted message and resume its retention clock. |
 | `get_message` | Fetch full body, headers, and attachment metadata for one message. |
 | `get_attachment` | Get one attachment's metadata + a short-lived `download_url` (fetch the bytes out of band); `inline: true` returns base64 `data` for small files (≤256 KB). |
 | `update_message_labels` | Add or remove labels on a message. |

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -114,12 +114,12 @@ Hosts that support OAuth connectors can instead add `https://api.e2a.dev/mcp` as
 
 ## Tools
 
-The server exposes up to **48** tools spanning agents, messages, human-in-the-loop
+The server exposes up to **50** tools spanning agents, messages, human-in-the-loop
 approval, attachments, domains, events, webhooks, API keys, and email templates
 (beta).
 **The visible set depends on your credential's scope:** an **agent**-scoped
-credential sees the 15 runtime/inbox tools (read, send, reply, restore messages, and view its
-pending queue); an **account**-scoped credential also sees the 34 admin/setup
+credential sees the 14 runtime/inbox tools (read, send, reply, restore messages,
+and view its pending queue); an **account**-scoped credential also sees the 36 admin/setup
 tools (agent/domain/webhook/event/template/API-key management — **and HITL
 approve/reject, which is an account-owner action, never agent self-approval**)
 — all 50.
@@ -133,7 +133,7 @@ shows the set your scope allows, with per-tool descriptions.
 | Tool | Description |
 | --- | --- |
 | `whoami` | Get the authenticated account's identity — user, scope, plan/limits; for an agent-scoped credential, also the bound agent address. |
-| `list_agents` | List agent inboxes; pass `deleted:true` to list the 30-day trash. |
+| `list_agents` | List agent inboxes; pass `deleted:true` to list the 30-day trash. (Admin/account-scoped.) |
 | `get_agent` | Get one agent inbox by its full email address. |
 | `create_agent` | Register a new agent by its full email address — on a verified domain you own, or the deployment's shared domain. No delivery "mode": inbound is always available via `list_messages` (poll) or a `create_webhook` subscription. (Admin/account-scoped.) |
 | `restore_agent` | Restore a soft-deleted agent and its configuration. (Admin/account-scoped.) |

--- a/mcp/src/client.ts
+++ b/mcp/src/client.ts
@@ -118,9 +118,9 @@ export class McpClient {
 
   // Cursor-paginated (GET /v1/agents). One page in `agents` + a next_cursor
   // when more remain; pass it back as `cursor`.
-  listAgents(params: { cursor?: string; limit?: number } = {}): Promise<Page<AgentView>> {
-    const { cursor, limit } = params;
-    return this.sdk.agents.list(limit !== undefined ? { limit } : {}).page(cursor);
+  listAgents(params: { cursor?: string; limit?: number; deleted?: boolean } = {}): Promise<Page<AgentView>> {
+    const { cursor, ...rest } = params;
+    return this.sdk.agents.list(rest).page(cursor);
   }
 
   // listAllAgents collapses the pager to a flat array for internal aggregations
@@ -162,6 +162,10 @@ export class McpClient {
   async deleteAgent(explicitAddress?: string): Promise<DeleteAgentResult> {
     const address = this.resolveAddress(explicitAddress);
     return this.sdk.agents.delete(address);
+  }
+
+  restoreAgent(explicitAddress?: string): Promise<AgentView> {
+    return this.sdk.agents.restore(this.resolveAddress(explicitAddress));
   }
 
   // ── Messages ────────────────────────────────────────────────────
@@ -277,10 +281,15 @@ export class McpClient {
     labels?: Array<string>;
     cursor?: string;
     limit?: number;
+    deleted?: boolean;
     explicitAddress?: string;
   }): Promise<Page<MessageSummaryView>> {
     const { explicitAddress, cursor, ...rest } = params;
     return this.sdk.messages.list(this.resolveAddress(explicitAddress), rest).page(cursor);
+  }
+
+  restoreMessage(messageId: string, explicitAddress?: string): Promise<MessageView> {
+    return this.sdk.messages.restore(this.resolveAddress(explicitAddress), messageId);
   }
 
   // ── Conversations ───────────────────────────────────────────────

--- a/mcp/src/tools/agents.ts
+++ b/mcp/src/tools/agents.ts
@@ -11,7 +11,7 @@ export function registerAgentTools(server: McpServer, client: McpClient): void {
       title: "List agents",
       annotations: { readOnlyHint: true },
       description:
-        "List the agent inboxes owned by the authenticated user, newest first. Set `deleted:true` to list the 30-day trash instead of live agents. **Cursor-paginated:** returns one page in `agents` plus a `next_cursor` when more remain — pass it back as `cursor` for the next page. Read-only.",
+        "List the agent inboxes owned by the authenticated account, newest first. Set `deleted:true` to list the 30-day trash instead of live agents. Account scope only. **Cursor-paginated:** returns one page in `agents` plus a `next_cursor` when more remain — pass it back as `cursor` for the next page. Read-only.",
       inputSchema: strictInputSchema({
         ...paginationInput,
         deleted: z.boolean().optional().describe("List trashed agents instead of live agents."),

--- a/mcp/src/tools/agents.ts
+++ b/mcp/src/tools/agents.ts
@@ -11,14 +11,18 @@ export function registerAgentTools(server: McpServer, client: McpClient): void {
       title: "List agents",
       annotations: { readOnlyHint: true },
       description:
-        "List the agent inboxes owned by the authenticated user, newest first. Useful for orientation — which inbox to send `from` or query messages against. **Cursor-paginated:** returns one page in `agents` plus a `next_cursor` when more remain — pass it back as `cursor` for the next page. Read-only.",
-      inputSchema: strictInputSchema({ ...paginationInput }),
+        "List the agent inboxes owned by the authenticated user, newest first. Set `deleted:true` to list the 30-day trash instead of live agents. **Cursor-paginated:** returns one page in `agents` plus a `next_cursor` when more remain — pass it back as `cursor` for the next page. Read-only.",
+      inputSchema: strictInputSchema({
+        ...paginationInput,
+        deleted: z.boolean().optional().describe("List trashed agents instead of live agents."),
+      }),
     },
     async (args) =>
       runTool(async () => {
         const page = await client.listAgents({
           ...(args.cursor !== undefined ? { cursor: args.cursor } : {}),
           ...(args.limit !== undefined ? { limit: args.limit } : {}),
+          ...(args.deleted !== undefined ? { deleted: args.deleted } : {}),
         });
         return { agents: page.items, ...(page.next_cursor ? { next_cursor: page.next_cursor } : {}) };
       }),
@@ -211,6 +215,20 @@ export function registerAgentTools(server: McpServer, client: McpClient): void {
         // the shape-identical view needs an explicit cast to PUT back.
         return client.updateProtection(cfg as unknown as ProtectionConfigRequest, args.email);
       }),
+  );
+
+  server.registerTool(
+    "restore_agent",
+    {
+      title: "Restore an agent from trash",
+      annotations: { destructiveHint: false, idempotentHint: false },
+      description:
+        "Restore an agent that was soft-deleted within the 30-day trash window, including its messages and configuration. Account scope only. Returns the restored agent; a live agent returns `not_in_trash`.",
+      inputSchema: strictInputSchema({
+        email: z.string().email().describe("Full email address of the trashed agent to restore."),
+      }),
+    },
+    async (args) => runTool(() => client.restoreAgent(args.email)),
   );
 
   server.registerTool(

--- a/mcp/src/tools/messages.ts
+++ b/mcp/src/tools/messages.ts
@@ -389,6 +389,10 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
           .describe(
             "AND-match filter on labels. A row is returned only if ALL given labels are present. Use lowercase strings matching `[a-z0-9:_-]+`; `e2a:*` system labels can be filtered even though setting them is server-only.",
           ),
+        deleted: z
+          .boolean()
+          .optional()
+          .describe("List the message trash instead of live messages."),
         email: z.string().optional(),
       }),
     },
@@ -410,10 +414,26 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
           ...(args.since !== undefined ? { since: args.since } : {}),
           ...(args.until !== undefined ? { until: args.until } : {}),
           ...(args.labels !== undefined ? { labels: args.labels } : {}),
+          ...(args.deleted !== undefined ? { deleted: args.deleted } : {}),
           ...(args.email !== undefined ? { explicitAddress: args.email } : {}),
         });
         return { messages: page.items, ...(page.next_cursor ? { next_cursor: page.next_cursor } : {}) };
       }),
+  );
+
+  server.registerTool(
+    "restore_message",
+    {
+      title: "Restore a message from trash",
+      annotations: { destructiveHint: false, idempotentHint: false },
+      description:
+        "Restore a soft-deleted message before its trash-retention window expires. Time spent in trash does not consume the message's normal retention. Returns the restored message; a live message returns `not_in_trash`.",
+      inputSchema: strictInputSchema({
+        message_id: z.string().describe("ID of the trashed message to restore."),
+        email: z.string().optional().describe("Owning agent; defaults to the bound agent."),
+      }),
+    },
+    async (args) => runTool(() => client.restoreMessage(args.message_id, args.email)),
   );
 
   server.registerTool(

--- a/mcp/src/tools/tiers.ts
+++ b/mcp/src/tools/tiers.ts
@@ -27,6 +27,7 @@ export const RUNTIME_TOOLS: ReadonlySet<string> = new Set([
   "list_messages",
   "get_message",
   "get_attachment",
+  "restore_message",
   "update_message_labels",
   "list_conversations",
   "get_conversation",
@@ -53,6 +54,7 @@ export const ADMIN_TOOLS: ReadonlySet<string> = new Set([
   "get_protection",
   "update_protection",
   "delete_agent",
+  "restore_agent",
   // Review approval is an account-owner / human review action — NOT something the
   // gated agent may do to its own held outbound (that would be self-approval,
   // defeating the review gate). The backend enforces this too: the approve/reject

--- a/mcp/src/tools/tiers.ts
+++ b/mcp/src/tools/tiers.ts
@@ -22,7 +22,6 @@
 /** Runtime/inbox tools — visible to BOTH agent- and account-scoped credentials. */
 export const RUNTIME_TOOLS: ReadonlySet<string> = new Set([
   "whoami",
-  "list_agents",
   "get_agent",
   "list_messages",
   "get_message",
@@ -46,6 +45,10 @@ export const RUNTIME_TOOLS: ReadonlySet<string> = new Set([
 
 /** Admin/setup tools — visible ONLY to account-scoped credentials. */
 export const ADMIN_TOOLS: ReadonlySet<string> = new Set([
+  // Listing the account's agent inventory (including trash) requires
+  // requireAccountUser at the REST handler; an agent-scoped credential can
+  // address only its bound agent via get_agent.
+  "list_agents",
   "create_agent",
   "update_agent",
   // Protection config is account-only — an agent-scoped session must not read or

--- a/mcp/tests/client.test.ts
+++ b/mcp/tests/client.test.ts
@@ -26,6 +26,65 @@ function mockSdk() {
   };
 }
 
+describe("McpClient trash/restore delegation", () => {
+  function mockTrashSdk() {
+    const agentsPage = vi.fn(async () => ({ items: [{ email: "trashed@test.dev" }], next_cursor: "agents_next" }));
+    const messagesPage = vi.fn(async () => ({ items: [{ id: "msg_trashed" }], next_cursor: "messages_next" }));
+    return {
+      agentsPage,
+      messagesPage,
+      sdk: {
+        agents: {
+          list: vi.fn(() => ({ page: agentsPage })),
+          restore: vi.fn(async (email: string) => ({ email })),
+        },
+        messages: {
+          list: vi.fn(() => ({ page: messagesPage })),
+          restore: vi.fn(async (email: string, id: string) => ({ email, id })),
+        },
+      },
+    };
+  }
+
+  it("listAgents forwards deleted/limit and resumes from cursor", async () => {
+    const { sdk, agentsPage } = mockTrashSdk();
+    const c = new McpClient(sdk as never, "", "account");
+    await c.listAgents({ deleted: true, limit: 25, cursor: "agents_cursor" });
+    expect(sdk.agents.list).toHaveBeenCalledWith({ deleted: true, limit: 25 });
+    expect(agentsPage).toHaveBeenCalledWith("agents_cursor");
+  });
+
+  it("restoreAgent forwards the resolved explicit address", async () => {
+    const { sdk } = mockTrashSdk();
+    const c = new McpClient(sdk as never, "", "account");
+    await c.restoreAgent("trashed@test.dev");
+    expect(sdk.agents.restore).toHaveBeenCalledWith("trashed@test.dev");
+  });
+
+  it("listMessages forwards deleted and explicitAddress without leaking it to the SDK filter", async () => {
+    const { sdk, messagesPage } = mockTrashSdk();
+    const c = new McpClient(sdk as never, "bound@test.dev", "agent");
+    await c.listMessages({
+      deleted: true,
+      limit: 10,
+      cursor: "messages_cursor",
+      explicitAddress: "other@test.dev",
+    });
+    expect(sdk.messages.list).toHaveBeenCalledWith(
+      "other@test.dev",
+      { deleted: true, limit: 10 },
+    );
+    expect(messagesPage).toHaveBeenCalledWith("messages_cursor");
+  });
+
+  it("restoreMessage forwards message id and resolved explicit address", async () => {
+    const { sdk } = mockTrashSdk();
+    const c = new McpClient(sdk as never, "bound@test.dev", "agent");
+    await c.restoreMessage("msg_trashed", "other@test.dev");
+    expect(sdk.messages.restore).toHaveBeenCalledWith("other@test.dev", "msg_trashed");
+  });
+});
+
 describe("McpClient review routing (tier-correct endpoints)", () => {
   it("approveReview → account-only reviews.approve (not messages.approve)", async () => {
     const sdk = mockSdk();

--- a/mcp/tests/events.test.ts
+++ b/mcp/tests/events.test.ts
@@ -192,14 +192,14 @@ describe("MCP events tools", () => {
   });
 
   describe("tool catalog", () => {
-    it("includes the 3 events tools in the full re-curated tool set — total 48", async () => {
+    it("includes the 3 events tools in the full re-curated tool set — total 50", async () => {
       const client = await buildClient(stub);
       const { tools } = await client.listTools();
       const names = new Set(tools.map((t) => t.name));
       // The events tools add list_events/get_event/redeliver_event; the
       // full registered set (incl. the 8 beta template tools and the 3
-      // api-key tools) is 48 tools.
-      expect(tools).toHaveLength(48);
+      // api-key tools and 2 trash-restore tools) is 50 tools.
+      expect(tools).toHaveLength(50);
       expect(names.has("list_events")).toBe(true);
       expect(names.has("get_event")).toBe(true);
       expect(names.has("redeliver_event")).toBe(true);

--- a/mcp/tests/http.test.ts
+++ b/mcp/tests/http.test.ts
@@ -232,12 +232,14 @@ describe("HTTP MCP server", () => {
         "list_messages",
         "get_message",
         "get_attachment",
+        "restore_message",
         "list_agents",
         "get_agent",
         "whoami",
         "create_agent",
         "update_agent",
         "delete_agent",
+        "restore_agent",
         "get_protection",
         "update_protection",
         "list_domains",
@@ -299,9 +301,11 @@ describe("HTTP MCP server", () => {
 
     const { client, transport } = await connect();
     const names = new Set((await client.listTools()).tools.map((t) => t.name));
-    expect(names.size).toBe(14);
+    expect(names.size).toBe(15);
     expect(names.has("send_message")).toBe(true); // runtime present
+    expect(names.has("restore_message")).toBe(true); // per-agent trash lifecycle
     expect(names.has("create_agent")).toBe(false); // admin hidden
+    expect(names.has("restore_agent")).toBe(false); // account administration
     expect(names.has("delete_domain")).toBe(false);
     expect(names.has("list_webhooks")).toBe(false);
     // approve/reject are account-scope (self-approval would defeat HITL).

--- a/mcp/tests/http.test.ts
+++ b/mcp/tests/http.test.ts
@@ -301,10 +301,11 @@ describe("HTTP MCP server", () => {
 
     const { client, transport } = await connect();
     const names = new Set((await client.listTools()).tools.map((t) => t.name));
-    expect(names.size).toBe(15);
+    expect(names.size).toBe(14);
     expect(names.has("send_message")).toBe(true); // runtime present
     expect(names.has("restore_message")).toBe(true); // per-agent trash lifecycle
     expect(names.has("create_agent")).toBe(false); // admin hidden
+    expect(names.has("list_agents")).toBe(false); // REST requires account scope
     expect(names.has("restore_agent")).toBe(false); // account administration
     expect(names.has("delete_domain")).toBe(false);
     expect(names.has("list_webhooks")).toBe(false);

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -67,6 +67,7 @@ function makeStubClient(
     getConversation: vi.fn(async () => ({ conversationId: "conv_1", messages: [] })),
     listMessages: vi.fn(async () => ({ items: [], next_cursor: undefined })),
     listAgents: vi.fn(async () => ({ items: [{ email: "bot@example.com" }], next_cursor: undefined })),
+    restoreAgent: vi.fn(async (addr?: string) => ({ email: addr ?? "bot@example.com" })),
     listAllAgents: vi.fn(async () => [{ email: "bot@example.com" }]),
     // whoami → client.whoami() returns an AccountView (the authenticated
     // account identity), NOT an agent record. No default-agent resolution.
@@ -155,6 +156,7 @@ function makeStubClient(
         { index: 0, filename: "report.pdf", contentType: "application/pdf", sizeBytes: 23 },
       ],
     })),
+    restoreMessage: vi.fn(async (id: string, _addr?: string) => ({ id })),
     getAttachment: vi.fn(async (id: string, index: number, opts?: { inline?: boolean }) => ({
       index,
       filename: "report.pdf",
@@ -307,12 +309,14 @@ describe("e2a MCP server", () => {
         "list_messages",
         "get_message",
         "get_attachment",
+        "restore_message",
         "list_agents",
         "get_agent",
         "whoami",
         "create_agent",
         "update_agent",
         "delete_agent",
+        "restore_agent",
         "get_protection",
         "update_protection",
         "list_domains",
@@ -392,7 +396,7 @@ describe("e2a MCP server", () => {
     registerTemplateTools(recorder, stub);
     registerApiKeyTools(recorder, stub);
 
-    expect(names).toHaveLength(48);
+    expect(names).toHaveLength(50);
     // Throws if any registered tool is untiered / double-tiered / phantom.
     expect(() => assertToolTiersComplete(names)).not.toThrow();
   });
@@ -401,32 +405,32 @@ describe("e2a MCP server", () => {
     expect(toolNamesForScope("bogus")).toBe(RUNTIME_TOOLS);
     expect(toolNamesForScope("")).toBe(RUNTIME_TOOLS);
     expect(toolNamesForScope("agent")).toBe(RUNTIME_TOOLS);
-    expect(toolNamesForScope("account").size).toBe(48);
+    expect(toolNamesForScope("account").size).toBe(50);
   });
 
-  it("account scope exposes all 48 tools (runtime + admin)", async () => {
+  it("account scope exposes all 50 tools (runtime + admin)", async () => {
     const acct = await connect(makeStubClient({ scope: "account" }));
     const { tools } = await acct.listTools();
-    expect(tools).toHaveLength(48);
+    expect(tools).toHaveLength(50);
   });
 
-  it("agent scope exposes only the 14 runtime tools — admin tools hidden", async () => {
+  it("agent scope exposes only the 15 runtime tools — admin tools hidden", async () => {
     const ag = await connect(makeStubClient({ scope: "agent" }));
     const names = new Set((await ag.listTools()).tools.map((t) => t.name));
-    expect(names.size).toBe(14);
+    expect(names.size).toBe(15);
     // Runtime tools present (an agent can send + read its own pending queue,
     // but NOT approve/reject — that's an account-owner action, see below):
     for (const n of [
       "whoami", "list_agents", "get_agent", "list_messages", "get_message",
       "get_attachment", "update_message_labels", "list_conversations",
       "get_conversation", "send_message", "reply_to_message", "forward_message",
-      "list_reviews", "get_review",
+      "list_reviews", "get_review", "restore_message",
     ]) {
       expect(names.has(n), `runtime tool ${n} should be visible to agent scope`).toBe(true);
     }
     // Admin tools hidden — incl. approve/reject: self-approval would defeat HITL.
     for (const n of [
-      "create_agent", "update_agent", "delete_agent",
+      "create_agent", "update_agent", "delete_agent", "restore_agent",
       "get_protection", "update_protection",
       "approve_review", "reject_review",
       "list_domains", "get_domain", "register_domain", "verify_domain", "delete_domain",
@@ -463,7 +467,7 @@ describe("e2a MCP server", () => {
   // ── §6a tool annotations (#2) ───────────────────────────────────────
 
   it("every tool carries MCP annotations with the correct hints", async () => {
-    const { tools } = await client.listTools(); // account scope → all 48
+    const { tools } = await client.listTools(); // account scope → all 50
     const byName = new Map(tools.map((t) => [t.name, t.annotations ?? {}]));
 
     // Every tool has an annotations object.
@@ -601,6 +605,17 @@ describe("e2a MCP server", () => {
       limit: 10,
       cursor: "c_prev",
     });
+  });
+
+  it("list_messages forwards deleted:true for the trash", async () => {
+    await client.callTool({ name: "list_messages", arguments: { deleted: true } });
+    expect(stub.listMessages).toHaveBeenCalledWith({ deleted: true });
+  });
+
+  it("restore_message restores through the bound agent by default", async () => {
+    const res = await client.callTool({ name: "restore_message", arguments: { message_id: "msg_1" } });
+    expect(stub.restoreMessage).toHaveBeenCalledWith("msg_1", undefined);
+    expect(JSON.parse((res.content as Array<{ text: string }>)[0]!.text).id).toBe("msg_1");
   });
 
   it("list_messages surfaces next_cursor when more pages remain", async () => {
@@ -821,6 +836,20 @@ describe("e2a MCP server", () => {
       arguments: { confirm: true },
     });
     expect(stub.deleteAgent).toHaveBeenCalledWith(undefined);
+  });
+
+  it("list_agents forwards deleted:true for the trash", async () => {
+    await client.callTool({ name: "list_agents", arguments: { deleted: true } });
+    expect(stub.listAgents).toHaveBeenCalledWith({ deleted: true });
+  });
+
+  it("restore_agent restores the requested trashed agent", async () => {
+    const res = await client.callTool({
+      name: "restore_agent",
+      arguments: { email: "bot@example.com" },
+    });
+    expect(stub.restoreAgent).toHaveBeenCalledWith("bot@example.com");
+    expect(JSON.parse((res.content as Array<{ text: string }>)[0]!.text).email).toBe("bot@example.com");
   });
 
   // ── Domain tools ────────────────────────────────────────────────

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -4,7 +4,7 @@ import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { E2AConnectionError, E2AError } from "@e2a/sdk/v1";
 import type { McpClient } from "../src/client.js";
 import { buildServer } from "../src/server.js";
-import { assertToolTiersComplete, toolNamesForScope, RUNTIME_TOOLS } from "../src/tools/tiers.js";
+import { ADMIN_TOOLS, assertToolTiersComplete, toolNamesForScope, RUNTIME_TOOLS } from "../src/tools/tiers.js";
 import { registerMessageTools } from "../src/tools/messages.js";
 import { registerAgentTools } from "../src/tools/agents.js";
 import { registerDomainTools } from "../src/tools/domains.js";
@@ -405,6 +405,8 @@ describe("e2a MCP server", () => {
     expect(toolNamesForScope("bogus")).toBe(RUNTIME_TOOLS);
     expect(toolNamesForScope("")).toBe(RUNTIME_TOOLS);
     expect(toolNamesForScope("agent")).toBe(RUNTIME_TOOLS);
+    expect(RUNTIME_TOOLS.size).toBe(14);
+    expect(ADMIN_TOOLS.size).toBe(36);
     expect(toolNamesForScope("account").size).toBe(50);
   });
 
@@ -414,14 +416,14 @@ describe("e2a MCP server", () => {
     expect(tools).toHaveLength(50);
   });
 
-  it("agent scope exposes only the 15 runtime tools — admin tools hidden", async () => {
+  it("agent scope exposes only the 14 runtime tools — admin tools hidden", async () => {
     const ag = await connect(makeStubClient({ scope: "agent" }));
     const names = new Set((await ag.listTools()).tools.map((t) => t.name));
-    expect(names.size).toBe(15);
+    expect(names.size).toBe(14);
     // Runtime tools present (an agent can send + read its own pending queue,
     // but NOT approve/reject — that's an account-owner action, see below):
     for (const n of [
-      "whoami", "list_agents", "get_agent", "list_messages", "get_message",
+      "whoami", "get_agent", "list_messages", "get_message",
       "get_attachment", "update_message_labels", "list_conversations",
       "get_conversation", "send_message", "reply_to_message", "forward_message",
       "list_reviews", "get_review", "restore_message",
@@ -430,7 +432,7 @@ describe("e2a MCP server", () => {
     }
     // Admin tools hidden — incl. approve/reject: self-approval would defeat HITL.
     for (const n of [
-      "create_agent", "update_agent", "delete_agent", "restore_agent",
+      "list_agents", "create_agent", "update_agent", "delete_agent", "restore_agent",
       "get_protection", "update_protection",
       "approve_review", "reject_review",
       "list_domains", "get_domain", "register_domain", "verify_domain", "delete_domain",

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -227,6 +227,20 @@ for m in client.messages.list("bot@agents.e2a.dev"):   # sync iteration
 page = client.messages.list("bot@agents.e2a.dev", limit=100).page()
 ```
 
+### Trash and restore
+
+Soft-deleted agents and messages remain restorable for about 30 days. List the
+trash with `deleted=True`, then restore an item through the same resource. The
+sync client exposes the same methods without `await`.
+
+```python
+trashed_agents = client.agents.list(deleted=True)
+await client.agents.restore("bot@agents.e2a.dev")
+
+trashed_messages = client.messages.list("bot@agents.e2a.dev", deleted=True)
+await client.messages.restore("bot@agents.e2a.dev", "msg_abc123")
+```
+
 ## WebSocket (real-time delivery for local agents)
 
 ```python

--- a/sdks/python/src/e2a/v1/client.py
+++ b/sdks/python/src/e2a/v1/client.py
@@ -283,10 +283,16 @@ class AgentsResource:
         self._api = api
         self._c = client
 
-    def list(self, *, limit: Optional[int] = None) -> AutoPager[AgentView]:
+    def list(
+        self, *, limit: Optional[int] = None, deleted: Optional[bool] = None
+    ) -> AutoPager[AgentView]:
         # Cursor-paginated: the AutoPager walks next_cursor to completion.
         async def fetch(cursor: Optional[str]) -> Page:
-            resp = await self._c._read(lambda h: self._api.list_agents(cursor=cursor, limit=limit, _headers=h))
+            resp = await self._c._read(
+                lambda h: self._api.list_agents(
+                    cursor=cursor, limit=limit, deleted=deleted, _headers=h
+                )
+            )
             return _page(resp.items, resp.next_cursor)
 
         return AutoPager(fetch)
@@ -325,6 +331,12 @@ class AgentsResource:
         # receipt ({deleted, email, messages_deleted}).
         return await self._c._write_idempotent(lambda h: self._api.delete_agent(email, confirm="DELETE", _headers=h))
 
+    async def restore(self, email: str) -> AgentView:
+        """Restore an agent from the 30-day trash. Account scope only."""
+        return await self._c._write_unsafe(
+            lambda h: self._api.restore_agent(email, _headers=h)
+        )
+
     async def test(self, email: str) -> SendResultView:
         return await self._c._write_unsafe(lambda h: self._api.test_agent(email, _headers=h))
 
@@ -348,6 +360,7 @@ class MessagesResource:
         since: Optional[str] = None,
         until: Optional[str] = None,
         limit: Optional[int] = None,
+        deleted: Optional[bool] = None,
     ) -> AutoPager[MessageSummaryView]:
         # `from` is a Python keyword; the generator is configured (via
         # --name-mappings/--parameter-name-mappings in generate-oag.sh) to expose
@@ -368,6 +381,7 @@ class MessagesResource:
                     until=until,
                     cursor=cursor,
                     limit=limit,
+                    deleted=deleted,
                     _headers=h,
                 )
             )
@@ -377,6 +391,12 @@ class MessagesResource:
 
     async def get(self, email: str, message_id: str) -> MessageView:
         return await self._c._read(lambda h: self._api.get_message(email, message_id, _headers=h))
+
+    async def restore(self, email: str, message_id: str) -> MessageView:
+        """Restore a soft-deleted message and resume its retention clock."""
+        return await self._c._write_unsafe(
+            lambda h: self._api.restore_message(email, message_id, _headers=h)
+        )
 
     async def get_attachment(
         self, email: str, message_id: str, index: int, *, inline: bool = False

--- a/sdks/python/tests/test_v1_client.py
+++ b/sdks/python/tests/test_v1_client.py
@@ -317,6 +317,25 @@ async def test_agents_list_autopager(httpx_mock):
     assert [a.email for a in items] == ["bot@test.dev"]
 
 
+@pytest.mark.anyio
+async def test_agents_list_deleted_lists_trash(httpx_mock):
+    httpx_mock.add_response(json={"items": [], "next_cursor": None})
+    async with _client() as c:
+        await c.agents.list(deleted=True).to_list(limit=10)
+    assert httpx_mock.get_requests()[-1].url.params["deleted"] == "true"
+
+
+@pytest.mark.anyio
+async def test_agents_restore(httpx_mock):
+    httpx_mock.add_response(json=_valid(AgentView, email="bot@test.dev"))
+    async with _client() as c:
+        restored = await c.agents.restore("bot@test.dev")
+    req = httpx_mock.get_requests()[-1]
+    assert req.method == "POST"
+    assert "/v1/agents/bot%40test.dev/restore" in str(req.url)
+    assert restored.email == "bot@test.dev"
+
+
 # ── messages: idempotency + pagination ──────────────────────────────
 
 @pytest.mark.anyio
@@ -389,6 +408,25 @@ async def test_messages_list_threads_cursor(httpx_mock):
     reqs = httpx_mock.get_requests()
     assert len(reqs) == 2
     assert "cursor=cur_2" in str(reqs[1].url)
+
+
+@pytest.mark.anyio
+async def test_messages_list_deleted_lists_trash(httpx_mock):
+    httpx_mock.add_response(json={"items": [], "next_cursor": None})
+    async with _client() as c:
+        await c.messages.list("bot@test.dev", deleted=True).to_list(limit=10)
+    assert httpx_mock.get_requests()[-1].url.params["deleted"] == "true"
+
+
+@pytest.mark.anyio
+async def test_messages_restore(httpx_mock):
+    httpx_mock.add_response(json=_valid(MessageView, id="msg_1"))
+    async with _client() as c:
+        restored = await c.messages.restore("bot@test.dev", "msg_1")
+    req = httpx_mock.get_requests()[-1]
+    assert req.method == "POST"
+    assert "/v1/agents/bot%40test.dev/messages/msg_1/restore" in str(req.url)
+    assert restored.id == "msg_1"
 
 
 # ── pagination: cursor-walking endpoints ────────────────────────────

--- a/sdks/python/tests/test_v1_sync_client.py
+++ b/sdks/python/tests/test_v1_sync_client.py
@@ -107,7 +107,8 @@ def test_parity_every_async_method_reachable_sync():
         expected = {
             "agents", "messages", "conversations", "domains", "events",
             "webhooks", "account", "reviews", "templates", "info", "listen",
-            "agents.get", "agents.list", "agents.create", "agents.delete",
+            "agents.get", "agents.list", "agents.create", "agents.delete", "agents.restore",
+            "messages.restore",
             "messages.send", "messages.reply", "webhooks.fetch_message",
             "account.suppressions", "account.suppressions.list",
             "account.api_keys", "account.api_keys.create",

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -200,6 +200,19 @@ stops with `E2AConnectionReplacedError` (WS close code `4000 "replaced"`)
 instead of reconnecting — reconnecting would steal the socket back and loop.
 The lower-level `WSListener` is also exported for advanced use.
 
+## Trash and restore
+
+Soft-deleted agents and messages remain restorable for about 30 days. List the
+trash with `deleted: true`, then restore an item through the same resource:
+
+```ts
+const trashedAgents = client.agents.list({ deleted: true });
+await client.agents.restore("bot@agents.e2a.dev");
+
+const trashedMessages = client.messages.list("bot@agents.e2a.dev", { deleted: true });
+await client.messages.restore("bot@agents.e2a.dev", "msg_abc123");
+```
+
 ## Conversation threading
 
 `conversationId` is an opaque string that ties multiple emails to one thread

--- a/sdks/typescript/src/v1/client.ts
+++ b/sdks/typescript/src/v1/client.ts
@@ -210,10 +210,10 @@ export class E2AClient {
 
 class AgentsResource {
   constructor(private readonly api: PromiseAgentsApi) {}
-  list(params: { limit?: number } = {}): AutoPager<AgentView> {
+  list(params: { limit?: number; deleted?: boolean } = {}): AutoPager<AgentView> {
     // Cursor-paginated: the AutoPager walks next_cursor to completion.
     return new AutoPager(async (cursor) => {
-      const page = await call(() => this.api.listAgents(cursor, params.limit));
+      const page = await call(() => this.api.listAgents(cursor, params.limit, params.deleted));
       return { items: page.items ?? [], next_cursor: page.nextCursor };
     });
   }
@@ -246,6 +246,10 @@ class AgentsResource {
     // receipt ({deleted:true, email, messages_deleted}).
     return call(() => this.api.deleteAgent(email, "DELETE"));
   }
+  /** Restore an agent from the 30-day trash. Account-scoped credentials only. */
+  restore(email: string): Promise<AgentView> {
+    return call(() => this.api.restoreAgent(email));
+  }
   test(email: string): Promise<SendResultView> {
     return call(() => this.api.testAgent(email));
   }
@@ -262,6 +266,8 @@ export interface ListMessagesParams {
   since?: string;
   until?: string;
   limit?: number;
+  /** List soft-deleted messages in the trash instead of live messages. */
+  deleted?: boolean;
 }
 
 class MessagesResource {
@@ -272,13 +278,17 @@ class MessagesResource {
       const page = await call(() =>
         this.api.listMessages(email, params.direction, params.readStatus, params.sort, params.from,
           params.subjectContains, params.conversationId, params.labels, params.since, params.until,
-          cursor, params.limit),
+          cursor, params.limit, params.deleted),
       );
       return { items: page.items ?? [], next_cursor: page.nextCursor };
     });
   }
   get(email: string, id: string): Promise<MessageView> {
     return call(() => this.api.getMessage(email, id));
+  }
+  /** Restore a soft-deleted message and resume its retention clock. */
+  restore(email: string, id: string): Promise<MessageView> {
+    return call(() => this.api.restoreMessage(email, id));
   }
   // getAttachment returns one attachment's metadata + a short-lived download_url
   // (+ expires_at). Pass { inline: true } to also receive base64 `data` for small

--- a/sdks/typescript/test/v1/client.test.ts
+++ b/sdks/typescript/test/v1/client.test.ts
@@ -165,6 +165,21 @@ describe("E2AClient", () => {
     expect(items[0].email).toBe("bot@test.dev");
   });
 
+  it("agents.list({ deleted: true }) lists the trash", async () => {
+    globalThis.fetch = mockFetch(200, { items: [], next_cursor: null });
+    await client.agents.list({ deleted: true }).toArray({ limit: 10 });
+    expect(new URL(lastCall().url).searchParams.get("deleted")).toBe("true");
+  });
+
+  it("agents.restore POSTs to the restore endpoint", async () => {
+    globalThis.fetch = mockFetch(200, { email: "bot@test.dev", domain: "test.dev" });
+    const restored = await client.agents.restore("bot@test.dev");
+    const { url, init } = lastCall();
+    expect(init.method).toBe("POST");
+    expect(url).toContain("/v1/agents/bot%40test.dev/restore");
+    expect(restored.email).toBe("bot@test.dev");
+  });
+
   // ── Messages: idempotency + pagination ──────────────────────────
 
   it("messages.send mints an Idempotency-Key for the POST", async () => {
@@ -206,6 +221,25 @@ describe("E2AClient", () => {
     expect(items.map((m) => m.id)).toEqual(["msg_1", "msg_2"]);
     expect(calls).toHaveLength(2);
     expect(calls[1]).toContain("cursor=cur_2");
+  });
+
+  it("messages.list({ deleted: true }) lists the trash", async () => {
+    globalThis.fetch = mockFetch(200, { items: [], next_cursor: null });
+    await client.messages.list("bot@test.dev", { deleted: true }).toArray({ limit: 10 });
+    expect(new URL(lastCall().url).searchParams.get("deleted")).toBe("true");
+  });
+
+  it("messages.restore POSTs to the restore endpoint", async () => {
+    globalThis.fetch = mockFetch(200, {
+      id: "msg_1", conversation_id: "conv_1", created_at: "2026-01-01T00:00:00Z",
+      delivered_to: "bot@test.dev", direction: "inbound", from: "a@x.dev",
+      raw_message: "", read_status: "unread", review_status: "none", subject: "hi",
+    });
+    const restored = await client.messages.restore("bot@test.dev", "msg_1");
+    const { url, init } = lastCall();
+    expect(init.method).toBe("POST");
+    expect(url).toContain("/v1/agents/bot%40test.dev/messages/msg_1/restore");
+    expect(restored.id).toBe("msg_1");
   });
 
   it("messages.getAttachment hits GET …/attachments/{index} and maps the view", async () => {


### PR DESCRIPTION
## Summary
- expose `deleted` trash filters and restore methods in TypeScript and Python ergonomic SDKs
- add MCP trash filtering plus `restore_agent` and `restore_message` tools with REST-aligned scope tiers
- document the lifecycle and extend SDK/MCP regression tests, including direct wrapper delegation coverage

## Validation
- `npm run build --workspace @e2a/sdk`
- `npm run build --workspace @e2a/mcp-server`
- `npm run test:unit --workspace @e2a/sdk` (159 passed)
- `npm test --workspace @e2a/mcp-server` (184 passed)
- `PYTHONPATH=sdks/python/src /opt/homebrew/bin/python3 -m pytest sdks/python/tests/ -q` (285 passed, 18 skipped)
- `python -m compileall -q sdks/python/src/e2a/v1`