### PR TITLE
docs(design-system): drop removed Topbar from extraction candidates

### DIFF
--- a/design-system/README.md
+++ b/design-system/README.md
@@ -74,9 +74,9 @@ and import the token bridge instead.
 4. Re-export it from `src/index.ts`.
 5. `npm run build` and you're done.
 
-Good next extraction candidates from the app: `PageShell` and `Topbar` (these
-lean on responsive Tailwind utilities — easiest once this package adopts
-Tailwind), and `Sidebar` (depends on Next.js routing + auth/pending-count
-context — decouple those first). `ThemeToggle` was extracted as a *controlled*
+Good next extraction candidates from the app: `PageShell` (leans on
+responsive Tailwind utilities — easiest once this package adopts Tailwind),
+and `Sidebar` (depends on Next.js routing + auth/pending-count context —
+decouple those first). `ThemeToggle` was extracted as a *controlled*
 component (it took its state from a React context in the app); wire its
 `value`/`onChange` to your own theme state.


### PR DESCRIPTION
## What was outdated

`design-system/README.md` listed `Topbar` as a "good next extraction candidate" from the web app, but the component no longer exists in `web/src/app/components/loft/`. `web/src/app/components/loft/Sidebar.tsx:239` explicitly notes: "The page Topbar it used to align with is gone."

## What changed

Removed `Topbar` from the extraction-candidates sentence, keeping `PageShell` and `Sidebar`. Documentation only, no code changes.

🤖 Generated by an automated documentation-audit routine.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNMuoikE7Jct8itn6vE25h)_