### PR TITLE
fix(identity): keep template timestamps monotonic

### DIFF
--- a/internal/identity/templates.go
+++ b/internal/identity/templates.go
@@ -100,7 +100,6 @@ func (s *Store) CreateTemplate(ctx context.Context, userID string, in TemplateCr
 		return nil, ErrTemplateLimitReached
 	}
 
-	now := time.Now()
 	tp := &Template{
 		ID:                 generateTemplateID(),
 		UserID:             userID,
@@ -111,15 +110,14 @@ func (s *Store) CreateTemplate(ctx context.Context, userID string, in TemplateCr
 		HTMLBody:           in.HTMLBody,
 		FromStarterAlias:   in.FromStarterAlias,
 		FromStarterVersion: in.FromStarterVersion,
-		CreatedAt:          now,
-		UpdatedAt:          now,
 	}
-	if _, err := s.pool.Exec(ctx,
-		`INSERT INTO templates (id, user_id, name, alias, subject, body, html_body, from_starter_alias, from_starter_version, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
+	if err := s.pool.QueryRow(ctx,
+		`INSERT INTO templates (id, user_id, name, alias, subject, body, html_body, from_starter_alias, from_starter_version)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+		 RETURNING created_at, updated_at`,
 		tp.ID, tp.UserID, tp.Name, nullIfEmpty(tp.Alias), tp.Subject, tp.Body, nullIfEmpty(tp.HTMLBody),
-		nullIfEmpty(tp.FromStarterAlias), nullIfEmpty(tp.FromStarterVersion), tp.CreatedAt, tp.UpdatedAt,
-	); err != nil {
+		nullIfEmpty(tp.FromStarterAlias), nullIfEmpty(tp.FromStarterVersion),
+	).Scan(&tp.CreatedAt, &tp.UpdatedAt); err != nil {
 		if isUniqueViolation(err) {
 			return nil, ErrTemplateAliasTaken
 		}
@@ -293,7 +291,7 @@ func (s *Store) UpdateTemplate(ctx context.Context, templateID, userID string, u
 		// No-op PATCH. Return the current row.
 		return s.GetTemplateByID(ctx, templateID, userID)
 	}
-	sets = append(sets, "updated_at = now()")
+	sets = append(sets, "updated_at = GREATEST(clock_timestamp(), updated_at + interval '1 microsecond')")
 
 	query := fmt.Sprintf(
 		`UPDATE templates SET %s WHERE id = $1 AND user_id = $2 RETURNING id`,

--- a/internal/identity/templates_test.go
+++ b/internal/identity/templates_test.go
@@ -301,6 +301,37 @@ func TestUpdateTemplate_PartialFields(t *testing.T) {
 	}
 }
 
+func TestUpdateTemplate_UpdatedAtStrictlyIncreases(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	ctx := context.Background()
+	userID := templateTestUser(t, store, "tmpl-upd-monotonic")
+	tp, err := store.CreateTemplate(ctx, userID, identity.TemplateCreate{Name: "Old", Subject: "Old subject", Body: "Old body"})
+	if err != nil {
+		t.Fatalf("CreateTemplate: %v", err)
+	}
+
+	// Simulate the database clock moving behind the timestamp already stored
+	// on the row. This is the same ordering hazard as creating with the Go
+	// process clock and updating with the PostgreSQL clock.
+	var previous time.Time
+	if err := pool.QueryRow(ctx,
+		`UPDATE templates SET updated_at = now() + interval '1 hour' WHERE id = $1 RETURNING updated_at`,
+		tp.ID,
+	).Scan(&previous); err != nil {
+		t.Fatalf("seed future updated_at: %v", err)
+	}
+
+	newName := "New"
+	got, err := store.UpdateTemplate(ctx, tp.ID, userID, identity.TemplateUpdate{Name: &newName})
+	if err != nil {
+		t.Fatalf("UpdateTemplate: %v", err)
+	}
+	if !got.UpdatedAt.After(previous) {
+		t.Errorf("updated_at not strictly increased: was %v now %v", previous, got.UpdatedAt)
+	}
+}
+
 func TestUpdateTemplate_ClearAliasAndHTML(t *testing.T) {
 	pool := testutil.TestDB(t)
 	store := identity.NewStore(pool)


### PR DESCRIPTION
## Summary

- source template `created_at` and `updated_at` from PostgreSQL defaults on create
- guarantee each mutating update strictly advances `updated_at`, even if the database wall clock moves backward
- add a deterministic regression test that simulates the stored timestamp being ahead of the current database clock

## Root cause

`CreateTemplate` returned timestamps from the Go process clock, while `UpdateTemplate` replaced `updated_at` with PostgreSQL `now()`. When those clocks were not perfectly synchronized, an immediate update could return an `updated_at` earlier than the creation timestamp and violate the store contract that updates always bump it.

The templates implementation and its ordering assertion were introduced together in #375 on July 3. The test usually passed because CI runs the Go process and PostgreSQL service against the same host clock. The failure is easier to trigger locally when Go runs on macOS and PostgreSQL runs in Docker Desktop's Linux VM, where small clock drift can appear. The original test was therefore timing- and environment-sensitive.

## Implementation

Creation now omits both timestamp columns and scans the values generated by PostgreSQL's schema defaults. Updates use `GREATEST(clock_timestamp(), updated_at + interval '1 microsecond')`, keeping PostgreSQL authoritative while preserving a strict per-row monotonic timestamp if the wall clock steps backward.

## TDD verification

- RED: `TestUpdateTemplate_UpdatedAtStrictlyIncreases` failed with the new timestamp almost one hour earlier than the seeded stored timestamp
- GREEN: original partial-update test plus the deterministic regression passed together
- package: `go test -tags integration -p 1 ./internal/identity -count=1` passed in 103.414s

Database: `postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable`
