### PR TITLE
feat(sdk-monitor): exercise message deletion on every round trip

### DIFF
--- a/tests/sdk-monitor/README.md
+++ b/tests/sdk-monitor/README.md
@@ -37,6 +37,22 @@ Anything that breaks any of those — a bad publish, a wire-contract drift, a
 packaging regression, an MCP transport change — stops that interface's
 success log line, without silencing the other four.
 
+Each round trip also **cleans up after itself through the same interface**:
+after the reply leg lands, the webhook hub trashes the probe (from B's
+inbox) and the reply (from A's inbox) via the interface named in the nonce —
+so four interfaces' `delete` paths (REST `DELETE …/messages/{id}`, the
+Python SDK's `messages.delete`, the TS SDK's `messages.delete`, and the MCP
+`delete_message` tool) are exercised every tick, and probe residue doesn't
+accumulate in the two inboxes forever. The published **CLI has no delete
+command**, so the `cli` interface's cleanup is a documented `monitor_skip`
+(`stage=cleanup`), never a substitution through another surface. Cleanup is
+deliberately decoupled from the success signal: it runs *after* the leg's
+`monitor_replied`/`monitor_ok` line, and a delete failure is a
+`monitor_error(stage=cleanup)` — never a 5xx that would redeliver the
+webhook and double-count the leg. Deletion is the soft (trash) path; the
+*sent* copies in the opposite folders are out of scope (the service is
+stateless — the send-side ids would have to ride in the nonce).
+
 ### Handlers
 
 - **`POST /tick`** (Cloud Scheduler, ~5 min). Fires ONE outbound leg PER
@@ -59,9 +75,11 @@ success log line, without silencing the other four.
   regardless of which interface the nonce names. It ignores non-
   `email.received` types, then branches on which agent received the mail:
   delivered to **B** → reply **via the interface named in the nonce** (so
-  each interface's reply/threading path is exercised too, not just send);
-  delivered to **A** → that's the reply coming home, emit the success line
-  with that interface's key.
+  each interface's reply/threading path is exercised too, not just send),
+  then trash the probe from B's inbox via that same interface; delivered to
+  **A** → that's the reply coming home, emit the success line with that
+  interface's key, then trash the reply from A's inbox (same interface
+  again). Both deletes are best-effort cleanup — see "What it exercises".
 - **`GET /health`** — liveness.
 
 The service is **stateless** across requests. Cloud Run scales to zero, so
@@ -153,9 +171,10 @@ labeled by `iface`:
 | `monitor_ok` | Round trip completed for `iface`. **Alert on the absence of this, per iface.** `latency_ms` is the metric. |
 | `monitor_tick` | Outbound leg sent for `iface`. |
 | `monitor_replied` | Inbound leg received and replied to, via `iface`. |
+| `monitor_deleted` | Cleanup done for `iface`: the leg's message was trashed via `iface` (carries `inbox` + `message_id`). |
 | `monitor_stale` | A probe arrived past `MAX_AGE_MS` on `leg` (`outbound` or `reply`) for `iface`; not a success. |
-| `monitor_skip` | `iface` was skipped this tick because its config is absent (currently only `mcp` without `E2A_MONITOR_MCP_URL`). |
-| `monitor_error` | Failure, with `stage` = `config` \| `send` \| `signature` \| `hydrate` \| `reply` \| `unknown_iface` \| `nonce_auth`, and (where applicable) `iface`. A `send`/`reply` failure includes a held (`pending_review`), terminal-`failed`, or unrecognized send-response `status` — see "Uniform send-status handling" below. |
+| `monitor_skip` | `iface` was skipped this tick because its config is absent (`stage=send`, currently only `mcp` without `E2A_MONITOR_MCP_URL`), or its cleanup was skipped because the interface's published client has no delete verb (`stage=cleanup`, currently always `cli`). |
+| `monitor_error` | Failure, with `stage` = `config` \| `send` \| `signature` \| `hydrate` \| `reply` \| `cleanup` \| `unknown_iface` \| `nonce_auth`, and (where applicable) `iface`. A `send`/`reply` failure includes a held (`pending_review`), terminal-`failed`, or unrecognized send-response `status` — see "Uniform send-status handling" below. A `cleanup` failure means the round trip succeeded (its `monitor_replied`/`monitor_ok` was already logged) but the trash step failed — hygiene, not an outage. |
 | `monitor_start` | Process start; lists the configured `ifaces` and whether `mcp` is configured. |
 
 Secret values are never logged — only env var *names* on a config failure. A
@@ -283,19 +302,24 @@ status-code semantics (all-ok → 200, one optional interface skipped but the
 rest ok → 200, partial failure → 207, total outage across every considered
 interface → 500), uniform non-`sent`/`accepted` send-status handling across
 every offline-exercisable interface (a stubbed `pending_review`/`failed`
-response raises immediately rather than logging success-shaped), the wire
-shape of the `api`/`ts_sdk`/`cli` strategies (argv/URL/headers, and that
-secrets never land in argv), the minimal subprocess environment (the full
-parent env, including the webhook secret, is never handed to a node/CLI
-child), and `McpStrategy`'s JSON-RPC response parsing (SSE framing, a
-JSON-RPC error, a tool-level `isError`, a leading notification or
-mismatched-id frame that must be skipped rather than mistaken for the real
-response, and the malformed-response guard). Every interface's actual
-send/reply I/O is stubbed with fakes injected into `monitor.STRATEGIES`, or
-with `urllib.request.urlopen` / `subprocess.run` monkeypatched to
-capture/replay a call — no real network call, no real subprocess to
-node/npm. The live round trips are only exercisable against a real
-deployment with a reachable webhook URL.
+response raises immediately rather than logging success-shaped), the cleanup
+behavior on both legs (the probe/reply is trashed via the nonce's own
+interface after the leg's success marker, a delete failure logs
+`stage=cleanup` without revoking `monitor_ok`/`monitor_replied` or the 200,
+and a delete-less interface is a `monitor_skip`, not an error), the wire
+shape of the `api`/`python_sdk`/`ts_sdk`/`cli`/`mcp` strategies for
+send/reply AND delete (argv/URL/headers/tool-arguments, `deleted:true`
+receipt validation, and that secrets never land in argv), the minimal
+subprocess environment (the full parent env, including the webhook secret,
+is never handed to a node/CLI child), and `McpStrategy`'s JSON-RPC response
+parsing (SSE framing, a JSON-RPC error, a tool-level `isError`, a leading
+notification or mismatched-id frame that must be skipped rather than
+mistaken for the real response, and the malformed-response guard). Every
+interface's actual send/reply/delete I/O is stubbed with fakes injected into
+`monitor.STRATEGIES`, or with `urllib.request.urlopen` / `subprocess.run`
+monkeypatched to capture/replay a call — no real network call, no real
+subprocess to node/npm. The live round trips are only exercisable against a
+real deployment with a reachable webhook URL.
 
 ## Design decisions to review
 

