### PR TITLE
docs: document CLI agents/keys/protection commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,9 +231,9 @@ web dashboard. The PR template checklists them.
   `v1/ws.ts`; webhook signature verification in `v1/webhook-signature.ts`.
 - **Python SDK** (`sdks/python/`): src layout, async-native (httpx), sync +
   async high-level clients over the generated base; PEP 561 `py.typed`.
-- **CLI** (`cli/`): commands login, listen, config, whoami, send, reply,
-  messages; config in `~/.e2a/config.json`; `listen --forward` proxies
-  WebSocket messages to a local HTTP endpoint. **Exit codes
+- **CLI** (`cli/`): commands login, whoami, agents, keys, protection, send,
+  reply, messages, listen, config; config in `~/.e2a/config.json`; `listen
+  --forward` proxies WebSocket messages to a local HTTP endpoint. **Exit codes
   (`cli/src/exit.ts`) are a frozen contract** — 0 ok, 1 transient, 2 usage,
   3 held-for-review, 4 auth, 5 permanent request error, 6 timeout,
   7 send-outcome. Add new codes, never renumber.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,7 @@ Layered: generated types → `E2AApi` (raw HTTP) → `E2AClient` (high-level wit
 
 ### CLI (`cli/`)
 
-Commands: login, listen, config, whoami, send, reply, messages. Config stored in `~/.e2a/config.json`. The `listen` command supports `--forward` mode for proxying WebSocket messages to local HTTP endpoints. The messaging commands (whoami/send/reply/messages) are the scripting surface for shell-based harnesses and publish a stable exit-code contract (`cli/src/exit.ts`): 0 ok, 1 transient error, 2 usage, 3 held-for-review (`pending_review` — HTTP-successful but undelivered), 4 auth, 5 permanent request error (non-retryable 4xx), 6 timeout (`listen --once --until` expired unmatched), 7 send-outcome (a persisted send failed or returned an unknown outcome; do not retry). Exit codes are frozen once published; add new ones, never renumber.
+Commands: login, whoami, agents, keys, protection, send, reply, messages, listen, config. Config stored in `~/.e2a/config.json`. The `listen` command supports `--forward` mode for proxying WebSocket messages to local HTTP endpoints. The messaging commands (whoami/send/reply/messages) are the scripting surface for shell-based harnesses and publish a stable exit-code contract (`cli/src/exit.ts`): 0 ok, 1 transient error, 2 usage, 3 held-for-review (`pending_review` — HTTP-successful but undelivered), 4 auth, 5 permanent request error (non-retryable 4xx), 6 timeout (`listen --once --until` expired unmatched), 7 send-outcome (a persisted send failed or returned an unknown outcome; do not retry). Exit codes are frozen once published; add new ones, never renumber.
 
 ### Web (`web/`)
 

--- a/README.md
+++ b/README.md
@@ -240,14 +240,20 @@ npm install -g @e2a/cli
 e2a login
 ```
 
-The CLI is a thin developer convenience — it covers only what the other surfaces
-don't do ergonomically. Drive agents (read/send/reply/list/labels) over the **MCP
-tools** or the **SDKs**; manage domains/agents/webhooks/keys/HITL in the **web
-dashboard**.
+The CLI covers both scripting (send/reply/messages/whoami, with a stable
+exit-code contract) and account management (agents, keys, protection). Drive
+agents interactively over the **MCP tools** or the **SDKs** instead; manage
+domains/webhooks in the **web dashboard**.
 
 | Command | Description |
 |---------|-------------|
 | `e2a login` | Open a browser login and save your API key + default agent to `~/.e2a/config.json` |
+| `e2a whoami` | Show the key identity: user, scope, bound agent, plan |
+| `e2a agents list\|create\|get` | Manage inboxes (requires an account-scoped key) |
+| `e2a keys create\|list\|delete` | Mint, list, and revoke API keys (requires an account-scoped key) |
+| `e2a protection get\|set` | Show or update an agent's HITL screening/review config |
+| `e2a send` / `e2a reply` | Send an email as the agent, or reply in-thread |
+| `e2a messages list\|get` | List or fetch messages for an agent |
 | `e2a listen --agent <email>` | Stream inbound email for an agent over WebSocket (real-time; `--json` for raw, `--forward <url>` to bridge to a local HTTP handler) |
 | `e2a config [list\|get\|set]` | View or update the local config |
 


### PR DESCRIPTION
## What was outdated

`README.md`, `AGENTS.md`, and `CLAUDE.md` all listed the CLI's commands as only `login, listen, config, whoami, send, reply, messages`. The CLI has since grown `e2a agents` (list/create/get), `e2a keys` (create/list/delete), and `e2a protection` (get/set) — all documented in `cli/README.md` and implemented in `cli/src/bin/e2a.ts`. `README.md` additionally claimed "manage domains/agents/webhooks/keys/HITL in the web dashboard", implying the CLI doesn't cover agent/key/HITL management — it does.

## What changed

- `README.md`: expanded the CLI command table to include `agents`, `keys`, `protection`, `send`/`reply`, and `messages`; softened the framing paragraph so it no longer claims agent/key/HITL management is dashboard-only.
- `AGENTS.md`: updated the one-line CLI command list.
- `CLAUDE.md`: updated the one-line CLI command list.

Documentation-only change, verified against `cli/src/bin/e2a.ts`'s USAGE string and `cli/README.md`'s command reference.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpDayhZEjRtxUh9nHE2Efe)_