### PR TITLE
feat(cli): read-only `e2a doctor` diagnostics command

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ domains/webhooks in the **web dashboard**.
 |---------|-------------|
 | `e2a login` | Open a browser login and save an account-scoped API key to `~/.e2a/config.json` (does not set a default agent — use `e2a config set agent_email` or `--agent`) |
 | `e2a whoami` | Show the key identity: user, scope, bound agent, plan |
+| `e2a doctor` | Read-only diagnostics of the production email path: config, API, agent access, custom-domain DNS (live), MCP, webhooks, outbound SMTP visibility. Never sends mail or mutates anything; `--json` for a versioned report |
 | `e2a agents list\|create\|get` | Manage inboxes (requires an account-scoped key) |
 | `e2a keys create\|list\|delete` | Mint, list, and revoke API keys (requires an account-scoped key) |
 | `e2a protection get\|set` | Show or update an agent's HITL screening/review config |

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## Unreleased
+
+**Added:** `e2a doctor` — read-only diagnostics for the production email path.
+Checks CLI config and credential scope, API connectivity (`GET /v1/info`),
+agent access, custom-domain DNS (live ownership TXT / MX / DKIM / SPF lookups
+against the server-prescribed records, plus an advisory DMARC check and the
+SES sending status), MCP reachability and advertised OAuth metadata, webhook
+configuration and delivery history, and outbound SMTP config visibility for
+self-hosted operators (credential presence only — values are never printed).
+It never sends mail and never mutates DNS, webhooks, or any other resource;
+in particular it does not call `POST /v1/domains/{domain}/verify` (which
+mutates verification state), `POST /v1/webhooks/{id}/test` (which delivers a
+real event), or `POST /v1/agents/{email}/test` (which sends real mail).
+`--json` emits a versioned `e2a.doctor/v1` report. Two exit codes were ADDED
+to the frozen contract (existing codes are unchanged): `8` — diagnostics
+completed with warnings only; `9` — diagnostics found a definite
+configuration failure. `0`/`1`/`4` keep their existing meanings for healthy,
+transient-connectivity, and authentication outcomes. Every network operation
+is bounded by a 5-second timeout.
+
 ## 2.0.0
 
 Current release. A major bump: the published 1.6.0 and this tree had diverged

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -5,10 +5,16 @@
 **Added:** `e2a doctor` — read-only diagnostics for the production email path.
 Checks CLI config and credential scope, API connectivity (`GET /v1/info`),
 agent access, custom-domain DNS (live ownership TXT / MX / DKIM / SPF lookups
-against the server-prescribed records, plus an advisory DMARC check and the
-SES sending status), MCP reachability and advertised OAuth metadata, webhook
-configuration and delivery history, and outbound SMTP config visibility for
-self-hosted operators (credential presence only — values are never printed).
+against the server-prescribed records, plus an advisory warn-only DMARC check
+and the SES sending status), MCP reachability and advertised OAuth metadata,
+webhook configuration and delivery history, and outbound SMTP config
+visibility for self-hosted operators (credential presence only — values are
+never printed). Record matching mirrors the server's own probe semantics:
+ownership TXT is a substring match, SPF is case-insensitive and tolerates
+extended records that keep the prescribed include, and DKIM compares only the
+extracted `p=` payload (extra tags and reordering are fine). An unexpected
+internal error while checking one domain or webhook is reported as a
+`doctor.internal` check instead of aborting the report.
 It never sends mail and never mutates DNS, webhooks, or any other resource;
 in particular it does not call `POST /v1/domains/{domain}/verify` (which
 mutates verification state), `POST /v1/webhooks/{id}/test` (which delivers a

--- a/cli/README.md
+++ b/cli/README.md
@@ -68,6 +68,81 @@ e2a whoami
 e2a whoami --json
 ```
 
+### `e2a doctor`
+
+Read-only diagnostics for the production email path. Doctor never sends mail
+and never mutates anything — no DNS changes, no webhook test deliveries, no
+domain re-verification — so it is safe to run against production at any time
+(including from CI and cron). Every network operation is bounded by a
+5-second timeout.
+
+```bash
+e2a doctor                     # human pass/warn/fail report
+e2a doctor --json              # versioned machine-readable report (e2a.doctor/v1)
+e2a doctor --agent bot@acme.com --domain acme.com
+```
+
+Checks, where applicable: CLI config and credential scope; API connectivity
+and server version (`GET /v1/info`); agent existence and access; for each
+registered custom domain, **live DNS lookups** of the server-prescribed
+records — ownership TXT, inbound MX, DKIM TXT, MAIL FROM MX, SPF TXT — plus
+an advisory DMARC check (warn-only; e2a does not prescribe a DMARC record)
+and the SES sending status; MCP endpoint reachability and advertised OAuth
+metadata; webhook configuration and recent delivery history; and outbound
+SMTP configuration visibility. Webhook *reachability* is reported as an
+explicit skip: the server's webhook test endpoint delivers a real event, so
+no safe non-delivering probe exists — recent delivery history is the
+observed signal instead.
+
+**Hosted (e2a.dev):**
+
+```bash
+e2a doctor --agent bot@acme.com
+# doctor: read-only diagnostics for https://e2a.dev (sends no mail; changes no DNS or webhooks)
+#
+# pass  cli.config            api key from ~/.e2a/config.json; deployment https://e2a.dev
+# pass  api.reachability      server version 1.0.0
+# pass  api.auth              key valid — scope account, plan scale
+# pass  agent.access          agent exists
+# pass  domain.mx             acme.com: MX record found (mx.e2a.dev)
+# warn  domain.dmarc          acme.com: no DMARC record
+#       fix: add TXT record _dmarc.acme.com with value "v=DMARC1; p=none;" …
+# pass  mcp.reachability      endpoint responded (HTTP 405)
+# …
+# 0 fail, 1 warn, 14 pass, 2 skip — warnings (exit 8)
+```
+
+The hosted MCP endpoint (`https://api.e2a.dev/mcp`) is probed automatically
+when the deployment root is `https://e2a.dev`.
+
+**Self-hosted:**
+
+```bash
+E2A_URL=https://mail.internal.example e2a doctor \
+  --mcp-url https://mail.internal.example/mcp
+```
+
+Self-hosted deployments skip the MCP checks unless `--mcp-url` names the MCP
+endpoint. Run doctor **on the server host** to also surface the outbound
+SMTP configuration (`smtp.config` reads `E2A_OUTBOUND_SMTP_HOST`, `_PORT`,
+and `_FROM_DOMAIN` from the environment; credentials are reported only as
+set/not set and never printed).
+
+With `--json`, doctor emits a stable, versioned report (`schema:
+"e2a.doctor/v1"`): top-level `status` (`healthy`/`warnings`/`failed`),
+`exit_code`, a `summary` count, and one entry per check with `id`, `status`
+(`pass`/`warn`/`fail`/`skip`), `reason_code`, optional `target`, a human
+`detail` line, structured `evidence`, and a `remediation` when something
+needs fixing. New check IDs and reason codes may be added over time; existing
+ones are never renamed.
+
+Doctor's exit code separates the failure classes so scripts and CI can
+branch without parsing the report: `0` healthy, `8` warnings only, `9` a
+definite configuration failure (missing DNS record, unregistered domain,
+auto-disabled webhook — retrying cannot fix it), `4` bad or rejected
+credentials, `1` transient connectivity failure (retry may help), `2` usage
+error.
+
 ### `e2a agents`
 
 Manage inboxes (requires an account-scoped key).
@@ -254,7 +329,7 @@ environment-only (`E2A_URL` and `E2A_SHARED_DOMAIN`).
 
 ## Exit codes
 
-`whoami`, `send`, `reply`, `messages`, and `listen` publish a stable, frozen
+`whoami`, `doctor`, `send`, `reply`, `messages`, and `listen` publish a stable, frozen
 exit-code contract (`cli/src/exit.ts`) so shell harnesses can branch on the
 process exit status instead of parsing JSON. Codes are never renumbered —
 only added to.
@@ -269,3 +344,5 @@ only added to.
 | `5` | Permanent request error (not found / invalid / conflict) — do not retry |
 | `6` | Bounded wait (`listen --once --until`) expired with no matching message |
 | `7` | A persisted send failed or returned an unrecognized outcome — do not retry; inspect the returned message id |
+| `8` | Diagnostics (`doctor`) completed with warnings only — nothing broken |
+| `9` | Diagnostics (`doctor`) found a definite configuration failure — do not retry; fix the reported configuration |

--- a/cli/src/__tests__/doctor.test.ts
+++ b/cli/src/__tests__/doctor.test.ts
@@ -1,0 +1,811 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { E2AError } from "@e2a/sdk/v1";
+import type { DoctorCheck, DoctorReport } from "../commands/doctor.js";
+
+const mockLoadConfig = vi.fn();
+vi.mock("../config.js", () => ({
+  loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
+}));
+
+const mockCreateClient = vi.fn();
+vi.mock("../sdk.js", () => ({
+  createClient: (...args: unknown[]) => mockCreateClient(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function baseConfig(overrides: Record<string, unknown> = {}) {
+  return {
+    api_key: "e2a_acct_testkey",
+    api_url: "https://e2a.dev",
+    agent_email: "bot@agents.e2a.dev",
+    shared_domain: "agents.e2a.dev",
+    key_scope: "account",
+    ...overrides,
+  };
+}
+
+function makeAccount(overrides: Record<string, unknown> = {}) {
+  return {
+    user: { id: "usr_1", email: "owner@example.com" },
+    scope: "account",
+    planCode: "free",
+    upgradeUrl: "https://e2a.dev/upgrade",
+    limits: { maxAgents: 5, maxDomains: 1, maxMessagesMonth: 1000, maxStorageBytes: 0 },
+    usage: { agents: 2, domains: 1, messagesMonth: 17, storageBytes: 0 },
+    ...overrides,
+  };
+}
+
+function makeAgent(overrides: Record<string, unknown> = {}) {
+  return {
+    email: "bot@agents.e2a.dev",
+    name: "Bot",
+    domain: "agents.e2a.dev",
+    registeredDomain: "agents.e2a.dev",
+    domainVerified: true,
+    createdAt: new Date("2026-07-01T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+function makeDomain(overrides: Record<string, unknown> = {}) {
+  return {
+    domain: "acme.com",
+    verified: true,
+    verificationToken: "e2a-verify-tok123",
+    agentCount: 1,
+    createdAt: new Date("2026-07-01T00:00:00Z"),
+    sendingStatus: "verified",
+    sendingRamp: { status: "complete" },
+    dnsRecords: [
+      {
+        type: "TXT",
+        name: "acme.com",
+        value: "e2a-verify-tok123",
+        priority: null,
+        purpose: "ownership",
+        status: "verified",
+      },
+      {
+        type: "MX",
+        name: "acme.com",
+        value: "smtp.e2a.dev",
+        priority: 10,
+        purpose: "inbound_mx",
+        status: "verified",
+      },
+      {
+        type: "TXT",
+        name: "sel1._domainkey.acme.com",
+        value: "v=DKIM1; k=rsa; p=MIIBIjAN",
+        priority: null,
+        purpose: "dkim",
+        status: "verified",
+      },
+      {
+        type: "MX",
+        name: "mail.acme.com",
+        value: "feedback-smtp.us-east-1.amazonses.com",
+        priority: 10,
+        purpose: "mail_from_mx",
+        status: "verified",
+      },
+      {
+        type: "TXT",
+        name: "mail.acme.com",
+        value: "v=spf1 include:amazonses.com ~all",
+        priority: null,
+        purpose: "mail_from_spf",
+        status: "verified",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeWebhook(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "wh_1",
+    url: "https://hooks.example.com/e2a",
+    description: "",
+    events: ["email.received"],
+    filters: {},
+    enabled: true,
+    createdAt: new Date("2026-07-01T00:00:00Z"),
+    lastDeliveredAt: new Date("2026-07-22T00:00:00Z"),
+    ...overrides,
+  };
+}
+
+function makeDelivery(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "whd_1",
+    type: "email.received",
+    status: "delivered",
+    attempts: 1,
+    createdAt: new Date("2026-07-22T00:00:00Z"),
+    lastAttemptAt: new Date("2026-07-22T00:00:01Z"),
+    lastStatusCode: 200,
+    ...overrides,
+  };
+}
+
+async function* pager<T>(items: T[]): AsyncGenerator<T> {
+  for (const item of items) yield item;
+}
+
+function fakeClient(overrides: Record<string, unknown> = {}) {
+  return {
+    account: { get: vi.fn(async () => makeAccount()) },
+    agents: { get: vi.fn(async () => makeAgent()) },
+    domains: {
+      list: vi.fn(() => pager([makeDomain()])),
+      get: vi.fn(async () => makeDomain()),
+    },
+    webhooks: {
+      list: vi.fn(() => pager([makeWebhook()])),
+      deliveries: vi.fn(() => pager([makeDelivery()])),
+    },
+    ...overrides,
+  };
+}
+
+// DNS answers matching makeDomain()'s prescribed records, all present.
+function healthyDNS() {
+  return {
+    txt: {
+      "acme.com": ["e2a-verify-tok123", "v=spf1 include:_spf.google.com ~all"],
+      "sel1._domainkey.acme.com": ["v=DKIM1; k=rsa; p=MIIBIjAN"],
+      "mail.acme.com": ["v=spf1 include:amazonses.com ~all"],
+      "_dmarc.acme.com": ["v=DMARC1; p=quarantine"],
+    } as Record<string, string[]>,
+    mx: {
+      "acme.com": [{ exchange: "smtp.e2a.dev", priority: 10 }],
+      "mail.acme.com": [{ exchange: "feedback-smtp.us-east-1.amazonses.com", priority: 10 }],
+    } as Record<string, Array<{ exchange: string; priority: number }>>,
+  };
+}
+
+interface FakeIOOptions {
+  dns?: ReturnType<typeof healthyDNS>;
+  http?: Record<string, { status: number; body: string }>;
+  env?: Record<string, string>;
+  httpError?: string;
+}
+
+function fakeIO(opts: FakeIOOptions = {}) {
+  const dns = opts.dns ?? healthyDNS();
+  const http: Record<string, { status: number; body: string }> = {
+    "https://e2a.dev/v1/info": {
+      status: 200,
+      body: JSON.stringify({
+        version: "1.0.0",
+        shared_domain: "agents.e2a.dev",
+        slug_registration_enabled: true,
+        public_url: "https://e2a.dev",
+      }),
+    },
+    "https://api.e2a.dev/mcp": { status: 405, body: "{}" },
+    "https://api.e2a.dev/.well-known/oauth-protected-resource": {
+      status: 200,
+      body: JSON.stringify({
+        resource: "https://api.e2a.dev/mcp",
+        authorization_servers: ["https://api.e2a.dev"],
+        scopes_supported: ["agent", "account"],
+      }),
+    },
+    ...opts.http,
+  };
+  return {
+    now: () => new Date("2026-07-23T12:00:00.000Z"),
+    cliVersion: () => "0.0.0-test",
+    env: (name: string) => opts.env?.[name],
+    httpGet: vi.fn(async (url: string) => {
+      if (opts.httpError) throw new Error(opts.httpError);
+      const res = http[url];
+      if (!res) throw new Error(`connect ECONNREFUSED (${url})`);
+      return res;
+    }),
+    resolveTxt: vi.fn(async (name: string) => dns.txt[name] ?? []),
+    resolveMx: vi.fn(async (name: string) => dns.mx[name] ?? []),
+  };
+}
+
+function check(report: DoctorReport, id: string, target?: string): DoctorCheck {
+  const found = report.checks.filter(
+    (c) => c.id === id && (target === undefined || c.target === target),
+  );
+  expect(found.length, `expected exactly one check ${id}`).toBe(1);
+  return found[0];
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("doctor", () => {
+  beforeEach(() => {
+    mockLoadConfig.mockReturnValue(baseConfig());
+    mockCreateClient.mockReturnValue(fakeClient());
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("healthy run", () => {
+    it("passes every applicable check and exits 0", async () => {
+      const { runDoctor, EXIT_HEALTHY } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO());
+
+      expect(report.schema).toBe("e2a.doctor/v1");
+      expect(report.status).toBe("healthy");
+      expect(report.exit_code).toBe(EXIT_HEALTHY);
+      expect(report.summary.fail).toBe(0);
+      expect(report.summary.warn).toBe(0);
+
+      expect(check(report, "cli.config").status).toBe("pass");
+      expect(check(report, "api.reachability").status).toBe("pass");
+      expect(check(report, "api.auth").status).toBe("pass");
+      expect(check(report, "agent.access").status).toBe("pass");
+      expect(check(report, "domain.ownership").status).toBe("pass");
+      expect(check(report, "domain.mx").status).toBe("pass");
+      expect(check(report, "domain.dkim").status).toBe("pass");
+      expect(check(report, "domain.mailfrom_mx").status).toBe("pass");
+      expect(check(report, "domain.spf").status).toBe("pass");
+      expect(check(report, "domain.dmarc").status).toBe("pass");
+      expect(check(report, "domain.sending").status).toBe("pass");
+      expect(check(report, "mcp.reachability").status).toBe("pass");
+      expect(check(report, "mcp.auth_metadata").status).toBe("pass");
+      expect(check(report, "webhook.config").status).toBe("pass");
+      expect(check(report, "webhook.delivery").status).toBe("pass");
+      // No safe non-delivering probe exists — always an explicit skip.
+      expect(check(report, "webhook.reachability").status).toBe("skip");
+      expect(check(report, "webhook.reachability").reason_code).toBe("no_safe_probe");
+    });
+
+    it("never calls a mutating endpoint or sends mail", async () => {
+      const client = fakeClient();
+      mockCreateClient.mockReturnValue(client);
+      const io = fakeIO();
+      const { runDoctor } = await import("../commands/doctor.js");
+      await runDoctor({}, io);
+
+      // The client fake exposes ONLY read methods; any write call would throw.
+      // Assert the HTTP probes were GETs to known read-only URLs.
+      for (const call of io.httpGet.mock.calls) {
+        expect(String(call[0])).not.toContain("/test");
+        expect(String(call[0])).not.toContain("/verify");
+      }
+    });
+  });
+
+  describe("auth failures (exit 4)", () => {
+    it("fails cli.config when no API key is configured", async () => {
+      mockLoadConfig.mockReturnValue(baseConfig({ api_key: "" }));
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO());
+
+      const c = check(report, "cli.config");
+      expect(c.status).toBe("fail");
+      expect(c.reason_code).toBe("no_api_key");
+      expect(report.exit_code).toBe(4);
+      expect(report.status).toBe("failed");
+      // Authenticated checks are skipped, not failed.
+      expect(check(report, "api.auth").status).toBe("skip");
+      expect(check(report, "agent.access").status).toBe("skip");
+      // Unauthenticated checks still run.
+      expect(check(report, "api.reachability").status).toBe("pass");
+    });
+
+    it("fails api.auth on a rejected key", async () => {
+      const client = fakeClient();
+      client.account.get = vi.fn(async () => {
+        throw new E2AError({
+          code: "unauthorized", message: "bad key", status: 401, retryable: false,
+        });
+      });
+      mockCreateClient.mockReturnValue(client);
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO());
+
+      const c = check(report, "api.auth");
+      expect(c.status).toBe("fail");
+      expect(c.reason_code).toBe("unauthorized");
+      expect(report.exit_code).toBe(4);
+    });
+
+    it("fails agent.access with forbidden for a foreign agent-bound key", async () => {
+      const client = fakeClient();
+      client.agents.get = vi.fn(async () => {
+        throw new E2AError({
+          code: "forbidden", message: "forbidden", status: 403, retryable: false,
+        });
+      });
+      mockCreateClient.mockReturnValue(client);
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO());
+
+      const c = check(report, "agent.access");
+      expect(c.status).toBe("fail");
+      expect(c.reason_code).toBe("forbidden");
+      expect(report.exit_code).toBe(4);
+    });
+  });
+
+  describe("configuration failures (exit 9)", () => {
+    it("fails agent.access when the agent does not exist", async () => {
+      const client = fakeClient();
+      client.agents.get = vi.fn(async () => {
+        throw new E2AError({
+          code: "not_found", message: "no such agent", status: 404, retryable: false,
+        });
+      });
+      mockCreateClient.mockReturnValue(client);
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO());
+
+      const c = check(report, "agent.access");
+      expect(c.status).toBe("fail");
+      expect(c.reason_code).toBe("agent_not_found");
+      expect(c.remediation).toBeTruthy();
+      expect(report.exit_code).toBe(9);
+    });
+
+    it("fails domain.mx when the live MX record is missing", async () => {
+      const dns = healthyDNS();
+      dns.mx["acme.com"] = [];
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO({ dns }));
+
+      const c = check(report, "domain.mx");
+      expect(c.status).toBe("fail");
+      expect(c.reason_code).toBe("record_missing");
+      expect(c.remediation).toContain("smtp.e2a.dev");
+      expect(report.exit_code).toBe(9);
+    });
+
+    it("fails domain.mx with record_mismatch when a different MX is published", async () => {
+      const dns = healthyDNS();
+      dns.mx["acme.com"] = [{ exchange: "mail.other.com", priority: 5 }];
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO({ dns }));
+
+      const c = check(report, "domain.mx");
+      expect(c.status).toBe("fail");
+      expect(c.reason_code).toBe("record_mismatch");
+      expect((c.evidence as Record<string, unknown>).found).toEqual(["mail.other.com"]);
+    });
+
+    it("fails domain.ownership when the TXT token is absent", async () => {
+      const dns = healthyDNS();
+      dns.txt["acme.com"] = ["v=spf1 include:_spf.google.com ~all"];
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO({ dns }));
+
+      const c = check(report, "domain.ownership");
+      expect(c.status).toBe("fail");
+      expect(c.reason_code).toBe("record_missing");
+      expect(report.exit_code).toBe(9);
+    });
+
+    it("fails domain.sending when SES reports failure", async () => {
+      const client = fakeClient();
+      const domain = makeDomain({ sendingStatus: "failed", sendingError: "DKIM verification failed" });
+      client.domains.list = vi.fn(() => pager([domain]));
+      mockCreateClient.mockReturnValue(client);
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO());
+
+      const c = check(report, "domain.sending");
+      expect(c.status).toBe("fail");
+      expect(c.reason_code).toBe("sending_failed");
+      expect((c.evidence as Record<string, unknown>).sending_error).toBe("DKIM verification failed");
+      expect(report.exit_code).toBe(9);
+    });
+
+    it("fails domain.registered when --domain names an unregistered domain", async () => {
+      const client = fakeClient();
+      client.domains.get = vi.fn(async () => {
+        throw new E2AError({
+          code: "not_found", message: "not found", status: 404, retryable: false,
+        });
+      });
+      mockCreateClient.mockReturnValue(client);
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({ domain: "missing.example" }, fakeIO());
+
+      const c = check(report, "domain.registered");
+      expect(c.status).toBe("fail");
+      expect(c.reason_code).toBe("not_registered");
+      expect(report.exit_code).toBe(9);
+    });
+
+    it("fails webhook.config when a webhook was auto-disabled", async () => {
+      const client = fakeClient();
+      client.webhooks.list = vi.fn(() =>
+        pager([makeWebhook({ enabled: false, autoDisabledAt: new Date("2026-07-20T00:00:00Z") })]),
+      );
+      mockCreateClient.mockReturnValue(client);
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO());
+
+      const c = check(report, "webhook.config");
+      expect(c.status).toBe("fail");
+      expect(c.reason_code).toBe("webhook_auto_disabled");
+      expect(report.exit_code).toBe(9);
+    });
+  });
+
+  describe("transient connectivity failures (exit 1)", () => {
+    it("fails api.reachability when the deployment is unreachable", async () => {
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO({ httpError: "connect ECONNREFUSED" }));
+
+      const c = check(report, "api.reachability");
+      expect(c.status).toBe("fail");
+      expect(c.reason_code).toBe("connection_failed");
+      expect(report.exit_code).toBe(1);
+      // API-dependent checks skip rather than pile on failures.
+      expect(check(report, "api.auth").status).toBe("skip");
+      expect(check(report, "agent.access").status).toBe("skip");
+    });
+
+    it("treats a 5xx from /v1/info as transient", async () => {
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor(
+        {},
+        fakeIO({ http: { "https://e2a.dev/v1/info": { status: 503, body: "unavailable" } } }),
+      );
+
+      const c = check(report, "api.reachability");
+      expect(c.status).toBe("fail");
+      expect(c.reason_code).toBe("http_error");
+      expect(report.exit_code).toBe(1);
+    });
+
+    it("treats a 404 from /v1/info as a configuration failure (wrong E2A_URL)", async () => {
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor(
+        {},
+        fakeIO({ http: { "https://e2a.dev/v1/info": { status: 404, body: "not here" } } }),
+      );
+
+      expect(check(report, "api.reachability").status).toBe("fail");
+      expect(report.exit_code).toBe(9);
+    });
+
+    it("fails domain DNS checks transiently when the resolver errors", async () => {
+      const io = fakeIO();
+      io.resolveMx = vi.fn(async () => {
+        throw new Error("queryMx ETIMEOUT acme.com");
+      });
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, io);
+
+      const c = check(report, "domain.mx");
+      expect(c.status).toBe("fail");
+      expect(c.reason_code).toBe("dns_lookup_failed");
+      expect(report.exit_code).toBe(1);
+    });
+
+    it("prefers auth over config over transient when mixed", async () => {
+      // Unauthorized key + broken DNS: exit must be 4, not 1/9.
+      const client = fakeClient();
+      client.account.get = vi.fn(async () => {
+        throw new E2AError({
+          code: "unauthorized", message: "bad key", status: 401, retryable: false,
+        });
+      });
+      mockCreateClient.mockReturnValue(client);
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO());
+      expect(report.exit_code).toBe(4);
+    });
+  });
+
+  describe("warnings (exit 8)", () => {
+    it("warns on a missing DMARC record without failing the run", async () => {
+      const dns = healthyDNS();
+      delete dns.txt["_dmarc.acme.com"];
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO({ dns }));
+
+      const c = check(report, "domain.dmarc");
+      expect(c.status).toBe("warn");
+      expect(c.reason_code).toBe("no_dmarc_record");
+      expect(c.remediation).toContain("_dmarc.acme.com");
+      expect(report.status).toBe("warnings");
+      expect(report.exit_code).toBe(8);
+    });
+
+    it("warns when sending status is still pending", async () => {
+      const client = fakeClient();
+      client.domains.list = vi.fn(() => pager([makeDomain({ sendingStatus: "pending" })]));
+      mockCreateClient.mockReturnValue(client);
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO());
+
+      expect(check(report, "domain.sending").status).toBe("warn");
+      expect(report.exit_code).toBe(8);
+    });
+
+    it("warns when a webhook is manually disabled", async () => {
+      const client = fakeClient();
+      client.webhooks.list = vi.fn(() => pager([makeWebhook({ enabled: false })]));
+      mockCreateClient.mockReturnValue(client);
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO());
+
+      const c = check(report, "webhook.config");
+      expect(c.status).toBe("warn");
+      expect(c.reason_code).toBe("webhook_disabled");
+      expect(report.exit_code).toBe(8);
+    });
+
+    it("warns when recent webhook deliveries are failing", async () => {
+      const client = fakeClient();
+      client.webhooks.deliveries = vi.fn(() =>
+        pager([makeDelivery({ status: "failed", lastError: "connection refused", lastStatusCode: 0, attempts: 5 })]),
+      );
+      mockCreateClient.mockReturnValue(client);
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO());
+
+      const c = check(report, "webhook.delivery");
+      expect(c.status).toBe("warn");
+      expect(c.reason_code).toBe("deliveries_failing");
+      expect((c.evidence as Record<string, unknown>).last_error).toBe("connection refused");
+    });
+
+    it("warns when MCP auth metadata is missing", async () => {
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor(
+        {},
+        fakeIO({
+          http: {
+            "https://api.e2a.dev/.well-known/oauth-protected-resource": { status: 404, body: "" },
+          },
+        }),
+      );
+
+      const c = check(report, "mcp.auth_metadata");
+      expect(c.status).toBe("warn");
+      expect(c.reason_code).toBe("metadata_missing");
+    });
+  });
+
+  describe("skips", () => {
+    it("skips agent.access when no agent is selected anywhere", async () => {
+      mockLoadConfig.mockReturnValue(baseConfig({ agent_email: "" }));
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO());
+
+      const c = check(report, "agent.access");
+      expect(c.status).toBe("skip");
+      expect(c.reason_code).toBe("no_agent_selected");
+      // A skip alone never degrades the run.
+      expect(report.exit_code).toBe(0);
+    });
+
+    it("skips domain and webhook checks for an agent-scoped key", async () => {
+      const client = fakeClient();
+      client.account.get = vi.fn(async () =>
+        makeAccount({ scope: "agent", agentEmail: "bot@agents.e2a.dev" }),
+      );
+      mockCreateClient.mockReturnValue(client);
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO());
+
+      expect(check(report, "domain.registered").reason_code).toBe("requires_account_scope");
+      expect(check(report, "webhook.config").reason_code).toBe("requires_account_scope");
+      expect(report.exit_code).toBe(0);
+    });
+
+    it("skips domain record checks when only the shared domain is in use", async () => {
+      const client = fakeClient();
+      client.domains.list = vi.fn(() => pager([]));
+      mockCreateClient.mockReturnValue(client);
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO());
+
+      const c = check(report, "domain.registered");
+      expect(c.status).toBe("skip");
+      expect(c.reason_code).toBe("no_domains");
+      expect(report.exit_code).toBe(0);
+    });
+
+    it("skips DKIM when the server has not provisioned a selector yet", async () => {
+      const client = fakeClient();
+      const domain = makeDomain();
+      (domain.dnsRecords as Array<{ purpose: string }>) = (
+        domain.dnsRecords as Array<{ purpose: string }>
+      ).filter((r) => !["dkim", "mail_from_mx", "mail_from_spf"].includes(r.purpose));
+      client.domains.list = vi.fn(() => pager([domain]));
+      mockCreateClient.mockReturnValue(client);
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO());
+
+      expect(check(report, "domain.dkim").reason_code).toBe("not_prescribed");
+      expect(check(report, "domain.spf").reason_code).toBe("not_prescribed");
+      expect(check(report, "domain.mailfrom_mx").reason_code).toBe("not_prescribed");
+    });
+
+    it("skips MCP checks for a self-hosted deployment without --mcp-url", async () => {
+      mockLoadConfig.mockReturnValue(baseConfig({ api_url: "https://mail.selfhosted.io" }));
+      const { runDoctor } = await import("../commands/doctor.js");
+      const io = fakeIO({
+        http: {
+          "https://mail.selfhosted.io/v1/info": {
+            status: 200,
+            body: JSON.stringify({ version: "1.0.0", shared_domain: "", slug_registration_enabled: false }),
+          },
+        },
+      });
+      const report = await runDoctor({}, io);
+
+      expect(check(report, "mcp.reachability").reason_code).toBe("no_mcp_url");
+      expect(check(report, "mcp.auth_metadata").reason_code).toBe("no_mcp_url");
+    });
+
+    it("probes an explicit --mcp-url", async () => {
+      const { runDoctor } = await import("../commands/doctor.js");
+      const io = fakeIO({
+        http: {
+          "https://mcp.selfhosted.io/mcp": { status: 405, body: "{}" },
+          "https://mcp.selfhosted.io/.well-known/oauth-protected-resource": {
+            status: 200,
+            body: JSON.stringify({ authorization_servers: ["https://mcp.selfhosted.io"], scopes_supported: ["agent"] }),
+          },
+        },
+      });
+      const report = await runDoctor({ mcpUrl: "https://mcp.selfhosted.io/mcp" }, io);
+
+      expect(check(report, "mcp.reachability").status).toBe("pass");
+      expect(check(report, "mcp.auth_metadata").status).toBe("pass");
+    });
+
+    it("skips webhook checks when none are configured", async () => {
+      const client = fakeClient();
+      client.webhooks.list = vi.fn(() => pager([]));
+      mockCreateClient.mockReturnValue(client);
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO());
+
+      const c = check(report, "webhook.config");
+      expect(c.status).toBe("skip");
+      expect(c.reason_code).toBe("no_webhooks");
+    });
+  });
+
+  describe("smtp.config (self-hosted outbound visibility)", () => {
+    it("reports outbound SMTP env config without exposing credentials", async () => {
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor(
+        {},
+        fakeIO({
+          env: {
+            E2A_OUTBOUND_SMTP_HOST: "email-smtp.us-east-1.amazonaws.com",
+            E2A_OUTBOUND_SMTP_PORT: "587",
+            E2A_OUTBOUND_SMTP_FROM_DOMAIN: "acme.com",
+            E2A_OUTBOUND_SMTP_USERNAME: "AKIA_SECRET_USER",
+            E2A_OUTBOUND_SMTP_PASSWORD: "supersecret",
+          },
+        }),
+      );
+
+      const c = check(report, "smtp.config");
+      expect(c.status).toBe("pass");
+      const evidence = c.evidence as Record<string, unknown>;
+      expect(evidence.host).toBe("email-smtp.us-east-1.amazonaws.com");
+      expect(evidence.credentials).toBe("set");
+      const serialized = JSON.stringify(report);
+      expect(serialized).not.toContain("supersecret");
+      expect(serialized).not.toContain("AKIA_SECRET_USER");
+    });
+
+    it("skips when no outbound SMTP env is visible", async () => {
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO());
+
+      const c = check(report, "smtp.config");
+      expect(c.status).toBe("skip");
+      expect(c.reason_code).toBe("not_visible");
+    });
+
+    it("warns on partial outbound SMTP config", async () => {
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor(
+        {},
+        fakeIO({ env: { E2A_OUTBOUND_SMTP_HOST: "localhost" } }),
+      );
+
+      const c = check(report, "smtp.config");
+      expect(c.status).toBe("warn");
+      expect(c.reason_code).toBe("smtp_partial");
+    });
+  });
+
+  describe("output", () => {
+    let mockStdout: ReturnType<typeof vi.spyOn>;
+    let mockExitCode: number | undefined;
+
+    beforeEach(() => {
+      mockStdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+      mockExitCode = process.exitCode as number | undefined;
+    });
+
+    afterEach(() => {
+      mockStdout.mockRestore();
+      process.exitCode = mockExitCode;
+    });
+
+    it("human output uses pass/warn/fail lines with remediation", async () => {
+      const dns = healthyDNS();
+      delete dns.txt["_dmarc.acme.com"];
+      dns.mx["acme.com"] = [];
+      const { doctor } = await import("../commands/doctor.js");
+      await doctor({}, fakeIO({ dns }));
+
+      const output = mockStdout.mock.calls.map((c: unknown[]) => c[0]).join("");
+      expect(output).toMatch(/^pass {2}cli\.config/m);
+      expect(output).toMatch(/^fail {2}domain\.mx/m);
+      expect(output).toMatch(/^warn {2}domain\.dmarc/m);
+      expect(output).toContain("fix:");
+      expect(output).toMatch(/exit 9/);
+      expect(process.exitCode).toBe(9);
+    });
+
+    it("--json emits the versioned report and nothing else", async () => {
+      const { doctor } = await import("../commands/doctor.js");
+      await doctor({ json: true }, fakeIO());
+
+      const output = mockStdout.mock.calls.map((c: unknown[]) => c[0]).join("");
+      const parsed = JSON.parse(output);
+      expect(parsed.schema).toBe("e2a.doctor/v1");
+      expect(parsed.exit_code).toBe(0);
+      expect(process.exitCode).toBe(0);
+    });
+  });
+
+  describe("golden fixtures (schema lock)", () => {
+    // The fixtures lock the e2a.doctor/v1 schema: any field rename, removal,
+    // or shape change fails here. To regenerate after an INTENTIONAL additive
+    // change: UPDATE_DOCTOR_FIXTURES=1 npx vitest run src/__tests__/doctor.test.ts
+    async function assertGolden(report: unknown, name: string) {
+      const { readFileSync, writeFileSync } = await import("node:fs");
+      const path = new URL(`./fixtures/${name}`, import.meta.url);
+      if (process.env.UPDATE_DOCTOR_FIXTURES) {
+        writeFileSync(path, JSON.stringify(report, null, 2) + "\n");
+        return;
+      }
+      expect(report).toEqual(JSON.parse(readFileSync(path, "utf-8")));
+    }
+
+    it("healthy hosted run matches the golden fixture", async () => {
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO());
+      await assertGolden(report, "doctor-healthy.json");
+    });
+
+    it("mixed-failure run matches the golden fixture", async () => {
+      mockLoadConfig.mockReturnValue(baseConfig({ agent_email: "" }));
+      const client = fakeClient();
+      client.domains.list = vi.fn(() =>
+        pager([makeDomain({ sendingStatus: "pending" })]),
+      );
+      client.webhooks.list = vi.fn(() => pager([makeWebhook({ enabled: false })]));
+      mockCreateClient.mockReturnValue(client);
+      const dns = healthyDNS();
+      dns.mx["acme.com"] = [{ exchange: "mail.other.com", priority: 5 }];
+      delete dns.txt["_dmarc.acme.com"];
+
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO({ dns }));
+      await assertGolden(report, "doctor-mixed.json");
+    });
+  });
+});