--- a/tests/sdk-monitor/js/monitor-helper.mjs
+++ b/tests/sdk-monitor/js/monitor-helper.mjs
@@ -13,6 +13,7 @@
 // Usage:
 //   node monitor-helper.mjs send <fromAgent> <toAgent> <subject> <body>
 //   node monitor-helper.mjs reply <inboxAgent> <messageId> <text> <idempotencyKey>
+//   node monitor-helper.mjs delete <inboxAgent> <messageId>
 
 import { E2AClient } from "@e2a/sdk/v1";
 
@@ -70,6 +71,22 @@ async function main() {
     const result = await client.messages.reply(inbox, messageId, { text }, opts);
     process.stdout.write(JSON.stringify(result) + "\n");
     checkSendStatus(result);
+    return;
+  }
+  if (cmd === "delete") {
+    const [inbox, messageId] = args;
+    if (!inbox || !messageId) {
+      fail("usage: monitor-helper.mjs delete <inbox> <message-id>");
+    }
+    const result = await client.messages.delete(inbox, messageId);
+    process.stdout.write(JSON.stringify(result) + "\n");
+    // The receipt is DeleteMessageResult ({deleted:true, id}) — anything else
+    // is a contract drift the parent monitor should see as a non-zero exit,
+    // same discipline as checkSendStatus on the send/reply paths.
+    if (result?.deleted !== true) {
+      process.stderr.write(`unexpected delete receipt: ${JSON.stringify(result)}\n`);
+      process.exitCode = 1;
+    }
     return;
   }
   fail(`unknown command: ${cmd ?? "(none)"}`);

--- a/tests/sdk-monitor/monitor.py
+++ b/tests/sdk-monitor/monitor.py
@@ -28,7 +28,9 @@ message subject, which now also carries which interface sent it:
                     "probe <nonce>"; nonce embeds the interface, the send
                     time, and randomness
     POST /webhook   email.received on B -> reply (via the SAME interface the
-                    nonce names); email.received on A -> success
+                    nonce names), then trash the probe; email.received on A
+                    -> success, then trash the reply (cleanup is best-effort
+                    and decoupled from the success signal — see _cleanup)
     GET  /health    liveness
 
 Success is a structured log line (``monitor_ok``) carrying `iface` and the
@@ -173,11 +175,19 @@ def _check_send_status(iface: str, status: object) -> None:
 # --------------------------------------------------------------------------
 # Interface strategies.
 #
-# Each interface implements the same two operations, uniform across all five
-# so the webhook hub can dispatch on the iface name alone:
+# Each interface implements the same three operations, uniform across all
+# five so the webhook hub can dispatch on the iface name alone:
 #
 #   send(agent_a, agent_b, subject, body) -> None    # outbound leg
 #   reply(inbox, message_id, text, idempotency_key) -> None   # inbound leg
