### PR TITLE
fix(examples): update agent framework integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,8 +277,8 @@ if event.type == "email.received":
     # event.data is metadata only — replying needs just the recipient + message_id
     # fetch the full body with client.webhooks.fetch_message(event) if needed
     meta = event.data
-    await client.messages.reply(meta["recipient"], meta["message_id"],
-                                {"body": "Got it!", "conversation_id": "conv_123"})
+    await client.messages.reply(meta["delivered_to"], meta["message_id"],
+                                {"text": "Got it!", "conversation_id": "conv_123"})
 ```
 
 WebSocket (no public URL needed):
@@ -287,10 +287,13 @@ WebSocket (no public URL needed):
 from e2a.v1 import AsyncE2AClient
 
 async with AsyncE2AClient(api_key="e2a_…") as client:
-    async for notif in client.listen("bot@your-domain.com"):
-        # notif is lightweight metadata — fetch the body when you want it
-        email = await client.messages.get(notif.recipient, notif.message_id)
-        await client.messages.reply(notif.recipient, notif.message_id, {"body": "Got it!"})
+    async for event in client.listen("bot@your-domain.com"):
+        if event.type != "email.received":
+            continue  # tolerate future event kinds
+        # The event is lightweight metadata — fetch the body when you want it.
+        meta = event.data
+        email = await client.webhooks.fetch_message(event)
+        await client.messages.reply(meta["delivered_to"], meta["message_id"], {"text": "Got it!"})
 ```
 
 See [sdks/python/README.md](sdks/python/README.md).

--- a/docs/events.md
+++ b/docs/events.md
@@ -36,8 +36,8 @@ const events = await client.events
     type: "email.received",
     since: new Date(Date.now() - 24 * 3600 * 1000).toISOString(),
   })
-  .toArray(); // auto-pages via next_cursor
-for (const e of events) console.log(e.id, e.type, e.created_at);
+  .toArray({ limit: 100 }); // auto-pages via next_cursor, bounded in memory
+for (const e of events) console.log(e.id, e.type, e.createdAt);
 ```
 
 In Python:
@@ -46,9 +46,9 @@ In Python:
 from e2a.v1 import AsyncE2AClient
 import os
 
-client = AsyncE2AClient(api_key=os.environ["E2A_API_KEY"])
-for e in client.events.list(type="email.received", limit=20):
-    print(e.id, e.type, e.created_at)
+async with AsyncE2AClient(api_key=os.environ["E2A_API_KEY"]) as client:
+    async for e in client.events.list(type="email.received", limit=20):
+        print(e.id, e.type, e.created_at)
 ```
 
 ## Event types
@@ -166,9 +166,10 @@ If your webhook receiver went down for an hour, the steps to reconcile are:
 ```python
 # Pseudocode for the reconciliation flow.
 processed = set(load_processed_event_ids_from_my_db())
-for e in client.events.list(since=outage_start, until=outage_end):
-    if e.id not in processed:
-        client.events.redeliver(e.id, webhook_id="wh_my_handler")
+async with AsyncE2AClient(api_key=os.environ["E2A_API_KEY"]) as client:
+    async for e in client.events.list(since=outage_start, until=outage_end):
+        if e.id not in processed:
+            await client.events.redeliver(e.id, {"webhook_id": "wh_my_handler"})
 ```
 
 ## Replay

--- a/examples/adk-cloud-webhook/.env.example
+++ b/examples/adk-cloud-webhook/.env.example
@@ -1,5 +1,10 @@
-# From e2a.dev — settings → API keys
+# Agent-scoped key bound to the inbox this app fetches from and replies as.
+# Webhook creation is account-scoped; use a separate account key for that
+# one-time setup call rather than giving this runtime admin credentials.
 E2A_API_KEY=e2a_...
+
+# Optional for self-hosted/local deployments; omit to use https://api.e2a.dev.
+# E2A_API_URL=http://localhost:8080
 
 # From e2a.dev — Settings → Webhook signing secrets → "Create".
 # Copy it the moment it's shown; it isn't retrievable later. Passed to

--- a/examples/adk-cloud-webhook/README.md
+++ b/examples/adk-cloud-webhook/README.md
@@ -17,7 +17,8 @@ this app
     +-- construct_event (verify HMAC + decode to a typed event)
     +-- look up / create ADK session keyed by conversation_id
     +-- runner.run_async(...)
-    +-- client.messages.reply(address, message_id, {text, conversation_id})
+    +-- client.messages.reply(address, message_id, {text, conversation_id},
+    |                         idempotency_key=event.id)
     |
     v
 e2a relay -> SMTP -> human
@@ -27,16 +28,17 @@ e2a relay -> SMTP -> human
 
 - Python 3.10+
 - An e2a account with a registered agent. Sign up at
