### PR TITLE
fix(api): make createApiKey idempotent via Idempotency-Key

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3653,6 +3653,13 @@ paths:
     post:
       description: Mint a new API key; the plaintext key is returned once. scope=account is workspace admin (agent/domain/key management); scope=agent binds the key to one inbox so it can act only as that agent. Account scope only.
       operationId: createApiKey
+      parameters:
+        - description: "Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request's response — the SAME key — instead of minting a second live credential. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). Dedup is best-effort: under idempotency-store degradation or a mid-request crash the guarantee degrades to at-least-once — a keyed retry may mint a new key rather than replay."
+          in: header
+          name: Idempotency-Key
+          schema:
+            description: "Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request's response — the SAME key — instead of minting a second live credential. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). Dedup is best-effort: under idempotency-store degradation or a mid-request crash the guarantee degrades to at-least-once — a keyed retry may mint a new key rather than replay."
+            type: string
       requestBody:
         content:
           application/json:

--- a/internal/httpapi/apikeys.go
+++ b/internal/httpapi/apikeys.go
@@ -59,7 +59,11 @@ type CreateAPIKeyRequest struct {
 	Agent     string `json:"agent_email,omitempty" doc:"Inbox email to bind the key to; required when scope=agent."`
 }
 
-type createAPIKeyInput struct{ Body CreateAPIKeyRequest }
+type createAPIKeyInput struct {
+	RawBody        []byte
+	IdempotencyKey string `header:"Idempotency-Key" doc:"Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request's response — the SAME key — instead of minting a second live credential. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). Dedup is best-effort: under idempotency-store degradation or a mid-request crash the guarantee degrades to at-least-once — a keyed retry may mint a new key rather than replay."`
+	Body           CreateAPIKeyRequest
+}
 type createAPIKeyOutput struct{ Body CreateAPIKeyResponse }
 
 type deleteAPIKeyInput struct {
@@ -177,14 +181,27 @@ func (s *Server) handleCreateAPIKey(ctx context.Context, in *createAPIKeyInput) 
 		agentID = ag.ID
 	}
 
-	key, err := s.deps.CreateScopedAPIKey(ctx, user.ID, in.Body.Name, scope, agentID, expiresAt)
+	// Wrap the mint in the keyed-idempotency guard (same machinery as
+	// send/reply/rotate-secret): a network-retried create carrying the same
+	// Idempotency-Key + byte-identical body replays the first response — the
+	// SAME key — instead of silently minting a SECOND live credential. Without a
+	// key the mint runs unguarded (idempotency is opt-in). See issue #493.
+	_, body, err := runIdempotent(s, ctx, user.ID, in.IdempotencyKey,
+		"/v1/account/api-keys", in.RawBody,
+		func() (int, CreateAPIKeyResponse, error) {
+			key, kerr := s.deps.CreateScopedAPIKey(ctx, user.ID, in.Body.Name, scope, agentID, expiresAt)
+			if kerr != nil {
+				return 0, CreateAPIKeyResponse{}, NewError(http.StatusInternalServerError, "internal_error", "failed to create API key")
+			}
+			return http.StatusCreated, CreateAPIKeyResponse{
+				APIKeyView: apiKeyView(*key),
+				Key:        key.PlaintextKey,
+			}, nil
+		})
 	if err != nil {
-		return nil, NewError(http.StatusInternalServerError, "internal_error", "failed to create API key")
+		return nil, err
 	}
