### PR TITLE
docs(mcp): fix stale tool-count claims (50 -> 59)

### DIFF
--- a/mcp/README.md
+++ b/mcp/README.md
@@ -121,15 +121,15 @@ Hosts that support OAuth connectors can instead add `https://api.e2a.dev/mcp` as
 
 ## Tools
 
-The server exposes up to **50** tools spanning agents, messages, human-in-the-loop
+The server exposes up to **59** tools spanning agents, messages, human-in-the-loop
 approval, attachments, domains, events, webhooks, API keys, and email templates
 (beta).
 **The visible set depends on your credential's scope:** an **agent**-scoped
-credential sees the 14 runtime/inbox tools (read, send, reply, restore messages,
-and view its pending queue); an **account**-scoped credential also sees the 36 admin/setup
+credential sees the 15 runtime/inbox tools (read, send, reply, restore messages,
+and view its pending queue); an **account**-scoped credential also sees the 44 admin/setup
 tools (agent/domain/webhook/event/template/API-key management — **and HITL
 approve/reject, which is an account-owner action, never agent self-approval**)
-— all 50.
+— all 59.
 Every tool carries MCP annotations (`readOnlyHint`/`destructiveHint`/
 `idempotentHint`) so hosts can auto-approve reads and flag destructive actions.
 The tables below highlight the most commonly used ones — your MCP host's tool list

--- a/mcp/examples/README.md
+++ b/mcp/examples/README.md
@@ -12,7 +12,7 @@ End-to-end demos showing how to wire the e2a MCP surface into popular agent fram
 
 ## One hosted endpoint, same tool surface
 
-Each example exercises the same e2a tool surface (50 tools; the visible set depends on your key's scope) against the hosted MCP server. The Python framework examples ship an `agent.py` script; the Codex example ships a TOML block (Codex is itself the agent, so you configure it instead of writing a script).
+Each example exercises the same e2a tool surface (59 tools; the visible set depends on your key's scope) against the hosted MCP server. The Python framework examples ship an `agent.py` script; the Codex example ships a TOML block (Codex is itself the agent, so you configure it instead of writing a script).
 
 Every example connects to `https://api.e2a.dev/mcp` over Streamable HTTP with an
 agent-scoped API key in the `Authorization` header. Set `E2A_MCP_URL` to point

--- a/mcp/examples/codex/README.md
+++ b/mcp/examples/codex/README.md
@@ -2,7 +2,7 @@
 
 [Codex CLI](https://github.com/openai/codex) is OpenAI's terminal coding agent (peer to Claude Code). It speaks MCP natively — you declare servers in `~/.codex/config.toml` and Codex connects to them at session start, then surfaces their tools to whatever model you're running.
 
-Unlike the [LangChain](../langchain/), [CrewAI](../crewai/), [Google ADK](../adk/), and [OpenAI Agents SDK](../openai-agents/) examples — which are Python scripts you run — Codex is itself the agent. The "example" here is the TOML you paste into your Codex config to add e2a's MCP tools (50 total; the visible set depends on your key's scope).
+Unlike the [LangChain](../langchain/), [CrewAI](../crewai/), [Google ADK](../adk/), and [OpenAI Agents SDK](../openai-agents/) examples — which are Python scripts you run — Codex is itself the agent. The "example" here is the TOML you paste into your Codex config to add e2a's MCP tools (59 total; the visible set depends on your key's scope).
 
 Codex opens a Streamable HTTP session to the hosted endpoint at `https://api.e2a.dev/mcp` with your API key in the `Authorization: Bearer …` header — no Node toolchain on the host (works on CI runners, dev containers, remote app servers, etc.).
 

--- a/plugins/e2a/skills/e2a/SKILL.md
+++ b/plugins/e2a/skills/e2a/SKILL.md
@@ -200,5 +200,5 @@ The full, current integration code — SDK install, send / reply / parse, webhoo
 - Webhook + SDK code: https://e2a.dev/sdk.md
 - Exact tool signatures: call `tools/list` (authoritative).
 - OpenAPI contract: https://e2a.dev/v1/openapi.yaml
-- The MCP surface is **50 tools** (14 runtime/inbox + 36 admin/setup) spanning agents, messages, attachments, domains, events, webhooks, API keys, and templates (beta). The set you see depends on your credential's scope: an agent-scoped credential sees the 14 runtime tools; an account-scoped credential sees all 50. Tool descriptions teach behavior; this skill teaches the mental model. (`create_api_key` mints **agent-scoped** keys only — account-scoped keys come from the dashboard or raw API.)
+- The MCP surface is **59 tools** (15 runtime/inbox + 44 admin/setup) spanning agents, messages, attachments, domains, events, webhooks, API keys, and templates (beta). The set you see depends on your credential's scope: an agent-scoped credential sees the 15 runtime tools; an account-scoped credential sees all 59. Tool descriptions teach behavior; this skill teaches the mental model. (`create_api_key` mints **agent-scoped** keys only — account-scoped keys come from the dashboard or raw API.)
 - Plugin homepage / docs index: https://e2a.dev (machine-readable index: https://e2a.dev/llms.txt)


### PR DESCRIPTION
## What was outdated

`mcp/README.md`, `mcp/examples/README.md`, `mcp/examples/codex/README.md`, and `plugins/e2a/skills/e2a/SKILL.md` all described the MCP server as exposing "50 tools" (14 runtime/inbox + 36 admin/setup).

The tool tiers in `mcp/src/tools/tiers.ts` have grown since that count was written — `mcp/tests/tools.test.ts` currently pins:
```
expect(RUNTIME_TOOLS.size).toBe(15);
expect(ADMIN_TOOLS.size).toBe(44);
expect(toolNamesForScope("account").size).toBe(59);
```

## What changed

Updated the tool counts in all four docs to 59 total (15 runtime + 44 admin) to match the current tier registry — documentation only, no code changes.

🤖 Generated by an automated documentation-audit routine.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNMuoikE7Jct8itn6vE25h)_