### PR TITLE
fix(web): label wildcard MX record

### DIFF
--- a/docs/superpowers/specs/2026-07-21-wildcard-mx-label-design.md
+++ b/docs/superpowers/specs/2026-07-21-wildcard-mx-label-design.md
@@ -1,0 +1,16 @@
+# Wildcard MX Label
+
+## Goal
+
+Replace the raw `inbound_mx_wildcard` purpose shown in DNS setup with a short, user-facing explanation.
+
+## Design
+
+- Display `Route email for all subdomains` for the `inbound_mx_wildcard` DNS record.
+- Apply the label consistently in both the domain details and onboarding DNS setup views.
+- Preserve the existing raw-purpose fallback for unknown future DNS record purposes.
+- Make no API or DNS behavior changes.
+
+## Verification
+
+Add or update focused web tests to confirm the wildcard record renders the new label and the internal purpose key is not shown.

--- a/web/src/app/(app)/domains/_components/DomainCard.tsx
+++ b/web/src/app/(app)/domains/_components/DomainCard.tsx
@@ -30,6 +30,10 @@ const PURPOSE_META: Record<
     group: "inbound",
   },
   inbound_mx: { label: "Route email to e2a", group: "inbound" },
+  inbound_mx_wildcard: {
+    label: "Route email for all subdomains",
+    group: "inbound",
+  },
   dkim: { label: "Authenticate outbound mail (DKIM)", group: "inbound" },
   mail_from_mx: {
     label: "Return path for bounces (MAIL FROM)",

--- a/web/src/app/(app)/domains/page.test.tsx
+++ b/web/src/app/(app)/domains/page.test.tsx
@@ -58,6 +58,14 @@ const sampleDomain = {
       purpose: "inbound_mx",
       status: "pending",
     },
+    {
+      type: "MX",
+      name: "*.mail.example.com",
+      value: "mx.e2a.dev",
+      priority: 10,
+      purpose: "inbound_mx_wildcard",
+      status: "pending",
+    },
   ],
   created_at: "2026-01-01T00:00:00Z",
   verified_at: null,
@@ -72,6 +80,7 @@ const verifiedDomain = {
   dns_records: [
     { ...sampleDomain.dns_records[0], status: "verified" },
     { ...sampleDomain.dns_records[1], status: "verified" },
+    { ...sampleDomain.dns_records[2], status: "verified" },
   ],
 };
 
@@ -403,6 +412,8 @@ describe("Domains page — unified sending records (by purpose)", () => {
     expect(screen.queryByText("Outbound sending")).not.toBeInTheDocument();
     // The inbound records still render, by purpose.
     expect(screen.getByText("Route email to e2a")).toBeInTheDocument();
+    expect(screen.getByText("Route email for all subdomains")).toBeInTheDocument();
+    expect(screen.queryByText("inbound_mx_wildcard")).not.toBeInTheDocument();
     expect(screen.getByText(/Prove domain ownership/)).toBeInTheDocument();
   });
 });

--- a/web/src/app/(app)/get-started/_components/DNSSetupCard.tsx
+++ b/web/src/app/(app)/get-started/_components/DNSSetupCard.tsx
@@ -14,6 +14,7 @@ import { track } from "../../../components/onboarding/analytics";
 const PURPOSE_LABEL: Record<DNSRecordPurpose, string> = {
   ownership: "Prove domain ownership",
   inbound_mx: "Route email to e2a",
+  inbound_mx_wildcard: "Route email for all subdomains",
   dkim: "Authenticate outbound mail (DKIM)",
   mail_from_mx: "Return path for bounces (MAIL FROM)",
   mail_from_spf: "Authorize sending (SPF)",

--- a/web/src/app/(app)/get-started/page.test.tsx
+++ b/web/src/app/(app)/get-started/page.test.tsx
@@ -98,6 +98,14 @@ const verifiedDomain = {
       purpose: "inbound_mx",
       status: "verified",
     },
+    {
+      type: "MX",
+      name: "*.verified.example.com",
+      value: "mx.e2a.dev",
+      priority: 10,
+      purpose: "inbound_mx_wildcard",
+      status: "verified",
+    },
   ],
   created_at: "2026-01-01T00:00:00Z",
   verified_at: "2026-01-15T00:00:00Z",
@@ -457,6 +465,8 @@ describe("Query param support", () => {
       expect(screen.getByText("Configure DNS records")).toBeInTheDocument();
     });
     expect(screen.getByText("Route email to e2a")).toBeInTheDocument();
+    expect(screen.getByText("Route email for all subdomains")).toBeInTheDocument();
+    expect(screen.queryByText("inbound_mx_wildcard")).not.toBeInTheDocument();
     expect(screen.getByText("Verify domain ownership")).toBeInTheDocument();
   });
 });

--- a/web/src/app/components/onboarding/types.ts
+++ b/web/src/app/components/onboarding/types.ts
@@ -34,6 +34,7 @@ export type DomainSendingStatus = "none" | "pending" | "verified" | "failed";
 export type DNSRecordPurpose =
   | "ownership"
   | "inbound_mx"
+  | "inbound_mx_wildcard"
   | "dkim"
   | "mail_from_mx"
   | "mail_from_spf";


### PR DESCRIPTION
## Summary

- label wildcard MX records as “Route email for all subdomains”
- apply the copy consistently in domain details and onboarding DNS setup
- add focused regression coverage for both views

## Why

The frontend’s known DNS-purpose type and label maps did not include `inbound_mx_wildcard`, so the UI fell back to displaying the internal purpose key.

## Validation

- `npm test -- --runInBand` — 426 tests passed
- `npm run lint` — 0 errors; one unrelated existing hook warning
