### PR TITLE
fix(mcp): emit snake_case tool output for SDK class instances

### DIFF
--- a/mcp/src/tools/util.ts
+++ b/mcp/src/tools/util.ts
@@ -37,25 +37,31 @@ function snakeCaseKey(key: string): string {
 /**
  * Convert SDK response models back to the REST-style names used by MCP.
  *
- * SDK models are plain objects whose generated property names are ergonomic
- * camelCase. MCP is a separate public boundary and deliberately follows the
- * REST contract's snake_case vocabulary. Recurse through arrays/nested view
- * objects without touching Dates or other class instances. Already-snake_case
- * keys (including reserved-word-safe `from_`) are preserved verbatim.
+ * SDK model property names are ergonomic camelCase. MCP is a separate public
+ * boundary and deliberately follows the REST contract's snake_case vocabulary.
+ * Recurse through arrays/nested view objects without touching Dates or
+ * primitives. Already-snake_case keys (including reserved-word-safe `from_`)
+ * are preserved verbatim.
+ *
+ * IMPORTANT: the generated SDK's ObjectSerializer.deserialize returns CLASS
+ * INSTANCES (`new typeMap[type]()`), not plain object literals, so the
+ * conversion must NOT be gated on `prototype === Object.prototype` — that
+ * guard silently passed every SDK model through unconverted, leaking camelCase
+ * keys from ~48 of 50 tools (the pre-GA e2e sweep's Bug 2). Any non-null,
+ * non-Array, non-Date object is treated as a convertible record; its own
+ * enumerable properties are renamed recursively (this matches the McpOutput
+ * type above, which already maps every object shape except Date/arrays).
  */
 export function toMcpOutput<T>(value: T): McpOutput<T> {
   if (Array.isArray(value)) {
     return value.map((item) => toMcpOutput(item)) as McpOutput<T>;
   }
-  if (value !== null && typeof value === "object") {
-    const prototype = Object.getPrototypeOf(value);
-    if (prototype === Object.prototype || prototype === null) {
-      const out: Record<string, unknown> = {};
-      for (const [key, item] of Object.entries(value)) {
-        out[snakeCaseKey(key)] = toMcpOutput(item);
-      }
-      return out as McpOutput<T>;
+  if (value !== null && typeof value === "object" && !(value instanceof Date)) {
+    const out: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value)) {
+      out[snakeCaseKey(key)] = toMcpOutput(item);
     }
+    return out as McpOutput<T>;
   }
   return value as McpOutput<T>;
 }

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -13,7 +13,7 @@ import { registerWebhookTools } from "../src/tools/webhooks.js";
 import { registerEventTools } from "../src/tools/events.js";
 import { registerTemplateTools } from "../src/tools/templates.js";
 import { registerApiKeyTools } from "../src/tools/apikeys.js";
-import { CodedError, runTool } from "../src/tools/util.js";
+import { CodedError, runTool, toMcpOutput } from "../src/tools/util.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 // Build a small RFC822 blob with one attachment so the MessageView's
@@ -1620,6 +1620,47 @@ describe("e2a MCP server", () => {
       delivery_meta: { created_at: "2026-07-16T00:00:00Z" },
       attachments: [{ content_type: "text/plain", size_bytes: 4 }],
     });
+  });
+
+  it("converts SDK class instances (non-plain objects) to snake_case recursively", async () => {
+    // Regression: the generated SDK's ObjectSerializer.deserialize does
+    // `new typeMap[type]()` and assigns camelCase attributes, so the values
+    // flowing through runTool are CLASS INSTANCES, not plain object literals.
+    // toMcpOutput used to gate conversion on `prototype === Object.prototype`,
+    // silently passing every SDK model through with camelCase keys — breaking
+    // the frozen snake_case MCP contract for every tool that forwards an SDK
+    // model verbatim.
+    class FakeDeliveryMeta {
+      createdAt = new Date("2026-07-16T00:00:00Z");
+      readStatus = "read";
+    }
+    class FakeAttachment {
+      contentType = "text/plain";
+      sizeBytes = 4;
+    }
+    class FakeMessageView {
+      messageId = "msg_1";
+      conversationId = null;
+      domainVerified = true;
+      deliveryMeta = new FakeDeliveryMeta();
+      attachments = [new FakeAttachment()];
+    }
+
+    const res = await runTool(async () => new FakeMessageView());
+    expect(JSON.parse(res.content[0]!.text)).toEqual({
+      message_id: "msg_1",
+      conversation_id: null,
+      domain_verified: true,
+      // Date instances must survive as timestamps, not be flattened to {}.
+      delivery_meta: { created_at: "2026-07-16T00:00:00.000Z", read_status: "read" },
+      attachments: [{ content_type: "text/plain", size_bytes: 4 }],
+    });
+
+    // Top-level arrays of class instances (list endpoints) convert too.
+    class FakeAgentView {
+      createdAt = "2026-06-01T00:00:00Z";
+    }
+    expect(toMcpOutput([new FakeAgentView()])).toEqual([{ created_at: "2026-06-01T00:00:00Z" }]);
   });
 
   // ── Templates (beta) ────────────────────────────────────────────


### PR DESCRIPTION
## Problem

The MCP server's tool outputs leaked SDK-idiomatic **camelCase** keys (`createdAt`, `messageId`, `domainVerified`, `signingSecret`, …) instead of the documented **snake_case** GA contract — confirmed live against staging for ~48 of 50 tools (pre-GA e2e sweep, Bug 2). Only `get_message`/`get_attachment` were correct, because their handlers hand-build plain-object literals.

This is a silent contract violation: tool descriptions and the API docs promise `message_id` etc., so a spec-following client reads `parsed.message_id`, gets `undefined`, and fails without any error signal.

## Root cause

`toMcpOutput()` in `mcp/src/tools/util.ts` only converted values whose prototype was exactly `Object.prototype` (or `null`). But the generated TS SDK's `ObjectSerializer.deserialize` returns **class instances** (`let instance = new typeMap[type]()` — `AgentView`, `MessageView`, `WebhookView`, …), whose prototype is the model class's prototype. The guard therefore silently skipped every SDK model, returning it (and all nested fields) unconverted.

## Fix

Treat any non-null, non-`Array`, non-`Date` object as a convertible record and rename its own enumerable properties recursively — which is exactly what the existing `McpOutput<T>` **type** already promised (it maps every object shape except `Date`/arrays; the runtime was out of sync with it).

- `Date`, primitives, and `null` pass through untouched (Dates still serialize as ISO timestamps, not `{}`).
- Already-snake_case keys (including reserved-word-safe `from_`) are preserved verbatim — no double conversion, so `get_message`/`get_attachment` and the list-envelope shapes are byte-identical to before.
- No change to the frozen list-envelope contract, error shapes, or input schemas.

## Test

New regression test in `mcp/tests/tools.test.ts` constructs class-instance-shaped values mirroring how the SDK deserializer builds models (camelCase props on a class, nested class instance, array of class instances, `Date`, `null`) and asserts the full snake_case output through `runTool`, plus a top-level array-of-instances case through `toMcpOutput` directly.

- **Before the fix:** the test fails with the exact observed leak (`messageId`, `deliveryMeta.createdAt`, `domainVerified`, …).
- **After the fix:** full suite green — `npm run build -w @e2a/mcp-server`, `vitest` 201/201 passed (10 files), `test:types` clean.

This restores the frozen snake_case GA contract for the ~48 affected tools without touching the two already-correct ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xhgqySFWhusy9ucxSdkf9