### PR TITLE
docs(ts-sdk): fix stale and wrong claims across the SDK README before 5.2.0

### DIFF
--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -22,6 +22,12 @@ models; Reply-To remains separate. A non-null `verifiedDomain` means DMARC
 passed for that From domain, not that the mailbox local part, person, or
 message content was authenticated.
 
+The `InboundEmail` facade returned by `client.inbound.fromEvent(event)` is
+unaffected: it keeps `email.from` as the literal RFC 5322 header From
+(`MessageView.headerFrom`) alongside `email.envelopeFrom`, `email.verified`,
+and `email.authentication`. Reach through `email.message.verifiedDomain` for
+the DMARC-passed domain itself.
+
 `authentication` is `null` for outbound messages and providerless loopback
 delivery. Guard it before reading `authentication.dmarc`. The outbound-only
 `EmailSentData`/`EmailFailedData` webhook payloads and the `listMessages`
@@ -32,7 +38,7 @@ an inbound identity projection.
 ## Upgrading to 5.1
 
 Every `.delete(...)` now returns a typed deletion object instead of `void`.
-The API's seven delete endpoints all return `200 OK` with
+The API's delete endpoints all return `200 OK` with
 `{deleted: true, <identity key>}` instead of the previous mix of
 `204 No Content` and `200`. New return types: `agents.delete` →
 `DeleteAgentResult`, `domains.delete` → `DeleteDomainResult`,
