### PR TITLE
chore(dependabot): track Python SDK via uv ecosystem (not pip)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,7 +59,11 @@ updates:
       npm-minor-patch:
         update-types: ["minor", "patch"]
 
-  - package-ecosystem: "pip"
+  # The Python SDK resolves through uv.lock, so use the native `uv`
+  # ecosystem — the `pip` ecosystem reads pyproject.toml but does NOT
+  # update uv.lock, which is why the lockfile's CVEs never got an
+  # auto-PR and had to be refreshed by hand.
+  - package-ecosystem: "uv"
     directory: "/sdks/python"
     schedule:
       interval: "weekly"
@@ -67,7 +71,7 @@ updates:
     commit-message:
       prefix: "deps(python)"
     groups:
-      pip-minor-patch:
+      uv-minor-patch:
         update-types: ["minor", "patch"]
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Summary

The repo already has a comprehensive `.github/dependabot.yml` (gomod, npm ×4, github-actions, docker). One real gap: the Python SDK entry used `package-ecosystem: "pip"`, which reads `pyproject.toml` but **does not update `uv.lock`** — the SDK resolves through uv.lock, so Dependabot never proposed lockfile bumps. That's precisely why the Python `uv.lock` CVEs (urllib3, cryptography, idna, pytest, Pygments) piled up with no auto-PR and had to be refreshed by hand in #527.

This switches that one entry to the native `uv` ecosystem so Dependabot maintains `uv.lock` going forward.

## Note on auto-fix PRs

Version-update config (this file) drives the *weekly* PRs. Separately, **"Dependabot security updates"** — a repo setting (Settings → Code security), not something expressible in this YAML — is what opens immediate fix-PRs for open alerts. If that toggle is off, alerts surface but no auto-PR lands. Worth confirming it's enabled so the backlog we just cleared by hand stays cleared automatically.

## Test plan

- [x] `yaml.safe_load` parses; 8 update entries resolve (`uv` now in place of `pip`)
- [ ] After merge: confirm Dependabot picks up the `uv` ecosystem (a validation run appears in the repo's Dependabot logs)