### PR TITLE
docs(mcp-examples): scope E2A_MCP_URL and shared-invariants claims to non-ADK examples

### DIFF
--- a/mcp/examples/README.md
+++ b/mcp/examples/README.md
@@ -16,15 +16,16 @@ Each example exercises the same e2a tool surface (50 tools; the visible set depe
 
 Every example connects to `https://api.e2a.dev/mcp` over Streamable HTTP with an
 agent-scoped API key in the `Authorization` header. Set `E2A_MCP_URL` to point
-the Python examples at a self-hosted deployment. No Node toolchain or local
-build is needed.
+the LangChain, CrewAI, and OpenAI Agents SDK examples at a self-hosted
+deployment (the Google ADK example currently hardcodes the hosted URL — see
+[adk/](./adk/)). No Node toolchain or local build is needed.
 
 Bring your own [e2a API key](https://e2a.dev) and an LLM key for whichever framework you're trying.
 
-The Python prompts share three email invariants: reply with
-`reply_to_message` to preserve the wire thread, treat `pending_review` as an
-accepted hold rather than an error, and retry only tool failures whose structured
-error reports `retryable: true`.
+The LangChain, CrewAI, and OpenAI Agents SDK prompts share three email
+invariants: reply with `reply_to_message` to preserve the wire thread, treat
+`pending_review` as an accepted hold rather than an error, and retry only
+tool failures whose structured error reports `retryable: true`.
 
 ## Things to try once a demo is running
 
@@ -35,6 +36,8 @@ error reports `retryable: true`.
 
 ## Pointing at a self-hosted e2a
 
-Set `E2A_MCP_URL=https://your-e2a.example/mcp` for the Python examples. Update
-the URL in the Codex `[mcp_servers.e2a-hosted]` block for the configuration-only
-example.
+Set `E2A_MCP_URL=https://your-e2a.example/mcp` for the LangChain, CrewAI, and
+OpenAI Agents SDK examples. Update the URL in the Codex
+`[mcp_servers.e2a-hosted]` block for the configuration-only example. The
+Google ADK example does not read `E2A_MCP_URL` — edit the hardcoded URL in
+`adk/agent.py` to point it at a self-hosted deployment.

--- a/mcp/examples/adk/README.md
+++ b/mcp/examples/adk/README.md
@@ -2,7 +2,7 @@
 
 Google ADK [`Agent`](https://adk.dev/) powered by Gemini that uses the hosted e2a [MCP server](https://api.e2a.dev/mcp) for the e2a tool surface.
 
-`agent.py` wires `McpToolset` + `StreamableHTTPConnectionParams` to the hosted endpoint at `https://api.e2a.dev/mcp`. This works locally and for ADK agents deployed to [Cloud Run](https://docs.cloud.google.com/run/docs/host-mcp-servers).
+`agent.py` wires `McpToolset` + `StreamableHTTPConnectionParams` to the hosted endpoint at `https://api.e2a.dev/mcp`. This works locally and for ADK agents deployed to [Cloud Run](https://docs.cloud.google.com/run/docs/host-mcp-servers). Unlike the LangChain/CrewAI/OpenAI Agents SDK examples, this URL is hardcoded — there's no `E2A_MCP_URL` override; to point at a self-hosted deployment, edit the `url` passed to `StreamableHTTPConnectionParams` directly.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

`mcp/examples/README.md` claimed every Python example supports an `E2A_MCP_URL` self-hosting override, and that all the Python prompts share the same three email invariants. Neither is true for the Google ADK example:

- `mcp/examples/adk/agent.py` hardcodes `url="https://api.e2a.dev/mcp"` — no env var read anywhere in the file. `crewai/agent.py`, `langchain/agent.py`, and `openai-agents/agent.py` all read `os.getenv("E2A_MCP_URL", ...)`.
- ADK's instruction string never mentions `pending_review` or `retryable`, unlike the other three.
- The repo's own `mcp/examples/test_framework_examples.py` (`test_all_frameworks_support_self_hosted_mcp_and_email_safety`) deliberately iterates only `("langchain", "crewai", "openai-agents")` — ADK is excluded from that contract test, confirming this isn't an oversight in the example itself, just in the README's wording.

Scoped both claims in `mcp/examples/README.md` to the three frameworks that actually implement them, and added a note to `adk/README.md` pointing out the hardcoded URL and how to change it.

Docs only, no code changes.

## Test plan

- [x] Verified via `adk/agent.py`, `crewai/agent.py`, `langchain/agent.py`, `openai-agents/agent.py`, and `test_framework_examples.py`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UHDpVSrVCw1Mwv1FYS2cBE)_