### PR TITLE
feat(api): version the account-export interior by schema_version (stable envelope, beta interiors)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -46,6 +46,7 @@ components:
         - key_prefix
         - created_at
       type: object
+      x-stability-level: beta
     APIKeyView:
       additionalProperties: true
       properties:
@@ -230,6 +231,7 @@ components:
         - inbound_scan_sensitivity
         - outbound_scan_sensitivity
       type: object
+      x-stability-level: beta
     AgentView:
       additionalProperties: true
       properties:
@@ -923,6 +925,7 @@ components:
         - agent_count
         - sending_status
       type: object
+      x-stability-level: beta
     DomainSendingFailedData:
       additionalProperties: true
       properties:
@@ -1928,6 +1931,7 @@ components:
         - created_at
         - expires_at
       type: object
+      x-stability-level: beta
     MessageBodyView:
       additionalProperties: true
       properties:
@@ -2161,6 +2165,7 @@ components:
         - scope
         - issued_at
       type: object
+      x-stability-level: beta
     PageAPIKeyView:
       additionalProperties: true
       properties:
@@ -2463,6 +2468,7 @@ components:
         - action
         - created_at
       type: object
+      x-stability-level: beta
     ProtectionGateRequest:
       additionalProperties: false
       properties:
@@ -2758,6 +2764,7 @@ components:
         - dkim
         - dmarc
       type: object
+      x-stability-level: beta
     RetryAfterDetails:
       additionalProperties: true
       properties:
@@ -3029,6 +3036,7 @@ components:
         - source
         - created_at
       type: object
+      x-stability-level: beta
     TemplatePartError:
       additionalProperties: true
       properties:
@@ -3269,6 +3277,7 @@ components:
         - type
         - created_at
       type: object
+      x-stability-level: beta
     UserExport:
       additionalProperties: true
       properties:
@@ -3300,6 +3309,7 @@ components:
             $ref: "#/components/schemas/ProtectionEventExportEntry"
           type: array
         schema_version:
+          description: Version of the interior record shapes in this export. The export envelope (the top-level keys and schema_version) is stable; interior record shapes are versioned by schema_version and may evolve — branch on schema_version before interpreting interior records. The current server emits "2".
           type: string
         suppressions:
           items:
@@ -3340,6 +3350,7 @@ components:
         - name
         - created_at
       type: object
+      x-stability-level: beta
     ValidateTemplateRequest:
       additionalProperties: false
       properties:
@@ -3766,7 +3777,7 @@ paths:
         - account
   /v1/account/export:
     get:
-      description: A JSON dump of every record the authenticated account owns.
+      description: "A JSON dump of every record the authenticated account owns. Contract: the export envelope (the top-level keys and schema_version) is stable; the interior record shapes are versioned by schema_version and may evolve — branch on schema_version before interpreting interior records. Interior schemas carry `x-stability-level: beta` in this document to mark that exemption machine-readably; the operation itself is stable GA surface."
       operationId: exportAccount
       responses:
         "200":

--- a/api/testdata/oasdiff/export-base.yaml
+++ b/api/testdata/oasdiff/export-base.yaml
@@ -1,0 +1,57 @@
+openapi: 3.1.0
+info:
+  title: Compatibility fixture (account-export versioned interior)
+  version: "1"
+paths:
+  /v1/account/export:
+    get:
+      operationId: exportAccount
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserExport"
+  /v1/things:
+    get:
+      operationId: listThings
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Shared"
+components:
+  schemas:
+    UserExport:
+      type: object
+      additionalProperties: true
+      required: [schema_version, agents]
+      properties:
+        schema_version:
+          type: string
+        agents:
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentIdentity"
+        shared:
+          $ref: "#/components/schemas/Shared"
+    AgentIdentity:
+      type: object
+      additionalProperties: true
+      required: [email, internal_detail]
+      properties:
+        email:
+          type: string
+        internal_detail:
+          type: string
+      x-stability-level: beta
+    Shared:
+      type: object
+      additionalProperties: true
+      required: [name]
+      properties:
+        name:
+          type: string

--- a/api/testdata/oasdiff/export-envelope-key-removed.yaml
+++ b/api/testdata/oasdiff/export-envelope-key-removed.yaml
@@ -1,0 +1,55 @@
+openapi: 3.1.0
+info:
+  title: Compatibility fixture (account-export versioned interior)
+  version: "1"
+paths:
+  /v1/account/export:
+    get:
+      operationId: exportAccount
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserExport"
+  /v1/things:
+    get:
+      operationId: listThings
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Shared"
+components:
+  schemas:
+    UserExport:
+      type: object
+      additionalProperties: true
+      required: [agents]
+      properties:
+        agents:
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentIdentity"
+        shared:
+          $ref: "#/components/schemas/Shared"
+    AgentIdentity:
+      type: object
+      additionalProperties: true
+      required: [email, internal_detail]
+      properties:
+        email:
+          type: string
+        internal_detail:
+          type: string
+      x-stability-level: beta
+    Shared:
+      type: object
+      additionalProperties: true
+      required: [name]
+      properties:
+        name:
+          type: string

--- a/api/testdata/oasdiff/export-interior-changed.yaml
+++ b/api/testdata/oasdiff/export-interior-changed.yaml
@@ -1,0 +1,55 @@
+openapi: 3.1.0
+info:
+  title: Compatibility fixture (account-export versioned interior)
+  version: "1"
+paths:
+  /v1/account/export:
+    get:
+      operationId: exportAccount
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserExport"
+  /v1/things:
+    get:
+      operationId: listThings
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Shared"
+components:
+  schemas:
+    UserExport:
+      type: object
+      additionalProperties: true
+      required: [schema_version, agents]
+      properties:
+        schema_version:
+          type: string
+        agents:
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentIdentity"
+        shared:
+          $ref: "#/components/schemas/Shared"
+    AgentIdentity:
+      type: object
+      additionalProperties: true
+      required: [email]
+      properties:
+        email:
+          type: string
+      x-stability-level: beta
+    Shared:
+      type: object
+      additionalProperties: true
+      required: [name]
+      properties:
+        name:
+          type: string

--- a/api/testdata/oasdiff/export-shared-schema-changed.yaml
+++ b/api/testdata/oasdiff/export-shared-schema-changed.yaml
@@ -1,0 +1,54 @@
+openapi: 3.1.0
+info:
+  title: Compatibility fixture (account-export versioned interior)
+  version: "1"
+paths:
+  /v1/account/export:
+    get:
+      operationId: exportAccount
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserExport"
+  /v1/things:
+    get:
+      operationId: listThings
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Shared"
+components:
+  schemas:
+    UserExport:
+      type: object
+      additionalProperties: true
+      required: [schema_version, agents]
+      properties:
+        schema_version:
+          type: string
+        agents:
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentIdentity"
+        shared:
+          $ref: "#/components/schemas/Shared"
+    AgentIdentity:
+      type: object
+      additionalProperties: true
+      required: [email, internal_detail]
+      properties:
+        email:
+          type: string
+        internal_detail:
+          type: string
+      x-stability-level: beta
+    Shared:
+      type: object
+      additionalProperties: true
+      properties: {}

