### PR TITLE
fix(tether): adopt the CLI 2.x contract — version floor, exit 7, agent_email

### DIFF
--- a/plugins/e2a/skills/tether/SKILL.md
+++ b/plugins/e2a/skills/tether/SKILL.md
@@ -51,10 +51,17 @@ the two directions use different mechanisms:
 
 ## Setup (once)
 
-> **Prerequisites:** Node (the transport is the `e2a` CLI ≥ the version pinned
-> in `lib.sh` — resolved from `$E2A_CLI`, then PATH, then fetched automatically
-> via `npx -y @e2a/cli@^MIN`, so there is nothing to install by hand) and
-> Python 3 (local state handling only).
+> **Prerequisites:** Node (the transport is the `e2a` CLI, currently the **2.x**
+> line pinned as `TETHER_MIN_CLI` in `lib.sh` — resolved from `$E2A_CLI`, then
+> PATH, then fetched automatically via `npx -y @e2a/cli@^MIN`, so there is
+> nothing to install by hand) and Python 3 (local state handling only).
+>
+> The range is **major-bounded on purpose**. tether parses the CLI's TSV columns
+> and branches on its exit codes, and a major bump is allowed to change both —
+> 2.0.0 did. So a CLI newer than the pinned major is *not* adopted automatically
+> (tether falls back to npx and says so); someone re-verifies tether against the
+> new major and bumps `TETHER_MIN_CLI`. Failing inert beats failing silently in
+> an unattended session.
 
 ### Fast path (recommended): `tether.sh setup`
 
@@ -103,9 +110,14 @@ e2a config set agent_email <inbox>       # or export E2A_AGENT_EMAIL
 
 or put the agent key + inbox in `~/.e2a-tether.env` and leave the CLI config alone.
 
-> If e2a returns `pending_review`, the message was not dispatched. `tether.sh`
-> detects this on every send: an affected intro makes `start` **refuse to arm**,
-> and an affected `update`/`ask` exits non-zero so the session fails loudly.
+> **Two ways a send can be accepted but never delivered — both fail loudly.**
+> `pending_review` means the message was held for approval; a terminal `failed`
+> means the server persisted a delivery failure. `tether.sh` detects both on
+> every send: an affected intro makes `start` **refuse to arm**, and an affected
+> `update`/`ask` exits non-zero (**2** = held, **5** = terminal failure) so the
+> session never mistakes either for a delivered message. A terminal failure is
+> **not** retryable — the server already recorded an outcome for that message
+> id, so re-sending risks a duplicate. Inspect it with `e2a messages get <id>`.
 
 ## First run (new user) — set them up, then tether
 
@@ -161,8 +173,11 @@ Let `T="${CLAUDE_PLUGIN_ROOT}/skills/tether/tether.sh"`.
    upload the file somewhere and send a link instead). Good moments: finished a
    slice, made a decision that's worth surfacing, hit a blocker, or before a
    long unattended stretch. Skip trivial
-   turns. If `update` reports `pending_review` (exit 2), the update did **not**
-   reach the user — stop and fix the inbox configuration before continuing.
+   turns. If `update` reports `pending_review` (**exit 2**), the update did
+   **not** reach the user — stop and fix the inbox configuration before
+   continuing. **Exit 5** means the send reached a terminal `failed` outcome:
+   also undelivered, but do **not** re-send it (the server already recorded that
+   message id) — inspect it with `e2a messages get <id>` first.
 4. **Need a decision from the user? Ask by email — never the terminal.** Run
    `"$T" ask "<question>"` (in the background); it emails the question and blocks
    until the user replies, then prints the answer. `--attach <file>` works here
@@ -173,8 +188,10 @@ Let `T="${CLAUDE_PLUGIN_ROOT}/skills/tether/tether.sh"`.
    so a background `listen` pauses and can't swallow your answer). Handle its exit
    codes: **exit 3** = timed out with no reply (default 30m) — re-`ask`, send a
    nudge `update`, or keep working and listening, but never fall back to a
