### PR TITLE
fix(api): reject null redelivery webhook id

### DIFF
--- a/internal/httpapi/events.go
+++ b/internal/httpapi/events.go
@@ -1,14 +1,16 @@
 package httpapi
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"log"
 	"net/http"
 	"time"
 
-	"github.com/tokencanopy/e2a/internal/agent"
 	"github.com/danielgtaylor/huma/v2"
+	"github.com/tokencanopy/e2a/internal/agent"
 )
 
 // EventQuery is the resolved filter + cursor position passed to the events
@@ -106,6 +108,25 @@ type RedeliverDelivery struct {
 // RedeliverEventRequest is the redeliver body (WH-6 naming).
 type RedeliverEventRequest struct {
 	WebhookID string `json:"webhook_id,omitempty"`
+}
+
+// UnmarshalJSON preserves the contract distinction between an omitted optional
+// webhook_id (bulk fan-out) and an explicitly null, non-nullable webhook_id.
+func (r *RedeliverEventRequest) UnmarshalJSON(data []byte) error {
+	type plain RedeliverEventRequest
+	var decoded plain
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
+	if raw, ok := fields["webhook_id"]; ok && bytes.Equal(bytes.TrimSpace(raw), []byte("null")) {
+		return errors.New("webhook_id must be a string")
+	}
+	*r = RedeliverEventRequest(decoded)
+	return nil
 }
 
 type RedeliverEventInput struct {

--- a/internal/httpapi/events_test.go
+++ b/internal/httpapi/events_test.go
@@ -107,6 +107,14 @@ func TestRedeliverEventFanout(t *testing.T) {
 	}
 }
 
+func TestRedeliverEventRejectsExplicitNullWebhookID(t *testing.T) {
+	srv := testServer(t)
+	code, body := postJSON(t, srv.URL+"/v1/events/evt_a/redeliver", "good", map[string]any{"webhook_id": nil})
+	if code != http.StatusUnprocessableEntity || errCode(body) != "invalid_request" {
+		t.Fatalf("want 422 invalid_request, got %d %v", code, body)
+	}
+}
+
 // TestEnqueueError_ReportsPendingNotFailure pins the reconciler-backed contract:
 // when the River enqueue seam errors, /test and redelivery must still report
 // success/pending (the row is durable and the periodic reconciler will re-drive it),


### PR DESCRIPTION
## Summary
- distinguish an omitted `webhook_id` from explicit JSON `null` during event redelivery decoding
- preserve `{}` as valid bulk fan-out while rejecting `{\"webhook_id\": null}` with `422 invalid_request`
- add regression coverage for the nullable-contract edge case

## Verification
- focused redelivery tests pass
- full `internal/httpapi` suite passes
- `make spec-check` passes
- worktree clean