### PR TITLE
docs(mcp): explain outbound review policy

### DIFF
--- a/mcp/src/tools/agents.ts
+++ b/mcp/src/tools/agents.ts
@@ -133,7 +133,7 @@ export function registerAgentTools(server: McpServer, client: McpClient): void {
       title: "Update an agent's protection config (beta)",
       annotations: { idempotentHint: true, destructiveHint: false },
       description:
-        "Set an agent's protection posture. Read-modify-write: only the fields you pass change; the rest keep their current value. The gate decides who may send and what a non-match does (flag/review/block); the scan sensitivity (off|low|medium|high) tunes content screening; holds govern the review queue. BETA. Account scope only.",
+        "Set an agent's protection posture. Read-modify-write: only the fields you pass change; the rest keep their current value. Outbound policy semantics: open matches every recipient; allowlist matches exact addresses in outbound_gate_allowlist; domain matches recipients on the agent's own domain. The outbound gate action applies when any recipient does not match. To require human review for every outbound message, set outbound_gate_policy=allowlist, outbound_gate_allowlist=[], outbound_gate_action=review, and holds_on_expiry=reject. Using open with review will hold nothing because every recipient matches. The scan sensitivity (off|low|medium|high) tunes content screening; holds govern the review queue. BETA. Account scope only.",
       inputSchema: strictInputSchema({
         email: z
           .string()
@@ -159,15 +159,21 @@ export function registerAgentTools(server: McpServer, client: McpClient): void {
         outbound_gate_policy: z
           .enum(["open", "allowlist", "domain"])
           .optional()
-          .describe("Outbound recipient gate."),
+          .describe(
+            "Outbound recipient gate: open matches every recipient; allowlist matches exact addresses in outbound_gate_allowlist; domain matches recipients on the agent's own domain. The gate action applies when any recipient does not match.",
+          ),
         outbound_gate_allowlist: z
           .array(z.string())
           .optional()
-          .describe("Outbound allowed recipient addresses or domains."),
+          .describe(
+            "Exact recipient addresses matched when outbound_gate_policy is allowlist. An empty list makes every recipient a non-match; combine it with outbound_gate_action=review to review every outbound message.",
+          ),
         outbound_gate_action: z
           .enum(["flag", "review", "block"])
           .optional()
-          .describe("What an outbound gate non-match does."),
+          .describe(
+            "What an outbound gate non-match does: flag (send + annotate), review (hold as pending_review for human approval), or block. With policy=open there are no non-matches, so this action never fires.",
+          ),
         outbound_scan_sensitivity: z
           .enum(["off", "low", "medium", "high"])
           .optional()
@@ -181,7 +187,9 @@ export function registerAgentTools(server: McpServer, client: McpClient): void {
         holds_on_expiry: z
           .enum(["approve", "reject"])
           .optional()
-          .describe("What happens to a held item at TTL expiry."),
+          .describe(
+            "What happens to a held item at TTL expiry. Use reject when outbound mail must never be sent without explicit human approval.",
+          ),
         holds_suppress_notifications: z
           .boolean()
           .optional()

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -355,6 +355,22 @@ describe("e2a MCP server", () => {
     );
   });
 
+  it("documents the fail-closed configuration for reviewing every outbound message", async () => {
+    const { tools } = await client.listTools();
+    const tool = tools.find((candidate) => candidate.name === "update_protection");
+    const description = tool?.description ?? "";
+    const properties = (tool?.inputSchema as {
+      properties?: Record<string, { description?: string }>;
+    })?.properties ?? {};
+
+    expect(description).toContain("outbound_gate_policy=allowlist");
+    expect(description).toContain("outbound_gate_allowlist=[]");
+    expect(description).toContain("outbound_gate_action=review");
+    expect(description).toMatch(/open.*review.*hold nothing/i);
+    expect(properties.outbound_gate_policy?.description).toMatch(/open.*every recipient/i);
+    expect(properties.holds_on_expiry?.description).toMatch(/reject.*explicit human approval/i);
+  });
+
   // The real backend status vocabulary (internal/httpapi/outbound.go
   // SendResultView) includes "accepted" — the async-outbound success status
   // that REPLACES "sent" for queue-first delivery. A model that doesn't know


### PR DESCRIPTION
## Summary

- Document `open`, `allowlist`, and `domain` outbound recipient policy semantics in the MCP tool schema.
- Add the fail-closed recipe for requiring human review on every outbound message.
- Clarify that expiry should reject when explicit approval is mandatory.
- Add a regression test for the published MCP help text.

## Why

The previous MCP descriptions exposed the configuration fields but did not explain that gate actions apply only to non-matches. This made `open + review` look like an always-review configuration even though it holds nothing.

## Client surface checklist

- [x] MCP tool description updated in `mcp/src/tools/agents.ts`
- [x] MCP regression test added in `mcp/tests/tools.test.ts`
- [x] No API shape or runtime behavior change
- [x] Other clients intentionally unchanged because this is MCP-only help text

## Operational risk

Documentation-only MCP schema change. No user data, auth, billing, notification, or delivery behavior changes.

## Test plan

- [x] `npm test -w @e2a/mcp-server` — 190 tests passed, including type tests
- [x] `npm run build -w @e2a/mcp-server`
- [x] `git diff --check`
