### PR TITLE
feat(sdk,mcp): expose messages.delete + gate SDK operation coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -472,6 +472,26 @@ jobs:
       - name: Check generated code is up to date
         run: make generate-sdk-check
 
+  sdk-operation-coverage:
+    # Guardrail: the generated layer is regenerated from api/openapi.yaml, but the
+    # ergonomic client users actually call is hand-written — so a new operation can
+    # land generated-but-unreachable with every other gate green. That is exactly
+    # how deleteMessage shipped: #466 added the endpoint, #480 wired up only the
+    # restore half, and the SDK READMEs documented a trash lifecycle you could not
+    # actually trash with. Sibling of tests/e2e-prod/coverage_gate.py ("is every
+    # operation EXERCISED?"); this one asks "is every operation EXPOSED?".
+    name: SDK operation coverage
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install pyyaml
+      - name: Check every operation is reachable from both SDKs
+        run: python3 scripts/check-sdk-operation-coverage.py
+
   design-system-dist:
     name: Design system dist freshness
     runs-on: ubuntu-latest

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -161,6 +161,7 @@ shows the set your scope allows, with per-tool descriptions.
 | `send_message` | Send a new email. The message is durably queued and returns `status: accepted` (the terminal outcome arrives via webhook/event or a follow-up read). When the agent's outbound policy or content scan holds it for review, it instead returns `status: pending_review`. |
 | `reply_to_message` | Reply to a message — one the agent received (replies to its sender) or one it sent (continues the thread to the original recipients). Preserves In-Reply-To / References for thread continuity. |
 | `list_messages` | List mail; pass `deleted:true` to list trash. Filter by `read_status` (unread / read / all) and sender with reserved-word-safe `from_`; cursor-paginated (`cursor` + `limit` in, `next_cursor` out). |
+| `delete_message` | Move a message to the trash (restorable for ~30 days). Requires `confirm: true`. Permanent deletion is deliberately not exposed over MCP — use the REST API/SDK. |
 | `restore_message` | Restore a soft-deleted message and resume its retention clock. |
 | `get_message` | Fetch full body, headers, and attachment metadata for one message. |
 | `get_attachment` | Get one attachment's metadata + a short-lived `download_url` (fetch the bytes out of band); `inline: true` returns base64 `data` for small files (≤256 KB). |

