### PR TITLE
feat(mcp): harden MCP HTTP path for production reliability

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -163,6 +163,16 @@ services:
       # keeps everything (issuer, AS endpoints, consent UI) on one
       # origin — the way production runs behind a single Caddy.
       MCP_AUTHORIZATION_SERVER_URL: "http://localhost:3000"
+    # Liveness only — /healthz never touches the backend, so an e2a API
+    # outage doesn't restart a healthy MCP container. Probed with node
+    # fetch (no curl in the image). Readiness (/readyz) is intentionally
+    # not wired here: a flapping backend would pull the container out of
+    # rotation in a single-node dev stack.
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:3000/healthz').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
 
 volumes:
   pgdata:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -147,7 +147,7 @@ essentials:
   different, host-visible origin).
 - **Endpoints**: `GET /healthz` (liveness — never touches the backend),
   `GET /readyz` (readiness — probes `{E2A_API_URL}/api/health`, 2s timeout,
-  result cached 10s; 503 + `Retry-After: 5` when the API is unreachable),
+  result cached 10s; 503 + `Retry-After: 10` (the failure-cache TTL) when the API is unreachable),
   `GET /metrics` (Prometheus exposition). All unauthenticated. Wire
   liveness → `/healthz`, readiness → `/readyz` — never liveness →
   `/readyz`, or a backend outage restarts healthy MCP replicas.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -129,6 +129,50 @@ The Next.js dashboard ships as a static export, so its config is inlined at buil
 | `NEXT_PUBLIC_FEEDBACK_EMAIL` | Address shown on the feedback form. Empty hides the "or email us at …" line. |
 | `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION` | Google Search Console token. Only emitted into `<head>` when set, so forks don't inherit upstream's property. |
 
+## MCP HTTP server
+
+The MCP transport (`ghcr.io/tokencanopy/e2a-mcp-http`, built from
+[`mcp/Dockerfile`](../mcp/Dockerfile)) is a separate stateless process that
+forwards client bearers to the API server. It listens on port **3000**
+(container-internal; compose maps host 8765). The full configuration and
+operations reference lives in [`mcp/README.md`](../mcp/README.md) and
+[`docs/runbooks/mcp-server.md`](runbooks/mcp-server.md); the deployment
+essentials:
+
+- **Required env**: `E2A_API_URL` must point at the API server (inside a
+  compose network that's the container hostname, e.g. `http://e2a:8080`).
+  `MCP_ALLOWED_HOSTS` must list every externally used hostname or clients
+  get 421. Behind a proxy, set `MCP_PUBLIC_URL` (and
+  `MCP_AUTHORIZATION_SERVER_URL` when the OAuth AS must be reached via a
+  different, host-visible origin).
+- **Endpoints**: `GET /healthz` (liveness — never touches the backend),
+  `GET /readyz` (readiness — probes `{E2A_API_URL}/api/health`, 2s timeout,
+  result cached 10s; 503 + `Retry-After: 5` when the API is unreachable),
+  `GET /metrics` (Prometheus exposition). All unauthenticated. Wire
+  liveness → `/healthz`, readiness → `/readyz` — never liveness →
+  `/readyz`, or a backend outage restarts healthy MCP replicas.
+- **Healthcheck examples** — the image ships one (`HEALTHCHECK` in
+  `mcp/Dockerfile`, node fetch against `/healthz`). For another
+  orchestrator:
+
+  ```yaml
+  # docker-compose
+  healthcheck:
+    test: ["CMD", "node", "-e", "fetch('http://localhost:3000/healthz').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"]
+    interval: 10s
+    timeout: 3s
+    retries: 5
+  ```
+
+  ```yaml
+  # kubernetes
+  livenessProbe:  { httpGet: { path: /healthz, port: 3000 } }
+  readinessProbe: { httpGet: { path: /readyz,  port: 3000 } }
+  ```
+
+- **Graceful shutdown**: SIGTERM/SIGINT stops the listener and drains with
+  a 30s ceiling; stateless, so there is nothing else to drain.
+
 ## Scaling and limitations
 
 **Most state is already DB-coordinated.** The HITL expiration worker, the webhook retry worker, and the periodic cleanup worker all use Postgres `SELECT … FOR UPDATE SKIP LOCKED` (or rely on `DELETE` idempotency for cleanup), so running multiple replicas concurrently is safe — only one worker claims a given pending message at a time, no duplicate sends. User sessions live in Postgres and the OAuth nonce travels in a cookie + the OAuth state parameter, so dashboard sign-in survives load-balancer rebalancing.

--- a/docs/runbooks/mcp-server.md
+++ b/docs/runbooks/mcp-server.md
@@ -1,0 +1,254 @@
+# MCP server runbook
+
+## Overview
+
+The MCP HTTP server (`mcp/`, image `ghcr.io/tokencanopy/e2a-mcp-http`) is the
+Streamable HTTP transport that lets MCP-aware hosts (Claude Code, Cursor,
+ADK, LangChain, …) drive an e2a inbox over `POST /mcp`. Hosted, it runs
+behind Caddy at `https://api.e2a.dev/mcp`; self-hosters run it via
+`docker-compose.yaml` or `mcp/Dockerfile`.
+
+The transport is **stateless by design**: no sessions, no `MCP-Session-Id`,
+no SSE stream. Every POST builds a fresh server + transport, forwards the
+client's `Authorization: Bearer` to the e2a backend unchanged, and is torn
+down when the response closes. `GET` and `DELETE /mcp` answer 405. The only
+cross-request state is an in-memory bearer→principal cache (a `whoami`
+lookup memo) plus the readiness-probe cache — an idle client is never
+disconnected, and a cache miss costs one extra `whoami`, never a dropped
+connection. "Reconnect" after an interruption is the client simply
+re-POSTing; MCP clients do this automatically.
+
+## Availability and connection-success measurements
+
+All signals come from `GET /metrics` (Prometheus text exposition,
+unauthenticated).
+
+- **Connection success rate** (the headline SLO):
+  `1 - 5xx / total` on the MCP route, from
+  `mcp_http_requests_total{route="mcp",status_class="5xx"}` over
+  `sum(mcp_http_requests_total{route="mcp"})`. 4xx responses (401, 405,
+  421) are client faults and do not count against availability.
+  Hosted target: **99.9% connection availability**.
+- **Auth-resolution health**: rate of
+  `mcp_auth_resolutions_total{result="fallback"}` (backend whoami
+  unreachable/5xx — server failed closed) and `{result="invalid"}`
+  (bad/revoked credentials). A `fallback` rate above zero tracks backend
+  pain; a rising `invalid` rate tracks credential hygiene, not the server.
+  Healthy baseline is dominated by `cache_hit` with occasional `resolved`.
+- **Readiness flaps**: watch
+  `mcp_readyz_checks_total{result="degraded"}`. Because the probe result is
+  cached 10s, increments of this counter are distinct probe *windows* failing,
+  not individual scrapes.
+- **Latency**: `mcp_http_request_duration_seconds` histogram per route.
+  A cold `whoami` on `route="mcp"` can legitimately reach the multi-second
+  buckets; p99 dominated by `cache_hit` should stay sub-second.
+
+## Health endpoints
+
+| Endpoint | Meaning | Backend contact | Response |
+|---|---|---|---|
+| `GET /healthz` | Process liveness only | none, ever | 200 `{ "ok": true }` |
+| `GET /readyz` | Can reach the e2a API (and therefore resolve credentials — credential resolution whoami-probes the same API) | probes `{E2A_API_URL}/api/health`, 2s timeout | 200 `{ "ok": true, "checks": { "api": "ok" } }`, or 503 `{ "ok": false, "checks": { "api": "unreachable" }, "request_id": "…" }` + `Retry-After: 5` |
+| `GET /metrics` | Prometheus scrape | none | text exposition (`text/plain; version=0.0.4`) |
+
+All three are unauthenticated. The exposition carries only counters/gauges
+over closed label vocabularies — no bearer, user, or request data.
+
+Orchestrator wiring: **liveness probe → `/healthz`**, **readiness probe →
+`/readyz`**. Never wire liveness to `/readyz`: a backend outage would
+restart healthy MCP processes and turn a backend incident into an MCP
+outage.
+
+The readyz probe caches its result — success *and* failure — for 10
+seconds. A scraping fleet (every pod in a k8s deployment probing every
+replica) therefore cannot fan out into a probe storm against an
+already-struggling backend: at most one real probe per 10s per MCP process
+reaches `{E2A_API_URL}/api/health`. A corollary for alerting: don't scrape
+readyz faster than the cache TTL expecting fresh data, and don't hammer it
+to "check if the backend is back" — the answer is up to 10s stale by
+design.
+
+## Failure classes
+
+| Class | Primary signal | Status surfaced to client |
+|---|---|---|
+| Backend API unreachable | `readyz` 503, `mcp_readyz_checks_total{result="degraded"}` | tool errors `retryable: true`; 503 on readyz only |
+| Expired / revoked credential | `mcp_auth_resolutions_total{result="invalid"}` | 401 `invalid_token` challenge |
+| Backend outage mid-request | `mcp_auth_resolutions_total{result="fallback"}` | request succeeds at agent scope |
+| DCR rate limiting | backend 429 `rate_limited` on `/oauth2/register` | 429 + `Retry-After` |
+| OAuth token exchange failure | backend `[oauth] /token … error:` logs | RFC 6749 error JSON |
+| DNS-rebinding guard | `mcp_http_requests_total{route="mcp",status_class="4xx"}` | 421 (empty body) |
+| Oversized request body | `terminal_error` log event | 500 JSON-RPC `-32603` |
+| Resolve-cache pressure | `mcp_resolve_cache_entries` pinned at cap | none (latency only) |
+
+### Backend API unreachable
+
+- **Symptoms**: `GET /readyz` returns 503 with `checks.api = "unreachable"`
+  and `Retry-After: 5`; load balancer drains the MCP replica. Tool calls
+  that reach the server fail with `structuredContent.retryable: true`.
+- **Detection**: `mcp_readyz_checks_total{result="degraded"}` rising;
+  `auth_resolution` log events with `result: "fallback"` at WARNING.
+- **Likely cause**: e2a API down or unreachable — wrong `E2A_API_URL`,
+  network partition between the MCP container and the API, or the API
+  itself failing its own `/api/health`.
+- **Remediation**: confirm `E2A_API_URL` points at the API server (inside
+  compose: the internal hostname, e.g. `http://e2a:8080`); curl
+  `$E2A_API_URL/api/health` from inside the MCP container/network; then
+  follow the backend's own health trail. The MCP server recovers on its
+  own — the 10s probe cache means readyz flips back within one window of
+  the backend returning.
+
+### Expired or revoked credentials
+
+- **Symptoms**: 401 from `POST /mcp` with
+  `WWW-Authenticate: Bearer realm="e2a", resource_metadata="…", error="invalid_token"`.
+- **Detection**: `mcp_auth_resolutions_total{result="invalid"}` rising;
+  `auth_resolution` WARNING log `bearer rejected by the backend`.
+- **Likely cause**: API key revoked/deleted, OAuth access token expired
+  with a broken refresh, or a client pointing at the wrong deployment.
+- **Remediation**: the *client* must re-authorize the OAuth flow (or the
+  user must mint a replacement API key). **Do not retry in a loop** — the
+  backend re-checks the credential on every uncached resolution and the
+  answer won't change. A sustained invalid rate from one client usually
+  means a stuck retry loop; rate-limit or fix the client.
+
+### Backend outage mid-request (fail-closed fallback)
+
+- **Symptoms**: requests succeed, but the credential is served at
+  least-privilege **agent scope**: account-scoped callers see the tool list
+  shrink from 60 tools to the 16 runtime tools, and the per-request default
+  agent is unset (explicit `email` required).
+- **Detection**: `auth_resolution` WARNING `whoami probe failed; serving
+  least-privilege fallback`; `mcp_auth_resolutions_total{result="fallback"}`.
+- **What happened**: the bounded whoami probe (`MCP_RESOLVE_TIMEOUT_MS`,
+  default 5000 ms, max 1 retry) timed out or got a backend 5xx. The server
+  fails closed rather than hanging the POST (previously this could stretch
+  to the SDK's 30s × 3-attempt worst case) or refusing the request. The
+  fallback resolution is deliberately **not cached** — the next request
+  re-probes, so the full surface returns automatically once the backend
+  recovers. The backend still authenticates the bearer on every API call,
+  so no privilege is widened.
+- **Remediation**: same as "Backend API unreachable". No MCP-side action
+  needed for recovery; persistent fallback means the whoami path
+  (`GET /account`) is down even if `/api/health` passes.
+
+### DCR rate limiting
+
+- **Symptoms**: 429 with `rate_limited` and a `Retry-After` header from
+  `POST /oauth2/register` on the backend.
+- **Likely cause**: dynamic client registration is capped at **10
+  registrations per IP per hour** (per server process). NAT'd fleets of MCP
+  clients share one IP and burn the budget together.
+- **Remediation**: clients must persist their `client_id` and re-use it
+  instead of re-registering on every connect; honor `Retry-After` before
+  retrying. On the hosted deployment, operators seeing legitimate shared-IP
+  pressure should file it as a product issue rather than widening the cap
+  ad hoc.
+
+### OAuth token exchange failures
+
+- **Symptoms**: client gets an RFC 6749 error JSON (e.g. `invalid_grant`)
+  from `POST /oauth2/token`.
+- **Detection**: backend log lines
+  `[oauth] /token <stage> error: request_id=<id> client="<id>" grant="<type>" code=<code> hint="<hint>" debug="<debug>"`.
+  `code` alone (`invalid_grant`) cannot distinguish causes; `hint` (and
+  `debug`, when present) separates **expired/used authorization code** from
+  **PKCE verifier mismatch** from **token replay**. These are static
+  category strings — no secrets are logged.
+- **Remediation**: join the client-visible `request_id` (present in the
+  DCR/register error body and always equal to the `X-Request-Id` response
+  header) to the log line's `request_id=`. Expired-code → restart the
+  browser flow; PKCE mismatch → fix the client's verifier persistence;
+  replay → investigate credential handling on that client.
+
+### 421 Misdirected Request
+
+- **Symptoms**: `POST /mcp` (and the discovery document) answered 421 with
+  an empty body, before any auth or body parsing.
+- **Detection**: `mcp_http_requests_total{route="mcp",status_class="4xx"}`
+  with a `Host` header outside the allowlist; correlating `http_request`
+  log line shows `status: 421`.
+- **Likely cause**: DNS-rebinding guard — the request's `Host` is not in
+  `MCP_ALLOWED_HOSTS` (default `api.e2a.dev`). Common self-host mistakes:
+  accessing via a hostname/IP not listed, or a fronting proxy rewriting
+  `Host`.
+- **Remediation**: add the externally used hostname(s) to
+  `MCP_ALLOWED_HOSTS` (comma-separated; ports are stripped before
+  comparison). Never work around it by disabling the guard. Clients must
+  not retry 421 — fix the URL.
+
+### Oversized request body
+
+- **Symptoms**: a `POST /mcp` with a JSON body over **40 MB** is rejected
+  at the parser. The limit clears the attachment contract (10 MB per file,
+  25 MB combined, base64-encoded ≈ 34 MB plus envelope) with headroom.
+- **Detection**: `terminal_error` log event with `error: "PayloadTooLargeError"`
+  and the request's `request_id`.
+- **Client-visible status**: the terminal error handler answers 500 with a
+  JSON-RPC `-32603` body (it does not currently special-case the parser's
+  413). The client should treat this as non-retryable and shrink the
+  payload (fewer/smaller attachments per call).
+- **Remediation**: if legitimate traffic exceeds 40 MB, the fronting proxy
+  limit and the attachment contract must move together — do not raise just
+  the parser limit.
+
+### Resolve-cache pressure
+
+- **Symptoms**: `mcp_resolve_cache_entries` gauge pinned at the cap;
+  `cache_hit` share drops and `resolved` (a real whoami round-trip per
+  request) rises, adding backend load and p99 latency.
+- **Likely cause**: more distinct live bearers than the cap (default 500),
+  or a TTL (default 300000 ms) too short for the client population.
+- **Remediation**: raise `MCP_MAX_SESSIONS` and/or `MCP_SESSION_IDLE_MS`
+  (legacy env names — they size the bearer→principal resolve cache, not
+  sessions; the transport is stateless). Eviction is oldest-first and a
+  miss costs one `whoami`, so this is a latency/load tuning issue, never a
+  correctness one.
+
+## Client retry guidance (the bounded-retry contract)
+
+The e2a SDK retries on the client's behalf (2 retries = 3 attempts,
+30s per attempt, jittered exponential backoff, honors `Retry-After`). When
+writing your own MCP caller:
+
+- Branch on `structuredContent`, not the error text. Honor
+  `retryable` and `retry_after_seconds`.
+- Retry only `retryable: true` errors, with exponential backoff + jitter,
+  capped at ~3 attempts.
+- **Never retry 4xx** — especially 401 and 421; they are deterministic.
+  After a 401 `invalid_token`, re-authenticate (OAuth re-authorize or new
+  API key), then retry the operation.
+- `pending_review` on send tools is a **success** status, not an error —
+  do not retry it.
+- Don't poll `/readyz` faster than ~10s per replica; the result is cached
+  and hammering it gains nothing.
+
+## Correlation: tracing one failing request
+
+Every MCP response carries an `X-Request-Id` header. An inbound
+`X-Request-Id` matching `^[A-Za-z0-9_-]{1,64}$` is honored verbatim;
+anything else is replaced with a server-minted `mcpreq_<12hex>`. The id is
+echoed on **all** responses including 401/405/421/500, and JSON-RPC error
+bodies for 401/405/500 carry it additively as `error.data.request_id`
+(error codes and messages are unchanged).
+
+MCP log lines are single-line JSON on stderr (GCE-shaped: `severity`,
+`event`, `message`, plus structured fields):
+
+- `auth_resolution` — `{request_id, result, duration_ms, scope?}`;
+  `invalid` and `fallback` are logged at WARNING.
+- `http_request` — `{request_id, route, method, status, duration_ms}`;
+  one per request, emitted when the response finishes.
+- `tool_execution` — `{request_id, tool, outcome, duration_ms, error_code?}`.
+- `terminal_error` — `{request_id, error}` for unhandled throws.
+
+Bearer tokens are never logged; the resolve cache is keyed by SHA-256
+fingerprints of the bearer.
+
+To trace across MCP → backend: the MCP request id is **not** forwarded to
+the backend API (the SDK has no per-request header seam). Join by timestamp
+and by the backend's own `req_*` id from its `X-Request-Id` header. For
+OAuth failures specifically, the backend's DCR error bodies include a
+`request_id` field equal to their `X-Request-Id` header, and all `[oauth]`
+log lines on register/token/consent carry `request_id=`, so that side of
+the trail is directly joinable.

--- a/docs/runbooks/mcp-server.md
+++ b/docs/runbooks/mcp-server.md
@@ -48,7 +48,7 @@ unauthenticated).
 | Endpoint | Meaning | Backend contact | Response |
 |---|---|---|---|
 | `GET /healthz` | Process liveness only | none, ever | 200 `{ "ok": true }` |
