### PR TITLE
docs(ts-sdk): fix stale Upgrading-to-5.2 section

### DIFF
--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -13,16 +13,21 @@ independent of the API version path (`/v1`): SDK 5.x targets the e2a v1 API.
 
 ## Upgrading to 5.2
 
-The reserved-word wire field `from` is now uniformly exposed as `from_` on
-generated models and the `listMessages` sender filter (was the
-private-looking `_from`, an OpenAPI Generator escape artifact). Affected
-models: `Message`, `MessageView`, `MessageSummaryView`, `ReviewView`,
-`EmailReceivedData`, `EmailSentData`, `EmailFailedData`. The wire JSON is
-unchanged — requests and responses still carry `from`; only the generated
-TS field name changed. The hand-written webhook/WS payload interfaces in
-`webhook-signature.ts` keep the literal `from` property (those are raw-JSON
-shapes, not generated models). Migrate: `message._from` → `message.from_`;
-`list(..., { _from })` → `{ from_ }`.
+Inbound sender and authentication fields now use the final DMARC-aligned
+contract. `Message`, `MessageView`, `MessageSummaryView`, `ReviewView`, and
+`EmailReceivedData` expose the literal RFC 5322 `headerFrom`, SMTP
+`envelopeFrom`, nullable `verifiedDomain`, and structured `authentication`
+evidence. The former inbound `from`/`from_` projection is removed from these
+models; Reply-To remains separate. A non-null `verifiedDomain` means DMARC
+passed for that From domain, not that the mailbox local part, person, or
+message content was authenticated.
+
+`authentication` is `null` for outbound messages and providerless loopback
+delivery. Guard it before reading `authentication.dmarc`. The outbound-only
+`EmailSentData`/`EmailFailedData` webhook payloads and the `listMessages`
+sender filter are unaffected and still use `from_` (an OpenAPI Generator
+escape artifact for the reserved word `from`) — that request parameter is not
+an inbound identity projection.
 
 ## Upgrading to 5.1
 


### PR DESCRIPTION
## Summary

Docs-only fix found during a Markdown documentation audit.

`sdks/typescript/README.md`'s "Upgrading to 5.2" section described an earlier `from` → `from_` rename that's since been superseded — the field moved again to the final DMARC-aligned contract (`headerFrom`/`envelopeFrom`/`verifiedDomain`/`authentication`), confirmed in `sdks/typescript/src/v1/generated/models/{MessageView,Message,MessageSummaryView,ReviewView,EmailReceivedData}.ts`.

`sdks/python/README.md` already documents this exact rename correctly under its own "Upgrading to 5.2" heading — the commit that shipped the API change updated the Python README plus both SDK CHANGELOGs, but missed the TypeScript README. This PR mirrors that wording so TypeScript users get the same upgrade guidance Python users already have.

No code changes — `sdks/typescript/README.md` only.

## Test plan

- [x] Read-only doc change; verified current field names directly against the generated TS model source cited above, and cross-checked against the equivalent (accurate) Python README section.


---
_Generated by [Claude Code](https://claude.ai/code/session_011gzsY9yKinSjeqJkdsv76L)_