### PR TITLE
feat(prober): assert on authentication evidence in the inbound round-trip

### DIFF
--- a/internal/selftest/scenarios.go
+++ b/internal/selftest/scenarios.go
@@ -16,6 +16,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/tokencanopy/e2a/internal/emailauth"
 )
 
 // defaultRoundTripTimeout bounds how long the inbound round-trip waits for the
@@ -127,7 +129,35 @@ func scenarioInboundRoundTrip(ctx context.Context, p *Probe) Result {
 	if !verifyHMAC(d.Headers.Get("X-E2A-Signature"), d.Body, p.WebhookSecret) {
 		return fail("webhook HMAC verification failed")
 	}
-	return pass("inbound round-trip + HMAC ok")
+
+	// This is the only scenario that originates real inbound SMTP (every other
+	// scenario is loopback or outbound), so it's the only place `authentication`
+	// evidence can be checked over the wire at all — the conformance suite runs
+	// off a GitHub-hosted runner with no SMTP access and can only assert the
+	// null-for-loopback case. The synthetic sender domain (e2a-selftest.invalid,
+	// an RFC 2606 reserved TLD) publishes no SPF/DKIM/DMARC records and is never
+	// signed, so a genuine DMARC pass isn't achievable here — but the field must
+	// still be present, well-formed, and correctly reflect "evaluated, did not
+	// authenticate" rather than being silently dropped, null, or malformed.
+	var env struct {
+		Data struct {
+			Authentication *emailauth.Authentication `json:"authentication"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(d.Body, &env); err != nil {
+		return fail("decode email.received envelope: %v", err)
+	}
+	auth := env.Data.Authentication
+	if auth == nil {
+		return fail("email.received data.authentication is null for a real inbound SMTP delivery (want populated evidence, even unauthenticated)")
+	}
+	if len(auth.DKIM) != 0 {
+		return fail("data.authentication.dkim: want empty (unsigned synthetic message), got %d signature(s)", len(auth.DKIM))
+	}
+	if auth.DMARC.Status == emailauth.StatusPass {
+		return fail("data.authentication.dmarc.status: want not-pass (e2a-selftest.invalid has no DNS/SPF/DKIM/DMARC infrastructure), got pass")
+	}
+	return pass(fmt.Sprintf("inbound round-trip + HMAC ok; authentication evidence present (dmarc=%s)", auth.DMARC.Status))
 }
 
 // scenarioOutboundSend is the real-egress counterpart to the inbound round-trip:


### PR DESCRIPTION
## Summary
- Companion to #612 — same underlying gap: the DMARC-alignment rewrite (`header_from`/`envelope_from`/`verified_domain`/`authentication`) has zero end-to-end coverage anywhere. #612 added a null-for-loopback regression guard to the TS conformance suite; this closes the other half.
- `scenarioInboundRoundTrip` (`internal/selftest/scenarios.go`) is the **only** selftest scenario that originates real inbound SMTP — every other scenario is loopback or outbound. It is therefore the only place `authentication` evidence can be checked against a real delivery at all: the `tests/e2e-prod` conformance suite runs off a GitHub-hosted runner with no SMTP access and can only ever assert the null case.
- A genuine DMARC **pass** isn't achievable from this scenario — the synthetic sender domain `e2a-selftest.invalid` is an RFC 2606 reserved TLD with no SPF/DKIM/DMARC records, and the message is never signed. But the field must still be present, well-formed, and correctly reflect "evaluated, did not authenticate" — not silently dropped, null, or malformed.

## Change
After the existing HMAC check, decode the `email.received` envelope's `data.authentication` and assert:
- non-null (a real inbound SMTP delivery must produce evidence)
- `dkim` is empty (the synthetic message is unsigned)
- `dmarc.status != pass` (no real infra behind the sender domain)

## Test plan
- [x] `go build ./...` — clean, no wider breakage.
- [x] `go vet ./internal/selftest/...` — clean.
- [x] `go test ./internal/selftest/... -v` — all pass, including `TestSelftestAll_AgainstRealServer`, which runs the **full** scenario battery (including the modified scenario) against a real in-process e2a server with a real SMTP listener. Observed exactly the predicted deterministic evidence: `SPF=none DKIM=0 DMARC=none` for the reserved-TLD synthetic sender — confirms the new assertions match actual server behavior, not just a guess.

## Known limitation (documented in the code comment)
This only proves the field is populated and correctly non-authenticating — it does not exercise a genuine DMARC-pass path (no automated staging/CI surface currently can: that would need a dedicated sending domain with real SPF/DKIM/DMARC records, which is a bigger infra lift, likely a good follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)