### PR TITLE
test(e2e-prod): cover agent suppression endpoints (coverage gate)

### DIFF
--- a/tests/e2e-prod/suites/24-agent-suppressions.test.ts
+++ b/tests/e2e-prod/suites/24-agent-suppressions.test.ts
@@ -1,0 +1,227 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { ApiClient } from "../harness/client.ts";
+import { uniqueSlug } from "../harness/fixtures.ts";
+import { track, cleanup } from "../harness/cleanup.ts";
+import { writeReport } from "../harness/report.ts";
+
+// Black-box conformance for the agent-scoped suppression surface (beta):
+// createAgentSuppression, listAgentSuppressions, deleteAgentSuppression.
+// Unlike ACCOUNT suppressions (which only a real SES bounce/complaint can
+// create, hence deleteSuppression's coverage-gate allowlist entry), the
+// agent-scoped list has a manual-create API — so the full lifecycle IS
+// black-box testable: create → list shows it → delete → list no longer
+// shows it. Everything runs against fresh throwaway agents on the shared
+// domain; no dependency on shared-account state.
+const SUITE = "24-agent-suppressions";
+const client = new ApiClient();
+
+interface AgentSuppressionView {
+  agent_email: string;
+  address: string;
+  source: string;
+  created_at: string;
+  reason?: string;
+}
+interface PageAgentSuppressionView {
+  items: AgentSuppressionView[];
+  next_cursor: string | null;
+}
+interface DeleteSuppressionResult {
+  deleted: boolean;
+  address: string;
+}
+interface ErrorEnvelope {
+  error?: { code?: string; message?: string; request_id?: string };
+}
+
+async function freshAgent(label: string): Promise<string> {
+  const email = `${uniqueSlug(label)}@${client.env.sharedDomain}`;
+  await client.post(`/v1/agents`, { body: { email, name: `suppr ${label}` }, expect: 201 });
+  track("agent", email);
+  return email;
+}
+
+function suppressionsPath(agent: string, address?: string): string {
+  const base = `/v1/agents/${encodeURIComponent(agent)}/suppressions`;
+  return address === undefined ? base : `${base}/${encodeURIComponent(address)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Full lifecycle: create → idempotent re-create → list shows it → delete →
+// list no longer shows it. This is the happy-path 2xx coverage for all three
+// operationIds.
+// ---------------------------------------------------------------------------
+test("lifecycle: create → list shows it → delete → gone", async () => {
+  const agent = await freshAgent("suplc");
+  const address = `blocked-${uniqueSlug("rcpt")}@example.com`;
+  const reason = "conformance manual block";
+
+  // createAgentSuppression → 200 AgentSuppressionView.
+  const create = await client.post<AgentSuppressionView>(suppressionsPath(agent), {
+    body: { address, reason },
+    expect: 200,
+  });
+  const sp = create.body!;
+  // AgentSuppressionView required: agent_email, address, source, created_at.
+  assert.equal(sp.agent_email, agent, "view.agent_email echoes the owning agent");
+  assert.equal(sp.address, address, "view.address echoes the suppressed recipient");
+  assert.equal(sp.source, "manual", `API-created block has source=manual, got: ${sp.source}`);
+  assert.ok(sp.created_at, "view.created_at present");
+  assert.equal(sp.reason, reason, "view.reason echoes the request");
+
+  // The spec documents create as idempotent — a byte-identical re-create must
+  // succeed (200 on the same entry), not conflict.
+  const again = await client.post<AgentSuppressionView>(suppressionsPath(agent), {
+    body: { address, reason },
+    expect: 200,
+  });
+  assert.equal(again.body?.address, address, "idempotent re-create returns the same entry");
+
+  // listAgentSuppressions → PageAgentSuppressionView envelope containing it.
+  const list = await client.get<PageAgentSuppressionView>(suppressionsPath(agent), {
+    query: { limit: 100 },
+    expect: 200,
+  });
+  assert.ok(Array.isArray(list.body?.items), "items is an array");
+  assert.ok(
+    list.body!.next_cursor === null || typeof list.body!.next_cursor === "string",
+    "next_cursor is string|null (required by PageAgentSuppressionView)",
+  );
+  const listed = list.body!.items.find((s) => s.address === address);
+  assert.ok(listed, "created suppression appears in the agent's list");
+  assert.equal(listed!.agent_email, agent, "list items are self-describing (agent_email)");
+  assert.equal(listed!.source, "manual", "listed entry keeps source=manual");
+
+  // deleteAgentSuppression (?confirm=DELETE) → DeleteSuppressionResult.
+  const del = await client.delete<DeleteSuppressionResult>(`${suppressionsPath(agent, address)}?confirm=DELETE`, {
+    expect: 200,
+  });
+  assert.equal(del.body?.deleted, true, "deletion object has deleted:true");
+  assert.equal(del.body?.address, address, "deletion object echoes the un-suppressed address");
+
+  // Gone from the list.
+  const afterDel = await client.get<PageAgentSuppressionView>(suppressionsPath(agent), { expect: 200 });
+  assert.ok(
+    !afterDel.body!.items.some((s) => s.address === address),
+    "deleted suppression no longer appears in the list",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Normalization: the lookup key is NormalizeEmail'd (lower-cased), so a
+// mixed-case create stores — and later matches — the canonical form.
+// ---------------------------------------------------------------------------
+test("create normalizes the address (mixed case → canonical lower-case)", async () => {
+  const agent = await freshAgent("supnc");
+  const canonical = `mixed-${uniqueSlug("rcpt")}@example.com`;
+  const mixed = canonical.toUpperCase();
+
+  const create = await client.post<AgentSuppressionView>(suppressionsPath(agent), {
+    body: { address: mixed },
+    expect: 200,
+  });
+  assert.equal(create.body?.address, canonical, "stored address is the normalized (lower-case) form");
+
+  // Deleting by the canonical form removes the mixed-case-created entry.
+  const del = await client.delete<DeleteSuppressionResult>(`${suppressionsPath(agent, canonical)}?confirm=DELETE`, {
+    expect: 200,
+  });
+  assert.equal(del.body?.deleted, true, "delete by canonical form finds the normalized entry");
+});
+
+// ---------------------------------------------------------------------------
+// Validation: a non-email address is rejected up front.
+// ---------------------------------------------------------------------------
+test("create: a syntactically invalid address returns 400 invalid_request", async () => {
+  const agent = await freshAgent("supiv");
+  const r = await client.post<ErrorEnvelope>(suppressionsPath(agent), {
+    body: { address: "not-an-email-address" },
+  });
+  assert.equal(r.status, 400, `invalid address → 400, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  assert.equal(r.body?.error?.code, "invalid_request", "error envelope code=invalid_request");
+});
+
+// ---------------------------------------------------------------------------
+// Anti-enumeration: a missing (or foreign) agent is a uniform 404 not_found
+// on every op of this surface.
+// ---------------------------------------------------------------------------
+test("unknown agent: all three ops return 404 not_found", async () => {
+  const ghost = `${uniqueSlug("supgh")}@${client.env.sharedDomain}`; // never created
+
+  const list = await client.get<ErrorEnvelope>(suppressionsPath(ghost));
+  assert.equal(list.status, 404, `list on unknown agent → 404, got ${list.status}: ${list.raw.slice(0, 200)}`);
+  assert.equal(list.body?.error?.code, "not_found");
+
+  const create = await client.post<ErrorEnvelope>(suppressionsPath(ghost), {
+    body: { address: "someone@example.com" },
+  });
+  assert.equal(create.status, 404, `create on unknown agent → 404, got ${create.status}: ${create.raw.slice(0, 200)}`);
+  assert.equal(create.body?.error?.code, "not_found");
+
+  const del = await client.delete<ErrorEnvelope>(`${suppressionsPath(ghost, "someone@example.com")}?confirm=DELETE`);
+  assert.equal(del.status, 404, `delete on unknown agent → 404, got ${del.status}: ${del.raw.slice(0, 200)}`);
+  assert.equal(del.body?.error?.code, "not_found");
+});
+
+test("delete: unknown address on an owned agent returns 404 not_found", async () => {
+  const agent = await freshAgent("supna");
+  const addr = `never-suppressed-${Date.now()}@example.com`;
+  const r = await client.delete<ErrorEnvelope>(`${suppressionsPath(agent, addr)}?confirm=DELETE`);
+  assert.equal(r.status, 404, `un-suppressing an unknown address → 404, got ${r.status}: ${r.raw.slice(0, 200)}`);
+  assert.equal(r.body?.error?.code, "not_found", "error envelope code=not_found");
+});
+
+// ---------------------------------------------------------------------------
+// Scope: the surface is account-administration — an agent-scoped credential
+// must be rejected with 403 forbidden. Mirrors 19-account's key hygiene: the
+// probe key is minted fresh and only THAT key is ever deleted.
+// ---------------------------------------------------------------------------
+test("scope: an agent-scoped credential is rejected with 403 forbidden", async () => {
+  const agent = await freshAgent("supsc");
+  const minted = await client.post<{ id: string; key: string }>("/v1/account/api-keys", {
+    body: { name: `conf-24-agent-scope-${Date.now()}`, scope: "agent", agent_email: agent },
+    expect: 201,
+  });
+  const agentKey = minted.body!.key;
+  assert.notEqual(agentKey, client.env.apiKey, "probe key is distinct from the auth key");
+  try {
+    const r = await client.get<ErrorEnvelope>(suppressionsPath(agent), { apiKey: agentKey });
+    assert.equal(r.status, 403, `agent-scoped list → 403, got ${r.status}: ${r.raw.slice(0, 200)}`);
+    assert.equal(r.body?.error?.code, "forbidden", "error envelope code=forbidden");
+  } finally {
+    await client.delete(`/v1/account/api-keys/${encodeURIComponent(minted.body!.id)}?confirm=DELETE`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Unauthenticated access — every op must reject with 401. As in 19-account:
+// body/param validation runs BEFORE the auth gate, so the POST sends a
+// well-formed body and the DELETE carries confirm=DELETE to make the 401
+// observable.
+// ---------------------------------------------------------------------------
+test("unauth: every agent-suppression op rejects an unauthenticated caller with 401", async () => {
+  const noAuth = { apiKey: null as null };
+  const agent = `unauth-probe@${client.env.sharedDomain}`;
+
+  const cases: Array<{ label: string; run: () => Promise<{ status: number; raw: string }> }> = [
+    { label: "GET  …/suppressions", run: () => client.get(suppressionsPath(agent), noAuth) },
+    {
+      label: "POST …/suppressions",
+      run: () => client.post(suppressionsPath(agent), { ...noAuth, body: { address: "unauth@example.com" } }),
+    },
+    {
+      label: "DELETE …/suppressions/{address}",
+      run: () => client.delete(`${suppressionsPath(agent, "unauth@example.com")}?confirm=DELETE`, noAuth),
+    },
+  ];
+  for (const c of cases) {
+    const r = await c.run();
+    assert.equal(r.status, 401, `${c.label} unauthenticated → 401, got ${r.status}: ${r.raw.slice(0, 160)}`);
+  }
+});
+
+after(async () => {
+  await cleanup(client);
+  await writeReport(`./reports/${SUITE}.json`);
+});


### PR DESCRIPTION
## Why

The release pipeline's conformance coverage gate failed on main: `api/openapi.yaml` gained three beta operations that no e2e-prod suite exercised —

- `createAgentSuppression` — `POST /v1/agents/{email}/suppressions`
- `listAgentSuppressions` — `GET /v1/agents/{email}/suppressions`
- `deleteAgentSuppression` — `DELETE /v1/agents/{email}/suppressions/{address}`

> GATE: FAIL — the above operation(s) are in the spec but no suite exercises them. (60 ops, 55 covered, 2 allowlisted)

## What

New suite `tests/e2e-prod/suites/24-agent-suppressions.test.ts` (zero-dependency, house style — throwaway agents on the shared domain, `track`/`cleanup`, coverage recorded via the ApiClient 2xx shard mechanism):

- **Lifecycle happy path** (the gate-relevant 2xx coverage of all three operationIds): create → idempotent re-create (spec documents create as idempotent) → list shows it (`PageAgentSuppressionView` envelope, self-describing `agent_email`, `source=manual`) → delete with `?confirm=DELETE` (`DeleteSuppressionResult`) → list no longer shows it.
- **Normalization**: a mixed-case address is stored canonically lower-cased and is deletable by the canonical form.
- **Negatives**, consistent with sibling suites: `400 invalid_request` on a non-email address; uniform `404 not_found` on an unknown agent for all three ops (anti-enumeration) and on an un-suppressed address; `403 forbidden` for an agent-scoped credential (account-administration surface; probe key minted fresh and only that key deleted); `401` for unauthenticated callers on all three ops (well-formed body / `confirm=DELETE` so the auth gate is observable, per the pinned body-before-auth quirk).

Unlike account suppressions (created only by a real SES bounce/complaint, hence `deleteSuppression`'s gate allowlist entry), the agent-scoped surface has a manual create API, so the full lifecycle is black-box testable — no allowlist growth needed.

## Verification

Ran against a locally built server at this ref (isolated Postgres 16, `-bootstrap-email` account key, shared domain `agents.localhost`):

```
✔ lifecycle: create → list shows it → delete → gone
✔ create normalizes the address (mixed case → canonical lower-case)
✔ create: a syntactically invalid address returns 400 invalid_request
✔ unknown agent: all three ops return 404 not_found
✔ delete: unknown address on an owned agent returns 404 not_found
✔ scope: an agent-scoped credential is rejected with 403 forbidden
✔ unauth: every agent-suppression op rejects an unauthenticated caller with 401
ℹ tests 7 / pass 7 / fail 0
```

`python3 coverage_gate.py` over this suite's shard alone: `createAgentSuppression`, `listAgentSuppressions`, and `deleteAgentSuppression` no longer appear in UNCOVERED (the remaining UNCOVERED entries are the other suites' ops, which weren't part of this single-suite run; the full run covers them as before).

`tsc --noEmit` adds no new errors (the 4 `ErrorEnvelope`-in-`{}` errors in 01/02 pre-exist on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)