### PR TITLE
docs(auth): distinguish DMARC none from fail in verified_domain docs

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -779,7 +779,7 @@ components:
             - string
             - "null"
         status:
-          description: DMARC verdict. Only pass authenticates domain-authorized use of the RFC 5322 Author Domain.
+          description: DMARC verdict. Only pass authenticates domain-authorized use of the RFC 5322 Author Domain. none means the sender publishes no DMARC record (common, not itself suspicious) and is distinct from fail, an actual alignment mismatch.
           enum:
             - pass
             - fail
@@ -1335,7 +1335,7 @@ components:
             type: string
           type: array
         verified_domain:
-          description: DMARC-authenticated RFC 5322 From domain when authentication passed; null when authentication failed, was unavailable, or was not evaluated.
+          description: DMARC-authenticated RFC 5322 From domain when authentication passed; null when authentication failed, was unavailable, or was not evaluated. A null caused by dmarc.status=none (sender publishes no DMARC record) is common and NOT itself suspicious — distinct from dmarc.status=fail, an actual mismatch. Only DMARC ties a passing SPF or DKIM identity back to this header domain; a bare SPF or DKIM pass without DMARC does not.
           type:
             - string
             - "null"
@@ -2130,7 +2130,7 @@ components:
         type:
           type: string
         verified_domain:
-          description: DMARC-authenticated RFC 5322 From domain when authentication passed; null when authentication failed, was unavailable, or was not evaluated.
+          description: DMARC-authenticated RFC 5322 From domain when authentication passed; null when authentication failed, was unavailable, or was not evaluated. A null caused by dmarc.status=none (sender publishes no DMARC record) is common and NOT itself suspicious — distinct from dmarc.status=fail, an actual mismatch. Only DMARC ties a passing SPF or DKIM identity back to this header domain; a bare SPF or DKIM pass without DMARC does not.
           type:
             - string
             - "null"
@@ -2251,7 +2251,7 @@ components:
             type: string
           type: array
         verified_domain:
-          description: RFC 5322 Author Domain validated by an aligned DMARC pass. Null otherwise. This authenticates the domain, not the address local part, individual sender, or message content.
+          description: RFC 5322 Author Domain validated by an aligned DMARC pass. Null otherwise — including dmarc.status=none (no DMARC record published, common and NOT itself suspicious), not just dmarc.status=fail (an actual mismatch). Only DMARC ties a passing SPF or DKIM identity back to this header domain; a bare SPF or DKIM pass without DMARC does not. This authenticates the domain, not the address local part, individual sender, or message content.
           type:
             - string
             - "null"
@@ -2381,7 +2381,7 @@ components:
             type: string
           type: array
         verified_domain:
-          description: RFC 5322 Author Domain validated by an aligned DMARC pass. Null for non-pass verdicts and deliveries without inbound SMTP evaluation. This authenticates the domain, not the address local part, individual sender, or message content.
+          description: RFC 5322 Author Domain validated by an aligned DMARC pass. Null for non-pass verdicts and deliveries without inbound SMTP evaluation — this includes dmarc.status=none (sender publishes no DMARC record, common and NOT itself suspicious) as well as dmarc.status=fail (an actual mismatch). Only DMARC ties a passing SPF or DKIM identity back to this header domain; a bare SPF or DKIM pass without DMARC does not. This authenticates the domain, not the address local part, individual sender, or message content.
           type:
             - string
             - "null"
@@ -3119,7 +3119,7 @@ components:
             type: string
           type: array
         verified_domain:
-          description: RFC 5322 Author Domain validated by an aligned DMARC pass. Null otherwise. This authenticates the domain, not the address local part, individual sender, or message content.
+          description: RFC 5322 Author Domain validated by an aligned DMARC pass. Null otherwise — including dmarc.status=none (no DMARC record published, common and NOT itself suspicious), not just dmarc.status=fail (an actual mismatch). Only DMARC ties a passing SPF or DKIM identity back to this header domain; a bare SPF or DKIM pass without DMARC does not. This authenticates the domain, not the address local part, individual sender, or message content.
           type:
             - string
             - "null"
@@ -5024,7 +5024,7 @@ paths:
       tags:
         - messages
     get:
-      description: Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and canonical inbound authentication evidence.
+      description: Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and canonical inbound authentication evidence. Fetching an unread inbound message marks it read as a side effect.
       operationId: getMessage
       parameters:
         - description: The agent's full email address.

