### PR TITLE
test(internal): raise coverage on 6 packages, expand coverage gates

### DIFF
--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -30,9 +30,17 @@ override:
   - threshold: 75
     path: ^internal/outboundsend$
   # Sending-ramp storage + River janitor — pre-provider abuse-control state.
-  - threshold: 70
+  - threshold: 80
     path: ^internal/sendramp$
   # Inbound processing on River — the at-least-once worker + reconciler + retention.
   # (The relay-side ProcessIntake adapter is covered cross-package by relay tests.)
   - threshold: 65
     path: ^internal/inboundprocess$
+  # Webhook delivery on River — SSRF-guarded POST worker, retry/backoff,
+  # signing-secret rotation, and the stranded-delivery reconciler.
+  - threshold: 88
+    path: ^internal/webhookdelivery$
+  # Durable job runtime — River client wiring + the generic stranded-row
+  # reconciler every queue-first flow relies on.
+  - threshold: 82
+    path: ^internal/jobs$

--- a/.testcoverage.yml
+++ b/.testcoverage.yml
@@ -44,3 +44,14 @@ override:
   # reconciler every queue-first flow relies on.
   - threshold: 82
     path: ^internal/jobs$
+  # API-key auth + user/dashboard session handlers — the authentication
+  # boundary for every /v1 request.
+  - threshold: 88
+    path: ^internal/auth$
+  # Process assembly — HTTP handler wiring, dep construction, delete-domain
+  # transactional hooks. Remainder is DNS/external-provider closures.
+  - threshold: 70
+    path: ^internal/apiserver$
+  # Agent-to-self loopback delivery — self-send detection and MIME compose.
+  - threshold: 95
+    path: ^internal/loopback$

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,7 +272,7 @@ manually on every API change even though the template won't remind you.
   `./internal/sendramp` and `./internal/outboundsend` with `-race`.
 - **Coverage ratchet**: `.testcoverage.yml` sets per-package floors (currently
   webhook, webhookpub, webhookdelivery, httpapi, outboundsend, sendramp,
-  inboundprocess, jobs).
+  inboundprocess, jobs, auth, apiserver, loopback).
   Ratchet floors UP, never down. `make cover-check` runs the same gate CI
   runs (`vladopajic/go-test-coverage`).
 - **Contract tests**: TS and Python SDK contract tests run against

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -271,7 +271,8 @@ manually on every API change even though the template won't remind you.
   runs everything with `-tags integration -p 1`. CI additionally race-checks
   `./internal/sendramp` and `./internal/outboundsend` with `-race`.
 - **Coverage ratchet**: `.testcoverage.yml` sets per-package floors (currently
-  webhook, webhookpub, httpapi, outboundsend, sendramp, inboundprocess).
+  webhook, webhookpub, webhookdelivery, httpapi, outboundsend, sendramp,
+  inboundprocess, jobs).
   Ratchet floors UP, never down. `make cover-check` runs the same gate CI
   runs (`vladopajic/go-test-coverage`).
 - **Contract tests**: TS and Python SDK contract tests run against

--- a/internal/apiserver/apiserver_db_test.go
+++ b/internal/apiserver/apiserver_db_test.go
@@ -1,0 +1,199 @@
+package apiserver_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/tokencanopy/e2a/internal/agent"
+	"github.com/tokencanopy/e2a/internal/apiserver"
+	"github.com/tokencanopy/e2a/internal/httpapi"
+	"github.com/tokencanopy/e2a/internal/identity"
+	"github.com/tokencanopy/e2a/internal/limits"
+	"github.com/tokencanopy/e2a/internal/testutil"
+	"github.com/tokencanopy/e2a/internal/usage"
+	"github.com/tokencanopy/e2a/internal/webhook"
+)
+
+// fakeSenderIdentity records SenderIdentityEnqueuer calls so the transactional
+// teardown contract can be asserted without SES/River.
+type fakeSenderIdentity struct {
+	deprovisionErr error
+	deprovisioned  []string
+}
+
+func (f *fakeSenderIdentity) EnqueueProvision(_ context.Context, _ string) error {
+	return nil
+}
+
+func (f *fakeSenderIdentity) EnqueueDeprovisionTx(_ context.Context, _ pgx.Tx, domain string) error {
+	f.deprovisioned = append(f.deprovisioned, domain)
+	return f.deprovisionErr
+}
+
+// realParams wires BuildDeps against a real (test) database — the same shape
+// the production binary and the contract harness use.
+func realParams(t *testing.T) (apiserver.Params, *identity.Store) {
+	t.Helper()
+	pool := testutil.TestDB(t)
+	store := identity.NewStore(pool)
+	usageStore := usage.NewStore(pool)
+	return apiserver.Params{
+		API:   &agent.API{},
+		Store: store,
+		Enforcer: limits.NewEnforcer(limits.NewStore(pool), usageStore, limits.Defaults{
+			PlanCode: "apiserver_test", MaxAgents: 100, MaxDomains: 100,
+			MaxMessagesMonth: 100, MaxStorageBytes: 1 << 40,
+		}, time.Minute),
+		UsageStore:      usageStore,
+		SubscriberStore: webhook.NewSubscriberStore(pool),
+		Pool:            pool,
+		SMTPDomain:      "test.e2a.dev",
+	}, store
+}
+
+func TestBuildDepsDeleteDomainWithSenderIdentity(t *testing.T) {
+	ctx := context.Background()
+	p, store := realParams(t)
+	fake := &fakeSenderIdentity{}
+	p.SenderIdentity = fake
+	deps := apiserver.BuildDeps(p)
+
+	user, err := store.CreateOrGetUser(ctx, "cov-del-owner@example.com", "Owner", "google-cov-del")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	const domain = "cov-del.example.com"
+	if _, err := store.ClaimOrCreateDomain(ctx, domain, user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+
+	if err := deps.DeleteDomain(ctx, domain, user.ID); err != nil {
+		t.Fatalf("DeleteDomain: %v", err)
+	}
+	if len(fake.deprovisioned) != 1 || fake.deprovisioned[0] != domain {
+		t.Fatalf("deprovisioned = %v, want [%s] — SES teardown must be enqueued", fake.deprovisioned, domain)
+	}
+	if _, err := store.LookupDomain(ctx, domain, user.ID); err == nil {
+		t.Fatal("domain row still present after DeleteDomain")
+	}
+}
+
+func TestBuildDepsDeleteDomainHookErrorRollsBack(t *testing.T) {
+	ctx := context.Background()
+	p, store := realParams(t)
+	hookErr := errors.New("ses enqueue failed")
+	fake := &fakeSenderIdentity{deprovisionErr: hookErr}
+	p.SenderIdentity = fake
+	deps := apiserver.BuildDeps(p)
+
+	user, err := store.CreateOrGetUser(ctx, "cov-rb-owner@example.com", "Owner", "google-cov-rb")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	const domain = "cov-rb.example.com"
+	if _, err := store.ClaimOrCreateDomain(ctx, domain, user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+
+	err = deps.DeleteDomain(ctx, domain, user.ID)
+	if !errors.Is(err, hookErr) {
+		t.Fatalf("DeleteDomain error = %v, want the hook error %v", err, hookErr)
+	}
+	// Atomicity contract (decision 4): a failed teardown enqueue rolls back
+	// the domain delete too — the row must still be there.
+	if _, err := store.LookupDomain(ctx, domain, user.ID); err != nil {
+		t.Fatalf("domain row gone after rolled-back delete: %v", err)
+	}
+}
+
+func TestBuildDepsGetUsageWithRealStores(t *testing.T) {
+	ctx := context.Background()
+	p, store := realParams(t)
+	deps := apiserver.BuildDeps(p)
+
+	user, err := store.CreateOrGetUser(ctx, "cov-usage@example.com", "Owner", "google-cov-usage")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+
+	// A fresh user has zero usage on every axis; the closure swallows
+	// per-metric errors, so a healthy DB must return exact zeros.
+	got := deps.GetUsage(ctx, user.ID)
+	if got.Agents != 0 || got.Domains != 0 || got.MessagesMonth != 0 || got.StorageBytes != 0 {
+		t.Fatalf("GetUsage = %+v, want all zeros for a fresh user", got)
+	}
+}
+
+func TestBuildDepsPoolClosuresWithRealStores(t *testing.T) {
+	ctx := context.Background()
+	p, store := realParams(t)
+	deps := apiserver.BuildDeps(p)
+
+	user, err := store.CreateOrGetUser(ctx, "cov-closures@example.com", "Owner", "google-cov-closures")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	const domain = "cov-closures.example.com"
+	if _, err := store.ClaimOrCreateDomain(ctx, domain, user.ID); err != nil {
+		t.Fatalf("ClaimOrCreateDomain: %v", err)
+	}
+
+	t.Run("send ramp snapshot for a claimed domain", func(t *testing.T) {
+		snap, err := deps.SendingRampSnapshot(ctx, user.ID, domain, time.Now())
+		if err != nil {
+			t.Fatalf("SendingRampSnapshot: %v", err)
+		}
+		if snap.Status == "" {
+			t.Fatal("SendingRampSnapshot returned an empty status for an existing domain")
+		}
+	})
+
+	t.Run("list events for a fresh user is empty", func(t *testing.T) {
+		events, err := deps.ListEvents(ctx, httpapi.EventQuery{UserID: user.ID, Limit: 10})
+		if err != nil {
+			t.Fatalf("ListEvents: %v", err)
+		}
+		if len(events) != 0 {
+			t.Fatalf("ListEvents = %d events, want 0 for a fresh user", len(events))
+		}
+	})
+
+	t.Run("get event with an unknown id errors", func(t *testing.T) {
+		if _, err := deps.GetEvent2(ctx, user.ID, "evt_does_not_exist"); err == nil {
+			t.Fatal("GetEvent2 with an unknown id returned nil error")
+		}
+	})
+
+	t.Run("load replay event with an unknown id errors", func(t *testing.T) {
+		if _, err := deps.LoadReplayEvent(ctx, user.ID, "evt_does_not_exist"); err == nil {
+			t.Fatal("LoadReplayEvent with an unknown id returned nil error")
+		}
+	})
+
+	t.Run("message lifecycle for an unknown message errors", func(t *testing.T) {
+		if _, err := deps.ListMessageLifecycle(ctx, "msg_does_not_exist", "agent@cov-closures.example.com"); err == nil {
+			t.Fatal("ListMessageLifecycle for an unknown message returned nil error")
+		}
+	})
+}
+
+func TestNewSmokeWithRealDeps(t *testing.T) {
+	p, _ := realParams(t)
+	srv := apiserver.New(p)
+
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/openapi.yaml", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /v1/openapi.yaml = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "openapi:") {
+		t.Fatalf("expected a YAML OpenAPI document, got: %.200s", rec.Body.String())
+	}
+}

--- a/internal/apiserver/apiserver_wiring_test.go
+++ b/internal/apiserver/apiserver_wiring_test.go
@@ -1,0 +1,236 @@
+package apiserver
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/tokencanopy/e2a/internal/agent"
+	"github.com/tokencanopy/e2a/internal/identity"
+	"github.com/tokencanopy/e2a/internal/limits"
+	"github.com/tokencanopy/e2a/internal/usage"
+	"github.com/tokencanopy/e2a/internal/webhook"
+)
+
+// minimalParams mirrors the zero-value wiring the existing package test uses:
+// every required dep present as an empty struct so BuildDeps can bind method
+// values without a database.
+func minimalParams() Params {
+	return Params{
+		API:             &agent.API{},
+		Store:           &identity.Store{},
+		Enforcer:        &limits.DBEnforcer{},
+		UsageStore:      &usage.Store{},
+		SubscriberStore: &webhook.SubscriberStore{},
+		Pool:            &pgxpool.Pool{},
+	}
+}
+
+// fakeSenderIdentity records SenderIdentityEnqueuer calls so tests can assert
+// on provisioning behavior without SES/River.
+type fakeSenderIdentity struct {
+	provisionErr   error
+	deprovisionErr error
+	provisioned    []string
+	deprovisioned  []string
+}
+
+func (f *fakeSenderIdentity) EnqueueProvision(_ context.Context, domain string) error {
+	f.provisioned = append(f.provisioned, domain)
+	return f.provisionErr
+}
+
+func (f *fakeSenderIdentity) EnqueueDeprovisionTx(_ context.Context, _ pgx.Tx, domain string) error {
+	f.deprovisioned = append(f.deprovisioned, domain)
+	return f.deprovisionErr
+}
+
+func TestNewServesOpenAPISpec(t *testing.T) {
+	srv := New(minimalParams())
+
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/openapi.yaml", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET /v1/openapi.yaml = %d, want 200; body: %s", rec.Code, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "openapi:") {
+		t.Fatalf("expected a YAML OpenAPI document, got: %.200s", rec.Body.String())
+	}
+}
+
+func TestNewUnknownV1RouteReturnsJSONNotFound(t *testing.T) {
+	legacyCalled := false
+	p := minimalParams()
+	p.Legacy = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		legacyCalled = true
+		w.WriteHeader(http.StatusTeapot)
+	})
+	srv := New(p)
+
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/definitely-not-a-route", nil))
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("unknown /v1 route = %d, want 404", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.Contains(ct, "application/json") {
+		t.Fatalf("unknown /v1 route Content-Type = %q, want the JSON error envelope", ct)
+	}
+	if !strings.Contains(rec.Body.String(), "not_found") {
+		t.Fatalf("expected not_found code in body, got: %s", rec.Body.String())
+	}
+	if legacyCalled {
+		t.Fatal("unknown /v1 route must NOT fall back to the legacy mux")
+	}
+}
+
+func TestNewNonV1RouteFallsBackToLegacy(t *testing.T) {
+	legacyCalled := false
+	p := minimalParams()
+	p.Legacy = http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		legacyCalled = true
+		w.WriteHeader(http.StatusTeapot)
+	})
+	srv := New(p)
+
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+
+	if !legacyCalled {
+		t.Fatal("non-/v1 route did not reach the legacy handler")
+	}
+	if rec.Code != http.StatusTeapot {
+		t.Fatalf("non-/v1 route = %d, want the legacy handler's 418", rec.Code)
+	}
+}
+
+func TestNewNonV1RouteWithoutLegacyIsPlainNotFound(t *testing.T) {
+	srv := New(minimalParams()) // no Legacy wired
+
+	rec := httptest.NewRecorder()
+	srv.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthz", nil))
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("non-/v1 route without legacy = %d, want 404", rec.Code)
+	}
+}
+
+func TestBuildDepsPoolGatedClosures(t *testing.T) {
+	t.Run("with pool", func(t *testing.T) {
+		deps := BuildDeps(minimalParams())
+		if deps.SendingRampSnapshot == nil {
+			t.Error("BuildDeps did not wire the send-ramp snapshot with a pool present")
+		}
+		if deps.ListMessageLifecycle == nil {
+			t.Error("BuildDeps did not wire the message lifecycle store with a pool present")
+		}
+	})
+
+	t.Run("without pool", func(t *testing.T) {
+		p := minimalParams()
+		p.Pool = nil
+		deps := BuildDeps(p)
+		if deps.SendingRampSnapshot != nil {
+			t.Error("BuildDeps wired the send-ramp snapshot without a pool")
+		}
+		if deps.ListMessageLifecycle != nil {
+			t.Error("BuildDeps wired the message lifecycle store without a pool")
+		}
+	})
+}
+
+func TestAttachmentStoreGating(t *testing.T) {
+	cases := []struct {
+		name    string
+		secret  string
+		public  string
+		wantNil bool
+	}{
+		{"neither secret nor public URL", "", "", true},
+		{"secret only", "s3cret", "", true},
+		{"public URL only", "", "https://api.example.com", true},
+		{"both secret and public URL", "s3cret", "https://api.example.com", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := minimalParams()
+			p.SigningSecret = tc.secret
+			p.PublicURL = tc.public
+			got := attachmentStore(p)
+			if tc.wantNil && got != nil {
+				t.Fatal("attachment store wired without both signing secret and public URL")
+			}
+			if !tc.wantNil && got == nil {
+				t.Fatal("attachment store not wired despite signing secret and public URL")
+			}
+		})
+	}
+}
+
+func TestEnqueueSenderProvisionFunc(t *testing.T) {
+	t.Run("nil sender identity leaves hook unwired", func(t *testing.T) {
+		if got := enqueueSenderProvisionFunc(minimalParams()); got != nil {
+			t.Fatal("expected a nil provision hook when SES is not configured")
+		}
+	})
+
+	t.Run("successful enqueue forwards the domain", func(t *testing.T) {
+		fake := &fakeSenderIdentity{}
+		p := minimalParams()
+		p.SenderIdentity = fake
+		hook := enqueueSenderProvisionFunc(p)
+		if hook == nil {
+			t.Fatal("expected a provision hook when SES is configured")
+		}
+		hook(context.Background(), "example.com")
+		if len(fake.provisioned) != 1 || fake.provisioned[0] != "example.com" {
+			t.Fatalf("provisioned = %v, want [example.com]", fake.provisioned)
+		}
+	})
+
+	t.Run("enqueue failure is logged, not propagated", func(t *testing.T) {
+		fake := &fakeSenderIdentity{provisionErr: errors.New("river down")}
+		p := minimalParams()
+		p.SenderIdentity = fake
+		hook := enqueueSenderProvisionFunc(p)
+		// Best-effort contract: a failed enqueue must not panic or error the
+		// verify request; the next POST /verify recovers it.
+		hook(context.Background(), "example.com")
+		if len(fake.provisioned) != 1 {
+			t.Fatalf("provisioned = %v, want one attempt", fake.provisioned)
+		}
+	})
+}
+
+func TestDeleteDomainFuncSelection(t *testing.T) {
+	t.Run("without sender identity it is the plain store delete", func(t *testing.T) {
+		store := &identity.Store{}
+		p := minimalParams()
+		p.Store = store
+		got := deleteDomainFunc(p)
+		if reflect.ValueOf(got).Pointer() != reflect.ValueOf(store.DeleteDomain).Pointer() {
+			t.Fatal("without SES, deleteDomainFunc should be exactly Store.DeleteDomain")
+		}
+	})
+
+	t.Run("with sender identity it wraps the transactional delete", func(t *testing.T) {
+		store := &identity.Store{}
+		p := minimalParams()
+		p.Store = store
+		p.SenderIdentity = &fakeSenderIdentity{}
+		got := deleteDomainFunc(p)
+		if got == nil {
+			t.Fatal("expected a delete function when SES is configured")
+		}
+		if reflect.ValueOf(got).Pointer() == reflect.ValueOf(store.DeleteDomain).Pointer() {
+			t.Fatal("with SES, deleteDomainFunc should wrap DeleteDomainTx, not plain DeleteDomain")
+		}
+	})
+}

