### PR TITLE
fix(agent): route testAgent through the durable outbound pipeline (platform-originated, msg_ id contract)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -5155,7 +5155,7 @@ paths:
       x-stability-level: beta
   /v1/agents/{email}/test:
     post:
-      description: Send a platform test email to the agent's own address to confirm inbound delivery. 202 when held for HITL.
+      description: "Send a platform-originated test email (From: the platform noreply identity) to the agent's own address over the real external SMTP route, to confirm inbound delivery end to end. Returns 202: status=accepted (the message is durably persisted and queued; message_id is the GET-able e2a message id, and the terminal outcome arrives via GET /v1/messages/{id} or the email.sent / email.failed webhook events — provider_message_id appears only after provider submission) or status=pending_review when held for review. Always branch on body.status."
       operationId: testAgent
       parameters:
         - description: The agent's full email address, e.g. support@acme.com.

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -1240,20 +1240,37 @@ func (a *API) DeliverOutbound(ctx context.Context, user *identity.User, agent *i
 	return &OutboundResult{MessageID: accepted.ID, Status: "accepted", SentAs: comp.SentAs, Method: comp.Method}, nil
 }
 
-// SendTestCore composes and sends (or HITL-holds) a platform test email to
-// the agent's own address. HTTP-free; shared by the legacy handler and the v1
-// layer. The caller has already authed, resolved + owned the agent,
-// domain-verified, and run the message-send cap.
+// SendTestCore accepts (or HITL-holds) a platform test email to the agent's
+// own address. HTTP-free; shared by the legacy handler and the v1 layer. The
+// caller has already authed, resolved + owned the agent, domain-verified,
+// rate-limited, and run the message-send cap.
+//
+// The message is PLATFORM-originated (From/envelope = noreply@<from_domain>)
+// and traverses the real external SMTP → inbound route back to the agent's
+// public address — that round-trip is the endpoint's purpose, so it must never
+// route through the agent self-send loopback. Delivery is queue-first like
+// every other send: a durable msg_ resource + outbound_send job are committed
+// before any provider I/O (status=accepted), and the terminal outcome arrives
+// via GET /v1/messages/{id} and the email.sent / email.failed events.
 func (a *API) SendTestCore(ctx context.Context, agent *identity.AgentIdentity) (*OutboundResult, *OutboundError) {
-	envelopeFrom := fmt.Sprintf("noreply@%s", a.fromDomain)
-	headerFrom := fmt.Sprintf("%q <%s>", "e2a", envelopeFrom)
 	to := []string{agent.EmailAddress()}
 	subject := "Test email from e2a"
 	body := fmt.Sprintf("This is a test email for %s.\n\nYour agent is set up and ready to receive emails.", agent.EmailAddress())
+	testReq := outbound.SendRequest{To: to, Subject: subject, Body: body}
+
+	// Suppression enforcement — the same recipient gate DeliverOutbound runs
+	// (decision 9): a suppressed agent address must never be submitted.
+	if supErr := a.checkSuppression(ctx, agent.UserID, testReq); supErr != nil {
+		return nil, supErr
+	}
+
+	// Mint the thread anchor exactly like DeliverOutbound does for a fresh send
+	// (#328), so the inbound copy — arriving over real SMTP with the
+	// X-E2A-Conversation-ID header — threads onto this outbound row.
+	testReq.ConversationID = identity.NewConversationID()
 
 	// A platform test is a normal outbound send through the same screening:
 	// block ⇒ refuse, review ⇒ hold, flag ⇒ send + annotate.
-	testReq := outbound.SendRequest{To: to, Subject: subject, Body: body}
 	verdict := a.screenOutbound(ctx, agent, testReq)
 	if verdict.Block() {
 		a.auditRowless(ctx, agent, blockAuditID(agent.ID, testReq), testReq, verdict)
@@ -1271,22 +1288,68 @@ func (a *API) SendTestCore(ctx context.Context, agent *identity.AgentIdentity) (
 		return &OutboundResult{Held: true, PendingMessageID: msg.ID, ApprovalExpiresAt: msg.ApprovalExpiresAt}, nil
 	}
 
-	message, err := outbound.ComposeMessage(headerFrom, to, nil, subject, body, "text/plain", "", nil, a.fromDomain, "", "")
-	if err != nil {
-		log.Printf("[api] compose test email failed: %v", err)
-		return nil, &OutboundError{Status: http.StatusInternalServerError, Code: "internal_error", Msg: "failed to compose test email"}
+	res, oerr := a.acceptPlatformSend(ctx, agent, testReq, "test")
+	if oerr != nil {
+		return nil, oerr
 	}
-	messageID, err := a.smtpRelay.Send(envelopeFrom, to, message)
-	if err != nil {
-		log.Printf("[api] send test email failed: %v", err)
-		return nil, &OutboundError{Status: http.StatusInternalServerError, Code: "internal_error", Msg: fmt.Sprintf("failed to send test email: %v", err)}
-	}
-	log.Printf("[api] test email sent to %s (message_id=%s)", agent.EmailAddress(), messageID)
-	// flag verdict: the test send persists no message row, so audit row-less.
 	if verdict.Annotate() {
-		a.auditRowless(ctx, agent, blockAuditID(agent.ID, testReq), testReq, verdict)
+		a.annotateAndAudit(ctx, agent, res.MessageID, testReq, verdict)
 	}
-	return &OutboundResult{MessageID: messageID, Method: "smtp"}, nil
+	return res, nil
+}
+
+// acceptPlatformSend durably persists + enqueues a PLATFORM-originated
+// outbound message (From/envelope = noreply@<from_domain>, never an agent
+// identity) on the same queue-first pipeline as DeliverOutbound's external
+// branch: message row (delivery_status='accepted') + outbound_send job +
+// job-id stamp in ONE transaction, with provider I/O strictly in the River
+// worker (internal/outboundsend), which records the terminal outcome
+// (email.sent / email.failed) and meters on success.
+//
+// It exists for the agent test send (msgType="test"), whose recipient is the
+// agent's OWN address: the agent-identity compose strips the agent's own
+// address ("no valid recipients") and the self-send predicate would reroute
+// delivery to local loopback — either would defeat the endpoint's purpose of
+// exercising the real external SMTP → inbound route. Callers run suppression
+// + screening first; this is the smallest accept seam, not a policy layer.
+func (a *API) acceptPlatformSend(ctx context.Context, agent *identity.AgentIdentity, req outbound.SendRequest, msgType string) (*OutboundResult, *OutboundError) {
+	// Missing queue wiring is a startup bug; fail closed before provider I/O
+	// and never submit inline (same contract as DeliverOutbound).
+	if a.outboundEnq == nil {
+		log.Printf("[api] outbound queue unavailable: agent=%s to=%v (platform %s)", agent.Domain, req.To, msgType)
+		return nil, &OutboundError{Status: http.StatusInternalServerError, Code: "internal_error", Msg: "outbound delivery queue unavailable"}
+	}
+	comp, cerr := a.sender.ComposePlatformForAccept(req)
+	if cerr != nil {
+		if outbound.IsValidationError(cerr) {
+			return nil, &OutboundError{Status: http.StatusBadRequest, Code: "invalid_request", Msg: cerr.Error()}
+		}
+		log.Printf("[api] platform compose failed: agent=%s to=%v error=%v", agent.Domain, req.To, cerr)
+		return nil, &OutboundError{Status: http.StatusInternalServerError, Code: "internal_error", Msg: fmt.Sprintf("compose failed: %v", cerr)}
+	}
+	var accepted *identity.Message
+	if txErr := a.store.WithTx(ctx, func(tx pgx.Tx) error {
+		msg, err := a.store.CreateOutboundMessageTx(ctx, tx, agent.ID, comp.To, comp.CC, comp.BCC, req.Subject, msgType, comp.Method, "", req.ConversationID, comp.Raw, "accepted", comp.EnvelopeFrom, comp.SentAs)
+		if err != nil {
+			return err
+		}
+		jobID, err := a.outboundEnq.EnqueueSendTx(ctx, tx, msg.ID)
+		if err != nil {
+			return err
+		}
+		if err := a.store.StampSendJobIDTx(ctx, tx, msg.ID, jobID); err != nil {
+			return err
+		}
+		accepted = msg
+		return nil
+	}); txErr != nil {
+		log.Printf("[api] platform accept tx failed: agent=%s to=%v error=%v", agent.Domain, req.To, txErr)
+		return nil, &OutboundError{Status: http.StatusInternalServerError, Code: "internal_error", Msg: "failed to accept message for send"}
+	}
+	slug, _, _ := strings.Cut(agent.EmailAddress(), "@")
+	log.Printf("[mail:%s] dir=outbound type=%s status=accepted from=%s to=%v slug=%s conv_id=%s subject=%q platform_originated=true",
+		accepted.ID, msgType, comp.EnvelopeFrom, comp.To, slug, req.ConversationID, req.Subject)
+	return &OutboundResult{MessageID: accepted.ID, Status: "accepted", SentAs: comp.SentAs, Method: comp.Method}, nil
 }
 
 // --- Send Email ---

--- a/internal/agent/hitl_api.go
+++ b/internal/agent/hitl_api.go
@@ -184,10 +184,21 @@ func (a *API) approveOutboundAsync(ctx context.Context, agent *identity.AgentIde
 		return nil, false, err
 	}
 	attachReferencesChain(ctx, a.store, agent.ID, &sendReq)
-	if isSelfSend(sendReq, agent.EmailAddress()) {
+	// A held platform test (type="test") targets the agent's own address by
+	// design, so the self-send predicate below would silently reroute its
+	// approval to local loopback — dropping the real SMTP → inbound round-trip
+	// the test exists to exercise. Keep it platform-originated instead: same
+	// compose the accept path (acceptPlatformSend) uses, same queued delivery.
+	isPlatformTest := draft.Type == "test"
+	if !isPlatformTest && isSelfSend(sendReq, agent.EmailAddress()) {
 		return nil, false, nil // self-send — caller uses the sync loopback path
 	}
-	comp, err := a.sender.ComposeForAccept(agent, sendReq)
+	var comp *outbound.ComposeResult
+	if isPlatformTest {
+		comp, err = a.sender.ComposePlatformForAccept(sendReq)
+	} else {
+		comp, err = a.sender.ComposeForAccept(agent, sendReq)
+	}
 	if err != nil {
 		return nil, false, err
 	}

--- a/internal/agent/test_send_async_test.go
+++ b/internal/agent/test_send_async_test.go
@@ -1,0 +1,361 @@
+package agent_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+
+	"github.com/tokencanopy/e2a/internal/agent"
+	"github.com/tokencanopy/e2a/internal/config"
+	"github.com/tokencanopy/e2a/internal/identity"
+	"github.com/tokencanopy/e2a/internal/outbound"
+	"github.com/tokencanopy/e2a/internal/outboundsend"
+	"github.com/tokencanopy/e2a/internal/testutil"
+	"github.com/tokencanopy/e2a/internal/usage"
+	"github.com/tokencanopy/e2a/internal/webhookpub"
+)
+
+// captureDeliverer records the SendJobs the SendWorker hands to the provider,
+// so tests can assert exactly what the wire would carry (envelope sender,
+// RCPT set, raw bytes) without a network.
+type captureDeliverer struct {
+	jobs []*outboundsend.SendJob
+	out  outboundsend.DeliverOutcome
+}
+
+func (c *captureDeliverer) Deliver(_ context.Context, j *outboundsend.SendJob) outboundsend.DeliverOutcome {
+	c.jobs = append(c.jobs, j)
+	return c.out
+}
+
+func countAgentMessages(t *testing.T, store *identity.Store, agentID, direction string) int {
+	t.Helper()
+	var n int
+	if err := store.WithTx(context.Background(), func(tx pgx.Tx) error {
+		return tx.QueryRow(context.Background(),
+			`SELECT count(*) FROM messages WHERE agent_id=$1 AND direction=$2`, agentID, direction,
+		).Scan(&n)
+	}); err != nil {
+		t.Fatalf("count messages: %v", err)
+	}
+	return n
+}
+
+// TestSendTestCore_AsyncAcceptPlatformOriginated is the endpoint's new core
+// contract: POST .../test durably accepts a PLATFORM-originated message —
+// msg_ resource + outbound_send job committed before any provider I/O — and
+// returns status=accepted with the e2a message id (never a provider id). The
+// real SendWorker then submits it over the external SMTP path with the
+// platform/noreply envelope sender and the agent's own address as recipient,
+// records provider_message_id, and emits email.sent. Local self-send loopback
+// is never used (no locally-fabricated inbound row).
+func TestSendTestCore_AsyncAcceptPlatformOriginated(t *testing.T) {
+	api, store, outbox, enq := setupAsyncAPI(t)
+	ctx := context.Background()
+	user, ag := selfAgent(t, store, "testaccept")
+
+	res, oerr := api.SendTestCore(ctx, ag)
+	if oerr != nil {
+		t.Fatalf("SendTestCore: status=%d code=%s msg=%s", oerr.Status, oerr.Code, oerr.Msg)
+	}
+	if res.Status != "accepted" {
+		t.Fatalf("Status = %q, want accepted", res.Status)
+	}
+	if !strings.HasPrefix(res.MessageID, "msg_") {
+		t.Fatalf("MessageID = %q, want a durable e2a msg_ id (never a provider id)", res.MessageID)
+	}
+	if res.ProviderMessageID != "" {
+		t.Fatalf("ProviderMessageID = %q, want empty before worker submission", res.ProviderMessageID)
+	}
+	if res.Method != "smtp" {
+		t.Fatalf("Method = %q, want smtp (loopback must not be used)", res.Method)
+	}
+
+	// The msg_ resource is GET-able through the owner-scoped store read that
+	// backs GET /v1/messages/{id}.
+	got, err := store.GetOutboundMessageForUser(ctx, res.MessageID, user.ID)
+	if err != nil {
+		t.Fatalf("accepted test message is not GET-able: %v", err)
+	}
+	if got.Type != "test" {
+		t.Errorf("message_type = %q, want test", got.Type)
+	}
+	if got.ConversationID == "" {
+		t.Errorf("conversation_id empty; a fresh thread anchor must be minted like other sends")
+	}
+
+	// Row invariants: accepted, job stamped, platform envelope persisted, no
+	// provider id yet, raw bytes carry the platform From identity.
+	var (
+		deliveryStatus, providerID, envelopeFrom, method string
+		sendJobID                                        *int64
+		raw                                              []byte
+		toRecipients                                     []string
+	)
+	if err := store.WithTx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT delivery_status, COALESCE(provider_message_id,''), COALESCE(envelope_from,''), method, send_job_id, raw_message, to_recipients FROM messages WHERE id=$1`,
+			res.MessageID,
+		).Scan(&deliveryStatus, &providerID, &envelopeFrom, &method, &sendJobID, &raw, &toRecipients)
+	}); err != nil {
+		t.Fatalf("read accepted row: %v", err)
+	}
+	if deliveryStatus != "accepted" {
+		t.Errorf("delivery_status = %q, want accepted", deliveryStatus)
+	}
+	if providerID != "" {
+		t.Errorf("provider_message_id = %q, want empty at accept", providerID)
+	}
+	if envelopeFrom != "noreply@test.e2a.dev" {
+		t.Errorf("envelope_from = %q, want noreply@test.e2a.dev (platform-originated)", envelopeFrom)
+	}
+	if method != "smtp" {
+		t.Errorf("method = %q, want smtp", method)
+	}
+	if sendJobID == nil || *sendJobID != enq.jobID {
+		t.Errorf("send_job_id = %v, want %d", sendJobID, enq.jobID)
+	}
+	if len(toRecipients) != 1 || toRecipients[0] != ag.EmailAddress() {
+		t.Errorf("to_recipients = %v, want [%s]", toRecipients, ag.EmailAddress())
+	}
+	if !strings.Contains(string(raw), `From: "e2a" <noreply@test.e2a.dev>`) {
+		t.Errorf("raw From header is not the platform identity:\n%s", raw)
+	}
+	// Loopback not used: no locally-fabricated inbound copy (the real inbound
+	// arrives via external SMTP, outside this process).
+	if n := countAgentMessages(t, store, ag.ID, "inbound"); n != 0 {
+		t.Errorf("inbound rows at accept = %d, want 0 (self-send loopback must not run)", n)
+	}
+	// Terminal outcome not reached: no email.sent yet.
+	if n := countEvents(t, store, ag.UserID, webhookpub.EventEmailSent); n != 0 {
+		t.Errorf("email.sent events at accept = %d, want 0", n)
+	}
+
+	// Run the real SendWorker over the production adapter + a capturing submit.
+	adapter := agent.NewOutboundSendStore(store, outbox, usage.NewNoopUsageTracker())
+	deliverer := &captureDeliverer{out: outboundsend.DeliverOutcome{ProviderMessageID: "<ses-test-1@amazonses.com>", SentAs: "relay"}}
+	worker := outboundsend.NewSendWorker(adapter, deliverer)
+	if err := worker.Work(ctx, workerJob(res.MessageID, 1)); err != nil {
+		t.Fatalf("worker.Work: %v", err)
+	}
+
+	// The provider saw the platform/noreply sender and the agent's own
+	// address as recipient — the real external route, not loopback.
+	if len(deliverer.jobs) != 1 {
+		t.Fatalf("provider submits = %d, want 1", len(deliverer.jobs))
+	}
+	j := deliverer.jobs[0]
+	if j.EnvelopeFrom != "noreply@test.e2a.dev" {
+		t.Errorf("provider envelope sender = %q, want noreply@test.e2a.dev", j.EnvelopeFrom)
+	}
+	if len(j.Recipients) != 1 || j.Recipients[0] != ag.EmailAddress() {
+		t.Errorf("provider recipients = %v, want [%s]", j.Recipients, ag.EmailAddress())
+	}
+
+	// Terminal state: provider id stored, email.sent emitted once.
+	if err := store.WithTx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT delivery_status, COALESCE(provider_message_id,'') FROM messages WHERE id=$1`,
+			res.MessageID,
+		).Scan(&deliveryStatus, &providerID)
+	}); err != nil {
+		t.Fatalf("read sent row: %v", err)
+	}
+	if deliveryStatus != "sent" {
+		t.Errorf("post-worker delivery_status = %q, want sent", deliveryStatus)
+	}
+	if providerID != "<ses-test-1@amazonses.com>" {
+		t.Errorf("provider_message_id = %q, want the provider id from the worker", providerID)
+	}
+	if n := countEvents(t, store, ag.UserID, webhookpub.EventEmailSent); n != 1 {
+		t.Errorf("email.sent events after worker = %d, want 1", n)
+	}
+	if n := countAgentMessages(t, store, ag.ID, "inbound"); n != 0 {
+		t.Errorf("inbound rows after worker = %d, want 0 (delivery is external)", n)
+	}
+}
+
+// TestSendTestCore_WorkerFailureEmitsEmailFailed: a terminal provider failure
+// on a queued test send surfaces through GET state (delivery_status=failed)
+// and the email.failed event — never a silent drop.
+func TestSendTestCore_WorkerFailureEmitsEmailFailed(t *testing.T) {
+	api, store, outbox, _ := setupAsyncAPI(t)
+	ctx := context.Background()
+	_, ag := selfAgent(t, store, "testfail")
+
+	res, oerr := api.SendTestCore(ctx, ag)
+	if oerr != nil {
+		t.Fatalf("SendTestCore: %+v", oerr)
+	}
+
+	adapter := agent.NewOutboundSendStore(store, outbox, usage.NewNoopUsageTracker())
+	worker := outboundsend.NewSendWorker(adapter, &captureDeliverer{
+		out: outboundsend.DeliverOutcome{Err: errors.New("550 mailbox unavailable"), Permanent: true},
+	})
+	// A permanent failure surfaces as a job-cancel error from Work; the row +
+	// event are what the contract pins.
+	_ = worker.Work(ctx, workerJob(res.MessageID, 1))
+
+	var deliveryStatus string
+	if err := store.WithTx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT delivery_status FROM messages WHERE id=$1`, res.MessageID).Scan(&deliveryStatus)
+	}); err != nil {
+		t.Fatalf("read failed row: %v", err)
+	}
+	if deliveryStatus != "failed" {
+		t.Errorf("delivery_status = %q, want failed", deliveryStatus)
+	}
+	if n := countEvents(t, store, ag.UserID, webhookpub.EventEmailFailed); n != 1 {
+		t.Errorf("email.failed events = %d, want 1", n)
+	}
+}
+
+// TestSendTestCore_SuppressedTargetNotAccepted: the test send honors the same
+// suppression gate as every other send — a suppressed agent address returns
+// the structured 422 and nothing is persisted or enqueued.
+func TestSendTestCore_SuppressedTargetNotAccepted(t *testing.T) {
+	api, store, _, _ := setupAsyncAPI(t)
+	ctx := context.Background()
+	user, ag := selfAgent(t, store, "testsuppr")
+
+	if _, err := store.AddSuppression(ctx, user.ID, ag.EmailAddress(), "hard_bounce", "manual", ""); err != nil {
+		t.Fatalf("AddSuppression: %v", err)
+	}
+
+	res, oerr := api.SendTestCore(ctx, ag)
+	if res != nil {
+		t.Fatalf("result = %+v, want nil for a suppressed recipient", res)
+	}
+	if oerr == nil || oerr.Status != 422 || oerr.Code != "recipient_suppressed" {
+		t.Fatalf("error = %+v, want 422 recipient_suppressed", oerr)
+	}
+	if n := countAgentMessages(t, store, ag.ID, "outbound"); n != 0 {
+		t.Errorf("outbound rows = %d, want 0 (suppressed target must not be accepted)", n)
+	}
+}
+
+// TestSendTestCore_MissingQueueFailsClosed: like DeliverOutbound, a miswired
+// process (no outbound enqueuer) fails closed before provider I/O — no inline
+// SMTP submit, no orphan row.
+func TestSendTestCore_MissingQueueFailsClosed(t *testing.T) {
+	smtpAddr, smtpDone := testutil.FakeSMTPServer(t)
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	smtpRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{Host: smtpAddr.Host, Port: smtpAddr.Port})
+	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
+	api := agent.NewAPI(store, sender, smtpRelay, nil, usage.NewNoopUsageTracker(),
+		"e2a.dev", "test.e2a.dev", "agents.e2a.dev", "", false)
+	_, ag := selfAgent(t, store, "testnoq")
+
+	res, oerr := api.SendTestCore(context.Background(), ag)
+	if res != nil {
+		t.Fatalf("result = %+v, want nil when outbound queue is unavailable", res)
+	}
+	if oerr == nil || oerr.Status != 500 || oerr.Code != "internal_error" {
+		t.Fatalf("error = %+v, want 500 internal_error", oerr)
+	}
+	if got := smtpDone(); len(got) != 0 {
+		t.Fatalf("missing queue submitted %d SMTP messages; want zero (fail closed)", len(got))
+	}
+	if n := countAgentMessages(t, store, ag.ID, "outbound"); n != 0 {
+		t.Errorf("outbound rows = %d, want 0", n)
+	}
+}
+
+// TestSendTestCore_ScreeningReviewHolds: outbound screening still governs the
+// test send — a review posture holds it as a durable pending_review msg_ row
+// (type=test), exactly as before the async cutover.
+func TestSendTestCore_ScreeningReviewHolds(t *testing.T) {
+	api, store, _, _ := setupAsyncAPI(t)
+	ctx := context.Background()
+	user, ag := selfAgent(t, store, "testreview")
+
+	if err := store.UpdateAgentProtection(ctx, ag.ID, user.ID, identity.ProtectionConfig{
+		InboundGatePolicy:       "open",
+		InboundGateAction:       "review",
+		InboundScanSensitivity:  identity.SensitivityOff,
+		OutboundGatePolicy:      "allowlist", // empty allowlist → every recipient flagged
+		OutboundGateAction:      "review",
+		OutboundScanSensitivity: identity.SensitivityOff,
+		HITLTTLSeconds:          3600,
+		HITLExpirationAction:    "approve",
+	}); err != nil {
+		t.Fatalf("UpdateAgentProtection: %v", err)
+	}
+	refreshed, err := store.GetAgentByID(ctx, ag.ID)
+	if err != nil {
+		t.Fatalf("GetAgentByID: %v", err)
+	}
+
+	res, oerr := api.SendTestCore(ctx, refreshed)
+	if oerr != nil {
+		t.Fatalf("SendTestCore: %+v", oerr)
+	}
+	if !res.Held || !strings.HasPrefix(res.PendingMessageID, "msg_") {
+		t.Fatalf("res = %+v, want held with a msg_ pending id", res)
+	}
+	var status, msgType string
+	if err := store.WithTx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx, `SELECT status, message_type FROM messages WHERE id=$1`, res.PendingMessageID).Scan(&status, &msgType)
+	}); err != nil {
+		t.Fatalf("read held row: %v", err)
+	}
+	if status != identity.MessageStatusPendingReview || msgType != "test" {
+		t.Errorf("held row = %s/%s, want pending_review/test", status, msgType)
+	}
+}
+
+// TestApprovePendingCore_TestHoldStaysPlatformSMTP: human approval of a held
+// platform test must keep the platform-originated external SMTP semantics —
+// queued onto the outbound pipeline with the noreply envelope — and must NOT
+// silently become local self-send loopback just because the recipient is the
+// agent's own address.
+func TestApprovePendingCore_TestHoldStaysPlatformSMTP(t *testing.T) {
+	api, store, _, enq := setupAsyncAPI(t)
+	ctx := context.Background()
+	user, ag := selfAgent(t, store, "testapprove")
+
+	msg, err := store.CreatePendingOutboundMessage(ctx, ag.ID,
+		[]string{ag.EmailAddress()}, nil, nil,
+		"Test email from e2a", "test body", "", nil, "test", "", "", "", 3600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sent, oerr := api.ApprovePendingCore(ctx, user.ID, msg.ID, ag.Email, agent.ApproveOverrides{}, nil)
+	if oerr != nil {
+		t.Fatalf("ApprovePendingCore: status=%d code=%s msg=%s", oerr.Status, oerr.Code, oerr.Msg)
+	}
+	if sent.DeliveryStatus != "accepted" {
+		t.Errorf("DeliveryStatus = %q, want accepted (queued, not loopback-delivered)", sent.DeliveryStatus)
+	}
+	if sent.Method != "smtp" {
+		t.Errorf("Method = %q, want smtp", sent.Method)
+	}
+
+	var envelopeFrom, method string
+	var sendJobID *int64
+	if err := store.WithTx(ctx, func(tx pgx.Tx) error {
+		return tx.QueryRow(ctx,
+			`SELECT COALESCE(envelope_from,''), method, send_job_id FROM messages WHERE id=$1`, msg.ID,
+		).Scan(&envelopeFrom, &method, &sendJobID)
+	}); err != nil {
+		t.Fatalf("read approved row: %v", err)
+	}
+	if envelopeFrom != "noreply@test.e2a.dev" {
+		t.Errorf("envelope_from = %q, want noreply@test.e2a.dev (platform-originated)", envelopeFrom)
+	}
+	if method != "smtp" {
+		t.Errorf("method = %q, want smtp (not loopback)", method)
+	}
+	if sendJobID == nil || *sendJobID != enq.jobID {
+		t.Errorf("send_job_id = %v, want %d (queued onto QueueOutbound)", sendJobID, enq.jobID)
+	}
+	// No locally-fabricated inbound twin — the real inbound arrives via SMTP.
+	if n := countAgentMessages(t, store, ag.ID, "inbound"); n != 0 {
+		t.Errorf("inbound rows = %d, want 0 (approval must not loopback a test)", n)
+	}
+}

--- a/internal/hitlworker/platform_test_approve_test.go
+++ b/internal/hitlworker/platform_test_approve_test.go
@@ -1,0 +1,76 @@
+package hitlworker_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/tokencanopy/e2a/internal/identity"
+)
+
+// TestWorkerAutoApproveAsync_PlatformTestStaysExternalSMTP: TTL auto-approval
+// of a held platform test (type="test") must preserve the platform-originated
+// external SMTP semantics — queued onto QueueOutbound with the noreply@
+// envelope — and must NOT be rerouted to the local self-send loopback just
+// because its recipient is the agent's own address. Loopback here would
+// fabricate the inbound copy locally and silently stop exercising the real
+// inbound route the test exists to verify.
+func TestWorkerAutoApproveAsync_PlatformTestStaysExternalSMTP(t *testing.T) {
+	w, store, pool, smtpDone := setupWorker(t)
+	ctx := context.Background()
+
+	agent := prepareAgent(t, store, "test-platform", identity.HITLExpirationApprove)
+	enq := &fakeEnq{}
+	w.SetOutboundEnqueuer(enq)
+
+	msg, err := store.CreatePendingOutboundMessage(ctx, agent.ID,
+		[]string{agent.EmailAddress()}, nil, nil,
+		"Test email from e2a", "test body", "", nil, "test", "", "", "", 60)
+	if err != nil {
+		t.Fatal(err)
+	}
+	backdateExpiry(t, pool, msg.ID)
+
+	w.RunOnce(ctx)
+
+	// Queued, not sent inline and not loopback-delivered.
+	if msgs := smtpDone(); len(msgs) != 0 {
+		t.Fatalf("async auto-approve must NOT send inline, got %d SMTP messages", len(msgs))
+	}
+	if len(enq.calls) != 1 || enq.calls[0] != msg.ID {
+		t.Fatalf("EnqueueSendTx calls = %v, want [%s] (platform test must be queued)", enq.calls, msg.ID)
+	}
+
+	var status, deliveryStatus, envelopeFrom, method string
+	var sendJobID *int64
+	if err := pool.QueryRow(ctx,
+		`SELECT status, COALESCE(delivery_status,''), COALESCE(envelope_from,''), method, send_job_id FROM messages WHERE id=$1`, msg.ID,
+	).Scan(&status, &deliveryStatus, &envelopeFrom, &method, &sendJobID); err != nil {
+		t.Fatal(err)
+	}
+	if status != identity.MessageStatusReviewExpiredApproved {
+		t.Errorf("status = %q, want %q", status, identity.MessageStatusReviewExpiredApproved)
+	}
+	if deliveryStatus != "accepted" {
+		t.Errorf("delivery_status = %q, want accepted", deliveryStatus)
+	}
+	if envelopeFrom != "noreply@test.e2a.dev" {
+		t.Errorf("envelope_from = %q, want noreply@test.e2a.dev (platform-originated)", envelopeFrom)
+	}
+	if method != "smtp" {
+		t.Errorf("method = %q, want smtp (not loopback)", method)
+	}
+	if sendJobID == nil || *sendJobID != 7777 {
+		t.Errorf("send_job_id = %v, want 7777", sendJobID)
+	}
+
+	// No locally-fabricated inbound twin.
+	var inbound int
+	if err := pool.QueryRow(ctx,
+		`SELECT count(*) FROM messages WHERE agent_id=$1 AND direction='inbound'`, agent.ID,
+	).Scan(&inbound); err != nil {
+		t.Fatal(err)
+	}
+	if inbound != 0 {
+		t.Errorf("inbound rows = %d, want 0 (TTL approval must not loopback a platform test)", inbound)
+	}
+}

--- a/internal/hitlworker/worker.go
+++ b/internal/hitlworker/worker.go
@@ -236,10 +236,22 @@ func (w *Worker) autoApproveAsync(ctx context.Context, agent *identity.AgentIden
 		return true
 	}
 	w.attachReferencesChain(ctx, agent.ID, &req)
-	if loopback.IsSelfSend(req, agent.EmailAddress()) {
+	// A held platform test (type="test") targets the agent's own address by
+	// design, so the self-send predicate below would silently reroute its TTL
+	// auto-approval to local loopback — dropping the real SMTP → inbound
+	// round-trip the test exists to exercise. Keep it platform-originated
+	// (noreply@<from_domain>) instead, mirroring the human-approve path in
+	// internal/agent/hitl_api.go.
+	isPlatformTest := msg.Type == "test"
+	if !isPlatformTest && loopback.IsSelfSend(req, agent.EmailAddress()) {
 		return false // self-send — fall through to the local loopback path
 	}
-	comp, err := w.sender.ComposeForAccept(agent, req)
+	var comp *outbound.ComposeResult
+	if isPlatformTest {
+		comp, err = w.sender.ComposePlatformForAccept(req)
+	} else {
+		comp, err = w.sender.ComposeForAccept(agent, req)
+	}
 	if err != nil {
 		// Compose failures are deterministic (bad addresses / no visible
 		// recipients) — a retry can't fix them, so reject the draft.

--- a/internal/httpapi/operations_test.go
+++ b/internal/httpapi/operations_test.go
@@ -494,7 +494,9 @@ func testServer(t *testing.T, opts ...func(*Deps)) *httptest.Server {
 			return nil
 		},
 		SendTest: func(ctx context.Context, ag *identity.AgentIdentity) (*agent.OutboundResult, *agent.OutboundError) {
-			return &agent.OutboundResult{MessageID: "msg_test_1", Method: "smtp"}, nil
+			// Queue-first platform test: durably accepted, provider id unknown
+			// until the SendWorker submits (mirrors SendTestCore).
+			return &agent.OutboundResult{MessageID: "msg_test_1", Status: "accepted", Method: "smtp"}, nil
 		},
 		ApprovePending: func(ctx context.Context, userID, messageID, expectedAgentEmail string, ovr agent.ApproveOverrides, _ agent.ApproveIdemCompleter) (*identity.Message, *agent.OutboundError) {
 			switch messageID {

--- a/internal/httpapi/outbound.go
+++ b/internal/httpapi/outbound.go
@@ -280,7 +280,7 @@ func (s *Server) registerOutbound() {
 	huma.Register(s.API, huma.Operation{
 		OperationID: "testAgent", Method: http.MethodPost, Path: "/v1/agents/{email}/test",
 		Summary: "Send a test email to the agent's own address", Tags: []string{"agents"},
-		Description: "Send a platform test email to the agent's own address to confirm inbound delivery. 202 when held for HITL.",
+		Description: "Send a platform-originated test email (From: the platform noreply identity) to the agent's own address over the real external SMTP route, to confirm inbound delivery end to end. Returns 202: status=accepted (the message is durably persisted and queued; message_id is the GET-able e2a message id, and the terminal outcome arrives via GET /v1/messages/{id} or the email.sent / email.failed webhook events — provider_message_id appears only after provider submission) or status=pending_review when held for review. Always branch on body.status.",
 		Security:    []map[string][]string{{"bearer": {}}},
 		Responses:   map[string]*huma.Response{"202": accepted202(), "402": s.limitExceededResponse(), "429": s.rateLimitedResponse(), "default": s.errorEnvelopeResponse()},
 	}, s.handleTestSend)
@@ -316,10 +316,12 @@ func (s *Server) handleTestSend(ctx context.Context, in *AddressParam) (*sendOut
 	if derr != nil {
 		return nil, envelopeFromOutboundError(derr)
 	}
-	if res.Held {
-		return &sendOutput{Status: http.StatusAccepted, Body: SendResultView{Status: "pending_review", MessageID: res.PendingMessageID, ApprovalExpiresAt: res.ApprovalExpiresAt}}, nil
-	}
-	return &sendOutput{Status: http.StatusOK, Body: SendResultView{Status: "sent", MessageID: res.MessageID, ProviderMessageID: res.ProviderMessageID, SentAs: res.SentAs, Method: res.Method}}, nil
+	// Same wire mapping as send/reply/forward (outboundResultView): held →
+	// 202 pending_review, queued → 202 accepted (message_id = the durable e2a
+	// msg_ id; provider_message_id arrives only after the worker submits). The
+	// test send is queue-first, so a terminal-synchronous 200 no longer occurs.
+	status, view := outboundResultView(res)
+	return &sendOutput{Status: status, Body: view}, nil
 }
 
 // ReplyRequest mirrors the legacy reply body.

--- a/internal/httpapi/outbound_test.go
+++ b/internal/httpapi/outbound_test.go
@@ -2,8 +2,10 @@ package httpapi
 
 import (
 	"encoding/base64"
+	"strings"
 	"testing"
 
+	"github.com/tokencanopy/e2a/internal/agent"
 	"github.com/tokencanopy/e2a/internal/outbound"
 )
 
@@ -422,11 +424,46 @@ func TestForwardMessageNotFound(t *testing.T) {
 	}
 }
 
-func TestTestSendSent(t *testing.T) {
+// TestTestSendAccepted: the test send is queue-first — the immediate response
+// is 202 status=accepted carrying the durable e2a msg_ id and NO provider id
+// (that arrives later via GET /v1/messages/{id} and email.sent/email.failed).
+func TestTestSendAccepted(t *testing.T) {
 	srv := testServer(t)
 	code, body := postJSON(t, srv.URL+"/v1/agents/support%40acme.com/test", "good", nil)
-	if code != 200 || body["status"] != "sent" || body["message_id"] != "msg_test_1" {
-		t.Fatalf("want 200 sent, got %d %v", code, body)
+	if code != 202 || body["status"] != "accepted" || body["message_id"] != "msg_test_1" {
+		t.Fatalf("want 202 accepted msg_test_1, got %d %v", code, body)
+	}
+	if _, ok := body["provider_message_id"]; ok {
+		t.Fatalf("provider_message_id must be absent before worker submission, got %v", body)
+	}
+}
+
+// TestSendResultViewMessageIDContract pins the SendResultView promise on every
+// outbound outcome shape: message_id is ALWAYS the GET-able e2a msg_ resource
+// id and never the upstream provider id (which belongs exclusively in
+// provider_message_id).
+func TestSendResultViewMessageIDContract(t *testing.T) {
+	providerID := "<0100019-abc-def@email.amazonses.com>"
+	cases := []struct {
+		name string
+		res  *agent.OutboundResult
+	}{
+		{"accepted", &agent.OutboundResult{MessageID: "msg_a1", Status: "accepted", Method: "smtp"}},
+		{"sent", &agent.OutboundResult{MessageID: "msg_a2", ProviderMessageID: providerID, SentAs: "relay", Method: "smtp"}},
+		{"held", &agent.OutboundResult{Held: true, PendingMessageID: "msg_a3"}},
+		{"loopback", &agent.OutboundResult{MessageID: "msg_a4", SentAs: "own_address", Method: "loopback"}},
+	}
+	for _, tc := range cases {
+		_, view := outboundResultView(tc.res)
+		if !strings.HasPrefix(view.MessageID, "msg_") {
+			t.Errorf("%s: message_id = %q, want an e2a msg_ id", tc.name, view.MessageID)
+		}
+		if view.MessageID == providerID || strings.HasPrefix(view.MessageID, "<") {
+			t.Errorf("%s: message_id = %q leaks a provider id", tc.name, view.MessageID)
+		}
+		if view.ProviderMessageID != "" && !strings.HasPrefix(view.MessageID, "msg_") {
+			t.Errorf("%s: provider id present but message_id %q is not a msg_ resource", tc.name, view.MessageID)
+		}
 	}
 }
 

--- a/internal/outbound/platform.go
+++ b/internal/outbound/platform.go
@@ -1,0 +1,109 @@
+package outbound
+
+import (
+	"fmt"
+)
+
+// PlatformDisplayName is the display name on platform-originated mail
+// (From: "e2a" <noreply@<from_domain>>). Matches the historical test-email
+// identity so recipients/agents see the same sender across releases.
+const PlatformDisplayName = "e2a"
+
+// PlatformEnvelopeFrom returns the platform/noreply sender address for a
+// deployment's outbound from-domain. Single source of truth for the
+// "noreply@<from_domain>" identity used by platform-originated messages.
+func PlatformEnvelopeFrom(fromDomain string) string {
+	return fmt.Sprintf("noreply@%s", fromDomain)
+}
+
+// ComposePlatformForAccept composes a PLATFORM-originated outbound message for
+// the async accept path WITHOUT submitting it. Unlike ComposeForAccept, the
+// sender identity is the platform itself — From: "e2a" <noreply@<from_domain>>
+// with a matching envelope MAIL FROM — never an agent, and the agent's own
+// address is NOT stripped from the recipient set. This is what the agent test
+// send (POST /v1/agents/{email}/test) requires: the message must traverse the
+// real external SMTP → inbound route back to the agent's own public address,
+// so both the agent-identity compose (which strips the agent's own address —
+// "no valid recipients") and the local self-send loopback would defeat it.
+//
+// The returned bytes flow through the identical durable pipeline as every
+// other accepted send: the accept-tx persists Raw/EnvelopeFrom/SentAs and the
+// River worker submits via SubmitOnce (which re-attaches the SES config-set
+// header, exactly as with ComposeForAccept output).
+//
+// DKIM: when a key exists for the platform from-domain it is applied, matching
+// what relay-From agent sends do; absent a stored key the message goes out
+// unsigned here and relies on the relay/SES edge signing — the same behavior
+// the legacy synchronous test send had.
+func (s *Sender) ComposePlatformForAccept(req SendRequest) (*ComposeResult, error) {
+	// Normalize and validate all addresses. No self-alias stripping — the
+	// whole point of a platform send is that the agent's own address is a
+	// legitimate external recipient.
+	to, err := normalizeAddrs(req.To)
+	if err != nil {
+		return nil, &ValidationError{Message: fmt.Sprintf("invalid To address: %v", err)}
+	}
+	cc, err := normalizeAddrs(req.CC)
+	if err != nil {
+		return nil, &ValidationError{Message: fmt.Sprintf("invalid CC address: %v", err)}
+	}
+	bcc, err := normalizeAddrs(req.BCC)
+	if err != nil {
+		return nil, &ValidationError{Message: fmt.Sprintf("invalid BCC address: %v", err)}
+	}
+
+	// Dedupe within each field, then cross-field (To > CC > BCC) — mirrors compose().
+	to = dedupe(to)
+	cc = dedupe(cc)
+	bcc = dedupe(bcc)
+	cc = removeAddrs(cc, to)
+	bcc = removeAddrs(bcc, to)
+	bcc = removeAddrs(bcc, cc)
+
+	if len(to) == 0 && len(cc) == 0 {
+		return nil, &ValidationError{Message: "no valid recipients"}
+	}
+
+	envelope := make([]string, 0, len(to)+len(cc)+len(bcc))
+	envelope = append(envelope, to...)
+	envelope = append(envelope, cc...)
+	envelope = append(envelope, bcc...)
+
+	envelopeFrom := PlatformEnvelopeFrom(s.fromDomain)
+	headerFrom := fmt.Sprintf("%q <%s>", PlatformDisplayName, envelopeFrom)
+
+	// Reply-To: platform mail defaults replies to the noreply sender (i.e. no
+	// override) unless the request carries one.
+	replyTo := req.ReplyTo
+
+	var message []byte
+	if len(req.Attachments) > 0 {
+		message, err = ComposeMessageWithAttachments(headerFrom, to, cc, req.Subject, req.Body, req.HTMLBody, req.ReplyToMessageID, req.References, s.fromDomain, replyTo, req.ConversationID, req.Attachments)
+	} else if req.HTMLBody != "" {
+		message, err = ComposeMultipartMessage(headerFrom, to, cc, req.Subject, req.Body, req.HTMLBody, req.ReplyToMessageID, req.References, s.fromDomain, replyTo, req.ConversationID)
+	} else {
+		message, err = ComposeMessage(headerFrom, to, cc, req.Subject, req.Body, "text/plain", req.ReplyToMessageID, req.References, s.fromDomain, replyTo, req.ConversationID)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("compose message: %w", err)
+	}
+
+	// Sign with the platform from-domain key when one exists (same fallback
+	// signing domain relay-From agent sends use); silently unsigned otherwise.
+	if s.dkimLookup != nil {
+		if signed, ok := s.signMessage(message, s.fromDomain); ok {
+			message = signed
+		}
+	}
+
+	return &ComposeResult{
+		EnvelopeFrom: envelopeFrom,
+		Recipients:   envelope,
+		SentAs:       "relay",
+		Method:       "smtp",
+		Raw:          message,
+		To:           to,
+		CC:           cc,
+		BCC:          bcc,
+	}, nil
+}

--- a/internal/outbound/platform_test.go
+++ b/internal/outbound/platform_test.go
@@ -1,0 +1,57 @@
+package outbound
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/tokencanopy/e2a/internal/config"
+)
+
+func platformSender() *Sender {
+	return NewSender(NewSMTPRelay(&config.OutboundSMTPConfig{}), "test.e2a.dev")
+}
+
+// TestComposePlatformForAccept_PlatformIdentity pins the platform-originated
+// sender contract: envelope + header From are noreply@<from_domain> (never an
+// agent identity) and the recipient — even an address that WOULD be a self-send
+// for the owning agent — is preserved on the envelope, not stripped.
+func TestComposePlatformForAccept_PlatformIdentity(t *testing.T) {
+	s := platformSender()
+	comp, err := s.ComposePlatformForAccept(SendRequest{
+		To:             []string{"bot@customer.example.com"},
+		Subject:        "Test email from e2a",
+		Body:           "hello",
+		ConversationID: "conv_abc123",
+	})
+	if err != nil {
+		t.Fatalf("ComposePlatformForAccept: %v", err)
+	}
+	if comp.EnvelopeFrom != "noreply@test.e2a.dev" {
+		t.Errorf("EnvelopeFrom = %q, want noreply@test.e2a.dev", comp.EnvelopeFrom)
+	}
+	if len(comp.Recipients) != 1 || comp.Recipients[0] != "bot@customer.example.com" {
+		t.Errorf("Recipients = %v, want [bot@customer.example.com]", comp.Recipients)
+	}
+	if comp.Method != "smtp" || comp.SentAs != "relay" {
+		t.Errorf("Method/SentAs = %q/%q, want smtp/relay", comp.Method, comp.SentAs)
+	}
+	raw := string(comp.Raw)
+	if !strings.Contains(raw, `From: "e2a" <noreply@test.e2a.dev>`) {
+		t.Errorf("raw From header missing platform identity:\n%s", raw)
+	}
+	if !strings.Contains(raw, "To: bot@customer.example.com") {
+		t.Errorf("raw To header missing the agent recipient:\n%s", raw)
+	}
+	if !strings.Contains(strings.ToLower(raw), "x-e2a-conversation-id: conv_abc123") {
+		t.Errorf("raw missing the conversation thread anchor header:\n%s", raw)
+	}
+}
+
+// TestComposePlatformForAccept_NoRecipients rejects an empty visible-recipient
+// set as a ValidationError (mapped to 400 by callers).
+func TestComposePlatformForAccept_NoRecipients(t *testing.T) {
+	s := platformSender()
+	if _, err := s.ComposePlatformForAccept(SendRequest{Subject: "x", Body: "y"}); !IsValidationError(err) {
+		t.Fatalf("err = %v, want ValidationError for no recipients", err)
+	}
+}

--- a/sdks/python/src/e2a/v1/generated/api/agents_api.py
+++ b/sdks/python/src/e2a/v1/generated/api/agents_api.py
@@ -2009,7 +2009,7 @@ class AgentsApi:
     ) -> SendResultView:
         """Send a test email to the agent's own address
 
-        Send a platform test email to the agent's own address to confirm inbound delivery. 202 when held for HITL.
+        Send a platform-originated test email (From: the platform noreply identity) to the agent's own address over the real external SMTP route, to confirm inbound delivery end to end. Returns 202: status=accepted (the message is durably persisted and queued; message_id is the GET-able e2a message id, and the terminal outcome arrives via GET /v1/messages/{id} or the email.sent / email.failed webhook events — provider_message_id appears only after provider submission) or status=pending_review when held for review. Always branch on body.status.
 
         :param email: The agent's full email address, e.g. support@acme.com. (required)
         :type email: str
@@ -2079,7 +2079,7 @@ class AgentsApi:
     ) -> ApiResponse[SendResultView]:
         """Send a test email to the agent's own address
 
-        Send a platform test email to the agent's own address to confirm inbound delivery. 202 when held for HITL.
+        Send a platform-originated test email (From: the platform noreply identity) to the agent's own address over the real external SMTP route, to confirm inbound delivery end to end. Returns 202: status=accepted (the message is durably persisted and queued; message_id is the GET-able e2a message id, and the terminal outcome arrives via GET /v1/messages/{id} or the email.sent / email.failed webhook events — provider_message_id appears only after provider submission) or status=pending_review when held for review. Always branch on body.status.
 
         :param email: The agent's full email address, e.g. support@acme.com. (required)
         :type email: str
@@ -2149,7 +2149,7 @@ class AgentsApi:
     ) -> RESTResponseType:
         """Send a test email to the agent's own address
 
-        Send a platform test email to the agent's own address to confirm inbound delivery. 202 when held for HITL.
+        Send a platform-originated test email (From: the platform noreply identity) to the agent's own address over the real external SMTP route, to confirm inbound delivery end to end. Returns 202: status=accepted (the message is durably persisted and queued; message_id is the GET-able e2a message id, and the terminal outcome arrives via GET /v1/messages/{id} or the email.sent / email.failed webhook events — provider_message_id appears only after provider submission) or status=pending_review when held for review. Always branch on body.status.
 
         :param email: The agent's full email address, e.g. support@acme.com. (required)
         :type email: str

--- a/sdks/typescript/src/v1/generated/apis/AgentsApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/AgentsApi.ts
@@ -352,7 +352,7 @@ export class AgentsApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
-     * Send a platform test email to the agent\'s own address to confirm inbound delivery. 202 when held for HITL.
+     * Send a platform-originated test email (From: the platform noreply identity) to the agent\'s own address over the real external SMTP route, to confirm inbound delivery end to end. Returns 202: status=accepted (the message is durably persisted and queued; message_id is the GET-able e2a message id, and the terminal outcome arrives via GET /v1/messages/{id} or the email.sent / email.failed webhook events — provider_message_id appears only after provider submission) or status=pending_review when held for review. Always branch on body.status.
      * Send a test email to the agent\'s own address
      * @param email The agent\&#39;s full email address, e.g. support@acme.com.
      */

--- a/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
@@ -659,7 +659,7 @@ export class ObjectAgentsApi {
     }
 
     /**
-     * Send a platform test email to the agent\'s own address to confirm inbound delivery. 202 when held for HITL.
+     * Send a platform-originated test email (From: the platform noreply identity) to the agent\'s own address over the real external SMTP route, to confirm inbound delivery end to end. Returns 202: status=accepted (the message is durably persisted and queued; message_id is the GET-able e2a message id, and the terminal outcome arrives via GET /v1/messages/{id} or the email.sent / email.failed webhook events — provider_message_id appears only after provider submission) or status=pending_review when held for review. Always branch on body.status.
      * Send a test email to the agent\'s own address
      * @param param the request object
      */
@@ -668,7 +668,7 @@ export class ObjectAgentsApi {
     }
 
     /**
-     * Send a platform test email to the agent\'s own address to confirm inbound delivery. 202 when held for HITL.
+     * Send a platform-originated test email (From: the platform noreply identity) to the agent\'s own address over the real external SMTP route, to confirm inbound delivery end to end. Returns 202: status=accepted (the message is durably persisted and queued; message_id is the GET-able e2a message id, and the terminal outcome arrives via GET /v1/messages/{id} or the email.sent / email.failed webhook events — provider_message_id appears only after provider submission) or status=pending_review when held for review. Always branch on body.status.
      * Send a test email to the agent\'s own address
      * @param param the request object
      */

--- a/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
@@ -693,7 +693,7 @@ export class ObservableAgentsApi {
     }
 
     /**
-     * Send a platform test email to the agent\'s own address to confirm inbound delivery. 202 when held for HITL.
+     * Send a platform-originated test email (From: the platform noreply identity) to the agent\'s own address over the real external SMTP route, to confirm inbound delivery end to end. Returns 202: status=accepted (the message is durably persisted and queued; message_id is the GET-able e2a message id, and the terminal outcome arrives via GET /v1/messages/{id} or the email.sent / email.failed webhook events — provider_message_id appears only after provider submission) or status=pending_review when held for review. Always branch on body.status.
      * Send a test email to the agent\'s own address
      * @param email The agent\&#39;s full email address, e.g. support@acme.com.
      */
@@ -718,7 +718,7 @@ export class ObservableAgentsApi {
     }
 
     /**
-     * Send a platform test email to the agent\'s own address to confirm inbound delivery. 202 when held for HITL.
+     * Send a platform-originated test email (From: the platform noreply identity) to the agent\'s own address over the real external SMTP route, to confirm inbound delivery end to end. Returns 202: status=accepted (the message is durably persisted and queued; message_id is the GET-able e2a message id, and the terminal outcome arrives via GET /v1/messages/{id} or the email.sent / email.failed webhook events — provider_message_id appears only after provider submission) or status=pending_review when held for review. Always branch on body.status.
      * Send a test email to the agent\'s own address
      * @param email The agent\&#39;s full email address, e.g. support@acme.com.
      */

--- a/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
@@ -510,7 +510,7 @@ export class PromiseAgentsApi {
     }
 
     /**
-     * Send a platform test email to the agent\'s own address to confirm inbound delivery. 202 when held for HITL.
+     * Send a platform-originated test email (From: the platform noreply identity) to the agent\'s own address over the real external SMTP route, to confirm inbound delivery end to end. Returns 202: status=accepted (the message is durably persisted and queued; message_id is the GET-able e2a message id, and the terminal outcome arrives via GET /v1/messages/{id} or the email.sent / email.failed webhook events — provider_message_id appears only after provider submission) or status=pending_review when held for review. Always branch on body.status.
      * Send a test email to the agent\'s own address
      * @param email The agent\&#39;s full email address, e.g. support@acme.com.
      */
@@ -521,7 +521,7 @@ export class PromiseAgentsApi {
     }
 
     /**
-     * Send a platform test email to the agent\'s own address to confirm inbound delivery. 202 when held for HITL.
+     * Send a platform-originated test email (From: the platform noreply identity) to the agent\'s own address over the real external SMTP route, to confirm inbound delivery end to end. Returns 202: status=accepted (the message is durably persisted and queued; message_id is the GET-able e2a message id, and the terminal outcome arrives via GET /v1/messages/{id} or the email.sent / email.failed webhook events — provider_message_id appears only after provider submission) or status=pending_review when held for review. Always branch on body.status.
      * Send a test email to the agent\'s own address
      * @param email The agent\&#39;s full email address, e.g. support@acme.com.
      */

--- a/web/src/app/(app)/get-started/_components/SuccessPanel.tsx
+++ b/web/src/app/(app)/get-started/_components/SuccessPanel.tsx
@@ -90,7 +90,7 @@ export function SuccessPanel({
               <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
                 <polyline points="20 6 9 17 4 12" />
               </svg>
-              Email is waiting in {agent.email}&apos;s inbox
+              Test email is on its way to {agent.email}
             </button>
             <p className="mt-3 text-sm text-muted text-center">
               Connect your agent below to receive it. It will be the first message that arrives.


### PR DESCRIPTION
## Root cause

`SendTestCore` composed the test email inline and called `smtpRelay.Send` directly: no message row was persisted, the raw SMTP/provider id was returned as `message_id` (violating the SendResultView promise that `message_id` is always a GET-able e2a `msg_` id), and the non-held path bypassed persist-first acceptance, `email.sent`/`email.failed` events, suppression enforcement, metering, and durable status tracking. Additionally, HITL approval (human, magic-link, and TTL auto-approve) of a held test draft rebuilt the SendRequest, matched the self-send predicate (recipient == the agent's own address), and silently released it via **local loopback** — fabricating the inbound copy locally and no longer exercising real inbound delivery at all.

## How real inbound-test semantics are preserved

New `Sender.ComposePlatformForAccept` (internal/outbound/platform.go): a platform-identity compose for the async accept path — From/envelope = `"e2a" <noreply@<from_domain>>`, **no agent self-alias stripping** (the agent's own address is a legitimate external recipient here), same `ComposeResult` shape the River SendWorker submits via `SubmitOnce`. The agent-identity compose could never carry this message (it strips the agent's own address → "no valid recipients"), and loopback would defeat the test — this seam is the smallest abstraction that keeps the real external SMTP → inbound round-trip (req 9).

## Durable pipeline design

`SendTestCore` now: suppression gate (same `checkSuppression` as `DeliverOutbound`) → mint conversation anchor (threads the SMTP-arriving inbound copy) → unchanged block/review screening → `acceptPlatformSend`: compose platform bytes, then in ONE tx `CreateOutboundMessageTx` (type=`test`, `delivery_status='accepted'`, platform `envelope_from`) + `EnqueueSendTx` + `StampSendJobIDTx`; fails closed (500, no inline submit) if the queue is unwired. Response: `202 status=accepted` with the durable `msg_` id and no provider id; the existing SendWorker records `provider_message_id`, flips to `sent`/`failed`, emits `email.sent`/`email.failed`, and meters on success — identical to every other send. Rate limit, quota, and domain-verified checks in the handler are unchanged. `handleTestSend` maps through the shared `outboundResultView` (202 accepted / 202 pending_review; the terminal-synchronous 200 no longer occurs).

**Idempotency-Key**: deliberately NOT added to testAgent in this PR — the endpoint has no request body and a duplicate test send is harmless to third parties (it targets the agent itself). Adding it later via the established `CompleteTx` accept-tx pattern is non-breaking.

## HITL behavior

`approveOutboundAsync` (covers dashboard **and** magic-link approve) and `hitlworker.autoApproveAsync` (TTL auto-approve) now branch on `draft.Type == "test"`: compose via `ComposePlatformForAccept` and enqueue onto QueueOutbound via the existing `ApproveAndAccept`, instead of falling into the self-send loopback path. Reject paths unchanged.

## Files changed

- `internal/outbound/platform.go` (new) + `platform_test.go` (new)
- `internal/agent/api.go` — `SendTestCore` rewrite + new `acceptPlatformSend`
- `internal/agent/hitl_api.go` — platform-test branch in `approveOutboundAsync`
- `internal/hitlworker/worker.go` — platform-test branch in `autoApproveAsync`
- `internal/httpapi/outbound.go` — handler mapping + testAgent op description
- `internal/agent/test_send_async_test.go`, `internal/hitlworker/platform_test_approve_test.go` (new tests)
- `internal/httpapi/outbound_test.go` (202-accepted + SendResultView msg_-id contract tests), `operations_test.go` (stub)
- `api/openapi.yaml` + regenerated SDK bases (`sdks/typescript/src/v1/generated/`, `sdks/python/src/e2a/v1/generated/`) — docstring-only diffs
- `web/src/app/(app)/get-started/_components/SuccessPanel.tsx` — copy tweak ("waiting in inbox" → "on its way"); both dashboard test buttons branch only on `res.ok`, so 202 keeps them working. No MCP tool exposes testAgent.

## Tests / checks run (dedicated DB `e2a_test_testagent` on :5433)

- `internal/outbound`, `internal/outboundsend`: **ok**
- `internal/agent` (full): **ok** — includes new accept/worker-success(email.sent + provider id)/worker-failure(email.failed)/suppressed-422/fail-closed/screening-hold/approve-platform tests; provider capture asserts envelope sender `noreply@…` + agent recipient; loopback asserted unused (no local inbound row)
- `internal/httpapi` (full, incl. `TestSpecGoldenNoDrift` after `make spec`): **ok**
- `internal/identity` (full): **ok**
- `internal/hitlworker` (full, incl. new TTL platform-path test): **ok**
- `internal/e2e` (`-tags integration`): **ok**
- `make spec` + `make spec-check`: **ok**; `make generate-sdk` (Docker): **ok**, docstring-only diffs
- `make test-unit`: all packages ok EXCEPT `internal/relay` — **fails identically on pristine origin/main in this environment** (known pre-existing local flake); `internal/webhook` failed only under parallel package load, passes sequentially on this branch
- NOT run: web Jest suite (no node_modules in the isolated worktree; the web change is copy-only, no test references the old text) and SDK unit tests (generated diffs are docstrings only)

## Expected merge conflicts (sibling GA branches)

- **fix/ga-suppression-hitl-paths**: `internal/agent/hitl_api.go` (my `approveOutboundAsync` compose branch vs their suppression checks — likely adjacent-line conflict) and `internal/hitlworker/worker.go` (`autoApproveAsync` region). Semantic note: their pre-I/O suppression guard in `internal/outboundsend/worker.go` composes with this PR cleanly — my accept-path suppression check uses the same `checkSuppression` gate, and the queued test job flows through their worker guard unchanged.
- **fix/ga-failed-correction-guard**: touches `internal/outboundsend/worker.go` / `terminal_reconcile.go` — this PR does not modify those files; only behavioral interaction is that test messages now traverse that worker (intended).
- **fix/ga-input-bounds**: `internal/agent/api.go` recipient parsing — different regions of the same file; textual conflict unlikely but possible in imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)