### PR TITLE
fix(api): retain standalone OpenAPI schemas

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -6538,7 +6538,7 @@ paths:
 servers:
   - description: Production
     url: https://api.e2a.dev
-x-e2a-exported-schemas:
+x-e2a-standalone-schema-refs:
   DomainSendingFailedData:
     $ref: "#/components/schemas/DomainSendingFailedData"
   DomainSendingVerifiedData:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -6538,3 +6538,36 @@ paths:
 servers:
   - description: Production
     url: https://api.e2a.dev
+x-e2a-exported-schemas:
+  DomainSendingFailedData:
+    $ref: "#/components/schemas/DomainSendingFailedData"
+  DomainSendingVerifiedData:
+    $ref: "#/components/schemas/DomainSendingVerifiedData"
+  DomainSuppressionAddedData:
+    $ref: "#/components/schemas/DomainSuppressionAddedData"
+  EmailBouncedData:
+    $ref: "#/components/schemas/EmailBouncedData"
+  EmailComplainedData:
+    $ref: "#/components/schemas/EmailComplainedData"
+  EmailDeliveredData:
+    $ref: "#/components/schemas/EmailDeliveredData"
+  EmailFailedData:
+    $ref: "#/components/schemas/EmailFailedData"
+  EmailReceivedData:
+    $ref: "#/components/schemas/EmailReceivedData"
+  EmailSentData:
+    $ref: "#/components/schemas/EmailSentData"
+  EventEnvelope:
+    $ref: "#/components/schemas/EventEnvelope"
+  LimitExceededDetails:
+    $ref: "#/components/schemas/LimitExceededDetails"
+  PayloadTooLargeDetails:
+    $ref: "#/components/schemas/PayloadTooLargeDetails"
+  RateLimitedDetails:
+    $ref: "#/components/schemas/RateLimitedDetails"
+  RetryAfterDetails:
+    $ref: "#/components/schemas/RetryAfterDetails"
+  TooManyRecipientsDetails:
+    $ref: "#/components/schemas/TooManyRecipientsDetails"
+  ValidationErrorDetails:
+    $ref: "#/components/schemas/ValidationErrorDetails"

--- a/docs/api-compatibility-gate.md
+++ b/docs/api-compatibility-gate.md
@@ -13,6 +13,14 @@ This separation matters: freshness prevents the implementation and committed
 spec from drifting together, while semantic comparison prevents both from
 changing incompatibly together.
 
+The semantic `x-e2a-event-data-schemas` and
+`x-e2a-error-details-schemas` mappings intentionally contain bare JSON Pointer
+strings so generators do not interpret them as model composition. The
+top-level `x-e2a-standalone-schema-refs` extension instead contains real
+`$ref` objects solely to keep those operation-unreachable public components
+in Huma's serialized document; consumers should use the semantic mappings for
+event- or error-specific schema lookup.
+
 ## Freeze baseline
 
 The cumulative pre-release `/v1` freeze anchor is commit

--- a/internal/httpapi/event_envelope_schema_test.go
+++ b/internal/httpapi/event_envelope_schema_test.go
@@ -83,6 +83,46 @@ func TestEventEnvelopeIsOpenAndMapped(t *testing.T) {
 	}
 }
 
