### PR TITLE
docs: fix wrong send-request field names and nonexistent CLI flag

### DIFF
--- a/docs/data-handling.md
+++ b/docs/data-handling.md
@@ -45,5 +45,5 @@ Things e2a doesn't (and can't) handle for you:
 - **Database backups.** Take them, encrypt them, set retention policy. e2a doesn't ship a backup story; use whatever your Postgres provider gives you.
 - **TLS termination** for the API and SMTP. Production mode enforces HTTPS for webhook delivery; the operator's reverse proxy / ingress terminates TLS for inbound API traffic and the SMTP relay's `tls_cert` / `tls_key` config covers `:2525`.
 - **At-rest encryption.** Disk-level / volume-level encryption is the operator's responsibility (Postgres TDE, EBS encryption, GCP CMEK, …). e2a does not currently encrypt message bodies or attachments at the application layer; if your threat model includes a privileged DBA, you'll want to add column-level encryption.
-- **Log redaction.** If your environment can't tolerate sender/recipient addresses in application logs, redact in your log forwarder or run with `--log-format=json` and filter the relevant fields downstream.
+- **Log redaction.** If your environment can't tolerate sender/recipient addresses in application logs, redact in your log forwarder — e2a does not currently offer a built-in structured-log toggle.
 - **Compliance attestations** (SOC 2, HIPAA, ISO 27001) — those are deployment-level, not code-level.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -50,7 +50,7 @@ interpreted; there is no escape sequence and no other directive syntax.
 ## Sending with a template
 
 Reference the template by its per-account alias (`template_alias`) or id
-(`template_id`) — mutually exclusive with literal `subject`/`body`/`html_body` —
+(`template_id`) — mutually exclusive with literal `subject`/`text`/`html` —
 and pass the variables in `template_data`:
 
 ```bash
@@ -77,7 +77,7 @@ curl -X POST https://api.e2a.dev/v1/agents/billing-bot%40agents.e2a.dev/messages
 Rendering happens **before** any human-in-the-loop review hold, so reviewers
 see the final subject and body.
 
-> **Wire change.** To make room for the template shape, `subject` and `body`
+> **Wire change.** To make room for the template shape, `subject` and `text`
 > moved from schema-required to handler-enforced on
 > `POST /v1/agents/{email}/messages`. A literal send that omits them now
 > returns **400 `invalid_request`** where it previously returned a **422**


### PR DESCRIPTION
## What was outdated

- `docs/templates.md` said a literal send uses `subject`/`body`/`html_body`, and that "`subject` and `body`" moved from schema-required to handler-enforced. The real `SendEmailRequest` fields are `subject`/`text`/`html` (`internal/httpapi/outbound.go`: error message is `"subject and text are required"`). `plugins/e2a/docs/templates.md` already carries this fix from an earlier commit (83132ab) — the standalone `docs/templates.md` copy never got it, so the two had drifted.
- `docs/data-handling.md` suggested running the server with `--log-format=json` for structured logs. `cmd/e2a/main.go` only defines `-config` and `-bootstrap-email`; there is no such flag, and all server logging goes through plain `log.Printf`.

## What changed

- Fixed the two `subject`/`body`/`html_body` → `subject`/`text`/`html` references in `docs/templates.md`.
- Reworded the log-redaction bullet in `docs/data-handling.md` to drop the nonexistent flag.

Documentation only, no code changes.

🤖 Generated by an automated documentation-audit routine.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YNMuoikE7Jct8itn6vE25h)_