### PR TITLE
test(unsubscribe): cover suppression integration seams

### DIFF
--- a/internal/agent/outbound_async_test.go
+++ b/internal/agent/outbound_async_test.go
@@ -70,6 +70,12 @@ func workerJobWithID(id string, jobID int64, attempt int) *river.Job[outboundsen
 
 func setupAsyncAPI(t *testing.T) (*agent.API, *identity.Store, webhookpub.Outbox, *fakeOutboundEnqueuer) {
 	t.Helper()
+	api, store, outbox, enq, _ := setupAsyncAPIWithPool(t)
+	return api, store, outbox, enq
+}
+
+func setupAsyncAPIWithPool(t *testing.T) (*agent.API, *identity.Store, webhookpub.Outbox, *fakeOutboundEnqueuer, *pgxpool.Pool) {
+	t.Helper()
 	pool := testutil.TestDB(t)
 	store := identity.NewStore(pool)
 	smtpRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{})
@@ -81,7 +87,7 @@ func setupAsyncAPI(t *testing.T) (*agent.API, *identity.Store, webhookpub.Outbox
 	api.SetOutbox(outbox)
 	enq := &fakeOutboundEnqueuer{jobID: 999}
 	api.SetOutboundEnqueuer(enq)
-	return api, store, outbox, enq
+	return api, store, outbox, enq, pool
 }
 
 func TestHoldForApprovalCore_SuppressedAgentCreatesHoldWithoutNotificationJob(t *testing.T) {

--- a/internal/agent/outbound_suppression_guard_test.go
+++ b/internal/agent/outbound_suppression_guard_test.go
@@ -7,15 +7,20 @@ package agent_test
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
 	"github.com/tokencanopy/e2a/internal/agent"
+	"github.com/tokencanopy/e2a/internal/delivery"
+	"github.com/tokencanopy/e2a/internal/identity"
 	"github.com/tokencanopy/e2a/internal/outbound"
 	"github.com/tokencanopy/e2a/internal/outboundsend"
+	"github.com/tokencanopy/e2a/internal/sendramp"
 	"github.com/tokencanopy/e2a/internal/usage"
 	"github.com/tokencanopy/e2a/internal/webhookpub"
 )
@@ -51,6 +56,19 @@ func (g *blockingRampGate) releasedIDs() []string {
 type countingDeliverer struct {
 	calls int
 	out   outboundsend.DeliverOutcome
+}
+
+type failOnceSuppressionStore struct {
+	outboundsend.Store
+	failed bool
+}
+
+func (s *failOnceSuppressionStore) SuppressedRecipients(ctx context.Context, userID, agentID string, recipients []string) ([]string, error) {
+	if !s.failed {
+		s.failed = true
+		return nil, errors.New("transient suppression lookup failure")
+	}
+	return s.Store.SuppressedRecipients(ctx, userID, agentID, recipients)
 }
 
 func (d *countingDeliverer) Deliver(_ context.Context, _ *outboundsend.SendJob) outboundsend.DeliverOutcome {
@@ -199,5 +217,96 @@ func TestSendWorker_SuppressionAddedDuringRampReservePreventsProviderIO(t *testi
 	}
 	if status != "failed" || !strings.Contains(detail, "recipient_suppressed") {
 		t.Fatalf("status/detail = %q/%q, want failed recipient_suppressed", status, detail)
+	}
+}
+
+func TestSendWorker_TransientSuppressionFailureReusesRealRampReservation(t *testing.T) {
+	api, store, outbox, _, pool := setupAsyncAPIWithPool(t)
+	ctx := context.Background()
+	user, ag := selfAgent(t, store, "rampretryreal")
+	if err := store.SetSendingStatus(ctx, ag.RegisteredDomain, "verified", "verified", "verified", "", nil); err != nil {
+		t.Fatalf("SetSendingStatus: %v", err)
+	}
+	res, oerr := api.DeliverOutbound(ctx, user, ag, outbound.SendRequest{
+		To: []string{"recipient@external.test"}, Subject: "retry after suppression lookup", Body: "x",
+	}, "send", "", nil, nil)
+	if oerr != nil {
+		t.Fatalf("DeliverOutbound: %+v", oerr)
+	}
+
+	baseStore := agent.NewOutboundSendStore(store, outbox, usage.NewNoopUsageTracker())
+	failingStore := &failOnceSuppressionStore{Store: baseStore}
+	day := time.Date(2026, 7, 19, 12, 0, 0, 0, time.UTC)
+	ramp := agent.NewOutboundRampGate(sendramp.NewStore(pool), sendramp.NewSchedule(50, 100, 2), true, func() time.Time { return day })
+	deliverer := &countingDeliverer{out: outboundsend.DeliverOutcome{ProviderMessageID: "ses-after-retry", SentAs: "own_address"}}
+	worker := outboundsend.NewSendWorker(failingStore, deliverer, ramp)
+
+	if err := worker.Work(ctx, workerJobWithID(res.MessageID, 999, 1)); err == nil {
+		t.Fatal("first worker attempt must return the injected transient error")
+	}
+	var firstState string
+	if err := pool.QueryRow(ctx, `SELECT state FROM sending_ramp_reservations WHERE message_id=$1`, res.MessageID).Scan(&firstState); err != nil {
+		t.Fatalf("read first reservation: %v", err)
+	}
+	if firstState != "reserved" {
+		t.Fatalf("reservation after transient error = %q, want reserved", firstState)
+	}
+	if deliverer.calls != 0 {
+		t.Fatalf("provider calls after transient error = %d, want zero", deliverer.calls)
+	}
+
+	if err := worker.Work(ctx, workerJobWithID(res.MessageID, 999, 2)); err != nil {
+		t.Fatalf("retry worker attempt: %v", err)
+	}
+	var finalState, status string
+	if err := pool.QueryRow(ctx, `SELECT state FROM sending_ramp_reservations WHERE message_id=$1`, res.MessageID).Scan(&finalState); err != nil {
+		t.Fatalf("read final reservation: %v", err)
+	}
+	if err := pool.QueryRow(ctx, `SELECT delivery_status FROM messages WHERE id=$1`, res.MessageID).Scan(&status); err != nil {
+		t.Fatalf("read final message: %v", err)
+	}
+	if finalState != "confirmed" || status != "sent" || deliverer.calls != 1 {
+		t.Fatalf("final reservation/status/provider calls = %q/%q/%d, want confirmed/sent/1", finalState, status, deliverer.calls)
+	}
+}
+
+func TestAccountSuppressionFromBounceBlocksEveryAgentSend(t *testing.T) {
+	api, store, _, _ := setupAsyncAPI(t)
+	ctx := context.Background()
+	user, first := selfAgent(t, store, "accountbounce")
+	second, err := store.CreateAgent(ctx, "second@"+first.RegisteredDomain, first.RegisteredDomain, "", "", "local", user.ID)
+	if err != nil {
+		t.Fatalf("CreateAgent(second): %v", err)
+	}
+
+	seed, err := store.CreateOutboundMessage(ctx, first.ID, []string{"bounced@external.test"}, nil, nil,
+		"seed provider bounce", "send", "smtp", "ses-account-bounce", "", []byte("raw"))
+	if err != nil {
+		t.Fatalf("CreateOutboundMessage: %v", err)
+	}
+	if err := store.MarkMessageSent(ctx, seed.ID, "own_address", []string{"bounced@external.test"}, nil, nil); err != nil {
+		t.Fatalf("MarkMessageSent: %v", err)
+	}
+	bounce, err := delivery.ParseSESNotification([]byte(`{
+		"eventType":"Bounce",
+		"mail":{"messageId":"ses-account-bounce"},
+		"bounce":{"bounceType":"Permanent","bouncedRecipients":[{
+			"emailAddress":"BOUNCED@EXTERNAL.TEST","diagnosticCode":"550 no such user"
+		}]}
+	}`))
+	if err != nil {
+		t.Fatalf("ParseSESNotification: %v", err)
+	}
+	if err := delivery.NewConsumer(store, nil).Process(ctx, bounce); err != nil {
+		t.Fatalf("Process bounce: %v", err)
+	}
+
+	for _, ag := range []*identity.AgentIdentity{first, second} {
+		res, oerr := api.DeliverOutbound(ctx, user, ag, outbound.SendRequest{
+			To: []string{"Bounced Recipient <BOUNCED@EXTERNAL.TEST>"}, Subject: "must be blocked", Body: "x",
+		}, "send", "", nil, nil)
+		if res != nil || oerr == nil || oerr.Code != "recipient_suppressed" {
+			t.Fatalf("agent %s result/error = %+v/%+v, want account-wide recipient_suppressed", ag.ID, res, oerr)
+		}
 	}
 }

--- a/internal/testutil/contract_server.go
+++ b/internal/testutil/contract_server.go
@@ -17,6 +17,7 @@ import (
 	"github.com/tokencanopy/e2a/internal/limits"
 	"github.com/tokencanopy/e2a/internal/outbound"
 	"github.com/tokencanopy/e2a/internal/relay"
+	"github.com/tokencanopy/e2a/internal/unsubscribe"
 	"github.com/tokencanopy/e2a/internal/usage"
 	"github.com/tokencanopy/e2a/internal/webhook"
 	"github.com/tokencanopy/e2a/internal/ws"
@@ -43,6 +44,11 @@ func StartContractServer(ctx context.Context, dbURL string) (*ContractServer, er
 	}
 
 	store := identity.NewStore(pool)
+	managedUnsubscribeIssuer, err := unsubscribe.NewIssuer(TestHMACSecret, "http://127.0.0.1", false, store)
+	if err != nil {
+		pool.Close()
+		return nil, err
+	}
 	signer := headers.NewSigner(TestHMACSecret)
 	smtpRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{})
 	sender := outbound.NewSender(smtpRelay, "test.e2a.dev")
@@ -79,8 +85,9 @@ func StartContractServer(ctx context.Context, dbURL string) (*ContractServer, er
 		SubscriberStore: subscriberStore, Idempotency: idempotencyStore, Pool: pool,
 		SMTPDomain: "test.e2a.dev", SharedDomain: "agents.e2a.dev",
 		PublicURL: "http://127.0.0.1", Production: false,
-		EventsEnabled: true,
-		Legacy:        router, WSHandle: wsHandler.ServeWithEmail,
+		EventsEnabled:            true,
+		ManagedUnsubscribeIssuer: managedUnsubscribeIssuer,
+		Legacy:                   router, WSHandle: wsHandler.ServeWithEmail,
 	})
 
 	httpLn, err := net.Listen("tcp", "127.0.0.1:0")

--- a/tests/contract/scenarios.yaml
+++ b/tests/contract/scenarios.yaml
@@ -615,6 +615,124 @@ scenarios:
             "items[0].review_status": pending_review
             "items[1].direction": inbound
 
+  - name: agent_suppression_and_managed_unsubscribe
+    description: >
+      The beta agent-suppression CRUD surface blocks the exact recipient until
+      deletion, and managed unsubscribe is accepted by the live send endpoint.
+      All setup is performed through public requests so every SDK contract
+      runner executes this scenario rather than skipping store-backed setup.
+    steps:
+      - id: register_domain
+        action: request
+        method: POST
+        path: /v1/domains
+        body:
+          domain: suppression-contract.test.dev
+        expect:
+          status: 201
+
+      - id: verify_domain
+        action: request
+        method: POST
+        path: /v1/domains/suppression-contract.test.dev/verify
+        expect:
+          status: 200
+          body_match:
+            verified: true
+
+      - id: register_agent
+        action: request
+        method: POST
+        path: /v1/agents
+        body:
+          email: bot@suppression-contract.test.dev
+        expect:
+          status: 201
+          body_match:
+            email: bot@suppression-contract.test.dev
+
+      - id: create_suppression
+        action: request
+        method: POST
+        path: /v1/agents/bot@suppression-contract.test.dev/suppressions
+        body:
+          address: recipient@example.net
+          reason: contract test
+        expect:
+          status: 200
+          body_match:
+            agent_email: bot@suppression-contract.test.dev
+            address: recipient@example.net
+            source: manual
+
+      - id: list_suppressions
+        action: request
+        method: GET
+        path: /v1/agents/bot@suppression-contract.test.dev/suppressions
+        expect:
+          status: 200
+          body_match:
+            "items.length": 1
+            "items[0].address": recipient@example.net
+
+      - id: suppressed_send_refused
+        action: request
+        method: POST
+        path: /v1/agents/bot@suppression-contract.test.dev/messages
+        body:
+          to:
+            - Recipient <recipient@example.net>
+          subject: blocked by agent suppression
+          text: must not be accepted
+        expect:
+          status: 422
+          body_match:
+            "error.code": recipient_suppressed
+
+      - id: delete_suppression
+        action: request
+        method: DELETE
+        path: /v1/agents/bot@suppression-contract.test.dev/suppressions/recipient@example.net?confirm=DELETE
+        expect:
+          status: 200
+          body_match:
+            deleted: true
+            address: recipient@example.net
+
+      - id: enable_outbound_review
+        action: request
+        method: PUT
+        path: /v1/agents/bot@suppression-contract.test.dev/protection
+        body:
+          inbound:
+            gate: {}
+            scan: {}
+          outbound:
+            gate:
+              policy: allowlist
+              action: review
+              allowlist: []
+            scan: {}
+          holds: {}
+        expect:
+          status: 200
+
+      - id: managed_unsubscribe_send_held
+        action: request
+        method: POST
+        path: /v1/agents/bot@suppression-contract.test.dev/messages
+        body:
+          to:
+            - recipient@example.net
+          subject: managed unsubscribe contract
+          text: held for review
+          unsubscribe:
+            mode: managed
+        expect:
+          status: 202
+          body_match:
+            status: pending_review
+
   - name: info_unauthenticated_shape
     description: >
       GET /v1/info is the deployment-discovery endpoint — works


### PR DESCRIPTION
## Summary
- verify a transient suppression lookup reuses a real Postgres ramp reservation across worker retries
- drive a raw SES bounce through account suppression storage and block sends from every agent
- exercise agent suppression CRUD, blocked send, deletion, and managed unsubscribe in the shared live SDK contract scenario

## Test plan
- `go test -tags integration -p 1 ./internal/agent ./internal/delivery ./internal/outboundsend ./internal/sendramp ./internal/testutil ./tests/contract`
- TypeScript SDK contract suite against a clean local contract server
- Python SDK contract suite against a clean local contract server
- regression proof: temporarily restored the harmful ramp release and confirmed the new test failed with reservation state `released`