-| `GET /readyz` | Can reach the e2a API (and therefore resolve credentials — credential resolution whoami-probes the same API) | probes `{E2A_API_URL}/api/health`, 2s timeout | 200 `{ "ok": true, "checks": { "api": "ok" } }`, or 503 `{ "ok": false, "checks": { "api": "unreachable" }, "request_id": "…" }` + `Retry-After: 5` |
+| `GET /readyz` | Can reach the e2a API (and therefore resolve credentials — credential resolution whoami-probes the same API) | probes `{E2A_API_URL}/api/health`, 2s timeout | 200 `{ "ok": true, "checks": { "api": "ok" } }`, or 503 `{ "ok": false, "checks": { "api": "unreachable" }, "request_id": "…" }` + `Retry-After: 10` (the cache TTL) |
 | `GET /metrics` | Prometheus scrape | none | text exposition (`text/plain; version=0.0.4`) |
 
 All three are unauthenticated. The exposition carries only counters/gauges
@@ -84,7 +84,7 @@ design.
 ### Backend API unreachable
 
 - **Symptoms**: `GET /readyz` returns 503 with `checks.api = "unreachable"`
-  and `Retry-After: 5`; load balancer drains the MCP replica. Tool calls
+  and `Retry-After: 10`; load balancer drains the MCP replica. Tool calls
   that reach the server fail with `structuredContent.retryable: true`.
 - **Detection**: `mcp_readyz_checks_total{result="degraded"}` rising;
   `auth_resolution` log events with `result: "fallback"` at WARNING.
