### PR TITLE
docs(plugin): bootstrap e2a MCP setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -292,6 +292,7 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: "22"
+      - run: node --test scripts/plugin-agent-guidance.test.mjs
       - run: node scripts/validate-plugin.mjs
 
   mcp:

--- a/docs/superpowers/plans/2026-07-20-e2a-mcp-bootstrap-workflow.md
+++ b/docs/superpowers/plans/2026-07-20-e2a-mcp-bootstrap-workflow.md
@@ -1,0 +1,159 @@
+# e2a MCP Bootstrap Workflow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Teach the e2a skill to detect, configure, authenticate, and verify the hosted e2a MCP connection before operating an inbox.
+
+**Architecture:** Add contract-style assertions to the existing plugin agent-guidance test, then replace the skill's ambiguous first-run prose with one compact state-driven bootstrap workflow. Keep client-specific connection essentials inline while retaining `e2a.md` as the long-form reference.
+
+**Tech Stack:** Markdown Agent Skill, Node.js built-in test runner, repository plugin validator
+
+---
+
+### Task 1: Lock the bootstrap guidance contract
+
+**Files:**
+- Modify: `scripts/plugin-agent-guidance.test.mjs`
+- Test: `scripts/plugin-agent-guidance.test.mjs`
+
+- [x] **Step 1: Add a failing contract test**
+
+Add one test that reads `plugins/e2a/skills/e2a/SKILL.md` and asserts all agreed branches:
+
+```js
+test("the e2a skill bootstraps and verifies an MCP connection", async () => {
+  const source = await readFile("plugins/e2a/skills/e2a/SKILL.md", "utf8");
+  const bootstrap = source.match(
+    /### First run:[\s\S]*?(?=\n### |\n## )/,
+  )?.[0] ?? "";
+
+  assert.match(bootstrap, /available e2a MCP tools/i);
+  assert.match(bootstrap, /e2a MCP [`\"]?whoami/i);
+  assert.match(bootstrap, /not.*(?:Unix|shell).*whoami/i);
+  assert.match(bootstrap, /claude mcp add --transport http --scope user e2a https:\/\/api\.e2a\.dev\/mcp/);
+  assert.match(bootstrap, /codex mcp login e2a/);
+  assert.match(bootstrap, /mcpServers/);
+  assert.match(bootstrap, /Streamable HTTP/i);
+  assert.match(bootstrap, /authentication failure/i);
+  assert.match(bootstrap, /network, timeout, or server/i);
+  assert.match(bootstrap, /list_messages/);
+  assert.match(bootstrap, /resume.*original/i);
+  assert.match(bootstrap, /never ask.*API key/i);
+});
+```
+
+- [x] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+node --test scripts/plugin-agent-guidance.test.mjs
+```
+
+Expected: the new bootstrap test fails because the current first-run section does not contain tool-availability detection, all client branches, or readiness verification.
+
+- [x] **Step 3: Commit the red test separately**
+
+```bash
+git add scripts/plugin-agent-guidance.test.mjs
+git commit -m "test(plugin): define MCP bootstrap guidance"
+```
+
+### Task 2: Implement the bootstrap workflow in the skill
+
+**Files:**
+- Modify: `plugins/e2a/skills/e2a/SKILL.md`
+- Test: `scripts/plugin-agent-guidance.test.mjs`
+
+- [x] **Step 1: Replace the first-run section**
+
+Replace the existing first-run prose with concise guidance that performs these operations in order:
+
+```markdown
+### First run: connect and verify e2a
+
+Before the first e2a operation in a task, inspect the tools available in the
+current client for the e2a MCP tool surface.
+
+1. If e2a tools are available, call the e2a MCP `whoami` tool (often exposed as
+   `mcp__e2a__whoami`). This never means the Unix or shell `whoami` command.
+2. If they are absent, identify the client and give its shortest setup path:
+   - Claude Code: `claude mcp add --transport http --scope user e2a
+     https://api.e2a.dev/mcp`, then `/mcp`.
+   - Codex: configure `[mcp_servers.e2a]` with
+     `url = "https://api.e2a.dev/mcp"`, then `codex mcp login e2a`.
+   - Cursor/Windsurf: configure
+     `{ "mcpServers": { "e2a": { "url": "https://api.e2a.dev/mcp" } } }`.
+   - Other remote-MCP clients: configure the same Streamable HTTP endpoint and
+     complete OAuth 2.1 authorization.
+3. Wait for the user to complete interactive OAuth, check the e2a tools again,
+   and call the e2a MCP `whoami` tool.
+4. Classify authentication failures separately from network, timeout, or server
+   failures; reauthorize only for the former.
+5. Resolve an agent-scoped or account-scoped inbox, verify it with
+   `list_messages`, then resume the user's original task.
+```
+
+The final text must include the exact canonical endpoint and setup commands from
+`plugins/e2a/docs/e2a.md`, must not silently edit client configuration, and must
+never ask for an API key during interactive OAuth setup.
+
+- [x] **Step 2: Update the skill version**
+
+Change both the YAML `version` and the matching HTML version comment from `18`
+to `19` so packaged consumers can identify the behavior revision.
+
+- [x] **Step 3: Run the focused test and verify GREEN**
+
+Run:
+
+```bash
+node --test scripts/plugin-agent-guidance.test.mjs
+```
+
+Expected: all agent-guidance tests pass.
+
+- [x] **Step 4: Commit the implementation**
+
+```bash
+git add plugins/e2a/skills/e2a/SKILL.md
+git commit -m "docs(plugin): add MCP bootstrap workflow"
+```
+
+### Task 3: Validate the plugin package
+
+**Files:**
+- Verify: `plugins/e2a/skills/e2a/SKILL.md`
+- Verify: `scripts/plugin-agent-guidance.test.mjs`
+
+- [x] **Step 1: Run plugin and documentation checks**
+
+Run:
+
+```bash
+node scripts/validate-plugin.mjs
+node scripts/sync-agent-docs.mjs --check
+git diff --check
+```
+
+Expected: every command exits successfully with no drift or whitespace errors.
+
+- [x] **Step 2: Run the complete agent-guidance test set**
+
+Run:
+
+```bash
+node --test scripts/plugin-agent-guidance.test.mjs scripts/sdk-examples-contract.test.mjs scripts/sync-agent-docs.test.mjs
+```
+
+Expected: all tests pass with zero failures.
+
+- [x] **Step 3: Inspect the final scoped diff**
+
+Run:
+
+```bash
+git diff -- scripts/plugin-agent-guidance.test.mjs plugins/e2a/skills/e2a/SKILL.md
+```
+
+Expected: the diff contains only the bootstrap contract test and the approved skill workflow in addition to the already-present HITL-removal edits.

--- a/docs/superpowers/specs/2026-07-20-e2a-mcp-bootstrap-workflow-design.md
+++ b/docs/superpowers/specs/2026-07-20-e2a-mcp-bootstrap-workflow-design.md
@@ -1,0 +1,84 @@
+# e2a MCP bootstrap workflow
+
+## Goal
+
+Make the e2a skill capable of determining whether its MCP server is available,
+helping a user connect it when necessary, verifying authentication, and leaving
+the agent with a usable inbox before it attempts the user's original e2a task.
+
+## Scope
+
+This changes agent guidance and its regression checks. It does not change the
+MCP server, OAuth implementation, plugin manifests, or e2a backend behavior.
+The workflow remains focused on interactive MCP usage and does not introduce
+human-in-the-loop setup guidance.
+
+## Bootstrap workflow
+
+Before the first e2a operation in a task, the agent checks whether e2a MCP tools
+are present. The check is for the e2a tool surface, not a shell executable.
+
+If the tools are present, the agent calls the e2a MCP `whoami` tool (commonly
+exposed as `mcp__e2a__whoami`). It must not invoke the Unix `whoami` command.
+
+If the tools are absent, the agent identifies the current client when possible
+and gives the shortest applicable connection instructions:
+
+- Claude Code: add `https://api.e2a.dev/mcp`, then use `/mcp` to authorize.
+- Codex: configure the same remote MCP URL, then run `codex mcp login e2a`.
+- Cursor or Windsurf: add an `mcpServers.e2a.url` entry for the hosted endpoint
+  and complete the client's OAuth prompt.
+- Other remote-MCP clients: configure the hosted Streamable HTTP endpoint and
+  complete OAuth 2.1 authorization.
+
+The skill includes these essentials inline and points to `https://e2a.dev/e2a.md`
+for alternate clients and deeper troubleshooting. It never asks an interactive
+user to paste an API key when OAuth is available, and it does not silently edit
+the user's client configuration. After the user completes the interactive
+step, the agent retries the MCP availability check and calls e2a `whoami`.
+
+## Failure classification
+
+The workflow distinguishes three cases rather than treating every failure as
+an unconfigured client:
+
+- Missing e2a tools: guide MCP configuration.
+- Authentication failure from e2a `whoami`: guide reauthorization in the
+  current client, then retry once the user completes it.
+- Network, timeout, or server failure: report the operational error and avoid
+  replacing known-good configuration or requesting new credentials.
+
+## Establishing a usable inbox
+
+When e2a `whoami` succeeds:
+
+- An agent-scoped session uses the returned `agent_email`.
+- An account-scoped session calls `list_agents`. If the task already identifies
+  an inbox, the agent selects that inbox; otherwise it asks when multiple
+  choices exist. If none exist, it offers to create a shared-domain address at
+  `agents.e2a.dev`, which requires no DNS setup.
+
+The agent verifies readiness with a harmless inbox read such as
+`list_messages`, passing the selected email for account-scoped sessions. It
+then resumes the user's original e2a request.
+
+## Documentation shape
+
+Replace the current ambiguous first-run paragraph with a compact decision
+workflow. Keep client-specific commands short and retain the canonical setup
+guide as the detailed reference. Tool names must explicitly say “e2a MCP tool”
+where confusion with a shell command is plausible.
+
+## Verification
+
+Repository checks will assert that the skill:
+
+- checks tool availability before calling e2a `whoami`;
+- identifies `whoami` as an MCP tool and rejects the shell-command reading;
+- contains setup branches for Claude Code, Codex, Cursor/Windsurf, and generic
+  remote-MCP clients;
+- distinguishes missing tools, authentication failures, and operational
+  failures;
+- verifies a selected inbox and resumes the original task;
+- does not recommend API keys for interactive OAuth setup; and
+- retains valid YAML frontmatter and passes the plugin validator.

