### PR TITLE
feat(monitoring): continuously exercise the published Python SDK against prod

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -5,9 +5,9 @@ on:
     branches: [main]
     tags: ["v*"]
   pull_request:
-    # Re-run on PRs that could plausibly change either image. Two image
-    # variants (server + web) build in parallel via the matrix below;
-    # doc-only PRs are still skipped.
+    # Re-run on PRs that could plausibly change any image. The image
+    # variants build in parallel via the matrix below; doc-only PRs are
+    # still skipped.
     paths:
       - "Dockerfile"
       - "go.mod"
@@ -16,6 +16,7 @@ on:
       - "internal/**"
       - "web/**"
       - "design-system/**"
+      - "tests/sdk-monitor/**"
       - ".github/workflows/build-image.yml"
   workflow_dispatch:
 
@@ -64,6 +65,14 @@ jobs:
             # with the server so the hosted deploy pins it to the same tag.
             context: .
             dockerfile: Dockerfile.prober
+          - image: e2a-sdk-monitor
+            display_name: SDK monitor image
+            # Continuously exercises the *published* Python SDK against prod
+            # (tests/sdk-monitor). Context is deliberately the service directory,
+            # not the repo root: the build must not be able to see sdks/python,
+            # so the SDK can only come from a real PyPI install.
+            context: tests/sdk-monitor
+            dockerfile: tests/sdk-monitor/Dockerfile
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -67,10 +67,12 @@ jobs:
             dockerfile: Dockerfile.prober
           - image: e2a-sdk-monitor
             display_name: SDK monitor image
-            # Continuously exercises the *published* Python SDK against prod
+            # Continuously exercises the *published* client surfaces (raw API,
+            # Python SDK, MCP, TypeScript SDK, CLI) against prod
             # (tests/sdk-monitor). Context is deliberately the service directory,
             # not the repo root: the build must not be able to see sdks/python,
-            # so the SDK can only come from a real PyPI install.
+            # sdks/typescript, or cli/, so every dependency can only come from a
+            # real PyPI/npm install of the published package.
             context: tests/sdk-monitor
             dockerfile: tests/sdk-monitor/Dockerfile
     steps:

--- a/tests/sdk-monitor/Dockerfile
+++ b/tests/sdk-monitor/Dockerfile
@@ -1,0 +1,23 @@
+# e2a-sdk-monitor image — continuously exercises the PUBLISHED Python SDK
+# against production (tests/sdk-monitor/monitor.py). Deployed as a Cloud Run
+# service; Cloud Scheduler drives POST /tick and e2a delivers to POST /webhook.
+#
+# Unlike Dockerfile.prober this builds from its own directory as context, not
+# the repo root: the image must not be able to see sdks/python, so the only way
+# to get the SDK is a real `pip install e2a==<version>` from PyPI.
+FROM python:3.12-slim
+
+# Only the pinned published SDK — no repo source is copied in.
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt
+
+COPY monitor.py /app/monitor.py
+WORKDIR /app
+
+RUN useradd -u 1001 -m e2a
+USER e2a
+
+# Cloud Run injects $PORT and monitor.py honors it; 8080 is the local default.
+EXPOSE 8080
+ENV PYTHONUNBUFFERED=1
+ENTRYPOINT ["python", "/app/monitor.py"]

--- a/tests/sdk-monitor/Dockerfile
+++ b/tests/sdk-monitor/Dockerfile
@@ -1,18 +1,38 @@
-# e2a-sdk-monitor image — continuously exercises the PUBLISHED Python SDK
-# against production (tests/sdk-monitor/monitor.py). Deployed as a Cloud Run
-# service; Cloud Scheduler drives POST /tick and e2a delivers to POST /webhook.
+# e2a-sdk-monitor image — continuously exercises the PUBLISHED client
+# surfaces (api/python_sdk/mcp/ts_sdk/cli — tests/sdk-monitor/monitor.py)
+# against production. Deployed as a Cloud Run service; Cloud Scheduler drives
+# POST /tick and e2a delivers to POST /webhook.
 #
 # Unlike Dockerfile.prober this builds from its own directory as context, not
-# the repo root: the image must not be able to see sdks/python, so the only way
-# to get the SDK is a real `pip install e2a==<version>` from PyPI.
+# the repo root: the image must not be able to see sdks/python, sdks/typescript,
+# or cli/, so both the Python and Node dependencies can only come from a real
+# `pip install` / `npm install` of the published packages.
 FROM python:3.12-slim
 
-# Only the pinned published SDK — no repo source is copied in.
+# Node is needed for the ts_sdk and cli interfaces (both shell out to a node
+# helper / the e2a bin rather than embedding a JS runtime elsewhere). Debian
+# bookworm's nodejs/npm packages are recent enough for @e2a/sdk and @e2a/cli
+# (both declare "engines": { "node": ">=18" }).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends nodejs npm \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Only the pinned published Python SDK — no repo source is copied in.
 COPY requirements.txt /app/requirements.txt
-RUN pip install --no-cache-dir -r /app/requirements.txt
+RUN pip install --no-cache-dir -r /app/requirements.txt \
+    && pip show e2a
+
+# Only the pinned published npm packages — no repo source is copied in.
+# --no-save: package.json already pins exact versions; this just materializes
+# node_modules without rewriting it (and without a lockfile to maintain).
+COPY package.json /app/package.json
+RUN npm install --no-save --omit=dev \
+    && npm ls @e2a/sdk @e2a/cli
 
 COPY monitor.py /app/monitor.py
-WORKDIR /app
+COPY js /app/js
 
 RUN useradd -u 1001 -m e2a
 USER e2a

--- a/tests/sdk-monitor/README.md
+++ b/tests/sdk-monitor/README.md
@@ -1,0 +1,141 @@
+# e2a-sdk-monitor
+
+Continuously exercises the **published** e2a Python SDK against production.
+
+## Why this exists
+
+The two existing continuous validators never touch an SDK. `cmd/e2a-prober`
+speaks raw HTTP; `tests/e2e-prod` deliberately uses zero-dependency `fetch`
+("no SDK" is a comment in the harness). So SDK regressions — including a
+failed or forgotten publish — were invisible to CI. That was not theoretical:
+the SDKs sat at 4.0.1 on PyPI/npm for weeks while `main` was at 5.2.0, and a
+downstream integration was broken against every fresh install in that window
+with nothing to catch it.
+
+This service closes that gap for Python. It lives beside `tests/e2e-prod`
+because it is the same kind of thing — a production-targeting harness that is
+not part of local dev — rather than under `cmd/`, which is Go binaries only.
+
+## What it exercises
+
+A full agent-to-agent round trip, entirely through the SDK's public surface:
+
+| SDK surface | Where |
+| --- | --- |
+| `E2AClient(api_key=…, base_url=…)` | client construction |
+| `client.messages.send(addr, body)` | `/tick` — outbound leg A → B |
+| `construct_event(raw, header, secret)` | `/webhook` — signature verification + envelope parsing |
+| `is_email_received(event)` | `/webhook` — event-type narrowing |
+| `client.inbound.from_event(event)` | `/webhook` — hydration to `InboundEmail` |
+| `email.reply(body, idempotency_key=…)` | `/webhook` — threaded reply B → A |
+
+Anything that breaks any of those — a bad publish, a wire-contract drift, a
+packaging regression — stops the success log line.
+
+### Handlers
+
+- **`POST /tick`** (Cloud Scheduler, ~5 min). Mints a nonce, sends
+  `probe <nonce>` from agent A to agent B. Returns 202.
+- **`POST /webhook`** (e2a delivers here — a real public HTTPS URL). Verifies
+  the signature, ignores non-`email.received` types, hydrates the message, then
+  branches on which agent received it: delivered to **B** → reply; delivered to
+  **A** → that's the reply coming home, emit the success line.
+- **`GET /health`** — liveness.
+
+The service is **stateless**. Cloud Run scales to zero, so nothing may live in
+memory between requests: the nonce in the subject carries all the correlation
+state, and the send timestamp embedded in it yields latency for free.
+
+`http.server` from the stdlib is deliberate — traffic is roughly one request
+per five minutes plus the webhook, and a framework would add dependencies that
+dilute the "does the SDK install and work" signal this image exists to produce.
+
+### Correlation and stale replies
+
+The nonce is `e2asdkmon.<epoch_ms>.<16 hex>`. The random suffix keeps
+concurrent probes distinct; the timestamp gives latency without storage. The
+leg is decided by `email.inbox` (the delivered-to agent), not by a `Re:`
+prefix, since subjects get rewritten in transit.
+
+A reply whose nonce timestamp is older than `E2A_MONITOR_MAX_AGE_MS`
+(default 15 min) logs `sdk_monitor_stale` and **not** `sdk_monitor_ok`, so a
+redelivered or long-delayed message can never refresh the freshness alert.
+Replies carry `idempotency_key=sdkmon:<event id>` so a webhook redelivery does
+not fan out into duplicate sends.
+
+## Log markers
+
+One JSON object per line on stdout. Build the alert on the success marker:
+
+```json
+{"event":"sdk_monitor_ok","nonce":"e2asdkmon.1753056000000.…","latency_ms":4231,"message_id":"msg_…"}
+```
+
+| `event` | Meaning |
+| --- | --- |
+| `sdk_monitor_ok` | Round trip completed. **Alert on the absence of this.** `latency_ms` is the metric. |
+| `sdk_monitor_tick` | Outbound leg sent. |
+| `sdk_monitor_replied` | Inbound leg received and replied to. |
+| `sdk_monitor_stale` | A probe arrived past `MAX_AGE_MS`; not a success. |
+| `sdk_monitor_error` | Failure, with `stage` = `config` \| `send` \| `signature` \| `hydrate` \| `reply`. |
+| `sdk_monitor_start` | Process start. |
+
+Secret values are never logged — only env var *names* on a config failure.
+
+## Configuration
+
+All via environment.
+
+| Var | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `E2A_API_KEY` | yes | — | Account-scoped key owning both agents. |
+| `E2A_MONITOR_AGENT_A` | yes | — | Sender; also receives the reply. |
+| `E2A_MONITOR_AGENT_B` | yes | — | Receiver; sends the reply. |
+| `E2A_MONITOR_WEBHOOK_SECRET` | yes | — | The `whsec_…` from the subscription. |
+| `E2A_BASE_URL` | no | `https://api.e2a.dev` | |
+| `E2A_MONITOR_MAX_AGE_MS` | no | `900000` | Stale-reply cutoff. |
+| `PORT` | no | `8080` | Cloud Run injects this. |
+
+Missing required vars exit 1 at startup so a misconfigured deploy fails loudly.
+The webhook additionally fails closed at request time: an unset secret or a bad
+signature is a 401, never an accepted delivery.
+
+## One-time setup (infrastructure, not application code)
+
+The service does **not** create its own webhook subscription — subscriptions
+are infrastructure, created once out of band:
+
+1. Create the two agents (A and B) on the monitoring account.
+2. Create an account-scoped webhook subscription pointing at the deployed
+   service's `https://…/webhook`, via the e2a MCP `create_webhook` tool or the
+   dashboard. The `whsec_…` secret is **shown only at creation** — capture it
+   then and store it as the deployment's `E2A_MONITOR_WEBHOOK_SECRET`. If it is
+   lost, rotate rather than trying to read it back.
+3. Point a Cloud Scheduler job at `POST /tick`.
+
+Note the subscription fans out every account event (`email.sent`, bounces,
+domain events), not just `email.received` — the handler narrows on its own.
+
+## SDK version bump policy
+
+`requirements.txt` pins an exact published version (currently **5.2.0**). It is
+**never** a path or editable dependency on `sdks/python` — installing from
+local source would defeat the entire purpose by hiding a broken publish.
+
+Bump the pin as a step of every Python SDK release, *after* the new version is
+live on PyPI. Rebuilding the image then proves the release is installable and
+works end to end against production. A build failure here is the intended
+signal, not something to work around.
+
+## Local checks
+
+```bash
+python -m venv venv && ./venv/bin/pip install -r requirements.txt
+E2A_MONITOR_WEBHOOK_SECRET=whsec_testsecret ./venv/bin/python test_monitor.py
+```
+
+`test_monitor.py` is offline and dependency-free (no pytest): it covers
+signature accept/reject, replay rejection, fail-closed on an unset secret,
+non-inbound event types, the stale-reply guard, and the success path with a
+stubbed hydration. The live round trip is only exercisable against a real
+deployment with a reachable webhook URL.

--- a/tests/sdk-monitor/README.md
+++ b/tests/sdk-monitor/README.md
@@ -1,86 +1,134 @@
 # e2a-sdk-monitor
 
-Continuously exercises the **published** e2a Python SDK against production.
+Continuously exercises **five published client surfaces** against production:
+the raw HTTP API, the Python SDK, the MCP server, the TypeScript SDK, and the
+CLI.
 
 ## Why this exists
 
-The two existing continuous validators never touch an SDK. `cmd/e2a-prober`
-speaks raw HTTP; `tests/e2e-prod` deliberately uses zero-dependency `fetch`
-("no SDK" is a comment in the harness). So SDK regressions — including a
-failed or forgotten publish — were invisible to CI. That was not theoretical:
-the SDKs sat at 4.0.1 on PyPI/npm for weeks while `main` was at 5.2.0, and a
-downstream integration was broken against every fresh install in that window
-with nothing to catch it.
+The two existing continuous validators never touch a published client.
+`cmd/e2a-prober` speaks raw HTTP; `tests/e2e-prod` deliberately uses
+zero-dependency `fetch` ("no SDK" is a comment in the harness). So client
+regressions — including a failed or forgotten publish — were invisible to CI.
+That was not theoretical: the SDKs sat at 4.0.1 on PyPI/npm for weeks while
+`main` was at 5.2.0, and a downstream integration was broken against every
+fresh install in that window with nothing to catch it.
 
-This service closes that gap for Python. It lives beside `tests/e2e-prod`
-because it is the same kind of thing — a production-targeting harness that is
-not part of local dev — rather than under `cmd/`, which is Go binaries only.
+This service closes that gap across every interface a user actually reaches
+for, each with its own success signal so a break in one pages distinctly from
+a break in another. It lives beside `tests/e2e-prod` because it is the same
+kind of thing — a production-targeting harness that is not part of local dev —
+rather than under `cmd/`, which is Go binaries only.
 
 ## What it exercises
 
-A full agent-to-agent round trip, entirely through the SDK's public surface:
+The same canonical agent-to-agent round trip, run once per tick through each
+of five interfaces:
 
-| SDK surface | Where |
-| --- | --- |
-| `E2AClient(api_key=…, base_url=…)` | client construction |
-| `client.messages.send(addr, body)` | `/tick` — outbound leg A → B |
-| `construct_event(raw, header, secret)` | `/webhook` — signature verification + envelope parsing |
-| `is_email_received(event)` | `/webhook` — event-type narrowing |
-| `client.inbound.from_event(event)` | `/webhook` — hydration to `InboundEmail` |
-| `email.reply(body, idempotency_key=…)` | `/webhook` — threaded reply B → A |
+| iface key | send + reply performed via | runtime |
+| --- | --- | --- |
+| `api` | raw HTTP against the server's `/v1/agents/{email}/messages` (and `.../reply`) endpoints — no SDK. Catches a server-contract break distinct from an SDK break. | python (stdlib `urllib`) |
+| `python_sdk` | the published `e2a` PyPI package | python |
+| `mcp` | the deployed MCP streamable-HTTP server's `send_message` / `reply_to_message` tools | python (hand-rolled JSON-RPC over `urllib`) |
+| `ts_sdk` | the published `@e2a/sdk` npm package (v5.2.0) | node, shelled out from python |
+| `cli` | the published `@e2a/cli` npm package (v2.0.0, bin `e2a`) | node, shelled out from python |
 
 Anything that breaks any of those — a bad publish, a wire-contract drift, a
-packaging regression — stops the success log line.
+packaging regression, an MCP transport change — stops that interface's
+success log line, without silencing the other four.
 
 ### Handlers
 
