### PR TITLE
fix(mcp): align delete receipts and semantics with REST

### DIFF
--- a/mcp/src/client.ts
+++ b/mcp/src/client.ts
@@ -41,6 +41,7 @@ import type {
   DeleteDomainResult,
   DeleteWebhookResult,
   DeleteTemplateResult,
+  DeleteApiKeyResult,
   Page,
 } from "@e2a/sdk/v1";
 import type { McpConfig } from "./config.js";
@@ -489,8 +490,8 @@ export class McpClient {
     return this.sdk.account.apiKeys.create(req);
   }
 
-  async deleteApiKey(id: string): Promise<void> {
-    await this.sdk.account.apiKeys.delete(id);
+  deleteApiKey(id: string): Promise<DeleteApiKeyResult> {
+    return this.sdk.account.apiKeys.delete(id);
   }
 
   // ── Templates (beta) ────────────────────────────────────────────

--- a/mcp/src/tools/agents.ts
+++ b/mcp/src/tools/agents.ts
@@ -219,7 +219,7 @@ export function registerAgentTools(server: McpServer, client: McpClient): void {
       title: "Delete an agent inbox (DESTRUCTIVE)",
       annotations: { destructiveHint: true, idempotentHint: true },
       description:
-        "Permanently delete the agent identity and CASCADE-remove every message, pending outbound, and webhook-delivery record bound to it. Irreversible. Existing OAuth tokens bound to this agent are revoked automatically. Requires `confirm: true` — set it explicitly to acknowledge the destructive action.",
+        "Move the agent inbox to trash for about 30 days. The agent stops receiving mail and disappears from normal lists, but its messages and configuration are retained so it can be restored before automatic purge. Requires `confirm: true` — set it explicitly to acknowledge the destructive action.",
       inputSchema: strictInputSchema({
         email: z
           .string()

--- a/mcp/src/tools/apikeys.ts
+++ b/mcp/src/tools/apikeys.ts
@@ -85,8 +85,8 @@ export function registerApiKeyTools(server: McpServer, client: McpClient): void 
         if (args.confirm !== true) {
           throw new Error("delete_api_key requires confirm:true.");
         }
-        await client.deleteApiKey(args.id);
-        return { deleted: args.id };
+        // Return the server's deletion object verbatim: {deleted:true, id}.
+        return client.deleteApiKey(args.id);
       }),
   );
 }

--- a/mcp/src/tools/domains.ts
+++ b/mcp/src/tools/domains.ts
@@ -91,7 +91,7 @@ export function registerDomainTools(server: McpServer, client: McpClient): void 
       title: "Delete a custom mail domain (DESTRUCTIVE)",
       annotations: { destructiveHint: true, idempotentHint: true },
       description:
