### PR TITLE
feat(feedback): fan out submissions to notify email + GitHub App auth

### DIFF
--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -1557,43 +1557,135 @@ func (a *API) handleFeedback(w http.ResponseWriter, r *http.Request) {
 		body += fmt.Sprintf("\n\n---\nSubmitted by: `%s`", sanitize(req.Email))
 	}
 
-	ghToken := os.Getenv("GITHUB_FEEDBACK_TOKEN")
-	if ghToken == "" {
+	// Fan out to every configured delivery channel. A submission succeeds if
+	// AT LEAST ONE channel delivers — one broken integration (e.g. an expired
+	// GitHub token) must not lose feedback while another channel still works.
+	attempted, delivered := 0, 0
+
+	// Channel 1: GitHub issue. Credential resolution (GitHub App preferred,
+	// PAT fallback) lives in feedback_github.go.
+	issueURL := ""
+	ghClient, ghErr := feedbackGitHubClient(r.Context())
+	switch {
+	case ghErr != nil:
+		attempted++
+		log.Printf("feedback: github auth: %v", ghErr)
+	case ghClient != nil:
+		attempted++
+		ghRepo := os.Getenv("GITHUB_FEEDBACK_REPO")
+		if ghRepo == "" {
+			ghRepo = "tokencanopy/e2a"
+		}
+		parts := strings.SplitN(ghRepo, "/", 2)
+		if len(parts) != 2 {
+			log.Printf("feedback: invalid GITHUB_FEEDBACK_REPO: %s", ghRepo)
+		} else {
+			issue, _, err := ghClient.Issues.Create(r.Context(), parts[0], parts[1], &github.IssueRequest{
+				Title:  github.Ptr(title),
+				Body:   github.Ptr(body),
+				Labels: &[]string{label},
+			})
+			if err != nil {
+				log.Printf("feedback: GitHub API error: %v", err)
+			} else {
+				delivered++
+				issueURL = issue.GetHTMLURL()
+			}
+		}
+	}
+
+	// Channel 2: notification email via the platform relay (hitlnotify-style
+	// compose + direct submit; the durable outbound pipeline requires an agent
+	// identity, which feedback has none). Recipients are deployment config via
+	// FEEDBACK_NOTIFY_TO / FEEDBACK_NOTIFY_CC (comma-separated) — empty means
+	// the channel is off (self-host default).
+	notifyTo := splitFeedbackAddrs(os.Getenv("FEEDBACK_NOTIFY_TO"))
+	notifyCC := splitFeedbackAddrs(os.Getenv("FEEDBACK_NOTIFY_CC"))
+	if len(notifyTo) > 0 || len(notifyCC) > 0 {
+		attempted++
+		// Surface the GitHub outcome in the email body: when the issue
+		// channel breaks, the notification doubles as the alert for it.
+		ghNote := ""
+		if ghClient != nil || ghErr != nil {
+			if issueURL != "" {
+				ghNote = "GitHub issue: " + issueURL
+			} else {
+				ghNote = "GitHub issue: creation FAILED (see server logs)"
+			}
+		}
+		if err := a.sendFeedbackEmail(title, req.Category, req.Message, req.Email, ghNote, notifyTo, notifyCC); err != nil {
+			log.Printf("feedback: notify email failed: %v", err)
+		} else {
+			delivered++
+		}
+	}
+
+	if attempted == 0 {
+		// No delivery channel configured — log-only graceful fallback.
 		safeMsg := strings.ReplaceAll(req.Message, "\n", " ")
 		if len([]rune(safeMsg)) > 200 {
 			safeMsg = string([]rune(safeMsg)[:200])
 		}
-		log.Printf("feedback: GITHUB_FEEDBACK_TOKEN not set, logging only: [%s] %s", req.Category, safeMsg)
-		w.Header().Set("Content-Type", "application/json")
-		writeJSON(w, map[string]string{"status": "ok"})
-		return
-	}
-
-	ghRepo := os.Getenv("GITHUB_FEEDBACK_REPO")
-	if ghRepo == "" {
-		ghRepo = "tokencanopy/e2a"
-	}
-	parts := strings.SplitN(ghRepo, "/", 2)
-	if len(parts) != 2 {
-		log.Printf("feedback: invalid GITHUB_FEEDBACK_REPO: %s", ghRepo)
-		http.Error(w, "failed to submit feedback", http.StatusInternalServerError)
-		return
-	}
-
-	client := github.NewClient(nil).WithAuthToken(ghToken)
-	_, _, err := client.Issues.Create(r.Context(), parts[0], parts[1], &github.IssueRequest{
-		Title:  github.Ptr(title),
-		Body:   github.Ptr(body),
-		Labels: &[]string{label},
-	})
-	if err != nil {
-		log.Printf("feedback: GitHub API error: %v", err)
+		log.Printf("feedback: no delivery channel configured, logging only: [%s] %s", req.Category, safeMsg)
+	} else if delivered == 0 {
 		http.Error(w, "failed to submit feedback", http.StatusInternalServerError)
 		return
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	writeJSON(w, map[string]string{"status": "ok"})
+}
+
+// sendFeedbackEmail emails a copy of a feedback submission to the configured
+// recipients through the platform relay (From: "e2a" <noreply@<from_domain>>).
+// Reply-To carries the submitter's address when given, so replying to the
+// notification reaches them directly; compose-layer header sanitization
+// neutralizes any CR/LF in that user-controlled value.
+func (a *API) sendFeedbackEmail(title, category, message, submitterEmail, ghNote string, to, cc []string) error {
+	if a.smtpRelay == nil || !a.smtpRelay.Configured() || a.fromDomain == "" {
+		return fmt.Errorf("outbound SMTP relay not configured")
+	}
+
+	from := outbound.PlatformEnvelopeFrom(a.fromDomain)
+	headerFrom := fmt.Sprintf("%q <%s>", outbound.PlatformDisplayName, from)
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "Category: %s\n", category)
+	if submitterEmail != "" {
+		fmt.Fprintf(&b, "Submitted by: %s\n", submitterEmail)
+	}
+	if ghNote != "" {
+		fmt.Fprintf(&b, "%s\n", ghNote)
+	}
+	fmt.Fprintf(&b, "\n%s\n", message)
+
+	raw, err := outbound.ComposeMessage(headerFrom, to, cc, "[e2a feedback] "+title, b.String(), "text/plain", "", nil, a.fromDomain, submitterEmail, "")
+	if err != nil {
+		return fmt.Errorf("compose: %w", err)
+	}
+
+	rcpts := make([]string, 0, len(to)+len(cc))
+	rcpts = append(rcpts, to...)
+	rcpts = append(rcpts, cc...)
+
+	// Send (not SendOnce) — no job queue owns retries for this path, so the
+	// relay's own transient-4xx backoff is the only retry envelope.
+	if _, err := a.smtpRelay.Send(from, rcpts, raw); err != nil {
+		return fmt.Errorf("smtp send: %w", err)
+	}
+	return nil
+}
+
+// splitFeedbackAddrs parses a comma-separated address list from env config,
+// trimming whitespace and dropping empties.
+func splitFeedbackAddrs(s string) []string {
+	var out []string
+	for _, p := range strings.Split(s, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
 }
 
 func truncate(s string, maxLen int) string {

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -46,6 +46,8 @@ import (
 // for provider fan-in while still bounding anonymous token lookup work.
 const unsubscribeRequestsPerMinute = 600
 
+var feedbackEmailTimeout = 10 * time.Second
+
 // writeJSON encodes payload as the response body. Logs encoding errors
 // rather than swallowing them — an Encode failure usually means the
 // client closed the connection mid-response or the payload contains a
@@ -1565,7 +1567,8 @@ func (a *API) handleFeedback(w http.ResponseWriter, r *http.Request) {
 	// Channel 1: GitHub issue. Credential resolution (GitHub App preferred,
 	// PAT fallback) lives in feedback_github.go.
 	issueURL := ""
-	ghClient, ghErr := feedbackGitHubClient(r.Context())
+	ghCtx, cancelGitHub := context.WithTimeout(r.Context(), feedbackGitHubTimeout)
+	ghClient, ghErr := feedbackGitHubClient(ghCtx)
 	switch {
 	case ghErr != nil:
 		attempted++
@@ -1580,7 +1583,7 @@ func (a *API) handleFeedback(w http.ResponseWriter, r *http.Request) {
 		if len(parts) != 2 {
 			log.Printf("feedback: invalid GITHUB_FEEDBACK_REPO: %s", ghRepo)
 		} else {
-			issue, _, err := ghClient.Issues.Create(r.Context(), parts[0], parts[1], &github.IssueRequest{
+			issue, _, err := ghClient.Issues.Create(ghCtx, parts[0], parts[1], &github.IssueRequest{
 				Title:  github.Ptr(title),
 				Body:   github.Ptr(body),
 				Labels: &[]string{label},
@@ -1593,6 +1596,7 @@ func (a *API) handleFeedback(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
+	cancelGitHub()
 
 	// Channel 2: notification email via the platform relay (hitlnotify-style
 	// compose + direct submit; the durable outbound pipeline requires an agent
@@ -1613,7 +1617,10 @@ func (a *API) handleFeedback(w http.ResponseWriter, r *http.Request) {
 				ghNote = "GitHub issue: creation FAILED (see server logs)"
 			}
 		}
-		if err := a.sendFeedbackEmail(title, req.Category, req.Message, req.Email, ghNote, notifyTo, notifyCC); err != nil {
+		emailCtx, cancelEmail := context.WithTimeout(r.Context(), feedbackEmailTimeout)
+		err := a.sendFeedbackEmail(emailCtx, title, req.Category, req.Message, req.Email, ghNote, notifyTo, notifyCC)
+		cancelEmail()
+		if err != nil {
 			log.Printf("feedback: notify email failed: %v", err)
 		} else {
 			delivered++
@@ -1641,7 +1648,7 @@ func (a *API) handleFeedback(w http.ResponseWriter, r *http.Request) {
 // Reply-To carries the submitter's address when given, so replying to the
 // notification reaches them directly; compose-layer header sanitization
 // neutralizes any CR/LF in that user-controlled value.
-func (a *API) sendFeedbackEmail(title, category, message, submitterEmail, ghNote string, to, cc []string) error {
+func (a *API) sendFeedbackEmail(ctx context.Context, title, category, message, submitterEmail, ghNote string, to, cc []string) error {
 	if a.smtpRelay == nil || !a.smtpRelay.Configured() || a.fromDomain == "" {
 		return fmt.Errorf("outbound SMTP relay not configured")
 	}
@@ -1670,7 +1677,7 @@ func (a *API) sendFeedbackEmail(title, category, message, submitterEmail, ghNote
 
 	// Send (not SendOnce) — no job queue owns retries for this path, so the
 	// relay's own transient-4xx backoff is the only retry envelope.
-	if _, err := a.smtpRelay.Send(from, rcpts, raw); err != nil {
+	if _, err := a.smtpRelay.SendWithContext(ctx, from, rcpts, raw); err != nil {
 		return fmt.Errorf("smtp send: %w", err)
 	}
 	return nil

--- a/internal/agent/api_test.go
+++ b/internal/agent/api_test.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"mime"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -330,5 +332,104 @@ func TestFeedback_MethodNotAllowed(t *testing.T) {
 
 	if resp.StatusCode != 405 {
 		t.Errorf("status = %d, want 405 for GET on feedback endpoint", resp.StatusCode)
+	}
+}
+
+// With the email channel configured (and GitHub off), a submission delivers
+// via the platform relay: one message, To+Cc in the envelope, submitter in
+// Reply-To and the body.
+func TestFeedback_EmailNotification(t *testing.T) {
+	server, _, _, smtpDone := setupAPIWithSMTP(t)
+	t.Setenv("GITHUB_FEEDBACK_TOKEN", "")
+	t.Setenv("FEEDBACK_NOTIFY_TO", "feedback-to@example.com")
+	t.Setenv("FEEDBACK_NOTIFY_CC", "feedback-cc@example.com")
+
+	payload := `{"email":"user@example.com","category":"bug","message":"Something is broken"}`
+	resp, err := http.Post(server.URL+"/api/feedback", "application/json", bytes.NewBufferString(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		t.Errorf("status = %d, want 200 (email channel delivers with GitHub off)", resp.StatusCode)
+	}
+
+	msgs := smtpDone()
+	if len(msgs) != 1 {
+		t.Fatalf("smtp messages = %d, want 1", len(msgs))
+	}
+	m := msgs[0]
+
+	if m.From != "noreply@test.e2a.dev" {
+		t.Errorf("envelope from = %q, want noreply@test.e2a.dev", m.From)
+	}
+	wantRcpts := []string{"feedback-to@example.com", "feedback-cc@example.com"}
+	if strings.Join(m.Recipients, ",") != strings.Join(wantRcpts, ",") {
+		t.Errorf("recipients = %v, want %v", m.Recipients, wantRcpts)
+	}
+	for _, want := range []string{
+		"To: feedback-to@example.com",
+		"Cc: feedback-cc@example.com",
+		"Reply-To: user@example.com",
+		"Category: bug",
+		"Submitted by: user@example.com",
+		"Something is broken",
+	} {
+		if !strings.Contains(m.Data, want) {
+			t.Errorf("message data missing %q", want)
+		}
+	}
+
+	// Subject is Q-encoded — decode before comparing. (fakesmtp captures
+	// Data with bare "\n" line endings, not the on-wire CRLF.)
+	headers := m.Data
+	if i := strings.Index(headers, "\n\n"); i >= 0 {
+		headers = headers[:i]
+	}
+	headers = strings.ReplaceAll(headers, "\n ", " ") // unfold
+	subject := ""
+	for _, line := range strings.Split(headers, "\n") {
+		if strings.HasPrefix(line, "Subject: ") {
+			subject = strings.TrimPrefix(line, "Subject: ")
+		}
+	}
+	decoded, err := new(mime.WordDecoder).DecodeHeader(subject)
+	if err != nil {
+		t.Fatalf("decode subject %q: %v", subject, err)
+	}
+	if want := "[e2a feedback] [bug] Something is broken"; decoded != want {
+		t.Errorf("subject = %q, want %q", decoded, want)
+	}
+}
+
+// When every configured channel fails (here: email on but the relay is
+// unreachable, GitHub off), the submission must surface a 500 so the user
+// knows it didn't land — the old log-only fallback only applies when NO
+// channel is configured.
+func TestFeedback_AllChannelsFail_500(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	deadRelay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{Host: "127.0.0.1", Port: 1})
+	sender := outbound.NewSender(deadRelay, "test.e2a.dev")
+	api := agent.NewAPI(store, sender, deadRelay, nil, usage.NewNoopUsageTracker(), "e2a.dev", "test.e2a.dev", "agents.e2a.dev", "", false)
+	router := mux.NewRouter()
+	api.RegisterRoutes(router)
+	server := httptest.NewServer(router)
+	t.Cleanup(server.Close)
+
+	t.Setenv("GITHUB_FEEDBACK_TOKEN", "")
+	t.Setenv("FEEDBACK_NOTIFY_TO", "feedback-to@example.com")
+	t.Setenv("FEEDBACK_NOTIFY_CC", "")
+
+	payload := `{"category":"general","message":"this should not land anywhere"}`
+	resp, err := http.Post(server.URL+"/api/feedback", "application/json", bytes.NewBufferString(payload))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 500 {
+		t.Errorf("status = %d, want 500 when every configured channel fails", resp.StatusCode)
 	}
 }

--- a/internal/agent/feedback_github.go
+++ b/internal/agent/feedback_github.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"time"
@@ -19,9 +20,12 @@ import (
 	"github.com/google/go-github/v72/github"
 )
 
-// githubAPIBaseURL is the GitHub REST root used for the App installation-token
-// exchange. A var (not const) so tests can point it at an httptest server.
-var githubAPIBaseURL = "https://api.github.com"
+// These are vars so tests can point the client at an httptest server and use a
+// short deadline without slowing the package suite.
+var (
+	githubAPIBaseURL      = "https://api.github.com"
+	feedbackGitHubTimeout = 10 * time.Second
+)
 
 // feedbackGitHubClient resolves the GitHub credential for the feedback →
 // issue channel, in precedence order:
@@ -46,16 +50,26 @@ func feedbackGitHubClient(ctx context.Context) (*github.Client, error) {
 		if err != nil {
 			return nil, fmt.Errorf("github app auth: %w", err)
 		}
-		return github.NewClient(nil).WithAuthToken(tok), nil
+		return newFeedbackGitHubClient(tok)
 	}
 	if appID != "" || instID != "" || privKey != "" {
 		log.Printf("feedback: GITHUB_FEEDBACK_APP_* partially set (need APP_ID, APP_INSTALLATION_ID, APP_PRIVATE_KEY) — falling back to GITHUB_FEEDBACK_TOKEN")
 	}
 
 	if pat := os.Getenv("GITHUB_FEEDBACK_TOKEN"); pat != "" {
-		return github.NewClient(nil).WithAuthToken(pat), nil
+		return newFeedbackGitHubClient(pat)
 	}
 	return nil, nil
+}
+
+func newFeedbackGitHubClient(token string) (*github.Client, error) {
+	client := github.NewClient(&http.Client{Timeout: feedbackGitHubTimeout})
+	baseURL, err := url.Parse(strings.TrimRight(githubAPIBaseURL, "/") + "/")
+	if err != nil {
+		return nil, fmt.Errorf("github api base url: %w", err)
+	}
+	client.BaseURL = baseURL
+	return client.WithAuthToken(token), nil
 }
 
 // exchangeInstallationToken signs a short-lived RS256 app JWT and exchanges it
@@ -92,7 +106,7 @@ func exchangeInstallationToken(ctx context.Context, appID, installationID, privK
 	req.Header.Set("Authorization", "Bearer "+appJWT)
 	req.Header.Set("Accept", "application/vnd.github+json")
 
-	resp, err := (&http.Client{Timeout: 15 * time.Second}).Do(req)
+	resp, err := (&http.Client{Timeout: feedbackGitHubTimeout}).Do(req)
 	if err != nil {
 		return "", fmt.Errorf("token exchange: %w", err)
 	}

--- a/internal/agent/feedback_github.go
+++ b/internal/agent/feedback_github.go
@@ -1,0 +1,147 @@
+package agent
+
+import (
+	"context"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	jose "github.com/go-jose/go-jose/v3"
+	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/google/go-github/v72/github"
+)
+
+// githubAPIBaseURL is the GitHub REST root used for the App installation-token
+// exchange. A var (not const) so tests can point it at an httptest server.
+var githubAPIBaseURL = "https://api.github.com"
+
+// feedbackGitHubClient resolves the GitHub credential for the feedback →
+// issue channel, in precedence order:
+//
+//  1. GitHub App — GITHUB_FEEDBACK_APP_ID + GITHUB_FEEDBACK_APP_INSTALLATION_ID
+//     + GITHUB_FEEDBACK_APP_PRIVATE_KEY all set: sign an app JWT and exchange
+//     it for an installation access token. The token is minted fresh per
+//     submission — feedback volume is far too low to need a token cache.
+//  2. PAT fallback — GITHUB_FEEDBACK_TOKEN (a static token; what self-hosters
+//     typically set).
+//
+// A partially-set App config falls through to the PAT with a loud log line —
+// a typo'd var name must not silently strand the deployment on the lesser
+// credential. (nil, nil) means the channel is off.
+func feedbackGitHubClient(ctx context.Context) (*github.Client, error) {
+	appID := os.Getenv("GITHUB_FEEDBACK_APP_ID")
+	instID := os.Getenv("GITHUB_FEEDBACK_APP_INSTALLATION_ID")
+	privKey := os.Getenv("GITHUB_FEEDBACK_APP_PRIVATE_KEY")
+
+	if appID != "" && instID != "" && privKey != "" {
+		tok, err := exchangeInstallationToken(ctx, appID, instID, privKey)
+		if err != nil {
+			return nil, fmt.Errorf("github app auth: %w", err)
+		}
+		return github.NewClient(nil).WithAuthToken(tok), nil
+	}
+	if appID != "" || instID != "" || privKey != "" {
+		log.Printf("feedback: GITHUB_FEEDBACK_APP_* partially set (need APP_ID, APP_INSTALLATION_ID, APP_PRIVATE_KEY) — falling back to GITHUB_FEEDBACK_TOKEN")
+	}
+
+	if pat := os.Getenv("GITHUB_FEEDBACK_TOKEN"); pat != "" {
+		return github.NewClient(nil).WithAuthToken(pat), nil
+	}
+	return nil, nil
+}
+
+// exchangeInstallationToken signs a short-lived RS256 app JWT and exchanges it
+// for an installation access token scoped to the repos the installation sees.
+// Mirrors the agentauth signing idiom (go-jose RS256, compact JWT).
+func exchangeInstallationToken(ctx context.Context, appID, installationID, privKey string) (string, error) {
+	key, err := parseGitHubAppKey(privKey)
+	if err != nil {
+		return "", err
+	}
+
+	sig, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: key},
+		(&jose.SignerOptions{}).WithType("JWT"),
+	)
+	if err != nil {
+		return "", fmt.Errorf("build signer: %w", err)
+	}
+	now := time.Now()
+	appJWT, err := jwt.Signed(sig).Claims(jwt.Claims{
+		Issuer:   appID,
+		IssuedAt: jwt.NewNumericDate(now.Add(-60 * time.Second)), // clock-skew margin
+		Expiry:   jwt.NewNumericDate(now.Add(9 * time.Minute)),   // GitHub caps JWTs at 10m
+	}).CompactSerialize()
+	if err != nil {
+		return "", fmt.Errorf("sign app jwt: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/app/installations/%s/access_tokens", githubAPIBaseURL, installationID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, nil)
+	if err != nil {
+		return "", fmt.Errorf("build token request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+appJWT)
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := (&http.Client{Timeout: 15 * time.Second}).Do(req)
+	if err != nil {
+		return "", fmt.Errorf("token exchange: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		return "", fmt.Errorf("token exchange: status %s", resp.Status)
+	}
+	var out struct {
+		Token string `json:"token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", fmt.Errorf("token exchange: decode: %w", err)
+	}
+	if out.Token == "" {
+		return "", fmt.Errorf("token exchange: empty token in response")
+	}
+	return out.Token, nil
+}
+
+// parseGitHubAppKey decodes the app private key from env form: either
+// base64-encoded PEM (canonical — survives .env / compose quoting) or raw PEM
+// with literal `\n` escapes.
+func parseGitHubAppKey(raw string) (*rsa.PrivateKey, error) {
+	raw = strings.TrimSpace(raw)
+	var pemBytes []byte
+	if strings.Contains(raw, "-----BEGIN") {
+		pemBytes = []byte(strings.ReplaceAll(raw, `\n`, "\n"))
+	} else {
+		b, err := base64.StdEncoding.DecodeString(raw)
+		if err != nil {
+			return nil, fmt.Errorf("app private key: neither PEM nor base64: %w", err)
+		}
+		pemBytes = b
+	}
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, fmt.Errorf("app private key: no PEM block found")
+	}
+	// GitHub emits PKCS#1 ("BEGIN RSA PRIVATE KEY"); accept PKCS#8 too.
+	if k, err := x509.ParsePKCS1PrivateKey(block.Bytes); err == nil {
+		return k, nil
+	}
+	k, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("app private key: parse: %w", err)
+	}
+	rsaKey, ok := k.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("app private key: not an RSA key")
+	}
+	return rsaKey, nil
+}

--- a/internal/agent/feedback_github_test.go
+++ b/internal/agent/feedback_github_test.go
@@ -1,0 +1,153 @@
+package agent
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v3/jwt"
+)
+
+// testAppKey generates a throwaway RSA key and returns it plus its
+// base64-encoded PKCS#1 PEM (the canonical GITHUB_FEEDBACK_APP_PRIVATE_KEY
+// env form).
+func testAppKey(t *testing.T) (*rsa.PrivateKey, string) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	return key, base64.StdEncoding.EncodeToString(pemBytes)
+}
+
+func TestParseGitHubAppKey(t *testing.T) {
+	key, b64 := testAppKey(t)
+
+	got, err := parseGitHubAppKey(b64)
+	if err != nil {
+		t.Fatalf("base64 form: %v", err)
+	}
+	if got.N.Cmp(key.N) != 0 {
+		t.Error("base64 form: wrong key")
+	}
+
+	// Raw PEM with literal `\n` escapes (the other accepted env form).
+	pemBytes, _ := base64.StdEncoding.DecodeString(b64)
+	escaped := strings.ReplaceAll(string(pemBytes), "\n", `\n`)
+	got, err = parseGitHubAppKey(escaped)
+	if err != nil {
+		t.Fatalf("escaped PEM form: %v", err)
+	}
+	if got.N.Cmp(key.N) != 0 {
+		t.Error("escaped PEM form: wrong key")
+	}
+
+	if _, err := parseGitHubAppKey("not-a-key"); err == nil {
+		t.Error("expected error for garbage input")
+	}
+}
+
+func TestExchangeInstallationToken(t *testing.T) {
+	key, b64 := testAppKey(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/app/installations/123/access_tokens" || r.Method != http.MethodPost {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		raw := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		tok, err := jwt.ParseSigned(raw)
+		if err != nil {
+			t.Errorf("parse app jwt: %v", err)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		var claims jwt.Claims
+		if err := tok.Claims(&key.PublicKey, &claims); err != nil {
+			t.Errorf("verify app jwt signature: %v", err)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if claims.Issuer != "456" {
+			t.Errorf("iss = %q, want %q", claims.Issuer, "456")
+		}
+		if claims.Expiry == nil || claims.IssuedAt == nil {
+			t.Error("app jwt missing iat/exp")
+		} else if d := claims.Expiry.Time().Sub(claims.IssuedAt.Time()); d < 9*time.Minute || d > 11*time.Minute {
+			t.Errorf("app jwt lifetime = %s, want ~10m", d)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		json.NewEncoder(w).Encode(map[string]string{"token": "ghs_test_token"})
+	}))
+	defer srv.Close()
+
+	old := githubAPIBaseURL
+	githubAPIBaseURL = srv.URL
+	defer func() { githubAPIBaseURL = old }()
+
+	tok, err := exchangeInstallationToken(context.Background(), "456", "123", b64)
+	if err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	if tok != "ghs_test_token" {
+		t.Errorf("token = %q, want %q", tok, "ghs_test_token")
+	}
+}
+
+func TestExchangeInstallationToken_ErrorStatus(t *testing.T) {
+	_, b64 := testAppKey(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	old := githubAPIBaseURL
+	githubAPIBaseURL = srv.URL
+	defer func() { githubAPIBaseURL = old }()
+
+	if _, err := exchangeInstallationToken(context.Background(), "456", "999", b64); err == nil {
+		t.Error("expected error on non-201 exchange response")
+	}
+}
+
+func TestFeedbackGitHubClient_Precedence(t *testing.T) {
+	// Hermetic env — none of the four vars leak in from the host.
+	t.Setenv("GITHUB_FEEDBACK_APP_ID", "")
+	t.Setenv("GITHUB_FEEDBACK_APP_INSTALLATION_ID", "")
+	t.Setenv("GITHUB_FEEDBACK_APP_PRIVATE_KEY", "")
+	t.Setenv("GITHUB_FEEDBACK_TOKEN", "")
+
+	// Nothing set → channel off.
+	if c, err := feedbackGitHubClient(context.Background()); c != nil || err != nil {
+		t.Errorf("no env: got client=%v err=%v, want nil,nil", c, err)
+	}
+
+	// PAT fallback.
+	t.Setenv("GITHUB_FEEDBACK_TOKEN", "pat")
+	if c, err := feedbackGitHubClient(context.Background()); c == nil || err != nil {
+		t.Errorf("PAT: got client=%v err=%v, want client,nil", c, err)
+	}
+
+	// Partial app config → loud log, still PAT.
+	t.Setenv("GITHUB_FEEDBACK_APP_ID", "456")
+	if c, err := feedbackGitHubClient(context.Background()); c == nil || err != nil {
+		t.Errorf("partial app config: got client=%v err=%v, want client,nil", c, err)
+	}
+
+	// Full app config with a bogus key → hard error, no silent PAT fallback.
+	t.Setenv("GITHUB_FEEDBACK_APP_INSTALLATION_ID", "123")
+	t.Setenv("GITHUB_FEEDBACK_APP_PRIVATE_KEY", "bogus")
+	if c, err := feedbackGitHubClient(context.Background()); err == nil || c != nil {
+		t.Errorf("bad app key: got client=%v err=%v, want nil,error", c, err)
+	}
+}

--- a/internal/agent/feedback_github_test.go
+++ b/internal/agent/feedback_github_test.go
@@ -1,6 +1,8 @@
 package agent
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
@@ -8,6 +10,8 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -15,7 +19,193 @@ import (
 	"time"
 
 	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/gorilla/mux"
+	"github.com/tokencanopy/e2a/internal/config"
+	"github.com/tokencanopy/e2a/internal/outbound"
+	"github.com/tokencanopy/e2a/internal/usage"
 )
+
+func startFeedbackSMTPServer(t *testing.T) (host string, port int, received <-chan string) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	messages := make(chan string, 1)
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer conn.Close()
+		reader := bufio.NewReader(conn)
+		fmt.Fprint(conn, "220 feedback-test ready\r\n")
+		var data []string
+		inData := false
+		for {
+			line, readErr := reader.ReadString('\n')
+			if readErr != nil {
+				return
+			}
+			line = strings.TrimRight(line, "\r\n")
+			if inData {
+				if line == "." {
+					messages <- strings.Join(data, "\n")
+					fmt.Fprint(conn, "250 Ok feedback-test-id\r\n")
+					inData = false
+					continue
+				}
+				data = append(data, line)
+				continue
+			}
+			if strings.EqualFold(line, "DATA") {
+				inData = true
+				fmt.Fprint(conn, "354 Go ahead\r\n")
+				continue
+			}
+			if strings.EqualFold(line, "QUIT") {
+				fmt.Fprint(conn, "221 Bye\r\n")
+				return
+			}
+			fmt.Fprint(conn, "250 OK\r\n")
+		}
+	}()
+
+	addr := listener.Addr().(*net.TCPAddr)
+	return addr.IP.String(), addr.Port, messages
+}
+
+func startHangingFeedbackSMTPServer(t *testing.T) (host string, port int) {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr == nil {
+			accepted <- conn
+		}
+	}()
+	t.Cleanup(func() {
+		_ = listener.Close()
+		select {
+		case conn := <-accepted:
+			_ = conn.Close()
+		default:
+		}
+	})
+	addr := listener.Addr().(*net.TCPAddr)
+	return addr.IP.String(), addr.Port
+}
+
+func TestFeedbackGitHubTimeoutStillDeliversEmail(t *testing.T) {
+	releaseGitHub := make(chan struct{})
+	githubServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-releaseGitHub:
+		}
+	}))
+	defer githubServer.Close()
+	defer close(releaseGitHub)
+
+	oldBaseURL := githubAPIBaseURL
+	githubAPIBaseURL = githubServer.URL
+	defer func() { githubAPIBaseURL = oldBaseURL }()
+	oldTimeout := feedbackGitHubTimeout
+	feedbackGitHubTimeout = 50 * time.Millisecond
+	defer func() { feedbackGitHubTimeout = oldTimeout }()
+
+	t.Setenv("GITHUB_FEEDBACK_APP_ID", "")
+	t.Setenv("GITHUB_FEEDBACK_APP_INSTALLATION_ID", "")
+	t.Setenv("GITHUB_FEEDBACK_APP_PRIVATE_KEY", "")
+	t.Setenv("GITHUB_FEEDBACK_TOKEN", "pat")
+	t.Setenv("GITHUB_FEEDBACK_REPO", "owner/repo")
+	t.Setenv("FEEDBACK_NOTIFY_TO", "feedback@example.com")
+	t.Setenv("FEEDBACK_NOTIFY_CC", "")
+
+	smtpHost, smtpPort, smtpMessages := startFeedbackSMTPServer(t)
+	relay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{Host: smtpHost, Port: smtpPort})
+	sender := outbound.NewSender(relay, "test.e2a.dev")
+	api := NewAPI(nil, sender, relay, nil, usage.NewNoopUsageTracker(), "e2a.dev", "test.e2a.dev", "agents.e2a.dev", "", false)
+	router := mux.NewRouter()
+	api.RegisterRoutes(router)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	started := time.Now()
+	resp, err := http.Post(server.URL+"/api/feedback", "application/json", bytes.NewBufferString(`{"category":"bug","message":"GitHub is stuck"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 because email delivered", resp.StatusCode)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("feedback returned after %s, want bounded GitHub failure within 1s", elapsed)
+	}
+
+	var message string
+	select {
+	case message = <-smtpMessages:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for feedback email")
+	}
+	if !strings.Contains(message, "GitHub issue: creation FAILED") {
+		t.Fatalf("email did not report GitHub failure:\n%s", message)
+	}
+}
+
+func TestFeedbackEmailTimeoutReturnsAfterGitHubDelivery(t *testing.T) {
+	githubServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"html_url":"https://github.example/owner/repo/issues/1"}`))
+	}))
+	defer githubServer.Close()
+
+	oldBaseURL := githubAPIBaseURL
+	githubAPIBaseURL = githubServer.URL
+	defer func() { githubAPIBaseURL = oldBaseURL }()
+	oldTimeout := feedbackEmailTimeout
+	feedbackEmailTimeout = 50 * time.Millisecond
+	defer func() { feedbackEmailTimeout = oldTimeout }()
+
+	t.Setenv("GITHUB_FEEDBACK_APP_ID", "")
+	t.Setenv("GITHUB_FEEDBACK_APP_INSTALLATION_ID", "")
+	t.Setenv("GITHUB_FEEDBACK_APP_PRIVATE_KEY", "")
+	t.Setenv("GITHUB_FEEDBACK_TOKEN", "pat")
+	t.Setenv("GITHUB_FEEDBACK_REPO", "owner/repo")
+	t.Setenv("FEEDBACK_NOTIFY_TO", "feedback@example.com")
+	t.Setenv("FEEDBACK_NOTIFY_CC", "")
+
+	smtpHost, smtpPort := startHangingFeedbackSMTPServer(t)
+	relay := outbound.NewSMTPRelay(&config.OutboundSMTPConfig{Host: smtpHost, Port: smtpPort})
+	sender := outbound.NewSender(relay, "test.e2a.dev")
+	api := NewAPI(nil, sender, relay, nil, usage.NewNoopUsageTracker(), "e2a.dev", "test.e2a.dev", "agents.e2a.dev", "", false)
+	router := mux.NewRouter()
+	api.RegisterRoutes(router)
+	server := httptest.NewServer(router)
+	defer server.Close()
+
+	started := time.Now()
+	resp, err := http.Post(server.URL+"/api/feedback", "application/json", bytes.NewBufferString(`{"category":"general","message":"SMTP is stuck"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 because GitHub delivered", resp.StatusCode)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("feedback returned after %s, want bounded SMTP failure within 1s", elapsed)
+	}
+}
 
 // testAppKey generates a throwaway RSA key and returns it plus its
 // base64-encoded PKCS#1 PEM (the canonical GITHUB_FEEDBACK_APP_PRIVATE_KEY

--- a/internal/outbound/smtp_relay.go
+++ b/internal/outbound/smtp_relay.go
@@ -1,6 +1,7 @@
 package outbound
 
 import (
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -30,7 +31,14 @@ func (r *SMTPRelay) Configured() bool {
 
 // Send sends an email to one or more recipients and returns the Message-ID assigned by the remote server (e.g. SES).
 func (r *SMTPRelay) Send(from string, recipients []string, message []byte) (string, error) {
-	return r.SendWithEnvelope(from, recipients, message)
+	return r.SendWithContext(context.Background(), from, recipients, message)
+}
+
+// SendWithContext sends an email while honoring ctx during SMTP I/O and retry
+// backoff. It is intended for request-bound callers that cannot allow the
+// relay's normal retry envelope to outlive the request budget.
+func (r *SMTPRelay) SendWithContext(ctx context.Context, from string, recipients []string, message []byte) (string, error) {
+	return r.SendWithEnvelopeContext(ctx, from, recipients, message)
 }
 
 // SendWithEnvelope sends an email using envelopeFrom for SMTP MAIL FROM.
@@ -38,24 +46,37 @@ func (r *SMTPRelay) Send(from string, recipients []string, message []byte) (stri
 // Returns the Message-ID assigned by the remote SMTP server from the DATA response.
 // Retries transient SMTP errors (4xx) up to 3 times with backoff.
 func (r *SMTPRelay) SendWithEnvelope(envelopeFrom string, recipients []string, message []byte) (string, error) {
+	return r.SendWithEnvelopeContext(context.Background(), envelopeFrom, recipients, message)
+}
+
+// SendWithEnvelopeContext is SendWithEnvelope with caller-controlled
+// cancellation and deadline propagation.
+func (r *SMTPRelay) SendWithEnvelopeContext(ctx context.Context, envelopeFrom string, recipients []string, message []byte) (string, error) {
 	if !r.Configured() {
 		return "", fmt.Errorf("outbound SMTP relay not configured")
 	}
 
 	var lastErr error
 	for attempt := 0; attempt <= len(smtpRetryBackoffs); attempt++ {
-		msgID, err := r.sendOnce(envelopeFrom, recipients, message)
+		msgID, err := r.sendOnceContext(ctx, envelopeFrom, recipients, message)
 		if err == nil {
 			return msgID, nil
 		}
 		lastErr = err
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
 		if !isTransientSMTPError(lastErr) {
 			return "", lastErr
 		}
 		if attempt < len(smtpRetryBackoffs) {
 			log.Printf("[smtp-relay] transient error sending to %v (attempt %d/%d), retrying in %s: %v",
 				recipients, attempt+1, len(smtpRetryBackoffs)+1, smtpRetryBackoffs[attempt], lastErr)
-			time.Sleep(smtpRetryBackoffs[attempt])
+			select {
+			case <-time.After(smtpRetryBackoffs[attempt]):
+			case <-ctx.Done():
+				return "", ctx.Err()
+			}
 		}
 	}
 	return "", lastErr
@@ -72,7 +93,7 @@ func (r *SMTPRelay) SendOnce(envelopeFrom string, recipients []string, message [
 	if !r.Configured() {
 		return "", fmt.Errorf("outbound SMTP relay not configured")
 	}
-	return r.sendOnce(envelopeFrom, recipients, message)
+	return r.sendOnceContext(context.Background(), envelopeFrom, recipients, message)
 }
 
 // IsTransientSMTPError reports whether err is a retryable SMTP failure (4xx /
@@ -137,15 +158,31 @@ func IsConnectionError(err error) bool {
 // SES returns the assigned Message-ID in the 250 response after DATA, e.g.:
 //
 //	250 Ok <010f019d2bd82cd5-49c4925c-...@us-east-2.amazonses.com>
-func (r *SMTPRelay) sendOnce(envelopeFrom string, recipients []string, message []byte) (string, error) {
+func (r *SMTPRelay) sendOnceContext(ctx context.Context, envelopeFrom string, recipients []string, message []byte) (msgID string, err error) {
+	defer func() {
+		if err != nil && ctx.Err() != nil {
+			err = ctx.Err()
+		}
+	}()
+
 	addr := net.JoinHostPort(r.cfg.Host, fmt.Sprintf("%d", r.cfg.Port))
 
-	conn, err := net.DialTimeout("tcp", addr, 30*time.Second)
+	dialer := net.Dialer{Timeout: 30 * time.Second}
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
 	if err != nil {
 		return "", fmt.Errorf("dial: %w", err)
 	}
 	// Set an overall deadline so a hanging server can't block forever
-	conn.SetDeadline(time.Now().Add(2 * time.Minute))
+	deadline := time.Now().Add(2 * time.Minute)
+	if ctxDeadline, ok := ctx.Deadline(); ok && ctxDeadline.Before(deadline) {
+		deadline = ctxDeadline
+	}
+	if err := conn.SetDeadline(deadline); err != nil {
+		_ = conn.Close()
+		return "", fmt.Errorf("set smtp deadline: %w", err)
+	}
+	stopCancel := context.AfterFunc(ctx, func() { _ = conn.SetDeadline(time.Now()) })
+	defer stopCancel()
 
 	c, err := smtp.NewClient(conn, r.cfg.Host)
 	if err != nil {

--- a/internal/outbound/smtp_relay_test.go
+++ b/internal/outbound/smtp_relay_test.go
@@ -1,14 +1,53 @@
 package outbound
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net"
 	"net/textproto"
 	"testing"
+	"time"
 
 	"github.com/tokencanopy/e2a/internal/config"
 )
+
+func TestSMTPRelaySendWithContextCancelsHangingServer(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		conn, acceptErr := listener.Accept()
+		if acceptErr == nil {
+			accepted <- conn
+		}
+	}()
+	t.Cleanup(func() {
+		select {
+		case conn := <-accepted:
+			_ = conn.Close()
+		default:
+		}
+	})
+
+	addr := listener.Addr().(*net.TCPAddr)
+	relay := NewSMTPRelay(&config.OutboundSMTPConfig{Host: addr.IP.String(), Port: addr.Port})
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	started := time.Now()
+	_, err = relay.SendWithContext(ctx, "noreply@example.com", []string{"feedback@example.com"}, []byte("Subject: test\r\n\r\nbody"))
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("SendWithContext error = %v, want context deadline exceeded", err)
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("SendWithContext returned after %s, want cancellation within 1s", elapsed)
+	}
+}
 
 // smtpErr mirrors PRODUCTION's error shape: net/smtp returns a *textproto.Error for
 // a non-2xx reply, which sendOnce wraps with a command prefix via %w. The


### PR DESCRIPTION
## Why

Prod incident: the feedback form (`POST /api/feedback`) 500'd on every submission because the `GITHUB_FEEDBACK_TOKEN` PAT had expired — and since GitHub was the only delivery channel, **user feedback was silently lost** (the UI just showed "Something went wrong"). Two independent breaks made it worse: the `Mnexa-AI` → `tokencanopy` org rename changed the API path's redirect behavior (301 rewrites POST→GET), so even a fresh PAT against the old default would have failed.

## What

`POST /api/feedback` now **fans out to every configured channel** and succeeds when at least one delivers:

| State | Response |
| --- | --- |
| ≥1 channel delivers | `200 ok` |
| All configured channels fail | `500` (unchanged for GitHub-only deployments) |
| No channels configured | `200` log-only fallback (unchanged self-host behavior) |

**Channel 1 — GitHub issue, now with GitHub App auth** (`internal/agent/feedback_github.go`):
- When `GITHUB_FEEDBACK_APP_ID` + `GITHUB_FEEDBACK_APP_INSTALLATION_ID` + `GITHUB_FEEDBACK_APP_PRIVATE_KEY` are all set, the server signs a short-lived RS256 app JWT (go-jose, same idiom as `agentauth`) and exchanges it for an installation token per submission. No PAT to rotate; feedback volume is far too low to need a token cache.
- Private key accepted as base64-encoded PEM (canonical, survives `.env`/compose quoting) or raw PEM with `\n` escapes.
- Partially-set app config → loud log + PAT fallback (`GITHUB_FEEDBACK_TOKEN`). Fully-set-but-broken app config → hard error, never a silent fallback.

**Channel 2 — notification email** (new, hitlnotify-style):
- `FEEDBACK_NOTIFY_TO` / `FEEDBACK_NOTIFY_CC` (comma-separated, empty = channel off). Compose via `outbound.ComposeMessage` (To+Cc, compose-layer CR/LF stripping), submit via `SMTPRelay.Send` — its transient-4xx backoff is the retry envelope since no job queue owns this path (the durable pipeline requires an agent identity, which feedback has none).
- `From: "e2a" <noreply@<from_domain>>`; submitter address in `Reply-To`; body carries category, submitter, message, and the **GitHub outcome** — when the issue channel breaks, the email doubles as the alert.

## Tests

- Email channel end-to-end via `FakeSMTPServer`: envelope To+Cc, `Reply-To`, decoded subject, body contents; 200 with GitHub off.
- All-configured-channels-fail → 500 (dead relay, GitHub off).
- App auth: key parsing (base64 / escaped-PEM / garbage), JWT signature + `iss`/lifetime against a fake token endpoint, non-201 exchange error, credential precedence matrix (none / PAT / partial-app / full-app-bad-key).
- Full `internal/agent` package green against merged `main`.

## Deployment

Companion ops PR [tokencanopy/e2a-ops#191](https://github.com/tokencanopy/e2a-ops/pull/191) wires the env (`GITHUB_FEEDBACK_APP_*`, `FEEDBACK_NOTIFY_TO/CC`, `GITHUB_FEEDBACK_REPO` pinned) and the VM `.env` is already staged. Inert-by-default: a deployment without the new env vars behaves exactly as before.