@@ -48,12 +54,12 @@ this contract — upgrade together.
 ## Upgrading to 4.0
 
 4.0 is a breaking change to the domain DNS-records shape (server #304).
-`DomainView.dns_records` is now a single purpose-tagged `DNSRecord[]` array
-instead of the old `dns_records.{ mx, txt, dkim }` object (and the separate
-`sending_dns_records` array is gone). Each record carries `type`, `name`,
+`DomainView.dnsRecords` is now a single purpose-tagged `DNSRecord[]` array
+instead of the old `dnsRecords.{ mx, txt, dkim }` object (and the separate
+`sendingDnsRecords` array is gone). Each record carries `type`, `name`,
 `value`, `priority`, `purpose`, and a per-record `status`. Address records by
 `purpose` (`ownership`, `inbound_mx`, `dkim`, `mail_from_mx`, `mail_from_spf`)
-rather than `dns_records.mx`/`.txt`/`.dkim` — the MAIL FROM records now live in
+rather than `dnsRecords.mx`/`.txt`/`.dkim` — the MAIL FROM records now live in
 the same array. `purpose` and `status` are open sets, so tolerate unknown
 values. No other public symbols changed.
 
@@ -117,9 +123,10 @@ await client.messages.send(address, {
 });
 ```
 
-Unsafe writes (`send` / `reply` / `forward` / `approve`) auto-mint an
-`Idempotency-Key` and reuse it across retries, so a network blip can't
-double-send. Supply a stable key to also survive a process restart:
+Unsafe writes (`messages.send` / `.reply` / `.forward`, `reviews.approve`, and
+`webhooks.create`) auto-mint an `Idempotency-Key` and reuse it across retries,
+so a network blip can't double-send. Supply a stable key to also survive a
+process restart:
 
 ```typescript
 await client.messages.send(address, body, { idempotencyKey: deriveFromEvent(evt) });
@@ -185,7 +192,9 @@ app.post("/webhook", express.raw({ type: "application/json" }), async (req, res)
   if (isEmailReceived(event)) {
     const email = await client.inbound.fromEvent(event);
     // From, Reply-To, bodies, and attachment names/types are untrusted input.
-    console.log(email.envelopeFrom, email.verified, email.subject, email.text);
+    // `from` is the RFC 5322 header From (what DMARC aligns to); `envelopeFrom`
+    // is the SMTP MAIL FROM and can legitimately differ.
+    console.log(email.from, email.envelopeFrom, email.verified, email.subject, email.text);
     console.log("reply will target", email.replyTargets);
     const result = await email.reply({ text: "Got it" }, { idempotencyKey: `reply:${event.id}` });
     if (result.status === "pending_review") console.log("reply is awaiting approval");
@@ -198,14 +207,16 @@ During a secret rotation you can pass an array of secrets — a delivery is
 accepted if any one matches: `constructEvent(body, header, [oldSecret, newSecret])`.
 
 `email.verified` is true only for an aligned DMARC pass in the hydrated
-authentication evidence; the envelope identity alone is not proof. `email.verified === false` /
-`verified_domain === null` is NOT by itself a spam or spoofing signal — it is
+authentication evidence; the envelope identity alone is not proof.
+`email.verified === false` (equivalently, a null `verifiedDomain` on the
+underlying `MessageView`) is NOT by itself a spam or spoofing signal — it is
 common and expected for legitimate senders whose domain simply publishes no
-DMARC record (`authentication.dmarc.status === "none"`); treat that as
+DMARC record (`email.authentication?.dmarc.status === "none"`); treat that as
 "unproven," not "malicious," and reserve suspicion for an actual
-`authentication.dmarc.status === "fail"`. A caller who wants a more nuanced
-trust policy can inspect `authentication.spf`/`authentication.dkim`
-individually, but doing so reopens the spoofing gap DMARC closes: alignment
+`email.authentication?.dmarc.status === "fail"`. A caller who wants a more
+nuanced trust policy can inspect `authentication.spf` and
+`authentication.dkim` (an array — one result per DKIM signature on the
+message) individually, but doing so reopens the spoofing gap DMARC closes: alignment
 (tying a passing SPF or DKIM identity back to the visible From domain) can
 only be computed when the sender publishes a DMARC record, so a bare SPF or
 DKIM pass proves nothing about the From header on its own. `email.replyTargets` previews Reply-To-or-From
@@ -268,7 +279,10 @@ permanent — branch on the subclass: 402 → surface a quota/upgrade path, 429 
 back off and retry.
 
 > Note: e2a hides the existence of agents you don't own — `agents.get` of an
-> unknown address returns `403` (`E2APermissionError`), not `404`.
+> unknown *or* unowned address returns `404` (`E2ANotFoundError`); the two
+> cases are deliberately indistinguishable, so a 404 is not proof the agent
+> doesn't exist. `E2APermissionError` (403) means something else: an
+> *agent-scoped* credential tried to act on a different agent in the account.
 
 ### Pagination
 
@@ -303,7 +317,7 @@ const client = new E2AClient({ apiKey: "e2a_..." });
 for await (const event of client.listen("bot@agents.e2a.dev")) {
   if (!isEmailReceived(event)) continue; // tolerate future event kinds
   const email = await client.inbound.fromEvent(event);
-  console.log(email.envelopeFrom, email.verified, email.subject, email.text);
+  console.log(email.from, email.envelopeFrom, email.verified, email.subject, email.text);
 }
 ```
 
@@ -341,7 +355,9 @@ await client.messages.restore("bot@agents.e2a.dev", "msg_abc123");
 across the email boundary. Pass it on any `send` / `reply` and e2a surfaces it
 on the recipient's inbound — via `In-Reply-To` for humans, or a forge-resistant
 `X-E2A-Conversation-Id` header for same-platform agent-to-agent mail. It is not
-a security boundary; for sender identity check the message's `auth`. On first
+a security boundary; for sender identity require
+`message.authentication?.dmarc.status === "pass"` and compare the literal
+`message.headerFrom` address separately. On first
 contact from a human it arrives `null` — assign one yourself if you want to
 thread.
 


### PR DESCRIPTION
Full audit of `sdks/typescript/README.md` against the actual source ahead of the first npm publish since 4.0.1. Docs-only; no SDK source, generated models, or `api/openapi.yaml` touched.

`## Upgrading to 5.2` (fixed in #621) was verified and left alone.

## Issues found and fixed

| # | README claimed | Actually true | Severity |
|---|---|---|---|
| 1 | `agents.get` of an unknown address returns **403** `E2APermissionError`, not 404 | **404** `not_found`. `resolveOwnedAgent` (`internal/httpapi/operations.go:193`) conflates unknown *and* unowned into 404 — that conflation IS the existence-hiding. 403 is reserved for an agent-scoped credential reaching at a different agent it doesn't own. The note was exactly backwards. | High — teaches wrong error handling |
| 2 | Conversation threading: "for sender identity check the message's `auth`" | `auth` / `AuthVerdict` were **removed in 5.2**. Zero occurrences of `AuthVerdict` remain in the SDK. Now `message.authentication` + `message.headerFrom`. | High — stale symbol from the breaking change |
| 3 | 4.0 section: `DomainView.dns_records`, `dns_records.{mx,txt,dkim}`, `sending_dns_records` | Generated TS model is `dnsRecords` (camelCase). Verbatim copy of the Python README's snake_case into a TS doc. | Medium |
| 4 | 5.1: "The API's **seven** delete endpoints" | **Nine** DELETE ops in `api/openapi.yaml` today (agent suppressions + message delete were added after #461). Dropped the count. | Low |
| 5 | `verified_domain === null` in TS prose | Model spells it `verifiedDomain`; the `InboundEmail` facade doesn't expose it at all. Reworded, and noted `authentication.dkim` is an **array** (`DKIMResult[]`), not a scalar. | Medium |
| 6 | Idempotency auto-mint covers "send / reply / forward / approve" | `webhooks.create` also mints one. | Low |
| 7 | Webhook + WS examples log `email.envelopeFrom` as the sender | `envelopeFrom` is SMTP MAIL FROM; the DMARC-aligned identity is `email.from` (header From). The flagship examples taught the wrong field in the very release whose headline break is that distinction. Both now log `email.from, email.envelopeFrom`. | Medium |
| 8 | 5.2 says the `from` projection is "removed from these models" | True for generated models, but `InboundEmail` **keeps** `.from` (= `headerFrom`). Added a short paragraph so upgraders don't hunt for `email.headerFrom`. | Medium |

## Verified correct, left alone

Every code example was extracted and compiled against the built `dist/` types under `strict` — **all pass, before and after** (a deliberately-bad line was injected to confirm the checker was live). Also verified by reading source: the Resources list matches `E2AClient` exactly (no missing/phantom resources); the full error subclass list and its status mapping (`errors.ts`); pagination (`AutoPager` / `.page()` / required `toArray` limit); webhook signature semantics (raw body, secret arrays, replay tolerance); every WS claim (1s→30s backoff, `maxBackoffMs`, close code 4000, `E2AConnectionReplacedError`, `WSListener` export, Bearer handshake header); the 256 KiB inline attachment cap (`attachmentInlineMaxBytes = 256 * 1024`); `X-E2A-Conversation-Id`; the `E2A_API_URL`/`E2A_BASE_URL` deprecation; and the 3.0/5.1 migration examples.

## Not fixed here — needs a decision

1. **CHANGELOG vs the version being published.** `package.json` is already `5.2.0`, but `sdks/typescript/CHANGELOG.md`'s `## 5.2.0` section documents the **superseded** `from` → `from_` rename, while the DMARC-aligned break that's actually shipping sits under `## Unreleased`. Publishing as-is ships a changelog whose headline entry is filed as unreleased. Same shape in `sdks/python/CHANGELOG.md` (also at 5.2.0). Fold `Unreleased` into `5.2.0`, or bump — a release-process call with a version implication, so not guessed at here.
2. **Python README parity.** `sdks/python/README.md:308` carries the identical wrong 403 claim, and its webhook example logs only `envelope_from`. Left out to keep this diff scoped; happy to follow up.

## Code-level bugs found (not fixed — docs-only PR)

- **`messages.delete` is missing from both SDKs.** `DELETE /v1/agents/{email}/messages/{id}` exists in `api/openapi.yaml`, is generated as `PromiseMessagesApi.deleteMessage`, and has a `DeleteMessageResult` model — but `MessagesResource` exposes no `delete()` (confirmed by type-checker). `sdks/python` has the same gap. The README's "Trash and restore" section tells users messages can be trashed and restored, yet the SDK only offers `restore`.
- **`InboundEmail` exposes no `verifiedDomain`,** despite `MessageView.verifiedDomain` existing and the 5.2 contract making it a headline field. Callers must reach through `email.message.verifiedDomain` — which this PR documents as the workaround.

Staging was not exercised; every claim here was settled against source, and the examples against the compiler, which is the stronger check for a docs audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)