--- a/plugins/e2a/.claude-plugin/plugin.json
+++ b/plugins/e2a/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "e2a",
   "displayName": "e2a",
   "version": "0.5.0",
-  "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 50 MCP tools over hosted streamable HTTP with OAuth.",
+  "description": "Authenticated email gateway for AI agents — per-agent inboxes, SPF/DKIM verification, and a queryable, replayable event log. 50 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "TokenCanopy",
     "url": "https://e2a.dev"
@@ -14,7 +14,6 @@
     "email",
     "smtp",
     "agents",
-    "hitl",
     "spf",
     "dkim",
     "inbox",

--- a/plugins/e2a/.codex-plugin/plugin.json
+++ b/plugins/e2a/.codex-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "e2a",
   "displayName": "e2a",
   "version": "0.5.0",
-  "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 50 MCP tools over hosted streamable HTTP with OAuth.",
+  "description": "Authenticated email gateway for AI agents — per-agent inboxes, SPF/DKIM verification, and a queryable, replayable event log. 50 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "TokenCanopy"
   },
@@ -13,7 +13,6 @@
     "email",
     "smtp",
     "agents",
-    "hitl",
     "spf",
     "dkim",
     "inbox",
@@ -25,7 +24,7 @@
   "interface": {
     "displayName": "e2a",
     "shortDescription": "Authenticated email for AI agents",
-    "longDescription": "Bundles the hosted e2a MCP server and an operate-well skill so an agent can send and receive real email from per-agent inboxes — with SPF/DKIM verification, human-in-the-loop review holds, custom domains, attachments, and a replayable event log.",
+    "longDescription": "Bundles the hosted e2a MCP server and an operate-well skill so an agent can send and receive real email from per-agent inboxes — with SPF/DKIM verification, custom domains, attachments, and a replayable event log.",
     "developerName": "TokenCanopy",
     "category": "Productivity",
     "websiteURL": "https://e2a.dev",

--- a/plugins/e2a/.cursor-plugin/plugin.json
+++ b/plugins/e2a/.cursor-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "e2a",
   "displayName": "e2a",
   "version": "0.5.0",
-  "description": "Authenticated email gateway for AI agents — per-agent inboxes, HITL approval, SPF/DKIM verification, and a queryable, replayable event log. 50 MCP tools over hosted streamable HTTP with OAuth.",
+  "description": "Authenticated email gateway for AI agents — per-agent inboxes, SPF/DKIM verification, and a queryable, replayable event log. 50 MCP tools over hosted streamable HTTP with OAuth.",
   "author": {
     "name": "TokenCanopy",
     "url": "https://e2a.dev"
@@ -12,7 +12,6 @@
     "email",
     "smtp",
     "agents",
-    "hitl",
     "spf",
     "dkim",
     "inbox",

--- a/plugins/e2a/README.md
+++ b/plugins/e2a/README.md
@@ -3,8 +3,8 @@
 Gives an AI coding agent a real, authenticated email inbox. Installing this
 plugin registers the hosted **e2a MCP server** (`https://api.e2a.dev/mcp`,
 Streamable HTTP + OAuth 2.1) and an **operate-well skill** so the agent can send
-and receive email, reply in-thread, hold outbound mail for human review (HITL),
-manage agents and custom domains, and work with attachments.
+and receive email, reply in-thread, manage agents and custom domains, and work
+with attachments.
 
 After installation, authorize e2a through your client's MCP flow (Claude Code:
 run `/mcp`; Codex CLI: `codex mcp login e2a`) — no API key to paste. For

--- a/plugins/e2a/docs/auth.md
+++ b/plugins/e2a/docs/auth.md
@@ -17,8 +17,8 @@ e2a also implements the first pieces of the WorkOS [auth.md](https://github.com/
 
 Before you do anything credential-shaped, check whether the user has already wired e2a into your environment. Most of the time they have, and you should not be handling credentials (API keys or OAuth tokens) yourself.
 
-1. **e2a MCP server** — if you are an MCP client (Claude, Cursor, Codex, ChatGPT, etc.), e2a's MCP server is hosted: point your MCP client at the Streamable HTTP endpoint `https://api.e2a.dev/mcp` (OAuth 2.1 — no key pasted) to get inbox, send, reply, agents, domains, and HITL approval as tools. Repository: `https://github.com/tokencanopy/e2a/tree/main/mcp`.
-2. **e2a agent skill** — a guidance document covering inbox patterns, idempotency, HITL approval, attachment handling, and webhook verification. Load it before calling the API directly so you don't relearn the gotchas on the user's dime.
+1. **e2a MCP server** — if you are an MCP client (Claude, Cursor, Codex, ChatGPT, etc.), e2a's MCP server is hosted: point your MCP client at the Streamable HTTP endpoint `https://api.e2a.dev/mcp` (OAuth 2.1 — no key pasted) to get inbox, send, reply, agents, and domains as tools. Repository: `https://github.com/tokencanopy/e2a/tree/main/mcp`.
+2. **e2a agent skill** — a guidance document covering inbox patterns, idempotency, attachment handling, and webhook verification. Load it before calling the API directly so you don't relearn the gotchas on the user's dime.
 3. **e2a CLI** — if you are running shell commands, prefer `e2a` over hand-rolled `curl`. It handles auth resolution, retries, and non-interactive flags. Install: `npm i -g @e2a/cli`. Repository: `https://github.com/tokencanopy/e2a/tree/main/cli`.
 
 If any of these is already configured, use it and stop. Do not ask the user for an API key you do not need.
@@ -96,11 +96,13 @@ HTML alternative is optional. A template send uses `template_id` or
 
 Read the credential from the environment at the moment of the call. Do not copy it into variables you log, do not echo it back to the user, do not include it in commit messages, PR descriptions, error reports, or screenshots. If you are running a shell command, never interpolate the credential inline — reference the environment variable so it does not appear in command history.
 
-Set an `Idempotency-Key` (UUIDv4 recommended) per logical operation on side-effectful calls (sends, replies, HITL approve). Reuse the **same** key on transport retries (network failures, timeouts) — the server replays the original response. Same key with a different body returns `422`; a genuinely new operation needs a fresh key.
+Set an `Idempotency-Key` (UUIDv4 recommended) per logical operation on side-effectful calls such as sends and replies. Reuse the **same** key on transport retries (network failures, timeouts) — the server replays the original response. Same key with a different body returns `422`; a genuinely new operation needs a fresh key.
 
-### HITL: handling 202 pending_review
+### Handling `pending_review`
 
-If the agent's protection config holds outbound mail for review, a send (and `reply`/`forward`) will return **`202 Accepted`** with `status: "pending_review"` instead of dispatching the message:
+If a send, reply, or forward returns **`202 Accepted`** with
+`status: "pending_review"`, the server accepted the message but did not dispatch
+it:
 
 ```json
 {
@@ -110,7 +112,8 @@ If the agent's protection config holds outbound mail for review, a send (and `re
 }
 ```
 
-The message is held until a human approves it via the dashboard, CLI, or magic link, or until `approval_expires_at` fires the configured expiration action. Do not retry the send — that would queue a duplicate. To learn the outcome, poll `GET /v1/agents/{address}/messages/{id}`: an approved outbound send becomes `sent`; a rejection becomes `review_rejected`; on TTL expiry it becomes `review_expired_approved` (auto-sent) or `review_expired_rejected` (discarded), per the hold's `on_expiry` action. Or surface the situation to the calling user and stop.
+Do not retry the send — another call can queue a duplicate. Surface the status,
+`message_id`, and `approval_expires_at` to the calling user, then stop.
 
 ### Errors
 

--- a/plugins/e2a/docs/e2a.md
+++ b/plugins/e2a/docs/e2a.md
@@ -2,8 +2,8 @@
 
 You are an AI agent — or the human wiring one up. e2a gives an agent its own
 **real email inbox**: a verified address it can send from, receive to, reply on,
-and (optionally) have its outbound mail held for human approval. This file tells
-you how to connect and what you can do. Read it once, then drive the tools.
+and use for multi-turn conversations. This file tells you how to connect and
+what you can do. Read it once, then drive the tools.
 
 The mental model flips the usual one. Pretraining assumes "a human reading their
 inbox." With e2a, **you are the agent and the inbox is yours** —
@@ -84,14 +84,11 @@ different tool — e2a is the agent's *own* address.
 Over MCP the tools appear as `mcp__e2a__*`. Always call `tools/list` for exact,
 current signatures and treat that as the source of truth. The surface, by area:
 
-- **Inboxes (agents)** — create / list / get / delete an addressable inbox;
-  configure its protection (screening + HITL) posture.
+- **Inboxes (agents)** — create / list / get / delete an addressable inbox and
+  inspect its configuration.
 - **Messages** — `send_message`, `reply_to_message` (keeps the thread),
   `forward_message`, list + read inbound and outbound, fetch attachments via
   short-lived download URLs.
-- **Human-in-the-loop** — held outbound drafts and screened inbound sit in
-  **review**; a human (or you, with an account-scoped credential) approves or
-  rejects them. Inbound holds release to the inbox on approval.
 - **Domains** — register a custom domain, read its required DNS records, verify
   ownership + sending identity.
 - **Webhooks & events** — subscribe to `email.received` and friends; the durable
@@ -108,9 +105,8 @@ current signatures and treat that as the source of truth. The surface, by area:
   `reply_to_message` sets. So a fresh `send` (even with the same
   `conversation_id`, or a changed subject) stays in the same e2a conversation but
   shows up as a separate thread in the user's inbox.
-- **HITL.** A send may come back `pending_review` instead of `sent`. That's the
-  human-approval gate, not an error; it resolves when a human approves/rejects
-  (or the review TTL expires).
+- **Non-terminal send status.** If a send returns `pending_review`, it was
+  accepted but not dispatched. Report the status and message ID; do not retry.
 - **Verification.** Inbound mail carries SPF/DKIM/DMARC results. Only a DMARC
   pass authenticates domain-authorized use of the RFC 5322 From domain; it does
   not authenticate the mailbox local part, a person, or the display name.
@@ -128,23 +124,17 @@ current signatures and treat that as the source of truth. The surface, by area:
 4. `reply_to_message(message_id, …)` — same thread; the recipient sees a normal
    reply.
 
-**Send for approval:** call `send_message`; if it returns `pending_review`, a
-human approves it in the dashboard (or you do, with an account-scoped
-credential). Don't retry — it's held, not failed.
-
 ## Constraints
 
 - Sending from a **custom domain** needs its sending identity verified in DNS;
   the shared `agents.e2a.dev` address works immediately.
-- Held messages carry a review **TTL** (default 7 days) after which they
-  auto-resolve.
 - Attachments are fetched via short-lived signed URLs by default; callers may
   request small attachments inline.
 
 ## Anti-patterns
 
-- ❌ Treating `pending_review` as a failure and retrying the send → you'll
-  double-queue. Wait for the human decision.
+- ❌ Retrying a `pending_review` send → the server already accepted it, so a new
+  call can create a duplicate. Report the status and stop.
 - ❌ Starting a new `send_message` to answer an inbound → breaks threading. Use
   `reply_to_message`.
 - ❌ Trusting `header_from` without checking alignment → require
@@ -155,8 +145,8 @@ credential). Don't retry — it's held, not failed.
 ## About & pricing
 
 e2a is an authenticated email gateway for AI agents: SMTP relay with SPF/DKIM
-verification, per-agent inboxes, HITL approval, WebSocket + webhook delivery, a
-CLI, and TypeScript/Python SDKs. The core is open source:
+verification, per-agent inboxes, WebSocket + webhook delivery, a CLI, and
+TypeScript/Python SDKs. The core is open source:
 https://github.com/tokencanopy/e2a.
 
 The full agent skill — mental model, gotchas, and worked examples — ships as the

--- a/plugins/e2a/docs/llms.txt
+++ b/plugins/e2a/docs/llms.txt
@@ -2,7 +2,7 @@
 
 > e2a is an authenticated email gateway for AI agents: it gives an agent its own
 > verified email inbox to send, receive, reply, and forward, with SPF/DKIM
-> verification and optional human-in-the-loop approval of outbound mail. Connect
+> verification. Connect
 > over a hosted MCP server (OAuth, no API key), the REST API, or the SDKs.
 
 ## Start here
@@ -15,7 +15,7 @@
 
 ## API & SDKs
 
-- [sdk.md](https://e2a.dev/sdk.md): TypeScript (`@e2a/sdk`) and Python (`e2a`) quick-start with code examples — send, receive (webhook → fetch → reply), HITL, real-time streaming — plus a Raw-REST section (base URL, auth, conventions) for other languages.
+- [sdk.md](https://e2a.dev/sdk.md): TypeScript (`@e2a/sdk`) and Python (`e2a`) quick-start with code examples — send, receive (webhook → fetch → reply), and real-time streaming — plus a Raw-REST section (base URL, auth, conventions) for other languages.
 - [openapi.yaml](https://e2a.dev/openapi.yaml): The full OpenAPI 3.1 contract — every endpoint, field, enum, and error, generated from the live handlers. Authoritative for exact signatures.
 - [templates.md](https://e2a.dev/templates.md): Email templates (beta) — server-rendered reusable emails with `{{variable}}` interpolation, a prebuilt starter catalog (`from_starter`), validation, and send-by-alias. Includes a copy-paste setup prompt for coding agents.
 

--- a/plugins/e2a/docs/sdk.md
+++ b/plugins/e2a/docs/sdk.md
@@ -29,8 +29,8 @@ import { E2AClient } from "@e2a/sdk";
 const client = new E2AClient({ apiKey: process.env.E2A_API_KEY });
 const messageId = "msg_..."; // an inbound message id from a webhook, WebSocket, or list call
 
-// Send (held drafts come back status="pending_review", not an error)
-await client.messages.send("bot@agents.e2a.dev", {
+// Send; if status is pending_review, report it and do not retry.
+const result = await client.messages.send("bot@agents.e2a.dev", {
   to: ["person@example.com"],
   subject: "Hello from my agent",
   text: "This was sent by an AI agent via e2a.",
@@ -79,7 +79,7 @@ if (isEmailReceived(event)) {
   const email = await client.inbound.fromEvent(event);
   console.log(email.envelopeFrom, email.verified, email.replyTargets);
   const result = await email.reply({ text: "On it." });
-  if (result.status === "pending_review") console.log("awaiting approval", result.messageId);
+  if (result.status === "pending_review") console.log("not dispatched", result.messageId);
 }
 ```
 
@@ -98,7 +98,7 @@ if event.type == "email.received":
     print(email.envelope_from, email.verified, email.reply_targets)
     result = await email.reply({"text": "On it."})
     if result.status == "pending_review":
-        print("awaiting approval", result.message_id)
+        print("not dispatched", result.message_id)
 ```
 
 `verified` is true only for an aligned DMARC pass in the hydrated authentication
@@ -112,23 +112,6 @@ inline data is available only within the server's 256 KiB cap.
 A full, runnable example (FastAPI + Google ADK agent, webhook → agent turn →
 reply) is at
 [examples/adk-cloud-webhook](https://github.com/tokencanopy/e2a/tree/main/examples/adk-cloud-webhook).
-
-## Human-in-the-loop
-
-Held messages (outbound drafts + screened inbound) are the account-scoped review
-queue. With an account-scoped key:
-
-```ts
-const held = await client.reviews.list().toArray({ limit: 100 });   // both directions
-await client.reviews.approve(id);                      // outbound: send; inbound: release
-await client.reviews.reject(id, { reason: "spam" });
-```
-
-```python
-held = await client.reviews.list().to_list(limit=100)
-await client.reviews.approve(message_id)
-await client.reviews.reject(message_id, {"reason": "spam"})
-```
 
 ## Real-time (no webhook)
 
@@ -166,13 +149,13 @@ Conventions:
   (null when exhausted).
 - **Errors** — non-2xx bodies are `{"error": {"code", "message", "request_id"}}`;
   branch on the machine `code`.
-- **Idempotency** — sends (`send`/`reply`/`forward`/approve) accept an
+- **Idempotency** — sends (`send`/`reply`/`forward`) accept an
   `Idempotency-Key` header; a retried call replays instead of double-sending.
-- **Scopes** — account keys manage agents/domains/keys/reviews; agent keys are
+- **Scopes** — account keys manage agents/domains/keys; agent keys are
   pinned to one inbox.
 
 The endpoint map, exact request/response bodies, enums, and error codes are all
 in the OpenAPI 3.1 contract — generated from the live handlers and checked for
 drift in CI: **https://e2a.dev/openapi.yaml**. The core resources are `agents`
-(inboxes), `messages` (send/reply/forward/get/list/attachments), `reviews`
-(HITL), `domains`, `webhooks`, `events`, and `account`.
+(inboxes), `messages` (send/reply/forward/get/list/attachments), `domains`,
+`webhooks`, `events`, and `account`.

--- a/plugins/e2a/docs/templates.md
+++ b/plugins/e2a/docs/templates.md
@@ -68,9 +68,6 @@ curl -X POST https://api.e2a.dev/v1/agents/billing-bot%40agents.e2a.dev/messages
   }'
 ```
 
-Rendering happens **before** any human-in-the-loop review hold, so reviewers
-see the final subject and body.
-
 > **Wire change.** To make room for the template shape, `subject` and `text`
 > moved from schema-required to handler-enforced on
 > `POST /v1/agents/{email}/messages`. A literal send that omits them now
@@ -93,7 +90,7 @@ copy freely afterwards.
 | `receipt` | Order receipt with a line-item table and hosted-receipt link | `company_name`, `support_email`, `company_address`, `preheader`*, `order_id`, `order_date`, **`items_html`** (raw), `items_text`, `total`, `receipt_url` |
 | `agent-status` | Numbers-first status report from an automated agent | `company_name`, `support_email`, `company_address`, `preheader`*, `agent_name`, `run_summary`, **`sections_html`** (raw), `sections_text`, `dashboard_url` |
 | `daily-digest` | Recurring daily summary with an unsubscribe link | `company_name`, `support_email`, `company_address`, `preheader`*, `agent_name`, `date`, `headline`, **`sections_html`** (raw), `sections_text`, `dashboard_url`, **`unsubscribe_html`** (raw) |
-| `approval-request` | Human-in-the-loop approval request with Approve/Reject buttons and expiry | `company_name`, `support_email`, `company_address`, `preheader`*, `agent_name`, `action_summary`, **`details_html`** (raw), `details_text`, `approve_url`, `reject_url`, `expires_at` |
+| `approval-request` | Human approval request with Approve/Reject buttons and expiry | `company_name`, `support_email`, `company_address`, `preheader`*, `agent_name`, `action_summary`, **`details_html`** (raw), `details_text`, `approve_url`, `reject_url`, `expires_at` |
 
 \* optional; **bold** = raw (`{{{…}}}`) slot. `GET /v1/starter-templates`
 returns the authoritative per-variable metadata (required/raw flags,

--- a/plugins/e2a/skills/e2a/SKILL.md
+++ b/plugins/e2a/skills/e2a/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: e2a
-description: Use when operating e2a (email for AI agents) over its MCP tools — sending or receiving email, replying in-thread, handling the human-in-the-loop review hold (pending_review), managing agents and custom domains, or working with attachments — OR when integrating e2a into your own software/service (the developer email-API use case: API keys, SDKs, webhooks). With e2a YOU are the agent and the inbox IS the agent (not a human reading their mail). Covers send_message vs reply_to_message threading, multi-agent disambiguation, the custom-domain DNS flow, the protection (screening + review) config, programmatic integration, and common gotchas.
-version: 17
+description: "Use when operating e2a (email for AI agents) over its MCP tools — sending or receiving email, replying in-thread, managing agents and custom domains, or working with attachments — OR when integrating e2a into your own software or service with API keys, SDKs, and webhooks. With e2a YOU are the agent and the inbox IS the agent, not a human reading their mail. Covers send_message vs reply_to_message threading, multi-agent disambiguation, the custom-domain DNS flow, programmatic integration, and common gotchas."
+version: 19
 ---
 
 # Using e2a
 
-<!-- version: 17 -->
+<!-- version: 19 -->
 
-e2a is an authenticated email gateway for AI agents. It gives an agent a real email address (`agent@agents.e2a.dev` or `agent@your-domain.com`), verifies sender identity (SPF/DKIM), threads conversations, and optionally holds outbound mail for human review.
+e2a is an authenticated email gateway for AI agents. It gives an agent a real email address (`agent@agents.e2a.dev` or `agent@your-domain.com`), verifies sender identity (SPF/DKIM), and threads conversations.
 
 ## How this fits
 
@@ -23,7 +23,7 @@ The mental model below holds regardless of surface. Tool descriptions teach the 
 
 ## The mental model
 
-Seven load-bearing facts. Internalize these before you start calling tools.
+Six load-bearing facts. Internalize these before you start calling tools.
 
 1. **An agent is an email address.** `support-bot@agents.e2a.dev` is an agent. When you send mail, the recipient sees a message FROM that address — not from "the user." When you list messages, you are reading the agent's own inbox, not the user's personal mail. You are not a secretary; you are the mailbox owner.
 
@@ -31,7 +31,7 @@ Seven load-bearing facts. Internalize these before you start calling tools.
 
    **Two threading systems, and they don't share a key.** e2a threads on `conversation_id` (it's what `list_conversations`/`get_conversation` group by). The recipient's mail client — Gmail, Outlook, Apple Mail — ignores `conversation_id` entirely and threads on the wire headers instead: `In-Reply-To`/`References` plus a **stable `Subject`**. `reply_to_message` sets those headers correctly, so it threads in *both* systems. A `send_message` — even one you tag with the same `conversation_id` — carries no `References` and lets you pick a new subject: e2a still files it in the same conversation, but the user's inbox shows a *separate* thread. This is the trap — the `conversation_id` looks like it threads because e2a's own views stay tidy, while Gmail splits the exchange in two. Within one ongoing exchange: reply, and keep the subject stable.
 
-3. **`pending_review` is success, not failure.** When the agent's protection config holds outbound mail, a send returns `{ status: "pending_review", message_id: "msg_..." }`. The message was accepted by the server and is being held for a human to review. Do NOT retry. Do NOT report this as an error to the user. Tell them the draft was queued for review, and (if asked) check on it via the pending tools.
+3. **`pending_review` is an accepted outcome, not a retry signal.** A send can return `{ status: "pending_review", message_id: "msg_..." }`. The server accepted the message but did not dispatch it. Do not retry: another call can create a duplicate. Report the status and message ID to the user, then stop.
 
 4. **Account-scoped sessions need an explicit inbox.** `whoami` tells you the
 credential scope and returns `agent_email` only for an agent-scoped credential.
@@ -44,20 +44,24 @@ clearly identifies an inbox.
 
 6. **Custom domains are a two-step async dance.** `register_domain` returns DNS records (MX + TXT) to publish — it does NOT make the domain live. The user (or a DNS-provider MCP, if one is loaded) must add those records out-of-band, wait for DNS propagation (minutes to hours), then `verify_domain`. Verification is idempotent and safe to retry. Until verification succeeds, the domain cannot send or receive mail. Don't promise the user their domain works the moment registration returns.
 
-7. **HITL lives in the protection config.** A new agent has no review hold by default. To turn one on, set the agent's protection posture (see below).
-
 ## Common workflows
 
-### First run: onboard a new user before anything else
+### First run: connect and verify e2a
 
-Before driving any e2a task or harness, check whether this is a **new/unconfigured user** and, if so, get them to a working setup instead of failing partway. One cheap probe answers it: call `whoami`.
+Before the first e2a operation in a task, inspect the current client's available e2a MCP tools. This is a tool-registry check, not a shell command.
 
-- **`whoami` errors with auth/connection failure** → not connected over MCP yet. Point the user at connecting the e2a plugin and completing OAuth: open **https://e2a.dev/e2a.md** (the connect guide) and, in Claude Code, run `/mcp` to authenticate. Interactive auth is theirs to complete — hand them the step, don't try to drive it. Once connected, continue.
-- **`whoami` succeeds** → inspect its `scope`. An agent-scoped credential includes
-  its bound `agent_email`. For account scope, call `list_agents`; if it is empty,
-  create the first shared-domain inbox with the full address
-  `name@agents.e2a.dev` (see mental-model fact #5). No custom domain, no DNS.
-The through-line: for a first-time user, **help them stand up a functional e2a setup first** (connect → create a shared-domain inbox), then run the harness — rather than assuming credentials and erroring. Default new inboxes to `agents.e2a.dev`; only involve a custom domain if the user owns one and asks for it.
+1. **Tools available:** call the e2a MCP `whoami` tool (often exposed as `mcp__e2a__whoami`). Never run the Unix or shell `whoami` command.
+2. **Tools absent:** identify the client and guide the user through its shortest setup path. Do not silently edit their configuration.
+   - **Claude Code:** run `claude mcp add --transport http --scope user e2a https://api.e2a.dev/mcp`, then have the user run `/mcp` and authorize in the browser.
+   - **Codex:** add `[mcp_servers.e2a]` with `url = "https://api.e2a.dev/mcp"` to the Codex config, then have the user run `codex mcp login e2a`.
+   - **Cursor / Windsurf:** add `{ "mcpServers": { "e2a": { "url": "https://api.e2a.dev/mcp" } } }` to the client's MCP configuration and complete its OAuth prompt.
+   - **Other remote-MCP clients:** configure the Streamable HTTP endpoint `https://api.e2a.dev/mcp` and complete OAuth 2.1 authorization. See https://e2a.dev/e2a.md for client-specific details.
+
+   These interactive paths use OAuth. Never ask the user to paste an API key.
+3. After the user completes authorization, inspect the tool registry again and call the e2a MCP `whoami` tool.
+4. **Classify failures:** an authentication failure means the user should reauthorize through the current client's MCP flow. A network, timeout, or server failure is operational: report it and preserve known-good configuration and credentials.
+5. **Select the inbox:** for agent scope, use the returned `agent_email`. For account scope, call `list_agents`. Honor an inbox identified by the task; use the sole result when there is one; ask the user to choose when there are several. If there are none, offer to create `name@agents.e2a.dev` after they choose the local part—no custom domain or DNS is required.
+6. Verify readiness with `list_messages`, passing the selected `email` for account scope. This read is harmless and does not mark messages read. Once it succeeds, resume the user's original e2a task.
 
 ### Triage the inbox
 
@@ -67,17 +71,17 @@ The through-line: for a first-time user, **help them stand up a functional e2a s
 
 For attachment bytes, use `get_attachment` with a 0-based index. It returns the attachment's metadata plus a short-lived `download_url`; pass `inline: true` to get base64 `data` inline for small files. Indexes are stable within a message.
 
-### Send a new email (with HITL awareness)
+### Send a new email
 
-1. `send_message` with `to`, `subject`, `body`.
+1. `send_message` with `to`, `subject`, `text`.
 2. Check the response:
    - `status: sent` — done.
    - `status: accepted` — also success, not a maybe. The send was durably persisted and queued for submission (async pipeline). Do NOT re-send. The terminal outcome (delivered or failed) arrives later via webhook events (`email.sent` / `email.failed`) or by polling `get_message`/`list_messages`.
-   - `status: pending_review` — the agent's protection config held it for review; the message is queued. Tell the user it's awaiting review. They can review in the dashboard, via the magic link in their notification email, or with the pending/review tools.
+   - `status: pending_review` — accepted but not dispatched. Do not retry; report the status and `message_id`, then stop.
 
 ### Templates (beta): recurring sends without free-writing
 
-When the same *kind* of email goes out repeatedly — run reports, digests, approval asks — don't compose it fresh each time. A stored template gives every send the same structure: recurring mail stays consistent, and a HITL reviewer can scan held drafts at a glance (they learn the shape once; only the variables change). Reach for one by the third same-shaped send; keep free-writing for one-offs and conversation.
+When the same *kind* of email goes out repeatedly — run reports, digests, approval asks — don't compose it fresh each time. A stored template gives every send the same structure. Reach for one by the third same-shaped send; keep free-writing for one-offs and conversation.
 
 Three starters are agent-native:
 
@@ -90,7 +94,7 @@ Three starters are agent-native:
 The flow is copy once, send many:
 
 1. `create_template` with `{ "from_starter": "agent-status", "alias": "run-report" }` — copies the starter verbatim into the account's library (account scope; once at setup). Customize the copy later with `update_template` if needed.
-2. Send by alias — no literal subject/body (a template reference is mutually exclusive with them); the server renders **before** any review hold, so the reviewer sees final content:
+2. Send by alias — no literal subject/body (a template reference is mutually exclusive with them):
 
 ```json
 { "to": ["owner@acme.com"], "template_alias": "run-report",
@@ -106,31 +110,6 @@ Syntax is a small Mustache-like subset: `{{var}}` (HTML-escaped in the HTML part
 **Approval links must be confirmation pages.** For `approval-request`, `approve_url` / `reject_url` must point to pages that require an explicit human click to act — never state-changing GET endpoints. Email security scanners prefetch every link in a message, so a GET-to-approve URL gets "approved" by a robot before the human ever opens the mail.
 
 Templates are beta: shapes may change before they're declared stable. Only `send_message` takes template references — reply and forward don't.
-
-### Review held messages (account scope)
-
-Holds — outbound drafts and screened inbound — are an **account-owner / human** action, never agent self-approval. With an account-scoped credential you can:
-
-- `list_reviews` / `get_review` — see what's held (runtime scope can view its own review queue).
-- `approve_review` / `reject_review` — release or discard a hold. These are **account/admin scope**; an agent-scoped credential is 403'd (releasing your own held outbound would defeat the review gate).
-
-For outbound, approving *is* sending. For inbound, approving releases the message into the inbox.
-
-### Turn on a review hold for an agent
-
-Posture lives on the protection sub-resource — `update_protection` (MCP) / `PUT /v1/agents/{email}/protection`. The config has three required top-level keys:
-
-```json
-{
-  "inbound":  { "gate": { "policy": "open" }, "scan": { "sensitivity": "off" } },
-  "outbound": { "gate": { "policy": "open", "action": "review" }, "scan": { "sensitivity": "off" } },
-  "holds":    { "ttl_seconds": 604800, "on_expiry": "reject" }
-}
-```
-
-- A direction's `gate.action` is what a non-match does: `flag` (deliver + annotate), `review` (hold), or `block`. Set `outbound.gate.action: "review"` (or turn on a content `scan`) to hold outbound mail for approval.
-- `holds.ttl_seconds` is how long a hold waits; `holds.on_expiry` is `approve` or `reject` when the TTL fires.
-- Read the current posture with `get_protection`. Both are account-scope only. Confirm the exact shape with `tools/list` / the OpenAPI contract — the protection config is beta and may change.
 
 ### Add a custom domain (e.g. `mail.acme.com`)
 
@@ -148,26 +127,26 @@ If the user is building a service that handles inbound mail in their own code, t
 
 ## Integrating e2a into software
 
-Everything above assumes **you** are the agent operating an inbox over MCP. But e2a is also a plain email API any software can build on — the "send and receive email from code" use case, except every address is an authenticated *agent* identity, with optional human-in-the-loop review. When a user asks you to **integrate e2a into their app, service, or agent framework**, you're helping them write code against the REST API with an API key — not driving these MCP tools. Make the pivot explicit:
+Everything above assumes **you** are the agent operating an inbox over MCP. But e2a is also a plain email API any software can build on — the "send and receive email from code" use case, except every address is an authenticated *agent* identity. When a user asks you to **integrate e2a into their app, service, or agent framework**, you're helping them write code against the REST API with an API key — not driving these MCP tools. Make the pivot explicit:
 
 - **MCP** (these tools) — interactive; the agent itself reads/sends mail; auth is OAuth; no integration code. This is you, right now.
 - **SDK / REST API** — programmatic; the user's software sends/receives mail; auth is an **API key**. This is what an integration uses.
 
-The mental model in this skill carries over unchanged: the REST/SDK responses use the same `status`, `message_id`, `pending_review` hold, and reply-threading semantics the MCP tools do — only the transport and auth differ.
+The mental model in this skill carries over unchanged: the REST/SDK responses use the same `status`, `message_id`, and reply-threading semantics the MCP tools do — only the transport and auth differ.
 
 ### Set it up
 
 1. **Issue an API key and choose its scope.** Programmatic access authenticates with a key sent as `Authorization: Bearer e2a_…` (not the OAuth flow MCP uses). Scope is the load-bearing decision:
-   - **account** — workspace admin: provision agents, domains, webhooks, and approve/reject review holds. Use for a backend that manages inboxes or drives the HITL queue.
+   - **account** — workspace admin: provision agents, domains, webhooks, and API keys. Use for a backend that manages inboxes.
    - **agent** — bound to one inbox (`agent` email at creation): send / read / reply for that identity only. Use for a service that *is* a single sender.
 
    The secret is returned **once** at creation — store it in the app's secret manager, never in source. (Keys + scopes: https://e2a.dev/auth.md.) An account-scoped MCP session can mint **agent**-scoped keys directly with `create_api_key`; **account**-scoped keys can only be issued from the dashboard or the raw API.
 
 2. **Have an agent identity to send as.** Mail goes out FROM an agent address — `name@agents.e2a.dev` out of the box, or `name@their-domain.com` after the custom-domain verify dance (see "Add a custom domain" above). Create it once (`create_agent` / `POST /v1/agents`) or reuse an existing one.
 
-3. **Send from code.** `POST /v1/agents/{email}/messages` to send, `…/messages/{id}/reply` to reply in-thread — or the equivalent helper in the TypeScript (`@e2a/sdk`) or Python SDK. A `pending_review` response is an accepted-and-held message, **not** an error, exactly as over MCP — surface it to the user as "queued for review," don't retry.
+3. **Send from code.** `POST /v1/agents/{email}/messages` to send, `…/messages/{id}/reply` to reply in-thread — or the equivalent helper in the TypeScript (`@e2a/sdk`) or Python SDK. If a response has `status: "pending_review"`, surface the status and message ID and do not retry.
 
-4. **Receive from code (optional).** To handle inbound mail or delivery/review *events* in their backend, subscribe a webhook (`create_webhook` / `POST /v1/webhooks`) and verify every POST with the per-webhook `whsec_…` secret — see "Receive mail in your own backend" above. Don't poll the API for new mail.
+4. **Receive from code (optional).** To handle inbound mail or delivery *events* in their backend, subscribe a webhook (`create_webhook` / `POST /v1/webhooks`) and verify every POST with the per-webhook `whsec_…` secret — see "Receive mail in your own backend" above. Don't poll the API for new mail.
 
 The full, current integration code — SDK install, send / reply / parse, webhook handlers with signature verification — lives in the docs, not here. Point the user at:
 
@@ -181,17 +160,14 @@ The full, current integration code — SDK install, send / reply / parse, webhoo
 - **Forwarding attachments is a verbatim copy.** Pass the `{filename, content_type, data}` tuple from `get_attachment` straight into the next send's `attachments[]`. No re-encoding, no re-naming necessary.
 - **`get_message` deliberately omits raw MIME and attachment bytes.** Don't ask for the "full message" — you have what you need (decoded text/html bodies, headers, attachment metadata). Use `get_attachment` for actual bytes when you need them.
 - **Destructive ops require `confirm: true`.** `delete_agent` and `delete_domain` refuse without explicit confirmation. This is a guard against hallucinated deletes; pass it only when the user has clearly asked for the destructive action.
-- **`approve_review` with `attachments: []` strips attachments.** An omitted `attachments` field keeps the original draft's attachments; an explicit empty array removes them. Same shape applies to other override fields — omit to keep, specify (including empty) to override.
-- **Held bodies are scrubbed after the terminal transition.** `get_review` returns the full body only while status is `pending_review`. Once it reaches a terminal state (`sent`, `review_rejected`, `review_expired_approved`, `review_expired_rejected`), body columns are wiped server-side for compliance.
 - **Token expiry on OAuth flows.** The hosted MCP runs over OAuth; if a tool starts erroring with auth failures across multiple calls, the token may have expired or been revoked — re-auth via `/mcp` in Claude Code.
 
 ## When NOT to use a tool
 
 - Don't send a fresh message to respond to something in the inbox — reply (threading).
-- Don't loop on the pending list waiting for an approval — there's no event in MCP; let the user drive when they want to check.
 - Don't verify a custom domain immediately after registering it — DNS has not propagated. If the user wants a verification check, call it once and report the result; don't poll.
 - Don't delete agents or domains from inferred intent. Require the user to say it.
-- Don't enumerate agents on every turn. `whoami` is cheaper for the common single-agent case; `list_agents` is only needed when `whoami` errors with the multi-agent diagnostic.
+- Don't enumerate agents on every turn. Call `whoami` first; use `list_agents` when it reports account scope and the task does not already identify an inbox.
 
 ## Reference
 
@@ -200,5 +176,5 @@ The full, current integration code — SDK install, send / reply / parse, webhoo
 - Webhook + SDK code: https://e2a.dev/sdk.md
 - Exact tool signatures: call `tools/list` (authoritative).
 - OpenAPI contract: https://e2a.dev/openapi.yaml
-- The MCP surface is **50 tools** (14 runtime/inbox + 36 admin/setup) spanning agents, messages, HITL review, attachments, domains, events, webhooks, API keys, and templates (beta). The set you see depends on your credential's scope: an agent-scoped credential sees the 14 runtime tools; an account-scoped credential sees all 50. Tool descriptions teach behavior; this skill teaches the mental model. (`create_api_key` mints **agent-scoped** keys only — account-scoped keys come from the dashboard or raw API.)
+- The MCP surface is **50 tools** (14 runtime/inbox + 36 admin/setup) spanning agents, messages, attachments, domains, events, webhooks, API keys, and templates (beta). The set you see depends on your credential's scope: an agent-scoped credential sees the 14 runtime tools; an account-scoped credential sees all 50. Tool descriptions teach behavior; this skill teaches the mental model. (`create_api_key` mints **agent-scoped** keys only — account-scoped keys come from the dashboard or raw API.)
 - Plugin homepage / docs index: https://e2a.dev (machine-readable index: https://e2a.dev/llms.txt)

--- a/plugins/e2a/skills/tether/SKILL.md
+++ b/plugins/e2a/skills/tether/SKILL.md
@@ -18,8 +18,8 @@ questions or new instructions — are picked up within a few minutes. Reply
 > the `e2a` skill (`${CLAUDE_PLUGIN_ROOT}/skills/e2a/SKILL.md`) — carries the
 > mental model this skill assumes: how threading really works (reply headers +
 > stable subject, **not** `conversation_id`), when a shared `agents.e2a.dev`
-> address is all you need vs. a custom domain, and the `pending_review`/HITL
-> gotcha. Read it if you're new to e2a; tether does not re-explain those.
+> address is all you need vs. a custom domain, and how to handle send statuses.
+> Read it if you're new to e2a; tether does not re-explain those.
 
 ## Architecture (why this shape)
 
@@ -68,12 +68,11 @@ bootstrap:
 
 It verifies the credential (`e2a whoami`), ensures a tether inbox (reusing an
 existing `tether-…` agent or creating one on the shared domain — it will
-**not** silently adopt a non-tether inbox), turns outbound review **off** on
-that inbox, mints a **least-privilege agent-scoped key** (`e2a_agt_…`), and
-writes `~/.e2a-tether.env` (previous file kept as `.bak`). Every step fails
-hard — it never stores the broad account key and never reports "ready" with a
-half-working config. Flags: `--email you@yourdomain` to use/create a specific
-inbox, `--new` to force a fresh one.
+**not** silently adopt a non-tether inbox), mints a **least-privilege
+agent-scoped key** (`e2a_agt_…`), and writes `~/.e2a-tether.env` (previous file
+kept as `.bak`). Every step fails hard — it never stores the broad account key
+and never reports "ready" with a half-working config. Flags: `--email
+you@yourdomain` to use/create a specific inbox, `--new` to force a fresh one.
 
 ### Manual setup (fallback)
 
@@ -104,12 +103,9 @@ e2a config set agent_email <inbox>       # or export E2A_AGENT_EMAIL
 
 or put the agent key + inbox in `~/.e2a-tether.env` and leave the CLI config alone.
 
-> The tether agent must have send-side protection / HITL **off**, or each update
-> is held for review instead of reaching you. `tether.sh` now detects this on
-> every send: a held intro makes `start` **refuse to arm**, and a held
-> `update`/`ask` prints a `HELD for review (pending_review)` warning and exits
-> non-zero — so a held session fails loudly instead of "reporting" into a queue
-> the user never sees.
+> If e2a returns `pending_review`, the message was not dispatched. `tether.sh`
+> detects this on every send: an affected intro makes `start` **refuse to arm**,
+> and an affected `update`/`ask` exits non-zero so the session fails loudly.
 
 ## First run (new user) — set them up, then tether
 
@@ -125,8 +121,8 @@ first-time user — **help them get to a working setup instead of just failing**
    dashboard, persist it with `e2a config set api_key <key>`, then validate it
    with `e2a whoami`.) Interactive sign-in is theirs to complete: hand them the
    command, don't drive it.
-2. **Run the bootstrap:** `"$T" setup` — it creates the inbox, disables
-   outbound review, mints the agent-scoped key, and writes
+2. **Run the bootstrap:** `"$T" setup` — it creates the inbox, mints the
+   agent-scoped key, and writes
    `~/.e2a-tether.env`. See **Setup** above for what it refuses to do.
 3. **Re-check.** `"$T" status` should now print `config: OK (agent …)`. Proceed
    to the runtime flow.
@@ -153,8 +149,8 @@ Let `T="${CLAUDE_PLUGIN_ROOT}/skills/tether/tether.sh"`.
    needs it stable), so title the *work*, not the first step. `--for` takes a **single
    unit** (`30m`, `2h`, `8h`, `1d`); a compound
    like `1h30m` is rejected rather than silently treated as no-limit. If the intro
-   comes back **held for review** (`pending_review`), `start` refuses to arm and
-   tells you to turn protection off — a held intro means the user never got it.
+   comes back `pending_review`, `start` refuses to arm because the intro was not
+   dispatched.
 3. **Work**, and **send updates as you see fit** — **prefer HTML**, it renders
    far better in mail clients: write the HTML to a file and run
    `"$T" update --html <file>` — a plain-text fallback is auto-derived (or pass
@@ -165,9 +161,8 @@ Let `T="${CLAUDE_PLUGIN_ROOT}/skills/tether/tether.sh"`.
    upload the file somewhere and send a link instead). Good moments: finished a
    slice, made a decision that's worth surfacing, hit a blocker, or before a
    long unattended stretch. Skip trivial
-   turns. If `update` prints a `HELD for review (pending_review)`
-   warning (exit 2), the update did **not** reach the user — stop and fix
-   protection before continuing; don't keep "reporting" into a review queue.
+   turns. If `update` reports `pending_review` (exit 2), the update did **not**
+   reach the user — stop and fix the inbox configuration before continuing.
 4. **Need a decision from the user? Ask by email — never the terminal.** Run
    `"$T" ask "<question>"` (in the background); it emails the question and blocks
    until the user replies, then prints the answer. `--attach <file>` works here
@@ -178,8 +173,8 @@ Let `T="${CLAUDE_PLUGIN_ROOT}/skills/tether/tether.sh"`.
    so a background `listen` pauses and can't swallow your answer). Handle its exit
    codes: **exit 3** = timed out with no reply (default 30m) — re-`ask`, send a
    nudge `update`, or keep working and listening, but never fall back to a
-   terminal prompt; **exit 4** = the question was held for review and never
-   reached the user (fix protection).
+   terminal prompt; **exit 4** = the question was not dispatched (fix the inbox
+   configuration).
 5. **Listen for the whole window**: run `"$T" listen` **in the background**. It
    waits on the CLI's WebSocket (real-time, no tokens while waiting; degrades
    to polling if the WS is unavailable) and exits with either:

--- a/plugins/e2a/skills/tether/tether.env.example
+++ b/plugins/e2a/skills/tether/tether.env.example
@@ -4,7 +4,7 @@
 
 # Required — get an agent-scoped key (e2a_agt_…) at https://e2a.dev/api-keys
 export E2A_API_KEY="e2a_agt_..."             # agent-scoped e2a API key
-export E2A_AGENT_EMAIL="tether@you.example"   # the sending/receiving agent (protection/HITL OFF)
+export E2A_AGENT_EMAIL="tether@you.example"   # the sending/receiving agent
 
 # Optional
 export E2A_URL="https://e2a.dev"                # self-host: your e2a deployment root

--- a/plugins/e2a/skills/tether/tether.sh
+++ b/plugins/e2a/skills/tether/tether.sh
@@ -120,11 +120,10 @@ question or instruction; reply \"stop\" to end early.
       echo "tether: intro NOT sent — auth failed (key invalid/revoked). Check 'e2a whoami' / E2A_API_KEY."
       exit 4
     fi
-    [ -n "$mid" ] || { echo "tether: intro send failed (check creds / base url / agent protection)"; exit 1; }
+    [ -n "$mid" ] || { echo "tether: intro send failed (check credentials and base URL)"; exit 1; }
     if [ "$rc" = "2" ]; then
-      echo "tether: intro was HELD for review (pending_review) — the user won't receive it, so NOT arming."
-      echo "        Fix: e2a protection set ${E2A_AGENT_EMAIL} --outbound-review off"
-      echo "        (needs the account-scoped 'e2a login' credential, or use the dashboard) — then run start again."
+      echo "tether: intro returned pending_review — it was not dispatched, so NOT arming."
+      echo "        Check the inbox configuration, then run start again."
       exit 1
     fi
     t_state_set armed 1 to "$to" conversation_id "$conv" last_message_id "$mid" \
@@ -166,7 +165,7 @@ question or instruction; reply \"stop\" to end early.
     fi
     t_state_set last_message_id "$mid"
     if [ "$rc" = "2" ]; then
-      echo "tether: WARNING update HELD for review (pending_review) — it did NOT reach the user. Disable send-side protection on ${E2A_AGENT_EMAIL}."
+      echo "tether: WARNING update returned pending_review — it did NOT reach the user. Check the inbox configuration."
       exit 2
     fi
     # The thread id in the success line makes cross-session misdirection
@@ -261,7 +260,7 @@ question or instruction; reply \"stop\" to end early.
     [ -n "$mid" ] || { echo "tether: ask send failed"; exit 1; }
     t_state_set last_message_id "$mid"
     if [ "$rc" = "2" ]; then
-      echo "tether: WARNING question HELD for review (pending_review) — it did NOT reach the user, so not waiting. Disable send-side protection on ${E2A_AGENT_EMAIL}."
+      echo "tether: WARNING question returned pending_review — it did NOT reach the user, so not waiting. Check the inbox configuration."
       exit 4
     fi
     echo "tether: question sent (${mid}); waiting for your reply…"
@@ -283,10 +282,9 @@ question or instruction; reply \"stop\" to end early.
   setup)
     # Zero-to-tethered bootstrap on the e2a CLI. Needs an ACCOUNT credential in
     # the CLI's own config (`e2a login`, or `e2a config set api_key` headless).
-    # Golden path: whoami → ensure inbox (verify/create) → outbound review off
-    # → mint a least-privilege agent key → write ~/.e2a-tether.env. Every step
-    # fails HARD: no protection clobber (the CLI never PUTs after a failed
-    # read), no silent account-key fallback, no "ready" with a broken config.
+    # Golden path: whoami → ensure inbox (verify/create) → mint a
+    # least-privilege agent key → write ~/.e2a-tether.env. Every step fails
+    # HARD: no silent account-key fallback and no "ready" with a broken config.
     #   --email <addr>  use/create this inbox (bare names expand on the shared domain)
     #   --new           always create a fresh tether-<rand> inbox
     force_new=0; want=""
@@ -315,9 +313,6 @@ try:print(json.load(sys.stdin).get("agentAddress",""))
 except Exception:print("")')"
       echo "tether setup: the CLI already holds an agent-scoped key (${bound}) — nothing to mint."
       echo "              tether will pick it up from ~/.e2a/config.json; run 'tether.sh status' to confirm."
-      echo "              NOTE this key cannot verify/disable outbound review on ${bound}. If 'start'"
-      echo "              refuses with a HELD intro, run 'e2a protection set ${bound} --outbound-review off'"
-      echo "              with an account-scoped login (or use the dashboard)."
       exit 0
     fi
     [ "$scope" = "account" ] || { echo "tether setup: could not determine key scope (e2a whoami failed?) — check 'e2a whoami'"; exit 1; }
@@ -342,30 +337,11 @@ except Exception:print("")')"
       echo "tether setup: creating ${inbox}…"
       t_cli agents create "$inbox" --name "tether" >/dev/null || { echo "tether setup: agent create failed (slug taken/invalid?)"; exit 1; }
     fi
-    case "$inbox" in
-      tether-*@*) : ;;
-      *) [ -n "$want" ] || { echo "tether setup: refusing to reconfigure non-tether inbox ${inbox} without an explicit --email"; exit 1; }
-         echo "tether setup: NOTE disabling OUTBOUND review on ${inbox} (explicitly requested via --email)";;
-    esac
-    # Mint FIRST, flip protection SECOND: the mint can fail (quota, 5xx), and
-    # the old order left outbound review disabled on the inbox while claiming
-    # "nothing written". This order is fully rollbackable — a protection
-    # failure revokes the just-minted key and aborts with zero server-side
-    # drift. (--json gives us the key id so the rollback can name it.)
     kjson="$(t_cli keys create --agent "$inbox" --name "tether-$(python3 -c 'import secrets;print(secrets.token_hex(2))')" --json 2>/dev/null)"
     agtkey="$(printf '%s' "$kjson" | python3 -c 'import json,sys
 try:print(json.load(sys.stdin).get("key","") or "")
 except Exception:print("")')"
-    keyid="$(printf '%s' "$kjson" | python3 -c 'import json,sys
-try:print(json.load(sys.stdin).get("id","") or "")
-except Exception:print("")')"
     [ -n "$agtkey" ] || { echo "tether setup: could not mint an agent-scoped key — aborting (NOT storing the broad account key)"; exit 1; }
-    if ! t_cli protection set "$inbox" --outbound-review off >/dev/null; then
-      [ -n "$keyid" ] && t_cli keys delete "$keyid" >/dev/null 2>&1
-      echo "tether setup: could not disable outbound review — aborting (minted key revoked, nothing changed)"
-      exit 1
-    fi
-    echo "tether setup: outbound review off on ${inbox}"
     envf="${HOME}/.e2a-tether.env"
     if [ -f "$envf" ]; then
       cp "$envf" "${envf}.bak" && chmod 600 "${envf}.bak" 2>/dev/null

--- a/scripts/plugin-agent-guidance.test.mjs
+++ b/scripts/plugin-agent-guidance.test.mjs
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { test } from "node:test";
+
+const coreAgentFiles = [
+  "plugins/e2a/README.md",
+  "plugins/e2a/docs/auth.md",
+  "plugins/e2a/docs/e2a.md",
+  "plugins/e2a/docs/llms.txt",
+  "plugins/e2a/docs/sdk.md",
+  "plugins/e2a/docs/templates.md",
+  "plugins/e2a/skills/e2a/SKILL.md",
+  "plugins/e2a/.claude-plugin/plugin.json",
+  "plugins/e2a/.codex-plugin/plugin.json",
+  "plugins/e2a/.cursor-plugin/plugin.json",
+];
+
+test("core agent guidance does not promote the HITL review surface", async () => {
+  const forbidden = /\bHITL\b|human-in-the-loop|approve_review|reject_review|list_reviews|get_review|turn on a review hold|review held messages/i;
+
+  for (const file of coreAgentFiles) {
+    const source = await readFile(file, "utf8");
+    assert.doesNotMatch(source, forbidden, file);
+  }
+});
+
+test("the e2a skill keeps a defensive pending_review no-retry warning", async () => {
+  const source = await readFile("plugins/e2a/skills/e2a/SKILL.md", "utf8");
+  assert.match(source, /pending_review/);
+  assert.match(source, /do not retry/i);
+});
+
+test("the e2a skill description is quoted YAML", async () => {
+  const source = await readFile("plugins/e2a/skills/e2a/SKILL.md", "utf8");
+  assert.match(source, /^description: "(?:[^"\\]|\\.)*"$/m);
+});
+
+test("the e2a skill bootstraps and verifies an MCP connection", async () => {
+  const source = await readFile("plugins/e2a/skills/e2a/SKILL.md", "utf8");
+  const bootstrap = source.match(
+    /### First run:[\s\S]*?(?=\n### |\n## )/,
+  )?.[0] ?? "";
+
+  assert.match(bootstrap, /available e2a MCP tools/i);
+  assert.match(bootstrap, /e2a MCP [`\"]?whoami/i);
+  assert.match(bootstrap, /(?:never|not).*(?:Unix|shell).*whoami/i);
+  assert.match(
+    bootstrap,
+    /claude mcp add --transport http --scope user e2a https:\/\/api\.e2a\.dev\/mcp/,
+  );
+  assert.match(bootstrap, /codex mcp login e2a/);
+  assert.match(bootstrap, /mcpServers/);
+  assert.match(bootstrap, /Streamable HTTP/i);
+  assert.match(bootstrap, /authentication failure/i);
+  assert.match(bootstrap, /network, timeout, or server/i);
+  assert.match(bootstrap, /list_messages/);
+  assert.match(bootstrap, /resume.*original/i);
+  assert.match(bootstrap, /never ask.*API key/i);
+});
+
+test("tether setup does not mutate review configuration", async () => {
+  const source = await readFile("plugins/e2a/skills/tether/tether.sh", "utf8");
+  assert.doesNotMatch(source, /protection set|outbound-review|outbound review/i);
+  assert.match(source, /pending_review/);
+});

