### PR TITLE
api: freeze stable generated SDK surface

### DIFF
--- a/api/testdata/oasdiff/sdk-base.yaml
+++ b/api/testdata/oasdiff/sdk-base.yaml
@@ -1,0 +1,43 @@
+openapi: 3.1.0
+info:
+  title: SDK compatibility fixture
+  version: "1"
+paths:
+  /stable:
+    get:
+      operationId: getStable
+      tags: [things]
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StableView"
+  /beta:
+    get:
+      operationId: getBeta
+      tags: [beta]
+      x-stability-level: beta
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BetaView"
+components:
+  schemas:
+    StableView:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+    BetaView:
+      type: object
+      additionalProperties: true
+      x-stability-level: beta
+      properties:
+        id:
+          type: string

--- a/api/testdata/oasdiff/sdk-beta-schema-renamed.yaml
+++ b/api/testdata/oasdiff/sdk-beta-schema-renamed.yaml
@@ -1,0 +1,43 @@
+openapi: 3.1.0
+info:
+  title: SDK compatibility fixture
+  version: "1"
+paths:
+  /stable:
+    get:
+      operationId: getStable
+      tags: [things]
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StableView"
+  /beta:
+    get:
+      operationId: getBeta
+      tags: [beta]
+      x-stability-level: beta
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RenamedBetaView"
+components:
+  schemas:
+    StableView:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+    RenamedBetaView:
+      type: object
+      additionalProperties: true
+      x-stability-level: beta
+      properties:
+        id:
+          type: string

--- a/api/testdata/oasdiff/sdk-operation-tag-changed-via-pathitem-ref.yaml
+++ b/api/testdata/oasdiff/sdk-operation-tag-changed-via-pathitem-ref.yaml
@@ -1,0 +1,46 @@
+openapi: 3.1.0
+info:
+  title: SDK compatibility fixture
+  version: "1"
+paths:
+  /stable:
+    $ref: "#/components/pathItems/Stable"
+  /beta:
+    get:
+      operationId: getBeta
+      tags: [beta]
+      x-stability-level: beta
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BetaView"
+components:
+  pathItems:
+    Stable:
+      get:
+        operationId: getStable
+        tags: [renamed]
+        responses:
+          "200":
+            description: Success
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/StableView"
+  schemas:
+    StableView:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+    BetaView:
+      type: object
+      additionalProperties: true
+      x-stability-level: beta
+      properties:
+        id:
+          type: string

--- a/api/testdata/oasdiff/sdk-operation-tag-changed.yaml
+++ b/api/testdata/oasdiff/sdk-operation-tag-changed.yaml
@@ -1,0 +1,43 @@
+openapi: 3.1.0
+info:
+  title: SDK compatibility fixture
+  version: "1"
+paths:
+  /stable:
+    get:
+      operationId: getStable
+      tags: [renamed]
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StableView"
+  /beta:
+    get:
+      operationId: getBeta
+      tags: [beta]
+      x-stability-level: beta
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BetaView"
+components:
+  schemas:
+    StableView:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+    BetaView:
+      type: object
+      additionalProperties: true
+      x-stability-level: beta
+      properties:
+        id:
+          type: string

--- a/api/testdata/oasdiff/sdk-stable-schema-renamed.yaml
+++ b/api/testdata/oasdiff/sdk-stable-schema-renamed.yaml
@@ -1,0 +1,43 @@
+openapi: 3.1.0
+info:
+  title: SDK compatibility fixture
+  version: "1"
+paths:
+  /stable:
+    get:
+      operationId: getStable
+      tags: [things]
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RenamedStableView"
+  /beta:
+    get:
+      operationId: getBeta
+      tags: [beta]
+      x-stability-level: beta
+      responses:
+        "200":
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/BetaView"
+components:
+  schemas:
+    RenamedStableView:
+      type: object
+      additionalProperties: true
+      properties:
+        id:
+          type: string
+    BetaView:
+      type: object
+      additionalProperties: true
+      x-stability-level: beta
+      properties:
+        id:
+          type: string

