### PR TITLE
feat: render inline (cid:) email images + attachment download chips in the dashboard

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -311,6 +311,9 @@ components:
     AttachmentMetaView:
       additionalProperties: true
       properties:
+        content_id:
+          description: "Content-ID (angle brackets stripped) for an inline part referenced by a body 'cid:' URL, e.g. an embedded image; the key a cid: reference resolves against. Omitted for non-inline attachments."
+          type: string
         content_type:
           type: string
         filename:
@@ -330,6 +333,9 @@ components:
     AttachmentView:
       additionalProperties: true
       properties:
+        content_id:
+          description: Content-ID (angle brackets stripped) for an inline part referenced by a body 'cid:' URL, e.g. an embedded image. Omitted for non-inline attachments.
+          type: string
         content_type:
           type: string
         data:

--- a/internal/eventpayload/payloads.go
+++ b/internal/eventpayload/payloads.go
@@ -48,6 +48,14 @@ type AttachmentMetaView struct {
 	// size_bytes (which is the raw MIME length of the whole message).
 	SizeBytes int `json:"size_bytes" doc:"DECODED attachment payload size in bytes (Content-Transfer-Encoding undone) — the size of the file a download yields, not its encoded size inside the raw MIME."`
 	Index     int `json:"index" doc:"Stable 0-based attachment index (document order) — the fetch key for the attachment-bytes endpoint."`
+	// ContentID is the attachment's Content-ID with angle brackets stripped
+	// (e.g. "ii_abc@mail.gmail.com"), present only for parts that carry one —
+	// typically inline images embedded by a mail client. It is the key an HTML
+	// body's `cid:` reference resolves against: a renderer maps
+	// `<img src="cid:ii_abc@mail.gmail.com">` to the attachment whose
+	// content_id matches, then fetches the bytes via the attachment endpoint.
+	// Omitted (empty) for ordinary, non-inline attachments.
+	ContentID string `json:"content_id,omitempty" doc:"Content-ID (angle brackets stripped) for an inline part referenced by a body 'cid:' URL, e.g. an embedded image; the key a cid: reference resolves against. Omitted for non-inline attachments."`
 }
 
 // EmailReceivedData is the `data` payload of an email.received event. The
@@ -247,6 +255,7 @@ func AttachmentMetadata(raw []byte) []AttachmentMetaView {
 			ContentType: a.ContentType,
 			SizeBytes:   len(a.Data),
 			Index:       i,
+			ContentID:   a.ContentID,
 		})
 	}
 	return out

--- a/internal/httpapi/attachment_endpoint_test.go
+++ b/internal/httpapi/attachment_endpoint_test.go
@@ -25,7 +25,7 @@ func attMultipart() []byte {
 		"Content-Type: multipart/mixed; boundary=B\r\n\r\n" +
 		"--B\r\nContent-Type: text/plain\r\n\r\nbody\r\n" +
 		"--B\r\nContent-Type: application/pdf\r\nContent-Disposition: attachment; filename=\"report.pdf\"\r\nContent-Transfer-Encoding: base64\r\n\r\n" + pdf + "\r\n" +
-		"--B\r\nContent-Type: image/png\r\nContent-Disposition: inline; filename=\"logo.png\"\r\nContent-Transfer-Encoding: base64\r\n\r\n" + png + "\r\n" +
+		"--B\r\nContent-Type: image/png\r\nContent-Disposition: inline; filename=\"logo.png\"\r\nContent-ID: <ii_logo@mail.gmail.com>\r\nContent-Transfer-Encoding: base64\r\n\r\n" + png + "\r\n" +
 		"--B--\r\n")
 }
 
@@ -118,6 +118,16 @@ func TestAttachment_MetadataAndSignedURL(t *testing.T) {
 	}
 	if _, hasData := body["data"]; hasData {
 		t.Errorf("data must NOT be present without inline=true: %v", body)
+	}
+	// The PDF is an ordinary attachment — no Content-ID.
+	if cid, present := body["content_id"]; present {
+		t.Errorf("non-inline attachment should omit content_id, got %v", cid)
+	}
+	// The inline image (index 1) carries its Content-ID (brackets stripped) so a
+	// renderer can resolve the body's `cid:` reference to it.
+	_, img := getJSONAtt(t, srv.URL+"/v1/agents/support%40acme.com/messages/msg_att/attachments/1", "acct")
+	if img["content_id"] != "ii_logo@mail.gmail.com" {
+		t.Errorf("inline image content_id want %q, got %v", "ii_logo@mail.gmail.com", img["content_id"])
 	}
 }
 

--- a/internal/httpapi/attachments.go
+++ b/internal/httpapi/attachments.go
@@ -149,6 +149,7 @@ type AttachmentView struct {
 	Index       int       `json:"index"`
 	Filename    string    `json:"filename,omitempty"`
 	ContentType string    `json:"content_type,omitempty"`
+	ContentID   string    `json:"content_id,omitempty" doc:"Content-ID (angle brackets stripped) for an inline part referenced by a body 'cid:' URL, e.g. an embedded image. Omitted for non-inline attachments."`
 	SizeBytes   int       `json:"size_bytes" doc:"DECODED attachment payload size in bytes (Content-Transfer-Encoding undone) — exactly what download_url serves and what the 256 KB inline cap is checked against; not the encoded size inside the raw MIME."`
 	DownloadURL string    `json:"download_url"`
 	ExpiresAt   time.Time `json:"expires_at" format:"date-time"`
@@ -202,6 +203,7 @@ func (s *Server) handleGetAttachment(ctx context.Context, in *attachmentParam) (
 		Index:       in.Index,
 		Filename:    att.Filename,
 		ContentType: att.ContentType,
+		ContentID:   att.ContentID,
 		SizeBytes:   len(att.Data),
 		DownloadURL: dl,
 		ExpiresAt:   exp.UTC(),

--- a/internal/httpapi/messages.go
+++ b/internal/httpapi/messages.go
@@ -210,6 +210,7 @@ func messageViewFromIdentity(m *identity.Message) MessageView {
 				Filename:    a.Filename,
 				ContentType: a.ContentType,
 				SizeBytes:   len(a.Data),
+				ContentID:   a.ContentID,
 			})
 		}
 	}

