### PR TITLE
docs: fix mcp examples README inaccuracies

### DIFF
--- a/mcp/examples/README.md
+++ b/mcp/examples/README.md
@@ -4,7 +4,7 @@ End-to-end demos showing how to wire the e2a MCP surface into popular agent fram
 
 | Framework | Path | LLM | Example |
 | --- | --- | --- | --- |
-| LangChain (LangGraph ReAct) | [langchain/](./langchain/) | Anthropic Claude | `agent.py` |
+| LangChain | [langchain/](./langchain/) | Anthropic Claude | `agent.py` |
 | CrewAI | [crewai/](./crewai/) | Anthropic Claude | `agent.py` |
 | Google ADK | [adk/](./adk/) | Google Gemini | `agent.py` |
 | OpenAI Agents SDK | [openai-agents/](./openai-agents/) | OpenAI GPT | `agent.py` |

--- a/mcp/examples/codex/README.md
+++ b/mcp/examples/codex/README.md
@@ -2,7 +2,7 @@
 
 [Codex CLI](https://github.com/openai/codex) is OpenAI's terminal coding agent (peer to Claude Code). It speaks MCP natively — you declare servers in `~/.codex/config.toml` and Codex connects to them at session start, then surfaces their tools to whatever model you're running.
 
-Unlike the [LangChain](../langchain/), [Google ADK](../adk/), and [OpenAI Agents SDK](../openai-agents/) examples — which are Python scripts you run — Codex is itself the agent. The "example" here is the TOML you paste into your Codex config to add e2a's MCP tools (50 total; the visible set depends on your key's scope).
+Unlike the [LangChain](../langchain/), [CrewAI](../crewai/), [Google ADK](../adk/), and [OpenAI Agents SDK](../openai-agents/) examples — which are Python scripts you run — Codex is itself the agent. The "example" here is the TOML you paste into your Codex config to add e2a's MCP tools (50 total; the visible set depends on your key's scope).
 
 Codex opens a Streamable HTTP session to the hosted endpoint at `https://api.e2a.dev/mcp` with your API key in the `Authorization: Bearer …` header — no Node toolchain on the host (works on CI runners, dev containers, remote app servers, etc.).
 


### PR DESCRIPTION
## What was outdated

- `mcp/examples/README.md` labeled the LangChain example "LangChain (LangGraph ReAct)", but `mcp/examples/langchain/agent.py` uses `langchain.agents.create_agent`, not LangGraph's prebuilt ReAct agent — `mcp/examples/test_framework_examples.py` explicitly asserts the code does *not* use `langgraph.prebuilt`. Stale label from an earlier version of the example.
- `mcp/examples/codex/README.md` said Codex is unlike "the LangChain, Google ADK, and OpenAI Agents SDK examples ... which are Python scripts you run", omitting CrewAI even though `mcp/examples/crewai/agent.py` exists and is listed alongside the others in `mcp/examples/README.md`'s own table.

## What changed

- Dropped the stale "(LangGraph ReAct)" qualifier from the LangChain row.
- Added CrewAI to the Codex README's list of Python-script examples.

Documentation-only change, two one-line fixes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EpDayhZEjRtxUh9nHE2Efe)_