### PR TITLE
fix(testutil): use production migration runner

### DIFF
--- a/cmd/e2a-prober/prober_test.go
+++ b/cmd/e2a-prober/prober_test.go
@@ -287,8 +287,8 @@ func TestCmdValidate_Failures(t *testing.T) {
 	}
 
 	// DB reachable + migrations recorded, but the probe identity is absent.
-	// RunMigrations populates schema_migrations (testutil applies DDL only) so
-	// cmdValidate's migrations-applied check passes and reaches the identity check.
+	// Re-running the production migration path verifies it is idempotent before
+	// cmdValidate's migrations-applied check reaches the identity check.
 	pool := testutil.TestDB(t)
 	if err := identity.RunMigrations(ctx, pool, migrations.FS, identity.ModeAuto); err != nil {
 		t.Fatalf("record migrations: %v", err)

--- a/cmd/e2a/readyz_test.go
+++ b/cmd/e2a/readyz_test.go
@@ -15,12 +15,9 @@ import (
 	"github.com/tokencanopy/e2a/migrations"
 )
 
-// migratedTestDB returns a test pool with the schema_migrations tracker
-// populated the way production does. testutil.TestDB applies migration DDL via
-// raw Exec but does NOT record schema_migrations, so the /readyz and /selftest
-// migration-applied checks (which query that tracker, as they do in prod) need
-// this. RunMigrations re-applies the already-present (idempotent) migrations and
-// records each filename.
+// migratedTestDB returns a test pool prepared through the production migration
+// runner. The explicit second call verifies the startup path is idempotent before
+// /readyz and /selftest query the schema_migrations tracker.
 func migratedTestDB(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	pool := testutil.TestDB(t)

--- a/internal/identity/migrate_test.go
+++ b/internal/identity/migrate_test.go
@@ -191,13 +191,10 @@ func TestRunMigrations_VerifyModeRefusesToApply(t *testing.T) {
 	}
 }
 
-// TestRunMigrations_SkipModeIsNoop ensures skip mode does nothing —
-// not even creating the schema_migrations table on a fresh DB.
+// TestRunMigrations_SkipModeIsNoop ensures skip mode does not apply pending SQL.
 func TestRunMigrations_SkipModeIsNoop(t *testing.T) {
 	ctx := context.Background()
 	pool := testutil.TestDB(t)
-	// The testutil's own migration runner doesn't create schema_migrations
-	// so this is genuinely "did skip touch the DB at all" for that table.
 
 	fsys := stubFS(map[string]string{
 		"any.sql": "CREATE TABLE IF NOT EXISTS migrate_test_skip (id TEXT);",

--- a/internal/testutil/db.go
+++ b/internal/testutil/db.go
@@ -2,6 +2,8 @@ package testutil
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"os"
 	"testing"
 
@@ -11,6 +13,19 @@ import (
 )
 
 const defaultTestDBURL = "postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable"
+
+type testDBPreparationError struct {
+	stage string
+	err   error
+}
+
+func (e *testDBPreparationError) Error() string {
+	return fmt.Sprintf("%s: %v", e.stage, e.err)
+}
+
+func (e *testDBPreparationError) Unwrap() error {
+	return e.err
+}
 
 func TestDBURL() string {
 	dbURL := os.Getenv("E2A_TEST_DATABASE_URL")
@@ -37,12 +52,12 @@ func OpenPreparedTestDB(ctx context.Context, dbURL string) (*pgxpool.Pool, error
 
 	if err := runMigrations(ctx, pool); err != nil {
 		pool.Close()
-		return nil, err
+		return nil, &testDBPreparationError{stage: "run migrations", err: err}
 	}
 
 	if err := truncateAll(ctx, pool); err != nil {
 		pool.Close()
-		return nil, err
+		return nil, &testDBPreparationError{stage: "truncate tables", err: err}
 	}
 
 	return pool, nil
@@ -54,6 +69,10 @@ func TestDB(t *testing.T) *pgxpool.Pool {
 	ctx := context.Background()
 	pool, err := OpenPreparedTestDB(ctx, TestDBURL())
 	if err != nil {
+		var preparationErr *testDBPreparationError
+		if errors.As(err, &preparationErr) {
+			t.Fatalf("failed to prepare test database: %v", err)
+		}
 		t.Skipf("test database not available: %v", err)
 	}
 

--- a/internal/testutil/db.go
+++ b/internal/testutil/db.go
@@ -2,13 +2,12 @@ package testutil
 
 import (
 	"context"
-	"fmt"
 	"os"
-	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/tokencanopy/e2a/internal/identity"
+	"github.com/tokencanopy/e2a/migrations"
 )
 
 const defaultTestDBURL = "postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable"
@@ -75,31 +74,7 @@ func TruncateAll(t *testing.T, pool *pgxpool.Pool) {
 }
 
 func runMigrations(ctx context.Context, pool *pgxpool.Pool) error {
-	migrationsDir := filepath.Join(projectRoot(), "migrations")
-	entries, err := os.ReadDir(migrationsDir)
-	if err != nil {
-		return err
-	}
-	for _, entry := range entries {
-		if entry.IsDir() || filepath.Ext(entry.Name()) != ".sql" {
-			continue
-		}
-		migration, err := os.ReadFile(filepath.Join(migrationsDir, entry.Name()))
-		if err != nil {
-			return err
-		}
-		if _, err := pool.Exec(ctx, string(migration)); err != nil {
-			// Existing tables / repeated extensions are expected when a
-			// previous run already applied the schema; ignoring those is
-			// the established convention here. But we log to stderr so a
-			// genuine SQL error in a new migration surfaces during
-			// `go test` instead of being absorbed silently — that would
-			// otherwise let a broken migration ship and only fail later
-			// in the real RunMigrations path.
-			fmt.Fprintf(os.Stderr, "[testutil] migration %s: %v\n", entry.Name(), err)
-		}
-	}
-	return nil
+	return identity.RunMigrations(ctx, pool, migrations.FS, identity.ModeAuto)
 }
 
 // truncateAll resets the DB between tests. Most tables are reached implicitly by
@@ -134,10 +109,4 @@ func truncateAll(ctx context.Context, pool *pgxpool.Pool) error {
 	// Re-seed shared domain (migration seeds it but truncation removes it)
 	pool.Exec(ctx, `INSERT INTO domains (domain, user_id, verified, verified_at) VALUES ('agents.e2a.dev', NULL, true, now()) ON CONFLICT DO NOTHING`)
 	return nil
-}
-
-func projectRoot() string {
-	_, filename, _, _ := runtime.Caller(0)
-	// internal/testutil/db.go -> project root
-	return filepath.Join(filepath.Dir(filename), "..", "..")
 }

--- a/internal/testutil/db_test.go
+++ b/internal/testutil/db_test.go
@@ -2,9 +2,17 @@ package testutil
 
 import (
 	"context"
+	"net/url"
+	"os"
+	"os/exec"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+const testDBErrorChildEnv = "E2A_TEST_DB_ERROR_CHILD"
 
 func TestTruncateAll_CleansInboundIntakeWithoutExclusiveTableLock(t *testing.T) {
 	pool := TestDB(t)
@@ -101,4 +109,74 @@ func TestRunMigrations_RepeatedPreparationUsesTrackerWithoutConsumingAttributeSl
 	if tracked != 3 {
 		t.Fatalf("tracked HITL migrations = %d, want 3", tracked)
 	}
+}
+
+func TestTestDB_PreparationFailureIsFatal(t *testing.T) {
+	if os.Getenv(testDBErrorChildEnv) == t.Name() {
+		_ = TestDB(t)
+		return
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, TestDBURL())
+	if err != nil {
+		t.Skipf("test database not available: %v", err)
+	}
+	defer pool.Close()
+	if err := pool.Ping(ctx); err != nil {
+		t.Skipf("test database not available: %v", err)
+	}
+
+	dbURL, err := url.Parse(TestDBURL())
+	if err != nil {
+		t.Fatalf("parse test database URL: %v", err)
+	}
+	query := dbURL.Query()
+	query.Set("search_path", "e2a_test_missing_schema")
+	dbURL.RawQuery = query.Encode()
+
+	output, err := runTestDBErrorChild(t, dbURL.String())
+	if err == nil {
+		t.Fatalf("TestDB preparation failure exited successfully; want fatal failure\n%s", output)
+	}
+	if !strings.Contains(output, "failed to prepare test database") {
+		t.Fatalf("fatal output missing preparation context:\n%s", output)
+	}
+}
+
+func TestTestDB_UnavailableDatabaseStillSkips(t *testing.T) {
+	if os.Getenv(testDBErrorChildEnv) == t.Name() {
+		_ = TestDB(t)
+		return
+	}
+
+	const unavailableURL = "postgres://e2a:e2a@127.0.0.1:1/e2a_test?sslmode=disable&connect_timeout=1"
+	output, err := runTestDBErrorChild(t, unavailableURL)
+	if err != nil {
+		t.Fatalf("unavailable test database should skip, not fail: %v\n%s", err, output)
+	}
+	if !strings.Contains(output, "SKIP") {
+		t.Fatalf("unavailable test database output missing skip:\n%s", output)
+	}
+}
+
+func runTestDBErrorChild(t *testing.T, dbURL string) (string, error) {
+	t.Helper()
+
+	cmd := exec.Command(os.Args[0], "-test.run=^"+t.Name()+"$", "-test.v")
+	cmd.Env = testDBChildEnv(t.Name(), dbURL)
+	output, err := cmd.CombinedOutput()
+	return string(output), err
+}
+
+func testDBChildEnv(testName, dbURL string) []string {
+	env := make([]string, 0, len(os.Environ())+2)
+	for _, item := range os.Environ() {
+		if strings.HasPrefix(item, testDBErrorChildEnv+"=") ||
+			strings.HasPrefix(item, "E2A_TEST_DATABASE_URL=") {
+			continue
+		}
+		env = append(env, item)
+	}
+	return append(env, testDBErrorChildEnv+"="+testName, "E2A_TEST_DATABASE_URL="+dbURL)
 }

--- a/internal/testutil/db_test.go
+++ b/internal/testutil/db_test.go
@@ -50,3 +50,55 @@ func TestTruncateAll_CleansInboundIntakeWithoutExclusiveTableLock(t *testing.T) 
 		t.Fatalf("inbound_intake rows after cleanup = %d, want 0", after)
 	}
 }
+
+func TestRunMigrations_RepeatedPreparationUsesTrackerWithoutConsumingAttributeSlots(t *testing.T) {
+	pool := TestDB(t)
+	ctx := context.Background()
+
+	var before int
+	if err := pool.QueryRow(ctx, `
+		SELECT max(attnum)
+		FROM pg_attribute
+		WHERE attrelid = 'public.agent_identities'::regclass
+		  AND attnum > 0
+	`).Scan(&before); err != nil {
+		t.Fatalf("read agent_identities max attnum before replay: %v", err)
+	}
+
+	if err := runMigrations(ctx, pool); err != nil {
+		t.Fatalf("repeat migrations: %v", err)
+	}
+
+	var after int
+	if err := pool.QueryRow(ctx, `
+		SELECT max(attnum)
+		FROM pg_attribute
+		WHERE attrelid = 'public.agent_identities'::regclass
+		  AND attnum > 0
+	`).Scan(&after); err != nil {
+		t.Fatalf("read agent_identities max attnum after replay: %v", err)
+	}
+
+	var hasTracker bool
+	if err := pool.QueryRow(ctx,
+		`SELECT to_regclass('public.schema_migrations') IS NOT NULL`,
+	).Scan(&hasTracker); err != nil {
+		t.Fatalf("check schema_migrations tracker: %v", err)
+	}
+
+	if after != before || !hasTracker {
+		t.Fatalf("repeated migration preparation: max attnum %d -> %d, schema_migrations exists=%v; want unchanged attnum and tracker", before, after, hasTracker)
+	}
+
+	var tracked int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*)
+		FROM schema_migrations
+		WHERE filename IN ('003_hitl.sql', '036_hitl_mode.sql', '043_drop_hitl_columns.sql')
+	`).Scan(&tracked); err != nil {
+		t.Fatalf("count tracked HITL migrations: %v", err)
+	}
+	if tracked != 3 {
+		t.Fatalf("tracked HITL migrations = %d, want 3", tracked)
+	}
+}


### PR DESCRIPTION
## Summary

- prepare test databases with the same tracked migration runner used in production
- stop replaying every migration on every test setup
- fail tests when schema preparation fails while preserving skips for an unavailable database

## Root cause

The test helper executed every SQL migration directly for every `TestDB` call and ignored individual migration errors. Early HITL migrations add columns that later migrations remove, so repeated preparation continually consumed PostgreSQL attribute slots until `agent_identities` reached the 1,600-column limit.

Using `identity.RunMigrations` with the embedded production migration set makes `schema_migrations` authoritative and prevents migration replay. Preparation-stage errors are now fatal so schema drift cannot silently turn into misleading downstream test results.

## Test plan

- `go test ./internal/testutil ./internal/identity ./cmd/e2a ./cmd/e2a-prober -run '^$'`
- `E2A_TEST_DATABASE_URL=postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable go test -tags integration -p 1 ./internal/testutil -run '^(TestRunMigrations_RepeatedPreparationUsesTrackerWithoutConsumingAttributeSlots|TestTestDB_PreparationFailureIsFatal|TestTestDB_UnavailableDatabaseStillSkips)$' -count=1`
- `E2A_TEST_DATABASE_URL=postgres://e2a:e2a@localhost:5433/e2a_test?sslmode=disable go test -tags integration -p 1 ./internal/testutil ./internal/identity ./cmd/e2a ./cmd/e2a-prober`
