### PR TITLE
docs(sdk): correct the 5.2.0 changelog sections in both SDKs

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -3,6 +3,20 @@
 ## Unreleased
 
 ### Added
+- **`client.messages.delete(email, message_id, *, permanent=False)`** — move a
+  message to the trash, reversible via `client.messages.restore(...)` until the
+  trash retention window expires (30 days by default), so the soft delete needs
+  no confirmation. Pass `permanent=True` to delete forever a message that is
+  already in the trash (irreversible, account scope only; the SDK supplies the
+  `?confirm=DELETE` guard the raw API requires on that path). Available on both
+  `AsyncE2AClient` and the synchronous `E2AClient`.
+
+## 5.2.0
+
+The first publish to PyPI since 4.0.1: 5.0.0, 5.1.0, and 5.2.0 all reach users
+in this release, so read those three sections together when upgrading from 4.x.
+
+### Added
 - `client.inbound.from_event(event)` returns `AsyncInboundEmail` on
   `AsyncE2AClient` and a blocking `InboundEmail` on `E2AClient`. The facade
   exposes explicit envelope/auth verdicts, reply targets, parsed-body
@@ -41,20 +55,23 @@
   ``EventJSON`` → ``EventView``, ``Suppression`` → ``SuppressionView``,
   ``Result`` → ``AuthVerdict``, ``AttachmentMeta`` → ``AttachmentMetaView``.
 
-## 5.2.0
-
-### Breaking (pre-GA)
-- **The reserved-word wire field `from` is now uniformly exposed as `from_`
-  (PEP 8 trailing underscore) on generated models** (was the generator-mangled
-  `var_from`). Affected models: `Message`, `MessageView`, `MessageSummaryView`,
-  `ReviewView`, `EmailReceivedData`, `EmailSentData`, `EmailFailedData`
-  (generated), plus the generated `list_messages` sender filter parameter. The
+- **The reserved-word wire field `from` is exposed as `from_` (PEP 8 trailing
+  underscore) where a sender is still projected** (was the generator-mangled
+  `var_from`). This is the generated `list_messages` sender filter parameter
+  and the outbound-only `EmailSentData` / `EmailFailedData` models; the
   hand-written layer's `messages.list(from_=...)` already used `from_`, so the
-  SDK now teaches exactly one spelling; the TypeScript SDK exposes the same
+  SDK teaches exactly one spelling, and the TypeScript SDK exposes the same
   `from_`. The wire JSON is unchanged — requests and responses still carry
   `from` (pydantic alias). The webhook/WS `data` payload TypedDicts are
-  wire-true dicts and keep the literal `"from"` key (access as
-  `data["from"]`). Migrate: `message.var_from` → `message.from_`.
+  wire-true dicts and keep the literal `"from"` key (access as `data["from"]`).
+
+  An intermediate step on `main` also renamed the *inbound* sender projection
+  on `Message`, `MessageView`, `MessageSummaryView`, `ReviewView`, and
+  `EmailReceivedData` from `var_from` to `from_`. The DMARC-aligned contract
+  above replaced that projection with `header_from` before this release, so
+  `from_` never reached PyPI on those models and there is nothing to migrate
+  off — 4.x callers reading `message.var_from` go straight to
+  `message.header_from`.
 
 ## 5.1.0
 

--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -3,6 +3,19 @@
 ## Unreleased
 
 ### Added
+- **`client.messages.delete(email, messageId, { permanent })`** — move a message
+  to the trash, reversible via `client.messages.restore(...)` until the trash
+  retention window expires (30 days by default), so the soft delete needs no
+  confirmation. Pass `permanent: true` to delete forever a message that is
+  already in the trash (irreversible, account scope only; the SDK supplies the
+  `?confirm=DELETE` guard the raw API requires on that path).
+
+## 5.2.0
+
+The first publish to npm since 4.0.1: 5.0.0, 5.1.0, and 5.2.0 all reach users
+in this release, so read those three sections together when upgrading from 4.x.
+
+### Added
 - `client.inbound.fromEvent(event)` returns a client-bound `InboundEmail`
   facade for verified webhook or authenticated WebSocket `email.received`
   envelopes. It exposes explicit envelope/auth verdicts, reply targets,
@@ -39,20 +52,23 @@
   `EventJSON` → `EventView`, `Suppression` → `SuppressionView`,
   `Result` → `AuthVerdict`, `AttachmentMeta` → `AttachmentMetaView`.
 
