### PR TITLE
fix(cli): isolate listen forward transport failures

### DIFF
--- a/cli/src/__tests__/listen.test.ts
+++ b/cli/src/__tests__/listen.test.ts
@@ -263,6 +263,32 @@ describe("listen notification handling", () => {
     expect(mockStdout).toHaveBeenCalledWith(`${JSON.stringify(full)}\n`);
   });
 
+  it("prints JSON when the independent forward side channel rejects", async () => {
+    const full = {
+      id: "msg_123",
+      subject: "Hello",
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("connection refused")),
+    );
+    const client = {
+      messages: { get: vi.fn().mockResolvedValue(full), reply: vi.fn() },
+    } as any;
+
+    await expect(
+      handleNotification(client, "bot@agents.e2a.dev", makeNotification(), {
+        json: true,
+        forward: "http://127.0.0.1:1/webhook",
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(mockStdout).toHaveBeenCalledWith(`${JSON.stringify(full)}\n`);
+    expect(mockStderr).toHaveBeenCalledWith(
+      "Forward failed: connection refused\n",
+    );
+  });
+
   it("forwards to OpenClaw and auto-replies when text is returned", async () => {
     // No parsed/body text — exercise the rawMessage decode fallback.
     const raw = "Subject: Hello\r\n\r\nHi there!";
@@ -331,6 +357,74 @@ describe("listen notification handling", () => {
     expect(mockStderr).toHaveBeenCalledWith(
       "Replied to alice@example.com (msg_123)\n",
     );
+  });
+});
+
+describe("listen --once forwarding failures", () => {
+  afterEach(() => {
+    vi.doUnmock("../sdk.js");
+    vi.resetModules();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("renders the matching message and exits after a forward transport error", async () => {
+    vi.resetModules();
+
+    const full = { id: "msg_123", subject: "Hello" };
+    const fakeStream = {
+      on: vi.fn(),
+      close: vi.fn(),
+      async *[Symbol.asyncIterator]() {
+        yield {
+          type: "email.received",
+          id: "evt_123",
+          schema_version: "1",
+          created_at: "2025-01-15T10:30:00Z",
+          data: makeNotification(),
+        };
+      },
+    };
+    const client = {
+      listen: vi.fn(() => fakeStream),
+      messages: {
+        get: vi.fn().mockResolvedValue(full),
+        reply: vi.fn(),
+      },
+    };
+    vi.doMock("../sdk.js", () => ({
+      createClient: () => client,
+      requireAgentEmail: (agent?: string) =>
+        agent ?? "bot@agents.e2a.dev",
+    }));
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("connection refused")),
+    );
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockImplementation(() => true);
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockImplementation(() => true);
+
+    const { listen } = await import("../commands/listen.js");
+    await listen({
+      agent: "bot@agents.e2a.dev",
+      once: true,
+      json: true,
+      forward: "http://127.0.0.1:1/webhook",
+    });
+
+    expect(stdoutSpy).toHaveBeenCalledTimes(1);
+    expect(stdoutSpy).toHaveBeenCalledWith(`${JSON.stringify(full)}\n`);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Forward failed: connection refused\n",
+    );
+    expect(stderrSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("Error handling message"),
+    );
+    expect(fakeStream.close).toHaveBeenCalled();
   });
 });
 

--- a/cli/src/commands/listen.ts
+++ b/cli/src/commands/listen.ts
@@ -305,11 +305,18 @@ export async function forwardMessage(
     }
   }
 
