### PR TITLE
fix(web): simplify agent setup prompts

### DIFF
--- a/docs/superpowers/plans/2026-07-19-canonical-agent-docs.md
+++ b/docs/superpowers/plans/2026-07-19-canonical-agent-docs.md
@@ -209,7 +209,7 @@ Skip this commit only when the inventory proves no reference edits are needed.
 - Regenerate: `web/public/llms.txt`
 - Modify: `plugins/e2a/README.md`
 
-- [ ] **Step 1: Write the failing exact mapping test**
+- [x] **Step 1: Write the failing exact mapping test**
 
 Assert that `AGENT_DOC_MIRRORS` exactly equals:
 
@@ -223,32 +223,32 @@ Assert that `AGENT_DOC_MIRRORS` exactly equals:
 ]
 ```
 
-- [ ] **Step 2: Run the focused test and verify RED**
+- [x] **Step 2: Run the focused test and verify RED**
 
 Run `node --test scripts/sync-agent-docs.test.mjs`.
 
 Expected: the mapping assertion fails because only `e2a.md` and
 `templates.md` are mapped.
 
-- [ ] **Step 3: Expand the mapping and add canonical sources**
+- [x] **Step 3: Expand the mapping and add canonical sources**
 
 Add the three mappings in the exact order above. Relocate the current public
 contents without changing bytes, then run `node scripts/sync-agent-docs.mjs`
 to refresh all five committed mirrors.
 
-- [ ] **Step 4: Update the plugin documentation inventory**
+- [x] **Step 4: Update the plugin documentation inventory**
 
 List `e2a.md`, `auth.md`, `sdk.md`, `templates.md`, and `llms.txt` beneath the
 `docs/` entry in `plugins/e2a/README.md`. Keep stable e2a.dev URLs in all
 user-facing instructions.
 
-- [ ] **Step 5: Verify all canonical, public, and build-output copies**
+- [x] **Step 5: Verify all canonical, public, and build-output copies**
 
 Run the Node tests, `--check`, repository integrity, the full web Jest suite,
 and the web production build. Use `cmp` to verify all five canonical files
 against both `web/public/` and `web/out/`.
 
-- [ ] **Step 6: Commit and update PR #575**
+- [x] **Step 6: Commit and update PR #575**
 
 ```bash
 git add docs/superpowers plugins/e2a/docs plugins/e2a/README.md scripts/sync-agent-docs.mjs scripts/sync-agent-docs.test.mjs web/public

--- a/docs/superpowers/plans/2026-07-19-canonical-agent-docs.md
+++ b/docs/superpowers/plans/2026-07-19-canonical-agent-docs.md
@@ -195,3 +195,63 @@ git commit -m "docs(plugin): align canonical agent doc references"
 ```
 
 Skip this commit only when the inventory proves no reference edits are needed.
+
+### Task 4: Canonicalize the remaining public agent documents
+
+**Files:**
+- Modify: `scripts/sync-agent-docs.test.mjs`
+- Modify: `scripts/sync-agent-docs.mjs`
+- Create: `plugins/e2a/docs/auth.md` from `web/public/auth.md`
+- Create: `plugins/e2a/docs/sdk.md` from `web/public/sdk.md`
+- Create: `plugins/e2a/docs/llms.txt` from `web/public/llms.txt`
+- Regenerate: `web/public/auth.md`
+- Regenerate: `web/public/sdk.md`
+- Regenerate: `web/public/llms.txt`
+- Modify: `plugins/e2a/README.md`
+
+- [ ] **Step 1: Write the failing exact mapping test**
+
+Assert that `AGENT_DOC_MIRRORS` exactly equals:
+
+```js
+[
+  ["plugins/e2a/docs/e2a.md", "web/public/e2a.md"],
+  ["plugins/e2a/docs/auth.md", "web/public/auth.md"],
+  ["plugins/e2a/docs/sdk.md", "web/public/sdk.md"],
+  ["plugins/e2a/docs/templates.md", "web/public/templates.md"],
+  ["plugins/e2a/docs/llms.txt", "web/public/llms.txt"],
+]
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run `node --test scripts/sync-agent-docs.test.mjs`.
+
+Expected: the mapping assertion fails because only `e2a.md` and
+`templates.md` are mapped.
+
+- [ ] **Step 3: Expand the mapping and add canonical sources**
+
+Add the three mappings in the exact order above. Relocate the current public
+contents without changing bytes, then run `node scripts/sync-agent-docs.mjs`
+to refresh all five committed mirrors.
+
+- [ ] **Step 4: Update the plugin documentation inventory**
+
+List `e2a.md`, `auth.md`, `sdk.md`, `templates.md`, and `llms.txt` beneath the
+`docs/` entry in `plugins/e2a/README.md`. Keep stable e2a.dev URLs in all
+user-facing instructions.
+
+- [ ] **Step 5: Verify all canonical, public, and build-output copies**
+
+Run the Node tests, `--check`, repository integrity, the full web Jest suite,
+and the web production build. Use `cmp` to verify all five canonical files
+against both `web/public/` and `web/out/`.
+
+- [ ] **Step 6: Commit and update PR #575**
+
+```bash
+git add docs/superpowers plugins/e2a/docs plugins/e2a/README.md scripts/sync-agent-docs.mjs scripts/sync-agent-docs.test.mjs web/public
+git commit -m "refactor(docs): canonicalize all public agent docs"
+git push
+```

--- a/docs/superpowers/plans/2026-07-19-canonical-agent-docs.md
+++ b/docs/superpowers/plans/2026-07-19-canonical-agent-docs.md
@@ -1,0 +1,197 @@
+# Canonical Agent Docs Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Author e2a's agent Markdown in `plugins/e2a/docs/` while publishing byte-identical, automatically refreshed mirrors from `web/public/` with CI drift enforcement.
+
+**Architecture:** A dependency-free Node module owns an explicit canonical-to-hosted file map and provides sync and non-mutating check modes. The web build invokes sync; the existing repository-integrity job invokes check. Canonical and hosted files remain committed and reviewable.
+
+**Tech Stack:** Node.js 22 ES modules, Node built-in test runner, Bash, npm/Next.js
+
+---
+
+### Task 1: Implement deterministic document synchronization
+
+**Files:**
+- Create: `scripts/sync-agent-docs.test.mjs`
+- Create: `scripts/sync-agent-docs.mjs`
+
+- [ ] **Step 1: Write failing sync behavior tests**
+
+Create tests that import `syncAgentDocs` and `parseArgs`, build canonical and
+mirror fixtures beneath `mkdtemp`, and assert:
+
+```js
+await assert.rejects(
+  syncAgentDocs({ repoRoot, check: true, log: () => {} }),
+  /missing hosted agent doc.*web\/public\/e2a\.md/s,
+);
+await syncAgentDocs({ repoRoot, check: false, log: () => {} });
+assert.deepEqual(
+  await readFile(join(repoRoot, "web/public/e2a.md")),
+  await readFile(join(repoRoot, "plugins/e2a/docs/e2a.md")),
+);
+await assert.doesNotReject(
+  syncAgentDocs({ repoRoot, check: true, log: () => {} }),
+);
+assert.throws(() => parseArgs(["--wat"]), /unknown option: --wat/);
+```
+
+Cover both mapped documents, stale mirrors, a missing canonical source, and
+aggregation of multiple check-mode mismatches.
+
+- [ ] **Step 2: Run the tests and verify RED**
+
+Run `node --test scripts/sync-agent-docs.test.mjs`.
+
+Expected: FAIL because `scripts/sync-agent-docs.mjs` does not exist.
+
+- [ ] **Step 3: Implement the synchronization module and CLI**
+
+Define this explicit map:
+
+```js
+export const AGENT_DOC_MIRRORS = [
+  ["plugins/e2a/docs/e2a.md", "web/public/e2a.md"],
+  ["plugins/e2a/docs/templates.md", "web/public/templates.md"],
+];
+```
+
+Implement `syncAgentDocs({ repoRoot, check, log })` with `readFile`, `mkdir`,
+and `writeFile`. Missing canonical files throw immediately. Check mode collects
+all missing/stale mirrors and throws one error after visiting the full map.
+Write mode creates parent directories and writes only mismatched bytes.
+Implement `parseArgs` accepting only no arguments or `--check`, then invoke the
+function when the module is the CLI entry point and set `process.exitCode = 1`
+on error.
+
+- [ ] **Step 4: Run the tests and verify GREEN**
+
+Run `node --test scripts/sync-agent-docs.test.mjs`.
+
+Expected: all synchronization and error-path tests pass.
+
+- [ ] **Step 5: Commit the synchronization engine**
+
+```bash
+git add scripts/sync-agent-docs.mjs scripts/sync-agent-docs.test.mjs docs/superpowers/plans/2026-07-19-canonical-agent-docs.md
+git commit -m "feat(docs): add agent doc mirror sync"
+```
+
+### Task 2: Relocate canonical docs and wire build/CI enforcement
+
+**Files:**
+- Create: `plugins/e2a/docs/e2a.md` from `web/public/e2a.md`
+- Create: `plugins/e2a/docs/templates.md` from `web/public/templates.md`
+- Regenerate: `web/public/e2a.md`
+- Regenerate: `web/public/templates.md`
+- Modify: `web/package.json`
+- Modify: `scripts/check-repository-text-integrity.sh`
+
+- [ ] **Step 1: Add a failing repository-integrity assertion**
+
+Add this command before the success message in the integrity script:
+
+```bash
+node scripts/sync-agent-docs.mjs --check
+```
+
+Run `scripts/check-repository-text-integrity.sh` before canonical files exist.
+
+Expected: FAIL naming `plugins/e2a/docs/e2a.md` as missing.
+
+- [ ] **Step 2: Move the authoritative content and regenerate mirrors**
+
+Relocate the current files without changing their bytes, then run:
+
+```bash
+node scripts/sync-agent-docs.mjs
+node scripts/sync-agent-docs.mjs --check
+cmp plugins/e2a/docs/e2a.md web/public/e2a.md
+cmp plugins/e2a/docs/templates.md web/public/templates.md
+```
+
+Expected: sync and check exit 0; both `cmp` commands report no differences.
+
+- [ ] **Step 3: Wire the production web build**
+
+Add this script to `web/package.json` before `build`:
+
+```json
+"prebuild": "node ../scripts/sync-agent-docs.mjs"
+```
+
+Do not add dependencies or change the hosted filenames.
+
+- [ ] **Step 4: Verify build and CI entry points**
+
+Run:
+
+```bash
+node --test scripts/sync-agent-docs.test.mjs
+scripts/check-repository-text-integrity.sh
+npm run build
+```
+
+Run the build from `web/`. Expected: all commands exit 0 and the Next static
+export retains `e2a.md` and `templates.md`.
+
+- [ ] **Step 5: Commit canonical ownership and wiring**
+
+```bash
+git add plugins/e2a/docs web/public/e2a.md web/public/templates.md web/package.json scripts/check-repository-text-integrity.sh
+git commit -m "refactor(docs): make plugin agent docs canonical"
+```
+
+### Task 3: Review every affected agent-facing document and reference
+
+**Files:**
+- Review/modify if inaccurate: `plugins/e2a/docs/**`
+- Review/modify if inaccurate: `plugins/e2a/skills/**`
+- Review/modify if inaccurate: `plugins/e2a/README.md`
+- Review/modify if inaccurate: `plugins/e2a/clients/**`
+- Review/modify if inaccurate: `web/public/llms.txt`
+- Review/modify if inaccurate: `web/src/app/(app)/get-started/**`
+- Review/modify if inaccurate: `docs/templates.md`
+
+- [ ] **Step 1: Inventory hosted and repository references**
+
+Run:
+
+```bash
+rg -n -S "e2a\.dev/(e2a|templates)\.md|web/public/(e2a|templates)\.md|plugins/e2a/docs|plugins/e2a/skills" plugins web docs README.md
+```
+
+Classify every hit: user-facing instructions keep stable e2a.dev URLs; source
+ownership and contributor instructions use `plugins/e2a/docs/`.
+
+- [ ] **Step 2: Correct stale ownership references**
+
+Update only references that incorrectly identify `web/public/` as canonical or
+tell maintainers to edit a mirror. Do not replace hosted URLs in end-user or
+agent setup instructions.
+
+- [ ] **Step 3: Re-sync after doc review and verify all agent docs**
+
+Run:
+
+```bash
+node scripts/sync-agent-docs.mjs
+node scripts/sync-agent-docs.mjs --check
+node --test scripts/sync-agent-docs.test.mjs
+scripts/check-repository-text-integrity.sh
+npm test -- --runInBand
+npm run build
+```
+
+Run the npm commands from `web/`. Expected: mirror check, Node tests,
+repository integrity, all Jest suites, and the production build pass.
+
+- [ ] **Step 4: Commit reviewed references if any changed**
+
+```bash
+git add plugins web/public docs web/src/app
+git commit -m "docs(plugin): align canonical agent doc references"
+```
+
+Skip this commit only when the inventory proves no reference edits are needed.

--- a/docs/superpowers/plans/2026-07-19-canonical-agent-docs.md
+++ b/docs/superpowers/plans/2026-07-19-canonical-agent-docs.md
@@ -1,6 +1,6 @@
 # Canonical Agent Docs Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
 
 **Goal:** Author e2a's agent Markdown in `plugins/e2a/docs/` while publishing byte-identical, automatically refreshed mirrors from `web/public/` with CI drift enforcement.
 
@@ -16,7 +16,7 @@
 - Create: `scripts/sync-agent-docs.test.mjs`
 - Create: `scripts/sync-agent-docs.mjs`
 
-- [ ] **Step 1: Write failing sync behavior tests**
+- [x] **Step 1: Write failing sync behavior tests**
 
 Create tests that import `syncAgentDocs` and `parseArgs`, build canonical and
 mirror fixtures beneath `mkdtemp`, and assert:
@@ -40,13 +40,13 @@ assert.throws(() => parseArgs(["--wat"]), /unknown option: --wat/);
 Cover both mapped documents, stale mirrors, a missing canonical source, and
 aggregation of multiple check-mode mismatches.
 
-- [ ] **Step 2: Run the tests and verify RED**
+- [x] **Step 2: Run the tests and verify RED**
 
 Run `node --test scripts/sync-agent-docs.test.mjs`.
 
 Expected: FAIL because `scripts/sync-agent-docs.mjs` does not exist.
 
-- [ ] **Step 3: Implement the synchronization module and CLI**
+- [x] **Step 3: Implement the synchronization module and CLI**
 
 Define this explicit map:
 
@@ -65,13 +65,13 @@ Implement `parseArgs` accepting only no arguments or `--check`, then invoke the
 function when the module is the CLI entry point and set `process.exitCode = 1`
 on error.
 
-- [ ] **Step 4: Run the tests and verify GREEN**
+- [x] **Step 4: Run the tests and verify GREEN**
 
 Run `node --test scripts/sync-agent-docs.test.mjs`.
 
 Expected: all synchronization and error-path tests pass.
 