--- a/cmd/e2a-openapi-normalize/main.go
+++ b/cmd/e2a-openapi-normalize/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 
@@ -25,9 +26,17 @@ func main() {
 		fmt.Fprintf(os.Stderr, "create output: %v\n", err)
 		os.Exit(1)
 	}
-	if err := openapicompat.NormalizeStability(in, out); err != nil {
+	var normalized bytes.Buffer
+	if err := openapicompat.NormalizeStability(in, &normalized); err != nil {
 		out.Close()
 		fmt.Fprintf(os.Stderr, "normalize OpenAPI: %v\n", err)
+		os.Exit(1)
+	}
+	// Collapse the account export's versioned-interior schemas so oasdiff
+	// gates only the stable envelope (see openapicompat.PruneExportInterior).
+	if err := openapicompat.PruneExportInterior(&normalized, out); err != nil {
+		out.Close()
+		fmt.Fprintf(os.Stderr, "prune export interior: %v\n", err)
 		os.Exit(1)
 	}
 	if err := out.Close(); err != nil {

--- a/docs/api-compatibility-gate.md
+++ b/docs/api-compatibility-gate.md
@@ -39,6 +39,25 @@ even when an entire path disappears. Removing the canonical marker promotes an
 operation into the stable gate; adding it to a stable operation is a blocked
 stability decrease.
 
+### The account export's versioned interior
+
+`GET /v1/account/export` (`exportAccount`) is a stable operation whose
+top-level `UserExport` envelope (the top-level keys and `schema_version`) is
+frozen, but whose interior record schemas are snapshots of internal storage
+models, versioned by `schema_version` instead of the v1 freeze (they carry
+`x-stability-level: beta` in the emitted spec). oasdiff only honors stability
+levels per operation, so the normalization step additionally collapses those
+interior schemas — computed by reachability from `UserExport`, excluding the
+envelope itself and any schema the stable surface reaches on its own — to
+open objects on **both** sides of the comparison
+(`openapicompat.PruneExportInterior`). Interior evolution is therefore
+invisible to the gate, while the envelope, the operation, and every shared
+schema (e.g. `CheckResult`, `AttachmentMeta`) remain fully gated. Because the
+boundary is computed, not read from the markers, hand-marking a stable schema
+beta cannot widen the exemption. `TestExportEnvelopeStableInteriorVersioned`
+(internal/httpapi) pins the marker boundary in the emitted spec, and the
+`export-*` fixtures in `make openapi-compat-test` pin the gate behavior.
+
 ## Running locally
 
 The default compares the current contract with `origin/main`:

--- a/docs/api.md
+++ b/docs/api.md
@@ -231,7 +231,11 @@ every `/v1` operation not listed here is covered by the GA freeze.
   `email.review_requested`, `email.review_approved`, `email.review_rejected`),
   the field carries `x-experimental-values` listing exactly those values —
   their payloads may still change; all other event types are stable. Anything
-  not marked experimental is stable surface.
+  not marked experimental is stable surface. One deliberate schema-level use
+  of the beta marker under a **stable** operation: the account export's
+  interior record schemas (`GET /v1/account/export`) are beta-marked because
+  they are versioned by the export's stable `schema_version` envelope field
+  rather than by the v1 freeze — see the account section below.
 - **Enums in responses are open.** Treat any `type` / `*_status` / `event_type`
   value as an open string set: we may introduce new values (e.g. a new event
   type or delivery state) without a major bump, so a client **must not crash on
@@ -267,6 +271,11 @@ Workspace identity, plan limits, keys, suppressions, and data rights.
   all owned data; returns per-table row counts (GDPR Art. 17). Irreversible.
 - `GET /v1/account/export` — JSON dump of every record the account owns (GDPR
   Art. 15). Omits internal identifiers; see [data-handling.md](data-handling.md).
+  The export **envelope** (the top-level keys and `schema_version`) is stable;
+  the **interior** record shapes are versioned by `schema_version` and may
+  evolve — branch on `schema_version` before interpreting interior records.
+  Interior schemas carry `x-stability-level: beta` in the OpenAPI document to
+  mark that exemption machine-readably; the operation itself is stable.
   Each exported message carries `attachments` as the same typed
   `AttachmentMeta` metadata (`{filename, content_type, size_bytes, index}`,
   `size_bytes` = decoded payload) the live API uses; the attachment **bytes**

--- a/internal/httpapi/account.go
+++ b/internal/httpapi/account.go
@@ -76,7 +76,12 @@ func (s *Server) registerAccount() {
 	huma.Register(s.API, huma.Operation{
 		OperationID: "exportAccount", Method: http.MethodGet, Path: "/v1/account/export",
 		Summary: "Export your data (GDPR right-of-access)", Tags: []string{"account"},
-		Description: "A JSON dump of every record the authenticated account owns.",
+		Description: "A JSON dump of every record the authenticated account owns. " +
+			"Contract: the export envelope (the top-level keys and schema_version) is stable; " +
+			"the interior record shapes are versioned by schema_version and may evolve — " +
+			"branch on schema_version before interpreting interior records. " +
+			"Interior schemas carry `x-stability-level: beta` in this document to mark that " +
+			"exemption machine-readably; the operation itself is stable GA surface.",
 		Security:    []map[string][]string{{"bearer": {}}},
 	}, s.handleExportUserData)
 

--- a/internal/httpapi/export_stability_test.go
+++ b/internal/httpapi/export_stability_test.go
@@ -1,0 +1,231 @@
+package httpapi
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// These tests pin the account export's versioned-interior exemption
+// (stability.go, exportOperationID/exportEnvelopeSchema):
+//
+//   - GET /v1/account/export is STABLE and its UserExport envelope (top-level
+//     keys + schema_version) is frozen with the GA surface;
+//   - every INTERIOR schema reachable from UserExport is exempt from the v1
+//     freeze — versioned by schema_version instead — and must carry the
+//     canonical `x-stability-level: beta` marker so oasdiff/compat tooling
+//     excludes interior evolution from the stable gate;
+//   - EXCEPT schemas the stable surface reaches on its own (via another
+//     stable operation or a stable documentation component): those must stay
+//     unmarked, because a global beta marker would silently degrade the
+//     stable endpoints/event payloads that share them.
+//
+// The boundary below is COMPUTED from the rendered document (independently of
+// the stamping code), not enumerated: a future field change inside an
+// existing interior schema touches nothing here, and a brand-new interior
+// schema is covered automatically — but if it ever renders UNMARKED (e.g. the
+// stamping pass is weakened or removed) this test fails.
+
+// exportSpecRefsIn collects component-schema names referenced anywhere under
+// a node of the generic rendered document.
+func exportSpecRefsIn(node any, out map[string]bool) {
+	switch n := node.(type) {
+	case map[string]any:
+		if ref, ok := n["$ref"].(string); ok {
+			const schemaPrefix = "#/components/schemas/"
+			if strings.HasPrefix(ref, schemaPrefix) {
+				out[strings.TrimPrefix(ref, schemaPrefix)] = true
+			}
+		}
+		for _, v := range n {
+			exportSpecRefsIn(v, out)
+		}
+	case []any:
+		for _, v := range n {
+			exportSpecRefsIn(v, out)
+		}
+	}
+}
+
+// exportSpecClosure expands root component names to everything transitively
+// referenced through components.schemas of the rendered document.
+func exportSpecClosure(t *testing.T, schemas map[string]any, roots map[string]bool) map[string]bool {
+	t.Helper()
+	seen := map[string]bool{}
+	stack := make([]string, 0, len(roots))
+	for name := range roots {
+		stack = append(stack, name)
+	}
+	for len(stack) > 0 {
+		name := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		sc, ok := schemas[name].(map[string]any)
+		if !ok {
+			t.Fatalf("schema %q referenced but not defined", name)
+		}
+		next := map[string]bool{}
+		exportSpecRefsIn(sc, next)
+		for n := range next {
+			if !seen[n] {
+				stack = append(stack, n)
+			}
+		}
+	}
+	return seen
+}
+
+func TestExportEnvelopeStableInteriorVersioned(t *testing.T) {
+	doc := renderSpec(t)
+	comps, _ := doc["components"].(map[string]any)
+	schemas, _ := comps["schemas"].(map[string]any)
+
+	// --- The envelope itself is frozen stable GA surface. ---
+	envelope, ok := schemas["UserExport"].(map[string]any)
+	if !ok {
+		t.Fatal("UserExport schema missing from the rendered spec — re-target the versioned-interior exemption and this test")
+	}
+	if got := envelope["x-stability-level"]; got != nil {
+		t.Errorf("UserExport (the export envelope) must NOT carry x-stability-level — it is frozen stable; got %v", got)
+	}
+	props, _ := envelope["properties"].(map[string]any)
+	sv, _ := props["schema_version"].(map[string]any)
+	if sv == nil {
+		t.Fatal("UserExport.schema_version missing — it is the version pivot of the whole exemption")
+	}
+	if got := sv["x-stability-level"]; got != nil {
+		t.Errorf("UserExport.schema_version must stay stable (no x-stability-level), got %v", got)
+	}
+	svDoc, _ := sv["description"].(string)
+	if !strings.Contains(svDoc, "branch on schema_version") {
+		t.Errorf("UserExport.schema_version description must tell consumers to branch on schema_version; got %q", svDoc)
+	}
+	required, _ := envelope["required"].([]any)
+	hasRequired := false
+	for _, r := range required {
+		if r == "schema_version" {
+			hasRequired = true
+		}
+	}
+	if !hasRequired {
+		t.Error("UserExport.schema_version must remain a required field — consumers cannot branch on an absent version")
+	}
+
+	// --- The operation stays stable and documents the contract. ---
+	op := operationByID(t, doc, "exportAccount")
+	if got := op["x-stability-level"]; got != nil {
+		t.Errorf("exportAccount is stable GA surface and must NOT carry x-stability-level, got %v", got)
+	}
+	opDesc, _ := op["description"].(string)
+	for _, needle := range []string{"schema_version", "stable", "branch on schema_version"} {
+		if !strings.Contains(opDesc, needle) {
+			t.Errorf("exportAccount description must state the versioned-interior contract; missing %q", needle)
+		}
+	}
+
+	// --- The exemption boundary, recomputed from the document. ---
+	exportSet := exportSpecClosure(t, schemas, map[string]bool{"UserExport": true})
+
+	// Stable surface that must keep the schemas it shares with the export
+	// unmarked: (a) everything reachable from a stable (non-beta) operation
+	// other than exportAccount; (b) everything reachable from a stable
+	// operation-unreachable documentation component (event payloads etc.).
+	allOpRoots := map[string]bool{}
+	stableOtherRoots := map[string]bool{}
+	paths, _ := doc["paths"].(map[string]any)
+	for _, pi := range paths {
+		item, _ := pi.(map[string]any)
+		for _, rawOp := range item {
+			opm, ok := rawOp.(map[string]any)
+			if !ok {
+				continue
+			}
+			id, _ := opm["operationId"].(string)
+			if id == "" {
+				continue
+			}
+			roots := map[string]bool{}
+			exportSpecRefsIn(opm["requestBody"], roots)
+			exportSpecRefsIn(opm["responses"], roots)
+			for name := range roots {
+				allOpRoots[name] = true
+				if id != "exportAccount" && opm["x-stability-level"] != "beta" {
+					stableOtherRoots[name] = true
+				}
+			}
+		}
+	}
+	opReachable := exportSpecClosure(t, schemas, allOpRoots)
+	stableSurface := exportSpecClosure(t, schemas, stableOtherRoots)
+	docRoots := map[string]bool{}
+	for name, raw := range schemas {
+		sc, _ := raw.(map[string]any)
+		if opReachable[name] || exportSet[name] || sc["x-stability-level"] == "beta" {
+			continue
+		}
+		docRoots[name] = true
+	}
+	for name := range exportSpecClosure(t, schemas, docRoots) {
+		stableSurface[name] = true
+	}
+
+	var interiorBeta, interiorShared []string
+	for name := range exportSet {
+		if name == "UserExport" {
+			continue
+		}
+		sc, _ := schemas[name].(map[string]any)
+		if stableSurface[name] {
+			// Shared with stable surface: must NOT be degraded to beta.
+			if got := sc["x-stability-level"]; got != nil {
+				t.Errorf("schema %s is shared with the stable surface and must NOT carry x-stability-level (marking it would degrade stable endpoints), got %v", name, got)
+			}
+			interiorShared = append(interiorShared, name)
+			continue
+		}
+		if got := sc["x-stability-level"]; got != "beta" {
+			t.Errorf("export interior schema %s must carry x-stability-level: beta (versioned by UserExport.schema_version, exempt from the v1 freeze), got %v", name, got)
+		}
+		interiorBeta = append(interiorBeta, name)
+	}
+	if len(interiorBeta) == 0 {
+		t.Fatal("no export-only interior schemas found — test wiring is wrong")
+	}
+
+	// Anchors: pin today's boundary by name so an accidental re-plumbing of a
+	// known schema (e.g. the export starts embedding MessageView, or a stable
+	// endpoint starts returning identity.Message) is caught consciously.
+	sort.Strings(interiorBeta)
+	sort.Strings(interiorShared)
+	mustBeBeta := []string{"APIKeyExportEntry", "AgentIdentity", "Domain", "Message", "OAuthConnectionEntry", "ProtectionEventExportEntry", "Result", "SuppressionExportEntry", "UsageEventEntry", "UserExportUser"}
+	for _, name := range mustBeBeta {
+		if !contains(interiorBeta, name) {
+			t.Errorf("expected %s among the beta-marked export interior schemas; got %v", name, interiorBeta)
+		}
+	}
+	// CheckResult is reachable via the stable message endpoints (AuthVerdict);
+	// AttachmentMeta via the stable email.received event payload
+	// (EmailReceivedData). Both stay stable everywhere, including inside the
+	// export.
+	for _, name := range []string{"CheckResult", "AttachmentMeta"} {
+		if !exportSet[name] {
+			t.Errorf("expected %s inside the export closure — if the export stopped using it, revisit this test's shared-schema assumptions", name)
+			continue
+		}
+		if !contains(interiorShared, name) {
+			t.Errorf("expected %s to be recognized as shared stable surface (unmarked); got shared=%v beta=%v", name, interiorShared, interiorBeta)
+		}
+	}
+}
+
+func contains(list []string, want string) bool {
+	for _, v := range list {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/httpapi/stability.go
+++ b/internal/httpapi/stability.go
@@ -38,6 +38,23 @@ const (
 	extExperimentalValues = "x-experimental-values"
 )
 
+// The account export's versioned-interior exemption (GA decision).
+//
+// GET /v1/account/export is a STABLE operation and its top-level UserExport
+// envelope (the top-level keys and schema_version) is frozen with the rest of
+// the GA surface. Its INTERIOR record shapes, however, are snapshots of
+// internal storage models (identity.AgentIdentity, identity.Message, …);
+// freezing them would freeze the storage layer itself. They are therefore
+// versioned by UserExport.schema_version instead of the v1 freeze: consumers
+// MUST branch on schema_version, and every component schema reachable from
+// UserExport — except the envelope itself and any schema the stable surface
+// reaches on its own — carries `x-stability-level: beta` so automated
+// compatibility tooling excludes interior evolution from the stable gate.
+const (
+	exportOperationID    = "exportAccount"
+	exportEnvelopeSchema = "UserExport"
+)
+
 // beta is the operation extension marking a surface as exempt from the
 // v1 freeze (may change without a major version). Returns a fresh map so no
 // two operations share mutable state.
@@ -61,6 +78,7 @@ func (s *Server) applyEvolutionStance() {
 	responseRoots := map[string]bool{} // referenced from a response body
 	betaRoots := map[string]bool{}
 	stableRoots := map[string]bool{}
+	exportOpRoots := map[string]bool{} // the export operation's own roots
 
 	// Inline (non-$ref) object schemas embedded directly in a response body
 	// also need opening; collect them while walking.
@@ -92,8 +110,15 @@ func (s *Server) applyEvolutionStance() {
 			}
 		}
 		dst := stableRoots
-		if isBeta {
+		switch {
+		case isBeta:
 			dst = betaRoots
+		case op.OperationID == exportOperationID:
+			// The export is stable, but routing its response tree into
+			// stableRoots would veto the versioned-interior markers below.
+			// Its non-envelope roots (error responses) rejoin stableRoots
+			// after the export closure is known.
+			dst = exportOpRoots
 		}
 		for name := range opRoots {
 			dst[name] = true
@@ -102,6 +127,19 @@ func (s *Server) applyEvolutionStance() {
 
 	requestSet := refClosure(schemas, requestRoots)
 	responseSet := refClosure(schemas, responseRoots)
+
+	// Versioned-interior exemption (see the constant block above): the export
+	// envelope's closure, computed before stableSet so only the envelope's own
+	// subtree is withheld from the stable-surface veto.
+	if _, ok := schemas[exportEnvelopeSchema]; !ok {
+		panic(fmt.Sprintf("httpapi: export envelope schema %q missing from the registry — re-target the versioned-interior exemption", exportEnvelopeSchema))
+	}
+	exportSet := refClosure(schemas, map[string]bool{exportEnvelopeSchema: true})
+	for name := range exportOpRoots {
+		if !exportSet[name] {
+			stableRoots[name] = true // e.g. error envelopes on the export op stay stable
+		}
+	}
 
 	// The invariant that makes the request/response split total: no schema may
 	// serve both masters. If this fires, split the Go type (input *Request vs
@@ -130,6 +168,44 @@ func (s *Server) applyEvolutionStance() {
 	stableSet := refClosure(schemas, stableRoots)
 	for name := range betaSet {
 		if stableSet[name] {
+			continue
+		}
+		sc := schemas[name]
+		if sc.Extensions == nil {
+			sc.Extensions = map[string]any{}
+		}
+		sc.Extensions[extStabilityLevel] = stabilityBeta
+	}
+
+	// Versioned-interior exemption for the account export (see the constant
+	// block above). Every schema reachable from the UserExport envelope gets
+	// the beta marker, EXCEPT:
+	//   - the envelope itself (top-level keys + schema_version stay frozen);
+	//   - any schema the stable surface reaches on its own — via another
+	//     stable operation (CheckResult, through the message endpoints'
+	//     AuthVerdict) or via a stable operation-unreachable documentation
+	//     component (AttachmentMeta, through the email.received event payload
+	//     EmailReceivedData). Marking those would silently degrade stable
+	//     endpoints/event payloads to beta.
+	// The set is computed, not enumerated, so a new export entry type can't
+	// leave an invisible hole in the freeze (same rationale as the beta-op
+	// inheritance above).
+	stableDocRoots := map[string]bool{}
+	for name, sc := range schemas {
+		if requestSet[name] || responseSet[name] || exportSet[name] {
+			continue
+		}
+		if sc.Extensions[extStabilityLevel] == stabilityBeta {
+			continue
+		}
+		stableDocRoots[name] = true
+	}
+	stableSurface := refClosure(schemas, stableDocRoots)
+	for name := range stableSet {
+		stableSurface[name] = true
+	}
+	for name := range exportSet {
+		if name == exportEnvelopeSchema || stableSurface[name] {
 			continue
 		}
 		sc := schemas[name]

--- a/internal/identity/user_data_rights.go
+++ b/internal/identity/user_data_rights.go
@@ -24,7 +24,7 @@ import (
 //   - User session tokens are transient and excluded.
 type UserExport struct {
 	GeneratedAt      time.Time                    `json:"generated_at"`
-	SchemaVersion    string                       `json:"schema_version"`
+	SchemaVersion    string                       `json:"schema_version" doc:"Version of the interior record shapes in this export. The export envelope (the top-level keys and schema_version) is stable; interior record shapes are versioned by schema_version and may evolve — branch on schema_version before interpreting interior records. The current server emits \"2\"."`
 	User             UserExportUser               `json:"user"`
 	Domains          []Domain                     `json:"domains" nullable:"false"`
 	Agents           []AgentIdentity              `json:"agents" nullable:"false"`

--- a/internal/openapicompat/exportprune.go
+++ b/internal/openapicompat/exportprune.go
@@ -1,0 +1,195 @@
+package openapicompat
+
+import (
+	"fmt"
+	"io"
+
+	"gopkg.in/yaml.v3"
+)
+
+// The account export's versioned-interior exemption, gate side.
+//
+// GET /v1/account/export (operation exportAccount) is a STABLE operation
+// whose top-level UserExport envelope (the top-level keys and schema_version)
+// is frozen with the GA surface. Its INTERIOR record schemas are snapshots of
+// internal storage models, versioned by UserExport.schema_version instead of
+// the v1 freeze (they carry `x-stability-level: beta` in the emitted spec —
+// see internal/httpapi/stability.go). oasdiff, however, only honors
+// stability levels at the OPERATION level, so without help the gate would
+// block every interior change (and the marker introduction itself) as a
+// breaking change on the stable export operation.
+//
+// PruneExportInterior therefore collapses the interior for gate comparison
+// only: every component schema reachable from UserExport — EXCEPT the
+// envelope itself and any schema the stable surface reaches on its own (via
+// another stable operation, or via a stable operation-unreachable
+// documentation component such as the event payloads) — is replaced by an
+// open object stamped beta. Applied to BOTH sides of the comparison, the
+// interiors always compare equal, while the envelope, the operation, and
+// every shared schema remain fully gated. The boundary is COMPUTED by
+// reachability (the same rule the server uses to stamp the markers), never
+// read from the markers themselves, so it holds for historical base
+// documents that predate the markers and cannot be widened by hand-marking a
+// stable schema beta.
+const (
+	exportOperationID    = "exportAccount"
+	exportEnvelopeSchema = "UserExport"
+)
+
+// PruneExportInterior rewrites an OpenAPI document for the compatibility
+// gate: the account export's versioned-interior schemas are collapsed to
+// `{type: object, additionalProperties: true, x-stability-level: beta}`.
+// A document with no UserExport component passes through semantically
+// unchanged. Like NormalizeStability, this never alters runtime behavior —
+// it only feeds oasdiff.
+func PruneExportInterior(r io.Reader, w io.Writer) error {
+	var doc map[string]any
+	if err := yaml.NewDecoder(r).Decode(&doc); err != nil {
+		return fmt.Errorf("decode OpenAPI YAML: %w", err)
+	}
+	if err := pruneExportInterior(doc); err != nil {
+		return err
+	}
+	enc := yaml.NewEncoder(w)
+	enc.SetIndent(2)
+	defer enc.Close()
+	if err := enc.Encode(doc); err != nil {
+		return fmt.Errorf("encode pruned OpenAPI YAML: %w", err)
+	}
+	return nil
+}
+
+func pruneExportInterior(doc map[string]any) error {
+	comps, _ := doc["components"].(map[string]any)
+	schemas, _ := comps["schemas"].(map[string]any)
+	if _, ok := schemas[exportEnvelopeSchema]; !ok {
+		return nil // document predates (or lacks) the export envelope
+	}
+
+	exportSet, err := schemaClosure(schemas, map[string]bool{exportEnvelopeSchema: true})
+	if err != nil {
+		return err
+	}
+
+	// Stable surface that must stay fully gated: everything reachable from an
+	// operation other than the export that is not beta, plus everything
+	// reachable from a stable operation-unreachable documentation component
+	// (event payload schemas etc.).
+	allOpRoots := map[string]bool{}
+	stableOtherRoots := map[string]bool{}
+	paths, _ := doc["paths"].(map[string]any)
+	for _, rawItem := range paths {
+		item, _ := rawItem.(map[string]any)
+		for _, rawOp := range item {
+			op, ok := rawOp.(map[string]any)
+			if !ok {
+				continue
+			}
+			id, _ := op["operationId"].(string)
+			if id == "" {
+				continue
+			}
+			roots := map[string]bool{}
+			collectSchemaRefs(op["requestBody"], roots)
+			collectSchemaRefs(op["responses"], roots)
+			isBeta := op[oasdiffExtension] == "beta" || op[e2aStabilityExtension] == "experimental"
+			for name := range roots {
+				allOpRoots[name] = true
+				if id != exportOperationID && !isBeta {
+					stableOtherRoots[name] = true
+				}
+			}
+		}
+	}
+	opReachable, err := schemaClosure(schemas, allOpRoots)
+	if err != nil {
+		return err
+	}
+	stableSurface, err := schemaClosure(schemas, stableOtherRoots)
+	if err != nil {
+		return err
+	}
+	docRoots := map[string]bool{}
+	for name, raw := range schemas {
+		sc, _ := raw.(map[string]any)
+		if opReachable[name] || exportSet[name] {
+			continue
+		}
+		if sc[oasdiffExtension] == "beta" || sc[e2aStabilityExtension] == "experimental" {
+			continue
+		}
+		docRoots[name] = true
+	}
+	docReachable, err := schemaClosure(schemas, docRoots)
+	if err != nil {
+		return err
+	}
+	for name := range docReachable {
+		stableSurface[name] = true
+	}
+
+	for name := range exportSet {
+		if name == exportEnvelopeSchema || stableSurface[name] {
+			continue
+		}
+		schemas[name] = map[string]any{
+			"type":                 "object",
+			"additionalProperties": true,
+			oasdiffExtension:       "beta",
+			"description": "Interior record shape of the account export, collapsed for compatibility " +
+				"comparison: it is versioned by UserExport.schema_version, not by the v1 freeze.",
+		}
+	}
+	return nil
+}
+
+// collectSchemaRefs records every component-schema name referenced anywhere
+// under a generic YAML node.
+func collectSchemaRefs(node any, out map[string]bool) {
+	switch n := node.(type) {
+	case map[string]any:
+		if ref, ok := n["$ref"].(string); ok {
+			const prefix = "#/components/schemas/"
+			if len(ref) > len(prefix) && ref[:len(prefix)] == prefix {
+				out[ref[len(prefix):]] = true
+			}
+		}
+		for _, v := range n {
+			collectSchemaRefs(v, out)
+		}
+	case []any:
+		for _, v := range n {
+			collectSchemaRefs(v, out)
+		}
+	}
+}
+
+// schemaClosure expands root component names to everything transitively
+// referenced through components.schemas.
+func schemaClosure(schemas map[string]any, roots map[string]bool) (map[string]bool, error) {
+	seen := map[string]bool{}
+	stack := make([]string, 0, len(roots))
+	for name := range roots {
+		stack = append(stack, name)
+	}
+	for len(stack) > 0 {
+		name := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		sc, ok := schemas[name]
+		if !ok {
+			return nil, fmt.Errorf("schema %q is referenced but not defined in components.schemas", name)
+		}
+		next := map[string]bool{}
+		collectSchemaRefs(sc, next)
+		for n := range next {
+			if !seen[n] {
+				stack = append(stack, n)
+			}
+		}
+	}
+	return seen, nil
+}

--- a/internal/openapicompat/exportprune_test.go
+++ b/internal/openapicompat/exportprune_test.go
@@ -1,0 +1,208 @@
+package openapicompat
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// A miniature contract exercising every side of the exemption boundary:
+//   - UserExport (envelope) → AgentIdentity (export-only interior),
+//     Shared (also returned by a stable operation), and DocShared
+//     (reachable only through a stable documentation component).
+const pruneFixture = `
+openapi: 3.1.0
+info: {title: t, version: "1"}
+paths:
+  /v1/account/export:
+    get:
+      operationId: exportAccount
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserExport"
+  /v1/things:
+    get:
+      operationId: listThings
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Shared"
+  /v1/beta-things:
+    get:
+      operationId: betaThings
+      x-stability-level: beta
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BetaOnly"
+components:
+  schemas:
+    UserExport:
+      type: object
+      additionalProperties: true
+      required: [schema_version, agents]
+      properties:
+        schema_version: {type: string}
+        agents:
+          type: array
+          items: {$ref: "#/components/schemas/AgentIdentity"}
+        shared: {$ref: "#/components/schemas/Shared"}
+        doc_shared: {$ref: "#/components/schemas/DocShared"}
+    AgentIdentity:
+      type: object
+      additionalProperties: true
+      required: [email]
+      properties:
+        email: {type: string}
+        secret_internal: {type: string}
+    Shared:
+      type: object
+      additionalProperties: true
+      properties:
+        name: {type: string}
+    DocShared:
+      type: object
+      additionalProperties: true
+      properties:
+        size: {type: integer}
+    EventPayloadDoc:
+      type: object
+      additionalProperties: true
+      properties:
+        attachment: {$ref: "#/components/schemas/DocShared"}
+    BetaOnly:
+      type: object
+      additionalProperties: true
+      x-stability-level: beta
+      properties:
+        experimental: {type: string}
+`
+
+func prune(t *testing.T, in string) map[string]any {
+	t.Helper()
+	var out bytes.Buffer
+	if err := PruneExportInterior(strings.NewReader(in), &out); err != nil {
+		t.Fatalf("PruneExportInterior: %v", err)
+	}
+	var doc map[string]any
+	if err := yaml.Unmarshal(out.Bytes(), &doc); err != nil {
+		t.Fatalf("unmarshal pruned YAML: %v", err)
+	}
+	return doc
+}
+
+func TestPruneExportInteriorCollapsesOnlyExportOnlySchemas(t *testing.T) {
+	doc := prune(t, pruneFixture)
+	schemas := doc["components"].(map[string]any)["schemas"].(map[string]any)
+
+	// Export-only interior: collapsed to an open beta object.
+	agent := schemas["AgentIdentity"].(map[string]any)
+	if _, ok := agent["properties"]; ok {
+		t.Error("AgentIdentity (export-only interior) must be collapsed — its properties are versioned by schema_version, not gated")
+	}
+	if got := agent["x-stability-level"]; got != "beta" {
+		t.Errorf("collapsed interior must be stamped beta, got %v", got)
+	}
+	if got := agent["additionalProperties"]; got != true {
+		t.Errorf("collapsed interior must stay an open object, got additionalProperties=%v", got)
+	}
+
+	// The envelope itself stays fully gated.
+	envelope := schemas["UserExport"].(map[string]any)
+	props, _ := envelope["properties"].(map[string]any)
+	if _, ok := props["schema_version"]; !ok {
+		t.Error("UserExport envelope must keep its properties (schema_version stays gated)")
+	}
+	if _, ok := envelope["x-stability-level"]; ok {
+		t.Error("UserExport envelope must not be marked beta by the prune")
+	}
+
+	// Schemas the stable surface reaches on its own stay fully gated.
+	for _, name := range []string{"Shared", "DocShared"} {
+		sc := schemas[name].(map[string]any)
+		if _, ok := sc["properties"]; !ok {
+			t.Errorf("%s is shared with the stable surface and must NOT be collapsed", name)
+		}
+	}
+
+	// Untouched bystanders.
+	if _, ok := schemas["EventPayloadDoc"].(map[string]any)["properties"]; !ok {
+		t.Error("stable documentation component must not be collapsed")
+	}
+	if _, ok := schemas["BetaOnly"].(map[string]any)["properties"]; !ok {
+		t.Error("beta-operation schema outside the export is not this prune's business")
+	}
+}
+
+// The prune's whole purpose: two documents whose export interiors differ must
+// prune to semantically identical schemas, while an envelope change must
+// survive the prune (so oasdiff still gates it).
+func TestPruneExportInteriorMakesInteriorChangesInvisible(t *testing.T) {
+	changed := strings.Replace(pruneFixture, "secret_internal: {type: string}", "renamed_field: {type: integer}", 1)
+	if changed == pruneFixture {
+		t.Fatal("fixture edit did not apply")
+	}
+	a := prune(t, pruneFixture)["components"].(map[string]any)["schemas"].(map[string]any)["AgentIdentity"]
+	b := prune(t, changed)["components"].(map[string]any)["schemas"].(map[string]any)["AgentIdentity"]
+	ay, _ := yaml.Marshal(a)
+	by, _ := yaml.Marshal(b)
+	if string(ay) != string(by) {
+		t.Errorf("interior change must be invisible after pruning:\n%s\nvs\n%s", ay, by)
+	}
+
+	dropped := strings.Replace(pruneFixture, "schema_version: {type: string}", "", 1)
+	env := prune(t, dropped)["components"].(map[string]any)["schemas"].(map[string]any)["UserExport"].(map[string]any)
+	props, _ := env["properties"].(map[string]any)
+	if _, ok := props["schema_version"]; ok {
+		t.Fatal("fixture edit did not apply")
+	}
+	// The point: the pruned document still differs from the unmodified one at
+	// the envelope, so oasdiff sees the removal.
+	orig := prune(t, pruneFixture)["components"].(map[string]any)["schemas"].(map[string]any)["UserExport"]
+	oy, _ := yaml.Marshal(orig)
+	ey, _ := yaml.Marshal(env)
+	if string(oy) == string(ey) {
+		t.Error("an envelope change must survive the prune so the gate can reject it")
+	}
+}
+
+func TestPruneExportInteriorNoEnvelopeIsANoOp(t *testing.T) {
+	in := `
+openapi: 3.1.0
+info: {title: t, version: "1"}
+paths:
+  /v1/things:
+    get:
+      operationId: listThings
+      responses:
+        "200":
+          description: ok
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Shared"
+components:
+  schemas:
+    Shared:
+      type: object
+      properties:
+        name: {type: string}
+`
+	doc := prune(t, in)
+	sc := doc["components"].(map[string]any)["schemas"].(map[string]any)["Shared"].(map[string]any)
+	if _, ok := sc["properties"]; !ok {
+		t.Error("document without a UserExport envelope must pass through unchanged")
+	}
+}

--- a/scripts/test-openapi-compat.sh
+++ b/scripts/test-openapi-compat.sh
@@ -44,12 +44,18 @@ expect_fail() {
 expect_pass "identical contract" "$fixtures/base.yaml" "$fixtures/base.yaml"
 expect_pass "additive response field" "$fixtures/base.yaml" "$fixtures/additive-response.yaml"
 expect_pass "experimental operation removal" "$fixtures/base.yaml" "$fixtures/experimental-removed.yaml"
+# The account export's versioned-interior exemption: interior record shapes
+# are versioned by UserExport.schema_version, not gated; the envelope and any
+# schema shared with the stable surface remain fully gated.
+expect_pass "export interior schema change" "$fixtures/export-base.yaml" "$fixtures/export-interior-changed.yaml"
 
 expect_fail "stable operation removal" "$fixtures/base.yaml" "$fixtures/stable-removed.yaml" "api-path-removed-without-deprecation"
 expect_fail "operationId rename" "$fixtures/base.yaml" "$fixtures/operation-id-renamed.yaml" "api-operation-id-removed"
 expect_fail "new required request field" "$fixtures/base.yaml" "$fixtures/required-request-field.yaml" "new-required-request-property"
 expect_fail "warning-level request removal" "$fixtures/base.yaml" "$fixtures/request-property-removed.yaml" "request-property-removed"
 expect_fail "stable operation marked beta" "$fixtures/base.yaml" "$fixtures/stability-decreased.yaml" "api-stability-decreased"
+expect_fail "export envelope key removal" "$fixtures/export-base.yaml" "$fixtures/export-envelope-key-removed.yaml" "response-required-property-removed"
+expect_fail "schema shared between export and stable surface" "$fixtures/export-base.yaml" "$fixtures/export-shared-schema-changed.yaml" "response-required-property-removed"
 expect_fail "bearer mechanism changed" "$fixtures/security-base.yaml" "$fixtures/security-scheme-changed.yaml" "security-schemes-changed"
 
 set +e

--- a/sdks/python/src/e2a/v1/generated/api/account_api.py
+++ b/sdks/python/src/e2a/v1/generated/api/account_api.py
@@ -1179,7 +1179,7 @@ class AccountApi:
     ) -> UserExport:
         """Export your data (GDPR right-of-access)
 
-        A JSON dump of every record the authenticated account owns.
+        A JSON dump of every record the authenticated account owns. Contract: the export envelope (the top-level keys and schema_version) is stable; the interior record shapes are versioned by schema_version and may evolve — branch on schema_version before interpreting interior records. Interior schemas carry `x-stability-level: beta` in this document to mark that exemption machine-readably; the operation itself is stable GA surface.
 
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -1242,7 +1242,7 @@ class AccountApi:
     ) -> ApiResponse[UserExport]:
         """Export your data (GDPR right-of-access)
 
-        A JSON dump of every record the authenticated account owns.
+        A JSON dump of every record the authenticated account owns. Contract: the export envelope (the top-level keys and schema_version) is stable; the interior record shapes are versioned by schema_version and may evolve — branch on schema_version before interpreting interior records. Interior schemas carry `x-stability-level: beta` in this document to mark that exemption machine-readably; the operation itself is stable GA surface.
 
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -1305,7 +1305,7 @@ class AccountApi:
     ) -> RESTResponseType:
         """Export your data (GDPR right-of-access)
 
-        A JSON dump of every record the authenticated account owns.
+        A JSON dump of every record the authenticated account owns. Contract: the export envelope (the top-level keys and schema_version) is stable; the interior record shapes are versioned by schema_version and may evolve — branch on schema_version before interpreting interior records. Interior schemas carry `x-stability-level: beta` in this document to mark that exemption machine-readably; the operation itself is stable GA surface.
 
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request

--- a/sdks/python/src/e2a/v1/generated/models/user_export.py
+++ b/sdks/python/src/e2a/v1/generated/models/user_export.py
@@ -18,7 +18,7 @@ import re  # noqa: F401
 import json
 
 from datetime import datetime
-from pydantic import BaseModel, ConfigDict, StrictStr
+from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from e2a.v1.generated.models.agent_identity import AgentIdentity
 from e2a.v1.generated.models.api_key_export_entry import APIKeyExportEntry
@@ -43,7 +43,7 @@ class UserExport(BaseModel):
     messages: List[Message]
     oauth_connections: Optional[List[OAuthConnectionEntry]] = None
     protection_events: List[ProtectionEventExportEntry]
-    schema_version: StrictStr
+    schema_version: StrictStr = Field(description="Version of the interior record shapes in this export. The export envelope (the top-level keys and schema_version) is stable; interior record shapes are versioned by schema_version and may evolve — branch on schema_version before interpreting interior records. The current server emits \"2\".")
     suppressions: List[SuppressionExportEntry]
     usage_events: Optional[List[UsageEventEntry]] = None
     user: UserExportUser

--- a/sdks/typescript/src/v1/generated/apis/AccountApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/AccountApi.ts
@@ -220,7 +220,7 @@ export class AccountApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
-     * A JSON dump of every record the authenticated account owns.
+     * A JSON dump of every record the authenticated account owns. Contract: the export envelope (the top-level keys and schema_version) is stable; the interior record shapes are versioned by schema_version and may evolve — branch on schema_version before interpreting interior records. Interior schemas carry `x-stability-level: beta` in this document to mark that exemption machine-readably; the operation itself is stable GA surface.
      * Export your data (GDPR right-of-access)
      */
     public async exportAccount(_options?: Configuration): Promise<RequestContext> {

--- a/sdks/typescript/src/v1/generated/models/UserExport.ts
+++ b/sdks/typescript/src/v1/generated/models/UserExport.ts
@@ -29,6 +29,9 @@ export class UserExport {
     'messages': Array<Message>;
     'oauthConnections'?: Array<OAuthConnectionEntry>;
     'protectionEvents': Array<ProtectionEventExportEntry>;
+    /**
+    * Version of the interior record shapes in this export. The export envelope (the top-level keys and schema_version) is stable; interior record shapes are versioned by schema_version and may evolve — branch on schema_version before interpreting interior records. The current server emits \"2\".
+    */
     'schemaVersion': string;
     'suppressions': Array<SuppressionExportEntry>;
     'usageEvents'?: Array<UsageEventEntry>;

--- a/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
@@ -318,7 +318,7 @@ export class ObjectAccountApi {
     }
 
     /**
-     * A JSON dump of every record the authenticated account owns.
+     * A JSON dump of every record the authenticated account owns. Contract: the export envelope (the top-level keys and schema_version) is stable; the interior record shapes are versioned by schema_version and may evolve — branch on schema_version before interpreting interior records. Interior schemas carry `x-stability-level: beta` in this document to mark that exemption machine-readably; the operation itself is stable GA surface.
      * Export your data (GDPR right-of-access)
      * @param param the request object
      */
@@ -327,7 +327,7 @@ export class ObjectAccountApi {
     }
 
     /**
-     * A JSON dump of every record the authenticated account owns.
+     * A JSON dump of every record the authenticated account owns. Contract: the export envelope (the top-level keys and schema_version) is stable; the interior record shapes are versioned by schema_version and may evolve — branch on schema_version before interpreting interior records. Interior schemas carry `x-stability-level: beta` in this document to mark that exemption machine-readably; the operation itself is stable GA surface.
      * Export your data (GDPR right-of-access)
      * @param param the request object
      */

--- a/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
@@ -291,7 +291,7 @@ export class ObservableAccountApi {
     }
 
     /**
-     * A JSON dump of every record the authenticated account owns.
+     * A JSON dump of every record the authenticated account owns. Contract: the export envelope (the top-level keys and schema_version) is stable; the interior record shapes are versioned by schema_version and may evolve — branch on schema_version before interpreting interior records. Interior schemas carry `x-stability-level: beta` in this document to mark that exemption machine-readably; the operation itself is stable GA surface.
      * Export your data (GDPR right-of-access)
      */
     public exportAccountWithHttpInfo(_options?: ConfigurationOptions): Observable<HttpInfo<UserExport>> {
@@ -315,7 +315,7 @@ export class ObservableAccountApi {
     }
 
     /**
-     * A JSON dump of every record the authenticated account owns.
+     * A JSON dump of every record the authenticated account owns. Contract: the export envelope (the top-level keys and schema_version) is stable; the interior record shapes are versioned by schema_version and may evolve — branch on schema_version before interpreting interior records. Interior schemas carry `x-stability-level: beta` in this document to mark that exemption machine-readably; the operation itself is stable GA surface.
      * Export your data (GDPR right-of-access)
      */
     public exportAccount(_options?: ConfigurationOptions): Observable<UserExport> {

--- a/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
@@ -239,7 +239,7 @@ export class PromiseAccountApi {
     }
 
     /**
-     * A JSON dump of every record the authenticated account owns.
+     * A JSON dump of every record the authenticated account owns. Contract: the export envelope (the top-level keys and schema_version) is stable; the interior record shapes are versioned by schema_version and may evolve — branch on schema_version before interpreting interior records. Interior schemas carry `x-stability-level: beta` in this document to mark that exemption machine-readably; the operation itself is stable GA surface.
      * Export your data (GDPR right-of-access)
      */
     public exportAccountWithHttpInfo(_options?: PromiseConfigurationOptions): Promise<HttpInfo<UserExport>> {
@@ -249,7 +249,7 @@ export class PromiseAccountApi {
     }
 
     /**
-     * A JSON dump of every record the authenticated account owns.
+     * A JSON dump of every record the authenticated account owns. Contract: the export envelope (the top-level keys and schema_version) is stable; the interior record shapes are versioned by schema_version and may evolve — branch on schema_version before interpreting interior records. Interior schemas carry `x-stability-level: beta` in this document to mark that exemption machine-readably; the operation itself is stable GA surface.
      * Export your data (GDPR right-of-access)
      */
     public exportAccount(_options?: PromiseConfigurationOptions): Promise<UserExport> {


### PR DESCRIPTION
## Rationale

`GET /v1/account/export` (`exportAccount`, **stable**) currently freezes raw internal storage models into the GA contract. Its `UserExport` schema embeds `identity.AgentIdentity` (including the legacy flat protection config — `hitl_ttl_seconds`, scan thresholds etc. — that the **beta** `/v1/agents/{email}/protection` sub-resource superseded), `identity.Domain`, `identity.Message` (with `reviewed_*`, scan fields, `provider_message_id`, …), `Result`, and a **required** `protection_events` field typed by beta screening data (`ProtectionEventExportEntry`). Freezing these would freeze the storage layer itself.

**Owner-approved exemption:** keep the export operation and the top-level `UserExport` envelope (top-level keys + `schema_version`) stable; version the interior record shapes by `UserExport.schema_version` instead of the v1 freeze, marked machine-readably with `x-stability-level: beta`. Consumers must branch on `schema_version` before interpreting interior records.

## What changed

1. **Marker pass** (`internal/httpapi/stability.go`): a computed pass in `applyEvolutionStance` stamps `x-stability-level: beta` on every schema reachable from `UserExport` — except the envelope itself and schemas the stable surface reaches on its own. Computed, not enumerated (same rationale as the existing beta-op inheritance), so a new export entry type cannot leave an invisible hole in the freeze.
2. **Gate plumbing** (`internal/openapicompat/exportprune.go`, wired into `cmd/e2a-openapi-normalize`): empirically, oasdiff v1.23.0 only honors stability levels at the **operation** level — schema-level beta markers neither exempt interior changes nor allow the marker introduction itself (13 `response-property-stability-decreased` errors, and a test interior-field removal still failed the gate). The gate's normalization step now collapses the same computed interior set to open objects on **both** sides of the comparison, so interior evolution is invisible to the gate while the envelope, the operation, and shared schemas remain fully gated. The boundary is computed by reachability, never read from the markers, so hand-marking a stable schema beta cannot widen the exemption.
3. **Docs**: `exportAccount` operation description, `UserExport.schema_version` field doc, `docs/api.md` (export bullet + stability-policy prose), `docs/api-compatibility-gate.md` (new "versioned interior" section).
4. **Tests**: see below.

No behavior changes. No field removals. `schema_version` stays required. SDK regen (`make generate-sdk`, Docker OpenAPI Generator v7.16.0) is docstring-only — zero consumer compile impact.

## Exact schema list marked beta (10)

`APIKeyExportEntry`, `AgentIdentity`, `Domain`, `Message`, `OAuthConnectionEntry`, `ProtectionEventExportEntry`, `Result`, `SuppressionExportEntry`, `UsageEventEntry`, `UserExportUser`

`UserExport` itself stays **unmarked** (stable envelope).

## Shared-schema analysis

Walked all `$ref`s from `UserExport` in the regenerated spec and cross-checked every name against (a) all other operations' request/response closures and (b) all operation-unreachable documentation components:

- **`CheckResult`** — shared: reachable from stable `getConversation` / `listMessages` / `getMessage` / `getReview` (via `AuthVerdict`) and beta `restoreMessage`. **NOT marked**; stays fully stable everywhere, including inside the export.
- **`AttachmentMeta`** — shared: referenced by `EmailReceivedData`, the **stable** `email.received` event-payload documentation component (operation-unreachable, so an operation-only walk misses it). **NOT marked**. The export's `Message.attachments` deliberately reuses the live wire shape ("one shape everywhere"), so it staying stable inside the export is coherent.
- All 10 marked schemas above are reachable **only** via `exportAccount` → no stable endpoint is degraded. No wrapper/alias types needed: the two shared schemas are stable in both worlds by construction, and the gate prune excludes exactly the export-only set.

## Test evidence

- `TestExportEnvelopeStableInteriorVersioned` (new, `internal/httpapi/export_stability_test.go`): recomputes the exemption boundary from the rendered document (independently of the stamping code) — asserts every export-only interior schema carries beta, `UserExport` + `schema_version` stay unmarked/required, shared schemas (`CheckResult`, `AttachmentMeta`) stay unmarked, and the operation description states the contract. Fails if a future interior schema renders unmarked or a shared schema gets degraded; a field change inside an existing interior schema touches nothing.
- `internal/openapicompat` unit tests (new): interior collapsed, envelope/shared/doc-component schemas untouched, interior diffs prune to identical output, envelope diffs survive the prune, no-envelope docs pass through.
- `make openapi-compat-test`: new fixtures — `export interior schema change` **passes** the gate; `export envelope key removal` and `schema shared between export and stable surface` **fail** it (`response-required-property-removed`). All pre-existing fixtures still pass.
- `make openapi-compat-check` vs `origin/main`: **no breaking changes**. End-to-end probes: interior field removal vs this branch → "No changes detected"; `schema_version` removal → blocked with `response-required-property-removed`.
- `make spec` + `make spec-check` + `TestSpecGoldenNoDrift`: green; full `internal/httpapi` suite green.
- Honest caveat: `make test-unit` shows pre-existing DB-backed failures in `internal/relay` / `internal/webhook` / `internal/identity` on this machine — verified **identical on a pristine `origin/main` worktree** (local test-DB state, unrelated to this change). `internal/httpapi`, `internal/openapicompat`, and `internal/identity`'s compile of the doc-tag change are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)