### PR TITLE
docs(examples): fix path param name in adk-cloud-webhook README

### DIFF
--- a/examples/adk-cloud-webhook/README.md
+++ b/examples/adk-cloud-webhook/README.md
@@ -152,7 +152,7 @@ field on the parsed payload.
   vision model.
 - **HITL.** The agent replies immediately. If you want human approval
   before the reply goes out, enable review holds on the agent's
-  protection config (`PUT /v1/agents/{address}/protection`,
+  protection config (`PUT /v1/agents/{email}/protection`,
   [docs](https://github.com/tokencanopy/e2a/blob/main/README.md)) and the
   `client.messages.reply(...)` call returns `status: "pending_review"`
   with the reply held for review.


### PR DESCRIPTION
## Summary

`examples/adk-cloud-webhook/README.md` referenced `PUT /v1/agents/{address}/protection`. The actual path parameter is `{email}` (`api/openapi.yaml:5281`), and it's `{email}` consistently everywhere else in the repo (root `README.md:200,212`). Functionally harmless — same endpoint — but this was the only place in the repo using `{address}` for it.

Docs only, no code changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UHDpVSrVCw1Mwv1FYS2cBE)_