-   terminal prompt; **exit 4** = the question was not dispatched (fix the inbox
-   configuration).
+   terminal prompt; **exit 4** = the question was held for review and not
+   dispatched (fix the inbox configuration); **exit 5** = the question hit a
+   terminal `failed` outcome — it never reached the user, so `ask` returns
+   immediately instead of blocking for the full timeout; don't blindly re-ask.
 5. **Listen for the whole window**: run `"$T" listen` **in the background**. It
    waits on the CLI's WebSocket (real-time, no tokens while waiting; degrades
    to polling if the WS is unavailable) and exits with either:

--- a/plugins/e2a/skills/tether/lib.sh
+++ b/plugins/e2a/skills/tether/lib.sh
@@ -71,10 +71,29 @@ t_now_iso()  { python3 -c 'import datetime;print(datetime.datetime.now(datetime.
 # --- e2a CLI resolution --------------------------------------------------------
 # The minimum CLI this skill's flags require (send --conversation-id, reply
 # --html-file/--attach, messages list TSV, listen --once, exit-code contract).
-# Bump in lockstep with any new flag use; the npx pin below follows it.
-TETHER_MIN_CLI="1.6.0"
+#
+# tether depends on the CLI's *contract*, not just its flags: the TSV column
+# order of `messages list`, the exit-code table (0/3/4/5/7), and the
+# whoami --json field names. A MAJOR bump is exactly the event that is allowed
+# to change all three — CLI 2.0.0 renamed AccountView.agent_address to
+# agent_email and added exit 7, both of which tether had to be taught. So the
+# accepted range is MAJOR-BOUNDED on BOTH resolution paths:
+#
+#   npx  → @e2a/cli@^2.0.0   (caret: 2.x, never 3.x)
+#   PATH → >= 2.0.0 AND major == 2
+#
+# The caret is deliberate, not an oversight. A bare floor (">=2.0.0") would
+# auto-adopt a future 3.0.0 whose renames silently break reply pickup — the
+# unattended-session failure this whole harness exists to avoid. Capping means
+# a new major is *inert* until someone verifies tether against it, which is the
+# safe direction to fail.
+#
+# MAINTENANCE: bump this on every CLI MAJOR (not just on new flag use — that
+# was the rule that let the 1.6.0 floor go stale across 2.0.0), and re-verify
+# the TSV columns, exit codes, and whoami fields before you do.
+TETHER_MIN_CLI="2.0.0"
 
-# t_ver_ge "<e2a 1.6.2>" "1.6.0" → 0 when the version (last token) >= min.
+# t_ver_ge "<e2a 2.0.1>" "2.0.0" → 0 when the version (last token) >= min.
 t_ver_ge() {
   python3 -c 'import sys
 def v(s):
@@ -83,10 +102,27 @@ def v(s):
 sys.exit(0 if v(sys.argv[1]) >= v(sys.argv[2]) else 1)' "$1" "$2" 2>/dev/null
 }
 
+# t_ver_major "<e2a 2.0.1>" → 2 (0 when unparseable).
+t_ver_major() {
+  python3 -c 'import sys
+s = sys.argv[1].strip()
+s = s.split()[-1] if s else "0"
+p = s.lstrip("v").split(".")[0]
+print(p if p.isdigit() else "0")' "$1" 2>/dev/null || echo 0
+}
+
+# t_ver_supported "<e2a 2.0.1>" → 0 when the version is inside tether's
+# supported range: >= TETHER_MIN_CLI and the same major.
+t_ver_supported() {
+  t_ver_ge "$1" "$TETHER_MIN_CLI" || return 1
+  [ "$(t_ver_major "$1")" = "$(t_ver_major "$TETHER_MIN_CLI")" ]
+}
+
 # t_cli <args...> — run the e2a CLI, bounded by a hard timeout. Resolution:
 #   1. $E2A_CLI override (multi-word ok, e.g. "node /repo/cli/dist/bin/e2a.js";
 #      paths containing SPACES are unsupported — use a wrapper script)
-#   2. `e2a` on PATH when --version >= TETHER_MIN_CLI (stale → warn, fall through)
+#   2. `e2a` on PATH when --version is inside tether's supported major range
+#      (too old OR too new → warn, fall through)
 #   3. npx -y @e2a/cli@^MIN  (auto-fetch; nothing for the user to install)
 # The result is exported (T_CLI_RESOLVED) so the many $(t_cli …) subshells
 # don't re-probe versions or re-print the staleness warning on every API call.
@@ -106,11 +142,19 @@ t_cli_resolve() {
       T_CLI=()
       return 127
     fi
-  elif command -v e2a >/dev/null 2>&1 && t_ver_ge "$(e2a --version 2>/dev/null)" "$TETHER_MIN_CLI"; then
+  elif command -v e2a >/dev/null 2>&1 && t_ver_supported "$(e2a --version 2>/dev/null)"; then
     T_CLI=(e2a)
   elif command -v npx >/dev/null 2>&1; then
     if command -v e2a >/dev/null 2>&1; then
-      echo "tether: global e2a CLI is older than ${TETHER_MIN_CLI} — using npx for this run (upgrade: npm i -g @e2a/cli@latest)" >&2
+      local gv; gv="$(e2a --version 2>/dev/null)"
+      # "too new" and "too old" need OPPOSITE fixes — never collapse them into
+      # one "upgrade" hint. A newer MAJOR is unverified against tether's TSV/
+      # exit-code contract, so upgrading further would make it worse.
+      if t_ver_ge "$gv" "$TETHER_MIN_CLI"; then
+        echo "tether: global e2a CLI (${gv}) is a NEWER major than tether supports (^${TETHER_MIN_CLI}) — using npx to pin ${TETHER_MIN_CLI%%.*}.x for this run. If that major is known good, bump TETHER_MIN_CLI in lib.sh." >&2
+      else
+        echo "tether: global e2a CLI (${gv}) is older than ${TETHER_MIN_CLI} — using npx for this run (upgrade: npm i -g @e2a/cli@latest)" >&2
+      fi
     fi
     T_CLI=(npx -y "@e2a/cli@^${TETHER_MIN_CLI}")
   else
@@ -141,7 +185,7 @@ t_cli() {
 # Human-readable description of what t_cli would run (for status/_selftest).
 t_cli_desc() {
   if [ -n "${E2A_CLI:-}" ]; then echo "\$E2A_CLI (${E2A_CLI})"
-  elif command -v e2a >/dev/null 2>&1 && t_ver_ge "$(e2a --version 2>/dev/null)" "$TETHER_MIN_CLI"; then
+  elif command -v e2a >/dev/null 2>&1 && t_ver_supported "$(e2a --version 2>/dev/null)"; then
     echo "e2a on PATH ($(e2a --version 2>/dev/null))"
   elif command -v npx >/dev/null 2>&1; then echo "npx @e2a/cli@^${TETHER_MIN_CLI}"
   else echo "MISSING (no e2a, no npx)"; fi
@@ -264,16 +308,30 @@ except Exception:print(2147483647)' "$exp"
 }
 
 # --- e2a API (via the CLI) -----------------------------------------------------
-# The CLI's exit-code contract does the heavy lifting: 0 sent / 3 HELD (any
-# non-"sent" status — accepted but NOT delivered) / 5 permanent request error /
-# 4 auth / 1 transient. These wrappers map it onto tether's internal codes
-# (0 ok, 2 held, 3 anchor-not-repliable) so tether.sh stays unchanged above.
+# The CLI's exit-code contract does the heavy lifting (CLI 2.x):
+#   0 sent OR accepted (durably queued — 2.0.0 stopped lumping `accepted` in
+#     with HELD, so a queued send no longer looks like a review hold)
+#   3 HELD (status pending_review — accepted by the API, NOT delivered)
+#   4 auth / 5 permanent request error / 7 terminal send outcome / 1 transient
+#
+# Exit 7 (SEND_OUTCOME) is new in 2.0.0: the server persisted a terminal
+# `failed` (or an unrecognized) status and returned a message id, so the send
+# must NOT be retried — a retry could duplicate. Before this mapping it fell
+# into the `*)` transient bucket, and because the CLI still prints the message
+# id on stdout, tether saw a non-empty id with a non-fatal code and cheerfully
+# reported "update sent" for a message that never went anywhere.
+#
+# These wrappers map the CLI's codes onto tether's internal ones:
+#   0 ok / 2 held / 3 anchor-not-repliable / 4 auth / 5 terminal (do not retry)
+#   1 transient
 # The CLI reads E2A_API_KEY / E2A_AGENT_EMAIL / E2A_URL straight from the
 # environment t_load_config resolves — no flag plumbing needed.
 
 # t_api_send <to> <subject> <body> <conversation_id> → prints message_id;
 # returns 2 if the send was HELD so the caller can refuse to arm; 4 = auth
-# failure (key revoked/invalid — callers must fail loud, not retry).
+# failure (key revoked/invalid — callers must fail loud, not retry); 5 = the
+# send reached a terminal failed/unknown outcome (do NOT retry — inspect the
+# printed message id instead).
 # The body travels via --body-file: free text may legitimately start with
 # "--" (which the flag parser rejects) and may exceed argv limits.
 t_api_send() {
@@ -283,7 +341,7 @@ t_api_send() {
   mid="$(t_cli send --to "$1" --subject "$2" --body-file "$bf" --conversation-id "$4")"; rc=$?
   rm -f "$bf"
   printf '%s' "$mid"
-  case "$rc" in 0) return 0;; 3) return 2;; 4) return 4;; *) return 1;; esac
+  case "$rc" in 0) return 0;; 3) return 2;; 4) return 4;; 7) return 5;; *) return 1;; esac
 }
 
 # Attachment cap: 15 MB of raw bytes total per send. Base64 inflates ~4/3 and