--- a/cli/src/__tests__/doctor.test.ts
+++ b/cli/src/__tests__/doctor.test.ts
@@ -137,20 +137,37 @@ async function* pager<T>(items: T[]): AsyncGenerator<T> {
   for (const item of items) yield item;
 }
 
+/**
+ * Traps any access to a method the fake doesn't define — the fakes define
+ * ONLY read methods, so doctor reaching for create/update/delete/test/verify
+ * (or anything else mutating) explodes loudly in every test, not just the
+ * dedicated read-only test.
+ */
+function readOnly<T extends object>(name: string, obj: T): T {
+  return new Proxy(obj, {
+    get(target, prop, receiver) {
+      if (typeof prop === "string" && !(prop in target)) {
+        throw new Error(`doctor accessed a non-read method: ${name}.${prop}`);
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+}
+
 function fakeClient(overrides: Record<string, unknown> = {}) {
-  return {
-    account: { get: vi.fn(async () => makeAccount()) },
-    agents: { get: vi.fn(async () => makeAgent()) },
-    domains: {
+  return readOnly("client", {
+    account: readOnly("account", { get: vi.fn(async () => makeAccount()) }),
+    agents: readOnly("agents", { get: vi.fn(async () => makeAgent()) }),
+    domains: readOnly("domains", {
       list: vi.fn(() => pager([makeDomain()])),
       get: vi.fn(async () => makeDomain()),
-    },
-    webhooks: {
+    }),
+    webhooks: readOnly("webhooks", {
       list: vi.fn(() => pager([makeWebhook()])),
       deliveries: vi.fn(() => pager([makeDelivery()])),
-    },
+    }),
     ...overrides,
-  };
+  });
 }
 
 // DNS answers matching makeDomain()'s prescribed records, all present.
@@ -268,18 +285,27 @@ describe("doctor", () => {
     });
 
     it("never calls a mutating endpoint or sends mail", async () => {
+      // The fake client defines ONLY read methods behind a Proxy that throws
+      // on any other property access (send/create/delete/test/verify/...),
+      // so a full run completing IS the proof no mutating method was touched.
       const client = fakeClient();
       mockCreateClient.mockReturnValue(client);
       const io = fakeIO();
       const { runDoctor } = await import("../commands/doctor.js");
-      await runDoctor({}, io);
+      const report = await runDoctor({}, io);
+      expect(report.status).toBe("healthy");
 
-      // The client fake exposes ONLY read methods; any write call would throw.
-      // Assert the HTTP probes were GETs to known read-only URLs.
+      // And the raw HTTP probes never hit the side-effecting endpoints.
       for (const call of io.httpGet.mock.calls) {
         expect(String(call[0])).not.toContain("/test");
         expect(String(call[0])).not.toContain("/verify");
       }
+    });
+
+    it("never leaks the API key into the serialized report", async () => {
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO());
+      expect(JSON.stringify(report)).not.toContain("e2a_acct_testkey");
     });
   });
 
@@ -530,16 +556,16 @@ describe("doctor", () => {
       const dns = healthyDNS();
       dns.mx["acme.com"] = []; // config-class failure
       const io = fakeIO({ dns });
-      const realResolveTxt = io.resolveTxt.getMockImplementation()!;
-      io.resolveTxt = vi.fn(async (name: string) => {
-        if (name.startsWith("_dmarc.")) throw new Error("queryTxt ETIMEOUT"); // transient
-        return realResolveTxt(name);
+      const realResolveMx = io.resolveMx.getMockImplementation()!;
+      io.resolveMx = vi.fn(async (name: string) => {
+        if (name === "mail.acme.com") throw new Error("queryMx ETIMEOUT"); // transient
+        return realResolveMx(name);
       });
       const { runDoctor } = await import("../commands/doctor.js");
       const report = await runDoctor({}, io);
 
       expect(check(report, "domain.mx").reason_code).toBe("record_missing");
-      expect(check(report, "domain.dmarc").reason_code).toBe("dns_lookup_failed");
+      expect(check(report, "domain.mailfrom_mx").reason_code).toBe("dns_lookup_failed");
       expect(report.exit_code).toBe(9);
     });
 
@@ -548,10 +574,10 @@ describe("doctor", () => {
       client.webhooks.list = vi.fn(() => pager([makeWebhook({ enabled: false })])); // warn
       mockCreateClient.mockReturnValue(client);
       const io = fakeIO();
-      const realResolveTxt = io.resolveTxt.getMockImplementation()!;
-      io.resolveTxt = vi.fn(async (name: string) => {
-        if (name.startsWith("_dmarc.")) throw new Error("queryTxt ETIMEOUT"); // transient
-        return realResolveTxt(name);
+      const realResolveMx = io.resolveMx.getMockImplementation()!;
+      io.resolveMx = vi.fn(async (name: string) => {
+        if (name === "mail.acme.com") throw new Error("queryMx ETIMEOUT"); // transient
+        return realResolveMx(name);
       });
       const { runDoctor } = await import("../commands/doctor.js");
       const report = await runDoctor({}, io);
@@ -972,6 +998,232 @@ describe("doctor", () => {
       expect(parsed.schema).toBe("e2a.doctor/v1");
       expect(parsed.exit_code).toBe(0);
       expect(process.exitCode).toBe(0);
+    });
+  });
+
+  describe("hardening (review round 2)", () => {
+    it("accepts a DKIM record with extra tags and reordering (p= payload match)", async () => {
+      const dns = healthyDNS();
+      // Same key, different tag order plus extra tags — the server's own
+      // verifier (classifyDKIM) accepts this; doctor must too.
+      dns.txt["sel1._domainkey.acme.com"] = ["k=rsa; s=email; t=s; v=DKIM1; p=MIIBIjAN"];
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO({ dns }));
+
+      expect(check(report, "domain.dkim").status).toBe("pass");
+    });
+
+    it("flags a DKIM record with a different p= payload as a mismatch", async () => {
+      const dns = healthyDNS();
+      dns.txt["sel1._domainkey.acme.com"] = ["v=DKIM1; k=rsa; p=TRUNCATEDKEY"];
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO({ dns }));
+
+      const c = check(report, "domain.dkim");
+      expect(c.status).toBe("fail");
+      expect(c.reason_code).toBe("record_mismatch");
+      expect(report.exit_code).toBe(9);
+    });
+
+    it("accepts an ownership token embedded in a larger TXT record (substring, like the server)", async () => {
+      const dns = healthyDNS();
+      dns.txt["acme.com"] = ["registrar-wrapped e2a-verify-tok123 suffix"];
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO({ dns }));
+
+      expect(check(report, "domain.ownership").status).toBe("pass");
+    });
+
+    it("matches SPF case-insensitively (like the server)", async () => {
+      const dns = healthyDNS();
+      dns.txt["mail.acme.com"] = ["V=SPF1 INCLUDE:AMAZONSES.COM ~ALL"];
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO({ dns }));
+
+      expect(check(report, "domain.spf").status).toBe("pass");
+    });
+
+    it("checks each domain against its own records (per-domain isolation)", async () => {
+      const client = fakeClient();
+      const beta = makeDomain({
+        domain: "beta.io",
+        verificationToken: "e2a-verify-beta",
+        dnsRecords: [
+          { type: "TXT", name: "beta.io", value: "e2a-verify-beta", priority: null, purpose: "ownership", status: "pending" },
+          { type: "MX", name: "beta.io", value: "smtp.e2a.dev", priority: 10, purpose: "inbound_mx", status: "pending" },
+        ],
+      });
+      client.domains.list = vi.fn(() => pager([makeDomain(), beta]));
+      mockCreateClient.mockReturnValue(client);
+      const dns = healthyDNS();
+      dns.txt["beta.io"] = ["e2a-verify-beta"];
+      dns.mx["beta.io"] = []; // beta's MX missing; acme's intact
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO({ dns }));
+
+      expect(check(report, "domain.mx", "acme.com").status).toBe("pass");
+      expect(check(report, "domain.mx", "beta.io").status).toBe("fail");
+      expect(check(report, "domain.ownership", "beta.io").status).toBe("pass");
+      expect(report.exit_code).toBe(9);
+    });
+
+    it("skips domain.sending when the identity is not provisioned (self-hosted)", async () => {
+      const client = fakeClient();
+      client.domains.list = vi.fn(() => pager([makeDomain({ sendingStatus: "none" })]));
+      mockCreateClient.mockReturnValue(client);
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO());
+
+      expect(check(report, "domain.sending").reason_code).toBe("sending_not_provisioned");
+    });
+
+    it("a DMARC lookup error is a warn, never a fail (advisory contract)", async () => {
+      const io = fakeIO();
+      const realResolveTxt = io.resolveTxt.getMockImplementation()!;
+      io.resolveTxt = vi.fn(async (name: string) => {
+        if (name.startsWith("_dmarc.")) throw new Error("queryTxt ETIMEOUT");
+        return realResolveTxt(name);
+      });
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, io);
+
+      const c = check(report, "domain.dmarc");
+      expect(c.status).toBe("warn");
+      expect(c.reason_code).toBe("dns_lookup_failed");
+      expect(report.exit_code).toBe(8);
+    });
+
+    it("fails the run transiently when the delivery-history API errors", async () => {
+      const client = fakeClient();
+      client.webhooks.deliveries = vi.fn(() => {
+        throw new E2AError({
+          code: "internal_error", message: "boom", status: 500, retryable: true,
+        });
+      });
+      mockCreateClient.mockReturnValue(client);
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO());
+
+      expect(check(report, "webhook.delivery").reason_code).toBe("connection_failed");
+      expect(report.exit_code).toBe(1);
+    });
+
+    it("classifies a connection-level agent lookup failure as transient", async () => {
+      const client = fakeClient();
+      client.agents.get = vi.fn(async () => {
+        throw new E2AError({
+          code: "connection_error", message: "socket hang up", status: 0, retryable: true,
+        });
+      });
+      mockCreateClient.mockReturnValue(client);
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO());
+
+      expect(check(report, "agent.access").reason_code).toBe("connection_failed");
+      expect(report.exit_code).toBe(1);
+    });
+
+    it("warns when the webhook list is truncated at the cap", async () => {
+      const client = fakeClient();
+      const many = Array.from({ length: 51 }, (_, i) => makeWebhook({ id: `wh_${i}` }));
+      client.webhooks.list = vi.fn(() => pager(many));
+      mockCreateClient.mockReturnValue(client);
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO());
+
+      const truncation = report.checks.find((c) => c.reason_code === "too_many_webhooks");
+      expect(truncation?.status).toBe("warn");
+    });
+
+    it("survives a malformed domain object and still emits the full report", async () => {
+      const client = fakeClient();
+      const broken = { domain: "broken.example", verified: true, sendingStatus: "verified" };
+      client.domains.list = vi.fn(() =>
+        pager([broken as unknown as ReturnType<typeof makeDomain>, makeDomain()]),
+      );
+      mockCreateClient.mockReturnValue(client);
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO());
+
+      const internal = report.checks.find((c) => c.id === "doctor.internal");
+      expect(internal?.reason_code).toBe("internal_error");
+      // The healthy domain and all later phases still reported.
+      expect(check(report, "domain.mx", "acme.com").status).toBe("pass");
+      expect(check(report, "smtp.config").status).toBe("skip");
+    });
+
+    it("strips basic-auth userinfo from webhook targets in the report", async () => {
+      const client = fakeClient();
+      client.webhooks.list = vi.fn(() =>
+        pager([makeWebhook({ url: "https://user:hunter2@hooks.example.com/e2a" })]),
+      );
+      mockCreateClient.mockReturnValue(client);
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO());
+
+      expect(check(report, "webhook.config").target).toBe("https://hooks.example.com/e2a");
+      expect(JSON.stringify(report)).not.toContain("hunter2");
+    });
+
+    it("fails api.reachability as config when E2A_URL is not an absolute http(s) URL", async () => {
+      mockLoadConfig.mockReturnValue(baseConfig({ api_url: "e2a.dev" }));
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO());
+
+      const c = check(report, "api.reachability");
+      expect(c.reason_code).toBe("invalid_deployment_url");
+      expect(report.exit_code).toBe(9);
+    });
+
+    it("treats 429 from /v1/info as transient, not config", async () => {
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor(
+        {},
+        fakeIO({ http: { "https://e2a.dev/v1/info": { status: 429, body: "slow down" } } }),
+      );
+
+      expect(check(report, "api.reachability").reason_code).toBe("http_error");
+      expect(report.exit_code).toBe(1);
+    });
+
+    it("treats a 5xx from the MCP endpoint as transient, not a pass", async () => {
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor(
+        {},
+        fakeIO({ http: { "https://api.e2a.dev/mcp": { status: 502, body: "" } } }),
+      );
+
+      const c = check(report, "mcp.reachability");
+      expect(c.status).toBe("fail");
+      expect(c.reason_code).toBe("http_error");
+      expect(report.exit_code).toBe(1);
+    });
+
+    it("normalizes a trailing-slash E2A_URL into the SDK client too", async () => {
+      mockLoadConfig.mockReturnValue(baseConfig({ api_url: "https://e2a.dev/" }));
+      const { runDoctor } = await import("../commands/doctor.js");
+      await runDoctor({}, fakeIO());
+
+      const [, configArg] = mockCreateClient.mock.calls[0] as [unknown, { api_url: string }];
+      expect(configArg.api_url).toBe("https://e2a.dev");
+    });
+
+    it("strips terminal control characters from human output", async () => {
+      const client = fakeClient();
+      client.webhooks.list = vi.fn(() =>
+        pager([makeWebhook({ id: "wh_\u001b[31mevil\u001b[0m" })]),
+      );
+      mockCreateClient.mockReturnValue(client);
+      const mockStdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+      const savedExit = process.exitCode as number | undefined;
+      const { doctor } = await import("../commands/doctor.js");
+      await doctor({}, fakeIO());
+      const output = mockStdout.mock.calls.map((c: unknown[]) => c[0]).join("");
+      mockStdout.mockRestore();
+      process.exitCode = savedExit;
+
+      expect(output).not.toContain("\u001b");
+      expect(output).toContain("wh_[31mevil[0m"); // escapes gone, text kept  
     });
   });
 

