### PR TITLE
fix(mcp): harden compatibility and output fidelity

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -301,12 +301,27 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
+        with:
+          # The MCP compatibility gate reads the base catalog directly from
+          # the comparison commit, like the OpenAPI compatibility job.
+          fetch-depth: 0
       - uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: "npm"
       - run: npm ci
       - run: npm run build --workspace @e2a/sdk
+      - run: node --test scripts/check-mcp-tool-compat.test.mjs
+      - name: Reject removed MCP tools in pull requests
+        if: github.event_name == 'pull_request'
+        env:
+          MCP_TOOL_BASE: ${{ github.event.pull_request.base.sha }}:mcp/tool-names.v1.json
+        run: node scripts/check-mcp-tool-compat.mjs "$MCP_TOOL_BASE"
+      - name: Reject removed MCP tools pushed to main
+        if: github.event_name == 'push' && github.event.before != '0000000000000000000000000000000000000000'
+        env:
+          MCP_TOOL_BASE: ${{ github.event.before }}:mcp/tool-names.v1.json
+        run: node scripts/check-mcp-tool-compat.mjs "$MCP_TOOL_BASE"
       - run: npm test --workspace @e2a/mcp-server
       - run: npm run build --workspace @e2a/mcp-server
 

--- a/mcp/src/tools/util.ts
+++ b/mcp/src/tools/util.ts
@@ -34,6 +34,24 @@ function snakeCaseKey(key: string): string {
     .toLowerCase();
 }
 
+type GeneratedAttribute = {
+  name: string;
+  baseName: string;
+  type: string;
+};
+
+function generatedAttributes(value: object): Map<string, GeneratedAttribute> | undefined {
+  const ctor = value.constructor as {
+    getAttributeTypeMap?: () => GeneratedAttribute[];
+  };
+  if (typeof ctor.getAttributeTypeMap !== "function") return undefined;
+  return new Map(ctor.getAttributeTypeMap().map((attribute) => [attribute.name, attribute]));
+}
+
+function isFreeFormMapType(type: string): boolean {
+  return /^\{\s*\[key:\s*string\]\s*:\s*(?:any|unknown);?\s*\}$/.test(type);
+}
+
 /**
  * Convert SDK response models back to the REST-style names used by MCP.
  *
@@ -44,26 +62,36 @@ function snakeCaseKey(key: string): string {
  * are preserved verbatim.
  *
  * IMPORTANT: the generated SDK's ObjectSerializer.deserialize returns CLASS
- * INSTANCES (`new typeMap[type]()`), not plain object literals, so the
- * conversion must NOT be gated on `prototype === Object.prototype` — that
- * guard silently passed every SDK model through unconverted, leaking camelCase
- * keys from ~48 of 50 tools (the pre-GA e2e sweep's Bug 2). Any non-null,
- * non-Array, non-Date object is treated as a convertible record; its own
- * enumerable properties are renamed recursively (this matches the McpOutput
- * type above, which already maps every object shape except Date/arrays).
+ * INSTANCES (`new typeMap[type]()`), not plain object literals. Their generated
+ * attribute map is the authoritative boundary metadata: `baseName` is the REST
+ * key and a `{ [key: string]: any }` attribute is an OPEN JSON map whose keys
+ * belong to the user/event payload and must remain byte-for-byte unchanged.
+ * Without that distinction, a template variable like `firstName` became
+ * `first_name` inside suggested_data and silently rendered blank when reused.
+ *
+ * Non-generated objects still use the historical recursive snake_case fallback
+ * so hand-built MCP envelopes and test doubles retain the frozen v1 shape.
  */
 export function toMcpOutput<T>(value: T): McpOutput<T> {
+  return convertMcpOutput(value, false) as McpOutput<T>;
+}
+
+function convertMcpOutput(value: unknown, preserveMapKeys: boolean): unknown {
   if (Array.isArray(value)) {
-    return value.map((item) => toMcpOutput(item)) as McpOutput<T>;
+    return value.map((item) => convertMcpOutput(item, preserveMapKeys));
   }
   if (value !== null && typeof value === "object" && !(value instanceof Date)) {
+    const attributes = preserveMapKeys ? undefined : generatedAttributes(value);
     const out: Record<string, unknown> = {};
     for (const [key, item] of Object.entries(value)) {
-      out[snakeCaseKey(key)] = toMcpOutput(item);
+      const attribute = attributes?.get(key);
+      const outputKey = preserveMapKeys ? key : attribute?.baseName ?? snakeCaseKey(key);
+      const preserveChildKeys = preserveMapKeys || (attribute !== undefined && isFreeFormMapType(attribute.type));
+      out[outputKey] = convertMcpOutput(item, preserveChildKeys);
     }
-    return out as McpOutput<T>;
+    return out;
   }
-  return value as McpOutput<T>;
+  return value;
 }
 
 // strictInputSchema wraps a zod raw shape in a strict ZodObject so the

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -2,7 +2,12 @@ import { describe, expect, it, beforeEach, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
-import { E2AConnectionError, E2AError } from "@e2a/sdk/v1";
+import {
+  E2AConnectionError,
+  E2AError,
+  EventView,
+  ValidateTemplateResponse,
+} from "@e2a/sdk/v1";
 import type { McpClient } from "../src/client.js";
 import { buildServer } from "../src/server.js";
 import { ADMIN_TOOLS, assertToolTiersComplete, toolNamesForScope, RUNTIME_TOOLS } from "../src/tools/tiers.js";
@@ -2072,6 +2077,42 @@ describe("e2a MCP server", () => {
       createdAt = "2026-06-01T00:00:00Z";
     }
     expect(toMcpOutput([new FakeAgentView()])).toEqual([{ created_at: "2026-06-01T00:00:00Z" }]);
+  });
+
+  it("preserves arbitrary keys inside generated free-form map fields", () => {
+    const validation = Object.assign(new ValidateTemplateResponse(), {
+      valid: true,
+      errors: [],
+      suggestedData: {
+        firstName: "firstName_value",
+        userProfile: { postalCode: "userProfile.postalCode_value" },
+      },
+    });
+    expect(JSON.parse(JSON.stringify(toMcpOutput(validation)))).toEqual({
+      valid: true,
+      errors: [],
+      suggested_data: {
+        firstName: "firstName_value",
+        userProfile: { postalCode: "userProfile.postalCode_value" },
+      },
+    });
+
+    const event = Object.assign(new EventView(), {
+      id: "evt_1",
+      type: "future.event",
+      schemaVersion: "1",
+      createdAt: new Date("2026-07-22T00:00:00Z"),
+      status: "processed",
+      data: { customKey: { nestedValue: true } },
+    });
+    expect(JSON.parse(JSON.stringify(toMcpOutput(event)))).toEqual({
+      id: "evt_1",
+      type: "future.event",
+      schema_version: "1",
+      created_at: "2026-07-22T00:00:00.000Z",
+      status: "processed",
+      data: { customKey: { nestedValue: true } },
+    });
   });
 
   // ── Templates (beta) ────────────────────────────────────────────