-  const res = await fetch(forwardUrl, {
-    method: "POST",
-    headers,
-    body: fetchBody,
-  });
+  let res: Response;
+  try {
+    res = await fetch(forwardUrl, {
+      method: "POST",
+      headers,
+      body: fetchBody,
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`Forward failed: ${message}\n`);
+    return;
+  }
 
   if (!res.ok) {
     process.stderr.write(

--- a/docs/superpowers/plans/2026-07-16-listen-forward-transport-errors.md
+++ b/docs/superpowers/plans/2026-07-16-listen-forward-transport-errors.md
@@ -1,0 +1,69 @@
+# Listen Forward Transport Errors Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep listener output and `--once` completion working when the forwarding HTTP request is rejected before receiving a response.
+
+**Architecture:** Normalize transport rejection at the shared `forwardMessage` boundary, where non-2xx failures are already converted to stderr diagnostics. Leave message retrieval and successful response handling unchanged.
+
+**Tech Stack:** TypeScript, Node.js `fetch`, Vitest
+
+---
+
+### Task 1: Lock down transport-failure behavior
+
+**Files:**
+- Test: `cli/src/__tests__/listen.test.ts`
+
+- [ ] **Step 1: Add a failing notification regression test**
+
+Add a test that stubs `fetch` to reject with `Error("connection refused")`, calls
+`handleNotification` with both `json` and `forward`, and expects JSON on stdout
+plus `Forward failed: connection refused` on stderr.
+
+- [ ] **Step 2: Add a failing `--once` regression test**
+
+Mock `createClient` with a one-event async stream, invoke `listen` with `once`,
+`json`, and `forward`, and assert one JSON line is written and the stream closes
+even though `fetch` rejects.
+
+- [ ] **Step 3: Verify red**
+
+Run: `npm test --workspace @e2a/cli -- --run src/__tests__/listen.test.ts`
+
+Expected: both new tests fail because the rejection escapes before rendering.
+
+### Task 2: Normalize forwarding transport errors
+
+**Files:**
+- Modify: `cli/src/commands/listen.ts`
+
+- [ ] **Step 1: Add the minimal catch**
+
+Wrap only the `fetch(forwardUrl, ...)` call in `try/catch`. On rejection, derive
+the message with `err instanceof Error ? err.message : String(err)`, write
+`Forward failed: ${message}\n` to stderr, and return.
+
+- [ ] **Step 2: Verify green**
+
+Run: `npm test --workspace @e2a/cli -- --run src/__tests__/listen.test.ts`
+
+Expected: the listen test file passes.
+
+- [ ] **Step 3: Verify the complete slice**
+
+Run: `npm test --workspace @e2a/cli`
+
+Expected: all CLI tests pass.
+
+Run: `npm run build --workspace @e2a/cli`
+
+Expected: TypeScript compilation succeeds.
+
+- [ ] **Step 4: Commit**
+
+Stage the command, tests, design, and plan, then commit with:
+
+```text
+fix(cli): isolate listen forward transport failures
+```

--- a/docs/superpowers/specs/2026-07-16-listen-forward-transport-errors-design.md
+++ b/docs/superpowers/specs/2026-07-16-listen-forward-transport-errors-design.md
@@ -1,0 +1,46 @@
+# Listen Forward Transport Error Design
+
+## Problem statement
+
+PR #497 made `--forward` independent from JSON selection, but a rejected
+network request still escapes `forwardMessage`. Because callers await the
+forward before rendering, a transport error suppresses requested output and,
+under `--once`, prevents the matching message from completing the wait.
+
+## Goals and non-goals
+
+- Preserve JSON/text/TSV rendering and `--once` completion when the forwarding
+  endpoint cannot be reached.
+- Report the forwarding failure on stderr, consistent with non-2xx responses.
+- Preserve successful generic and OpenClaw forwarding behavior.
+- Do not add retries, change exit codes, or alter message-fetch failures.
+
+## Proposed design
+
+Handle only `fetch` transport rejections inside `forwardMessage`. Convert the
+unknown rejection to a readable message, write `Forward failed: <message>` to
+stderr, and return. Keep message retrieval outside the catch because rendering
+also depends on retrieval and SDK errors should retain their existing mapping.
+
+This shared boundary covers continuous listening and `--once` without adding
+duplicated caller-level catches. It also matches the existing treatment of
+non-2xx forward responses, which are reported and returned rather than thrown.
+
+## Failure handling
+
+- Rejected `fetch`: log and return; callers continue rendering/completing.
+- Non-2xx response: retain the existing status/body diagnostic.
+- Message retrieval failure: continue throwing because no payload is available.
+- Successful OpenClaw response: retain response parsing and auto-reply behavior.
+
+## Verification strategy
+
+- Add a `handleNotification` regression test proving rejected forwarding still
+  emits JSON and reports the error.
+- Add a `listen({ once: true, json: true, forward: ... })` regression test proving
+  the first matching message renders once and closes the stream after rejection.
+- Run the focused listen tests, the full CLI test suite, and the CLI build.
+
+## Open questions
+
+None. Retry and exit-code policy remain intentionally out of scope.


### PR DESCRIPTION
## Summary

- keep `--json`, `--text`, and `--once` behavior independent from forwarding transport failures
- report rejected forwarding requests on stderr, matching existing non-2xx handling
- add regression coverage for continuous notification handling and `--once`

## Root cause

PR #497 made forwarding an independent side channel by invoking it before rendering, but `forwardMessage` still allowed a rejected `fetch` to escape. That skipped rendering and, under `--once`, left the matched message incomplete so the listener continued waiting.

This follow-up catches only the outbound HTTP transport rejection inside `forwardMessage`. Message retrieval errors and successful generic/OpenClaw behavior remain unchanged.

## Test plan

- [x] Red/green verification for rejected `fetch` in JSON notification handling
- [x] Red/green verification for `listen --once --json --forward`
- [x] `npm test` in `cli` — 117 passed
- [x] `npm run build` in `cli`

Follow-up to #497.
