### PR TITLE
fix(mcp): unify account review tools

### DIFF
--- a/docs/superpowers/plans/2026-07-22-mcp-account-review-tools.md
+++ b/docs/superpowers/plans/2026-07-22-mcp-account-review-tools.md
@@ -1,0 +1,192 @@
+# MCP Account Review Tools Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make MCP review discovery account-only, complete for both directions, and backed directly by the canonical paginated reviews SDK resource.
+
+**Architecture:** Move `list_reviews` and `get_review` into the admin tool tier. Replace the per-agent outbound message scan in `McpClient` with direct `sdk.reviews.list().page()` and `sdk.reviews.get()` delegation, then expose the existing MCP pagination envelope at the tool boundary.
+
+**Tech Stack:** TypeScript, MCP TypeScript SDK, `@e2a/sdk`, Zod, Vitest.
+
+---
+
+## File structure
+
+- Modify `mcp/src/client.ts`: direct typed review-resource delegation.
+- Modify `mcp/src/tools/review.ts`: account-only descriptions, pagination schema, and response envelope.
+- Modify `mcp/src/tools/tiers.ts`: move review discovery from runtime to admin.
+- Modify `mcp/tests/client.test.ts`: lock direct SDK routing and prevent message/agent fan-out.
+- Modify `mcp/tests/tools.test.ts`: lock catalog scope, pagination inputs, and MCP output shape.
+
+### Task 1: Lock canonical review SDK routing
+
+**Files:**
+- Modify: `mcp/tests/client.test.ts`
+- Modify: `mcp/src/client.ts`
+
+- [ ] **Step 1: Write failing client-routing tests**
+
+Replace the review mock with a canonical pager:
+
+```ts
+const reviewPage = vi.fn(async (cursor?: string) => ({
+  items: [
+    { id: "msg_in", direction: "inbound" },
+    { id: "msg_out", direction: "outbound" },
+  ],
+  next_cursor: cursor ? undefined : "reviews_next",
+}));
+
+reviews: {
+  list: vi.fn(() => ({ page: reviewPage })),
+  get: vi.fn(async (id: string) => ({ id })),
+  approve: vi.fn(async () => ({ messageId: "msg_p", status: "sent" })),
+  reject: vi.fn(async () => ({ messageId: "msg_p", status: "rejected" })),
+}
+```
+
+Replace the agent-visible routing assertions with tests that:
+
+```ts
+const page = await c.listReviews({ cursor: "reviews_cursor", limit: 25 });
+expect(sdk.reviews.list).toHaveBeenCalledWith({ limit: 25 });
+expect(reviewPage).toHaveBeenCalledWith("reviews_cursor");
+expect(page.items.map((row) => row.direction)).toEqual(["inbound", "outbound"]);
+expect(sdk.agents.list).not.toHaveBeenCalled();
+expect(sdk.messages.list).not.toHaveBeenCalled();
+
+await c.getReview("msg_p");
+expect(sdk.reviews.get).toHaveBeenCalledWith("msg_p");
+expect(sdk.messages.get).not.toHaveBeenCalled();
+```
+
+- [ ] **Step 2: Run the focused client tests and verify RED**
+
+Run:
+
+```bash
+npm exec --workspace @e2a/mcp-server -- vitest run tests/client.test.ts
+```
+
+Expected: FAIL because `listReviews` has no pagination arguments and both methods still scan `sdk.messages`.
+
+- [ ] **Step 3: Implement direct review-resource delegation**
+
+Import `ReviewView`, remove `MessageSummaryView`, `PENDING_REVIEW_STATUS`, and the now-unused `listAllAgents` helper. Define:
+
+```ts
+listReviews(params: { cursor?: string; limit?: number } = {}): Promise<Page<ReviewView>> {
+  const { cursor, ...rest } = params;
+  return this.sdk.reviews.list(rest).page(cursor);
+}
+
+getReview(messageId: string): Promise<MessageView> {
+  return this.sdk.reviews.get(messageId);
+}
+```
+
+Delete `ownerOfPending` and its synthetic `CodedError` path. Remove the `CodedError` import if no other caller remains.
+
+- [ ] **Step 4: Run the focused client tests and verify GREEN**
+
+Run the command from Step 2. Expected: all client tests PASS.
+
+### Task 2: Enforce the account-only paginated tool contract
+
+**Files:**
+- Modify: `mcp/tests/tools.test.ts`
+- Modify: `mcp/src/tools/review.ts`
+- Modify: `mcp/src/tools/tiers.ts`
+
+- [ ] **Step 1: Write failing tool and scope tests**
+
+Update the scope assertions so an agent-scoped catalog excludes
+`list_reviews`, `get_review`, `approve_review`, and `reject_review`, while an
+account-scoped catalog includes all four.
+
+Update the `list_reviews` tool test to call:
+
+```ts
+const result = await client.callTool({
+  name: "list_reviews",
+  arguments: { cursor: "reviews_cursor", limit: 25 },
+});
+expect(stub.listReviews).toHaveBeenCalledWith({
+  cursor: "reviews_cursor",
+  limit: 25,
+});
+expect(JSON.parse(text(result))).toEqual({
+  reviews: expect.any(Array),
+  next_cursor: "reviews_next",
+});
+```
+
+Add a last-page assertion that `next_cursor` is omitted. Ensure the stub page
+contains one inbound and one outbound review row.
+
+- [ ] **Step 2: Run focused tool tests and verify RED**
+
+Run:
+
+```bash
+npm exec --workspace @e2a/mcp-server -- vitest run tests/tools.test.ts
+```
+
+Expected: FAIL because the tools remain runtime-tier, reject pagination inputs,
+and return a flat array from the old client contract.
+
+- [ ] **Step 3: Implement the tool contract**
+
+Move `list_reviews` and `get_review` from `RUNTIME_TOOLS` to `ADMIN_TOOLS`.
+Import `paginationInput` in `review.ts`, spread it into `list_reviews`' strict
+input schema, and call `client.listReviews` with defined cursor/limit fields.
+Return:
+
+```ts
+{
+  reviews: page.items,
+  ...(page.next_cursor ? { next_cursor: page.next_cursor } : {}),
+}
+```
+
+Update both descriptions to state `Account scope only`, cover both inbound and
+outbound holds, document cursor use, and state that review IDs are shared by
+get/approve/reject.
+
+- [ ] **Step 4: Run focused MCP tests and verify GREEN**
+
+Run both focused test files. Expected: PASS.
+
+### Task 3: Verify, review, and publish
+
+**Files:**
+- Verify all files changed above plus this plan and the approved design.
+
+- [ ] **Step 1: Run full verification**
+
+```bash
+npm run build --workspace @e2a/sdk
+npm run build --workspace @e2a/mcp-server
+npm test --workspace @e2a/mcp-server
+git diff --check origin/main...HEAD
+git status --short
+```
+
+Expected: builds, all MCP tests, and type tests PASS; diff check is clean.
+
+- [ ] **Step 2: Review against the approved design**
+
+Confirm no review-discovery path calls `sdk.agents` or `sdk.messages`, all four
+review tools are admin-tier, approve/reject behavior is unchanged, and no alias
+work leaked into this PR.
+
+- [ ] **Step 3: Commit and publish**
+
+Commit the implementation and tests as:
+
+```bash
+git commit -m "fix(mcp): unify account review tools"
+```
+
+Push `codex/mcp-account-reviews` and open a draft PR against `main` containing
+the contract correction and verification evidence. Do not merge it.

