### PR TITLE
test(e2e-prod): cover the soft-delete/restore trio (deleteMessage, restoreMessage, restoreAgent)

### DIFF
--- a/tests/e2e-prod/suites/23-coverage-happy-path.test.ts
+++ b/tests/e2e-prod/suites/23-coverage-happy-path.test.ts
@@ -7,11 +7,12 @@ import { writeReport } from "../harness/report.ts";
 
 // Happy-path coverage for operations the rest of the suite only PROBES negatively
 // (updateAgent, updateMessage, forwardMessage, getConversation, replyToMessage,
-// approveReview). The operationId coverage gate records an op as covered only on
-// a 2xx, so an op that elsewhere gets nothing but a 404/400 probe reads as
-// UNCOVERED. These tests close that gap by INVOKING each op successfully on fresh,
-// isolated agents — no dependency on shared-account state (which made the messaging
-// suite's approve/reply flaky under the full concurrent run).
+// approveReview) or not at all (the soft-delete/restore trio: deleteMessage,
+// restoreMessage, restoreAgent). The operationId coverage gate records an op as
+// covered only on a 2xx, so an op that elsewhere gets nothing but a 404/400 probe
+// reads as UNCOVERED. These tests close that gap by INVOKING each op successfully
+// on fresh, isolated agents — no dependency on shared-account state (which made
+// the messaging suite's approve/reply flaky under the full concurrent run).
 const SUITE = "23-coverage-happy-path";
 const client = new ApiClient();
 
@@ -116,6 +117,87 @@ test("approveReview: approve a HITL-held outbound (200 terminal or 202 enqueued)
   );
   assert.equal(ap.body?.message_id, id);
   assert.equal(ap.body?.status, ap.status === 202 ? "accepted" : "sent");
