### PR TITLE
docs: fix broken openapi.yaml links (missing /v1/ prefix)

### DIFF
--- a/plugins/e2a/docs/auth.md
+++ b/plugins/e2a/docs/auth.md
@@ -191,4 +191,4 @@ The user revokes API keys in the e2a dashboard. OAuth access tokens are revoked 
 
 - WorkOS [auth.md protocol](https://workos.com/auth-md) — the open spec this document follows
 - [github.com/workos/auth.md](https://github.com/workos/auth.md) — reference implementation
-- e2a [OpenAPI contract](https://e2a.dev/openapi.yaml) — full reference for the endpoints above
+- e2a [OpenAPI contract](https://e2a.dev/v1/openapi.yaml) — full reference for the endpoints above

--- a/plugins/e2a/docs/llms.txt
+++ b/plugins/e2a/docs/llms.txt
@@ -16,7 +16,7 @@
 ## API & SDKs
 
 - [sdk.md](https://e2a.dev/sdk.md): TypeScript (`@e2a/sdk`) and Python (`e2a`) quick-start with code examples — send, receive (webhook → fetch → reply), and real-time streaming — plus a Raw-REST section (base URL, auth, conventions) for other languages.
-- [openapi.yaml](https://e2a.dev/openapi.yaml): The full OpenAPI 3.1 contract — every endpoint, field, enum, and error, generated from the live handlers. Authoritative for exact signatures.
+- [openapi.yaml](https://e2a.dev/v1/openapi.yaml): The full OpenAPI 3.1 contract — every endpoint, field, enum, and error, generated from the live handlers. Authoritative for exact signatures.
 - [templates.md](https://e2a.dev/templates.md): Email templates (beta) — server-rendered reusable emails with `{{variable}}` interpolation, a prebuilt starter catalog (`from_starter`), validation, and send-by-alias. Includes a copy-paste setup prompt for coding agents.
 
 ## MCP & plugin

--- a/plugins/e2a/docs/sdk.md
+++ b/plugins/e2a/docs/sdk.md
@@ -9,7 +9,7 @@ MCP. Two SDKs, same surface.
 
 Prefer a typed client; if you're calling the REST API raw, see
 [Raw REST](#raw-rest-without-an-sdk) below. The exhaustive contract is
-https://e2a.dev/openapi.yaml, and the auth model (API key vs OAuth) is in
+https://e2a.dev/v1/openapi.yaml, and the auth model (API key vs OAuth) is in
 https://e2a.dev/auth.md.
 
 ## Install
@@ -176,6 +176,6 @@ Conventions:
 
 The endpoint map, exact request/response bodies, enums, and error codes are all
 in the OpenAPI 3.1 contract — generated from the live handlers and checked for
-drift in CI: **https://e2a.dev/openapi.yaml**. The core resources are `agents`
+drift in CI: **https://e2a.dev/v1/openapi.yaml**. The core resources are `agents`
 (inboxes), `messages` (send/reply/forward/get/list/attachments), `domains`,
 `webhooks`, `events`, and `account`.

--- a/plugins/e2a/docs/setup.md
+++ b/plugins/e2a/docs/setup.md
@@ -93,7 +93,7 @@ Registration flow in [auth.md](https://e2a.dev/auth.md).
 
 If your client does not use MCP, follow [sdk.md](https://e2a.dev/sdk.md) for
 TypeScript, Python, and raw REST examples. The complete API contract is
-[openapi.yaml](https://e2a.dev/openapi.yaml).
+[openapi.yaml](https://e2a.dev/v1/openapi.yaml).
 
 ## 2. Verify the connection
 

--- a/plugins/e2a/docs/templates.md
+++ b/plugins/e2a/docs/templates.md
@@ -1,7 +1,7 @@
 # Email templates (beta)
 
 > **Beta.** Templates are unstable — their shape may change before they are
-> declared stable. The canonical contract is [`api/openapi.yaml`](https://e2a.dev/openapi.yaml).
+> declared stable. The canonical contract is [`api/openapi.yaml`](https://e2a.dev/v1/openapi.yaml).
 
 ## Using a coding agent?
 
@@ -134,4 +134,4 @@ tokens alone do not save you — the scanner's GET consumes the token.)
 ## See also
 
 - [`docs/api.md`](https://github.com/tokencanopy/e2a/blob/main/docs/api.md) — REST surface overview and conventions
-- [`api/openapi.yaml`](https://e2a.dev/openapi.yaml) — the canonical machine-readable contract
+- [`api/openapi.yaml`](https://e2a.dev/v1/openapi.yaml) — the canonical machine-readable contract

--- a/plugins/e2a/skills/e2a/SKILL.md
+++ b/plugins/e2a/skills/e2a/SKILL.md
@@ -17,7 +17,7 @@ This file is the **operate-well manual** — the mental model and gotchas. It as
 - **Connect / pick a client / first inbox** → https://e2a.dev/setup.md
 - **Auth (OAuth 2.1 DCR + PKCE, API keys, scopes)** → https://e2a.dev/auth.md
 - **Webhook + SDK code (TypeScript / Python, signature verification)** → https://e2a.dev/sdk.md
-- **Exact, current tool signatures** → call `tools/list` (authoritative), or the OpenAPI contract at https://e2a.dev/openapi.yaml
+- **Exact, current tool signatures** → call `tools/list` (authoritative), or the OpenAPI contract at https://e2a.dev/v1/openapi.yaml
 
 The mental model below holds regardless of surface. Tool descriptions teach the precise per-tool contract; this file teaches the model the descriptions assume.
 
@@ -176,7 +176,7 @@ The full, current integration code — SDK install, send / reply / parse, webhoo
 
 - SDK + webhook code (TypeScript / Python): https://e2a.dev/sdk.md
 - Auth (API keys, scopes, OAuth): https://e2a.dev/auth.md
-- REST contract: https://e2a.dev/openapi.yaml
+- REST contract: https://e2a.dev/v1/openapi.yaml
 
 ## Gotchas
 
@@ -199,6 +199,6 @@ The full, current integration code — SDK install, send / reply / parse, webhoo
 - Auth (OAuth 2.1 DCR + PKCE, API keys, scopes): https://e2a.dev/auth.md
 - Webhook + SDK code: https://e2a.dev/sdk.md
 - Exact tool signatures: call `tools/list` (authoritative).
-- OpenAPI contract: https://e2a.dev/openapi.yaml
+- OpenAPI contract: https://e2a.dev/v1/openapi.yaml
 - The MCP surface is **50 tools** (14 runtime/inbox + 36 admin/setup) spanning agents, messages, attachments, domains, events, webhooks, API keys, and templates (beta). The set you see depends on your credential's scope: an agent-scoped credential sees the 14 runtime tools; an account-scoped credential sees all 50. Tool descriptions teach behavior; this skill teaches the mental model. (`create_api_key` mints **agent-scoped** keys only — account-scoped keys come from the dashboard or raw API.)
 - Plugin homepage / docs index: https://e2a.dev (machine-readable index: https://e2a.dev/llms.txt)

--- a/web/public/auth.md
+++ b/web/public/auth.md
@@ -191,4 +191,4 @@ The user revokes API keys in the e2a dashboard. OAuth access tokens are revoked 
 
 - WorkOS [auth.md protocol](https://workos.com/auth-md) — the open spec this document follows
 - [github.com/workos/auth.md](https://github.com/workos/auth.md) — reference implementation
-- e2a [OpenAPI contract](https://e2a.dev/openapi.yaml) — full reference for the endpoints above
+- e2a [OpenAPI contract](https://e2a.dev/v1/openapi.yaml) — full reference for the endpoints above

--- a/web/public/llms.txt
+++ b/web/public/llms.txt
@@ -16,7 +16,7 @@
 ## API & SDKs
 
 - [sdk.md](https://e2a.dev/sdk.md): TypeScript (`@e2a/sdk`) and Python (`e2a`) quick-start with code examples — send, receive (webhook → fetch → reply), and real-time streaming — plus a Raw-REST section (base URL, auth, conventions) for other languages.
-- [openapi.yaml](https://e2a.dev/openapi.yaml): The full OpenAPI 3.1 contract — every endpoint, field, enum, and error, generated from the live handlers. Authoritative for exact signatures.
+- [openapi.yaml](https://e2a.dev/v1/openapi.yaml): The full OpenAPI 3.1 contract — every endpoint, field, enum, and error, generated from the live handlers. Authoritative for exact signatures.
 - [templates.md](https://e2a.dev/templates.md): Email templates (beta) — server-rendered reusable emails with `{{variable}}` interpolation, a prebuilt starter catalog (`from_starter`), validation, and send-by-alias. Includes a copy-paste setup prompt for coding agents.
 
 ## MCP & plugin

--- a/web/public/sdk.md
+++ b/web/public/sdk.md
@@ -9,7 +9,7 @@ MCP. Two SDKs, same surface.
 
 Prefer a typed client; if you're calling the REST API raw, see
 [Raw REST](#raw-rest-without-an-sdk) below. The exhaustive contract is
-https://e2a.dev/openapi.yaml, and the auth model (API key vs OAuth) is in
+https://e2a.dev/v1/openapi.yaml, and the auth model (API key vs OAuth) is in
 https://e2a.dev/auth.md.
 
 ## Install
@@ -176,6 +176,6 @@ Conventions:
 
 The endpoint map, exact request/response bodies, enums, and error codes are all
 in the OpenAPI 3.1 contract — generated from the live handlers and checked for
-drift in CI: **https://e2a.dev/openapi.yaml**. The core resources are `agents`
+drift in CI: **https://e2a.dev/v1/openapi.yaml**. The core resources are `agents`
 (inboxes), `messages` (send/reply/forward/get/list/attachments), `domains`,
 `webhooks`, `events`, and `account`.

--- a/web/public/setup.md
+++ b/web/public/setup.md
@@ -93,7 +93,7 @@ Registration flow in [auth.md](https://e2a.dev/auth.md).
 
 If your client does not use MCP, follow [sdk.md](https://e2a.dev/sdk.md) for
 TypeScript, Python, and raw REST examples. The complete API contract is
-[openapi.yaml](https://e2a.dev/openapi.yaml).
+[openapi.yaml](https://e2a.dev/v1/openapi.yaml).
 
 ## 2. Verify the connection
 

--- a/web/public/templates.md
+++ b/web/public/templates.md
@@ -1,7 +1,7 @@
 # Email templates (beta)
 
 > **Beta.** Templates are unstable — their shape may change before they are
-> declared stable. The canonical contract is [`api/openapi.yaml`](https://e2a.dev/openapi.yaml).
+> declared stable. The canonical contract is [`api/openapi.yaml`](https://e2a.dev/v1/openapi.yaml).
 
 ## Using a coding agent?
 
@@ -134,4 +134,4 @@ tokens alone do not save you — the scanner's GET consumes the token.)
 ## See also
 
 - [`docs/api.md`](https://github.com/tokencanopy/e2a/blob/main/docs/api.md) — REST surface overview and conventions
-- [`api/openapi.yaml`](https://e2a.dev/openapi.yaml) — the canonical machine-readable contract
+- [`api/openapi.yaml`](https://e2a.dev/v1/openapi.yaml) — the canonical machine-readable contract


### PR DESCRIPTION
## What was outdated

The OpenAPI spec is served at `/v1/openapi.yaml` — confirmed by `internal/httpapi/spec_test.go` (`http.Get(srv.URL + "/v1/openapi.yaml")`) and by `web/public/scalar.html` (`Redoc.init('/v1/openapi.yaml', ...)`). There is no route or static file at the bare `/openapi.yaml`.

Several docs still linked to `https://e2a.dev/openapi.yaml` (missing the `/v1/` prefix), a 404:
- `plugins/e2a/skills/e2a/SKILL.md` (3 occurrences)
- `plugins/e2a/docs/setup.md`, `sdk.md` (2 occurrences), `auth.md`, `templates.md` (2 occurrences), `llms.txt`

## What changed

Fixed all links to `https://e2a.dev/v1/openapi.yaml` in the canonical source (`plugins/e2a/docs/` + `plugins/e2a/skills/e2a/SKILL.md`), then ran `node scripts/sync-agent-docs.mjs` to regenerate the `web/public/` mirrors so they stay byte-identical, per the existing sync-agent-docs CI gate. Documentation only, no code changes.

🤖 Generated by an automated documentation-audit routine.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNMuoikE7Jct8itn6vE25h)_