### PR TITLE
fix(api): unify recipient cap errors

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -238,14 +238,14 @@ components:
             $ref: "#/components/schemas/Attachment"
           type: array
         bcc:
+          description: Override Bcc recipients. The message is limited to 50 recipients across to, cc, and bcc combined.
           items:
             type: string
-          maxItems: 50
           type: array
         cc:
+          description: Override Cc recipients. The message is limited to 50 recipients across to, cc, and bcc combined.
           items:
             type: string
-          maxItems: 50
           type: array
         html:
           maxLength: 1048576
@@ -257,9 +257,9 @@ components:
           maxLength: 1048576
           type: string
         to:
+          description: Override primary recipients. The message is limited to 50 recipients across to, cc, and bcc combined.
           items:
             type: string
-          maxItems: 50
           type: array
       type: object
     Attachment:
@@ -1305,14 +1305,14 @@ components:
             $ref: "#/components/schemas/Attachment"
           type: array
         bcc:
+          description: Bcc recipients. The message is limited to 50 recipients across to, cc, and bcc combined.
           items:
             type: string
-          maxItems: 50
           type: array
         cc:
+          description: Cc recipients. The message is limited to 50 recipients across to, cc, and bcc combined.
           items:
             type: string
-          maxItems: 50
           type: array
         conversation_id:
           type: string
@@ -1326,9 +1326,9 @@ components:
           maxLength: 1048576
           type: string
         to:
+          description: Primary recipients. The message is limited to 50 recipients across to, cc, and bcc combined.
           items:
             type: string
-          maxItems: 50
           type: array
       required:
         - to
@@ -2324,14 +2324,14 @@ components:
             $ref: "#/components/schemas/Attachment"
           type: array
         bcc:
+          description: Additional Bcc recipients. The final message is limited to 50 recipients across to, cc, and bcc combined.
           items:
             type: string
-          maxItems: 50
           type: array
         cc:
+          description: Additional Cc recipients. The final message is limited to 50 recipients across to, cc, and bcc combined.
           items:
             type: string
-          maxItems: 50
           type: array
         conversation_id:
           type: string
@@ -2428,14 +2428,14 @@ components:
             $ref: "#/components/schemas/Attachment"
           type: array
         bcc:
+          description: Bcc recipients. The message is limited to 50 recipients across to, cc, and bcc combined.
           items:
             type: string
-          maxItems: 50
           type: array
         cc:
+          description: Cc recipients. The message is limited to 50 recipients across to, cc, and bcc combined.
           items:
             type: string
-          maxItems: 50
           type: array
         conversation_id:
           type: string
@@ -2468,9 +2468,9 @@ components:
           maxLength: 1048576
           type: string
         to:
+          description: Primary recipients. The message is limited to 50 recipients across to, cc, and bcc combined.
           items:
             type: string
-          maxItems: 50
           type: array
       required:
         - to
@@ -4855,6 +4855,12 @@ paths:
               schema:
                 $ref: "#/components/schemas/SendResultView"
           description: Accepted — the approved outbound message was durably queued for async submission (status=accepted); terminal outcome via GET/webhook events.
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: Bad Request — invalid reviewer overrides. error.code includes too_many_recipients when to, cc, and bcc contain more than 50 recipients combined; error.details reports max_recipients and provided.
         "409":
           content:
             application/json:

--- a/internal/agent/hitl_api.go
+++ b/internal/agent/hitl_api.go
@@ -23,9 +23,9 @@ type approveRequest struct {
 	Subject     *string                `json:"subject,omitempty" maxLength:"2000"`
 	BodyText    *string                `json:"text,omitempty" maxLength:"1048576"`
 	BodyHTML    *string                `json:"html,omitempty" maxLength:"1048576"`
-	To          *[]string              `json:"to,omitempty" nullable:"false" maxItems:"50"`
-	CC          *[]string              `json:"cc,omitempty" nullable:"false" maxItems:"50"`
-	BCC         *[]string              `json:"bcc,omitempty" nullable:"false" maxItems:"50"`
+	To          *[]string              `json:"to,omitempty" nullable:"false" doc:"Override primary recipients. The message is limited to 50 recipients across to, cc, and bcc combined."`
+	CC          *[]string              `json:"cc,omitempty" nullable:"false" doc:"Override Cc recipients. The message is limited to 50 recipients across to, cc, and bcc combined."`
+	BCC         *[]string              `json:"bcc,omitempty" nullable:"false" doc:"Override Bcc recipients. The message is limited to 50 recipients across to, cc, and bcc combined."`
 	Attachments *[]outbound.Attachment `json:"attachments,omitempty"`
 }
 

--- a/internal/httpapi/outbound.go
+++ b/internal/httpapi/outbound.go
@@ -141,13 +141,11 @@ const (
 )
 
 // Per-field GA contract limits on outbound request bodies. These are the named
