### PR TITLE
docs: fix stale root-doc claims (openapi serving, exit codes, Node, idempotency)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ make generate-sdk   # regenerate the TS + Python SDK bases from api/openapi.yaml
 make generate       # both of the above
 ```
 
-After changing a `/v1` handler, run `make generate` and commit the regenerated `api/openapi.yaml` plus the SDK bases in `sdks/typescript/src/v1/generated/` and `sdks/python/src/e2a/v1/generated/`. CI (`spec-check` + `generate-sdk-check`) fails if either is stale. (The legacy swag pipeline is gone — `web/public/openapi.yaml` is a frozen copy for the dashboard's API-reference page only and no longer feeds the SDKs.)
+After changing a `/v1` handler, run `make generate` and commit the regenerated `api/openapi.yaml` plus the SDK bases in `sdks/typescript/src/v1/generated/` and `sdks/python/src/e2a/v1/generated/`. CI (`spec-check` + `generate-sdk-check`) fails if either is stale. (The legacy swag pipeline is gone — the dashboard's API-reference page fetches the spec live from `/v1/openapi.yaml`, served directly by the Huma handlers; there is no static copy and no separate feed into the SDKs.)
 
 ## Architecture
 
@@ -140,9 +140,10 @@ ergonomic layer (`client.ts` / `client.py` etc.) wired up via
 any `/v1` handler change.
 
 The old swag-annotation pipeline was fully retired (the `make swagger` target and
-its `internal/agent/api_docs.go` source are gone). `web/public/openapi.yaml` is
-retained only because the dashboard's API-reference page
-(`web/public/scalar.html`) renders it; it is a frozen copy and not CI-checked.
+its `internal/agent/api_docs.go` source are gone). The dashboard's
+API-reference page (`web/public/scalar.html`) renders the spec by fetching it
+live from `/v1/openapi.yaml`, served directly by the `/v1` Huma handlers —
+there is no static `web/public/openapi.yaml` file and nothing to keep in sync.
 
 ### TypeScript SDK (`sdks/typescript/`)
 
@@ -150,7 +151,7 @@ Layered: generated types → `E2AApi` (raw HTTP) → `E2AClient` (high-level wit
 
 ### CLI (`cli/`)
 
-Commands: login, listen, config, whoami, send, reply, messages. Config stored in `~/.e2a/config.json`. The `listen` command supports `--forward` mode for proxying WebSocket messages to local HTTP endpoints. The messaging commands (whoami/send/reply/messages) are the scripting surface for shell-based harnesses and publish a stable exit-code contract (`cli/src/exit.ts`): 0 ok, 1 transient error, 2 usage, 3 held-for-review (any non-`sent` status — HTTP-successful but undelivered), 4 auth, 5 permanent request error (non-retryable 4xx). Exit codes are frozen once published; add new ones, never renumber.
+Commands: login, listen, config, whoami, send, reply, messages. Config stored in `~/.e2a/config.json`. The `listen` command supports `--forward` mode for proxying WebSocket messages to local HTTP endpoints. The messaging commands (whoami/send/reply/messages) are the scripting surface for shell-based harnesses and publish a stable exit-code contract (`cli/src/exit.ts`): 0 ok, 1 transient error, 2 usage, 3 held-for-review (`pending_review` — HTTP-successful but undelivered), 4 auth, 5 permanent request error (non-retryable 4xx), 6 timeout (`listen --once --until` expired unmatched), 7 send-outcome (a persisted send failed or returned an unknown outcome; do not retry). Exit codes are frozen once published; add new ones, never renumber.
 
 ### Web (`web/`)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ The fork workflow above is the expected path for everyone else.
 | Tool | Version | Why |
 |---|---|---|
 | Go | 1.25 | backend |
-| Node | 24+ | CLI, TypeScript SDK, MCP server, web dashboard |
+| Node | 18+ (CI tests on 22) | CLI, TypeScript SDK, MCP server, web dashboard |
 | Python | 3.10+ | Python SDK |
 | Docker (Desktop or engine) | any recent | local Postgres + Mailpit |
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -40,9 +40,9 @@ MCP tool surface), see:
   hand-rolled clients must do it themselves.
 - **Pagination.** List endpoints return `{ items, next_cursor }`; pass
   `next_cursor` back as `?cursor=…` to page forward. The SDKs auto-page.
-- **Idempotency.** Six mutating operations honor an opt-in `Idempotency-Key`
+- **Idempotency.** Seven mutating operations honor an opt-in `Idempotency-Key`
   header: `sendMessage`, `replyToMessage`, `forwardMessage`, `approveReview`,
-  `rotateWebhookSecret`, and `createApiKey`. Semantics:
+  `createWebhook`, `rotateWebhookSecret`, and `createApiKey`. Semantics:
   - **Replay.** A retry with the same key and a **byte-identical** body replays
     the first request's response instead of re-executing the side effect (the
     dedup hash covers the route + the raw body bytes, so the same key on a


### PR DESCRIPTION
## What was outdated

- **CLAUDE.md** claimed `web/public/openapi.yaml` is a static "frozen copy" retained for the dashboard's API-reference page. That file doesn't exist and never has (checked `git log`, `find web -iname '*.yaml'`) — `web/public/scalar.html` fetches the spec live from `/v1/openapi.yaml`, served directly by the `/v1` Huma handlers (confirmed via `internal/httpapi/spec_test.go`'s `TestSpecServedOverHTTP`, which hits that exact route).
- **CLAUDE.md** documented the CLI exit-code contract as only 0–5, but `cli/src/exit.ts` defines 8 codes (0–7) — codes 6 (`TIMEOUT`, for `listen --once --until`) and 7 (`SEND_OUTCOME`, for a persisted send with a failed/unknown terminal outcome) were missing.
- **CONTRIBUTING.md** listed Node "24+" as the prerequisite for CLI/TS SDK/MCP/web work. Every package (`cli`, `sdks/typescript`, `mcp`) declares `engines: ">=18"`, and the functional CI test lane (`.github/workflows/test.yml`) runs Node 22 — only the release-publish workflows use 24.
- **docs/api.md** said six operations honor `Idempotency-Key` and listed them, but `createWebhook` (`internal/httpapi/webhooks.go`) uses the same `runIdempotent` path and was left off the list.

## What changed

Corrected each claim in place, preserving the surrounding structure/tone. No behavior changes — documentation only.

## Test plan

- [x] Verified each claim directly against current code (`internal/httpapi/spec_test.go`, `cli/src/exit.ts`, package.json `engines` fields + `.github/workflows/test.yml`, `internal/httpapi/webhooks.go`) before editing.
- N/A — docs-only change, no build/test impact.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Sk9NmEAhgWyAGmYcX2ZKSb)_