### PR TITLE
fix(mcp): harden P1 interface behavior

### DIFF
--- a/.github/workflows/publish-mcp-http.yml
+++ b/.github/workflows/publish-mcp-http.yml
@@ -28,6 +28,21 @@ jobs:
 
       - uses: docker/setup-buildx-action@v4
 
+      - name: Resolve MCP server version
+        id: server-version
+        shell: bash
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/mcp-http-v* ]]; then
+            value="${GITHUB_REF_NAME#mcp-http-v}"
+          elif [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            value="${GITHUB_REF_NAME#v}"
+          else
+            product_version="$(tr -d '[:space:]' < VERSION)"
+            value="${product_version}+sha.${GITHUB_SHA:0:12}"
+          fi
+          test -n "${value}"
+          echo "value=${value}" >> "${GITHUB_OUTPUT}"
+
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
@@ -59,6 +74,8 @@ jobs:
         with:
           context: .
           file: mcp/Dockerfile
+          build-args: |
+            MCP_SERVER_VERSION=${{ steps.server-version.outputs.value }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/docs/superpowers/plans/2026-07-22-mcp-p1-hardening.md
+++ b/docs/superpowers/plans/2026-07-22-mcp-p1-hardening.md
@@ -1,0 +1,191 @@
+# MCP P1 Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Correct MCP side-effect metadata, report the deployed build version, and authenticate requests before accepting large JSON bodies.
+
+**Architecture:** Keep tool metadata local to registration, isolate product/deployment version resolution in a small module, and split the HTTP POST path into authentication middleware followed by route-local JSON parsing and stateless dispatch. Preserve the current SDK transport and 40 MB authenticated attachment allowance.
+
+**Tech Stack:** TypeScript, Express, MCP TypeScript SDK, Vitest, Docker BuildKit, GitHub Actions
+
+---
+
+### Task 1: Correct `get_message` metadata
+
+**Files:**
+- Modify: `mcp/src/tools/messages.ts`
+- Test: `mcp/tests/tools.test.ts`
+
+- [ ] **Step 1: Write the failing catalog assertion**
+
+Move `get_message` out of the read-only list and assert it is non-read-only:
+
+```ts
+for (const n of ["get_message", "create_agent", "send_message", "approve_review", "create_webhook", "create_template", "create_api_key"]) {
+  expect(byName.get(n)?.readOnlyHint ?? false, `${n} not read-only`).toBe(false);
+}
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run: `npm test --workspace @e2a/mcp-server -- --run mcp/tests/tools.test.ts -t "every tool carries"`
+
+Expected: FAIL because `get_message.readOnlyHint` is `true`.
+
+- [ ] **Step 3: Remove the false hint**
+
+Keep an empty annotations object so the catalog-wide annotations invariant remains true:
+
+```ts
+annotations: {},
+```
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run the command from Step 2. Expected: PASS.
+
+- [ ] **Step 5: Commit the metadata slice**
+
+```bash
+git add mcp/src/tools/messages.ts mcp/tests/tools.test.ts
+git commit -m "fix(mcp): mark get_message as stateful"
+```
+
+### Task 2: Report the product/deployment version
+
+**Files:**
+- Create: `mcp/src/version.ts`
+- Modify: `mcp/src/server.ts`
+- Modify: `mcp/server.json`
+- Modify: `mcp/Dockerfile`
+- Modify: `.github/workflows/publish-mcp-http.yml`
+- Test: `mcp/tests/version.test.ts`
+
+- [ ] **Step 1: Write failing resolver and drift tests**
+
+Add tests that expect environment override, root `VERSION` fallback, manifest
+agreement with root `VERSION`, and the live handshake to report root `VERSION`:
+
+```ts
+expect(resolveServerVersion({ MCP_SERVER_VERSION: "1.0.0+sha.abcdef123456" })).toBe("1.0.0+sha.abcdef123456");
+expect(resolveServerVersion({})).toBe(readFileSync(new URL("../../VERSION", import.meta.url), "utf8").trim());
+expect(manifest.version).toBe(productVersion);
+expect(client.getServerVersion()).toEqual({ name: "e2a", version: productVersion });
+```
+
+- [ ] **Step 2: Run the version test and verify it fails**
+
+Run: `npm test --workspace @e2a/mcp-server -- --run mcp/tests/version.test.ts`
+
+Expected: FAIL because the resolver does not exist and the manifest/live server still use `0.5.0`.
+
+- [ ] **Step 3: Implement the resolver and server wiring**
+
+Create a resolver that trims `MCP_SERVER_VERSION`, otherwise reads root `VERSION` relative to `import.meta.url`, and throws if either selected value is empty. Replace `PACKAGE_VERSION` in `server.ts` with `resolveServerVersion()` while retaining the existing injectable `version` test seam.
+
+- [ ] **Step 4: Wire image metadata**
+
+Update `mcp/server.json` to `1.0.0`. Add Docker `ARG MCP_SERVER_VERSION`, runtime `ENV MCP_SERVER_VERSION=${MCP_SERVER_VERSION}`, and copy root `VERSION`. Add a workflow step that derives exact tag versions or `<VERSION>+sha.<12 SHA>` and passes it through `build-args`.
+
+- [ ] **Step 5: Run version tests and build**
+
+Run:
+
+```bash
+npm test --workspace @e2a/mcp-server -- --run mcp/tests/version.test.ts
+npm run build --workspace @e2a/mcp-server
+```
+
+Expected: both commands PASS.
+
+- [ ] **Step 6: Commit the version slice**
+
+```bash
+git add mcp/src/version.ts mcp/src/server.ts mcp/tests/version.test.ts mcp/server.json mcp/Dockerfile .github/workflows/publish-mcp-http.yml
+git commit -m "fix(mcp): report deployed server version"
+```
+
+### Task 3: Authenticate before JSON parsing
+
+**Files:**
+- Modify: `mcp/src/http-server.ts`
+- Test: `mcp/tests/http.test.ts`
+
+- [ ] **Step 1: Write failing pre-parse rejection tests**
+
+Send malformed JSON with no bearer and with a bearer whose `whoami` returns
+401. Expect both responses to be 401 JSON-RPC errors with `id: null`, proving
+the parser was not reached. Change the large-body test to use a valid bearer
+and expect the MCP handler response rather than a pre-auth 401.
+
+- [ ] **Step 2: Run focused HTTP tests and verify they fail**
+
+Run: `npm test --workspace @e2a/mcp-server -- --run mcp/tests/http.test.ts -t "bearer|larger than 1 MB"`
+
+Expected: malformed JSON is rejected before the current auth path, and the new valid-bearer large-body expectation fails.
+
+- [ ] **Step 3: Split authentication from dispatch**
+
+Remove global `app.use(express.json(...))`. Add a route chain:
+
+```ts
+app.post(
+  "/mcp",
+  authenticateClient(cache, opts),
+  express.json({ limit: "40mb" }),
+  async (req, res) => handleAuthenticatedClientRequest(req, res, opts),
+);
+```
+
+The authentication middleware resolves and caches the principal, stores
+`{ bearer, principal }` in `res.locals`, and returns missing/invalid-token 401s
+with `jsonRpcError(null, ...)`. The dispatch function reads those locals and
+retains the existing transport lifecycle.
+
+- [ ] **Step 4: Run focused and full MCP tests**
+
+Run:
+
+```bash
+npm test --workspace @e2a/mcp-server -- --run mcp/tests/http.test.ts
+npm test --workspace @e2a/mcp-server
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit the transport slice**
+
+```bash
+git add mcp/src/http-server.ts mcp/tests/http.test.ts
+git commit -m "fix(mcp): authenticate before parsing request bodies"
+```
+
+### Task 4: Final verification and PR
+
+**Files:**
+- Verify all files changed by Tasks 1-3
+
+- [ ] **Step 1: Run final gates**
+
+```bash
+npm test --workspace @e2a/mcp-server
+npm run build --workspace @e2a/mcp-server
+git diff --check
+```
+
+Expected: all MCP tests pass, TypeScript builds, and `git diff --check` prints no errors.
+
+- [ ] **Step 2: Review the branch diff**
+
+Run: `git diff --stat origin/main...HEAD && git diff origin/main...HEAD`
+
+Expected: only the three approved P1 fixes plus their design/plan and tests.
+
+- [ ] **Step 3: Push and open one ready PR**
+
+```bash
+git push -u origin codex/mcp-p1-hardening
+gh pr create --base main --head codex/mcp-p1-hardening --title "fix(mcp): harden P1 interface behavior" --body-file <prepared-body>
+```
+
+Expected: GitHub returns the new PR URL.

--- a/docs/superpowers/specs/2026-07-22-mcp-p1-hardening-design.md
+++ b/docs/superpowers/specs/2026-07-22-mcp-p1-hardening-design.md
@@ -1,0 +1,57 @@
+# MCP P1 Hardening Design
+
+## Goal
+
+Fix three remaining P1 defects in the hosted MCP surface: `get_message` is
+incorrectly advertised as read-only, deployed servers report a stale npm
+version, and unauthenticated callers can make Express parse the full 40 MB MCP
+request allowance before their bearer is rejected.
+
+## Tool metadata
+
+`get_message` marks unread inbound mail as read, so it must not carry
+`readOnlyHint: true`. Remove only that hint and retain the existing description
+that documents the side effect. The tool-catalog test will explicitly group
+`get_message` with non-read-only tools so future annotation cleanup cannot
+reintroduce the false promise.
+
+## Server version identity
+
+The hosted MCP server is co-versioned with the product, not with the retired
+npm package. The version resolver uses `MCP_SERVER_VERSION` when supplied by a
+deployment and otherwise reads the repository's root `VERSION` file. It never
+falls back to `mcp/package.json`.
+
+The image workflow computes a value for every build:
+
+- product tag `vX.Y.Z` reports `X.Y.Z`;
+- MCP-only tag `mcp-http-vX.Y.Z` reports `X.Y.Z`;
+- `main` and manual non-tag builds report `<VERSION>+sha.<12-character SHA>`.
+
+The Docker build receives that value as `MCP_SERVER_VERSION` and persists it in
+the runtime image. The root `VERSION` file is also copied so direct/local image
+builds have a truthful fallback. `mcp/server.json` remains a release manifest,
+so its version matches root `VERSION` rather than a deployment-specific SHA.
+
+## Authenticate before body parsing
+
+Keep Host validation first. For `POST /mcp`, extract and validate the bearer,
+including the cached/remote `whoami` resolution, before invoking the route-local
+40 MB JSON parser. Once authenticated, attach the bearer and resolved principal
+to `res.locals`, parse JSON, and dispatch through the existing stateless MCP
+transport.
+
+Pre-parse 401 responses necessarily use JSON-RPC `id: null`, since reading an
+attacker-controlled body merely to recover its request id would defeat the
+hardening. Authenticated requests retain the current 40 MB attachment envelope
+and request-id behavior. Discovery, health, GET/DELETE `/mcp`, scope gating,
+and backend authorization remain unchanged.
+
+## Tests and non-goals
+
+Tests cover the corrected annotation, root/env version precedence and live
+handshake, workflow/Docker version wiring, missing and invalid bearer rejection
+without JSON parsing, and successful parsing of a body larger than 1 MB after
+authentication. This change does not add stateful sessions or `listChanged`,
+alter attachment limits, change message read semantics, or revive MCP npm
+publishing.

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -28,7 +28,9 @@ RUN npm run build --workspace @e2a/mcp-server
 
 FROM node:22-alpine AS runtime
 WORKDIR /app
+ARG MCP_SERVER_VERSION
 ENV NODE_ENV=production
+ENV MCP_SERVER_VERSION=${MCP_SERVER_VERSION}
 # Fresh install with production-only deps so the runtime image is lean.
 COPY --from=build /app/package.json ./
 COPY --from=build /app/sdks/typescript/package.json sdks/typescript/
@@ -39,6 +41,7 @@ RUN npm install --package-lock=false --omit=dev --workspaces --no-audit --no-fun
 # Built JS only — no TypeScript source ships in the image.
 COPY --from=build /app/sdks/typescript/dist ./sdks/typescript/dist
 COPY --from=build /app/mcp/dist ./mcp/dist
+COPY VERSION ./VERSION
 EXPOSE 3000
 USER node
 CMD ["node", "mcp/dist/bin/http.js"]

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -9,7 +9,7 @@
     "source": "github",
     "subfolder": "mcp"
   },
-  "version": "0.5.0",
+  "version": "1.0.0",
   "remotes": [
     {
       "type": "streamable-http",

--- a/mcp/src/http-server.ts
+++ b/mcp/src/http-server.ts
@@ -87,13 +87,6 @@ export function buildApp(opts: HttpServerOptions): BuiltApp {
   // Set this before any route reads req.protocol. The default trusts only the
   // same-host production proxy, so public clients cannot spoof the scheme.
   app.set("trust proxy", opts.trustProxy ?? "loopback");
-  // The body limit must clear the attachment contract: the tools advertise up
-  // to 10 MB/attachment and 25 MB combined (see tools/attachments.ts), which
-  // base64-encode to ~34 MB on the wire, plus the JSON-RPC envelope. A 1 MB cap
-  // silently 413'd any real attachment before it reached the tool. 40 MB gives
-  // headroom over the combined cap; the fronting proxy (Caddy) is the outer
-  // guard against pathological unauthenticated bodies.
-  app.use(express.json({ limit: "40mb" }));
   // CORS open for v0.2; revisit when we have a real allowlist of MCP hosts.
   app.use(cors({ origin: "*", exposedHeaders: ["Mcp-Session-Id"] }));
 
@@ -167,9 +160,20 @@ export function buildApp(opts: HttpServerOptions): BuiltApp {
     });
   });
 
-  app.post("/mcp", async (req, res) => {
-    await handleClientRequest(req, res, cache, opts);
-  });
+  // Authenticate before reading a potentially large request body. The body
+  // limit must clear the attachment contract: tools advertise 10 MB per file
+  // and 25 MB combined, which base64-encode to ~34 MB plus the envelope.
+  // Route-local parsing ensures a missing/revoked credential cannot spend that
+  // parser budget. The fronting proxy remains the outer wire-size guard.
+  const parseMcpJson = express.json({ limit: "40mb" });
+  app.post(
+    "/mcp",
+    authenticateClient(cache, opts),
+    parseMcpJson,
+    async (req, res) => {
+      await handleAuthenticatedClientRequest(req, res, opts);
+    },
+  );
 
   // Stateless transport: there is no standalone SSE stream and no session to
   // terminate, so the GET (SSE notifications) and DELETE (session teardown)
@@ -253,49 +257,62 @@ class InvalidBearerError extends Error {
   }
 }
 
