### PR TITLE
refactor(env): rename E2A_BASE_URL to E2A_API_URL; split it from the CLI's E2A_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ WebSocket (no public URL needed):
 from e2a.v1 import AsyncE2AClient
 
 async with AsyncE2AClient(api_key="e2a_…") as client:
-    async for notif in client.listen("bot@your-domain.com"):  # falls back to E2A_AGENT_EMAIL
+    async for notif in client.listen("bot@your-domain.com"):
         # notif is lightweight metadata — fetch the body when you want it
         email = await client.messages.get(notif.recipient, notif.message_id)
         await client.messages.reply(notif.recipient, notif.message_id, {"body": "Got it!"})

--- a/README.md
+++ b/README.md
@@ -310,7 +310,8 @@ Three audiences each configure a different surface:
 | Audience | What they configure | Where |
 |---|---|---|
 | **Server operator** — runs the Go backend | DB, signing key, SMTP, OAuth, optional shared domain | `config.yaml` + `E2A_*` env |
-| **CLI / SDK user** — calls the API from their machine | Just the deployment URL (and login) | `E2A_URL` + `e2a login` |
+| **CLI user** — drives an inbox from a terminal | Deployment URL + login | `E2A_URL` + `e2a login` |
+| **SDK / MCP user** — calls `/v1` from code | API host + key | `E2A_API_URL` + `E2A_API_KEY` |
 | **Web dashboard deployer** — hosts the Next.js dashboard | Public site URL + branding | `NEXT_PUBLIC_*` build-time env |
 
 The Go binary runs on any container host; storage is plain Postgres 14+; outbound mail goes through standard SMTP. Most workers coordinate via `SELECT … FOR UPDATE SKIP LOCKED`, so multi-replica is safe — the two real horizontal-scaling caveats are in-memory WebSocket fan-out and per-process rate limits.

--- a/cli/README.md
+++ b/cli/README.md
@@ -87,6 +87,28 @@ e2a config get agent_email
 e2a config set agent_email bot@acme.com
 ```
 
+## Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `E2A_API_KEY` | — | API key. Skips `e2a login` — useful in CI and scripts |
+| `E2A_URL` | `https://e2a.dev` | The e2a deployment root. Set for self-host |
+| `E2A_AGENT_EMAIL` | — | Default sending/listening inbox (what `--agent` overrides) |
+| `E2A_SHARED_DOMAIN` | auto-discovered | Force the shared domain instead of discovering it via `GET /v1/info` |
+
+**Precedence:** command-line flags beat environment variables, which beat
+`~/.e2a/config.json`, which beats the defaults above.
+
+`E2A_URL` is the deployment root — the host that serves the `e2a login` browser
+flow and `/get-started`, and proxies the `/v1` API. It is *not* the SDKs'
+`E2A_API_URL`, which names the API host alone; pointing the CLI at an API host
+breaks `e2a login`. The CLI does not read `E2A_API_URL` or the SDKs' older
+`E2A_BASE_URL`.
+
+Values that come from the environment are **not** written back to
+`~/.e2a/config.json` — so with `E2A_URL` exported, `e2a config set api_url …`
+has no effect until you unset it.
+
 ## Options
 
 - `--help`, `-h` — show help

--- a/cli/src/__tests__/config.test.ts
+++ b/cli/src/__tests__/config.test.ts
@@ -63,24 +63,51 @@ describe("loadConfig", () => {
     expect(config.api_url).toBe("https://custom.dev");
   });
 
-  it("honors the tether env names: E2A_BASE_URL alias and E2A_AGENT_EMAIL", () => {
+  it("honors the tether env name E2A_AGENT_EMAIL", () => {
     vi.mocked(readFileSync).mockImplementation(() => {
       throw new Error("ENOENT");
     });
-    process.env.E2A_BASE_URL = "https://api.selfhost.dev";
     process.env.E2A_AGENT_EMAIL = "tether@agents.e2a.dev";
     try {
-      const config = loadConfig();
-      expect(config.api_url).toBe("https://api.selfhost.dev");
-      expect(config.agent_email).toBe("tether@agents.e2a.dev");
+      expect(loadConfig().agent_email).toBe("tether@agents.e2a.dev");
+    } finally {
+      delete process.env.E2A_AGENT_EMAIL;
+    }
+  });
 
-      // Canonical E2A_URL wins over the alias.
-      process.env.E2A_URL = "https://canonical.dev";
-      expect(loadConfig().api_url).toBe("https://canonical.dev");
+  // api_url is the deployment root: `login` opens a browser against it and
+  // points at /get-started, both served by the web front (which proxies /v1).
+  // E2A_BASE_URL names the API host alone, so honouring it here silently
+  // repointed the CLI at the API host and broke `e2a login`.
+  it("ignores E2A_BASE_URL and warns that it is not the CLI's var", () => {
+    vi.mocked(readFileSync).mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    const warn = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    process.env.E2A_BASE_URL = "https://api.selfhost.dev";
+    try {
+      expect(loadConfig().api_url).toBe("https://e2a.dev");
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("E2A_BASE_URL is set"));
     } finally {
       delete process.env.E2A_BASE_URL;
-      delete process.env.E2A_AGENT_EMAIL;
+      warn.mockRestore();
+    }
+  });
+
+  it("stays quiet about E2A_BASE_URL when the CLI is pointed somewhere explicitly", () => {
+    vi.mocked(readFileSync).mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    const warn = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    process.env.E2A_BASE_URL = "https://api.selfhost.dev";
+    process.env.E2A_URL = "https://canonical.dev";
+    try {
+      expect(loadConfig().api_url).toBe("https://canonical.dev");
+      expect(warn).not.toHaveBeenCalled();
+    } finally {
+      delete process.env.E2A_BASE_URL;
       delete process.env.E2A_URL;
+      warn.mockRestore();
     }
   });
 });