-- [ ] **Step 5: Commit the synchronization engine**
+- [x] **Step 5: Commit the synchronization engine**
 
 ```bash
 git add scripts/sync-agent-docs.mjs scripts/sync-agent-docs.test.mjs docs/superpowers/plans/2026-07-19-canonical-agent-docs.md
@@ -88,7 +88,7 @@ git commit -m "feat(docs): add agent doc mirror sync"
 - Modify: `web/package.json`
 - Modify: `scripts/check-repository-text-integrity.sh`
 
-- [ ] **Step 1: Add a failing repository-integrity assertion**
+- [x] **Step 1: Add a failing repository-integrity assertion**
 
 Add this command before the success message in the integrity script:
 
@@ -100,7 +100,7 @@ Run `scripts/check-repository-text-integrity.sh` before canonical files exist.
 
 Expected: FAIL naming `plugins/e2a/docs/e2a.md` as missing.
 
-- [ ] **Step 2: Move the authoritative content and regenerate mirrors**
+- [x] **Step 2: Move the authoritative content and regenerate mirrors**
 
 Relocate the current files without changing their bytes, then run:
 
@@ -113,7 +113,7 @@ cmp plugins/e2a/docs/templates.md web/public/templates.md
 
 Expected: sync and check exit 0; both `cmp` commands report no differences.
 
-- [ ] **Step 3: Wire the production web build**
+- [x] **Step 3: Wire the production web build**
 
 Add this script to `web/package.json` before `build`:
 
@@ -123,7 +123,7 @@ Add this script to `web/package.json` before `build`:
 
 Do not add dependencies or change the hosted filenames.
 
-- [ ] **Step 4: Verify build and CI entry points**
+- [x] **Step 4: Verify build and CI entry points**
 
 Run:
 
@@ -136,7 +136,7 @@ npm run build
 Run the build from `web/`. Expected: all commands exit 0 and the Next static
 export retains `e2a.md` and `templates.md`.
 
-- [ ] **Step 5: Commit canonical ownership and wiring**
+- [x] **Step 5: Commit canonical ownership and wiring**
 
 ```bash
 git add plugins/e2a/docs web/public/e2a.md web/public/templates.md web/package.json scripts/check-repository-text-integrity.sh
@@ -154,7 +154,7 @@ git commit -m "refactor(docs): make plugin agent docs canonical"
 - Review/modify if inaccurate: `web/src/app/(app)/get-started/**`
 - Review/modify if inaccurate: `docs/templates.md`
 
-- [ ] **Step 1: Inventory hosted and repository references**
+- [x] **Step 1: Inventory hosted and repository references**
 
 Run:
 
@@ -165,13 +165,13 @@ rg -n -S "e2a\.dev/(e2a|templates)\.md|web/public/(e2a|templates)\.md|plugins/e2
 Classify every hit: user-facing instructions keep stable e2a.dev URLs; source
 ownership and contributor instructions use `plugins/e2a/docs/`.
 
-- [ ] **Step 2: Correct stale ownership references**
+- [x] **Step 2: Correct stale ownership references**
 
 Update only references that incorrectly identify `web/public/` as canonical or
 tell maintainers to edit a mirror. Do not replace hosted URLs in end-user or
 agent setup instructions.
 
-- [ ] **Step 3: Re-sync after doc review and verify all agent docs**
+- [x] **Step 3: Re-sync after doc review and verify all agent docs**
 
 Run:
 
@@ -187,7 +187,7 @@ npm run build
 Run the npm commands from `web/`. Expected: mirror check, Node tests,
 repository integrity, all Jest suites, and the production build pass.
 
-- [ ] **Step 4: Commit reviewed references if any changed**
+- [x] **Step 4: Commit reviewed references if any changed**
 
 ```bash
 git add plugins web/public docs web/src/app

--- a/docs/superpowers/plans/2026-07-19-short-agent-prompts.md
+++ b/docs/superpowers/plans/2026-07-19-short-agent-prompts.md
@@ -1,0 +1,91 @@
+# Short Agent Prompts Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the three long dashboard coding-agent prompts with concise, page-specific MCP prompts.
+
+**Architecture:** Keep `AGENT_PROMPTS` as the single source for card copy. Add exact-value regression assertions before changing the three prompt strings; the shared component and clipboard behavior remain unchanged.
+
+**Tech Stack:** TypeScript, React 19, Jest, Testing Library
+
+---
+
+### Task 1: Shorten the existing agent prompts
+
+**Files:**
+- Modify: `web/src/app/components/AgentPromptCard.test.tsx`
+- Modify: `web/src/app/components/AgentPromptCard.tsx`
+
+- [x] **Step 1: Write the failing exact-copy test**
+
+Replace the broad published-document test with:
+
+```tsx
+test("uses concise page-specific MCP prompts", () => {
+  expect(AGENT_PROMPTS.inboxes.prompt).toBe(
+    "Help me set up an e2a inbox using https://api.e2a.dev/mcp",
+  );
+  expect(AGENT_PROMPTS.domains.prompt).toBe(
+    "Help me connect a custom domain to e2a using https://api.e2a.dev/mcp",
+  );
+  expect(AGENT_PROMPTS.templates.prompt).toBe(
+    "Help me set up e2a email templates using https://api.e2a.dev/mcp",
+  );
+});
+```
+
+- [x] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+npm test -- --runInBand src/app/components/AgentPromptCard.test.tsx
+```
+
+from `web/`.
+
+Expected: FAIL because `AGENT_PROMPTS` still contains the existing long prompts.
+
+- [x] **Step 3: Replace the prompt values**
+
+Set the three `prompt` fields in `AgentPromptCard.tsx` to:
+
+```tsx
+prompt: "Help me set up e2a email templates using https://api.e2a.dev/mcp",
+prompt: "Help me set up an e2a inbox using https://api.e2a.dev/mcp",
+prompt: "Help me connect a custom domain to e2a using https://api.e2a.dev/mcp",
+```
+
+Keep the existing order (`templates`, `inboxes`, `domains`) and do not change
+the blurbs, heading, component markup, or copy interaction.
+
+- [x] **Step 4: Run focused verification and verify GREEN**
+
+Run:
+
+```bash
+npm test -- --runInBand src/app/components/AgentPromptCard.test.tsx
+```
+
+from `web/`.
+
+Expected: PASS for the rendering, exact-copy, and clipboard tests.
+
+- [x] **Step 5: Run the full web test suite**
+
+Run:
+
+```bash
+npm test -- --runInBand
+```
+
+from `web/`.
+
+Expected: all Jest suites pass with zero failures.
+
+- [x] **Step 6: Commit the completed slice**
+
+```bash
+git add web/src/app/components/AgentPromptCard.tsx web/src/app/components/AgentPromptCard.test.tsx docs/superpowers/plans/2026-07-19-short-agent-prompts.md
+git commit -m "fix(web): shorten coding agent prompts"
+```

--- a/docs/superpowers/specs/2026-07-19-canonical-agent-docs-design.md
+++ b/docs/superpowers/specs/2026-07-19-canonical-agent-docs-design.md
@@ -2,18 +2,17 @@
 
 ## Problem Statement
 
-The agent-facing Markdown at `web/public/e2a.md` and
-`web/public/templates.md` is published at stable e2a.dev URLs, but its current
-location makes the website tree appear authoritative. Agent documentation and
+The agent-facing documents published from `web/public/` at stable e2a.dev URLs
+currently make the website tree appear authoritative. Agent documentation and
 skills should instead be authored together in the OSS plugin tree while the
 website continues to publish stable mirrors.
 
 ## Goals
 
-- Make `plugins/e2a/docs/e2a.md` and `plugins/e2a/docs/templates.md` the
-  canonical sources.
-- Preserve `https://e2a.dev/e2a.md` and
-  `https://e2a.dev/templates.md` with byte-identical files in `web/public/`.
+- Make `plugins/e2a/docs/e2a.md`, `auth.md`, `sdk.md`, `templates.md`, and
+  `llms.txt` the canonical agent-document sources.
+- Preserve the corresponding stable `https://e2a.dev/*` URLs with
+  byte-identical files in `web/public/`.
 - Refresh the hosted mirrors automatically before a web production build.
 - Fail the existing repository-integrity CI job when a committed mirror is
   missing or differs from its canonical source.
@@ -26,6 +25,8 @@ website continues to publish stable mirrors.
 - Do not change the published URLs or Markdown content as part of the move.
 - Do not redirect e2a.dev Markdown URLs to GitHub.
 - Do not relocate `plugins/e2a/skills/**`.
+- Do not move website implementation or visual assets such as `scalar.html`,
+  icons, logos, or social images into the plugin docs tree.
 - Do not add runtime fetching or a website-server dependency.
 - Do not address the deferred Domains-card placement or Webhooks prompt card.
 
@@ -40,8 +41,8 @@ modes:
 - `--check` mode performs no writes. It reports each missing or stale mirror
   and exits nonzero if any mismatch exists.
 
-The file mapping is explicit in the script rather than discovered by glob, so
-adding a new public agent document is a deliberate contract change.
+The five-file mapping is explicit in the script rather than discovered by
+glob, so adding a new public agent document is a deliberate contract change.
 
 Add `prebuild` to `web/package.json` so `npm run build` invokes the default sync
 before Next.js static export. Extend

--- a/docs/superpowers/specs/2026-07-19-canonical-agent-docs-design.md
+++ b/docs/superpowers/specs/2026-07-19-canonical-agent-docs-design.md
@@ -1,0 +1,88 @@
+# Canonical Agent Docs and Hosted Mirrors
+
+## Problem Statement
+
+The agent-facing Markdown at `web/public/e2a.md` and
+`web/public/templates.md` is published at stable e2a.dev URLs, but its current
+location makes the website tree appear authoritative. Agent documentation and
+skills should instead be authored together in the OSS plugin tree while the
+website continues to publish stable mirrors.
+
+## Goals
+
+- Make `plugins/e2a/docs/e2a.md` and `plugins/e2a/docs/templates.md` the
+  canonical sources.
+- Preserve `https://e2a.dev/e2a.md` and
+  `https://e2a.dev/templates.md` with byte-identical files in `web/public/`.
+- Refresh the hosted mirrors automatically before a web production build.
+- Fail the existing repository-integrity CI job when a committed mirror is
+  missing or differs from its canonical source.
+- Review all agent-facing docs and skills after the move so references remain
+  accurate and consistently distinguish canonical repository paths from
+  stable hosted URLs.
+
+## Non-goals
+
+- Do not change the published URLs or Markdown content as part of the move.
+- Do not redirect e2a.dev Markdown URLs to GitHub.
+- Do not relocate `plugins/e2a/skills/**`.
+- Do not add runtime fetching or a website-server dependency.
+- Do not address the deferred Domains-card placement or Webhooks prompt card.
+
+## Proposed Design
+
+Add a dependency-free Node script at `scripts/sync-agent-docs.mjs` with two
+modes:
+
+- Default mode copies each canonical file to its matching `web/public/`
+  destination. It creates the destination directory if needed and only writes
+  when bytes differ.
+- `--check` mode performs no writes. It reports each missing or stale mirror
+  and exits nonzero if any mismatch exists.
+
+The file mapping is explicit in the script rather than discovered by glob, so
+adding a new public agent document is a deliberate contract change.
+
+Add `prebuild` to `web/package.json` so `npm run build` invokes the default sync
+before Next.js static export. Extend
+`scripts/check-repository-text-integrity.sh` to invoke the script with
+`--check`; the existing `repository-integrity` CI job will therefore enforce
+mirror freshness without another workflow or dependency installation.
+
+The mirrors remain committed. This keeps changes reviewable, ensures the
+static site has deployable files even outside the npm lifecycle, and lets CI
+detect contributors who edit a mirror instead of its canonical source.
+
+## Failure Handling
+
+- Missing canonical source: both modes fail with a clear path-specific error.
+- Missing hosted mirror: sync mode creates it; check mode fails.
+- Stale hosted mirror: sync mode replaces it atomically enough for a local
+  build; check mode fails without modifying the checkout.
+- Unknown command-line option: fail with usage information rather than
+  silently choosing write mode.
+- Multiple mismatches: check every mapping and report all failures in one run.
+
+## Testing and Verification
+
+Add a Node built-in test suite for the sync logic using a temporary directory.
+Tests cover missing and stale mirrors in check mode, exact copying in sync
+mode, successful verification after sync, missing canonical sources, and
+unknown options. The script will expose testable functions while keeping its
+CLI entry point dependency-free.
+
+Run:
+
+- the sync script in `--check` mode;
+- the repository-integrity script;
+- the sync-script unit tests;
+- the full web Jest suite;
+- the web production build;
+- a repository diff check confirming canonical files and mirrors are
+  byte-identical.
+
+Finally, review `plugins/e2a/docs/**`, `plugins/e2a/skills/**`,
+`plugins/e2a/README.md`, `plugins/e2a/clients/**`, `web/public/llms.txt`, and
+dashboard onboarding references. Hosted URLs should remain in user-facing
+instructions; repository references that describe source ownership should use
+the canonical `plugins/e2a/docs/` paths.

--- a/docs/superpowers/specs/2026-07-19-short-agent-prompts-design.md
+++ b/docs/superpowers/specs/2026-07-19-short-agent-prompts-design.md
@@ -1,0 +1,31 @@
+# Short Agent Prompts
+
+## Goal
+
+Make the dashboard's copyable coding-agent prompts quick to understand and
+paste. The prompt should state the page-specific outcome and the hosted e2a MCP
+endpoint without prescribing a long implementation sequence.
+
+## Scope
+
+Replace only the `prompt` text for the three existing `AgentPromptCard`
+variants:
+
+- Inboxes: `Help me set up an e2a inbox using https://api.e2a.dev/mcp`
+- Domains: `Help me connect a custom domain to e2a using https://api.e2a.dev/mcp`
+- Templates: `Help me set up e2a email templates using https://api.e2a.dev/mcp`
+
+The shared heading, explanatory blurbs, copy interaction, card layout, and MCP
+URL remain unchanged.
+
+## Testing
+
+Update the shared card tests to assert the three exact short prompts and their
+common MCP endpoint. Preserve the clipboard regression test so it continues to
+prove that the displayed prompt is copied verbatim.
+
+## Deferred Work
+
+This slice does not move the Domains card, add a Webhooks prompt card, relocate
+agent documentation, or change the hosted Markdown routes. Those changes can be
+handled separately after the prompt copy is shortened.

--- a/plugins/e2a/README.md
+++ b/plugins/e2a/README.md
@@ -52,7 +52,12 @@ plugins/e2a/
 ├── .cursor-plugin/plugin.json   # Cursor manifest
 ├── .mcp.json                    # the hosted MCP server (single source of truth)
 ├── assets/icon.svg
