### PR TITLE
fix(sdk-ts): finish WSStream on normal close

### DIFF
--- a/sdks/typescript/src/v1/ws.ts
+++ b/sdks/typescript/src/v1/ws.ts
@@ -316,14 +316,17 @@ export class WSStream extends EventEmitter<WSListenerEvents>
     this.listener.on("open", () => this.emit("open"));
     this.listener.on("close", (code, reason) => {
       this.emit("close", code, reason);
-      // A transient close with reconnect disabled emits no "error" (nothing is
-      // fatally wrong) yet the listener schedules no redial — so a pending
-      // next() would hang forever. End iteration cleanly. This is deferred to a
-      // microtask because a fatal close emits its typed "error" synchronously
-      // right after this "close"; letting that run first lets the error path
+      // A normal close is terminal regardless of the reconnect setting. A
+      // transient close is also terminal when reconnect is disabled, because
+      // the listener schedules no redial. End iteration cleanly in both cases
+      // so a pending next() cannot hang forever. This is deferred to a microtask
+      // because a fatal close emits its typed "error" synchronously right after
+      // this "close"; letting that run first lets the error path
       // (finishWithError) win, and finish() then no-ops on the already-closed
-      // stream. Mirrors the Python SDK's reconnect=False behavior.
-      if (!this.reconnectEnabled) queueMicrotask(() => this.finish());
+      // stream. Mirrors the Python SDK's close behavior.
+      if (code === 1000 || !this.reconnectEnabled) {
+        queueMicrotask(() => this.finish());
+      }
     });
     this.listener.on("error", (err) => {
       // Node's EventEmitter THROWS when "error" is emitted with no registered

--- a/sdks/typescript/test/v1/ws.test.ts
+++ b/sdks/typescript/test/v1/ws.test.ts
@@ -441,4 +441,25 @@ describe("WSStream error handling (async-iterator consumers)", () => {
     vi.doUnmock("ws");
     vi.resetModules();
   });
+
+  it("ends iteration cleanly on a normal peer close when reconnect is enabled", async () => {
+    const { stream } = await makeStream(10, /* reconnect */ true);
+    const iterator = stream[Symbol.asyncIterator]();
+    const nextP = iterator.next();
+    let result: IteratorResult<unknown> | undefined;
+    void nextP.then((value) => {
+      result = value;
+    });
+
+    FakeWS.instances[0].serverOpen();
+    FakeWS.instances[0].serverClose(1000, "");
+    await new Promise<void>((resolve) => queueMicrotask(resolve));
+
+    expect(result).toEqual({ value: undefined, done: true });
+    expect(FakeWS.instances).toHaveLength(1); // normal close never redials
+
+    stream.close();
+    vi.doUnmock("ws");
+    vi.resetModules();
+  });
 });


### PR DESCRIPTION
## Summary

- finish `WSStream` async iteration when the peer sends a normal `1000` close, even with reconnect enabled
- preserve reconnect behavior for transient closes and typed-error delivery for fatal closes
- add a regression test covering the default reconnect configuration

## Root cause

`WSListener` treats close code `1000` as terminal and schedules no reconnect, but `WSStream` only settled pending iterators when reconnect was disabled. With the default `reconnect: true`, a pending `next()` therefore waited forever after a normal peer close.

## Validation

- `npm test --workspace @e2a/sdk` — 179 tests passed
- `npm run build --workspace @e2a/sdk`
- regression test verified red before the implementation and green afterward
