### PR TITLE
fix(contract): persist inbound event envelope

### DIFF
--- a/tests/contract/contract_test.go
+++ b/tests/contract/contract_test.go
@@ -24,8 +24,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/tokencanopy/e2a/internal/eventpayload"
+	"github.com/tokencanopy/e2a/internal/headers"
 	"github.com/tokencanopy/e2a/internal/identity"
 	"github.com/tokencanopy/e2a/internal/testutil"
+	"github.com/tokencanopy/e2a/internal/webhookpub"
 	"github.com/tokencanopy/e2a/internal/ws"
 	"gopkg.in/yaml.v3"
 	"nhooyr.io/websocket"
@@ -98,6 +102,8 @@ type expectation struct {
 type testEnv struct {
 	baseURL string
 	store   *identity.Store
+	outbox  webhookpub.Outbox
+	signer  *headers.Signer
 	wsHub   *ws.Hub
 	apiKey  string
 	userID  string
@@ -120,6 +126,8 @@ func setupEnv(t *testing.T) *testEnv {
 	return &testEnv{
 		baseURL: cs.BaseURL,
 		store:   cs.Store,
+		outbox:  webhookpub.NewOutbox(cs.DBPool, webhookpub.StaticFlag(true)),
+		signer:  cs.Signer,
 		wsHub:   cs.WSHub,
 		apiKey:  cs.APIKey,
 		userID:  cs.UserID,
@@ -164,15 +172,107 @@ func (e *testEnv) injectInboundMessage(t *testing.T, agentEmail, from, subject s
 	// view omits the field (it is omitempty), which is not how a real received
 	// message looks. Populate both so the contract exercises the real shape.
 	raw := []byte("From: " + from + "\r\nTo: " + agentEmail + "\r\nSubject: " + subject + "\r\n\r\nbody\r\n")
-	authHeaders := map[string]string{
-		"X-E2A-Auth-Results":  "spf=pass; dkim=pass; dmarc=pass",
-		"X-E2A-Auth-Verified": "true",
-	}
-	msg, err := e.store.CreateInboundMessage(ctx, "", ag.ID, from, agentEmail, "", subject, "", "unread", raw, authHeaders, nil, false, "", nil, nil, nil, identity.InboundScreening{})
+	messageID := identity.NewMessageID()
+	authHeaders := e.signer.Sign(headers.AuthPayload{
+		Verified:    true,
+		Sender:      from,
+		EntityType:  "human",
+		DomainCheck: "spf=pass; dkim=pass; dmarc=pass",
+		MessageID:   messageID,
+		BodyHash:    headers.HashBody(raw),
+	})
+	to := []string{agentEmail}
+	var msg *identity.Message
+	// Match the production inbound invariant: the inbox row and its canonical
+	// email.received envelope become durable in the same transaction.
+	err = e.store.WithTx(ctx, func(tx pgx.Tx) error {
+		var txErr error
+		msg, txErr = e.store.CreateInboundMessageInTx(
+			ctx, tx, messageID, ag.ID, from, agentEmail, "", subject, "", "unread",
+			raw, authHeaders, nil, false, "", to, nil, nil, identity.InboundScreening{},
+		)
+		if txErr != nil {
+			return txErr
+		}
+
+		event := webhookpub.NewEvent(webhookpub.EventEmailReceived, ag.UserID, eventpayload.EmailReceivedData{
+			MessageID:         msg.ID,
+			AgentEmail:        agentEmail,
+			Direction:         "inbound",
+			From:              from,
+			AuthenticatedFrom: from,
+			To:                to,
+			DeliveredTo:       agentEmail,
+			Subject:           subject,
+			AuthHeaders:       authHeaders,
+			ReceivedAt:        msg.CreatedAt.UTC(),
+			Attachments:       eventpayload.AttachmentMetadata(raw),
+		})
+		event.ID = webhookpub.DeterministicEventID(msg.ID, webhookpub.EventEmailReceived)
+		event.AgentID = ag.ID
+		event.MessageID = msg.ID
+		return e.outbox.PublishTx(ctx, tx, event)
+	})
 	if err != nil {
 		t.Fatalf("store message: %v", err)
 	}
 	return msg.ID
+}
+
+func TestInjectInboundMessagePersistsDurableEnvelope(t *testing.T) {
+	env := setupEnv(t)
+	r := newRunner(env, scenario{})
+
+	if _, err := env.store.ClaimOrCreateDomain(context.Background(), "ws-envelope.test.dev", env.userID); err != nil {
+		t.Fatalf("claim domain: %v", err)
+	}
+	if err := env.store.VerifyDomain(context.Background(), "ws-envelope.test.dev", env.userID); err != nil {
+		t.Fatalf("verify domain: %v", err)
+	}
+	r.setupRegisterAgent(t, &agentSetup{Email: "bot@ws-envelope.test.dev"})
+
+	msgID := env.injectInboundMessage(t, "bot@ws-envelope.test.dev", "alice@example.com", "WS envelope test")
+	envelope, err := env.store.GetEventEnvelope(context.Background(), msgID, webhookpub.EventEmailReceived)
+	if err != nil {
+		t.Fatalf("get durable email.received envelope: %v", err)
+	}
+	if len(envelope) == 0 {
+		t.Fatal("durable email.received envelope is empty")
+	}
+	var event struct {
+		Data struct {
+			MessageID   string              `json:"message_id"`
+			AuthHeaders headers.AuthHeaders `json:"auth_headers"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(envelope, &event); err != nil {
+		t.Fatalf("decode durable email.received envelope: %v", err)
+	}
+	if event.Data.MessageID != msgID {
+		t.Fatalf("event message_id = %q, want %q", event.Data.MessageID, msgID)
+	}
+	if !env.signer.Verify(event.Data.AuthHeaders) {
+		t.Fatal("durable email.received auth_headers do not carry a valid contract-server attestation")
+	}
+	wantRaw := []byte("From: alice@example.com\r\nTo: bot@ws-envelope.test.dev\r\nSubject: WS envelope test\r\n\r\nbody\r\n")
+	wantHeaders := map[string]string{
+		headers.HeaderVerified:    "true",
+		headers.HeaderSender:      "alice@example.com",
+		headers.HeaderEntityType:  "human",
+		headers.HeaderDomainCheck: "spf=pass; dkim=pass; dmarc=pass",
+		headers.HeaderMessageID:   msgID,
+		headers.HeaderBodyHash:    headers.HashBody(wantRaw),
+	}
+	for name, want := range wantHeaders {
+		if got := event.Data.AuthHeaders[name]; got != want {
+			t.Errorf("auth header %s = %q, want %q", name, got, want)
+		}
+	}
+	for _, name := range []string{headers.HeaderTimestamp, headers.HeaderSignature} {
+		if event.Data.AuthHeaders[name] == "" {
+			t.Errorf("auth header %s is empty", name)
+		}
+	}
 }
 
 // ── Scenario runner ────────────────────────────────────────────────


### PR DESCRIPTION
<!--
Thanks for the PR! Keep the description tight — explain *why*, link the
context, and use the checklist below to surface anything that's still
open.

If this PR doesn't touch the API or any client surface (e.g. docs-only,
infra, refactor), feel free to delete the "Client surface checklist"
section entirely.
-->

## Summary

<!-- 1–3 sentences: what changes, why. Link the issue / RFC / Slack thread if any. -->

## Client surface checklist

<!--
Every API change must land in every client at the same time. Skipping a
client should be an explicit decision noted below, not an oversight.
Delete rows that genuinely don't apply (e.g. `e2a config` doesn't need
to be in the Python SDK).
-->

- [ ] Go handler + integration tests
- [ ] Migration written + idempotent + safe on prod-sized tables (see [CLAUDE.md](../CLAUDE.md))
- [ ] OpenAPI spec + generated types refreshed (`make generate` is clean)
- [ ] TypeScript SDK — generated base regenerated (`make generate-sdk`) **and** resource added to the hand-written `E2AClient` (`sdks/typescript/src/v1/client.ts`)
- [ ] Python SDK — generated base regenerated (`make generate-sdk`) **and** resource added to the hand-written `AsyncE2AClient` (`sdks/python/src/e2a/v1/client.py`)
- [ ] CLI command or flag in `cli/src/commands/` + wired into `cli/src/bin/e2a.ts`
- [ ] MCP tool in `mcp/src/tools/` + registry assertion in `mcp/tests/{tools,http}.test.ts`
- [ ] Tests at each surface above (positive + at least one negative-path / regression case)

**If a row is intentionally skipped**, state why here so the reviewer doesn't have to guess:

> _e.g. "MCP tool deferred — endpoint is admin-only and not useful to an LLM"_

## Operational risk

<!--
Touched user data, side effects, auth, billing, notifications, or
external integrations? Note rollback behavior, feature flags, anything
worth flagging to oncall.
-->

## Test plan

<!--
What you ran locally, what should be tried after merge. Tick items as
they're verified.
-->

- [ ]
- [ ]