+});
+
+test("deleteMessage + restoreMessage: trash a message, then bring it back (200)", async () => {
+  const email = await freshAgent("covdm");
+  const { id } = await loopbackMessage(email, uniqueSubject("cov dm"));
+  const base = `/v1/agents/${encodeURIComponent(email)}/messages`;
+
+  // Default DELETE = reversible move to trash: no ?confirm needed, 200 receipt.
+  const del = await client.delete<{ deleted: boolean; id: string }>(`${base}/${id}`, { expect: 200 });
+  assert.equal(del.body?.deleted, true, "delete receipt must say deleted:true");
+  assert.equal(del.body?.id, id, "delete receipt echoes the message id");
+
+  // Trashed: gone from the ordinary list, present in the trash (deleted=true)
+  // list, and still directly readable with deleted_at stamped. List checks pass
+  // read_status=all: the inbound list defaults to read_status=unread, and the
+  // direct GET below marks the message read — without read_status=all the
+  // restored message would be invisible for the wrong reason.
+  const live = await client.get<{ items: Array<{ id: string }> }>(base, {
+    query: { read_status: "all", limit: 50 },
+    expect: 200,
+  });
+  assert.ok(!live.body?.items?.some((m) => m.id === id), "trashed message must leave the ordinary list");
+  const trash = await client.get<{ items: Array<{ id: string }> }>(base, {
+    query: { deleted: "true", limit: 50 },
+    expect: 200,
+  });
+  assert.ok(trash.body?.items?.some((m) => m.id === id), "trashed message must appear in the deleted=true list");
+  const direct = await client.get<{ id: string; deleted_at?: string }>(`${base}/${id}`, { expect: 200 });
+  assert.ok(direct.body?.deleted_at, "direct GET of a trashed message includes deleted_at");
+
+  // Restore: 200 MessageView, live again (deleted_at omitted), back in the list.
+  const rst = await client.post<{ id: string; deleted_at?: string }>(`${base}/${id}/restore`, { expect: 200 });
+  assert.equal(rst.body?.id, id, "restore returns the restored message view");
+  assert.equal(rst.body?.deleted_at, undefined, "restored view must omit deleted_at");
+  const relisted = await client.get<{ items: Array<{ id: string }> }>(base, {
+    query: { read_status: "all", limit: 50 },
+    expect: 200,
+  });
+  assert.ok(relisted.body?.items?.some((m) => m.id === id), "restored message must rejoin the ordinary list");
+
+  // Restoring a live message is a 409 not_in_trash (coverage already recorded
+  // on the 2xx above — this only pins the error contract).
+  const again = await client.post<{ error?: { code?: string } }>(`${base}/${id}/restore`, { expect: 409 });
+  assert.equal(again.body?.error?.code, "not_in_trash");
+});
+
+test("deleteAgent (trash) + restoreAgent: trash an agent, then bring it back with messages intact", async () => {
+  const email = await freshAgent("covra");
+  const subject = uniqueSubject("cov ra");
+  await loopbackMessage(email, subject);
+  const agentPath = `/v1/agents/${encodeURIComponent(email)}`;
+
+  // Soft delete (no permanent=true) moves the agent to the trash. The receipt's
+  // messages_deleted is zero — nothing is purged on a trash move.
+  const del = await client.delete<{ deleted: boolean; email: string; messages_deleted: number }>(
+    `${agentPath}?confirm=DELETE`,
+    { expect: 200 },
+  );
+  assert.equal(del.body?.deleted, true);
+  assert.equal(del.body?.messages_deleted, 0, "trash move must not purge messages");
+
+  // A trashed agent is 404 for every live lookup.
+  await client.get(agentPath, { expect: 404 });
+
+  // Restore: 200 AgentView, live again, messages intact.
+  const rst = await client.post<{ email: string; deleted_at?: string }>(`${agentPath}/restore`, { expect: 200 });
+  assert.equal(rst.body?.email, email, "restore returns the restored agent view");
+  assert.equal(rst.body?.deleted_at, undefined, "restored agent must omit deleted_at");
+  await client.get(agentPath, { expect: 200 });
+  const msgs = await client.get<{ items: Array<{ subject: string }> }>(`${agentPath}/messages`, {
+    query: { direction: "inbound", read_status: "all", limit: 50 },
+    expect: 200,
+  });
+  assert.ok(
+    msgs.body?.items?.some((m) => m.subject === subject),
+    "agent restore must bring its messages back with it",
+  );
+
+  // Restoring a live agent is a 409 not_in_trash.
+  const again = await client.post<{ error?: { code?: string } }>(`${agentPath}/restore`, { expect: 409 });
+  assert.equal(again.body?.error?.code, "not_in_trash");
 });
 
 after(async () => {


### PR DESCRIPTION
## Why

The staging conformance run failed `coverage_gate.py` with exactly 3 UNCOVERED operations — the recently-landed trash lifecycle:

- `deleteMessage` — `DELETE /v1/agents/{email}/messages/{id}`
- `restoreMessage` — `POST /v1/agents/{email}/messages/{id}/restore`
- `restoreAgent` — `POST /v1/agents/{email}/restore`

No suite ever exercised them with a 2xx (the gate only counts successes, per `harness/coverage.ts`).

## What

Extends `suites/23-coverage-happy-path.test.ts` — the designated home for closing operationId coverage gaps on fresh, isolated agents — with two tests:

**deleteMessage + restoreMessage** (loopback self-send → trash → restore):
- `DELETE` with no confirm → 200 `{deleted: true, id}` (default delete is the reversible trash move)
- trashed: absent from the ordinary list, present in the `deleted=true` trash list, still directly readable with `deleted_at` stamped
- `POST …/restore` → 200 MessageView with `deleted_at` omitted, back in the ordinary list
- second restore on the now-live message → 409 `not_in_trash` (contract pin; coverage was already recorded on the 2xx)

**deleteAgent (trash) + restoreAgent**:
- soft delete (`?confirm=DELETE`, no `permanent`) → 200 receipt with `messages_deleted: 0` (nothing purged on a trash move)
- trashed agent → 404 on live GET
- `POST …/restore` → 200 AgentView, live GET 200 again, and the pre-delete loopback message is back in the inbox (agent restore brings its messages with it)
- restore of a live agent → 409 `not_in_trash`

List assertions pass `read_status=all`: the inbound list defaults to `read_status=unread` and the direct GET marks the message read, which would otherwise hide the restored message for the wrong reason (found this the hard way — first local run failed on exactly that).

## Verified locally

Booted a fresh server from this branch (throwaway Postgres 16 + Mailpit, `-bootstrap-email` key), then:

- `node --test suites/23-coverage-happy-path.test.ts` → **7/7 pass** (5 existing + 2 new)
- `python3 coverage_gate.py` on that single-suite shard → 16 ops covered; `deleteMessage` / `restoreMessage` / `restoreAgent` no longer appear in UNCOVERED (the remaining UNCOVERED entries all belong to suites not run in the single-file check)
- `tsc --noEmit`: no errors in the touched file. Note: 4 pre-existing `TS2339` errors in `01-basic` / `02-authz` reproduce on a clean `origin/main` checkout with a fresh `npm install` (no committed lockfile, TS floats at `^5.4`) — untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)