+#   delete(inbox, message_id) -> None                # cleanup (trash the
+#                                                    # probe/reply message)
+#
+# supports_delete() reports whether the interface's published client HAS a
+# delete verb at all — the published @e2a/cli has no delete command, so the
+# cli interface reports False and its cleanup is a documented skip, never a
+# silent substitution through another surface (which would mask the missing
+# capability).
 #
 # None of the five ever sets a subject on reply: every wire shape (REST
 # ReplyRequest, the SDKs' reply(), the CLI's `reply`, the MCP
@@ -195,6 +205,10 @@ class Interface(Protocol):
         self, *, inbox: str, message_id: str, text: str, idempotency_key: str
     ) -> None: ...
 
+    def supports_delete(self) -> bool: ...
+
+    def delete(self, *, inbox: str, message_id: str) -> None: ...
+
 
 class ApiStrategy:
     """Raw HTTP against the server API — no SDK. Exercises the wire contract
@@ -209,11 +223,19 @@ class ApiStrategy:
     def available(self) -> bool:
         return True  # core interface; required config already gates startup
 
-    def _request(self, path: str, body: dict, idempotency_key: Optional[str] = None) -> dict:
+    def _request(
+        self,
+        path: str,
+        body: Optional[dict] = None,
+        method: str = "POST",
+        idempotency_key: Optional[str] = None,
+    ) -> dict:
         url = f"{self._base_url}{path}"
-        req = urllib.request.Request(url, data=json.dumps(body).encode(), method="POST")
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(url, data=data, method=method)
         req.add_header("Authorization", f"Bearer {self._api_key}")
-        req.add_header("Content-Type", "application/json")
+        if data is not None:
+            req.add_header("Content-Type", "application/json")
         req.add_header("User-Agent", USER_AGENT)
         if idempotency_key:
             req.add_header("Idempotency-Key", idempotency_key)
@@ -243,6 +265,21 @@ class ApiStrategy:
         result = self._request(path, {"text": text}, idempotency_key=idempotency_key)
         _check_send_status("api", result.get("status"))
 
+    def supports_delete(self) -> bool:
+        return True
+
+    def delete(self, *, inbox: str, message_id: str) -> None:
+        path = (
+            f"/v1/agents/{urllib.parse.quote(inbox, safe='')}"
+            f"/messages/{urllib.parse.quote(message_id, safe='')}"
+        )
+        result = self._request(path, method="DELETE")
+        # The receipt is DeleteMessageResult ({deleted:true, id}) — a 200 with
+        # anything else is a contract drift worth failing on, same discipline
+        # as _check_send_status on the send path.
+        if result.get("deleted") is not True:
+            raise RuntimeError(f"api delete returned an unexpected receipt: {result!r}")
+
 
 class PythonSdkStrategy:
     """The published `e2a` PyPI package — today's original path."""
@@ -259,6 +296,14 @@ class PythonSdkStrategy:
             inbox, message_id, {"text": text}, idempotency_key=idempotency_key
         )
         _check_send_status("python_sdk", getattr(result, "status", None))
+
+    def supports_delete(self) -> bool:
+        return True
+
+    def delete(self, *, inbox: str, message_id: str) -> None:
+        result = client().messages.delete(inbox, message_id)
+        if getattr(result, "deleted", None) is not True:
+            raise RuntimeError(f"python_sdk delete returned an unexpected receipt: {result!r}")
 
 
 # Fixed id shared by every send/reply JSON-RPC request this service makes.
@@ -370,11 +415,13 @@ class McpStrategy:
         return result
 
     @staticmethod
-    def _result_status(result: dict) -> Optional[str]:
-        """The tool's success text block is a JSON-stringified SendResultView
-        (mcp/src/tools/util.ts's runTool + toMcpOutput) — pull `status` out of
-        it so a held/failed send can be treated as a failure here too, not
-        just on the api/python_sdk/ts_sdk interfaces."""
+    def _result_json(result: dict) -> Optional[dict]:
+        """The tool's success text block is a JSON-stringified view
+        (mcp/src/tools/util.ts's runTool + toMcpOutput) — a SendResultView on
+        send/reply, a DeleteMessageResult on delete. Pull the parsed payload
+        out so callers can check `status` / `deleted` and treat a held/failed
+        or unreceipted outcome as a failure here too, not just on the
+        api/python_sdk/ts_sdk interfaces."""
         for block in result.get("content") or []:
             if isinstance(block, dict) and block.get("type") == "text":
                 try:
@@ -382,7 +429,7 @@ class McpStrategy:
                 except ValueError:
                     return None
                 if isinstance(payload, dict):
-                    return payload.get("status")
+                    return payload
         return None
 
     def send(self, *, agent_a: str, agent_b: str, subject: str, body: str) -> None:
@@ -390,7 +437,7 @@ class McpStrategy:
             "send_message",
             {"to": [agent_b], "subject": subject, "text": body, "email": agent_a},
         )
