### PR TITLE
docs(sdk): dedupe split 4.1.0 changelog entry (TS + Python)

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -161,10 +161,6 @@ Additive, no breaking changes.
   `retry_after_seconds` and retry. A `402` previously surfaced as the base
   `E2AError`; it now surfaces as this subclass (still an `E2AError`, so existing
   `except E2AError` handlers are unaffected).
-
-Additive, no breaking changes.
-
-### Added
 - `email.received` is a metadata-only notification; `webhooks.fetch_message(event)`
   + the `EmailReceivedPayload` type fetch the full message (body + attachments)
   on demand (#321).

--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -103,10 +103,6 @@ Additive, no breaking changes.
   `retryAfterSeconds` and retry. A `402` previously surfaced as the base
   `E2AError`; it now surfaces as this subclass (still an `E2AError` via
   `instanceof`, so existing catch-all handling is unaffected).
-
-Additive, no breaking changes.
-
-### Added
 - `email.received` is a metadata-only notification; `webhooks.fetchMessage(event)`
   + the `EmailReceivedPayload` type fetch the full message (body + attachments)
   on demand (#321).


### PR DESCRIPTION
## What was outdated

Both `sdks/typescript/CHANGELOG.md` and `sdks/python/CHANGELOG.md` had their `## 4.1.0` section containing two separate "Additive, no breaking changes." + "### Added" header pairs back to back, with the bullet list split across them — an accidental concatenation (two PRs' entries never merged into one section).

## What changed

Merged each into a single "Additive, no breaking changes." + "### Added" list. No content added or removed, only the duplicated headers dropped.

## Test plan

N/A — docs-only formatting fix, content unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Sk9NmEAhgWyAGmYcX2ZKSb)_