### PR TITLE
feat(web): show sidebar unread count

### DIFF
--- a/docs/superpowers/plans/2026-07-22-sidebar-inboxes-unread-count.md
+++ b/docs/superpowers/plans/2026-07-22-sidebar-inboxes-unread-count.md
@@ -1,0 +1,343 @@
+# Sidebar Inboxes Unread Count Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show the account-wide unread inbound-message count beside the Sidebar's Inboxes entry, using the same accent pill as Pending and displaying `99+` for larger totals.
+
+**Architecture:** Add one SWR hook that lists the user's inboxes, fetches each existing per-inbox unread rollup in parallel, and projects those results into a capped account total. Give that aggregate its own cache key, refresh it with the existing 15-second unread polling policy, and invalidate it whenever the current per-inbox unread cache is invalidated. Sidebar remains presentation-only and selects either the Inboxes aggregate or Pending count for the existing badge treatment.
+
+**Tech Stack:** Next.js 16, React 19, TypeScript, SWR 2, Jest, React Testing Library
+
+---
+
+## Task 1: Add the account-wide unread aggregate and cache contract
+
+**Files:**
+- Create: `web/src/app/components/hooks/useUnreadCount.ts`
+- Create: `web/src/app/components/hooks/useUnreadCount.test.tsx`
+- Modify: `web/src/lib/swrKeys.ts`
+- Modify: `web/src/lib/swrKeys.test.ts`
+
+- [ ] **Step 1: Write the failing aggregate-hook tests**
+
+Add `web/src/app/components/hooks/useUnreadCount.test.tsx` with mocked API helpers and SWR. Pin all material states: loading, aggregation, cap propagation, empty inboxes, and retention after a transient revalidation error.
+
+```tsx
+import useSWR from "swr";
+import { accountUnreadKey } from "../../../lib/swrKeys";
+import { unreadPolling } from "../../../lib/livePolling";
+import {
+  getInboxUnread,
+  listAgents,
+  UNREAD_BADGE_CAP,
+} from "../onboarding/api";
+import { loadUnreadCount, useUnreadCount } from "./useUnreadCount";
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+jest.mock("../onboarding/api", () => ({
+  listAgents: jest.fn(),
+  getInboxUnread: jest.fn(),
+  UNREAD_BADGE_CAP: 99,
+}));
+
+const mockUseSWR = useSWR as jest.MockedFunction<typeof useSWR>;
+const mockListAgents = listAgents as jest.MockedFunction<typeof listAgents>;
+const mockGetInboxUnread = getInboxUnread as jest.MockedFunction<
+  typeof getInboxUnread
+>;
+
+beforeEach(() => jest.clearAllMocks());
+
+it("loads every inbox in parallel and aggregates unread messages", async () => {
+  mockListAgents.mockResolvedValue([
+    { email: "a@example.com" },
+    { email: "b@example.com" },
+  ] as Awaited<ReturnType<typeof listAgents>>);
+  mockGetInboxUnread
+    .mockResolvedValueOnce({ count: 2, more: false })
+    .mockResolvedValueOnce({ count: 3, more: false });
+
+  await expect(loadUnreadCount()).resolves.toEqual({ count: 5, more: false });
+  expect(mockGetInboxUnread).toHaveBeenCalledTimes(2);
+});
+
+it("caps the total and preserves the more-than-cap signal", async () => {
+  mockListAgents.mockResolvedValue([
+    { email: "a@example.com" },
+    { email: "b@example.com" },
+  ] as Awaited<ReturnType<typeof listAgents>>);
+  mockGetInboxUnread
+    .mockResolvedValueOnce({ count: 60, more: false })
+    .mockResolvedValueOnce({ count: 50, more: false });
+
+  await expect(loadUnreadCount()).resolves.toEqual({
+    count: UNREAD_BADGE_CAP,
+    more: true,
+  });
+});
+
+it("returns zero when the account has no inboxes", async () => {
+  mockListAgents.mockResolvedValue([]);
+  await expect(loadUnreadCount()).resolves.toEqual({ count: 0, more: false });
+  expect(mockGetInboxUnread).not.toHaveBeenCalled();
+});
+
+it("subscribes with unread polling and returns null until data exists", () => {
+  mockUseSWR.mockReturnValue({ data: undefined } as ReturnType<typeof useSWR>);
+  expect(useUnreadCount()).toBeNull();
+  expect(mockUseSWR).toHaveBeenCalledWith(
+    accountUnreadKey,
+    loadUnreadCount,
+    unreadPolling,
+  );
+});
+
+it("keeps the last successful total when revalidation fails", () => {
+  mockUseSWR.mockReturnValue({
+    data: { count: 4, more: false },
+    error: new Error("transient"),
+  } as ReturnType<typeof useSWR>);
+  expect(useUnreadCount()).toEqual({ count: 4, more: false });
+});
+```
+
+- [ ] **Step 2: Write the failing cache invalidation test**
+
+Extend `web/src/lib/swrKeys.test.ts` to subscribe to both keys and assert that the existing message-read invalidation path revalidates the per-inbox cache and the new account aggregate while leaving unrelated inboxes alone.
+
+```tsx
+import {
+  accountUnreadKey,
+  agentUnreadKey,
+  invalidateAgentUnread,
+  invalidateMessageDetail,
+  messageDetailKey,
+} from "./swrKeys";
+
+it("revalidates the per-inbox and account-wide unread entries", async () => {
+  const agentFetcher = jest.fn().mockResolvedValue({ count: 1, more: false });
+  const accountFetcher = jest.fn().mockResolvedValue({ count: 1, more: false });
+  const otherFetcher = jest.fn().mockResolvedValue({ count: 2, more: false });
+  renderHook(() => useSWR(agentUnreadKey("a@example.com"), agentFetcher));
+  renderHook(() => useSWR(accountUnreadKey, accountFetcher));
+  renderHook(() => useSWR(agentUnreadKey("b@example.com"), otherFetcher));
+  await waitFor(() => {
+    expect(agentFetcher).toHaveBeenCalledTimes(1);
+    expect(accountFetcher).toHaveBeenCalledTimes(1);
+    expect(otherFetcher).toHaveBeenCalledTimes(1);
+  });
+
+  await act(async () => {
+    await invalidateAgentUnread("a@example.com");
+  });
+
+  await waitFor(() => {
+    expect(agentFetcher).toHaveBeenCalledTimes(2);
+    expect(accountFetcher).toHaveBeenCalledTimes(2);
+  });
+  expect(otherFetcher).toHaveBeenCalledTimes(1);
+});
+```
+
+- [ ] **Step 3: Run the focused tests and confirm they fail**
+
+Run:
+
+```bash
+cd web && npm test -- --runInBand src/app/components/hooks/useUnreadCount.test.tsx src/lib/swrKeys.test.ts
+```
+
+Expected: FAIL because `useUnreadCount`, `accountUnreadKey`, and the aggregate invalidation do not exist.
+
+- [ ] **Step 4: Add the cache key and dual invalidation**
+
+In `web/src/lib/swrKeys.ts`, add the account key beside the existing unread key and make the established helper invalidate both entries:
+
+```ts
+export const accountUnreadKey = "account-unread";
+
+export function invalidateAgentUnread(email: string) {
+  return Promise.all([
+    mutate(agentUnreadKey(email)),
+    mutate(accountUnreadKey),
+  ]);
+}
+```
+
+This keeps every existing caller in `ThreadBubble.tsx` and trash flows correct without adding parallel mutation APIs.
+
+- [ ] **Step 5: Implement the aggregate hook**
+
+Create `web/src/app/components/hooks/useUnreadCount.ts`:
+
+```ts
+import useSWR from "swr";
+import { accountUnreadKey } from "../../../lib/swrKeys";
+import { unreadPolling } from "../../../lib/livePolling";
+import {
+  getInboxUnread,
+  listAgents,
+  UNREAD_BADGE_CAP,
+} from "../onboarding/api";
+
+export type UnreadCount = { count: number; more: boolean };
+
+export async function loadUnreadCount(): Promise<UnreadCount> {
+  const agents = await listAgents();
+  const unread = await Promise.all(
+    agents.map((agent) => getInboxUnread(agent.email)),
+  );
+  const total = unread.reduce((sum, item) => sum + item.count, 0);
+  return {
+    count: Math.min(total, UNREAD_BADGE_CAP),
+    more: total > UNREAD_BADGE_CAP || unread.some((item) => item.more),
+  };
+}
+
+export function useUnreadCount(): UnreadCount | null {
+  const { data } = useSWR(accountUnreadKey, loadUnreadCount, unreadPolling);
+  return data ?? null;
+}
+```
+
+- [ ] **Step 6: Re-run the focused tests**
+
+Run:
+
+```bash
+cd web && npm test -- --runInBand src/app/components/hooks/useUnreadCount.test.tsx src/lib/swrKeys.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit the data-layer slice**
+
+```bash
+git add web/src/app/components/hooks/useUnreadCount.ts web/src/app/components/hooks/useUnreadCount.test.tsx web/src/lib/swrKeys.ts web/src/lib/swrKeys.test.ts
+git commit -m "feat(web): aggregate sidebar unread count"
+```
+
+## Task 2: Render the Inboxes badge consistently with Pending
+
+**Files:**
+- Modify: `web/src/app/components/loft/Sidebar.tsx`
+- Modify: `web/src/app/components/loft/Sidebar.test.tsx`
+
+- [ ] **Step 1: Write failing Sidebar presentation tests**
+
+Mock `useUnreadCount` beside `usePendingCount`, reset it in `beforeEach`, and pin hidden, numeric, capped, and coexistence behavior:
+
+```tsx
+let mockUnreadCount: { count: number; more: boolean } | null = null;
+jest.mock("../hooks/useUnreadCount", () => ({
+  useUnreadCount: () => mockUnreadCount,
+}));
+
+beforeEach(() => {
+  mockUnreadCount = null;
+});
+
+it("shows the Inboxes unread count only when it is positive", () => {
+  mockUnreadCount = { count: 0, more: false };
+  const { rerender } = render(<Sidebar />);
+  const inboxes = document.querySelector(`a[href="/inboxes"]`);
+  expect(inboxes?.querySelector("[data-nav-badge]")).toBeNull();
+
+  mockUnreadCount = { count: 7, more: false };
+  rerender(<Sidebar />);
+  expect(inboxes?.querySelector("[data-nav-badge]")).toHaveTextContent("7");
+});
+
+it("shows 99+ when the aggregate says more unread messages exist", () => {
+  mockUnreadCount = { count: 99, more: true };
+  render(<Sidebar />);
+  const inboxes = document.querySelector(`a[href="/inboxes"]`);
+  expect(inboxes?.querySelector("[data-nav-badge]")).toHaveTextContent("99+");
+});
+
+it("can show Inboxes and Pending counts at the same time", () => {
+  mockUnreadCount = { count: 4, more: false };
+  mockPendingCount = 2;
+  render(<Sidebar />);
+  expect(document.querySelector(`a[href="/inboxes"]`)).toHaveTextContent("4");
+  expect(document.querySelector(`a[href="/reviews"]`)).toHaveTextContent("2");
+});
+```
+
+Also update the existing Pending assertion to select `[data-nav-badge]`; this avoids false positives from unrelated nav text.
+
+- [ ] **Step 2: Run the Sidebar test and confirm it fails**
+
+Run:
+
+```bash
+cd web && npm test -- --runInBand src/app/components/loft/Sidebar.test.tsx
+```
+
+Expected: FAIL because Sidebar does not consume or render the unread aggregate.
+
+- [ ] **Step 3: Generalize the existing badge rendering**
+
+Import and call `useUnreadCount`, compute one `badgeLabel` per nav item, and reuse the exact existing Pending pill:
+
+```tsx
+const unreadCount = useUnreadCount();
+
+const badgeLabel =
+  item.href === "/inboxes" && unreadCount && unreadCount.count > 0
+    ? unreadCount.more
+      ? "99+"
+      : String(unreadCount.count)
+    : item.href === "/reviews" && pendingCount !== null && pendingCount > 0
+      ? String(pendingCount)
+      : null;
+```
+
+Render `badgeLabel` in the current pill, adding `data-nav-badge` for scoped assertions. Do not introduce new colors, dimensions, animation, or layout behavior: Inboxes and Pending use the same `var(--accent)` background, white bold monospace text, `18px` height, and pill radius.
+
+- [ ] **Step 4: Run the Sidebar test and confirm it passes**
+
+Run:
+
+```bash
+cd web && npm test -- --runInBand src/app/components/loft/Sidebar.test.tsx
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run the full web verification**
+
+Run:
+
+```bash
+cd web && npm test -- --runInBand
+cd web && npm run lint
+cd web && npm run build
+```
+
+Expected: all tests pass, ESLint exits 0, and Next.js static export succeeds.
+
+- [ ] **Step 6: Verify the seeded unread message in the running local UI**
+
+Open `http://127.0.0.1:3000/inboxes/messages?email=demo-inbox%40local.test` without selecting the unread message. Confirm:
+
+- Inboxes shows an accent-colored `1` pill matching Pending's visual treatment.
+- The unread message remains visually darker in the list.
+- Opening that message marks it read and the Inboxes badge clears after invalidation/revalidation.
+
+- [ ] **Step 7: Commit the presentation slice**
+
+```bash
+git add web/src/app/components/loft/Sidebar.tsx web/src/app/components/loft/Sidebar.test.tsx
+git commit -m "feat(web): show unread count in sidebar"
+```
+
+## Final verification
+
+- [ ] Confirm `git status --short` contains only expected work (leave `.superpowers/` untracked and uncommitted).
+- [ ] Review the diff against `docs/superpowers/specs/2026-07-22-sidebar-inboxes-unread-count-design.md`.
+- [ ] Confirm no placeholders (`TODO`, `TBD`, omitted test bodies) remain in implementation or tests.
+- [ ] Confirm the hook, Sidebar mock, and exported cache-key types agree under the production TypeScript build.