-async function handleClientRequest(
-  req: Request,
-  res: Response,
+interface AuthenticatedContext {
+  bearer: string;
+  principal: ResolvedPrincipal;
+}
+
+function authenticateClient(
   cache: ResolveCache,
   opts: HttpServerOptions,
-): Promise<void> {
-  const bearer = extractBearer(req);
-  if (!bearer) {
-    res.setHeader("WWW-Authenticate", bearerChallenge(req, opts));
-    res.status(401).json(jsonRpcError(req.body, -32001, "missing bearer token"));
-    return;
-  }
-
-  // Resolve the credential's scope + bound agent. A cache hit skips the
-  // backend round-trip; a miss probes `whoami` once and caches the result.
-  // A revoked/expired bearer surfaces as 401 here (InvalidBearerError).
-  let principal = cache.get(bearer);
-  if (!principal) {
-    let resolved: { value: ResolvedPrincipal; cacheable: boolean };
-    try {
-      resolved = await resolvePrincipal(opts, bearer);
-    } catch (err) {
-      if (err instanceof InvalidBearerError) {
-        res.setHeader(
-          "WWW-Authenticate",
-          `${bearerChallenge(req, opts)}, error="invalid_token"`,
-        );
-        res.status(401).json(jsonRpcError(req.body, -32001, "invalid bearer token"));
-        return;
-      }
-      throw err;
+): (req: Request, res: Response, next: NextFunction) => Promise<void> {
+  return async (req, res, next) => {
+    const bearer = extractBearer(req);
+    if (!bearer) {
+      res.setHeader("WWW-Authenticate", bearerChallenge(req, opts));
+      res.status(401).json(jsonRpcError(null, -32001, "missing bearer token"));
+      return;
     }
-    principal = resolved.value;
-    // Only cache a genuine whoami result. A transient backend failure yields a
-    // least-privilege fallback that must NOT stick — re-probe next request so
-    // the session self-corrects once the backend recovers.
-    if (resolved.cacheable) cache.set(bearer, principal);
-  }
 
-  // The cold-path whoami probe above is awaited, so the client may have
-  // disconnected meanwhile. If so, `res`'s "close" has already fired — bail
-  // before building a transport whose teardown listener would never run.
-  if (res.closed) return;
+    // Resolve the credential's scope + bound agent before parsing JSON. A
+    // cache hit skips the backend round-trip; revoked/expired tokens fail here.
+    let principal = cache.get(bearer);
+    if (!principal) {
+      let resolved: { value: ResolvedPrincipal; cacheable: boolean };
+      try {
+        resolved = await resolvePrincipal(opts, bearer);
+      } catch (err) {
+        if (err instanceof InvalidBearerError) {
+          res.setHeader(
+            "WWW-Authenticate",
+            `${bearerChallenge(req, opts)}, error="invalid_token"`,
+          );
+          res.status(401).json(jsonRpcError(null, -32001, "invalid bearer token"));
+          return;
+        }
+        throw err;
+      }
+      principal = resolved.value;
+      if (resolved.cacheable) cache.set(bearer, principal);
+    }
+
+    // The cold-path whoami probe is awaited, so the client may have
+    // disconnected meanwhile. Do not hand an abandoned request to the parser.
+    if (res.closed) return;
+
+    res.locals.auth = { bearer, principal } satisfies AuthenticatedContext;
+    next();
+  };
+}
+
+async function handleAuthenticatedClientRequest(
+  req: Request,
+  res: Response,
+  opts: HttpServerOptions,
+): Promise<void> {
+  const auth = res.locals.auth as AuthenticatedContext | undefined;
+  if (!auth) throw new Error("missing authenticated MCP request context");
+  const { bearer, principal } = auth;
 
   // Stateless: a fresh server + transport per request, torn down when the
   // response closes. The SDK forbids reusing a stateless transport across

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -1,4 +1,3 @@
-import { createRequire } from "node:module";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { McpClient } from "./client.js";
 import { registerMessageTools } from "./tools/messages.js";
@@ -11,17 +10,7 @@ import { registerTemplateTools } from "./tools/templates.js";
 import { registerApiKeyTools } from "./tools/apikeys.js";
 import { registerLegacyTools } from "./tools/legacy.js";
 import { toolNamesForScope } from "./tools/tiers.js";
-
-// package.json is the single source of truth for the reported MCP server
-// version (mirrors what npm publishes). createRequire lets a plain ESM
-// module (module: Node16 — no "with { type: 'json' }" import-attribute
-// syntax needed, no resolveJsonModule tsconfig flag) load JSON exactly like
-// CommonJS `require`, on every Node version the package supports (>=18).
-// "../package.json" resolves the same way from both src/server.ts (ts-node /
-// vitest) and the compiled dist/server.js (tsc's outDir mirrors rootDir one
-// level under mcp/) — both sit one directory below mcp/package.json.
-const require = createRequire(import.meta.url);
-const PACKAGE_VERSION: string = require("../package.json").version;
+import { resolveServerVersion } from "./version.js";
 
 export interface BuildServerOptions {
   client: McpClient;
@@ -47,7 +36,7 @@ function gateRegistration(server: McpServer, allowed: ReadonlySet<string>): void
   }) as McpServer["registerTool"];
 }
 
-export function buildServer({ client, version = PACKAGE_VERSION }: BuildServerOptions): McpServer {
+export function buildServer({ client, version = resolveServerVersion() }: BuildServerOptions): McpServer {
   const server = new McpServer({
     name: "e2a",
     version,

--- a/mcp/src/tools/messages.ts
+++ b/mcp/src/tools/messages.ts
@@ -476,7 +476,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
     "get_message",
     {
       title: "Get a message",
-      annotations: {},
+      annotations: { readOnlyHint: false },
       description:
         "Use after `list_messages` to read one inbound or outbound message in full; for outbound messages, this is also how you poll a send's terminal outcome. Returns text + HTML, direction, labels, delivery/review lifecycle, suspicious-message flags and protection findings, header_from, envelope_from, verified_domain, SPF/DKIM/DMARC evidence, conversation id, and attachment metadata. `truncated:true` means the inbound parser clipped the decoded body. A non-null verified_domain means DMARC passed for the RFC 5322 From domain; it does not authenticate the mailbox local part, a person, or message content. Pass the message's `id` from the list response. **Side effect:** fetching an unread inbound message marks it read — there is no peek-without-consuming and no mark-unread, so only open a message when you mean to consume it. Attachment bytes and raw MIME are intentionally omitted to protect context; the response lists each attachment's filename, content_type, 0-based `index`, and size_bytes. Call `get_attachment` with that index to fetch one file by reference.",
       inputSchema: strictInputSchema({

--- a/mcp/src/tools/messages.ts
+++ b/mcp/src/tools/messages.ts
@@ -476,7 +476,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
     "get_message",
     {
       title: "Get a message",
-      annotations: { readOnlyHint: true },
+      annotations: {},
       description:
         "Use after `list_messages` to read one inbound or outbound message in full; for outbound messages, this is also how you poll a send's terminal outcome. Returns text + HTML, direction, labels, delivery/review lifecycle, suspicious-message flags and protection findings, header_from, envelope_from, verified_domain, SPF/DKIM/DMARC evidence, conversation id, and attachment metadata. `truncated:true` means the inbound parser clipped the decoded body. A non-null verified_domain means DMARC passed for the RFC 5322 From domain; it does not authenticate the mailbox local part, a person, or message content. Pass the message's `id` from the list response. **Side effect:** fetching an unread inbound message marks it read — there is no peek-without-consuming and no mark-unread, so only open a message when you mean to consume it. Attachment bytes and raw MIME are intentionally omitted to protect context; the response lists each attachment's filename, content_type, 0-based `index`, and size_bytes. Call `get_attachment` with that index to fetch one file by reference.",
       inputSchema: strictInputSchema({

--- a/mcp/src/version.ts
+++ b/mcp/src/version.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+
+const productVersionUrl = new URL("../../VERSION", import.meta.url);
+
+/** Resolve the identity reported in the MCP initialize handshake. */
+export function resolveServerVersion(env: NodeJS.ProcessEnv = process.env): string {
+  const deployedVersion = env.MCP_SERVER_VERSION?.trim();
+  if (deployedVersion) return deployedVersion;
+
+  const productVersion = readFileSync(productVersionUrl, "utf8").trim();
+  if (!productVersion) {
+    throw new Error("root VERSION is empty; cannot determine MCP server version");
+  }
+  return productVersion;
+}

--- a/mcp/tests/http.test.ts
+++ b/mcp/tests/http.test.ts
@@ -167,28 +167,50 @@ describe("HTTP MCP server", () => {
     expect(body.error.message).toMatch(/missing bearer/);
   });
 
-  it("accepts a request body larger than 1 MB (the attachment contract), not a 413", async () => {
-    // The attachment tools advertise up to 10 MB/attachment and 25 MB total,
-    // and Streamable-HTTP is the only transport — so the body limit must clear
-    // the attachment contract. A ~2 MB body must reach the handler (→ 401 for
-    // the missing bearer here), NOT be rejected with 413 by the body parser
-    // before auth even runs.
-    const bigArg = "x".repeat(2 * 1024 * 1024); // ~2 MB, well over the old 1 MB cap
+  it("rejects a missing bearer before parsing malformed JSON", async () => {
     const res = await fetch(url, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         Accept: "application/json, text/event-stream",
       },
+      body: '{"jsonrpc":',
+    });
+
+    expect(res.status).toBe(401);
+    expect(res.headers.get("www-authenticate")).toMatch(/Bearer realm="e2a"/);
+    expect(await res.json()).toMatchObject({
+      jsonrpc: "2.0",
+      id: null,
+      error: { code: -32001, message: "missing bearer token" },
+    });
+  });
+
+  it("accepts a request body larger than 1 MB (the attachment contract), not a 413", async () => {
+    // The attachment tools advertise up to 10 MB/attachment and 25 MB total,
+    // and Streamable-HTTP is the only transport — so the body limit must clear
+    // the attachment contract. An authenticated ~2 MB body must reach the MCP
+    // handler, not be rejected with 413 by the route-local parser.
+    const bigArg = "x".repeat(2 * 1024 * 1024); // ~2 MB, well over the old 1 MB cap
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        Authorization: "Bearer e2a_test",
+      },
       body: JSON.stringify({
         jsonrpc: "2.0",
         id: 1,
-        method: "tools/call",
-        params: { name: "send_message", arguments: { big: bigArg } },
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: bigArg, version: "0" },
+        },
       }),
     });
-    expect(res.status).not.toBe(413); // pre-fix: express.json 413s before auth
-    expect(res.status).toBe(401); // body parsed → missing-bearer path reached
+    expect(res.status).toBe(200);
   });
 
   it("invalid bearer (whoami 401) is rejected with an invalid_token challenge", async () => {
@@ -233,6 +255,39 @@ describe("HTTP MCP server", () => {
     expect(invalidStub.whoami).toHaveBeenCalledOnce();
     const body = await res.json();
     expect(body.error.message).toMatch(/invalid bearer/);
+  });
+
+  it("rejects an invalid bearer before parsing malformed JSON", async () => {
+    await close();
+    const invalidStub = makeStubClient();
+    invalidStub.whoami = vi.fn(async () => {
+      throw makeHttpError(401);
+    }) as McpClient["whoami"];
+    const { close: c, port } = await startHttpServer(0, {
+      baseUrl: "http://e2a.local",
+      allowedHosts: ["127.0.0.1", "localhost"],
+      clientFactory: () => invalidStub,
+    });
+    close = c;
+    url = `http://127.0.0.1:${port}/mcp`;
+
+    const res = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        Authorization: "Bearer bogus_token",
+      },
+      body: '{"jsonrpc":',
+    });
+
+    expect(res.status).toBe(401);
+    expect(invalidStub.whoami).toHaveBeenCalledOnce();
+    expect(await res.json()).toMatchObject({
+      jsonrpc: "2.0",
+      id: null,
+      error: { code: -32001, message: "invalid bearer token" },
+    });
   });
 
   it("stateless: the initialize response carries no Mcp-Session-Id", async () => {
@@ -899,11 +954,11 @@ describe("HTTP MCP server", () => {
     expect(res.status).toBeGreaterThanOrEqual(500);
   });
 
-  it("a post-auth failure returns a JSON-RPC error without leaking a stack trace", async () => {
+  it("a pre-body authentication failure returns a JSON-RPC error without leaking a stack trace", async () => {
     // Without a terminal error middleware, Express's default finalhandler dumps
     // the error stack into the response body when NODE_ENV !== "production"
     // (bin/http never sets it) and never produces a JSON-RPC error. The factory
-    // throws during the whoami probe, so the failure surfaces post-routing.
+    // throws during the whoami probe, before the request body is parsed.
     await close();
     const { close: c, port } = await startHttpServer(0, {
       baseUrl: "http://e2a.local",
@@ -935,11 +990,12 @@ describe("HTTP MCP server", () => {
     expect(text).not.toContain("synthetic-secret-in-stack");
     expect(text).not.toContain("\n    at ");
     expect(text).not.toMatch(/http-server\.(ts|js)/);
-    // Proper JSON-RPC error envelope, request id preserved.
+    // Proper JSON-RPC error envelope. The id is intentionally null because
+    // authentication failed before the untrusted request body was parsed.
     const body = JSON.parse(text);
     expect(body.jsonrpc).toBe("2.0");
     expect(body.error).toBeTruthy();
-    expect(body.id).toBe(7);
+    expect(body.id).toBeNull();
   });
 
   it("publicUrl override drives both protected-resource metadata and WWW-Authenticate", async () => {

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -577,7 +577,7 @@ describe("e2a MCP server", () => {
       expect(byName.get(n)?.destructiveHint, `${n} destructiveHint`).toBe(false);
       expect(byName.get(n)?.readOnlyHint ?? false, `${n} not read-only`).toBe(false);
     }
-    expect(byName.get("get_message")?.readOnlyHint ?? false, "get_message not read-only").toBe(false);
+    expect(byName.get("get_message")?.readOnlyHint, "get_message not read-only").toBe(false);
   });
 
   it("send_message forwards args to client.send", async () => {

--- a/mcp/tests/tools.test.ts
+++ b/mcp/tests/tools.test.ts
@@ -555,7 +555,7 @@ describe("e2a MCP server", () => {
     }
 
     // Reads → readOnlyHint.
-    for (const n of ["list_messages", "get_message", "whoami", "list_domains", "get_event", "list_webhook_deliveries", "list_templates", "get_template", "validate_template", "list_starter_templates", "get_starter_template", "list_api_keys"]) {
+    for (const n of ["list_messages", "whoami", "list_domains", "get_event", "list_webhook_deliveries", "list_templates", "get_template", "validate_template", "list_starter_templates", "get_starter_template", "list_api_keys"]) {
       expect(byName.get(n)?.readOnlyHint, `${n} readOnlyHint`).toBe(true);
     }
     // Deletes → destructive + idempotent.
@@ -577,6 +577,7 @@ describe("e2a MCP server", () => {
       expect(byName.get(n)?.destructiveHint, `${n} destructiveHint`).toBe(false);
       expect(byName.get(n)?.readOnlyHint ?? false, `${n} not read-only`).toBe(false);
     }
+    expect(byName.get("get_message")?.readOnlyHint ?? false, "get_message not read-only").toBe(false);
   });
 
   it("send_message forwards args to client.send", async () => {

--- a/mcp/tests/version.test.ts
+++ b/mcp/tests/version.test.ts
@@ -1,22 +1,23 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import type { McpClient } from "../src/client.js";
-import { buildServer } from "../src/server.js";
 
 // Drift guard (mirrors the repo's spec-check / generate-sdk-check pattern):
-// mcp/package.json is the single source of truth for the reported MCP
-// server version. mcp/server.json (the registry manifest) and the live
-// initialize handshake's serverInfo.version must never silently diverge
-// from it. Before this test, all three disagreed (0.5.0 / 0.4.0 / 0.1.0)
-// with no shared constant — this is the in-tree gate that would have
-// caught it and prevents a future re-drift.
+// the hosted MCP server follows the product release, not the retired npm
+// package. The registry manifest matches root VERSION, while deployed images
+// may inject an immutable build identity through MCP_SERVER_VERSION.
 const mcpDir = fileURLToPath(new URL("..", import.meta.url));
+const productVersion = readFileSync(new URL("../../VERSION", import.meta.url), "utf8").trim();
 
 function readJson(relPath: string): Record<string, unknown> {
   return JSON.parse(readFileSync(`${mcpDir}${relPath}`, "utf8"));
+}
+
+function readText(relPath: string): string {
+  return readFileSync(`${mcpDir}${relPath}`, "utf8");
 }
 
 // Minimal stub — buildServer only needs `client.scope` (for §6a tool
@@ -25,20 +26,55 @@ function makeStubClient(): McpClient {
   return { scope: "account" } as unknown as McpClient;
 }
 
-describe("MCP server version — single source of truth (package.json)", () => {
-  it("server.json's version matches package.json's version", () => {
-    const pkg = readJson("package.json");
+async function reportedVersion(): Promise<{ name: string; version: string } | undefined> {
+  vi.resetModules();
+  const { buildServer } = await import("../src/server.js");
+  const server = buildServer({ client: makeStubClient() });
+  const client = new Client({ name: "version-test-client", version: "0.0.0" });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  const version = client.getServerVersion();
+  await Promise.all([client.close(), server.close()]);
+  return version;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.resetModules();
+});
+
+describe("MCP server version — product and build identity", () => {
+  it("server.json's version matches root VERSION", () => {
     const manifest = readJson("server.json");
-    expect(manifest.version).toBe(pkg.version);
+    expect(manifest.version).toBe(productVersion);
   });
 
-  it("the live initialize handshake reports package.json's version", async () => {
-    const pkg = readJson("package.json");
-    const server = buildServer({ client: makeStubClient() });
-    const client = new Client({ name: "version-test-client", version: "0.0.0" });
-    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  it("the live handshake defaults to root VERSION", async () => {
+    vi.stubEnv("MCP_SERVER_VERSION", "");
+    expect(await reportedVersion()).toEqual({ name: "e2a", version: productVersion });
+  });
 
-    expect(client.getServerVersion()).toEqual({ name: "e2a", version: pkg.version });
+  it("the live handshake prefers the injected deployment version", async () => {
+    vi.stubEnv("MCP_SERVER_VERSION", "1.0.0+sha.abcdef123456");
+    expect(await reportedVersion()).toEqual({
+      name: "e2a",
+      version: "1.0.0+sha.abcdef123456",
+    });
+  });
+
+  it("persists the injected version in the runtime image", () => {
+    const dockerfile = readText("Dockerfile");
+    expect(dockerfile).toContain("ARG MCP_SERVER_VERSION");
+    expect(dockerfile).toContain("ENV MCP_SERVER_VERSION=${MCP_SERVER_VERSION}");
+    expect(dockerfile).toContain("COPY VERSION ./VERSION");
+  });
+
+  it("passes the computed build identity into the image build", () => {
+    const workflow = readFileSync(
+      new URL("../../.github/workflows/publish-mcp-http.yml", import.meta.url),
+      "utf8",
+    );
+    expect(workflow).toContain("id: server-version");
+    expect(workflow).toContain("MCP_SERVER_VERSION=${{ steps.server-version.outputs.value }}");
   });
 });


### PR DESCRIPTION
## Summary
- mark get_message explicitly non-read-only because fetching unread inbound mail marks it read
- report product or immutable deployment build versions instead of the retired MCP npm package version
- authenticate bearer credentials before parsing the 40 MB JSON attachment envelope

## Verification
- npm test --workspace @e2a/mcp-server (232 tests)
- npm run build --workspace @e2a/mcp-server
- git diff --check origin/main...HEAD