### PR TITLE
docs(design-system): fix accent token group label (ember -> Spark)

### DIFF
--- a/design-system/.design-sync/conventions.md
+++ b/design-system/.design-sync/conventions.md
@@ -25,7 +25,7 @@ reference Loft tokens. The real vocabulary:
 | Surfaces | `--bg` (app), `--bg-panel` (cards), `--bg-elev` (raised), `--bg-sunken` |
 | Text | `--fg`, `--fg-strong`, `--fg-muted`, `--fg-subtle` |
 | Borders | `--border`, `--border-sub`, `--border-strong` |
-| Accent (ember) | `--accent`, `--accent-fill`, `--accent-strong`, `--accent-soft`, `--accent-fg` |
+| Accent (Spark) | `--accent`, `--accent-fill`, `--accent-strong`, `--accent-soft`, `--accent-fg` |
 | Semantic | `--success`, `--warn`, `--danger`, `--info` (+ `-bg`, `-strong` pairs) |
 | Ink (agent console) | `--ink`, `--ink-elev`, `--ink-fg`, `--ink-fg-muted`, `--spectral`, `--machine` |
 | Radii | `--r-sm` `--r-md` `--r-lg` `--r-xl` |


### PR DESCRIPTION
## Summary

Docs-only fix found during a Markdown documentation audit.

`design-system/.design-sync/conventions.md`'s token-vocabulary table labeled the accent token group "ember", but the source consistently calls it "Spark" (`design-system/src/tokens.css:47` — `/* ── Accent · Spark (warm gold); fills stay canopy green ── */`, and `design-system/src/Logo/Logo.tsx:10`). No occurrence of "ember" exists anywhere else in `design-system/` or `web/src/`. The token names in the table (`--accent`, `--accent-fill`, etc.) were already correct — only the group's display label was stale.

No code changes — one word in `design-system/.design-sync/conventions.md`.

## Test plan

- [x] Read-only doc change; confirmed "Spark" is the current name via `design-system/src/tokens.css` and `Logo.tsx`, and confirmed "ember" appears nowhere else in the design-system or web source.


---
_Generated by [Claude Code](https://claude.ai/code/session_011gzsY9yKinSjeqJkdsv76L)_