### PR TITLE
fix(mcp): normalize success output shapes

### DIFF
--- a/mcp/src/tools/messages.ts
+++ b/mcp/src/tools/messages.ts
@@ -461,7 +461,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
         return {
           id: email.id,
           conversation_id: email.conversationId,
-          from: email.from_,
+          from_: email.from_,
           delivered_to: email.deliveredTo,
           to: email.to,
           cc: email.cc,

--- a/mcp/src/tools/util.ts
+++ b/mcp/src/tools/util.ts
@@ -7,6 +7,59 @@ export type ToolResult = {
   isError?: boolean;
 };
 
+type SnakeCase<S extends string> =
+  S extends `${infer Head}${infer Tail}`
+    ? Head extends Lowercase<Head>
+      ? `${Head}${SnakeCase<Tail>}`
+      : `_${Lowercase<Head>}${SnakeCase<Tail>}`
+    : S;
+
+type TrimLeadingUnderscore<S extends string> = S extends `_${infer Rest}` ? Rest : S;
+
+/** The public MCP success shape corresponding to an ergonomic SDK value. */
+export type McpOutput<T> =
+  T extends Date ? T
+    : T extends readonly (infer Item)[] ? McpOutput<Item>[]
+      : T extends object ? {
+          [Key in keyof T as Key extends string
+            ? TrimLeadingUnderscore<SnakeCase<Key>>
+            : Key]: McpOutput<T[Key]>
+        }
+        : T;
+
+function snakeCaseKey(key: string): string {
+  return key
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
+    .replace(/([a-z0-9])([A-Z])/g, "$1_$2")
+    .toLowerCase();
+}
+
+/**
+ * Convert SDK response models back to the REST-style names used by MCP.
+ *
+ * SDK models are plain objects whose generated property names are ergonomic
+ * camelCase. MCP is a separate public boundary and deliberately follows the
+ * REST contract's snake_case vocabulary. Recurse through arrays/nested view
+ * objects without touching Dates or other class instances. Already-snake_case
+ * keys (including reserved-word-safe `from_`) are preserved verbatim.
+ */
+export function toMcpOutput<T>(value: T): McpOutput<T> {
+  if (Array.isArray(value)) {
+    return value.map((item) => toMcpOutput(item)) as McpOutput<T>;
+  }
+  if (value !== null && typeof value === "object") {
+    const prototype = Object.getPrototypeOf(value);
+    if (prototype === Object.prototype || prototype === null) {
+      const out: Record<string, unknown> = {};
+      for (const [key, item] of Object.entries(value)) {
+        out[snakeCaseKey(key)] = toMcpOutput(item);
+      }
+      return out as McpOutput<T>;
+    }
+  }
+  return value as McpOutput<T>;
+}
+
 // strictInputSchema wraps a zod raw shape in a strict ZodObject so the
 // MCP SDK rejects unknown argument keys instead of silently stripping
 // them. Without this, a typo like `limit` against a tool that takes
@@ -73,12 +126,13 @@ export class CodedError extends Error {
 export async function runTool<T>(fn: () => Promise<T>): Promise<ToolResult> {
   try {
     const result = await fn();
+    const output = toMcpOutput(result);
     const text =
-      result === undefined
+      output === undefined
         ? "OK"
-        : typeof result === "string"
-          ? result
-          : JSON.stringify(result, null, 2);
+        : typeof output === "string"
+          ? output
+          : JSON.stringify(output, null, 2);
     return { content: [{ type: "text", text }] };
   } catch (err) {
     // Every tool error carries BOTH representations (GA review Tier-2 #12/#31):

--- a/mcp/tests/client.types.ts
+++ b/mcp/tests/client.types.ts
@@ -1,4 +1,5 @@
 import type { McpClient } from "../src/client.js";
+import type { McpOutput } from "../src/tools/util.js";
 
 type ListMessagesParams = Parameters<McpClient["listMessages"]>[0];
 
@@ -9,3 +10,25 @@ void senderFilter;
 // @ts-expect-error `from` is the REST wire name, not the MCP input name.
 const removedSenderFilter: ListMessagesParams = { from: "alice@example.com" };
 void removedSenderFilter;
+
+// Success payloads cross a second public boundary after the ergonomic SDK:
+// MCP deliberately exposes REST-style snake_case, recursively. Keep the
+// reserved-word-safe `from_` spelling uniform with the MCP input contract.
+type NormalizedSuccess = McpOutput<{
+  messageId: string;
+  from_: string;
+  deliveryMeta: { createdAt: string };
+  attachments: Array<{ contentType: string; sizeBytes: number }>;
+}>;
+
+const normalizedSuccess: NormalizedSuccess = {
+  message_id: "msg_1",
+  from_: "alice@example.com",
+  delivery_meta: { created_at: "2026-07-16T00:00:00Z" },
+  attachments: [{ content_type: "text/plain", size_bytes: 1 }],
+};
+void normalizedSuccess;
+
+// @ts-expect-error SDK camelCase must not be accepted as MCP output keys.
+const leakedSdkSuccess: NormalizedSuccess = { messageId: "msg_1" };
+void leakedSdkSuccess;

--- a/mcp/tests/events-streamable-http.test.ts
+++ b/mcp/tests/events-streamable-http.test.ts
@@ -112,7 +112,7 @@ describe("MCP events tools over streamable-http", () => {
       arguments: { event_id: "evt_x", webhook_id: "wh_y" },
     });
     const parsed = parseToolResult(result);
-    expect(parsed.deliveryId).toBe("whd_replay_http");
+    expect(parsed.delivery_id).toBe("whd_replay_http");
     expect(stub.redeliverEvent).toHaveBeenCalledWith("evt_x", "wh_y");
     await client.close();
   });

--- a/mcp/tests/events.test.ts
+++ b/mcp/tests/events.test.ts
@@ -150,7 +150,7 @@ describe("MCP events tools", () => {
         arguments: { event_id: "evt_xyz" },
       });
       const parsed = parseToolResult(result);
-      const ds = parsed.deliveryStatus as Record<string, number>;
+      const ds = parsed.delivery_status as Record<string, number>;
       expect(ds.delivered).toBe(1);
     });
   });
