### PR TITLE
ci(release): always publish a GitHub Release when a v* tag is pushed

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -140,3 +140,45 @@ jobs:
             images+="${tag}@${DIGEST} "
           done
           cosign sign --yes ${images}
+
+  # Every v* tag must surface as a *published* GitHub Release. Downstream
+  # automation keys off the Release object, not the git tag: the hosted-ops
+  # release poller discovers new versions via `gh release list`, and
+  # publish-cli.yml triggers on `release: published`. v1.0.9, v1.0.10, and
+  # v1.0.10-hotfix.1 existed only as bare tags, so neither ever fired.
+  # Runs after the image builds so a Release never advertises a version
+  # whose images aren't pullable yet. Idempotent: an already-published
+  # Release is left untouched; a hand-created draft is published in place.
+  #
+  # KNOWN LIMIT: a Release created with the workflow's GITHUB_TOKEN does
+  # NOT fire other workflows' `release: published` triggers (GitHub's
+  # recursion guard) — so this closes the poller gap (`gh release list`
+  # sees the Release regardless of author) but publish-cli.yml still won't
+  # auto-fire off it; run it via workflow_dispatch, or publish the release
+  # by hand as before. No regression: a bare tag fired nothing either.
+  release:
+    name: Publish GitHub Release
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Ensure a published release exists for the tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          if gh release view "$TAG" --json isDraft --jq '.isDraft' > is_draft.txt 2>/dev/null; then
+            if [ "$(cat is_draft.txt)" = "true" ]; then
+              echo "Draft release exists for $TAG — publishing it."
+              gh release edit "$TAG" --draft=false
+            else
+              echo "Release $TAG already published — nothing to do."
+            fi
+          else
+            gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes
+          fi


### PR DESCRIPTION
## Why

`v1.0.9`, `v1.0.10`, and `v1.0.10-hotfix.1` exist as git tags but have **no GitHub Release object** (releases stop at `v1.0.8`). Downstream automation keys off the Release, not the tag:

- the hosted-ops hourly release poller discovers versions via `gh release list` → those three were never auto-deployed to staging
- `publish-cli.yml` triggers on `release: published` → it never fired for them either

## What

Adds a `release` job to `build-image.yml` (the `v*`-tag workflow that builds the server/web/prober images) that ensures a **published** Release exists for the tag:

- `if: startsWith(github.ref, 'refs/tags/v')`, `needs: build` — the Release only appears once all three images are pushed, so the ops poller can never pick up a version whose images aren't pullable yet
- idempotent: an already-published Release is left untouched; a hand-created **draft** is published in place (`gh release edit --draft=false`); otherwise `gh release create "$TAG" --verify-tag --title "$TAG" --generate-notes`
- job-scoped `permissions: contents: write` (workflow default stays `read`)

## Known limit (documented in the workflow comment)

A Release created with the workflow's `GITHUB_TOKEN` does **not** fire other workflows' `release: published` triggers (GitHub's recursion guard). So this closes the staging-poller gap — polling `gh release list` sees the Release regardless of author — but `publish-cli.yml` still won't auto-fire off an auto-created Release; use its `workflow_dispatch` or publish the release by hand as before. That's no regression: a bare tag fired nothing at all. If full chaining is wanted later, the job would need a PAT/GitHub-App token instead of `GITHUB_TOKEN`.

Validated: YAML parses cleanly; job structure mirrors the existing jobs in this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)