+func TestStandaloneSchemasHaveExportAnchors(t *testing.T) {
+	raw, err := json.Marshal(New(Deps{}).API.OpenAPI())
+	if err != nil {
+		t.Fatalf("render OpenAPI: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse OpenAPI: %v", err)
+	}
+
+	anchors, ok := doc["x-e2a-exported-schemas"].(map[string]any)
+	if !ok {
+		t.Fatalf("x-e2a-exported-schemas = %#v, want object", doc["x-e2a-exported-schemas"])
+	}
+	want := map[string]string{
+		"EventEnvelope": "#/components/schemas/EventEnvelope",
+	}
+	for _, event := range eventpayload.StableEvents {
+		want[event.SchemaName] = "#/components/schemas/" + event.SchemaName
+	}
+	for _, entry := range errorCodeCatalog {
+		if entry.DetailsSchema != "" {
+			want[entry.DetailsSchema] = "#/components/schemas/" + entry.DetailsSchema
+		}
+	}
+	if len(anchors) != len(want) {
+		t.Errorf("x-e2a-exported-schemas has %d entries, want %d", len(anchors), len(want))
+	}
+	for name, ref := range want {
+		anchor, ok := anchors[name].(map[string]any)
+		if !ok {
+			t.Errorf("x-e2a-exported-schemas[%s] = %#v, want $ref object", name, anchors[name])
+			continue
+		}
+		if got := anchor["$ref"]; got != ref {
+			t.Errorf("x-e2a-exported-schemas[%s].$ref = %#v, want %q", name, got, ref)
+		}
+	}
+}
+
 func TestStableEventFixturesValidateAgainstEnvelopeAndMappedData(t *testing.T) {
 	server := New(Deps{})
 	registry := server.API.OpenAPI().Components.Schemas

--- a/internal/httpapi/event_envelope_schema_test.go
+++ b/internal/httpapi/event_envelope_schema_test.go
@@ -83,7 +83,7 @@ func TestEventEnvelopeIsOpenAndMapped(t *testing.T) {
 	}
 }
 
-func TestStandaloneSchemasHaveExportAnchors(t *testing.T) {
+func TestStandaloneSchemaRefsResolveInRenderedDocument(t *testing.T) {
 	raw, err := json.Marshal(New(Deps{}).API.OpenAPI())
 	if err != nil {
 		t.Fatalf("render OpenAPI: %v", err)
@@ -93,9 +93,17 @@ func TestStandaloneSchemasHaveExportAnchors(t *testing.T) {
 		t.Fatalf("parse OpenAPI: %v", err)
 	}
 
-	anchors, ok := doc["x-e2a-exported-schemas"].(map[string]any)
+	anchors, ok := doc["x-e2a-standalone-schema-refs"].(map[string]any)
 	if !ok {
-		t.Fatalf("x-e2a-exported-schemas = %#v, want object", doc["x-e2a-exported-schemas"])
+		t.Fatalf("x-e2a-standalone-schema-refs = %#v, want object", doc["x-e2a-standalone-schema-refs"])
+	}
+	components, ok := doc["components"].(map[string]any)
+	if !ok {
+		t.Fatalf("components = %#v, want object", doc["components"])
+	}
+	schemas, ok := components["schemas"].(map[string]any)
+	if !ok {
+		t.Fatalf("components.schemas = %#v, want object", components["schemas"])
 	}
 	want := map[string]string{
 		"EventEnvelope": "#/components/schemas/EventEnvelope",
@@ -109,17 +117,23 @@ func TestStandaloneSchemasHaveExportAnchors(t *testing.T) {
 		}
 	}
 	if len(anchors) != len(want) {
-		t.Errorf("x-e2a-exported-schemas has %d entries, want %d", len(anchors), len(want))
+		t.Errorf("x-e2a-standalone-schema-refs has %d entries, want %d", len(anchors), len(want))
 	}
 	for name, ref := range want {
 		anchor, ok := anchors[name].(map[string]any)
 		if !ok {
-			t.Errorf("x-e2a-exported-schemas[%s] = %#v, want $ref object", name, anchors[name])
+			t.Errorf("x-e2a-standalone-schema-refs[%s] = %#v, want $ref object", name, anchors[name])
 			continue
 		}
 		if got := anchor["$ref"]; got != ref {
-			t.Errorf("x-e2a-exported-schemas[%s].$ref = %#v, want %q", name, got, ref)
+			t.Errorf("x-e2a-standalone-schema-refs[%s].$ref = %#v, want %q", name, got, ref)
 		}
+		if schemas[name] == nil {
+			t.Errorf("anchored component schema %s is missing from the rendered document", name)
+		}
+	}
+	if schemas["FieldError"] == nil {
+		t.Error("transitively referenced component schema FieldError is missing from the rendered document")
 	}
 }
 

--- a/internal/httpapi/eventpayload_schemas.go
+++ b/internal/httpapi/eventpayload_schemas.go
@@ -123,7 +123,7 @@ func (s *Server) registerStandaloneSchemaExports() {
 			}
 		}
 	}
