### PR TITLE
feat(api): Idempotency-Key support on createWebhook

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -6205,7 +6205,15 @@ paths:
       tags:
         - webhooks
     post:
+      description: Register a webhook subscriber; the one-time signing secret is returned only on this response. Honors Idempotency-Key so a retried create replays the same webhook (same id + secret) instead of registering a second subscription; omit the key to intentionally create distinct subscriptions, including several to the same URL.
       operationId: createWebhook
+      parameters:
+        - description: "Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request's response — the SAME webhook id and one-time signing secret — instead of registering a second active subscription. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). A keyed create commits the webhook and its replay response atomically, so an accepted create always replays; dedup is best-effort only under idempotency-store degradation before that commit."
+          in: header
+          name: Idempotency-Key
+          schema:
+            description: "Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request's response — the SAME webhook id and one-time signing secret — instead of registering a second active subscription. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). A keyed create commits the webhook and its replay response atomically, so an accepted create always replays; dedup is best-effort only under idempotency-store degradation before that commit."
+            type: string
       requestBody:
         content:
           application/json:
@@ -6222,12 +6230,30 @@ paths:
           headers:
             X-Request-Id:
               $ref: "#/components/headers/XRequestID"
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: "Conflict — code idempotency_in_flight: a request with this Idempotency-Key is still executing. Retry-able: wait for the first request to finish, then retry with the SAME key and byte-identical body — the retry replays the first request's response instead of re-executing the side effect."
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/XRequestID"
+        "422":
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorEnvelope"
+          description: "Unprocessable — branch on error.code. idempotency_key_reuse: this Idempotency-Key was already used with a DIFFERENT request body (the dedup hash covers the route + the raw body bytes) — do NOT retry as-is; a legitimate retry must resend the byte-identical body, and a genuinely new request needs a fresh key. invalid_request: a semantic validation failure in the request body."
+          headers:
+            X-Request-Id:
+              $ref: "#/components/headers/XRequestID"
         default:
           content:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorEnvelope"
-          description: Error
+          description: Error — the standard envelope; branch on error.code.
           headers:
             X-Request-Id:
               $ref: "#/components/headers/XRequestID"

--- a/internal/apiserver/apiserver.go
+++ b/internal/apiserver/apiserver.go
@@ -182,7 +182,7 @@ func BuildDeps(p Params) httpapi.Deps {
 			return agent.InsertReplayDelivery(ctx, p.Pool, eventID, webhookID, eventType, messageID, envelope)
 		},
 
-		CreateWebhook:     p.Store.CreateWebhook,
+		CreateWebhook:     p.Store.CreateWebhookIdem,
 		ListWebhooks:      p.Store.ListWebhooksByUser,
 		GetWebhook:        p.Store.GetWebhookByID,
 		UpdateWebhook:     p.Store.UpdateWebhook,

