### PR TITLE
docs: fix example SDK version pin and wrong API field name

### DIFF
--- a/examples/adk-cloud-webhook/pyproject.toml
+++ b/examples/adk-cloud-webhook/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
   # google-adk 2.0 is in pre-release as of writing and may reorganize imports.
   # Pin to the 1.x line until 2.0 ships and the code is verified against it.
   "google-adk>=1.31,<2",
-  "e2a>=4,<5",
+  "e2a>=5,<6",
   "fastapi>=0.115",
   "uvicorn[standard]>=0.30",
   "python-dotenv>=1.0",

--- a/plugins/e2a/skills/agentify/references/setup-checklist.md
+++ b/plugins/e2a/skills/agentify/references/setup-checklist.md
@@ -27,7 +27,7 @@ emails.
 - Create the agent: `mcp__e2a__create_agent` with the `support_address`
   from config (a verified domain you own), or `POST /v1/agents`.
 - Mint an **agent-scoped** API key bound to that address:
-  `POST /v1/account/api-keys` with `scope: agent`, `agent: <support_address>`.
+  `POST /v1/account/api-keys` with `scope: agent`, `agent_email: <support_address>`.
   The plaintext key is shown ONCE.
 - Add it as the repo secret `E2A_API_KEY`.
 - Run the mailbox with screening/HITL **off** — it is an intake firehose;


### PR DESCRIPTION
## What was outdated

`examples/adk-cloud-webhook/pyproject.toml` pinned `"e2a>=4,<5"`, but `webhook.py:45` imports `AsyncE2AClient` — a name introduced in the Python SDK's 5.0.0 release (`sdks/python/CHANGELOG.md`'s "5.0.0" entry: "`E2AClient` → `AsyncE2AClient`"). Following the example's own setup instructions (`pip install -e .`) resolves a dependency range that predates the class the code imports, so it would raise `ImportError` on 4.x.

`plugins/e2a/skills/agentify/references/setup-checklist.md`'s create-key example used `agent: <support_address>` in the request body, but `CreateAPIKeyRequest`'s real field (`api/openapi.yaml`) is `agent_email`.

## What changed

- Repointed the pin to `"e2a>=5,<6"`.
- Fixed the field name to `agent_email`.

## Test plan

- [x] Verified against `sdks/python/CHANGELOG.md`'s 5.0.0 entry, `examples/adk-cloud-webhook/webhook.py`'s import, and `api/openapi.yaml`'s `CreateAPIKeyRequest` schema.
- N/A — docs/example-config-only change, no application code touched.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Sk9NmEAhgWyAGmYcX2ZKSb)_