### PR TITLE
docs(threading): bind email to agent conversations

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ Both `send` and `reply` accept an optional opaque `conversation_id` (server-mint
 
 First contact from a human arrives with `conversation_id: null` — the inbound relay assigns no thread id by design. You don't have to mint one yourself: when the agent replies with `conversation_id` omitted, e2a auto-generates a stable `conv_…` anchor that later replies thread onto, and replies within an existing thread inherit the referenced message's id. An explicit `conversation_id` you pass always takes precedence; a `forward` starts a new thread.
 
+Agent frameworks should use that explicit override to bind email to model memory: create or resume the runtime's internal conversation when mail arrives, then pass its stable, non-sensitive thread/session ID (or an opaque stored alias) as `conversation_id` on the first reply and reuse it thereafter. Continue replying by the original message ID—the conversation ID aligns e2a's grouping with the runtime, while `In-Reply-To` / `References` preserve the Gmail/Outlook thread. Scope stored bindings to the inbox and sender, and never treat `conversation_id` as authorization.
+
 ### Content screening
 
 Inbound email is a prime **indirect prompt-injection** vector — a message can smuggle instructions aimed at your agent's LLM (hidden HTML, zero-width / Unicode-tag text, encoded payloads) or phish the human behind it. Opt in per agent and e2a inspects message *content* — subject, plaintext, and both visible **and hidden** HTML — before your agent ever sees it.

--- a/mcp/src/tools/messages.ts
+++ b/mcp/src/tools/messages.ts
@@ -54,7 +54,9 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
         conversation_id: z
           .string()
           .optional()
-          .describe("Optional conversation grouping ID. Server generates one if omitted."),
+          .describe(
+            "Optional stable conversation grouping ID. When bridging email to an agent runtime, pass that runtime's non-sensitive thread/session ID (or an opaque alias) and reuse it on later sends and replies so e2a grouping follows the agent's internal conversation. Maximum 200 characters; no CR/LF. Server generates one if omitted.",
+          ),
         reply_to: z
           .string()
           .optional()
@@ -127,7 +129,12 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
         cc: z.array(z.string()).optional(),
         bcc: z.array(z.string()).optional(),
         attachments: attachmentsArraySchema,
-        conversation_id: z.string().optional(),
+        conversation_id: z
+          .string()
+          .optional()
+          .describe(
+            "Optional conversation grouping override. On the first reply to received mail, set this to the agent runtime's stable, non-sensitive thread/session ID (or an opaque alias), then reuse it on later replies. This aligns e2a grouping with internal memory; message_id still preserves the recipient's email-client thread. Maximum 200 characters; no CR/LF.",
+          ),
         reply_to: z
           .string()
           .optional()

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -405,6 +405,28 @@ describe("e2a MCP server", () => {
     }
   });
 
