### PR TITLE
fix(api): finish createApiKey idempotency surfaces

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -3677,12 +3677,30 @@ paths:
           headers:
             X-Request-Id:
               $ref: "#/components/headers/XRequestID"
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: "Conflict — code idempotency_in_flight: a request with this Idempotency-Key is still executing. Retry-able: wait for the first request to finish, then retry with the SAME key and byte-identical body — the retry replays the first request's response instead of re-executing the side effect."
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/XRequestID"
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: "Unprocessable — branch on error.code. idempotency_key_reuse: this Idempotency-Key was already used with a DIFFERENT request body (the dedup hash covers the route + the raw body bytes) — do NOT retry as-is; a legitimate retry must resend the byte-identical body, and a genuinely new request needs a fresh key. invalid_request: a semantic validation failure in the request body."
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/XRequestID"
         default:
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorEnvelope"
-          description: Error
+          description: Error — the standard envelope; branch on error.code.
           headers:
             X-Request-Id:
               $ref: "#/components/headers/XRequestID"

--- a/docs/api.md
+++ b/docs/api.md
@@ -40,9 +40,9 @@ MCP tool surface), see:
   hand-rolled clients must do it themselves.
 - **Pagination.** List endpoints return `{ items, next_cursor }`; pass
   `next_cursor` back as `?cursor=…` to page forward. The SDKs auto-page.
-- **Idempotency.** Five mutating operations honor an opt-in `Idempotency-Key`
+- **Idempotency.** Six mutating operations honor an opt-in `Idempotency-Key`
   header: `sendMessage`, `replyToMessage`, `forwardMessage`, `approveReview`,
-  and `rotateWebhookSecret`. Semantics:
+  `rotateWebhookSecret`, and `createApiKey`. Semantics:
   - **Replay.** A retry with the same key and a **byte-identical** body replays
     the first request's response instead of re-executing the side effect (the
     dedup hash covers the route + the raw body bytes, so the same key on a

