### PR TITLE
docs: clarify v1 GA timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Receive inbound over **webhook · WebSocket · REST · MCP**. Send through an **
 ---
 
 > [!IMPORTANT]
-> **The `/v1` API and SDKs are contract-frozen release candidates.** GA begins only with an explicitly announced GA release tag; after that, the stable interface evolves additively. Existing `v1.0.x` application/cherry-pick tags predate the API freeze and are not `/v1` compatibility baselines. Pin your SDK versions and watch [Releases](https://github.com/tokencanopy/e2a/releases).
+> **The `/v1` API and SDKs are release candidates and are not yet stable. GA is planned by July 31, 2026; stable compatibility guarantees begin only with the explicitly announced GA release tag.** Existing `v1.0.x` application/cherry-pick tags predate the API freeze and are not `/v1` compatibility baselines. Pin your SDK versions and watch [Releases](https://github.com/tokencanopy/e2a/releases).
 
 e2a is an **authenticated email gateway for AI agents**. It receives inbound mail, verifies the sender (SPF/DKIM), and delivers it to your agent as structured data with HMAC-signed `X-E2A-Auth-*` headers — over whichever channel fits your runtime. Outbound goes back out through an HTTP API, with an optional human-in-the-loop approval gate.
 


### PR DESCRIPTION
## What changed

Updated the README release-candidate notice to state that `/v1` is not yet
stable and that GA is planned by July 31, 2026.

## Why

The existing notice described the GA tag boundary but did not communicate the
planned GA date clearly.

## Impact

Readers now get an explicit stability warning and GA timeline. No code or API
behavior changes.

## Validation

- `git diff --check origin/main...HEAD`
- Verified the PR changes only `README.md`