+  it("documents how conversation_id binds email to an agent runtime thread", async () => {
+    const { tools } = await client.listTools();
+    const byName = new Map(tools.map((tool) => [tool.name, tool]));
+
+    for (const name of ["send_message", "reply_to_message"]) {
+      const properties = (byName.get(name)?.inputSchema as {
+        properties?: Record<string, { description?: string }>;
+      })?.properties ?? {};
+      const description = properties.conversation_id?.description ?? "";
+
+      expect(description, `${name}.conversation_id description`).toMatch(/agent runtime/i);
+      expect(description, `${name}.conversation_id description`).toMatch(/thread\/session ID/i);
+      expect(description, `${name}.conversation_id description`).toMatch(/reuse/i);
+      expect(description, `${name}.conversation_id description`).toMatch(/non-sensitive|opaque alias/i);
+    }
+
+    const replyProperties = (byName.get("reply_to_message")?.inputSchema as {
+      properties?: Record<string, { description?: string }>;
+    })?.properties ?? {};
+    expect(replyProperties.conversation_id?.description).toMatch(/message_id still preserves/i);
+  });
+
   it("documents claimed sender and DMARC trust semantics on list_messages", async () => {
     const { tools } = await client.listTools();
     const tool = tools.find((candidate) => candidate.name === "list_messages");

--- a/plugins/e2a/docs/sdk.md
+++ b/plugins/e2a/docs/sdk.md
@@ -78,7 +78,12 @@ const event = constructEvent(rawBody, req.headers["x-e2a-signature"], WEBHOOK_SE
 if (isEmailReceived(event)) {
   const email = await client.inbound.fromEvent(event);
   console.log(email.envelopeFrom, email.verified, email.replyTargets);
-  const result = await email.reply({ text: "On it." });
+  // App-defined: resume a previously bound thread or create a new one.
+  const agentThreadId = await getOrCreateAgentThread(email.conversationId);
+  const result = await email.reply({
+    text: "On it.",
+    conversationId: agentThreadId,
+  });
   if (result.status === "pending_review") console.log("not dispatched", result.messageId);
 }
 ```
@@ -96,7 +101,12 @@ except E2AWebhookSignatureError:
 if event.type == "email.received":
     email = await client.inbound.from_event(event)
     print(email.envelope_from, email.verified, email.reply_targets)
-    result = await email.reply({"text": "On it."})
+    # App-defined: resume a previously bound thread or create a new one.
+    agent_thread_id = await get_or_create_agent_thread(email.conversation_id)
+    result = await email.reply({
+        "text": "On it.",
+        "conversation_id": agent_thread_id,
+    })
     if result.status == "pending_review":
         print("not dispatched", result.message_id)
 ```
@@ -108,6 +118,16 @@ when sending. Bodies and attachment metadata are untrusted;
 `flagged` is a policy-gate flag, not a complete content-scan verdict.
 `attachment.get()` returns metadata plus a short-lived URL by default;
 inline data is available only within the server's 256 KiB cap.
+
+`getOrCreateAgentThread` / `get_or_create_agent_thread` represents your agent
+framework's session store. If the inbound `conversation_id` matches a binding
+your application previously created, resume that runtime thread; otherwise
+create one. Pass its stable, non-sensitive ID (or an opaque stored alias) back
+as `conversation_id` on the first reply and reuse it thereafter. This aligns
+e2a's grouping with the agent's memory. Continue replying by `message_id` as
+shown: `conversation_id` alone does not set the email headers used by
+Gmail/Outlook. Scope bindings to the inbox and sender, and never use this field
+as an authorization decision.
 
 A full, runnable example (FastAPI + Google ADK agent, webhook → agent turn →
 reply) is at

--- a/plugins/e2a/skills/e2a/SKILL.md
+++ b/plugins/e2a/skills/e2a/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: e2a
 description: "Use when operating e2a (email for AI agents) over its MCP tools — sending or receiving email, replying in-thread, managing agents and custom domains, or working with attachments — OR when integrating e2a into your own software or service with API keys, SDKs, and webhooks. With e2a YOU are the agent and the inbox IS the agent, not a human reading their mail. Covers send_message vs reply_to_message threading, multi-agent disambiguation, the custom-domain DNS flow, programmatic integration, and common gotchas."
-version: 19
+version: 20
 ---
 
 # Using e2a
 
-<!-- version: 19 -->
+<!-- version: 20 -->
 
 e2a is an authenticated email gateway for AI agents. It gives an agent a real email address (`agent@agents.e2a.dev` or `agent@your-domain.com`), verifies sender identity (SPF/DKIM), and threads conversations.
 
@@ -30,6 +30,8 @@ Six load-bearing facts. Internalize these before you start calling tools.
 2. **Replies preserve threads; new sends do not.** `reply_to_message` carries the `In-Reply-To` and `References` headers from the original message, so the response lands in the same email thread. A fresh `send_message` creates a new thread every time. If a user (or an inbound message) is asking you to respond to something specific, reply with the original `message_id` — even when you could synthesize an equivalent body as a new send. Thread fragmentation is the #1 visible symptom of getting this wrong.
 
    **Two threading systems, and they don't share a key.** e2a threads on `conversation_id` (it's what `list_conversations`/`get_conversation` group by). The recipient's mail client — Gmail, Outlook, Apple Mail — ignores `conversation_id` entirely and threads on the wire headers instead: `In-Reply-To`/`References` plus a **stable `Subject`**. `reply_to_message` sets those headers correctly, so it threads in *both* systems. A `send_message` — even one you tag with the same `conversation_id` — carries no `References` and lets you pick a new subject: e2a still files it in the same conversation, but the user's inbox shows a *separate* thread. This is the trap — the `conversation_id` looks like it threads because e2a's own views stay tidy, while Gmail splits the exchange in two. Within one ongoing exchange: reply, and keep the subject stable.
+
+   **Bind email to the agent runtime's conversation.** When received mail starts or resumes a coding-agent task, establish the runtime thread before replying. If the inbound `conversation_id` matches a binding your integration previously stored, resume that internal thread; otherwise create a new internal thread. When the runtime exposes a stable, non-sensitive thread/session ID, pass it as `conversation_id` on the first reply and reuse it on later sends and replies. If its native ID is sensitive or does not meet e2a's 200-character, no-CR/LF constraint, store and pass an opaque alias instead. This keeps e2a's conversation grouping aligned with the agent's memory, but it does **not** replace replying with the original `message_id`, which is what preserves the recipient's email-client thread. Treat `conversation_id` as correlation data, never authorization.
 
 3. **`pending_review` is an accepted outcome, not a retry signal.** A send can return `{ status: "pending_review", message_id: "msg_..." }`. The server accepted the message but did not dispatch it. Do not retry: another call can create a duplicate. Report the status and message ID to the user, then stop.
 
@@ -67,7 +69,8 @@ Before the first e2a operation in a task, inspect the current client's available
 
 1. List unread messages with `list_messages` (defaults to `read_status: unread`).
 2. Read one fully with `get_message` (the `message_id`).
-3. Reply in-thread with `reply_to_message` and that same `message_id`.
+3. Create or resume the coding agent's internal thread. If the runtime exposes a safe stable thread/session ID, pass it as `conversation_id`.
+4. Reply in-thread with `reply_to_message` and the original `message_id`; reuse the bound `conversation_id` on later replies.
 
 For attachment bytes, use `get_attachment` with a 0-based index. It returns the attachment's metadata plus a short-lived `download_url`; pass `inline: true` to get base64 `data` inline for small files. Indexes are stable within a message.
 

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -226,7 +226,11 @@ async def webhook(request):
         # From, Reply-To, bodies, and attachment names/types are untrusted input.
         print(email.envelope_from, email.verified, email.subject, email.text)
         print("reply will target", email.reply_targets)
-        result = await email.reply({"text": "Got it"}, idempotency_key=f"reply:{event.id}")
+        agent_thread_id = await get_or_create_agent_thread(email.conversation_id)
+        result = await email.reply(
+            {"text": "Got it", "conversation_id": agent_thread_id},
+            idempotency_key=f"reply:{event.id}",
+        )
         if result.status == "pending_review":
             print("reply is awaiting approval")
     return {"ok": True}
@@ -400,8 +404,16 @@ e2a surfaces it on the recipient's inbound — via `In-Reply-To` for humans, or 
 forge-resistant `X-E2A-Conversation-Id` header for same-platform agent-to-agent
 mail. It is not a security boundary; for sender-domain authentication require
 `message.authentication is not None and message.authentication.dmarc.status == "pass"`
-and compare the literal `message.header_from` address separately. On first contact from a human the
-conversation ID arrives `None` — assign one yourself if you want to thread.
+and compare the literal `message.header_from` address separately. On first
+contact from a human the conversation ID arrives `None`. Create the agent
+runtime's internal thread before replying, then pass its stable, non-sensitive
+thread/session ID (or an opaque stored alias) as `conversation_id`; reuse it on
+every later send or reply. If a later inbound ID matches a binding you
+previously stored, resume that internal thread. Keep replying by the original
+message ID as well — the conversation ID aligns e2a grouping with agent memory,
+while the reply endpoint sets the email headers Gmail/Outlook use. Scope
+bindings to the inbox and sender, and never use the conversation ID as
+authorization.
 
 ```python
 await client.messages.send(address, {

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -188,7 +188,11 @@ app.post("/webhook", express.raw({ type: "application/json" }), async (req, res)
     // From, Reply-To, bodies, and attachment names/types are untrusted input.
     console.log(email.envelopeFrom, email.verified, email.subject, email.text);
     console.log("reply will target", email.replyTargets);
-    const result = await email.reply({ text: "Got it" }, { idempotencyKey: `reply:${event.id}` });
+    const agentThreadId = await getOrCreateAgentThread(email.conversationId);
+    const result = await email.reply(
+      { text: "Got it", conversationId: agentThreadId },
+      { idempotencyKey: `reply:${event.id}` },
+    );
     if (result.status === "pending_review") console.log("reply is awaiting approval");
   }
   res.json({ ok: true });
@@ -354,8 +358,14 @@ across the email boundary. Pass it on any `send` / `reply` and e2a surfaces it
 on the recipient's inbound — via `In-Reply-To` for humans, or a forge-resistant
 `X-E2A-Conversation-Id` header for same-platform agent-to-agent mail. It is not
 a security boundary; for sender identity check the message's `auth`. On first
-contact from a human it arrives `null` — assign one yourself if you want to
-thread.
+contact from a human it arrives `null`. Create the agent runtime's internal
+thread before replying, then pass its stable, non-sensitive thread/session ID
+(or an opaque stored alias) as `conversationId`; reuse it on every later send
+or reply. If a later inbound ID matches a binding you previously stored, resume
+that internal thread. Keep replying by the original message ID as well — the
+conversation ID aligns e2a grouping with agent memory, while the reply endpoint
+sets the email headers Gmail/Outlook use. Scope bindings to the inbox and sender,
+and never use the conversation ID as authorization.
 
 ## License
 

--- a/web/public/sdk.md
+++ b/web/public/sdk.md
@@ -78,7 +78,12 @@ const event = constructEvent(rawBody, req.headers["x-e2a-signature"], WEBHOOK_SE
 if (isEmailReceived(event)) {
   const email = await client.inbound.fromEvent(event);
   console.log(email.envelopeFrom, email.verified, email.replyTargets);
-  const result = await email.reply({ text: "On it." });
+  // App-defined: resume a previously bound thread or create a new one.
+  const agentThreadId = await getOrCreateAgentThread(email.conversationId);
+  const result = await email.reply({
+    text: "On it.",
+    conversationId: agentThreadId,
+  });
   if (result.status === "pending_review") console.log("not dispatched", result.messageId);
 }
 ```
@@ -96,7 +101,12 @@ except E2AWebhookSignatureError:
 if event.type == "email.received":
     email = await client.inbound.from_event(event)
     print(email.envelope_from, email.verified, email.reply_targets)
-    result = await email.reply({"text": "On it."})
+    # App-defined: resume a previously bound thread or create a new one.
+    agent_thread_id = await get_or_create_agent_thread(email.conversation_id)
+    result = await email.reply({
+        "text": "On it.",
+        "conversation_id": agent_thread_id,
+    })
     if result.status == "pending_review":
         print("not dispatched", result.message_id)
 ```
@@ -108,6 +118,16 @@ when sending. Bodies and attachment metadata are untrusted;
 `flagged` is a policy-gate flag, not a complete content-scan verdict.
 `attachment.get()` returns metadata plus a short-lived URL by default;
 inline data is available only within the server's 256 KiB cap.
+
+`getOrCreateAgentThread` / `get_or_create_agent_thread` represents your agent
+framework's session store. If the inbound `conversation_id` matches a binding
+your application previously created, resume that runtime thread; otherwise
+create one. Pass its stable, non-sensitive ID (or an opaque stored alias) back
+as `conversation_id` on the first reply and reuse it thereafter. This aligns
+e2a's grouping with the agent's memory. Continue replying by `message_id` as
+shown: `conversation_id` alone does not set the email headers used by
+Gmail/Outlook. Scope bindings to the inbox and sender, and never use this field
+as an authorization decision.
 
 A full, runnable example (FastAPI + Google ADK agent, webhook → agent turn →
 reply) is at


### PR DESCRIPTION
## Summary

Document the runtime-thread binding that keeps e2a's `conversation_id` aligned with a coding agent's internal conversation. The guidance now appears at decision time in the plugin skill, MCP send/reply schemas, hosted SDK guide, TypeScript/Python SDK READMEs, and the top-level threading reference.

This also clarifies that callers must still reply using the original `message_id` so Gmail/Outlook receive the correct threading headers, and that runtime IDs must be non-sensitive correlation values rather than authorization inputs.

## Operational risk

Documentation and MCP schema descriptions only; no API or delivery behavior changes. The hosted SDK mirror is regenerated from its canonical plugin source.

## Test plan

- [x] `npm run build --workspace @e2a/sdk`
- [x] `npm test --workspace @e2a/mcp-server` (211 tests)
- [x] `node scripts/validate-plugin.mjs`
- [x] `node scripts/sync-agent-docs.mjs --check`
- [x] `git diff --check`