-├── docs/                        # canonical agent docs mirrored at e2a.dev/*.md
+├── docs/                        # canonical agent docs mirrored at e2a.dev
+│   ├── e2a.md                   # connect guide + first-inbox workflow
+│   ├── auth.md                  # OAuth, API keys, scopes, agent identity
+│   ├── sdk.md                   # SDK + webhook integration guide
+│   ├── templates.md             # email-template guide
+│   └── llms.txt                 # machine-readable hosted docs index
 ├── skills/e2a/SKILL.md          # the "operate-well" skill (surfaces as /e2a)
 ├── skills/agentify/SKILL.md     # deploy the autonomous-repo feedback loop (/agentify)
 ├── skills/tether/SKILL.md       # email handoff for long-running sessions (/tether)

--- a/plugins/e2a/README.md
+++ b/plugins/e2a/README.md
@@ -6,9 +6,9 @@ Streamable HTTP + OAuth 2.1) and an **operate-well skill** so the agent can send
 and receive email, reply in-thread, hold outbound mail for human review (HITL),
 manage agents and custom domains, and work with attachments.
 
-On first use of an MCP tool the agent runs the OAuth flow in your browser — no
-API key to paste. (For headless/CI, an account API key works too; see
-[`clients/`](./clients).)
+After installation, authorize e2a through your client's MCP flow (Claude Code:
+run `/mcp`; Codex CLI: `codex mcp login e2a`) — no API key to paste. For
+headless/CI, an account API key works too; see [`clients/`](./clients).
 
 ## Install
 

--- a/plugins/e2a/README.md
+++ b/plugins/e2a/README.md
@@ -52,6 +52,7 @@ plugins/e2a/
 ├── .cursor-plugin/plugin.json   # Cursor manifest
 ├── .mcp.json                    # the hosted MCP server (single source of truth)
 ├── assets/icon.svg
+├── docs/                        # canonical agent docs mirrored at e2a.dev/*.md
 ├── skills/e2a/SKILL.md          # the "operate-well" skill (surfaces as /e2a)
 ├── skills/agentify/SKILL.md     # deploy the autonomous-repo feedback loop (/agentify)
 ├── skills/tether/SKILL.md       # email handoff for long-running sessions (/tether)
@@ -86,6 +87,13 @@ validates every manifest parses, that the version is identical across all
 Claude/Codex/Cursor manifests, that marketplace `source` paths resolve, and that
 each `SKILL.md` satisfies Claude Code's frontmatter constraints. A change that
 wouldn't load fails CI.
+
+Agent-facing Markdown is authored in `docs/`. Run
+`node ../../scripts/sync-agent-docs.mjs` from this directory (or
+`node scripts/sync-agent-docs.mjs` from the repository root) to refresh its
+committed `web/public/` mirrors. The repository-integrity CI job runs the same
+script with `--check` and fails if a hosted mirror drifts from its canonical
+source.
 
 When bumping the plugin version, update `.claude-plugin/plugin.json` (the source
 of truth) **and** the other manifests + marketplace metadata to match — the

--- a/plugins/e2a/clients/README.md
+++ b/plugins/e2a/clients/README.md
@@ -7,11 +7,11 @@ server (`https://api.e2a.dev/mcp`, Streamable HTTP + OAuth 2.1):
   `mcpServers` + `url` shape).
 - **`vscode.mcp.json`** — VS Code / GitHub Copilot (`.vscode/mcp.json`; note the
   `servers` key + explicit `type`).
-- **`codex.toml`** — OpenAI Codex CLI (`~/.codex/config.toml`; bridges to the
-  hosted HTTP server via the `mcp-remote` stdio shim).
+- **`codex.toml`** — OpenAI Codex CLI (`~/.codex/config.toml`; native remote
+  Streamable HTTP, followed by `codex mcp login e2a`).
 
 Clients that speak remote MCP take the URL directly and run OAuth in the browser;
-stdio-only clients (Codex, Zed) wrap it with `npx -y mcp-remote …`.
+older or stdio-only clients can wrap it with `npx -y mcp-remote …`.
 
 **Full per-client guide** — Zed, Goose, headless API-key auth, and more:
 https://e2a.dev/e2a.md (the "Connecting other MCP clients" section)

--- a/plugins/e2a/clients/codex.toml
+++ b/plugins/e2a/clients/codex.toml
@@ -1,11 +1,9 @@
 # e2a MCP for OpenAI Codex CLI — add to ~/.codex/config.toml
-# Codex speaks stdio MCP, so we bridge to the hosted HTTP server with mcp-remote
-# (it runs the OAuth browser flow on first use — no API key to paste).
+# Then run `codex mcp login e2a` to complete OAuth in the browser.
 [mcp_servers.e2a]
-command = "npx"
-args = ["-y", "mcp-remote", "https://api.e2a.dev/mcp"]
+url = "https://api.e2a.dev/mcp"
 
 # Alternative (headless / CI, no browser): use an account API key instead of OAuth.
 # [mcp_servers.e2a]
-# command = "npx"
-# args = ["-y", "mcp-remote", "https://api.e2a.dev/mcp", "--header", "Authorization: Bearer ${E2A_API_KEY}"]
+# url = "https://api.e2a.dev/mcp"
+# bearer_token_env_var = "E2A_API_KEY"

--- a/plugins/e2a/docs/auth.md
+++ b/plugins/e2a/docs/auth.md
@@ -25,10 +25,10 @@ If any of these is already configured, use it and stop. Do not ask the user for 
 
 ## Credentials
 
-e2a accepts two credential shapes at every `/v1/...` endpoint, dispatched by token prefix:
+Authenticated `/v1/...` endpoints accept two credential shapes, dispatched by token prefix:
 
 - **OAuth access token** (`ate2a_…`, refresh `rte2a_…`) — issued by the e2a OAuth server to a registered client after the user consents in a browser. Use this if you are an MCP client.
-- **API key** (`e2a_acct_…` for account scope, `e2a_agt_…` for a single-agent scope) — issued by the user directly from the dashboard, supplied to your environment out of band. Use this if you are a CLI, script, server-side integration, or direct API consumer.
+- **API key** (`e2a_acct_…` for account scope, `e2a_agt_…` for a single-agent scope) — issued through the dashboard, CLI, or account API and supplied to your environment out of band. Use this if you are a CLI, script, server-side integration, or direct API consumer.
 
 Both are presented as `Authorization: Bearer <credential>`.
 
@@ -66,7 +66,10 @@ If none of the above is set and you genuinely need a key, **do not ask the user 
 
 This keeps the key out of your transcript, out of any logs the user shares, and out of the model provider's training data.
 
-API keys do not expire on their own. Treat a `401` on a previously-working key as revocation: drop it from memory and ask the user to refresh whichever source you read it from.
+API keys may have an optional hard expiry chosen at creation; a key created
+without `expires_at` does not expire automatically. Treat a `401` on a
+previously-working key as expiry or revocation: drop it from memory and ask the
+user to refresh whichever source you read it from.
 
 ### How to use the credential
 
