### PR TITLE
docs: fix stale MCP self-hosting/npm-publish claim in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Authenticate either with **OAuth 2.1** (add e2a as a connector and authorize in 
 
 The toolset covers the full agent loop — inbox (`list_messages`, `get_message`, `get_attachment`, `list_conversations`, `get_conversation`, `update_message_labels`), outbound (`send_message`, `reply_to_message`, `forward_message`), HITL review (`list_reviews`, `get_review`, `approve_review`, `reject_review`), plus agent/domain/webhook management. Inbound is consumed by polling (`list_messages`) or a `create_webhook` subscription.
 
-The server publishes to npm as [`@e2a/mcp-server`](https://www.npmjs.com/package/@e2a/mcp-server) for self-hosting. See [mcp/README.md](mcp/README.md) for per-framework setup and the full tool reference.
+The hosted server is the primary path; npm publishing of `@e2a/mcp-server` is retired (frozen at `0.4.0`). See [mcp/README.md](mcp/README.md) for per-framework setup and the full tool reference.
 
 ## CLI
 


### PR DESCRIPTION
## What was outdated

`README.md`'s MCP section said "The server publishes to npm as `@e2a/mcp-server` ... for self-hosting."

npm publishing for the MCP server is retired (`publish-mcp.yml` was deleted in #247, "re-curate MCP (hosted-only)"). `@e2a/mcp-server` is frozen on npm at `0.4.0`; the `0.5.0` currently in `mcp/package.json` was never shipped there. The current self-host path is the hosted HTTP image (`ghcr.io/tokencanopy/e2a-mcp-http`, built by `publish-mcp-http.yml`). `mcp/README.md` itself already only documents the hosted endpoint, consistent with this.

## What changed

Replaced the npm-publish sentence with an accurate description of the current hosted/self-host path, keeping the link to `mcp/README.md` for details.

Documentation-only change, verified against `.github/workflows/`, `mcp/package.json`, `mcp/README.md`, and `CLAUDE.md`'s existing (accurate) description of this retirement.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpDayhZEjRtxUh9nHE2Efe)_