### PR TITLE
docs: fix Python version requirement in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ The fork workflow above is the expected path for everyone else.
 |---|---|---|
 | Go | 1.25 | backend |
 | Node | 18+ (CI tests on 22) | CLI, TypeScript SDK, MCP server, web dashboard |
-| Python | 3.10+ | Python SDK |
+| Python | 3.9+ | Python SDK |
 | Docker (Desktop or engine) | any recent | local Postgres + Mailpit |
 
 You don't need all four to contribute — touching only the TS SDK


### PR DESCRIPTION
## What was outdated

`CONTRIBUTING.md`'s prerequisites table listed `Python 3.10+`, but `sdks/python/pyproject.toml` declares `requires-python = ">=3.9"` (and its mypy config targets `python_version = "3.9"`). `AGENTS.md` already correctly says "Python ≥3.9", so `CONTRIBUTING.md` was inconsistent with both the package metadata and the sibling doc.

## What changed

Changed the prerequisites table entry from `3.10+` to `3.9+`.

Documentation-only change, one line.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpDayhZEjRtxUh9nHE2Efe)_