### PR TITLE
docs(mcp): fix stale tool-count references and send_message status wording

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -151,7 +151,7 @@ shows the set your scope allows, with per-tool descriptions.
 
 | Tool | Description |
 | --- | --- |
-| `send_message` | Send a new email. When the agent's outbound policy or content scan holds it for review, the message is held and returns `status: pending_review` instead of `sent`. |
+| `send_message` | Send a new email. The message is durably queued and returns `status: accepted` (the terminal outcome arrives via webhook/event or a follow-up read). When the agent's outbound policy or content scan holds it for review, it instead returns `status: pending_review`. |
 | `reply_to_message` | Reply to a message — one the agent received (replies to its sender) or one it sent (continues the thread to the original recipients). Preserves In-Reply-To / References for thread continuity. |
 | `list_messages` | List mail; pass `deleted:true` to list trash. Filter by `read_status` (unread / read / all) and sender with reserved-word-safe `from_`; cursor-paginated (`cursor` + `limit` in, `next_cursor` out). |
 | `restore_message` | Restore a soft-deleted message and resume its retention clock. |

--- a/mcp/examples/README.md
+++ b/mcp/examples/README.md
@@ -12,7 +12,7 @@ End-to-end demos showing how to wire the e2a MCP surface into popular agent fram
 
 ## One hosted endpoint, same tool surface
 
-Each example exercises the same e2a tool surface (37 tools; the visible set depends on your key's scope) against the hosted MCP server. The Python framework examples ship an `agent.py` script; the Codex example ships a TOML block (Codex is itself the agent, so you configure it instead of writing a script).
+Each example exercises the same e2a tool surface (50 tools; the visible set depends on your key's scope) against the hosted MCP server. The Python framework examples ship an `agent.py` script; the Codex example ships a TOML block (Codex is itself the agent, so you configure it instead of writing a script).
 
 Every example connects to `https://api.e2a.dev/mcp` over Streamable HTTP with your API key in the `Authorization` header. No Node toolchain or local build is needed, and updates land without rebuilding the agent's image — so it works equally well on a laptop or on serverless runtimes (Cloud Run, Lambda, Vercel).
 

--- a/mcp/examples/codex/README.md
+++ b/mcp/examples/codex/README.md
@@ -2,7 +2,7 @@
 
 [Codex CLI](https://github.com/openai/codex) is OpenAI's terminal coding agent (peer to Claude Code). It speaks MCP natively — you declare servers in `~/.codex/config.toml` and Codex connects to them at session start, then surfaces their tools to whatever model you're running.
 
-Unlike the [LangChain](../langchain/), [Google ADK](../adk/), and [OpenAI Agents SDK](../openai-agents/) examples — which are Python scripts you run — Codex is itself the agent. The "example" here is the TOML you paste into your Codex config to add e2a's MCP tools (37 total; the visible set depends on your key's scope).
+Unlike the [LangChain](../langchain/), [Google ADK](../adk/), and [OpenAI Agents SDK](../openai-agents/) examples — which are Python scripts you run — Codex is itself the agent. The "example" here is the TOML you paste into your Codex config to add e2a's MCP tools (50 total; the visible set depends on your key's scope).
 
 Codex opens a Streamable HTTP session to the hosted endpoint at `https://api.e2a.dev/mcp` with your API key in the `Authorization: Bearer …` header — no Node toolchain on the host (works on CI runners, dev containers, remote app servers, etc.).
 

--- a/plugins/e2a/.claude-plugin/plugin.json
+++ b/plugins/e2a/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "e2a",
   "displayName": "e2a",
   "version": "0.5.0",
-  "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 37 MCP tools over hosted streamable HTTP with OAuth.",
+  "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 50 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "TokenCanopy",
     "url": "https://e2a.dev"

--- a/plugins/e2a/.codex-plugin/plugin.json
+++ b/plugins/e2a/.codex-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "e2a",
   "displayName": "e2a",
   "version": "0.5.0",
-  "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 37 MCP tools over hosted streamable HTTP with OAuth.",
+  "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 50 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "TokenCanopy"
   },

--- a/plugins/e2a/.cursor-plugin/plugin.json
+++ b/plugins/e2a/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "e2a",
   "displayName": "e2a",
   "version": "0.5.0",
-  "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 37 MCP tools over hosted streamable HTTP with OAuth.",
+  "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 50 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "TokenCanopy",
     "url": "https://e2a.dev"

--- a/plugins/e2a/skills/e2a/SKILL.md
+++ b/plugins/e2a/skills/e2a/SKILL.md
@@ -191,5 +191,5 @@ The full, current integration code — SDK install, send / reply / parse, webhoo
 - Webhook + SDK code: https://e2a.dev/sdk.md
 - Exact tool signatures: call `tools/list` (authoritative).
 - OpenAPI contract: https://e2a.dev/openapi.yaml
-- The MCP surface is **48 tools** (14 runtime/inbox + 34 admin/setup) spanning agents, messages, HITL review, attachments, domains, events, webhooks, API keys, and templates (beta). The set you see depends on your credential's scope: an agent-scoped credential sees the 14 runtime tools; an account-scoped credential sees all 48. Tool descriptions teach behavior; this skill teaches the mental model. (`create_api_key` mints **agent-scoped** keys only — account-scoped keys come from the dashboard or raw API.)
+- The MCP surface is **50 tools** (14 runtime/inbox + 36 admin/setup) spanning agents, messages, HITL review, attachments, domains, events, webhooks, API keys, and templates (beta). The set you see depends on your credential's scope: an agent-scoped credential sees the 14 runtime tools; an account-scoped credential sees all 50. Tool descriptions teach behavior; this skill teaches the mental model. (`create_api_key` mints **agent-scoped** keys only — account-scoped keys come from the dashboard or raw API.)
 - Plugin homepage / docs index: https://e2a.dev (machine-readable index: https://e2a.dev/llms.txt)


### PR DESCRIPTION
## What was outdated

`mcp/src/tools/tiers.ts` currently defines 14 `RUNTIME_TOOLS` + 36 `ADMIN_TOOLS` = 50 total (I counted both sets directly), matching `mcp/README.md`'s own claim ("up to 50... 14 runtime/inbox... 36 admin/setup"). But six other files had drifted to two different stale counts:

- `mcp/examples/README.md:15` and `mcp/examples/codex/README.md:5` — "37 tools"
- `plugins/e2a/.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `.cursor-plugin/plugin.json` — "37 MCP tools" (identical description text in all three)
- `plugins/e2a/skills/e2a/SKILL.md:194` — "48 tools (14 runtime/inbox + 34 admin/setup)" — a different stale number again

`mcp/README.md`'s `send_message` row also said the message "returns `status: pending_review` instead of `sent`," implying `sent` is the normal immediate response status. Since outbound send is always queue-first for GA (per `CLAUDE.md`), the immediate non-held status is actually `accepted` (`api/openapi.yaml`'s `SendResultView.status` doc: "durably accepted but not yet delivered... terminal outcome via GET/webhook events") — `sent` only appears later.

## What changed

Updated all six tool-count references to 50, and reworded the `send_message` description to name `accepted` as the normal immediate status and `pending_review` as the held case.

## Test plan

- [x] Counted `RUNTIME_TOOLS` (14) and `ADMIN_TOOLS` (36) directly in `mcp/src/tools/tiers.ts`.
- [x] Verified the `accepted`/`pending_review` status semantics against `api/openapi.yaml`'s `SendResultView` schema and `internal/agent/api.go`.
- N/A — docs-only change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Sk9NmEAhgWyAGmYcX2ZKSb)_