--- a/web/public/auth.md
+++ b/web/public/auth.md
@@ -17,8 +17,8 @@ e2a also implements the first pieces of the WorkOS [auth.md](https://github.com/
 
 Before you do anything credential-shaped, check whether the user has already wired e2a into your environment. Most of the time they have, and you should not be handling credentials (API keys or OAuth tokens) yourself.
 
-1. **e2a MCP server** — if you are an MCP client (Claude, Cursor, Codex, ChatGPT, etc.), e2a's MCP server is hosted: point your MCP client at the Streamable HTTP endpoint `https://api.e2a.dev/mcp` (OAuth 2.1 — no key pasted) to get inbox, send, reply, agents, domains, and HITL approval as tools. Repository: `https://github.com/tokencanopy/e2a/tree/main/mcp`.
-2. **e2a agent skill** — a guidance document covering inbox patterns, idempotency, HITL approval, attachment handling, and webhook verification. Load it before calling the API directly so you don't relearn the gotchas on the user's dime.
+1. **e2a MCP server** — if you are an MCP client (Claude, Cursor, Codex, ChatGPT, etc.), e2a's MCP server is hosted: point your MCP client at the Streamable HTTP endpoint `https://api.e2a.dev/mcp` (OAuth 2.1 — no key pasted) to get inbox, send, reply, agents, and domains as tools. Repository: `https://github.com/tokencanopy/e2a/tree/main/mcp`.
+2. **e2a agent skill** — a guidance document covering inbox patterns, idempotency, attachment handling, and webhook verification. Load it before calling the API directly so you don't relearn the gotchas on the user's dime.
 3. **e2a CLI** — if you are running shell commands, prefer `e2a` over hand-rolled `curl`. It handles auth resolution, retries, and non-interactive flags. Install: `npm i -g @e2a/cli`. Repository: `https://github.com/tokencanopy/e2a/tree/main/cli`.
 
 If any of these is already configured, use it and stop. Do not ask the user for an API key you do not need.
@@ -96,11 +96,13 @@ HTML alternative is optional. A template send uses `template_id` or
 
 Read the credential from the environment at the moment of the call. Do not copy it into variables you log, do not echo it back to the user, do not include it in commit messages, PR descriptions, error reports, or screenshots. If you are running a shell command, never interpolate the credential inline — reference the environment variable so it does not appear in command history.
 
-Set an `Idempotency-Key` (UUIDv4 recommended) per logical operation on side-effectful calls (sends, replies, HITL approve). Reuse the **same** key on transport retries (network failures, timeouts) — the server replays the original response. Same key with a different body returns `422`; a genuinely new operation needs a fresh key.
+Set an `Idempotency-Key` (UUIDv4 recommended) per logical operation on side-effectful calls such as sends and replies. Reuse the **same** key on transport retries (network failures, timeouts) — the server replays the original response. Same key with a different body returns `422`; a genuinely new operation needs a fresh key.
 
-### HITL: handling 202 pending_review
+### Handling `pending_review`
 
-If the agent's protection config holds outbound mail for review, a send (and `reply`/`forward`) will return **`202 Accepted`** with `status: "pending_review"` instead of dispatching the message:
+If a send, reply, or forward returns **`202 Accepted`** with
+`status: "pending_review"`, the server accepted the message but did not dispatch
+it:
 
 ```json
 {
@@ -110,7 +112,8 @@ If the agent's protection config holds outbound mail for review, a send (and `re
 }
 ```
 
-The message is held until a human approves it via the dashboard, CLI, or magic link, or until `approval_expires_at` fires the configured expiration action. Do not retry the send — that would queue a duplicate. To learn the outcome, poll `GET /v1/agents/{address}/messages/{id}`: an approved outbound send becomes `sent`; a rejection becomes `review_rejected`; on TTL expiry it becomes `review_expired_approved` (auto-sent) or `review_expired_rejected` (discarded), per the hold's `on_expiry` action. Or surface the situation to the calling user and stop.
+Do not retry the send — another call can queue a duplicate. Surface the status,
+`message_id`, and `approval_expires_at` to the calling user, then stop.
 
 ### Errors
 

--- a/web/public/e2a.md
+++ b/web/public/e2a.md
@@ -2,8 +2,8 @@
 
 You are an AI agent — or the human wiring one up. e2a gives an agent its own
 **real email inbox**: a verified address it can send from, receive to, reply on,
-and (optionally) have its outbound mail held for human approval. This file tells
-you how to connect and what you can do. Read it once, then drive the tools.
+and use for multi-turn conversations. This file tells you how to connect and
+what you can do. Read it once, then drive the tools.
 
 The mental model flips the usual one. Pretraining assumes "a human reading their
 inbox." With e2a, **you are the agent and the inbox is yours** —
@@ -84,14 +84,11 @@ different tool — e2a is the agent's *own* address.
 Over MCP the tools appear as `mcp__e2a__*`. Always call `tools/list` for exact,
 current signatures and treat that as the source of truth. The surface, by area:
 
-- **Inboxes (agents)** — create / list / get / delete an addressable inbox;
-  configure its protection (screening + HITL) posture.
+- **Inboxes (agents)** — create / list / get / delete an addressable inbox and
+  inspect its configuration.
 - **Messages** — `send_message`, `reply_to_message` (keeps the thread),
   `forward_message`, list + read inbound and outbound, fetch attachments via
   short-lived download URLs.
-- **Human-in-the-loop** — held outbound drafts and screened inbound sit in
-  **review**; a human (or you, with an account-scoped credential) approves or
-  rejects them. Inbound holds release to the inbox on approval.
 - **Domains** — register a custom domain, read its required DNS records, verify
   ownership + sending identity.
 - **Webhooks & events** — subscribe to `email.received` and friends; the durable
@@ -108,9 +105,8 @@ current signatures and treat that as the source of truth. The surface, by area:
   `reply_to_message` sets. So a fresh `send` (even with the same
   `conversation_id`, or a changed subject) stays in the same e2a conversation but
   shows up as a separate thread in the user's inbox.
-- **HITL.** A send may come back `pending_review` instead of `sent`. That's the
-  human-approval gate, not an error; it resolves when a human approves/rejects
-  (or the review TTL expires).
+- **Non-terminal send status.** If a send returns `pending_review`, it was
+  accepted but not dispatched. Report the status and message ID; do not retry.
 - **Verification.** Inbound mail carries SPF/DKIM/DMARC results. Only a DMARC
   pass authenticates domain-authorized use of the RFC 5322 From domain; it does
   not authenticate the mailbox local part, a person, or the display name.
@@ -128,23 +124,17 @@ current signatures and treat that as the source of truth. The surface, by area:
 4. `reply_to_message(message_id, …)` — same thread; the recipient sees a normal
    reply.
 
-**Send for approval:** call `send_message`; if it returns `pending_review`, a
-human approves it in the dashboard (or you do, with an account-scoped
-credential). Don't retry — it's held, not failed.
-
 ## Constraints
 
 - Sending from a **custom domain** needs its sending identity verified in DNS;
   the shared `agents.e2a.dev` address works immediately.
-- Held messages carry a review **TTL** (default 7 days) after which they
-  auto-resolve.
 - Attachments are fetched via short-lived signed URLs by default; callers may
   request small attachments inline.
 
 ## Anti-patterns
 
-- ❌ Treating `pending_review` as a failure and retrying the send → you'll
-  double-queue. Wait for the human decision.
+- ❌ Retrying a `pending_review` send → the server already accepted it, so a new
+  call can create a duplicate. Report the status and stop.
 - ❌ Starting a new `send_message` to answer an inbound → breaks threading. Use
   `reply_to_message`.
 - ❌ Trusting `header_from` without checking alignment → require
@@ -155,8 +145,8 @@ credential). Don't retry — it's held, not failed.
 ## About & pricing
 
 e2a is an authenticated email gateway for AI agents: SMTP relay with SPF/DKIM
-verification, per-agent inboxes, HITL approval, WebSocket + webhook delivery, a
-CLI, and TypeScript/Python SDKs. The core is open source:
+verification, per-agent inboxes, WebSocket + webhook delivery, a CLI, and
+TypeScript/Python SDKs. The core is open source:
 https://github.com/tokencanopy/e2a.
 
 The full agent skill — mental model, gotchas, and worked examples — ships as the

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -2,7 +2,7 @@
 
 > e2a is an authenticated email gateway for AI agents: it gives an agent its own
 > verified email inbox to send, receive, reply, and forward, with SPF/DKIM
-> verification and optional human-in-the-loop approval of outbound mail. Connect
+> verification. Connect
 > over a hosted MCP server (OAuth, no API key), the REST API, or the SDKs.
 
 ## Start here
@@ -15,7 +15,7 @@
 
 ## API & SDKs
 
-- [sdk.md](https://e2a.dev/sdk.md): TypeScript (`@e2a/sdk`) and Python (`e2a`) quick-start with code examples — send, receive (webhook → fetch → reply), HITL, real-time streaming — plus a Raw-REST section (base URL, auth, conventions) for other languages.
+- [sdk.md](https://e2a.dev/sdk.md): TypeScript (`@e2a/sdk`) and Python (`e2a`) quick-start with code examples — send, receive (webhook → fetch → reply), and real-time streaming — plus a Raw-REST section (base URL, auth, conventions) for other languages.
 - [openapi.yaml](https://e2a.dev/openapi.yaml): The full OpenAPI 3.1 contract — every endpoint, field, enum, and error, generated from the live handlers. Authoritative for exact signatures.
 - [templates.md](https://e2a.dev/templates.md): Email templates (beta) — server-rendered reusable emails with `{{variable}}` interpolation, a prebuilt starter catalog (`from_starter`), validation, and send-by-alias. Includes a copy-paste setup prompt for coding agents.
 

--- a/web/public/sdk.md
+++ b/web/public/sdk.md
@@ -29,8 +29,8 @@ import { E2AClient } from "@e2a/sdk";
 const client = new E2AClient({ apiKey: process.env.E2A_API_KEY });
 const messageId = "msg_..."; // an inbound message id from a webhook, WebSocket, or list call
 
-// Send (held drafts come back status="pending_review", not an error)
-await client.messages.send("bot@agents.e2a.dev", {
+// Send; if status is pending_review, report it and do not retry.
+const result = await client.messages.send("bot@agents.e2a.dev", {
   to: ["person@example.com"],
   subject: "Hello from my agent",
   text: "This was sent by an AI agent via e2a.",
@@ -79,7 +79,7 @@ if (isEmailReceived(event)) {
   const email = await client.inbound.fromEvent(event);
   console.log(email.envelopeFrom, email.verified, email.replyTargets);
   const result = await email.reply({ text: "On it." });
-  if (result.status === "pending_review") console.log("awaiting approval", result.messageId);
+  if (result.status === "pending_review") console.log("not dispatched", result.messageId);
 }
 ```
 
