### PR TITLE
docs(cli): document listen's exit-1 behaviors

### DIFF
--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -25,8 +25,8 @@ Set a default with `e2a config set agent_email <email>`; a value set that way is
 preserved across re-login.
 
 `listen` now exits `1` (previously `0`) in two cases that used to look like a
-clean stop: a long-running listen whose stream ends for any reason, including
-a server-side close during a deploy drain; and, under `--once --forward`, a
+clean stop: a long-running listen whose stream ends for any reason, such as a
+peer's normal WebSocket close (code 1000); and, under `--once --forward`, a
 forward POST that fails after the message was already consumed off the
 stream and printed to stdout.
 

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -24,6 +24,12 @@ spans every inbox, so there is no inbox to infer. Commands needing one resolve
 Set a default with `e2a config set agent_email <email>`; a value set that way is
 preserved across re-login.
 
+`listen` now exits `1` (previously `0`) in two cases that used to look like a
+clean stop: a long-running listen whose stream ends for any reason, including
+a server-side close during a deploy drain; and, under `--once --forward`, a
+forward POST that fails after the message was already consumed off the
+stream and printed to stdout.
+
 ## 1.6.0
 
 Current release. Adds the CLI's scripting/harness surface: `whoami`,

--- a/cli/README.md
+++ b/cli/README.md
@@ -175,12 +175,13 @@ auto-reconnecting would steal the socket back from the newer listener and
 loop.
 
 `listen` also participates in the exit-code contract below: a long-running
-listen (no `--once`) exits `1` whenever the stream ends for any reason,
-including a clean server-side close — a supervisor (`systemd
-Restart=on-failure`, a retry loop) should treat that as "restart me," not
-"stopped on purpose." Under `--once`, a forward that never reaches the
-`--forward` endpoint also exits `1` even though the message itself was
-printed to stdout — the message was consumed off the stream, so a silent
+listen (no `--once`) exits `1` whenever the stream actually ends, such as
+after a peer's normal WebSocket close (code 1000). Deploy drains use close code
+1001 and reconnect with backoff, so they do not end the stream. A supervisor
+(`systemd Restart=on-failure`, a retry loop) should treat exit `1` as
+"restart me," not "stopped on purpose." Under `--once`, a forward that never
+reaches the `--forward` endpoint also exits `1` even though the message itself
+was printed to stdout — the message was consumed off the stream, so a silent
 exit `0` would read as a successful hand-off to a harness when it wasn't.
 
 #### OpenAI Responses auto-reply

--- a/cli/README.md
+++ b/cli/README.md
@@ -174,6 +174,15 @@ for the same agent connects (a second `e2a listen`, or an SDK
 auto-reconnecting would steal the socket back from the newer listener and
 loop.
 
+`listen` also participates in the exit-code contract below: a long-running
+listen (no `--once`) exits `1` whenever the stream ends for any reason,
+including a clean server-side close — a supervisor (`systemd
+Restart=on-failure`, a retry loop) should treat that as "restart me," not
+"stopped on purpose." Under `--once`, a forward that never reaches the
+`--forward` endpoint also exits `1` even though the message itself was
+printed to stdout — the message was consumed off the stream, so a silent
+exit `0` would read as a successful hand-off to a harness when it wasn't.
+
 #### OpenAI Responses auto-reply
 
 When the `--forward <url>` path ends in `/v1/responses`, `listen` switches to
@@ -230,9 +239,10 @@ environment-only (`E2A_URL` and `E2A_SHARED_DOMAIN`).
 
 ## Exit codes
 
-`whoami`, `send`, `reply`, and `messages` publish a stable, frozen exit-code
-contract (`cli/src/exit.ts`) so shell harnesses can branch on the process exit
-status instead of parsing JSON. Codes are never renumbered — only added to.
+`whoami`, `send`, `reply`, `messages`, and `listen` publish a stable, frozen
+exit-code contract (`cli/src/exit.ts`) so shell harnesses can branch on the
+process exit status instead of parsing JSON. Codes are never renumbered —
+only added to.
 
 | Code | Meaning |
 |---|---|


### PR DESCRIPTION
## Summary

#592 changed `e2a listen`'s exit-code behavior in two places (`cli/src/commands/listen.ts`):
- A long-running listen (no `--once`) now exits `1` when the stream ends for any reason, including a clean server-side close — previously exited `0`, which a supervisor (`systemd Restart=on-failure`, a shell retry loop) read as "stopped on purpose."
- Under `--once --forward`, a forward POST that fails after the message was already consumed off the stream now exits `1` — previously exited `0`, which a harness read as a successful hand-off.

Neither behavior was documented. `cli/README.md`'s `### e2a listen` section only mentioned exit `5` (listener replaced) and `6` (`--once --until` timeout), and the `## Exit codes` intro sentence listed only `whoami`/`send`/`reply`/`messages` as participating in the contract, omitting `listen`. Added a paragraph documenting both cases, updated the intro sentence, and added a changelog entry to `cli/CHANGELOG.md`'s Unreleased section.

Docs only, no code changes.

## Test plan

- [x] Verified both exit-1 paths directly in `cli/src/commands/listen.ts` (lines ~216, ~224, ~235).


---
_Generated by [Claude Code](https://claude.ai/code/session_01UHDpVSrVCw1Mwv1FYS2cBE)_