### PR TITLE
feat(api): promote the trash surface to stable for GA

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -5115,7 +5115,7 @@ paths:
       x-stability-level: beta
   /v1/agents/{email}/restore:
     post:
-      description: "Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent's live messages resume their clocks exactly where they stopped: each message's expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse (auto-resolve) the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash."
+      description: "Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent's live messages resume their clocks exactly where they stopped: each message's expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash."
       operationId: restoreAgent
       parameters:
         - description: The agent's full email address, e.g. support@acme.com.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -237,7 +237,7 @@ components:
           format: date-time
           type: string
         deleted_at:
-          description: When the agent was moved to the trash. Omitted for live agents.
+          description: When the agent was moved to the trash. Omitted for live agents. A trashed agent is restorable until purged — 30 days after deletion by default (deployment-configurable). While it sits in the trash its messages' expiry clocks are paused; restore resumes them where they stopped.
           format: date-time
           type: string
         domain:
@@ -751,7 +751,6 @@ components:
         - deleted
         - id
       type: object
-      x-stability-level: beta
     DeleteSuppressionResult:
       additionalProperties: true
       properties:
@@ -1964,7 +1963,7 @@ components:
           format: date-time
           type: string
         deleted_at:
-          description: When the message was moved to the trash. Omitted for live messages.
+          description: When the message was moved to the trash. Omitted for live messages. A trashed message is restorable until purged — 30 days after deletion by default (deployment-configurable). While it sits in the trash its natural expiry clock (expires_at) is paused; restore shifts expires_at forward by the time spent in the trash.
           format: date-time
           type: string
         delivered_to:
@@ -2055,7 +2054,7 @@ components:
           format: date-time
           type: string
         deleted_at:
-          description: When the message was moved to the trash. Omitted for live messages.
+          description: When the message was moved to the trash. Omitted for live messages. A trashed message is restorable until purged — 30 days after deletion by default (deployment-configurable). While it sits in the trash its natural expiry clock (expires_at) is paused; restore shifts expires_at forward by the time spent in the trash.
           format: date-time
           type: string
         delivered_to:
@@ -3909,12 +3908,12 @@ paths:
             maximum: 100
             minimum: 1
             type: integer
-        - description: "List the trash instead: agents that were soft-deleted and are restorable until purged (~30 days). Defaults to false (live agents only)."
+        - description: "List the trash instead: agents that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live agents only)."
           explode: false
           in: query
           name: deleted
           schema:
-            description: "List the trash instead: agents that were soft-deleted and are restorable until purged (~30 days). Defaults to false (live agents only)."
+            description: "List the trash instead: agents that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live agents only)."
             type: boolean
       responses:
         "200":
@@ -4019,7 +4018,7 @@ paths:
         - agents
   /v1/agents/{email}:
     delete:
-      description: Move an agent the caller owns to the trash. Requires ?confirm=DELETE. A trashed agent stops receiving mail, disappears from lists, and its held messages leave the review queue; restore it via POST /v1/agents/{email}/restore within 30 days, after which it is purged permanently (messages included). Pass permanent=true to skip the trash and delete irreversibly right away (accepts live and trashed agents). Returns 200 with a deletion receipt; messages_deleted is zero when the agent is moved to trash.
+      description: Move an agent the caller owns to the trash. Requires ?confirm=DELETE. A trashed agent stops receiving mail, disappears from lists, and its held messages leave the review queue; restore it via POST /v1/agents/{email}/restore within the trash retention window — 30 days by default (deployment-configurable) — after which it is purged permanently (messages included). While the agent sits in the trash its messages' expiry clocks are paused; restore resumes them exactly where they stopped. Pass permanent=true to skip the trash and delete irreversibly right away (accepts live and trashed agents). Returns 200 with a deletion receipt; messages_deleted is zero when the agent is moved to trash.
       operationId: deleteAgent
       parameters:
         - in: path
@@ -4271,7 +4270,7 @@ paths:
         - conversations
   /v1/agents/{email}/messages:
     get:
-      description: List an agent's messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review. Pass deleted=true for the trash (soft-deleted messages, restorable until purged ~30 days after deletion); the trash view defaults to direction=all and read_status=all.
+      description: List an agent's messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review. Pass deleted=true for the trash (soft-deleted messages, restorable until purged — 30 days after deletion by default, deployment-configurable); the trash view defaults to direction=all and read_status=all.
       operationId: listMessages
       parameters:
         - in: path
@@ -4369,12 +4368,12 @@ paths:
             maximum: 100
             minimum: 1
             type: integer
-        - description: "List the trash instead: messages that were soft-deleted and are restorable until purged (~30 days after deletion). Defaults to false (live messages only)."
+        - description: "List the trash instead: messages that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live messages only)."
           explode: false
           in: query
           name: deleted
           schema:
-            description: "List the trash instead: messages that were soft-deleted and are restorable until purged (~30 days after deletion). Defaults to false (live messages only)."
+            description: "List the trash instead: messages that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live messages only)."
             type: boolean
       responses:
         "200":
@@ -4531,7 +4530,7 @@ paths:
         - messages
   /v1/agents/{email}/messages/{id}:
     delete:
-      description: Move a message to the trash. Trashed messages disappear from lists, threads, and reply targets, but can be restored via POST …/messages/{id}/restore until they are purged ~30 days after deletion. No confirmation is required because the default delete is reversible. Pass permanent=true with confirm=DELETE to permanently delete a message that is ALREADY in the trash ("delete forever"). A message held for review (review_status=pending_review) cannot be deleted — resolve it in the review queue first (409 message_held).
+      description: Move a message to the trash. Trashed messages disappear from lists, threads, and reply targets, but can be restored via POST …/messages/{id}/restore until they are purged — 30 days after deletion by default (the trash retention window is deployment-configurable). While a message sits in the trash its natural expiry clock (expires_at) is paused; only the trash clock runs. No confirmation is required because the default delete is reversible. Pass permanent=true with confirm=DELETE to permanently delete a message that is ALREADY in the trash ("delete forever"). A message held for review (review_status=pending_review) cannot be deleted — resolve it in the review queue first (409 message_held).
       operationId: deleteMessage
       parameters:
         - description: The agent's full email address.
@@ -4586,9 +4585,8 @@ paths:
       summary: Delete a message (move to trash)
       tags:
         - messages
-      x-stability-level: beta
     get:
-      description: Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (~30 days after deletion); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and inbound auth headers.
+      description: Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and inbound auth headers.
       operationId: getMessage
       parameters:
         - description: The agent's full email address.
@@ -4995,7 +4993,7 @@ paths:
         - messages
   /v1/agents/{email}/messages/{id}/restore:
     post:
-      description: Bring a trashed (soft-deleted) message back to the inbox. Its remaining retention resumes where it left off — time spent in the trash does not count against the message's normal lifetime. Returns the restored message. 409 not_in_trash when the message is not in the trash.
+      description: Bring a trashed (soft-deleted) message back to the inbox. Its remaining retention resumes where it left off — expires_at is shifted forward by the time the message spent in the trash, so time in the trash does not count against the message's normal lifetime. Returns the restored message. 409 not_in_trash when the message is not in the trash.
       operationId: restoreMessage
       parameters:
         - description: The agent's full email address.
@@ -5036,7 +5034,6 @@ paths:
       summary: Restore a message from the trash
       tags:
         - messages
-      x-stability-level: beta
   /v1/agents/{email}/protection:
     get:
       description: "Read the agent's protection posture — inbound/outbound trust gate, content-scan sensitivity, and hold-queue mechanism. Account scope only: an agent-scoped credential cannot read its own protection config. Beta: the agent protection config is unstable — its shape may change before it is declared stable."
@@ -5118,7 +5115,7 @@ paths:
       x-stability-level: beta
   /v1/agents/{email}/restore:
     post:
-      description: Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
+      description: "Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent's live messages resume their clocks exactly where they stopped: each message's expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse (auto-resolve) the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash."
       operationId: restoreAgent
       parameters:
         - description: The agent's full email address, e.g. support@acme.com.
@@ -5152,7 +5149,6 @@ paths:
       summary: Restore an agent from the trash
       tags:
         - agents
-      x-stability-level: beta
   /v1/agents/{email}/test:
     post:
       description: Send a platform test email to the agent's own address to confirm inbound delivery. 202 when held for HITL.

--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -101,6 +101,13 @@ func main() {
 		log.Fatalf("Failed to load config: %v", err)
 	}
 
+	// Trash retention (trash.retention_days / E2A_TRASH_RETENTION_DAYS,
+	// default 30, validated ≥1 by config.Load). Applied before any store,
+	// janitor, or worker is constructed — every consumer (the janitor's
+	// purge SQL, PurgeDeletedAgents/PruneExpired) reads the package var at
+	// query time, so a single startup assignment governs the deployment.
+	identity.TrashRetention = time.Duration(cfg.Trash.RetentionDays) * 24 * time.Hour
+
 	// Database
 	ctx := context.Background()
 	pool, err := pgxpool.New(ctx, cfg.Database.URL)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -139,6 +139,16 @@ limits:
   # billing_hook_url: "http://billing:9000/api/internal/billing/cancel"
   billing_hook_url: ""
 
+# — Trash (soft delete) ———————————————————————————————————————————————————————
+# How many days a soft-deleted resource (agent inbox or message) stays
+# restorable in the trash before it is purged permanently. The public API
+# documents "30 days by default (deployment-configurable)" — this is the
+# knob. Minimum 1; while a resource sits in the trash its natural expiry
+# clock is paused (restore resumes it where it stopped). Override with
+# E2A_TRASH_RETENTION_DAYS.
+trash:
+  retention_days: 30
+
 
 
 # — Content screening (piguard) ——————————————————————————————————————————————

--- a/docs/api.md
+++ b/docs/api.md
@@ -193,7 +193,6 @@ every `/v1` operation not listed here is covered by the GA freeze.
 | operationId | Method and path | Surface |
 | --- | --- | --- |
 | `createTemplate` | `POST /v1/templates` | Templates |
-| `deleteMessage` | `DELETE /v1/agents/{email}/messages/{id}` | Message trash |
 | `deleteTemplate` | `DELETE /v1/templates/{id}` | Templates |
 | `getAgentProtection` | `GET /v1/agents/{email}/protection` | Protection config |
 | `getStarterTemplate` | `GET /v1/starter-templates/{alias}` | Starter templates |
@@ -201,8 +200,6 @@ every `/v1` operation not listed here is covered by the GA freeze.
 | `listStarterTemplates` | `GET /v1/starter-templates` | Starter templates |
 | `listTemplates` | `GET /v1/templates` | Templates |
 | `putAgentProtection` | `PUT /v1/agents/{email}/protection` | Protection config |
-| `restoreAgent` | `POST /v1/agents/{email}/restore` | Agent trash |
-| `restoreMessage` | `POST /v1/agents/{email}/messages/{id}/restore` | Message trash |
 | `updateTemplate` | `PATCH /v1/templates/{id}` | Templates |
 | `validateTemplate` | `POST /v1/templates/validate` | Templates |
 
