### PR TITLE
fix(web): show domain deletion errors inline

### DIFF
--- a/web/src/app/(app)/domains/_components/DomainCard.tsx
+++ b/web/src/app/(app)/domains/_components/DomainCard.tsx
@@ -227,6 +227,7 @@ export function DomainCard({
   const [verifying, setVerifying] = useState(false);
   const [verifyError, setVerifyError] = useState("");
   const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState("");
   // Cached per-record diagnostic from the most recent verify probe. Until the
   // user re-checks, this is null and the rows fall back to the server-derived
   // per-record status carried in dns_records.
@@ -265,12 +266,15 @@ export function DomainCard({
   const handleDelete = async () => {
     if (!confirm(`Delete domain ${domain.domain}? This cannot be undone.`))
       return;
+    setDeleteError("");
     setDeleting(true);
     try {
       await deleteDomain(domain.domain);
       onDeleted();
     } catch (err) {
-      alert(err instanceof Error ? err.message : "Failed to delete domain");
+      setDeleteError(
+        err instanceof Error ? err.message : "Failed to delete domain",
+      );
     } finally {
       setDeleting(false);
     }
@@ -409,6 +413,21 @@ export function DomainCard({
             DNS changes can take a few minutes to propagate. Wait a bit and
             try again.
           </p>
+        </div>
+      )}
+
+      {deleteError && (
+        <div
+          className="mt-3 p-3 text-[13px]"
+          role="alert"
+          style={{
+            background: "var(--danger-bg)",
+            color: "var(--danger-strong)",
+            border: "1px solid var(--danger-bg)",
+            borderRadius: "var(--r-md)",
+          }}
+        >
+          {deleteError}
         </div>
       )}
 

--- a/web/src/app/(app)/domains/page.test.tsx
+++ b/web/src/app/(app)/domains/page.test.tsx
@@ -246,6 +246,46 @@ describe("Domains page — with domains", () => {
     expect(screen.getByText("Create inbox")).toHaveAttribute("href", "/get-started?domain=verified.example.com");
   });
 
+  it("shows an inline error instead of an alert when domain deletion fails", async () => {
+    mockDomainsAndAgents([sampleDomain], []);
+    mockFetch.mockImplementation((url: string) => {
+      if (url === "/v1/domains") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ items: [sampleDomain] }),
+        });
+      }
+      if (url === "/v1/agents") {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ items: [] }),
+        });
+      }
+      if (
+        url ===
+        `/v1/domains/${encodeURIComponent(sampleDomain.domain)}?confirm=DELETE`
+      ) {
+        return Promise.resolve({
+          ok: false,
+          text: () => Promise.resolve("Deletion is blocked"),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        text: () => Promise.resolve("not found"),
+      });
+    });
+    jest.spyOn(window, "confirm").mockReturnValue(true);
+    const alertSpy = jest.spyOn(window, "alert").mockImplementation(() => {});
+
+    render(<DomainsPage />);
+
+    await userEvent.click(await screen.findByText("Delete"));
+
+    expect(await screen.findByText("Deletion is blocked")).toBeInTheDocument();
+    expect(alertSpy).not.toHaveBeenCalled();
+  });
+
   it("toggles DNS records visibility", async () => {
     mockDomainsAndAgents([sampleDomain], []);
     render(<DomainsPage />);


### PR DESCRIPTION
## Summary

- Replace the Domains page's raw browser alert with an inline, accessible deletion error.
- Add a regression test covering a failed delete request, including the `confirm=DELETE` API contract.

## Root cause

The confirmation query parameter is already sent by the current dashboard helper. However, any API failure was surfaced through `alert()`, which exposed raw response text and did not provide an in-page error state.

## Validation

- `npm test -- --runInBand`
- `npm run lint` (passes with one pre-existing unrelated hook-dependency warning)