@@ -98,7 +98,7 @@ if event.type == "email.received":
     print(email.envelope_from, email.verified, email.reply_targets)
     result = await email.reply({"text": "On it."})
     if result.status == "pending_review":
-        print("awaiting approval", result.message_id)
+        print("not dispatched", result.message_id)
 ```
 
 `verified` is true only for an aligned DMARC pass in the hydrated authentication
@@ -112,23 +112,6 @@ inline data is available only within the server's 256 KiB cap.
 A full, runnable example (FastAPI + Google ADK agent, webhook → agent turn →
 reply) is at
 [examples/adk-cloud-webhook](https://github.com/tokencanopy/e2a/tree/main/examples/adk-cloud-webhook).
-
-## Human-in-the-loop
-
-Held messages (outbound drafts + screened inbound) are the account-scoped review
-queue. With an account-scoped key:
-
-```ts
-const held = await client.reviews.list().toArray({ limit: 100 });   // both directions
-await client.reviews.approve(id);                      // outbound: send; inbound: release
-await client.reviews.reject(id, { reason: "spam" });
-```
-
-```python
-held = await client.reviews.list().to_list(limit=100)
-await client.reviews.approve(message_id)
-await client.reviews.reject(message_id, {"reason": "spam"})
-```
 
 ## Real-time (no webhook)
 
@@ -166,13 +149,13 @@ Conventions:
   (null when exhausted).
 - **Errors** — non-2xx bodies are `{"error": {"code", "message", "request_id"}}`;
   branch on the machine `code`.
-- **Idempotency** — sends (`send`/`reply`/`forward`/approve) accept an
+- **Idempotency** — sends (`send`/`reply`/`forward`) accept an
   `Idempotency-Key` header; a retried call replays instead of double-sending.
-- **Scopes** — account keys manage agents/domains/keys/reviews; agent keys are
+- **Scopes** — account keys manage agents/domains/keys; agent keys are
   pinned to one inbox.
 
 The endpoint map, exact request/response bodies, enums, and error codes are all
 in the OpenAPI 3.1 contract — generated from the live handlers and checked for
 drift in CI: **https://e2a.dev/openapi.yaml**. The core resources are `agents`
-(inboxes), `messages` (send/reply/forward/get/list/attachments), `reviews`
-(HITL), `domains`, `webhooks`, `events`, and `account`.
+(inboxes), `messages` (send/reply/forward/get/list/attachments), `domains`,
+`webhooks`, `events`, and `account`.

--- a/web/public/templates.md
+++ b/web/public/templates.md
@@ -68,9 +68,6 @@ curl -X POST https://api.e2a.dev/v1/agents/billing-bot%40agents.e2a.dev/messages
   }'
 ```
 
