### PR TITLE
test(e2e-prod): guard loopback null authentication/envelope_from/verified_domain

### DIFF
--- a/tests/e2e-prod/suites/23-coverage-happy-path.test.ts
+++ b/tests/e2e-prod/suites/23-coverage-happy-path.test.ts
@@ -81,6 +81,26 @@ test("updateMessage + getConversation: label an inbound message, fetch its conve
   assert.ok(conv.body, "conversation fetched");
 });
 
+test("getMessage: loopback self-send has null authentication/envelope_from/verified_domain", async () => {
+  // Providerless loopback delivery (a self-send) never touches a real SMTP peer,
+  // so there's no inbound evidence to authenticate — MessageView documents all
+  // three fields as null in this case (api/openapi.yaml MessageView.authentication
+  // description: "Null means there was no authenticating inbound SMTP peer, as
+  // with outbound or providerless loopback delivery"). This locks that contract;
+  // it can't exercise a real DMARC pass since this suite has no SMTP access.
+  const email = await freshAgent("covauth");
+  const { id } = await loopbackMessage(email, uniqueSubject("cov auth"));
+
+  const msg = await client.get<{
+    authentication: unknown;
+    envelope_from: string | null;
+    verified_domain: string | null;
+  }>(`/v1/agents/${encodeURIComponent(email)}/messages/${id}`, { expect: 200 });
+  assert.equal(msg.body?.authentication, null, "loopback message.authentication is null — no inbound SMTP peer");
+  assert.equal(msg.body?.envelope_from, null, "loopback message.envelope_from is null — no SMTP MAIL FROM");
+  assert.equal(msg.body?.verified_domain, null, "loopback message.verified_domain is null — no DMARC evaluation");
+});
+
 test("replyToMessage: reply to an inbound message (self-loopback → 200)", async () => {
   const email = await freshAgent("covrp");
   const { id } = await loopbackMessage(email, uniqueSubject("cov rp"));


### PR DESCRIPTION
## Summary

The DMARC-alignment rewrite (`MessageView`/`ReviewView` now carry `header_from`, `envelope_from`, `verified_domain`, and a structured `authentication` object instead of a bare `from` string) documents that `authentication`, `envelope_from`, and `verified_domain` are `null` for **providerless loopback delivery** — a self-send never touches a real SMTP peer, so there's no inbound evidence to authenticate (`api/openapi.yaml` `MessageView.authentication` description: *"Null means there was no authenticating inbound SMTP peer, as with outbound or providerless loopback delivery"*).

An audit of `tests/e2e-prod/suites/` and the Go prober (`internal/selftest/`) found **zero** assertions on `authentication`/`dmarc`/`spf`/`dkim` anywhere in either — this documented null-for-loopback contract had no regression guard. (Follows up on #612, which fixed a related stale `from` → `header_from`/`envelope_from` assertion in `18-reviews.test.ts`.)

- Adds a new test to `tests/e2e-prod/suites/23-coverage-happy-path.test.ts`, alongside the existing `loopbackMessage()`-based coverage tests, that:
  1. Creates a fresh agent and sends it a self-send (loopback) message
  2. `GET /v1/agents/{email}/messages/{id}` for the full `MessageView`
  3. Asserts `authentication === null`, `envelope_from === null`, `verified_domain === null`

This can't exercise a real DMARC-pass case — this suite runs on a GitHub-hosted runner with no SMTP access — but it locks the documented null-for-loopback contract so a future regression there gets caught.

## Test plan

- [x] Ran the new test in isolation against staging (`https://api-staging.e2a.dev`) with a fresh throwaway bootstrap account + agent — **passed**.
- [x] Ran the two preceding tests in the same file (`updateAgent`, `updateMessage + getConversation`) unaffected — **passed**.
- [x] Confirmed the file's later tests (`replyToMessage`, `forwardMessage`, `approveReview`) hit a pre-existing `402 limit_exceeded` (Free-plan 3-agent cap) that reproduces identically on a fresh account **with my change reverted** — i.e. not something this change introduces; CI presumably runs this suite against a higher-limit account.
- [x] All throwaway staging accounts created during verification were deleted via `DELETE /v1/account?confirm=DELETE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)