--- a/internal/auth/handlers_extra_test.go
+++ b/internal/auth/handlers_extra_test.go
@@ -1,0 +1,815 @@
+package auth_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/tokencanopy/e2a/internal/auth"
+	"github.com/tokencanopy/e2a/internal/config"
+	"github.com/tokencanopy/e2a/internal/identity"
+	"github.com/tokencanopy/e2a/internal/testutil"
+	"golang.org/x/oauth2"
+)
+
+// --- POST /api/auth/logout ---
+
+func TestHandleLogout_DeletesSessionAndClearsCookie(t *testing.T) {
+	ua, store, token := setupUserAuth(t)
+
+	req := authedRequest("POST", "/api/auth/logout", token)
+	w := httptest.NewRecorder()
+	ua.HandleLogout(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+
+	// The response must expire the session cookie.
+	var cleared *http.Cookie
+	for _, c := range w.Result().Cookies() {
+		if c.Name == auth.SessionCookieName {
+			cleared = c
+		}
+	}
+	if cleared == nil {
+		t.Fatal("logout response did not set a session cookie")
+	}
+	if cleared.Value != "" || cleared.MaxAge != -1 {
+		t.Errorf("logout cookie = %+v, want empty value with MaxAge -1", cleared)
+	}
+
+	// The session row must be gone: the old token no longer authenticates.
+	if _, err := store.GetUserSession(context.Background(), token); err == nil {
+		t.Error("session still resolves after logout")
+	}
+	if user := ua.AuthenticateRequest(authedRequest("GET", "/api/auth/me", token)); user != nil {
+		t.Error("AuthenticateRequest still returns a user after logout")
+	}
+}
+
+func TestHandleLogout_WithoutCookieStillSucceeds(t *testing.T) {
+	ua, _, _ := setupUserAuth(t)
+
+	req := httptest.NewRequest("POST", "/api/auth/logout", nil)
+	w := httptest.NewRecorder()
+	ua.HandleLogout(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (logout is idempotent)", w.Code)
+	}
+}
+
+// --- GET /api/auth/me ---
+
+func TestHandleMe_Unauthenticated(t *testing.T) {
+	ua, _, _ := setupUserAuth(t)
+
+	req := httptest.NewRequest("GET", "/api/auth/me", nil)
+	w := httptest.NewRecorder()
+	ua.HandleMe(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestHandleMe_ReturnsCurrentUser(t *testing.T) {
+	ua, _, token := setupUserAuth(t)
+
+	req := authedRequest("GET", "/api/auth/me", token)
+	w := httptest.NewRecorder()
+	ua.HandleMe(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	var got identity.User
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Email != "josh@test.com" {
+		t.Errorf("Email = %q, want josh@test.com", got.Email)
+	}
+	if got.Name != "Josh" {
+		t.Errorf("Name = %q, want Josh", got.Name)
+	}
+}
+
+// --- GET /api/dashboard/agents ---
+
+func TestHandleDashboardAgents_Unauthenticated(t *testing.T) {
+	ua, _, _ := setupUserAuth(t)
+
+	req := httptest.NewRequest("GET", "/api/dashboard/agents", nil)
+	w := httptest.NewRecorder()
+	ua.HandleDashboardAgents(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestHandleDashboardAgents_EmptyListIsJSONArray(t *testing.T) {
+	ua, _, token := setupUserAuth(t)
+
+	req := authedRequest("GET", "/api/dashboard/agents", token)
+	w := httptest.NewRecorder()
+	ua.HandleDashboardAgents(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	// The dashboard iterates the array; null would break rendering, so an
+	// empty workspace must serialize as [] rather than null.
+	var got struct {
+		Agents []identity.AgentIdentity `json:"agents"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Agents == nil {
+		t.Errorf("agents = null, want [] (body=%s)", w.Body.String())
+	}
+}
+
+func TestHandleDashboardAgents_ListsOwnedAgents(t *testing.T) {
+	ua, store, token := setupUserAuth(t)
+	ctx := context.Background()
+
+	user, _ := store.GetUserSession(ctx, token)
+	store.ClaimOrCreateDomain(ctx, "dash-list.example.com", user.ID)
+	if _, err := store.CreateAgent(ctx, "bot@dash-list.example.com", "dash-list.example.com", "Bot", "https://example.com/webhook", "", user.ID); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+	// An agent owned by someone else must not leak into the listing.
+	other, _ := store.CreateOrGetUser(ctx, "other@dash-list.example.com", "Other", "google-other-dash")
+	store.ClaimOrCreateDomain(ctx, "dash-foreign.example.com", other.ID)
+	store.CreateAgent(ctx, "bot@dash-foreign.example.com", "dash-foreign.example.com", "", "https://example.com/webhook", "", other.ID)
+
+	req := authedRequest("GET", "/api/dashboard/agents", token)
+	w := httptest.NewRecorder()
+	ua.HandleDashboardAgents(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var got struct {
+		Agents []identity.AgentIdentity `json:"agents"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Agents) != 1 {
+		t.Fatalf("expected exactly 1 owned agent, got %d: %+v", len(got.Agents), got.Agents)
+	}
+	if got.Agents[0].Email != "bot@dash-list.example.com" {
+		t.Errorf("agent email = %q, want bot@dash-list.example.com", got.Agents[0].Email)
+	}
+}
+
+// --- DELETE /api/dashboard/agents/{email} ---
+
+func TestHandleDeleteAgent_Unauthenticated(t *testing.T) {
+	ua, _, _ := setupUserAuth(t)
+
+	req := httptest.NewRequest("DELETE", "/api/dashboard/agents/agent%40test.example.com", nil)
+	w := httptest.NewRecorder()
+	ua.HandleDeleteAgent(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestHandleDeleteAgent_EmptyEmail(t *testing.T) {
+	ua, _, token := setupUserAuth(t)
+
+	req := authedRequest("DELETE", "/api/dashboard/agents/", token)
+	w := httptest.NewRecorder()
+	ua.HandleDeleteAgent(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleDeleteAgent_NotFound(t *testing.T) {
+	ua, _, token := setupUserAuth(t)
+
+	req := authedRequest("DELETE", "/api/dashboard/agents/agent%40missing.example.com", token)
+	w := httptest.NewRecorder()
+	ua.HandleDeleteAgent(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestHandleDeleteAgent_NotOwned(t *testing.T) {
+	ua, store, token := setupUserAuth(t)
+	ctx := context.Background()
+
+	other, _ := store.CreateOrGetUser(ctx, "other@del.example.com", "Other", "google-other-del")
+	store.ClaimOrCreateDomain(ctx, "del-foreign.example.com", other.ID)
+	store.CreateAgent(ctx, "agent@del-foreign.example.com", "del-foreign.example.com", "", "https://example.com/webhook", "", other.ID)
+
+	req := authedRequest("DELETE", "/api/dashboard/agents/agent%40del-foreign.example.com", token)
+	w := httptest.NewRecorder()
+	ua.HandleDeleteAgent(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 for an agent owned by another user", w.Code)
+	}
+}
+
+func TestHandleDeleteAgent_HappyPath(t *testing.T) {
+	ua, store, token := setupUserAuth(t)
+	ctx := context.Background()
+
+	user, _ := store.GetUserSession(ctx, token)
+	store.ClaimOrCreateDomain(ctx, "del.example.com", user.ID)
+	if _, err := store.CreateAgent(ctx, "agent@del.example.com", "del.example.com", "", "https://example.com/webhook", "", user.ID); err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	req := authedRequest("DELETE", "/api/dashboard/agents/agent%40del.example.com", token)
+	w := httptest.NewRecorder()
+	ua.HandleDeleteAgent(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	// Soft delete: live lookups must stop resolving the agent.
+	if _, err := store.GetAgentByEmail(ctx, "agent@del.example.com"); err == nil {
+		t.Error("agent still resolves via GetAgentByEmail after delete")
+	}
+	// Deleting again surfaces the not-found path (agent no longer resolves).
+	req = authedRequest("DELETE", "/api/dashboard/agents/agent%40del.example.com", token)
+	w = httptest.NewRecorder()
+	ua.HandleDeleteAgent(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("second delete status = %d, want 404", w.Code)
+	}
+}
+
+// --- PUT /api/dashboard/agents/{email} ---
+
+func TestHandleUpdateAgent_Unauthenticated(t *testing.T) {
+	ua, _, _ := setupUserAuth(t)
+
+	req := httptest.NewRequest("PUT", "/api/dashboard/agents/agent%40test.example.com", strings.NewReader(`{}`))
+	w := httptest.NewRecorder()
+	ua.HandleUpdateAgent(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestHandleUpdateAgent_EmptyEmail(t *testing.T) {
+	ua, _, token := setupUserAuth(t)
+
+	req := authedJSON("PUT", "/api/dashboard/agents/", token, `{"hitl_ttl_seconds":60}`)
+	w := httptest.NewRecorder()
+	ua.HandleUpdateAgent(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleUpdateAgent_MalformedBody(t *testing.T) {
+	ua, _, token := setupUserAuth(t)
+
+	req := authedJSON("PUT", "/api/dashboard/agents/agent%40test.example.com", token, `{not-json}`)
+	w := httptest.NewRecorder()
+	ua.HandleUpdateAgent(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleUpdateAgent_NotFound(t *testing.T) {
+	ua, _, token := setupUserAuth(t)
+
+	req := authedJSON("PUT", "/api/dashboard/agents/agent%40missing.example.com", token, `{"hitl_ttl_seconds":60}`)
+	w := httptest.NewRecorder()
+	ua.HandleUpdateAgent(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestHandleUpdateAgent_NoRecognizedFields(t *testing.T) {
+	ua, store, token := setupUserAuth(t)
+	ctx := context.Background()
+
+	user, _ := store.GetUserSession(ctx, token)
+	store.ClaimOrCreateDomain(ctx, "upd-empty.example.com", user.ID)
+	store.CreateAgent(ctx, "agent@upd-empty.example.com", "upd-empty.example.com", "", "https://example.com/webhook", "", user.ID)
+
+	req := authedJSON("PUT", "/api/dashboard/agents/agent%40upd-empty.example.com", token, `{}`)
+	w := httptest.NewRecorder()
+	ua.HandleUpdateAgent(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for an empty PUT (no silent no-op)", w.Code)
+	}
+}
+
+func TestHandleUpdateAgent_InvalidHITLConfig(t *testing.T) {
+	ua, store, token := setupUserAuth(t)
+	ctx := context.Background()
+
+	user, _ := store.GetUserSession(ctx, token)
+	store.ClaimOrCreateDomain(ctx, "upd-bad.example.com", user.ID)
+	store.CreateAgent(ctx, "agent@upd-bad.example.com", "upd-bad.example.com", "", "https://example.com/webhook", "", user.ID)
+
+	// TTL below the store's valid range (1..HITLMaxTTLSeconds).
+	req := authedJSON("PUT", "/api/dashboard/agents/agent%40upd-bad.example.com", token, `{"hitl_ttl_seconds":-5}`)
+	w := httptest.NewRecorder()
+	ua.HandleUpdateAgent(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleUpdateAgent_UpdatesHITLSettings(t *testing.T) {
+	ua, store, token := setupUserAuth(t)
+	ctx := context.Background()
+
+	user, _ := store.GetUserSession(ctx, token)
+	store.ClaimOrCreateDomain(ctx, "upd.example.com", user.ID)
+	before, err := store.CreateAgent(ctx, "agent@upd.example.com", "upd.example.com", "", "https://example.com/webhook", "", user.ID)
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	// TTL only — the expiration action must keep its current value.
+	req := authedJSON("PUT", "/api/dashboard/agents/agent%40upd.example.com", token, `{"hitl_ttl_seconds":3600}`)
+	w := httptest.NewRecorder()
+	ua.HandleUpdateAgent(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("TTL update status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	after, err := store.GetAgentByEmail(ctx, "agent@upd.example.com")
+	if err != nil {
+		t.Fatalf("GetAgentByEmail: %v", err)
+	}
+	if after.HITLTTLSeconds != 3600 {
+		t.Errorf("HITLTTLSeconds = %d, want 3600", after.HITLTTLSeconds)
+	}
+	if after.HITLExpirationAction != before.HITLExpirationAction {
+		t.Errorf("HITLExpirationAction changed from %q to %q; untouched fields must be preserved",
+			before.HITLExpirationAction, after.HITLExpirationAction)
+	}
+
+	// Both fields in one PUT.
+	req = authedJSON("PUT", "/api/dashboard/agents/agent%40upd.example.com", token,
+		`{"hitl_ttl_seconds":7200,"hitl_expiration_action":"approve"}`)
+	w = httptest.NewRecorder()
+	ua.HandleUpdateAgent(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("combined update status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	after, err = store.GetAgentByEmail(ctx, "agent@upd.example.com")
+	if err != nil {
+		t.Fatalf("GetAgentByEmail: %v", err)
+	}
+	if after.HITLTTLSeconds != 7200 || after.HITLExpirationAction != "approve" {
+		t.Errorf("HITL settings = ttl:%d action:%q, want ttl:7200 action:approve",
+			after.HITLTTLSeconds, after.HITLExpirationAction)
+	}
+}
+
+// --- DELETE /api/keys/{id} ---
+
+func TestHandleDeleteAPIKey_Unauthenticated(t *testing.T) {
+	ua, _, _ := setupUserAuth(t)
+
+	req := httptest.NewRequest("DELETE", "/api/keys/key_123", nil)
+	w := httptest.NewRecorder()
+	ua.HandleDeleteAPIKey(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestHandleDeleteAPIKey_EmptyKeyID(t *testing.T) {
+	ua, _, token := setupUserAuth(t)
+
+	req := authedRequest("DELETE", "/api/keys/", token)
+	w := httptest.NewRecorder()
+	ua.HandleDeleteAPIKey(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleDeleteAPIKey_NotFound(t *testing.T) {
+	ua, _, token := setupUserAuth(t)
+
+	req := authedRequest("DELETE", "/api/keys/key_does_not_exist", token)
+	w := httptest.NewRecorder()
+	ua.HandleDeleteAPIKey(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", w.Code)
+	}
+}
+
+func TestHandleDeleteAPIKey_OtherUsersKey(t *testing.T) {
+	ua, store, token := setupUserAuth(t)
+	ctx := context.Background()
+
+	other, _ := store.CreateOrGetUser(ctx, "other@keys.example.com", "Other", "google-other-keys")
+	otherKey, err := store.CreateAPIKey(ctx, other.ID, "foreign key", nil)
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+
+	req := authedRequest("DELETE", "/api/keys/"+otherKey.ID, token)
+	w := httptest.NewRecorder()
+	ua.HandleDeleteAPIKey(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 (no cross-user key deletion)", w.Code)
+	}
+}
+
+func TestHandleDeleteAPIKey_HappyPath(t *testing.T) {
+	ua, store, token := setupUserAuth(t)
+	ctx := context.Background()
+
+	user, _ := store.GetUserSession(ctx, token)
+	key, err := store.CreateAPIKey(ctx, user.ID, "to-delete", nil)
+	if err != nil {
+		t.Fatalf("CreateAPIKey: %v", err)
+	}
+
+	req := authedRequest("DELETE", "/api/keys/"+key.ID, token)
+	w := httptest.NewRecorder()
+	ua.HandleDeleteAPIKey(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	// Revoked keys disappear from the listing.
+	keys, err := store.ListAPIKeys(ctx, user.ID, 0, time.Time{}, "")
+	if err != nil {
+		t.Fatalf("ListAPIKeys: %v", err)
+	}
+	for _, k := range keys {
+		if k.ID == key.ID {
+			t.Errorf("deleted key %s still listed", key.ID)
+		}
+	}
+
+	// Deleting again is a 404 (already revoked).
+	req = authedRequest("DELETE", "/api/keys/"+key.ID, token)
+	w = httptest.NewRecorder()
+	ua.HandleDeleteAPIKey(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("second delete status = %d, want 404", w.Code)
+	}
+}
+
+// --- GET /api/keys (uncovered branches) ---
+
+func TestHandleListAPIKeys_Unauthenticated(t *testing.T) {
+	ua, _, _ := setupUserAuth(t)
+
+	req := httptest.NewRequest("GET", "/api/keys", nil)
+	w := httptest.NewRecorder()
+	ua.HandleListAPIKeys(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestHandleListAPIKeys_EmptyListIsJSONArray(t *testing.T) {
+	ua, _, token := setupUserAuth(t)
+
+	req := authedRequest("GET", "/api/keys", token)
+	w := httptest.NewRecorder()
+	ua.HandleListAPIKeys(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if body := strings.TrimSpace(w.Body.String()); body != "[]" {
+		t.Errorf("body = %q, want [] for a user with no keys", body)
+	}
+}
+
+// --- POST /api/keys (uncovered branches) ---
+
+func TestHandleCreateAPIKey_Unauthenticated(t *testing.T) {
+	ua, _, _ := setupUserAuth(t)
+
+	req := httptest.NewRequest("POST", "/api/keys", strings.NewReader(`{"name":"x"}`))
+	w := httptest.NewRecorder()
+	ua.HandleCreateAPIKey(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}
+
+func TestHandleCreateAPIKey_RejectsInvalidScope(t *testing.T) {
+	ua, _, token := setupUserAuth(t)
+
+	req := authedJSON("POST", "/api/keys", token, `{"name":"x","scope":"universe"}`)
+	w := httptest.NewRecorder()
+	ua.HandleCreateAPIKey(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleCreateAPIKey_AgentScopeRequiresAgentEmail(t *testing.T) {
+	ua, _, token := setupUserAuth(t)
+
+	req := authedJSON("POST", "/api/keys", token, `{"name":"x","scope":"agent"}`)
+	w := httptest.NewRecorder()
+	ua.HandleCreateAPIKey(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleCreateAPIKey_AgentScopeRejectsUnknownAgent(t *testing.T) {
+	ua, _, token := setupUserAuth(t)
+
+	req := authedJSON("POST", "/api/keys", token, `{"name":"x","scope":"agent","agent":"ghost@nowhere.example.com"}`)
+	w := httptest.NewRecorder()
+	ua.HandleCreateAPIKey(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400; body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleCreateAPIKey_AgentScopeRejectsForeignAgent(t *testing.T) {
+	ua, store, token := setupUserAuth(t)
+	ctx := context.Background()
+
+	other, _ := store.CreateOrGetUser(ctx, "other@scoped.example.com", "Other", "google-other-scoped")
+	store.ClaimOrCreateDomain(ctx, "scoped-foreign.example.com", other.ID)
+	store.CreateAgent(ctx, "agent@scoped-foreign.example.com", "scoped-foreign.example.com", "", "https://example.com/webhook", "", other.ID)
+
+	req := authedJSON("POST", "/api/keys", token, `{"name":"x","scope":"agent","agent":"agent@scoped-foreign.example.com"}`)
+	w := httptest.NewRecorder()
+	ua.HandleCreateAPIKey(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400 for an agent owned by another user", w.Code)
+	}
+}
+
+func TestHandleCreateAPIKey_AgentScopeHappyPath(t *testing.T) {
+	ua, store, token := setupUserAuth(t)
+	ctx := context.Background()
+
+	user, _ := store.GetUserSession(ctx, token)
+	store.ClaimOrCreateDomain(ctx, "scoped.example.com", user.ID)
+	agent, err := store.CreateAgent(ctx, "agent@scoped.example.com", "scoped.example.com", "", "https://example.com/webhook", "", user.ID)
+	if err != nil {
+		t.Fatalf("CreateAgent: %v", err)
+	}
+
+	req := authedJSON("POST", "/api/keys", token, `{"name":"agent key","scope":"agent","agent":"agent@scoped.example.com"}`)
+	w := httptest.NewRecorder()
+	ua.HandleCreateAPIKey(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want 201; body=%s", w.Code, w.Body.String())
+	}
+	var created identity.APIKey
+	if err := json.NewDecoder(w.Body).Decode(&created); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if created.Scope != identity.ScopeAgent {
+		t.Errorf("Scope = %q, want %q", created.Scope, identity.ScopeAgent)
+	}
+	if created.AgentID == nil || *created.AgentID != agent.ID {
+		t.Errorf("AgentID = %v, want %s", created.AgentID, agent.ID)
+	}
+	if !strings.HasPrefix(created.PlaintextKey, "e2a_agt_") {
+		t.Errorf("agent-scoped key prefix missing e2a_agt_: %q", created.PlaintextKey)
+	}
+}
+
+// --- GET /api/auth/login cli_callback validation (uncovered branches) ---
+
+// TestHandleLogin_CLICallbackValidation exercises validateCLICallbackURL's
+// remaining reject branches plus the hostname (not IP-literal) loopback path.
+func TestHandleLogin_CLICallbackValidation(t *testing.T) {
+	cases := []struct {
+		name       string
+		cliCB      string
+		wantStatus int
+	}{
+		{"user info rejected", "http://user@127.0.0.1:9000/cb", http.StatusBadRequest},
+		{"missing host rejected", "http:///cb", http.StatusBadRequest},
+		{"non-loopback IP rejected", "http://8.8.8.8/cb", http.StatusBadRequest},
+		{"non-loopback hostname rejected", "http://callback.example.com/cb", http.StatusBadRequest},
+		{"localhost hostname allowed", "http://localhost:9000/cb", http.StatusFound},
+		{"ipv4 loopback allowed", "http://127.0.0.1:9000/cb", http.StatusFound},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ua, _, _ := setupUserAuth(t)
+			req := httptest.NewRequest(http.MethodGet,
+				"/api/auth/login?cli_callback="+url.QueryEscape(tc.cliCB)+"&cli_state=cli_state_x", nil)
+			w := httptest.NewRecorder()
+			ua.HandleLogin(w, req)
+			if w.Code != tc.wantStatus {
+				t.Errorf("cli_callback=%q: status = %d, want %d; body=%s", tc.cliCB, w.Code, tc.wantStatus, w.Body.String())
+			}
+		})
+	}
+}
+
+func TestHandleLogin_CLIParamsMustComeInPairs(t *testing.T) {
+	ua, _, _ := setupUserAuth(t)
+
+	// cli_callback without cli_state (and vice versa) is a 400.
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/auth/login?cli_callback="+url.QueryEscape("http://127.0.0.1:9000/cb"), nil)
+	w := httptest.NewRecorder()
+	ua.HandleLogin(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("cli_callback alone: status = %d, want 400", w.Code)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/api/auth/login?cli_state=cli_state_x", nil)
+	w = httptest.NewRecorder()
+	ua.HandleLogin(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("cli_state alone: status = %d, want 400", w.Code)
+	}
+}
+
+// --- GET /api/auth/callback error branches ---
+
+// setupUserAuthWithFailingOAuth builds a UserAuth whose token exchange and/or
+// userinfo call fails, for HandleCallback's post-nonce error branches.
+// Either handler may be nil to use a working default.
+func setupUserAuthWithFailingOAuth(t *testing.T, tokenHandler, userInfoHandler http.HandlerFunc) *auth.UserAuth {
+	t.Helper()
+	mux := http.NewServeMux()
+	if tokenHandler == nil {
+		tokenHandler = func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token": "fake-access-token",
+				"token_type":   "Bearer",
+				"expires_in":   3600,
+			})
+		}
+	}
+	if userInfoHandler == nil {
+		userInfoHandler = func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"sub":            "google-sub-cb-test",
+				"email":          "cbuser@test.com",
+				"email_verified": true,
+				"name":           "Callback User",
+			})
+		}
+	}
+	mux.HandleFunc("/token", tokenHandler)
+	mux.HandleFunc("/userinfo", userInfoHandler)
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	oauthCfg := &oauth2.Config{
+		ClientID:     "test",
+		ClientSecret: "test",
+		RedirectURL:  "http://localhost/api/auth/callback",
+		Endpoint: oauth2.Endpoint{
+			TokenURL: srv.URL + "/token",
+			AuthURL:  srv.URL + "/authorize",
+		},
+		Scopes: []string{"openid", "email", "profile"},
+	}
+	cfg := &config.OAuthConfig{
+		GoogleClientID:     oauthCfg.ClientID,
+		GoogleClientSecret: oauthCfg.ClientSecret,
+		RedirectURL:        oauthCfg.RedirectURL,
+	}
+	store := identity.NewStore(testutil.TestDB(t))
+	return auth.NewUserAuthWithOAuthConfig(cfg, oauthCfg, store, false, srv.URL+"/userinfo")
+}
+
+// callbackReqWithValidState builds a callback request whose nonce cookie
+// matches the OAuth state, so the handler proceeds past CSRF validation
+// into the exchange/userinfo branches under test.
+func callbackReqWithValidState(query string) *http.Request {
+	nonce := "cb-test-nonce"
+	state := auth.EncodeOAuthState(&auth.OAuthState{Nonce: nonce})
+	sep := "&"
+	if query == "" {
+		sep = ""
+	}
+	req := httptest.NewRequest(http.MethodGet,
+		fmt.Sprintf("/api/auth/callback?%s%sstate=%s", query, sep, url.QueryEscape(state)), nil)
+	req.AddCookie(&http.Cookie{Name: auth.StateCookieName, Value: nonce})
+	return req
+}
+
+func TestHandleCallback_MissingCodeOrState(t *testing.T) {
+	ua, _, srv := setupUserAuthWithFakeOAuth(t)
+	_ = srv
+
+	// No code, no state at all.
+	req := httptest.NewRequest(http.MethodGet, "/api/auth/callback", nil)
+	w := httptest.NewRecorder()
+	ua.HandleCallback(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("no params: status = %d, want 400", w.Code)
+	}
+
+	// State present but code missing.
+	req = callbackReqWithValidState("")
+	w = httptest.NewRecorder()
+	ua.HandleCallback(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("missing code: status = %d, want 400", w.Code)
+	}
+}
+
+func TestHandleCallback_ExchangeFailure(t *testing.T) {
+	ua := setupUserAuthWithFailingOAuth(t, func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, `{"error":"invalid_grant"}`, http.StatusBadRequest)
+	}, nil)
+
+	req := callbackReqWithValidState("code=bad-code")
+	w := httptest.NewRecorder()
+	ua.HandleCallback(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500 on token exchange failure", w.Code)
+	}
+}
+
+func TestHandleCallback_UserInfoFailure(t *testing.T) {
+	ua := setupUserAuthWithFailingOAuth(t, nil, func(w http.ResponseWriter, _ *http.Request) {
+		// fetchGoogleUserInfo decodes the body without a status check, so an
+		// undecodable payload is what drives its error branch.
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("not-json"))
+	})
+
+	req := callbackReqWithValidState("code=fake-code")
+	w := httptest.NewRecorder()
+	ua.HandleCallback(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500 on userinfo fetch failure", w.Code)
+	}
+}
+
+func TestHandleCallback_UnverifiedEmailRejected(t *testing.T) {
+	ua := setupUserAuthWithFailingOAuth(t, nil, func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"sub":            "google-sub-unverified",
+			"email":          "unverified@test.com",
+			"email_verified": false,
+			"name":           "Unverified",
+		})
+	})
+
+	req := callbackReqWithValidState("code=fake-code")
+	w := httptest.NewRecorder()
+	ua.HandleCallback(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403 for an unverified Google email", w.Code)
+	}
+}

--- a/internal/jobs/reconcile_test.go
+++ b/internal/jobs/reconcile_test.go
@@ -1,0 +1,307 @@
+package jobs_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/tokencanopy/e2a/internal/jobs"
+	"github.com/tokencanopy/e2a/internal/testutil"
+)
+
+// reconcileScratch creates a throwaway row table shaped like a domain table
+// ReconcilePending works against (id + a nullable bigint job column) and
+// returns the spec pointing at it. The table is dropped on test cleanup so
+// repeated runs and sibling tests never see each other's rows — the shared
+// truncate-between-tests harness does not know about it.
+func reconcileScratch(t *testing.T, pool *pgxpool.Pool, table string) jobs.ReconcileSpec {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, fmt.Sprintf(
+		`CREATE TABLE %s (id text PRIMARY KEY, state text NOT NULL, send_job_id bigint)`, table)); err != nil {
+		t.Fatalf("create scratch table: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := pool.Exec(context.Background(), fmt.Sprintf(`DROP TABLE IF EXISTS %s`, table)); err != nil {
+			t.Errorf("drop scratch table: %v", err)
+		}
+	})
+	return jobs.ReconcileSpec{
+		Table:     table,
+		JobColumn: "send_job_id",
+		Where:     "state = 'pending'",
+		LogPrefix: "[jobs-test-reconcile]",
+	}
+}
+
+func insertReconcileRow(t *testing.T, pool *pgxpool.Pool, table, id, state string, jobID *int64) {
+	t.Helper()
+	if _, err := pool.Exec(context.Background(), fmt.Sprintf(
+		`INSERT INTO %s (id, state, send_job_id) VALUES ($1, $2, $3)`, table), id, state, jobID); err != nil {
+		t.Fatalf("insert row %s: %v", id, err)
+	}
+}
+
+func rowJobID(t *testing.T, pool *pgxpool.Pool, table, id string) *int64 {
+	t.Helper()
+	var jobID *int64
+	if err := pool.QueryRow(context.Background(), fmt.Sprintf(
+		`SELECT send_job_id FROM %s WHERE id = $1`, table), id).Scan(&jobID); err != nil {
+		t.Fatalf("read row %s: %v", id, err)
+	}
+	return jobID
+}
+
+// stampEnqueue records the ids it was asked to enqueue and hands out
+// sequential job ids, mimicking a domain's EnqueueXTx.
+type stampEnqueue struct {
+	ids  []string
+	next int64
+}
+
+func (e *stampEnqueue) enqueue(_ context.Context, _ pgx.Tx, id string) (int64, error) {
+	e.ids = append(e.ids, id)
+	e.next++
+	return 1000 + e.next, nil
+}
+
+// TestReconcilePending_EnqueuesOnlyStrandedRows covers the happy path: rows
+// matching Where with a NULL job column get enqueued and stamped; rows already
+// stamped or not matching Where are left alone.
+func TestReconcilePending_EnqueuesOnlyStrandedRows(t *testing.T) {
+	pool := testutil.TestDB(t)
+	spec := reconcileScratch(t, pool, "jobs_reconcile_happy")
+	ctx := context.Background()
+
+	stamped := int64(42)
+	insertReconcileRow(t, pool, spec.Table, "stranded", "pending", nil)
+	insertReconcileRow(t, pool, spec.Table, "already", "pending", &stamped)
+	insertReconcileRow(t, pool, spec.Table, "other-state", "done", nil)
+
+	enq := &stampEnqueue{}
+	// Batch 0 exercises the DefaultReconcileBatch fallback.
+	n, err := jobs.ReconcilePending(ctx, pool, spec, enq.enqueue)
+	if err != nil {
+		t.Fatalf("ReconcilePending: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("enqueued count = %d, want 1", n)
+	}
+	if len(enq.ids) != 1 || enq.ids[0] != "stranded" {
+		t.Errorf("enqueueTx called with %v, want [stranded]", enq.ids)
+	}
+	if got := rowJobID(t, pool, spec.Table, "stranded"); got == nil || *got != 1001 {
+		t.Errorf("stranded row job id = %v, want 1001", got)
+	}
+	if got := rowJobID(t, pool, spec.Table, "already"); got == nil || *got != 42 {
+		t.Errorf("already-stamped row job id = %v, want untouched 42", got)
+	}
+	if got := rowJobID(t, pool, spec.Table, "other-state"); got != nil {
+		t.Errorf("non-matching row job id = %v, want NULL", *got)
+	}
+}
+
+// TestReconcilePending_IdempotentSecondRun proves the documented guarantee: a
+// re-run (startup cutover racing a live reconcile worker) never double-enqueues.
+func TestReconcilePending_IdempotentSecondRun(t *testing.T) {
+	pool := testutil.TestDB(t)
+	spec := reconcileScratch(t, pool, "jobs_reconcile_idem")
+	ctx := context.Background()
+
+	insertReconcileRow(t, pool, spec.Table, "r1", "pending", nil)
+	insertReconcileRow(t, pool, spec.Table, "r2", "pending", nil)
+
+	enq := &stampEnqueue{}
+	if n, err := jobs.ReconcilePending(ctx, pool, spec, enq.enqueue); err != nil || n != 2 {
+		t.Fatalf("first pass: n=%d err=%v, want 2 nil", n, err)
+	}
+	n, err := jobs.ReconcilePending(ctx, pool, spec, enq.enqueue)
+	if err != nil {
+		t.Fatalf("second pass: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("second pass enqueued %d rows, want 0", n)
+	}
+	if len(enq.ids) != 2 {
+		t.Errorf("enqueueTx called %d times total, want 2", len(enq.ids))
+	}
+}
+
+// TestReconcilePending_EnqueueFailureSkipsRowForNextPass covers the per-row
+// failure path: a failing row is logged and skipped (no error returned), its
+// job column stays NULL so the NEXT pass retries it, while healthy rows in the
+// same pass still commit.
+func TestReconcilePending_EnqueueFailureSkipsRowForNextPass(t *testing.T) {
+	pool := testutil.TestDB(t)
+	spec := reconcileScratch(t, pool, "jobs_reconcile_fail")
+	ctx := context.Background()
+
+	insertReconcileRow(t, pool, spec.Table, "bad", "pending", nil)
+	insertReconcileRow(t, pool, spec.Table, "good", "pending", nil)
+
+	boom := errors.New("boom")
+	failOnce := true
+	var calls atomic.Int64
+	enqueue := func(_ context.Context, _ pgx.Tx, id string) (int64, error) {
+		calls.Add(1)
+		if id == "bad" && failOnce {
+			return 0, boom
+		}
+		return 2001, nil
+	}
+
+	n, err := jobs.ReconcilePending(ctx, pool, spec, enqueue)
+	if err != nil {
+		t.Fatalf("first pass returned error %v, want nil (per-row failures are skipped)", err)
+	}
+	if n != 1 {
+		t.Errorf("first pass enqueued %d rows, want 1 (only the healthy row)", n)
+	}
+	if got := rowJobID(t, pool, spec.Table, "bad"); got != nil {
+		t.Errorf("failed row job id = %v, want NULL (retry next pass)", *got)
+	}
+	if got := rowJobID(t, pool, spec.Table, "good"); got == nil || *got != 2001 {
+		t.Errorf("healthy row job id = %v, want 2001", got)
+	}
+
+	failOnce = false
+	n, err = jobs.ReconcilePending(ctx, pool, spec, enqueue)
+	if err != nil {
+		t.Fatalf("retry pass: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("retry pass enqueued %d rows, want 1 (the previously failed row)", n)
+	}
+	if got := rowJobID(t, pool, spec.Table, "bad"); got == nil || *got != 2001 {
+		t.Errorf("retried row job id = %v, want 2001", got)
+	}
+}
+
+// TestReconcilePending_BatchCapsOnePass covers spec.Batch: one pass scans at
+// most Batch rows, and the remainder is picked up by the following passes.
+func TestReconcilePending_BatchCapsOnePass(t *testing.T) {
+	pool := testutil.TestDB(t)
+	spec := reconcileScratch(t, pool, "jobs_reconcile_batch")
+	ctx := context.Background()
+
+	for i := 0; i < 5; i++ {
+		insertReconcileRow(t, pool, spec.Table, fmt.Sprintf("r%d", i), "pending", nil)
+	}
+
+	spec.Batch = 2
+	enq := &stampEnqueue{}
+	n, err := jobs.ReconcilePending(ctx, pool, spec, enq.enqueue)
+	if err != nil {
+		t.Fatalf("pass 1: %v", err)
+	}
+	if n != 2 {
+		t.Errorf("pass 1 enqueued %d rows, want capped at Batch=2", n)
+	}
+	if len(enq.ids) != 2 {
+		t.Errorf("pass 1 enqueueTx calls = %d, want 2", len(enq.ids))
+	}
+
+	total := n
+	for n > 0 {
+		n, err = jobs.ReconcilePending(ctx, pool, spec, enq.enqueue)
+		if err != nil {
+			t.Fatalf("drain pass: %v", err)
+		}
+		total += n
+	}
+	if total != 5 {
+		t.Errorf("drained %d rows total, want 5", total)
+	}
+	if len(enq.ids) != 5 {
+		t.Errorf("enqueueTx called %d times total, want 5 (each row exactly once)", len(enq.ids))
+	}
+}
+
+// TestReconcilePending_SkipsRowStampedConcurrently covers the FOR UPDATE
+// re-check: a row stranded at scan time but stamped by another process before
+// this pass's per-row transaction takes its lock must be skipped, not
+// double-enqueued. Deterministic: hold the row lock in an open transaction
+// that stamps the row, run the reconcile (its scan sees the pre-commit NULL,
+// its FOR UPDATE blocks), then commit.
+func TestReconcilePending_SkipsRowStampedConcurrently(t *testing.T) {
+	pool := testutil.TestDB(t)
+	spec := reconcileScratch(t, pool, "jobs_reconcile_race")
+	ctx := context.Background()
+
+	insertReconcileRow(t, pool, spec.Table, "raced", "pending", nil)
+
+	stamper, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin stamper tx: %v", err)
+	}
+	if _, err := stamper.Exec(ctx, fmt.Sprintf(
+		`UPDATE %s SET send_job_id = 777 WHERE id = 'raced'`, spec.Table)); err != nil {
+		t.Fatalf("stamper update: %v", err)
+	}
+
+	enq := &stampEnqueue{}
+	type result struct {
+		n   int
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		n, err := jobs.ReconcilePending(ctx, pool, spec, enq.enqueue)
+		done <- result{n, err}
+	}()
+
+	// Give the reconcile time to scan (sees committed NULL) and block on the
+	// stamper's lock in its FOR UPDATE re-check.
+	time.Sleep(500 * time.Millisecond)
+	if err := stamper.Commit(ctx); err != nil {
+		t.Fatalf("commit stamper tx: %v", err)
+	}
+
+	select {
+	case res := <-done:
+		if res.err != nil {
+			t.Fatalf("ReconcilePending: %v", res.err)
+		}
+		if res.n != 0 {
+			t.Errorf("enqueued %d rows, want 0 (row was stamped concurrently)", res.n)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("reconcile did not finish after the blocking lock was released")
+	}
+	if len(enq.ids) != 0 {
+		t.Errorf("enqueueTx called with %v, want no calls (no double-enqueue)", enq.ids)
+	}
+	if got := rowJobID(t, pool, spec.Table, "raced"); got == nil || *got != 777 {
+		t.Errorf("row job id = %v, want the concurrent stamp 777", got)
+	}
+}
+
+// TestReconcilePending_BadSpecReturnsError covers the scan-query error return:
+// a spec pointing at a nonexistent table surfaces the error instead of
+// swallowing it.
+func TestReconcilePending_BadSpecReturnsError(t *testing.T) {
+	pool := testutil.TestDB(t)
+	spec := jobs.ReconcileSpec{
+		Table:     "jobs_reconcile_nonexistent_table",
+		JobColumn: "send_job_id",
+		Where:     "state = 'pending'",
+		LogPrefix: "[jobs-test-reconcile]",
+	}
+	enq := &stampEnqueue{}
+	n, err := jobs.ReconcilePending(context.Background(), pool, spec, enq.enqueue)
+	if err == nil {
+		t.Fatal("expected an error for a nonexistent table, got nil")
+	}
+	if n != 0 {
+		t.Errorf("n = %d, want 0 on scan error", n)
+	}
+	if len(enq.ids) != 0 {
+		t.Errorf("enqueueTx called with %v, want no calls on scan error", enq.ids)
+	}
+}

--- a/internal/loopback/loopback_extra_test.go
+++ b/internal/loopback/loopback_extra_test.go
@@ -1,0 +1,267 @@
+package loopback
+
+import (
+	"net/mail"
+	"strings"
+	"testing"
+
+	"github.com/tokencanopy/e2a/internal/identity"
+	"github.com/tokencanopy/e2a/internal/outbound"
+)
+
+// TestIsSelfSend pins the self-send detection contract: exactly one To
+// recipient equal (case-insensitive, trimmed) to the agent's own address,
+// with no Cc/Bcc. Anything else — external or mixed recipients, extra To
+// entries, any Cc/Bcc — must route through normal SMTP.
+func TestIsSelfSend(t *testing.T) {
+	const agent = "bot@example.com"
+
+	cases := []struct {
+		name string
+		req  outbound.SendRequest
+		want bool
+	}{
+		{"single To matching agent", outbound.SendRequest{To: []string{"bot@example.com"}}, true},
+		{"case-insensitive match", outbound.SendRequest{To: []string{"BOT@Example.COM"}}, true},
+		{"whitespace-trimmed match", outbound.SendRequest{To: []string{"  bot@example.com \t"}}, true},
+		{"empty To", outbound.SendRequest{}, false},
+		{"different recipient", outbound.SendRequest{To: []string{"other@example.com"}}, false},
+		{"two To entries including self", outbound.SendRequest{To: []string{"bot@example.com", "bot@example.com"}}, false},
+		{"self plus external To", outbound.SendRequest{To: []string{"bot@example.com", "ext@example.com"}}, false},
+		{"Cc present even when To is self", outbound.SendRequest{To: []string{"bot@example.com"}, CC: []string{"ext@example.com"}}, false},
+		{"Cc carrying agent alias blocks self-send", outbound.SendRequest{To: []string{"bot@example.com"}, CC: []string{"bot@example.com"}}, false},
+		{"Bcc present even when To is self", outbound.SendRequest{To: []string{"bot@example.com"}, BCC: []string{"ext@example.com"}}, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsSelfSend(tc.req, agent); got != tc.want {
+				t.Errorf("IsSelfSend(%+v, %q) = %v, want %v", tc.req, agent, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestStripAgentSelfAliases pins the alias-strip contract: case-insensitive,
+// whitespace-trimmed matches of the agent address are removed; everything
+// else survives in order; the input slice is never mutated.
+func TestStripAgentSelfAliases(t *testing.T) {
+	const agent = "bot@example.com"
+
+	t.Run("removes matches, keeps others in order", func(t *testing.T) {
+		in := []string{"bot@example.com", "ext@example.com", " BOT@example.com ", "other@example.com"}
+		got := StripAgentSelfAliases(in, agent)
+		want := []string{"ext@example.com", "other@example.com"}
+		if len(got) != len(want) {
+			t.Fatalf("StripAgentSelfAliases = %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("StripAgentSelfAliases = %v, want %v", got, want)
+			}
+		}
+	})
+
+	t.Run("does not mutate input", func(t *testing.T) {
+		in := []string{"bot@example.com", "ext@example.com"}
+		_ = StripAgentSelfAliases(in, agent)
+		if in[0] != "bot@example.com" || in[1] != "ext@example.com" {
+			t.Errorf("input mutated: %v", in)
+		}
+	})
+
+	t.Run("empty slice returns empty", func(t *testing.T) {
+		if got := StripAgentSelfAliases(nil, agent); len(got) != 0 {
+			t.Errorf("StripAgentSelfAliases(nil) = %v, want empty", got)
+		}
+	})
+
+	t.Run("no matches returns equal slice", func(t *testing.T) {
+		in := []string{"a@example.com", "b@example.com"}
+		got := StripAgentSelfAliases(in, agent)
+		if len(got) != 2 || got[0] != in[0] || got[1] != in[1] {
+			t.Errorf("StripAgentSelfAliases = %v, want %v", got, in)
+		}
+	})
+}
+
+// TestIsSelfSendAfterStrip covers the documented reply-all-on-self-thread
+// flow: stripping the agent alias from Cc first lets IsSelfSend recognize
+// the message as a self-send.
+func TestIsSelfSendAfterStrip(t *testing.T) {
+	const agent = "bot@example.com"
+	req := outbound.SendRequest{
+		To: []string{"bot@example.com"},
+		CC: []string{"bot@example.com", "ext@example.com"},
+	}
+	if IsSelfSend(req, agent) {
+		t.Fatal("IsSelfSend before strip = true, want false (Cc present)")
+	}
+	req.CC = StripAgentSelfAliases(req.CC, agent)
+	if IsSelfSend(req, agent) {
+		t.Fatal("IsSelfSend after strip with external Cc = true, want false")
+	}
+	req.CC = StripAgentSelfAliases([]string{"bot@example.com"}, agent)
+	if !IsSelfSend(req, agent) {
+		t.Fatal("IsSelfSend after stripping only-alias Cc = false, want true")
+	}
+}
+
+// TestProviderIDShape pins the provider-ID contract: an RFC 5322-shaped
+// Message-ID under the loopback.<domain> host, with the e2a.local fallback
+// when no from-domain is configured, and uniqueness across calls.
+func TestProviderIDShape(t *testing.T) {
+	t.Run("uses configured domain", func(t *testing.T) {
+		id := ProviderID("example.com")
+		if !strings.HasPrefix(id, "<") || !strings.HasSuffix(id, "@loopback.example.com>") {
+			t.Errorf("ProviderID = %q, want <hex@loopback.example.com>", id)
+		}
+		if _, err := mail.ParseAddress(id); err == nil {
+			// ParseAddress accepts angle-addrs; Message-ID is not an address,
+			// so this is only a loose sanity check — shape assertions above are authoritative.
+			t.Logf("note: %q parses as an address (informational only)", id)
+		}
+	})
+
+	t.Run("empty domain falls back to e2a.local", func(t *testing.T) {
+		id := ProviderID("")
+		if !strings.HasSuffix(id, "@loopback.e2a.local>") {
+			t.Errorf("ProviderID(\"\") = %q, want suffix @loopback.e2a.local>", id)
+		}
+	})
+
+	t.Run("unique across calls", func(t *testing.T) {
+		a, b := ProviderID("example.com"), ProviderID("example.com")
+		if a == b {
+			t.Errorf("two ProviderID calls returned identical IDs: %q", a)
+		}
+	})
+}
+
+// TestComposeMIMEReceivedLine pins the synthetic Received: header the
+// loopback path prepends: it carries the "with loopback" grep signal, the
+// provider ID, and the recipient, ahead of the composed message.
+func TestComposeMIMEReceivedLine(t *testing.T) {
+	agent := &identity.AgentIdentity{ID: "bot@example.com", Domain: "example.com"}
+	providerID := ProviderID("example.com")
+	raw, err := ComposeMIME(agent, outbound.SendRequest{To: []string{agent.ID}, Subject: "hi", Body: "note"}, providerID, "example.com")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(raw)
+	if !strings.HasPrefix(s, "Received: by example.com (e2a) with loopback id "+providerID+" for <bot@example.com>;") {
+		t.Errorf("message does not start with expected Received line:\n%s", s)
+	}
+	if strings.Count(s, "with loopback") != 1 {
+		t.Errorf("want exactly one 'with loopback' marker, got %d", strings.Count(s, "with loopback"))
+	}
+}
+
+// TestComposeMIMEReceivedLineDefaultHost covers the e2a.local fallback host
+// in the Received line when no from-domain is configured.
+func TestComposeMIMEReceivedLineDefaultHost(t *testing.T) {
+	agent := &identity.AgentIdentity{ID: "bot@example.com", Domain: "example.com"}
+	raw, err := ComposeMIME(agent, outbound.SendRequest{To: []string{agent.ID}, Subject: "hi", Body: "note"}, ProviderID(""), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(string(raw), "Received: by e2a.local (e2a) with loopback id ") {
+		t.Errorf("Received line missing e2a.local fallback host:\n%s", string(raw))
+	}
+}
+
+// TestComposeMIMEFromHeader pins the From header shape: display name quoted
+// when the agent has one, bare address when it doesn't.
+func TestComposeMIMEFromHeader(t *testing.T) {
+	parseFrom := func(t *testing.T, raw []byte) string {
+		t.Helper()
+		s := string(raw)
+		if i := strings.Index(s, "\r\nFrom:"); i >= 0 {
+			s = s[i+2:]
+		}
+		m, err := mail.ReadMessage(strings.NewReader(s))
+		if err != nil {
+			t.Fatalf("parse loopback MIME: %v\n%s", err, string(raw))
+		}
+		return m.Header.Get("From")
+	}
+
+	t.Run("named agent gets quoted display name", func(t *testing.T) {
+		agent := &identity.AgentIdentity{ID: "bot@example.com", Domain: "example.com", Name: "Support Bot"}
+		raw, err := ComposeMIME(agent, outbound.SendRequest{To: []string{agent.ID}, Subject: "hi", Body: "note"}, ProviderID("example.com"), "example.com")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := parseFrom(t, raw); got != `"Support Bot" <bot@example.com>` {
+			t.Errorf("From = %q, want %q", got, `"Support Bot" <bot@example.com>`)
+		}
+	})
+
+	t.Run("nameless agent gets bare address", func(t *testing.T) {
+		agent := &identity.AgentIdentity{ID: "bot@example.com", Domain: "example.com"}
+		raw, err := ComposeMIME(agent, outbound.SendRequest{To: []string{agent.ID}, Subject: "hi", Body: "note"}, ProviderID("example.com"), "example.com")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := parseFrom(t, raw); got != "bot@example.com" {
+			t.Errorf("From = %q, want %q", got, "bot@example.com")
+		}
+	})
+}
+
+// TestComposeMIMEHTMLBody pins the single-part content-type switch: an
+// HTMLBody selects text/html and the HTML body; without it the message
+// stays text/plain.
+func TestComposeMIMEHTMLBody(t *testing.T) {
+	agent := &identity.AgentIdentity{ID: "bot@example.com", Domain: "example.com"}
+
+	parse := func(t *testing.T, raw []byte) *mail.Message {
+		t.Helper()
+		s := string(raw)
+		if i := strings.Index(s, "\r\nFrom:"); i >= 0 {
+			s = s[i+2:]
+		}
+		m, err := mail.ReadMessage(strings.NewReader(s))
+		if err != nil {
+			t.Fatalf("parse loopback MIME: %v\n%s", err, string(raw))
+		}
+		return m
+	}
+
+	t.Run("html body wins over plain", func(t *testing.T) {
+		raw, err := ComposeMIME(agent, outbound.SendRequest{
+			To: []string{agent.ID}, Subject: "hi", Body: "plain", HTMLBody: "<p>html</p>",
+		}, ProviderID("example.com"), "example.com")
+		if err != nil {
+			t.Fatal(err)
+		}
+		m := parse(t, raw)
+		if ct := m.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/html") {
+			t.Errorf("Content-Type = %q, want text/html", ct)
+		}
+	})
+
+	t.Run("composer error propagates", func(t *testing.T) {
+		// A CR/LF in the attachment filename is refused by the underlying
+		// composer (header-injection guard); ComposeMIME must surface the error.
+		_, err := ComposeMIME(agent, outbound.SendRequest{
+			To: []string{agent.ID}, Subject: "hi", Body: "note",
+			Attachments: []outbound.Attachment{{Filename: "evil\r\nInjected: yes", ContentType: "text/plain", Data: "aGVsbG8="}},
+		}, ProviderID("example.com"), "example.com")
+		if err == nil {
+			t.Fatal("ComposeMIME with CR/LF attachment filename returned nil error")
+		}
+	})
+
+	t.Run("plain-only stays text/plain", func(t *testing.T) {
+		raw, err := ComposeMIME(agent, outbound.SendRequest{
+			To: []string{agent.ID}, Subject: "hi", Body: "plain",
+		}, ProviderID("example.com"), "example.com")
+		if err != nil {
+			t.Fatal(err)
+		}
+		m := parse(t, raw)
+		if ct := m.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/plain") {
+			t.Errorf("Content-Type = %q, want text/plain", ct)
+		}
+	})
+}

--- a/internal/sendramp/schedule_extra_test.go
+++ b/internal/sendramp/schedule_extra_test.go
@@ -1,0 +1,31 @@
+package sendramp_test
+
+import (
+	"testing"
+
+	"github.com/tokencanopy/e2a/internal/sendramp"
+)
+
+func TestCapForActiveDaySingleDayRampReachesTargetImmediately(t *testing.T) {
+	s := sendramp.NewSchedule(50, 2000, 1)
+	if got := s.CapForActiveDay(0); got != 2000 {
+		t.Fatalf("CapForActiveDay(0) = %d, want target 2000 on a one-day ramp", got)
+	}
+}
+
+func TestCapForActiveDayInterpolatesLinearlyBetweenStartAndTarget(t *testing.T) {
+	s := sendramp.NewSchedule(50, 150, 3)
+	if got := s.CapForActiveDay(1); got != 100 {
+		t.Fatalf("CapForActiveDay(1) = %d, want midpoint 100", got)
+	}
+}
+
+func TestCapForActiveDayNegativeIndexBehavesAsDayZero(t *testing.T) {
+	s := sendramp.NewSchedule(50, 150, 3)
+	if got := s.CapForActiveDay(-2); got != 50 {
+		t.Fatalf("CapForActiveDay(-2) = %d, want start 50", got)
+	}
+	if got := sendramp.NewSchedule(50, 2000, 1).CapForActiveDay(-2); got != 2000 {
+		t.Fatalf("one-day ramp CapForActiveDay(-2) = %d, want target 2000", got)
+	}
+}

--- a/internal/sendramp/store_extra_test.go
+++ b/internal/sendramp/store_extra_test.go
@@ -1,0 +1,438 @@
+package sendramp_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/tokencanopy/e2a/internal/identity"
+	"github.com/tokencanopy/e2a/internal/sendramp"
+	"github.com/tokencanopy/e2a/internal/testutil"
+)
+
+func TestPermanentErrorErrorReturnsWrappedMessage(t *testing.T) {
+	err := &sendramp.PermanentError{Err: errors.New("boom")}
+	if err.Error() != "boom" {
+		t.Fatalf("Error() = %q, want %q", err.Error(), "boom")
+	}
+	var permanent permanentMarker = err
+	if !permanent.Permanent() {
+		t.Fatal("PermanentError must report Permanent() = true")
+	}
+}
+
+func TestExemptRejectsDomainOwnedByAnotherUser(t *testing.T) {
+	store, pool, _, domain, _ := seedRampMessage(t, "exempt-foreign")
+	other, err := identity.NewStore(pool).CreateOrGetUser(context.Background(), "exempt-other@example.com", "Other", "exempt-other")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = store.Exempt(context.Background(), other.ID, domain)
+	var permanent permanentMarker
+	if !errors.As(err, &permanent) || !permanent.Permanent() {
+		t.Fatalf("Exempt by non-owner err=%v, want permanent owner-mismatch error", err)
+	}
+}
+
+func TestExemptNoopsWhenDomainCannotTransition(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("unverified domain stays inactive", func(t *testing.T) {
+		pool := testutil.TestDB(t)
+		store := sendramp.NewStore(pool)
+		ids := identity.NewStore(pool)
+		user, err := ids.CreateOrGetUser(ctx, "exempt-unverified@example.com", "Unverified", "exempt-unverified")
+		if err != nil {
+			t.Fatal(err)
+		}
+		domain := "exempt-unverified.example.com"
+		if _, err := ids.ClaimOrCreateDomain(ctx, domain, user.ID); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.Exempt(ctx, user.ID, domain); err != nil {
+			t.Fatalf("Exempt on unverified domain: %v", err)
+		}
+		var status string
+		if err := pool.QueryRow(ctx, `SELECT sending_ramp_status FROM domains WHERE domain=$1`, domain).Scan(&status); err != nil {
+			t.Fatal(err)
+		}
+		if status != sendramp.StatusInactive {
+			t.Fatalf("status=%q, want %q", status, sendramp.StatusInactive)
+		}
+	})
+
+	t.Run("ramping domain stays ramping", func(t *testing.T) {
+		store, pool, userID, domain, messageID := seedRampMessage(t, "exempt-ramping")
+		day := time.Date(2026, 7, 18, 0, 0, 0, 0, time.UTC)
+		if got := reserve(t, store, userID, domain, messageID, 1, day, sendramp.DefaultSchedule); !got.Allowed {
+			t.Fatalf("reserve = %+v, want allowed", got)
+		}
+		if err := store.Exempt(ctx, userID, domain); err != nil {
+			t.Fatalf("Exempt on ramping domain: %v", err)
+		}
+		var status string
+		if err := pool.QueryRow(ctx, `SELECT sending_ramp_status FROM domains WHERE domain=$1`, domain).Scan(&status); err != nil {
+			t.Fatal(err)
+		}
+		if status != sendramp.StatusRamping {
+			t.Fatalf("status=%q, want %q", status, sendramp.StatusRamping)
+		}
+	})
+}
+
+func TestSnapshotErrorsForUnknownDomain(t *testing.T) {
+	store, _, userID, _, _ := seedRampMessage(t, "snapshot-missing")
+	if _, err := store.Snapshot(context.Background(), userID, "missing.example.com", time.Now()); err == nil {
+		t.Fatal("Snapshot on unknown domain must return an error")
+	}
+}
+
+func TestSnapshotReturnsStatusOnlyForNonRampingDomain(t *testing.T) {
+	store, _, userID, domain, _ := seedRampMessage(t, "snapshot-inactive")
+	now := time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC)
+
+	inactive, err := store.Snapshot(context.Background(), userID, domain, now)
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if inactive.Status != sendramp.StatusInactive || inactive.DailyLimit != 0 || inactive.UsedToday != 0 || inactive.StartedAt != nil {
+		t.Fatalf("inactive snapshot = %+v, want status-only", inactive)
+	}
+
+	if err := store.Exempt(context.Background(), userID, domain); err != nil {
+		t.Fatalf("Exempt: %v", err)
+	}
+	exempt, err := store.Snapshot(context.Background(), userID, domain, now)
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if exempt.Status != sendramp.StatusExempt || exempt.DailyLimit != 0 || exempt.StartedAt != nil {
+		t.Fatalf("exempt snapshot = %+v, want status-only exempt", exempt)
+	}
+}
+
+func TestSnapshotDerivesLimitFromScheduleWhenNoCounterRow(t *testing.T) {
+	store, pool, userID, domain, _ := seedRampMessage(t, "snapshot-no-counter")
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, `UPDATE domains SET sending_ramp_status='ramping' WHERE domain=$1`, domain); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO sending_ramp_scopes (user_id,domain,start_daily,target_daily,ramp_days) VALUES ($1,'example.com',50,200,4)`, userID); err != nil {
+		t.Fatal(err)
+	}
+	snap, err := store.Snapshot(ctx, userID, domain, time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if snap.Status != sendramp.StatusRamping || snap.StartedAt == nil || snap.CompletedAt != nil ||
+		snap.ActiveDays != 0 || snap.StartDaily != 50 || snap.TargetDaily != 200 || snap.RampDays != 4 ||
+		snap.DailyLimit != 50 || snap.UsedToday != 0 {
+		t.Fatalf("snapshot = %+v, want ramping day-zero limit 50 unused", snap)
+	}
+}
+
+func TestSnapshotReportsCompleteWhenScopeCompleted(t *testing.T) {
+	store, pool, userID, domain, _ := seedRampMessage(t, "snapshot-complete")
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, `UPDATE domains SET sending_ramp_status='ramping' WHERE domain=$1`, domain); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO sending_ramp_scopes (user_id,domain,status,active_days,start_daily,target_daily,ramp_days) VALUES ($1,'example.com','complete',4,50,200,4)`, userID); err != nil {
+		t.Fatal(err)
+	}
+	snap, err := store.Snapshot(ctx, userID, domain, time.Date(2026, 7, 18, 12, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("Snapshot: %v", err)
+	}
+	if snap.Status != sendramp.StatusComplete || snap.TargetDaily != 200 || snap.ActiveDays != 4 {
+		t.Fatalf("snapshot = %+v, want completed scope snapshot", snap)
+	}
+}
+
+func TestReserveAllowsUnverifiedDomainWithoutAccounting(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := sendramp.NewStore(pool)
+	ids := identity.NewStore(pool)
+	ctx := context.Background()
+	user, err := ids.CreateOrGetUser(ctx, "reserve-unverified@example.com", "Unverified", "reserve-unverified")
+	if err != nil {
+		t.Fatal(err)
+	}
+	domain := "reserve-unverified.example.com"
+	if _, err := ids.ClaimOrCreateDomain(ctx, domain, user.ID); err != nil {
+		t.Fatal(err)
+	}
+	agent, err := ids.CreateAgent(ctx, "agent@"+domain, domain, "", "", "local", user.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	messageID := createMessageForAgent(t, pool, agent.ID, "unverified-first")
+
+	d, err := store.Reserve(ctx, sendramp.ReserveRequest{
+		MessageID: messageID, UserID: user.ID, Domain: domain,
+		Units: 1, Day: time.Date(2026, 7, 18, 0, 0, 0, 0, time.UTC), Schedule: sendramp.DefaultSchedule,
+	})
+	if err != nil {
+		t.Fatalf("Reserve: %v", err)
+	}
+	if !d.Allowed || d.Status != sendramp.StatusInactive || d.DailyLimit != 0 {
+		t.Fatalf("decision = %+v, want allowed passthrough with inactive status", d)
+	}
+	var counters, reservations int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM domain_send_counters WHERE user_id=$1`, user.ID).Scan(&counters); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM sending_ramp_reservations WHERE message_id=$1`, messageID).Scan(&reservations); err != nil {
+		t.Fatal(err)
+	}
+	if counters != 0 || reservations != 0 {
+		t.Fatalf("counters=%d reservations=%d, want no ramp accounting for unverified domain", counters, reservations)
+	}
+}
+
+func TestReserveRejectsDomainOwnedByAnotherUser(t *testing.T) {
+	store, pool, _, domain, messageID := seedRampMessage(t, "reserve-foreign")
+	other, err := identity.NewStore(pool).CreateOrGetUser(context.Background(), "reserve-other@example.com", "Other", "reserve-other")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = store.Reserve(context.Background(), sendramp.ReserveRequest{
+		MessageID: messageID, UserID: other.ID, Domain: domain,
+		Units: 1, Day: time.Date(2026, 7, 18, 0, 0, 0, 0, time.UTC), Schedule: sendramp.DefaultSchedule,
+	})
+	var permanent permanentMarker
+	if !errors.As(err, &permanent) || !permanent.Permanent() {
+		t.Fatalf("Reserve by non-owner err=%v, want permanent owner-mismatch error", err)
+	}
+}
+
+func TestReserveCompletesDomainWhenScopeAlreadyComplete(t *testing.T) {
+	store, pool, userID, domain, messageID := seedRampMessage(t, "reserve-scope-complete")
+	ctx := context.Background()
+	if _, err := pool.Exec(ctx, `INSERT INTO sending_ramp_scopes (user_id,domain,status,active_days,start_daily,target_daily,ramp_days) VALUES ($1,'example.com','complete',2,50,100,2)`, userID); err != nil {
+		t.Fatal(err)
+	}
+	d := reserve(t, store, userID, domain, messageID, 1, time.Date(2026, 7, 18, 0, 0, 0, 0, time.UTC), sendramp.NewSchedule(50, 100, 2))
+	if !d.Allowed || d.Status != sendramp.StatusComplete || d.DailyLimit != 0 {
+		t.Fatalf("decision = %+v, want allowed complete without accounting", d)
+	}
+	var status string
+	if err := pool.QueryRow(ctx, `SELECT sending_ramp_status FROM domains WHERE domain=$1`, domain).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != sendramp.StatusComplete {
+		t.Fatalf("domain status=%q, want persisted complete", status)
+	}
+}
+
+func TestReserveDeniesWhenUnitsExceedLimit(t *testing.T) {
+	store, pool, userID, domain, messageID := seedRampMessage(t, "reserve-over-limit")
+	day := time.Date(2026, 7, 18, 0, 0, 0, 0, time.UTC)
+	d := reserve(t, store, userID, domain, messageID, 60, day, sendramp.NewSchedule(50, 100, 2))
+	if d.Allowed || d.Status != sendramp.StatusRamping || d.DailyLimit != 50 || d.UsedToday != 0 {
+		t.Fatalf("decision = %+v, want denied at 0/50", d)
+	}
+	if !d.RetryAt.Equal(day.Add(24 * time.Hour)) {
+		t.Fatalf("RetryAt = %v, want next UTC day %v", d.RetryAt, day.Add(24*time.Hour))
+	}
+	var counters, reservations int
+	if err := pool.QueryRow(context.Background(), `SELECT count(*) FROM domain_send_counters WHERE user_id=$1`, userID).Scan(&counters); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(context.Background(), `SELECT count(*) FROM sending_ramp_reservations WHERE message_id=$1`, messageID).Scan(&reservations); err != nil {
+		t.Fatal(err)
+	}
+	if counters != 0 || reservations != 0 {
+		t.Fatalf("counters=%d reservations=%d, want no accounting rows for over-limit single send", counters, reservations)
+	}
+}
+
+func TestReserveRejectsReplayAfterRelease(t *testing.T) {
+	store, _, userID, domain, messageID := seedRampMessage(t, "reserve-after-release")
+	day := time.Date(2026, 7, 18, 0, 0, 0, 0, time.UTC)
+	schedule := sendramp.NewSchedule(50, 100, 2)
+	if got := reserve(t, store, userID, domain, messageID, 2, day, schedule); !got.Allowed {
+		t.Fatalf("reserve = %+v, want allowed", got)
+	}
+	if err := store.Release(context.Background(), messageID); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+	_, err := store.Reserve(context.Background(), sendramp.ReserveRequest{
+		MessageID: messageID, UserID: userID, Domain: domain, Units: 2, Day: day, Schedule: schedule,
+	})
+	var permanent permanentMarker
+	if !errors.As(err, &permanent) || !permanent.Permanent() {
+		t.Fatalf("re-reserve after release err=%v, want permanent already-released error", err)
+	}
+}
+
+func TestReserveRejectsUnitMismatchOnRetry(t *testing.T) {
+	store, _, userID, domain, messageID := seedRampMessage(t, "reserve-unit-mismatch")
+	day := time.Date(2026, 7, 18, 0, 0, 0, 0, time.UTC)
+	schedule := sendramp.NewSchedule(50, 100, 2)
+	if got := reserve(t, store, userID, domain, messageID, 2, day, schedule); !got.Allowed {
+		t.Fatalf("reserve = %+v, want allowed", got)
+	}
+	_, err := store.Reserve(context.Background(), sendramp.ReserveRequest{
+		MessageID: messageID, UserID: userID, Domain: domain, Units: 3, Day: day, Schedule: schedule,
+	})
+	var permanent permanentMarker
+	if !errors.As(err, &permanent) || !permanent.Permanent() {
+		t.Fatalf("retry with different units err=%v, want permanent unit-mismatch error", err)
+	}
+}
+
+func TestReserveReplaysConfirmedReservationAsAllowed(t *testing.T) {
+	store, _, userID, domain, messageID := seedRampMessage(t, "reserve-after-confirm")
+	day := time.Date(2026, 7, 18, 0, 0, 0, 0, time.UTC)
+	schedule := sendramp.NewSchedule(50, 100, 2)
+	if got := reserve(t, store, userID, domain, messageID, 2, day, schedule); !got.Allowed {
+		t.Fatalf("reserve = %+v, want allowed", got)
+	}
+	if err := store.Confirm(context.Background(), messageID); err != nil {
+		t.Fatalf("Confirm: %v", err)
+	}
+	replay := reserve(t, store, userID, domain, messageID, 2, day, schedule)
+	if !replay.Allowed || replay.Status != sendramp.StatusRamping {
+		t.Fatalf("replay after confirm = %+v, want allowed ramping", replay)
+	}
+}
+
+func TestReserveWithZeroDayUsesCurrentUTCDay(t *testing.T) {
+	store, pool, userID, domain, messageID := seedRampMessage(t, "reserve-zero-day")
+	now := time.Now().UTC()
+	wantDay := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	if got := reserve(t, store, userID, domain, messageID, 3, time.Time{}, sendramp.DefaultSchedule); !got.Allowed {
+		t.Fatalf("reserve with zero day = %+v, want allowed", got)
+	}
+	var day time.Time
+	var reserved int
+	if err := pool.QueryRow(context.Background(), `SELECT day, reserved_count FROM domain_send_counters WHERE user_id=$1 AND domain='example.com'`, userID).Scan(&day, &reserved); err != nil {
+		t.Fatal(err)
+	}
+	if !day.Equal(wantDay) || reserved != 3 {
+		t.Fatalf("counter day=%v reserved=%d, want %v/3", day, reserved, wantDay)
+	}
+}
+
+func TestReserveScopesSingleLabelDomainToItself(t *testing.T) {
+	pool := testutil.TestDB(t)
+	store := sendramp.NewStore(pool)
+	ids := identity.NewStore(pool)
+	ctx := context.Background()
+	user, err := ids.CreateOrGetUser(ctx, "single-label@example.com", "Single", "single-label")
+	if err != nil {
+		t.Fatal(err)
+	}
+	domain := "localhost"
+	if _, err := ids.ClaimOrCreateDomain(ctx, domain, user.ID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `UPDATE domains SET sending_status = 'verified' WHERE domain = $1`, domain); err != nil {
+		t.Fatal(err)
+	}
+	agent, err := ids.CreateAgent(ctx, "agent@"+domain, domain, "", "", "local", user.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	messageID := createMessageForAgent(t, pool, agent.ID, "single-label-first")
+
+	day := time.Date(2026, 7, 18, 0, 0, 0, 0, time.UTC)
+	if got := reserve(t, store, user.ID, domain, messageID, 4, day, sendramp.DefaultSchedule); !got.Allowed {
+		t.Fatalf("reserve = %+v, want allowed", got)
+	}
+	var reserved int
+	if err := pool.QueryRow(ctx, `SELECT reserved_count FROM domain_send_counters WHERE user_id=$1 AND domain='localhost' AND day=$2`, user.ID, day).Scan(&reserved); err != nil {
+		t.Fatalf("counter scoped to raw single-label domain: %v", err)
+	}
+	if reserved != 4 {
+		t.Fatalf("reserved=%d, want 4", reserved)
+	}
+}
+
+func TestConfirmRejectsEmptyMessageID(t *testing.T) {
+	store, _, _, _, _ := seedRampMessage(t, "confirm-empty")
+	err := store.Confirm(context.Background(), "")
+	var permanent permanentMarker
+	if !errors.As(err, &permanent) || !permanent.Permanent() {
+		t.Fatalf("Confirm(\"\") err=%v, want permanent empty-id error", err)
+	}
+}
+
+func TestConfirmUnknownReservationIsNoop(t *testing.T) {
+	store, _, _, _, _ := seedRampMessage(t, "confirm-missing")
+	if err := store.Confirm(context.Background(), "msg_ramp_never_reserved"); err != nil {
+		t.Fatalf("Confirm on unknown reservation: %v", err)
+	}
+}
+
+func TestReleaseRejectsEmptyMessageID(t *testing.T) {
+	store, _, _, _, _ := seedRampMessage(t, "release-empty")
+	err := store.Release(context.Background(), "")
+	var permanent permanentMarker
+	if !errors.As(err, &permanent) || !permanent.Permanent() {
+		t.Fatalf("Release(\"\") err=%v, want permanent empty-id error", err)
+	}
+}
+
+func TestReleaseUnknownReservationIsNoop(t *testing.T) {
+	store, _, _, _, _ := seedRampMessage(t, "release-missing")
+	if err := store.Release(context.Background(), "msg_ramp_never_reserved"); err != nil {
+		t.Fatalf("Release on unknown reservation: %v", err)
+	}
+}
+
+func TestReleaseConfirmedReservationIsNoop(t *testing.T) {
+	store, pool, userID, domain, messageID := seedRampMessage(t, "release-confirmed")
+	day := time.Date(2026, 7, 18, 0, 0, 0, 0, time.UTC)
+	if got := reserve(t, store, userID, domain, messageID, 5, day, sendramp.DefaultSchedule); !got.Allowed {
+		t.Fatalf("reserve = %+v, want allowed", got)
+	}
+	if err := store.Confirm(context.Background(), messageID); err != nil {
+		t.Fatalf("Confirm: %v", err)
+	}
+	if err := store.Release(context.Background(), messageID); err != nil {
+		t.Fatalf("Release on confirmed reservation: %v", err)
+	}
+	var state string
+	var reserved, confirmed int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT r.state, c.reserved_count, c.confirmed_count
+		   FROM sending_ramp_reservations r
+		   JOIN domain_send_counters c ON c.user_id=r.user_id AND c.domain=r.domain AND c.day=r.day
+		  WHERE r.message_id=$1`, messageID).Scan(&state, &reserved, &confirmed); err != nil {
+		t.Fatal(err)
+	}
+	if state != "confirmed" || reserved != 5 || confirmed != 5 {
+		t.Fatalf("state=%q reserved=%d confirmed=%d, want confirmed/5/5 untouched", state, reserved, confirmed)
+	}
+}
+
+func TestResolveUnknownMessageIsNoop(t *testing.T) {
+	store, _, _, _, _ := seedRampMessage(t, "resolve-missing")
+	if err := store.Resolve(context.Background(), "msg_ramp_never_existed"); err != nil {
+		t.Fatalf("Resolve on unknown message: %v", err)
+	}
+}
+
+func TestResolveIgnoresNonTerminalDeliveryStatus(t *testing.T) {
+	store, pool, userID, domain, messageID := seedRampMessage(t, "resolve-nonterminal")
+	day := time.Date(2026, 7, 18, 0, 0, 0, 0, time.UTC)
+	if got := reserve(t, store, userID, domain, messageID, 2, day, sendramp.DefaultSchedule); !got.Allowed {
+		t.Fatalf("reserve = %+v, want allowed", got)
+	}
+	if _, err := pool.Exec(context.Background(), `UPDATE messages SET delivery_status='sending' WHERE id=$1`, messageID); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Resolve(context.Background(), messageID); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	var state string
+	if err := pool.QueryRow(context.Background(), `SELECT state FROM sending_ramp_reservations WHERE message_id=$1`, messageID).Scan(&state); err != nil {
+		t.Fatal(err)
+	}
+	if state != "reserved" {
+		t.Fatalf("state=%q, want reserved (non-terminal outcome must not settle)", state)
+	}
+}

--- a/internal/webhookdelivery/worker_extra_test.go
+++ b/internal/webhookdelivery/worker_extra_test.go
@@ -1,0 +1,313 @@
+package webhookdelivery_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
+
+	"github.com/tokencanopy/e2a/internal/identity"
+	"github.com/tokencanopy/e2a/internal/jobs"
+	"github.com/tokencanopy/e2a/internal/testutil"
+	"github.com/tokencanopy/e2a/internal/webhook"
+	"github.com/tokencanopy/e2a/internal/webhookdelivery"
+)
+
+// recordingDeliverer captures the arguments the worker passes to Deliver so tests
+// can assert signing-secret handling, and counts calls so no-op paths can prove
+// the endpoint was never hit.
+type recordingDeliverer struct {
+	out        webhook.DeliveryOutcome
+	calls      int
+	secretPrev string
+}
+
+func (r *recordingDeliverer) Deliver(_ context.Context, _ string, _ []byte, _, secretPrev, _, _ string) webhook.DeliveryOutcome {
+	r.calls++
+	r.secretPrev = secretPrev
+	return r.out
+}
+
+// failEnq is a jobs.Enqueuer whose inserts always fail.
+type failEnq struct{ err error }
+
+func (f failEnq) Insert(_ context.Context, _ river.JobArgs, _ *river.InsertOpts) (*rivertype.JobInsertResult, error) {
+	return nil, f.err
+}
+func (f failEnq) InsertTx(_ context.Context, _ pgx.Tx, _ river.JobArgs, _ *river.InsertOpts) (*rivertype.JobInsertResult, error) {
+	return nil, f.err
+}
+
+// TestDeliverWorker_MissingDeliveryRowIsNoop: the delivery row can disappear
+// between enqueue and execution (webhook deleted, cascade) — Work treats a gone
+// row as done rather than erroring (an error would burn River retries forever).
+func TestDeliverWorker_MissingDeliveryRowIsNoop(t *testing.T) {
+	pool := testutil.TestDB(t)
+	sub := webhook.NewSubscriberStore(pool)
+	rec := &recordingDeliverer{out: webhook.DeliveryOutcome{Success: true, StatusCode: 200}}
+	w := webhookdelivery.NewDeliverWorker(sub, rec, fakeWebhooks{err: errors.New("unreachable")})
+	if err := w.Work(context.Background(), job("whd_does_not_exist", 1)); err != nil {
+		t.Fatalf("Work on missing row = %v, want nil (nothing to do)", err)
+	}
+	if rec.calls != 0 {
+		t.Errorf("deliverer called %d times for a missing row, want 0", rec.calls)
+	}
+}
+
+// TestDeliverWorker_AlreadyDeliveredIsNoop: a re-driven job after a crash
+// post-MarkDelivered must not POST the endpoint again — the endpoint sees the
+// delivery exactly once even though River is at-least-once at the job level.
+func TestDeliverWorker_AlreadyDeliveredIsNoop(t *testing.T) {
+	id, sub, _, wh := seed(t, "wd-redeliver")
+	ctx := context.Background()
+	if err := sub.MarkDelivered(ctx, id, 200); err != nil {
+		t.Fatalf("MarkDelivered: %v", err)
+	}
+	rec := &recordingDeliverer{out: webhook.DeliveryOutcome{Success: false, StatusCode: 500, Error: "should never fire"}}
+	w := webhookdelivery.NewDeliverWorker(sub, rec, fakeWebhooks{wh: wh})
+	if err := w.Work(ctx, job(id, 1)); err != nil {
+		t.Fatalf("Work on delivered row = %v, want nil (idempotent no-op)", err)
+	}
+	if rec.calls != 0 {
+		t.Errorf("deliverer called %d times for an already-delivered row, want 0 (duplicate POST)", rec.calls)
+	}
+}
+
+// TestDeliverWorker_DBErrorIsRetryable: a transient store error on the initial
+// fetch is returned verbatim so River retries — a crash-safe redrive beats a
+// silent skip that would strand the row.
+func TestDeliverWorker_DBErrorIsRetryable(t *testing.T) {
+	ctx := context.Background()
+	pool, err := testutil.OpenPreparedTestDB(ctx, testutil.TestDBURL())
+	if err != nil {
+		t.Skipf("test database not available: %v", err)
+	}
+	sub := webhook.NewSubscriberStore(pool)
+	pool.Close() // simulate a DB outage
+
+	w := webhookdelivery.NewDeliverWorker(sub, fakeDeliverer{}, fakeWebhooks{})
+	if err := w.Work(ctx, job("whd_any", 1)); err == nil {
+		t.Fatal("Work with a dead DB returned nil — River would not retry a transient error")
+	}
+}
+
+// TestDeliverWorker_ExpiredPrevSigningSecretNotHonored: once the rotation grace
+// window closes, the previous signing secret must not be sent — a consumer still
+// trusting it would accept signatures with a retired secret.
+func TestDeliverWorker_ExpiredPrevSigningSecretNotHonored(t *testing.T) {
+	id, sub, _, wh := seed(t, "wd-prev-expired")
+	past := time.Now().Add(-time.Hour)
+	wh.SigningSecret = "current-secret"
+	wh.SigningSecretPrev = "retired-secret"
+	wh.SigningSecretPrevExpiresAt = &past
+
+	rec := &recordingDeliverer{out: webhook.DeliveryOutcome{Success: true, StatusCode: 200}}
+	w := webhookdelivery.NewDeliverWorker(sub, rec, fakeWebhooks{wh: wh})
+	if err := w.Work(context.Background(), job(id, 1)); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	if rec.calls != 1 {
+		t.Fatalf("deliverer called %d times, want 1", rec.calls)
+	}
+	if rec.secretPrev != "" {
+		t.Errorf("prev secret after grace expiry = %q, want empty (retired secret must not sign)", rec.secretPrev)
+	}
+}
+
+// TestDeliverWorker_PrevSigningSecretWithinGraceIsHonored: inside the rotation
+// grace window the previous secret IS passed through, so consumers mid-rotation
+// can verify against either secret.
+func TestDeliverWorker_PrevSigningSecretWithinGraceIsHonored(t *testing.T) {
+	id, sub, _, wh := seed(t, "wd-prev-grace")
+	future := time.Now().Add(time.Hour)
+	wh.SigningSecret = "current-secret"
+	wh.SigningSecretPrev = "rotating-secret"
+	wh.SigningSecretPrevExpiresAt = &future
+
+	rec := &recordingDeliverer{out: webhook.DeliveryOutcome{Success: true, StatusCode: 200}}
+	w := webhookdelivery.NewDeliverWorker(sub, rec, fakeWebhooks{wh: wh})
+	if err := w.Work(context.Background(), job(id, 1)); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+	if rec.secretPrev != "rotating-secret" {
+		t.Errorf("prev secret within grace = %q, want %q", rec.secretPrev, "rotating-secret")
+	}
+}
+
+// TestDeliverWorker_TerminalWriteFailureIsReturned: when the webhook is gone AND
+// the terminal 'failed' write itself keeps failing, Work must surface the store
+// error (River retries) rather than cancelling with an unmarked row — a cancel
+// would strand the row 'pending' with a dead job the reconciler can't see.
+// The negative attempt number trips the attempts >= 0 CHECK constraint on every
+// try, exhausting markFailedReliably's bounded retries deterministically.
+func TestDeliverWorker_TerminalWriteFailureIsReturned(t *testing.T) {
+	id, sub, _, _ := seed(t, "wd-markfail")
+	w := webhookdelivery.NewDeliverWorker(sub, fakeDeliverer{out: webhook.DeliveryOutcome{Success: true}},
+		fakeWebhooks{err: errors.New("webhook gone")})
+	err := w.Work(context.Background(), job(id, -1))
+	if err == nil {
+		t.Fatal("Work returned nil even though the terminal 'failed' write never succeeded")
+	}
+	// The row must NOT have been marked failed — every write errored.
+	if d := statusOf(t, sub, id); d.Status != "pending" {
+		t.Errorf("status = %q, want pending (the failing terminal write must not half-apply)", d.Status)
+	}
+}
+
+// TestDeliverWorker_TerminalWriteHonorsContextCancel: a cancelled context aborts
+// markFailedReliably's backoff sleep instead of sleeping out the full retry
+// budget — the worker stays responsive to River's stop signal. The row lock makes
+// the terminal write block until the deadline so the cancel branch fires.
+func TestDeliverWorker_TerminalWriteHonorsContextCancel(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	// Seed inline on this one pool (the shared seed helper acquires its own pool,
+	// and a second testutil.TestDB call would truncate the row out from under us).
+	store := identity.NewStore(pool)
+	user, err := store.CreateOrGetUser(ctx, "owner-wd-markcancel@example.com", "Owner", "google-wd-markcancel")
+	if err != nil {
+		t.Fatalf("CreateOrGetUser: %v", err)
+	}
+	wh, err := store.CreateWebhook(ctx, user.ID, "https://example.com/hook", "", []string{"email.received"}, identity.WebhookFilters{})
+	if err != nil {
+		t.Fatalf("CreateWebhook: %v", err)
+	}
+	sub := webhook.NewSubscriberStore(pool)
+	id, err := sub.InsertPendingForTest(ctx, wh.ID, "email.received", []byte(`{"type":"email.received"}`))
+	if err != nil {
+		t.Fatalf("InsertPendingForTest: %v", err)
+	}
+
+	// Hold an exclusive lock on the delivery row so MarkSubscriberFailed's UPDATE
+	// blocks (a plain SELECT does not, so the initial fetch still succeeds).
+	lockTx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin lock tx: %v", err)
+	}
+	defer lockTx.Rollback(ctx)
+	if _, err := lockTx.Exec(ctx,
+		`UPDATE webhook_subscriber_deliveries SET last_error = 'lock-holder' WHERE id = $1`, id); err != nil {
+		t.Fatalf("lock row: %v", err)
+	}
+
+	workCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	w := webhookdelivery.NewDeliverWorker(sub, fakeDeliverer{out: webhook.DeliveryOutcome{Success: true}},
+		fakeWebhooks{err: errors.New("webhook gone")})
+	err = w.Work(workCtx, job(id, 1))
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("Work error = %v, want context.DeadlineExceeded (cancel must abort the retry backoff)", err)
+	}
+}
+
+// TestNextRetry_OutOfRangeAttemptsFallsBackToClientPolicy: attempts outside the
+// frozen envelope (0 is invalid; MaxDeliveryAttempts is terminal and discarded
+// by River anyway) return the zero time so River's client-wide policy applies —
+// never a panic from indexing past the backoff table.
+func TestNextRetry_OutOfRangeAttemptsFallsBackToClientPolicy(t *testing.T) {
+	w := webhookdelivery.NewDeliverWorker(nil, nil, nil)
+	for _, attempt := range []int{0, webhookdelivery.MaxDeliveryAttempts, webhookdelivery.MaxDeliveryAttempts + 5} {
+		if got := w.NextRetry(job("x", attempt)); !got.IsZero() {
+			t.Errorf("NextRetry(attempt %d) = %v, want zero time (fall back to client policy)", attempt, got)
+		}
+	}
+}
+
+// TestEnqueueDelivery_UnknownDeliveryID: enqueueing for a delivery row that
+// doesn't exist is an error, not a silent no-op — the caller (/test endpoint,
+// redelivery API) needs to know the row it just created isn't the one found.
+func TestEnqueueDelivery_UnknownDeliveryID(t *testing.T) {
+	pool := testutil.TestDB(t)
+	sub := webhook.NewSubscriberStore(pool)
+	j := webhookdelivery.NewJobs(sub, fakeDeliverer{}, fakeWebhooks{}, pool)
+	j.SetEnqueuer(&fakeEnq{})
+	if err := j.EnqueueDelivery(context.Background(), pool, "whd_does_not_exist"); err == nil {
+		t.Fatal("EnqueueDelivery on a missing row returned nil, want an error")
+	}
+}
+
+// TestEnqueueDeliveryTx_EnqueuerError: a River insert failure inside the outbox
+// tx propagates (and returns no job id) so the caller's transaction rolls back —
+// the Layer 2 row and its job must commit together or not at all.
+func TestEnqueueDeliveryTx_EnqueuerError(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	sub := webhook.NewSubscriberStore(pool)
+	wantErr := errors.New("river insert boom")
+	j := webhookdelivery.NewJobs(sub, fakeDeliverer{}, fakeWebhooks{}, pool)
+	j.SetEnqueuer(failEnq{err: wantErr})
+
+	tx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatalf("begin: %v", err)
+	}
+	defer tx.Rollback(ctx)
+	jobID, err := j.EnqueueDeliveryTx(ctx, tx, "whd_any")
+	if !errors.Is(err, wantErr) {
+		t.Errorf("EnqueueDeliveryTx error = %v, want %v", err, wantErr)
+	}
+	if jobID != 0 {
+		t.Errorf("EnqueueDeliveryTx job id = %d, want 0 on failure", jobID)
+	}
+}
+
+// TestReconcileWorker_EndToEnd drives the live reconciler through a REAL River
+// client: a stranded pending row (job_id IS NULL — the /test or redelivery
+// separate-tx path, or an outbox-drain crash window) gets a webhook_deliver job
+// enqueued and job_id stamped within one reconcile run, not just on restart.
+func TestReconcileWorker_EndToEnd(t *testing.T) {
+	pool := testutil.TestDB(t)
+	ctx := context.Background()
+	if err := jobs.Migrate(ctx, pool); err != nil {
+		t.Fatalf("jobs.Migrate: %v", err)
+	}
+
+	id1, sub, _, wh := seed(t, "wd-reconcile-a")
+	id2, err := sub.InsertPendingForTest(ctx, wh.ID, "email.received", []byte(`{"type":"email.received"}`))
+	if err != nil {
+		t.Fatalf("InsertPendingForTest: %v", err)
+	}
+
+	j := webhookdelivery.NewJobs(sub, fakeDeliverer{}, fakeWebhooks{wh: wh}, pool)
+	client, err := jobs.New(pool, jobs.Config{}, j)
+	if err != nil {
+		t.Fatalf("jobs.New: %v", err)
+	}
+	j.SetEnqueuer(client)
+
+	if err := client.Start(ctx); err != nil {
+		t.Fatalf("client.Start: %v", err)
+	}
+	t.Cleanup(func() {
+		stopCtx, stop := context.WithTimeout(context.Background(), 10*time.Second)
+		defer stop()
+		_ = client.Stop(stopCtx)
+	})
+
+	// Fire the reconcile worker directly (the periodic runs every minute — too
+	// slow for a test).
+	if _, err := client.Insert(ctx, webhookdelivery.WebhookReconcileArgs{}, &river.InsertOpts{Queue: jobs.QueueMaintenance}); err != nil {
+		t.Fatalf("insert reconcile job: %v", err)
+	}
+
+	// Both stranded rows must get a job_id stamped by the reconcile run.
+	jobIDOf := func(id string) *int64 {
+		var jobID *int64
+		if err := pool.QueryRow(ctx, `SELECT job_id FROM webhook_subscriber_deliveries WHERE id=$1`, id).Scan(&jobID); err != nil {
+			t.Fatalf("read job_id for %s: %v", id, err)
+		}
+		return jobID
+	}
+	deadline := time.Now().Add(15 * time.Second)
+	for time.Now().Before(deadline) {
+		if jobIDOf(id1) != nil && jobIDOf(id2) != nil {
+			return
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	t.Errorf("reconcile worker did not stamp job_id: %s=%v %s=%v", id1, jobIDOf(id1), id2, jobIDOf(id2))
+}


### PR DESCRIPTION
## Summary

Two rounds of behavior-focused test additions, written test-first against each package's production contract. No production code changed; no test exposed a bug.

### Round 1 — queue-first delivery paths
| Package | Before | After | Floor |
|---|---|---|---|
| `sendramp` | 70.6% | 83.6% | 70 → 80 |
| `webhookdelivery` | 71.4% | 92.2% | new: 88 |
| `jobs` | 40.6% | 87.5% | new: 82 |

- `jobs.ReconcilePending` was 0% covered — now exercised for stranded-row stamping, second-run idempotency, per-row failure skip+retry, batch caps, and a deterministic `FOR UPDATE` concurrent-stamp race
- `webhookdelivery`: crash-recovery no-re-POST, signing-secret grace windows, terminal-write retry exhaustion, end-to-end reconcile through a real River client
- `sendramp`: reservation replay/idempotency, over-cap denial, owner-mismatch rejections, ramp-schedule interpolation

### Round 2 — auth boundary + wiring
| Package | Before | After | Floor |
|---|---|---|---|
| `auth` | 67.8% | 91.0% | new: 88 |
| `apiserver` | 35.2% | 74.1% | new: 70 |
| `loopback` | 58.5% | 100% | new: 95 |

- `auth`: six previously 0% handlers (logout, me, dashboard agents, delete/update agent, delete API key), API-key scope validation with cross-user isolation, OAuth callback failure branches
- `apiserver`: `New` 0%→100%, `BuildDeps` wiring, delete-domain transactional rollback
- `loopback`: self-send detection, alias stripping, MIME compose → 100%

### Totals
- Repo coverage: 76.1% → **77.5%**
- Gated packages in `.testcoverage.yml`: 6 → **11**
- `make cover-check` passes with all new floors

### Notes
- Remaining uncovered paths are `crypto/rand` failure branches, real DNS lookups, and DB fault-injection branches — intentionally left
- Pre-existing (untouched, no drive-by): `gofmt` flags `internal/auth/cli_login_test.go`

🤖 Generated with [Kimi Code](https://www.kimi.com/code)