--- a/internal/httpapi/apikeys_idem_test.go
+++ b/internal/httpapi/apikeys_idem_test.go
@@ -22,14 +22,19 @@ import (
 // honors the request body-hash: a second Claim of the same key with a DIFFERENT
 // body-hash is a Mismatch (→422), matching the real Store. This lets the tests
 // exercise both the retry-replay path and the reuse-with-different-body path,
-// and proves the handler threads RawBody through for the body-hash.
+// and proves the handler threads RawBody through for the body-hash. Like the
+// real Store it scopes rows by (user_id, key) — two accounts may reuse the same
+// key — and Complete only lands on an in-flight claim (the real Store's
+// `WHERE status = 'in_progress'` guard), so a post-hoc Complete after an
+// in-transaction CompleteTx is a harmless no-op instead of corrupting the
+// cached row.
 type bodyAwareIdem struct {
 	mu       sync.Mutex
 	cached   map[string]struct {
 		hash string
 		resp idempotency.CachedResponse
 	}
-	inflight map[string]string // key -> body hash
+	inflight map[string]string // (uid|key) -> body hash
 }
 
 func newBodyAwareIdem() *bodyAwareIdem {
@@ -42,33 +47,39 @@ func newBodyAwareIdem() *bodyAwareIdem {
 	}
 }
 
-func (m *bodyAwareIdem) Claim(_ context.Context, _, key, _, bodyHash string) (idempotency.ClaimResult, error) {
+func (m *bodyAwareIdem) Claim(_ context.Context, uid, key, _, bodyHash string) (idempotency.ClaimResult, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if c, ok := m.cached[key]; ok {
+	k := uid + "|" + key
+	if c, ok := m.cached[k]; ok {
 		if c.hash != bodyHash {
 			return idempotency.ClaimResult{Outcome: idempotency.OutcomeMismatch}, nil
 		}
 		return idempotency.ClaimResult{Outcome: idempotency.OutcomeReplay, Cached: c.resp}, nil
 	}
-	if h, ok := m.inflight[key]; ok {
+	if h, ok := m.inflight[k]; ok {
 		if h != bodyHash {
 			return idempotency.ClaimResult{Outcome: idempotency.OutcomeMismatch}, nil
 		}
 		return idempotency.ClaimResult{Outcome: idempotency.OutcomeInFlight}, nil
 	}
-	m.inflight[key] = bodyHash
+	m.inflight[k] = bodyHash
 	return idempotency.ClaimResult{Outcome: idempotency.OutcomeAcquired}, nil
 }
 
-func (m *bodyAwareIdem) Complete(_ context.Context, _, key string, resp idempotency.CachedResponse) error {
+func (m *bodyAwareIdem) Complete(_ context.Context, uid, key string, resp idempotency.CachedResponse) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.cached[key] = struct {
+	k := uid + "|" + key
+	h, ok := m.inflight[k]
+	if !ok {
+		return nil // already completed (e.g. via CompleteTx) — mirrors the real in_progress guard
+	}
+	m.cached[k] = struct {
 		hash string
 		resp idempotency.CachedResponse
-	}{hash: m.inflight[key], resp: resp}
-	delete(m.inflight, key)
+	}{hash: h, resp: resp}
+	delete(m.inflight, k)
 	return nil
 }
 
@@ -76,10 +87,10 @@ func (m *bodyAwareIdem) CompleteTx(_ context.Context, _ pgx.Tx, uid, key string,
 	return m.Complete(context.Background(), uid, key, resp)
 }
 
-func (m *bodyAwareIdem) Release(_ context.Context, _, key string) error {
+func (m *bodyAwareIdem) Release(_ context.Context, uid, key string) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	delete(m.inflight, key)
+	delete(m.inflight, uid+"|"+key)
 	return nil
 }
 

--- a/internal/httpapi/httpapi.go
+++ b/internal/httpapi/httpapi.go
@@ -258,7 +258,12 @@ type Deps struct {
 	EventsEnabled bool
 
 	// webhooks
-	CreateWebhook func(ctx context.Context, userID, url, description string, events []string, filters identity.WebhookFilters) (*identity.Webhook, error)
+	// CreateWebhook mirrors identity.Store.CreateWebhookIdem: when the request
+	// carries an Idempotency-Key the handler passes a completer that the store
+	// runs INSIDE the insert transaction, committing the webhook row and the
+	// cached replay response atomically (same-tx pattern as the send/approve
+	// paths). idemCompleteTx is nil for unkeyed creates.
+	CreateWebhook func(ctx context.Context, userID, url, description string, events []string, filters identity.WebhookFilters, idemCompleteTx identity.WebhookIdemCompleter) (*identity.Webhook, error)
 	// ListWebhooks is keyset-paginated on (created_at, id): the handler passes
 	// limit+1 to detect a further page (limit<=0 = all) and the after-key from the
 	// previous page's last row (zero afterCreatedAt = first page).

--- a/internal/httpapi/operations_test.go
+++ b/internal/httpapi/operations_test.go
@@ -438,11 +438,19 @@ func testServer(t *testing.T, opts ...func(*Deps)) *httptest.Server {
 		InsertReplayDelivery: func(ctx context.Context, eventID, webhookID, eventType string, messageID *string, envelope []byte) (string, error) {
 			return "whd_" + webhookID, nil
 		},
-		CreateWebhook: func(ctx context.Context, userID, url, description string, events []string, filters identity.WebhookFilters) (*identity.Webhook, error) {
+		CreateWebhook: func(ctx context.Context, userID, url, description string, events []string, filters identity.WebhookFilters, idemCompleteTx identity.WebhookIdemCompleter) (*identity.Webhook, error) {
 			if strings.Contains(url, "capped") {
 				return nil, identity.ErrWebhookCapReached
 			}
-			return &identity.Webhook{ID: "wh_1", URL: url, Description: description, Events: events, Filters: filters, SigningSecret: "whsec_xyz", Enabled: true, CreatedAt: time.Unix(1700000000, 0).UTC()}, nil
+			wh := &identity.Webhook{ID: "wh_1", URL: url, Description: description, Events: events, Filters: filters, SigningSecret: "whsec_xyz", Enabled: true, CreatedAt: time.Unix(1700000000, 0).UTC()}
+			// Mirror identity.CreateWebhookIdem: a keyed create completes its
+			// idempotency row atomically with the insert.
+			if idemCompleteTx != nil {
+				if err := idemCompleteTx(ctx, nil, wh); err != nil {
+					return nil, err
+				}
+			}
+			return wh, nil
 		},
 		ListWebhooks: func(ctx context.Context, userID string, limit int, afterCreatedAt time.Time, afterID string) ([]identity.Webhook, error) {
 			return []identity.Webhook{{ID: "wh_1", URL: "https://x.com/h", Events: []string{"email.received"}, Enabled: true, SigningSecret: "whsec_should_be_hidden", CreatedAt: time.Unix(1700000000, 0).UTC()}}, nil

--- a/internal/httpapi/spec_review_test.go
+++ b/internal/httpapi/spec_review_test.go
@@ -80,7 +80,7 @@ func TestSpecIdempotencyResponsesDeclared(t *testing.T) {
 	doc := renderSpec(t)
 	for _, operationID := range []string{
 		"sendMessage", "replyToMessage", "forwardMessage", "approveReview",
-		"rotateWebhookSecret", "createApiKey",
+		"rotateWebhookSecret", "createApiKey", "createWebhook",
 	} {
 		resp := operationResponses(t, doc, operationID)
 		for _, code := range []string{"409", "422"} {
@@ -90,6 +90,27 @@ func TestSpecIdempotencyResponsesDeclared(t *testing.T) {
 			}
 		}
 	}
+}
+
+// createWebhook mints a one-time signing secret, so a lost-response retry must
+// be able to replay the first response instead of creating a second active
+// subscription with a second secret: the operation must declare the optional
+// Idempotency-Key request header (same semantics as the other side-effecting
+// creates).
+func TestSpecCreateWebhookIdempotencyKeyDeclared(t *testing.T) {
+	doc := renderSpec(t)
+	op := operationByID(t, doc, "createWebhook")
+	params, _ := op["parameters"].([]any)
+	for _, raw := range params {
+		param, _ := raw.(map[string]any)
+		if param["in"] == "header" && param["name"] == "Idempotency-Key" {
+			if req, _ := param["required"].(bool); req {
+				t.Error("createWebhook Idempotency-Key must be optional")
+			}
+			return
+		}
+	}
+	t.Errorf("createWebhook must declare the Idempotency-Key header parameter; params=%v", params)
 }
 
 // schemaProps returns the properties map of a named component schema.

--- a/internal/httpapi/webhooks.go
+++ b/internal/httpapi/webhooks.go
@@ -12,7 +12,10 @@ import (
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
+	"github.com/jackc/pgx/v5"
+
 	"github.com/tokencanopy/e2a/internal/agent"
+	"github.com/tokencanopy/e2a/internal/idempotency"
 	"github.com/tokencanopy/e2a/internal/identity"
 	"github.com/tokencanopy/e2a/internal/webhookpub"
 )
@@ -202,7 +205,18 @@ type CreateWebhookRequest struct {
 	Filters     *WebhookFiltersRequest `json:"filters,omitempty"`
 	Description string                 `json:"description,omitempty"`
 }
-type createWebhookInput struct{ Body CreateWebhookRequest }
+
+// createWebhookInput carries an optional Idempotency-Key so a retried create
+// replays the first subscription (same id, same one-time signing secret)
+// instead of registering a SECOND active subscription with a second secret.
+// Intentional duplicates — including several subscriptions to the same URL —
+// remain expressible by omitting the key (idempotency is opt-in; there is
+// deliberately no unique(user_id, url) constraint).
+type createWebhookInput struct {
+	RawBody        []byte
+	IdempotencyKey string `header:"Idempotency-Key" doc:"Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request's response — the SAME webhook id and one-time signing secret — instead of registering a second active subscription. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). A keyed create commits the webhook and its replay response atomically, so an accepted create always replays; dedup is best-effort only under idempotency-store degradation before that commit."`
+	Body           CreateWebhookRequest
+}
 
 // WebhookIDParam is the path input for single-webhook read/update ops.
 type WebhookIDParam struct {
@@ -220,7 +234,13 @@ func (s *Server) registerWebhooks() {
 	huma.Register(s.API, huma.Operation{
 		OperationID: "createWebhook", Method: http.MethodPost, Path: "/v1/webhooks",
 		Summary: "Create a webhook", Tags: []string{"webhooks"},
-		Security: []map[string][]string{{"bearer": {}}}, DefaultStatus: http.StatusCreated,
+		Description: "Register a webhook subscriber; the one-time signing secret is returned only on this response. Honors Idempotency-Key so a retried create replays the same webhook (same id + secret) instead of registering a second subscription; omit the key to intentionally create distinct subscriptions, including several to the same URL.",
+		Security:    []map[string][]string{{"bearer": {}}}, DefaultStatus: http.StatusCreated,
+		Responses: map[string]*huma.Response{
+			"409":     s.idempotencyInFlightResponse(),
+			"422":     s.idempotencyReuseResponse(),
+			"default": s.errorEnvelopeResponse(),
+		},
 	}, s.handleCreateWebhook)
 
 	huma.Register(s.API, huma.Operation{
@@ -563,28 +583,69 @@ func (s *Server) handleCreateWebhook(ctx context.Context, in *createWebhookInput
 	if err != nil {
 		return nil, err
 	}
-	var filters WebhookFiltersView
-	if in.Body.Filters != nil {
-		filters = WebhookFiltersView(*in.Body.Filters)
-	}
-	if env := s.validateWebhookFields(ctx, user.ID, in.Body.URL, in.Body.Events, filters, in.Body.Description); env != nil {
-		return nil, env
-	}
-	wh, err := s.deps.CreateWebhook(ctx, user.ID, in.Body.URL, in.Body.Description, in.Body.Events, identity.WebhookFilters{
-		AgentIDs:        filters.AgentIDs,
-		ConversationIDs: filters.ConversationIDs,
-		Labels:          filters.Labels,
-	})
-	if err != nil {
-		if errors.Is(err, identity.ErrWebhookCapReached) {
-			return nil, NewError(http.StatusBadRequest, "webhook_limit_reached", err.Error())
+	// idemCompleteTx lets the store (identity.CreateWebhookIdem) commit this
+	// request's idempotency-key completion in the SAME transaction as the
+	// webhook insert — so a crash after that commit replays the first response
+	// (same webhook id + one-time secret) instead of re-creating; there is no
+	// post-insert window in which a webhook exists without a replayable
+	// response. It caches the EXACT wire body this handler returns, keeping the
+	// replay byte-faithful. The cached body carries the one-time signing secret
+	// — intended: a same-account byte-identical keyed retry re-reads the secret
+	// it already owns, and the row lives in the same TTL-swept idempotency
+	// store that already caches the createApiKey plaintext key. nil when the
+	// request has no Idempotency-Key or no store is wired; runIdempotent's
+	// post-hoc Complete then no-ops on the in_progress guard (or, unkeyed, the
+	// create runs unguarded — idempotency is opt-in). Mirrors deliver()'s
+	// AcceptIdemCompleter.
+	var idemCompleteTx identity.WebhookIdemCompleter
+	if in.IdempotencyKey != "" && s.deps.Idempotency != nil {
+		nsKey := idemUserNS + in.IdempotencyKey
+		uid := user.ID
+		idemCompleteTx = func(ctx context.Context, tx pgx.Tx, wh *identity.Webhook) error {
+			raw, mErr := json.Marshal(CreateWebhookResponse{WebhookView: webhookView(wh), SigningSecret: wh.SigningSecret})
+			if mErr != nil {
+				raw = []byte("{}")
+			}
+			return s.deps.Idempotency.CompleteTx(ctx, tx, uid, nsKey, idempotency.CachedResponse{
+				StatusCode: http.StatusCreated, ContentType: "application/json", Body: raw,
+			})
 		}
-		return nil, NewError(http.StatusInternalServerError, "internal_error", "failed to create webhook")
 	}
-	return &webhookCreateOutput{Body: CreateWebhookResponse{
-		WebhookView:   webhookView(wh),
-		SigningSecret: wh.SigningSecret,
-	}}, nil
+	// Validation runs INSIDE the claimed execution (like the send path): a
+	// keyed replay short-circuits before it — byte-faithful even if mutable
+	// state (agent-filter ownership, the webhook cap) has changed since the
+	// first attempt — and a validation/limit failure returns an error strictly
+	// before the insert, so runIdempotent releases the key for reuse instead
+	// of consuming it.
+	_, body, err := runIdempotent(s, ctx, user.ID, in.IdempotencyKey, "/v1/webhooks", in.RawBody,
+		func() (int, CreateWebhookResponse, error) {
+			var filters WebhookFiltersView
+			if in.Body.Filters != nil {
+				filters = WebhookFiltersView(*in.Body.Filters)
+			}
+			if env := s.validateWebhookFields(ctx, user.ID, in.Body.URL, in.Body.Events, filters, in.Body.Description); env != nil {
+				return 0, CreateWebhookResponse{}, env
+			}
+			wh, cerr := s.deps.CreateWebhook(ctx, user.ID, in.Body.URL, in.Body.Description, in.Body.Events, identity.WebhookFilters{
+				AgentIDs:        filters.AgentIDs,
+				ConversationIDs: filters.ConversationIDs,
+				Labels:          filters.Labels,
+			}, idemCompleteTx)
+			if cerr != nil {
+				if errors.Is(cerr, identity.ErrWebhookCapReached) {
+					return 0, CreateWebhookResponse{}, NewError(http.StatusBadRequest, "webhook_limit_reached", cerr.Error())
+				}
+				return 0, CreateWebhookResponse{}, NewError(http.StatusInternalServerError, "internal_error", "failed to create webhook")
+			}
+			return http.StatusCreated, CreateWebhookResponse{
+				WebhookView:   webhookView(wh),
+				SigningSecret: wh.SigningSecret,
+			}, nil
+		})
+	if err != nil {
+		return nil, err
+	}
+	return &webhookCreateOutput{Body: body}, nil
 }
 
 // listWebhooksInput carries the standard cursor/limit (PageParams).

--- a/internal/httpapi/webhooks_create_idem_test.go
+++ b/internal/httpapi/webhooks_create_idem_test.go
@@ -1,0 +1,291 @@
+package httpapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/tokencanopy/e2a/internal/identity"
+)
+
+// webhookCreateFake is the deps.CreateWebhook signature (kept as a named type
+// so the fakes below stay readable).
+type webhookCreateFake func(ctx context.Context, userID, url, description string, events []string, filters identity.WebhookFilters, idemCompleteTx identity.WebhookIdemCompleter) (*identity.Webhook, error)
+
+// webhookCreateIdemServer wires the body-aware idempotency store (the same
+// fake the createApiKey idempotency tests use — it honors the body hash AND
+// mirrors the real store's completed-row guard) plus a caller-supplied
+// CreateWebhook fake. Two bearer tokens map to two distinct accounts so the
+// cross-account key-scoping test is expressible.
+func webhookCreateIdemServer(t *testing.T, create webhookCreateFake) *httptest.Server {
+	t.Helper()
+	srv := httptest.NewServer(New(Deps{
+		Authenticator: func(r *http.Request) (*identity.User, error) {
+			switch r.Header.Get("Authorization") {
+			case "Bearer good":
+				return &identity.User{ID: "u_1", Email: "owner@acme.com"}, nil
+			case "Bearer other":
+				return &identity.User{ID: "u_2", Email: "other@beta.com"}, nil
+			}
+			return nil, errors.New("unauthorized")
+		},
+		Idempotency:   newBodyAwareIdem(),
+		CreateWebhook: create,
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// countingWebhookCreate is a production-faithful CreateWebhook fake: each call
+// mints a DISTINCT id + one-time signing secret (so a double-create is
+// observable) and — mirroring identity.Store.CreateWebhookIdem — invokes the
+// idempotency completer with the new webhook before returning, aborting the
+// create if the completer fails. URLs containing "capped" simulate the
+// per-user webhook limit.
+func countingWebhookCreate(creates *int) webhookCreateFake {
+	return func(ctx context.Context, userID, url, description string, events []string, filters identity.WebhookFilters, idemCompleteTx identity.WebhookIdemCompleter) (*identity.Webhook, error) {
+		if strings.Contains(url, "capped") {
+			return nil, identity.ErrWebhookCapReached
+		}
+		*creates++
+		wh := &identity.Webhook{
+			ID: fmt.Sprintf("wh_%d", *creates), UserID: userID, URL: url, Description: description,
+			Events: events, Filters: filters, SigningSecret: fmt.Sprintf("whsec_create_%d", *creates),
+			Enabled: true, CreatedAt: time.Unix(1700000000, 0).UTC(),
+		}
+		if idemCompleteTx != nil {
+			if err := idemCompleteTx(ctx, nil, wh); err != nil {
+				return nil, err
+			}
+		}
+		return wh, nil
+	}
+}
+
+func createWebhookCall(t *testing.T, url, bearer, idemKey, body string) (int, map[string]any) {
+	t.Helper()
+	req, _ := http.NewRequest("POST", url, bytes.NewReader([]byte(body)))
+	req.Header.Set("Authorization", "Bearer "+bearer)
+	req.Header.Set("Content-Type", "application/json")
+	if idemKey != "" {
+		req.Header.Set("Idempotency-Key", idemKey)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var m map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&m)
+	return resp.StatusCode, m
+}
+
+const whCreateBody = `{"url":"https://example.com/hook","events":["email.received"]}`
+
+// A retried createWebhook carrying the SAME Idempotency-Key must replay the
+// first response — the SAME webhook id, 201, and one-time signing secret —
+// and NOT create a second active subscription with a second secret.
+func TestCreateWebhook_IdempotentReplay(t *testing.T) {
+	var creates int
+	srv := webhookCreateIdemServer(t, countingWebhookCreate(&creates))
+	url := srv.URL + "/v1/webhooks"
+
+	code1, b1 := createWebhookCall(t, url, "good", "whk-1", whCreateBody)
+	code2, b2 := createWebhookCall(t, url, "good", "whk-1", whCreateBody) // network retry, byte-identical
+
+	if code1 != 201 || code2 != 201 {
+		t.Fatalf("want 201/201, got %d/%d (b1=%v b2=%v)", code1, code2, b1, b2)
+	}
+	if creates != 1 {
+		t.Fatalf("retry created a SECOND subscription: creates=%d, want 1", creates)
+	}
+	if b1["id"] != b2["id"] || b1["signing_secret"] != b2["signing_secret"] {
+		t.Fatalf("retry returned a different webhook: id %v vs %v, secret %v vs %v",
+			b1["id"], b2["id"], b1["signing_secret"], b2["signing_secret"])
+	}
+}
+
+// Same key + a DIFFERENT body is a caller bug, not a retry: 422, no replay,
+// no second create.
+func TestCreateWebhook_KeyReuseDifferentBody422(t *testing.T) {
+	var creates int
+	srv := webhookCreateIdemServer(t, countingWebhookCreate(&creates))
+	url := srv.URL + "/v1/webhooks"
+
+	code1, _ := createWebhookCall(t, url, "good", "whk-2", whCreateBody)
+	code2, b2 := createWebhookCall(t, url, "good", "whk-2", `{"url":"https://example.com/DIFFERENT","events":["email.received"]}`)
+
+	if code1 != 201 {
+		t.Fatalf("first create: want 201, got %d", code1)
+	}
+	if code2 != 422 || errCode(b2) != "idempotency_key_reuse" {
+		t.Fatalf("same key + different body: want 422 idempotency_key_reuse, got %d %v", code2, b2)
+	}
+	if creates != 1 {
+		t.Fatalf("key reuse must not create: creates=%d, want 1", creates)
+	}
+}
+
+// While the first keyed request is still executing, a concurrent duplicate is
+// a 409 idempotency_in_flight — never a second create.
+func TestCreateWebhook_InFlight409(t *testing.T) {
+	var creates int
+	inner := countingWebhookCreate(&creates)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	srv := webhookCreateIdemServer(t, func(ctx context.Context, userID, url, description string, events []string, filters identity.WebhookFilters, idemCompleteTx identity.WebhookIdemCompleter) (*identity.Webhook, error) {
+		once.Do(func() { close(entered) })
+		<-release
+		return inner(ctx, userID, url, description, events, filters, idemCompleteTx)
+	})
+	url := srv.URL + "/v1/webhooks"
+
+	first := make(chan int, 1)
+	go func() {
+		code, _ := createWebhookCall(t, url, "good", "whk-3", whCreateBody)
+		first <- code
+	}()
+	<-entered // first request holds the claim inside CreateWebhook
+
+	code2, b2 := createWebhookCall(t, url, "good", "whk-3", whCreateBody)
+	if code2 != 409 || errCode(b2) != "idempotency_in_flight" {
+		t.Fatalf("concurrent duplicate: want 409 idempotency_in_flight, got %d %v", code2, b2)
+	}
+
+	close(release)
+	if code1 := <-first; code1 != 201 {
+		t.Fatalf("original request: want 201, got %d", code1)
+	}
+	if creates != 1 {
+		t.Fatalf("in-flight collision must not create twice: creates=%d, want 1", creates)
+	}
+}
+
+// Idempotency keys are scoped per authenticated account: two accounts may use
+// the same key without colliding (each gets its own webhook).
+func TestCreateWebhook_DifferentAccountsSameKey(t *testing.T) {
+	var creates int
+	srv := webhookCreateIdemServer(t, countingWebhookCreate(&creates))
+	url := srv.URL + "/v1/webhooks"
+
+	code1, b1 := createWebhookCall(t, url, "good", "whk-shared", whCreateBody)
+	code2, b2 := createWebhookCall(t, url, "other", "whk-shared", whCreateBody)
+
+	if code1 != 201 || code2 != 201 {
+		t.Fatalf("want 201/201, got %d/%d (b1=%v b2=%v)", code1, code2, b1, b2)
+	}
+	if creates != 2 {
+		t.Fatalf("distinct accounts must each create: creates=%d, want 2", creates)
+	}
+	if b1["id"] == b2["id"] {
+		t.Fatalf("distinct accounts must get distinct webhooks, both got %v", b1["id"])
+	}
+}
+
+// Without a key, intentional duplicate subscriptions — including two
+// subscriptions to the SAME URL — remain allowed (idempotency is opt-in;
+// multiple webhooks per URL is a supported pattern, see the no-unique(url)
+// decision).
+func TestCreateWebhook_NoKeyDuplicatesAllowed(t *testing.T) {
+	var creates int
+	srv := webhookCreateIdemServer(t, countingWebhookCreate(&creates))
+	url := srv.URL + "/v1/webhooks"
+
+	code1, b1 := createWebhookCall(t, url, "good", "", whCreateBody)
+	code2, b2 := createWebhookCall(t, url, "good", "", whCreateBody) // same URL, no key
+
+	if code1 != 201 || code2 != 201 {
+		t.Fatalf("want 201/201, got %d/%d", code1, code2)
+	}
+	if creates != 2 {
+		t.Fatalf("unkeyed duplicates must both create: creates=%d, want 2", creates)
+	}
+	if b1["id"] == b2["id"] {
+		t.Fatalf("unkeyed duplicates must be distinct subscriptions, both got %v", b1["id"])
+	}
+}
+
+// A validation failure happens strictly before the side effect, so it must
+// RELEASE the key (runIdempotent's fn-error contract) — a later request may
+// reuse the key with a corrected (different) body and succeed.
+func TestCreateWebhook_ValidationFailureReleasesKey(t *testing.T) {
+	var creates int
+	srv := webhookCreateIdemServer(t, countingWebhookCreate(&creates))
+	url := srv.URL + "/v1/webhooks"
+
+	// http:// fails the SSRF/scheme validation (agent.ValidateWebhookURL).
+	code1, b1 := createWebhookCall(t, url, "good", "whk-4", `{"url":"http://example.com/hook","events":["email.received"]}`)
+	if code1 != 400 || errCode(b1) != "invalid_webhook_url" {
+		t.Fatalf("want 400 invalid_webhook_url, got %d %v", code1, b1)
+	}
+	if creates != 0 {
+		t.Fatalf("validation failure must not create: creates=%d", creates)
+	}
+
+	// The corrected retry has a DIFFERENT body: only a released key allows it
+	// (a consumed key would 422, an orphaned in-flight claim would 409).
+	code2, b2 := createWebhookCall(t, url, "good", "whk-4", whCreateBody)
+	if code2 != 201 {
+		t.Fatalf("key must be reusable after a validation failure: want 201, got %d %v", code2, b2)
+	}
+	if creates != 1 {
+		t.Fatalf("creates=%d, want 1", creates)
+	}
+}
+
+// The webhook-limit error surfaces before any insert, so it follows the same
+// release behavior: the key is not consumed.
+func TestCreateWebhook_LimitErrorReleasesKey(t *testing.T) {
+	var creates int
+	srv := webhookCreateIdemServer(t, countingWebhookCreate(&creates))
+	url := srv.URL + "/v1/webhooks"
+
+	code1, b1 := createWebhookCall(t, url, "good", "whk-5", `{"url":"https://example.com/capped","events":["email.received"]}`)
+	if code1 != 400 || errCode(b1) != "webhook_limit_reached" {
+		t.Fatalf("want 400 webhook_limit_reached, got %d %v", code1, b1)
+	}
+	code2, b2 := createWebhookCall(t, url, "good", "whk-5", whCreateBody)
+	if code2 != 201 {
+		t.Fatalf("key must be reusable after a limit error: want 201, got %d %v", code2, b2)
+	}
+	if creates != 1 {
+		t.Fatalf("creates=%d, want 1", creates)
+	}
+}
+
+// A transient store failure (500) also releases the key: the retry re-executes
+// (at-least-once, per the documented fn contract) instead of being locked out.
+func TestCreateWebhook_TransientFailureReleasesKey(t *testing.T) {
+	var creates int
+	inner := countingWebhookCreate(&creates)
+	failFirst := true
+	srv := webhookCreateIdemServer(t, func(ctx context.Context, userID, url, description string, events []string, filters identity.WebhookFilters, idemCompleteTx identity.WebhookIdemCompleter) (*identity.Webhook, error) {
+		if failFirst {
+			failFirst = false
+			return nil, errors.New("transient db error")
+		}
+		return inner(ctx, userID, url, description, events, filters, idemCompleteTx)
+	})
+	url := srv.URL + "/v1/webhooks"
+
+	code1, b1 := createWebhookCall(t, url, "good", "whk-6", whCreateBody)
+	if code1 != 500 || errCode(b1) != "internal_error" {
+		t.Fatalf("want 500 internal_error, got %d %v", code1, b1)
+	}
+	code2, b2 := createWebhookCall(t, url, "good", "whk-6", whCreateBody)
+	if code2 != 201 {
+		t.Fatalf("retry after transient failure: want 201, got %d %v", code2, b2)
+	}
+	if creates != 1 {
+		t.Fatalf("creates=%d, want 1", creates)
+	}
+}

--- a/internal/identity/webhooks.go
+++ b/internal/identity/webhooks.go
@@ -94,6 +94,14 @@ func generateWebhookSecret() string {
 	return "whsec_" + hex.EncodeToString(b)
 }
 
+// WebhookIdemCompleter completes a keyed create's idempotency row inside the
+// webhook-insert transaction, so the new subscription and its cached replay
+// response commit atomically — a crash after the commit replays the first
+// response (same webhook id + one-time secret) instead of re-creating. Same
+// shape as agent.AcceptIdemCompleter on the async accept path. nil = no
+// idempotency (unkeyed create).
+type WebhookIdemCompleter func(ctx context.Context, tx pgx.Tx, wh *Webhook) error
+
 // CreateWebhook inserts a new row and returns it with the plaintext
 // signing secret populated. The plaintext is only available on this
 // response — subsequent GET/list calls scrub it.
@@ -102,6 +110,17 @@ func generateWebhookSecret() string {
 // handler's job in slice 2; the storage layer only verifies the
 // per-user count cap from account_limits.max_webhooks.
 func (s *Store) CreateWebhook(ctx context.Context, userID, url, description string, events []string, filters WebhookFilters) (*Webhook, error) {
+	return s.CreateWebhookIdem(ctx, userID, url, description, events, filters, nil)
+}
+
+// CreateWebhookIdem is CreateWebhook with an optional idempotency completer.
+// When idemCompleteTx is non-nil the insert runs in a transaction and the
+// completer is invoked inside it (mirroring the send/approve same-tx pattern —
+// idempotency.Store.CompleteTx): the webhook row and the completed idempotency
+// key commit together, so there is no window in which a webhook exists without
+// a replayable cached response. A completer error aborts the create entirely.
+// With a nil completer the insert stays the original single statement.
+func (s *Store) CreateWebhookIdem(ctx context.Context, userID, url, description string, events []string, filters WebhookFilters, idemCompleteTx WebhookIdemCompleter) (*Webhook, error) {
 	// Enforce the per-user cap before generating any state. Race
 	// across concurrent creates is bounded by the cap + 1 in the
 	// worst case; an exact race-free check would need SELECT FOR
@@ -136,12 +155,32 @@ func (s *Store) CreateWebhook(ctx context.Context, userID, url, description stri
 		Enabled:       true,
 		CreatedAt:     time.Now(),
 	}
-	if _, err := s.pool.Exec(ctx,
-		`INSERT INTO webhooks (id, user_id, url, description, events, filters, signing_secret, enabled, created_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+	const insertSQL = `INSERT INTO webhooks (id, user_id, url, description, events, filters, signing_secret, enabled, created_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`
+	if idemCompleteTx == nil {
+		if _, err := s.pool.Exec(ctx, insertSQL,
+			w.ID, w.UserID, w.URL, w.Description, w.Events, filtersJSON, w.SigningSecret, w.Enabled, w.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("insert webhook: %w", err)
+		}
+		return w, nil
+	}
+
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin webhook create tx: %w", err)
+	}
+	defer tx.Rollback(ctx)
+	if _, err := tx.Exec(ctx, insertSQL,
 		w.ID, w.UserID, w.URL, w.Description, w.Events, filtersJSON, w.SigningSecret, w.Enabled, w.CreatedAt,
 	); err != nil {
 		return nil, fmt.Errorf("insert webhook: %w", err)
+	}
+	if err := idemCompleteTx(ctx, tx, w); err != nil {
+		return nil, fmt.Errorf("complete idempotency in webhook create tx: %w", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit webhook create tx: %w", err)
 	}
 	return w, nil
 }

--- a/internal/identity/webhooks_test.go
+++ b/internal/identity/webhooks_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
+
 	"github.com/tokencanopy/e2a/internal/identity"
 	"github.com/tokencanopy/e2a/internal/testutil"
 )
@@ -329,5 +331,83 @@ func TestDeleteWebhook_OwnerOnly(t *testing.T) {
 	// Second delete is idempotent: not-found, not silent success.
 	if err := store.DeleteWebhook(ctx, w.ID, userA); !errors.Is(err, identity.ErrWebhookNotFound) {
 		t.Errorf("delete-already-gone err = %v, want ErrWebhookNotFound", err)
+	}
+}
+
+// CreateWebhookIdem must run the idempotency completer INSIDE the insert
+// transaction: the completer's tx observes the not-yet-committed webhook row,
+// and the row + the completion commit together (the createWebhook retry-safety
+// requirement — no window where a webhook exists without a replayable cached
+// response).
+func TestCreateWebhookIdem_CompleterRunsInInsertTx(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	userID := webhookTestUser(t, store, "wh-idem-tx")
+
+	var sawInsertInTx bool
+	wh, err := store.CreateWebhookIdem(ctx, userID, "https://example.com/hook", "", []string{"email.received"}, identity.WebhookFilters{},
+		func(ctx context.Context, tx pgx.Tx, w *identity.Webhook) error {
+			var n int
+			if err := tx.QueryRow(ctx, `SELECT count(*) FROM webhooks WHERE id = $1`, w.ID).Scan(&n); err != nil {
+				return err
+			}
+			sawInsertInTx = n == 1
+			return nil
+		})
+	if err != nil {
+		t.Fatalf("CreateWebhookIdem: %v", err)
+	}
+	if !sawInsertInTx {
+		t.Error("completer must observe the webhook insert within its own transaction")
+	}
+	if _, err := store.GetWebhookByID(ctx, wh.ID, userID); err != nil {
+		t.Errorf("webhook must be committed after CreateWebhookIdem: %v", err)
+	}
+}
+
+// A completer failure must abort the whole create: no webhook row may commit
+// without its idempotency completion (the atomic pairing is the point).
+func TestCreateWebhookIdem_CompleterErrorRollsBackInsert(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	userID := webhookTestUser(t, store, "wh-idem-rb")
+
+	sentinel := errors.New("idempotency completion failed")
+	var attemptedID string
+	_, err := store.CreateWebhookIdem(ctx, userID, "https://example.com/hook", "", []string{"email.received"}, identity.WebhookFilters{},
+		func(_ context.Context, _ pgx.Tx, w *identity.Webhook) error {
+			attemptedID = w.ID
+			return sentinel
+		})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("CreateWebhookIdem err = %v, want the completer's error", err)
+	}
+	if attemptedID == "" {
+		t.Fatal("completer was never invoked")
+	}
+	if _, gerr := store.GetWebhookByID(ctx, attemptedID, userID); !errors.Is(gerr, identity.ErrWebhookNotFound) {
+		t.Errorf("completer failure must roll back the webhook insert; GetWebhookByID err = %v, want ErrWebhookNotFound", gerr)
+	}
+}
+
+// A nil completer keeps the plain single-statement create path byte-identical
+// in behavior (CreateWebhook delegates with nil).
+func TestCreateWebhookIdem_NilCompleter(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	userID := webhookTestUser(t, store, "wh-idem-nil")
+
+	wh, err := store.CreateWebhookIdem(ctx, userID, "https://example.com/hook", "", []string{"email.received"}, identity.WebhookFilters{}, nil)
+	if err != nil {
+		t.Fatalf("CreateWebhookIdem(nil completer): %v", err)
+	}
+	if wh.ID == "" || wh.SigningSecret == "" {
+		t.Errorf("empty id/secret: %+v", wh)
+	}
+	if _, err := store.GetWebhookByID(ctx, wh.ID, userID); err != nil {
+		t.Errorf("GetWebhookByID: %v", err)
 	}
 }

--- a/sdks/python/src/e2a/v1/client.py
+++ b/sdks/python/src/e2a/v1/client.py
@@ -232,8 +232,8 @@ class AsyncE2AClient:
         return await request_with_retry(make, cfg=self._cfg, retryable=True, idempotency=False)
 
     async def _write_keyed(self, make: _Make, idempotency_key: Optional[str]) -> Any:
-        # send/reply/forward/approve/create-api-key: the server dedupes on the
-        # key, so retrying the same serialized request is safe.
+        # send/reply/forward/approve/create-api-key/create-webhook: the server
+        # dedupes on the key, so retrying the same serialized request is safe.
         return await request_with_retry(
             make, cfg=self._cfg, retryable=True, idempotency=True, idempotency_key=idempotency_key
         )
@@ -711,9 +711,19 @@ class WebhooksResource:
     async def get(self, webhook_id: str) -> WebhookView:
         return await self._c._read(lambda h: self._api.get_webhook(webhook_id, _headers=h))
 
-    async def create(self, body: Body) -> CreateWebhookResponse:
+    async def create(
+        self, body: Body, *, idempotency_key: Optional[str] = None
+    ) -> CreateWebhookResponse:
+        # Returns the one-time signing secret in `.signing_secret` — store it
+        # now. Server-deduped via Idempotency-Key: a keyed retry replays the
+        # same webhook (id + secret) instead of registering a second
+        # subscription, so the SDK can safely retry an ambiguous transport
+        # failure. A key is minted per call when not supplied, so intentional
+        # duplicate subscriptions (even to the same URL) stay expressible.
         req = _coerce(CreateWebhookRequest, body)
-        return await self._c._write_unsafe(lambda h: self._api.create_webhook(req, _headers=h))
+        return await self._c._write_keyed(
+            lambda h: self._api.create_webhook(req, _headers=h), idempotency_key
+        )
 
     async def update(self, webhook_id: str, patch: Body) -> WebhookView:
         req = _coerce(UpdateWebhookRequest, patch)

--- a/sdks/python/src/e2a/v1/generated/api/webhooks_api.py
+++ b/sdks/python/src/e2a/v1/generated/api/webhooks_api.py
@@ -52,6 +52,7 @@ class WebhooksApi:
     async def create_webhook(
         self,
         create_webhook_request: CreateWebhookRequest,
+        idempotency_key: Annotated[Optional[StrictStr], Field(description="Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request's response — the SAME webhook id and one-time signing secret — instead of registering a second active subscription. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). A keyed create commits the webhook and its replay response atomically, so an accepted create always replays; dedup is best-effort only under idempotency-store degradation before that commit.")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -67,9 +68,12 @@ class WebhooksApi:
     ) -> CreateWebhookResponse:
         """Create a webhook
 
+        Register a webhook subscriber; the one-time signing secret is returned only on this response. Honors Idempotency-Key so a retried create replays the same webhook (same id + secret) instead of registering a second subscription; omit the key to intentionally create distinct subscriptions, including several to the same URL.
 
         :param create_webhook_request: (required)
         :type create_webhook_request: CreateWebhookRequest
+        :param idempotency_key: Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request's response — the SAME webhook id and one-time signing secret — instead of registering a second active subscription. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). A keyed create commits the webhook and its replay response atomically, so an accepted create always replays; dedup is best-effort only under idempotency-store degradation before that commit.
+        :type idempotency_key: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -94,6 +98,7 @@ class WebhooksApi:
 
         _param = self._create_webhook_serialize(
             create_webhook_request=create_webhook_request,
+            idempotency_key=idempotency_key,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -102,6 +107,8 @@ class WebhooksApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '201': "CreateWebhookResponse",
+            '409': "ErrorEnvelope",
+            '422': "ErrorEnvelope",
         }
         response_data = await self.api_client.call_api(
             *_param,
@@ -118,6 +125,7 @@ class WebhooksApi:
     async def create_webhook_with_http_info(
         self,
         create_webhook_request: CreateWebhookRequest,
+        idempotency_key: Annotated[Optional[StrictStr], Field(description="Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request's response — the SAME webhook id and one-time signing secret — instead of registering a second active subscription. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). A keyed create commits the webhook and its replay response atomically, so an accepted create always replays; dedup is best-effort only under idempotency-store degradation before that commit.")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -133,9 +141,12 @@ class WebhooksApi:
     ) -> ApiResponse[CreateWebhookResponse]:
         """Create a webhook
 
+        Register a webhook subscriber; the one-time signing secret is returned only on this response. Honors Idempotency-Key so a retried create replays the same webhook (same id + secret) instead of registering a second subscription; omit the key to intentionally create distinct subscriptions, including several to the same URL.
 
         :param create_webhook_request: (required)
         :type create_webhook_request: CreateWebhookRequest
+        :param idempotency_key: Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request's response — the SAME webhook id and one-time signing secret — instead of registering a second active subscription. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). A keyed create commits the webhook and its replay response atomically, so an accepted create always replays; dedup is best-effort only under idempotency-store degradation before that commit.
+        :type idempotency_key: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -160,6 +171,7 @@ class WebhooksApi:
 
         _param = self._create_webhook_serialize(
             create_webhook_request=create_webhook_request,
+            idempotency_key=idempotency_key,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -168,6 +180,8 @@ class WebhooksApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '201': "CreateWebhookResponse",
+            '409': "ErrorEnvelope",
+            '422': "ErrorEnvelope",
         }
         response_data = await self.api_client.call_api(
             *_param,
@@ -184,6 +198,7 @@ class WebhooksApi:
     async def create_webhook_without_preload_content(
         self,
         create_webhook_request: CreateWebhookRequest,
+        idempotency_key: Annotated[Optional[StrictStr], Field(description="Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request's response — the SAME webhook id and one-time signing secret — instead of registering a second active subscription. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). A keyed create commits the webhook and its replay response atomically, so an accepted create always replays; dedup is best-effort only under idempotency-store degradation before that commit.")] = None,
         _request_timeout: Union[
             None,
             Annotated[StrictFloat, Field(gt=0)],
@@ -199,9 +214,12 @@ class WebhooksApi:
     ) -> RESTResponseType:
         """Create a webhook
 
+        Register a webhook subscriber; the one-time signing secret is returned only on this response. Honors Idempotency-Key so a retried create replays the same webhook (same id + secret) instead of registering a second subscription; omit the key to intentionally create distinct subscriptions, including several to the same URL.
 
         :param create_webhook_request: (required)
         :type create_webhook_request: CreateWebhookRequest
+        :param idempotency_key: Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request's response — the SAME webhook id and one-time signing secret — instead of registering a second active subscription. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). A keyed create commits the webhook and its replay response atomically, so an accepted create always replays; dedup is best-effort only under idempotency-store degradation before that commit.
+        :type idempotency_key: str
         :param _request_timeout: timeout setting for this request. If one
                                  number provided, it will be total request
                                  timeout. It can also be a pair (tuple) of
@@ -226,6 +244,7 @@ class WebhooksApi:
 
         _param = self._create_webhook_serialize(
             create_webhook_request=create_webhook_request,
+            idempotency_key=idempotency_key,
             _request_auth=_request_auth,
             _content_type=_content_type,
             _headers=_headers,
@@ -234,6 +253,8 @@ class WebhooksApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '201': "CreateWebhookResponse",
+            '409': "ErrorEnvelope",
+            '422': "ErrorEnvelope",
         }
         response_data = await self.api_client.call_api(
             *_param,
@@ -245,6 +266,7 @@ class WebhooksApi:
     def _create_webhook_serialize(
         self,
         create_webhook_request,
+        idempotency_key,
         _request_auth,
         _content_type,
         _headers,
@@ -268,6 +290,8 @@ class WebhooksApi:
         # process the path parameters
         # process the query parameters
         # process the header parameters
+        if idempotency_key is not None:
+            _header_params['Idempotency-Key'] = idempotency_key
         # process the form parameters
         # process the body parameter
         if create_webhook_request is not None:

--- a/sdks/python/tests/test_v1_client.py
+++ b/sdks/python/tests/test_v1_client.py
@@ -28,6 +28,7 @@ from e2a.v1.generated.models import (
     AttachmentView,
     ConversationSummaryView,
     CreateAPIKeyResponse,
+    CreateWebhookResponse,
     DomainView,
     EventJSON,
     ErrorBody,
@@ -480,6 +481,61 @@ async def test_create_api_key_uses_caller_idempotency_key(httpx_mock):
         await c.account.api_keys.create({"name": "ci"}, idempotency_key="create-key-123")
 
     assert httpx_mock.get_requests()[-1].headers["Idempotency-Key"] == "create-key-123"
+
+
+@pytest.mark.anyio
+async def test_create_webhook_retry_reuses_minted_idempotency_key(httpx_mock):
+    # webhooks.create mints a one-time signing secret, so a blind retry would
+    # register a SECOND subscription with a second secret. The keyed write
+    # makes the retry replay: the transport retry re-sends the SAME minted
+    # Idempotency-Key and the server dedupes.
+    httpx_mock.add_response(
+        status_code=503,
+        json={"error": {"code": "internal_error", "message": "down", "request_id": "req_1"}},
+    )
+    httpx_mock.add_response(
+        status_code=201,
+        json=_valid(
+            CreateWebhookResponse,
+            id="wh_1",
+            url="https://x.com/h",
+            events=["email.received"],
+            signing_secret="whsec_x",
+        ),
+    )
+
+    async with _client() as c:
+        created = await c.webhooks.create({"url": "https://x.com/h", "events": ["email.received"]})
+
+    assert created.id == "wh_1"
+    assert created.signing_secret == "whsec_x"
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 2
+    keys = [request.headers.get("Idempotency-Key") for request in requests]
+    assert keys[0]
+    assert keys[1] == keys[0]
+
+
+@pytest.mark.anyio
+async def test_create_webhook_uses_caller_idempotency_key(httpx_mock):
+    httpx_mock.add_response(
+        status_code=201,
+        json=_valid(
+            CreateWebhookResponse,
+            id="wh_1",
+            url="https://x.com/h",
+            events=["email.received"],
+            signing_secret="whsec_x",
+        ),
+    )
+
+    async with _client() as c:
+        await c.webhooks.create(
+            {"url": "https://x.com/h", "events": ["email.received"]},
+            idempotency_key="wh-key-123",
+        )
+
+    assert httpx_mock.get_requests()[-1].headers["Idempotency-Key"] == "wh-key-123"
 
 
 @pytest.mark.anyio

--- a/sdks/typescript/src/v1/client.ts
+++ b/sdks/typescript/src/v1/client.ts
@@ -505,8 +505,15 @@ class WebhooksResource {
   get(id: string): Promise<WebhookView> {
     return call(() => this.api.getWebhook(id));
   }
-  create(body: CreateWebhookRequest): Promise<CreateWebhookResponse> {
-    return call(() => this.api.createWebhook(body));
+  // create returns the one-time signing secret in `.signingSecret` — store it
+  // now. Server-deduped via Idempotency-Key: a keyed retry replays the same
+  // webhook (id + secret) instead of registering a second subscription, so the
+  // retry layer can safely re-send ambiguous transport failures. Omit
+  // opts.idempotencyKey and the SDK mints one per call (intentional duplicate
+  // subscriptions — even to the same URL — stay expressible: each create call
+  // gets its own key).
+  create(body: CreateWebhookRequest, opts: RequestOptions = {}): Promise<CreateWebhookResponse> {
+    return call(() => this.api.createWebhook(body, opts.idempotencyKey));
   }
   update(id: string, patch: UpdateWebhookRequest): Promise<WebhookView> {
     return call(() => this.api.updateWebhook(id, patch));

--- a/sdks/typescript/src/v1/generated/apis/WebhooksApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/WebhooksApi.ts
@@ -26,10 +26,12 @@ import { WebhookView } from '../models/WebhookView.js';
 export class WebhooksApiRequestFactory extends BaseAPIRequestFactory {
 
     /**
+     * Register a webhook subscriber; the one-time signing secret is returned only on this response. Honors Idempotency-Key so a retried create replays the same webhook (same id + secret) instead of registering a second subscription; omit the key to intentionally create distinct subscriptions, including several to the same URL.
      * Create a webhook
      * @param createWebhookRequest 
+     * @param idempotencyKey Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request\&#39;s response — the SAME webhook id and one-time signing secret — instead of registering a second active subscription. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). A keyed create commits the webhook and its replay response atomically, so an accepted create always replays; dedup is best-effort only under idempotency-store degradation before that commit.
      */
-    public async createWebhook(createWebhookRequest: CreateWebhookRequest, _options?: Configuration): Promise<RequestContext> {
+    public async createWebhook(createWebhookRequest: CreateWebhookRequest, idempotencyKey?: string, _options?: Configuration): Promise<RequestContext> {
         let _config = _options || this.configuration;
 
         // verify required parameter 'createWebhookRequest' is not null or undefined
@@ -38,12 +40,16 @@ export class WebhooksApiRequestFactory extends BaseAPIRequestFactory {
         }
 
 
+
         // Path Params
         const localVarPath = '/v1/webhooks';
 
         // Make Request Context
         const requestContext = _config.baseServer.makeRequestContext(localVarPath, HttpMethod.POST);
         requestContext.setHeaderParam("Accept", "application/json, */*;q=0.8")
+
+        // Header Params
+        requestContext.setHeaderParam("Idempotency-Key", ObjectSerializer.serialize(idempotencyKey, "string", ""));
 
 
         // Body Params
@@ -437,12 +443,26 @@ export class WebhooksApiResponseProcessor {
             ) as CreateWebhookResponse;
             return new HttpInfo(response.httpStatusCode, response.headers, response.body, body);
         }
+        if (isCodeInRange("409", response.httpStatusCode)) {
+            const body: ErrorEnvelope = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "ErrorEnvelope", ""
+            ) as ErrorEnvelope;
+            throw new ApiException<ErrorEnvelope>(response.httpStatusCode, "Conflict — code idempotency_in_flight: a request with this Idempotency-Key is still executing. Retry-able: wait for the first request to finish, then retry with the SAME key and byte-identical body — the retry replays the first request\&#39;s response instead of re-executing the side effect.", body, response.headers);
+        }
+        if (isCodeInRange("422", response.httpStatusCode)) {
+            const body: ErrorEnvelope = ObjectSerializer.deserialize(
+                ObjectSerializer.parse(await response.body.text(), contentType),
+                "ErrorEnvelope", ""
+            ) as ErrorEnvelope;
+            throw new ApiException<ErrorEnvelope>(response.httpStatusCode, "Unprocessable — branch on error.code. idempotency_key_reuse: this Idempotency-Key was already used with a DIFFERENT request body (the dedup hash covers the route + the raw body bytes) — do NOT retry as-is; a legitimate retry must resend the byte-identical body, and a genuinely new request needs a fresh key. invalid_request: a semantic validation failure in the request body.", body, response.headers);
+        }
         if (isCodeInRange("0", response.httpStatusCode)) {
             const body: ErrorEnvelope = ObjectSerializer.deserialize(
                 ObjectSerializer.parse(await response.body.text(), contentType),
                 "ErrorEnvelope", ""
             ) as ErrorEnvelope;
-            throw new ApiException<ErrorEnvelope>(response.httpStatusCode, "Error", body, response.headers);
+            throw new ApiException<ErrorEnvelope>(response.httpStatusCode, "Error — the standard envelope; branch on error.code.", body, response.headers);
         }
 
         // Work around for missing responses in specification, e.g. for petstore.yaml

--- a/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
@@ -2069,6 +2069,13 @@ export interface WebhooksApiCreateWebhookRequest {
      * @memberof WebhooksApicreateWebhook
      */
     createWebhookRequest: CreateWebhookRequest
+    /**
+     * Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request\&#39;s response — the SAME webhook id and one-time signing secret — instead of registering a second active subscription. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). A keyed create commits the webhook and its replay response atomically, so an accepted create always replays; dedup is best-effort only under idempotency-store degradation before that commit.
+     * Defaults to: undefined
+     * @type string
+     * @memberof WebhooksApicreateWebhook
+     */
+    idempotencyKey?: string
 }
 
 export interface WebhooksApiDeleteWebhookRequest {
@@ -2207,19 +2214,21 @@ export class ObjectWebhooksApi {
     }
 
     /**
+     * Register a webhook subscriber; the one-time signing secret is returned only on this response. Honors Idempotency-Key so a retried create replays the same webhook (same id + secret) instead of registering a second subscription; omit the key to intentionally create distinct subscriptions, including several to the same URL.
      * Create a webhook
      * @param param the request object
      */
     public createWebhookWithHttpInfo(param: WebhooksApiCreateWebhookRequest, options?: ConfigurationOptions): Promise<HttpInfo<CreateWebhookResponse>> {
-        return this.api.createWebhookWithHttpInfo(param.createWebhookRequest,  options).toPromise();
+        return this.api.createWebhookWithHttpInfo(param.createWebhookRequest, param.idempotencyKey,  options).toPromise();
     }
 
     /**
+     * Register a webhook subscriber; the one-time signing secret is returned only on this response. Honors Idempotency-Key so a retried create replays the same webhook (same id + secret) instead of registering a second subscription; omit the key to intentionally create distinct subscriptions, including several to the same URL.
      * Create a webhook
      * @param param the request object
      */
     public createWebhook(param: WebhooksApiCreateWebhookRequest, options?: ConfigurationOptions): Promise<CreateWebhookResponse> {
-        return this.api.createWebhook(param.createWebhookRequest,  options).toPromise();
+        return this.api.createWebhook(param.createWebhookRequest, param.idempotencyKey,  options).toPromise();
     }
 
     /**

--- a/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
@@ -2099,13 +2099,15 @@ export class ObservableWebhooksApi {
     }
 
     /**
+     * Register a webhook subscriber; the one-time signing secret is returned only on this response. Honors Idempotency-Key so a retried create replays the same webhook (same id + secret) instead of registering a second subscription; omit the key to intentionally create distinct subscriptions, including several to the same URL.
      * Create a webhook
      * @param createWebhookRequest
+     * @param [idempotencyKey] Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request\&#39;s response — the SAME webhook id and one-time signing secret — instead of registering a second active subscription. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). A keyed create commits the webhook and its replay response atomically, so an accepted create always replays; dedup is best-effort only under idempotency-store degradation before that commit.
      */
-    public createWebhookWithHttpInfo(createWebhookRequest: CreateWebhookRequest, _options?: ConfigurationOptions): Observable<HttpInfo<CreateWebhookResponse>> {
+    public createWebhookWithHttpInfo(createWebhookRequest: CreateWebhookRequest, idempotencyKey?: string, _options?: ConfigurationOptions): Observable<HttpInfo<CreateWebhookResponse>> {
         const _config = mergeConfiguration(this.configuration, _options);
 
-        const requestContextPromise = this.requestFactory.createWebhook(createWebhookRequest, _config);
+        const requestContextPromise = this.requestFactory.createWebhook(createWebhookRequest, idempotencyKey, _config);
         // build promise chain
         let middlewarePreObservable = from<RequestContext>(requestContextPromise);
         for (const middleware of _config.middleware) {
@@ -2123,11 +2125,13 @@ export class ObservableWebhooksApi {
     }
 
     /**
+     * Register a webhook subscriber; the one-time signing secret is returned only on this response. Honors Idempotency-Key so a retried create replays the same webhook (same id + secret) instead of registering a second subscription; omit the key to intentionally create distinct subscriptions, including several to the same URL.
      * Create a webhook
      * @param createWebhookRequest
+     * @param [idempotencyKey] Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request\&#39;s response — the SAME webhook id and one-time signing secret — instead of registering a second active subscription. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). A keyed create commits the webhook and its replay response atomically, so an accepted create always replays; dedup is best-effort only under idempotency-store degradation before that commit.
      */
-    public createWebhook(createWebhookRequest: CreateWebhookRequest, _options?: ConfigurationOptions): Observable<CreateWebhookResponse> {
-        return this.createWebhookWithHttpInfo(createWebhookRequest, _options).pipe(map((apiResponse: HttpInfo<CreateWebhookResponse>) => apiResponse.data));
+    public createWebhook(createWebhookRequest: CreateWebhookRequest, idempotencyKey?: string, _options?: ConfigurationOptions): Observable<CreateWebhookResponse> {
+        return this.createWebhookWithHttpInfo(createWebhookRequest, idempotencyKey, _options).pipe(map((apiResponse: HttpInfo<CreateWebhookResponse>) => apiResponse.data));
     }
 
     /**

--- a/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
@@ -1516,22 +1516,26 @@ export class PromiseWebhooksApi {
     }
 
     /**
+     * Register a webhook subscriber; the one-time signing secret is returned only on this response. Honors Idempotency-Key so a retried create replays the same webhook (same id + secret) instead of registering a second subscription; omit the key to intentionally create distinct subscriptions, including several to the same URL.
      * Create a webhook
      * @param createWebhookRequest
+     * @param [idempotencyKey] Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request\&#39;s response — the SAME webhook id and one-time signing secret — instead of registering a second active subscription. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). A keyed create commits the webhook and its replay response atomically, so an accepted create always replays; dedup is best-effort only under idempotency-store degradation before that commit.
      */
-    public createWebhookWithHttpInfo(createWebhookRequest: CreateWebhookRequest, _options?: PromiseConfigurationOptions): Promise<HttpInfo<CreateWebhookResponse>> {
+    public createWebhookWithHttpInfo(createWebhookRequest: CreateWebhookRequest, idempotencyKey?: string, _options?: PromiseConfigurationOptions): Promise<HttpInfo<CreateWebhookResponse>> {
         const observableOptions = wrapOptions(_options);
-        const result = this.api.createWebhookWithHttpInfo(createWebhookRequest, observableOptions);
+        const result = this.api.createWebhookWithHttpInfo(createWebhookRequest, idempotencyKey, observableOptions);
         return result.toPromise();
     }
 
     /**
+     * Register a webhook subscriber; the one-time signing secret is returned only on this response. Honors Idempotency-Key so a retried create replays the same webhook (same id + secret) instead of registering a second subscription; omit the key to intentionally create distinct subscriptions, including several to the same URL.
      * Create a webhook
      * @param createWebhookRequest
+     * @param [idempotencyKey] Optional idempotency key for safe retries (unique per logical request). A retry with the same key and byte-identical body replays the first request\&#39;s response — the SAME webhook id and one-time signing secret — instead of registering a second active subscription. Completed keys are remembered for at least 24 hours (the published minimum dedup window). Within the window: same key + different body → 422 idempotency_key_reuse (do not retry as-is); same key while the first request is still executing → 409 idempotency_in_flight (wait, then retry unchanged). A keyed create commits the webhook and its replay response atomically, so an accepted create always replays; dedup is best-effort only under idempotency-store degradation before that commit.
      */
-    public createWebhook(createWebhookRequest: CreateWebhookRequest, _options?: PromiseConfigurationOptions): Promise<CreateWebhookResponse> {
+    public createWebhook(createWebhookRequest: CreateWebhookRequest, idempotencyKey?: string, _options?: PromiseConfigurationOptions): Promise<CreateWebhookResponse> {
         const observableOptions = wrapOptions(_options);
-        const result = this.api.createWebhook(createWebhookRequest, observableOptions);
+        const result = this.api.createWebhook(createWebhookRequest, idempotencyKey, observableOptions);
         return result.toPromise();
     }
 

--- a/sdks/typescript/src/v1/retry.ts
+++ b/sdks/typescript/src/v1/retry.ts
@@ -146,11 +146,11 @@ export class RetryHttpLibrary implements HttpLibrary {
   //     end state — EXCEPT account deletion, which is irreversible and whose
   //     post-success retry would surface a spurious 404 to the caller;
   //   - server-deduped POSTs (send/reply/forward/approve, rotate-secret,
-  //     create-api-key),
+  //     create-api-key, create-webhook),
   //     recognised by the Idempotency-Key header the generated layer emits ONLY
   //     for those ops — the server replays the first result on a keyed retry.
-  // Every other POST (create agent/domain/webhook, reject, verify, redeliver,
-  // test) carries no server-honored key and is NOT retried.
+  // Every other POST (create agent/domain, reject, verify, redeliver, test)
+  // carries no server-honored key and is NOT retried.
   // Mirrors the Python SDK's per-operation retry gating (rotate-secret →
   // _write_idempotent there, retried + keyed, same as here).
   private isRetrySafe(request: RequestContext): boolean {

--- a/sdks/typescript/test/v1/client.test.ts
+++ b/sdks/typescript/test/v1/client.test.ts
@@ -307,6 +307,25 @@ describe("E2AClient", () => {
     ).toThrow(/delivered_to/);
   });
 
+  // ── webhooks.create: server-deduped one-time-secret mint ────────
+  it("webhooks.create mints an Idempotency-Key for the POST", async () => {
+    globalThis.fetch = mockFetch(201, { id: "wh_1", signing_secret: "whsec_x" });
+    await client.webhooks.create({ url: "https://x.com/h", events: ["email.received"] } as never);
+    const { url, init, headers } = lastCall();
+    expect(init.method).toBe("POST");
+    expect(url).toContain("/v1/webhooks");
+    expect(headers["Idempotency-Key"]).toBeTruthy();
+  });
+
+  it("webhooks.create uses a caller-supplied idempotency key", async () => {
+    globalThis.fetch = mockFetch(201, { id: "wh_1", signing_secret: "whsec_x" });
+    await client.webhooks.create(
+      { url: "https://x.com/h", events: ["email.received"] } as never,
+      { idempotencyKey: "wh-key-123" },
+    );
+    expect(lastCall().headers["Idempotency-Key"]).toBe("wh-key-123");
+  });
+
   // ── Reviews: account-scoped, id-addressed (no inbox email) ──────
   it("reviews.approve hits POST /v1/reviews/{id}/approve (no inbox email) + mints Idempotency-Key", async () => {
     globalThis.fetch = mockFetch(200, { message_id: "msg_r1", status: "sent" });

--- a/sdks/typescript/test/v1/retry.test.ts
+++ b/sdks/typescript/test/v1/retry.test.ts
@@ -44,15 +44,15 @@ class FakeHttp implements HttpLibrary {
 }
 
 const noSleep = async () => {};
-// A server-deduped POST (send/reply/forward/approve/rotate-secret/create-api-key):
-// the generated layer emits an empty Idempotency-Key stub, which marks the op
-// safe to retry.
+// A server-deduped POST (send/reply/forward/approve/rotate-secret/create-api-key/
+// create-webhook): the generated layer emits an empty Idempotency-Key stub, which
+// marks the op safe to retry.
 const post = () => {
   const r = new RequestContext("https://api.e2a.dev/v1/agents/a@x.com/messages", HttpMethod.POST);
   r.setHeaderParam("Idempotency-Key", ""); // empty generated stub
   return r;
 };
-// A bare, non-idempotent POST (create agent/domain/webhook, reject, redeliver,
+// A bare, non-idempotent POST (create agent/domain, reject, redeliver,
 // verify, test): no server-honored key — must NOT be retried.
 const barePost = (url = "https://api.e2a.dev/v1/agents") =>
   new RequestContext(url, HttpMethod.POST);


### PR DESCRIPTION
## Problem

`POST /v1/webhooks` mints a one-time signing secret and had no `Idempotency-Key` input. A timeout or lost response followed by a retry registered a **second active subscription with a second secret** — the same GA-class hole already closed for send/reply/forward/approve, rotate-secret, and createApiKey (#493).

## Behavior

- **Optional `Idempotency-Key`** on `POST /v1/webhooks`, same documented semantics as the other side-effecting creates (24h minimum dedup window, account-scoped, `u:` untrusted-user namespace).
- **Replay**: same account + key + byte-identical body → the same webhook id, the same 201, the same one-time signing secret, the same full body (byte-faithful cached response).
- **422 `idempotency_key_reuse`** on same key + different route/body (route folded into the dedup hash via `idempotency.HashRequest`).
- **409 `idempotency_in_flight`** on a concurrent duplicate.
- **No key = unchanged**: intentional duplicate subscriptions — including several to the same URL — stay expressible; deliberately **no** `unique(user_id, url)` constraint.

## Atomicity design

Follows the send/approve **same-tx completion** pattern, not createApiKey's post-response `Complete`: new `identity.Store.CreateWebhookIdem` runs the webhook INSERT in a transaction and invokes a `WebhookIdemCompleter` (→ `idempotency.Store.CompleteTx`) inside it, so the subscription row and its cached replay response commit atomically. There is **no post-insert crash window** in which a webhook exists without a replayable response. A completer failure rolls back the insert entirely. Validation, agent-filter ownership, and the webhook cap are evaluated inside the claimed execution (like `deliver()`): failures release the key; replays skip re-validation so the response stays byte-identical even if mutable state changed. `runIdempotent`'s post-hoc `Complete` no-ops on the store's `in_progress` guard.

**Security note:** the cached replay body carries the one-time secret by design (byte-identical replay to the same account+key). It lives in the same TTL-swept `idempotency_keys` store that already caches the createApiKey plaintext key — same protection, same precedent.

## SDKs

- Spec: `createWebhook` now declares the `Idempotency-Key` header param + typed 409/422 responses (`make spec`, golden regenerated; `TestSpecGoldenNoDrift` green).
- Generated bases regenerated via `make generate-sdk` (Docker, deterministic — `make generate-sdk-check` green post-commit).
- **TS facade**: `webhooks.create(body, opts?)` gains `opts.idempotencyKey` (the established `RequestOptions` pattern); the retry layer now recognizes the generated header stub, auto-mints a key, and safely retries createWebhook (it was previously classified un-retryable).
- **Python facade**: `webhooks.create(body, *, idempotency_key=None)` moves from `_write_unsafe` to `_write_keyed` — parity with `account.api_keys.create` (key minted per call when omitted, reused across transport retries).

## Tests

- HTTP: replay (same id+secret, one create), 422 different-body reuse, 409 in-flight (blocking-fake concurrency), cross-account key reuse allowed, no-key duplicates allowed, validation/limit/transient failures release the key (`internal/httpapi/webhooks_create_idem_test.go`).
- DB-backed: completer runs inside the insert tx; completer error rolls the insert back; nil-completer path unchanged (`TestCreateWebhookIdem_*`).
- Spec: `TestSpecCreateWebhookIdempotencyKeyDeclared` + `createWebhook` added to `TestSpecIdempotencyResponsesDeclared`.
- SDK: TS minted + caller-supplied key tests; Python retry-reuses-minted-key + caller-supplied key tests. Full TS (181) and Python (318) unit suites green.
- The `bodyAwareIdem` test fake now mirrors the real store's `(user_id, key)` scoping and completed-row guard so same-tx double-completion is faithfully exercised.

## Remaining caveats

- Dedup is best-effort **before** the atomic commit: if the idempotency store degrades at claim time the request 500s (no side effect); a panic strictly between claim and the insert releases the key (at-least-once, same guarantee as every other keyed op).
- The sync-path `Complete` after replay-decode failure and the 5-minute stale-claim takeover window are inherited, unchanged, from the shared `runIdempotent` machinery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)