### PR TITLE
fix(delivery): emit email.failed when SES rejects after acceptance

### DIFF
--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -56,14 +56,16 @@ import (
 // derived deterministically from dedupKey so duplicate SNS notifications
 // produce the same id — receivers dedup on it (at-least-once delivery).
 func deliveryEventFirer(pub webhookpub.Publisher) delivery.Firer {
-	return func(ctx context.Context, userID, agentID, eventType string, data any, dedupKey string) {
+	return func(ctx context.Context, e delivery.FiredEvent) {
 		pub.Publish(ctx, webhookpub.Event{
-			ID:        webhookpub.DeterministicEventID(dedupKey),
-			Type:      eventType,
-			CreatedAt: time.Now().UTC(),
-			UserID:    userID,
-			AgentID:   agentID,
-			Data:      data,
+			ID:             webhookpub.DeterministicEventID(e.DedupKey),
+			Type:           e.Type,
+			CreatedAt:      time.Now().UTC(),
+			UserID:         e.UserID,
+			AgentID:        e.AgentID,
+			ConversationID: e.ConversationID,
+			MessageID:      e.MessageID,
+			Data:           e.Data,
 		})
 	}
 }

--- a/docs/events.md
+++ b/docs/events.md
@@ -58,7 +58,7 @@ for e in client.events.list(type="email.received", limit=20):
 | `email.received` | Inbound SMTP message accepted | **At-least-once** end-to-end |
 | `email.flagged` | Inbound message accepted but did not match the agent's `inbound_policy` (delivered + flagged, never dropped) | **At-least-once** end-to-end |
 | `email.sent` | Outbound `/send` accepted by SES | Best-effort |
-| `email.failed` | Outbound send terminally failed (retries exhausted / permanent reject) — carries `reason` | **At-least-once** |
+| `email.failed` | Outbound send terminally failed — retries exhausted / permanent reject at send time, or the provider rejected the already-accepted message (SES `Reject` delivery feedback, e.g. content scan) — carries `reason` | **At-least-once** from the send path; best-effort when emitted via delivery feedback |
 | `email.review_requested` | Message held for human review (outbound HITL or inbound screening) — carries `direction` | **At-least-once** |
 | `email.review_approved` | Review approved (outbound: sent; inbound: released to the inbox) | Best-effort |
 | `email.review_rejected` | Review rejected (outbound: discarded; inbound: dropped) | **At-least-once** |
@@ -120,6 +120,7 @@ beta event types must still parse. The stable mapping is:
 Notes:
 
 - The delivery-outcome events (`email.delivered`/`bounced`/`complained`) carry **no `status` field** — the event type IS the outcome.
+- `email.failed` is **message-level** (its `to`/`cc`/`bcc` lists carry the recipients — never one event per recipient) and fires **at most once per message** across both emission paths: the send worker and the SES `Reject` delivery-feedback path derive the same deterministic event id, so duplicate SNS deliveries and cross-path double emission collapse in the outbox.
 - `delivered_to` is always a **scalar**: on `email.received` it's the one per-agent copy (the relay emits one event per delivery); on the delivery-outcome events it's the one recipient the outcome is about. The peer `to`/`cc` lists are the message's parsed headers.
 - These shapes are locked by committed golden fixtures (`internal/eventpayload/testdata/`) that the server builders AND both SDKs test against — a payload change is a conscious, reviewed fixture regeneration.
 - Every full and minimal stable-event fixture validates twice: once against the

--- a/internal/agent/events_delivery_feedback_test.go
+++ b/internal/agent/events_delivery_feedback_test.go
@@ -1,0 +1,149 @@
+//go:build integration
+
+package agent_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tokencanopy/e2a/internal/agent"
+	"github.com/tokencanopy/e2a/internal/delivery"
+	"github.com/tokencanopy/e2a/internal/identity"
+	"github.com/tokencanopy/e2a/internal/testutil"
+	"github.com/tokencanopy/e2a/internal/webhookpub"
+)
+
+// realDeliveryFirer wires the delivery consumer to the SAME production
+// publisher path as cmd/e2a/main.go's deliveryEventFirer: it persists each
+// delivery-feedback event to webhook_events with its envelope routing keys
+// (agent_id/conversation_id/message_id), which is exactly what the Events API
+// filters on. Kept in lockstep with main.go by construction.
+func realDeliveryFirer(pub webhookpub.Publisher) delivery.Firer {
+	return func(ctx context.Context, e delivery.FiredEvent) {
+		pub.Publish(ctx, webhookpub.Event{
+			ID:             webhookpub.DeterministicEventID(e.DedupKey),
+			Type:           e.Type,
+			CreatedAt:      time.Now().UTC(),
+			UserID:         e.UserID,
+			AgentID:        e.AgentID,
+			ConversationID: e.ConversationID,
+			MessageID:      e.MessageID,
+			Data:           e.Data,
+		})
+	}
+}
+
+// TestDeliveryFeedback_FindableByMessageID is the regression test for the
+// review finding: delivery-feedback events (email.failed via SES Reject, and
+// email.delivered) fired through the production publisher must be findable via
+// GET /v1/events?message_id= and ?conversation_id=. Before the fix the firer
+// dropped MessageID/ConversationID, so the persisted webhook_events row had
+// message_id=NULL and the reconciliation query returned nothing.
+func TestDeliveryFeedback_FindableByMessageID(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	store := identity.NewStore(pool)
+
+	user, err := store.CreateOrGetUser(ctx, "owner-dfb@example.com", "Owner", "g-dfb")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	const domain = "dfb.example.com"
+	if _, err := store.ClaimOrCreateDomain(ctx, domain, user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+	if err := store.VerifyDomain(ctx, domain, user.ID); err != nil {
+		t.Fatalf("VerifyDomain: %v", err)
+	}
+	agentEmail := "bot@" + domain
+	if _, err := store.CreateAgent(ctx, agentEmail, domain, "", "", "", user.ID); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	// One rejected message (conversation-threaded) and one delivered message.
+	const convID = "conv_dfb_1"
+	rejMsg, err := store.CreateOutboundMessage(ctx, agentEmail, []string{"a@x.com"}, nil, nil, "Rejected subj", "send", "smtp", "ses-dfb-reject", convID, nil)
+	if err != nil {
+		t.Fatalf("CreateOutboundMessage(reject): %v", err)
+	}
+	if err := store.MarkMessageSent(ctx, rejMsg.ID, "relay", []string{"a@x.com"}, nil, nil); err != nil {
+		t.Fatalf("MarkMessageSent(reject): %v", err)
+	}
+	dlvMsg, err := store.CreateOutboundMessage(ctx, agentEmail, []string{"b@x.com"}, nil, nil, "Delivered subj", "send", "smtp", "ses-dfb-delivered", "", nil)
+	if err != nil {
+		t.Fatalf("CreateOutboundMessage(delivered): %v", err)
+	}
+	if err := store.MarkMessageSent(ctx, dlvMsg.ID, "relay", []string{"b@x.com"}, nil, nil); err != nil {
+		t.Fatalf("MarkMessageSent(delivered): %v", err)
+	}
+
+	outbox := webhookpub.NewOutbox(pool, webhookpub.StaticFlag(true))
+	pub := webhookpub.NewOutboxPublisher(outbox, pool)
+	consumer := delivery.NewConsumer(store, realDeliveryFirer(pub))
+
+	if err := consumer.Process(ctx, &delivery.Event{
+		Kind: delivery.KindReject, SESMessageID: "ses-dfb-reject",
+		Recipients: []delivery.RecipientOutcome{{Address: "a@x.com", Status: delivery.StatusFailed, Detail: "Bad content"}},
+	}); err != nil {
+		t.Fatalf("Process(reject): %v", err)
+	}
+	if err := consumer.Process(ctx, &delivery.Event{
+		Kind: delivery.KindDelivery, SESMessageID: "ses-dfb-delivered",
+		Recipients: []delivery.RecipientOutcome{{Address: "b@x.com", Status: delivery.StatusDelivered}},
+	}); err != nil {
+		t.Fatalf("Process(delivered): %v", err)
+	}
+
+	// The reconciliation query: GET /v1/events?message_id=<rejected msg> must
+	// return the email.failed emitted via delivery feedback.
+	byRejMsg, err := agent.ListEventsForUser(ctx, pool, user.ID, "", "", "", rejMsg.ID, nil, nil, time.Time{}, "", 50)
+	if err != nil {
+		t.Fatalf("ListEventsForUser(message_id=reject): %v", err)
+	}
+	if !hasEventType(byRejMsg, "email.failed") {
+		t.Fatalf("GET /v1/events?message_id=%s returned no email.failed (found %v) — Reject event is invisible to the reconciliation query", rejMsg.ID, eventTypes(byRejMsg))
+	}
+
+	// And findable by its conversation thread.
+	byConv, err := agent.ListEventsForUser(ctx, pool, user.ID, "", "", convID, "", nil, nil, time.Time{}, "", 50)
+	if err != nil {
+		t.Fatalf("ListEventsForUser(conversation_id): %v", err)
+	}
+	if !hasEventType(byConv, "email.failed") {
+		t.Fatalf("GET /v1/events?conversation_id=%s returned no email.failed (found %v)", convID, eventTypes(byConv))
+	}
+
+	// The delivered event is likewise findable by its message_id.
+	byDlvMsg, err := agent.ListEventsForUser(ctx, pool, user.ID, "", "", "", dlvMsg.ID, nil, nil, time.Time{}, "", 50)
+	if err != nil {
+		t.Fatalf("ListEventsForUser(message_id=delivered): %v", err)
+	}
+	if !hasEventType(byDlvMsg, "email.delivered") {
+		t.Fatalf("GET /v1/events?message_id=%s returned no email.delivered (found %v)", dlvMsg.ID, eventTypes(byDlvMsg))
+	}
+
+	// Cross-check: the rejected message's query must NOT surface the OTHER
+	// message's event (proves the message_id filter is actually applied, not a
+	// blanket return).
+	if hasEventType(byRejMsg, "email.delivered") {
+		t.Fatalf("message_id filter leaked another message's event: %v", eventTypes(byRejMsg))
+	}
+}
+
+func hasEventType(evs []agent.EventJSON, typ string) bool {
+	for i := range evs {
+		if evs[i].Type == typ {
+			return true
+		}
+	}
+	return false
+}
+
+func eventTypes(evs []agent.EventJSON) []string {
+	out := make([]string, 0, len(evs))
+	for i := range evs {
+		out = append(out, evs[i].Type)
+	}
+	return out
+}

--- a/internal/delivery/consumer.go
+++ b/internal/delivery/consumer.go
@@ -7,15 +7,35 @@ import (
 	"github.com/tokencanopy/e2a/internal/eventpayload"
 )
 
+// CorrelatedMessage is CorrelateBySESMessageID's result: the outbound message
+// a SES provider id maps to, plus the message fields the canonical event
+// payloads need — all columns of the same row/join the correlation SELECT
+// already reads, so widening it costs no extra query.
+type CorrelatedMessage struct {
+	MessageID string
+	UserID    string
+	// AgentID is the agent's own address (an agent identity's id IS its
+	// email), so it doubles as agent_email on event payloads.
+	AgentID        string
+	Subject        string
+	ConversationID string
+	Method         string
+	MessageType    string
+	From           string
+	To             []string
+	CC             []string
+	BCC            []string
+}
+
 // Store is the narrow persistence surface the consumer needs. *identity.Store
 // satisfies it.
 type Store interface {
 	// CorrelateBySESMessageID finds the outbound message + owning user + agent
-	// (plus the message subject, for the event payloads — same single SELECT,
+	// (plus the message fields the event payloads need — same single SELECT,
 	// no extra query) by the SES-assigned provider_message_id captured at send
 	// time. found=false when the id is unknown (message expired, or an event
 	// for another deployment).
-	CorrelateBySESMessageID(ctx context.Context, sesMessageID string) (messageID, userID, agentID, subject string, found bool, err error)
+	CorrelateBySESMessageID(ctx context.Context, sesMessageID string) (m *CorrelatedMessage, found bool, err error)
 	// RecordDeliveryOutcome upserts the per-recipient status monotonically and
 	// recomputes the message rollup (worst status by precedence). Idempotent:
 	// a duplicate/older event is a no-op.
@@ -28,7 +48,7 @@ type Store interface {
 // Firer publishes a delivery/suppression webhook event to the owning user's
 // subscribers. data is the canonical typed payload for the event
 // (eventpayload.EmailDeliveredData / EmailBouncedData / EmailComplainedData /
-// DomainSuppressionAddedData). agentID lets subscribers with an agent_ids
+// EmailFailedData / DomainSuppressionAddedData). agentID lets subscribers with an agent_ids
 // filter match (empty for account-scoped events like suppression). dedupKey
 // makes redeliveries idempotent (the publisher derives a stable event id from
 // it). Injected as a closure so this package does not depend on webhookpub.
@@ -36,16 +56,27 @@ type Firer func(ctx context.Context, userID, agentID, eventType string, data any
 
 // Event push types for delivery outcomes (decision 9 vocabulary).
 const (
-	EventEmailDelivered     = "email.delivered"
-	EventEmailBounced       = "email.bounced"
-	EventEmailComplained    = "email.complained"
+	EventEmailDelivered  = "email.delivered"
+	EventEmailBounced    = "email.bounced"
+	EventEmailComplained = "email.complained"
+	// EventEmailFailed is the canonical stable terminal-failure event
+	// (webhookpub.EventEmailFailed — string-duplicated so this package stays a
+	// light leaf). The SES Reject path emits it MESSAGE-level, not per
+	// recipient; see Process.
+	EventEmailFailed        = "email.failed"
 	EventSuppressionAdded   = "domain.suppression_added" // account-scoped despite the prefix (design vocab)
 	suppressionSourceBounce = "bounce"
 	suppressionSourceCompl  = "complaint"
 )
 
-// pushEventFor maps a recipient status to its webhook event type, or "" for
-// statuses with no push event (queued/sent/deferred/failed — poll instead).
+// rejectFallbackReason keeps email.failed's required `reason` non-empty when
+// an SES Reject notification carries no reject.reason.
+const rejectFallbackReason = "rejected by the email provider after acceptance"
+
+// pushEventFor maps a recipient status to its PER-RECIPIENT webhook event
+// type, or "" for statuses with no per-recipient push event (queued/sent/
+// deferred — poll instead; failed is emitted message-level by the Reject path
+// in Process, never per recipient).
 func pushEventFor(s Status) string {
 	switch s {
 	case StatusDelivered:
@@ -78,7 +109,7 @@ func (c *Consumer) Process(ctx context.Context, ev *Event) error {
 	if ev == nil || len(ev.Recipients) == 0 {
 		return nil
 	}
-	messageID, userID, agentID, subject, found, err := c.store.CorrelateBySESMessageID(ctx, ev.SESMessageID)
+	m, found, err := c.store.CorrelateBySESMessageID(ctx, ev.SESMessageID)
 	if err != nil {
 		return err
 	}
@@ -87,24 +118,42 @@ func (c *Consumer) Process(ctx context.Context, ev *Event) error {
 		return nil
 	}
 
+	recorded := 0
 	for _, r := range ev.Recipients {
 		if r.Address == "" || !r.Status.Valid() {
 			continue
 		}
-		if err := c.store.RecordDeliveryOutcome(ctx, messageID, r.Address, r.Status, r.Detail); err != nil {
+		if err := c.store.RecordDeliveryOutcome(ctx, m.MessageID, r.Address, r.Status, r.Detail); err != nil {
 			return err
 		}
+		recorded++
 		if evType := pushEventFor(r.Status); evType != "" && c.fire != nil {
-			// agentID is the agent's own address (agent identity id == email), so it
-			// doubles as agent_email. smtp_detail is the SES diagnostic string (named
-			// to disambiguate from email.failed's `reason`). The event TYPE is the
-			// outcome — there is no redundant `status` field (contract freeze PR-2).
-			c.fire(ctx, userID, agentID, evType, deliveryEventData(evType, messageID, agentID, subject, ev, r),
-				evType+"|"+messageID+"|"+r.Address)
+			// m.AgentID is the agent's own address (agent identity id == email), so
+			// it doubles as agent_email. smtp_detail is the SES diagnostic string
+			// (named to disambiguate from email.failed's `reason`). The event TYPE
+			// is the outcome — there is no redundant `status` field (contract
+			// freeze PR-2).
+			c.fire(ctx, m.UserID, m.AgentID, evType, deliveryEventData(evType, m, ev, r),
+				evType+"|"+m.MessageID+"|"+r.Address)
 		}
 		if r.Suppress {
-			c.suppress(ctx, userID, messageID, r)
+			c.suppress(ctx, m.UserID, m.MessageID, r)
 		}
+	}
+
+	// An SES Reject is the provider refusing the whole already-accepted
+	// message (e.g. content scan), so it emits ONE message-level email.failed
+	// — the same canonical stable event/shape the async send worker publishes
+	// on terminal send failure — never a per-recipient event: the payload's
+	// to/cc/bcc lists carry the recipients, and two events for one message
+	// would be conflicting duplicates of a message-level fact. The dedup key
+	// hashes to the IDENTICAL deterministic event id as the worker path
+	// (DeterministicEventID(messageID, "email.failed")), so duplicate SNS
+	// deliveries AND any cross-path double emission collapse in the durable
+	// outbox via ON CONFLICT (id) DO NOTHING.
+	if ev.Kind == KindReject && recorded > 0 && c.fire != nil {
+		c.fire(ctx, m.UserID, m.AgentID, EventEmailFailed,
+			failedEventData(m, rejectReason(ev)), m.MessageID+"|"+EventEmailFailed)
 	}
 	return nil
 }
@@ -113,7 +162,7 @@ func (c *Consumer) Process(ctx context.Context, ev *Event) error {
 // delivery outcome. bounce_type/bounce_sub_type come from the SES bounce
 // notification's classification, parsed in ParseSESNotification; a bounced
 // outcome that somehow lacks one is "undetermined" (the field is required).
-func deliveryEventData(evType, messageID, agentEmail, subject string, ev *Event, r RecipientOutcome) any {
+func deliveryEventData(evType string, m *CorrelatedMessage, ev *Event, r RecipientOutcome) any {
 	switch evType {
 	case EventEmailBounced:
 		bounceType := ev.BounceType
@@ -121,34 +170,78 @@ func deliveryEventData(evType, messageID, agentEmail, subject string, ev *Event,
 			bounceType = "undetermined"
 		}
 		return eventpayload.EmailBouncedData{
-			MessageID:     messageID,
-			AgentEmail:    agentEmail,
+			MessageID:     m.MessageID,
+			AgentEmail:    m.AgentID,
 			Direction:     "outbound",
 			DeliveredTo:   r.Address,
-			Subject:       subject,
+			Subject:       m.Subject,
 			SMTPDetail:    r.Detail,
 			BounceType:    bounceType,
 			BounceSubType: ev.BounceSubType,
 		}
 	case EventEmailComplained:
 		return eventpayload.EmailComplainedData{
-			MessageID:   messageID,
-			AgentEmail:  agentEmail,
+			MessageID:   m.MessageID,
+			AgentEmail:  m.AgentID,
 			Direction:   "outbound",
 			DeliveredTo: r.Address,
-			Subject:     subject,
+			Subject:     m.Subject,
 			SMTPDetail:  r.Detail,
 		}
 	default: // EventEmailDelivered
 		return eventpayload.EmailDeliveredData{
-			MessageID:   messageID,
-			AgentEmail:  agentEmail,
+			MessageID:   m.MessageID,
+			AgentEmail:  m.AgentID,
 			Direction:   "outbound",
 			DeliveredTo: r.Address,
-			Subject:     subject,
+			Subject:     m.Subject,
 			SMTPDetail:  r.Detail,
 		}
 	}
+}
+
+// failedEventData builds the canonical eventpayload.EmailFailedData for an SES
+// Reject — byte-identical in shape to the async send worker's emission
+// (golden-fixture-locked): every field the correlated message carries is
+// populated; ReasonCode and Retryable stay unset because the SES Reject
+// notification carries only the human-readable reject.reason, matching the
+// worker path's convention (absent ≠ false).
+func failedEventData(m *CorrelatedMessage, reason string) eventpayload.EmailFailedData {
+	return eventpayload.EmailFailedData{
+		MessageID:      m.MessageID,
+		AgentEmail:     m.AgentID,
+		Direction:      "outbound",
+		ConversationID: m.ConversationID,
+		Method:         m.Method,
+		From:           m.From,
+		To:             nonNil(m.To),
+		CC:             m.CC,
+		BCC:            m.BCC,
+		Subject:        m.Subject,
+		MessageType:    m.MessageType,
+		Reason:         reason,
+	}
+}
+
+// rejectReason returns the SES reject.reason (the parser stamps the same
+// reason on every recipient outcome), or a stable fallback so email.failed's
+// required `reason` is never empty.
+func rejectReason(ev *Event) string {
+	for _, r := range ev.Recipients {
+		if r.Detail != "" {
+			return r.Detail
+		}
+	}
+	return rejectFallbackReason
+}
+
+// nonNil keeps `to` (nullable:false in the published schema) marshaling as []
+// when the correlated row carried no recipient list.
+func nonNil(s []string) []string {
+	if s == nil {
+		return []string{}
+	}
+	return s
 }
 
 func (c *Consumer) suppress(ctx context.Context, userID, messageID string, r RecipientOutcome) {

--- a/internal/delivery/consumer.go
+++ b/internal/delivery/consumer.go
@@ -45,14 +45,35 @@ type Store interface {
 	AddSuppression(ctx context.Context, userID, address, reason, source, sourceMessageID string) (added bool, err error)
 }
 
-// Firer publishes a delivery/suppression webhook event to the owning user's
-// subscribers. data is the canonical typed payload for the event
-// (eventpayload.EmailDeliveredData / EmailBouncedData / EmailComplainedData /
-// EmailFailedData / DomainSuppressionAddedData). agentID lets subscribers with an agent_ids
-// filter match (empty for account-scoped events like suppression). dedupKey
-// makes redeliveries idempotent (the publisher derives a stable event id from
-// it). Injected as a closure so this package does not depend on webhookpub.
-type Firer func(ctx context.Context, userID, agentID, eventType string, data any, dedupKey string)
+// FiredEvent is the set of fields delivery hands its Firer for one webhook
+// event. Data is the canonical typed payload (eventpayload.EmailDeliveredData /
+// EmailBouncedData / EmailComplainedData / EmailFailedData /
+// DomainSuppressionAddedData).
+//
+// AgentID, ConversationID, and MessageID are the ENVELOPE ROUTING KEYS: they
+// let subscribers' agent_ids/labels filters match AND they populate the
+// webhook_events row's agent_id/conversation_id/message_id columns, which is
+// what makes the persisted event findable via GET /v1/events?message_id= /
+// ?conversation_id= — the reconciliation query an integrator uses to learn a
+// specific message's fate. A message-backed delivery-feedback event must set
+// all three (they mirror the send-worker path's envelope, giving full
+// payload+envelope parity); account-scoped events (suppression) leave them
+// empty. DedupKey makes redeliveries idempotent (the publisher derives a stable
+// event id from it, independent of the routing keys).
+type FiredEvent struct {
+	UserID         string
+	AgentID        string
+	ConversationID string
+	MessageID      string
+	Type           string
+	Data           any
+	DedupKey       string
+}
+
+// Firer publishes one delivery/suppression webhook event to the owning user's
+// subscribers. Injected as a closure so this package does not depend on
+// webhookpub.
+type Firer func(ctx context.Context, e FiredEvent)
 
 // Event push types for delivery outcomes (decision 9 vocabulary).
 const (
@@ -132,9 +153,17 @@ func (c *Consumer) Process(ctx context.Context, ev *Event) error {
 			// it doubles as agent_email. smtp_detail is the SES diagnostic string
 			// (named to disambiguate from email.failed's `reason`). The event TYPE
 			// is the outcome — there is no redundant `status` field (contract
-			// freeze PR-2).
-			c.fire(ctx, m.UserID, m.AgentID, evType, deliveryEventData(evType, m, ev, r),
-				evType+"|"+m.MessageID+"|"+r.Address)
+			// freeze PR-2). MessageID/ConversationID on the envelope keep the
+			// persisted event findable via GET /v1/events?message_id=/?conversation_id=.
+			c.fire(ctx, FiredEvent{
+				UserID:         m.UserID,
+				AgentID:        m.AgentID,
+				ConversationID: m.ConversationID,
+				MessageID:      m.MessageID,
+				Type:           evType,
+				Data:           deliveryEventData(evType, m, ev, r),
+				DedupKey:       evType + "|" + m.MessageID + "|" + r.Address,
+			})
 		}
 		if r.Suppress {
 			c.suppress(ctx, m.UserID, m.MessageID, r)
@@ -152,8 +181,15 @@ func (c *Consumer) Process(ctx context.Context, ev *Event) error {
 	// deliveries AND any cross-path double emission collapse in the durable
 	// outbox via ON CONFLICT (id) DO NOTHING.
 	if ev.Kind == KindReject && recorded > 0 && c.fire != nil {
-		c.fire(ctx, m.UserID, m.AgentID, EventEmailFailed,
-			failedEventData(m, rejectReason(ev)), m.MessageID+"|"+EventEmailFailed)
+		c.fire(ctx, FiredEvent{
+			UserID:         m.UserID,
+			AgentID:        m.AgentID,
+			ConversationID: m.ConversationID,
+			MessageID:      m.MessageID,
+			Type:           EventEmailFailed,
+			Data:           failedEventData(m, rejectReason(ev)),
+			DedupKey:       m.MessageID + "|" + EventEmailFailed,
+		})
 	}
 	return nil
 }
@@ -256,12 +292,21 @@ func (c *Consumer) suppress(ctx context.Context, userID, messageID string, r Rec
 	}
 	if added && c.fire != nil {
 		// Auto-suppression emits an event so the tenant is alerted, not silently
-		// cut off (decision 9). Account-scoped → empty agentID.
-		c.fire(ctx, userID, "", EventSuppressionAdded, eventpayload.DomainSuppressionAddedData{
-			Address:   r.Address,
-			Source:    source,
-			Reason:    r.Detail,
-			MessageID: messageID,
-		}, EventSuppressionAdded+"|"+userID+"|"+r.Address)
+		// cut off (decision 9). It is ACCOUNT-scoped, not tied to one message
+		// thread: no AgentID/ConversationID/MessageID envelope routing keys (the
+		// triggering message rides in the payload's source_message_id instead), so
+		// it is not filtered out of a message/thread-scoped GET /v1/events query it
+		// was never about.
+		c.fire(ctx, FiredEvent{
+			UserID: userID,
+			Type:   EventSuppressionAdded,
+			Data: eventpayload.DomainSuppressionAddedData{
+				Address:   r.Address,
+				Source:    source,
+				Reason:    r.Detail,
+				MessageID: messageID,
+			},
+			DedupKey: EventSuppressionAdded + "|" + userID + "|" + r.Address,
+		})
 	}
 }

--- a/internal/delivery/consumer_crosspath_test.go
+++ b/internal/delivery/consumer_crosspath_test.go
@@ -42,9 +42,9 @@ func TestRejectEmailFailedIDCollapsesAcrossPaths(t *testing.T) {
 		MessageID: msgID, UserID: "u_1", AgentID: "bot@x.com", To: []string{"a@x.com"},
 	}}
 	var keys []string
-	fire := func(_ context.Context, _, _, eventType string, _ any, dedupKey string) {
-		if eventType == delivery.EventEmailFailed {
-			keys = append(keys, dedupKey)
+	fire := func(_ context.Context, e delivery.FiredEvent) {
+		if e.Type == delivery.EventEmailFailed {
+			keys = append(keys, e.DedupKey)
 		}
 	}
 	c := delivery.NewConsumer(store, fire)

--- a/internal/delivery/consumer_crosspath_test.go
+++ b/internal/delivery/consumer_crosspath_test.go
@@ -1,0 +1,67 @@
+// External test package: delivery itself must stay a light leaf (no webhookpub
+// import — webhookpub pulls in identity, which imports delivery), but the
+// cross-path event-id invariant below needs webhookpub.DeterministicEventID.
+package delivery_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tokencanopy/e2a/internal/delivery"
+	"github.com/tokencanopy/e2a/internal/webhookpub"
+)
+
+type crossPathStore struct{ corr *delivery.CorrelatedMessage }
+
+func (s *crossPathStore) CorrelateBySESMessageID(ctx context.Context, id string) (*delivery.CorrelatedMessage, bool, error) {
+	return s.corr, s.corr != nil, nil
+}
+func (s *crossPathStore) RecordDeliveryOutcome(ctx context.Context, messageID, address string, status delivery.Status, detail string) error {
+	return nil
+}
+func (s *crossPathStore) AddSuppression(ctx context.Context, userID, address, reason, source, sourceMessageID string) (bool, error) {
+	return false, nil
+}
+
+// TestRejectEmailFailedIDCollapsesAcrossPaths pins the dedup design: the async
+// send worker publishes email.failed with
+// webhookpub.DeterministicEventID(messageID, EventEmailFailed), and main.go's
+// deliveryEventFirer derives the SNS-path event id as
+// DeterministicEventID(dedupKey). The consumer's Reject dedup key must hash to
+// the SAME id, so (a) duplicate SNS deliveries and (b) any cross-path double
+// emission collapse to one message-level email.failed in the outbox
+// (ON CONFLICT (id) DO NOTHING) — subscribers can never receive two
+// conflicting terminal events for one message.
+func TestRejectEmailFailedIDCollapsesAcrossPaths(t *testing.T) {
+	if delivery.EventEmailFailed != webhookpub.EventEmailFailed {
+		t.Fatalf("event type drift: delivery=%q webhookpub=%q", delivery.EventEmailFailed, webhookpub.EventEmailFailed)
+	}
+
+	const msgID = "msg_crosspath"
+	store := &crossPathStore{corr: &delivery.CorrelatedMessage{
+		MessageID: msgID, UserID: "u_1", AgentID: "bot@x.com", To: []string{"a@x.com"},
+	}}
+	var keys []string
+	fire := func(_ context.Context, _, _, eventType string, _ any, dedupKey string) {
+		if eventType == delivery.EventEmailFailed {
+			keys = append(keys, dedupKey)
+		}
+	}
+	c := delivery.NewConsumer(store, fire)
+	for i := 0; i < 2; i++ { // duplicate SNS delivery of the same Reject
+		if err := c.Process(context.Background(), &delivery.Event{
+			Kind: delivery.KindReject, SESMessageID: "ses-crosspath",
+			Recipients: []delivery.RecipientOutcome{{Address: "a@x.com", Status: delivery.StatusFailed, Detail: "Bad content"}},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if len(keys) != 2 || keys[0] != keys[1] {
+		t.Fatalf("dedup keys = %v, want two identical keys", keys)
+	}
+	got := webhookpub.DeterministicEventID(keys[0])
+	want := webhookpub.DeterministicEventID(msgID, webhookpub.EventEmailFailed)
+	if got != want {
+		t.Fatalf("SNS-path event id %s != worker-path event id %s — cross-path dedup broken", got, want)
+	}
+}

--- a/internal/delivery/consumer_test.go
+++ b/internal/delivery/consumer_test.go
@@ -45,15 +45,15 @@ func (f *fakeConsumerStore) AddSuppression(ctx context.Context, userID, address,
 }
 
 type firedEvent struct {
-	userID, agentID, eventType string
-	data                       any
-	dedupKey                   string
+	userID, agentID, conversationID, messageID, eventType string
+	data                                                  any
+	dedupKey                                              string
 }
 
 func recordingFirer() (Firer, *[]firedEvent) {
 	var events []firedEvent
-	f := func(ctx context.Context, userID, agentID, eventType string, data any, dedupKey string) {
-		events = append(events, firedEvent{userID, agentID, eventType, data, dedupKey})
+	f := func(ctx context.Context, e FiredEvent) {
+		events = append(events, firedEvent{e.UserID, e.AgentID, e.ConversationID, e.MessageID, e.Type, e.Data, e.DedupKey})
 	}
 	return f, &events
 }
@@ -96,6 +96,11 @@ func TestConsumerProcess(t *testing.T) {
 		e := (*events)[0]
 		if e.eventType != EventEmailDelivered || e.userID != "u_1" || e.agentID != "bot@x.com" {
 			t.Fatalf("event=%+v", e)
+		}
+		// The delivery-feedback events share the firer; the message-level routing
+		// key must be set so the persisted event is findable by message_id.
+		if e.messageID != "msg_1" {
+			t.Errorf("email.delivered envelope messageID=%q, want msg_1 (findability)", e.messageID)
 		}
 		data, ok := e.data.(eventpayload.EmailDeliveredData)
 		if !ok {
@@ -165,8 +170,14 @@ func TestConsumerProcess(t *testing.T) {
 			Recipients: []RecipientOutcome{{Address: "c@x.com", Status: StatusComplained, Suppress: true}},
 		})
 		for _, e := range *events {
-			if e.eventType == EventSuppressionAdded && e.agentID != "" {
-				t.Errorf("suppression event is account-scoped; agentID should be empty, got %q", e.agentID)
+			if e.eventType == EventSuppressionAdded {
+				// Account-scoped: no agent/message/conversation envelope routing keys
+				// (so it is not filtered out of a message/thread-scoped events query
+				// it was never about; the triggering message is in the payload).
+				if e.agentID != "" || e.messageID != "" || e.conversationID != "" {
+					t.Errorf("suppression event is account-scoped; agentID/messageID/conversationID should be empty, got %q/%q/%q",
+						e.agentID, e.messageID, e.conversationID)
+				}
 			}
 		}
 	})
@@ -222,6 +233,12 @@ func TestConsumerProcess(t *testing.T) {
 		e := (*events)[0]
 		if e.eventType != EventEmailFailed || e.userID != "u_5" || e.agentID != "bot@x.com" {
 			t.Fatalf("event=%+v", e)
+		}
+		// Envelope routing keys must be set so the persisted event is findable
+		// via GET /v1/events?message_id=/?conversation_id= (the reconciliation
+		// query) and matches the send-worker path's envelope.
+		if e.messageID != "msg_5" || e.conversationID != "conv_5" {
+			t.Fatalf("envelope routing keys missing: messageID=%q conversationID=%q", e.messageID, e.conversationID)
 		}
 		if e.dedupKey != "msg_5|"+EventEmailFailed {
 			t.Fatalf("dedupKey=%q, want the worker-path deterministic formula message_id|event_type", e.dedupKey)

--- a/internal/delivery/consumer_test.go
+++ b/internal/delivery/consumer_test.go
@@ -10,8 +10,8 @@ import (
 
 // fakeConsumerStore is an in-memory delivery.Store.
 type fakeConsumerStore struct {
-	// correlation: sesMessageID → (messageID, userID, agentID, subject)
-	corr map[string][4]string
+	// correlation: sesMessageID → correlated message
+	corr map[string]*CorrelatedMessage
 	// recorded outcomes + suppressions
 	outcomes    [][3]string // {messageID, address, status}
 	suppressed  map[string]bool
@@ -21,12 +21,12 @@ type fakeConsumerStore struct {
 }
 
 func newFakeConsumerStore() *fakeConsumerStore {
-	return &fakeConsumerStore{corr: map[string][4]string{}, suppressed: map[string]bool{}, alreadySupp: map[string]bool{}}
+	return &fakeConsumerStore{corr: map[string]*CorrelatedMessage{}, suppressed: map[string]bool{}, alreadySupp: map[string]bool{}}
 }
 
-func (f *fakeConsumerStore) CorrelateBySESMessageID(ctx context.Context, id string) (string, string, string, string, bool, error) {
-	v, ok := f.corr[id]
-	return v[0], v[1], v[2], v[3], ok, nil
+func (f *fakeConsumerStore) CorrelateBySESMessageID(ctx context.Context, id string) (*CorrelatedMessage, bool, error) {
+	m, ok := f.corr[id]
+	return m, ok, nil
 }
 func (f *fakeConsumerStore) RecordDeliveryOutcome(ctx context.Context, messageID, address string, st Status, detail string) error {
 	f.outcomes = append(f.outcomes, [3]string{messageID, address, string(st)})
@@ -77,7 +77,7 @@ func TestConsumerProcess(t *testing.T) {
 
 	t.Run("delivery records outcome + fires email.delivered with agent id", func(t *testing.T) {
 		store := newFakeConsumerStore()
-		store.corr["ses-1"] = [4]string{"msg_1", "u_1", "bot@x.com", "hi"}
+		store.corr["ses-1"] = &CorrelatedMessage{MessageID: "msg_1", UserID: "u_1", AgentID: "bot@x.com", Subject: "hi"}
 		fire, events := recordingFirer()
 		c := NewConsumer(store, fire)
 		err := c.Process(context.Background(), &Event{
@@ -111,7 +111,7 @@ func TestConsumerProcess(t *testing.T) {
 
 	t.Run("hard bounce records + fires bounced + suppresses + fires suppression", func(t *testing.T) {
 		store := newFakeConsumerStore()
-		store.corr["ses-2"] = [4]string{"msg_2", "u_2", "bot@x.com", ""}
+		store.corr["ses-2"] = &CorrelatedMessage{MessageID: "msg_2", UserID: "u_2", AgentID: "bot@x.com"}
 		fire, events := recordingFirer()
 		c := NewConsumer(store, fire)
 		_ = c.Process(context.Background(), &Event{
@@ -142,7 +142,7 @@ func TestConsumerProcess(t *testing.T) {
 
 	t.Run("bounce without a classification defaults to undetermined", func(t *testing.T) {
 		store := newFakeConsumerStore()
-		store.corr["ses-2b"] = [4]string{"msg_2b", "u_2", "bot@x.com", ""}
+		store.corr["ses-2b"] = &CorrelatedMessage{MessageID: "msg_2b", UserID: "u_2", AgentID: "bot@x.com"}
 		fire, events := recordingFirer()
 		c := NewConsumer(store, fire)
 		_ = c.Process(context.Background(), &Event{
@@ -157,7 +157,7 @@ func TestConsumerProcess(t *testing.T) {
 
 	t.Run("complaint suppresses with no agent id on the suppression event", func(t *testing.T) {
 		store := newFakeConsumerStore()
-		store.corr["ses-3"] = [4]string{"msg_3", "u_3", "bot@x.com", ""}
+		store.corr["ses-3"] = &CorrelatedMessage{MessageID: "msg_3", UserID: "u_3", AgentID: "bot@x.com"}
 		fire, events := recordingFirer()
 		c := NewConsumer(store, fire)
 		_ = c.Process(context.Background(), &Event{
@@ -173,7 +173,7 @@ func TestConsumerProcess(t *testing.T) {
 
 	t.Run("re-suppression fires the event at most once", func(t *testing.T) {
 		store := newFakeConsumerStore()
-		store.corr["ses-4"] = [4]string{"msg_4", "u_4", "bot@x.com", ""}
+		store.corr["ses-4"] = &CorrelatedMessage{MessageID: "msg_4", UserID: "u_4", AgentID: "bot@x.com"}
 		store.alreadySupp["u_4|d@x.com"] = true // already on the list
 		fire, events := recordingFirer()
 		c := NewConsumer(store, fire)
@@ -185,6 +185,143 @@ func TestConsumerProcess(t *testing.T) {
 			if e.eventType == EventSuppressionAdded {
 				t.Error("suppression_added must not fire when the address was already suppressed")
 			}
+		}
+	})
+
+	t.Run("reject records failed per recipient + fires exactly ONE message-level email.failed", func(t *testing.T) {
+		store := newFakeConsumerStore()
+		store.corr["ses-5"] = &CorrelatedMessage{
+			MessageID: "msg_5", UserID: "u_5", AgentID: "bot@x.com", Subject: "hello",
+			ConversationID: "conv_5", Method: "smtp", MessageType: "send",
+			From: "bot@x.com", To: []string{"a@x.com", "b@x.com"}, CC: []string{"c@x.com"},
+		}
+		fire, events := recordingFirer()
+		c := NewConsumer(store, fire)
+		err := c.Process(context.Background(), &Event{
+			Kind: KindReject, SESMessageID: "ses-5",
+			Recipients: []RecipientOutcome{
+				{Address: "a@x.com", Status: StatusFailed, Detail: "Bad content"},
+				{Address: "b@x.com", Status: StatusFailed, Detail: "Bad content"},
+				{Address: "c@x.com", Status: StatusFailed, Detail: "Bad content"},
+			},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(store.outcomes) != 3 {
+			t.Fatalf("outcomes=%v, want one failed outcome per recipient", store.outcomes)
+		}
+		for _, o := range store.outcomes {
+			if o[0] != "msg_5" || o[2] != "failed" {
+				t.Fatalf("outcome=%v, want (msg_5, _, failed)", o)
+			}
+		}
+		if len(*events) != 1 {
+			t.Fatalf("got %d events %v, want exactly one message-level email.failed (never one per recipient)", len(*events), *events)
+		}
+		e := (*events)[0]
+		if e.eventType != EventEmailFailed || e.userID != "u_5" || e.agentID != "bot@x.com" {
+			t.Fatalf("event=%+v", e)
+		}
+		if e.dedupKey != "msg_5|"+EventEmailFailed {
+			t.Fatalf("dedupKey=%q, want the worker-path deterministic formula message_id|event_type", e.dedupKey)
+		}
+		data, ok := e.data.(eventpayload.EmailFailedData)
+		if !ok {
+			t.Fatalf("data is not the canonical typed payload: %T", e.data)
+		}
+		if data.MessageID != "msg_5" || data.AgentEmail != "bot@x.com" || data.Direction != "outbound" {
+			t.Fatalf("data=%+v", data)
+		}
+		if data.ConversationID != "conv_5" || data.Method != "smtp" || data.MessageType != "send" ||
+			data.From != "bot@x.com" || data.Subject != "hello" {
+			t.Fatalf("correlated message fields not wired through: %+v", data)
+		}
+		if len(data.To) != 2 || data.To[0] != "a@x.com" || data.To[1] != "b@x.com" ||
+			len(data.CC) != 1 || data.CC[0] != "c@x.com" {
+			t.Fatalf("recipient lists must come from the correlated message: to=%v cc=%v", data.To, data.CC)
+		}
+		if data.Reason != "Bad content" {
+			t.Fatalf("reason=%q, want the SES reject reason", data.Reason)
+		}
+		if data.ReasonCode != "" || data.Retryable != nil {
+			t.Fatalf("reason_code/retryable must stay unset (same shape as the send-worker emission): %+v", data)
+		}
+	})
+
+	t.Run("reject never suppresses and fires no suppression event", func(t *testing.T) {
+		store := newFakeConsumerStore()
+		store.corr["ses-6"] = &CorrelatedMessage{MessageID: "msg_6", UserID: "u_6", AgentID: "bot@x.com"}
+		fire, events := recordingFirer()
+		c := NewConsumer(store, fire)
+		_ = c.Process(context.Background(), &Event{
+			Kind: KindReject, SESMessageID: "ses-6",
+			Recipients: []RecipientOutcome{{Address: "a@x.com", Status: StatusFailed, Detail: "Bad content"}},
+		})
+		if len(store.suppressed) != 0 {
+			t.Fatalf("SES Reject must not add suppressions: %v", store.suppressed)
+		}
+		for _, e := range *events {
+			if e.eventType == EventSuppressionAdded {
+				t.Fatal("SES Reject must not fire domain.suppression_added")
+			}
+		}
+	})
+
+	t.Run("duplicate reject notifications fire with an identical dedup key", func(t *testing.T) {
+		store := newFakeConsumerStore()
+		store.corr["ses-7"] = &CorrelatedMessage{MessageID: "msg_7", UserID: "u_7", AgentID: "bot@x.com"}
+		fire, events := recordingFirer()
+		c := NewConsumer(store, fire)
+		ev := &Event{
+			Kind: KindReject, SESMessageID: "ses-7",
+			Recipients: []RecipientOutcome{{Address: "a@x.com", Status: StatusFailed, Detail: "Bad content"}},
+		}
+		for i := 0; i < 2; i++ { // SNS is at-least-once — the same notification can arrive twice
+			if err := c.Process(context.Background(), ev); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if len(*events) != 2 {
+			t.Fatalf("events=%v", *events)
+		}
+		if (*events)[0].dedupKey != (*events)[1].dedupKey {
+			t.Fatalf("dedup keys differ across redelivery: %q vs %q — the outbox could not collapse them",
+				(*events)[0].dedupKey, (*events)[1].dedupKey)
+		}
+	})
+
+	t.Run("reject with no reason falls back to a stable non-empty reason", func(t *testing.T) {
+		store := newFakeConsumerStore()
+		store.corr["ses-8"] = &CorrelatedMessage{MessageID: "msg_8", UserID: "u_8", AgentID: "bot@x.com", To: nil}
+		fire, events := recordingFirer()
+		c := NewConsumer(store, fire)
+		_ = c.Process(context.Background(), &Event{
+			Kind: KindReject, SESMessageID: "ses-8",
+			Recipients: []RecipientOutcome{{Address: "a@x.com", Status: StatusFailed}},
+		})
+		data := (*events)[0].data.(eventpayload.EmailFailedData)
+		if data.Reason == "" {
+			t.Fatal("email.failed requires a non-empty reason; an SES Reject without reject.reason must use the fallback")
+		}
+		if data.To == nil {
+			t.Fatal("to is nullable:false — a correlated row without a recipient list must still marshal []")
+		}
+	})
+
+	t.Run("reject for an uncorrelated message is a no-op ack", func(t *testing.T) {
+		store := newFakeConsumerStore()
+		fire, events := recordingFirer()
+		c := NewConsumer(store, fire)
+		err := c.Process(context.Background(), &Event{
+			Kind: KindReject, SESMessageID: "unknown-reject",
+			Recipients: []RecipientOutcome{{Address: "a@x.com", Status: StatusFailed, Detail: "Bad content"}},
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(store.outcomes) != 0 || len(*events) != 0 {
+			t.Fatal("nothing should be recorded or fired for an uncorrelated reject")
 		}
 	})
 }
@@ -205,7 +342,7 @@ func TestConsumerGoldenPayloads(t *testing.T) {
 	fireGolden := func(sesEvent *Event) *[]firedEvent {
 		t.Helper()
 		store := newFakeConsumerStore()
-		store.corr["ses-golden"] = [4]string{msgID, userID, agent, subject}
+		store.corr["ses-golden"] = &CorrelatedMessage{MessageID: msgID, UserID: userID, AgentID: agent, Subject: subject}
 		fire, events := recordingFirer()
 		c := NewConsumer(store, fire)
 		if err := c.Process(context.Background(), sesEvent); err != nil {
@@ -254,7 +391,7 @@ func TestConsumerGoldenPayloads(t *testing.T) {
 	fireMinimal := func(sesEvent *Event) *[]firedEvent {
 		t.Helper()
 		store := newFakeConsumerStore()
-		store.corr["ses-golden-min"] = [4]string{msgID, userID, agent, ""} // no subject
+		store.corr["ses-golden-min"] = &CorrelatedMessage{MessageID: msgID, UserID: userID, AgentID: agent} // no subject
 		fire, events := recordingFirer()
 		c := NewConsumer(store, fire)
 		if err := c.Process(context.Background(), sesEvent); err != nil {
@@ -286,6 +423,68 @@ func TestConsumerGoldenPayloads(t *testing.T) {
 			Recipients: []RecipientOutcome{{Address: "carol@customer.example.com", Status: StatusComplained}},
 		})
 		goldenassert.Data(t, fixture+"email.complained.min.json", (*events)[0].data)
+	})
+
+	// email.failed via SES Reject must byte-match the SAME committed fixtures
+	// the async send worker's emission is locked to (internal/eventpayload's
+	// golden_test builds them from eventpayload.EmailFailedData directly) —
+	// there is exactly one canonical email.failed shape, whichever path emits it.
+	t.Run("email.failed via SES Reject", func(t *testing.T) {
+		store := newFakeConsumerStore()
+		store.corr["ses-golden-reject"] = &CorrelatedMessage{
+			MessageID:      "msg_01h2xcejqtf2nbrexx3vqjhp43",
+			UserID:         userID,
+			AgentID:        agent,
+			Subject:        subject,
+			ConversationID: "conv_9f8e7d6c",
+			Method:         "smtp",
+			MessageType:    "send",
+			From:           agent,
+			To:             []string{"alice@customer.example.com"},
+			CC:             []string{"ops@customer.example.com"},
+			BCC:            []string{"audit@agents.example.com"},
+		}
+		fire, events := recordingFirer()
+		c := NewConsumer(store, fire)
+		if err := c.Process(context.Background(), &Event{
+			Kind: KindReject, SESMessageID: "ses-golden-reject",
+			Recipients: []RecipientOutcome{{
+				Address: "alice@customer.example.com", Status: StatusFailed,
+				Detail: "550 5.1.1 user unknown",
+			}},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if len(*events) != 1 {
+			t.Fatalf("expected exactly one email.failed, got %v", *events)
+		}
+		goldenassert.Data(t, fixture+"email.failed.json", (*events)[0].data)
+	})
+
+	t.Run("email.failed via SES Reject minimal", func(t *testing.T) {
+		store := newFakeConsumerStore()
+		store.corr["ses-golden-reject-min"] = &CorrelatedMessage{
+			MessageID:   "msg_01h2xcejqtf2nbrexx3vqjhp43",
+			UserID:      userID,
+			AgentID:     agent,
+			Subject:     subject,
+			Method:      "smtp",
+			MessageType: "send",
+			From:        agent,
+			To:          []string{"alice@customer.example.com"},
+		}
+		fire, events := recordingFirer()
+		c := NewConsumer(store, fire)
+		if err := c.Process(context.Background(), &Event{
+			Kind: KindReject, SESMessageID: "ses-golden-reject-min",
+			Recipients: []RecipientOutcome{{
+				Address: "alice@customer.example.com", Status: StatusFailed,
+				Detail: "550 5.1.1 user unknown",
+			}},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		goldenassert.Data(t, fixture+"email.failed.min.json", (*events)[0].data)
 	})
 }
 

--- a/internal/delivery/event_catalog_test.go
+++ b/internal/delivery/event_catalog_test.go
@@ -18,6 +18,7 @@ func TestDeliveryEventConstantsInCatalog(t *testing.T) {
 		delivery.EventEmailDelivered,
 		delivery.EventEmailBounced,
 		delivery.EventEmailComplained,
+		delivery.EventEmailFailed,
 		delivery.EventSuppressionAdded,
 	} {
 		if !webhookpub.IsValidEventType(et) {

--- a/internal/delivery/integration_test.go
+++ b/internal/delivery/integration_test.go
@@ -211,12 +211,12 @@ func TestDeliveryPipeline_RejectFailsMessageOnceWithoutSuppression(t *testing.T)
 	}
 
 	type fired struct {
-		typ, dedup string
-		data       any
+		typ, dedup, messageID, conversationID string
+		data                                  any
 	}
 	var events []fired
-	consumer := delivery.NewConsumer(store, func(_ context.Context, _, _, eventType string, data any, dedupKey string) {
-		events = append(events, fired{eventType, dedupKey, data})
+	consumer := delivery.NewConsumer(store, func(_ context.Context, e delivery.FiredEvent) {
+		events = append(events, fired{e.Type, e.DedupKey, e.MessageID, e.ConversationID, e.Data})
 	})
 
 	rejectEv := &delivery.Event{
@@ -247,6 +247,10 @@ func TestDeliveryPipeline_RejectFailsMessageOnceWithoutSuppression(t *testing.T)
 	// Exactly ONE message-level email.failed — not one per recipient.
 	if len(events) != 1 || events[0].typ != "email.failed" {
 		t.Fatalf("events=%+v, want exactly one email.failed", events)
+	}
+	// Envelope carries the message routing key (findability via ?message_id=).
+	if events[0].messageID != msgID {
+		t.Fatalf("email.failed envelope messageID=%q, want %q", events[0].messageID, msgID)
 	}
 	data, ok := events[0].data.(eventpayload.EmailFailedData)
 	if !ok {

--- a/internal/delivery/integration_test.go
+++ b/internal/delivery/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/tokencanopy/e2a/internal/delivery"
+	"github.com/tokencanopy/e2a/internal/eventpayload"
 	"github.com/tokencanopy/e2a/internal/identity"
 	"github.com/tokencanopy/e2a/internal/testutil"
 )
@@ -162,14 +163,23 @@ func TestCorrelationMatchesBracketedSESID(t *testing.T) {
 	store := identity.NewStore(pool)
 
 	// Store the realistic bracketed+suffixed shape; correlate with the bare id.
-	_, msgID, agentEmail := seedOutbound(t, store, "corr", "<010f0193abc-000000@us-east-2.amazonses.com>", []string{"a@x.com"})
+	userID, msgID, agentEmail := seedOutbound(t, store, "corr", "<010f0193abc-000000@us-east-2.amazonses.com>", []string{"a@x.com"})
 
-	mID, _, _, _, found, err := store.CorrelateBySESMessageID(ctx, "010f0193abc-000000")
+	m, found, err := store.CorrelateBySESMessageID(ctx, "010f0193abc-000000")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !found || mID != msgID {
-		t.Fatalf("bare-id correlation against bracketed stored id failed: found=%v id=%q want %q", found, mID, msgID)
+	if !found || m.MessageID != msgID {
+		t.Fatalf("bare-id correlation against bracketed stored id failed: found=%v m=%+v want id %q", found, m, msgID)
+	}
+	// The correlation result carries the message fields the canonical event
+	// payloads need — locked here against the seeded row.
+	if m.UserID != userID || m.AgentID != agentEmail || m.Subject != "Subj" ||
+		m.From != agentEmail || m.Method != "smtp" || m.MessageType != "send" {
+		t.Fatalf("correlated fields wrong: %+v", m)
+	}
+	if len(m.To) != 1 || m.To[0] != "a@x.com" || len(m.CC) != 0 || len(m.BCC) != 0 {
+		t.Fatalf("correlated recipient lists wrong: %+v", m)
 	}
 
 	// And the full pipeline must transition delivery_status via the bare id.
@@ -181,6 +191,95 @@ func TestCorrelationMatchesBracketedSESID(t *testing.T) {
 	}
 	if got := deliveryStatus(t, store, msgID, agentEmail); got != "delivered" {
 		t.Fatalf("delivery_status=%q, want delivered (bare-id correlation)", got)
+	}
+}
+
+// TestDeliveryPipeline_RejectFailsMessageOnceWithoutSuppression drives the SES
+// Reject path end-to-end against the real store: a correlated Reject must (1)
+// transition the sent rollup to failed, (2) fire exactly ONE message-level
+// email.failed with the canonical correlated payload, (3) never suppress, and
+// (4) stay idempotent under duplicate SNS delivery (same dedup key, monotonic
+// no-op status writes).
+func TestDeliveryPipeline_RejectFailsMessageOnceWithoutSuppression(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	store := identity.NewStore(pool)
+
+	userID, msgID, agentEmail := seedOutbound(t, store, "rej", "ses-reject-1", []string{"a@x.com", "b@x.com"})
+	if got := deliveryStatus(t, store, msgID, agentEmail); got != "sent" {
+		t.Fatalf("initial delivery_status=%q, want sent", got)
+	}
+
+	type fired struct {
+		typ, dedup string
+		data       any
+	}
+	var events []fired
+	consumer := delivery.NewConsumer(store, func(_ context.Context, _, _, eventType string, data any, dedupKey string) {
+		events = append(events, fired{eventType, dedupKey, data})
+	})
+
+	rejectEv := &delivery.Event{
+		Kind: delivery.KindReject, SESMessageID: "ses-reject-1",
+		Recipients: []delivery.RecipientOutcome{
+			{Address: "a@x.com", Status: delivery.StatusFailed, Detail: "Bad content"},
+			{Address: "b@x.com", Status: delivery.StatusFailed, Detail: "Bad content"},
+		},
+	}
+	if err := consumer.Process(ctx, rejectEv); err != nil {
+		t.Fatal(err)
+	}
+
+	// sent → failed on the message rollup, and both recipient rows failed.
+	if got := deliveryStatus(t, store, msgID, agentEmail); got != "failed" {
+		t.Fatalf("delivery_status=%q, want failed after SES Reject", got)
+	}
+	var failedRows int
+	if err := pool.QueryRow(ctx,
+		"SELECT count(*) FROM message_recipients WHERE message_id=$1 AND status='failed'", msgID,
+	).Scan(&failedRows); err != nil {
+		t.Fatal(err)
+	}
+	if failedRows != 2 {
+		t.Fatalf("failed recipient rows=%d, want 2", failedRows)
+	}
+
+	// Exactly ONE message-level email.failed — not one per recipient.
+	if len(events) != 1 || events[0].typ != "email.failed" {
+		t.Fatalf("events=%+v, want exactly one email.failed", events)
+	}
+	data, ok := events[0].data.(eventpayload.EmailFailedData)
+	if !ok {
+		t.Fatalf("data is not the canonical typed payload: %T", events[0].data)
+	}
+	if data.MessageID != msgID || data.AgentEmail != agentEmail || data.Direction != "outbound" ||
+		data.From != agentEmail || data.Subject != "Subj" || data.Method != "smtp" ||
+		data.MessageType != "send" || data.Reason != "Bad content" {
+		t.Fatalf("payload=%+v", data)
+	}
+	if len(data.To) != 2 || data.To[0] != "a@x.com" || data.To[1] != "b@x.com" {
+		t.Fatalf("payload to=%v, want both recipients from the correlated row", data.To)
+	}
+
+	// A Reject must never suppress the recipient addresses.
+	supp, err := store.SuppressedAddresses(ctx, userID, []string{"a@x.com", "b@x.com"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(supp) != 0 {
+		t.Fatalf("SES Reject must not suppress, got %v", supp)
+	}
+
+	// Duplicate SNS delivery: status stays failed, refire carries the SAME
+	// dedup key (the outbox collapses it via the deterministic event id).
+	if err := consumer.Process(ctx, rejectEv); err != nil {
+		t.Fatal(err)
+	}
+	if got := deliveryStatus(t, store, msgID, agentEmail); got != "failed" {
+		t.Fatalf("delivery_status=%q after duplicate, want failed", got)
+	}
+	if len(events) != 2 || events[1].typ != "email.failed" || events[1].dedup != events[0].dedup {
+		t.Fatalf("duplicate delivery must refire with an identical dedup key: %+v", events)
 	}
 }
 

--- a/internal/delivery/ses.go
+++ b/internal/delivery/ses.go
@@ -76,6 +76,9 @@ type sesNotification struct {
 			DiagnosticCode string `json:"diagnosticCode"`
 		} `json:"delayedRecipients"`
 	} `json:"deliveryDelay"`
+	Reject *struct {
+		Reason string `json:"reason"` // e.g. "Bad content"
+	} `json:"reject"`
 }
 
 // ParseSESNotification parses the SES event JSON (the decoded SNS Message
@@ -144,9 +147,19 @@ func ParseSESNotification(messageBody []byte) (*Event, error) {
 	case "Send":
 		ev.Kind = KindSend
 	case "Reject":
+		// SES rejected the ALREADY-ACCEPTED message itself (e.g. a virus was
+		// detected in the content) — a message-level verdict, so every envelope
+		// recipient terminally fails; reject.reason carries the classification
+		// ("Bad content"). NEVER suppresses: a Reject is about this message's
+		// content, not the recipient addresses (decision 9 suppresses only on
+		// hard bounce or complaint).
 		ev.Kind = KindReject
+		var reason string
+		if n.Reject != nil {
+			reason = n.Reject.Reason
+		}
 		for _, a := range n.Mail.Destination {
-			ev.Recipients = append(ev.Recipients, RecipientOutcome{Address: norm(a), Status: StatusFailed})
+			ev.Recipients = append(ev.Recipients, RecipientOutcome{Address: norm(a), Status: StatusFailed, Detail: reason})
 		}
 	default:
 		ev.Kind = KindOther

--- a/internal/delivery/ses_test.go
+++ b/internal/delivery/ses_test.go
@@ -72,6 +72,50 @@ func TestParseSESNotification(t *testing.T) {
 		}
 	})
 
+	t.Run("reject → failed for every destination, reason carried, never suppresses", func(t *testing.T) {
+		ev, err := ParseSESNotification([]byte(`{
+			"eventType":"Reject",
+			"mail":{"messageId":"ses-8","destination":["G@x.com","h@y.com"]},
+			"reject":{"reason":"Bad content"}
+		}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ev.Kind != KindReject || len(ev.Recipients) != 2 {
+			t.Fatalf("ev=%+v", ev)
+		}
+		for _, r := range ev.Recipients {
+			if r.Status != StatusFailed {
+				t.Fatalf("status=%s, want failed", r.Status)
+			}
+			if r.Suppress {
+				t.Fatal("SES Reject is about the message content, not the address — it must never auto-suppress")
+			}
+			if r.Detail != "Bad content" {
+				t.Fatalf("detail=%q, want the reject.reason", r.Detail)
+			}
+		}
+		if ev.Recipients[0].Address != "g@x.com" || ev.Recipients[1].Address != "h@y.com" {
+			t.Fatalf("addresses must be normalized: %+v", ev.Recipients)
+		}
+	})
+
+	t.Run("reject without a reject block still fails recipients (empty detail)", func(t *testing.T) {
+		ev, err := ParseSESNotification([]byte(`{
+			"eventType":"Reject",
+			"mail":{"messageId":"ses-9","destination":["i@x.com"]}
+		}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ev.Kind != KindReject || len(ev.Recipients) != 1 {
+			t.Fatalf("ev=%+v", ev)
+		}
+		if r := ev.Recipients[0]; r.Status != StatusFailed || r.Detail != "" || r.Suppress {
+			t.Fatalf("recipient=%+v", r)
+		}
+	})
+
 	t.Run("legacy notificationType key", func(t *testing.T) {
 		ev, err := ParseSESNotification([]byte(`{
 			"notificationType":"Delivery",

--- a/internal/identity/delivery_store.go
+++ b/internal/identity/delivery_store.go
@@ -25,8 +25,9 @@ const OutboundSendClaimStaleWindow = 10 * time.Minute
 // SES-assigned provider_message_id captured at send time. found=false when the
 // id is unknown (expired message, or an event for a different deployment).
 //
-// subject rides along for the delivered/bounced/complained event payloads —
-// it's a column on the very row this query already reads, so including it
+// The message fields (subject, and the envelope/threading fields the
+// message-level email.failed payload needs on an SES Reject) ride along —
+// they're columns on the very row this query already reads, so including them
 // costs no extra query (contract freeze PR-2: `subject` on delivery events).
 //
 // The SNS notification carries the BARE SES id (e.g. 010f0193…-000000), but the
@@ -34,12 +35,16 @@ const OutboundSendClaimStaleWindow = 10 * time.Minute
 // suffix (parseMessageIDFromResponse) — same discrepancy LookupConversationID
 // works around. Match all three stored shapes against the bare id: exact,
 // <id>, and <id@…>. SES ids are [A-Za-z0-9-] so they carry no LIKE metacharacters.
-func (s *Store) CorrelateBySESMessageID(ctx context.Context, sesMessageID string) (messageID, userID, agentID, subject string, found bool, err error) {
+func (s *Store) CorrelateBySESMessageID(ctx context.Context, sesMessageID string) (*delivery.CorrelatedMessage, bool, error) {
 	if sesMessageID == "" {
-		return "", "", "", "", false, nil
+		return nil, false, nil
 	}
-	err = s.pool.QueryRow(ctx,
-		`SELECT m.id, a.user_id, m.agent_id, COALESCE(m.subject, '')
+	m := &delivery.CorrelatedMessage{}
+	err := s.pool.QueryRow(ctx,
+		`SELECT m.id, a.user_id, m.agent_id, COALESCE(m.subject, ''),
+		        COALESCE(m.conversation_id, ''), COALESCE(m.method, ''),
+		        COALESCE(m.message_type, ''), COALESCE(m.sender, ''),
+		        m.to_recipients, m.cc, m.bcc
 		   FROM messages m
 		   JOIN agent_identities a ON a.id = m.agent_id
 		  WHERE m.direction = 'outbound'
@@ -48,14 +53,16 @@ func (s *Store) CorrelateBySESMessageID(ctx context.Context, sesMessageID string
 		       OR m.provider_message_id LIKE '<' || $1 || '@%' )
 		  LIMIT 1`,
 		sesMessageID,
-	).Scan(&messageID, &userID, &agentID, &subject)
+	).Scan(&m.MessageID, &m.UserID, &m.AgentID, &m.Subject,
+		&m.ConversationID, &m.Method, &m.MessageType, &m.From,
+		&m.To, &m.CC, &m.BCC)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return "", "", "", "", false, nil
+		return nil, false, nil
 	}
 	if err != nil {
-		return "", "", "", "", false, err
+		return nil, false, err
 	}
-	return messageID, userID, agentID, subject, true, nil
+	return m, true, nil
 }
 
 // RecordDeliveryOutcome upserts one recipient's status monotonically (by the


### PR DESCRIPTION
## Root cause

`internal/delivery/ses.go` parses SES `Reject` into `RecipientOutcome{Status: StatusFailed}` and the consumer durably persists the `sent → failed` transition — but `pushEventFor` mapped only delivered/bounced/complained. A post-acceptance Reject therefore flipped the message to `failed` **silently**: event-driven consumers held the earlier `email.sent` result forever unless they polled.

## Fix

A correlated SES Reject now also publishes the canonical stable **`email.failed`** event, reusing `eventpayload.EmailFailedData` unchanged (the exact shape the async send worker emits — no second failed-event shape, **no schema change**, so no OpenAPI/SDK regeneration; `TestSpecGoldenNoDrift` passes untouched).

### Cardinality + dedup design
- **One message-level event per rejected message**, never per recipient: a Reject is SES refusing the whole accepted message (content scan), and `EmailFailedData` is message-level — its `to`/`cc`/`bcc` lists (from the correlated row) preserve the recipient information. Per-recipient `failed` outcomes are still recorded in `message_recipients` as before.
- **Deterministic event id shared with the worker path**: the dedup key is `message_id|email.failed`, which hashes (via `webhookpub.DeterministicEventID`) to the *identical* id the send worker uses. Duplicate SNS deliveries AND any cross-path double emission collapse in the durable outbox via `ON CONFLICT (id) DO NOTHING` — subscribers can never receive two conflicting terminal events for one message. Pinned by `TestRejectEmailFailedIDCollapsesAcrossPaths`.
- `ParseSESNotification` now captures `reject.reason` (e.g. `"Bad content"`) as the recipient detail / event `reason`, with a stable fallback so the required field is never empty. `reason_code`/`retryable` stay unset, matching the worker emission and the committed golden fixtures.
- `CorrelateBySESMessageID` widens to a `CorrelatedMessage` struct — same single SELECT/join, now also carrying `conversation_id`, `method`, `message_type`, `from`, `to/cc/bcc` so the canonical payload is fully populated.
- **Reject never suppresses** (no explicit rule requires it — suppression stays bounce/complaint-only). Bounce, complaint, delivery, and delivery-delay behavior untouched. Uncorrelated/unknown SES ids remain acked no-ops.

### Docs
`docs/events.md`: the `email.failed` guarantee row now names both emission paths honestly — **at-least-once** from the send path (same-tx outbox), **best-effort** via delivery feedback (fire-after-the-fact `OutboxPublisher`) — plus a note on the message-level, at-most-once-per-message id.

## Tests (TDD; all on a dedicated `e2a_test_sesreject` DB to avoid shared-DB contention)
- Reject parsing (multi-recipient, reason, no-suppress, missing `reject` block) — `ses_test.go`
- Consumer: exactly one message-level `email.failed` for a 3-recipient Reject; duplicate-notification dedup key stability; no suppression; fallback reason; nil→`[]` for `to`; uncorrelated no-op — `consumer_test.go`
- Golden fixtures: the Reject-path payload byte-matches the committed `email.failed.json` / `email.failed.min.json` (same files the SDKs assert against)
- Cross-path deterministic-id equality with the worker path — `consumer_crosspath_test.go`
- DB integration: `sent→failed` rollup, both recipient rows failed, exactly one event with correlated payload, no suppression rows, idempotent duplicate processing; correlation field widening under the bracketed-SES-id shapes — `integration_test.go`

`go test -tags integration -p 1 ./internal/delivery/` ✅ · `./internal/identity/ ./internal/webhookpub/ ./internal/eventpayload/...` ✅ · `TestSpecGolden*` ✅ · `go vet`, `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)