--- a/cmd/e2a-openapi-sdk-check/main.go
+++ b/cmd/e2a-openapi-sdk-check/main.go
@@ -1,0 +1,34 @@
+// e2a-openapi-sdk-check protects generated SDK names that wire-level OpenAPI
+// compatibility tools do not compare. It is an internal build tool, not a
+// shipped command.
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/tokencanopy/e2a/internal/openapicompat"
+)
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Fprintf(os.Stderr, "usage: %s <base.yaml> <revision.yaml>\n", os.Args[0])
+		os.Exit(2)
+	}
+	base, err := os.Open(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "open base: %v\n", err)
+		os.Exit(1)
+	}
+	defer base.Close()
+	revision, err := os.Open(os.Args[2])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "open revision: %v\n", err)
+		os.Exit(1)
+	}
+	defer revision.Close()
+	if err := openapicompat.CheckStableSDKSurface(base, revision); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/docs/api-compatibility-gate.md
+++ b/docs/api-compatibility-gate.md
@@ -39,6 +39,10 @@ The default oasdiff breaking-change rules apply with the overrides in
 `api/oasdiff-levels.txt`. In particular, the gate additionally rejects:
 
 - an `operationId` change, because it renames generated SDK methods;
+- removal or renaming of a stable `components.schemas` entry, because its
+  component key is the public model name in generated SDKs;
+- changing the ordered tags of a stable operation, because generators use
+  them to group methods into public SDK classes or modules;
 - removal of a stable endpoint or parameter, including after deprecation;
 - any authentication or security-scheme change without an API-version review.
   A strict semantic comparison of `components.securitySchemes` supplements
@@ -65,6 +69,12 @@ The gate uses the `stable` threshold, so beta operations are excluded
 even when an entire path disappears. Removing the canonical marker promotes an
 operation into the stable gate; adding it to a stable operation is a blocked
 stability decrease.
+
+The same beta exemption applies to generated SDK names: beta component schemas
+may be renamed or removed, and beta operation tags may change. A stable schema
+cannot be relabeled beta to escape the frozen SDK surface. These name checks
+supplement oasdiff, which compares wire compatibility but does not treat an
+equivalent component rename or operation-tag change as breaking.
 
 ### The account export's versioned interior
 

--- a/internal/openapicompat/sdk.go
+++ b/internal/openapicompat/sdk.go
@@ -103,13 +103,17 @@ func readSDKSurface(r io.Reader) (sdkSurface, error) {
 	}
 	components, _ := doc["components"].(map[string]any)
 	schemas, _ := components["schemas"].(map[string]any)