--- a/mcp/src/client.ts
+++ b/mcp/src/client.ts
@@ -38,6 +38,7 @@ import type {
   StarterTemplateView,
   StarterTemplateDetailView,
   DeleteAgentResult,
+  DeleteMessageResult,
   DeleteDomainResult,
   DeleteWebhookResult,
   DeleteTemplateResult,
@@ -291,6 +292,14 @@ export class McpClient {
 
   restoreMessage(messageId: string, explicitAddress?: string): Promise<MessageView> {
     return this.sdk.messages.restore(this.resolveAddress(explicitAddress), messageId);
+  }
+
+  deleteMessage(messageId: string, explicitAddress?: string): Promise<DeleteMessageResult> {
+    // Soft delete only — the MCP surface deliberately does not expose
+    // permanent=true ("delete forever"). An LLM should never be one hallucinated
+    // tool call away from an irreversible purge; restore_message is the safety
+    // net, and permanent deletion stays a deliberate REST/SDK action.
+    return this.sdk.messages.delete(this.resolveAddress(explicitAddress), messageId);
   }
 
   // ── Conversations ───────────────────────────────────────────────

--- a/mcp/src/tools/messages.ts
+++ b/mcp/src/tools/messages.ts
@@ -437,6 +437,35 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
   );
 
   server.registerTool(
+    "delete_message",
+    {
+      title: "Delete a message (move to trash)",
+      annotations: { destructiveHint: true, idempotentHint: true },
+      description:
+        "Move a message to the trash. It disappears from lists, threads, and reply targets, but stays restorable with `restore_message` until the trash-retention window expires (30 days by default). Permanent deletion (\"delete forever\") is deliberately NOT exposed here — use the REST API/SDK for that. A message held for review cannot be deleted (`message_held`) — resolve it in the review queue first. Requires `confirm: true` — set it explicitly to acknowledge the destructive action.",
+      inputSchema: strictInputSchema({
+        message_id: z.string().describe("ID of the message to move to trash."),
+        email: z.string().optional().describe("Owning agent; defaults to the bound agent."),
+        confirm: z
+          .literal(true)
+          .describe(
+            "Must be set to true to proceed. Guard against an LLM hallucinating a delete from ambiguous context.",
+          ),
+      }),
+    },
+    async (args) =>
+      runTool(async () => {
+        if (args.confirm !== true) {
+          throw new Error(
+            "delete_message requires confirm:true — refusing to proceed without explicit confirmation.",
+          );
+        }
+        // Return the server's deletion receipt verbatim: {deleted:true, id}.
+        return client.deleteMessage(args.message_id, args.email);
+      }),
+  );
+
+  server.registerTool(
     "get_message",
     {
       title: "Get a message",

--- a/mcp/src/tools/tiers.ts
+++ b/mcp/src/tools/tiers.ts
@@ -26,6 +26,12 @@ export const RUNTIME_TOOLS: ReadonlySet<string> = new Set([
   "list_messages",
   "get_message",
   "get_attachment",
+  // Soft delete + restore are both per-agent inbox hygiene: the REST handler
+  // pins an agent-scoped credential to its own bound agent (resolveOwnedAgent).
+  // The PERMANENT purge is account-only server-side, and the MCP tool doesn't
+  // expose it at all — so no agent-scoped session can destroy evidence
+  // irreversibly, which is why this stays runtime while delete_agent is admin.
+  "delete_message",
   "restore_message",
   "update_message_labels",
   "list_conversations",

--- a/mcp/tests/client.test.ts
+++ b/mcp/tests/client.test.ts
@@ -41,6 +41,7 @@ describe("McpClient trash/restore delegation", () => {
         messages: {
           list: vi.fn(() => ({ page: messagesPage })),
           restore: vi.fn(async (email: string, id: string) => ({ email, id })),
+          delete: vi.fn(async (_email: string, id: string) => ({ deleted: true, id })),
         },
       },
     };
@@ -82,6 +83,22 @@ describe("McpClient trash/restore delegation", () => {
     const c = new McpClient(sdk as never, "bound@test.dev", "agent");
     await c.restoreMessage("msg_trashed", "other@test.dev");
     expect(sdk.messages.restore).toHaveBeenCalledWith("other@test.dev", "msg_trashed");
+  });
+
+  it("deleteMessage forwards message id and resolved explicit address, soft-delete only", async () => {
+    const { sdk } = mockTrashSdk();
+    const c = new McpClient(sdk as never, "bound@test.dev", "agent");
+    await c.deleteMessage("msg_1", "other@test.dev");
+    // No third argument: the MCP surface never passes { permanent: true }, so
+    // an irreversible purge is unreachable from a tool call.
+    expect(sdk.messages.delete).toHaveBeenCalledWith("other@test.dev", "msg_1");
+  });
+
+  it("deleteMessage falls back to the bound agent when no address is given", async () => {
+    const { sdk } = mockTrashSdk();
+    const c = new McpClient(sdk as never, "bound@test.dev", "agent");
+    await c.deleteMessage("msg_1");
+    expect(sdk.messages.delete).toHaveBeenCalledWith("bound@test.dev", "msg_1");
   });
 });
 

--- a/mcp/tests/events.test.ts
+++ b/mcp/tests/events.test.ts
@@ -192,14 +192,14 @@ describe("MCP events tools", () => {
   });
 
   describe("tool catalog", () => {
-    it("includes the 3 events tools in the full re-curated tool set — total 50", async () => {
+    it("includes the 3 events tools in the full re-curated tool set — total 51", async () => {
       const client = await buildClient(stub);
       const { tools } = await client.listTools();
       const names = new Set(tools.map((t) => t.name));
       // The events tools add list_events/get_event/redeliver_event; the
       // full registered set (incl. the 8 beta template tools and the 3
-      // api-key tools and 2 trash-restore tools) is 50 tools.
-      expect(tools).toHaveLength(50);
+      // api-key tools and the 3 trash-lifecycle tools) is 51 tools.
+      expect(tools).toHaveLength(51);
       expect(names.has("list_events")).toBe(true);
       expect(names.has("get_event")).toBe(true);
       expect(names.has("redeliver_event")).toBe(true);

--- a/mcp/tests/http.test.ts
+++ b/mcp/tests/http.test.ts
@@ -292,6 +292,7 @@ describe("HTTP MCP server", () => {
         "get_message",
         "get_attachment",
         "restore_message",
+        "delete_message",
         "list_agents",
         "get_agent",
         "whoami",
@@ -360,9 +361,10 @@ describe("HTTP MCP server", () => {
 
     const { client, transport } = await connect();
     const names = new Set((await client.listTools()).tools.map((t) => t.name));
-    expect(names.size).toBe(14);
+    expect(names.size).toBe(15);
     expect(names.has("send_message")).toBe(true); // runtime present
     expect(names.has("restore_message")).toBe(true); // per-agent trash lifecycle
+    expect(names.has("delete_message")).toBe(true); // soft delete is per-agent too
     expect(names.has("create_agent")).toBe(false); // admin hidden
     expect(names.has("list_agents")).toBe(false); // REST requires account scope
     expect(names.has("restore_agent")).toBe(false); // account administration

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -165,6 +165,7 @@ function makeStubClient(
       ],
     })),
     restoreMessage: vi.fn(async (id: string, _addr?: string) => ({ id })),
+    deleteMessage: vi.fn(async (id: string, _addr?: string) => ({ deleted: true, id })),
     getAttachment: vi.fn(async (id: string, index: number, opts?: { inline?: boolean }) => ({
       index,
       filename: "report.pdf",
@@ -318,6 +319,7 @@ describe("e2a MCP server", () => {
         "get_message",
         "get_attachment",
         "restore_message",
+        "delete_message",
         "list_agents",
         "get_agent",
         "whoami",
@@ -442,7 +444,7 @@ describe("e2a MCP server", () => {
     registerTemplateTools(recorder, stub);
     registerApiKeyTools(recorder, stub);
 
-    expect(names).toHaveLength(50);
+    expect(names).toHaveLength(51);
     // Throws if any registered tool is untiered / double-tiered / phantom.
     expect(() => assertToolTiersComplete(names)).not.toThrow();
   });
@@ -451,28 +453,28 @@ describe("e2a MCP server", () => {
     expect(toolNamesForScope("bogus")).toBe(RUNTIME_TOOLS);
     expect(toolNamesForScope("")).toBe(RUNTIME_TOOLS);
     expect(toolNamesForScope("agent")).toBe(RUNTIME_TOOLS);
-    expect(RUNTIME_TOOLS.size).toBe(14);
+    expect(RUNTIME_TOOLS.size).toBe(15);
     expect(ADMIN_TOOLS.size).toBe(36);
-    expect(toolNamesForScope("account").size).toBe(50);
+    expect(toolNamesForScope("account").size).toBe(51);
   });
 
-  it("account scope exposes all 50 tools (runtime + admin)", async () => {
+  it("account scope exposes all 51 tools (runtime + admin)", async () => {
     const acct = await connect(makeStubClient({ scope: "account" }));
     const { tools } = await acct.listTools();
-    expect(tools).toHaveLength(50);
+    expect(tools).toHaveLength(51);
   });
 
-  it("agent scope exposes only the 14 runtime tools — admin tools hidden", async () => {
+  it("agent scope exposes only the 15 runtime tools — admin tools hidden", async () => {
     const ag = await connect(makeStubClient({ scope: "agent" }));
     const names = new Set((await ag.listTools()).tools.map((t) => t.name));
-    expect(names.size).toBe(14);
+    expect(names.size).toBe(15);
     // Runtime tools present (an agent can send + read its own pending queue,
     // but NOT approve/reject — that's an account-owner action, see below):
     for (const n of [
       "whoami", "get_agent", "list_messages", "get_message",
       "get_attachment", "update_message_labels", "list_conversations",
       "get_conversation", "send_message", "reply_to_message", "forward_message",
-      "list_reviews", "get_review", "restore_message",
+      "list_reviews", "get_review", "restore_message", "delete_message",
     ]) {
       expect(names.has(n), `runtime tool ${n} should be visible to agent scope`).toBe(true);
     }
@@ -515,7 +517,7 @@ describe("e2a MCP server", () => {
   // ── §6a tool annotations (#2) ───────────────────────────────────────
 
   it("every tool carries MCP annotations with the correct hints", async () => {
-    const { tools } = await client.listTools(); // account scope → all 50
+    const { tools } = await client.listTools(); // account scope → all 51
     const byName = new Map(tools.map((t) => [t.name, t.annotations ?? {}]));
 
     // Every tool has an annotations object.
@@ -528,7 +530,7 @@ describe("e2a MCP server", () => {
       expect(byName.get(n)?.readOnlyHint, `${n} readOnlyHint`).toBe(true);
     }
     // Deletes → destructive + idempotent.
-    for (const n of ["delete_agent", "delete_domain", "delete_webhook", "delete_template", "delete_api_key"]) {
+    for (const n of ["delete_agent", "delete_message", "delete_domain", "delete_webhook", "delete_template", "delete_api_key"]) {
       expect(byName.get(n)?.destructiveHint, `${n} destructiveHint`).toBe(true);
       expect(byName.get(n)?.idempotentHint, `${n} idempotentHint`).toBe(true);
     }
@@ -680,6 +682,51 @@ describe("e2a MCP server", () => {
     const res = await client.callTool({ name: "restore_message", arguments: { message_id: "msg_1" } });
     expect(stub.restoreMessage).toHaveBeenCalledWith("msg_1", undefined);
     expect(JSON.parse((res.content as Array<{ text: string }>)[0]!.text).id).toBe("msg_1");
+  });
+
+  it("delete_message requires confirm:true — server-side schema rejects when omitted", async () => {
+    // Same guard as delete_agent: `confirm` is a required literal(true), so the
+    // validator errors before the runTool body and deleteMessage is never called.
+    const res = await client.callTool({
+      name: "delete_message",
+      arguments: { message_id: "msg_1" },
+    });
+    expect(res.isError).toBe(true);
+    expect(stub.deleteMessage).not.toHaveBeenCalled();
+  });
+
+  it("delete_message trashes through the bound agent on explicit confirm:true", async () => {
+    const res = await client.callTool({
+      name: "delete_message",
+      arguments: { message_id: "msg_1", confirm: true },
+    });
+    expect(stub.deleteMessage).toHaveBeenCalledWith("msg_1", undefined);
+    const content = res.content as Array<{ type: string; text: string }>;
+    expect(JSON.parse(content[0]!.text)).toEqual({ deleted: true, id: "msg_1" });
+  });
+
+  it("delete_message forwards an explicit owning agent", async () => {
+    await client.callTool({
+      name: "delete_message",
+      arguments: { message_id: "msg_1", email: "other@test.dev", confirm: true },
+    });
+    expect(stub.deleteMessage).toHaveBeenCalledWith("msg_1", "other@test.dev");
+  });
+
+  it("delete_message does not expose a permanent/purge input (MCP is soft-delete only)", async () => {
+    // "Delete forever" is deliberately absent from the MCP surface — an LLM must
+    // not be one hallucinated call away from an irreversible purge. strictInputSchema
+    // rejects unknown keys, so even a hand-crafted permanent:true is refused.
+    const { tools } = await client.listTools();
+    const schema = tools.find((t) => t.name === "delete_message")!.inputSchema as {
+      properties: Record<string, unknown>;
+    };
+    expect(Object.keys(schema.properties).sort()).toEqual(["confirm", "email", "message_id"]);
+    const res = await client.callTool({
+      name: "delete_message",
+      arguments: { message_id: "msg_1", confirm: true, permanent: true },
+    });
+    expect(res.isError).toBe(true);
   });
 
   it("list_messages surfaces next_cursor when more pages remain", async () => {

--- a/scripts/check-sdk-operation-coverage.py
+++ b/scripts/check-sdk-operation-coverage.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""SDK ergonomic-surface coverage gate.
+
+Sibling of tests/e2e-prod/coverage_gate.py. That gate asks "is every operation
+EXERCISED by the conformance suite?"; this one asks "is every operation REACHABLE
+through the hand-written ergonomic client?" — the layer users actually call.
+
+Why this exists: both SDKs are two-layer. `generated/` is produced from
+api/openapi.yaml by OpenAPI Generator, so a new spec operation lands there
+automatically and the generated-code-freshness gate stays green. But the
+ergonomic surface (`client.messages.send(...)`, the pagers, typed errors) is
+hand-written, and nothing forced a new operation to be wired into it. That's how
+`deleteMessage` shipped generated-but-unreachable: PR #466 added the endpoint,
+PR #480 wired up only the restore half, and no gate noticed the delete half was
+never surfaced. Regenerating would not have fixed it — the generated layer had
+the method all along.
+
+How reachability is decided (deliberately stricter than a substring grep):
+  - Comments and docstrings are stripped from the hand-written sources first, so
+    an operation merely NAMED in prose can never produce a false green. This is
+    the failure mode that matters — a stale doc comment silently satisfying the
+    gate is worse than no gate.
+  - What's matched is a CALL SITE, not a mention: `.<method>(` anchored on a word
+    boundary and an opening paren. Anchoring on the paren also kills prefix
+    collisions — `.deleteAgentSuppression(` does not satisfy `deleteAgent`,
+    because the character after `deleteAgent` is `S`, not `(`.
+  - The Python method name is derived from the operationId by snake_case, then
+    CHECKED to exist in the generated api modules. A derivation that stops
+    matching the generator's naming is a gate failure, not a silent pass.
+
+Usage: python3 scripts/check-sdk-operation-coverage.py [--openapi PATH]
+Exit 0 = every operation reachable (or explicitly allowlisted); 1 = a gap; 2 = usage/IO error.
+"""
+import argparse
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+
+# Operations deliberately NOT surfaced on the ergonomic client, with the reason.
+# Keep this list SHORT and justified — every entry is a hole in the typed surface
+# that a user must drop to raw HTTP (or another client) to fill. An entry here is
+# a decision; the absence of an entry is a bug.
+#
+# Keyed by operationId → {"ts": reason, "py": reason} (or a bare string to
+# allowlist both SDKs for the same reason).
+ALLOWLIST: dict[str, object] = {}
+
+
+def die(msg):
+    print(f"sdk-operation-coverage: {msg}", file=sys.stderr)
+    return 2
+
+
+def load_ops(openapi_path):
+    try:
+        import yaml
+    except ImportError:
+        return None, die("PyYAML required (pip install pyyaml)")
+    with open(openapi_path) as f:
+        spec = yaml.safe_load(f)
+    ops = []  # (operationId, METHOD, path)
+    for path, item in (spec.get("paths") or {}).items():
+        for method, op in (item or {}).items():
+            if isinstance(op, dict) and "operationId" in op:
+                ops.append((op["operationId"], method.upper(), path))
+    return ops, 0
+
+
+def snake(name):
+    """lowerCamelCase → snake_case, matching the Python generator's method names."""
+    return re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower()
+
+
+def strip_ts_comments(src):
+    """Remove // line and /* */ block comments (incl. JSDoc).
+
+    Not a full JS lexer: a `//` or `/*` inside a string literal would be dropped
+    too. That direction is SAFE for this gate — over-stripping can only hide a
+    call site (false FAIL, loud), never invent one (false PASS, silent)."""
+    src = re.sub(r"/\*.*?\*/", " ", src, flags=re.S)
+    src = re.sub(r"//[^\n]*", " ", src)
+    return src
+
+
+def strip_py_comments(src):
+    """Remove # comments and triple-quoted strings (docstrings).
+
+    Same safety argument as the TS stripper: erring toward over-stripping can
+    only cause a false failure, never a false pass."""
+    src = re.sub(r'""".*?"""', " ", src, flags=re.S)
+    src = re.sub(r"'''.*?'''", " ", src, flags=re.S)
+    src = re.sub(r"#[^\n]*", " ", src)
+    return src
+
+
+def read_sources(root, exts, strip):
+    """Concatenate the hand-written sources under `root`, skipping generated/."""
+    if not os.path.isdir(root):
+        return None
+    chunks = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d != "generated"]
+        for fn in sorted(filenames):
+            if fn.endswith(exts):
+                with open(os.path.join(dirpath, fn), encoding="utf-8") as f:
+                    chunks.append(strip(f.read()))
+    return "\n".join(chunks)
+
+
+def calls(src, method):
+    """True if `src` contains a call site `.method(` (word-boundary + paren)."""
+    return re.search(r"\.\s*" + re.escape(method) + r"\s*\(", src) is not None
+
+
+def reasons_for(opid, sdk):
+    entry = ALLOWLIST.get(opid)
+    if entry is None:
+        return None
+    if isinstance(entry, str):
+        return entry
+    return entry.get(sdk)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--openapi", default=os.path.join(ROOT, "api", "openapi.yaml"))
+    args = ap.parse_args()
+
+    if not os.path.exists(args.openapi):
+        return die(f"openapi spec not found: {args.openapi}")
+
+    ops, err = load_ops(args.openapi)
+    if err:
+        return err
+    if not ops:
+        return die("no operations parsed from the spec — wrong file?")
+
+    ts_src = read_sources(os.path.join(ROOT, "sdks", "typescript", "src"), (".ts",), strip_ts_comments)
+    py_src = read_sources(os.path.join(ROOT, "sdks", "python", "src"), (".py",), strip_py_comments)
+    if ts_src is None:
+        return die("TypeScript SDK sources not found")
+    if py_src is None:
+        return die("Python SDK sources not found")
+
+    # The generated layer is the naming authority: if the snake_case derivation
+    # stops matching what the generator emits, fail loudly rather than silently
+    # reporting every Python operation as missing.
+    py_generated = read_sources(
+        os.path.join(ROOT, "sdks", "python", "src", "e2a", "v1", "generated", "api"),
+        (".py",),
+        lambda s: s,
+    )
+    if py_generated is None:
+        return die("Python generated api modules not found")
+
+    # An allowlist entry that no longer names a real operationId is a silent hole
+    # (e.g. the op was renamed) — fail loudly so the allowlist can't drift stale.
+    all_ids = {opid for opid, _, _ in ops}
+    stale = set(ALLOWLIST) - all_ids
+    if stale:
+        return die(f"allowlist entries not in the spec (renamed/removed?): {sorted(stale)}")
+
+    missing = {"ts": [], "py": []}
+    allowed = {"ts": [], "py": []}
+    bad_derivation = []
+
+    for opid, method, path in sorted(ops):
+        py_name = snake(opid)
+        if not re.search(r"def\s+" + re.escape(py_name) + r"\s*\(", py_generated):
+            bad_derivation.append((opid, py_name))
+            continue
+        for sdk, src, name in (("ts", ts_src, opid), ("py", py_src, py_name)):
+            if calls(src, name):
+                continue
+            reason = reasons_for(opid, sdk)
+            if reason:
+                allowed[sdk].append((opid, reason))
+            else:
+                missing[sdk].append((opid, method, path, name))
+
+    if bad_derivation:
+        print("\nOPERATION-ID → PYTHON METHOD DERIVATION BROKEN:", file=sys.stderr)
+        for opid, py_name in bad_derivation:
+            print(f"  - {opid} → {py_name} (no such def in generated/api)", file=sys.stderr)
+        print(
+            "\nGATE: FAIL — the generator's naming changed; fix snake() in this script.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"OpenAPI operations      : {len(all_ids)}")
+    for sdk, label in (("ts", "TypeScript"), ("py", "Python")):
+        reachable = len(all_ids) - len(missing[sdk]) - len(allowed[sdk])
+        note = f"  (allowlisted: {len(allowed[sdk])})" if allowed[sdk] else ""
+        print(f"Reachable via {label:11s}: {reachable}{note}")
+        for opid, reason in sorted(allowed[sdk]):
+            print(f"    allowlisted: {opid} — {reason}")
+
+    total_missing = missing["ts"] + missing["py"]
+    if total_missing:
+        for sdk, label in (("ts", "TypeScript"), ("py", "Python")):
+            if not missing[sdk]:
+                continue
+            print(f"\nUNREACHABLE — {label} ({len(missing[sdk])}):")
+            for opid, method, path, name in sorted(missing[sdk]):
+                print(f"  - {opid:28s} {method} {path}")
+                print(f"      generated as `{name}`, but no hand-written client calls it")
+        print(
+            "\nGATE: FAIL — the above operation(s) exist in the generated layer but are not\n"
+            "exposed by the hand-written ergonomic client, so users can only reach them via\n"
+            "raw HTTP. Add the method to the matching Resource class, or add an ALLOWLIST\n"
+            "entry in this script with a written reason."
+        )
+        return 1
+
+    print("\nGATE: PASS — every OpenAPI operation is reachable from both SDKs' ergonomic surface.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -337,16 +337,27 @@ page = client.messages.list("bot@agents.e2a.dev", limit=100).page()
 
 ### Trash and restore
 
-Soft-deleted agents and messages remain restorable for about 30 days. List the
-trash with `deleted=True`, then restore an item through the same resource. The
-sync client exposes the same methods without `await`.
+`delete()` is a soft delete: agents and messages move to the trash and stay
+restorable for about 30 days. List the trash with `deleted=True`, then restore
+an item through the same resource. The sync client exposes the same methods
+without `await`.
 
 ```python
+await client.agents.delete("bot@agents.e2a.dev")
 trashed_agents = client.agents.list(deleted=True)
 await client.agents.restore("bot@agents.e2a.dev")
 
+await client.messages.delete("bot@agents.e2a.dev", "msg_abc123")
 trashed_messages = client.messages.list("bot@agents.e2a.dev", deleted=True)
 await client.messages.restore("bot@agents.e2a.dev", "msg_abc123")
+```
+
+A message already in the trash can be purged early and irreversibly. That path
+needs an account-scoped credential; the SDK supplies the API's `?confirm=DELETE`
+guard for you:
+
+```python
+await client.messages.delete("bot@agents.e2a.dev", "msg_abc123", permanent=True)
 ```
 
 ## WebSocket (real-time delivery for local agents)

--- a/sdks/python/src/e2a/v1/client.py
+++ b/sdks/python/src/e2a/v1/client.py
@@ -45,6 +45,7 @@ from .generated.models import (
     DeleteAgentResult,
     DeleteApiKeyResult,
     DeleteDomainResult,
+    DeleteMessageResult,
     DeleteSuppressionResult,
     DeleteTemplateResult,
     DeleteUserDataResult,
@@ -476,6 +477,33 @@ class MessagesResource:
 
     async def get(self, email: str, message_id: str) -> MessageView:
         return await self._c._read(lambda h: self._api.get_message(email, message_id, _headers=h))
+
+    async def delete(
+        self, email: str, message_id: str, *, permanent: bool = False
+    ) -> DeleteMessageResult:
+        """Move a message to the trash.
+
+        Reversible via ``restore()`` until the trash retention window expires
+        (30 days by default), so the default soft delete needs no confirmation.
+
+        Pass ``permanent=True`` to permanently delete a message that is ALREADY
+        in the trash ("delete forever") — irreversible, account scope only. The
+        typed .delete() call is the confirmation; the SDK supplies the
+        ?confirm=DELETE guard the raw API requires on that path (it is ignored
+        when permanent is unset).
+
+        A message held for review cannot be deleted (409 message_held) — resolve
+        it on the review queue first. Returns the deletion receipt
+        ({deleted, id}).
+        """
+        return await self._c._write_idempotent(
+            lambda h: self._api.delete_message(
+                # `permanent or None` omits the param entirely on the soft path,
+                # matching the TS SDK's wire shape (the server treats an absent
+                # and a false `permanent` identically).
+                email, message_id, permanent=permanent or None, confirm="DELETE", _headers=h
+            )
+        )
 
     async def restore(self, email: str, message_id: str) -> MessageView:
         """Restore a soft-deleted message and resume its retention clock."""

--- a/sdks/python/tests/test_v1_client.py
+++ b/sdks/python/tests/test_v1_client.py
@@ -657,6 +657,35 @@ async def test_messages_list_deleted_lists_trash(httpx_mock):
 
 
 @pytest.mark.anyio
+async def test_messages_delete_soft_by_default(httpx_mock):
+    httpx_mock.add_response(json={"deleted": True, "id": "msg_1"})
+    async with _client() as c:
+        res = await c.messages.delete("bot@test.dev", "msg_1")
+    req = httpx_mock.get_requests()[-1]
+    assert req.method == "DELETE"
+    assert "/v1/agents/bot%40test.dev/messages/msg_1" in str(req.url)
+    # The soft delete is reversible, so `permanent` is omitted entirely (wire
+    # parity with the TS SDK); only the permanent path is gated on it.
+    assert "permanent" not in req.url.params
+    # 200 + typed deletion receipt (uniform delete contract).
+    assert res.deleted is True
+    assert res.id == "msg_1"
+
+
+@pytest.mark.anyio
+async def test_messages_delete_permanent_sends_confirm(httpx_mock):
+    httpx_mock.add_response(json={"deleted": True, "id": "msg_1"})
+    async with _client() as c:
+        res = await c.messages.delete("bot@test.dev", "msg_1", permanent=True)
+    req = httpx_mock.get_requests()[-1]
+    assert req.method == "DELETE"
+    assert req.url.params["permanent"] == "true"
+    # The typed call is the confirmation; the SDK supplies the raw-API guard.
+    assert "confirm=DELETE" in str(req.url)
+    assert res.deleted is True
+
+
+@pytest.mark.anyio
 async def test_messages_restore(httpx_mock):
     httpx_mock.add_response(json=_valid(MessageView, id="msg_1"))
     async with _client() as c:

--- a/sdks/python/tests/test_v1_sync_client.py
+++ b/sdks/python/tests/test_v1_sync_client.py
@@ -110,7 +110,7 @@ def test_parity_every_async_method_reachable_sync():
             "agents", "messages", "conversations", "domains", "events",
             "webhooks", "inbound", "account", "reviews", "templates", "info", "listen",
             "agents.get", "agents.list", "agents.create", "agents.delete", "agents.restore",
-            "messages.restore",
+            "messages.delete", "messages.restore",
             "messages.send", "messages.reply", "webhooks.fetch_message",
             "inbound.from_event",
             "account.suppressions", "account.suppressions.list",
@@ -222,6 +222,21 @@ def test_send_uses_caller_idempotency_key(httpx_mock):
             idempotency_key="caller-key-123",
         )
     assert httpx_mock.get_requests()[-1].headers["Idempotency-Key"] == "caller-key-123"
+
+
+def test_messages_delete_blocks_and_returns_receipt(httpx_mock):
+    # The sync facade mirrors the async coroutine: it blocks and hands back the
+    # typed receipt, and the keyword-only `permanent` flag survives the bridge.
+    httpx_mock.add_response(json={"deleted": True, "id": "msg_1"})
+    with _client() as c:
+        res = c.messages.delete("bot@test.dev", "msg_1", permanent=True)
+    assert res.deleted is True
+    assert res.id == "msg_1"
+    req = httpx_mock.get_requests()[-1]
+    assert req.method == "DELETE"
+    assert "/v1/agents/bot%40test.dev/messages/msg_1" in str(req.url)
+    assert req.url.params["permanent"] == "true"
+    assert "confirm=DELETE" in str(req.url)
 
 
 def test_templates_list_multi_page_walk_and_page_resume(httpx_mock):

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -324,15 +324,26 @@ The lower-level `WSListener` is also exported for advanced use.
 
 ## Trash and restore
 
-Soft-deleted agents and messages remain restorable for about 30 days. List the
-trash with `deleted: true`, then restore an item through the same resource:
+`delete()` is a soft delete: agents and messages move to the trash and stay
+restorable for about 30 days. List the trash with `deleted: true`, then restore
+an item through the same resource:
 
 ```ts
+await client.agents.delete("bot@agents.e2a.dev");
 const trashedAgents = client.agents.list({ deleted: true });
 await client.agents.restore("bot@agents.e2a.dev");
 
+await client.messages.delete("bot@agents.e2a.dev", "msg_abc123");
 const trashedMessages = client.messages.list("bot@agents.e2a.dev", { deleted: true });
 await client.messages.restore("bot@agents.e2a.dev", "msg_abc123");
+```
+
+A message already in the trash can be purged early and irreversibly. That path
+needs an account-scoped credential; the SDK supplies the API's `?confirm=DELETE`
+guard for you:
+
+```ts
+await client.messages.delete("bot@agents.e2a.dev", "msg_abc123", { permanent: true });
 ```
 
 ## Conversation threading

--- a/sdks/typescript/src/v1/client.ts
+++ b/sdks/typescript/src/v1/client.ts
@@ -60,6 +60,7 @@ import type {
   UserExport,
   DeleteUserDataResult,
   DeleteAgentResult,
+  DeleteMessageResult,
   DeleteDomainResult,
   DeleteSuppressionResult,
   DeleteApiKeyResult,
@@ -345,6 +346,24 @@ class MessagesResource {
   }
   get(email: string, id: string): Promise<MessageView> {
     return call(() => this.api.getMessage(email, id));
+  }
+  /**
+   * Move a message to the trash. Reversible via `restore()` until the trash
+   * retention window expires (30 days by default), so the default soft delete
+   * needs no confirmation.
+   *
+   * Pass `{ permanent: true }` to permanently delete a message that is ALREADY
+   * in the trash ("delete forever") — irreversible, account-scoped credentials
+   * only. The typed .delete() call is itself the confirmation; the SDK supplies
+   * the ?confirm=DELETE guard the raw API requires on that path (the query
+   * guard exists to protect raw/curl callers). It is ignored when permanent is
+   * unset.
+   *
+   * A message held for review cannot be deleted (409 message_held) — resolve it
+   * on the review queue first. Returns the deletion receipt ({deleted:true, id}).
+   */
+  delete(email: string, id: string, opts: { permanent?: boolean } = {}): Promise<DeleteMessageResult> {
+    return call(() => this.api.deleteMessage(email, id, opts.permanent, "DELETE"));
   }
   /** Restore a soft-deleted message and resume its retention clock. */
   restore(email: string, id: string): Promise<MessageView> {

--- a/sdks/typescript/test/v1/client.test.ts
+++ b/sdks/typescript/test/v1/client.test.ts
@@ -322,6 +322,31 @@ describe("E2AClient", () => {
     expect(new URL(lastCall().url).searchParams.get("deleted")).toBe("true");
   });
 
+  it("messages.delete soft-deletes by default and returns the deletion receipt", async () => {
+    globalThis.fetch = mockFetch(200, { deleted: true, id: "msg_1" });
+    const res = await client.messages.delete("bot@test.dev", "msg_1");
+    const { url, init } = lastCall();
+    expect(init.method).toBe("DELETE");
+    expect(url).toContain("/v1/agents/bot%40test.dev/messages/msg_1");
+    // The soft delete is reversible, so `permanent` is omitted entirely — only
+    // the permanent path is gated on it server-side.
+    expect(new URL(url).searchParams.get("permanent")).toBeNull();
+    expect(res.deleted).toBe(true);
+    expect(res.id).toBe("msg_1");
+  });
+
+  it("messages.delete({ permanent: true }) auto-sends confirm=DELETE", async () => {
+    globalThis.fetch = mockFetch(200, { deleted: true, id: "msg_1" });
+    const res = await client.messages.delete("bot@test.dev", "msg_1", { permanent: true });
+    const { url, init } = lastCall();
+    expect(init.method).toBe("DELETE");
+    const params = new URL(url).searchParams;
+    expect(params.get("permanent")).toBe("true");
+    // The typed call is the confirmation; the SDK supplies the raw-API guard.
+    expect(params.get("confirm")).toBe("DELETE");
+    expect(res.deleted).toBe(true);
+  });
+
   it("messages.restore POSTs to the restore endpoint", async () => {
     globalThis.fetch = mockFetch(200, {
       id: "msg_1", conversation_id: "conv_1", created_at: "2026-01-01T00:00:00Z",


### PR DESCRIPTION
## The bug

`DELETE /v1/agents/{email}/messages/{id}` (operationId **`deleteMessage`**) has been in the spec and on the server since #466. #480 (`feat(sdk,mcp): expose trash restore lifecycle`) wired up only the **restore** half. A `messages.delete()` never existed — there's no removal commit, it was simply never added.

Net effect: both SDK READMEs have a "Trash and restore" section, and neither SDK gave you a way to *trash* anything. Every other resource — agents, templates, domains, webhooks, suppressions, apiKeys, account — exposes `delete()`. `agents` has both `delete()` and `restore()`. `messages` had restore with no delete, so the only way to trash a message was raw HTTP.

Confirmed against staging by raw HTTP before fixing: `deleteMessage` → 200, `restoreMessage` → 200. The endpoint was fine; only the SDK surface was missing.

## Why regeneration wouldn't have fixed this

Both SDKs are **two-layer**:

- **Generated** (`sdks/*/generated/`) — API client + models produced from `api/openapi.yaml` by OpenAPI Generator. `deleteMessage` and `DeleteMessageResult` were *already there*, correct, the whole time.
- **Hand-written** (`client.ts` / `client.py` and siblings) — the ergonomic namespaced surface users actually call.

So the "Generated code freshness" gate was green, `make generate-sdk-check` was green, and the operation was still unreachable. Regenerating produces the low-level method; nothing ever forced it to be *surfaced*. That gap is the second half of this PR.

## What's added

**TypeScript** — `MessagesResource.delete(email, id, { permanent? })` → `DeleteMessageResult`.
**Python** — `MessagesResource.delete(email, message_id, *, permanent=False)` → `DeleteMessageResult`, async client + sync facade (the facade mirrors dynamically, and the parity walk now asserts `messages.delete`).

Both follow the sibling conventions: typed result (not `void`), and the SDK supplies the API's `?confirm=DELETE` guard on the caller's behalf, exactly as `agents.delete()` does — the typed call *is* the confirmation, the query guard exists to protect raw/curl callers.

One thing worth flagging: `deleteMessage`'s `confirm` requirement is **conditional**, unlike its siblings. Per the spec and `handleDeleteMessage`, the default delete is a reversible soft-delete needing no confirmation; `confirm=DELETE` is required only with `permanent=true`, which is also account-scope-only. So `delete()` defaults to the soft path and takes an opt-in `permanent` flag, and `permanent` is omitted from the query string entirely on the soft path in both SDKs (wire parity; the server treats absent and false identically).

**MCP** — verified rather than assumed: `mcp/src/tools/messages.ts` exposed `restore_message` and no delete. Added `delete_message`, following the `delete_agent` pattern (`confirm: true` literal, `destructiveHint`). Two deliberate calls:

- **Soft delete only.** `permanent` is not exposed over MCP at all — an LLM should never be one hallucinated tool call away from an irreversible purge. `restore_message` is the safety net; "delete forever" stays a deliberate REST/SDK action. There's a test asserting the input schema has exactly `{message_id, email, confirm}` and that a hand-crafted `permanent: true` is rejected.
- **Runtime tier, not admin** (unlike `delete_agent`). This matches the server: `handleDeleteMessage` treats the soft delete as a per-agent operation via `resolveOwnedAgent`, and gates only the permanent purge behind `requireAccountScope`. Since MCP can't reach the permanent path, no agent-scoped session can destroy evidence irreversibly.

The MCP tool-count drift guards fired as designed (50→51 tools, 14→15 runtime) and were updated.

READMEs for all three now document the delete side of the lifecycle they already described.

## Tests

- TS (`test/v1/client.test.ts`): soft delete omits `permanent` + returns the receipt; `{ permanent: true }` sends `permanent=true&confirm=DELETE`.
- Python (`test_v1_client.py`): the same two, async.
- Python (`test_v1_sync_client.py`): `messages.delete` added to the parity walk, plus a behavioral test that the sync facade blocks, returns the typed receipt, and passes `permanent` through the bridge.
- MCP (`tests/tools.test.ts`, `tests/client.test.ts`): confirm-required-and-not-called, forwards to bound agent, forwards explicit agent, no permanent input; client-layer address resolution both ways.

Suites: TS 199, Python 353, MCP 210, CLI 171 — all green.

## The gate

New `scripts/check-sdk-operation-coverage.py`, wired into `.github/workflows/test.yml` as **`SDK operation coverage`**, alongside the existing "Generated code freshness" / "Internal SDK version sync" guardrails.

It's the deliberate sibling of `tests/e2e-prod/coverage_gate.py` — that one asks *"is every operation **exercised** by the conformance suite?"*, this one asks *"is every operation **exposed** by the hand-written client?"* — and follows its structure (allowlist-with-reasons, stale-allowlist detection, per-op failure report).

Hardened past the ad-hoc `grep operationId client.ts` that originally found this:

- **Comments and docstrings are stripped first**, so an operation merely *named* in prose can't produce a false green. A stale doc comment silently satisfying the gate would be worse than no gate.
- **Call sites, not mentions**: matches `.<method>(` on a word boundary + open paren. The paren anchor also kills prefix collisions — `.deleteAgentSuppression(` does not satisfy `deleteAgent`.
- **The Python name derivation is self-checking**: the snake_case name is verified to exist as a `def` in `generated/api/` first, so if the generator's naming ever changes the gate fails loudly instead of reporting every Python op as missing.
- Over-stripping is the safe direction by construction — it can only cause a false *failure* (loud), never a false *pass* (silent).

**Allowlist: empty.** I looked for legitimately-unsurfaced operations and found none — all 60 operations are reachable from both SDKs after this change. The structure is in place (keyed by operationId, per-SDK reasons, stale entries fail the gate) so a future intentional omission is recorded with a reason and stays distinguishable from an accident.

## Proof the gate fails when it should

Four checks, not just one:

1. **Against pristine `origin/main`** (the strongest form — stash everything, run the gate): reports **59/60 for both SDKs**, flagging exactly `deleteMessage` and nothing else. Independently reproduces the manual finding this PR started from.
2. **TS `delete()` removed, Python left intact** → exit 1, TypeScript 59/60, Python 60/60. Fails per-SDK, not all-or-nothing.
3. **Python `delete()` removed, TS left intact** → exit 1, Python 59/60, with the correct generated name (`delete_message`) in the message.
4. **False-green check**: replaced the real TS call site with a comment reading `// TODO: wire up this.api.deleteMessage(email, id) — see #480.` — the gate **still failed**, confirming the comment-stripping closes the naive-grep hole.

On the fixed tree: 60/60 both SDKs, exit 0.

## Release note

**Additive** — a new method on an existing resource, no behavior change to anything existing. Minor bump: the SDKs were just published at 5.2.0, so this ships as **5.3.0**.

I deliberately did **not** bump `package.json` / `pyproject.toml` here, since a release is in flight and version choices are being coordinated — say the word and I'll add the bump.
