### PR TITLE
docs(web): fix templates.md syntax/field names and sdk.md pagination examples

### DIFF
--- a/web/public/sdk.md
+++ b/web/public/sdk.md
@@ -106,13 +106,13 @@ Held messages (outbound drafts + screened inbound) are the account-scoped review
 queue. With an account-scoped key:
 
 ```ts
-const held = await client.reviews.list().toArray();   // both directions
+const held = await client.reviews.list().toArray({ limit: 100 });   // both directions
 await client.reviews.approve(id);                      // outbound: send; inbound: release
 await client.reviews.reject(id, { reason: "spam" });
 ```
 
 ```python
-held = await client.reviews.list().to_list()
+held = await client.reviews.list().to_list(limit=100)
 await client.reviews.approve(message_id)
 await client.reviews.reject(message_id, {"reason": "spam"})
 ```

--- a/web/public/templates.md
+++ b/web/public/templates.md
@@ -29,8 +29,8 @@ a rendered preview with an HTML/text tab switch and light/dark toggle).
 
 ## Syntax
 
-Template syntax is intentionally minimal — **flat variables only**, no loops,
-no conditionals, no partials:
+Template syntax is intentionally minimal — variable interpolation only, no
+loops, no conditionals, no partials:
 
 | Form | Behavior |
 |---|---|
@@ -38,7 +38,8 @@ no conditionals, no partials:
 | `{{{variable}}}` | Raw insertion (HTML part): the value is inserted **without escaping**. For pre-rendered HTML fragments only — see the warning below. |
 
 Missing variables render as **empty strings**. Variable names match
-`[A-Za-z][A-Za-z0-9_]*`-style flat identifiers (e.g. `order_id`, `items_html`).
+`[A-Za-z_][A-Za-z0-9_.]*` — dot paths into nested objects are supported
+(e.g. `order_id`, `items_html`, `customer.name`).
 
 **Reserved-section note:** anything that is not a `{{…}}` / `{{{…}}}` slot is
 literal template text and is emitted verbatim — including `{` and `}`
@@ -48,7 +49,7 @@ interpreted; there is no escape sequence and no other directive syntax.
 ## Sending with a template
 
 Reference the template by its per-account alias (`template_alias`) or id
-(`template_id`) — mutually exclusive with literal `subject`/`body`/`html_body` —
+(`template_id`) — mutually exclusive with literal `subject`/`text`/`html` —
 and pass the variables in `template_data`:
 
 ```bash
@@ -75,7 +76,7 @@ curl -X POST https://api.e2a.dev/v1/agents/billing-bot%40agents.e2a.dev/messages
 Rendering happens **before** any human-in-the-loop review hold, so reviewers
 see the final subject and body.
 
-> **Wire change.** To make room for the template shape, `subject` and `body`
+> **Wire change.** To make room for the template shape, `subject` and `text`
 > moved from schema-required to handler-enforced on
 > `POST /v1/agents/{email}/messages`. A literal send that omits them now
 > returns **400 `invalid_request`** where it previously returned a **422**
@@ -140,5 +141,5 @@ tokens alone do not save you — the scanner's GET consumes the token.)
 
 ## See also
 
-- [`docs/api.md`](api.md) — REST surface overview and conventions
+- [`docs/api.md`](https://github.com/tokencanopy/e2a/blob/main/docs/api.md) — REST surface overview and conventions
 - [`api/openapi.yaml`](https://e2a.dev/openapi.yaml) — the canonical machine-readable contract


### PR DESCRIPTION
## What was outdated

**`web/public/templates.md`**
- Claimed "flat variables only" and gave a no-dot identifier regex, but `internal/emailtemplate/emailtemplate.go`'s `validIdent` regex already allows dots, and its `resolve()` function walks dot paths through nested objects (`{{user.name}}`) — `TemplateData`'s own OpenAPI doc comment says "dot paths into nested objects."
- Referred to the literal send fields as `subject`/`body`/`html_body`; the real JSON fields (`internal/httpapi/outbound.go`'s `SendEmailRequest`) are `subject`/`text`/`html` — this also contradicted `auth.md`'s own (correct) usage of `text`/`html` elsewhere on the same site.
- The `[docs/api.md](api.md)` link resolves to `https://e2a.dev/api.md` on the live site, which doesn't exist.

**`web/public/sdk.md`**
- Both HITL pagination examples (`client.reviews.list().toArray()` in TS, `.to_list()` in Python) omitted the required `limit` argument — `sdks/typescript/src/v1/pagination.ts` and `sdks/python/src/e2a/v1/pagination.py` both require it with no default, so the snippets as written throw / fail to compile.

## What changed

- Fixed the variable-syntax description and field names in `templates.md`; repointed the `docs/api.md` link to the GitHub blob URL (matching the convention `sdk.md` already uses for the SDK READMEs).
- Added `{ limit: 100 }` / `limit=100` to the `sdk.md` pagination examples.

## Test plan

- [x] Verified against `internal/emailtemplate/emailtemplate.go`, `internal/httpapi/outbound.go`, `sdks/typescript/src/v1/pagination.ts`, `sdks/python/src/e2a/v1/pagination.py`.
- N/A — docs-only change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Sk9NmEAhgWyAGmYcX2ZKSb)_