@@ -308,9 +366,11 @@ if total>maxb:
 # t_api_reply <in_reply_to_id> <body> [html_file] [attach_file ...] → prints
 # new message_id. NOTE the third arg is now an HTML *file path* (the CLI takes
 # --html-file and derives the plain-text fallback itself when body is empty).
-# Returns: 0 sent; 2 HELD (accepted, NOT delivered — CLI exit 3); 3 anchor not
-# repliable here (CLI exit 5, permanent request error) so t_reply_anchored can
-# try the next anchor; 4 auth failure (fail loud, don't retry); 1 anything
+# Returns: 0 sent; 2 HELD (pending_review, NOT delivered — CLI exit 3); 3 anchor
+# not repliable here (CLI exit 5, permanent request error) so t_reply_anchored
+# can try the next anchor; 4 auth failure (fail loud, don't retry); 5 terminal
+# send outcome (CLI exit 7 — the server persisted a failure; do NOT retry and do
+# NOT fall through to another anchor, which would risk a duplicate); 1 anything
 # else (transient).
 t_api_reply() {
   local rid="$1" body="${2:-}" htmlfile="${3:-}"
@@ -328,7 +388,7 @@ t_api_reply() {
   mid="$(t_cli "${args[@]}")"; rc=$?
   [ -n "$bf" ] && rm -f "$bf"
   printf '%s' "$mid"
-  case "$rc" in 0) return 0;; 3) return 2;; 4) return 4;; 5) return 3;; *) return 1;; esac
+  case "$rc" in 0) return 0;; 3) return 2;; 4) return 4;; 5) return 3;; 7) return 5;; *) return 1;; esac
 }
 
 # t_reply_anchored <body> <html_file> [attach_file ...] → send a threaded reply,
