### PR TITLE
docs(agentify): fix scaffolding table to list all copied scripts

### DIFF
--- a/plugins/e2a/skills/agentify/SKILL.md
+++ b/plugins/e2a/skills/agentify/SKILL.md
@@ -34,7 +34,7 @@ the install itself goes through the same human gate the framework runs on.
 |---|---|
 | `autonomous-repo.config.yml.tmpl` | `autonomous-repo.config.yml` (the only file the adopter owns) |
 | `runtime-skill/**` | `.claude/skills/autonomous-repo/**` |
-| `scripts/ticket_card.sh` | `scripts/ticket_card.sh` |
+| `scripts/*.sh` (`ticket_card.sh`, `comms_send.sh`, `released_markers.sh`) | `scripts/*.sh` |
 | `workflows/*.yml.tmpl` | `.github/workflows/*.yml` |
 
 ## Deploy procedure


### PR DESCRIPTION
## Summary

`plugins/e2a/skills/agentify/SKILL.md`'s "What gets scaffolded into the target repo" table listed only `scripts/ticket_card.sh` → `scripts/ticket_card.sh`. But `agentify-render.sh:63` (`cp "$TEMPLATES"/scripts/*.sh "$t/scripts/"`, also documented in its own header comment at line 20) copies **all** scripts in `templates/scripts/` — currently `ticket_card.sh`, `comms_send.sh`, and `released_markers.sh`.

This is more than cosmetic: `comms_send.sh` is called out as a load-bearing security control in `references/security-invariants.md:75` ("all sends go through `scripts/comms_send.sh`, which... never sets `cc`/`bcc`/`reply_all`"), and `released_markers.sh` backs the `feedback-released.yml.tmpl` workflow — yet neither is mentioned in the scaffolding table, `security-invariants.md`, or `setup-checklist.md`. A reader of this table alone wouldn't know these two files land in their repo.

Docs only, no code changes.

## Test plan

- [x] Verified against `agentify-render.sh:20,63-64` and `templates/scripts/` contents.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UHDpVSrVCw1Mwv1FYS2cBE)_