### PR TITLE
fix(web): include agent docs in image build

### DIFF
--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -31,6 +31,11 @@ WORKDIR /app
 # `next build`. No build step needed here — dist/ is prebuilt and committed.
 COPY design-system ./design-system
 
+# The web prebuild mirrors canonical agent docs into web/public. Keep the
+# script and only its canonical inputs in the image build context.
+COPY scripts/sync-agent-docs.mjs ./scripts/
+COPY plugins/e2a/docs ./plugins/e2a/docs/
+
 # Install web deps first so the layer caches when only source changes.
 COPY web/package.json web/package-lock.json ./web/
 WORKDIR /app/web

--- a/web/Dockerfile.dockerignore
+++ b/web/Dockerfile.dockerignore
@@ -27,7 +27,11 @@ docs
 examples
 assets
 bin
-plugins
+plugins/*
+!plugins/e2a/
+plugins/e2a/*
+!plugins/e2a/docs/
+!plugins/e2a/docs/**
 *.go
 go.mod
 go.sum


### PR DESCRIPTION
## Summary
- copy the agent-doc sync script into the web image builder
- include only canonical plugin docs in the Docker build context
- restore the web image build after the new prebuild hook

## Verification
- `docker build --progress=plain -f web/Dockerfile -t e2a-web-doc-sync-green .`
- `npm test -- --runInBand` (341 tests)
- `node scripts/sync-agent-docs.mjs --check`