@@ -347,6 +407,10 @@ t_reply_anchored() {
     case " $tried " in *" $rid "*) continue;; esac
     tried="$tried $rid"
     mid="$(t_api_reply "$rid" "$body" "$html" "$@")"; rc=$?
+    # ONLY 3 (anchor not repliable) advances to the next anchor. A terminal
+    # outcome (5) means the server already persisted this send — retrying it
+    # against a different anchor would risk delivering a duplicate — so it
+    # propagates immediately, as do held (2) and auth (4).
     [ "$rc" = "3" ] && continue   # anchor not repliable here — try the next one
     printf '%s' "$mid"; return $rc
   done

--- a/plugins/e2a/skills/tether/tether.env.example
+++ b/plugins/e2a/skills/tether/tether.env.example
@@ -7,10 +7,15 @@ export E2A_API_KEY="e2a_agt_..."             # agent-scoped e2a API key
 export E2A_AGENT_EMAIL="tether@you.example"   # the sending/receiving agent
 
 # Optional
+# E2A_URL is the CLI's DEPLOYMENT ROOT (it serves the dashboard and proxies /v1)
+# — not the bare API host. Do not use E2A_BASE_URL/E2A_API_URL here: those name
+# the API host and configure the SDKs; the CLI does not read them.
 export E2A_URL="https://e2a.dev"                # self-host: your e2a deployment root
 export E2A_TETHER_POLL_INTERVAL="20"            # fallback poll cadence (WS wait is primary)
 export E2A_TETHER_ASK_TIMEOUT="1800"            # seconds `ask` blocks for an answer
 # export E2A_CLI="node /path/to/cli/dist/bin/e2a.js"  # override the e2a CLI (default: PATH, then npx)
