### PR TITLE
fix: make self-send contract-equivalent

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1219,7 +1219,7 @@ components:
           description: "Send kind. Open set; tolerate unknown values. Known values: send, reply, forward."
           type: string
         method:
-          description: "Transport used for the send. Open set; tolerate unknown values. Known values: smtp."
+          description: "Transport used for the send. Open set; tolerate unknown values. Known values: smtp, loopback."
           type: string
         provider_message_id:
           type: string
@@ -1233,7 +1233,6 @@ components:
         - message_id
         - agent_email
         - direction
-        - provider_message_id
         - method
         - from
         - to

--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -603,6 +603,8 @@ func main() {
 	// handler are constructed here and threaded in.
 	wsHub := ws.NewHub()
 	defer wsHub.Close()
+	api.SetWebSocketHub(wsHub)
+	hitlWorker.SetWebSocketHub(wsHub)
 	wsHandler := ws.NewHandler(wsHub, store)
 
 	// v1 contract layer (api-v1-redesign Slice 1). The new chi + Huma surface

--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -339,6 +339,9 @@ func main() {
 	// publisher as the agent API). Load-bearing for inbound approve: a TTL-released
 	// inbound message has no other push signal.
 	hitlWorker.SetPublisher(outboxPublisher)
+	// Self-send auto-approval is a local DB delivery, so its Sent/Inbox rows and
+	// email.sent/email.received outcome records share one transaction.
+	hitlWorker.SetOutbox(webhookOutbox)
 	// Route the sweep's auto-approve send onto QueueOutbound (the
 	// SendWorker does the SMTP submit) instead of a blocking in-process send, so the
 	// sweep is DB-only. Two-phase like the API's SetOutboundEnqueuer: pass the

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -1027,7 +1027,7 @@ type OutboundResult struct {
 	Held              bool
 	PendingMessageID  string
 	ApprovalExpiresAt *time.Time
-	MessageID         string // the e2a msg_ id when sent (GET-able); loopback id for self-send
+	MessageID         string // the e2a msg_ id (GET-able) for every send method
 	ProviderMessageID string // provider/SES id when sent via smtp
 	SentAs            string // "own_address" | "relay" (decision 4)
 	Method            string // "smtp" | "loopback"
@@ -1157,19 +1157,17 @@ func (a *API) DeliverOutbound(ctx context.Context, user *identity.User, agent *i
 	// §7.2 / async-send-contract.md): billing must not run ahead of a durable
 	// message row, or a crash between meter and persist bills an invisible send.
 	if isSelfSend(req, agent.EmailAddress()) {
-		providerID, err := a.performSelfSend(ctx, agent, req, msgType)
+		outMsg, err := a.performSelfSend(ctx, agent, req, msgType, idemCompleteTx)
 		if err != nil {
 			log.Printf("[api] self-send failed: agent=%s error=%v", agent.EmailAddress(), err)
 			return nil, &OutboundError{Status: http.StatusInternalServerError, Code: "internal_error", Msg: "self-send failed"}
 		}
-		// Meter after the loopback delivery succeeds (side-effect only — never
-		// block on quota; the cap pre-check is the gate).
-		if _, err := a.usage.RecordAndCheck(ctx, user.ID, agent.ID, agent.Domain, "outbound"); err != nil {
-			log.Printf("[api] usage recording error: %v", err)
-		}
+		// Meter both durable copies after the local delivery commits. Never block
+		// on metering; the pre-check remains the quota gate.
+		a.recordLoopbackUsage(ctx, user.ID, agent)
 		slug, _, _ := strings.Cut(agent.EmailAddress(), "@")
-		log.Printf("[mail] dir=outbound type=%s method=loopback from=%s to=%s slug=%s conv_id=%s subject=%q provider_id=%s", msgType, agent.EmailAddress(), agent.EmailAddress(), slug, req.ConversationID, req.Subject, providerID)
-		return &OutboundResult{MessageID: providerID, Method: "loopback"}, nil
+		log.Printf("[mail:%s] dir=outbound type=%s method=loopback status=sent from=%s to=%s slug=%s conv_id=%s subject=%q", outMsg.ID, msgType, agent.EmailAddress(), agent.EmailAddress(), slug, req.ConversationID, req.Subject)
+		return &OutboundResult{MessageID: outMsg.ID, SentAs: "own_address", Method: "loopback"}, nil
 	}
 
 	// Queue-first accept path. We are past self-send / hold / block, so this is the
@@ -1215,7 +1213,7 @@ func (a *API) DeliverOutbound(ctx context.Context, user *identity.User, agent *i
 			return err
 		}
 		if idemCompleteTx != nil {
-			if err := idemCompleteTx(ctx, tx, msg.ID); err != nil {
+			if err := idemCompleteTx(ctx, tx, &OutboundResult{MessageID: msg.ID, Status: "accepted"}); err != nil {
 				return err
 			}
 		}

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -223,7 +223,16 @@ type API struct {
 	// DeliverOutbound persists the message + enqueues the outbound_send job in one
 	// transaction and returns accepted before provider submission.
 	outboundEnq OutboundEnqueuer
+	wsHub       WebSocketHub
 }
+
+// WebSocketHub is the narrow live-delivery seam shared with internal/ws.
+type WebSocketHub interface {
+	IsConnected(agentID string) bool
+	Send(agentID string, msg []byte) bool
+}
+
+func (a *API) SetWebSocketHub(h WebSocketHub) { a.wsHub = h }
 
 // SetOutboundEnqueuer wires the mandatory queue-first outbound pipeline. Tests may
 // leave it unset to verify that a miswired process fails closed before provider I/O.

--- a/internal/agent/approve_async_test.go
+++ b/internal/agent/approve_async_test.go
@@ -94,15 +94,51 @@ func TestApprovePendingCore_AsyncSelfSendStaysSync(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sent, oerr := api.ApprovePendingCore(ctx, user.ID, msg.ID, ag.Email, agent.ApproveOverrides{}, nil)
+	idemCompleted := false
+	complete := func(ctx context.Context, tx pgx.Tx, approved *identity.Message) error {
+		var deliveryStatus string
+		var raw []byte
+		if err := tx.QueryRow(ctx,
+			`SELECT COALESCE(delivery_status,''), raw_message FROM messages WHERE id=$1`, approved.ID,
+		).Scan(&deliveryStatus, &raw); err != nil {
+			return err
+		}
+		var inboundRows, outcomeEvents int
+		if err := tx.QueryRow(ctx,
+			`SELECT count(*) FROM messages WHERE agent_id=$1 AND direction='inbound' AND subject='To self'`, ag.ID,
+		).Scan(&inboundRows); err != nil {
+			return err
+		}
+		if err := tx.QueryRow(ctx,
+			`SELECT count(*) FROM webhook_events
+			  WHERE message_id IN (
+			    SELECT id FROM messages WHERE agent_id=$1 AND subject='To self'
+			  ) AND type IN ('email.sent','email.received')`, ag.ID,
+		).Scan(&outcomeEvents); err != nil {
+			return err
+		}
+		if deliveryStatus != "sent" || len(raw) == 0 || inboundRows != 1 || outcomeEvents != 2 {
+			t.Fatalf("self-send approval not atomic in completion tx: delivery_status=%q raw=%d inbound=%d events=%d",
+				deliveryStatus, len(raw), inboundRows, outcomeEvents)
+		}
+		idemCompleted = true
+		return nil
+	}
+	sent, oerr := api.ApprovePendingCore(ctx, user.ID, msg.ID, ag.Email, agent.ApproveOverrides{}, complete)
 	if oerr != nil {
 		t.Fatalf("ApprovePendingCore: status=%d code=%s msg=%s", oerr.Status, oerr.Code, oerr.Msg)
 	}
 	if sent.Status != identity.MessageStatusSent {
 		t.Errorf("status = %q, want %q", sent.Status, identity.MessageStatusSent)
 	}
-	if sent.DeliveryStatus == "accepted" {
-		t.Errorf("self-send must NOT be async-accepted (sync loopback), got DeliveryStatus=%q", sent.DeliveryStatus)
+	if sent.DeliveryStatus != "sent" {
+		t.Errorf("self-send delivery_status=%q want sent", sent.DeliveryStatus)
+	}
+	if len(sent.RawMessage) == 0 {
+		t.Error("self-send approved Sent copy must retain composed MIME")
+	}
+	if !idemCompleted {
+		t.Error("self-send approval did not complete idempotency in the local-delivery transaction")
 	}
 
 	var sendJobID *int64
@@ -113,5 +149,17 @@ func TestApprovePendingCore_AsyncSelfSendStaysSync(t *testing.T) {
 	}
 	if sendJobID != nil {
 		t.Errorf("self-send must NOT be enqueued onto QueueOutbound, send_job_id = %v", *sendJobID)
+	}
+
+	var inboundRows int
+	if err := store.WithTx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT count(*) FROM messages WHERE agent_id=$1 AND direction='inbound' AND subject='To self'`, ag.ID,
+		).Scan(&inboundRows)
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if inboundRows != 1 {
+		t.Errorf("self-send approval inbound rows=%d want 1", inboundRows)
 	}
 }

--- a/internal/agent/hitl_api.go
+++ b/internal/agent/hitl_api.go
@@ -139,18 +139,7 @@ func (a *API) ApprovePendingCore(ctx context.Context, userID, messageID, expecte
 		return sent, nil
 	}
 
-	sent, err = a.store.ApproveAndSend(ctx, messageID, userID, edits,
-		func(locked *identity.Message) (identity.SendResult, error) {
-			sendReq, err := buildSendRequestFromMessage(locked)
-			if err != nil {
-				return identity.SendResult{}, err
-			}
-			attachReferencesChain(ctx, a.store, agent.ID, &sendReq)
-			if !isSelfSend(sendReq, agent.EmailAddress()) {
-				return identity.SendResult{}, errors.New("external outbound approval must be queued")
-			}
-			return a.selfSendApprovalDelivery(ctx, agent, sendReq)
-		})
+	sent, err = a.approveSelfSend(ctx, agent, messageID, userID, edits, idemCompleteTx)
 	if err != nil {
 		switch {
 		case errors.Is(err, identity.ErrMessageNotFound):
@@ -167,9 +156,7 @@ func (a *API) ApprovePendingCore(ctx context.Context, userID, messageID, expecte
 		}
 	}
 
-	if _, err := a.usage.RecordAndCheck(ctx, userID, agent.ID, agent.Domain, "outbound"); err != nil {
-		log.Printf("[api] usage recording error: %v", err)
-	}
+	a.recordLoopbackUsage(ctx, userID, agent)
 	slug, _, _ := strings.Cut(agent.EmailAddress(), "@")
 	log.Printf("[mail:%s] dir=outbound type=%s status=%s from=%s to=%v slug=%s subject=%q edited=%v approved=user:%s",
 		sent.ID, sent.Type, sent.Status, agent.EmailAddress(), sent.ToRecipients, slug, sent.Subject, sent.Edited, userID)

--- a/internal/agent/hitl_magic_api.go
+++ b/internal/agent/hitl_magic_api.go
@@ -208,21 +208,7 @@ func (a *API) magicApprove(w http.ResponseWriter, r *http.Request, messageID, us
 		return
 	}
 
-	sent, err = a.store.ApproveAndSend(r.Context(), messageID, userID, identity.PendingApprovalEdit{},
-		func(locked *identity.Message) (identity.SendResult, error) {
-			sendReq, err := buildSendRequestFromMessage(locked)
-			if err != nil {
-				return identity.SendResult{}, err
-			}
-			attachReferencesChain(r.Context(), a.store, agent.ID, &sendReq)
-			// Self-sends (including the Test email button) deliver via
-			// loopback — see the dashboard-approve branch in hitl_api.go
-			// for the rationale; both paths must stay symmetric.
-			if !isSelfSend(sendReq, agent.EmailAddress()) {
-				return identity.SendResult{}, errors.New("external outbound approval must be queued")
-			}
-			return a.selfSendApprovalDelivery(r.Context(), agent, sendReq)
-		})
+	sent, err = a.approveSelfSend(r.Context(), agent, messageID, userID, identity.PendingApprovalEdit{}, nil)
 	if err != nil {
 		switch {
 		case errors.Is(err, identity.ErrMessageNotFound):
@@ -248,9 +234,7 @@ func (a *API) magicApprove(w http.ResponseWriter, r *http.Request, messageID, us
 		return
 	}
 
-	if _, err := a.usage.RecordAndCheck(r.Context(), userID, agent.ID, agent.Domain, "outbound"); err != nil {
-		log.Printf("[api] magic-approve usage error: %v", err)
-	}
+	a.recordLoopbackUsage(r.Context(), userID, agent)
 	log.Printf("[mail:%s] dir=outbound type=%s status=%s agent=%s to=%v approved=magic-link:user:%s",
 		sent.ID, sent.Type, sent.Status, agent.EmailAddress(), sent.ToRecipients, userID)
 

--- a/internal/agent/outbound_async.go
+++ b/internal/agent/outbound_async.go
@@ -22,12 +22,11 @@ import (
 // agent package (not outboundsend) because agent already owns the store, outbox,
 // usage tracker, and sender — and agent may import outboundsend, never the reverse.
 
-// AcceptIdemCompleter completes the idempotency key inside the accept-tx, given
-// the freshly minted message id. The httpapi layer supplies it (it owns the key +
-// the wire response shape); DeliverOutbound invokes it inside the accept-tx so the
-// key commits atomically with the message + send job. nil when the request carries
-// no Idempotency-Key (or no idempotency store is wired).
-type AcceptIdemCompleter func(ctx context.Context, tx pgx.Tx, messageID string) error
+// AcceptIdemCompleter completes the idempotency key inside the delivery tx with
+// the exact result the wire will render. External sends cache 202/accepted;
+// terminal local loopback caches 200/sent. nil when the request carries no
+// Idempotency-Key (or no idempotency store is wired).
+type AcceptIdemCompleter func(ctx context.Context, tx pgx.Tx, result *OutboundResult) error
 
 // ApproveIdemCompleter completes an approval's idempotency key inside the
 // async approve-and-enqueue transaction. It receives the resolved message so

--- a/internal/agent/outbound_async_test.go
+++ b/internal/agent/outbound_async_test.go
@@ -3,6 +3,7 @@ package agent_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -112,8 +113,11 @@ func TestDeliverOutbound_AcceptTransactionRollsBackAsAUnit(t *testing.T) {
 
 	res, oerr := api.DeliverOutbound(ctx, user, ag, outbound.SendRequest{
 		To: []string{"alice@external.test"}, Subject: "rollback boundary", Body: "never accepted",
-	}, "send", "", nil, func(_ context.Context, _ pgx.Tx, _ string) error {
+	}, "send", "", nil, func(_ context.Context, _ pgx.Tx, result *agent.OutboundResult) error {
 		callbackCalled = true
+		if result.Status != "accepted" || !strings.HasPrefix(result.MessageID, "msg_") {
+			t.Fatalf("accept idempotency result=%+v want accepted msg_ resource", result)
+		}
 		return errors.New("idempotency completion failed")
 	})
 	if !callbackCalled {

--- a/internal/agent/selfsend.go
+++ b/internal/agent/selfsend.go
@@ -2,11 +2,16 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"log"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/tokencanopy/e2a/internal/eventpayload"
 	"github.com/tokencanopy/e2a/internal/identity"
 	"github.com/tokencanopy/e2a/internal/loopback"
 	"github.com/tokencanopy/e2a/internal/outbound"
+	"github.com/tokencanopy/e2a/internal/webhookpub"
 )
 
 // isSelfSend / stripAgentSelfAliases delegate to internal/loopback so the
@@ -33,12 +38,11 @@ func stripAgentSelfAliases(addrs []string, agentEmail string) []string {
 // list_messages, threading, and downstream tooling don't need any
 // special-casing.
 //
-// This is the non-HITL fast path. The HITL-gated counterpart
-// (selfSendApprovalDelivery) writes ONLY the inbound row; the outbound
-// row already exists from holdForApproval and gets updated to
-// status=sent by ApproveAndSend.
+// HITL approval uses the same transactional local-delivery invariants through
+// approveSelfSend while preserving its pre-existing outbound resource id.
 //
-// Returns the provider-style message id used for the outbound row.
+// Returns the GET-able outbound message resource. The provider-style RFC
+// Message-ID remains an internal threading key shared with the inbound twin.
 // Method on the outbound row is "loopback" so operators can tell the
 // difference from "smtp" in logs and audits.
 // msgType is one of "send", "reply", or "forward" — recorded on the
@@ -52,7 +56,8 @@ func (a *API) performSelfSend(
 	agent *identity.AgentIdentity,
 	req outbound.SendRequest,
 	msgType string,
-) (string, error) {
+	idemCompleteTx AcceptIdemCompleter,
+) (*identity.Message, error) {
 	email := agent.EmailAddress()
 
 	// Allocate providerID up front so the outbound row and inbound row
@@ -60,72 +65,173 @@ func (a *API) performSelfSend(
 	// SMTP roundtrip produces.
 	providerID := loopback.ProviderID(a.fromDomain)
 
-	if _, err := a.store.CreateOutboundMessage(
-		ctx,
-		agent.ID,
-		[]string{email},
-		nil,
-		nil,
-		req.Subject,
-		msgType,
-		"loopback",
-		providerID,
-		req.ConversationID,
-		nil, // self-send body is retained on the inbound twin row; don't double-store
-	); err != nil {
-		return "", fmt.Errorf("self-send outbound row: %w", err)
-	}
-
 	rawMessage, err := loopback.ComposeMIME(agent, req, providerID, a.fromDomain)
 	if err != nil {
-		return "", fmt.Errorf("self-send compose: %w", err)
-	}
-	if _, err := a.store.CreateInboundMessage(
-		ctx,
-		"",
-		agent.ID,
-		email,
-		email,
-		providerID,
-		req.Subject,
-		req.ConversationID,
-		"unread",
-		rawMessage,
-		nil,
-		nil,
-		false,
-		"",
-		[]string{email},
-		nil,
-		nil,
-		identity.InboundScreening{}, // self-send: not externally screened
-	); err != nil {
-		return "", fmt.Errorf("self-send inbound row: %w", err)
+		return nil, fmt.Errorf("self-send compose: %w", err)
 	}
 
-	return providerID, nil
+	var outboundMsg *identity.Message
+	err = a.store.WithTx(ctx, func(tx pgx.Tx) error {
+		var txErr error
+		outboundMsg, txErr = a.store.CreateOutboundMessageTx(
+			ctx, tx, agent.ID, []string{email}, nil, nil, req.Subject, msgType,
+			"loopback", providerID, req.ConversationID, rawMessage,
+			"sent", "", "own_address",
+		)
+		if txErr != nil {
+			return fmt.Errorf("self-send outbound row: %w", txErr)
+		}
+
+		inboundMsg, txErr := a.store.CreateInboundMessageInTx(
+			ctx, tx, "", agent.ID, email, email, providerID, req.Subject,
+			req.ConversationID, "unread", rawMessage, nil, nil, false, "",
+			[]string{email}, nil, replyToList(req.ReplyTo), identity.InboundScreening{},
+		)
+		if txErr != nil {
+			return fmt.Errorf("self-send inbound row: %w", txErr)
+		}
+
+		if a.outbox != nil {
+			if txErr = a.publishLoopbackEventsTx(ctx, tx, agent, outboundMsg, inboundMsg, req, msgType, rawMessage); txErr != nil {
+				return txErr
+			}
+		}
+
+		if idemCompleteTx != nil {
+			if txErr = idemCompleteTx(ctx, tx, &OutboundResult{
+				MessageID: outboundMsg.ID, SentAs: "own_address", Method: "loopback",
+			}); txErr != nil {
+				return txErr
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if a.outbox != nil {
+		a.emit().OutboxEventsPublished(webhookpub.EventEmailSent)
+		a.emit().OutboxEventsPublished(webhookpub.EventEmailReceived)
+	}
+	return outboundMsg, nil
 }
 
-// selfSendApprovalDelivery is the HITL-gated counterpart of performSelfSend:
-// it writes ONLY the inbound row (via loopback.DeliverInbound) and returns
-// an identity.SendResult shaped for ApproveAndSend's send callback. The
-// pre-existing held outbound row is finalized to status=sent by
-// ApproveAndSend itself using the result's provider_message_id + method
-// columns — calling CreateOutboundMessage here would create a duplicate
-// row and unanchor the operator-visible audit trail (held → sent for a
-// specific row id).
-//
-// Failure-mode note: the inbound row write happens INSIDE ApproveAndSend's
-// send callback but uses a non-tx connection. If the callback succeeds but
-// the subsequent tx UPDATE / Commit fails, the inbound row will exist
-// while the outbound row stays pending_review. Same crash-window class
-// as the existing SES-side issue documented on ApproveAndSend's docstring.
-// Operator-visible symptom: a "self-message" inbox row with no matching
-// status=sent outbound row.
-func (a *API) selfSendApprovalDelivery(
+func (a *API) publishLoopbackEventsTx(
+	ctx context.Context,
+	tx pgx.Tx,
+	agent *identity.AgentIdentity,
+	outboundMsg, inboundMsg *identity.Message,
+	req outbound.SendRequest,
+	msgType string,
+	rawMessage []byte,
+) error {
+	sentResult := &outbound.SendResult{
+		Method: "loopback", To: []string{agent.EmailAddress()},
+		SentAs: "own_address", Raw: rawMessage,
+	}
+	sentEvent := a.buildSentEvent(agent, outboundMsg, sentResult, req, msgType)
+	sentEvent.ID = webhookpub.DeterministicEventID(outboundMsg.ID, webhookpub.EventEmailSent)
+	if err := a.outbox.PublishTx(ctx, tx, sentEvent); err != nil {
+		return fmt.Errorf("self-send email.sent event: %w", err)
+	}
+
+	receivedEvent := buildLoopbackReceivedEvent(agent, inboundMsg, req, rawMessage)
+	if err := a.outbox.PublishTx(ctx, tx, receivedEvent); err != nil {
+		return fmt.Errorf("self-send email.received event: %w", err)
+	}
+	return nil
+}
+
+func (a *API) approveSelfSend(
 	ctx context.Context,
 	agent *identity.AgentIdentity,
-	req outbound.SendRequest,
-) (identity.SendResult, error) {
-	return loopback.DeliverInbound(ctx, a.store, agent, req, a.fromDomain)
+	messageID, userID string,
+	edits identity.PendingApprovalEdit,
+	idemCompleteTx ApproveIdemCompleter,
+) (*identity.Message, error) {
+	var req outbound.SendRequest
+	sent, err := a.store.ApproveAndDeliverLocal(ctx, messageID, userID, edits,
+		func(locked *identity.Message) (identity.SendResult, error) {
+			var buildErr error
+			req, buildErr = buildSendRequestFromMessage(locked)
+			if buildErr != nil {
+				return identity.SendResult{}, buildErr
+			}
+			attachReferencesChain(ctx, a.store, agent.ID, &req)
+			if !isSelfSend(req, agent.EmailAddress()) {
+				return identity.SendResult{}, errors.New("external outbound approval must be queued")
+			}
+			providerID := loopback.ProviderID(a.fromDomain)
+			raw, composeErr := loopback.ComposeMIME(agent, req, providerID, a.fromDomain)
+			if composeErr != nil {
+				return identity.SendResult{}, composeErr
+			}
+			return identity.SendResult{
+				ProviderMessageID: providerID,
+				Method:            "loopback",
+				To:                []string{agent.EmailAddress()},
+				Raw:               raw,
+			}, nil
+		},
+		func(ctx context.Context, tx pgx.Tx, outboundMsg, inboundMsg *identity.Message, result identity.SendResult) error {
+			if a.outbox != nil {
+				if hookErr := a.publishLoopbackEventsTx(ctx, tx, agent, outboundMsg, inboundMsg, req, outboundMsg.Type, result.Raw); hookErr != nil {
+					return hookErr
+				}
+			}
+			if idemCompleteTx != nil {
+				return idemCompleteTx(ctx, tx, outboundMsg)
+			}
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	if a.outbox != nil {
+		a.emit().OutboxEventsPublished(webhookpub.EventEmailSent)
+		a.emit().OutboxEventsPublished(webhookpub.EventEmailReceived)
+	}
+	return sent, nil
+}
+
+func (a *API) recordLoopbackUsage(ctx context.Context, userID string, agent *identity.AgentIdentity) {
+	for _, direction := range []string{"outbound", "inbound"} {
+		if _, err := a.usage.RecordAndCheck(ctx, userID, agent.ID, agent.Domain, direction); err != nil {
+			log.Printf("[api] self-send %s usage recording error: %v", direction, err)
+		}
+	}
+}
+
+func replyToList(replyTo string) []string {
+	if replyTo == "" {
+		return nil
+	}
+	return []string{replyTo}
+}
+
+func buildLoopbackReceivedEvent(agent *identity.AgentIdentity, msg *identity.Message, req outbound.SendRequest, raw []byte) webhookpub.Event {
+	data := eventpayload.EmailReceivedData{
+		MessageID:         msg.ID,
+		AgentEmail:        agent.EmailAddress(),
+		Direction:         "inbound",
+		ConversationID:    req.ConversationID,
+		From:              agent.EmailAddress(),
+		AuthenticatedFrom: agent.EmailAddress(),
+		To:                []string{agent.EmailAddress()},
+		CC:                []string{},
+		ReplyTo:           replyToList(req.ReplyTo),
+		DeliveredTo:       agent.EmailAddress(),
+		Subject:           req.Subject,
+		AuthHeaders:       map[string]string{},
+		ReceivedAt:        msg.CreatedAt.UTC(),
+		Attachments:       eventpayload.AttachmentMetadata(raw),
+	}
+	e := webhookpub.NewEvent(webhookpub.EventEmailReceived, agent.UserID, data)
+	e.ID = webhookpub.DeterministicEventID(msg.ID, webhookpub.EventEmailReceived)
+	e.AgentID = agent.ID
+	e.ConversationID = req.ConversationID
+	e.MessageID = msg.ID
+	return e
 }

--- a/internal/agent/selfsend.go
+++ b/internal/agent/selfsend.go
@@ -2,9 +2,11 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log"
+	"net/mail"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/tokencanopy/e2a/internal/eventpayload"
@@ -71,6 +73,7 @@ func (a *API) performSelfSend(
 	}
 
 	var outboundMsg *identity.Message
+	var receivedEvent webhookpub.Event
 	err = a.store.WithTx(ctx, func(tx pgx.Tx) error {
 		var txErr error
 		outboundMsg, txErr = a.store.CreateOutboundMessageTx(
@@ -83,16 +86,20 @@ func (a *API) performSelfSend(
 		}
 
 		inboundMsg, txErr := a.store.CreateInboundMessageInTx(
-			ctx, tx, "", agent.ID, email, email, providerID, req.Subject,
+			ctx, tx, "", agent.ID, loopbackDisplayFrom(req, email), email, providerID, req.Subject,
 			req.ConversationID, "unread", rawMessage, nil, nil, false, "",
 			[]string{email}, nil, replyToList(req.ReplyTo), identity.InboundScreening{},
 		)
 		if txErr != nil {
 			return fmt.Errorf("self-send inbound row: %w", txErr)
 		}
+		if _, txErr = tx.Exec(ctx, `UPDATE messages SET method='loopback' WHERE id=$1`, inboundMsg.ID); txErr != nil {
+			return fmt.Errorf("self-send inbound method: %w", txErr)
+		}
+		inboundMsg.Method = "loopback"
 
 		if a.outbox != nil {
-			if txErr = a.publishLoopbackEventsTx(ctx, tx, agent, outboundMsg, inboundMsg, req, msgType, rawMessage); txErr != nil {
+			if receivedEvent, txErr = a.publishLoopbackEventsTx(ctx, tx, agent, outboundMsg, inboundMsg, req, msgType, rawMessage); txErr != nil {
 				return txErr
 			}
 		}
@@ -114,6 +121,7 @@ func (a *API) performSelfSend(
 		a.emit().OutboxEventsPublished(webhookpub.EventEmailSent)
 		a.emit().OutboxEventsPublished(webhookpub.EventEmailReceived)
 	}
+	a.pushLoopbackReceived(agent.ID, receivedEvent)
 	return outboundMsg, nil
 }
 
@@ -125,7 +133,7 @@ func (a *API) publishLoopbackEventsTx(
 	req outbound.SendRequest,
 	msgType string,
 	rawMessage []byte,
-) error {
+) (webhookpub.Event, error) {
 	sentResult := &outbound.SendResult{
 		Method: "loopback", To: []string{agent.EmailAddress()},
 		SentAs: "own_address", Raw: rawMessage,
@@ -133,14 +141,14 @@ func (a *API) publishLoopbackEventsTx(
 	sentEvent := a.buildSentEvent(agent, outboundMsg, sentResult, req, msgType)
 	sentEvent.ID = webhookpub.DeterministicEventID(outboundMsg.ID, webhookpub.EventEmailSent)
 	if err := a.outbox.PublishTx(ctx, tx, sentEvent); err != nil {
-		return fmt.Errorf("self-send email.sent event: %w", err)
+		return webhookpub.Event{}, fmt.Errorf("self-send email.sent event: %w", err)
 	}
 
 	receivedEvent := buildLoopbackReceivedEvent(agent, inboundMsg, req, rawMessage)
 	if err := a.outbox.PublishTx(ctx, tx, receivedEvent); err != nil {
-		return fmt.Errorf("self-send email.received event: %w", err)
+		return webhookpub.Event{}, fmt.Errorf("self-send email.received event: %w", err)
 	}
-	return nil
+	return receivedEvent, nil
 }
 
 func (a *API) approveSelfSend(
@@ -151,6 +159,7 @@ func (a *API) approveSelfSend(
 	idemCompleteTx ApproveIdemCompleter,
 ) (*identity.Message, error) {
 	var req outbound.SendRequest
+	var receivedEvent webhookpub.Event
 	sent, err := a.store.ApproveAndDeliverLocal(ctx, messageID, userID, edits,
 		func(locked *identity.Message) (identity.SendResult, error) {
 			var buildErr error
@@ -171,12 +180,15 @@ func (a *API) approveSelfSend(
 				ProviderMessageID: providerID,
 				Method:            "loopback",
 				To:                []string{agent.EmailAddress()},
+				Sender:            loopbackDisplayFrom(req, agent.EmailAddress()),
 				Raw:               raw,
 			}, nil
 		},
 		func(ctx context.Context, tx pgx.Tx, outboundMsg, inboundMsg *identity.Message, result identity.SendResult) error {
 			if a.outbox != nil {
-				if hookErr := a.publishLoopbackEventsTx(ctx, tx, agent, outboundMsg, inboundMsg, req, outboundMsg.Type, result.Raw); hookErr != nil {
+				var hookErr error
+				receivedEvent, hookErr = a.publishLoopbackEventsTx(ctx, tx, agent, outboundMsg, inboundMsg, req, outboundMsg.Type, result.Raw)
+				if hookErr != nil {
 					return hookErr
 				}
 			}
@@ -193,6 +205,7 @@ func (a *API) approveSelfSend(
 		a.emit().OutboxEventsPublished(webhookpub.EventEmailSent)
 		a.emit().OutboxEventsPublished(webhookpub.EventEmailReceived)
 	}
+	a.pushLoopbackReceived(agent.ID, receivedEvent)
 	return sent, nil
 }
 
@@ -217,7 +230,7 @@ func buildLoopbackReceivedEvent(agent *identity.AgentIdentity, msg *identity.Mes
 		AgentEmail:        agent.EmailAddress(),
 		Direction:         "inbound",
 		ConversationID:    req.ConversationID,
-		From:              agent.EmailAddress(),
+		From:              loopbackDisplayFrom(req, agent.EmailAddress()),
 		AuthenticatedFrom: agent.EmailAddress(),
 		To:                []string{agent.EmailAddress()},
 		CC:                []string{},
@@ -234,4 +247,24 @@ func buildLoopbackReceivedEvent(agent *identity.AgentIdentity, msg *identity.Mes
 	e.ConversationID = req.ConversationID
 	e.MessageID = msg.ID
 	return e
+}
+
+func loopbackDisplayFrom(req outbound.SendRequest, agentEmail string) string {
+	if req.ReplyTo != "" {
+		if address, err := mail.ParseAddress(req.ReplyTo); err == nil {
+			return address.Address
+		}
+		return req.ReplyTo
+	}
+	return agentEmail
+}
+
+func (a *API) pushLoopbackReceived(agentID string, event webhookpub.Event) {
+	if a.wsHub == nil || event.ID == "" || !a.wsHub.IsConnected(agentID) {
+		return
+	}
+	payload, err := json.Marshal(event.AsEnvelope())
+	if err == nil {
+		a.wsHub.Send(agentID, payload)
+	}
 }

--- a/internal/agent/selfsend_test.go
+++ b/internal/agent/selfsend_test.go
@@ -2,9 +2,11 @@ package agent_test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/tokencanopy/e2a/internal/agent"
 	"github.com/tokencanopy/e2a/internal/config"
@@ -12,6 +14,7 @@ import (
 	"github.com/tokencanopy/e2a/internal/outbound"
 	"github.com/tokencanopy/e2a/internal/testutil"
 	"github.com/tokencanopy/e2a/internal/usage"
+	"github.com/tokencanopy/e2a/internal/webhookpub"
 )
 
 // TestSelfSend_DetectionEdgeCases: case-insensitive, whitespace-
@@ -62,6 +65,7 @@ func setupCoreAPI(t *testing.T) (*agent.API, *identity.Store, *pgxpool.Pool) {
 	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
 	api := agent.NewAPI(store, sender, smtpRelay, nil, usage.NewNoopUsageTracker(),
 		"e2a.dev", "test.e2a.dev", "agents.e2a.dev", "", false)
+	api.SetOutbox(webhookpub.NewOutbox(pool, webhookpub.StaticFlag(true)))
 	return api, store, pool
 }
 
@@ -108,8 +112,11 @@ func TestSelfSend_HappyPath(t *testing.T) {
 	if res.Method != "loopback" {
 		t.Errorf("method=%q want loopback", res.Method)
 	}
-	if !strings.HasPrefix(res.MessageID, "<") || !strings.Contains(res.MessageID, "loopback.") {
-		t.Errorf("message_id=%q should look like an RFC 5322 Message-ID with loopback host", res.MessageID)
+	if !strings.HasPrefix(res.MessageID, "msg_") {
+		t.Errorf("message_id=%q should be the GET-able outbound resource id", res.MessageID)
+	}
+	if res.ProviderMessageID != "" {
+		t.Errorf("provider_message_id=%q want empty for providerless loopback delivery", res.ProviderMessageID)
 	}
 
 	var outboundCount, inboundCount int
@@ -134,12 +141,109 @@ func TestSelfSend_HappyPath(t *testing.T) {
 		t.Errorf("self-note row sender=%q recipient=%q; both must be the agent's own address", sender, recipient)
 	}
 
-	var method string
+	var method, deliveryStatus, providerID string
+	var outboundRaw []byte
 	pool.QueryRow(ctx,
-		`SELECT method FROM messages WHERE agent_id=$1 AND direction='outbound' AND subject='note to self'`,
-		ag.ID).Scan(&method)
+		`SELECT method, COALESCE(delivery_status,''), provider_message_id, raw_message
+		   FROM messages WHERE id=$1`, res.MessageID).Scan(&method, &deliveryStatus, &providerID, &outboundRaw)
 	if method != "loopback" {
 		t.Errorf("outbound method=%q want loopback", method)
+	}
+	if deliveryStatus != "sent" {
+		t.Errorf("outbound delivery_status=%q want sent", deliveryStatus)
+	}
+	if len(outboundRaw) == 0 || !strings.Contains(string(outboundRaw), "remember to refill coffee") {
+		t.Errorf("outbound sent copy must retain readable MIME; raw=%q", outboundRaw)
+	}
+
+	var inboundProviderID string
+	if err := pool.QueryRow(ctx,
+		`SELECT email_message_id FROM messages
+		  WHERE agent_id=$1 AND direction='inbound' AND subject='note to self'`, ag.ID,
+	).Scan(&inboundProviderID); err != nil {
+		t.Fatalf("fetch inbound Message-ID: %v", err)
+	}
+	if providerID == "" || inboundProviderID != providerID {
+		t.Errorf("loopback Message-ID mismatch: outbound=%q inbound=%q", providerID, inboundProviderID)
+	}
+
+	rows, err := pool.Query(ctx,
+		`SELECT type, message_id FROM webhook_events
+		  WHERE message_id IN (
+		    SELECT id FROM messages WHERE agent_id=$1 AND subject='note to self'
+		  ) ORDER BY type`, ag.ID)
+	if err != nil {
+		t.Fatalf("list loopback events: %v", err)
+	}
+	defer rows.Close()
+	var eventTypes []string
+	for rows.Next() {
+		var eventType, messageID string
+		if err := rows.Scan(&eventType, &messageID); err != nil {
+			t.Fatalf("scan loopback event: %v", err)
+		}
+		eventTypes = append(eventTypes, eventType)
+	}
+	if got, want := strings.Join(eventTypes, ","), "email.received,email.sent"; got != want {
+		t.Errorf("loopback events=%q want %q", got, want)
+	}
+	var sentEventHasProviderID bool
+	if err := pool.QueryRow(ctx,
+		`SELECT envelope->'data' ? 'provider_message_id'
+		   FROM webhook_events WHERE message_id=$1 AND type='email.sent'`, res.MessageID,
+	).Scan(&sentEventHasProviderID); err != nil {
+		t.Fatalf("read loopback email.sent payload: %v", err)
+	}
+	if sentEventHasProviderID {
+		t.Error("providerless loopback email.sent must omit provider_message_id")
+	}
+}
+
+// The idempotency completion hook must share the same transaction as both
+// loopback message rows and their lifecycle events. A completion failure is a
+// failure to commit the local delivery, not a partial Sent/Inbox pair.
+func TestSelfSend_IdempotencyCompletionFailureRollsBackDelivery(t *testing.T) {
+	api, store, pool := setupCoreAPI(t)
+	ctx := context.Background()
+	user, ag := selfAgent(t, store, "idemrollback")
+
+	_, oerr := api.DeliverOutbound(ctx, user, ag, outbound.SendRequest{
+		To: []string{ag.EmailAddress()}, Subject: "atomic rollback", Body: "must not persist",
+	}, "send", "", nil, func(_ context.Context, tx pgx.Tx, result *agent.OutboundResult) error {
+		if !strings.HasPrefix(result.MessageID, "msg_") {
+			t.Errorf("idempotency completion message_id=%q want msg_ resource id", result.MessageID)
+		}
+		if result.Method != "loopback" || result.Status != "" {
+			t.Errorf("idempotency completion result=%+v want terminal loopback", result)
+		}
+		var count int
+		if err := tx.QueryRow(ctx,
+			`SELECT count(*) FROM messages WHERE agent_id=$1 AND subject='atomic rollback'`, ag.ID,
+		).Scan(&count); err != nil {
+			t.Fatalf("count transaction-local loopback rows: %v", err)
+		}
+		if count != 2 {
+			t.Errorf("transaction-local loopback rows=%d want 2", count)
+		}
+		return errors.New("inject idempotency completion failure")
+	})
+	if oerr == nil || oerr.Code != "internal_error" {
+		t.Fatalf("DeliverOutbound error=%v want internal_error", oerr)
+	}
+
+	var messages, events int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM messages WHERE agent_id=$1 AND subject='atomic rollback'`, ag.ID,
+	).Scan(&messages); err != nil {
+		t.Fatalf("count rolled-back messages: %v", err)
+	}
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM webhook_events WHERE agent_id=$1 AND envelope->'data'->>'subject'='atomic rollback'`, ag.ID,
+	).Scan(&events); err != nil {
+		t.Fatalf("count rolled-back events: %v", err)
+	}
+	if messages != 0 || events != 0 {
+		t.Fatalf("partial loopback commit: messages=%d events=%d; want both zero", messages, events)
 	}
 }
 

--- a/internal/agent/selfsend_test.go
+++ b/internal/agent/selfsend_test.go
@@ -2,7 +2,9 @@ package agent_test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -15,7 +17,16 @@ import (
 	"github.com/tokencanopy/e2a/internal/testutil"
 	"github.com/tokencanopy/e2a/internal/usage"
 	"github.com/tokencanopy/e2a/internal/webhookpub"
+	wsnotify "github.com/tokencanopy/e2a/internal/ws"
 )
+
+type captureHub struct{ payload []byte }
+
+func (h *captureHub) IsConnected(string) bool { return true }
+func (h *captureHub) Send(_ string, payload []byte) bool {
+	h.payload = append([]byte(nil), payload...)
+	return true
+}
 
 // TestSelfSend_DetectionEdgeCases: case-insensitive, whitespace-
 // trimmed, single-address requirement. Mixed/external recipients must
@@ -102,9 +113,13 @@ func TestSelfSend_HappyPath(t *testing.T) {
 	api, store, pool := setupCoreAPI(t)
 	ctx := context.Background()
 	user, ag := selfAgent(t, store, "owner")
+	hub := &captureHub{}
+	api.SetWebSocketHub(hub)
+	const replyTo = "Support <support@example.com>"
 
 	res, oerr := api.DeliverOutbound(ctx, user, ag, outbound.SendRequest{
-		To: []string{ag.EmailAddress()}, Subject: "note to self", Body: "remember to refill coffee",
+		To: []string{ag.EmailAddress()}, Subject: "note to self", Body: "remember to refill coffee", ReplyTo: replyTo,
+		Attachments: []outbound.Attachment{{Filename: "note.txt", ContentType: "text/plain", Data: "aGVsbG8="}},
 	}, "send", "", nil, nil)
 	if oerr != nil {
 		t.Fatalf("DeliverOutbound: status=%d code=%s msg=%s", oerr.Status, oerr.Code, oerr.Msg)
@@ -133,12 +148,12 @@ func TestSelfSend_HappyPath(t *testing.T) {
 		t.Errorf("inbound rows=%d want 1", inboundCount)
 	}
 
-	var sender, recipient string
+	var inboundID, sender, recipient string
 	pool.QueryRow(ctx,
-		`SELECT sender, recipient FROM messages WHERE agent_id=$1 AND direction='inbound' AND subject='note to self'`,
-		ag.ID).Scan(&sender, &recipient)
-	if sender != ag.EmailAddress() || recipient != ag.EmailAddress() {
-		t.Errorf("self-note row sender=%q recipient=%q; both must be the agent's own address", sender, recipient)
+		`SELECT id, sender, recipient FROM messages WHERE agent_id=$1 AND direction='inbound' AND subject='note to self'`,
+		ag.ID).Scan(&inboundID, &sender, &recipient)
+	if sender != "support@example.com" || recipient != ag.EmailAddress() {
+		t.Errorf("self-note row sender=%q recipient=%q; want Reply-To and agent address", sender, recipient)
 	}
 
 	var method, deliveryStatus, providerID string
@@ -165,6 +180,9 @@ func TestSelfSend_HappyPath(t *testing.T) {
 	}
 	if providerID == "" || inboundProviderID != providerID {
 		t.Errorf("loopback Message-ID mismatch: outbound=%q inbound=%q", providerID, inboundProviderID)
+	}
+	if !strings.Contains(string(outboundRaw), "Message-ID: "+providerID) {
+		t.Errorf("loopback MIME missing its synthetic Message-ID header: %q", outboundRaw)
 	}
 
 	rows, err := pool.Query(ctx,
@@ -196,6 +214,49 @@ func TestSelfSend_HappyPath(t *testing.T) {
 	}
 	if sentEventHasProviderID {
 		t.Error("providerless loopback email.sent must omit provider_message_id")
+	}
+	var durableEnvelope []byte
+	if err := pool.QueryRow(ctx,
+		`SELECT envelope FROM webhook_events WHERE message_id=$1 AND type='email.received'`, inboundID,
+	).Scan(&durableEnvelope); err != nil {
+		t.Fatalf("read durable received envelope: %v", err)
+	}
+	var durable, live map[string]any
+	if err := json.Unmarshal(durableEnvelope, &durable); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(hub.payload, &live); err != nil {
+		t.Fatalf("live WebSocket payload: %v (%q)", err, hub.payload)
+	}
+	if !reflect.DeepEqual(live, durable) {
+		t.Errorf("live WebSocket envelope drifted from durable webhook event\nlive=%v\ndurable=%v", live, durable)
+	}
+	listed, err := store.GetMessagesByAgent(ctx, identity.MessageListFilter{
+		AgentID: ag.ID, Status: "all", Direction: "inbound", Limit: 10,
+	})
+	if err != nil || len(listed) != 1 {
+		t.Fatalf("list reconnect message: len=%d err=%v", len(listed), err)
+	}
+	if listed[0].Method != "loopback" {
+		t.Fatalf("reconnect row method = %q, want durable loopback marker", listed[0].Method)
+	}
+	var reconnect map[string]any
+	if err := json.Unmarshal(wsnotify.NotificationForMessage(ctx, store, &listed[0]), &reconnect); err != nil {
+		t.Fatal(err)
+	}
+	reconnectData := reconnect["data"].(map[string]any)
+	if !reflect.DeepEqual(reconnect, durable) {
+		t.Errorf("reconnect envelope drifted from durable event\nreconnect=%v\ndurable=%v", reconnect, durable)
+	}
+	if reconnect["id"] != live["id"] || reconnectData["from"] != "support@example.com" || reconnectData["authenticated_from"] != ag.EmailAddress() {
+		t.Errorf("reconnect identity drift: %v", reconnect)
+	}
+	data := live["data"].(map[string]any)
+	if data["from"] != "support@example.com" || data["authenticated_from"] != ag.EmailAddress() {
+		t.Errorf("received identities = from:%v authenticated_from:%v", data["from"], data["authenticated_from"])
+	}
+	if attachments, ok := data["attachments"].([]any); !ok || len(attachments) != 1 {
+		t.Errorf("live/durable/reconnect envelope lost attachment metadata: %v", data["attachments"])
 	}
 }
 

--- a/internal/agent/webhooks_api.go
+++ b/internal/agent/webhooks_api.go
@@ -116,16 +116,18 @@ func (a *API) buildApprovedEvent(
 	reviewerUserID string,
 ) webhookpub.Event {
 	data := map[string]interface{}{
-		"message_id":          sent.ID,
-		"direction":           "outbound",
-		"agent_email":         agent.EmailAddress(),
-		"provider_message_id": sent.ProviderMessageID,
-		"method":              sent.Method,
-		"from":                agent.EmailAddress(),
-		"to":                  sent.ToRecipients,
-		"subject":             sent.Subject,
-		"message_type":        sent.Type,
-		"edited":              sent.Edited,
+		"message_id":   sent.ID,
+		"direction":    "outbound",
+		"agent_email":  agent.EmailAddress(),
+		"method":       sent.Method,
+		"from":         agent.EmailAddress(),
+		"to":           sent.ToRecipients,
+		"subject":      sent.Subject,
+		"message_type": sent.Type,
+		"edited":       sent.Edited,
+	}
+	if sent.ProviderMessageID != "" && sent.Method != "loopback" {
+		data["provider_message_id"] = sent.ProviderMessageID
 	}
 	return webhookpub.Event{
 		ID:        generateEventIDForAgent(),

--- a/internal/agent/webhooks_events_test.go
+++ b/internal/agent/webhooks_events_test.go
@@ -251,6 +251,15 @@ func TestBuildApprovedEvent(t *testing.T) {
 	if _, ok := data["reviewed_by_user_id"]; ok {
 		t.Errorf("reviewed_by_user_id must not be exposed, got %v", data["reviewed_by_user_id"])
 	}
+	if data["provider_message_id"] != "ses_a" {
+		t.Errorf("provider_message_id = %v, want ses_a", data["provider_message_id"])
+	}
+	sent.Method = "loopback"
+	sent.ProviderMessageID = "<local@loopback.x.example.com>"
+	localData := a.buildApprovedEvent(agent, sent, "u_reviewer").Data.(map[string]interface{})
+	if _, ok := localData["provider_message_id"]; ok {
+		t.Errorf("providerless loopback review event leaked provider_message_id: %v", localData)
+	}
 }
 
 func TestBuildRejectedEvent(t *testing.T) {

--- a/internal/eventpayload/payloads.go
+++ b/internal/eventpayload/payloads.go
@@ -91,8 +91,8 @@ type EmailReceivedData struct {
 }
 
 // EmailSentData is the `data` payload of an email.sent event — an outbound
-// send was accepted by the provider. Emitted by BOTH the synchronous send
-// path and the async send worker with the identical shape.
+// send reached its terminal sent state, either by provider acceptance or by
+// atomic local loopback delivery.
 type EmailSentData struct {
 	MessageID      string `json:"message_id"`
 	AgentEmail     string `json:"agent_email"`
@@ -100,9 +100,10 @@ type EmailSentData struct {
 	ConversationID string `json:"conversation_id,omitempty"`
 	// ProviderMessageID is the provider-assigned (SES) message id — distinct
 	// from the e2a message_id, and the correlation key for the async
-	// delivered/bounced/complained feedback events.
-	ProviderMessageID string   `json:"provider_message_id"`
-	Method            string   `json:"method" doc:"Transport used for the send. Open set; tolerate unknown values. Known values: smtp."`
+	// delivered/bounced/complained feedback events. Omitted for providerless
+	// local loopback delivery.
+	ProviderMessageID string   `json:"provider_message_id,omitempty"`
+	Method            string   `json:"method" doc:"Transport used for the send. Open set; tolerate unknown values. Known values: smtp, loopback."`
 	From              string   `json:"from"`
 	To                []string `json:"to" nullable:"false"`
 	CC                []string `json:"cc,omitempty" nullable:"false"`

--- a/internal/hitlworker/events.go
+++ b/internal/hitlworker/events.go
@@ -84,17 +84,19 @@ func (w *Worker) emitOutboundApproved(agent *identity.AgentIdentity, sent *ident
 		return
 	}
 	data := map[string]interface{}{
-		"message_id":          sent.ID,
-		"direction":           "outbound",
-		"agent_email":         agent.EmailAddress(),
-		"provider_message_id": sent.ProviderMessageID,
-		"method":              sent.Method,
-		"from":                agent.EmailAddress(),
-		"to":                  sent.ToRecipients,
-		"subject":             sent.Subject,
-		"message_type":        sent.Type,
-		"edited":              false,
-		"auto_resolved":       true,
+		"message_id":    sent.ID,
+		"direction":     "outbound",
+		"agent_email":   agent.EmailAddress(),
+		"method":        sent.Method,
+		"from":          agent.EmailAddress(),
+		"to":            sent.ToRecipients,
+		"subject":       sent.Subject,
+		"message_type":  sent.Type,
+		"edited":        false,
+		"auto_resolved": true,
+	}
+	if sent.ProviderMessageID != "" && sent.Method != "loopback" {
+		data["provider_message_id"] = sent.ProviderMessageID
 	}
 	e := webhookpub.NewEvent(webhookpub.EventEmailReviewApproved, agent.UserID, data)
 	e.AgentID = agent.ID

--- a/internal/hitlworker/events_test.go
+++ b/internal/hitlworker/events_test.go
@@ -179,6 +179,28 @@ func TestWorkerEmitsOutboundReviewApprovedOnExpiry(t *testing.T) {
 	}
 }
 
+func TestWorkerLoopbackReviewApprovedOmitsProviderID(t *testing.T) {
+	w, store, pool, _ := setupWorker(t)
+	cap := &capPub{}
+	w.SetPublisher(cap)
+	ctx := context.Background()
+	agent := prepareAgent(t, store, "emit-loopback-approve", identity.HITLExpirationApprove)
+	msg, err := store.CreatePendingOutboundMessage(ctx, agent.ID,
+		[]string{agent.EmailAddress()}, nil, nil, "Held self", "body", "", nil, "send", "", "", "", 60)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backdateExpiry(t, pool, msg.ID)
+	w.RunOnce(ctx)
+	d := dataOf(t, cap.waitFor(t, webhookpub.EventEmailReviewApproved))
+	if d["method"] != "loopback" {
+		t.Fatalf("method = %v", d["method"])
+	}
+	if _, exists := d["provider_message_id"]; exists {
+		t.Fatalf("providerless loopback review event leaked provider_message_id: %v", d)
+	}
+}
+
 // TestWorkerNilPublisherStillResolves: with no publisher wired the sweep still
 // transitions rows (emission is best-effort, never load-bearing for resolution).
 func TestWorkerNilPublisherStillResolves(t *testing.T) {

--- a/internal/hitlworker/worker.go
+++ b/internal/hitlworker/worker.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 
+	"github.com/tokencanopy/e2a/internal/eventpayload"
 	"github.com/tokencanopy/e2a/internal/identity"
 	"github.com/tokencanopy/e2a/internal/loopback"
 	"github.com/tokencanopy/e2a/internal/outbound"
@@ -49,6 +50,9 @@ type Worker struct {
 	// from internal/agent). Optional — nil leaves the sweep silent (legacy
 	// behavior). Wired via SetPublisher.
 	publisher webhookpub.Publisher
+	// outbox writes the terminal loopback email.sent/email.received pair in the
+	// same transaction as the expired hold's Sent/Inbox persistence.
+	outbox webhookpub.Outbox
 	// outboundEnq routes an approved external send onto QueueOutbound. Main always
 	// wires it; a nil value fails closed and leaves the hold pending. Self-sends use
 	// the local loopback path.
@@ -58,6 +62,11 @@ type Worker struct {
 // SetPublisher wires the webhook publisher used to emit review-resolution events
 // on TTL auto-resolution. Without it the sweep transitions rows silently.
 func (w *Worker) SetPublisher(p webhookpub.Publisher) { w.publisher = p }
+
+// SetOutbox wires the transactional outcome-event writer for providerless
+// local delivery. Production uses the same unconditional outbox as all other
+// message triggers.
+func (w *Worker) SetOutbox(o webhookpub.Outbox) { w.outbox = o }
 
 // SetOutboundEnqueuer wires the mandatory outbound send enqueuer. Two-phase
 // wiring: pass the *outboundsend.Jobs pointer; its shared River client is injected
@@ -253,9 +262,11 @@ func (w *Worker) autoApproveAsync(ctx context.Context, agent *identity.AgentIden
 }
 
 func (w *Worker) autoApproveLoopback(ctx context.Context, agent *identity.AgentIdentity, c identity.ExpirationCandidate) {
-	sent, err := w.store.ExpireApproveAndSend(ctx, c.MessageID,
+	var req outbound.SendRequest
+	sent, err := w.store.ExpireAndDeliverLocal(ctx, c.MessageID,
 		func(msg *identity.Message) (identity.SendResult, error) {
-			req, err := sendRequestFromStoredMessage(msg)
+			var err error
+			req, err = sendRequestFromStoredMessage(msg)
 			if err != nil {
 				return identity.SendResult{}, err
 			}
@@ -273,7 +284,23 @@ func (w *Worker) autoApproveLoopback(ctx context.Context, agent *identity.AgentI
 			if !loopback.IsSelfSend(req, agent.EmailAddress()) {
 				return identity.SendResult{}, errors.New("external outbound approval must be queued")
 			}
-			return loopback.DeliverInbound(ctx, w.store, agent, req, w.fromDomain)
+			providerID := loopback.ProviderID(w.fromDomain)
+			raw, err := loopback.ComposeMIME(agent, req, providerID, w.fromDomain)
+			if err != nil {
+				return identity.SendResult{}, err
+			}
+			return identity.SendResult{
+				ProviderMessageID: providerID,
+				Method:            "loopback",
+				To:                []string{agent.EmailAddress()},
+				Raw:               raw,
+			}, nil
+		},
+		func(ctx context.Context, tx pgx.Tx, outboundMsg, inboundMsg *identity.Message, result identity.SendResult) error {
+			if w.outbox == nil {
+				return nil
+			}
+			return w.publishLoopbackOutcomeEventsTx(ctx, tx, agent, outboundMsg, inboundMsg, req, result)
 		})
 	if err != nil {
 		// ErrNotPendingApproval means another worker (or a human) handled
@@ -297,9 +324,12 @@ func (w *Worker) autoApproveLoopback(ctx context.Context, agent *identity.AgentI
 		return
 	}
 	// External sends are metered by the outbound worker after provider success.
-	// Loopback is terminal here, so preserve the same post-delivery accounting.
-	if _, err := w.usage.RecordAndCheck(ctx, agent.UserID, agent.ID, agent.Domain, "outbound"); err != nil {
-		log.Printf("[hitl-worker] usage recording error: %v", err)
+	// Loopback is terminal here and persisted both a Sent and an Inbox copy, so
+	// account for both directions after the transaction commits.
+	for _, direction := range []string{"outbound", "inbound"} {
+		if _, err := w.usage.RecordAndCheck(ctx, agent.UserID, agent.ID, agent.Domain, direction); err != nil {
+			log.Printf("[hitl-worker] %s usage recording error: %v", direction, err)
+		}
 	}
 
 	log.Printf("[mail:%s] dir=outbound type=%s status=%s agent=%s to=%v auto_sent=true",
@@ -307,6 +337,67 @@ func (w *Worker) autoApproveLoopback(ctx context.Context, agent *identity.AgentI
 	// Mirror the user-driven approve: fire email.review_approved (the send
 	// already happened; this is the post-side-effect notification).
 	w.emitOutboundApproved(agent, sent)
+}
+
+func (w *Worker) publishLoopbackOutcomeEventsTx(
+	ctx context.Context,
+	tx pgx.Tx,
+	agent *identity.AgentIdentity,
+	outboundMsg, inboundMsg *identity.Message,
+	req outbound.SendRequest,
+	result identity.SendResult,
+) error {
+	sentData := eventpayload.EmailSentData{
+		MessageID:      outboundMsg.ID,
+		AgentEmail:     agent.EmailAddress(),
+		Direction:      "outbound",
+		ConversationID: outboundMsg.ConversationID,
+		Method:         "loopback",
+		From:           agent.EmailAddress(),
+		To:             []string{agent.EmailAddress()},
+		CC:             []string{},
+		BCC:            []string{},
+		Subject:        outboundMsg.Subject,
+		MessageType:    outboundMsg.Type,
+	}
+	sentEvent := webhookpub.NewEvent(webhookpub.EventEmailSent, agent.UserID, sentData)
+	sentEvent.ID = webhookpub.DeterministicEventID(outboundMsg.ID, webhookpub.EventEmailSent)
+	sentEvent.AgentID = agent.ID
+	sentEvent.ConversationID = outboundMsg.ConversationID
+	sentEvent.MessageID = outboundMsg.ID
+	if err := w.outbox.PublishTx(ctx, tx, sentEvent); err != nil {
+		return fmt.Errorf("self-send email.sent event: %w", err)
+	}
+
+	replyTo := []string{}
+	if req.ReplyTo != "" {
+		replyTo = []string{req.ReplyTo}
+	}
+	receivedData := eventpayload.EmailReceivedData{
+		MessageID:         inboundMsg.ID,
+		AgentEmail:        agent.EmailAddress(),
+		Direction:         "inbound",
+		ConversationID:    inboundMsg.ConversationID,
+		From:              agent.EmailAddress(),
+		AuthenticatedFrom: agent.EmailAddress(),
+		To:                []string{agent.EmailAddress()},
+		CC:                []string{},
+		ReplyTo:           replyTo,
+		DeliveredTo:       agent.EmailAddress(),
+		Subject:           inboundMsg.Subject,
+		AuthHeaders:       map[string]string{},
+		ReceivedAt:        inboundMsg.CreatedAt.UTC(),
+		Attachments:       eventpayload.AttachmentMetadata(result.Raw),
+	}
+	receivedEvent := webhookpub.NewEvent(webhookpub.EventEmailReceived, agent.UserID, receivedData)
+	receivedEvent.ID = webhookpub.DeterministicEventID(inboundMsg.ID, webhookpub.EventEmailReceived)
+	receivedEvent.AgentID = agent.ID
+	receivedEvent.ConversationID = inboundMsg.ConversationID
+	receivedEvent.MessageID = inboundMsg.ID
+	if err := w.outbox.PublishTx(ctx, tx, receivedEvent); err != nil {
+		return fmt.Errorf("self-send email.received event: %w", err)
+	}
+	return nil
 }
 
 func (w *Worker) autoReject(ctx context.Context, messageID, reason string) {

--- a/internal/hitlworker/worker.go
+++ b/internal/hitlworker/worker.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/mail"
 
 	"github.com/jackc/pgx/v5"
 
@@ -29,6 +30,11 @@ import (
 // instead of blocking on Sender.Send. Self-sends never use it (they loopback).
 type OutboundEnqueuer interface {
 	EnqueueSendTx(ctx context.Context, tx pgx.Tx, messageID string) (int64, error)
+}
+
+type WebSocketHub interface {
+	IsConnected(agentID string) bool
+	Send(agentID string, msg []byte) bool
 }
 
 // DefaultBatchSize caps how many rows one sweep will try to finalize. The
@@ -57,6 +63,7 @@ type Worker struct {
 	// wires it; a nil value fails closed and leaves the hold pending. Self-sends use
 	// the local loopback path.
 	outboundEnq OutboundEnqueuer
+	wsHub       WebSocketHub
 }
 
 // SetPublisher wires the webhook publisher used to emit review-resolution events
@@ -72,6 +79,7 @@ func (w *Worker) SetOutbox(o webhookpub.Outbox) { w.outbox = o }
 // wiring: pass the *outboundsend.Jobs pointer; its shared River client is injected
 // later via the jobs client's SetEnqueuer.
 func (w *Worker) SetOutboundEnqueuer(e OutboundEnqueuer) { w.outboundEnq = e }
+func (w *Worker) SetWebSocketHub(h WebSocketHub)         { w.wsHub = h }
 
 // New constructs a Worker. fromDomain is the deployment's outbound
 // from-domain (cfg.OutboundSMTP.FromDomain) — used by the self-send
@@ -263,6 +271,7 @@ func (w *Worker) autoApproveAsync(ctx context.Context, agent *identity.AgentIden
 
 func (w *Worker) autoApproveLoopback(ctx context.Context, agent *identity.AgentIdentity, c identity.ExpirationCandidate) {
 	var req outbound.SendRequest
+	var receivedEvent webhookpub.Event
 	sent, err := w.store.ExpireAndDeliverLocal(ctx, c.MessageID,
 		func(msg *identity.Message) (identity.SendResult, error) {
 			var err error
@@ -293,6 +302,7 @@ func (w *Worker) autoApproveLoopback(ctx context.Context, agent *identity.AgentI
 				ProviderMessageID: providerID,
 				Method:            "loopback",
 				To:                []string{agent.EmailAddress()},
+				Sender:            loopbackDisplayFrom(req, agent.EmailAddress()),
 				Raw:               raw,
 			}, nil
 		},
@@ -300,7 +310,9 @@ func (w *Worker) autoApproveLoopback(ctx context.Context, agent *identity.AgentI
 			if w.outbox == nil {
 				return nil
 			}
-			return w.publishLoopbackOutcomeEventsTx(ctx, tx, agent, outboundMsg, inboundMsg, req, result)
+			var eventErr error
+			receivedEvent, eventErr = w.publishLoopbackOutcomeEventsTx(ctx, tx, agent, outboundMsg, inboundMsg, req, result)
+			return eventErr
 		})
 	if err != nil {
 		// ErrNotPendingApproval means another worker (or a human) handled
@@ -323,6 +335,7 @@ func (w *Worker) autoApproveLoopback(ctx context.Context, agent *identity.AgentI
 		w.autoReject(ctx, c.MessageID, fmt.Sprintf("auto-approve send failed: %v", err))
 		return
 	}
+	w.pushLoopbackReceived(agent.ID, receivedEvent)
 	// External sends are metered by the outbound worker after provider success.
 	// Loopback is terminal here and persisted both a Sent and an Inbox copy, so
 	// account for both directions after the transaction commits.
@@ -346,7 +359,7 @@ func (w *Worker) publishLoopbackOutcomeEventsTx(
 	outboundMsg, inboundMsg *identity.Message,
 	req outbound.SendRequest,
 	result identity.SendResult,
-) error {
+) (webhookpub.Event, error) {
 	sentData := eventpayload.EmailSentData{
 		MessageID:      outboundMsg.ID,
 		AgentEmail:     agent.EmailAddress(),
@@ -366,7 +379,7 @@ func (w *Worker) publishLoopbackOutcomeEventsTx(
 	sentEvent.ConversationID = outboundMsg.ConversationID
 	sentEvent.MessageID = outboundMsg.ID
 	if err := w.outbox.PublishTx(ctx, tx, sentEvent); err != nil {
-		return fmt.Errorf("self-send email.sent event: %w", err)
+		return webhookpub.Event{}, fmt.Errorf("self-send email.sent event: %w", err)
 	}
 
 	replyTo := []string{}
@@ -378,7 +391,7 @@ func (w *Worker) publishLoopbackOutcomeEventsTx(
 		AgentEmail:        agent.EmailAddress(),
 		Direction:         "inbound",
 		ConversationID:    inboundMsg.ConversationID,
-		From:              agent.EmailAddress(),
+		From:              loopbackDisplayFrom(req, agent.EmailAddress()),
 		AuthenticatedFrom: agent.EmailAddress(),
 		To:                []string{agent.EmailAddress()},
 		CC:                []string{},
@@ -395,9 +408,29 @@ func (w *Worker) publishLoopbackOutcomeEventsTx(
 	receivedEvent.ConversationID = inboundMsg.ConversationID
 	receivedEvent.MessageID = inboundMsg.ID
 	if err := w.outbox.PublishTx(ctx, tx, receivedEvent); err != nil {
-		return fmt.Errorf("self-send email.received event: %w", err)
+		return webhookpub.Event{}, fmt.Errorf("self-send email.received event: %w", err)
 	}
-	return nil
+	return receivedEvent, nil
+}
+
+func loopbackDisplayFrom(req outbound.SendRequest, agentEmail string) string {
+	if req.ReplyTo != "" {
+		if address, err := mail.ParseAddress(req.ReplyTo); err == nil {
+			return address.Address
+		}
+		return req.ReplyTo
+	}
+	return agentEmail
+}
+
+func (w *Worker) pushLoopbackReceived(agentID string, event webhookpub.Event) {
+	if w.wsHub == nil || event.ID == "" || !w.wsHub.IsConnected(agentID) {
+		return
+	}
+	payload, err := json.Marshal(event.AsEnvelope())
+	if err == nil {
+		w.wsHub.Send(agentID, payload)
+	}
 }
 
 func (w *Worker) autoReject(ctx context.Context, messageID, reason string) {

--- a/internal/hitlworker/worker_test.go
+++ b/internal/hitlworker/worker_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/tokencanopy/e2a/internal/outbound"
 	"github.com/tokencanopy/e2a/internal/testutil"
 	"github.com/tokencanopy/e2a/internal/usage"
+	"github.com/tokencanopy/e2a/internal/webhookpub"
 )
 
 // setupWorker wires a worker + fake SMTP on a fresh test database. Returns
@@ -32,6 +33,7 @@ func setupWorker(t *testing.T) (
 	smtpRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{Host: smtpAddr.Host, Port: smtpAddr.Port})
 	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
 	w := hitlworker.New(store, sender, usage.NewUsageTracker(usage.NewStore(pool)), "test.e2a.dev")
+	w.SetOutbox(webhookpub.NewOutbox(pool, webhookpub.StaticFlag(true)))
 	w.SetOutboundEnqueuer(&fakeEnq{})
 	return w, store, pool, smtpDone
 }
@@ -221,13 +223,15 @@ func TestWorkerAutoApproveSelfSendDeliversViaLoopback(t *testing.T) {
 	}
 
 	// Outbound row → expired_approved, method=loopback, body scrubbed.
-	var status, method string
+	var status, method, deliveryStatus string
 	var providerID *string
 	var bodyText *string
+	var raw []byte
 	err = pool.QueryRow(ctx,
-		`SELECT status, method, provider_message_id, body_text FROM messages WHERE id = $1`,
+		`SELECT status, method, COALESCE(delivery_status,''), provider_message_id, body_text, raw_message
+		   FROM messages WHERE id = $1`,
 		msg.ID,
-	).Scan(&status, &method, &providerID, &bodyText)
+	).Scan(&status, &method, &deliveryStatus, &providerID, &bodyText, &raw)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -237,8 +241,14 @@ func TestWorkerAutoApproveSelfSendDeliversViaLoopback(t *testing.T) {
 	if method != "loopback" {
 		t.Errorf("method = %q, want loopback", method)
 	}
+	if deliveryStatus != "sent" {
+		t.Errorf("delivery_status = %q, want sent", deliveryStatus)
+	}
 	if providerID == nil || *providerID == "" {
 		t.Error("provider_message_id should be populated after loopback delivery")
+	}
+	if len(raw) == 0 || !strings.Contains(string(raw), "note to self body") {
+		t.Errorf("approved Sent copy must retain readable MIME; raw=%q", raw)
 	}
 	if bodyText != nil {
 		t.Errorf("body_text not scrubbed: %v", bodyText)
@@ -253,6 +263,18 @@ func TestWorkerAutoApproveSelfSendDeliversViaLoopback(t *testing.T) {
 	if inboundCount != 1 {
 		t.Errorf("inbound rows after self-send auto-approve = %d, want 1", inboundCount)
 	}
+	var outcomeEvents int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM webhook_events
+		  WHERE message_id IN (
+		    SELECT id FROM messages WHERE agent_id=$1 AND subject='self auto-approve'
+		  ) AND type IN ('email.sent','email.received')`, agent.ID,
+	).Scan(&outcomeEvents); err != nil {
+		t.Fatal(err)
+	}
+	if outcomeEvents != 2 {
+		t.Errorf("self-send outcome events=%d want 2", outcomeEvents)
+	}
 	var usageCount int
 	if err := pool.QueryRow(ctx,
 		`SELECT count(*) FROM usage_events WHERE agent_id=$1 AND direction='outbound'`,
@@ -262,6 +284,16 @@ func TestWorkerAutoApproveSelfSendDeliversViaLoopback(t *testing.T) {
 	}
 	if usageCount != 1 {
 		t.Errorf("outbound usage events after self-send auto-approve = %d, want 1", usageCount)
+	}
+	var inboundUsageCount int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM usage_events WHERE agent_id=$1 AND direction='inbound'`,
+		agent.ID,
+	).Scan(&inboundUsageCount); err != nil {
+		t.Fatal(err)
+	}
+	if inboundUsageCount != 1 {
+		t.Errorf("inbound usage events after self-send auto-approve = %d, want 1", inboundUsageCount)
 	}
 }
 

--- a/internal/hitlworker/worker_test.go
+++ b/internal/hitlworker/worker_test.go
@@ -2,6 +2,7 @@ package hitlworker_test
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
@@ -15,6 +16,14 @@ import (
 	"github.com/tokencanopy/e2a/internal/usage"
 	"github.com/tokencanopy/e2a/internal/webhookpub"
 )
+
+type workerCaptureHub struct{ payload []byte }
+
+func (h *workerCaptureHub) IsConnected(string) bool { return true }
+func (h *workerCaptureHub) Send(_ string, p []byte) bool {
+	h.payload = append([]byte(nil), p...)
+	return true
+}
 
 // setupWorker wires a worker + fake SMTP on a fresh test database. Returns
 // the worker, the shared store, the underlying pool (for backdating
@@ -206,10 +215,13 @@ func TestWorkerAutoApproveSelfSendDeliversViaLoopback(t *testing.T) {
 	ctx := context.Background()
 
 	agent := prepareAgent(t, store, "auto-approve-self", identity.HITLExpirationApprove)
+	hub := &workerCaptureHub{}
+	w.SetWebSocketHub(hub)
+	const replyTo = "Support <support@example.com>"
 	msg, err := store.CreatePendingOutboundMessage(ctx, agent.ID,
 		[]string{agent.EmailAddress()}, nil, nil,
 		"self auto-approve", "note to self body", "", nil,
-		"send", "", "", "", 60)
+		"send", "", "", replyTo, 60)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -274,6 +286,19 @@ func TestWorkerAutoApproveSelfSendDeliversViaLoopback(t *testing.T) {
 	}
 	if outcomeEvents != 2 {
 		t.Errorf("self-send outcome events=%d want 2", outcomeEvents)
+	}
+	var live struct {
+		Type string `json:"type"`
+		Data struct {
+			From              string `json:"from"`
+			AuthenticatedFrom string `json:"authenticated_from"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(hub.payload, &live); err != nil {
+		t.Fatalf("live WebSocket payload: %v (%q)", err, hub.payload)
+	}
+	if live.Type != webhookpub.EventEmailReceived || live.Data.From != "support@example.com" || live.Data.AuthenticatedFrom != agent.EmailAddress() {
+		t.Errorf("loopback live event drift: %+v", live)
 	}
 	var usageCount int
 	if err := pool.QueryRow(ctx,

--- a/internal/httpapi/hitl.go
+++ b/internal/httpapi/hitl.go
@@ -143,9 +143,13 @@ func approveResult(sent *identity.Message) (int, SendResultView) {
 		statusCode = http.StatusAccepted
 		status = "accepted"
 	}
+	providerMessageID := sent.ProviderMessageID
+	if sent.Method == "loopback" {
+		providerMessageID = ""
+	}
 	edited := sent.Edited
 	return statusCode, SendResultView{
-		Status: status, MessageID: sent.ID, ProviderMessageID: sent.ProviderMessageID,
+		Status: status, MessageID: sent.ID, ProviderMessageID: providerMessageID,
 		SentAs: sent.SentAs, Method: sent.Method, Edited: &edited,
 	}
 }

--- a/internal/httpapi/hitl_test.go
+++ b/internal/httpapi/hitl_test.go
@@ -15,6 +15,19 @@ import (
 	"github.com/tokencanopy/e2a/internal/identity"
 )
 
+func TestApproveResultLoopbackOmitsProviderMessageID(t *testing.T) {
+	_, view := approveResult(&identity.Message{
+		ID: "msg_local", Method: "loopback", ProviderMessageID: "<local@loopback.e2a.test>",
+		DeliveryStatus: "sent", SentAs: "own_address",
+	})
+	if view.MessageID != "msg_local" {
+		t.Fatalf("message_id=%q want msg_local", view.MessageID)
+	}
+	if view.ProviderMessageID != "" {
+		t.Fatalf("provider_message_id=%q want omitted for providerless loopback", view.ProviderMessageID)
+	}
+}
+
 // These exercise the account-scoped review queue approve/reject dispatch
 // (/v1/reviews/{id}/approve|reject) — the only approve/reject path since the
 // deprecated agent-path (/v1/agents/{email}/messages/{id}/approve|reject) was

--- a/internal/httpapi/outbound.go
+++ b/internal/httpapi/outbound.go
@@ -689,13 +689,14 @@ func (s *Server) deliver(ctx context.Context, user *identity.User, ag *identity.
 	if idemKey != "" && s.deps.Idempotency != nil {
 		nsKey := idemUserNS + idemKey
 		uid := user.ID
-		idemCompleteTx = func(ctx context.Context, tx pgx.Tx, messageID string) error {
-			raw, mErr := json.Marshal(acceptedView(messageID))
+		idemCompleteTx = func(ctx context.Context, tx pgx.Tx, result *agent.OutboundResult) error {
+			status, view := outboundResultView(result)
+			raw, mErr := json.Marshal(view)
 			if mErr != nil {
 				raw = []byte("{}")
 			}
 			return s.deps.Idempotency.CompleteTx(ctx, tx, uid, nsKey, idempotency.CachedResponse{
-				StatusCode: http.StatusAccepted, ContentType: "application/json", Body: raw,
+				StatusCode: status, ContentType: "application/json", Body: raw,
 			})
 		}
 	}
@@ -728,20 +729,8 @@ func (s *Server) deliver(ctx context.Context, user *identity.User, ag *identity.
 		if derr != nil {
 			return 0, SendResultView{}, envelopeFromOutboundError(derr)
 		}
-		if res.Held {
-			return http.StatusAccepted, SendResultView{Status: "pending_review", MessageID: res.PendingMessageID, ApprovalExpiresAt: res.ApprovalExpiresAt}, nil
-		}
-		// Async accept (slice C): 202 Accepted with status=accepted — the message
-		// is durably persisted and queued for async submission; the terminal
-		// outcome (sent/failed) arrives later via GET / webhooks, not this
-		// response. The body MUST match acceptedView (the idempotency cache is
-		// keyed to it) — no provider id / sent_as yet (the send hasn't happened).
-		// The cached StatusCode (idemCompleteTx, above) is likewise 202 so a
-		// replayed idempotent request returns the same 202, never a stale 200.
-		if res.Status == "accepted" {
-			return http.StatusAccepted, acceptedView(res.MessageID), nil
-		}
-		return http.StatusOK, SendResultView{Status: "sent", MessageID: res.MessageID, ProviderMessageID: res.ProviderMessageID, SentAs: res.SentAs, Method: res.Method}, nil
+		status, view := outboundResultView(res)
+		return status, view, nil
 	})
 	if err != nil {
 		return nil, err
@@ -792,6 +781,27 @@ func (s *Server) waitForSent(ctx context.Context, acceptedStatus int, accepted S
 // later via GET /v1/messages/{id} and the email.sent / email.failed webhooks.
 func acceptedView(messageID string) SendResultView {
 	return SendResultView{Status: "accepted", MessageID: messageID, Method: "smtp"}
+}
+
+// outboundResultView is shared by the live response and the same-transaction
+// idempotency completion. That keeps queue acceptance (202/accepted) distinct
+// from terminal providerless loopback delivery (200/sent) on every replay.
+func outboundResultView(res *agent.OutboundResult) (int, SendResultView) {
+	if res.Held {
+		return http.StatusAccepted, SendResultView{
+			Status: "pending_review", MessageID: res.PendingMessageID,
+			ApprovalExpiresAt: res.ApprovalExpiresAt,
+		}
+	}
+	if res.Status == "accepted" {
+		return http.StatusAccepted, acceptedView(res.MessageID)
+	}
+	return http.StatusOK, SendResultView{
+		Status: "sent", MessageID: res.MessageID,
+		ProviderMessageID: res.ProviderMessageID,
+		SentAs:            res.SentAs,
+		Method:            res.Method,
+	}
 }
 
 // literalRequest wraps an already-built SendRequest as a deliver prepare

--- a/internal/httpapi/outbound_idem_test.go
+++ b/internal/httpapi/outbound_idem_test.go
@@ -127,15 +127,15 @@ func (m *memIdem) Claim(ctx context.Context, userID, key, path, bodyHash string)
 func (m *memIdem) Complete(ctx context.Context, userID, key string, resp idempotency.CachedResponse) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if row, ok := m.rows[userID+"\x00"+key]; ok {
+	if row, ok := m.rows[userID+"\x00"+key]; ok && !row.done {
 		row.done, row.resp = true, resp
 	}
 	return nil
 }
 
-// CompleteTx mirrors Complete for the in-memory fake (tx is irrelevant here); the
-// in_progress→completed transition is the same, so a later post-hoc Complete with
-// the same body is a harmless idempotent overwrite.
+// CompleteTx mirrors Complete for the in-memory fake (tx is irrelevant here).
+// Like the real store, completion is in_progress→completed only: a later
+// post-hoc Complete cannot overwrite the response committed in the business tx.
 func (m *memIdem) CompleteTx(ctx context.Context, tx pgx.Tx, userID, key string, resp idempotency.CachedResponse) error {
 	return m.Complete(ctx, userID, key, resp)
 }
@@ -264,5 +264,55 @@ func TestSendAccepted202AndIdempotentReplay(t *testing.T) {
 	}
 	if deliveries != 1 {
 		t.Fatalf("DeliverOutbound ran %d times, want exactly 1 (retry must replay, not re-enqueue)", deliveries)
+	}
+}
+
+// A loopback send reaches its terminal local state in the request transaction.
+// Its in-transaction idempotency completion must cache that exact 200/sent
+// resource response, not the external queue's 202/accepted shape.
+func TestSelfSendIdempotentReplayPreservesSentResult(t *testing.T) {
+	deliveries := 0
+	srv := httptest.NewServer(New(Deps{
+		Authenticator: func(r *http.Request) (*identity.User, error) { return &identity.User{ID: "u_1"}, nil },
+		GetAgent: func(ctx context.Context, address string) (*identity.AgentIdentity, error) {
+			return &identity.AgentIdentity{ID: address, Email: address, UserID: "u_1", DomainVerified: true}, nil
+		},
+		Idempotency: newMemIdem(),
+		DeliverOutbound: func(ctx context.Context, u *identity.User, ag *identity.AgentIdentity, req outbound.SendRequest, mt, rt string, ref *identity.Message, ic agent.AcceptIdemCompleter) (*agent.OutboundResult, *agent.OutboundError) {
+			deliveries++
+			if err := ic(ctx, nil, &agent.OutboundResult{
+				MessageID: "msg_local", Method: "loopback", SentAs: "own_address",
+			}); err != nil {
+				t.Fatalf("complete loopback idempotency: %v", err)
+			}
+			return &agent.OutboundResult{MessageID: "msg_local", Method: "loopback", SentAs: "own_address"}, nil
+		},
+	}))
+	t.Cleanup(srv.Close)
+
+	rawBody := []byte(`{"to":["a@acme.com"],"subject":"Note","text":"hello"}`)
+	send := func() (int, map[string]any) {
+		req, _ := http.NewRequest("POST", srv.URL+"/v1/agents/a%40acme.com/messages", bytes.NewReader(rawBody))
+		req.Header.Set("Authorization", "Bearer good")
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Idempotency-Key", "local-key-1")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		var body map[string]any
+		_ = json.NewDecoder(resp.Body).Decode(&body)
+		return resp.StatusCode, body
+	}
+
+	for attempt := 1; attempt <= 2; attempt++ {
+		code, body := send()
+		if code != http.StatusOK || body["status"] != "sent" || body["message_id"] != "msg_local" || body["method"] != "loopback" {
+			t.Fatalf("attempt %d: want replayed 200 sent msg_local loopback, got %d %v", attempt, code, body)
+		}
+	}
+	if deliveries != 1 {
+		t.Fatalf("DeliverOutbound ran %d times, want exactly 1", deliveries)
 	}
 }

--- a/internal/identity/local_delivery.go
+++ b/internal/identity/local_delivery.go
@@ -1,0 +1,270 @@
+package identity
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+)
+
+// LocalDeliveryTxHook runs after both sides of a providerless local delivery
+// are visible in tx and before commit. Callers use it for durable outcome
+// events and idempotency completion so none can diverge from the Sent/Inbox
+// pair.
+type LocalDeliveryTxHook func(ctx context.Context, tx pgx.Tx, outbound, inbound *Message, result SendResult) error
+
+// ApproveAndDeliverLocal atomically resolves a pending outbound review hold
+// whose only recipient is a mailbox owned by this service. Unlike
+// ApproveAndSend, compose must be a local, side-effect-free operation: the
+// outbound update, recipient-side insert, events, and idempotency completion
+// all commit or roll back together, so the SES-oriented send_attempts journal
+// is neither needed nor appropriate.
+func (s *Store) ApproveAndDeliverLocal(
+	ctx context.Context,
+	messageID, userID string,
+	edits PendingApprovalEdit,
+	compose func(msg *Message) (SendResult, error),
+	beforeCommit LocalDeliveryTxHook,
+) (*Message, error) {
+	txCtx, cancel := context.WithTimeout(ctx, approvalTxTimeout)
+	defer cancel()
+
+	tx, err := s.pool.Begin(txCtx)
+	if err != nil {
+		return nil, err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback(txCtx)
+		}
+	}()
+
+	m, ownerUserID, err := loadPendingOutboundForLocalDelivery(txCtx, tx, messageID)
+	if err != nil {
+		return nil, err
+	}
+	if ownerUserID != userID {
+		return nil, ErrMessageNotFound
+	}
+
+	editedByReviewer := edits.Apply(m)
+	result, err := compose(m)
+	if err != nil {
+		return nil, err
+	}
+	if result.Method != "loopback" || len(result.To) != 1 || len(result.Raw) == 0 || result.ProviderMessageID == "" {
+		return nil, errors.New("identity: invalid local delivery result")
+	}
+
+	reviewerID := userID
+	inbound, err := finalizeLocalDeliveryTx(txCtx, tx, m, result, MessageStatusSent, editedByReviewer, &reviewerID)
+	if err != nil {
+		return nil, err
+	}
+
+	if beforeCommit != nil {
+		if err := beforeCommit(ctx, tx, m, inbound, result); err != nil {
+			return nil, err
+		}
+	}
+	if err := tx.Commit(txCtx); err != nil {
+		return nil, err
+	}
+	committed = true
+	return m, nil
+}
+
+// ExpireAndDeliverLocal is the TTL-worker counterpart of
+// ApproveAndDeliverLocal. It requires an expired pending row, records the
+// review_expired_approved lifecycle, and atomically creates the Inbox copy and
+// outcome events without using the external-provider send journal.
+func (s *Store) ExpireAndDeliverLocal(
+	ctx context.Context,
+	messageID string,
+	compose func(msg *Message) (SendResult, error),
+	beforeCommit LocalDeliveryTxHook,
+) (*Message, error) {
+	txCtx, cancel := context.WithTimeout(ctx, approvalTxTimeout)
+	defer cancel()
+
+	tx, err := s.pool.Begin(txCtx)
+	if err != nil {
+		return nil, err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback(txCtx)
+		}
+	}()
+
+	m, _, err := loadPendingOutboundForLocalDelivery(txCtx, tx, messageID)
+	if err != nil {
+		return nil, err
+	}
+	if m.ApprovalExpiresAt == nil || m.ApprovalExpiresAt.After(time.Now()) {
+		return nil, ErrNotPendingApproval
+	}
+
+	result, err := compose(m)
+	if err != nil {
+		return nil, err
+	}
+	if result.Method != "loopback" || len(result.To) != 1 || len(result.Raw) == 0 || result.ProviderMessageID == "" {
+		return nil, errors.New("identity: invalid local delivery result")
+	}
+
+	inbound, err := finalizeLocalDeliveryTx(txCtx, tx, m, result, MessageStatusReviewExpiredApproved, false, nil)
+	if err != nil {
+		return nil, err
+	}
+	if beforeCommit != nil {
+		if err := beforeCommit(ctx, tx, m, inbound, result); err != nil {
+			return nil, err
+		}
+	}
+	if err := tx.Commit(txCtx); err != nil {
+		return nil, err
+	}
+	committed = true
+	return m, nil
+}
+
+func finalizeLocalDeliveryTx(
+	ctx context.Context,
+	tx pgx.Tx,
+	m *Message,
+	result SendResult,
+	targetStatus string,
+	editedByReviewer bool,
+	reviewedByUserID *string,
+) (*Message, error) {
+	_, err := tx.Exec(ctx,
+		`UPDATE messages
+		    SET status                = $2,
+		        delivery_status       = 'sent',
+		        provider_message_id   = $3,
+		        method                = $4,
+		        to_recipients         = $5,
+		        cc                    = $6,
+		        bcc                   = $7,
+		        recipient             = $8,
+		        subject               = $9,
+		        edited                = $10,
+		        reviewed_at           = now(),
+		        reviewed_by_user_id   = $11,
+		        raw_message           = $12::bytea,
+		        sent_as               = 'own_address',
+		        body_text             = NULL,
+		        body_html             = NULL,
+		        attachments_json      = NULL
+		  WHERE id = $1`,
+		m.ID,
+		targetStatus,
+		result.ProviderMessageID,
+		result.Method,
+		result.To,
+		result.CC,
+		result.BCC,
+		firstOr(result.To, ""),
+		m.Subject,
+		editedByReviewer || m.Edited,
+		reviewedByUserID,
+		result.Raw,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	inbound, err := createInboundMessage(
+		ctx, tx, "", m.AgentID, m.AgentID, m.AgentID,
+		result.ProviderMessageID, m.Subject, m.ConversationID, "unread",
+		result.Raw, nil, nil, false, "", result.To, result.CC, m.ReplyTo,
+		InboundScreening{},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("local delivery inbound row: %w", err)
+	}
+
+	m.Status = targetStatus
+	m.DeliveryStatus = "sent"
+	m.ProviderMessageID = result.ProviderMessageID
+	m.Method = result.Method
+	m.ToRecipients = result.To
+	m.CC = result.CC
+	m.BCC = result.BCC
+	m.Recipient = firstOr(result.To, "")
+	m.Edited = editedByReviewer || m.Edited
+	m.RawMessage = result.Raw
+	m.SentAs = "own_address"
+	m.BodyText = ""
+	m.BodyHTML = ""
+	m.AttachmentsJSON = nil
+	now := time.Now()
+	m.ReviewedAt = &now
+	m.ReviewedByUserID = reviewedByUserID
+	return inbound, nil
+}
+
+func loadPendingOutboundForLocalDelivery(ctx context.Context, tx pgx.Tx, messageID string) (*Message, string, error) {
+	var (
+		m                  Message
+		ownerUserID        string
+		bodyText, bodyHTML *string
+		attachments        []byte
+		method, msgType    *string
+		approvalExpires    *time.Time
+	)
+	err := tx.QueryRow(ctx,
+		`SELECT m.id, m.agent_id, m.direction, m.sender, m.recipient, m.subject,
+		        m.email_message_id, m.method, m.message_type,
+		        m.conversation_id, m.created_at, m.expires_at,
+		        m.to_recipients, m.cc, m.bcc, m.reply_to,
+		        m.status, m.approval_expires_at, m.edited,
+		        m.body_text, m.body_html, m.attachments_json,
+		        a.user_id
+		   FROM messages m
+		   JOIN agent_identities a ON a.id = m.agent_id
+		  WHERE m.id = $1 AND m.direction = 'outbound'
+		    AND a.deleted_at IS NULL
+		  FOR NO KEY UPDATE OF m`,
+		messageID,
+	).Scan(
+		&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.Subject,
+		&m.EmailMessageID, &method, &msgType,
+		&m.ConversationID, &m.CreatedAt, &m.ExpiresAt,
+		&m.ToRecipients, &m.CC, &m.BCC, &m.ReplyTo,
+		&m.Status, &approvalExpires, &m.Edited,
+		&bodyText, &bodyHTML, &attachments,
+		&ownerUserID,
+	)
+	if err != nil {
+		return nil, "", ErrMessageNotFound
+	}
+	if m.Status != MessageStatusPendingReview {
+		return nil, "", ErrNotPendingApproval
+	}
+	if method != nil {
+		m.Method = *method
+	}
+	if msgType != nil {
+		m.Type = *msgType
+	}
+	if approvalExpires != nil {
+		m.ApprovalExpiresAt = approvalExpires
+	}
+	if bodyText != nil {
+		m.BodyText = *bodyText
+	}
+	if bodyHTML != nil {
+		m.BodyHTML = *bodyHTML
+	}
+	if len(attachments) > 0 {
+		m.AttachmentsJSON = json.RawMessage(attachments)
+	}
+	return &m, ownerUserID, nil
+}

--- a/internal/identity/local_delivery.go
+++ b/internal/identity/local_delivery.go
@@ -16,6 +16,18 @@ import (
 // pair.
 type LocalDeliveryTxHook func(ctx context.Context, tx pgx.Tx, outbound, inbound *Message, result SendResult) error
 
+// GetEventEnvelope returns the exact durable event envelope for a message.
+// WebSocket reconnect drain uses this instead of rebuilding an event whose
+// timestamp or attachment metadata could differ under the same event id.
+func (s *Store) GetEventEnvelope(ctx context.Context, messageID, eventType string) ([]byte, error) {
+	var envelope []byte
+	err := s.pool.QueryRow(ctx,
+		`SELECT envelope FROM webhook_events WHERE message_id=$1 AND type=$2`,
+		messageID, eventType,
+	).Scan(&envelope)
+	return envelope, err
+}
+
 // ApproveAndDeliverLocal atomically resolves a pending outbound review hold
 // whose only recipient is a mailbox owned by this service. Unlike
 // ApproveAndSend, compose must be a local, side-effect-free operation: the
@@ -56,7 +68,7 @@ func (s *Store) ApproveAndDeliverLocal(
 	if err != nil {
 		return nil, err
 	}
-	if result.Method != "loopback" || len(result.To) != 1 || len(result.Raw) == 0 || result.ProviderMessageID == "" {
+	if result.Method != "loopback" || len(result.To) != 1 || len(result.Raw) == 0 || result.ProviderMessageID == "" || result.Sender == "" {
 		return nil, errors.New("identity: invalid local delivery result")
 	}
 
@@ -102,19 +114,16 @@ func (s *Store) ExpireAndDeliverLocal(
 		}
 	}()
 
-	m, _, err := loadPendingOutboundForLocalDelivery(txCtx, tx, messageID)
+	m, _, err := loadExpiredPendingOutboundForLocalDelivery(txCtx, tx, messageID)
 	if err != nil {
 		return nil, err
-	}
-	if m.ApprovalExpiresAt == nil || m.ApprovalExpiresAt.After(time.Now()) {
-		return nil, ErrNotPendingApproval
 	}
 
 	result, err := compose(m)
 	if err != nil {
 		return nil, err
 	}
-	if result.Method != "loopback" || len(result.To) != 1 || len(result.Raw) == 0 || result.ProviderMessageID == "" {
+	if result.Method != "loopback" || len(result.To) != 1 || len(result.Raw) == 0 || result.ProviderMessageID == "" || result.Sender == "" {
 		return nil, errors.New("identity: invalid local delivery result")
 	}
 
@@ -181,7 +190,7 @@ func finalizeLocalDeliveryTx(
 	}
 
 	inbound, err := createInboundMessage(
-		ctx, tx, "", m.AgentID, m.AgentID, m.AgentID,
+		ctx, tx, "", m.AgentID, result.Sender, m.AgentID,
 		result.ProviderMessageID, m.Subject, m.ConversationID, "unread",
 		result.Raw, nil, nil, false, "", result.To, result.CC, m.ReplyTo,
 		InboundScreening{},
@@ -189,6 +198,10 @@ func finalizeLocalDeliveryTx(
 	if err != nil {
 		return nil, fmt.Errorf("local delivery inbound row: %w", err)
 	}
+	if _, err := tx.Exec(ctx, `UPDATE messages SET method='loopback' WHERE id=$1`, inbound.ID); err != nil {
+		return nil, fmt.Errorf("local delivery inbound method: %w", err)
+	}
+	inbound.Method = "loopback"
 
 	m.Status = targetStatus
 	m.DeliveryStatus = "sent"
@@ -210,7 +223,30 @@ func finalizeLocalDeliveryTx(
 	return inbound, nil
 }
 
+func loadExpiredPendingOutboundForLocalDelivery(ctx context.Context, tx pgx.Tx, messageID string) (*Message, string, error) {
+	return scanPendingOutboundForLocalDelivery(tx.QueryRow(ctx, localDeliverySelect+
+		` AND m.approval_expires_at < now()
+		  FOR NO KEY UPDATE OF m SKIP LOCKED`, messageID), ErrNotPendingApproval)
+}
+
 func loadPendingOutboundForLocalDelivery(ctx context.Context, tx pgx.Tx, messageID string) (*Message, string, error) {
+	return scanPendingOutboundForLocalDelivery(tx.QueryRow(ctx, localDeliverySelect+
+		` FOR NO KEY UPDATE OF m`, messageID), ErrMessageNotFound)
+}
+
+const localDeliverySelect = `SELECT m.id, m.agent_id, m.direction, m.sender, m.recipient, m.subject,
+		m.email_message_id, m.method, m.message_type,
+		m.conversation_id, m.created_at, m.expires_at,
+		m.to_recipients, m.cc, m.bcc, m.reply_to,
+		m.status, m.approval_expires_at, m.edited,
+		m.body_text, m.body_html, m.attachments_json,
+		a.user_id
+	 FROM messages m
+	 JOIN agent_identities a ON a.id = m.agent_id
+	WHERE m.id = $1 AND m.direction = 'outbound'
+	  AND a.deleted_at IS NULL`
+
+func scanPendingOutboundForLocalDelivery(row pgx.Row, noRowError error) (*Message, string, error) {
 	var (
 		m                  Message
 		ownerUserID        string
@@ -219,21 +255,7 @@ func loadPendingOutboundForLocalDelivery(ctx context.Context, tx pgx.Tx, message
 		method, msgType    *string
 		approvalExpires    *time.Time
 	)
-	err := tx.QueryRow(ctx,
-		`SELECT m.id, m.agent_id, m.direction, m.sender, m.recipient, m.subject,
-		        m.email_message_id, m.method, m.message_type,
-		        m.conversation_id, m.created_at, m.expires_at,
-		        m.to_recipients, m.cc, m.bcc, m.reply_to,
-		        m.status, m.approval_expires_at, m.edited,
-		        m.body_text, m.body_html, m.attachments_json,
-		        a.user_id
-		   FROM messages m
-		   JOIN agent_identities a ON a.id = m.agent_id
-		  WHERE m.id = $1 AND m.direction = 'outbound'
-		    AND a.deleted_at IS NULL
-		  FOR NO KEY UPDATE OF m`,
-		messageID,
-	).Scan(
+	err := row.Scan(
 		&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.Subject,
 		&m.EmailMessageID, &method, &msgType,
 		&m.ConversationID, &m.CreatedAt, &m.ExpiresAt,
@@ -243,7 +265,10 @@ func loadPendingOutboundForLocalDelivery(ctx context.Context, tx pgx.Tx, message
 		&ownerUserID,
 	)
 	if err != nil {
-		return nil, "", ErrMessageNotFound
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, "", noRowError
+		}
+		return nil, "", err
 	}
 	if m.Status != MessageStatusPendingReview {
 		return nil, "", ErrNotPendingApproval

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -2342,9 +2342,13 @@ type SendResult struct {
 	To                []string
 	CC                []string
 	BCC               []string
+	// Sender is the inbound-facing From value for providerless local delivery.
+	// It prefers an explicit Reply-To while authenticated identity remains the
+	// owning agent address in the event envelope.
+	Sender string
 	// Raw is the composed MIME that was sent, retained as the message's
-	// "Sent folder" copy (raw_message). Empty for loopback self-sends (the body
-	// lives on the inbound twin) and on already-sent replay.
+	// "Sent folder" copy (raw_message). Local loopback retains the same bytes on
+	// both Sent and Inbox rows; it is empty only on already-sent replay.
 	Raw []byte
 }
 
@@ -3219,7 +3223,7 @@ func (s *Store) GetMessagesByAgent(ctx context.Context, f MessageListFilter) ([]
 	var query string
 	var args []interface{}
 
-	baseSelect := `SELECT m.id, m.agent_id, m.direction, m.sender, m.recipient, m.to_recipients, m.cc, m.reply_to, m.subject, m.email_message_id, m.conversation_id, COALESCE(m.inbox_status, ''), COALESCE(m.status, ''), COALESCE(wd.status, ''), COALESCE(wd.last_error, ''), COALESCE(octet_length(m.raw_message), 0), m.created_at, m.deleted_at, m.labels, COALESCE(m.delivery_status, ''), COALESCE(m.delivery_detail, ''), COALESCE(m.sent_as, ''), m.auth_verdict, COALESCE(m.flagged, false), COALESCE(m.flag_reason, ''), m.auth_headers
+	baseSelect := `SELECT m.id, m.agent_id, m.direction, m.sender, m.recipient, m.to_recipients, m.cc, m.reply_to, m.subject, m.email_message_id, COALESCE(m.method, ''), m.conversation_id, COALESCE(m.inbox_status, ''), COALESCE(m.status, ''), COALESCE(wd.status, ''), COALESCE(wd.last_error, ''), COALESCE(octet_length(m.raw_message), 0), m.created_at, m.deleted_at, m.labels, COALESCE(m.delivery_status, ''), COALESCE(m.delivery_detail, ''), COALESCE(m.sent_as, ''), m.auth_verdict, COALESCE(m.flagged, false), COALESCE(m.flag_reason, ''), m.auth_headers
 		 FROM messages m
 		 LEFT JOIN webhook_deliveries wd ON wd.message_id = m.id
 		 WHERE m.agent_id = $1`
@@ -3347,7 +3351,7 @@ func (s *Store) GetMessagesByAgent(ctx context.Context, f MessageListFilter) ([]
 		var authHeadersJSON []byte
 		if err := rows.Scan(
 			&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.Recipient, &m.ToRecipients, &m.CC, &m.ReplyTo,
-			&m.Subject, &m.EmailMessageID, &m.ConversationID,
+			&m.Subject, &m.EmailMessageID, &m.Method, &m.ConversationID,
 			&m.InboxStatus, &m.Status, &m.WebhookStatus, &m.WebhookError, &m.SizeBytes,
 			&m.CreatedAt, &m.DeletedAt, &m.Labels,
 			&outboundDeliveryStatus, &m.DeliveryDetail, &m.SentAs, &authVerdict, &m.Flagged, &m.FlagReason,

--- a/internal/loopback/loopback.go
+++ b/internal/loopback/loopback.go
@@ -167,5 +167,6 @@ func ComposeMIME(agent *identity.AgentIdentity, req outbound.SendRequest, provid
 		email,
 		time.Now().UTC().Format(time.RFC1123Z),
 	)
-	return append([]byte(received), msg...), nil
+	messageID := fmt.Sprintf("Message-ID: %s\r\n", providerID)
+	return append([]byte(received+messageID), msg...), nil
 }

--- a/internal/loopback/loopback.go
+++ b/internal/loopback/loopback.go
@@ -4,22 +4,9 @@
 // roundtrip through SES + MX + the local SMTP receiver is wasted work
 // when the destination is local anyway.
 //
-// Two callers, two entry points:
-//
-//   - internal/agent reaches us via DeliverInbound from the HITL
-//     approval finalizer (selfSendApprovalDelivery) and from its own
-//     fast path (performSelfSend). The fast path writes the outbound
-//     row itself; the approval path lets ApproveAndSend update the
-//     pre-existing held outbound row.
-//   - internal/hitlworker reaches us via DeliverInbound from the TTL
-//     auto-approve callback. Same shape as the user-driven approval
-//     path — the held outbound row already exists; we only write the
-//     inbound counterpart.
-//
-// Living here (rather than in internal/agent) lets the worker import us
-// without dragging the entire agent package's surface in. Mirrors the
-// existing duplication strategy for sendRequestFromStoredMessage but
-// avoids it for the larger MIME-composition body.
+// The package owns self-recipient detection and byte-identical MIME
+// composition. Persistence lives in the identity store so Sent/Inbox rows,
+// idempotency, and outcome events can share one database transaction.
 package loopback
 
 import (
@@ -28,8 +15,6 @@ import (
 	"fmt"
 	"strings"
 	"time"
-
-	"context"
 
 	"github.com/tokencanopy/e2a/internal/identity"
 	"github.com/tokencanopy/e2a/internal/outbound"
@@ -183,75 +168,4 @@ func ComposeMIME(agent *identity.AgentIdentity, req outbound.SendRequest, provid
 		time.Now().UTC().Format(time.RFC1123Z),
 	)
 	return append([]byte(received), msg...), nil
-}
-
-// InboundWriter is the subset of *identity.Store DeliverInbound uses.
-// Lets tests swap in fakes; production code passes the real store.
-type InboundWriter interface {
-	CreateInboundMessage(ctx context.Context, id, agentID, senderEmail, recipient, emailMessageID, subject, conversationID, deliveryStatus string, rawMessage []byte, authHeaders map[string]string, authVerdict []byte, flagged bool, flagReason string, toRecipients, cc, replyTo []string, screening identity.InboundScreening) (*identity.Message, error)
-}
-
-// DeliverInbound writes the recipient-side row for a loopback self-send
-// and returns an identity.SendResult shaped for the ApproveAndSend send
-// callback (or the worker's ExpireApproveAndSend send callback).
-//
-// Does NOT write the outbound row — the caller is one of:
-//   - HITL approval: the held outbound row already exists;
-//     ApproveAndSend's UPDATE flips it to status=sent + method=loopback
-//     using the result's columns.
-//   - hitlworker TTL auto-approve: same shape via ExpireApproveAndSend.
-//
-// The non-HITL fast path in internal/agent (performSelfSend) calls
-// CreateOutboundMessage itself before calling DeliverInbound; that
-// path has no held row to update.
-//
-// Notable choices documented because they diverge from a pure-SMTP
-// send:
-//   - Webhook + WebSocket delivery are intentionally NOT fired on the
-//     inbound row. Cloud-mode agents whose webhook handler triggered
-//     the send would otherwise re-enter their own code and loop.
-//     Local-mode agents pick up the row via the next list_messages
-//     poll, which IS the intended UX.
-//   - auth_headers stays NULL: no DKIM/SPF was actually evaluated
-//     because nothing arrived over the wire. The operator-facing signal
-//     "this row didn't come from external mail" is preserved by that
-//     null column.
-//   - Domain verification + rate limit are enforced upstream by the
-//     caller. Loopback isn't a backdoor for those gates.
-func DeliverInbound(ctx context.Context, store InboundWriter, agent *identity.AgentIdentity, req outbound.SendRequest, fromDomain string) (identity.SendResult, error) {
-	providerID := ProviderID(fromDomain)
-	email := agent.EmailAddress()
-
-	rawMessage, err := ComposeMIME(agent, req, providerID, fromDomain)
-	if err != nil {
-		return identity.SendResult{}, fmt.Errorf("loopback compose: %w", err)
-	}
-	if _, err := store.CreateInboundMessage(
-		ctx,
-		"", // generate fresh id; mirrors the SMTP path which never reuses outbound ids
-		agent.ID,
-		email, // sender
-		email, // recipient (per-delivery target)
-		providerID,
-		req.Subject,
-		req.ConversationID,
-		"unread",
-		rawMessage,
-		nil,   // no DKIM/SPF auth headers on a synthetic loopback
-		nil,   // no auth verdict on a synthetic loopback
-		false, // not flagged: loopback self-send bypasses the inbound policy gate
-		"",    // no flag reason
-		[]string{email},
-		nil,                         // cc
-		nil,                         // reply_to
-		identity.InboundScreening{}, // loopback self-send: not externally screened
-	); err != nil {
-		return identity.SendResult{}, fmt.Errorf("loopback inbound row: %w", err)
-	}
-
-	return identity.SendResult{
-		ProviderMessageID: providerID,
-		Method:            "loopback",
-		To:                []string{email},
-	}, nil
 }

--- a/internal/loopback/loopback_test.go
+++ b/internal/loopback/loopback_test.go
@@ -62,3 +62,19 @@ func TestComposeMIMEReplyToOverride(t *testing.T) {
 		t.Errorf("plain self-send Reply-To = %q, want empty", got)
 	}
 }
+
+func TestComposeMIMEIncludesSyntheticMessageID(t *testing.T) {
+	agent := &identity.AgentIdentity{ID: "bot@example.com", Domain: "example.com"}
+	providerID := ProviderID("example.com")
+	raw, err := ComposeMIME(agent, outbound.SendRequest{To: []string{agent.ID}, Subject: "hi", Body: "note"}, providerID, "example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	m, err := mail.ReadMessage(strings.NewReader(string(raw)))
+	if err != nil {
+		t.Fatalf("parse loopback MIME: %v", err)
+	}
+	if got := m.Header.Get("Message-ID"); got != providerID {
+		t.Fatalf("Message-ID = %q, want %q", got, providerID)
+	}
+}

--- a/internal/testutil/contract_server.go
+++ b/internal/testutil/contract_server.go
@@ -68,6 +68,7 @@ func StartContractServer(ctx context.Context, dbURL string) (*ContractServer, er
 	api.RegisterRoutes(router)
 
 	wsHub := ws.NewHub()
+	api.SetWebSocketHub(wsHub)
 	wsHandler := ws.NewHandler(wsHub, store)
 
 	// Wrap the legacy mux with the typed /v1 surface using the SAME builder

--- a/internal/testutil/server.go
+++ b/internal/testutil/server.go
@@ -192,6 +192,7 @@ func TestServer(t *testing.T, pool *pgxpool.Pool, opts ...TestServerOption) *E2A
 
 	// WebSocket live-tail transport — wired as a /v1 route via WSHandle below.
 	wsHub := ws.NewHub()
+	api.SetWebSocketHub(wsHub)
 	wsHandler := ws.NewHandler(wsHub, store)
 
 	// Wrap the legacy mux with the typed /v1 surface (the same apiserver

--- a/internal/ws/handler.go
+++ b/internal/ws/handler.go
@@ -26,6 +26,10 @@ type HandlerStore interface {
 	GetMessagesByAgent(ctx context.Context, f identity.MessageListFilter) ([]identity.Message, error)
 }
 
+type eventEnvelopeStore interface {
+	GetEventEnvelope(ctx context.Context, messageID, eventType string) ([]byte, error)
+}
+
 // Handler upgrades HTTP connections to WebSocket. Open to any agent the
 // caller owns — the legacy local-mode gate was removed (migration 029).
 type Handler struct {
@@ -178,8 +182,10 @@ func (h *Handler) drainUnread(agent *identity.AgentIdentity) {
 	}
 
 	for _, msg := range messages {
-		notification := BuildNotification(&msg)
-		h.hub.Send(agent.ID, notification)
+		notification := NotificationForMessage(ctx, h.store, &msg)
+		if len(notification) > 0 {
+			h.hub.Send(agent.ID, notification)
+		}
 	}
 
 	if len(messages) > 0 {
@@ -187,14 +193,29 @@ func (h *Handler) drainUnread(agent *identity.AgentIdentity) {
 	}
 }
 
-// BuildNotification renders the WS frame for one inbound message: the SAME
-// versioned event envelope the webhook channel delivers —
+// NotificationForMessage prefers the immutable envelope persisted by the
+// transactional outbox. The fallback preserves compatibility for test/legacy
+// stores without the outbox lookup seam.
+func NotificationForMessage(ctx context.Context, store HandlerStore, msg *identity.Message) []byte {
+	if events, ok := store.(eventEnvelopeStore); ok {
+		if envelope, err := events.GetEventEnvelope(ctx, msg.ID, webhookpub.EventEmailReceived); err == nil && len(envelope) > 0 {
+			return envelope
+		}
+		// A production store promises exact cross-channel envelopes. If its
+		// durable event is unavailable, fail closed instead of inventing a
+		// different payload under the deterministic event id.
+		return nil
+	}
+	return BuildNotification(msg)
+}
+
+// BuildNotification reconstructs the same versioned envelope SHAPE for stores
+// that cannot return the durable event —
 // {type:"email.received", id, schema_version, created_at, data} with the
 // canonical typed eventpayload.EmailReceivedData — so a consumer can share one
-// parser across both channels. The event id is the same deterministic
+// parser across both channels. The event id uses the same deterministic
 // derivation the outbox uses (sha256(message_id|type)), so a subscriber that
-// receives the message on both channels can dedup on it, and the drain path
-// re-emits a byte-stable id across reconnects.
+// receives the message on both channels can dedup on it.
 //
 // This drain-path rebuild populates what the message ROW provides, including
 // the persisted signed auth attestation: auth_headers is stored at intake
@@ -206,11 +227,9 @@ func (h *Handler) drainUnread(agent *identity.AgentIdentity) {
 // deterministic event id with the webhook delivery, so a mistrusted drain
 // frame would permanently mistrust a verified message).
 //
-// The only genuine drain divergences from the live event are:
-//   - attachments: raw_message is not selected by the drain's list query →
-//     omitted (fetch the message for attachment metadata + bytes).
-//   - timestamps: created_at / received_at are the message ROW's created_at,
-//     not the original event's publish time.
+// Production reconnect drain uses NotificationForMessage and therefore reuses
+// the exact persisted envelope. This builder remains the compatibility fallback
+// for stores that do not expose durable events.
 //
 // The live relay path (internal/relay) marshals the actual outbox event: the
 // same event envelope — identical fields and event id — as the webhook
@@ -225,6 +244,13 @@ func BuildNotification(msg *identity.Message) []byte {
 	if to == nil {
 		to = []string{}
 	}
+	authenticatedFrom := authHeaders[headers.HeaderSender]
+	// Providerless local delivery has no signed transport attestation because it
+	// never crosses SMTP. Its server-owned method marker records that the
+	// authenticated agent sent to its own mailbox.
+	if authenticatedFrom == "" && msg.Sender != "" && msg.Method == "loopback" {
+		authenticatedFrom = msg.AgentID
+	}
 	ev := webhookpub.Event{
 		ID:        webhookpub.DeterministicEventID(msg.ID, webhookpub.EventEmailReceived),
 		Type:      webhookpub.EventEmailReceived,
@@ -235,7 +261,7 @@ func BuildNotification(msg *identity.Message) []byte {
 			Direction:         "inbound",
 			ConversationID:    msg.ConversationID,
 			From:              msg.Sender,
-			AuthenticatedFrom: authHeaders[headers.HeaderSender],
+			AuthenticatedFrom: authenticatedFrom,
 			To:                to,
 			CC:                msg.CC,
 			ReplyTo:           msg.ReplyTo,

--- a/sdks/python/src/e2a/v1/generated/models/email_sent_data.py
+++ b/sdks/python/src/e2a/v1/generated/models/email_sent_data.py
@@ -34,8 +34,8 @@ class EmailSentData(BaseModel):
     from_: StrictStr = Field(alias="from")
     message_id: StrictStr
     message_type: StrictStr = Field(description="Send kind. Open set; tolerate unknown values. Known values: send, reply, forward.")
-    method: StrictStr = Field(description="Transport used for the send. Open set; tolerate unknown values. Known values: smtp.")
-    provider_message_id: StrictStr
+    method: StrictStr = Field(description="Transport used for the send. Open set; tolerate unknown values. Known values: smtp, loopback.")
+    provider_message_id: Optional[StrictStr] = None
     subject: StrictStr
     to: List[StrictStr]
     additional_properties: Dict[str, Any] = {}

--- a/sdks/python/src/e2a/v1/webhook_signature.py
+++ b/sdks/python/src/e2a/v1/webhook_signature.py
@@ -176,10 +176,9 @@ EmailSentData = TypedDict(
         "agent_email": str,
         "direction": str,  # always "outbound"
         "conversation_id": NotRequired[str],
-        # Provider-assigned (SES) id — the correlation key for the async
-        # delivered/bounced/complained feedback events.
-        "provider_message_id": str,
-        "method": str,  # open set; known values: smtp
+        # Provider-assigned (SES) id — absent for providerless local loopback.
+        "provider_message_id": NotRequired[str],
+        "method": str,  # open set; known values: smtp, loopback
         "from": str,
         "to": List[str],
         "cc": NotRequired[List[str]],
@@ -189,8 +188,8 @@ EmailSentData = TypedDict(
     },
 )
 EmailSentData.__doc__ = (
-    "``data`` of an ``email.sent`` event — the provider accepted an outbound "
-    "send. Identical from the sync and async send paths."
+    "``data`` of an ``email.sent`` event — an outbound send reached its sent "
+    "state through provider acceptance or atomic local loopback delivery."
 )
 
 EmailFailedData = TypedDict(

--- a/sdks/python/tests/typecheck_event_envelope.py
+++ b/sdks/python/tests/typecheck_event_envelope.py
@@ -1,6 +1,7 @@
 """Static contract checks for the public event-envelope constructors."""
 
 from e2a.v1 import WebhookEvent, WSEvent
+from e2a.v1.webhook_signature import EmailSentData
 
 
 webhook_event = WebhookEvent(
@@ -17,6 +18,17 @@ ws_event = WSEvent(
     created_at="2026-07-01T10:30:00Z",
     data={},
 )
+
+loopback_sent_data: EmailSentData = {
+    "message_id": "msg_local",
+    "agent_email": "bot@example.com",
+    "direction": "outbound",
+    "method": "loopback",
+    "from": "bot@example.com",
+    "to": ["bot@example.com"],
+    "subject": "Note to self",
+    "message_type": "send",
+}
 
 # These ignores are intentional assertions: warn_unused_ignores makes mypy
 # fail if the core fields ever become optional again.

--- a/sdks/typescript/src/v1/generated/models/EmailSentData.ts
+++ b/sdks/typescript/src/v1/generated/models/EmailSentData.ts
@@ -28,10 +28,10 @@ export class EmailSentData {
     */
     'messageType': string;
     /**
-    * Transport used for the send. Open set; tolerate unknown values. Known values: smtp.
+    * Transport used for the send. Open set; tolerate unknown values. Known values: smtp, loopback.
     */
     'method': string;
-    'providerMessageId': string;
+    'providerMessageId'?: string;
     'subject': string;
     'to': Array<string>;
 

--- a/sdks/typescript/src/v1/webhook-signature.ts
+++ b/sdks/typescript/src/v1/webhook-signature.ts
@@ -139,8 +139,8 @@ export interface EmailReceivedData {
   attachments?: AttachmentMeta[];
 }
 
-/** Typed payload of an `email.sent` event — an outbound send was accepted by
- *  the provider. Identical from the sync and async send paths. */
+/** Typed payload of an `email.sent` event — an outbound send reached its sent
+ *  state through provider acceptance or atomic local loopback delivery. */
 export interface EmailSentData {
   message_id: string;
   agent_email: string;
@@ -148,9 +148,10 @@ export interface EmailSentData {
   direction: string;
   conversation_id?: string;
   /** Provider-assigned (SES) id — the correlation key for the async
-   *  delivered/bounced/complained feedback events. */
-  provider_message_id: string;
-  /** Open set; tolerate unknown values. Known values: smtp. */
+   *  delivered/bounced/complained feedback events. Absent for providerless
+   *  local loopback delivery. */
+  provider_message_id?: string;
+  /** Open set; tolerate unknown values. Known values: smtp, loopback. */
   method: string;
   from: string;
   to: string[];

--- a/sdks/typescript/test/v1/client.types.ts
+++ b/sdks/typescript/test/v1/client.types.ts
@@ -1,7 +1,7 @@
 import type { FieldError } from "../../src/v1/generated/models/FieldError.js";
 import type { ErrorBody } from "../../src/v1/generated/models/ErrorBody.js";
 import type { ListMessagesParams } from "../../src/v1/index.js";
-import type { WebhookEvent } from "../../src/v1/webhook-signature.js";
+import type { EmailSentData, WebhookEvent } from "../../src/v1/webhook-signature.js";
 import type { WSEvent } from "../../src/v1/ws.js";
 
 const senderFilter: ListMessagesParams = { from_: "alice@example.com" };
@@ -40,6 +40,18 @@ const eventEnvelope: WebhookEvent = {
 };
 const wsEnvelope: WSEvent = eventEnvelope;
 void wsEnvelope;
+
+const loopbackSentData: EmailSentData = {
+  message_id: "msg_local",
+  agent_email: "bot@example.com",
+  direction: "outbound",
+  method: "loopback",
+  from: "bot@example.com",
+  to: ["bot@example.com"],
+  subject: "Note to self",
+  message_type: "send",
+};
+void loopbackSentData;
 
 // @ts-expect-error all five core envelope fields are required.
 const incompleteEventEnvelope: WebhookEvent = { type: "email.received", data: {} };


### PR DESCRIPTION
## Summary
- make direct, human-approved, magic-link, and TTL-approved self-sends persist Sent and Inbox rows atomically
- publish transactional email.sent/email.received events, preserve exact live/webhook/reconnect WebSocket envelope parity, and normalize Reply-To like SMTP intake
- retain full MIME with a synthetic Message-ID, provide terminal idempotent responses, omit provider-only IDs, meter both directions, and restore safe TTL row claiming
- update generated SDK contracts for providerless sent events and loopback transport

## Verification
- affected Go suites pass on a fresh throwaway Postgres database
- focused self-send/HITL/WebSocket/identity list tests pass
- make spec-check
- make openapi-compat-check (no breaking changes)
- make generate-sdk-check
- TypeScript SDK build + 173 unit/type tests
- Python webhook payload tests (19) + event-envelope mypy check
- independent code review: approved

## Note
A broad internal/identity package run against a reused shared test DB hit pre-existing migration-test interference; the targeted identity store tests pass on the isolated database.