### PR TITLE
fix(mcp): advertise https for public hosts in discovery metadata

### DIFF
--- a/mcp/src/http-server.ts
+++ b/mcp/src/http-server.ts
@@ -16,10 +16,11 @@ export interface HttpServerOptions {
    * Externally reachable URL of this MCP server. When set, used verbatim
    * for the RFC 9728 protected-resource metadata `resource` field and
    * the `WWW-Authenticate: resource_metadata=...` value on 401s. When
-   * unset (production default behind Caddy), we synthesize
-   * `https://{Host}` from the inbound request. The local-dev runbook
-   * sets this to `http://localhost:8765` so Claude Code's OAuth probe
-   * can resolve the metadata over loopback http.
+   * unset (production default behind Caddy), we synthesize the URL from
+   * the inbound request Host, forcing `https` for any non-loopback host
+   * (a public MCP endpoint is always TLS-fronted — see #635). The
+   * local-dev runbook sets this to `http://localhost:8765` so Claude
+   * Code's OAuth probe can resolve the metadata over loopback http.
    */
   publicUrl?: string;
   /**
@@ -141,7 +142,7 @@ export function buildApp(opts: HttpServerOptions): BuiltApp {
     if (!host) return null;
     const bare = host.split(":")[0]!.toLowerCase();
     if (!allowedHosts.has(bare)) return null;
-    return `${externalScheme(req)}://${host}`;
+    return `${discoveryScheme(req, host)}://${host}`;
   };
 
   app.get("/.well-known/oauth-protected-resource", (req, res) => {
@@ -210,13 +211,33 @@ function externalScheme(req: Request): string {
   return req.protocol === "https" ? "https" : "http";
 }
 
+// isLoopbackHost reports whether a Host header names a local-dev loopback
+// address. Mirrors the bare-host extraction used by the allowlist check (port
+// stripped; IPv6 literals aren't a supported deployment shape for this server).
+function isLoopbackHost(host: string): boolean {
+  const bare = host.split(":")[0]!.toLowerCase();
+  return bare === "localhost" || bare === "127.0.0.1";
+}
+
+// discoveryScheme picks the scheme for synthesized discovery URLs (used only
+// when publicUrl is unset). A public host is always TLS-fronted, so we force
+// https there — this keeps the RFC 9728 `resource` identifier correct even when
+// the fronting proxy's X-Forwarded-Proto isn't trusted (E2A_TRUST_PROXY
+// misconfig, which silently downgraded prod to http; see #635). Loopback dev
+// keeps deriving from the trusted request scheme so http://localhost still works
+// (and local dev sets publicUrl explicitly anyway).
+function discoveryScheme(req: Request, host: string): string {
+  return isLoopbackHost(host) ? externalScheme(req) : "https";
+}
+
 // resourceMetadataURL returns the value the `WWW-Authenticate` header
 // should advertise. Honors publicUrl when set (local-dev http), falls
-// back to the trusted request scheme + Host otherwise.
+// back to the synthesized scheme + Host otherwise.
 function resourceMetadataURL(req: Request, opts: HttpServerOptions): string {
+  const host = req.headers.host ?? "";
   const base = opts.publicUrl
     ? opts.publicUrl.replace(/\/+$/, "")
-    : `${externalScheme(req)}://${req.headers.host}`;
+    : `${discoveryScheme(req, host)}://${host}`;
   return `${base}/.well-known/oauth-protected-resource`;
 }
 

--- a/mcp/src/http-server.ts
+++ b/mcp/src/http-server.ts
@@ -131,7 +131,8 @@ export function buildApp(opts: HttpServerOptions): BuiltApp {
   //      or any deployment behind a fronting proxy that knows its own
   //      external URL better than we do).
   //   2. unset + Host header present + Host in allowlist: synthesize the URL
-  //      from the trusted request protocol and Host.
+  //      from Host, forcing https for non-loopback hosts while preserving the
+  //      trusted request protocol for loopback development.
   //   3. unset + Host missing/disallowed: caller wrapped function
   //      rejects with 421 before reaching here.
   const resolveResourceUrl = (req: Request): string | null => {

--- a/mcp/tests/http.test.ts
+++ b/mcp/tests/http.test.ts
@@ -36,6 +36,41 @@ function getJsonWithHost(
   });
 }
 
+function postJsonWithHost(
+  port: number,
+  path: string,
+  host: string,
+  body: unknown,
+): Promise<{ statusCode?: number; wwwAuthenticate?: string }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: "127.0.0.1",
+        port,
+        path,
+        method: "POST",
+        headers: {
+          Host: host,
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+        },
+      },
+      (res) => {
+        res.resume();
+        res.on("end", () => {
+          const challenge = res.headers["www-authenticate"];
+          resolve({
+            statusCode: res.statusCode,
+            wwwAuthenticate: Array.isArray(challenge) ? challenge.join(", ") : challenge,
+          });
+        });
+      },
+    );
+    req.on("error", reject);
+    req.end(JSON.stringify(body));
+  });
+}
+
 // Stub the McpClient wrapper — only the methods the tools and the
 // session prefetch (listAgents / agentEmail) actually touch. List
 // methods return flat arrays (the wrapper collapses the SDK pager).
@@ -326,6 +361,21 @@ describe("HTTP MCP server", () => {
       "api.e2a.dev",
     );
     expect(body.resource).toBe("https://api.e2a.dev");
+
+    const challenge = await postJsonWithHost(port, "/mcp", "api.e2a.dev", {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "x", version: "0" },
+      },
+    });
+    expect(challenge.statusCode).toBe(401);
+    expect(challenge.wwwAuthenticate).toContain(
+      'resource_metadata="https://api.e2a.dev/.well-known/oauth-protected-resource"',
+    );
   });
 
   it("lists every registered tool after initialize", async () => {

--- a/mcp/tests/http.test.ts
+++ b/mcp/tests/http.test.ts
@@ -1,10 +1,40 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import http from "node:http";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import type { McpClient } from "../src/client.js";
 import { startHttpServer } from "../src/http-server.js";
 import { ResolveCache } from "../src/resolve.js";
+
+// GET a URL with an explicit Host header. undici's fetch forbids overriding
+// Host, so host-sensitive discovery tests drop to the raw http client.
+function getJsonWithHost(
+  port: number,
+  path: string,
+  host: string,
+  extraHeaders: Record<string, string> = {},
+): Promise<{ resource?: string; [k: string]: unknown }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { host: "127.0.0.1", port, path, method: "GET", headers: { Host: host, ...extraHeaders } },
+      (res) => {
+        let data = "";
+        res.setEncoding("utf8");
+        res.on("data", (chunk) => (data += chunk));
+        res.on("end", () => {
+          try {
+            resolve(JSON.parse(data));
+          } catch {
+            reject(new Error(`non-JSON response (${res.statusCode}): ${data}`));
+          }
+        });
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
 
 // Stub the McpClient wrapper — only the methods the tools and the
 // session prefetch (listAgents / agentEmail) actually touch. List
@@ -275,6 +305,27 @@ describe("HTTP MCP server", () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.resource).toBe(`http://127.0.0.1:${port}`);
+  });
+
+  // #635: prod served https://api.e2a.dev/mcp but advertised the resource as
+  // http://api.e2a.dev because the fronting proxy's X-Forwarded-Proto wasn't
+  // trusted. A public (non-loopback) host must always be advertised as https,
+  // even without a trusted forwarded-proto header.
+  it("synthesizes https for a public host without X-Forwarded-Proto (#635)", async () => {
+    await close();
+    const { close: c, port } = await startHttpServer(0, {
+      baseUrl: "http://e2a.local",
+      allowedHosts: ["api.e2a.dev"],
+      trustProxy: false,
+      clientFactory: () => stub,
+    });
+    close = c;
+    const body = await getJsonWithHost(
+      port,
+      "/.well-known/oauth-protected-resource",
+      "api.e2a.dev",
+    );
+    expect(body.resource).toBe("https://api.e2a.dev");
   });
 
   it("lists every registered tool after initialize", async () => {


### PR DESCRIPTION
## What

When `MCP_PUBLIC_URL` is unset, the synthesized RFC 9728 discovery URL now
forces `https` for any non-loopback host, instead of deriving the scheme from
`req.protocol`.

Fixes #635.

## Why

The hosted server serves `https://api.e2a.dev/mcp` but was advertising:

```
$ curl -s https://api.e2a.dev/.well-known/oauth-protected-resource
{"resource":"http://api.e2a.dev",            ← http
 "authorization_servers":["https://api.e2a.dev"], ← https
 ...}
```

`resource` is synthesized from the request scheme, which is only `https` when
the fronting proxy's `X-Forwarded-Proto` is trusted (`E2A_TRUST_PROXY`, default
`loopback`). In prod that isn't the case, so it fell back to `http`, and every
OAuth-capable MCP client (Claude Code, Cursor, MCP Inspector) rejects the
`http` vs `https` scheme mismatch — nobody can authenticate to the hosted MCP
server. (`authorization_servers` was already correct because it comes from the
static `baseUrl` config, not the request.)

Discovered while testing the new `send_at` (scheduled send) feature end-to-end
through the MCP tools — the flow never got past the OAuth handshake.

## Approach

A publicly reachable MCP endpoint is always TLS-fronted, so a non-loopback host
should never be advertised over `http`. This forces `https` for public hosts
while leaving loopback dev untouched:

- Loopback (`localhost` / `127.0.0.1`) still derives the scheme from the trusted
  request protocol, so `http://localhost` dev keeps working. Local dev also sets
  `publicUrl` explicitly, which bypasses synthesis entirely.
- This **complements #92** (trusted `X-Forwarded-Proto` derivation) rather than
  reverting it — it just removes the silent `http` footgun for public hosts when
  the proxy-trust config isn't perfectly aligned.

Setting `MCP_PUBLIC_URL=https://api.e2a.dev` on the deployment is still the
recommended belt-and-suspenders remedy; this change makes the server correct by
default even without it.

## Tests

- New: `synthesizes https for a public host without X-Forwarded-Proto (#635)`.
- All existing discovery-scheme tests (loopback fallback, trusted/untrusted
  X-Forwarded-Proto, `publicUrl` override) unchanged and still pass.
- Full MCP suite: 212 passing; `tsc` build + type-tests clean.