-## 5.2.0
+- **The reserved-word wire field `from` is exposed as `from_` where a sender is
+  still projected** (was the private-looking `_from`, an OpenAPI Generator
+  escape artifact). This is the `listMessages` sender filter and the
+  outbound-only `EmailSentData` / `EmailFailedData` payloads; the Python SDK
+  exposes the same `from_` spelling, so both SDKs teach exactly one name. The
+  wire JSON is unchanged — requests and responses still carry `from`. The
+  hand-written webhook/WS payload interfaces in `webhook-signature.ts` are
+  wire-true and keep the literal `from` property (legal in TS) — those are
+  raw-JSON shapes, not generated models. Migrate:
+  `list(..., { _from })` → `{ from_ }`.
 
-### Breaking (pre-GA)
-- **The reserved-word wire field `from` is now uniformly exposed as `from_` on
-  generated models and the `listMessages` sender filter** (was the
-  private-looking `_from`, an OpenAPI Generator escape artifact). Affected
-  models: `Message`, `MessageView`, `MessageSummaryView`, `ReviewView`,
-  `EmailReceivedData`, `EmailSentData`, `EmailFailedData` (generated). The
-  Python SDK exposes the same `from_` spelling, so both SDKs now teach exactly
-  one name. The wire JSON is unchanged — requests and responses still carry
-  `from`. The hand-written webhook/WS payload interfaces in
-  `webhook-signature.ts` are wire-true and keep the literal `from` property
-  (legal in TS) — those are raw-JSON shapes, not generated models. Migrate:
-  `message._from` → `message.from_`; `list(..., { _from })` → `{ from_ }`.
+  An intermediate step on `main` also renamed the *inbound* sender projection
+  on `Message`, `MessageView`, `MessageSummaryView`, `ReviewView`, and
+  `EmailReceivedData` from `_from` to `from_`. The DMARC-aligned contract above
+  replaced that projection with `headerFrom` before this release, so `from_`
+  never reached npm on those models and there is nothing to migrate off — 4.x
+  callers reading `message._from` go straight to `message.headerFrom`.
 
 ## 5.1.0
 


### PR DESCRIPTION
Both SDK CHANGELOGs attributed the wrong change to `## 5.2.0`. Since 5.2.0 is already published to npm and PyPI — and a breaking-release comms email will reference these notes — the released section needs to describe what actually shipped.

## What was wrong

`## 5.2.0` documented a **superseded** intermediate rename (`_from` / `var_from` → `from_` across all sender-bearing models), while the change that actually shipped under that version — the DMARC-aligned inbound contract, the schema-name renames, and the inbound facade — sat under `## Unreleased`.

## Ground truth used

Both `ts-sdk-v5.2.0` and `python-v5.2.0` point at `3280ec8b`, so `ts-sdk-v4.0.1..3280ec8b` is definitionally "what shipped in 5.2.0". That range contains `9b2c15aa` (canonical inbound authentication, #607), `7c472ba7` (schema renames), and `b6717656` (inbound facade). Cross-checked against the generated models at the tag:

- `Message`, `MessageView`, `MessageSummaryView`, `ReviewView`, `EmailReceivedData` → `header_from` / `envelope_from` / `verified_domain` / `authentication`, **no** `from_`.
- `EmailSentData`, `EmailFailedData`, and the `list_messages` / `listMessages` sender filter → **do** carry `from_`.

This matches the Python README's "Upgrading to 5.2" (already correct) and the TS one as corrected in #621.

## Changes

- Moved the DMARC contract, schema-rename, and inbound-facade entries from `## Unreleased` into `## 5.2.0`, verbatim and in place.
- Rewrote the `from_` entry to cover only the part that shipped (the sender filter and the outbound-only event payloads), and added a short paragraph recording plainly that the inbound `from_` projection was replaced by `header_from` before publish and **never reached the registries** — so 4.x callers migrate `_from` / `var_from` straight to `headerFrom` / `header_from` with no `from_` stop in between. Deleting it silently would have left git history unexplained.
- Added a one-line note under `## 5.2.0` that it is the first publish since 4.0.1, so the 5.0.0 / 5.1.0 / 5.2.0 sections all reach users at once. Those two sections are accurate as written and are otherwise untouched.
- Left `## Unreleased` holding `messages.delete` (#625), which is **not** in the published 5.2.0 and will ship in 5.3.0. It had no changelog entry at all, so one was added.

Docs only — no SDK source, generated code, `api/openapi.yaml`, or version numbers touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)