### PR TITLE
docs: fix OAuth session TTL in data-handling.md

### DIFF
--- a/docs/data-handling.md
+++ b/docs/data-handling.md
@@ -14,7 +14,7 @@ For vulnerability reporting and the security model, see [SECURITY.md](../SECURIT
 | Attachments | Postgres rows (`attachments_json`, JSONB) | Same lifetime as the parent message — no S3/GCS |
 | Agent + domain ownership records | Postgres `agent_identities`, `domains` | Until the user deletes the agent/domain or the account |
 | API keys | Postgres `api_keys`, **hash only** (hex-encoded SHA-256 of the plaintext) | Until revoked or the user is deleted; plaintext exists only in the create response and is never persisted |
-| OAuth sessions | Postgres `user_sessions` | 30 days; cleanup worker removes expired rows hourly |
+| OAuth sessions | Postgres `user_sessions` | 7 days; cleanup worker removes expired rows hourly |
 | Usage events / summaries (only when `E2A_USAGE_TRACKING=true`) | Postgres `usage_events`, `usage_summaries` | Indefinite by default — operator can purge or override |
 | Per-webhook signing secret (`whsec_…`) | Postgres, **plaintext** | Until the webhook is deleted. Returned once at creation; rotate via `POST /v1/webhooks/{id}/rotate-secret` (the previous secret stays valid for a 24h grace window). |
 | Deployment-wide HMAC signing secret (operator key) | Operator's env (`E2A_HMAC_SECRET`); never written to DB | Lifetime of the deployment. The **sole** signer for the relay's `X-E2A-Auth-*` headers and HITL approval / magic-link tokens. SDKs verify inbound deliveries with `E2A_WEBHOOK_SECRET` (the per-webhook `whsec_`), not this. |


### PR DESCRIPTION
## What was outdated

`docs/data-handling.md` claimed dashboard/OAuth sessions (`user_sessions`) live for 30 days. The actual TTL, per `internal/identity/store.go` (`const SessionTTL = 7 * 24 * time.Hour`, used directly in `CreateUserSession`), is 7 days. The 30-day figure appears to have been copied from the unrelated OAuth **refresh-token** lifespan (`internal/oauth/provider.go`, `RefreshTokenLifespan = 30 * 24 * time.Hour`) — a different mechanism and table.

## What changed

Changed the retention entry for `user_sessions` from "30 days" to "7 days"; the hourly-cleanup detail was already correct and is unchanged.

Documentation-only change, one line.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpDayhZEjRtxUh9nHE2Efe)_