### PR TITLE
docs(readme): fix stale e2a login description

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ domains/webhooks in the **web dashboard**.
 
 | Command | Description |
 |---------|-------------|
-| `e2a login` | Open a browser login and save your API key + default agent to `~/.e2a/config.json` |
+| `e2a login` | Open a browser login and save an account-scoped API key to `~/.e2a/config.json` (does not set a default agent — use `e2a config set agent_email` or `--agent`) |
 | `e2a whoami` | Show the key identity: user, scope, bound agent, plan |
 | `e2a agents list\|create\|get` | Manage inboxes (requires an account-scoped key) |
 | `e2a keys create\|list\|delete` | Mint, list, and revoke API keys (requires an account-scoped key) |


### PR DESCRIPTION
## Summary

`e2a login` stopped setting a default `agent_email` in #592 (account-scoped keys span every inbox, so there's nothing to infer). `cli/README.md` and `plugins/e2a/skills/tether/SKILL.md` were updated in that PR, but the root `README.md`'s CLI command table still said login saves "your API key + default agent" — no longer true.

Docs only, no code changes.

## Test plan

- [x] Verified against `cli/src/commands/login.ts` (no `agent_email` write) and the already-corrected `cli/README.md` wording.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UHDpVSrVCw1Mwv1FYS2cBE)_