### PR TITLE
feat(web): add optional outbound review setup notice

### DIFF
--- a/docs/superpowers/plans/2026-07-21-outbound-human-review-setup-notice.md
+++ b/docs/superpowers/plans/2026-07-21-outbound-human-review-setup-notice.md
@@ -1,0 +1,332 @@
+# Outbound Human-Review Setup Notice Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an optional inbox-page instruction and matching agent guidance for configuring every outbound email to require human review.
+
+**Architecture:** Extend the existing shared `AgentPromptCard` with optional, data-driven notice content so only the inbox variant renders the new callout. Teach the same opt-in policy through the canonical e2a skill and setup guide, then regenerate the hosted setup-guide mirror.
+
+**Tech Stack:** React 19, TypeScript, Jest/Testing Library, Markdown agent skills/docs, Node.js repository validation scripts.
+
+---
+
+## File structure
+
+- Modify `web/src/app/components/AgentPromptCard.tsx`: define the inbox-only notice data and render an optional semantic notice.
+- Modify `web/src/app/components/AgentPromptCard.test.tsx`: cover notice presence, notice absence, and unchanged primary prompt copying.
+- Modify `scripts/plugin-agent-guidance.test.mjs`: lock the exact opt-in protection configuration and the warning about `open + review` into agent guidance.
+- Modify `plugins/e2a/skills/e2a/SKILL.md`: teach agents when and how to apply the always-review policy; increment the skill content version.
+- Modify `plugins/e2a/docs/setup.md`: document the same optional setup instruction for agents without the installed skill.
+- Modify generated mirror `web/public/setup.md`: refreshed from the canonical setup guide by `scripts/sync-agent-docs.mjs`.
+
+### Task 1: Render the optional inbox notice
+
+**Files:**
+- Modify: `web/src/app/components/AgentPromptCard.test.tsx`
+- Modify: `web/src/app/components/AgentPromptCard.tsx`
+
+- [ ] **Step 1: Write failing component tests**
+
+Add these tests after the existing concise-prompts test:
+
+```tsx
+test("shows the optional outbound-review instruction for inbox setup", () => {
+  render(<AgentPromptCard {...AGENT_PROMPTS.inboxes} />);
+
+  const notice = screen.getByRole("note", {
+    name: "Optional outbound review setup",
+  });
+  expect(notice).toHaveTextContent("Want every outbound email reviewed first?");
+  expect(notice).toHaveTextContent(
+    "Configure this inbox so every outbound email requires human review.",
+  );
+});
+
+test("does not show the inbox-only notice on other setup cards", () => {
+  const { rerender } = render(
+    <AgentPromptCard {...AGENT_PROMPTS.templates} />,
+  );
+  expect(
+    screen.queryByRole("note", { name: "Optional outbound review setup" }),
+  ).not.toBeInTheDocument();
+
+  rerender(<AgentPromptCard {...AGENT_PROMPTS.domains} />);
+  expect(
+    screen.queryByRole("note", { name: "Optional outbound review setup" }),
+  ).not.toBeInTheDocument();
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run from `web/`:
+
+```bash
+npm test -- --runInBand src/app/components/AgentPromptCard.test.tsx
+```
+
+Expected: FAIL because `AGENT_PROMPTS.inboxes` has no notice and no element with role `note` is rendered.
+
+- [ ] **Step 3: Add the optional notice data and prop**
+
+Add this property to `AGENT_PROMPTS.inboxes`, after `prompt`:
+
+```tsx
+    notice: {
+      label: "Want every outbound email reviewed first?",
+      instruction:
+        "Configure this inbox so every outbound email requires human review.",
+    },
+```
+
+Extend the props and function signature:
+
+```tsx
+export type AgentPromptCardProps = {
+  blurb: string;
+  prompt: string;
+  notice?: {
+    label: string;
+    instruction: string;
+  };
+};
+
+export function AgentPromptCard({
+  blurb,
+  prompt,
+  notice,
+}: AgentPromptCardProps) {
+```
+
+- [ ] **Step 4: Render the notice below the primary prompt**
+
+Immediately after the closing `</pre>`, add:
+
+```tsx
+      {notice ? (
+        <aside
+          role="note"
+          aria-label="Optional outbound review setup"
+          className="mt-3 rounded-[var(--r-md)] border px-3.5 py-3 text-[12px] leading-[1.6]"
+          style={{
+            color: "var(--fg-muted)",
+            background: "var(--bg)",
+            borderColor: "var(--border)",
+          }}
+        >
+          <span className="font-semibold" style={{ color: "var(--fg)" }}>
+            {notice.label}
+          </span>{" "}
+          Ask your agent: “{notice.instruction}”
+        </aside>
+      ) : null}
+```
+
+- [ ] **Step 5: Run the focused test and verify it passes**
+
+Run from `web/`:
+
+```bash
+npm test -- --runInBand src/app/components/AgentPromptCard.test.tsx
+```
+
+Expected: PASS for all `AgentPromptCard` tests, including the unchanged primary-prompt assertion and clipboard test.
+
+- [ ] **Step 6: Commit the dashboard change**
+
+```bash
+git add web/src/app/components/AgentPromptCard.tsx web/src/app/components/AgentPromptCard.test.tsx
+git commit -m "feat(web): add optional outbound review setup notice"
+```
+
+### Task 2: Lock the agent-guidance contract with tests
+
+**Files:**
+- Modify: `scripts/plugin-agent-guidance.test.mjs`
+
+- [ ] **Step 1: Add failing assertions for both canonical guidance files**
+
+Add the following helper and test before the tether test:
+
+```js
+const assertAlwaysReviewGuidance = (source, file) => {
+  assert.match(source, /update_protection/, file);
+  assert.match(source, /outbound_gate_policy["`:\s]+allowlist/, file);
+  assert.match(source, /outbound_gate_allowlist["`:\s]+\[\]/, file);
+  assert.match(source, /outbound_gate_action["`:\s]+review/, file);
+  assert.match(source, /holds_on_expiry["`:\s]+reject/, file);
+  assert.match(source, /open.*review.*hold(?:s|ing)? nothing/is, file);
+  assert.match(source, /only when the user (?:asks|requests)/i, file);
+};
+
+test("agent guidance teaches the opt-in always-review protection policy", async () => {
+  for (const file of [
+    "plugins/e2a/skills/e2a/SKILL.md",
+    "plugins/e2a/docs/setup.md",
+  ]) {
+    const source = await readFile(file, "utf8");
+    assertAlwaysReviewGuidance(source, file);
+  }
+});
+```
+
+- [ ] **Step 2: Run the guidance tests and verify they fail**
+
+Run from the repository root:
+
+```bash
+node --test scripts/plugin-agent-guidance.test.mjs
+```
+
+Expected: FAIL in `agent guidance teaches the opt-in always-review protection policy` because neither canonical guidance file contains the full configuration.
+
+### Task 3: Teach the installed e2a skill
+
+**Files:**
+- Modify: `plugins/e2a/skills/e2a/SKILL.md`
+
+- [ ] **Step 1: Increment the skill content version**
+
+Change both skill-local version markers from 19 to 20:
+
+```yaml
+version: 20
+```
+
+```markdown
+<!-- version: 20 -->
+```
+
+Do not change the plugin package version (`0.5.0`); this is a guidance-content revision, not a plugin release bump.
+
+- [ ] **Step 2: Add the opt-in policy workflow**
+
+After the numbered “First run: connect and verify e2a” workflow and before “Triage the inbox,” add:
+
+````markdown
+### Optional: require human review for every outbound email
+
+Only configure this when the user asks for every outbound email to require
+human review. After selecting the inbox, call `update_protection` for that
+inbox with:
+
+```json
+{
+  "outbound_gate_policy": "allowlist",
+  "outbound_gate_allowlist": [],
+  "outbound_gate_action": "review",
+  "holds_on_expiry": "reject"
+}
+```
+
+The empty allowlist makes every recipient a gate non-match, `review` holds each
+non-match for a human, and `reject` prevents an unreviewed message from being
+sent when its hold expires. Do not use `open` with `review` for this outcome:
+`open` matches every recipient, so the recipient gate holds nothing. This is
+opt-in; never enable it merely because an inbox was created.
+````
+
+- [ ] **Step 3: Run the guidance test and confirm the skill half now matches**
+
+Run:
+
+```bash
+node --test scripts/plugin-agent-guidance.test.mjs
+```
+
+Expected: still FAIL because `plugins/e2a/docs/setup.md` has not yet received the matching guidance; the skill assertions pass.
+
+### Task 4: Update and synchronize the setup guide
+
+**Files:**
+- Modify: `plugins/e2a/docs/setup.md`
+- Modify: `web/public/setup.md` (generated mirror)
+
+- [ ] **Step 1: Add the optional setup section**
+
+After “## 4. Confirm readiness” and before “## Use the inbox safely,” add:
+
+````markdown
+## Optional: require human review for every outbound email
+
+Only when the user asks for this protection, call `update_protection` for the
+selected inbox with:
+
+```json
+{
+  "outbound_gate_policy": "allowlist",
+  "outbound_gate_allowlist": [],
+  "outbound_gate_action": "review",
+  "holds_on_expiry": "reject"
+}
+```
+
+An empty allowlist makes every recipient a gate non-match, `review` holds every
+non-match for a human, and `reject` prevents expiry from sending an unreviewed
+message. Do not use `open` with `review`: `open` matches every recipient, so the
+recipient gate holds nothing. Inbox creation alone is not permission to enable
+this policy.
+````
+
+- [ ] **Step 2: Refresh the hosted documentation mirror**
+
+Run from the repository root:
+
+```bash
+node scripts/sync-agent-docs.mjs
+```
+
+Expected: `web/public/setup.md` becomes byte-identical to `plugins/e2a/docs/setup.md`; no other mirror changes.
+
+- [ ] **Step 3: Run guidance, sync, and plugin validation**
+
+```bash
+node --test scripts/plugin-agent-guidance.test.mjs
+node scripts/sync-agent-docs.mjs --check
+node scripts/validate-plugin.mjs
+```
+
+Expected: all guidance tests PASS; sync reports no drift; validator reports the plugin valid with all manifests still at version `0.5.0`.
+
+- [ ] **Step 4: Commit the agent-guidance change**
+
+```bash
+git add scripts/plugin-agent-guidance.test.mjs plugins/e2a/skills/e2a/SKILL.md plugins/e2a/docs/setup.md web/public/setup.md
+git commit -m "docs(plugin): teach opt-in outbound review policy"
+```
+
+### Task 5: Final verification
+
+**Files:**
+- Verify all files changed in Tasks 1–4.
+
+- [ ] **Step 1: Run the focused web suite**
+
+Run from `web/`:
+
+```bash
+npm test -- --runInBand src/app/components/AgentPromptCard.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run repository agent-guidance gates**
+
+Run from the repository root:
+
+```bash
+node --test scripts/plugin-agent-guidance.test.mjs scripts/sync-agent-docs.test.mjs
+node scripts/sync-agent-docs.mjs --check
+node scripts/validate-plugin.mjs
+```
+
+Expected: all tests and checks PASS.
+
+- [ ] **Step 3: Check formatting and the final diff**
+
+```bash
+git diff --check HEAD~2..HEAD
+git status --short
+```
+
+Expected: no whitespace errors and a clean worktree. The two implementation commits should contain only the UI/test changes and agent-guidance/mirror changes described above.

--- a/docs/superpowers/specs/2026-07-21-outbound-human-review-setup-notice-design.md
+++ b/docs/superpowers/specs/2026-07-21-outbound-human-review-setup-notice-design.md
@@ -1,0 +1,74 @@
+# Optional outbound human-review setup notice
+
+## Goal
+
+Make the inbox setup page and the installed e2a agent guidance explain how to
+configure an inbox so every outbound email requires human review, without
+changing the default inbox-creation flow or automatically enabling the policy.
+
+## Dashboard notice
+
+The inbox variant of `AgentPromptCard` will show a compact optional notice below
+the existing copy-paste prompt. The primary prompt and its **Copy prompt** action
+remain unchanged.
+
+The notice will tell the user that they can ask their coding agent to enable
+review for every outbound email and provide this instruction verbatim:
+
+> Configure this inbox so every outbound email requires human review.
+
+The notice is inbox-specific. The templates and domains variants of the shared
+card will not display it. The implementation should follow the existing Loft
+tokens and typography rather than introducing a new design-system component.
+
+## Agent guidance
+
+The canonical `plugins/e2a/skills/e2a/SKILL.md` setup workflow will gain an
+optional outbound-review subsection. When a user asks for every outbound email
+to require review, the agent must call `update_protection` for the selected
+inbox with:
+
+```json
+{
+  "outbound_gate_policy": "allowlist",
+  "outbound_gate_allowlist": [],
+  "outbound_gate_action": "review",
+  "holds_on_expiry": "reject"
+}
+```
+
+The guidance will explain why all four fields matter:
+
+- An empty allowlist makes every recipient a gate non-match.
+- The `review` action holds every non-matching outbound message for a human.
+- `reject` prevents an unreviewed message from being sent when its hold expires.
+- `open` combined with `review` is not equivalent: `open` matches every
+  recipient, so the recipient gate holds nothing.
+
+This remains opt-in. Agents must not enable the policy unless the user requests
+it. Existing `pending_review` handling remains unchanged: a held send is
+accepted but not dispatched, and the agent must not retry it.
+
+The canonical setup guide at `plugins/e2a/docs/setup.md` will also include the
+same optional instruction so agents following hosted setup documentation receive
+the guidance even when the plugin skill is unavailable. Its committed hosted
+mirror will be refreshed using the repository's existing sync script.
+
+## Testing and validation
+
+- Extend `AgentPromptCard` tests to verify the inbox notice and instruction are
+  rendered.
+- Verify templates and domains do not receive the inbox-only notice.
+- Keep the existing assertion that the primary inbox prompt is unchanged.
+- Run the focused web test for `AgentPromptCard`.
+- Run the agent-doc sync check and plugin manifest validator to catch mirrored
+  documentation or skill metadata drift.
+
+## Non-goals
+
+- Automatically enabling human review during inbox creation.
+- Changing the copied primary inbox-setup prompt.
+- Adding a second policy card or a dashboard control that mutates protection
+  settings directly.
+- Changing protection-policy API behavior, MCP tool schemas, or review-queue
+  behavior.

--- a/plugins/e2a/docs/setup.md
+++ b/plugins/e2a/docs/setup.md
@@ -130,6 +130,26 @@ If the call succeeds, setup is complete. The agent can now send, receive,
 reply, forward, manage attachments, subscribe to events, and configure a custom
 domain when one is actually needed.
 
+## Optional: require human review for every outbound email
+
+Only when the user asks for this protection, call `update_protection` for the
+selected inbox with:
+
+```json
+{
+  "outbound_gate_policy": "allowlist",
+  "outbound_gate_allowlist": [],
+  "outbound_gate_action": "review",
+  "holds_on_expiry": "reject"
+}
+```
+
+An empty allowlist makes every recipient a gate non-match, `review` holds every
+non-match for a human, and `reject` prevents expiry from sending an unreviewed
+message. Do not use `open` with `review`: `open` matches every recipient, so the
+recipient gate holds nothing. Inbox creation alone is not permission to enable
+this policy.
+
 ## Use the inbox safely
 
 - Reply with `reply_to_message` and the original `message_id`; a new

--- a/plugins/e2a/skills/e2a/SKILL.md
+++ b/plugins/e2a/skills/e2a/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: e2a
 description: "Use when operating e2a (email for AI agents) over its MCP tools — sending or receiving email, replying in-thread, managing agents and custom domains, or working with attachments — OR when integrating e2a into your own software or service with API keys, SDKs, and webhooks. With e2a YOU are the agent and the inbox IS the agent, not a human reading their mail. Covers send_message vs reply_to_message threading, multi-agent disambiguation, the custom-domain DNS flow, programmatic integration, and common gotchas."
-version: 19
+version: 20
 ---
 
 # Using e2a
 
-<!-- version: 19 -->
+<!-- version: 20 -->
 
 e2a is an authenticated email gateway for AI agents. It gives an agent a real email address (`agent@agents.e2a.dev` or `agent@your-domain.com`), verifies sender identity (SPF/DKIM), and threads conversations.
 
@@ -62,6 +62,27 @@ Before the first e2a operation in a task, inspect the current client's available
 4. **Classify failures:** an authentication failure means the user should reauthorize through the current client's MCP flow. A network, timeout, or server failure is operational: report it and preserve known-good configuration and credentials.
 5. **Select the inbox:** for agent scope, use the returned `agent_email`. For account scope, call `list_agents`. Honor an inbox identified by the task; use the sole result when there is one; ask the user to choose when there are several. If there are none, offer to create `name@agents.e2a.dev` after they choose the local part—no custom domain or DNS is required.
 6. Verify readiness with `list_messages`, passing the selected `email` for account scope. This read is harmless and does not mark messages read. Once it succeeds, resume the user's original e2a task.
+
+### Optional: require human review for every outbound email
+
+Only when the user asks for every outbound email to require human review,
+configure this policy. After selecting the inbox, call `update_protection` for
+that inbox with:
+
+```json
+{
+  "outbound_gate_policy": "allowlist",
+  "outbound_gate_allowlist": [],
+  "outbound_gate_action": "review",
+  "holds_on_expiry": "reject"
+}
+```
+
+The empty allowlist makes every recipient a gate non-match, `review` holds each
+non-match for a human, and `reject` prevents an unreviewed message from being
+sent when its hold expires. Do not use `open` with `review` for this outcome:
+`open` matches every recipient, so the recipient gate holds nothing. This is
+opt-in; never enable it merely because an inbox was created.
 
 ### Triage the inbox
 

--- a/scripts/plugin-agent-guidance.test.mjs
+++ b/scripts/plugin-agent-guidance.test.mjs
@@ -72,6 +72,26 @@ test("the setup guide reaches a verified first inbox", async () => {
   assert.doesNotMatch(source, /Always call `tools\/list`/);
 });
 
+const assertAlwaysReviewGuidance = (source, file) => {
+  assert.match(source, /update_protection/, file);
+  assert.match(source, /outbound_gate_policy["`:\s]+allowlist/, file);
+  assert.match(source, /outbound_gate_allowlist["`:\s]+\[\]/, file);
+  assert.match(source, /outbound_gate_action["`:\s]+review/, file);
+  assert.match(source, /holds_on_expiry["`:\s]+reject/, file);
+  assert.match(source, /open.*review.*hold(?:s|ing)? nothing/is, file);
+  assert.match(source, /only when the user (?:asks|requests)/i, file);
+};
+
+test("agent guidance teaches the opt-in always-review protection policy", async () => {
+  for (const file of [
+    "plugins/e2a/skills/e2a/SKILL.md",
+    "plugins/e2a/docs/setup.md",
+  ]) {
+    const source = await readFile(file, "utf8");
+    assertAlwaysReviewGuidance(source, file);
+  }
+});
+
 test("tether setup does not mutate review configuration", async () => {
   const source = await readFile("plugins/e2a/skills/tether/tether.sh", "utf8");
   assert.doesNotMatch(source, /protection set|outbound-review|outbound review/i);

--- a/web/public/setup.md
+++ b/web/public/setup.md
@@ -130,6 +130,26 @@ If the call succeeds, setup is complete. The agent can now send, receive,
 reply, forward, manage attachments, subscribe to events, and configure a custom
 domain when one is actually needed.
 
+## Optional: require human review for every outbound email
+
+Only when the user asks for this protection, call `update_protection` for the
+selected inbox with:
+
+```json
+{
+  "outbound_gate_policy": "allowlist",
+  "outbound_gate_allowlist": [],
+  "outbound_gate_action": "review",
+  "holds_on_expiry": "reject"
+}
+```
+
+An empty allowlist makes every recipient a gate non-match, `review` holds every
+non-match for a human, and `reject` prevents expiry from sending an unreviewed
+message. Do not use `open` with `review`: `open` matches every recipient, so the
+recipient gate holds nothing. Inbox creation alone is not permission to enable
+this policy.
+
 ## Use the inbox safely
 
 - Reply with `reply_to_message` and the original `message_id`; a new

--- a/web/src/app/components/AgentPromptCard.test.tsx
+++ b/web/src/app/components/AgentPromptCard.test.tsx
@@ -29,6 +29,32 @@ test("uses concise page-specific MCP prompts", () => {
   );
 });
 
+test("shows the optional outbound-review instruction for inbox setup", () => {
+  render(<AgentPromptCard {...AGENT_PROMPTS.inboxes} />);
+
+  const notice = screen.getByRole("note", {
+    name: "Optional outbound review setup",
+  });
+  expect(notice).toHaveTextContent("Want every outbound email reviewed first?");
+  expect(notice).toHaveTextContent(
+    "Configure this inbox so every outbound email requires human review.",
+  );
+});
+
+test("does not show the inbox-only notice on other setup cards", () => {
+  const { rerender } = render(
+    <AgentPromptCard {...AGENT_PROMPTS.templates} />,
+  );
+  expect(
+    screen.queryByRole("note", { name: "Optional outbound review setup" }),
+  ).not.toBeInTheDocument();
+
+  rerender(<AgentPromptCard {...AGENT_PROMPTS.domains} />);
+  expect(
+    screen.queryByRole("note", { name: "Optional outbound review setup" }),
+  ).not.toBeInTheDocument();
+});
+
 test("copy button writes the card's prompt to the clipboard and flips its label", async () => {
   render(<AgentPromptCard {...AGENT_PROMPTS.domains} />);
   fireEvent.click(screen.getByRole("button", { name: "Copy prompt" }));

--- a/web/src/app/components/AgentPromptCard.tsx
+++ b/web/src/app/components/AgentPromptCard.tsx
@@ -16,6 +16,11 @@ export const AGENT_PROMPTS = {
     blurb:
       "Creating and wiring an inbox is a one-time setup your coding agent can do headlessly — paste this into Claude Code, Cursor, or any agent connected to e2a.",
     prompt: "Help me set up an e2a inbox using https://api.e2a.dev/mcp",
+    notice: {
+      label: "Want every outbound email reviewed first?",
+      instruction:
+        "Configure this inbox so every outbound email requires human review.",
+    },
   },
   domains: {
     blurb:
@@ -28,12 +33,20 @@ export const AGENT_PROMPTS = {
 export type AgentPromptCardProps = {
   blurb: string;
   prompt: string;
+  notice?: {
+    label: string;
+    instruction: string;
+  };
 };
 
 // A copy-paste prompt card: these surfaces are one-time-setup shaped, so
 // the card hands the developer's coding agent the whole job instead of
 // walking the human through clicks.
-export function AgentPromptCard({ blurb, prompt }: AgentPromptCardProps) {
+export function AgentPromptCard({
+  blurb,
+  prompt,
+  notice,
+}: AgentPromptCardProps) {
   const [copied, setCopied] = useState(false);
   const copyTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -93,6 +106,23 @@ export function AgentPromptCard({ blurb, prompt }: AgentPromptCardProps) {
       >
         {prompt}
       </pre>
+      {notice ? (
+        <aside
+          role="note"
+          aria-label="Optional outbound review setup"
+          className="mt-3 rounded-[var(--r-md)] border px-3.5 py-3 text-[12px] leading-[1.6]"
+          style={{
+            color: "var(--fg-muted)",
+            background: "var(--bg)",
+            borderColor: "var(--border)",
+          }}
+        >
+          <span className="font-semibold" style={{ color: "var(--fg)" }}>
+            {notice.label}
+          </span>{" "}
+          Ask your agent: “{notice.instruction}”
+        </aside>
+      ) : null}
     </section>
   );
 }


### PR DESCRIPTION
## Summary

- add an inbox-only notice with an optional instruction for requiring human review on every outbound email
- teach the e2a skill and setup guide the exact fail-closed `update_protection` configuration
- add UI and agent-guidance regression coverage and synchronize the hosted setup guide

## Why

The protection API already supported reviewing every outbound message, but the inbox setup surface and installed agent guidance did not make the opt-in workflow discoverable. This exposes the workflow without changing the default setup prompt or enabling the policy automatically.

## Validation

- `npm test -- --runInBand` in `web/` — 51 suites, 428 tests passed
- scoped ESLint for `AgentPromptCard.tsx` and its test — passed
- `node --test scripts/plugin-agent-guidance.test.mjs scripts/sync-agent-docs.test.mjs` — 12 tests passed
- `node scripts/sync-agent-docs.mjs --check` — no drift
- `node scripts/validate-plugin.mjs` — plugin and manifests valid

## Note

`npm run build` was also attempted. Next.js remained in the optimization phase without completing or reporting an error, so it was stopped; the full web test suite and scoped lint checks completed successfully.