-# Fallback: if these are unset, tether reads ~/.e2a/config.json from `e2a login`
-# (after `e2a login --agent <inbox>` that's already a least-privilege agent key).
-# Prefer `tether.sh setup` over hand-editing this file.
+# Fallback: if these are unset, tether reads ~/.e2a/config.json from `e2a login`.
+# That alone is NOT enough: `e2a login` saves an ACCOUNT-scoped key and does not
+# set agent_email. Mint a least-privilege inbox key with
+# `e2a keys create --agent <inbox>` — or just run `tether.sh setup`, which does
+# the whole bootstrap, rather than hand-editing this file.

--- a/plugins/e2a/skills/tether/tether.sh
+++ b/plugins/e2a/skills/tether/tether.sh
@@ -120,6 +120,15 @@ question or instruction; reply \"stop\" to end early.
       echo "tether: intro NOT sent — auth failed (key invalid/revoked). Check 'e2a whoami' / E2A_API_KEY."
       exit 4
     fi
+    if [ "$rc" = "5" ]; then
+      # Terminal server-side outcome. The message id IS populated (the send was
+      # persisted), so this must be checked before the empty-id test below —
+      # otherwise it reads as a success and arms a session whose intro never
+      # reached the user.
+      echo "tether: intro reached a terminal FAILED outcome (${mid}) — it was NOT delivered, so NOT arming."
+      echo "        Do not retry blindly; inspect it: e2a messages get ${mid}"
+      exit 5
+    fi
     [ -n "$mid" ] || { echo "tether: intro send failed (check credentials and base URL)"; exit 1; }
     if [ "$rc" = "2" ]; then
       echo "tether: intro returned pending_review — it was not dispatched, so NOT arming."
@@ -158,6 +167,15 @@ question or instruction; reply \"stop\" to end early.
     if [ "$rc" = "4" ]; then
       echo "tether: update NOT sent — auth failed (key invalid/revoked). Check 'e2a whoami' / E2A_API_KEY."
       exit 4
+    fi
+    if [ "$rc" = "5" ]; then
+      # Checked BEFORE the empty-id test and before last_message_id is advanced:
+      # the CLI prints the id of a terminally-failed send, so the old code fell
+      # through to the success path and reported "update sent" for a message the
+      # user never received.
+      echo "tether: update reached a terminal FAILED outcome (${mid}) — it did NOT reach the user."
+      echo "        Do not retry blindly; inspect it: e2a messages get ${mid}"
+      exit 5
     fi
     if [ -z "$mid" ]; then
       echo "tether: update send failed (if anchors are exhausted, 'tether.sh stop' and start a fresh session)"
@@ -257,6 +275,14 @@ question or instruction; reply \"stop\" to end early.
       echo "tether: ask NOT sent — auth failed (key invalid/revoked). Check 'e2a whoami' / E2A_API_KEY."
       exit 1
     fi