-        "Permanently remove a domain registration. CASCADES to every agent on that domain and every message/pending-outbound/webhook-delivery bound to those agents. Irreversible. Existing OAuth tokens bound to those agents are revoked. Requires `confirm: true` — set it explicitly to acknowledge the destructive scope.",
+        "Permanently remove a domain registration and deprovision its sending identity. The operation succeeds only when the domain has no agents; delete or move those inboxes first. Irreversible. Requires `confirm: true` — set it explicitly to acknowledge the destructive scope.",
       inputSchema: strictInputSchema({
         domain: z.string().min(1).describe("Domain to delete."),
         confirm: z

--- a/mcp/src/tools/domains.ts
+++ b/mcp/src/tools/domains.ts
@@ -91,7 +91,7 @@ export function registerDomainTools(server: McpServer, client: McpClient): void 
       title: "Delete a custom mail domain (DESTRUCTIVE)",
       annotations: { destructiveHint: true, idempotentHint: true },
       description:
-        "Permanently remove a domain registration and deprovision its sending identity. The operation succeeds only when the domain has no agents; delete or move those inboxes first. Irreversible. Requires `confirm: true` — set it explicitly to acknowledge the destructive scope.",
+        "Permanently remove a domain registration and deprovision its sending identity. The operation succeeds only when the domain has no agents: permanently delete every live or trashed agent on the domain first. Moving an agent to trash is not sufficient because trashed agents still belong to the domain. Irreversible. Requires `confirm: true` — set it explicitly to acknowledge the destructive scope.",
       inputSchema: strictInputSchema({
         domain: z.string().min(1).describe("Domain to delete."),
         confirm: z

--- a/mcp/tests/client.test.ts
+++ b/mcp/tests/client.test.ts
@@ -123,7 +123,7 @@ describe("McpClient API keys (agent-scope-only minting)", () => {
       apiKeys: {
         list: vi.fn(() => ({ page: async () => ({ items: [{ id: "key_1" }], next_cursor: undefined }) })),
         create: vi.fn(async (req: Record<string, unknown>) => ({ id: "key_new", key: "plaintext-once", ...req })),
-        delete: vi.fn(async () => undefined),
+        delete: vi.fn(async (id: string) => ({ deleted: true, id })),
       },
     },
   });
@@ -150,11 +150,11 @@ describe("McpClient API keys (agent-scope-only minting)", () => {
     expect(req.scope).toBe("agent");
   });
 
-  it("listApiKeys pages and deleteApiKey forwards the id", async () => {
+  it("listApiKeys pages and deleteApiKey returns the SDK's typed deletion receipt", async () => {
     const sdk = mockApiKeysSdk();
     const c = new McpClient(sdk as never, "", "account");
     expect(await c.listApiKeys()).toEqual({ items: [{ id: "key_1" }], next_cursor: undefined });
-    await c.deleteApiKey("key_1");
+    expect(await c.deleteApiKey("key_1")).toEqual({ deleted: true, id: "key_1" });
     expect(sdk.account.apiKeys.delete).toHaveBeenCalledWith("key_1");
   });
 });

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -1599,7 +1599,14 @@ describe("e2a MCP server", () => {
 
     expect(byName.get("delete_agent")).toContain("trash");
     expect(byName.get("delete_agent")).not.toContain("Permanently delete");
-    expect(byName.get("delete_domain")).toContain("no agents");
+    expect(byName.get("delete_domain")).toContain(
+      "permanently delete every live or trashed agent",
+    );
+    expect(byName.get("delete_domain")).toContain(
+      "Moving an agent to trash is not sufficient",
+    );
+    expect(byName.get("delete_domain")).toContain("trashed agents still belong to the domain");
+    expect(byName.get("delete_domain")).not.toContain("move those inboxes");
     expect(byName.get("delete_domain")).not.toContain("CASCADES to every agent");
   });
 

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -125,6 +125,7 @@ function makeStubClient(
       sendingStatus: "verified",
     })),
     deleteDomain: vi.fn(async (domain: string) => ({ deleted: true, domain })),
+    deleteWebhook: vi.fn(async (id: string) => ({ deleted: true, id })),
     listWebhookDeliveries: vi.fn(
       async (id: string, _params: { status?: string; cursor?: string; limit?: number }) => ({
         items: [{ id: "whd_1", webhookId: id, status: "delivered", attempts: 1 }],
@@ -259,7 +260,7 @@ function makeStubClient(
       ...(body.expiresAt ? { expiresAt: body.expiresAt.toISOString() } : {}),
       key: "e2a_agt_new1_PLAINTEXT_ONCE",
     })),
-    deleteApiKey: vi.fn(async () => undefined),
+    deleteApiKey: vi.fn(async (id: string) => ({ deleted: true, id })),
     getStarterTemplate: vi.fn(async (alias: string) => ({
       alias,
       name: "Approval request",
@@ -812,7 +813,11 @@ describe("e2a MCP server", () => {
     });
     expect(stub.deleteAgent).toHaveBeenCalledWith("bot@example.com");
     const content = res.content as Array<{ type: string; text: string }>;
-    expect(content[0]?.text).toMatch(/bot@example\.com/);
+    expect(JSON.parse(content[0]!.text)).toEqual({
+      deleted: true,
+      email: "bot@example.com",
+      messagesDeleted: 0,
+    });
   });
 
   it("delete_agent passes undefined when email omitted (wrapper resolves bound agent)", async () => {
@@ -885,7 +890,17 @@ describe("e2a MCP server", () => {
     });
     expect(stub.deleteDomain).toHaveBeenCalledWith("mail.acme.com");
     const content = res.content as Array<{ type: string; text: string }>;
-    expect(content[0]?.text).toMatch(/mail\.acme\.com/);
+    expect(JSON.parse(content[0]!.text)).toEqual({ deleted: true, domain: "mail.acme.com" });
+  });
+
+  it("delete_webhook returns the REST deletion receipt unchanged", async () => {
+    const res = await client.callTool({
+      name: "delete_webhook",
+      arguments: { id: "wh_1", confirm: true },
+    });
+    expect(stub.deleteWebhook).toHaveBeenCalledWith("wh_1");
+    const content = res.content as Array<{ type: string; text: string }>;
+    expect(JSON.parse(content[0]!.text)).toEqual({ deleted: true, id: "wh_1" });
   });
 
   // ── API keys (admin tier; create is agent-scope-only by construction) ─────
@@ -957,7 +972,7 @@ describe("e2a MCP server", () => {
     });
     expect(stub.deleteApiKey).toHaveBeenCalledWith("key_1");
     const content = res.content as Array<{ type: string; text: string }>;
-    expect(content[0]?.text).toMatch(/key_1/);
+    expect(JSON.parse(content[0]!.text)).toEqual({ deleted: true, id: "key_1" });
   });
 
   it("list_reviews calls the SDK", async () => {
@@ -1572,7 +1587,20 @@ describe("e2a MCP server", () => {
       arguments: { id: "tmpl_1", confirm: true },
     });
     expect(stub.deleteTemplate).toHaveBeenCalledWith("tmpl_1");
-    expect((res.content as Array<{ text: string }>)[0]?.text).toMatch(/tmpl_1/);
+    expect(JSON.parse((res.content as Array<{ text: string }>)[0]!.text)).toEqual({
+      deleted: true,
+      id: "tmpl_1",
+    });
+  });
+
+  it("delete tool descriptions match REST's reversible-agent and guarded-domain semantics", async () => {
+    const { tools } = await client.listTools();
+    const byName = new Map(tools.map((tool) => [tool.name, tool.description ?? ""]));
+
+    expect(byName.get("delete_agent")).toContain("trash");
+    expect(byName.get("delete_agent")).not.toContain("Permanently delete");
+    expect(byName.get("delete_domain")).toContain("no agents");
+    expect(byName.get("delete_domain")).not.toContain("CASCADES to every agent");
   });
 
   it("validate_template forwards source parts + test_data", async () => {


### PR DESCRIPTION
## Summary

Align MCP delete tools with the REST contract:

- return the typed API-key deletion receipt instead of fabricating `{ deleted: id }`
- describe agent deletion as a 30-day soft delete, not a permanent cascade
- describe domain deletion as non-cascading and surface `domain_has_agents`
- lock all five existing MCP delete tools to their typed receipt shapes

## Client surface checklist

- [x] MCP tool behavior and descriptions
- [x] Exact typed deletion-receipt tests for all existing delete tools
- [x] No REST/OpenAPI/generated SDK changes required

## Operational risk

Low. This changes MCP response fidelity and tool descriptions only; REST behavior is unchanged.

## Test plan

- [x] Focused MCP tests: 99 passed
- [x] Full MCP suite: 178 passed
- [x] MCP TypeScript build
- [x] `git diff --check`
