### PR TITLE
chore(sdk-monitor): bump SDK pins to 5.3.0

### DIFF
--- a/tests/sdk-monitor/README.md
+++ b/tests/sdk-monitor/README.md
@@ -30,7 +30,7 @@ of five interfaces:
 | `api` | raw HTTP against the server's `/v1/agents/{email}/messages` (and `.../reply`) endpoints — no SDK. Catches a server-contract break distinct from an SDK break. | python (stdlib `urllib`) |
 | `python_sdk` | the published `e2a` PyPI package | python |
 | `mcp` | the deployed MCP streamable-HTTP server's `send_message` / `reply_to_message` tools | python (hand-rolled JSON-RPC over `urllib`) |
-| `ts_sdk` | the published `@e2a/sdk` npm package (v5.2.0) | node, shelled out from python |
+| `ts_sdk` | the published `@e2a/sdk` npm package (v5.3.0) | node, shelled out from python |
 | `cli` | the published `@e2a/cli` npm package (v2.0.0, bin `e2a`) | node, shelled out from python |
 
 Anything that breaks any of those — a bad publish, a wire-contract drift, a
@@ -274,7 +274,7 @@ signal, not something to work around.
 ## SDK / package version bump policy
 
 `requirements.txt` pins an exact published Python SDK version (currently
-**5.2.0**); `package.json` pins exact published `@e2a/sdk` (**5.2.0**) and
+**5.3.0**); `package.json` pins exact published `@e2a/sdk` (**5.3.0**) and
 `@e2a/cli` (**2.0.0**) versions. None of these is ever a path or workspace
 dependency on the corresponding source directory — installing from local
 source would defeat the entire purpose by hiding a broken publish.

--- a/tests/sdk-monitor/js/monitor-helper.mjs
+++ b/tests/sdk-monitor/js/monitor-helper.mjs
@@ -3,7 +3,7 @@
 //
 // The Python service shells out to this script rather than embedding a JS
 // runtime. It imports `@e2a/sdk/v1` resolved from node_modules — populated at
-// image build time by `npm install @e2a/sdk@5.2.0` (see ../Dockerfile), the
+// image build time by `npm install @e2a/sdk@5.3.0` (see ../Dockerfile), the
 // same "published package only, never workspace source" discipline as
 // requirements.txt for the Python SDK.
 //

--- a/tests/sdk-monitor/monitor.py
+++ b/tests/sdk-monitor/monitor.py
@@ -502,7 +502,7 @@ class TsSdkStrategy:
     (js/monitor-helper.mjs) — this Python service shells out rather than
     embedding a JS runtime. Never workspace source: the helper imports
     `@e2a/sdk/v1` resolved from node_modules, populated at image build time by
-    `npm install @e2a/sdk@5.2.0` (see Dockerfile), same discipline as
+    `npm install @e2a/sdk@5.3.0` (see Dockerfile), same discipline as
     requirements.txt for the Python SDK.
 
     Send-status handling lives in the helper itself, not here: it now checks

--- a/tests/sdk-monitor/package.json
+++ b/tests/sdk-monitor/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "description": "Node-runtime dependencies for tests/sdk-monitor's ts_sdk and cli interfaces — pinned to the exact PUBLISHED npm packages so a broken publish surfaces here, never workspace source. Never add a path/workspace dependency on ../../sdks/typescript or ../../cli.",
   "dependencies": {
-    "@e2a/sdk": "5.2.0",
+    "@e2a/sdk": "5.3.0",
     "@e2a/cli": "2.0.0"
   }
 }

--- a/tests/sdk-monitor/requirements.txt
+++ b/tests/sdk-monitor/requirements.txt
@@ -2,4 +2,4 @@
 # this MUST stay a pinned PyPI release — never a path/editable dep on
 # ../../sdks/python. A broken publish has to surface here, not be papered over
 # by local source. Bump this on every Python SDK release (see README.md).
-e2a==5.2.0
+e2a==5.3.0


### PR DESCRIPTION
Bumps the monitor's published-package pins now that 5.3.0 is live on PyPI and npm (PR #656, tags `python-v5.3.0` / `ts-sdk-v5.3.0`):

- `requirements.txt`: `e2a==5.2.0` → `e2a==5.3.0`
- `package.json`: `@e2a/sdk` `5.2.0` → `5.3.0`
- matching doc references in `monitor.py`, `js/monitor-helper.mjs`, `README.md`

5.3.0 carries `messages.delete`, which the cleanup step (#653) exercises on the `python_sdk` and `ts_sdk` interfaces — both currently log `monitor_error(stage=cleanup)` every tick against 5.2.0. Per the bump policy, the image rebuild after merge proves the release installs and works end to end against prod.

Offline suite: 168 checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