+    if [ "$rc" = "5" ]; then
+      # A terminally-failed question must never fall through to the wait loop:
+      # the user never got it, so blocking would burn the full ask timeout
+      # waiting for an answer to a question that was never asked.
+      echo "tether: question reached a terminal FAILED outcome (${mid}) — it did NOT reach the user, so not waiting."
+      echo "        Do not retry blindly; inspect it: e2a messages get ${mid}"
+      exit 5
+    fi
     [ -n "$mid" ] || { echo "tether: ask send failed"; exit 1; }
     t_state_set last_message_id "$mid"
     if [ "$rc" = "2" ]; then
@@ -308,8 +334,12 @@ question or instruction; reply \"stop\" to end early.
 try:print(json.load(sys.stdin).get("scope",""))
 except Exception:print("")')"
     if [ "$scope" = "agent" ]; then
+      # `agentEmail`, not the pre-2.0.0 `agentAddress`: CLI 2.0.0 renamed
+      # AccountView.agent_address → agent_email as part of the agent-reference
+      # unification. Reading the old name silently yielded an empty string, so
+      # this line reported "already holds an agent-scoped key ()".
       bound="$(printf '%s' "$who" | python3 -c 'import json,sys
-try:print(json.load(sys.stdin).get("agentAddress",""))
+try:print(json.load(sys.stdin).get("agentEmail",""))
 except Exception:print("")')"
       echo "tether setup: the CLI already holds an agent-scoped key (${bound}) — nothing to mint."
       echo "              tether will pick it up from ~/.e2a/config.json; run 'tether.sh status' to confirm."
@@ -456,9 +486,40 @@ except Exception:print("")')"
     rm -rf "$sb" "$armf"
 
     echo "# CLI resolution:"
-    ck "version compare: 1.6.2 >= 1.6.0" "$(t_ver_ge "e2a 1.6.2" "1.6.0" && echo yes)" "yes"
-    ck "version compare: 1.5.9 <  1.6.0" "$(t_ver_ge "e2a 1.5.9" "1.6.0" || echo no)" "no"
+    ck "version compare: 2.0.2 >= 2.0.0" "$(t_ver_ge "e2a 2.0.2" "2.0.0" && echo yes)" "yes"
+    ck "version compare: 1.6.0 <  2.0.0" "$(t_ver_ge "e2a 1.6.0" "2.0.0" || echo no)" "no"
+    ck "major parse" "$(t_ver_major "e2a 2.0.1")" "2"
+    # The floor must track the CLI major tether was actually verified against.
+    ck "min CLI is 2.x" "$(t_ver_major "$TETHER_MIN_CLI")" "2"
+    # Supported range is major-BOUNDED at both ends: the pre-2.0.0 CLI is too
+    # old, and an unverified next major is too new (it may rename the TSV
+    # columns / whoami fields again, exactly as 2.0.0 did).
+    ck "supported: 2.0.0"      "$(t_ver_supported "e2a 2.0.0" && echo yes)" "yes"
+    ck "supported: 2.9.3"      "$(t_ver_supported "e2a 2.9.3" && echo yes)" "yes"
+    ck "unsupported: 1.6.0 (too old)" "$(t_ver_supported "e2a 1.6.0" || echo no)" "no"
+    ck "unsupported: 3.0.0 (too new)" "$(t_ver_supported "e2a 3.0.0" || echo no)" "no"
     ck "E2A_CLI override is honored" "$(E2A_CLI="/bin/echo e2a-override" bash -c '. "'"${here}"'/lib.sh"; t_cli ping' 2>/dev/null)" "e2a-override ping"