-        _check_send_status("mcp", self._result_status(result))
+        _check_send_status("mcp", (self._result_json(result) or {}).get("status"))
 
     def reply(self, *, inbox: str, message_id: str, text: str, idempotency_key: str) -> None:
         result = self._call(
@@ -402,7 +449,18 @@ class McpStrategy:
                 "idempotency_key": idempotency_key,
             },
         )
-        _check_send_status("mcp", self._result_status(result))
+        _check_send_status("mcp", (self._result_json(result) or {}).get("status"))
+
+    def supports_delete(self) -> bool:
+        return True
+
+    def delete(self, *, inbox: str, message_id: str) -> None:
+        result = self._call(
+            "delete_message",
+            {"message_id": message_id, "email": inbox, "confirm": True},
+        )
+        if (self._result_json(result) or {}).get("deleted") is not True:
+            raise RuntimeError("mcp delete_message returned an unexpected receipt")
 
 
 # The full parent environment is never handed to a child: it would carry
@@ -470,6 +528,12 @@ class TsSdkStrategy:
             self._env,
         )
 
+    def supports_delete(self) -> bool:
+        return True
+
+    def delete(self, *, inbox: str, message_id: str) -> None:
+        _run_subprocess(["node", NODE_HELPER, "delete", inbox, message_id], self._env)
+
 
 class CliStrategy:
     """The published `@e2a/cli` npm package's `e2a` bin, invoked directly
@@ -505,6 +569,16 @@ class CliStrategy:
             self._env,
         )
 
+    def supports_delete(self) -> bool:
+        # The published @e2a/cli (cli/src/commands/) has no delete command.
+        # Cleanup for this interface is a documented skip (monitor_skip,
+        # stage=cleanup) — never a silent substitution through another
+        # interface's surface, which would mask the missing capability.
+        return False
+
+    def delete(self, *, inbox: str, message_id: str) -> None:
+        raise RuntimeError("cli interface has no delete command (supports_delete is False)")
+
 
 def _build_strategies() -> dict:
     return {
@@ -520,6 +594,31 @@ def _build_strategies() -> dict:
 # Correlation state (which round trip is in flight) still lives entirely in
 # the message subject, never here.
 STRATEGIES: dict = _build_strategies()
+
+
+def _cleanup(strategy: Interface, iface: str, nonce: str, *, inbox: str, message_id: str) -> None:
+    """Best-effort trash of one round-trip message via the SAME interface
+    that carried the leg — each interface's delete path is exercised every
+    tick, and probe/reply residue doesn't accumulate in the two inboxes
+    forever (trash purges after the retention window; the *sent* copies in
+    the opposite folders are out of scope — the service is stateless and the
+    send-side ids would have to ride in the nonce).
+
+    Cleanup is deliberately decoupled from the success signal: the leg's
+    monitor_replied/monitor_ok line is logged BEFORE this runs, so a delete
+    failure is a monitor_error(stage=cleanup), never a 5xx — a webhook
+    redelivery must not fan out duplicate replies or double-count a success
+    for what is only a hygiene failure. An interface without a delete verb
+    (cli) is a documented skip, not an error."""
+    if not strategy.supports_delete():
+        log("monitor_skip", stage="cleanup", iface=iface, detail="interface has no delete verb")
+        return
+    try:
+        strategy.delete(inbox=inbox, message_id=message_id)
+    except Exception as exc:  # noqa: BLE001 - cleanup failure is a signal, not a crash
+        log("monitor_error", stage="cleanup", iface=iface, nonce=nonce, error=type(exc).__name__, detail=str(exc))
+        return
+    log("monitor_deleted", iface=iface, nonce=nonce, inbox=inbox, message_id=message_id)
 
 
 def handle_tick() -> tuple[int, dict]:
@@ -657,6 +756,8 @@ def handle_webhook(raw_body: bytes, signature: str) -> tuple[int, dict]:
             log("monitor_error", stage="reply", iface=iface, nonce=nonce, error=type(exc).__name__, detail=str(exc))
             return 500, {"ok": False, "stage": "reply"}
         log("monitor_replied", iface=iface, nonce=nonce, age_ms=age_ms)
+        # Reply succeeded — trash the probe sitting in B's inbox.
+        _cleanup(strategy, iface, nonce, inbox=AGENT_B, message_id=email.id)
         return 200, {"ok": True, "leg": "outbound"}
 
     if inbox == AGENT_A.lower():
@@ -666,6 +767,8 @@ def handle_webhook(raw_body: bytes, signature: str) -> tuple[int, dict]:
             log("monitor_stale", leg="reply", iface=iface, nonce=nonce, age_ms=age_ms)
             return 200, {"ok": True, "stale": True}
         log("monitor_ok", iface=iface, nonce=nonce, latency_ms=age_ms, message_id=email.id)
+        # Success is logged — trash the reply sitting in A's inbox.
+        _cleanup(strategy, iface, nonce, inbox=AGENT_A, message_id=email.id)
         return 200, {"ok": True, "leg": "reply", "iface": iface, "latency_ms": age_ms}
 
     return 200, {"ok": True, "ignored": "unknown inbox"}

--- a/tests/sdk-monitor/test_monitor.py
+++ b/tests/sdk-monitor/test_monitor.py
@@ -12,15 +12,20 @@ even match), the stale-reply guard (both legs), the interface-strategy
 dispatch, the unknown-iface safety net, the /tick aggregate + status-code
 semantics (all-ok / partial / total-outage / an optional interface skipped),
 uniform non-success send-status handling across every offline-exercisable
-interface, the wire shape of the api/ts_sdk/cli strategies (argv/URL/headers,
-and that secrets never land in argv), the minimal subprocess environment, and
-McpStrategy's JSON-RPC response parsing (SSE framing, a JSON-RPC error, a
-tool-level isError, a leading notification/mismatched-id frame that must be
-skipped rather than mistaken for our response, and the malformed-response
-guard). Every interface's actual send/reply I/O is stubbed with fakes
+interface, the cleanup (message-deletion) behavior on both legs (trash via
+the nonce's own interface AFTER the leg's success marker, a cleanup failure
+never revoking monitor_ok/monitor_replied, and a delete-less interface being
+a documented monitor_skip rather than an error), the wire shape of the
+api/python_sdk/ts_sdk/cli/mcp strategies for send/reply AND delete
+(argv/URL/headers/tool-arguments, receipt validation, and that secrets never
+land in argv), the minimal subprocess environment, and McpStrategy's
+JSON-RPC response parsing (SSE framing, a JSON-RPC error, a tool-level
+isError, a leading notification/mismatched-id frame that must be skipped
+rather than mistaken for our response, and the malformed-response guard).
+Every interface's actual send/reply/delete I/O is stubbed with fakes
 injected into monitor.STRATEGIES, or with urllib.request.urlopen /
-subprocess.run monkeypatched to capture/replay a call — no real network call,
-no real subprocess to node/npm.
+subprocess.run monkeypatched to capture/replay a call — no real network
+call, no real subprocess to node/npm.
 """
 
 import hashlib