--- a/cli/src/__tests__/config.test.ts
+++ b/cli/src/__tests__/config.test.ts
@@ -23,11 +23,13 @@ describe("loadConfig", () => {
     vi.mocked(readFileSync).mockReset();
     delete process.env.E2A_API_KEY;
     delete process.env.E2A_URL;
+    delete process.env.E2A_BASE_URL;
   });
 
   afterEach(() => {
     delete process.env.E2A_API_KEY;
     delete process.env.E2A_URL;
+    delete process.env.E2A_BASE_URL;
   });
 
   it("returns defaults when no config file exists", () => {
@@ -107,6 +109,28 @@ describe("loadConfig", () => {
     } finally {
       delete process.env.E2A_BASE_URL;
       delete process.env.E2A_URL;
+      warn.mockRestore();
+    }
+  });
+
+  // Regression: E2A_BASE_URL used to override ~/.e2a/config.json. A user with a
+  // stored host (from `e2a login`) and a legacy env override now silently keeps
+  // the stored host. The warning must still fire — gating it on "resolved ==
+  // default" would miss exactly this case — and must name the host in use.
+  it("warns about ignored E2A_BASE_URL even when a non-default api_url is stored", () => {
+    vi.mocked(readFileSync).mockReturnValue(
+      JSON.stringify({ api_key: "e2a_stored", api_url: "https://stored.selfhost.dev" }),
+    );
+    const warn = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    process.env.E2A_BASE_URL = "https://other.selfhost.dev";
+    try {
+      // Stored host wins (env E2A_BASE_URL is not an alias) — the silent part.
+      expect(loadConfig().api_url).toBe("https://stored.selfhost.dev");
+      // …but it is no longer silent, and the message names the host actually used.
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("E2A_BASE_URL is set"));
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("https://stored.selfhost.dev"));
+    } finally {
+      delete process.env.E2A_BASE_URL;
       warn.mockRestore();
     }
   });

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -52,15 +52,32 @@ export function loadConfig(): Config {
     // No config file yet
   }
 
-  // Env vars override file. E2A_BASE_URL is accepted as an alias for E2A_URL
-  // and E2A_AGENT_EMAIL selects the inbox — these are the exact names the
-  // tether harness trains users to export, so ignoring them is a silent trap
-  // for the CLI's primary scripting consumer. E2A_URL wins over the alias.
+  // Env vars override file. E2A_AGENT_EMAIL selects the inbox — the exact name
+  // the tether harness trains users to export, so ignoring it is a silent trap
+  // for the CLI's primary scripting consumer.
+  //
+  // E2A_BASE_URL is deliberately NOT read here. api_url is the deployment root
+  // (login opens a browser against it and points at /get-started, both served
+  // by the web front, which proxies /v1 through), whereas E2A_BASE_URL/
+  // E2A_API_URL name the API host alone. Accepting it as an alias meant that
+  // exporting E2A_BASE_URL=https://api.e2a.dev to configure an SDK silently
+  // repointed the CLI at the API host and broke `e2a login`.
   if (process.env.E2A_API_KEY) config.api_key = process.env.E2A_API_KEY;
   if (process.env.E2A_URL) config.api_url = process.env.E2A_URL;
-  else if (process.env.E2A_BASE_URL) config.api_url = process.env.E2A_BASE_URL;
   if (process.env.E2A_AGENT_EMAIL) config.agent_email = process.env.E2A_AGENT_EMAIL;
   if (process.env.E2A_SHARED_DOMAIN) config.shared_domain = process.env.E2A_SHARED_DOMAIN;
+
+  // Someone who set E2A_BASE_URL expecting it to steer the CLI (it used to)
+  // would otherwise silently talk to the default host — i.e. a self-hoster
+  // hitting production. Say so, but only when we actually fell through to the
+  // default: an SDK user who ALSO configured the CLI properly gets no noise.
+  if (!process.env.E2A_URL && process.env.E2A_BASE_URL && config.api_url === DEFAULT_URL) {
+    process.stderr.write(
+      `e2a: E2A_BASE_URL is set but the CLI does not read it — that name configures the SDKs.\n` +
+        `     The CLI uses E2A_URL for the deployment root and is defaulting to ${DEFAULT_URL}.\n` +
+        `     Set E2A_URL to point it at a self-hosted deployment.\n`,
+    );
+  }
 
   return config;
 }