-- **`POST /tick`** (Cloud Scheduler, ~5 min). Mints a nonce, sends
-  `probe <nonce>` from agent A to agent B. Returns 202.
-- **`POST /webhook`** (e2a delivers here — a real public HTTPS URL). Verifies
-  the signature, ignores non-`email.received` types, hydrates the message, then
-  branches on which agent received it: delivered to **B** → reply; delivered to
-  **A** → that's the reply coming home, emit the success line.
+- **`POST /tick`** (Cloud Scheduler, ~5 min). Fires ONE outbound leg PER
+  interface: mints a nonce that encodes the interface, sends
+  `probe <nonce>` from agent A to agent B via that interface, and returns a
+  per-interface summary. A single interface's send failure is logged
+  (`monitor_error`, `stage=send`) and does **not** abort the other four.
+- **`POST /webhook`** (e2a delivers here — a real public HTTPS URL). This
+  handler is the correlation hub and is itself the service's own
+  infrastructure — verification and hydration always go through the
+  published Python SDK's `construct_event` / `inbound.from_event`,
+  regardless of which interface the nonce names. It ignores non-
+  `email.received` types, then branches on which agent received the mail:
+  delivered to **B** → reply **via the interface named in the nonce** (so
+  each interface's reply/threading path is exercised too, not just send);
+  delivered to **A** → that's the reply coming home, emit the success line
+  with that interface's key.
 - **`GET /health`** — liveness.
 
-The service is **stateless**. Cloud Run scales to zero, so nothing may live in
-memory between requests: the nonce in the subject carries all the correlation
-state, and the send timestamp embedded in it yields latency for free.
+The service is **stateless** across requests. Cloud Run scales to zero, so
+nothing may live in memory between requests except the five interface
+strategy objects built once at import time from static config (API key, base
+URL, MCP URL) — never per-round-trip state. All correlation state (which
+round trip is in flight, when it started, which interface owns it) travels in
+the message subject; the send timestamp embedded in it yields latency for
+free.
 
-`http.server` from the stdlib is deliberate — traffic is roughly one request
-per five minutes plus the webhook, and a framework would add dependencies that
-dilute the "does the SDK install and work" signal this image exists to produce.
+`http.server` from the stdlib is deliberate for the Python side — traffic is
+roughly one request per five minutes plus the webhook, and a framework would
+add dependencies that dilute the "do these clients install and work" signal
+this image exists to produce. The Node interfaces are invoked as short-lived
+subprocesses rather than embedding a JS runtime elsewhere in the request path.
 
-### Correlation and stale replies
+### Correlation, interface encoding, and stale replies
 
-The nonce is `e2asdkmon.<epoch_ms>.<16 hex>`. The random suffix keeps
-concurrent probes distinct; the timestamp gives latency without storage. The
-leg is decided by `email.inbox` (the delivered-to agent), not by a `Re:`
-prefix, since subjects get rewritten in transit.
+The nonce is `e2asdkmon.<iface>.<epoch_ms>.<16 hex>`, where `<iface>` is one
+of `api`, `python_sdk`, `mcp`, `ts_sdk`, `cli`. The iface segment lets the
+webhook hub dispatch the reply leg to the exact interface that sent the
+probe — a `ts_sdk` outbound leg gets a `ts_sdk` reply, never a different
+interface silently substituting for it. `NONCE_RE` captures the iface
+generically (not hardcoded to the five known keys); a nonce naming an
+interface this build doesn't recognize is handled safely — logged
+(`monitor_error`, `stage=unknown_iface`) and ignored, never crashed on and
+never credited with a success. Older, pre-multi-interface nonces (no iface
+segment) simply don't match; there is no deployed consumer of that shape to
+stay compatible with.
 
-A reply whose nonce timestamp is older than `E2A_MONITOR_MAX_AGE_MS`
-(default 15 min) logs `sdk_monitor_stale` and **not** `sdk_monitor_ok`, so a
-redelivered or long-delayed message can never refresh the freshness alert.
-Replies carry `idempotency_key=sdkmon:<event id>` so a webhook redelivery does
-not fan out into duplicate sends.
+The random suffix keeps concurrent probes distinct; the timestamp gives
+latency without storage. The leg is decided by `email.inbox` (the
+delivered-to agent), not by a `Re:` prefix, since subjects get rewritten in
+transit. None of the five interfaces sets a subject override on reply — every
+wire shape (the REST `ReplyRequest`, both SDKs' `reply()`, the CLI's `reply`
+subcommand, the MCP `reply_to_message` tool) derives it server-side as
+`Re: <original subject>`, which still satisfies `NONCE_RE.search()` since the
+nonce is a substring.
+
+A reply whose nonce timestamp is older than `E2A_MONITOR_MAX_AGE_MS` (default
+15 min) logs `monitor_stale` and **not** `monitor_ok`, so a redelivered or
+long-delayed message can never refresh the freshness alert — on both the
+outbound leg (blocks a duplicate reply from firing) and the reply leg (blocks
+a stale success). Replies carry `idempotency_key=sdkmon:<event id>` on every
+interface so a webhook redelivery does not fan out into duplicate sends.
 
 ## Log markers
 
-One JSON object per line on stdout. Build the alert on the success marker:
+One JSON object per line on stdout. Build the alert on the success marker,
+labeled by `iface`:
 
 ```json
-{"event":"sdk_monitor_ok","nonce":"e2asdkmon.1753056000000.…","latency_ms":4231,"message_id":"msg_…"}
+{"event":"monitor_ok","iface":"ts_sdk","nonce":"e2asdkmon.ts_sdk.1753056000000.…","latency_ms":4231,"message_id":"msg_…"}
 ```
 
 | `event` | Meaning |
 | --- | --- |
-| `sdk_monitor_ok` | Round trip completed. **Alert on the absence of this.** `latency_ms` is the metric. |
-| `sdk_monitor_tick` | Outbound leg sent. |
-| `sdk_monitor_replied` | Inbound leg received and replied to. |
-| `sdk_monitor_stale` | A probe arrived past `MAX_AGE_MS`; not a success. |
-| `sdk_monitor_error` | Failure, with `stage` = `config` \| `send` \| `signature` \| `hydrate` \| `reply`. |
-| `sdk_monitor_start` | Process start. |
+| `monitor_ok` | Round trip completed for `iface`. **Alert on the absence of this, per iface.** `latency_ms` is the metric. |
+| `monitor_tick` | Outbound leg sent for `iface`. |
+| `monitor_replied` | Inbound leg received and replied to, via `iface`. |
+| `monitor_stale` | A probe arrived past `MAX_AGE_MS` on `leg` (`outbound` or `reply`) for `iface`; not a success. |
+| `monitor_skip` | `iface` was skipped this tick because its config is absent (currently only `mcp` without `E2A_MONITOR_MCP_URL`). |
+| `monitor_error` | Failure, with `stage` = `config` \| `send` \| `signature` \| `hydrate` \| `reply` \| `unknown_iface`, and (where applicable) `iface`. |
+| `monitor_start` | Process start; lists the configured `ifaces` and whether `mcp` is configured. |
 
 Secret values are never logged — only env var *names* on a config failure.
+
+### Ops contract
+
+Build a log-based metric on `monitor_ok`, labeled by `iface`. Alert per
+interface — "no `monitor_ok{iface=X}` in N minutes" — for each of the five
+`iface` values independently, so a regression in one client surface (say, a
+broken `@e2a/cli` publish) pages distinctly from a break in another (say, the
+raw API contract). This is intentionally built *after* this service, as a
+separate ops step; the log line is the whole contract this service owes ops.
 
 ## Configuration
 
@@ -88,17 +136,26 @@ All via environment.
 
 | Var | Required | Default | Notes |
 | --- | --- | --- | --- |
-| `E2A_API_KEY` | yes | — | Account-scoped key owning both agents. |
+| `E2A_API_KEY` | yes | — | Account-scoped key owning both agents; shared by every interface. |
 | `E2A_MONITOR_AGENT_A` | yes | — | Sender; also receives the reply. |
 | `E2A_MONITOR_AGENT_B` | yes | — | Receiver; sends the reply. |
 | `E2A_MONITOR_WEBHOOK_SECRET` | yes | — | The `whsec_…` from the subscription. |
-| `E2A_BASE_URL` | no | `https://api.e2a.dev` | |
+| `E2A_BASE_URL` | no | `https://api.e2a.dev` | API host, shared by `api`, `python_sdk`, `ts_sdk` (as `E2A_API_URL`), and `cli` (as `E2A_URL`). |
+| `E2A_MONITOR_MCP_URL` | no | — | Full streamable-HTTP MCP endpoint (e.g. `https://api.e2a.dev/mcp`), matching the prober's `E2A_PROBE_MCP_URL` convention. **Optional**: when unset, the `mcp` interface is skipped every tick (`monitor_skip`) instead of failing the whole service — see "Design decisions to review" below. |
 | `E2A_MONITOR_MAX_AGE_MS` | no | `900000` | Stale-reply cutoff. |
 | `PORT` | no | `8080` | Cloud Run injects this. |
 
-Missing required vars exit 1 at startup so a misconfigured deploy fails loudly.
-The webhook additionally fails closed at request time: an unset secret or a bad
-signature is a 401, never an accepted delivery.
+`api`, `python_sdk`, `ts_sdk`, and `cli` are **core** interfaces: they need no
+config beyond the vars already required at startup, so they run every tick.
+`mcp` is the one **optional** interface — its endpoint may not be reachable
+or fixed in every deployment, so an unset `E2A_MONITOR_MCP_URL` skips it
+(mirrors the prober's convention for `E2A_PROBE_MCP_URL`) rather than failing
+the whole service.
+
+Missing REQUIRED vars exit 1 at startup so a misconfigured deploy fails
+loudly (names only, never values). The webhook additionally fails closed at
+request time: an unset secret or a bad signature is a 401, never an accepted
+delivery.
 
 ## One-time setup (infrastructure, not application code)
 
@@ -112,20 +169,38 @@ are infrastructure, created once out of band:
    then and store it as the deployment's `E2A_MONITOR_WEBHOOK_SECRET`. If it is
    lost, rotate rather than trying to read it back.
 3. Point a Cloud Scheduler job at `POST /tick`.
+4. If the deployed MCP server is reachable at a fixed URL, set
+   `E2A_MONITOR_MCP_URL` to its full `/mcp` endpoint to enable that interface.
 
 Note the subscription fans out every account event (`email.sent`, bounces,
 domain events), not just `email.received` — the handler narrows on its own.
 
-## SDK version bump policy
+## Multi-runtime image
 
-`requirements.txt` pins an exact published version (currently **5.2.0**). It is
-**never** a path or editable dependency on `sdks/python` — installing from
-local source would defeat the entire purpose by hiding a broken publish.
-
-Bump the pin as a step of every Python SDK release, *after* the new version is
-live on PyPI. Rebuilding the image then proves the release is installable and
-works end to end against production. A build failure here is the intended
+The image now needs **both** Python and Node: Python drives the service and
+the `api`/`python_sdk`/`mcp` interfaces directly; `ts_sdk` and `cli` are
+short-lived Node subprocesses (`js/monitor-helper.mjs` for the TS SDK; the
+`@e2a/cli` bin directly for the CLI). The build stays faithful to "published
+packages only, never workspace source" for BOTH ecosystems: `requirements.txt`
+pins the exact PyPI `e2a` version; `package.json` pins the exact npm
+`@e2a/sdk` and `@e2a/cli` versions. Neither `sdks/python`, `sdks/typescript`,
+nor `cli/` is reachable from the build context (`tests/sdk-monitor`), so both
+dependency trees can only come from a real registry install. The Dockerfile
+verifies this at build time (`pip show e2a`, `npm ls @e2a/sdk @e2a/cli`) —
+a version mismatch or failed install fails the build, which is the intended
 signal, not something to work around.
+
+## SDK / package version bump policy
+
+`requirements.txt` pins an exact published Python SDK version (currently
+**5.2.0**); `package.json` pins exact published `@e2a/sdk` (**5.2.0**) and
+`@e2a/cli` (**2.0.0**) versions. None of these is ever a path or workspace
+dependency on the corresponding source directory — installing from local
+source would defeat the entire purpose by hiding a broken publish.
+
+Bump each pin as a step of its package's release, *after* the new version is
+live on PyPI/npm. Rebuilding the image then proves the release is installable
+and works end to end against production.
 
 ## Local checks
 
@@ -136,6 +211,40 @@ E2A_MONITOR_WEBHOOK_SECRET=whsec_testsecret ./venv/bin/python test_monitor.py
 
 `test_monitor.py` is offline and dependency-free (no pytest): it covers
 signature accept/reject, replay rejection, fail-closed on an unset secret,
-non-inbound event types, the stale-reply guard, and the success path with a
-stubbed hydration. The live round trip is only exercisable against a real
-deployment with a reachable webhook URL.
+non-inbound event types, the nonce↔iface encoding round trip for all five
+interfaces, the stale-reply guard on both legs, interface-strategy dispatch
+(a reply goes to the exact interface the nonce names, and no other), the
+unknown-iface safety net, and the `/tick` fan-out (one interface's failure
+doesn't abort the others; an unavailable interface is skipped, not attempted).
+Every interface's actual send/reply I/O is stubbed with fakes injected into
+`monitor.STRATEGIES` — no real network call, no real subprocess to node/npm.
+The live round trips are only exercisable against a real deployment with a
+reachable webhook URL.
+
+## Design decisions to review
+
+A few choices were made from reading the OSS source rather than a written
+spec; flagging them explicitly:
+
+- **MCP transport**: the deployed MCP server is stateless
+  (`sessionIdGenerator: undefined` in `mcp/src/http-server.ts`), which skips
+  all session/initialize gating — so a bare `tools/call` JSON-RPC request
+  dispatches with no prior `initialize`. The server answers with an SSE
+  response (`enableJsonResponse` is left unset, i.e. `false`), so the `mcp`
+  interface hand-rolls a single JSON-RPC POST over stdlib `urllib` and parses
+  the `data:` frames itself, mirroring
+  `internal/selftest/scenarios.go`'s `parseJSONRPCEnvelope` rather than
+  pulling in the `mcp` Python package — one dependency-free request/response,
+  no session to keep alive, matches this service's "stateless, minimal deps"
+  design.
+- **`E2A_MONITOR_MCP_URL` is optional and un-defaulted.** It is NOT derived
+  from `E2A_BASE_URL` + `/mcp` even though the hosted deployment happens to
+  serve both on `api.e2a.dev` today, because the deployed MCP server's
+  reachable URL is a deployment detail this monitor shouldn't assume; unset
+  it and the `mcp` interface just skips (`monitor_skip`) rather than the
+  whole service refusing to start.
+- **CLI reply does NOT need a send-only fallback.** `e2a reply <message-id>
+  --body … --agent …` (`cli/src/commands/send.ts`) calls
+  `client.messages.reply`, whose wire `ReplyRequest` has no subject field —
+  the server always derives `Re: <original subject>`, so the CLI's reply is a
+  genuine in-thread reply like every other interface, not a plain send.

--- a/tests/sdk-monitor/README.md
+++ b/tests/sdk-monitor/README.md
@@ -43,7 +43,15 @@ success log line, without silencing the other four.
   interface: mints a nonce that encodes the interface, sends
   `probe <nonce>` from agent A to agent B via that interface, and returns a
   per-interface summary. A single interface's send failure is logged
-  (`monitor_error`, `stage=send`) and does **not** abort the other four.
+  (`monitor_error`, `stage=send`) and does **not** abort the other four. The
+  response's `ok` boolean and HTTP status are computed over **considered**
+  interfaces only — one skipped this tick (currently only `mcp` absent
+  `E2A_MONITOR_MCP_URL`) doesn't count against the aggregate either way:
+  `200` when every considered interface succeeded, `207` when some but not
+  all did (partial failure), `500` when every considered interface failed
+  (total outage — a non-2xx so Cloud Scheduler doesn't read a full send-side
+  blackout as healthy). The per-interface `results` body always carries the
+  detail regardless of the aggregate.
 - **`POST /webhook`** (e2a delivers here — a real public HTTPS URL). This
   handler is the correlation hub and is itself the service's own
   infrastructure — verification and hydration always go through the
@@ -72,26 +80,57 @@ subprocesses rather than embedding a JS runtime elsewhere in the request path.
 
 ### Correlation, interface encoding, and stale replies
 
-The nonce is `e2asdkmon.<iface>.<epoch_ms>.<16 hex>`, where `<iface>` is one
-of `api`, `python_sdk`, `mcp`, `ts_sdk`, `cli`. The iface segment lets the
-webhook hub dispatch the reply leg to the exact interface that sent the
-probe — a `ts_sdk` outbound leg gets a `ts_sdk` reply, never a different
-interface silently substituting for it. `NONCE_RE` captures the iface
-generically (not hardcoded to the five known keys); a nonce naming an
+The nonce is `e2asdkmon.<iface>.<epoch_ms>.<16 hex>.<16 hex tag>`, where
+`<iface>` is one of `api`, `python_sdk`, `mcp`, `ts_sdk`, `cli`. The iface
+segment lets the webhook hub dispatch the reply leg to the exact interface
+that sent the probe — a `ts_sdk` outbound leg gets a `ts_sdk` reply, never a
+different interface silently substituting for it. `NONCE_RE` captures the
+iface generically (not hardcoded to the five known keys); a nonce naming an
 interface this build doesn't recognize is handled safely — logged
 (`monitor_error`, `stage=unknown_iface`) and ignored, never crashed on and
-never credited with a success. Older, pre-multi-interface nonces (no iface
-segment) simply don't match; there is no deployed consumer of that shape to
-stay compatible with.
+never credited with a success. Older, pre-multi-interface or pre-MAC nonces
+(no iface/tag segment) simply don't match; there is no deployed consumer of
+that shape to stay compatible with.
 
 The random suffix keeps concurrent probes distinct; the timestamp gives
-latency without storage. The leg is decided by `email.inbox` (the
-delivered-to agent), not by a `Re:` prefix, since subjects get rewritten in
-transit. None of the five interfaces sets a subject override on reply — every
-wire shape (the REST `ReplyRequest`, both SDKs' `reply()`, the CLI's `reply`
-subcommand, the MCP `reply_to_message` tool) derives it server-side as
-`Re: <original subject>`, which still satisfies `NONCE_RE.search()` since the
-nonce is a substring.
+latency without storage. The trailing `tag` is the first 16 hex chars of
+`HMAC-SHA256(NONCE_KEY, "e2asdkmon-nonce:<iface>.<epoch_ms>.<16 hex>")` —
+see "Nonce authentication" below; every leg of the round trip re-derives and
+constant-time-compares it before acting. The leg is decided by `email.inbox`
+(the delivered-to agent), not by a `Re:` prefix, since subjects get rewritten
+in transit. None of the five interfaces sets a subject override on reply —
+every wire shape (the REST `ReplyRequest`, both SDKs' `reply()`, the CLI's
+`reply` subcommand, the MCP `reply_to_message` tool) derives it server-side
+as `Re: <original subject>`, which still satisfies `NONCE_RE.search()` since
+the nonce is a substring.
+
+### Nonce authentication
+
+Without a MAC, the nonce is entirely attacker-choosable: anyone able to
+email agent A could pick any `iface`/timestamp/random suffix and forge a
+`monitor_ok{iface=X}` for a chosen interface, with no binding to a real
+`/tick`. `handle_webhook` closes this by re-deriving the expected tag from
+the parsed `iface`/`epoch_ms`/16-hex segments and comparing it to the
+received tag with `hmac.compare_digest` **before acting on either leg** — a
+mismatch is logged (`monitor_error`, `stage=nonce_auth`, never the key or the
+tag) and the request is treated as not-our-probe (`200`,
+`{"ignored": "bad nonce mac"}`): no reply is sent, no `monitor_ok` is
+emitted. This also authenticates `sent_ms` itself, so a forged nonce can't
+look artificially fresh to defeat the `MAX_AGE_MS` staleness guard.
+
+The signing key (`NONCE_KEY`) is `E2A_MONITOR_NONCE_SECRET` if set, else the
+already-required `E2A_MONITOR_WEBHOOK_SECRET` — no new required config.
+Reusing the webhook secret is safe: the fixed `e2asdkmon-nonce:` prefix in
+the signed message domain-separates this MAC from the webhook's own HMAC
+over the same value, so a forger who somehow obtained one signature could
+still not derive the other.
+
+**This is defense-in-depth, not the primary control.** The primary
+mitigation is infrastructure, not code — see "One-time setup" below: create
+agents A and B with an inbound allowlist naming only each other, so e2a
+rejects a third party's mail to them at the source, before it ever reaches
+this service. The signed nonce protects against the case where that
+allowlist is misconfigured or absent.
 
 A reply whose nonce timestamp is older than `E2A_MONITOR_MAX_AGE_MS` (default
 15 min) logs `monitor_stale` and **not** `monitor_ok`, so a redelivered or
@@ -116,10 +155,24 @@ labeled by `iface`:
 | `monitor_replied` | Inbound leg received and replied to, via `iface`. |
 | `monitor_stale` | A probe arrived past `MAX_AGE_MS` on `leg` (`outbound` or `reply`) for `iface`; not a success. |
 | `monitor_skip` | `iface` was skipped this tick because its config is absent (currently only `mcp` without `E2A_MONITOR_MCP_URL`). |
-| `monitor_error` | Failure, with `stage` = `config` \| `send` \| `signature` \| `hydrate` \| `reply` \| `unknown_iface`, and (where applicable) `iface`. |
+| `monitor_error` | Failure, with `stage` = `config` \| `send` \| `signature` \| `hydrate` \| `reply` \| `unknown_iface` \| `nonce_auth`, and (where applicable) `iface`. A `send`/`reply` failure includes a held (`pending_review`), terminal-`failed`, or unrecognized send-response `status` — see "Uniform send-status handling" below. |
 | `monitor_start` | Process start; lists the configured `ifaces` and whether `mcp` is configured. |
 
-Secret values are never logged — only env var *names* on a config failure.
+Secret values are never logged — only env var *names* on a config failure. A
+`nonce_auth` failure logs `iface` only, never the nonce-signing key or the
+received/expected tag.
+
+### Uniform send-status handling
+
+`SendResultView.status` (`api/openapi.yaml`) is an open string set; only
+`sent` and `accepted` are genuinely successful outcomes. Every interface —
+`api`, `python_sdk`, `mcp`, `ts_sdk` (checked in `js/monitor-helper.mjs`, the
+node helper it shells out to), and `cli` (via its own `emitSendResult`,
+`cli/src/commands/send.ts`) — treats `pending_review` (held for review),
+`failed` (terminal failure), and any status this build doesn't recognize as
+an immediate failure: `monitor_error(stage=send` or `reply)` at send/reply
+time, not a success logged now that only surfaces later as a
+`monitor_stale` timeout once the reply never arrives.
 
 ### Ops contract
 
@@ -139,7 +192,8 @@ All via environment.
 | `E2A_API_KEY` | yes | — | Account-scoped key owning both agents; shared by every interface. |
 | `E2A_MONITOR_AGENT_A` | yes | — | Sender; also receives the reply. |
 | `E2A_MONITOR_AGENT_B` | yes | — | Receiver; sends the reply. |
-| `E2A_MONITOR_WEBHOOK_SECRET` | yes | — | The `whsec_…` from the subscription. |
+| `E2A_MONITOR_WEBHOOK_SECRET` | yes | — | The `whsec_…` from the subscription. Also the nonce-signing key's fallback — see `E2A_MONITOR_NONCE_SECRET`. |
+| `E2A_MONITOR_NONCE_SECRET` | no | falls back to `E2A_MONITOR_WEBHOOK_SECRET` | Dedicated key for the nonce HMAC tag (see "Nonce authentication" above). Optional so protection never depends on an unset var — set it only if you want to rotate the nonce key independently of the webhook secret. |
 | `E2A_BASE_URL` | no | `https://api.e2a.dev` | API host, shared by `api`, `python_sdk`, `ts_sdk` (as `E2A_API_URL`), and `cli` (as `E2A_URL`). |
 | `E2A_MONITOR_MCP_URL` | no | — | Full streamable-HTTP MCP endpoint (e.g. `https://api.e2a.dev/mcp`), matching the prober's `E2A_PROBE_MCP_URL` convention. **Optional**: when unset, the `mcp` interface is skipped every tick (`monitor_skip`) instead of failing the whole service — see "Design decisions to review" below. |
 | `E2A_MONITOR_MAX_AGE_MS` | no | `900000` | Stale-reply cutoff. |
@@ -162,7 +216,15 @@ delivery.
 The service does **not** create its own webhook subscription — subscriptions
 are infrastructure, created once out of band:
 
-1. Create the two agents (A and B) on the monitoring account.
+1. Create the two agents (A and B) on the monitoring account, then set each
+   one's inbound protection to an allowlist naming only the other
+   (`inbound_gate_policy=allowlist`, `inbound_gate_allowlist=[the other
+   agent's address]`, `inbound_gate_action=block` or `review`). This is the
+   **primary** mitigation against a forged probe — e2a rejects (or holds)
+   any third-party inbound mail to A or B at the source, before it ever
+   reaches this service. The signed nonce (see "Nonce authentication" above)
+   is defense-in-depth for the case where this allowlist is misconfigured,
+   absent, or loosened later.
 2. Create an account-scoped webhook subscription pointing at the deployed
    service's `https://…/webhook`, via the e2a MCP `create_webhook` tool or the
    dashboard. The `whsec_…` secret is **shown only at creation** — capture it
@@ -211,15 +273,29 @@ E2A_MONITOR_WEBHOOK_SECRET=whsec_testsecret ./venv/bin/python test_monitor.py
 
 `test_monitor.py` is offline and dependency-free (no pytest): it covers
 signature accept/reject, replay rejection, fail-closed on an unset secret,
-non-inbound event types, the nonce↔iface encoding round trip for all five
-interfaces, the stale-reply guard on both legs, interface-strategy dispatch
-(a reply goes to the exact interface the nonce names, and no other), the
-unknown-iface safety net, and the `/tick` fan-out (one interface's failure
-doesn't abort the others; an unavailable interface is skipped, not attempted).
-Every interface's actual send/reply I/O is stubbed with fakes injected into
-`monitor.STRATEGIES` — no real network call, no real subprocess to node/npm.
-The live round trips are only exercisable against a real deployment with a
-reachable webhook URL.
+non-inbound event types, the nonce↔iface encoding round trip (including the
+HMAC tag) for all five interfaces, nonce-MAC authentication (a tampered
+iface/timestamp/tag is rejected — no reply, no `monitor_ok`; a pre-MAC
+3-part nonce doesn't even match), the stale-reply guard on both legs,
+interface-strategy dispatch (a reply goes to the exact interface the nonce
+names, and no other), the unknown-iface safety net, the `/tick` aggregate +
+status-code semantics (all-ok → 200, one optional interface skipped but the
+rest ok → 200, partial failure → 207, total outage across every considered
+interface → 500), uniform non-`sent`/`accepted` send-status handling across
+every offline-exercisable interface (a stubbed `pending_review`/`failed`
+response raises immediately rather than logging success-shaped), the wire
+shape of the `api`/`ts_sdk`/`cli` strategies (argv/URL/headers, and that
+secrets never land in argv), the minimal subprocess environment (the full
+parent env, including the webhook secret, is never handed to a node/CLI
+child), and `McpStrategy`'s JSON-RPC response parsing (SSE framing, a
+JSON-RPC error, a tool-level `isError`, a leading notification or
+mismatched-id frame that must be skipped rather than mistaken for the real
+response, and the malformed-response guard). Every interface's actual
+send/reply I/O is stubbed with fakes injected into `monitor.STRATEGIES`, or
+with `urllib.request.urlopen` / `subprocess.run` monkeypatched to
+capture/replay a call — no real network call, no real subprocess to
+node/npm. The live round trips are only exercisable against a real
+deployment with a reachable webhook URL.
 
 ## Design decisions to review
 

--- a/tests/sdk-monitor/js/monitor-helper.mjs
+++ b/tests/sdk-monitor/js/monitor-helper.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// Node-runtime helper for the ts_sdk interface (tests/sdk-monitor/monitor.py).
+//
+// The Python service shells out to this script rather than embedding a JS
+// runtime. It imports `@e2a/sdk/v1` resolved from node_modules — populated at
+// image build time by `npm install @e2a/sdk@5.2.0` (see ../Dockerfile), the
+// same "published package only, never workspace source" discipline as
+// requirements.txt for the Python SDK.
+//
+// Secrets travel via environment only (E2A_API_KEY), never argv — subject,
+// body, and addresses are not secret and are passed as positional args.
+//
+// Usage:
+//   node monitor-helper.mjs send <fromAgent> <toAgent> <subject> <body>
+//   node monitor-helper.mjs reply <inboxAgent> <messageId> <text> <idempotencyKey>
+
+import { E2AClient } from "@e2a/sdk/v1";
+
+const [, , cmd, ...args] = process.argv;
+
+function fail(message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+}
+
+const apiKey = process.env.E2A_API_KEY;
+if (!apiKey) fail("missing E2A_API_KEY");
+
+// E2A_API_URL is the canonical env name the SDK reads (falls back to the
+// hosted default if unset, matching the SDK's own resolution order).
+const client = new E2AClient({ apiKey, baseUrl: process.env.E2A_API_URL });
+
+async function main() {
+  if (cmd === "send") {
+    const [from, to, subject, body] = args;
+    if (!from || !to || subject === undefined || body === undefined) {
+      fail("usage: monitor-helper.mjs send <from> <to> <subject> <body>");
+    }
+    const result = await client.messages.send(from, { to: [to], subject, text: body });
+    process.stdout.write(JSON.stringify(result) + "\n");
+    return;
+  }
+  if (cmd === "reply") {
+    const [inbox, messageId, text, idempotencyKey] = args;
+    if (!inbox || !messageId || text === undefined) {
+      fail("usage: monitor-helper.mjs reply <inbox> <message-id> <text> <idempotency-key>");
+    }
+    const opts = idempotencyKey ? { idempotencyKey } : {};
+    const result = await client.messages.reply(inbox, messageId, { text }, opts);
+    process.stdout.write(JSON.stringify(result) + "\n");
+    return;
+  }
+  fail(`unknown command: ${cmd ?? "(none)"}`);
+}
+
+main().catch((err) => {
+  fail(err?.message ?? String(err));
+});

--- a/tests/sdk-monitor/js/monitor-helper.mjs
+++ b/tests/sdk-monitor/js/monitor-helper.mjs
@@ -23,6 +23,26 @@ function fail(message) {
   process.exit(1);
 }
 
+// Mirrors cli/src/commands/send.ts's emitSendResult: SendResultView.status is
+// an open set (api/openapi.yaml), and only "sent"/"accepted" are genuinely
+// successful outcomes. "pending_review" (held for review) and "failed" (or
+// any status this build doesn't recognize) must not be reported as success —
+// without this check the parent monitor.py (_run_subprocess) would see exit
+// 0 and log a held/failed send as monitor_tick success, only surfacing the
+// problem later as a monitor_stale timeout instead of an immediate
+// monitor_error(stage="send"/"reply").
+const SEND_OK_STATUSES = new Set(["sent", "accepted"]);
+
+function checkSendStatus(result) {
+  if (!SEND_OK_STATUSES.has(result?.status)) {
+    // process.exitCode (not process.exit()) so the stdout write below still
+    // flushes before the process exits — same reasoning as the CLI's
+    // emitSendResult.
+    process.stderr.write(`non-success send status: ${JSON.stringify(result?.status)}\n`);
+    process.exitCode = 1;
+  }
+}
+
 const apiKey = process.env.E2A_API_KEY;
 if (!apiKey) fail("missing E2A_API_KEY");
 
@@ -38,6 +58,7 @@ async function main() {
     }
     const result = await client.messages.send(from, { to: [to], subject, text: body });
     process.stdout.write(JSON.stringify(result) + "\n");
+    checkSendStatus(result);
     return;
   }
   if (cmd === "reply") {
@@ -48,6 +69,7 @@ async function main() {
     const opts = idempotencyKey ? { idempotencyKey } : {};
     const result = await client.messages.reply(inbox, messageId, { text }, opts);
     process.stdout.write(JSON.stringify(result) + "\n");
+    checkSendStatus(result);
     return;
   }
   fail(`unknown command: ${cmd ?? "(none)"}`);

--- a/tests/sdk-monitor/monitor.py
+++ b/tests/sdk-monitor/monitor.py
@@ -39,6 +39,8 @@ lose — everything needed to build the alert lives in one log line.
 
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
 import os
 import re
@@ -60,15 +62,17 @@ from e2a.v1 import (
 )
 
 # Subject carries the correlation state: a marker, WHICH INTERFACE performed
-# the send, the send time in epoch ms (so latency needs no storage), and
+# the send, the send time in epoch ms (so latency needs no storage),
 # randomness so concurrent probes and redelivered events can never be
-# confused for one another. The iface segment is captured generically
-# (`[a-z0-9_]+`) rather than hardcoded to the five known keys, so an
-# unrecognized value is a *parsed-but-unknown* iface (handled explicitly,
-# see handle_webhook) instead of silently falling through "not a probe".
-# Older nonces (pre-multi-interface, no iface segment) simply won't match —
-# no deployed consumer depends on parsing those today.
-NONCE_RE = re.compile(r"e2asdkmon\.([a-z0-9_]+)\.(\d+)\.[0-9a-f]{16}")
+# confused for one another, and a keyed MAC tag binding all three together
+# (see NONCE_KEY / _nonce_tag below) so the nonce can only be minted by this
+# service — not just anyone who can email agent A. The iface segment is
+# captured generically (`[a-z0-9_]+`) rather than hardcoded to the five known
+# keys, so an unrecognized value is a *parsed-but-unknown* iface (handled
+# explicitly, see handle_webhook) instead of silently falling through "not a
+# probe". Older nonces (pre-multi-interface or pre-MAC, no iface/tag segment)
+# simply won't match — no deployed consumer depends on parsing those today.
+NONCE_RE = re.compile(r"e2asdkmon\.([a-z0-9_]+)\.(\d+)\.([0-9a-f]{16})\.([0-9a-f]{16})")
 SUBJECT_PREFIX = "probe"
 
 API_KEY = os.environ.get("E2A_API_KEY", "")
@@ -76,6 +80,14 @@ BASE_URL = os.environ.get("E2A_BASE_URL", "https://api.e2a.dev")
 AGENT_A = os.environ.get("E2A_MONITOR_AGENT_A", "")
 AGENT_B = os.environ.get("E2A_MONITOR_AGENT_B", "")
 WEBHOOK_SECRET = os.environ.get("E2A_MONITOR_WEBHOOK_SECRET", "")
+# Nonce-signing key. Optional and dedicated (E2A_MONITOR_NONCE_SECRET) so it
+# CAN be rotated independently of the webhook HMAC secret, but falls back to
+# the already-required WEBHOOK_SECRET so protection never silently depends on
+# an unset var — no new required config. Domain separation from the webhook
+# signature's own use of this same value comes from the fixed message prefix
+# in _nonce_tag, not from a distinct key.
+NONCE_SECRET = os.environ.get("E2A_MONITOR_NONCE_SECRET", "")
+NONCE_KEY = NONCE_SECRET or WEBHOOK_SECRET
 # Full streamable-HTTP MCP endpoint (e.g. https://api.e2a.dev/mcp), matching
 # the prober's E2A_PROBE_MCP_URL convention. Optional: when unset, the mcp
 # interface is skipped (monitor_skip) rather than failing the whole service —
@@ -110,8 +122,44 @@ def client() -> E2AClient:
     return _client
 
 
+NONCE_TAG_PREFIX = "e2asdkmon-nonce:"
+
+
+def _nonce_tag(iface: str, epoch_ms: int, rand_hex: str, key: str = NONCE_KEY) -> str:
+    """First 16 hex chars of HMAC-SHA256(key, "e2asdkmon-nonce:<iface>.<epoch_ms>.<rand_hex>").
+    The fixed prefix domain-separates this MAC from any other use of `key`
+    (e.g. the webhook signature, which also derives from WEBHOOK_SECRET when
+    no dedicated E2A_MONITOR_NONCE_SECRET is set). Never log `key` or the
+    resulting `tag` alongside enough context to look like the secret itself —
+    the tag is a public value that rides in the nonce, but callers should
+    still avoid gratuitously echoing it."""
+    msg = f"{NONCE_TAG_PREFIX}{iface}.{epoch_ms}.{rand_hex}".encode()
+    return hmac.new(key.encode(), msg, hashlib.sha256).hexdigest()[:16]
+
+
 def new_nonce(iface: str) -> str:
-    return f"e2asdkmon.{iface}.{int(time.time() * 1000)}.{secrets.token_hex(8)}"
+    epoch_ms = int(time.time() * 1000)
+    rand_hex = secrets.token_hex(8)
+    tag = _nonce_tag(iface, epoch_ms, rand_hex)
+    return f"e2asdkmon.{iface}.{epoch_ms}.{rand_hex}.{tag}"
+
+
+# Send-response outcome handling, uniform across every interface (api,
+# python_sdk, mcp, ts_sdk via js/monitor-helper.mjs, cli via its own subprocess
+# exit code). SendResultView.status (api/openapi.yaml) is an open string set;
+# only `sent` and `accepted` are genuinely successful outcomes (`accepted` =
+# durably queued for async submission, the normal non-held outcome).
+# `pending_review` (held for human review) and `failed` (terminal failure) —
+# and any status this build doesn't recognize — must NOT be logged
+# success-shaped; they must fail immediately at send/reply time rather than
+# only surfacing later as a monitor_stale timeout. Mirrors the CLI's
+# emitSendResult (cli/src/commands/send.ts), which already got this right.
+SEND_OK_STATUSES = frozenset({"sent", "accepted"})
+
+
+def _check_send_status(iface: str, status: object) -> None:
+    if status not in SEND_OK_STATUSES:
+        raise RuntimeError(f"{iface} send/reply returned non-success status: {status!r}")
 
 
 # --------------------------------------------------------------------------
@@ -153,7 +201,7 @@ class ApiStrategy:
     def available(self) -> bool:
         return True  # core interface; required config already gates startup
 
-    def _request(self, path: str, body: dict, idempotency_key: Optional[str] = None) -> None:
+    def _request(self, path: str, body: dict, idempotency_key: Optional[str] = None) -> dict:
         url = f"{self._base_url}{path}"
         req = urllib.request.Request(url, data=json.dumps(body).encode(), method="POST")
         req.add_header("Authorization", f"Bearer {self._api_key}")
@@ -162,21 +210,29 @@ class ApiStrategy:
             req.add_header("Idempotency-Key", idempotency_key)
         try:
             with urllib.request.urlopen(req, timeout=15) as resp:
-                resp.read()
+                raw = resp.read()
         except urllib.error.HTTPError as exc:
             detail = exc.read().decode("utf-8", "replace")[:300]
             raise RuntimeError(f"api HTTP {exc.code}: {detail}") from exc
+        if not raw:
+            return {}
+        try:
+            return json.loads(raw.decode("utf-8", "replace"))
+        except ValueError:
+            return {}
 
     def send(self, *, agent_a: str, agent_b: str, subject: str, body: str) -> None:
         path = f"/v1/agents/{urllib.parse.quote(agent_a, safe='')}/messages"
-        self._request(path, {"to": [agent_b], "subject": subject, "text": body})
+        result = self._request(path, {"to": [agent_b], "subject": subject, "text": body})
+        _check_send_status("api", result.get("status"))
 
     def reply(self, *, inbox: str, message_id: str, text: str, idempotency_key: str) -> None:
         path = (
             f"/v1/agents/{urllib.parse.quote(inbox, safe='')}"
             f"/messages/{urllib.parse.quote(message_id, safe='')}/reply"
         )
-        self._request(path, {"text": text}, idempotency_key=idempotency_key)
+        result = self._request(path, {"text": text}, idempotency_key=idempotency_key)
+        _check_send_status("api", result.get("status"))
 
 
 class PythonSdkStrategy:
@@ -186,21 +242,46 @@ class PythonSdkStrategy:
         return True  # core interface; required config already gates startup
 
     def send(self, *, agent_a: str, agent_b: str, subject: str, body: str) -> None:
-        client().messages.send(agent_a, {"to": [agent_b], "subject": subject, "text": body})
+        result = client().messages.send(agent_a, {"to": [agent_b], "subject": subject, "text": body})
+        _check_send_status("python_sdk", getattr(result, "status", None))
 
     def reply(self, *, inbox: str, message_id: str, text: str, idempotency_key: str) -> None:
-        client().messages.reply(
+        result = client().messages.reply(
             inbox, message_id, {"text": text}, idempotency_key=idempotency_key
         )
+        _check_send_status("python_sdk", getattr(result, "status", None))
 
 
-def _parse_jsonrpc_envelope(raw: bytes, content_type: str) -> dict:
+# Fixed id shared by every send/reply JSON-RPC request this service makes.
+# Fixing it lets the parser positively identify OUR response frame instead of
+# just grabbing the first jsonrpc-shaped thing in the stream: if the MCP
+# server ever emits a leading notification (no id) before the real
+# tools/call response, or a stream somehow interleaves an unrelated
+# response, a bare "first dict with jsonrpc in it" match would false-fail (or
+# worse, false-succeed on) a healthy round trip.
+MCP_REQUEST_ID = 1
+
+
+def _is_matching_jsonrpc_response(env: object, request_id: int) -> bool:
+    """True only for the frame that is actually THIS request's response:
+    right id, and carrying a `result` or `error` (a notification has neither
+    and must be skipped, not mistaken for the answer)."""
+    return (
+        isinstance(env, dict)
+        and env.get("id") == request_id
+        and ("result" in env or "error" in env)
+    )
+
+
+def _parse_jsonrpc_envelope(raw: bytes, content_type: str, request_id: int = MCP_REQUEST_ID) -> dict:
     """Decode a JSON-RPC message from an MCP streamable-HTTP response,
     accepting either a bare JSON body or an SSE stream (the deployed MCP
     server runs stateless with `enableJsonResponse` unset, so it answers with
     SSE — see mcp/src/http-server.ts). Mirrors
     internal/selftest/scenarios.go's parseJSONRPCEnvelope so both validators
-    agree on the wire shape."""
+    agree on the wire shape. Skips any frame that isn't THIS request's
+    response (wrong id, or a notification with neither result nor error) —
+    see _is_matching_jsonrpc_response."""
     if "text/event-stream" in content_type:
         body = raw.decode("utf-8", "replace").replace("\r\n", "\n")
         for event in body.split("\n\n"):
@@ -215,10 +296,13 @@ def _parse_jsonrpc_envelope(raw: bytes, content_type: str) -> dict:
                 env = json.loads("\n".join(data_lines))
             except ValueError:
                 continue
-            if isinstance(env, dict) and "jsonrpc" in env:
+            if _is_matching_jsonrpc_response(env, request_id):
                 return env
-        raise RuntimeError("no JSON-RPC message in SSE stream")
-    return json.loads(raw.decode("utf-8", "replace"))
+        raise RuntimeError("no matching JSON-RPC response in SSE stream")
+    env = json.loads(raw.decode("utf-8", "replace"))
+    if not _is_matching_jsonrpc_response(env, request_id):
+        raise RuntimeError(f"JSON-RPC response id mismatch or missing result/error: {env}")
+    return env
 
 
 class McpStrategy:
@@ -236,11 +320,16 @@ class McpStrategy:
     def available(self) -> bool:
         return bool(self._url)
 
-    def _call(self, name: str, arguments: dict) -> None:
+    def _call(self, name: str, arguments: dict) -> dict:
         if not self._url:
             raise RuntimeError("E2A_MONITOR_MCP_URL not configured")
         payload = json.dumps(
-            {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": name, "arguments": arguments}}
+            {
+                "jsonrpc": "2.0",
+                "id": MCP_REQUEST_ID,
+                "method": "tools/call",
+                "params": {"name": name, "arguments": arguments},
+            }
         ).encode()
         req = urllib.request.Request(self._url, data=payload, method="POST")
         req.add_header("Authorization", f"Bearer {self._api_key}")
@@ -254,13 +343,12 @@ class McpStrategy:
         except urllib.error.HTTPError as exc:
             detail = exc.read().decode("utf-8", "replace")[:300]
             raise RuntimeError(f"mcp HTTP {exc.code}: {detail}") from exc
+        # _parse_jsonrpc_envelope already guarantees the returned frame
+        # matches our request id and carries a result or error — a malformed/
+        # incomplete/mismatched-id response raises there, before we get here.
         env = _parse_jsonrpc_envelope(raw, content_type)
         if env.get("error"):
             raise RuntimeError(f"mcp JSON-RPC error: {env['error']}")
-        if "result" not in env:
-            # Neither a JSON-RPC error nor a result — a malformed/incomplete
-            # response must not be silently treated as success.
-            raise RuntimeError(f"mcp response missing both result and error: {env}")
         result = env.get("result") or {}
         if result.get("isError"):
             text = ""
@@ -269,15 +357,33 @@ class McpStrategy:
                     text = block.get("text", "")
                     break
             raise RuntimeError(f"mcp tool error: {text}")
+        return result
+
+    @staticmethod
+    def _result_status(result: dict) -> Optional[str]:
+        """The tool's success text block is a JSON-stringified SendResultView
+        (mcp/src/tools/util.ts's runTool + toMcpOutput) — pull `status` out of
+        it so a held/failed send can be treated as a failure here too, not
+        just on the api/python_sdk/ts_sdk interfaces."""
+        for block in result.get("content") or []:
+            if isinstance(block, dict) and block.get("type") == "text":
+                try:
+                    payload = json.loads(block.get("text", ""))
+                except ValueError:
+                    return None
+                if isinstance(payload, dict):
+                    return payload.get("status")
+        return None
 
     def send(self, *, agent_a: str, agent_b: str, subject: str, body: str) -> None:
-        self._call(
+        result = self._call(
             "send_message",
             {"to": [agent_b], "subject": subject, "text": body, "email": agent_a},
         )
+        _check_send_status("mcp", self._result_status(result))
 
     def reply(self, *, inbox: str, message_id: str, text: str, idempotency_key: str) -> None:
-        self._call(
+        result = self._call(
             "reply_to_message",
             {
                 "message_id": message_id,
@@ -286,10 +392,27 @@ class McpStrategy:
                 "idempotency_key": idempotency_key,
             },
         )
+        _check_send_status("mcp", self._result_status(result))
+
+
+# The full parent environment is never handed to a child: it would carry
+# E2A_MONITOR_WEBHOOK_SECRET (and anything else configured on this Cloud Run
+# service), which neither the ts_sdk helper nor the CLI needs — a dump-env-
+# to-stderr bug in either child could then leak it straight into a logged
+# monitor_error. Only PATH + HOME are passed through (verified sufficient to
+# run node: `env -i PATH="$PATH" HOME="$HOME" node -e '...'` works), merged
+# with the caller's explicit overrides (E2A_API_KEY + the base-url var).
+_MINIMAL_ENV_PASSTHROUGH = ("PATH", "HOME")
+
+
+def _minimal_env(env_overrides: dict) -> dict:
+    env = {name: os.environ[name] for name in _MINIMAL_ENV_PASSTHROUGH if name in os.environ}
+    env.update(env_overrides)
+    return env
 
 
 def _run_subprocess(argv: list[str], env_overrides: dict) -> str:
-    env = {**os.environ, **env_overrides}
+    env = _minimal_env(env_overrides)
     try:
         proc = subprocess.run(
             argv,
@@ -312,7 +435,12 @@ class TsSdkStrategy:
     embedding a JS runtime. Never workspace source: the helper imports
     `@e2a/sdk/v1` resolved from node_modules, populated at image build time by
     `npm install @e2a/sdk@5.2.0` (see Dockerfile), same discipline as
-    requirements.txt for the Python SDK."""
+    requirements.txt for the Python SDK.
+
+    Send-status handling lives in the helper itself, not here: it now checks
+    the same SEND_OK_STATUSES set (mirroring the CLI's emitSendResult) and
+    exits non-zero on a held/failed/unrecognized status, so `_run_subprocess`
+    raises uniformly with every other interface."""
 
     def __init__(self, base_url: str, api_key: str) -> None:
         # E2A_API_URL is the canonical name the TS SDK reads (client.ts);
@@ -410,7 +538,27 @@ def handle_tick() -> tuple[int, dict]:
             continue
         log("monitor_tick", iface=iface, nonce=nonce)
         results[iface] = {"ok": True, "nonce": nonce}
-    return 200, {"ok": all(r.get("ok") for r in results.values()), "results": results}
+
+    # Aggregate over CONSIDERED interfaces only — one that was skipped this
+    # tick (currently only `mcp` absent E2A_MONITOR_MCP_URL, a supported
+    # normal deployment) must not permanently pin `ok` to False even though
+    # every configured interface succeeded.
+    considered = [r for r in results.values() if not r.get("skipped")]
+    ok = bool(considered) and all(r.get("ok") for r in considered)
+    if not considered:
+        # Nothing configured to attempt this tick — vacuously nothing failed.
+        status_code = 200
+    elif ok:
+        status_code = 200
+    elif any(r.get("ok") for r in considered):
+        # Partial failure: some interfaces are broken, but not all — distinct
+        # from a total outage so an alert/dashboard can tell them apart.
+        status_code = 207
+    else:
+        # Total outage across every considered interface: Cloud Scheduler
+        # needs a non-2xx so a send-side blackout doesn't read as healthy.
+        status_code = 500
+    return status_code, {"ok": ok, "results": results}
 
 
 def handle_webhook(raw_body: bytes, signature: str) -> tuple[int, dict]:
@@ -447,7 +595,25 @@ def handle_webhook(raw_body: bytes, signature: str) -> tuple[int, dict]:
     match = NONCE_RE.search(email.subject or "")
     if not match:
         return 200, {"ok": True, "ignored": "not a probe"}
-    nonce, iface, sent_ms = match.group(0), match.group(1), int(match.group(2))
+    nonce, iface, sent_ms, rand_hex, received_tag = (
+        match.group(0),
+        match.group(1),
+        int(match.group(2)),
+        match.group(3),
+        match.group(4),
+    )
+
+    # Authenticate the nonce BEFORE acting on either leg: anyone who can email
+    # agent A can pick an iface/timestamp/16-hex suffix, but only this service
+    # (holder of NONCE_KEY) can produce the matching tag. This also
+    # authenticates sent_ms itself, so a forger can't mint a fresh-looking
+    # nonce to defeat the staleness guard below. Never log the key or the
+    # tag alongside anything that could reconstruct it.
+    expected_tag = _nonce_tag(iface, sent_ms, rand_hex)
+    if not hmac.compare_digest(expected_tag, received_tag):
+        log("monitor_error", stage="nonce_auth", iface=iface)
+        return 200, {"ok": True, "ignored": "bad nonce mac"}
+
     age_ms = int(time.time() * 1000) - sent_ms
 
     strategy = STRATEGIES.get(iface)

--- a/tests/sdk-monitor/monitor.py
+++ b/tests/sdk-monitor/monitor.py
@@ -1,22 +1,40 @@
-"""Continuous production monitor for the *published* e2a Python SDK.
+"""Continuous production conformance monitor for the *published* e2a client
+surfaces: the raw HTTP API, the Python SDK, the TypeScript SDK, the CLI, and
+the MCP server.
 
-Neither existing validator touches an SDK: `cmd/e2a-prober` speaks raw HTTP and
-`tests/e2e-prod` uses zero-dependency `fetch` on purpose. So a broken publish is
-invisible — the SDKs sat at 4.0.1 on PyPI/npm while `main` was at 5.2.0 and
-nothing caught it. This service closes that gap by driving a real agent-to-agent
-round trip through the SDK a user would actually `pip install` (pinned in
-requirements.txt, never the workspace source).
+Neither existing validator touches a published client. `cmd/e2a-prober`
+speaks raw HTTP against a staging deploy and `tests/e2e-prod` deliberately
+uses zero-dependency `fetch`. So a broken publish is invisible — the SDKs sat
+at 4.0.1 on PyPI/npm while `main` was at 5.2.0 and nothing caught it. This
+service closes that gap by driving a real agent-to-agent round trip through
+EACH of five interfaces a user would actually reach for:
 
-Stateless and request-driven — Cloud Run scales to zero, so nothing may live in
-memory between requests. Correlation state travels in the message subject:
+    api          raw HTTP against the server (no SDK) — isolates a
+                 server-contract break from an SDK break
+    python_sdk   the published `e2a` PyPI package
+    mcp          the deployed MCP streamable-HTTP server's tool call
+    ts_sdk       the published `@e2a/sdk` npm package (shelled to node)
+    cli          the published `@e2a/cli` npm package (shelled to node)
 
-    POST /tick      send A -> B, subject "probe <nonce>"; nonce embeds send time
-    POST /webhook   email.received on B -> reply; email.received on A -> success
+All five never touch workspace source (pinned in requirements.txt / package.json,
+installed from PyPI/npm — see Dockerfile).
+
+Stateless and request-driven — Cloud Run scales to zero, so nothing may live
+in memory between requests except immutable, config-derived interface
+strategies (no per-round-trip state). Correlation state travels in the
+message subject, which now also carries which interface sent it:
+
+    POST /tick      one round trip PER interface: send A -> B, subject
+                    "probe <nonce>"; nonce embeds the interface, the send
+                    time, and randomness
+    POST /webhook   email.received on B -> reply (via the SAME interface the
+                    nonce names); email.received on A -> success
     GET  /health    liveness
 
-Success is a structured log line (``sdk_monitor_ok``) carrying the round-trip
-latency; ops builds a log-based metric plus a "no success in N minutes" alert on
-it. There is no in-process aggregation to lose.
+Success is a structured log line (``monitor_ok``) carrying `iface` and the
+round-trip `latency_ms`; ops builds a log-based metric plus a per-interface
+"no success in N minutes" alert on it. There is no in-process aggregation to
+lose — everything needed to build the alert lives in one log line.
 """
 
 from __future__ import annotations
@@ -25,9 +43,14 @@ import json
 import os
 import re
 import secrets
+import subprocess
 import sys
 import time
+import urllib.error
+import urllib.parse
+import urllib.request
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Optional, Protocol
 
 from e2a.v1 import (
     E2AClient,
@@ -36,10 +59,16 @@ from e2a.v1 import (
     is_email_received,
 )
 
-# Subject carries the correlation state: a marker, the send time in epoch ms
-# (so latency needs no storage), and randomness so concurrent probes and
-# redelivered events can never be confused for one another.
-NONCE_RE = re.compile(r"e2asdkmon\.(\d+)\.[0-9a-f]{16}")
+# Subject carries the correlation state: a marker, WHICH INTERFACE performed
+# the send, the send time in epoch ms (so latency needs no storage), and
+# randomness so concurrent probes and redelivered events can never be
+# confused for one another. The iface segment is captured generically
+# (`[a-z0-9_]+`) rather than hardcoded to the five known keys, so an
+# unrecognized value is a *parsed-but-unknown* iface (handled explicitly,
+# see handle_webhook) instead of silently falling through "not a probe".
+# Older nonces (pre-multi-interface, no iface segment) simply won't match —
+# no deployed consumer depends on parsing those today.
+NONCE_RE = re.compile(r"e2asdkmon\.([a-z0-9_]+)\.(\d+)\.[0-9a-f]{16}")
 SUBJECT_PREFIX = "probe"
 
 API_KEY = os.environ.get("E2A_API_KEY", "")
@@ -47,12 +76,26 @@ BASE_URL = os.environ.get("E2A_BASE_URL", "https://api.e2a.dev")
 AGENT_A = os.environ.get("E2A_MONITOR_AGENT_A", "")
 AGENT_B = os.environ.get("E2A_MONITOR_AGENT_B", "")
 WEBHOOK_SECRET = os.environ.get("E2A_MONITOR_WEBHOOK_SECRET", "")
+# Full streamable-HTTP MCP endpoint (e.g. https://api.e2a.dev/mcp), matching
+# the prober's E2A_PROBE_MCP_URL convention. Optional: when unset, the mcp
+# interface is skipped (monitor_skip) rather than failing the whole service —
+# not every deployment necessarily exposes the MCP server at a fixed URL this
+# monitor can reach.
+MCP_URL = os.environ.get("E2A_MONITOR_MCP_URL", "")
 # A reply older than this is a stale redelivery, not a fresh success — it must
 # never refresh the alert's "last seen" clock.
 MAX_AGE_MS = int(os.environ.get("E2A_MONITOR_MAX_AGE_MS", "900000"))
 PORT = int(os.environ.get("PORT", "8080"))
 
-_client: E2AClient | None = None
+# Every interface this service exercises, in the fixed order /tick fires them.
+IFACES = ("api", "python_sdk", "mcp", "ts_sdk", "cli")
+
+APP_DIR = os.path.dirname(os.path.abspath(__file__))
+NODE_HELPER = os.path.join(APP_DIR, "js", "monitor-helper.mjs")
+CLI_BIN = os.path.join(APP_DIR, "node_modules", "@e2a", "cli", "dist", "bin", "e2a.js")
+SUBPROCESS_TIMEOUT_S = 20
+
+_client: Optional[E2AClient] = None
 
 
 def log(event: str, **fields: object) -> None:
@@ -67,42 +110,325 @@ def client() -> E2AClient:
     return _client
 
 
-def new_nonce() -> str:
-    return f"e2asdkmon.{int(time.time() * 1000)}.{secrets.token_hex(8)}"
+def new_nonce(iface: str) -> str:
+    return f"e2asdkmon.{iface}.{int(time.time() * 1000)}.{secrets.token_hex(8)}"
+
+
+# --------------------------------------------------------------------------
+# Interface strategies.
+#
+# Each interface implements the same two operations, uniform across all five
+# so the webhook hub can dispatch on the iface name alone:
+#
+#   send(agent_a, agent_b, subject, body) -> None    # outbound leg
+#   reply(inbox, message_id, text, idempotency_key) -> None   # inbound leg
+#
+# None of the five ever sets a subject on reply: every wire shape (REST
+# ReplyRequest, the SDKs' reply(), the CLI's `reply`, the MCP
+# reply_to_message tool) derives it server-side as "Re: <original subject>",
+# which still satisfies NONCE_RE.search() since the nonce is a substring.
+# --------------------------------------------------------------------------
+
+
+class Interface(Protocol):
+    def available(self) -> bool: ...
+
+    def send(self, *, agent_a: str, agent_b: str, subject: str, body: str) -> None: ...
+
+    def reply(
+        self, *, inbox: str, message_id: str, text: str, idempotency_key: str
+    ) -> None: ...
+
+
+class ApiStrategy:
+    """Raw HTTP against the server API — no SDK. Exercises the wire contract
+    directly, so a server-side regression shows up here even if every SDK
+    happens to paper over it (or vice versa: an SDK-only bug does NOT show up
+    here, which is exactly the point of running both)."""
+
+    def __init__(self, base_url: str, api_key: str) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._api_key = api_key
+
+    def available(self) -> bool:
+        return True  # core interface; required config already gates startup
+
+    def _request(self, path: str, body: dict, idempotency_key: Optional[str] = None) -> None:
+        url = f"{self._base_url}{path}"
+        req = urllib.request.Request(url, data=json.dumps(body).encode(), method="POST")
+        req.add_header("Authorization", f"Bearer {self._api_key}")
+        req.add_header("Content-Type", "application/json")
+        if idempotency_key:
+            req.add_header("Idempotency-Key", idempotency_key)
+        try:
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                resp.read()
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", "replace")[:300]
+            raise RuntimeError(f"api HTTP {exc.code}: {detail}") from exc
+
+    def send(self, *, agent_a: str, agent_b: str, subject: str, body: str) -> None:
+        path = f"/v1/agents/{urllib.parse.quote(agent_a, safe='')}/messages"
+        self._request(path, {"to": [agent_b], "subject": subject, "text": body})
+
+    def reply(self, *, inbox: str, message_id: str, text: str, idempotency_key: str) -> None:
+        path = (
+            f"/v1/agents/{urllib.parse.quote(inbox, safe='')}"
+            f"/messages/{urllib.parse.quote(message_id, safe='')}/reply"
+        )
+        self._request(path, {"text": text}, idempotency_key=idempotency_key)
+
+
+class PythonSdkStrategy:
+    """The published `e2a` PyPI package — today's original path."""
+
+    def available(self) -> bool:
+        return True  # core interface; required config already gates startup
+
+    def send(self, *, agent_a: str, agent_b: str, subject: str, body: str) -> None:
+        client().messages.send(agent_a, {"to": [agent_b], "subject": subject, "text": body})
+
+    def reply(self, *, inbox: str, message_id: str, text: str, idempotency_key: str) -> None:
+        client().messages.reply(
+            inbox, message_id, {"text": text}, idempotency_key=idempotency_key
+        )
+
+
+def _parse_jsonrpc_envelope(raw: bytes, content_type: str) -> dict:
+    """Decode a JSON-RPC message from an MCP streamable-HTTP response,
+    accepting either a bare JSON body or an SSE stream (the deployed MCP
+    server runs stateless with `enableJsonResponse` unset, so it answers with
+    SSE — see mcp/src/http-server.ts). Mirrors
+    internal/selftest/scenarios.go's parseJSONRPCEnvelope so both validators
+    agree on the wire shape."""
+    if "text/event-stream" in content_type:
+        body = raw.decode("utf-8", "replace").replace("\r\n", "\n")
+        for event in body.split("\n\n"):
+            data_lines = [
+                line[len("data:") :].lstrip(" ")
+                for line in event.split("\n")
+                if line.startswith("data:")
+            ]
+            if not data_lines:
+                continue
+            try:
+                env = json.loads("\n".join(data_lines))
+            except ValueError:
+                continue
+            if isinstance(env, dict) and "jsonrpc" in env:
+                return env
+        raise RuntimeError("no JSON-RPC message in SSE stream")
+    return json.loads(raw.decode("utf-8", "replace"))
+
+
+class McpStrategy:
+    """The deployed MCP server's `send_message` / `reply_to_message` tools
+    over streamable HTTP (mcp/src/tools/messages.ts). Stateless: the server
+    skips all session/initialize gating when built with
+    `sessionIdGenerator: undefined` (mcp/src/http-server.ts), so a bare
+    `tools/call` dispatches with no prior `initialize` — a hand-rolled single
+    JSON-RPC request suffices without a full client library."""
+
+    def __init__(self, url: str, api_key: str) -> None:
+        self._url = url
+        self._api_key = api_key
+
+    def available(self) -> bool:
+        return bool(self._url)
+
+    def _call(self, name: str, arguments: dict) -> None:
+        if not self._url:
+            raise RuntimeError("E2A_MONITOR_MCP_URL not configured")
+        payload = json.dumps(
+            {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": name, "arguments": arguments}}
+        ).encode()
+        req = urllib.request.Request(self._url, data=payload, method="POST")
+        req.add_header("Authorization", f"Bearer {self._api_key}")
+        req.add_header("Content-Type", "application/json")
+        # Streamable-HTTP requires the client to accept both framings.
+        req.add_header("Accept", "application/json, text/event-stream")
+        try:
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                raw = resp.read()
+                content_type = resp.headers.get("Content-Type", "")
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", "replace")[:300]
+            raise RuntimeError(f"mcp HTTP {exc.code}: {detail}") from exc
+        env = _parse_jsonrpc_envelope(raw, content_type)
+        if env.get("error"):
+            raise RuntimeError(f"mcp JSON-RPC error: {env['error']}")
+        if "result" not in env:
+            # Neither a JSON-RPC error nor a result — a malformed/incomplete
+            # response must not be silently treated as success.
+            raise RuntimeError(f"mcp response missing both result and error: {env}")
+        result = env.get("result") or {}
+        if result.get("isError"):
+            text = ""
+            for block in result.get("content") or []:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    text = block.get("text", "")
+                    break
+            raise RuntimeError(f"mcp tool error: {text}")
+
+    def send(self, *, agent_a: str, agent_b: str, subject: str, body: str) -> None:
+        self._call(
+            "send_message",
+            {"to": [agent_b], "subject": subject, "text": body, "email": agent_a},
+        )
+
+    def reply(self, *, inbox: str, message_id: str, text: str, idempotency_key: str) -> None:
+        self._call(
+            "reply_to_message",
+            {
+                "message_id": message_id,
+                "text": text,
+                "email": inbox,
+                "idempotency_key": idempotency_key,
+            },
+        )
+
+
+def _run_subprocess(argv: list[str], env_overrides: dict) -> str:
+    env = {**os.environ, **env_overrides}
+    try:
+        proc = subprocess.run(
+            argv,
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=SUBPROCESS_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"{argv[0]} timed out after {SUBPROCESS_TIMEOUT_S}s") from exc
+    if proc.returncode != 0:
+        detail = (proc.stderr or proc.stdout or "").strip()[:300]
+        raise RuntimeError(f"{argv[0]} exited {proc.returncode}: {detail}")
+    return proc.stdout
+
+
+class TsSdkStrategy:
+    """The published `@e2a/sdk` npm package, driven from a small node helper
+    (js/monitor-helper.mjs) — this Python service shells out rather than
+    embedding a JS runtime. Never workspace source: the helper imports
+    `@e2a/sdk/v1` resolved from node_modules, populated at image build time by
+    `npm install @e2a/sdk@5.2.0` (see Dockerfile), same discipline as
+    requirements.txt for the Python SDK."""
+
+    def __init__(self, base_url: str, api_key: str) -> None:
+        # E2A_API_URL is the canonical name the TS SDK reads (client.ts);
+        # E2A_BASE_URL is accepted too but emits a one-shot deprecation
+        # warning on stderr, which would pollute the structured log stream.
+        self._env = {"E2A_API_KEY": api_key, "E2A_API_URL": base_url}
+
+    def available(self) -> bool:
+        return True  # core interface; baked into the image at build time
+
+    def send(self, *, agent_a: str, agent_b: str, subject: str, body: str) -> None:
+        _run_subprocess(["node", NODE_HELPER, "send", agent_a, agent_b, subject, body], self._env)
+
+    def reply(self, *, inbox: str, message_id: str, text: str, idempotency_key: str) -> None:
+        _run_subprocess(
+            ["node", NODE_HELPER, "reply", inbox, message_id, text, idempotency_key],
+            self._env,
+        )
+
+
+class CliStrategy:
+    """The published `@e2a/cli` npm package's `e2a` bin, invoked directly
+    (`node .../dist/bin/e2a.js ...`) rather than relying on a PATH-installed
+    symlink — more robust across base images. `e2a reply <id> --body ...`
+    supports true in-thread reply (confirmed: cli/src/commands/send.ts calls
+    `client.messages.reply`, whose wire ReplyRequest has no subject field, so
+    the server derives "Re: <original subject>" the same as every other
+    interface) — no send-only fallback needed."""
+
+    def __init__(self, base_url: str, api_key: str) -> None:
+        # The CLI reads E2A_URL (not E2A_BASE_URL/E2A_API_URL) for its API
+        # host — see cli/src/config.ts. It also serves /mcp and /v1/* on the
+        # same api.e2a.dev host per the Caddy allowlist, so pointing E2A_URL
+        # straight at BASE_URL (rather than the dashboard root) works and
+        # skips an extra proxy hop.
+        self._env = {"E2A_API_KEY": api_key, "E2A_URL": base_url}
+
+    def available(self) -> bool:
+        return True  # core interface; baked into the image at build time
+
+    def send(self, *, agent_a: str, agent_b: str, subject: str, body: str) -> None:
+        _run_subprocess(
+            ["node", CLI_BIN, "send", "--to", agent_b, "--subject", subject, "--body", body,
+             "--agent", agent_a, "--json"],
+            self._env,
+        )
+
+    def reply(self, *, inbox: str, message_id: str, text: str, idempotency_key: str) -> None:
+        _run_subprocess(
+            ["node", CLI_BIN, "reply", message_id, "--body", text, "--agent", inbox,
+             "--idempotency-key", idempotency_key, "--json"],
+            self._env,
+        )
+
+
+def _build_strategies() -> dict:
+    return {
+        "api": ApiStrategy(BASE_URL, API_KEY),
+        "python_sdk": PythonSdkStrategy(),
+        "mcp": McpStrategy(MCP_URL, API_KEY),
+        "ts_sdk": TsSdkStrategy(BASE_URL, API_KEY),
+        "cli": CliStrategy(BASE_URL, API_KEY),
+    }
+
+
+# Built once at import time from static config — not per-request state.
+# Correlation state (which round trip is in flight) still lives entirely in
+# the message subject, never here.
+STRATEGIES: dict = _build_strategies()
 
 
 def handle_tick() -> tuple[int, dict]:
-    """Send the outbound leg: agent A -> agent B, nonce in subject and body."""
-    nonce = new_nonce()
-    try:
-        result = client().messages.send(
-            AGENT_A,
-            {"to": [AGENT_B], "subject": f"{SUBJECT_PREFIX} {nonce}", "text": nonce},
-        )
-    except Exception as exc:  # noqa: BLE001 - any SDK failure is a monitor signal
-        log("sdk_monitor_error", stage="send", nonce=nonce, error=type(exc).__name__, detail=str(exc))
-        return 500, {"ok": False, "stage": "send"}
-    log(
-        "sdk_monitor_tick",
-        nonce=nonce,
-        message_id=result.message_id,
-        status=result.status,
-        method=result.method,
-    )
-    return 202, {"ok": True, "nonce": nonce}
+    """Fire one outbound leg PER interface: agent A -> agent B, nonce
+    (encoding the interface) in subject and body. A per-interface send
+    failure is reported in the summary and logged, but never aborts the
+    others."""
+    results: dict = {}
+    for iface in IFACES:
+        strategy = STRATEGIES[iface]
+        if not strategy.available():
+            log("monitor_skip", iface=iface, stage="send", detail="interface not configured")
+            results[iface] = {"ok": False, "skipped": True}
+            continue
+        nonce = new_nonce(iface)
+        try:
+            strategy.send(
+                agent_a=AGENT_A,
+                agent_b=AGENT_B,
+                subject=f"{SUBJECT_PREFIX} {nonce}",
+                body=nonce,
+            )
+        except Exception as exc:  # noqa: BLE001 - any interface failure is a monitor signal
+            log("monitor_error", stage="send", iface=iface, nonce=nonce, error=type(exc).__name__, detail=str(exc))
+            results[iface] = {"ok": False, "nonce": nonce}
+            continue
+        log("monitor_tick", iface=iface, nonce=nonce)
+        results[iface] = {"ok": True, "nonce": nonce}
+    return 200, {"ok": all(r.get("ok") for r in results.values()), "results": results}
 
 
 def handle_webhook(raw_body: bytes, signature: str) -> tuple[int, dict]:
-    """Verify, hydrate, then act on which leg of the round trip this is."""
+    """Verify, hydrate, then act on which leg of the round trip this is.
+
+    Verification and hydration ALWAYS go through the published Python SDK
+    (this hub is the service's own infra, not the interface under test — the
+    interface named in the nonce is exercised on send and on reply, not on
+    receiving the webhook)."""
     # Fail closed: an unset secret means the deployment is misconfigured, and
     # accepting unverified deliveries would make the whole signal forgeable.
     if not WEBHOOK_SECRET:
-        log("sdk_monitor_error", stage="config", detail="webhook secret not configured")
+        log("monitor_error", stage="config", detail="webhook secret not configured")
         return 401, {"error": "unauthorized"}
     try:
         event = construct_event(raw_body, signature, WEBHOOK_SECRET)
     except E2AWebhookSignatureError as exc:
-        log("sdk_monitor_error", stage="signature", code=getattr(exc, "code", None))
+        log("monitor_error", stage="signature", code=getattr(exc, "code", None))
         return 401, {"error": "unauthorized"}
 
     # An account-scoped subscription fans out email.sent, bounces, domain
@@ -113,7 +439,7 @@ def handle_webhook(raw_body: bytes, signature: str) -> tuple[int, dict]:
     try:
         email = client().inbound.from_event(event)
     except Exception as exc:  # noqa: BLE001
-        log("sdk_monitor_error", stage="hydrate", event_id=event.id, error=type(exc).__name__, detail=str(exc))
+        log("monitor_error", stage="hydrate", event_id=event.id, error=type(exc).__name__, detail=str(exc))
         # 5xx so e2a retries: a transient hydration failure shouldn't silently
         # drop a leg and manufacture a false alert.
         return 500, {"ok": False, "stage": "hydrate"}
@@ -121,8 +447,18 @@ def handle_webhook(raw_body: bytes, signature: str) -> tuple[int, dict]:
     match = NONCE_RE.search(email.subject or "")
     if not match:
         return 200, {"ok": True, "ignored": "not a probe"}
-    nonce, sent_ms = match.group(0), int(match.group(1))
+    nonce, iface, sent_ms = match.group(0), match.group(1), int(match.group(2))
     age_ms = int(time.time() * 1000) - sent_ms
+
+    strategy = STRATEGIES.get(iface)
+    if strategy is None:
+        # A nonce that matches the shape but names an iface we don't
+        # recognize (deploy skew, a hand-crafted probe, a future interface
+        # this build predates) — handled safely: log and ignore, never crash
+        # and never claim a success or a stale-guard outcome for a strategy
+        # we don't have.
+        log("monitor_error", stage="unknown_iface", nonce=nonce, iface=iface)
+        return 200, {"ok": True, "ignored": "unknown iface"}
 
     # Which leg this is comes from the recipient, not from a "Re:" prefix:
     # mailers rewrite subjects, but the delivered-to agent is authoritative.
@@ -130,26 +466,31 @@ def handle_webhook(raw_body: bytes, signature: str) -> tuple[int, dict]:
 
     if inbox == AGENT_B.lower():
         if age_ms > MAX_AGE_MS:
-            log("sdk_monitor_stale", leg="outbound", nonce=nonce, age_ms=age_ms)
+            log("monitor_stale", leg="outbound", iface=iface, nonce=nonce, age_ms=age_ms)
             return 200, {"ok": True, "stale": True}
         try:
             # idempotency_key keyed on the event so a webhook redelivery can't
             # fan out into duplicate replies.
-            email.reply({"text": nonce}, idempotency_key=f"sdkmon:{event.id}")
+            strategy.reply(
+                inbox=AGENT_B,
+                message_id=email.id,
+                text=nonce,
+                idempotency_key=f"sdkmon:{event.id}",
+            )
         except Exception as exc:  # noqa: BLE001
-            log("sdk_monitor_error", stage="reply", nonce=nonce, error=type(exc).__name__, detail=str(exc))
+            log("monitor_error", stage="reply", iface=iface, nonce=nonce, error=type(exc).__name__, detail=str(exc))
             return 500, {"ok": False, "stage": "reply"}
-        log("sdk_monitor_replied", nonce=nonce, age_ms=age_ms)
+        log("monitor_replied", iface=iface, nonce=nonce, age_ms=age_ms)
         return 200, {"ok": True, "leg": "outbound"}
 
     if inbox == AGENT_A.lower():
         if age_ms > MAX_AGE_MS:
-            # Deliberately not sdk_monitor_ok: a stale reply must not reset the
+            # Deliberately not monitor_ok: a stale reply must not reset the
             # freshness alert.
-            log("sdk_monitor_stale", leg="reply", nonce=nonce, age_ms=age_ms)
+            log("monitor_stale", leg="reply", iface=iface, nonce=nonce, age_ms=age_ms)
             return 200, {"ok": True, "stale": True}
-        log("sdk_monitor_ok", nonce=nonce, latency_ms=age_ms, message_id=email.id)
-        return 200, {"ok": True, "leg": "reply", "latency_ms": age_ms}
+        log("monitor_ok", iface=iface, nonce=nonce, latency_ms=age_ms, message_id=email.id)
+        return 200, {"ok": True, "leg": "reply", "iface": iface, "latency_ms": age_ms}
 
     return 200, {"ok": True, "ignored": "unknown inbox"}
 
@@ -200,9 +541,17 @@ def main() -> None:
     ]
     if missing:
         # Names only — never the values.
-        log("sdk_monitor_error", stage="config", detail=f"missing env: {', '.join(missing)}")
+        log("monitor_error", stage="config", detail=f"missing env: {', '.join(missing)}")
         sys.exit(1)
-    log("sdk_monitor_start", port=PORT, base_url=BASE_URL, agent_a=AGENT_A, agent_b=AGENT_B)
+    log(
+        "monitor_start",
+        port=PORT,
+        base_url=BASE_URL,
+        agent_a=AGENT_A,
+        agent_b=AGENT_B,
+        ifaces=list(IFACES),
+        mcp_configured=bool(MCP_URL),
+    )
     ThreadingHTTPServer(("0.0.0.0", PORT), Handler).serve_forever()
 
 

--- a/tests/sdk-monitor/monitor.py
+++ b/tests/sdk-monitor/monitor.py
@@ -1,0 +1,210 @@
+"""Continuous production monitor for the *published* e2a Python SDK.
+
+Neither existing validator touches an SDK: `cmd/e2a-prober` speaks raw HTTP and
+`tests/e2e-prod` uses zero-dependency `fetch` on purpose. So a broken publish is
+invisible — the SDKs sat at 4.0.1 on PyPI/npm while `main` was at 5.2.0 and
+nothing caught it. This service closes that gap by driving a real agent-to-agent
+round trip through the SDK a user would actually `pip install` (pinned in
+requirements.txt, never the workspace source).
+
+Stateless and request-driven — Cloud Run scales to zero, so nothing may live in
+memory between requests. Correlation state travels in the message subject:
+
+    POST /tick      send A -> B, subject "probe <nonce>"; nonce embeds send time
+    POST /webhook   email.received on B -> reply; email.received on A -> success
+    GET  /health    liveness
+
+Success is a structured log line (``sdk_monitor_ok``) carrying the round-trip
+latency; ops builds a log-based metric plus a "no success in N minutes" alert on
+it. There is no in-process aggregation to lose.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import secrets
+import sys
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from e2a.v1 import (
+    E2AClient,
+    E2AWebhookSignatureError,
+    construct_event,
+    is_email_received,
+)
+
+# Subject carries the correlation state: a marker, the send time in epoch ms
+# (so latency needs no storage), and randomness so concurrent probes and
+# redelivered events can never be confused for one another.
+NONCE_RE = re.compile(r"e2asdkmon\.(\d+)\.[0-9a-f]{16}")
+SUBJECT_PREFIX = "probe"
+
+API_KEY = os.environ.get("E2A_API_KEY", "")
+BASE_URL = os.environ.get("E2A_BASE_URL", "https://api.e2a.dev")
+AGENT_A = os.environ.get("E2A_MONITOR_AGENT_A", "")
+AGENT_B = os.environ.get("E2A_MONITOR_AGENT_B", "")
+WEBHOOK_SECRET = os.environ.get("E2A_MONITOR_WEBHOOK_SECRET", "")
+# A reply older than this is a stale redelivery, not a fresh success — it must
+# never refresh the alert's "last seen" clock.
+MAX_AGE_MS = int(os.environ.get("E2A_MONITOR_MAX_AGE_MS", "900000"))
+PORT = int(os.environ.get("PORT", "8080"))
+
+_client: E2AClient | None = None
+
+
+def log(event: str, **fields: object) -> None:
+    """One JSON line per event on stdout. Never pass a secret in here."""
+    print(json.dumps({"event": event, **fields}, default=str), flush=True)
+
+
+def client() -> E2AClient:
+    global _client
+    if _client is None:
+        _client = E2AClient(api_key=API_KEY, base_url=BASE_URL)
+    return _client
+
+
+def new_nonce() -> str:
+    return f"e2asdkmon.{int(time.time() * 1000)}.{secrets.token_hex(8)}"
+
+
+def handle_tick() -> tuple[int, dict]:
+    """Send the outbound leg: agent A -> agent B, nonce in subject and body."""
+    nonce = new_nonce()
+    try:
+        result = client().messages.send(
+            AGENT_A,
+            {"to": [AGENT_B], "subject": f"{SUBJECT_PREFIX} {nonce}", "text": nonce},
+        )
+    except Exception as exc:  # noqa: BLE001 - any SDK failure is a monitor signal
+        log("sdk_monitor_error", stage="send", nonce=nonce, error=type(exc).__name__, detail=str(exc))
+        return 500, {"ok": False, "stage": "send"}
+    log(
+        "sdk_monitor_tick",
+        nonce=nonce,
+        message_id=result.message_id,
+        status=result.status,
+        method=result.method,
+    )
+    return 202, {"ok": True, "nonce": nonce}
+
+
+def handle_webhook(raw_body: bytes, signature: str) -> tuple[int, dict]:
+    """Verify, hydrate, then act on which leg of the round trip this is."""
+    # Fail closed: an unset secret means the deployment is misconfigured, and
+    # accepting unverified deliveries would make the whole signal forgeable.
+    if not WEBHOOK_SECRET:
+        log("sdk_monitor_error", stage="config", detail="webhook secret not configured")
+        return 401, {"error": "unauthorized"}
+    try:
+        event = construct_event(raw_body, signature, WEBHOOK_SECRET)
+    except E2AWebhookSignatureError as exc:
+        log("sdk_monitor_error", stage="signature", code=getattr(exc, "code", None))
+        return 401, {"error": "unauthorized"}
+
+    # An account-scoped subscription fans out email.sent, bounces, domain
+    # events — everything that is not an inbound delivery is not our business.
+    if not is_email_received(event):
+        return 200, {"ok": True, "ignored": event.type}
+
+    try:
+        email = client().inbound.from_event(event)
+    except Exception as exc:  # noqa: BLE001
+        log("sdk_monitor_error", stage="hydrate", event_id=event.id, error=type(exc).__name__, detail=str(exc))
+        # 5xx so e2a retries: a transient hydration failure shouldn't silently
+        # drop a leg and manufacture a false alert.
+        return 500, {"ok": False, "stage": "hydrate"}
+
+    match = NONCE_RE.search(email.subject or "")
+    if not match:
+        return 200, {"ok": True, "ignored": "not a probe"}
+    nonce, sent_ms = match.group(0), int(match.group(1))
+    age_ms = int(time.time() * 1000) - sent_ms
+
+    # Which leg this is comes from the recipient, not from a "Re:" prefix:
+    # mailers rewrite subjects, but the delivered-to agent is authoritative.
+    inbox = (email.inbox or "").lower()
+
+    if inbox == AGENT_B.lower():
+        if age_ms > MAX_AGE_MS:
+            log("sdk_monitor_stale", leg="outbound", nonce=nonce, age_ms=age_ms)
+            return 200, {"ok": True, "stale": True}
+        try:
+            # idempotency_key keyed on the event so a webhook redelivery can't
+            # fan out into duplicate replies.
+            email.reply({"text": nonce}, idempotency_key=f"sdkmon:{event.id}")
+        except Exception as exc:  # noqa: BLE001
+            log("sdk_monitor_error", stage="reply", nonce=nonce, error=type(exc).__name__, detail=str(exc))
+            return 500, {"ok": False, "stage": "reply"}
+        log("sdk_monitor_replied", nonce=nonce, age_ms=age_ms)
+        return 200, {"ok": True, "leg": "outbound"}
+
+    if inbox == AGENT_A.lower():
+        if age_ms > MAX_AGE_MS:
+            # Deliberately not sdk_monitor_ok: a stale reply must not reset the
+            # freshness alert.
+            log("sdk_monitor_stale", leg="reply", nonce=nonce, age_ms=age_ms)
+            return 200, {"ok": True, "stale": True}
+        log("sdk_monitor_ok", nonce=nonce, latency_ms=age_ms, message_id=email.id)
+        return 200, {"ok": True, "leg": "reply", "latency_ms": age_ms}
+
+    return 200, {"ok": True, "ignored": "unknown inbox"}
+
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = "e2a-sdk-monitor"
+
+    def _respond(self, status: int, payload: dict) -> None:
+        body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        if self.path.split("?")[0] == "/health":
+            self._respond(200, {"status": "ok"})
+        else:
+            self._respond(404, {"error": "not found"})
+
+    def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+        path = self.path.split("?")[0]
+        raw = self.rfile.read(int(self.headers.get("Content-Length") or 0))
+        if path == "/tick":
+            self._respond(*handle_tick())
+        elif path == "/webhook":
+            # Must be the RAW bytes — re-serialized JSON won't match the HMAC.
+            self._respond(*handle_webhook(raw, self.headers.get("X-E2A-Signature") or ""))
+        else:
+            self._respond(404, {"error": "not found"})
+
+    def log_message(self, fmt: str, *args: object) -> None:
+        """Silence the default access log — it would interleave non-JSON lines
+        into the structured stream the alert parses."""
+
+
+def main() -> None:
+    missing = [
+        name
+        for name, value in (
+            ("E2A_API_KEY", API_KEY),
+            ("E2A_MONITOR_AGENT_A", AGENT_A),
+            ("E2A_MONITOR_AGENT_B", AGENT_B),
+            ("E2A_MONITOR_WEBHOOK_SECRET", WEBHOOK_SECRET),
+        )
+        if not value
+    ]
+    if missing:
+        # Names only — never the values.
+        log("sdk_monitor_error", stage="config", detail=f"missing env: {', '.join(missing)}")
+        sys.exit(1)
+    log("sdk_monitor_start", port=PORT, base_url=BASE_URL, agent_a=AGENT_A, agent_b=AGENT_B)
+    ThreadingHTTPServer(("0.0.0.0", PORT), Handler).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/sdk-monitor/package.json
+++ b/tests/sdk-monitor/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "e2a-sdk-monitor-node-runtime",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Node-runtime dependencies for tests/sdk-monitor's ts_sdk and cli interfaces — pinned to the exact PUBLISHED npm packages so a broken publish surfaces here, never workspace source. Never add a path/workspace dependency on ../../sdks/typescript or ../../cli.",
+  "dependencies": {
+    "@e2a/sdk": "5.2.0",
+    "@e2a/cli": "2.0.0"
+  }
+}

--- a/tests/sdk-monitor/requirements.txt
+++ b/tests/sdk-monitor/requirements.txt
@@ -1,0 +1,5 @@
+# The whole point of this service is validating what users actually install, so
+# this MUST stay a pinned PyPI release — never a path/editable dep on
+# ../../sdks/python. A broken publish has to surface here, not be papered over
+# by local source. Bump this on every Python SDK release (see README.md).
+e2a==5.2.0

--- a/tests/sdk-monitor/test_monitor.py
+++ b/tests/sdk-monitor/test_monitor.py
@@ -1,11 +1,16 @@
-"""Offline checks for the webhook handler. No pytest, no network:
+"""Offline checks for the multi-interface conformance monitor. No pytest, no
+network, no real subprocess to npm/node:
 
     E2A_API_KEY=x E2A_MONITOR_AGENT_A=a@x E2A_MONITOR_AGENT_B=b@x \
     E2A_MONITOR_WEBHOOK_SECRET=whsec_test python test_monitor.py
 
 Covers the parts that must not regress silently: signature accept/reject,
-fail-closed on an unset secret, non-inbound event types, and the stale-reply
-guard. The round trip itself is only exercisable against a live deployment.
+fail-closed on an unset secret, non-inbound event types, the nonce <-> iface
+encoding round trip, the stale-reply guard (both legs), the interface-strategy
+dispatch, and the unknown-iface safety net. Every interface's actual send/reply
+I/O is stubbed with fakes injected into monitor.STRATEGIES — no real network
+call, no real subprocess. The live round trips are only exercisable against a
+real deployment.
 """
 
 import hashlib
@@ -51,6 +56,32 @@ def envelope(event_type: str, data: dict) -> bytes:
     ).encode()
 
 
+# ---------------------------------------------------------------------------
+# Nonce <-> iface encoding round trip.
+# ---------------------------------------------------------------------------
+
+for _iface in monitor.IFACES:
+    _nonce = monitor.new_nonce(_iface)
+    _match = monitor.NONCE_RE.search(f"probe {_nonce}")
+    check(f"nonce round-trips iface={_iface}", _match is not None, True)
+    if _match:
+        check(f"nonce iface group matches ({_iface})", _match.group(1), _iface)
+        check(f"nonce timestamp group is numeric ({_iface})", _match.group(2).isdigit(), True)
+        check(f"nonce full match is the nonce itself ({_iface})", _match.group(0), _nonce)
+
+# A nonce naming an iface this build doesn't recognize still matches the
+# generic regex (handled explicitly downstream — see the unknown-iface test
+# below) rather than silently failing to parse.
+_unknown_nonce = f"e2asdkmon.some_future_iface.{int(time.time() * 1000)}.0123456789abcdef"
+_unknown_match = monitor.NONCE_RE.search(f"probe {_unknown_nonce}")
+check("unrecognized-but-shaped iface still parses", _unknown_match is not None, True)
+check("unrecognized iface group captured", _unknown_match.group(1) if _unknown_match else None, "some_future_iface")
+
+
+# ---------------------------------------------------------------------------
+# Webhook signature verification: fail-closed, replay, non-inbound ignore.
+# ---------------------------------------------------------------------------
+
 body = envelope("email.sent", {"message_id": "msg_1"})
 
 status, _ = monitor.handle_webhook(body, sign(body))
@@ -70,15 +101,32 @@ status, _ = monitor.handle_webhook(body, sign(body, secret=saved))
 check("unset secret fails closed", status, 401)
 monitor.WEBHOOK_SECRET = saved
 
-# Stale guard: a reply whose nonce timestamp is older than MAX_AGE_MS must not
-# emit sdk_monitor_ok. Stub hydration so this stays offline.
-old_ms = int(time.time() * 1000) - monitor.MAX_AGE_MS - 60_000
+
+# ---------------------------------------------------------------------------
+# Fakes for the interface-strategy dispatch + stale-guard + success-path
+# tests. Every strategy's I/O is stubbed — no network, no subprocess.
+# ---------------------------------------------------------------------------
+
+
+class FakeStrategy:
+    def __init__(self):
+        self.send_calls = []
+        self.reply_calls = []
+
+    def available(self):
+        return True
+
+    def send(self, **kwargs):
+        self.send_calls.append(kwargs)
+
+    def reply(self, **kwargs):
+        self.reply_calls.append(kwargs)
 
 
 class FakeEmail:
     id = "msg_stale"
     inbox = monitor.AGENT_A
-    subject = f"Re: probe e2asdkmon.{old_ms}.0123456789abcdef"
+    subject = ""  # set per-test below
 
 
 class FakeInbound:
@@ -92,26 +140,241 @@ class FakeClient:
 
 monitor._client = FakeClient()
 emitted = []
-monitor.log = lambda event, **f: emitted.append(event)
+monitor.log = lambda event, **f: emitted.append((event, f))
+
+fake_strategies = {iface: FakeStrategy() for iface in monitor.IFACES}
+monitor.STRATEGIES = fake_strategies
 
 inbound_body = envelope("email.received", {"message_id": "msg_stale", "delivered_to": monitor.AGENT_A})
+
+
+def emitted_events():
+    return [e for e, _ in emitted]
+
+
+# Stale guard on the reply leg (inbox == A): a reply whose nonce timestamp is
+# older than MAX_AGE_MS must not emit monitor_ok.
+old_ms = int(time.time() * 1000) - monitor.MAX_AGE_MS - 60_000
+FakeEmail.subject = f"Re: probe e2asdkmon.python_sdk.{old_ms}.0123456789abcdef"
+emitted.clear()
 status, _ = monitor.handle_webhook(inbound_body, sign(inbound_body))
 check("stale reply returns 200", status, 200)
-check("stale reply does not emit sdk_monitor_ok", "sdk_monitor_ok" in emitted, False)
-check("stale reply emits sdk_monitor_stale", "sdk_monitor_stale" in emitted, True)
+check("stale reply does not emit monitor_ok", "monitor_ok" in emitted_events(), False)
+check("stale reply emits monitor_stale", "monitor_stale" in emitted_events(), True)
 
-# Fresh reply on the same path emits the success marker with latency.
-FakeEmail.subject = f"Re: probe e2asdkmon.{int(time.time() * 1000) - 4200}.0123456789abcdef"
+# Fresh reply on the same path emits the success marker with iface + latency,
+# and does NOT dispatch to any strategy (inbox == A is the terminal leg).
+FakeEmail.subject = f"Re: probe e2asdkmon.python_sdk.{int(time.time() * 1000) - 4200}.0123456789abcdef"
 emitted.clear()
 status, payload = monitor.handle_webhook(inbound_body, sign(inbound_body))
-check("fresh reply emits sdk_monitor_ok", "sdk_monitor_ok" in emitted, True)
+check("fresh reply emits monitor_ok", "monitor_ok" in emitted_events(), True)
 check("fresh reply reports latency", payload["latency_ms"] >= 4200, True)
+ok_fields = next(f for e, f in emitted if e == "monitor_ok")
+check("fresh reply's monitor_ok carries iface", ok_fields.get("iface"), "python_sdk")
+check("fresh reply's monitor_ok carries latency_ms", ok_fields.get("latency_ms", 0) >= 4200, True)
 
 # A subject with no probe nonce is ignored, not counted.
 FakeEmail.subject = "hello from a real human"
 emitted.clear()
 status, payload = monitor.handle_webhook(inbound_body, sign(inbound_body))
 check("non-probe subject ignored", payload.get("ignored"), "not a probe")
+
+
+# ---------------------------------------------------------------------------
+# Interface-strategy dispatch: the outbound leg (inbox == B) replies via the
+# EXACT strategy named in the nonce, and no other strategy is touched.
+# ---------------------------------------------------------------------------
+
+
+class FakeEmailB:
+    id = "msg_fresh_b"
+    inbox = monitor.AGENT_B
+    subject = ""
+
+
+class FakeInboundB:
+    def from_event(self, event):
+        return FakeEmailB()
+
+
+class FakeClientB:
+    inbound = FakeInboundB()
+
+
+monitor._client = FakeClientB()
+
+fresh_ms = int(time.time() * 1000) - 100
+FakeEmailB.subject = f"probe e2asdkmon.ts_sdk.{fresh_ms}.0123456789abcdef"
+for s in fake_strategies.values():
+    s.reply_calls.clear()
+emitted.clear()
+inbound_body_b = envelope("email.received", {"message_id": "msg_fresh_b", "delivered_to": monitor.AGENT_B})
+status, payload = monitor.handle_webhook(inbound_body_b, sign(inbound_body_b))
+check("outbound leg (fresh) returns 200", status, 200)
+check("outbound leg dispatches to the nonce's own iface (ts_sdk)", len(fake_strategies["ts_sdk"].reply_calls), 1)
+check("outbound leg does not touch other ifaces", sum(len(s.reply_calls) for k, s in fake_strategies.items() if k != "ts_sdk"), 0)
+replied_kwargs = fake_strategies["ts_sdk"].reply_calls[0]
+check("dispatched reply targets inbox B", replied_kwargs.get("inbox"), monitor.AGENT_B)
+check("dispatched reply carries the message id", replied_kwargs.get("message_id"), "msg_fresh_b")
+check("dispatched reply carries an idempotency key scoped to the event", replied_kwargs.get("idempotency_key"), "sdkmon:evt_test_1")
+check("monitor_replied logs the dispatched iface", any(e == "monitor_replied" and f.get("iface") == "ts_sdk" for e, f in emitted), True)
+
+# Stale guard on the outbound leg (inbox == B) must ALSO block dispatch —
+# never calls the strategy's reply().
+FakeEmailB.subject = f"probe e2asdkmon.cli.{old_ms}.0123456789abcdef"
+for s in fake_strategies.values():
+    s.reply_calls.clear()
+emitted.clear()
+status, _ = monitor.handle_webhook(inbound_body_b, sign(inbound_body_b))
+check("stale outbound leg does not dispatch a reply", len(fake_strategies["cli"].reply_calls), 0)
+check("stale outbound leg emits monitor_stale", "monitor_stale" in emitted_events(), True)
+
+
+# ---------------------------------------------------------------------------
+# Unknown iface: parses but isn't in STRATEGIES — handled safely, no crash,
+# no success/stale claim, no dispatch.
+# ---------------------------------------------------------------------------
+
+FakeEmailB.subject = f"probe e2asdkmon.some_future_iface.{fresh_ms}.0123456789abcdef"
+for s in fake_strategies.values():
+    s.reply_calls.clear()
+emitted.clear()
+status, payload = monitor.handle_webhook(inbound_body_b, sign(inbound_body_b))
+check("unknown iface handled without crashing (200)", status, 200)
+check("unknown iface does not dispatch any strategy", sum(len(s.reply_calls) for s in fake_strategies.values()), 0)
+check("unknown iface logs a distinct error stage", any(e == "monitor_error" and f.get("stage") == "unknown_iface" for e, f in emitted), True)
+check("unknown iface never emits monitor_ok", "monitor_ok" in emitted_events(), False)
+
+
+# ---------------------------------------------------------------------------
+# /tick fan-out: every interface is attempted; one failure doesn't abort the
+# others; a strategy reporting unavailable is skipped, not attempted.
+# ---------------------------------------------------------------------------
+
+
+class SendOnlyStrategy(FakeStrategy):
+    def __init__(self, should_fail=False):
+        super().__init__()
+        self.should_fail = should_fail
+
+    def send(self, **kwargs):
+        super().send(**kwargs)
+        if self.should_fail:
+            raise RuntimeError("boom")
+
+
+tick_strategies = {iface: SendOnlyStrategy() for iface in monitor.IFACES}
+tick_strategies["mcp"].should_fail = True  # simulate one interface's failure
+
+
+class UnavailableStrategy(SendOnlyStrategy):
+    def available(self):
+        return False
+
+
+tick_strategies["cli"] = UnavailableStrategy()
+monitor.STRATEGIES = tick_strategies
+emitted.clear()
+status, payload = monitor.handle_tick()
+check("tick returns 200", status, 200)
+check("tick attempts every non-skipped iface", tick_strategies["api"].send_calls != [], True)
+check("tick's overall failure is reflected", payload["ok"], False)
+check("tick reports the failing iface as not ok", payload["results"]["mcp"]["ok"], False)
+check("tick reports the succeeding ifaces as ok", payload["results"]["python_sdk"]["ok"], True)
+check("tick does not call send on an unavailable iface", tick_strategies["cli"].send_calls, [])
+check("tick marks an unavailable iface as skipped", payload["results"]["cli"]["skipped"], True)
+check("tick logs monitor_skip for the unavailable iface", any(e == "monitor_skip" and f.get("iface") == "cli" for e, f in emitted), True)
+check("tick logs monitor_error for the failing iface", any(e == "monitor_error" and f.get("iface") == "mcp" and f.get("stage") == "send" for e, f in emitted), True)
+
+
+# ---------------------------------------------------------------------------
+# McpStrategy response parsing: SSE framing, JSON-RPC error, tool isError, and
+# the malformed-response guard (neither result nor error present must NOT be
+# silently treated as success — found in adversarial review of this change).
+# Stubs urllib.request.urlopen directly; no real network.
+# ---------------------------------------------------------------------------
+
+import urllib.request as _urllib_request  # noqa: E402
+
+
+class _FakeHeaders:
+    def __init__(self, content_type):
+        self._content_type = content_type
+
+    def get(self, name, default=None):
+        return self._content_type if name == "Content-Type" else default
+
+
+class _FakeResponse:
+    def __init__(self, raw: bytes, content_type: str):
+        self._raw = raw
+        self.headers = _FakeHeaders(content_type)
+
+    def read(self):
+        return self._raw
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _stub_urlopen(sse_body: str):
+    def _fake_urlopen(req, timeout=None):
+        return _FakeResponse(sse_body.encode(), "text/event-stream")
+
+    return _fake_urlopen
+
+
+_saved_urlopen = _urllib_request.urlopen
+_mcp = monitor.McpStrategy("https://mcp.example/mcp", "e2a_acct_test")
+
+_urllib_request.urlopen = _stub_urlopen(
+    'data: {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"ok"}]}}\n\n'
+)
+try:
+    _mcp.send(agent_a="a@x", agent_b="b@x", subject="probe x", body="x")
+    _mcp_send_ok = True
+except Exception:
+    _mcp_send_ok = False
+check("mcp strategy parses a well-formed SSE result", _mcp_send_ok, True)
+
+_urllib_request.urlopen = _stub_urlopen(
+    'data: {"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"boom"}}\n\n'
+)
+try:
+    _mcp.send(agent_a="a@x", agent_b="b@x", subject="probe x", body="x")
+    _mcp_error_raised = False
+except RuntimeError:
+    _mcp_error_raised = True
+check("mcp strategy raises on a JSON-RPC error envelope", _mcp_error_raised, True)
+
+_urllib_request.urlopen = _stub_urlopen(
+    'data: {"jsonrpc":"2.0","id":1,"result":{"isError":true,"content":[{"type":"text","text":"e2a error [invalid_request]: bad"}]}}\n\n'
+)
+try:
+    _mcp.send(agent_a="a@x", agent_b="b@x", subject="probe x", body="x")
+    _mcp_tool_error_raised = False
+except RuntimeError:
+    _mcp_tool_error_raised = True
+check("mcp strategy raises on a tool-level isError result", _mcp_tool_error_raised, True)
+
+# The malformed case: neither "result" nor "error" — must raise, not silently
+# succeed (this was the adversarial-review finding this test guards).
+_urllib_request.urlopen = _stub_urlopen('data: {"jsonrpc":"2.0","id":1}\n\n')
+try:
+    _mcp.send(agent_a="a@x", agent_b="b@x", subject="probe x", body="x")
+    _mcp_malformed_raised = False
+except RuntimeError:
+    _mcp_malformed_raised = True
+check("mcp strategy raises on a response with neither result nor error", _mcp_malformed_raised, True)
+
+_urllib_request.urlopen = _saved_urlopen
+
+check("mcp strategy reports unavailable when no URL is configured", monitor.McpStrategy("", "k").available(), False)
+check("mcp strategy reports available when a URL is configured", monitor.McpStrategy("https://x/mcp", "k").available(), True)
+
 
 print()
 if failures:

--- a/tests/sdk-monitor/test_monitor.py
+++ b/tests/sdk-monitor/test_monitor.py
@@ -6,11 +6,21 @@ network, no real subprocess to npm/node:
 
 Covers the parts that must not regress silently: signature accept/reject,
 fail-closed on an unset secret, non-inbound event types, the nonce <-> iface
-encoding round trip, the stale-reply guard (both legs), the interface-strategy
-dispatch, and the unknown-iface safety net. Every interface's actual send/reply
-I/O is stubbed with fakes injected into monitor.STRATEGIES — no real network
-call, no real subprocess. The live round trips are only exercisable against a
-real deployment.
+encoding round trip (including the HMAC tag), nonce-MAC authentication (a
+tampered iface/timestamp/tag is rejected, and a pre-MAC 3-part nonce doesn't
+even match), the stale-reply guard (both legs), the interface-strategy
+dispatch, the unknown-iface safety net, the /tick aggregate + status-code
+semantics (all-ok / partial / total-outage / an optional interface skipped),
+uniform non-success send-status handling across every offline-exercisable
+interface, the wire shape of the api/ts_sdk/cli strategies (argv/URL/headers,
+and that secrets never land in argv), the minimal subprocess environment, and
+McpStrategy's JSON-RPC response parsing (SSE framing, a JSON-RPC error, a
+tool-level isError, a leading notification/mismatched-id frame that must be
+skipped rather than mistaken for our response, and the malformed-response
+guard). Every interface's actual send/reply I/O is stubbed with fakes
+injected into monitor.STRATEGIES, or with urllib.request.urlopen /
+subprocess.run monkeypatched to capture/replay a call — no real network call,
+no real subprocess to node/npm.
 """
 
 import hashlib
@@ -56,8 +66,27 @@ def envelope(event_type: str, data: dict) -> bytes:
     ).encode()
 
 
+def make_nonce(iface: str, epoch_ms: int, rand_hex: str = "0123456789abcdef") -> str:
+    """Build a correctly-tagged nonce for an arbitrary timestamp — the tests
+    need to control staleness/freshness directly, so this mirrors
+    monitor.new_nonce() but takes epoch_ms as an argument instead of reading
+    the clock."""
+    tag = monitor._nonce_tag(iface, epoch_ms, rand_hex)
+    return f"e2asdkmon.{iface}.{epoch_ms}.{rand_hex}.{tag}"
+
+
+def header(headers: dict, name: str):
+    """Case-insensitive header lookup — urllib.request.Request.add_header
+    stores keys via str.capitalize() (e.g. "Idempotency-Key" ->
+    "Idempotency-key"), not as-passed."""
+    for k, v in headers.items():
+        if k.lower() == name.lower():
+            return v
+    return None
+
+
 # ---------------------------------------------------------------------------
-# Nonce <-> iface encoding round trip.
+# Nonce <-> iface encoding round trip, including the HMAC tag (FIX 1).
 # ---------------------------------------------------------------------------
 
 for _iface in monitor.IFACES:
@@ -68,14 +97,22 @@ for _iface in monitor.IFACES:
         check(f"nonce iface group matches ({_iface})", _match.group(1), _iface)
         check(f"nonce timestamp group is numeric ({_iface})", _match.group(2).isdigit(), True)
         check(f"nonce full match is the nonce itself ({_iface})", _match.group(0), _nonce)
+        _expected_tag = monitor._nonce_tag(_iface, int(_match.group(2)), _match.group(3))
+        check(f"nonce tag matches HMAC({_iface})", _match.group(4), _expected_tag)
 
 # A nonce naming an iface this build doesn't recognize still matches the
 # generic regex (handled explicitly downstream — see the unknown-iface test
-# below) rather than silently failing to parse.
-_unknown_nonce = f"e2asdkmon.some_future_iface.{int(time.time() * 1000)}.0123456789abcdef"
+# below) rather than silently failing to parse. Shape only here — no mac
+# correctness claim (that's tested against handle_webhook further down).
+_unknown_nonce = f"e2asdkmon.some_future_iface.{int(time.time() * 1000)}.0123456789abcdef.abcdef0123456789"
 _unknown_match = monitor.NONCE_RE.search(f"probe {_unknown_nonce}")
 check("unrecognized-but-shaped iface still parses", _unknown_match is not None, True)
 check("unrecognized iface group captured", _unknown_match.group(1) if _unknown_match else None, "some_future_iface")
+
+# Old-style pre-MAC nonce (3 parts, no tag segment) simply does not match the
+# new 4-group NONCE_RE at all.
+_old_style_nonce = f"e2asdkmon.python_sdk.{int(time.time() * 1000)}.0123456789abcdef"
+check("old-style 3-part nonce does not match the new regex", monitor.NONCE_RE.search(f"probe {_old_style_nonce}"), None)
 
 
 # ---------------------------------------------------------------------------
@@ -155,7 +192,7 @@ def emitted_events():
 # Stale guard on the reply leg (inbox == A): a reply whose nonce timestamp is
 # older than MAX_AGE_MS must not emit monitor_ok.
 old_ms = int(time.time() * 1000) - monitor.MAX_AGE_MS - 60_000
-FakeEmail.subject = f"Re: probe e2asdkmon.python_sdk.{old_ms}.0123456789abcdef"
+FakeEmail.subject = f"Re: probe {make_nonce('python_sdk', old_ms)}"
 emitted.clear()
 status, _ = monitor.handle_webhook(inbound_body, sign(inbound_body))
 check("stale reply returns 200", status, 200)
@@ -164,7 +201,7 @@ check("stale reply emits monitor_stale", "monitor_stale" in emitted_events(), Tr
 
 # Fresh reply on the same path emits the success marker with iface + latency,
 # and does NOT dispatch to any strategy (inbox == A is the terminal leg).
-FakeEmail.subject = f"Re: probe e2asdkmon.python_sdk.{int(time.time() * 1000) - 4200}.0123456789abcdef"
+FakeEmail.subject = f"Re: probe {make_nonce('python_sdk', int(time.time() * 1000) - 4200)}"
 emitted.clear()
 status, payload = monitor.handle_webhook(inbound_body, sign(inbound_body))
 check("fresh reply emits monitor_ok", "monitor_ok" in emitted_events(), True)
@@ -204,7 +241,7 @@ class FakeClientB:
 monitor._client = FakeClientB()
 
 fresh_ms = int(time.time() * 1000) - 100
-FakeEmailB.subject = f"probe e2asdkmon.ts_sdk.{fresh_ms}.0123456789abcdef"
+FakeEmailB.subject = f"probe {make_nonce('ts_sdk', fresh_ms)}"
 for s in fake_strategies.values():
     s.reply_calls.clear()
 emitted.clear()
@@ -221,7 +258,7 @@ check("monitor_replied logs the dispatched iface", any(e == "monitor_replied" an
 
 # Stale guard on the outbound leg (inbox == B) must ALSO block dispatch —
 # never calls the strategy's reply().
-FakeEmailB.subject = f"probe e2asdkmon.cli.{old_ms}.0123456789abcdef"
+FakeEmailB.subject = f"probe {make_nonce('cli', old_ms)}"
 for s in fake_strategies.values():
     s.reply_calls.clear()
 emitted.clear()
@@ -231,11 +268,86 @@ check("stale outbound leg emits monitor_stale", "monitor_stale" in emitted_event
 
 
 # ---------------------------------------------------------------------------
-# Unknown iface: parses but isn't in STRATEGIES — handled safely, no crash,
-# no success/stale claim, no dispatch.
+# Nonce MAC authentication (FIX 1): only a nonce whose tag actually matches
+# _nonce_tag(iface, sent_ms, rand_hex) may act on either leg. Anyone able to
+# email agent A can pick an iface/timestamp/random hex freely, but without
+# NONCE_KEY they cannot produce a matching tag — the forged nonce must be
+# silently ignored: no reply dispatched, no monitor_ok, no crash.
 # ---------------------------------------------------------------------------
 
-FakeEmailB.subject = f"probe e2asdkmon.some_future_iface.{fresh_ms}.0123456789abcdef"
+_valid_epoch = fresh_ms
+_valid_rand = "abcdef0123456789"
+_valid_tag = monitor._nonce_tag("ts_sdk", _valid_epoch, _valid_rand)
+
+# Tampered iface: a real tag, but minted for "ts_sdk" and replayed under a
+# different iface name in the subject.
+FakeEmailB.subject = f"probe e2asdkmon.cli.{_valid_epoch}.{_valid_rand}.{_valid_tag}"
+for s in fake_strategies.values():
+    s.reply_calls.clear()
+emitted.clear()
+status, payload = monitor.handle_webhook(inbound_body_b, sign(inbound_body_b))
+check("tampered-iface nonce returns 200", status, 200)
+check("tampered-iface nonce is ignored as a bad nonce mac", payload.get("ignored"), "bad nonce mac")
+check("tampered-iface nonce dispatches no reply", sum(len(s.reply_calls) for s in fake_strategies.values()), 0)
+check("tampered-iface nonce logs stage=nonce_auth", any(e == "monitor_error" and f.get("stage") == "nonce_auth" for e, f in emitted), True)
+check("tampered-iface nonce never emits monitor_ok", "monitor_ok" in emitted_events(), False)
+check("tampered-iface nonce never emits monitor_replied", "monitor_replied" in emitted_events(), False)
+
+# Tampered timestamp: a real tag for _valid_epoch, replayed under a forged
+# (fresher) epoch in the subject — the forger can't produce a tag for a
+# timestamp they didn't request one for, so this also defeats trying to
+# "refresh" a captured nonce's apparent age.
+_forged_epoch = _valid_epoch + 1
+FakeEmailB.subject = f"probe e2asdkmon.ts_sdk.{_forged_epoch}.{_valid_rand}.{_valid_tag}"
+for s in fake_strategies.values():
+    s.reply_calls.clear()
+emitted.clear()
+status, payload = monitor.handle_webhook(inbound_body_b, sign(inbound_body_b))
+check("tampered-timestamp nonce is ignored as a bad nonce mac", payload.get("ignored"), "bad nonce mac")
+check("tampered-timestamp nonce dispatches no reply", sum(len(s.reply_calls) for s in fake_strategies.values()), 0)
+
+# Tampered tag: correct iface/epoch/rand, but the tag itself is flipped.
+_bad_tag = ("0" if _valid_tag[0] != "0" else "1") + _valid_tag[1:]
+FakeEmailB.subject = f"probe e2asdkmon.ts_sdk.{_valid_epoch}.{_valid_rand}.{_bad_tag}"
+for s in fake_strategies.values():
+    s.reply_calls.clear()
+emitted.clear()
+status, payload = monitor.handle_webhook(inbound_body_b, sign(inbound_body_b))
+check("tampered-tag nonce is ignored as a bad nonce mac", payload.get("ignored"), "bad nonce mac")
+check("tampered-tag nonce dispatches no reply", sum(len(s.reply_calls) for s in fake_strategies.values()), 0)
+
+# Old-style 3-part nonce (pre-MAC, no tag segment): NONCE_RE simply doesn't
+# match it, so it's "not a probe", not "bad nonce mac" — there is no partial
+# parse to reject.
+FakeEmailB.subject = f"probe e2asdkmon.ts_sdk.{_valid_epoch}.{_valid_rand}"
+for s in fake_strategies.values():
+    s.reply_calls.clear()
+emitted.clear()
+status, payload = monitor.handle_webhook(inbound_body_b, sign(inbound_body_b))
+check("old-style 3-part nonce is not treated as a probe", payload.get("ignored"), "not a probe")
+check("old-style 3-part nonce dispatches no reply", sum(len(s.reply_calls) for s in fake_strategies.values()), 0)
+
+# The positive counterpart, right next to the tamper tests above: a
+# correctly-tagged fresh nonce on the outbound leg is accepted end-to-end and
+# dispatches exactly one reply via the named interface.
+FakeEmailB.subject = f"probe e2asdkmon.ts_sdk.{_valid_epoch}.{_valid_rand}.{_valid_tag}"
+for s in fake_strategies.values():
+    s.reply_calls.clear()
+emitted.clear()
+status, payload = monitor.handle_webhook(inbound_body_b, sign(inbound_body_b))
+check("valid nonce accepted end-to-end (200)", status, 200)
+check("valid nonce dispatches exactly one reply via its iface", len(fake_strategies["ts_sdk"].reply_calls), 1)
+check("valid nonce does not touch other ifaces", sum(len(s.reply_calls) for k, s in fake_strategies.items() if k != "ts_sdk"), 0)
+
+
+# ---------------------------------------------------------------------------
+# Unknown iface: parses AND authenticates (a real tag for that iface name),
+# but isn't in STRATEGIES — handled safely, no crash, no success/stale claim,
+# no dispatch.
+# ---------------------------------------------------------------------------
+
+_unknown_iface_tag = monitor._nonce_tag("some_future_iface", fresh_ms, "0123456789abcdef")
+FakeEmailB.subject = f"probe e2asdkmon.some_future_iface.{fresh_ms}.0123456789abcdef.{_unknown_iface_tag}"
 for s in fake_strategies.values():
     s.reply_calls.clear()
 emitted.clear()
@@ -247,15 +359,20 @@ check("unknown iface never emits monitor_ok", "monitor_ok" in emitted_events(), 
 
 
 # ---------------------------------------------------------------------------
-# /tick fan-out: every interface is attempted; one failure doesn't abort the
-# others; a strategy reporting unavailable is skipped, not attempted.
+# /tick aggregate + status-code semantics (FIX 2): the aggregate is computed
+# over non-skipped ("considered") interfaces only, and the HTTP status
+# distinguishes all-ok / partial / total outage for Cloud Scheduler.
 # ---------------------------------------------------------------------------
 
 
 class SendOnlyStrategy(FakeStrategy):
-    def __init__(self, should_fail=False):
+    def __init__(self, should_fail=False, is_available=True):
         super().__init__()
         self.should_fail = should_fail
+        self._available = is_available
+
+    def available(self):
+        return self._available
 
     def send(self, **kwargs):
         super().send(**kwargs)
@@ -263,38 +380,68 @@ class SendOnlyStrategy(FakeStrategy):
             raise RuntimeError("boom")
 
 
-tick_strategies = {iface: SendOnlyStrategy() for iface in monitor.IFACES}
-tick_strategies["mcp"].should_fail = True  # simulate one interface's failure
+def tick_strategies(fail=(), unavailable=()):
+    return {
+        iface: SendOnlyStrategy(should_fail=iface in fail, is_available=iface not in unavailable)
+        for iface in monitor.IFACES
+    }
 
 
-class UnavailableStrategy(SendOnlyStrategy):
-    def available(self):
-        return False
-
-
-tick_strategies["cli"] = UnavailableStrategy()
-monitor.STRATEGIES = tick_strategies
+# All interfaces succeed -> 200, ok=True.
+monitor.STRATEGIES = tick_strategies()
 emitted.clear()
 status, payload = monitor.handle_tick()
-check("tick returns 200", status, 200)
-check("tick attempts every non-skipped iface", tick_strategies["api"].send_calls != [], True)
-check("tick's overall failure is reflected", payload["ok"], False)
-check("tick reports the failing iface as not ok", payload["results"]["mcp"]["ok"], False)
-check("tick reports the succeeding ifaces as ok", payload["results"]["python_sdk"]["ok"], True)
-check("tick does not call send on an unavailable iface", tick_strategies["cli"].send_calls, [])
-check("tick marks an unavailable iface as skipped", payload["results"]["cli"]["skipped"], True)
-check("tick logs monitor_skip for the unavailable iface", any(e == "monitor_skip" and f.get("iface") == "cli" for e, f in emitted), True)
-check("tick logs monitor_error for the failing iface", any(e == "monitor_error" and f.get("iface") == "mcp" and f.get("stage") == "send" for e, f in emitted), True)
+check("tick all-ok returns 200", status, 200)
+check("tick all-ok reports ok=True", payload["ok"], True)
+
+# `mcp` skipped (unconfigured — a supported normal deployment), every other
+# interface succeeds -> still 200, ok=True: a skip must not permanently pin
+# the aggregate to False.
+mcp_skipped_strategies = tick_strategies(unavailable={"mcp"})
+monitor.STRATEGIES = mcp_skipped_strategies
+emitted.clear()
+status, payload = monitor.handle_tick()
+check("tick mcp-skipped-others-ok returns 200", status, 200)
+check("tick mcp-skipped-others-ok reports ok=True", payload["ok"], True)
+check("tick mcp-skipped-others-ok marks mcp as skipped", payload["results"]["mcp"]["skipped"], True)
+check("tick mcp-skipped-others-ok does not call send on the skipped iface", mcp_skipped_strategies["mcp"].send_calls, [])
+check("tick mcp-skipped-others-ok logs monitor_skip for mcp", any(e == "monitor_skip" and f.get("iface") == "mcp" for e, f in emitted), True)
+
+# Partial failure: mcp's send fails, cli is unavailable (skipped), the rest
+# succeed -> 207, ok=False.
+partial_strategies = tick_strategies(fail={"mcp"}, unavailable={"cli"})
+monitor.STRATEGIES = partial_strategies
+emitted.clear()
+status, payload = monitor.handle_tick()
+check("tick partial-failure returns 207", status, 207)
+check("tick partial-failure reports ok=False", payload["ok"], False)
+check("tick partial-failure attempts every non-skipped iface", partial_strategies["api"].send_calls != [], True)
+check("tick partial-failure reports the failing iface as not ok", payload["results"]["mcp"]["ok"], False)
+check("tick partial-failure reports a succeeding iface as ok", payload["results"]["python_sdk"]["ok"], True)
+check("tick partial-failure does not call send on the unavailable iface", partial_strategies["cli"].send_calls, [])
+check("tick partial-failure marks the unavailable iface as skipped", payload["results"]["cli"]["skipped"], True)
+check("tick partial-failure logs monitor_skip for the unavailable iface", any(e == "monitor_skip" and f.get("iface") == "cli" for e, f in emitted), True)
+check("tick partial-failure logs monitor_error for the failing iface", any(e == "monitor_error" and f.get("iface") == "mcp" and f.get("stage") == "send" for e, f in emitted), True)
+
+# Total outage: every CONSIDERED interface fails (mcp is skipped, so it's not
+# considered and can't rescue the aggregate) -> 500, ok=False.
+all_fail_strategies = tick_strategies(fail=set(monitor.IFACES) - {"mcp"}, unavailable={"mcp"})
+monitor.STRATEGIES = all_fail_strategies
+emitted.clear()
+status, payload = monitor.handle_tick()
+check("tick all-fail (considered) returns 500", status, 500)
+check("tick all-fail reports ok=False", payload["ok"], False)
+check("tick all-fail still marks the skipped iface as skipped, not failed", payload["results"]["mcp"]["skipped"], True)
 
 
 # ---------------------------------------------------------------------------
-# McpStrategy response parsing: SSE framing, JSON-RPC error, tool isError, and
-# the malformed-response guard (neither result nor error present must NOT be
-# silently treated as success — found in adversarial review of this change).
-# Stubs urllib.request.urlopen directly; no real network.
+# FIX 3: uniform non-"sent"/"accepted" send-status handling. A held
+# (pending_review), failed, or unrecognized status must raise immediately
+# for every offline-exercisable interface — never logged success-shaped.
 # ---------------------------------------------------------------------------
 
 import urllib.request as _urllib_request  # noqa: E402
+import urllib.error as _urllib_error  # noqa: E402
 
 
 class _FakeHeaders:
@@ -327,14 +474,327 @@ def _stub_urlopen(sse_body: str):
     return _fake_urlopen
 
 
+def _stub_urlopen_json(response_body: dict):
+    def _fake_urlopen(req, timeout=None):
+        return _FakeResponse(json.dumps(response_body).encode(), "application/json")
+
+    return _fake_urlopen
+
+
 _saved_urlopen = _urllib_request.urlopen
+
+# --- api ---
+_api = monitor.ApiStrategy("https://api.example", "e2a_acct_test")
+for _status in ("pending_review", "failed", "some_unrecognized_status"):
+    _urllib_request.urlopen = _stub_urlopen_json({"status": _status, "message_id": "msg_x"})
+    try:
+        _api.send(agent_a="a@x", agent_b="b@x", subject="probe x", body="x")
+        _api_raised = False
+    except RuntimeError:
+        _api_raised = True
+    check(f"api strategy raises on send status={_status!r}", _api_raised, True)
+
+_urllib_request.urlopen = _stub_urlopen_json({"status": "accepted", "message_id": "msg_x"})
+try:
+    _api.send(agent_a="a@x", agent_b="b@x", subject="probe x", body="x")
+    _api_ok = True
+except Exception:
+    _api_ok = False
+check("api strategy does not raise on status=accepted", _api_ok, True)
+_urllib_request.urlopen = _saved_urlopen
+
+
+# --- python_sdk ---
+class _FakeSendResult:
+    def __init__(self, status):
+        self.status = status
+        self.message_id = "msg_x"
+
+
+class _FakeMessagesResource:
+    def __init__(self, status):
+        self._status = status
+
+    def send(self, *a, **k):
+        return _FakeSendResult(self._status)
+
+    def reply(self, *a, **k):
+        return _FakeSendResult(self._status)
+
+
+class _FakePySdkClient:
+    def __init__(self, status):
+        self.messages = _FakeMessagesResource(status)
+
+
+_py = monitor.PythonSdkStrategy()
+_saved_client = monitor._client
+for _status in ("pending_review", "failed", None):
+    monitor._client = _FakePySdkClient(_status)
+    try:
+        _py.send(agent_a="a@x", agent_b="b@x", subject="probe x", body="x")
+        _py_raised = False
+    except RuntimeError:
+        _py_raised = True
+    check(f"python_sdk strategy raises on send status={_status!r}", _py_raised, True)
+
+monitor._client = _FakePySdkClient("accepted")
+try:
+    _py.send(agent_a="a@x", agent_b="b@x", subject="probe x", body="x")
+    _py_ok = True
+except Exception:
+    _py_ok = False
+check("python_sdk strategy does not raise on status=accepted", _py_ok, True)
+monitor._client = _saved_client
+
+
+# --- mcp ---
+def _mcp_sse_for_status(status):
+    text = json.dumps({"status": status, "message_id": "msg_x"})
+    env = {"jsonrpc": "2.0", "id": 1, "result": {"content": [{"type": "text", "text": text}]}}
+    return f"data: {json.dumps(env)}\n\n"
+
+
 _mcp = monitor.McpStrategy("https://mcp.example/mcp", "e2a_acct_test")
 
-_urllib_request.urlopen = _stub_urlopen(
-    'data: {"jsonrpc":"2.0","id":1,"result":{"content":[{"type":"text","text":"ok"}]}}\n\n'
-)
+for _status in ("pending_review", "failed"):
+    _urllib_request.urlopen = _stub_urlopen(_mcp_sse_for_status(_status))
+    try:
+        _mcp.send(agent_a="a@x", agent_b="b@x", subject="probe x", body="x")
+        _mcp_status_raised = False
+    except RuntimeError:
+        _mcp_status_raised = True
+    check(f"mcp strategy raises on send status={_status!r}", _mcp_status_raised, True)
+
+_urllib_request.urlopen = _stub_urlopen(_mcp_sse_for_status("accepted"))
 try:
     _mcp.send(agent_a="a@x", agent_b="b@x", subject="probe x", body="x")
+    _mcp_status_ok = True
+except Exception:
+    _mcp_status_ok = False
+check("mcp strategy does not raise on status=accepted", _mcp_status_ok, True)
+_urllib_request.urlopen = _saved_urlopen
+
+
+# --- ts_sdk (via the node helper's exit code, mirroring the CLI) ---
+def _fake_subprocess_run_factory(returncode: int, stdout: str = "", stderr: str = ""):
+    def _fake_run(argv, env=None, capture_output=None, text=None, timeout=None):
+        class _Result:
+            pass
+
+        r = _Result()
+        r.returncode = returncode
+        r.stdout = stdout
+        r.stderr = stderr
+        return r
+
+    return _fake_run
+
+
+_saved_subprocess_run = monitor.subprocess.run
+_ts = monitor.TsSdkStrategy("https://api.e2a.dev", "e2a_acct_secret")
+
+monitor.subprocess.run = _fake_subprocess_run_factory(
+    1, stdout=json.dumps({"status": "pending_review", "message_id": "msg_x"}) + "\n",
+    stderr='non-success send status: "pending_review"\n',
+)
+try:
+    _ts.send(agent_a="a@x", agent_b="b@x", subject="probe x", body="x")
+    _ts_raised = False
+except RuntimeError:
+    _ts_raised = True
+check("ts_sdk strategy raises when the node helper exits non-zero (held/failed)", _ts_raised, True)
+
+monitor.subprocess.run = _fake_subprocess_run_factory(
+    0, stdout=json.dumps({"status": "accepted", "message_id": "msg_x"}) + "\n"
+)
+try:
+    _ts.send(agent_a="a@x", agent_b="b@x", subject="probe x", body="x")
+    _ts_ok = True
+except Exception:
+    _ts_ok = False
+check("ts_sdk strategy does not raise when the node helper exits 0 (accepted)", _ts_ok, True)
+
+monitor.subprocess.run = _saved_subprocess_run
+
+
+# ---------------------------------------------------------------------------
+# FIX 4: minimal subprocess environment — the full parent environment
+# (including secrets this child never needs, like the webhook secret) must
+# never be handed to a node/CLI subprocess.
+# ---------------------------------------------------------------------------
+
+_captured_env_calls = []
+
+
+def _capturing_subprocess_run(argv, env=None, capture_output=None, text=None, timeout=None):
+    _captured_env_calls.append({"argv": list(argv), "env": dict(env or {})})
+
+    class _Result:
+        returncode = 0
+        stdout = json.dumps({"status": "accepted", "message_id": "msg_x"}) + "\n"
+        stderr = ""
+
+    return _Result()
+
+
+os.environ["E2A_MONITOR_TEST_SHOULD_NOT_LEAK"] = "super-secret-value"
+monitor.subprocess.run = _capturing_subprocess_run
+_captured_env_calls.clear()
+_ts.send(agent_a="a@x", agent_b="b@x", subject="probe x", body="x")
+_env = _captured_env_calls[-1]["env"]
+check("subprocess env does not leak an arbitrary parent env var", "E2A_MONITOR_TEST_SHOULD_NOT_LEAK" in _env, False)
+check("subprocess env does not leak the webhook secret", "E2A_MONITOR_WEBHOOK_SECRET" in _env, False)
+check("subprocess env still carries PATH", "PATH" in _env, True)
+check("subprocess env carries the explicit override (E2A_API_KEY)", _env.get("E2A_API_KEY"), "e2a_acct_secret")
+del os.environ["E2A_MONITOR_TEST_SHOULD_NOT_LEAK"]
+monitor.subprocess.run = _saved_subprocess_run
+
+
+# ---------------------------------------------------------------------------
+# FIX 5: wire-shape assertions for api / ts_sdk / cli — a flag/route/header
+# typo must fail a test, not ship silently.
+# ---------------------------------------------------------------------------
+
+
+class _CapturedRequest:
+    def __init__(self, req):
+        self.full_url = req.full_url
+        self.method = req.get_method()
+        self.headers = {k: v for k, v in req.header_items()}
+        self.data = req.data
+
+
+_captured_requests = []
+
+
+def _capturing_urlopen(response_body: dict):
+    def _fake_urlopen(req, timeout=None):
+        _captured_requests.append(_CapturedRequest(req))
+        return _FakeResponse(json.dumps(response_body).encode(), "application/json")
+
+    return _fake_urlopen
+
+
+# ApiStrategy: POST /v1/agents/{email}/messages, Authorization: Bearer, JSON
+# body shape (api/openapi.yaml SendEmailRequest: to/subject/text).
+_urllib_request.urlopen = _capturing_urlopen({"status": "accepted", "message_id": "msg_x"})
+_api_wire = monitor.ApiStrategy("https://api.e2a.dev", "e2a_acct_secret")
+_captured_requests.clear()
+_api_wire.send(agent_a="mon-a@agents.e2a.dev", agent_b="mon-b@agents.e2a.dev", subject="probe nonce123", body="nonce123")
+_req = _captured_requests[-1]
+check("ApiStrategy.send method is POST", _req.method, "POST")
+check(
+    "ApiStrategy.send URL is /v1/agents/{email}/messages",
+    _req.full_url,
+    "https://api.e2a.dev/v1/agents/mon-a%40agents.e2a.dev/messages",
+)
+check("ApiStrategy.send sends Authorization: Bearer <key>", header(_req.headers, "Authorization"), "Bearer e2a_acct_secret")
+check(
+    "ApiStrategy.send body shape matches SendEmailRequest(to, subject, text)",
+    json.loads(_req.data.decode()),
+    {"to": ["mon-b@agents.e2a.dev"], "subject": "probe nonce123", "text": "nonce123"},
+)
+check("ApiStrategy.send: the API key never appears in the URL", "e2a_acct_secret" in _req.full_url, False)
+
+# ApiStrategy.reply: POST .../messages/{id}/reply, Idempotency-Key header, and
+# ReplyRequest's wire shape (text only — no subject field).
+_captured_requests.clear()
+_api_wire.reply(inbox="mon-a@agents.e2a.dev", message_id="msg_abc", text="nonce123", idempotency_key="sdkmon:evt_1")
+_req = _captured_requests[-1]
+check(
+    "ApiStrategy.reply URL is .../messages/{id}/reply",
+    _req.full_url,
+    "https://api.e2a.dev/v1/agents/mon-a%40agents.e2a.dev/messages/msg_abc/reply",
+)
+check("ApiStrategy.reply sends Idempotency-Key", header(_req.headers, "Idempotency-Key"), "sdkmon:evt_1")
+check("ApiStrategy.reply body shape is text-only (ReplyRequest has no subject)", json.loads(_req.data.decode()), {"text": "nonce123"})
+
+_urllib_request.urlopen = _saved_urlopen
+
+
+# TsSdkStrategy / CliStrategy: capture subprocess.run's argv + env.
+_captured_calls = []
+
+
+def _capturing_subprocess_run_for_wire(argv, env=None, capture_output=None, text=None, timeout=None):
+    _captured_calls.append({"argv": list(argv), "env": dict(env or {})})
+
+    class _Result:
+        returncode = 0
+        stdout = json.dumps({"status": "accepted", "message_id": "msg_x"}) + "\n"
+        stderr = ""
+
+    return _Result()
+
+
+monitor.subprocess.run = _capturing_subprocess_run_for_wire
+
+_ts_wire = monitor.TsSdkStrategy("https://api.e2a.dev", "e2a_acct_secret")
+_captured_calls.clear()
+_ts_wire.send(agent_a="mon-a@agents.e2a.dev", agent_b="mon-b@agents.e2a.dev", subject="probe x", body="x")
+_call = _captured_calls[-1]
+check("TsSdkStrategy.send invokes node with the helper path", _call["argv"][:2], ["node", monitor.NODE_HELPER])
+check(
+    "TsSdkStrategy.send passes send + positional args",
+    _call["argv"][2:],
+    ["send", "mon-a@agents.e2a.dev", "mon-b@agents.e2a.dev", "probe x", "x"],
+)
+check("TsSdkStrategy child env carries E2A_API_URL", _call["env"].get("E2A_API_URL"), "https://api.e2a.dev")
+check("TsSdkStrategy child env carries E2A_API_KEY", _call["env"].get("E2A_API_KEY"), "e2a_acct_secret")
+check("TsSdkStrategy secret never appears in argv", any("e2a_acct_secret" in a for a in _call["argv"]), False)
+
+_captured_calls.clear()
+_ts_wire.reply(inbox="mon-a@agents.e2a.dev", message_id="msg_abc", text="x", idempotency_key="sdkmon:evt_1")
+_call = _captured_calls[-1]
+check(
+    "TsSdkStrategy.reply passes reply + positional args",
+    _call["argv"][2:],
+    ["reply", "mon-a@agents.e2a.dev", "msg_abc", "x", "sdkmon:evt_1"],
+)
+
+_cli_wire = monitor.CliStrategy("https://api.e2a.dev", "e2a_acct_secret")
+_captured_calls.clear()
+_cli_wire.send(agent_a="mon-a@agents.e2a.dev", agent_b="mon-b@agents.e2a.dev", subject="probe x", body="x")
+_call = _captured_calls[-1]
+check("CliStrategy.send invokes CLI_BIN via node", _call["argv"][:2], ["node", monitor.CLI_BIN])
+check(
+    "CliStrategy.send argv matches cli/src/bin/e2a.ts's send flags",
+    _call["argv"][2:],
+    [
+        "send", "--to", "mon-b@agents.e2a.dev", "--subject", "probe x", "--body", "x",
+        "--agent", "mon-a@agents.e2a.dev", "--json",
+    ],
+)
+check("CliStrategy child env carries E2A_URL", _call["env"].get("E2A_URL"), "https://api.e2a.dev")
+check("CliStrategy secret never appears in argv", any("e2a_acct_secret" in a for a in _call["argv"]), False)
+
+_captured_calls.clear()
+_cli_wire.reply(inbox="mon-a@agents.e2a.dev", message_id="msg_abc", text="x", idempotency_key="sdkmon:evt_1")
+_call = _captured_calls[-1]
+check(
+    "CliStrategy.reply argv matches cli/src/bin/e2a.ts's reply flags",
+    _call["argv"][2:],
+    ["reply", "msg_abc", "--body", "x", "--agent", "mon-a@agents.e2a.dev", "--idempotency-key", "sdkmon:evt_1", "--json"],
+)
+
+monitor.subprocess.run = _saved_subprocess_run
+
+
+# ---------------------------------------------------------------------------
+# McpStrategy response parsing (FIX 6 additions at the end): SSE framing,
+# JSON-RPC error, tool isError, a leading notification/mismatched-id frame
+# that must be skipped (not mistaken for our response), a stream where no
+# frame matches our request id, and the malformed-response guard (neither
+# result nor error present must NOT be silently treated as success — found
+# in adversarial review of the original change).
+# ---------------------------------------------------------------------------
+
+_mcp2 = monitor.McpStrategy("https://mcp.example/mcp", "e2a_acct_test")
+
+_urllib_request.urlopen = _stub_urlopen(_mcp_sse_for_status("accepted"))
+try:
+    _mcp2.send(agent_a="a@x", agent_b="b@x", subject="probe x", body="x")
     _mcp_send_ok = True
 except Exception:
     _mcp_send_ok = False
@@ -344,7 +804,7 @@ _urllib_request.urlopen = _stub_urlopen(
     'data: {"jsonrpc":"2.0","id":1,"error":{"code":-32000,"message":"boom"}}\n\n'
 )
 try:
-    _mcp.send(agent_a="a@x", agent_b="b@x", subject="probe x", body="x")
+    _mcp2.send(agent_a="a@x", agent_b="b@x", subject="probe x", body="x")
     _mcp_error_raised = False
 except RuntimeError:
     _mcp_error_raised = True
@@ -354,7 +814,7 @@ _urllib_request.urlopen = _stub_urlopen(
     'data: {"jsonrpc":"2.0","id":1,"result":{"isError":true,"content":[{"type":"text","text":"e2a error [invalid_request]: bad"}]}}\n\n'
 )
 try:
-    _mcp.send(agent_a="a@x", agent_b="b@x", subject="probe x", body="x")
+    _mcp2.send(agent_a="a@x", agent_b="b@x", subject="probe x", body="x")
     _mcp_tool_error_raised = False
 except RuntimeError:
     _mcp_tool_error_raised = True
@@ -364,11 +824,46 @@ check("mcp strategy raises on a tool-level isError result", _mcp_tool_error_rais
 # succeed (this was the adversarial-review finding this test guards).
 _urllib_request.urlopen = _stub_urlopen('data: {"jsonrpc":"2.0","id":1}\n\n')
 try:
-    _mcp.send(agent_a="a@x", agent_b="b@x", subject="probe x", body="x")
+    _mcp2.send(agent_a="a@x", agent_b="b@x", subject="probe x", body="x")
     _mcp_malformed_raised = False
 except RuntimeError:
     _mcp_malformed_raised = True
 check("mcp strategy raises on a response with neither result nor error", _mcp_malformed_raised, True)
+
+# A leading notification (no id) plus an unrelated mismatched-id response,
+# both BEFORE the real id:1 result — must be skipped, not mistaken for our
+# response and not falsely tripped by the malformed-response guard.
+_leading_notification = '{"jsonrpc":"2.0","method":"notifications/progress","params":{}}'
+_mismatched_id_frame = '{"jsonrpc":"2.0","id":99,"result":{"content":[]}}'
+_real_result_frame = json.dumps(
+    {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "result": {"content": [{"type": "text", "text": json.dumps({"status": "accepted", "message_id": "msg_x"})}]},
+    }
+)
+_sse_with_leading_frames = (
+    f"data: {_leading_notification}\n\n"
+    f"data: {_mismatched_id_frame}\n\n"
+    f"data: {_real_result_frame}\n\n"
+)
+_urllib_request.urlopen = _stub_urlopen(_sse_with_leading_frames)
+try:
+    _mcp2.send(agent_a="a@x", agent_b="b@x", subject="probe x", body="x")
+    _mcp_leading_frames_ok = True
+except Exception:
+    _mcp_leading_frames_ok = False
+check("mcp strategy skips a leading notification/mismatched-id frame and finds the real id:1 result", _mcp_leading_frames_ok, True)
+
+# Only a mismatched-id frame present anywhere in the stream — no frame ever
+# matches our request id, so this must raise, not silently succeed.
+_urllib_request.urlopen = _stub_urlopen(f"data: {_mismatched_id_frame}\n\n")
+try:
+    _mcp2.send(agent_a="a@x", agent_b="b@x", subject="probe x", body="x")
+    _mcp_only_mismatched_raised = False
+except RuntimeError:
+    _mcp_only_mismatched_raised = True
+check("mcp strategy raises when no frame matches our request id", _mcp_only_mismatched_raised, True)
 
 _urllib_request.urlopen = _saved_urlopen
 

--- a/tests/sdk-monitor/test_monitor.py
+++ b/tests/sdk-monitor/test_monitor.py
@@ -1,0 +1,122 @@
+"""Offline checks for the webhook handler. No pytest, no network:
+
+    E2A_API_KEY=x E2A_MONITOR_AGENT_A=a@x E2A_MONITOR_AGENT_B=b@x \
+    E2A_MONITOR_WEBHOOK_SECRET=whsec_test python test_monitor.py
+
+Covers the parts that must not regress silently: signature accept/reject,
+fail-closed on an unset secret, non-inbound event types, and the stale-reply
+guard. The round trip itself is only exercisable against a live deployment.
+"""
+
+import hashlib
+import hmac
+import json
+import os
+import sys
+import time
+
+os.environ.setdefault("E2A_API_KEY", "e2a_acct_test")
+os.environ.setdefault("E2A_BASE_URL", "https://api.e2a.dev")
+os.environ.setdefault("E2A_MONITOR_AGENT_A", "mon-a@agents.e2a.dev")
+os.environ.setdefault("E2A_MONITOR_AGENT_B", "mon-b@agents.e2a.dev")
+os.environ.setdefault("E2A_MONITOR_WEBHOOK_SECRET", "whsec_testsecret")
+
+import monitor  # noqa: E402
+
+SECRET = monitor.WEBHOOK_SECRET
+failures = []
+
+
+def check(name, got, want):
+    if got != want:
+        failures.append(f"{name}: got {got!r}, want {want!r}")
+    print(("PASS " if got == want else "FAIL ") + name)
+
+
+def sign(body: bytes, secret: str = SECRET, ts: int | None = None) -> str:
+    ts = ts if ts is not None else int(time.time())
+    mac = hmac.new(secret.encode(), f"{ts}".encode() + b"." + body, hashlib.sha256)
+    return f"t={ts},v1={mac.hexdigest()}"
+
+
+def envelope(event_type: str, data: dict) -> bytes:
+    return json.dumps(
+        {
+            "id": "evt_test_1",
+            "type": event_type,
+            "schema_version": "1",
+            "created_at": "2026-07-21T00:00:00Z",
+            "data": data,
+        }
+    ).encode()
+
+
+body = envelope("email.sent", {"message_id": "msg_1"})
+
+status, _ = monitor.handle_webhook(body, sign(body))
+check("valid signature accepted (non-inbound ignored)", status, 200)
+
+status, _ = monitor.handle_webhook(body, sign(body, secret="whsec_wrong"))
+check("bad signature rejected", status, 401)
+
+status, _ = monitor.handle_webhook(body, "")
+check("missing signature header rejected", status, 401)
+
+status, _ = monitor.handle_webhook(body, sign(body, ts=int(time.time()) - 3600))
+check("replayed timestamp rejected", status, 401)
+
+saved, monitor.WEBHOOK_SECRET = monitor.WEBHOOK_SECRET, ""
+status, _ = monitor.handle_webhook(body, sign(body, secret=saved))
+check("unset secret fails closed", status, 401)
+monitor.WEBHOOK_SECRET = saved
+
+# Stale guard: a reply whose nonce timestamp is older than MAX_AGE_MS must not
+# emit sdk_monitor_ok. Stub hydration so this stays offline.
+old_ms = int(time.time() * 1000) - monitor.MAX_AGE_MS - 60_000
+
+
+class FakeEmail:
+    id = "msg_stale"
+    inbox = monitor.AGENT_A
+    subject = f"Re: probe e2asdkmon.{old_ms}.0123456789abcdef"
+
+
+class FakeInbound:
+    def from_event(self, event):
+        return FakeEmail()
+
+
+class FakeClient:
+    inbound = FakeInbound()
+
+
+monitor._client = FakeClient()
+emitted = []
+monitor.log = lambda event, **f: emitted.append(event)
+
+inbound_body = envelope("email.received", {"message_id": "msg_stale", "delivered_to": monitor.AGENT_A})
+status, _ = monitor.handle_webhook(inbound_body, sign(inbound_body))
+check("stale reply returns 200", status, 200)
+check("stale reply does not emit sdk_monitor_ok", "sdk_monitor_ok" in emitted, False)
+check("stale reply emits sdk_monitor_stale", "sdk_monitor_stale" in emitted, True)
+
+# Fresh reply on the same path emits the success marker with latency.
+FakeEmail.subject = f"Re: probe e2asdkmon.{int(time.time() * 1000) - 4200}.0123456789abcdef"
+emitted.clear()
+status, payload = monitor.handle_webhook(inbound_body, sign(inbound_body))
+check("fresh reply emits sdk_monitor_ok", "sdk_monitor_ok" in emitted, True)
+check("fresh reply reports latency", payload["latency_ms"] >= 4200, True)
+
+# A subject with no probe nonce is ignored, not counted.
+FakeEmail.subject = "hello from a real human"
+emitted.clear()
+status, payload = monitor.handle_webhook(inbound_body, sign(inbound_body))
+check("non-probe subject ignored", payload.get("ignored"), "not a probe")
+
+print()
+if failures:
+    print(f"{len(failures)} failure(s):")
+    for f in failures:
+        print("  " + f)
+    sys.exit(1)
+print("all checks passed")


### PR DESCRIPTION
## The gap

Neither existing continuous validator ever invokes an SDK. `cmd/e2a-prober` speaks raw HTTP; `tests/e2e-prod` uses zero-dependency `fetch` on purpose (its own comment says "no SDK"). So SDK regressions — including a failed or forgotten publish — were invisible to CI.

Not theoretical: the SDKs sat at **4.0.1** on PyPI/npm for weeks while `main` was at **5.2.0**, and a downstream consumer's integration was silently broken against every fresh install since June. Nothing caught it.

## What this adds

`tests/sdk-monitor/` — a single-file service that drives a real agent-to-agent round trip through the **published** Python SDK's public surface: `messages.send`, `construct_event`, `is_email_received`, `inbound.from_event`, `email.reply`.

It is **stateless and request-driven** because the target is Cloud Run, which scales to zero — no in-memory round-trip state, no background thread:

- `POST /tick` (Cloud Scheduler, ~5m) — send A → B, subject `probe <nonce>`
- `POST /webhook` — verify signature, ignore non-inbound types, hydrate; delivered to B → reply, delivered to A → emit success
- `GET /health` — liveness

Success is the log line `{"event":"sdk_monitor_ok","latency_ms":…}`. Ops builds a log-based metric plus a "no success in N minutes" alert on it. Latency comes free from the send timestamp embedded in the nonce — nothing is stored.

**Nothing is deployed by this PR.** The image builds and pushes via the existing `build-image.yml` matrix; the Cloud Run service and its webhook subscription are provisioned separately in `e2a-ops`.

### Depends on the published package, not the workspace

`requirements.txt` pins `e2a==5.2.0` from PyPI. The Dockerfile's build context is the **service directory**, not the repo root, so `sdks/python` is physically unreachable from the build — the SDK can only arrive via a real `pip install`. A broken publish surfaces here rather than being papered over by local source. README documents the bump-on-release policy.

### Placement

`tests/sdk-monitor/`, beside `tests/e2e-prod/` — same category (a production-targeting harness that is not part of local dev, per AGENTS.md) and same "not a Go binary" constraint that keeps it out of `cmd/`.

### Correlation and stale replies

Nonce is `e2asdkmon.<epoch_ms>.<16 hex>`: the random suffix keeps concurrent probes distinct, the timestamp gives latency without storage. The leg is decided by `email.inbox`, not a `Re:` prefix, since subjects get rewritten in transit. A reply older than `E2A_MONITOR_MAX_AGE_MS` (default 15m) logs `sdk_monitor_stale` and **not** `sdk_monitor_ok`, so a redelivery can never refresh the freshness alert. Replies carry `idempotency_key=sdkmon:<event id>`.

### Security

Fails closed on the webhook: an unset secret or a bad signature is a 401, never an accepted delivery. Secret values are never logged — only env var *names* on a config failure.

## Verification

- **Clean venv, real published `e2a==5.2.0` from PyPI** (not workspace source): imports, boots, `/health` → `{"status":"ok"}`, unsigned `/webhook` → 401.
- `test_monitor.py` (offline, no pytest): valid signature accepted, bad signature rejected, missing header rejected, replayed timestamp rejected, unset secret fails closed, stale reply does not emit `sdk_monitor_ok`, fresh reply does with latency, non-probe subject ignored. **All pass.**
- **Docker image builds** and runs; `pip show e2a` inside the image confirms 5.2.0.
- **Live SDK call against staging** with a throwaway bootstrap account: `messages.send` via published 5.2.0 → `status=sent method=loopback`, probe subject landed in the inbox. Account deleted afterwards (`DELETE /v1/account?confirm=DELETE`).

Full webhook round trip is not locally exercisable — it needs a publicly reachable HTTPS URL, and staging has no external MX so agent→agent egresses via SES and fails there. That leg gets exercised on first deploy against prod.

## Follow-up (out of scope)

- The `e2a-ops` side: Cloud Run service, Cloud Scheduler job, the one-time webhook subscription, and the log-based metric + alert.
- A TypeScript sibling would close the same gap for the TS SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)