@@ -149,6 +154,7 @@ class FakeStrategy:
     def __init__(self):
         self.send_calls = []
         self.reply_calls = []
+        self.delete_calls = []
 
     def available(self):
         return True
@@ -158,6 +164,12 @@ class FakeStrategy:
 
     def reply(self, **kwargs):
         self.reply_calls.append(kwargs)
+
+    def supports_delete(self):
+        return True
+
+    def delete(self, **kwargs):
+        self.delete_calls.append(kwargs)
 
 
 class FakeEmail:
@@ -359,6 +371,120 @@ check("unknown iface never emits monitor_ok", "monitor_ok" in emitted_events(), 
 
 
 # ---------------------------------------------------------------------------
+# Cleanup (message deletion): each leg trashes its message via the SAME
+# interface, AFTER the leg's success marker — a hygiene/coverage step that is
+# deliberately decoupled from the round-trip success signal.
+# ---------------------------------------------------------------------------
+
+
+class CleanupStrategy(FakeStrategy):
+    def __init__(self, fail_delete=False, delete_supported=True):
+        super().__init__()
+        self.fail_delete = fail_delete
+        self._delete_supported = delete_supported
+
+    def supports_delete(self):
+        return self._delete_supported
+
+    def delete(self, **kwargs):
+        super().delete(**kwargs)
+        if self.fail_delete:
+            raise RuntimeError("delete boom")
+
+
+# B leg: after the reply is dispatched, the probe in B's inbox is trashed via
+# the nonce's own interface, logged as monitor_deleted, after monitor_replied.
+cleanup_ts = CleanupStrategy()
+monitor._client = FakeClientB()
+monitor.STRATEGIES = {iface: FakeStrategy() for iface in monitor.IFACES}
+monitor.STRATEGIES["ts_sdk"] = cleanup_ts
+FakeEmailB.subject = f"probe {make_nonce('ts_sdk', int(time.time() * 1000) - 100)}"
+emitted.clear()
+status, payload = monitor.handle_webhook(inbound_body_b, sign(inbound_body_b))
+check("cleanup (B leg) returns 200", status, 200)
+check("cleanup (B leg) still dispatches the reply first", len(cleanup_ts.reply_calls), 1)
+check("cleanup (B leg) deletes via the nonce's own iface", len(cleanup_ts.delete_calls), 1)
+_del_kwargs = cleanup_ts.delete_calls[0]
+check(
+    "cleanup (B leg) deletes the probe from B's inbox",
+    (_del_kwargs.get("inbox"), _del_kwargs.get("message_id")),
+    (monitor.AGENT_B, "msg_fresh_b"),
+)
+check(
+    "cleanup (B leg) does not delete via other ifaces",
+    sum(len(s.delete_calls) for k, s in monitor.STRATEGIES.items() if k != "ts_sdk"),
+    0,
+)
+check("cleanup (B leg) logs monitor_deleted", any(e == "monitor_deleted" and f.get("iface") == "ts_sdk" for e, f in emitted), True)
+check(
+    "cleanup (B leg) runs after monitor_replied",
+    [e for e, _ in emitted].index("monitor_replied") < [e for e, _ in emitted].index("monitor_deleted"),
+    True,
+)
+
+# A leg: after monitor_ok, the reply in A's inbox is trashed the same way.
+cleanup_py = CleanupStrategy()
+monitor._client = FakeClient()
+monitor.STRATEGIES = {iface: FakeStrategy() for iface in monitor.IFACES}
+monitor.STRATEGIES["python_sdk"] = cleanup_py
+FakeEmail.subject = f"Re: probe {make_nonce('python_sdk', int(time.time() * 1000) - 3000)}"
+emitted.clear()
+status, payload = monitor.handle_webhook(inbound_body, sign(inbound_body))
+check("cleanup (A leg) returns 200", status, 200)
+check("cleanup (A leg) still emits monitor_ok", "monitor_ok" in emitted_events(), True)
+check("cleanup (A leg) deletes via the nonce's own iface", len(cleanup_py.delete_calls), 1)
+check(
+    "cleanup (A leg) deletes the reply from A's inbox",
+    (cleanup_py.delete_calls[0].get("inbox"), cleanup_py.delete_calls[0].get("message_id")),
+    (monitor.AGENT_A, FakeEmail.id),
+)
+check(
+    "cleanup (A leg) runs after monitor_ok",
+    [e for e, _ in emitted].index("monitor_ok") < [e for e, _ in emitted].index("monitor_deleted"),
+    True,
+)
+
+# A cleanup failure is decoupled from the success signal: 200, monitor_ok
+# stands, stage=cleanup error logged, no monitor_deleted.
+failing_cleanup = CleanupStrategy(fail_delete=True)
+monitor.STRATEGIES = {iface: FakeStrategy() for iface in monitor.IFACES}
+monitor.STRATEGIES["python_sdk"] = failing_cleanup
+emitted.clear()
+status, payload = monitor.handle_webhook(inbound_body, sign(inbound_body))
+check("cleanup failure (A leg) still returns 200", status, 200)
+check("cleanup failure (A leg) still emits monitor_ok", "monitor_ok" in emitted_events(), True)
+check(
+    "cleanup failure (A leg) logs stage=cleanup",
+    any(e == "monitor_error" and f.get("stage") == "cleanup" and f.get("iface") == "python_sdk" for e, f in emitted),
+    True,
+)
+check("cleanup failure (A leg) does not log monitor_deleted", "monitor_deleted" in emitted_events(), False)
+
+# An interface without a delete verb (cli): cleanup is a documented skip, not
+# an error — the reply is still dispatched and no delete is attempted.
+no_delete_cleanup = CleanupStrategy(delete_supported=False)
+monitor._client = FakeClientB()
+monitor.STRATEGIES = {iface: FakeStrategy() for iface in monitor.IFACES}
+monitor.STRATEGIES["cli"] = no_delete_cleanup
+FakeEmailB.subject = f"probe {make_nonce('cli', int(time.time() * 1000) - 100)}"
+emitted.clear()
+status, payload = monitor.handle_webhook(inbound_body_b, sign(inbound_body_b))
+check("cleanup-unsupported iface still replies and returns 200", status, 200)
+check("cleanup-unsupported iface dispatches the reply", len(no_delete_cleanup.reply_calls), 1)
+check("cleanup-unsupported iface does not attempt a delete", no_delete_cleanup.delete_calls, [])
+check(
+    "cleanup-unsupported iface logs monitor_skip stage=cleanup",
+    any(e == "monitor_skip" and f.get("stage") == "cleanup" and f.get("iface") == "cli" for e, f in emitted),
+    True,
+)
+check(
+    "cleanup-unsupported iface does not log a cleanup error",
+    any(e == "monitor_error" and f.get("stage") == "cleanup" for e, f in emitted),
+    False,
+)
+
+
+# ---------------------------------------------------------------------------
 # /tick aggregate + status-code semantics (FIX 2): the aggregate is computed
 # over non-skipped ("considered") interfaces only, and the HTTP status
 # distinguishes all-ok / partial / total outage for Cloud Scheduler.
@@ -548,6 +674,52 @@ check("python_sdk strategy does not raise on status=accepted", _py_ok, True)
 monitor._client = _saved_client
 
 
+# python_sdk delete: client.messages.delete(inbox, message_id) with the
+# DeleteMessageResult receipt validated.
+class _FakeDeleteReceipt:
+    def __init__(self, deleted):
+        self.deleted = deleted
+
+
+class _FakeDeleteMessages:
+    def __init__(self, deleted):
+        self._deleted = deleted
+        self.delete_calls = []
+
+    def delete(self, *a, **k):
+        self.delete_calls.append((a, k))
+        return _FakeDeleteReceipt(self._deleted)
+
+
+class _FakePySdkDeleteClient:
+    def __init__(self, deleted):
+        self.messages = _FakeDeleteMessages(deleted)
+
+
+_saved_client = monitor._client
+monitor._client = _FakePySdkDeleteClient(True)
+try:
+    _py.delete(inbox="mon-b@agents.e2a.dev", message_id="msg_abc")
+    _py_del_ok = True
+except Exception:
+    _py_del_ok = False
+check("python_sdk strategy accepts a deleted:true receipt", _py_del_ok, True)
+check(
+    "python_sdk delete calls client.messages.delete(inbox, message_id)",
+    monitor._client.messages.delete_calls,
+    [(("mon-b@agents.e2a.dev", "msg_abc"), {})],
+)
+
+monitor._client = _FakePySdkDeleteClient(False)
+try:
+    _py.delete(inbox="mon-b@agents.e2a.dev", message_id="msg_abc")
+    _py_del_raised = False
+except RuntimeError:
+    _py_del_raised = True
+check("python_sdk strategy raises on a non-deleted receipt", _py_del_raised, True)
+monitor._client = _saved_client
+
+
 # --- mcp ---
 def _mcp_sse_for_status(status):
     text = json.dumps({"status": status, "message_id": "msg_x"})
@@ -710,6 +882,29 @@ check(
 check("ApiStrategy.reply sends Idempotency-Key", header(_req.headers, "Idempotency-Key"), "sdkmon:evt_1")
 check("ApiStrategy.reply body shape is text-only (ReplyRequest has no subject)", json.loads(_req.data.decode()), {"text": "nonce123"})
 
+# ApiStrategy.delete: DELETE /v1/agents/{email}/messages/{id}, no body, and
+# the DeleteMessageResult receipt ({deleted:true, id}) is validated.
+_urllib_request.urlopen = _capturing_urlopen({"deleted": True, "id": "msg_abc"})
+_captured_requests.clear()
+_api_wire.delete(inbox="mon-b@agents.e2a.dev", message_id="msg_abc")
+_req = _captured_requests[-1]
+check("ApiStrategy.delete method is DELETE", _req.method, "DELETE")
+check(
+    "ApiStrategy.delete URL is .../messages/{id}",
+    _req.full_url,
+    "https://api.e2a.dev/v1/agents/mon-b%40agents.e2a.dev/messages/msg_abc",
+)
+check("ApiStrategy.delete sends no body", _req.data, None)
+check("ApiStrategy.delete sends Authorization: Bearer <key>", header(_req.headers, "Authorization"), "Bearer e2a_acct_secret")
+
+_urllib_request.urlopen = _capturing_urlopen({"deleted": False, "id": "msg_abc"})
+try:
+    _api_wire.delete(inbox="mon-b@agents.e2a.dev", message_id="msg_abc")
+    _api_del_raised = False
+except RuntimeError:
+    _api_del_raised = True
+check("ApiStrategy.delete raises on a non-deleted receipt", _api_del_raised, True)
+
 _urllib_request.urlopen = _saved_urlopen
 
 
@@ -753,6 +948,16 @@ check(
     ["reply", "mon-a@agents.e2a.dev", "msg_abc", "x", "sdkmon:evt_1"],
 )
 
+_captured_calls.clear()
+_ts_wire.delete(inbox="mon-b@agents.e2a.dev", message_id="msg_abc")
+_call = _captured_calls[-1]
+check(
+    "TsSdkStrategy.delete passes delete + positional args",
+    _call["argv"][2:],
+    ["delete", "mon-b@agents.e2a.dev", "msg_abc"],
+)
+check("TsSdkStrategy.delete secret never appears in argv", any("e2a_acct_secret" in a for a in _call["argv"]), False)
+
 _cli_wire = monitor.CliStrategy("https://api.e2a.dev", "e2a_acct_secret")
 _captured_calls.clear()
 _cli_wire.send(agent_a="mon-a@agents.e2a.dev", agent_b="mon-b@agents.e2a.dev", subject="probe x", body="x")
@@ -777,6 +982,17 @@ check(
     _call["argv"][2:],
     ["reply", "msg_abc", "--body", "x", "--agent", "mon-a@agents.e2a.dev", "--idempotency-key", "sdkmon:evt_1", "--json"],
 )
+
+# The published CLI has no delete command: CliStrategy must report no delete
+# support (so cleanup is a documented skip) and its delete() must never be
+# silently wired to some other verb.
+check("CliStrategy reports no delete support", _cli_wire.supports_delete(), False)
+try:
+    _cli_wire.delete(inbox="mon-b@agents.e2a.dev", message_id="msg_abc")
+    _cli_del_raised = False
+except RuntimeError:
+    _cli_del_raised = True
+check("CliStrategy.delete raises (no delete verb in the published CLI)", _cli_del_raised, True)
 
 monitor.subprocess.run = _saved_subprocess_run
 
@@ -864,6 +1080,47 @@ try:
 except RuntimeError:
     _mcp_only_mismatched_raised = True
 check("mcp strategy raises when no frame matches our request id", _mcp_only_mismatched_raised, True)
+
+_urllib_request.urlopen = _saved_urlopen
+
+
+# McpStrategy.delete: the delete_message tool call's wire shape (name +
+# message_id/email/confirm:true arguments) and receipt validation.
+def _mcp_sse_for_payload(payload: dict):
+    env = {"jsonrpc": "2.0", "id": 1, "result": {"content": [{"type": "text", "text": json.dumps(payload)}]}}
+    return f"data: {json.dumps(env)}\n\n"
+
+
+_captured_mcp_requests = []
+
+
+def _capturing_urlopen_sse(sse_body: str):
+    def _fake_urlopen(req, timeout=None):
+        _captured_mcp_requests.append(_CapturedRequest(req))
+        return _FakeResponse(sse_body.encode(), "text/event-stream")
+
+    return _fake_urlopen
+
+
+_mcp_wire = monitor.McpStrategy("https://mcp.example/mcp", "e2a_acct_test")
+_urllib_request.urlopen = _capturing_urlopen_sse(_mcp_sse_for_payload({"deleted": True, "id": "msg_abc"}))
+_captured_mcp_requests.clear()
+_mcp_wire.delete(inbox="mon-b@agents.e2a.dev", message_id="msg_abc")
+_mcp_payload = json.loads(_captured_mcp_requests[-1].data.decode())
+check("McpStrategy.delete calls the delete_message tool", _mcp_payload["params"]["name"], "delete_message")
+check(
+    "McpStrategy.delete passes message_id + email + confirm:true",
+    _mcp_payload["params"]["arguments"],
+    {"message_id": "msg_abc", "email": "mon-b@agents.e2a.dev", "confirm": True},
+)
+
+_urllib_request.urlopen = _stub_urlopen(_mcp_sse_for_payload({"unexpected": "receipt"}))
+try:
+    _mcp_wire.delete(inbox="mon-b@agents.e2a.dev", message_id="msg_abc")
+    _mcp_del_raised = False
+except RuntimeError:
+    _mcp_del_raised = True
+check("McpStrategy.delete raises on a non-deleted receipt", _mcp_del_raised, True)
 
 _urllib_request.urlopen = _saved_urlopen
 


### PR DESCRIPTION
## What

Every sdk-monitor round trip now **exercises message deletion through the same interface** that carried the leg, and cleans up after itself:

- **B leg** (probe delivered): after the reply is dispatched, the probe is trashed from B's inbox via the nonce's interface.
- **A leg** (reply home): after `monitor_ok` is logged, the reply is trashed from A's inbox, same interface.

Per-interface delete coverage added: `api` (raw REST `DELETE /v1/agents/{email}/messages/{id}`), `python_sdk` (`client.messages.delete`), `mcp` (`delete_message` with `confirm:true`), `ts_sdk` (new `delete` subcommand in `js/monitor-helper.mjs`).

**`cli` is a documented skip** — the published `@e2a/cli` has no delete command, so `CliStrategy.supports_delete()` is `false` and cleanup logs `monitor_skip(stage=cleanup)` instead of silently substituting another surface (which would mask the missing capability).

## Design decisions

- **Cleanup is decoupled from the success signal.** It runs *after* the leg's `monitor_replied`/`monitor_ok` line; a delete failure logs `monitor_error(stage=cleanup)` and the webhook still returns 200 — a 5xx would redeliver the webhook and double-count the leg for what is only a hygiene failure.
- **Receipt validation everywhere.** Each interface checks the `{deleted:true}` receipt (raises otherwise), same discipline as the existing send-status checks — a contract drift fails loudly.
- **Soft delete only.** The trash path purges after the retention window; the *sent* copies in the opposite folders are out of scope (the service is stateless — the send-side ids would have to ride in the nonce).

## Why

- Covers the `delete` path on four client surfaces every 5 minutes — previously untested by the canary.
- Stops probe/reply residue accumulating in the monitor inboxes (~8.6k messages/month).

## Testing

`test_monitor.py` (offline, no pytest): **168 checks pass** — both-leg cleanup dispatch and ordering (after the success marker), failure decoupling (cleanup failure never revokes `monitor_ok`/`monitor_replied` or the 200), cli skip, and wire shapes for all five strategies (argv/URL/tool-arguments, receipt validation, secrets never in argv).

README updated: "What it exercises", `/webhook` handler description, log-markers table (`monitor_deleted`, `stage=cleanup`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
