### PR TITLE
feat(web): add live inbox polling and delivery status

### DIFF
--- a/docs/superpowers/plans/2026-07-19-live-inbox-delivery-status.md
+++ b/docs/superpowers/plans/2026-07-19-live-inbox-delivery-status.md
@@ -6,6 +6,16 @@
 
 **Architecture:** Add scoped SWR polling options only to the three live dashboard queries, leaving static resources untouched and preserving focus/reconnect revalidation. Extend the existing message-status component into the canonical review/delivery mapping, then consume it in compact thread rows and outbound conversation messages.
 
+> **Implementation outcome/correction:** Pending polling has one explicit owner:
+> `PendingPollingOwner`, mounted once in the authenticated app layout. The
+> sidebar's `usePendingCount` and the Review page are passive subscribers to
+> the same `pendingMessagesKey`; they do not each configure polling, and
+> identical subscriber options are not relied on to guarantee one request.
+> Transient revalidation errors retain cached pending counts/messages and
+> unread badge data, so those successful values remain visible. The task steps
+> below preserve the original TDD history; where they describe polling on both
+> pending consumers, this outcome note records the reviewed final architecture.
+
 **Tech Stack:** Next.js 16 App Router, React 19, TypeScript, SWR 2, Jest 30, React Testing Library, `@e2a/ui` Loft components.
 
 ---

