### PR TITLE
ci(cli): publish on v* tag push, consistent with image builds

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,8 +1,8 @@
 name: Publish CLI
 
 on:
-  release:
-    types: [published]
+  push:
+    tags: ["v*"]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Why

\`publish-cli.yml\` was the lone release-artifact workflow triggering off the GitHub Release \`published\` event instead of the \`v*\` tag push that the other two use:

- \`build-image.yml\` → \`on: push: { branches: [main], tags: ["v*"] }\`
- \`publish-mcp-http.yml\` → \`on: push: { branches: [main], tags: ["v*", "mcp-http-v*"] }\`
- \`publish-cli.yml\` (before) → \`on: release: { types: [published] }\`

This PR makes the CLI publish consistent with the image builds: trigger off the \`v*\` tag push.

## What changed

\`\`\`diff
 on:
-  release:
-    types: [published]
+  push:
+    tags: ["v*"]
   workflow_dispatch:
\`\`\`

## Replace vs. keep \`release:\`

Replaced rather than kept both. The repo's release flow pushes an annotated \`v*\` tag **and** publishes a GitHub Release for the same cut, so keeping both triggers would fire the publish job twice per release — the second run would just fail benignly ("cannot publish over the previously published version"), but it's needless noise. Matching \`build-image.yml\`'s tag-only trigger is cleaner and there's no concrete reason found to need both.

## Job body: no other changes needed

Read the whole workflow — nothing else references release-event context (\`github.event.release.*\`, \`github.event.action\`, etc.). The \`npm publish --workspace @e2a/cli\` step is versioned purely from \`cli/package.json\`'s \`version\` field, independent of the tag, so the trigger swap is fully self-contained.

Note: \`cli/package.json\` is currently at \`2.0.0\`, so this won't actually publish until that's bumped past the last-published version (npm rejects republish) — expected, out of scope here.

Co-Authored-By: Claude Sonnet <noreply@anthropic.com>