--- a/cli/src/__tests__/doctor.test.ts
+++ b/cli/src/__tests__/doctor.test.ts
@@ -507,6 +507,210 @@ describe("doctor", () => {
     });
   });
 
+  describe("exit precedence ladder (each rung individually)", () => {
+    it("auth beats config: forbidden agent + missing MX exits 4", async () => {
+      const client = fakeClient();
+      client.agents.get = vi.fn(async () => {
+        throw new E2AError({
+          code: "forbidden", message: "forbidden", status: 403, retryable: false,
+        });
+      });
+      mockCreateClient.mockReturnValue(client);
+      const dns = healthyDNS();
+      dns.mx["acme.com"] = []; // config-class failure alongside the auth one
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO({ dns }));
+
+      expect(check(report, "agent.access").status).toBe("fail");
+      expect(check(report, "domain.mx").status).toBe("fail");
+      expect(report.exit_code).toBe(4);
+    });
+
+    it("config beats transient: missing MX + DNS timeout exits 9", async () => {
+      const dns = healthyDNS();
+      dns.mx["acme.com"] = []; // config-class failure
+      const io = fakeIO({ dns });
+      const realResolveTxt = io.resolveTxt.getMockImplementation()!;
+      io.resolveTxt = vi.fn(async (name: string) => {
+        if (name.startsWith("_dmarc.")) throw new Error("queryTxt ETIMEOUT"); // transient
+        return realResolveTxt(name);
+      });
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, io);
+
+      expect(check(report, "domain.mx").reason_code).toBe("record_missing");
+      expect(check(report, "domain.dmarc").reason_code).toBe("dns_lookup_failed");
+      expect(report.exit_code).toBe(9);
+    });
+
+    it("transient beats warn: DNS timeout + disabled webhook exits 1", async () => {
+      const client = fakeClient();
+      client.webhooks.list = vi.fn(() => pager([makeWebhook({ enabled: false })])); // warn
+      mockCreateClient.mockReturnValue(client);
+      const io = fakeIO();
+      const realResolveTxt = io.resolveTxt.getMockImplementation()!;
+      io.resolveTxt = vi.fn(async (name: string) => {
+        if (name.startsWith("_dmarc.")) throw new Error("queryTxt ETIMEOUT"); // transient
+        return realResolveTxt(name);
+      });
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, io);
+
+      expect(check(report, "webhook.config").status).toBe("warn");
+      expect(report.exit_code).toBe(1);
+    });
+  });
+
+  describe("hardening (review findings)", () => {
+    it("a malformed --mcp-url never crashes runDoctor and classifies as config", async () => {
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({ mcpUrl: "api.e2a.dev/mcp" }, fakeIO());
+
+      expect(check(report, "mcp.reachability").reason_code).toBe("invalid_mcp_url");
+      expect(check(report, "mcp.auth_metadata").reason_code).toBe("invalid_mcp_url");
+      expect(report.exit_code).toBe(9);
+    });
+
+    it("doctor rejects a malformed --mcp-url as a usage error (exit 2)", async () => {
+      const mockExit = vi.spyOn(process, "exit").mockImplementation(() => {
+        throw new Error("process.exit");
+      });
+      const mockStderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+      const { doctor } = await import("../commands/doctor.js");
+      await expect(doctor({ mcpUrl: "not a url" }, fakeIO())).rejects.toThrow("process.exit");
+      expect(mockExit).toHaveBeenCalledWith(2);
+      mockExit.mockRestore();
+      mockStderr.mockRestore();
+    });
+
+    it("HTTP 404 at the MCP URL is a routing failure, not a pass", async () => {
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor(
+        {},
+        fakeIO({ http: { "https://api.e2a.dev/mcp": { status: 404, body: "" } } }),
+      );
+
+      const c = check(report, "mcp.reachability");
+      expect(c.status).toBe("fail");
+      expect(c.reason_code).toBe("not_routed");
+      expect(report.exit_code).toBe(9);
+    });
+
+    it("fails mcp.reachability transiently when the endpoint is unreachable", async () => {
+      const io = fakeIO();
+      const realHttpGet = io.httpGet.getMockImplementation()!;
+      io.httpGet = vi.fn(async (url: string) => {
+        if (url === "https://api.e2a.dev/mcp") throw new Error("connect ETIMEDOUT");
+        return realHttpGet(url);
+      });
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, io);
+
+      expect(check(report, "mcp.reachability").reason_code).toBe("connection_failed");
+      expect(report.exit_code).toBe(1);
+    });
+
+    it("warns on invalid MCP auth metadata (no authorization_servers)", async () => {
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor(
+        {},
+        fakeIO({
+          http: {
+            "https://api.e2a.dev/.well-known/oauth-protected-resource": { status: 200, body: "{}" },
+          },
+        }),
+      );
+
+      expect(check(report, "mcp.auth_metadata").reason_code).toBe("metadata_invalid");
+    });
+
+    it("a trailing slash on the deployment URL still detects hosted and probes cleanly", async () => {
+      mockLoadConfig.mockReturnValue(baseConfig({ api_url: "https://e2a.dev/" }));
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO());
+
+      expect(check(report, "api.reachability").status).toBe("pass");
+      expect(check(report, "mcp.reachability").status).toBe("pass");
+      expect(report.deployment_url).toBe("https://e2a.dev");
+    });
+
+    it("accepts a legitimately extended SPF record (inclusion, not equality)", async () => {
+      const dns = healthyDNS();
+      dns.txt["mail.acme.com"] = ["v=spf1 include:amazonses.com include:_spf.corp.example ~all"];
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO({ dns }));
+
+      expect(check(report, "domain.spf").status).toBe("pass");
+    });
+
+    it("flags an SPF record that lost the prescribed include as a mismatch", async () => {
+      const dns = healthyDNS();
+      dns.txt["mail.acme.com"] = ["v=spf1 include:other.example ~all"];
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO({ dns }));
+
+      const c = check(report, "domain.spf");
+      expect(c.status).toBe("fail");
+      expect(c.reason_code).toBe("record_mismatch");
+    });
+
+    it("treats a 200 non-JSON /v1/info body as a config failure (wrong E2A_URL)", async () => {
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor(
+        {},
+        fakeIO({ http: { "https://e2a.dev/v1/info": { status: 200, body: "<html>welcome</html>" } } }),
+      );
+
+      const c = check(report, "api.reachability");
+      expect(c.reason_code).toBe("unexpected_response");
+      expect(report.exit_code).toBe(9);
+    });
+
+    it("warns on a plain-HTTP webhook URL", async () => {
+      const client = fakeClient();
+      client.webhooks.list = vi.fn(() => pager([makeWebhook({ url: "http://hooks.example.com/e2a" })]));
+      mockCreateClient.mockReturnValue(client);
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO());
+
+      expect(check(report, "webhook.config").reason_code).toBe("insecure_url");
+      expect(report.exit_code).toBe(8);
+    });
+
+    it("skips webhook.delivery when no delivery has completed yet", async () => {
+      const client = fakeClient();
+      client.webhooks.deliveries = vi.fn(() => pager([]));
+      mockCreateClient.mockReturnValue(client);
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO());
+
+      expect(check(report, "webhook.delivery").reason_code).toBe("no_deliveries");
+    });
+
+    it("reports the key source as E2A_API_KEY when set via environment", async () => {
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, fakeIO({ env: { E2A_API_KEY: "e2a_acct_envkey" } }));
+
+      const c = check(report, "cli.config");
+      expect((c.evidence as Record<string, unknown>).key_source).toBe("E2A_API_KEY");
+    });
+
+    it("warns when the domain list is truncated at the cap", async () => {
+      const client = fakeClient();
+      const many = Array.from({ length: 51 }, (_, i) => makeDomain({ domain: `d${i}.example` }));
+      client.domains.list = vi.fn(() => pager(many));
+      mockCreateClient.mockReturnValue(client);
+      const io = fakeIO();
+      // Domain names beyond acme.com have no DNS fixtures; resolve empty is fine —
+      // this test only asserts the truncation warning exists.
+      const { runDoctor } = await import("../commands/doctor.js");
+      const report = await runDoctor({}, io);
+
+      const truncation = report.checks.find((c) => c.reason_code === "too_many_domains");
+      expect(truncation?.status).toBe("warn");
+    });
+  });
+
   describe("warnings (exit 8)", () => {
     it("warns on a missing DMARC record without failing the run", async () => {
       const dns = healthyDNS();

--- a/cli/src/__tests__/exit.test.ts
+++ b/cli/src/__tests__/exit.test.ts
@@ -12,3 +12,18 @@ describe("API error exit classification", () => {
     expect(exitCodeForAPIError({ code: "rate_limited", retryable: true })).toBe(EXIT.ERROR);
   });
 });
+
+describe("exit code contract", () => {
+  it("published values are frozen — add codes, never renumber", () => {
+    expect(EXIT.OK).toBe(0);
+    expect(EXIT.ERROR).toBe(1);
+    expect(EXIT.USAGE).toBe(2);
+    expect(EXIT.HELD).toBe(3);
+    expect(EXIT.AUTH).toBe(4);
+    expect(EXIT.REQUEST).toBe(5);
+    expect(EXIT.TIMEOUT).toBe(6);
+    expect(EXIT.SEND_OUTCOME).toBe(7);
+    expect(EXIT.WARN).toBe(8);
+    expect(EXIT.CONFIG).toBe(9);
+  });
+});

--- a/cli/src/__tests__/fixtures/doctor-healthy.json
+++ b/cli/src/__tests__/fixtures/doctor-healthy.json
@@ -1,0 +1,226 @@
+{
+  "schema": "e2a.doctor/v1",
+  "generated_at": "2026-07-23T12:00:00.000Z",
+  "cli_version": "0.0.0-test",
+  "deployment_url": "https://e2a.dev",
+  "status": "healthy",
+  "exit_code": 0,
+  "summary": {
+    "pass": 16,
+    "warn": 0,
+    "fail": 0,
+    "skip": 2
+  },
+  "checks": [
+    {
+      "id": "cli.config",
+      "title": "CLI configuration",
+      "status": "pass",
+      "reason_code": "ok",
+      "detail": "api key from ~/.e2a/config.json; deployment https://e2a.dev",
+      "evidence": {
+        "deployment_url": "https://e2a.dev",
+        "key_source": "~/.e2a/config.json",
+        "key_scope": "account"
+      }
+    },
+    {
+      "id": "api.reachability",
+      "title": "API reachability",
+      "status": "pass",
+      "reason_code": "ok",
+      "detail": "server version 1.0.0",
+      "target": "https://e2a.dev",
+      "evidence": {
+        "version": "1.0.0",
+        "shared_domain": "agents.e2a.dev",
+        "public_url": "https://e2a.dev"
+      }
+    },
+    {
+      "id": "api.auth",
+      "title": "API credentials",
+      "status": "pass",
+      "reason_code": "ok",
+      "detail": "key valid — scope account, plan free",
+      "evidence": {
+        "user_email": "owner@example.com",
+        "scope": "account",
+        "plan_code": "free"
+      }
+    },
+    {
+      "id": "agent.access",
+      "title": "Agent access",
+      "status": "pass",
+      "reason_code": "ok",
+      "detail": "agent exists",
+      "target": "bot@agents.e2a.dev",
+      "evidence": {
+        "email": "bot@agents.e2a.dev",
+        "domain": "agents.e2a.dev",
+        "domain_verified": true
+      }
+    },
+    {
+      "id": "domain.registered",
+      "title": "Domain registration",
+      "status": "pass",
+      "reason_code": "ok",
+      "detail": "acme.com: registered, verified",
+      "target": "acme.com",
+      "evidence": {
+        "verified": true,
+        "sending_status": "verified",
+        "agent_count": 1
+      }
+    },
+    {
+      "id": "domain.ownership",
+      "title": "Ownership TXT record",
+      "status": "pass",
+      "reason_code": "ok",
+      "detail": "acme.com: TXT record found at acme.com",
+      "target": "acme.com",
+      "evidence": {
+        "expected": "e2a-verify-tok123",
+        "server_status": "verified"
+      }
+    },
+    {
+      "id": "domain.mx",
+      "title": "Inbound MX record",
+      "status": "pass",
+      "reason_code": "ok",
+      "detail": "acme.com: MX record found (smtp.e2a.dev)",
+      "target": "acme.com",
+      "evidence": {
+        "expected": "smtp.e2a.dev",
+        "server_status": "verified"
+      }
+    },
+    {
+      "id": "domain.dkim",
+      "title": "DKIM TXT record",
+      "status": "pass",
+      "reason_code": "ok",
+      "detail": "acme.com: TXT record found at sel1._domainkey.acme.com",
+      "target": "sel1._domainkey.acme.com",
+      "evidence": {
+        "expected": "v=DKIM1; k=rsa; p=MIIBIjAN",
+        "server_status": "verified"
+      }
+    },
+    {
+      "id": "domain.mailfrom_mx",
+      "title": "MAIL FROM MX record",
+      "status": "pass",
+      "reason_code": "ok",
+      "detail": "acme.com: MX record found (feedback-smtp.us-east-1.amazonses.com)",
+      "target": "mail.acme.com",
+      "evidence": {
+        "expected": "feedback-smtp.us-east-1.amazonses.com",
+        "server_status": "verified"
+      }
+    },
+    {
+      "id": "domain.spf",
+      "title": "SPF TXT record",
+      "status": "pass",
+      "reason_code": "ok",
+      "detail": "acme.com: TXT record found at mail.acme.com",
+      "target": "mail.acme.com",
+      "evidence": {
+        "expected": "v=spf1 include:amazonses.com ~all",
+        "server_status": "verified"
+      }
+    },
+    {
+      "id": "domain.dmarc",
+      "title": "DMARC record (advisory)",
+      "status": "pass",
+      "reason_code": "ok",
+      "detail": "acme.com: DMARC record present",
+      "target": "_dmarc.acme.com",
+      "evidence": {
+        "record": "v=DMARC1; p=quarantine"
+      }
+    },
+    {
+      "id": "domain.sending",
+      "title": "Sending status",
+      "status": "pass",
+      "reason_code": "ok",
+      "detail": "acme.com: sending identity verified",
+      "target": "acme.com"
+    },
+    {
+      "id": "mcp.reachability",
+      "title": "MCP reachability",
+      "status": "pass",
+      "reason_code": "ok",
+      "detail": "endpoint responded (HTTP 405)",
+      "target": "https://api.e2a.dev/mcp",
+      "evidence": {
+        "http_status": 405
+      }
+    },
+    {
+      "id": "mcp.auth_metadata",
+      "title": "MCP auth metadata",
+      "status": "pass",
+      "reason_code": "ok",
+      "detail": "advertises https://api.e2a.dev",
+      "target": "https://api.e2a.dev/.well-known/oauth-protected-resource",
+      "evidence": {
+        "authorization_servers": [
+          "https://api.e2a.dev"
+        ],
+        "scopes_supported": [
+          "agent",
+          "account"
+        ]
+      }
+    },
+    {
+      "id": "webhook.config",
+      "title": "Webhook configuration",
+      "status": "pass",
+      "reason_code": "ok",
+      "detail": "wh_1: enabled, 1 event type(s)",
+      "target": "https://hooks.example.com/e2a",
+      "evidence": {
+        "id": "wh_1",
+        "events": [
+          "email.received"
+        ]
+      }
+    },
+    {
+      "id": "webhook.delivery",
+      "title": "Webhook delivery history",
+      "status": "pass",
+      "reason_code": "ok",
+      "detail": "wh_1: latest delivery succeeded",
+      "target": "wh_1",
+      "evidence": {
+        "last_status": "delivered",
+        "last_status_code": 200
+      }
+    },
+    {
+      "id": "webhook.reachability",
+      "title": "Webhook reachability",
+      "status": "skip",
+      "reason_code": "no_safe_probe",
+      "detail": "skipped: no safe non-delivering probe exists (POST /v1/webhooks/{id}/test delivers a real event) — webhook.delivery reflects observed reachability"
+    },
+    {
+      "id": "smtp.config",
+      "title": "Outbound SMTP configuration",
+      "status": "skip",
+      "reason_code": "not_visible",
+      "detail": "no E2A_OUTBOUND_SMTP_* environment visible from this machine (normal for hosted e2a; self-hosted operators should run doctor on the server host)"
+    }
+  ]
+}

--- a/cli/src/__tests__/fixtures/doctor-mixed.json
+++ b/cli/src/__tests__/fixtures/doctor-mixed.json
@@ -1,0 +1,222 @@
+{
+  "schema": "e2a.doctor/v1",
+  "generated_at": "2026-07-23T12:00:00.000Z",
+  "cli_version": "0.0.0-test",
+  "deployment_url": "https://e2a.dev",
+  "status": "failed",
+  "exit_code": 9,
+  "summary": {
+    "pass": 11,
+    "warn": 3,
+    "fail": 1,
+    "skip": 3
+  },
+  "checks": [
+    {
+      "id": "cli.config",
+      "title": "CLI configuration",
+      "status": "pass",
+      "reason_code": "ok",
+      "detail": "api key from ~/.e2a/config.json; deployment https://e2a.dev",
+      "evidence": {
+        "deployment_url": "https://e2a.dev",
+        "key_source": "~/.e2a/config.json",
+        "key_scope": "account"
+      }
+    },
+    {
+      "id": "api.reachability",
+      "title": "API reachability",
+      "status": "pass",
+      "reason_code": "ok",
+      "detail": "server version 1.0.0",
+      "target": "https://e2a.dev",
+      "evidence": {
+        "version": "1.0.0",
+        "shared_domain": "agents.e2a.dev",
+        "public_url": "https://e2a.dev"
+      }
+    },
+    {
+      "id": "api.auth",
+      "title": "API credentials",
+      "status": "pass",
+      "reason_code": "ok",
+      "detail": "key valid — scope account, plan free",
+      "evidence": {
+        "user_email": "owner@example.com",
+        "scope": "account",
+        "plan_code": "free"
+      }
+    },
+    {
+      "id": "agent.access",
+      "title": "Agent access",
+      "status": "skip",
+      "reason_code": "no_agent_selected",
+      "detail": "skipped: no agent selected",
+      "remediation": "pass --agent, set E2A_AGENT_EMAIL, or run `e2a config set agent_email <email>`"
+    },
+    {
+      "id": "domain.registered",
+      "title": "Domain registration",
+      "status": "pass",
+      "reason_code": "ok",
+      "detail": "acme.com: registered, verified",
+      "target": "acme.com",
+      "evidence": {
+        "verified": true,
+        "sending_status": "pending",
+        "agent_count": 1
+      }
+    },
+    {
+      "id": "domain.ownership",
+      "title": "Ownership TXT record",
+      "status": "pass",
+      "reason_code": "ok",
+      "detail": "acme.com: TXT record found at acme.com",
+      "target": "acme.com",
+      "evidence": {
+        "expected": "e2a-verify-tok123",
+        "server_status": "verified"
+      }
+    },
+    {
+      "id": "domain.mx",
+      "title": "Inbound MX record",
+      "status": "fail",
+      "reason_code": "record_mismatch",
+      "detail": "acme.com: MX at acme.com points elsewhere",
+      "target": "acme.com",
+      "evidence": {
+        "expected": "smtp.e2a.dev",
+        "found": [
+          "mail.other.com"
+        ],
+        "server_status": "verified"
+      },
+      "remediation": "add MX record acme.com → smtp.e2a.dev (priority 10)"
+    },
+    {
+      "id": "domain.dkim",
+      "title": "DKIM TXT record",
+      "status": "pass",
+      "reason_code": "ok",
+      "detail": "acme.com: TXT record found at sel1._domainkey.acme.com",
+      "target": "sel1._domainkey.acme.com",
+      "evidence": {
+        "expected": "v=DKIM1; k=rsa; p=MIIBIjAN",
+        "server_status": "verified"
+      }
+    },
+    {
+      "id": "domain.mailfrom_mx",
+      "title": "MAIL FROM MX record",
+      "status": "pass",
+      "reason_code": "ok",
+      "detail": "acme.com: MX record found (feedback-smtp.us-east-1.amazonses.com)",
+      "target": "mail.acme.com",
+      "evidence": {
+        "expected": "feedback-smtp.us-east-1.amazonses.com",
+        "server_status": "verified"
+      }
+    },
+    {
+      "id": "domain.spf",
+      "title": "SPF TXT record",
+      "status": "pass",
+      "reason_code": "ok",
+      "detail": "acme.com: TXT record found at mail.acme.com",
+      "target": "mail.acme.com",
+      "evidence": {
+        "expected": "v=spf1 include:amazonses.com ~all",
+        "server_status": "verified"
+      }
+    },
+    {
+      "id": "domain.dmarc",
+      "title": "DMARC record (advisory)",
+      "status": "warn",
+      "reason_code": "no_dmarc_record",
+      "detail": "acme.com: no DMARC record",
+      "target": "_dmarc.acme.com",
+      "remediation": "add TXT record _dmarc.acme.com with value \"v=DMARC1; p=none;\" and tighten the policy once reports look clean"
+    },
+    {
+      "id": "domain.sending",
+      "title": "Sending status",
+      "status": "warn",
+      "reason_code": "sending_pending",
+      "detail": "acme.com: sending identity still pending",
+      "target": "acme.com",
+      "remediation": "publish the prescribed DNS records and allow time for propagation, then re-run doctor"
+    },
+    {
+      "id": "mcp.reachability",
+      "title": "MCP reachability",
+      "status": "pass",
+      "reason_code": "ok",
+      "detail": "endpoint responded (HTTP 405)",
+      "target": "https://api.e2a.dev/mcp",
+      "evidence": {
+        "http_status": 405
+      }
+    },
+    {
+      "id": "mcp.auth_metadata",
+      "title": "MCP auth metadata",
+      "status": "pass",
+      "reason_code": "ok",
+      "detail": "advertises https://api.e2a.dev",
+      "target": "https://api.e2a.dev/.well-known/oauth-protected-resource",
+      "evidence": {
+        "authorization_servers": [
+          "https://api.e2a.dev"
+        ],
+        "scopes_supported": [
+          "agent",
+          "account"
+        ]
+      }
+    },
+    {
+      "id": "webhook.config",
+      "title": "Webhook configuration",
+      "status": "warn",
+      "reason_code": "webhook_disabled",
+      "detail": "wh_1: disabled",
+      "target": "https://hooks.example.com/e2a",
+      "evidence": {
+        "id": "wh_1"
+      },
+      "remediation": "events are not being delivered — re-enable it if that is unintended"
+    },
+    {
+      "id": "webhook.delivery",
+      "title": "Webhook delivery history",
+      "status": "pass",
+      "reason_code": "ok",
+      "detail": "wh_1: latest delivery succeeded",
+      "target": "wh_1",
+      "evidence": {
+        "last_status": "delivered",
+        "last_status_code": 200
+      }
+    },
+    {
+      "id": "webhook.reachability",
+      "title": "Webhook reachability",
+      "status": "skip",
+      "reason_code": "no_safe_probe",
+      "detail": "skipped: no safe non-delivering probe exists (POST /v1/webhooks/{id}/test delivers a real event) — webhook.delivery reflects observed reachability"
+    },
+    {
+      "id": "smtp.config",
+      "title": "Outbound SMTP configuration",
+      "status": "skip",
+      "reason_code": "not_visible",
+      "detail": "no E2A_OUTBOUND_SMTP_* environment visible from this machine (normal for hosted e2a; self-hosted operators should run doctor on the server host)"
+    }
+  ]
+}

--- a/cli/src/bin/e2a.ts
+++ b/cli/src/bin/e2a.ts
@@ -16,6 +16,7 @@ import { login } from "../commands/login.js";
 import { config } from "../commands/config.js";
 import { listen } from "../commands/listen.js";
 import { whoami } from "../commands/whoami.js";
+import { doctor } from "../commands/doctor.js";
 import { send, reply } from "../commands/send.js";
 import { messagesList, messagesGet, messagesLifecycle } from "../commands/messages.js";
 import { agentsList, agentsCreate, agentsGet } from "../commands/agents.js";
@@ -38,6 +39,14 @@ management (domains, webhooks, review queues) lives in the MCP tools, the SDKs
 Usage:
   e2a login                         Log in via browser (account-scoped key)
   e2a whoami [--json]               Show key identity: user, scope, bound agent, plan
+  e2a doctor [options]              Read-only diagnostics: config, API, agent access,
+                                   custom-domain DNS, MCP, webhooks, outbound SMTP.
+                                   Never sends mail or changes DNS/webhooks.
+        --agent <email>            Inbox to check (or config agent_email)
+        --domain <domain>          Check one custom domain (default: all registered)
+        --mcp-url <url>            MCP endpoint to probe (default: the hosted
+                                   endpoint when using https://e2a.dev, else skipped)
+        --json                     Versioned machine-readable report (e2a.doctor/v1)
   e2a agents list                   List owned inboxes (account key)
   e2a agents create <email> [--name <n>]   Create an inbox (account key)
   e2a agents get <email>            Show one inbox
@@ -103,6 +112,8 @@ Exit codes (stable scripting contract):
   5  permanent request error (not found / invalid / conflict) — do NOT retry
   6  bounded wait (listen --once --until) expired with no matching message
   7  failed or unrecognized persisted send outcome — do NOT retry; inspect its id
+  8  diagnostics (doctor) completed with warnings only
+  9  diagnostics (doctor) found a configuration failure — fix config, do NOT retry
 `;
 
 function parseArgs(argv: string[]): { command: string; args: string[] } {
@@ -404,6 +415,16 @@ async function main() {
       checkFlags(args, ["--json"]);
       getPositionals(args, 0, "usage: e2a whoami [--json]");
       await whoami({ json: hasFlag(args, "--json") });
+      break;
+    case "doctor":
+      checkFlags(args, ["--agent", "--domain", "--mcp-url", "--json"]);
+      getPositionals(args, 0, "usage: e2a doctor [options]");
+      await doctor({
+        agent: getFlagChecked(args, "--agent"),
+        domain: getFlagChecked(args, "--domain"),
+        mcpUrl: getFlagChecked(args, "--mcp-url"),
+        json: hasFlag(args, "--json"),
+      });
       break;
     case "send":
       checkFlags(args, [

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -3,7 +3,7 @@ import { createRequire } from "node:module";
 import { E2AError } from "@e2a/sdk/v1";
 import { loadConfig } from "../config.js";
 import { createClient } from "../sdk.js";
-import { EXIT } from "../exit.js";
+import { EXIT, fail } from "../exit.js";
 
 // `doctor` diagnoses the production email path WITHOUT creating, deleting, or
 // mutating anything: it only issues GETs (plus client-side DNS lookups) and
@@ -24,7 +24,6 @@ const HOSTED_MCP_URL = "https://api.e2a.dev/mcp";
 /** Enumeration caps — noted in the report evidence when hit, never silent. */
 const MAX_DOMAINS = 50;
 const MAX_WEBHOOKS = 50;
-const MAX_DELIVERIES = 5;
 
 export type CheckStatus = "pass" | "warn" | "fail" | "skip";
 
@@ -91,6 +90,22 @@ export function defaultIO(): DoctorIO {
   const resolver = new Resolver({ timeout: DOCTOR_TIMEOUT_MS, tries: 1 });
   const noRecord = (err: unknown): boolean =>
     NO_RECORD.has((err as NodeJS.ErrnoException)?.code ?? "");
+  // The Resolver `timeout` option is per-server, per-try: with several
+  // nameservers configured one lookup could stack multiples of it. This race
+  // enforces DOCTOR_TIMEOUT_MS as a hard per-operation bound regardless.
+  const deadline = <T>(p: Promise<T>): Promise<T> => {
+    let timer: NodeJS.Timeout;
+    return Promise.race([
+      p,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`DNS lookup timed out after ${DOCTOR_TIMEOUT_MS}ms`)),
+          DOCTOR_TIMEOUT_MS,
+        );
+        timer.unref();
+      }),
+    ]).finally(() => clearTimeout(timer));
+  };
   return {
     now: () => new Date(),
     cliVersion: () => (require("../../package.json") as { version: string }).version,
@@ -104,7 +119,7 @@ export function defaultIO(): DoctorIO {
     },
     resolveTxt: async (name) => {
       try {
-        return (await resolver.resolveTxt(name)).map((chunks) => chunks.join(""));
+        return (await deadline(resolver.resolveTxt(name))).map((chunks) => chunks.join(""));
       } catch (err) {
         if (noRecord(err)) return [];
         throw err;
@@ -112,7 +127,7 @@ export function defaultIO(): DoctorIO {
     },
     resolveMx: async (name) => {
       try {
-        return await resolver.resolveMx(name);
+        return await deadline(resolver.resolveMx(name));
       } catch (err) {
         if (noRecord(err)) return [];
         throw err;
@@ -477,9 +492,17 @@ async function checkTxtRecord(
     });
     return;
   }
+  // SPF uses inclusion semantics, matching the server's own live probe: a
+  // record that starts with v=spf1 and contains the prescribed include is
+  // valid even when the operator legitimately extended it with more
+  // mechanisms. Ownership tokens are exact; DKIM is normalized-exact.
+  const spf = record.value.trim().startsWith("v=spf1");
+  const spfInclude = spf ? record.value.split(/\s+/).find((t) => t.startsWith("include:")) : undefined;
   const matches = dkim
     ? published.some((v) => normDkim(v) === normDkim(record.value))
-    : published.some((v) => v.trim() === record.value.trim());
+    : spf && spfInclude
+      ? published.some((v) => v.trim().startsWith("v=spf1") && v.includes(spfInclude))
+      : published.some((v) => v.trim() === record.value.trim());
   if (matches) {
     rec.pass(id, title, `${domain}: TXT record found at ${record.name}`, {
       target: record.name,
@@ -716,6 +739,16 @@ async function checkDomains(ctx: Ctx): Promise<void> {
 
 // --- MCP ---------------------------------------------------------------------
 
+/** Absolute http(s) URL or undefined. Doctor must never crash on flag input. */
+export function parseMcpUrl(raw: string): URL | undefined {
+  try {
+    const url = new URL(raw);
+    return url.protocol === "http:" || url.protocol === "https:" ? url : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 async function checkMcp(ctx: Ctx): Promise<void> {
   const { rec, io, opts, config } = ctx;
   const mcpUrl = opts.mcpUrl ?? (config.api_url === HOSTED_URL ? HOSTED_MCP_URL : undefined);
@@ -726,15 +759,40 @@ async function checkMcp(ctx: Ctx): Promise<void> {
     rec.skip("mcp.auth_metadata", "MCP auth metadata", "no_mcp_url", detail, { remediation });
     return;
   }
-  try {
-    // Any HTTP response (405 for GET on a POST-only endpoint, 401 without a
-    // token) proves the endpoint is routed and alive; only a network-level
-    // failure is a problem. GET carries no JSON-RPC payload → no side effects.
-    const res = await io.httpGet(mcpUrl);
-    rec.pass("mcp.reachability", "MCP reachability", `endpoint responded (HTTP ${res.status})`, {
+  // The doctor() wrapper rejects a malformed --mcp-url as a usage error;
+  // this guard keeps runDoctor crash-free for programmatic callers too.
+  const parsed = parseMcpUrl(mcpUrl);
+  if (!parsed) {
+    const detail = `${mcpUrl} is not an absolute http(s) URL`;
+    const remediation = "pass --mcp-url as an absolute URL, e.g. https://host.example/mcp";
+    rec.fail("mcp.reachability", "MCP reachability", "invalid_mcp_url", "config", detail, {
       target: mcpUrl,
-      evidence: { http_status: res.status },
+      remediation,
     });
+    rec.fail("mcp.auth_metadata", "MCP auth metadata", "invalid_mcp_url", "config", detail, {
+      target: mcpUrl,
+      remediation,
+    });
+    return;
+  }
+  try {
+    // 405 (GET on the POST-only JSON-RPC endpoint) and 401 (no token) both
+    // prove the endpoint is routed and alive; 404/410 mean the path is NOT
+    // routed — the exact misconfiguration this check exists to catch. GET
+    // carries no JSON-RPC payload → no side effects.
+    const res = await io.httpGet(mcpUrl);
+    if (res.status === 404 || res.status === 410) {
+      rec.fail("mcp.reachability", "MCP reachability", "not_routed", "config", `HTTP ${res.status} — no MCP endpoint at ${mcpUrl}`, {
+        target: mcpUrl,
+        evidence: { http_status: res.status },
+        remediation: "check the MCP path (hosted: https://api.e2a.dev/mcp; self-hosted: usually /mcp on the MCP server host)",
+      });
+    } else {
+      rec.pass("mcp.reachability", "MCP reachability", `endpoint responded (HTTP ${res.status})`, {
+        target: mcpUrl,
+        evidence: { http_status: res.status },
+      });
+    }
   } catch (err) {
     rec.fail("mcp.reachability", "MCP reachability", "connection_failed", "transient", `cannot reach ${mcpUrl}`, {
       target: mcpUrl,
@@ -743,7 +801,7 @@ async function checkMcp(ctx: Ctx): Promise<void> {
     });
   }
 
-  const metadataUrl = `${new URL(mcpUrl).origin}/.well-known/oauth-protected-resource`;
+  const metadataUrl = `${parsed.origin}/.well-known/oauth-protected-resource`;
   try {
     const res = await io.httpGet(metadataUrl);
     if (res.status !== 200) {
@@ -864,9 +922,11 @@ async function checkWebhooks(ctx: Ctx): Promise<void> {
     }
 
     try {
+      // Deliveries come newest-first; only the latest outcome matters here,
+      // so fetch exactly one — never a second page.
       const deliveries = (await collect(
-        ctx.client!.webhooks.deliveries(wh.id, { limit: MAX_DELIVERIES }) as AsyncIterable<DeliveryLike>,
-        MAX_DELIVERIES,
+        ctx.client!.webhooks.deliveries(wh.id, { limit: 1 }) as AsyncIterable<DeliveryLike>,
+        1,
       )).items;
       const latest = deliveries[0];
       if (!latest || (latest.status === "pending" && latest.attempts === 0)) {
@@ -956,7 +1016,9 @@ function checkSmtpConfig(ctx: Ctx): void {
 // ---------------------------------------------------------------------------
 
 export async function runDoctor(opts: DoctorOptions, io: DoctorIO): Promise<DoctorReport> {
-  const config = loadConfig();
+  const config = { ...loadConfig() };
+  // A trailing slash on E2A_URL must not break probe URLs or hosted detection.
+  config.api_url = config.api_url.replace(/\/+$/, "") || config.api_url;
   const rec = new Recorder();
   const ctx: Ctx = { io, rec, config, opts, apiReachable: false };
   if (config.api_key) {
@@ -995,6 +1057,9 @@ function renderHuman(report: DoctorReport): string {
 }
 
 export async function doctor(opts: DoctorOptions, io: DoctorIO = defaultIO()): Promise<void> {
+  if (opts.mcpUrl !== undefined && !parseMcpUrl(opts.mcpUrl)) {
+    fail(EXIT.USAGE, "--mcp-url must be an absolute http(s) URL, e.g. https://host.example/mcp");
+  }
   const report = await runDoctor(opts, io);
   if (opts.json) {
     process.stdout.write(JSON.stringify(report, null, 2) + "\n");

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -81,6 +81,25 @@ export interface DoctorIO {
 
 const require = createRequire(import.meta.url);
 
+/** Absolute http(s) URL or undefined. Doctor must never crash on bad input. */
+export function parseHttpUrl(raw: string): URL | undefined {
+  try {
+    const url = new URL(raw);
+    return url.protocol === "http:" || url.protocol === "https:" ? url : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/** URL safe to embed in a report: credentials stripped, unparseable left as-is. */
+function redactUrl(raw: string): string {
+  const url = parseHttpUrl(raw);
+  if (!url || (!url.username && !url.password)) return raw;
+  url.username = "";
+  url.password = "";
+  return url.toString();
+}
+
 export function defaultIO(): DoctorIO {
   // ENOTFOUND/ENODATA mean "no such record" — a definite answer, not an
   // error. Anything else (timeout, SERVFAIL, refused) is inconclusive and
@@ -276,6 +295,23 @@ function checkCliConfig(ctx: Ctx): void {
 
 async function checkApiReachability(ctx: Ctx): Promise<void> {
   const { rec, io, config } = ctx;
+  if (!parseHttpUrl(config.api_url)) {
+    // A schemeless/garbled E2A_URL is a configuration problem, not a network
+    // one — without this, fetch's URL-parse rejection would masquerade as a
+    // retryable connection failure.
+    rec.fail(
+      "api.reachability",
+      "API reachability",
+      "invalid_deployment_url",
+      "config",
+      `${config.api_url} is not an absolute http(s) URL`,
+      {
+        target: config.api_url,
+        remediation: "set E2A_URL to the deployment root, e.g. https://e2a.dev or https://mail.internal.example",
+      },
+    );
+    return;
+  }
   const url = `${config.api_url}/v1/info`;
   let res: { status: number; body: string };
   try {
@@ -296,10 +332,11 @@ async function checkApiReachability(ctx: Ctx): Promise<void> {
     return;
   }
   if (res.status !== 200) {
-    // 5xx: the deployment exists but is unhealthy — retryable. Anything else
-    // (404 from some other website, 3xx chain ending badly) means E2A_URL
-    // doesn't point at an e2a deployment root — a configuration problem.
-    const transient = res.status >= 500;
+    // 5xx/408/429: the deployment exists but is unhealthy or throttling —
+    // retryable. Anything else (404 from some other website, 3xx chain
+    // ending badly) means E2A_URL doesn't point at an e2a deployment root —
+    // a configuration problem.
+    const transient = res.status >= 500 || res.status === 408 || res.status === 429;
     rec.fail(
       "api.reachability",
       "API reachability",
@@ -468,9 +505,21 @@ async function collect<T>(pager: AsyncIterable<T>, max: number): Promise<{ items
 }
 
 const normHost = (h: string): string => h.toLowerCase().replace(/\.$/, "");
-/** DKIM values are compared with quotes/whitespace stripped: providers split
- * and re-quote long TXT values, which is cosmetic, not a mismatch. */
-const normDkim = (s: string): string => s.replace(/["\s]/g, "");
+
+/**
+ * The p= payload of a DKIM TXT record, whitespace/quote-stripped — mirrors
+ * the server's dkim.ExtractPublicKeyFromTXT: only the key material is
+ * compared, so extra tags (s=, t=, …) and tag reordering that operators
+ * paste are tolerated exactly like the server's own verifier tolerates them.
+ */
+export function extractDkimKey(txt: string): string {
+  const i = txt.indexOf("p=");
+  if (i < 0) return "";
+  let tail = txt.slice(i + 2);
+  const j = tail.indexOf(";");
+  if (j >= 0) tail = tail.slice(0, j);
+  return tail.replace(/[\s"]/g, "");
+}
 
 async function checkTxtRecord(
   ctx: Ctx,
@@ -488,21 +537,26 @@ async function checkTxtRecord(
     rec.fail(id, title, "dns_lookup_failed", "transient", `TXT lookup for ${record.name} failed`, {
       target: record.name,
       evidence: { error: err instanceof Error ? err.message : String(err) },
-      remediation: "DNS lookup was inconclusive — retry, or check the record with `dig TXT " + record.name + "`",
+      remediation: `DNS lookup was inconclusive — retry, or check the record with \`dig TXT '${record.name}'\``,
     });
     return;
   }