--- a/internal/emailauth/result.go
+++ b/internal/emailauth/result.go
@@ -46,7 +46,7 @@ type DKIMResult struct {
 }
 
 type DMARCResult struct {
-	Status Status  `json:"status" enum:"pass,fail,none,temperror,permerror" doc:"DMARC verdict. Only pass authenticates domain-authorized use of the RFC 5322 Author Domain."`
+	Status Status  `json:"status" enum:"pass,fail,none,temperror,permerror" doc:"DMARC verdict. Only pass authenticates domain-authorized use of the RFC 5322 Author Domain. none means the sender publishes no DMARC record (common, not itself suspicious) and is distinct from fail, an actual alignment mismatch."`
 	Domain *string `json:"domain" nullable:"true" doc:"RFC 5322 Author Domain evaluated by DMARC; null when no single valid Author Domain exists."`
 	// Closed response enum: exhaustive DMARC policy classification.
 	Policy *DMARCPolicy `json:"policy" nullable:"true" enum:"none,quarantine,reject" doc:"Effective policy requested by the applicable DMARC record. This is sender-published metadata, not an action e2a took and not authentication strength."`

--- a/internal/eventpayload/payloads.go
+++ b/internal/eventpayload/payloads.go
@@ -71,7 +71,7 @@ type EmailReceivedData struct {
 	ConversationID string                    `json:"conversation_id,omitempty"`
 	HeaderFrom     *string                   `json:"header_from" nullable:"true" doc:"Parsed RFC 5322 From address; never replaced by Reply-To."`
 	EnvelopeFrom   *string                   `json:"envelope_from" nullable:"true" doc:"SMTP MAIL FROM address for inbound SMTP delivery; null for a null reverse path or providerless delivery."`
-	VerifiedDomain *string                   `json:"verified_domain" nullable:"true" doc:"DMARC-authenticated RFC 5322 From domain when authentication passed; null when authentication failed, was unavailable, or was not evaluated."`
+	VerifiedDomain *string                   `json:"verified_domain" nullable:"true" doc:"DMARC-authenticated RFC 5322 From domain when authentication passed; null when authentication failed, was unavailable, or was not evaluated. A null caused by dmarc.status=none (sender publishes no DMARC record) is common and NOT itself suspicious — distinct from dmarc.status=fail, an actual mismatch. Only DMARC ties a passing SPF or DKIM identity back to this header domain; a bare SPF or DKIM pass without DMARC does not."`
 	To             []string                  `json:"to" nullable:"false"`
 	CC             []string                  `json:"cc" nullable:"false"`
 	ReplyTo        []string                  `json:"reply_to" nullable:"false"`

--- a/internal/httpapi/messages.go
+++ b/internal/httpapi/messages.go
@@ -25,7 +25,7 @@ type MessageView struct {
 	ID             string                    `json:"id"`
 	HeaderFrom     *string                   `json:"header_from" nullable:"true" doc:"Parsed RFC 5322 From address for inbound mail or the sender identity for outbound mail; null when unavailable and never replaced by Reply-To."`
 	EnvelopeFrom   *string                   `json:"envelope_from" nullable:"true" doc:"SMTP MAIL FROM address for inbound SMTP delivery; null for outbound messages, a null reverse path, or providerless delivery."`
-	VerifiedDomain *string                   `json:"verified_domain" nullable:"true" doc:"RFC 5322 Author Domain validated by an aligned DMARC pass. Null for non-pass verdicts and deliveries without inbound SMTP evaluation. This authenticates the domain, not the address local part, individual sender, or message content."`
+	VerifiedDomain *string                   `json:"verified_domain" nullable:"true" doc:"RFC 5322 Author Domain validated by an aligned DMARC pass. Null for non-pass verdicts and deliveries without inbound SMTP evaluation — this includes dmarc.status=none (sender publishes no DMARC record, common and NOT itself suspicious) as well as dmarc.status=fail (an actual mismatch). Only DMARC ties a passing SPF or DKIM identity back to this header domain; a bare SPF or DKIM pass without DMARC does not. This authenticates the domain, not the address local part, individual sender, or message content."`
 	Authentication *emailauth.Authentication `json:"authentication" doc:"Inbound SMTP authentication evidence. Only dmarc.status=pass authenticates the RFC 5322 From domain; even a pass does not authenticate the mailbox local part, a person, or message content. Null means there was no authenticating inbound SMTP peer, as with outbound or providerless loopback delivery."`
 	To             []string                  `json:"to" nullable:"false"`
 	CC             []string                  `json:"cc" nullable:"false"`
@@ -253,7 +253,7 @@ type MessageSummaryView struct {
 	Direction      string   `json:"direction" enum:"inbound,outbound"`
 	HeaderFrom     *string  `json:"header_from" nullable:"true" doc:"Parsed RFC 5322 From address for inbound mail or the sender identity for outbound mail; null when unavailable and never replaced by Reply-To."`
 	EnvelopeFrom   *string  `json:"envelope_from" nullable:"true" doc:"SMTP MAIL FROM address for inbound SMTP delivery; null for outbound messages, a null reverse path, or providerless delivery."`
-	VerifiedDomain *string  `json:"verified_domain" nullable:"true" doc:"RFC 5322 Author Domain validated by an aligned DMARC pass. Null otherwise. This authenticates the domain, not the address local part, individual sender, or message content."`
+	VerifiedDomain *string  `json:"verified_domain" nullable:"true" doc:"RFC 5322 Author Domain validated by an aligned DMARC pass. Null otherwise — including dmarc.status=none (no DMARC record published, common and NOT itself suspicious), not just dmarc.status=fail (an actual mismatch). Only DMARC ties a passing SPF or DKIM identity back to this header domain; a bare SPF or DKIM pass without DMARC does not. This authenticates the domain, not the address local part, individual sender, or message content."`
 	To             []string `json:"to" nullable:"false"`
 	CC             []string `json:"cc,omitempty" nullable:"false"`
 	ReplyTo        []string `json:"reply_to,omitempty" nullable:"false" doc:"The parsed Reply-To header of an inbound message. Populated for inbound only; always empty for outbound (a Reply-To you SET on a send is a request-side field and is not echoed back here)."`
@@ -432,7 +432,7 @@ func (s *Server) registerMessages() {
 		Method:      http.MethodGet,
 		Path:        "/v1/agents/{email}/messages/{id}",
 		Summary:     "Get a message",
-		Description: "Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and canonical inbound authentication evidence.",
+		Description: "Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and canonical inbound authentication evidence. Fetching an unread inbound message marks it read as a side effect.",
 		Tags:        []string{"messages"},
 		Security:    []map[string][]string{{"bearer": {}}},
 	}, func(ctx context.Context, in *MessageIDParam) (*messageOutput, error) {

--- a/internal/httpapi/reviews.go
+++ b/internal/httpapi/reviews.go
@@ -33,7 +33,7 @@ type ReviewView struct {
 	Direction      string          `json:"direction" enum:"inbound,outbound"`
 	HeaderFrom     *string         `json:"header_from" nullable:"true" doc:"Parsed RFC 5322 From address for inbound mail or the sender identity for outbound mail; null when unavailable and never replaced by Reply-To."`
 	EnvelopeFrom   *string         `json:"envelope_from" nullable:"true" doc:"SMTP MAIL FROM address for inbound SMTP delivery; null for outbound messages, a null reverse path, or providerless delivery."`
-	VerifiedDomain *string         `json:"verified_domain" nullable:"true" doc:"RFC 5322 Author Domain validated by an aligned DMARC pass. Null otherwise. This authenticates the domain, not the address local part, individual sender, or message content."`
+	VerifiedDomain *string         `json:"verified_domain" nullable:"true" doc:"RFC 5322 Author Domain validated by an aligned DMARC pass. Null otherwise — including dmarc.status=none (no DMARC record published, common and NOT itself suspicious), not just dmarc.status=fail (an actual mismatch). Only DMARC ties a passing SPF or DKIM identity back to this header domain; a bare SPF or DKIM pass without DMARC does not. This authenticates the domain, not the address local part, individual sender, or message content."`
 	To             []string        `json:"to" nullable:"false"`
 	Subject        string          `json:"subject"`
 	ConversationID string          `json:"conversation_id,omitempty"`

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -323,7 +323,7 @@ type Message struct {
 	// remain separate from ReplyTo and from the legacy Sender projection.
 	HeaderFrom        string                    `json:"header_from" doc:"Parsed RFC 5322 From address for inbound mail; null in the export when unavailable and never replaced by Reply-To."`
 	EnvelopeFrom      string                    `json:"envelope_from" doc:"SMTP MAIL FROM address for inbound SMTP delivery; null in the export for outbound messages, a null reverse path, or providerless delivery."`
-	VerifiedDomain    *string                   `json:"verified_domain" nullable:"true" doc:"DMARC-authenticated RFC 5322 From domain when authentication passed; null when authentication failed, was unavailable, or was not evaluated."`
+	VerifiedDomain    *string                   `json:"verified_domain" nullable:"true" doc:"DMARC-authenticated RFC 5322 From domain when authentication passed; null when authentication failed, was unavailable, or was not evaluated. A null caused by dmarc.status=none (sender publishes no DMARC record) is common and NOT itself suspicious — distinct from dmarc.status=fail, an actual mismatch. Only DMARC ties a passing SPF or DKIM identity back to this header domain; a bare SPF or DKIM pass without DMARC does not."`
 	Authentication    *emailauth.Authentication `json:"authentication" doc:"Inbound SMTP authentication evidence. Only dmarc.status=pass authenticates the RFC 5322 From domain; even a pass does not authenticate the mailbox local part, a person, or message content. Null means there was no authenticating inbound SMTP peer, as with outbound or providerless loopback delivery."`
 	Recipient         string                    `json:"delivered_to"`
 	Subject           string                    `json:"subject"`

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -236,7 +236,17 @@ During a rotation you can pass a list of secrets — accepted if any matches:
 `construct_event(body, header, [old_secret, new_secret])`.
 
 `email.verified` is true only for an aligned DMARC pass in the hydrated
-authentication evidence; the envelope identity alone is not proof. `email.reply_targets` previews Reply-To-or-From
+authentication evidence; the envelope identity alone is not proof. `email.verified is False` /
+`verified_domain is None` is NOT by itself a spam or spoofing signal — it is
+common and expected for legitimate senders whose domain simply publishes no
+DMARC record (`authentication.dmarc.status == "none"`); treat that as
+"unproven," not "malicious," and reserve suspicion for an actual
+`authentication.dmarc.status == "fail"`. A caller who wants a more nuanced
+trust policy can inspect `authentication.spf`/`authentication.dkim`
+individually, but doing so reopens the spoofing gap DMARC closes: alignment
+(tying a passing SPF or DKIM identity back to the visible From domain) can
+only be computed when the sender publishes a DMARC record, so a bare SPF or
+DKIM pass proves nothing about the From header on its own. `email.reply_targets` previews Reply-To-or-From
 routing and may be attacker-controlled; the server resolves the stored MIME
 again when sending. `email.flagged` is
 the inbound policy-gate flag, not a complete content-scan verdict. Treat all

--- a/sdks/python/src/e2a/v1/generated/api/messages_api.py
+++ b/sdks/python/src/e2a/v1/generated/api/messages_api.py
@@ -1046,7 +1046,7 @@ class MessagesApi:
     ) -> MessageView:
         """Get a message
 
-        Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and canonical inbound authentication evidence.
+        Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and canonical inbound authentication evidence. Fetching an unread inbound message marks it read as a side effect.
 
         :param email: The agent's full email address. (required)
         :type email: str
@@ -1117,7 +1117,7 @@ class MessagesApi:
     ) -> ApiResponse[MessageView]:
         """Get a message
 
-        Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and canonical inbound authentication evidence.
+        Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and canonical inbound authentication evidence. Fetching an unread inbound message marks it read as a side effect.
 
         :param email: The agent's full email address. (required)
         :type email: str
@@ -1188,7 +1188,7 @@ class MessagesApi:
     ) -> RESTResponseType:
         """Get a message
 
-        Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and canonical inbound authentication evidence.
+        Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and canonical inbound authentication evidence. Fetching an unread inbound message marks it read as a side effect.
 
         :param email: The agent's full email address. (required)
         :type email: str

--- a/sdks/python/src/e2a/v1/generated/models/dmarc_result.py
+++ b/sdks/python/src/e2a/v1/generated/models/dmarc_result.py
@@ -29,7 +29,7 @@ class DMARCResult(BaseModel):
     detail: Optional[StrictStr] = Field(default=None, description="Free-text diagnostic for humans and logs. Never parse or branch on this field.")
     domain: Optional[StrictStr] = Field(description="RFC 5322 Author Domain evaluated by DMARC; null when no single valid Author Domain exists.")
     policy: Optional[StrictStr] = Field(description="Effective policy requested by the applicable DMARC record. This is sender-published metadata, not an action e2a took and not authentication strength.")
-    status: StrictStr = Field(description="DMARC verdict. Only pass authenticates domain-authorized use of the RFC 5322 Author Domain.")
+    status: StrictStr = Field(description="DMARC verdict. Only pass authenticates domain-authorized use of the RFC 5322 Author Domain. none means the sender publishes no DMARC record (common, not itself suspicious) and is distinct from fail, an actual alignment mismatch.")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["aligned_by", "detail", "domain", "policy", "status"]
 

--- a/sdks/python/src/e2a/v1/generated/models/email_received_data.py
+++ b/sdks/python/src/e2a/v1/generated/models/email_received_data.py
@@ -43,7 +43,7 @@ class EmailReceivedData(BaseModel):
     reply_to: List[StrictStr]
     subject: StrictStr
     to: List[StrictStr]
-    verified_domain: Optional[StrictStr] = Field(description="DMARC-authenticated RFC 5322 From domain when authentication passed; null when authentication failed, was unavailable, or was not evaluated.")
+    verified_domain: Optional[StrictStr] = Field(description="DMARC-authenticated RFC 5322 From domain when authentication passed; null when authentication failed, was unavailable, or was not evaluated. A null caused by dmarc.status=none (sender publishes no DMARC record) is common and NOT itself suspicious — distinct from dmarc.status=fail, an actual mismatch. Only DMARC ties a passing SPF or DKIM identity back to this header domain; a bare SPF or DKIM pass without DMARC does not.")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["agent_email", "attachments", "authentication", "cc", "conversation_id", "delivered_to", "direction", "envelope_from", "header_from", "message_id", "received_at", "reply_to", "subject", "to", "verified_domain"]
 

--- a/sdks/python/src/e2a/v1/generated/models/message.py
+++ b/sdks/python/src/e2a/v1/generated/models/message.py
@@ -71,7 +71,7 @@ class Message(BaseModel):
     text: Optional[StrictStr] = None
     to: Optional[List[StrictStr]] = None
     type: Optional[StrictStr] = None
-    verified_domain: Optional[StrictStr] = Field(description="DMARC-authenticated RFC 5322 From domain when authentication passed; null when authentication failed, was unavailable, or was not evaluated.")
+    verified_domain: Optional[StrictStr] = Field(description="DMARC-authenticated RFC 5322 From domain when authentication passed; null when authentication failed, was unavailable, or was not evaluated. A null caused by dmarc.status=none (sender publishes no DMARC record) is common and NOT itself suspicious — distinct from dmarc.status=fail, an actual mismatch. Only DMARC ties a passing SPF or DKIM identity back to this header domain; a bare SPF or DKIM pass without DMARC does not.")
     webhook_attempts: Optional[StrictInt] = None
     webhook_error: Optional[StrictStr] = None
     webhook_status: Optional[StrictStr] = None

--- a/sdks/python/src/e2a/v1/generated/models/message_summary_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/message_summary_view.py
@@ -48,7 +48,7 @@ class MessageSummaryView(BaseModel):
     size_bytes: Optional[StrictInt] = Field(default=None, description="RAW MIME byte length of the whole stored message (headers + bodies + encoded attachments as transported). Distinct from an attachment's size_bytes, which is its DECODED payload size. This value is the dominant term of the account's storage-quota accounting (usage.storage_bytes).")
     subject: StrictStr
     to: List[StrictStr]
-    verified_domain: Optional[StrictStr] = Field(description="RFC 5322 Author Domain validated by an aligned DMARC pass. Null otherwise. This authenticates the domain, not the address local part, individual sender, or message content.")
+    verified_domain: Optional[StrictStr] = Field(description="RFC 5322 Author Domain validated by an aligned DMARC pass. Null otherwise — including dmarc.status=none (no DMARC record published, common and NOT itself suspicious), not just dmarc.status=fail (an actual mismatch). Only DMARC ties a passing SPF or DKIM identity back to this header domain; a bare SPF or DKIM pass without DMARC does not. This authenticates the domain, not the address local part, individual sender, or message content.")
     webhook_error: Optional[StrictStr] = None
     webhook_status: Optional[StrictStr] = None
     additional_properties: Dict[str, Any] = {}

--- a/sdks/python/src/e2a/v1/generated/models/message_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/message_view.py
@@ -60,7 +60,7 @@ class MessageView(BaseModel):
     size_bytes: Optional[StrictInt] = Field(default=None, description="RAW MIME byte length of the whole stored message (headers + bodies + encoded attachments as transported). Distinct from attachments[].size_bytes, which is one attachment's DECODED payload size. This value is the dominant term of the account's storage-quota accounting (usage.storage_bytes).")
     subject: StrictStr
     to: List[StrictStr]
-    verified_domain: Optional[StrictStr] = Field(description="RFC 5322 Author Domain validated by an aligned DMARC pass. Null for non-pass verdicts and deliveries without inbound SMTP evaluation. This authenticates the domain, not the address local part, individual sender, or message content.")
+    verified_domain: Optional[StrictStr] = Field(description="RFC 5322 Author Domain validated by an aligned DMARC pass. Null for non-pass verdicts and deliveries without inbound SMTP evaluation — this includes dmarc.status=none (sender publishes no DMARC record, common and NOT itself suspicious) as well as dmarc.status=fail (an actual mismatch). Only DMARC ties a passing SPF or DKIM identity back to this header domain; a bare SPF or DKIM pass without DMARC does not. This authenticates the domain, not the address local part, individual sender, or message content.")
     webhook_error: Optional[StrictStr] = None
     webhook_status: Optional[StrictStr] = None
     additional_properties: Dict[str, Any] = {}

--- a/sdks/python/src/e2a/v1/generated/models/review_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/review_view.py
@@ -41,7 +41,7 @@ class ReviewView(BaseModel):
     review_status: StrictStr = Field(description="Hold state of this queue item. Open set; tolerate unknown values. Currently always pending_review (the queue lists held items).")
     subject: StrictStr
     to: List[StrictStr]
-    verified_domain: Optional[StrictStr] = Field(description="RFC 5322 Author Domain validated by an aligned DMARC pass. Null otherwise. This authenticates the domain, not the address local part, individual sender, or message content.")
+    verified_domain: Optional[StrictStr] = Field(description="RFC 5322 Author Domain validated by an aligned DMARC pass. Null otherwise — including dmarc.status=none (no DMARC record published, common and NOT itself suspicious), not just dmarc.status=fail (an actual mismatch). Only DMARC ties a passing SPF or DKIM identity back to this header domain; a bare SPF or DKIM pass without DMARC does not. This authenticates the domain, not the address local part, individual sender, or message content.")
     additional_properties: Dict[str, Any] = {}
     __properties: ClassVar[List[str]] = ["agent_email", "conversation_id", "created_at", "direction", "envelope_from", "flag_reason", "flagged", "header_from", "hold_reason", "id", "review_status", "subject", "to", "verified_domain"]
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -193,7 +193,17 @@ During a secret rotation you can pass an array of secrets — a delivery is
 accepted if any one matches: `constructEvent(body, header, [oldSecret, newSecret])`.
 
 `email.verified` is true only for an aligned DMARC pass in the hydrated
-authentication evidence; the envelope identity alone is not proof. `email.replyTargets` previews Reply-To-or-From
+authentication evidence; the envelope identity alone is not proof. `email.verified === false` /
+`verified_domain === null` is NOT by itself a spam or spoofing signal — it is
+common and expected for legitimate senders whose domain simply publishes no
+DMARC record (`authentication.dmarc.status === "none"`); treat that as
+"unproven," not "malicious," and reserve suspicion for an actual
+`authentication.dmarc.status === "fail"`. A caller who wants a more nuanced
+trust policy can inspect `authentication.spf`/`authentication.dkim`
+individually, but doing so reopens the spoofing gap DMARC closes: alignment
+(tying a passing SPF or DKIM identity back to the visible From domain) can
+only be computed when the sender publishes a DMARC record, so a bare SPF or
+DKIM pass proves nothing about the From header on its own. `email.replyTargets` previews Reply-To-or-From
 routing and may be attacker-controlled; the server resolves the stored MIME
 again when sending. `email.flagged` is
 the inbound policy-gate flag, not a complete content-scan verdict. Treat all

--- a/sdks/typescript/src/v1/generated/apis/MessagesApi.ts
+++ b/sdks/typescript/src/v1/generated/apis/MessagesApi.ts
@@ -225,7 +225,7 @@ export class MessagesApiRequestFactory extends BaseAPIRequestFactory {
     }
 
     /**
-     * Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and canonical inbound authentication evidence.
+     * Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and canonical inbound authentication evidence. Fetching an unread inbound message marks it read as a side effect.
      * Get a message
      * @param email The agent\&#39;s full email address.
      * @param id The message id, e.g. msg_abc123.

--- a/sdks/typescript/src/v1/generated/models/DMARCResult.ts
+++ b/sdks/typescript/src/v1/generated/models/DMARCResult.ts
@@ -29,7 +29,7 @@ export class DMARCResult {
     */
     'policy': DMARCResultPolicyEnum | null;
     /**
-    * DMARC verdict. Only pass authenticates domain-authorized use of the RFC 5322 Author Domain.
+    * DMARC verdict. Only pass authenticates domain-authorized use of the RFC 5322 Author Domain. none means the sender publishes no DMARC record (common, not itself suspicious) and is distinct from fail, an actual alignment mismatch.
     */
     'status': DMARCResultStatusEnum;
 

--- a/sdks/typescript/src/v1/generated/models/EmailReceivedData.ts
+++ b/sdks/typescript/src/v1/generated/models/EmailReceivedData.ts
@@ -48,7 +48,7 @@ export class EmailReceivedData {
     'subject': string;
     'to': Array<string>;
     /**
-    * DMARC-authenticated RFC 5322 From domain when authentication passed; null when authentication failed, was unavailable, or was not evaluated.
+    * DMARC-authenticated RFC 5322 From domain when authentication passed; null when authentication failed, was unavailable, or was not evaluated. A null caused by dmarc.status=none (sender publishes no DMARC record) is common and NOT itself suspicious — distinct from dmarc.status=fail, an actual mismatch. Only DMARC ties a passing SPF or DKIM identity back to this header domain; a bare SPF or DKIM pass without DMARC does not.
     */
     'verifiedDomain': string | null;
 

--- a/sdks/typescript/src/v1/generated/models/Message.ts
+++ b/sdks/typescript/src/v1/generated/models/Message.ts
@@ -73,7 +73,7 @@ export class Message {
     'to'?: Array<string> | null;
     'type'?: string;
     /**
-    * DMARC-authenticated RFC 5322 From domain when authentication passed; null when authentication failed, was unavailable, or was not evaluated.
+    * DMARC-authenticated RFC 5322 From domain when authentication passed; null when authentication failed, was unavailable, or was not evaluated. A null caused by dmarc.status=none (sender publishes no DMARC record) is common and NOT itself suspicious — distinct from dmarc.status=fail, an actual mismatch. Only DMARC ties a passing SPF or DKIM identity back to this header domain; a bare SPF or DKIM pass without DMARC does not.
     */
     'verifiedDomain': string | null;
     'webhookAttempts'?: number;

--- a/sdks/typescript/src/v1/generated/models/MessageSummaryView.ts
+++ b/sdks/typescript/src/v1/generated/models/MessageSummaryView.ts
@@ -62,7 +62,7 @@ export class MessageSummaryView {
     'subject': string;
     'to': Array<string>;
     /**
-    * RFC 5322 Author Domain validated by an aligned DMARC pass. Null otherwise. This authenticates the domain, not the address local part, individual sender, or message content.
+    * RFC 5322 Author Domain validated by an aligned DMARC pass. Null otherwise — including dmarc.status=none (no DMARC record published, common and NOT itself suspicious), not just dmarc.status=fail (an actual mismatch). Only DMARC ties a passing SPF or DKIM identity back to this header domain; a bare SPF or DKIM pass without DMARC does not. This authenticates the domain, not the address local part, individual sender, or message content.
     */
     'verifiedDomain': string | null;
     'webhookError'?: string;

--- a/sdks/typescript/src/v1/generated/models/MessageView.ts
+++ b/sdks/typescript/src/v1/generated/models/MessageView.ts
@@ -84,7 +84,7 @@ export class MessageView {
     'subject': string;
     'to': Array<string>;
     /**
-    * RFC 5322 Author Domain validated by an aligned DMARC pass. Null for non-pass verdicts and deliveries without inbound SMTP evaluation. This authenticates the domain, not the address local part, individual sender, or message content.
+    * RFC 5322 Author Domain validated by an aligned DMARC pass. Null for non-pass verdicts and deliveries without inbound SMTP evaluation — this includes dmarc.status=none (sender publishes no DMARC record, common and NOT itself suspicious) as well as dmarc.status=fail (an actual mismatch). Only DMARC ties a passing SPF or DKIM identity back to this header domain; a bare SPF or DKIM pass without DMARC does not. This authenticates the domain, not the address local part, individual sender, or message content.
     */
     'verifiedDomain': string | null;
     'webhookError'?: string;

--- a/sdks/typescript/src/v1/generated/models/ReviewView.ts
+++ b/sdks/typescript/src/v1/generated/models/ReviewView.ts
@@ -46,7 +46,7 @@ export class ReviewView {
     'subject': string;
     'to': Array<string>;
     /**
-    * RFC 5322 Author Domain validated by an aligned DMARC pass. Null otherwise. This authenticates the domain, not the address local part, individual sender, or message content.
+    * RFC 5322 Author Domain validated by an aligned DMARC pass. Null otherwise — including dmarc.status=none (no DMARC record published, common and NOT itself suspicious), not just dmarc.status=fail (an actual mismatch). Only DMARC ties a passing SPF or DKIM identity back to this header domain; a bare SPF or DKIM pass without DMARC does not. This authenticates the domain, not the address local part, individual sender, or message content.
     */
     'verifiedDomain': string | null;
 

--- a/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObjectParamAPI.ts
@@ -1626,7 +1626,7 @@ export class ObjectMessagesApi {
     }
 
     /**
-     * Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and canonical inbound authentication evidence.
+     * Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and canonical inbound authentication evidence. Fetching an unread inbound message marks it read as a side effect.
      * Get a message
      * @param param the request object
      */
@@ -1635,7 +1635,7 @@ export class ObjectMessagesApi {
     }
 
     /**
-     * Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and canonical inbound authentication evidence.
+     * Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and canonical inbound authentication evidence. Fetching an unread inbound message marks it read as a side effect.
      * Get a message
      * @param param the request object
      */

--- a/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/ObservableAPI.ts
@@ -1439,7 +1439,7 @@ export class ObservableMessagesApi {
     }
 
     /**
-     * Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and canonical inbound authentication evidence.
+     * Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and canonical inbound authentication evidence. Fetching an unread inbound message marks it read as a side effect.
      * Get a message
      * @param email The agent\&#39;s full email address.
      * @param id The message id, e.g. msg_abc123.
@@ -1465,7 +1465,7 @@ export class ObservableMessagesApi {
     }
 
     /**
-     * Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and canonical inbound authentication evidence.
+     * Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and canonical inbound authentication evidence. Fetching an unread inbound message marks it read as a side effect.
      * Get a message
      * @param email The agent\&#39;s full email address.
      * @param id The message id, e.g. msg_abc123.

--- a/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
+++ b/sdks/typescript/src/v1/generated/types/PromiseAPI.ts
@@ -1044,7 +1044,7 @@ export class PromiseMessagesApi {
     }
 
     /**
-     * Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and canonical inbound authentication evidence.
+     * Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and canonical inbound authentication evidence. Fetching an unread inbound message marks it read as a side effect.
      * Get a message
      * @param email The agent\&#39;s full email address.
      * @param id The message id, e.g. msg_abc123.
@@ -1056,7 +1056,7 @@ export class PromiseMessagesApi {
     }
 
     /**
-     * Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and canonical inbound authentication evidence.
+     * Fetch a single message (inbound or outbound) by id, scoped to an agent the caller owns. A trashed message remains readable by this direct GET and includes deleted_at until it is permanently purged (30 days after deletion by default, deployment-configurable); ordinary lists, conversations, reply targets, and forward targets exclude it. Includes the raw message and canonical inbound authentication evidence. Fetching an unread inbound message marks it read as a side effect.
      * Get a message
      * @param email The agent\&#39;s full email address.
      * @param id The message id, e.g. msg_abc123.


### PR DESCRIPTION
## Summary

Sibling to #612, #613, #614 — same live staging DMARC-alignment testing session. Two real senders confirmed correct-but-undocumented behavior:

- `josh@tokencanopy.com` (real SPF pass + real DKIM pass, but `tokencanopy.com` publishes **no** `_dmarc` record) → `authentication.dmarc.status: "none"`, `verified_domain: null`.
- A personal `@gmail.com` address (gmail.com publishes DMARC) → `authentication.dmarc.status: "pass"`, `aligned_by: ["spf","dkim"]`, `verified_domain: "gmail.com"`.

Both are correct — this is a **documentation-only** change, not a logic change. `emailauth/result.go`'s `Passed()`/`VerifiedDomain()` and all query/handler logic are untouched.

## The gap

Every `verified_domain` doc tag described `null` as covering "authentication failed, was unavailable, or was not evaluated" without distinguishing a real mismatch (DMARC `fail`, suspicious) from "no DMARC policy published" (DMARC `none`, extremely common for smaller/legitimate domains, not suspicious). Nothing warned an integrator against treating `verified_domain === null` / `email.verified === false` as a spam/spoofing signal on its own.

**Why the strict design is correct as-is:** DMARC is the only mechanism that ties a passing SPF or DKIM identity back to the *visible* `From:` header domain, via alignment — and alignment is only computable when a DMARC record exists (`SPFResult.Aligned`'s own doc tag: "null unless status is pass **and an applicable DMARC record was discovered**"). Without a DMARC record there's no default alignment mode (relaxed vs strict) to safely assume — that's itself a policy choice published in the record's `aspf`/`adkim` tags. So a bare SPF or DKIM pass, without DMARC, proves nothing about the `From:` header. `verified_domain: null` because of `none` is honestly "unknown," not "no."

## Changes

- Doc tags updated to distinguish `none` vs `fail`, and note that only DMARC (not a bare SPF/DKIM pass) authenticates the From domain:
  - `internal/httpapi/messages.go` — `MessageView.VerifiedDomain`, `MessageSummaryView.VerifiedDomain`
  - `internal/httpapi/reviews.go` — `ReviewView.VerifiedDomain`
  - `internal/identity/store.go:326`
  - `internal/eventpayload/payloads.go:74` — `EmailReceivedData.VerifiedDomain`
  - `internal/emailauth/result.go` — small addition to `DMARCResult.Status` distinguishing `none` from `fail`
- `api/openapi.yaml` and both SDKs' generated model files regenerated (`make spec && make generate-sdk`)
- `sdks/typescript/README.md` / `sdks/python/README.md` — added the same caveat where `email.verified` is already explained: a null/none result is common for legitimate senders without DMARC and is NOT a spam signal on its own; a caller wanting a more nuanced policy can inspect `authentication.spf`/`authentication.dkim` individually, with an explicit warning that doing so reopens the alignment gap DMARC-pass closes.
- Bundled small fix: `getMessage`'s OpenAPI description didn't mention that fetching an unread inbound message marks it read as a side effect (previously only in an internal Go doc comment on `GetMessageWithContent`). Added one sentence.

## Test plan

- [x] `go build ./...` — clean
- [x] `make spec` then `make generate-sdk` — regenerated `api/openapi.yaml` + `sdks/typescript/src/v1/generated/` + `sdks/python/src/e2a/v1/generated/`
- [x] `make spec-check` — passes against committed state
- [x] `make generate-sdk-check` — passes against committed state (includes the import-normalization unittest + `git diff --exit-code` on generated dirs)
- [x] `git diff` reviewed — Go doc tags + generated spec/SDK files + two READMEs + one bundled description sentence, nothing else

🤖 Generated with [Claude Code](https://claude.com/claude-code)