### PR TITLE
fix(cli): deliver listen --forward as an independent side channel under --json

### DIFF
--- a/cli/src/__tests__/listen.test.ts
+++ b/cli/src/__tests__/listen.test.ts
@@ -228,6 +228,41 @@ describe("listen notification handling", () => {
     );
   });
 
+  it("forwards AND prints JSON when --forward and --json are both set (regression: silent forward drop)", async () => {
+    const full = {
+      id: "msg_123",
+      from_: "alice@example.com",
+      delivered_to: "bot@agents.e2a.dev",
+      subject: "Hello",
+      rawMessage: "U3ViamVjdDogSGVsbG8NCg0KSGkgdGhlcmUh",
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: () => Promise.resolve("ok"),
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const client = {
+      messages: { get: vi.fn().mockResolvedValue(full), reply: vi.fn() },
+    } as any;
+
+    await handleNotification(client, "bot@agents.e2a.dev", makeNotification(), {
+      json: true,
+      forward: "https://example.com/webhook",
+      forwardToken: "secret",
+    });
+
+    // The forward is a side channel: it MUST fire even though --json is also
+    // set (before the fix, --json short-circuited and the forward was dropped).
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://example.com/webhook",
+      expect.objectContaining({ method: "POST", body: JSON.stringify(full) }),
+    );
+    // ...and the JSON rendering still reaches stdout.
+    expect(mockStdout).toHaveBeenCalledWith(`${JSON.stringify(full)}\n`);
+  });
+
   it("forwards to OpenClaw and auto-replies when text is returned", async () => {
     // No parsed/body text — exercise the rawMessage decode fallback.
     const raw = "Subject: Hello\r\n\r\nHi there!";

--- a/cli/src/commands/listen.ts
+++ b/cli/src/commands/listen.ts
@@ -139,10 +139,18 @@ export async function listen(opts: ListenOptions): Promise<void> {
         if (!ok) continue;
       }
       if (opts.once) {
-        // --forward still delivers under --once; the blocking wait must not
-        // silently drop the webhook side channel.
+        // --forward still delivers under --once (a side channel that must not
+        // be silently dropped). Call forwardMessage directly — NOT
+        // handleNotification, which also renders stdout and would double-print
+        // under --json, since the --once block renders below.
         if (opts.forward) {
-          await handleNotification(client, agentEmail, notification, opts);
+          await forwardMessage(
+            client,
+            agentEmail,
+            notification,
+            opts.forward,
+            opts.forwardToken,
+          );
         }
         if (opts.text) {
           const full = await client.messages.get(agentEmail, notification.message_id);
@@ -208,12 +216,11 @@ export async function handleNotification(
   notification: EmailReceivedData,
   opts: Pick<ListenOptions, "json" | "forward" | "forwardToken">,
 ): Promise<void> {
-  if (opts.json) {
-    const full = await client.messages.get(agentEmail, notification.message_id);
-    process.stdout.write(JSON.stringify(full) + "\n");
-    return;
-  }
-
+  // Forward is an independent SIDE CHANNEL: it must fire whenever --forward is
+  // set, regardless of how (or whether) the message is also rendered to stdout.
+  // Gating it behind an `else` after --json silently dropped the forward when
+  // both flags were passed — the exact silent side-channel drop the CLI's
+  // exit-code contract exists to prevent.
   if (opts.forward) {
     await forwardMessage(
       client,
@@ -222,8 +229,17 @@ export async function handleNotification(
       opts.forward,
       opts.forwardToken,
     );
+  }
+
+  if (opts.json) {
+    const full = await client.messages.get(agentEmail, notification.message_id);
+    process.stdout.write(JSON.stringify(full) + "\n");
     return;
   }
+
+  // Forward-only mode keeps stdout clean (forwardMessage logs to stderr); the
+  // human summary is only for the plain (non-json, non-forward) default.
+  if (opts.forward) return;
 
   const time = new Date(notification.received_at).toLocaleTimeString();
   process.stdout.write(


### PR DESCRIPTION
## Summary

`e2a listen --forward <url> --json` **silently dropped the forward**. `handleNotification` returned right after printing JSON, before ever reaching the forward branch — so `--forward` combined with `--json` printed to stdout and never POSTed. Under `--once` it was worse: the once-path routed through `handleNotification` (which also renders stdout), so `listen --once --forward --json` **double-printed the JSON and delivered zero forwards**.

The `--forward` webhook proxy is a documented side channel; dropping it silently is exactly the failure class the CLI's frozen exit-code / anti-silent-drop contract exists to prevent.

## Fix
- `handleNotification` now fires the forward **whenever `--forward` is set, independent of stdout rendering** (json/text/default) — no more `return` before the forward branch.
- The `--once` block calls `forwardMessage` **directly** (not `handleNotification`), so the once-block's own render doesn't duplicate output.
- Forward-only mode keeps stdout clean; the human summary is only for the plain default.

## Test plan
- [x] New regression test — *"forwards AND prints JSON when --forward and --json are both set"* — asserts `fetch` (the forward) fires **and** JSON reaches stdout. Fails before the fix, passes after.
- [x] `npm test --workspace @e2a/cli` — **115 passed** (was 114; +1 regression test).
- [x] **Live end-to-end** against a running server: `listen --once --forward <local-sink> --json` now delivers **1 forward POST + 1 JSON line** (before the fix: **0 forwards + 2 JSON**); `--forward` without `--json` unchanged (1 forward, clean stdout).

## Scope
Focused on the single blocker per #493 — no unrelated changes. Consolidates the in-progress `fix/cli-listen-json-forward-drop` work into a reviewable, verified PR.

Refs #493 (GA blocker: CLI listen forward-drop). CLI-side only, non-breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