--- a/scripts/check-mcp-tool-compat.mjs
+++ b/scripts/check-mcp-tool-compat.mjs
@@ -1,0 +1,72 @@
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const repoRoot = fileURLToPath(new URL("../", import.meta.url));
+
+function validateCatalog(label, value) {
+  if (!Array.isArray(value) || value.some((name) => typeof name !== "string")) {
+    throw new Error(`${label} MCP tool catalog must contain only strings`);
+  }
+  const sortedUnique = [...new Set(value)].sort();
+  if (JSON.stringify(value) !== JSON.stringify(sortedUnique)) {
+    throw new Error(`${label} MCP tool catalog must be sorted and unique`);
+  }
+  return value;
+}
+
+export function assertAdditiveToolCatalog(base, revision) {
+  const baseNames = validateCatalog("base", base);
+  const revisionNames = validateCatalog("revision", revision);
+  const revisionSet = new Set(revisionNames);
+  const removed = baseNames.filter((name) => !revisionSet.has(name));
+  if (removed.length > 0) {
+    throw new Error(`removed MCP tool names: ${removed.join(", ")}`);
+  }
+}
+
+function readCatalog(source) {
+  let raw;
+  if (existsSync(source)) {
+    raw = readFileSync(source, "utf8");
+  } else {
+    const shown = spawnSync("git", ["show", source], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    });
+    if (shown.status !== 0) {
+      const detail = shown.stderr.trim() || `git show exited ${shown.status}`;
+      throw new Error(`MCP tool catalog is not a file or Git object: ${source} (${detail})`);
+    }
+    raw = shown.stdout;
+  }
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`invalid MCP tool catalog JSON at ${source}: ${message}`);
+  }
+}
+
+function main(args) {
+  if (args.length < 1 || args.length > 2) {
+    console.error("usage: node scripts/check-mcp-tool-compat.mjs <base-catalog> [revision-catalog]");
+    process.exitCode = 2;
+    return;
+  }
+  const [baseSource, revisionSource = resolve(repoRoot, "mcp/tool-names.v1.json")] = args;
+  try {
+    const base = readCatalog(baseSource);
+    const revision = readCatalog(revisionSource);
+    assertAdditiveToolCatalog(base, revision);
+    console.log(`MCP tool catalog is additive (${base.length} base, ${revision.length} revision)`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  main(process.argv.slice(2));
+}

--- a/scripts/check-mcp-tool-compat.test.mjs
+++ b/scripts/check-mcp-tool-compat.test.mjs
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { assertAdditiveToolCatalog } from "./check-mcp-tool-compat.mjs";
+
+test("rejects a tool removed from the base catalog", () => {
+  assert.throws(
+    () => assertAdditiveToolCatalog(["get_message", "send_message"], ["send_message"]),
+    /removed MCP tool names: get_message/,
+  );
+});
+
+test("allows tools to be added without removing the base catalog", () => {
+  assert.doesNotThrow(() =>
+    assertAdditiveToolCatalog(
+      ["get_message", "send_message"],
+      ["get_message", "list_messages", "send_message"],
+    ),
+  );
+});
+
+test("rejects malformed catalogs before comparing them", () => {
+  assert.throws(
+    () => assertAdditiveToolCatalog(["send_message", "send_message"], ["send_message"]),
+    /base MCP tool catalog must be sorted and unique/,
+  );
+  assert.throws(
+    () => assertAdditiveToolCatalog(["send_message"], ["send_message", 42]),
+    /revision MCP tool catalog must contain only strings/,
+  );
+});


### PR DESCRIPTION
## Summary
- enforce MCP tool-name compatibility against the PR base / previous main commit so editing the local baseline cannot hide removals
- preserve arbitrary keys inside generated free-form response maps while continuing to emit REST field names for SDK models
- add regressions for removed tools, malformed catalogs, template variable maps, and open event payloads

## Verification
- npm test --workspace @e2a/mcp-server (227 passed)
- npm run build --workspace @e2a/mcp-server
- node --test scripts/check-mcp-tool-compat.test.mjs
- node scripts/check-mcp-tool-compat.mjs origin/main:mcp/tool-names.v1.json
- git diff --check origin/main...HEAD