### PR TITLE
docs(mcp): fix stale tool-count (59 → 60) in example READMEs and skill doc

### DIFF
--- a/mcp/examples/README.md
+++ b/mcp/examples/README.md
@@ -12,7 +12,7 @@ End-to-end demos showing how to wire the e2a MCP surface into popular agent fram
 
 ## One hosted endpoint, same tool surface
 
-Each example exercises the same e2a tool surface (59 tools; the visible set depends on your key's scope) against the hosted MCP server. The Python framework examples ship an `agent.py` script; the Codex example ships a TOML block (Codex is itself the agent, so you configure it instead of writing a script).
+Each example exercises the same e2a tool surface (60 tools; the visible set depends on your key's scope) against the hosted MCP server. The Python framework examples ship an `agent.py` script; the Codex example ships a TOML block (Codex is itself the agent, so you configure it instead of writing a script).
 
 Every example connects to `https://api.e2a.dev/mcp` over Streamable HTTP with an
 agent-scoped API key in the `Authorization` header. Set `E2A_MCP_URL` to point

--- a/mcp/examples/codex/README.md
+++ b/mcp/examples/codex/README.md
@@ -2,7 +2,7 @@
 
 [Codex CLI](https://github.com/openai/codex) is OpenAI's terminal coding agent (peer to Claude Code). It speaks MCP natively — you declare servers in `~/.codex/config.toml` and Codex connects to them at session start, then surfaces their tools to whatever model you're running.
 
-Unlike the [LangChain](../langchain/), [CrewAI](../crewai/), [Google ADK](../adk/), and [OpenAI Agents SDK](../openai-agents/) examples — which are Python scripts you run — Codex is itself the agent. The "example" here is the TOML you paste into your Codex config to add e2a's MCP tools (59 total; the visible set depends on your key's scope).
+Unlike the [LangChain](../langchain/), [CrewAI](../crewai/), [Google ADK](../adk/), and [OpenAI Agents SDK](../openai-agents/) examples — which are Python scripts you run — Codex is itself the agent. The "example" here is the TOML you paste into your Codex config to add e2a's MCP tools (60 total; the visible set depends on your key's scope).
 
 Codex opens a Streamable HTTP session to the hosted endpoint at `https://api.e2a.dev/mcp` with your API key in the `Authorization: Bearer …` header — no Node toolchain on the host (works on CI runners, dev containers, remote app servers, etc.).
 

--- a/plugins/e2a/skills/e2a/SKILL.md
+++ b/plugins/e2a/skills/e2a/SKILL.md
@@ -200,5 +200,5 @@ The full, current integration code — SDK install, send / reply / parse, webhoo
 - Webhook + SDK code: https://e2a.dev/sdk.md
 - Exact tool signatures: call `tools/list` (authoritative).
 - OpenAPI contract: https://e2a.dev/v1/openapi.yaml
-- The MCP surface is **59 tools** (15 runtime/inbox + 44 admin/setup) spanning agents, messages, attachments, domains, events, webhooks, API keys, and templates (beta). The set you see depends on your credential's scope: an agent-scoped credential sees the 15 runtime tools; an account-scoped credential sees all 59. Tool descriptions teach behavior; this skill teaches the mental model. (`create_api_key` mints **agent-scoped** keys only — account-scoped keys come from the dashboard or raw API.)
+- The MCP surface is **60 tools** (16 runtime/inbox + 44 admin/setup) spanning agents, messages, attachments, domains, events, webhooks, API keys, and templates (beta). The set you see depends on your credential's scope: an agent-scoped credential sees the 16 runtime tools; an account-scoped credential sees all 60. Tool descriptions teach behavior; this skill teaches the mental model. (`create_api_key` mints **agent-scoped** keys only — account-scoped keys come from the dashboard or raw API.)
 - Plugin homepage / docs index: https://e2a.dev (machine-readable index: https://e2a.dev/llms.txt)


### PR DESCRIPTION
## Summary

`mcp/README.md` and `mcp/tool-names.v1.json` were already corrected to reflect **60** MCP tools (16 runtime + 44 admin) in a prior pass (after a legacy tool alias was preserved), but three other docs still carried the pre-fix **59**/**15** figures:

- `mcp/examples/README.md` — "59 tools" → "60 tools"
- `mcp/examples/codex/README.md` — "59 total" → "60 total"
- `plugins/e2a/skills/e2a/SKILL.md` — "59 tools (15 runtime/inbox + 44 admin/setup)" → "60 tools (16 runtime/inbox + 44 admin/setup)"

Verified the 16 + 44 = 60 split directly against `mcp/src/tools/tiers.ts` (`RUNTIME_TOOLS`/`ADMIN_TOOLS` sets, which are the CI-enforced source of truth per `mcp/tests/tools.test.ts`) and `mcp/tool-names.v1.json` (60 entries), and confirmed no other `.md` file in the repo still references the stale counts.

This is part of a broader documentation audit of the repo's Markdown files; this was the only high-confidence stale/inaccurate finding — everything else checked out consistent with the current code.

## Operational risk

None — text-only change to example/skill documentation, no code or config touched.

## Test plan

- [x] `grep -rn "59 tool\|59 total\|15 runtime" --include="*.md" .` returns no matches after the change
- [x] Manually counted `RUNTIME_TOOLS` (16) and `ADMIN_TOOLS` (44) entries in `mcp/src/tools/tiers.ts` and cross-checked against `mcp/tool-names.v1.json` (60 entries)

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8kXVAyqXzGWenrkrW6BHH)_