--- a/internal/mailparse/attachments.go
+++ b/internal/mailparse/attachments.go
@@ -15,7 +15,13 @@ import (
 type Attachment struct {
 	Filename    string // decoded filename (RFC 2047/2231), "" if the part has none
 	ContentType string // media type only (e.g. "application/pdf"), params stripped
-	Data        []byte // decoded bytes (Content-Transfer-Encoding applied)
+	// ContentID is the part's Content-ID with the surrounding angle brackets
+	// stripped (e.g. "ii_abc@mail.gmail.com"), or "" if the part carries none.
+	// This is the key an HTML body's `cid:` reference resolves against, so a
+	// renderer can map `<img src="cid:ii_abc@mail.gmail.com">` to this
+	// attachment. Present mainly on inline images embedded by mail clients.
+	ContentID string
+	Data      []byte // decoded bytes (Content-Transfer-Encoding applied)
 }
 
 // Attachments walks the MIME tree of a raw RFC 5322 message and returns its
@@ -41,6 +47,7 @@ func Attachments(raw []byte) []Attachment {
 		msg.Header.Get("Content-Type"),
 		msg.Header.Get("Content-Transfer-Encoding"),
 		msg.Header.Get("Content-Disposition"),
+		msg.Header.Get("Content-ID"),
 		"", // top-level has no part filename
 		msg.Body,
 		0,
@@ -61,7 +68,7 @@ func AttachmentAt(raw []byte, index int) (Attachment, bool) {
 }
 
 // collectAttachments appends attachment leaves found under this part to *out.
-func collectAttachments(contentType, cte, disposition, partFilename string, body io.Reader, depth int, out *[]Attachment) {
+func collectAttachments(contentType, cte, disposition, contentID, partFilename string, body io.Reader, depth int, out *[]Attachment) {
 	mediaType, params, err := mime.ParseMediaType(contentType)
 	if err != nil {
 		mediaType = "text/plain" // missing/invalid Content-Type → body text, not an attachment
@@ -85,6 +92,7 @@ func collectAttachments(contentType, cte, disposition, partFilename string, body
 				part.Header.Get("Content-Type"),
 				part.Header.Get("Content-Transfer-Encoding"),
 				part.Header.Get("Content-Disposition"),
+				part.Header.Get("Content-ID"),
 				part.FileName(), // decoded by mime/multipart
 				part,
 				depth+1,
@@ -114,8 +122,20 @@ func collectAttachments(contentType, cte, disposition, partFilename string, body
 	*out = append(*out, Attachment{
 		Filename:    filename,
 		ContentType: mediaType,
+		ContentID:   trimContentID(contentID),
 		Data:        decodeBytes(body, cte),
 	})
+}
+
+// trimContentID normalizes a raw Content-ID header value to the token an HTML
+// `cid:` URL references: surrounding angle brackets and whitespace stripped
+// (e.g. "<ii_abc@mail.gmail.com>" → "ii_abc@mail.gmail.com"). Returns "" for an
+// empty/blank header.
+func trimContentID(raw string) string {
+	s := strings.TrimSpace(raw)
+	s = strings.TrimPrefix(s, "<")
+	s = strings.TrimSuffix(s, ">")
+	return strings.TrimSpace(s)
 }
 
 // decodeBytes reads a body applying its Content-Transfer-Encoding, returning raw

--- a/internal/mailparse/attachments.go
+++ b/internal/mailparse/attachments.go
@@ -115,14 +115,23 @@ func collectAttachments(contentType, cte, disposition, contentID, partFilename s
 		}
 	}
 	isAttachmentDisp := strings.HasPrefix(strings.ToLower(strings.TrimSpace(disposition)), "attachment")
-	if filename == "" && !isAttachmentDisp {
+	cid := trimContentID(contentID)
+	// A part with a Content-ID but no filename is still a fetchable inline
+	// resource an HTML `cid:` reference resolves to (some clients embed images
+	// this way) — include it so the renderer can resolve it. Guard against the
+	// message's own body parts: a text/plain or text/html part can carry a
+	// Content-ID (a multipart/related root) and must stay a body, never an
+	// attachment.
+	isTextBody := mediaType == "text/plain" || mediaType == "text/html"
+	isNamedInline := cid != "" && !isTextBody
+	if filename == "" && !isAttachmentDisp && !isNamedInline {
 		return // body text / unnamed inline part — not a fetchable attachment
 	}
 
 	*out = append(*out, Attachment{
 		Filename:    filename,
 		ContentType: mediaType,
-		ContentID:   trimContentID(contentID),
+		ContentID:   cid,
 		Data:        decodeBytes(body, cte),
 	})
 }

--- a/internal/mailparse/attachments_test.go
+++ b/internal/mailparse/attachments_test.go
@@ -29,6 +29,7 @@ func sampleMultipart() []byte {
 		"--BOUND\r\n" +
 		"Content-Type: image/png\r\n" +
 		"Content-Disposition: inline; filename=\"logo.png\"\r\n" +
+		"Content-ID: <ii_logo@mail.gmail.com>\r\n" +
 		"Content-Transfer-Encoding: base64\r\n" +
 		"\r\n" + b64("\x89PNG\r\n fake png") + "\r\n" +
 		"--BOUND--\r\n")
@@ -50,6 +51,37 @@ func TestAttachments_OrderAndDecode(t *testing.T) {
 	}
 	if !bytes.Equal(atts[1].Data, []byte("\x89PNG\r\n fake png")) {
 		t.Errorf("att1 binary bytes not decoded: %q", atts[1].Data)
+	}
+}
+
+// The inline image's Content-ID is captured (angle brackets stripped) so a
+// renderer can resolve an HTML `cid:` reference to it; the ordinary PDF
+// attachment carries none.
+func TestAttachments_ContentID(t *testing.T) {
+	atts := Attachments(sampleMultipart())
+	if len(atts) != 2 {
+		t.Fatalf("want 2 attachments, got %d", len(atts))
+	}
+	if atts[0].ContentID != "" {
+		t.Errorf("PDF attachment should have no Content-ID, got %q", atts[0].ContentID)
+	}
+	if atts[1].ContentID != "ii_logo@mail.gmail.com" {
+		t.Errorf("inline image Content-ID want %q, got %q", "ii_logo@mail.gmail.com", atts[1].ContentID)
+	}
+}
+
+func TestTrimContentID(t *testing.T) {
+	cases := map[string]string{
+		"<ii_abc@mail.gmail.com>": "ii_abc@mail.gmail.com",
+		"  <ii_abc>  ":            "ii_abc",
+		"ii_bare":                 "ii_bare",
+		"":                        "",
+		"   ":                     "",
+	}
+	for in, want := range cases {
+		if got := trimContentID(in); got != want {
+			t.Errorf("trimContentID(%q) = %q, want %q", in, got, want)
+		}
 	}
 }
 

--- a/internal/mailparse/attachments_test.go
+++ b/internal/mailparse/attachments_test.go
@@ -70,6 +70,33 @@ func TestAttachments_ContentID(t *testing.T) {
 	}
 }
 
+// An inline image with a Content-ID but NO filename and no attachment
+// disposition is still included (it's a fetchable cid: resource), while a
+// text/html body part carrying a Content-ID (a multipart/related root) stays a
+// body and is NOT treated as an attachment.
+func TestAttachments_CidOnlyInlineIncludedButBodyExcluded(t *testing.T) {
+	png := b64("\x89PNG cid-only")
+	raw := []byte("MIME-Version: 1.0\r\n" +
+		"Content-Type: multipart/related; boundary=R\r\n\r\n" +
+		"--R\r\n" +
+		"Content-Type: text/html\r\n" +
+		"Content-ID: <root.html>\r\n" +
+		"\r\n<p><img src=\"cid:logo\"></p>\r\n" +
+		"--R\r\n" +
+		"Content-Type: image/png\r\n" +
+		"Content-ID: <logo>\r\n" +
+		"Content-Transfer-Encoding: base64\r\n" +
+		"\r\n" + png + "\r\n" +
+		"--R--\r\n")
+	atts := Attachments(raw)
+	if len(atts) != 1 {
+		t.Fatalf("want 1 attachment (the cid-only image; the html body excluded), got %d: %+v", len(atts), atts)
+	}
+	if atts[0].ContentID != "logo" || atts[0].ContentType != "image/png" || atts[0].Filename != "" {
+		t.Errorf("cid-only inline image meta wrong: %+v", atts[0])
+	}
+}
+
 func TestTrimContentID(t *testing.T) {
 	cases := map[string]string{
 		"<ii_abc@mail.gmail.com>": "ii_abc@mail.gmail.com",

--- a/sdks/python/src/e2a/v1/generated/models/attachment_meta_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/attachment_meta_view.py
@@ -26,12 +26,13 @@ class AttachmentMetaView(BaseModel):
     """
     AttachmentMetaView
     """ # noqa: E501
+    content_id: Optional[StrictStr] = Field(default=None, description="Content-ID (angle brackets stripped) for an inline part referenced by a body 'cid:' URL, e.g. an embedded image; the key a cid: reference resolves against. Omitted for non-inline attachments.")
     content_type: Optional[StrictStr] = None
     filename: Optional[StrictStr] = None
     index: StrictInt = Field(description="Stable 0-based attachment index (document order) — the fetch key for the attachment-bytes endpoint.")
     size_bytes: StrictInt = Field(description="DECODED attachment payload size in bytes (Content-Transfer-Encoding undone) — the size of the file a download yields, not its encoded size inside the raw MIME.")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["content_type", "filename", "index", "size_bytes"]
+    __properties: ClassVar[List[str]] = ["content_id", "content_type", "filename", "index", "size_bytes"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -91,6 +92,7 @@ class AttachmentMetaView(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
+            "content_id": obj.get("content_id"),
             "content_type": obj.get("content_type"),
             "filename": obj.get("filename"),
             "index": obj.get("index"),

--- a/sdks/python/src/e2a/v1/generated/models/attachment_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/attachment_view.py
@@ -27,6 +27,7 @@ class AttachmentView(BaseModel):
     """
     AttachmentView
     """ # noqa: E501
+    content_id: Optional[StrictStr] = Field(default=None, description="Content-ID (angle brackets stripped) for an inline part referenced by a body 'cid:' URL, e.g. an embedded image. Omitted for non-inline attachments.")
     content_type: Optional[StrictStr] = None
     data: Optional[StrictStr] = None
     download_url: StrictStr
@@ -35,7 +36,7 @@ class AttachmentView(BaseModel):
     index: StrictInt
     size_bytes: StrictInt = Field(description="DECODED attachment payload size in bytes (Content-Transfer-Encoding undone) — exactly what download_url serves and what the 256 KB inline cap is checked against; not the encoded size inside the raw MIME.")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["content_type", "data", "download_url", "expires_at", "filename", "index", "size_bytes"]
+    __properties: ClassVar[List[str]] = ["content_id", "content_type", "data", "download_url", "expires_at", "filename", "index", "size_bytes"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -95,6 +96,7 @@ class AttachmentView(BaseModel):
             return cls.model_validate(obj)
 
         _obj = cls.model_validate({
+            "content_id": obj.get("content_id"),
             "content_type": obj.get("content_type"),
             "data": obj.get("data"),
             "download_url": obj.get("download_url"),

--- a/sdks/typescript/src/v1/generated/models/AttachmentMetaView.ts
+++ b/sdks/typescript/src/v1/generated/models/AttachmentMetaView.ts
@@ -13,6 +13,10 @@
 import { HttpFile } from '../http/http.js';
 
 export class AttachmentMetaView {
+    /**
+    * Content-ID (angle brackets stripped) for an inline part referenced by a body \'cid:\' URL, e.g. an embedded image; the key a cid: reference resolves against. Omitted for non-inline attachments.
+    */
+    'contentId'?: string;
     'contentType'?: string;
     'filename'?: string;
     /**
@@ -29,6 +33,12 @@ export class AttachmentMetaView {
     static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
+        {
+            "name": "contentId",
+            "baseName": "content_id",
+            "type": "string",
+            "format": ""
+        },
         {
             "name": "contentType",
             "baseName": "content_type",

--- a/sdks/typescript/src/v1/generated/models/AttachmentView.ts
+++ b/sdks/typescript/src/v1/generated/models/AttachmentView.ts
@@ -13,6 +13,10 @@
 import { HttpFile } from '../http/http.js';
 
 export class AttachmentView {
+    /**
+    * Content-ID (angle brackets stripped) for an inline part referenced by a body \'cid:\' URL, e.g. an embedded image. Omitted for non-inline attachments.
+    */
+    'contentId'?: string;
     'contentType'?: string;
     'data'?: string;
     'downloadUrl': string;
@@ -29,6 +33,12 @@ export class AttachmentView {
     static readonly mapping: {[index: string]: string} | undefined = undefined;
 
     static readonly attributeTypeMap: Array<{name: string, baseName: string, type: string, format: string}> = [
+        {
+            "name": "contentId",
+            "baseName": "content_id",
+            "type": "string",
+            "format": ""
+        },
         {
             "name": "contentType",
             "baseName": "content_type",

--- a/web/src/app/(app)/inboxes/(view)/messages/view/page.tsx
+++ b/web/src/app/(app)/inboxes/(view)/messages/view/page.tsx
@@ -29,6 +29,10 @@ import type {
 import { Chip, Dot, Eyebrow, InkConsole, type InkLine } from "@e2a/ui";
 import { Collapsible } from "../../../../../components/messages/Collapsible";
 import { EmailHtmlBody } from "../../../../../components/messages/EmailHtmlBody";
+import {
+  AttachmentChips,
+  downloadableAttachments,
+} from "../../../../../components/messages/AttachmentChips";
 import { MessageDirectionIcon } from "../../../../../components/messages/MessageDirectionIcon";
 import {
   MessageLifecycleTimeline,
@@ -585,6 +589,12 @@ function BodyCard({
   }, [msg]);
 
   const isOutbound = msg.direction === "outbound";
+  // Inbound attachments: inline images (cid-referenced) render in the body; the
+  // rest surface as download chips. The owning agent is the delivered-to
+  // recipient — the email the attachment endpoint is keyed by.
+  const attachments = msg.direction === "inbound" ? msg.data.attachments ?? [] : [];
+  const agentEmail = msg.direction === "inbound" ? msg.data.recipient : "";
+  const chipAttachments = downloadableAttachments(attachments, bodyHtml);
   // A non-pending outbound row with no body_text is a sent/scrubbed
   // draft — its body is no longer available. Keyed off the threaded
   // pending flag rather than the (delivery-rollup) detail `status`.
@@ -635,13 +645,25 @@ function BodyCard({
               Body no longer available (scrubbed after delivery).
             </span>
           ) : bodyHtml.trim() !== "" ? (
-            <EmailHtmlBody html={bodyHtml} />
+            <EmailHtmlBody
+              html={bodyHtml}
+              attachments={attachments}
+              email={agentEmail}
+              messageId={msg.data.id}
+            />
           ) : (
             bodyText || (
               <span style={{ color: "var(--fg-muted)", fontStyle: "italic" }}>
                 (message body not available)
               </span>
             )
+          )}
+          {!isTerminal && chipAttachments.length > 0 && agentEmail && (
+            <AttachmentChips
+              email={agentEmail}
+              messageId={msg.data.id}
+              attachments={chipAttachments}
+            />
           )}
         </div>
       )}

--- a/web/src/app/components/messages/AttachmentChips.test.tsx
+++ b/web/src/app/components/messages/AttachmentChips.test.tsx
@@ -1,0 +1,85 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import {
+  AttachmentChips,
+  downloadableAttachments,
+} from "./AttachmentChips";
+import type { AttachmentMeta } from "../types";
+
+jest.mock("../onboarding/api", () => ({
+  getAttachment: jest.fn(),
+}));
+import { getAttachment } from "../onboarding/api";
+
+const inlineImg: AttachmentMeta = {
+  index: 0,
+  filename: "image.png",
+  content_type: "image/png",
+  size_bytes: 1000,
+  content_id: "ii_a@mail",
+};
+const pdf: AttachmentMeta = {
+  index: 1,
+  filename: "report.pdf",
+  content_type: "application/pdf",
+  size_bytes: 200000,
+};
+
+describe("downloadableAttachments", () => {
+  it("excludes inline images referenced by a cid: in the body", () => {
+    const html = '<p>hi</p><img src="cid:ii_a@mail">';
+    expect(downloadableAttachments([inlineImg, pdf], html)).toEqual([pdf]);
+  });
+
+  it("includes an image attachment NOT referenced inline", () => {
+    // Same image, but the body never references its content_id → it's a real
+    // (downloadable) attachment, not an inline image.
+    expect(downloadableAttachments([inlineImg, pdf], "<p>no images</p>")).toEqual([
+      inlineImg,
+      pdf,
+    ]);
+  });
+
+  it("treats every attachment as downloadable when there is no HTML body", () => {
+    expect(downloadableAttachments([inlineImg, pdf], undefined)).toEqual([
+      inlineImg,
+      pdf,
+    ]);
+  });
+
+  it("returns [] for no attachments", () => {
+    expect(downloadableAttachments([], "<p>x</p>")).toEqual([]);
+    expect(downloadableAttachments(undefined, "<p>x</p>")).toEqual([]);
+  });
+});
+
+describe("AttachmentChips", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("renders a chip per attachment with filename and size", () => {
+    render(
+      <AttachmentChips email="a@x.dev" messageId="msg_1" attachments={[pdf]} />,
+    );
+    const chip = screen.getByTestId("attachment-chip");
+    expect(chip).toHaveTextContent("report.pdf");
+    expect(chip).toHaveTextContent("195 KB");
+  });
+
+  it("fetches a download url on click", async () => {
+    (getAttachment as jest.Mock).mockResolvedValue({
+      download_url: "https://api.e2a.dev/v1/…/download?token=t",
+    });
+    // jsdom: <a>.click() would navigate; stub it so the click is observable.
+    const clickSpy = jest
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(() => {});
+    render(
+      <AttachmentChips email="a@x.dev" messageId="msg_1" attachments={[pdf]} />,
+    );
+    fireEvent.click(screen.getByTestId("attachment-chip"));
+    await waitFor(() =>
+      expect(getAttachment).toHaveBeenCalledWith("a@x.dev", "msg_1", 1),
+    );
+    expect(clickSpy).toHaveBeenCalled();
+    clickSpy.mockRestore();
+  });
+});

--- a/web/src/app/components/messages/AttachmentChips.tsx
+++ b/web/src/app/components/messages/AttachmentChips.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+// Download chips for a message's attachments that are NOT inline images — i.e.
+// the ones not rendered in the body via a `cid:` reference (PDFs, documents,
+// images sent as real attachments). Each chip fetches a short-lived signed
+// download URL on click and opens it; the backend streams the bytes with
+// Content-Disposition: attachment, so the browser saves the file.
+
+import { useState } from "react";
+import { getAttachment } from "../onboarding/api";
+import { findCidRefs } from "./inlineImages";
+import type { AttachmentMeta } from "../types";
+
+function fmtBytes(n: number): string {
+  if (n < 1024) return `${n} B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(0)} KB`;
+  return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// Attachments whose content_id is referenced by a `cid:` in the body render
+// inline; the rest are downloadable. When there's no HTML body, every
+// attachment is downloadable.
+export function downloadableAttachments(
+  attachments: AttachmentMeta[] | undefined,
+  html: string | undefined,
+): AttachmentMeta[] {
+  const list = attachments ?? [];
+  if (list.length === 0) return [];
+  const refs = html ? findCidRefs(html) : new Set<string>();
+  return list.filter((a) => !(a.content_id && refs.has(a.content_id)));
+}
+
+function AttachmentChip({
+  email,
+  messageId,
+  att,
+}: {
+  email: string;
+  messageId: string;
+  att: AttachmentMeta;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(false);
+
+  const onClick = async () => {
+    setBusy(true);
+    setError(false);
+    try {
+      const meta = await getAttachment(email, messageId, att.index);
+      const a = document.createElement("a");
+      a.href = meta.download_url;
+      a.target = "_blank";
+      a.rel = "noopener";
+      a.click();
+    } catch {
+      setError(true);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={busy}
+      title={error ? "Download failed — try again" : `Download ${att.filename || "attachment"}`}
+      data-testid="attachment-chip"
+      className="flex items-center"
+      style={{
+        gap: 8,
+        padding: "6px 10px",
+        fontSize: 12,
+        maxWidth: "100%",
+        cursor: busy ? "default" : "pointer",
+        color: error ? "var(--danger-strong)" : "var(--fg)",
+        background: "var(--bg-elev)",
+        border: `1px solid ${error ? "var(--danger-strong)" : "var(--border-sub)"}`,
+        borderRadius: "var(--r-sm)",
+      }}
+    >
+      <span aria-hidden style={{ flexShrink: 0 }}>{busy ? "…" : "📎"}</span>
+      <span
+        style={{
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+          minWidth: 0,
+        }}
+      >
+        {att.filename || `attachment ${att.index}`}
+      </span>
+      <span style={{ color: "var(--fg-subtle)", flexShrink: 0 }}>
+        {fmtBytes(att.size_bytes)}
+      </span>
+    </button>
+  );
+}
+
+export function AttachmentChips({
+  email,
+  messageId,
+  attachments,
+}: {
+  email: string;
+  messageId: string;
+  attachments: AttachmentMeta[];
+}) {
+  if (attachments.length === 0) return null;
+  return (
+    <div
+      className="flex items-center"
+      data-testid="attachment-chips"
+      style={{ gap: 8, marginTop: 10, flexWrap: "wrap" }}
+    >
+      {attachments.map((a) => (
+        <AttachmentChip key={a.index} email={email} messageId={messageId} att={a} />
+      ))}
+    </div>
+  );
+}

--- a/web/src/app/components/messages/EmailHtmlBody.test.tsx
+++ b/web/src/app/components/messages/EmailHtmlBody.test.tsx
@@ -3,8 +3,14 @@
 // blocking — plus the "Load images" opt-in, since a silent regression in any of
 // them reintroduces XSS or tracking-pixel leakage.
 
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { EmailHtmlBody } from "./EmailHtmlBody";
+import type { AttachmentMeta } from "../types";
+
+jest.mock("../onboarding/api", () => ({
+  loadInlineAttachmentUrl: jest.fn(),
+}));
+import { loadInlineAttachmentUrl } from "../onboarding/api";
 
 function srcdocOf(): string {
   const frame = screen.getByTitle("Email body") as HTMLIFrameElement;
@@ -85,5 +91,65 @@ describe("EmailHtmlBody", () => {
   it("shows no banner when there is nothing remote to block", () => {
     render(<EmailHtmlBody html="<p>just <b>text</b></p>" />);
     expect(screen.queryByText(/Remote images blocked/i)).not.toBeInTheDocument();
+  });
+
+  describe("inline (cid:) images", () => {
+    const inlineAtt: AttachmentMeta = {
+      index: 0,
+      filename: "image.png",
+      content_type: "image/png",
+      size_bytes: 1000,
+      content_id: "ii_a@mail.gmail.com",
+    };
+
+    beforeEach(() => jest.clearAllMocks());
+
+    it("resolves a cid: image to its fetched bytes and renders it inline", async () => {
+      (loadInlineAttachmentUrl as jest.Mock).mockResolvedValue({
+        url: "data:image/png;base64,AAAA",
+      });
+      render(
+        <EmailHtmlBody
+          html={'<p>see</p><img src="cid:ii_a@mail.gmail.com">'}
+          attachments={[inlineAtt]}
+          email="a@x.dev"
+          messageId="msg_1"
+        />,
+      );
+      await waitFor(() => expect(srcdocOf()).toContain("data:image/png;base64,AAAA"));
+      const doc = srcdocOf();
+      expect(doc).not.toContain("cid:"); // the cid reference was rewritten away
+      // Inline images render by DEFAULT (no "Load images" opt-in) and CSP allows
+      // them even while remote images are blocked.
+      expect(screen.queryByText(/Remote images blocked/i)).not.toBeInTheDocument();
+      expect(doc).toMatch(/img-src[^;"]*data:/);
+    });
+
+    it("does not treat a resolved inline image as a remote tracker", async () => {
+      // A large inline image resolves to a client-encoded data: URL.
+      (loadInlineAttachmentUrl as jest.Mock).mockResolvedValue({
+        url: "data:image/png;base64,BBBB",
+      });
+      render(
+        <EmailHtmlBody
+          html={'<img src="cid:ii_a@mail.gmail.com">'}
+          attachments={[inlineAtt]}
+          email="a@x.dev"
+          messageId="msg_1"
+        />,
+      );
+      await waitFor(() => expect(srcdocOf()).toContain("data:image/png;base64,BBBB"));
+      expect(screen.queryByText(/Remote images blocked/i)).not.toBeInTheDocument();
+    });
+
+    it("does not fetch bytes when message coordinates are absent", () => {
+      render(
+        <EmailHtmlBody
+          html={'<img src="cid:ii_a@mail.gmail.com">'}
+          attachments={[inlineAtt]}
+        />,
+      );
+      expect(loadInlineAttachmentUrl).not.toHaveBeenCalled();
+    });
   });
 });

--- a/web/src/app/components/messages/EmailHtmlBody.tsx
+++ b/web/src/app/components/messages/EmailHtmlBody.tsx
@@ -148,9 +148,10 @@ export function EmailHtmlBody({
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
   // Resolve inline (cid:) images: match each `cid:` reference in the body to an
-  // attachment by content_id, fetch its bytes, and build a cid→URL map. Runs
-  // whenever the body or its attachment set changes; object URLs are revoked on
-  // cleanup. No-op when we lack the message coordinates needed to fetch bytes.
+  // attachment by content_id, fetch its bytes as a data: URL, and build a
+  // cid→URL map. Runs whenever the body or its attachment set changes; a
+  // cancelled flag drops results from a superseded run. No-op when we lack the
+  // message coordinates needed to fetch bytes.
   useEffect(() => {
     if (!email || !messageId) return;
     const refs = findCidRefs(html);

--- a/web/src/app/components/messages/EmailHtmlBody.tsx
+++ b/web/src/app/components/messages/EmailHtmlBody.tsx
@@ -5,8 +5,13 @@
 //   2. The cleaned markup is rendered inside a sandboxed <iframe srcdoc> with
 //      NO allow-scripts — so even if something slipped past the sanitizer it
 //      cannot execute, touch cookies, or reach the dashboard DOM.
-// Remote images are blocked by default (tracking-pixel / read-receipt defense,
-// the Gmail convention) and loaded only when the user opts in.
+//
+// Inline images (attachments the body references by a `cid:` URL — e.g. a
+// pasted screenshot) are resolved to data:/blob: URLs of the fetched bytes and
+// rendered BY DEFAULT: they travelled with the mail and are not a remote
+// tracking vector. Remote http(s) images ARE blocked by default (tracking-pixel
+// / read-receipt defense, the Gmail convention) and loaded only when the user
+// opts in.
 //
 // The iframe keeps `allow-same-origin` (so we can measure its content height to
 // auto-size) and `allow-popups` (so sanitized links can open in a new tab via
@@ -15,10 +20,30 @@
 
 import DOMPurify from "dompurify";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { loadInlineAttachmentUrl } from "../onboarding/api";
+import type { AttachmentMeta } from "../types";
+import { findCidRefs, rewriteCidImages } from "./inlineImages";
+
+// isRemoteUrl reports whether a single URL points off-origin over the network
+// (http/https/protocol-relative). data:/relative URLs are NOT remote — a data:
+// URL is self-contained (an inline image we resolved) and must survive the
+// remote-image block. Scheme is checked at the START so a "//" inside base64
+// data can't be mistaken for a protocol-relative host.
+function isRemoteUrl(v: string): boolean {
+  const s = v.trim().toLowerCase();
+  return s.startsWith("http://") || s.startsWith("https://") || s.startsWith("//");
+}
+
+// isRemoteSrcset reports whether a srcset (comma-separated `url descriptor`
+// candidates) references any remote URL.
+function isRemoteSrcset(v: string): boolean {
+  return v.split(",").some((cand) => isRemoteUrl(cand.trim().split(/\s+/)[0] ?? ""));
+}
 
 // sanitizeEmail cleans the raw email HTML. When showImages is false it also
-// neutralizes remote image sources (img src/srcset and CSS url() backgrounds),
-// reporting whether anything was actually blocked so the caller can offer a
+// neutralizes REMOTE image sources (img src/srcset and CSS url() backgrounds)
+// while leaving already-resolved inline data:/blob: images intact, reporting
+// whether any remote resource was actually blocked so the caller can offer a
 // "Load images" affordance only when it matters.
 function sanitizeEmail(
   html: string,
@@ -34,20 +59,33 @@ function sanitizeEmail(
       el.setAttribute("rel", "noopener noreferrer nofollow");
     }
     if (!showImages) {
-      // Strip every remote-resource carrier so the "Load images" banner is
-      // honest (blockedRemote reflects what was actually present). This is the
-      // belt; the CSP injected in wrapDocument is the authoritative block that
-      // also covers CSS-escaped url() and any vector missed here.
-      for (const attr of ["src", "srcset", "background", "poster"] as const) {
-        if (el.getAttribute?.(attr)) {
+      // Strip only REMOTE resource carriers so inline (data:/blob:) images we
+      // resolved still render; blockedRemote reflects what was actually blocked.
+      // This is the belt; the CSP injected in wrapDocument is the authoritative
+      // block that also covers CSS-escaped url() and any vector missed here.
+      for (const attr of ["src", "background", "poster"] as const) {
+        const val = el.getAttribute?.(attr);
+        if (val && isRemoteUrl(val)) {
           blockedRemote = true;
           el.removeAttribute(attr);
         }
       }
+      const srcset = el.getAttribute?.("srcset");
+      if (srcset && isRemoteSrcset(srcset)) {
+        blockedRemote = true;
+        el.removeAttribute("srcset");
+      }
       const style = el.getAttribute?.("style");
       if (style && /url\s*\(/i.test(style)) {
-        blockedRemote = true;
-        el.setAttribute("style", style.replace(/url\s*\([^)]*\)/gi, "none"));
+        // Neutralize only remote url()s; keep inline data:/blob: backgrounds.
+        const next = style.replace(/url\s*\(\s*(['"]?)([^)'"]*)\1\s*\)/gi, (whole, _q, inner) => {
+          if (isRemoteUrl(inner)) {
+            blockedRemote = true;
+            return "none";
+          }
+          return whole;
+        });
+        el.setAttribute("style", next);
       }
     }
   });
@@ -67,11 +105,10 @@ function sanitizeEmail(
 // images, and a base target so links open in a new tab.
 //
 // The Content-Security-Policy is the AUTHORITATIVE control, not the DOMPurify
-// hook: `default-src 'none'` blocks scripts/frames/objects/fetches outright,
-// and when images are blocked `img-src data:` (no http/https) defeats every
-// remote-resource vector at once — <img>, CSS url() (including CSS-escaped
-// forms), <td background>, <video poster>, <source srcset>, web fonts — so the
-// tracking-pixel block can't be bypassed by markup the hook didn't anticipate.
+// hook: `default-src 'none'` blocks scripts/frames/objects/fetches outright.
+// Inline images (resolved to data: URLs) are always allowed — they are trusted
+// content that travelled with the mail; only when the user loads images does
+// `img-src` gain http:/https:, defeating remote-tracking vectors until then.
 function wrapDocument(innerHTML: string, showImages: boolean): string {
   const csp = showImages
     ? "default-src 'none'; img-src http: https: data:; media-src http: https: data:; style-src 'unsafe-inline'; font-src http: https: data:"
@@ -95,13 +132,60 @@ function wrapDocument(innerHTML: string, showImages: boolean): string {
   );
 }
 
-export function EmailHtmlBody({ html }: { html: string }) {
+export function EmailHtmlBody({
+  html,
+  attachments,
+  email,
+  messageId,
+}: {
+  html: string;
+  attachments?: AttachmentMeta[];
+  email?: string;
+  messageId?: string;
+}) {
   const [showImages, setShowImages] = useState(false);
+  const [cidUrls, setCidUrls] = useState<Map<string, string>>(() => new Map());
   const iframeRef = useRef<HTMLIFrameElement>(null);
 
+  // Resolve inline (cid:) images: match each `cid:` reference in the body to an
+  // attachment by content_id, fetch its bytes, and build a cid→URL map. Runs
+  // whenever the body or its attachment set changes; object URLs are revoked on
+  // cleanup. No-op when we lack the message coordinates needed to fetch bytes.
+  useEffect(() => {
+    if (!email || !messageId) return;
+    const refs = findCidRefs(html);
+    if (refs.size === 0) return;
+    const inline = (attachments ?? []).filter(
+      (a) => a.content_id && refs.has(a.content_id),
+    );
+    if (inline.length === 0) return;
+
+    let cancelled = false;
+    (async () => {
+      const resolved = new Map<string, string>();
+      await Promise.all(
+        inline.map(async (a) => {
+          try {
+            const { url } = await loadInlineAttachmentUrl(email, messageId, a);
+            if (!cancelled) resolved.set(a.content_id as string, url);
+          } catch {
+            /* leave this image unresolved — it degrades to a broken icon */
+          }
+        }),
+      );
+      if (!cancelled && resolved.size > 0) setCidUrls(resolved);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [html, attachments, email, messageId]);
+
+  const resolvedHtml = useMemo(() => rewriteCidImages(html, cidUrls), [html, cidUrls]);
+
   const { clean, blockedRemote } = useMemo(
-    () => sanitizeEmail(html, showImages),
-    [html, showImages],
+    () => sanitizeEmail(resolvedHtml, showImages),
+    [resolvedHtml, showImages],
   );
   const srcDoc = useMemo(() => wrapDocument(clean, showImages), [clean, showImages]);
 

--- a/web/src/app/components/messages/ThreadBubble.tsx
+++ b/web/src/app/components/messages/ThreadBubble.tsx
@@ -12,13 +12,14 @@ import useSWR from "swr";
 import { Chip, Dot } from "@e2a/ui";
 import { CounterpartyAvatar } from "./CounterpartyAvatar";
 import { EmailHtmlBody } from "./EmailHtmlBody";
+import { AttachmentChips, downloadableAttachments } from "./AttachmentChips";
 import { getMessageDetail, deleteMessage } from "../onboarding/api";
 import {
   invalidateAgentMessages,
   invalidateAgentTrash,
   invalidateAgentUnread,
 } from "../../../lib/swrKeys";
-import type { MessageSummary } from "../types";
+import type { AttachmentMeta, MessageSummary } from "../types";
 import type { Counterparty } from "./threading";
 
 // Absolute, human time for the message header (e.g. "Jun 21, 8:07 PM").
@@ -122,6 +123,7 @@ export function ThreadBubble({
   // backend-parsed bodies (QP/base64 decoded); the raw decode is last resort.
   let textBody = "";
   let htmlBody = "";
+  let attachments: AttachmentMeta[] = [];
   if (detail) {
     if (detail.direction === "outbound") {
       textBody = detail.data.body_text ?? "";
@@ -133,9 +135,13 @@ export function ThreadBubble({
         detail.data.body?.text ||
         decodeRawBody(detail.data.raw_message) ||
         "";
+      attachments = detail.data.attachments ?? [];
     }
   }
   const showBody = htmlBody.trim() !== "" || textBody.trim() !== "";
+  // Attachments not embedded inline in the body (PDFs, docs, non-inline images)
+  // surface as download chips beneath it.
+  const chipAttachments = downloadableAttachments(attachments, htmlBody);
 
   const senderName = isInbound ? counterparty.name : "Inbox";
   const senderEmail = isInbound ? counterparty.email : agentEmail;
@@ -316,9 +322,21 @@ export function ThreadBubble({
               </span>
             )
           ) : htmlBody.trim() !== "" ? (
-            <EmailHtmlBody html={htmlBody} />
+            <EmailHtmlBody
+              html={htmlBody}
+              attachments={attachments}
+              email={agentEmail}
+              messageId={message.id}
+            />
           ) : (
             <div style={{ whiteSpace: "pre-wrap" }}>{textBody}</div>
+          )}
+          {chipAttachments.length > 0 && (
+            <AttachmentChips
+              email={agentEmail}
+              messageId={message.id}
+              attachments={chipAttachments}
+            />
           )}
         </div>
       </div>

--- a/web/src/app/components/messages/inlineImages.test.ts
+++ b/web/src/app/components/messages/inlineImages.test.ts
@@ -1,0 +1,48 @@
+import { findCidRefs, rewriteCidImages } from "./inlineImages";
+
+describe("findCidRefs", () => {
+  it("extracts cid tokens from img src (both quote styles)", () => {
+    const html =
+      '<img src="cid:ii_a@mail.gmail.com"> <img src=\'cid:logo\'>';
+    expect(findCidRefs(html)).toEqual(new Set(["ii_a@mail.gmail.com", "logo"]));
+  });
+
+  it("extracts cid tokens from CSS url() backgrounds", () => {
+    expect(findCidRefs('<td style="background:url(cid:bg1)">')).toEqual(
+      new Set(["bg1"]),
+    );
+  });
+
+  it("returns an empty set when there are no cid references", () => {
+    expect(findCidRefs('<img src="https://x/y.png"><p>hi</p>').size).toBe(0);
+  });
+});
+
+describe("rewriteCidImages", () => {
+  it("replaces each cid reference with its resolved url", () => {
+    const html = '<img src="cid:a"><img src="cid:b">';
+    const out = rewriteCidImages(
+      html,
+      new Map([
+        ["a", "data:image/png;base64,AAA"],
+        ["b", "blob:http://app/xyz"],
+      ]),
+    );
+    expect(out).toBe(
+      '<img src="data:image/png;base64,AAA"><img src="blob:http://app/xyz">',
+    );
+    expect(out).not.toContain("cid:");
+  });
+
+  it("leaves unresolved cid references untouched", () => {
+    const html = '<img src="cid:known"><img src="cid:missing">';
+    const out = rewriteCidImages(html, new Map([["known", "data:x"]]));
+    expect(out).toContain("data:x");
+    expect(out).toContain("cid:missing");
+  });
+
+  it("is a no-op when the url map is empty", () => {
+    const html = '<img src="cid:a">';
+    expect(rewriteCidImages(html, new Map())).toBe(html);
+  });
+});

--- a/web/src/app/components/messages/inlineImages.ts
+++ b/web/src/app/components/messages/inlineImages.ts
@@ -3,9 +3,9 @@
 // Mail clients embed pasted images as a MIME part referenced from the HTML by a
 // Content-ID URL — `<img src="cid:ii_abc@mail.gmail.com">` (or `url(cid:…)` in a
 // CSS background). The browser can't resolve `cid:` in a web document, so these
-// must be rewritten to a real URL (a data: or blob: URL of the fetched bytes)
-// before the HTML is rendered. These helpers are the pure string half of that;
-// the byte-fetching + React wiring lives in EmailHtmlBody.
+// must be rewritten to a real URL (a data: URL of the fetched bytes) before the
+// HTML is rendered. These helpers are the pure string half of that; the
+// byte-fetching + React wiring lives in EmailHtmlBody.
 
 // Matches a `cid:` reference and captures the Content-ID token — the part after
 // `cid:` up to the closing quote, whitespace, `)` (CSS url()), or `>`. Covers

--- a/web/src/app/components/messages/inlineImages.ts
+++ b/web/src/app/components/messages/inlineImages.ts
@@ -1,0 +1,31 @@
+// Pure helpers for resolving inline (cid:) images in an email HTML body.
+//
+// Mail clients embed pasted images as a MIME part referenced from the HTML by a
+// Content-ID URL — `<img src="cid:ii_abc@mail.gmail.com">` (or `url(cid:…)` in a
+// CSS background). The browser can't resolve `cid:` in a web document, so these
+// must be rewritten to a real URL (a data: or blob: URL of the fetched bytes)
+// before the HTML is rendered. These helpers are the pure string half of that;
+// the byte-fetching + React wiring lives in EmailHtmlBody.
+
+// Matches a `cid:` reference and captures the Content-ID token — the part after
+// `cid:` up to the closing quote, whitespace, `)` (CSS url()), or `>`. Covers
+// both `src="cid:X"` and `url(cid:X)` forms.
+const CID_REF = /cid:([^"'\s)>]+)/gi;
+
+// findCidRefs returns the distinct Content-ID tokens referenced by `cid:` URLs
+// in the HTML (empty set when there are none).
+export function findCidRefs(html: string): Set<string> {
+  const out = new Set<string>();
+  for (const m of html.matchAll(CID_REF)) {
+    if (m[1]) out.add(m[1]);
+  }
+  return out;
+}
+
+// rewriteCidImages replaces every `cid:<id>` reference whose id is present in
+// `urls` with the resolved URL. References with no entry (bytes unavailable) are
+// left untouched — they degrade to a broken image, exactly as before.
+export function rewriteCidImages(html: string, urls: Map<string, string>): string {
+  if (urls.size === 0) return html;
+  return html.replace(CID_REF, (whole, id: string) => urls.get(id) ?? whole);
+}

--- a/web/src/app/components/onboarding/api.ts
+++ b/web/src/app/components/onboarding/api.ts
@@ -7,6 +7,7 @@ import type {
   ProtectionConfig,
 } from "./types";
 import type {
+  AttachmentMeta,
   DashboardAgent,
   InboundMessageDetail,
   ListMessagesResponse,
@@ -337,6 +338,7 @@ type MessageViewWire = {
   // Backend-derived body: `text` (injection-reduced) for any message with raw
   // MIME, plus `html` (decoded text/html part) for rich display when present.
   parsed?: { text?: string; html?: string };
+  attachments?: AttachmentMeta[];
   raw_message?: string;
 };
 
@@ -428,9 +430,101 @@ export async function getMessageDetail(
       auth_headers: w.auth_headers ?? {},
       parsed: w.parsed,
       body: w.body,
+      attachments: w.attachments ?? [],
       raw_message: w.raw_message ?? "",
     },
   };
+}
+
+// ── Attachments ──────────────────────────────────────────
+
+// Wire shape of AttachmentView (GET …/messages/{id}/attachments/{index}):
+// metadata + a short-lived signed download_url; `data` (base64) is present
+// only when `?inline=true` was requested for an attachment within the 256 KB
+// inline cap.
+type AttachmentViewWire = {
+  index: number;
+  filename?: string;
+  content_type?: string;
+  content_id?: string;
+  size_bytes: number;
+  download_url: string;
+  expires_at: string;
+  data?: string;
+};
+
+// GET one attachment's metadata + a short-lived signed download_url. Pass
+// inline=true to also receive base64 `data` for small attachments (≤256 KB);
+// the server rejects larger inline requests (413).
+export async function getAttachment(
+  email: string,
+  messageId: string,
+  index: number,
+  opts?: { inline?: boolean },
+): Promise<AttachmentViewWire> {
+  const q = opts?.inline ? "?inline=true" : "";
+  return request<AttachmentViewWire>(
+    "/v1/agents/" +
+      encodeURIComponent(email) +
+      "/messages/" +
+      encodeURIComponent(messageId) +
+      "/attachments/" +
+      index +
+      q,
+  );
+}
+
+// The largest attachment the backend will base64-inline (`?inline=true`); must
+// mirror httpapi.attachmentInlineMaxBytes. At/below it we fetch one JSON
+// round-trip that already carries the base64; above it we stream the bytes and
+// encode them client-side.
+const ATTACHMENT_INLINE_CAP = 256 * 1024;
+
+// Strip an absolute download_url down to a same-origin path so the browser
+// fetches it through the dashboard's own /v1 proxy (the signed token, not a
+// cookie, authorizes it) — avoiding a cross-origin request to the API host.
+function sameOriginPath(absoluteURL: string): string {
+  try {
+    const u = new URL(absoluteURL);
+    return u.pathname + u.search;
+  } catch {
+    return absoluteURL; // already relative
+  }
+}
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = () => reject(reader.error ?? new Error("read failed"));
+    reader.readAsDataURL(blob);
+  });
+}
+
+// Load one inline image's bytes as a `data:` URL usable inside the email
+// iframe. Small images come straight back base64-encoded from the inline
+// endpoint (one round-trip); larger ones stream through the signed download URL
+// and are encoded client-side. A data: URL is used (not blob:) because
+// DOMPurify's URI filter permits data: images but not blob:, and the sandboxed
+// iframe's CSP already allows `img-src data:`. Base64 in the browser is a
+// memory concern only — never the agent-context concern the API's inline cap
+// guards, so any size is fine to render here.
+export async function loadInlineAttachmentUrl(
+  email: string,
+  messageId: string,
+  meta: AttachmentMeta,
+): Promise<{ url: string }> {
+  const contentType = meta.content_type || "application/octet-stream";
+  if (meta.size_bytes <= ATTACHMENT_INLINE_CAP) {
+    const a = await getAttachment(email, messageId, meta.index, { inline: true });
+    if (a.data) {
+      return { url: `data:${contentType};base64,${a.data}` };
+    }
+  }
+  const a = await getAttachment(email, messageId, meta.index);
+  const res = await fetch(sameOriginPath(a.download_url), { credentials: "include" });
+  if (!res.ok) throw new ApiError("attachment fetch failed", res.status);
+  return { url: await blobToDataUrl(await res.blob()) };
 }
 
 // ── Protection config (review-queue holds) ──────────────

--- a/web/src/app/components/types.ts
+++ b/web/src/app/components/types.ts
@@ -56,6 +56,18 @@ export type PendingAttachment = {
   data: string; // base64
 };
 
+// Metadata for one attachment of a received/sent message — never the bytes.
+// `index` is the stable 0-based fetch key for the attachment-bytes endpoint;
+// `content_id` (when present) is the Content-ID an HTML body's `cid:` URL
+// resolves against, marking the part as an inline image embedded in the body.
+export type AttachmentMeta = {
+  index: number;
+  filename?: string;
+  content_type?: string;
+  size_bytes: number;
+  content_id?: string;
+};
+
 export type PendingMessageDetail = PendingMessageSummary & {
   email_message_id?: string;
   body_text?: string;
@@ -154,6 +166,10 @@ export type InboundMessageDetail = {
   parsed?: { text?: string; html?: string };
   // Held-draft body shape (outbound). Inbound rows carry `parsed` instead.
   body?: { text?: string; html?: string };
+  // Per-attachment metadata (never bytes). Inline images (those with a
+  // content_id referenced by a `cid:` in `parsed.html`) render in the body;
+  // the rest surface as download chips. Bytes are fetched on demand.
+  attachments?: AttachmentMeta[];
   // Raw RFC-5322 bytes, base64-encoded by the JSON layer. Decoded only as a
   // last-resort fallback when neither `parsed.html` nor `parsed.text` is present.
   raw_message: string;


### PR DESCRIPTION
## Summary

The dashboard couldn't render inline email images — a pasted image (Gmail's `<img src="cid:…">`) showed a broken-image icon — and it surfaced no attachments (PDFs, etc.) at all. Root cause: `mailparse` dropped the `Content-ID` header, so nothing could map a `cid:` reference to its attachment, and the web layer never consumed attachment metadata. This exposes `content_id` on attachment metadata (additive) and teaches the conversation view + message focus page to render inline images and offer download chips for the rest.

Reported case: a 204 KB `image/png` embedded by Gmail as `cid:` — now renders inline.

## How it works

- **Backend:** capture `Content-ID` (angle brackets stripped) on `mailparse.Attachment` and expose it, **additively**, as `content_id` on the message view's `attachments[]`, the `email.received` event payload, and the `getAttachment` response. Omitted for ordinary non-inline attachments.
- **Web:** resolve each `cid:` to its attachment by `content_id`, fetch the bytes (inline endpoint for ≤256 KB, else the signed `download_url`, client-encoded to a `data:` URL), and rewrite the `<img src>`. **Inline images render by default** — they travelled with the mail and are not a remote tracker; genuine remote `http(s)` images stay behind the existing "Load images" opt-in, which is now scheme-aware so `data:` inline images survive the block. Non-inline attachments render as download chips.

Security posture unchanged: DOMPurify + sandboxed no-scripts iframe + authoritative CSP. `data:` is the only new inline-image source (already CSP-allowed; `blob:` is intentionally avoided because DOMPurify strips it). The 256 KB inline cap is an *agent-context* guard, not a rendering limit — large inline images stream via the signed download URL, matching how every webmail client serves images.

## Client surface checklist

- [x] Go handler + tests — `mailparse` (Content-ID capture + cid-only inline inclusion) and `httpapi` attachment-endpoint test assert `content_id` flows through
- [x] ~~Migration~~ — N/A, no table/schema change (parsed from raw MIME at read time)
- [x] OpenAPI spec + generated types refreshed (`make generate` clean)
- [x] TypeScript SDK — generated base regenerated; **no hand-written `E2AClient` change needed** — this is an additive field on the existing `AttachmentView`/`AttachmentMetaView` models, not a new resource
- [x] Python SDK — generated base regenerated; same (additive field on existing models)
- [x] ~~CLI~~ — N/A, additive field flows through existing message/attachment outputs
- [x] ~~MCP tool~~ — N/A, `content_id` surfaces automatically on the existing `get_message`/`get_attachment` tool outputs
- [x] Tests at each surface (positive + negative): Go unit + httpapi; web adds `inlineImages`, `AttachmentChips`, and `EmailHtmlBody` inline-image tests

## Operational risk

Low. Additive API field only — no migration, no behavior change for existing clients. Attachment bytes are still fetched out of band (never inlined into the agent-facing `parsed.html`). The web fetches inline-image bytes through the dashboard's own same-origin `/v1` proxy using the existing signed capability token — no new auth surface. No billing/notification/external-integration impact.

## Test plan

- [x] `go test ./internal/mailparse/ ./internal/httpapi/ ./internal/eventpayload/` — pass (incl. `TestSpecGoldenNoDrift`)
- [x] `make generate` clean; `make generate-sdk-check` passes once committed
- [x] Web: full Jest suite (333 tests, 15 new), `tsc` clean on changed files, ESLint clean, `npm run build` succeeds
- [x] High-effort self-review; fixed the one real gap (filename-less `cid:`-only inline images)
- [ ] After merge: verify end-to-end against a live inbound `cid:` message (needs running stack + a real inline-image email) — not exercised locally; covered by unit/component tests and the reported 204 KB image uses the inline path
