### PR TITLE
release(sdk): Python + TypeScript SDK 5.3.0

### DIFF
--- a/sdks/python/CHANGELOG.md
+++ b/sdks/python/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 5.3.0
 
 ### Added
 - **`client.messages.delete(email, message_id, *, permanent=False)`** — move a
@@ -10,6 +10,9 @@
   already in the trash (irreversible, account scope only; the SDK supplies the
   `?confirm=DELETE` guard the raw API requires on that path). Available on both
   `AsyncE2AClient` and the synchronous `E2AClient`.
+- **`client.messages.get_lifecycle(email, message_id, *, cursor=None, limit=None)`**
+  — page through a message's canonical lifecycle transitions (send, delivery,
+  bounce, review, deletion, …) as `PageMessageLifecycleTransition`. Beta.
 
 ## 5.2.0
 

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "e2a"
-version = "5.2.0"
+version = "5.3.0"
 description = "Python SDK for the e2a protocol — email-to-agent authentication"
 readme = "README.md"
 license = "Apache-2.0"

--- a/sdks/typescript/CHANGELOG.md
+++ b/sdks/typescript/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 5.3.0
 
 ### Added
 - **`client.messages.delete(email, messageId, { permanent })`** — move a message
@@ -9,6 +9,9 @@
   confirmation. Pass `permanent: true` to delete forever a message that is
   already in the trash (irreversible, account scope only; the SDK supplies the
   `?confirm=DELETE` guard the raw API requires on that path).
+- **`client.messages.getLifecycle(email, messageId, { cursor, limit })`** —
+  page through a message's canonical lifecycle transitions (send, delivery,
+  bounce, review, deletion, …) as `PageMessageLifecycleTransition`. Beta.
 
 ## 5.2.0
 

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2a/sdk",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "TypeScript SDK for e2a — email for AI agents",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
## What

Release **Python SDK 5.3.0** and **TypeScript SDK 5.3.0** (additive minor, both in lockstep):

- `messages.delete` — soft-delete to trash / permanent delete of trashed messages (#625). Changelogs already carried this under `Unreleased`; this PR renames the sections to `5.3.0`.
- `messages.get_lifecycle` / `getLifecycle` (beta) — canonical lifecycle-transition paging (`f1261aa3`, `3f029ded` + follow-ups). Changelog entries added here.

Version bumps: `sdks/python/pyproject.toml` and `sdks/typescript/package.json` → `5.3.0`. Grep-verified no other version references exist in code or tests.

## Why now

The sdk-monitor's delete-cleanup step (#653) caught the published `5.2.0` packages lacking `messages.delete` — live `monitor_error(stage=cleanup)` on the `python_sdk` and `ts_sdk` interfaces every tick. Exactly the "published package lags source" class of gap the monitor exists to detect.

## After merge

Push tags on the merge commit to trigger trusted-publisher workflows:

```bash
git tag python-v5.3.0 <merge-sha> && git tag ts-sdk-v5.3.0 <merge-sha>
git push origin python-v5.3.0 ts-sdk-v5.3.0
```

Then bump the sdk-monitor pins (`requirements.txt` → `e2a==5.3.0`, `package.json` → `@e2a/sdk@5.3.0`) per the monitor's bump policy and rebuild its image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
