### PR TITLE
test(e2e): accept 202 async send + widen attachment fixture poll window

### DIFF
--- a/tests/e2e-prod/suites/20-attachments.test.ts
+++ b/tests/e2e-prod/suites/20-attachments.test.ts
@@ -23,9 +23,11 @@ import { fail, info, warn, writeReport } from "../harness/report.ts";
 //     deliberate server property (internal/httpapi/messages.go: "held drafts
 //     (no raw_message) carry []"). We assert it below rather than assume it.
 //   - REAL outbound to the SES simulator (success@simulator.amazonses.com)
-//     WITHOUT holding DOES work: staging sends via relay, persists the sent
-//     MIME, and getAttachment/download then operate on real bytes. This is the
-//     happy path this suite uses. If a real send ever stops yielding a
+//     WITHOUT holding DOES work: the send returns 202 "accepted" (a no-hold
+//     send is async — the River worker delivers it and persists the sent MIME
+//     afterwards), and getAttachment/download then operate on real bytes. This
+//     is the happy path this suite uses; the setup polls the sent message to
+//     tolerate the async worker. If a real send ever stops yielding a
 //     retrievable attachment, the happy-path tests self-downgrade to a flagged
 //     staging limitation (see ensureSentAttachment) rather than fail.
 
@@ -81,22 +83,22 @@ async function doSetup(): Promise<SentAttachment | null> {
       },
     },
   );
-  if (send.status !== 200 || !send.body?.message_id) {
-    warn(SUITE, "setup", `real send with attachment did not return 200+message_id (got ${send.status}); happy-path flagged`, send.raw.slice(0, 200));
+  if ((send.status !== 200 && send.status !== 202) || !send.body?.message_id) {
+    warn(SUITE, "setup", `real send with attachment did not return 200/202+message_id (got ${send.status}); happy-path flagged`, send.raw.slice(0, 200));
     return null;
   }
   const messageId = send.body.message_id;
 
-  // The sent MIME is normally persisted synchronously, but poll a few times to
-  // tolerate an async delivery worker before flagging a limitation.
-  for (let attempt = 0; attempt < 8; attempt++) {
+  // A no-hold send is async (202 accepted): the worker persists the sent MIME
+  // only after delivery, so poll generously before flagging a limitation.
+  for (let attempt = 0; attempt < 24; attempt++) {
     const msg = await client.get<{ attachments?: Array<{ index: number }> }>(
       `/v1/agents/${encodeURIComponent(agentEmail)}/messages/${messageId}`,
     );
     if (msg.status === 200 && Array.isArray(msg.body?.attachments) && msg.body!.attachments.length > 0) {
       return { agentEmail, messageId };
     }
-    await new Promise((r) => setTimeout(r, 750));
+    await new Promise((r) => setTimeout(r, 1000));
   }
   warn(
     SUITE,


### PR DESCRIPTION
## Problem

The staging conformance gate skipped all **6 attachment happy-path tests** in `tests/e2e-prod/suites/20-attachments.test.ts` with "staging could not produce a retrievable attachment fixture".

Root cause: the suite's `doSetup()` does a real outbound send (with attachment) to the SES simulator and required `send.status === 200`. But on current `main`, a **no-hold agent send is async** — it returns **202 "accepted"** with a `message_id`, and the River worker delivers the message and persists the sent MIME afterwards. The stale 200-only guard tripped, `doSetup` returned null, and every happy-path test self-skipped.

202 is the correct current contract (the test was stale, not the server): `21-webhook-events.test.ts` already asserts `send.status === 202` + `body.status === "accepted"` for a no-hold real send, and this suite's own held-draft test shows a 202 body carrying `message_id`.

## Fix (test-only)

- Setup guard now accepts **200 or 202** (still requires `message_id`); warn text updated.
- Because the sent MIME is now persisted asynchronously post-delivery, the `attachments[]` poll window is widened from 8×750ms (~6s) to **24×1000ms (~24s)**.
- The intentional graceful self-downgrade on genuine timeout (flagged `warn` + null → tests skip, never silently pass) is preserved.
- Top-of-file doc comment updated to describe the 202/async behavior.

No server/product source touched; negative-path tests untouched.

## Verification

- `node --experimental-strip-types --check tests/e2e-prod/suites/20-attachments.test.ts` — clean.
- Real verification is a staging pipeline re-run: the 6 attachment happy-path tests should now execute against the fixture instead of skipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)