+
+    echo "# CLI exit-code mapping (2.x contract):"
+    # A stub CLI that prints a message id and exits 7 (SEND_OUTCOME) — the
+    # server persisted a terminal `failed`. The id being non-empty is the trap:
+    # tether must NOT read that as a delivered message.
+    stub7=/tmp/tether-selftest-exit7.sh
+    printf '#!/usr/bin/env bash\necho msg_selftest_terminal\nexit 7\n' > "$stub7"; chmod +x "$stub7"
+    armf7=/tmp/tether-selftest-exit7.json
+    printf '{"armed":"1","conversation_id":"tether-x","to":"a@b.c","last_message_id":"msg_anchor"}' > "$armf7"
+    out="$(env E2A_API_KEY='e2a_agt_selftest123' E2A_AGENT_EMAIL='selftest@agents.e2a.dev' \
+      E2A_CLI="$stub7" TETHER_STATE="$armf7" bash "${here}/tether.sh" update "terminal failure" 2>&1)"; rc=$?
+    ck "update: CLI exit 7 → exit 5, reported NOT delivered" \
+      "$rc:$(printf '%s' "$out" | grep -c 'terminal FAILED outcome')" "5:1"
+    # And the state pointer must NOT advance onto an undelivered message.
+    ck "update: exit 7 leaves last_message_id untouched" \
+      "$(TETHER_STATE="$armf7" bash -c '. "'"${here}"'/lib.sh"; t_state_get last_message_id')" "msg_anchor"
+    out="$(env E2A_API_KEY='e2a_agt_selftest123' E2A_AGENT_EMAIL='selftest@agents.e2a.dev' \
+      E2A_CLI="$stub7" TETHER_STATE="$armf7" bash "${here}/tether.sh" ask "will this block?" 2>&1)"; rc=$?
+    ck "ask: CLI exit 7 → exit 5, does not wait" \
+      "$rc:$(printf '%s' "$out" | grep -c 'not waiting')" "5:1"
+    rm -f "$stub7" "$armf7" "${armf7%.json}.ask.lock" "${armf7}.lock"
 
     echo "# attachments:"
     af=/tmp/tether-selftest-att.txt; printf 'hello attachment' > "$af"


### PR DESCRIPTION
**Depends on #618** (the `@e2a/cli` 2.0.0 version bump) and should merge **after** it. Also note: tether's npx fallback resolves `@e2a/cli@^2.0.0`, so **CLI 2.0.0 must actually be published to npm** before that path works for users who don't have the CLI installed. Until then, `$E2A_CLI` / a global install still resolve normally.

## The bug

`plugins/e2a/skills/tether/lib.sh` pinned `TETHER_MIN_CLI="1.6.0"` and built its npx fallback as `@e2a/cli@^1.6.0`. A caret range never crosses a major, so once CLI 2.0.0 publishes, tether resolves `1.6.x` forever and never picks up 2.x.

Bumping the number alone would have been wrong. tether was only safe because it was pinned to old behavior — point it at 2.x and the breaking changes land on it. So each touchpoint was checked against the CLI source on this branch and against a live staging deployment.

## Touchpoint audit

