### PR TITLE
docs(agentify): fix runtime-skill template docs contradicting comms guardrails

### DIFF
--- a/plugins/e2a/skills/agentify/templates/runtime-skill/templates/approval-request.md
+++ b/plugins/e2a/skills/agentify/templates/runtime-skill/templates/approval-request.md
@@ -1,9 +1,10 @@
 # approval-request template (fix_gate hitl)
 
 The maintainer-approval email — the human gate that decides whether the
-coding agent drafts a PR. Sent by `send_message` to `fix_gate.approver`
-(config) ONLY; the reply (approve/decline) is routed back by the comms lane's
-inbound pass. This `to` is never an address from email content.
+coding agent drafts a PR. Sent by `comms_send.sh approval` to
+`fix_gate.approver` (config) ONLY; the reply (approve/decline) is routed back
+by the comms lane's inbound pass. This `to` is never an address from email
+content.
 
 ---
 Subject: [{{product_name}}] Approve a fix for issue #{{issue_number}}?

--- a/plugins/e2a/skills/agentify/templates/runtime-skill/templates/shipped.md
+++ b/plugins/e2a/skills/agentify/templates/runtime-skill/templates/shipped.md
@@ -1,4 +1,4 @@
-# shipped template (slice 3 — dormant until the fix + release lanes land)
+# shipped template (slice 3 — fix + release lanes)
 
 Sent into the filer thread when a ticket reaches `shipped` (the fix PR
 merged/released). The "here's how it works" prose is NOT free-form: it is the

--- a/plugins/e2a/skills/agentify/templates/runtime-skill/templates/triage-ack.md
+++ b/plugins/e2a/skills/agentify/templates/runtime-skill/templates/triage-ack.md
@@ -1,8 +1,8 @@
 # triage-ack template
 
 The first email to a filer — it acks AND informs in one message (no separate
-"received" email). Sent by `reply_to_message` into the filer's thread, so it
-also becomes the reply channel. Slot-fill the bracketed parts; keep the
+"received" email). Sent by `comms_send.sh reply` into the filer's thread, so
+it also becomes the reply channel. Slot-fill the bracketed parts; keep the
 framing fixed. Promise discipline: commit only to a status-change
 notification, never to shipping.
 


### PR DESCRIPTION
## What was outdated

- `templates/runtime-skill/templates/triage-ack.md` and `approval-request.md` described sends as going through the raw MCP tools `reply_to_message` / `send_message`. But `comms.md` and `references/security-invariants.md` (§5) are explicit that those raw tools are **structurally disallowed** for the comms lane — every send must go through `scripts/comms_send.sh` (`reply`/`approval` subcommands), which computes recipients itself specifically so a filer's email content can never set `cc`/`bcc`/`reply_all`. `comms.md`'s own send instructions (lines 50, 54) already use `comms_send.sh`.
- `templates/runtime-skill/templates/shipped.md`'s header said "dormant until the fix + release lanes land," but `runtime-skill/SKILL.md` marks `fix.md` "Slice 3 — implemented," the top-level `agentify/SKILL.md` describes v0 as shipping fix + release, and `comms.md`'s outbound-notification table treats `shipped` as a live, owed notification.

## What changed

- Updated `triage-ack.md` / `approval-request.md` to name `comms_send.sh reply` / `comms_send.sh approval`, matching `comms.md`.
- Updated `shipped.md`'s header to drop the stale "dormant" framing.

Documentation only, no code/script changes.

🤖 Generated by an automated documentation-audit routine.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNMuoikE7Jct8itn6vE25h)_