### PR TITLE
docs: fill in SDK README pagination/upgrade gaps

### DIFF
--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -13,6 +13,36 @@ pip install e2a          # add the [ws] extra for client.listen(): pip install "
 The SDK major version tracks the SDK package's own breaking changes and is
 independent of the API version path (`/v1`): SDK 5.x targets the e2a v1 API.
 
+## Upgrading to 5.2
+
+The reserved-word wire field `from` is now uniformly exposed as `from_`
+(PEP 8 trailing underscore) on generated models (was the generator-mangled
+`var_from`). Affected models: `Message`, `MessageView`, `MessageSummaryView`,
+`ReviewView`, `EmailReceivedData`, `EmailSentData`, `EmailFailedData`, plus
+the `list_messages` sender filter parameter. The hand-written layer's
+`messages.list(from_=...)` already used `from_`, so the SDK now teaches
+exactly one spelling. The wire JSON is unchanged — requests and responses
+still carry `from` (pydantic alias). The webhook/WS `data` payload
+TypedDicts are wire-true dicts and keep the literal `"from"` key (access as
+`data["from"]`). Migrate: `message.var_from` → `message.from_`.
+
+## Upgrading to 5.1
+
+Every `.delete(...)` now returns a typed deletion object instead of `None`.
+The API's seven delete endpoints all return `200 OK` with
+`{"deleted": true, <identity key>}` instead of the previous mix of
+`204 No Content` and `200`. New return types: `agents.delete` →
+`DeleteAgentResult`, `domains.delete` → `DeleteDomainResult`,
+`webhooks.delete` → `DeleteWebhookResult`, `templates.delete` →
+`DeleteTemplateResult`, `account.api_keys.delete` → `DeleteApiKeyResult`,
+`account.suppressions.delete` → `DeleteSuppressionResult`;
+`account.delete()` still returns `DeleteUserDataResult`, which now also
+carries `deleted: true`. `deleted` is always `True` — a failed delete raises
+a typed error. Applies identically to the sync `E2AClient` facade. Callers
+that ignored the old `None` return need no changes. Older SDK versions
+expecting `204` are incompatible with servers running this contract —
+upgrade together.
+
 ## Upgrading to 5.0
 
 5.0 renames the async client and introduces a synchronous client under the

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -11,6 +11,35 @@ npm install @e2a/sdk
 The SDK major version tracks the SDK package's own breaking changes and is
 independent of the API version path (`/v1`): SDK 5.x targets the e2a v1 API.
 
+## Upgrading to 5.2
+
+The reserved-word wire field `from` is now uniformly exposed as `from_` on
+generated models and the `listMessages` sender filter (was the
+private-looking `_from`, an OpenAPI Generator escape artifact). Affected
+models: `Message`, `MessageView`, `MessageSummaryView`, `ReviewView`,
+`EmailReceivedData`, `EmailSentData`, `EmailFailedData`. The wire JSON is
+unchanged — requests and responses still carry `from`; only the generated
+TS field name changed. The hand-written webhook/WS payload interfaces in
+`webhook-signature.ts` keep the literal `from` property (those are raw-JSON
+shapes, not generated models). Migrate: `message._from` → `message.from_`;
+`list(..., { _from })` → `{ from_ }`.
+
+## Upgrading to 5.1
+
+Every `.delete(...)` now returns a typed deletion object instead of `void`.
+The API's seven delete endpoints all return `200 OK` with
+`{deleted: true, <identity key>}` instead of the previous mix of
+`204 No Content` and `200`. New return types: `agents.delete` →
+`DeleteAgentResult`, `domains.delete` → `DeleteDomainResult`,
+`webhooks.delete` → `DeleteWebhookResult`, `templates.delete` →
+`DeleteTemplateResult`, `account.apiKeys.delete` → `DeleteApiKeyResult`,
+`account.suppressions.delete` → `DeleteSuppressionResult`;
+`account.delete()` still returns `DeleteUserDataResult`, which now also
+carries `deleted: true`. `deleted` is always `true` — a failed delete throws
+a typed error. Callers that ignored the old `void` return need no changes.
+Older SDK versions expecting `204` are incompatible with servers running
+this contract — upgrade together.
+
 ## Upgrading to 4.0
 
 4.0 is a breaking change to the domain DNS-records shape (server #304).
@@ -171,6 +200,18 @@ List methods return an `AutoPager<T>` — an `AsyncIterable` that threads the
 cursor for you. Use `for await`, or `.toArray({ limit })` (the limit is
 required, to bound memory on a large inbox), or `.forEach(fn)` (return `false`
 to stop early).
+
+For manual, caller-driven pagination (e.g. checkpoint/resume from a queue), use
+`.page(cursor)`: it fetches a SINGLE page and returns a `{ items, next_cursor }`
+object. Omit the cursor for the first page and pass the previous page's
+`next_cursor` to resume; a `null`/`undefined`/empty `next_cursor` means there
+are no more pages.
+
+```ts
+const page = await client.messages.list("bot@agents.e2a.dev", { limit: 100 }).page();
+process(page.items);
+checkpoint(page.next_cursor); // resume later with .page(savedCursor)
+```
 
 ## WebSocket (real-time delivery for local agents)
 


### PR DESCRIPTION
## What was incomplete

- `sdks/typescript/README.md`'s Pagination section only documented `for await`, `.toArray({ limit })`, and `.forEach(fn)` — it never mentioned `AutoPager.page(cursor)`, the manual/checkpoint-resume primitive that `sdks/typescript/src/v1/pagination.ts` has exported since it was added. `sdks/python/README.md` already documents the equivalent `pager.page(cursor)` in detail.
- Both SDK READMEs jump from their most recent "Upgrading to X.0" section straight to nothing, even though both packages are now at `5.2.0` and both CHANGELOGs mark `5.1.0` and `5.2.0` as `### Breaking (pre-GA)` (uniform typed `.delete(...)` responses; the `from`/`from_` field rename). Readers upgrading from 5.0/4.x who only read the README had no guidance on either breaking change.

## What changed

- Added a `.page(cursor)` subsection to the TypeScript README's Pagination section, mirroring the Python README's existing one.
- Added "Upgrading to 5.1" and "Upgrading to 5.2" sections to both READMEs, summarizing the delete-response-shape change and the `from_` rename, in the same style as the existing "Upgrading to 4.0" sections.

Documentation-only change, verified against `sdks/typescript/src/v1/pagination.ts` and both CHANGELOGs' `5.1.0`/`5.2.0` entries.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpDayhZEjRtxUh9nHE2Efe)_