@@ -187,7 +187,7 @@ describe("MCP events tools", () => {
         arguments: { event_id: "evt_abc", webhook_id: "wh_x" },
       });
       const parsed = parseToolResult(result);
-      expect(parsed.deliveryId).toBe("whd_replay_xyz");
+      expect(parsed.delivery_id).toBe("whd_replay_xyz");
     });
   });
 

--- a/mcp/tests/http.test.ts
+++ b/mcp/tests/http.test.ts
@@ -349,7 +349,7 @@ describe("HTTP MCP server", () => {
       ((await client.callTool({ name: "list_messages", arguments: { cursor: page1.next_cursor } }))
         .content as Array<{ text: string }>)[0].text,
     );
-    expect(page2.messages).toEqual([{ messageId: "m3" }]);
+    expect(page2.messages).toEqual([{ message_id: "m3" }]);
     expect(page2).not.toHaveProperty("next_cursor"); // last page
     await transport.close();
   });

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -575,7 +575,7 @@ describe("e2a MCP server", () => {
     });
     const res = await client.callTool({ name: "list_conversations", arguments: {} });
     const payload = JSON.parse((res.content as Array<{ text: string }>)[0].text);
-    expect(payload.conversations).toEqual([{ conversationId: "conv_1" }]);
+    expect(payload.conversations).toEqual([{ conversation_id: "conv_1" }]);
     expect(payload.next_cursor).toBe("c_next");
   });
 
@@ -644,7 +644,7 @@ describe("e2a MCP server", () => {
     });
     const res = await client.callTool({ name: "list_messages", arguments: {} });
     const payload = JSON.parse((res.content as Array<{ text: string }>)[0].text);
-    expect(payload.messages).toEqual([{ messageId: "m1" }]);
+    expect(payload.messages).toEqual([{ message_id: "m1" }]);
     expect(payload.next_cursor).toBe("c_next");
   });
 
@@ -671,7 +671,8 @@ describe("e2a MCP server", () => {
     const content = res.content as Array<{ type: string; text: string }>;
     const parsed = JSON.parse(content[0]!.text) as Record<string, unknown>;
     expect(parsed.id).toBe("msg_abc");
-    expect(parsed.from).toBe("alice@example.com");
+    expect(parsed.from_).toBe("alice@example.com");
+    expect(parsed).not.toHaveProperty("from");
     expect(parsed.text).toBe("hello world");
     // Critical: attachments surfaced as metadata-only (no `data`)
     // — bytes blow the LLM's context if returned here. Same reason
@@ -786,7 +787,7 @@ describe("e2a MCP server", () => {
       limit: 10,
     });
     const payload = JSON.parse((res.content as Array<{ text: string }>)[0].text);
-    expect(payload.deliveries[0].webhookId).toBe("wh_abc");
+    expect(payload.deliveries[0].webhook_id).toBe("wh_abc");
   });
 
   it("update_agent sends the name and uses bound agent by default", async () => {
@@ -849,7 +850,7 @@ describe("e2a MCP server", () => {
     expect(JSON.parse(content[0]!.text)).toEqual({
       deleted: true,
       email: "bot@example.com",
-      messagesDeleted: 0,
+      messages_deleted: 0,
     });
   });
 
@@ -894,7 +895,7 @@ describe("e2a MCP server", () => {
     // The returned shape must surface the DNS records so the LLM can
     // hand them to a DNS-provider MCP. If a future SDK change drops
     // them from the response, this test trips immediately.
-    expect(content[0]?.text).toContain("dnsRecords");
+    expect(content[0]?.text).toContain("dns_records");
     expect(content[0]?.text).toContain("mx.e2a.dev");
     expect(content[0]?.text).toContain("tok_new");
   });
@@ -918,7 +919,7 @@ describe("e2a MCP server", () => {
     const content = res.content as Array<{ type: string; text: string }>;
     // get_domain is the sending_status poll target after verify_domain.
     expect(content[0]?.text).toContain("mail.acme.com");
-    expect(content[0]?.text).toContain("sendingStatus");
+    expect(content[0]?.text).toContain("sending_status");
   });
 
   it("delete_domain requires confirm:true — schema validator catches the omission", async () => {
@@ -959,8 +960,8 @@ describe("e2a MCP server", () => {
     });
     expect(stub.listApiKeys).toHaveBeenCalledWith({ cursor: "c1", limit: 10 });
     const content = res.content as Array<{ type: string; text: string }>;
-    const body = JSON.parse(content[0]!.text) as { api_keys: Array<{ keyPrefix: string }>; next_cursor?: string };
-    expect(body.api_keys[0]?.keyPrefix).toBe("e2a_agt_abc1");
+    const body = JSON.parse(content[0]!.text) as { api_keys: Array<{ key_prefix: string }>; next_cursor?: string };
+    expect(body.api_keys[0]?.key_prefix).toBe("e2a_agt_abc1");
     expect(body.next_cursor).toBeUndefined();
   });
 
@@ -1564,7 +1565,7 @@ describe("e2a MCP server", () => {
     });
   });
 