-// source-of-truth for the maxLength / maxItems struct tags on SendEmailRequest,
-// ReplyRequest, ForwardRequest, and agent.ApproveOverrides — the tags use the
-// numeric literals (struct tags can't reference consts), so keep the literals in
-// sync with these values (TestOutboundFieldLimitTagsMatchConsts guards against
-// drift). Grounded in provider research: subject matches Resend/Postmark parity
-// (SES accepts it); the 1 MiB body field is a per-field backstop independent of
-// the composed-message ceiling; maxItems mirrors the runtime maxRecipients cap.
+// source of truth for maxLength struct tags on SendEmailRequest, ReplyRequest,
+// ForwardRequest, and agent.ApproveOverrides. Struct tags use numeric literals,
+// so TestOutboundFieldLimitTagsMatchConsts guards against drift. Recipient count
+// is handler-validated separately so every distribution across to/cc/bcc returns
+// the same structured too_many_recipients error.
 const (
 	// maxSubjectLen caps a single subject line. Enforced via maxLength struct tags.
 	maxSubjectLen = 2000
@@ -193,9 +191,9 @@ func recipientCountError(groups ...[]string) *ErrorEnvelope {
 // processing. subject/text moved from schema-required to handler-enforced so
 // the template shape can omit them.
 type SendEmailRequest struct {
-	To             []string              `json:"to" nullable:"false" maxItems:"50"`
-	CC             []string              `json:"cc,omitempty" nullable:"false" maxItems:"50"`
-	BCC            []string              `json:"bcc,omitempty" nullable:"false" maxItems:"50"`
+	To             []string              `json:"to" nullable:"false" doc:"Primary recipients. The message is limited to 50 recipients across to, cc, and bcc combined."`
+	CC             []string              `json:"cc,omitempty" nullable:"false" doc:"Cc recipients. The message is limited to 50 recipients across to, cc, and bcc combined."`
+	BCC            []string              `json:"bcc,omitempty" nullable:"false" doc:"Bcc recipients. The message is limited to 50 recipients across to, cc, and bcc combined."`
 	Subject        string                `json:"subject,omitempty" maxLength:"2000" doc:"Literal subject. Required unless a template reference is used (mutually exclusive with template_id/template_alias)."`
 	Body           string                `json:"text,omitempty" maxLength:"1048576" doc:"Literal plain-text body. Required unless a template reference is used (mutually exclusive with template_id/template_alias)."`
 	HTMLBody       string                `json:"html,omitempty" maxLength:"1048576" doc:"Literal HTML body. Mutually exclusive with template_id/template_alias."`
@@ -322,8 +320,8 @@ type ReplyRequest struct {
 	Body           string                `json:"text" maxLength:"1048576"` // required (MSG-3); to/subject derived from the original
 	HTMLBody       string                `json:"html,omitempty" maxLength:"1048576"`
 	ReplyAll       bool                  `json:"reply_all,omitempty"`
-	CC             []string              `json:"cc,omitempty" nullable:"false" maxItems:"50"`
-	BCC            []string              `json:"bcc,omitempty" nullable:"false" maxItems:"50"`
+	CC             []string              `json:"cc,omitempty" nullable:"false" doc:"Additional Cc recipients. The final message is limited to 50 recipients across to, cc, and bcc combined."`
+	BCC            []string              `json:"bcc,omitempty" nullable:"false" doc:"Additional Bcc recipients. The final message is limited to 50 recipients across to, cc, and bcc combined."`
 	ConversationID string                `json:"conversation_id,omitempty"`
 	ReplyTo        string                `json:"reply_to,omitempty" doc:"Sets the Reply-To header — where replies to this message are directed. A single RFC 5322 address, optionally with a display name. Defaults to the sending agent's own address."`
 	Attachments    []outbound.Attachment `json:"attachments,omitempty" nullable:"false" doc:"File attachments (base64 in each item's data). Limits: at most 10 attachments, each ≤ 10 MB decoded, and ≤ 25 MB decoded combined. Exceeding the count → 400 invalid_request; exceeding a size → 413 payload_too_large."`
@@ -455,9 +453,9 @@ func (s *Server) replyRecipients(msg *identity.Message, replyAll bool, extraCC [
 
 // ForwardRequest mirrors the legacy forward body.
 type ForwardRequest struct {
-	To             []string              `json:"to" nullable:"false" maxItems:"50"` // required (MSG-3)
-	CC             []string              `json:"cc,omitempty" nullable:"false" maxItems:"50"`
-	BCC            []string              `json:"bcc,omitempty" nullable:"false" maxItems:"50"`
+	To             []string              `json:"to" nullable:"false" doc:"Primary recipients. The message is limited to 50 recipients across to, cc, and bcc combined."` // required (MSG-3)
+	CC             []string              `json:"cc,omitempty" nullable:"false" doc:"Cc recipients. The message is limited to 50 recipients across to, cc, and bcc combined."`
+	BCC            []string              `json:"bcc,omitempty" nullable:"false" doc:"Bcc recipients. The message is limited to 50 recipients across to, cc, and bcc combined."`
 	Body           string                `json:"text" maxLength:"1048576"` // required (MSG-3); subject derived as "Fwd:"
 	HTMLBody       string                `json:"html,omitempty" maxLength:"1048576"`
 	ConversationID string                `json:"conversation_id,omitempty"`

--- a/internal/httpapi/outbound_field_limits_test.go
+++ b/internal/httpapi/outbound_field_limits_test.go
@@ -134,9 +134,10 @@ func TestComposedMessageSizeCountsDecodedNotWire(t *testing.T) {
 
 // --- struct-tag / const drift guard ---
 
-// The maxLength / maxItems struct-tag literals can't reference Go consts, so
-// this test guards against drift: if someone bumps the const but forgets the
-// tag (or vice versa), this fails. Covers all four outbound request shapes.
+// The maxLength struct-tag literals can't reference Go consts, so this test
+// guards against drift: if someone bumps a const but forgets the tag (or vice
+// versa), this fails. Recipient totals are handler-validated because per-field
+// maxItems would preempt the documented too_many_recipients error contract.
 func TestOutboundFieldLimitTagsMatchConsts(t *testing.T) {
 	type want struct {
 		field    string
@@ -152,22 +153,14 @@ func TestOutboundFieldLimitTagsMatchConsts(t *testing.T) {
 			{"Subject", "maxLength", fmt.Sprintf("%d", maxSubjectLen)},
 			{"Body", "maxLength", fmt.Sprintf("%d", maxBodyFieldBytes)},
 			{"HTMLBody", "maxLength", fmt.Sprintf("%d", maxBodyFieldBytes)},
-			{"To", "maxItems", fmt.Sprintf("%d", maxRecipients)},
-			{"CC", "maxItems", fmt.Sprintf("%d", maxRecipients)},
-			{"BCC", "maxItems", fmt.Sprintf("%d", maxRecipients)},
 		}},
 		{"ReplyRequest", ReplyRequest{}, []want{
 			{"Body", "maxLength", fmt.Sprintf("%d", maxBodyFieldBytes)},
 			{"HTMLBody", "maxLength", fmt.Sprintf("%d", maxBodyFieldBytes)},
-			{"CC", "maxItems", fmt.Sprintf("%d", maxRecipients)},
-			{"BCC", "maxItems", fmt.Sprintf("%d", maxRecipients)},
 		}},
 		{"ForwardRequest", ForwardRequest{}, []want{
 			{"Body", "maxLength", fmt.Sprintf("%d", maxBodyFieldBytes)},
 			{"HTMLBody", "maxLength", fmt.Sprintf("%d", maxBodyFieldBytes)},
-			{"To", "maxItems", fmt.Sprintf("%d", maxRecipients)},
-			{"CC", "maxItems", fmt.Sprintf("%d", maxRecipients)},
-			{"BCC", "maxItems", fmt.Sprintf("%d", maxRecipients)},
 		}},
 	}
 	for _, c := range cases {

--- a/internal/httpapi/outbound_recipient_cap_test.go
+++ b/internal/httpapi/outbound_recipient_cap_test.go
@@ -1,18 +1,29 @@
 package httpapi
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 	"testing"
+
+	"github.com/Mnexa-AI/e2a/internal/identity"
 )
 
-// MED-4 — a send whose total to+cc+bcc recipient count exceeds the cap (50)
-// is rejected before any delivery. With the GA maxItems:"50" schema tags, a
-// single field over 50 is now caught earlier — at the Huma schema-validation
-// layer — as a 422 invalid_request (the same canonical validation code as 400,
-// just the "well-formed but unprocessable" status). The runtime combined-count
-// cap (to+cc+bcc > 50 with each field ≤ 50) is covered by
-// TestSendRecipientCapCountsAllFields below and still returns 400
-// too_many_recipients.
+func assertTooManyRecipients(t *testing.T, code int, body map[string]any, provided int) {
+	t.Helper()
+	if code != 400 || errCode(body) != "too_many_recipients" {
+		t.Fatalf("want 400 too_many_recipients, got %d %v", code, body)
+	}
+	errObj, _ := body["error"].(map[string]any)
+	details, _ := errObj["details"].(map[string]any)
+	if details["max_recipients"] != float64(maxRecipients) || details["provided"] != float64(provided) {
+		t.Fatalf("want recipient-cap details max=%d provided=%d, got %v", maxRecipients, provided, body)
+	}
+}
+
+// A single recipient field over the total cap must reach the same handler-level
+// validation as a cap violation distributed across fields.
 func TestSendTooManyRecipients(t *testing.T) {
 	srv := testServer(t)
 	to := make([]string, 51)
@@ -22,9 +33,7 @@ func TestSendTooManyRecipients(t *testing.T) {
 	code, body := postJSON(t, srv.URL+sendURL, "good", map[string]any{
 		"to": to, "subject": "Hi", "text": "hello",
 	})
-	if code != 422 || errCode(body) != "invalid_request" {
-		t.Fatalf("want 422 invalid_request (schema-level maxItems), got %d %v", code, body)
-	}
+	assertTooManyRecipients(t, code, body, 51)
 }
 
 // The cap counts to+cc+bcc together, so 50 split across the three fields must
@@ -44,9 +53,7 @@ func TestSendRecipientCapCountsAllFields(t *testing.T) {
 	code, body := postJSON(t, srv.URL+sendURL, "good", map[string]any{
 		"to": mk("t", 20), "cc": mk("c", 20), "bcc": mk("b", 11), "subject": "Hi", "text": "hello",
 	})
-	if code != 400 || errCode(body) != "too_many_recipients" {
-		t.Fatalf("split over cap: want 400 too_many_recipients, got %d %v", code, body)
-	}
+	assertTooManyRecipients(t, code, body, 51)
 	// 20 + 20 + 10 = 50 -> at the cap, allowed (subject HOLD avoided -> sent).
 	code, _ = postJSON(t, srv.URL+sendURL, "good", map[string]any{
 		"to": mk("t", 20), "cc": mk("c", 20), "bcc": mk("b", 10), "subject": "Hi", "text": "hello",
@@ -56,9 +63,7 @@ func TestSendRecipientCapCountsAllFields(t *testing.T) {
 	}
 }
 
-// The forward path enforces the same schema-level maxItems cap (>50 in a single
-// field → 422). The runtime combined-count path is shared with send via
-// recipientCountError.
+// Forward uses the same 400/code/details contract.
 func TestForwardTooManyRecipients(t *testing.T) {
 	srv := testServer(t)
 	to := make([]string, 51)
@@ -68,14 +73,10 @@ func TestForwardTooManyRecipients(t *testing.T) {
 	code, body := postJSON(t, srv.URL+"/v1/agents/support%40acme.com/messages/msg_in1/forward", "good", map[string]any{
 		"to": to, "text": "fwd",
 	})
-	if code != 422 || errCode(body) != "invalid_request" {
-		t.Fatalf("forward: want 422 invalid_request (schema-level maxItems), got %d %v", code, body)
-	}
+	assertTooManyRecipients(t, code, body, 51)
 }
 
-// The reply path enforces the same schema-level maxItems cap on cc (>50 in a
-// single field → 422). The runtime combined-count path is shared via
-// recipientCountError.
+// Reply uses the same 400/code/details contract.
 func TestReplyTooManyRecipients(t *testing.T) {
 	srv := testServer(t)
 	cc := make([]string, 51)
@@ -85,7 +86,84 @@ func TestReplyTooManyRecipients(t *testing.T) {
 	code, body := postJSON(t, srv.URL+"/v1/agents/support%40acme.com/messages/msg_in1/reply", "good", map[string]any{
 		"text": "re", "cc": cc,
 	})
-	if code != 422 || errCode(body) != "invalid_request" {
-		t.Fatalf("reply: want 422 invalid_request (schema-level maxItems), got %d %v", code, body)
+	assertTooManyRecipients(t, code, body, 51)
+}
+
+// Reviewer overrides must not bypass or drift from the normal outbound cap.
+func TestApproveOverrideTooManyRecipients(t *testing.T) {
+	srv := testServer(t)
+	to := make([]string, 51)
+	for i := range to {
+		to[i] = fmt.Sprintf("r%d@x.com", i)
+	}
+	code, body := postJSON(t, srv.URL+"/v1/reviews/msg_pending/approve", "good", map[string]any{"to": to})
+	assertTooManyRecipients(t, code, body, 51)
+}
+
+// An override replaces only the fields it supplies. Count the final merged
+// draft, not just the override arrays, so a partial edit cannot push a valid
+// held message over the cap.
+func TestApprovePartialOverrideCountsStoredRecipients(t *testing.T) {
+	srv := testServer(t, func(d *Deps) {
+		d.GetReviewWithContent = func(_ context.Context, _, id string) (*identity.Message, error) {
+			if id != "msg_pending" {
+				return nil, fmt.Errorf("not found")
+			}
+			to := make([]string, 30)
+			for i := range to {
+				to[i] = fmt.Sprintf("stored%d@x.com", i)
+			}
+			return &identity.Message{
+				ID: id, AgentID: "support@acme.com", Direction: "outbound",
+				Status: "pending_review", ToRecipients: to,
+			}, nil
+		}
+	})
+	bcc := make([]string, 21)
+	for i := range bcc {
+		bcc[i] = fmt.Sprintf("override%d@x.com", i)
+	}
+	code, body := postJSON(t, srv.URL+"/v1/reviews/msg_pending/approve", "good", map[string]any{"bcc": bcc})
+	assertTooManyRecipients(t, code, body, 51)
+}
+
+// The combined cap cannot be represented by JSON Schema maxItems on each
+// individual array without changing the error contract. Keep it discoverable
+// in the generated schema descriptions while leaving handler validation in
+// control of the uniform 400 response.
+func TestRecipientCapIsDocumentedWithoutPerFieldSchemaValidation(t *testing.T) {
+	raw, err := json.Marshal(New(Deps{}).API.OpenAPI())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		Components struct {
+			Schemas map[string]struct {
+				Properties map[string]struct {
+					Description string `json:"description"`
+					MaxItems    *int   `json:"maxItems"`
+				} `json:"properties"`
+			} `json:"schemas"`
+		} `json:"components"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatal(err)
+	}
+	for schema, fields := range map[string][]string{
+		"SendEmailRequest": {"to", "cc", "bcc"},
+		"ReplyRequest":     {"cc", "bcc"},
+		"ForwardRequest":   {"to", "cc", "bcc"},
+		"ApproveRequest":   {"to", "cc", "bcc"},
+	} {
+		for _, field := range fields {
+			property := doc.Components.Schemas[schema].Properties[field]
+			if property.MaxItems != nil {
+				t.Errorf("%s.%s: maxItems must not preempt the uniform handler error, got %d", schema, field, *property.MaxItems)
+			}
+			description := strings.ToLower(property.Description)
+			if !strings.Contains(description, "50") || !strings.Contains(description, "combined") {
+				t.Errorf("%s.%s: recipient cap is not discoverable in description %q", schema, field, property.Description)
+			}
+		}
 	}
 }

--- a/internal/httpapi/reviews.go
+++ b/internal/httpapi/reviews.go
@@ -98,12 +98,14 @@ func (s *Server) registerReviews() {
 	huma.Register(s.API, huma.Operation{
 		OperationID: "approveReview", Method: http.MethodPost, Path: "/v1/reviews/{id}/approve",
 		Summary: "Approve a held message", Tags: []string{"reviews"},
-		Description: "Approve a hold. Branches on direction: an outbound draft is sent via SES (honoring Idempotency-Key + optional reviewer overrides); an inbound hold is released to the inbox. Returns 202 with status=accepted when outbound delivery is durably queued for async submission, and 200 for a synchronous terminal sent result or an inbound release. Account-scoped only — an agent cannot approve its own hold. Approving an outbound draft applies the same per-agent send-rate limit as a direct send: 429 rate_limited when the agent is over its throughput limit (back off Retry-After seconds and retry).",
+		Description:  "Approve a hold. Branches on direction: an outbound draft is sent via SES (honoring Idempotency-Key + optional reviewer overrides); an inbound hold is released to the inbox. Returns 202 with status=accepted when outbound delivery is durably queued for async submission, and 200 for a synchronous terminal sent result or an inbound release. Account-scoped only — an agent cannot approve its own hold. Approving an outbound draft applies the same per-agent send-rate limit as a direct send: 429 rate_limited when the agent is over its throughput limit (back off Retry-After seconds and retry).",
 		Security:     []map[string][]string{{"bearer": {}}},
 		MaxBodyBytes: maxOutboundBytes, // matches send/reply/forward: a reviewer editing attachments needs the same 40 MB body budget as the original send path.
 		Responses: map[string]*huma.Response{
 			"202": s.jsonResponse(reflect.TypeOf(SendResultView{}), "SendResultView",
 				"Accepted — the approved outbound message was durably queued for async submission (status=accepted); terminal outcome via GET/webhook events."),
+			"400": s.jsonResponse(reflect.TypeOf(ErrorEnvelope{}), "ErrorEnvelope",
+				"Bad Request — invalid reviewer overrides. error.code includes too_many_recipients when to, cc, and bcc contain more than 50 recipients combined; error.details reports max_recipients and provided."),
 			// approve's 409 is shared by two codes, so it gets a merged description
 			// instead of the stock idempotencyInFlightResponse.
 			"409": s.jsonResponse(reflect.TypeOf(ErrorEnvelope{}), "ErrorEnvelope",
@@ -200,6 +202,21 @@ func (s *Server) handleApproveReview(ctx context.Context, in *approveReviewInput
 	msg, err := s.requireOwnedReview(ctx, p.User.ID, in.ID)
 	if err != nil {
 		return nil, err
+	}
+	if msg.Direction == "outbound" {
+		to, cc, bcc := msg.ToRecipients, msg.CC, msg.BCC
+		if in.Body.To != nil {
+			to = *in.Body.To
+		}
+		if in.Body.CC != nil {
+			cc = *in.Body.CC
+		}
+		if in.Body.BCC != nil {
+			bcc = *in.Body.BCC
+		}
+		if env := recipientCountError(to, cc, bcc); env != nil {
+			return nil, env
+		}
 	}
 	status, view, err := s.approveHeld(ctx, p.User.ID, in.ID, msg.AgentID, in.Body, in.IdempotencyKey, in.RawBody)
 	if err != nil {

--- a/sdks/python/src/e2a/v1/generated/api/reviews_api.py
+++ b/sdks/python/src/e2a/v1/generated/api/reviews_api.py
@@ -108,6 +108,7 @@ class ReviewsApi:
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "SendResultView",
             '202': "SendResultView",
+            '400': "ErrorEnvelope",
             '409': "ErrorEnvelope",
             '422': "ErrorEnvelope",
             '429': "RateLimitedEnvelope",
@@ -187,6 +188,7 @@ class ReviewsApi:
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "SendResultView",
             '202': "SendResultView",
+            '400': "ErrorEnvelope",
             '409': "ErrorEnvelope",
             '422': "ErrorEnvelope",
             '429': "RateLimitedEnvelope",
@@ -266,6 +268,7 @@ class ReviewsApi:
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "SendResultView",
             '202': "SendResultView",
+            '400': "ErrorEnvelope",
             '409': "ErrorEnvelope",
             '422': "ErrorEnvelope",
             '429': "RateLimitedEnvelope",

--- a/sdks/python/src/e2a/v1/generated/models/approve_request.py
+++ b/sdks/python/src/e2a/v1/generated/models/approve_request.py
@@ -29,12 +29,12 @@ class ApproveRequest(BaseModel):
     ApproveRequest
     """ # noqa: E501
     attachments: Optional[List[Attachment]] = None
-    bcc: Optional[Annotated[List[StrictStr], Field(max_length=50)]] = None
-    cc: Optional[Annotated[List[StrictStr], Field(max_length=50)]] = None
+    bcc: Optional[List[StrictStr]] = Field(default=None, description="Override Bcc recipients. The message is limited to 50 recipients across to, cc, and bcc combined.")
+    cc: Optional[List[StrictStr]] = Field(default=None, description="Override Cc recipients. The message is limited to 50 recipients across to, cc, and bcc combined.")
     html: Optional[Annotated[str, Field(strict=True, max_length=1048576)]] = None
     subject: Optional[Annotated[str, Field(strict=True, max_length=2000)]] = None
     text: Optional[Annotated[str, Field(strict=True, max_length=1048576)]] = None
-    to: Optional[Annotated[List[StrictStr], Field(max_length=50)]] = None
+    to: Optional[List[StrictStr]] = Field(default=None, description="Override primary recipients. The message is limited to 50 recipients across to, cc, and bcc combined.")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["attachments", "bcc", "cc", "html", "subject", "text", "to"]
 

--- a/sdks/python/src/e2a/v1/generated/models/forward_request.py
+++ b/sdks/python/src/e2a/v1/generated/models/forward_request.py
@@ -29,13 +29,13 @@ class ForwardRequest(BaseModel):
     ForwardRequest
     """ # noqa: E501
     attachments: Optional[List[Attachment]] = Field(default=None, description="Additional attachments to include alongside the forwarded message's original attachments, which are carried over automatically. Limits apply to the combined set (originals + these): at most 10 attachments, each ≤ 10 MB decoded, and ≤ 25 MB decoded combined. Exceeding the count → 400 invalid_request; exceeding a size → 413 payload_too_large.")
-    bcc: Optional[Annotated[List[StrictStr], Field(max_length=50)]] = None
-    cc: Optional[Annotated[List[StrictStr], Field(max_length=50)]] = None
+    bcc: Optional[List[StrictStr]] = Field(default=None, description="Bcc recipients. The message is limited to 50 recipients across to, cc, and bcc combined.")
+    cc: Optional[List[StrictStr]] = Field(default=None, description="Cc recipients. The message is limited to 50 recipients across to, cc, and bcc combined.")
     conversation_id: Optional[StrictStr] = None
     html: Optional[Annotated[str, Field(strict=True, max_length=1048576)]] = None
     reply_to: Optional[StrictStr] = Field(default=None, description="Sets the Reply-To header — where replies to this message are directed. A single RFC 5322 address, optionally with a display name. Defaults to the sending agent's own address.")
     text: Annotated[str, Field(strict=True, max_length=1048576)]
-    to: Annotated[List[StrictStr], Field(max_length=50)]
+    to: List[StrictStr] = Field(description="Primary recipients. The message is limited to 50 recipients across to, cc, and bcc combined.")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["attachments", "bcc", "cc", "conversation_id", "html", "reply_to", "text", "to"]
 

--- a/sdks/python/src/e2a/v1/generated/models/reply_request.py
+++ b/sdks/python/src/e2a/v1/generated/models/reply_request.py
@@ -29,8 +29,8 @@ class ReplyRequest(BaseModel):
     ReplyRequest
     """ # noqa: E501
     attachments: Optional[List[Attachment]] = Field(default=None, description="File attachments (base64 in each item's data). Limits: at most 10 attachments, each ≤ 10 MB decoded, and ≤ 25 MB decoded combined. Exceeding the count → 400 invalid_request; exceeding a size → 413 payload_too_large.")
-    bcc: Optional[Annotated[List[StrictStr], Field(max_length=50)]] = None
-    cc: Optional[Annotated[List[StrictStr], Field(max_length=50)]] = None
+    bcc: Optional[List[StrictStr]] = Field(default=None, description="Additional Bcc recipients. The final message is limited to 50 recipients across to, cc, and bcc combined.")
+    cc: Optional[List[StrictStr]] = Field(default=None, description="Additional Cc recipients. The final message is limited to 50 recipients across to, cc, and bcc combined.")
     conversation_id: Optional[StrictStr] = None
     html: Optional[Annotated[str, Field(strict=True, max_length=1048576)]] = None
     reply_all: Optional[StrictBool] = None

--- a/sdks/python/src/e2a/v1/generated/models/send_email_request.py
+++ b/sdks/python/src/e2a/v1/generated/models/send_email_request.py
@@ -29,8 +29,8 @@ class SendEmailRequest(BaseModel):
     SendEmailRequest
     """ # noqa: E501
     attachments: Optional[List[Attachment]] = Field(default=None, description="File attachments (base64 in each item's data). Limits: at most 10 attachments, each ≤ 10 MB decoded, and ≤ 25 MB decoded combined. Exceeding the count → 400 invalid_request; exceeding a size → 413 payload_too_large.")
-    bcc: Optional[Annotated[List[StrictStr], Field(max_length=50)]] = None
-    cc: Optional[Annotated[List[StrictStr], Field(max_length=50)]] = None
+    bcc: Optional[List[StrictStr]] = Field(default=None, description="Bcc recipients. The message is limited to 50 recipients across to, cc, and bcc combined.")
+    cc: Optional[List[StrictStr]] = Field(default=None, description="Cc recipients. The message is limited to 50 recipients across to, cc, and bcc combined.")
     conversation_id: Optional[StrictStr] = None
     html: Optional[Annotated[str, Field(strict=True, max_length=1048576)]] = Field(default=None, description="Literal HTML body. Mutually exclusive with template_id/template_alias.")
     reply_to: Optional[StrictStr] = Field(default=None, description="Sets the Reply-To header — where replies to this message are directed. A single RFC 5322 address, optionally with a display name (e.g. \"Support <support@acme.com>\"). Defaults to the sending agent's own address.")
@@ -39,7 +39,7 @@ class SendEmailRequest(BaseModel):
     template_data: Optional[Dict[str, Any]] = Field(default=None, description="Variables for the referenced template ({{name}}, dot paths into nested objects). Missing variables render as empty strings. Beta: templates are unstable — their shape may change before they are declared stable.")
     template_id: Optional[StrictStr] = Field(default=None, description="Send using a stored template (rendered server-side, before any review hold). Mutually exclusive with template_alias and with literal subject/body/html_body. Beta: templates are unstable — their shape may change before they are declared stable.")
     text: Optional[Annotated[str, Field(strict=True, max_length=1048576)]] = Field(default=None, description="Literal plain-text body. Required unless a template reference is used (mutually exclusive with template_id/template_alias).")
-    to: Annotated[List[StrictStr], Field(max_length=50)]
+    to: List[StrictStr] = Field(description="Primary recipients. The message is limited to 50 recipients across to, cc, and bcc combined.")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["attachments", "bcc", "cc", "conversation_id", "html", "reply_to", "subject", "template_alias", "template_data", "template_id", "text", "to"]
 

--- a/sdks/typescript/src/v1/generated/apis/ReviewsApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/ReviewsApi.ts
@@ -248,6 +248,13 @@ export class ReviewsApiResponseProcessor {
             ) as SendResultView;
             return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
+        if (isCodeInRange("400", response.httpStatusCode)) {
+            const body: ErrorEnvelope = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "ErrorEnvelope", ""
+            ) as ErrorEnvelope;
+            throw new ApiException<ErrorEnvelope>(response.httpStatusCode, "Bad Request — invalid reviewer overrides. error.code includes too_many_recipients when to, cc, and bcc contain more than 50 recipients combined; error.details reports max_recipients and provided.", body, response.headers);
+        }
         if (isCodeInRange("409", response.httpStatusCode)) {
             const body: ErrorEnvelope = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),

--- a/sdks/typescript/src/v1/generated/models/ApproveRequest.ts
+++ b/sdks/typescript/src/v1/generated/models/ApproveRequest.ts
@@ -15,11 +15,20 @@ import { HttpFile } from '../http/http.js';
 
 export class ApproveRequest {
     'attachments'?: Array<Attachment>;
+    /**
+    * Override Bcc recipients. The message is limited to 50 recipients across to, cc, and bcc combined.
+    */
     'bcc'?: Array<string>;
+    /**
+    * Override Cc recipients. The message is limited to 50 recipients across to, cc, and bcc combined.
+    */
     'cc'?: Array<string>;
     'html'?: string;
     'subject'?: string;
     'text'?: string;
+    /**
+    * Override primary recipients. The message is limited to 50 recipients across to, cc, and bcc combined.
+    */
     'to'?: Array<string>;
 
     static readonly discriminator: string | undefined = undefined;

--- a/sdks/typescript/src/v1/generated/models/ForwardRequest.ts
+++ b/sdks/typescript/src/v1/generated/models/ForwardRequest.ts
@@ -18,7 +18,13 @@ export class ForwardRequest {
     * Additional attachments to include alongside the forwarded message\'s original attachments, which are carried over automatically. Limits apply to the combined set (originals + these): at most 10 attachments, each ≤ 10 MB decoded, and ≤ 25 MB decoded combined. Exceeding the count → 400 invalid_request; exceeding a size → 413 payload_too_large.
     */
     'attachments'?: Array<Attachment>;
+    /**
+    * Bcc recipients. The message is limited to 50 recipients across to, cc, and bcc combined.
+    */
     'bcc'?: Array<string>;
+    /**
+    * Cc recipients. The message is limited to 50 recipients across to, cc, and bcc combined.
+    */
     'cc'?: Array<string>;
     'conversationId'?: string;
     'html'?: string;
@@ -27,6 +33,9 @@ export class ForwardRequest {
     */
     'replyTo'?: string;
     'text': string;
+    /**
+    * Primary recipients. The message is limited to 50 recipients across to, cc, and bcc combined.
+    */
     'to': Array<string>;
 
     static readonly discriminator: string | undefined = undefined;

--- a/sdks/typescript/src/v1/generated/models/ReplyRequest.ts
+++ b/sdks/typescript/src/v1/generated/models/ReplyRequest.ts
@@ -18,7 +18,13 @@ export class ReplyRequest {
     * File attachments (base64 in each item\'s data). Limits: at most 10 attachments, each ≤ 10 MB decoded, and ≤ 25 MB decoded combined. Exceeding the count → 400 invalid_request; exceeding a size → 413 payload_too_large.
     */
     'attachments'?: Array<Attachment>;
+    /**
+    * Additional Bcc recipients. The final message is limited to 50 recipients across to, cc, and bcc combined.
+    */
     'bcc'?: Array<string>;
+    /**
+    * Additional Cc recipients. The final message is limited to 50 recipients across to, cc, and bcc combined.
+    */
     'cc'?: Array<string>;
     'conversationId'?: string;
     'html'?: string;

--- a/sdks/typescript/src/v1/generated/models/SendEmailRequest.ts
+++ b/sdks/typescript/src/v1/generated/models/SendEmailRequest.ts
@@ -18,7 +18,13 @@ export class SendEmailRequest {
     * File attachments (base64 in each item\'s data). Limits: at most 10 attachments, each ≤ 10 MB decoded, and ≤ 25 MB decoded combined. Exceeding the count → 400 invalid_request; exceeding a size → 413 payload_too_large.
     */
     'attachments'?: Array<Attachment>;
+    /**
+    * Bcc recipients. The message is limited to 50 recipients across to, cc, and bcc combined.
+    */
     'bcc'?: Array<string>;
+    /**
+    * Cc recipients. The message is limited to 50 recipients across to, cc, and bcc combined.
+    */
     'cc'?: Array<string>;
     'conversationId'?: string;
     /**
@@ -49,6 +55,9 @@ export class SendEmailRequest {
     * Literal plain-text body. Required unless a template reference is used (mutually exclusive with template_id/template_alias).
     */
     'text'?: string;
+    /**
+    * Primary recipients. The message is limited to 50 recipients across to, cc, and bcc combined.
+    */
     'to': Array<string>;
 
     static readonly discriminator: string | undefined = undefined;


### PR DESCRIPTION
## Summary
- route all outbound recipient-count violations through the documented 400 too_many_recipients envelope
- count approval overrides after merging with the stored held draft
- keep the combined 50-recipient cap discoverable in OpenAPI descriptions and regenerate both SDK bases

## Test plan
- go test ./internal/httpapi -count=1
- go test ./internal/agent -run TestApprovePendingCore -count=1
- make generate-check
- npm run build --workspace @e2a/sdk
