### PR TITLE
docs(templates): fix stale flat-variables-only claim

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -29,8 +29,8 @@ a rendered preview with an HTML/text tab switch and light/dark toggle).
 
 ## Syntax
 
-Template syntax is intentionally minimal — **flat variables only**, no loops,
-no conditionals, no partials:
+Template syntax is intentionally minimal — variable interpolation only, no
+loops, no conditionals, no partials:
 
 | Form | Behavior |
 |---|---|
@@ -38,7 +38,9 @@ no conditionals, no partials:
 | `{{{variable}}}` | Raw insertion (HTML part): the value is inserted **without escaping**. For pre-rendered HTML fragments only — see the warning below. |
 
 Missing variables render as **empty strings**. Variable names match
-`[A-Za-z][A-Za-z0-9_]*`-style flat identifiers (e.g. `order_id`, `items_html`).
+`[A-Za-z_][A-Za-z0-9_.]*`-style identifiers (e.g. `order_id`, `items_html`) —
+a dot path (e.g. `{{user.name}}`) resolves into a nested object, matching how
+`template_data`/`template_variables` are passed as nested JSON.
 
 **Reserved-section note:** anything that is not a `{{…}}` / `{{{…}}}` slot is
 literal template text and is emitted verbatim — including `{` and `}`


### PR DESCRIPTION
## Summary

`docs/templates.md` said template syntax is "flat variables only" and gave the identifier grammar as `[A-Za-z][A-Za-z0-9_]*`. The renderer actually supports dot-path variables into nested objects: `internal/emailtemplate/emailtemplate.go`'s `validIdent` allows dots (and a leading underscore), and `resolve()` walks a dot path through nested `map[string]any` data — with dedicated test cases ("dot path", "deep dot path", "dot path through non-map", "dot path missing leaf"). The HTTP layer's own doc comments already describe this (`internal/httpapi/outbound.go:244`, `internal/httpapi/templates.go:602`).

Updated the syntax description and identifier grammar to reflect dot-path support, while keeping the accurate "no loops/conditionals/partials" framing.

Docs only, no code changes.

## Test plan

- [x] Verified against `internal/emailtemplate/emailtemplate.go` (`validIdent`, `resolve()`) and its test file's dot-path cases.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UHDpVSrVCw1Mwv1FYS2cBE)_