--- a/internal/httpapi/apikeys.go
+++ b/internal/httpapi/apikeys.go
@@ -85,6 +85,11 @@ func (s *Server) registerAPIKeys() {
 		Summary: "Create an API key", Tags: []string{"account"},
 		Description: "Mint a new API key; the plaintext key is returned once. scope=account is workspace admin (agent/domain/key management); scope=agent binds the key to one inbox so it can act only as that agent. Account scope only.",
 		Security:    []map[string][]string{{"bearer": {}}}, DefaultStatus: http.StatusCreated,
+		Responses: map[string]*huma.Response{
+			"409":     s.idempotencyInFlightResponse(),
+			"422":     s.idempotencyReuseResponse(),
+			"default": s.errorEnvelopeResponse(),
+		},
 	}, s.handleCreateAPIKey)
 
 	huma.Register(s.API, huma.Operation{

--- a/internal/httpapi/idempotency.go
+++ b/internal/httpapi/idempotency.go
@@ -34,8 +34,9 @@ const (
 
 // runIdempotent executes fn under a caller-supplied `Idempotency-Key` header
 // and returns the (status, body) to emit. It is the one place the v1 write
-// endpoints (send/reply/forward/approve) get retry-safety, replacing the
-// legacy capturingWriter (which doesn't fit Huma's return-value handler model).
+// endpoints (send/reply/forward/approve/rotate-secret/create-api-key) get
+// retry-safety, replacing the legacy capturingWriter (which doesn't fit
+// Huma's return-value handler model).
 //
 // Semantics (api-v1-redesign §4 decision 8):
 //   - No key, or no store wired → just run fn (idempotency is opt-in).

--- a/internal/httpapi/outbound.go
+++ b/internal/httpapi/outbound.go
@@ -67,7 +67,8 @@ func (s *Server) rateLimitedResponse() *huma.Response {
 }
 
 // idempotencyInFlightResponse is the declared 409 for every operation that
-// honors the Idempotency-Key header (send/reply/forward/approve/rotate-secret):
+// honors the Idempotency-Key header
+// (send/reply/forward/approve/rotate-secret/create-api-key):
 // a request with the same key is still executing. It is RETRY-ABLE — the retry
 // contract is the opposite of the 422 below, so the two must stay separately
 // documented on every keyed operation.

--- a/internal/httpapi/spec_review_test.go
+++ b/internal/httpapi/spec_review_test.go
@@ -72,6 +72,26 @@ func TestSpecOutboundIdempotencyDocumentsResponseLoss(t *testing.T) {
 	}
 }
 
+// Every operation that honors Idempotency-Key must publish the two distinct
+// error branches callers need to handle: 409 is retryable after the in-flight
+// request completes, while 422 means the key was reused for a different
+// request and must not be retried as-is.
+func TestSpecIdempotencyResponsesDeclared(t *testing.T) {
+	doc := renderSpec(t)
+	for _, operationID := range []string{
+		"sendMessage", "replyToMessage", "forwardMessage", "approveReview",
+		"rotateWebhookSecret", "createApiKey",
+	} {
+		resp := operationResponses(t, doc, operationID)
+		for _, code := range []string{"409", "422"} {
+			if ref := responseSchemaRef(resp, code); ref != "#/components/schemas/ErrorEnvelope" {
+				t.Errorf("%s: %s must be declared with ErrorEnvelope, got %q; codes=%v",
+					operationID, code, ref, keysOf(resp))
+			}
+		}
+	}
+}
+
 // schemaProps returns the properties map of a named component schema.
 func schemaProps(t *testing.T, doc map[string]any, schemaName string) map[string]any {
 	t.Helper()

--- a/sdks/python/src/e2a/v1/_retry.py
+++ b/sdks/python/src/e2a/v1/_retry.py
@@ -6,7 +6,8 @@ exposes no such seam — its ``ApiClient`` builds its own client — so we retry
 the hand-written resource layer instead:
 
 * Mint an ``Idempotency-Key`` ONCE per write and pass it (via ``_headers``) on
-  every attempt, so the server dedupes a retried send/reply/forward/approve.
+  every attempt, so the server dedupes a retried send/reply/forward/approve or
+  API-key creation.
 * Retry only the SAFE subset on a retryable failure: reads, the server-deduped
   keyed writes, and HTTP-idempotent writes (PUT/PATCH/DELETE). A bare,
   non-idempotent POST (create/reject/redeliver/test) is NOT retried on an

--- a/sdks/python/src/e2a/v1/client.py
+++ b/sdks/python/src/e2a/v1/client.py
@@ -232,7 +232,8 @@ class AsyncE2AClient:
         return await request_with_retry(make, cfg=self._cfg, retryable=True, idempotency=False)
 
     async def _write_keyed(self, make: _Make, idempotency_key: Optional[str]) -> Any:
-        # send/reply/forward/approve: server dedupes on the key → safe to retry.
+        # send/reply/forward/approve/create-api-key: the server dedupes on the
+        # key, so retrying the same serialized request is safe.
         return await request_with_retry(
             make, cfg=self._cfg, retryable=True, idempotency=True, idempotency_key=idempotency_key
         )
@@ -786,12 +787,16 @@ class APIKeysResource:
 
         return AutoPager(fetch)
 
-    async def create(self, body: Body) -> CreateAPIKeyResponse:
-        # Returns the one-time plaintext key in `.key` — store it now. Not
-        # retried (mirrors webhooks.create): minting a secret isn't safely
-        # replayable.
+    async def create(
+        self, body: Body, *, idempotency_key: Optional[str] = None
+    ) -> CreateAPIKeyResponse:
+        # Returns the one-time plaintext key in `.key` — store it now. The
+        # server replays the same credential for a keyed retry, so the SDK can
+        # safely retry an ambiguous transport failure without minting twice.
         req = _coerce(CreateAPIKeyRequest, body)
-        return await self._c._write_unsafe(lambda h: self._api.create_api_key(req, _headers=h))
+        return await self._c._write_keyed(
+            lambda h: self._api.create_api_key(req, _headers=h), idempotency_key
+        )
 
     async def delete(self, key_id: str) -> DeleteApiKeyResult:
         # Returns the deletion object ({deleted, id}).

--- a/sdks/python/src/e2a/v1/generated/api/account_api.py
+++ b/sdks/python/src/e2a/v1/generated/api/account_api.py
@@ -106,6 +106,8 @@ class AccountApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '201': "CreateAPIKeyResponse",
+            '409': "ErrorEnvelope",
+            '422': "ErrorEnvelope",
         }
         response_data = await self.api_client.call_api(
             *_param,
@@ -177,6 +179,8 @@ class AccountApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '201': "CreateAPIKeyResponse",
+            '409': "ErrorEnvelope",
+            '422': "ErrorEnvelope",
         }
         response_data = await self.api_client.call_api(
             *_param,
@@ -248,6 +252,8 @@ class AccountApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '201': "CreateAPIKeyResponse",
+            '409': "ErrorEnvelope",
+            '422': "ErrorEnvelope",
         }
         response_data = await self.api_client.call_api(
             *_param,

--- a/sdks/python/tests/test_v1_client.py
+++ b/sdks/python/tests/test_v1_client.py
@@ -27,6 +27,7 @@ from e2a.v1.generated.models import (
     APIKeyView,
     AttachmentView,
     ConversationSummaryView,
+    CreateAPIKeyResponse,
     DomainView,
     EventJSON,
     ErrorBody,
@@ -432,6 +433,53 @@ async def test_send_uses_caller_idempotency_key(httpx_mock):
             idempotency_key="caller-key-123",
         )
     assert httpx_mock.get_requests()[-1].headers["Idempotency-Key"] == "caller-key-123"
+
+
+@pytest.mark.anyio
+async def test_create_api_key_retries_with_one_idempotency_key(httpx_mock):
+    httpx_mock.add_response(
+        status_code=503,
+        json={"error": {"code": "internal_error", "message": "down", "request_id": "req_1"}},
+    )
+    httpx_mock.add_response(
+        status_code=201,
+        json=_valid(
+            CreateAPIKeyResponse,
+            id="apk_1",
+            key="e2a_account_secret",
+            key_prefix="e2a_acct_abcd",
+            scope="account",
+        ),
+    )
+
+    async with _client() as c:
+        created = await c.account.api_keys.create({"name": "ci"})
+
+    assert created.id == "apk_1"
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 2
+    keys = [request.headers.get("Idempotency-Key") for request in requests]
+    assert keys[0]
+    assert keys[1] == keys[0]
+
+
+@pytest.mark.anyio
+async def test_create_api_key_uses_caller_idempotency_key(httpx_mock):
+    httpx_mock.add_response(
+        status_code=201,
+        json=_valid(
+            CreateAPIKeyResponse,
+            id="apk_1",
+            key="e2a_account_secret",
+            key_prefix="e2a_acct_abcd",
+            scope="account",
+        ),
+    )
+
+    async with _client() as c:
+        await c.account.api_keys.create({"name": "ci"}, idempotency_key="create-key-123")
+
+    assert httpx_mock.get_requests()[-1].headers["Idempotency-Key"] == "create-key-123"
 
 
 @pytest.mark.anyio

--- a/sdks/typescript/src/v1/generated/apis/AccountApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/AccountApi.ts
@@ -387,12 +387,26 @@ export class AccountApiResponseProcessor {
             ) as CreateAPIKeyResponse;
             return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
+        if (isCodeInRange("409", response.httpStatusCode)) {
+            const body: ErrorEnvelope = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "ErrorEnvelope", ""
+            ) as ErrorEnvelope;
+            throw new ApiException<ErrorEnvelope>(response.httpStatusCode, "Conflict — code idempotency_in_flight: a request with this Idempotency-Key is still executing. Retry-able: wait for the first request to finish, then retry with the SAME key and byte-identical body — the retry replays the first request\&#39;s response instead of re-executing the side effect.", body, response.headers);
+        }
+        if (isCodeInRange("422", response.httpStatusCode)) {
+            const body: ErrorEnvelope = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "ErrorEnvelope", ""
+            ) as ErrorEnvelope;
+            throw new ApiException<ErrorEnvelope>(response.httpStatusCode, "Unprocessable — branch on error.code. idempotency_key_reuse: this Idempotency-Key was already used with a DIFFERENT request body (the dedup hash covers the route + the raw body bytes) — do NOT retry as-is; a legitimate retry must resend the byte-identical body, and a genuinely new request needs a fresh key. invalid_request: a semantic validation failure in the request body.", body, response.headers);
+        }
         if (isCodeInRange("0", response.httpStatusCode)) {
             const body: ErrorEnvelope = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "ErrorEnvelope", ""
             ) as ErrorEnvelope;
-            throw new ApiException<ErrorEnvelope>(response.httpStatusCode, "Error", body, response.headers);
+            throw new ApiException<ErrorEnvelope>(response.httpStatusCode, "Error — the standard envelope; branch on error.code.", body, response.headers);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/sdks/typescript/src/v1/retry.ts
+++ b/sdks/typescript/src/v1/retry.ts
@@ -145,7 +145,8 @@ export class RetryHttpLibrary implements HttpLibrary {
   //   - HTTP-idempotent writes (PUT/PATCH/DELETE) — repeating reaches the same
   //     end state — EXCEPT account deletion, which is irreversible and whose
   //     post-success retry would surface a spurious 404 to the caller;
-  //   - server-deduped POSTs (send/reply/forward/approve, rotate-secret),
+  //   - server-deduped POSTs (send/reply/forward/approve, rotate-secret,
+  //     create-api-key),
   //     recognised by the Idempotency-Key header the generated layer emits ONLY
   //     for those ops — the server replays the first result on a keyed retry.
   // Every other POST (create agent/domain/webhook, reject, verify, redeliver,
@@ -172,7 +173,7 @@ export class RetryHttpLibrary implements HttpLibrary {
   }
 
   // The generated layer sets an Idempotency-Key header param (possibly an empty
-  // stub) on exactly the four server-deduped POSTs. Its mere presence — not its
+  // stub) on the server-deduped POSTs. Its mere presence — not its
   // value — marks an op the server will dedupe, hence safe to retry.
   private hasIdempotencyHeader(request: RequestContext): boolean {
     const headers = request.getHeaders();
@@ -216,8 +217,8 @@ export class RetryHttpLibrary implements HttpLibrary {
   // means every retry of this request reuses the same key.
   //
   // The generated layer calls setHeaderParam("Idempotency-Key", serialize(undefined))
-  // on send/reply/forward/approve, leaving the header *present but empty* when the
-  // caller passed no key. So "present" isn't enough to mean "caller-supplied" —
+  // on send/reply/forward/approve/create-api-key, leaving the header *present but
+  // empty* when the caller passed no key. So "present" isn't enough to mean "caller-supplied" —
   // only a non-empty value counts; otherwise we mint (overwriting the empty stub).
   private ensureIdempotencyKey(request: RequestContext): void {
     if (request.getHttpMethod() !== HttpMethod.POST) return;

--- a/sdks/typescript/test/v1/retry.test.ts
+++ b/sdks/typescript/test/v1/retry.test.ts
@@ -44,15 +44,16 @@ class FakeHttp implements HttpLibrary {
 }
 
 const noSleep = async () => {};
-// A server-deduped POST (send/reply/forward/approve): the generated layer emits
-// an empty Idempotency-Key stub, which marks the op safe to retry.
+// A server-deduped POST (send/reply/forward/approve/rotate-secret/create-api-key):
+// the generated layer emits an empty Idempotency-Key stub, which marks the op
+// safe to retry.
 const post = () => {
   const r = new RequestContext("https://api.e2a.dev/v1/agents/a@x.com/messages", HttpMethod.POST);
   r.setHeaderParam("Idempotency-Key", ""); // empty generated stub
   return r;
 };
 // A bare, non-idempotent POST (create agent/domain/webhook, reject, redeliver,
-// verify, test, rotate-secret): no server-honored key — must NOT be retried.
+// verify, test): no server-honored key — must NOT be retried.
 const barePost = (url = "https://api.e2a.dev/v1/agents") =>
   new RequestContext(url, HttpMethod.POST);
 const get = () => new RequestContext("https://api.e2a.dev/v1/agents/a@x.com/messages", HttpMethod.GET);


### PR DESCRIPTION
## Summary

- route Python `account.api_keys.create` through the keyed retry executor, with an optional caller-supplied stable key
- declare the `409 idempotency_in_flight` and `422 idempotency_key_reuse` responses on `createApiKey` and regenerate both SDK bases
- update the frozen API documentation and retry comments to list all six keyed operations

## Why

PR #495 added server-side replay protection, but the high-level Python SDK still treated API-key creation as an unsafe, non-keyed POST. An ambiguous transport failure therefore left Python callers unable to retry safely. The OpenAPI operation also described the two idempotency errors without declaring their response statuses.

## Developer impact

`await client.account.api_keys.create(body)` now mints one idempotency key and reuses it across automatic retries. Callers that need process-stable deduplication can pass `idempotency_key=...` explicitly.

## Test plan

- [x] `go test -short ./internal/httpapi`
- [x] `sdks/python/.venv/bin/pytest -q` — 312 passed, 18 skipped
- [x] `npm test` in `sdks/typescript` — 173 tests passed plus type checks
- [x] `make generate-sdk-check`
- [x] independent code review

Follow-up to #495 and #493.
