### PR TITLE
fix: complete notification suppression surfaces

### DIFF
--- a/cli/src/__tests__/protection.test.ts
+++ b/cli/src/__tests__/protection.test.ts
@@ -22,7 +22,7 @@ function makeDoc() {
       gate: { policy: "allowlist", allowlist: ["trusted@x.com"], action: "review" },
       scan: { sensitivity: "medium" },
     },
-    holds: { ttlSeconds: 3600, onExpiry: "approve" },
+    holds: { ttlSeconds: 3600, onExpiry: "approve", suppressNotifications: false },
   };
 }
 
@@ -72,6 +72,20 @@ describe("protection commands", () => {
     expect(put.inbound.scan.sensitivity).toBe("high"); // untouched
   });
 
+  it("set --suppress-notifications on changes only notification delivery", async () => {
+    mockGetProtection.mockResolvedValue(makeDoc());
+    mockReplaceProtection.mockImplementation(async (_email: string, doc: unknown) => doc);
+    const { protectionSet } = await import("../commands/protection.js");
+    await protectionSet("bot@agents.e2a.dev", { suppressNotifications: "on" });
+
+    const put = mockReplaceProtection.mock.calls[0][1];
+    expect(put.holds.suppressNotifications).toBe(true);
+    expect(put.inbound).toEqual(makeDoc().inbound);
+    expect(put.outbound).toEqual(makeDoc().outbound);
+    expect(put.holds.ttlSeconds).toBe(3600);
+    expect(put.holds.onExpiry).toBe("approve");
+  });
+
   it("set --outbound-review on re-enables a disabled scan (off→on round-trip restores holding)", async () => {
     // Under gate policy "open" every sender matches, so the gate action never
     // fires — HITL "on" without a scan would look on while holding nothing.
@@ -104,6 +118,7 @@ describe("protection commands", () => {
     await expect(protectionSet(undefined, { outboundReview: "off" })).rejects.toThrow("process.exit");
     await expect(protectionSet("a@b.c", {})).rejects.toThrow("process.exit");
     await expect(protectionSet("a@b.c", { outboundReview: "sideways" })).rejects.toThrow("process.exit");
+    await expect(protectionSet("a@b.c", { suppressNotifications: "sideways" })).rejects.toThrow("process.exit");
     expect(mockExit).toHaveBeenCalledWith(2);
     expect(mockGetProtection).not.toHaveBeenCalled();
   });
@@ -117,6 +132,7 @@ describe("protection commands", () => {
     expect(output).toContain("outbound: gate=allowlist/review scan=medium");
     expect(output).toContain("inbound:  gate=open/review scan=high");
     expect(output).toContain("holds:    ttl=3600s on_expiry=approve");
+    expect(output).toContain("notifications=enabled");
 
     mockStdout.mockClear();
     await protectionGet("bot@agents.e2a.dev", { json: true });

--- a/cli/src/bin/e2a.ts
+++ b/cli/src/bin/e2a.ts
@@ -53,6 +53,7 @@ Usage:
   e2a protection set <email>        Flip review posture, only the named knobs
         --outbound-review on|off   off = sends go out unheld (gate=flag, scan=off)
         --inbound-review on|off    off = inbound delivered unheld
+        --suppress-notifications on|off   silence or enable hold-review emails
   e2a send [options]                Send an email as the agent
         --to <email>               Recipient (repeatable)
         --subject <s>              Subject line
@@ -303,15 +304,16 @@ async function main() {
         checkFlags(rest, ["--json"]);
         await protectionGet(getPositionals(rest)[0], { json: hasFlag(rest, "--json") });
       } else if (sub === "set") {
-        checkFlags(rest, ["--outbound-review", "--inbound-review", "--json"]);
+        checkFlags(rest, ["--outbound-review", "--inbound-review", "--suppress-notifications", "--json"]);
         await protectionSet(getPositionals(rest)[0], {
           outboundReview: getFlagChecked(rest, "--outbound-review"),
           inboundReview: getFlagChecked(rest, "--inbound-review"),
+          suppressNotifications: getFlagChecked(rest, "--suppress-notifications"),
           json: hasFlag(rest, "--json"),
         });
       } else {
         process.stderr.write(
-          "Usage: e2a protection [get <email>|set <email> [--outbound-review on|off] [--inbound-review on|off]]\n",
+          "Usage: e2a protection [get <email>|set <email> [--outbound-review on|off] [--inbound-review on|off] [--suppress-notifications on|off]]\n",
         );
         process.exit(EXIT.USAGE);
       }

--- a/cli/src/commands/protection.ts
+++ b/cli/src/commands/protection.ts
@@ -13,12 +13,13 @@ export interface ProtectionGetOptions {
 export interface ProtectionSetOptions {
   outboundReview?: string;
   inboundReview?: string;
+  suppressNotifications?: string;
   json?: boolean;
 }
 
 const GET_USAGE = "usage: e2a protection get <agent-email> [--json]";
 const SET_USAGE =
-  "usage: e2a protection set <agent-email> [--outbound-review on|off] [--inbound-review on|off] [--json]";
+  "usage: e2a protection set <agent-email> [--outbound-review on|off] [--inbound-review on|off] [--suppress-notifications on|off] [--json]";
 
 function summarize(config: ProtectionConfigView): string {
   const dir = (d: ProtectionDirectionView) =>
@@ -26,7 +27,7 @@ function summarize(config: ProtectionConfigView): string {
   return (
     `outbound: ${dir(config.outbound)}\n` +
     `inbound:  ${dir(config.inbound)}\n` +
-    `holds:    ttl=${config.holds.ttlSeconds ?? 604800}s on_expiry=${config.holds.onExpiry ?? "reject"}\n`
+    `holds:    ttl=${config.holds.ttlSeconds ?? 604800}s on_expiry=${config.holds.onExpiry ?? "reject"} notifications=${config.holds.suppressNotifications ? "suppressed" : "enabled"}\n`
   );
 }
 
@@ -67,10 +68,14 @@ export async function protectionSet(
   opts: ProtectionSetOptions,
 ): Promise<void> {
   if (!email) fail(EXIT.USAGE, SET_USAGE);
-  for (const v of [opts.outboundReview, opts.inboundReview]) {
+  for (const v of [opts.outboundReview, opts.inboundReview, opts.suppressNotifications]) {
     if (v !== undefined && v !== "on" && v !== "off") fail(EXIT.USAGE, SET_USAGE);
   }
-  if (opts.outboundReview === undefined && opts.inboundReview === undefined) {
+  if (
+    opts.outboundReview === undefined &&
+    opts.inboundReview === undefined &&
+    opts.suppressNotifications === undefined
+  ) {
     fail(EXIT.USAGE, SET_USAGE);
   }
 
@@ -83,6 +88,9 @@ export async function protectionSet(
 
   if (opts.outboundReview) applyReview(config.outbound, opts.outboundReview as "on" | "off");
   if (opts.inboundReview) applyReview(config.inbound, opts.inboundReview as "on" | "off");
+  if (opts.suppressNotifications !== undefined) {
+    config.holds.suppressNotifications = opts.suppressNotifications === "on";
+  }
 
   // ProtectionConfigRequest is the View's field-for-field request twin (the
   // spec splits them only so responses can be additive-open while requests

--- a/internal/agent/outbound_async_test.go
+++ b/internal/agent/outbound_async_test.go
@@ -30,6 +30,13 @@ func (f *fakeOutboundEnqueuer) EnqueueSendTx(_ context.Context, _ pgx.Tx, _ stri
 	return f.jobID, nil
 }
 
+type fakeNotifyEnqueuer struct{ called int }
+
+func (f *fakeNotifyEnqueuer) EnqueueNotifyTx(_ context.Context, _ pgx.Tx, _ string) (int64, error) {
+	f.called++
+	return 123, nil
+}
+
 // fakeAsyncDeliverer is the SMTP submit the SendWorker calls — no network.
 type fakeAsyncDeliverer struct{ out outboundsend.DeliverOutcome }
 
@@ -73,6 +80,27 @@ func setupAsyncAPI(t *testing.T) (*agent.API, *identity.Store, webhookpub.Outbox
 	enq := &fakeOutboundEnqueuer{jobID: 999}
 	api.SetOutboundEnqueuer(enq)
 	return api, store, outbox, enq
+}
+
+func TestHoldForApprovalCore_SuppressedAgentCreatesHoldWithoutNotificationJob(t *testing.T) {
+	api, store, _ := newReviewAPI(t)
+	_, ag := selfAgent(t, store, "suppressedhold")
+	ag.SuppressNotifications = true
+	notify := &fakeNotifyEnqueuer{}
+	api.SetNotifyEnqueuer(notify)
+
+	msg, err := api.HoldForApprovalCore(context.Background(), ag, outbound.SendRequest{
+		To: []string{"review-target@example.test"}, Subject: "held quietly", Body: "body",
+	}, "send", "")
+	if err != nil {
+		t.Fatalf("HoldForApprovalCore: %v", err)
+	}
+	if msg == nil || msg.Status != identity.MessageStatusPendingReview {
+		t.Fatalf("held message = %+v, want pending_review", msg)
+	}
+	if notify.called != 0 {
+		t.Errorf("notification jobs enqueued = %d, want 0", notify.called)
+	}
 }
 
 // TestDeliverOutbound_MissingQueueFailsClosed prevents a regression to the

--- a/internal/hitlnotify/worker_test.go
+++ b/internal/hitlnotify/worker_test.go
@@ -86,6 +86,20 @@ func TestNotifyWorker_MessageGoneIsNoOp(t *testing.T) {
 	}
 }
 
+func TestNotifyWorker_SuppressedAgentIsNoOp(t *testing.T) {
+	pn := pending("msg_suppressed")
+	pn.Agent.SuppressNotifications = true
+	st := &fakeStore{pn: pn}
+	dl := &fakeDeliverer{}
+	w := hitlnotify.NewNotifyWorker(st, dl)
+	if err := w.Work(context.Background(), job("msg_suppressed", 1)); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	if dl.called != 0 || len(st.notified) != 0 {
+		t.Errorf("suppressed agent must be a no-op (deliver=%d notified=%v)", dl.called, st.notified)
+	}
+}
+
 func TestNotifyWorker_ResolvedIsNoOp(t *testing.T) {
 	pn := pending("msg_1")
 	pn.Message.Status = identity.MessageStatusSent // approved/resolved before we notified

--- a/internal/httpapi/protection_test.go
+++ b/internal/httpapi/protection_test.go
@@ -46,6 +46,7 @@ func protectionServer(t *testing.T) (*httptest.Server, *identity.AgentIdentity) 
 			ag.OutboundScanSensitivity = cfg.OutboundScanSensitivity
 			ag.HITLTTLSeconds = cfg.HITLTTLSeconds
 			ag.HITLExpirationAction = cfg.HITLExpirationAction
+			ag.SuppressNotifications = cfg.SuppressNotifications
 			return nil
 		},
 		Legacy: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusTeapot) }),
@@ -69,7 +70,7 @@ func TestProtectionPutGetRoundTrip(t *testing.T) {
 			"gate": map[string]any{"policy": "domain", "allowlist": []string{"acme.com"}, "action": "block"},
 			"scan": map[string]any{"sensitivity": "off"},
 		},
-		"holds": map[string]any{"ttl_seconds": 3600, "on_expiry": "approve"},
+		"holds": map[string]any{"ttl_seconds": 3600, "on_expiry": "approve", "suppress_notifications": true},
 	}
 	code, body := sendJSON(t, "PUT", srv.URL+"/v1/agents/support%40acme.com/protection", "good", put)
 	if code != 200 {
@@ -92,6 +93,9 @@ func TestProtectionPutGetRoundTrip(t *testing.T) {
 	holds, _ := got["holds"].(map[string]any)
 	if holds["on_expiry"] != "approve" {
 		t.Errorf("holds.on_expiry = %v, want approve", holds["on_expiry"])
+	}
+	if holds["suppress_notifications"] != true {
+		t.Errorf("holds.suppress_notifications = %v, want true", holds["suppress_notifications"])
 	}
 }
 

--- a/internal/identity/protection_test.go
+++ b/internal/identity/protection_test.go
@@ -56,6 +56,7 @@ func TestUpdateAgentProtectionRoundTrip(t *testing.T) {
 		OutboundScanSensitivity: identity.SensitivityOff,
 		HITLTTLSeconds:          3600,
 		HITLExpirationAction:    "approve",
+		SuppressNotifications:   true,
 	}
 	if err := store.UpdateAgentProtection(ctx, agentID, userID, cfg); err != nil {
 		t.Fatalf("UpdateAgentProtection: %v", err)
@@ -89,6 +90,9 @@ func TestUpdateAgentProtectionRoundTrip(t *testing.T) {
 	// Holds persisted.
 	if got.HITLTTLSeconds != 3600 || got.HITLExpirationAction != "approve" {
 		t.Errorf("holds not persisted: ttl=%d expiry=%q", got.HITLTTLSeconds, got.HITLExpirationAction)
+	}
+	if !got.SuppressNotifications {
+		t.Error("suppress_notifications was not persisted")
 	}
 }
 

--- a/internal/identity/user_data_rights.go
+++ b/internal/identity/user_data_rights.go
@@ -378,6 +378,7 @@ func scanAgentsForUser(ctx context.Context, tx pgx.Tx, userID string) ([]AgentId
 	rows, err := tx.Query(ctx,
 		`SELECT a.id, a.domain, a.name,
 		        a.hitl_ttl_seconds, a.hitl_expiration_action,
+		        a.suppress_notifications,
 		        a.public, a.created_at, a.user_id,
 		        `+webhookStatusSQL+` AS webhook_status
 		   FROM agent_identities a WHERE a.user_id = $1 ORDER BY a.created_at`, userID)
@@ -390,6 +391,7 @@ func scanAgentsForUser(ctx context.Context, tx pgx.Tx, userID string) ([]AgentId
 		var a AgentIdentity
 		if err := rows.Scan(&a.ID, &a.Domain, &a.Name,
 			&a.HITLTTLSeconds, &a.HITLExpirationAction,
+			&a.SuppressNotifications,
 			&a.Public, &a.CreatedAt, &a.UserID, &a.WebhookStatus); err != nil {
 			return nil, err
 		}

--- a/internal/identity/user_data_rights_test.go
+++ b/internal/identity/user_data_rights_test.go
@@ -129,6 +129,10 @@ func TestExportUserData(t *testing.T) {
 	ctx := context.Background()
 
 	user := seedUserData(t, store, ctx, "exporter")
+	if _, err := pool.Exec(ctx,
+		`UPDATE agent_identities SET suppress_notifications = true WHERE user_id = $1`, user.ID); err != nil {
+		t.Fatalf("enable notification suppression: %v", err)
+	}
 
 	dump, err := store.ExportUserData(ctx, user.ID)
 	if err != nil {
@@ -144,6 +148,9 @@ func TestExportUserData(t *testing.T) {
 	}
 	if len(dump.Agents) != 1 {
 		t.Errorf("agents: got %d, want 1", len(dump.Agents))
+	}
+	if len(dump.Agents) == 1 && !dump.Agents[0].SuppressNotifications {
+		t.Error("exported agent lost suppress_notifications=true")
 	}
 	// The export keys an agent on `email` only. The #436 rename dropped the
 	// redundant `id` (id == email) from every other surface; guard that the

--- a/mcp/src/tools/agents.ts
+++ b/mcp/src/tools/agents.ts
@@ -182,6 +182,10 @@ export function registerAgentTools(server: McpServer, client: McpClient): void {
           .enum(["approve", "reject"])
           .optional()
           .describe("What happens to a held item at TTL expiry."),
+        holds_suppress_notifications: z
+          .boolean()
+          .optional()
+          .describe("When true, keep creating holds but do not email approval notifications."),
       }),
     },
     async (args) =>
@@ -209,6 +213,8 @@ export function registerAgentTools(server: McpServer, client: McpClient): void {
         if (args.holds_ttl_seconds !== undefined) cfg.holds.ttlSeconds = args.holds_ttl_seconds;
         if (args.holds_on_expiry !== undefined)
           cfg.holds.onExpiry = args.holds_on_expiry as typeof cfg.holds.onExpiry;
+        if (args.holds_suppress_notifications !== undefined)
+          cfg.holds.suppressNotifications = args.holds_suppress_notifications;
         // ProtectionConfigRequest is the View's field-for-field request twin
         // (the spec splits them only so responses can be additive-open while
         // requests stay strict), but the generated enum types are nominal, so

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -98,7 +98,7 @@ function makeStubClient(
     getProtection: vi.fn(async (_addr?: string) => ({
       inbound: { gate: { policy: "open", allowlist: [], action: "flag" }, scan: { sensitivity: "off" } },
       outbound: { gate: { policy: "open", allowlist: [], action: "flag" }, scan: { sensitivity: "off" } },
-      holds: { ttlSeconds: 604800, onExpiry: "reject" },
+      holds: { ttlSeconds: 604800, onExpiry: "reject", suppressNotifications: false },
     })),
     updateProtection: vi.fn(async (config: unknown, _addr?: string) => config),
     deleteAgent: vi.fn(async (addr?: string) => ({ deleted: true, email: addr ?? "bot@example.com", messagesDeleted: 0 })),
@@ -815,9 +815,13 @@ describe("e2a MCP server", () => {
   it("update_protection read-modify-writes only the provided fields", async () => {
     await client.callTool({
       name: "update_protection",
-      arguments: { inbound_scan_sensitivity: "high", outbound_gate_policy: "allowlist" },
+      arguments: {
+        inbound_scan_sensitivity: "high",
+        outbound_gate_policy: "allowlist",
+        holds_suppress_notifications: true,
+      },
     });
-    // Reads current config, then writes back with only the two fields changed.
+    // Reads current config, then writes back with only the provided fields changed.
     expect(stub.getProtection).toHaveBeenCalled();
     const [cfg, addr] = stub.updateProtection.mock.calls.at(-1)!;
     expect(cfg.inbound.scan.sensitivity).toBe("high");
@@ -825,6 +829,7 @@ describe("e2a MCP server", () => {
     // Untouched sections keep their current value.
     expect(cfg.inbound.gate.policy).toBe("open");
     expect(cfg.holds.onExpiry).toBe("reject");
+    expect(cfg.holds.suppressNotifications).toBe(true);
     expect(addr).toBeUndefined();
   });
 


### PR DESCRIPTION
Follow-up to #416.

This completes the beta notification-suppression feature by:
- exposing the setting through the CLI and MCP update_protection tool
- preserving suppress_notifications in user data exports
- adding regression coverage for hold creation, queued-worker suppression, HTTP and database round-trips, exports, CLI, and MCP

Verification:
- go test -p 1 ./internal/identity ./internal/agent ./internal/hitlnotify ./internal/httpapi
- npm test --workspace cli
- npm test --workspace mcp
- npm run build --workspace cli
- npm run build --workspace mcp