-  // SPF uses inclusion semantics, matching the server's own live probe: a
-  // record that starts with v=spf1 and contains the prescribed include is
-  // valid even when the operator legitimately extended it with more
-  // mechanisms. Ownership tokens are exact; DKIM is normalized-exact.
-  const spf = record.value.trim().startsWith("v=spf1");
-  const spfInclude = spf ? record.value.split(/\s+/).find((t) => t.startsWith("include:")) : undefined;
+  // Match with the server's OWN probe semantics (internal/agent/api.go
+  // checkDomainRecords + classifyDKIM), so doctor never fails a record the
+  // server accepts: ownership is a substring match (any TXT containing the
+  // token), SPF is case-insensitive starts-with-v=spf1 plus contains the
+  // prescribed include, DKIM compares only the extracted p= payload.
+  const spf = record.value.trim().toLowerCase().startsWith("v=spf1");
+  const spfInclude = spf
+    ? record.value.toLowerCase().split(/\s+/).find((t) => t.startsWith("include:"))
+    : undefined;
   const matches = dkim
-    ? published.some((v) => normDkim(v) === normDkim(record.value))
+    ? published.some((v) => extractDkimKey(v) !== "" && extractDkimKey(v) === extractDkimKey(record.value))
     : spf && spfInclude
-      ? published.some((v) => v.trim().startsWith("v=spf1") && v.includes(spfInclude))
-      : published.some((v) => v.trim() === record.value.trim());
+      ? published.some((v) => v.trim().toLowerCase().startsWith("v=spf1") && v.toLowerCase().includes(spfInclude))
+      : record.purpose === "ownership"
+        ? published.some((v) => v.includes(record.value))
+        : published.some((v) => v.trim() === record.value.trim());
   if (matches) {
     rec.pass(id, title, `${domain}: TXT record found at ${record.name}`, {
       target: record.name,
@@ -510,10 +564,15 @@ async function checkTxtRecord(
     });
     return;
   }
-  // A same-purpose record with a different value is a mismatch (stale copy);
-  // otherwise the record is simply missing among unrelated TXT entries.
-  const prefix = dkim ? "v=DKIM1" : record.value.startsWith("v=spf1") ? "v=spf1" : undefined;
-  const conflicting = prefix ? published.filter((v) => v.trim().startsWith(prefix)) : [];
+  // A same-purpose record with a different value is a mismatch (usually a
+  // truncated or stale copy — the distinction tells the user to re-publish
+  // the full value rather than "add the record"); otherwise the record is
+  // simply missing among unrelated TXT entries.
+  const conflicting = dkim
+    ? published.filter((v) => extractDkimKey(v) !== "")
+    : spf
+      ? published.filter((v) => v.trim().toLowerCase().startsWith("v=spf1"))
+      : [];
   if (conflicting.length > 0) {
     rec.fail(id, title, "record_mismatch", "config", `${domain}: TXT at ${record.name} does not match`, {
       target: record.name,
@@ -545,7 +604,7 @@ async function checkMxRecord(
     rec.fail(id, title, "dns_lookup_failed", "transient", `MX lookup for ${record.name} failed`, {
       target: record.name,
       evidence: { error: err instanceof Error ? err.message : String(err), ...extraEvidence },
-      remediation: "DNS lookup was inconclusive — retry, or check the record with `dig MX " + record.name + "`",
+      remediation: `DNS lookup was inconclusive — retry, or check the record with \`dig MX '${record.name}'\``,
     });
     return;
   }
@@ -648,7 +707,9 @@ async function checkOneDomain(ctx: Ctx, domain: DomainLike): Promise<void> {
       });
     }
   } catch (err) {
-    rec.fail("domain.dmarc", "DMARC record (advisory)", "dns_lookup_failed", "transient", `TXT lookup for ${dmarcName} failed`, {
+    // Advisory check, advisory outcome: an inconclusive lookup here must not
+    // fail the run — DMARC can never fail doctor, per its warn-only contract.
+    rec.warn("domain.dmarc", "DMARC record (advisory)", "dns_lookup_failed", `TXT lookup for ${dmarcName} was inconclusive`, {
       target: dmarcName,
       evidence: { error: err instanceof Error ? err.message : String(err) },
     });
@@ -733,21 +794,18 @@ async function checkDomains(ctx: Ctx): Promise<void> {
     });
   }
   for (const domain of domains) {
-    await checkOneDomain(ctx, domain);
+    // One malformed domain object must not cost the rest of the report.
+    try {
+      await checkOneDomain(ctx, domain);
+    } catch (err) {
+      rec.fail("doctor.internal", "Doctor internal error", "internal_error", "transient", `${domain?.domain ?? "domain"}: unexpected error: ${err instanceof Error ? err.message : String(err)}`, {
+        target: domain?.domain,
+      });
+    }
   }
 }
 
 // --- MCP ---------------------------------------------------------------------
-
-/** Absolute http(s) URL or undefined. Doctor must never crash on flag input. */
-export function parseMcpUrl(raw: string): URL | undefined {
-  try {
-    const url = new URL(raw);
-    return url.protocol === "http:" || url.protocol === "https:" ? url : undefined;
-  } catch {
-    return undefined;
-  }
-}
 
 async function checkMcp(ctx: Ctx): Promise<void> {
   const { rec, io, opts, config } = ctx;
@@ -761,7 +819,7 @@ async function checkMcp(ctx: Ctx): Promise<void> {
   }
   // The doctor() wrapper rejects a malformed --mcp-url as a usage error;
   // this guard keeps runDoctor crash-free for programmatic callers too.
-  const parsed = parseMcpUrl(mcpUrl);
+  const parsed = parseHttpUrl(mcpUrl);
   if (!parsed) {
     const detail = `${mcpUrl} is not an absolute http(s) URL`;
     const remediation = "pass --mcp-url as an absolute URL, e.g. https://host.example/mcp";
@@ -786,6 +844,12 @@ async function checkMcp(ctx: Ctx): Promise<void> {
         target: mcpUrl,
         evidence: { http_status: res.status },
         remediation: "check the MCP path (hosted: https://api.e2a.dev/mcp; self-hosted: usually /mcp on the MCP server host)",
+      });
+    } else if (res.status >= 500) {
+      rec.fail("mcp.reachability", "MCP reachability", "http_error", "transient", `HTTP ${res.status} from ${mcpUrl}`, {
+        target: mcpUrl,
+        evidence: { http_status: res.status },
+        remediation: "the MCP endpoint is routed but erroring — retry, then check the MCP server logs",
       });
     } else {
       rec.pass("mcp.reachability", "MCP reachability", `endpoint responded (HTTP ${res.status})`, {
@@ -877,8 +941,11 @@ async function checkWebhooks(ctx: Ctx): Promise<void> {
     return;
   }
   let webhooks: WebhookLike[];
+  let truncated = false;
   try {
-    webhooks = (await collect(ctx.client!.webhooks.list({}) as AsyncIterable<WebhookLike>, MAX_WEBHOOKS)).items;
+    const collected = await collect(ctx.client!.webhooks.list({}) as AsyncIterable<WebhookLike>, MAX_WEBHOOKS);
+    webhooks = collected.items;
+    truncated = collected.truncated;
   } catch (err) {
     const { kind, message } = classifyError(err);
     rec.fail(
@@ -894,74 +961,20 @@ async function checkWebhooks(ctx: Ctx): Promise<void> {
     rec.skip("webhook.config", "Webhook configuration", "no_webhooks", "no webhooks configured — agents rely on WebSocket, polling, or MCP", {});
     return;
   }
+  if (truncated) {
+    rec.warn("webhook.config", "Webhook configuration", "too_many_webhooks", `only the first ${MAX_WEBHOOKS} webhooks were checked`, {
+      evidence: { checked: MAX_WEBHOOKS },
+    });
+  }
 
   for (const wh of webhooks) {
-    if (wh.autoDisabledAt) {
-      rec.fail("webhook.config", "Webhook configuration", "webhook_auto_disabled", "config", `${wh.id}: auto-disabled after repeated delivery failures`, {
-        target: wh.url,
-        evidence: { id: wh.id, auto_disabled_at: new Date(wh.autoDisabledAt).toISOString() },
-        remediation: "fix the receiving endpoint, then re-enable the webhook (dashboard or MCP `update_webhook`)",
-      });
-    } else if (!wh.enabled) {
-      rec.warn("webhook.config", "Webhook configuration", "webhook_disabled", `${wh.id}: disabled`, {
-        target: wh.url,
-        evidence: { id: wh.id },
-        remediation: "events are not being delivered — re-enable it if that is unintended",
-      });
-    } else if (!wh.url.startsWith("https://")) {
-      rec.warn("webhook.config", "Webhook configuration", "insecure_url", `${wh.id}: URL is not HTTPS`, {
-        target: wh.url,
-        evidence: { id: wh.id },
-        remediation: "use an HTTPS endpoint — production deployments reject plain HTTP webhook URLs",
-      });
-    } else {
-      rec.pass("webhook.config", "Webhook configuration", `${wh.id}: enabled, ${wh.events.length} event type(s)`, {
-        target: wh.url,
-        evidence: { id: wh.id, events: wh.events },
-      });
-    }
-
+    // One malformed webhook object must not cost the rest of the report.
     try {
-      // Deliveries come newest-first; only the latest outcome matters here,
-      // so fetch exactly one — never a second page.
-      const deliveries = (await collect(
-        ctx.client!.webhooks.deliveries(wh.id, { limit: 1 }) as AsyncIterable<DeliveryLike>,
-        1,
-      )).items;
-      const latest = deliveries[0];
-      if (!latest || (latest.status === "pending" && latest.attempts === 0)) {
-        rec.skip("webhook.delivery", "Webhook delivery history", "no_deliveries", `${wh.id}: no completed deliveries yet`, {
-          target: wh.id,
-        });
-      } else if (latest.status === "delivered") {
-        const evidence: Record<string, unknown> = { last_status: "delivered" };
-        if (latest.lastStatusCode !== undefined) evidence.last_status_code = latest.lastStatusCode;
-        rec.pass("webhook.delivery", "Webhook delivery history", `${wh.id}: latest delivery succeeded`, {
-          target: wh.id,
-          evidence,
-        });
-      } else {
-        rec.warn("webhook.delivery", "Webhook delivery history", "deliveries_failing", `${wh.id}: latest delivery ${latest.status}`, {
-          target: wh.id,
-          evidence: {
-            last_status: latest.status,
-            last_error: latest.lastError ?? "",
-            last_status_code: latest.lastStatusCode ?? 0,
-            attempts: latest.attempts,
-          },
-          remediation: "check the receiving endpoint's logs and TLS setup; deliveries retry with backoff",
-        });
-      }
+      await checkOneWebhook(ctx, wh);
     } catch (err) {
-      const { kind, message } = classifyError(err);
-      rec.fail(
-        "webhook.delivery",
-        "Webhook delivery history",
-        kind === "transient" ? "connection_failed" : "http_error",
-        kind === "transient" ? "transient" : "config",
-        `${wh.id}: ${message}`,
-        { target: wh.id },
-      );
+      rec.fail("doctor.internal", "Doctor internal error", "internal_error", "transient", `webhook ${wh.id}: unexpected error: ${err instanceof Error ? err.message : String(err)}`, {
+        target: wh.id,
+      });
     }
   }
 
@@ -972,6 +985,79 @@ async function checkWebhooks(ctx: Ctx): Promise<void> {
     "skipped: no safe non-delivering probe exists (POST /v1/webhooks/{id}/test delivers a real event) — webhook.delivery reflects observed reachability",
     {},
   );
+}
+
+async function checkOneWebhook(ctx: Ctx, wh: WebhookLike): Promise<void> {
+  const { rec } = ctx;
+  // Webhook URLs can carry basic-auth userinfo; never echo credentials.
+  const target = redactUrl(wh.url);
+  if (wh.autoDisabledAt) {
+    rec.fail("webhook.config", "Webhook configuration", "webhook_auto_disabled", "config", `${wh.id}: auto-disabled after repeated delivery failures`, {
+      target,
+      evidence: { id: wh.id, auto_disabled_at: new Date(wh.autoDisabledAt).toISOString() },
+      remediation: "fix the receiving endpoint, then re-enable the webhook (dashboard or MCP `update_webhook`)",
+    });
+  } else if (!wh.enabled) {
+    rec.warn("webhook.config", "Webhook configuration", "webhook_disabled", `${wh.id}: disabled`, {
+      target,
+      evidence: { id: wh.id },
+      remediation: "events are not being delivered — re-enable it if that is unintended",
+    });
+  } else if (!wh.url.startsWith("https://")) {
+    rec.warn("webhook.config", "Webhook configuration", "insecure_url", `${wh.id}: URL is not HTTPS`, {
+      target,
+      evidence: { id: wh.id },
+      remediation: "use an HTTPS endpoint — production deployments reject plain HTTP webhook URLs",
+    });
+  } else {
+    rec.pass("webhook.config", "Webhook configuration", `${wh.id}: enabled, ${wh.events.length} event type(s)`, {
+      target,
+      evidence: { id: wh.id, events: wh.events },
+    });
+  }
+
+  try {
+    // Deliveries come newest-first; only the latest outcome matters here,
+    // so fetch exactly one — never a second page.
+    const deliveries = (await collect(
+      ctx.client!.webhooks.deliveries(wh.id, { limit: 1 }) as AsyncIterable<DeliveryLike>,
+      1,
+    )).items;
+    const latest = deliveries[0];
+    if (!latest || (latest.status === "pending" && latest.attempts === 0)) {
+      rec.skip("webhook.delivery", "Webhook delivery history", "no_deliveries", `${wh.id}: no completed deliveries yet`, {
+        target: wh.id,
+      });
+    } else if (latest.status === "delivered") {
+      const evidence: Record<string, unknown> = { last_status: "delivered" };
+      if (latest.lastStatusCode !== undefined) evidence.last_status_code = latest.lastStatusCode;
+      rec.pass("webhook.delivery", "Webhook delivery history", `${wh.id}: latest delivery succeeded`, {
+        target: wh.id,
+        evidence,
+      });
+    } else {
+      rec.warn("webhook.delivery", "Webhook delivery history", "deliveries_failing", `${wh.id}: latest delivery ${latest.status}`, {
+        target: wh.id,
+        evidence: {
+          last_status: latest.status,
+          last_error: latest.lastError ?? "",
+          last_status_code: latest.lastStatusCode ?? 0,
+          attempts: latest.attempts,
+        },
+        remediation: "check the receiving endpoint's logs and TLS setup; deliveries retry with backoff",
+      });
+    }
+  } catch (err) {
+    const { kind, message } = classifyError(err);
+    rec.fail(
+      "webhook.delivery",
+      "Webhook delivery history",
+      kind === "transient" ? "connection_failed" : "http_error",
+      kind === "transient" ? "transient" : "config",
+      `${wh.id}: ${message}`,
+      { target: wh.id },
+    );
+  }
 }
 
 // --- outbound SMTP visibility ---------------------------------------------------
@@ -1022,7 +1108,9 @@ export async function runDoctor(opts: DoctorOptions, io: DoctorIO): Promise<Doct
   const rec = new Recorder();
   const ctx: Ctx = { io, rec, config, opts, apiReachable: false };
   if (config.api_key) {
-    ctx.client = createClient({ timeoutMs: DOCTOR_TIMEOUT_MS, maxRetries: 0 });
+    // Pass the normalized config through so the SDK client hits the exact
+    // same base URL the probes use (and the config file isn't parsed twice).
+    ctx.client = createClient({ timeoutMs: DOCTOR_TIMEOUT_MS, maxRetries: 0 }, config);
   }
 
   checkCliConfig(ctx);
@@ -1037,6 +1125,12 @@ export async function runDoctor(opts: DoctorOptions, io: DoctorIO): Promise<Doct
   return buildReport(io, config.api_url, rec);
 }
 
+// Details and remediations interpolate server- and DNS-derived strings; strip
+// control characters (including ANSI escapes) so a hostile record can't
+// inject terminal escapes into the report. JSON output is already safe via
+// JSON.stringify's escaping.
+const stripControl = (s: string): string => s.replace(/[\u0000-\u0008\u000b-\u001f\u007f-\u009f]/g, "");
+
 function renderHuman(report: DoctorReport): string {
   const lines: string[] = [
     `doctor: read-only diagnostics for ${report.deployment_url} (sends no mail; changes no DNS or webhooks)`,
@@ -1044,7 +1138,9 @@ function renderHuman(report: DoctorReport): string {
   ];
   for (const c of report.checks) {
     lines.push(`${c.status.padEnd(4)}  ${c.id.padEnd(22)}${c.detail}`);
-    if (c.remediation && (c.status === "fail" || c.status === "warn")) {
+    // Skips carry guidance too (e.g. how to enable the MCP probe) — print
+    // every remediation, not just failing ones.
+    if (c.remediation) {
       lines.push(`      fix: ${c.remediation}`);
     }
   }
@@ -1053,11 +1149,11 @@ function renderHuman(report: DoctorReport): string {
     "",
     `${s.fail} fail, ${s.warn} warn, ${s.pass} pass, ${s.skip} skip — ${report.status} (exit ${report.exit_code})`,
   );
-  return lines.join("\n") + "\n";
+  return lines.map(stripControl).join("\n") + "\n";
 }
 
 export async function doctor(opts: DoctorOptions, io: DoctorIO = defaultIO()): Promise<void> {
-  if (opts.mcpUrl !== undefined && !parseMcpUrl(opts.mcpUrl)) {
+  if (opts.mcpUrl !== undefined && !parseHttpUrl(opts.mcpUrl)) {
     fail(EXIT.USAGE, "--mcp-url must be an absolute http(s) URL, e.g. https://host.example/mcp");
   }
   const report = await runDoctor(opts, io);

--- a/cli/src/commands/doctor.ts
+++ b/cli/src/commands/doctor.ts
@@ -1,0 +1,1006 @@
+import { Resolver } from "node:dns/promises";
+import { createRequire } from "node:module";
+import { E2AError } from "@e2a/sdk/v1";
+import { loadConfig } from "../config.js";
+import { createClient } from "../sdk.js";
+import { EXIT } from "../exit.js";
+
+// `doctor` diagnoses the production email path WITHOUT creating, deleting, or
+// mutating anything: it only issues GETs (plus client-side DNS lookups) and
+// never calls the three endpoints with real-world side effects —
+// POST /v1/domains/{d}/verify (flips verified state, enqueues SES
+// provisioning), POST /v1/webhooks/{id}/test (delivers a real event to the
+// customer's endpoint), POST /v1/agents/{email}/test (sends real mail).
+// Webhook reachability therefore has no safe probe and is reported as an
+// explicit skip, with recent delivery history as the observed signal.
+
+export const DOCTOR_SCHEMA = "e2a.doctor/v1";
+/** Hard per-operation deadline for every network call doctor makes. */
+export const DOCTOR_TIMEOUT_MS = 5000;
+export const EXIT_HEALTHY = EXIT.OK;
+
+const HOSTED_URL = "https://e2a.dev";
+const HOSTED_MCP_URL = "https://api.e2a.dev/mcp";
+/** Enumeration caps — noted in the report evidence when hit, never silent. */
+const MAX_DOMAINS = 50;
+const MAX_WEBHOOKS = 50;
+const MAX_DELIVERIES = 5;
+
+export type CheckStatus = "pass" | "warn" | "fail" | "skip";
+
+export interface DoctorCheck {
+  /** Stable machine ID (e.g. "domain.mx"). New IDs may be added; never renamed. */
+  id: string;
+  /** Stable human label for the check. */
+  title: string;
+  status: CheckStatus;
+  /** Stable machine reason (e.g. "record_missing"). */
+  reason_code: string;
+  /** What was checked (URL, domain, record name, webhook id) when not global. */
+  target?: string;
+  /** One-line human explanation of the outcome. */
+  detail: string;
+  /** Check-specific structured facts. Never contains credentials. */
+  evidence?: Record<string, unknown>;
+  /** Concise fix, present on warn/fail (and some skips). */
+  remediation?: string;
+}
+
+export interface DoctorReport {
+  schema: typeof DOCTOR_SCHEMA;
+  generated_at: string;
+  cli_version: string;
+  deployment_url: string;
+  status: "healthy" | "warnings" | "failed";
+  exit_code: number;
+  summary: { pass: number; warn: number; fail: number; skip: number };
+  checks: DoctorCheck[];
+}
+
+export interface DoctorOptions {
+  agent?: string;
+  domain?: string;
+  mcpUrl?: string;
+  json?: boolean;
+}
+
+/**
+ * All I/O behind one seam so tests drive every status/exit path
+ * deterministically. Every operation is bounded by DOCTOR_TIMEOUT_MS.
+ */
+export interface DoctorIO {
+  now(): Date;
+  cliVersion(): string;
+  env(name: string): string | undefined;
+  /** GET the URL; resolves for any HTTP response, throws on network failure. */
+  httpGet(url: string): Promise<{ status: number; body: string }>;
+  /** TXT records with chunks joined; [] when the name/records don't exist. */
+  resolveTxt(name: string): Promise<string[]>;
+  /** MX records; [] when the name/records don't exist. */
+  resolveMx(name: string): Promise<Array<{ exchange: string; priority: number }>>;
+}
+
+const require = createRequire(import.meta.url);
+
+export function defaultIO(): DoctorIO {
+  // ENOTFOUND/ENODATA mean "no such record" — a definite answer, not an
+  // error. Anything else (timeout, SERVFAIL, refused) is inconclusive and
+  // propagates so the check reports dns_lookup_failed instead of a false
+  // "record missing".
+  const NO_RECORD = new Set(["ENOTFOUND", "ENODATA"]);
+  const resolver = new Resolver({ timeout: DOCTOR_TIMEOUT_MS, tries: 1 });
+  const noRecord = (err: unknown): boolean =>
+    NO_RECORD.has((err as NodeJS.ErrnoException)?.code ?? "");
+  return {
+    now: () => new Date(),
+    cliVersion: () => (require("../../package.json") as { version: string }).version,
+    env: (name) => process.env[name],
+    httpGet: async (url) => {
+      const res = await fetch(url, {
+        signal: AbortSignal.timeout(DOCTOR_TIMEOUT_MS),
+        headers: { accept: "application/json" },
+      });
+      return { status: res.status, body: await res.text() };
+    },
+    resolveTxt: async (name) => {
+      try {
+        return (await resolver.resolveTxt(name)).map((chunks) => chunks.join(""));
+      } catch (err) {
+        if (noRecord(err)) return [];
+        throw err;
+      }
+    },
+    resolveMx: async (name) => {
+      try {
+        return await resolver.resolveMx(name);
+      } catch (err) {
+        if (noRecord(err)) return [];
+        throw err;
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Check accumulation and exit-code computation
+// ---------------------------------------------------------------------------
+
+/** Which exit code a failing (or degraded) check argues for. */
+type ExitClass = "auth" | "config" | "transient";
+
+interface Recorded {
+  check: DoctorCheck;
+  exitClass?: ExitClass;
+}
+
+class Recorder {
+  readonly recorded: Recorded[] = [];
+
+  add(check: DoctorCheck, exitClass?: ExitClass): void {
+    this.recorded.push({ check, exitClass });
+  }
+
+  pass(id: string, title: string, detail: string, extra: Partial<DoctorCheck> = {}): void {
+    this.add({ id, title, status: "pass", reason_code: "ok", detail, ...extra });
+  }
+
+  skip(id: string, title: string, reason: string, detail: string, extra: Partial<DoctorCheck> = {}): void {
+    this.add({ id, title, status: "skip", reason_code: reason, detail, ...extra });
+  }
+
+  warn(id: string, title: string, reason: string, detail: string, extra: Partial<DoctorCheck> = {}): void {
+    this.add({ id, title, status: "warn", reason_code: reason, detail, ...extra });
+  }
+
+  fail(
+    id: string,
+    title: string,
+    reason: string,
+    exitClass: ExitClass,
+    detail: string,
+    extra: Partial<DoctorCheck> = {},
+  ): void {
+    this.add({ id, title, status: "fail", reason_code: reason, detail, ...extra }, exitClass);
+  }
+}
+
+function buildReport(io: DoctorIO, deploymentUrl: string, rec: Recorder): DoctorReport {
+  const checks = rec.recorded.map((r) => r.check);
+  const summary = { pass: 0, warn: 0, fail: 0, skip: 0 };
+  for (const c of checks) summary[c.status]++;
+
+  // Severity order: a bad credential (4) must win over the config errors it
+  // may cause downstream; a definite configuration failure (9) must win over
+  // an incidental transient (1) so retry loops don't spin on a problem only
+  // a human can fix; transient (1) means "retry doctor"; warnings (8) mean
+  // "nothing broken, read the report".
+  const classes = new Set(rec.recorded.map((r) => r.exitClass).filter(Boolean));
+  let exitCode: number = EXIT.OK;
+  if (classes.has("auth")) exitCode = EXIT.AUTH;
+  else if (classes.has("config")) exitCode = EXIT.CONFIG;
+  else if (classes.has("transient")) exitCode = EXIT.ERROR;
+  else if (summary.warn > 0) exitCode = EXIT.WARN;
+
+  return {
+    schema: DOCTOR_SCHEMA,
+    generated_at: io.now().toISOString(),
+    cli_version: io.cliVersion(),
+    deployment_url: deploymentUrl,
+    status: summary.fail > 0 ? "failed" : summary.warn > 0 ? "warnings" : "healthy",
+    exit_code: exitCode,
+    summary,
+    checks,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Error classification
+// ---------------------------------------------------------------------------
+
+type ErrorKind = "auth" | "not_found" | "transient" | "request";
+
+function classifyError(err: unknown): { kind: ErrorKind; message: string } {
+  if (err instanceof E2AError) {
+    if (err.status === 401 || err.status === 403) return { kind: "auth", message: err.message };
+    if (err.status === 404 || err.status === 410) return { kind: "not_found", message: err.message };
+    if (err.status === 0 || err.status >= 500 || err.retryable) {
+      return { kind: "transient", message: err.message };
+    }
+    return { kind: "request", message: err.message };
+  }
+  return { kind: "transient", message: err instanceof Error ? err.message : String(err) };
+}
+
+// ---------------------------------------------------------------------------
+// Individual checks
+// ---------------------------------------------------------------------------
+
+interface Ctx {
+  io: DoctorIO;
+  rec: Recorder;
+  config: ReturnType<typeof loadConfig>;
+  opts: DoctorOptions;
+  client?: ReturnType<typeof createClient>;
+  apiReachable: boolean;
+  /** Parsed /v1/info payload when reachable. */
+  info?: { version?: string; shared_domain?: string; public_url?: string };
+  account?: {
+    user: { id: string; email: string };
+    scope: string;
+    planCode: string;
+    agentEmail?: string;
+  };
+}
+
+function checkCliConfig(ctx: Ctx): void {
+  const { rec, io, config } = ctx;
+  const keySource = io.env("E2A_API_KEY") ? "E2A_API_KEY" : config.api_key ? "~/.e2a/config.json" : "none";
+  if (!config.api_key) {
+    rec.fail(
+      "cli.config",
+      "CLI configuration",
+      "no_api_key",
+      "auth",
+      `no API key configured; deployment ${config.api_url}`,
+      {
+        evidence: { deployment_url: config.api_url, key_source: keySource },
+        remediation: "run `e2a login` (browser), or set E2A_API_KEY",
+      },
+    );
+    return;
+  }
+  const evidence: Record<string, unknown> = {
+    deployment_url: config.api_url,
+    key_source: keySource,
+  };
+  if (config.key_scope) evidence.key_scope = config.key_scope;
+  rec.pass("cli.config", "CLI configuration", `api key from ${keySource}; deployment ${config.api_url}`, {
+    evidence,
+  });
+}
+
+async function checkApiReachability(ctx: Ctx): Promise<void> {
+  const { rec, io, config } = ctx;
+  const url = `${config.api_url}/v1/info`;
+  let res: { status: number; body: string };
+  try {
+    res = await io.httpGet(url);
+  } catch (err) {
+    rec.fail(
+      "api.reachability",
+      "API reachability",
+      "connection_failed",
+      "transient",
+      `cannot reach ${url}`,
+      {
+        target: config.api_url,
+        evidence: { error: err instanceof Error ? err.message : String(err) },
+        remediation: "check the network and E2A_URL; for self-hosted, confirm the server is running",
+      },
+    );
+    return;
+  }
+  if (res.status !== 200) {
+    // 5xx: the deployment exists but is unhealthy — retryable. Anything else
+    // (404 from some other website, 3xx chain ending badly) means E2A_URL
+    // doesn't point at an e2a deployment root — a configuration problem.
+    const transient = res.status >= 500;
+    rec.fail(
+      "api.reachability",
+      "API reachability",
+      "http_error",
+      transient ? "transient" : "config",
+      `GET ${url} returned HTTP ${res.status}`,
+      {
+        target: config.api_url,
+        evidence: { http_status: res.status },
+        remediation: transient
+          ? "the deployment is up but unhealthy — retry, then check server logs"
+          : "E2A_URL must be the e2a deployment root (the host serving /v1)",
+      },
+    );
+    return;
+  }
+  let info: Ctx["info"];
+  try {
+    info = JSON.parse(res.body) as Ctx["info"];
+  } catch {
+    info = undefined;
+  }
+  if (!info || typeof info.version !== "string") {
+    rec.fail(
+      "api.reachability",
+      "API reachability",
+      "unexpected_response",
+      "config",
+      `GET ${url} did not return a /v1/info payload`,
+      {
+        target: config.api_url,
+        remediation: "E2A_URL must be the e2a deployment root (the host serving /v1)",
+      },
+    );
+    return;
+  }
+  ctx.apiReachable = true;
+  ctx.info = info;
+  const evidence: Record<string, unknown> = { version: info.version };
+  if (info.shared_domain) evidence.shared_domain = info.shared_domain;
+  if (info.public_url) evidence.public_url = info.public_url;
+  rec.pass("api.reachability", "API reachability", `server version ${info.version}`, {
+    target: config.api_url,
+    evidence,
+  });
+}
+
+async function checkApiAuth(ctx: Ctx): Promise<void> {
+  const { rec } = ctx;
+  if (!ctx.config.api_key) {
+    rec.skip("api.auth", "API credentials", "no_api_key", "skipped: no API key configured");
+    return;
+  }
+  if (!ctx.apiReachable) {
+    rec.skip("api.auth", "API credentials", "blocked_by_failure", "skipped: API unreachable", {
+      evidence: { blocked_on: "api.reachability" },
+    });
+    return;
+  }
+  try {
+    const account = await ctx.client!.account.get();
+    ctx.account = account;
+    const evidence: Record<string, unknown> = {
+      user_email: account.user.email,
+      scope: account.scope,
+      plan_code: account.planCode,
+    };
+    if (account.agentEmail) evidence.bound_agent = account.agentEmail;
+    rec.pass(
+      "api.auth",
+      "API credentials",
+      `key valid — scope ${account.scope}, plan ${account.planCode}`,
+      { evidence },
+    );
+  } catch (err) {
+    const { kind, message } = classifyError(err);
+    if (kind === "auth") {
+      rec.fail("api.auth", "API credentials", "unauthorized", "auth", `key rejected: ${message}`, {
+        remediation: "run `e2a login` again, or set a valid E2A_API_KEY (e2a keys list)",
+      });
+    } else if (kind === "transient") {
+      rec.fail("api.auth", "API credentials", "connection_failed", "transient", message);
+    } else {
+      rec.fail("api.auth", "API credentials", "http_error", "config", message);
+    }
+  }
+}
+
+async function checkAgentAccess(ctx: Ctx): Promise<void> {
+  const { rec, opts, config } = ctx;
+  const email = opts.agent || config.agent_email || ctx.account?.agentEmail || "";
+  if (!ctx.config.api_key || !ctx.apiReachable || !ctx.account) {
+    rec.skip("agent.access", "Agent access", "blocked_by_failure", "skipped: API credentials not verified", {
+      evidence: { blocked_on: ctx.config.api_key ? (ctx.apiReachable ? "api.auth" : "api.reachability") : "cli.config" },
+    });
+    return;
+  }
+  if (!email) {
+    rec.skip(
+      "agent.access",
+      "Agent access",
+      "no_agent_selected",
+      "skipped: no agent selected",
+      { remediation: "pass --agent, set E2A_AGENT_EMAIL, or run `e2a config set agent_email <email>`" },
+    );
+    return;
+  }
+  try {
+    const agent = await ctx.client!.agents.get(email);
+    rec.pass(
+      "agent.access",
+      "Agent access",
+      `agent exists${agent.domainVerified ? "" : " (domain unverified)"}`,
+      {
+        target: email,
+        evidence: { email: agent.email, domain: agent.domain, domain_verified: agent.domainVerified },
+      },
+    );
+  } catch (err) {
+    const { kind, message } = classifyError(err);
+    if (kind === "not_found") {
+      rec.fail("agent.access", "Agent access", "agent_not_found", "config", `no agent ${email}`, {
+        target: email,
+        remediation: "check the address (`e2a agents list`) or create it (`e2a agents create`)",
+      });
+    } else if (kind === "auth") {
+      rec.fail("agent.access", "Agent access", "forbidden", "auth", `key cannot access ${email}: ${message}`, {
+        target: email,
+        remediation: "this key is bound to a different inbox — use that inbox or an account-scoped key",
+      });
+    } else if (kind === "transient") {
+      rec.fail("agent.access", "Agent access", "connection_failed", "transient", message, { target: email });
+    } else {
+      rec.fail("agent.access", "Agent access", "http_error", "config", message, { target: email });
+    }
+  }
+}
+
+// --- domains ---------------------------------------------------------------
+
+interface DomainRecord {
+  type: string;
+  name: string;
+  value: string;
+  priority: number | null;
+  purpose: string;
+  status: string;
+}
+
+interface DomainLike {
+  domain: string;
+  verified: boolean;
+  agentCount: number;
+  sendingStatus: string;
+  sendingError?: string;
+  dnsRecords: DomainRecord[];
+}
+
+async function collect<T>(pager: AsyncIterable<T>, max: number): Promise<{ items: T[]; truncated: boolean }> {
+  const items: T[] = [];
+  for await (const item of pager) {
+    if (items.length >= max) return { items, truncated: true };
+    items.push(item);
+  }
+  return { items, truncated: false };
+}
+
+const normHost = (h: string): string => h.toLowerCase().replace(/\.$/, "");
+/** DKIM values are compared with quotes/whitespace stripped: providers split
+ * and re-quote long TXT values, which is cosmetic, not a mismatch. */
+const normDkim = (s: string): string => s.replace(/["\s]/g, "");
+
+async function checkTxtRecord(
+  ctx: Ctx,
+  id: string,
+  title: string,
+  domain: string,
+  record: DomainRecord,
+): Promise<void> {
+  const { rec, io } = ctx;
+  const dkim = record.purpose === "dkim";
+  let published: string[];
+  try {
+    published = await io.resolveTxt(record.name);
+  } catch (err) {
+    rec.fail(id, title, "dns_lookup_failed", "transient", `TXT lookup for ${record.name} failed`, {
+      target: record.name,
+      evidence: { error: err instanceof Error ? err.message : String(err) },
+      remediation: "DNS lookup was inconclusive — retry, or check the record with `dig TXT " + record.name + "`",
+    });
+    return;
+  }
+  const matches = dkim
+    ? published.some((v) => normDkim(v) === normDkim(record.value))
+    : published.some((v) => v.trim() === record.value.trim());
+  if (matches) {
+    rec.pass(id, title, `${domain}: TXT record found at ${record.name}`, {
+      target: record.name,
+      evidence: { expected: record.value, server_status: record.status },
+    });
+    return;
+  }
+  // A same-purpose record with a different value is a mismatch (stale copy);
+  // otherwise the record is simply missing among unrelated TXT entries.
+  const prefix = dkim ? "v=DKIM1" : record.value.startsWith("v=spf1") ? "v=spf1" : undefined;
+  const conflicting = prefix ? published.filter((v) => v.trim().startsWith(prefix)) : [];
+  if (conflicting.length > 0) {
+    rec.fail(id, title, "record_mismatch", "config", `${domain}: TXT at ${record.name} does not match`, {
+      target: record.name,
+      evidence: { expected: record.value, found: conflicting, server_status: record.status },
+      remediation: `replace the TXT record at ${record.name} with "${record.value}"`,
+    });
+    return;
+  }
+  rec.fail(id, title, "record_missing", "config", `${domain}: TXT record missing at ${record.name}`, {
+    target: record.name,
+    evidence: { expected: record.value, server_status: record.status },
+    remediation: `add TXT record ${record.name} with value "${record.value}"`,
+  });
+}
+
+async function checkMxRecord(
+  ctx: Ctx,
+  id: string,
+  title: string,
+  domain: string,
+  record: DomainRecord,
+  extraEvidence: Record<string, unknown> = {},
+): Promise<void> {
+  const { rec, io } = ctx;
+  let published: Array<{ exchange: string; priority: number }>;
+  try {
+    published = await io.resolveMx(record.name);
+  } catch (err) {
+    rec.fail(id, title, "dns_lookup_failed", "transient", `MX lookup for ${record.name} failed`, {
+      target: record.name,
+      evidence: { error: err instanceof Error ? err.message : String(err), ...extraEvidence },
+      remediation: "DNS lookup was inconclusive — retry, or check the record with `dig MX " + record.name + "`",
+    });
+    return;
+  }
+  const remediation = `add MX record ${record.name} → ${record.value}` +
+    (record.priority !== null ? ` (priority ${record.priority})` : "");
+  if (published.some((mx) => normHost(mx.exchange) === normHost(record.value))) {
+    rec.pass(id, title, `${domain}: MX record found (${record.value})`, {
+      target: record.name,
+      evidence: { expected: record.value, server_status: record.status, ...extraEvidence },
+    });
+  } else if (published.length > 0) {
+    rec.fail(id, title, "record_mismatch", "config", `${domain}: MX at ${record.name} points elsewhere`, {
+      target: record.name,
+      evidence: {
+        expected: record.value,
+        found: published.map((mx) => normHost(mx.exchange)).sort(),
+        server_status: record.status,
+        ...extraEvidence,
+      },
+      remediation,
+    });
+  } else {
+    rec.fail(id, title, "record_missing", "config", `${domain}: MX record missing — expected ${record.value}`, {
+      target: record.name,
+      evidence: { expected: record.value, server_status: record.status, ...extraEvidence },
+      remediation,
+    });
+  }
+}
+
+async function checkOneDomain(ctx: Ctx, domain: DomainLike): Promise<void> {
+  const { rec, io } = ctx;
+  const d = domain.domain;
+  rec.pass("domain.registered", "Domain registration", `${d}: registered${domain.verified ? ", verified" : ", not yet verified"}`, {
+    target: d,
+    evidence: { verified: domain.verified, sending_status: domain.sendingStatus, agent_count: domain.agentCount },
+  });
+
+  const byPurpose = new Map<string, DomainRecord>();
+  for (const r of domain.dnsRecords) byPurpose.set(r.purpose, r);
+
+  const ownership = byPurpose.get("ownership");
+  if (ownership) await checkTxtRecord(ctx, "domain.ownership", "Ownership TXT record", d, ownership);
+
+  const mx = byPurpose.get("inbound_mx");
+  if (mx) {
+    const wildcardPrescribed = byPurpose.has("inbound_mx_wildcard");
+    await checkMxRecord(
+      ctx,
+      "domain.mx",
+      "Inbound MX record",
+      d,
+      mx,
+      wildcardPrescribed ? { wildcard_prescribed: true } : {},
+    );
+  }
+
+  const dkim = byPurpose.get("dkim");
+  if (dkim) {
+    await checkTxtRecord(ctx, "domain.dkim", "DKIM TXT record", d, dkim);
+  } else {
+    rec.skip("domain.dkim", "DKIM TXT record", "not_prescribed", `${d}: no DKIM record prescribed yet`, {
+      target: d,
+      remediation: "DKIM is provisioned after domain verification — publish the ownership TXT and inbound MX first",
+    });
+  }
+
+  const mailFromMx = byPurpose.get("mail_from_mx");
+  if (mailFromMx) {
+    await checkMxRecord(ctx, "domain.mailfrom_mx", "MAIL FROM MX record", d, mailFromMx);
+  } else {
+    rec.skip("domain.mailfrom_mx", "MAIL FROM MX record", "not_prescribed", `${d}: no MAIL FROM MX prescribed`, {
+      target: d,
+    });
+  }
+
+  const spf = byPurpose.get("mail_from_spf");
+  if (spf) {
+    await checkTxtRecord(ctx, "domain.spf", "SPF TXT record", d, spf);
+  } else {
+    rec.skip("domain.spf", "SPF TXT record", "not_prescribed", `${d}: no SPF record prescribed`, {
+      target: d,
+    });
+  }
+
+  // DMARC is advisory: e2a does not prescribe a record, but receivers
+  // increasingly require one for inbox placement. Warn-only, never fail.
+  const dmarcName = `_dmarc.${d}`;
+  try {
+    const dmarc = (await io.resolveTxt(dmarcName)).filter((v) => v.trim().startsWith("v=DMARC1"));
+    if (dmarc.length > 0) {
+      rec.pass("domain.dmarc", "DMARC record (advisory)", `${d}: DMARC record present`, {
+        target: dmarcName,
+        evidence: { record: dmarc[0] },
+      });
+    } else {
+      rec.warn("domain.dmarc", "DMARC record (advisory)", "no_dmarc_record", `${d}: no DMARC record`, {
+        target: dmarcName,
+        remediation: `add TXT record ${dmarcName} with value "v=DMARC1; p=none;" and tighten the policy once reports look clean`,
+      });
+    }
+  } catch (err) {
+    rec.fail("domain.dmarc", "DMARC record (advisory)", "dns_lookup_failed", "transient", `TXT lookup for ${dmarcName} failed`, {
+      target: dmarcName,
+      evidence: { error: err instanceof Error ? err.message : String(err) },
+    });
+  }
+
+  switch (domain.sendingStatus) {
+    case "verified":
+      rec.pass("domain.sending", "Sending status", `${d}: sending identity verified`, { target: d });
+      break;
+    case "pending":
+      rec.warn("domain.sending", "Sending status", "sending_pending", `${d}: sending identity still pending`, {
+        target: d,
+        remediation: "publish the prescribed DNS records and allow time for propagation, then re-run doctor",
+      });
+      break;
+    case "failed":
+      rec.fail("domain.sending", "Sending status", "sending_failed", "config", `${d}: sending identity failed`, {
+        target: d,
+        evidence: { sending_error: domain.sendingError ?? "" },
+        remediation: "fix the reported record, then re-verify the domain from the dashboard or MCP tools",
+      });
+      break;
+    default:
+      rec.skip("domain.sending", "Sending status", "sending_not_provisioned", `${d}: sending identity not provisioned`, {
+        target: d,
+      });
+  }
+}
+
+async function checkDomains(ctx: Ctx): Promise<void> {
+  const { rec, opts } = ctx;
+  if (!ctx.account) {
+    rec.skip("domain.registered", "Domain registration", "blocked_by_failure", "skipped: API credentials not verified", {
+      evidence: { blocked_on: "api.auth" },
+    });
+    return;
+  }
+  if (ctx.account.scope !== "account") {
+    rec.skip(
+      "domain.registered",
+      "Domain registration",
+      "requires_account_scope",
+      "skipped: domain checks need an account-scoped key",
+      { remediation: "run doctor with an account-scoped key (`e2a login`) to check custom domains" },
+    );
+    return;
+  }
+  let domains: DomainLike[];
+  let truncated = false;
+  try {
+    if (opts.domain) {
+      domains = [(await ctx.client!.domains.get(opts.domain)) as unknown as DomainLike];
+    } else {
+      const collected = await collect(ctx.client!.domains.list({}) as AsyncIterable<DomainLike>, MAX_DOMAINS);
+      domains = collected.items;
+      truncated = collected.truncated;
+    }
+  } catch (err) {
+    const { kind, message } = classifyError(err);
+    if (kind === "not_found" && opts.domain) {
+      rec.fail("domain.registered", "Domain registration", "not_registered", "config", `${opts.domain} is not registered on this account`, {
+        target: opts.domain,
+        remediation: "register it first (dashboard or MCP `register_domain`), or check the spelling",
+      });
+    } else if (kind === "transient") {
+      rec.fail("domain.registered", "Domain registration", "connection_failed", "transient", message);
+    } else {
+      rec.fail("domain.registered", "Domain registration", "http_error", "config", message);
+    }
+    return;
+  }
+  if (domains.length === 0) {
+    rec.skip("domain.registered", "Domain registration", "no_domains", "no custom domains registered — using the shared domain", {
+      evidence: ctx.info?.shared_domain ? { shared_domain: ctx.info.shared_domain } : undefined,
+    });
+    return;
+  }
+  if (truncated) {
+    rec.warn("domain.registered", "Domain registration", "too_many_domains", `only the first ${MAX_DOMAINS} domains were checked`, {
+      evidence: { checked: MAX_DOMAINS },
+      remediation: "re-run with --domain <domain> to check a specific domain",
+    });
+  }
+  for (const domain of domains) {
+    await checkOneDomain(ctx, domain);
+  }
+}
+
+// --- MCP ---------------------------------------------------------------------
+
+async function checkMcp(ctx: Ctx): Promise<void> {
+  const { rec, io, opts, config } = ctx;
+  const mcpUrl = opts.mcpUrl ?? (config.api_url === HOSTED_URL ? HOSTED_MCP_URL : undefined);
+  if (!mcpUrl) {
+    const detail = "skipped: no MCP endpoint known for this deployment";
+    const remediation = "pass --mcp-url https://<host>/mcp to probe a self-hosted MCP server";
+    rec.skip("mcp.reachability", "MCP reachability", "no_mcp_url", detail, { remediation });
+    rec.skip("mcp.auth_metadata", "MCP auth metadata", "no_mcp_url", detail, { remediation });
+    return;
+  }
+  try {
+    // Any HTTP response (405 for GET on a POST-only endpoint, 401 without a
+    // token) proves the endpoint is routed and alive; only a network-level
+    // failure is a problem. GET carries no JSON-RPC payload → no side effects.
+    const res = await io.httpGet(mcpUrl);
+    rec.pass("mcp.reachability", "MCP reachability", `endpoint responded (HTTP ${res.status})`, {
+      target: mcpUrl,
+      evidence: { http_status: res.status },
+    });
+  } catch (err) {
+    rec.fail("mcp.reachability", "MCP reachability", "connection_failed", "transient", `cannot reach ${mcpUrl}`, {
+      target: mcpUrl,
+      evidence: { error: err instanceof Error ? err.message : String(err) },
+      remediation: "check the MCP host and network; for self-hosted, confirm the MCP server is running",
+    });
+  }
+
+  const metadataUrl = `${new URL(mcpUrl).origin}/.well-known/oauth-protected-resource`;
+  try {
+    const res = await io.httpGet(metadataUrl);
+    if (res.status !== 200) {
+      rec.warn("mcp.auth_metadata", "MCP auth metadata", "metadata_missing", `HTTP ${res.status} from ${metadataUrl}`, {
+        target: metadataUrl,
+        evidence: { http_status: res.status },
+        remediation: "OAuth clients discover the authorization server here (RFC 9728); interactive MCP login may fail without it",
+      });
+      return;
+    }
+    let meta: { authorization_servers?: unknown; scopes_supported?: unknown };
+    try {
+      meta = JSON.parse(res.body) as typeof meta;
+    } catch {
+      meta = {};
+    }
+    if (!Array.isArray(meta.authorization_servers) || meta.authorization_servers.length === 0) {
+      rec.warn("mcp.auth_metadata", "MCP auth metadata", "metadata_invalid", `no authorization_servers advertised at ${metadataUrl}`, {
+        target: metadataUrl,
+      });
+      return;
+    }
+    rec.pass("mcp.auth_metadata", "MCP auth metadata", `advertises ${(meta.authorization_servers as string[]).join(", ")}`, {
+      target: metadataUrl,
+      evidence: {
+        authorization_servers: meta.authorization_servers,
+        scopes_supported: meta.scopes_supported,
+      },
+    });
+  } catch (err) {
+    rec.fail("mcp.auth_metadata", "MCP auth metadata", "connection_failed", "transient", `cannot reach ${metadataUrl}`, {
+      target: metadataUrl,
+      evidence: { error: err instanceof Error ? err.message : String(err) },
+    });
+  }
+}
+
+// --- webhooks -----------------------------------------------------------------
+
+interface WebhookLike {
+  id: string;
+  url: string;
+  enabled: boolean;
+  events: string[];
+  autoDisabledAt?: Date;
+  lastDeliveredAt?: Date;
+}
+
+interface DeliveryLike {
+  status: string;
+  attempts: number;
+  lastError?: string;
+  lastStatusCode?: number;
+  lastAttemptAt?: Date;
+}
+
+async function checkWebhooks(ctx: Ctx): Promise<void> {
+  const { rec } = ctx;
+  if (!ctx.account) {
+    rec.skip("webhook.config", "Webhook configuration", "blocked_by_failure", "skipped: API credentials not verified", {
+      evidence: { blocked_on: "api.auth" },
+    });
+    return;
+  }
+  if (ctx.account.scope !== "account") {
+    rec.skip(
+      "webhook.config",
+      "Webhook configuration",
+      "requires_account_scope",
+      "skipped: webhook checks need an account-scoped key",
+      { remediation: "run doctor with an account-scoped key (`e2a login`) to check webhooks" },
+    );
+    return;
+  }
+  let webhooks: WebhookLike[];
+  try {
+    webhooks = (await collect(ctx.client!.webhooks.list({}) as AsyncIterable<WebhookLike>, MAX_WEBHOOKS)).items;
+  } catch (err) {
+    const { kind, message } = classifyError(err);
+    rec.fail(
+      "webhook.config",
+      "Webhook configuration",
+      kind === "transient" ? "connection_failed" : "http_error",
+      kind === "transient" ? "transient" : "config",
+      message,
+    );
+    return;
+  }
+  if (webhooks.length === 0) {
+    rec.skip("webhook.config", "Webhook configuration", "no_webhooks", "no webhooks configured — agents rely on WebSocket, polling, or MCP", {});
+    return;
+  }
+
+  for (const wh of webhooks) {
+    if (wh.autoDisabledAt) {
+      rec.fail("webhook.config", "Webhook configuration", "webhook_auto_disabled", "config", `${wh.id}: auto-disabled after repeated delivery failures`, {
+        target: wh.url,
+        evidence: { id: wh.id, auto_disabled_at: new Date(wh.autoDisabledAt).toISOString() },
+        remediation: "fix the receiving endpoint, then re-enable the webhook (dashboard or MCP `update_webhook`)",
+      });
+    } else if (!wh.enabled) {
+      rec.warn("webhook.config", "Webhook configuration", "webhook_disabled", `${wh.id}: disabled`, {
+        target: wh.url,
+        evidence: { id: wh.id },
+        remediation: "events are not being delivered — re-enable it if that is unintended",
+      });
+    } else if (!wh.url.startsWith("https://")) {
+      rec.warn("webhook.config", "Webhook configuration", "insecure_url", `${wh.id}: URL is not HTTPS`, {
+        target: wh.url,
+        evidence: { id: wh.id },
+        remediation: "use an HTTPS endpoint — production deployments reject plain HTTP webhook URLs",
+      });
+    } else {
+      rec.pass("webhook.config", "Webhook configuration", `${wh.id}: enabled, ${wh.events.length} event type(s)`, {
+        target: wh.url,
+        evidence: { id: wh.id, events: wh.events },
+      });
+    }
+
+    try {
+      const deliveries = (await collect(
+        ctx.client!.webhooks.deliveries(wh.id, { limit: MAX_DELIVERIES }) as AsyncIterable<DeliveryLike>,
+        MAX_DELIVERIES,
+      )).items;
+      const latest = deliveries[0];
+      if (!latest || (latest.status === "pending" && latest.attempts === 0)) {
+        rec.skip("webhook.delivery", "Webhook delivery history", "no_deliveries", `${wh.id}: no completed deliveries yet`, {
+          target: wh.id,
+        });
+      } else if (latest.status === "delivered") {
+        const evidence: Record<string, unknown> = { last_status: "delivered" };
+        if (latest.lastStatusCode !== undefined) evidence.last_status_code = latest.lastStatusCode;
+        rec.pass("webhook.delivery", "Webhook delivery history", `${wh.id}: latest delivery succeeded`, {
+          target: wh.id,
+          evidence,
+        });
+      } else {
+        rec.warn("webhook.delivery", "Webhook delivery history", "deliveries_failing", `${wh.id}: latest delivery ${latest.status}`, {
+          target: wh.id,
+          evidence: {
+            last_status: latest.status,
+            last_error: latest.lastError ?? "",
+            last_status_code: latest.lastStatusCode ?? 0,
+            attempts: latest.attempts,
+          },
+          remediation: "check the receiving endpoint's logs and TLS setup; deliveries retry with backoff",
+        });
+      }
+    } catch (err) {
+      const { kind, message } = classifyError(err);
+      rec.fail(
+        "webhook.delivery",
+        "Webhook delivery history",
+        kind === "transient" ? "connection_failed" : "http_error",
+        kind === "transient" ? "transient" : "config",
+        `${wh.id}: ${message}`,
+        { target: wh.id },
+      );
+    }
+  }
+
+  rec.skip(
+    "webhook.reachability",
+    "Webhook reachability",
+    "no_safe_probe",
+    "skipped: no safe non-delivering probe exists (POST /v1/webhooks/{id}/test delivers a real event) — webhook.delivery reflects observed reachability",
+    {},
+  );
+}
+
+// --- outbound SMTP visibility ---------------------------------------------------
+
+function checkSmtpConfig(ctx: Ctx): void {
+  const { rec, io } = ctx;
+  const host = io.env("E2A_OUTBOUND_SMTP_HOST");
+  const port = io.env("E2A_OUTBOUND_SMTP_PORT");
+  const fromDomain = io.env("E2A_OUTBOUND_SMTP_FROM_DOMAIN");
+  const credentialsSet = Boolean(io.env("E2A_OUTBOUND_SMTP_USERNAME") || io.env("E2A_OUTBOUND_SMTP_PASSWORD"));
+  if (!host && !port && !fromDomain) {
+    rec.skip(
+      "smtp.config",
+      "Outbound SMTP configuration",
+      "not_visible",
+      "no E2A_OUTBOUND_SMTP_* environment visible from this machine (normal for hosted e2a; self-hosted operators should run doctor on the server host)",
+      {},
+    );
+    return;
+  }
+  // Never echo E2A_OUTBOUND_SMTP_USERNAME / _PASSWORD — presence only.
+  const evidence: Record<string, unknown> = {
+    host: host ?? "",
+    port: port ?? "",
+    from_domain: fromDomain ?? "",
+    credentials: credentialsSet ? "set" : "not_set",
+  };
+  if (host && fromDomain) {
+    rec.pass("smtp.config", "Outbound SMTP configuration", `outbound SMTP via ${host}${port ? `:${port}` : ""}, from_domain ${fromDomain}`, {
+      evidence,
+    });
+  } else {
+    rec.warn("smtp.config", "Outbound SMTP configuration", "smtp_partial", "outbound SMTP configuration is incomplete", {
+      evidence,
+      remediation: "set E2A_OUTBOUND_SMTP_HOST, E2A_OUTBOUND_SMTP_PORT, and E2A_OUTBOUND_SMTP_FROM_DOMAIN together",
+    });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Runner + output
+// ---------------------------------------------------------------------------
+
+export async function runDoctor(opts: DoctorOptions, io: DoctorIO): Promise<DoctorReport> {
+  const config = loadConfig();
+  const rec = new Recorder();
+  const ctx: Ctx = { io, rec, config, opts, apiReachable: false };
+  if (config.api_key) {
+    ctx.client = createClient({ timeoutMs: DOCTOR_TIMEOUT_MS, maxRetries: 0 });
+  }
+
+  checkCliConfig(ctx);
+  await checkApiReachability(ctx);
+  await checkApiAuth(ctx);
+  await checkAgentAccess(ctx);
+  await checkDomains(ctx);
+  await checkMcp(ctx);
+  await checkWebhooks(ctx);
+  checkSmtpConfig(ctx);
+
+  return buildReport(io, config.api_url, rec);
+}
+
+function renderHuman(report: DoctorReport): string {
+  const lines: string[] = [
+    `doctor: read-only diagnostics for ${report.deployment_url} (sends no mail; changes no DNS or webhooks)`,
+    "",
+  ];
+  for (const c of report.checks) {
+    lines.push(`${c.status.padEnd(4)}  ${c.id.padEnd(22)}${c.detail}`);
+    if (c.remediation && (c.status === "fail" || c.status === "warn")) {
+      lines.push(`      fix: ${c.remediation}`);
+    }
+  }
+  const s = report.summary;
+  lines.push(
+    "",
+    `${s.fail} fail, ${s.warn} warn, ${s.pass} pass, ${s.skip} skip — ${report.status} (exit ${report.exit_code})`,
+  );
+  return lines.join("\n") + "\n";
+}
+
+export async function doctor(opts: DoctorOptions, io: DoctorIO = defaultIO()): Promise<void> {
+  const report = await runDoctor(opts, io);
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(report, null, 2) + "\n");
+  } else {
+    process.stdout.write(renderHuman(report));
+  }
+  // exitCode (not process.exit) so stdout flushes; doctor holds no sockets open.
+  process.exitCode = report.exit_code;
+}

--- a/cli/src/exit.ts
+++ b/cli/src/exit.ts
@@ -31,6 +31,20 @@ export const EXIT = {
   TIMEOUT: 6,
   /** A persisted send failed or returned an unknown outcome; do not retry. */
   SEND_OUTCOME: 7,
+  /**
+   * Diagnostics (`doctor`) completed with warnings only — nothing is broken,
+   * but something deserves attention. Distinct from OK so CI can gate on a
+   * fully clean environment without parsing the report.
+   */
+  WARN: 8,
+  /**
+   * Diagnostics found a definite configuration failure (missing DNS record,
+   * unregistered domain, auto-disabled webhook, wrong deployment URL).
+   * Distinct from ERROR (1) so retry-on-transient wrappers don't loop on a
+   * problem that only a human fixing configuration can resolve, and from
+   * REQUEST (5) because nothing about the invocation itself was wrong.
+   */
+  CONFIG: 9,
 } as const;
 
 export function exitCodeForAPIError(error: { code: string; retryable: boolean }): number {

--- a/cli/src/sdk.ts
+++ b/cli/src/sdk.ts
@@ -2,10 +2,17 @@ import { E2AClient } from "@e2a/sdk/v1";
 import { loadConfig, requireApiKey } from "./config.js";
 import { EXIT, fail } from "./exit.js";
 
-export function createClient(): E2AClient {
+export interface CreateClientOptions {
+  /** Per-attempt request timeout in ms (SDK default 30000). */
+  timeoutMs?: number;
+  /** Retry budget (SDK default 2). `doctor` sets 0: it reports, not retries. */
+  maxRetries?: number;
+}
+
+export function createClient(options: CreateClientOptions = {}): E2AClient {
   const config = loadConfig();
   const apiKey = requireApiKey(config);
-  return new E2AClient({ apiKey, baseUrl: config.api_url });
+  return new E2AClient({ apiKey, baseUrl: config.api_url, ...options });
 }
 
 export function requireAgentEmail(fromOverride?: string): string {

--- a/cli/src/sdk.ts
+++ b/cli/src/sdk.ts
@@ -1,5 +1,5 @@
 import { E2AClient } from "@e2a/sdk/v1";
-import { loadConfig, requireApiKey } from "./config.js";
+import { loadConfig, requireApiKey, type Config } from "./config.js";
 import { EXIT, fail } from "./exit.js";
 
 export interface CreateClientOptions {
@@ -9,8 +9,13 @@ export interface CreateClientOptions {
   maxRetries?: number;
 }
 
-export function createClient(options: CreateClientOptions = {}): E2AClient {
-  const config = loadConfig();
+export function createClient(
+  options: CreateClientOptions = {},
+  // Callers that already loaded (and possibly normalized) the config pass it
+  // through so the client uses the exact same URL and the config file isn't
+  // parsed twice per invocation.
+  config: Config = loadConfig(),
+): E2AClient {
   const apiKey = requireApiKey(config);
   return new E2AClient({ apiKey, baseUrl: config.api_url, ...options });
 }


### PR DESCRIPTION
## Summary

Adds `e2a doctor` — a strictly read-only diagnostic command for the production email path, per the production-trust strategy (§6.3 / roadmap "Ship `e2a doctor` with human and JSON output"). It diagnoses configuration and the production path end-to-end while guaranteeing it never sends mail and never mutates server state, DNS, or webhooks.

**Checks** (18 stable IDs): CLI config + credential scope · API connectivity/version (`GET /v1/info`) · key validity/scope (`GET /v1/account`) · agent existence/access · per registered custom domain, **live DNS lookups** of the server-prescribed records (ownership TXT, inbound MX, DKIM TXT, MAIL FROM MX, SPF with the server's inclusion semantics) plus an advisory warn-only DMARC check and the SES sending-status rollup · MCP endpoint reachability + advertised OAuth metadata (RFC 9728) · webhook config + recent delivery history · outbound SMTP env visibility for self-hosted operators (credential *presence* only — values never printed).

**Read-only guarantee**: only GETs and client-side DNS. Deliberately avoids `POST /v1/domains/{d}/verify` (mutates verification state + enqueues SES provisioning), `POST /v1/webhooks/{id}/test` (delivers a real event), and `POST /v1/agents/{email}/test` (sends real mail). Webhook reachability is an explicit `skip: no_safe_probe`, with delivery history as the observed signal.

**Output**: human `pass/warn/fail/skip` lines with `fix:` remediations; `--json` emits a versioned `e2a.doctor/v1` report (`id`, `status`, `reason_code`, `target`, `detail`, `evidence`, `remediation`) locked by two golden fixtures (regenerate with `UPDATE_DOCTOR_FIXTURES=1`).

**Exit codes** (additive to the frozen contract — nothing renumbered; values pinned by a new test): `0` healthy · `8` (new `EXIT.WARN`) warnings only · `9` (new `EXIT.CONFIG`) definite configuration failure · `4` auth failure · `1` transient connectivity · `2` usage. Precedence auth > config > transient > warn, each rung individually tested.

**Timeouts**: every network op bounded by 5s (`AbortSignal.timeout` for HTTP; `Resolver` timeout plus a hard per-lookup deadline race for DNS, since the resolver option is per-server/per-try).

The second commit applies fixes from an adversarial review pass: malformed `--mcp-url` crash (was: unhandled `new URL()` throw discarding the whole report), MCP 404 false-positive, SPF strict-equality false-negative, DNS deadline hardening, trailing-slash `E2A_URL` handling, and coverage for previously untested branches.

## Client surface checklist

- [x] CLI command or flag in `cli/src/commands/` + wired into `cli/src/bin/e2a.ts`
- [x] Tests at each surface above (positive + negative-path cases: 52 doctor tests + exit-code pinning)

> All other rows intentionally skipped: **no `/v1` API change** — doctor only consumes existing read-only endpoints, so there is nothing to mirror into the Go handlers, spec, SDKs, MCP, or dashboard. No migrations.

## Operational risk

None to the server — the command is client-side and read-only by construction (a test asserts no probe URL contains `/test` or `/verify`, and the review pass verified every SDK call maps to a GET). New exit codes 8/9 are additive; existing scripts branching on 0–7 are unaffected. Credentials are never echoed (test-asserted).

## Test plan

- [x] `npm test --workspace @e2a/cli` — 226 passed (15 files), including 52 doctor tests covering every check status (pass/warn/fail/skip) and every exit-code path (0/1/2/4/8/9)
- [x] `npm run build --workspace @e2a/cli` — clean
- [x] Golden JSON fixtures lock the `e2a.doctor/v1` schema
- [x] `scripts/check-repository-text-integrity.sh`, `scripts/check-sdk-version-sync.mjs` — pass
- [x] Live smoke vs production: healthy account → exit 8 with only genuine DMARC advisories across 6 custom domains (all live DNS checks pass); `--json` parses; `--mcp-url notaurl` → exit 2; `-h` short-circuits before any network call
- [ ] Post-merge: run `e2a doctor` from a machine with a stale/invalid key → expect exit 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)