--- a/docs/superpowers/specs/2026-07-22-sidebar-inboxes-unread-count-design.md
+++ b/docs/superpowers/specs/2026-07-22-sidebar-inboxes-unread-count-design.md
@@ -1,0 +1,71 @@
+# Sidebar Inboxes Unread Count
+
+## Goal
+
+Show the account-wide unread inbound-message total beside the sidebar's
+**Inboxes** navigation item so unread mail remains visible from every dashboard
+route.
+
+## User experience
+
+- Render a numeric badge beside **Inboxes** when at least one unread inbound
+  message exists across the account.
+- Match the existing **Pending** navigation badge exactly: the same filled
+  `var(--accent)` pill, white bold monospace text, dimensions, and spacing.
+- Hide the badge when the total is zero or has not loaded yet.
+- Display `99+` when the known total exceeds 99 or any inbox reports more than
+  its capped page.
+- Poll every 15 seconds only while the page is visible and online, matching the
+  existing unread-card cadence.
+- Retain the last successful count when a transient refresh fails. An initial
+  failure remains visually quiet and renders no badge.
+
+## Data flow
+
+Add one sidebar-owned SWR query under an account-wide unread cache key. Its
+fetcher lists the account's agents, requests each agent's existing capped unread
+probe, and aggregates `{count, more}` into an account total. This reuses the
+current `/v1/agents/{address}/messages?direction=inbound&read_status=unread`
+contract and avoids a backend/OpenAPI/client-surface change.
+
+The query is intentionally one owner rather than one hook per navigation item.
+The number of HTTP requests remains one agent-list request plus one capped
+unread request per inbox. If that fan-out becomes material for large accounts,
+the follow-up is a server-side account unread aggregate.
+
+When reading, deleting, restoring, or otherwise changing a message invalidates
+an agent's unread cache, the account-wide unread key must also be invalidated so
+the sidebar responds immediately instead of waiting for its next poll.
+
+## Components
+
+- `swrKeys.ts`: define the account-wide unread key and include it in unread
+  invalidation.
+- `useUnreadCount.ts`: own aggregation, `99+` semantics, and the shared polling
+  subscription.
+- `Sidebar.tsx`: subscribe to the count and render the existing navigation badge
+  treatment for **Inboxes** as well as **Pending**.
+
+## Error handling
+
+SWR keeps the last successful value when a refresh rejects. Before the first
+successful response, the hook returns an unknown state and the sidebar omits the
+badge. The navigation remains usable regardless of unread-probe failures.
+
+## Testing
+
+- Hook tests: aggregate multiple inboxes, hide at zero/unknown, cap at `99+`,
+  retain cached data on a transient failure, and refresh every 15 seconds.
+- Sidebar tests: show the unread badge only on **Inboxes**, use `99+` when
+  capped, and preserve the existing **Pending** badge behavior.
+- Cache tests: message-read invalidation revalidates both the per-agent and
+  account-wide unread queries.
+- Live verification: seed an unread inbound message in the isolated local e2a
+  service and confirm the sidebar badge appears without opening the message.
+
+## Non-goals
+
+- No backend or OpenAPI changes.
+- No per-inbox unread breakdown in the sidebar.
+- No change to when fetching message detail marks an inbound message read.
+- No change to the message-row unread highlight.

