### PR TITLE
docs(marketplace): update stale MCP tool count (37 -> 50)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
   "plugins": [
     {
       "name": "e2a",
-      "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 37 MCP tools over hosted streamable HTTP with OAuth.",
+      "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 50 MCP tools over hosted streamable HTTP with OAuth.",
       "category": "productivity",
       "source": "./plugins/e2a",
       "homepage": "https://e2a.dev"


### PR DESCRIPTION
## Summary

`.claude-plugin/marketplace.json`'s plugin description said "37 MCP tools," last touched 2026-07-15. `plugins/e2a/.claude-plugin/plugin.json`, `.codex-plugin/plugin.json`, `.cursor-plugin/plugin.json`, and `plugins/e2a/skills/e2a/SKILL.md` all say "50 MCP tools" (last touched 2026-07-18) — matching the actual count of 50 `server.registerTool(` calls across `mcp/src/tools/*.ts` (14 runtime / 36 admin, per `mcp/src/tools/tiers.ts`). The root marketplace manifest was never updated when the tool count grew.

Docs only, no code changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UHDpVSrVCw1Mwv1FYS2cBE)_