### PR TITLE
docs(design): add second as-built addendum to api-v1-redesign.md

### DIFF
--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -33,7 +33,7 @@
 > the `email.rejected` strings left in `internal/agent/api.go` are stale code
 > comments, not the wire value, which is `webhookpub.EventEmailRejected`).
 >
-> **Second as-built update (post-GA drift — read this too).** A few of the
+> **Second as-built update (later pre-GA drift — read this too).** A few of the
 > "shipped" claims above were accurate when written but have since been
 > superseded by later, unrelated changes; `docs/api.md` + `api/openapi.yaml`
 > remain the single current source of truth. Concretely: the nested

--- a/docs/design/api-v1-redesign.md
+++ b/docs/design/api-v1-redesign.md
@@ -32,6 +32,22 @@
 > `api/openapi.yaml` + the webhook-subscription and `/v1/events` enums all use it;
 > the `email.rejected` strings left in `internal/agent/api.go` are stale code
 > comments, not the wire value, which is `webhookpub.EventEmailRejected`).
+>
+> **Second as-built update (post-GA drift — read this too).** A few of the
+> "shipped" claims above were accurate when written but have since been
+> superseded by later, unrelated changes; `docs/api.md` + `api/openapi.yaml`
+> remain the single current source of truth. Concretely: the nested
+> `…/messages/{id}/approve`/`reject` routes described above and in §5 **were
+> themselves later removed** in the pre-GA vocabulary freeze, replaced by the
+> account-scoped **Reviews queue** (`POST /v1/reviews/{id}/approve`·`reject`);
+> decision 10's "no `/inbound-policies` CRUD, agent property only" **no longer
+> holds** — protection config now lives on the dedicated
+> `GET/PUT /v1/agents/{email}/protection` sub-resource; the API-key-lifecycle
+> decision's "dashboard-only, never an API-key-authed `/v1` endpoint" **no
+> longer holds** — `GET/POST /v1/account/api-keys` and
+> `DELETE /v1/account/api-keys/{id}` are live, bearer-authed operations; and
+> Decision 3's `reply_to` — called "deferred, not rejected" above — has since
+> **shipped** on the send/reply/forward bodies.
 
 ## 1. Problem statement
 


### PR DESCRIPTION
## Summary

Docs-only fix found during a Markdown documentation audit.

`docs/design/api-v1-redesign.md` carries a prominent "As-built note (read first)" banner whose whole job is to keep readers from being misled by the doc's earlier interim design language, explicitly deferring to `docs/api.md` + `api/openapi.yaml` as authoritative. Four of the banner's own "shipped" claims have since been superseded by later, unrelated changes and would mislead a reader trusting the banner at face value:

- The nested `.../messages/{id}/approve|reject` routes it describes as shipped were themselves later removed in the pre-GA vocabulary freeze, replaced by the account-scoped Reviews queue (`docs/api.md`'s Reviews section; `api/openapi.yaml` has no nested approve/reject path anymore).
- Decision 10's "no `/inbound-policies` CRUD, agent property only" no longer holds — protection config is now the dedicated `GET/PUT /v1/agents/{email}/protection` sub-resource.
- The API-key-lifecycle decision's "dashboard-only, never an API-key-authed `/v1` endpoint" no longer holds — `GET/POST /v1/account/api-keys` and `DELETE .../api-keys/{id}` are live, bearer-authed operations (`api/openapi.yaml` declares `security: - bearer: []` on all three).
- `reply_to`, called "deferred, not rejected" in the banner, has since shipped on the send/reply/forward bodies.

Added a second dated addendum in the same tone/structure as the existing banner, rather than rewriting the historical §5/§10 prose, so the document still reads as the evolving record it is meant to be.

No code changes — one addendum paragraph in `docs/design/api-v1-redesign.md`.

## Test plan

- [x] Read-only doc change; verified each corrected claim against `api/openapi.yaml` and `docs/api.md`'s current Reviews/Agents/Account sections.


---
_Generated by [Claude Code](https://claude.ai/code/session_011gzsY9yKinSjeqJkdsv76L)_