### PR TITLE
test(e2e): implement the email.blocked emission test (outbound gate block)

### DIFF
--- a/tests/e2e-prod/suites/21-webhook-events.test.ts
+++ b/tests/e2e-prod/suites/21-webhook-events.test.ts
@@ -40,12 +40,13 @@ import { writeReport, info } from "../harness/report.ts";
 //   email.review_approved — approve a held message addressed to the simulator
 //                           (approve→send succeeds; a non-simulator recipient
 //                           500s on staging's SES sandbox).
+//   email.blocked         — outbound gate policy=allowlist action=block + a
+//                           non-allowlisted recipient → the send is REFUSED
+//                           (403 blocked_by_policy) and email.blocked fires.
 //
 // Event types SKIPPED with reasons (not HTTP-triggerable on staging here):
 //   email.received  — needs a real inbound SMTP delivery; that is the prober's
 //                     dedicated round-trip, not an API-driven trigger.
-//   email.blocked   — needs a screening `block` gate/scan config to refuse a
-//                     message; out of scope for the emission battery.
 //   email.delivered/bounced/complained — async SES delivery-feedback, arrives via
 //                     SNS on an unbounded timeline (and the simulator's feedback
 //                     is not deterministic within a test window).
@@ -433,6 +434,60 @@ test("emit: email.review_approved — approving a hold (to the simulator) emits 
   }
 });
 