| tether touchpoint | 2.0.0 change | Broken? |
|---|---|---|
| `messages list` TSV cols 1/2/3 (`t_poll_once`) | `message_id`→`id`, `from`→`headerFrom` | **No** — renames are field names; TSV is still positionally `id⇥headerFrom⇥createdAt` |
| `messages get --text` | unchanged | No |
| `send` exit codes (`t_api_send`) | `accepted` 3→0; new **7** | **Yes** — exit 7 |
| `reply` exit codes (`t_api_reply`) | new **7** | **Yes** — exit 7 |
| `listen --once --until` exits 0/6 (`t_ws_wait`) | unchanged; stdout discarded | No |
| `whoami --json` → `.scope` | unchanged | No |
| `whoami --json` → `.agentAddress` | renamed to `agent_email` (#436) | **Yes** |
| `keys create --json` → `.key` | unchanged | No |
| `agents list` col 1, `agents get/create` | unchanged | No |
| `config get shared_domain`, `config set api_key\|agent_email` | still valid / still settable | No |
| `E2A_URL` / `E2A_BASE_URL` | CLI reads `E2A_URL`; ignores `E2A_BASE_URL` | No — tether already migrated and unsets the stale name |

Two genuine breaks, both reproduced live before fixing:

**1. `whoami --json` field rename.** `tether.sh setup` read `agentAddress`, which silently yielded `""`:
```
tether setup: the CLI already holds an agent-scoped key () — nothing to mint.
```

**2. Exit 7 (`SEND_OUTCOME`) fell into the `*)` transient bucket.** The CLI still prints the message id of a terminally-failed send, so tether saw a non-empty id with a non-fatal code:
```
tether: update sent (msg_terminalfailure0000) [thread tether-…]
update rc=0
```
A message the user never received, reported as delivered — the exact silent-failure class `cli/src/exit.ts` says "bit the tether harness twice".

## Changes

- `TETHER_MIN_CLI` → `2.0.0`; npx pin follows as `@e2a/cli@^2.0.0`.
- The **PATH branch now enforces the same bound as npx** (`>= floor` AND same major) via new `t_ver_major` / `t_ver_supported`. Previously PATH had an open-ended floor while npx capped — so a future global 3.x would have been used unchecked.
- CLI exit 7 → new tether code **5** across `t_api_send`/`t_api_reply`, handled in `start` (refuses to arm), `update`, and `ask` (returns immediately rather than blocking the full 30m timeout). `t_reply_anchored` deliberately does **not** fall through to the next anchor on 5 — the server already persisted an outcome for that id, so a retry risks a duplicate.
- `agentAddress` → `agentEmail` in `setup`.
- SKILL.md: documents exit 5 and the major-bounded range. tether.env.example: drops `e2a login --agent <inbox>` (removed in 2.0.0), clarifies `E2A_URL` vs `E2A_BASE_URL`/`E2A_API_URL`.
- Selftest: supported-range boundaries (too old / too new) and the exit-7 mapping for `update` + `ask`, including that a terminal failure does not advance `last_message_id`.

## On the range expression

`^2.0.0`, not a bare `>=2.0.0` floor. tether parses TSV columns and branches on exit codes, so a **major bump is precisely the event allowed to break it** — this PR exists because one did. A bare floor would auto-adopt a future 3.0.0 and silently break reply pickup in an unattended session, which is the failure mode the whole harness exists to avoid. Capping makes a new major *inert* until someone verifies tether against it; failing inert beats failing silently. The maintenance note in `lib.sh` now says to bump on every CLI major (the old rule — "bump on new flag use" — is what let the 1.6.0 floor go stale), and the stale-CLI warning distinguishes "too old" from "too new", which need opposite fixes.

## Left alone on purpose

`listen --once` still emits the WS envelope's `message_id` while `messages list` emits the REST model's `id`. Those are legitimately different objects, not drift to reconcile — and tether discards `listen`'s stdout anyway (pure wake signal).

`accepted` now exiting 0 instead of 3 is strictly better for tether: a durably-queued send no longer trips the "held → refuse to arm" path.

## Verification

Built the CLI locally from this branch (`sdks/typescript` first, then `cli/`) since 2.0.0 isn't on npm:

- `cli/` test suite: **171 passed** (14 files).
- `tether.sh _selftest`: **PASS**, including the new range + exit-7 cases.
- **Real end-to-end against `https://api-staging.e2a.dev`** with a throwaway bootstrapped account: `setup` (both the mint path and the already-agent-scoped path), `start`, `update`, `poll`, `ask`, and `listen` with a live WebSocket reply round-trip (`REPLY_RECEIVED` with correct sender + body). Raw TSV inspected byte-wise to confirm the column positions.
- The anchor-fallback path was exercised incidentally: a stale anchor 404'd (CLI exit 5 → tether 3), tether advanced to the next anchor and delivered.

Throwaway staging account deleted afterwards (`DELETE /v1/account` → 200, 12 messages / 1 agent / 2 keys / user removed; the key now 401s).

Not exercised: a *real* server-side terminal `failed` outcome — staging gave no way to force one, so exit 7 was verified with a stub CLI that reproduces the contract (prints an id, exits 7). Also not exercised: agent→agent inbound (staging has no external MX; loopback self-send only).

## Follow-up (not fixed here — `cli/` is #618's scope)

`e2a messages list | head` crashes with an unhandled `EPIPE` instead of exiting quietly. Cosmetic, but it makes the CLI noisy in ordinary shell pipelines. Worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)