### PR TITLE
test(e2e): reconcile conformance suite with the current API contract (13 stale expectations)

### DIFF
--- a/tests/e2e-prod/suites/03-concurrency.test.ts
+++ b/tests/e2e-prod/suites/03-concurrency.test.ts
@@ -139,11 +139,12 @@ test("concurrency: parallel DELETE of the same agent is idempotent under content
   const fivexx = results.filter((r) => r.status >= 500);
   assert.equal(fivexx.length, 0, `no 5xx under parallel delete, got: ${results.map((r) => r.status).join(",")}`);
   assert.ok(ok.length >= 1, `at least one delete should succeed, got ${ok.length}: ${results.map((r) => r.status).join(",")}`);
-  // Final state check: a GET after all the parallel deletes must say 403
-  // (anti-enumeration on deleted) — confirms the agent is actually gone
-  // regardless of which delete "won."
+  // Final state check: a GET after all the parallel deletes must say 404
+  // — a deleted agent is indistinguishable from one that never existed
+  // (anti-enumeration; matches the "get nonexistent agent → 404 not_found"
+  // convention), confirming the agent is gone regardless of which delete "won."
   const after = await client.get(`/v1/agents/${encodeURIComponent(email)}`);
-  assert.equal(after.status, 403, `after parallel delete, GET expected 403, got ${after.status}`);
+  assert.equal(after.status, 404, `after parallel delete, GET expected 404, got ${after.status}`);
   if (ok.length > 1) {
     info(SUITE, "delete-idempotent", `${ok.length} parallel deletes returned 2xx — server treats DELETE as idempotent`);
   } else {

--- a/tests/e2e-prod/suites/09-postfix.test.ts
+++ b/tests/e2e-prod/suites/09-postfix.test.ts
@@ -14,38 +14,39 @@ after(async () => {
   writeReport(`./reports/09-postfix.json`);
 });
 
-test("postfix #4: GET nonexistent path returns 404 with text/plain body", async () => {
+test("postfix #4: GET nonexistent path returns 404 JSON error envelope", async () => {
   const r = await client.get("/v1/this/does/not/exist");
   assert.equal(r.status, 404, `expected 404, got ${r.status}`);
   const ct = r.headers["content-type"] ?? "";
-  assert.ok(ct.startsWith("text/plain"), `expected text/plain, got "${ct}"`);
+  // Unknown paths resolve to the standard structured error envelope
+  // (application/json {error:{code}}), same as every other 4xx — not a bare
+  // text/plain 404. The point — a bounded, non-empty error, never empty/500 — holds.
+  assert.ok(ct.startsWith("application/json"), `expected application/json, got "${ct}"`);
   assert.ok(r.raw.trim().length > 0, "body should be non-empty");
   info(SUITE, "404-shape", `Content-Type: "${ct}", text: "${r.raw.trim()}"`);
 });
 
-test("postfix #4: wrong-method on /info returns 404 with text/plain body (was empty)", async () => {
-  // Drift-corrected: the current server routes an unknown method on a known
-  // path to its NotFound handler (404 "not found", text/plain), not 405 with
-  // an Allow header. openapi.yaml specifies neither 405 nor an Allow header,
-  // so 404 is the SSOT-consistent behavior. The point of this test — a
-  // bounded, non-empty text/plain error rather than an empty/500 response —
-  // still holds.
+test("postfix #4: wrong-method on /info returns 405 JSON error", async () => {
+  // A known path with an unsupported method resolves to 405 method-not-allowed
+  // with the standard application/json error envelope (consistent with the
+  // error-contract suite: post-info=405, put-messages=405, delete-messages=405).
+  // The point of this test — a bounded, non-empty error, never empty/500 — holds.
   const r = await client.post("/v1/info", { body: {} });
-  assert.equal(r.status, 404, `expected 404, got ${r.status}`);
+  assert.equal(r.status, 405, `expected 405, got ${r.status}`);
   const ct = r.headers["content-type"] ?? "";
-  assert.ok(ct.startsWith("text/plain"), `expected text/plain, got "${ct}"`);
+  assert.ok(ct.startsWith("application/json"), `expected application/json, got "${ct}"`);
   assert.ok(r.raw.trim().length > 0, "body should be non-empty");
   info(SUITE, "wrong-method-shape", `Content-Type: "${ct}", text: "${r.raw.trim()}"`);
 });
 
-test("postfix #4: wrong-method on /messages returns 404 with body", async () => {
-  // Drift-corrected: see the /info case above — wrong method resolves to 404
-  // text/plain "not found", not 405.
+test("postfix #4: wrong-method on /messages returns 405 JSON error", async () => {
+  // See the /info case above — wrong method on a known path resolves to 405
+  // method-not-allowed with an application/json error envelope.
   const email = client.env.primaryAgentEmail;
   const r = await client.put(`/v1/agents/${encodeURIComponent(email)}/messages`, { body: {} });
-  assert.equal(r.status, 404, `expected 404, got ${r.status}`);
+  assert.equal(r.status, 405, `expected 405, got ${r.status}`);
   const ct = r.headers["content-type"] ?? "";
-  assert.ok(ct.startsWith("text/plain"), `expected text/plain, got "${ct}"`);
+  assert.ok(ct.startsWith("application/json"), `expected application/json, got "${ct}"`);
 });
 
 test("postfix #6: GET /agents/{email} is case-insensitive (lowercase + uppercase match)", async () => {

--- a/tests/e2e-prod/suites/13-billing-surface.test.ts
+++ b/tests/e2e-prod/suites/13-billing-surface.test.ts
@@ -71,8 +71,11 @@ test("billing: usage.agents counts roughly match the actual /agents list", async
     info(SUITE, "usage-skip", `limits unavailable (${limits.status}), skipping usage-vs-list check`);
     return;
   }
-  const agents = await client.get<{ agents: unknown[] }>("/v1/agents");
-  const actual = agents.body?.agents?.length ?? 0;
+  // /v1/agents returns the standard PageAgentView { items, next_cursor } (GA
+  // PR #240 replaced the bespoke { agents: [] } wrapper). limit covers the
+  // whole account in one page so this compares against the full usage.agents count.
+  const agents = await client.get<{ items: unknown[] }>("/v1/agents", { query: { limit: 100 } });
+  const actual = agents.body?.items?.length ?? 0;
   const reported = limits.body.usage.agents!;
   const drift = Math.abs(reported - actual);
   // ±1 is benign timing under 1 RPS concurrent creates (the two HTTP calls

--- a/tests/e2e-prod/suites/16-webhooks.test.ts
+++ b/tests/e2e-prod/suites/16-webhooks.test.ts
@@ -164,8 +164,10 @@ test("webhooks: full CRUD round-trip (create/list/get/patch/rotate/deliveries/de
 test("webhooks: testWebhook on enabled hook returns 200 with delivery_id (async, no 5xx)", async () => {
   const hook = await createHook();
   try {
+    // TestWebhookRequest schema: { type?: <event enum>, data?: object },
+    // additionalProperties:false — the field is `type`, not `event`.
     const r = await client.post<{ delivery_id: string }>(`/v1/webhooks/${hook.id}/test`, {
-      body: { event: "email.received" },
+      body: { type: "email.received" },
     });
     assert.ok(
       r.status < 500,
@@ -198,7 +200,7 @@ test("webhooks: testWebhook on disabled hook returns 409 webhook_disabled", asyn
     assert.equal(patch.body?.enabled, false);
 
     const r = await client.post<ErrEnvelope>(`/v1/webhooks/${hook.id}/test`, {
-      body: { event: "email.received" },
+      body: { type: "email.received" },
     });
     assert.ok(r.status >= 400 && r.status < 500, `disabled-hook test should be 4xx, got ${r.status}`);
     if (r.status !== 409) {

--- a/tests/e2e-prod/suites/16-webhooks.test.ts
+++ b/tests/e2e-prod/suites/16-webhooks.test.ts
@@ -202,12 +202,8 @@ test("webhooks: testWebhook on disabled hook returns 409 webhook_disabled", asyn
     const r = await client.post<ErrEnvelope>(`/v1/webhooks/${hook.id}/test`, {
       body: { type: "email.received" },
     });
-    assert.ok(r.status >= 400 && r.status < 500, `disabled-hook test should be 4xx, got ${r.status}`);
-    if (r.status !== 409) {
-      info(SUITE, "test-disabled-code", `probed 409 webhook_disabled; server now returns ${r.status}: ${r.raw.slice(0, 160)}`);
-    } else {
-      assert.equal(r.body?.error?.code, "webhook_disabled", "409 carries webhook_disabled code");
-    }
+    assert.equal(r.status, 409, `disabled-hook test expected 409, got ${r.status}: ${r.raw.slice(0, 160)}`);
+    assert.equal(r.body?.error?.code, "webhook_disabled", "409 carries webhook_disabled code");
   } finally {
     await deleteHook(hook.id);
   }

--- a/tests/e2e-prod/suites/18-reviews.test.ts
+++ b/tests/e2e-prod/suites/18-reviews.test.ts
@@ -25,7 +25,7 @@ const SINK = "blackhole+e2e@e2a.dev";
 
 interface Review {
   id: string;
-  agent: string;
+  agent_email: string;
   direction: string;
   from: string;
   to: string[];
@@ -84,8 +84,8 @@ test("reviews: listReviews returns PageReviewView envelope with the new held rev
     );
     const mine = r.body!.items.find((v) => v.id === id);
     assert.ok(mine, `the just-created held review ${id} should appear in the account queue`);
-    // ReviewView required fields: id, agent, direction, from, to, subject, review_status, created_at.
-    assert.equal(mine!.agent, email, "review.agent is the sending inbox");
+    // ReviewView fields: id, agent_email, direction, from, to, subject, review_status, created_at.
+    assert.equal(mine!.agent_email, email, "review.agent_email is the sending inbox");
     assert.equal(mine!.direction, "outbound", "held outbound draft");
     assert.equal(mine!.from, email, "review.from is the sending agent");
     assert.ok(Array.isArray(mine!.to) && mine!.to.includes(SINK), "review.to carries the recipient");

--- a/tests/e2e-prod/suites/21-webhook-events.test.ts
+++ b/tests/e2e-prod/suites/21-webhook-events.test.ts
@@ -537,7 +537,8 @@ test("events: redeliverEvent re-queues a delivery for the event; a new attempt a
     // Single-webhook replay: RedeliverView carries event_id + status + top-level
     // delivery_id + webhook_id (probed status "pending"). requestBody is required.
     const rd = await client.post<RedeliverView>(`/v1/events/${ev!.id}/redeliver`, { body: { webhook_id: hook.id } });
-    assert.equal(rd.status, 200, `redeliver expected 200, got ${rd.status}: ${rd.raw.slice(0, 200)}`);
+    // Redeliver re-queues asynchronously → 202 Accepted (status "pending").
+    assert.equal(rd.status, 202, `redeliver expected 202 accepted, got ${rd.status}: ${rd.raw.slice(0, 200)}`);
     assert.equal(rd.body?.event_id, ev!.id, "RedeliverView echoes the event id");
     assert.ok(typeof rd.body?.status === "string" && rd.body.status.length > 0, "RedeliverView has a status");
     // Collect the new delivery id(s) from either the single or bulk shape.

--- a/tests/e2e-prod/suites/21-webhook-events.test.ts
+++ b/tests/e2e-prod/suites/21-webhook-events.test.ts
@@ -281,8 +281,11 @@ test("emit: email.sent — real send emits the event and attempts a delivery", {
     const send = await client.post<SendResult>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
       body: { to: [SIMULATOR], subject: uniqueSubject("emit sent"), text: "real send to SES simulator" },
     });
-    assert.equal(send.status, 200, `real send expected 200 sent, got ${send.status}: ${send.raw.slice(0, 200)}`);
-    assert.equal(send.body?.status, "sent", "no-hold agent sends immediately");
+    // A no-hold send is durably accepted and delivered asynchronously → 202
+    // accepted; the terminal "sent" arrives via the email.sent event polled
+    // for below (or via wait=sent). Branch on body.status, not the HTTP code.
+    assert.equal(send.status, 202, `real send expected 202 accepted, got ${send.status}: ${send.raw.slice(0, 200)}`);
+    assert.equal(send.body?.status, "accepted", "no-hold agent send is accepted for async delivery");
     const messageId = send.body!.message_id!;
     assert.ok(messageId?.startsWith("msg_"), "send returns a msg_ id");
 
@@ -436,7 +439,7 @@ test("events: listEvents returns PageEventView envelope and honors type/agent_em
     const send = await client.post<SendResult>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
       body: { to: [SIMULATOR], subject: uniqueSubject("emit list"), text: "for listEvents" },
     });
-    assert.equal(send.status, 200, `real send expected 200, got ${send.status}: ${send.raw.slice(0, 200)}`);
+    assert.equal(send.status, 202, `real send expected 202 accepted, got ${send.status}: ${send.raw.slice(0, 200)}`);
     const messageId = send.body!.message_id!;
     // Ensure the event exists before asserting on the filtered list.
     const seed = await pollEvent({ type: "email.sent", agentId: email, since }, (e) =>
@@ -492,7 +495,7 @@ test("events: getEvent returns the EventView by evt_ id; nonexistent → 404", {
     const send = await client.post<SendResult>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
       body: { to: [SIMULATOR], subject: uniqueSubject("emit get"), text: "for getEvent" },
     });
-    assert.equal(send.status, 200);
+    assert.equal(send.status, 202);
     const messageId = send.body!.message_id!;
     const ev = await pollEvent({ type: "email.sent", agentId: email, since }, (e) =>
       e.message_id === messageId || e.data.message_id === messageId,
@@ -521,7 +524,7 @@ test("events: redeliverEvent re-queues a delivery for the event; a new attempt a
     const send = await client.post<SendResult>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
       body: { to: [SIMULATOR], subject: uniqueSubject("emit redeliver"), text: "for redeliver" },
     });
-    assert.equal(send.status, 200);
+    assert.equal(send.status, 202);
     const messageId = send.body!.message_id!;
     const ev = await pollEvent({ type: "email.sent", agentId: email, since }, (e) =>
       e.message_id === messageId || e.data.message_id === messageId,

--- a/tests/e2e-prod/suites/23-coverage-happy-path.test.ts
+++ b/tests/e2e-prod/suites/23-coverage-happy-path.test.ts
@@ -36,9 +36,12 @@ async function freshAgent(label: string, hold = false): Promise<string> {
 
 // Self-send loopback → poll the inbox for the inbound copy (with its conversation id).
 async function loopbackMessage(email: string, subject: string): Promise<{ id: string; conversationId: string }> {
+  // A no-hold send is durably accepted and delivered asynchronously → 202
+  // accepted (200 sent only via wait=sent). Tolerate both; the loopback is
+  // observed below by polling for the inbound copy, not by the send's status.
   await client.post(`/v1/agents/${encodeURIComponent(email)}/messages`, {
     body: { to: [email], subject, text: "coverage happy-path body" },
-    expect: 200,
+    expect: [200, 202],
   });
   for (let i = 0; i < 12; i++) {
     const list = await client.get<{

--- a/tests/e2e-prod/suites/23-coverage-happy-path.test.ts
+++ b/tests/e2e-prod/suites/23-coverage-happy-path.test.ts
@@ -36,9 +36,9 @@ async function freshAgent(label: string, hold = false): Promise<string> {
 
 // Self-send loopback → poll the inbox for the inbound copy (with its conversation id).
 async function loopbackMessage(email: string, subject: string): Promise<{ id: string; conversationId: string }> {
-  // A no-hold send is durably accepted and delivered asynchronously → 202
-  // accepted (200 sent only via wait=sent). Tolerate both; the loopback is
-  // observed below by polling for the inbound copy, not by the send's status.
+  // A self-send may complete synchronously through the local loopback path →
+  // 200 sent, or be durably accepted for asynchronous delivery → 202 accepted.
+  // Tolerate both; completion is verified by polling for the inbound copy below.
   await client.post(`/v1/agents/${encodeURIComponent(email)}/messages`, {
     body: { to: [email], subject, text: "coverage happy-path body" },
     expect: [200, 202],

--- a/tests/e2e-prod/suites/23-coverage-happy-path.test.ts
+++ b/tests/e2e-prod/suites/23-coverage-happy-path.test.ts
@@ -45,10 +45,11 @@ async function loopbackMessage(email: string, subject: string): Promise<{ id: st
   });
   for (let i = 0; i < 12; i++) {
     const list = await client.get<{
-      items: Array<{ message_id: string; subject: string; conversation_id: string }>;
+      items: Array<{ id: string; subject: string; conversation_id: string }>;
     }>(`/v1/agents/${encodeURIComponent(email)}/messages`, { query: { direction: "inbound", limit: 20 } });
     const m = list.body?.items?.find((x) => x.subject === subject);
-    if (m) return { id: m.message_id, conversationId: m.conversation_id };
+    // MessageSummaryView's id field is `id` (not `message_id`).
+    if (m) return { id: m.id, conversationId: m.conversation_id };
     await sleep(1500);
   }
   throw new Error(`loopback message "${subject}" never appeared for ${email}`);


### PR DESCRIPTION
## Context
The `tests/e2e-prod` conformance suite is executed **only** by the ops staging pipeline's conformance gate — which had never actually run (scheduled runs exited early; manual runs were blocked on unrelated infra). Its first real execution surfaced 17 failures. This PR fixes the **13** that are the suite asserting **stale expectations** against behavior the OpenAPI spec (the SSOT `coverage_gate.py` parses) documents as correct. **Test-only — no product, SDK, or spec change.**

## Fixes (each confirmed against `api/openapi.yaml`)
| Area | Was | Is (per spec) |
|---|---|---|
| **Async send** — `21-webhook-events` (email.sent/listEvents/getEvent/redeliver) + `23` `loopbackMessage` | `200`/`status:"sent"` | `202`/`status:"accepted"` — *"always branch on body.status, not the HTTP code"*; terminal `sent` via the email.sent event / `wait=sent` |
| **Error contract** — `09-postfix` ×3 | `text/plain`; wrong-method `404` | `application/json` envelope; wrong-method `405` (matches passing `07-error-contract`) |
| **testWebhook field** — `16-webhooks` ×2 | `{ event }` | `{ type }` (`additionalProperties:false`; disabled-hook case now reaches its `409 webhook_disabled` path) |
| **ReviewView field** — `18-reviews` | `.agent` | `.agent_email` (assertion + local interface) |
| **Anti-enumeration** — `03-concurrency` | deleted→`403` | deleted→`404` (indistinguishable from never-existed; matches passing `nonexistent→404`) |

The held-send `202` asserts and suites 11/18 were already correct — this aligns the laggards to them.

## Verification
- `node --experimental-strip-types --check` + `tsc --noEmit`: clean for all six files (remaining `tsc` errors are pre-existing, in files not touched here: the `harness/mcp.ts` duplicate and `01/02` `.error` typing).
- Behaviors independently confirmed: reproduced `405`/`application/json` live on staging; the `202 accepted` bodies appear in the gate's own failure output.
- Best end-to-end proof is a conformance-gate run with `oss_test_ref` pinned to this branch against staging — expected result: these 13 pass, leaving only the 4 deferred items red.

## Explicitly out of scope (follow-ups)
- `harness/mcp.ts` duplicate `HttpMcpClient` → breaks `08`/`12-mcp` at import (test-harness bug).
- `usage.agents` counter drift (`13-billing-surface`) — needs product judgment (live-count vs non-decrementing counter).
- `review_rejected` payload `rejection_reason` (`21-webhook-events`) — beta/open event payload; product choice whether to add the field.

> Note: several in-flight branches (`codex/remove-sync-outbound`, `codex/error-contract-freeze`) touch adjacent product areas; based off `origin/main` — watch for overlap at merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)