### PR TITLE
docs(security): route vulnerability reports to security@tokencanopy.com

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@ For what e2a stores, how long it lives, log handling, and the user/operator data
 
 ## Reporting a vulnerability
 
-Email **josh@tokencanopy.com** with:
+Email **security@tokencanopy.com** with:
 
 - A description of the issue
 - Steps to reproduce (or a proof-of-concept)


### PR DESCRIPTION
Updates the vulnerability-reporting address in `SECURITY.md` from `josh@tokencanopy.com` to `security@tokencanopy.com`.

Author metadata in `sdks/python/pyproject.toml` and `sdks/typescript/package.json` still uses the personal address — left unchanged since those are maintainer/author fields, not the security contact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)