### PR TITLE
fix(events): stop dropping email.blocked for outbound gate-blocks (message_id FK)

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -72,6 +72,8 @@ for e in client.events.list(type="email.received", limit=20):
 
 The review-hold + screening events (`email.flagged`, `email.blocked`, `email.review_requested`, `email.review_approved`, `email.review_rejected`) are **beta** — their payloads may change before they are declared stable.
 
+One `email.blocked` asymmetry to know: an **outbound** gate-block refuses the send outright, so no message row exists — its `data.message_id` is a stable rowless soft-ref (`msgblk_…`), the event's top-level `message_id` is absent, and `GET /v1/events?message_id=…` cannot match it (filter by `type` + `agent_email`, or by `conversation_id`, instead). **Inbound** blocks are accept-then-quarantine, reference a real message, and filter normally.
+
 ## Envelope and typed payloads
 
 Webhook deliveries and WebSocket frames use the canonical OpenAPI

--- a/internal/agent/export_test.go
+++ b/internal/agent/export_test.go
@@ -55,5 +55,7 @@ func MarkSideEffectCommittedForTest(w http.ResponseWriter) {
 func BuildBlockedOutboundEventForTest(agent *identity.AgentIdentity, req outbound.SendRequest, reviewReason, reason string) (webhookpub.Event, string) {
 	softRef := blockAuditID(agent.ID, req)
 	v := outboundVerdict{Applied: "block", ReviewReason: reviewReason, Reason: reason}
+	// Receiver deliberately zero: the builder must stay stateless (pure over
+	// its arguments) — if it ever reads API fields this seam nil-panics.
 	return (&API{}).buildBlockedOutboundEvent(agent, softRef, req, v), softRef
 }

--- a/internal/agent/export_test.go
+++ b/internal/agent/export_test.go
@@ -6,7 +6,9 @@ package agent
 import (
 	"net/http"
 
+	"github.com/tokencanopy/e2a/internal/identity"
 	"github.com/tokencanopy/e2a/internal/outbound"
+	"github.com/tokencanopy/e2a/internal/webhookpub"
 )
 
 // IsSelfSendForTest is the agent_test-package handle for isSelfSend.
@@ -43,4 +45,15 @@ func (a *API) IdempotencyGuardForTest(w http.ResponseWriter, r *http.Request, us
 // inside a synthetic handler.
 func MarkSideEffectCommittedForTest(w http.ResponseWriter) {
 	markSideEffectCommitted(w)
+}
+
+// BuildBlockedOutboundEventForTest exposes buildBlockedOutboundEvent (and the
+// blockAuditID soft-ref it is keyed on) so the external agent_test package can
+// drive the exact event the emit path constructs through a real outbox +
+// production schema. Takes primitives so outboundVerdict stays unexported.
+// Returns the event and the msgblk_ soft-ref.
+func BuildBlockedOutboundEventForTest(agent *identity.AgentIdentity, req outbound.SendRequest, reviewReason, reason string) (webhookpub.Event, string) {
+	softRef := blockAuditID(agent.ID, req)
+	v := outboundVerdict{Applied: "block", ReviewReason: reviewReason, Reason: reason}
+	return (&API{}).buildBlockedOutboundEvent(agent, softRef, req, v), softRef
 }

--- a/internal/agent/screening.go
+++ b/internal/agent/screening.go
@@ -297,13 +297,14 @@ func (a *API) auditRowless(ctx context.Context, agent *identity.AgentIdentity, m
 }
 
 // emitBlockedOutbound fires the fire-and-forget email.blocked event for an outbound
-// send refused by screening (applied action = block). messageID is the stable
-// soft-ref (blockAuditID) since no message row is persisted, so the deterministic id
-// keeps retries idempotent. reason_source mirrors the protection_events vocabulary
+// send refused by screening (applied action = block). softRef is the stable
+// rowless soft-ref (blockAuditID) — NOT a messages-row id; no message row is
+// persisted for a block. The deterministic id keeps retries idempotent.
+// reason_source mirrors the protection_events vocabulary
 // (recipient_gate / outbound_scan).
-func (a *API) buildBlockedOutboundEvent(agent *identity.AgentIdentity, messageID string, req outbound.SendRequest, v outboundVerdict) webhookpub.Event {
+func (a *API) buildBlockedOutboundEvent(agent *identity.AgentIdentity, softRef string, req outbound.SendRequest, v outboundVerdict) webhookpub.Event {
 	e := webhookpub.NewEvent(webhookpub.EventEmailBlocked, agent.UserID, map[string]interface{}{
-		"message_id":    messageID,
+		"message_id":    softRef,
 		"agent_email":   agent.EmailAddress(),
 		"direction":     "outbound",
 		"to":            req.To,
@@ -319,14 +320,16 @@ func (a *API) buildBlockedOutboundEvent(agent *identity.AgentIdentity, messageID
 	// messages(id), and a blocked send persists no message row — writing the
 	// msgblk_ soft-ref there fails the FK and rolls back the whole event (the
 	// column is for real rows only; consumers already see NULL there after
-	// ON DELETE SET NULL). The soft-ref still travels in data.message_id and
-	// still keys the deterministic event id, so retried blocks dedupe.
-	e.ID = webhookpub.DeterministicEventID(messageID, webhookpub.EventEmailBlocked)
+	// ON DELETE SET NULL, and the fan-out copies the column into
+	// webhook_subscriber_deliveries.message_id, which carries the same FK).
+	// The soft-ref still travels in data.message_id and still keys the
+	// deterministic event id, so retried blocks dedupe.
+	e.ID = webhookpub.DeterministicEventID(softRef, webhookpub.EventEmailBlocked)
 	return e
 }
 
-func (a *API) emitBlockedOutbound(agent *identity.AgentIdentity, messageID string, req outbound.SendRequest, v outboundVerdict) {
-	e := a.buildBlockedOutboundEvent(agent, messageID, req, v)
+func (a *API) emitBlockedOutbound(agent *identity.AgentIdentity, softRef string, req outbound.SendRequest, v outboundVerdict) {
+	e := a.buildBlockedOutboundEvent(agent, softRef, req, v)
 	// Durable emit via the (unconditional) outbox. An outbound block is rowless,
 	// so the event is written in its own transaction; the deterministic id dedupes
 	// a retried block through ON CONFLICT (id) DO NOTHING. Every event now flows

--- a/internal/agent/screening.go
+++ b/internal/agent/screening.go
@@ -315,7 +315,12 @@ func (a *API) buildBlockedOutboundEvent(agent *identity.AgentIdentity, messageID
 	})
 	e.AgentID = agent.ID
 	e.ConversationID = req.ConversationID
-	e.MessageID = messageID
+	// e.MessageID stays UNSET: the webhook_events.message_id column has an FK to
+	// messages(id), and a blocked send persists no message row — writing the
+	// msgblk_ soft-ref there fails the FK and rolls back the whole event (the
+	// column is for real rows only; consumers already see NULL there after
+	// ON DELETE SET NULL). The soft-ref still travels in data.message_id and
+	// still keys the deterministic event id, so retried blocks dedupe.
 	e.ID = webhookpub.DeterministicEventID(messageID, webhookpub.EventEmailBlocked)
 	return e
 }
@@ -331,6 +336,7 @@ func (a *API) emitBlockedOutbound(agent *identity.AgentIdentity, messageID strin
 			return a.outbox.PublishTx(context.Background(), tx, e)
 		}); err != nil {
 			log.Printf("[api] outbox tx for email.blocked err: %v", err)
+			a.emit().OutboxFailures("publish")
 		}
 	}
 }

--- a/internal/agent/screening_integration_test.go
+++ b/internal/agent/screening_integration_test.go
@@ -2,6 +2,7 @@ package agent_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/jackc/pgx/v5"
@@ -53,7 +54,7 @@ func TestEmitBlockedOutbound_Integration_SurvivesMessageIDFK(t *testing.T) {
 		   FROM webhook_events WHERE id = $1 AND type = $2`,
 		e.ID, webhookpub.EventEmailBlocked,
 	).Scan(&colMessageID, &dataMessageID)
-	if err == pgx.ErrNoRows {
+	if errors.Is(err, pgx.ErrNoRows) {
 		t.Fatalf("email.blocked event %s not in webhook_events — dropped", e.ID)
 	}
 	if err != nil {

--- a/internal/agent/screening_integration_test.go
+++ b/internal/agent/screening_integration_test.go
@@ -1,0 +1,68 @@
+package agent_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/tokencanopy/e2a/internal/agent"
+	"github.com/tokencanopy/e2a/internal/identity"
+	"github.com/tokencanopy/e2a/internal/outbound"
+	"github.com/tokencanopy/e2a/internal/testutil"
+	"github.com/tokencanopy/e2a/internal/webhookpub"
+)
+
+// TestEmitBlockedOutbound_Integration_SurvivesMessageIDFK drives the exact
+// event emitBlockedOutbound builds through the real outbox into the
+// production schema. A blocked send is rowless — its msgblk_ soft-ref must
+// never be written to the webhook_events.message_id column, whose FK to
+// messages(id) would reject it and roll back (= drop) the event. That drop
+// shipped silently because the unit tests never crossed the FK; this test
+// exists so it can't come back.
+func TestEmitBlockedOutbound_Integration_SurvivesMessageIDFK(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+
+	ids := identity.NewStore(pool)
+	user, err := ids.CreateOrGetUser(ctx, "blocked-fk@example.com", "Blocked FK", "blocked-fk-subject")
+	if err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+
+	ag := &identity.AgentIdentity{ID: "blocked-bot@x.example.com", Domain: "x.example.com", UserID: user.ID}
+	req := outbound.SendRequest{To: []string{"alice@evil.com"}, Subject: "blocked by gate", Body: "refused"}
+	e, softRef := agent.BuildBlockedOutboundEventForTest(ag, req, "recipient_gate", "recipient not in allowlist")
+
+	outbox := webhookpub.NewOutbox(pool, webhookpub.StaticFlag(true))
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck // no-op after commit
+	if err := outbox.PublishTx(ctx, tx, e); err != nil {
+		t.Fatalf("PublishTx: %v (a 23503 here means the msgblk_ soft-ref hit the messages FK again)", err)
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	var colMessageID *string
+	var dataMessageID string
+	err = pool.QueryRow(ctx,
+		`SELECT message_id, envelope->'data'->>'message_id'
+		   FROM webhook_events WHERE id = $1 AND type = $2`,
+		e.ID, webhookpub.EventEmailBlocked,
+	).Scan(&colMessageID, &dataMessageID)
+	if err == pgx.ErrNoRows {
+		t.Fatalf("email.blocked event %s not in webhook_events — dropped", e.ID)
+	}
+	if err != nil {
+		t.Fatalf("query webhook_events: %v", err)
+	}
+	if colMessageID != nil {
+		t.Errorf("message_id column = %q, want NULL (rowless block must not reference messages)", *colMessageID)
+	}
+	if dataMessageID != softRef {
+		t.Errorf("envelope data.message_id = %q, want soft-ref %q", dataMessageID, softRef)
+	}
+}

--- a/internal/agent/webhooks_events_test.go
+++ b/internal/agent/webhooks_events_test.go
@@ -301,8 +301,15 @@ func TestEmitBlockedOutbound(t *testing.T) {
 	if ev.Type != webhookpub.EventEmailBlocked {
 		t.Errorf("Type = %q, want email.blocked", ev.Type)
 	}
-	if ev.UserID != "u_1" || ev.AgentID != agent.ID || ev.MessageID != softRef {
-		t.Errorf("routing keys = (user=%q agent=%q msg=%q)", ev.UserID, ev.AgentID, ev.MessageID)
+	// MessageID must stay UNSET: webhook_events.message_id has an FK to
+	// messages(id) and a blocked send is rowless — the msgblk_ soft-ref there
+	// fails the FK and the event is dropped (the exact bug the staging
+	// conformance gate caught). The soft-ref travels in data.message_id only.
+	if ev.UserID != "u_1" || ev.AgentID != agent.ID || ev.MessageID != "" {
+		t.Errorf("routing keys = (user=%q agent=%q msg=%q), want msg unset", ev.UserID, ev.AgentID, ev.MessageID)
+	}
+	if got := ev.Data.(map[string]interface{})["message_id"]; got != softRef {
+		t.Errorf("data.message_id = %v, want soft-ref %q", got, softRef)
 	}
 	// Deterministic id keeps a retried block idempotent.
 	if want := webhookpub.DeterministicEventID(softRef, webhookpub.EventEmailBlocked); ev.ID != want {

--- a/internal/agent/webhooks_events_test.go
+++ b/internal/agent/webhooks_events_test.go
@@ -308,9 +308,6 @@ func TestEmitBlockedOutbound(t *testing.T) {
 	if ev.UserID != "u_1" || ev.AgentID != agent.ID || ev.MessageID != "" {
 		t.Errorf("routing keys = (user=%q agent=%q msg=%q), want msg unset", ev.UserID, ev.AgentID, ev.MessageID)
 	}
-	if got := ev.Data.(map[string]interface{})["message_id"]; got != softRef {
-		t.Errorf("data.message_id = %v, want soft-ref %q", got, softRef)
-	}
 	// Deterministic id keeps a retried block idempotent.
 	if want := webhookpub.DeterministicEventID(softRef, webhookpub.EventEmailBlocked); ev.ID != want {
 		t.Errorf("ID = %q, want deterministic %q", ev.ID, want)
@@ -318,6 +315,9 @@ func TestEmitBlockedOutbound(t *testing.T) {
 	data, ok := ev.Data.(map[string]interface{})
 	if !ok {
 		t.Fatalf("Data is not a map: %T", ev.Data)
+	}
+	if data["message_id"] != softRef {
+		t.Errorf("data.message_id = %v, want soft-ref %q", data["message_id"], softRef)
 	}
 	if data["direction"] != "outbound" {
 		t.Errorf("direction = %v, want outbound", data["direction"])

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -38,8 +38,11 @@ type Metrics interface {
 	// webhook fire?"
 	OutboxEventsNoMatch(eventType string)
 
-	// OutboxFailures is incremented on any worker-side failure.
-	// stage in {"lease", "list_webhooks", "insert_delivery", "update_status"}.
+	// OutboxFailures is incremented on any outbox failure — worker-side
+	// (stage in {"lease", "list_webhooks", "insert_delivery", "update_status"})
+	// or emit-side when a producer's PublishTx fails and an event is
+	// DROPPED (stage "publish"). A non-zero "publish" rate means contract
+	// events are silently missing from the log — alert on it.
 	OutboxFailures(stage string)
 
 	// RedeliverRequests is incremented on each customer-driven replay.

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -40,9 +40,11 @@ type Metrics interface {
 
 	// OutboxFailures is incremented on any outbox failure — worker-side
 	// (stage in {"lease", "list_webhooks", "insert_delivery", "update_status"})
-	// or emit-side when a producer's PublishTx fails and an event is
-	// DROPPED (stage "publish"). A non-zero "publish" rate means contract
-	// events are silently missing from the log — alert on it.
+	// or emit-side when a fire-and-forget producer's PublishTx fails and the
+	// event is DROPPED (stage "publish" — today only the outbound
+	// email.blocked producer; other producers either surface the error to
+	// the caller or log via PublishBestEffortTx). A non-zero "publish" rate
+	// means contract events are silently missing from the log.
 	OutboxFailures(stage string)
 
 	// RedeliverRequests is incremented on each customer-driven replay.


### PR DESCRIPTION
## Summary

Every outbound `email.blocked` event has been silently dropped in production: a gate-blocked send is rowless by design (403 `blocked_by_policy`, no `messages` row), but `buildBlockedOutboundEvent` wrote its `msgblk_` soft-ref into `e.MessageID`, so the outbox INSERT violated `webhook_events.message_id`'s FK to `messages(id)` (SQLSTATE 23503) and the event transaction rolled back — leaving only a log line. Caught by the staging conformance gate the first time #548's emission test ran (`emit: email.blocked` timing out on `listEvents`).

Fix: leave `e.MessageID` unset for rowless blocks. The column is reserved for real message rows (consumers already handle NULL there via `ON DELETE SET NULL`); the soft-ref still travels in `data.message_id` and still keys the deterministic event id, so retried blocks keep deduping via `ON CONFLICT (id) DO NOTHING`.

Hardening shipped with it:
- **Integration test on the production schema** (`internal/agent/screening_integration_test.go`, via #569's fixed testutil migration runner): drives the exact built event through the real outbox — reproduces the 23503 without the fix, passes with it.
- **Emit-side drops are now countable:** `emitBlockedOutbound`'s failure path emits `OutboxFailures("publish")` in addition to the log line, so a silently-missing contract event is alertable.
- The unit test that had enshrined `MessageID == softRef` (`TestEmitBlockedOutbound`) now pins the opposite invariant, with the FK rationale in a comment.

## Client surface checklist

No API/wire change — the event envelope (`data.message_id` = `msgblk_…`) is unchanged; only the previously-failing DB write is fixed. The events read API's top-level `message_id` is now consistently `null` for outbound blocks, matching the already-documented nullable shape.

## Operational risk

None beyond the fix itself: no migration, no config. Rollback = revert. After deploy, gate-blocked sends start emitting `email.blocked` events that were previously absent — subscribers filtering on that type will begin receiving them (that's the contract working as documented).

## Test plan

- [x] `go test ./internal/agent/ ./internal/telemetry/ ./internal/webhookpub/` green locally (DB-backed, production migrations)
- [x] New integration test fails with the exact staging 23503 when the fix is reverted
- [ ] Staging release pipeline: conformance gate's `emit: email.blocked` passes on the next candidate containing this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)