### PR TITLE
test(e2e-prod): cover getMessageLifecycle in the happy-path suite

### DIFF
--- a/tests/e2e-prod/coverage_gate.py
+++ b/tests/e2e-prod/coverage_gate.py
@@ -15,8 +15,8 @@ Maps each exercised concrete path to the most-specific matching operationId, the
 compares the covered set to the full catalog (minus an explicit allowlist of
 operations the black-box suite legitimately must not call).
 
-SCOPE: this gate covers the 56 typed /v1 OpenAPI operations (the operationId
-catalog). Non-/v1 surface (billing, MCP, OAuth machine endpoints, /api/health,
+SCOPE: this gate covers the typed /v1 OpenAPI operations (the operationId
+catalog, counted dynamically from api/openapi.yaml). Non-/v1 surface (billing, MCP, OAuth machine endpoints, /api/health,
 /webhooks/*) and the webhook EVENT types are NOT operationIds and are out of scope
 here — they have their own dedicated suites (e.g. 21-webhook-events for event
 emission). Exercised paths that don't map to a /v1 operationId are reported (as

--- a/tests/e2e-prod/suites/23-coverage-happy-path.test.ts
+++ b/tests/e2e-prod/suites/23-coverage-happy-path.test.ts
@@ -7,7 +7,7 @@ import { writeReport } from "../harness/report.ts";
 
 // Happy-path coverage for operations the rest of the suite only PROBES negatively
 // (updateAgent, updateMessage, forwardMessage, getConversation, replyToMessage,
-// approveReview). The operationId coverage gate records an op as covered only on
+// approveReview) or doesn't touch at all (getMessageLifecycle). The operationId coverage gate records an op as covered only on
 // a 2xx, so an op that elsewhere gets nothing but a 404/400 probe reads as
 // UNCOVERED. These tests close that gap by INVOKING each op successfully on fresh,
 // isolated agents — no dependency on shared-account state (which made the messaging
@@ -120,6 +120,55 @@ test("forwardMessage: forward an inbound message to the simulator (200)", async 
     expect: [200, 202],
   });
   assert.ok(r.body?.message_id, "forward returned a message id");
+});
+
+test("getMessageLifecycle: outbound send records an ascending acceptance-first lifecycle (200)", async () => {
+  const email = await freshAgent("covlc");
+  const send = await client.post<{ message_id: string }>(`/v1/agents/${encodeURIComponent(email)}/messages`, {
+    body: { to: [email], subject: uniqueSubject("cov lc"), text: "lifecycle coverage body" },
+    expect: [200, 202],
+  });
+  const id = send.body!.message_id;
+
+  // The acceptance transition is written in the accept transaction, so one item
+  // is visible immediately; later stages land asynchronously — poll briefly so a
+  // read-replica/queue lag can't flake the assertion.
+  type Transition = {
+    id: string;
+    message_id: string;
+    direction: string;
+    stage: string;
+    outcome: string;
+    reason_code: string;
+    occurred_at: string;
+  };
+  let items: Transition[] = [];
+  for (let i = 0; i < 8; i++) {
+    const r = await client.get<{ items: Transition[] }>(
+      `/v1/agents/${encodeURIComponent(email)}/messages/${id}/lifecycle`,
+      { expect: 200 },
+    );
+    items = r.body?.items ?? [];
+    if (items.length > 0) break;
+    await sleep(1500);
+  }
+
+  assert.ok(items.length > 0, "lifecycle has at least one transition");
+  const first = items[0];
+  assert.match(first.id, /^mlt_/, "transition ids are mlt_-prefixed");
+  assert.equal(first.message_id, id);
+  assert.equal(first.direction, "outbound");
+  assert.equal(first.stage, "accepted", "the first transition is the acceptance");
+  assert.equal(first.outcome, "accepted");
+  // Wire contract: deterministic ascending (occurred_at, id) order.
+  for (let i = 1; i < items.length; i++) {
+    const prev = items[i - 1];
+    const cur = items[i];
+    assert.ok(
+      prev.occurred_at < cur.occurred_at || (prev.occurred_at === cur.occurred_at && prev.id < cur.id),
+      `transitions sorted ascending (occurred_at, id): ${prev.id} before ${cur.id}`,
+    );
+  }
 });
 
 test("approveReview: approve a HITL-held outbound (200 terminal or 202 enqueued)", async () => {


### PR DESCRIPTION
## Summary

An API-contract coverage audit found `get-message-lifecycle` is the **one uncovered `/v1` operation** in the e2e-prod conformance gate (58 covered + 2 allowlisted of 61) — no suite calls `GET /v1/agents/{email}/messages/{id}/lifecycle`, so the next `npm run coverage` in `tests/e2e-prod` would fail the gate.

- **`23-coverage-happy-path.test.ts`**: new `getMessageLifecycle` test — loopback self-send on a fresh agent, capture the outbound `message_id`, poll the lifecycle (brief retry so replica/queue lag can't flake it), then assert:
  - ≥1 transition; `mlt_`-prefixed ids; `message_id` matches; `direction: outbound`
  - first transition is the acceptance (`stage: accepted`, `outcome: accepted` — `acceptance.outbound_api` family)
  - deterministic ascending `(occurred_at, id)` order, per the handler's documented wire contract
- **`coverage_gate.py`**: fix the stale hardcoded "56 typed operations" in the docstring — the catalog is counted dynamically from `api/openapi.yaml` (now 61).

## Verification

- `tsc --noEmit` clean.
- Gate template-matching confirmed: a concrete lifecycle path maps to `get-message-lifecycle`.
- Test **passes against a local `e2a-contract-server`**, and with its shard the gate flips to **PASS (59 + 2 allowlisted = 61/61)**.

## ⚠️ Deploy dependency

Running the new test against prod today returns a **router-level 404** ("resource not found", not the handler's "message not found") — the lifecycle endpoint (already in `api/openapi.yaml` on main) **has not been deployed to prod yet**. That undeployed route is the real root cause of the coverage gap. This test will pass on the first e2e-prod run after the next prod deploy; until then it fails with the 404 above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)