-  it("success results are unchanged: no structuredContent", async () => {
+  it("success results use REST-style snake_case without structuredContent", async () => {
     const res = await client.callTool({
       name: "send_message",
       arguments: { to: ["x@example.com"], subject: "s", text: "b" },
@@ -1572,23 +1573,41 @@ describe("e2a MCP server", () => {
     expect(res.isError).toBeFalsy();
     expect(res.structuredContent).toBeUndefined();
     const text = (res.content as Array<{ text: string }>)[0]?.text ?? "";
-    expect(JSON.parse(text)).toMatchObject({ messageId: "msg_sent" });
+    expect(JSON.parse(text)).toEqual({ message_id: "msg_sent", status: "sent" });
+  });
+
+  it("normalizes stable success payload keys recursively while preserving from_", async () => {
+    const res = await runTool(async () => ({
+      messageId: "msg_1",
+      messagesDeleted: 2,
+      from_: "alice@example.com",
+      deliveryMeta: { createdAt: "2026-07-16T00:00:00Z" },
+      attachments: [{ contentType: "text/plain", sizeBytes: 4 }],
+    }));
+
+    expect(JSON.parse(res.content[0]!.text)).toEqual({
+      message_id: "msg_1",
+      messages_deleted: 2,
+      from_: "alice@example.com",
+      delivery_meta: { created_at: "2026-07-16T00:00:00Z" },
+      attachments: [{ content_type: "text/plain", size_bytes: 4 }],
+    });
   });
 
   // ── Templates (beta) ────────────────────────────────────────────
   //
   // The eight template tools are thin pass-throughs over the McpClient's
   // SDK-backed template methods: snake_case tool args (house arg style) map
-  // to camelCase SDK request fields, and results are camelCase SDK views;
-  // the server enforces the create-mode and send-reference exclusivity
-  // rules. These tests pin the arg plumbing and the confirm guard.
+  // to camelCase SDK request fields, then success results return through the
+  // common MCP snake_case boundary. Templates remain explicitly beta; the
+  // server enforces the create-mode and send-reference exclusivity rules.
 
   it("list_templates returns the summary rows", async () => {
     const res = await client.callTool({ name: "list_templates", arguments: {} });
     expect(stub.listTemplates).toHaveBeenCalledOnce();
     const payload = JSON.parse((res.content as Array<{ text: string }>)[0].text);
     expect(payload.templates[0].id).toBe("tmpl_1");
-    expect(payload.templates[0].createdAt).toBe("2026-06-01T00:00:00Z");
+    expect(payload.templates[0].created_at).toBe("2026-06-01T00:00:00Z");
     expect(payload).not.toHaveProperty("next_cursor");
   });
 
@@ -1697,7 +1716,7 @@ describe("e2a MCP server", () => {
     const payload = JSON.parse((res.content as Array<{ text: string }>)[0].text);
     expect(payload.valid).toBe(true);
     expect(payload.rendered.subject).toBe("Welcome, Ada!");
-    expect(payload.suggestedData).toEqual({ name: "Ada" });
+    expect(payload.suggested_data).toEqual({ name: "Ada" });
   });
 
   it("list_starter_templates surfaces the catalog", async () => {


### PR DESCRIPTION
## Summary
- normalize MCP success payloads recursively from SDK camelCase to the REST contract's snake_case
- preserve already-canonical keys and the reserved-word-safe `from_` field
- cover all stable tool families, including nested objects/arrays, deletion results, pagination, domains, webhooks, events, and API keys
- leave structured MCP error responses unchanged

## Verification
- MCP build passes
- 10 test files and 189 tests pass
- MCP type tests pass
- worktree clean