+	pathItems, _ := components["pathItems"].(map[string]any)
 	for name, rawSchema := range schemas {
 		surface.schemas[name] = nodeIsBeta(rawSchema)
 	}
 
 	paths, _ := doc["paths"].(map[string]any)
 	for path, rawItem := range paths {
-		item, _ := rawItem.(map[string]any)
+		item, err := resolvePathItem(rawItem, pathItems, nil)
+		if err != nil {
+			return sdkSurface{}, fmt.Errorf("path %s: %w", path, err)
+		}
 		for method, rawOperation := range item {
 			if !openAPIMethods[method] {
 				continue
@@ -133,6 +137,62 @@ func readSDKSurface(r io.Reader) (sdkSurface, error) {
 		}
 	}
 	return surface, nil
+}
+
+func resolvePathItem(raw any, pathItems map[string]any, resolving map[string]bool) (map[string]any, error) {
+	item, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("path item is not an object")
+	}
+	ref, _ := item["$ref"].(string)
+	if ref == "" {
+		return item, nil
+	}
+
+	const prefix = "#/components/pathItems/"
+	if !strings.HasPrefix(ref, prefix) {
+		return nil, fmt.Errorf("unsupported path item reference %q", ref)
+	}
+	name, err := decodeJSONPointerToken(strings.TrimPrefix(ref, prefix))
+	if err != nil {
+		return nil, fmt.Errorf("invalid path item reference %q: %w", ref, err)
+	}
+	if resolving[name] {
+		return nil, fmt.Errorf("cyclic path item reference %q", ref)
+	}
+	referenced, ok := pathItems[name]
+	if !ok {
+		return nil, fmt.Errorf("path item reference %q is not defined", ref)
+	}
+	if resolving == nil {
+		resolving = map[string]bool{}
+	}
+	resolving[name] = true
+	defer delete(resolving, name)
+	return resolvePathItem(referenced, pathItems, resolving)
+}
+
+func decodeJSONPointerToken(token string) (string, error) {
+	if token == "" || strings.Contains(token, "/") {
+		return "", fmt.Errorf("expected one non-empty JSON Pointer token")
+	}
+	var decoded strings.Builder
+	for i := 0; i < len(token); i++ {
+		if token[i] != '~' {
+			decoded.WriteByte(token[i])
+			continue
+		}
+		if i+1 >= len(token) || (token[i+1] != '0' && token[i+1] != '1') {
+			return "", fmt.Errorf("invalid JSON Pointer escape")
+		}
+		i++
+		if token[i] == '0' {
+			decoded.WriteByte('~')
+		} else {
+			decoded.WriteByte('/')
+		}
+	}
+	return decoded.String(), nil
 }
 
 var openAPIMethods = map[string]bool{

--- a/internal/openapicompat/sdk.go
+++ b/internal/openapicompat/sdk.go
@@ -1,0 +1,172 @@
+package openapicompat
+
+import (
+	"fmt"
+	"io"
+	"slices"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// CheckStableSDKSurface protects OpenAPI names that are part of generated SDK
+// APIs but are not treated as wire-level breaking changes by oasdiff.
+//
+// The inputs must already have passed NormalizeStability and
+// PruneExportInterior. That makes the canonical beta marker authoritative and
+// preserves the account export's versioned-interior exemption.
+func CheckStableSDKSurface(base, revision io.Reader) error {
+	baseSurface, err := readSDKSurface(base)
+	if err != nil {
+		return fmt.Errorf("decode base SDK surface: %w", err)
+	}
+	revisionSurface, err := readSDKSurface(revision)
+	if err != nil {
+		return fmt.Errorf("decode revision SDK surface: %w", err)
+	}
+
+	var findings []string
+	schemaNames := make([]string, 0, len(baseSurface.schemas))
+	for name, beta := range baseSurface.schemas {
+		if !beta {
+			schemaNames = append(schemaNames, name)
+		}
+	}
+	sort.Strings(schemaNames)
+	for _, name := range schemaNames {
+		revisionBeta, ok := revisionSurface.schemas[name]
+		switch {
+		case !ok:
+			findings = append(findings, fmt.Sprintf(
+				"[stable-sdk-schema-removed] stable component schema %q was removed or renamed; generated SDK model names are frozen",
+				name,
+			))
+		case revisionBeta:
+			findings = append(findings, fmt.Sprintf(
+				"[stable-sdk-schema-stability-decreased] stable component schema %q was marked beta; generated SDK models cannot leave the stable surface",
+				name,
+			))
+		}
+	}
+
+	operationIDs := make([]string, 0, len(baseSurface.operations))
+	for id, operation := range baseSurface.operations {
+		if !operation.beta {
+			operationIDs = append(operationIDs, id)
+		}
+	}
+	sort.Strings(operationIDs)
+	for _, id := range operationIDs {
+		baseOperation := baseSurface.operations[id]
+		revisionOperation, ok := revisionSurface.operations[id]
+		// Operation removal/rename and stability decreases already have dedicated
+		// oasdiff findings. Only compare tags while the operation remains stable.
+		if !ok || revisionOperation.beta {
+			continue
+		}
+		if !slices.Equal(baseOperation.tags, revisionOperation.tags) {
+			findings = append(findings, fmt.Sprintf(
+				"[stable-sdk-operation-tags-changed] stable operation %q tags changed from %s to %s; generated SDK grouping is frozen",
+				id, formatTags(baseOperation.tags), formatTags(revisionOperation.tags),
+			))
+		}
+	}
+
+	if len(findings) > 0 {
+		return fmt.Errorf("%s", strings.Join(findings, "\n"))
+	}
+	return nil
+}
+
+type sdkSurface struct {
+	// schemas maps every component schema name to whether it is beta.
+	schemas map[string]bool
+	// operations maps every operationId to its lifecycle and ordered tags.
+	operations map[string]sdkOperation
+}
+
+type sdkOperation struct {
+	beta bool
+	tags []string
+}
+
+func readSDKSurface(r io.Reader) (sdkSurface, error) {
+	var doc map[string]any
+	if err := yaml.NewDecoder(r).Decode(&doc); err != nil {
+		return sdkSurface{}, err
+	}
+
+	surface := sdkSurface{
+		schemas:    map[string]bool{},
+		operations: map[string]sdkOperation{},
+	}
+	components, _ := doc["components"].(map[string]any)
+	schemas, _ := components["schemas"].(map[string]any)
+	for name, rawSchema := range schemas {
+		surface.schemas[name] = nodeIsBeta(rawSchema)
+	}
+
+	paths, _ := doc["paths"].(map[string]any)
+	for path, rawItem := range paths {
+		item, _ := rawItem.(map[string]any)
+		for method, rawOperation := range item {
+			if !openAPIMethods[method] {
+				continue
+			}
+			operation, ok := rawOperation.(map[string]any)
+			if !ok {
+				continue
+			}
+			id, _ := operation["operationId"].(string)
+			if id == "" {
+				continue
+			}
+			if _, duplicate := surface.operations[id]; duplicate {
+				return sdkSurface{}, fmt.Errorf("duplicate operationId %q", id)
+			}
+			tags, err := readTags(operation["tags"])
+			if err != nil {
+				return sdkSurface{}, fmt.Errorf("%s %s operation %q: %w", strings.ToUpper(method), path, id, err)
+			}
+			surface.operations[id] = sdkOperation{beta: nodeIsBeta(operation), tags: tags}
+		}
+	}
+	return surface, nil
+}
+
+var openAPIMethods = map[string]bool{
+	"get": true, "put": true, "post": true, "delete": true,
+	"options": true, "head": true, "patch": true, "trace": true,
+}
+
+func nodeIsBeta(raw any) bool {
+	node, _ := raw.(map[string]any)
+	return node[oasdiffExtension] == "beta" || node[e2aStabilityExtension] == "experimental"
+}
+
+func readTags(raw any) ([]string, error) {
+	if raw == nil {
+		return nil, nil
+	}
+	items, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("tags is not an array")
+	}
+	tags := make([]string, len(items))
+	for i, rawTag := range items {
+		tag, ok := rawTag.(string)
+		if !ok {
+			return nil, fmt.Errorf("tags[%d] is not a string", i)
+		}
+		tags[i] = tag
+	}
+	return tags, nil
+}
+
+func formatTags(tags []string) string {
+	if tags == nil {
+		return "[]"
+	}
+	return fmt.Sprintf("%q", tags)
+}

--- a/internal/openapicompat/sdk_test.go
+++ b/internal/openapicompat/sdk_test.go
@@ -65,6 +65,38 @@ func TestCheckStableSDKSurfaceRejectsStableOperationTagChange(t *testing.T) {
 	}
 }
 