+// ---- email.blocked: outbound gate action=block refuses the send ----
+test("emit: email.blocked — a gate-blocked send emits the event and attempts a delivery", { skip }, async () => {
+  const email = await createAgent("blocked");
+  // Block-all-outbound: same allowlist+empty-list gate as holdAllOutbound, but
+  // with action=block — every recipient is unknown to the allowlist and every
+  // send is REFUSED outright (vs. held for review). The /protection
+  // sub-resource is a full replace (PUT), so send the complete shape.
+  const prot = await client.put(`/v1/agents/${encodeURIComponent(email)}/protection`, {
+    body: {
+      inbound: { gate: {}, scan: {} },
+      outbound: { gate: { policy: "allowlist", action: "block", allowlist: [] }, scan: {} },
+      holds: {},
+    },
+  });
+  if (prot.status !== 200) {
+    await delAgent(email);
+    throw new Error(`block-all-outbound protection PUT failed: ${prot.status} ${prot.raw.slice(0, 200)}`);
+  }
+  const hook = await createHook(["email.blocked"]);
+  const since = sinceNow();
+  try {
+    const subject = uniqueSubject("emit blocked");
+    const send = await client.post<SendResult>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
+      body: { to: [SIMULATOR], subject, text: "refused by the outbound gate" },
+    });
+    // An egress block REFUSES the send: 403 blocked_by_policy, and NO message
+    // row is persisted. The event anchors to a stable server-derived soft-ref
+    // id (msgblk_…) that the 403 body does NOT return — so the poll below
+    // correlates on the unique subject instead of a message id.
+    assert.equal(send.status, 403, `blocked send expected 403, got ${send.status}: ${send.raw.slice(0, 200)}`);
+    assert.equal((send.body as { error?: { code?: string } })?.error?.code, "blocked_by_policy", "403 carries the blocked_by_policy code");
+
+    const ev = await pollEvent({ type: "email.blocked", agentId: email, since }, (e) => e.data.subject === subject);
+    assert.ok(ev, `email.blocked event for subject ${JSON.stringify(subject)} must appear in listEvents within 15s`);
+    assertEventShape(ev!, { type: "email.blocked", agentId: email });
+    // Beta payload: rowless soft-ref message id + the gate attribution.
+    const blockedId = ev!.data.message_id;
+    assert.ok(typeof blockedId === "string" && blockedId.startsWith("msgblk_"), `blocked payload carries the msgblk_ soft-ref id: ${String(blockedId)}`);
+    assert.equal(ev!.data.direction, "outbound", "blocked payload carries direction=outbound");
+    assert.equal(ev!.data.reason_source, "recipient_gate", "block is attributed to the recipient gate");
+    assert.deepEqual(ev!.data.to, [SIMULATOR], "blocked payload echoes the refused recipient");
+
+    const fanout = await pollEventFanout(ev!.id);
+    assert.ok(fanout, `event ${ev!.id} must fan out (matched_webhooks>=1) within 15s`);
+    const del = await pollDelivery(hook.id, "email.blocked");
+    assert.ok(del, `a delivery ATTEMPT for email.blocked must appear on webhook ${hook.id}`);
+    assert.ok(del!.attempts >= 1, `delivery attempted (attempts=${del!.attempts})`);
+    info(SUITE, "email.blocked", `emitted evt=${ev!.id} fanned to ${fanout!.matched_webhooks} webhook(s); our webhook whd=${del!.id} attempts=${del!.attempts}`);
+  } finally {
+    await delHook(hook.id);
+    await delAgent(email);
+  }
+});
+
 // ---- Events read API: listEvents envelope + filters ----
 test("events: listEvents returns PageEventView envelope and honors type/agent_email/since/limit filters", { skip }, async () => {
   const email = await createAgent("list");
@@ -577,7 +632,6 @@ test("events: unauthenticated listEvents / getEvent → 401", async () => {
 
 // ---- Documented skips for events that can't be HTTP-triggered on staging here ----
 test("emit: email.received — needs real inbound SMTP (prober's round-trip)", { skip: "email.received requires a real inbound SMTP delivery; that is the prober's dedicated job, not an API-driven trigger from this suite" }, () => {});
-test("emit: email.blocked — needs a screening block config", { skip: "email.blocked requires a screening gate/scan `block` action to refuse a message; out of scope for the HTTP emission battery" }, () => {});
 test("emit: email.delivered/bounced/complained — async SES delivery feedback", { skip: "delivery-feedback events arrive async via SES→SNS on an unbounded timeline and are not deterministic within a test window" }, () => {});
 test("emit: domain.sending_verified/failed, domain.suppression_added — need sending-identity provisioning", { skip: "domain.* events require real SES sending-identity provisioning against a custom domain, not available to a throwaway shared-domain agent" }, () => {});
 


### PR DESCRIPTION
## What

Un-skips the `email.blocked` documented-skip placeholder in `tests/e2e-prod/suites/21-webhook-events.test.ts` and replaces it with a real, running emission test.

## Why it was skipped

The placeholder claimed `email.blocked` needed a screening block config that was "out of scope for the HTTP emission battery." It is in fact fully API-triggerable: the outbound gate `action` enum is `flag | review | block` (`internal/identity/protection.go`, `api/openapi.yaml`).

## How the block is triggered

1. Create a throwaway agent.
2. `PUT /v1/agents/{email}/protection` with `outbound.gate = { policy: "allowlist", action: "block", allowlist: [] }` — every recipient is unknown to the empty allowlist, so every send is refused (the block-flavored sibling of the harness's `holdAllOutbound`).
3. Send to the SES simulator → the server refuses the send.

## Assertions (grounded in the server source)

Per `internal/agent/api.go` (`DeliverOutbound`) + `internal/agent/screening.go`:
- The blocked send returns **403** with error code **`blocked_by_policy`**; no message row is persisted.
- `email.blocked` is emitted through the durable outbox anchored to a stable soft-ref id (`msgblk_…`, `blockAuditID`) that the 403 body does **not** return — so the test correlates on a unique subject instead of a message id.
- Payload assertions: `message_id` has the `msgblk_` prefix, `direction=outbound`, `reason_source=recipient_gate`, `to` echoes the refused recipient.
- Same three-signal proof as the other emit tests: listEvents row + event-scoped fanout (`matched_webhooks>=1`) + webhook-scoped delivery attempt (`attempts>=1`).

The suite-level staging-only `{ skip }` guard is honored like every other emit test. The other three documented skips (`email.received`, `email.delivered/bounced/complained`, `domain.*`) are intentionally untouched.

## Verification

- `node --experimental-strip-types --check tests/e2e-prod/suites/21-webhook-events.test.ts` passes.
- The live run happens on the next staging pipeline re-run (this suite is staging-only; no staging secrets locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)