### PR TITLE
fix(sdk-monitor): send a real User-Agent on raw urllib requests

### DIFF
--- a/tests/sdk-monitor/monitor.py
+++ b/tests/sdk-monitor/monitor.py
@@ -102,6 +102,14 @@ PORT = int(os.environ.get("PORT", "8080"))
 # Every interface this service exercises, in the fixed order /tick fires them.
 IFACES = ("api", "python_sdk", "mcp", "ts_sdk", "cli")
 
+# The raw-HTTP interfaces (api, mcp) call urllib directly; its default
+# User-Agent (Python-urllib/x.y) is blocked by Cloudflare bot rules
+# (HTTP 403 / error 1010) on Cloudflare-fronted hosts such as prod
+# api.e2a.dev. Present a real, identifiable UA so the monitor's traffic
+# isn't treated as an anonymous scraper. The python_sdk/ts_sdk/cli
+# interfaces set their own client UAs and are unaffected.
+USER_AGENT = "e2a-sdk-monitor/1.0"
+
 APP_DIR = os.path.dirname(os.path.abspath(__file__))
 NODE_HELPER = os.path.join(APP_DIR, "js", "monitor-helper.mjs")
 CLI_BIN = os.path.join(APP_DIR, "node_modules", "@e2a", "cli", "dist", "bin", "e2a.js")
@@ -206,6 +214,7 @@ class ApiStrategy:
         req = urllib.request.Request(url, data=json.dumps(body).encode(), method="POST")
         req.add_header("Authorization", f"Bearer {self._api_key}")
         req.add_header("Content-Type", "application/json")
+        req.add_header("User-Agent", USER_AGENT)
         if idempotency_key:
             req.add_header("Idempotency-Key", idempotency_key)
         try:
@@ -334,6 +343,7 @@ class McpStrategy:
         req = urllib.request.Request(self._url, data=payload, method="POST")
         req.add_header("Authorization", f"Bearer {self._api_key}")
         req.add_header("Content-Type", "application/json")
+        req.add_header("User-Agent", USER_AGENT)
         # Streamable-HTTP requires the client to accept both framings.
         req.add_header("Accept", "application/json, text/event-stream")
         try:


### PR DESCRIPTION
## Why

The prod sdk-monitor's `api` and `mcp` interfaces fail against `https://api.e2a.dev` with HTTP 403 / Cloudflare error **1010**. Root cause (verified via curl UA sweep): Cloudflare's default bot rules block requests whose User-Agent is `Python-urllib/x.y` — the default UA of the stdlib `urllib` client these two strategies use. Every other UA tested (curl, python-requests, Go-http-client, node-fetch, custom) passes, which is why the `python_sdk`/`ts_sdk`/`cli` interfaces (and real customers) are unaffected, and why staging (not Cloudflare-proxied) is 5/5 green.

## What

- Add a `USER_AGENT = "e2a-sdk-monitor/1.0"` constant (confirmed to return 200 through Cloudflare).
- Send it from both raw-urllib call sites: `ApiStrategy._request` and `McpStrategy._call`.

An honest, identifiable UA is also just good citizenship for synthetic monitor traffic.

## Testing

- `python3 tests/sdk-monitor/test_monitor.py` — all checks passed (offline suite).
- UA behavior against prod Cloudflare verified independently: `curl -A "e2a-sdk-monitor/1.0" https://api.e2a.dev/api/health` → 200; `-A "Python-urllib/3.11"` → 403/1010.

After merge: re-mirror the rebuilt `e2a-sdk-monitor:main` image to prod AR and bump the prod Cloud Run service to get prod to 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)