### PR TITLE
feat(web): show canonical message lifecycle

### DIFF
--- a/web/src/app/(app)/inboxes/(view)/messages/view/page.test.tsx
+++ b/web/src/app/(app)/inboxes/(view)/messages/view/page.test.tsx
@@ -128,9 +128,14 @@ function isDetailGet(url: string): boolean {
   return (
     url.includes("/v1/agents/") &&
     url.includes("/messages/") &&
+    !url.endsWith("/lifecycle?limit=100") &&
     !url.endsWith("/approve") &&
     !url.endsWith("/reject")
   );
+}
+
+function isLifecycleGet(url: string): boolean {
+  return url.endsWith("/lifecycle?limit=100");
 }
 
 function jsonText(body: unknown, status = 200) {
@@ -192,6 +197,51 @@ describe("AgentMessageFocusPage", () => {
     expect(screen.getByRole("heading", { name: /Re: Q3 contract renewal/ })).toBeInTheDocument();
     expect(screen.getByTestId("action-card")).toBeInTheDocument();
     expect(screen.getByText(/Awaiting your approval/)).toBeInTheDocument();
+  });
+
+  it("renders the canonical beta lifecycle for a pending review", async () => {
+    setSearchParams({ email: AGENT_EMAIL, id: "msg_pending", direction: "outbound", pending: "1" });
+    mockFetch.mockImplementation((url: string) => {
+      if (isLifecycleGet(url)) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({
+            items: [{
+              id: "mlt_pending",
+              message_id: "msg_pending",
+              direction: "outbound",
+              recipient: "maya@stripe.com",
+              stage: "review",
+              outcome: "pending",
+              reason_code: "review.hold_created",
+              retryable: false,
+              evidence: {},
+              correlation_ids: {},
+              occurred_at: minutesAgo(12),
+              reconstructed: false,
+            }],
+            next_cursor: null,
+          }),
+        });
+      }
+      if (isDetailGet(url)) return jsonText(OUTBOUND_PENDING);
+      return jsonText({}, 404);
+    });
+
+    render(<AgentMessageFocusPage />);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/v1/agents/support%40acme.io/messages/msg_pending/lifecycle?limit=100",
+        { credentials: "include" },
+      );
+    });
+    expect(screen.getByRole("button", { name: /Lifecycle/i })).toHaveAttribute("aria-expanded", "true");
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(await screen.findByText(/review\.hold_created/)).toBeInTheDocument();
+    expect(screen.getAllByText("Pending review")).toHaveLength(2);
+    expect(screen.getByText("Beta")).toBeInTheDocument();
   });
 
   it("renders the headers section open when ?headers=1", async () => {
@@ -559,8 +609,8 @@ describe("AgentMessageFocusPage", () => {
   // post-fix shape on a fetch path that pre-fix code would also have
   // passed), we render WITHOUT the test-utils/swr fresh-Map wrapper,
   // use the module-level SWR cache, pre-seed messageDetailKey(id)
-  // before mounting, and assert mockFetch was never called for the
-  // outbound endpoint. A pre-fix implementation (onSuccess-only seed)
+  // before mounting, and assert the detail endpoint was never called.
+  // The independent lifecycle subresource may still load. A pre-fix implementation (onSuccess-only seed)
   // would observe data via the cache but never fire onSuccess, so
   // the textarea would be empty and the assertion would fail.
   it("seeds the textarea from pre-populated SWR cache without firing a fetch (true cache-hit regression)", async () => {
@@ -585,11 +635,18 @@ describe("AgentMessageFocusPage", () => {
       [{ id: "ag_1", email: "support@acme.io", hitl_enabled: true }],
       { revalidate: false },
     );
-    // Fetch must NOT be called: any call indicates the page hit the
-    // network rather than the cache, defeating the bug reproduction.
-    mockFetch.mockImplementation(() => {
+    // The independent lifecycle may fetch, but the message-detail endpoint
+    // must not: that would defeat the cache-hit reproduction.
+    mockFetch.mockImplementation((url: string) => {
+      if (isLifecycleGet(url)) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ items: [], next_cursor: null }),
+        });
+      }
       throw new Error(
-        "fetch was called — cache hit did not happen, test reproduces nothing",
+        "message detail fetch was called — cache hit did not happen",
       );
     });
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
@@ -604,8 +661,8 @@ describe("AgentMessageFocusPage", () => {
     await waitFor(() => {
       expect(screen.getByTestId("action-card")).toBeInTheDocument();
     });
-    // Assert no outbound fetch happened.
-    expect(mockFetch).not.toHaveBeenCalled();
+    // Assert no message-detail fetch happened.
+    expect(mockFetch.mock.calls.filter(([url]) => isDetailGet(String(url)))).toHaveLength(0);
 
     // The H3 fix's invariant: textarea is seeded from cache-resolved
     // data, even though onSuccess never fired.

--- a/web/src/app/(app)/inboxes/(view)/messages/view/page.test.tsx
+++ b/web/src/app/(app)/inboxes/(view)/messages/view/page.test.tsx
@@ -239,7 +239,8 @@ describe("AgentMessageFocusPage", () => {
     });
     expect(screen.getByRole("button", { name: /Lifecycle/i })).toHaveAttribute("aria-expanded", "true");
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
-    expect(await screen.findByText(/review\.hold_created/)).toBeInTheDocument();
+    expect(await screen.findByText("Waiting for review")).toBeInTheDocument();
+    expect(screen.queryByText(/review\.hold_created/)).not.toBeInTheDocument();
     expect(screen.getAllByText("Pending review")).toHaveLength(2);
     expect(screen.getByText("Beta")).toBeInTheDocument();
   });

--- a/web/src/app/(app)/inboxes/(view)/messages/view/page.tsx
+++ b/web/src/app/(app)/inboxes/(view)/messages/view/page.tsx
@@ -43,6 +43,7 @@ import {
   invalidateAgentUnread,
   invalidateAgents,
   invalidateMessageDetail,
+  invalidateMessageLifecycle,
   invalidatePendingList,
   messageDetailKey,
 } from "../../../../../../lib/swrKeys";
@@ -226,15 +227,18 @@ function FocusContent({
       ? `${inboxLink}#${msg.data.conversation_id ? `conv:${msg.data.conversation_id}` : `orphan:${msg.data.id}`}`
       : inboxLink;
 
-  // Both approve and reject invalidate four SWR caches so the rest
+  // Both approve and reject invalidate five SWR caches so the rest
   // of the dashboard reflects the new state immediately:
-  //   • pendingMessagesKey  → Sidebar badge drops
-  //   • pendingMessageKey   → this focus page itself (the row's
-  //                            status moves from pending_approval
-  //                            to sent/rejected)
-  //   • agentMessagesKey*   → the inbox view drops the pending callout
-  //   • agentsKey           → /inboxes agent cards show updated
-  //                            `pending_count` per agent
+  //   • pendingMessagesKey    → Sidebar badge drops
+  //   • pendingMessageKey     → this focus page itself (the row's
+  //                              status moves from pending_approval
+  //                              to sent/rejected)
+  //   • messageLifecycleKey*  → open lifecycle panels pick up the
+  //                              review-resolution + queueing
+  //                              transitions the action just created
+  //   • agentMessagesKey*     → the inbox view drops the pending callout
+  //   • agentsKey             → /inboxes agent cards show updated
+  //                              `pending_count` per agent
   // We `await Promise.all(...)` before navigating so the inbox
   // re-render happens against fresh data, not the previous payload.
   const refreshAfterMutation = useCallback(
@@ -242,6 +246,7 @@ function FocusContent({
       await Promise.all([
         invalidatePendingList(),
         invalidateMessageDetail(msgId),
+        invalidateMessageLifecycle(email, msgId),
         invalidateAgentMessages(email),
         invalidateAgents(),
       ]);

--- a/web/src/app/(app)/inboxes/(view)/messages/view/page.tsx
+++ b/web/src/app/(app)/inboxes/(view)/messages/view/page.tsx
@@ -35,8 +35,7 @@ import {
 } from "../../../../../components/messages/AttachmentChips";
 import { MessageDirectionIcon } from "../../../../../components/messages/MessageDirectionIcon";
 import {
-  MessageLifecycleTimeline,
-  deriveLifecycleSteps,
+  MessageLifecycleData,
 } from "../../../../../components/messages/MessageLifecycleTimeline";
 import { formatRelativeAge } from "../../../../../../lib/relativeTime";
 import {
@@ -148,11 +147,6 @@ function FocusContent({
   initialHeadersOpen: boolean;
 }) {
   const router = useRouter();
-
-  // Holds are now driven by inbound/outbound policy + content scans
-  // (there's no per-agent HITL on/off flag any more), so the lifecycle
-  // panel always includes the "Held for review" step.
-  const hitlEnabled = true;
 
   // `hasUserEditedRef` flips true the first time the user types into
   // the draft-body textarea OR clicks Edit. The seeding effect (below)
@@ -547,7 +541,7 @@ function FocusContent({
               )}
             </>
           )}
-          <LifecycleSection msg={msg} hitlEnabled={hitlEnabled} />
+          <LifecycleSection msg={msg} email={email} />
           {isPending && msg.direction === "outbound" && (
             <ApproveHint messageId={msg.data.id} />
           )}
@@ -1036,64 +1030,28 @@ function ActionCard({
   );
 }
 
-function LifecycleSection({ msg, hitlEnabled }: { msg: LoadedMessage; hitlEnabled: boolean }) {
-  // Inbound messages don't go through the HITL lifecycle — show a small
-  // "received" summary instead of the timeline.
-  if (msg.direction === "inbound") {
-    return (
-      <section
-        style={{
-          background: "var(--bg-panel)",
-          border: "1px solid var(--border)",
-          borderRadius: "var(--r-lg)",
-          padding: "14px 18px",
-        }}
-      >
-        <Eyebrow>Lifecycle</Eyebrow>
-        <div
-          style={{
-            marginTop: 10,
-            fontFamily: "var(--f-mono)",
-            fontSize: 11,
-            color: "var(--fg-muted)",
-            lineHeight: 1.7,
-          }}
-        >
-          received {formatRelativeAge(msg.data.created_at)}
-        </div>
-      </section>
-    );
-  }
-
-  const d = msg.data;
-  const steps = deriveLifecycleSteps({
-    status: d.status,
-    draftedAt: d.created_at,
-    inboundReceivedAt: d.inbound?.created_at ?? null,
-    reviewedAt: d.reviewed_at ?? null,
-    hitlEnabled,
-  });
-  // Collapsible meta tracks the latest meaningful event. For HITL-off
-  // agents the held step doesn't exist, so we summarize sent/created
-  // directly instead of the misleading "resolved" fallback.
-  const sentAt = d.reviewed_at ?? (!hitlEnabled ? d.created_at : null);
-  const heldSummary = d.status === "pending_review"
-    ? "held"
-    : sentAt
-      ? `${hitlEnabled ? "resolved" : "sent"} ${formatRelativeAge(sentAt)}`
-      : "resolved";
-
+function LifecycleSection({ msg, email }: { msg: LoadedMessage; email: string }) {
   return (
     <Collapsible
       label="Lifecycle"
       meta={
-        <span style={{ color: d.status === "pending_review" ? "var(--warn-strong)" : "var(--fg-subtle)" }}>
-          {heldSummary}
+        <span
+          style={{
+            padding: "1px 5px",
+            borderRadius: 3,
+            background: "var(--info-bg)",
+            color: "var(--info-strong)",
+            fontSize: 9,
+            fontWeight: 700,
+            textTransform: "uppercase",
+          }}
+        >
+          Beta
         </span>
       }
       defaultOpen
     >
-      <MessageLifecycleTimeline steps={steps} />
+      <MessageLifecycleData email={email} messageId={msg.data.id} />
     </Collapsible>
   );
 }

--- a/web/src/app/(app)/inboxes/(view)/messages/view/page.tsx
+++ b/web/src/app/(app)/inboxes/(view)/messages/view/page.tsx
@@ -1034,21 +1034,6 @@ function LifecycleSection({ msg, email }: { msg: LoadedMessage; email: string })
   return (
     <Collapsible
       label="Lifecycle"
-      meta={
-        <span
-          style={{
-            padding: "1px 5px",
-            borderRadius: 3,
-            background: "var(--info-bg)",
-            color: "var(--info-strong)",
-            fontSize: 9,
-            fontWeight: 700,
-            textTransform: "uppercase",
-          }}
-        >
-          Beta
-        </span>
-      }
       defaultOpen
     >
       <MessageLifecycleData email={email} messageId={msg.data.id} />

--- a/web/src/app/(app)/reviews/_components/PendingRow.test.tsx
+++ b/web/src/app/(app)/reviews/_components/PendingRow.test.tsx
@@ -3,6 +3,12 @@ import userEvent from "@testing-library/user-event";
 import { PendingRow } from "./PendingRow";
 import type { PendingMessageSummary } from "../../../components/types";
 
+jest.mock("../../../components/messages/MessageLifecycleTimeline", () => ({
+  MessageLifecycleData: ({ email, messageId }: { email: string; messageId: string }) => (
+    <div>lifecycle:{email}:{messageId}</div>
+  ),
+}));
+
 const AGENT = "support@acme.dev";
 const summary: PendingMessageSummary = {
   id: "msg_1",
@@ -140,6 +146,17 @@ describe("PendingRow", () => {
     expect(screen.getByRole("button", { name: "Approve & send" })).toBeInTheDocument();
     // Editor is opt-in — no Subject input until Edit draft.
     expect(screen.queryByText("Subject")).not.toBeInTheDocument();
+  });
+
+  it("loads the lifecycle lazily beside Details", async () => {
+    stage();
+    const user = userEvent.setup();
+    render(<PendingRow summary={summary} expanded onToggle={() => {}} onResolved={() => {}} />);
+    await screen.findByText(/your refund is on the way/);
+
+    expect(screen.queryByText(`lifecycle:${AGENT}:msg_1`)).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /lifecycle/i }));
+    expect(screen.getByText(`lifecycle:${AGENT}:msg_1`)).toBeInTheDocument();
   });
 
   it("approve POSTs to /approve and calls onResolved", async () => {

--- a/web/src/app/(app)/reviews/_components/PendingRow.tsx
+++ b/web/src/app/(app)/reviews/_components/PendingRow.tsx
@@ -28,6 +28,7 @@ import type {
 import { Chip, Dot } from "@e2a/ui";
 import { diffApproveEdits, joinCSV } from "./edits";
 import { categoryLabel, holdReasonSummary } from "./reviewReason";
+import { MessageLifecycleData } from "../../../components/messages/MessageLifecycleTimeline";
 
 function formatQueuedAgo(iso: string): string {
   const sec = Math.floor((Date.now() - new Date(iso).getTime()) / 1000);
@@ -110,6 +111,7 @@ export function PendingRow({
   // revalidation can't stomp an in-progress edit.
   const hasUserEditedRef = useRef(false);
   const [showDetails, setShowDetails] = useState(false);
+  const [showLifecycle, setShowLifecycle] = useState(false);
   const [showScreeningDetails, setShowScreeningDetails] = useState(false);
   const [rejectOpen, setRejectOpen] = useState(false);
 
@@ -150,6 +152,7 @@ export function PendingRow({
       setEditing(false);
       setRejectOpen(false);
       setShowDetails(false);
+      setShowLifecycle(false);
       setShowScreeningDetails(false);
       setActionError("");
     }
@@ -380,14 +383,25 @@ export function PendingRow({
                         ? `from ${summary.from || "—"}`
                         : `to ${joinCSV(msg.to) || "—"}`}
                     </span>
-                    <button
-                      type="button"
-                      onClick={() => setShowDetails((s) => !s)}
-                      className="font-mono text-[11px] shrink-0 cursor-pointer hover:underline"
-                      style={{ color: "var(--fg-subtle)" }}
-                    >
-                      Details {showDetails ? "▴" : "▾"}
-                    </button>
+                    <div className="flex items-center gap-2 shrink-0">
+                      <button
+                        type="button"
+                        onClick={() => setShowDetails((s) => !s)}
+                        className="font-mono text-[11px] cursor-pointer hover:underline"
+                        style={{ color: "var(--fg-subtle)" }}
+                      >
+                        Details {showDetails ? "▴" : "▾"}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setShowLifecycle((shown) => !shown)}
+                        aria-expanded={showLifecycle}
+                        className="font-mono text-[11px] cursor-pointer hover:underline"
+                        style={{ color: "var(--accent-strong)" }}
+                      >
+                        {showLifecycle ? "Hide lifecycle ▴" : "Lifecycle ▾"}
+                      </button>
+                    </div>
                   </div>
                   {showDetails && (
                     <div
@@ -401,6 +415,18 @@ export function PendingRow({
                       {msg.conversation_id && (
                         <span>conversation {msg.conversation_id}</span>
                       )}
+                    </div>
+                  )}
+                  {showLifecycle && (
+                    <div
+                      className="mb-3"
+                      style={{
+                        border: "1px solid var(--border-sub)",
+                        borderRadius: "var(--r-md)",
+                        overflow: "hidden",
+                      }}
+                    >
+                      <MessageLifecycleData email={agentEmail} messageId={id} />
                     </div>
                   )}
                   <div

--- a/web/src/app/(app)/reviews/page.tsx
+++ b/web/src/app/(app)/reviews/page.tsx
@@ -8,6 +8,7 @@ import {
   invalidateAgents,
   invalidateAllAgentMessages,
   invalidateMessageDetail,
+  invalidateMessageLifecycle,
   pendingMessagesKey,
 } from "../../../lib/swrKeys";
 import type { PendingMessageSummary } from "../../components/types";
@@ -56,17 +57,21 @@ function PendingContent() {
 
   // After approve/reject: refetch the queue, collapse to a clean list,
   // and invalidate the derived caches (sidebar badge, agent cards, the
-  // inbox views) so the resolved row drops everywhere — mirroring what
-  // the focus page used to do.
+  // inbox views, the resolved message's lifecycle panel) so the resolved
+  // row drops everywhere — mirroring what the focus page used to do.
   const handleResolved = useCallback(async () => {
+    const resolved = messages.find((m) => m.id === selectedId);
     void Promise.all([
       selectedId ? invalidateMessageDetail(selectedId) : Promise.resolve(),
+      resolved
+        ? invalidateMessageLifecycle(resolved.agent_email, resolved.id)
+        : Promise.resolve(),
       invalidateAgents(),
       invalidateAllAgentMessages(),
     ]);
     router.replace("/reviews", { scroll: false });
     await mutate(pendingMessagesKey);
-  }, [router, selectedId]);
+  }, [router, selectedId, messages]);
 
   return (
     <PageShell

--- a/web/src/app/components/messages/MessageLifecycleData.test.tsx
+++ b/web/src/app/components/messages/MessageLifecycleData.test.tsx
@@ -1,0 +1,66 @@
+import { fireEvent, render, screen } from "../../../test-utils/swr";
+import { getMessageLifecycle } from "../../../lib/messageLifecycle";
+import { MessageLifecycleData } from "./MessageLifecycleTimeline";
+
+jest.mock("../../../lib/messageLifecycle", () => ({
+  ...jest.requireActual("../../../lib/messageLifecycle"),
+  getMessageLifecycle: jest.fn(),
+}));
+
+const mockGetLifecycle = getMessageLifecycle as jest.MockedFunction<
+  typeof getMessageLifecycle
+>;
+
+const transition = (id: string, reason: "acceptance.outbound_api" | "submission.upstream_accepted") => ({
+  id,
+  message_id: "msg_pages",
+  direction: "outbound" as const,
+  recipient: "person@example.com",
+  stage: reason === "acceptance.outbound_api" ? "accepted" as const : "submission" as const,
+  outcome: "accepted" as const,
+  reason_code: reason,
+  retryable: false,
+  evidence: {},
+  correlation_ids: {},
+  occurred_at: reason === "acceptance.outbound_api" ? "2026-07-22T12:00:00Z" : "2026-07-22T12:01:00Z",
+  reconstructed: false,
+});
+
+afterEach(() => mockGetLifecycle.mockReset());
+
+describe("MessageLifecycleData", () => {
+  it("loads subsequent cursor pages without losing earlier observations", async () => {
+    mockGetLifecycle
+      .mockResolvedValueOnce({
+        items: [transition("mlt_1", "acceptance.outbound_api")],
+        next_cursor: "cursor_2",
+      })
+      .mockResolvedValueOnce({
+        items: [transition("mlt_2", "submission.upstream_accepted")],
+        next_cursor: null,
+      });
+
+    render(<MessageLifecycleData email="agent@example.com" messageId="msg_pages" />);
+
+    expect(await screen.findByText("Accepted by e2a")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /load more observations/i }));
+    expect(await screen.findByText("Accepted by upstream provider")).toBeInTheDocument();
+    expect(screen.getByText("Accepted by e2a")).toBeInTheDocument();
+    expect(mockGetLifecycle).toHaveBeenLastCalledWith(
+      "agent@example.com",
+      "msg_pages",
+      { cursor: "cursor_2", limit: 100 },
+    );
+  });
+
+  it("renders honest empty and unavailable states", async () => {
+    mockGetLifecycle.mockResolvedValueOnce({ items: [], next_cursor: null });
+    const empty = render(<MessageLifecycleData email="agent@example.com" messageId="msg_empty" />);
+    expect(await screen.findByText(/No lifecycle observations/)).toBeInTheDocument();
+    empty.unmount();
+
+    mockGetLifecycle.mockRejectedValueOnce(new Error("offline"));
+    render(<MessageLifecycleData email="agent@example.com" messageId="msg_error" />);
+    expect(await screen.findByRole("alert")).toHaveTextContent("Lifecycle unavailable");
+  });
+});

--- a/web/src/app/components/messages/MessageLifecycleData.test.tsx
+++ b/web/src/app/components/messages/MessageLifecycleData.test.tsx
@@ -44,7 +44,7 @@ describe("MessageLifecycleData", () => {
 
     expect(await screen.findByText("Accepted by e2a")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /load more observations/i }));
-    expect(await screen.findByText("Accepted by upstream provider")).toBeInTheDocument();
+    expect(await screen.findByText("Handed off to delivery provider")).toBeInTheDocument();
     expect(screen.getByText("Accepted by e2a")).toBeInTheDocument();
     expect(mockGetLifecycle).toHaveBeenLastCalledWith(
       "agent@example.com",

--- a/web/src/app/components/messages/MessageLifecycleTimeline.test.ts
+++ b/web/src/app/components/messages/MessageLifecycleTimeline.test.ts
@@ -2,7 +2,12 @@
 
 import { fireEvent, render, screen } from "@testing-library/react";
 import { createElement, type ComponentType } from "react";
-import { MessageLifecycleTimeline } from "./MessageLifecycleTimeline";
+import {
+  LIFECYCLE_PRESENTATION,
+  MessageLifecycleTimeline,
+  formatLifecycleDiagnostics,
+} from "./MessageLifecycleTimeline";
+import { MESSAGE_LIFECYCLE_REASON_CODES } from "../../../lib/messageLifecycle";
 
 const transition = (overrides: Record<string, unknown> = {}) => ({
   id: "mlt_1",
@@ -27,6 +32,12 @@ const renderTimeline = (transitions: Array<Record<string, unknown>>) =>
   render(createElement(CanonicalTimeline, { transitions }));
 
 describe("MessageLifecycleTimeline canonical observations", () => {
+  it("defines friendly presentation copy for every canonical reason code", () => {
+    expect(Object.keys(LIFECYCLE_PRESENTATION).sort()).toEqual(
+      [...MESSAGE_LIFECYCLE_REASON_CODES].sort(),
+    );
+  });
+
   it("renders observations as an overflow-safe horizontal timeline", () => {
     renderTimeline([
       transition(),
@@ -53,7 +64,13 @@ describe("MessageLifecycleTimeline canonical observations", () => {
     renderTimeline([transition()]);
 
     expect(screen.getByText("Accepted by e2a")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "e2a accepted and saved this message. It is waiting for the next delivery step.",
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByText("Accepted · awaiting next observation")).toBeInTheDocument();
+    expect(screen.queryByText("acceptance.outbound_api")).not.toBeInTheDocument();
     expect(screen.queryByText(/sent to recipient/i)).not.toBeInTheDocument();
   });
 
@@ -70,7 +87,10 @@ describe("MessageLifecycleTimeline canonical observations", () => {
     ]);
 
     expect(screen.getByText("Pending review")).toBeInTheDocument();
-    expect(screen.getByText("Held for review")).toBeInTheDocument();
+    expect(screen.getByText("Waiting for review")).toBeInTheDocument();
+    expect(
+      screen.getByText("This message is waiting for approval before e2a sends it."),
+    ).toBeInTheDocument();
   });
 
   it("calls provider acceptance sent while keeping recipient-server delivery distinct", () => {
@@ -87,8 +107,47 @@ describe("MessageLifecycleTimeline canonical observations", () => {
     ]);
 
     expect(screen.getByText("Sent")).toBeInTheDocument();
-    expect(screen.getByText("Accepted by upstream provider")).toBeInTheDocument();
+    expect(screen.getByText("Handed off to delivery provider")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "e2a successfully handed off the message, and the provider agreed to process it.",
+      ),
+    ).toBeInTheDocument();
     expect(screen.queryByText(/recipient server/i)).not.toBeInTheDocument();
+  });
+
+  it("keeps machine outcomes beside the diagnostics instead of across the stage heading", () => {
+    renderTimeline([
+      transition({
+        stage: "queued",
+        outcome: "enqueued",
+        reason_code: "queue.outbound_submission",
+      }),
+    ]);
+
+    expect(screen.getByText("Queued for delivery")).toBeInTheDocument();
+    expect(
+      screen.getByText("The message is waiting to be handed off to the delivery provider."),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Enqueued")).not.toBeInTheDocument();
+    expect(screen.queryByText("queue.outbound_submission")).not.toBeInTheDocument();
+  });
+
+  it("keeps recipient-server acceptance distinct from inbox placement", () => {
+    renderTimeline([
+      transition({
+        stage: "delivery",
+        outcome: "delivered",
+        reason_code: "delivery.recipient_server_accepted",
+      }),
+    ]);
+
+    expect(screen.getByText("Accepted by recipient server")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "The recipient's mail server accepted the message. This does not confirm inbox placement.",
+      ),
+    ).toBeInTheDocument();
   });
 
   it("reveals safe evidence, correlation ids, retryability, and reconstruction on demand", () => {
@@ -103,9 +162,74 @@ describe("MessageLifecycleTimeline canonical observations", () => {
 
     expect(screen.queryByText("smtp_code")).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /diagnostics/i }));
+    expect(
+      screen.getByText("Include these details when filing feedback or reporting a bug."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Transition ID")).toBeInTheDocument();
+    expect(screen.getByText("Message ID")).toBeInTheDocument();
+    expect(screen.getByText("Direction")).toBeInTheDocument();
+    expect(screen.getByText("Stage")).toBeInTheDocument();
+    expect(screen.getByText("Occurred at")).toBeInTheDocument();
     expect(screen.getByText("Reconstructed from durable history")).toBeInTheDocument();
     expect(screen.getByText("Retryable")).toBeInTheDocument();
     expect(screen.getByText("smtp_code")).toBeInTheDocument();
     expect(screen.getByText("job_id")).toBeInTheDocument();
+  });
+
+  it("formats deterministic support diagnostics without message content", () => {
+    const row = transition({
+      evidence: { zeta: 2, alpha: { second: true, first: false } },
+      correlation_ids: { z_job: "9", a_provider: "1" },
+    });
+
+    const diagnostics = formatLifecycleDiagnostics(
+      row as Parameters<typeof formatLifecycleDiagnostics>[0],
+    );
+    expect(diagnostics).toContain('Evidence: {"alpha":{"first":false,"second":true},"zeta":2}');
+    expect(diagnostics).toContain('Correlation IDs: {"a_provider":"1","z_job":"9"}');
+    expect(diagnostics).not.toMatch(/body|html|raw_message|attachments/i);
+  });
+
+  it("copies support diagnostics and confirms success", async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText },
+    });
+    renderTimeline([transition()]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Diagnostics" }));
+    fireEvent.click(screen.getByRole("button", { name: "Copy diagnostics" }));
+
+    expect(await screen.findByRole("button", { name: "Copied" })).toBeInTheDocument();
+    expect(writeText).toHaveBeenCalledWith(
+      formatLifecycleDiagnostics(
+        transition() as Parameters<typeof formatLifecycleDiagnostics>[0],
+      ),
+    );
+  });
+
+  it("keeps diagnostics visible when clipboard access fails", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { writeText: jest.fn().mockRejectedValue(new Error("denied")) },
+    });
+    renderTimeline([transition()]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Diagnostics" }));
+    fireEvent.click(screen.getByRole("button", { name: "Copy diagnostics" }));
+
+    expect(
+      await screen.findByRole("button", { name: "Copy failed — try again" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Transition ID")).toBeInTheDocument();
+  });
+
+  it("labels the shared lifecycle panel as beta", () => {
+    renderTimeline([transition()]);
+
+    const timeline = screen.getByTestId("lifecycle-timeline");
+    expect(timeline).toHaveTextContent("Lifecycle");
+    expect(timeline).toHaveTextContent("Beta");
   });
 });

--- a/web/src/app/components/messages/MessageLifecycleTimeline.test.ts
+++ b/web/src/app/components/messages/MessageLifecycleTimeline.test.ts
@@ -1,126 +1,89 @@
-// Lifecycle step derivation contract.
+// Canonical lifecycle presentation contract.
 
-import { deriveLifecycleSteps } from "./MessageLifecycleTimeline";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { createElement, type ComponentType } from "react";
+import { MessageLifecycleTimeline } from "./MessageLifecycleTimeline";
 
-describe("deriveLifecycleSteps", () => {
-  it("pending_approval w/ inbound parent → 4 steps, 3rd is current, 4th pending", () => {
-    const steps = deriveLifecycleSteps({
-      status: "pending_review",
-      draftedAt: "2026-05-24T14:18:09Z",
-      inboundReceivedAt: "2026-05-24T14:05:12Z",
-    });
-    expect(steps.map((s) => s.label)).toEqual([
-      "Inbound received",
-      "Agent drafted reply",
-      "Held for review",
-      "Sent to recipient",
+const transition = (overrides: Record<string, unknown> = {}) => ({
+  id: "mlt_1",
+  message_id: "msg_1",
+  direction: "outbound",
+  recipient: "person@example.com",
+  stage: "accepted",
+  outcome: "accepted",
+  reason_code: "acceptance.outbound_api",
+  retryable: false,
+  evidence: {},
+  correlation_ids: {},
+  occurred_at: "2026-07-22T12:00:00Z",
+  reconstructed: false,
+  ...overrides,
+});
+
+const CanonicalTimeline = MessageLifecycleTimeline as unknown as ComponentType<{
+  transitions: Array<Record<string, unknown>>;
+}>;
+const renderTimeline = (transitions: Array<Record<string, unknown>>) =>
+  render(createElement(CanonicalTimeline, { transitions }));
+
+describe("MessageLifecycleTimeline canonical observations", () => {
+  it("shows an accepted-only message without claiming it was sent", () => {
+    renderTimeline([transition()]);
+
+    expect(screen.getByText("Accepted by e2a")).toBeInTheDocument();
+    expect(screen.getByText("Accepted · awaiting next observation")).toBeInTheDocument();
+    expect(screen.queryByText(/sent to recipient/i)).not.toBeInTheDocument();
+  });
+
+  it("distinguishes pending review from upstream acceptance", () => {
+    renderTimeline([
+      transition(),
+      transition({
+        id: "mlt_2",
+        stage: "review",
+        outcome: "pending",
+        reason_code: "review.hold_created",
+        occurred_at: "2026-07-22T12:01:00Z",
+      }),
     ]);
-    expect(steps[2].current).toBe(true);
-    expect(steps[3].pending).toBe(true);
+
+    expect(screen.getByText("Pending review")).toBeInTheDocument();
+    expect(screen.getByText("Held for review")).toBeInTheDocument();
   });
 
-  it("plain outbound (no inbound parent) → 3 steps", () => {
-    const steps = deriveLifecycleSteps({
-      status: "pending_review",
-      draftedAt: "2026-05-24T14:18:09Z",
-    });
-    expect(steps.map((s) => s.label)).toEqual([
-      "Agent drafted reply",
-      "Held for review",
-      "Sent to recipient",
+  it("calls provider acceptance sent while keeping recipient-server delivery distinct", () => {
+    renderTimeline([
+      transition(),
+      transition({
+        id: "mlt_2",
+        stage: "submission",
+        outcome: "accepted",
+        reason_code: "submission.upstream_accepted",
+        correlation_ids: { provider_message_id: "provider-123" },
+        occurred_at: "2026-07-22T12:02:00Z",
+      }),
     ]);
+
+    expect(screen.getByText("Sent")).toBeInTheDocument();
+    expect(screen.getByText("Accepted by upstream provider")).toBeInTheDocument();
+    expect(screen.queryByText(/recipient server/i)).not.toBeInTheDocument();
   });
 
-  it("sent → final step is success 'Sent to recipient'", () => {
-    const steps = deriveLifecycleSteps({
-      status: "sent",
-      draftedAt: "2026-05-24T14:18:09Z",
-      reviewedAt: "2026-05-24T14:25:00Z",
-    });
-    const last = steps[steps.length - 1];
-    expect(last.label).toBe("Sent to recipient");
-    expect(last.kind).toBe("success");
-    expect(last.pending).toBeUndefined();
-  });
-
-  it("expired_approved → 'auto-approved' caption on the final step", () => {
-    const steps = deriveLifecycleSteps({
-      status: "review_expired_approved",
-      draftedAt: "2026-05-24T14:18:09Z",
-      reviewedAt: "2026-05-24T15:18:09Z",
-    });
-    const last = steps[steps.length - 1];
-    expect(last.label).toBe("Sent to recipient");
-    expect(last.caption).toContain("auto-approved");
-  });
-
-  it("rejected → 'Rejected' final step", () => {
-    const steps = deriveLifecycleSteps({
-      status: "review_rejected",
-      draftedAt: "2026-05-24T14:18:09Z",
-      reviewedAt: "2026-05-24T14:22:00Z",
-    });
-    const last = steps[steps.length - 1];
-    expect(last.label).toBe("Rejected");
-    expect(last.caption).toContain("by reviewer");
-  });
-
-  it("expired_rejected → 'Rejected' final step, 'auto-rejected' caption", () => {
-    const steps = deriveLifecycleSteps({
-      status: "review_expired_rejected",
-      draftedAt: "2026-05-24T14:18:09Z",
-      reviewedAt: "2026-05-24T15:18:09Z",
-    });
-    const last = steps[steps.length - 1];
-    expect(last.label).toBe("Rejected");
-    expect(last.caption).toContain("auto-rejected");
-  });
-
-  it("hitlEnabled=false → skips the Held step and uses draftedAt as the delivered timestamp", () => {
-    const steps = deriveLifecycleSteps({
-      status: "sent",
-      draftedAt: "2026-05-24T14:18:09Z",
-      hitlEnabled: false,
-    });
-    expect(steps.map((s) => s.label)).toEqual([
-      "Agent drafted reply",
-      "Sent to recipient",
+  it("reveals safe evidence, correlation ids, retryability, and reconstruction on demand", () => {
+    renderTimeline([
+      transition({
+        reconstructed: true,
+        retryable: true,
+        evidence: { smtp_code: 451 },
+        correlation_ids: { job_id: "42" },
+      }),
     ]);
-    const sent = steps[steps.length - 1];
-    expect(sent.caption).toMatch(/delivered$/);
-    // Caption must carry a real timestamp, not the "—" placeholder
-    // that this fix is replacing.
-    expect(sent.caption).not.toMatch(/^—/);
-  });
 
-  it("hitlEnabled=false w/ inbound parent → Inbound + Drafted + Sent, no Held", () => {
-    const steps = deriveLifecycleSteps({
-      status: "sent",
-      draftedAt: "2026-05-24T14:18:09Z",
-      inboundReceivedAt: "2026-05-24T14:05:12Z",
-      hitlEnabled: false,
-    });
-    expect(steps.map((s) => s.label)).toEqual([
-      "Inbound received",
-      "Agent drafted reply",
-      "Sent to recipient",
-    ]);
-  });
-
-  it("Held step is always present; status drives current/terminal caption", () => {
-    const pending = deriveLifecycleSteps({
-      status: "pending_review",
-      draftedAt: "2026-05-24T14:18:09Z",
-    });
-    const held = pending.find((s) => s.label === "Held for review");
-    expect(held?.current).toBe(true);
-    expect(held?.caption).toBe("awaiting reviewer");
-
-    const sent = deriveLifecycleSteps({
-      status: "sent",
-      draftedAt: "2026-05-24T14:18:09Z",
-      reviewedAt: "2026-05-24T14:25:00Z",
-    });
-    expect(sent.find((s) => s.label === "Held for review")?.caption).toContain("resolved");
+    expect(screen.queryByText("smtp_code")).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /diagnostics/i }));
+    expect(screen.getByText("Reconstructed from durable history")).toBeInTheDocument();
+    expect(screen.getByText("Retryable")).toBeInTheDocument();
+    expect(screen.getByText("smtp_code")).toBeInTheDocument();
+    expect(screen.getByText("job_id")).toBeInTheDocument();
   });
 });

--- a/web/src/app/components/messages/MessageLifecycleTimeline.test.ts
+++ b/web/src/app/components/messages/MessageLifecycleTimeline.test.ts
@@ -27,6 +27,28 @@ const renderTimeline = (transitions: Array<Record<string, unknown>>) =>
   render(createElement(CanonicalTimeline, { transitions }));
 
 describe("MessageLifecycleTimeline canonical observations", () => {
+  it("renders observations as an overflow-safe horizontal timeline", () => {
+    renderTimeline([
+      transition(),
+      transition({
+        id: "mlt_2",
+        stage: "queued",
+        outcome: "enqueued",
+        reason_code: "queue.outbound_submission",
+        occurred_at: "2026-07-22T12:01:00Z",
+      }),
+    ]);
+
+    const observations = screen.getByRole("list", {
+      name: "Message lifecycle observations",
+    });
+    expect(observations).toHaveStyle({
+      display: "grid",
+      gridAutoFlow: "column",
+      overflowX: "auto",
+    });
+  });
+
   it("shows an accepted-only message without claiming it was sent", () => {
     renderTimeline([transition()]);
 

--- a/web/src/app/components/messages/MessageLifecycleTimeline.tsx
+++ b/web/src/app/components/messages/MessageLifecycleTimeline.tsx
@@ -323,7 +323,7 @@ export function MessageLifecycleTimeline({
           {lifecycleSummary(transitions[transitions.length - 1])}
         </div>
         <div style={{ marginTop: 2, fontFamily: "var(--f-mono)", fontSize: 10, color: "var(--fg-subtle)" }}>
-          Observations recorded by e2a · not an inbox-placement claim
+          Observations recorded by e2a
         </div>
       </div>
       <ol

--- a/web/src/app/components/messages/MessageLifecycleTimeline.tsx
+++ b/web/src/app/components/messages/MessageLifecycleTimeline.tsx
@@ -10,37 +10,41 @@ import {
   type MessageLifecycleTransitionWire,
 } from "../../../lib/messageLifecycle";
 
-const REASON_LABELS: Record<MessageLifecycleTransitionWire["reason_code"], string> = {
-  "acceptance.inbound_smtp": "Accepted via inbound SMTP",
-  "acceptance.outbound_api": "Accepted by e2a",
-  "acceptance.local_loopback": "Accepted for local delivery",
-  "authentication.dmarc_pass": "DMARC passed",
-  "authentication.dmarc_fail": "DMARC failed",
-  "authentication.dmarc_none": "DMARC had no policy",
-  "authentication.dmarc_temporary_error": "DMARC check temporarily unavailable",
-  "authentication.dmarc_permanent_error": "DMARC check failed",
-  "review.hold_created": "Held for review",
-  "review.approved": "Review approved",
-  "review.rejected": "Review rejected",
-  "review.expired_approved": "Review expired and was approved",
-  "review.expired_rejected": "Review expired and was rejected",
-  "suppression.recipient_blocked": "Recipient suppressed",
-  "suppression.hard_bounce_applied": "Suppressed after hard bounce",
-  "suppression.complaint_applied": "Suppressed after complaint",
-  "queue.inbound_processing": "Queued for inbound processing",
-  "queue.outbound_submission": "Queued for submission",
-  "submission.upstream_accepted": "Accepted by upstream provider",
-  "submission.local_loopback_accepted": "Accepted for local delivery",
-  "submission.temporary_failure": "Submission delayed",
-  "submission.provider_rejected": "Rejected by upstream provider",
-  "submission.local_retries_exhausted": "Submission retries exhausted",
-  "submission.cancelled": "Submission cancelled",
-  "delivery.recipient_server_accepted": "Accepted by recipient server",
-  "delivery.temporary_delay": "Delivery temporarily delayed",
-  "delivery.permanent_bounce": "Permanently bounced",
-  "delivery.transient_bounce": "Temporarily bounced",
-  "delivery.undetermined_bounce": "Bounce classification unavailable",
-  "complaint.recipient_reported": "Recipient reported spam",
+type ReasonCode = MessageLifecycleTransitionWire["reason_code"];
+
+export type LifecyclePresentation = { title: string; description: string };
+
+export const LIFECYCLE_PRESENTATION: Record<ReasonCode, LifecyclePresentation> = {
+  "acceptance.inbound_smtp": { title: "Received by e2a", description: "e2a received and saved this incoming message. It is waiting to be processed." },
+  "acceptance.outbound_api": { title: "Accepted by e2a", description: "e2a accepted and saved this message. It is waiting for the next delivery step." },
+  "acceptance.local_loopback": { title: "Accepted for local delivery", description: "e2a accepted this message for delivery to another e2a inbox." },
+  "authentication.dmarc_pass": { title: "Sender authentication passed", description: "The sender's domain authentication checks passed." },
+  "authentication.dmarc_fail": { title: "Sender authentication failed", description: "The message failed its sender-domain authentication check. Treat it with caution." },
+  "authentication.dmarc_none": { title: "No DMARC policy found", description: "The sender's domain does not publish a DMARC policy, so this check could not confirm the sender." },
+  "authentication.dmarc_temporary_error": { title: "Authentication temporarily unavailable", description: "e2a could not complete the sender authentication check because of a temporary error." },
+  "authentication.dmarc_permanent_error": { title: "Authentication check failed", description: "e2a could not complete the sender authentication check." },
+  "review.hold_created": { title: "Waiting for review", description: "This message is waiting for approval before e2a sends it." },
+  "review.approved": { title: "Review approved", description: "A reviewer approved this message. e2a can now send it." },
+  "review.rejected": { title: "Review rejected", description: "A reviewer rejected this message, so e2a will not send it." },
+  "review.expired_approved": { title: "Automatically approved", description: "The review period expired, and the configured policy approved the message." },
+  "review.expired_rejected": { title: "Automatically rejected", description: "The review period expired, and the configured policy rejected the message." },
+  "suppression.recipient_blocked": { title: "Delivery blocked", description: "e2a did not send the message because this recipient is blocked." },
+  "suppression.hard_bounce_applied": { title: "Recipient suppressed", description: "Future messages to this recipient were blocked after a permanent delivery failure." },
+  "suppression.complaint_applied": { title: "Recipient suppressed", description: "Future messages to this recipient were blocked after a spam complaint." },
+  "queue.inbound_processing": { title: "Queued for processing", description: "The incoming message is waiting for e2a to process it." },
+  "queue.outbound_submission": { title: "Queued for delivery", description: "The message is waiting to be handed off to the delivery provider." },
+  "submission.upstream_accepted": { title: "Handed off to delivery provider", description: "e2a successfully handed off the message, and the provider agreed to process it." },
+  "submission.local_loopback_accepted": { title: "Handed off within e2a", description: "e2a accepted the message for delivery to another e2a inbox." },
+  "submission.temporary_failure": { title: "Delivery handoff delayed", description: "e2a could not hand off the message because of a temporary error. It may be retried." },
+  "submission.provider_rejected": { title: "Delivery provider rejected message", description: "The delivery provider refused the message, so it was not handed off." },
+  "submission.local_retries_exhausted": { title: "Delivery failed", description: "e2a could not hand off the message after repeated attempts." },
+  "submission.cancelled": { title: "Delivery cancelled", description: "Delivery was stopped before the message was handed off." },
+  "delivery.recipient_server_accepted": { title: "Accepted by recipient server", description: "The recipient's mail server accepted the message. This does not confirm inbox placement." },
+  "delivery.temporary_delay": { title: "Delivery delayed", description: "The delivery provider reported a temporary delay." },
+  "delivery.permanent_bounce": { title: "Delivery failed permanently", description: "The recipient's mail server permanently rejected the message." },
+  "delivery.transient_bounce": { title: "Temporary delivery failure", description: "The provider reported a temporary delivery failure." },
+  "delivery.undetermined_bounce": { title: "Delivery failed", description: "The provider reported a bounce but did not identify whether it was temporary or permanent." },
+  "complaint.recipient_reported": { title: "Spam complaint received", description: "The recipient reported this message as spam. Future messages may be blocked." },
 };
 
 function lifecycleSummary(last: MessageLifecycleTransitionWire): string {
@@ -77,7 +81,7 @@ function lifecycleSummary(last: MessageLifecycleTransitionWire): string {
     case "suppression.recipient_blocked":
       return "Failed";
     default:
-      return REASON_LABELS[last.reason_code];
+      return LIFECYCLE_PRESENTATION[last.reason_code].title;
   }
 }
 
@@ -106,6 +110,39 @@ function formatTimestamp(iso: string): string {
   });
 }
 
+function stableValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stableValue);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, nested]) => [key, stableValue(nested)]),
+    );
+  }
+  return value;
+}
+
+function stableJSON(value: unknown): string {
+  return JSON.stringify(stableValue(value));
+}
+
+export function formatLifecycleDiagnostics(row: MessageLifecycleTransitionWire): string {
+  return [
+    ["Transition ID", row.id],
+    ["Message ID", row.message_id],
+    ["Direction", row.direction],
+    ["Stage", row.stage],
+    ["Outcome", row.outcome],
+    ["Reason code", row.reason_code],
+    ["Occurred at", row.occurred_at],
+    ["Retryable", String(row.retryable)],
+    ["Reconstructed", String(row.reconstructed)],
+    ["Recipient", row.recipient ?? ""],
+    ["Evidence", stableJSON(row.evidence)],
+    ["Correlation IDs", stableJSON(row.correlation_ids)],
+  ].map(([label, value]) => `${label}: ${value}`).join("\n");
+}
+
 function DiagnosticMap({ title, values }: { title: string; values: Record<string, unknown> }) {
   const entries = Object.entries(values);
   if (entries.length === 0) return null;
@@ -122,9 +159,27 @@ function DiagnosticMap({ title, values }: { title: string; values: Record<string
   );
 }
 
+function DiagnosticField({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex" style={{ gap: 8 }}>
+      <span style={{ color: "var(--fg-muted)" }}>{label}</span>
+      <span style={{ color: "var(--fg)" }}>{value || "—"}</span>
+    </div>
+  );
+}
+
 function CanonicalObservation({ row, last }: { row: MessageLifecycleTransitionWire; last: boolean }) {
   const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
-  const label = REASON_LABELS[row.reason_code];
+  const [copyStatus, setCopyStatus] = useState<"idle" | "copied" | "failed">("idle");
+  const presentation = LIFECYCLE_PRESENTATION[row.reason_code];
+  const copyDiagnostics = async () => {
+    try {
+      await navigator.clipboard.writeText(formatLifecycleDiagnostics(row));
+      setCopyStatus("copied");
+    } catch {
+      setCopyStatus("failed");
+    }
+  };
   return (
     <li style={{ position: "relative", minWidth: 0 }}>
       {!last && (
@@ -153,16 +208,14 @@ function CanonicalObservation({ row, last }: { row: MessageLifecycleTransitionWi
         }}
       />
       <div style={{ minWidth: 0, marginTop: 10 }}>
-        <div className="flex items-start" style={{ gap: 8 }}>
-          <div className="flex-1 min-w-0">
-            <div style={{ fontSize: 12, fontWeight: last ? 650 : 500, color: "var(--fg)" }}>{label}</div>
-            <div style={{ fontFamily: "var(--f-mono)", fontSize: 10, color: "var(--fg-subtle)", marginTop: 2 }}>
-              {formatTimestamp(row.occurred_at)} · {row.reason_code}
-            </div>
+        <div>
+          <div style={{ fontSize: 12, fontWeight: last ? 650 : 500, color: "var(--fg)" }}>{presentation.title}</div>
+          <div style={{ fontSize: 11, lineHeight: 1.45, color: "var(--fg-muted)", marginTop: 3 }}>
+            {presentation.description}
           </div>
-          <span style={{ fontFamily: "var(--f-mono)", fontSize: 10, color: observationTone(row), textTransform: "capitalize" }}>
-            {row.outcome}
-          </span>
+          <div style={{ fontFamily: "var(--f-mono)", fontSize: 10, color: "var(--fg-subtle)", marginTop: 4 }}>
+            {formatTimestamp(row.occurred_at)}
+          </div>
         </div>
         <button
           type="button"
@@ -197,10 +250,37 @@ function CanonicalObservation({ row, last }: { row: MessageLifecycleTransitionWi
               overflowWrap: "anywhere",
             }}
           >
-            <div className="flex flex-wrap" style={{ gap: 8, color: "var(--fg-muted)" }}>
-              {row.retryable && <span>Retryable</span>}
-              {row.reconstructed && <span>Reconstructed from durable history</span>}
-              {row.recipient && <span>Recipient: {row.recipient}</span>}
+            <div style={{ color: "var(--fg-muted)", fontFamily: "var(--f-sans)" }}>
+              Include these details when filing feedback or reporting a bug.
+            </div>
+            <button
+              type="button"
+              onClick={() => void copyDiagnostics()}
+              style={{
+                justifySelf: "start",
+                padding: 0,
+                border: 0,
+                background: "transparent",
+                color: "var(--accent-strong)",
+                cursor: "pointer",
+                fontFamily: "inherit",
+                fontSize: "inherit",
+              }}
+            >
+              {copyStatus === "copied" ? "Copied" : copyStatus === "failed" ? "Copy failed — try again" : "Copy diagnostics"}
+            </button>
+            <div style={{ display: "grid", gap: 2 }}>
+              <DiagnosticField label="Transition ID" value={row.id} />
+              <DiagnosticField label="Message ID" value={row.message_id} />
+              <DiagnosticField label="Direction" value={row.direction} />
+              <DiagnosticField label="Stage" value={row.stage} />
+              <DiagnosticField label="Outcome" value={row.outcome} />
+              <DiagnosticField label="Reason code" value={row.reason_code} />
+              <DiagnosticField label="Occurred at" value={row.occurred_at} />
+              <DiagnosticField label="Retryable" value={String(row.retryable)} />
+              <DiagnosticField label="Reconstructed" value={String(row.reconstructed)} />
+              {row.reconstructed && <span style={{ color: "var(--fg-muted)" }}>Reconstructed from durable history</span>}
+              <DiagnosticField label="Recipient" value={row.recipient ?? ""} />
             </div>
             <DiagnosticMap title="Evidence" values={row.evidence} />
             <DiagnosticMap title="Correlation IDs" values={row.correlation_ids} />
@@ -220,6 +300,24 @@ export function MessageLifecycleTimeline({
   return (
     <div data-testid="lifecycle-timeline" style={{ padding: "14px 18px 16px", position: "relative" }}>
       <div style={{ marginBottom: 13 }}>
+        <div className="flex items-center" style={{ gap: 7, marginBottom: 5 }}>
+          <span style={{ fontSize: 11, fontWeight: 650, color: "var(--fg)" }}>Lifecycle</span>
+          <span
+            style={{
+              padding: "1px 4px",
+              borderRadius: 3,
+              background: "var(--info-bg)",
+              color: "var(--info-strong)",
+              fontFamily: "var(--f-mono)",
+              fontSize: 8,
+              fontWeight: 700,
+              letterSpacing: "0.08em",
+              textTransform: "uppercase",
+            }}
+          >
+            Beta
+          </span>
+        </div>
         <div style={{ fontSize: 13, fontWeight: 650, color: "var(--fg)" }}>
           {lifecycleSummary(transitions[transitions.length - 1])}
         </div>

--- a/web/src/app/components/messages/MessageLifecycleTimeline.tsx
+++ b/web/src/app/components/messages/MessageLifecycleTimeline.tsx
@@ -1,201 +1,308 @@
 "use client";
 
-// 4-step vertical timeline shown inside the focus page's Lifecycle
-// collapsible. The four steps cover the outbound HITL lifecycle:
-//
-//   1. Inbound received     (only when this is a reply — for plain
-//      outbound sends the step is omitted)
-//   2. Agent drafted reply
-//   3. Held for HITL approval
-//   4. Sent to recipient
-//
-// We compute step state from the focus payload's status + timestamps.
-// All inputs are pure — the caller passes the resolved values and we
-// render. Keeps the timeline easy to unit-test.
+// Canonical observation timeline shown in the conversation and focus views.
 
-export type LifecycleStepKind = "success" | "info" | "warn" | "neutral";
+import { useState } from "react";
+import useSWRInfinite from "swr/infinite";
+import {
+  getMessageLifecycle,
+  type MessageLifecyclePageWire,
+  type MessageLifecycleTransitionWire,
+} from "../../../lib/messageLifecycle";
 
-export type LifecycleStep = {
-  label: string;
-  /** Mono caption shown under the label (timestamp + sub-info). Empty allowed. */
-  caption: string;
-  /** Dot color. */
-  kind: LifecycleStepKind;
-  /** Step is the current one — gets a warn-bg halo. */
-  current?: boolean;
-  /** Step hasn't happened yet — renders as a dashed outline dot. */
-  pending?: boolean;
+const REASON_LABELS: Record<MessageLifecycleTransitionWire["reason_code"], string> = {
+  "acceptance.inbound_smtp": "Accepted via inbound SMTP",
+  "acceptance.outbound_api": "Accepted by e2a",
+  "acceptance.local_loopback": "Accepted for local delivery",
+  "authentication.dmarc_pass": "DMARC passed",
+  "authentication.dmarc_fail": "DMARC failed",
+  "authentication.dmarc_none": "DMARC had no policy",
+  "authentication.dmarc_temporary_error": "DMARC check temporarily unavailable",
+  "authentication.dmarc_permanent_error": "DMARC check failed",
+  "review.hold_created": "Held for review",
+  "review.approved": "Review approved",
+  "review.rejected": "Review rejected",
+  "review.expired_approved": "Review expired and was approved",
+  "review.expired_rejected": "Review expired and was rejected",
+  "suppression.recipient_blocked": "Recipient suppressed",
+  "suppression.hard_bounce_applied": "Suppressed after hard bounce",
+  "suppression.complaint_applied": "Suppressed after complaint",
+  "queue.inbound_processing": "Queued for inbound processing",
+  "queue.outbound_submission": "Queued for submission",
+  "submission.upstream_accepted": "Accepted by upstream provider",
+  "submission.local_loopback_accepted": "Accepted for local delivery",
+  "submission.temporary_failure": "Submission delayed",
+  "submission.provider_rejected": "Rejected by upstream provider",
+  "submission.local_retries_exhausted": "Submission retries exhausted",
+  "submission.cancelled": "Submission cancelled",
+  "delivery.recipient_server_accepted": "Accepted by recipient server",
+  "delivery.temporary_delay": "Delivery temporarily delayed",
+  "delivery.permanent_bounce": "Permanently bounced",
+  "delivery.transient_bounce": "Temporarily bounced",
+  "delivery.undetermined_bounce": "Bounce classification unavailable",
+  "complaint.recipient_reported": "Recipient reported spam",
 };
 
-export function MessageLifecycleTimeline({ steps }: { steps: LifecycleStep[] }) {
+function lifecycleSummary(last: MessageLifecycleTransitionWire): string {
+  switch (last.reason_code) {
+    case "review.hold_created":
+      return "Pending review";
+    case "acceptance.inbound_smtp":
+    case "acceptance.outbound_api":
+    case "acceptance.local_loopback":
+      return "Accepted · awaiting next observation";
+    case "queue.inbound_processing":
+      return "Queued · awaiting processing";
+    case "queue.outbound_submission":
+      return "Queued · awaiting submission";
+    case "submission.temporary_failure":
+    case "delivery.temporary_delay":
+      return last.retryable ? "Delayed · retrying" : "Delayed";
+    case "submission.upstream_accepted":
+    case "submission.local_loopback_accepted":
+      return "Sent";
+    case "delivery.recipient_server_accepted":
+      return "Delivered to recipient server";
+    case "delivery.permanent_bounce":
+    case "delivery.transient_bounce":
+    case "delivery.undetermined_bounce":
+      return "Bounced";
+    case "complaint.recipient_reported":
+      return "Complaint reported";
+    case "review.rejected":
+    case "review.expired_rejected":
+    case "submission.provider_rejected":
+    case "submission.local_retries_exhausted":
+    case "submission.cancelled":
+    case "suppression.recipient_blocked":
+      return "Failed";
+    default:
+      return REASON_LABELS[last.reason_code];
+  }
+}
+
+function observationTone(row: MessageLifecycleTransitionWire): string {
+  if (["failed", "rejected", "blocked", "bounced", "reported"].includes(row.outcome)) {
+    return "var(--danger-strong)";
+  }
+  if (row.outcome === "pending" || row.outcome === "deferred" || row.retryable) {
+    return "var(--warn-strong)";
+  }
+  if (["passed", "approved", "delivered", "accepted"].includes(row.outcome)) {
+    return "var(--success)";
+  }
+  return "var(--fg-muted)";
+}
+
+function formatTimestamp(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+function DiagnosticMap({ title, values }: { title: string; values: Record<string, unknown> }) {
+  const entries = Object.entries(values);
+  if (entries.length === 0) return null;
   return (
-    <div
-      data-testid="lifecycle-timeline"
-      style={{ padding: "14px 18px 16px", position: "relative" }}
-    >
-      {steps.map((s, i) => (
-        <div
-          key={i}
-          className="flex"
-          style={{
-            gap: 11,
-            position: "relative",
-            paddingBottom: i < steps.length - 1 ? 12 : 0,
-          }}
-        >
-          {/* connector line — only between dots, not after the last */}
-          {i < steps.length - 1 && (
-            <span
-              aria-hidden
-              style={{
-                position: "absolute",
-                left: 5,
-                top: 14,
-                bottom: 0,
-                width: 1,
-                background: "var(--border-sub)",
-              }}
-            />
-          )}
-          <span
-            aria-hidden
-            style={{
-              width: 11,
-              height: 11,
-              borderRadius: "50%",
-              background: s.pending
-                ? "var(--bg-elev)"
-                : s.kind === "success"
-                  ? "var(--success)"
-                  : s.kind === "info"
-                    ? "var(--info)"
-                    : s.kind === "warn"
-                      ? "var(--warn)"
-                      : "var(--fg-subtle)",
-              border: s.pending ? "1px dashed var(--border-strong)" : "none",
-              marginTop: 4,
-              flexShrink: 0,
-              boxShadow: s.current ? "0 0 0 3px var(--warn-bg)" : "none",
-            }}
-          />
-          <div className="flex-1 min-w-0">
-            <div
-              style={{
-                fontSize: 12,
-                fontWeight: s.current ? 600 : 500,
-                color: s.pending ? "var(--fg-subtle)" : "var(--fg)",
-              }}
-            >
-              {s.label}
-            </div>
-            {s.caption && (
-              <div
-                style={{
-                  fontFamily: "var(--f-mono)",
-                  fontSize: 10,
-                  color: "var(--fg-subtle)",
-                  letterSpacing: "0.02em",
-                  marginTop: 1,
-                }}
-              >
-                {s.caption}
-              </div>
-            )}
-          </div>
+    <div>
+      <div style={{ color: "var(--fg-subtle)", marginBottom: 3 }}>{title}</div>
+      {entries.map(([key, value]) => (
+        <div key={key} className="flex" style={{ gap: 8 }}>
+          <span style={{ color: "var(--fg-muted)" }}>{key}</span>
+          <span style={{ color: "var(--fg)" }}>{typeof value === "string" ? value : JSON.stringify(value)}</span>
         </div>
       ))}
     </div>
   );
 }
 
-// Derive the 4-step lifecycle from an outbound focus payload's status +
-// timestamps. Pure function exported for testing.
-export type LifecycleInput = {
-  /** Outbound HITL status: 'sent' | 'pending_approval' | 'rejected' |
-   *  'expired_approved' | 'expired_rejected'. */
-  status: string;
-  /** ISO created_at of the outbound draft. */
-  draftedAt: string;
-  /** Optional ISO timestamp of the parent inbound (only present for replies). */
-  inboundReceivedAt?: string | null;
-  /** Optional ISO timestamp of the approval/rejection action. */
-  reviewedAt?: string | null;
-  /** Whether the owning agent has HITL enabled. When false the held
-   *  step is omitted and the delivered timestamp falls back to
-   *  `draftedAt` (messages go straight from draft → sent). Defaults
-   *  to true to preserve the historical contract. */
-  hitlEnabled?: boolean;
-};
-
-function fmtClock(iso: string): string {
-  const d = new Date(iso);
-  if (isNaN(d.getTime())) return iso;
-  return d.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+function CanonicalObservation({ row, last }: { row: MessageLifecycleTransitionWire; last: boolean }) {
+  const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
+  const label = REASON_LABELS[row.reason_code];
+  return (
+    <div className="flex" style={{ gap: 11, position: "relative", paddingBottom: last ? 0 : 15 }}>
+      {!last && (
+        <span aria-hidden style={{ position: "absolute", left: 5, top: 14, bottom: 0, width: 1, background: "var(--border-sub)" }} />
+      )}
+      <span
+        aria-hidden
+        style={{
+          width: 11,
+          height: 11,
+          marginTop: 4,
+          flexShrink: 0,
+          borderRadius: "50%",
+          background: observationTone(row),
+          boxShadow: last ? "0 0 0 3px var(--bg-elev)" : "none",
+        }}
+      />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-start" style={{ gap: 8 }}>
+          <div className="flex-1 min-w-0">
+            <div style={{ fontSize: 12, fontWeight: last ? 650 : 500, color: "var(--fg)" }}>{label}</div>
+            <div style={{ fontFamily: "var(--f-mono)", fontSize: 10, color: "var(--fg-subtle)", marginTop: 2 }}>
+              {formatTimestamp(row.occurred_at)} · {row.reason_code}
+            </div>
+          </div>
+          <span style={{ fontFamily: "var(--f-mono)", fontSize: 10, color: observationTone(row), textTransform: "capitalize" }}>
+            {row.outcome}
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={() => setDiagnosticsOpen((open) => !open)}
+          aria-expanded={diagnosticsOpen}
+          style={{
+            marginTop: 5,
+            padding: 0,
+            border: 0,
+            background: "transparent",
+            color: "var(--accent-strong)",
+            cursor: "pointer",
+            fontFamily: "var(--f-mono)",
+            fontSize: 10,
+          }}
+        >
+          {diagnosticsOpen ? "Hide diagnostics" : "Diagnostics"}
+        </button>
+        {diagnosticsOpen && (
+          <div
+            style={{
+              display: "grid",
+              gap: 7,
+              marginTop: 7,
+              padding: "8px 10px",
+              background: "var(--bg-elev)",
+              border: "1px solid var(--border-sub)",
+              borderRadius: "var(--r-sm)",
+              fontFamily: "var(--f-mono)",
+              fontSize: 10,
+              lineHeight: 1.5,
+              overflowWrap: "anywhere",
+            }}
+          >
+            <div className="flex flex-wrap" style={{ gap: 8, color: "var(--fg-muted)" }}>
+              {row.retryable && <span>Retryable</span>}
+              {row.reconstructed && <span>Reconstructed from durable history</span>}
+              {row.recipient && <span>Recipient: {row.recipient}</span>}
+            </div>
+            <DiagnosticMap title="Evidence" values={row.evidence} />
+            <DiagnosticMap title="Correlation IDs" values={row.correlation_ids} />
+          </div>
+        )}
+      </div>
+    </div>
+  );
 }
 
-export function deriveLifecycleSteps(input: LifecycleInput): LifecycleStep[] {
-  const steps: LifecycleStep[] = [];
-  const hitlEnabled = input.hitlEnabled ?? true;
+export function MessageLifecycleTimeline({
+  transitions,
+}: {
+  transitions: MessageLifecycleTransitionWire[];
+}) {
+  if (transitions.length === 0) return null;
+  return (
+    <div data-testid="lifecycle-timeline" style={{ padding: "14px 18px 16px", position: "relative" }}>
+      <div style={{ marginBottom: 13 }}>
+        <div style={{ fontSize: 13, fontWeight: 650, color: "var(--fg)" }}>
+          {lifecycleSummary(transitions[transitions.length - 1])}
+        </div>
+        <div style={{ marginTop: 2, fontFamily: "var(--f-mono)", fontSize: 10, color: "var(--fg-subtle)" }}>
+          Observations recorded by e2a · not an inbox-placement claim
+        </div>
+      </div>
+      {transitions.map((row, index) => (
+        <CanonicalObservation key={row.id} row={row} last={index === transitions.length - 1} />
+      ))}
+    </div>
+  );
+}
 
-  if (input.inboundReceivedAt) {
-    steps.push({
-      label: "Inbound received",
-      caption: `${fmtClock(input.inboundReceivedAt)} · auth verified`,
-      kind: "success",
-    });
+export function MessageLifecycleData({
+  email,
+  messageId,
+}: {
+  email: string;
+  messageId: string;
+}) {
+  const { data: pages, error, isLoading, isValidating, size, setSize } = useSWRInfinite<MessageLifecyclePageWire>(
+    (pageIndex, previousPage) => {
+      if (previousPage && previousPage.next_cursor === null) return null;
+      return [
+        "message-lifecycle",
+        email,
+        messageId,
+        pageIndex,
+        previousPage?.next_cursor ?? null,
+      ] as const;
+    },
+    ([, lifecycleEmail, lifecycleMessageId, , cursor]: readonly [
+      string,
+      string,
+      string,
+      number,
+      string | null,
+    ]) =>
+      getMessageLifecycle(
+        lifecycleEmail,
+        lifecycleMessageId,
+        cursor ? { cursor, limit: 100 } : { limit: 100 },
+      ),
+    { shouldRetryOnError: false, revalidateFirstPage: false },
+  );
+  const items = pages?.flatMap((page) => page.items) ?? [];
+  const nextCursor = pages?.[pages.length - 1]?.next_cursor ?? null;
+
+  if (isLoading) {
+    return (
+      <div role="status" style={{ padding: "14px 18px", fontSize: 12, color: "var(--fg-muted)" }}>
+        Loading lifecycle…
+      </div>
+    );
   }
-
-  steps.push({
-    label: "Agent drafted reply",
-    caption: `${fmtClock(input.draftedAt)} · agent`,
-    kind: "info",
-  });
-
-  const terminal =
-    input.status === "sent" ||
-    input.status === "review_rejected" ||
-    input.status === "review_expired_approved" ||
-    input.status === "review_expired_rejected";
-
-  if (hitlEnabled) {
-    steps.push({
-      label: "Held for review",
-      caption: terminal
-        ? input.reviewedAt
-          ? `${fmtClock(input.reviewedAt)} · resolved`
-          : "resolved"
-        : "awaiting reviewer",
-      kind: "warn",
-      current: input.status === "pending_review",
-    });
+  if (error) {
+    return (
+      <div role="alert" style={{ padding: "14px 18px", fontSize: 12, color: "var(--danger-strong)" }}>
+        Lifecycle unavailable. Try again shortly.
+      </div>
+    );
   }
-
-  // When HITL is off the message goes straight from draft → SMTP, so
-  // the draft timestamp is the best signal we have for "delivered."
-  // When HITL is on we still prefer reviewedAt (approval = send-time).
-  const sentAt = input.reviewedAt ?? (hitlEnabled ? null : input.draftedAt);
-
-  if (input.status === "sent" || input.status === "review_expired_approved") {
-    steps.push({
-      label: "Sent to recipient",
-      caption: `${sentAt ? fmtClock(sentAt) : "—"} · ${input.status === "review_expired_approved" ? "auto-approved" : "delivered"}`,
-      kind: "success",
-    });
-  } else if (input.status === "review_rejected" || input.status === "review_expired_rejected") {
-    steps.push({
-      label: "Rejected",
-      caption: `${input.reviewedAt ? fmtClock(input.reviewedAt) : "—"} · ${input.status === "review_expired_rejected" ? "auto-rejected" : "by reviewer"}`,
-      kind: "neutral",
-    });
-  } else {
-    // Pending — last step is in the future.
-    steps.push({
-      label: "Sent to recipient",
-      caption: "— · awaiting reviewer",
-      kind: "neutral",
-      pending: true,
-    });
+  if (items.length === 0) {
+    return (
+      <div style={{ padding: "14px 18px", fontSize: 12, color: "var(--fg-muted)" }}>
+        No lifecycle observations were recorded for this message.
+      </div>
+    );
   }
-
-  return steps;
+  return (
+    <>
+      <MessageLifecycleTimeline transitions={items} />
+      {nextCursor && (
+        <button
+          type="button"
+          onClick={() => void setSize(size + 1)}
+          disabled={isValidating}
+          style={{
+            width: "100%",
+            padding: "9px 18px",
+            background: "var(--bg-elev)",
+            border: 0,
+            borderTop: "1px solid var(--border-sub)",
+            color: "var(--accent-strong)",
+            cursor: isValidating ? "default" : "pointer",
+            fontFamily: "var(--f-mono)",
+            fontSize: 10,
+          }}
+        >
+          {isValidating ? "Loading more…" : "Load more observations"}
+        </button>
+      )}
+    </>
+  );
 }

--- a/web/src/app/components/messages/MessageLifecycleTimeline.tsx
+++ b/web/src/app/components/messages/MessageLifecycleTimeline.tsx
@@ -126,23 +126,33 @@ function CanonicalObservation({ row, last }: { row: MessageLifecycleTransitionWi
   const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
   const label = REASON_LABELS[row.reason_code];
   return (
-    <div className="flex" style={{ gap: 11, position: "relative", paddingBottom: last ? 0 : 15 }}>
+    <li style={{ position: "relative", minWidth: 0 }}>
       {!last && (
-        <span aria-hidden style={{ position: "absolute", left: 5, top: 14, bottom: 0, width: 1, background: "var(--border-sub)" }} />
+        <span
+          aria-hidden
+          style={{
+            position: "absolute",
+            left: 11,
+            right: -23,
+            top: 5,
+            height: 1,
+            background: "var(--border-sub)",
+          }}
+        />
       )}
       <span
         aria-hidden
         style={{
           width: 11,
           height: 11,
-          marginTop: 4,
-          flexShrink: 0,
           borderRadius: "50%",
           background: observationTone(row),
           boxShadow: last ? "0 0 0 3px var(--bg-elev)" : "none",
+          display: "block",
+          position: "relative",
         }}
       />
-      <div className="flex-1 min-w-0">
+      <div style={{ minWidth: 0, marginTop: 10 }}>
         <div className="flex items-start" style={{ gap: 8 }}>
           <div className="flex-1 min-w-0">
             <div style={{ fontSize: 12, fontWeight: last ? 650 : 500, color: "var(--fg)" }}>{label}</div>
@@ -197,7 +207,7 @@ function CanonicalObservation({ row, last }: { row: MessageLifecycleTransitionWi
           </div>
         )}
       </div>
-    </div>
+    </li>
   );
 }
 
@@ -217,9 +227,24 @@ export function MessageLifecycleTimeline({
           Observations recorded by e2a · not an inbox-placement claim
         </div>
       </div>
-      {transitions.map((row, index) => (
-        <CanonicalObservation key={row.id} row={row} last={index === transitions.length - 1} />
-      ))}
+      <ol
+        aria-label="Message lifecycle observations"
+        style={{
+          display: "grid",
+          gridAutoFlow: "column",
+          gridAutoColumns: "minmax(210px, 1fr)",
+          gap: 18,
+          margin: 0,
+          padding: "0 0 4px",
+          listStyle: "none",
+          overflowX: "auto",
+          overflowY: "hidden",
+        }}
+      >
+        {transitions.map((row, index) => (
+          <CanonicalObservation key={row.id} row={row} last={index === transitions.length - 1} />
+        ))}
+      </ol>
     </div>
   );
 }

--- a/web/src/app/components/messages/MessageLifecycleTimeline.tsx
+++ b/web/src/app/components/messages/MessageLifecycleTimeline.tsx
@@ -9,6 +9,7 @@ import {
   type MessageLifecyclePageWire,
   type MessageLifecycleTransitionWire,
 } from "../../../lib/messageLifecycle";
+import { messageLifecycleKey } from "../../../lib/swrKeys";
 
 type ReasonCode = MessageLifecycleTransitionWire["reason_code"];
 
@@ -358,9 +359,7 @@ export function MessageLifecycleData({
     (pageIndex, previousPage) => {
       if (previousPage && previousPage.next_cursor === null) return null;
       return [
-        "message-lifecycle",
-        email,
-        messageId,
+        ...messageLifecycleKey(email, messageId),
         pageIndex,
         previousPage?.next_cursor ?? null,
       ] as const;

--- a/web/src/app/components/messages/ThreadBubble.test.tsx
+++ b/web/src/app/components/messages/ThreadBubble.test.tsx
@@ -3,9 +3,10 @@
 // parsed.text is shown as escaped text. Pins the fallback order so a regression
 // can't silently drop back to rendering raw MIME.
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { ThreadBubble } from "./ThreadBubble";
 import { getMessageDetailWire } from "../onboarding/api";
+import { getMessageLifecycle } from "../../../lib/messageLifecycle";
 import {
   invalidateAgentMessages,
   invalidateAgentUnread,
@@ -24,6 +25,10 @@ jest.mock("../../../lib/swrKeys", () => ({
   invalidateAgentMessages: jest.fn(),
   invalidateAgentUnread: jest.fn(),
 }));
+jest.mock("../../../lib/messageLifecycle", () => ({
+  ...jest.requireActual("../../../lib/messageLifecycle"),
+  getMessageLifecycle: jest.fn(),
+}));
 const mockGet = getMessageDetailWire as jest.MockedFunction<
   typeof getMessageDetailWire
 >;
@@ -31,6 +36,9 @@ const mockInvalidateMessages =
   invalidateAgentMessages as jest.MockedFunction<typeof invalidateAgentMessages>;
 const mockInvalidateUnread =
   invalidateAgentUnread as jest.MockedFunction<typeof invalidateAgentUnread>;
+const mockGetLifecycle = getMessageLifecycle as jest.MockedFunction<
+  typeof getMessageLifecycle
+>;
 
 // Each test uses a distinct id: useSWR keys the body cache by id and
 // that cache is process-global, so reusing an id would leak one test's body
@@ -63,6 +71,50 @@ afterEach(() => {
   mockGet.mockReset();
   mockInvalidateMessages.mockReset();
   mockInvalidateUnread.mockReset();
+  mockGetLifecycle.mockReset();
+});
+
+describe("ThreadBubble canonical lifecycle", () => {
+  it("loads and expands the beta lifecycle for the selected message", async () => {
+    outbound("sent body");
+    mockGetLifecycle.mockResolvedValue({
+      items: [{
+        id: "mlt_thread_sent",
+        message_id: "msg_lifecycle_thread",
+        direction: "outbound",
+        recipient: "james@x.com",
+        stage: "submission",
+        outcome: "accepted",
+        reason_code: "submission.upstream_accepted",
+        retryable: false,
+        evidence: {},
+        correlation_ids: {},
+        occurred_at: "2026-07-22T12:00:00Z",
+        reconstructed: false,
+      }],
+      next_cursor: null,
+    });
+    const m: MessageSummary = {
+      ...msg("msg_lifecycle_thread"),
+      direction: "outbound",
+      from: "support@acme.dev",
+      recipient: "james@x.com",
+      status: "sent",
+    };
+
+    render(<ThreadBubble message={m} counterparty={CP} agentEmail="support@acme.dev" />);
+
+    const toggle = screen.getByRole("button", { name: /lifecycle.*beta/i });
+    expect(mockGetLifecycle).not.toHaveBeenCalled();
+    fireEvent.click(toggle);
+
+    expect(await screen.findByText("Accepted by upstream provider")).toBeInTheDocument();
+    expect(mockGetLifecycle).toHaveBeenCalledWith(
+      "support@acme.dev",
+      "msg_lifecycle_thread",
+      { limit: 100 },
+    );
+  });
 });
 
 describe("ThreadBubble body precedence", () => {

--- a/web/src/app/components/messages/ThreadBubble.test.tsx
+++ b/web/src/app/components/messages/ThreadBubble.test.tsx
@@ -104,11 +104,12 @@ describe("ThreadBubble canonical lifecycle", () => {
 
     render(<ThreadBubble message={m} counterparty={CP} agentEmail="support@acme.dev" />);
 
-    const toggle = screen.getByRole("button", { name: /lifecycle.*beta/i });
+    const toggle = screen.getByRole("button", { name: /show lifecycle/i });
+    expect(toggle).not.toHaveTextContent(/beta/i);
     expect(mockGetLifecycle).not.toHaveBeenCalled();
     fireEvent.click(toggle);
 
-    expect(await screen.findByText("Accepted by upstream provider")).toBeInTheDocument();
+    expect(await screen.findByText("Handed off to delivery provider")).toBeInTheDocument();
     expect(mockGetLifecycle).toHaveBeenCalledWith(
       "support@acme.dev",
       "msg_lifecycle_thread",

--- a/web/src/app/components/messages/ThreadBubble.tsx
+++ b/web/src/app/components/messages/ThreadBubble.tsx
@@ -315,7 +315,7 @@ export function ThreadBubble({
             type="button"
             onClick={() => setShowLifecycle((value) => !value)}
             aria-expanded={showLifecycle}
-            aria-label={`${showLifecycle ? "Hide" : "Show"} lifecycle beta`}
+            aria-label={`${showLifecycle ? "Hide" : "Show"} lifecycle`}
             style={{
               color: "var(--accent-strong)",
               background: "transparent",
@@ -327,21 +327,7 @@ export function ThreadBubble({
               flexShrink: 0,
             }}
           >
-            {showLifecycle ? "Hide lifecycle ▴" : "Lifecycle ▾"}{" "}
-            <span
-              style={{
-                display: "inline-block",
-                padding: "0 4px",
-                borderRadius: 3,
-                background: "var(--info-bg)",
-                color: "var(--info-strong)",
-                fontSize: 9,
-                fontWeight: 700,
-                textTransform: "uppercase",
-              }}
-            >
-              Beta
-            </span>
+            {showLifecycle ? "Hide lifecycle ▴" : "Lifecycle ▾"}
           </button>
         </div>
 

--- a/web/src/app/components/messages/ThreadBubble.tsx
+++ b/web/src/app/components/messages/ThreadBubble.tsx
@@ -13,6 +13,7 @@ import { CounterpartyAvatar } from "./CounterpartyAvatar";
 import { MessageStatusChip } from "./MessageStatusChip";
 import { EmailHtmlBody } from "./EmailHtmlBody";
 import { AttachmentChips, downloadableAttachments } from "./AttachmentChips";
+import { MessageLifecycleData } from "./MessageLifecycleTimeline";
 import {
   getMessageDetailWire,
   projectMessageDetail,
@@ -78,6 +79,7 @@ export function ThreadBubble({
   const isInbound = message.direction === "inbound";
   const pending = message.review_status === "pending_review";
   const [showDetails, setShowDetails] = useState(false);
+  const [showLifecycle, setShowLifecycle] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState("");
 
@@ -309,6 +311,38 @@ export function ThreadBubble({
           >
             {showDetails ? "Hide details ▴" : "Details ▾"}
           </button>
+          <button
+            type="button"
+            onClick={() => setShowLifecycle((value) => !value)}
+            aria-expanded={showLifecycle}
+            aria-label={`${showLifecycle ? "Hide" : "Show"} lifecycle beta`}
+            style={{
+              color: "var(--accent-strong)",
+              background: "transparent",
+              border: "none",
+              padding: 0,
+              cursor: "pointer",
+              fontFamily: "inherit",
+              fontSize: "inherit",
+              flexShrink: 0,
+            }}
+          >
+            {showLifecycle ? "Hide lifecycle ▴" : "Lifecycle ▾"}{" "}
+            <span
+              style={{
+                display: "inline-block",
+                padding: "0 4px",
+                borderRadius: 3,
+                background: "var(--info-bg)",
+                color: "var(--info-strong)",
+                fontSize: 9,
+                fontWeight: 700,
+                textTransform: "uppercase",
+              }}
+            >
+              Beta
+            </span>
+          </button>
         </div>
 
         {/* Details panel */}
@@ -334,6 +368,20 @@ export function ThreadBubble({
             {message.reply_to && message.reply_to.length > 0 && (
               <MetaRow label="Reply-To" value={message.reply_to.join(", ")} />
             )}
+          </div>
+        )}
+
+        {showLifecycle && (
+          <div
+            className="mb-3"
+            style={{
+              background: "var(--bg-panel)",
+              border: "1px solid var(--border)",
+              borderRadius: "var(--r-lg)",
+              overflow: "hidden",
+            }}
+          >
+            <MessageLifecycleData email={agentEmail} messageId={message.id} />
           </div>
         )}
 

--- a/web/src/lib/swrKeys.test.ts
+++ b/web/src/lib/swrKeys.test.ts
@@ -21,7 +21,9 @@ import {
   agentUnreadKey,
   invalidateAgentUnread,
   invalidateMessageDetail,
+  invalidateMessageLifecycle,
   messageDetailKey,
+  messageLifecycleKey,
 } from "./swrKeys";
 
 describe("accountUnreadKey", () => {
@@ -108,5 +110,62 @@ describe("invalidateMessageDetail", () => {
 
     await waitFor(() => expect(fetcherA).toHaveBeenCalledTimes(2));
     expect(fetcherB).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("invalidateMessageLifecycle", () => {
+  it("revalidates every paginated key sharing the message's prefix", async () => {
+    // MessageLifecycleData pages with useSWRInfinite, so live keys carry
+    // trailing page-index/cursor slots beyond messageLifecycleKey. The
+    // predicate must match the shared prefix, not the exact tuple.
+    const pageOneFetcher = jest.fn().mockResolvedValue({ items: [], next_cursor: "c2" });
+    const pageTwoFetcher = jest.fn().mockResolvedValue({ items: [], next_cursor: null });
+    renderHook(() =>
+      useSWR([...messageLifecycleKey("agent@agents.test", "msg_lc_a"), 0, null], pageOneFetcher),
+    );
+    renderHook(() =>
+      useSWR([...messageLifecycleKey("agent@agents.test", "msg_lc_a"), 1, "c2"], pageTwoFetcher),
+    );
+    await waitFor(() => {
+      expect(pageOneFetcher).toHaveBeenCalledTimes(1);
+      expect(pageTwoFetcher).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      await invalidateMessageLifecycle("agent@agents.test", "msg_lc_a");
+    });
+
+    await waitFor(() => {
+      expect(pageOneFetcher).toHaveBeenCalledTimes(2);
+      expect(pageTwoFetcher).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("leaves other messages' and other agents' panels alone", async () => {
+    const targetFetcher = jest.fn().mockResolvedValue({ items: [] });
+    const otherMessageFetcher = jest.fn().mockResolvedValue({ items: [] });
+    const otherAgentFetcher = jest.fn().mockResolvedValue({ items: [] });
+    renderHook(() =>
+      useSWR([...messageLifecycleKey("agent@agents.test", "msg_lc_b"), 0, null], targetFetcher),
+    );
+    renderHook(() =>
+      useSWR([...messageLifecycleKey("agent@agents.test", "msg_lc_c"), 0, null], otherMessageFetcher),
+    );
+    renderHook(() =>
+      useSWR([...messageLifecycleKey("other@agents.test", "msg_lc_b"), 0, null], otherAgentFetcher),
+    );
+    await waitFor(() => {
+      expect(targetFetcher).toHaveBeenCalledTimes(1);
+      expect(otherMessageFetcher).toHaveBeenCalledTimes(1);
+      expect(otherAgentFetcher).toHaveBeenCalledTimes(1);
+    });
+
+    await act(async () => {
+      await invalidateMessageLifecycle("agent@agents.test", "msg_lc_b");
+    });
+
+    await waitFor(() => expect(targetFetcher).toHaveBeenCalledTimes(2));
+    expect(otherMessageFetcher).toHaveBeenCalledTimes(1);
+    expect(otherAgentFetcher).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/src/lib/swrKeys.ts
+++ b/web/src/lib/swrKeys.ts
@@ -74,6 +74,13 @@ export const agentUnreadKey = (email: string) =>
 export const messageDetailKey = (id: string) =>
   ["message-detail", id] as const;
 
+// Per-message canonical lifecycle observations (GET /v1/agents/{address}/
+// messages/{id}/lifecycle). MessageLifecycleData pages through the endpoint
+// with useSWRInfinite, so live keys carry trailing page-index/cursor slots
+// beyond this prefix — invalidation matches the shared prefix only.
+export const messageLifecycleKey = (email: string, id: string) =>
+  ["message-lifecycle", email, id] as const;
+
 // ── Invalidation helpers ─────────────────────────────────
 
 // After any agent mutation (create/update/delete/test) the agents
@@ -98,6 +105,20 @@ export function invalidateMessageDetail(id: string) {
   return mutate(
     (key) =>
       Array.isArray(key) && key[0] === "message-detail" && key[1] === id,
+  );
+}
+
+// After approve / reject the message's lifecycle ledger gains new
+// transitions (review resolution, queueing, submission), so any open
+// lifecycle panel for the message is stale. Matches the shared prefix of
+// every paginated key for the message, across all loaded pages.
+export function invalidateMessageLifecycle(email: string, id: string) {
+  return mutate(
+    (key) =>
+      Array.isArray(key) &&
+      key[0] === "message-lifecycle" &&
+      key[1] === email &&
+      key[2] === id,
   );
 }
 


### PR DESCRIPTION
## Summary

Adds a **Lifecycle · Beta** toggle to every message in the conversation thread and replaces the focus page's inferred timeline with the canonical beta lifecycle API. Operators can now inspect the exact observations e2a recorded without conflating upstream acceptance, recipient-server delivery, or inbox placement.

This is a web-only consumer of the existing beta endpoint. There are no API schema, SDK, CLI, MCP, database, or migration changes.

## Operational risk

Low. Read-only UI presentation with lazy lifecycle fetching and cursor pagination. Safe evidence and correlation identifiers remain collapsed behind per-observation diagnostics.

## Test plan

- [x] `cd web && npm test -- --runInBand` — 54 suites, 448 tests passed
- [x] `cd web && npm run lint` — 0 errors; 1 pre-existing warning
- [x] `cd web && npm run build` — production build and 36 static routes passed
- [x] `git diff --check`