-	return &createAPIKeyOutput{Body: CreateAPIKeyResponse{
-		APIKeyView: apiKeyView(*key),
-		Key:        key.PlaintextKey,
-	}}, nil
+	return &createAPIKeyOutput{Body: body}, nil
 }
 
 func (s *Server) handleDeleteAPIKey(ctx context.Context, in *deleteAPIKeyInput) (*deleteAPIKeyOutput, error) {

--- a/internal/httpapi/apikeys_idem_test.go
+++ b/internal/httpapi/apikeys_idem_test.go
@@ -1,0 +1,185 @@
+package httpapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/tokencanopy/e2a/internal/idempotency"
+	"github.com/tokencanopy/e2a/internal/identity"
+)
+
+// bodyAwareIdem is an in-memory idempotency store that (unlike statefulIdem)
+// honors the request body-hash: a second Claim of the same key with a DIFFERENT
+// body-hash is a Mismatch (→422), matching the real Store. This lets the tests
+// exercise both the retry-replay path and the reuse-with-different-body path,
+// and proves the handler threads RawBody through for the body-hash.
+type bodyAwareIdem struct {
+	mu       sync.Mutex
+	cached   map[string]struct {
+		hash string
+		resp idempotency.CachedResponse
+	}
+	inflight map[string]string // key -> body hash
+}
+
+func newBodyAwareIdem() *bodyAwareIdem {
+	return &bodyAwareIdem{
+		cached: map[string]struct {
+			hash string
+			resp idempotency.CachedResponse
+		}{},
+		inflight: map[string]string{},
+	}
+}
+
+func (m *bodyAwareIdem) Claim(_ context.Context, _, key, _, bodyHash string) (idempotency.ClaimResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if c, ok := m.cached[key]; ok {
+		if c.hash != bodyHash {
+			return idempotency.ClaimResult{Outcome: idempotency.OutcomeMismatch}, nil
+		}
+		return idempotency.ClaimResult{Outcome: idempotency.OutcomeReplay, Cached: c.resp}, nil
+	}
+	if h, ok := m.inflight[key]; ok {
+		if h != bodyHash {
+			return idempotency.ClaimResult{Outcome: idempotency.OutcomeMismatch}, nil
+		}
+		return idempotency.ClaimResult{Outcome: idempotency.OutcomeInFlight}, nil
+	}
+	m.inflight[key] = bodyHash
+	return idempotency.ClaimResult{Outcome: idempotency.OutcomeAcquired}, nil
+}
+
+func (m *bodyAwareIdem) Complete(_ context.Context, _, key string, resp idempotency.CachedResponse) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.cached[key] = struct {
+		hash string
+		resp idempotency.CachedResponse
+	}{hash: m.inflight[key], resp: resp}
+	delete(m.inflight, key)
+	return nil
+}
+
+func (m *bodyAwareIdem) CompleteTx(_ context.Context, _ pgx.Tx, uid, key string, resp idempotency.CachedResponse) error {
+	return m.Complete(context.Background(), uid, key, resp)
+}
+
+func (m *bodyAwareIdem) Release(_ context.Context, _, key string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	delete(m.inflight, key)
+	return nil
+}
+
+// createKeyIdemServer wires a stateful in-memory idempotency store plus a
+// CreateScopedAPIKey fake that counts mints and returns a distinct id/secret per
+// call, so a retried request that mints a SECOND credential is observable.
+func createKeyIdemServer(t *testing.T, mints *int) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(New(Deps{
+		Authenticator: func(r *http.Request) (*identity.User, error) {
+			if r.Header.Get("Authorization") == "Bearer good" {
+				return &identity.User{ID: "u_1", Email: "owner@acme.com"}, nil
+			}
+			return nil, errors.New("unauthorized")
+		},
+		Idempotency: newBodyAwareIdem(),
+		CreateScopedAPIKey: func(_ context.Context, userID, name, scope, agentID string, expiresAt *time.Time) (*identity.APIKey, error) {
+			*mints++
+			return &identity.APIKey{
+				ID: fmt.Sprintf("apk_%d", *mints), UserID: userID, Name: name,
+				KeyPrefix: "e2a_acct_abcd", PlaintextKey: fmt.Sprintf("e2a_account_secret_%d", *mints),
+				Scope: scope, CreatedAt: time.Unix(1700000400, 0).UTC(), ExpiresAt: expiresAt,
+			}, nil
+		},
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+func createKeyCall(t *testing.T, url, idemKey, body string) (int, map[string]any) {
+	t.Helper()
+	req, _ := http.NewRequest("POST", url, bytes.NewReader([]byte(body)))
+	req.Header.Set("Authorization", "Bearer good")
+	req.Header.Set("Content-Type", "application/json")
+	if idemKey != "" {
+		req.Header.Set("Idempotency-Key", idemKey)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var m map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&m)
+	return resp.StatusCode, m
+}
+
+// A retried createApiKey carrying the SAME Idempotency-Key must replay the first
+// key and NOT mint a second live credential — otherwise a network-blip retry
+// silently doubles the caller's live API keys. (GA blocker: createApiKey
+// idempotency, issue #493.)
+func TestCreateAPIKey_IdempotentReplay(t *testing.T) {
+	var mints int
+	srv := createKeyIdemServer(t, &mints)
+	url := srv.URL + "/v1/account/api-keys"
+	body := `{"name":"ci","scope":"account"}`
+
+	code1, b1 := createKeyCall(t, url, "mkkey-1", body)
+	code2, b2 := createKeyCall(t, url, "mkkey-1", body) // network retry, byte-identical
+
+	if code1 != 201 || code2 != 201 {
+		t.Fatalf("want 201/201, got %d/%d (b1=%v b2=%v)", code1, code2, b1, b2)
+	}
+	if mints != 1 {
+		t.Fatalf("retry minted a SECOND live key: mints=%d, want 1", mints)
+	}
+	if b1["id"] != b2["id"] || b1["key"] != b2["key"] {
+		t.Fatalf("retry returned a different credential: id %v vs %v, key %v vs %v",
+			b1["id"], b2["id"], b1["key"], b2["key"])
+	}
+}
+
+// Same key + a DIFFERENT body is a caller bug, not a retry: 422 (do not replay).
+func TestCreateAPIKey_KeyReuseDifferentBody422(t *testing.T) {
+	var mints int
+	srv := createKeyIdemServer(t, &mints)
+	url := srv.URL + "/v1/account/api-keys"
+
+	code1, _ := createKeyCall(t, url, "mkkey-2", `{"name":"a","scope":"account"}`)
+	code2, _ := createKeyCall(t, url, "mkkey-2", `{"name":"DIFFERENT","scope":"account"}`)
+
+	if code1 != 201 {
+		t.Fatalf("first create: want 201, got %d", code1)
+	}
+	if code2 != 422 {
+		t.Fatalf("same key + different body: want 422 idempotency_key_reuse, got %d", code2)
+	}
+}
+
+// Distinct keys still mint separately — the guard dedupes retries, it does not
+// block intentional key creation.
+func TestCreateAPIKey_DistinctKeysMint(t *testing.T) {
+	var mints int
+	srv := createKeyIdemServer(t, &mints)
+	url := srv.URL + "/v1/account/api-keys"
+
+	createKeyCall(t, url, "mkkey-a", `{"name":"a","scope":"account"}`)
+	createKeyCall(t, url, "mkkey-b", `{"name":"b","scope":"account"}`)
+
+	if mints != 2 {
+		t.Fatalf("two distinct creates should both mint: mints=%d, want 2", mints)
+	}
+}

--- a/sdks/python/src/e2a/v1/generated/api/account_api.py
+++ b/sdks/python/src/e2a/v1/generated/api/account_api.py
@@ -51,6 +51,7 @@ class AccountApi:
     async def create_api_key(
         self,
         create_api_key_request: CreateAPIKeyRequest,
+        idempotency_key: Annotated[Optional[StrictStr], Field(description="Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request's response — the SAME key — instead of minting a second live credential. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). Dedup is best-effort: under idempotency-store degradation or a mid-request crash the guarantee degrades to at-least-once — a keyed retry may mint a new key rather than replay.")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -70,6 +71,8 @@ class AccountApi:
 
         :param create_api_key_request: (required)
         :type create_api_key_request: CreateAPIKeyRequest
+        :param idempotency_key: Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request's response — the SAME key — instead of minting a second live credential. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). Dedup is best-effort: under idempotency-store degradation or a mid-request crash the guarantee degrades to at-least-once — a keyed retry may mint a new key rather than replay.
+        :type idempotency_key: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -94,6 +97,7 @@ class AccountApi:
 
         _param = self._create_api_key_serialize(
             create_api_key_request=create_api_key_request,
+            idempotency_key=idempotency_key,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -118,6 +122,7 @@ class AccountApi:
     async def create_api_key_with_http_info(
         self,
         create_api_key_request: CreateAPIKeyRequest,
+        idempotency_key: Annotated[Optional[StrictStr], Field(description="Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request's response — the SAME key — instead of minting a second live credential. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). Dedup is best-effort: under idempotency-store degradation or a mid-request crash the guarantee degrades to at-least-once — a keyed retry may mint a new key rather than replay.")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -137,6 +142,8 @@ class AccountApi:
 
         :param create_api_key_request: (required)
         :type create_api_key_request: CreateAPIKeyRequest
+        :param idempotency_key: Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request's response — the SAME key — instead of minting a second live credential. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). Dedup is best-effort: under idempotency-store degradation or a mid-request crash the guarantee degrades to at-least-once — a keyed retry may mint a new key rather than replay.
+        :type idempotency_key: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -161,6 +168,7 @@ class AccountApi:
 
         _param = self._create_api_key_serialize(
             create_api_key_request=create_api_key_request,
+            idempotency_key=idempotency_key,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -185,6 +193,7 @@ class AccountApi:
     async def create_api_key_without_preload_content(
         self,
         create_api_key_request: CreateAPIKeyRequest,
+        idempotency_key: Annotated[Optional[StrictStr], Field(description="Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request's response — the SAME key — instead of minting a second live credential. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). Dedup is best-effort: under idempotency-store degradation or a mid-request crash the guarantee degrades to at-least-once — a keyed retry may mint a new key rather than replay.")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -204,6 +213,8 @@ class AccountApi:
 
         :param create_api_key_request: (required)
         :type create_api_key_request: CreateAPIKeyRequest
+        :param idempotency_key: Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request's response — the SAME key — instead of minting a second live credential. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). Dedup is best-effort: under idempotency-store degradation or a mid-request crash the guarantee degrades to at-least-once — a keyed retry may mint a new key rather than replay.
+        :type idempotency_key: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -228,6 +239,7 @@ class AccountApi:
 
         _param = self._create_api_key_serialize(
             create_api_key_request=create_api_key_request,
+            idempotency_key=idempotency_key,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -247,6 +259,7 @@ class AccountApi:
     def _create_api_key_serialize(
         self,
         create_api_key_request,
+        idempotency_key,
         _request_auth,
         _content_type,
         _headers,
@@ -270,6 +283,8 @@ class AccountApi:
         # process the path parameters
         # process the query parameters
         # process the header parameters
+        if idempotency_key is not None:
+            _header_params['Idempotency-Key'] = idempotency_key
         # process the form parameters
         # process the body parameter
         if create_api_key_request is not None:

--- a/sdks/typescript/src/v1/generated/apis/AccountApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/AccountApi.ts
@@ -28,8 +28,9 @@ export class AccountApiRequestFactory extends BaseAPIRequestFactory {
      * Mint a new API key; the plaintext key is returned once. scope=account is workspace admin (agent/domain/key management); scope=agent binds the key to one inbox so it can act only as that agent. Account scope only.
      * Create an API key
      * @param createAPIKeyRequest 
+     * @param idempotencyKey Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request\&#39;s response — the SAME key — instead of minting a second live credential. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). Dedup is best-effort: under idempotency-store degradation or a mid-request crash the guarantee degrades to at-least-once — a keyed retry may mint a new key rather than replay.
      */
-    public async createApiKey(createAPIKeyRequest: CreateAPIKeyRequest, _options?: Configuration): Promise<RequestContext> {
+    public async createApiKey(createAPIKeyRequest: CreateAPIKeyRequest, idempotencyKey?: string, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
 
         // verify required parameter 'createAPIKeyRequest' is not null or undefined
@@ -38,12 +39,16 @@ export class AccountApiRequestFactory extends BaseAPIRequestFactory {
         }
 
 
+
         // Path Params
         const localVarPath = '/v1/account/api-keys';
 
         // Make Request Context
         const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
+
+        // Header Params
+        requestContext.setHeaderParam("Idempotency-Key", ObjectSerializer.serialize(idempotencyKey, "string", ""));
 
 
         // Body Params

--- a/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
@@ -141,6 +141,13 @@ export interface AccountApiCreateApiKeyRequest {
      * @memberof AccountApicreateApiKey
      */
     createAPIKeyRequest: CreateAPIKeyRequest
+    /**
+     * Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request\&#39;s response — the SAME key — instead of minting a second live credential. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). Dedup is best-effort: under idempotency-store degradation or a mid-request crash the guarantee degrades to at-least-once — a keyed retry may mint a new key rather than replay.
+     * Defaults to: undefined
+     * @type string
+     * @memberof AccountApicreateApiKey
+     */
+    idempotencyKey?: string
 }
 
 export interface AccountApiDeleteAccountRequest {
@@ -244,7 +251,7 @@ export class ObjectAccountApi {
      * @param param the request object
      */
     public createApiKeyWithHttpInfo(param: AccountApiCreateApiKeyRequest, options?: ConfigurationOptions): Promise<HttpInfo<CreateAPIKeyResponse>> {
-        return this.api.createApiKeyWithHttpInfo(param.createAPIKeyRequest,  options).toPromise();
+        return this.api.createApiKeyWithHttpInfo(param.createAPIKeyRequest, param.idempotencyKey,  options).toPromise();
     }
 
     /**
@@ -253,7 +260,7 @@ export class ObjectAccountApi {
      * @param param the request object
      */
     public createApiKey(param: AccountApiCreateApiKeyRequest, options?: ConfigurationOptions): Promise<CreateAPIKeyResponse> {
-        return this.api.createApiKey(param.createAPIKeyRequest,  options).toPromise();
+        return this.api.createApiKey(param.createAPIKeyRequest, param.idempotencyKey,  options).toPromise();
     }
 
     /**

--- a/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
@@ -152,11 +152,12 @@ export class ObservableAccountApi {
      * Mint a new API key; the plaintext key is returned once. scope=account is workspace admin (agent/domain/key management); scope=agent binds the key to one inbox so it can act only as that agent. Account scope only.
      * Create an API key
      * @param createAPIKeyRequest
+     * @param [idempotencyKey] Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request\&#39;s response — the SAME key — instead of minting a second live credential. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). Dedup is best-effort: under idempotency-store degradation or a mid-request crash the guarantee degrades to at-least-once — a keyed retry may mint a new key rather than replay.
      */
-    public createApiKeyWithHttpInfo(createAPIKeyRequest: CreateAPIKeyRequest, _options?: ConfigurationOptions): Observable<HttpInfo<CreateAPIKeyResponse>> {
+    public createApiKeyWithHttpInfo(createAPIKeyRequest: CreateAPIKeyRequest, idempotencyKey?: string, _options?: ConfigurationOptions): Observable<HttpInfo<CreateAPIKeyResponse>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.createApiKey(createAPIKeyRequest, _config);
+        const requestContextPromise = this.requestFactory.createApiKey(createAPIKeyRequest, idempotencyKey, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -177,9 +178,10 @@ export class ObservableAccountApi {
      * Mint a new API key; the plaintext key is returned once. scope=account is workspace admin (agent/domain/key management); scope=agent binds the key to one inbox so it can act only as that agent. Account scope only.
      * Create an API key
      * @param createAPIKeyRequest
+     * @param [idempotencyKey] Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request\&#39;s response — the SAME key — instead of minting a second live credential. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). Dedup is best-effort: under idempotency-store degradation or a mid-request crash the guarantee degrades to at-least-once — a keyed retry may mint a new key rather than replay.
      */
-    public createApiKey(createAPIKeyRequest: CreateAPIKeyRequest, _options?: ConfigurationOptions): Observable<CreateAPIKeyResponse> {
-        return this.createApiKeyWithHttpInfo(createAPIKeyRequest, _options).pipe(map((apiResponse: HttpInfo<CreateAPIKeyResponse>) => apiResponse.data));
+    public createApiKey(createAPIKeyRequest: CreateAPIKeyRequest, idempotencyKey?: string, _options?: ConfigurationOptions): Observable<CreateAPIKeyResponse> {
+        return this.createApiKeyWithHttpInfo(createAPIKeyRequest, idempotencyKey, _options).pipe(map((apiResponse: HttpInfo<CreateAPIKeyResponse>) => apiResponse.data));
     }
 
     /**

--- a/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
@@ -148,10 +148,11 @@ export class PromiseAccountApi {
      * Mint a new API key; the plaintext key is returned once. scope=account is workspace admin (agent/domain/key management); scope=agent binds the key to one inbox so it can act only as that agent. Account scope only.
      * Create an API key
      * @param createAPIKeyRequest
+     * @param [idempotencyKey] Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request\&#39;s response — the SAME key — instead of minting a second live credential. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). Dedup is best-effort: under idempotency-store degradation or a mid-request crash the guarantee degrades to at-least-once — a keyed retry may mint a new key rather than replay.
      */
-    public createApiKeyWithHttpInfo(createAPIKeyRequest: CreateAPIKeyRequest, _options?: PromiseConfigurationOptions): Promise<HttpInfo<CreateAPIKeyResponse>> {
+    public createApiKeyWithHttpInfo(createAPIKeyRequest: CreateAPIKeyRequest, idempotencyKey?: string, _options?: PromiseConfigurationOptions): Promise<HttpInfo<CreateAPIKeyResponse>> {
         const observableOptions = wrapOptions(_options);
-        const result = this.api.createApiKeyWithHttpInfo(createAPIKeyRequest, observableOptions);
+        const result = this.api.createApiKeyWithHttpInfo(createAPIKeyRequest, idempotencyKey, observableOptions);
         return result.toPromise();
     }
 
@@ -159,10 +160,11 @@ export class PromiseAccountApi {
      * Mint a new API key; the plaintext key is returned once. scope=account is workspace admin (agent/domain/key management); scope=agent binds the key to one inbox so it can act only as that agent. Account scope only.
      * Create an API key
      * @param createAPIKeyRequest
+     * @param [idempotencyKey] Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request\&#39;s response — the SAME key — instead of minting a second live credential. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). Dedup is best-effort: under idempotency-store degradation or a mid-request crash the guarantee degrades to at-least-once — a keyed retry may mint a new key rather than replay.
      */
-    public createApiKey(createAPIKeyRequest: CreateAPIKeyRequest, _options?: PromiseConfigurationOptions): Promise<CreateAPIKeyResponse> {
+    public createApiKey(createAPIKeyRequest: CreateAPIKeyRequest, idempotencyKey?: string, _options?: PromiseConfigurationOptions): Promise<CreateAPIKeyResponse> {
         const observableOptions = wrapOptions(_options);
-        const result = this.api.createApiKey(createAPIKeyRequest, observableOptions);
+        const result = this.api.createApiKey(createAPIKeyRequest, idempotencyKey, observableOptions);
         return result.toPromise();
     }
 


### PR DESCRIPTION
## Summary

`createApiKey` was **not idempotent**: a network-retried `POST /v1/account/api-keys` with the same `Idempotency-Key` silently minted a **second live API key**. Unlike agent/domain/template creates (which 409-dedup on a natural identifier), API keys have no natural uniqueness — `name` is optional — so a retry can't be caught, doubling the caller's live credentials.

This wires the mint through the existing `runIdempotent` guard (the same machinery used by `send`/`reply`/`forward`/`rotate-secret`): a keyed retry with a byte-identical body **replays the first response — the same key** — instead of re-minting. Without a key the mint runs unguarded (idempotency stays opt-in, matching the rest of the surface).

Confirmed the bug live before the fix (two distinct `apk_…` ids from a same-key retry) and gone after.

## Changes
- `internal/httpapi/apikeys.go` — add `RawBody` + `Idempotency-Key` header to `createAPIKeyInput`; wrap `CreateScopedAPIKey` in `runIdempotent` keyed on `(user, "/v1/account/api-keys", body-hash)`.
- `internal/httpapi/apikeys_idem_test.go` — **regression test (fails before, passes after)**: keyed replay mints exactly once and returns the same key; same-key/different-body → `422 idempotency_key_reuse`; distinct keys still mint.
- `api/openapi.yaml` + `sdks/typescript/src/v1/generated/` + `sdks/python/src/e2a/v1/generated/` — regenerated for the new `Idempotency-Key` param (`make spec` + `make generate-sdk`).

## Test plan
- [x] `go test ./internal/httpapi/ -run TestCreateAPIKey` — fails before the fix (`mints=2`), passes after (`mints=1`, same key; different-body → 422).
- [x] `go test -short ./internal/httpapi/` — green (incl. `TestSpecGoldenNoDrift` after regenerating the spec).
- [x] `go build ./...` — clean.
- [x] `generate-sdk-check` — regenerated TS + Python bases; diff is scoped to the new `Idempotency-Key` param on `createApiKey` only.

## Scope / non-goals
Focused on the single blocker per #493. **Not** included (deliberately, to avoid opportunistic scope creep):
- Extending `Idempotency-Key` to the other non-idempotent creates (`createAgent`/`registerDomain`/`createTemplate`/`createWebhook`) — they have natural 409 dedup; can follow separately.
- Teaching the hand-written SDK layer to mint+retry a key for `createApiKey` now that the server deduplicates it (SDK-ergonomics follow-up).

Refs #493 (GA blocker: createApiKey idempotency). Additive/non-breaking — safe to land before or after the v1 freeze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