@@ -223,8 +220,8 @@ every `/v1` operation not listed here is covered by the GA freeze.
 - **Beta surfaces are marked `x-stability-level: beta`** in the spec
   for automated compatibility tools
   (operations, schemas, and individual fields — e.g. the `template_*` fields on
-  send) and `(beta)` in prose — today: templates, starter templates, the agent
-  protection config, and the agent/message trash operations listed above. They are **exempt from the
+  send) and `(beta)` in prose — today: templates, starter templates, and the agent
+  protection config. They are **exempt from the
   freeze**: they may change or be removed without a major version. Where only
   specific *values* of a stable field are experimental (the screening +
   review-hold event types `email.flagged`, `email.blocked`,
@@ -352,7 +349,8 @@ single message.
 - `GET …/messages/{id}` — fetch one message (inbound or outbound), including the
   raw message and inbound auth headers. Reading an unread inbound message flips it
   to `read`. A soft-deleted message remains readable by this direct GET and carries
-  `deleted_at` until it is permanently purged (normally ~30 days after deletion).
+  `deleted_at` until it is permanently purged (30 days after deletion by default;
+  the trash retention window is deployment-configurable).
   Ordinary message lists, conversations, reply targets, and forward targets hide
   trashed messages; use `GET …/messages?deleted=true` to enumerate the trash.
 - `PATCH …/messages/{id}` — apply a labels delta (`add_labels` / `remove_labels`).

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,6 +46,7 @@ type Config struct {
 	SenderIdentity   SenderIdentityConfig   `yaml:"sender_identity"`
 	DeliveryFeedback DeliveryFeedbackConfig `yaml:"delivery_feedback"`
 	Limits           LimitsConfig           `yaml:"limits"`
+	Trash            TrashConfig            `yaml:"trash"`
 	Env              string                 `yaml:"env"` // "development" or "production"
 	// SharedDomain enables slug-based agent registration. When set
 	// (e.g. "agents.example.com"), users can register agents with just a
@@ -231,6 +232,18 @@ type LimitsConfig struct {
 	BillingHookURL string `yaml:"billing_hook_url"`
 }
 
+// TrashConfig tunes the soft-delete (trash) subsystem.
+type TrashConfig struct {
+	// RetentionDays is how many days a soft-deleted resource (agent inbox
+	// or message) stays restorable in the trash before the janitor purges
+	// it permanently. This is the knob behind the API contract's "30 days
+	// by default (deployment-configurable)" wording — the default is 30.
+	// Minimum 1 (a sub-day trash would break the restore promise the
+	// stable API documents); the server refuses to start on a lower value.
+	// Override with E2A_TRASH_RETENTION_DAYS.
+	RetentionDays int `yaml:"retention_days"`
+}
+
 func Load(path string) (*Config, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -258,6 +271,7 @@ func Load(path string) (*Config, error) {
 		},
 		Inbound:       InboundConfig{Mode: "sync"},
 		WebhookFanout: WebhookFanoutConfig{Mode: "legacy"},
+		Trash:         TrashConfig{RetentionDays: 30},
 		Env:           "development",
 	}
 
@@ -336,6 +350,11 @@ func Load(path string) (*Config, error) {
 	if v := os.Getenv("E2A_SENDER_IDENTITY_SES_REGION"); v != "" {
 		cfg.SenderIdentity.SESRegion = v
 	}
+	if v := os.Getenv("E2A_TRASH_RETENTION_DAYS"); v != "" {
+		if d, err := strconv.Atoi(v); err == nil {
+			cfg.Trash.RetentionDays = d
+		}
+	}
 	if v := os.Getenv("E2A_DELIVERY_SES_CONFIGURATION_SET"); v != "" {
 		cfg.DeliveryFeedback.SESConfigurationSet = v
 	}
@@ -382,6 +401,9 @@ func (c *Config) Validate() error {
 		if len(c.Signing.HMACSecret) < minHMACSecretBytes {
 			return fmt.Errorf("config: signing.hmac_secret is %d bytes; production requires at least %d (run `openssl rand -hex 32` to generate)", len(c.Signing.HMACSecret), minHMACSecretBytes)
 		}
+	}
+	if c.Trash.RetentionDays < 1 {
+		return fmt.Errorf("config: trash.retention_days must be at least 1 (got %d) — the stable API promises soft-deleted resources stay restorable", c.Trash.RetentionDays)
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -218,3 +218,55 @@ func TestIsProduction(t *testing.T) {
 		t.Error("expected IsProduction() to return false for development")
 	}
 }
+
+// Trash retention: defaults to 30 days, yaml + env override, and a value
+// below 1 day is refused at startup (the stable API promises soft-deleted
+// resources stay restorable — see internal/identity.TrashRetention).
+func TestTrashRetentionDefaultOverrideAndValidation(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name, body string) string {
+		t.Helper()
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte(body), 0644); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+
+	// Absent → default 30.
+	cfg, err := Load(write("default.yaml", "env: \"development\"\n"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Trash.RetentionDays != 30 {
+		t.Errorf("default Trash.RetentionDays = %d, want 30", cfg.Trash.RetentionDays)
+	}
+
+	// YAML override.
+	cfg, err = Load(write("yaml.yaml", "env: \"development\"\ntrash:\n  retention_days: 7\n"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Trash.RetentionDays != 7 {
+		t.Errorf("yaml Trash.RetentionDays = %d, want 7", cfg.Trash.RetentionDays)
+	}
+
+	// Env override wins over yaml.
+	t.Setenv("E2A_TRASH_RETENTION_DAYS", "90")
+	cfg, err = Load(write("env.yaml", "env: \"development\"\ntrash:\n  retention_days: 7\n"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Trash.RetentionDays != 90 {
+		t.Errorf("env Trash.RetentionDays = %d, want 90", cfg.Trash.RetentionDays)
+	}
+	t.Setenv("E2A_TRASH_RETENTION_DAYS", "")
+
+	// Below 1 day → refused.
+	if _, err := Load(write("zero.yaml", "env: \"development\"\ntrash:\n  retention_days: 0\n")); err == nil {
+		t.Error("Load should reject trash.retention_days: 0")
+	}
+	if _, err := Load(write("neg.yaml", "env: \"development\"\ntrash:\n  retention_days: -3\n")); err == nil {
+		t.Error("Load should reject a negative trash.retention_days")
+	}
+}

--- a/internal/httpapi/agents_write.go
+++ b/internal/httpapi/agents_write.go
@@ -113,7 +113,7 @@ func (s *Server) registerAgentWrites() {
 		Method:      http.MethodDelete,
 		Path:        "/v1/agents/{email}",
 		Summary:     "Delete an agent",
-		Description: "Move an agent the caller owns to the trash. Requires ?confirm=DELETE. A trashed agent stops receiving mail, disappears from lists, and its held messages leave the review queue; restore it via POST /v1/agents/{email}/restore within 30 days, after which it is purged permanently (messages included). Pass permanent=true to skip the trash and delete irreversibly right away (accepts live and trashed agents). Returns 200 with a deletion receipt; messages_deleted is zero when the agent is moved to trash.",
+		Description: "Move an agent the caller owns to the trash. Requires ?confirm=DELETE. A trashed agent stops receiving mail, disappears from lists, and its held messages leave the review queue; restore it via POST /v1/agents/{email}/restore within the trash retention window — 30 days by default (deployment-configurable) — after which it is purged permanently (messages included). While the agent sits in the trash its messages' expiry clocks are paused; restore resumes them exactly where they stopped. Pass permanent=true to skip the trash and delete irreversibly right away (accepts live and trashed agents). Returns 200 with a deletion receipt; messages_deleted is zero when the agent is moved to trash.",
 		Tags:        []string{"agents"},
 		Security:    []map[string][]string{{"bearer": {}}},
 	}, s.handleDeleteAgent)
@@ -123,10 +123,9 @@ func (s *Server) registerAgentWrites() {
 		Method:      http.MethodPost,
 		Path:        "/v1/agents/{email}/restore",
 		Summary:     "Restore an agent from the trash",
-		Description: "Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.",
+		Description: "Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent's live messages resume their clocks exactly where they stopped: each message's expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse (auto-resolve) the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.",
 		Tags:        []string{"agents"},
 		Security:    []map[string][]string{{"bearer": {}}},
-		Extensions:  beta(),
 	}, s.handleRestoreAgent)
 }
 

--- a/internal/httpapi/agents_write.go
+++ b/internal/httpapi/agents_write.go
@@ -123,7 +123,7 @@ func (s *Server) registerAgentWrites() {
 		Method:      http.MethodPost,
 		Path:        "/v1/agents/{email}/restore",
 		Summary:     "Restore an agent from the trash",
-		Description: "Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent's live messages resume their clocks exactly where they stopped: each message's expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse (auto-resolve) the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.",
+		Description: "Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent's live messages resume their clocks exactly where they stopped: each message's expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.",
 		Tags:        []string{"agents"},
 		Security:    []map[string][]string{{"bearer": {}}},
 	}, s.handleRestoreAgent)

--- a/internal/httpapi/messages.go
+++ b/internal/httpapi/messages.go
@@ -81,7 +81,7 @@ type MessageView struct {
 	// moved there, omitted on live messages. Trashed messages appear only in
 	// the deleted=true list view and this single-message get; they are purged
 	// ~30 days after deletion (docs/design/trash-soft-delete.md).
-	DeletedAt *time.Time `json:"deleted_at,omitempty" format:"date-time" doc:"When the message was moved to the trash. Omitted for live messages."`
+	DeletedAt *time.Time `json:"deleted_at,omitempty" format:"date-time" doc:"When the message was moved to the trash. Omitted for live messages. A trashed message is restorable until purged — 30 days after deletion by default (deployment-configurable). While it sits in the trash its natural expiry clock (expires_at) is paused; restore shifts expires_at forward by the time spent in the trash."`
 	// AuthHeaders is the raw X-E2A-Auth-* blob — a convenience copy, optional
 	// (MSG-12): omitted on outbound, where there is no inbound verdict. `auth`
 	// (AuthVerdict) is the primary, structured verdict.
@@ -272,7 +272,7 @@ type MessageSummaryView struct {
 	CreatedAt time.Time `json:"created_at" format:"date-time"`
 	// DeletedAt marks a message in the trash — set on rows of the deleted=true
 	// list view, omitted on live messages. See MessageView.DeletedAt.
-	DeletedAt *time.Time `json:"deleted_at,omitempty" format:"date-time" doc:"When the message was moved to the trash. Omitted for live messages."`
+	DeletedAt *time.Time `json:"deleted_at,omitempty" format:"date-time" doc:"When the message was moved to the trash. Omitted for live messages. A trashed message is restorable until purged — 30 days after deletion by default (deployment-configurable). While it sits in the trash its natural expiry clock (expires_at) is paused; restore shifts expires_at forward by the time spent in the trash."`
 	// Auth is the structured inbound authentication verdict (migration 032).
 	// Inbound-only; omitted on outbound rows.
 	Auth *AuthVerdict `json:"auth,omitempty"`
@@ -355,7 +355,7 @@ type ListMessagesInput struct {
 	Until           string   `query:"until" doc:"RFC3339; created_at < until."`
 	Cursor          string   `query:"cursor"`
 	Limit           int      `query:"limit" minimum:"1" maximum:"100" default:"100"`
-	Deleted         bool     `query:"deleted" doc:"List the trash instead: messages that were soft-deleted and are restorable until purged (~30 days after deletion). Defaults to false (live messages only)."`
+	Deleted         bool     `query:"deleted" doc:"List the trash instead: messages that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live messages only)."`
 }
 
 type listMessagesOutput struct {
@@ -387,7 +387,7 @@ func (s *Server) registerMessages() {
 		Method:      http.MethodGet,
 		Path:        "/v1/agents/{email}/messages",
 		Summary:     "List messages",
-		Description: "List an agent's messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review. Pass deleted=true for the trash (soft-deleted messages, restorable until purged ~30 days after deletion); the trash view defaults to direction=all and read_status=all.",
+		Description: "List an agent's messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review. Pass deleted=true for the trash (soft-deleted messages, restorable until purged — 30 days after deletion by default, deployment-configurable); the trash view defaults to direction=all and read_status=all.",
 		Tags:        []string{"messages"},
 		Security:    []map[string][]string{{"bearer": {}}},
 	}, s.handleListMessages)
@@ -397,10 +397,9 @@ func (s *Server) registerMessages() {
 		Method:      http.MethodDelete,
 		Path:        "/v1/agents/{email}/messages/{id}",
 		Summary:     "Delete a message (move to trash)",
-		Description: "Move a message to the trash. Trashed messages disappear from lists, threads, and reply targets, but can be restored via POST …/messages/{id}/restore until they are purged ~30 days after deletion. No confirmation is required because the default delete is reversible. Pass permanent=true with confirm=DELETE to permanently delete a message that is ALREADY in the trash (\"delete forever\"). A message held for review (review_status=pending_review) cannot be deleted — resolve it in the review queue first (409 message_held).",
+		Description: "Move a message to the trash. Trashed messages disappear from lists, threads, and reply targets, but can be restored via POST …/messages/{id}/restore until they are purged — 30 days after deletion by default (the trash retention window is deployment-configurable). While a message sits in the trash its natural expiry clock (expires_at) is paused; only the trash clock runs. No confirmation is required because the default delete is reversible. Pass permanent=true with confirm=DELETE to permanently delete a message that is ALREADY in the trash (\"delete forever\"). A message held for review (review_status=pending_review) cannot be deleted — resolve it in the review queue first (409 message_held).",
 		Tags:        []string{"messages"},
 		Security:    []map[string][]string{{"bearer": {}}},
-		Extensions:  beta(),
 	}, s.handleDeleteMessage)
 
 	huma.Register(s.API, huma.Operation{
@@ -408,10 +407,9 @@ func (s *Server) registerMessages() {
 		Method:      http.MethodPost,
 		Path:        "/v1/agents/{email}/messages/{id}/restore",
 		Summary:     "Restore a message from the trash",
-		Description: "Bring a trashed (soft-deleted) message back to the inbox. Its remaining retention resumes where it left off — time spent in the trash does not count against the message's normal lifetime. Returns the restored message. 409 not_in_trash when the message is not in the trash.",
+		Description: "Bring a trashed (soft-deleted) message back to the inbox. Its remaining retention resumes where it left off — expires_at is shifted forward by the time the message spent in the trash, so time in the trash does not count against the message's normal lifetime. Returns the restored message. 409 not_in_trash when the message is not in the trash.",
 		Tags:        []string{"messages"},
 		Security:    []map[string][]string{{"bearer": {}}},
-		Extensions:  beta(),
 	}, s.handleRestoreMessage)
 
 	huma.Register(s.API, huma.Operation{
@@ -419,7 +417,7 @@ func (s *Server) registerMessages() {
 		Method:      http.MethodGet,
 		Path:        "/v1/agents/{email}/messages/{id}",
 		Summary:     "Get a message",
-		Description: "Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (~30 days after deletion); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and inbound auth headers.",
+		Description: "Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and inbound auth headers.",
 		Tags:        []string{"messages"},
 		Security:    []map[string][]string{{"bearer": {}}},
 	}, func(ctx context.Context, in *MessageIDParam) (*messageOutput, error) {

--- a/internal/httpapi/operations.go
+++ b/internal/httpapi/operations.go
@@ -68,7 +68,7 @@ type AgentView struct {
 	// was moved there, omitted on live agents. Trashed agents appear only via
 	// GET /v1/agents?deleted=true and restore/permanent-delete operations; they
 	// are purged ~30 days after deletion (docs/design/trash-soft-delete.md).
-	DeletedAt *time.Time `json:"deleted_at,omitempty" format:"date-time" doc:"When the agent was moved to the trash. Omitted for live agents."`
+	DeletedAt *time.Time `json:"deleted_at,omitempty" format:"date-time" doc:"When the agent was moved to the trash. Omitted for live agents. A trashed agent is restorable until purged — 30 days after deletion by default (deployment-configurable). While it sits in the trash its messages' expiry clocks are paused; restore resumes them where they stopped."`
 }
 
 // agentViewFromIdentity maps the storage record to the public view.
@@ -94,7 +94,7 @@ type listAgentsOutput struct {
 // trash-view flag.
 type listAgentsInput struct {
 	PageParams
-	Deleted bool `query:"deleted" doc:"List the trash instead: agents that were soft-deleted and are restorable until purged (~30 days). Defaults to false (live agents only)."`
+	Deleted bool `query:"deleted" doc:"List the trash instead: agents that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live agents only)."`
 }
 
 // AddressParam is the shared path input for per-agent operations. The

--- a/internal/httpapi/stability_test.go
+++ b/internal/httpapi/stability_test.go
@@ -14,7 +14,6 @@ import (
 
 var betaOperationIDs = []string{
 	"createTemplate",
-	"deleteMessage",
 	"deleteTemplate",
 	"getAgentProtection",
 	"getStarterTemplate",
@@ -22,8 +21,6 @@ var betaOperationIDs = []string{
 	"listStarterTemplates",
 	"listTemplates",
 	"putAgentProtection",
-	"restoreAgent",
-	"restoreMessage",
 	"updateTemplate",
 	"validateTemplate",
 }
@@ -277,7 +274,7 @@ func TestSpecBetaMarkers(t *testing.T) {
 			t.Errorf("%s must carry canonical x-stability-level: beta, got %v", id, got)
 		}
 	}
-	for _, id := range []string{"sendMessage", "createAgent", "listMessages", "createWebhook", "listEvents"} {
+	for _, id := range []string{"sendMessage", "createAgent", "listMessages", "createWebhook", "listEvents", "deleteMessage", "restoreMessage", "restoreAgent", "deleteAgent"} {
 		if got := opExt(id, "x-stability"); got != nil {
 			t.Errorf("%s is stable GA surface and must NOT carry x-stability, got %v", id, got)
 		}
@@ -303,7 +300,7 @@ func TestSpecBetaMarkers(t *testing.T) {
 			t.Errorf("schema %s must carry canonical x-stability-level: beta, got %v", name, got)
 		}
 	}
-	for _, name := range []string{"MessageView", "AgentView", "WebhookView", "SendEmailRequest", "ErrorEnvelope"} {
+	for _, name := range []string{"MessageView", "AgentView", "WebhookView", "SendEmailRequest", "ErrorEnvelope", "DeleteMessageResult"} {
 		if got := schemaExt(name, "x-stability"); got != nil {
 			t.Errorf("schema %s is stable and must NOT carry x-stability, got %v", name, got)
 		}

--- a/internal/identity/review.go
+++ b/internal/identity/review.go
@@ -208,9 +208,17 @@ func (s *Store) ListExpiredReviews(ctx context.Context, limit int) ([]Expiration
 // guard for human-driven transitions (a reviewer may only release a message
 // belonging to an agent they own; the handler resolves the owned agent first).
 // Worker-driven (TTL) transitions pass "" (system-scoped) and a nil reviewerID.
+//
+// The agent-not-trashed guard is part of the CAS: a hold whose agent was moved
+// to the trash after ListExpiredReviews selected it must not auto-resolve —
+// trashed holds stay pending_review with their clock paused until RestoreAgent
+// shifts approval_expires_at (or the trash purge drops them). Same TOCTOU
+// closure as the outbound arms (ExpireReject / ApproveAndAccept).
 func (s *Store) transitionReview(ctx context.Context, messageID, agentID, newStatus string, reviewerID *string, rejectionReason string) error {
 	args := []any{messageID, newStatus, reviewerID, rejectionReason}
-	where := `id = $1 AND direction = 'inbound' AND status = 'pending_review'`
+	where := `id = $1 AND direction = 'inbound' AND status = 'pending_review'
+	    AND NOT EXISTS (SELECT 1 FROM agent_identities ai
+	                     WHERE ai.id = messages.agent_id AND ai.deleted_at IS NOT NULL)`
 	if agentID != "" {
 		args = append(args, agentID)
 		where += ` AND agent_id = $5`

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -1526,7 +1526,12 @@ const MessageTTL = 10 * 24 * time.Hour // 10 days
 // the Gmail-style 30-day window (docs/design/trash-soft-delete.md). While a
 // message sits in the trash its natural expiry clock (MessageTTL /
 // expires_at) is suspended; the trash clock alone governs. A var (not a
-// const) so a deployment or test can tune it; default 30 days.
+// const): cmd/e2a/main.go assigns it at startup from the deployment config
+// (trash.retention_days / E2A_TRASH_RETENTION_DAYS, validated ≥1 day), and
+// tests may tune it directly. Default 30 days — the number the stable API
+// contract documents ("30 days by default, deployment-configurable").
+// Every consumer reads it at query time, so the startup assignment (before
+// any janitor/worker starts) governs the whole process.
 var TrashRetention = 30 * 24 * time.Hour
 
 // ErrNotInTrash is returned by restore/purge operations that target a
@@ -2734,6 +2739,8 @@ func (s *Store) ExpireApproveAndSend(
 		   AND direction = 'outbound'
 		   AND status = 'pending_review'
 		   AND approval_expires_at < now()
+		   AND NOT EXISTS (SELECT 1 FROM agent_identities ai
+		                    WHERE ai.id = messages.agent_id AND ai.deleted_at IS NOT NULL)
 		 FOR NO KEY UPDATE SKIP LOCKED`,
 		messageID,
 	).Scan(
@@ -2877,7 +2884,12 @@ type AcceptedSend struct {
 //
 // The WHERE status='pending_review' is the compare-and-set guard: RETURNING no row
 // means a human/other worker already resolved the hold → ErrNotPendingApproval (a
-// no-op for the caller). Body columns are scrubbed exactly like ApproveAndSend.
+// no-op for the caller). The agent-not-trashed guard sits in the same WHERE so it
+// is atomic with the CAS: a hold whose agent was trashed after the caller's
+// pre-checks (the TTL sweep's candidate SELECT, or a human path's ownership load)
+// must NOT resolve — trashed holds stay pending_review with their clock paused
+// until RestoreAgent shifts approval_expires_at (or the trash purge drops them).
+// Body columns are scrubbed exactly like ApproveAndSend.
 func (s *Store) ApproveAndAccept(
 	ctx context.Context,
 	messageID, reviewedByUserID, targetStatus string,
@@ -2909,6 +2921,8 @@ func (s *Store) ApproveAndAccept(
 			        edited              = $13,
 			        body_text = NULL, body_html = NULL, attachments_json = NULL
 			  WHERE id = $1 AND direction = 'outbound' AND status = 'pending_review'
+			    AND NOT EXISTS (SELECT 1 FROM agent_identities ai
+			                     WHERE ai.id = messages.agent_id AND ai.deleted_at IS NOT NULL)
 			  RETURNING id, agent_id, message_type, subject, to_recipients, cc, bcc, status, edited`,
 			messageID,
 			targetStatus,
@@ -3000,8 +3014,13 @@ func (s *Store) LoadOutboundDraft(ctx context.Context, messageID string) (*Messa
 
 // ExpireReject transitions a pending_review message to review_expired_rejected
 // and scrubs body columns. No user ownership check — this is the worker
-// path. If the row is no longer pending (racing worker, already handled)
-// returns ErrNotPendingApproval; caller can treat as a no-op.
+// path. If the row is no longer pending (racing worker, already handled),
+// or the agent was moved to the trash after the sweep listed the row (the
+// hold must survive intact — its scrubbed body would be unrecoverable, and
+// RestoreAgent shifts approval_expires_at so the clock resumes on restore),
+// returns ErrNotPendingApproval; caller can treat as a no-op. The trash
+// guard lives INSIDE the CAS so it is atomic with the transition — a
+// separate read would reopen the sweep's TOCTOU window.
 func (s *Store) ExpireReject(ctx context.Context, messageID, reason string) (*Message, error) {
 	tag, err := s.pool.Exec(ctx,
 		`UPDATE messages
@@ -3011,7 +3030,9 @@ func (s *Store) ExpireReject(ctx context.Context, messageID, reason string) (*Me
 		        body_text = NULL,
 		        body_html = NULL,
 		        attachments_json = NULL
-		  WHERE id = $1 AND status = 'pending_review' AND direction = 'outbound'`,
+		  WHERE id = $1 AND status = 'pending_review' AND direction = 'outbound'
+		    AND NOT EXISTS (SELECT 1 FROM agent_identities ai
+		                     WHERE ai.id = messages.agent_id AND ai.deleted_at IS NOT NULL)`,
 		messageID, MessageStatusReviewExpiredRejected, reason,
 	)
 	if err != nil {

--- a/internal/identity/trash_hold_guard_test.go
+++ b/internal/identity/trash_hold_guard_test.go
@@ -1,0 +1,264 @@
+package identity_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/tokencanopy/e2a/internal/identity"
+	"github.com/tokencanopy/e2a/internal/testutil"
+)
+
+// These tests pin the paused-clock invariant the stable trash contract
+// documents: a review hold whose agent sits in the trash must NEVER
+// auto-resolve — not by the TTL sweep's reject arm (which scrubs the draft
+// body unrecoverably), not by its approve arm, and not via a stale
+// human-approve. The guard must be atomic with the resolve CAS itself:
+// the sweep's candidate SELECT (ListExpiredPending / ListExpiredReviews)
+// filters trashed agents, but an agent can be trashed between that SELECT
+// and the per-row resolve (TOCTOU), so each resolve UPDATE re-checks.
+
+// pendingHoldRow reads back the columns the guard protects.
+func pendingHoldRow(t *testing.T, pool interface {
+	QueryRow(ctx context.Context, sql string, args ...any) pgx.Row
+}, msgID string) (status string, bodyText *string, approvalExpiresAt *time.Time) {
+	t.Helper()
+	if err := pool.QueryRow(context.Background(),
+		`SELECT status, body_text, approval_expires_at FROM messages WHERE id=$1`, msgID,
+	).Scan(&status, &bodyText, &approvalExpiresAt); err != nil {
+		t.Fatalf("read back hold row: %v", err)
+	}
+	return status, bodyText, approvalExpiresAt
+}
+
+// TestExpireRejectSkipsTrashedAgentHold: the reject arm of the TTL sweep is
+// the destructive one (it NULLs body_text/body_html/attachments_json), so a
+// trashed agent's expired hold must survive it byte-intact.
+func TestExpireRejectSkipsTrashedAgentHold(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, a := setupPendingAgent(t, store, "trash-guard-rej")
+	msg, err := store.CreatePendingOutboundMessage(ctx, a.ID,
+		[]string{"x@example.com"}, nil, nil, "held subject", "held body", "", nil,
+		"send", "", "", "", 60)
+	if err != nil {
+		t.Fatalf("CreatePendingOutboundMessage: %v", err)
+	}
+	// Expired hold — exactly what the sweep would pick up…
+	if _, err := pool.Exec(ctx, `UPDATE messages SET approval_expires_at = now() - interval '10 minutes' WHERE id=$1`, msg.ID); err != nil {
+		t.Fatal(err)
+	}
+	// …but the agent is trashed between the sweep's SELECT and the resolve.
+	if err := store.SoftDeleteAgent(ctx, a.ID, user.ID); err != nil {
+		t.Fatalf("SoftDeleteAgent: %v", err)
+	}
+
+	if _, err := store.ExpireReject(ctx, msg.ID, "ttl_expired"); !errors.Is(err, identity.ErrNotPendingApproval) {
+		t.Fatalf("ExpireReject on trashed agent's hold = %v, want ErrNotPendingApproval (no-op)", err)
+	}
+	status, body, _ := pendingHoldRow(t, pool, msg.ID)
+	if status != identity.MessageStatusPendingReview {
+		t.Errorf("status = %q, want pending_review (hold must survive the trash)", status)
+	}
+	if body == nil || *body != "held body" {
+		t.Errorf("body_text = %v, want intact draft body", body)
+	}
+
+	// Sanity: the sweep's candidate list also excludes it while trashed.
+	cands, err := store.ListExpiredPending(ctx, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range cands {
+		if c.MessageID == msg.ID {
+			t.Error("ListExpiredPending must exclude a trashed agent's hold")
+		}
+	}
+}
+
+// TestApproveAndAcceptSkipsTrashedAgentHold: the approve arm (shared by the
+// TTL sweep's auto-approve and the human/magic-link async approve) must not
+// resolve+enqueue a trashed agent's hold — otherwise the SendWorker's own
+// trash check cancels it into a spurious terminal failure.
+func TestApproveAndAcceptSkipsTrashedAgentHold(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, a := setupPendingAgent(t, store, "trash-guard-app")
+	msg, err := store.CreatePendingOutboundMessage(ctx, a.ID,
+		[]string{"x@example.com"}, nil, nil, "held subject", "held body", "", nil,
+		"send", "", "", "", 60)
+	if err != nil {
+		t.Fatalf("CreatePendingOutboundMessage: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE messages SET approval_expires_at = now() - interval '10 minutes' WHERE id=$1`, msg.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SoftDeleteAgent(ctx, a.ID, user.ID); err != nil {
+		t.Fatalf("SoftDeleteAgent: %v", err)
+	}
+
+	enqueued := 0
+	enqueue := func(_ context.Context, _ pgx.Tx, _ string) (int64, error) {
+		enqueued++
+		return 1, nil
+	}
+	acc := identity.AcceptedSend{
+		To: []string{"x@example.com"}, Subject: "held subject", Method: "smtp",
+		EnvelopeFrom: "bot@trash-guard-app.example.com", SentAs: "relay", Raw: []byte("raw"),
+	}
+	_, err = store.ApproveAndAccept(ctx, msg.ID, "", identity.MessageStatusReviewExpiredApproved, false, acc, enqueue, nil)
+	if !errors.Is(err, identity.ErrNotPendingApproval) {
+		t.Fatalf("ApproveAndAccept on trashed agent's hold = %v, want ErrNotPendingApproval (no-op)", err)
+	}
+	if enqueued != 0 {
+		t.Errorf("enqueue called %d times, want 0 — no send job may exist for a trashed agent's hold", enqueued)
+	}
+	status, body, _ := pendingHoldRow(t, pool, msg.ID)
+	if status != identity.MessageStatusPendingReview {
+		t.Errorf("status = %q, want pending_review", status)
+	}
+	if body == nil || *body != "held body" {
+		t.Errorf("body_text = %v, want intact draft body", body)
+	}
+}
+
+// TestExpireApproveAndSendSkipsTrashedAgentHold covers the synchronous
+// expire-approve path: its locked SELECT must not hand a trashed agent's
+// draft to the send callback.
+func TestExpireApproveAndSendSkipsTrashedAgentHold(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, a := setupPendingAgent(t, store, "trash-guard-sync")
+	msg, err := store.CreatePendingOutboundMessage(ctx, a.ID,
+		[]string{"x@example.com"}, nil, nil, "held subject", "held body", "", nil,
+		"send", "", "", "", 60)
+	if err != nil {
+		t.Fatalf("CreatePendingOutboundMessage: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE messages SET approval_expires_at = now() - interval '10 minutes' WHERE id=$1`, msg.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SoftDeleteAgent(ctx, a.ID, user.ID); err != nil {
+		t.Fatalf("SoftDeleteAgent: %v", err)
+	}
+
+	_, err = store.ExpireApproveAndSend(ctx, msg.ID, func(_ *identity.Message) (identity.SendResult, error) {
+		t.Error("send callback must not run for a trashed agent's hold")
+		return identity.SendResult{}, errors.New("must not send")
+	})
+	if !errors.Is(err, identity.ErrNotPendingApproval) {
+		t.Fatalf("ExpireApproveAndSend on trashed agent's hold = %v, want ErrNotPendingApproval", err)
+	}
+	status, _, _ := pendingHoldRow(t, pool, msg.ID)
+	if status != identity.MessageStatusPendingReview {
+		t.Errorf("status = %q, want pending_review", status)
+	}
+}
+
+// TestInboundExpireArmsSkipTrashedAgentHold: the inbound TTL arms
+// (ExpireApproveReview / ExpireRejectReview) share the same TOCTOU window
+// against ListExpiredReviews and must no-op on a trashed agent's hold.
+func TestInboundExpireArmsSkipTrashedAgentHold(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	userID, agentID := seedReviewAgent(t, store, ctx, "trash-guard-in.example.com")
+
+	past := time.Now().Add(-10 * time.Minute)
+	heldApprove := createInbound(t, store, ctx, agentID, "s@x.com", "held-a", identity.InboundScreening{
+		Status: identity.MessageStatusPendingReview, ScanAction: "review",
+		ReviewReason: identity.ReviewReasonInboundScan, ApprovalExpiresAt: &past,
+	})
+	heldReject := createInbound(t, store, ctx, agentID, "s@x.com", "held-r", identity.InboundScreening{
+		Status: identity.MessageStatusPendingReview, ScanAction: "review",
+		ReviewReason: identity.ReviewReasonInboundScan, ApprovalExpiresAt: &past,
+	})
+	if err := store.SoftDeleteAgent(ctx, agentID, userID); err != nil {
+		t.Fatalf("SoftDeleteAgent: %v", err)
+	}
+
+	if err := store.ExpireApproveReview(ctx, heldApprove); !errors.Is(err, identity.ErrNotPendingReview) {
+		t.Errorf("ExpireApproveReview on trashed agent's hold = %v, want ErrNotPendingReview", err)
+	}
+	if err := store.ExpireRejectReview(ctx, heldReject, "ttl_expired"); !errors.Is(err, identity.ErrNotPendingReview) {
+		t.Errorf("ExpireRejectReview on trashed agent's hold = %v, want ErrNotPendingReview", err)
+	}
+	for _, id := range []string{heldApprove, heldReject} {
+		status, _, _ := pendingHoldRow(t, pool, id)
+		if status != identity.MessageStatusPendingReview {
+			t.Errorf("inbound hold %s status = %q, want pending_review", id, status)
+		}
+	}
+}
+
+// TestRestoreAgentShiftsHoldClockAndKeepsHoldPending pins the restore half
+// of the invariant: an agent restored after time in the trash gets its held
+// drafts' approval_expires_at shifted forward by exactly the trashed
+// interval, so a hold that had review time left cannot fire the instant the
+// agent returns — it re-enters the queue with its remaining TTL.
+func TestRestoreAgentShiftsHoldClockAndKeepsHoldPending(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, a := setupPendingAgent(t, store, "trash-guard-res")
+	msg, err := store.CreatePendingOutboundMessage(ctx, a.ID,
+		[]string{"x@example.com"}, nil, nil, "held subject", "held body", "", nil,
+		"send", "", "", "", 300) // 5 minutes of review time left
+	if err != nil {
+		t.Fatalf("CreatePendingOutboundMessage: %v", err)
+	}
+	if err := store.SoftDeleteAgent(ctx, a.ID, user.ID); err != nil {
+		t.Fatalf("SoftDeleteAgent: %v", err)
+	}
+	// Simulate that the trashing happened 10 minutes ago with 5 minutes of
+	// review TTL left at that moment: original expiry = trash time + 5m =
+	// now - 5m. Without the restore shift the hold would come back 5
+	// minutes PAST its TTL and the next sweep would fire it immediately.
+	if _, err := pool.Exec(ctx,
+		`UPDATE agent_identities SET deleted_at = now() - interval '10 minutes' WHERE id=$1`, a.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx,
+		`UPDATE messages SET approval_expires_at = now() - interval '5 minutes' WHERE id=$1`, msg.ID); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.RestoreAgent(ctx, a.ID, user.ID); err != nil {
+		t.Fatalf("RestoreAgent: %v", err)
+	}
+
+	status, body, expiresAt := pendingHoldRow(t, pool, msg.ID)
+	if status != identity.MessageStatusPendingReview {
+		t.Fatalf("status after restore = %q, want pending_review", status)
+	}
+	if body == nil || *body != "held body" {
+		t.Errorf("body_text after restore = %v, want intact draft body", body)
+	}
+	if expiresAt == nil {
+		t.Fatal("approval_expires_at is NULL after restore")
+	}
+	// ~5 minutes of TTL remained at trash time; the shift must return it.
+	remaining := time.Until(*expiresAt)
+	if remaining < 4*time.Minute || remaining > 6*time.Minute {
+		t.Errorf("approval_expires_at remaining = %v, want ≈5m (clock resumed where it stopped)", remaining)
+	}
+	// Not expired → the sweep must not list it.
+	cands, err := store.ListExpiredPending(ctx, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, c := range cands {
+		if c.MessageID == msg.ID {
+			t.Error("restored hold with remaining TTL must not appear in ListExpiredPending")
+		}
+	}
+}

--- a/sdks/python/src/e2a/v1/generated/api/agents_api.py
+++ b/sdks/python/src/e2a/v1/generated/api/agents_api.py
@@ -1748,7 +1748,7 @@ class AgentsApi:
     ) -> AgentView:
         """Restore an agent from the trash
 
-        Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent's live messages resume their clocks exactly where they stopped: each message's expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse (auto-resolve) the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
+        Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent's live messages resume their clocks exactly where they stopped: each message's expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
 
         :param email: The agent's full email address, e.g. support@acme.com. (required)
         :type email: str
@@ -1815,7 +1815,7 @@ class AgentsApi:
     ) -> ApiResponse[AgentView]:
         """Restore an agent from the trash
 
-        Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent's live messages resume their clocks exactly where they stopped: each message's expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse (auto-resolve) the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
+        Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent's live messages resume their clocks exactly where they stopped: each message's expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
 
         :param email: The agent's full email address, e.g. support@acme.com. (required)
         :type email: str
@@ -1882,7 +1882,7 @@ class AgentsApi:
     ) -> RESTResponseType:
         """Restore an agent from the trash
 
-        Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent's live messages resume their clocks exactly where they stopped: each message's expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse (auto-resolve) the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
+        Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent's live messages resume their clocks exactly where they stopped: each message's expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
 
         :param email: The agent's full email address, e.g. support@acme.com. (required)
         :type email: str

--- a/sdks/python/src/e2a/v1/generated/api/agents_api.py
+++ b/sdks/python/src/e2a/v1/generated/api/agents_api.py
@@ -347,7 +347,7 @@ class AgentsApi:
     ) -> DeleteAgentResult:
         """Delete an agent
 
-        Move an agent the caller owns to the trash. Requires ?confirm=DELETE. A trashed agent stops receiving mail, disappears from lists, and its held messages leave the review queue; restore it via POST /v1/agents/{email}/restore within 30 days, after which it is purged permanently (messages included). Pass permanent=true to skip the trash and delete irreversibly right away (accepts live and trashed agents). Returns 200 with a deletion receipt; messages_deleted is zero when the agent is moved to trash.
+        Move an agent the caller owns to the trash. Requires ?confirm=DELETE. A trashed agent stops receiving mail, disappears from lists, and its held messages leave the review queue; restore it via POST /v1/agents/{email}/restore within the trash retention window — 30 days by default (deployment-configurable) — after which it is purged permanently (messages included). While the agent sits in the trash its messages' expiry clocks are paused; restore resumes them exactly where they stopped. Pass permanent=true to skip the trash and delete irreversibly right away (accepts live and trashed agents). Returns 200 with a deletion receipt; messages_deleted is zero when the agent is moved to trash.
 
         :param email: (required)
         :type email: str
@@ -422,7 +422,7 @@ class AgentsApi:
     ) -> ApiResponse[DeleteAgentResult]:
         """Delete an agent
 
-        Move an agent the caller owns to the trash. Requires ?confirm=DELETE. A trashed agent stops receiving mail, disappears from lists, and its held messages leave the review queue; restore it via POST /v1/agents/{email}/restore within 30 days, after which it is purged permanently (messages included). Pass permanent=true to skip the trash and delete irreversibly right away (accepts live and trashed agents). Returns 200 with a deletion receipt; messages_deleted is zero when the agent is moved to trash.
+        Move an agent the caller owns to the trash. Requires ?confirm=DELETE. A trashed agent stops receiving mail, disappears from lists, and its held messages leave the review queue; restore it via POST /v1/agents/{email}/restore within the trash retention window — 30 days by default (deployment-configurable) — after which it is purged permanently (messages included). While the agent sits in the trash its messages' expiry clocks are paused; restore resumes them exactly where they stopped. Pass permanent=true to skip the trash and delete irreversibly right away (accepts live and trashed agents). Returns 200 with a deletion receipt; messages_deleted is zero when the agent is moved to trash.
 
         :param email: (required)
         :type email: str
@@ -497,7 +497,7 @@ class AgentsApi:
     ) -> RESTResponseType:
         """Delete an agent
 
-        Move an agent the caller owns to the trash. Requires ?confirm=DELETE. A trashed agent stops receiving mail, disappears from lists, and its held messages leave the review queue; restore it via POST /v1/agents/{email}/restore within 30 days, after which it is purged permanently (messages included). Pass permanent=true to skip the trash and delete irreversibly right away (accepts live and trashed agents). Returns 200 with a deletion receipt; messages_deleted is zero when the agent is moved to trash.
+        Move an agent the caller owns to the trash. Requires ?confirm=DELETE. A trashed agent stops receiving mail, disappears from lists, and its held messages leave the review queue; restore it via POST /v1/agents/{email}/restore within the trash retention window — 30 days by default (deployment-configurable) — after which it is purged permanently (messages included). While the agent sits in the trash its messages' expiry clocks are paused; restore resumes them exactly where they stopped. Pass permanent=true to skip the trash and delete irreversibly right away (accepts live and trashed agents). Returns 200 with a deletion receipt; messages_deleted is zero when the agent is moved to trash.
 
         :param email: (required)
         :type email: str
@@ -1148,7 +1148,7 @@ class AgentsApi:
         self,
         cursor: Annotated[Optional[StrictStr], Field(description="Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.")] = None,
         limit: Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=1)]], Field(description="Maximum number of items to return (1-100).")] = None,
-        deleted: Annotated[Optional[StrictBool], Field(description="List the trash instead: agents that were soft-deleted and are restorable until purged (~30 days). Defaults to false (live agents only).")] = None,
+        deleted: Annotated[Optional[StrictBool], Field(description="List the trash instead: agents that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live agents only).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1170,7 +1170,7 @@ class AgentsApi:
         :type cursor: str
         :param limit: Maximum number of items to return (1-100).
         :type limit: int
-        :param deleted: List the trash instead: agents that were soft-deleted and are restorable until purged (~30 days). Defaults to false (live agents only).
+        :param deleted: List the trash instead: agents that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live agents only).
         :type deleted: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -1223,7 +1223,7 @@ class AgentsApi:
         self,
         cursor: Annotated[Optional[StrictStr], Field(description="Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.")] = None,
         limit: Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=1)]], Field(description="Maximum number of items to return (1-100).")] = None,
-        deleted: Annotated[Optional[StrictBool], Field(description="List the trash instead: agents that were soft-deleted and are restorable until purged (~30 days). Defaults to false (live agents only).")] = None,
+        deleted: Annotated[Optional[StrictBool], Field(description="List the trash instead: agents that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live agents only).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1245,7 +1245,7 @@ class AgentsApi:
         :type cursor: str
         :param limit: Maximum number of items to return (1-100).
         :type limit: int
-        :param deleted: List the trash instead: agents that were soft-deleted and are restorable until purged (~30 days). Defaults to false (live agents only).
+        :param deleted: List the trash instead: agents that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live agents only).
         :type deleted: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -1298,7 +1298,7 @@ class AgentsApi:
         self,
         cursor: Annotated[Optional[StrictStr], Field(description="Opaque pagination cursor from a previous response's next_cursor. Continuation requests must not change the other filters.")] = None,
         limit: Annotated[Optional[Annotated[int, Field(le=100, strict=True, ge=1)]], Field(description="Maximum number of items to return (1-100).")] = None,
-        deleted: Annotated[Optional[StrictBool], Field(description="List the trash instead: agents that were soft-deleted and are restorable until purged (~30 days). Defaults to false (live agents only).")] = None,
+        deleted: Annotated[Optional[StrictBool], Field(description="List the trash instead: agents that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live agents only).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1320,7 +1320,7 @@ class AgentsApi:
         :type cursor: str
         :param limit: Maximum number of items to return (1-100).
         :type limit: int
-        :param deleted: List the trash instead: agents that were soft-deleted and are restorable until purged (~30 days). Defaults to false (live agents only).
+        :param deleted: List the trash instead: agents that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live agents only).
         :type deleted: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -1748,7 +1748,7 @@ class AgentsApi:
     ) -> AgentView:
         """Restore an agent from the trash
 
-        Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
+        Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent's live messages resume their clocks exactly where they stopped: each message's expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse (auto-resolve) the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
 
         :param email: The agent's full email address, e.g. support@acme.com. (required)
         :type email: str
@@ -1815,7 +1815,7 @@ class AgentsApi:
     ) -> ApiResponse[AgentView]:
         """Restore an agent from the trash
 
-        Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
+        Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent's live messages resume their clocks exactly where they stopped: each message's expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse (auto-resolve) the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
 
         :param email: The agent's full email address, e.g. support@acme.com. (required)
         :type email: str
@@ -1882,7 +1882,7 @@ class AgentsApi:
     ) -> RESTResponseType:
         """Restore an agent from the trash
 
-        Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
+        Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent's live messages resume their clocks exactly where they stopped: each message's expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse (auto-resolve) the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
 
         :param email: The agent's full email address, e.g. support@acme.com. (required)
         :type email: str

--- a/sdks/python/src/e2a/v1/generated/api/messages_api.py
+++ b/sdks/python/src/e2a/v1/generated/api/messages_api.py
@@ -70,7 +70,7 @@ class MessagesApi:
     ) -> DeleteMessageResult:
         """Delete a message (move to trash)
 
-        Move a message to the trash. Trashed messages disappear from lists, threads, and reply targets, but can be restored via POST …/messages/{id}/restore until they are purged ~30 days after deletion. No confirmation is required because the default delete is reversible. Pass permanent=true with confirm=DELETE to permanently delete a message that is ALREADY in the trash (\"delete forever\"). A message held for review (review_status=pending_review) cannot be deleted — resolve it in the review queue first (409 message_held).
+        Move a message to the trash. Trashed messages disappear from lists, threads, and reply targets, but can be restored via POST …/messages/{id}/restore until they are purged — 30 days after deletion by default (the trash retention window is deployment-configurable). While a message sits in the trash its natural expiry clock (expires_at) is paused; only the trash clock runs. No confirmation is required because the default delete is reversible. Pass permanent=true with confirm=DELETE to permanently delete a message that is ALREADY in the trash (\"delete forever\"). A message held for review (review_status=pending_review) cannot be deleted — resolve it in the review queue first (409 message_held).
 
         :param email: The agent's full email address. (required)
         :type email: str
@@ -149,7 +149,7 @@ class MessagesApi:
     ) -> ApiResponse[DeleteMessageResult]:
         """Delete a message (move to trash)
 
-        Move a message to the trash. Trashed messages disappear from lists, threads, and reply targets, but can be restored via POST …/messages/{id}/restore until they are purged ~30 days after deletion. No confirmation is required because the default delete is reversible. Pass permanent=true with confirm=DELETE to permanently delete a message that is ALREADY in the trash (\"delete forever\"). A message held for review (review_status=pending_review) cannot be deleted — resolve it in the review queue first (409 message_held).
+        Move a message to the trash. Trashed messages disappear from lists, threads, and reply targets, but can be restored via POST …/messages/{id}/restore until they are purged — 30 days after deletion by default (the trash retention window is deployment-configurable). While a message sits in the trash its natural expiry clock (expires_at) is paused; only the trash clock runs. No confirmation is required because the default delete is reversible. Pass permanent=true with confirm=DELETE to permanently delete a message that is ALREADY in the trash (\"delete forever\"). A message held for review (review_status=pending_review) cannot be deleted — resolve it in the review queue first (409 message_held).
 
         :param email: The agent's full email address. (required)
         :type email: str
@@ -228,7 +228,7 @@ class MessagesApi:
     ) -> RESTResponseType:
         """Delete a message (move to trash)
 
-        Move a message to the trash. Trashed messages disappear from lists, threads, and reply targets, but can be restored via POST …/messages/{id}/restore until they are purged ~30 days after deletion. No confirmation is required because the default delete is reversible. Pass permanent=true with confirm=DELETE to permanently delete a message that is ALREADY in the trash (\"delete forever\"). A message held for review (review_status=pending_review) cannot be deleted — resolve it in the review queue first (409 message_held).
+        Move a message to the trash. Trashed messages disappear from lists, threads, and reply targets, but can be restored via POST …/messages/{id}/restore until they are purged — 30 days after deletion by default (the trash retention window is deployment-configurable). While a message sits in the trash its natural expiry clock (expires_at) is paused; only the trash clock runs. No confirmation is required because the default delete is reversible. Pass permanent=true with confirm=DELETE to permanently delete a message that is ALREADY in the trash (\"delete forever\"). A message held for review (review_status=pending_review) cannot be deleted — resolve it in the review queue first (409 message_held).
 
         :param email: The agent's full email address. (required)
         :type email: str
@@ -1046,7 +1046,7 @@ class MessagesApi:
     ) -> MessageView:
         """Get a message
 
-        Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (~30 days after deletion); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and inbound auth headers.
+        Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and inbound auth headers.
 
         :param email: The agent's full email address. (required)
         :type email: str
@@ -1117,7 +1117,7 @@ class MessagesApi:
     ) -> ApiResponse[MessageView]:
         """Get a message
 
-        Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (~30 days after deletion); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and inbound auth headers.
+        Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and inbound auth headers.
 
         :param email: The agent's full email address. (required)
         :type email: str
@@ -1188,7 +1188,7 @@ class MessagesApi:
     ) -> RESTResponseType:
         """Get a message
 
-        Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (~30 days after deletion); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and inbound auth headers.
+        Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and inbound auth headers.
 
         :param email: The agent's full email address. (required)
         :type email: str
@@ -1317,7 +1317,7 @@ class MessagesApi:
         until: Annotated[Optional[StrictStr], Field(description="RFC3339; created_at < until.")] = None,
         cursor: Optional[StrictStr] = None,
         limit: Optional[Annotated[int, Field(le=100, strict=True, ge=1)]] = None,
-        deleted: Annotated[Optional[StrictBool], Field(description="List the trash instead: messages that were soft-deleted and are restorable until purged (~30 days after deletion). Defaults to false (live messages only).")] = None,
+        deleted: Annotated[Optional[StrictBool], Field(description="List the trash instead: messages that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live messages only).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1333,7 +1333,7 @@ class MessagesApi:
     ) -> PageMessageSummaryView:
         """List messages
 
-        List an agent's messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review. Pass deleted=true for the trash (soft-deleted messages, restorable until purged ~30 days after deletion); the trash view defaults to direction=all and read_status=all.
+        List an agent's messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review. Pass deleted=true for the trash (soft-deleted messages, restorable until purged — 30 days after deletion by default, deployment-configurable); the trash view defaults to direction=all and read_status=all.
 
         :param email: (required)
         :type email: str
@@ -1359,7 +1359,7 @@ class MessagesApi:
         :type cursor: str
         :param limit:
         :type limit: int
-        :param deleted: List the trash instead: messages that were soft-deleted and are restorable until purged (~30 days after deletion). Defaults to false (live messages only).
+        :param deleted: List the trash instead: messages that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live messages only).
         :type deleted: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -1432,7 +1432,7 @@ class MessagesApi:
         until: Annotated[Optional[StrictStr], Field(description="RFC3339; created_at < until.")] = None,
         cursor: Optional[StrictStr] = None,
         limit: Optional[Annotated[int, Field(le=100, strict=True, ge=1)]] = None,
-        deleted: Annotated[Optional[StrictBool], Field(description="List the trash instead: messages that were soft-deleted and are restorable until purged (~30 days after deletion). Defaults to false (live messages only).")] = None,
+        deleted: Annotated[Optional[StrictBool], Field(description="List the trash instead: messages that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live messages only).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1448,7 +1448,7 @@ class MessagesApi:
     ) -> ApiResponse[PageMessageSummaryView]:
         """List messages
 
-        List an agent's messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review. Pass deleted=true for the trash (soft-deleted messages, restorable until purged ~30 days after deletion); the trash view defaults to direction=all and read_status=all.
+        List an agent's messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review. Pass deleted=true for the trash (soft-deleted messages, restorable until purged — 30 days after deletion by default, deployment-configurable); the trash view defaults to direction=all and read_status=all.
 
         :param email: (required)
         :type email: str
@@ -1474,7 +1474,7 @@ class MessagesApi:
         :type cursor: str
         :param limit:
         :type limit: int
-        :param deleted: List the trash instead: messages that were soft-deleted and are restorable until purged (~30 days after deletion). Defaults to false (live messages only).
+        :param deleted: List the trash instead: messages that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live messages only).
         :type deleted: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -1547,7 +1547,7 @@ class MessagesApi:
         until: Annotated[Optional[StrictStr], Field(description="RFC3339; created_at < until.")] = None,
         cursor: Optional[StrictStr] = None,
         limit: Optional[Annotated[int, Field(le=100, strict=True, ge=1)]] = None,
-        deleted: Annotated[Optional[StrictBool], Field(description="List the trash instead: messages that were soft-deleted and are restorable until purged (~30 days after deletion). Defaults to false (live messages only).")] = None,
+        deleted: Annotated[Optional[StrictBool], Field(description="List the trash instead: messages that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live messages only).")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -1563,7 +1563,7 @@ class MessagesApi:
     ) -> RESTResponseType:
         """List messages
 
-        List an agent's messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review. Pass deleted=true for the trash (soft-deleted messages, restorable until purged ~30 days after deletion); the trash view defaults to direction=all and read_status=all.
+        List an agent's messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review. Pass deleted=true for the trash (soft-deleted messages, restorable until purged — 30 days after deletion by default, deployment-configurable); the trash view defaults to direction=all and read_status=all.
 
         :param email: (required)
         :type email: str
@@ -1589,7 +1589,7 @@ class MessagesApi:
         :type cursor: str
         :param limit:
         :type limit: int
-        :param deleted: List the trash instead: messages that were soft-deleted and are restorable until purged (~30 days after deletion). Defaults to false (live messages only).
+        :param deleted: List the trash instead: messages that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live messages only).
         :type deleted: bool
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
@@ -2145,7 +2145,7 @@ class MessagesApi:
     ) -> MessageView:
         """Restore a message from the trash
 
-        Bring a trashed (soft-deleted) message back to the inbox. Its remaining retention resumes where it left off — time spent in the trash does not count against the message's normal lifetime. Returns the restored message. 409 not_in_trash when the message is not in the trash.
+        Bring a trashed (soft-deleted) message back to the inbox. Its remaining retention resumes where it left off — expires_at is shifted forward by the time the message spent in the trash, so time in the trash does not count against the message's normal lifetime. Returns the restored message. 409 not_in_trash when the message is not in the trash.
 
         :param email: The agent's full email address. (required)
         :type email: str
@@ -2216,7 +2216,7 @@ class MessagesApi:
     ) -> ApiResponse[MessageView]:
         """Restore a message from the trash
 
-        Bring a trashed (soft-deleted) message back to the inbox. Its remaining retention resumes where it left off — time spent in the trash does not count against the message's normal lifetime. Returns the restored message. 409 not_in_trash when the message is not in the trash.
+        Bring a trashed (soft-deleted) message back to the inbox. Its remaining retention resumes where it left off — expires_at is shifted forward by the time the message spent in the trash, so time in the trash does not count against the message's normal lifetime. Returns the restored message. 409 not_in_trash when the message is not in the trash.
 
         :param email: The agent's full email address. (required)
         :type email: str
@@ -2287,7 +2287,7 @@ class MessagesApi:
     ) -> RESTResponseType:
         """Restore a message from the trash
 
-        Bring a trashed (soft-deleted) message back to the inbox. Its remaining retention resumes where it left off — time spent in the trash does not count against the message's normal lifetime. Returns the restored message. 409 not_in_trash when the message is not in the trash.
+        Bring a trashed (soft-deleted) message back to the inbox. Its remaining retention resumes where it left off — expires_at is shifted forward by the time the message spent in the trash, so time in the trash does not count against the message's normal lifetime. Returns the restored message. 409 not_in_trash when the message is not in the trash.
 
         :param email: The agent's full email address. (required)
         :type email: str

--- a/sdks/python/src/e2a/v1/generated/models/agent_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/agent_view.py
@@ -28,7 +28,7 @@ class AgentView(BaseModel):
     AgentView
     """ # noqa: E501
     created_at: datetime
-    deleted_at: Optional[datetime] = Field(default=None, description="When the agent was moved to the trash. Omitted for live agents.")
+    deleted_at: Optional[datetime] = Field(default=None, description="When the agent was moved to the trash. Omitted for live agents. A trashed agent is restorable until purged — 30 days after deletion by default (deployment-configurable). While it sits in the trash its messages' expiry clocks are paused; restore resumes them where they stopped.")
     domain: StrictStr
     domain_verified: StrictBool
     email: StrictStr

--- a/sdks/python/src/e2a/v1/generated/models/message_summary_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/message_summary_view.py
@@ -32,7 +32,7 @@ class MessageSummaryView(BaseModel):
     cc: Optional[List[StrictStr]] = None
     conversation_id: Optional[StrictStr] = None
     created_at: datetime
-    deleted_at: Optional[datetime] = Field(default=None, description="When the message was moved to the trash. Omitted for live messages.")
+    deleted_at: Optional[datetime] = Field(default=None, description="When the message was moved to the trash. Omitted for live messages. A trashed message is restorable until purged — 30 days after deletion by default (deployment-configurable). While it sits in the trash its natural expiry clock (expires_at) is paused; restore shifts expires_at forward by the time spent in the trash.")
     delivered_to: StrictStr = Field(description="The envelope Delivered-To address — this delivery's per-agent target (the mailbox that actually received this row), distinct from the To header (the to array).")
     delivery_detail: Optional[StrictStr] = None
     delivery_status: Optional[StrictStr] = Field(default=None, description="Outbound delivery rollup (worst recipient status by precedence; outbound only). Open set; tolerate unknown values. Known values: accepted, sending, sent, delivered, deferred, bounced, complained, failed. Lifecycle: accepted → sending → sent → delivered | deferred | bounced | complained | failed. (Legacy 'queued' is superseded by 'accepted'.)")

--- a/sdks/python/src/e2a/v1/generated/models/message_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/message_view.py
@@ -38,7 +38,7 @@ class MessageView(BaseModel):
     cc: List[StrictStr]
     conversation_id: StrictStr
     created_at: datetime
-    deleted_at: Optional[datetime] = Field(default=None, description="When the message was moved to the trash. Omitted for live messages.")
+    deleted_at: Optional[datetime] = Field(default=None, description="When the message was moved to the trash. Omitted for live messages. A trashed message is restorable until purged — 30 days after deletion by default (deployment-configurable). While it sits in the trash its natural expiry clock (expires_at) is paused; restore shifts expires_at forward by the time spent in the trash.")
     delivered_to: StrictStr = Field(description="The envelope Delivered-To address — this delivery's per-agent target (the mailbox that actually received this row), distinct from the To header (the to array).")
     delivery_detail: Optional[StrictStr] = None
     delivery_status: Optional[StrictStr] = Field(default=None, description="Outbound delivery rollup (worst recipient status by precedence; outbound only). Open set; tolerate unknown values. Known values: accepted, sending, sent, delivered, deferred, bounced, complained, failed. Lifecycle: accepted → sending → sent → delivered | deferred | bounced | complained | failed. (Legacy 'queued' is superseded by 'accepted'.)")

--- a/sdks/typescript/src/v1/generated/apis/AgentsApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/AgentsApi.ts
@@ -314,7 +314,7 @@ export class AgentsApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
-     * Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent\'s live messages resume their clocks exactly where they stopped: each message\'s expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse (auto-resolve) the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
+     * Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent\'s live messages resume their clocks exactly where they stopped: each message\'s expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
      * Restore an agent from the trash
      * @param email The agent\&#39;s full email address, e.g. support@acme.com.
      */

--- a/sdks/typescript/src/v1/generated/apis/AgentsApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/AgentsApi.ts
@@ -74,7 +74,7 @@ export class AgentsApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
-     * Move an agent the caller owns to the trash. Requires ?confirm=DELETE. A trashed agent stops receiving mail, disappears from lists, and its held messages leave the review queue; restore it via POST /v1/agents/{email}/restore within 30 days, after which it is purged permanently (messages included). Pass permanent=true to skip the trash and delete irreversibly right away (accepts live and trashed agents). Returns 200 with a deletion receipt; messages_deleted is zero when the agent is moved to trash.
+     * Move an agent the caller owns to the trash. Requires ?confirm=DELETE. A trashed agent stops receiving mail, disappears from lists, and its held messages leave the review queue; restore it via POST /v1/agents/{email}/restore within the trash retention window — 30 days by default (deployment-configurable) — after which it is purged permanently (messages included). While the agent sits in the trash its messages\' expiry clocks are paused; restore resumes them exactly where they stopped. Pass permanent=true to skip the trash and delete irreversibly right away (accepts live and trashed agents). Returns 200 with a deletion receipt; messages_deleted is zero when the agent is moved to trash.
      * Delete an agent
      * @param email 
      * @param confirm Must be the literal DELETE. The default action moves the agent to trash; permanent&#x3D;true is irreversible.
@@ -211,7 +211,7 @@ export class AgentsApiRequestFactory extends BaseAPIRequestFactory {
      * List agents
      * @param cursor Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
      * @param limit Maximum number of items to return (1-100).
-     * @param deleted List the trash instead: agents that were soft-deleted and are restorable until purged (~30 days). Defaults to false (live agents only).
+     * @param deleted List the trash instead: agents that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live agents only).
      */
     public async listAgents(cursor?: string, limit?: number, deleted?: boolean, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
@@ -314,7 +314,7 @@ export class AgentsApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
-     * Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
+     * Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent\'s live messages resume their clocks exactly where they stopped: each message\'s expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse (auto-resolve) the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
      * Restore an agent from the trash
      * @param email The agent\&#39;s full email address, e.g. support@acme.com.
      */

--- a/sdks/typescript/src/v1/generated/apis/MessagesApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/MessagesApi.ts
@@ -28,7 +28,7 @@ import { UpdateMessageResultView } from '../models/UpdateMessageResultView.js';
 export class MessagesApiRequestFactory extends BaseAPIRequestFactory {
 
     /**
-     * Move a message to the trash. Trashed messages disappear from lists, threads, and reply targets, but can be restored via POST …/messages/{id}/restore until they are purged ~30 days after deletion. No confirmation is required because the default delete is reversible. Pass permanent=true with confirm=DELETE to permanently delete a message that is ALREADY in the trash (\"delete forever\"). A message held for review (review_status=pending_review) cannot be deleted — resolve it in the review queue first (409 message_held).
+     * Move a message to the trash. Trashed messages disappear from lists, threads, and reply targets, but can be restored via POST …/messages/{id}/restore until they are purged — 30 days after deletion by default (the trash retention window is deployment-configurable). While a message sits in the trash its natural expiry clock (expires_at) is paused; only the trash clock runs. No confirmation is required because the default delete is reversible. Pass permanent=true with confirm=DELETE to permanently delete a message that is ALREADY in the trash (\"delete forever\"). A message held for review (review_status=pending_review) cannot be deleted — resolve it in the review queue first (409 message_held).
      * Delete a message (move to trash)
      * @param email The agent\&#39;s full email address.
      * @param id The message id, e.g. msg_abc123.
@@ -225,7 +225,7 @@ export class MessagesApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
-     * Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (~30 days after deletion); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and inbound auth headers.
+     * Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and inbound auth headers.
      * Get a message
      * @param email The agent\&#39;s full email address.
      * @param id The message id, e.g. msg_abc123.
@@ -271,7 +271,7 @@ export class MessagesApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
-     * List an agent\'s messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review. Pass deleted=true for the trash (soft-deleted messages, restorable until purged ~30 days after deletion); the trash view defaults to direction=all and read_status=all.
+     * List an agent\'s messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review. Pass deleted=true for the trash (soft-deleted messages, restorable until purged — 30 days after deletion by default, deployment-configurable); the trash view defaults to direction=all and read_status=all.
      * List messages
      * @param email 
      * @param direction Defaults to inbound.
@@ -285,7 +285,7 @@ export class MessagesApiRequestFactory extends BaseAPIRequestFactory {
      * @param until RFC3339; created_at &lt; until.
      * @param cursor 
      * @param limit 
-     * @param deleted List the trash instead: messages that were soft-deleted and are restorable until purged (~30 days after deletion). Defaults to false (live messages only).
+     * @param deleted List the trash instead: messages that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live messages only).
      */
     public async listMessages(email: string, direction?: 'inbound' | 'outbound' | 'all', readStatus?: 'unread' | 'read' | 'all', sort?: 'asc' | 'desc', from_?: string, subjectContains?: string, conversationId?: string, labels?: Array<string>, since?: string, until?: string, cursor?: string, limit?: number, deleted?: boolean, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
@@ -469,7 +469,7 @@ export class MessagesApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
-     * Bring a trashed (soft-deleted) message back to the inbox. Its remaining retention resumes where it left off — time spent in the trash does not count against the message\'s normal lifetime. Returns the restored message. 409 not_in_trash when the message is not in the trash.
+     * Bring a trashed (soft-deleted) message back to the inbox. Its remaining retention resumes where it left off — expires_at is shifted forward by the time the message spent in the trash, so time in the trash does not count against the message\'s normal lifetime. Returns the restored message. 409 not_in_trash when the message is not in the trash.
      * Restore a message from the trash
      * @param email The agent\&#39;s full email address.
      * @param id The message id, e.g. msg_abc123.

--- a/sdks/typescript/src/v1/generated/models/AgentView.ts
+++ b/sdks/typescript/src/v1/generated/models/AgentView.ts
@@ -15,7 +15,7 @@ import { HttpFile } from '../http/http.js';
 export class AgentView {
     'createdAt': Date;
     /**
-    * When the agent was moved to the trash. Omitted for live agents.
+    * When the agent was moved to the trash. Omitted for live agents. A trashed agent is restorable until purged — 30 days after deletion by default (deployment-configurable). While it sits in the trash its messages\' expiry clocks are paused; restore resumes them where they stopped.
     */
     'deletedAt'?: Date;
     'domain': string;

--- a/sdks/typescript/src/v1/generated/models/MessageSummaryView.ts
+++ b/sdks/typescript/src/v1/generated/models/MessageSummaryView.ts
@@ -19,7 +19,7 @@ export class MessageSummaryView {
     'conversationId'?: string;
     'createdAt': Date;
     /**
-    * When the message was moved to the trash. Omitted for live messages.
+    * When the message was moved to the trash. Omitted for live messages. A trashed message is restorable until purged — 30 days after deletion by default (deployment-configurable). While it sits in the trash its natural expiry clock (expires_at) is paused; restore shifts expires_at forward by the time spent in the trash.
     */
     'deletedAt'?: Date;
     /**

--- a/sdks/typescript/src/v1/generated/models/MessageView.ts
+++ b/sdks/typescript/src/v1/generated/models/MessageView.ts
@@ -25,7 +25,7 @@ export class MessageView {
     'conversationId': string;
     'createdAt': Date;
     /**
-    * When the message was moved to the trash. Omitted for live messages.
+    * When the message was moved to the trash. Omitted for live messages. A trashed message is restorable until purged — 30 days after deletion by default (deployment-configurable). While it sits in the trash its natural expiry clock (expires_at) is paused; restore shifts expires_at forward by the time spent in the trash.
     */
     'deletedAt'?: Date;
     /**

--- a/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
@@ -465,7 +465,7 @@ export interface AgentsApiListAgentsRequest {
      */
     limit?: number
     /**
-     * List the trash instead: agents that were soft-deleted and are restorable until purged (~30 days). Defaults to false (live agents only).
+     * List the trash instead: agents that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live agents only).
      * Defaults to: undefined
      * @type boolean
      * @memberof AgentsApilistAgents
@@ -551,7 +551,7 @@ export class ObjectAgentsApi {
     }
 
     /**
-     * Move an agent the caller owns to the trash. Requires ?confirm=DELETE. A trashed agent stops receiving mail, disappears from lists, and its held messages leave the review queue; restore it via POST /v1/agents/{email}/restore within 30 days, after which it is purged permanently (messages included). Pass permanent=true to skip the trash and delete irreversibly right away (accepts live and trashed agents). Returns 200 with a deletion receipt; messages_deleted is zero when the agent is moved to trash.
+     * Move an agent the caller owns to the trash. Requires ?confirm=DELETE. A trashed agent stops receiving mail, disappears from lists, and its held messages leave the review queue; restore it via POST /v1/agents/{email}/restore within the trash retention window — 30 days by default (deployment-configurable) — after which it is purged permanently (messages included). While the agent sits in the trash its messages\' expiry clocks are paused; restore resumes them exactly where they stopped. Pass permanent=true to skip the trash and delete irreversibly right away (accepts live and trashed agents). Returns 200 with a deletion receipt; messages_deleted is zero when the agent is moved to trash.
      * Delete an agent
      * @param param the request object
      */
@@ -560,7 +560,7 @@ export class ObjectAgentsApi {
     }
 
     /**
-     * Move an agent the caller owns to the trash. Requires ?confirm=DELETE. A trashed agent stops receiving mail, disappears from lists, and its held messages leave the review queue; restore it via POST /v1/agents/{email}/restore within 30 days, after which it is purged permanently (messages included). Pass permanent=true to skip the trash and delete irreversibly right away (accepts live and trashed agents). Returns 200 with a deletion receipt; messages_deleted is zero when the agent is moved to trash.
+     * Move an agent the caller owns to the trash. Requires ?confirm=DELETE. A trashed agent stops receiving mail, disappears from lists, and its held messages leave the review queue; restore it via POST /v1/agents/{email}/restore within the trash retention window — 30 days by default (deployment-configurable) — after which it is purged permanently (messages included). While the agent sits in the trash its messages\' expiry clocks are paused; restore resumes them exactly where they stopped. Pass permanent=true to skip the trash and delete irreversibly right away (accepts live and trashed agents). Returns 200 with a deletion receipt; messages_deleted is zero when the agent is moved to trash.
      * Delete an agent
      * @param param the request object
      */
@@ -641,7 +641,7 @@ export class ObjectAgentsApi {
     }
 
     /**
-     * Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
+     * Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent\'s live messages resume their clocks exactly where they stopped: each message\'s expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse (auto-resolve) the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
      * Restore an agent from the trash
      * @param param the request object
      */
@@ -650,7 +650,7 @@ export class ObjectAgentsApi {
     }
 
     /**
-     * Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
+     * Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent\'s live messages resume their clocks exactly where they stopped: each message\'s expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse (auto-resolve) the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
      * Restore an agent from the trash
      * @param param the request object
      */
@@ -1323,7 +1323,7 @@ export interface MessagesApiListMessagesRequest {
      */
     limit?: number
     /**
-     * List the trash instead: messages that were soft-deleted and are restorable until purged (~30 days after deletion). Defaults to false (live messages only).
+     * List the trash instead: messages that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live messages only).
      * Defaults to: undefined
      * @type boolean
      * @memberof MessagesApilistMessages
@@ -1446,7 +1446,7 @@ export class ObjectMessagesApi {
     }
 
     /**
-     * Move a message to the trash. Trashed messages disappear from lists, threads, and reply targets, but can be restored via POST …/messages/{id}/restore until they are purged ~30 days after deletion. No confirmation is required because the default delete is reversible. Pass permanent=true with confirm=DELETE to permanently delete a message that is ALREADY in the trash (\"delete forever\"). A message held for review (review_status=pending_review) cannot be deleted — resolve it in the review queue first (409 message_held).
+     * Move a message to the trash. Trashed messages disappear from lists, threads, and reply targets, but can be restored via POST …/messages/{id}/restore until they are purged — 30 days after deletion by default (the trash retention window is deployment-configurable). While a message sits in the trash its natural expiry clock (expires_at) is paused; only the trash clock runs. No confirmation is required because the default delete is reversible. Pass permanent=true with confirm=DELETE to permanently delete a message that is ALREADY in the trash (\"delete forever\"). A message held for review (review_status=pending_review) cannot be deleted — resolve it in the review queue first (409 message_held).
      * Delete a message (move to trash)
      * @param param the request object
      */
@@ -1455,7 +1455,7 @@ export class ObjectMessagesApi {
     }
 
     /**
-     * Move a message to the trash. Trashed messages disappear from lists, threads, and reply targets, but can be restored via POST …/messages/{id}/restore until they are purged ~30 days after deletion. No confirmation is required because the default delete is reversible. Pass permanent=true with confirm=DELETE to permanently delete a message that is ALREADY in the trash (\"delete forever\"). A message held for review (review_status=pending_review) cannot be deleted — resolve it in the review queue first (409 message_held).
+     * Move a message to the trash. Trashed messages disappear from lists, threads, and reply targets, but can be restored via POST …/messages/{id}/restore until they are purged — 30 days after deletion by default (the trash retention window is deployment-configurable). While a message sits in the trash its natural expiry clock (expires_at) is paused; only the trash clock runs. No confirmation is required because the default delete is reversible. Pass permanent=true with confirm=DELETE to permanently delete a message that is ALREADY in the trash (\"delete forever\"). A message held for review (review_status=pending_review) cannot be deleted — resolve it in the review queue first (409 message_held).
      * Delete a message (move to trash)
      * @param param the request object
      */
@@ -1500,7 +1500,7 @@ export class ObjectMessagesApi {
     }
 
     /**
-     * Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (~30 days after deletion); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and inbound auth headers.
+     * Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and inbound auth headers.
      * Get a message
      * @param param the request object
      */
@@ -1509,7 +1509,7 @@ export class ObjectMessagesApi {
     }
 
     /**
-     * Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (~30 days after deletion); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and inbound auth headers.
+     * Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and inbound auth headers.
      * Get a message
      * @param param the request object
      */
@@ -1518,7 +1518,7 @@ export class ObjectMessagesApi {
     }
 
     /**
-     * List an agent\'s messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review. Pass deleted=true for the trash (soft-deleted messages, restorable until purged ~30 days after deletion); the trash view defaults to direction=all and read_status=all.
+     * List an agent\'s messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review. Pass deleted=true for the trash (soft-deleted messages, restorable until purged — 30 days after deletion by default, deployment-configurable); the trash view defaults to direction=all and read_status=all.
      * List messages
      * @param param the request object
      */
@@ -1527,7 +1527,7 @@ export class ObjectMessagesApi {
     }
 
     /**
-     * List an agent\'s messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review. Pass deleted=true for the trash (soft-deleted messages, restorable until purged ~30 days after deletion); the trash view defaults to direction=all and read_status=all.
+     * List an agent\'s messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review. Pass deleted=true for the trash (soft-deleted messages, restorable until purged — 30 days after deletion by default, deployment-configurable); the trash view defaults to direction=all and read_status=all.
      * List messages
      * @param param the request object
      */
@@ -1554,7 +1554,7 @@ export class ObjectMessagesApi {
     }
 
     /**
-     * Bring a trashed (soft-deleted) message back to the inbox. Its remaining retention resumes where it left off — time spent in the trash does not count against the message\'s normal lifetime. Returns the restored message. 409 not_in_trash when the message is not in the trash.
+     * Bring a trashed (soft-deleted) message back to the inbox. Its remaining retention resumes where it left off — expires_at is shifted forward by the time the message spent in the trash, so time in the trash does not count against the message\'s normal lifetime. Returns the restored message. 409 not_in_trash when the message is not in the trash.
      * Restore a message from the trash
      * @param param the request object
      */
@@ -1563,7 +1563,7 @@ export class ObjectMessagesApi {
     }
 
     /**
-     * Bring a trashed (soft-deleted) message back to the inbox. Its remaining retention resumes where it left off — time spent in the trash does not count against the message\'s normal lifetime. Returns the restored message. 409 not_in_trash when the message is not in the trash.
+     * Bring a trashed (soft-deleted) message back to the inbox. Its remaining retention resumes where it left off — expires_at is shifted forward by the time the message spent in the trash, so time in the trash does not count against the message\'s normal lifetime. Returns the restored message. 409 not_in_trash when the message is not in the trash.
      * Restore a message from the trash
      * @param param the request object
      */

--- a/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
@@ -641,7 +641,7 @@ export class ObjectAgentsApi {
     }
 
     /**
-     * Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent\'s live messages resume their clocks exactly where they stopped: each message\'s expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse (auto-resolve) the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
+     * Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent\'s live messages resume their clocks exactly where they stopped: each message\'s expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
      * Restore an agent from the trash
      * @param param the request object
      */
@@ -650,7 +650,7 @@ export class ObjectAgentsApi {
     }
 
     /**
-     * Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent\'s live messages resume their clocks exactly where they stopped: each message\'s expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse (auto-resolve) the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
+     * Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent\'s live messages resume their clocks exactly where they stopped: each message\'s expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
      * Restore an agent from the trash
      * @param param the request object
      */

--- a/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
@@ -479,7 +479,7 @@ export class ObservableAgentsApi {
     }
 
     /**
-     * Move an agent the caller owns to the trash. Requires ?confirm=DELETE. A trashed agent stops receiving mail, disappears from lists, and its held messages leave the review queue; restore it via POST /v1/agents/{email}/restore within 30 days, after which it is purged permanently (messages included). Pass permanent=true to skip the trash and delete irreversibly right away (accepts live and trashed agents). Returns 200 with a deletion receipt; messages_deleted is zero when the agent is moved to trash.
+     * Move an agent the caller owns to the trash. Requires ?confirm=DELETE. A trashed agent stops receiving mail, disappears from lists, and its held messages leave the review queue; restore it via POST /v1/agents/{email}/restore within the trash retention window — 30 days by default (deployment-configurable) — after which it is purged permanently (messages included). While the agent sits in the trash its messages\' expiry clocks are paused; restore resumes them exactly where they stopped. Pass permanent=true to skip the trash and delete irreversibly right away (accepts live and trashed agents). Returns 200 with a deletion receipt; messages_deleted is zero when the agent is moved to trash.
      * Delete an agent
      * @param email
      * @param confirm Must be the literal DELETE. The default action moves the agent to trash; permanent&#x3D;true is irreversible.
@@ -506,7 +506,7 @@ export class ObservableAgentsApi {
     }
 
     /**
-     * Move an agent the caller owns to the trash. Requires ?confirm=DELETE. A trashed agent stops receiving mail, disappears from lists, and its held messages leave the review queue; restore it via POST /v1/agents/{email}/restore within 30 days, after which it is purged permanently (messages included). Pass permanent=true to skip the trash and delete irreversibly right away (accepts live and trashed agents). Returns 200 with a deletion receipt; messages_deleted is zero when the agent is moved to trash.
+     * Move an agent the caller owns to the trash. Requires ?confirm=DELETE. A trashed agent stops receiving mail, disappears from lists, and its held messages leave the review queue; restore it via POST /v1/agents/{email}/restore within the trash retention window — 30 days by default (deployment-configurable) — after which it is purged permanently (messages included). While the agent sits in the trash its messages\' expiry clocks are paused; restore resumes them exactly where they stopped. Pass permanent=true to skip the trash and delete irreversibly right away (accepts live and trashed agents). Returns 200 with a deletion receipt; messages_deleted is zero when the agent is moved to trash.
      * Delete an agent
      * @param email
      * @param confirm Must be the literal DELETE. The default action moves the agent to trash; permanent&#x3D;true is irreversible.
@@ -589,7 +589,7 @@ export class ObservableAgentsApi {
      * List agents
      * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
      * @param [limit] Maximum number of items to return (1-100).
-     * @param [deleted] List the trash instead: agents that were soft-deleted and are restorable until purged (~30 days). Defaults to false (live agents only).
+     * @param [deleted] List the trash instead: agents that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live agents only).
      */
     public listAgentsWithHttpInfo(cursor?: string, limit?: number, deleted?: boolean, _options?: ConfigurationOptions): Observable<HttpInfo<PageAgentView>> {
         const _config = mergeConfiguration(this.configuration, _options);
@@ -616,7 +616,7 @@ export class ObservableAgentsApi {
      * List agents
      * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
      * @param [limit] Maximum number of items to return (1-100).
-     * @param [deleted] List the trash instead: agents that were soft-deleted and are restorable until purged (~30 days). Defaults to false (live agents only).
+     * @param [deleted] List the trash instead: agents that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live agents only).
      */
     public listAgents(cursor?: string, limit?: number, deleted?: boolean, _options?: ConfigurationOptions): Observable<PageAgentView> {
         return this.listAgentsWithHttpInfo(cursor, limit, deleted, _options).pipe(map((apiResponse: HttpInfo<PageAgentView>) => apiResponse.data));
@@ -659,7 +659,7 @@ export class ObservableAgentsApi {
     }
 
     /**
-     * Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
+     * Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent\'s live messages resume their clocks exactly where they stopped: each message\'s expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse (auto-resolve) the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
      * Restore an agent from the trash
      * @param email The agent\&#39;s full email address, e.g. support@acme.com.
      */
@@ -684,7 +684,7 @@ export class ObservableAgentsApi {
     }
 
     /**
-     * Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
+     * Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent\'s live messages resume their clocks exactly where they stopped: each message\'s expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse (auto-resolve) the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
      * Restore an agent from the trash
      * @param email The agent\&#39;s full email address, e.g. support@acme.com.
      */
@@ -1199,7 +1199,7 @@ export class ObservableMessagesApi {
     }
 
     /**
-     * Move a message to the trash. Trashed messages disappear from lists, threads, and reply targets, but can be restored via POST …/messages/{id}/restore until they are purged ~30 days after deletion. No confirmation is required because the default delete is reversible. Pass permanent=true with confirm=DELETE to permanently delete a message that is ALREADY in the trash (\"delete forever\"). A message held for review (review_status=pending_review) cannot be deleted — resolve it in the review queue first (409 message_held).
+     * Move a message to the trash. Trashed messages disappear from lists, threads, and reply targets, but can be restored via POST …/messages/{id}/restore until they are purged — 30 days after deletion by default (the trash retention window is deployment-configurable). While a message sits in the trash its natural expiry clock (expires_at) is paused; only the trash clock runs. No confirmation is required because the default delete is reversible. Pass permanent=true with confirm=DELETE to permanently delete a message that is ALREADY in the trash (\"delete forever\"). A message held for review (review_status=pending_review) cannot be deleted — resolve it in the review queue first (409 message_held).
      * Delete a message (move to trash)
      * @param email The agent\&#39;s full email address.
      * @param id The message id, e.g. msg_abc123.
@@ -1227,7 +1227,7 @@ export class ObservableMessagesApi {
     }
 
     /**
-     * Move a message to the trash. Trashed messages disappear from lists, threads, and reply targets, but can be restored via POST …/messages/{id}/restore until they are purged ~30 days after deletion. No confirmation is required because the default delete is reversible. Pass permanent=true with confirm=DELETE to permanently delete a message that is ALREADY in the trash (\"delete forever\"). A message held for review (review_status=pending_review) cannot be deleted — resolve it in the review queue first (409 message_held).
+     * Move a message to the trash. Trashed messages disappear from lists, threads, and reply targets, but can be restored via POST …/messages/{id}/restore until they are purged — 30 days after deletion by default (the trash retention window is deployment-configurable). While a message sits in the trash its natural expiry clock (expires_at) is paused; only the trash clock runs. No confirmation is required because the default delete is reversible. Pass permanent=true with confirm=DELETE to permanently delete a message that is ALREADY in the trash (\"delete forever\"). A message held for review (review_status=pending_review) cannot be deleted — resolve it in the review queue first (409 message_held).
      * Delete a message (move to trash)
      * @param email The agent\&#39;s full email address.
      * @param id The message id, e.g. msg_abc123.
@@ -1321,7 +1321,7 @@ export class ObservableMessagesApi {
     }
 
     /**
-     * Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (~30 days after deletion); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and inbound auth headers.
+     * Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and inbound auth headers.
      * Get a message
      * @param email The agent\&#39;s full email address.
      * @param id The message id, e.g. msg_abc123.
@@ -1347,7 +1347,7 @@ export class ObservableMessagesApi {
     }
 
     /**
-     * Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (~30 days after deletion); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and inbound auth headers.
+     * Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and inbound auth headers.
      * Get a message
      * @param email The agent\&#39;s full email address.
      * @param id The message id, e.g. msg_abc123.
@@ -1357,7 +1357,7 @@ export class ObservableMessagesApi {
     }
 
     /**
-     * List an agent\'s messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review. Pass deleted=true for the trash (soft-deleted messages, restorable until purged ~30 days after deletion); the trash view defaults to direction=all and read_status=all.
+     * List an agent\'s messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review. Pass deleted=true for the trash (soft-deleted messages, restorable until purged — 30 days after deletion by default, deployment-configurable); the trash view defaults to direction=all and read_status=all.
      * List messages
      * @param email
      * @param [direction] Defaults to inbound.
@@ -1371,7 +1371,7 @@ export class ObservableMessagesApi {
      * @param [until] RFC3339; created_at &lt; until.
      * @param [cursor]
      * @param [limit]
-     * @param [deleted] List the trash instead: messages that were soft-deleted and are restorable until purged (~30 days after deletion). Defaults to false (live messages only).
+     * @param [deleted] List the trash instead: messages that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live messages only).
      */
     public listMessagesWithHttpInfo(email: string, direction?: 'inbound' | 'outbound' | 'all', readStatus?: 'unread' | 'read' | 'all', sort?: 'asc' | 'desc', from_?: string, subjectContains?: string, conversationId?: string, labels?: Array<string>, since?: string, until?: string, cursor?: string, limit?: number, deleted?: boolean, _options?: ConfigurationOptions): Observable<HttpInfo<PageMessageSummaryView>> {
         const _config = mergeConfiguration(this.configuration, _options);
@@ -1394,7 +1394,7 @@ export class ObservableMessagesApi {
     }
 
     /**
-     * List an agent\'s messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review. Pass deleted=true for the trash (soft-deleted messages, restorable until purged ~30 days after deletion); the trash view defaults to direction=all and read_status=all.
+     * List an agent\'s messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review. Pass deleted=true for the trash (soft-deleted messages, restorable until purged — 30 days after deletion by default, deployment-configurable); the trash view defaults to direction=all and read_status=all.
      * List messages
      * @param email
      * @param [direction] Defaults to inbound.
@@ -1408,7 +1408,7 @@ export class ObservableMessagesApi {
      * @param [until] RFC3339; created_at &lt; until.
      * @param [cursor]
      * @param [limit]
-     * @param [deleted] List the trash instead: messages that were soft-deleted and are restorable until purged (~30 days after deletion). Defaults to false (live messages only).
+     * @param [deleted] List the trash instead: messages that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live messages only).
      */
     public listMessages(email: string, direction?: 'inbound' | 'outbound' | 'all', readStatus?: 'unread' | 'read' | 'all', sort?: 'asc' | 'desc', from_?: string, subjectContains?: string, conversationId?: string, labels?: Array<string>, since?: string, until?: string, cursor?: string, limit?: number, deleted?: boolean, _options?: ConfigurationOptions): Observable<PageMessageSummaryView> {
         return this.listMessagesWithHttpInfo(email, direction, readStatus, sort, from_, subjectContains, conversationId, labels, since, until, cursor, limit, deleted, _options).pipe(map((apiResponse: HttpInfo<PageMessageSummaryView>) => apiResponse.data));
@@ -1457,7 +1457,7 @@ export class ObservableMessagesApi {
     }
 
     /**
-     * Bring a trashed (soft-deleted) message back to the inbox. Its remaining retention resumes where it left off — time spent in the trash does not count against the message\'s normal lifetime. Returns the restored message. 409 not_in_trash when the message is not in the trash.
+     * Bring a trashed (soft-deleted) message back to the inbox. Its remaining retention resumes where it left off — expires_at is shifted forward by the time the message spent in the trash, so time in the trash does not count against the message\'s normal lifetime. Returns the restored message. 409 not_in_trash when the message is not in the trash.
      * Restore a message from the trash
      * @param email The agent\&#39;s full email address.
      * @param id The message id, e.g. msg_abc123.
@@ -1483,7 +1483,7 @@ export class ObservableMessagesApi {
     }
 
     /**
-     * Bring a trashed (soft-deleted) message back to the inbox. Its remaining retention resumes where it left off — time spent in the trash does not count against the message\'s normal lifetime. Returns the restored message. 409 not_in_trash when the message is not in the trash.
+     * Bring a trashed (soft-deleted) message back to the inbox. Its remaining retention resumes where it left off — expires_at is shifted forward by the time the message spent in the trash, so time in the trash does not count against the message\'s normal lifetime. Returns the restored message. 409 not_in_trash when the message is not in the trash.
      * Restore a message from the trash
      * @param email The agent\&#39;s full email address.
      * @param id The message id, e.g. msg_abc123.

--- a/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
@@ -659,7 +659,7 @@ export class ObservableAgentsApi {
     }
 
     /**
-     * Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent\'s live messages resume their clocks exactly where they stopped: each message\'s expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse (auto-resolve) the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
+     * Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent\'s live messages resume their clocks exactly where they stopped: each message\'s expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
      * Restore an agent from the trash
      * @param email The agent\&#39;s full email address, e.g. support@acme.com.
      */
@@ -684,7 +684,7 @@ export class ObservableAgentsApi {
     }
 
     /**
-     * Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent\'s live messages resume their clocks exactly where they stopped: each message\'s expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse (auto-resolve) the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
+     * Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent\'s live messages resume their clocks exactly where they stopped: each message\'s expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
      * Restore an agent from the trash
      * @param email The agent\&#39;s full email address, e.g. support@acme.com.
      */

--- a/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
@@ -368,7 +368,7 @@ export class PromiseAgentsApi {
     }
 
     /**
-     * Move an agent the caller owns to the trash. Requires ?confirm=DELETE. A trashed agent stops receiving mail, disappears from lists, and its held messages leave the review queue; restore it via POST /v1/agents/{email}/restore within 30 days, after which it is purged permanently (messages included). Pass permanent=true to skip the trash and delete irreversibly right away (accepts live and trashed agents). Returns 200 with a deletion receipt; messages_deleted is zero when the agent is moved to trash.
+     * Move an agent the caller owns to the trash. Requires ?confirm=DELETE. A trashed agent stops receiving mail, disappears from lists, and its held messages leave the review queue; restore it via POST /v1/agents/{email}/restore within the trash retention window — 30 days by default (deployment-configurable) — after which it is purged permanently (messages included). While the agent sits in the trash its messages\' expiry clocks are paused; restore resumes them exactly where they stopped. Pass permanent=true to skip the trash and delete irreversibly right away (accepts live and trashed agents). Returns 200 with a deletion receipt; messages_deleted is zero when the agent is moved to trash.
      * Delete an agent
      * @param email
      * @param confirm Must be the literal DELETE. The default action moves the agent to trash; permanent&#x3D;true is irreversible.
@@ -381,7 +381,7 @@ export class PromiseAgentsApi {
     }
 
     /**
-     * Move an agent the caller owns to the trash. Requires ?confirm=DELETE. A trashed agent stops receiving mail, disappears from lists, and its held messages leave the review queue; restore it via POST /v1/agents/{email}/restore within 30 days, after which it is purged permanently (messages included). Pass permanent=true to skip the trash and delete irreversibly right away (accepts live and trashed agents). Returns 200 with a deletion receipt; messages_deleted is zero when the agent is moved to trash.
+     * Move an agent the caller owns to the trash. Requires ?confirm=DELETE. A trashed agent stops receiving mail, disappears from lists, and its held messages leave the review queue; restore it via POST /v1/agents/{email}/restore within the trash retention window — 30 days by default (deployment-configurable) — after which it is purged permanently (messages included). While the agent sits in the trash its messages\' expiry clocks are paused; restore resumes them exactly where they stopped. Pass permanent=true to skip the trash and delete irreversibly right away (accepts live and trashed agents). Returns 200 with a deletion receipt; messages_deleted is zero when the agent is moved to trash.
      * Delete an agent
      * @param email
      * @param confirm Must be the literal DELETE. The default action moves the agent to trash; permanent&#x3D;true is irreversible.
@@ -442,7 +442,7 @@ export class PromiseAgentsApi {
      * List agents
      * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
      * @param [limit] Maximum number of items to return (1-100).
-     * @param [deleted] List the trash instead: agents that were soft-deleted and are restorable until purged (~30 days). Defaults to false (live agents only).
+     * @param [deleted] List the trash instead: agents that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live agents only).
      */
     public listAgentsWithHttpInfo(cursor?: string, limit?: number, deleted?: boolean, _options?: PromiseConfigurationOptions): Promise<HttpInfo<PageAgentView>> {
         const observableOptions = wrapOptions(_options);
@@ -455,7 +455,7 @@ export class PromiseAgentsApi {
      * List agents
      * @param [cursor] Opaque pagination cursor from a previous response\&#39;s next_cursor. Continuation requests must not change the other filters.
      * @param [limit] Maximum number of items to return (1-100).
-     * @param [deleted] List the trash instead: agents that were soft-deleted and are restorable until purged (~30 days). Defaults to false (live agents only).
+     * @param [deleted] List the trash instead: agents that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live agents only).
      */
     public listAgents(cursor?: string, limit?: number, deleted?: boolean, _options?: PromiseConfigurationOptions): Promise<PageAgentView> {
         const observableOptions = wrapOptions(_options);
@@ -488,7 +488,7 @@ export class PromiseAgentsApi {
     }
 
     /**
-     * Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
+     * Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent\'s live messages resume their clocks exactly where they stopped: each message\'s expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse (auto-resolve) the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
      * Restore an agent from the trash
      * @param email The agent\&#39;s full email address, e.g. support@acme.com.
      */
@@ -499,7 +499,7 @@ export class PromiseAgentsApi {
     }
 
     /**
-     * Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
+     * Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent\'s live messages resume their clocks exactly where they stopped: each message\'s expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse (auto-resolve) the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
      * Restore an agent from the trash
      * @param email The agent\&#39;s full email address, e.g. support@acme.com.
      */
@@ -876,7 +876,7 @@ export class PromiseMessagesApi {
     }
 
     /**
-     * Move a message to the trash. Trashed messages disappear from lists, threads, and reply targets, but can be restored via POST …/messages/{id}/restore until they are purged ~30 days after deletion. No confirmation is required because the default delete is reversible. Pass permanent=true with confirm=DELETE to permanently delete a message that is ALREADY in the trash (\"delete forever\"). A message held for review (review_status=pending_review) cannot be deleted — resolve it in the review queue first (409 message_held).
+     * Move a message to the trash. Trashed messages disappear from lists, threads, and reply targets, but can be restored via POST …/messages/{id}/restore until they are purged — 30 days after deletion by default (the trash retention window is deployment-configurable). While a message sits in the trash its natural expiry clock (expires_at) is paused; only the trash clock runs. No confirmation is required because the default delete is reversible. Pass permanent=true with confirm=DELETE to permanently delete a message that is ALREADY in the trash (\"delete forever\"). A message held for review (review_status=pending_review) cannot be deleted — resolve it in the review queue first (409 message_held).
      * Delete a message (move to trash)
      * @param email The agent\&#39;s full email address.
      * @param id The message id, e.g. msg_abc123.
@@ -890,7 +890,7 @@ export class PromiseMessagesApi {
     }
 
     /**
-     * Move a message to the trash. Trashed messages disappear from lists, threads, and reply targets, but can be restored via POST …/messages/{id}/restore until they are purged ~30 days after deletion. No confirmation is required because the default delete is reversible. Pass permanent=true with confirm=DELETE to permanently delete a message that is ALREADY in the trash (\"delete forever\"). A message held for review (review_status=pending_review) cannot be deleted — resolve it in the review queue first (409 message_held).
+     * Move a message to the trash. Trashed messages disappear from lists, threads, and reply targets, but can be restored via POST …/messages/{id}/restore until they are purged — 30 days after deletion by default (the trash retention window is deployment-configurable). While a message sits in the trash its natural expiry clock (expires_at) is paused; only the trash clock runs. No confirmation is required because the default delete is reversible. Pass permanent=true with confirm=DELETE to permanently delete a message that is ALREADY in the trash (\"delete forever\"). A message held for review (review_status=pending_review) cannot be deleted — resolve it in the review queue first (409 message_held).
      * Delete a message (move to trash)
      * @param email The agent\&#39;s full email address.
      * @param id The message id, e.g. msg_abc123.
@@ -962,7 +962,7 @@ export class PromiseMessagesApi {
     }
 
     /**
-     * Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (~30 days after deletion); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and inbound auth headers.
+     * Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and inbound auth headers.
      * Get a message
      * @param email The agent\&#39;s full email address.
      * @param id The message id, e.g. msg_abc123.
@@ -974,7 +974,7 @@ export class PromiseMessagesApi {
     }
 
     /**
-     * Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (~30 days after deletion); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and inbound auth headers.
+     * Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and inbound auth headers.
      * Get a message
      * @param email The agent\&#39;s full email address.
      * @param id The message id, e.g. msg_abc123.
@@ -986,7 +986,7 @@ export class PromiseMessagesApi {
     }
 
     /**
-     * List an agent\'s messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review. Pass deleted=true for the trash (soft-deleted messages, restorable until purged ~30 days after deletion); the trash view defaults to direction=all and read_status=all.
+     * List an agent\'s messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review. Pass deleted=true for the trash (soft-deleted messages, restorable until purged — 30 days after deletion by default, deployment-configurable); the trash view defaults to direction=all and read_status=all.
      * List messages
      * @param email
      * @param [direction] Defaults to inbound.
@@ -1000,7 +1000,7 @@ export class PromiseMessagesApi {
      * @param [until] RFC3339; created_at &lt; until.
      * @param [cursor]
      * @param [limit]
-     * @param [deleted] List the trash instead: messages that were soft-deleted and are restorable until purged (~30 days after deletion). Defaults to false (live messages only).
+     * @param [deleted] List the trash instead: messages that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live messages only).
      */
     public listMessagesWithHttpInfo(email: string, direction?: 'inbound' | 'outbound' | 'all', readStatus?: 'unread' | 'read' | 'all', sort?: 'asc' | 'desc', from_?: string, subjectContains?: string, conversationId?: string, labels?: Array<string>, since?: string, until?: string, cursor?: string, limit?: number, deleted?: boolean, _options?: PromiseConfigurationOptions): Promise<HttpInfo<PageMessageSummaryView>> {
         const observableOptions = wrapOptions(_options);
@@ -1009,7 +1009,7 @@ export class PromiseMessagesApi {
     }
 
     /**
-     * List an agent\'s messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review. Pass deleted=true for the trash (soft-deleted messages, restorable until purged ~30 days after deletion); the trash view defaults to direction=all and read_status=all.
+     * List an agent\'s messages (inbound + outbound) with filters and cursor pagination. Held outbound drafts appear as status=pending_review. Pass deleted=true for the trash (soft-deleted messages, restorable until purged — 30 days after deletion by default, deployment-configurable); the trash view defaults to direction=all and read_status=all.
      * List messages
      * @param email
      * @param [direction] Defaults to inbound.
@@ -1023,7 +1023,7 @@ export class PromiseMessagesApi {
      * @param [until] RFC3339; created_at &lt; until.
      * @param [cursor]
      * @param [limit]
-     * @param [deleted] List the trash instead: messages that were soft-deleted and are restorable until purged (~30 days after deletion). Defaults to false (live messages only).
+     * @param [deleted] List the trash instead: messages that were soft-deleted and are restorable until purged (30 days after deletion by default, deployment-configurable). Defaults to false (live messages only).
      */
     public listMessages(email: string, direction?: 'inbound' | 'outbound' | 'all', readStatus?: 'unread' | 'read' | 'all', sort?: 'asc' | 'desc', from_?: string, subjectContains?: string, conversationId?: string, labels?: Array<string>, since?: string, until?: string, cursor?: string, limit?: number, deleted?: boolean, _options?: PromiseConfigurationOptions): Promise<PageMessageSummaryView> {
         const observableOptions = wrapOptions(_options);
@@ -1062,7 +1062,7 @@ export class PromiseMessagesApi {
     }
 
     /**
-     * Bring a trashed (soft-deleted) message back to the inbox. Its remaining retention resumes where it left off — time spent in the trash does not count against the message\'s normal lifetime. Returns the restored message. 409 not_in_trash when the message is not in the trash.
+     * Bring a trashed (soft-deleted) message back to the inbox. Its remaining retention resumes where it left off — expires_at is shifted forward by the time the message spent in the trash, so time in the trash does not count against the message\'s normal lifetime. Returns the restored message. 409 not_in_trash when the message is not in the trash.
      * Restore a message from the trash
      * @param email The agent\&#39;s full email address.
      * @param id The message id, e.g. msg_abc123.
@@ -1074,7 +1074,7 @@ export class PromiseMessagesApi {
     }
 
     /**
-     * Bring a trashed (soft-deleted) message back to the inbox. Its remaining retention resumes where it left off — time spent in the trash does not count against the message\'s normal lifetime. Returns the restored message. 409 not_in_trash when the message is not in the trash.
+     * Bring a trashed (soft-deleted) message back to the inbox. Its remaining retention resumes where it left off — expires_at is shifted forward by the time the message spent in the trash, so time in the trash does not count against the message\'s normal lifetime. Returns the restored message. 409 not_in_trash when the message is not in the trash.
      * Restore a message from the trash
      * @param email The agent\&#39;s full email address.
      * @param id The message id, e.g. msg_abc123.

--- a/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
@@ -488,7 +488,7 @@ export class PromiseAgentsApi {
     }
 
     /**
-     * Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent\'s live messages resume their clocks exactly where they stopped: each message\'s expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse (auto-resolve) the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
+     * Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent\'s live messages resume their clocks exactly where they stopped: each message\'s expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
      * Restore an agent from the trash
      * @param email The agent\&#39;s full email address, e.g. support@acme.com.
      */
@@ -499,7 +499,7 @@ export class PromiseAgentsApi {
     }
 
     /**
-     * Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent\'s live messages resume their clocks exactly where they stopped: each message\'s expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse (auto-resolve) the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
+     * Bring a trashed (soft-deleted) agent back into service, messages and configuration intact. The agent\'s live messages resume their clocks exactly where they stopped: each message\'s expires_at — and, for drafts still held for review, approval_expires_at — is shifted forward by the time the agent spent in the trash, so a restore never resurrects an inbox whose mail immediately expires, and a review hold can never lapse the instant the agent returns. Returns the restored agent. 409 not_in_trash when the agent is not in the trash.
      * Restore an agent from the trash
      * @param email The agent\&#39;s full email address, e.g. support@acme.com.
      */


### PR DESCRIPTION
## Why

Stable `deleteAgent` already makes the trash observable and load-bearing: every default agent delete lands its target in the trash, reserves the address (`409 address_in_trash`), and points at `POST …/restore` as the way back. Leaving restoration and the related fields marked beta was therefore not a meaningful compatibility boundary — a client using only stable surface still depends on trash semantics. This promotes the ENTIRE soft-delete surface to stable and freezes its semantics together. **Markers + documentation only — no handler or store behavior changes.**

## What was promoted

Operations (dropped `x-stability-level: beta`):
- `deleteMessage` — `DELETE /v1/agents/{email}/messages/{id}`
- `restoreMessage` — `POST /v1/agents/{email}/messages/{id}/restore`
- `restoreAgent` — `POST /v1/agents/{email}/restore`

Schema: `DeleteMessageResult` (was beta only by derivation from `deleteMessage`; now pinned stable in `TestSpecBetaMarkers`).

Already stable, now documented coherently with frozen semantics:
- `AgentView.deleted_at`, `MessageView.deleted_at`, `MessageSummaryView.deleted_at`
- `listAgents ?deleted=` and `listMessages ?deleted=` trash-view params
- Error codes (already in the machine-checked catalog, unchanged): `address_in_trash` (409), `not_in_trash` (409), and the message-delete 409s `message_held` / `send_in_progress`
- The trashed-message readability promise on `getMessage` (direct GET keeps working, with `deleted_at`, until purge)

## Frozen semantics (now spec text, verified against code)

- **Retention:** a trashed resource is restorable for **30 days by default** before the janitor purges it permanently (`identity.TrashRetention = 30 * 24 * time.Hour`, `internal/identity/store.go:1530`; it is a package `var`, so documented as deployment-configurable).
- **Paused clock:** while in the trash the natural expiry clock is suspended; only the trash clock runs.
  - Message restore shifts `expires_at` forward by the time spent in the trash (`Store.RestoreMessage`, `internal/identity/store.go:3598`).
  - Agent restore shifts its live messages' `expires_at` **and** still-held drafts' `approval_expires_at` (`Store.RestoreAgent`, `internal/identity/store.go:1416` — the pending_review CASE at ~1447–1454), so restored mail never immediately expires and a review hold can never lapse (auto-resolve) the instant an agent is restored.

## Docs / test inventory updates

- `docs/api.md`: the three ops removed from the "Beta operations" inventory table; beta-surfaces prose no longer lists the trash ops; retention wording frozen (doc-sync test `TestDocumentedBetaOperationsMatchOpenAPI` enforces the table).
- `internal/httpapi/stability_test.go`: `betaOperationIDs` shrunk to templates + protection; the promoted ops (+ `deleteAgent`) and `DeleteMessageResult` pinned as marker-free stable surface.
- The stability-policy constitution in `info.description` names no specific ops — no change needed there.
- Swept `mcp/src`, `cli/src`, `web/src`, and the hand-written SDK layers: no beta wording on the trash tools/ops existed (MCP `delete_message`/`restore_*` descriptions were already unmarked).

## Regeneration

- `make spec` → `api/openapi.yaml` (3 op markers + 1 derived schema marker dropped, descriptions frozen).
- `make generate-sdk` (Docker, openapi-generator v7.16.0) → TS + Python generated bases; **doc-comment changes only**, no type/shape changes.

## Test evidence

- `TestSpecGoldenNoDrift`, `TestSpecBetaMarkers`, `TestDocumentedBetaOperationsMatchOpenAPI`, `TestSpecStabilityPolicyPresent`, `TestDocsErrorCodeTableMatchesCatalog`, and the full spec/trash suites: **pass**.
- `make test-unit`: `internal/httpapi` and all other packages pass except two pre-existing `internal/relay` failures (`TestInbound_ProcessIntake_RealPath`, `TestE2E_InboundInjectionHeldOverSMTP`) — reproduced identically on a pristine `origin/main` checkout (local DB-backed flakes, unrelated to this diff).
- `go build ./...`: clean.
- TS SDK: `npm run build --workspace @e2a/sdk` + `npm test --workspace @e2a/sdk` → **179/179 pass, exit 0** (incl. type tests).

Note: a sibling branch is concurrently touching enum struct tags (`apikeys.go`, `account.go`, `eventpayload/payloads.go`) — expect a trivial `api/openapi.yaml` regeneration on whichever merges second; this diff does not touch those lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
