### PR TITLE
feat: scheduled send via send_at

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1886,6 +1886,10 @@ components:
           description: Sets the Reply-To header — where replies to this message are directed. A single RFC 5322 address, optionally with a display name. At most 320 characters (display name + address combined). Defaults to the sending agent's own address.
           maxLength: 320
           type: string
+        send_at:
+          description: Optional scheduled-send time (RFC 3339 with a UTC offset). When set to a future instant the forward is accepted immediately and returns status=scheduled; it is submitted at approximately this time ("not before", accurate to the scheduler poll interval). A value at or before now sends immediately. Must be no more than 90 days ahead (over → 400 invalid_request). Scheduling does not survive a review hold. Cancel by moving the message to trash.
+          format: date-time
+          type: string
         text:
           maxLength: 1048576
           type: string
@@ -2144,6 +2148,9 @@ components:
         scan_score:
           format: double
           type: number
+        scheduled_at:
+          format: date-time
+          type: string
         sent_as:
           type: string
         size_bytes:
@@ -2506,6 +2513,10 @@ components:
           type: array
         review_status:
           description: "Review-hold lifecycle (outbound only). Open set; tolerate unknown values. Known values: pending_review, sent, review_rejected, review_expired_approved, review_expired_rejected. Note: an APPROVED outbound hold reads as sent here — the message view intentionally collapses the approved outcome into the delivery lifecycle. The distinct review_approved spelling appears only in the approve result (SendResultView.status, for inbound release) and the email.review_approved webhook event, not in this field."
+          type: string
+        scheduled_at:
+          description: Future instant a scheduled outbound send was queued to be submitted (outbound only; treat as "not before"). Set when the message was created with a future send_at and retained afterwards; omitted for immediate sends. Cancel a scheduled send by moving the message to trash.
+          format: date-time
           type: string
         sent_as:
           description: "From identity used at relay accept time (outbound only). Open set; tolerate unknown values. Known values: own_address, relay."
@@ -3205,6 +3216,10 @@ components:
           description: Sets the Reply-To header — where replies to this message are directed. A single RFC 5322 address, optionally with a display name. At most 320 characters (display name + address combined). Defaults to the sending agent's own address.
           maxLength: 320
           type: string
+        send_at:
+          description: Optional scheduled-send time (RFC 3339 with a UTC offset). When set to a future instant the reply is accepted immediately and returns status=scheduled; it is submitted at approximately this time ("not before", accurate to the scheduler poll interval). A value at or before now sends immediately. Must be no more than 90 days ahead (over → 400 invalid_request). Scheduling does not survive a review hold. Cancel by moving the message to trash.
+          format: date-time
+          type: string
         text:
           maxLength: 1048576
           type: string
@@ -3368,6 +3383,10 @@ components:
           description: Sets the Reply-To header — where replies to this message are directed. A single RFC 5322 address, optionally with a display name (e.g. "Support <support@acme.com>"). At most 320 characters (display name + address combined). Defaults to the sending agent's own address.
           maxLength: 320
           type: string
+        send_at:
+          description: "Optional scheduled-send time (RFC 3339 with a UTC offset). When set to a future instant the message is accepted immediately and returns status=scheduled; it is submitted to the provider at approximately this time. Treat it as \"not before\" — accurate to within the scheduler's poll interval (seconds), not exact-to-the-millisecond, and actual delivery can be later under provider retry/outage. A value at or before now sends immediately (identical to omitting it). Must be no more than 90 days ahead (over → 400 invalid_request). Note: scheduling does NOT survive a review hold — if the message is held for review, send_at is dropped and it sends on approval. Cancel a scheduled send by moving the message to trash."
+          format: date-time
+          type: string
         subject:
           description: Literal subject. Required unless a template reference is used (mutually exclusive with template_id/template_alias).
           maxLength: 2000
@@ -3418,11 +3437,15 @@ components:
         provider_message_id:
           description: Upstream provider (SES) id. Optional/absent until the message is actually sent — an accepted-but-not-yet-sent message has no provider id.
           type: string
+        scheduled_at:
+          description: "Set only when status=scheduled: the future instant this message is queued to be submitted (approximate — treat as \"not before\"). Cancel a scheduled send by moving the message to trash."
+          format: date-time
+          type: string
         sent_as:
           description: "From identity used. Open set; tolerate unknown values. Known values: own_address, relay."
           type: string
         status:
-          description: "Outcome. Open set; tolerate unknown values. Known values: accepted, sent, pending_review, review_approved, failed. accepted = durably persisted and queued for submission (async pipeline); the terminal outcome arrives via webhook events (email.sent / email.failed) or GET /v1/messages/{id}. failed = terminal failure. Always branch on this field, not the HTTP status code."
+          description: "Outcome. Open set; tolerate unknown values. Known values: accepted, scheduled, sent, pending_review, review_approved, failed. accepted = durably persisted and queued for immediate submission (async pipeline); the terminal outcome arrives via webhook events (email.sent / email.failed) or GET /v1/messages/{id}. scheduled = accepted but deferred to a future send_at (see scheduled_at); it becomes accepted→sent at that time. failed = terminal failure. Always branch on this field, not the HTTP status code."
           type: string
       required:
         - status

--- a/cli/src/__tests__/send.test.ts
+++ b/cli/src/__tests__/send.test.ts
@@ -136,6 +136,36 @@ describe("send/reply commands", () => {
     expect(mockSend.mock.calls[0][1].conversationId).toBe("conv-1");
   });
 
