### PR TITLE
fix(outbound): qualify SES message-id with region domain so replies thread

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -61,6 +61,12 @@ outbound_smtp:
   username: ""
   password: ""
   from_domain: "relay.example.com"
+  # Domain the provider stamps on outgoing Message-ID headers (SES:
+  # "<region>.amazonses.com"). Used to qualify the bare id SES returns in the
+  # SMTP 250 response so replies thread correctly. Leave empty to derive it
+  # from a standard SES host (email-smtp.<region>.amazonaws.com); set it
+  # explicitly only for non-standard endpoints.
+  # message_id_domain: "us-east-2.amazonses.com"
 
 # Outbound delivery is always asynchronous and at-least-once. The send API
 # durably persists the message and enqueues a River job in one transaction,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -123,6 +123,15 @@ type OutboundSMTPConfig struct {
 	// off for dev relays (e.g. Mailpit on :1025 with no TLS). Regardless
 	// of this flag, PLAIN auth is never sent over a cleartext connection.
 	RequireTLS *bool `yaml:"require_tls"`
+	// MessageIDDomain is the domain the upstream provider stamps on the
+	// Message-ID header of relayed mail (SES: "<region>.amazonses.com").
+	// SES's SMTP 250 response returns the assigned id BARE — without this
+	// domain — so the relay appends it to make the captured id match the
+	// on-wire Message-ID; a mismatch there breaks In-Reply-To/References
+	// threading on replies to the agent's own outbound. Empty (the default)
+	// derives it from a standard SES Host (email-smtp.<region>.amazonaws.com);
+	// set it explicitly for non-standard endpoints (e.g. VPC endpoints).
+	MessageIDDomain string `yaml:"message_id_domain"`
 }
 
 // InboundConfig selects the inbound processing model (inbound-message-pipeline-
