### PR TITLE
feat(api): raise the per-user poll rate limit from 60/min to 240/min

### DIFF
--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -498,6 +498,7 @@ func main() {
 	// the web app (the authorization_endpoint + login/consent stay on
 	// public_url because they need the web app's session cookie).
 	api.SetAPIURL(cfg.HTTP.APIURL)
+	api.SetPollRateLimit(cfg.RateLimits.PollPerMinute)
 	// HITL magic-link token signer reuses the shared HMAC secret so operators
 	// don't have to configure a second key.
 	approvalSigner := approvaltoken.NewSigner(cfg.Signing.HMACSecret)

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -173,6 +173,13 @@ limits:
   # billing_hook_url: "http://billing:9000/api/internal/billing/cancel"
   billing_hook_url: ""
 
+# Per-user budget shared by authenticated message, conversation, and webhook
+# reads across every agent client and dashboard session on the account. The
+# default allows 240 requests per minute; tune this for the combined workload,
+# not for one polling client. Rate limits are in-memory and apply per process.
+rate_limits:
+  poll_per_minute: 240
+
 # — Trash (soft delete) ———————————————————————————————————————————————————————
 # How many days a soft-deleted resource (agent inbox or message) stays
 # restorable in the trash before it is purged permanently. The public API

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -33,6 +33,13 @@ Copy `config.example.yaml` to `config.yaml` and fill in values, or set the envir
 
 `env: production` in [config.example.yaml](../config.example.yaml) enforces TLS for SMTP and HTTPS for webhook URLs. Leave it as `development` for local work.
 
+Non-secret request-rate tuning lives in `config.yaml`. The
+`rate_limits.poll_per_minute` setting controls the per-user budget shared by
+authenticated message, conversation, and webhook reads across all agent
+clients and dashboard sessions for that account. It defaults to 240 requests
+per minute and, like the other in-memory rate limits, applies independently to
+each server process.
+
 ### Shared-domain setup
 
 If you set `E2A_SHARED_DOMAIN` (or `shared_domain` in `config.yaml`) so users can register agents with just a slug — `alice@agents.yourcompany.com` — there are two parts to it: DNS you set up once, and a database row the server takes care of for you.

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -521,10 +521,10 @@ func NewAPI(store *identity.Store, sender *outbound.Sender, smtpRelay *outbound.
 		publicURL:    publicURL,
 		// Default the API/issuer URL to the web URL; SetAPIURL overrides it
 		// for split web/API-host deployments.
-		apiURL:           publicURL,
-		production:       production,
-		sendLimit:        ratelimit.New(1*time.Minute, 60),                           // 60 sends per agent per minute
-		regLimit:         ratelimit.New(1*time.Hour, 200),                            // 200 registrations per IP per hour
+		apiURL:     publicURL,
+		production: production,
+		sendLimit:  ratelimit.New(1*time.Minute, 60), // 60 sends per agent per minute
+		regLimit:   ratelimit.New(1*time.Hour, 200),  // 200 registrations per IP per hour
 		// The poll bucket is keyed per USER and shared by every reader the
 		// account runs — each agent's polling loop plus the dashboard, whose
 		// thread view fetches message bodies individually. 60/min starved
@@ -538,15 +538,14 @@ func NewAPI(store *identity.Store, sender *outbound.Sender, smtpRelay *outbound.
 	}
 }
 
-// SetPollRateLimit replaces the per-user poll limiter with a fresh bucket of
-// perMinute requests per minute (config: rate_limits.poll_per_minute). Values
-// <= 0 are ignored and keep the built-in default. Call during startup wiring,
-// before the API serves traffic — the limiter swap is not synchronized.
+// SetPollRateLimit sets the per-user poll budget to perMinute requests per
+// minute (config: rate_limits.poll_per_minute). Values <= 0 are ignored and
+// keep the built-in default.
 func (a *API) SetPollRateLimit(perMinute int) {
 	if perMinute <= 0 {
 		return
 	}
-	a.pollLimit = ratelimit.New(1*time.Minute, perMinute)
+	a.pollLimit.SetMax(perMinute)
 }
 
 // buildAgentScreenEngine constructs the piguard screening engine for outbound agent

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -525,16 +525,28 @@ func NewAPI(store *identity.Store, sender *outbound.Sender, smtpRelay *outbound.
 		production:       production,
 		sendLimit:        ratelimit.New(1*time.Minute, 60),                           // 60 sends per agent per minute
 		regLimit:         ratelimit.New(1*time.Hour, 200),                            // 200 registrations per IP per hour
-		// 240/min: the bucket is keyed per USER and shared by every reader the
+		// The poll bucket is keyed per USER and shared by every reader the
 		// account runs — each agent's polling loop plus the dashboard, whose
 		// thread view fetches message bodies individually. 60/min starved
 		// multi-agent accounts the moment a human opened a long thread.
+		// Operators tune this via rate_limits.poll_per_minute (SetPollRateLimit).
 		pollLimit:        ratelimit.New(1*time.Minute, 240),                          // 240 poll requests per user per minute
 		feedbackLimit:    ratelimit.New(1*time.Hour, 10),                             // 10 feedback submissions per IP per hour
 		dcrLimit:         ratelimit.New(1*time.Hour, 10),                             // 10 OAuth client registrations per IP per hour
 		downloadLimit:    ratelimit.New(1*time.Minute, 120),                          // 120 attachment downloads per IP per minute
 		unsubscribeLimit: ratelimit.New(1*time.Minute, unsubscribeRequestsPerMinute), // provider-friendly one-click budget
 	}
+}
+
+// SetPollRateLimit replaces the per-user poll limiter with a fresh bucket of
+// perMinute requests per minute (config: rate_limits.poll_per_minute). Values
+// <= 0 are ignored and keep the built-in default. Call during startup wiring,
+// before the API serves traffic — the limiter swap is not synchronized.
+func (a *API) SetPollRateLimit(perMinute int) {
+	if perMinute <= 0 {
+		return
+	}
+	a.pollLimit = ratelimit.New(1*time.Minute, perMinute)
 }
 
 // buildAgentScreenEngine constructs the piguard screening engine for outbound agent

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -525,7 +525,11 @@ func NewAPI(store *identity.Store, sender *outbound.Sender, smtpRelay *outbound.
 		production:       production,
 		sendLimit:        ratelimit.New(1*time.Minute, 60),                           // 60 sends per agent per minute
 		regLimit:         ratelimit.New(1*time.Hour, 200),                            // 200 registrations per IP per hour
-		pollLimit:        ratelimit.New(1*time.Minute, 60),                           // 60 poll requests per user per minute
+		// 240/min: the bucket is keyed per USER and shared by every reader the
+		// account runs — each agent's polling loop plus the dashboard, whose
+		// thread view fetches message bodies individually. 60/min starved
+		// multi-agent accounts the moment a human opened a long thread.
+		pollLimit:        ratelimit.New(1*time.Minute, 240),                          // 240 poll requests per user per minute
 		feedbackLimit:    ratelimit.New(1*time.Hour, 10),                             // 10 feedback submissions per IP per hour
 		dcrLimit:         ratelimit.New(1*time.Hour, 10),                             // 10 OAuth client registrations per IP per hour
 		downloadLimit:    ratelimit.New(1*time.Minute, 120),                          // 120 attachment downloads per IP per minute

--- a/internal/agent/api_ratelimit_test.go
+++ b/internal/agent/api_ratelimit_test.go
@@ -1,0 +1,22 @@
+package agent
+
+import (
+	"testing"
+
+	"github.com/tokencanopy/e2a/internal/usage"
+)
+
+func TestSetPollRateLimitReusesLimiter(t *testing.T) {
+	api := NewAPI(nil, nil, nil, nil, usage.NewNoopUsageTracker(), "", "", "", "", false)
+	original := api.pollLimit
+
+	api.SetPollRateLimit(600)
+
+	if api.pollLimit != original {
+		t.Fatal("SetPollRateLimit replaced the limiter; the original cleanup goroutine would be abandoned")
+	}
+	_, _, limit, _, _ := api.PollLimitAllow("user_test")
+	if limit != 600 {
+		t.Fatalf("poll limit = %d, want 600", limit)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,7 @@ type Config struct {
 	DeliveryFeedback DeliveryFeedbackConfig `yaml:"delivery_feedback"`
 	SendingRamp      SendingRampConfig      `yaml:"sending_ramp"`
 	Limits           LimitsConfig           `yaml:"limits"`
+	RateLimits       RateLimitsConfig       `yaml:"rate_limits"`
 	Trash            TrashConfig            `yaml:"trash"`
 	Env              string                 `yaml:"env"` // "development" or "production"
 	// SharedDomain enables slug-based agent registration. When set
@@ -264,6 +265,19 @@ type LimitsConfig struct {
 	BillingHookURL string `yaml:"billing_hook_url"`
 }
 
+// RateLimitsConfig tunes server-side request rate limits. A zero value
+// means "use the built-in default", so configs that omit the section
+// keep current behavior.
+type RateLimitsConfig struct {
+	// PollPerMinute is the shared per-user budget for the authenticated
+	// read (polling) endpoints: list/get messages, conversations, and
+	// webhooks. The bucket is keyed per USER and shared by every reader
+	// the account runs — each agent's polling loop plus the dashboard,
+	// whose thread view fetches message bodies individually. Size it for
+	// the whole account, not a single client. Default 240.
+	PollPerMinute int `yaml:"poll_per_minute"`
+}
+
 // TrashConfig tunes the soft-delete (trash) subsystem.
 type TrashConfig struct {
 	// RetentionDays is how many days a soft-deleted resource (agent inbox
@@ -308,8 +322,9 @@ func Load(path string) (*Config, error) {
 			TargetDaily: 2000,
 			RampDays:    30,
 		},
-		Trash: TrashConfig{RetentionDays: 30},
-		Env:   "development",
+		RateLimits: RateLimitsConfig{PollPerMinute: 240},
+		Trash:      TrashConfig{RetentionDays: 30},
+		Env:        "development",
 	}
 
 	if err := yaml.Unmarshal(data, cfg); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -454,3 +454,43 @@ func TestTrashRetentionDefaultOverrideAndValidation(t *testing.T) {
 		t.Error("Load should reject a negative trash.retention_days")
 	}
 }
+
+func TestLoadConfigRateLimitsDefault(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`
+database:
+  url: "postgres://test:test@localhost/test"
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if got := cfg.RateLimits.PollPerMinute; got != 240 {
+		t.Errorf("default RateLimits.PollPerMinute = %d, want 240", got)
+	}
+}
+
+func TestLoadConfigRateLimitsOverride(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte(`
+database:
+  url: "postgres://test:test@localhost/test"
+rate_limits:
+  poll_per_minute: 600
+`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if got := cfg.RateLimits.PollPerMinute; got != 600 {
+		t.Errorf("RateLimits.PollPerMinute = %d, want 600", got)
+	}
+}

--- a/internal/httpapi/ratelimit.go
+++ b/internal/httpapi/ratelimit.go
@@ -29,7 +29,7 @@ type RateSnapshot func(key string) (ok bool, retryAfter time.Duration, limit, re
 // label PATCH stays legacy-only). The legacy surface deliberately did NOT
 // poll-limit agents/domains/events/limits/export reads, so neither do we:
 // notably the events API is built for reconciliation polling and must not
-// compete for the shared 60/min message-read budget. getInfo is public (no
+// compete for the shared per-user message-read budget. getInfo is public (no
 // principal to key on).
 var pollLimitedOps = map[string]bool{
 	"listMessages": true, "getMessage": true,

--- a/internal/ratelimit/ratelimit.go
+++ b/internal/ratelimit/ratelimit.go
@@ -23,6 +23,17 @@ func New(window time.Duration, max int) *Limiter {
 	return l
 }
 
+// SetMax updates the request budget without replacing the limiter, preserving
+// its cleanup goroutine and any existing per-key window state.
+func (l *Limiter) SetMax(max int) {
+	if max <= 0 {
+		return
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.max = max
+}
+
 // Allow returns true if the key has not exceeded the rate limit.
 // If allowed, the attempt is recorded.
 func (l *Limiter) Allow(key string) bool {

--- a/internal/ratelimit/ratelimit_test.go
+++ b/internal/ratelimit/ratelimit_test.go
@@ -24,6 +24,17 @@ func TestAllow(t *testing.T) {
 	}
 }
 
+func TestSetMaxIgnoresNonPositiveValues(t *testing.T) {
+	l := New(time.Minute, 3)
+
+	l.SetMax(0)
+
+	ok, _, limit, _, _ := l.AllowSnapshot("key")
+	if !ok || limit != 3 {
+		t.Fatalf("snapshot after SetMax(0) = ok=%v limit=%d, want ok=true limit=3", ok, limit)
+	}
+}
+
 func TestWindowExpiry(t *testing.T) {
 	l := New(50*time.Millisecond, 2)
 


### PR DESCRIPTION
## Why

The poll limiter (`internal/agent/api.go`) is keyed **per user** and shared by every reader an account runs: each agent's `list_messages`/`get_message` polling loop **plus the dashboard**, whose thread view fetches message bodies one request per bubble.

Observed in prod (2026-07-19): an account running two polling agents hit sustained `rate_limited` 429s whenever the owner had a 148-message thread open in the dashboard — the page load alone can consume most of the 60/min budget. To the agents this looked like mail silently not arriving.

## What

- `pollLimit` default: 60/min → **240/min** per user (4 rps — still conservative DB load), with a comment explaining the shared-bucket sizing rationale.
- **New config knob: `rate_limits.poll_per_minute`** (default 240) — threaded via `api.SetPollRateLimit()` at startup wiring (mirrors the `SetAPIURL` pattern; the 31 `NewAPI` call sites stay untouched). Values ≤ 0 keep the built-in default; configs omitting the section keep current behavior.
- Config tests for the default and a YAML override; refreshed a stale `60/min` comment in `internal/httpapi/ratelimit.go`.

## Not in scope (follow-ups)

- Dashboard thread view N+1 body fetch (self-DoS on long threads)
- Dashboard rendering the raw 429 JSON instead of retrying via `Retry-After`
- Separate buckets for dashboard-session vs API-credential traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8aZZoVbksSuLURnH76y2t