--- a/docs/superpowers/specs/2026-07-22-mcp-account-review-tools-design.md
+++ b/docs/superpowers/specs/2026-07-22-mcp-account-review-tools-design.md
@@ -1,0 +1,62 @@
+# MCP Account Review Tools
+
+## Goal
+
+Make `list_reviews` and `get_review` truthful, complete account-administration
+tools backed by the canonical review API. They must expose inbound and outbound
+holds across the authenticated account and must not be visible to agent-scoped
+credentials.
+
+## Tool surface
+
+`list_reviews` moves from the runtime tier to the admin tier. It accepts the
+shared `cursor` and `limit` pagination inputs and returns the stable MCP list
+envelope `{ reviews, next_cursor? }`. The implementation calls
+`sdk.reviews.list({ limit }).page(cursor)` exactly once per requested page. It
+does not enumerate agents, scan message histories, or filter outbound messages
+inside the MCP process.
+
+`get_review` also moves to the admin tier. It remains addressed by
+`message_id`, which is the review ID, and calls `sdk.reviews.get(message_id)`
+directly. It does not discover an owning inbox through message-list scans.
+
+The descriptions will explicitly say that both tools require an account-scoped
+credential, cover inbound screening holds and outbound send holds, and use the
+same IDs consumed by `approve_review` and `reject_review`.
+
+## Scope and security
+
+Account-scoped sessions expose all four review tools. Agent-scoped sessions
+expose none of them: an agent may create a hold by sending mail, but it cannot
+inspect account review data or release its own hold. The backend remains the
+authorization boundary; MCP tier gating reduces accidental disclosure and
+keeps the advertised catalog aligned with the API.
+
+## Compatibility
+
+This intentionally corrects a pre-GA contract that was internally
+contradictory: the descriptions promised the unified account queue while the
+implementation exposed an outbound-only agent-visible approximation.
+`approve_review` and `reject_review` are unchanged.
+
+The list envelope follows the existing frozen MCP pagination convention:
+domain-named array, optional `next_cursor`, and omission of the cursor on the
+last page.
+
+## Testing
+
+- Prove agent-scoped catalogs exclude all four review tools.
+- Prove account-scoped catalogs include all four review tools.
+- Prove `list_reviews` forwards `cursor` and `limit`, returns inbound and
+  outbound review rows unchanged, and emits the MCP pagination envelope.
+- Prove `get_review` delegates directly to `sdk.reviews.get`.
+- Prove the old agent/message fan-out path is not called.
+- Run the SDK build, MCP build, full MCP test suite, type tests, and
+  `git diff --check`.
+
+## Non-goals
+
+- Renaming review tools or adding compatibility aliases; that is a separate
+  P0 compatibility PR.
+- Changing approve/reject behavior or backend authorization.
+- Adding output schemas or changing the success-output representation.