-Rendering happens **before** any human-in-the-loop review hold, so reviewers
-see the final subject and body.
-
 > **Wire change.** To make room for the template shape, `subject` and `text`
 > moved from schema-required to handler-enforced on
 > `POST /v1/agents/{email}/messages`. A literal send that omits them now
@@ -93,7 +90,7 @@ copy freely afterwards.
 | `receipt` | Order receipt with a line-item table and hosted-receipt link | `company_name`, `support_email`, `company_address`, `preheader`*, `order_id`, `order_date`, **`items_html`** (raw), `items_text`, `total`, `receipt_url` |
 | `agent-status` | Numbers-first status report from an automated agent | `company_name`, `support_email`, `company_address`, `preheader`*, `agent_name`, `run_summary`, **`sections_html`** (raw), `sections_text`, `dashboard_url` |
 | `daily-digest` | Recurring daily summary with an unsubscribe link | `company_name`, `support_email`, `company_address`, `preheader`*, `agent_name`, `date`, `headline`, **`sections_html`** (raw), `sections_text`, `dashboard_url`, **`unsubscribe_html`** (raw) |
-| `approval-request` | Human-in-the-loop approval request with Approve/Reject buttons and expiry | `company_name`, `support_email`, `company_address`, `preheader`*, `agent_name`, `action_summary`, **`details_html`** (raw), `details_text`, `approve_url`, `reject_url`, `expires_at` |
+| `approval-request` | Human approval request with Approve/Reject buttons and expiry | `company_name`, `support_email`, `company_address`, `preheader`*, `agent_name`, `action_summary`, **`details_html`** (raw), `details_text`, `approve_url`, `reject_url`, `expires_at` |
 
 \* optional; **bold** = raw (`{{{…}}}`) slot. `GET /v1/starter-templates`
 returns the authoritative per-variable metadata (required/raw flags,


### PR DESCRIPTION
## Summary

- teach the e2a skill to detect whether its MCP tools are available before calling the e2a MCP `whoami` tool
- add concise setup and OAuth recovery branches for Claude Code, Codex, Cursor/Windsurf, and generic remote-MCP clients
- verify credential scope and inbox readiness before resuming the original task
- remove HITL promotional and setup guidance while preserving defensive `pending_review` no-retry handling
- add agent-guidance regression tests to CI and keep hosted documentation mirrors synchronized

## Why

The skill previously assumed e2a was already connected and treated missing tools, authentication failures, and operational failures as one case. That left agents unable to guide first-time users reliably and could make `whoami` ambiguous with the shell command.

## User impact

Agents can now help users connect e2a through their current MCP client, complete OAuth, select or create an inbox, verify it with a harmless read, and continue the requested email task. Interactive setup does not request API keys or silently edit user configuration.

## Validation

- `node --test scripts/plugin-agent-guidance.test.mjs scripts/sdk-examples-contract.test.mjs scripts/sync-agent-docs.test.mjs`
- `node scripts/validate-plugin.mjs`
- `node scripts/sync-agent-docs.mjs --check`
- `bash plugins/e2a/skills/tether/tether.sh _selftest`
- `scripts/check-repository-text-integrity.sh`
- `git diff --check`