@@ -297,6 +306,9 @@ func Load(path string) (*Config, error) {
 	}
 	if v := os.Getenv("E2A_OUTBOUND_SMTP_FROM_DOMAIN"); v != "" {
 		cfg.OutboundSMTP.FromDomain = v
+	}
+	if v := os.Getenv("E2A_OUTBOUND_SMTP_MESSAGE_ID_DOMAIN"); v != "" {
+		cfg.OutboundSMTP.MessageIDDomain = v
 	}
 	if v := os.Getenv("E2A_INBOUND_MODE"); v != "" {
 		cfg.Inbound.Mode = v

--- a/internal/e2e/reply_threading_ses_e2e_test.go
+++ b/internal/e2e/reply_threading_ses_e2e_test.go
@@ -1,0 +1,85 @@
+//go:build integration
+
+package e2e_test
+
+import (
+	"context"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/tokencanopy/e2a/internal/testutil"
+)
+
+// TestReplyThreadingSESMessageIDE2E pins the SES reply-threading fix through
+// the real API + store + relay against a fake SES that mimics production SMTP:
+// the 250 response carries the assigned id BARE (no angle brackets, no domain),
+// while the Message-ID SES stamps on the delivered message is
+// <id@<region>.amazonses.com>. The relay must qualify the captured id with the
+// provider domain so that:
+//  1. the stored provider_message_id equals the on-wire Message-ID verbatim;
+//  2. a reply to the agent's own outbound anchors In-Reply-To/References on
+//     that exact value.
+//
+// Before the fix, the bare id was stored and echoed into the reply's threading
+// headers; the missing @<region>.amazonses.com meant no msg-id match, and every
+// compliant client (Gmail included) forked the reply into a separate thread.
+func TestReplyThreadingSESMessageIDE2E(t *testing.T) {
+	pool := testutil.TestDB(t)
+	// In-process fake SES: returns bare ids in the 250 response, like the real
+	// email-smtp.<region>.amazonaws.com endpoint. Tests dial 127.0.0.1, so the
+	// SES-host region derivation can't fire — the message_id_domain override
+	// exercises the same qualification path production takes.
+	fakeSMTP, smtpDone := testutil.FakeSMTPServer(t)
+	ts := testutil.TestServer(t, pool,
+		testutil.WithOutboundSMTP(fakeSMTP.Host, fakeSMTP.Port, "test.e2a.dev"),
+		testutil.WithOutboundSMTPMessageIDDomain("us-east-2.amazonses.com"))
+	_, key, agent := setupDomainAndAgent(t, ts, "agent@sesthread.example.com", "sesthread.example.com", "", "")
+	ctx := context.Background()
+
+	// (1) Send. The fake's 250 carried a bare id; the captured provider id must
+	// come back domain-qualified — i.e. equal to the on-wire Message-ID.
+	status, body := authedJSON(t, "POST", sendURL(ts.HTTPServer.URL, agent.EmailAddress()), key.PlaintextKey,
+		`{"to":["alice@gmail.com"],"subject":"Kickoff","text":"first touch"}`)
+	if status != 200 {
+		t.Fatalf("send status=%d body=%s", status, body)
+	}
+	sent := parseThreadSend(t, body)
+	qualified := regexp.MustCompile(`^<[^@>]+@us-east-2\.amazonses\.com>$`)
+	if !qualified.MatchString(sent.ProviderMessageID) {
+		t.Fatalf("provider_message_id = %q, want the domain-qualified on-wire form <id@us-east-2.amazonses.com>",
+			sent.ProviderMessageID)
+	}
+
+	// (2) Reply to the agent's own outbound. Its threading headers must carry
+	// the parent's real Message-ID verbatim — the qualified id, not the bare one.
+	status, body = authedJSON(t, "POST", subResource(ts.HTTPServer.URL, agent.EmailAddress(), sent.MessageID, "reply"),
+		key.PlaintextKey, `{"text":"second touch"}`)
+	if status != 200 {
+		t.Fatalf("reply-to-outbound status=%d body=%s", status, body)
+	}
+	rep := parseThreadSend(t, body)
+	repMsg, err := ts.Store.GetMessageWithContent(ctx, rep.MessageID, agent.ID)
+	if err != nil {
+		t.Fatalf("load reply row: %v", err)
+	}
+	raw := string(repMsg.RawMessage)
+	if !strings.Contains(raw, "In-Reply-To: "+sent.ProviderMessageID) {
+		t.Errorf("reply In-Reply-To not anchored on the parent's on-wire Message-ID %q; raw headers=\n%s",
+			sent.ProviderMessageID, raw[:min(len(raw), 600)])
+	}
+	if !strings.Contains(raw, "References: "+sent.ProviderMessageID) {
+		t.Errorf("reply References missing the parent's on-wire Message-ID %q; raw headers=\n%s",
+			sent.ProviderMessageID, raw[:min(len(raw), 600)])
+	}
+
+	// (3) Same assertion on what actually crossed the wire to the provider —
+	// the second message the fake accepted is the reply.
+	msgs := smtpDone()
+	if len(msgs) != 2 {
+		t.Fatalf("fake SMTP saw %d messages, want 2 (send + reply)", len(msgs))
+	}
+	if !strings.Contains(msgs[1].Data, "In-Reply-To: "+sent.ProviderMessageID) {
+		t.Errorf("on-wire reply In-Reply-To missing qualified parent id %q", sent.ProviderMessageID)
+	}
+}

--- a/internal/outbound/smtp_relay.go
+++ b/internal/outbound/smtp_relay.go
@@ -230,15 +230,58 @@ func (r *SMTPRelay) sendOnce(envelopeFrom string, recipients []string, message [
 	}
 
 	// Parse Message-ID from response like "Ok <xxx@us-east-2.amazonses.com>"
-	sesMessageID := parseMessageIDFromResponse(msg)
+	// and qualify it with the provider domain when the response carried the id
+	// bare — the captured value must equal the on-wire Message-ID verbatim.
+	sesMessageID := qualifyMessageIDDomain(parseMessageIDFromResponse(msg), r.cfg)
 
 	c.Quit()
 	return sesMessageID, nil
 }
 
+// qualifyMessageIDDomain appends the provider's Message-ID domain to an id
+// that lacks one. SES's SMTP 250 response returns the assigned id BARE
+// (010f...-000000, no domain), but the Message-ID it stamps on the message is
+// <010f...-000000@<region>.amazonses.com>. The stored provider_message_id is
+// what replies anchor In-Reply-To/References on, so it must equal the on-wire
+// header verbatim — the domainless form matches nothing and every RFC 5322
+// client forks the thread. Already-qualified ids pass through untouched; when
+// no domain can be determined the id is left as-is (never fabricate one).
+func qualifyMessageIDDomain(id string, cfg *config.OutboundSMTPConfig) string {
+	if id == "" || strings.Contains(id, "@") {
+		return id
+	}
+	domain := cfg.MessageIDDomain
+	if domain == "" {
+		if region := sesRegionFromHost(cfg.Host); region != "" {
+			domain = region + ".amazonses.com"
+		}
+	}
+	if domain == "" {
+		return id
+	}
+	inner := strings.TrimSuffix(strings.TrimPrefix(id, "<"), ">")
+	return "<" + inner + "@" + domain + ">"
+}
+
+// sesRegionFromHost extracts the region from a standard SES SMTP endpoint
+// (email-smtp.<region>.amazonaws.com). Returns "" for anything else — a
+// non-SES relay or non-standard endpoint needs message_id_domain set instead.
+func sesRegionFromHost(host string) string {
+	rest, ok := strings.CutPrefix(host, "email-smtp.")
+	if !ok {
+		return ""
+	}
+	region, ok := strings.CutSuffix(rest, ".amazonaws.com")
+	if !ok || region == "" || strings.Contains(region, ".") {
+		return ""
+	}
+	return region
+}
+
 // parseMessageIDFromResponse extracts a Message-ID from an SMTP response string.
 // SES format: "Ok <010f019d...@us-east-2.amazonses.com>"
-// Some SES endpoints return bare IDs without angle brackets: "Ok 010f019d..."
+// Production SES SMTP returns bare IDs without angle brackets or domain:
+// "Ok 010f019d...-000000" — qualifyMessageIDDomain adds the domain afterward.
 // Returns the full angle-bracket ID including <>, or the bare ID wrapped in <>.
 func parseMessageIDFromResponse(resp string) string {
 	if i := strings.Index(resp, "<"); i >= 0 {

--- a/internal/outbound/smtp_relay_test.go
+++ b/internal/outbound/smtp_relay_test.go
@@ -6,6 +6,8 @@ import (
 	"net"
 	"net/textproto"
 	"testing"
+
+	"github.com/tokencanopy/e2a/internal/config"
 )
 
 // smtpErr mirrors PRODUCTION's error shape: net/smtp returns a *textproto.Error for
@@ -97,6 +99,9 @@ func TestParseMessageIDFromResponse(t *testing.T) {
 		{"Ok <010f019d2bd82cd5-49c4925c@us-east-2.amazonses.com>", "<010f019d2bd82cd5-49c4925c@us-east-2.amazonses.com>"},
 		{"<simple@example.com>", "<simple@example.com>"},
 		{"Ok no-angle-brackets", "<no-angle-brackets>"},
+		// Parse alone only wraps a bare id — sendOnce then appends the provider
+		// domain via qualifyMessageIDDomain. The composed capture path is pinned
+		// in TestCapturedMessageIDMatchesOnWireHeader.
 		{"Ok 010f019d4b3843be-53882e6f-46de-4221-a56a-ba993e8f83e8-000000", "<010f019d4b3843be-53882e6f-46de-4221-a56a-ba993e8f83e8-000000>"},
 		{"", ""},
 		{"  whitespace  ", "<whitespace>"},
@@ -107,5 +112,70 @@ func TestParseMessageIDFromResponse(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("parseMessageIDFromResponse(%q) = %q, want %q", tt.input, got, tt.want)
 		}
+	}
+}
+
+func TestQualifyMessageIDDomain(t *testing.T) {
+	sesCfg := &config.OutboundSMTPConfig{Host: "email-smtp.us-east-2.amazonaws.com"}
+	tests := []struct {
+		name string
+		id   string
+		cfg  *config.OutboundSMTPConfig
+		want string
+	}{
+		{"bare id gains the region domain derived from the SES host",
+			"<010f-abc-000000>", sesCfg, "<010f-abc-000000@us-east-2.amazonses.com>"},
+		{"already-qualified id passes through untouched",
+			"<010f-abc-000000@us-east-2.amazonses.com>", sesCfg, "<010f-abc-000000@us-east-2.amazonses.com>"},
+		{"explicit message_id_domain wins over host derivation",
+			"<010f-abc-000000>",
+			&config.OutboundSMTPConfig{Host: "email-smtp.us-east-2.amazonaws.com", MessageIDDomain: "eu-west-1.amazonses.com"},
+			"<010f-abc-000000@eu-west-1.amazonses.com>"},
+		{"non-SES host with no override leaves the id alone (never fabricate)",
+			"<010f-abc-000000>", &config.OutboundSMTPConfig{Host: "smtp.example.com"}, "<010f-abc-000000>"},
+		{"empty id stays empty", "", sesCfg, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := qualifyMessageIDDomain(tt.id, tt.cfg); got != tt.want {
+				t.Errorf("qualifyMessageIDDomain(%q) = %q, want %q", tt.id, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSESRegionFromHost(t *testing.T) {
+	tests := []struct {
+		host string
+		want string
+	}{
+		{"email-smtp.us-east-2.amazonaws.com", "us-east-2"},
+		{"email-smtp.eu-west-1.amazonaws.com", "eu-west-1"},
+		{"smtp.example.com", ""},
+		{"email-smtp.amazonaws.com", ""},     // no region segment
+		{"email-smtp.a.b.amazonaws.com", ""}, // region can't contain dots
+		{"localhost", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		if got := sesRegionFromHost(tt.host); got != tt.want {
+			t.Errorf("sesRegionFromHost(%q) = %q, want %q", tt.host, got, tt.want)
+		}
+	}
+}
+
+// TestCapturedMessageIDMatchesOnWireHeader pins the full capture path
+// (parse → qualify) on the exact 250 shape production SES SMTP returns: the
+// id arrives BARE (no brackets, no domain), while the Message-ID SES stamps
+// on the delivered message is <id@<region>.amazonses.com>. The captured value
+// is stored as provider_message_id and copied verbatim into a reply's
+// In-Reply-To/References — so anything other than the on-wire form forks the
+// recipient's thread in every RFC 5322 client.
+func TestCapturedMessageIDMatchesOnWireHeader(t *testing.T) {
+	cfg := &config.OutboundSMTPConfig{Host: "email-smtp.us-east-2.amazonaws.com"}
+	resp := "Ok 010f019d4b3843be-53882e6f-46de-4221-a56a-ba993e8f83e8-000000"
+	want := "<010f019d4b3843be-53882e6f-46de-4221-a56a-ba993e8f83e8-000000@us-east-2.amazonses.com>"
+	if got := qualifyMessageIDDomain(parseMessageIDFromResponse(resp), cfg); got != want {
+		t.Errorf("captured id = %q, want the on-wire Message-ID %q", got, want)
 	}
 }

--- a/internal/testutil/fakesmtp.go
+++ b/internal/testutil/fakesmtp.go
@@ -95,10 +95,14 @@ func handleSMTPConn(conn net.Conn, mu *sync.Mutex, messages *[]SMTPMessage) {
 					Data:       strings.Join(dataLines, "\n"),
 				})
 				mu.Unlock()
-				// Return a fake SES-style Message-ID in the 250 response
+				// Return the id the way production SES SMTP does: BARE in the
+				// 250 response — no angle brackets, no @domain (the real
+				// Message-ID SES stamps on the wire is <id@<region>.amazonses.com>).
+				// A bracketed/qualified fake here would mask the relay's
+				// capture path (parse + domain qualification) from every test.
 				b := make([]byte, 16)
 				rand.Read(b)
-				fmt.Fprintf(conn, "250 Ok <%x@us-east-2.amazonses.com>\r\n", b)
+				fmt.Fprintf(conn, "250 Ok %x-000000\r\n", b)
 				continue
 			}
 			dataLines = append(dataLines, line)

--- a/internal/testutil/server.go
+++ b/internal/testutil/server.go
@@ -40,9 +40,10 @@ const TestHMACSecret = "test-hmac-secret-for-testing"
 // growing the TestServer call site. Add fields here rather than new
 // constructor parameters — every existing caller stays untouched.
 type testServerOpts struct {
-	outboundSMTPHost       string
-	outboundSMTPPort       int
-	outboundSMTPFromDomain string
+	outboundSMTPHost            string
+	outboundSMTPPort            int
+	outboundSMTPFromDomain      string
+	outboundSMTPMessageIDDomain string
 }
 
 type TestServerOption func(*testServerOpts)
@@ -56,6 +57,17 @@ func WithOutboundSMTP(host string, port int, fromDomain string) TestServerOption
 		o.outboundSMTPHost = host
 		o.outboundSMTPPort = port
 		o.outboundSMTPFromDomain = fromDomain
+	}
+}
+
+// WithOutboundSMTPMessageIDDomain sets the provider Message-ID domain the
+// relay appends to bare ids from the 250 response (config message_id_domain).
+// Tests dial the relay at 127.0.0.1, so the SES-host derivation can never
+// fire — this override is how a test exercises the qualification path the
+// way production does against a real email-smtp.<region>.amazonaws.com host.
+func WithOutboundSMTPMessageIDDomain(domain string) TestServerOption {
+	return func(o *testServerOpts) {
+		o.outboundSMTPMessageIDDomain = domain
 	}
 }
 
@@ -128,8 +140,9 @@ func TestServer(t *testing.T, pool *pgxpool.Pool, opts ...TestServerOption) *E2A
 	store := identity.NewStore(pool)
 	signer := headers.NewSigner(TestHMACSecret)
 	outboundCfg := &config.OutboundSMTPConfig{
-		Host: o.outboundSMTPHost,
-		Port: o.outboundSMTPPort,
+		Host:            o.outboundSMTPHost,
+		Port:            o.outboundSMTPPort,
+		MessageIDDomain: o.outboundSMTPMessageIDDomain,
 	}
 	fromDomain := "test.e2a.dev"
 	if o.outboundSMTPFromDomain != "" {


### PR DESCRIPTION
## Summary

Replies to e2a's **own outbound (SES-sent) messages never thread** — Gmail and every RFC 5322 client fork the reply into a separate conversation. Root cause: SES's SMTP `250` response returns the assigned message id **bare** (`010f…-000000`, no domain), but the `Message-ID` SES actually stamps on the wire is `<010f…-000000@<region>.amazonses.com>`. `parseMessageIDFromResponse` (internal/outbound/smtp_relay.go) wrapped the bare id in angle brackets and stored it as `provider_message_id`; every reply then copied that domainless value verbatim into `In-Reply-To`/`References` — no msg-id match, thread forked. This affects **every e2a→SES reply-to-own-outbound**, not one integrator.

The fix qualifies the id **at capture**, inside the relay adapter: after parsing, a bare id gains `@<region>.amazonses.com`, with the region derived from the standard SES host (`email-smtp.<region>.amazonaws.com`). A new optional `outbound_smtp.message_id_domain` config (env: `E2A_OUTBOUND_SMTP_MESSAGE_ID_DOMAIN`) overrides the derivation for non-standard endpoints; when explicitly set it wins. If neither yields a domain, the id is left as-is — never fabricate one. Downstream propagation (`Message.ThreadMessageID` → `handleReply` → `BuildReferencesChain`) was already faithful and is untouched.

### Evidence (raw Gmail headers, live probe)

Original's real on-wire Message-ID (Gmail "Show original"):
```
Message-ID: <010f019f6ccbcce4-65395574-33bc-4074-b5bd-c3d1f2e82bc9-000000@us-east-2.amazonses.com>
```
The `/reply` against that outbound message went out with:
```
In-Reply-To: <010f019f6ccbcce4-65395574-33bc-4074-b5bd-c3d1f2e82bc9-000000>
References:  <010f019f6ccbcce4-65395574-33bc-4074-b5bd-c3d1f2e82bc9-000000>
```
Missing right-hand side → no match → two separate Gmail threads (confirmed visually and by headers).

### Why the test suite stayed green on this bug

Two fixtures encoded the wrong assumption; both are corrected here:

1. `internal/testutil/fakesmtp.go` returned `250 Ok <id@us-east-2.amazonses.com>` — bracketed **and** domain-qualified, so no test ever exercised the real bare-id path. It now returns the id bare, the way production SES SMTP does.
2. `internal/outbound/smtp_relay_test.go` asserted the bare-id → domainless mapping as correct. The capture path (parse → qualify) is now pinned to the on-wire form in `TestCapturedMessageIDMatchesOnWireHeader`, plus unit coverage for the qualifier and region derivation.

New end-to-end regression (`internal/e2e/reply_threading_ses_e2e_test.go`): against a fake SES returning bare `250` ids, a send must surface a domain-qualified `provider_message_id`, and a reply to that outbound must carry it verbatim in `In-Reply-To`/`References` — asserted both on the stored raw message and on the bytes the fake SMTP received. Verified red without the fix (fails exactly on the bare id) and green with it.

### Alternative considered (not implemented)

e2a could stamp its **own** `Message-ID` in `internal/outbound/compose.go` (which currently omits it) and store that instead of the SES id — fully provider-independent, no region derivation, survives leaving SES. It's a bigger change and needs verification that SES preserves a supplied `Message-ID` over SMTP rather than overwriting it. Worth a follow-up; this PR ships the minimal capture-side fix.

## Client surface checklist

N/A — backend-only. No `/v1` handler change (the fix is inside `internal/outbound`), so no OpenAPI/SDK/CLI/MCP regeneration applies; the spec drift gate (`TestSpecGoldenNoDrift` in `make test-unit`) passes unchanged. No DB migration: `provider_message_id` keeps its column and shape, only the captured value gains the domain the wire always had.

## Operational risk

- Only **newly captured** provider ids change shape. Existing stored bare ids keep working: `CorrelateBySESMessageID` already matches bare, `<id>`, and `<id@…>` shapes, and `LookupConversationID` prefix-matches domainless stored ids by design — both workarounds for exactly this discrepancy, both untouched.
- Replies to *pre-fix* outbound rows still reference the stored bare id (unavoidable — the qualified form was never stored for them); replies to *post-fix* sends thread correctly.
- New config is optional; default behavior (derive from standard SES host) requires no deploy-time action. Non-SES relays are unaffected (no domain derived → id passes through unchanged, as before).
- Rollback: revert the commit; no data or schema to unwind.

## Test plan

- [x] `make test-unit` — includes the new `TestQualifyMessageIDDomain`, `TestSESRegionFromHost`, `TestCapturedMessageIDMatchesOnWireHeader`, and the spec drift gate
- [x] `make test-integration` — full tier against Postgres, with the corrected bare-id fake SMTP
- [x] `make test` — all tiers (`-tags integration -p 1`), green
- [x] Red/green verification: with the qualify call removed, `TestReplyThreadingSESMessageIDE2E` fails on the bare `provider_message_id`; with the fix it passes
- [ ] Post-merge: send + `/reply` against a real SES-backed deploy, confirm one Gmail thread and `In-Reply-To` == the original's on-wire `Message-ID`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