--- a/docs/superpowers/plans/2026-07-19-live-inbox-delivery-status.md
+++ b/docs/superpowers/plans/2026-07-19-live-inbox-delivery-status.md
@@ -1,0 +1,929 @@
+# Live Inbox Polling and Delivery Status Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make inbox messages, unread badges, and review counts refresh automatically while surfacing attention-aware outbound delivery states in the existing Loft UI.
+
+**Architecture:** Add scoped SWR polling options only to the three live dashboard queries, leaving static resources untouched and preserving focus/reconnect revalidation. Extend the existing message-status component into the canonical review/delivery mapping, then consume it in compact thread rows and outbound conversation messages.
+
+**Tech Stack:** Next.js 16 App Router, React 19, TypeScript, SWR 2, Jest 30, React Testing Library, `@e2a/ui` Loft components.
+
+---
+
+## File map
+
+- Create `web/src/lib/livePolling.ts` — shared polling cadences and SWR option objects.
+- Create `web/src/lib/livePolling.test.ts` — exact cadence and hidden/offline behavior contract.
+- Modify `web/src/app/components/messages/MessageStatusChip.tsx` — canonical review and delivery status derivation and rendering.
+- Modify `web/src/app/components/messages/MessageStatusChip.test.tsx` — exhaustive mapping, precedence, attention, empty, and unknown-state tests.
+- Modify `web/src/app/components/messages/ThreadRow.tsx` — compact attention status for the latest outbound message.
+- Create `web/src/app/components/messages/ThreadRow.test.tsx` — row-level visibility and latest-message behavior.
+- Modify `web/src/app/components/messages/ThreadBubble.tsx` — status chip on every outbound conversation message.
+- Modify `web/src/app/components/messages/ThreadBubble.test.tsx` — outbound status rendering and inbound omission.
+- Modify `web/src/app/(app)/inboxes/(view)/messages/page.tsx` — 10-second active-inbox polling.
+- Modify `web/src/app/(app)/inboxes/(view)/messages/page.test.tsx` — timer-driven inbox refresh test.
+- Modify `web/src/app/components/hooks/usePendingCount.ts` — 10-second shared pending-query polling.
+- Modify `web/src/app/(app)/reviews/page.tsx` — use the same pending polling options on the shared cache key.
+- Modify `web/src/app/(app)/inboxes/_components/AgentCard.tsx` — 15-second unread-probe polling.
+- Modify existing pending and AgentCard tests to pin the shared polling configuration.
+
+## Task 1: Canonical outbound status mapping
+
+**Files:**
+- Modify: `web/src/app/components/messages/MessageStatusChip.test.tsx`
+- Modify: `web/src/app/components/messages/MessageStatusChip.tsx`
+
+- [ ] **Step 1: Replace the status-helper tests with the approved lifecycle contract**
+
+Update `MessageStatusChip.test.tsx` so it asserts the complete mapping and precedence. Keep the existing inbound read/unread cases for backward compatibility:
+
+```tsx
+import { deriveStatusChip } from "./MessageStatusChip";
+
+describe("deriveStatusChip", () => {
+  test.each([
+    ["accepted", "Queued", "info", true],
+    ["sending", "Sending", "info", true],
+    ["deferred", "Delayed", "warn", true],
+    ["failed", "Failed", "danger", true],
+    ["bounced", "Bounced", "danger", true],
+    ["complained", "Complaint", "danger", true],
+    ["sent", "Sent", "success", false],
+    ["delivered", "Delivered", "success", false],
+  ])(
+    "maps delivery_status=%s to %s",
+    (deliveryStatus, label, tone, attention) => {
+      expect(
+        deriveStatusChip({
+          direction: "outbound",
+          delivery_status: deliveryStatus,
+        }),
+      ).toEqual({ tone, label, attention });
+    },
+  );
+
+  it("prioritizes unresolved and rejected review states over delivery", () => {
+    expect(
+      deriveStatusChip({
+        direction: "outbound",
+        delivery_status: "sent",
+        review_status: "pending_review",
+      }),
+    ).toEqual({ tone: "warn", label: "Pending review", dot: true, attention: true });
+
+    expect(
+      deriveStatusChip({
+        direction: "outbound",
+        delivery_status: "sent",
+        review_status: "review_rejected",
+      }),
+    ).toEqual({ tone: "danger", label: "Rejected", attention: true });
+
+    expect(
+      deriveStatusChip({
+        direction: "outbound",
+        delivery_status: "sent",
+        review_status: "review_expired_rejected",
+      }),
+    ).toEqual({ tone: "danger", label: "Auto-rejected", attention: true });
+  });
+
+  it("lets delivery state override the collapsed review sent value", () => {
+    expect(
+      deriveStatusChip({
+        direction: "outbound",
+        delivery_status: "accepted",
+        review_status: "sent",
+      }),
+    ).toEqual({ tone: "info", label: "Queued", attention: true });
+  });
+
+  it("falls back to settled review outcomes only without delivery state", () => {
+    expect(
+      deriveStatusChip({ direction: "outbound", review_status: "sent" }),
+    ).toEqual({ tone: "success", label: "Sent", attention: false });
+    expect(
+      deriveStatusChip({
+        direction: "outbound",
+        review_status: "review_expired_approved",
+      }),
+    ).toEqual({ tone: "success", label: "Sent (auto)", attention: false });
+  });
+
+  it("shows an unknown delivery state neutrally in detail", () => {
+    expect(
+      deriveStatusChip({ direction: "outbound", delivery_status: "routing" }),
+    ).toEqual({ tone: "neutral", label: "routing", attention: false });
+  });
+
+  it("returns null for an outbound message with no lifecycle state", () => {
+    expect(deriveStatusChip({ direction: "outbound" })).toBeNull();
+  });
+
+  it("preserves inbound read-state mapping", () => {
+    expect(
+      deriveStatusChip({ direction: "inbound", inbox_status: "unread" }),
+    ).toEqual({ tone: "info", label: "Unread", attention: false });
+    expect(
+      deriveStatusChip({ direction: "inbound", inbox_status: "read" }),
+    ).toEqual({ tone: "neutral", label: "Read", attention: false });
+  });
+});
+```
+
+- [ ] **Step 2: Run the helper test and verify the new contract fails**
+
+Run:
+
+```bash
+cd web
+npm test -- --runInBand src/app/components/messages/MessageStatusChip.test.tsx
+```
+
+Expected: FAIL because `delivery_status`, `attention`, null output, and the new labels are not implemented.
+
+- [ ] **Step 3: Implement the canonical mapping in `MessageStatusChip.tsx`**
+
+Replace the current input/spec types and derivation with:
+
+```tsx
+import { Chip, Dot, type ChipTone } from "@e2a/ui";
+
+export type MessageStatusInput = {
+  direction: "inbound" | "outbound";
+  delivery_status?: string;
+  review_status?: string;
+  inbox_status?: string;
+};
+
+export type MessageStatusSpec = {
+  tone: ChipTone;
+  label: string;
+  dot?: boolean;
+  attention: boolean;
+};
+
+const DELIVERY_STATUS: Record<string, MessageStatusSpec> = {
+  accepted: { tone: "info", label: "Queued", attention: true },
+  sending: { tone: "info", label: "Sending", attention: true },
+  deferred: { tone: "warn", label: "Delayed", attention: true },
+  failed: { tone: "danger", label: "Failed", attention: true },
+  bounced: { tone: "danger", label: "Bounced", attention: true },
+  complained: { tone: "danger", label: "Complaint", attention: true },
+  sent: { tone: "success", label: "Sent", attention: false },
+  delivered: { tone: "success", label: "Delivered", attention: false },
+};
+
+export function deriveStatusChip(
+  input: MessageStatusInput,
+): MessageStatusSpec | null {
+  if (input.direction === "inbound") {
+    if (input.inbox_status === "unread") {
+      return { tone: "info", label: "Unread", attention: false };
+    }
+    return { tone: "neutral", label: "Read", attention: false };
+  }
+
+  switch (input.review_status) {
+    case "pending_review":
+      return {
+        tone: "warn",
+        label: "Pending review",
+        dot: true,
+        attention: true,
+      };
+    case "review_rejected":
+      return { tone: "danger", label: "Rejected", attention: true };
+    case "review_expired_rejected":
+      return { tone: "danger", label: "Auto-rejected", attention: true };
+  }
+
+  if (input.delivery_status) {
+    return (
+      DELIVERY_STATUS[input.delivery_status] ?? {
+        tone: "neutral",
+        label: input.delivery_status,
+        attention: false,
+      }
+    );
+  }
+
+  if (input.review_status === "review_expired_approved") {
+    return { tone: "success", label: "Sent (auto)", attention: false };
+  }
+  if (input.review_status === "sent") {
+    return { tone: "success", label: "Sent", attention: false };
+  }
+  return null;
+}
+
+export function MessageStatusChip(props: MessageStatusInput) {
+  const spec = deriveStatusChip(props);
+  if (!spec) return null;
+  const dotTone =
+    spec.tone === "warn"
+      ? "warn"
+      : spec.tone === "danger"
+        ? "danger"
+        : null;
+  return (
+    <Chip tone={spec.tone}>
+      {spec.dot && dotTone && <Dot tone={dotTone} />}
+      {spec.label}
+    </Chip>
+  );
+}
+```
+
+Remove the obsolete `webhook_status` handling from this component. Webhook
+subscriber delivery and SMTP email delivery are separate axes; the inbox chip
+must describe the email lifecycle requested by this feature.
+
+- [ ] **Step 4: Run the helper test and verify it passes**
+
+Run:
+
+```bash
+cd web
+npm test -- --runInBand src/app/components/messages/MessageStatusChip.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the canonical mapping**
+
+```bash
+git add web/src/app/components/messages/MessageStatusChip.tsx web/src/app/components/messages/MessageStatusChip.test.tsx
+git commit -m "feat(web): map outbound delivery statuses"
+```
+
+## Task 2: Attention-aware status in thread rows and conversations
+
+**Files:**
+- Create: `web/src/app/components/messages/ThreadRow.test.tsx`
+- Modify: `web/src/app/components/messages/ThreadRow.tsx`
+- Modify: `web/src/app/components/messages/ThreadBubble.test.tsx`
+- Modify: `web/src/app/components/messages/ThreadBubble.tsx`
+
+- [ ] **Step 1: Add failing `ThreadRow` visibility tests**
+
+Create `ThreadRow.test.tsx`:
+
+```tsx
+import { render, screen } from "@testing-library/react";
+import { ThreadRow } from "./ThreadRow";
+import type { MessageSummary } from "../types";
+import type { Thread } from "./threading";
+
+function message(
+  id: string,
+  overrides: Partial<MessageSummary> = {},
+): MessageSummary {
+  return {
+    id,
+    direction: "outbound",
+    from: "support@acme.dev",
+    to: ["alice@example.com"],
+    recipient: "alice@example.com",
+    subject: "Status update",
+    status: "accepted",
+    created_at: `2026-07-19T10:0${id.slice(-1)}:00Z`,
+    ...overrides,
+  };
+}
+
+function thread(messages: MessageSummary[]): Thread {
+  const latest = messages[messages.length - 1];
+  return {
+    key: "conv:status",
+    conversationId: "status",
+    counterparty: { email: "alice@example.com", name: "Alice" },
+    subject: "Status update",
+    state: messages.some((m) => m.review_status === "pending_review")
+      ? "pending"
+      : "active",
+    lastMessageAt: latest.created_at,
+    startedAt: messages[0].created_at,
+    msgCount: messages.length,
+    lastDirection: latest.direction,
+    lastPreview: latest.subject,
+    messages,
+  };
+}
+
+it("shows attention-worthy status for the latest outbound message", () => {
+  render(
+    <ThreadRow
+      thread={thread([message("1", { status: "accepted" })])}
+      active={false}
+      onSelect={jest.fn()}
+    />,
+  );
+  expect(screen.getByText("Queued")).toBeInTheDocument();
+});
+
+it("omits settled delivery status from the compact row", () => {
+  render(
+    <ThreadRow
+      thread={thread([message("2", { status: "delivered" })])}
+      active={false}
+      onSelect={jest.fn()}
+    />,
+  );
+  expect(screen.queryByText("Delivered")).not.toBeInTheDocument();
+});
+
+it("does not surface a historical failure after a newer inbound message", () => {
+  const failed = message("3", { status: "failed" });
+  const inbound = message("4", {
+    direction: "inbound",
+    from: "alice@example.com",
+    to: ["support@acme.dev"],
+    recipient: "support@acme.dev",
+    status: "",
+    read_status: "unread",
+  });
+  render(
+    <ThreadRow
+      thread={thread([failed, inbound])}
+      active={false}
+      onSelect={jest.fn()}
+    />,
+  );
+  expect(screen.queryByText("Failed")).not.toBeInTheDocument();
+});
+
+it("preserves the thread-level pending signal when pending is historical", () => {
+  const held = message("5", { status: "", review_status: "pending_review" });
+  const inbound = message("6", {
+    direction: "inbound",
+    from: "alice@example.com",
+    to: ["support@acme.dev"],
+    recipient: "support@acme.dev",
+    status: "",
+  });
+  render(
+    <ThreadRow
+      thread={thread([held, inbound])}
+      active={false}
+      onSelect={jest.fn()}
+    />,
+  );
+  expect(screen.getByText("Pending")).toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Add failing outbound-status tests to `ThreadBubble.test.tsx`**
+
+Append:
+
+```tsx
+describe("ThreadBubble outbound delivery status", () => {
+  function outboundMessage(id: string, status: string): MessageSummary {
+    return {
+      ...msg(id),
+      direction: "outbound",
+      from: "support@acme.dev",
+      to: ["james@x.com"],
+      status,
+      review_status: "sent",
+    };
+  }
+
+  it.each([
+    ["accepted", "Queued"],
+    ["sending", "Sending"],
+    ["sent", "Sent"],
+    ["delivered", "Delivered"],
+    ["failed", "Failed"],
+  ])("renders %s as %s", async (status, label) => {
+    mockGet.mockResolvedValue({
+      direction: "outbound",
+      data: { body_text: "outbound body", body_html: "" },
+    } as never);
+    render(
+      <ThreadBubble
+        message={outboundMessage(`msg_status_${status}`, status)}
+        counterparty={CP}
+        agentEmail="support@acme.dev"
+      />,
+    );
+    expect(screen.getByText(label)).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText("outbound body")).toBeInTheDocument());
+  });
+
+  it("does not add a delivery chip to inbound messages", async () => {
+    inbound({ parsed: { text: "inbound body" }, raw_message: "" });
+    render(
+      <ThreadBubble
+        message={msg("msg_no_delivery_chip")}
+        counterparty={CP}
+        agentEmail="support@acme.dev"
+      />,
+    );
+    await waitFor(() => expect(screen.getByText("inbound body")).toBeInTheDocument());
+    expect(screen.queryByText("Sent")).not.toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 3: Run both component tests and verify they fail**
+
+Run:
+
+```bash
+cd web
+npm test -- --runInBand src/app/components/messages/ThreadRow.test.tsx src/app/components/messages/ThreadBubble.test.tsx
+```
+
+Expected: FAIL because neither component renders delivery status.
+
+- [ ] **Step 4: Implement latest-message attention status in `ThreadRow.tsx`**
+
+Add imports:
+
+```tsx
+import { MessageStatusChip, deriveStatusChip } from "./MessageStatusChip";
+```
+
+After `pending`, derive the latest outbound state:
+
+```tsx
+const latest = thread.messages[thread.messages.length - 1];
+const latestStatus =
+  latest.direction === "outbound"
+    ? deriveStatusChip({
+        direction: "outbound",
+        delivery_status: latest.status,
+        review_status: latest.review_status,
+      })
+    : null;
+const showLatestStatus = latestStatus?.attention === true;
+```
+
+Replace the current pending-pill block with:
+
+```tsx
+{showLatestStatus ? (
+  <span className="shrink-0">
+    <MessageStatusChip
+      direction="outbound"
+      delivery_status={latest.status}
+      review_status={latest.review_status}
+    />
+  </span>
+) : pending ? (
+  <span
+    className="shrink-0"
+    style={{
+      fontSize: 10,
+      fontWeight: 600,
+      color: "var(--warn-strong)",
+      background: "var(--warn-bg)",
+      borderRadius: 999,
+      padding: "1px 8px",
+      whiteSpace: "nowrap",
+    }}
+  >
+    Pending
+  </span>
+) : null}
+```
+
+- [ ] **Step 5: Implement outbound status in `ThreadBubble.tsx`**
+
+Add:
+
+```tsx
+import { MessageStatusChip } from "./MessageStatusChip";
+```
+
+Replace the pending-only chip beside `senderEmail` with:
+
+```tsx
+{!isInbound && (
+  <MessageStatusChip
+    direction="outbound"
+    delivery_status={message.status}
+    review_status={message.review_status}
+  />
+)}
+```
+
+Keep the `pending` boolean for the delete-button restriction. Do not change the
+body-fetch or cache-invalidation logic.
+
+- [ ] **Step 6: Run both component tests and verify they pass**
+
+Run:
+
+```bash
+cd web
+npm test -- --runInBand src/app/components/messages/ThreadRow.test.tsx src/app/components/messages/ThreadBubble.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the UI status placement**
+
+```bash
+git add web/src/app/components/messages/ThreadRow.tsx web/src/app/components/messages/ThreadRow.test.tsx web/src/app/components/messages/ThreadBubble.tsx web/src/app/components/messages/ThreadBubble.test.tsx
+git commit -m "feat(web): show attention-aware delivery status"
+```
+
+## Task 3: Shared scoped polling configuration
+
+**Files:**
+- Create: `web/src/lib/livePolling.ts`
+- Create: `web/src/lib/livePolling.test.ts`
+
+- [ ] **Step 1: Write the polling-options contract test**
+
+Create `livePolling.test.ts`:
+
+```ts
+import {
+  inboxPolling,
+  pendingPolling,
+  unreadPolling,
+} from "./livePolling";
+
+describe("live dashboard polling", () => {
+  it("refreshes inbox messages and review holds every 10 seconds", () => {
+    expect(inboxPolling).toEqual({
+      refreshInterval: 10_000,
+      refreshWhenHidden: false,
+      refreshWhenOffline: false,
+    });
+    expect(pendingPolling).toEqual(inboxPolling);
+  });
+
+  it("refreshes mounted unread probes every 15 seconds", () => {
+    expect(unreadPolling).toEqual({
+      refreshInterval: 15_000,
+      refreshWhenHidden: false,
+      refreshWhenOffline: false,
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and verify the module is missing**
+
+Run:
+
+```bash
+cd web
+npm test -- --runInBand src/lib/livePolling.test.ts
+```
+
+Expected: FAIL with `Cannot find module './livePolling'`.
+
+- [ ] **Step 3: Implement the shared polling options**
+
+Create `livePolling.ts`:
+
+```ts
+export const inboxPolling = {
+  refreshInterval: 10_000,
+  refreshWhenHidden: false,
+  refreshWhenOffline: false,
+} as const;
+
+export const pendingPolling = inboxPolling;
+
+export const unreadPolling = {
+  refreshInterval: 15_000,
+  refreshWhenHidden: false,
+  refreshWhenOffline: false,
+} as const;
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run:
+
+```bash
+cd web
+npm test -- --runInBand src/lib/livePolling.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the polling contract**
+
+```bash
+git add web/src/lib/livePolling.ts web/src/lib/livePolling.test.ts
+git commit -m "feat(web): define live polling cadence"
+```
+
+## Task 4: Poll the active inbox
+
+**Files:**
+- Modify: `web/src/app/(app)/inboxes/(view)/messages/page.test.tsx`
+- Modify: `web/src/app/(app)/inboxes/(view)/messages/page.tsx`
+
+- [ ] **Step 1: Add a timer-driven inbox refresh test**
+
+Import `act` from the existing SWR test helper:
+
+```tsx
+import { render, screen, waitFor, within, act } from "../../../../../test-utils/swr";
+```
+
+Add to the `AgentInboxPage` suite:
+
+```tsx
+it("polls the active inbox every 10 seconds", async () => {
+  setSearchParams({ email: "support@acme.io" });
+  mockMessages([ORPHAN_INBOUND]);
+
+  render(<AgentInboxPage />);
+  await waitFor(() => expect(screen.getByTestId("thread-row")).toBeInTheDocument());
+  const initialCalls = mockFetch.mock.calls.length;
+
+  await act(async () => {
+    jest.advanceTimersByTime(10_000);
+    await Promise.resolve();
+  });
+
+  await waitFor(() => {
+    expect(mockFetch.mock.calls.length).toBeGreaterThan(initialCalls);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and verify no interval refresh occurs**
+
+Run:
+
+```bash
+cd web
+npm test -- --runInBand 'src/app/(app)/inboxes/(view)/messages/page.test.tsx'
+```
+
+Expected: FAIL because `mockFetch` remains at the initial call count after 10 seconds.
+
+- [ ] **Step 3: Apply `inboxPolling` to the inbox SWR query**
+
+Import:
+
+```tsx
+import { inboxPolling } from "../../../../../lib/livePolling";
+```
+
+Change the existing per-query options to preserve the agent-switch safety rule
+while enabling polling:
+
+```tsx
+{
+  ...inboxPolling,
+  keepPreviousData: false,
+}
+```
+
+- [ ] **Step 4: Run the inbox test and verify it passes**
+
+Run:
+
+```bash
+cd web
+npm test -- --runInBand 'src/app/(app)/inboxes/(view)/messages/page.test.tsx'
+```
+
+Expected: PASS, including the new interval assertion and existing pagination,
+selection, and pending-callout cases.
+
+- [ ] **Step 5: Commit active-inbox polling**
+
+```bash
+git add 'web/src/app/(app)/inboxes/(view)/messages/page.tsx' 'web/src/app/(app)/inboxes/(view)/messages/page.test.tsx'
+git commit -m "feat(web): poll active inbox messages"
+```
+
+## Task 5: Poll Pending Review and unread badges
+
+**Files:**
+- Modify: `web/src/app/components/hooks/usePendingCount.test.tsx`
+- Create: `web/src/app/components/hooks/usePendingCount.polling.test.tsx`
+- Modify: `web/src/app/components/hooks/usePendingCount.ts`
+- Modify: `web/src/app/(app)/reviews/page.test.tsx`
+- Modify: `web/src/app/(app)/reviews/page.tsx`
+- Modify: `web/src/app/(app)/inboxes/_components/AgentCard.test.tsx`
+- Modify: `web/src/app/(app)/inboxes/_components/AgentCard.tsx`
+
+- [ ] **Step 1: Add source-level polling assertions to the focused tests**
+
+In `usePendingCount.test.tsx`, mock `swr` before importing the hook and assert
+that the shared key receives `pendingPolling`. Because this file currently
+tests real SWR behavior, place the option assertion in a new sibling file
+`usePendingCount.polling.test.tsx` to avoid invalidating its existing tests:
+
+```tsx
+import useSWR from "swr";
+import { usePendingCount } from "./usePendingCount";
+import { pendingMessagesKey } from "../../../lib/swrKeys";
+import { pendingPolling } from "../../../lib/livePolling";
+
+jest.mock("swr", () => ({ __esModule: true, default: jest.fn() }));
+jest.mock("../onboarding/api", () => ({ listPendingMessages: jest.fn() }));
+
+const mockUseSWR = useSWR as jest.Mock;
+
+it("subscribes the shared pending key with live polling", () => {
+  mockUseSWR.mockReturnValue({ data: [], error: undefined });
+  usePendingCount();
+  expect(mockUseSWR).toHaveBeenCalledWith(
+    pendingMessagesKey,
+    expect.any(Function),
+    pendingPolling,
+  );
+});
+```
+
+Create the file at
+`web/src/app/components/hooks/usePendingCount.polling.test.tsx` and add it to
+the task's file list when committing.
+
+In `AgentCard.test.tsx`, add a behavioral fake-timer case using the existing
+mocked `getInboxUnread`:
+
+```tsx
+it("refreshes the unread probe every 15 seconds", async () => {
+  jest.useFakeTimers();
+  mockUnread.mockResolvedValue({ count: 1, more: false });
+  render(<AgentCard agent={agent} />);
+  await waitFor(() => expect(screen.getByTitle("1 unread")).toBeInTheDocument());
+  const initialCalls = mockUnread.mock.calls.length;
+
+  await act(async () => {
+    jest.advanceTimersByTime(15_000);
+    await Promise.resolve();
+  });
+  await waitFor(() => expect(mockUnread.mock.calls.length).toBeGreaterThan(initialCalls));
+  jest.useRealTimers();
+});
+```
+
+Add `act` to the test-helper import and make `afterEach` always call
+`jest.useRealTimers()` before resetting the mock.
+
+The existing Review-page cache-sharing test already proves the page and sidebar
+use `pendingMessagesKey`; no second timer test is needed for the same cache.
+
+- [ ] **Step 2: Run the focused tests and verify they fail**
+
+Run:
+
+```bash
+cd web
+npm test -- --runInBand src/app/components/hooks/usePendingCount.polling.test.tsx 'src/app/(app)/reviews/page.test.tsx' 'src/app/(app)/inboxes/_components/AgentCard.test.tsx'
+```
+
+Expected: FAIL because the hook has no third SWR argument and AgentCard does not
+refresh after 15 seconds.
+
+- [ ] **Step 3: Apply pending polling to both consumers of the shared key**
+
+In `usePendingCount.ts`, import `pendingPolling` and change the hook to:
+
+```tsx
+const { data, error } = useSWR(
+  pendingMessagesKey,
+  () => listPendingMessages(),
+  pendingPolling,
+);
+```
+
+In `reviews/page.tsx`, import `pendingPolling` and change the existing call to:
+
+```tsx
+useSWR<PendingMessageSummary[]>(
+  pendingMessagesKey,
+  () => listPendingMessages(),
+  pendingPolling,
+);
+```
+
+Passing identical key, fetcher behavior, and options preserves SWR sharing and
+deduplication between the sidebar and Review page.
+
+- [ ] **Step 4: Apply unread polling to `AgentCard`**
+
+Import `unreadPolling` and pass it as the third SWR argument:
+
+```tsx
+const { data: unread } = useSWR(
+  agentUnreadKey(agent.email),
+  () => getInboxUnread(agent.email).catch(() => ({ count: 0, more: false })),
+  unreadPolling,
+);
+```
+
+- [ ] **Step 5: Run the focused tests and verify they pass**
+
+Run:
+
+```bash
+cd web
+npm test -- --runInBand src/app/components/hooks/usePendingCount.test.tsx src/app/components/hooks/usePendingCount.polling.test.tsx 'src/app/(app)/reviews/page.test.tsx' 'src/app/(app)/inboxes/_components/AgentCard.test.tsx'
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit shared Pending and unread polling**
+
+```bash
+git add web/src/app/components/hooks/usePendingCount.ts web/src/app/components/hooks/usePendingCount.test.tsx web/src/app/components/hooks/usePendingCount.polling.test.tsx 'web/src/app/(app)/reviews/page.tsx' 'web/src/app/(app)/reviews/page.test.tsx' 'web/src/app/(app)/inboxes/_components/AgentCard.tsx' 'web/src/app/(app)/inboxes/_components/AgentCard.test.tsx'
+git commit -m "feat(web): refresh pending and unread counts"
+```
+
+## Task 6: Full verification and documentation consistency
+
+**Files:**
+- Modify only if a verification failure reveals a scoped defect.
+
+- [ ] **Step 1: Run all focused feature tests together**
+
+```bash
+cd web
+npm test -- --runInBand \
+  src/lib/livePolling.test.ts \
+  src/app/components/messages/MessageStatusChip.test.tsx \
+  src/app/components/messages/ThreadRow.test.tsx \
+  src/app/components/messages/ThreadBubble.test.tsx \
+  'src/app/(app)/inboxes/(view)/messages/page.test.tsx' \
+  src/app/components/hooks/usePendingCount.test.tsx \
+  src/app/components/hooks/usePendingCount.polling.test.tsx \
+  'src/app/(app)/reviews/page.test.tsx' \
+  'src/app/(app)/inboxes/_components/AgentCard.test.tsx'
+```
+
+Expected: PASS with no open handles or timer warnings.
+
+- [ ] **Step 2: Run the complete web test suite**
+
+```bash
+cd web
+npm test -- --runInBand
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run lint**
+
+```bash
+cd web
+npm run lint
+```
+
+Expected: exit 0 with no ESLint errors.
+
+- [ ] **Step 4: Run the production build**
+
+```bash
+cd web
+npm run build
+```
+
+Expected: Next.js static export completes successfully. The prebuild agent-doc
+sync must not produce an unrelated diff.
+
+- [ ] **Step 5: Check the final diff for generated or unrelated changes**
+
+```bash
+git status --short
+git diff --check
+git diff --stat HEAD~4..HEAD
+```
+
+Expected: only the web status/polling files, tests, and the approved design/plan
+documents are changed. `.superpowers/` remains untracked and must not be staged.
+
+- [ ] **Step 6: Commit any verification-only correction**
+
+Only if Steps 1–4 required a source or test correction:
+
+```bash
+git add \
+  web/src/lib/livePolling.ts \
+  web/src/lib/livePolling.test.ts \
+  web/src/app/components/messages/MessageStatusChip.tsx \
+  web/src/app/components/messages/MessageStatusChip.test.tsx \
+  web/src/app/components/messages/ThreadRow.tsx \
+  web/src/app/components/messages/ThreadRow.test.tsx \
+  web/src/app/components/messages/ThreadBubble.tsx \
+  web/src/app/components/messages/ThreadBubble.test.tsx \
+  'web/src/app/(app)/inboxes/(view)/messages/page.tsx' \
+  'web/src/app/(app)/inboxes/(view)/messages/page.test.tsx' \
+  web/src/app/components/hooks/usePendingCount.ts \
+  web/src/app/components/hooks/usePendingCount.test.tsx \
+  web/src/app/components/hooks/usePendingCount.polling.test.tsx \
+  'web/src/app/(app)/reviews/page.tsx' \
+  'web/src/app/(app)/reviews/page.test.tsx' \
+  'web/src/app/(app)/inboxes/_components/AgentCard.tsx' \
+  'web/src/app/(app)/inboxes/_components/AgentCard.test.tsx'
+git commit -m "test(web): harden live inbox refresh"
+```
+
+If no correction was needed, do not create an empty commit.

--- a/docs/superpowers/specs/2026-07-19-live-inbox-delivery-status-design.md
+++ b/docs/superpowers/specs/2026-07-19-live-inbox-delivery-status-design.md
@@ -203,11 +203,13 @@ intervals without changing presentation components.
   outbound messages and no delivery chip on inbound messages.
 - Use fake timers or SWR test configuration to verify the active inbox refetches
   at 10 seconds.
-- Verify `usePendingCount` and the Review page share the key and refresh at the
-  10-second cadence without duplicate visible state.
+- Verify the single authenticated-layout `PendingPollingOwner` refreshes
+  `pendingMessagesKey` at the 10-second cadence, while `usePendingCount` and
+  the Review page are passive subscribers to that same key.
 - Verify unread probes refresh at 15 seconds and retain the existing `99+`
   behavior.
-- Verify hidden/offline polling options are disabled at each live-data hook.
+- Verify hidden/offline polling options are disabled at each polling owner or
+  polling query, not at the passive pending subscribers.
 
 ### Repository checks
 

--- a/docs/superpowers/specs/2026-07-19-live-inbox-delivery-status-design.md
+++ b/docs/superpowers/specs/2026-07-19-live-inbox-delivery-status-design.md
@@ -1,0 +1,222 @@
+# Live Inbox Polling and Delivery Status Design
+
+## Problem statement
+
+The web dashboard fetches inbox messages, unread counts, and review holds with
+SWR, but it only revalidates on mount, browser focus, reconnect, or explicit
+mutations. A user who keeps the dashboard visible does not see newly received
+mail or outbound status transitions until another revalidation occurs.
+
+The message API already exposes the outbound delivery lifecycle, but the inbox
+only labels `pending_review`. An outbound row persisted as `accepted` and later
+transitioned through `sending` to `sent` is listed by the API, yet the UI does
+not distinguish those states.
+
+## Goals and non-goals
+
+### Goals
+
+- Make the active inbox converge on new inbound and outbound messages without a
+  manual refresh.
+- Keep account-wide Pending Review counts and visible per-inbox unread badges
+  fresh.
+- Surface attention-worthy outbound delivery states in compact thread rows.
+- Surface every outbound message's delivery or review state in the opened
+  conversation.
+- Preserve the existing Gmail-like density and Loft design language.
+- Reuse the existing REST API, SWR cache keys, and mutation invalidation
+  helpers.
+
+### Non-goals
+
+- No OpenAPI, backend handler, database, SDK, CLI, MCP, or event-schema change.
+- No browser WebSocket or SSE transport.
+- No change to the agent WebSocket authentication or its one-connection-per-
+  agent replacement policy.
+- No polling of static dashboard resources such as domains, API keys, billing,
+  templates, or settings.
+- No server-side aggregate unread-count endpoint in this slice.
+
+## Relevant context and constraints
+
+- `SWRProvider` already enables focus and reconnect revalidation, request
+  deduplication, previous-data retention, and bounded retries.
+- The active inbox uses `agentMessagesKey(email, "all", "all")` and fetches the
+  newest 100 mixed inbound and outbound summaries.
+- The sidebar and Review page share `pendingMessagesKey`, so one SWR refresh
+  updates both consumers.
+- Inbox cards use one `agentUnreadKey(email)` probe per mounted card. These
+  probes exist only while the Inboxes page is mounted.
+- `MessageSummary.status` already projects `delivery_status`; its
+  `review_status` remains a separate lifecycle axis.
+- Delivery statuses are an open set. Known values are `accepted`, `sending`,
+  `sent`, `delivered`, `deferred`, `bounced`, `complained`, and `failed`.
+- The existing agent WebSocket cannot be reused safely in a browser: browsers
+  cannot set its bearer handshake header, and a second connection replaces the
+  active CLI or SDK listener.
+
+## Proposed design
+
+### 1. Scoped polling
+
+Add shared web constants for the two agreed refresh cadences:
+
+- Active inbox messages: 10 seconds.
+- Shared Pending Review query: 10 seconds.
+- Mounted inbox-card unread probes: 15 seconds.
+
+Apply `refreshInterval` only at these SWR call sites. Set
+`refreshWhenHidden: false` and `refreshWhenOffline: false` explicitly so the
+contract is visible in code rather than relying on library defaults. Existing
+`revalidateOnFocus` and `revalidateOnReconnect` behavior remains enabled.
+
+The Review page and `usePendingCount` must continue using the same SWR key and
+fetcher. SWR therefore coalesces them into one cache entry and one request per
+interval when both are mounted.
+
+Background refresh errors retain the last successful cached result. Existing
+initial-load and visible-page error states remain unchanged; polling does not
+clear already-rendered messages or counts.
+
+### 2. Canonical status derivation
+
+Refactor the existing message-status helper into the single source of truth for
+outbound status labels, tones, and whether a state belongs in a compact thread
+row. It accepts both `delivery_status` (the UI's current `status` field) and
+`review_status`.
+
+Precedence is:
+
+1. Unresolved or rejected review lifecycle states.
+2. Delivery lifecycle state.
+3. Review `sent` only when no delivery state is present.
+
+This prevents `review_status="sent"` from masking
+`delivery_status="accepted"`, `sending`, or a terminal delivery failure.
+
+| Source state | UI label | Tone | Compact thread row |
+|---|---|---|---|
+| `review_status=pending_review` | Pending review | warn | yes |
+| `review_status=review_rejected` | Rejected | danger | yes |
+| `review_status=review_expired_rejected` | Auto-rejected | danger | yes |
+| `delivery_status=accepted` | Queued | info | yes |
+| `delivery_status=sending` | Sending | info | yes |
+| `delivery_status=deferred` | Delayed | warn | yes |
+| `delivery_status=failed` | Failed | danger | yes |
+| `delivery_status=bounced` | Bounced | danger | yes |
+| `delivery_status=complained` | Complaint | danger | yes |
+| `delivery_status=sent` | Sent | success | no |
+| `delivery_status=delivered` | Delivered | success | no |
+| `review_status=review_expired_approved` with no delivery state | Sent (auto) | success | no |
+| `review_status=sent` with no delivery state | Sent | success | no |
+| unknown non-empty delivery state | unchanged raw value | neutral | no |
+
+Inbound unread/read presentation remains separate and unchanged.
+
+### 3. Thread-list presentation
+
+`ThreadRow` derives the latest message from the thread's existing oldest-to-
+newest `messages` array. If that message is outbound, it asks the canonical
+status helper for the compact-row status. Attention-worthy states render as the
+existing small Loft chip immediately before the timestamp.
+
+Only the latest message drives this row-level indicator. Historical failures
+remain visible inside the conversation but do not permanently label a thread
+whose later message succeeded. The existing thread-level Pending behavior and
+pending-first sorting remain unchanged.
+
+### 4. Conversation presentation
+
+`ThreadBubble` renders a canonical status chip beside the sender metadata for
+every outbound message. This includes settled `Sent` and `Delivered` states as
+well as transient and failed states. Inbound bubbles receive no new delivery
+chip.
+
+The existing pending-review callout, review navigation, delete restrictions,
+message-body loading, and attachment behavior remain unchanged.
+
+### 5. Live-update experience
+
+Polling updates the SWR data in place. New messages are grouped and sorted by
+the existing pure threading logic, so a newly active thread moves to its normal
+position without a full-page reload. Updated delivery states replace their
+chips in place.
+
+The sidebar Pending badge and visible unread badges update from their existing
+components. The first implementation does not add a persistent "connected"
+indicator or toast: polling is an implementation detail, and normal background
+refresh should stay visually quiet like Gmail. Existing loading and error UI is
+used only when it is already relevant.
+
+## Edge cases and failure handling
+
+- Hidden or offline tabs do not poll. Focus or reconnect triggers an immediate
+  revalidation through the existing global SWR policy.
+- Concurrent consumers with the same key are deduplicated by SWR.
+- A slow request does not create overlapping visible data mutations; SWR keeps
+  its normal request deduplication and race handling.
+- A background 4xx is not retried by the global error policy. A background 5xx
+  retains prior data and uses the existing bounded retry policy.
+- Unknown future delivery values remain legible in message detail without
+  cluttering the compact thread list.
+- An outbound message with no delivery or review status renders no status chip
+  rather than incorrectly claiming it was sent.
+- Review status wins only for pending/rejected outcomes. A stale or collapsed
+  review `sent` value cannot hide a newer delivery state.
+- Polling the first 100 rows preserves the existing pagination boundary. This
+  feature does not attempt to refresh imperatively loaded older pages.
+
+## Scalability and extensibility notes
+
+Scoped polling avoids repeatedly loading unrelated dashboard resources. The
+only N-per-inbox behavior is the existing unread probe on the Inboxes page; a
+15-second cadence is acceptable for the current product scale because those
+hooks are not mounted elsewhere.
+
+If accounts grow to enough inboxes that unread polling becomes expensive, the
+follow-up is an account-level unread-count projection on `GET /v1/agents` or a
+dedicated aggregate endpoint. That is deliberately outside this UI-only slice.
+
+The canonical status helper isolates the open delivery vocabulary. New states
+can be added in one mapping without changing `ThreadRow` and `ThreadBubble`.
+A later server-push transport can invalidate the same SWR keys and remove the
+intervals without changing presentation components.
+
+## Verification strategy
+
+### Unit and component tests
+
+- Cover every known status mapping, tone, precedence rule, compact visibility
+  rule, empty status, and unknown status.
+- Verify `ThreadRow` shows transient/failure states for the latest outbound
+  message, omits settled states, and does not surface a historical failure when
+  a newer message exists.
+- Verify `ThreadBubble` shows settled, transient, review, and failure states on
+  outbound messages and no delivery chip on inbound messages.
+- Use fake timers or SWR test configuration to verify the active inbox refetches
+  at 10 seconds.
+- Verify `usePendingCount` and the Review page share the key and refresh at the
+  10-second cadence without duplicate visible state.
+- Verify unread probes refresh at 15 seconds and retain the existing `99+`
+  behavior.
+- Verify hidden/offline polling options are disabled at each live-data hook.
+
+### Repository checks
+
+- Run the focused message, inbox-page, pending-count, Review-page, and AgentCard
+  Jest tests while iterating.
+- Run `npm test` in `web/`.
+- Run `npm run lint` in `web/`.
+- Run `npm run build` in `web/`.
+
+## Rollout
+
+This is a web-only, backward-compatible change and needs no migration or feature
+flag. Deploy with the normal dashboard build. Monitor API request volume and
+browser error reporting after release, with particular attention to accounts
+that have many inboxes open on the Inboxes page.
+
+## Open questions
+
+None. Polling cadence, status vocabulary, placement, failure behavior, and
+scope were approved during design review.

--- a/docs/superpowers/specs/2026-07-19-live-inbox-delivery-status-design.md
+++ b/docs/superpowers/specs/2026-07-19-live-inbox-delivery-status-design.md
@@ -43,7 +43,9 @@ not distinguish those states.
   deduplication, previous-data retention, and bounded retries.
 - The active inbox uses `agentMessagesKey(email, "all", "all")` and fetches the
   newest 100 mixed inbound and outbound summaries.
-- The sidebar and Review page share `pendingMessagesKey`, so one SWR refresh
+- The authenticated app layout mounts one `PendingPollingOwner` for
+  `pendingMessagesKey`. The sidebar's `usePendingCount` hook and the Review
+  page are passive subscribers to that same cache key, so the owner's refresh
   updates both consumers.
 - Inbox cards use one `agentUnreadKey(email)` probe per mounted card. These
   probes exist only while the Inboxes page is mounted.
@@ -65,18 +67,24 @@ Add shared web constants for the two agreed refresh cadences:
 - Shared Pending Review query: 10 seconds.
 - Mounted inbox-card unread probes: 15 seconds.
 
-Apply `refreshInterval` only at these SWR call sites. Set
-`refreshWhenHidden: false` and `refreshWhenOffline: false` explicitly so the
-contract is visible in code rather than relying on library defaults. Existing
-`revalidateOnFocus` and `revalidateOnReconnect` behavior remains enabled.
+Apply `refreshInterval` to the active-inbox and unread-probe queries, and mount
+one `PendingPollingOwner` inside the authenticated app layout to own
+`pendingPolling`. Set `refreshWhenHidden: false` and
+`refreshWhenOffline: false` explicitly so the contract is visible in code
+rather than relying on library defaults. Existing `revalidateOnFocus` and
+`revalidateOnReconnect` behavior remains enabled.
 
-The Review page and `usePendingCount` must continue using the same SWR key and
-fetcher. SWR therefore coalesces them into one cache entry and one request per
-interval when both are mounted.
+The Review page and the sidebar's `usePendingCount` continue using the same
+`pendingMessagesKey` and fetcher, but neither consumer owns a polling timer.
+They are passive same-key subscribers to the authenticated-layout
+`PendingPollingOwner`. This single explicit owner, rather than identical SWR
+options on multiple subscribers, guarantees one pending polling source.
 
-Background refresh errors retain the last successful cached result. Existing
-initial-load and visible-page error states remain unchanged; polling does not
-clear already-rendered messages or counts.
+Background refresh errors retain the last successful cached result. In
+particular, cached pending messages and counts and cached unread badge data
+remain visible during a transient revalidation error. Existing initial-load
+and visible-page error states remain unchanged; polling does not clear
+already-rendered messages or counts.
 
 ### 2. Canonical status derivation
 

--- a/web/src/app/(app)/inboxes/(view)/messages/page.test.tsx
+++ b/web/src/app/(app)/inboxes/(view)/messages/page.test.tsx
@@ -2,7 +2,7 @@
 // callout fires when a thread has a pending draft, empty state, "load
 // older" button.
 
-import { render, screen, waitFor, within } from "../../../../../test-utils/swr";
+import { act, render, screen, waitFor, within } from "../../../../../test-utils/swr";
 import userEvent from "@testing-library/user-event";
 import AgentInboxPage from "./page";
 import type { MessageSummary } from "../../../../components/types";
@@ -134,6 +134,27 @@ describe("AgentInboxPage", () => {
     expect(screen.getAllByText("PR #2841 merged").length).toBeGreaterThan(0);
     // Synthetic thread key — used by the URL fragment when selected.
     expect(screen.getByTestId("thread-row").dataset.threadKey).toBe("orphan:msg_solo");
+  });
+
+  it("polls the active inbox for new messages", async () => {
+    setSearchParams({ email: "support@acme.io" });
+    mockMessages([ORPHAN_INBOUND]);
+
+    render(<AgentInboxPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("thread-row")).toBeInTheDocument();
+    });
+    const initialFetchCount = mockFetch.mock.calls.length;
+
+    await act(async () => {
+      jest.advanceTimersByTime(10_000);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(mockFetch.mock.calls.length).toBeGreaterThan(initialFetchCount);
+    });
   });
 
   it("pending callout appears in the thread detail when a thread is pending", async () => {

--- a/web/src/app/(app)/inboxes/(view)/messages/page.test.tsx
+++ b/web/src/app/(app)/inboxes/(view)/messages/page.test.tsx
@@ -157,6 +157,48 @@ describe("AgentInboxPage", () => {
     });
   });
 
+  it("retains cached inbox rows when background polling fails", async () => {
+    setSearchParams({ email: "support@acme.io" });
+    let messageRequestCount = 0;
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("/v1/agents/") && url.includes("/messages")) {
+        messageRequestCount += 1;
+        if (messageRequestCount === 1) {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            text: () =>
+              Promise.resolve(
+                JSON.stringify({ items: [ORPHAN_INBOUND], next_cursor: null }),
+              ),
+          });
+        }
+        return Promise.reject(new Error("refresh failed"));
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve("not found"),
+      });
+    });
+
+    render(<AgentInboxPage />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("thread-row")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      jest.advanceTimersByTime(10_000);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("refresh failed")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("thread-row")).toBeInTheDocument();
+  });
+
   it("pending callout appears in the thread detail when a thread is pending", async () => {
     setSearchParams({ email: "support@acme.io" });
     mockMessages([PENDING_REPLY, PARENT_INBOUND]);

--- a/web/src/app/(app)/inboxes/(view)/messages/page.test.tsx
+++ b/web/src/app/(app)/inboxes/(view)/messages/page.test.tsx
@@ -199,6 +199,73 @@ describe("AgentInboxPage", () => {
     expect(screen.getByTestId("thread-row")).toBeInTheDocument();
   });
 
+  it("clears pagination state when switching agents", async () => {
+    const agentACurrent = {
+      ...ORPHAN_INBOUND,
+      id: "msg_agent_a_current",
+      subject: "Agent A current",
+    };
+    const agentAOlder = {
+      ...ORPHAN_INBOUND,
+      id: "msg_agent_a_older",
+      subject: "Agent A older",
+    };
+    const agentBCurrent = {
+      ...ORPHAN_INBOUND,
+      id: "msg_agent_b_current",
+      subject: "Agent B current",
+    };
+    setSearchParams({ email: "agent-a@acme.io" });
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes("/v1/agents/agent-a%40acme.io/messages")) {
+        const page = url.includes("cursor=cursor-a")
+          ? { items: [agentAOlder], next_cursor: "cursor-a-more" }
+          : { items: [agentACurrent], next_cursor: "cursor-a" };
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          text: () => Promise.resolve(JSON.stringify(page)),
+        });
+      }
+      if (url.includes("/v1/agents/agent-b%40acme.io/messages")) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          text: () =>
+            Promise.resolve(
+              JSON.stringify({ items: [agentBCurrent], next_cursor: null }),
+            ),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve("not found"),
+      });
+    });
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
+    const { rerender } = render(<AgentInboxPage />);
+    await waitFor(() => {
+      expect(screen.getByText("Agent A current")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /load older/i }));
+    await waitFor(() => {
+      expect(screen.getByText("Agent A older")).toBeInTheDocument();
+    });
+
+    setSearchParams({ email: "agent-b@acme.io" });
+    rerender(<AgentInboxPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Agent B current")).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Agent A current")).not.toBeInTheDocument();
+    expect(screen.queryByText("Agent A older")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /load older/i })).not.toBeInTheDocument();
+  });
+
   it("pending callout appears in the thread detail when a thread is pending", async () => {
     setSearchParams({ email: "support@acme.io" });
     mockMessages([PENDING_REPLY, PARENT_INBOUND]);

--- a/web/src/app/(app)/inboxes/(view)/messages/page.tsx
+++ b/web/src/app/(app)/inboxes/(view)/messages/page.tsx
@@ -222,7 +222,7 @@ function AgentInboxContent() {
           Loading inbox…
         </div>
       )}
-      {!error && initialPage && (
+      {initialPage && (
         <div className="flex-1 flex flex-col">
           {selected ? (
             <ThreadDetail

--- a/web/src/app/(app)/inboxes/(view)/messages/page.tsx
+++ b/web/src/app/(app)/inboxes/(view)/messages/page.tsx
@@ -43,15 +43,19 @@ function useUrlHash(): string {
 export default function AgentInboxPage() {
   return (
     <Suspense fallback={null}>
-      <AgentInboxContent />
+      <AgentInboxRoute />
     </Suspense>
   );
 }
 
-function AgentInboxContent() {
-  const router = useRouter();
+function AgentInboxRoute() {
   const searchParams = useSearchParams();
   const email = searchParams.get("email") ?? "";
+  return <AgentInboxContent key={email} email={email} />;
+}
+
+function AgentInboxContent({ email }: { email: string }) {
+  const router = useRouter();
 
   // Initial 100-row window. SWR keys by email so navigating between
   // agents fetches independently; mutations on the focus page call

--- a/web/src/app/(app)/inboxes/(view)/messages/page.tsx
+++ b/web/src/app/(app)/inboxes/(view)/messages/page.tsx
@@ -19,6 +19,7 @@ import type { MessageSummary } from "../../../../components/types";
 import { ThreadList } from "../../../../components/messages/ThreadList";
 import { ThreadDetail } from "../../../../components/messages/ThreadDetail";
 import { groupIntoThreads } from "../../../../components/messages/threading";
+import { inboxPolling } from "../../../../../lib/livePolling";
 import { agentMessagesKey } from "../../../../../lib/swrKeys";
 
 // Sync the URL fragment into React state. useSyncExternalStore is the
@@ -66,7 +67,7 @@ function AgentInboxContent() {
     // during a ?email=A → ?email=B switch. Disable here so the page
     // flashes a brief loading state instead of mis-attributing
     // messages to the new agent.
-    { keepPreviousData: false },
+    { ...inboxPolling, keepPreviousData: false },
   );
 
   // "Load older" appends additional pages keyed by the prior page's

--- a/web/src/app/(app)/inboxes/_components/AgentCard.test.tsx
+++ b/web/src/app/(app)/inboxes/_components/AgentCard.test.tsx
@@ -3,7 +3,7 @@
 // pin the count/"99+"/hidden-at-zero rendering and the graceful-degrade
 // on probe failure.
 
-import { render, screen, waitFor } from "../../../../test-utils/swr";
+import { act, render, screen, waitFor } from "../../../../test-utils/swr";
 import { AgentCard } from "./AgentCard";
 import { getInboxUnread } from "../../../components/onboarding/api";
 import type { DashboardAgent } from "../../../components/types";
@@ -41,7 +41,10 @@ const agent: DashboardAgent = {
   created_at: "2026-05-10T00:00:00Z",
 };
 
-afterEach(() => mockUnread.mockReset());
+afterEach(() => {
+  jest.useRealTimers();
+  mockUnread.mockReset();
+});
 
 it("renders the unread count as a red badge", async () => {
   mockUnread.mockResolvedValue({ count: 3, more: false });
@@ -71,4 +74,24 @@ it("degrades to no badge when the probe rejects", async () => {
   render(<AgentCard agent={agent} />);
   await waitFor(() => expect(screen.getByText("billing@acme.dev")).toBeInTheDocument());
   expect(screen.queryByText("unread messages", { exact: false })).not.toBeInTheDocument();
+});
+
+it("refreshes the unread probe every 15 seconds", async () => {
+  jest.useFakeTimers();
+  mockUnread.mockResolvedValue({ count: 1, more: false });
+
+  render(<AgentCard agent={agent} />);
+
+  await act(async () => {
+    await Promise.resolve();
+  });
+  expect(screen.getByTitle("1 unread")).toBeInTheDocument();
+  const initialCallCount = mockUnread.mock.calls.length;
+
+  await act(async () => {
+    jest.advanceTimersByTime(15_000);
+    await Promise.resolve();
+  });
+
+  expect(mockUnread.mock.calls.length).toBeGreaterThan(initialCallCount);
 });

--- a/web/src/app/(app)/inboxes/_components/AgentCard.test.tsx
+++ b/web/src/app/(app)/inboxes/_components/AgentCard.test.tsx
@@ -95,3 +95,27 @@ it("refreshes the unread probe every 15 seconds", async () => {
 
   expect(mockUnread.mock.calls.length).toBeGreaterThan(initialCallCount);
 });
+
+it("keeps the prior unread badge when a polling refresh fails", async () => {
+  jest.useFakeTimers();
+  mockUnread
+    .mockResolvedValueOnce({ count: 4, more: false })
+    .mockRejectedValueOnce(new Error("transient"));
+
+  render(<AgentCard agent={agent} />);
+
+  await act(async () => {
+    await Promise.resolve();
+  });
+  expect(screen.getByTitle("4 unread")).toBeInTheDocument();
+  const initialCallCount = mockUnread.mock.calls.length;
+
+  await act(async () => {
+    jest.advanceTimersByTime(15_000);
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  expect(mockUnread.mock.calls.length).toBeGreaterThan(initialCallCount);
+  expect(screen.getByTitle("4 unread")).toBeInTheDocument();
+});

--- a/web/src/app/(app)/inboxes/_components/AgentCard.tsx
+++ b/web/src/app/(app)/inboxes/_components/AgentCard.tsx
@@ -8,6 +8,7 @@ import {
   getInboxUnread,
   UNREAD_BADGE_CAP,
 } from "../../../components/onboarding/api";
+import { unreadPolling } from "../../../../lib/livePolling";
 import { agentUnreadKey } from "../../../../lib/swrKeys";
 
 export function AgentCard({
@@ -16,11 +17,14 @@ export function AgentCard({
   agent: DashboardAgent;
 }) {
   // Option A unread affordance: one lightweight per-card probe against the
-  // messages endpoint (read_status=unread). SWR shares/dedupes the call and
-  // revalidates on focus, so returning to this tab after reading an inbox
-  // updates the count. Failures degrade silently to "no badge".
-  const { data: unread } = useSWR(agentUnreadKey(agent.email), () =>
-    getInboxUnread(agent.email).catch(() => ({ count: 0, more: false })),
+  // messages endpoint (read_status=unread). SWR shares/dedupes the call,
+  // polls while visible and online, and revalidates on focus. Failures
+  // degrade silently to "no badge".
+  const { data: unread } = useSWR(
+    agentUnreadKey(agent.email),
+    () =>
+      getInboxUnread(agent.email).catch(() => ({ count: 0, more: false })),
+    unreadPolling,
   );
   const unreadCount = unread?.count ?? 0;
   const unreadLabel =

--- a/web/src/app/(app)/inboxes/_components/AgentCard.tsx
+++ b/web/src/app/(app)/inboxes/_components/AgentCard.tsx
@@ -18,12 +18,11 @@ export function AgentCard({
 }) {
   // Option A unread affordance: one lightweight per-card probe against the
   // messages endpoint (read_status=unread). SWR shares/dedupes the call,
-  // polls while visible and online, and revalidates on focus. Failures
-  // degrade silently to "no badge".
+  // polls while visible and online, and revalidates on focus. An initial
+  // failure shows no badge; a transient refresh failure retains cached data.
   const { data: unread } = useSWR(
     agentUnreadKey(agent.email),
-    () =>
-      getInboxUnread(agent.email).catch(() => ({ count: 0, more: false })),
+    () => getInboxUnread(agent.email),
     unreadPolling,
   );
   const unreadCount = unread?.count ?? 0;

--- a/web/src/app/(app)/layout.pendingPolling.test.tsx
+++ b/web/src/app/(app)/layout.pendingPolling.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import AppLayout from "./layout";
+
+jest.mock("next/link", () => {
+  return function MockLink({ children }: { children: React.ReactNode }) {
+    return <a>{children}</a>;
+  };
+});
+
+jest.mock("../components/AuthProvider", () => ({
+  useAuth: () => ({ user: { email: "user@example.com" }, loading: false }),
+}));
+
+jest.mock("../components/swr/SWRProvider", () => ({
+  SWRProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("../components/swr/PendingPollingOwner", () => ({
+  PendingPollingOwner: () => <span data-testid="pending-polling-owner" />,
+}));
+
+jest.mock("../components/loft/Sidebar", () => ({
+  Sidebar: () => <nav />,
+}));
+
+jest.mock("../components/SignInLink", () => ({
+  SignInLink: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+it("renders exactly one pending polling owner for the authenticated app", () => {
+  render(
+    <AppLayout>
+      <div>content</div>
+    </AppLayout>,
+  );
+
+  expect(screen.getAllByTestId("pending-polling-owner")).toHaveLength(1);
+});

--- a/web/src/app/(app)/layout.tsx
+++ b/web/src/app/(app)/layout.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { useAuth } from "../components/AuthProvider";
 import { SWRProvider } from "../components/swr/SWRProvider";
+import { PendingPollingOwner } from "../components/swr/PendingPollingOwner";
 import { SignInLink } from "../components/SignInLink";
 import { Sidebar } from "../components/loft/Sidebar";
 
@@ -125,6 +126,7 @@ export default function AppLayout({
       // pages keep their own visual density.
       data-app-surface=""
     >
+      <PendingPollingOwner />
       {/* Desktop sidebar */}
       <Sidebar />
 

--- a/web/src/app/(app)/reviews/page.polling.test.tsx
+++ b/web/src/app/(app)/reviews/page.polling.test.tsx
@@ -1,0 +1,40 @@
+import { render } from "@testing-library/react";
+import useSWR from "swr";
+import { pendingMessagesKey } from "../../../lib/swrKeys";
+import { listPendingMessages } from "../../components/onboarding/api";
+import PendingPage from "./page";
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ data: [], error: undefined, isLoading: false })),
+  mutate: jest.fn(),
+}));
+
+jest.mock("next/navigation", () => ({
+  useSearchParams: () => ({ get: () => null }),
+  useRouter: () => ({ replace: jest.fn() }),
+}));
+
+jest.mock("../../components/onboarding/api", () => ({
+  listPendingMessages: jest.fn(),
+}));
+
+jest.mock("../../components/loft/PageShell", () => ({
+  PageShell: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock("./_components/PendingRow", () => ({
+  PendingRow: () => null,
+}));
+
+it("subscribes to pending messages without owning a polling interval", () => {
+  render(<PendingPage />);
+
+  expect(useSWR).toHaveBeenCalledWith(
+    pendingMessagesKey,
+    listPendingMessages,
+  );
+
+  listPendingMessages();
+  expect(listPendingMessages).toHaveBeenCalledTimes(1);
+});

--- a/web/src/app/(app)/reviews/page.tsx
+++ b/web/src/app/(app)/reviews/page.tsx
@@ -4,7 +4,6 @@ import { Suspense, useCallback } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import useSWR, { mutate } from "swr";
 import { listPendingMessages } from "../../components/onboarding/api";
-import { pendingPolling } from "../../../lib/livePolling";
 import {
   invalidateAgents,
   invalidateAllAgentMessages,
@@ -33,11 +32,7 @@ function PendingContent() {
     data: messages = [],
     error: swrError,
     isLoading,
-  } = useSWR<PendingMessageSummary[]>(
-    pendingMessagesKey,
-    () => listPendingMessages(),
-    pendingPolling,
-  );
+  } = useSWR<PendingMessageSummary[]>(pendingMessagesKey, listPendingMessages);
   const loading = isLoading && messages.length === 0;
   const error = swrError
     ? swrError instanceof Error

--- a/web/src/app/(app)/reviews/page.tsx
+++ b/web/src/app/(app)/reviews/page.tsx
@@ -4,6 +4,7 @@ import { Suspense, useCallback } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import useSWR, { mutate } from "swr";
 import { listPendingMessages } from "../../components/onboarding/api";
+import { pendingPolling } from "../../../lib/livePolling";
 import {
   invalidateAgents,
   invalidateAllAgentMessages,
@@ -32,8 +33,10 @@ function PendingContent() {
     data: messages = [],
     error: swrError,
     isLoading,
-  } = useSWR<PendingMessageSummary[]>(pendingMessagesKey, () =>
-    listPendingMessages(),
+  } = useSWR<PendingMessageSummary[]>(
+    pendingMessagesKey,
+    () => listPendingMessages(),
+    pendingPolling,
   );
   const loading = isLoading && messages.length === 0;
   const error = swrError

--- a/web/src/app/components/hooks/usePendingCount.polling.test.tsx
+++ b/web/src/app/components/hooks/usePendingCount.polling.test.tsx
@@ -1,5 +1,4 @@
 import useSWR from "swr";
-import { pendingPolling } from "../../../lib/livePolling";
 import { pendingMessagesKey } from "../../../lib/swrKeys";
 import { listPendingMessages } from "../onboarding/api";
 import { usePendingCount } from "./usePendingCount";
@@ -18,16 +17,23 @@ const mockListPendingMessages = listPendingMessages as jest.MockedFunction<
   typeof listPendingMessages
 >;
 
-it("uses the shared pending polling policy", () => {
+it("subscribes to pending messages without owning a polling interval", () => {
   usePendingCount();
 
   expect(mockUseSWR).toHaveBeenCalledWith(
     pendingMessagesKey,
-    expect.any(Function),
-    pendingPolling,
+    listPendingMessages,
   );
 
-  const fetcher = mockUseSWR.mock.calls[0][1] as () => unknown;
-  fetcher();
+  listPendingMessages();
   expect(mockListPendingMessages).toHaveBeenCalledTimes(1);
+});
+
+it("keeps the last successful count when revalidation fails", () => {
+  mockUseSWR.mockReturnValueOnce({
+    data: [{ id: "msg_1" }, { id: "msg_2" }],
+    error: new Error("transient"),
+  } as ReturnType<typeof useSWR>);
+
+  expect(usePendingCount()).toBe(2);
 });

--- a/web/src/app/components/hooks/usePendingCount.polling.test.tsx
+++ b/web/src/app/components/hooks/usePendingCount.polling.test.tsx
@@ -1,0 +1,33 @@
+import useSWR from "swr";
+import { pendingPolling } from "../../../lib/livePolling";
+import { pendingMessagesKey } from "../../../lib/swrKeys";
+import { listPendingMessages } from "../onboarding/api";
+import { usePendingCount } from "./usePendingCount";
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ data: [], error: undefined })),
+}));
+
+jest.mock("../onboarding/api", () => ({
+  listPendingMessages: jest.fn(),
+}));
+
+const mockUseSWR = useSWR as jest.MockedFunction<typeof useSWR>;
+const mockListPendingMessages = listPendingMessages as jest.MockedFunction<
+  typeof listPendingMessages
+>;
+
+it("uses the shared pending polling policy", () => {
+  usePendingCount();
+
+  expect(mockUseSWR).toHaveBeenCalledWith(
+    pendingMessagesKey,
+    expect.any(Function),
+    pendingPolling,
+  );
+
+  const fetcher = mockUseSWR.mock.calls[0][1] as () => unknown;
+  fetcher();
+  expect(mockListPendingMessages).toHaveBeenCalledTimes(1);
+});

--- a/web/src/app/components/hooks/usePendingCount.ts
+++ b/web/src/app/components/hooks/usePendingCount.ts
@@ -9,21 +9,15 @@
 //      error) maps to `null` for back-compat with the old hook's
 //      contract — callers can distinguish "unknown" from "zero".
 //
-// Live refresh uses the shared pending polling policy; focus / reconnect /
-// dedup defaults still live in SWRProvider. Mutation sites that drop the
-// count (approve, reject) call `invalidatePendingList()` from lib/swrKeys.ts.
+// Live refresh is owned once by PendingPollingOwner; this hook only
+// subscribes to that shared cache. Mutation sites that drop the count
+// (approve, reject) call `invalidatePendingList()` from lib/swrKeys.ts.
 
 import useSWR from "swr";
 import { listPendingMessages } from "../onboarding/api";
-import { pendingPolling } from "../../../lib/livePolling";
 import { pendingMessagesKey } from "../../../lib/swrKeys";
 
 export function usePendingCount(): number | null {
-  const { data, error } = useSWR(
-    pendingMessagesKey,
-    () => listPendingMessages(),
-    pendingPolling,
-  );
-  if (error) return null;
-  return data ? data.length : null;
+  const { data } = useSWR(pendingMessagesKey, listPendingMessages);
+  return data !== undefined ? data.length : null;
 }

--- a/web/src/app/components/hooks/usePendingCount.ts
+++ b/web/src/app/components/hooks/usePendingCount.ts
@@ -9,16 +9,21 @@
 //      error) maps to `null` for back-compat with the old hook's
 //      contract — callers can distinguish "unknown" from "zero".
 //
-// Refresh wiring (focus / reconnect / dedup) lives in SWRProvider's
-// config, not here. Mutation sites that drop the count (approve,
-// reject) call `invalidatePendingList()` from lib/swrKeys.ts.
+// Live refresh uses the shared pending polling policy; focus / reconnect /
+// dedup defaults still live in SWRProvider. Mutation sites that drop the
+// count (approve, reject) call `invalidatePendingList()` from lib/swrKeys.ts.
 
 import useSWR from "swr";
 import { listPendingMessages } from "../onboarding/api";
+import { pendingPolling } from "../../../lib/livePolling";
 import { pendingMessagesKey } from "../../../lib/swrKeys";
 
 export function usePendingCount(): number | null {
-  const { data, error } = useSWR(pendingMessagesKey, () => listPendingMessages());
+  const { data, error } = useSWR(
+    pendingMessagesKey,
+    () => listPendingMessages(),
+    pendingPolling,
+  );
   if (error) return null;
   return data ? data.length : null;
 }

--- a/web/src/app/components/messages/MessageStatusChip.test.tsx
+++ b/web/src/app/components/messages/MessageStatusChip.test.tsx
@@ -1,79 +1,94 @@
-// Contract for deriveStatusChip — the
-// (direction, review_status, webhook_status, inbox_status) → chip tone
-// mapping. Mocking-free pure-function test so the README's status
-// chip table has a corresponding assertion in code.
-
 import { deriveStatusChip } from "./MessageStatusChip";
 
 describe("deriveStatusChip", () => {
-  it("outbound pending_approval → warn 'Pending' with dot", () => {
-    expect(
-      deriveStatusChip({ direction: "outbound", review_status: "pending_review" }),
-    ).toEqual({ tone: "warn", label: "Pending", dot: true });
-  });
+  it.each([
+    ["accepted", "info", "Queued", true],
+    ["sending", "info", "Sending", true],
+    ["deferred", "warn", "Delayed", true],
+    ["failed", "danger", "Failed", true],
+    ["bounced", "danger", "Bounced", true],
+    ["complained", "danger", "Complaint", true],
+    ["sent", "success", "Sent", false],
+    ["delivered", "success", "Delivered", false],
+  ] as const)(
+    "maps outbound delivery_status=%s to %s %s",
+    (delivery_status, tone, label, attention) => {
+      expect(deriveStatusChip({ direction: "outbound", delivery_status })).toEqual({
+        tone,
+        label,
+        attention,
+      });
+    },
+  );
 
-  it("outbound sent → success 'Sent'", () => {
-    expect(deriveStatusChip({ direction: "outbound", review_status: "sent" })).toEqual({
-      tone: "success",
-      label: "Sent",
+  it("gives pending review precedence over delivery state", () => {
+    expect(
+      deriveStatusChip({
+        direction: "outbound",
+        delivery_status: "delivered",
+        review_status: "pending_review",
+      }),
+    ).toEqual({
+      tone: "warn",
+      label: "Pending review",
+      dot: true,
+      attention: true,
     });
   });
 
-  it("outbound rejected → danger 'Rejected'", () => {
-    expect(
-      deriveStatusChip({ direction: "outbound", review_status: "review_rejected" }),
-    ).toEqual({ tone: "danger", label: "Rejected" });
-  });
-
-  it("outbound expired_approved → success 'Sent (auto)'", () => {
-    expect(
-      deriveStatusChip({ direction: "outbound", review_status: "review_expired_approved" }),
-    ).toEqual({ tone: "success", label: "Sent (auto)" });
-  });
-
-  it("outbound expired_rejected → danger 'Auto-rejected'", () => {
-    expect(
-      deriveStatusChip({ direction: "outbound", review_status: "review_expired_rejected" }),
-    ).toEqual({ tone: "danger", label: "Auto-rejected" });
-  });
-
-  it("webhook_status='failed' overrides outbound review_status with danger 'Failed'", () => {
-    // Even a 'sent' message gets Failed if the webhook gave up — the
-    // delivery is what the dashboard surfaces, not the send state.
+  it.each([
+    ["review_rejected", "Rejected"],
+    ["review_expired_rejected", "Auto-rejected"],
+  ] as const)("gives %s precedence over delivery state", (review_status, label) => {
     expect(
       deriveStatusChip({
         direction: "outbound",
+        delivery_status: "delivered",
+        review_status,
+      }),
+    ).toEqual({ tone: "danger", label, attention: true });
+  });
+
+  it("lets delivery_status=accepted override collapsed review_status=sent", () => {
+    expect(
+      deriveStatusChip({
+        direction: "outbound",
+        delivery_status: "accepted",
         review_status: "sent",
-        webhook_status: "failed",
       }),
-    ).toEqual({ tone: "danger", label: "Failed", dot: true });
+    ).toEqual({ tone: "info", label: "Queued", attention: true });
   });
 
-  // Theoretical edge case the data model can't currently produce
-  // (delivery only fires post-approval), but pin the precedence so a
-  // future change to that invariant doesn't silently downgrade the
-  // alarm. webhook_status='failed' wins over review_status='pending_approval':
-  // an op who sees Failed knows something needs investigation, where
-  // Pending would just look like normal queue depth.
-  it("webhook_status='failed' dominates HITL pending_approval", () => {
+  it.each([
+    ["sent", "Sent"],
+    ["review_expired_approved", "Sent (auto)"],
+  ] as const)("falls back from review_status=%s when delivery state is absent", (review_status, label) => {
+    expect(deriveStatusChip({ direction: "outbound", review_status })).toEqual({
+      tone: "success",
+      label,
+      attention: false,
+    });
+  });
+
+  it("surfaces an unknown non-empty delivery status as a neutral raw label", () => {
     expect(
-      deriveStatusChip({
-        direction: "outbound",
-        review_status: "pending_review",
-        webhook_status: "failed",
-      }),
-    ).toEqual({ tone: "danger", label: "Failed", dot: true });
+      deriveStatusChip({ direction: "outbound", delivery_status: "new_status" }),
+    ).toEqual({ tone: "neutral", label: "new_status", attention: false });
   });
 
-  it("inbound unread → info 'Unread' (no dot — passive label)", () => {
+  it("returns null for outbound messages without lifecycle state", () => {
+    expect(deriveStatusChip({ direction: "outbound" })).toBeNull();
+  });
+
+  it("preserves inbound unread as a passive info chip", () => {
     expect(
       deriveStatusChip({ direction: "inbound", inbox_status: "unread" }),
-    ).toEqual({ tone: "info", label: "Unread" });
+    ).toEqual({ tone: "info", label: "Unread", attention: false });
   });
 
-  it("inbound read → neutral 'Read'", () => {
+  it("preserves inbound read as a passive neutral chip", () => {
     expect(
       deriveStatusChip({ direction: "inbound", inbox_status: "read" }),
-    ).toEqual({ tone: "neutral", label: "Read" });
+    ).toEqual({ tone: "neutral", label: "Read", attention: false });
   });
 });

--- a/web/src/app/components/messages/MessageStatusChip.tsx
+++ b/web/src/app/components/messages/MessageStatusChip.tsx
@@ -1,69 +1,92 @@
-// Maps a message's (direction, review_status, webhook_status, inbox_status)
-// to a Loft Chip. The chip is the single source of truth for tone +
-// label across the inbox bubble footer and the focus-page title row.
-//
-// Status taxonomy in the backend:
-//   - Outbound `review_status`: 'sent' | 'pending_approval' | 'rejected'
-//     | 'expired_approved' | 'expired_rejected'.
-//   - Outbound `webhook_status`: webhook delivery state. 'failed' is
-//     terminal post-retry-exhaustion.
-//   - Inbound `inbox_status`: 'unread' | 'read'.
-//
-// Precedence: webhook_status='failed' dominates HITL state on outbound.
-// The data model can't currently produce "pending_approval + failed"
-// concurrently (delivery only fires post-approval), but if it ever
-// does the chip surfaces Failed — delivery is a louder alarm than a
-// stale-but-recoverable approval.
-
 import { Chip, Dot, type ChipTone } from "@e2a/ui";
 
 export type MessageStatusInput = {
   direction: "inbound" | "outbound";
+  /** Outbound delivery lifecycle. Empty on inbound. */
+  delivery_status?: string;
   /** Outbound HITL/send lifecycle. Empty on inbound. */
   review_status?: string;
-  /** Outbound webhook delivery state. */
-  webhook_status?: string;
   /** Inbound unread→read marker. Empty on outbound. */
   inbox_status?: string;
 };
 
-type ChipSpec = { tone: ChipTone; label: string; dot?: boolean };
+export type MessageStatusSpec = {
+  tone: ChipTone;
+  label: string;
+  dot?: boolean;
+  attention: boolean;
+};
 
-export function deriveStatusChip(m: MessageStatusInput): ChipSpec {
-  if (m.direction === "outbound") {
-    if (m.webhook_status === "failed") {
-      return { tone: "danger", label: "Failed", dot: true };
+export function deriveStatusChip(m: MessageStatusInput): MessageStatusSpec | null {
+  if (m.direction === "inbound") {
+    if (m.inbox_status === "unread") {
+      return { tone: "info", label: "Unread", attention: false };
     }
-    switch (m.review_status) {
-      case "pending_review":
-        return { tone: "warn", label: "Pending", dot: true };
-      case "review_rejected":
-        return { tone: "danger", label: "Rejected" };
-      case "review_expired_approved":
-        return { tone: "success", label: "Sent (auto)" };
-      case "review_expired_rejected":
-        return { tone: "danger", label: "Auto-rejected" };
+    return { tone: "neutral", label: "Read", attention: false };
+  }
+
+  switch (m.review_status) {
+    case "pending_review":
+      return {
+        tone: "warn",
+        label: "Pending review",
+        dot: true,
+        attention: true,
+      };
+    case "review_rejected":
+      return { tone: "danger", label: "Rejected", attention: true };
+    case "review_expired_rejected":
+      return { tone: "danger", label: "Auto-rejected", attention: true };
+  }
+
+  if (m.delivery_status) {
+    switch (m.delivery_status) {
+      case "accepted":
+        return { tone: "info", label: "Queued", attention: true };
+      case "sending":
+        return { tone: "info", label: "Sending", attention: true };
+      case "deferred":
+        return { tone: "warn", label: "Delayed", attention: true };
+      case "failed":
+        return { tone: "danger", label: "Failed", attention: true };
+      case "bounced":
+        return { tone: "danger", label: "Bounced", attention: true };
+      case "complained":
+        return { tone: "danger", label: "Complaint", attention: true };
       case "sent":
-      case undefined:
-      case "":
-        return { tone: "success", label: "Sent" };
+        return { tone: "success", label: "Sent", attention: false };
+      case "delivered":
+        return { tone: "success", label: "Delivered", attention: false };
       default:
-        return { tone: "neutral", label: m.review_status };
+        return {
+          tone: "neutral",
+          label: m.delivery_status,
+          attention: false,
+        };
     }
   }
-  // Inbound
-  if (m.inbox_status === "unread") return { tone: "info", label: "Unread" };
-  return { tone: "neutral", label: "Read" };
+
+  switch (m.review_status) {
+    case "sent":
+      return { tone: "success", label: "Sent", attention: false };
+    case "review_expired_approved":
+      return { tone: "success", label: "Sent (auto)", attention: false };
+    default:
+      return null;
+  }
 }
 
 export function MessageStatusChip(props: MessageStatusInput) {
   const spec = deriveStatusChip(props);
-  // Only the live-state chips (Pending / Failed) get a leading dot —
-  // matches the design mocks. Passive labels (Sent / Read / Unread) read
-  // cleaner without one.
+  if (!spec) return null;
+
   const dotTone =
-    spec.tone === "warn" ? "warn" :
-    spec.tone === "danger" ? "danger" : null;
+    spec.tone === "warn"
+      ? "warn"
+      : spec.tone === "danger"
+        ? "danger"
+        : null;
+
   return (
     <Chip tone={spec.tone}>
       {spec.dot && dotTone && <Dot tone={dotTone} />}

--- a/web/src/app/components/messages/MessageStatusChip.tsx
+++ b/web/src/app/components/messages/MessageStatusChip.tsx
@@ -76,7 +76,10 @@ export function deriveStatusChip(m: MessageStatusInput): MessageStatusSpec | nul
   }
 }
 
-export function MessageStatusChip(props: MessageStatusInput) {
+export function MessageStatusChip({
+  className,
+  ...props
+}: MessageStatusInput & { className?: string }) {
   const spec = deriveStatusChip(props);
   if (!spec) return null;
 
@@ -88,7 +91,7 @@ export function MessageStatusChip(props: MessageStatusInput) {
         : null;
 
   return (
-    <Chip tone={spec.tone}>
+    <Chip tone={spec.tone} className={className}>
       {spec.dot && dotTone && <Dot tone={dotTone} />}
       {spec.label}
     </Chip>

--- a/web/src/app/components/messages/ThreadBubble.test.tsx
+++ b/web/src/app/components/messages/ThreadBubble.test.tsx
@@ -115,9 +115,12 @@ describe("ThreadBubble outbound delivery status", () => {
   it.each([
     ["accepted", "Queued"],
     ["sending", "Sending"],
+    ["deferred", "Delayed"],
     ["sent", "Sent"],
     ["delivered", "Delivered"],
     ["failed", "Failed"],
+    ["bounced", "Bounced"],
+    ["complained", "Complaint"],
   ] as const)("renders %s as %s", async (status, label) => {
     const id = `msg_status_${status}`;
     mockGet.mockResolvedValue({
@@ -135,7 +138,31 @@ describe("ThreadBubble outbound delivery status", () => {
 
     render(<ThreadBubble message={m} counterparty={CP} agentEmail="support@acme.dev" />);
 
-    expect(await screen.findByText(label)).toBeInTheDocument();
+    expect(await screen.findByText(label)).toHaveClass("shrink-0", "whitespace-nowrap");
+  });
+
+  it.each([
+    ["pending_review", "Pending review"],
+    ["review_rejected", "Rejected"],
+  ] as const)("renders review status %s as %s", async (review_status, label) => {
+    const id = `msg_review_${review_status}`;
+    mockGet.mockResolvedValue({
+      direction: "outbound",
+      data: { body_text: `${review_status} body`, body_html: "" },
+    } as never);
+    const m: MessageSummary = {
+      ...msg(id),
+      direction: "outbound",
+      from: "support@acme.dev",
+      to: ["james@x.com"],
+      recipient: "james@x.com",
+      status: "",
+      review_status,
+    };
+
+    render(<ThreadBubble message={m} counterparty={CP} agentEmail="support@acme.dev" />);
+
+    expect(await screen.findByText(label)).toHaveClass("shrink-0", "whitespace-nowrap");
   });
 
   it("does not render an outbound delivery chip on an inbound message", async () => {

--- a/web/src/app/components/messages/ThreadBubble.test.tsx
+++ b/web/src/app/components/messages/ThreadBubble.test.tsx
@@ -110,3 +110,41 @@ describe("ThreadBubble marks-read cache refresh", () => {
     expect(mockInvalidateUnread).not.toHaveBeenCalled();
   });
 });
+
+describe("ThreadBubble outbound delivery status", () => {
+  it.each([
+    ["accepted", "Queued"],
+    ["sending", "Sending"],
+    ["sent", "Sent"],
+    ["delivered", "Delivered"],
+    ["failed", "Failed"],
+  ] as const)("renders %s as %s", async (status, label) => {
+    const id = `msg_status_${status}`;
+    mockGet.mockResolvedValue({
+      direction: "outbound",
+      data: { body_text: `${status} body`, body_html: "" },
+    } as never);
+    const m: MessageSummary = {
+      ...msg(id),
+      direction: "outbound",
+      from: "support@acme.dev",
+      to: ["james@x.com"],
+      recipient: "james@x.com",
+      status,
+    };
+
+    render(<ThreadBubble message={m} counterparty={CP} agentEmail="support@acme.dev" />);
+
+    expect(await screen.findByText(label)).toBeInTheDocument();
+  });
+
+  it("does not render an outbound delivery chip on an inbound message", async () => {
+    inbound({ parsed: { text: "inbound body" }, raw_message: "" });
+    const m = { ...msg("msg_status_inbound"), status: "failed" };
+
+    render(<ThreadBubble message={m} counterparty={CP} agentEmail="support@acme.dev" />);
+
+    await screen.findByText("inbound body");
+    expect(screen.queryByText("Failed")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/app/components/messages/ThreadBubble.tsx
+++ b/web/src/app/components/messages/ThreadBubble.tsx
@@ -201,6 +201,7 @@ export function ThreadBubble({
           </span>
           {!isInbound && (
             <MessageStatusChip
+              className="shrink-0 whitespace-nowrap"
               direction="outbound"
               delivery_status={message.status}
               review_status={message.review_status}

--- a/web/src/app/components/messages/ThreadBubble.tsx
+++ b/web/src/app/components/messages/ThreadBubble.tsx
@@ -9,8 +9,8 @@
 
 import { useState } from "react";
 import useSWR from "swr";
-import { Chip, Dot } from "@e2a/ui";
 import { CounterpartyAvatar } from "./CounterpartyAvatar";
+import { MessageStatusChip } from "./MessageStatusChip";
 import { EmailHtmlBody } from "./EmailHtmlBody";
 import { AttachmentChips, downloadableAttachments } from "./AttachmentChips";
 import { getMessageDetail, deleteMessage } from "../onboarding/api";
@@ -199,10 +199,12 @@ export function ThreadBubble({
           >
             {senderEmail}
           </span>
-          {pending && (
-            <Chip tone="warn">
-              <Dot tone="warn" /> Pending
-            </Chip>
+          {!isInbound && (
+            <MessageStatusChip
+              direction="outbound"
+              delivery_status={message.status}
+              review_status={message.review_status}
+            />
           )}
           <span className="flex-1" />
           <span

--- a/web/src/app/components/messages/ThreadRow.test.tsx
+++ b/web/src/app/components/messages/ThreadRow.test.tsx
@@ -47,7 +47,7 @@ describe("ThreadRow delivery status", () => {
   it("renders Queued when the latest outbound message was accepted", () => {
     renderRow(thread([message("msg_1", "outbound", "accepted")]));
 
-    expect(screen.getByText("Queued")).toBeInTheDocument();
+    expect(screen.getByText("Queued")).toHaveClass("shrink-0", "whitespace-nowrap");
   });
 
   it("omits Delivered for a settled latest outbound message", () => {
@@ -79,5 +79,11 @@ describe("ThreadRow delivery status", () => {
     );
 
     expect(screen.getByText("Pending")).toBeInTheDocument();
+  });
+
+  it("renders safely when a thread has no messages", () => {
+    const value = thread([message("msg_7", "inbound", "")]);
+
+    expect(() => renderRow({ ...value, messages: [] })).not.toThrow();
   });
 });

--- a/web/src/app/components/messages/ThreadRow.test.tsx
+++ b/web/src/app/components/messages/ThreadRow.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import { ThreadRow } from "./ThreadRow";
+import type { MessageSummary } from "../types";
+import type { Thread } from "./threading";
+
+function message(
+  id: string,
+  direction: MessageSummary["direction"],
+  status: string,
+  review_status?: string,
+): MessageSummary {
+  return {
+    id,
+    direction,
+    from: direction === "inbound" ? "james@x.com" : "support@acme.dev",
+    to: [direction === "inbound" ? "support@acme.dev" : "james@x.com"],
+    recipient: direction === "inbound" ? "support@acme.dev" : "james@x.com",
+    subject: "Status update",
+    status,
+    review_status,
+    created_at: `2026-07-19T10:0${id.slice(-1)}:00.000Z`,
+  };
+}
+
+function thread(messages: MessageSummary[], state: Thread["state"] = "active"): Thread {
+  const latest = messages[messages.length - 1];
+  return {
+    key: "conv:status-test",
+    conversationId: "status-test",
+    counterparty: { email: "james@x.com", name: "James" },
+    subject: "Status update",
+    state,
+    lastMessageAt: latest.created_at,
+    startedAt: messages[0].created_at,
+    msgCount: messages.length,
+    lastDirection: latest.direction,
+    lastPreview: latest.subject,
+    messages,
+  };
+}
+
+function renderRow(value: Thread) {
+  render(<ThreadRow thread={value} active={false} onSelect={jest.fn()} />);
+}
+
+describe("ThreadRow delivery status", () => {
+  it("renders Queued when the latest outbound message was accepted", () => {
+    renderRow(thread([message("msg_1", "outbound", "accepted")]));
+
+    expect(screen.getByText("Queued")).toBeInTheDocument();
+  });
+
+  it("omits Delivered for a settled latest outbound message", () => {
+    renderRow(thread([message("msg_2", "outbound", "delivered")]));
+
+    expect(screen.queryByText("Delivered")).not.toBeInTheDocument();
+  });
+
+  it("does not surface a historical failure after a newer inbound message", () => {
+    renderRow(
+      thread([
+        message("msg_3", "outbound", "failed"),
+        message("msg_4", "inbound", ""),
+      ]),
+    );
+
+    expect(screen.queryByText("Failed")).not.toBeInTheDocument();
+  });
+
+  it("preserves Pending when an older held message exists and the latest is inbound", () => {
+    renderRow(
+      thread(
+        [
+          message("msg_5", "outbound", "", "pending_review"),
+          message("msg_6", "inbound", ""),
+        ],
+        "pending",
+      ),
+    );
+
+    expect(screen.getByText("Pending")).toBeInTheDocument();
+  });
+});

--- a/web/src/app/components/messages/ThreadRow.tsx
+++ b/web/src/app/components/messages/ThreadRow.tsx
@@ -28,7 +28,7 @@ export function ThreadRow({
   const pending = thread.state === "pending";
   const latest = thread.messages[thread.messages.length - 1];
   const latestStatus =
-    latest.direction === "outbound"
+    latest?.direction === "outbound"
       ? deriveStatusChip({
           direction: "outbound",
           delivery_status: latest.status,
@@ -111,6 +111,7 @@ export function ThreadRow({
       {/* Right meta: attention status + timestamp. */}
       {latestStatus?.attention && (
         <MessageStatusChip
+          className="shrink-0 whitespace-nowrap"
           direction="outbound"
           delivery_status={latest.status}
           review_status={latest.review_status}

--- a/web/src/app/components/messages/ThreadRow.tsx
+++ b/web/src/app/components/messages/ThreadRow.tsx
@@ -6,6 +6,7 @@
 
 import { useState } from "react";
 import { CounterpartyAvatar } from "./CounterpartyAvatar";
+import { MessageStatusChip, deriveStatusChip } from "./MessageStatusChip";
 import { formatRelativeAge } from "../../../lib/relativeTime";
 import type { Thread } from "./threading";
 
@@ -25,6 +26,15 @@ export function ThreadRow({
     (m) => m.direction === "inbound" && m.read_status === "unread",
   );
   const pending = thread.state === "pending";
+  const latest = thread.messages[thread.messages.length - 1];
+  const latestStatus =
+    latest.direction === "outbound"
+      ? deriveStatusChip({
+          direction: "outbound",
+          delivery_status: latest.status,
+          review_status: latest.review_status,
+        })
+      : null;
   const fw = unread ? 600 : 400;
   // Hover highlight via state, not a `hover:bg-*` class: the inline
   // `background` below (active/unread tinting) would otherwise win over a
@@ -98,8 +108,15 @@ export function ThreadRow({
         )}
       </span>
 
-      {/* Right meta: pending pill (needs attention) + timestamp. */}
-      {pending && (
+      {/* Right meta: attention status + timestamp. */}
+      {latestStatus?.attention && (
+        <MessageStatusChip
+          direction="outbound"
+          delivery_status={latest.status}
+          review_status={latest.review_status}
+        />
+      )}
+      {pending && !latestStatus?.attention && (
         <span
           className="shrink-0"
           style={{

--- a/web/src/app/components/swr/PendingPollingOwner.test.tsx
+++ b/web/src/app/components/swr/PendingPollingOwner.test.tsx
@@ -1,0 +1,24 @@
+import useSWR from "swr";
+import { pendingPolling } from "../../../lib/livePolling";
+import { pendingMessagesKey } from "../../../lib/swrKeys";
+import { listPendingMessages } from "../onboarding/api";
+import { PendingPollingOwner } from "./PendingPollingOwner";
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ data: undefined, error: undefined })),
+}));
+
+jest.mock("../onboarding/api", () => ({
+  listPendingMessages: jest.fn(),
+}));
+
+it("owns the shared pending-list polling interval", () => {
+  expect(PendingPollingOwner()).toBeNull();
+
+  expect(useSWR).toHaveBeenCalledWith(
+    pendingMessagesKey,
+    listPendingMessages,
+    pendingPolling,
+  );
+});

--- a/web/src/app/components/swr/PendingPollingOwner.tsx
+++ b/web/src/app/components/swr/PendingPollingOwner.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import useSWR from "swr";
+import { pendingPolling } from "../../../lib/livePolling";
+import { pendingMessagesKey } from "../../../lib/swrKeys";
+import { listPendingMessages } from "../onboarding/api";
+
+export function PendingPollingOwner() {
+  useSWR(pendingMessagesKey, listPendingMessages, pendingPolling);
+  return null;
+}

--- a/web/src/app/components/types.ts
+++ b/web/src/app/components/types.ts
@@ -141,8 +141,9 @@ export type MessageSummary = {
   recipient: string;
   subject: string;
   conversation_id?: string;
-  // Delivery rollup (from v1 delivery_status): queued | sent | delivered
-  // | bounced | complained | deferred | failed. Empty on a held draft.
+  // Delivery rollup (from v1 delivery_status): accepted | sending | sent |
+  // delivered | deferred | bounced | complained | failed. The UI labels
+  // accepted as "Queued". Empty on a held draft.
   status: string;
   // Review lifecycle (from v1 review_status): pending_review | sent |
   // review_rejected | review_expired_approved | review_expired_rejected.

--- a/web/src/lib/livePolling.test.ts
+++ b/web/src/lib/livePolling.test.ts
@@ -1,0 +1,27 @@
+import { inboxPolling, pendingPolling, unreadPolling } from './livePolling';
+
+describe('live polling configuration', () => {
+  it('polls inbox data every 10 seconds only while visible and online', () => {
+    expect(inboxPolling).toEqual({
+      refreshInterval: 10000,
+      refreshWhenHidden: false,
+      refreshWhenOffline: false,
+    });
+  });
+
+  it('uses the inbox polling contract for pending data', () => {
+    expect(pendingPolling).toEqual({
+      refreshInterval: 10000,
+      refreshWhenHidden: false,
+      refreshWhenOffline: false,
+    });
+  });
+
+  it('polls unread data every 15 seconds only while visible and online', () => {
+    expect(unreadPolling).toEqual({
+      refreshInterval: 15000,
+      refreshWhenHidden: false,
+      refreshWhenOffline: false,
+    });
+  });
+});

--- a/web/src/lib/livePolling.ts
+++ b/web/src/lib/livePolling.ts
@@ -1,0 +1,13 @@
+export const inboxPolling = {
+  refreshInterval: 10000,
+  refreshWhenHidden: false,
+  refreshWhenOffline: false,
+} as const;
+
+export const pendingPolling = inboxPolling;
+
+export const unreadPolling = {
+  refreshInterval: 15000,
+  refreshWhenHidden: false,
+  refreshWhenOffline: false,
+} as const;


### PR DESCRIPTION
## Summary

- add visibility-aware lightweight polling for the active inbox, pending-review counts, and mounted unread badges
- show attention-aware outbound delivery states in thread rows and complete lifecycle status in conversation details
- retain cached inbox and badge data during transient refresh failures
- isolate pagination state when switching between agent inboxes

## Why

The dashboard previously refreshed mainly on focus or reconnect, so new inbound messages, pending reviews, unread counts, and outbound delivery changes could remain stale until a manual refresh. This provides a Gmail-like live experience without introducing WebSocket or API changes.

## User impact

- active inboxes refresh every 10 seconds while visible and online
- pending-review counts refresh every 10 seconds from a single layout-owned polling source
- mounted unread badges refresh every 15 seconds
- compact rows highlight queued, sending, delayed, failed, bounced, and complaint states
- open conversations also show settled sent and delivered states
- review states continue to take precedence over delivery states

## Validation

- `cd web && npm test -- --runInBand` — 47 suites, 379 tests passed
- `cd web && npm run lint` — 0 errors; 1 pre-existing exhaustive-deps warning
- `cd web && npm run build` — production build, typecheck, and 36-page static export passed
- `git diff --check` — passed

## API impact

No backend, API, schema, OpenAPI, or SDK changes.
