### PR TITLE
docs: refresh CLAUDE.md, CONTRIBUTING.md, README.md to current codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,9 +16,12 @@ make test               # all Go tests (needs Postgres on :5433)
 make test-unit          # Go unit tests only (no DB needed)
 make test-integration   # Go integration tests (needs Postgres on :5433)
 make test-e2e           # Go e2e tests (needs Postgres on :5433)
+make cover-check        # run tests with coverage + enforce per-package floors (.testcoverage.yml; needs Postgres)
 make docker-up          # start local Postgres + Mailpit via docker compose
 make migrate            # apply SQL migrations to local DB
 ```
+
+`make cover` writes `cover.out` across `internal/...`; `make cover-check` enforces the per-package floors in `.testcoverage.yml` (same gate CI runs via the `vladopajic/go-test-coverage` action). `make openapi-compat-check` (backward-compat gate) diffs the freshly verified Huma contract against `origin/main:api/openapi.yaml`; `make openapi-compat-test` runs its test harness.
 
 Go tests that need the database use `E2A_TEST_DATABASE_URL="postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable"`.
 
@@ -79,16 +82,35 @@ The main server (`cmd/e2a/main.go`) runs an SMTP relay and HTTP API. Key interna
 - **relay** — SMTP server, receives inbound email
 - **emailauth** — SPF/DKIM verification on inbound messages
 - **agent** — Agent CRUD, API endpoints, routes
-- **identity** — Domain ownership verification and storage
+- **identity** / **senderidentity** — domain ownership verification/storage and sender-identity resolution
 - **headers** — HMAC-SHA256 signing of `X-E2A-Auth-*` headers
-- **webhook** — HTTP POST delivery to agent endpoints with retry
 - **ws** — WebSocket hub for real-time message push
-- **outbound** — Compose and send emails via upstream SMTP (SES)
-- **billing** — Stripe integration, usage metering
+- **outbound** / **outboundsend** — compose and send emails via upstream SMTP (SES); queue-first send worker
+- **inboundprocess** / **inboundpolicy** — async inbound processing worker and screening/policy decisions
+- **piguard** — prompt-injection / content screening (paid-tier PI scan)
+- **hitlworker** / **hitlnotify** — human-in-the-loop review holds (`pending_review`) and approval notifications
+- **webhook** / **webhookdelivery** / **webhookpub** — webhook subscriptions plus durable fan-out + HTTP POST delivery with retry
+- **jobs** — River-backed durable job runtime (queue registry, reconciler)
+- **janitor** — periodic TTL sweeps / cleanup (trash expiry, expired holds)
+- **idempotency** — `Idempotency-Key` storage + replay for sends and mutations
+- **usage** / **limits** — usage metering and plan/account entitlement limits
 - **auth** — API key authentication
 - **config** — YAML config + env var overrides
 
 Inbound flow: SMTP → emailauth (SPF/DKIM) → agent lookup → headers signing → webhook or WebSocket delivery.
+
+### Delivery is durable (River jobs)
+
+The outbound send, inbound processing, webhook fan-out/delivery, and HITL-notify
+paths run on a River-backed durable job system (`internal/jobs` + per-domain
+worker packages) for at-least-once semantics. **Outbound send is always
+queue-first for GA** — the accept transaction atomically persists the message and
+enqueues the send job before returning; the legacy `E2A_OUTBOUND_MODE` switch and
+its config model were removed (guarded by `TestOutboundModeConfigurationRemoved`).
+Inbound and webhook fan-out still ship behind fail-safe opt-in flags:
+`E2A_INBOUND_MODE=async` (default `sync`) and `E2A_WEBHOOK_FANOUT_MODE=river`
+(default `legacy`); any other value falls back to the historical in-process path.
+Design docs live under `docs/design/`.
 
 ### OpenAPI spec source of truth
 
@@ -174,7 +196,7 @@ the built-in `GITHUB_TOKEN` (no trusted publisher involved).
 
 - **npm workspaces**: root `package.json` declares `cli`, `sdks/typescript`, `mcp`, and `design-system` as workspaces. Always use `--workspace` flag for workspace commands. Use `--package-lock=false` for install.
 - **Go module**: `github.com/tokencanopy/e2a`, Go 1.25
-- **Go test tiers**: `test-unit` needs no DB. `test-integration` needs Postgres (runs identity/agent packages). `test-e2e` uses build tag `integration` and runs `internal/e2e/`. `make test` runs everything (including e2e) with `-tags integration -p 1`.
+- **Go test tiers**: `test-unit` needs no DB (headers, outbound, relay, config, webhook, approvaltoken, limits, httpapi, ratelimit). `test-integration` needs Postgres (identity, agent, hitlworker, hitlnotify, limits, relay). `test-e2e` uses build tag `integration` and runs `internal/e2e/` + `internal/senderidentity/`. `make test` runs everything (including e2e) with `-tags integration -p 1`. `make cover-check` enforces per-package coverage floors from `.testcoverage.yml`.
 - **Schema changes**: when changing a table shape, add or update DB-backed tests for every package that writes direct SQL against that table. Higher-level e2e tests are not enough. Our migration helper is idempotent and will not automatically catch old query assumptions if runtime SQL drifts from the redesigned schema.
 - **Migrations**: every `migrations/00N_*.sql` must be **idempotent** (use `CREATE TABLE IF NOT EXISTS`, `ADD COLUMN IF NOT EXISTS`, etc.) and **non-destructive on prod-sized tables** (`ALTER TABLE ... ADD COLUMN` is safe; `ALTER COLUMN TYPE` can rewrite the whole table — avoid on `messages` and `usage_events`). The e2a binary embeds `migrations/*.sql` via `migrations/embed.go` and auto-applies pending ones at startup against a `schema_migrations` tracker table; `E2A_MIGRATION_MODE` controls the behavior (`auto` default, `verify` to refuse and report pending, `skip` for emergency surgery). New migrations land in prod on the next binary deploy with zero manual ceremony.
 - **Postgres**: local dev DB runs on port 5433 (not 5432) via docker compose.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,11 +168,14 @@ For API-only contributions you can skip the dashboard.
 | `internal/agent/` | Agent CRUD, HITL, REST API |
 | `internal/identity/` | Domain ownership, message store |
 | `internal/headers/` | HMAC-signed `X-E2A-Auth-*` headers |
-| `internal/webhook/` | Outbound webhook delivery + retry |
-| `internal/webhookpub/` | Stripe-tier durable outbox |
+| `internal/webhook/`, `internal/webhookdelivery/`, `internal/webhookpub/` | Webhook subscriptions, durable fan-out + delivery outbox |
 | `internal/ws/` | WebSocket hub for real-time push |
-| `internal/outbound/` | Compose + send via upstream SMTP |
-| `internal/billing/` | Stripe + usage metering |
+| `internal/outbound/`, `internal/outboundsend/` | Compose + send via upstream SMTP; queue-first send worker |
+| `internal/inboundprocess/`, `internal/inboundpolicy/` | Async inbound processing worker + screening/policy |
+| `internal/hitlworker/`, `internal/hitlnotify/` | HITL review holds + approval notifications |
+| `internal/jobs/`, `internal/janitor/` | River durable-job runtime; periodic TTL sweeps |
+| `internal/idempotency/` | `Idempotency-Key` storage + replay |
+| `internal/usage/`, `internal/limits/` | Usage metering + plan/account entitlement limits |
 | `internal/auth/` | API key + user auth |
 | `internal/config/` | YAML config + env var overrides |
 | `cli/` | `e2a` CLI (TypeScript) |
@@ -196,8 +199,9 @@ slow and need a database.
 ```bash
 make test-unit          # no DB needed — fast
 make test-integration   # needs Postgres on :5433 (make docker-up)
-make test-e2e           # build tag 'integration', runs internal/e2e/*
+make test-e2e           # build tag 'integration', runs internal/e2e/* + senderidentity
 make test               # all three, with -p 1 to avoid DB-state races
+make cover-check        # tests + per-package coverage floors (.testcoverage.yml)
 ```
 
 Run a single Go test against the local DB:

--- a/README.md
+++ b/README.md
@@ -401,6 +401,7 @@ make test                # all Go tests (needs Postgres on :5433)
 make test-unit           # Go unit tests only (no DB)
 make test-integration    # integration tests (needs Postgres)
 make test-e2e            # e2e tests (needs Postgres)
+make cover-check         # tests + per-package coverage floors (needs Postgres)
 make docker-up           # start local Postgres + Mailpit via docker compose
 make migrate             # apply SQL migrations to local DB
 ```


### PR DESCRIPTION
## Summary

Documentation-only refresh bringing the top-level docs in line with the current internal layout and delivery model. No code changes.

- Drop the removed `internal/billing` package reference; metering is now `usage`/`limits`.
- Document the River durable-jobs packages (`jobs`, `webhookdelivery`, `inboundprocess`, `hitlworker`/`hitlnotify`, `idempotency`, `janitor`, `outboundsend`, etc.).
- Note that outbound send is always queue-first for GA (`E2A_OUTBOUND_MODE` removed, guarded by `TestOutboundModeConfigurationRemoved`), while inbound (`E2A_INBOUND_MODE=async`) and webhook fan-out (`E2A_WEBHOOK_FANOUT_MODE=river`) stay fail-safe opt-in.
- Add `cover-check` / `openapi-compat-check` make targets and correct the test-tier package sets across CLAUDE.md, CONTRIBUTING.md, and README.md.

## Verification

Cross-checked against the `Makefile`, the `internal/` package tree, and `config.go` / `config_test.go`. Docs-only; no build or test surface affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)