### PR TITLE
docs: fix docker-up description and self-host port list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,10 @@ make test-integration   # integration tests (needs Postgres on :5433)
 make test-e2e           # discovers every package with //go:build integration tests
 make cover              # coverage profile cover.out across internal/... (needs Postgres)
 make cover-check        # cover + enforce per-package floors in .testcoverage.yml
-make docker-up          # local Postgres (:5433) + Mailpit (SMTP :1025, UI :8025)
+make docker-up          # docker compose up -d: full stack — Postgres (:5433), Mailpit
+                        # (SMTP :1025, UI :8025), dockerized API/SMTP (:8080/:2525),
+                        # dashboard (:3000), MCP (:8765). For host-binary dev use
+                        # `docker compose up -d postgres mailpit` instead (see below).
 make migrate            # manually apply migrations/*.sql to the local DB
 make spec               # regenerate api/openapi.yaml from the live Huma handlers
 make spec-check         # drift gate: committed spec must byte-equal handler output
@@ -132,7 +135,10 @@ npm run build   # Next.js static export
 
 ```bash
 cp config.example.yaml config.yaml
-make docker-up     # Postgres :5433 + Mailpit :1025/:8025
+docker compose up -d postgres mailpit   # Postgres :5433 + Mailpit :1025/:8025 only
+                                         # (plain `make docker-up` also starts the
+                                         # dockerized API on :8080/:2525 — conflicts
+                                         # with `make run` below)
 make run           # API on :8080, SMTP relay on :2525; auto-applies migrations
 ./bin/e2a -config config.yaml -bootstrap-email you@example.com  # create user + API key
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,10 @@ make test-unit          # Go unit tests only (no DB needed)
 make test-integration   # Go integration tests (needs Postgres on :5433)
 make test-e2e           # Go e2e tests (needs Postgres on :5433)
 make cover-check        # run tests with coverage + enforce per-package floors (.testcoverage.yml; needs Postgres)
-make docker-up          # start local Postgres + Mailpit via docker compose
+make docker-up          # docker compose up -d: full local stack (Postgres, Mailpit,
+                        # dockerized API/SMTP, dashboard, MCP). For `make run` below,
+                        # start only `docker compose up -d postgres mailpit` instead —
+                        # the dockerized API/SMTP would otherwise conflict on :8080/:2525
 make migrate            # apply SQL migrations to local DB
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,8 +101,10 @@ git clone https://github.com/<you>/e2a.git
 cd e2a
 cp config.example.yaml config.yaml
 
-# 2. start Postgres (:5433) + Mailpit (:1025 SMTP, :8025 UI)
-make docker-up
+# 2. start Postgres (:5433) + Mailpit (:1025 SMTP, :8025 UI) only
+#    (plain `make docker-up` also starts the dockerized API on :8080/:2525,
+#    which conflicts with the host binary started in step 4)
+docker compose up -d postgres mailpit
 
 # 3. point outbound at Mailpit so HITL approvals + test-email work
 #    Edit config.yaml under `outbound_smtp:`:

--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ make test-unit           # Go unit tests only (no DB)
 make test-integration    # integration tests (needs Postgres)
 make test-e2e            # e2e tests (needs Postgres)
 make cover-check         # tests + per-package coverage floors (needs Postgres)
-make docker-up           # start local Postgres + Mailpit via docker compose
+docker compose up -d postgres mailpit  # local Postgres + Mailpit only
 make migrate             # apply SQL migrations to local DB
 ```
 
@@ -427,11 +427,12 @@ cd e2a
 docker compose up -d
 ```
 
-Postgres comes up first (migrations run automatically), then the API server, then the dashboard. Three host ports:
+Postgres comes up first (migrations run automatically), then the API server, then the dashboard. Four host ports:
 
 - `:8080` — HTTP API
 - `:2525` — SMTP relay
 - `:3000` — Dashboard (Caddy + Next.js, proxies `/api/*` to the API server)
+- `:8765` — Local MCP HTTP endpoint (what `claude mcp add` expects)
 
 Health check:
 


### PR DESCRIPTION
## Summary

`make docker-up` is `docker compose up -d` with no service filter, which brings up all five compose services — Postgres, Mailpit, the dockerized API/SMTP, the dashboard, and MCP. README, AGENTS.md, CONTRIBUTING.md, and CLAUDE.md all described it as starting only "Postgres + Mailpit," and their documented "First run" sequences (`make docker-up` then `make run`) would collide on ports `:8080`/`:2525` between the dockerized API and the host binary if followed literally.

- Corrected the `make docker-up` description everywhere it appears (README, AGENTS.md, CONTRIBUTING.md, CLAUDE.md).
- Pointed the host-binary "First run" flows (CONTRIBUTING.md, AGENTS.md) at `docker compose up -d postgres mailpit` instead, so following the steps doesn't produce a port conflict.
- Added the missing `:8765` MCP port to README's "Self-host (Docker)" port list (it listed three of the compose file's four published ports).

No code or compose changes — docs only.

## Test plan

- [x] Verified `Makefile`'s `docker-up` target and `docker-compose.yaml`'s service/port definitions directly.
- [x] Re-read the edited sections in each file for internal consistency.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UHDpVSrVCw1Mwv1FYS2cBE)_