### PR TITLE
fix(hitl): serve magic-link routes from the chi root; fix dashboard link

### DIFF
--- a/cmd/e2a/main.go
+++ b/cmd/e2a/main.go
@@ -655,7 +655,9 @@ func main() {
 	// owns the `/v1` prefix (OpenAPI-as-source-of-truth, standardized error
 	// envelope + cursor pagination + X-Request-Id), and falls back to the
 	// legacy gorilla/mux for the remaining non-v1 routes (OAuth, session auth,
-	// health/feedback, magic-link pages). The `/api/v1` surface is fully retired.
+	// health/feedback). The HITL magic-link pages (/v1/approve, /v1/reject)
+	// are registered directly on the chi root via the MagicLink* deps.
+	// The `/api/v1` surface is fully retired.
 	// The chi root is the process HTTP handler.
 	v1 := apiserver.New(apiserver.Params{
 		API:                       api,

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -596,17 +596,12 @@ func (a *API) RegisterRoutes(r *mux.Router) {
 	// request body; deliberately not advertised in OpenAPI.
 	r.HandleFunc("/api/internal/limits/invalidate", a.handleInvalidateLimits).Methods("POST")
 
-	// HITL magic-link pages. Human-facing token-gated HTML (not the JSON
-	// API), opened from the approval email. GET renders a confirmation
-	// page with a POST form; POST executes the action. Splitting this way
-	// keeps email-client URL scanners (Gmail, Outlook Safe Links,
-	// corporate mail gateways) from triggering side effects just by
-	// previewing the link. Served under /v1 via the chi root's fallback to
-	// this mux (these are raw HTML routes, not Huma operations).
-	r.HandleFunc("/v1/approve", a.handleApproveMagicLinkGet).Methods("GET")
-	r.HandleFunc("/v1/approve", a.handleApproveMagicLinkPost).Methods("POST")
-	r.HandleFunc("/v1/reject", a.handleRejectMagicLinkGet).Methods("GET")
-	r.HandleFunc("/v1/reject", a.handleRejectMagicLinkPost).Methods("POST")
+	// HITL magic-link pages (/v1/approve, /v1/reject) are NOT registered on
+	// this mux: the chi root (internal/httpapi) owns every /v1/* path and
+	// serves them directly via API.ApproveMagicLinkHandler /
+	// API.RejectMagicLinkHandler. Registering them here would be dead code —
+	// the chi root's not-found handler never falls back to this mux for
+	// /v1/* paths.
 
 	// --- Non-versioned operational endpoints ---
 	r.HandleFunc("/api/health", a.handleHealth).Methods("GET", "HEAD")

--- a/internal/agent/hitl_magic_api.go
+++ b/internal/agent/hitl_magic_api.go
@@ -28,6 +28,40 @@ import (
 
 // --- GET confirmation pages ---
 
+// ApproveMagicLinkHandler serves the /v1/approve magic-link endpoint as a
+// self-contained handler — GET renders the token-gated confirmation page,
+// POST executes the approval. The chi root (internal/httpapi) registers it
+// directly; the legacy gorilla/mux no longer carries these routes.
+func (a *API) ApproveMagicLinkHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			a.handleApproveMagicLinkGet(w, r)
+		case http.MethodPost:
+			a.handleApproveMagicLinkPost(w, r)
+		default:
+			w.Header().Set("Allow", "GET, POST")
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+}
+
+// RejectMagicLinkHandler is the /v1/reject counterpart of
+// ApproveMagicLinkHandler.
+func (a *API) RejectMagicLinkHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			a.handleRejectMagicLinkGet(w, r)
+		case http.MethodPost:
+			a.handleRejectMagicLinkPost(w, r)
+		default:
+			w.Header().Set("Allow", "GET, POST")
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+	})
+}
+
 func (a *API) handleApproveMagicLinkGet(w http.ResponseWriter, r *http.Request) {
 	a.renderConfirmPage(w, r, approvaltoken.ActionApprove)
 }

--- a/internal/agent/hitl_magic_api_test.go
+++ b/internal/agent/hitl_magic_api_test.go
@@ -51,6 +51,10 @@ func setupMagicLinkAPI(t *testing.T) (
 	api.SetApprovalSigner(signer)
 	router := mux.NewRouter()
 	api.RegisterRoutes(router)
+	// Magic-link routes are no longer part of RegisterRoutes — the chi root
+	// owns them in production; mount them directly here.
+	router.Handle("/v1/approve", api.ApproveMagicLinkHandler())
+	router.Handle("/v1/reject", api.RejectMagicLinkHandler())
 	server := httptest.NewServer(router)
 	t.Cleanup(server.Close)
 	return server, store, signer, smtpDone
@@ -643,6 +647,9 @@ func TestMagicLinkDisabledWhenSignerMissing(t *testing.T) {
 	api := agent.NewAPI(store, sender, smtpRelay, nil, usage.NewNoopUsageTracker(), "e2a.dev", "test.e2a.dev", "agents.e2a.dev", "", false)
 	router := mux.NewRouter()
 	api.RegisterRoutes(router)
+	// Magic-link routes are no longer part of RegisterRoutes — mount directly.
+	router.Handle("/v1/approve", api.ApproveMagicLinkHandler())
+	router.Handle("/v1/reject", api.RejectMagicLinkHandler())
 	server := httptest.NewServer(router)
 	defer server.Close()
 

--- a/internal/apiserver/apiserver.go
+++ b/internal/apiserver/apiserver.go
@@ -113,6 +113,8 @@ func BuildDeps(p Params) httpapi.Deps {
 		Authenticator:          p.API.AuthenticateUser,
 		PrincipalAuthenticator: p.API.AuthenticatePrincipal,
 		AuthChallenge:          p.API.WWWAuthenticateChallenge,
+		MagicLinkApprove:       p.API.ApproveMagicLinkHandler(),
+		MagicLinkReject:        p.API.RejectMagicLinkHandler(),
 		ListAgents:             p.Store.ListAgentsByUser,
 		GetAgent:               p.Store.GetAgentByEmail,
 		GetMessage:             p.Store.GetMessageWithContent,

--- a/internal/hitlnotify/notifier.go
+++ b/internal/hitlnotify/notifier.go
@@ -188,10 +188,15 @@ func (n *Notifier) magicURL(path, token string) string {
 }
 
 func (n *Notifier) dashboardURL(messageID string) string {
+	// The dashboard's pending page is a static route that reads the message
+	// id from the ?id= query param (it redirects to /reviews?id=…). A
+	// path-style /dashboard/pending/{id} URL 404s — the static export has no
+	// per-message route.
+	query := "?id=" + url.QueryEscape(messageID)
 	if n.publicURL == "" {
-		return "/dashboard/pending/" + messageID
+		return "/dashboard/pending" + query
 	}
-	return n.publicURL + "/dashboard/pending/" + messageID
+	return n.publicURL + "/dashboard/pending" + query
 }
 
 func truncate(s string, n int) string {

--- a/internal/hitlnotify/notifier_test.go
+++ b/internal/hitlnotify/notifier_test.go
@@ -111,7 +111,7 @@ func TestNotifierSendsEmailToOwner(t *testing.T) {
 		"Important draft",              // subject
 		"/v1/approve?t=",               // magic approve link
 		"/v1/reject?t=",                // magic reject link
-		"/dashboard/pending/" + msg.ID, // dashboard link
+		"/dashboard/pending?id=" + msg.ID, // dashboard link (query-style; no per-message static route)
 	} {
 		if !strings.Contains(data, needle) {
 			t.Errorf("email body missing %q", needle)
@@ -186,7 +186,7 @@ func TestNotifierBuildsAbsoluteURLs(t *testing.T) {
 	if !strings.Contains(data, publicURL+"/v1/approve?t=") {
 		t.Errorf("approve URL should be absolute under %q, got:\n%s", publicURL, data)
 	}
-	if !strings.Contains(data, publicURL+"/dashboard/pending/") {
+	if !strings.Contains(data, publicURL+"/dashboard/pending?id=") {
 		t.Errorf("dashboard URL should be absolute under %q", publicURL)
 	}
 }

--- a/internal/httpapi/httpapi.go
+++ b/internal/httpapi/httpapi.go
@@ -373,6 +373,16 @@ type Deps struct {
 	// package; the real one is ws.Handler.ServeWithEmail.
 	WSHandle func(w http.ResponseWriter, r *http.Request, address string)
 
+	// MagicLinkApprove / MagicLinkReject serve the HITL magic-link endpoints
+	// at /v1/approve and /v1/reject: GET renders the token-gated confirmation
+	// page, POST executes the action. Raw HTML handlers owned by
+	// internal/agent (API.ApproveMagicLinkHandler / RejectMagicLinkHandler),
+	// injected so the chi root serves them directly — the legacy mux no
+	// longer registers these paths, and routeNotFound would answer them with
+	// the JSON 404 envelope (it never consults Legacy for /v1/*).
+	MagicLinkApprove http.Handler
+	MagicLinkReject  http.Handler
+
 	// Legacy is the existing gorilla/mux handler. The chi root falls back
 	// to it for every route not yet ported onto Huma (the strangler), so
 	// the service stays fully functional through the multi-sub-slice port.
@@ -496,6 +506,19 @@ func New(deps Deps) *Server {
 	// Managed unsubscribe is a bearer-capability route, not an authenticated
 	// /v1 management operation. GET is deliberately read-only for link scanners.
 	root.Handle("/u/{token}", http.HandlerFunc(s.handlePublicUnsubscribe))
+
+	// HITL magic-link pages (approve/reject confirmation + execution). Raw
+	// token-gated HTML handlers owned by internal/agent — NOT Huma
+	// operations. They must be registered here explicitly: routeNotFound
+	// short-circuits unmatched /v1/* with the JSON envelope and never
+	// consults Legacy, so without these registrations every approve/reject
+	// link in notification emails 404s.
+	if deps.MagicLinkApprove != nil {
+		root.Handle("/v1/approve", deps.MagicLinkApprove)
+	}
+	if deps.MagicLinkReject != nil {
+		root.Handle("/v1/reject", deps.MagicLinkReject)
+	}
 
 	root.NotFound(s.routeNotFound)
 	root.MethodNotAllowed(s.routeMethodNotAllowed)

--- a/internal/httpapi/router_errors_test.go
+++ b/internal/httpapi/router_errors_test.go
@@ -70,3 +70,58 @@ func TestLegacyFallbackRemainsOutsideV1(t *testing.T) {
 		t.Fatalf("legacy handler called %d times, want 2", legacyCalls)
 	}
 }
+
+// The HITL magic-link pages are raw HTML handlers (internal/agent) injected
+// via Deps and registered directly on the chi root — without registration,
+// routeNotFound would answer them with the JSON 404 envelope and every
+// approve/reject link in notification emails would break.
+func TestMagicLinkRoutesServed(t *testing.T) {
+	calls := 0
+	stub := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusTeapot)
+	})
+	s := New(Deps{MagicLinkApprove: stub, MagicLinkReject: stub})
+
+	for _, tc := range []struct {
+		method string
+		path   string
+	}{
+		{http.MethodGet, "/v1/approve"},
+		{http.MethodPost, "/v1/approve"},
+		{http.MethodGet, "/v1/reject"},
+		{http.MethodPost, "/v1/reject"},
+	} {
+		rr := httptest.NewRecorder()
+		s.ServeHTTP(rr, httptest.NewRequest(tc.method, tc.path+"?t=x", nil))
+		if rr.Code != http.StatusTeapot {
+			t.Fatalf("%s %s status = %d, want injected magic-link handler (%d); body=%q",
+				tc.method, tc.path, rr.Code, http.StatusTeapot, rr.Body.String())
+		}
+	}
+	if calls != 4 {
+		t.Fatalf("magic-link handlers called %d times, want 4", calls)
+	}
+}
+
+// Without the magic-link handlers wired (Deps zero value), the /v1/approve
+// and /v1/reject paths fall back to the canonical JSON 404 — they must NOT
+// silently reach the legacy mux.
+func TestMagicLinkRoutesAbsentWithoutDeps(t *testing.T) {
+	legacyCalls := 0
+	s := New(Deps{Legacy: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		legacyCalls++
+		w.WriteHeader(http.StatusTeapot)
+	})})
+
+	for _, path := range []string{"/v1/approve", "/v1/reject"} {
+		rr := httptest.NewRecorder()
+		s.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, path, nil))
+		if rr.Code != http.StatusNotFound {
+			t.Fatalf("GET %s status = %d, want 404; body=%q", path, rr.Code, rr.Body.String())
+		}
+	}
+	if legacyCalls != 0 {
+		t.Fatalf("legacy handler called %d times for magic-link paths", legacyCalls)
+	}
+}


### PR DESCRIPTION
## Summary

Two production bugs in the HITL approval-notification email, both surfaced by running `tests/e2e-prod` against prod and clicking the links in a real notification email:

1. **`GET /v1/approve?t=…` (and `/v1/reject`) returned the JSON 404 envelope.** The magic-link handlers were registered only on the legacy gorilla/mux, but the chi root owns every `/v1/*` path and `routeNotFound` short-circuits unmatched `/v1/*` with the JSON envelope without ever consulting the legacy mux. The unit tests passed because they exercise the legacy mux directly, bypassing the chi root.
2. **The "edit before approving" dashboard link 404'd.** `hitlnotify` generated path-style `/dashboard/pending/{msgID}`, but the web app's static export only has `/dashboard/pending` reading `?id=` (which redirects to `/reviews?id=…`).

Fix:

- `agent.API` now exposes self-contained `ApproveMagicLinkHandler()` / `RejectMagicLinkHandler()` (GET → token-gated confirm page, POST → execute, else 405). These are injected via `httpapi.Deps.MagicLinkApprove/MagicLinkReject` and registered directly on the chi root; `apiserver.BuildDeps` wires them from `Params.API` so every server assembly gets them. The dead legacy-mux registrations are removed — no legacy involvement remains for these paths.
- The notifier now generates `/dashboard/pending?id={msgID}`.

## Client surface checklist

Not an API-contract change: no `/v1` operation, schema, or error-code change — the OpenAPI document is untouched (the magic-link pages are raw token-gated HTML, never Huma operations). SDK/CLI/MCP/web rows intentionally skipped.

> Skipped: all client surfaces — no `/v1` contract change; routing/URL-generation fix only.

## Operational risk

Low. Only touches how two existing routes are mounted (same handlers, same token verification, same HTML) and one URL string in the notification email. Until this deploys, every approve/reject/dashboard link in HITL notification emails 404s in prod — worth shipping promptly. Rollback: revert this commit; no data or schema changes.

## Test plan

- [x] New `TestMagicLinkRoutesServed` / `TestMagicLinkRoutesAbsentWithoutDeps` in `internal/httpapi/router_errors_test.go`
- [x] All 20 existing `TestMagic*` tests in `internal/agent` pass against handlers mounted via the new exported constructors
- [x] Full `internal/agent`, `internal/httpapi`, `internal/hitlnotify` packages green; `go build ./...` clean
- [ ] After deploy: request a HITL hold on a prod agent, click the approve link in the notification email, confirm the Loft confirm page renders (and `/dashboard/pending?id=…` redirects to `/reviews`)