### PR TITLE
fix(domains): reject IP literals in domain registration

### DIFF
--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -1703,12 +1703,27 @@ func validateDomain(domain string) (string, error) {
 	if domain == "" {
 		return "", errors.New("domain is required")
 	}
+	// Reject IP literals outright: every all-numeric label is valid
+	// IDNA, so "192.168.1.1" would otherwise parse as four legal
+	// labels and register as a "domain" — burning quota on a name
+	// that can never carry the MX/TXT/DKIM records we provision and
+	// can never verify. Check the raw input (catches IPv4, IPv6, and
+	// bracketed IPv6 before IDNA rejects the colons with a more
+	// confusing error) and, below, the IDNA-normalized form (catches
+	// Unicode digit forms like "１０.０.０.５" that only become an IP
+	// literal after mapping).
+	if isIPLiteral(domain) {
+		return "", errors.New("invalid domain: IP address is not a registrable domain")
+	}
 	if !strings.Contains(domain, ".") {
 		return "", errors.New("domain must contain at least one period")
 	}
 	ascii, err := idna.Lookup.ToASCII(domain)
 	if err != nil {
 		return "", fmt.Errorf("invalid domain: %w", err)
+	}
+	if isIPLiteral(ascii) {
+		return "", errors.New("invalid domain: IP address is not a registrable domain")
 	}
 	// IDNA's VerifyDNSLength option only enforces the 253-char total
 	// length; the 63-char per-label DNS limit (RFC 1035) is not
@@ -1723,6 +1738,15 @@ func validateDomain(domain string) (string, error) {
 		}
 	}
 	return ascii, nil
+}
+
+// isIPLiteral reports whether s is a bare IP literal (IPv4 or IPv6),
+// including the bracketed IPv6 form used in URLs/SMTP address literals.
+func isIPLiteral(s string) bool {
+	if len(s) >= 2 && s[0] == '[' && s[len(s)-1] == ']' {
+		s = s[1 : len(s)-1]
+	}
+	return net.ParseIP(s) != nil
 }
 
 // clientIP keys the per-IP limiters on the same trusted source as the

--- a/internal/agent/validate_test.go
+++ b/internal/agent/validate_test.go
@@ -70,6 +70,7 @@ func TestValidateDomain(t *testing.T) {
 		// Valid
 		{"plain ASCII", "example.com", false, "example.com"},
 		{"subdomain", "agents.example.com", false, "agents.example.com"},
+		{"multi-level public suffix", "sub.example.co.uk", false, "sub.example.co.uk"},
 		{"with hyphen", "my-domain.example.com", false, "my-domain.example.com"},
 		{"IDN normalizes to Punycode", "пример.рф", false, "xn--e1afmkfd.xn--p1ai"},
 		// Invalid — what today's prod was accepting before the fix
@@ -81,6 +82,19 @@ func TestValidateDomain(t *testing.T) {
 		{"control char", "exa\x00mple.com", true, ""},
 		// Length bounds — IDNA enforces 63-char label and 253-char total
 		{"label exceeds 63 chars", strings.Repeat("a", 64) + ".com", true, ""},
+		// IP literals are not registrable domains (B3): all-numeric
+		// labels are valid IDNA, so without an explicit check a bare
+		// IPv4 address sails through and registers with a nonsensical
+		// wildcard-MX/DKIM record set, burning domain quota on a name
+		// that can never verify.
+		{"IPv4 literal — private", "10.0.0.5", true, ""},
+		{"IPv4 literal — the bug repro", "192.168.1.1", true, ""},
+		{"IPv4 literal — broadcast", "255.255.255.255", true, ""},
+		{"IPv6 literal — loopback", "::1", true, ""},
+		{"IPv6 literal — doc range", "2001:db8::1", true, ""},
+		{"IPv6 literal — bracketed", "[2001:db8::1]", true, ""},
+		{"IPv4-mapped IPv6 literal", "::ffff:192.168.1.1", true, ""},
+		{"full-width-digit IPv4 — normalizes to an IP", "１９２.１６８.１.１", true, ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Bug (B3, Medium)

`POST /v1/domains` with `{"domain":"192.168.1.1"}` (or any bare IP literal) returned **201** and fully registered the "domain" — generating a nonsensical wildcard MX (`*.192.168.1.1 -> mx…`) and a DKIM selector record for a non-hostname, and consuming the account's domain quota on something that can never verify or function. Every other malformed input (scheme prefix, embedded space, single label, trailing dot, garbage) correctly returned **400 `invalid_domain`**.

## Root cause

`validateDomain` (`internal/agent/api.go`) is an IDNA-Lookup syntax check plus a has-a-period check. All-numeric labels are perfectly valid IDNA, so `192.168.1.1` parses as four legal DNS labels and passes — there was no check that the string isn't a bare IP literal.

## Fix

`validateDomain` now rejects IP literals with the same `invalid_domain` 400 as other malformed inputs, via a small `isIPLiteral` helper (`net.ParseIP`, with bracketed-IPv6 unwrapping). The check runs twice:

- on the **raw input** — catches IPv4, IPv6 (`::1`, `2001:db8::1`), bracketed IPv6, and IPv4-mapped IPv6 with a clear error before IDNA rejects the colons with a confusing one;
- on the **IDNA-normalized form** — catches Unicode digit spellings (e.g. full-width `１９２.１６８.１.１`) that only become an IP literal after mapping.

Valid-domain behavior is unchanged (plain, subdomain, hyphenated, multi-level public suffix, IDN→Punycode all still pass). Since the fix lives in the shared `ValidateDomain` seam, the agent-creation path that reuses it is hardened too.

## Tests

Extended `TestValidateDomain` (`internal/agent/validate_test.go`) with rejection cases for `10.0.0.5`, `192.168.1.1`, `255.255.255.255`, `::1`, `2001:db8::1`, `[2001:db8::1]`, `::ffff:192.168.1.1`, and the full-width-digit IPv4 form, plus an acceptance case for `sub.example.co.uk`. Confirmed **FAIL before** the fix (all three bare-IPv4 cases + the full-width form passed validation) and **PASS after**. `go build ./...` and `go test -short ./...` green (two DB-backed `cmd/e2a` tests flaked on Postgres deadlocks under the parallel run; both pass when run serially — unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xhgqySFWhusy9ucxSdkf9