### PR TITLE
test(ci): wire orphaned test suites into CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,24 @@ jobs:
         with:
           node-version: "22"
       - run: scripts/check-repository-text-integrity.sh
+      - run: node --test scripts/sync-agent-docs.test.mjs
+
+  harness-tests:
+    name: Test harnesses (e2e-prod unit, sdk-monitor)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "22"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      # Network-free unit tests only — the e2e-prod suites against a live
+      # deployment stay manual. No npm ci needed: node --test type-strips.
+      - run: node --test tests/e2e-prod/harness/*.test.ts
+      - run: python3 tests/sdk-monitor/test_monitor.py
 
   go:
     name: Go tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,11 @@ jobs:
       # Network-free unit tests only — the e2e-prod suites against a live
       # deployment stay manual. No npm ci needed: node --test type-strips.
       - run: node --test tests/e2e-prod/harness/*.test.ts
-      - run: python3 tests/sdk-monitor/test_monitor.py
+      # monitor.py imports the Python SDK (from e2a.v1 import ...) — install
+      # the repo's SDK so the gate tests this tree, not a published release.
+      - run: |
+          pip install ./sdks/python
+          python3 tests/sdk-monitor/test_monitor.py
 
   go:
     name: Go tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -287,7 +287,8 @@ manually on every API change even though the template won't remind you.
   Go e2e, web, ts-sdk, agent-framework-examples, adk-cloud-webhook-example,
   ts-contract, cli, mcp, spec gates, python-sdk, python-contract,
   generated-code freshness, design-system dist freshness, SDK-version-sync,
-  plugin manifests, repo text integrity, SDK operation coverage).
+  plugin manifests, repo text integrity, SDK operation coverage, test
+  harnesses).
 - `tests/e2e-prod/` is a production smoke harness — not part of local dev.
 - Two more CI workflows cover the `plugins/e2a/skills/agentify` framework:
   `.github/workflows/agentify-test.yml` (deterministic script/addon/config

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -22,7 +22,7 @@
     "build": "tsc",
     "test": "npm run typecheck && npm run test:unit && npm run test:types",
     "typecheck": "tsc --project tsconfig.test.json",
-    "test:unit": "vitest run test/v1/client.test.ts test/v1/inbound.test.ts test/v1/ws.test.ts test/v1/webhook-signature.test.ts test/v1/webhook-payloads.test.ts test/v1/errors.test.ts test/v1/retry.test.ts test/v1/pagination.test.ts",
+    "test:unit": "vitest run test/v1 --exclude '**/contract*.test.ts'",
     "test:coverage": "npm run typecheck && npm run test:unit -- --coverage && npm run test:types",
     "test:types": "tsc -p tsconfig.type-tests.json",
     "test:contract": "vitest run test/v1/contract.test.ts test/v1/contract-client.test.ts",

--- a/tests/contract/contract_test.go
+++ b/tests/contract/contract_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 // Package contract contains behavioral contract tests for the public /v1 API.
 //
 // These tests verify that the Go API server behaves as documented: correct

--- a/tests/contract/runner_cleanup_test.go
+++ b/tests/contract/runner_cleanup_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package contract
 
 import (


### PR DESCRIPTION
## Summary

Fixes the "orphaned tests" findings from a full repo test audit: suites that existed and passed but never executed in CI (or could silently go unrun).

### Changes

- **`tests/contract/` tagged `//go:build integration`** (both test files). The Go runner for `scenarios.yaml` previously had no tag, so `make test-e2e`'s tag-based discovery missed it, `make cover` only scopes `./internal/...`, and the `go` CI job (no Postgres) hit its `t.Skipf` — the repo's flagship language-agnostic contract suite was skip-only in CI on the Go side while TS/Python runners executed. Now `go-e2e` runs it. Verified: discovery finds `./tests/contract`, suite passes against a real DB (6.2s), `go list ./...` and plain `go test` unaffected.
- **New `harness-tests` CI job** running two previously-unwired suites:
  - `node --test tests/e2e-prod/harness/*.test.ts` — network-free unit tests for the prod-smoke harness (no `npm ci` needed; Node 22 type-strips). The 25 live-prod suites stay manual by design.
  - `python3 tests/sdk-monitor/test_monitor.py` — the 1,137-line monitor suite; CI built the monitor image but never ran its tests.
- **`scripts/sync-agent-docs.test.mjs`** added to the `repository-integrity` job (CI previously used only the script's `--check` mode, never its unit tests).
- **`@e2a/sdk` `test:unit` glob**: replaces the hard-listed 8 files with `vitest run test/v1 --exclude '**/contract*.test.ts'` — a new unit test file can no longer be silently skipped by omission. Verified: still runs exactly the same 8 files / 206 tests, and `test:coverage` floors still pass.

### Verification

All four newly-wired suites pass locally; workflow YAML parses; AGENTS.md CI job list updated.

### Not in scope (deliberately)

- Cred-gated live suites (SDK `test:live`, CLI `test:e2e`, Python `test_e2e.py`, ADK live integration) — need a scheduled staging workflow with secrets; separate decision.
- `tests/e2e-prod` live suites + `coverage_gate.py` — same reason.
- design-system has no tests at all; web has no coverage gate — larger investments.

🤖 Generated with [Kimi Code](https://www.kimi.com/code)
