### PR TITLE
docs(design-system): fix nonexistent .prompt.md ref and contradictory node_modules path

### DIFF
--- a/design-system/.design-sync/NOTES.md
+++ b/design-system/.design-sync/NOTES.md
@@ -22,9 +22,14 @@ Durable, human-readable notes for future syncs. Committed.
   ```
   (Re-stage `.ds-sync/` first per storybook §2.4 if it's missing — it's gitignored.)
 - **Shape:** storybook. Reference built into `.design-sync/sb-reference` from `.storybook/`.
-- **Own-source-repo build:** there is no `node_modules/@e2a/ui`, so the converter
-  runs with `--entry ./dist/index.js` (the built barrel) and `--node-modules ./node_modules`.
-  Always `npm run build` before the converter so `dist/` is fresh.
+- **Own-source-repo build (generic case — does not apply in this monorepo):**
+  outside a monorepo layout, where `@e2a/ui` isn't hoisted into a shared
+  `node_modules`, the converter would instead run with
+  `--entry ./dist/index.js` and `--node-modules ./node_modules` (this
+  package's own). **In this repo, use the monorepo command above
+  (`--node-modules ../node_modules`) instead** — React is hoisted to the
+  repo-root `node_modules`, not `design-system/node_modules`. Always
+  `npm run build` before the converter so `dist/` is fresh.
 - **CSS is flattened at build time.** `scripts/flatten-css.mjs` (wired into tsup
   `onSuccess`) inlines `src/tokens.css` into `dist/styles.css` so the shipped
   stylesheet is self-contained (no relative `@import` the converter would drop).

--- a/design-system/.design-sync/conventions.md
+++ b/design-system/.design-sync/conventions.md
@@ -43,9 +43,10 @@ tone), `Eyebrow` (uppercase mono kicker), `ThemeToggle` (controlled — pass
 input; controlled `value`/`onChange`), `Avatar` (initials square, deterministic
 `--av-*` color from `email`/`name`), `Collapsible` (disclosure with `label` +
 `children`), `Card` (the panel surface container — wrap content blocks in it).
-Read each component's `.prompt.md` for props and examples, and its `.d.ts` for
-the exact API. The stylesheet (`styles.css`, which defines all the tokens above)
-is the authority on the visual language — read it before inventing styling.
+Read each component's `.stories.tsx` (under `src/<Component>/`) for usage
+examples, and its `dist/<Component>/<Component>.d.ts` for the exact API. The
+stylesheet (`styles.css`, which defines all the tokens above) is the
+authority on the visual language — read it before inventing styling.
 
 ## Idiomatic example
 


### PR DESCRIPTION
## Summary

Two small issues in the design-sync dev-tooling notes:

- `conventions.md` told readers to read each component's `.prompt.md` for props and examples. No `.prompt.md` file exists anywhere in the repo — confirmed via `find`. The actual sources are each component's `.stories.tsx` (under `src/<Component>/`) and its generated `dist/<Component>/<Component>.d.ts`.
- `NOTES.md` gives the resync converter two different `--node-modules` values (`../node_modules` vs `./node_modules`) with no qualifier distinguishing when each applies — a future engineer following it literally would hit an inconsistency. Clarified the second bullet as generic non-monorepo guidance that doesn't apply to this repo's actual layout, and pointed back at the monorepo command.

Docs only, no code changes.

## Test plan

- [x] Confirmed no `.prompt.md` files exist repo-wide; confirmed `.stories.tsx` exists per component.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UHDpVSrVCw1Mwv1FYS2cBE)_