### PR TITLE
docs(sdk-ts): fix stale wiring status in generated/README.md

### DIFF
--- a/sdks/typescript/src/v1/generated/README.md
+++ b/sdks/typescript/src/v1/generated/README.md
@@ -9,6 +9,7 @@ so the base uses the runtime's native global `fetch` (Node 18+, browsers,
 edge/Workers) — no fetch dependency.
 
 Generated transport + models + typed `ApiException<ErrorEnvelope>`. The
-hand-written ergonomic layer (`client.ts`, `ws.ts`, `webhook-signature.ts`,
-`inbound-email.ts`) wraps it — api-v1-redesign **Slice 8**. Staged now; wired
-into the published client in the next slice.
+hand-written ergonomic layer (`client.ts`, `ws.ts`, `webhook-signature.ts`)
+wraps it — api-v1-redesign **Slice 8**. Wired into the published `E2AClient`;
+the legacy hand-written `api.ts` / `inbound-email.ts` surface and the old
+swag-generated types have been retired in favor of this.


### PR DESCRIPTION
## What was outdated

`sdks/typescript/src/v1/generated/README.md` said the generated base was "Staged now; wired into the published client in the next slice," and listed `inbound-email.ts` as part of the current hand-written layer.

In reality the base is already wired in: `sdks/typescript/src/v1/index.ts`'s own header comment says "the legacy hand-written `api.ts` / `inbound-email.ts` surface and the old swag-generated types have been retired in favour of this," `client.ts` imports extensively from `./generated/*`, and `docs/design/api-v1-redesign.md` documents the retirement as already done. `inbound-email.ts` no longer exists under `sdks/typescript/src/v1/`.

## What changed

Updated the status line and dropped `inbound-email.ts` from the file listing.

## Test plan

- [x] Confirmed via `ls sdks/typescript/src/v1/` and `index.ts`'s header comment.
- N/A — docs-only change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Sk9NmEAhgWyAGmYcX2ZKSb)_