--- a/cli/src/config.ts
+++ b/cli/src/config.ts
@@ -68,13 +68,16 @@ export function loadConfig(): Config {
   if (process.env.E2A_SHARED_DOMAIN) config.shared_domain = process.env.E2A_SHARED_DOMAIN;
 
   // Someone who set E2A_BASE_URL expecting it to steer the CLI (it used to)
-  // would otherwise silently talk to the default host — i.e. a self-hoster
-  // hitting production. Say so, but only when we actually fell through to the
-  // default: an SDK user who ALSO configured the CLI properly gets no noise.
-  if (!process.env.E2A_URL && process.env.E2A_BASE_URL && config.api_url === DEFAULT_URL) {
+  // would otherwise be ignored silently. Warn whenever it's set without the
+  // canonical E2A_URL — the CLI then resolves to either its default OR a host
+  // stored by `e2a login`, and neither is what E2A_BASE_URL asked for. It used
+  // to override the stored config, so a user with stored host A and legacy
+  // env host B now silently gets A. Show the host actually in use so that
+  // mismatch is visible rather than hidden.
+  if (!process.env.E2A_URL && process.env.E2A_BASE_URL) {
     process.stderr.write(
       `e2a: E2A_BASE_URL is set but the CLI does not read it — that name configures the SDKs.\n` +
-        `     The CLI uses E2A_URL for the deployment root and is defaulting to ${DEFAULT_URL}.\n` +
+        `     The CLI uses E2A_URL for the deployment root and is talking to ${config.api_url}.\n` +
         `     Set E2A_URL to point it at a self-hosted deployment.\n`,
     );
   }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -145,8 +145,8 @@ services:
     ports:
       - "8765:3000"
     environment:
-      # e2a backend reachable from inside the compose network.
-      E2A_URL: "http://e2a:8080"
+      # e2a API reachable from inside the compose network.
+      E2A_API_URL: "http://e2a:8080"
       # Allow loopback Host headers so Claude Code (which calls via
       # http://localhost:8765) doesn't trip the DNS-rebinding guard.
       MCP_ALLOWED_HOSTS: "localhost,127.0.0.1"
@@ -156,7 +156,7 @@ services:
       MCP_PUBLIC_URL: "http://localhost:8765"
       # Container-internal baseUrl ≠ host-reachable AS URL. The MCP
       # server forwards bearers via the compose-network hostname
-      # (E2A_URL above) but Claude Code runs on the host and
+      # (E2A_API_URL above) but Claude Code runs on the host and
       # must reach the AS through the same web frontend that serves
       # the consent UI. :3000 is the host-mapped web container, which
       # proxies /api/oauth/* back to the e2a backend via Caddy. This

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -64,9 +64,19 @@ The CLI hits `GET /v1/info` on login and caches `shared_domain` to `~/.e2a/confi
 
 | Variable | Description |
 |---|---|
-| `E2A_URL` | CLI base URL (default `https://e2a.dev`) — the unified host that serves the `e2a login` browser flow and proxies the `/v1` API |
+| `E2A_URL` | **CLI** base URL (default `https://e2a.dev`) — the unified host that serves the `e2a login` browser flow and proxies the `/v1` API |
+| `E2A_API_URL` | **SDK/MCP** base URL (default `https://api.e2a.dev`) — the `/v1` API host alone |
 | `E2A_API_KEY` | Bypass `e2a login` — useful in CI |
 | `E2A_SHARED_DOMAIN` | Force the shared domain instead of auto-discovering it |
+
+`E2A_URL` and `E2A_API_URL` are deliberately separate: the CLI opens browser
+pages (the login flow, `/get-started`) that only the web front serves, so it
+needs the deployment root, while the SDKs and the MCP server only ever call
+`/v1` and want the API host. Pointing the CLI at an API host breaks `e2a login`.
+On a single-host deployment both can be the same URL. Setting `E2A_API_URL` for
+an SDK also tells a **server** running on that host what its own externally
+visible API base is (it is the OAuth issuer) — keep that in mind if you run a
+server and point an SDK at a *different* deployment from the same environment.
 
 The TypeScript and Python SDKs follow the same pattern: pass `baseUrl` (or `base_url`) once and call `E2AApi.fetchInfo()` if you need the deployment's shared domain in your own code.
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -5,7 +5,8 @@ There are three audiences who configure something — and confusing them is the 
 | Audience | What they configure | Where |
 |---|---|---|
 | **Server operator** — runs the Go backend | DB, signing key, SMTP, OAuth, optional shared domain | `config.yaml` + `E2A_*` env |
-| **CLI / SDK user** — calls the API from their machine | Just the deployment URL (and login) | `E2A_URL` + `e2a login` |
+| **CLI user** — drives an inbox from a terminal | Deployment URL + login | `E2A_URL` + `e2a login` |
+| **SDK / MCP user** — calls `/v1` from code | API host + key | `E2A_API_URL` + `E2A_API_KEY` |
 | **Web dashboard deployer** — hosts the Next.js dashboard | Public site URL + branding | `NEXT_PUBLIC_*` build-time env |
 
 ## Server operator
@@ -51,9 +52,9 @@ The shared domain needs a row in the `domains` table — it's the FK target for 
 
 If you leave `shared_domain` empty, slug registration is disabled and every agent must use a custom domain the user verifies — no DNS setup required from you.
 
-## CLI / SDK user
+## CLI user
 
-End-users only need to know the deployment URL — the rest is auto-discovered.
+The CLI only needs the deployment URL — the rest is auto-discovered.
 
 ```bash
 export E2A_URL=https://e2a.example.com   # default: https://e2a.dev
@@ -64,19 +65,41 @@ The CLI hits `GET /v1/info` on login and caches `shared_domain` to `~/.e2a/confi
 
 | Variable | Description |
 |---|---|
-| `E2A_URL` | **CLI** base URL (default `https://e2a.dev`) — the unified host that serves the `e2a login` browser flow and proxies the `/v1` API |
-| `E2A_API_URL` | **SDK/MCP** base URL (default `https://api.e2a.dev`) — the `/v1` API host alone |
+| `E2A_URL` | CLI base URL (default `https://e2a.dev`) — the deployment root that serves the `e2a login` browser flow and proxies the `/v1` API |
 | `E2A_API_KEY` | Bypass `e2a login` — useful in CI |
 | `E2A_SHARED_DOMAIN` | Force the shared domain instead of auto-discovering it |
+
+The CLI does **not** read `E2A_API_URL` (the SDK var below). It uses `E2A_URL` and defaults to `https://e2a.dev`, so a self-hoster who only exports `E2A_API_URL` leaves the CLI pointed at production.
+
+## SDK / MCP user
+
+The SDKs and the MCP server only ever call `/v1`, so they take the **API host** — not the CLI's deployment root:
+
+```bash
+export E2A_API_URL=https://api.e2a.example.com   # default: https://api.e2a.dev
+export E2A_API_KEY=e2a_…
+```
+
+```ts
+// env is only the fallback — you can pass it directly instead
+const client = new E2AClient({ baseUrl: "https://api.e2a.example.com", apiKey: "e2a_…" });
+```
+
+| Variable | Description |
+|---|---|
+| `E2A_API_URL` | SDK + MCP base URL (default `https://api.e2a.dev`) — the `/v1` API host alone. `E2A_BASE_URL` is the SDKs' former name for it, still read with a deprecation warning. |
+| `E2A_API_KEY` | The API key the SDK / MCP authenticates with |
 
 `E2A_URL` and `E2A_API_URL` are deliberately separate: the CLI opens browser
 pages (the login flow, `/get-started`) that only the web front serves, so it
 needs the deployment root, while the SDKs and the MCP server only ever call
-`/v1` and want the API host. Pointing the CLI at an API host breaks `e2a login`.
-On a single-host deployment both can be the same URL. Setting `E2A_API_URL` for
-an SDK also tells a **server** running on that host what its own externally
-visible API base is (it is the OAuth issuer) — keep that in mind if you run a
-server and point an SDK at a *different* deployment from the same environment.
+`/v1` and want the API host. **Pointing the CLI at an API host breaks
+`e2a login`; pointing an SDK at the deployment root only works if that host
+also proxies `/v1`.** On a single-host deployment both can be the same URL.
+Setting `E2A_API_URL` for an SDK also tells a **server** running on that host
+what its own externally visible API base is (it is the OAuth issuer) — keep
+that in mind if you run a server and point an SDK at a *different* deployment
+from the same environment.
 
 The TypeScript and Python SDKs follow the same pattern: pass `baseUrl` (or `base_url`) once and call `E2AApi.fetchInfo()` if you need the deployment's shared domain in your own code.
 

--- a/mcp/src/bin/http.ts
+++ b/mcp/src/bin/http.ts
@@ -61,29 +61,31 @@ function parseHostList(raw: string, def: string): string[] {
   return list;
 }
 
-// resolveBaseUrl picks the deployment URL the HTTP MCP server talks
-// to. Canonical is E2A_URL (matches the CLI + SDK docs); E2A_BASE_URL
-// is the legacy name this binary shipped with — still accepted so
-// existing deployment manifests keep working, with a one-shot stderr
-// deprecation note.
+// resolveBaseUrl picks the API host this server talks to. Canonical is
+// E2A_API_URL — the same concept the backend names with E2A_API_URL (its
+// externally visible API base) and the SDKs read. This server is a pure API
+// client, so it wants the API host, NOT the deployment root that the CLI's
+// E2A_URL points at (that one also serves the dashboard).
+//
+// E2A_URL and E2A_BASE_URL are both legacy names this binary has shipped with;
+// still accepted so existing deployment manifests keep working, with a stderr
+// deprecation note. main() calls loadConfig exactly once, so the note is emitted
+// once per process without needing a module-level guard to dedupe it.
 function resolveBaseUrl(env: NodeJS.ProcessEnv): string {
-  const canonical = env.E2A_URL;
-  const legacy = env.E2A_BASE_URL;
+  const canonical = env.E2A_API_URL;
   if (canonical) return canonical;
-  if (legacy) {
-    if (!resolveBaseUrl.warned) {
-      logJson(
-        "WARNING",
-        "e2a_base_url_deprecated",
-        "E2A_BASE_URL is deprecated; rename it to E2A_URL (both names work today).",
-      );
-      resolveBaseUrl.warned = true;
-    }
-    return legacy;
+  for (const legacy of ["E2A_URL", "E2A_BASE_URL"] as const) {
+    const v = env[legacy];
+    if (!v) continue;
+    logJson(
+      "WARNING",
+      "e2a_api_url_legacy_name",
+      `${legacy} is deprecated; rename it to E2A_API_URL (the old names still work today).`,
+    );
+    return v;
   }
-  return "https://e2a.dev";
+  return "https://api.e2a.dev";
 }
-resolveBaseUrl.warned = false;
 
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): BinConfig {
   return {

--- a/mcp/tests/bin-http.test.ts
+++ b/mcp/tests/bin-http.test.ts
@@ -6,49 +6,55 @@ describe("bin/http loadConfig", () => {
     const cfg = loadConfig({});
     expect(cfg).toEqual({
       port: 3000,
-      baseUrl: "https://e2a.dev",
+      // This server is a pure API client, so it defaults to the API host —
+      // not the deployment root the CLI's E2A_URL points at.
+      baseUrl: "https://api.e2a.dev",
       allowedHosts: ["api.e2a.dev"],
       sessionIdleMs: 5 * 60_000,
       maxSessions: 500,
     });
   });
 
-  it("parses valid values (canonical E2A_URL)", () => {
+  it("parses valid values (canonical E2A_API_URL)", () => {
     const cfg = loadConfig({
       PORT: "8080",
-      E2A_URL: "https://staging.e2a.dev",
+      E2A_API_URL: "https://api.staging.e2a.dev",
       MCP_ALLOWED_HOSTS: "api.e2a.dev,mcp-staging.e2a.dev",
       MCP_SESSION_IDLE_MS: "60000",
       MCP_MAX_SESSIONS: "100",
     });
     expect(cfg).toEqual({
       port: 8080,
-      baseUrl: "https://staging.e2a.dev",
+      baseUrl: "https://api.staging.e2a.dev",
       allowedHosts: ["api.e2a.dev", "mcp-staging.e2a.dev"],
       sessionIdleMs: 60_000,
       maxSessions: 100,
     });
   });
 
-  it("falls back to E2A_BASE_URL when E2A_URL is unset (structured deprecation log)", () => {
-    const lines: string[] = [];
-    const warn = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
-      lines.push(String(chunk));
-      return true;
-    });
-    const cfg = loadConfig({ E2A_BASE_URL: "https://legacy.example.com" });
-    expect(cfg.baseUrl).toBe("https://legacy.example.com");
-    // The deprecation notice is emitted as one structured JSON line that
-    // Cloud Logging can parse — severity + event + a human-readable message.
-    const entry = JSON.parse(lines.at(-1)!);
-    expect(entry).toMatchObject({ severity: "WARNING", event: "e2a_base_url_deprecated" });
-    expect(typeof entry.message).toBe("string");
-    warn.mockRestore();
-  });
+  it.each([["E2A_URL"], ["E2A_BASE_URL"]])(
+    "falls back to %s when E2A_API_URL is unset (structured deprecation log)",
+    (legacy) => {
+      const lines: string[] = [];
+      const warn = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+        lines.push(String(chunk));
+        return true;
+      });
+      const cfg = loadConfig({ [legacy]: "https://legacy.example.com" });
+      expect(cfg.baseUrl).toBe("https://legacy.example.com");
+      // The deprecation notice is emitted as one structured JSON line that
+      // Cloud Logging can parse — severity + event + a human-readable message.
+      const entry = JSON.parse(lines.at(-1)!);
+      expect(entry).toMatchObject({ severity: "WARNING", event: "e2a_api_url_legacy_name" });
+      expect(entry.message).toContain(legacy);
+      warn.mockRestore();
+    },
+  );
 
-  it("prefers canonical E2A_URL when both are set", () => {
+  it("prefers canonical E2A_API_URL over both legacy names", () => {
     const cfg = loadConfig({
-      E2A_URL: "https://canonical.example.com",
+      E2A_API_URL: "https://canonical.example.com",
+      E2A_URL: "https://deployment-root.example.com",
       E2A_BASE_URL: "https://legacy.example.com",
     });
     expect(cfg.baseUrl).toBe("https://canonical.example.com");

--- a/plugins/e2a/skills/tether/SKILL.md
+++ b/plugins/e2a/skills/tether/SKILL.md
@@ -240,7 +240,7 @@ lands.
 |---|---|---|
 | `E2A_TETHER_POLL_INTERVAL` | `20` (s) | fallback poll cadence when the WS wait is unavailable |
 | `E2A_TETHER_ASK_TIMEOUT` | `1800` (s) | how long `ask` blocks for an answer before giving up |
-| `E2A_BASE_URL` | `https://api.e2a.dev` | API base (set for self-host) |
+| `E2A_URL` | `https://e2a.dev` | e2a deployment root (set for self-host) |
 | `E2A_CLI` | (auto) | override the e2a CLI invocation (e.g. `node /repo/cli/dist/bin/e2a.js`) |
 
 The only thing that costs a turn per tick is a `/loop` **heartbeat** (tier 2

--- a/plugins/e2a/skills/tether/lib.sh
+++ b/plugins/e2a/skills/tether/lib.sh
@@ -15,7 +15,7 @@
 t_load_config() {
   # Explicit env vars win; each fallback source fills only the vars still missing
   # (so exporting just E2A_API_KEY in the env doesn't skip an email set in the file).
-  local envk="${E2A_API_KEY:-}" enve="${E2A_AGENT_EMAIL:-}" envu="${E2A_BASE_URL:-}"
+  local envk="${E2A_API_KEY:-}" enve="${E2A_AGENT_EMAIL:-}" envu="${E2A_URL:-${E2A_BASE_URL:-}}"
 
   # 1) explicit tether config
   if { [ -z "${E2A_API_KEY:-}" ] || [ -z "${E2A_AGENT_EMAIL:-}" ]; } && [ -f "${HOME}/.e2a-tether.env" ]; then
@@ -29,13 +29,23 @@ try:
   d=json.load(open(os.path.expanduser("~/.e2a/config.json")))
   if d.get("api_key"):     print("export E2A_API_KEY="+shlex.quote(d["api_key"]))
   if d.get("agent_email"): print("export E2A_AGENT_EMAIL="+shlex.quote(d["agent_email"]))
-  if d.get("api_url"):     print("export E2A_BASE_URL="+shlex.quote(d["api_url"].rstrip("/")))
+  if d.get("api_url"):     print("export E2A_URL="+shlex.quote(d["api_url"].rstrip("/")))
 except Exception:pass')"
   fi
+  # A ~/.e2a-tether.env written before the rename still says E2A_BASE_URL. Carry
+  # it over rather than silently falling back to the default host (which would
+  # point a self-hoster at production), then drop the stale name so the CLI —
+  # which no longer reads it — doesn't warn about a var tether already handled.
+  if [ -z "${E2A_URL:-}" ] && [ -n "${E2A_BASE_URL:-}" ]; then
+    E2A_URL="$E2A_BASE_URL"
+    echo "tether: E2A_BASE_URL is deprecated — rename it to E2A_URL in ~/.e2a-tether.env" >&2
+  fi
+  unset E2A_BASE_URL
+
   # explicit env always wins over whatever a fallback source supplied
   [ -n "$envk" ] && E2A_API_KEY="$envk"
   [ -n "$enve" ] && E2A_AGENT_EMAIL="$enve"
-  [ -n "$envu" ] && E2A_BASE_URL="$envu"
+  [ -n "$envu" ] && E2A_URL="$envu"
 
   # Treat the copied-but-unfilled tether.env.example placeholders as unset, so a
   # user who ran `cp … tether.env.example` without editing gets `config: MISSING`
@@ -48,7 +58,11 @@ except Exception:pass')"
   # EXPORTED: the transport is a child process (the e2a CLI). An unexported
   # default here would leave the CLI on its own default host while status
   # reports this one — a silent split-brain once the hosts diverge.
-  export E2A_BASE_URL="${E2A_BASE_URL:-https://api.e2a.dev}"
+  #
+  # E2A_URL is the CLI's deployment root (it serves the dashboard and proxies
+  # /v1), NOT the API host — so this default tracks the CLI's own default
+  # rather than forcing api.e2a.dev on it as the old E2A_BASE_URL name did.
+  export E2A_URL="${E2A_URL:-https://e2a.dev}"
   [ -n "${E2A_API_KEY:-}" ] && [ -n "${E2A_AGENT_EMAIL:-}" ]
 }
 
@@ -254,7 +268,7 @@ except Exception:print(2147483647)' "$exp"
 # non-"sent" status — accepted but NOT delivered) / 5 permanent request error /
 # 4 auth / 1 transient. These wrappers map it onto tether's internal codes
 # (0 ok, 2 held, 3 anchor-not-repliable) so tether.sh stays unchanged above.
-# The CLI reads E2A_API_KEY / E2A_AGENT_EMAIL / E2A_BASE_URL straight from the
+# The CLI reads E2A_API_KEY / E2A_AGENT_EMAIL / E2A_URL straight from the
 # environment t_load_config resolves — no flag plumbing needed.
 
 # t_api_send <to> <subject> <body> <conversation_id> → prints message_id;

--- a/plugins/e2a/skills/tether/tether.env.example
+++ b/plugins/e2a/skills/tether/tether.env.example
@@ -7,7 +7,7 @@ export E2A_API_KEY="e2a_agt_..."             # agent-scoped e2a API key
 export E2A_AGENT_EMAIL="tether@you.example"   # the sending/receiving agent (protection/HITL OFF)
 
 # Optional
-export E2A_BASE_URL="https://api.e2a.dev"       # self-host: your API base
+export E2A_URL="https://e2a.dev"                # self-host: your e2a deployment root
 export E2A_TETHER_POLL_INTERVAL="20"            # fallback poll cadence (WS wait is primary)
 export E2A_TETHER_ASK_TIMEOUT="1800"            # seconds `ask` blocks for an answer
 # export E2A_CLI="node /path/to/cli/dist/bin/e2a.js"  # override the e2a CLI (default: PATH, then npx)

--- a/plugins/e2a/skills/tether/tether.sh
+++ b/plugins/e2a/skills/tether/tether.sh
@@ -376,7 +376,7 @@ except Exception:print("")')"
       { echo "# written by tether.sh setup — $(t_now_iso)"
         echo "export E2A_API_KEY=\"${agtkey}\""
         echo "export E2A_AGENT_EMAIL=\"${inbox}\""
-        [ -n "${E2A_BASE_URL:-}" ] && echo "export E2A_BASE_URL=\"${E2A_BASE_URL}\""
+        [ -n "${E2A_URL:-}" ] && echo "export E2A_URL=\"${E2A_URL}\""
       } > "$envf"
     )
     chmod 600 "$envf" 2>/dev/null || true
@@ -387,7 +387,7 @@ except Exception:print("")')"
     ;;
 
   status)
-    if t_load_config; then echo "config: OK (agent ${E2A_AGENT_EMAIL}, base ${E2A_BASE_URL})"; else echo "config: MISSING"; fi
+    if t_load_config; then echo "config: OK (agent ${E2A_AGENT_EMAIL}, base ${E2A_URL})"; else echo "config: MISSING"; fi
     echo "cli:    $(t_cli_desc)"
     if [ "$(t_state_get armed)" = "1" ]; then
       echo "armed:  yes"

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -172,8 +172,9 @@ re-implemented), so the two surfaces are identical by construction.
 
 `E2AClient` (sync) takes exactly the same arguments.
 
-`api_key` falls back to `E2A_API_KEY`; `base_url` to `E2A_BASE_URL` then
-`https://api.e2a.dev`. `timeout_ms` is the per-request timeout (default 30s); a
+`api_key` falls back to `E2A_API_KEY`; `base_url` to `E2A_API_URL` then
+`https://api.e2a.dev`. (`E2A_BASE_URL` is the SDK's former name for
+`E2A_API_URL` — still read, with a `DeprecationWarning`.) `timeout_ms` is the per-request timeout (default 30s); a
 timed-out request retries like any other connection failure. Passing
 `timeout_ms=0` or `None` removes the SDK's override and falls back to the HTTP
 transport's built-in **300s** ceiling — it does **not** make requests unbounded
@@ -244,7 +245,7 @@ await client.messages.restore("bot@agents.e2a.dev", "msg_abc123")
 ## WebSocket (real-time delivery for local agents)
 
 ```python
-async for event in client.listen("bot@agents.e2a.dev"):  # falls back to E2A_AGENT_EMAIL
+async for event in client.listen("bot@agents.e2a.dev"):
     if event.type != "email.received":
         continue  # tolerate future event kinds
     data = event.data

--- a/sdks/python/src/e2a/v1/client.py
+++ b/sdks/python/src/e2a/v1/client.py
@@ -10,6 +10,7 @@ lists as an :class:`~e2a.v1.pagination.AutoPager`. Async-only.
 from __future__ import annotations
 
 import os
+import warnings
 from typing import Any, Awaitable, Callable, List, Optional, Protocol, Sequence, Type, TypeVar, Union
 
 from pydantic import ValidationError
@@ -119,6 +120,28 @@ def _env(name: str) -> Optional[str]:
     return v or None
 
 
+def _resolve_base_url() -> Optional[str]:
+    """Read the API host from the environment.
+
+    Canonical is ``E2A_API_URL`` — the same concept the server names with
+    ``E2A_API_URL`` (its externally visible API base). ``E2A_BASE_URL`` is the
+    name the SDKs shipped with; still honoured so published integrations keep
+    working, with a deprecation warning.
+    """
+    canonical = _env("E2A_API_URL")
+    if canonical:
+        return canonical
+    legacy = _env("E2A_BASE_URL")
+    if legacy:
+        warnings.warn(
+            "E2A_BASE_URL is deprecated — rename it to E2A_API_URL. "
+            "The old name still works for now but will be dropped.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+    return legacy
+
+
 def _coerce(model_cls: Type[T], body: Optional[Body]) -> T:
     if body is None:
         return model_cls()  # type: ignore[call-arg]
@@ -173,7 +196,7 @@ class AsyncE2AClient:
                 retryable=False,
             )
         self._api_key = key
-        self._base_url = base_url or _env("E2A_BASE_URL") or DEFAULT_BASE_URL
+        self._base_url = base_url or _resolve_base_url() or DEFAULT_BASE_URL
         self._cfg = _retry_config or RetryConfig(
             max_retries=max_retries, max_elapsed_ms=max_elapsed_ms
         )

--- a/sdks/python/tests/test_v1_client.py
+++ b/sdks/python/tests/test_v1_client.py
@@ -135,7 +135,7 @@ def _valid(model_cls, **overrides):
 
 @pytest.fixture(autouse=True)
 def _clear_env(monkeypatch):
-    for v in ("E2A_API_KEY", "E2A_BASE_URL", "E2A_AGENT_EMAIL"):
+    for v in ("E2A_API_KEY", "E2A_API_URL", "E2A_BASE_URL", "E2A_AGENT_EMAIL"):
         monkeypatch.delenv(v, raising=False)
 
 
@@ -154,6 +154,36 @@ def _client():
 def test_requires_api_key():
     with pytest.raises(E2AError, match="api_key is required"):
         AsyncE2AClient(base_url=BASE)
+
+
+# Base-URL resolution: base_url= > E2A_API_URL > E2A_BASE_URL (deprecated) >
+# the api.e2a.dev default. Mirrors the TypeScript SDK's suite.
+
+def test_base_url_defaults_to_api_host():
+    assert AsyncE2AClient(api_key="e2a_test")._base_url == "https://api.e2a.dev"
+
+
+def test_base_url_reads_e2a_api_url(monkeypatch):
+    monkeypatch.setenv("E2A_API_URL", "https://api.self-host.example")
+    assert AsyncE2AClient(api_key="e2a_test")._base_url == "https://api.self-host.example"
+
+
+def test_base_url_honours_deprecated_e2a_base_url(monkeypatch):
+    monkeypatch.setenv("E2A_BASE_URL", "https://legacy.example")
+    with pytest.warns(DeprecationWarning, match="E2A_BASE_URL is deprecated"):
+        client = AsyncE2AClient(api_key="e2a_test")
+    assert client._base_url == "https://legacy.example"
+
+
+def test_base_url_prefers_canonical_over_deprecated(monkeypatch):
+    monkeypatch.setenv("E2A_API_URL", "https://canonical.example")
+    monkeypatch.setenv("E2A_BASE_URL", "https://legacy.example")
+    assert AsyncE2AClient(api_key="e2a_test")._base_url == "https://canonical.example"
+
+
+def test_explicit_base_url_beats_env(monkeypatch):
+    monkeypatch.setenv("E2A_API_URL", "https://api.self-host.example")
+    assert AsyncE2AClient(api_key="e2a_test", base_url=BASE)._base_url == BASE
 
 
 def test_resources_exposed():

--- a/sdks/python/tests/test_v1_sync_client.py
+++ b/sdks/python/tests/test_v1_sync_client.py
@@ -36,7 +36,7 @@ BASE = "http://test.local"
 
 @pytest.fixture(autouse=True)
 def _clear_env(monkeypatch):
-    for v in ("E2A_API_KEY", "E2A_BASE_URL", "E2A_AGENT_EMAIL"):
+    for v in ("E2A_API_KEY", "E2A_API_URL", "E2A_BASE_URL", "E2A_AGENT_EMAIL"):
         monkeypatch.delenv(v, raising=False)
 
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -133,10 +133,14 @@ argument.
 | Option         | Type     | Default                 | Description                              |
 |----------------|----------|-------------------------|------------------------------------------|
 | `apiKey`       | `string` | `E2A_API_KEY` env       | Account (`e2a_acct_`) or agent key/token |
-| `baseUrl`      | `string` | `https://api.e2a.dev`   | API base URL (override for self-host)    |
+| `baseUrl`      | `string` | `E2A_API_URL` env, else `https://api.e2a.dev` | API base URL (override for self-host)    |
 | `maxRetries`   | `number` | `2`                     | Retries on 429/5xx/connection            |
 | `maxElapsedMs` | `number` | —                       | Optional total deadline across attempts  |
 | `timeoutMs`    | `number` | `30000`                 | Per-attempt request timeout (see below)  |
+
+`baseUrl` names the **API host**, not the deployment root the CLI's `E2A_URL`
+points at (that one also serves the dashboard). `E2A_BASE_URL` is this SDK's
+former name for `E2A_API_URL` — still read, with a deprecation warning.
 
 `timeoutMs` bounds each individual attempt; a timed-out attempt is treated as a
 retryable connection failure, so it composes with `maxRetries`/`maxElapsedMs`.
@@ -187,7 +191,7 @@ for await (const event of client.listen("bot@agents.e2a.dev")) {
 }
 ```
 
-`client.listen(address)` (address falls back to `E2A_AGENT_EMAIL`) returns a
+`client.listen(address)` returns a
 `WSStream` that is **both** an `AsyncIterable<WSEvent>` and an
 `EventEmitter` — each item is the same versioned `{type, id, schema_version,
 created_at, data}` envelope a webhook delivery carries, so

--- a/sdks/typescript/src/v1/client.ts
+++ b/sdks/typescript/src/v1/client.ts
@@ -90,7 +90,10 @@ export interface E2AClientOptions {
   /** Account (`e2a_acct_`) or agent (`e2a_agt_`) key, or an OAuth access token.
    *  Falls back to `E2A_API_KEY`. */
   apiKey?: string;
-  /** API base URL. Default `https://api.e2a.dev`; override for self-host. */
+  /** API base URL. Falls back to `E2A_API_URL`, then the deprecated
+   *  `E2A_BASE_URL`. Default `https://api.e2a.dev`; override for self-host.
+   *  This is the API host — not the deployment root the CLI's `E2A_URL`
+   *  points at (that one also serves the dashboard). */
   baseUrl?: string;
   /** Max retry attempts on 429/5xx/connection (default 2). */
   maxRetries?: RetryOptions["maxRetries"];
@@ -113,6 +116,26 @@ export interface RequestOptions {
 function envVar(name: string): string | undefined {
   if (typeof process !== "undefined" && process.env && process.env[name]) return process.env[name];
   return undefined;
+}
+
+let warnedBaseUrlDeprecated = false;
+
+// resolveBaseUrl reads the API host. Canonical is E2A_API_URL — the same
+// concept the server names with E2A_API_URL (its externally visible API base).
+// E2A_BASE_URL is the name the SDKs shipped with; still honoured so published
+// integrations keep working, with a one-shot deprecation note.
+function resolveBaseUrl(): string | undefined {
+  const canonical = envVar("E2A_API_URL");
+  if (canonical) return canonical;
+  const legacy = envVar("E2A_BASE_URL");
+  if (legacy && !warnedBaseUrlDeprecated) {
+    warnedBaseUrlDeprecated = true;
+    console.warn(
+      "[e2a] E2A_BASE_URL is deprecated — rename it to E2A_API_URL. " +
+        "The old name still works for now but will be dropped.",
+    );
+  }
+  return legacy;
 }
 
 // Map generated/transport failures to the typed hierarchy: ApiException →
@@ -152,7 +175,7 @@ export class E2AClient {
         retryable: false,
       });
     }
-    const baseUrl = opts.baseUrl ?? envVar("E2A_BASE_URL") ?? "https://api.e2a.dev";
+    const baseUrl = opts.baseUrl ?? resolveBaseUrl() ?? "https://api.e2a.dev";
     this.apiKey = apiKey;
     this.baseUrl = baseUrl;
     const httpApi = new RetryHttpLibrary(new IsomorphicFetchHttpLibrary(), {

--- a/sdks/typescript/test/v1/client.test.ts
+++ b/sdks/typescript/test/v1/client.test.ts
@@ -60,10 +60,12 @@ describe("E2AClient", () => {
   beforeEach(() => {
     savedEnv = {
       E2A_API_KEY: process.env.E2A_API_KEY,
+      E2A_API_URL: process.env.E2A_API_URL,
       E2A_BASE_URL: process.env.E2A_BASE_URL,
       E2A_AGENT_EMAIL: process.env.E2A_AGENT_EMAIL,
     };
     delete process.env.E2A_API_KEY;
+    delete process.env.E2A_API_URL;
     delete process.env.E2A_BASE_URL;
     delete process.env.E2A_AGENT_EMAIL;
     client = new E2AClient({ apiKey: "e2a_test", baseUrl: BASE });
@@ -86,6 +88,45 @@ describe("E2AClient", () => {
   it("falls back to E2A_API_KEY from the environment", () => {
     process.env.E2A_API_KEY = "e2a_env";
     expect(() => new E2AClient({ baseUrl: BASE })).not.toThrow();
+  });
+
+  // Base-URL resolution: opts.baseUrl > E2A_API_URL > E2A_BASE_URL (deprecated)
+  // > the api.e2a.dev default. Asserted through the wire because baseUrl is
+  // private — the URL fetch is called with is the observable contract.
+  describe("base URL resolution", () => {
+    async function baseUrlOf(opts: { baseUrl?: string } = {}) {
+      globalThis.fetch = mockFetch(200, {});
+      await new E2AClient({ apiKey: "e2a_test", ...opts }).info();
+      return new URL(lastCall().url).origin;
+    }
+
+    it("defaults to the API host", async () => {
+      expect(await baseUrlOf()).toBe("https://api.e2a.dev");
+    });
+
+    it("reads E2A_API_URL", async () => {
+      process.env.E2A_API_URL = "https://api.self-host.example";
+      expect(await baseUrlOf()).toBe("https://api.self-host.example");
+    });
+
+    it("still honours the deprecated E2A_BASE_URL, with a warning", async () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      process.env.E2A_BASE_URL = "https://legacy.example";
+      expect(await baseUrlOf()).toBe("https://legacy.example");
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining("E2A_BASE_URL is deprecated"));
+      warn.mockRestore();
+    });
+
+    it("prefers E2A_API_URL over the deprecated name", async () => {
+      process.env.E2A_API_URL = "https://canonical.example";
+      process.env.E2A_BASE_URL = "https://legacy.example";
+      expect(await baseUrlOf()).toBe("https://canonical.example");
+    });
+
+    it("lets an explicit baseUrl beat the environment", async () => {
+      process.env.E2A_API_URL = "https://api.self-host.example";
+      expect(await baseUrlOf({ baseUrl: BASE })).toBe(BASE);
+    });
   });
 
   it("maps a per-request timeout to E2AConnectionError", async () => {


### PR DESCRIPTION
## Why

The client-side base-URL env vars named one concept badly and two concepts identically, so **following our own docs silently misrouted traffic**.

`E2A_URL` and the SDKs' `E2A_BASE_URL` are not the same thing:

- The CLI's `api_url` is the **deployment root**. `login` opens a browser against it (`cli/src/commands/login.ts:310`) and points users at `/get-started` — a Next.js route (`web/src/app/(app)/get-started`) the Go backend does not serve. `https://e2a.dev` works because the web front also proxies `/v1` (`web/Caddyfile:35`).
- The SDKs and the MCP server only ever call `/v1`, and want the **API host** alone.

Two names for "the base URL", with two different defaults, hid that distinction. The concrete failures:

| | |
|---|---|
| **Docs taught a var the SDKs don't read** | `README.md` and `docs/deployment.md` teach `E2A_URL`; the SDKs read only `E2A_BASE_URL`. A self-hoster who followed the docs got their SDK silently pointed at production `api.e2a.dev`. |
| **The CLI alias broke `e2a login`** | The CLI accepted `E2A_BASE_URL` as an alias for its deployment root, so exporting `E2A_BASE_URL=https://api.e2a.dev` to configure an SDK silently repointed the CLI at the API host. |
| **tether forced the CLI onto the API host** | `tether.env.example` taught `E2A_BASE_URL` ("self-host: your API base") and `lib.sh:51` defaulted it to `api.e2a.dev` — overriding the CLI's own `e2a.dev` default through that alias. |

## What changed

- **SDKs (TS + Python)** read `E2A_API_URL`, matching the name the server already uses for the same concept (`internal/config/config.go:344` — its externally visible API base). `E2A_BASE_URL` still works, with a deprecation warning (`console.warn` / `DeprecationWarning`).
- **MCP** moves to `E2A_API_URL` (`E2A_URL` + `E2A_BASE_URL` deprecated) and now defaults to the API host — it is a pure API client.
- **CLI** keeps `E2A_URL` alone and no longer reads `E2A_BASE_URL`. Dropping the alias *silently* would strand tether self-hosters on production, so it warns — gated to the actually-dangerous case (legacy var set, `E2A_URL` unset, root still at default), so a legitimate SDK user who also configured their CLI gets no noise.
- **tether** migrates to `E2A_URL`, carries a legacy `~/.e2a-tether.env` over with a warning (rather than reverting to prod), unsets the stale name so the CLI doesn't double-warn, and tracks the CLI's default instead of forcing `api.e2a.dev`.
- **Docs**: dropped the `E2A_AGENT_EMAIL` fallback claim from both SDK READMEs and the root README — it was never implemented in either SDK (they raise `missing_email`), though it is real in the CLI and tether. Added the CLI's env-var table (it documented none despite reading five) and split `E2A_URL` vs `E2A_API_URL` in `docs/deployment.md`.

Also removed the MCP one-shot deprecation guard: `main()` calls `loadConfig` exactly once, so it deduped nothing and only leaked state across tests.

## Compatibility

Additive. Every previously-working configuration still works; the old names warn rather than break. The one behavior change is the CLI ignoring `E2A_BASE_URL` — loud, not silent, and tether (its main consumer) migrates itself.

## Verification

Suites: TS SDK typecheck+unit+types, MCP vitest+types, Python 323 passed / 18 skipped, CLI 120 passed, tether `bash -n` clean.

Driven for real, not just unit-tested:
- Both SDKs against actual dialed origins across all four resolution cases (default → `E2A_API_URL` → deprecated `E2A_BASE_URL` + warning → both set, canonical wins).
- The built CLI binary: warning fires for the self-hoster case, silent when `E2A_URL` is set.
- `t_load_config` through the legacy-migration path: carries over, warns, unsets, and defaults correctly.

> ⚠️ `pytest` inside a git worktree silently tests the **main checkout** via the editable install — run it with `PYTHONPATH=$(pwd)/src` or you are testing the wrong tree.

## Follow-ups (not in this PR)

- `mcp/src/config.ts` is dead code (nothing in `src/` imports it but a type; no `bin` field since npm stdio publishing was retired in #247) and now also contradicts the new canonical name. Deleting it is a separate call.
- The split-host topology `internal/config/config.go:377` describes ("web on one host, API/MCP on another") still can't be expressed by the CLI, which holds only one URL. That's the deeper fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)