+func TestCheckStableSDKSurfaceRejectsTagChangeThroughPathItemRef(t *testing.T) {
+	revision := `
+openapi: 3.1.0
+paths:
+  /stable:
+    $ref: "#/components/pathItems/Stable"
+  /beta:
+    get:
+      operationId: getBeta
+      tags: [beta]
+      x-stability-level: beta
+      responses: {}
+components:
+  pathItems:
+    Stable:
+      get:
+        operationId: getStable
+        tags: [renamed]
+        responses: {}
+  schemas:
+    StableView:
+      type: object
+    BetaView:
+      type: object
+      x-stability-level: beta
+`
+	err := CheckStableSDKSurface(strings.NewReader(sdkSurfaceBase), strings.NewReader(revision))
+	if err == nil || !strings.Contains(err.Error(), "stable-sdk-operation-tags-changed") {
+		t.Fatalf("error = %v, want stable-sdk-operation-tags-changed", err)
+	}
+}
+
 func TestCheckStableSDKSurfaceAllowsBetaOperationTagChange(t *testing.T) {
 	revision := strings.Replace(sdkSurfaceBase, "tags: [beta]", "tags: [experimental]", 1)
 	if err := CheckStableSDKSurface(strings.NewReader(sdkSurfaceBase), strings.NewReader(revision)); err != nil {

--- a/internal/openapicompat/sdk_test.go
+++ b/internal/openapicompat/sdk_test.go
@@ -1,0 +1,73 @@
+package openapicompat
+
+import (
+	"strings"
+	"testing"
+)
+
+const sdkSurfaceBase = `
+openapi: 3.1.0
+paths:
+  /stable:
+    get:
+      operationId: getStable
+      tags: [things, reads]
+      responses: {}
+  /beta:
+    get:
+      operationId: getBeta
+      tags: [beta]
+      x-stability-level: beta
+      responses: {}
+components:
+  schemas:
+    StableView:
+      type: object
+    BetaView:
+      type: object
+      x-stability-level: beta
+`
+
+func TestCheckStableSDKSurfaceAcceptsEquivalentDocuments(t *testing.T) {
+	if err := CheckStableSDKSurface(strings.NewReader(sdkSurfaceBase), strings.NewReader(sdkSurfaceBase)); err != nil {
+		t.Fatalf("CheckStableSDKSurface: %v", err)
+	}
+}
+
+func TestCheckStableSDKSurfaceRejectsStableSchemaRename(t *testing.T) {
+	revision := strings.Replace(sdkSurfaceBase, "StableView:", "RenamedStableView:", 1)
+	err := CheckStableSDKSurface(strings.NewReader(sdkSurfaceBase), strings.NewReader(revision))
+	if err == nil || !strings.Contains(err.Error(), "stable-sdk-schema-removed") {
+		t.Fatalf("error = %v, want stable-sdk-schema-removed", err)
+	}
+}
+
+func TestCheckStableSDKSurfaceRejectsStableSchemaDemotion(t *testing.T) {
+	revision := strings.Replace(sdkSurfaceBase, "StableView:\n      type: object", "StableView:\n      type: object\n      x-stability-level: beta", 1)
+	err := CheckStableSDKSurface(strings.NewReader(sdkSurfaceBase), strings.NewReader(revision))
+	if err == nil || !strings.Contains(err.Error(), "stable-sdk-schema-stability-decreased") {
+		t.Fatalf("error = %v, want stable-sdk-schema-stability-decreased", err)
+	}
+}
+
+func TestCheckStableSDKSurfaceAllowsBetaSchemaRename(t *testing.T) {
+	revision := strings.Replace(sdkSurfaceBase, "BetaView:", "RenamedBetaView:", 1)
+	if err := CheckStableSDKSurface(strings.NewReader(sdkSurfaceBase), strings.NewReader(revision)); err != nil {
+		t.Fatalf("CheckStableSDKSurface: %v", err)
+	}
+}
+
+func TestCheckStableSDKSurfaceRejectsStableOperationTagChange(t *testing.T) {
+	revision := strings.Replace(sdkSurfaceBase, "tags: [things, reads]", "tags: [reads, things]", 1)
+	err := CheckStableSDKSurface(strings.NewReader(sdkSurfaceBase), strings.NewReader(revision))
+	if err == nil || !strings.Contains(err.Error(), "stable-sdk-operation-tags-changed") {
+		t.Fatalf("error = %v, want stable-sdk-operation-tags-changed", err)
+	}
+}
+
+func TestCheckStableSDKSurfaceAllowsBetaOperationTagChange(t *testing.T) {
+	revision := strings.Replace(sdkSurfaceBase, "tags: [beta]", "tags: [experimental]", 1)
+	if err := CheckStableSDKSurface(strings.NewReader(sdkSurfaceBase), strings.NewReader(revision)); err != nil {
+		t.Fatalf("CheckStableSDKSurface: %v", err)
+	}
+}

--- a/scripts/check-openapi-compat.sh
+++ b/scripts/check-openapi-compat.sh
@@ -71,3 +71,8 @@ run_oasdiff breaking \
   --severity-levels "$levels" \
   --format "$format" \
   "$tmpdir/base.yaml" "$tmpdir/revision.yaml"
+
+# oasdiff findings take precedence when both the wire contract and generated
+# SDK surface change. If the wire contract is compatible, freeze the stable
+# component model names and operation grouping used by SDK generators.
+(cd "$repo_root" && GOWORK=off go run ./cmd/e2a-openapi-sdk-check "$tmpdir/base.yaml" "$tmpdir/revision.yaml")

--- a/scripts/test-openapi-compat.sh
+++ b/scripts/test-openapi-compat.sh
@@ -61,6 +61,7 @@ expect_fail "schema shared between export and stable surface" "$fixtures/export-
 expect_fail "bearer mechanism changed" "$fixtures/security-base.yaml" "$fixtures/security-scheme-changed.yaml" "security-schemes-changed"
 expect_fail "stable SDK schema rename" "$fixtures/sdk-base.yaml" "$fixtures/sdk-stable-schema-renamed.yaml" "stable-sdk-schema-removed"
 expect_fail "stable operation tag change" "$fixtures/sdk-base.yaml" "$fixtures/sdk-operation-tag-changed.yaml" "stable-sdk-operation-tags-changed"
+expect_fail "stable operation tag change through path item ref" "$fixtures/sdk-base.yaml" "$fixtures/sdk-operation-tag-changed-via-pathitem-ref.yaml" "stable-sdk-operation-tags-changed"
 
 set +e
 version_output="$(OASDIFF_BIN=/usr/bin/true "$checker" "$fixtures/base.yaml" "$fixtures/base.yaml" 2>&1)"

--- a/scripts/test-openapi-compat.sh
+++ b/scripts/test-openapi-compat.sh
@@ -44,6 +44,7 @@ expect_fail() {
 expect_pass "identical contract" "$fixtures/base.yaml" "$fixtures/base.yaml"
 expect_pass "additive response field" "$fixtures/base.yaml" "$fixtures/additive-response.yaml"
 expect_pass "experimental operation removal" "$fixtures/base.yaml" "$fixtures/experimental-removed.yaml"
+expect_pass "beta SDK schema rename" "$fixtures/sdk-base.yaml" "$fixtures/sdk-beta-schema-renamed.yaml"
 # The account export's versioned-interior exemption: interior record shapes
 # are versioned by UserExport.schema_version, not gated; the envelope and any
 # schema shared with the stable surface remain fully gated.
@@ -58,6 +59,8 @@ expect_fail "stable operation marked beta" "$fixtures/base.yaml" "$fixtures/stab
 expect_fail "export envelope key removal" "$fixtures/export-base.yaml" "$fixtures/export-envelope-key-removed.yaml" "response-required-property-removed"
 expect_fail "schema shared between export and stable surface" "$fixtures/export-base.yaml" "$fixtures/export-shared-schema-changed.yaml" "response-required-property-removed"
 expect_fail "bearer mechanism changed" "$fixtures/security-base.yaml" "$fixtures/security-scheme-changed.yaml" "security-schemes-changed"
+expect_fail "stable SDK schema rename" "$fixtures/sdk-base.yaml" "$fixtures/sdk-stable-schema-renamed.yaml" "stable-sdk-schema-removed"
+expect_fail "stable operation tag change" "$fixtures/sdk-base.yaml" "$fixtures/sdk-operation-tag-changed.yaml" "stable-sdk-operation-tags-changed"
 
 set +e
 version_output="$(OASDIFF_BIN=/usr/bin/true "$checker" "$fixtures/base.yaml" "$fixtures/base.yaml" 2>&1)"


### PR DESCRIPTION
## Summary

- freeze stable `components.schemas` names that become public generated SDK models
- freeze ordered tags for stable operations because generators use them for SDK grouping
- retain the existing beta and account-export interior exemptions

## Why

The GA audit in #493 identified a compatibility-gate gap: oasdiff accepts a structurally equivalent component-schema rename, even though it renames public models in generated TypeScript/Python SDKs. Operation tag changes can similarly move public methods between generated classes or modules.

This adds a post-oasdiff SDK-surface check without changing the runtime or wire contract. Existing wire-level findings keep priority.

## Validation

- `make spec-check`
- `make openapi-compat-test`
- `make openapi-compat-check OPENAPI_BASE=af5d3c7486db76cf7e62ba18763b47e4a5b95b35:api/openapi.yaml`
- `GOWORK=off go test ./...`

Related to #493.