### PR TITLE
fix(e2e-prod): update 18-reviews.test.ts for the header_from/envelope_from rename

### DIFF
--- a/tests/e2e-prod/suites/18-reviews.test.ts
+++ b/tests/e2e-prod/suites/18-reviews.test.ts
@@ -27,7 +27,9 @@ interface Review {
   id: string;
   agent_email: string;
   direction: string;
-  from: string;
+  header_from: string | null;
+  envelope_from: string | null;
+  verified_domain: string | null;
   to: string[];
   subject: string;
   conversation_id?: string;
@@ -84,10 +86,12 @@ test("reviews: listReviews returns PageReviewView envelope with the new held rev
     );
     const mine = r.body!.items.find((v) => v.id === id);
     assert.ok(mine, `the just-created held review ${id} should appear in the account queue`);
-    // ReviewView fields: id, agent_email, direction, from, to, subject, review_status, created_at.
+    // ReviewView fields: id, agent_email, direction, header_from, envelope_from,
+    // verified_domain, to, subject, review_status, created_at.
     assert.equal(mine!.agent_email, email, "review.agent_email is the sending inbox");
     assert.equal(mine!.direction, "outbound", "held outbound draft");
-    assert.equal(mine!.from, email, "review.from is the sending agent");
+    assert.equal(mine!.header_from, email, "review.header_from is the sending agent identity for outbound mail");
+    assert.equal(mine!.envelope_from, null, "review.envelope_from is null for outbound messages");
     assert.ok(Array.isArray(mine!.to) && mine!.to.includes(SINK), "review.to carries the recipient");
     assert.equal(mine!.subject, subject, "review.subject matches the sent subject");
     assert.equal(mine!.review_status, "pending_review", "queued item is pending_review");


### PR DESCRIPTION
## Summary
- `ReviewView` dropped the bare `from` field in favor of `header_from` / `envelope_from` / `verified_domain` (the same DMARC-aligned rename `MessageView` already got, per the SDK 5.2 upgrade notes and `api/openapi.yaml`'s `ReviewView` schema).
- `tests/e2e-prod/suites/18-reviews.test.ts` still asserted the old `review.from` field, which is now always `undefined` on the wire — a **stale test**, not a server regression.
- Caught by the staging release pipeline's conformance gate on a manual `main` dispatch (run [29803276549](https://github.com/tokencanopy/e2a-ops/actions/runs/29803276549)): `AssertionError: review.from is the sending agent — actual: undefined`.

## Changes
- `Review` interface: `from: string` → `header_from: string | null`, `envelope_from: string | null`, `verified_domain: string | null` (matches the required fields in `ReviewView`'s OpenAPI schema).
- Assertion updated: `review.header_from` equals the sending agent identity for the outbound held draft; added `review.envelope_from === null` (documented as always null for outbound).

## Test plan
- [x] Ran `18-reviews.test.ts` standalone against `api-staging.e2a.dev` with a throwaway bootstrap account — all 6 tests pass (previously 1 failing).
- [x] Verified `header_from`/`envelope_from` are the actual current `ReviewView` wire fields against `api/openapi.yaml` (SSOT) — `from` does not exist in the schema.
- [x] No other suite references the stale `review.from` (only hit outside this file is an unrelated `from: "alice@example.com"` request payload in `14-v030-features.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)