### PR TITLE
feat(auth): lazy OIDC issuer discovery with background retry

### DIFF
--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -475,7 +475,8 @@ func main() {
 	// retained for any future static/constructor-time failure mode, but
 	// today NewOIDCAuth only fails to construct if E2A is misconfigured in a
 	// way config.Validate() would already have caught.
-	oidcAuth, err := auth.NewOIDCAuth(ctx, cfg.OIDC, store, cfg.IsProduction(), cfg.HTTP.PublicURL)
+	oidcCtx, oidcCancel := context.WithCancel(ctx)
+	oidcAuth, err := auth.NewOIDCAuth(oidcCtx, cfg.OIDC, store, cfg.IsProduction(), cfg.HTTP.PublicURL)
 	if err != nil {
 		log.Fatalf("Failed to initialize OIDC login: %v", err)
 	}
@@ -769,6 +770,9 @@ func main() {
 
 	<-sigCh
 	log.Println("Shutting down...")
+
+	// Stop OIDC issuer discovery promptly, including an in-flight attempt.
+	oidcCancel()
 
 	// Signal the remaining background workers to stop. Their inner ctx-select
 	// branches return on the next iteration; work already in flight finishes

--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -467,13 +467,20 @@ func main() {
 	// User auth (Google OAuth for agent developers)
 	userAuth := auth.NewUserAuth(&cfg.OAuth, store, cfg.IsProduction())
 	// Generic OIDC Authorization Code login. Disabled configurations perform
-	// no discovery and leave both OIDC routes unregistered.
+	// no discovery and leave both OIDC routes unregistered. Enabled
+	// configurations construct synchronously (no network call) and discover
+	// the issuer in a background goroutine with retry/backoff, so an
+	// unreachable identity provider never blocks or fails server boot; the
+	// OIDC routes fail closed with 503 until discovery completes. err is
+	// retained for any future static/constructor-time failure mode, but
+	// today NewOIDCAuth only fails to construct if E2A is misconfigured in a
+	// way config.Validate() would already have caught.
 	oidcAuth, err := auth.NewOIDCAuth(ctx, cfg.OIDC, store, cfg.IsProduction(), cfg.HTTP.PublicURL)
 	if err != nil {
 		log.Fatalf("Failed to initialize OIDC login: %v", err)
 	}
 	if oidcAuth != nil {
-		log.Printf("[auth] OIDC login enabled (issuer=%s)", cfg.OIDC.IssuerURL)
+		log.Printf("[auth] OIDC login enabled (issuer=%s); discovering issuer in the background", cfg.OIDC.IssuerURL)
 	}
 
 	// HTTP API

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -35,6 +35,7 @@ const (
 	// on real wall-clock time.
 	oidcDiscoveryInitialBackoff = time.Second
 	oidcDiscoveryMaxBackoff     = 60 * time.Second
+	oidcDiscoveryAttemptTimeout = 10 * time.Second
 
 	// oidcDiscoveryFailureLogGap rate-limits repeated discovery-failure log
 	// lines: the first failure always logs, subsequent failures log at most
@@ -77,6 +78,7 @@ type OIDCAuth struct {
 	// package defaults and no completion signal.
 	discoveryBackoff    time.Duration
 	discoveryMaxBackoff time.Duration
+	discoveryTimeout    time.Duration
 	discoveryDone       chan<- struct{}
 }
 
@@ -95,6 +97,15 @@ func WithOIDCDiscoveryBackoff(initial, maxBackoff time.Duration) OIDCOption {
 	return func(oa *OIDCAuth) {
 		oa.discoveryBackoff = initial
 		oa.discoveryMaxBackoff = maxBackoff
+	}
+}
+
+// WithOIDCDiscoveryAttemptTimeout overrides the maximum duration of one
+// issuer discovery HTTP request (production default: 10s). Intended for tests
+// that exercise a provider which accepts a connection but never responds.
+func WithOIDCDiscoveryAttemptTimeout(timeout time.Duration) OIDCOption {
+	return func(oa *OIDCAuth) {
+		oa.discoveryTimeout = timeout
 	}
 }
 
@@ -134,6 +145,7 @@ func NewOIDCAuth(ctx context.Context, cfg config.OIDCConfig, store *identity.Sto
 		baseURL:             strings.TrimRight(baseURL, "/"),
 		discoveryBackoff:    oidcDiscoveryInitialBackoff,
 		discoveryMaxBackoff: oidcDiscoveryMaxBackoff,
+		discoveryTimeout:    oidcDiscoveryAttemptTimeout,
 	}
 	for _, opt := range opts {
 		opt(oa)
@@ -163,7 +175,9 @@ func (oa *OIDCAuth) discoverWithRetry(ctx context.Context) {
 	for {
 		attempt++
 
-		provider, err := oidc.NewProvider(ctx, oa.cfg.IssuerURL)
+		attemptCtx, cancel := context.WithTimeout(ctx, oa.discoveryTimeout)
+		provider, err := oidc.NewProvider(attemptCtx, oa.cfg.IssuerURL)
+		cancel()
 		if err == nil {
 			oa.ready.Store(&oidcReadyState{
 				oauthConfig: &oauth2.Config{
@@ -213,7 +227,6 @@ func (oa *OIDCAuth) discoverWithRetry(ctx context.Context) {
 func (oa *OIDCAuth) HandleLogin(w http.ResponseWriter, r *http.Request) {
 	rs := oa.ready.Load()
 	if rs == nil {
-		log.Printf("[auth] OIDC login rejected: issuer discovery has not completed yet")
 		http.Error(w, "login temporarily unavailable", http.StatusServiceUnavailable)
 		return
 	}
@@ -251,7 +264,6 @@ func (oa *OIDCAuth) HandleLogin(w http.ResponseWriter, r *http.Request) {
 func (oa *OIDCAuth) HandleCallback(w http.ResponseWriter, r *http.Request) {
 	rs := oa.ready.Load()
 	if rs == nil {
-		log.Printf("[auth] OIDC callback rejected: issuer discovery has not completed yet")
 		http.Error(w, "login temporarily unavailable", http.StatusServiceUnavailable)
 		return
 	}

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/coreos/go-oidc/v3/oidc"
@@ -24,54 +25,199 @@ const (
 	oidcVerifierCookieName = "e2a_oidc_verifier"
 	oidcCookiePath         = "/api/auth/oidc"
 	oidcTransactionMaxAge  = 10 * time.Minute
+
+	// oidcDiscoveryInitialBackoff/oidcDiscoveryMaxBackoff govern the
+	// background discovery retry loop started by NewOIDCAuth: the first
+	// attempt happens immediately, then failures back off exponentially
+	// from oidcDiscoveryInitialBackoff, doubling on every failed attempt,
+	// capped at oidcDiscoveryMaxBackoff, forever (until ctx is cancelled).
+	// Tests override these via WithOIDCDiscoveryBackoff so they don't block
+	// on real wall-clock time.
+	oidcDiscoveryInitialBackoff = time.Second
+	oidcDiscoveryMaxBackoff     = 60 * time.Second
+
+	// oidcDiscoveryFailureLogGap rate-limits repeated discovery-failure log
+	// lines: the first failure always logs, subsequent failures log at most
+	// once per this interval so a persistently-down issuer doesn't flood
+	// the log.
+	oidcDiscoveryFailureLogGap = time.Minute
 )
+
+// oidcReadyState holds everything a successful provider discovery produces:
+// the OAuth2 client config (carrying the provider's real authorization/token
+// endpoints) and the ID-token verifier bound to the provider's JWKS. It is
+// published as a single atomic value once discovery succeeds so a concurrent
+// HandleLogin/HandleCallback either sees "not ready yet" (nil) or a fully
+// consistent, fully-built pair -- never a half-initialized one.
+type oidcReadyState struct {
+	oauthConfig *oauth2.Config
+	verifier    *oidc.IDTokenVerifier
+}
 
 // OIDCAuth implements an optional OpenID Connect relying party for browser
 // login. It accepts only Authorization Code responses initiated by HandleLogin,
 // verifies the returned ID token, and maps a configured claim to an existing
 // e2a users.id. It never provisions users.
 type OIDCAuth struct {
-	cfg         config.OIDCConfig
-	oauthConfig *oauth2.Config
-	verifier    *oidc.IDTokenVerifier
-	store       *identity.Store
-	secure      bool
-	baseURL     string
+	cfg     config.OIDCConfig
+	store   *identity.Store
+	secure  bool
+	baseURL string
+
+	// ready is nil until the background discovery goroutine (started in
+	// NewOIDCAuth) successfully discovers the issuer, at which point it
+	// holds the built *oidcReadyState for the remaining lifetime of oa.
+	// HandleLogin/HandleCallback fail closed (503) while it is nil.
+	ready atomic.Pointer[oidcReadyState]
+
+	// discoveryBackoff/discoveryMaxBackoff seed the retry loop's backoff
+	// schedule; discoveryDone, if set, is closed when the discovery
+	// goroutine returns (success or ctx cancellation). Both are test-only
+	// hooks set via functional options -- production callers get the
+	// package defaults and no completion signal.
+	discoveryBackoff    time.Duration
+	discoveryMaxBackoff time.Duration
+	discoveryDone       chan<- struct{}
+}
+
+// OIDCOption configures optional, non-default behavior of NewOIDCAuth.
+// Production callers don't need any; they exist for tests that need the
+// background discovery retry loop to run on a compressed timescale, or to
+// observe the loop's lifecycle without a sleep-based race.
+type OIDCOption func(*OIDCAuth)
+
+// WithOIDCDiscoveryBackoff overrides the discovery retry loop's initial and
+// maximum backoff durations (production defaults: 1s initial, doubling,
+// capped at 60s). Intended for tests exercising the retry path against a
+// short-lived httptest server, where waiting out the real defaults would
+// make the suite slow.
+func WithOIDCDiscoveryBackoff(initial, maxBackoff time.Duration) OIDCOption {
+	return func(oa *OIDCAuth) {
+		oa.discoveryBackoff = initial
+		oa.discoveryMaxBackoff = maxBackoff
+	}
+}
+
+// WithOIDCDiscoveryDone registers a channel that the background discovery
+// goroutine closes when it returns, whether that's because discovery
+// succeeded or because ctx was cancelled. It exists so tests can assert the
+// goroutine actually exits (no leak) without guessing at a sleep duration.
+func WithOIDCDiscoveryDone(done chan<- struct{}) OIDCOption {
+	return func(oa *OIDCAuth) {
+		oa.discoveryDone = done
+	}
 }
 
 // NewOIDCAuth returns nil without performing discovery when OIDC is disabled.
-// Enabled configurations are discovered immediately so startup fails closed if
-// the configured issuer cannot provide valid OIDC metadata.
-func NewOIDCAuth(ctx context.Context, cfg config.OIDCConfig, store *identity.Store, production bool, baseURL string) (*OIDCAuth, error) {
+// Enabled configurations construct the handler synchronously -- this call
+// never touches the network -- and start one background goroutine that
+// discovers the issuer immediately, then retries with exponential backoff
+// (capped, forever) until it succeeds or ctx is cancelled. Until discovery
+// succeeds, HandleLogin and HandleCallback fail closed with 503. This keeps
+// e2a's boot decoupled from the identity provider's availability (an
+// unreachable issuer no longer prevents the whole process -- mail included
+// -- from starting) while preserving fail-closed login behavior: there is no
+// window where login silently no-ops or half-completes.
+//
+// Static/config-shaped problems are not this function's concern: they are
+// caught by config.OIDCConfig validation before this is ever called. Only
+// the network-dependent discovery call moved off the boot path.
+func NewOIDCAuth(ctx context.Context, cfg config.OIDCConfig, store *identity.Store, production bool, baseURL string, opts ...OIDCOption) (*OIDCAuth, error) {
 	if !cfg.Enabled {
 		return nil, nil
 	}
 
-	provider, err := oidc.NewProvider(ctx, cfg.IssuerURL)
-	if err != nil {
-		return nil, fmt.Errorf("discover OIDC issuer: %w", err)
+	oa := &OIDCAuth{
+		cfg:                 cfg,
+		store:               store,
+		secure:              production,
+		baseURL:             strings.TrimRight(baseURL, "/"),
+		discoveryBackoff:    oidcDiscoveryInitialBackoff,
+		discoveryMaxBackoff: oidcDiscoveryMaxBackoff,
+	}
+	for _, opt := range opts {
+		opt(oa)
 	}
 
-	return &OIDCAuth{
-		cfg: cfg,
-		oauthConfig: &oauth2.Config{
-			ClientID:     cfg.ClientID,
-			ClientSecret: cfg.ClientSecret,
-			RedirectURL:  cfg.RedirectURL,
-			Endpoint:     provider.Endpoint(),
-			Scopes:       []string{oidc.ScopeOpenID},
-		},
-		verifier: provider.Verifier(&oidc.Config{ClientID: cfg.ClientID}),
-		store:    store,
-		secure:   production,
-		baseURL:  strings.TrimRight(baseURL, "/"),
-	}, nil
+	go oa.discoverWithRetry(ctx)
+
+	return oa, nil
+}
+
+// discoverWithRetry runs for the lifetime of oa on its own goroutine. It
+// attempts oidc.NewProvider immediately, then on failure retries with
+// exponential backoff (starting at oa.discoveryBackoff, doubling each
+// attempt, capped at oa.discoveryMaxBackoff) until it succeeds or ctx is
+// cancelled. On success it builds the oauth2.Config and ID-token verifier
+// exactly as the old synchronous constructor did and publishes them
+// atomically via oa.ready, then returns -- there is nothing left to retry.
+func (oa *OIDCAuth) discoverWithRetry(ctx context.Context) {
+	if oa.discoveryDone != nil {
+		defer close(oa.discoveryDone)
+	}
+
+	backoff := oa.discoveryBackoff
+	var lastLogged time.Time
+	attempt := 0
+
+	for {
+		attempt++
+
+		provider, err := oidc.NewProvider(ctx, oa.cfg.IssuerURL)
+		if err == nil {
+			oa.ready.Store(&oidcReadyState{
+				oauthConfig: &oauth2.Config{
+					ClientID:     oa.cfg.ClientID,
+					ClientSecret: oa.cfg.ClientSecret,
+					RedirectURL:  oa.cfg.RedirectURL,
+					Endpoint:     provider.Endpoint(),
+					Scopes:       []string{oidc.ScopeOpenID},
+				},
+				verifier: provider.Verifier(&oidc.Config{ClientID: oa.cfg.ClientID}),
+			})
+			log.Printf("[auth] OIDC issuer discovered: %s", oa.cfg.IssuerURL)
+			return
+		}
+
+		if ctx.Err() != nil {
+			// Shutdown in progress -- stop retrying without logging the
+			// (expected, ctx-cancelled) discovery error as a failure.
+			return
+		}
+
+		if attempt == 1 || time.Since(lastLogged) >= oidcDiscoveryFailureLogGap {
+			log.Printf("[auth] OIDC issuer discovery failed, retrying in background (attempt %d): %v", attempt, err)
+			lastLogged = time.Now()
+		}
+
+		timer := time.NewTimer(backoff)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+
+		backoff *= 2
+		if backoff > oa.discoveryMaxBackoff {
+			backoff = oa.discoveryMaxBackoff
+		}
+	}
 }
 
 // HandleLogin creates a browser-bound OIDC transaction and redirects to the
 // provider's authorization endpoint. The PKCE verifier and OIDC nonce never
-// appear in application logs or identity-bearing cookies.
+// appear in application logs or identity-bearing cookies. Until background
+// issuer discovery has completed at least once, this fails closed with 503
+// rather than attempting a partial or misconfigured flow.
 func (oa *OIDCAuth) HandleLogin(w http.ResponseWriter, r *http.Request) {
+	rs := oa.ready.Load()
+	if rs == nil {
+		log.Printf("[auth] OIDC login rejected: issuer discovery has not completed yet")
+		http.Error(w, "login temporarily unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
 	state, err := randomOIDCValue()
 	if err != nil {
 		log.Printf("[auth] OIDC login initialization failed: %v", err)
@@ -90,7 +236,7 @@ func (oa *OIDCAuth) HandleLogin(w http.ResponseWriter, r *http.Request) {
 	oa.setTransactionCookie(w, oidcNonceCookieName, nonce, int(oidcTransactionMaxAge.Seconds()))
 	oa.setTransactionCookie(w, oidcVerifierCookieName, verifier, int(oidcTransactionMaxAge.Seconds()))
 
-	location := oa.oauthConfig.AuthCodeURL(
+	location := rs.oauthConfig.AuthCodeURL(
 		state,
 		oidc.Nonce(nonce),
 		oauth2.S256ChallengeOption(verifier),
@@ -100,8 +246,16 @@ func (oa *OIDCAuth) HandleLogin(w http.ResponseWriter, r *http.Request) {
 
 // HandleCallback validates the browser transaction, exchanges the short-lived
 // authorization code over the back channel, verifies the ID token, and creates
-// the same e2a session used by the legacy Google flow.
+// the same e2a session used by the legacy Google flow. Until background
+// issuer discovery has completed at least once, this fails closed with 503.
 func (oa *OIDCAuth) HandleCallback(w http.ResponseWriter, r *http.Request) {
+	rs := oa.ready.Load()
+	if rs == nil {
+		log.Printf("[auth] OIDC callback rejected: issuer discovery has not completed yet")
+		http.Error(w, "login temporarily unavailable", http.StatusServiceUnavailable)
+		return
+	}
+
 	stateCookie, stateErr := r.Cookie(oidcStateCookieName)
 	nonceCookie, nonceErr := r.Cookie(oidcNonceCookieName)
 	verifierCookie, verifierErr := r.Cookie(oidcVerifierCookieName)
@@ -133,7 +287,7 @@ func (oa *OIDCAuth) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	token, err := oa.oauthConfig.Exchange(r.Context(), code, oauth2.VerifierOption(verifierCookie.Value))
+	token, err := rs.oauthConfig.Exchange(r.Context(), code, oauth2.VerifierOption(verifierCookie.Value))
 	if err != nil {
 		log.Printf("[auth] OIDC code exchange failed: %v", err)
 		http.Error(w, "login verification failed", http.StatusUnauthorized)
@@ -145,7 +299,7 @@ func (oa *OIDCAuth) HandleCallback(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "login verification failed", http.StatusUnauthorized)
 		return
 	}
-	idToken, err := oa.verifier.Verify(r.Context(), rawIDToken)
+	idToken, err := rs.verifier.Verify(r.Context(), rawIDToken)
 	if err != nil {
 		log.Printf("[auth] OIDC ID token verification failed: %v", err)
 		http.Error(w, "login verification failed", http.StatusUnauthorized)

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -1,12 +1,14 @@
 package auth_test
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -313,6 +315,82 @@ func TestNewOIDCAuthConstructsWithUnreachableIssuer(t *testing.T) {
 	oidcAuth.HandleCallback(callbackW, httptest.NewRequest(http.MethodGet, "/api/auth/oidc/callback?code=x&state=y", nil))
 	if callbackW.Code != http.StatusServiceUnavailable {
 		t.Fatalf("HandleCallback status = %d, want 503 while discovery is unreachable", callbackW.Code)
+	}
+}
+
+func TestOIDCDiscoveryTimesOutStalledAttemptAndRetries(t *testing.T) {
+	var attempts atomic.Int32
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if attempts.Add(1) == 1 {
+			<-r.Context().Done()
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                 server.URL,
+			"authorization_endpoint": server.URL + "/authorize",
+			"token_endpoint":         server.URL + "/token",
+			"jwks_uri":               server.URL + "/jwks",
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	oidcAuth, err := auth.NewOIDCAuth(ctx, config.OIDCConfig{
+		Enabled: true, IssuerURL: server.URL, ClientID: "client", ClientSecret: "secret",
+		RedirectURL: testOIDCRedirectURL, UserIDClaim: testOIDCUserIDClaim,
+	}, nil, false, "",
+		auth.WithOIDCDiscoveryBackoff(testOIDCDiscoveryInitialBackoff, testOIDCDiscoveryMaxBackoff),
+		auth.WithOIDCDiscoveryAttemptTimeout(25*time.Millisecond),
+	)
+	if err != nil {
+		t.Fatalf("NewOIDCAuth: %v", err)
+	}
+
+	waitOIDCReady(t, oidcAuth)
+	if got := attempts.Load(); got < 2 {
+		t.Fatalf("discovery attempts = %d, want at least 2 after stalled attempt timed out", got)
+	}
+}
+
+func TestOIDCUnavailableHandlersDoNotLogPerRequest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	var logs bytes.Buffer
+	previousOutput := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(previousOutput) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	oidcAuth, err := auth.NewOIDCAuth(ctx, config.OIDCConfig{
+		Enabled: true, IssuerURL: server.URL, ClientID: "client", ClientSecret: "secret",
+		RedirectURL: testOIDCRedirectURL, UserIDClaim: testOIDCUserIDClaim,
+	}, nil, false, "",
+		auth.WithOIDCDiscoveryBackoff(testOIDCDiscoveryInitialBackoff, testOIDCDiscoveryMaxBackoff),
+		auth.WithOIDCDiscoveryDone(done),
+	)
+	if err != nil {
+		t.Fatalf("NewOIDCAuth: %v", err)
+	}
+
+	oidcAuth.HandleLogin(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/api/auth/oidc/login", nil))
+	oidcAuth.HandleCallback(httptest.NewRecorder(), httptest.NewRequest(http.MethodGet, "/api/auth/oidc/callback", nil))
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("discovery goroutine did not exit after cancellation")
+	}
+
+	got := logs.String()
+	if strings.Contains(got, "OIDC login rejected") || strings.Contains(got, "OIDC callback rejected") {
+		t.Fatalf("unavailable handlers logged per-request messages: %q", got)
 	}
 }
 

--- a/internal/auth/oidc_test.go
+++ b/internal/auth/oidc_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -21,6 +22,16 @@ import (
 	"github.com/tokencanopy/e2a/internal/config"
 	"github.com/tokencanopy/e2a/internal/identity"
 	"github.com/tokencanopy/e2a/internal/testutil"
+)
+
+// testOIDCDiscoveryInitial/MaxBackoff shorten the background discovery retry
+// loop for tests that deliberately start against an unreachable issuer:
+// production defaults (1s initial, 60s cap) would make those tests slow.
+const (
+	testOIDCDiscoveryInitialBackoff = 10 * time.Millisecond
+	testOIDCDiscoveryMaxBackoff     = 50 * time.Millisecond
+	testOIDCReadyPollTimeout        = 2 * time.Second
+	testOIDCReadyPollInterval       = 5 * time.Millisecond
 )
 
 const (
@@ -89,14 +100,40 @@ func setupOIDC(t *testing.T) *oidcFixture {
 		RedirectURL:  testOIDCRedirectURL,
 		UserIDClaim:  testOIDCUserIDClaim,
 	}
-	fx.oidc, err = auth.NewOIDCAuth(context.Background(), cfg, fx.store, false, "http://app.example.com")
+	fx.oidc, err = auth.NewOIDCAuth(context.Background(), cfg, fx.store, false, "http://app.example.com",
+		auth.WithOIDCDiscoveryBackoff(testOIDCDiscoveryInitialBackoff, testOIDCDiscoveryMaxBackoff))
 	if err != nil {
 		t.Fatalf("NewOIDCAuth: %v", err)
 	}
 	if fx.oidc == nil {
 		t.Fatal("NewOIDCAuth returned nil for enabled config")
 	}
+	// Discovery now runs in a background goroutine (see NewOIDCAuth); the
+	// issuer here is reachable immediately, so this should resolve on the
+	// very first attempt, but we still bound-poll rather than assume a
+	// synchronous completion.
+	waitOIDCReady(t, fx.oidc)
 	return fx
+}
+
+// waitOIDCReady bound-polls oa until background issuer discovery has
+// completed (HandleLogin stops returning 503), or fails the test. It has no
+// visibility into oa's internal readiness state -- by design, that's
+// unexported -- so it probes the same way a real client would.
+func waitOIDCReady(t *testing.T, oa *auth.OIDCAuth) {
+	t.Helper()
+	deadline := time.Now().Add(testOIDCReadyPollTimeout)
+	for {
+		w := httptest.NewRecorder()
+		oa.HandleLogin(w, httptest.NewRequest(http.MethodGet, "/api/auth/oidc/login", nil))
+		if w.Code != http.StatusServiceUnavailable {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("OIDC discovery did not become ready within %s", testOIDCReadyPollTimeout)
+		}
+		time.Sleep(testOIDCReadyPollInterval)
+	}
 }
 
 func (fx *oidcFixture) handleDiscovery(w http.ResponseWriter, _ *http.Request) {
@@ -242,18 +279,162 @@ func TestNewOIDCAuthDisabledReturnsNil(t *testing.T) {
 	}
 }
 
-func TestNewOIDCAuthDiscoveryFailure(t *testing.T) {
+// TestNewOIDCAuthConstructsWithUnreachableIssuer covers target behavior 1+2:
+// boot never blocks or fails on discovery, and the handler fails closed
+// (503) on both routes until discovery succeeds in the background.
+func TestNewOIDCAuthConstructsWithUnreachableIssuer(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "unavailable", http.StatusServiceUnavailable)
 	}))
 	defer server.Close()
 
-	_, err := auth.NewOIDCAuth(context.Background(), config.OIDCConfig{
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	oidcAuth, err := auth.NewOIDCAuth(ctx, config.OIDCConfig{
 		Enabled: true, IssuerURL: server.URL, ClientID: "client", ClientSecret: "secret",
 		RedirectURL: testOIDCRedirectURL, UserIDClaim: testOIDCUserIDClaim,
-	}, nil, false, "")
-	if err == nil {
-		t.Fatal("enabled OIDC must fail when provider discovery fails")
+	}, nil, false, "",
+		auth.WithOIDCDiscoveryBackoff(testOIDCDiscoveryInitialBackoff, testOIDCDiscoveryMaxBackoff))
+	if err != nil {
+		t.Fatalf("NewOIDCAuth must not fail synchronously when the issuer is unreachable: %v", err)
+	}
+	if oidcAuth == nil {
+		t.Fatal("enabled OIDC must return a non-nil handler even before discovery completes")
+	}
+
+	loginW := httptest.NewRecorder()
+	oidcAuth.HandleLogin(loginW, httptest.NewRequest(http.MethodGet, "/api/auth/oidc/login", nil))
+	if loginW.Code != http.StatusServiceUnavailable {
+		t.Fatalf("HandleLogin status = %d, want 503 while discovery is unreachable", loginW.Code)
+	}
+
+	callbackW := httptest.NewRecorder()
+	oidcAuth.HandleCallback(callbackW, httptest.NewRequest(http.MethodGet, "/api/auth/oidc/callback?code=x&state=y", nil))
+	if callbackW.Code != http.StatusServiceUnavailable {
+		t.Fatalf("HandleCallback status = %d, want 503 while discovery is unreachable", callbackW.Code)
+	}
+}
+
+// TestOIDCBecomesReadyAfterDiscoverySucceeds covers target behavior 3: once
+// the issuer becomes reachable, the background retry loop discovers it and
+// the handler transitions from failing closed to serving the normal flow,
+// with no restart or reconstruction required.
+func TestOIDCBecomesReadyAfterDiscoverySucceeds(t *testing.T) {
+	fx := &oidcFixture{store: identity.NewStore(testutil.TestDB(t))}
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("generate RSA key: %v", err)
+	}
+	fx.privateKey = privateKey
+	fx.signingKey = privateKey
+	fx.keyID = "oidc-retry-test-key"
+	fx.tokenAudience = testOIDCClientID
+	fx.tokenExpiry = time.Now().Add(5 * time.Minute)
+	fx.includeIDToken = true
+	fx.includeUserID = true
+	// Zero value of the `any` field is nil, not "" -- signIDToken's
+	// `value == ""` fallback to fx.userID only fires when this is
+	// explicitly the empty string (mirrors setupOIDC's fixture init).
+	fx.userIDClaimValue = ""
+
+	var discoverable atomic.Bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		if !discoverable.Load() {
+			http.Error(w, "issuer not yet available", http.StatusServiceUnavailable)
+			return
+		}
+		fx.handleDiscovery(w, r)
+	})
+	mux.HandleFunc("/authorize", func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "authorization is exercised as a redirect only", http.StatusNotImplemented)
+	})
+	mux.HandleFunc("/token", fx.handleToken)
+	mux.HandleFunc("/jwks", fx.handleJWKS)
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	fx.server = server
+	fx.tokenIssuer = server.URL
+
+	cfg := config.OIDCConfig{
+		Enabled: true, IssuerURL: server.URL, ClientID: testOIDCClientID,
+		ClientSecret: testOIDCClientSecret, RedirectURL: testOIDCRedirectURL,
+		UserIDClaim: testOIDCUserIDClaim,
+	}
+	oidcAuth, err := auth.NewOIDCAuth(context.Background(), cfg, fx.store, false, "http://app.example.com",
+		auth.WithOIDCDiscoveryBackoff(testOIDCDiscoveryInitialBackoff, testOIDCDiscoveryMaxBackoff))
+	if err != nil {
+		t.Fatalf("NewOIDCAuth: %v", err)
+	}
+	fx.oidc = oidcAuth
+
+	// The issuer is deliberately unreachable at construction: the handler
+	// must be unready and fail closed rather than partially serve.
+	w := httptest.NewRecorder()
+	oidcAuth.HandleLogin(w, httptest.NewRequest(http.MethodGet, "/api/auth/oidc/login", nil))
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("HandleLogin status = %d, want 503 before discovery succeeds", w.Code)
+	}
+
+	// Now let discovery succeed and wait (bounded) for the background retry
+	// loop to pick it up.
+	discoverable.Store(true)
+	waitOIDCReady(t, oidcAuth)
+
+	user, err := fx.store.CreateOrGetUser(context.Background(), "retry@example.com", "Retry", "google-sub-retry")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	fx.userID = user.ID
+
+	tx := beginOIDCLogin(t, fx)
+	callbackW := httptest.NewRecorder()
+	fx.oidc.HandleCallback(callbackW, callbackRequest(tx, "code=valid-code&state="+url.QueryEscape(tx.state)))
+	if callbackW.Code != http.StatusFound {
+		t.Fatalf("callback status = %d, want 302; body=%s", callbackW.Code, callbackW.Body.String())
+	}
+	session := findCookie(callbackW.Result().Cookies(), auth.SessionCookieName)
+	if session == nil || session.Value == "" {
+		t.Fatal("expected non-empty e2a session cookie once ready")
+	}
+}
+
+// TestOIDCDiscoveryGoroutineExitsOnContextCancel covers target behavior 1's
+// lifecycle requirement: the retry goroutine must stop (not leak) when the
+// ctx passed to NewOIDCAuth is cancelled, e.g. on server shutdown.
+func TestOIDCDiscoveryGoroutineExitsOnContextCancel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+
+	_, err := auth.NewOIDCAuth(ctx, config.OIDCConfig{
+		Enabled: true, IssuerURL: server.URL, ClientID: "client", ClientSecret: "secret",
+		RedirectURL: testOIDCRedirectURL, UserIDClaim: testOIDCUserIDClaim,
+	}, nil, false, "",
+		auth.WithOIDCDiscoveryBackoff(testOIDCDiscoveryInitialBackoff, testOIDCDiscoveryMaxBackoff),
+		auth.WithOIDCDiscoveryDone(done),
+	)
+	if err != nil {
+		t.Fatalf("NewOIDCAuth: %v", err)
+	}
+
+	select {
+	case <-done:
+		t.Fatal("discovery goroutine exited before ctx was cancelled")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("discovery goroutine did not exit within 2s of ctx cancellation")
 	}
 }
 
@@ -483,10 +664,12 @@ func TestOIDCLoginUsesSecureCookiesInProduction(t *testing.T) {
 		ClientSecret: testOIDCClientSecret, RedirectURL: testOIDCRedirectURL,
 		UserIDClaim: testOIDCUserIDClaim,
 	}
-	oidcAuth, err := auth.NewOIDCAuth(context.Background(), cfg, fx.store, true, "https://app.example.com")
+	oidcAuth, err := auth.NewOIDCAuth(context.Background(), cfg, fx.store, true, "https://app.example.com",
+		auth.WithOIDCDiscoveryBackoff(testOIDCDiscoveryInitialBackoff, testOIDCDiscoveryMaxBackoff))
 	if err != nil {
 		t.Fatal(err)
 	}
+	waitOIDCReady(t, oidcAuth)
 	w := httptest.NewRecorder()
 	oidcAuth.HandleLogin(w, httptest.NewRequest(http.MethodGet, "/api/auth/oidc/login", nil))
 	for _, cookie := range w.Result().Cookies() {


### PR DESCRIPTION
Removes the boot-time availability coupling introduced with the OIDC RP (#536): previously, `E2A_OIDC_ENABLED=true` + an unreachable issuer meant `oidc.NewProvider` failed in `NewOIDCAuth` and `main.go` exited fatally — the whole server (mail included) crash-looped until the identity provider came back.

## What changes
- `NewOIDCAuth` no longer performs discovery synchronously (never touches the network). It starts one background goroutine that attempts discovery immediately, then retries with exponential backoff (1s → 60s cap, forever, until ctx cancellation).
- Until discovery succeeds, `/api/auth/oidc/login` and `/callback` **fail closed with 503** ("login temporarily unavailable") — no partial flows, no cookies, no redirects.
- On first success the `oauth2.Config` + ID-token verifier are built exactly as before and published atomically (`atomic.Pointer`, single write) — the post-ready request path is byte-for-byte unchanged.
- Config validation is untouched: malformed issuer/redirect URLs still fail boot. Only the network dependency moved off the boot path.
- Discovery-failure logs are rate-limited (first failure, then ≤1/min).

## Why now
Enabling OIDC in a real deployment otherwise couples e2a's ability to *boot* (VM restart, crash recovery, deploy) to the IdP's availability. Steady-state was already fine (JWKS is fetched lazily); this closes the boot window.

## Testing
- New: constructs cleanly with an unreachable issuer (both handlers 503); becomes ready when the issuer appears (togglable httptest issuer, compressed backoff via a functional option) then completes the full login→callback→session flow; retry goroutine exits on ctx cancel (leak-asserted via a done channel).
- Full `go test -tags integration ./...` green; `internal/auth` also green under `-race`. `go build` + `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D9vWvwP1beGxs94ocitAhU