+  it("parses --send-at into a Date, exits OK, and notes the scheduled time", async () => {
+    const at = "2026-08-01T09:00:00Z";
+    mockSend.mockResolvedValue({
+      messageId: "msg_sched",
+      status: "scheduled",
+      scheduledAt: new Date(at),
+    });
+    const { send } = await import("../commands/send.js");
+    await send({ to: ["you@example.com"], subject: "s", body: "b", sendAt: at });
+
+    const bodyArg = mockSend.mock.calls[0][1];
+    expect(bodyArg.sendAt).toBeInstanceOf(Date);
+    expect((bodyArg.sendAt as Date).toISOString()).toBe(new Date(at).toISOString());
+    // Scheduled is a successful, intended acceptance: id printed, exit 0, note on stderr.
+    expect(mockStdout).toHaveBeenCalledWith("msg_sched\n");
+    expect(mockStderr).toHaveBeenCalledWith(expect.stringContaining("scheduled"));
+    // The note renders the instant via toISOString() (millisecond precision).
+    expect(mockStderr).toHaveBeenCalledWith(expect.stringContaining(new Date(at).toISOString()));
+    expect(process.exitCode).toBe(0);
+  });
+
+  it("exits USAGE (2) when --send-at is not a valid date-time", async () => {
+    const { send } = await import("../commands/send.js");
+    await expect(
+      send({ to: ["you@example.com"], subject: "s", body: "b", sendAt: "not-a-date" }),
+    ).rejects.toThrow("process.exit");
+    expect(mockExit).toHaveBeenCalledWith(2);
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
   it("exits USAGE (2) when --to or --subject is missing", async () => {
     const { send } = await import("../commands/send.js");
     await expect(send({ to: [], subject: "s", body: "b" })).rejects.toThrow("process.exit");

--- a/cli/src/bin/e2a.ts
+++ b/cli/src/bin/e2a.ts
@@ -57,6 +57,8 @@ Usage:
         --attach <file>            Attach a file (repeatable; max 10 files, 10 MB each, 25 MB total)
         --conversation-id <id>     Thread id (alias: --conversation)
         --reply-to <email>         Reply-To header (where replies go; default: the agent)
+        --send-at <rfc3339>        Schedule the send for a future time (e.g. 2026-08-01T09:00:00Z);
+                                   status=scheduled, sent "not before" then. Cancel by trashing it (dashboard/API)
         --idempotency-key <k>      Stable key so a retried invocation can't double-send
         --agent <email>            Sending inbox (or config agent_email / E2A_AGENT_EMAIL)
         --json                     Print the full send result as JSON
@@ -408,7 +410,7 @@ async function main() {
     case "send":
       checkFlags(args, [
         "--to", "--subject", "--body", "--body-file", "--html-file", "--attach",
-        "--conversation-id", "--conversation", "--reply-to", "--agent", "--idempotency-key", "--json",
+        "--conversation-id", "--conversation", "--reply-to", "--send-at", "--agent", "--idempotency-key", "--json",
       ]);
       getPositionals(args, 0, "usage: e2a send [options]");
       await send({
@@ -423,6 +425,7 @@ async function main() {
         // rejection) is shared via getConversationId — see FIX 3.
         conversationId: getConversationId(args),
         replyTo: getFlagChecked(args, "--reply-to"),
+        sendAt: getFlagChecked(args, "--send-at"),
         agent: getFlagChecked(args, "--agent"),
         idempotencyKey: getFlagChecked(args, "--idempotency-key"),
         json: hasFlag(args, "--json"),
@@ -430,7 +433,7 @@ async function main() {
       break;
     case "reply":
       checkFlags(args, [
-        "--body", "--body-file", "--html-file", "--attach", "--reply-to", "--agent", "--idempotency-key", "--json",
+        "--body", "--body-file", "--html-file", "--attach", "--reply-to", "--send-at", "--agent", "--idempotency-key", "--json",
       ]);
       await reply(getPositionals(args, 1, "usage: e2a reply <message-id> [options]")[0], {
         attach: getFlagsChecked(args, "--attach"),
@@ -438,6 +441,7 @@ async function main() {
         bodyFile: getFlagChecked(args, "--body-file"),
         htmlFile: getFlagChecked(args, "--html-file"),
         replyTo: getFlagChecked(args, "--reply-to"),
+        sendAt: getFlagChecked(args, "--send-at"),
         agent: getFlagChecked(args, "--agent"),
         idempotencyKey: getFlagChecked(args, "--idempotency-key"),
         json: hasFlag(args, "--json"),

--- a/cli/src/commands/send.ts
+++ b/cli/src/commands/send.ts
@@ -17,6 +17,7 @@ export interface SendOptions {
   json?: boolean;
   idempotencyKey?: string;
   attach?: string[];
+  sendAt?: string;
 }
 
 export interface ReplyOptions {
@@ -28,6 +29,7 @@ export interface ReplyOptions {
   json?: boolean;
   idempotencyKey?: string;
   attach?: string[];
+  sendAt?: string;
 }
 
 const MIME_BY_EXT: Record<string, string> = {
@@ -62,9 +64,27 @@ function readAttachments(paths: string[] | undefined): Attachment[] | undefined 
 }
 
 const SEND_USAGE =
-  "usage: e2a send --to <email> --subject <s> (--body <text> | --body-file <f> | --html-file <f>) [--conversation-id <id>] [--reply-to <email>] [--agent <inbox>] [--json]";
+  "usage: e2a send --to <email> --subject <s> (--body <text> | --body-file <f> | --html-file <f>) [--conversation-id <id>] [--reply-to <email>] [--send-at <rfc3339>] [--agent <inbox>] [--json]";
 const REPLY_USAGE =
-  "usage: e2a reply <message-id> (--body <text> | --body-file <f> | --html-file <f>) [--reply-to <email>] [--agent <inbox>] [--json]";
+  "usage: e2a reply <message-id> (--body <text> | --body-file <f> | --html-file <f>) [--reply-to <email>] [--send-at <rfc3339>] [--agent <inbox>] [--json]";
+
+/**
+ * Parse the optional --send-at flag into a Date for scheduled send. Accepts any
+ * value the Date constructor understands; an RFC 3339 timestamp with an explicit
+ * offset (e.g. 2026-08-01T09:00:00Z) is recommended so the instant is
+ * unambiguous. A value at or before now sends immediately (the server treats a
+ * past instant as "now"); a value more than 90 days ahead is rejected server-
+ * side. An unparseable value is a local usage error. Returns undefined when the
+ * flag is absent (an immediate send).
+ */
+export function parseSendAt(value: string | undefined, usage: string): Date | undefined {
+  if (value === undefined) return undefined;
+  const at = new Date(value);
+  if (Number.isNaN(at.getTime())) {
+    return fail(EXIT.USAGE, `--send-at is not a valid date-time: "${value}" (use RFC 3339, e.g. 2026-08-01T09:00:00Z)\n${usage}`);
+  }
+  return at;
+}
 
 function readFileOrUsage(path: string, flag: string): string {
   try {
@@ -114,6 +134,15 @@ function emitSendResult(result: SendResultView, json?: boolean): void {
     // stdout before the message id above flushes, and scripts need that id to
     // approve the held message.
     process.exitCode = EXIT.HELD;
+  } else if (result.status === "scheduled") {
+    // Scheduled is a SUCCESSFUL, intended acceptance (exit 0): the message is
+    // durably queued to go out at send_at, not held by mistake. Note it so a
+    // human sees the deferral, and point at how to cancel.
+    const when = result.scheduledAt ? new Date(result.scheduledAt).toISOString() : "the requested time";
+    process.stderr.write(
+      `NOTE: send accepted as "scheduled" — it will be submitted at ${when} (not before), not now. ` +
+        `Cancel it before then by moving message ${result.messageId} to trash (via the dashboard or the delete-message API).\n`,
+    );
   } else if (result.status === "failed") {
     process.stderr.write(
       `WARNING: send reached terminal status "failed" for message "${result.messageId}". ` +
@@ -141,6 +170,7 @@ export async function send(opts: SendOptions): Promise<void> {
 
   const client = createClient();
   const agentEmail = requireAgentEmail(opts.agent);
+  const sendAt = parseSendAt(opts.sendAt, SEND_USAGE);
   // Optional fields may be undefined — the generated serializer drops
   // undefined-valued keys before they reach the wire. An explicit
   // --idempotency-key makes a *re-invocation* after an ambiguous failure
@@ -156,6 +186,7 @@ export async function send(opts: SendOptions): Promise<void> {
       conversationId: opts.conversationId,
       replyTo: opts.replyTo,
       attachments: readAttachments(opts.attach),
+      sendAt,
     },
     opts.idempotencyKey ? { idempotencyKey: opts.idempotencyKey } : undefined,
   );
@@ -168,10 +199,11 @@ export async function reply(messageId: string | undefined, opts: ReplyOptions): 
 
   const client = createClient();
   const agentEmail = requireAgentEmail(opts.agent);
+  const sendAt = parseSendAt(opts.sendAt, REPLY_USAGE);
   const result = await client.messages.reply(
     agentEmail,
     messageId,
-    { text: body, html: htmlBody, replyTo: opts.replyTo, attachments: readAttachments(opts.attach) },
+    { text: body, html: htmlBody, replyTo: opts.replyTo, attachments: readAttachments(opts.attach), sendAt },
     opts.idempotencyKey ? { idempotencyKey: opts.idempotencyKey } : undefined,
   );
   emitSendResult(result, opts.json);

--- a/internal/agent/api.go
+++ b/internal/agent/api.go
@@ -1132,8 +1132,14 @@ type OutboundResult struct {
 	// Status is the send progression the wire maps to `status`. Empty on the
 	// synchronous path (the caller renders "sent"); "accepted" on the async path
 	// (durably persisted + queued; the terminal outcome arrives via email.sent /
-	// email.failed). See async-message-pipeline.md, slice C.
+	// email.failed); "scheduled" when the send was deferred to a future instant
+	// (ScheduledAt). See async-message-pipeline.md, slice C.
 	Status string
+	// ScheduledAt is set only when Status=="scheduled": the future instant the
+	// queued send will be submitted. It must be carried on BOTH the live return
+	// and the in-transaction idempotency completion so a keyed replay renders the
+	// identical scheduled view (never a bare "accepted").
+	ScheduledAt *time.Time
 }
 
 // OutboundError carries an HTTP status + message so both the legacy handler
@@ -1331,6 +1337,16 @@ func (a *API) DeliverOutbound(ctx context.Context, user *identity.User, agent *i
 		log.Printf("[api] async compose failed: agent=%s to=%v error=%v", agent.Domain, req.To, cerr)
 		return nil, &OutboundError{Status: http.StatusInternalServerError, Code: "internal_error", Msg: fmt.Sprintf("compose failed: %v", cerr)}
 	}
+	// Scheduled send (migration 079): a future req.ScheduledAt defers WHEN the
+	// send job runs (river ScheduledAt) — the message is still accepted + queued
+	// atomically here, and the row stays delivery_status='accepted'. The edge has
+	// already validated that ScheduledAt, when set, is in the future and within
+	// the max horizon; a nil/past value is an ordinary immediate send.
+	scheduledAt := req.ScheduledAt
+	acceptStatus := "accepted"
+	if scheduledAt != nil {
+		acceptStatus = "scheduled"
+	}
 	var accepted *identity.Message
 	// Crash boundary:
 	//   - Before Commit returns, WithTx rolls back the message, River job, and
@@ -1345,7 +1361,18 @@ func (a *API) DeliverOutbound(ctx context.Context, user *identity.User, agent *i
 		if err != nil {
 			return err
 		}
-		jobID, err := a.outboundEnq.EnqueueSendTx(ctx, tx, msg.ID)
+		// Stamp the schedule marker + enqueue the job to run at that instant. Both
+		// happen in this same tx, so scheduled_at and the River job's ScheduledAt
+		// are committed together with the message.
+		var jobID int64
+		if scheduledAt != nil {
+			if err := a.store.StampScheduledAtTx(ctx, tx, msg.ID, *scheduledAt); err != nil {
+				return err
+			}
+			jobID, err = a.outboundEnq.EnqueueScheduledSendTx(ctx, tx, msg.ID, *scheduledAt)
+		} else {
+			jobID, err = a.outboundEnq.EnqueueSendTx(ctx, tx, msg.ID)
+		}
 		if err != nil {
 			return err
 		}
@@ -1353,7 +1380,7 @@ func (a *API) DeliverOutbound(ctx context.Context, user *identity.User, agent *i
 			return err
 		}
 		if idemCompleteTx != nil {
-			if err := idemCompleteTx(ctx, tx, &OutboundResult{MessageID: msg.ID, Status: "accepted"}); err != nil {
+			if err := idemCompleteTx(ctx, tx, &OutboundResult{MessageID: msg.ID, Status: acceptStatus, ScheduledAt: scheduledAt}); err != nil {
 				return err
 			}
 		}
@@ -1367,8 +1394,12 @@ func (a *API) DeliverOutbound(ctx context.Context, user *identity.User, agent *i
 		a.annotateAndAudit(ctx, agent, accepted.ID, req, verdict)
 	}
 	slug, _, _ := strings.Cut(agent.EmailAddress(), "@")
-	log.Printf("[mail:%s] dir=outbound type=%s status=accepted from=%s to=%v slug=%s conv_id=%s subject=%q", accepted.ID, msgType, agent.EmailAddress(), comp.To, slug, req.ConversationID, req.Subject)
-	return &OutboundResult{MessageID: accepted.ID, Status: "accepted", SentAs: comp.SentAs, Method: comp.Method}, nil
+	scheduledLog := "-"
+	if scheduledAt != nil {
+		scheduledLog = scheduledAt.UTC().Format(time.RFC3339)
+	}
+	log.Printf("[mail:%s] dir=outbound type=%s status=%s scheduled_at=%s from=%s to=%v slug=%s conv_id=%s subject=%q", accepted.ID, msgType, acceptStatus, scheduledLog, agent.EmailAddress(), comp.To, slug, req.ConversationID, req.Subject)
+	return &OutboundResult{MessageID: accepted.ID, Status: acceptStatus, ScheduledAt: scheduledAt, SentAs: comp.SentAs, Method: comp.Method}, nil
 }
 
 // SendTestCore accepts (or HITL-holds) a platform test email to the agent's

--- a/internal/agent/outbound_async.go
+++ b/internal/agent/outbound_async.go
@@ -46,6 +46,10 @@ type ApproveIdemCompleter func(ctx context.Context, tx pgx.Tx, approved *identit
 // closed before provider I/O.
 type OutboundEnqueuer interface {
 	EnqueueSendTx(ctx context.Context, tx pgx.Tx, messageID string) (int64, error)
+	// EnqueueScheduledSendTx enqueues the send job to run no earlier than `at`
+	// (scheduled send). Same outbox transaction as EnqueueSendTx; only the job's
+	// first-run time differs. *outboundsend.Jobs satisfies it.
+	EnqueueScheduledSendTx(ctx context.Context, tx pgx.Tx, messageID string, at time.Time) (int64, error)
 }
 
 // outboundSendStore implements outboundsend.Store over identity.Store +

--- a/internal/agent/outbound_async_test.go
+++ b/internal/agent/outbound_async_test.go
@@ -69,10 +69,20 @@ func eventLifecycle(t *testing.T, pool *pgxpool.Pool, messageID, eventType strin
 }
 
 // fakeOutboundEnqueuer stands in for the shared River client: it records the
-// in-tx enqueue and returns a stable job id the accept-tx stamps on the row.
-type fakeOutboundEnqueuer struct{ jobID int64 }
+// in-tx enqueue and returns a stable job id the accept-tx stamps on the row. For
+// a scheduled send it also records the requested run instant so tests can assert
+// the send_at was threaded through to the job.
+type fakeOutboundEnqueuer struct {
+	jobID       int64
+	scheduledAt time.Time // set when EnqueueScheduledSendTx was used
+}
 
 func (f *fakeOutboundEnqueuer) EnqueueSendTx(_ context.Context, _ pgx.Tx, _ string) (int64, error) {
+	return f.jobID, nil
+}
+
+func (f *fakeOutboundEnqueuer) EnqueueScheduledSendTx(_ context.Context, _ pgx.Tx, _ string, at time.Time) (int64, error) {
+	f.scheduledAt = at
 	return f.jobID, nil
 }
 
@@ -82,6 +92,10 @@ func (txSentinelEnqueuer) EnqueueSendTx(ctx context.Context, tx pgx.Tx, messageI
 	var id int64
 	err := tx.QueryRow(ctx, `INSERT INTO task6_durable_jobs (message_id) VALUES ($1) RETURNING id`, messageID).Scan(&id)
 	return id, err
+}
+
+func (s txSentinelEnqueuer) EnqueueScheduledSendTx(ctx context.Context, tx pgx.Tx, messageID string, _ time.Time) (int64, error) {
+	return s.EnqueueSendTx(ctx, tx, messageID)
 }
 
 func installTask6DurableJobs(t *testing.T, pool *pgxpool.Pool) {
@@ -329,6 +343,44 @@ func TestDeliverOutbound_QueueLifecycleFailureRollsBack(t *testing.T) {
 	}
 	if jobsCount != 0 || lifecycleAfter != lifecycleBaseline {
 		t.Fatalf("partial accept jobs=%d lifecycle before=%d after=%d", jobsCount, lifecycleBaseline, lifecycleAfter)
+	}
+}
+
+// TestDeliverOutbound_ScheduledAccept pins the scheduled-send accept path
+// (migration 079): a future ScheduledAt is accepted as status=scheduled, threads
+// the instant into the River enqueue (EnqueueScheduledSendTx), persists
+// scheduled_at on the row, and — deliberately — leaves delivery_status='accepted'
+// (no new status; a future-scheduled River job is invisible to the reconciler).
+func TestDeliverOutbound_ScheduledAccept(t *testing.T) {
+	api, store, _, enq := setupAsyncAPI(t)
+	ctx := context.Background()
+	user, ag := selfAgent(t, store, "scheduledaccept")
+	at := time.Now().Add(48 * time.Hour).UTC().Truncate(time.Second)
+
+	res, oerr := api.DeliverOutbound(ctx, user, ag, outbound.SendRequest{
+		To: []string{"alice@external.test"}, Subject: "later", Body: "scheduled body",
+		ScheduledAt: &at,
+	}, "send", "", nil, nil)
+	if oerr != nil {
+		t.Fatalf("DeliverOutbound: %+v", oerr)
+	}
+	if res == nil || res.Status != "scheduled" || res.ScheduledAt == nil || !res.ScheduledAt.Equal(at) {
+		t.Fatalf("result = %+v, want status=scheduled with ScheduledAt=%v", res, at)
+	}
+	// The scheduled instant was threaded to the River enqueue (not the immediate path).
+	if !enq.scheduledAt.Equal(at) {
+		t.Fatalf("enqueued ScheduledAt = %v, want %v", enq.scheduledAt, at)
+	}
+	// The row persists scheduled_at and stays delivery_status='accepted'.
+	m, err := store.GetMessageWithContent(ctx, res.MessageID, ag.ID)
+	if err != nil {
+		t.Fatalf("GetMessageWithContent: %v", err)
+	}
+	if m.DeliveryStatus != "accepted" {
+		t.Errorf("delivery_status = %q, want accepted (scheduled rows stay accepted)", m.DeliveryStatus)
+	}
+	if m.ScheduledAt == nil || !m.ScheduledAt.Equal(at) {
+		t.Errorf("stored scheduled_at = %v, want %v", m.ScheduledAt, at)
 	}
 }
 

--- a/internal/httpapi/messages.go
+++ b/internal/httpapi/messages.go
@@ -72,6 +72,12 @@ type MessageView struct {
 	// SentAs is the From identity actually used at relay accept time.
 	// Outbound-only; omitted on inbound messages.
 	SentAs string `json:"sent_as,omitempty" doc:"From identity used at relay accept time (outbound only). Open set; tolerate unknown values. Known values: own_address, relay."`
+	// ScheduledAt is the future instant a scheduled outbound send was queued to be
+	// submitted (migration 079). Set on outbound rows created with a future
+	// send_at and retained afterwards (it records the scheduled instant and is not
+	// cleared once the send fires); omitted for immediate sends and all inbound
+	// rows. delivery_status stays 'accepted' while scheduled.
+	ScheduledAt *time.Time `json:"scheduled_at,omitempty" format:"date-time" doc:"Future instant a scheduled outbound send was queued to be submitted (outbound only; treat as \"not before\"). Set when the message was created with a future send_at and retained afterwards; omitted for immediate sends. Cancel a scheduled send by moving the message to trash."`
 	// Flagged + FlagReason carry the beta inbound ingestion verdict: true when
 	// the agent's inbound-policy gate flagged this message on arrival while still
 	// delivering it. Polling agents need this signal because no review item is
@@ -193,6 +199,7 @@ func messageViewFromIdentity(m *identity.Message) MessageView {
 		v.DeliveryStatus = m.DeliveryStatus
 		v.DeliveryDetail = m.DeliveryDetail
 		v.SentAs = m.SentAs
+		v.ScheduledAt = utcPtr(m.ScheduledAt)
 		// HITL lifecycle (status column) — outbound only, mirroring the summary
 		// view; on inbound rows `status` is not the HITL value (review F1).
 		v.HITLStatus = m.Status

--- a/internal/httpapi/outbound.go
+++ b/internal/httpapi/outbound.go
@@ -123,11 +123,12 @@ type SendResultView struct {
 	// review_approved is the inbound-release outcome of POST .../approve (an
 	// inbound hold released to the agent's inbox — no send). sent/pending_review
 	// are the send/outbound-approve outcomes.
-	Status            string     `json:"status" doc:"Outcome. Open set; tolerate unknown values. Known values: accepted, sent, pending_review, review_approved, failed. accepted = durably persisted and queued for submission (async pipeline); the terminal outcome arrives via webhook events (email.sent / email.failed) or GET /v1/messages/{id}. failed = terminal failure. Always branch on this field, not the HTTP status code."`
+	Status            string     `json:"status" doc:"Outcome. Open set; tolerate unknown values. Known values: accepted, scheduled, sent, pending_review, review_approved, failed. accepted = durably persisted and queued for immediate submission (async pipeline); the terminal outcome arrives via webhook events (email.sent / email.failed) or GET /v1/messages/{id}. scheduled = accepted but deferred to a future send_at (see scheduled_at); it becomes accepted→sent at that time. failed = terminal failure. Always branch on this field, not the HTTP status code."`
 	MessageID         string     `json:"message_id"`
 	ProviderMessageID string     `json:"provider_message_id,omitempty" doc:"Upstream provider (SES) id. Optional/absent until the message is actually sent — an accepted-but-not-yet-sent message has no provider id."`
 	SentAs            string     `json:"sent_as,omitempty" doc:"From identity used. Open set; tolerate unknown values. Known values: own_address, relay."`
 	Method            string     `json:"method,omitempty" doc:"Send transport. Open set; tolerate unknown values. Known values: smtp, loopback."`
+	ScheduledAt       *time.Time `json:"scheduled_at,omitempty" format:"date-time" doc:"Set only when status=scheduled: the future instant this message is queued to be submitted (approximate — treat as \"not before\"). Cancel a scheduled send by moving the message to trash."`
 	ApprovalExpiresAt *time.Time `json:"approval_expires_at,omitempty"`
 	// Edited is set only by approve (true/false = did the reviewer edit the
 	// draft before sending); omitted on the plain send path.
@@ -224,6 +225,34 @@ func recipientCountError(groups ...[]string) *ErrorEnvelope {
 	return nil
 }
 
+// maxScheduleHorizon caps how far into the future a send_at may be scheduled.
+// River retains a `scheduled` job indefinitely (pruning only touches finalized
+// jobs), so an unbounded send_at is a footgun that also stretches the
+// trash-cancel window; 90 days is a generous planning horizon well short of
+// "forever".
+const maxScheduleHorizon = 90 * 24 * time.Hour
+
+// scheduledInstant validates a caller-supplied send_at and returns the effective
+// future schedule instant (UTC), or nil to send immediately. A nil/zero value or
+// one at/before `now` is immediate (nil, nil). A value beyond maxScheduleHorizon
+// is rejected with 400 invalid_request. Keeping the "past = immediate" rule (vs
+// a hard error) is deliberate: minor client/server clock skew shouldn't turn an
+// intended-now send into an error.
+func scheduledInstant(sendAt *time.Time, now time.Time) (*time.Time, *ErrorEnvelope) {
+	if sendAt == nil || sendAt.IsZero() {
+		return nil, nil
+	}
+	if !sendAt.After(now) {
+		return nil, nil // at/before now — send immediately
+	}
+	if sendAt.After(now.Add(maxScheduleHorizon)) {
+		return nil, NewError(http.StatusBadRequest, "invalid_request",
+			fmt.Sprintf("send_at is too far in the future — at most %d days ahead", int(maxScheduleHorizon/(24*time.Hour))))
+	}
+	at := sendAt.UTC()
+	return &at, nil
+}
+
 // SendEmailRequest is the new-thread send body. `to` is required (RFC 5321
 // requires ≥1 recipient; From/Date are server-set). Content comes in one of
 // two mutually exclusive shapes: literal subject + text (+ optional
@@ -246,6 +275,7 @@ type SendEmailRequest struct {
 	ReplyTo        string                `json:"reply_to,omitempty" maxLength:"320" doc:"Sets the Reply-To header — where replies to this message are directed. A single RFC 5322 address, optionally with a display name (e.g. \"Support <support@acme.com>\"). At most 320 characters (display name + address combined). Defaults to the sending agent's own address."`
 	Attachments    []outbound.Attachment `json:"attachments,omitempty" nullable:"false" doc:"File attachments (base64 in each item's data). Limits: at most 10 attachments, each ≤ 10 MiB decoded, and ≤ 25 MiB decoded combined. Exceeding the count → 400 invalid_request; exceeding a size → 413 payload_too_large."`
 	Unsubscribe    UnsubscribeOptions    `json:"unsubscribe,omitempty" doc:"Beta: opts this message into e2a-managed unsubscribe handling. This field may change before it is declared stable."`
+	SendAt         *time.Time            `json:"send_at,omitempty" format:"date-time" doc:"Optional scheduled-send time (RFC 3339 with a UTC offset). When set to a future instant the message is accepted immediately and returns status=scheduled; it is submitted to the provider at approximately this time. Treat it as \"not before\" — accurate to within the scheduler's poll interval (seconds), not exact-to-the-millisecond, and actual delivery can be later under provider retry/outage. A value at or before now sends immediately (identical to omitting it). Must be no more than 90 days ahead (over → 400 invalid_request). Note: scheduling does NOT survive a review hold — if the message is held for review, send_at is dropped and it sends on approval. Cancel a scheduled send by moving the message to trash."`
 }
 
 // UnsubscribeOptions is the beta per-message opt-in to e2a-managed unsubscribe
@@ -395,6 +425,7 @@ type ReplyRequest struct {
 	ReplyTo        string                `json:"reply_to,omitempty" maxLength:"320" doc:"Sets the Reply-To header — where replies to this message are directed. A single RFC 5322 address, optionally with a display name. At most 320 characters (display name + address combined). Defaults to the sending agent's own address."`
 	Attachments    []outbound.Attachment `json:"attachments,omitempty" nullable:"false" doc:"File attachments (base64 in each item's data). Limits: at most 10 attachments, each ≤ 10 MiB decoded, and ≤ 25 MiB decoded combined. Exceeding the count → 400 invalid_request; exceeding a size → 413 payload_too_large."`
 	Unsubscribe    UnsubscribeOptions    `json:"unsubscribe,omitempty" doc:"Beta: opts this message into e2a-managed unsubscribe handling. This field may change before it is declared stable."`
+	SendAt         *time.Time            `json:"send_at,omitempty" format:"date-time" doc:"Optional scheduled-send time (RFC 3339 with a UTC offset). When set to a future instant the reply is accepted immediately and returns status=scheduled; it is submitted at approximately this time (\"not before\", accurate to the scheduler poll interval). A value at or before now sends immediately. Must be no more than 90 days ahead (over → 400 invalid_request). Scheduling does not survive a review hold. Cancel by moving the message to trash."`
 }
 
 type replyInput struct {
@@ -541,6 +572,11 @@ func (s *Server) handleReply(ctx context.Context, in *replyInput) (*sendOutput, 
 	if env := recipientCountError(req.To, req.CC, req.BCC); env != nil {
 		return nil, env
 	}
+	sched, senv := scheduledInstant(b.SendAt, time.Now())
+	if senv != nil {
+		return nil, senv
+	}
+	req.ScheduledAt = sched
 	return s.deliver(ctx, user, ag, literalRequest(req), "reply", parentMessageID, "/v1/reply/"+in.ID, in.IdempotencyKey, in.Wait, in.RawBody, msg)
 }
 
@@ -584,6 +620,7 @@ type ForwardRequest struct {
 	ReplyTo        string                `json:"reply_to,omitempty" maxLength:"320" doc:"Sets the Reply-To header — where replies to this message are directed. A single RFC 5322 address, optionally with a display name. At most 320 characters (display name + address combined). Defaults to the sending agent's own address."`
 	Attachments    []outbound.Attachment `json:"attachments,omitempty" nullable:"false" doc:"Additional attachments to include alongside the forwarded message's original attachments, which are carried over automatically. Limits apply to the combined set (originals + these): at most 10 attachments, each ≤ 10 MiB decoded, and ≤ 25 MiB decoded combined. Exceeding the count → 400 invalid_request; exceeding a size → 413 payload_too_large."`
 	Unsubscribe    UnsubscribeOptions    `json:"unsubscribe,omitempty" doc:"Beta: opts this message into e2a-managed unsubscribe handling. This field may change before it is declared stable."`
+	SendAt         *time.Time            `json:"send_at,omitempty" format:"date-time" doc:"Optional scheduled-send time (RFC 3339 with a UTC offset). When set to a future instant the forward is accepted immediately and returns status=scheduled; it is submitted at approximately this time (\"not before\", accurate to the scheduler poll interval). A value at or before now sends immediately. Must be no more than 90 days ahead (over → 400 invalid_request). Scheduling does not survive a review hold. Cancel by moving the message to trash."`
 }
 
 type forwardInput struct {
@@ -636,6 +673,11 @@ func (s *Server) handleForward(ctx context.Context, in *forwardInput) (*sendOutp
 	}
 	req.CC = agent.StripAgentSelfAliases(req.CC, ag.EmailAddress())
 	req.BCC = agent.StripAgentSelfAliases(req.BCC, ag.EmailAddress())
+	sched, senv := scheduledInstant(b.SendAt, time.Now())
+	if senv != nil {
+		return nil, senv
+	}
+	req.ScheduledAt = sched
 	return s.deliver(ctx, user, ag, literalRequest(req), "forward", msg.ThreadMessageID(), "/v1/forward/"+in.ID, in.IdempotencyKey, in.Wait, in.RawBody, msg)
 }
 
@@ -909,6 +951,15 @@ func acceptedView(messageID string) SendResultView {
 	return SendResultView{Status: "accepted", MessageID: messageID, Method: "smtp"}
 }
 
+// scheduledView is the async-accept wire body for a scheduled send. Like
+// acceptedView it is built identically for the live response and the idempotency
+// cache entry (byte-identical replay), and it deliberately reports status
+// "scheduled" (not "accepted") so the wait=sent poll loop is skipped — a
+// scheduled send has no imminent outcome to wait for.
+func scheduledView(messageID string, at *time.Time) SendResultView {
+	return SendResultView{Status: "scheduled", MessageID: messageID, Method: "smtp", ScheduledAt: at}
+}
+
 // outboundResultView is shared by the live response and the same-transaction
 // idempotency completion. That keeps queue acceptance (202/accepted) distinct
 // from terminal providerless loopback delivery (200/sent) on every replay.
@@ -918,6 +969,9 @@ func outboundResultView(res *agent.OutboundResult) (int, SendResultView) {
 			Status: "pending_review", MessageID: res.PendingMessageID,
 			ApprovalExpiresAt: res.ApprovalExpiresAt,
 		}
+	}
+	if res.Status == "scheduled" {
+		return http.StatusAccepted, scheduledView(res.MessageID, res.ScheduledAt)
 	}
 	if res.Status == "accepted" {
 		return http.StatusAccepted, acceptedView(res.MessageID)
@@ -997,6 +1051,10 @@ func (s *Server) handleCreateMessage(ctx context.Context, in *createMessageInput
 		if env := validateReplyTo(b.ReplyTo); env != nil {
 			return outbound.SendRequest{}, env
 		}
+		sched, senv := scheduledInstant(b.SendAt, time.Now())
+		if senv != nil {
+			return outbound.SendRequest{}, senv
+		}
 		// The sender is the path agent (decision 3) — there is no body `from`;
 		// the agent is the path and auth scopes the sender, so no spoofing is
 		// possible.
@@ -1005,6 +1063,7 @@ func (s *Server) handleCreateMessage(ctx context.Context, in *createMessageInput
 			Body: b.Body, HTMLBody: b.HTMLBody, ConversationID: b.ConversationID,
 			ReplyTo: b.ReplyTo, Attachments: b.Attachments,
 			Unsubscribe: outboundUnsubscribe(b.Unsubscribe),
+			ScheduledAt: sched,
 		}, nil
 	}
 	// A cold send has no referenced inbound (nil) — it's not a reply/forward.

--- a/internal/httpapi/outbound_scheduled_test.go
+++ b/internal/httpapi/outbound_scheduled_test.go
@@ -1,0 +1,123 @@
+package httpapi
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/tokencanopy/e2a/internal/agent"
+	"github.com/tokencanopy/e2a/internal/identity"
+	"github.com/tokencanopy/e2a/internal/outbound"
+)
+
+// scheduleEchoDeps wires a DeliverOutbound that mirrors the real accept path's
+// scheduled/immediate decision (Status="scheduled" + ScheduledAt when the edge
+// parsed a future send_at, else "accepted"), and a PollSendOutcome that flips
+// *polled so a test can assert wait=sent never polled a scheduled send.
+func scheduleEchoDeps(polled *bool) func(*Deps) {
+	return func(d *Deps) {
+		d.DeliverOutbound = func(_ context.Context, _ *identity.User, _ *identity.AgentIdentity, req outbound.SendRequest, _, _ string, _ *identity.Message, _ agent.AcceptIdemCompleter) (*agent.OutboundResult, *agent.OutboundError) {
+			if req.ScheduledAt != nil {
+				return &agent.OutboundResult{MessageID: "msg_sched_1", Status: "scheduled", ScheduledAt: req.ScheduledAt, Method: "smtp"}, nil
+			}
+			return &agent.OutboundResult{MessageID: "msg_imm_1", Status: "accepted", Method: "smtp"}, nil
+		}
+		d.PollSendOutcome = func(_ context.Context, _ string) (identity.SendOutcome, error) {
+			if polled != nil {
+				*polled = true
+			}
+			return identity.SendOutcome{DeliveryStatus: "sent", ProviderMessageID: "ses-x", SentAs: "relay"}, nil
+		}
+	}
+}
+
+// TestSend_ScheduledFuture: a future send_at is accepted as status=scheduled with
+// scheduled_at echoed, at 202 — and wait=sent must NOT poll (a scheduled send has
+// no imminent outcome; the "scheduled" presentation status is what skips the poll
+// loop). This pins the edge→DeliverOutbound threading and outboundResultView.
+func TestSend_ScheduledFuture(t *testing.T) {
+	polled := false
+	srv := testServer(t, scheduleEchoDeps(&polled))
+	at := time.Now().Add(24 * time.Hour).UTC().Format(time.RFC3339)
+	code, body := postJSON(t, srv.URL+"/v1/agents/support%40acme.com/messages?wait=sent", "good",
+		map[string]any{"to": []string{"x@y.com"}, "subject": "s", "text": "b", "send_at": at})
+	if code != 202 {
+		t.Fatalf("scheduled send: want 202, got %d (%v)", code, body)
+	}
+	if body["status"] != "scheduled" {
+		t.Fatalf("want status=scheduled, got %v", body["status"])
+	}
+	if body["scheduled_at"] == nil || body["scheduled_at"] == "" {
+		t.Fatalf("want scheduled_at echoed, got %v", body["scheduled_at"])
+	}
+	if polled {
+		t.Fatal("wait=sent must NOT poll a scheduled send")
+	}
+}
+
+// TestSend_PastSendAt_Immediate: a send_at at/before now is treated as an ordinary
+// immediate send (status=accepted), never rejected — clock skew shouldn't turn an
+// intended-now send into an error.
+func TestSend_PastSendAt_Immediate(t *testing.T) {
+	srv := testServer(t, scheduleEchoDeps(nil))
+	at := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	code, body := postJSON(t, srv.URL+"/v1/agents/support%40acme.com/messages", "good",
+		map[string]any{"to": []string{"x@y.com"}, "subject": "s", "text": "b", "send_at": at})
+	if code != 202 || body["status"] != "accepted" {
+		t.Fatalf("past send_at: want 202 accepted (immediate), got %d %v", code, body)
+	}
+	if body["scheduled_at"] != nil {
+		t.Fatalf("immediate send must not carry scheduled_at, got %v", body["scheduled_at"])
+	}
+}
+
+// TestSend_SendAtBeyondHorizon_Rejected: a send_at past the max horizon is a 400
+// invalid_request, and never reaches DeliverOutbound.
+func TestSend_SendAtBeyondHorizon_Rejected(t *testing.T) {
+	delivered := false
+	srv := testServer(t, func(d *Deps) {
+		scheduleEchoDeps(nil)(d)
+		d.DeliverOutbound = func(_ context.Context, _ *identity.User, _ *identity.AgentIdentity, _ outbound.SendRequest, _, _ string, _ *identity.Message, _ agent.AcceptIdemCompleter) (*agent.OutboundResult, *agent.OutboundError) {
+			delivered = true
+			return &agent.OutboundResult{MessageID: "msg_no", Status: "accepted"}, nil
+		}
+	})
+	at := time.Now().Add(100 * 24 * time.Hour).UTC().Format(time.RFC3339)
+	code, body := postJSON(t, srv.URL+"/v1/agents/support%40acme.com/messages", "good",
+		map[string]any{"to": []string{"x@y.com"}, "subject": "s", "text": "b", "send_at": at})
+	if code != 400 || errCode(body) != "invalid_request" {
+		t.Fatalf("over-horizon send_at: want 400 invalid_request, got %d %v", code, body)
+	}
+	if delivered {
+		t.Fatal("over-horizon send_at must be rejected before DeliverOutbound")
+	}
+}
+
+// TestScheduledInstant pins the edge validation/normalization directly.
+func TestScheduledInstant(t *testing.T) {
+	now := time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC)
+	future := now.Add(48 * time.Hour)
+
+	if got, env := scheduledInstant(nil, now); got != nil || env != nil {
+		t.Fatalf("nil send_at: want (nil,nil), got (%v,%v)", got, env)
+	}
+	var zero time.Time
+	if got, env := scheduledInstant(&zero, now); got != nil || env != nil {
+		t.Fatalf("zero send_at: want (nil,nil), got (%v,%v)", got, env)
+	}
+	past := now.Add(-time.Minute)
+	if got, env := scheduledInstant(&past, now); got != nil || env != nil {
+		t.Fatalf("past send_at: want immediate (nil,nil), got (%v,%v)", got, env)
+	}
+	got, env := scheduledInstant(&future, now)
+	if env != nil || got == nil || !got.Equal(future) {
+		t.Fatalf("future send_at: want (%v,nil), got (%v,%v)", future, got, env)
+	}
+	if got.Location() != time.UTC {
+		t.Fatalf("scheduled instant must be normalized to UTC, got %v", got.Location())
+	}
+	tooFar := now.Add(maxScheduleHorizon + time.Hour)
+	if got, env := scheduledInstant(&tooFar, now); env == nil || got != nil {
+		t.Fatalf("over-horizon send_at: want error, got (%v,%v)", got, env)
+	}
+}

--- a/internal/identity/store.go
+++ b/internal/identity/store.go
@@ -354,8 +354,13 @@ type Message struct {
 	// SentAs is the From identity actually used when the outbound message was
 	// accepted by the relay. Outbound-only; empty on inbound rows. Source:
 	// messages.sent_as.
-	SentAs    string    `json:"sent_as,omitempty"`
-	CreatedAt time.Time `json:"created_at"`
+	SentAs string `json:"sent_as,omitempty"`
+	// ScheduledAt is the future instant a scheduled outbound send is queued to be
+	// submitted (migration 079). Nil for immediate sends and every inbound row.
+	// The row stays delivery_status='accepted' while scheduled; this timestamp is
+	// the introspection marker (the actual deferral lives on the River job).
+	ScheduledAt *time.Time `json:"scheduled_at,omitempty"`
+	CreatedAt   time.Time  `json:"created_at"`
 	// ExpiresAt is nil for indefinitely retained messages. It remains on the
 	// model for compatibility with account exports and legacy database rows.
 	ExpiresAt *time.Time `json:"expires_at" nullable:"true" format:"date-time" doc:"Message expiry. Null means the message is retained indefinitely."`
@@ -2329,6 +2334,16 @@ func (s *Store) StampSendJobIDTx(ctx context.Context, tx pgx.Tx, messageID strin
 	return err
 }
 
+// StampScheduledAtTx records the future send instant on a scheduled outbound
+// message, WITHIN the accept-tx (mirrors StampSendJobIDTx). Called only when the
+// caller supplied a future send_at; immediate sends never call this, leaving
+// scheduled_at NULL. The corresponding River job is enqueued with the same
+// instant as its ScheduledAt, so the column and the job agree.
+func (s *Store) StampScheduledAtTx(ctx context.Context, tx pgx.Tx, messageID string, at time.Time) error {
+	_, err := tx.Exec(ctx, `UPDATE messages SET scheduled_at = $2 WHERE id = $1`, messageID, at)
+	return err
+}
+
 // CreatePendingOutboundMessage stores a fully composed outbound email in
 // pending_review status, including body_text, body_html, and attachments so
 // that approval can reconstruct the original SendRequest (or accept edits)
@@ -3872,12 +3887,12 @@ func (s *Store) GetMessageWithContent(ctx context.Context, messageID, agentID st
 		   UPDATE messages SET inbox_status = CASE WHEN inbox_status = 'unread' THEN 'read' ELSE inbox_status END
 		   WHERE id = $1 AND agent_id = $2
 		     AND NOT (direction = 'inbound' AND status IN (`+heldInboundStatuses+`))
-		   RETURNING id, agent_id, direction, sender, COALESCE(header_from, '') AS header_from, COALESCE(envelope_from, '') AS envelope_from, authentication, recipient, to_recipients, cc, reply_to, subject, email_message_id, conversation_id, COALESCE(inbox_status, '') AS inbox_status, raw_message, auth_headers, auth_verdict, COALESCE(flagged, false) AS flagged, COALESCE(flag_reason, '') AS flag_reason, created_at, expires_at, deleted_at, labels, COALESCE(delivery_status, '') AS delivery_status, COALESCE(delivery_detail, '') AS delivery_detail, COALESCE(sent_as, '') AS sent_as, COALESCE(body_text, '') AS body_text, COALESCE(body_html, '') AS body_html, COALESCE(status, '') AS status, COALESCE(method, '') AS method
+		   RETURNING id, agent_id, direction, sender, COALESCE(header_from, '') AS header_from, COALESCE(envelope_from, '') AS envelope_from, authentication, recipient, to_recipients, cc, reply_to, subject, email_message_id, conversation_id, COALESCE(inbox_status, '') AS inbox_status, raw_message, auth_headers, auth_verdict, COALESCE(flagged, false) AS flagged, COALESCE(flag_reason, '') AS flag_reason, created_at, expires_at, deleted_at, labels, COALESCE(delivery_status, '') AS delivery_status, COALESCE(delivery_detail, '') AS delivery_detail, COALESCE(sent_as, '') AS sent_as, COALESCE(body_text, '') AS body_text, COALESCE(body_html, '') AS body_html, COALESCE(status, '') AS status, COALESCE(method, '') AS method, scheduled_at
 		 )
-		 SELECT upd.id, upd.agent_id, upd.direction, upd.sender, upd.header_from, upd.envelope_from, upd.authentication, upd.recipient, upd.to_recipients, upd.cc, upd.reply_to, upd.subject, upd.email_message_id, upd.conversation_id, upd.inbox_status, upd.raw_message, upd.auth_headers, upd.auth_verdict, upd.flagged, upd.flag_reason, upd.created_at, upd.expires_at, upd.deleted_at, upd.labels, upd.delivery_status, upd.delivery_detail, upd.sent_as, upd.body_text, upd.body_html, upd.status, upd.method, COALESCE(wd.status, ''), COALESCE(wd.last_error, '')
+		 SELECT upd.id, upd.agent_id, upd.direction, upd.sender, upd.header_from, upd.envelope_from, upd.authentication, upd.recipient, upd.to_recipients, upd.cc, upd.reply_to, upd.subject, upd.email_message_id, upd.conversation_id, upd.inbox_status, upd.raw_message, upd.auth_headers, upd.auth_verdict, upd.flagged, upd.flag_reason, upd.created_at, upd.expires_at, upd.deleted_at, upd.labels, upd.delivery_status, upd.delivery_detail, upd.sent_as, upd.body_text, upd.body_html, upd.status, upd.method, upd.scheduled_at, COALESCE(wd.status, ''), COALESCE(wd.last_error, '')
 		 FROM upd LEFT JOIN webhook_deliveries wd ON wd.message_id = upd.id`,
 		messageID, agentID,
-	).Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.HeaderFrom, &m.EnvelopeFrom, &authentication, &m.Recipient, &m.ToRecipients, &m.CC, &m.ReplyTo, &m.Subject, &m.EmailMessageID, &m.ConversationID, &m.InboxStatus, &m.RawMessage, &authHeadersJSON, &authVerdict, &m.Flagged, &m.FlagReason, &m.CreatedAt, &m.ExpiresAt, &m.DeletedAt, &m.Labels, &outboundDeliveryStatus, &m.DeliveryDetail, &m.SentAs, &m.BodyText, &m.BodyHTML, &m.Status, &m.Method, &m.WebhookStatus, &m.WebhookError)
+	).Scan(&m.ID, &m.AgentID, &m.Direction, &m.Sender, &m.HeaderFrom, &m.EnvelopeFrom, &authentication, &m.Recipient, &m.ToRecipients, &m.CC, &m.ReplyTo, &m.Subject, &m.EmailMessageID, &m.ConversationID, &m.InboxStatus, &m.RawMessage, &authHeadersJSON, &authVerdict, &m.Flagged, &m.FlagReason, &m.CreatedAt, &m.ExpiresAt, &m.DeletedAt, &m.Labels, &outboundDeliveryStatus, &m.DeliveryDetail, &m.SentAs, &m.BodyText, &m.BodyHTML, &m.Status, &m.Method, &m.ScheduledAt, &m.WebhookStatus, &m.WebhookError)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/outbound/sender.go
+++ b/internal/outbound/sender.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/mail"
 	"strings"
+	"time"
 
 	"github.com/tokencanopy/e2a/internal/delivery"
 	"github.com/tokencanopy/e2a/internal/dkim"
@@ -78,6 +79,12 @@ type SendRequest struct {
 	ConversationID   string              `json:"conversation_id,omitempty"`
 	Attachments      []Attachment        `json:"attachments,omitempty"`
 	Unsubscribe      *UnsubscribeOptions `json:"unsubscribe,omitempty"`
+	// ScheduledAt, when non-nil, defers this send to a future instant: the
+	// message is accepted + queued immediately (delivery_status='accepted'), but
+	// its River outbound_send job is held until this time. Nil means send now.
+	// The API edge validates it (future + within the max horizon) and normalizes
+	// a nil/past value to nil before this reaches DeliverOutbound.
+	ScheduledAt *time.Time `json:"scheduled_at,omitempty"`
 }
 
 type UnsubscribeOptions struct {

--- a/internal/outboundsend/jobs.go
+++ b/internal/outboundsend/jobs.go
@@ -2,6 +2,7 @@ package outboundsend
 
 import (
 	"context"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -78,10 +79,32 @@ func (j *Jobs) ReconcilePending(ctx context.Context, pool *pgxpool.Pool) (int, e
 // the reconciler can find stranded rows (`accepted` with no job). Mirrors
 // webhookdelivery.EnqueueDeliveryTx.
 func (j *Jobs) EnqueueSendTx(ctx context.Context, tx pgx.Tx, messageID string) (int64, error) {
-	res, err := j.enq.InsertTx(ctx, tx, OutboundSendArgs{MessageID: messageID}, &river.InsertOpts{
+	return j.enqueueSendTx(ctx, tx, messageID, time.Time{})
+}
+
+// EnqueueScheduledSendTx is EnqueueSendTx for a scheduled send: it enqueues the
+// same outbound_send job in the caller's transaction, but with
+// river.InsertOpts.ScheduledAt=at so River holds the job in state `scheduled`
+// and does not promote it to a worker until `at`. Everything downstream (claim,
+// suppression re-check, retry envelope, terminal reconciler) is byte-identical
+// to an immediate send — scheduling changes only WHEN the job first runs. A zero
+// `at` behaves exactly like EnqueueSendTx (immediate).
+func (j *Jobs) EnqueueScheduledSendTx(ctx context.Context, tx pgx.Tx, messageID string, at time.Time) (int64, error) {
+	return j.enqueueSendTx(ctx, tx, messageID, at)
+}
+
+// enqueueSendTx is the shared outbox insert behind the immediate and scheduled
+// entry points. A non-zero `at` sets InsertOpts.ScheduledAt; a zero value omits
+// it (River defaults ScheduledAt to now, i.e. immediately available).
+func (j *Jobs) enqueueSendTx(ctx context.Context, tx pgx.Tx, messageID string, at time.Time) (int64, error) {
+	opts := &river.InsertOpts{
 		Queue:       jobs.QueueOutbound,
 		MaxAttempts: MaxSendAttempts,
-	})
+	}
+	if !at.IsZero() {
+		opts.ScheduledAt = at
+	}
+	res, err := j.enq.InsertTx(ctx, tx, OutboundSendArgs{MessageID: messageID}, opts)
 	if err != nil {
 		return 0, err
 	}

--- a/mcp/src/client.ts
+++ b/mcp/src/client.ts
@@ -178,6 +178,7 @@ export class McpClient {
       attachments?: Array<Attachment>;
       conversationId?: string;
       replyTo?: string;
+      sendAt?: Date;
     },
     opts: SendOpts = {},
     explicitAddress?: string,
@@ -196,6 +197,7 @@ export class McpClient {
       attachments?: Array<Attachment>;
       conversationId?: string;
       replyTo?: string;
+      sendAt?: Date;
     },
     opts: SendOpts = {},
     explicitAddress?: string,
@@ -219,6 +221,7 @@ export class McpClient {
       attachments?: Array<Attachment>;
       conversationId?: string;
       replyTo?: string;
+      sendAt?: Date;
     },
     opts: SendOpts = {},
     explicitAddress?: string,

--- a/mcp/src/tools/messages.ts
+++ b/mcp/src/tools/messages.ts
@@ -64,6 +64,17 @@ export function messageViewForTool(email: MessageView) {
   };
 }
 
+// Shared scheduled-send input. A future send_at defers submission to that
+// instant (status "scheduled"); the tool passes it through as a Date so the SDK
+// serializes it as a date-time. Same field on send/reply/forward.
+const sendAtField = z
+  .string()
+  .datetime({ offset: true })
+  .optional()
+  .describe(
+    'Optional scheduled-send time (RFC 3339 with a UTC offset, e.g. "2026-08-01T09:00:00Z"). When set to a future instant, the message is accepted immediately with status "scheduled" and submitted at approximately that time ("not before", accurate to seconds). A value at or before now sends immediately; more than 90 days ahead is rejected. Scheduling does NOT survive a review hold (send_at is dropped and it sends on approval). Cancel a scheduled send with delete_message (move to trash).',
+  );
+
 export function registerMessageTools(server: McpServer, client: McpClient): void {
   server.registerTool(
     "send_message",
@@ -116,6 +127,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
           .describe(
             "Stable key for retry-safe sends. Set to deduplicate when the caller has its own retry loop (e.g. a stable triggering event id). When omitted the SDK mints a fresh UUIDv4 per call — protects against network-layer retries only, not user-driven retries.",
           ),
+        send_at: sendAtField,
         email: z
           .string()
           .optional()
@@ -151,6 +163,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
               ? { conversationId: args.conversation_id }
               : {}),
             ...(args.reply_to !== undefined ? { replyTo: args.reply_to } : {}),
+            ...(args.send_at !== undefined ? { sendAt: new Date(args.send_at) } : {}),
           },
           opts,
           args.email,
@@ -194,6 +207,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
           .describe(
             "Stable key for retry-safe replies. A natural choice is the inbound `message_id` you're replying to — the same triggering event yields the same key, so a retry replays the original response instead of double-sending. Omit to let the SDK mint a fresh UUIDv4 per call.",
           ),
+        send_at: sendAtField,
         email: z.string().optional(),
       }),
     },
@@ -218,6 +232,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
               ? { conversationId: args.conversation_id }
               : {}),
             ...(args.reply_to !== undefined ? { replyTo: args.reply_to } : {}),
+            ...(args.send_at !== undefined ? { sendAt: new Date(args.send_at) } : {}),
           },
           opts,
           args.email,
@@ -263,6 +278,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
           .describe(
             "Stable key for retry-safe forwards. The inbound `message_id` plus target list is a natural choice.",
           ),
+        send_at: sendAtField,
         email: z.string().optional(),
       }),
     },
@@ -289,6 +305,7 @@ export function registerMessageTools(server: McpServer, client: McpClient): void
               ? { conversationId: args.conversation_id }
               : {}),
             ...(args.reply_to !== undefined ? { replyTo: args.reply_to } : {}),
+            ...(args.send_at !== undefined ? { sendAt: new Date(args.send_at) } : {}),
           },
           opts,
           args.email,

--- a/migrations/079_messages_scheduled_at.sql
+++ b/migrations/079_messages_scheduled_at.sql
@@ -1,0 +1,15 @@
+-- 079_messages_scheduled_at.sql
+-- Scheduled send: the future instant at which a queued outbound message should
+-- be submitted to the provider. NULL for immediate sends (the default, and the
+-- value for every pre-existing row).
+--
+-- A scheduled message is accepted and persisted exactly like an immediate send
+-- (delivery_status='accepted'); the ONLY difference is WHEN its River
+-- outbound_send job runs (river InsertOpts.ScheduledAt). A future-scheduled job
+-- sits in River state 'scheduled', so the terminal reconciler (which only sweeps
+-- 'accepted' rows whose job is missing/cancelled/discarded/completed) leaves it
+-- alone until it fires. No new delivery_status value is introduced.
+--
+-- Nullable, no default: a metadata-only ADD COLUMN, safe (non-rewriting) on the
+-- prod-sized messages table. Idempotent per the migration contract.
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS scheduled_at TIMESTAMPTZ;

--- a/sdks/python/src/e2a/v1/generated/models/forward_request.py
+++ b/sdks/python/src/e2a/v1/generated/models/forward_request.py
@@ -17,6 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
+from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field
 from typing import Any, ClassVar, Dict, List, Optional
 from typing_extensions import Annotated
@@ -35,11 +36,12 @@ class ForwardRequest(BaseModel):
     conversation_id: Optional[Annotated[str, Field(strict=True, max_length=200)]] = Field(default=None, description="Caller-assigned conversation (thread) id override. At most 200 characters — deliberately the same cap as the webhook conversation_ids filter-value limit and the message-list conversation_id filter limit (both 200), so an accepted conversation_id is never too long to filter by. Must not contain CR or LF.")
     html: Optional[Annotated[str, Field(strict=True, max_length=1048576)]] = None
     reply_to: Optional[Annotated[str, Field(strict=True, max_length=320)]] = Field(default=None, description="Sets the Reply-To header — where replies to this message are directed. A single RFC 5322 address, optionally with a display name. At most 320 characters (display name + address combined). Defaults to the sending agent's own address.")
+    send_at: Optional[datetime] = Field(default=None, description="Optional scheduled-send time (RFC 3339 with a UTC offset). When set to a future instant the forward is accepted immediately and returns status=scheduled; it is submitted at approximately this time (\"not before\", accurate to the scheduler poll interval). A value at or before now sends immediately. Must be no more than 90 days ahead (over → 400 invalid_request). Scheduling does not survive a review hold. Cancel by moving the message to trash.")
     text: Annotated[str, Field(strict=True, max_length=1048576)]
     to: List[Annotated[str, Field(strict=True, max_length=320)]] = Field(description="Primary recipients. The message is limited to 50 recipients across to, cc, and bcc combined. Each recipient string (display name + address combined) is limited to 320 characters.")
     unsubscribe: Optional[UnsubscribeOptions] = Field(default=None, description="Beta: opts this message into e2a-managed unsubscribe handling. This field may change before it is declared stable.")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["attachments", "bcc", "cc", "conversation_id", "html", "reply_to", "text", "to", "unsubscribe"]
+    __properties: ClassVar[List[str]] = ["attachments", "bcc", "cc", "conversation_id", "html", "reply_to", "send_at", "text", "to", "unsubscribe"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -115,6 +117,7 @@ class ForwardRequest(BaseModel):
             "conversation_id": obj.get("conversation_id"),
             "html": obj.get("html"),
             "reply_to": obj.get("reply_to"),
+            "send_at": obj.get("send_at"),
             "text": obj.get("text"),
             "to": obj.get("to"),
             "unsubscribe": UnsubscribeOptions.from_dict(obj["unsubscribe"]) if obj.get("unsubscribe") is not None else None

--- a/sdks/python/src/e2a/v1/generated/models/message.py
+++ b/sdks/python/src/e2a/v1/generated/models/message.py
@@ -64,6 +64,7 @@ class Message(BaseModel):
     reviewed_by_user_id: Optional[StrictStr] = None
     scan_action: Optional[StrictStr] = None
     scan_score: Optional[Union[StrictFloat, StrictInt]] = None
+    scheduled_at: Optional[datetime] = None
     sent_as: Optional[StrictStr] = None
     size_bytes: Optional[StrictInt] = Field(default=None, description="RAW MIME byte length of the whole stored message (octet length of raw_message). Distinct from an attachment's size_bytes (DECODED payload size). Dominant term of storage-quota accounting (usage.storage_bytes).")
     status: Optional[StrictStr] = None
@@ -76,7 +77,7 @@ class Message(BaseModel):
     webhook_error: Optional[StrictStr] = None
     webhook_status: Optional[StrictStr] = None
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["agent_email", "approval_expires_at", "attachments", "authentication", "bcc", "cc", "conversation_id", "created_at", "deleted_at", "delivered_to", "delivery_detail", "delivery_status", "direction", "edited", "email_message_id", "envelope_from", "expires_at", "flag_reason", "flagged", "header_from", "html", "id", "labels", "method", "provider_message_id", "raw_message", "read_status", "rejection_reason", "reply_to", "review_reason", "reviewed_at", "reviewed_by_name", "reviewed_by_user_id", "scan_action", "scan_score", "sent_as", "size_bytes", "status", "subject", "text", "to", "type", "verified_domain", "webhook_attempts", "webhook_error", "webhook_status"]
+    __properties: ClassVar[List[str]] = ["agent_email", "approval_expires_at", "attachments", "authentication", "bcc", "cc", "conversation_id", "created_at", "deleted_at", "delivered_to", "delivery_detail", "delivery_status", "direction", "edited", "email_message_id", "envelope_from", "expires_at", "flag_reason", "flagged", "header_from", "html", "id", "labels", "method", "provider_message_id", "raw_message", "read_status", "rejection_reason", "reply_to", "review_reason", "reviewed_at", "reviewed_by_name", "reviewed_by_user_id", "scan_action", "scan_score", "scheduled_at", "sent_as", "size_bytes", "status", "subject", "text", "to", "type", "verified_domain", "webhook_attempts", "webhook_error", "webhook_status"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -236,6 +237,7 @@ class Message(BaseModel):
             "reviewed_by_user_id": obj.get("reviewed_by_user_id"),
             "scan_action": obj.get("scan_action"),
             "scan_score": obj.get("scan_score"),
+            "scheduled_at": obj.get("scheduled_at"),
             "sent_as": obj.get("sent_as"),
             "size_bytes": obj.get("size_bytes"),
             "status": obj.get("status"),

--- a/sdks/python/src/e2a/v1/generated/models/message_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/message_view.py
@@ -56,6 +56,7 @@ class MessageView(BaseModel):
     read_status: StrictStr
     reply_to: List[StrictStr] = Field(description="The parsed Reply-To header of an inbound message. Populated for inbound only; always empty for outbound (a Reply-To you SET on a send is a request-side field on the send/reply/forward body and is not echoed back here).")
     review_status: Optional[StrictStr] = Field(default=None, description="Review-hold lifecycle (outbound only). Open set; tolerate unknown values. Known values: pending_review, sent, review_rejected, review_expired_approved, review_expired_rejected. Note: an APPROVED outbound hold reads as sent here — the message view intentionally collapses the approved outcome into the delivery lifecycle. The distinct review_approved spelling appears only in the approve result (SendResultView.status, for inbound release) and the email.review_approved webhook event, not in this field.")
+    scheduled_at: Optional[datetime] = Field(default=None, description="Future instant a scheduled outbound send was queued to be submitted (outbound only; treat as \"not before\"). Set when the message was created with a future send_at and retained afterwards; omitted for immediate sends. Cancel a scheduled send by moving the message to trash.")
     sent_as: Optional[StrictStr] = Field(default=None, description="From identity used at relay accept time (outbound only). Open set; tolerate unknown values. Known values: own_address, relay.")
     size_bytes: Optional[StrictInt] = Field(default=None, description="RAW MIME byte length of the whole stored message (headers + bodies + encoded attachments as transported). Distinct from attachments[].size_bytes, which is one attachment's DECODED payload size. This value is the dominant term of the account's storage-quota accounting (usage.storage_bytes).")
     subject: StrictStr
@@ -64,7 +65,7 @@ class MessageView(BaseModel):
     webhook_error: Optional[StrictStr] = None
     webhook_status: Optional[StrictStr] = None
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["attachments", "authentication", "body", "cc", "conversation_id", "created_at", "deleted_at", "delivered_to", "delivery_detail", "delivery_status", "direction", "envelope_from", "flag_reason", "flagged", "header_from", "hold_reason", "id", "labels", "parsed", "protection", "raw_message", "read_status", "reply_to", "review_status", "sent_as", "size_bytes", "subject", "to", "verified_domain", "webhook_error", "webhook_status"]
+    __properties: ClassVar[List[str]] = ["attachments", "authentication", "body", "cc", "conversation_id", "created_at", "deleted_at", "delivered_to", "delivery_detail", "delivery_status", "direction", "envelope_from", "flag_reason", "flagged", "header_from", "hold_reason", "id", "labels", "parsed", "protection", "raw_message", "read_status", "reply_to", "review_status", "scheduled_at", "sent_as", "size_bytes", "subject", "to", "verified_domain", "webhook_error", "webhook_status"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -204,6 +205,7 @@ class MessageView(BaseModel):
             "read_status": obj.get("read_status"),
             "reply_to": obj.get("reply_to"),
             "review_status": obj.get("review_status"),
+            "scheduled_at": obj.get("scheduled_at"),
             "sent_as": obj.get("sent_as"),
             "size_bytes": obj.get("size_bytes"),
             "subject": obj.get("subject"),

--- a/sdks/python/src/e2a/v1/generated/models/reply_request.py
+++ b/sdks/python/src/e2a/v1/generated/models/reply_request.py
@@ -17,6 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
+from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictBool
 from typing import Any, ClassVar, Dict, List, Optional
 from typing_extensions import Annotated
@@ -36,10 +37,11 @@ class ReplyRequest(BaseModel):
     html: Optional[Annotated[str, Field(strict=True, max_length=1048576)]] = None
     reply_all: Optional[StrictBool] = None
     reply_to: Optional[Annotated[str, Field(strict=True, max_length=320)]] = Field(default=None, description="Sets the Reply-To header — where replies to this message are directed. A single RFC 5322 address, optionally with a display name. At most 320 characters (display name + address combined). Defaults to the sending agent's own address.")
+    send_at: Optional[datetime] = Field(default=None, description="Optional scheduled-send time (RFC 3339 with a UTC offset). When set to a future instant the reply is accepted immediately and returns status=scheduled; it is submitted at approximately this time (\"not before\", accurate to the scheduler poll interval). A value at or before now sends immediately. Must be no more than 90 days ahead (over → 400 invalid_request). Scheduling does not survive a review hold. Cancel by moving the message to trash.")
     text: Annotated[str, Field(strict=True, max_length=1048576)]
     unsubscribe: Optional[UnsubscribeOptions] = Field(default=None, description="Beta: opts this message into e2a-managed unsubscribe handling. This field may change before it is declared stable.")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["attachments", "bcc", "cc", "conversation_id", "html", "reply_all", "reply_to", "text", "unsubscribe"]
+    __properties: ClassVar[List[str]] = ["attachments", "bcc", "cc", "conversation_id", "html", "reply_all", "reply_to", "send_at", "text", "unsubscribe"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -116,6 +118,7 @@ class ReplyRequest(BaseModel):
             "html": obj.get("html"),
             "reply_all": obj.get("reply_all"),
             "reply_to": obj.get("reply_to"),
+            "send_at": obj.get("send_at"),
             "text": obj.get("text"),
             "unsubscribe": UnsubscribeOptions.from_dict(obj["unsubscribe"]) if obj.get("unsubscribe") is not None else None
         })

--- a/sdks/python/src/e2a/v1/generated/models/send_email_request.py
+++ b/sdks/python/src/e2a/v1/generated/models/send_email_request.py
@@ -17,6 +17,7 @@ import pprint
 import re  # noqa: F401
 import json
 
+from datetime import datetime
 from pydantic import BaseModel, ConfigDict, Field, StrictStr
 from typing import Any, ClassVar, Dict, List, Optional
 from typing_extensions import Annotated
@@ -35,6 +36,7 @@ class SendEmailRequest(BaseModel):
     conversation_id: Optional[Annotated[str, Field(strict=True, max_length=200)]] = Field(default=None, description="Caller-assigned conversation (thread) id. At most 200 characters — deliberately the same cap as the webhook conversation_ids filter-value limit and the message-list conversation_id filter limit (both 200), so an accepted conversation_id is never too long to filter by. Must not contain CR or LF.")
     html: Optional[Annotated[str, Field(strict=True, max_length=1048576)]] = Field(default=None, description="Literal HTML body. Mutually exclusive with template_id/template_alias.")
     reply_to: Optional[Annotated[str, Field(strict=True, max_length=320)]] = Field(default=None, description="Sets the Reply-To header — where replies to this message are directed. A single RFC 5322 address, optionally with a display name (e.g. \"Support <support@acme.com>\"). At most 320 characters (display name + address combined). Defaults to the sending agent's own address.")
+    send_at: Optional[datetime] = Field(default=None, description="Optional scheduled-send time (RFC 3339 with a UTC offset). When set to a future instant the message is accepted immediately and returns status=scheduled; it is submitted to the provider at approximately this time. Treat it as \"not before\" — accurate to within the scheduler's poll interval (seconds), not exact-to-the-millisecond, and actual delivery can be later under provider retry/outage. A value at or before now sends immediately (identical to omitting it). Must be no more than 90 days ahead (over → 400 invalid_request). Note: scheduling does NOT survive a review hold — if the message is held for review, send_at is dropped and it sends on approval. Cancel a scheduled send by moving the message to trash.")
     subject: Optional[Annotated[str, Field(strict=True, max_length=2000)]] = Field(default=None, description="Literal subject. Required unless a template reference is used (mutually exclusive with template_id/template_alias).")
     template_alias: Optional[StrictStr] = Field(default=None, description="Send using a stored template resolved by its per-user alias. Mutually exclusive with template_id and with literal subject/text/html. Beta: templates are unstable — their shape may change before they are declared stable.")
     template_data: Optional[Dict[str, Any]] = Field(default=None, description="Variables for the referenced template ({{name}}, dot paths into nested objects). Missing variables render as empty strings. Beta: templates are unstable — their shape may change before they are declared stable.")
@@ -43,7 +45,7 @@ class SendEmailRequest(BaseModel):
     to: List[Annotated[str, Field(strict=True, max_length=320)]] = Field(description="Primary recipients. The message is limited to 50 recipients across to, cc, and bcc combined. Each recipient string (display name + address combined) is limited to 320 characters.")
     unsubscribe: Optional[UnsubscribeOptions] = Field(default=None, description="Beta: opts this message into e2a-managed unsubscribe handling. This field may change before it is declared stable.")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["attachments", "bcc", "cc", "conversation_id", "html", "reply_to", "subject", "template_alias", "template_data", "template_id", "text", "to", "unsubscribe"]
+    __properties: ClassVar[List[str]] = ["attachments", "bcc", "cc", "conversation_id", "html", "reply_to", "send_at", "subject", "template_alias", "template_data", "template_id", "text", "to", "unsubscribe"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -119,6 +121,7 @@ class SendEmailRequest(BaseModel):
             "conversation_id": obj.get("conversation_id"),
             "html": obj.get("html"),
             "reply_to": obj.get("reply_to"),
+            "send_at": obj.get("send_at"),
             "subject": obj.get("subject"),
             "template_alias": obj.get("template_alias"),
             "template_data": obj.get("template_data"),

--- a/sdks/python/src/e2a/v1/generated/models/send_result_view.py
+++ b/sdks/python/src/e2a/v1/generated/models/send_result_view.py
@@ -32,10 +32,11 @@ class SendResultView(BaseModel):
     message_id: StrictStr
     method: Optional[StrictStr] = Field(default=None, description="Send transport. Open set; tolerate unknown values. Known values: smtp, loopback.")
     provider_message_id: Optional[StrictStr] = Field(default=None, description="Upstream provider (SES) id. Optional/absent until the message is actually sent — an accepted-but-not-yet-sent message has no provider id.")
+    scheduled_at: Optional[datetime] = Field(default=None, description="Set only when status=scheduled: the future instant this message is queued to be submitted (approximate — treat as \"not before\"). Cancel a scheduled send by moving the message to trash.")
     sent_as: Optional[StrictStr] = Field(default=None, description="From identity used. Open set; tolerate unknown values. Known values: own_address, relay.")
-    status: StrictStr = Field(description="Outcome. Open set; tolerate unknown values. Known values: accepted, sent, pending_review, review_approved, failed. accepted = durably persisted and queued for submission (async pipeline); the terminal outcome arrives via webhook events (email.sent / email.failed) or GET /v1/messages/{id}. failed = terminal failure. Always branch on this field, not the HTTP status code.")
+    status: StrictStr = Field(description="Outcome. Open set; tolerate unknown values. Known values: accepted, scheduled, sent, pending_review, review_approved, failed. accepted = durably persisted and queued for immediate submission (async pipeline); the terminal outcome arrives via webhook events (email.sent / email.failed) or GET /v1/messages/{id}. scheduled = accepted but deferred to a future send_at (see scheduled_at); it becomes accepted→sent at that time. failed = terminal failure. Always branch on this field, not the HTTP status code.")
     additional_properties: Dict[str, Any] = {}
-    __properties: ClassVar[List[str]] = ["approval_expires_at", "edited", "message_id", "method", "provider_message_id", "sent_as", "status"]
+    __properties: ClassVar[List[str]] = ["approval_expires_at", "edited", "message_id", "method", "provider_message_id", "scheduled_at", "sent_as", "status"]
 
     model_config = ConfigDict(
         populate_by_name=True,
@@ -100,6 +101,7 @@ class SendResultView(BaseModel):
             "message_id": obj.get("message_id"),
             "method": obj.get("method"),
             "provider_message_id": obj.get("provider_message_id"),
+            "scheduled_at": obj.get("scheduled_at"),
             "sent_as": obj.get("sent_as"),
             "status": obj.get("status")
         })

--- a/sdks/typescript/src/v1/generated/models/ForwardRequest.ts
+++ b/sdks/typescript/src/v1/generated/models/ForwardRequest.ts
@@ -36,6 +36,10 @@ export class ForwardRequest {
     * Sets the Reply-To header — where replies to this message are directed. A single RFC 5322 address, optionally with a display name. At most 320 characters (display name + address combined). Defaults to the sending agent\'s own address.
     */
     'replyTo'?: string;
+    /**
+    * Optional scheduled-send time (RFC 3339 with a UTC offset). When set to a future instant the forward is accepted immediately and returns status=scheduled; it is submitted at approximately this time (\"not before\", accurate to the scheduler poll interval). A value at or before now sends immediately. Must be no more than 90 days ahead (over → 400 invalid_request). Scheduling does not survive a review hold. Cancel by moving the message to trash.
+    */
+    'sendAt'?: Date;
     'text': string;
     /**
     * Primary recipients. The message is limited to 50 recipients across to, cc, and bcc combined. Each recipient string (display name + address combined) is limited to 320 characters.
@@ -86,6 +90,12 @@ export class ForwardRequest {
             "baseName": "reply_to",
             "type": "string",
             "format": ""
+        },
+        {
+            "name": "sendAt",
+            "baseName": "send_at",
+            "type": "Date",
+            "format": "date-time"
         },
         {
             "name": "text",

--- a/sdks/typescript/src/v1/generated/models/Message.ts
+++ b/sdks/typescript/src/v1/generated/models/Message.ts
@@ -62,6 +62,7 @@ export class Message {
     'reviewedByUserId'?: string;
     'scanAction'?: string;
     'scanScore'?: number;
+    'scheduledAt'?: Date;
     'sentAs'?: string;
     /**
     * RAW MIME byte length of the whole stored message (octet length of raw_message). Distinct from an attachment\'s size_bytes (DECODED payload size). Dominant term of storage-quota accounting (usage.storage_bytes).
@@ -294,6 +295,12 @@ export class Message {
             "baseName": "scan_score",
             "type": "number",
             "format": "double"
+        },
+        {
+            "name": "scheduledAt",
+            "baseName": "scheduled_at",
+            "type": "Date",
+            "format": "date-time"
         },
         {
             "name": "sentAs",

--- a/sdks/typescript/src/v1/generated/models/MessageView.ts
+++ b/sdks/typescript/src/v1/generated/models/MessageView.ts
@@ -74,6 +74,10 @@ export class MessageView {
     */
     'reviewStatus'?: string;
     /**
+    * Future instant a scheduled outbound send was queued to be submitted (outbound only; treat as \"not before\"). Set when the message was created with a future send_at and retained afterwards; omitted for immediate sends. Cancel a scheduled send by moving the message to trash.
+    */
+    'scheduledAt'?: Date;
+    /**
     * From identity used at relay accept time (outbound only). Open set; tolerate unknown values. Known values: own_address, relay.
     */
     'sentAs'?: string;
@@ -238,6 +242,12 @@ export class MessageView {
             "baseName": "review_status",
             "type": "string",
             "format": ""
+        },
+        {
+            "name": "scheduledAt",
+            "baseName": "scheduled_at",
+            "type": "Date",
+            "format": "date-time"
         },
         {
             "name": "sentAs",

--- a/sdks/typescript/src/v1/generated/models/ReplyRequest.ts
+++ b/sdks/typescript/src/v1/generated/models/ReplyRequest.ts
@@ -37,6 +37,10 @@ export class ReplyRequest {
     * Sets the Reply-To header — where replies to this message are directed. A single RFC 5322 address, optionally with a display name. At most 320 characters (display name + address combined). Defaults to the sending agent\'s own address.
     */
     'replyTo'?: string;
+    /**
+    * Optional scheduled-send time (RFC 3339 with a UTC offset). When set to a future instant the reply is accepted immediately and returns status=scheduled; it is submitted at approximately this time (\"not before\", accurate to the scheduler poll interval). A value at or before now sends immediately. Must be no more than 90 days ahead (over → 400 invalid_request). Scheduling does not survive a review hold. Cancel by moving the message to trash.
+    */
+    'sendAt'?: Date;
     'text': string;
     /**
     * Beta: opts this message into e2a-managed unsubscribe handling. This field may change before it is declared stable.
@@ -89,6 +93,12 @@ export class ReplyRequest {
             "baseName": "reply_to",
             "type": "string",
             "format": ""
+        },
+        {
+            "name": "sendAt",
+            "baseName": "send_at",
+            "type": "Date",
+            "format": "date-time"
         },
         {
             "name": "text",

--- a/sdks/typescript/src/v1/generated/models/SendEmailRequest.ts
+++ b/sdks/typescript/src/v1/generated/models/SendEmailRequest.ts
@@ -40,6 +40,10 @@ export class SendEmailRequest {
     */
     'replyTo'?: string;
     /**
+    * Optional scheduled-send time (RFC 3339 with a UTC offset). When set to a future instant the message is accepted immediately and returns status=scheduled; it is submitted to the provider at approximately this time. Treat it as \"not before\" — accurate to within the scheduler\'s poll interval (seconds), not exact-to-the-millisecond, and actual delivery can be later under provider retry/outage. A value at or before now sends immediately (identical to omitting it). Must be no more than 90 days ahead (over → 400 invalid_request). Note: scheduling does NOT survive a review hold — if the message is held for review, send_at is dropped and it sends on approval. Cancel a scheduled send by moving the message to trash.
+    */
+    'sendAt'?: Date;
+    /**
     * Literal subject. Required unless a template reference is used (mutually exclusive with template_id/template_alias).
     */
     'subject'?: string;
@@ -108,6 +112,12 @@ export class SendEmailRequest {
             "baseName": "reply_to",
             "type": "string",
             "format": ""
+        },
+        {
+            "name": "sendAt",
+            "baseName": "send_at",
+            "type": "Date",
+            "format": "date-time"
         },
         {
             "name": "subject",

--- a/sdks/typescript/src/v1/generated/models/SendResultView.ts
+++ b/sdks/typescript/src/v1/generated/models/SendResultView.ts
@@ -25,11 +25,15 @@ export class SendResultView {
     */
     'providerMessageId'?: string;
     /**
+    * Set only when status=scheduled: the future instant this message is queued to be submitted (approximate — treat as \"not before\"). Cancel a scheduled send by moving the message to trash.
+    */
+    'scheduledAt'?: Date;
+    /**
     * From identity used. Open set; tolerate unknown values. Known values: own_address, relay.
     */
     'sentAs'?: string;
     /**
-    * Outcome. Open set; tolerate unknown values. Known values: accepted, sent, pending_review, review_approved, failed. accepted = durably persisted and queued for submission (async pipeline); the terminal outcome arrives via webhook events (email.sent / email.failed) or GET /v1/messages/{id}. failed = terminal failure. Always branch on this field, not the HTTP status code.
+    * Outcome. Open set; tolerate unknown values. Known values: accepted, scheduled, sent, pending_review, review_approved, failed. accepted = durably persisted and queued for immediate submission (async pipeline); the terminal outcome arrives via webhook events (email.sent / email.failed) or GET /v1/messages/{id}. scheduled = accepted but deferred to a future send_at (see scheduled_at); it becomes accepted→sent at that time. failed = terminal failure. Always branch on this field, not the HTTP status code.
     */
     'status': string;
 
@@ -67,6 +71,12 @@ export class SendResultView {
             "baseName": "provider_message_id",
             "type": "string",
             "format": ""
+        },
+        {
+            "name": "scheduledAt",
+            "baseName": "scheduled_at",
+            "type": "Date",
+            "format": "date-time"
         },
         {
             "name": "sentAs",


### PR DESCRIPTION
## Scheduled send (`send_at`)

This adds scheduled sending to e2a. `send`, `reply`, and `forward` now accept an optional RFC 3339 `send_at` timestamp. When `send_at` is in the future, the message is accepted immediately and returned with `status=scheduled` (plus the resolved `scheduled_at`), then submitted to the provider at approximately that instant — "not before", accurate to the scheduler's poll interval rather than exact to the millisecond. A `send_at` at or before now behaves exactly like an ordinary immediate send, and a `send_at` more than 90 days out is rejected with `400 invalid_request`.

### What it builds on

The work is built on the latest `main` and integrates cleanly, with no conflicts.

### How it works, and what did (and didn't) change

Outbound send is already queue-first on River, so scheduling reduces to *when the existing send job runs*. The accept transaction enqueues the same `outbound_send` job using River's `InsertOpts.ScheduledAt` and records the requested instant on the message; a future-scheduled job simply waits in River's `scheduled` state until it fires.

Deliberately, most of the pipeline did **not** need to change. The message stays `delivery_status='accepted'` (no new delivery status is introduced), the terminal reconciler already ignores jobs sitting in `scheduled` state, and claim/rollup, usage metering (still counted at fire time), and the approve/reconcile callback signatures are all untouched. The only new logic is small edge validation: cap `send_at` at 90 days and treat a past instant as immediate (clock-skew tolerant).

Two product decisions for this first cut: a scheduled send is cancelled by trashing the message (the existing claim-time trash-cancel already stops it from going out), and scheduling does not survive a review hold (if held, the message sends when it is approved).

### How it fits with the rest of the surface

The feature is wired through every client, not just the HTTP API:

- **TS & Python SDKs** — the generated bases carry the new request field (`sendAt` / `send_at`) and the `scheduled` result, so scheduling works with no hand-written SDK glue.
- **CLI** — `send` and `reply` gain a `--send-at` flag, and a `status=scheduled` result is treated as a successful (exit 0) outcome with a note.
- **MCP** — `send_message`, `reply_to_message`, and `forward_message` accept a validated `send_at` and pass it through to the SDK, so an agent operating over MCP can schedule mail.

### Testing

- **Go** — the full build is clean, and the handler/edge unit tests pass: future → `scheduled` (and `wait=sent` correctly skips its poll loop), past → immediate, beyond-horizon → `400`, plus the `scheduledInstant` normalization unit. The DB-backed accept test (persists the instant, enqueues a scheduled job, stays `accepted`) compiles under the integration build tag.
- **SDKs / MCP** — `@e2a/sdk` and the MCP server type-check and build cleanly. The OpenAPI spec regenerates byte-identical to what the live handlers emit, and both SDK bases regenerate cleanly from that spec.
- **End-to-end** — running this branch in Docker against a Mailpit catch-all: a message scheduled two minutes out returned `202 status=scheduled` with `scheduled_at` echoed, was absent from the mailbox before its time, and was delivered just after it (never early); a past `send_at` was delivered immediately; a `send_at` beyond 90 days was rejected with `400`.

The branch is based on the latest `main`, integrates with no conflicts, and everything above is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
