### PR TITLE
test(e2e): pass email to the MCP list_messages call (account-scoped cred)

### DIFF
--- a/tests/e2e-prod/suites/08-mcp.test.ts
+++ b/tests/e2e-prod/suites/08-mcp.test.ts
@@ -116,11 +116,15 @@ test("mcp: list_messages tool works against the inbox", async () => {
     info(SUITE, "list-messages-absent", "no list_messages tool — skipping");
     return;
   }
-  // list_messages is cursor-paginated with no page-size knob in its strict
-  // schema (direction / read_status / sort / cursor / search filters only).
-  // Call with a valid arg; the strict-schema test below verifies unknown
-  // keys are rejected.
-  const r = await callTool(mcp, "list_messages", { direction: "inbound" });
+  // list_messages is per-inbox and cursor-paginated (direction / read_status /
+  // sort / cursor / search filters). Under an account-scoped credential `email`
+  // is required to select the inbox (an agent-scoped credential resolves it);
+  // the conformance key is account-scoped, so pass it explicitly. The
+  // strict-schema test below verifies unknown keys are rejected.
+  const r = await callTool(mcp, "list_messages", {
+    email: apiClient.env.primaryAgentEmail,
+    direction: "inbound",
+  });
   assert.equal(r.isError, undefined, `list_messages isError: ${JSON.stringify(r)}`);
   const text = r.content?.find((c) => c.type === "text")?.text;
   assert.ok(text, "text content present");


### PR DESCRIPTION
The very last conformance-suite failure — surfaced only once #538 unblocked the MCP suites to actually execute (`tests` grew 216→231 as ~15 previously-dead MCP tests started running).

## Problem
`08-mcp.test.ts` `mcp: list_messages` called the tool with just `{ direction: "inbound" }`. `list_messages` is **per-inbox**, and under an **account-scoped** credential the server requires an explicit `email` to select the inbox (an agent-scoped credential resolves it automatically). The conformance key is account-scoped, so the call returned:
> `isError invalid_request: "email is required — pass it explicitly, or connect with an agent-scoped credential…"`

This is the intended contract, not a bug — which is why `list_agents`/`whoami` (account-level, no inbox selector) passed and only this one failed.

## Fix
Pass `apiClient.env.primaryAgentEmail`. One call site (verified: `get_message` in 12-mcp-extended locates by globally-unique `message_id` and needs no email; it passed).

## Verification
- `node --experimental-strip-types --check` clean.
- Full staging conformance run before this: **pass 219 / fail 1** (this test). After merge, a re-run should read **fail 0** — closing out all 17+ of the gate's first-run failures.

Completes the reconciliation series: #537 (14) + #538 (mcp harness) + #540 (review_rejected) + this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)