-	oapi.Extensions["x-e2a-exported-schemas"] = exported
+	oapi.Extensions["x-e2a-standalone-schema-refs"] = exported
 }
 
 // openResponseComponent flips additionalProperties from the strict default to

--- a/internal/httpapi/eventpayload_schemas.go
+++ b/internal/httpapi/eventpayload_schemas.go
@@ -94,6 +94,38 @@ func (s *Server) registerEventPayloadSchemas() {
 	data.Extensions["x-e2a-event-data-schemas"] = mapping
 }
 
+// registerStandaloneSchemaExports anchors public component schemas that are
+// deliberately not referenced by an HTTP operation.
+func (s *Server) registerStandaloneSchemaExports() {
+	// Huma prunes component schemas that are not reachable through a real
+	// OpenAPI $ref when serializing the document. The event schemas and some
+	// structured error-detail schemas are intentionally operation-unreachable:
+	// consumers select them using the string-valued mappings published on the
+	// open EventEnvelope and ErrorBody. Publish explicit anchors so these
+	// standalone schemas remain part of the public contract without turning
+	// either open shape into a closed union.
+	oapi := s.API.OpenAPI()
+	if oapi.Extensions == nil {
+		oapi.Extensions = map[string]any{}
+	}
+	exported := map[string]any{
+		"EventEnvelope": map[string]any{"$ref": "#/components/schemas/EventEnvelope"},
+	}
+	for _, event := range eventpayload.StableEvents {
+		exported[event.SchemaName] = map[string]any{
+			"$ref": "#/components/schemas/" + event.SchemaName,
+		}
+	}
+	for _, entry := range errorCodeCatalog {
+		if entry.DetailsSchema != "" {
+			exported[entry.DetailsSchema] = map[string]any{
+				"$ref": "#/components/schemas/" + entry.DetailsSchema,
+			}
+		}
+	}
+	oapi.Extensions["x-e2a-exported-schemas"] = exported
+}
+
 // openResponseComponent flips additionalProperties from the strict default to
 // true on a consumer-facing component and every object reachable from it.
 // Event envelopes and error-detail schemas share this additive response rule.

--- a/internal/httpapi/httpapi.go
+++ b/internal/httpapi/httpapi.go
@@ -518,6 +518,9 @@ func (s *Server) registerOperations() {
 	// Not an operation: exports the typed per-event `data` payload schemas
 	// (EmailReceivedData, …) into components.schemas for docs + codegen.
 	s.registerEventPayloadSchemas()
+	// Preserve the intentionally public schemas that are selected through
+	// string-valued metadata rather than referenced by an HTTP operation.
+	s.registerStandaloneSchemaExports()
 }
 
 // suppressRawBodyOctetStream removes the phantom `application/octet-stream`


### PR DESCRIPTION
## Summary

- explicitly anchor intentionally public, operation-unreachable OpenAPI schemas
- derive event and error-detail anchors from their existing catalogs
- add a regression test and regenerate the canonical OpenAPI document

## Root cause

Huma 2.39 prunes component schemas that are not reachable through a real `$ref` when serializing OpenAPI. E2A intentionally publishes event payload and structured error-detail schemas through string-valued metadata, so they remained in Huma's registry but disappeared from the exported document.

The new `x-e2a-standalone-schema-refs` extension contains real `$ref` objects, preserving those public components without closing the open event or error contracts. The compatibility documentation explains why the semantic event/error mappings remain bare JSON Pointer strings while the retention extension uses actual `$ref` objects.

## Impact

This prepares `main` for Dependabot PR #534 while keeping the dependency-only PR clean. The generated TypeScript and Python SDKs are unchanged.

## Verification

- `go test ./internal/httpapi -count=1`
- full `internal/httpapi` suite against Huma 2.39 via a temporary module file
- regression coverage that every anchor resolves in serialized `components.schemas` and nested-only `FieldError` survives transitively
- `make spec-check`
- `make openapi-compat-check` — no breaking changes
- `make generate-sdk-check` — no generated SDK drift

The broad parallel `go test ./...` was not used as a passing signal because local database-backed packages raced migrations and exhausted the shared test database connection pool; the change-specific and contract gates above passed.