--- a/web/src/app/(app)/inboxes/(view)/messages/view/page.test.tsx
+++ b/web/src/app/(app)/inboxes/(view)/messages/view/page.test.tsx
@@ -40,6 +40,7 @@ jest.mock("next/link", () => {
 // `as const` tuples), so we keep `requireActual` and override only
 // the side-effect functions we want to observe.
 const mockInvalidateAgentMessages = jest.fn();
+const mockInvalidateAgentUnread = jest.fn();
 const mockInvalidateMessageDetail = jest.fn();
 jest.mock("../../../../../../lib/swrKeys", () => {
   const actual = jest.requireActual("../../../../../../lib/swrKeys");
@@ -47,6 +48,7 @@ jest.mock("../../../../../../lib/swrKeys", () => {
     ...actual,
     invalidateAgentMessages: (email: string) =>
       mockInvalidateAgentMessages(email),
+    invalidateAgentUnread: (email: string) => mockInvalidateAgentUnread(email),
     invalidateMessageDetail: (id: string) => mockInvalidateMessageDetail(id),
   };
 });
@@ -167,6 +169,7 @@ beforeEach(() => {
   mockFetch.mockReset();
   mockRouterPush.mockReset();
   mockInvalidateAgentMessages.mockReset();
+  mockInvalidateAgentUnread.mockReset();
   mockInvalidateMessageDetail.mockReset();
 });
 
@@ -344,7 +347,7 @@ describe("AgentMessageFocusPage", () => {
   // window-focus revalidation eventually catches up. Pre-SWR this
   // was free (every navigation refetched the inbox); post-SWR it
   // needs an explicit cache invalidation.
-  it("invalidates the per-agent inbox cache after a successful inbound load", async () => {
+  it("invalidates the inbox and unread caches after a successful inbound load", async () => {
     setSearchParams({ email: "support@acme.io", id: "msg_in1", direction: "inbound" });
     mockDetail(INBOUND_DETAIL);
 
@@ -357,7 +360,29 @@ describe("AgentMessageFocusPage", () => {
       expect(mockInvalidateAgentMessages).toHaveBeenCalledWith(
         "support@acme.io",
       );
+      expect(mockInvalidateAgentUnread).toHaveBeenCalledWith(
+        "support@acme.io",
+      );
     });
+  });
+
+  it("does not invalidate unread counts after a successful outbound load", async () => {
+    setSearchParams({
+      email: "support@acme.io",
+      id: "msg_pending",
+      direction: "outbound",
+      pending: "1",
+    });
+    mockDetail(OUTBOUND_PENDING);
+
+    render(<AgentMessageFocusPage />);
+
+    await waitFor(() => {
+      expect(mockInvalidateAgentMessages).toHaveBeenCalledWith(
+        "support@acme.io",
+      );
+    });
+    expect(mockInvalidateAgentUnread).not.toHaveBeenCalled();
   });
 
   it("clicking Approve POSTs to /v1/reviews/{id}/approve and redirects to the thread", async () => {

--- a/web/src/app/(app)/inboxes/(view)/messages/view/page.tsx
+++ b/web/src/app/(app)/inboxes/(view)/messages/view/page.tsx
@@ -41,6 +41,7 @@ import {
 import { formatRelativeAge } from "../../../../../../lib/relativeTime";
 import {
   invalidateAgentMessages,
+  invalidateAgentUnread,
   invalidateAgents,
   invalidateMessageDetail,
   invalidatePendingList,
@@ -173,11 +174,14 @@ function FocusContent({
     {
       shouldRetryOnError: false,
       keepPreviousData: false,
-      // The detail GET flips inbox_status unread → read server-side as a
-      // side effect. Invalidate the inbox cache so the row's read state
-      // reflects immediately rather than waiting for focus revalidation.
-      onSuccess: () => {
+      // An inbound detail GET flips inbox_status unread → read server-side.
+      // Every detail refreshes its inbox row; only inbound wires refresh
+      // unread rollups because outbound loads cannot change that total.
+      onSuccess: (wire) => {
         void invalidateAgentMessages(email);
+        if (wire.direction === "inbound") {
+          void invalidateAgentUnread(email);
+        }
       },
     },
   );

--- a/web/src/app/(app)/inboxes/(view)/settings/page.test.tsx
+++ b/web/src/app/(app)/inboxes/(view)/settings/page.test.tsx
@@ -36,6 +36,15 @@ jest.mock("next/link", () => {
   };
 });
 
+const mockInvalidateAgentUnread = jest.fn();
+jest.mock("../../../../../lib/swrKeys", () => {
+  const actual = jest.requireActual("../../../../../lib/swrKeys");
+  return {
+    ...actual,
+    invalidateAgentUnread: (email: string) => mockInvalidateAgentUnread(email),
+  };
+});
+
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
 
@@ -88,6 +97,7 @@ beforeEach(() => {
   mockFetch.mockReset();
   mockRouterPush.mockReset();
   mockRouterReplace.mockReset();
+  mockInvalidateAgentUnread.mockReset();
   jest.spyOn(window, "confirm").mockReturnValue(true);
 });
 
@@ -179,6 +189,7 @@ describe("AgentSettingsPage", () => {
 
   it("clicking 'Delete inbox' DELETEs and routes back to /inboxes", async () => {
     setSearchParams({ email: baseAgent.email });
+    mockInvalidateAgentUnread.mockReturnValue(new Promise(() => {}));
     let deleted = false;
     mockFetch.mockImplementation((url: string, init?: RequestInit) => {
       if (url === "/v1/agents" && !init?.method) {
@@ -217,6 +228,48 @@ describe("AgentSettingsPage", () => {
       expect(deleted).toBe(true);
     });
     expect(mockRouterReplace).toHaveBeenCalledWith("/inboxes");
+    expect(mockInvalidateAgentUnread).toHaveBeenCalledWith(baseAgent.email);
+  });
+
+  it("surfaces a failed DELETE without invalidating unread counts", async () => {
+    setSearchParams({ email: baseAgent.email });
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === "/v1/agents" && !init?.method) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ items: [baseAgent] }),
+        });
+      }
+      if (
+        url === `/v1/agents/${encodeURIComponent(baseAgent.email)}?confirm=DELETE` &&
+        init?.method === "DELETE"
+      ) {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          text: () => Promise.resolve("delete exploded"),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve("not found"),
+      });
+    });
+
+    render(<AgentSettingsPage />);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Delete inbox/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: /Delete inbox/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("delete exploded")).toBeInTheDocument();
+    });
+    expect(mockInvalidateAgentUnread).not.toHaveBeenCalled();
+    expect(mockRouterReplace).not.toHaveBeenCalled();
   });
 
   it("aborts deletion when the confirm prompt is cancelled", async () => {
@@ -250,6 +303,7 @@ describe("AgentSettingsPage", () => {
     // the negative assertion deterministic).
     await new Promise((r) => setTimeout(r, 10));
     expect(deleted).toBe(false);
+    expect(mockInvalidateAgentUnread).not.toHaveBeenCalled();
     expect(mockRouterReplace).not.toHaveBeenCalled();
   });
 });

--- a/web/src/app/(app)/inboxes/(view)/settings/page.tsx
+++ b/web/src/app/(app)/inboxes/(view)/settings/page.tsx
@@ -12,6 +12,7 @@ import { deleteAgent, getProtection } from "../../../../components/onboarding/ap
 import { useAgents } from "../../../../components/hooks/useAgents";
 import {
   invalidateAgents,
+  invalidateAgentUnread,
   invalidateDeletedAgents,
   invalidateProtection,
   protectionKey,
@@ -82,6 +83,7 @@ function AgentSettingsContent({ email }: { email: string }) {
     setDeleteError("");
     try {
       await deleteAgent(agent.email);
+      void invalidateAgentUnread(agent.email);
       await invalidateAgents();
       // The inbox now lives in the trash — a mounted /trash page is stale.
       void invalidateDeletedAgents();

--- a/web/src/app/(app)/trash/page.test.tsx
+++ b/web/src/app/(app)/trash/page.test.tsx
@@ -29,6 +29,15 @@ jest.mock("next/link", () => {
   };
 });
 
+const mockInvalidateAgentUnread = jest.fn();
+jest.mock("../../../lib/swrKeys", () => {
+  const actual = jest.requireActual("../../../lib/swrKeys");
+  return {
+    ...actual,
+    invalidateAgentUnread: (email: string) => mockInvalidateAgentUnread(email),
+  };
+});
+
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
 
@@ -60,6 +69,7 @@ function mockTrash(items: unknown[]) {
 
 beforeEach(() => {
   mockFetch.mockReset();
+  mockInvalidateAgentUnread.mockReset();
 });
 
 describe("TrashPage", () => {
@@ -83,6 +93,7 @@ describe("TrashPage", () => {
   });
 
   it("Restore POSTs to the restore endpoint", async () => {
+    mockInvalidateAgentUnread.mockReturnValue(new Promise(() => {}));
     let restored = false;
     mockFetch.mockImplementation((url: string, init?: RequestInit) => {
       if (url === "/v1/agents?deleted=true" && !init?.method) {
@@ -124,7 +135,50 @@ describe("TrashPage", () => {
     fireEvent.click(screen.getByRole("button", { name: /^Restore$/ }));
     await waitFor(() => {
       expect(restored).toBe(true);
+      expect(mockInvalidateAgentUnread).toHaveBeenCalledWith(
+        "support@acme.com",
+      );
     });
+    await waitFor(() => {
+      expect(screen.getByTestId("trash-empty")).toBeInTheDocument();
+    });
+  });
+
+  it("surfaces a failed restore without invalidating unread counts", async () => {
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === "/v1/agents?deleted=true" && !init?.method) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ items: [trashedAgent] }),
+        });
+      }
+      if (
+        url === "/v1/agents/support%40acme.com/restore" &&
+        init?.method === "POST"
+      ) {
+        return Promise.resolve({
+          ok: false,
+          status: 500,
+          text: () => Promise.resolve("restore exploded"),
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        text: () => Promise.resolve("not found"),
+      });
+    });
+
+    render(<TrashPage />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: /^Restore$/ }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("restore exploded")).toBeInTheDocument();
+    });
+    expect(mockInvalidateAgentUnread).not.toHaveBeenCalled();
   });
 
   it("Delete forever requires a second confirming click", async () => {
@@ -173,5 +227,9 @@ describe("TrashPage", () => {
         "/v1/agents/support%40acme.com?confirm=DELETE&permanent=true",
       );
     });
+    await waitFor(() => {
+      expect(screen.getByTestId("trash-empty")).toBeInTheDocument();
+    });
+    expect(mockInvalidateAgentUnread).not.toHaveBeenCalled();
   });
 });

--- a/web/src/app/(app)/trash/page.tsx
+++ b/web/src/app/(app)/trash/page.tsx
@@ -17,7 +17,11 @@ import {
 import { PageShell } from "../../components/loft/PageShell";
 import { CounterpartyAvatar } from "../../components/messages/CounterpartyAvatar";
 import { formatRelativeAge } from "../../../lib/relativeTime";
-import { deletedAgentsKey, invalidateAgents } from "../../../lib/swrKeys";
+import {
+  deletedAgentsKey,
+  invalidateAgentUnread,
+  invalidateAgents,
+} from "../../../lib/swrKeys";
 import { TRASH_RETENTION_DAYS, daysLeft } from "../../../lib/trash";
 import type { DashboardAgent } from "../../components/types";
 
@@ -33,11 +37,16 @@ export default function TrashPage() {
   // Two-click "Delete forever": first click arms, second click fires.
   const [armed, setArmed] = useState<string | null>(null);
 
-  const run = async (email: string, op: () => Promise<unknown>) => {
+  const run = async (
+    email: string,
+    op: () => Promise<unknown>,
+    afterSuccess?: () => void,
+  ) => {
     setBusy(email);
     setRowError(null);
     try {
       await op();
+      afterSuccess?.();
       await mutate(); // refresh the trash list
       void invalidateAgents(); // a restore re-adds the inbox to the live list
     } catch (err) {
@@ -139,7 +148,15 @@ export default function TrashPage() {
               <button
                 type="button"
                 disabled={busy === a.email}
-                onClick={() => run(a.email, () => restoreAgent(a.email))}
+                onClick={() =>
+                  run(
+                    a.email,
+                    () => restoreAgent(a.email),
+                    () => {
+                      void invalidateAgentUnread(a.email);
+                    },
+                  )
+                }
                 className="text-[12px] px-3 py-1.5 hover:bg-[var(--bg-elev)] transition"
                 style={{
                   background: "var(--bg-panel)",

--- a/web/src/app/components/hooks/useUnreadCount.test.tsx
+++ b/web/src/app/components/hooks/useUnreadCount.test.tsx
@@ -1,0 +1,122 @@
+import useSWR from "swr";
+import { unreadPolling } from "../../../lib/livePolling";
+import { accountUnreadKey } from "../../../lib/swrKeys";
+import { getInboxUnread, listAgents } from "../onboarding/api";
+import { loadUnreadCount, useUnreadCount } from "./useUnreadCount";
+
+jest.mock("swr", () => ({
+  __esModule: true,
+  default: jest.fn(() => ({ data: undefined, error: undefined })),
+}));
+
+jest.mock("../onboarding/api", () => ({
+  getInboxUnread: jest.fn(),
+  listAgents: jest.fn(),
+  UNREAD_BADGE_CAP: 99,
+}));
+
+const mockUseSWR = useSWR as jest.MockedFunction<typeof useSWR>;
+const mockGetInboxUnread = getInboxUnread as jest.MockedFunction<
+  typeof getInboxUnread
+>;
+const mockListAgents = listAgents as jest.MockedFunction<typeof listAgents>;
+
+const agent = (email: string) => ({
+  domain: "agents.test",
+  email,
+  name: email,
+  domain_verified: true,
+  created_at: "2026-07-22T00:00:00Z",
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseSWR.mockReturnValue({
+    data: undefined,
+    error: undefined,
+  } as ReturnType<typeof useSWR>);
+});
+
+describe("loadUnreadCount", () => {
+  it("fetches every inbox in parallel and aggregates unread counts", async () => {
+    mockListAgents.mockResolvedValue([
+      agent("one@agents.test"),
+      agent("two@agents.test"),
+    ]);
+    let resolveOne!: (value: { count: number; more: boolean }) => void;
+    let resolveTwo!: (value: { count: number; more: boolean }) => void;
+    mockGetInboxUnread
+      .mockImplementationOnce(
+        () => new Promise((resolve) => { resolveOne = resolve; }),
+      )
+      .mockImplementationOnce(
+        () => new Promise((resolve) => { resolveTwo = resolve; }),
+      );
+
+    const pending = loadUnreadCount();
+    await Promise.resolve();
+    expect(mockGetInboxUnread).toHaveBeenNthCalledWith(1, "one@agents.test");
+    expect(mockGetInboxUnread).toHaveBeenNthCalledWith(2, "two@agents.test");
+
+    resolveOne({ count: 12, more: false });
+    resolveTwo({ count: 7, more: false });
+    await expect(pending).resolves.toEqual({ count: 19, more: false });
+  });
+
+  it("caps the account total at 99 and marks it as more", async () => {
+    mockListAgents.mockResolvedValue([
+      agent("one@agents.test"),
+      agent("two@agents.test"),
+    ]);
+    mockGetInboxUnread
+      .mockResolvedValueOnce({ count: 60, more: false })
+      .mockResolvedValueOnce({ count: 50, more: false });
+
+    await expect(loadUnreadCount()).resolves.toEqual({ count: 99, more: true });
+  });
+
+  it("propagates a per-agent more flag even below the account cap", async () => {
+    mockListAgents.mockResolvedValue([agent("one@agents.test")]);
+    mockGetInboxUnread.mockResolvedValue({ count: 8, more: true });
+
+    await expect(loadUnreadCount()).resolves.toEqual({ count: 8, more: true });
+  });
+
+  it("returns zero without unread requests for an empty account", async () => {
+    mockListAgents.mockResolvedValue([]);
+
+    await expect(loadUnreadCount()).resolves.toEqual({ count: 0, more: false });
+    expect(mockGetInboxUnread).not.toHaveBeenCalled();
+  });
+});
+
+describe("useUnreadCount", () => {
+  it("subscribes with the account key, loader, and exact unread polling config", () => {
+    expect(useUnreadCount()).toBeNull();
+
+    expect(mockUseSWR).toHaveBeenCalledWith(
+      accountUnreadKey,
+      loadUnreadCount,
+      unreadPolling,
+    );
+  });
+
+  it("returns null while no data is available", () => {
+    mockUseSWR.mockReturnValueOnce({
+      data: undefined,
+      error: new Error("initial failure"),
+    } as ReturnType<typeof useSWR>);
+
+    expect(useUnreadCount()).toBeNull();
+  });
+
+  it("keeps stale data when revalidation reports an error", () => {
+    const stale = { count: 14, more: false };
+    mockUseSWR.mockReturnValueOnce({
+      data: stale,
+      error: new Error("transient"),
+    } as ReturnType<typeof useSWR>);
+
+    expect(useUnreadCount()).toEqual(stale);
+  });
+});

--- a/web/src/app/components/hooks/useUnreadCount.ts
+++ b/web/src/app/components/hooks/useUnreadCount.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import useSWR from "swr";
+import { unreadPolling } from "../../../lib/livePolling";
+import { accountUnreadKey } from "../../../lib/swrKeys";
+import {
+  getInboxUnread,
+  listAgents,
+  UNREAD_BADGE_CAP,
+} from "../onboarding/api";
+
+export type UnreadCount = { count: number; more: boolean };
+
+export async function loadUnreadCount(): Promise<UnreadCount> {
+  const agents = await listAgents();
+  const unread = await Promise.all(
+    agents.map(({ email }) => getInboxUnread(email)),
+  );
+  const total = unread.reduce((sum, result) => sum + result.count, 0);
+
+  return {
+    count: Math.min(total, UNREAD_BADGE_CAP),
+    more: total > UNREAD_BADGE_CAP || unread.some((result) => result.more),
+  };
+}
+
+export function useUnreadCount(): UnreadCount | null {
+  const { data } = useSWR(accountUnreadKey, loadUnreadCount, unreadPolling);
+  return data ?? null;
+}

--- a/web/src/app/components/loft/Sidebar.test.tsx
+++ b/web/src/app/components/loft/Sidebar.test.tsx
@@ -48,10 +48,20 @@ jest.mock("../hooks/usePendingCount", () => ({
   usePendingCount: () => mockPendingCount,
 }));
 
+let mockUnreadCount: { count: number; more: boolean } | null = null;
+jest.mock("../hooks/useUnreadCount", () => ({
+  useUnreadCount: () => mockUnreadCount,
+}));
+
 beforeEach(() => {
   mockPathname = "/inboxes";
   mockPendingCount = null;
+  mockUnreadCount = null;
 });
+
+function navBadge(href: string): Element | null {
+  return document.querySelector(`a[href="${href}"] [data-nav-badge]`);
+}
 
 // The Sidebar's NAV_ITEMS array is the canonical source of truth for
 // what the user can reach from the global chrome. These tests pin the
@@ -147,15 +157,47 @@ describe("Sidebar — nav entries", () => {
     expect(agents).not.toHaveAttribute("aria-current", "page");
   });
 
+  it("does not show an Inboxes badge while unread count is unknown or zero", () => {
+    const { rerender } = render(<Sidebar />);
+    expect(navBadge("/inboxes")).toBeNull();
+
+    mockUnreadCount = { count: 0, more: false };
+    rerender(<Sidebar />);
+    expect(navBadge("/inboxes")).toBeNull();
+  });
+
+  it("shows a positive unread count only in the Inboxes link", () => {
+    mockUnreadCount = { count: 7, more: false };
+    render(<Sidebar />);
+
+    expect(navBadge("/inboxes")).toHaveTextContent("7");
+    expect(navBadge("/reviews")).toBeNull();
+  });
+
+  it("shows 99+ when the unread result says more messages exist", () => {
+    mockUnreadCount = { count: 99, more: true };
+    render(<Sidebar />);
+
+    expect(navBadge("/inboxes")).toHaveTextContent("99+");
+  });
+
+  it("shows Inboxes and Pending badges with their own values", () => {
+    mockUnreadCount = { count: 12, more: false };
+    mockPendingCount = 3;
+    render(<Sidebar />);
+
+    expect(navBadge("/inboxes")).toHaveTextContent("12");
+    expect(navBadge("/reviews")).toHaveTextContent("3");
+  });
+
   it("shows the pending count badge only when > 0", () => {
     mockPendingCount = 0;
     const { rerender } = render(<Sidebar />);
-    expect(screen.queryByText("0")).not.toBeInTheDocument();
+    expect(navBadge("/reviews")).toBeNull();
     // Re-render with a real count → badge appears in the Pending link.
     mockPendingCount = 3;
     rerender(<Sidebar />);
-    const pending = document.querySelector(`a[href="/reviews"]`);
-    expect(pending?.textContent).toContain("3");
+    expect(navBadge("/reviews")).toHaveTextContent("3");
   });
 });
 

--- a/web/src/app/components/loft/Sidebar.tsx
+++ b/web/src/app/components/loft/Sidebar.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import type { ReactNode } from "react";
 import { useAuth } from "../AuthProvider";
 import { usePendingCount } from "../hooks/usePendingCount";
+import { useUnreadCount } from "../hooks/useUnreadCount";
 import { ThemeToggle } from "./ThemeToggle";
 import { TokenCanopyGlyph } from "./TokenCanopyBadge";
 
@@ -224,6 +225,7 @@ export function Sidebar({
   const pathname = usePathname() ?? "";
   const { user, signOut } = useAuth();
   const pendingCount = usePendingCount();
+  const unreadCount = useUnreadCount();
 
   return (
     <aside
@@ -281,10 +283,16 @@ export function Sidebar({
       <nav className="flex-1 px-3 pt-3 pb-1.5">
         {NAV_ITEMS.map((item) => {
           const active = isActive(pathname, item);
-          const showBadge =
+          let badgeLabel: number | string | null = null;
+          if (item.href === "/inboxes" && unreadCount && unreadCount.count > 0) {
+            badgeLabel = unreadCount.more ? "99+" : unreadCount.count;
+          } else if (
             item.href === "/reviews" &&
             pendingCount !== null &&
-            pendingCount > 0;
+            pendingCount > 0
+          ) {
+            badgeLabel = pendingCount;
+          }
           return (
             <Link
               key={item.href}
@@ -301,8 +309,9 @@ export function Sidebar({
             >
               <NavIcon kind={item.icon} />
               <span className="flex-1">{item.label}</span>
-              {showBadge && (
+              {badgeLabel !== null && (
                 <span
+                  data-nav-badge
                   className="inline-flex items-center justify-center font-mono text-[10px] font-bold text-white"
                   style={{
                     minWidth: 18,
@@ -312,7 +321,7 @@ export function Sidebar({
                     borderRadius: 999,
                   }}
                 >
-                  {pendingCount}
+                  {badgeLabel}
                 </span>
               )}
             </Link>

--- a/web/src/app/components/onboarding/api.test.ts
+++ b/web/src/app/components/onboarding/api.test.ts
@@ -6,6 +6,7 @@
 // pin the projection to the v1 field names so that can't recur.
 
 import {
+  listAgents,
   listAgentMessages,
   listPendingMessages,
   getInboxUnread,
@@ -34,6 +35,49 @@ function okJson(obj: unknown) {
 function notFound() {
   return Promise.resolve({ ok: false, status: 404, text: () => Promise.resolve("nf") });
 }
+
+describe("listAgents", () => {
+  it("follows the next cursor and combines agent pages in order", async () => {
+    const first = {
+      domain: "agents.test",
+      email: "first@agents.test",
+      name: "First",
+      domain_verified: true,
+      created_at: "2026-07-22T00:00:00Z",
+    };
+    const second = {
+      ...first,
+      email: "second@agents.test",
+      name: "Second",
+    };
+    mockFetch.mockImplementation((url: string) => {
+      if (url === "/v1/agents") {
+        return okJson({ items: [first], next_cursor: "next page" });
+      }
+      if (url === "/v1/agents?cursor=next%20page") {
+        return okJson({ items: [second], next_cursor: null });
+      }
+      return notFound();
+    });
+
+    await expect(listAgents()).resolves.toEqual([first, second]);
+    expect(mockFetch.mock.calls.map(([url]) => url)).toEqual([
+      "/v1/agents",
+      "/v1/agents?cursor=next%20page",
+    ]);
+  });
+
+  it("rejects instead of returning a partial list when the page cap is exhausted", async () => {
+    mockFetch.mockImplementation(() =>
+      okJson({ items: [], next_cursor: `cursor-${mockFetch.mock.calls.length}` }),
+    );
+
+    await expect(listAgents()).rejects.toThrow(
+      "Failed to load all agents: pagination exceeded 20 pages",
+    );
+    expect(mockFetch).toHaveBeenCalledTimes(20);
+  });
+});
 
 describe("message projection (v1 contract)", () => {
   it("maps v1 review_status/delivery_status onto the app fields", async () => {

--- a/web/src/app/components/onboarding/api.ts
+++ b/web/src/app/components/onboarding/api.ts
@@ -88,10 +88,28 @@ export async function deleteDomain(domain: string): Promise<void> {
 // GET /v1/agents → PageAgentView. AgentView carries exactly the slim
 // identity fields the dashboard list needs (id/domain/email/name/
 // domain_verified/created_at), so the wire rows map straight onto
-// DashboardAgent. (Per-agent config moved to the protection sub-resource.)
+// DashboardAgent. Follow next_cursor so account-wide consumers see every
+// inbox, with the same defensive page cap used by the templates surface.
+// (Per-agent config moved to the protection sub-resource.)
 export async function listAgents(): Promise<DashboardAgent[]> {
-  const data = await request<{ items?: DashboardAgent[] | null }>("/v1/agents");
-  return data.items ?? [];
+  const agents: DashboardAgent[] = [];
+  let cursor: string | null = null;
+  for (let page = 0; page < 20; page++) {
+    const url: string = cursor
+      ? "/v1/agents?cursor=" + encodeURIComponent(cursor)
+      : "/v1/agents";
+    const data: {
+      items?: DashboardAgent[] | null;
+      next_cursor?: string | null;
+    } = await request(url);
+    agents.push(...(data.items ?? []));
+    cursor = data.next_cursor ?? null;
+    if (!cursor) break;
+  }
+  if (cursor) {
+    throw new Error("Failed to load all agents: pagination exceeded 20 pages");
+  }
+  return agents;
 }
 
 // POST /v1/agents registers by full email only — a shared-domain agent is

--- a/web/src/lib/swrKeys.test.ts
+++ b/web/src/lib/swrKeys.test.ts
@@ -16,7 +16,46 @@
 
 import { renderHook, waitFor, act } from "@testing-library/react";
 import useSWR from "swr";
-import { invalidateMessageDetail, messageDetailKey } from "./swrKeys";
+import {
+  accountUnreadKey,
+  agentUnreadKey,
+  invalidateAgentUnread,
+  invalidateMessageDetail,
+  messageDetailKey,
+} from "./swrKeys";
+
+describe("accountUnreadKey", () => {
+  it("uses the canonical account-wide cache key", () => {
+    expect(accountUnreadKey).toBe("account-unread");
+  });
+});
+
+describe("invalidateAgentUnread", () => {
+  it("revalidates the specified agent and account total without touching another agent", async () => {
+    const targetFetcher = jest.fn().mockResolvedValue({ count: 1, more: false });
+    const otherFetcher = jest.fn().mockResolvedValue({ count: 2, more: false });
+    const accountFetcher = jest.fn().mockResolvedValue({ count: 3, more: false });
+
+    renderHook(() => useSWR(agentUnreadKey("target@agents.test"), targetFetcher));
+    renderHook(() => useSWR(agentUnreadKey("other@agents.test"), otherFetcher));
+    renderHook(() => useSWR(accountUnreadKey, accountFetcher));
+    await waitFor(() => {
+      expect(targetFetcher).toHaveBeenCalledTimes(1);
+      expect(otherFetcher).toHaveBeenCalledTimes(1);
+      expect(accountFetcher).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      await invalidateAgentUnread("target@agents.test");
+    });
+
+    await waitFor(() => {
+      expect(targetFetcher).toHaveBeenCalledTimes(2);
+      expect(accountFetcher).toHaveBeenCalledTimes(2);
+    });
+    expect(otherFetcher).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe("messageDetailKey", () => {
   it("keys a message by id ALONE — no owning-inbox component", () => {

--- a/web/src/lib/swrKeys.ts
+++ b/web/src/lib/swrKeys.ts
@@ -17,6 +17,7 @@ import { mutate } from "swr";
 export const agentsKey = "agents";
 export const domainsKey = "domains";
 export const pendingMessagesKey = "pending-messages";
+export const accountUnreadKey = "account-unread";
 
 // Trash views (soft-deleted resources, restorable ~30 days).
 // deletedAgentsKey backs the account-wide /trash page
@@ -122,10 +123,14 @@ export function invalidateAllAgentMessages() {
 }
 
 // After a message is read (its detail fetch flips inbox_status → read on
-// the backend), the Inboxes list unread badge for that agent is stale.
-// Revalidate its per-agent probe so the count drops without a hard refresh.
+// the backend), both its per-agent badge and the account-wide total are
+// stale. Leave every other agent's independent unread probe untouched.
 export function invalidateAgentUnread(email: string) {
-  return mutate(agentUnreadKey(email));
+  return mutate(
+    (key) =>
+      key === accountUnreadKey ||
+      (Array.isArray(key) && key[0] === "agent-unread" && key[1] === email),
+  );
 }
 
 export function invalidateDomains() {


### PR DESCRIPTION
## Summary

- show the account-wide unread inbound-message count beside **Inboxes**, matching the existing **Pending** badge and capping the label at `99+`
- aggregate existing per-inbox unread probes with visible/online polling, complete agent pagination, stale-data retention, and shared cache invalidation
- refresh unread state immediately after inbound reads and successful inbox delete/restore operations without blocking navigation

## Why

New inbound email was stored as unread, but the global sidebar had no unread signal. Users could miss new mail unless they were already viewing the Inboxes page.

## Impact

The unread count is now visible throughout the dashboard. Opening an inbound message clears the count immediately, while transient refresh failures preserve the last successful value. No backend or OpenAPI changes are included.

## Validation

- `cd web && npm test -- --runInBand` — 52 suites, 446 tests passed
- `cd web && npm run lint` — 0 errors; one pre-existing hook warning
- `cd web && npm run build` — production static build passed
- live local SMTP seed — Inboxes showed `1`; opening the unread message cleared it; a fresh unread message remains seeded for visual review
