### PR TITLE
fix(outbound): map deadline-driven i/o timeout to context.DeadlineExceeded

### DIFF
--- a/internal/outbound/smtp_relay.go
+++ b/internal/outbound/smtp_relay.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"net/smtp"
 	"net/textproto"
+	"os"
 	"strings"
 	"time"
 
@@ -160,8 +161,19 @@ func IsConnectionError(err error) bool {
 //	250 Ok <010f019d2bd82cd5-49c4925c-...@us-east-2.amazonses.com>
 func (r *SMTPRelay) sendOnceContext(ctx context.Context, envelopeFrom string, recipients []string, message []byte) (msgID string, err error) {
 	defer func() {
-		if err != nil && ctx.Err() != nil {
+		if err == nil {
+			return
+		}
+		if ctx.Err() != nil {
 			err = ctx.Err()
+			return
+		}
+		// The conn deadline is set to the ctx deadline below, so the net
+		// poller's timer races the context's own timer to the same instant.
+		// When the poller wins, the I/O error surfaces while ctx.Err() is
+		// still nil — map it to the deadline error the caller contracted for.
+		if d, ok := ctx.Deadline(); ok && !time.Now().Before(d) && errors.Is(err, os.ErrDeadlineExceeded) {
+			err = context.DeadlineExceeded
 		}
 	}()
 


### PR DESCRIPTION
## Problem

`TestSMTPRelaySendWithContextCancelsHangingServer` is a ~5% flake on main (10/200 local repro at 759c8d6a) — it first surfaced failing CI on the unrelated #586. Introduced by bc76b3c5 (feedback delivery-channel timeouts).

`sendOnceContext` sets the TCP connection deadline to the ctx deadline, so two independent timers target the same instant: the net poller's read deadline and the context's internal timer. When the poller fires first, `smtp.NewClient` returns `smtp client: read tcp …: i/o timeout` while `ctx.Err()` is still nil — the deferred `err = ctx.Err()` remap is skipped and the raw i/o timeout escapes. It isn't classified transient, so the retry loop returns it immediately, breaking the `SendWithContext` contract the test (and the River worker's error classification) relies on.

## Fix

Extend the deferred mapping: when the error is `os.ErrDeadlineExceeded` and the ctx deadline has passed, map it to `context.DeadlineExceeded` even if the context's own timer hasn't fired yet.

The fix is in the code, not the test — the test correctly pins the "honors ctx" contract that callers depend on.

## Verification

- Before: 10/200 failures on clean main
- After: 500/500 passes (`-count=500`)
- `go vet` + `go test -race ./internal/outbound/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xnaw5ELZ5PWvYhBSPGvezL