--- a/mcp/src/client.ts
+++ b/mcp/src/client.ts
@@ -5,6 +5,7 @@ import type {
   MessageView,
   AttachmentView,
   MessageSummaryView,
+  ReviewView,
   SendResultView,
   RejectResultView,
   UpdateMessageResultView,
@@ -47,13 +48,6 @@ import type {
 } from "@e2a/sdk/v1";
 import type { McpConfig } from "./config.js";
 import type { Scope } from "./tools/tiers.js";
-import { CodedError } from "./tools/util.js";
-
-// Outbound drafts held for human review surface in the message list with
-// this status (the hold vocabulary was unified on `pending_review` across
-// both directions — see api/openapi.yaml). There is no dedicated status
-// query param for them, so the review queue filters outbound rows on this value.
-export const PENDING_REVIEW_STATUS = "pending_review";
 
 const DEFAULT_LIST_LIMIT = 1000;
 
@@ -123,12 +117,6 @@ export class McpClient {
   listAgents(params: { cursor?: string; limit?: number; deleted?: boolean } = {}): Promise<Page<AgentView>> {
     const { cursor, ...rest } = params;
     return this.sdk.agents.list(rest).page(cursor);
-  }
-
-  // listAllAgents collapses the pager to a flat array for internal aggregations
-  // (list_reviews fan-out) that need every agent, not one page.
-  listAllAgents(): Promise<AgentView[]> {
-    return this.sdk.agents.list().toArray({ limit: DEFAULT_LIST_LIMIT });
   }
 
   getAgent(address: string): Promise<AgentView> {
@@ -322,59 +310,15 @@ export class McpClient {
     );
   }
 
-  // ── Review queue (pending outbound) ─────────────────────────────
+  // ── Account review queue ─────────────────────────────────────────
 
-  // Pending drafts surface as outbound messages with status=pending_review.
-  // There is no dedicated "pending" status filter, so we list outbound and
-  // filter on the status field. Searches across every owned agent when no
-  // default address is pinned so the queue is visible without a default.
-  async listReviews(): Promise<MessageSummaryView[]> {
-    const addresses = this.agentEmail
-      ? [this.agentEmail]
-      : (await this.listAllAgents()).map((a) => a.email);
-    const out: MessageSummaryView[] = [];
-    for (const address of addresses) {
-      const rows = await this.sdk.messages
-        .list(address, { direction: "outbound" })
-        .toArray({ limit: DEFAULT_LIST_LIMIT });
-      for (const r of rows) {
-        // Held drafts carry the review-hold lifecycle in review_status
-        // (read_status is the inbox read-state, "" for outbound). MSG-1.
-        if (r.reviewStatus === PENDING_REVIEW_STATUS) out.push(r);
-      }
-    }
-    return out;
+  listReviews(params: { cursor?: string; limit?: number } = {}): Promise<Page<ReviewView>> {
+    const { cursor, ...rest } = params;
+    return this.sdk.reviews.list(rest).page(cursor);
   }
 
-  // Resolve the owning agent of a pending OUTBOUND draft by scanning the queue.
-  // get_review is a RUNTIME-tier tool (agent-visible), so it must hit
-  // the agent-reachable GET /v1/agents/{email}/messages/{id} — NOT the account-
-  // only /v1/reviews/{id}, which 403s an agent-scoped credential. For a pinned
-  // session this is one list call.
-  private async ownerOfPending(messageId: string): Promise<string> {
-    const addresses = this.agentEmail
-      ? [this.agentEmail]
-      : (await this.listAllAgents()).map((a) => a.email);
-    for (const address of addresses) {
-      const rows = await this.sdk.messages
-        .list(address, { direction: "outbound" })
-        .toArray({ limit: DEFAULT_LIST_LIMIT });
-      if (rows.some((r) => r.id === messageId)) return address;
-    }
-    // Not-found/already-resolved, NOT malformed input — carry the server's
-    // canonical `not_found` code so an agent branching on structuredContent
-    // doesn't wrongly re-validate its arguments (PR #453 review).
-    throw new CodedError(
-      "not_found",
-      `pending message ${messageId} not found on any owned agent (it may have already been approved, rejected, or expired).`,
-    );
-  }
-
-  async getReview(messageId: string): Promise<MessageView> {
-    // Runtime-tier (agent-visible): use the agent-reachable messages path, not
-    // the account-only /v1/reviews/{id}. Resolve the owning inbox first.
-    const address = await this.ownerOfPending(messageId);
-    return this.sdk.messages.get(address, messageId);
+  getReview(messageId: string): Promise<MessageView> {
+    return this.sdk.reviews.get(messageId);
   }
 
   async approveReview(

--- a/mcp/src/tools/review.ts
+++ b/mcp/src/tools/review.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { McpClient } from "../client.js";
 import { z } from "zod";
-import { runTool, strictInputSchema } from "./util.js";
+import { paginationInput, runTool, strictInputSchema } from "./util.js";
 import { attachmentsArraySchema } from "./attachments.js";
 
 export function registerReviewTools(server: McpServer, client: McpClient): void {
@@ -11,10 +11,20 @@ export function registerReviewTools(server: McpServer, client: McpClient): void 
       title: "List messages awaiting review",
       annotations: { readOnlyHint: true },
       description:
-        "Use when the user asks what's awaiting approval, or after a `send_message`/`reply_to_message` returned `pending_review` and they want to see the review queue. Lists every held message across the account's inboxes — outbound drafts awaiting send approval and inbound messages held by a screening gate — sorted by soonest-expiring first. Body content is summary-only; call `get_review` for full detail. The `email.review_requested` webhook is an additional push notification for either direction and carries the same `message_id`. Read-only; cheap, but don't poll it on a loop.",
-      inputSchema: strictInputSchema({}),
+        "Account scope only. Use when the account owner asks what's awaiting approval, or after a send returned `pending_review`. Lists inbound screening holds and outbound send holds across every inbox in the authenticated account, sorted by soonest-expiring first. Body content is summary-only; call `get_review` with the review's `id` for full detail, then use that same ID with `approve_review` or `reject_review`. **Cursor-paginated:** returns one page in `reviews` plus `next_cursor` only when more remain; pass it back as `cursor`. The `email.review_requested` webhook is an additional push notification for either direction. Read-only; don't poll it on a loop.",
+      inputSchema: strictInputSchema({ ...paginationInput }),
     },
-    async () => runTool(async () => ({ reviews: await client.listReviews() })),
+    async (args) =>
+      runTool(async () => {
+        const page = await client.listReviews({
+          ...(args.cursor !== undefined ? { cursor: args.cursor } : {}),
+          ...(args.limit !== undefined ? { limit: args.limit } : {}),
+        });
+        return {
+          reviews: page.items,
+          ...(page.next_cursor ? { next_cursor: page.next_cursor } : {}),
+        };
+      }),
   );
 
   server.registerTool(
@@ -23,7 +33,7 @@ export function registerReviewTools(server: McpServer, client: McpClient): void 
       title: "Get a review (full detail)",
       annotations: { readOnlyHint: true },
       description:
-        "Fetch the full draft (subject, recipients, body, attachments) of one held message under review. A review's `id` is the held message's id (msg_…) — a review IS the held message pending approval. Body content is only present while the message is `pending_review` — after a terminal transition the server scrubs it.",
+        "Account scope only. Fetch the full detail of one inbound screening hold or outbound send hold, including subject, recipients, body, attachments, and screening context. A review's `id` is the held message's id (msg_…) and is the same ID accepted by `approve_review` and `reject_review`. Body content is only present while the message is `pending_review`; after a terminal transition the server scrubs it.",
       inputSchema: strictInputSchema({
         message_id: z.string().describe("The held message / review ID (msg_…)."),
       }),

--- a/mcp/src/tools/tiers.ts
+++ b/mcp/src/tools/tiers.ts
@@ -39,14 +39,8 @@ export const RUNTIME_TOOLS: ReadonlySet<string> = new Set([
   "send_message",
   "reply_to_message",
   "forward_message",
-  // NOTE: approve_review / reject_review are deliberately NOT here — they are
-  // admin/account-scope (below). Letting the gated agent approve its own held
-  // outbound would be self-approval and defeat the review gate; approval is an
-  // account-owner / human action (or the magic-link browser flow). An
-  // agent-scoped credential can send (which gets held) and SEE its review
-  // queue (list_reviews / get_review), but not release it.
-  "list_reviews",
-  "get_review",
+  // Review discovery and decisions are deliberately NOT here. They expose the
+  // account-wide queue and belong to the account owner / human reviewer.
 ]);
 
 /** Admin/setup tools — visible ONLY to account-scoped credentials. */
@@ -64,6 +58,11 @@ export const ADMIN_TOOLS: ReadonlySet<string> = new Set([
   "update_protection",
   "delete_agent",
   "restore_agent",
+  // All review operations are account-only. Letting the gated agent inspect or
+  // resolve holds could disclose quarantined inbound content or enable
+  // self-approval of its own outbound mail.
+  "list_reviews",
+  "get_review",
   // Review approval is an account-owner / human review action — NOT something the
   // gated agent may do to its own held outbound (that would be self-approval,
   // defeating the review gate). The backend enforces this too: the approve/reject

--- a/mcp/tests/client.test.ts
+++ b/mcp/tests/client.test.ts
@@ -1,19 +1,25 @@
-// McpClient review-queue routing: the tools split across credential tiers, so
-// they MUST hit tier-correct endpoints —
-//   approve_review / reject_review  → ADMIN (account-only)  → sdk.reviews.*
-//   list_reviews / get_review          → RUNTIME (agent-visible) → sdk.messages.*
-// The account-only /v1/reviews path 403s an agent-scoped credential, so routing
-// a runtime-tier tool through it is a regression. These tests pin the routing.
+// McpClient review-queue routing: all four tools are account-only and MUST hit
+// the canonical sdk.reviews resource. Discovery must not fan out over agents or
+// scan per-inbox message histories: that path missed inbound screening holds.
 
 import { describe, it, expect, vi } from "vitest";
 import { McpClient } from "../src/client.js";
 
 function mockSdk() {
+  const reviewPage = vi.fn(async (cursor?: string) => ({
+    items: [
+      { id: "msg_in", direction: "inbound" },
+      { id: "msg_out", direction: "outbound" },
+    ],
+    next_cursor: cursor ? undefined : "reviews_next",
+  }));
   return {
+    reviewPage,
     reviews: {
+      list: vi.fn(() => ({ page: reviewPage })),
       approve: vi.fn(async () => ({ messageId: "msg_p", status: "sent" })),
       reject: vi.fn(async () => ({ messageId: "msg_p", status: "rejected" })),
-      get: vi.fn(async () => ({ id: "msg_p" })),
+      get: vi.fn(async (id: string) => ({ id })),
     },
     messages: {
       get: vi.fn(async () => ({ id: "msg_p" })),
@@ -117,28 +123,28 @@ describe("McpClient review routing (tier-correct endpoints)", () => {
     expect(sdk.reviews.reject).toHaveBeenCalledWith("msg_p", { reason: "spam" });
   });
 
-  it("getReview → agent-reachable messages.get, NOT account-only reviews.get", async () => {
-    // Regression guard (PR #284 adversarial finding): get_review is a
-    // runtime-tier tool, so it must NOT route through sdk.reviews.get — that path
-    // 403s an agent-scoped credential.
+  it("listReviews pages the canonical account queue without agent/message fan-out", async () => {
     const sdk = mockSdk();
-    const c = new McpClient(sdk as never, "bot@test.dev", "agent");
-    await c.getReview("msg_p");
-    expect(sdk.messages.get).toHaveBeenCalledWith("bot@test.dev", "msg_p");
-    expect(sdk.reviews.get).not.toHaveBeenCalled();
+    const c = new McpClient(sdk as never, "", "account");
+
+    const page = await c.listReviews({ cursor: "reviews_cursor", limit: 25 });
+
+    expect(sdk.reviews.list).toHaveBeenCalledWith({ limit: 25 });
+    expect(sdk.reviewPage).toHaveBeenCalledWith("reviews_cursor");
+    expect(page.items.map((row) => row.direction)).toEqual(["inbound", "outbound"]);
+    expect(sdk.agents.list).not.toHaveBeenCalled();
+    expect(sdk.messages.list).not.toHaveBeenCalled();
   });
 
-  it("getReview on a missing/resolved pending draft throws not_found, not invalid_request", async () => {
-    // PR #453 review: an already-approved/rejected/expired draft is a
-    // not-found condition — a CodedError with the server's canonical
-    // `not_found` code, so structuredError doesn't mislabel it as a
-    // caller-input problem.
+  it("getReview delegates directly to the canonical account review resource", async () => {
     const sdk = mockSdk();
-    const c = new McpClient(sdk as never, "bot@test.dev", "agent");
-    await expect(c.getReview("msg_gone")).rejects.toMatchObject({
-      code: "not_found",
-      message: expect.stringContaining("already been approved, rejected, or expired"),
-    });
+    const c = new McpClient(sdk as never, "", "account");
+
+    await expect(c.getReview("msg_p")).resolves.toEqual({ id: "msg_p" });
+
+    expect(sdk.reviews.get).toHaveBeenCalledWith("msg_p");
+    expect(sdk.messages.get).not.toHaveBeenCalled();
+    expect(sdk.messages.list).not.toHaveBeenCalled();
   });
 });
 

--- a/mcp/tests/http.test.ts
+++ b/mcp/tests/http.test.ts
@@ -462,7 +462,7 @@ describe("HTTP MCP server", () => {
 
     const { client, transport } = await connect();
     const names = new Set((await client.listTools()).tools.map((t) => t.name));
-    expect(names.size).toBe(15);
+    expect(names.size).toBe(13);
     expect(names.has("send_message")).toBe(true); // runtime present
     expect(names.has("restore_message")).toBe(true); // per-agent trash lifecycle
     expect(names.has("delete_message")).toBe(true); // soft delete is per-agent too
@@ -471,7 +471,9 @@ describe("HTTP MCP server", () => {
     expect(names.has("restore_agent")).toBe(false); // account administration
     expect(names.has("delete_domain")).toBe(false);
     expect(names.has("list_webhooks")).toBe(false);
-    // approve/reject are account-scope (self-approval would defeat HITL).
+    // The account-wide review queue and decisions are account-scope only.
+    expect(names.has("list_reviews")).toBe(false);
+    expect(names.has("get_review")).toBe(false);
     expect(names.has("approve_review")).toBe(false);
     // credential minting is account-scope (an agent must not mint itself keys).
     expect(names.has("create_api_key")).toBe(false);

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -175,7 +175,13 @@ function makeStubClient(
       expiresAt: "2026-05-20T10:15:00Z",
       ...(opts?.inline ? { data: Buffer.from("%PDF-1.4 fake pdf bytes").toString("base64") } : {}),
     })),
-    listReviews: vi.fn(async () => []),
+    listReviews: vi.fn(async (params: { cursor?: string; limit?: number } = {}) => ({
+      items: [
+        { id: "msg_in", direction: "inbound", reviewStatus: "pending_review" },
+        { id: "msg_out", direction: "outbound", reviewStatus: "pending_review" },
+      ],
+      next_cursor: params.cursor ? undefined : "reviews_next",
+    })),
     getReview: vi.fn(async (id: string) => ({
       messageId: id,
       reviewStatus: "pending_review",
@@ -475,8 +481,8 @@ describe("e2a MCP server", () => {
     expect(toolNamesForScope("bogus")).toBe(RUNTIME_TOOLS);
     expect(toolNamesForScope("")).toBe(RUNTIME_TOOLS);
     expect(toolNamesForScope("agent")).toBe(RUNTIME_TOOLS);
-    expect(RUNTIME_TOOLS.size).toBe(15);
-    expect(ADMIN_TOOLS.size).toBe(36);
+    expect(RUNTIME_TOOLS.size).toBe(13);
+    expect(ADMIN_TOOLS.size).toBe(38);
     expect(toolNamesForScope("account").size).toBe(51);
   });
 
@@ -484,27 +490,32 @@ describe("e2a MCP server", () => {
     const acct = await connect(makeStubClient({ scope: "account" }));
     const { tools } = await acct.listTools();
     expect(tools).toHaveLength(51);
+    const names = new Set(tools.map((tool) => tool.name));
+    for (const name of ["list_reviews", "get_review", "approve_review", "reject_review"]) {
+      expect(names.has(name), `account review tool ${name} should be visible`).toBe(true);
+    }
   });
 
-  it("agent scope exposes only the 15 runtime tools — admin tools hidden", async () => {
+  it("agent scope exposes only the 13 runtime tools — all review tools hidden", async () => {
     const ag = await connect(makeStubClient({ scope: "agent" }));
     const names = new Set((await ag.listTools()).tools.map((t) => t.name));
-    expect(names.size).toBe(15);
-    // Runtime tools present (an agent can send + read its own pending queue,
-    // but NOT approve/reject — that's an account-owner action, see below):
+    expect(names.size).toBe(13);
+    // Runtime tools present: an agent can send and read its own mailbox, but
+    // account review discovery and decisions stay with the account owner.
     for (const n of [
       "whoami", "get_agent", "list_messages", "get_message",
       "get_attachment", "update_message_labels", "list_conversations",
       "get_conversation", "send_message", "reply_to_message", "forward_message",
-      "list_reviews", "get_review", "restore_message", "delete_message",
+      "restore_message", "delete_message",
     ]) {
       expect(names.has(n), `runtime tool ${n} should be visible to agent scope`).toBe(true);
     }
-    // Admin tools hidden — incl. approve/reject: self-approval would defeat HITL.
+    // Admin tools hidden — all review operations are account-only; exposing
+    // discovery would leak held inbound content and account-wide queue state.
     for (const n of [
       "list_agents", "create_agent", "update_agent", "delete_agent", "restore_agent",
       "get_protection", "update_protection",
-      "approve_review", "reject_review",
+      "list_reviews", "get_review", "approve_review", "reject_review",
       "list_domains", "get_domain", "register_domain", "verify_domain", "delete_domain",
       "list_webhooks", "get_webhook", "create_webhook", "update_webhook",
       "delete_webhook", "rotate_webhook_secret", "test_webhook", "list_webhook_deliveries",
@@ -1271,9 +1282,29 @@ describe("e2a MCP server", () => {
     expect(JSON.parse(content[0]!.text)).toEqual({ deleted: true, id: "key_1" });
   });
 
-  it("list_reviews calls the SDK", async () => {
-    await client.callTool({ name: "list_reviews", arguments: {} });
-    expect(stub.listReviews).toHaveBeenCalledOnce();
+  it("list_reviews forwards pagination and returns both directions in the MCP envelope", async () => {
+    const result = await client.callTool({
+      name: "list_reviews",
+      arguments: { cursor: "reviews_cursor", limit: 25 },
+    });
+    expect(stub.listReviews).toHaveBeenCalledWith({
+      cursor: "reviews_cursor",
+      limit: 25,
+    });
+    const content = result.content as Array<{ type: string; text: string }>;
+    expect(JSON.parse(content[0]!.text)).toEqual({
+      reviews: [
+        { id: "msg_in", direction: "inbound", review_status: "pending_review" },
+        { id: "msg_out", direction: "outbound", review_status: "pending_review" },
+      ],
+    });
+  });
+
+  it("list_reviews returns next_cursor only when another page exists", async () => {
+    const result = await client.callTool({ name: "list_reviews", arguments: {} });
+    expect(stub.listReviews).toHaveBeenCalledWith({});
+    const content = result.content as Array<{ type: string; text: string }>;
+    expect(JSON.parse(content[0]!.text)).toMatchObject({ next_cursor: "reviews_next" });
   });
 
   it("get_review forwards the id", async () => {


### PR DESCRIPTION
## What changed

- Make `list_reviews` and `get_review` account-only alongside approve/reject.
- Route review discovery directly through the canonical paginated `sdk.reviews` resource.
- Return the stable MCP `{ reviews, next_cursor? }` list envelope.
- Remove per-agent outbound message scans that omitted inbound screening holds.
- Align tool descriptions with scope, both hold directions, pagination, and shared review IDs.

## Why

The MCP descriptions promised a unified account review queue, but the implementation exposed discovery to agent credentials and reconstructed it by scanning outbound messages. That omitted inbound screening holds, incurred account-wide fan-out, and contradicted the account-only review contract.

## Impact

Account credentials see complete inbound and outbound review state through the canonical API. Agent credentials no longer see review discovery or decision tools, preventing held-content disclosure and self-review workflows.

## Validation

- Focused client/tool suites: 124 tests passed
- Full MCP suite: 215 tests passed
- MCP type tests passed
- `npm run build --workspace @e2a/sdk`
- `npm run build --workspace @e2a/mcp-server`
- `git diff --check`