### PR TITLE
Fix outbound sends after registered-domain rename

### DIFF
--- a/internal/identity/delivery_store.go
+++ b/internal/identity/delivery_store.go
@@ -398,18 +398,18 @@ func (s *Store) GetSendOutcome(ctx context.Context, messageID string) (SendOutco
 // bytes; does not touch message_recipients (those are written at MarkSent).
 func (s *Store) LoadOutboundForSend(ctx context.Context, messageID string) (*OutboundSendPayload, error) {
 	var (
-		deliveryStatus string
-		envelopeFrom   string
-		sentAs         string
-		userID         string
-		domain         string
-		messageType    string
-		to, cc, bcc    []string
-		raw            []byte
-		createdAt      time.Time
+		deliveryStatus   string
+		envelopeFrom     string
+		sentAs           string
+		userID           string
+		registeredDomain string
+		messageType      string
+		to, cc, bcc      []string
+		raw              []byte
+		createdAt        time.Time
 	)
 	err := s.pool.QueryRow(ctx,
-		`SELECT COALESCE(m.delivery_status,''), COALESCE(m.envelope_from,''), COALESCE(m.sent_as,''), a.user_id, a.domain,
+		`SELECT COALESCE(m.delivery_status,''), COALESCE(m.envelope_from,''), COALESCE(m.sent_as,''), a.user_id, a.registered_domain,
 		        COALESCE(m.message_type,''),
 		        m.to_recipients, m.cc, m.bcc, m.raw_message, m.created_at
 		   FROM messages m
@@ -417,7 +417,7 @@ func (s *Store) LoadOutboundForSend(ctx context.Context, messageID string) (*Out
 		  WHERE m.id = $1 AND m.direction = 'outbound'
 		    AND m.deleted_at IS NULL AND a.deleted_at IS NULL`,
 		messageID,
-	).Scan(&deliveryStatus, &envelopeFrom, &sentAs, &userID, &domain, &messageType, &to, &cc, &bcc, &raw, &createdAt)
+	).Scan(&deliveryStatus, &envelopeFrom, &sentAs, &userID, &registeredDomain, &messageType, &to, &cc, &bcc, &raw, &createdAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
 	}
@@ -431,7 +431,7 @@ func (s *Store) LoadOutboundForSend(ctx context.Context, messageID string) (*Out
 	return &OutboundSendPayload{
 		ID:             messageID,
 		UserID:         userID,
-		Domain:         domain,
+		Domain:         registeredDomain,
 		MessageType:    messageType,
 		DeliveryStatus: deliveryStatus,
 		EnvelopeFrom:   envelopeFrom,
@@ -487,13 +487,13 @@ func (s *Store) ClaimOutboundForSend(ctx context.Context, messageID string, jobI
 		providerMessageID  string
 		messageType        string
 	)
-	var userID, domain string
+	var userID, registeredDomain string
 	// Lock agent first to match permanent agent deletion's lock order, then
 	// lock the message. Message-only trash operations never need the agent lock.
 	err = tx.QueryRow(ctx,
-		`SELECT deleted_at, user_id, domain FROM agent_identities WHERE id = $1 FOR UPDATE`,
+		`SELECT deleted_at, user_id, registered_domain FROM agent_identities WHERE id = $1 FOR UPDATE`,
 		agentID,
-	).Scan(&agentDeletedAt, &userID, &domain)
+	).Scan(&agentDeletedAt, &userID, &registeredDomain)
 	if errors.Is(err, pgx.ErrNoRows) {
 		if err := tx.Commit(ctx); err != nil {
 			return nil, err
@@ -566,7 +566,7 @@ func (s *Store) ClaimOutboundForSend(ctx context.Context, messageID string, jobI
 	p := &OutboundSendPayload{
 		ID:                messageID,
 		UserID:            userID,
-		Domain:            domain,
+		Domain:            registeredDomain,
 		MessageType:       messageType,
 		DeliveryStatus:    deliveryStatus,
 		EnvelopeFrom:      envelopeFrom,

--- a/internal/identity/outbound_async_test.go
+++ b/internal/identity/outbound_async_test.go
@@ -140,6 +140,60 @@ func TestClaimOutboundForSend_JobOwnership(t *testing.T) {
 	}
 }
 
+func TestOutboundForSend_UsesRegisteredParentDomain(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+
+	user, err := store.CreateOrGetUser(ctx, "owner@example.com", "Owner", "claim-parent-domain")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	if _, err := store.ClaimOrCreateDomain(ctx, "parent.example.com", user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+	if err := store.VerifyDomain(ctx, "parent.example.com", user.ID); err != nil {
+		t.Fatalf("VerifyDomain: %v", err)
+	}
+	agent, err := store.CreateAgent(ctx, "agent@child.parent.example.com", "parent.example.com", "", "", "", user.ID)
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	var messageID string
+	if err := store.WithTx(ctx, func(tx pgx.Tx) error {
+		message, err := store.CreateOutboundMessageTx(ctx, tx, agent.ID,
+			[]string{"recipient@example.net"}, nil, nil, "Subject", "send", "smtp", "", "conv-parent-domain",
+			[]byte("raw"), "accepted", agent.EmailAddress(), "relay")
+		if err != nil {
+			return err
+		}
+		messageID = message.ID
+		return store.StampSendJobIDTx(ctx, tx, messageID, 5150)
+	}); err != nil {
+		t.Fatalf("accept tx: %v", err)
+	}
+
+	loaded, err := store.LoadOutboundForSend(ctx, messageID)
+	if err != nil {
+		t.Fatalf("LoadOutboundForSend: %v", err)
+	}
+	if loaded == nil || loaded.Domain != "parent.example.com" {
+		t.Fatalf("loaded payload = %+v, want registered parent domain", loaded)
+	}
+
+	payload, err := store.ClaimOutboundForSend(ctx, messageID, 5150)
+	if err != nil {
+		t.Fatalf("ClaimOutboundForSend: %v", err)
+	}
+	if payload == nil {
+		t.Fatal("ClaimOutboundForSend returned nil")
+	}
+	if payload.Domain != "parent.example.com" {
+		t.Fatalf("payload domain = %q, want registered parent domain", payload.Domain)
+	}
+}
+
 // TestMarkOutboundSentTx flips a claimed sending row to sent with the provider id +
 // per-recipient rows, and returns the owning user/domain for the caller.
 func TestMarkOutboundSentTx(t *testing.T) {


### PR DESCRIPTION
## Summary

- read `agent_identities.registered_domain` when loading and claiming outbound sends
- preserve the registered parent identity for subdomain-agent ramp accounting
- add a real-Postgres regression covering both outbound payload paths

## Root cause

Migration 067 renamed `agent_identities.domain` to `registered_domain`, but the outbound payload loaders added in #545 still queried the old column. Async jobs therefore remained accepted and retried, causing the Go e2e threading and webhook tests to time out.

Failed run: https://github.com/tokencanopy/e2a/actions/runs/29654591011/job/88106548422

## Verification

- focused RED/GREEN regression against PostgreSQL
- `make test-integration`
- `make test-e2e`
- `go test ./internal/outboundsend -count=1`
- `git diff --check`
