### PR TITLE
test(e2e): read review_rejected event reason from data.reason (#451 rename)

### DIFF
--- a/tests/e2e-prod/suites/21-webhook-events.test.ts
+++ b/tests/e2e-prod/suites/21-webhook-events.test.ts
@@ -372,7 +372,10 @@ test("emit: email.review_rejected — rejecting a hold emits the event and attem
     );
     assert.ok(ev, `email.review_rejected event for ${heldId} must appear within 15s`);
     assertEventShape(ev!, { type: "email.review_rejected", agentId: email, messageId: heldId });
-    assert.equal(ev!.data.rejection_reason, reason, "payload echoes the rejection reason");
+    // The event-data "why" field is `reason` (unified across events in #451,
+    // renamed from `rejection_reason`). The RejectResultView response still
+    // exposes `rejection_reason`; only the event payload was renamed.
+    assert.equal(ev!.data.reason, reason, "payload echoes the rejection reason");
 
     const fanout = await pollEventFanout(ev!.id);
     assert.ok(fanout, `event ${ev!.id} must fan out (matched_webhooks>=1) within 15s`);


### PR DESCRIPTION
Follow-up completing the conformance-suite reconciliation (after #537 + #538) — the last of the original 17 failures.

## What
The `email.review_rejected` webhook event's assertion read `ev.data.rejection_reason`, which is `undefined` on the current contract → test failed on *"payload echoes the rejection reason."*

## Why it's a stale test, not a missing field
**#451** (`refactor!: reconcile event data fields …`, D1) **unified the event 'why' field to `reason`**, renaming `rejection_reason` → `reason` in the event payload. The server emits it (`agent/webhooks_api.go`, `hitlworker/events.go` → `"reason": reason`); the suite just never caught up. The reason **is** in the payload — the test read the pre-#451 name.

Distinct fields, both correct: the **event payload** uses `reason`; the **`RejectResultView` response** and message view still expose `rejection_reason`. #451 only renamed the event field.

## Verification
`node --experimental-strip-types --check` clean. One-line assertion change.

## Closes the set
All 17 conformance failures from the gate's first real run are now test-side, zero product bugs: 13 + 4 second-layer (#537), 2 harness duplicate (#538), and this. Root causes trace to GA-era contract changes the e2e suite lagged — #240 (list `{items,next_cursor}` envelopes), #451 (event-data reconciliation), async-202 sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)