@@ -238,7 +238,10 @@ MCP log lines are single-line JSON on stderr (GCE-shaped: `severity`,
 - `auth_resolution` — `{request_id, result, duration_ms, scope?}`;
   `invalid` and `fallback` are logged at WARNING.
 - `http_request` — `{request_id, route, method, status, duration_ms}`;
-  one per request, emitted when the response finishes.
+  one per request, emitted when the response finishes. Successful (<400)
+  probe/scrape traffic (`healthz`, `readyz`, `metrics` routes) is metered
+  but not logged — it would be ~14k noise lines/day/replica; failures on
+  those routes still log.
 - `tool_execution` — `{request_id, tool, outcome, duration_ms, error_code?}`.
 - `terminal_error` — `{request_id, error}` for unhandled throws.
 

--- a/internal/agent/agent_identity.go
+++ b/internal/agent/agent_identity.go
@@ -57,7 +57,7 @@ type identityAssertionResponse struct {
 // silently self-provisioned.)
 func (a *API) handleAgentIdentity(w http.ResponseWriter, r *http.Request) {
 	if !a.agentAuthReady() {
-		writeOAuthError(w, http.StatusNotImplemented, "not_implemented",
+		writeOAuthError(w, r, http.StatusNotImplemented, "not_implemented",
 			"agent identity is not enabled on this deployment")
 		return
 	}
@@ -70,7 +70,7 @@ func (a *API) handleAgentIdentity(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if p.Scope != identity.ScopeAgent || p.AgentID == "" {
-		writeOAuthError(w, http.StatusForbidden, "forbidden",
+		writeOAuthError(w, r, http.StatusForbidden, "forbidden",
 			"agent identity requires an agent-scoped credential bound to one agent")
 		return
 	}
@@ -79,13 +79,13 @@ func (a *API) handleAgentIdentity(w http.ResponseWriter, r *http.Request) {
 	// counter stamped into the token).
 	ag, err := a.store.GetAgentByID(r.Context(), p.AgentID)
 	if err != nil || ag == nil || ag.UserID != p.User.ID {
-		writeOAuthError(w, http.StatusForbidden, "forbidden", "agent not found")
+		writeOAuthError(w, r, http.StatusForbidden, "forbidden", "agent not found")
 		return
 	}
 
 	assertion, exp, err := a.signer.SignIdentityAssertion(ag.ID, identity.ScopeAgent, ag.AssertionVersion, a.agentAuthIssuer())
 	if err != nil {
-		writeOAuthError(w, http.StatusInternalServerError, "server_error", "failed to mint identity assertion")
+		writeOAuthError(w, r, http.StatusInternalServerError, "server_error", "failed to mint identity assertion")
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -111,35 +111,35 @@ type accessTokenResponse struct {
 // Returns RFC 6749 §5.2 error bodies.
 func (a *API) handleJWTBearerGrant(w http.ResponseWriter, r *http.Request) {
 	if !a.agentAuthReady() {
-		writeOAuthError(w, http.StatusNotImplemented, "unsupported_grant_type",
+		writeOAuthError(w, r, http.StatusNotImplemented, "unsupported_grant_type",
 			"agent identity is not enabled on this deployment")
 		return
 	}
 	assertion := strings.TrimSpace(r.PostForm.Get("assertion"))
 	if assertion == "" {
-		writeOAuthError(w, http.StatusBadRequest, "invalid_request", "assertion is required")
+		writeOAuthError(w, r, http.StatusBadRequest, "invalid_request", "assertion is required")
 		return
 	}
 	claims, err := a.signer.VerifyToken(assertion, agentauth.TypIdentityAssertion, a.agentAuthIssuer())
 	if err != nil {
-		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "identity assertion is invalid or expired")
+		writeOAuthError(w, r, http.StatusBadRequest, "invalid_grant", "identity assertion is invalid or expired")
 		return
 	}
 	// Freshness / kill switch: the assertion's assertion_version must match the
 	// live agent row. A bump (revocation) makes every prior assertion stale.
 	ag, err := a.store.GetAgentByID(r.Context(), claims.Subject)
 	if err != nil || ag == nil {
-		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "agent not found")
+		writeOAuthError(w, r, http.StatusBadRequest, "invalid_grant", "agent not found")
 		return
 	}
 	if ag.AssertionVersion != claims.AssertionVersion {
-		writeOAuthError(w, http.StatusBadRequest, "invalid_grant", "assertion is stale; re-acquire an identity assertion")
+		writeOAuthError(w, r, http.StatusBadRequest, "invalid_grant", "assertion is stale; re-acquire an identity assertion")
 		return
 	}
 
 	token, exp, err := a.signer.SignAccessToken(ag.ID, identity.ScopeAgent, ag.AssertionVersion, a.agentAuthIssuer())
 	if err != nil {
-		writeOAuthError(w, http.StatusInternalServerError, "server_error", "failed to mint access token")
+		writeOAuthError(w, r, http.StatusInternalServerError, "server_error", "failed to mint access token")
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/agent/oauth_handlers.go
+++ b/internal/agent/oauth_handlers.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -118,19 +119,29 @@ type OAuthError struct {
 	RequestID        string `json:"request_id,omitempty"`
 }
 
+// validRequestID bounds the ids this package will reflect into [oauth] log
+// lines and error bodies. Client-supplied X-Request-Id values outside this
+// alphabet/length (field-spoofing text, multi-KB padding) are replaced with
+// a minted id rather than logged verbatim. Same rule as the MCP transport's
+// INBOUND_REQUEST_ID in mcp/src/correlation.ts.
+var validRequestID = regexp.MustCompile(`^[A-Za-z0-9_-]{1,64}$`)
+
 // oauthRequestID returns the request id used to correlate error bodies and
 // [oauth] log lines with the X-Request-Id response header. The httpapi root
 // middleware sets X-Request-Id on the response writer before dispatching
 // (it wraps the legacy mux too), so downstream handlers can read back the
 // exact id the client will see. When no middleware ran (bare-mux test
 // servers), honor a client-supplied header, else mint one and set it on the
-// response — header, body, and logs stay consistent either way. Returns ""
-// only if crypto/rand fails; callers degrade gracefully (omit the id).
+// response — header, body, and logs stay consistent either way. Any id that
+// fails validRequestID (the middleware echoes client input unchecked) is
+// replaced with a minted one, overwriting the response header so header,
+// body, and logs still agree. Returns "" only if crypto/rand fails; callers
+// degrade gracefully (omit the id).
 func oauthRequestID(w http.ResponseWriter, r *http.Request) string {
-	if id := w.Header().Get("X-Request-Id"); id != "" {
+	if id := w.Header().Get("X-Request-Id"); validRequestID.MatchString(id) {
 		return id
 	}
-	if id := r.Header.Get("X-Request-Id"); id != "" {
+	if id := r.Header.Get("X-Request-Id"); validRequestID.MatchString(id) {
 		w.Header().Set("X-Request-Id", id)
 		return id
 	}

--- a/internal/agent/oauth_handlers.go
+++ b/internal/agent/oauth_handlers.go
@@ -48,6 +48,9 @@ func (a *API) handleOAuthToken(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	ctx := r.Context()
+	// Resolve the request id up front so error log lines (and the
+	// X-Request-Id header when no middleware ran) can carry it.
+	reqID := oauthRequestID(w, r)
 
 	// Hand fosite a fresh session pointer. NewAccessRequest will
 	// populate it from the stored auth-code / refresh-token row;
@@ -57,7 +60,7 @@ func (a *API) handleOAuthToken(w http.ResponseWriter, r *http.Request) {
 
 	accessReq, err := a.oauthProvider.NewAccessRequest(ctx, r, session)
 	if err != nil {
-		logTokenError(accessReq, "new_access_request", err)
+		logTokenError(accessReq, "new_access_request", reqID, err)
 		// fosite writes the canonical RFC 6749 §5.2 JSON error body
 		// here: {"error":"invalid_grant",...} with correct status
 		// code and Cache-Control: no-store.
@@ -67,7 +70,7 @@ func (a *API) handleOAuthToken(w http.ResponseWriter, r *http.Request) {
 
 	accessResp, err := a.oauthProvider.NewAccessResponse(ctx, accessReq)
 	if err != nil {
-		logTokenError(accessReq, "new_access_response", err)
+		logTokenError(accessReq, "new_access_response", reqID, err)
 		a.oauthProvider.WriteAccessError(ctx, w, accessReq, err)
 		return
 	}
@@ -106,16 +109,53 @@ type OAuthRegisterResponse struct {
 
 // OAuthError is the RFC 7591 §3.2.2 / RFC 6749 §5.2 JSON error body.
 // Used for DCR-side errors and direct (non-redirected) authorize errors.
+// request_id is an extension member (both RFCs permit additional fields
+// in the error response) so a client can quote the id from the body when
+// reporting a failure; it always matches the X-Request-Id response header.
 type OAuthError struct {
 	Error            string `json:"error"`
 	ErrorDescription string `json:"error_description,omitempty"`
+	RequestID        string `json:"request_id,omitempty"`
 }
 
-func writeOAuthError(w http.ResponseWriter, status int, code, desc string) {
+// oauthRequestID returns the request id used to correlate error bodies and
+// [oauth] log lines with the X-Request-Id response header. The httpapi root
+// middleware sets X-Request-Id on the response writer before dispatching
+// (it wraps the legacy mux too), so downstream handlers can read back the
+// exact id the client will see. When no middleware ran (bare-mux test
+// servers), honor a client-supplied header, else mint one and set it on the
+// response — header, body, and logs stay consistent either way. Returns ""
+// only if crypto/rand fails; callers degrade gracefully (omit the id).
+func oauthRequestID(w http.ResponseWriter, r *http.Request) string {
+	if id := w.Header().Get("X-Request-Id"); id != "" {
+		return id
+	}
+	if id := r.Header.Get("X-Request-Id"); id != "" {
+		w.Header().Set("X-Request-Id", id)
+		return id
+	}
+	b := make([]byte, 12)
+	if _, err := rand.Read(b); err != nil {
+		return ""
+	}
+	id := "req_" + hex.EncodeToString(b)
+	w.Header().Set("X-Request-Id", id)
+	return id
+}
+
+func writeOAuthError(w http.ResponseWriter, r *http.Request, status int, code, desc string) {
+	// Resolve the id before WriteHeader: oauthRequestID may have to set
+	// X-Request-Id on the response (no-middleware case), which only works
+	// while headers are still mutable.
+	reqID := oauthRequestID(w, r)
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "no-store")
 	w.WriteHeader(status)
-	_ = json.NewEncoder(w).Encode(OAuthError{Error: code, ErrorDescription: desc})
+	_ = json.NewEncoder(w).Encode(OAuthError{
+		Error:            code,
+		ErrorDescription: desc,
+		RequestID:        reqID,
+	})
 }
 
 // dcrSourceIP returns the per-IP key for DCR rate-limiting. DCR is
@@ -322,24 +362,24 @@ func (a *API) handleOAuthRegister(w http.ResponseWriter, r *http.Request) {
 			secs = 1
 		}
 		w.Header().Set("Retry-After", strconv.Itoa(secs))
-		writeOAuthError(w, http.StatusTooManyRequests, "rate_limited",
+		writeOAuthError(w, r, http.StatusTooManyRequests, "rate_limited",
 			"too many registrations from this IP; try again later")
 		return
 	}
 
 	var req OAuthRegisterRequest
 	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, 64*1024)).Decode(&req); err != nil {
-		writeOAuthError(w, http.StatusBadRequest, "invalid_client_metadata", "request body must be JSON")
+		writeOAuthError(w, r, http.StatusBadRequest, "invalid_client_metadata", "request body must be JSON")
 		return
 	}
 
 	// client_name: required, length-bound.
 	if strings.TrimSpace(req.ClientName) == "" {
-		writeOAuthError(w, http.StatusBadRequest, "invalid_client_metadata", "client_name is required")
+		writeOAuthError(w, r, http.StatusBadRequest, "invalid_client_metadata", "client_name is required")
 		return
 	}
 	if len(req.ClientName) > 200 {
-		writeOAuthError(w, http.StatusBadRequest, "invalid_client_metadata",
+		writeOAuthError(w, r, http.StatusBadRequest, "invalid_client_metadata",
 			"client_name must be 200 characters or fewer")
 		return
 	}
@@ -348,12 +388,12 @@ func (a *API) handleOAuthRegister(w http.ResponseWriter, r *http.Request) {
 	// custom URI, deduped to prevent a hostile DCR caller from
 	// padding the soft cap with identical URLs.
 	if len(req.RedirectURIs) == 0 {
-		writeOAuthError(w, http.StatusBadRequest, "invalid_redirect_uri",
+		writeOAuthError(w, r, http.StatusBadRequest, "invalid_redirect_uri",
 			"at least one redirect_uri is required")
 		return
 	}
 	if len(req.RedirectURIs) > 10 {
-		writeOAuthError(w, http.StatusBadRequest, "invalid_redirect_uri",
+		writeOAuthError(w, r, http.StatusBadRequest, "invalid_redirect_uri",
 			"too many redirect_uris (max 10)")
 		return
 	}
@@ -361,7 +401,7 @@ func (a *API) handleOAuthRegister(w http.ResponseWriter, r *http.Request) {
 	deduped := req.RedirectURIs[:0]
 	for _, raw := range req.RedirectURIs {
 		if err := validateRedirectURI(raw); err != nil {
-			writeOAuthError(w, http.StatusBadRequest, "invalid_redirect_uri", err.Error())
+			writeOAuthError(w, r, http.StatusBadRequest, "invalid_redirect_uri", err.Error())
 			return
 		}
 		if _, ok := seen[raw]; ok {
@@ -388,20 +428,20 @@ func (a *API) handleOAuthRegister(w http.ResponseWriter, r *http.Request) {
 	// instead of a confusing one at /token.
 	for _, gt := range req.GrantTypes {
 		if gt != "authorization_code" && gt != "refresh_token" {
-			writeOAuthError(w, http.StatusBadRequest, "invalid_client_metadata",
+			writeOAuthError(w, r, http.StatusBadRequest, "invalid_client_metadata",
 				"unsupported grant_type: "+gt)
 			return
 		}
 	}
 	for _, rt := range req.ResponseTypes {
 		if rt != "code" {
-			writeOAuthError(w, http.StatusBadRequest, "invalid_client_metadata",
+			writeOAuthError(w, r, http.StatusBadRequest, "invalid_client_metadata",
 				"unsupported response_type: "+rt)
 			return
 		}
 	}
 	if req.TokenEndpointAuthMethod != "none" {
-		writeOAuthError(w, http.StatusBadRequest, "invalid_client_metadata",
+		writeOAuthError(w, r, http.StatusBadRequest, "invalid_client_metadata",
 			`only token_endpoint_auth_method="none" (public clients with PKCE) is supported`)
 		return
 	}
@@ -460,8 +500,8 @@ func (a *API) handleOAuthRegister(w http.ResponseWriter, r *http.Request) {
 		VALUES ($1, $2, $3, $4, $5, $6, ARRAY[]::TEXT[], $7, TRUE, 'dcr')
 	`, clientID, req.ClientName, req.RedirectURIs, req.GrantTypes,
 		req.ResponseTypes, scopeCeiling, req.TokenEndpointAuthMethod); err != nil {
-		log.Printf("[oauth] DCR insert failed: %v", err)
-		writeOAuthError(w, http.StatusInternalServerError, "server_error", "failed to register client")
+		log.Printf("[oauth] DCR insert failed: request_id=%s err=%v", oauthRequestID(w, r), err)
+		writeOAuthError(w, r, http.StatusInternalServerError, "server_error", "failed to register client")
 		return
 	}
 
@@ -528,7 +568,7 @@ func (a *API) handleOAuthGetClient(w http.ResponseWriter, r *http.Request) {
 			secs = 1
 		}
 		w.Header().Set("Retry-After", strconv.Itoa(secs))
-		writeOAuthError(w, http.StatusTooManyRequests, "rate_limited",
+		writeOAuthError(w, r, http.StatusTooManyRequests, "rate_limited",
 			"too many client-metadata requests from this IP; try again later")
 		return
 	}
@@ -557,8 +597,9 @@ func (a *API) handleOAuthGetClient(w http.ResponseWriter, r *http.Request) {
 			http.NotFound(w, r)
 			return
 		}
-		log.Printf("[oauth] client metadata lookup failed: client=%q err=%v", clientID, err)
-		writeOAuthError(w, http.StatusInternalServerError, "server_error",
+		log.Printf("[oauth] client metadata lookup failed: request_id=%s client=%q err=%v",
+			oauthRequestID(w, r), clientID, err)
+		writeOAuthError(w, r, http.StatusInternalServerError, "server_error",
 			"client metadata lookup failed; try again")
 		return
 	}
@@ -759,10 +800,15 @@ func (a *API) handleOAuthRevoke(w http.ResponseWriter, r *http.Request) {
 // logTokenError emits a structured line for a failed /token exchange.
 // Captures enough to spot patterns (repeated invalid_grant from one
 // client, brute-force bad-PKCE attempts) without leaking anything
-// sensitive — fosite's error message is the only operator-visible
-// detail. fosite may hand us a nil requester or a partial one when
-// the request failed during parsing; we don't panic on either.
-func logTokenError(req fosite.AccessRequester, stage string, err error) {
+// sensitive. fosite's RFC6749Error.Error() returns only the code string
+// ("invalid_grant"), which can't distinguish expired-code from
+// PKCE-mismatch from replay — so we also log the hint (and debug, when
+// present). Safe to log: on every /token grant path (auth-code, refresh,
+// PKCE) fosite's hints are static category strings, and debug carries the
+// wrapped storage error text — never the code, verifier, or tokens.
+// fosite may hand us a nil requester or a partial one when the request
+// failed during parsing; we don't panic on either.
+func logTokenError(req fosite.AccessRequester, stage, reqID string, err error) {
 	clientID := ""
 	grantType := ""
 	if req != nil {
@@ -771,8 +817,9 @@ func logTokenError(req fosite.AccessRequester, stage string, err error) {
 		}
 		grantType = req.GetRequestForm().Get("grant_type")
 	}
-	log.Printf("[oauth] /token %s error: client=%q grant=%q err=%v",
-		stage, clientID, grantType, err)
+	rfcErr := fosite.ErrorToRFC6749Error(err)
+	log.Printf("[oauth] /token %s error: request_id=%s client=%q grant=%q code=%s hint=%q debug=%q",
+		stage, reqID, clientID, grantType, rfcErr.ErrorField, rfcErr.Reason(), rfcErr.Debug())
 }
 
 // ───────────────────────── /authorize ─────────────────────────
@@ -865,11 +912,16 @@ func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
 		http.NotFound(w, r)
 		return
 	}
+	// Resolved up front so every failure log line below can carry it;
+	// matches the X-Request-Id response header (middleware-set in prod).
+	reqID := oauthRequestID(w, r)
 	if a.userAuth == nil {
+		log.Printf("[oauth] /consent unavailable: user auth not configured: request_id=%s", reqID)
 		http.Error(w, "user auth not configured on this deployment", http.StatusServiceUnavailable)
 		return
 	}
 	if a.oauthStorage == nil {
+		log.Printf("[oauth] /consent unavailable: oauth storage not configured: request_id=%s", reqID)
 		http.Error(w, "oauth storage not configured on this deployment", http.StatusServiceUnavailable)
 		return
 	}
@@ -933,7 +985,7 @@ func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
 		// principal resolver maps (account, no agent) to an account principal,
 		// exactly like an e2a_acct_ key; any agent_choice is ignored.
 		if err := a.issueOAuthCode(ctx, w, r, ar, user.ID, "", identity.ScopeAccount); err != nil {
-			log.Printf("[oauth] /consent issue (account) failed: %v", err)
+			log.Printf("[oauth] /consent issue (account) failed: request_id=%s err=%v", reqID, err)
 			a.oauthProvider.WriteAuthorizeError(ctx, w, ar, err)
 		}
 		return
@@ -963,7 +1015,7 @@ func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
 		// No agent creation needed — drop straight into the code-
 		// issue path with the resolved email on the session.
 		if err := a.issueOAuthCode(ctx, w, r, ar, user.ID, email, identity.ScopeAgent); err != nil {
-			log.Printf("[oauth] /consent issue (existing agent) failed: %v", err)
+			log.Printf("[oauth] /consent issue (existing agent) failed: request_id=%s err=%v", reqID, err)
 			a.oauthProvider.WriteAuthorizeError(ctx, w, ar, err)
 		}
 
@@ -982,7 +1034,7 @@ func (a *API) handleOAuthConsent(w http.ResponseWriter, r *http.Request) {
 		}
 		agentEmail := slug + "@" + a.sharedDomain
 		if err := a.issueOAuthCodeWithNewAgent(ctx, w, r, ar, user.ID, agentEmail, identity.ScopeAgent); err != nil {
-			log.Printf("[oauth] /consent issue (new agent) failed: %v", err)
+			log.Printf("[oauth] /consent issue (new agent) failed: request_id=%s err=%v", reqID, err)
 			a.oauthProvider.WriteAuthorizeError(ctx, w, ar, err)
 		}
 

--- a/internal/agent/oauth_register_test.go
+++ b/internal/agent/oauth_register_test.go
@@ -501,6 +501,32 @@ func TestHTTP_Register_ErrorRequestID(t *testing.T) {
 			t.Errorf("minted request_id = %q, want req_ prefix", body.RequestID)
 		}
 	})
+
+	// Ids outside ^[A-Za-z0-9_-]{1,64}$ are reflected into log lines, so
+	// they must be replaced with a minted id, not honored.
+	t.Run("invalid inbound id replaced with minted", func(t *testing.T) {
+		for name, hostile := range map[string]string{
+			"field spoofing": `x client="victim" err=forged`,
+			"oversized":      strings.Repeat("a", 65),
+		} {
+			req, _ := http.NewRequest("POST", srv.URL+"/oauth2/register", badBody())
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("X-Request-Id", hostile)
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			body := assertOAuthError(t, resp, http.StatusBadRequest, "invalid_client_metadata")
+			assertRequestIDMatch(t, resp, body)
+			if body.RequestID == hostile {
+				t.Errorf("%s: hostile request_id %q was honored, want a minted replacement", name, hostile)
+			}
+			if !strings.HasPrefix(body.RequestID, "req_") {
+				t.Errorf("%s: request_id = %q, want a minted req_* id", name, body.RequestID)
+			}
+			resp.Body.Close()
+		}
+	})
 }
 
 // TestHTTP_Register_XFFCannotBypass: rotating X-Forwarded-For must

--- a/internal/agent/oauth_register_test.go
+++ b/internal/agent/oauth_register_test.go
@@ -60,7 +60,7 @@ func postRegister(t *testing.T, srv *httptest.Server, body any) *http.Response {
 	return resp
 }
 
-func assertOAuthError(t *testing.T, resp *http.Response, wantStatus int, wantErrCode string) {
+func assertOAuthError(t *testing.T, resp *http.Response, wantStatus int, wantErrCode string) OAuthErrorBody {
 	t.Helper()
 	if resp.StatusCode != wantStatus {
 		t.Errorf("status = %d, want %d", resp.StatusCode, wantStatus)
@@ -71,6 +71,24 @@ func assertOAuthError(t *testing.T, resp *http.Response, wantStatus int, wantErr
 	}
 	if body.Error != wantErrCode {
 		t.Errorf("error code = %q, want %q (description: %q)", body.Error, wantErrCode, body.ErrorDescription)
+	}
+	return body
+}
+
+// assertRequestIDMatch asserts the response carries an X-Request-Id header
+// and that the error body's request_id extension member echoes it exactly —
+// the join clients quote when reporting a failure.
+func assertRequestIDMatch(t *testing.T, resp *http.Response, body OAuthErrorBody) {
+	t.Helper()
+	hdr := resp.Header.Get("X-Request-Id")
+	if hdr == "" {
+		t.Error("X-Request-Id response header must be set on error responses")
+	}
+	if body.RequestID == "" {
+		t.Error("error body must carry request_id")
+	}
+	if hdr != "" && body.RequestID != "" && body.RequestID != hdr {
+		t.Errorf("body request_id = %q, want it to match X-Request-Id header %q", body.RequestID, hdr)
 	}
 }
 
@@ -437,7 +455,52 @@ func TestHTTP_Register_RateLimited(t *testing.T) {
 	}
 	resp := postRegister(t, srv, good(11))
 	defer resp.Body.Close()
-	assertOAuthError(t, resp, http.StatusTooManyRequests, "rate_limited")
+	body := assertOAuthError(t, resp, http.StatusTooManyRequests, "rate_limited")
+	assertRequestIDMatch(t, resp, body)
+}
+
+// TestHTTP_Register_ErrorRequestID: every DCR JSON error body carries a
+// request_id extension member (RFC 7591/6749 permit extension fields) that
+// matches the X-Request-Id response header on the same response — a
+// client-supplied id is honored, and without one the server mints a req_* id
+// that is consistent between header and body.
+func TestHTTP_Register_ErrorRequestID(t *testing.T) {
+	srv := newDCRServer(t)
+	badBody := func() *bytes.Reader {
+		buf, _ := json.Marshal(agent.OAuthRegisterRequest{
+			RedirectURIs: []string{"https://example.com/cb"}, // no client_name → 400
+		})
+		return bytes.NewReader(buf)
+	}
+
+	t.Run("client-supplied id honored", func(t *testing.T) {
+		req, _ := http.NewRequest("POST", srv.URL+"/oauth2/register", badBody())
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-Request-Id", "req_client_supplied_001")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		body := assertOAuthError(t, resp, http.StatusBadRequest, "invalid_client_metadata")
+		assertRequestIDMatch(t, resp, body)
+		if body.RequestID != "req_client_supplied_001" {
+			t.Errorf("request_id = %q, want the client-supplied id honored", body.RequestID)
+		}
+	})
+
+	t.Run("server-minted id without inbound header", func(t *testing.T) {
+		resp, err := http.Post(srv.URL+"/oauth2/register", "application/json", badBody())
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+		body := assertOAuthError(t, resp, http.StatusBadRequest, "invalid_client_metadata")
+		assertRequestIDMatch(t, resp, body)
+		if !strings.HasPrefix(body.RequestID, "req_") {
+			t.Errorf("minted request_id = %q, want req_ prefix", body.RequestID)
+		}
+	})
 }
 
 // TestHTTP_Register_XFFCannotBypass: rotating X-Forwarded-For must

--- a/internal/agent/oauth_revoke_test.go
+++ b/internal/agent/oauth_revoke_test.go
@@ -171,8 +171,10 @@ func TestHTTP_Revoke_WrongClient(t *testing.T) {
 
 // OAuthErrorBody mirrors the RFC 6749 §5.2 error JSON shape for
 // asserting error bodies. Renamed to avoid clashing with the
-// production OAuthError type in oauth_handlers.go.
+// production OAuthError type in oauth_handlers.go. RequestID is the
+// e2a extension member that echoes the X-Request-Id response header.
 type OAuthErrorBody struct {
 	Error            string `json:"error"`
 	ErrorDescription string `json:"error_description"`
+	RequestID        string `json:"request_id"`
 }

--- a/internal/agent/oauth_token_test.go
+++ b/internal/agent/oauth_token_test.go
@@ -298,6 +298,64 @@ func TestHTTP_Token_BadPKCE(t *testing.T) {
 	}
 }
 
+// TestHTTP_Token_ErrorRequestID: a failed /token exchange carries the
+// X-Request-Id header so operators can join the RFC 6749 §5.2 response to
+// the server-side [oauth] /token log line (fosite writes the error body,
+// so the id travels on the header only). A client-supplied id is honored;
+// without one the handler mints a req_* id.
+func TestHTTP_Token_ErrorRequestID(t *testing.T) {
+	server, provider, _, clientID, userID := setupOAuthAPI(t)
+	redirectURI := "http://localhost:8765/callback"
+
+	badPKCEPost := func(t *testing.T, suppliedID string) *http.Response {
+		t.Helper()
+		_, challenge := newPKCE(t)
+		code := mintAuthCode(t, provider, clientID, userID, redirectURI, challenge)
+		form := url.Values{}
+		form.Set("grant_type", "authorization_code")
+		form.Set("code", code)
+		form.Set("client_id", clientID)
+		form.Set("redirect_uri", redirectURI)
+		form.Set("code_verifier", "not-the-right-verifier-not-the-right-verifier")
+		req, err := http.NewRequest("POST", server.URL+"/oauth2/token",
+			strings.NewReader(form.Encode()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		if suppliedID != "" {
+			req.Header.Set("X-Request-Id", suppliedID)
+		}
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return resp
+	}
+
+	t.Run("client-supplied id honored", func(t *testing.T) {
+		resp := badPKCEPost(t, "req_token_supplied_01")
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400 invalid_grant", resp.StatusCode)
+		}
+		if got := resp.Header.Get("X-Request-Id"); got != "req_token_supplied_01" {
+			t.Errorf("X-Request-Id = %q, want the client-supplied id honored", got)
+		}
+	})
+
+	t.Run("server-minted id without inbound header", func(t *testing.T) {
+		resp := badPKCEPost(t, "")
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("status = %d, want 400 invalid_grant", resp.StatusCode)
+		}
+		if got := resp.Header.Get("X-Request-Id"); !strings.HasPrefix(got, "req_") {
+			t.Errorf("X-Request-Id = %q, want a minted req_* id", got)
+		}
+	})
+}
+
 // TestHTTP_Token_CodeReplay drives the code-reuse path: exchange
 // once (success), then re-present the same code (rejection + the
 // originally issued tokens get revoked per RFC 6749 §10.5).

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -44,4 +44,10 @@ COPY --from=build /app/mcp/dist ./mcp/dist
 COPY VERSION ./VERSION
 EXPOSE 3000
 USER node
+# Liveness only: /healthz never touches the backend, so a backend outage
+# can't restart a healthy MCP process. Probe with node's built-in fetch
+# (always present; the image has no curl, only busybox wget). Readiness
+# (/readyz) is an orchestrator-level concern and deliberately not baked in.
+HEALTHCHECK --interval=10s --timeout=3s --start-period=10s --retries=5 \
+    CMD node -e "fetch('http://127.0.0.1:3000/healthz').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
 CMD ["node", "mcp/dist/bin/http.js"]

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -258,6 +258,75 @@ representations of the error**:
 Successful results are unaffected (JSON in a text block; list tools return a
 domain-named array plus `next_cursor` while more pages remain).
 
+## Operating the HTTP server
+
+Self-hosters run the HTTP transport via `mcp/Dockerfile` or the `mcp`
+service in the repo's `docker-compose.yaml`. Day-2 operations (SLOs,
+failure classes, correlation) are covered by
+[`docs/runbooks/mcp-server.md`](../docs/runbooks/mcp-server.md); this
+section is the reference for configuration and surface.
+
+### Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `PORT` | `3000` | Listen port. |
+| `E2A_API_URL` | `https://api.e2a.dev` | Base URL of the e2a API server this transport forwards bearers to (and probes for readiness). Canonical name; `E2A_URL` and `E2A_BASE_URL` are legacy aliases, still accepted with a deprecation warning. |
+| `MCP_ALLOWED_HOSTS` | `api.e2a.dev` | Comma-separated Host allowlist (DNS-rebinding guard). Requests to `/mcp` and the discovery document with a Host outside the list get 421. Ports are stripped before comparison. |
+| `MCP_PUBLIC_URL` | unset | Externally reachable URL of this MCP server, used verbatim in the RFC 9728 protected-resource metadata and the 401 `WWW-Authenticate` challenge. Set when the fronting proxy's view of the URL differs from the inbound Host (local dev: `http://localhost:8765`). |
+| `MCP_AUTHORIZATION_SERVER_URL` | `$E2A_API_URL` | Authorization-server URL advertised in protected-resource metadata. Override when the bearer-forwarding URL is container-internal but OAuth clients must reach the AS from the host. |
+| `E2A_TRUST_PROXY` | `loopback` | Express `trust proxy` setting — which hops' `X-Forwarded-*` headers are honored for discovery URLs. `true`/`false`, a hop count, or a preset/subnet list. |
+| `MCP_RESOLVE_TIMEOUT_MS` | `5000` | Positive-int bound (ms) on the whoami probe that resolves a bearer to its principal, with at most 1 retry. On timeout/backend 5xx the request is served fail-closed at least-privilege agent scope, uncached, and logged as `auth_resolution result=fallback`. |
+| `MCP_SESSION_IDLE_MS` | `300000` | **Legacy name — sizes the resolve cache, not sessions.** TTL (ms) of a cached bearer→principal resolution. The transport is stateless; there are no sessions to time out. |
+| `MCP_MAX_SESSIONS` | `500` | **Legacy name — sizes the resolve cache, not sessions.** Max cached bearer→principal entries; oldest evicted past the cap. A miss costs one `whoami`, never a disconnect. |
+
+### Health endpoints
+
+All three are unauthenticated:
+
+- `GET /healthz` — process liveness only, never touches the backend:
+  `{ "ok": true }`. Wire to your liveness probe.
+- `GET /readyz` — readiness: probes `{E2A_API_URL}/api/health` (2s timeout,
+  result cached 10s so a scraping fleet can't cause a probe storm). 200
+  `{ "ok": true, "checks": { "api": "ok" } }` when reachable; 503
+  `{ "ok": false, "checks": { "api": "unreachable" }, "request_id": "…" }`
+  + `Retry-After: 5` when not. Wire to your readiness probe.
+- `GET /metrics` — Prometheus text exposition. Example lines:
+
+  ```
+  mcp_http_requests_total{route="mcp",status_class="2xx"} 1523
+  mcp_http_request_duration_seconds_bucket{route="mcp",le="0.5"} 1480
+  mcp_auth_resolutions_total{result="cache_hit"} 1490
+  mcp_tool_executions_total{tool="list_messages",outcome="ok"} 412
+  mcp_readyz_checks_total{result="ok"} 60
+  mcp_resolve_cache_entries 7
+  ```
+
+  Route labels are bounded: `mcp | healthz | readyz | metrics | discovery | other`.
+
+### Structured logs
+
+Single-line JSON on stderr (GCE-shaped `severity` / `event` / `message`
+plus fields). Request-scoped events carry `request_id` (the response's
+`X-Request-Id`): `auth_resolution` (`result`, `duration_ms`, `scope?`;
+`invalid`/`fallback` at WARNING), `http_request` (`route`, `method`,
+`status`, `duration_ms`), `tool_execution` (`tool`, `outcome`,
+`duration_ms`, `error_code?`), `terminal_error`. Bearer tokens are never
+logged; the resolve cache is keyed by SHA-256 fingerprints. An inbound
+`X-Request-Id` matching `^[A-Za-z0-9_-]{1,64}$` is honored; otherwise the
+server mints `mcpreq_<12hex>`. The id is echoed on every response but is
+**not** forwarded to the backend API.
+
+### Client retry policy
+
+Failed tool calls return `structuredContent` (see [Errors](#errors)):
+branch on `code` / `retryable` / `retry_after_seconds`. Retry only
+`retryable: true` errors with exponential backoff + jitter, ~3 attempts
+max. Never retry 4xx (401 → re-authenticate; 421 → fix the URL).
+`pending_review` on send tools is a success outcome — do not retry it. The
+transport is stateless, so "reconnect" after an interruption is simply
+re-POSTing; MCP clients do this automatically.
+
 ## Links
 
 - [e2a docs](https://e2a.dev)

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -290,7 +290,7 @@ All three are unauthenticated:
   result cached 10s so a scraping fleet can't cause a probe storm). 200
   `{ "ok": true, "checks": { "api": "ok" } }` when reachable; 503
   `{ "ok": false, "checks": { "api": "unreachable" }, "request_id": "…" }`
-  + `Retry-After: 5` when not. Wire to your readiness probe.
+  + `Retry-After: 10` (the failure-cache TTL) when not. Wire to your readiness probe.
 - `GET /metrics` — Prometheus text exposition. Example lines:
 
   ```
@@ -310,7 +310,8 @@ Single-line JSON on stderr (GCE-shaped `severity` / `event` / `message`
 plus fields). Request-scoped events carry `request_id` (the response's
 `X-Request-Id`): `auth_resolution` (`result`, `duration_ms`, `scope?`;
 `invalid`/`fallback` at WARNING), `http_request` (`route`, `method`,
-`status`, `duration_ms`), `tool_execution` (`tool`, `outcome`,
+`status`, `duration_ms`; successful probe/scrape traffic on
+`healthz`/`readyz`/`metrics` is metered but not logged), `tool_execution` (`tool`, `outcome`,
 `duration_ms`, `error_code?`), `terminal_error`. Bearer tokens are never
 logged; the resolve cache is keyed by SHA-256 fingerprints. An inbound
 `X-Request-Id` matching `^[A-Za-z0-9_-]{1,64}$` is honored; otherwise the

--- a/mcp/src/bin/http.ts
+++ b/mcp/src/bin/http.ts
@@ -7,6 +7,7 @@ interface BinConfig {
   allowedHosts: string[];
   sessionIdleMs: number;
   maxSessions: number;
+  resolveTimeoutMs: number;
   publicUrl?: string;
   authorizationServerUrl?: string;
   trustProxy: boolean | number | string;
@@ -110,6 +111,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): BinConfig {
     allowedHosts: parseHostList(env.MCP_ALLOWED_HOSTS ?? "", "api.e2a.dev"),
     sessionIdleMs: parsePositiveInt("MCP_SESSION_IDLE_MS", env.MCP_SESSION_IDLE_MS ?? "", 5 * 60_000),
     maxSessions: parsePositiveInt("MCP_MAX_SESSIONS", env.MCP_MAX_SESSIONS ?? "", 500),
+    resolveTimeoutMs: parsePositiveInt("MCP_RESOLVE_TIMEOUT_MS", env.MCP_RESOLVE_TIMEOUT_MS ?? "", 5000),
     publicUrl: env.MCP_PUBLIC_URL || undefined,
     authorizationServerUrl: env.MCP_AUTHORIZATION_SERVER_URL || undefined,
     trustProxy: parseTrustProxy(env.E2A_TRUST_PROXY ?? ""),
@@ -138,9 +140,14 @@ async function main(): Promise<void> {
     // kept so existing deploy manifests keep working.
     resolveCacheTtlMs: cfg.sessionIdleMs,
     resolveCacheMaxEntries: cfg.maxSessions,
+    resolveTimeoutMs: cfg.resolveTimeoutMs,
     publicUrl: cfg.publicUrl,
     authorizationServerUrl: cfg.authorizationServerUrl,
     trustProxy: cfg.trustProxy,
+    // Route all request-scoped events (http_request, auth_resolution,
+    // tool_execution, terminal_error) through the same writer as the
+    // process-lifecycle events.
+    logger: logJson,
   });
   logJson("INFO", "listening", `e2a-mcp-http listening on :${bound}`, {
     port: bound,

--- a/mcp/src/correlation.ts
+++ b/mcp/src/correlation.ts
@@ -1,0 +1,32 @@
+import { randomBytes } from "node:crypto";
+import type { NextFunction, Request, Response } from "express";
+
+// Inbound ids are honored only when they match a safe, bounded alphabet —
+// the value is reflected into logs and JSON-RPC error bodies, so anything
+// exotic (control chars, huge strings) is discarded and replaced.
+const INBOUND_REQUEST_ID = /^[A-Za-z0-9_-]{1,64}$/;
+
+export function mintRequestId(): string {
+  return `mcpreq_${randomBytes(6).toString("hex")}`;
+}
+
+/**
+ * Correlation middleware: attach a request id to every request and echo it
+ * back as X-Request-Id on every response (the header is set eagerly, so it
+ * rides 401/405/500 responses too). The id lives on res.locals and is what
+ * the request-scoped log events and JSON-RPC error `data.request_id` fields
+ * carry.
+ */
+export function correlationMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const inbound = req.headers["x-request-id"];
+  const id =
+    typeof inbound === "string" && INBOUND_REQUEST_ID.test(inbound) ? inbound : mintRequestId();
+  res.locals.requestId = id;
+  res.setHeader("X-Request-Id", id);
+  next();
+}
+
+/** The request id attached by {@link correlationMiddleware}. */
+export function requestIdOf(res: Response): string {
+  return typeof res.locals.requestId === "string" ? res.locals.requestId : "unknown";
+}

--- a/mcp/src/http-server.ts
+++ b/mcp/src/http-server.ts
@@ -2,10 +2,14 @@ import express, { type Express, type NextFunction, type Request, type Response }
 import cors from "cors";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { E2AClient } from "@e2a/sdk/v1";
-import { buildServer } from "./server.js";
+import { buildServer, type ToolExecutionRecord } from "./server.js";
 import { McpClient } from "./client.js";
 import type { Scope } from "./tools/tiers.js";
 import { ResolveCache, type ResolvedPrincipal } from "./resolve.js";
+import { MetricsRegistry, type RouteLabel } from "./metrics.js";
+import { correlationMiddleware, requestIdOf } from "./correlation.js";
+import { defaultLogger, type Logger } from "./logging.js";
+import { ReadinessProber, type ReadyzOptions } from "./readyz.js";
 
 export interface HttpServerOptions {
   /** Base URL of the e2a backend (Bearer is forwarded as-is). */
@@ -46,6 +50,20 @@ export interface HttpServerOptions {
   /** Hard cap on cached principals. */
   resolveCacheMaxEntries?: number;
   /**
+   * Bound (ms) on the whoami scope-resolution probe, with at most one
+   * retry. Default 5000. Without this a hung backend could hold a POST
+   * for the SDK's 30s × 3-attempt worst case before failing closed.
+   */
+  resolveTimeoutMs?: number;
+  /** Metrics registry for /metrics and the internal counters (defaults to
+   *  a fresh one per app — inject for test isolation or to read back). */
+  metrics?: MetricsRegistry;
+  /** Structured log sink for request-scoped events (defaults to single-line
+   *  JSON on stderr; the bin passes its logJson). */
+  logger?: Logger;
+  /** Readiness-probe seams for GET /readyz (timeout/cache/clock/fetcher). */
+  readyz?: ReadyzOptions;
+  /**
    * Test seam: override how the per-request E2AClient is built. The
    * default constructs `new E2AClient({ apiKey: bearer, baseUrl })`.
    *
@@ -60,6 +78,29 @@ export interface HttpServerOptions {
 interface BuiltApp {
   app: Express;
   cache: ResolveCache;
+  metrics: MetricsRegistry;
+}
+
+// Runtime bundles the per-app dependencies the route handlers share, so the
+// middleware factories don't grow parallel parameter lists.
+interface Runtime {
+  opts: HttpServerOptions;
+  cache: ResolveCache;
+  metrics: MetricsRegistry;
+  logger: Logger;
+}
+
+const DEFAULT_RESOLVE_TIMEOUT_MS = 5_000;
+
+// classifyRoute maps a request path to its bounded metric/log label. Any
+// path outside the known set collapses to "other" so cardinality stays fixed.
+function classifyRoute(path: string): RouteLabel {
+  if (path === "/mcp") return "mcp";
+  if (path === "/healthz") return "healthz";
+  if (path === "/readyz") return "readyz";
+  if (path === "/metrics") return "metrics";
+  if (path.startsWith("/.well-known/")) return "discovery";
+  return "other";
 }
 
 /**
@@ -82,6 +123,9 @@ export function buildApp(opts: HttpServerOptions): BuiltApp {
       ttlMs: opts.resolveCacheTtlMs ?? 60_000,
       maxEntries: opts.resolveCacheMaxEntries ?? 500,
     });
+  const metrics = opts.metrics ?? new MetricsRegistry();
+  const logger = opts.logger ?? defaultLogger;
+  const rt: Runtime = { opts, cache, metrics, logger };
 
   const app = express();
   // Set this before any route reads req.protocol. The default trusts only the
@@ -90,8 +134,63 @@ export function buildApp(opts: HttpServerOptions): BuiltApp {
   // CORS open for v0.2; revisit when we have a real allowlist of MCP hosts.
   app.use(cors({ origin: "*", exposedHeaders: ["Mcp-Session-Id"] }));
 
+  // Correlation first: every response (including 401/405/421/500) carries
+  // the X-Request-Id this request is logged under.
+  app.use(correlationMiddleware);
+
+  // Per-request metric + structured access log, emitted when the response
+  // finishes (covers every route and status, success or error). The route is
+  // classified NOW, before any mounted middleware strips the mount prefix
+  // from req.url (a 421 from the /mcp host guard would otherwise label as
+  // "other" at finish time).
+  app.use((req, res, next) => {
+    const start = Date.now();
+    const path = req.path;
+    const route = classifyRoute(path);
+    res.on("finish", () => {
+      const durationMs = Date.now() - start;
+      const statusClass = `${Math.floor(res.statusCode / 100)}xx`;
+      metrics.incHttpRequest(route, statusClass);
+      metrics.observeRequestDuration(route, durationMs / 1000);
+      logger("INFO", "http_request", `${req.method} ${path} ${res.statusCode}`, {
+        request_id: requestIdOf(res),
+        route,
+        method: req.method,
+        status: res.statusCode,
+        duration_ms: durationMs,
+      });
+    });
+    next();
+  });
+
+  // Pure liveness only — never consults the backend.
   app.get("/healthz", (_req, res) => {
     res.json({ ok: true });
+  });
+
+  // Readiness: probes the backend API health (bounded + cached) so a
+  // load balancer can tell "process alive" from "can actually serve".
+  const prober = new ReadinessProber(opts.baseUrl, opts.readyz);
+  app.get("/readyz", async (_req, res) => {
+    const ok = await prober.check();
+    metrics.incReadyzCheck(ok ? "ok" : "degraded");
+    if (ok) {
+      res.json({ ok: true, checks: { api: "ok" } });
+      return;
+    }
+    res.setHeader("Retry-After", "5");
+    res.status(503).json({
+      ok: false,
+      checks: { api: "unreachable" },
+      request_id: requestIdOf(res),
+    });
+  });
+
+  // Prometheus scrape. Unauthenticated like /healthz: the exposition carries
+  // only counters/gauges over closed label vocabularies — no bearer, user, or
+  // request data.
+  app.get("/metrics", (_req, res) => {
+    res.type("text/plain; version=0.0.4; charset=utf-8").send(metrics.render());
   });
 
   // DNS rebinding protection. The SDK deprecated its in-transport allowlist
@@ -168,10 +267,10 @@ export function buildApp(opts: HttpServerOptions): BuiltApp {
   const parseMcpJson = express.json({ limit: "40mb" });
   app.post(
     "/mcp",
-    authenticateClient(cache, opts),
+    authenticateClient(rt),
     parseMcpJson,
     async (req, res) => {
-      await handleAuthenticatedClientRequest(req, res, opts);
+      await handleAuthenticatedClientRequest(req, res, rt);
     },
   );
 
@@ -192,23 +291,33 @@ export function buildApp(opts: HttpServerOptions): BuiltApp {
   // client/model.
   app.use((err: unknown, req: Request, res: Response, next: NextFunction) => {
     const message = err instanceof Error ? err.message : String(err);
-    console.error(`[e2a-mcp] unhandled request error: ${message}`);
+    const name = err instanceof Error ? err.name : typeof err;
+    logger("ERROR", "terminal_error", `unhandled request error: ${message}`, {
+      request_id: requestIdOf(res),
+      error: name,
+    });
     if (res.headersSent) {
       // The streaming transport already began writing; we can't reshape the
       // response, so let Express abort the connection.
       next(err);
       return;
     }
-    res.status(500).json(jsonRpcError(req.body, -32603, "internal server error"));
+    res
+      .status(500)
+      .json(jsonRpcError(req.body, -32603, "internal server error", { request_id: requestIdOf(res) }));
   });
 
-  return { app, cache };
+  return { app, cache, metrics };
 }
 
 function methodNotAllowed(_req: Request, res: Response): void {
   res
     .status(405)
-    .json(jsonRpcError(null, -32000, "Method not allowed: the e2a MCP server is stateless"));
+    .json(
+      jsonRpcError(null, -32000, "Method not allowed: the e2a MCP server is stateless", {
+        request_id: requestIdOf(res),
+      }),
+    );
 }
 
 // req.protocol honors X-Forwarded-Proto only for hops allowed by `trust proxy`.
@@ -263,38 +372,79 @@ interface AuthenticatedContext {
 }
 
 function authenticateClient(
-  cache: ResolveCache,
-  opts: HttpServerOptions,
+  rt: Runtime,
 ): (req: Request, res: Response, next: NextFunction) => Promise<void> {
+  const { cache, opts, metrics, logger } = rt;
   return async (req, res, next) => {
+    const requestId = requestIdOf(res);
     const bearer = extractBearer(req);
     if (!bearer) {
       res.setHeader("WWW-Authenticate", bearerChallenge(req, opts));
-      res.status(401).json(jsonRpcError(null, -32001, "missing bearer token"));
+      res
+        .status(401)
+        .json(jsonRpcError(null, -32001, "missing bearer token", { request_id: requestId }));
       return;
     }
 
     // Resolve the credential's scope + bound agent before parsing JSON. A
     // cache hit skips the backend round-trip; revoked/expired tokens fail here.
     let principal = cache.get(bearer);
-    if (!principal) {
+    if (principal) {
+      metrics.incAuthResolution("cache_hit");
+      logger("INFO", "auth_resolution", "bearer resolved from cache", {
+        request_id: requestId,
+        result: "cache_hit",
+        duration_ms: 0,
+        scope: principal.scope,
+      });
+    } else {
+      const start = Date.now();
       let resolved: { value: ResolvedPrincipal; cacheable: boolean };
       try {
         resolved = await resolvePrincipal(opts, bearer);
       } catch (err) {
         if (err instanceof InvalidBearerError) {
+          metrics.incAuthResolution("invalid");
+          logger("WARNING", "auth_resolution", "bearer rejected by the backend", {
+            request_id: requestId,
+            result: "invalid",
+            duration_ms: Date.now() - start,
+          });
           res.setHeader(
             "WWW-Authenticate",
             `${bearerChallenge(req, opts)}, error="invalid_token"`,
           );
-          res.status(401).json(jsonRpcError(null, -32001, "invalid bearer token"));
+          res
+            .status(401)
+            .json(jsonRpcError(null, -32001, "invalid bearer token", { request_id: requestId }));
           return;
         }
         throw err;
       }
+      const durationMs = Date.now() - start;
       principal = resolved.value;
-      if (resolved.cacheable) cache.set(bearer, principal);
+      if (resolved.cacheable) {
+        metrics.incAuthResolution("resolved");
+        logger("INFO", "auth_resolution", "bearer resolved via whoami", {
+          request_id: requestId,
+          result: "resolved",
+          duration_ms: durationMs,
+          scope: principal.scope,
+        });
+        cache.set(bearer, principal);
+      } else {
+        // The previously silent fail-closed path: a non-auth backend failure
+        // (5xx/timeout) now leaves an operable trace.
+        metrics.incAuthResolution("fallback");
+        logger("WARNING", "auth_resolution", "whoami probe failed; serving least-privilege fallback", {
+          request_id: requestId,
+          result: "fallback",
+          duration_ms: durationMs,
+          scope: principal.scope,
+        });
+      }
     }
+    metrics.setResolveCacheEntries(cache.size());
 
     // The cold-path whoami probe is awaited, so the client may have
     // disconnected meanwhile. Do not hand an abandoned request to the parser.
@@ -308,11 +458,13 @@ function authenticateClient(
 async function handleAuthenticatedClientRequest(
   req: Request,
   res: Response,
-  opts: HttpServerOptions,
+  rt: Runtime,
 ): Promise<void> {
+  const { opts, metrics, logger } = rt;
   const auth = res.locals.auth as AuthenticatedContext | undefined;
   if (!auth) throw new Error("missing authenticated MCP request context");
   const { bearer, principal } = auth;
+  const requestId = requestIdOf(res);
 
   // Stateless: a fresh server + transport per request, torn down when the
   // response closes. The SDK forbids reusing a stateless transport across
@@ -320,7 +472,19 @@ async function handleAuthenticatedClientRequest(
   // sessionIdGenerator=undefined skips all session/initialize gating, so a
   // bare tools/call dispatches without a prior initialize on this instance.
   const client = buildClient(opts, bearer, principal);
-  const server = buildServer({ client });
+  const server = buildServer({
+    client,
+    onToolExecution: (rec: ToolExecutionRecord) => {
+      metrics.incToolExecution(rec.tool, rec.outcome);
+      logger(rec.outcome === "ok" ? "INFO" : "WARNING", "tool_execution", `tool ${rec.tool} ${rec.outcome}`, {
+        request_id: requestId,
+        tool: rec.tool,
+        outcome: rec.outcome,
+        duration_ms: rec.durationMs,
+        ...(rec.errorCode ? { error_code: rec.errorCode } : {}),
+      });
+    },
+  });
   const transport = new StreamableHTTPServerTransport({
     sessionIdGenerator: undefined,
   });
@@ -386,19 +550,44 @@ function buildClient(
  * backend hiccup) returns a least-privilege fallback marked `cacheable: false`
  * so it doesn't stick — the backend still enforces scope, and the next request
  * re-probes once the backend recovers.
+ *
+ * The probe is BOUNDED two ways (resolveTimeoutMs, default 5s): the race below
+ * caps the total wait regardless of the client implementation, and the
+ * default-path E2AClient is built with a per-attempt `timeoutMs` +
+ * `maxRetries: 1` so it can't stretch to the SDK's 30s × 3-attempt worst case
+ * on its own.
  */
 export async function resolvePrincipal(
   opts: HttpServerOptions,
   bearer: string,
 ): Promise<{ value: ResolvedPrincipal; cacheable: boolean }> {
+  const timeoutMs = opts.resolveTimeoutMs ?? DEFAULT_RESOLVE_TIMEOUT_MS;
   // The probe only calls whoami; its scope/agent don't matter. Build it bare
   // (factory(bearer) with no resolved opts) so the construction is
   // distinguishable from the final, resolved client.
   const probe = opts.clientFactory
     ? opts.clientFactory(bearer)
-    : new McpClient(new E2AClient({ apiKey: bearer, baseUrl: opts.baseUrl }), "", "account");
+    : new McpClient(
+        new E2AClient({
+          apiKey: bearer,
+          baseUrl: opts.baseUrl,
+          timeoutMs,
+          maxRetries: 1,
+        }),
+        "",
+        "account",
+      );
+  let timer: ReturnType<typeof setTimeout> | undefined;
   try {
-    const me = await probe.whoami();
+    const me = await Promise.race([
+      probe.whoami(),
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`whoami probe timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ]);
     const scope: Scope = me.scope === "account" ? "account" : "agent";
     const agentEmail = scope === "agent" && me.agentEmail ? me.agentEmail : undefined;
     return { value: { scope, ...(agentEmail ? { agentEmail } : {}) }, cacheable: true };
@@ -408,6 +597,8 @@ export async function resolvePrincipal(
     }
     // Fail-closed: least-privilege runtime tier, no default agent, not cached.
     return { value: { scope: "agent" }, cacheable: false };
+  } finally {
+    if (timer) clearTimeout(timer);
   }
 }
 
@@ -436,25 +627,32 @@ function jsonRpcError(
   body: unknown,
   code: number,
   message: string,
+  data?: Record<string, unknown>,
 ): Record<string, unknown> {
   // Preserve the request id when we can identify it; otherwise null.
   const id =
     body && typeof body === "object" && "id" in body
       ? (body as { id: unknown }).id
       : null;
-  return { jsonrpc: "2.0", id, error: { code, message } };
+  return { jsonrpc: "2.0", id, error: { code, message, ...(data ? { data } : {}) } };
 }
 
 /**
  * Start the HTTP server on `port`. Returns a closer that stops the listener —
  * wire it to SIGTERM in bin/http.ts. The server is stateless, so there are no
  * sessions to drain; closing the listener is the whole shutdown.
+ *
+ * NOTE on correlation: the request id is NOT forwarded to the backend on
+ * whoami or tool calls — the @e2a/sdk client exposes no per-request header
+ * hook (whoami goes through sdk.account.get(), which takes no options), and
+ * this slice must not modify the SDK. If the SDK grows a header seam, thread
+ * res.locals.requestId through buildClient/resolvePrincipal here.
  */
 export async function startHttpServer(
   port: number,
   opts: HttpServerOptions,
-): Promise<{ close: () => Promise<void>; port: number }> {
-  const { app, cache } = buildApp(opts);
+): Promise<{ close: () => Promise<void>; port: number; metrics: MetricsRegistry }> {
+  const { app, cache, metrics } = buildApp(opts);
   const server = app.listen(port);
   await new Promise<void>((resolve, reject) => {
     server.once("listening", resolve);
@@ -463,6 +661,7 @@ export async function startHttpServer(
   const actualPort = (server.address() as { port: number }).port;
   return {
     port: actualPort,
+    metrics,
     close: async () => {
       await new Promise<void>((resolve) => server.close(() => resolve()));
       cache.clear();

--- a/mcp/src/http-server.ts
+++ b/mcp/src/http-server.ts
@@ -92,6 +92,11 @@ interface Runtime {
 
 const DEFAULT_RESOLVE_TIMEOUT_MS = 5_000;
 
+// Routes whose successful responses are counted in metrics but skipped by
+// the access log (orchestrator probes and scrapers hit them every few
+// seconds forever). Failures on these routes still log.
+const QUIET_ROUTES: ReadonlySet<RouteLabel> = new Set(["healthz", "readyz", "metrics"]);
+
 // classifyRoute maps a request path to its bounded metric/log label. Any
 // path outside the known set collapses to "other" so cardinality stays fixed.
 function classifyRoute(path: string): RouteLabel {
@@ -143,6 +148,11 @@ export function buildApp(opts: HttpServerOptions): BuiltApp {
   // classified NOW, before any mounted middleware strips the mount prefix
   // from req.url (a 421 from the /mcp host guard would otherwise label as
   // "other" at finish time).
+  //
+  // Probe/scrape routes are metered but not access-logged on success: a 10s
+  // healthcheck plus a 15s Prometheus scrape is ~14k INFO lines/day/replica
+  // of pure noise (and real log-ingest cost). Failures (>=400) on those
+  // routes still log — a 503 readyz is exactly what an operator greps for.
   app.use((req, res, next) => {
     const start = Date.now();
     const path = req.path;
@@ -152,6 +162,7 @@ export function buildApp(opts: HttpServerOptions): BuiltApp {
       const statusClass = `${Math.floor(res.statusCode / 100)}xx`;
       metrics.incHttpRequest(route, statusClass);
       metrics.observeRequestDuration(route, durationMs / 1000);
+      if (QUIET_ROUTES.has(route) && res.statusCode < 400) return;
       logger("INFO", "http_request", `${req.method} ${path} ${res.statusCode}`, {
         request_id: requestIdOf(res),
         route,
@@ -178,7 +189,8 @@ export function buildApp(opts: HttpServerOptions): BuiltApp {
       res.json({ ok: true, checks: { api: "ok" } });
       return;
     }
-    res.setHeader("Retry-After", "5");
+    // Match the failure-cache TTL: any sooner retry would hit the cached 503.
+    res.setHeader("Retry-After", String(prober.cacheTtlSeconds));
     res.status(503).json({
       ok: false,
       checks: { api: "unreachable" },

--- a/mcp/src/logging.ts
+++ b/mcp/src/logging.ts
@@ -1,0 +1,22 @@
+export type LogSeverity = "INFO" | "WARNING" | "ERROR";
+
+/**
+ * Request-scoped structured log sink: one operational event as a single-line
+ * JSON object. Same shape as the bin's logJson (severity / event / message +
+ * fields) so GCE Cloud Logging parses it into structured jsonPayload fields.
+ */
+export type Logger = (
+  severity: LogSeverity,
+  event: string,
+  message: string,
+  fields?: Record<string, unknown>,
+) => void;
+
+/**
+ * Default sink: single-line JSON on stderr. Keeps the library usable
+ * standalone (tests, embedding); the bin passes its own logJson instead so
+ * all process logs share one writer.
+ */
+export const defaultLogger: Logger = (severity, event, message, fields = {}) => {
+  process.stderr.write(`${JSON.stringify({ severity, event, message, ...fields })}\n`);
+};

--- a/mcp/src/metrics.ts
+++ b/mcp/src/metrics.ts
@@ -1,0 +1,165 @@
+/**
+ * Dependency-free in-process metrics registry for the MCP HTTP transport.
+ *
+ * Counters and a fixed-bucket request-duration histogram, rendered in the
+ * Prometheus text exposition format for `GET /metrics`. Label values come
+ * from closed vocabularies (route names, result/outcome tokens, tool names),
+ * so cardinality stays bounded; no bearer, user, or request data ever lands
+ * in a label. Node's single-threaded event loop makes the increments safe
+ * without locking.
+ *
+ * The registry is injectable into {@link buildApp} (`HttpServerOptions
+ * .metrics`) so tests can assert against an isolated instance; the server
+ * creates a fresh one per app otherwise.
+ */
+
+export type RouteLabel = "mcp" | "healthz" | "readyz" | "metrics" | "discovery" | "other";
+export type AuthResolutionResult = "cache_hit" | "resolved" | "invalid" | "fallback";
+export type ToolOutcome = "ok" | "error";
+export type ReadyzResult = "ok" | "degraded";
+
+// Fixed histogram buckets (seconds), covering fast health checks up to a
+// slow cold whoami probe.
+const REQUEST_DURATION_BUCKETS = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10] as const;
+
+type LabelSet = Record<string, string>;
+
+interface CounterSeries {
+  labels: LabelSet;
+  value: number;
+}
+
+interface HistogramSeries {
+  route: string;
+  /** Cumulative counts aligned with REQUEST_DURATION_BUCKETS. */
+  buckets: number[];
+  sum: number;
+  count: number;
+}
+
+// Map key for a label set: sorted, NUL-joined (NUL can't appear in our
+// closed label vocabularies).
+function labelKey(labels: LabelSet): string {
+  return Object.keys(labels)
+    .sort()
+    .map((k) => `${k}=${labels[k]}`)
+    .join("\x00");
+}
+
+function escapeLabelValue(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
+}
+
+function renderLabels(labels: LabelSet): string {
+  const keys = Object.keys(labels).sort();
+  if (keys.length === 0) return "";
+  return `{${keys.map((k) => `${k}="${escapeLabelValue(labels[k]!)}"`).join(",")}}`;
+}
+
+function inc(map: Map<string, CounterSeries>, labels: LabelSet): void {
+  const key = labelKey(labels);
+  const series = map.get(key);
+  if (series) {
+    series.value += 1;
+  } else {
+    map.set(key, { labels, value: 1 });
+  }
+}
+
+export class MetricsRegistry {
+  private readonly httpRequests = new Map<string, CounterSeries>();
+  private readonly authResolutions = new Map<string, CounterSeries>();
+  private readonly toolExecutions = new Map<string, CounterSeries>();
+  private readonly readyzChecks = new Map<string, CounterSeries>();
+  private readonly durations = new Map<string, HistogramSeries>();
+  private resolveCacheEntries = 0;
+
+  incHttpRequest(route: RouteLabel, statusClass: string): void {
+    inc(this.httpRequests, { route, status_class: statusClass });
+  }
+
+  incAuthResolution(result: AuthResolutionResult): void {
+    inc(this.authResolutions, { result });
+  }
+
+  incToolExecution(tool: string, outcome: ToolOutcome): void {
+    inc(this.toolExecutions, { tool, outcome });
+  }
+
+  incReadyzCheck(result: ReadyzResult): void {
+    inc(this.readyzChecks, { result });
+  }
+
+  observeRequestDuration(route: RouteLabel, seconds: number): void {
+    let series = this.durations.get(route);
+    if (!series) {
+      series = {
+        route,
+        buckets: REQUEST_DURATION_BUCKETS.map(() => 0),
+        sum: 0,
+        count: 0,
+      };
+      this.durations.set(route, series);
+    }
+    for (let i = 0; i < REQUEST_DURATION_BUCKETS.length; i++) {
+      if (seconds <= REQUEST_DURATION_BUCKETS[i]!) series.buckets[i]! += 1;
+    }
+    series.sum += seconds;
+    series.count += 1;
+  }
+
+  setResolveCacheEntries(n: number): void {
+    this.resolveCacheEntries = n;
+  }
+
+  reset(): void {
+    this.httpRequests.clear();
+    this.authResolutions.clear();
+    this.toolExecutions.clear();
+    this.readyzChecks.clear();
+    this.durations.clear();
+    this.resolveCacheEntries = 0;
+  }
+
+  /** Render the Prometheus text exposition format (v0.0.4). */
+  render(): string {
+    const lines: string[] = [];
+    const emitCounter = (name: string, help: string, map: Map<string, CounterSeries>) => {
+      lines.push(`# HELP ${name} ${help}`, `# TYPE ${name} counter`);
+      for (const series of map.values()) {
+        lines.push(`${name}${renderLabels(series.labels)} ${series.value}`);
+      }
+    };
+    emitCounter("mcp_http_requests_total", "HTTP requests by route and status class.", this.httpRequests);
+    emitCounter(
+      "mcp_auth_resolutions_total",
+      "Bearer-to-principal whoami resolutions by result.",
+      this.authResolutions,
+    );
+    emitCounter("mcp_tool_executions_total", "MCP tool executions by tool and outcome.", this.toolExecutions);
+    emitCounter("mcp_readyz_checks_total", "Readiness probe checks by result.", this.readyzChecks);
+
+    lines.push(
+      "# HELP mcp_http_request_duration_seconds HTTP request duration in seconds.",
+      "# TYPE mcp_http_request_duration_seconds histogram",
+    );
+    for (const series of this.durations.values()) {
+      const route = escapeLabelValue(series.route);
+      series.buckets.forEach((count, i) => {
+        lines.push(
+          `mcp_http_request_duration_seconds_bucket{route="${route}",le="${REQUEST_DURATION_BUCKETS[i]}"} ${count}`,
+        );
+      });
+      lines.push(`mcp_http_request_duration_seconds_bucket{route="${route}",le="+Inf"} ${series.count}`);
+      lines.push(`mcp_http_request_duration_seconds_sum{route="${route}"} ${series.sum}`);
+      lines.push(`mcp_http_request_duration_seconds_count{route="${route}"} ${series.count}`);
+    }
+
+    lines.push(
+      "# HELP mcp_resolve_cache_entries Bearer-to-principal cache entries currently held.",
+      "# TYPE mcp_resolve_cache_entries gauge",
+      `mcp_resolve_cache_entries ${this.resolveCacheEntries}`,
+    );
+    return lines.join("\n") + "\n";
+  }
+}

--- a/mcp/src/readyz.ts
+++ b/mcp/src/readyz.ts
@@ -1,0 +1,71 @@
+const DEFAULT_TIMEOUT_MS = 2_000;
+const DEFAULT_CACHE_TTL_MS = 10_000;
+
+export interface ReadyzOptions {
+  /** Probe timeout (ms). Default 2000. */
+  timeoutMs?: number;
+  /** How long a probe result (ok OR degraded) is cached (ms). Default 10000. */
+  cacheTtlMs?: number;
+  /** Test seam: clock override. Defaults to Date.now. */
+  now?: () => number;
+  /** Test seam: probe implementation. Resolves = reachable, rejects/never
+   *  settles past the timeout = unreachable. */
+  fetcher?: (url: string) => Promise<unknown>;
+}
+
+// defaultFetcher treats any non-2xx (or a network/abort failure) as
+// unreachable; the AbortSignal bounds the probe so a hung connection can't
+// outlive the timeout by much.
+async function defaultFetcher(url: string, timeoutMs: number): Promise<unknown> {
+  const res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+  if (!res.ok) throw new Error(`api health probe returned ${res.status}`);
+  return res;
+}
+
+/**
+ * Readiness prober for `GET /readyz`: checks `{baseUrl}/api/health` with a
+ * bounded timeout and caches the outcome (success AND failure) for
+ * `cacheTtlMs` so a scraping fleet can't fan out into a probe storm against
+ * an already-struggling backend. Pure liveness (`/healthz`) never touches
+ * this.
+ */
+export class ReadinessProber {
+  private cached: { ok: boolean; expiresAt: number } | undefined;
+  private readonly now: () => number;
+  private readonly timeoutMs: number;
+  private readonly cacheTtlMs: number;
+  private readonly fetcher: (url: string) => Promise<unknown>;
+
+  constructor(private readonly baseUrl: string, opts: ReadyzOptions = {}) {
+    this.now = opts.now ?? Date.now;
+    this.timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.cacheTtlMs = opts.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+    this.fetcher = opts.fetcher ?? ((url) => defaultFetcher(url, this.timeoutMs));
+  }
+
+  /** true when the backend API is reachable (possibly from the cache). */
+  async check(): Promise<boolean> {
+    const now = this.now();
+    if (this.cached && this.cached.expiresAt > now) return this.cached.ok;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    let ok = false;
+    try {
+      await Promise.race([
+        this.fetcher(`${this.baseUrl}/api/health`),
+        new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(
+            () => reject(new Error(`readyz probe timed out after ${this.timeoutMs}ms`)),
+            this.timeoutMs,
+          );
+        }),
+      ]);
+      ok = true;
+    } catch {
+      ok = false;
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+    this.cached = { ok, expiresAt: now + this.cacheTtlMs };
+    return ok;
+  }
+}

--- a/mcp/src/readyz.ts
+++ b/mcp/src/readyz.ts
@@ -43,6 +43,14 @@ export class ReadinessProber {
     this.fetcher = opts.fetcher ?? ((url) => defaultFetcher(url, this.timeoutMs));
   }
 
+  /**
+   * The cache TTL in whole seconds — what a 503's Retry-After should say.
+   * A shorter value would invite retries into a still-cached failure.
+   */
+  get cacheTtlSeconds(): number {
+    return Math.max(1, Math.ceil(this.cacheTtlMs / 1000));
+  }
+
   /** true when the backend API is reachable (possibly from the cache). */
   async check(): Promise<boolean> {
     const now = this.now();

--- a/mcp/src/server.ts
+++ b/mcp/src/server.ts
@@ -12,9 +12,67 @@ import { registerLegacyTools } from "./tools/legacy.js";
 import { toolNamesForScope } from "./tools/tiers.js";
 import { resolveServerVersion } from "./version.js";
 
+export interface ToolExecutionRecord {
+  tool: string;
+  outcome: "ok" | "error";
+  durationMs: number;
+  /** Server-vocabulary error code from the isError result, when present. */
+  errorCode?: string;
+}
+
 export interface BuildServerOptions {
   client: McpClient;
   version?: string;
+  /**
+   * Observability hook fired once per tool execution (both ok and isError
+   * results, plus handler throws). The HTTP transport wires this to the
+   * tool_execution metric + log event; in-process callers can ignore it.
+   */
+  onToolExecution?: (rec: ToolExecutionRecord) => void;
+}
+
+function isErrorResult(result: unknown): boolean {
+  return !!result && typeof result === "object" && (result as { isError?: unknown }).isError === true;
+}
+
+function errorCodeOf(result: unknown): string | undefined {
+  if (!isErrorResult(result)) return undefined;
+  const code = (result as { structuredContent?: { code?: unknown } }).structuredContent?.code;
+  return typeof code === "string" ? code : undefined;
+}
+
+// registerTool's last argument is always the handler (the overloads only
+// vary whether a config object precedes it). Wrap it to time the call and
+// classify the outcome without changing the handler's behavior or result.
+function wrapToolHandlerArgs(
+  name: string,
+  args: unknown[],
+  onToolExecution?: (rec: ToolExecutionRecord) => void,
+): unknown[] {
+  if (!onToolExecution) return args;
+  const last = args.length - 1;
+  if (last < 0 || typeof args[last] !== "function") return args;
+  const handler = args[last] as (...a: unknown[]) => unknown;
+  const wrapped = async (...callArgs: unknown[]) => {
+    const start = Date.now();
+    try {
+      const result = await handler(...callArgs);
+      const errorCode = errorCodeOf(result);
+      onToolExecution({
+        tool: name,
+        outcome: isErrorResult(result) ? "error" : "ok",
+        durationMs: Date.now() - start,
+        ...(errorCode ? { errorCode } : {}),
+      });
+      return result;
+    } catch (err) {
+      onToolExecution({ tool: name, outcome: "error", durationMs: Date.now() - start });
+      throw err;
+    }
+  };
+  const copy = args.slice();
+  copy[last] = wrapped;
+  return copy;
 }
 
 // gateRegistration intercepts server.registerTool so a session only registers
@@ -24,7 +82,11 @@ export interface BuildServerOptions {
 // are silently skipped (not registered → not listed → not callable). This is a
 // surface/decision-space optimization; the backend still enforces scope, so a
 // skipped tool is never the security boundary.
-function gateRegistration(server: McpServer, allowed: ReadonlySet<string>): void {
+function gateRegistration(
+  server: McpServer,
+  allowed: ReadonlySet<string>,
+  onToolExecution?: (rec: ToolExecutionRecord) => void,
+): void {
   const original = server.registerTool.bind(server) as (...a: unknown[]) => unknown;
   server.registerTool = ((name: string, ...rest: unknown[]) => {
     if (!allowed.has(name)) {
@@ -32,11 +94,17 @@ function gateRegistration(server: McpServer, allowed: ReadonlySet<string>): void
       // register*Tools callers don't use the return value.
       return undefined as unknown as ReturnType<McpServer["registerTool"]>;
     }
-    return original(name, ...rest) as ReturnType<McpServer["registerTool"]>;
+    return original(name, ...wrapToolHandlerArgs(name, rest, onToolExecution)) as ReturnType<
+      McpServer["registerTool"]
+    >;
   }) as McpServer["registerTool"];
 }
 
-export function buildServer({ client, version = resolveServerVersion() }: BuildServerOptions): McpServer {
+export function buildServer({
+  client,
+  version = resolveServerVersion(),
+  onToolExecution,
+}: BuildServerOptions): McpServer {
   const server = new McpServer({
     name: "e2a",
     version,
@@ -44,7 +112,7 @@ export function buildServer({ client, version = resolveServerVersion() }: BuildS
   // Scope-gate the surface to the connecting credential's tier (client.scope,
   // resolved at session init via whoami). account → full surface; agent →
   // runtime/inbox subset.
-  gateRegistration(server, toolNamesForScope(client.scope));
+  gateRegistration(server, toolNamesForScope(client.scope), onToolExecution);
   registerMessageTools(server, client);
   registerAgentTools(server, client);
   registerDomainTools(server, client);

--- a/mcp/tests/bin-http.test.ts
+++ b/mcp/tests/bin-http.test.ts
@@ -12,6 +12,7 @@ describe("bin/http loadConfig", () => {
       allowedHosts: ["api.e2a.dev"],
       sessionIdleMs: 5 * 60_000,
       maxSessions: 500,
+      resolveTimeoutMs: 5000,
       trustProxy: "loopback",
     });
   });
@@ -23,6 +24,7 @@ describe("bin/http loadConfig", () => {
       MCP_ALLOWED_HOSTS: "api.e2a.dev,mcp-staging.e2a.dev",
       MCP_SESSION_IDLE_MS: "60000",
       MCP_MAX_SESSIONS: "100",
+      MCP_RESOLVE_TIMEOUT_MS: "2500",
     });
     expect(cfg).toEqual({
       port: 8080,
@@ -30,6 +32,7 @@ describe("bin/http loadConfig", () => {
       allowedHosts: ["api.e2a.dev", "mcp-staging.e2a.dev"],
       sessionIdleMs: 60_000,
       maxSessions: 100,
+      resolveTimeoutMs: 2500,
       trustProxy: "loopback",
     });
   });
@@ -83,6 +86,18 @@ describe("bin/http loadConfig", () => {
   it("rejects non-integer MCP_SESSION_IDLE_MS", () => {
     expect(() => loadConfig({ MCP_SESSION_IDLE_MS: "3.14" })).toThrowError(ConfigError);
   });
+
+  it("defaults MCP_RESOLVE_TIMEOUT_MS to 5000", () => {
+    expect(loadConfig({}).resolveTimeoutMs).toBe(5000);
+  });
+
+  it.each([["0"], ["-100"], ["abc"], ["3.14"]])(
+    "rejects invalid MCP_RESOLVE_TIMEOUT_MS=%s",
+    (raw) => {
+      expect(() => loadConfig({ MCP_RESOLVE_TIMEOUT_MS: raw })).toThrowError(ConfigError);
+      expect(() => loadConfig({ MCP_RESOLVE_TIMEOUT_MS: raw })).toThrow(/MCP_RESOLVE_TIMEOUT_MS/);
+    },
+  );
 
   it("rejects empty MCP_ALLOWED_HOSTS after filtering", () => {
     // "," and ", ,," both filter down to []. Must fail loudly to avoid

--- a/mcp/tests/http.test.ts
+++ b/mcp/tests/http.test.ts
@@ -1355,6 +1355,42 @@ describe("HTTP MCP server", () => {
         spy.mockRestore();
       }
     });
+
+    it("meters but does not log successful probe/scrape routes; failures still log", async () => {
+      const { events, logger } = makeLogCapture();
+      const registry = new MetricsRegistry();
+      // readyz probe fails deterministically → 503 (the loggable case).
+      await restart({
+        logger,
+        metrics: registry,
+        readyz: {
+          fetcher: async () => {
+            throw new Error("backend down");
+          },
+        },
+      });
+      const origin = url.replace("/mcp", "");
+
+      for (const path of ["/healthz", "/metrics"]) {
+        const res = await fetch(`${origin}${path}`);
+        expect(res.status).toBe(200);
+        await res.text(); // drain so the server-side finish (and log) has fired
+      }
+      const quiet = events.filter((e) => e.event === "http_request");
+      expect(quiet).toEqual([]); // successful probe/scrape traffic is silent
+
+      const readyz = await fetch(`${origin}/readyz`);
+      expect(readyz.status).toBe(503);
+      await readyz.text();
+      const failure = events.filter((e) => e.event === "http_request");
+      expect(failure).toHaveLength(1); // ...but failures on those routes log
+      expect(failure[0]).toMatchObject({ route: "readyz", status: 503 });
+
+      // Metrics counted every request, logged or not.
+      const rendered = registry.render();
+      expect(rendered).toContain('mcp_http_requests_total{route="healthz",status_class="2xx"} 1');
+      expect(rendered).toContain('mcp_http_requests_total{route="readyz",status_class="5xx"} 1');
+    });
   });
 
   describe("bounded whoami probe (resolveTimeoutMs)", () => {

--- a/mcp/tests/http.test.ts
+++ b/mcp/tests/http.test.ts
@@ -5,8 +5,10 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import type { McpClient } from "../src/client.js";
-import { startHttpServer } from "../src/http-server.js";
+import { startHttpServer, type HttpServerOptions } from "../src/http-server.js";
 import { ResolveCache } from "../src/resolve.js";
+import { MetricsRegistry } from "../src/metrics.js";
+import type { Logger } from "../src/logging.js";
 
 const frozenToolNames = JSON.parse(
   readFileSync(new URL("../tool-names.v1.json", import.meta.url), "utf8"),
@@ -123,6 +125,8 @@ describe("HTTP MCP server", () => {
       // Loopback hostnames vary with the random port; allow them all.
       allowedHosts: ["127.0.0.1", "localhost"],
       clientFactory: () => stub,
+      // Keep test output quiet; logging behavior has dedicated tests below.
+      logger: () => {},
     });
     close = c;
     url = `http://127.0.0.1:${port}/mcp`;
@@ -1083,5 +1087,347 @@ describe("HTTP MCP server", () => {
       }),
     });
     expect(res.status).toBe(421);
+  });
+
+  // ── Correlation ids, structured logging, bounded probe ──────────────
+
+  const initializeBody = {
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "x", version: "0" } },
+  };
+
+  function postMcp(body: unknown, headers: Record<string, string> = {}) {
+    return fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        ...headers,
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  type CapturedEvent = Record<string, unknown> & {
+    severity: string;
+    event: string;
+    message: string;
+  };
+
+  function makeLogCapture(): { events: CapturedEvent[]; logger: Logger } {
+    const events: CapturedEvent[] = [];
+    const logger: Logger = (severity, event, message, fields = {}) => {
+      events.push({ severity, event, message, ...fields });
+    };
+    return { events, logger };
+  }
+
+  // restart replaces the shared server with one built from the given opts
+  // (mirrors the ad-hoc teardown pattern used by the tests above).
+  async function restart(opts: Partial<HttpServerOptions> = {}) {
+    await close();
+    const { close: c, port } = await startHttpServer(0, {
+      baseUrl: "http://e2a.local",
+      allowedHosts: ["127.0.0.1", "localhost"],
+      clientFactory: () => stub,
+      logger: () => {},
+      ...opts,
+    });
+    close = c;
+    url = `http://127.0.0.1:${port}/mcp`;
+  }
+
+  describe("correlation ids", () => {
+    it("honors a valid inbound X-Request-Id on the header and the 401 error body", async () => {
+      const res = await postMcp(initializeBody, { "X-Request-Id": "abc-DEF_123" });
+      expect(res.status).toBe(401);
+      expect(res.headers.get("x-request-id")).toBe("abc-DEF_123");
+      const body = await res.json();
+      expect(body.error.message).toBe("missing bearer token"); // unchanged
+      expect(body.error.data).toEqual({ request_id: "abc-DEF_123" });
+    });
+
+    it("mints mcpreq_<12 hex> when the inbound id has invalid characters", async () => {
+      const res = await postMcp(initializeBody, { "X-Request-Id": "bad id with spaces!" });
+      expect(res.status).toBe(401);
+      const id = res.headers.get("x-request-id");
+      expect(id).toMatch(/^mcpreq_[0-9a-f]{12}$/);
+      const body = await res.json();
+      expect(body.error.data.request_id).toBe(id);
+    });
+
+    it("mints a fresh id when no inbound id is present", async () => {
+      const res = await postMcp(initializeBody);
+      expect(res.headers.get("x-request-id")).toMatch(/^mcpreq_[0-9a-f]{12}$/);
+    });
+
+    it("sets X-Request-Id on 405 responses with request_id in the body", async () => {
+      const res = await fetch(url, { method: "GET" });
+      expect(res.status).toBe(405);
+      const id = res.headers.get("x-request-id");
+      expect(id).toMatch(/^mcpreq_[0-9a-f]{12}$/);
+      const body = await res.json();
+      expect(body.error.message).toMatch(/stateless/); // unchanged
+      expect(body.error.data).toEqual({ request_id: id });
+    });
+
+    it("sets X-Request-Id on 500 responses with request_id in the body", async () => {
+      await restart({
+        clientFactory: () => {
+          throw new Error("synthetic factory failure");
+        },
+      });
+      const res = await postMcp(initializeBody, {
+        Authorization: "Bearer e2a_test",
+        "X-Request-Id": "err-500-correlation",
+      });
+      expect(res.status).toBe(500);
+      expect(res.headers.get("x-request-id")).toBe("err-500-correlation");
+      const body = await res.json();
+      expect(body.error.message).toBe("internal server error"); // unchanged
+      expect(body.error.data).toEqual({ request_id: "err-500-correlation" });
+    });
+
+    it("includes request_id in the invalid_token challenge body (expired credential)", async () => {
+      const invalidStub = makeStubClient();
+      invalidStub.whoami = vi.fn(async () => {
+        throw makeHttpError(401);
+      }) as McpClient["whoami"];
+      await restart({ clientFactory: () => invalidStub });
+      const res = await postMcp(initializeBody, {
+        Authorization: "Bearer bogus_token",
+        "X-Request-Id": "expired-cred-1",
+      });
+      expect(res.status).toBe(401);
+      expect(res.headers.get("www-authenticate")).toMatch(/error="invalid_token"/);
+      expect(res.headers.get("x-request-id")).toBe("expired-cred-1");
+      const body = await res.json();
+      expect(body.error.message).toBe("invalid bearer token"); // unchanged
+      expect(body.error.data).toEqual({ request_id: "expired-cred-1" });
+    });
+  });
+
+  describe("structured request logging", () => {
+    it("emits auth_resolution + http_request events sharing one request_id", async () => {
+      const { events, logger } = makeLogCapture();
+      await restart({ logger });
+      const res = await postMcp(
+        { jsonrpc: "2.0", id: 1, method: "tools/list" },
+        { Authorization: "Bearer e2a_test" },
+      );
+      expect(res.status).toBe(200);
+      await res.text();
+
+      const auth = events.find((e) => e.event === "auth_resolution");
+      expect(auth).toMatchObject({ severity: "INFO", result: "resolved", scope: "account" });
+      expect(typeof auth!.duration_ms).toBe("number");
+      expect(auth!.request_id).toBe(res.headers.get("x-request-id"));
+
+      const httpEvent = events.find((e) => e.event === "http_request");
+      expect(httpEvent).toMatchObject({
+        severity: "INFO",
+        route: "mcp",
+        method: "POST",
+        status: 200,
+      });
+      expect(typeof httpEvent!.duration_ms).toBe("number");
+      expect(httpEvent!.request_id).toBe(res.headers.get("x-request-id"));
+      // The bearer itself must never appear in any log field.
+      expect(JSON.stringify(events)).not.toContain("e2a_test");
+    });
+
+    it("logs cache_hit on a repeat request from the same bearer", async () => {
+      const { events, logger } = makeLogCapture();
+      await restart({ logger });
+      for (const id of [1, 2]) {
+        const res = await postMcp(
+          { jsonrpc: "2.0", id, method: "tools/list" },
+          { Authorization: "Bearer repeat_token" },
+        );
+        expect(res.status).toBe(200);
+        await res.text();
+      }
+      const results = events.filter((e) => e.event === "auth_resolution").map((e) => e.result);
+      expect(results).toEqual(["resolved", "cache_hit"]);
+    });
+
+    it("emits tool_execution events for ok and error outcomes", async () => {
+      const { events, logger } = makeLogCapture();
+      const registry = new MetricsRegistry();
+      await restart({ logger, metrics: registry });
+      const { client, transport } = await connect();
+
+      await client.callTool({ name: "list_agents", arguments: {} });
+      vi.mocked(stub.listAgents).mockRejectedValueOnce(new Error("boom"));
+      const failed = await client.callTool({ name: "list_agents", arguments: {} });
+      expect((failed as { isError?: boolean }).isError).toBe(true);
+      await transport.close();
+
+      const toolEvents = events.filter((e) => e.event === "tool_execution");
+      expect(toolEvents).toHaveLength(2);
+      expect(toolEvents[0]).toMatchObject({
+        severity: "INFO",
+        tool: "list_agents",
+        outcome: "ok",
+      });
+      expect(toolEvents[1]).toMatchObject({
+        severity: "WARNING",
+        tool: "list_agents",
+        outcome: "error",
+        error_code: "invalid_request",
+      });
+      // Each callTool is its own POST (stateless), so each carries its own
+      // minted request id.
+      expect(toolEvents[0]!.request_id).toMatch(/^mcpreq_[0-9a-f]{12}$/);
+      expect(toolEvents[1]!.request_id).toMatch(/^mcpreq_[0-9a-f]{12}$/);
+      expect(typeof toolEvents[0]!.duration_ms).toBe("number");
+      // Same seam feeds the metric.
+      const rendered = registry.render();
+      expect(rendered).toContain('mcp_tool_executions_total{outcome="ok",tool="list_agents"} 1');
+      expect(rendered).toContain('mcp_tool_executions_total{outcome="error",tool="list_agents"} 1');
+    });
+
+    it("emits terminal_error (structured, with request_id) on the 500 path", async () => {
+      const { events, logger } = makeLogCapture();
+      await restart({
+        logger,
+        clientFactory: () => {
+          throw new Error("synthetic factory failure");
+        },
+      });
+      const res = await postMcp(initializeBody, { Authorization: "Bearer e2a_test" });
+      expect(res.status).toBe(500);
+      await res.text();
+      const terminal = events.find((e) => e.event === "terminal_error");
+      expect(terminal).toMatchObject({ severity: "ERROR", error: "Error" });
+      expect(terminal!.request_id).toBe(res.headers.get("x-request-id"));
+    });
+
+    it("logs the fail-closed fallback resolution as a WARNING", async () => {
+      const { events, logger } = makeLogCapture();
+      const downStub = makeStubClient();
+      downStub.whoami = vi.fn(async () => {
+        throw new Error("upstream 500");
+      }) as McpClient["whoami"];
+      await restart({ logger, clientFactory: () => downStub });
+      const res = await postMcp(
+        { jsonrpc: "2.0", id: 1, method: "tools/list" },
+        { Authorization: "Bearer e2a_test" },
+      );
+      expect(res.status).toBe(200);
+      await res.text();
+      const auth = events.find((e) => e.event === "auth_resolution");
+      expect(auth).toMatchObject({ severity: "WARNING", result: "fallback", scope: "agent" });
+      expect(typeof auth!.duration_ms).toBe("number");
+    });
+
+    it("the default logger writes single-line JSON events to stderr", async () => {
+      // Explicit undefined overrides restart's silent-logger default, so the
+      // server falls back to its built-in stderr JSON logger.
+      await restart({ logger: undefined });
+      const lines: string[] = [];
+      const spy = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+        lines.push(String(chunk));
+        return true;
+      });
+      try {
+        const res = await postMcp(initializeBody); // 401 missing bearer
+        expect(res.status).toBe(401);
+        await res.text();
+        const httpLine = lines.find((l) => l.includes('"http_request"'));
+        expect(httpLine).toBeDefined();
+        // Single line: trailing newline, no embedded newlines.
+        expect(httpLine!.endsWith("\n")).toBe(true);
+        expect(httpLine!.trimEnd()).not.toContain("\n");
+        const parsed = JSON.parse(httpLine!);
+        expect(parsed).toMatchObject({
+          severity: "INFO",
+          event: "http_request",
+          route: "mcp",
+          method: "POST",
+          status: 401,
+          request_id: res.headers.get("x-request-id"),
+        });
+        expect(typeof parsed.duration_ms).toBe("number");
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  });
+
+  describe("bounded whoami probe (resolveTimeoutMs)", () => {
+    it("a hung whoami falls back fast (fail-closed, logged, metered) instead of holding the POST", async () => {
+      const { events, logger } = makeLogCapture();
+      const registry = new MetricsRegistry();
+      const hungStub = {
+        agentEmail: "",
+        scope: "agent" as const,
+        whoami: vi.fn(() => new Promise<never>(() => {})), // never settles
+      } as unknown as McpClient;
+      // 25ms bound: deterministic — the probe never resolves, so the request
+      // can only complete via the timeout path. Asserts the old ~90s
+      // (30s x 3 SDK attempts) worst case is gone.
+      await restart({
+        resolveTimeoutMs: 25,
+        clientFactory: () => hungStub,
+        logger,
+        metrics: registry,
+      });
+
+      const started = Date.now();
+      const res = await postMcp(
+        { jsonrpc: "2.0", id: 1, method: "tools/list" },
+        { Authorization: "Bearer e2a_test" },
+      );
+      expect(res.status).toBe(200); // fail-closed fallback still serves
+      await res.text();
+      expect(Date.now() - started).toBeLessThan(5_000);
+
+      const auth = events.find((e) => e.event === "auth_resolution");
+      expect(auth).toMatchObject({ severity: "WARNING", result: "fallback", scope: "agent" });
+      expect(registry.render()).toContain('mcp_auth_resolutions_total{result="fallback"} 1');
+    });
+  });
+
+  describe("backend recovery", () => {
+    it("down → fallback served uncached; recovered → next request resolves the real scope", async () => {
+      let down = true;
+      const probe = {
+        agentEmail: "",
+        scope: "account" as const,
+        whoami: vi.fn(async () => {
+          if (down) throw new Error("upstream 500");
+          return { user: "owner@example.com", scope: "account", agentEmail: undefined };
+        }),
+        listMessages: vi.fn(async () => ({ items: [], next_cursor: undefined })),
+      } as unknown as McpClient;
+      const factory = vi.fn(() => probe);
+      await restart({ clientFactory: factory });
+
+      const first = await postMcp(
+        { jsonrpc: "2.0", id: 1, method: "tools/list" },
+        { Authorization: "Bearer e2a_test" },
+      );
+      expect(first.status).toBe(200);
+      await first.text();
+      // Fallback: probe (bearer only), then per-request client pinned to the
+      // least-privilege tier, and NOT cached.
+      expect(factory.mock.calls[0]).toEqual(["e2a_test"]);
+      expect(factory.mock.calls[1]).toEqual(["e2a_test", { scope: "agent" }]);
+
+      down = false;
+      const second = await postMcp(
+        { jsonrpc: "2.0", id: 2, method: "tools/list" },
+        { Authorization: "Bearer e2a_test" },
+      );
+      expect(second.status).toBe(200);
+      await second.text();
+      // The fallback didn't stick: re-probed, now resolved to the real scope.
+      expect(probe.whoami).toHaveBeenCalledTimes(2);
+      expect(factory.mock.calls[2]).toEqual(["e2a_test"]);
+      expect(factory.mock.calls[3]).toEqual(["e2a_test", { scope: "account" }]);
+    });
   });
 });

--- a/mcp/tests/metrics.test.ts
+++ b/mcp/tests/metrics.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MetricsRegistry } from "../src/metrics.js";
+import { startHttpServer } from "../src/http-server.js";
+import type { McpClient } from "../src/client.js";
+
+function makeStubClient(): McpClient {
+  const stub = {
+    agentEmail: "bot@example.com",
+    scope: "account" as const,
+    whoami: vi.fn(async () => ({ user: "owner@example.com", scope: "account", agentEmail: undefined })),
+  };
+  return stub as unknown as McpClient;
+}
+
+describe("MetricsRegistry", () => {
+  it("renders HTTP request counters in Prometheus exposition format", () => {
+    const m = new MetricsRegistry();
+    m.incHttpRequest("mcp", "2xx");
+    m.incHttpRequest("mcp", "2xx");
+    m.incHttpRequest("healthz", "2xx");
+    m.incHttpRequest("mcp", "4xx");
+    const text = m.render();
+    expect(text).toContain("# HELP mcp_http_requests_total ");
+    expect(text).toContain("# TYPE mcp_http_requests_total counter");
+    expect(text).toContain('mcp_http_requests_total{route="mcp",status_class="2xx"} 2');
+    expect(text).toContain('mcp_http_requests_total{route="healthz",status_class="2xx"} 1');
+    expect(text).toContain('mcp_http_requests_total{route="mcp",status_class="4xx"} 1');
+  });
+
+  it("tracks auth resolutions by result", () => {
+    const m = new MetricsRegistry();
+    m.incAuthResolution("cache_hit");
+    m.incAuthResolution("resolved");
+    m.incAuthResolution("invalid");
+    m.incAuthResolution("fallback");
+    const text = m.render();
+    expect(text).toContain("# TYPE mcp_auth_resolutions_total counter");
+    expect(text).toContain('mcp_auth_resolutions_total{result="cache_hit"} 1');
+    expect(text).toContain('mcp_auth_resolutions_total{result="resolved"} 1');
+    expect(text).toContain('mcp_auth_resolutions_total{result="invalid"} 1');
+    expect(text).toContain('mcp_auth_resolutions_total{result="fallback"} 1');
+  });
+
+  it("tracks tool executions by tool and outcome", () => {
+    const m = new MetricsRegistry();
+    m.incToolExecution("list_agents", "ok");
+    m.incToolExecution("send_message", "error");
+    const text = m.render();
+    expect(text).toContain("# TYPE mcp_tool_executions_total counter");
+    expect(text).toContain('mcp_tool_executions_total{outcome="ok",tool="list_agents"} 1');
+    expect(text).toContain('mcp_tool_executions_total{outcome="error",tool="send_message"} 1');
+  });
+
+  it("tracks readiness checks by result", () => {
+    const m = new MetricsRegistry();
+    m.incReadyzCheck("ok");
+    m.incReadyzCheck("degraded");
+    m.incReadyzCheck("degraded");
+    const text = m.render();
+    expect(text).toContain("# TYPE mcp_readyz_checks_total counter");
+    expect(text).toContain('mcp_readyz_checks_total{result="ok"} 1');
+    expect(text).toContain('mcp_readyz_checks_total{result="degraded"} 2');
+  });
+
+  it("observes request durations into a fixed-bucket histogram", () => {
+    const m = new MetricsRegistry();
+    m.observeRequestDuration("mcp", 0.04);
+    m.observeRequestDuration("mcp", 0.6);
+    const text = m.render();
+    expect(text).toContain("# TYPE mcp_http_request_duration_seconds histogram");
+    // 0.04 lands in the 0.05 bucket; both land in every wider bucket.
+    expect(text).toContain('mcp_http_request_duration_seconds_bucket{route="mcp",le="0.025"} 0');
+    expect(text).toContain('mcp_http_request_duration_seconds_bucket{route="mcp",le="0.05"} 1');
+    expect(text).toContain('mcp_http_request_duration_seconds_bucket{route="mcp",le="1"} 2');
+    expect(text).toContain('mcp_http_request_duration_seconds_bucket{route="mcp",le="+Inf"} 2');
+    expect(text).toContain('mcp_http_request_duration_seconds_sum{route="mcp"} 0.64');
+    expect(text).toContain('mcp_http_request_duration_seconds_count{route="mcp"} 2');
+  });
+
+  it("exposes the resolve-cache entry count as a gauge", () => {
+    const m = new MetricsRegistry();
+    m.setResolveCacheEntries(7);
+    const text = m.render();
+    expect(text).toContain("# TYPE mcp_resolve_cache_entries gauge");
+    expect(text).toContain("mcp_resolve_cache_entries 7");
+  });
+
+  it("reset() clears every series back to empty", () => {
+    const m = new MetricsRegistry();
+    m.incHttpRequest("mcp", "2xx");
+    m.incAuthResolution("resolved");
+    m.incToolExecution("list_agents", "ok");
+    m.incReadyzCheck("ok");
+    m.observeRequestDuration("mcp", 0.04);
+    m.setResolveCacheEntries(3);
+    m.reset();
+    const text = m.render();
+    expect(text).not.toContain("mcp_http_requests_total{");
+    expect(text).not.toContain("mcp_auth_resolutions_total{");
+    expect(text).not.toContain("mcp_tool_executions_total{");
+    expect(text).not.toContain("mcp_readyz_checks_total{");
+    expect(text).not.toContain("mcp_http_request_duration_seconds_bucket{");
+    expect(text).toContain("mcp_resolve_cache_entries 0");
+  });
+});
+
+describe("GET /metrics", () => {
+  let close: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    await close?.();
+    close = undefined;
+  });
+
+  it("serves exposition text containing counters incremented by prior requests", async () => {
+    const stub = makeStubClient();
+    const started = await startHttpServer(0, {
+      baseUrl: "http://e2a.local",
+      allowedHosts: ["127.0.0.1", "localhost"],
+      clientFactory: () => stub,
+      logger: () => {},
+    });
+    close = started.close;
+    const origin = `http://127.0.0.1:${started.port}`;
+
+    const health = await fetch(`${origin}/healthz`);
+    expect(health.status).toBe(200);
+    const unauth = await fetch(`${origin}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    });
+    expect(unauth.status).toBe(401);
+    await unauth.text();
+
+    const res = await fetch(`${origin}/metrics`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/plain");
+    const text = await res.text();
+    expect(text).toContain('mcp_http_requests_total{route="healthz",status_class="2xx"} 1');
+    expect(text).toContain('mcp_http_requests_total{route="mcp",status_class="4xx"} 1');
+    expect(text).toContain('mcp_http_request_duration_seconds_count{route="mcp"} 1');
+    expect(text).toContain('mcp_http_request_duration_seconds_count{route="healthz"} 1');
+    // The scrape itself is counted too (after this render, on finish).
+    const second = await fetch(`${origin}/metrics`);
+    expect(await second.text()).toContain('mcp_http_requests_total{route="metrics",status_class="2xx"} 1');
+  });
+
+  it("reports the resolve-cache gauge from live traffic", async () => {
+    const stub = makeStubClient();
+    const started = await startHttpServer(0, {
+      baseUrl: "http://e2a.local",
+      allowedHosts: ["127.0.0.1", "localhost"],
+      clientFactory: () => stub,
+      logger: () => {},
+    });
+    close = started.close;
+    const origin = `http://127.0.0.1:${started.port}`;
+
+    const res = await fetch(`${origin}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        Authorization: "Bearer gauge_token",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    });
+    expect(res.status).toBe(200);
+    await res.text();
+
+    const text = await (await fetch(`${origin}/metrics`)).text();
+    expect(text).toContain("mcp_resolve_cache_entries 1");
+    expect(text).toContain('mcp_auth_resolutions_total{result="resolved"} 1');
+  });
+});

--- a/mcp/tests/readyz.test.ts
+++ b/mcp/tests/readyz.test.ts
@@ -51,7 +51,9 @@ describe("GET /readyz", () => {
     const origin = await start({ fetcher });
     const res = await fetch(`${origin}/readyz`, { headers: { "X-Request-Id": "readyz-check-1" } });
     expect(res.status).toBe(503);
-    expect(res.headers.get("retry-after")).toBe("5");
+    // Retry-After matches the failure-cache TTL (default 10s): retrying
+    // sooner is guaranteed to hit the cached 503.
+    expect(res.headers.get("retry-after")).toBe("10");
     expect(res.headers.get("x-request-id")).toBe("readyz-check-1");
     expect(await res.json()).toEqual({
       ok: false,

--- a/mcp/tests/readyz.test.ts
+++ b/mcp/tests/readyz.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { startHttpServer, type HttpServerOptions } from "../src/http-server.js";
+import { MetricsRegistry } from "../src/metrics.js";
+import type { McpClient } from "../src/client.js";
+
+function makeStubClient(): McpClient {
+  const stub = {
+    agentEmail: "bot@example.com",
+    scope: "account" as const,
+    whoami: vi.fn(async () => ({ user: "owner@example.com", scope: "account", agentEmail: undefined })),
+  };
+  return stub as unknown as McpClient;
+}
+
+describe("GET /readyz", () => {
+  let close: (() => Promise<void>) | undefined;
+
+  afterEach(async () => {
+    await close?.();
+    close = undefined;
+  });
+
+  async function start(readyz?: HttpServerOptions["readyz"], metrics?: MetricsRegistry) {
+    const started = await startHttpServer(0, {
+      baseUrl: "http://e2a.local",
+      allowedHosts: ["127.0.0.1", "localhost"],
+      clientFactory: () => makeStubClient(),
+      logger: () => {},
+      ...(readyz ? { readyz } : {}),
+      ...(metrics ? { metrics } : {}),
+    });
+    close = started.close;
+    return `http://127.0.0.1:${started.port}`;
+  }
+
+  it("returns 200 {ok:true} when the API health probe succeeds", async () => {
+    const fetcher = vi.fn(async () => ({}));
+    const origin = await start({ fetcher });
+    const res = await fetch(`${origin}/readyz`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, checks: { api: "ok" } });
+    expect(fetcher).toHaveBeenCalledWith("http://e2a.local/api/health");
+    // Unauthenticated, like /healthz, but still correlated.
+    expect(res.headers.get("x-request-id")).toMatch(/^mcpreq_[0-9a-f]{12}$/);
+  });
+
+  it("returns 503 + Retry-After when the probe fails, with request_id in the body", async () => {
+    const fetcher = vi.fn(async () => {
+      throw new Error("connection refused");
+    });
+    const origin = await start({ fetcher });
+    const res = await fetch(`${origin}/readyz`, { headers: { "X-Request-Id": "readyz-check-1" } });
+    expect(res.status).toBe(503);
+    expect(res.headers.get("retry-after")).toBe("5");
+    expect(res.headers.get("x-request-id")).toBe("readyz-check-1");
+    expect(await res.json()).toEqual({
+      ok: false,
+      checks: { api: "unreachable" },
+      request_id: "readyz-check-1",
+    });
+  });
+
+  it("treats a probe that never answers (past the timeout) as unreachable", async () => {
+    // The deferred promise never settles, so the only way this request can
+    // complete is the timeout path — deterministic, no fake clock needed.
+    const fetcher = vi.fn(() => new Promise<unknown>(() => {}));
+    const origin = await start({ fetcher, timeoutMs: 1 });
+    const res = await fetch(`${origin}/readyz`);
+    expect(res.status).toBe(503);
+    expect((await res.json()).checks).toEqual({ api: "unreachable" });
+  });
+
+  it("caches the probe result for 10s (injectable clock)", async () => {
+    let now = 0;
+    const fetcher = vi.fn(async () => ({}));
+    const origin = await start({ fetcher, now: () => now });
+
+    const first = await fetch(`${origin}/readyz`);
+    expect(first.status).toBe(200);
+    const second = await fetch(`${origin}/readyz`);
+    expect(second.status).toBe(200);
+    // Two rapid requests share one probe.
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    // Just inside the TTL: still cached.
+    now = 9_999;
+    await fetch(`${origin}/readyz`);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    // Past the TTL: re-probes.
+    now = 10_001;
+    const third = await fetch(`${origin}/readyz`);
+    expect(third.status).toBe(200);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches failures too, then recovers after the TTL", async () => {
+    let now = 0;
+    let down = true;
+    const fetcher = vi.fn(async () => {
+      if (down) throw new Error("api down");
+      return {};
+    });
+    const origin = await start({ fetcher, now: () => now });
+
+    expect((await fetch(`${origin}/readyz`)).status).toBe(503);
+    // A rapid retry serves the cached failure without re-probing.
+    expect((await fetch(`${origin}/readyz`)).status).toBe(503);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    down = false;
+    now = 10_001;
+    expect((await fetch(`${origin}/readyz`)).status).toBe(200);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("increments mcp_readyz_checks_total by result", async () => {
+    const registry = new MetricsRegistry();
+    let down = true;
+    let now = 0;
+    const fetcher = vi.fn(async () => {
+      if (down) throw new Error("api down");
+      return {};
+    });
+    const origin = await start({ fetcher, now: () => now }, registry);
+
+    await fetch(`${origin}/readyz`); // degraded
+    down = false;
+    now = 10_001;
+    await fetch(`${origin}/readyz`); // ok
+
+    const text = registry.render();
+    expect(text).toContain('mcp_readyz_checks_total{result="degraded"} 1');
+    expect(text).toContain('mcp_readyz_checks_total{result="ok"} 1');
+  });
+
+  it("/healthz stays pure liveness even when the API is down", async () => {
+    const fetcher = vi.fn(async () => {
+      throw new Error("api down");
+    });
+    const origin = await start({ fetcher });
+    const res = await fetch(`${origin}/healthz`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    // Liveness never consults the probe.
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+});

--- a/mcp/tests/resolve-principal.test.ts
+++ b/mcp/tests/resolve-principal.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resolvePrincipal } from "../src/http-server.js";
+import type { McpClient } from "../src/client.js";
+
+// Unit-level coverage for the bounded whoami probe (MCP_RESOLVE_TIMEOUT_MS).
+// resolvePrincipal is the exact seam authenticateClient uses, so the timeout
+// behavior proven here is what every POST /mcp gets.
+describe("resolvePrincipal bounded whoami probe", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function factoryReturning(client: Partial<McpClient>) {
+    return vi.fn(() => client as McpClient);
+  }
+
+  it("a hung whoami falls back to least-privilege after resolveTimeoutMs (fake clock, no real wait)", async () => {
+    vi.useFakeTimers();
+    const whoami = vi.fn(() => new Promise<never>(() => {})); // never settles
+    const factory = factoryReturning({ whoami: whoami as McpClient["whoami"] });
+
+    const promise = resolvePrincipal(
+      {
+        baseUrl: "http://e2a.local",
+        allowedHosts: [],
+        resolveTimeoutMs: 5000,
+        clientFactory: factory,
+      },
+      "tok_slow",
+    );
+    const assertion = expect(promise).resolves.toEqual({
+      value: { scope: "agent" },
+      cacheable: false,
+    });
+    // Advance past the probe timeout; the race must settle on its own.
+    await vi.advanceTimersByTimeAsync(5000);
+    await assertion;
+    expect(whoami).toHaveBeenCalledOnce();
+  });
+
+  it("a hung whoami does NOT resolve early (timeout is the trigger, not a fixed delay)", async () => {
+    vi.useFakeTimers();
+    const whoami = vi.fn(() => new Promise<never>(() => {}));
+    const factory = factoryReturning({ whoami: whoami as McpClient["whoami"] });
+
+    let settled = false;
+    const promise = resolvePrincipal(
+      {
+        baseUrl: "http://e2a.local",
+        allowedHosts: [],
+        resolveTimeoutMs: 5000,
+        clientFactory: factory,
+      },
+      "tok_slow",
+    ).then((r) => {
+      settled = true;
+      return r;
+    });
+    await vi.advanceTimersByTimeAsync(4999);
+    expect(settled).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    await promise;
+    expect(settled).toBe(true);
+  });
+
+  it("a fast whoami resolves normally within the timeout", async () => {
+    const whoami = vi.fn(async () => ({
+      user: "owner@example.com",
+      scope: "agent",
+      agentEmail: "bot@example.com",
+    }));
+    const factory = factoryReturning({ whoami: whoami as McpClient["whoami"] });
+    const resolved = await resolvePrincipal(
+      {
+        baseUrl: "http://e2a.local",
+        allowedHosts: [],
+        resolveTimeoutMs: 5000,
+        clientFactory: factory,
+      },
+      "tok_fast",
+    );
+    expect(resolved).toEqual({
+      value: { scope: "agent", agentEmail: "bot@example.com" },
+      cacheable: true,
+    });
+  });
+
+  it("a 401 within the timeout still maps to the invalid-bearer challenge", async () => {
+    const err = new Error("HTTP 401") as Error & { statusCode: number };
+    err.statusCode = 401;
+    const whoami = vi.fn(async () => {
+      throw err;
+    });
+    const factory = factoryReturning({ whoami: whoami as McpClient["whoami"] });
+    await expect(
+      resolvePrincipal(
+        {
+          baseUrl: "http://e2a.local",
+          allowedHosts: [],
+          resolveTimeoutMs: 5000,
+          clientFactory: factory,
+        },
+        "tok_expired",
+      ),
+    ).rejects.toThrowError(/invalid bearer/);
+  });
+
+  it("a non-auth failure within the timeout keeps the existing fail-closed fallback", async () => {
+    const whoami = vi.fn(async () => {
+      throw new Error("upstream 500");
+    });
+    const factory = factoryReturning({ whoami: whoami as McpClient["whoami"] });
+    const resolved = await resolvePrincipal(
+      {
+        baseUrl: "http://e2a.local",
+        allowedHosts: [],
+        resolveTimeoutMs: 5000,
+        clientFactory: factory,
+      },
+      "tok_blip",
+    );
+    expect(resolved).toEqual({ value: { scope: "agent" }, cacheable: false });
+  });
+});


### PR DESCRIPTION
## Summary

Hardens the hosted and self-hosted MCP path for production reliability: the MCP HTTP server gains readiness (`/readyz`), Prometheus metrics (`/metrics`), X-Request-Id correlation, structured request-scoped logs, and a bounded credential-resolution probe; the Go OAuth/DCR error path gains correlation IDs and hint-level failure logging. The stateless transport, tool error contract, and canonical message lifecycle are unchanged. Context: production-trust strategy (MCP OAuth/connection/failure-reporting hardening).

## Client surface checklist

No `/v1` API change — `/oauth2/*` is outside `/v1`, and the OpenAPI doc, generated SDKs, CLI, and tool catalog are untouched (`tool-names.v1.json` unchanged; `scripts/check-repository-text-integrity.sh` passes).

- [x] Go handler + integration tests — additive `request_id` on DCR error bodies + log correlation only; tests extended in `internal/agent/oauth_{register,token}_test.go`
- [x] Tests at each surface above (positive + at least one negative-path / regression case)

**Intentionally skipped:** migration (no schema change), OpenAPI spec + generated types (no `/v1` change), TS/Python SDK (no API change), CLI (unaffected), MCP tool registry (no tool added/removed/renamed), web dashboard (not applicable).

## Operational risk

- **New endpoints** `/readyz` and `/metrics` on the MCP HTTP server — unauthenticated like `/healthz`; metrics carry only counters over closed label vocabularies (no bearer/user data). `/readyz` probes the backend with a 2s timeout and caches the result 10s, so a scraping fleet can't fan out into a probe storm.
- **Behavior change:** the whoami credential-resolution probe is now bounded by `MCP_RESOLVE_TIMEOUT_MS` (default 5000ms) + max 1 retry (was the SDK's 30s × 3-attempt worst case). On timeout the server fails closed to least-privilege agent scope, uncached — same policy as before, now observable via `auth_resolution{result="fallback"}` logs/metrics.
- **OAuth errors:** DCR error bodies gain an additive `request_id` field (RFC 6749/7591 permit extension members); error codes, descriptions, and statuses unchanged. Token-error logs add fosite `hint=`/`debug=` — verified against vendored fosite v0.49 to contain only static category strings, no secrets.
- **Rollback:** single revert; no migrations, no flags.

## Test plan

- [x] `npm test --workspace @e2a/mcp-server` — 277/277 (baseline 237, +40), incl. type tests
- [x] `npm run build --workspace @e2a/mcp-server` — clean
- [x] `go test ./internal/oauth/ ./internal/auth/ ./internal/agent/ -tags integration -p 1` (private DB `e2a_test_mcp`) — all pass
- [x] Deterministic tests, no arbitrary sleeps: DCR error `request_id` (400/429), token error `X-Request-Id` joinability, whoami-probe timeout (fake timers), readyz 200/503 + probe caching (injected clock/fetcher), backend-interruption fallback → recovery, expired-credential 401 challenge, resolve-cache TTL eviction
- [ ] Post-merge: verify `/readyz` + `/metrics` on the staging MCP deployment and wire orchestrator readiness to `/readyz`

🤖 Generated with [Kimi Code](https://www.kimi.com/code)