-  [e2a.dev](https://e2a.dev) and create an agent. You'll need its
-  **API key** and a public webhook URL (see "Exposing the webhook"
-  below). The webhook's **HMAC signing secret** is returned once when you
-  create the subscription (`POST /v1/webhooks` — copy it the moment it's
-  shown, it's not retrievable later; rotate via
-  `POST /v1/webhooks/{id}/rotate-secret`).
+  [e2a.dev](https://e2a.dev) and create an agent. The running app should use an
+  **agent-scoped API key** bound to that inbox for fetch + reply. Creating the
+  webhook subscription is an account-admin operation and requires a separate
+  **account-scoped API key**. The webhook's **HMAC signing secret** is returned
+  once by `POST /v1/webhooks` — copy it immediately; rotate it later with
+  `POST /v1/webhooks/{id}/rotate-secret`.
 - A Google AI Studio API key for Gemini —
   [aistudio.google.com/apikey](https://aistudio.google.com/apikey).
 
-> **ADK line:** this example pins ADK 1.x (`google-adk>=1.31,<2`); the MCP
+> **Version lines:** this example pins ADK 1.x (`google-adk>=1.31,<2`) and
+> targets the current e2a 5.x SDK contract. The MCP
 > quick-start example under [`mcp/examples/adk`](../../mcp/examples/adk/)
 > targets ADK 2.x. They intentionally track different ADK releases.
 
@@ -75,12 +77,13 @@ ngrok http 18080
 ```
 
 Subscribe that public URL to your agent's inbound mail. Webhooks are a separate
-resource (`/v1/webhooks`) — pass the agent's address as a filter (replace
-`<YOUR_AGENT_EMAIL>` and `<YOUR_API_KEY>`):
+resource (`/v1/webhooks`) — pass the agent's address as a filter. This setup
+call requires an account-scoped key; the app itself can keep using its narrower
+agent-scoped key. Replace `<YOUR_AGENT_EMAIL>` and `<YOUR_ACCOUNT_API_KEY>`:
 
 ```bash
 curl -X POST https://api.e2a.dev/v1/webhooks \
-  -H "Authorization: Bearer <YOUR_API_KEY>" \
+  -H "Authorization: Bearer <YOUR_ACCOUNT_API_KEY>" \
   -H "Content-Type: application/json" \
   -d '{
     "url": "https://abc123.ngrok.io/webhook",
@@ -103,11 +106,12 @@ Email is stateless at the SMTP layer. e2a re-creates threading by
 propagating an opaque `conversation_id` through each round-trip:
 
 1. **First inbound** has `conversation_id = None` (the human just
-   started a thread). The webhook mints `conv_<random>` and uses it as
-   the ADK `session_id` when creating the session.
+   started a thread). The webhook derives a stable `conv_<event-id-prefix>`
+   anchor and uses it as the ADK `session_id`. A retry derives the same value,
+   so it also reuses an identical reply request body and idempotency key.
 2. The webhook calls `client.messages.reply(address, message_id,
-   {"text": text, "conversation_id": "conv_<random>"})`. e2a stamps
-   `X-E2A-Conversation-Id: conv_<random>` on the outbound message and
+   {"text": text, "conversation_id": "conv_<event-id-prefix>"})`. e2a stamps
+   that value into `X-E2A-Conversation-Id` on the outbound message and
    remembers the binding to the message ID.
 3. **Subsequent inbound** (the human replies in their mail client) lands
    with the same `conversation_id` set — recovered from `In-Reply-To` /
@@ -118,6 +122,12 @@ propagating an opaque `conversation_id` through each round-trip:
 This is the entire trick. The webhook is ~30 lines of business logic;
 ADK does the actual memory work, e2a does the actual email work.
 
+e2a delivers webhooks at least once. The example claims each event ID before
+running ADK and reuses that ID as the reply's `Idempotency-Key`, so a timed-out
+delivery cannot send the same reply twice in the single-process demo. A
+duplicate that is still running receives a retryable 503; a completed duplicate
+is acknowledged without another agent turn.
+
 See [webhook.py](webhook.py) for the implementation, including
 [HMAC signature verification](https://github.com/tokencanopy/e2a/blob/main/sdks/python/README.md#quick-start)
 which you should *always* do on a public webhook before trusting any
@@ -125,19 +135,21 @@ field on the parsed payload.
 
 ## What this example deliberately doesn't show
 
-- **Persistence + multi-worker safety.** `InMemorySessionService` loses
-  everything on restart. It also lives in *one* Python process — running
-  `uvicorn ... --workers 4` shards sessions per-worker, so the same
-  conversation can land on different workers and lose memory at random.
-  For anything beyond the demo, use `DatabaseSessionService` (Postgres /
-  SQLite) — see [ADK sessions docs](https://adk.dev/sessions/session/).
+- **Durable sessions + event deduplication.** `InMemorySessionService` and the
+  example's `EventDeduper` both lose state on restart and live in one process.
+  Running `uvicorn ... --workers 4` shards both, so a conversation or duplicate
+  delivery can land on different workers. For production, use
+  `DatabaseSessionService` (Postgres / SQLite) and replace `EventDeduper` with a
+  durable unique claim keyed by `event.id`; keep the event-derived reply
+  idempotency key. See [ADK sessions docs](https://adk.dev/sessions/session/).
 - **Tools.** The agent has no tools beyond text generation. Add them to
   `agent.py` once the email loop works end-to-end.
-- **Attachments.** Attachment metadata lives on the `MessageView` you
-  fetch with `client.messages.get(address, message_id)` (the typed event
-  from `construct_event` carries the message payload); this example
-  ignores it. ADK's `Content` supports inline data parts if you want to
-  feed attachments to a vision model.
+- **Attachments.** The verified event carries attachment metadata only. The
+  `MessageView` fetched with `client.webhooks.fetch_message(event)` carries the
+  parsed body and attachment metadata; fetch attachment bytes separately with
+  `client.messages.get_attachment(...)`. This example ignores them. ADK's
+  `Content` supports inline data parts if you want to feed attachments to a
+  vision model.
 - **HITL.** The agent replies immediately. If you want human approval
   before the reply goes out, enable review holds on the agent's
   protection config (`PUT /v1/agents/{address}/protection`,

--- a/examples/adk-cloud-webhook/delivery_state.py
+++ b/examples/adk-cloud-webhook/delivery_state.py
@@ -1,0 +1,58 @@
+"""In-process webhook event state for the single-worker tutorial app.
+
+Production deployments should replace this with a durable store keyed by the
+e2a event id. The small abstraction keeps the example's duplicate handling
+explicit without coupling it to a particular database.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from typing import Literal
+
+ClaimResult = Literal["new", "processing", "processed"]
+
+
+def conversation_id_for(event_id: str, existing: str | None) -> str:
+    """Return the upstream thread id or a retry-stable first-contact anchor."""
+    if existing:
+        return existing
+    suffix = event_id.removeprefix("evt_")[:12]
+    return f"conv_{suffix}"
+
+
+class EventDeduper:
+    """Track event claims so at-least-once webhook delivery is side-effect safe."""
+
+    def __init__(self, *, max_processed: int = 10_000) -> None:
+        if max_processed <= 0:
+            raise ValueError("max_processed must be positive")
+        self._lock = asyncio.Lock()
+        self._max_processed = max_processed
+        self._processing: set[str] = set()
+        self._processed: set[str] = set()
+        self._processed_order: deque[str] = deque()
+
+    async def claim(self, event_id: str) -> ClaimResult:
+        async with self._lock:
+            if event_id in self._processed:
+                return "processed"
+            if event_id in self._processing:
+                return "processing"
+            self._processing.add(event_id)
+            return "new"
+
+    async def complete(self, event_id: str) -> None:
+        async with self._lock:
+            self._processing.discard(event_id)
+            if event_id not in self._processed:
+                self._processed.add(event_id)
+                self._processed_order.append(event_id)
+            while len(self._processed_order) > self._max_processed:
+                expired = self._processed_order.popleft()
+                self._processed.discard(expired)
+
+    async def release(self, event_id: str) -> None:
+        async with self._lock:
+            self._processing.discard(event_id)

--- a/examples/adk-cloud-webhook/pyproject.toml
+++ b/examples/adk-cloud-webhook/pyproject.toml
@@ -10,8 +10,8 @@ readme = "README.md"
 requires-python = ">=3.10"
 
 dependencies = [
-  # google-adk 2.0 is in pre-release as of writing and may reorganize imports.
-  # Pin to the 1.x line until 2.0 ships and the code is verified against it.
+  # Keep this webhook tutorial on the verified ADK 1.x API. The separate MCP
+  # quick start under mcp/examples/adk targets the current ADK 2.x line.
   "google-adk>=1.31,<2",
   "e2a>=5,<6",
   "fastapi>=0.115",
@@ -20,5 +20,5 @@ dependencies = [
 ]
 
 [tool.hatch.build.targets.wheel]
-packages = ["agent", "webhook"]
-only-include = ["agent.py", "webhook.py"]
+packages = ["agent", "webhook", "delivery_state"]
+only-include = ["agent.py", "webhook.py", "delivery_state.py"]

--- a/examples/adk-cloud-webhook/test_delivery_state.py
+++ b/examples/adk-cloud-webhook/test_delivery_state.py
@@ -1,0 +1,87 @@
+import ast
+from pathlib import Path
+import unittest
+
+from delivery_state import EventDeduper, conversation_id_for
+
+
+class ConversationIDTest(unittest.TestCase):
+    def test_preserves_an_existing_conversation_id(self) -> None:
+        self.assertEqual(conversation_id_for("evt_1", "conv_existing"), "conv_existing")
+
+    def test_first_contact_id_is_deterministic_for_retries(self) -> None:
+        first = conversation_id_for("evt_0123456789abcdef", None)
+        second = conversation_id_for("evt_0123456789abcdef", None)
+
+        self.assertEqual(first, second)
+        self.assertEqual(first, "conv_0123456789ab")
+
+
+class EventDeduperTest(unittest.IsolatedAsyncioTestCase):
+    async def test_claim_distinguishes_new_processing_and_completed_events(self) -> None:
+        deduper = EventDeduper()
+
+        self.assertEqual(await deduper.claim("evt_1"), "new")
+        self.assertEqual(await deduper.claim("evt_1"), "processing")
+
+        await deduper.complete("evt_1")
+        self.assertEqual(await deduper.claim("evt_1"), "processed")
+
+    async def test_release_allows_a_failed_event_to_retry(self) -> None:
+        deduper = EventDeduper()
+
+        self.assertEqual(await deduper.claim("evt_2"), "new")
+        await deduper.release("evt_2")
+
+        self.assertEqual(await deduper.claim("evt_2"), "new")
+
+    async def test_completed_event_cache_is_bounded(self) -> None:
+        deduper = EventDeduper(max_processed=1)
+
+        self.assertEqual(await deduper.claim("evt_old"), "new")
+        await deduper.complete("evt_old")
+        self.assertEqual(await deduper.claim("evt_new"), "new")
+        await deduper.complete("evt_new")
+
+        self.assertEqual(await deduper.claim("evt_old"), "new")
+
+
+class WebhookExampleContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        source = Path(__file__).with_name("webhook.py").read_text()
+        cls.tree = ast.parse(source)
+
+    def test_reply_uses_event_id_as_idempotency_key(self) -> None:
+        reply_calls = [
+            node
+            for node in ast.walk(self.tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "reply"
+        ]
+        self.assertEqual(len(reply_calls), 1)
+        keyword = next(
+            (item for item in reply_calls[0].keywords if item.arg == "idempotency_key"),
+            None,
+        )
+        self.assertIsNotNone(keyword)
+        self.assertEqual(ast.unparse(keyword.value), "event.id")
+
+    def test_lifespan_closes_the_async_client(self) -> None:
+        awaited_calls = [
+            node.value
+            for node in ast.walk(self.tree)
+            if isinstance(node, ast.Await) and isinstance(node.value, ast.Call)
+        ]
+        self.assertTrue(
+            any(
+                isinstance(call.func, ast.Attribute)
+                and call.func.attr == "aclose"
+                for call in awaited_calls
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/adk-cloud-webhook/test_live_integration.py
+++ b/examples/adk-cloud-webhook/test_live_integration.py
@@ -1,0 +1,141 @@
+"""Opt-in live dry run for the ADK webhook example.
+
+Run this against the repository's contract server. The test uses the real
+Python SDK and HTTP handlers for agent creation, self-send loopback, message
+fetch, and reply. Only the Gemini turn is replaced with a deterministic local
+runner so the dry run is repeatable and never consumes model quota.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import hmac
+import importlib
+import json
+import os
+import time
+from types import SimpleNamespace
+import unittest
+from urllib.parse import quote
+
+
+class _DeterministicRunner:
+    def __init__(self, reply_text: str) -> None:
+        self.calls = 0
+        self.reply_text = reply_text
+
+    async def run_async(self, **_kwargs):
+        self.calls += 1
+        yield SimpleNamespace(
+            is_final_response=lambda: True,
+            content=SimpleNamespace(
+                parts=[SimpleNamespace(text=self.reply_text)],
+            ),
+        )
+
+
+@unittest.skipUnless(
+    os.environ.get("E2A_DRY_RUN") == "1",
+    "set E2A_DRY_RUN=1 with a live contract server to run",
+)
+class LiveWebhookIntegrationTest(unittest.TestCase):
+    def test_signed_inbound_fetches_and_replies_once(self) -> None:
+        from fastapi.testclient import TestClient
+        import httpx
+
+        base_url = os.environ["E2A_API_URL"]
+        api_key = os.environ["E2A_API_KEY"]
+        signing_secret = os.environ["E2A_WEBHOOK_SECRET"]
+        bot = f"adk-dry-run-{time.time_ns():x}@agents.e2a.dev"
+        subject = f"ADK webhook dry run {time.time_ns()}"
+        encoded_bot = quote(bot, safe="")
+        auth = {"Authorization": f"Bearer {api_key}"}
+
+        async def arrange() -> str:
+            # Provisioning is deliberately raw HTTP: the application under test
+            # uses an agent-scoped SDK client and never creates/deletes agents.
+            async with httpx.AsyncClient(base_url=base_url, headers=auth) as client:
+                created = await client.post(
+                    "/v1/agents", json={"email": bot, "name": "ADK webhook dry run"}
+                )
+                self.assertEqual(created.status_code, 201, created.text)
+                sent = await client.post(
+                    f"/v1/agents/{encoded_bot}/messages",
+                    json={"to": [bot], "subject": subject, "text": "Please confirm receipt."},
+                    headers={"Idempotency-Key": f"dry-run-send-{time.time_ns()}"},
+                )
+                self.assertEqual(sent.status_code, 200, sent.text)
+                self.assertIn(sent.json()["status"], {"sent", "accepted"})
+
+                for _ in range(20):
+                    listed = await client.get(
+                        f"/v1/agents/{encoded_bot}/messages",
+                        params={"direction": "inbound", "limit": 20},
+                    )
+                    self.assertEqual(listed.status_code, 200, listed.text)
+                    match = next(
+                        (item for item in listed.json()["items"] if item["subject"] == subject),
+                        None,
+                    )
+                    if match is not None:
+                        return match["id"]
+                    await asyncio.sleep(0.25)
+                self.fail("self-send did not produce an inbound message")
+
+        async def cleanup() -> None:
+            async with httpx.AsyncClient(base_url=base_url, headers=auth) as client:
+                deleted = await client.delete(
+                    f"/v1/agents/{encoded_bot}", params={"confirm": "DELETE"}
+                )
+                self.assertEqual(deleted.status_code, 200, deleted.text)
+
+        message_id = asyncio.run(arrange())
+        try:
+            event_id = f"evt_dryrun_{time.time_ns():x}"
+            payload = {
+                "type": "email.received",
+                "id": event_id,
+                "schema_version": "1",
+                "created_at": "2026-07-19T00:00:00Z",
+                "data": {
+                    "message_id": message_id,
+                    "agent_email": bot,
+                    "direction": "inbound",
+                    "from": bot,
+                    "authenticated_from": bot,
+                    "to": [bot],
+                    "delivered_to": bot,
+                    "subject": subject,
+                    "auth_headers": {},
+                    "received_at": "2026-07-19T00:00:00Z",
+                },
+            }
+            raw_body = json.dumps(payload, separators=(",", ":")).encode()
+            timestamp = str(int(time.time()))
+            signature = hmac.new(
+                signing_secret.encode(),
+                timestamp.encode() + b"." + raw_body,
+                hashlib.sha256,
+            ).hexdigest()
+
+            webhook_app = importlib.import_module("webhook")
+            runner = _DeterministicRunner("Confirmed by the ADK webhook dry run.")
+            with TestClient(webhook_app.app) as http:
+                webhook_app.app.state.runner = runner
+                headers = {"X-E2A-Signature": f"t={timestamp},v1={signature}"}
+
+                response = http.post("/webhook", content=raw_body, headers=headers)
+                self.assertEqual(response.status_code, 200, response.text)
+                self.assertEqual(response.json()["status"], "replied")
+
+                duplicate = http.post("/webhook", content=raw_body, headers=headers)
+                self.assertEqual(duplicate.status_code, 200, duplicate.text)
+                self.assertEqual(duplicate.json()["status"], "duplicate")
+                self.assertEqual(runner.calls, 1)
+        finally:
+            asyncio.run(cleanup())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/examples/adk-cloud-webhook/webhook.py
+++ b/examples/adk-cloud-webhook/webhook.py
@@ -32,7 +32,6 @@ from __future__ import annotations
 
 import logging
 import os
-import uuid
 from contextlib import asynccontextmanager
 from typing import AsyncIterator
 
@@ -45,10 +44,12 @@ from google.genai import types
 from e2a.v1 import AsyncE2AClient, construct_event, E2AWebhookSignatureError
 
 from agent import APP_NAME, agent
+from delivery_state import EventDeduper, conversation_id_for
 
 load_dotenv()
 log = logging.getLogger("adk-webhook")
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(name)s %(levelname)s %(message)s")
+event_deduper = EventDeduper()
 
 
 def _require_env(name: str) -> str:
@@ -72,12 +73,19 @@ _require_env("GOOGLE_API_KEY")
 @asynccontextmanager
 async def lifespan(_: FastAPI) -> AsyncIterator[None]:
     # Lazy-init shared resources once per process.
-    app.state.e2a = AsyncE2AClient()
+    client = AsyncE2AClient(
+        api_key=os.environ["E2A_API_KEY"],
+        base_url=os.getenv("E2A_API_URL") or None,
+    )
+    app.state.e2a = client
     app.state.sessions = InMemorySessionService()
     app.state.runner = Runner(
         agent=agent, app_name=APP_NAME, session_service=app.state.sessions
     )
-    yield
+    try:
+        yield
+    finally:
+        await client.aclose()
 
 
 app = FastAPI(title="ADK + e2a webhook", lifespan=lifespan)
@@ -105,64 +113,90 @@ async def webhook(request: Request) -> dict[str, str]:
     if event.type != "email.received":
         return {"status": "ignored", "type": event.type}
 
-    client: AsyncE2AClient = request.app.state.e2a
-    data = event.data  # WebhookPayload: message_id, delivered_to, from, conversation_id, …
-    delivered_to = data["delivered_to"]
-    message_id = data["message_id"]
+    # Webhooks are delivered at least once. Claim the stable envelope id before
+    # running the model so a timed-out POST cannot create a second agent turn.
+    # A duplicate still in flight returns non-2xx so e2a retries it later; a
+    # completed duplicate is acknowledged without repeating side effects.
+    claim = await event_deduper.claim(event.id)
+    if claim == "processed":
+        return {"status": "duplicate", "event_id": event.id}
+    if claim == "processing":
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="event is already being processed; retry later",
+        )
 
-    # The inbound webhook payload is metadata; fetch the parsed message for the
-    # subject + body to feed the agent.
-    inbound = await client.messages.get(delivered_to, message_id)
+    try:
+        client: AsyncE2AClient = request.app.state.e2a
+        data = event.data  # WebhookPayload: message_id, delivered_to, from, conversation_id, …
+        delivered_to = data["delivered_to"]
+        message_id = data["message_id"]
 
-    # First contact has no conversation_id — mint one so this thread has an
-    # ID we can echo back on every reply. The same id becomes the ADK
-    # session_id, keying multi-turn memory.
-    conversation_id = data.get("conversation_id") or f"conv_{uuid.uuid4().hex[:12]}"
+        # The inbound webhook payload is metadata; fetch the parsed message for
+        # the subject + body to feed the agent.
+        inbound = await client.webhooks.fetch_message(event)
 
-    # user_id scopes a session to a particular human counterpart. Different
-    # senders get isolated session histories even on the same agent.
-    user_id = data["from"]
+        # First contact has no conversation_id — mint one so this thread has an
+        # ID we can echo back on every reply. The same id becomes the ADK
+        # session_id, keying multi-turn memory.
+        conversation_id = conversation_id_for(event.id, data.get("conversation_id"))
 
-    sessions = request.app.state.sessions
-    session = await sessions.get_session(
-        app_name=APP_NAME, user_id=user_id, session_id=conversation_id
-    )
-    if session is None:
-        session = await sessions.create_session(
+        # user_id scopes a session to a particular human counterpart. Different
+        # senders get isolated session histories even on the same agent.
+        user_id = data["from"]
+
+        sessions = request.app.state.sessions
+        session = await sessions.get_session(
             app_name=APP_NAME, user_id=user_id, session_id=conversation_id
         )
+        if session is None:
+            session = await sessions.create_session(
+                app_name=APP_NAME, user_id=user_id, session_id=conversation_id
+            )
 
-    prompt = types.Content(
-        role="user",
-        parts=[types.Part(text=_format_email_for_agent(inbound))],
-    )
-
-    runner: Runner = request.app.state.runner
-    reply_text = ""
-    async for event in runner.run_async(
-        user_id=user_id, session_id=conversation_id, new_message=prompt
-    ):
-        if event.is_final_response() and event.content and event.content.parts:
-            reply_text = event.content.parts[0].text or ""
-
-    if not reply_text:
-        # Agent produced no response (rare — usually means a tool call without
-        # a final text turn). Don't reply with an empty email; log so the
-        # operator can investigate why the run finished without text.
-        log.warning(
-            "agent produced no reply text user=%s conv=%s msg=%s",
-            user_id, conversation_id, message_id,
+        prompt = types.Content(
+            role="user",
+            parts=[types.Part(text=_format_email_for_agent(inbound))],
         )
-        return {"status": "no_reply", "conversation_id": conversation_id}
 
-    log.info(
-        "replying user=%s conv=%s msg=%s reply_chars=%d",
-        user_id, conversation_id, message_id, len(reply_text),
-    )
-    await client.messages.reply(
-        delivered_to, message_id, {"text": reply_text, "conversation_id": conversation_id}
-    )
-    return {"status": "replied", "conversation_id": conversation_id}
+        runner: Runner = request.app.state.runner
+        reply_text = ""
+        async for agent_event in runner.run_async(
+            user_id=user_id, session_id=conversation_id, new_message=prompt
+        ):
+            if agent_event.is_final_response() and agent_event.content and agent_event.content.parts:
+                reply_text = agent_event.content.parts[0].text or ""
+
+        if not reply_text:
+            # Agent produced no response (rare — usually means a tool call without
+            # a final text turn). Don't reply with an empty email; log so the
+            # operator can investigate why the run finished without text.
+            log.warning(
+                "agent produced no reply text user=%s conv=%s msg=%s",
+                user_id, conversation_id, message_id,
+            )
+            await event_deduper.complete(event.id)
+            return {"status": "no_reply", "conversation_id": conversation_id}
+
+        log.info(
+            "replying user=%s conv=%s msg=%s reply_chars=%d",
+            user_id, conversation_id, message_id, len(reply_text),
+        )
+        result = await client.messages.reply(
+            delivered_to,
+            message_id,
+            {"text": reply_text, "conversation_id": conversation_id},
+            idempotency_key=event.id,
+        )
+        await event_deduper.complete(event.id)
+        response_status = "replied" if result.status in {"sent", "accepted"} else result.status
+        return {"status": response_status, "conversation_id": conversation_id}
+    except BaseException:
+        # Let e2a's retry schedule redeliver genuine failures. The stable
+        # event-derived Idempotency-Key prevents a later retry from sending a
+        # second reply if the first API response was lost after acceptance.
+        await event_deduper.release(event.id)
+        raise
 
 
 def _format_email_for_agent(inbound) -> str:

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -55,13 +55,13 @@ Using [`langchain-mcp-adapters`](https://github.com/langchain-ai/langchain-mcp-a
 ```python
 import os
 
+from langchain.agents import create_agent
 from langchain_mcp_adapters.client import MultiServerMCPClient
-from langgraph.prebuilt import create_react_agent
 
 client = MultiServerMCPClient({
     "e2a": {
-        "transport": "streamable_http",
-        "url": "https://api.e2a.dev/mcp",
+        "transport": "http",
+        "url": os.getenv("E2A_MCP_URL", "https://api.e2a.dev/mcp"),
         "headers": {
             "Authorization": f"Bearer {os.environ['E2A_API_KEY']}",
         },
@@ -69,7 +69,11 @@ client = MultiServerMCPClient({
 })
 
 tools = await client.get_tools()
-agent = create_react_agent("anthropic:claude-sonnet-4-6", tools)
+agent = create_agent(
+    "anthropic:claude-sonnet-4-6",
+    tools=tools,
+    system_prompt="Reply with reply_to_message; pending_review is accepted, so do not retry it.",
+)
 ```
 
 ### OpenAI Agents SDK (Python)
@@ -83,11 +87,14 @@ from agents.mcp import MCPServerStreamableHttp
 async with MCPServerStreamableHttp(
     name="e2a",
     params={
-        "url": "https://api.e2a.dev/mcp",
+        "url": os.getenv("E2A_MCP_URL", "https://api.e2a.dev/mcp"),
         "headers": {
             "Authorization": f"Bearer {os.environ['E2A_API_KEY']}",
         },
+        "timeout": 30,
     },
+    cache_tools_list=True,
+    max_retry_attempts=3,
 ) as e2a:
     agent = Agent(name="e2a_agent", mcp_servers=[e2a])
     result = await Runner.run(agent, "Reply to the latest unread email politely.")

--- a/mcp/examples/README.md
+++ b/mcp/examples/README.md
@@ -14,9 +14,17 @@ End-to-end demos showing how to wire the e2a MCP surface into popular agent fram
 
 Each example exercises the same e2a tool surface (50 tools; the visible set depends on your key's scope) against the hosted MCP server. The Python framework examples ship an `agent.py` script; the Codex example ships a TOML block (Codex is itself the agent, so you configure it instead of writing a script).
 
-Every example connects to `https://api.e2a.dev/mcp` over Streamable HTTP with your API key in the `Authorization` header. No Node toolchain or local build is needed, and updates land without rebuilding the agent's image — so it works equally well on a laptop or on serverless runtimes (Cloud Run, Lambda, Vercel).
+Every example connects to `https://api.e2a.dev/mcp` over Streamable HTTP with an
+agent-scoped API key in the `Authorization` header. Set `E2A_MCP_URL` to point
+the Python examples at a self-hosted deployment. No Node toolchain or local
+build is needed.
 
 Bring your own [e2a API key](https://e2a.dev) and an LLM key for whichever framework you're trying.
+
+The Python prompts share three email invariants: reply with
+`reply_to_message` to preserve the wire thread, treat `pending_review` as an
+accepted hold rather than an error, and retry only tool failures whose structured
+error reports `retryable: true`.
 
 ## Things to try once a demo is running
 
@@ -27,4 +35,6 @@ Bring your own [e2a API key](https://e2a.dev) and an LLM key for whichever frame
 
 ## Pointing at a self-hosted e2a
 
-The examples are pinned to `https://api.e2a.dev/mcp` — edit the `url` literal in `agent.py` (or in the Codex `[mcp_servers.e2a-hosted]` block) if you run your own MCP server.
+Set `E2A_MCP_URL=https://your-e2a.example/mcp` for the Python examples. Update
+the URL in the Codex `[mcp_servers.e2a-hosted]` block for the configuration-only
+example.

--- a/mcp/examples/crewai/README.md
+++ b/mcp/examples/crewai/README.md
@@ -1,13 +1,13 @@
 # CrewAI × e2a
 
-Single-agent CrewAI crew that drives the hosted e2a [MCP server](https://api.e2a.dev/mcp) via [`crewai-tools`](https://github.com/crewAIInc/crewAI-tools)' `MCPServerAdapter`. Picks up the e2a tool surface and uses it to answer natural-language email tasks.
+Single-agent CrewAI 1.x crew that drives the hosted e2a [MCP server](https://api.e2a.dev/mcp) through CrewAI's native `MCPServerHTTP` integration. It discovers the e2a tool surface and uses it to answer natural-language email tasks.
 
 `agent.py` connects to the hosted endpoint at `https://api.e2a.dev/mcp` (Streamable HTTP) with your API key in the `Authorization` header.
 
 ## Prerequisites
 
 - Python 3.10+
-- An [e2a API key](https://e2a.dev)
+- An **agent-scoped** [e2a API key](https://e2a.dev), recommended so the runtime can act only as its own inbox
 - An [Anthropic API key](https://console.anthropic.com/)
 
 ## Run
@@ -16,15 +16,28 @@ Single-agent CrewAI crew that drives the hosted e2a [MCP server](https://api.e2a
 pip install -r requirements.txt
 export E2A_API_KEY=e2a_…
 export ANTHROPIC_API_KEY=sk-ant-…
+# Optional: export E2A_MCP_URL=https://your-e2a.example/mcp
+# Optional: export CREWAI_MODEL=anthropic/claude-sonnet-4-6
 
 python agent.py "what's in my inbox?"
 python agent.py "reply to the most recent message politely"
 ```
 
-If your credential resolves a single agent, the hosted endpoint scopes tools to it server-side. With an account-scoped key and multiple agents, pass `agent_email` per tool call.
+The example deliberately uses an agent-scoped key. An account-scoped key exposes
+admin/setup tools as well and requires `agent_email` on inbox calls when the
+account owns multiple agents; use that broader scope only for a provisioning UI.
 
 ## How it works
 
-`MCPServerAdapter` connects to the hosted Streamable HTTP endpoint (via a dict with `transport: "streamable-http"` and a Bearer header). Inside the `with` block, the adapter yields one CrewAI tool per MCP tool — wired straight into the `Agent` so the crew can call them.
+`MCPServerHTTP(streamable=True)` is attached directly through `Agent(mcps=[...])`,
+the current CrewAI-recommended integration. CrewAI discovers and cleans up the
+remote tools around the crew run. Tool schemas are cached for that run. The
+backstory tells the agent to retry only structured errors marked `retryable`,
+and to treat `pending_review` as accepted rather than retrying it.
+
+CrewAI namespaces discovered tool names with the MCP server identifier (for
+example, a name ending in `_list_messages`). The model still receives each
+tool's original description and schema; this prevents collisions when an agent
+uses more than one MCP server.
 
 To swap models, change `"anthropic/claude-sonnet-4-6"` to any [LiteLLM-compatible model string](https://docs.litellm.ai/docs/providers) CrewAI accepts (CrewAI uses LiteLLM under the hood).

--- a/mcp/examples/crewai/agent.py
+++ b/mcp/examples/crewai/agent.py
@@ -17,54 +17,52 @@ import os
 import sys
 
 from crewai import Agent, Crew, Process, Task
-from crewai_tools import MCPServerAdapter
+from crewai.mcp import MCPServerHTTP
 
-BACKSTORY = (
-    "You manage email through the e2a tools. Call whoami once to find "
-    "your inbox address. Use list_messages and get_message to read; "
-    "use reply_to_message when replying to an existing thread (preserves "
-    "In-Reply-To and References headers), and send_message to start a new "
-    "thread."
-)
+MCP_URL = os.getenv("E2A_MCP_URL", "https://api.e2a.dev/mcp")
+MODEL = os.getenv("CREWAI_MODEL", "anthropic/claude-sonnet-4-6")
+BACKSTORY = """You manage email through the e2a tools.
+Use an agent-scoped e2a key so this runtime can act only as its own inbox.
+Call whoami once to learn that inbox address. Use list_messages and then
+get_message to read mail. Use reply_to_message for an existing thread so the
+In-Reply-To and References headers are preserved; use send_message only for a
+new thread. If send_message or reply_to_message returns pending_review, the
+message was accepted for human review: report that status and Do not retry it.
+Never approve or reject the agent's own held mail. Retry a failed tool call only
+when its structured error says retryable=true, honoring retry_after_seconds.
+"""
 
 
 def main(prompt: str) -> None:
-    server_params = {
-        "url": "https://api.e2a.dev/mcp",
-        "transport": "streamable-http",
-        "headers": {
+    e2a = MCPServerHTTP(
+        url=MCP_URL,
+        headers={
             "Authorization": f"Bearer {os.environ['E2A_API_KEY']}",
         },
-    }
-
-    with MCPServerAdapter(server_params) as e2a_tools:
-        print(
-            f"Loaded {len(e2a_tools)} e2a tools: "
-            f"{', '.join(t.name for t in e2a_tools)}\n"
-        )
-
-        agent = Agent(
-            role="Email Manager",
-            goal="Handle the operator's email request precisely and concisely.",
-            backstory=BACKSTORY,
-            tools=e2a_tools,
-            llm="anthropic/claude-sonnet-4-6",
-            allow_delegation=False,
-            verbose=True,
-        )
-        task = Task(
-            description=prompt,
-            expected_output="A clear, concise answer to the user's email-related request.",
-            agent=agent,
-        )
-        crew = Crew(
-            agents=[agent],
-            tasks=[task],
-            process=Process.sequential,
-            verbose=False,
-        )
-        result = crew.kickoff()
-        print(result)
+        streamable=True,
+        cache_tools_list=True,
+    )
+    agent = Agent(
+        role="Email Manager",
+        goal="Handle the operator's email request precisely and concisely.",
+        backstory=BACKSTORY,
+        mcps=[e2a],
+        llm=MODEL,
+        allow_delegation=False,
+        verbose=True,
+    )
+    task = Task(
+        description=prompt,
+        expected_output="A clear, concise answer to the user's email-related request.",
+        agent=agent,
+    )
+    crew = Crew(
+        agents=[agent],
+        tasks=[task],
+        process=Process.sequential,
+        verbose=False,
+    )
+    print(crew.kickoff())
 
 
 if __name__ == "__main__":

--- a/mcp/examples/crewai/requirements.txt
+++ b/mcp/examples/crewai/requirements.txt
@@ -1,3 +1,2 @@
-crewai[anthropic]>=0.80.0
-crewai-tools[mcp]>=0.25.0
-email-validator>=2.0
+crewai[anthropic]>=1.13,<2
+mcp>=1,<2

--- a/mcp/examples/langchain/README.md
+++ b/mcp/examples/langchain/README.md
@@ -1,13 +1,13 @@
 # LangChain × e2a
 
-LangGraph ReAct agent that drives the hosted e2a [MCP server](https://api.e2a.dev/mcp) via [`langchain-mcp-adapters`](https://github.com/langchain-ai/langchain-mcp-adapters). Picks up the e2a tool surface and uses it to answer natural-language email tasks.
+LangChain 1.x agent that drives the hosted e2a [MCP server](https://api.e2a.dev/mcp) via [`langchain-mcp-adapters`](https://github.com/langchain-ai/langchain-mcp-adapters). Picks up the e2a tool surface and uses it to answer natural-language email tasks.
 
 `agent.py` connects to the hosted endpoint at `https://api.e2a.dev/mcp` (Streamable HTTP) with your API key in the `Authorization` header.
 
 ## Prerequisites
 
 - Python 3.10+
-- An [e2a API key](https://e2a.dev)
+- An **agent-scoped** [e2a API key](https://e2a.dev), recommended so the runtime can act only as its own inbox
 - An [Anthropic API key](https://console.anthropic.com/)
 
 ## Run
@@ -16,15 +16,24 @@ LangGraph ReAct agent that drives the hosted e2a [MCP server](https://api.e2a.de
 pip install -r requirements.txt
 export E2A_API_KEY=e2a_…
 export ANTHROPIC_API_KEY=sk-ant-…
+# Optional: export E2A_MCP_URL=https://your-e2a.example/mcp
+# Optional: export LANGCHAIN_MODEL=anthropic:claude-sonnet-4-6
 
 python agent.py "what's in my inbox?"
 python agent.py "reply to the most recent message politely"
 ```
 
-If your credential resolves a single agent, the hosted endpoint scopes tools to it server-side. With an account-scoped key and multiple agents, pass `agent_email` per tool call.
+The example deliberately uses an agent-scoped key. An account-scoped key exposes
+admin/setup tools as well and requires `agent_email` on inbox calls when the
+account owns multiple agents; use that broader scope only for a provisioning UI.
 
 ## How it works
 
-`MultiServerMCPClient` connects to the hosted Streamable HTTP endpoint with `transport: "streamable_http"` and a Bearer header. `client.get_tools()` returns LangChain `BaseTool` objects, one per MCP tool. The ReAct agent treats them like any other LangChain tool.
+`MultiServerMCPClient` connects with the current `transport: "http"` spelling and
+a Bearer header. `client.get_tools()` returns LangChain tools, and
+`langchain.agents.create_agent` runs the tool loop. MCP `isError` results remain
+model-visible failed tool messages; transport/authentication failures still
+raise. The system prompt tells the agent to retry only structured errors marked
+`retryable`, and to treat `pending_review` as accepted rather than retrying it.
 
 To swap models, change `"anthropic:claude-sonnet-4-6"` to any provider:model string [`init_chat_model`](https://python.langchain.com/docs/how_to/chat_models_universal_init/) accepts.

--- a/mcp/examples/langchain/agent.py
+++ b/mcp/examples/langchain/agent.py
@@ -16,37 +16,43 @@ Run:
 import asyncio
 import os
 import sys
-from datetime import timedelta
 
+from langchain.agents import create_agent
 from langchain_mcp_adapters.client import MultiServerMCPClient
-from langgraph.prebuilt import create_react_agent
 
-SYSTEM_PROMPT = (
-    "You manage email through the e2a tools. Call whoami once to find "
-    "your inbox address. Use list_messages and get_message to read; "
-    "use reply_to_message when replying to an existing thread (preserves "
-    "In-Reply-To and References headers), and send_message to start a new "
-    "thread."
-)
+MCP_URL = os.getenv("E2A_MCP_URL", "https://api.e2a.dev/mcp")
+MODEL = os.getenv("LANGCHAIN_MODEL", "anthropic:claude-sonnet-4-6")
+SYSTEM_PROMPT = """You manage email through the e2a tools.
+Use an agent-scoped e2a key so this runtime can act only as its own inbox.
+Call whoami once to learn that inbox address. Use list_messages and then
+get_message to read mail. Use reply_to_message for an existing thread so the
+In-Reply-To and References headers are preserved; use send_message only for a
+new thread. If send_message or reply_to_message returns pending_review, the
+message was accepted for human review: report that status and Do not retry it.
+Never approve or reject the agent's own held mail. Retry a failed tool call only
+when its structured error says retryable=true, honoring retry_after_seconds.
+"""
 
 
 async def main(prompt: str) -> None:
     client = MultiServerMCPClient(
         {
             "e2a": {
-                "transport": "streamable_http",
-                "url": "https://api.e2a.dev/mcp",
+                "transport": "http",
+                "url": MCP_URL,
                 "headers": {
                     "Authorization": f"Bearer {os.environ['E2A_API_KEY']}",
                 },
-                "timeout": timedelta(seconds=30),
             },
-        }
+        },
+        # MCP isError results become model-visible failed ToolMessages. Transport
+        # failures still raise, which keeps broken auth/connectivity explicit.
+        handle_tool_errors=True,
     )
     tools = await client.get_tools()
     print(f"Loaded {len(tools)} e2a tools: {', '.join(t.name for t in tools)}\n")
 
-    agent = create_react_agent("anthropic:claude-sonnet-4-6", tools, prompt=SYSTEM_PROMPT)
+    agent = create_agent(MODEL, tools=tools, system_prompt=SYSTEM_PROMPT)
     result = await agent.ainvoke({"messages": [{"role": "user", "content": prompt}]})
 
     final = result["messages"][-1]

--- a/mcp/examples/langchain/requirements.txt
+++ b/mcp/examples/langchain/requirements.txt
@@ -1,3 +1,3 @@
-langchain-mcp-adapters>=0.1.0
-langgraph>=0.2.0
-langchain-anthropic>=0.3.0
+langchain>=1,<2
+langchain-mcp-adapters>=0.3,<1
+langchain-anthropic>=1,<2

--- a/mcp/examples/openai-agents/README.md
+++ b/mcp/examples/openai-agents/README.md
@@ -7,7 +7,7 @@
 ## Prerequisites
 
 - Python 3.10+
-- An [e2a API key](https://e2a.dev)
+- An **agent-scoped** [e2a API key](https://e2a.dev), recommended so the runtime can act only as its own inbox
 - An [OpenAI API key](https://platform.openai.com/api-keys)
 
 ## Run
@@ -16,13 +16,21 @@
 pip install -r requirements.txt
 export E2A_API_KEY=e2a_…
 export OPENAI_API_KEY=sk-…
+# Optional: export E2A_MCP_URL=https://your-e2a.example/mcp
 
 python agent.py "what's in my inbox?"
 python agent.py "reply to the most recent message politely"
 ```
 
-If your credential resolves a single agent, the hosted endpoint scopes tools to it server-side. With an account-scoped key and multiple agents, pass `agent_email` per tool call.
+The example deliberately uses an agent-scoped key. An account-scoped key exposes
+admin/setup tools as well and requires `agent_email` on inbox calls when the
+account owns multiple agents; use that broader scope only for a provisioning UI.
 
 ## How it works
 
-`MCPServerStreamableHttp` connects to the hosted e2a tool surface, the `Agent` picks them up as its toolset, and `Runner.run` drives the loop. The async-context-manager wrapper ensures the HTTP client is cleaned up when the run finishes.
+`MCPServerStreamableHttp` connects to the hosted e2a tool surface, caches its
+stable tool list for the run, and retries initial MCP connection failures up to
+three times. The `Agent` receives those tools and `Runner.run` drives the loop.
+The async context manager closes the HTTP client. Instructions tell the agent to
+retry only structured errors marked `retryable`, and to treat `pending_review`
+as accepted rather than retrying it.

--- a/mcp/examples/openai-agents/agent.py
+++ b/mcp/examples/openai-agents/agent.py
@@ -20,29 +20,35 @@ import sys
 from agents import Agent, Runner
 from agents.mcp import MCPServerStreamableHttp
 
+MCP_URL = os.getenv("E2A_MCP_URL", "https://api.e2a.dev/mcp")
+INSTRUCTIONS = """Manage email through the e2a tools.
+Use an agent-scoped e2a key so this runtime can act only as its own inbox.
+Call whoami once to learn that inbox address. Use list_messages and then
+get_message to read mail. Use reply_to_message for an existing thread so the
+In-Reply-To and References headers are preserved; use send_message only for a
+new thread. If send_message or reply_to_message returns pending_review, the
+message was accepted for human review: report that status and Do not retry it.
+Never approve or reject the agent's own held mail. Retry a failed tool call only
+when its structured error says retryable=true, honoring retry_after_seconds.
+"""
+
 
 async def main(prompt: str) -> None:
     async with MCPServerStreamableHttp(
         name="e2a",
         params={
-            "url": "https://api.e2a.dev/mcp",
+            "url": MCP_URL,
             "headers": {
                 "Authorization": f"Bearer {os.environ['E2A_API_KEY']}",
             },
+            "timeout": 30,
         },
-        # Default is 5s — too tight for the first request against a
-        # cold serverless backend. Match the ADK and LangChain
-        # examples at 30s.
-        client_session_timeout_seconds=30,
+        cache_tools_list=True,
+        max_retry_attempts=3,
     ) as e2a:
         agent = Agent(
             name="e2a_agent",
-            instructions=(
-                "Manage email through the e2a tools. Use whoami once to "
-                "find the inbox; list_messages + get_message to read; "
-                "reply_to_message to reply in-thread, and send_message to "
-                "start a new one."
-            ),
+            instructions=INSTRUCTIONS,
             mcp_servers=[e2a],
         )
         result = await Runner.run(agent, prompt)

--- a/mcp/examples/openai-agents/requirements.txt
+++ b/mcp/examples/openai-agents/requirements.txt
@@ -1,1 +1,1 @@
-openai-agents>=0.0.15
+openai-agents>=0.13,<1

--- a/mcp/examples/test_framework_examples.py
+++ b/mcp/examples/test_framework_examples.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).parent
+
+
+def source(framework: str, filename: str = "agent.py") -> str:
+    return (ROOT / framework / filename).read_text()
+
+
+class FrameworkExampleContractTest(unittest.TestCase):
+    def test_all_frameworks_support_self_hosted_mcp_and_email_safety(self) -> None:
+        for framework in ("langchain", "crewai", "openai-agents"):
+            with self.subTest(framework=framework):
+                agent = source(framework)
+                self.assertIn("E2A_MCP_URL", agent)
+                self.assertIn("pending_review", agent)
+                self.assertIn("Do not retry", agent)
+                self.assertIn("agent-scoped", agent)
+
+    def test_langchain_uses_current_agent_and_http_transport(self) -> None:
+        agent = source("langchain")
+        requirements = source("langchain", "requirements.txt")
+
+        self.assertIn("from langchain.agents import create_agent", agent)
+        self.assertNotIn("langgraph.prebuilt", agent)
+        self.assertIn('"transport": "http"', agent)
+        self.assertIn("langchain-mcp-adapters>=0.3", requirements)
+        self.assertIn("langchain>=1", requirements)
+
+    def test_crewai_uses_current_native_mcp_configuration(self) -> None:
+        agent = source("crewai")
+        requirements = source("crewai", "requirements.txt")
+
+        self.assertIn("from crewai.mcp import MCPServerHTTP", agent)
+        self.assertIn("mcps=[e2a]", agent)
+        self.assertNotIn("MCPServerAdapter", agent)
+        self.assertIn("crewai[anthropic]>=1.13", requirements)
+        self.assertNotIn("crewai-tools", requirements)
+
+    def test_openai_agents_uses_current_remote_mcp_resilience_options(self) -> None:
+        agent = source("openai-agents")
+        requirements = source("openai-agents", "requirements.txt")
+
+        self.assertIn("cache_tools_list=True", agent)
+        self.assertIn("max_retry_attempts=3", agent)
+        self.assertIn("openai-agents>=0.13", requirements)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/check-repository-text-integrity.sh
+++ b/scripts/check-repository-text-integrity.sh
@@ -18,4 +18,8 @@ node -e '
   }
 ' package-lock.json web/package-lock.json
 
+node scripts/check-sdk-example-contracts.mjs
+python3 -m unittest discover -s examples/adk-cloud-webhook -p 'test_*.py'
+python3 -m unittest discover -s mcp/examples -p 'test_*.py'
+
 echo "repository text integrity checks passed"

--- a/scripts/check-sdk-example-contracts.mjs
+++ b/scripts/check-sdk-example-contracts.mjs
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+const checks = new Map([
+  ["README.md", [
+    /meta\["recipient"\]/,
+    /notif\.recipient/,
+    /notif\.message_id/,
+    /\{"body": "Got it!"/,
+  ]],
+  ["sdks/typescript/README.md", [
+    /^\+ .*\{ status: "unread"/m,
+    /^\+ .*\.messageId/m,
+    /^\+ .*\{ body: /m,
+    /^for await .*\{ status: "unread"/m,
+    /m\.messageId/,
+    /htmlBody:/,
+  ]],
+  ["sdks/python/README.md", [
+    /messages\.reply\([^\n]+\{"body":/,
+    /"body": "Hi from my agent!"/,
+    /"html_body":/,
+  ]],
+  ["web/public/sdk.md", [
+    /n\.delivered_to/,
+    /n\.message_id/,
+  ]],
+  ["docs/events.md", [
+    /\.toArray\(\);/,
+    /^for e in client\.events\.list/m,
+    /redeliver\(e\.id, webhook_id=/,
+  ]],
+]);
+
+let failed = false;
+for (const [file, patterns] of checks) {
+  const source = fs.readFileSync(file, "utf8");
+  for (const pattern of patterns) {
+    if (pattern.test(source)) {
+      console.error(`${file}: stale SDK example contract matched ${pattern}`);
+      failed = true;
+    }
+  }
+}
+
+if (failed) process.exit(1);
+console.log("SDK example contract checks passed");

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -84,7 +84,7 @@ with E2AClient() as client:
     for m in client.messages.list(address, read_status="unread"):
         email = client.messages.get(address, m.id)
         print(email.subject)
-        client.messages.reply(address, m.id, {"body": "Got it!"})
+        client.messages.reply(address, m.id, {"text": "Got it!"})
 ```
 
 The sync client must not be used from async code — any call made while an
@@ -106,7 +106,7 @@ async def main():
         async for m in client.messages.list(address, read_status="unread"):
             email = await client.messages.get(address, m.id)
             print(email.subject)
-            await client.messages.reply(address, m.id, {"body": "Got it!"})
+            await client.messages.reply(address, m.id, {"text": "Got it!"})
 
 asyncio.run(main())
 ```
@@ -117,8 +117,8 @@ asyncio.run(main())
 await client.messages.send(address, {
     "to": ["alice@example.com"],
     "subject": "Hello",
-    "body": "Hi from my agent!",
-    "html_body": "<p>Hi!</p>",
+    "text": "Hi from my agent!",
+    "html": "<p>Hi!</p>",
 })
 ```
 
@@ -288,7 +288,7 @@ you want to thread.
 await client.messages.send(address, {
     "to": ["alice@example.com"],
     "subject": "Hello",
-    "body": "Hi from my agent!",
+    "text": "Hi from my agent!",
     "conversation_id": "thread-42",
 })
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -9,7 +9,7 @@ npm install @e2a/sdk
 ```
 
 The SDK major version tracks the SDK package's own breaking changes and is
-independent of the API version path (`/v1`): SDK 4.x targets the e2a v1 API.
+independent of the API version path (`/v1`): SDK 5.x targets the e2a v1 API.
 
 ## Upgrading to 4.0
 
@@ -47,8 +47,8 @@ retries + idempotency, and auto-pagination.
 - const { messages } = await client.getMessages({ status: "unread" });
 - const email = await client.getMessage(messages[0].messageId);
 - await email.reply("Thanks!");
-+ const messages = await client.messages.list(address, { status: "unread" }).toArray({ limit: 50 });
-+ await client.messages.reply(address, messages[0].messageId, { body: "Thanks!" });
++ const messages = await client.messages.list(address, { readStatus: "unread" }).toArray({ limit: 50 });
++ await client.messages.reply(address, messages[0].id, { text: "Thanks!" });
 ```
 
 ## Quick Start
@@ -64,10 +64,10 @@ const address = "my-agent@agents.e2a.dev";
 
 ```typescript
 // List endpoints return an AutoPager: iterate, or collect with a required limit.
-for await (const m of client.messages.list(address, { status: "unread" })) {
-  const email = await client.messages.get(address, m.messageId);
-  console.log(email.subject, email.body?.text);
-  await client.messages.reply(address, m.messageId, { body: "Got it!" });
+for await (const m of client.messages.list(address, { readStatus: "unread" })) {
+  const email = await client.messages.get(address, m.id);
+  console.log(email.subject, email.parsed?.text);
+  await client.messages.reply(address, m.id, { text: "Got it!" });
 }
 ```
 
@@ -77,8 +77,8 @@ for await (const m of client.messages.list(address, { status: "unread" })) {
 await client.messages.send(address, {
   to: ["alice@example.com"],
   subject: "Hello",
-  body: "Hi from my agent!",
-  htmlBody: "<p>Hi!</p>",
+  text: "Hi from my agent!",
+  html: "<p>Hi!</p>",
   cc: ["carol@example.com"],
 });
 ```

--- a/web/public/sdk.md
+++ b/web/public/sdk.md
@@ -27,6 +27,7 @@ pip install e2a             # Python (async)
 import { E2AClient } from "@e2a/sdk";
 
 const client = new E2AClient({ apiKey: process.env.E2A_API_KEY });
+const messageId = "msg_..."; // an inbound message id from a webhook, WebSocket, or list call
 
 // Send (held drafts come back status="pending_review", not an error)
 await client.messages.send("bot@agents.e2a.dev", {
@@ -44,9 +45,11 @@ await client.messages.reply("bot@agents.e2a.dev", messageId, {
 ### Python
 
 ```python
+import os
 from e2a.v1 import AsyncE2AClient
 
 async with AsyncE2AClient(api_key=os.environ["E2A_API_KEY"]) as client:
+    message_id = "msg_..."  # an inbound message id from a webhook, WebSocket, or list call
     await client.messages.send("bot@agents.e2a.dev", {
         "to": ["person@example.com"],
         "subject": "Hello from my agent",
@@ -67,15 +70,14 @@ the HMAC and throws on a bad/forged/replayed delivery.
 ### TypeScript
 
 ```ts
-import { constructEvent, E2AClient } from "@e2a/sdk";
+import { constructEvent, E2AClient, isEmailReceived } from "@e2a/sdk";
 
 // in your HTTP handler, with the RAW request body:
 const event = constructEvent(rawBody, req.headers["x-e2a-signature"], WEBHOOK_SECRET);
-if (event.type === "email.received") {
-  const { delivered_to, message_id } = event.data as { delivered_to: string; message_id: string };
-  const msg = await client.messages.get(delivered_to, message_id); // typed: from, subject, parsed.text, attachments
+if (isEmailReceived(event)) {
+  const msg = await client.webhooks.fetchMessage(event); // typed: from_, subject, parsed.text, attachments
   // …decide a reply…
-  await client.messages.reply(delivered_to, message_id, { text: "On it." });
+  await client.messages.reply(event.data.delivered_to, event.data.message_id, { text: "On it." });
 }
 ```
 
@@ -91,7 +93,7 @@ except E2AWebhookSignatureError:
 
 if event.type == "email.received":
     data = event.data
-    inbound = await client.messages.get(data["delivered_to"], data["message_id"])
+    inbound = await client.webhooks.fetch_message(event)
     # inbound.from_, inbound.subject, inbound.parsed.text
     await client.messages.reply(data["delivered_to"], data["message_id"], {"text": "On it."})
 ```
@@ -122,14 +124,20 @@ await client.reviews.reject(message_id, {"reason": "spam"})
 Open a notification stream instead of hosting a webhook:
 
 ```ts
-for await (const n of client.listen("bot@agents.e2a.dev")) {
-  const msg = await client.messages.get(n.delivered_to, n.message_id);
+import { E2AClient, isEmailReceived } from "@e2a/sdk";
+
+const client = new E2AClient();
+for await (const event of client.listen("bot@agents.e2a.dev")) {
+  if (!isEmailReceived(event)) continue;
+  const msg = await client.webhooks.fetchMessage(event);
 }
 ```
 
 ```python
-async for n in client.listen("bot@agents.e2a.dev"):
-    msg = await client.messages.get(n.delivered_to, n.message_id)
+async for event in client.listen("bot@agents.e2a.dev"):
+    if event.type != "email.received":
+        continue
+    msg = await client.webhooks.fetch_message(event)
 ```
 
 ## Raw REST (without an SDK)


### PR DESCRIPTION
## Summary

- update TypeScript and Python SDK examples to the current e2a 5.x field, pagination, webhook, WebSocket, and send/reply contracts
- harden the ADK webhook example with verified message fetching, deterministic conversation IDs, event deduplication, idempotent replies, least-privilege credential guidance, and live integration coverage
- migrate LangChain, CrewAI, and OpenAI Agents examples to their current native MCP APIs, including self-hosted URL support and email-specific retry/HITL guidance
- add repository guardrails that reject stale SDK and framework example patterns

## Why

The examples had drifted across both an e2a SDK major-version transition and upstream agent-framework API changes. Several snippets used stale request/response fields, while LangChain and CrewAI still demonstrated superseded integration APIs. The webhook example also lacked at-least-once delivery protection.

## Impact

Users can copy the examples against current SDK and framework releases. Agent runtimes are guided toward agent-scoped credentials, thread-preserving replies, correct `pending_review` handling, and retry-safe email behavior.

## Validation

- `scripts/check-repository-text-integrity.sh`
- `npm test --workspace @e2a/sdk` — 188 tests passed
- `npm test --workspace @e2a/mcp-server` — 201 tests passed
- Python SDK suite — 332 passed, 18 skipped
- ADK live local contract-server fetch/reply dry run with deterministic mocked model boundary
- live authenticated MCP discovery and `whoami` invocation through LangChain 1.3.14, CrewAI 1.15.4, and OpenAI Agents 0.18.3
- TypeScript SDK and MCP builds
- Python example compilation and `git diff --check`