@@ -87,7 +90,9 @@ Idempotency-Key: <UUIDv4>
 }
 ```
 
-The plain-text body field is `text` (required). The HTML alternative is `html` (optional).
+For a literal send, `subject` and the plain-text `text` body are required; the
+HTML alternative is optional. A template send uses `template_id` or
+`template_alias` instead and must omit literal `subject`, `text`, and `html`.
 
 Read the credential from the environment at the moment of the call. Do not copy it into variables you log, do not echo it back to the user, do not include it in commit messages, PR descriptions, error reports, or screenshots. If you are running a shell command, never interpolate the credential inline — reference the environment variable so it does not appear in command history.
 
@@ -125,7 +130,7 @@ The `WWW-Authenticate` header on 401 responses tells you whether the failing cre
 
 This section describes e2a's bet on where agent auth is heading. The bootstrap identity endpoint below is shipped (behind an opt-in signing-key config); third-party ID-JAG consumption and the email-loop claim ceremony are still direction, not shipped surface. If you are implementing today, use the credential paths above for anything beyond the identity bootstrap.
 
-Every e2a agent has a stable, verified email address. The owner proved control of the domain (via DNS records and a verification token), and e2a enforces SPF and DKIM on every inbound message routed to that agent. Equivalently for agents on the shared `agents.e2a.dev` domain, e2a is the authoritative issuer. **The agent's email is not a label — it's an identity claim e2a stands behind.**
+Every e2a agent has a stable, verified email address. The owner proved control of the domain (via DNS records and a verification token), and e2a evaluates SPF, DKIM, and DMARC on every inbound message routed to that agent. Equivalently for agents on the shared `agents.e2a.dev` domain, e2a is the authoritative issuer. **The agent's email is not a label — it's an identity claim e2a stands behind.**
 
 We are building two pieces on top of this:
 

--- a/plugins/e2a/docs/auth.md
+++ b/plugins/e2a/docs/auth.md
@@ -1,0 +1,186 @@
+# auth.md
+
+You are an agent that wants to use e2a — the authenticated email gateway for AI agents. This file describes how to obtain credentials today, how to handle them safely, and where the protocol is going.
+
+Two hosts are relevant:
+
+- **API** — `https://api.e2a.dev` — the resource server you will call (`/v1/...`, MCP at `/mcp`).
+- **Dashboard & docs** — `https://e2a.dev` — where the user manages agents, domains, API keys, and billing, and where these `.md` docs live.
+
+## Current state
+
+e2a already implements the OAuth 2.1 surface that MCP clients depend on: RFC 8414 authorization-server metadata at [`/.well-known/oauth-authorization-server`](https://api.e2a.dev/.well-known/oauth-authorization-server), RFC 7591 Dynamic Client Registration at `/oauth2/register` (rate-limited per IP), `authorization_code` + `refresh_token` grants with PKCE S256, RFC 7009 revocation, and RFC 6750 Bearer challenges on 401s. MCP clients can register and onboard without any human-supplied secret — the user only sees a browser consent screen.
+
+e2a also implements the first pieces of the WorkOS [auth.md](https://github.com/workos/auth.md) autonomous-agent flow: a JSON Web Key Set at `/.well-known/jwks.json`, an `agent_auth` block in the AS metadata, and a bootstrap endpoint (`POST /agent/identity`) that exchanges an agent-scoped API key for a long-lived identity assertion, redeemable at `/oauth2/token` via `grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer` for a short-lived access token. Still missing: an RFC 9728 protected-resource metadata document, ID-JAG assertion intake from third parties, and the email-OTP claim ceremony. See [Agent identity](#agent-identity) for where we're heading — because every e2a agent has an end-to-end-verified email address, e2a is positioned to act as an identity provider in this protocol, and that's the direction we're building.
+
+## Use the existing tooling first
+
+Before you do anything credential-shaped, check whether the user has already wired e2a into your environment. Most of the time they have, and you should not be handling credentials (API keys or OAuth tokens) yourself.
+
+1. **e2a MCP server** — if you are an MCP client (Claude, Cursor, Codex, ChatGPT, etc.), e2a's MCP server is hosted: point your MCP client at the Streamable HTTP endpoint `https://api.e2a.dev/mcp` (OAuth 2.1 — no key pasted) to get inbox, send, reply, agents, domains, and HITL approval as tools. Repository: `https://github.com/tokencanopy/e2a/tree/main/mcp`.
+2. **e2a agent skill** — a guidance document covering inbox patterns, idempotency, HITL approval, attachment handling, and webhook verification. Load it before calling the API directly so you don't relearn the gotchas on the user's dime.
+3. **e2a CLI** — if you are running shell commands, prefer `e2a` over hand-rolled `curl`. It handles auth resolution, retries, and non-interactive flags. Install: `npm i -g @e2a/cli`. Repository: `https://github.com/tokencanopy/e2a/tree/main/cli`.
+
+If any of these is already configured, use it and stop. Do not ask the user for an API key you do not need.
+
+## Credentials
+
+e2a accepts two credential shapes at every `/v1/...` endpoint, dispatched by token prefix:
+
+- **OAuth access token** (`ate2a_…`, refresh `rte2a_…`) — issued by the e2a OAuth server to a registered client after the user consents in a browser. Use this if you are an MCP client.
+- **API key** (`e2a_acct_…` for account scope, `e2a_agt_…` for a single-agent scope) — issued by the user directly from the dashboard, supplied to your environment out of band. Use this if you are a CLI, script, server-side integration, or direct API consumer.
+
+Both are presented as `Authorization: Bearer <credential>`.
+
+### Path A — MCP client via OAuth DCR
+
+If you are an MCP client, you do not need an API key. Run the standard discovery + DCR + authorization-code flow:
+
+1. **Discover** — `GET https://api.e2a.dev/.well-known/oauth-authorization-server`. Read `registration_endpoint`, `authorization_endpoint`, `token_endpoint`. Scope to request: `mcp`.
+2. **Register** — `POST` your client metadata to `registration_endpoint` (RFC 7591). You'll receive a `client_id`. Token endpoint auth method is `none` — you are a public client.
+3. **Authorize** — redirect the user to `authorization_endpoint` with `response_type=code`, your `client_id`, `redirect_uri`, `scope=mcp`, and PKCE S256 (`code_challenge`, `code_challenge_method=S256`). The user logs in to e2a and consents.
+4. **Token exchange** — `POST` `code` + `code_verifier` to `token_endpoint`. You receive `access_token` (prefix `ate2a_…`) and `refresh_token`.
+5. **Use** — present the access token as a bearer; refresh with the refresh token before `expires_in`.
+
+Access tokens carry the user identity that consented to your client; every `/v1/...` call is scoped to that user.
+
+### Path B — Direct API consumer via API key
+
+The user issues an API key from the e2a dashboard and supplies it to you through a secure channel — never by pasting it into chat.
+
+#### How to pick the key up
+
+Look for it in this order. Stop at the first one that exists:
+
+1. `E2A_API_KEY` in your process environment.
+2. A project `.env` file the user has told you to read.
+3. The user's CLI config at `~/.e2a/config.json` (populated via `e2a login`; used automatically when you invoke the `e2a` CLI).
+
+If you're invoking the e2a MCP server, you don't pick the key up at all — the server reads `E2A_API_KEY` from its own environment (set in the MCP client's `env` block) and you call tools through it.
+
+If none of the above is set and you genuinely need a key, **do not ask the user to paste it into the conversation**. Instead, tell them to:
+
+- Create one in the e2a dashboard.
+- Put it in `E2A_API_KEY` in their shell, `.env`, MCP client config, or run `e2a login` to populate `~/.e2a/config.json` — whichever matches how they invoke you.
+- Resume the task once it is set.
+
+This keeps the key out of your transcript, out of any logs the user shares, and out of the model provider's training data.
+
+API keys do not expire on their own. Treat a `401` on a previously-working key as revocation: drop it from memory and ask the user to refresh whichever source you read it from.
+
+### How to use the credential
+
+Whether `access_token` or `api_key`, present it as a bearer token. The message surface is agent-scoped — the sending agent is in the path (URL-encode the `@`), so there is no `from` field in the body. Example send:
+
+```http
+POST /v1/agents/bot%40agents.e2a.dev/messages HTTP/1.1
+Host: api.e2a.dev
+Authorization: Bearer $CREDENTIAL
+Content-Type: application/json
+Idempotency-Key: <UUIDv4>
+
+{
+  "to": ["alice@example.com"],
+  "subject": "Hello from your agent",
+  "text": "Plain-text body. Required.",
+  "html": "<p>Optional HTML alternative.</p>"
+}
+```
+
+The plain-text body field is `text` (required). The HTML alternative is `html` (optional).
+
+Read the credential from the environment at the moment of the call. Do not copy it into variables you log, do not echo it back to the user, do not include it in commit messages, PR descriptions, error reports, or screenshots. If you are running a shell command, never interpolate the credential inline — reference the environment variable so it does not appear in command history.
+
+Set an `Idempotency-Key` (UUIDv4 recommended) per logical operation on side-effectful calls (sends, replies, HITL approve). Reuse the **same** key on transport retries (network failures, timeouts) — the server replays the original response. Same key with a different body returns `422`; a genuinely new operation needs a fresh key.
+
+### HITL: handling 202 pending_review
+
+If the agent's protection config holds outbound mail for review, a send (and `reply`/`forward`) will return **`202 Accepted`** with `status: "pending_review"` instead of dispatching the message:
+
+```json
+{
+  "message_id": "msg_abc123",
+  "status": "pending_review",
+  "approval_expires_at": "2026-05-28T13:00:00Z"
+}
+```
+
+The message is held until a human approves it via the dashboard, CLI, or magic link, or until `approval_expires_at` fires the configured expiration action. Do not retry the send — that would queue a duplicate. To learn the outcome, poll `GET /v1/agents/{address}/messages/{id}`: an approved outbound send becomes `sent`; a rejection becomes `review_rejected`; on TTL expiry it becomes `review_expired_approved` (auto-sent) or `review_expired_rejected` (discarded), per the hold's `on_expiry` action. Or surface the situation to the calling user and stop.
+
+### Errors
+
+| Status | Where | Meaning | What to do |
+| --- | --- | --- | --- |
+| `400` | send, reply | Missing `subject` or `text`; malformed recipient; CRLF in subject. | Fix the payload before retrying. |
+| `401` first use | any | Credential missing, malformed, revoked, or for a different environment. | Ask the user to confirm the value in their `E2A_API_KEY` / config is current and active in the dashboard. MCP clients should restart at discovery. |
+| `401` on previously-working credential | any | Revoked or rotated. | Drop the cached value. API-key consumers re-read from the same source you loaded it from. MCP clients refresh, then re-run the authorization-code flow if refresh fails. |
+| `403` | send, reply | Agent's sending domain is not verified. | Ask the user to register and verify the domain in the dashboard (`POST /v1/domains` then `POST /v1/domains/{domain}/verify`). |
+| `409` | send, reply, approve | An in-flight request with this `Idempotency-Key` is still being processed, or the message is no longer in the expected state. | Wait and re-poll `GET /v1/agents/{address}/messages/{id}`. |
+| `422` | send, reply | `Idempotency-Key` reused with a different body. | Mint a fresh key for the new payload. |
+| `429` | any | Rate limited (60 sends/agent/minute; 200 agent registrations/IP/hour on `/v1/agents`). | Back off; honor `Retry-After` (delay-seconds form). |
+
+The `WWW-Authenticate` header on 401 responses tells you whether the failing credential was an OAuth token (carries RFC 6750 §3.1 `error="invalid_token"` params) or an API key (bare `Bearer realm="e2a"`). MCP clients should branch on this.
+
+## Agent identity
+
+This section describes e2a's bet on where agent auth is heading. The bootstrap identity endpoint below is shipped (behind an opt-in signing-key config); third-party ID-JAG consumption and the email-loop claim ceremony are still direction, not shipped surface. If you are implementing today, use the credential paths above for anything beyond the identity bootstrap.
+
+Every e2a agent has a stable, verified email address. The owner proved control of the domain (via DNS records and a verification token), and e2a enforces SPF and DKIM on every inbound message routed to that agent. Equivalently for agents on the shared `agents.e2a.dev` domain, e2a is the authoritative issuer. **The agent's email is not a label — it's an identity claim e2a stands behind.**
+
+We are building two pieces on top of this:
+
+### e2a as an identity provider
+
+e2a already operates as an OAuth issuer at `https://api.e2a.dev` (see AS metadata above), publishes a JSON Web Key Set at `https://api.e2a.dev/.well-known/jwks.json`, and lets an agent bootstrap a long-lived identity assertion from its API key via `POST /agent/identity`, redeemable for a short-lived access token at `/oauth2/token`. The remaining work is issuing audience-bound [ID-JAG](https://datatracker.ietf.org/doc/draft-ietf-oauth-identity-assertion-authz-grant/) assertions (`urn:ietf:params:oauth:token-type:id-jag`) that a *third-party* service can verify, with:
+
+- `iss` = `https://api.e2a.dev`
+- `sub` = the agent's verified email
+- `email` / `email_verified: true`
+- `aud` = the third-party service the agent is registering with
+- Short `exp` (≤5 minutes), fresh `jti`
+
+Any auth.md-implementing service that adds e2a to its trust list will be able to onboard an e2a agent without an OTP ceremony — the agent's e2a identity vouches for it. e2a's contribution is an identity rooted in a verifiable email address, stable across agent runtimes.
+
+If you operate an agent service and want to accept e2a-issued assertions, watch for `iss: https://api.e2a.dev` to land in the WorkOS reference trust list, or open an issue at `https://github.com/tokencanopy/e2a/issues` to pre-register.
+
+### Email-loop claim completion (proposed)
+
+The WorkOS auth.md OTP ceremony assumes a human reads a 6-digit code back to the agent. For agents that have an e2a inbox, we are prototyping an inbox-driven completion:
+
+1. The third-party service sends a single-click approval mail to the user.
+2. The user clicks "confirm".
+3. The service emails a confirmation to the agent's e2a inbox.
+4. The agent receives the confirmation via WebSocket or webhook and posts to `/agent/auth/claim/complete`.
+
+No code reading, no copy-paste, no transcript leakage. This is uniquely possible for e2a because the agent's mailbox is part of the product. We will publish a flow extension when the prototype is stable; if you are building an auth.md service and want to support this from day one, open an issue at `https://github.com/tokencanopy/e2a/issues`.
+
+## Discovery
+
+What e2a publishes today:
+
+- **RFC 8414 authorization-server metadata** at [`https://api.e2a.dev/.well-known/oauth-authorization-server`](https://api.e2a.dev/.well-known/oauth-authorization-server) — advertises `authorization_endpoint`, `token_endpoint`, `registration_endpoint`, `revocation_endpoint`, supported grants (`authorization_code`, `refresh_token`), PKCE (`S256`), and the RFC 9207 `iss` parameter. Request the `mcp` scope.
+- **RFC 6750 Bearer challenges** on every 401 from `/v1/...` — `WWW-Authenticate: Bearer realm="e2a"` for unknown/missing credentials, plus RFC 6750 §3.1 error params for OAuth-bearer failures.
+
+What e2a publishes for the autonomous-agent path today (gated behind an opt-in signing-key config; see [Agent identity](#agent-identity)):
+
+- An `agent_auth` block in the AS metadata (`identity_endpoint`, `jwks_uri`, and related fields).
+- A JSON Web Key Set at `/.well-known/jwks.json`.
+- A bootstrap endpoint, `POST /agent/identity`, that mints an identity assertion from an agent-scoped API key — e2a's adaptation of the flow (the bootstrap credential is a domain-verified agent-scoped key, not an ownerless self-registration).
+
+What's missing for full auth.md compliance:
+
+- An RFC 9728 protected-resource metadata document at `/.well-known/oauth-protected-resource`, and `resource_metadata="..."` parameter on the WWW-Authenticate challenge so agents can auto-discover it.
+- ID-JAG assertion intake so third-party services can register e2a-issued assertions (the `anonymous` and `identity_assertion + id-jag` flows from the spec).
+- The email-OTP claim ceremony (see [Email-loop claim completion](#email-loop-claim-completion-proposed)).
+
+When these land, this document will be updated and the AS metadata will carry the canonical machine-readable description.
+
+## Revocation
+
+The user revokes API keys in the e2a dashboard. OAuth access tokens are revoked via `POST /oauth2/revoke` (RFC 7009) or by the user disconnecting the client in the dashboard. Either way, you will discover revocation as a `401` on a previously-working credential — drop it and re-acquire from the same source you loaded it from. Once e2a issues ID-JAGs, providers will be able to POST logout tokens to a `revocation_uri` advertised in AS metadata; that is not in scope for the current credential paths.
+
+## References
+
+- WorkOS [auth.md protocol](https://workos.com/auth-md) — the open spec this document follows
+- [github.com/workos/auth.md](https://github.com/workos/auth.md) — reference implementation
+- e2a [OpenAPI contract](https://e2a.dev/openapi.yaml) — full reference for the endpoints above

--- a/plugins/e2a/docs/e2a.md
+++ b/plugins/e2a/docs/e2a.md
@@ -1,0 +1,167 @@
+# e2a.md
+
+You are an AI agent — or the human wiring one up. e2a gives an agent its own
+**real email inbox**: a verified address it can send from, receive to, reply on,
+and (optionally) have its outbound mail held for human approval. This file tells
+you how to connect and what you can do. Read it once, then drive the tools.
+
+The mental model flips the usual one. Pretraining assumes "a human reading their
+inbox." With e2a, **you are the agent and the inbox is yours** —
+`you@agents.e2a.dev`, or `you@your-domain.com` on a domain you verify.
+
+## Service map
+
+> **Two hosts.** These docs (`e2a.md`, `auth.md`, `sdk.md`, `openapi.yaml`,
+> `llms.txt`) live on **`e2a.dev`**. The API and MCP server live on
+> **`api.e2a.dev`** (REST at `https://api.e2a.dev/v1/...`, MCP at
+> `https://api.e2a.dev/mcp`). Don't fetch docs from `api.e2a.dev` or call the
+> API on `e2a.dev`.
+
+Pick the row that fits you:
+
+- **A human is setting this up** → sign up at https://e2a.dev (free, no card) and
+  follow **Get started** in the dashboard — one inbox in ~1 minute on the shared
+  domain.
+- **You're an agent with a terminal** (Claude Code, Cursor, Goose, Windsurf,
+  Zed) → connect over MCP in one command:
+  ```
+  claude mcp add --transport http --scope user e2a https://api.e2a.dev/mcp
+  ```
+  `--scope user` installs e2a globally so it's available in every project (drop
+  it to scope the server to just the current directory). A browser opens for
+  OAuth sign-in — no API key to paste.
+- **You're an agent without a terminal** (Claude Desktop, a chat box) → ask your
+  host to add the MCP connector `https://api.e2a.dev/mcp` and authorize in the
+  browser, then come back here.
+- **You self-register** (autonomous, no human in the loop) → see
+  https://e2a.dev/auth.md for the OAuth 2.1 + Dynamic Client Registration flow
+  (RFC 8414 / 7591, PKCE S256). Register and onboard with no human-supplied
+  secret.
+- **You're not on MCP** → call the REST API via the TypeScript or Python SDK
+  (`@e2a/sdk` / `e2a`): see https://e2a.dev/sdk.md for quick-start + code
+  examples (and a Raw-REST section for other languages). The exhaustive contract
+  is https://e2a.dev/openapi.yaml.
+
+## Connecting other MCP clients
+
+One endpoint — `https://api.e2a.dev/mcp` (Streamable HTTP, OAuth 2.1). Clients
+that speak remote MCP take the URL and run OAuth in the browser; stdio-only
+clients (Codex, Zed) wrap it with `npx -y mcp-remote …`.
+
+- **Cursor / Windsurf / Claude Desktop** — `mcpServers` + `url`:
+  ```json
+  { "mcpServers": { "e2a": { "url": "https://api.e2a.dev/mcp" } } }
+  ```
+- **VS Code (Copilot)** — `.vscode/mcp.json` (note the `servers` key):
+  ```json
+  { "servers": { "e2a": { "type": "http", "url": "https://api.e2a.dev/mcp" } } }
+  ```
+- **OpenAI Codex CLI** — `~/.codex/config.toml`:
+  ```toml
+  [mcp_servers.e2a]
+  command = "npx"
+  args = ["-y", "mcp-remote", "https://api.e2a.dev/mcp"]
+  ```
+- **Headless / CI** (no browser for OAuth) — authenticate with an account API
+  key via a header instead:
+  ```
+  npx -y mcp-remote https://api.e2a.dev/mcp --header "Authorization: Bearer $E2A_API_KEY"
+  ```
+
+Ready-to-paste config files for each client:
+https://github.com/tokencanopy/e2a/tree/main/plugins/e2a/clients
+
+## When to use this
+
+Use e2a whenever your agent needs to **act over email as a first-class
+participant**: reach a person, receive and act on their replies, run a
+support/ops inbox, send notifications, or hold a multi-turn conversation with a
+human counterpart. If you only need to read a human's existing Gmail, that's a
+different tool — e2a is the agent's *own* address.
+
+## What you can do
+
+Over MCP the tools appear as `mcp__e2a__*`. Always call `tools/list` for exact,
+current signatures and treat that as the source of truth. The surface, by area:
+
+- **Inboxes (agents)** — create / list / get / delete an addressable inbox;
+  configure its protection (screening + HITL) posture.
+- **Messages** — `send_message`, `reply_to_message` (keeps the thread),
+  `forward_message`, list + read inbound and outbound, fetch attachments via
+  short-lived download URLs.
+- **Human-in-the-loop** — held outbound drafts and screened inbound sit in
+  **review**; a human (or you, with an account-scoped credential) approves or
+  rejects them. Inbound holds release to the inbox on approval.
+- **Domains** — register a custom domain, read its required DNS records, verify
+  ownership + sending identity.
+- **Webhooks & events** — subscribe to `email.received` and friends; the durable
+  event log is queryable and replayable.
+
+## Conventions
+
+- **You are the agent; the inbox is yours.** Don't model a separate "user
+  mailbox."
+- **Threading.** Answer with `reply_to_message` (not a fresh `send`) to stay in
+  the same conversation. e2a threads on `conversation_id`, but the recipient's
+  mail client (Gmail/Outlook) ignores that and threads on the reply's
+  `In-Reply-To`/`References` headers plus a stable subject — which
+  `reply_to_message` sets. So a fresh `send` (even with the same
+  `conversation_id`, or a changed subject) stays in the same e2a conversation but
+  shows up as a separate thread in the user's inbox.
+- **HITL.** A send may come back `pending_review` instead of `sent`. That's the
+  human-approval gate, not an error; it resolves when a human approves/rejects
+  (or the review TTL expires).
+- **Verification.** Inbound mail carries SPF/DKIM/DMARC results — trust the
+  authenticated sender, not the display name.
+- **Webhook signatures.** Verify inbound webhook deliveries with the per-webhook
+  secret via the SDK's `construct_event` / `constructEvent`.
+
+## Patterns
+
+**Receive → act → reply** (the core loop):
+
+1. An `email.received` webhook (or a `list` of the inbox) gives you a
+   `message_id`.
+2. Read it — subject, body, sender, attachments.
+3. Do the work.
+4. `reply_to_message(message_id, …)` — same thread; the recipient sees a normal
+   reply.
+
+**Send for approval:** call `send_message`; if it returns `pending_review`, a
+human approves it in the dashboard (or you do, with an account-scoped
+credential). Don't retry — it's held, not failed.
+
+## Constraints
+
+- Sending from a **custom domain** needs its sending identity verified in DNS;
+  the shared `agents.e2a.dev` address works immediately.
+- Held messages carry a review **TTL** (default 7 days) after which they
+  auto-resolve.
+- Attachments are fetched via short-lived signed URLs, not streamed inline.
+
+## Anti-patterns
+
+- ❌ Treating `pending_review` as a failure and retrying the send → you'll
+  double-queue. Wait for the human decision.
+- ❌ Starting a new `send_message` to answer an inbound → breaks threading. Use
+  `reply_to_message`.
+- ❌ Trusting the `From` display name → use the authenticated SPF/DKIM identity.
+- ❌ Hardcoding tool signatures from this doc → call `tools/list`; it's
+  authoritative.
+
+## About & pricing
+
+e2a is an authenticated email gateway for AI agents: SMTP relay with SPF/DKIM
+verification, per-agent inboxes, HITL approval, WebSocket + webhook delivery, a
+CLI, and TypeScript/Python SDKs. The core is open source:
+https://github.com/tokencanopy/e2a.
+
+The full agent skill — mental model, gotchas, and worked examples — ships as the
+**e2a** Claude Code plugin (the `e2a` skill + the hosted MCP server). Add it from
+the marketplace at https://github.com/tokencanopy/e2a.
+
+Getting started is free (shared domain, no card). Paid plans for custom domains
+and higher volume aren't enabled yet; when they land they'll be opt-in and the
+open-source code path stays unchanged. See https://e2a.dev for current status.
+
+Machine-readable doc index for agents: https://e2a.dev/llms.txt.

--- a/plugins/e2a/docs/e2a.md
+++ b/plugins/e2a/docs/e2a.md
@@ -28,8 +28,8 @@ Pick the row that fits you:
   claude mcp add --transport http --scope user e2a https://api.e2a.dev/mcp
   ```
   `--scope user` installs e2a globally so it's available in every project (drop
-  it to scope the server to just the current directory). A browser opens for
-  OAuth sign-in — no API key to paste.
+  it to scope the server to just the current directory). Then run `/mcp` in
+  Claude Code and complete OAuth in the browser — no API key to paste.
 - **You're an agent without a terminal** (Claude Desktop, a chat box) → ask your
   host to add the MCP connector `https://api.e2a.dev/mcp` and authorize in the
   browser, then come back here.
@@ -44,9 +44,9 @@ Pick the row that fits you:
 
 ## Connecting other MCP clients
 
-One endpoint — `https://api.e2a.dev/mcp` (Streamable HTTP, OAuth 2.1). Clients
-that speak remote MCP take the URL and run OAuth in the browser; stdio-only
-clients (Codex, Zed) wrap it with `npx -y mcp-remote …`.
+One endpoint — `https://api.e2a.dev/mcp` (Streamable HTTP, OAuth 2.1). Current
+clients that speak remote MCP take the URL directly and run OAuth in the
+browser. Older or stdio-only clients can bridge it with `mcp-remote`.
 
 - **Cursor / Windsurf / Claude Desktop** — `mcpServers` + `url`:
   ```json
@@ -59,13 +59,13 @@ clients (Codex, Zed) wrap it with `npx -y mcp-remote …`.
 - **OpenAI Codex CLI** — `~/.codex/config.toml`:
   ```toml
   [mcp_servers.e2a]
-  command = "npx"
-  args = ["-y", "mcp-remote", "https://api.e2a.dev/mcp"]
+  url = "https://api.e2a.dev/mcp"
   ```
-- **Headless / CI** (no browser for OAuth) — authenticate with an account API
-  key via a header instead:
+  Then run `codex mcp login e2a` to complete OAuth.
+- **Headless Codex / CI** (no browser for OAuth) — add the remote server with
+  an account API key read from the environment:
   ```
-  npx -y mcp-remote https://api.e2a.dev/mcp --header "Authorization: Bearer $E2A_API_KEY"
+  codex mcp add e2a --url https://api.e2a.dev/mcp --bearer-token-env-var E2A_API_KEY
   ```
 
 Ready-to-paste config files for each client:
@@ -137,7 +137,8 @@ credential). Don't retry — it's held, not failed.
   the shared `agents.e2a.dev` address works immediately.
 - Held messages carry a review **TTL** (default 7 days) after which they
   auto-resolve.
-- Attachments are fetched via short-lived signed URLs, not streamed inline.
+- Attachments are fetched via short-lived signed URLs by default; callers may
+  request small attachments inline.
 
 ## Anti-patterns
 
@@ -145,7 +146,8 @@ credential). Don't retry — it's held, not failed.
   double-queue. Wait for the human decision.
 - ❌ Starting a new `send_message` to answer an inbound → breaks threading. Use
   `reply_to_message`.
-- ❌ Trusting the `From` display name → use the authenticated SPF/DKIM identity.
+- ❌ Trusting the `From` display name → use the authenticated SPF/DKIM/DMARC
+  result and `authenticated_from` identity.
 - ❌ Hardcoding tool signatures from this doc → call `tools/list`; it's
   authoritative.
 
@@ -160,8 +162,8 @@ The full agent skill — mental model, gotchas, and worked examples — ships as
 **e2a** Claude Code plugin (the `e2a` skill + the hosted MCP server). Add it from
 the marketplace at https://github.com/tokencanopy/e2a.
 
-Getting started is free (shared domain, no card). Paid plans for custom domains
-and higher volume aren't enabled yet; when they land they'll be opt-in and the
-open-source code path stays unchanged. See https://e2a.dev for current status.
+Getting started is free (shared domain, no card). The hosted service also offers
+opt-in paid plans for higher limits; self-hosting and the open-source code path
+stay unchanged. See https://e2a.dev for current plans.
 
 Machine-readable doc index for agents: https://e2a.dev/llms.txt.

--- a/plugins/e2a/docs/llms.txt
+++ b/plugins/e2a/docs/llms.txt
@@ -21,8 +21,8 @@
 
 ## MCP & plugin
 
-- [Claude Code plugin + skill](https://github.com/tokencanopy/e2a/tree/main/plugins/e2a): The `e2a` plugin bundles the hosted MCP server config and the `e2a` skill (mental model, gotchas, worked examples).
-- MCP endpoint: `https://api.e2a.dev/mcp` (Streamable HTTP, OAuth 2.1). Add with `claude mcp add --transport http --scope user e2a https://api.e2a.dev/mcp` (`--scope user` installs it globally; drop it for current-directory only). Per-client config (Cursor, VS Code, Codex, …) is in [e2a.md](https://e2a.dev/e2a.md).
+- [Agent plugin + skills](https://github.com/tokencanopy/e2a/tree/main/plugins/e2a): The `e2a` plugin bundles the hosted MCP server config and agent guidance for Claude Code, Codex, and Cursor.
+- MCP endpoint: `https://api.e2a.dev/mcp` (Streamable HTTP, OAuth 2.1). Add with `claude mcp add --transport http --scope user e2a https://api.e2a.dev/mcp`, then run `/mcp` to authorize (`--scope user` installs it globally; drop it for current-directory only). Per-client config (Cursor, VS Code, Codex, …) is in [e2a.md](https://e2a.dev/e2a.md).
 
 ## Source
 

--- a/plugins/e2a/docs/llms.txt
+++ b/plugins/e2a/docs/llms.txt
@@ -1,0 +1,29 @@
+# e2a
+
+> e2a is an authenticated email gateway for AI agents: it gives an agent its own
+> verified email inbox to send, receive, reply, and forward, with SPF/DKIM
+> verification and optional human-in-the-loop approval of outbound mail. Connect
+> over a hosted MCP server (OAuth, no API key), the REST API, or the SDKs.
+
+## Start here
+
+- [e2a.md](https://e2a.dev/e2a.md): What e2a is, how an agent connects (one MCP command), and what it can do. Read this first.
+
+## Connecting & auth
+
+- [auth.md](https://e2a.dev/auth.md): Authentication — OAuth 2.1 + Dynamic Client Registration (RFC 8414/7591, PKCE) so an agent can self-register with no human-supplied secret. Bearer API keys (account vs agent scope) also covered.
+
+## API & SDKs
+
+- [sdk.md](https://e2a.dev/sdk.md): TypeScript (`@e2a/sdk`) and Python (`e2a`) quick-start with code examples — send, receive (webhook → fetch → reply), HITL, real-time streaming — plus a Raw-REST section (base URL, auth, conventions) for other languages.
+- [openapi.yaml](https://e2a.dev/openapi.yaml): The full OpenAPI 3.1 contract — every endpoint, field, enum, and error, generated from the live handlers. Authoritative for exact signatures.
+- [templates.md](https://e2a.dev/templates.md): Email templates (beta) — server-rendered reusable emails with `{{variable}}` interpolation, a prebuilt starter catalog (`from_starter`), validation, and send-by-alias. Includes a copy-paste setup prompt for coding agents.
+
+## MCP & plugin
+
+- [Claude Code plugin + skill](https://github.com/tokencanopy/e2a/tree/main/plugins/e2a): The `e2a` plugin bundles the hosted MCP server config and the `e2a` skill (mental model, gotchas, worked examples).
+- MCP endpoint: `https://api.e2a.dev/mcp` (Streamable HTTP, OAuth 2.1). Add with `claude mcp add --transport http --scope user e2a https://api.e2a.dev/mcp` (`--scope user` installs it globally; drop it for current-directory only). Per-client config (Cursor, VS Code, Codex, …) is in [e2a.md](https://e2a.dev/e2a.md).
+
+## Source
+
+- [GitHub: tokencanopy/e2a](https://github.com/tokencanopy/e2a): Open-source core — Go backend, TS/Python SDKs, CLI, MCP server, Next.js dashboard.

--- a/plugins/e2a/docs/sdk.md
+++ b/plugins/e2a/docs/sdk.md
@@ -153,7 +153,7 @@ Conventions:
   pinned to one inbox.
 
 The endpoint map, exact request/response bodies, enums, and error codes are all
-in the OpenAPI 3.1 contract — generated from the live handlers, so it never
-lags: **https://e2a.dev/openapi.yaml**. The core resources are `agents`
+in the OpenAPI 3.1 contract — generated from the live handlers and checked for
+drift in CI: **https://e2a.dev/openapi.yaml**. The core resources are `agents`
 (inboxes), `messages` (send/reply/forward/get/list/attachments), `reviews`
 (HITL), `domains`, `webhooks`, `events`, and `account`.

--- a/plugins/e2a/docs/sdk.md
+++ b/plugins/e2a/docs/sdk.md
@@ -1,0 +1,159 @@
+# sdk.md
+
+Typed clients for the e2a REST API + webhook verification, for when you're
+driving e2a from your own code (a webhook handler, a worker) rather than over
+MCP. Two SDKs, same surface.
+
+- **TypeScript** — `@e2a/sdk` (npm) · [README](https://github.com/tokencanopy/e2a/blob/main/sdks/typescript/README.md)
+- **Python** — `e2a` (PyPI) · [README](https://github.com/tokencanopy/e2a/blob/main/sdks/python/README.md)
+
+Prefer a typed client; if you're calling the REST API raw, see
+[Raw REST](#raw-rest-without-an-sdk) below. The exhaustive contract is
+https://e2a.dev/openapi.yaml, and the auth model (API key vs OAuth) is in
+https://e2a.dev/auth.md.
+
+## Install
+
+```bash
+npm install @e2a/sdk        # TypeScript / Node
+pip install e2a             # Python (async)
+```
+
+## Quick start
+
+### TypeScript
+
+```ts
+import { E2AClient } from "@e2a/sdk";
+
+const client = new E2AClient({ apiKey: process.env.E2A_API_KEY });
+
+// Send (held drafts come back status="pending_review", not an error)
+await client.messages.send("bot@agents.e2a.dev", {
+  to: ["person@example.com"],
+  subject: "Hello from my agent",
+  text: "This was sent by an AI agent via e2a.",
+});
+
+// Reply in-thread to an inbound message
+await client.messages.reply("bot@agents.e2a.dev", messageId, {
+  text: "Thanks — handled.",
+});
+```
+
+### Python
+
+```python
+from e2a.v1 import AsyncE2AClient
+
+async with AsyncE2AClient(api_key=os.environ["E2A_API_KEY"]) as client:
+    await client.messages.send("bot@agents.e2a.dev", {
+        "to": ["person@example.com"],
+        "subject": "Hello from my agent",
+        "text": "This was sent by an AI agent via e2a.",
+    })
+
+    await client.messages.reply("bot@agents.e2a.dev", message_id, {
+        "text": "Thanks — handled.",
+    })
+```
+
+## Receiving mail (webhook → fetch → reply)
+
+The webhook delivery is a metadata trigger; fetch the parsed message by id, then
+reply. Always **verify the signature** first — `construct_event` parses + checks
+the HMAC and throws on a bad/forged/replayed delivery.
+
+### TypeScript
+
+```ts
+import { constructEvent, E2AClient } from "@e2a/sdk";
+
+// in your HTTP handler, with the RAW request body:
+const event = constructEvent(rawBody, req.headers["x-e2a-signature"], WEBHOOK_SECRET);
+if (event.type === "email.received") {
+  const { delivered_to, message_id } = event.data as { delivered_to: string; message_id: string };
+  const msg = await client.messages.get(delivered_to, message_id); // typed: from, subject, parsed.text, attachments
+  // …decide a reply…
+  await client.messages.reply(delivered_to, message_id, { text: "On it." });
+}
+```
+
+### Python
+
+```python
+from e2a.v1 import construct_event, E2AWebhookSignatureError
+
+try:
+    event = construct_event(body, request.headers["X-E2A-Signature"], WEBHOOK_SECRET)
+except E2AWebhookSignatureError:
+    raise HTTPException(401, "bad signature")
+
+if event.type == "email.received":
+    data = event.data
+    inbound = await client.messages.get(data["delivered_to"], data["message_id"])
+    # inbound.from_, inbound.subject, inbound.parsed.text
+    await client.messages.reply(data["delivered_to"], data["message_id"], {"text": "On it."})
+```
+
+A full, runnable example (FastAPI + Google ADK agent, webhook → agent turn →
+reply) is at
+[examples/adk-cloud-webhook](https://github.com/tokencanopy/e2a/tree/main/examples/adk-cloud-webhook).
+
+## Human-in-the-loop
+
+Held messages (outbound drafts + screened inbound) are the account-scoped review
+queue. With an account-scoped key:
+
+```ts
+const held = await client.reviews.list().toArray({ limit: 100 });   // both directions
+await client.reviews.approve(id);                      // outbound: send; inbound: release
+await client.reviews.reject(id, { reason: "spam" });
+```
+
+```python
+held = await client.reviews.list().to_list(limit=100)
+await client.reviews.approve(message_id)
+await client.reviews.reject(message_id, {"reason": "spam"})
+```
+
+## Real-time (no webhook)
+
+Open a notification stream instead of hosting a webhook:
+
+```ts
+for await (const n of client.listen("bot@agents.e2a.dev")) {
+  const msg = await client.messages.get(n.delivered_to, n.message_id);
+}
+```
+
+```python
+async for n in client.listen("bot@agents.e2a.dev"):
+    msg = await client.messages.get(n.delivered_to, n.message_id)
+```
+
+## Raw REST (without an SDK)
+
+No SDK for your language? Call the API directly. Base URL
+`https://api.e2a.dev/v1/...`, JSON in/out, bearer auth on every request:
+
+```
+Authorization: Bearer <e2a_acct_… | e2a_agt_… | OAuth access token>
+```
+
+Conventions:
+
+- **Pagination** — list endpoints take `?cursor=` and return `next_cursor`
+  (null when exhausted).
+- **Errors** — non-2xx bodies are `{"error": {"code", "message", "request_id"}}`;
+  branch on the machine `code`.
+- **Idempotency** — sends (`send`/`reply`/`forward`/approve) accept an
+  `Idempotency-Key` header; a retried call replays instead of double-sending.
+- **Scopes** — account keys manage agents/domains/keys/reviews; agent keys are
+  pinned to one inbox.
+
+The endpoint map, exact request/response bodies, enums, and error codes are all
+in the OpenAPI 3.1 contract — generated from the live handlers, so it never
+lags: **https://e2a.dev/openapi.yaml**. The core resources are `agents`
+(inboxes), `messages` (send/reply/forward/get/list/attachments), `reviews`
+(HITL), `domains`, `webhooks`, `events`, and `account`.

--- a/plugins/e2a/docs/templates.md
+++ b/plugins/e2a/docs/templates.md
@@ -1,0 +1,145 @@
+# Email templates (beta)
+
+> **Beta.** Templates are unstable — their shape may change before they are
+> declared stable. The canonical contract is [`api/openapi.yaml`](https://e2a.dev/openapi.yaml).
+
+## Using a coding agent?
+
+Templates are a one-time setup your coding agent can do headlessly — copy this prompt:
+
+> Read https://e2a.dev/templates.md and set up e2a email
+> templates for this project: browse the starter templates, copy the ones we need via
+> `from_starter`, brand them (accent color is marked `<!-- BRAND: accent -->`), and wire
+> our transactional sends using `template_alias` + `template_data`. Use the e2a MCP tools
+> if connected (otherwise the REST API with `$E2A_API_KEY`), validate each template before
+> wiring it in, and finish by listing the templates you created plus the send code you added.
+
+Templates are reusable email sources — a subject, a plain-text body, and an
+optional HTML body — stored on your account and **rendered server-side at send
+time**. Instead of composing subject/body in your agent code, you reference a
+template by alias and pass the variable values:
+
+- `POST /v1/templates` — create (or copy a starter with `from_starter`)
+- `GET/PATCH/DELETE /v1/templates/{id}` — manage
+- `POST /v1/templates/validate` — dry-run sources + render a preview without persisting
+- `GET /v1/starter-templates` / `GET /v1/starter-templates/{alias}` — the read-only starter catalog
+
+The dashboard surface lives at **/templates** (list, edit, starter gallery, and
+a rendered preview with an HTML/text tab switch and light/dark toggle).
+
+## Syntax
+
+Template syntax is intentionally minimal — variable interpolation only, no
+loops, no conditionals, no partials:
+
+| Form | Behavior |
+|---|---|
+| `{{variable}}` | Interpolates the value. In the **HTML part** the value is HTML-escaped; in the subject and plain-text parts it is inserted as-is. |
+| `{{{variable}}}` | Raw insertion (HTML part): the value is inserted **without escaping**. For pre-rendered HTML fragments only — see the warning below. |
+
+Missing variables render as **empty strings**. Variable names match
+`[A-Za-z_][A-Za-z0-9_.]*` — dot paths into nested objects are supported
+(e.g. `order_id`, `items_html`, `customer.name`).
+
+**Reserved-section note:** anything that is not a `{{…}}` / `{{{…}}}` slot is
+literal template text and is emitted verbatim — including `{` and `}`
+characters in CSS or code samples. Only the double/triple-brace forms are
+interpreted; there is no escape sequence and no other directive syntax.
+
+## Sending with a template
+
+Reference the template by its per-account alias (`template_alias`) or id
+(`template_id`) — mutually exclusive with literal `subject`/`text`/`html` —
+and pass the variables in `template_data`:
+
+```bash
+curl -X POST https://api.e2a.dev/v1/agents/billing-bot%40agents.e2a.dev/messages \
+  -H "Authorization: Bearer $E2A_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": ["customer@example.com"],
+    "template_alias": "receipt",
+    "template_data": {
+      "company_name": "Acme",
+      "support_email": "support@acme.com",
+      "company_address": "100 Main St, San Francisco, CA 94105",
+      "order_id": "ORD-10432",
+      "order_date": "July 2, 2026",
+      "items_html": "<tr><td style=\"padding:8px 0;\">1x Pro plan (monthly)</td><td style=\"padding:8px 0;\" align=\"right\">$29.00</td></tr>",
+      "items_text": "1x Pro plan (monthly) — $29.00",
+      "total": "$29.00",
+      "receipt_url": "https://app.acme.com/receipts/ORD-10432"
+    }
+  }'
+```
+
+Rendering happens **before** any human-in-the-loop review hold, so reviewers
+see the final subject and body.
+
+> **Wire change.** To make room for the template shape, `subject` and `text`
+> moved from schema-required to handler-enforced on
+> `POST /v1/agents/{email}/messages`. A literal send that omits them now
+> returns **400 `invalid_request`** where it previously returned a **422**
+> schema-validation error. Sends that include them are unaffected.
+
+## Starter templates
+
+The deployment ships a read-only catalog of pre-built, ISP-friendly starters
+(responsive tables, dark-mode support, CAN-SPAM footer). `POST /v1/templates`
+with `{"from_starter": "<alias>"}` copies the master **verbatim** into your
+library (name/alias default to the starter's and may be overridden); edit the
+copy freely afterwards.
+
+| Alias | Purpose | Variables |
+|---|---|---|
+| `welcome` | Warm, brief welcome with a single primary CTA | `company_name`, `support_email`, `company_address`, `preheader`*, `recipient_name`, `cta_url`, `cta_label` |
+| `verify-code` | Terse one-time verification code (selectable monospace chip, no button) | `company_name`, `support_email`, `company_address`, `preheader`*, `code`, `expires_minutes` |
+| `password-reset` | Security-neutral password reset with one reset button and expiry notice | `company_name`, `support_email`, `company_address`, `preheader`*, `action_url`, `expires_minutes` |
+| `receipt` | Order receipt with a line-item table and hosted-receipt link | `company_name`, `support_email`, `company_address`, `preheader`*, `order_id`, `order_date`, **`items_html`** (raw), `items_text`, `total`, `receipt_url` |
+| `agent-status` | Numbers-first status report from an automated agent | `company_name`, `support_email`, `company_address`, `preheader`*, `agent_name`, `run_summary`, **`sections_html`** (raw), `sections_text`, `dashboard_url` |
+| `daily-digest` | Recurring daily summary with an unsubscribe link | `company_name`, `support_email`, `company_address`, `preheader`*, `agent_name`, `date`, `headline`, **`sections_html`** (raw), `sections_text`, `dashboard_url`, **`unsubscribe_html`** (raw) |
+| `approval-request` | Human-in-the-loop approval request with Approve/Reject buttons and expiry | `company_name`, `support_email`, `company_address`, `preheader`*, `agent_name`, `action_summary`, **`details_html`** (raw), `details_text`, `approve_url`, `reject_url`, `expires_at` |
+
+\* optional; **bold** = raw (`{{{…}}}`) slot. `GET /v1/starter-templates`
+returns the authoritative per-variable metadata (required/raw flags,
+descriptions, example values usable directly as `template_data`).
+
+## The `{{{items_html}}}` fragment pattern
+
+Several starters take a **raw HTML fragment** for their repeated content (line
+items, report sections, key-value rows). The template owns the surrounding
+table and styling; your agent supplies only the inner rows, pre-rendered with
+inline styles:
+
+```json
+{
+  "items_html": "<tr><td style=\"padding:8px 0;font-family:'Helvetica Neue',Arial,sans-serif;font-size:14px;color:#1F2430;\">1x Pro plan (monthly)</td><td style=\"padding:8px 0;font-size:14px;color:#1F2430;\" align=\"right\">$29.00</td></tr><tr><td style=\"padding:8px 0;font-size:14px;color:#1F2430;\">1x Extra seat</td><td style=\"padding:8px 0;font-size:14px;color:#1F2430;\" align=\"right\">$10.00</td></tr>",
+  "items_text": "1x Pro plan (monthly) — $29.00\n1x Extra seat — $10.00"
+}
+```
+
+> **Warning — escape user content in raw slots.** `{{{…}}}` inserts the value
+> into the HTML part **without escaping**. If any part of the fragment comes
+> from user- or third-party-controlled data (product names, memo lines,
+> addresses), HTML-escape those substrings *before* building the fragment —
+> e.g. a product name `Widget <img src=x onerror=…>` must be inserted as
+> `Widget &lt;img src=x onerror=…&gt;`. Never pass untrusted input to a raw
+> slot; use the escaped `{{…}}` form wherever a plain string will do. Always
+> fill the matching `*_text` variable too, so the plain-text part carries the
+> same content.
+
+## Approval-request URLs: **require a confirmation page**
+
+**`approve_url` and `reject_url` MUST land on a page that requires an explicit
+human click to take effect — never on a state-changing GET.** Corporate
+mail-security scanners (Safe Links, spam filters, previewers) **fetch every
+link in an email** before or after delivery. If your approve/reject URL
+mutates state directly on GET, a scanner will silently approve or reject the
+action with no human involved. Serve a confirmation page at those URLs and
+perform the actual approve/reject on a POST from that page's button. (One-time
+tokens alone do not save you — the scanner's GET consumes the token.)
+
+## See also
+
+- [`docs/api.md`](https://github.com/tokencanopy/e2a/blob/main/docs/api.md) — REST surface overview and conventions
+- [`api/openapi.yaml`](https://e2a.dev/openapi.yaml) — the canonical machine-readable contract

--- a/plugins/e2a/docs/templates.md
+++ b/plugins/e2a/docs/templates.md
@@ -5,14 +5,9 @@
 
 ## Using a coding agent?
 
-Templates are a one-time setup your coding agent can do headlessly — copy this prompt:
+Copy this prompt into your coding agent:
 
-> Read https://e2a.dev/templates.md and set up e2a email
-> templates for this project: browse the starter templates, copy the ones we need via
-> `from_starter`, brand them (accent color is marked `<!-- BRAND: accent -->`), and wire
-> our transactional sends using `template_alias` + `template_data`. Use the e2a MCP tools
-> if connected (otherwise the REST API with `$E2A_API_KEY`), validate each template before
-> wiring it in, and finish by listing the templates you created plus the send code you added.
+> Help me set up e2a email templates using https://api.e2a.dev/mcp
 
 Templates are reusable email sources — a subject, a plain-text body, and an
 optional HTML body — stored on your account and **rendered server-side at send

--- a/plugins/e2a/skills/e2a/SKILL.md
+++ b/plugins/e2a/skills/e2a/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: e2a
 description: Use when operating e2a (email for AI agents) over its MCP tools — sending or receiving email, replying in-thread, handling the human-in-the-loop review hold (pending_review), managing agents and custom domains, or working with attachments — OR when integrating e2a into your own software/service (the developer email-API use case: API keys, SDKs, webhooks). With e2a YOU are the agent and the inbox IS the agent (not a human reading their mail). Covers send_message vs reply_to_message threading, multi-agent disambiguation, the custom-domain DNS flow, the protection (screening + review) config, programmatic integration, and common gotchas.
-version: 16
+version: 17
 ---
 
 # Using e2a
 
-<!-- version: 16 -->
+<!-- version: 17 -->
 
 e2a is an authenticated email gateway for AI agents. It gives an agent a real email address (`agent@agents.e2a.dev` or `agent@your-domain.com`), verifies sender identity (SPF/DKIM), threads conversations, and optionally holds outbound mail for human review.
 
@@ -33,9 +33,14 @@ Seven load-bearing facts. Internalize these before you start calling tools.
 
 3. **`pending_review` is success, not failure.** When the agent's protection config holds outbound mail, a send returns `{ status: "pending_review", message_id: "msg_..." }`. The message was accepted by the server and is being held for a human to review. Do NOT retry. Do NOT report this as an error to the user. Tell them the draft was queued for review, and (if asked) check on it via the pending tools.
 
-4. **Multi-agent accounts need `agent_email` per call.** If the account owns exactly one agent (the common case), tools auto-resolve to it — `whoami` is the cheapest way to confirm. If the account owns more than one, you'll get "agentEmail required." The fix is to enumerate once (`list_agents`), then pass `agent_email` explicitly to subsequent calls. Don't guess; don't pick at random; don't ask the user to pick if context already makes the choice obvious (e.g. they said "my support inbox").
+4. **Account-scoped sessions need an explicit inbox.** `whoami` tells you the
+credential scope and returns `agent_email` only for an agent-scoped credential.
+An account-scoped MCP session never guesses a default, even when the account has
+one inbox: enumerate once with `list_agents`, then pass the tool's `email` field
+explicitly. Don't guess or pick at random; use the user's stated context when it
+clearly identifies an inbox.
 
-5. **Most users don't need a custom domain — default to the shared one.** Every account can create agents on the shared `agents.e2a.dev` domain with zero DNS setup: `create_agent` with just a local part (e.g. `support-bot`) yields `support-bot@agents.e2a.dev`, live immediately. This is the right default for onboarding and for anyone who doesn't already **own** a domain. Only reach for a custom domain when the user explicitly owns a domain and wants branded addresses — if they don't own one, stay on `agents.e2a.dev` and skip the domain flow entirely. Don't send a user who just wants to get started down the DNS dance.
+5. **Most users don't need a custom domain — default to the shared one.** Every account can create agents on the shared `agents.e2a.dev` domain with zero DNS setup: call `create_agent` with the full address (for example, `support-bot@agents.e2a.dev`), and it is live immediately. This is the right default for onboarding and for anyone who doesn't already **own** a domain. Only reach for a custom domain when the user explicitly owns a domain and wants branded addresses — if they don't own one, stay on `agents.e2a.dev` and skip the domain flow entirely. Don't send a user who just wants to get started down the DNS dance.
 
 6. **Custom domains are a two-step async dance.** `register_domain` returns DNS records (MX + TXT) to publish — it does NOT make the domain live. The user (or a DNS-provider MCP, if one is loaded) must add those records out-of-band, wait for DNS propagation (minutes to hours), then `verify_domain`. Verification is idempotent and safe to retry. Until verification succeeds, the domain cannot send or receive mail. Don't promise the user their domain works the moment registration returns.
 
@@ -47,10 +52,11 @@ Seven load-bearing facts. Internalize these before you start calling tools.
 
 Before driving any e2a task or harness, check whether this is a **new/unconfigured user** and, if so, get them to a working setup instead of failing partway. One cheap probe answers it: call `whoami`.
 
-- **`whoami` errors with auth/connection failure** → not connected over MCP yet. Point the user at connecting the e2a plugin and completing OAuth: open **https://e2a.dev/e2a.md** (the connect guide) and, in Claude Code, run `/plugin` to authenticate. Interactive auth is theirs to complete — hand them the step, don't try to drive it. Once connected, continue.
-- **`whoami` succeeds but the account has no agent** (or `list_agents` is empty) → connected, but no inbox exists. Create their first one on the shared domain with `create_agent` (local part only → `name@agents.e2a.dev`, live immediately — see mental-model fact #5). No custom domain, no DNS.
-- **`whoami` returns an agent** → already set up; proceed straight to the task.
-
+- **`whoami` errors with auth/connection failure** → not connected over MCP yet. Point the user at connecting the e2a plugin and completing OAuth: open **https://e2a.dev/e2a.md** (the connect guide) and, in Claude Code, run `/mcp` to authenticate. Interactive auth is theirs to complete — hand them the step, don't try to drive it. Once connected, continue.
+- **`whoami` succeeds** → inspect its `scope`. An agent-scoped credential includes
+  its bound `agent_email`. For account scope, call `list_agents`; if it is empty,
+  create the first shared-domain inbox with the full address
+  `name@agents.e2a.dev` (see mental-model fact #5). No custom domain, no DNS.
 The through-line: for a first-time user, **help them stand up a functional e2a setup first** (connect → create a shared-domain inbox), then run the harness — rather than assuming credentials and erroring. Default new inboxes to `agents.e2a.dev`; only involve a custom domain if the user owns one and asks for it.
 
 ### Triage the inbox
@@ -88,11 +94,14 @@ The flow is copy once, send many:
 
 ```json
 { "to": ["owner@acme.com"], "template_alias": "run-report",
-  "template_data": { "agent_name": "deploy-bot", "status": "success",
-                     "summary": "3 services deployed", "sections_html": "<ul><li>api: ok</li></ul>" } }
+  "template_data": { "company_name": "Acme", "support_email": "ops@acme.com",
+    "company_address": "100 Main St, San Francisco, CA 94105",
+    "agent_name": "deploy-bot", "run_summary": "3 services deployed, 0 failed",
+    "sections_html": "<p>api: ok</p>", "sections_text": "api: ok",
+    "dashboard_url": "https://app.acme.com/runs/123" } }
 ```
 
-Syntax is a flat Mustache subset: `{{var}}` (HTML-escaped in the HTML part), `{{{var}}}` raw, dot paths into nested data — no loops or conditionals. **Missing variables render as empty strings, silently.** Preview with `validate_template` (its `suggestedData` names every variable the source references) instead of discovering blanks in sent mail. List/table content goes through raw `{{{…_html}}}` fragment slots: you build the HTML fragment, and you must HTML-escape any user-supplied text inside it — raw slots bypass escaping.
+Syntax is a small Mustache-like subset: `{{var}}` (HTML-escaped in the HTML part), `{{{var}}}` raw, and dot paths into nested data — no loops or conditionals. **Missing variables render as empty strings, silently.** Preview with `validate_template` (its `suggestedData` names every variable the source references) instead of discovering blanks in sent mail. List/table content goes through raw `{{{…_html}}}` fragment slots: you build the HTML fragment, and you must HTML-escape any user-supplied text inside it — raw slots bypass escaping.
 
 **Approval links must be confirmation pages.** For `approval-request`, `approve_url` / `reject_url` must point to pages that require an explicit human click to act — never state-changing GET endpoints. Email security scanners prefetch every link in a message, so a GET-to-approve URL gets "approved" by a robot before the human ever opens the mail.
 
@@ -174,7 +183,7 @@ The full, current integration code — SDK install, send / reply / parse, webhoo
 - **Destructive ops require `confirm: true`.** `delete_agent` and `delete_domain` refuse without explicit confirmation. This is a guard against hallucinated deletes; pass it only when the user has clearly asked for the destructive action.
 - **`approve_review` with `attachments: []` strips attachments.** An omitted `attachments` field keeps the original draft's attachments; an explicit empty array removes them. Same shape applies to other override fields — omit to keep, specify (including empty) to override.
 - **Held bodies are scrubbed after the terminal transition.** `get_review` returns the full body only while status is `pending_review`. Once it reaches a terminal state (`sent`, `review_rejected`, `review_expired_approved`, `review_expired_rejected`), body columns are wiped server-side for compliance.
-- **Token expiry on OAuth flows.** The hosted MCP runs over OAuth; if a tool starts erroring with auth failures across multiple calls, the refresh token has likely expired — re-auth via `/plugin` in Claude Code.
+- **Token expiry on OAuth flows.** The hosted MCP runs over OAuth; if a tool starts erroring with auth failures across multiple calls, the token may have expired or been revoked — re-auth via `/mcp` in Claude Code.
 
 ## When NOT to use a tool
 

--- a/scripts/check-repository-text-integrity.sh
+++ b/scripts/check-repository-text-integrity.sh
@@ -18,4 +18,6 @@ node -e '
   }
 ' package-lock.json web/package-lock.json
 
+node scripts/sync-agent-docs.mjs --check
+
 echo "repository text integrity checks passed"

--- a/scripts/sync-agent-docs.mjs
+++ b/scripts/sync-agent-docs.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const AGENT_DOC_MIRRORS = [
+  ["plugins/e2a/docs/e2a.md", "web/public/e2a.md"],
+  ["plugins/e2a/docs/templates.md", "web/public/templates.md"],
+];
+
+const usage = "usage: node scripts/sync-agent-docs.mjs [--check]";
+
+export function parseArgs(args) {
+  if (args.length === 0) return { check: false };
+  if (args.length === 1 && args[0] === "--check") return { check: true };
+  if (args.length === 1) throw new Error(`unknown option: ${args[0]}\n${usage}`);
+  throw new Error(usage);
+}
+
+export async function syncAgentDocs({ repoRoot, check, log = console.log }) {
+  const mismatches = [];
+
+  for (const [source, target] of AGENT_DOC_MIRRORS) {
+    let canonical;
+    try {
+      canonical = await readFile(join(repoRoot, source));
+    } catch (error) {
+      if (error?.code === "ENOENT") {
+        throw new Error(`missing canonical agent doc: ${source}`);
+      }
+      throw error;
+    }
+
+    let hosted;
+    try {
+      hosted = await readFile(join(repoRoot, target));
+    } catch (error) {
+      if (error?.code !== "ENOENT") throw error;
+    }
+
+    if (hosted?.equals(canonical)) continue;
+
+    if (check) {
+      mismatches.push(
+        `${hosted === undefined ? "missing" : "stale"} hosted agent doc: ${target}`,
+      );
+      continue;
+    }
+
+    const targetPath = join(repoRoot, target);
+    await mkdir(dirname(targetPath), { recursive: true });
+    await writeFile(targetPath, canonical);
+    log(`synced ${source} -> ${target}`);
+  }
+
+  if (mismatches.length > 0) {
+    throw new Error(mismatches.join("\n"));
+  }
+}
+
+const scriptPath = fileURLToPath(import.meta.url);
+const isMain = process.argv[1] && resolve(process.argv[1]) === scriptPath;
+
+if (isMain) {
+  try {
+    const options = parseArgs(process.argv.slice(2));
+    const repoRoot = resolve(dirname(scriptPath), "..");
+    await syncAgentDocs({ repoRoot, ...options });
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/sync-agent-docs.mjs
+++ b/scripts/sync-agent-docs.mjs
@@ -6,7 +6,10 @@ import { fileURLToPath } from "node:url";
 
 export const AGENT_DOC_MIRRORS = [
   ["plugins/e2a/docs/e2a.md", "web/public/e2a.md"],
+  ["plugins/e2a/docs/auth.md", "web/public/auth.md"],
+  ["plugins/e2a/docs/sdk.md", "web/public/sdk.md"],
   ["plugins/e2a/docs/templates.md", "web/public/templates.md"],
+  ["plugins/e2a/docs/llms.txt", "web/public/llms.txt"],
 ];
 
 const usage = "usage: node scripts/sync-agent-docs.mjs [--check]";

--- a/scripts/sync-agent-docs.test.mjs
+++ b/scripts/sync-agent-docs.test.mjs
@@ -1,0 +1,86 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, test } from "node:test";
+
+import {
+  AGENT_DOC_MIRRORS,
+  parseArgs,
+  syncAgentDocs,
+} from "./sync-agent-docs.mjs";
+
+const roots = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true })));
+});
+
+async function fixture() {
+  const repoRoot = await mkdtemp(join(tmpdir(), "e2a-agent-docs-"));
+  roots.push(repoRoot);
+  for (const [index, [source]] of AGENT_DOC_MIRRORS.entries()) {
+    const sourcePath = join(repoRoot, source);
+    await mkdir(join(sourcePath, ".."), { recursive: true });
+    await writeFile(sourcePath, `canonical-${index}\n`);
+  }
+  return repoRoot;
+}
+
+test("sync creates byte-identical hosted mirrors and check accepts them", async () => {
+  const repoRoot = await fixture();
+
+  await syncAgentDocs({ repoRoot, check: false, log: () => {} });
+
+  for (const [source, target] of AGENT_DOC_MIRRORS) {
+    assert.deepEqual(
+      await readFile(join(repoRoot, target)),
+      await readFile(join(repoRoot, source)),
+    );
+  }
+  await assert.doesNotReject(
+    syncAgentDocs({ repoRoot, check: true, log: () => {} }),
+  );
+});
+
+test("check reports every missing or stale hosted mirror without writing", async () => {
+  const repoRoot = await fixture();
+  const [, staleTarget] = AGENT_DOC_MIRRORS[1];
+  await mkdir(join(repoRoot, staleTarget, ".."), { recursive: true });
+  await writeFile(join(repoRoot, staleTarget), "stale\n");
+
+  await assert.rejects(
+    syncAgentDocs({ repoRoot, check: true, log: () => {} }),
+    (error) => {
+      assert.match(error.message, /missing hosted agent doc: web\/public\/e2a\.md/);
+      assert.match(error.message, /stale hosted agent doc: web\/public\/templates\.md/);
+      return true;
+    },
+  );
+  const missingState = await readFile(join(repoRoot, AGENT_DOC_MIRRORS[0][1])).then(
+    () => "present",
+    () => "missing",
+  );
+  assert.equal(missingState, "missing");
+  assert.equal(await readFile(join(repoRoot, staleTarget), "utf8"), "stale\n");
+});
+
+test("sync fails clearly when a canonical source is missing", async () => {
+  const repoRoot = await fixture();
+  await rm(join(repoRoot, AGENT_DOC_MIRRORS[0][0]));
+
+  await assert.rejects(
+    syncAgentDocs({ repoRoot, check: false, log: () => {} }),
+    /missing canonical agent doc: plugins\/e2a\/docs\/e2a\.md/,
+  );
+});
+
+test("parseArgs accepts check mode and rejects unknown options", () => {
+  assert.deepEqual(parseArgs([]), { check: false });
+  assert.deepEqual(parseArgs(["--check"]), { check: true });
+  assert.throws(() => parseArgs(["--wat"]), /unknown option: --wat/);
+  assert.throws(
+    () => parseArgs(["--check", "extra"]),
+    /usage: node scripts\/sync-agent-docs\.mjs \[--check\]/,
+  );
+});

--- a/scripts/sync-agent-docs.test.mjs
+++ b/scripts/sync-agent-docs.test.mjs
@@ -27,6 +27,16 @@ async function fixture() {
   return repoRoot;
 }
 
+test("maps every public agent document to its canonical plugin source", () => {
+  assert.deepEqual(AGENT_DOC_MIRRORS, [
+    ["plugins/e2a/docs/e2a.md", "web/public/e2a.md"],
+    ["plugins/e2a/docs/auth.md", "web/public/auth.md"],
+    ["plugins/e2a/docs/sdk.md", "web/public/sdk.md"],
+    ["plugins/e2a/docs/templates.md", "web/public/templates.md"],
+    ["plugins/e2a/docs/llms.txt", "web/public/llms.txt"],
+  ]);
+});
+
 test("sync creates byte-identical hosted mirrors and check accepts them", async () => {
   const repoRoot = await fixture();
 
@@ -45,7 +55,9 @@ test("sync creates byte-identical hosted mirrors and check accepts them", async 
 
 test("check reports every missing or stale hosted mirror without writing", async () => {
   const repoRoot = await fixture();
-  const [, staleTarget] = AGENT_DOC_MIRRORS[1];
+  const [, staleTarget] = AGENT_DOC_MIRRORS.find(
+    ([, target]) => target === "web/public/templates.md",
+  );
   await mkdir(join(repoRoot, staleTarget, ".."), { recursive: true });
   await writeFile(join(repoRoot, staleTarget), "stale\n");
 

--- a/web/package.json
+++ b/web/package.json
@@ -5,6 +5,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "dev": "next dev",
+    "prebuild": "node ../scripts/sync-agent-docs.mjs",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",

--- a/web/public/auth.md
+++ b/web/public/auth.md
@@ -25,10 +25,10 @@ If any of these is already configured, use it and stop. Do not ask the user for 
 
 ## Credentials
 
-e2a accepts two credential shapes at every `/v1/...` endpoint, dispatched by token prefix:
+Authenticated `/v1/...` endpoints accept two credential shapes, dispatched by token prefix:
 
 - **OAuth access token** (`ate2a_…`, refresh `rte2a_…`) — issued by the e2a OAuth server to a registered client after the user consents in a browser. Use this if you are an MCP client.
-- **API key** (`e2a_acct_…` for account scope, `e2a_agt_…` for a single-agent scope) — issued by the user directly from the dashboard, supplied to your environment out of band. Use this if you are a CLI, script, server-side integration, or direct API consumer.
+- **API key** (`e2a_acct_…` for account scope, `e2a_agt_…` for a single-agent scope) — issued through the dashboard, CLI, or account API and supplied to your environment out of band. Use this if you are a CLI, script, server-side integration, or direct API consumer.
 
 Both are presented as `Authorization: Bearer <credential>`.
 
@@ -66,7 +66,10 @@ If none of the above is set and you genuinely need a key, **do not ask the user 
 
 This keeps the key out of your transcript, out of any logs the user shares, and out of the model provider's training data.
 
-API keys do not expire on their own. Treat a `401` on a previously-working key as revocation: drop it from memory and ask the user to refresh whichever source you read it from.
+API keys may have an optional hard expiry chosen at creation; a key created
+without `expires_at` does not expire automatically. Treat a `401` on a
+previously-working key as expiry or revocation: drop it from memory and ask the
+user to refresh whichever source you read it from.
 
 ### How to use the credential
 
@@ -87,7 +90,9 @@ Idempotency-Key: <UUIDv4>
 }
 ```
 
-The plain-text body field is `text` (required). The HTML alternative is `html` (optional).
+For a literal send, `subject` and the plain-text `text` body are required; the
+HTML alternative is optional. A template send uses `template_id` or
+`template_alias` instead and must omit literal `subject`, `text`, and `html`.
 
 Read the credential from the environment at the moment of the call. Do not copy it into variables you log, do not echo it back to the user, do not include it in commit messages, PR descriptions, error reports, or screenshots. If you are running a shell command, never interpolate the credential inline — reference the environment variable so it does not appear in command history.
 
@@ -125,7 +130,7 @@ The `WWW-Authenticate` header on 401 responses tells you whether the failing cre
 
 This section describes e2a's bet on where agent auth is heading. The bootstrap identity endpoint below is shipped (behind an opt-in signing-key config); third-party ID-JAG consumption and the email-loop claim ceremony are still direction, not shipped surface. If you are implementing today, use the credential paths above for anything beyond the identity bootstrap.
 
-Every e2a agent has a stable, verified email address. The owner proved control of the domain (via DNS records and a verification token), and e2a enforces SPF and DKIM on every inbound message routed to that agent. Equivalently for agents on the shared `agents.e2a.dev` domain, e2a is the authoritative issuer. **The agent's email is not a label — it's an identity claim e2a stands behind.**
+Every e2a agent has a stable, verified email address. The owner proved control of the domain (via DNS records and a verification token), and e2a evaluates SPF, DKIM, and DMARC on every inbound message routed to that agent. Equivalently for agents on the shared `agents.e2a.dev` domain, e2a is the authoritative issuer. **The agent's email is not a label — it's an identity claim e2a stands behind.**
 
 We are building two pieces on top of this:
 

--- a/web/public/e2a.md
+++ b/web/public/e2a.md
@@ -28,8 +28,8 @@ Pick the row that fits you:
   claude mcp add --transport http --scope user e2a https://api.e2a.dev/mcp
   ```
   `--scope user` installs e2a globally so it's available in every project (drop
-  it to scope the server to just the current directory). A browser opens for
-  OAuth sign-in — no API key to paste.
+  it to scope the server to just the current directory). Then run `/mcp` in
+  Claude Code and complete OAuth in the browser — no API key to paste.
 - **You're an agent without a terminal** (Claude Desktop, a chat box) → ask your
   host to add the MCP connector `https://api.e2a.dev/mcp` and authorize in the
   browser, then come back here.
@@ -44,9 +44,9 @@ Pick the row that fits you:
 
 ## Connecting other MCP clients
 
-One endpoint — `https://api.e2a.dev/mcp` (Streamable HTTP, OAuth 2.1). Clients
-that speak remote MCP take the URL and run OAuth in the browser; stdio-only
-clients (Codex, Zed) wrap it with `npx -y mcp-remote …`.
+One endpoint — `https://api.e2a.dev/mcp` (Streamable HTTP, OAuth 2.1). Current
+clients that speak remote MCP take the URL directly and run OAuth in the
+browser. Older or stdio-only clients can bridge it with `mcp-remote`.
 
 - **Cursor / Windsurf / Claude Desktop** — `mcpServers` + `url`:
   ```json
@@ -59,13 +59,13 @@ clients (Codex, Zed) wrap it with `npx -y mcp-remote …`.
 - **OpenAI Codex CLI** — `~/.codex/config.toml`:
   ```toml
   [mcp_servers.e2a]
-  command = "npx"
-  args = ["-y", "mcp-remote", "https://api.e2a.dev/mcp"]
+  url = "https://api.e2a.dev/mcp"
   ```
-- **Headless / CI** (no browser for OAuth) — authenticate with an account API
-  key via a header instead:
+  Then run `codex mcp login e2a` to complete OAuth.
+- **Headless Codex / CI** (no browser for OAuth) — add the remote server with
+  an account API key read from the environment:
   ```
-  npx -y mcp-remote https://api.e2a.dev/mcp --header "Authorization: Bearer $E2A_API_KEY"
+  codex mcp add e2a --url https://api.e2a.dev/mcp --bearer-token-env-var E2A_API_KEY
   ```
 
 Ready-to-paste config files for each client:
@@ -137,7 +137,8 @@ credential). Don't retry — it's held, not failed.
   the shared `agents.e2a.dev` address works immediately.
 - Held messages carry a review **TTL** (default 7 days) after which they
   auto-resolve.
-- Attachments are fetched via short-lived signed URLs, not streamed inline.
+- Attachments are fetched via short-lived signed URLs by default; callers may
+  request small attachments inline.
 
 ## Anti-patterns
 
@@ -145,7 +146,8 @@ credential). Don't retry — it's held, not failed.
   double-queue. Wait for the human decision.
 - ❌ Starting a new `send_message` to answer an inbound → breaks threading. Use
   `reply_to_message`.
-- ❌ Trusting the `From` display name → use the authenticated SPF/DKIM identity.
+- ❌ Trusting the `From` display name → use the authenticated SPF/DKIM/DMARC
+  result and `authenticated_from` identity.
 - ❌ Hardcoding tool signatures from this doc → call `tools/list`; it's
   authoritative.
 
@@ -160,8 +162,8 @@ The full agent skill — mental model, gotchas, and worked examples — ships as
 **e2a** Claude Code plugin (the `e2a` skill + the hosted MCP server). Add it from
 the marketplace at https://github.com/tokencanopy/e2a.
 
-Getting started is free (shared domain, no card). Paid plans for custom domains
-and higher volume aren't enabled yet; when they land they'll be opt-in and the
-open-source code path stays unchanged. See https://e2a.dev for current status.
+Getting started is free (shared domain, no card). The hosted service also offers
+opt-in paid plans for higher limits; self-hosting and the open-source code path
+stay unchanged. See https://e2a.dev for current plans.
 
 Machine-readable doc index for agents: https://e2a.dev/llms.txt.

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -21,8 +21,8 @@
 
 ## MCP & plugin
 
-- [Claude Code plugin + skill](https://github.com/tokencanopy/e2a/tree/main/plugins/e2a): The `e2a` plugin bundles the hosted MCP server config and the `e2a` skill (mental model, gotchas, worked examples).
-- MCP endpoint: `https://api.e2a.dev/mcp` (Streamable HTTP, OAuth 2.1). Add with `claude mcp add --transport http --scope user e2a https://api.e2a.dev/mcp` (`--scope user` installs it globally; drop it for current-directory only). Per-client config (Cursor, VS Code, Codex, …) is in [e2a.md](https://e2a.dev/e2a.md).
+- [Agent plugin + skills](https://github.com/tokencanopy/e2a/tree/main/plugins/e2a): The `e2a` plugin bundles the hosted MCP server config and agent guidance for Claude Code, Codex, and Cursor.
+- MCP endpoint: `https://api.e2a.dev/mcp` (Streamable HTTP, OAuth 2.1). Add with `claude mcp add --transport http --scope user e2a https://api.e2a.dev/mcp`, then run `/mcp` to authorize (`--scope user` installs it globally; drop it for current-directory only). Per-client config (Cursor, VS Code, Codex, …) is in [e2a.md](https://e2a.dev/e2a.md).
 
 ## Source
 

--- a/web/public/sdk.md
+++ b/web/public/sdk.md
@@ -153,7 +153,7 @@ Conventions:
   pinned to one inbox.
 
 The endpoint map, exact request/response bodies, enums, and error codes are all
-in the OpenAPI 3.1 contract — generated from the live handlers, so it never
-lags: **https://e2a.dev/openapi.yaml**. The core resources are `agents`
+in the OpenAPI 3.1 contract — generated from the live handlers and checked for
+drift in CI: **https://e2a.dev/openapi.yaml**. The core resources are `agents`
 (inboxes), `messages` (send/reply/forward/get/list/attachments), `reviews`
 (HITL), `domains`, `webhooks`, `events`, and `account`.

--- a/web/public/templates.md
+++ b/web/public/templates.md
@@ -5,14 +5,9 @@
 
 ## Using a coding agent?
 
-Templates are a one-time setup your coding agent can do headlessly — copy this prompt:
+Copy this prompt into your coding agent:
 
-> Read https://e2a.dev/templates.md and set up e2a email
-> templates for this project: browse the starter templates, copy the ones we need via
-> `from_starter`, brand them (accent color is marked `<!-- BRAND: accent -->`), and wire
-> our transactional sends using `template_alias` + `template_data`. Use the e2a MCP tools
-> if connected (otherwise the REST API with `$E2A_API_KEY`), validate each template before
-> wiring it in, and finish by listing the templates you created plus the send code you added.
+> Help me set up e2a email templates using https://api.e2a.dev/mcp
 
 Templates are reusable email sources — a subject, a plain-text body, and an
 optional HTML body — stored on your account and **rendered server-side at send

--- a/web/src/app/(app)/get-started/_components/AgentSetupCards.tsx
+++ b/web/src/app/(app)/get-started/_components/AgentSetupCards.tsx
@@ -13,9 +13,9 @@ import { useState } from "react";
 // Hosted, account-scoped MCP endpoint (mcp/README.md). OAuth 2.1 → the
 // `mcp add` command opens a browser consent flow; no key to copy.
 const MCP_URL = "https://api.e2a.dev/mcp";
-// Hosted agent-facing setup doc (web/public/e2a.md). The pasted agent fetches
-// it to learn how to connect over MCP + drive e2a — it carries the connect
-// instructions, so the prompt just points the agent at it.
+// Stable hosted mirror of the canonical agent-facing setup doc at
+// plugins/e2a/docs/e2a.md. The pasted agent fetches it to learn how to connect
+// over MCP + drive e2a, so the prompt just points the agent at it.
 const DOC_URL = "https://e2a.dev/e2a.md";
 
 const PASTE_PROMPT = `Give yourself an email inbox with e2a. Read ${DOC_URL} and follow it to connect over MCP (${MCP_URL}) and set up my inbox, then walk me through it.`;

--- a/web/src/app/components/AgentPromptCard.test.tsx
+++ b/web/src/app/components/AgentPromptCard.test.tsx
@@ -17,11 +17,16 @@ test("renders the blurb and prompt verbatim", () => {
   expect(screen.getByText(AGENT_PROMPTS.templates.prompt)).toBeInTheDocument();
 });
 
-test("every prompt anchors on a published e2a.dev doc, not a GitHub path", () => {
-  for (const { prompt } of Object.values(AGENT_PROMPTS)) {
-    expect(prompt).toMatch(/https:\/\/e2a\.dev\/(templates|e2a)\.md/);
-    expect(prompt).not.toContain("github.com");
-  }
+test("uses concise page-specific MCP prompts", () => {
+  expect(AGENT_PROMPTS.inboxes.prompt).toBe(
+    "Help me set up an e2a inbox using https://api.e2a.dev/mcp",
+  );
+  expect(AGENT_PROMPTS.domains.prompt).toBe(
+    "Help me connect a custom domain to e2a using https://api.e2a.dev/mcp",
+  );
+  expect(AGENT_PROMPTS.templates.prompt).toBe(
+    "Help me set up e2a email templates using https://api.e2a.dev/mcp",
+  );
 });
 
 test("copy button writes the card's prompt to the clipboard and flips its label", async () => {

--- a/web/src/app/components/AgentPromptCard.tsx
+++ b/web/src/app/components/AgentPromptCard.tsx
@@ -4,24 +4,24 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { Button } from "./loft/Button";
 
 // Copy-paste prompts for driving each workspace surface from a coding
-// agent (Claude Code, Cursor, …) instead of the dashboard. The templates
-// prompt is kept in sync with docs/templates.md ("Using a coding
-// agent?"); the others anchor on the agent-facing doc at e2a.dev/e2a.md.
+// agent (Claude Code, Cursor, …) instead of the dashboard. Each prompt
+// names the desired outcome and points the agent at the hosted MCP server.
 export const AGENT_PROMPTS = {
   templates: {
     blurb:
       "Templates are a one-time setup your coding agent can do headlessly — paste this into Claude Code, Cursor, or any agent connected to e2a.",
-    prompt: `Read https://e2a.dev/templates.md and set up e2a email templates for this project: browse the starter templates, copy the ones we need via from_starter, brand them (accent color is marked <!-- BRAND: accent -->), and wire our transactional sends using template_alias + template_data. Use the e2a MCP tools if connected (otherwise the REST API with $E2A_API_KEY), validate each template before wiring it in, and finish by listing the templates you created plus the send code you added.`,
+    prompt: "Help me set up e2a email templates using https://api.e2a.dev/mcp",
   },
   inboxes: {
     blurb:
       "Creating and wiring an inbox is a one-time setup your coding agent can do headlessly — paste this into Claude Code, Cursor, or any agent connected to e2a.",
-    prompt: `Read https://e2a.dev/e2a.md and set up e2a email for this project's agent: connect over MCP (https://api.e2a.dev/mcp) or the REST API with $E2A_API_KEY, create an agent inbox, and wire inbound delivery into this project (webhook, or WebSocket listen for local dev). Finish by sending a test email to the new inbox and replying to it in-thread to prove the send/receive loop works.`,
+    prompt: "Help me set up an e2a inbox using https://api.e2a.dev/mcp",
   },
   domains: {
     blurb:
       "Domain setup is a one-time task your coding agent can drive end to end — paste this into Claude Code, Cursor, or any agent connected to e2a.",
-    prompt: `Read https://e2a.dev/e2a.md and connect our custom domain to e2a: register it, show me the DNS records to add (or add them yourself if you have access to our DNS provider), poll verification until it passes, then create the agent inboxes we need on the domain. Use the e2a MCP tools if connected, otherwise the REST API with $E2A_API_KEY.`,
+    prompt:
+      "Help me connect a custom domain to e2a using https://api.e2a.dev/mcp",
   },
 } as const;
 


### PR DESCRIPTION
## Summary
- replace long dashboard coding-agent prompts with concise, page-specific MCP requests
- make plugins/e2a/docs the canonical source for agent Markdown while preserving byte-identical hosted mirrors
- add tested sync/check automation, web prebuild refresh, CI drift enforcement, and reviewed ownership references

## Test plan
- node --test scripts/sync-agent-docs.test.mjs
- node scripts/sync-agent-docs.mjs --check
- scripts/check-repository-text-integrity.sh
- npm --prefix web test -- --runInBand
- npm --prefix web run build
- compare canonical docs with web/public and web/out mirrors